### PR TITLE
fix(ui): Home answers failed scans; stale results cannot pose as current (KEN-508)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -306,7 +306,8 @@ changes carry a **Breaking** call-out with their migration note inline.
   says its read failed and offers Try again instead of claiming "No
   marketplaces yet", and overlapping reads of updates and marketplaces can
   no longer land out of order — a slow early read cannot overwrite a
-  fresher answer or take back a change that just succeeded.
+  fresher answer or take back a change that just succeeded, and a check
+  that fetched the sources outranks any quicker re-read of old mirrors.
 - `kendex apply --replace-unmanaged` no longer gives up on the whole scope
   because one item cannot be settled. A repo arriving on kendex with one
   odd corner — say, a shortcut somebody set up where a skill installs —

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -310,8 +310,10 @@ changes carry a **Breaking** call-out with their migration note inline.
   the same last-checked note with their toggle and unsubscribe held, and
   overlapping reads of updates and marketplaces can
   no longer land out of order — a slow early read cannot overwrite a
-  fresher answer or take back a change that just succeeded, and a check
-  that fetched the sources outranks any quicker re-read of old mirrors.
+  fresher answer or take back a change that just succeeded, a check that
+  fetched the sources outranks any quicker re-read of old mirrors whether
+  it succeeded or failed, and back-to-back changes land in the order they
+  were made.
 - `kendex apply --replace-unmanaged` no longer gives up on the whole scope
   because one item cannot be settled. A repo arriving on kendex with one
   odd corner — say, a shortcut somebody set up where a skill installs —

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -286,6 +286,14 @@ changes carry a **Breaking** call-out with their migration note inline.
   research deferred as standalone work.
 
 ### Fixed
+- Home no longer shows its loading skeletons forever when the first scan of
+  the machine fails: the page says the scan failed, shows why, and offers
+  Scan again. When a later scan fails, Home still draws what it had, headed
+  by a note that these are the last figures kendex could check, with the
+  retry beside it. A failed update check now appears in Needs attention and
+  turns the sidebar's Updates badge into a warning instead of contributing
+  silence, and the Marketplaces tile shows a dash rather than a definite
+  zero when its read did not answer.
 - `kendex apply --replace-unmanaged` no longer gives up on the whole scope
   because one item cannot be settled. A repo arriving on kendex with one
   odd corner — say, a shortcut somebody set up where a skill installs —

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -302,7 +302,11 @@ changes carry a **Breaking** call-out with their migration note inline.
   engine refuses. Update buttons wait for a check that succeeded — updating
   from versions nobody confirmed could move a held package to a stale
   commit — and a failed check always leaves its retry reachable, even when
-  everything noteworthy is muted.
+  everything noteworthy is muted. The Marketplaces page's Subscribed tab
+  says its read failed and offers Try again instead of claiming "No
+  marketplaces yet", and overlapping reads of updates and marketplaces can
+  no longer land out of order — a slow early read cannot overwrite a
+  fresher answer or take back a change that just succeeded.
 - `kendex apply --replace-unmanaged` no longer gives up on the whole scope
   because one item cannot be settled. A repo arriving on kendex with one
   odd corner — say, a shortcut somebody set up where a skill installs —

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -320,7 +320,10 @@ changes carry a **Breaking** call-out with their migration note inline.
   it succeeded or failed, and back-to-back changes — updates, mutes,
   follow switches, and fork decisions alike — land in the order they were
   made. A change that fails midway re-reads the standing rather than
-  presenting the old rows as current. The status footer stops saying "Up
+  presenting the old rows as current, a change whose call never reached
+  the engine reports the failure instead of staying silent or toasting
+  success, and updating waits out a running check rather than applying
+  versions it is about to replace. The status footer stops saying "Up
   to date" beside a failed scan: a failed first scan reads "Couldn't
   scan", and a kept result is labeled last-scanned instead of current.
 - `kendex apply --replace-unmanaged` no longer gives up on the whole scope

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -302,9 +302,13 @@ changes carry a **Breaking** call-out with their migration note inline.
   engine refuses. Update buttons wait for a check that succeeded — updating
   from versions nobody confirmed could move a held package to a stale
   commit — and a failed check always leaves its retry reachable, even when
-  everything noteworthy is muted. The Marketplaces page's Subscribed tab
-  says its read failed and offers Try again instead of claiming "No
-  marketplaces yet", and overlapping reads of updates and marketplaces can
+  everything noteworthy is muted, with the Follow source switch waiting
+  alongside the Update buttons — switching follow off from a stale row
+  would pin a package to an old commit. The Marketplaces page's Subscribed
+  tab says its read failed and offers Try again instead of claiming "No
+  marketplaces yet", subscriptions kept from a failed read are drawn under
+  the same last-checked note with their toggle and unsubscribe held, and
+  overlapping reads of updates and marketplaces can
   no longer land out of order — a slow early read cannot overwrite a
   fresher answer or take back a change that just succeeded, and a check
   that fetched the sources outranks any quicker re-read of old mirrors.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -322,7 +322,10 @@ changes carry a **Breaking** call-out with their migration note inline.
   made. A change that fails midway re-reads the standing rather than
   presenting the old rows as current, a change whose call never reached
   the engine reports the failure instead of staying silent or toasting
-  success, and updating waits out anything already re-reading the standing
+  success, a change that landed but whose first re-read failed reports
+  the success once that re-read catches up — with its toast and refreshed
+  tables — instead of calling the change failed, and updating waits out
+  anything already re-reading the standing
   — a running check, a focus-triggered re-read, another change landing —
   rather than applying versions it is about to replace. The status footer stops saying "Up
   to date" beside a failed scan: a failed first scan reads "Couldn't

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -322,8 +322,9 @@ changes carry a **Breaking** call-out with their migration note inline.
   made. A change that fails midway re-reads the standing rather than
   presenting the old rows as current, a change whose call never reached
   the engine reports the failure instead of staying silent or toasting
-  success, and updating waits out a running check rather than applying
-  versions it is about to replace. The status footer stops saying "Up
+  success, and updating waits out anything already re-reading the standing
+  — a running check, a focus-triggered re-read, another change landing —
+  rather than applying versions it is about to replace. The status footer stops saying "Up
   to date" beside a failed scan: a failed first scan reads "Couldn't
   scan", and a kept result is labeled last-scanned instead of current.
 - `kendex apply --replace-unmanaged` no longer gives up on the whole scope

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -299,7 +299,10 @@ changes carry a **Breaking** call-out with their migration note inline.
   when a check fails, and heads versions kept from an earlier check as the
   last kendex could check instead of presenting them as current. These
   states now also cover a call that fails in transport, not only one the
-  engine refuses.
+  engine refuses. Update buttons wait for a check that succeeded — updating
+  from versions nobody confirmed could move a held package to a stale
+  commit — and a failed check always leaves its retry reachable, even when
+  everything noteworthy is muted.
 - `kendex apply --replace-unmanaged` no longer gives up on the whole scope
   because one item cannot be settled. A repo arriving on kendex with one
   odd corner — say, a shortcut somebody set up where a skill installs —

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -292,8 +292,14 @@ changes carry a **Breaking** call-out with their migration note inline.
   by a note that these are the last figures kendex could check, with the
   retry beside it. A failed update check now appears in Needs attention and
   turns the sidebar's Updates badge into a warning instead of contributing
-  silence, and the Marketplaces tile shows a dash rather than a definite
-  zero when its read did not answer.
+  silence, a failed safety check appears there too with its own Try again,
+  and the Marketplaces tile shows a dash rather than a definite zero when
+  its read did not answer. The Updates page makes the same distinctions:
+  it says it is checking until the first read answers, says so with a retry
+  when a check fails, and heads versions kept from an earlier check as the
+  last kendex could check instead of presenting them as current. These
+  states now also cover a call that fails in transport, not only one the
+  engine refuses.
 - `kendex apply --replace-unmanaged` no longer gives up on the whole scope
   because one item cannot be settled. A repo arriving on kendex with one
   odd corner — say, a shortcut somebody set up where a skill installs —

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -302,13 +302,15 @@ changes carry a **Breaking** call-out with their migration note inline.
   engine refuses. Update buttons wait for a check that succeeded — updating
   from versions nobody confirmed could move a held package to a stale
   commit — and a failed check always leaves its retry reachable, even when
-  everything noteworthy is muted, with the Follow source switch waiting
-  alongside the Update buttons — switching follow off from a stale row
-  would pin a package to an old commit. The Marketplaces page's Subscribed
-  tab says its read failed and offers Try again instead of claiming "No
-  marketplaces yet", subscriptions kept from a failed read are drawn under
-  the same last-checked note with their toggle and unsubscribe held, and
-  overlapping reads of updates and marketplaces can
+  everything noteworthy is muted, with the Follow source switch and an
+  edited package's "Use new version" waiting alongside the Update buttons
+  — acting from a stale row would pin a package to an old commit. The
+  Marketplaces page's Subscribed tab says its read failed and offers Try
+  again instead of claiming "No marketplaces yet", subscriptions kept from
+  a failed read are drawn under the same last-checked note with their
+  toggle and unsubscribe held — on the tab and on each marketplace's own
+  page — a failed subscribe can no longer rewrite the reason that note
+  shows, and overlapping reads of updates and marketplaces can
   no longer land out of order — a slow early read cannot overwrite a
   fresher answer or take back a change that just succeeded, a check that
   fetched the sources outranks any quicker re-read of old mirrors whether

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -310,7 +310,10 @@ changes carry a **Breaking** call-out with their migration note inline.
   a failed read are drawn under the same last-checked note with their
   toggle and unsubscribe held — on the tab and on each marketplace's own
   page — a failed subscribe can no longer rewrite the reason that note
-  shows, and overlapping reads of updates and marketplaces can
+  shows. These holds are enforced where the action runs, not only on the
+  buttons: a confirmation dialog already open when a check fails can no
+  longer commit from the stale rows it was opened over. And overlapping
+  reads of updates and marketplaces can
   no longer land out of order — a slow early read cannot overwrite a
   fresher answer or take back a change that just succeeded, a check that
   fetched the sources outranks any quicker re-read of old mirrors whether

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -314,8 +314,12 @@ changes carry a **Breaking** call-out with their migration note inline.
   no longer land out of order — a slow early read cannot overwrite a
   fresher answer or take back a change that just succeeded, a check that
   fetched the sources outranks any quicker re-read of old mirrors whether
-  it succeeded or failed, and back-to-back changes land in the order they
-  were made.
+  it succeeded or failed, and back-to-back changes — updates, mutes,
+  follow switches, and fork decisions alike — land in the order they were
+  made. A change that fails midway re-reads the standing rather than
+  presenting the old rows as current. The status footer stops saying "Up
+  to date" beside a failed scan: a failed first scan reads "Couldn't
+  scan", and a kept result is labeled last-scanned instead of current.
 - `kendex apply --replace-unmanaged` no longer gives up on the whole scope
   because one item cannot be settled. A repo arriving on kendex with one
   odd corner — say, a shortcut somebody set up where a skill installs —

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -269,8 +269,13 @@ lives in one capability table read by core and UI.
 - A section with nothing in it is not rendered; an empty state appears only
   when the page would otherwise be blank.
 - A list whose data has not arrived draws skeleton rows; the empty state
-  waits for the read to finish. Startup reads — settings, scan, audit,
-  updates — run side by side.
+  waits for the read to finish. Skeletons stand only while a read is
+  genuinely in flight: a read that failed is an answer, and the page shows
+  its error with a retry instead. Figures kept from before a failed re-read
+  are drawn but headed as the last kendex could check, and nothing derived
+  from a read that did not answer is presented as a definite count — least
+  of all zero. Startup reads — settings, scan, audit, updates — run side by
+  side.
 - Commands that touch disk, git, or a subprocess are
   `#[tauri::command(async)]`. Only window operations stay synchronous.
 - No database: manifests, locks, and native dirs are the state; scans are

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -267,15 +267,10 @@ lives in one capability table read by core and UI.
   other hook's. Custom hook commands pass the same safety gate as catalog
   scripts.
 - A section with nothing in it is not rendered; an empty state appears only
-  when the page would otherwise be blank.
-- A list whose data has not arrived draws skeleton rows; the empty state
-  waits for the read to finish. Skeletons stand only while a read is
-  genuinely in flight: a read that failed is an answer, and the page shows
-  its error with a retry instead. Figures kept from before a failed re-read
-  are drawn but headed as the last kendex could check, and nothing derived
-  from a read that did not answer is presented as a definite count — least
-  of all zero. Startup reads — settings, scan, audit, updates — run side by
-  side.
+  when the page would otherwise be blank, its read done. Skeletons draw
+  mid-read; a failed read shows its error with a retry, kept figures headed
+  as the last kendex could check, never a definite count — least of all
+  zero. Startup reads — settings, scan, audit, updates — run side by side.
 - Commands that touch disk, git, or a subprocess are
   `#[tauri::command(async)]`. Only window operations stay synchronous.
 - No database: manifests, locks, and native dirs are the state; scans are

--- a/ui/src/components/confirm-dialog.tsx
+++ b/ui/src/components/confirm-dialog.tsx
@@ -19,6 +19,8 @@ export function ConfirmDialog({
   confirmLabel,
   destructive,
   busy,
+  confirmDisabled,
+  confirmDisabledNote,
   onConfirm,
   children,
 }: {
@@ -29,6 +31,11 @@ export function ConfirmDialog({
   confirmLabel: string;
   destructive?: boolean;
   busy?: boolean;
+  /** Holds the confirm button alone — Cancel stays live, so a dialog whose
+   *  premise went stale underneath it can still be closed. */
+  confirmDisabled?: boolean;
+  /** Why the confirm is held, shown as the button's title. */
+  confirmDisabledNote?: string;
   onConfirm: () => void;
   children?: ReactNode;
 }) {
@@ -52,7 +59,8 @@ export function ConfirmDialog({
           </Button>
           <Button
             variant={destructive ? "destructive" : "default"}
-            disabled={busy}
+            disabled={busy || confirmDisabled}
+            title={confirmDisabled ? confirmDisabledNote : undefined}
             onClick={onConfirm}
           >
             {confirmLabel}

--- a/ui/src/components/customized-actions.test.tsx
+++ b/ui/src/components/customized-actions.test.tsx
@@ -5,12 +5,14 @@ import { UpdatesTable } from "./updates-table";
 import { updateRow as row } from "./updates-test-rows";
 
 // Static rendering reads a zustand store's initial snapshot, never one set
-// later, so the store hook is wrapped to let a test flip `busy`.
-const stub = vi.hoisted(() => ({ busy: false }));
+// later, so the store hook is wrapped to let a test flip `busy` and
+// `loaded`. Rows on screen imply a read that answered, so that is the
+// default.
+const stub = vi.hoisted(() => ({ busy: false, loaded: true }));
 vi.mock("@/stores/updates", async (importOriginal) => {
   const mod = await importOriginal<typeof import("@/stores/updates")>();
   const hook = (selector?: (state: unknown) => unknown) => {
-    const state = { ...mod.useUpdatesStore.getState(), busy: stub.busy };
+    const state = { ...mod.useUpdatesStore.getState(), ...stub };
     return selector ? selector(state) : state;
   };
   return { ...mod, useUpdatesStore: Object.assign(hook, mod.useUpdatesStore) };
@@ -112,6 +114,27 @@ describe("customized places", () => {
     expect(html).toContain(">Keep as my own<");
     expect(html).not.toContain(">Use new version…<");
     expect(html).toContain(">No longer in its source<");
+  });
+
+  // Discarding edits on a held place moves the hold to row.latest's commit
+  // — a stale row would pin exactly the old version the Update guards now
+  // prevent. Keeping the files as a fork copies what is on disk, so it
+  // stays live.
+  it("holds Use new version on rows a failed check left behind", () => {
+    stub.loaded = false;
+    try {
+      const html = render([
+        row("one", null, {
+          blockedByLocalEdit: true,
+          editedHarnesses: ["claude"],
+          forkableHarness: "claude",
+        }),
+      ]);
+      expect(html).toMatch(/<button[^>]*disabled=""[^>]*>Use new version…</);
+      expect(html).not.toMatch(/<button[^>]*disabled=""[^>]*>Keep as my own</);
+    } finally {
+      stub.loaded = true;
+    }
   });
 
   it("holds the fork decision while another update is running", () => {

--- a/ui/src/components/customized-actions.tsx
+++ b/ui/src/components/customized-actions.tsx
@@ -38,7 +38,9 @@ export function CustomizedActions({
   // version the other Update guards prevent — so the discard waits for a
   // check the same as Update. Keeping the files as a fork copies what is
   // on disk and stays live.
-  const held = useUpdatesStore((s) => !s.loaded || s.checking);
+  const held = useUpdatesStore(
+    (s) => !s.loaded || s.checking || s.overviewInFlight,
+  );
   const whyNoFork = row.derived
     ? DERIVED_EDIT_NOTE
     : row.editedHarnesses.length > 1

--- a/ui/src/components/customized-actions.tsx
+++ b/ui/src/components/customized-actions.tsx
@@ -34,10 +34,11 @@ export function CustomizedActions({
 }) {
   const [confirmDiscard, setConfirmDiscard] = useState(false);
   // Discarding edits on a held place moves the hold to row.latest's commit
-  // — from a stale row that pins exactly the old version the other Update
-  // guards prevent — so the discard waits for a check the same as Update.
-  // Keeping the files as a fork copies what is on disk and stays live.
-  const loaded = useUpdatesStore((s) => s.loaded);
+  // — from a stale or about-to-be-replaced row that pins exactly the old
+  // version the other Update guards prevent — so the discard waits for a
+  // check the same as Update. Keeping the files as a fork copies what is
+  // on disk and stays live.
+  const held = useUpdatesStore((s) => !s.loaded || s.checking);
   const whyNoFork = row.derived
     ? DERIVED_EDIT_NOTE
     : row.editedHarnesses.length > 1
@@ -69,8 +70,8 @@ export function CustomizedActions({
         <Button
           size="sm"
           variant="outline"
-          disabled={busy || !loaded}
-          title={!loaded ? UPDATE_NEEDS_CHECK_NOTE : undefined}
+          disabled={busy || held}
+          title={held ? UPDATE_NEEDS_CHECK_NOTE : undefined}
           onClick={() => setConfirmDiscard(true)}
         >
           {row.canTakeLatest ? USE_NEW_VERSION_LABEL : DISCARD_EDITS_LABEL}
@@ -85,7 +86,7 @@ export function CustomizedActions({
         confirmLabel={DISCARD_EDITS_CONFIRM_LABEL}
         destructive
         busy={busy}
-        confirmDisabled={!loaded}
+        confirmDisabled={held}
         confirmDisabledNote={UPDATE_NEEDS_CHECK_NOTE}
         onConfirm={() =>
           void takeNewVersion(row).then(() => setConfirmDiscard(false))

--- a/ui/src/components/customized-actions.tsx
+++ b/ui/src/components/customized-actions.tsx
@@ -14,9 +14,11 @@ import {
   DERIVED_EDIT_NOTE,
   MULTI_TOOL_EDIT_NOTE,
   UNFORKABLE_EDIT_NOTE,
+  UPDATE_NEEDS_CHECK_NOTE,
   USE_NEW_VERSION_LABEL,
 } from "@/lib/copy-updates";
 import { scopeKey } from "@/lib/scope";
+import { useUpdatesStore } from "@/stores/updates";
 import { keepAsOwn, takeNewVersion } from "@/stores/updates-edits";
 
 /** A place whose files were edited by hand: the update waits on a
@@ -31,6 +33,11 @@ export function CustomizedActions({
   busy: boolean;
 }) {
   const [confirmDiscard, setConfirmDiscard] = useState(false);
+  // Discarding edits on a held place moves the hold to row.latest's commit
+  // — from a stale row that pins exactly the old version the other Update
+  // guards prevent — so the discard waits for a check the same as Update.
+  // Keeping the files as a fork copies what is on disk and stays live.
+  const loaded = useUpdatesStore((s) => s.loaded);
   const whyNoFork = row.derived
     ? DERIVED_EDIT_NOTE
     : row.editedHarnesses.length > 1
@@ -62,7 +69,8 @@ export function CustomizedActions({
         <Button
           size="sm"
           variant="outline"
-          disabled={busy}
+          disabled={busy || !loaded}
+          title={!loaded ? UPDATE_NEEDS_CHECK_NOTE : undefined}
           onClick={() => setConfirmDiscard(true)}
         >
           {row.canTakeLatest ? USE_NEW_VERSION_LABEL : DISCARD_EDITS_LABEL}

--- a/ui/src/components/customized-actions.tsx
+++ b/ui/src/components/customized-actions.tsx
@@ -85,6 +85,8 @@ export function CustomizedActions({
         confirmLabel={DISCARD_EDITS_CONFIRM_LABEL}
         destructive
         busy={busy}
+        confirmDisabled={!loaded}
+        confirmDisabledNote={UPDATE_NEEDS_CHECK_NOTE}
         onConfirm={() =>
           void takeNewVersion(row).then(() => setConfirmDiscard(false))
         }

--- a/ui/src/components/home/attention-rows.ts
+++ b/ui/src/components/home/attention-rows.ts
@@ -1,0 +1,145 @@
+import type { AuditView, ScanResult, UpdateRow } from "@/bindings";
+import type { AttentionRow } from "@/components/home/attention-section";
+import { auditCounts } from "@/lib/audit-counts";
+import {
+  FORKED_ATTENTION_DETAIL,
+  forkedAttentionTitle,
+  REVIEW_ACTION_LABEL,
+  UPDATES_ATTENTION_DETAIL,
+  UPDATES_ATTENTION_TITLE,
+} from "@/lib/copy";
+
+/** Everything Home's attention list is derived from, with the way into
+ *  each row's destination handed in — the derivation orders the rows,
+ *  worst first, and the page stays a layout. */
+export interface AttentionSource {
+  editedPackages: UpdateRow[];
+  views: AuditView[];
+  result: ScanResult | null;
+  /** Why the last update check failed, or null. A failed check is a state
+   *  to show, not a silence: with nothing said, a list without an "edited
+   *  packages" row would read as kendex having looked and found nothing. */
+  updatesError: string | null;
+  onReview: () => void;
+  onUnmanaged: () => void;
+  onProjects: () => void;
+  onUpdates: () => void;
+  onLibrary: () => void;
+  onPackage: (row: UpdateRow) => void;
+}
+
+export function attentionRows(source: AttentionSource): AttentionRow[] {
+  const {
+    changes: actionableCount,
+    inTheWay,
+    unmanaged: unmanagedCount,
+    blocked,
+    open,
+  } = auditCounts(source.views);
+  const { editedPackages, result, updatesError } = source;
+  const missing = result?.missingProjects ?? [];
+
+  const rows: AttentionRow[] = [];
+  if (editedPackages.length > 0) {
+    const first = editedPackages[0];
+    rows.push({
+      key: "edited",
+      tone: "warning",
+      title: forkedAttentionTitle(editedPackages.length),
+      detail: FORKED_ATTENTION_DETAIL,
+      action:
+        editedPackages.length === 1 && first
+          ? { label: first.name, onClick: () => source.onPackage(first) }
+          : { label: "Library", onClick: source.onLibrary },
+    });
+  }
+  if (blocked > 0) {
+    rows.push({
+      key: "safety",
+      tone: "critical",
+      title: blocked === 1 ? "1 problem found" : `${blocked} problems found`,
+      detail: "Held back until you accept them.",
+      action: { label: REVIEW_ACTION_LABEL, onClick: source.onReview },
+    });
+  }
+  if (open > 0) {
+    rows.push({
+      key: "decisions",
+      tone: "warning",
+      title: open === 1 ? "1 finding to review" : `${open} findings to review`,
+      detail: "In content already installed.",
+      action: { label: REVIEW_ACTION_LABEL, onClick: source.onReview },
+    });
+  }
+  if (inTheWay > 0) {
+    rows.push({
+      key: "in-the-way",
+      tone: "warning",
+      title:
+        inTheWay === 1
+          ? "1 item needs your decision"
+          : `${inTheWay} items need your decision`,
+      detail: "Files are already where they go.",
+      action: { label: REVIEW_ACTION_LABEL, onClick: source.onReview },
+    });
+  }
+  if (actionableCount > 0) {
+    rows.push({
+      key: "drift",
+      tone: "info",
+      title:
+        actionableCount === 1
+          ? "1 change ready to apply"
+          : `${actionableCount} changes ready to apply`,
+      action: { label: REVIEW_ACTION_LABEL, onClick: source.onReview },
+    });
+  }
+  if (unmanagedCount > 0) {
+    rows.push({
+      key: "unmanaged",
+      tone: "muted",
+      title:
+        unmanagedCount === 1
+          ? "1 unmanaged item"
+          : `${unmanagedCount} unmanaged items`,
+      detail: "kendex didn't put them there.",
+      action: { label: "Review", onClick: source.onUnmanaged },
+    });
+  }
+  if (missing.length > 0) {
+    rows.push({
+      key: "missing-projects",
+      tone: "warning",
+      title:
+        missing.length === 1
+          ? "1 project folder can't be found"
+          : `${missing.length} project folders can't be found`,
+      detail:
+        missing.length === 1
+          ? `We can't find ${missing[0]}. If you moved it, add it again.`
+          : "If you moved these, add them again from Harnesses & Projects.",
+      action: { label: "Projects", onClick: source.onProjects },
+    });
+  }
+  if (updatesError !== null) {
+    rows.push({
+      key: "updates-unchecked",
+      tone: "warning",
+      title: UPDATES_ATTENTION_TITLE,
+      detail: UPDATES_ATTENTION_DETAIL,
+      action: { label: "Updates", onClick: source.onUpdates },
+    });
+  }
+  if (result && result.warnings.length > 0) {
+    rows.push({
+      key: "warnings",
+      tone: "warning",
+      title:
+        result.warnings.length === 1
+          ? "1 file couldn't be read"
+          : `${result.warnings.length} files couldn't be read`,
+      detail: result.warnings[0],
+    });
+  }
+  return rows;
+}

--- a/ui/src/components/home/attention-rows.ts
+++ b/ui/src/components/home/attention-rows.ts
@@ -2,16 +2,19 @@ import type { AuditView, ScanResult, UpdateRow } from "@/bindings";
 import type { AttentionRow } from "@/components/home/attention-section";
 import { auditCounts } from "@/lib/audit-counts";
 import {
+  AUDIT_ATTENTION_DETAIL,
+  AUDIT_ATTENTION_TITLE,
   FORKED_ATTENTION_DETAIL,
   forkedAttentionTitle,
   REVIEW_ACTION_LABEL,
+  TRY_AGAIN_LABEL,
   UPDATES_ATTENTION_DETAIL,
   UPDATES_ATTENTION_TITLE,
 } from "@/lib/copy";
 
 /** Everything Home's attention list is derived from, with the way into
- *  each row's destination handed in — the derivation orders the rows,
- *  worst first, and the page stays a layout. */
+ *  each row's destination handed in — the derivation emits the rows in a
+ *  fixed product order, and the page stays a layout. */
 export interface AttentionSource {
   editedPackages: UpdateRow[];
   views: AuditView[];
@@ -20,12 +23,17 @@ export interface AttentionSource {
    *  to show, not a silence: with nothing said, a list without an "edited
    *  packages" row would read as kendex having looked and found nothing. */
   updatesError: string | null;
+  /** Why the last audit failed, or null — the counts above came from an
+   *  audit that could not finish, so what needs attention may be missing
+   *  from this very list. */
+  auditError: string | null;
   onReview: () => void;
   onUnmanaged: () => void;
   onProjects: () => void;
   onUpdates: () => void;
   onLibrary: () => void;
   onPackage: (row: UpdateRow) => void;
+  onAuditRetry: () => void;
 }
 
 export function attentionRows(source: AttentionSource): AttentionRow[] {
@@ -36,7 +44,7 @@ export function attentionRows(source: AttentionSource): AttentionRow[] {
     blocked,
     open,
   } = auditCounts(source.views);
-  const { editedPackages, result, updatesError } = source;
+  const { editedPackages, result, updatesError, auditError } = source;
   const missing = result?.missingProjects ?? [];
 
   const rows: AttentionRow[] = [];
@@ -119,6 +127,18 @@ export function attentionRows(source: AttentionSource): AttentionRow[] {
           ? `We can't find ${missing[0]}. If you moved it, add it again.`
           : "If you moved these, add them again from Harnesses & Projects.",
       action: { label: "Projects", onClick: source.onProjects },
+    });
+  }
+  // A failed audit means the counts above answer for less than the whole
+  // machine — the row says so and offers the retry, instead of the section
+  // holding its skeleton for the session.
+  if (auditError !== null) {
+    rows.push({
+      key: "audit-unchecked",
+      tone: "warning",
+      title: AUDIT_ATTENTION_TITLE,
+      detail: AUDIT_ATTENTION_DETAIL,
+      action: { label: TRY_AGAIN_LABEL, onClick: source.onAuditRetry },
     });
   }
   if (updatesError !== null) {

--- a/ui/src/components/marketplaces/detail-header.test.tsx
+++ b/ui/src/components/marketplaces/detail-header.test.tsx
@@ -1,0 +1,92 @@
+import { renderToStaticMarkup } from "react-dom/server";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { Catalog, MarketplaceRow } from "@/bindings";
+import { TRY_AGAIN_LABEL } from "@/lib/copy";
+import {
+  MARKETPLACES_NEEDS_CHECK_NOTE,
+  MARKETPLACES_UNCONFIRMED_TITLE,
+} from "@/lib/copy-marketplaces";
+import { DetailHeader } from "./detail-header";
+
+// Static rendering reads a zustand store's initial snapshot, never one set
+// later, so the store is wrapped to let a test stage what the last read
+// left behind.
+const stub = vi.hoisted(() => ({
+  loaded: true,
+  rowsCurrent: true,
+  checkError: null as string | null,
+}));
+
+vi.mock("@/stores/marketplaces", async (importOriginal) => {
+  const mod = await importOriginal<typeof import("@/stores/marketplaces")>();
+  const hook = (selector?: (state: unknown) => unknown) => {
+    const state = {
+      ...mod.useMarketplacesStore.getState(),
+      ...stub,
+      load: async () => {},
+    };
+    return selector ? selector(state) : state;
+  };
+  return {
+    ...mod,
+    useMarketplacesStore: Object.assign(hook, mod.useMarketplacesStore),
+  };
+});
+
+const catalog: Catalog = {
+  by: "subscription",
+  scope: { scope: "global" },
+  source: "kit",
+};
+
+const row: MarketplaceRow = {
+  scope: { scope: "global" },
+  name: "kit",
+  repo: "Acme/Kit",
+  repoKey: "acme/kit",
+  path: null,
+  rev: null,
+  commit: null,
+  enabled: true,
+  counts: null,
+  meta: null,
+  mode: null,
+};
+
+const render = () =>
+  renderToStaticMarkup(
+    <DetailHeader
+      requested={catalog}
+      catalog={catalog}
+      row={row}
+      summary={null}
+    />,
+  );
+
+beforeEach(() => {
+  stub.loaded = true;
+  stub.rowsCurrent = true;
+  stub.checkError = null;
+});
+
+// The detail page selects its row from the store's retained rows, so a
+// failed overview re-read leaves it drawing a subscription nobody could
+// confirm — said on the page, with its changes held until a read answers.
+describe("DetailHeader for a subscription a failed read left behind", () => {
+  it("holds the switch and says the row may be stale, with the retry", () => {
+    stub.rowsCurrent = false;
+    stub.checkError = "offline";
+    const html = render();
+    expect(html).toMatch(/<span[^>]*data-disabled=""[^>]*role="switch"/);
+    expect(html).toContain(`title="${MARKETPLACES_NEEDS_CHECK_NOTE}"`);
+    expect(html).toContain(MARKETPLACES_UNCONFIRMED_TITLE);
+    expect(html).toContain("offline");
+    expect(html).toContain(TRY_AGAIN_LABEL);
+  });
+
+  it("carries no stale note or held switch over a current read", () => {
+    const html = render();
+    expect(html).not.toContain(MARKETPLACES_UNCONFIRMED_TITLE);
+    expect(html).not.toMatch(/<span[^>]*data-disabled=""[^>]*role="switch"/);
+  });
+});

--- a/ui/src/components/marketplaces/detail-header.tsx
+++ b/ui/src/components/marketplaces/detail-header.tsx
@@ -4,6 +4,7 @@ import type { Catalog, CatalogSummary, MarketplaceRow } from "@/bindings";
 import { RepoAction } from "@/components/marketplaces/repo-action";
 import { UnsubscribeDialog } from "@/components/marketplaces/unsubscribe-dialog";
 import { PageHeader } from "@/components/page-header";
+import { StatusNote } from "@/components/status-note";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import {
@@ -13,6 +14,12 @@ import {
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
 import { Switch } from "@/components/ui/switch";
+import { TRY_AGAIN_LABEL } from "@/lib/copy";
+import {
+  MARKETPLACES_NEEDS_CHECK_NOTE,
+  MARKETPLACES_UNCONFIRMED_TITLE,
+} from "@/lib/copy-marketplaces";
+import { PAGE_BODY, WIDE_CONTENT_WIDTH } from "@/lib/layout";
 import { cn } from "@/lib/utils";
 import { useCommunityStore } from "@/stores/community";
 import { useMarketplacesStore } from "@/stores/marketplaces";
@@ -36,6 +43,15 @@ export function DetailHeader({
   const toggle = useMarketplacesStore((s) => s.toggle);
   const checkForUpdates = useMarketplacesStore((s) => s.checkForUpdates);
   const busy = useMarketplacesStore((s) => s.busy);
+  // A subscription row selected from rows a failed read left behind may
+  // not be the subscription as it stands now: its switch and Unsubscribe
+  // wait for a read that succeeds, and the page says so below the header.
+  // Check for updates stays live — it is the way back.
+  const loaded = useMarketplacesStore((s) => s.loaded);
+  const rowsCurrent = useMarketplacesStore((s) => s.rowsCurrent);
+  const checkError = useMarketplacesStore((s) => s.checkError);
+  const load = useMarketplacesStore((s) => s.load);
+  const stale = catalog.by === "subscription" && loaded && !rowsCurrent;
   const listing = useCommunityStore((s) =>
     requested.by === "repo"
       ? s.directory?.rows.find((r) => r.repo === requested.repo)
@@ -66,6 +82,8 @@ export function DetailHeader({
         {row ? (
           <Switch
             checked={row.enabled}
+            disabled={stale}
+            title={stale ? MARKETPLACES_NEEDS_CHECK_NOTE : undefined}
             onCheckedChange={(enabled) => void toggle(scope, source, enabled)}
             aria-label={row.enabled ? "Turn off" : "Turn on"}
           />
@@ -90,6 +108,7 @@ export function DetailHeader({
           <DropdownMenuContent align="end">
             <DropdownMenuItem
               className="text-critical"
+              disabled={stale}
               onClick={() => setUnsubscribeOpen(true)}
             >
               Unsubscribe…
@@ -115,36 +134,55 @@ export function DetailHeader({
   }
 
   return (
-    <PageHeader
-      wide
-      title={
-        <span className="flex items-center gap-2.5">
-          {title}
-          {listing?.featured ? (
-            <Badge variant="secondary" className="gap-1">
-              <Star className="size-3" /> featured
-            </Badge>
-          ) : null}
-        </span>
-      }
-      subtitle={
-        <>
-          {description ? <p>{description}</p> : null}
-          {metaLine.length > 0 ? (
-            <p className="mt-1 font-mono text-xs">{metaLine.join(" · ")}</p>
-          ) : null}
-          {tags.length > 0 ? (
-            <span className="mt-2 flex flex-wrap gap-1.5">
-              {tags.map((tag) => (
-                <Badge key={tag} variant="secondary">
-                  {tag}
-                </Badge>
-              ))}
-            </span>
-          ) : null}
-        </>
-      }
-      action={action}
-    />
+    <>
+      <PageHeader
+        wide
+        title={
+          <span className="flex items-center gap-2.5">
+            {title}
+            {listing?.featured ? (
+              <Badge variant="secondary" className="gap-1">
+                <Star className="size-3" /> featured
+              </Badge>
+            ) : null}
+          </span>
+        }
+        subtitle={
+          <>
+            {description ? <p>{description}</p> : null}
+            {metaLine.length > 0 ? (
+              <p className="mt-1 font-mono text-xs">{metaLine.join(" · ")}</p>
+            ) : null}
+            {tags.length > 0 ? (
+              <span className="mt-2 flex flex-wrap gap-1.5">
+                {tags.map((tag) => (
+                  <Badge key={tag} variant="secondary">
+                    {tag}
+                  </Badge>
+                ))}
+              </span>
+            ) : null}
+          </>
+        }
+        action={action}
+      />
+      {stale ? (
+        <div className={cn(PAGE_BODY, "pt-0")}>
+          <div className={WIDE_CONTENT_WIDTH}>
+            <StatusNote
+              tone="warning"
+              title={MARKETPLACES_UNCONFIRMED_TITLE}
+              action={
+                <Button size="sm" variant="outline" onClick={() => void load()}>
+                  {TRY_AGAIN_LABEL}
+                </Button>
+              }
+            >
+              {checkError}
+            </StatusNote>
+          </div>
+        </div>
+      ) : null}
+    </>
   );
 }

--- a/ui/src/components/marketplaces/subscribed-row.tsx
+++ b/ui/src/components/marketplaces/subscribed-row.tsx
@@ -10,6 +10,7 @@ import {
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
 import { Switch } from "@/components/ui/switch";
+import { MARKETPLACES_NEEDS_CHECK_NOTE } from "@/lib/copy-marketplaces";
 import { subscription, useMarketplacesStore } from "@/stores/marketplaces";
 import { useNavStore } from "@/stores/nav";
 
@@ -25,6 +26,10 @@ export function SubscribedRow({ row }: { row: MarketplaceRow }) {
   const toggle = useMarketplacesStore((s) => s.toggle);
   const checkForUpdates = useMarketplacesStore((s) => s.checkForUpdates);
   const busy = useMarketplacesStore((s) => s.busy);
+  // A row kept from before a failed read may not be the subscription as it
+  // stands now — changing or removing it acts on a guess. Check for
+  // updates stays live: it is the way back to a confirmed answer.
+  const rowsCurrent = useMarketplacesStore((s) => s.rowsCurrent);
   const [unsubscribeOpen, setUnsubscribeOpen] = useState(false);
 
   const where = row.repo ?? row.path ?? "";
@@ -55,6 +60,8 @@ export function SubscribedRow({ row }: { row: MarketplaceRow }) {
       </div>
       <Switch
         checked={row.enabled}
+        disabled={!rowsCurrent}
+        title={rowsCurrent ? undefined : MARKETPLACES_NEEDS_CHECK_NOTE}
         onCheckedChange={(enabled) => void toggle(row.scope, row.name, enabled)}
         aria-label={row.enabled ? "Turn off" : "Turn on"}
       />
@@ -81,12 +88,14 @@ export function SubscribedRow({ row }: { row: MarketplaceRow }) {
             <RefreshCw className="size-4" /> Check for updates
           </DropdownMenuItem>
           <DropdownMenuItem
+            disabled={!rowsCurrent}
             onClick={() => void toggle(row.scope, row.name, !row.enabled)}
           >
             {row.enabled ? "Turn off" : "Turn on"}
           </DropdownMenuItem>
           <DropdownMenuItem
             className="text-critical"
+            disabled={!rowsCurrent}
             onClick={() => setUnsubscribeOpen(true)}
           >
             Unsubscribe…

--- a/ui/src/components/marketplaces/subscribed-tab.test.tsx
+++ b/ui/src/components/marketplaces/subscribed-tab.test.tsx
@@ -1,0 +1,65 @@
+import { renderToStaticMarkup } from "react-dom/server";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  MARKETPLACES_CHECK_FAILED_TITLE,
+  MARKETPLACES_EMPTY_TITLE,
+  TRY_AGAIN_LABEL,
+} from "@/lib/copy";
+import { SubscribedTab } from "./subscribed-tab";
+
+// Static markup escapes apostrophes, so a pinned copy token must be
+// escaped the same way before it can be looked for.
+const esc = (copy: string) => copy.replace(/'/g, "&#x27;");
+
+// Static rendering reads a zustand store's initial snapshot, never one set
+// later, so the store is wrapped to let a test stage what the last read
+// left behind.
+const stub = vi.hoisted(() => ({
+  loaded: true,
+  rowsCurrent: true,
+  error: null as string | null,
+}));
+
+vi.mock("@/stores/marketplaces", async (importOriginal) => {
+  const mod = await importOriginal<typeof import("@/stores/marketplaces")>();
+  const hook = (selector?: (state: unknown) => unknown) => {
+    const state = {
+      ...mod.useMarketplacesStore.getState(),
+      rows: [],
+      ...stub,
+      load: async () => {},
+    };
+    return selector ? selector(state) : state;
+  };
+  return {
+    ...mod,
+    useMarketplacesStore: Object.assign(hook, mod.useMarketplacesStore),
+  };
+});
+
+beforeEach(() => {
+  stub.loaded = true;
+  stub.rowsCurrent = true;
+  stub.error = null;
+});
+
+// Empty rows after a read that failed are not a confirmed emptiness:
+// "No marketplaces yet" with a Subscribe pitch would draw the failure as
+// the exact good news nobody could check.
+describe("SubscribedTab with nothing to list", () => {
+  it("invites a subscription only after a read confirmed the emptiness", () => {
+    const html = renderToStaticMarkup(<SubscribedTab onSubscribe={() => {}} />);
+    expect(html).toContain(MARKETPLACES_EMPTY_TITLE);
+    expect(html).not.toContain(esc(MARKETPLACES_CHECK_FAILED_TITLE));
+  });
+
+  it("shows the failure with the retry when the read failed, not the pitch", () => {
+    stub.rowsCurrent = false;
+    stub.error = "offline";
+    const html = renderToStaticMarkup(<SubscribedTab onSubscribe={() => {}} />);
+    expect(html).toContain(esc(MARKETPLACES_CHECK_FAILED_TITLE));
+    expect(html).toContain("offline");
+    expect(html).toContain(TRY_AGAIN_LABEL);
+    expect(html).not.toContain(MARKETPLACES_EMPTY_TITLE);
+  });
+});

--- a/ui/src/components/marketplaces/subscribed-tab.test.tsx
+++ b/ui/src/components/marketplaces/subscribed-tab.test.tsx
@@ -21,7 +21,7 @@ const stub = vi.hoisted(() => ({
   rows: [] as unknown[],
   loaded: true,
   rowsCurrent: true,
-  error: null as string | null,
+  checkError: null as string | null,
 }));
 
 vi.mock("@/stores/marketplaces", async (importOriginal) => {
@@ -58,7 +58,7 @@ beforeEach(() => {
   stub.rows = [];
   stub.loaded = true;
   stub.rowsCurrent = true;
-  stub.error = null;
+  stub.checkError = null;
 });
 
 // Empty rows after a read that failed are not a confirmed emptiness:
@@ -73,7 +73,7 @@ describe("SubscribedTab with nothing to list", () => {
 
   it("shows the failure with the retry when the read failed, not the pitch", () => {
     stub.rowsCurrent = false;
-    stub.error = "offline";
+    stub.checkError = "offline";
     const html = renderToStaticMarkup(<SubscribedTab onSubscribe={() => {}} />);
     expect(html).toContain(esc(MARKETPLACES_CHECK_FAILED_TITLE));
     expect(html).toContain("offline");
@@ -89,7 +89,7 @@ describe("SubscribedTab with rows a failed read left behind", () => {
   it("draws them under the stale note with the retry", () => {
     stub.rows = [kept];
     stub.rowsCurrent = false;
-    stub.error = "offline";
+    stub.checkError = "offline";
     const html = renderToStaticMarkup(<SubscribedTab onSubscribe={() => {}} />);
     expect(html).toContain(MARKETPLACES_UNCONFIRMED_TITLE);
     expect(html).toContain("offline");
@@ -101,7 +101,7 @@ describe("SubscribedTab with rows a failed read left behind", () => {
   it("holds the toggle until a read succeeds again", () => {
     stub.rows = [kept];
     stub.rowsCurrent = false;
-    stub.error = "offline";
+    stub.checkError = "offline";
     const html = renderToStaticMarkup(<SubscribedTab onSubscribe={() => {}} />);
     expect(html).toMatch(/<span[^>]*data-disabled=""[^>]*role="switch"/);
     expect(html).toContain(`title="${MARKETPLACES_NEEDS_CHECK_NOTE}"`);

--- a/ui/src/components/marketplaces/subscribed-tab.test.tsx
+++ b/ui/src/components/marketplaces/subscribed-tab.test.tsx
@@ -1,10 +1,13 @@
 import { renderToStaticMarkup } from "react-dom/server";
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { MarketplaceRow } from "@/bindings";
+import { TRY_AGAIN_LABEL } from "@/lib/copy";
 import {
   MARKETPLACES_CHECK_FAILED_TITLE,
   MARKETPLACES_EMPTY_TITLE,
-  TRY_AGAIN_LABEL,
-} from "@/lib/copy";
+  MARKETPLACES_NEEDS_CHECK_NOTE,
+  MARKETPLACES_UNCONFIRMED_TITLE,
+} from "@/lib/copy-marketplaces";
 import { SubscribedTab } from "./subscribed-tab";
 
 // Static markup escapes apostrophes, so a pinned copy token must be
@@ -15,6 +18,7 @@ const esc = (copy: string) => copy.replace(/'/g, "&#x27;");
 // later, so the store is wrapped to let a test stage what the last read
 // left behind.
 const stub = vi.hoisted(() => ({
+  rows: [] as unknown[],
   loaded: true,
   rowsCurrent: true,
   error: null as string | null,
@@ -25,7 +29,6 @@ vi.mock("@/stores/marketplaces", async (importOriginal) => {
   const hook = (selector?: (state: unknown) => unknown) => {
     const state = {
       ...mod.useMarketplacesStore.getState(),
-      rows: [],
       ...stub,
       load: async () => {},
     };
@@ -37,7 +40,22 @@ vi.mock("@/stores/marketplaces", async (importOriginal) => {
   };
 });
 
+const kept: MarketplaceRow = {
+  scope: { scope: "global" },
+  name: "kit",
+  repo: "Acme/Kit",
+  repoKey: "acme/kit",
+  path: null,
+  rev: null,
+  commit: null,
+  enabled: true,
+  counts: null,
+  meta: null,
+  mode: null,
+};
+
 beforeEach(() => {
+  stub.rows = [];
   stub.loaded = true;
   stub.rowsCurrent = true;
   stub.error = null;
@@ -61,5 +79,38 @@ describe("SubscribedTab with nothing to list", () => {
     expect(html).toContain("offline");
     expect(html).toContain(TRY_AGAIN_LABEL);
     expect(html).not.toContain(MARKETPLACES_EMPTY_TITLE);
+  });
+});
+
+// Rows kept from before a failed read stay on screen, but headed as the
+// last read that answered — and acting on them would act on a guess, so
+// the toggle waits for a read that succeeds.
+describe("SubscribedTab with rows a failed read left behind", () => {
+  it("draws them under the stale note with the retry", () => {
+    stub.rows = [kept];
+    stub.rowsCurrent = false;
+    stub.error = "offline";
+    const html = renderToStaticMarkup(<SubscribedTab onSubscribe={() => {}} />);
+    expect(html).toContain(MARKETPLACES_UNCONFIRMED_TITLE);
+    expect(html).toContain("offline");
+    expect(html).toContain(TRY_AGAIN_LABEL);
+    // The kept rows are still drawn under it.
+    expect(html).toContain("kit");
+  });
+
+  it("holds the toggle until a read succeeds again", () => {
+    stub.rows = [kept];
+    stub.rowsCurrent = false;
+    stub.error = "offline";
+    const html = renderToStaticMarkup(<SubscribedTab onSubscribe={() => {}} />);
+    expect(html).toMatch(/<span[^>]*data-disabled=""[^>]*role="switch"/);
+    expect(html).toContain(`title="${MARKETPLACES_NEEDS_CHECK_NOTE}"`);
+  });
+
+  it("carries no stale note over rows from a current read", () => {
+    stub.rows = [kept];
+    const html = renderToStaticMarkup(<SubscribedTab onSubscribe={() => {}} />);
+    expect(html).not.toContain(MARKETPLACES_UNCONFIRMED_TITLE);
+    expect(html).not.toMatch(/<span[^>]*data-disabled=""[^>]*role="switch"/);
   });
 });

--- a/ui/src/components/marketplaces/subscribed-tab.tsx
+++ b/ui/src/components/marketplaces/subscribed-tab.tsx
@@ -22,7 +22,9 @@ export function SubscribedTab({ onSubscribe }: { onSubscribe: () => void }) {
   const rows = useMarketplacesStore((s) => s.rows);
   const loaded = useMarketplacesStore((s) => s.loaded);
   const rowsCurrent = useMarketplacesStore((s) => s.rowsCurrent);
-  const error = useMarketplacesStore((s) => s.error);
+  // `checkError`, not the store's shared `error`: actions write the shared
+  // field too, and a failed subscribe is not a failed overview read.
+  const checkError = useMarketplacesStore((s) => s.checkError);
   const load = useMarketplacesStore((s) => s.load);
 
   if (loaded && rows.length === 0) {
@@ -40,7 +42,7 @@ export function SubscribedTab({ onSubscribe }: { onSubscribe: () => void }) {
             </Button>
           }
         >
-          {error}
+          {checkError}
         </EmptyState>
       );
     }
@@ -73,7 +75,7 @@ export function SubscribedTab({ onSubscribe }: { onSubscribe: () => void }) {
               </Button>
             }
           >
-            {error}
+            {checkError}
           </StatusNote>
         ) : null}
         {groups.map(({ scope, list }) => (

--- a/ui/src/components/marketplaces/subscribed-tab.tsx
+++ b/ui/src/components/marketplaces/subscribed-tab.tsx
@@ -1,8 +1,13 @@
-import { Store } from "lucide-react";
+import { Store, TriangleAlert } from "lucide-react";
 import type { MarketplaceRow, Scope } from "@/bindings";
 import { EmptyState } from "@/components/empty-state";
 import { SubscribedRow } from "@/components/marketplaces/subscribed-row";
 import { Button } from "@/components/ui/button";
+import {
+  MARKETPLACES_CHECK_FAILED_TITLE,
+  MARKETPLACES_EMPTY_TITLE,
+  TRY_AGAIN_LABEL,
+} from "@/lib/copy";
 import { scopeLabel } from "@/lib/derive";
 import { scopeName, scopePath } from "@/lib/labels";
 import { PAGE_BODY, WIDE_CONTENT_WIDTH } from "@/lib/layout";
@@ -14,12 +19,33 @@ import { useMarketplacesStore } from "@/stores/marketplaces";
 export function SubscribedTab({ onSubscribe }: { onSubscribe: () => void }) {
   const rows = useMarketplacesStore((s) => s.rows);
   const loaded = useMarketplacesStore((s) => s.loaded);
+  const rowsCurrent = useMarketplacesStore((s) => s.rowsCurrent);
+  const error = useMarketplacesStore((s) => s.error);
+  const load = useMarketplacesStore((s) => s.load);
 
   if (loaded && rows.length === 0) {
+    // Empty with nothing retained from a read that failed is a failure to
+    // show, not an invitation to subscribe: "No marketplaces yet" here
+    // would assert an emptiness nobody could check.
+    if (!rowsCurrent) {
+      return (
+        <EmptyState
+          icon={TriangleAlert}
+          title={MARKETPLACES_CHECK_FAILED_TITLE}
+          action={
+            <Button variant="outline" onClick={() => void load()}>
+              {TRY_AGAIN_LABEL}
+            </Button>
+          }
+        >
+          {error}
+        </EmptyState>
+      );
+    }
     return (
       <EmptyState
         icon={Store}
-        title="No marketplaces yet"
+        title={MARKETPLACES_EMPTY_TITLE}
         action={<Button onClick={onSubscribe}>Subscribe to one</Button>}
       >
         Subscribe to a repository of skills and agents to start installing from

--- a/ui/src/components/marketplaces/subscribed-tab.tsx
+++ b/ui/src/components/marketplaces/subscribed-tab.tsx
@@ -2,12 +2,14 @@ import { Store, TriangleAlert } from "lucide-react";
 import type { MarketplaceRow, Scope } from "@/bindings";
 import { EmptyState } from "@/components/empty-state";
 import { SubscribedRow } from "@/components/marketplaces/subscribed-row";
+import { StatusNote } from "@/components/status-note";
 import { Button } from "@/components/ui/button";
+import { TRY_AGAIN_LABEL } from "@/lib/copy";
 import {
   MARKETPLACES_CHECK_FAILED_TITLE,
   MARKETPLACES_EMPTY_TITLE,
-  TRY_AGAIN_LABEL,
-} from "@/lib/copy";
+  MARKETPLACES_UNCONFIRMED_TITLE,
+} from "@/lib/copy-marketplaces";
 import { scopeLabel } from "@/lib/derive";
 import { scopeName, scopePath } from "@/lib/labels";
 import { PAGE_BODY, WIDE_CONTENT_WIDTH } from "@/lib/layout";
@@ -58,6 +60,22 @@ export function SubscribedTab({ onSubscribe }: { onSubscribe: () => void }) {
   return (
     <div className={cn(PAGE_BODY, "pt-0")}>
       <div className={cn(WIDE_CONTENT_WIDTH, "space-y-8")}>
+        {/* Rows kept from before a failed read stay on screen — right —
+            but headed as what they are: the last read that answered, not
+            confirmed subscriptions. Their actions gate on the same flag. */}
+        {loaded && !rowsCurrent ? (
+          <StatusNote
+            tone="warning"
+            title={MARKETPLACES_UNCONFIRMED_TITLE}
+            action={
+              <Button size="sm" variant="outline" onClick={() => void load()}>
+                {TRY_AGAIN_LABEL}
+              </Button>
+            }
+          >
+            {error}
+          </StatusNote>
+        ) : null}
         {groups.map(({ scope, list }) => (
           <section key={scopeLabel(scope)}>
             <div className="mb-2 flex items-baseline gap-2">

--- a/ui/src/components/marketplaces/unsubscribe-dialog.tsx
+++ b/ui/src/components/marketplaces/unsubscribe-dialog.tsx
@@ -10,6 +10,7 @@ import {
   DialogTitle,
 } from "@/components/ui/dialog";
 import { Label } from "@/components/ui/label";
+import { MARKETPLACES_NEEDS_CHECK_NOTE } from "@/lib/copy-marketplaces";
 import { kindLabel, scopeName } from "@/lib/labels";
 import { cn } from "@/lib/utils";
 import { useMarketplacesStore } from "@/stores/marketplaces";
@@ -30,6 +31,9 @@ export function UnsubscribeDialog({
 }) {
   const unsubscribe = useMarketplacesStore((s) => s.unsubscribe);
   const busy = useMarketplacesStore((s) => s.busy);
+  // The read can fail underneath an open dialog; the store action refuses
+  // stale rows regardless, and this keeps the button honest about it.
+  const rowsCurrent = useMarketplacesStore((s) => s.rowsCurrent);
   const [preview, setPreview] = useState<UnsubscribePreview | null>(null);
   const [previewError, setPreviewError] = useState<string | null>(null);
   const [keep, setKeep] = useState(true);
@@ -126,6 +130,12 @@ export function UnsubscribeDialog({
           </div>
         ) : null}
 
+        {!rowsCurrent ? (
+          <p className="text-sm text-warning" role="alert">
+            {MARKETPLACES_NEEDS_CHECK_NOTE}
+          </p>
+        ) : null}
+
         {error ? (
           <p className="text-sm text-critical" role="alert">
             {error}
@@ -138,7 +148,8 @@ export function UnsubscribeDialog({
           </Button>
           <Button
             variant="destructive"
-            disabled={busy || !preview || hasEdited}
+            disabled={busy || !preview || hasEdited || !rowsCurrent}
+            title={!rowsCurrent ? MARKETPLACES_NEEDS_CHECK_NOTE : undefined}
             onClick={confirm}
           >
             {busy ? "Unsubscribing…" : "Unsubscribe"}

--- a/ui/src/components/package/fork-notice.tsx
+++ b/ui/src/components/package/fork-notice.tsx
@@ -42,10 +42,11 @@ export function ForkNotice({
 }) {
   const busy = useUpdatesStore((s) => s.busy);
   // Discarding applies the retained row's latest commit when the place is
-  // held — from rows a failed check left behind, that pins an old version,
-  // so the discard waits for a check. Keeping the files as a fork copies
-  // what is on disk and stays live.
-  const loaded = useUpdatesStore((s) => s.loaded);
+  // held — from rows a failed check left behind, or rows a running check
+  // is about to replace, that pins an old version — so the discard waits
+  // for a check. Keeping the files as a fork copies what is on disk and
+  // stays live.
+  const held = useUpdatesStore((s) => !s.loaded || s.checking);
   const [confirmDiscard, setConfirmDiscard] = useState(false);
   const several = row.editedHarnesses.length > 1;
   const whyNoFork = row.derived
@@ -102,8 +103,8 @@ export function ForkNotice({
           <Button
             size="sm"
             variant="outline"
-            disabled={busy || !loaded}
-            title={!loaded ? UPDATE_NEEDS_CHECK_NOTE : undefined}
+            disabled={busy || held}
+            title={held ? UPDATE_NEEDS_CHECK_NOTE : undefined}
             onClick={() => setConfirmDiscard(true)}
           >
             {several ? DISCARD_ALL_EDITS_LABEL : DISCARD_EDITS_LABEL}
@@ -118,7 +119,7 @@ export function ForkNotice({
         confirmLabel={DISCARD_EDITS_CONFIRM_LABEL}
         destructive
         busy={busy}
-        confirmDisabled={!loaded}
+        confirmDisabled={held}
         confirmDisabledNote={UPDATE_NEEDS_CHECK_NOTE}
         onConfirm={() =>
           void takeNewVersion(row).then(() => {

--- a/ui/src/components/package/fork-notice.tsx
+++ b/ui/src/components/package/fork-notice.tsx
@@ -46,7 +46,9 @@ export function ForkNotice({
   // is about to replace, that pins an old version — so the discard waits
   // for a check. Keeping the files as a fork copies what is on disk and
   // stays live.
-  const held = useUpdatesStore((s) => !s.loaded || s.checking);
+  const held = useUpdatesStore(
+    (s) => !s.loaded || s.checking || s.overviewInFlight,
+  );
   const [confirmDiscard, setConfirmDiscard] = useState(false);
   const several = row.editedHarnesses.length > 1;
   const whyNoFork = row.derived

--- a/ui/src/components/package/fork-notice.tsx
+++ b/ui/src/components/package/fork-notice.tsx
@@ -19,6 +19,7 @@ import {
   VIEW_CHANGES_LABEL,
   viewChangesInLabel,
 } from "@/lib/copy";
+import { UPDATE_NEEDS_CHECK_NOTE } from "@/lib/copy-updates";
 import { harnessName } from "@/lib/labels";
 import { sameScope } from "@/lib/scope";
 import { useUpdatesStore } from "@/stores/updates";
@@ -40,6 +41,11 @@ export function ForkNotice({
   onResolved: () => void;
 }) {
   const busy = useUpdatesStore((s) => s.busy);
+  // Discarding applies the retained row's latest commit when the place is
+  // held — from rows a failed check left behind, that pins an old version,
+  // so the discard waits for a check. Keeping the files as a fork copies
+  // what is on disk and stays live.
+  const loaded = useUpdatesStore((s) => s.loaded);
   const [confirmDiscard, setConfirmDiscard] = useState(false);
   const several = row.editedHarnesses.length > 1;
   const whyNoFork = row.derived
@@ -96,7 +102,8 @@ export function ForkNotice({
           <Button
             size="sm"
             variant="outline"
-            disabled={busy}
+            disabled={busy || !loaded}
+            title={!loaded ? UPDATE_NEEDS_CHECK_NOTE : undefined}
             onClick={() => setConfirmDiscard(true)}
           >
             {several ? DISCARD_ALL_EDITS_LABEL : DISCARD_EDITS_LABEL}
@@ -111,6 +118,8 @@ export function ForkNotice({
         confirmLabel={DISCARD_EDITS_CONFIRM_LABEL}
         destructive
         busy={busy}
+        confirmDisabled={!loaded}
+        confirmDisabledNote={UPDATE_NEEDS_CHECK_NOTE}
         onConfirm={() =>
           void takeNewVersion(row).then(() => {
             setConfirmDiscard(false);

--- a/ui/src/components/sidebar.test.tsx
+++ b/ui/src/components/sidebar.test.tsx
@@ -2,6 +2,7 @@ import { renderToStaticMarkup } from "react-dom/server";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { UPDATES_ATTENTION_TITLE } from "@/lib/copy";
 import { Sidebar } from "./sidebar";
+import { updateRow } from "./updates-test-rows";
 
 // Static markup escapes apostrophes, so a pinned copy token must be
 // escaped the same way before it can be looked for.
@@ -40,6 +41,18 @@ describe("the Updates badge after a failed check", () => {
     stub.updates = { rows: [], error: "no network" };
     const html = renderToStaticMarkup(<Sidebar />);
     expect(html).toContain(">?<");
+    expect(html).toContain(esc(UPDATES_ATTENTION_TITLE));
+  });
+
+  // Rows kept from before the failure still carry their count — last-known
+  // is worth showing — but the badge wears the warning tone for it rather
+  // than presenting the number as confirmed.
+  it("keeps a last-known count, in the warning tone", () => {
+    stub.updates = { rows: [updateRow("gh", null)], error: "no network" };
+    const html = renderToStaticMarkup(<Sidebar />);
+    expect(html).toContain(">1<");
+    expect(html).not.toContain(">?<");
+    expect(html).toContain("text-warning");
     expect(html).toContain(esc(UPDATES_ATTENTION_TITLE));
   });
 });

--- a/ui/src/components/sidebar.test.tsx
+++ b/ui/src/components/sidebar.test.tsx
@@ -1,0 +1,45 @@
+import { renderToStaticMarkup } from "react-dom/server";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { UPDATES_ATTENTION_TITLE } from "@/lib/copy";
+import { Sidebar } from "./sidebar";
+
+// Static markup escapes apostrophes, so a pinned copy token must be
+// escaped the same way before it can be looked for.
+const esc = (copy: string) => copy.replace(/'/g, "&#x27;");
+
+// Static rendering reads a zustand store's initial snapshot, never one set
+// later, so the updates store is wrapped to stage what the last check left.
+const stub = vi.hoisted(() => ({
+  updates: { rows: [] as unknown[], error: null as string | null },
+}));
+
+vi.mock("@/stores/updates", async (importOriginal) => {
+  const mod = await importOriginal<typeof import("@/stores/updates")>();
+  const hook = (selector?: (state: unknown) => unknown) => {
+    const state = { ...mod.useUpdatesStore.getState(), ...stub.updates };
+    return selector ? selector(state) : state;
+  };
+  return { ...mod, useUpdatesStore: Object.assign(hook, mod.useUpdatesStore) };
+});
+
+beforeEach(() => {
+  stub.updates = { rows: [], error: null };
+});
+
+// Before the first read the badge is absent because nothing is known yet;
+// after a failed check, absence would read as "nothing to update" — the
+// row wears the question mark and says why instead.
+describe("the Updates badge after a failed check", () => {
+  it("shows no badge while nothing is known and nothing failed", () => {
+    const html = renderToStaticMarkup(<Sidebar />);
+    expect(html).not.toContain(esc(UPDATES_ATTENTION_TITLE));
+    expect(html).not.toContain(">?<");
+  });
+
+  it("marks the row rather than staying silent", () => {
+    stub.updates = { rows: [], error: "no network" };
+    const html = renderToStaticMarkup(<Sidebar />);
+    expect(html).toContain(">?<");
+    expect(html).toContain(esc(UPDATES_ATTENTION_TITLE));
+  });
+});

--- a/ui/src/components/sidebar.tsx
+++ b/ui/src/components/sidebar.tsx
@@ -14,6 +14,7 @@ import { useEffect } from "react";
 import { commands } from "@/bindings";
 import { Button } from "@/components/ui/button";
 import { auditCounts, needsReviewCount } from "@/lib/audit-counts";
+import { UPDATES_ATTENTION_TITLE } from "@/lib/copy";
 import { isSearchShortcutKey } from "@/lib/search-shortcut";
 import { cn } from "@/lib/utils";
 import { useAuditStore } from "@/stores/audit";
@@ -47,6 +48,10 @@ export function Sidebar() {
     needsReviewCount(auditCounts(s.views)),
   );
   const updateCount = useUpdatesStore((s) => visibleUpdateCount(s.rows));
+  // A failed check keeps the last rows, so any count shown is last-known;
+  // the badge wears the warning tone for it. With no rows at all, "?" is
+  // the honest number: absence would read as "nothing to update".
+  const updatesUnchecked = useUpdatesStore((s) => s.error !== null);
 
   // The shortcut lives in the always-mounted chrome so "/" works on every
   // page, not only the one holding the search box.
@@ -112,9 +117,17 @@ export function Sidebar() {
                 {driftCount}
               </span>
             ) : null}
-            {target === "updates" && updateCount > 0 ? (
-              <span className="rounded bg-foreground/[0.09] px-1.5 py-0.5 text-[11px] font-medium tabular-nums">
-                {updateCount}
+            {target === "updates" && (updateCount > 0 || updatesUnchecked) ? (
+              <span
+                title={updatesUnchecked ? UPDATES_ATTENTION_TITLE : undefined}
+                className={cn(
+                  "rounded px-1.5 py-0.5 text-[11px] font-medium tabular-nums",
+                  updatesUnchecked
+                    ? "bg-warning/15 text-warning"
+                    : "bg-foreground/[0.09]",
+                )}
+              >
+                {updateCount > 0 ? updateCount : "?"}
               </span>
             ) : null}
           </button>

--- a/ui/src/components/sidebar.tsx
+++ b/ui/src/components/sidebar.tsx
@@ -16,11 +16,12 @@ import { Button } from "@/components/ui/button";
 import { auditCounts, needsReviewCount } from "@/lib/audit-counts";
 import { UPDATES_ATTENTION_TITLE } from "@/lib/copy";
 import { isSearchShortcutKey } from "@/lib/search-shortcut";
+import { visibleUpdateCount } from "@/lib/update-groups";
 import { cn } from "@/lib/utils";
 import { useAuditStore } from "@/stores/audit";
 import { type Page, useNavStore } from "@/stores/nav";
 import { useScanStore } from "@/stores/scan";
-import { useUpdatesStore, visibleUpdateCount } from "@/stores/updates";
+import { useUpdatesStore } from "@/stores/updates";
 
 // One row shape for every nav item, so the icon column and the text column
 // line up down the whole sidebar. The transparent border is load-bearing:

--- a/ui/src/components/stat-tile.tsx
+++ b/ui/src/components/stat-tile.tsx
@@ -9,9 +9,10 @@ export function StatTile({
   onClick,
 }: {
   label: string;
-  /** A count, or "—" when the read behind it has not answered — a tile
-   *  must not show a definite zero off a read that failed. */
-  value: number | string;
+  /** A count, or null when the read behind it has not answered — a tile
+   *  must not show a definite zero off a read that failed, and the dash
+   *  that stands in is this component's to draw. */
+  value: number | null;
   detail?: ReactNode;
   onClick?: () => void;
 }) {
@@ -25,7 +26,7 @@ export function StatTile({
         onClick && "cursor-pointer hover:bg-accent",
       )}
     >
-      <p className="text-2xl font-semibold tracking-tight">{value}</p>
+      <p className="text-2xl font-semibold tracking-tight">{value ?? "—"}</p>
       <p className="text-xs font-medium tracking-widest text-muted-foreground uppercase">
         {label}
       </p>

--- a/ui/src/components/stat-tile.tsx
+++ b/ui/src/components/stat-tile.tsx
@@ -9,7 +9,9 @@ export function StatTile({
   onClick,
 }: {
   label: string;
-  value: number;
+  /** A count, or "—" when the read behind it has not answered — a tile
+   *  must not show a definite zero off a read that failed. */
+  value: number | string;
   detail?: ReactNode;
   onClick?: () => void;
 }) {

--- a/ui/src/components/status-footer.test.tsx
+++ b/ui/src/components/status-footer.test.tsx
@@ -1,0 +1,59 @@
+import { renderToStaticMarkup } from "react-dom/server";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { scanFailedStatusLabel, scanStatusLabel } from "@/lib/copy-footer";
+import { StatusFooter } from "./status-footer";
+
+// Static markup escapes apostrophes, so a pinned copy token must be
+// escaped the same way before it can be looked for.
+const esc = (copy: string) => copy.replace(/'/g, "&#x27;");
+
+// Static rendering reads a zustand store's initial snapshot, never one set
+// later, so the store is wrapped to let a test stage how the last scan
+// went.
+const stub = vi.hoisted(() => ({
+  scanning: false,
+  lastScanAt: null as number | null,
+  error: null as string | null,
+}));
+
+vi.mock("@/stores/scan", async (importOriginal) => {
+  const mod = await importOriginal<typeof import("@/stores/scan")>();
+  const hook = (selector?: (state: unknown) => unknown) => {
+    const state = { ...mod.useScanStore.getState(), ...stub };
+    return selector ? selector(state) : state;
+  };
+  return { ...mod, useScanStore: Object.assign(hook, mod.useScanStore) };
+});
+
+beforeEach(() => {
+  stub.scanning = false;
+  stub.lastScanAt = null;
+  stub.error = null;
+});
+
+// The footer is mounted on every page: "Up to date" beside a failed scan
+// would have it and Home answering the same question oppositely.
+describe("the status footer across scan states", () => {
+  it("calls a failed first scan failed, not up to date", () => {
+    stub.error = "config unreadable";
+    const html = renderToStaticMarkup(<StatusFooter />);
+    expect(html).toContain(esc(scanFailedStatusLabel(null)));
+    expect(html).not.toContain(scanStatusLabel(null));
+  });
+
+  it("labels a kept result last-known when a later scan fails", () => {
+    stub.error = "no disk";
+    stub.lastScanAt = Date.now() - 60_000;
+    const html = renderToStaticMarkup(<StatusFooter />);
+    // The age suffix moves with the clock; the label up to it is pinned.
+    expect(html).toContain(esc(scanFailedStatusLabel("")).trimEnd());
+    expect(html).not.toContain(scanStatusLabel(null));
+  });
+
+  it("says up to date only while no failure stands", () => {
+    stub.lastScanAt = Date.now() - 60_000;
+    const html = renderToStaticMarkup(<StatusFooter />);
+    expect(html).toContain(scanStatusLabel(null));
+    expect(html).not.toContain(esc(scanFailedStatusLabel(null)));
+  });
+});

--- a/ui/src/components/status-footer.tsx
+++ b/ui/src/components/status-footer.tsx
@@ -6,8 +6,9 @@ import {
   decisionsFooterLabel,
   pendingChangesLabel,
   SCANNING_LABEL,
+  scanFailedStatusLabel,
   scanStatusLabel,
-} from "@/lib/copy";
+} from "@/lib/copy-footer";
 import { problemsFooterLabel } from "@/lib/error-copy";
 import { relativeTime } from "@/lib/relative-time";
 import { useAuditStore } from "@/stores/audit";
@@ -23,6 +24,7 @@ const AGE_TICK_MS = 30_000;
 export function StatusFooter() {
   const scanning = useScanStore((s) => s.scanning);
   const lastScanAt = useScanStore((s) => s.lastScanAt);
+  const scanError = useScanStore((s) => s.error);
   const views = useAuditStore((s) => s.views);
   const problems = useProblems();
   const goTo = useNavStore((s) => s.goTo);
@@ -57,6 +59,15 @@ export function StatusFooter() {
             <>
               <RefreshCw className="size-3 animate-spin" />
               {SCANNING_LABEL}
+            </>
+          ) : scanError !== null ? (
+            // Never scanned is a failed status; a kept result is
+            // last-known — either way, not "Up to date".
+            <>
+              <StatusDot tone={lastScanAt ? "warning" : "critical"} />
+              {scanFailedStatusLabel(
+                lastScanAt ? relativeTime(lastScanAt, now) : null,
+              )}
             </>
           ) : (
             scanStatusLabel(lastScanAt ? relativeTime(lastScanAt, now) : null)

--- a/ui/src/components/update-place-cells.tsx
+++ b/ui/src/components/update-place-cells.tsx
@@ -42,11 +42,19 @@ export function PlaceCells({
   among: Scope[];
   onIgnore?: (row: UpdateRow) => void;
 }) {
-  const { busy, loaded, checking, updateOne, setAutoUpdate, setIgnored } =
-    useUpdatesStore();
-  // Mid-check the rows are about to be replaced; the store actions refuse
-  // regardless, and the controls say so instead of inviting the click.
-  const held = !loaded || checking;
+  const {
+    busy,
+    loaded,
+    checking,
+    overviewInFlight,
+    updateOne,
+    setAutoUpdate,
+    setIgnored,
+  } = useUpdatesStore();
+  // Anything overview-producing in flight is about to replace these rows;
+  // the store actions refuse regardless, and the controls say so instead
+  // of inviting the click.
+  const held = !loaded || checking || overviewInFlight;
   const goToPackage = useNavStore((s) => s.goToPackage);
   const name = packageDisplayName(row);
   const place = placeName(row.scope, among);

--- a/ui/src/components/update-place-cells.tsx
+++ b/ui/src/components/update-place-cells.tsx
@@ -20,6 +20,7 @@ import {
   followSourceLabel,
   HELD_BY_OWNER_NOTE,
   heldBySourceNote,
+  UPDATE_NEEDS_CHECK_NOTE,
 } from "@/lib/copy-updates";
 import { packageDisplayName } from "@/lib/labels";
 import { heldByOwner, placeName, switchLockedBy } from "@/lib/update-groups";
@@ -41,7 +42,8 @@ export function PlaceCells({
   among: Scope[];
   onIgnore?: (row: UpdateRow) => void;
 }) {
-  const { busy, updateOne, setAutoUpdate, setIgnored } = useUpdatesStore();
+  const { busy, loaded, updateOne, setAutoUpdate, setIgnored } =
+    useUpdatesStore();
   const goToPackage = useNavStore((s) => s.goToPackage);
   const name = packageDisplayName(row);
   const place = placeName(row.scope, among);
@@ -111,8 +113,16 @@ export function PlaceCells({
                 <Button
                   size="sm"
                   variant="outline"
-                  disabled={busy || !row.updateAvailable || heldByOwner(row)}
-                  title={heldByOwner(row) ? HELD_BY_OWNER_NOTE : undefined}
+                  disabled={
+                    busy || !loaded || !row.updateAvailable || heldByOwner(row)
+                  }
+                  title={
+                    heldByOwner(row)
+                      ? HELD_BY_OWNER_NOTE
+                      : !loaded
+                        ? UPDATE_NEEDS_CHECK_NOTE
+                        : undefined
+                  }
                   onClick={() => void updateOne(row)}
                 >
                   {UPDATE_LABEL}

--- a/ui/src/components/update-place-cells.tsx
+++ b/ui/src/components/update-place-cells.tsx
@@ -82,16 +82,21 @@ export function PlaceCells({
       ) : (
         <>
           <TableCell className="text-center">
+            {/* Switching follow OFF holds the package at row.current's
+                commit — from a stale row that pins it to an old version,
+                so the switch waits for a check the same as Update. */}
             <Switch
               aria-label={followSourceLabel(name, place)}
               checked={!row.pinned}
-              disabled={busy || locked !== null}
+              disabled={busy || !loaded || locked !== null}
               title={
                 locked?.kind === "source"
                   ? heldBySourceNote(locked.name)
                   : locked
                     ? HELD_BY_OWNER_NOTE
-                    : undefined
+                    : !loaded
+                      ? UPDATE_NEEDS_CHECK_NOTE
+                      : undefined
               }
               onCheckedChange={(follow) => void setAutoUpdate(row, follow)}
             />

--- a/ui/src/components/update-place-cells.tsx
+++ b/ui/src/components/update-place-cells.tsx
@@ -42,8 +42,11 @@ export function PlaceCells({
   among: Scope[];
   onIgnore?: (row: UpdateRow) => void;
 }) {
-  const { busy, loaded, updateOne, setAutoUpdate, setIgnored } =
+  const { busy, loaded, checking, updateOne, setAutoUpdate, setIgnored } =
     useUpdatesStore();
+  // Mid-check the rows are about to be replaced; the store actions refuse
+  // regardless, and the controls say so instead of inviting the click.
+  const held = !loaded || checking;
   const goToPackage = useNavStore((s) => s.goToPackage);
   const name = packageDisplayName(row);
   const place = placeName(row.scope, among);
@@ -88,13 +91,13 @@ export function PlaceCells({
             <Switch
               aria-label={followSourceLabel(name, place)}
               checked={!row.pinned}
-              disabled={busy || !loaded || locked !== null}
+              disabled={busy || held || locked !== null}
               title={
                 locked?.kind === "source"
                   ? heldBySourceNote(locked.name)
                   : locked
                     ? HELD_BY_OWNER_NOTE
-                    : !loaded
+                    : held
                       ? UPDATE_NEEDS_CHECK_NOTE
                       : undefined
               }
@@ -119,12 +122,12 @@ export function PlaceCells({
                   size="sm"
                   variant="outline"
                   disabled={
-                    busy || !loaded || !row.updateAvailable || heldByOwner(row)
+                    busy || held || !row.updateAvailable || heldByOwner(row)
                   }
                   title={
                     heldByOwner(row)
                       ? HELD_BY_OWNER_NOTE
-                      : !loaded
+                      : held
                         ? UPDATE_NEEDS_CHECK_NOTE
                         : undefined
                   }

--- a/ui/src/components/updates-before-list.tsx
+++ b/ui/src/components/updates-before-list.tsx
@@ -1,0 +1,79 @@
+import { CheckCircle2, TriangleAlert } from "lucide-react";
+import type { ReactNode } from "react";
+import { EmptyState } from "@/components/empty-state";
+import { DotSpinner } from "@/components/loading";
+import { Button } from "@/components/ui/button";
+import {
+  CHECK_FOR_UPDATES_LABEL,
+  UPDATES_ATTENTION_TITLE,
+  UPDATES_EMPTY,
+  UPDATES_EMPTY_BODY,
+} from "@/lib/copy";
+import { UPDATES_CHECKING } from "@/lib/copy-updates";
+
+/** What the Updates page shows while there is no list to show, or null
+ *  once there is one. Three different answers that must never blur: a
+ *  first read still on its way, a read that failed with nothing kept from
+ *  a better one, and a completed error-free read that found nothing —
+ *  only the last may say "Everything is up to date". */
+export function updatesBeforeList({
+  loaded,
+  error,
+  empty,
+  checking,
+  onCheck,
+}: {
+  loaded: boolean;
+  error: string | null;
+  empty: boolean;
+  checking: boolean;
+  onCheck: () => void;
+}): ReactNode | null {
+  const retry = (
+    <Button variant="outline" disabled={checking} onClick={onCheck}>
+      {CHECK_FOR_UPDATES_LABEL}
+    </Button>
+  );
+  // Before the first read answers there is nothing to report either way —
+  // "Everything is up to date" here would assert an up-to-dateness nobody
+  // has checked yet.
+  if (!loaded && error === null) {
+    return (
+      <div className="flex min-h-full items-center justify-center">
+        <p className="flex items-center gap-2 text-sm text-muted-foreground">
+          <DotSpinner />
+          {UPDATES_CHECKING}
+        </p>
+      </div>
+    );
+  }
+  // A read that failed with nothing kept from a better one: the page says
+  // so and offers the retry — the same claim Home's attention row makes,
+  // answered here where the row sends people.
+  if (error !== null && empty) {
+    return (
+      <div className="flex min-h-full items-center justify-center">
+        <EmptyState
+          icon={TriangleAlert}
+          title={UPDATES_ATTENTION_TITLE}
+          action={retry}
+        >
+          {error}
+        </EmptyState>
+      </div>
+    );
+  }
+  // With nothing to update there is nothing to introduce: a title and a
+  // sentence explaining a list that isn't there is furniture around good
+  // news. The sidebar already says which page this is.
+  if (empty) {
+    return (
+      <div className="flex min-h-full items-center justify-center">
+        <EmptyState icon={CheckCircle2} title={UPDATES_EMPTY} action={retry}>
+          {UPDATES_EMPTY_BODY}
+        </EmptyState>
+      </div>
+    );
+  }
+  return null;
+}

--- a/ui/src/components/updates-table.test.tsx
+++ b/ui/src/components/updates-table.test.tsx
@@ -178,9 +178,14 @@ describe("UpdatesTable", () => {
     );
     expect(html).toMatch(/<button[^>]*disabled=""[^>]*>Update all</);
     expect(html.match(/<button[^>]*disabled=""[^>]*>Update</g)).toHaveLength(2);
+    // The Follow switch holds at row.current's commit when switched off —
+    // a stale row would pin an old version — so it waits too.
+    expect(
+      html.match(/<span[^>]*data-disabled=""[^>]*role="switch"/g),
+    ).toHaveLength(2);
     expect(
       html.match(new RegExp(`title="${UPDATE_NEEDS_CHECK_NOTE}"`, "g")),
-    ).toHaveLength(3);
+    ).toHaveLength(5);
   });
 
   it("offers no package-wide Update all in the muted table", () => {

--- a/ui/src/components/updates-table.test.tsx
+++ b/ui/src/components/updates-table.test.tsx
@@ -1,13 +1,21 @@
 import { renderToStaticMarkup } from "react-dom/server";
-import { describe, expect, it } from "vitest";
+import { beforeEach, describe, expect, it } from "vitest";
 import type { UpdateRow } from "@/bindings";
 import { Table, TableBody } from "@/components/ui/table";
+import { UPDATE_NEEDS_CHECK_NOTE } from "@/lib/copy-updates";
 import { groupUpdates } from "@/lib/update-groups";
+import { useUpdatesStore } from "@/stores/updates";
 import { PackageRows, UpdatesTable } from "./updates-table";
 import { updateRow as row } from "./updates-test-rows";
 
 const render = (rows: UpdateRow[]) =>
   renderToStaticMarkup(<UpdatesTable rows={rows} onIgnore={() => {}} />);
+
+// The table reads the real store; the rows it renders imply a read that
+// answered, so each test starts from that state.
+beforeEach(() => {
+  useUpdatesStore.setState({ loaded: true, busy: false });
+});
 
 describe("UpdatesTable", () => {
   it("names the follow-source column once in the header, not per row", () => {
@@ -135,6 +143,31 @@ describe("UpdatesTable", () => {
       "Held by the source &quot;cat&quot; as a whole — release it where that source is declared",
     );
     expect(html).toMatch(/<button[^>]*>Update</);
+  });
+
+  // Rows kept from before a failed check name a `latest` nobody confirmed
+  // — updating from them would move a hold to a stale commit, so every
+  // Update action waits for a check that succeeds.
+  it("holds every Update action on rows a failed check left behind", () => {
+    useUpdatesStore.setState({ loaded: false });
+    const html = renderToStaticMarkup(
+      <Table>
+        <TableBody>
+          <PackageRows
+            group={
+              groupUpdates([row("gh", null), row("gh", "/home/x/acme")])[0]
+            }
+            onIgnore={() => {}}
+            defaultOpen
+          />
+        </TableBody>
+      </Table>,
+    );
+    expect(html).toMatch(/<button[^>]*disabled=""[^>]*>Update all</);
+    expect(html.match(/<button[^>]*disabled=""[^>]*>Update</g)).toHaveLength(2);
+    expect(
+      html.match(new RegExp(`title="${UPDATE_NEEDS_CHECK_NOTE}"`, "g")),
+    ).toHaveLength(3);
   });
 
   it("offers no package-wide Update all in the muted table", () => {

--- a/ui/src/components/updates-table.test.tsx
+++ b/ui/src/components/updates-table.test.tsx
@@ -1,20 +1,33 @@
 import { renderToStaticMarkup } from "react-dom/server";
-import { beforeEach, describe, expect, it } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { UpdateRow } from "@/bindings";
 import { Table, TableBody } from "@/components/ui/table";
 import { UPDATE_NEEDS_CHECK_NOTE } from "@/lib/copy-updates";
 import { groupUpdates } from "@/lib/update-groups";
-import { useUpdatesStore } from "@/stores/updates";
 import { PackageRows, UpdatesTable } from "./updates-table";
 import { updateRow as row } from "./updates-test-rows";
 
 const render = (rows: UpdateRow[]) =>
   renderToStaticMarkup(<UpdatesTable rows={rows} onIgnore={() => {}} />);
 
-// The table reads the real store; the rows it renders imply a read that
-// answered, so each test starts from that state.
+// Static rendering reads a zustand store's initial snapshot, never one set
+// later, so the store is wrapped to let a test stage what the last read
+// left behind. Rows on the table imply a read that answered, so that is
+// the default.
+const stub = vi.hoisted(() => ({ loaded: true, busy: false }));
+
+vi.mock("@/stores/updates", async (importOriginal) => {
+  const mod = await importOriginal<typeof import("@/stores/updates")>();
+  const hook = (selector?: (state: unknown) => unknown) => {
+    const state = { ...mod.useUpdatesStore.getState(), ...stub };
+    return selector ? selector(state) : state;
+  };
+  return { ...mod, useUpdatesStore: Object.assign(hook, mod.useUpdatesStore) };
+});
+
 beforeEach(() => {
-  useUpdatesStore.setState({ loaded: true, busy: false });
+  stub.loaded = true;
+  stub.busy = false;
 });
 
 describe("UpdatesTable", () => {
@@ -149,7 +162,7 @@ describe("UpdatesTable", () => {
   // — updating from them would move a hold to a stale commit, so every
   // Update action waits for a check that succeeds.
   it("holds every Update action on rows a failed check left behind", () => {
-    useUpdatesStore.setState({ loaded: false });
+    stub.loaded = false;
     const html = renderToStaticMarkup(
       <Table>
         <TableBody>

--- a/ui/src/components/updates-table.tsx
+++ b/ui/src/components/updates-table.tsx
@@ -94,7 +94,9 @@ export function PackageRows({
   const [open, setOpen] = useState(defaultOpen);
   const placesId = useId();
   const busy = useUpdatesStore((s) => s.busy);
-  const loaded = useUpdatesStore((s) => s.loaded);
+  // Not loaded and mid-check hold Update alike: either way these rows are
+  // not the rows an update would act on.
+  const unconfirmed = useUpdatesStore((s) => !s.loaded || s.checking);
   const updateRows = useUpdatesStore((s) => s.updateRows);
   const Icon = kindIcon(group.kind);
   const name = packageDisplayName(group);
@@ -157,9 +159,9 @@ export function PackageRows({
                   size="sm"
                   variant="outline"
                   disabled={
-                    busy || !loaded || updatablePlaces(places).length === 0
+                    busy || unconfirmed || updatablePlaces(places).length === 0
                   }
-                  title={!loaded ? UPDATE_NEEDS_CHECK_NOTE : undefined}
+                  title={unconfirmed ? UPDATE_NEEDS_CHECK_NOTE : undefined}
                   onClick={() => void updateRows(places)}
                 >
                   {UPDATE_PACKAGE_EVERYWHERE_LABEL}

--- a/ui/src/components/updates-table.tsx
+++ b/ui/src/components/updates-table.tsx
@@ -94,9 +94,11 @@ export function PackageRows({
   const [open, setOpen] = useState(defaultOpen);
   const placesId = useId();
   const busy = useUpdatesStore((s) => s.busy);
-  // Not loaded and mid-check hold Update alike: either way these rows are
-  // not the rows an update would act on.
-  const unconfirmed = useUpdatesStore((s) => !s.loaded || s.checking);
+  // Not loaded, mid-check, and mid-load hold Update alike: either way
+  // these rows are not the rows an update would act on.
+  const unconfirmed = useUpdatesStore(
+    (s) => !s.loaded || s.checking || s.overviewInFlight,
+  );
   const updateRows = useUpdatesStore((s) => s.updateRows);
   const Icon = kindIcon(group.kind);
   const name = packageDisplayName(group);

--- a/ui/src/components/updates-table.tsx
+++ b/ui/src/components/updates-table.tsx
@@ -21,6 +21,7 @@ import {
   FOLLOW_SOURCE_COLUMN,
   heldInLabel,
   placesLabel,
+  UPDATE_NEEDS_CHECK_NOTE,
   UPDATE_PACKAGE_EVERYWHERE_LABEL,
   UPDATES_NAME_COLUMN,
   UPDATES_PLACE_COLUMN,
@@ -93,6 +94,7 @@ export function PackageRows({
   const [open, setOpen] = useState(defaultOpen);
   const placesId = useId();
   const busy = useUpdatesStore((s) => s.busy);
+  const loaded = useUpdatesStore((s) => s.loaded);
   const updateRows = useUpdatesStore((s) => s.updateRows);
   const Icon = kindIcon(group.kind);
   const name = packageDisplayName(group);
@@ -154,7 +156,10 @@ export function PackageRows({
                 <Button
                   size="sm"
                   variant="outline"
-                  disabled={busy || updatablePlaces(places).length === 0}
+                  disabled={
+                    busy || !loaded || updatablePlaces(places).length === 0
+                  }
+                  title={!loaded ? UPDATE_NEEDS_CHECK_NOTE : undefined}
                   onClick={() => void updateRows(places)}
                 >
                   {UPDATE_PACKAGE_EVERYWHERE_LABEL}

--- a/ui/src/lib/copy-footer.ts
+++ b/ui/src/lib/copy-footer.ts
@@ -1,0 +1,21 @@
+// Status footer copy: the always-mounted strip's scan status and quiet
+// counts — kept apart from the rest so the wording is reviewed in one
+// place.
+
+// The left side: what the last scan is telling you.
+export const SCANNING_LABEL = "Scanning…";
+export const scanStatusLabel = (scannedAgo: string | null): string =>
+  scannedAgo ? `Up to date · scanned ${scannedAgo}` : "Up to date";
+// "Up to date" beside a scan that failed would have the footer and Home
+// answering the same question oppositely: a failed first scan is a failed
+// status, and a kept result is last-known, not current.
+export const scanFailedStatusLabel = (scannedAgo: string | null): string =>
+  scannedAgo ? `Couldn't scan · last scanned ${scannedAgo}` : "Couldn't scan";
+
+// The right side: quiet counts that link to Review & apply.
+export const pendingChangesLabel = (count: number): string =>
+  count === 1 ? "1 change ready" : `${count} changes ready`;
+export const decisionsFooterLabel = (count: number): string =>
+  count === 1
+    ? "1 thing needs your decision"
+    : `${count} things need your decision`;

--- a/ui/src/lib/copy-marketplaces.ts
+++ b/ui/src/lib/copy-marketplaces.ts
@@ -1,0 +1,12 @@
+// Marketplaces copy: the Subscribed tab's read states and Home's tile
+// detail — kept apart from the rest so the wording is reviewed in one
+// place. A read that failed is said and retried where it failed; rows
+// kept from a better read are drawn, never presented as current.
+export const MARKETPLACES_UNCHECKED_DETAIL = "couldn't be checked";
+export const MARKETPLACES_CHECK_FAILED_TITLE =
+  "Couldn't check your marketplaces";
+export const MARKETPLACES_EMPTY_TITLE = "No marketplaces yet";
+export const MARKETPLACES_UNCONFIRMED_TITLE =
+  "These are the last subscriptions kendex could check";
+export const MARKETPLACES_NEEDS_CHECK_NOTE =
+  "Changing subscriptions needs a check that succeeds first";

--- a/ui/src/lib/copy-updates.ts
+++ b/ui/src/lib/copy-updates.ts
@@ -43,3 +43,10 @@ export const updatedCountToastLabel = (updated: number): string =>
   `Updated ${updated === 1 ? "1 package" : `${updated} packages`}`;
 export const nothingToUpdateToastLabel = (skipped: number): string =>
   `Nothing to update — ${skipped === 1 ? "1 place needs" : `${skipped} places need`} attention on its own row`;
+
+// Before the first read answers there is nothing to be up to date about,
+// and a check that failed leaves the last rows on screen rather than
+// blanking the page — drawn, but never presented as current.
+export const UPDATES_CHECKING = "Checking for updates…";
+export const UPDATES_UNCONFIRMED_TITLE =
+  "These are the last versions kendex could check";

--- a/ui/src/lib/copy-updates.ts
+++ b/ui/src/lib/copy-updates.ts
@@ -50,3 +50,5 @@ export const nothingToUpdateToastLabel = (skipped: number): string =>
 export const UPDATES_CHECKING = "Checking for updates…";
 export const UPDATES_UNCONFIRMED_TITLE =
   "These are the last versions kendex could check";
+export const UPDATE_NEEDS_CHECK_NOTE =
+  "Updating needs a check that succeeds first — these versions may be stale";

--- a/ui/src/lib/copy.ts
+++ b/ui/src/lib/copy.ts
@@ -160,6 +160,9 @@ export const AUDIT_ATTENTION_DETAIL =
   "Problems and pending changes may be missing here.";
 export const TRY_AGAIN_LABEL = "Try again";
 export const MARKETPLACES_UNCHECKED_DETAIL = "couldn't be checked";
+export const MARKETPLACES_CHECK_FAILED_TITLE =
+  "Couldn't check your marketplaces";
+export const MARKETPLACES_EMPTY_TITLE = "No marketplaces yet";
 
 // The status footer's right side: quiet counts that link to Review & apply.
 export const pendingChangesLabel = (count: number): string =>

--- a/ui/src/lib/copy.ts
+++ b/ui/src/lib/copy.ts
@@ -146,6 +146,17 @@ export const SCANNING_LABEL = "Scanning…";
 export const scanStatusLabel = (scannedAgo: string | null): string =>
   scannedAgo ? `Up to date · scanned ${scannedAgo}` : "Up to date";
 
+// Home. A read that failed is an answer, not a wait: the page says what
+// happened instead of holding skeletons up, and a result kept from before
+// a failed re-scan is drawn as last-known rather than current.
+export const SCAN_AGAIN_LABEL = "Scan again";
+export const SCAN_FAILED_TITLE = "Couldn't scan this machine";
+export const SCAN_STALE_TITLE = "These are the last figures kendex could check";
+export const UPDATES_ATTENTION_TITLE = "Couldn't check for updates";
+export const UPDATES_ATTENTION_DETAIL =
+  "Anything new since the last check isn't counted here.";
+export const MARKETPLACES_UNCHECKED_DETAIL = "couldn't be checked";
+
 // The status footer's right side: quiet counts that link to Review & apply.
 export const pendingChangesLabel = (count: number): string =>
   count === 1 ? "1 change ready" : `${count} changes ready`;

--- a/ui/src/lib/copy.ts
+++ b/ui/src/lib/copy.ts
@@ -159,10 +159,6 @@ export const AUDIT_ATTENTION_TITLE = "Couldn't check installed content";
 export const AUDIT_ATTENTION_DETAIL =
   "Problems and pending changes may be missing here.";
 export const TRY_AGAIN_LABEL = "Try again";
-export const MARKETPLACES_UNCHECKED_DETAIL = "couldn't be checked";
-export const MARKETPLACES_CHECK_FAILED_TITLE =
-  "Couldn't check your marketplaces";
-export const MARKETPLACES_EMPTY_TITLE = "No marketplaces yet";
 
 // The status footer's right side: quiet counts that link to Review & apply.
 export const pendingChangesLabel = (count: number): string =>

--- a/ui/src/lib/copy.ts
+++ b/ui/src/lib/copy.ts
@@ -155,6 +155,10 @@ export const SCAN_STALE_TITLE = "These are the last figures kendex could check";
 export const UPDATES_ATTENTION_TITLE = "Couldn't check for updates";
 export const UPDATES_ATTENTION_DETAIL =
   "Anything new since the last check isn't counted here.";
+export const AUDIT_ATTENTION_TITLE = "Couldn't check installed content";
+export const AUDIT_ATTENTION_DETAIL =
+  "Problems and pending changes may be missing here.";
+export const TRY_AGAIN_LABEL = "Try again";
 export const MARKETPLACES_UNCHECKED_DETAIL = "couldn't be checked";
 
 // The status footer's right side: quiet counts that link to Review & apply.

--- a/ui/src/lib/copy.ts
+++ b/ui/src/lib/copy.ts
@@ -141,11 +141,6 @@ export const WINDOW_CONTROL_LABELS = {
   close: "Close",
 } as const;
 
-// The status footer's left side: what the last scan is telling you.
-export const SCANNING_LABEL = "Scanning…";
-export const scanStatusLabel = (scannedAgo: string | null): string =>
-  scannedAgo ? `Up to date · scanned ${scannedAgo}` : "Up to date";
-
 // Home. A read that failed is an answer, not a wait: the page says what
 // happened instead of holding skeletons up, and a result kept from before
 // a failed re-scan is drawn as last-known rather than current.
@@ -159,14 +154,6 @@ export const AUDIT_ATTENTION_TITLE = "Couldn't check installed content";
 export const AUDIT_ATTENTION_DETAIL =
   "Problems and pending changes may be missing here.";
 export const TRY_AGAIN_LABEL = "Try again";
-
-// The status footer's right side: quiet counts that link to Review & apply.
-export const pendingChangesLabel = (count: number): string =>
-  count === 1 ? "1 change ready" : `${count} changes ready`;
-export const decisionsFooterLabel = (count: number): string =>
-  count === 1
-    ? "1 thing needs your decision"
-    : `${count} things need your decision`;
 
 // Package page: files, versions, and the diff between them.
 export const PACKAGE_FILES_TITLE = "Files";

--- a/ui/src/lib/settled.test.ts
+++ b/ui/src/lib/settled.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from "vitest";
+import { NO_REASON_GIVEN, settled } from "./settled";
+
+describe("settled", () => {
+  it("passes a returned refusal through untouched", async () => {
+    await expect(
+      settled(Promise.resolve({ status: "error" as const, error: "refused" })),
+    ).resolves.toEqual({ status: "error", error: "refused" });
+  });
+
+  it("lands a rejection as the same shape as a refusal", async () => {
+    await expect(
+      settled(Promise.reject(new Error("ipc down"))),
+    ).resolves.toEqual({ status: "error", error: "ipc down" });
+  });
+
+  // An Error thrown with no message would land as an empty string, which
+  // renders as a blank error body — and reads as no error at all to any
+  // consumer testing the message by truthiness.
+  it("never lands an empty failure message", async () => {
+    await expect(settled(Promise.reject(new Error()))).resolves.toEqual({
+      status: "error",
+      error: NO_REASON_GIVEN,
+    });
+    await expect(settled(Promise.reject(""))).resolves.toEqual({
+      status: "error",
+      error: NO_REASON_GIVEN,
+    });
+  });
+});

--- a/ui/src/lib/settled.test.ts
+++ b/ui/src/lib/settled.test.ts
@@ -14,9 +14,10 @@ describe("settled", () => {
     ).resolves.toEqual({ status: "error", error: "ipc down" });
   });
 
-  // An Error thrown with no message would land as an empty string, which
-  // renders as a blank error body — and reads as no error at all to any
-  // consumer testing the message by truthiness.
+  // An empty failure message renders as a blank error body — and reads as
+  // no error at all to any consumer testing the message by truthiness —
+  // whether it arrives as a thrown Error with no message or as a refusal
+  // the engine returned with an empty reason.
   it("never lands an empty failure message", async () => {
     await expect(settled(Promise.reject(new Error()))).resolves.toEqual({
       status: "error",
@@ -26,5 +27,8 @@ describe("settled", () => {
       status: "error",
       error: NO_REASON_GIVEN,
     });
+    await expect(
+      settled(Promise.resolve({ status: "error" as const, error: "" })),
+    ).resolves.toEqual({ status: "error", error: NO_REASON_GIVEN });
   });
 });

--- a/ui/src/lib/settled.ts
+++ b/ui/src/lib/settled.ts
@@ -16,7 +16,13 @@ export async function settled<T>(
   read: Promise<CommandResult<T>>,
 ): Promise<CommandResult<T>> {
   try {
-    return await read;
+    const response = await read;
+    // The engine can return a refusal with an empty reason too — normalize
+    // it the same way as an unsaid rejection below.
+    if (response.status === "error" && response.error === "") {
+      return { status: "error", error: NO_REASON_GIVEN };
+    }
+    return response;
   } catch (thrown) {
     const message = thrown instanceof Error ? thrown.message : String(thrown);
     return {

--- a/ui/src/lib/settled.ts
+++ b/ui/src/lib/settled.ts
@@ -1,0 +1,21 @@
+type CommandResult<T> =
+  | { status: "ok"; data: T }
+  | { status: "error"; error: string };
+
+/** Await a command so it always answers. A rejected call — transport
+ *  failing, not the engine refusing — used to escape the stores entirely,
+ *  leaving no error and no result: to the person that silence read as a
+ *  read still on its way. Here it lands as the same shape as a returned
+ *  refusal, so every store has exactly one failure state. */
+export async function settled<T>(
+  read: Promise<CommandResult<T>>,
+): Promise<CommandResult<T>> {
+  try {
+    return await read;
+  } catch (thrown) {
+    return {
+      status: "error",
+      error: thrown instanceof Error ? thrown.message : String(thrown),
+    };
+  }
+}

--- a/ui/src/lib/settled.ts
+++ b/ui/src/lib/settled.ts
@@ -2,6 +2,11 @@ type CommandResult<T> =
   | { status: "ok"; data: T }
   | { status: "error"; error: string };
 
+/** Stands in when a rejection carries no message at all. An empty error
+ *  body renders as blank under whatever title shows it, and consumers that
+ *  test the message by truthiness would read the failure as no failure. */
+export const NO_REASON_GIVEN = "Something went wrong, but no reason was given";
+
 /** Await a command so it always answers. A rejected call — transport
  *  failing, not the engine refusing — used to escape the stores entirely,
  *  leaving no error and no result: to the person that silence read as a
@@ -13,9 +18,10 @@ export async function settled<T>(
   try {
     return await read;
   } catch (thrown) {
+    const message = thrown instanceof Error ? thrown.message : String(thrown);
     return {
       status: "error",
-      error: thrown instanceof Error ? thrown.message : String(thrown),
+      error: message === "" ? NO_REASON_GIVEN : message,
     };
   }
 }

--- a/ui/src/lib/update-groups.ts
+++ b/ui/src/lib/update-groups.ts
@@ -109,3 +109,26 @@ const pathParts = (root: string): string[] =>
 
 export const placeKey = (row: UpdateRow): string =>
   `${groupKey(row)}:${scopeKey(row.scope)}`;
+
+/** A row worth a line on the page: a newer version, a package gone from
+ *  its source, or installs disagreeing on their version — each a standing
+ *  fact someone can act on. */
+const noteworthy = (row: UpdateRow): boolean =>
+  row.updateAvailable || row.removedUpstream || row.mixed;
+
+/** The sidebar badge's number: packages with news someone would want to
+ *  hear, counted once however many places they are installed in. Ignored
+ *  ones asked not to be counted; held ones still count — a hold is "not
+ *  yet", not "never tell me". */
+export const visibleUpdateCount = (rows: UpdateRow[]): number =>
+  packageCount(visibleUpdates(rows));
+
+/** The Updates page's main list: everything noteworthy that has not been
+ *  muted. */
+export const visibleUpdates = (rows: UpdateRow[]): UpdateRow[] =>
+  rows.filter((row) => noteworthy(row) && !row.ignored);
+
+/** The collapsed "hidden updates" section: muted packages whose news is
+ *  still real — with the way back out. */
+export const hiddenUpdates = (rows: UpdateRow[]): UpdateRow[] =>
+  rows.filter((row) => noteworthy(row) && row.ignored);

--- a/ui/src/pages/overview.test.tsx
+++ b/ui/src/pages/overview.test.tsx
@@ -31,6 +31,7 @@ const { stub, wrap } = vi.hoisted(() => {
     market: { rowsCurrent: true, loaded: true },
     audit: {
       auditedAt: null as number | null,
+      checkError: null as string | null,
       error: null as string | null,
     },
   };
@@ -86,7 +87,7 @@ beforeEach(() => {
   stub.scan = { result: null, error: null, scanning: false };
   stub.updates = { error: null };
   stub.market = { rowsCurrent: true, loaded: true };
-  stub.audit = { auditedAt: null, error: null };
+  stub.audit = { auditedAt: null, checkError: null, error: null };
 });
 
 // `result` starting null and staying null used to leave every section on
@@ -105,6 +106,15 @@ describe("Home when the first scan fails", () => {
     expect(html).toContain(esc(SCAN_FAILED_TITLE));
     expect(html).toContain("config unreadable");
     expect(html).toContain(SCAN_AGAIN_LABEL);
+    expect(html).not.toContain('data-slot="skeleton"');
+  });
+
+  // An empty message is still a failure — testing it by truthiness would
+  // read "" as no error and hold the skeletons for the session.
+  it("treats a failure with an empty message as a failure, not a wait", () => {
+    stub.scan.error = "";
+    const html = renderToStaticMarkup(<OverviewPage />);
+    expect(html).toContain(esc(SCAN_FAILED_TITLE));
     expect(html).not.toContain('data-slot="skeleton"');
   });
 });
@@ -129,6 +139,11 @@ describe("Home when a later scan fails", () => {
       SCAN_STALE_TITLE,
     );
   });
+
+  it("marks retained figures stale on a failure with an empty message", () => {
+    stub.scan = { result: scanned, error: "", scanning: false };
+    expect(renderToStaticMarkup(<OverviewPage />)).toContain(SCAN_STALE_TITLE);
+  });
 });
 
 // Home derives its attention list from the updates store's rows; a failed
@@ -137,7 +152,7 @@ describe("Home when a later scan fails", () => {
 describe("Home when the update check fails", () => {
   it("says updates couldn't be checked in the attention list", () => {
     stub.scan = { result: scanned, error: null, scanning: false };
-    stub.audit = { auditedAt: Date.now(), error: null };
+    stub.audit = { auditedAt: Date.now(), checkError: null, error: null };
     stub.updates = { error: "no network" };
     expect(renderToStaticMarkup(<OverviewPage />)).toContain(
       esc(UPDATES_ATTENTION_TITLE),
@@ -146,7 +161,7 @@ describe("Home when the update check fails", () => {
 
   it("claims nothing when the check answered", () => {
     stub.scan = { result: scanned, error: null, scanning: false };
-    stub.audit = { auditedAt: Date.now(), error: null };
+    stub.audit = { auditedAt: Date.now(), checkError: null, error: null };
     expect(renderToStaticMarkup(<OverviewPage />)).not.toContain(
       esc(UPDATES_ATTENTION_TITLE),
     );
@@ -166,7 +181,11 @@ describe("Home when the audit fails", () => {
 
   it("drops the skeleton and says the audit failed, with the retry", () => {
     stub.scan = { result: scanned, error: null, scanning: false };
-    stub.audit = { auditedAt: null, error: "audit crashed" };
+    stub.audit = {
+      auditedAt: null,
+      checkError: "audit crashed",
+      error: "audit crashed",
+    };
     const html = renderToStaticMarkup(<OverviewPage />);
     expect(html).toContain(esc(AUDIT_ATTENTION_TITLE));
     expect(html).toContain(TRY_AGAIN_LABEL);
@@ -175,10 +194,38 @@ describe("Home when the audit fails", () => {
 
   it("no longer suppresses the other failure rows", () => {
     stub.scan = { result: scanned, error: null, scanning: false };
-    stub.audit = { auditedAt: null, error: "audit crashed" };
+    stub.audit = {
+      auditedAt: null,
+      checkError: "audit crashed",
+      error: "audit crashed",
+    };
     stub.updates = { error: "no network" };
     expect(renderToStaticMarkup(<OverviewPage />)).toContain(
       esc(UPDATES_ATTENTION_TITLE),
+    );
+  });
+
+  // The inverse control: a healthy Home must carry no audit row, or the
+  // row's gate could be anything at all and the suite would not notice.
+  it("claims nothing when the audit answered clean", () => {
+    stub.scan = { result: scanned, error: null, scanning: false };
+    stub.audit = { auditedAt: Date.now(), checkError: null, error: null };
+    expect(renderToStaticMarkup(<OverviewPage />)).not.toContain(
+      esc(AUDIT_ATTENTION_TITLE),
+    );
+  });
+
+  // Item actions write the store's shared `error`; only `checkError` —
+  // written by refresh alone — may put the couldn't-check row on Home.
+  it("does not blame the audit for a failed item action", () => {
+    stub.scan = { result: scanned, error: null, scanning: false };
+    stub.audit = {
+      auditedAt: Date.now(),
+      checkError: null,
+      error: "couldn't remove gh",
+    };
+    expect(renderToStaticMarkup(<OverviewPage />)).not.toContain(
+      esc(AUDIT_ATTENTION_TITLE),
     );
   });
 });

--- a/ui/src/pages/overview.test.tsx
+++ b/ui/src/pages/overview.test.tsx
@@ -1,0 +1,166 @@
+import { renderToStaticMarkup } from "react-dom/server";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { ScanResult } from "@/bindings";
+import {
+  MARKETPLACES_UNCHECKED_DETAIL,
+  SCAN_AGAIN_LABEL,
+  SCAN_FAILED_TITLE,
+  SCAN_STALE_TITLE,
+  UPDATES_ATTENTION_TITLE,
+} from "@/lib/copy";
+import { OverviewPage } from "./overview";
+
+// Static markup escapes apostrophes, so a pinned copy token must be
+// escaped the same way before it can be looked for.
+const esc = (copy: string) => copy.replace(/'/g, "&#x27;");
+
+// Static rendering reads a zustand store's initial snapshot, never one set
+// later, so each store is wrapped to let a test stage what the last reads
+// left behind. Both live in vi.hoisted: the mock factories run before any
+// top-level statement of this file.
+const { stub, wrap } = vi.hoisted(() => {
+  const stub = {
+    scan: {
+      result: null as unknown,
+      error: null as string | null,
+      scanning: false,
+    },
+    updates: { error: null as string | null },
+    market: { rowsCurrent: true, error: null as string | null },
+    audit: { auditedAt: null as number | null },
+  };
+  const wrap = <M extends object>(
+    mod: M,
+    key: keyof M,
+    over: () => Record<string, unknown>,
+  ): M => {
+    const store = mod[key] as { getState: () => object };
+    const hook = (selector?: (state: unknown) => unknown) => {
+      const state = { ...store.getState(), ...over() };
+      return selector ? selector(state) : state;
+    };
+    return { ...mod, [key]: Object.assign(hook, store) };
+  };
+  return { stub, wrap };
+});
+
+vi.mock("@/stores/scan", async (importOriginal) => {
+  const mod = await importOriginal<typeof import("@/stores/scan")>();
+  return wrap(mod, "useScanStore", () => ({
+    ...stub.scan,
+    refresh: async () => {},
+  }));
+});
+vi.mock("@/stores/updates", async (importOriginal) => {
+  const mod = await importOriginal<typeof import("@/stores/updates")>();
+  return wrap(mod, "useUpdatesStore", () => stub.updates);
+});
+vi.mock("@/stores/marketplaces", async (importOriginal) => {
+  const mod = await importOriginal<typeof import("@/stores/marketplaces")>();
+  return wrap(mod, "useMarketplacesStore", () => ({
+    ...stub.market,
+    load: async () => {},
+  }));
+});
+vi.mock("@/stores/audit", async (importOriginal) => {
+  const mod = await importOriginal<typeof import("@/stores/audit")>();
+  return wrap(mod, "useAuditStore", () => stub.audit);
+});
+
+const scanned: ScanResult = {
+  harnesses: [],
+  items: [],
+  missingProjects: [],
+  warnings: [],
+};
+
+beforeEach(() => {
+  stub.scan = { result: null, error: null, scanning: false };
+  stub.updates = { error: null };
+  stub.market = { rowsCurrent: true, error: null };
+  stub.audit = { auditedAt: null };
+});
+
+// `result` starting null and staying null used to leave every section on
+// its loading skeleton for the rest of the session: a read that came back
+// unable to answer is not a read still on its way.
+describe("Home when the first scan fails", () => {
+  it("shows skeletons while the scan is genuinely still running", () => {
+    const html = renderToStaticMarkup(<OverviewPage />);
+    expect(html).toContain('data-slot="skeleton"');
+    expect(html).not.toContain(esc(SCAN_FAILED_TITLE));
+  });
+
+  it("says the scan failed and offers the retry, with no skeletons", () => {
+    stub.scan.error = "config unreadable";
+    const html = renderToStaticMarkup(<OverviewPage />);
+    expect(html).toContain(esc(SCAN_FAILED_TITLE));
+    expect(html).toContain("config unreadable");
+    expect(html).toContain(SCAN_AGAIN_LABEL);
+    expect(html).not.toContain('data-slot="skeleton"');
+  });
+});
+
+// The store keeps the last good result so the page does not blank — right —
+// but drawing it with nothing said presents counts and activity as current
+// when kendex knows they are not.
+describe("Home when a later scan fails", () => {
+  it("still draws the last result and says the figures are last-known", () => {
+    stub.scan = { result: scanned, error: "no disk", scanning: false };
+    const html = renderToStaticMarkup(<OverviewPage />);
+    expect(html).toContain(SCAN_STALE_TITLE);
+    expect(html).toContain("no disk");
+    expect(html).toContain(SCAN_AGAIN_LABEL);
+    // The figures themselves are still on the page.
+    expect(html).toContain("Harnesses");
+  });
+
+  it("carries no stale note while the result is current", () => {
+    stub.scan = { result: scanned, error: null, scanning: false };
+    expect(renderToStaticMarkup(<OverviewPage />)).not.toContain(
+      SCAN_STALE_TITLE,
+    );
+  });
+});
+
+// Home derives its attention list from the updates store's rows; a failed
+// update check used to contribute silence, which reads as kendex having
+// looked and found nothing.
+describe("Home when the update check fails", () => {
+  it("says updates couldn't be checked in the attention list", () => {
+    stub.scan = { result: scanned, error: null, scanning: false };
+    stub.audit = { auditedAt: Date.now() };
+    stub.updates = { error: "no network" };
+    expect(renderToStaticMarkup(<OverviewPage />)).toContain(
+      esc(UPDATES_ATTENTION_TITLE),
+    );
+  });
+
+  it("claims nothing when the check answered", () => {
+    stub.scan = { result: scanned, error: null, scanning: false };
+    stub.audit = { auditedAt: Date.now() };
+    expect(renderToStaticMarkup(<OverviewPage />)).not.toContain(
+      esc(UPDATES_ATTENTION_TITLE),
+    );
+  });
+});
+
+// `marketplaceCount` used to read `rows.length` with no regard for how the
+// read went, presenting a failed read as a definite zero.
+describe("the Marketplaces tile when its read is not current", () => {
+  it("shows a dash and the failure note instead of a definite zero", () => {
+    stub.scan = { result: scanned, error: null, scanning: false };
+    stub.market = { rowsCurrent: false, error: "offline" };
+    const html = renderToStaticMarkup(<OverviewPage />);
+    expect(html).toContain(">—<");
+    expect(html).toContain(esc(MARKETPLACES_UNCHECKED_DETAIL));
+    expect(html).not.toContain("browse and subscribe");
+  });
+
+  it("counts a current read, zero included", () => {
+    stub.scan = { result: scanned, error: null, scanning: false };
+    const html = renderToStaticMarkup(<OverviewPage />);
+    expect(html).toContain("browse and subscribe");
+    expect(html).not.toContain(esc(MARKETPLACES_UNCHECKED_DETAIL));
+  });
+});

--- a/ui/src/pages/overview.test.tsx
+++ b/ui/src/pages/overview.test.tsx
@@ -2,10 +2,12 @@ import { renderToStaticMarkup } from "react-dom/server";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { ScanResult } from "@/bindings";
 import {
+  AUDIT_ATTENTION_TITLE,
   MARKETPLACES_UNCHECKED_DETAIL,
   SCAN_AGAIN_LABEL,
   SCAN_FAILED_TITLE,
   SCAN_STALE_TITLE,
+  TRY_AGAIN_LABEL,
   UPDATES_ATTENTION_TITLE,
 } from "@/lib/copy";
 import { OverviewPage } from "./overview";
@@ -26,8 +28,11 @@ const { stub, wrap } = vi.hoisted(() => {
       scanning: false,
     },
     updates: { error: null as string | null },
-    market: { rowsCurrent: true, error: null as string | null },
-    audit: { auditedAt: null as number | null },
+    market: { rowsCurrent: true, loaded: true },
+    audit: {
+      auditedAt: null as number | null,
+      error: null as string | null,
+    },
   };
   const wrap = <M extends object>(
     mod: M,
@@ -64,7 +69,10 @@ vi.mock("@/stores/marketplaces", async (importOriginal) => {
 });
 vi.mock("@/stores/audit", async (importOriginal) => {
   const mod = await importOriginal<typeof import("@/stores/audit")>();
-  return wrap(mod, "useAuditStore", () => stub.audit);
+  return wrap(mod, "useAuditStore", () => ({
+    ...stub.audit,
+    refresh: async () => {},
+  }));
 });
 
 const scanned: ScanResult = {
@@ -77,8 +85,8 @@ const scanned: ScanResult = {
 beforeEach(() => {
   stub.scan = { result: null, error: null, scanning: false };
   stub.updates = { error: null };
-  stub.market = { rowsCurrent: true, error: null };
-  stub.audit = { auditedAt: null };
+  stub.market = { rowsCurrent: true, loaded: true };
+  stub.audit = { auditedAt: null, error: null };
 });
 
 // `result` starting null and staying null used to leave every section on
@@ -129,7 +137,7 @@ describe("Home when a later scan fails", () => {
 describe("Home when the update check fails", () => {
   it("says updates couldn't be checked in the attention list", () => {
     stub.scan = { result: scanned, error: null, scanning: false };
-    stub.audit = { auditedAt: Date.now() };
+    stub.audit = { auditedAt: Date.now(), error: null };
     stub.updates = { error: "no network" };
     expect(renderToStaticMarkup(<OverviewPage />)).toContain(
       esc(UPDATES_ATTENTION_TITLE),
@@ -138,8 +146,38 @@ describe("Home when the update check fails", () => {
 
   it("claims nothing when the check answered", () => {
     stub.scan = { result: scanned, error: null, scanning: false };
-    stub.audit = { auditedAt: Date.now() };
+    stub.audit = { auditedAt: Date.now(), error: null };
     expect(renderToStaticMarkup(<OverviewPage />)).not.toContain(
+      esc(UPDATES_ATTENTION_TITLE),
+    );
+  });
+});
+
+// auditedAt stays null forever after a failed startup audit; gating the
+// skeleton on it alone held the section in "still looking" for the session
+// and swallowed every other attention row.
+describe("Home when the audit fails", () => {
+  it("keeps the skeleton only while the audit has not answered", () => {
+    stub.scan = { result: scanned, error: null, scanning: false };
+    const html = renderToStaticMarkup(<OverviewPage />);
+    expect(html).toContain('data-slot="skeleton"');
+    expect(html).not.toContain(esc(AUDIT_ATTENTION_TITLE));
+  });
+
+  it("drops the skeleton and says the audit failed, with the retry", () => {
+    stub.scan = { result: scanned, error: null, scanning: false };
+    stub.audit = { auditedAt: null, error: "audit crashed" };
+    const html = renderToStaticMarkup(<OverviewPage />);
+    expect(html).toContain(esc(AUDIT_ATTENTION_TITLE));
+    expect(html).toContain(TRY_AGAIN_LABEL);
+    expect(html).not.toContain('data-slot="skeleton"');
+  });
+
+  it("no longer suppresses the other failure rows", () => {
+    stub.scan = { result: scanned, error: null, scanning: false };
+    stub.audit = { auditedAt: null, error: "audit crashed" };
+    stub.updates = { error: "no network" };
+    expect(renderToStaticMarkup(<OverviewPage />)).toContain(
       esc(UPDATES_ATTENTION_TITLE),
     );
   });
@@ -150,11 +188,19 @@ describe("Home when the update check fails", () => {
 describe("the Marketplaces tile when its read is not current", () => {
   it("shows a dash and the failure note instead of a definite zero", () => {
     stub.scan = { result: scanned, error: null, scanning: false };
-    stub.market = { rowsCurrent: false, error: "offline" };
+    stub.market = { rowsCurrent: false, loaded: true };
     const html = renderToStaticMarkup(<OverviewPage />);
     expect(html).toContain(">—<");
     expect(html).toContain(esc(MARKETPLACES_UNCHECKED_DETAIL));
     expect(html).not.toContain("browse and subscribe");
+  });
+
+  it("shows the dash alone while the first read is still on its way", () => {
+    stub.scan = { result: scanned, error: null, scanning: false };
+    stub.market = { rowsCurrent: false, loaded: false };
+    const html = renderToStaticMarkup(<OverviewPage />);
+    expect(html).toContain(">—<");
+    expect(html).not.toContain(esc(MARKETPLACES_UNCHECKED_DETAIL));
   });
 
   it("counts a current read, zero included", () => {

--- a/ui/src/pages/overview.test.tsx
+++ b/ui/src/pages/overview.test.tsx
@@ -3,13 +3,13 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { ScanResult } from "@/bindings";
 import {
   AUDIT_ATTENTION_TITLE,
-  MARKETPLACES_UNCHECKED_DETAIL,
   SCAN_AGAIN_LABEL,
   SCAN_FAILED_TITLE,
   SCAN_STALE_TITLE,
   TRY_AGAIN_LABEL,
   UPDATES_ATTENTION_TITLE,
 } from "@/lib/copy";
+import { MARKETPLACES_UNCHECKED_DETAIL } from "@/lib/copy-marketplaces";
 import { OverviewPage } from "./overview";
 
 // Static markup escapes apostrophes, so a pinned copy token must be

--- a/ui/src/pages/overview.tsx
+++ b/ui/src/pages/overview.tsx
@@ -1,8 +1,6 @@
 import { useEffect } from "react";
-import {
-  type AttentionRow,
-  AttentionSection,
-} from "@/components/home/attention-section";
+import { attentionRows } from "@/components/home/attention-rows";
+import { AttentionSection } from "@/components/home/attention-section";
 import {
   AttentionSkeleton,
   RecentSkeleton,
@@ -12,11 +10,13 @@ import { RecentActivity } from "@/components/home/recent-activity";
 import { PageHeader } from "@/components/page-header";
 import { Section } from "@/components/section";
 import { StatTile } from "@/components/stat-tile";
-import { auditCounts } from "@/lib/audit-counts";
+import { StatusNote } from "@/components/status-note";
+import { Button } from "@/components/ui/button";
 import {
-  FORKED_ATTENTION_DETAIL,
-  forkedAttentionTitle,
-  REVIEW_ACTION_LABEL,
+  MARKETPLACES_UNCHECKED_DETAIL,
+  SCAN_AGAIN_LABEL,
+  SCAN_FAILED_TITLE,
+  SCAN_STALE_TITLE,
 } from "@/lib/copy";
 import { groupItems, recentItems } from "@/lib/derive";
 import { harnessName } from "@/lib/labels";
@@ -32,7 +32,7 @@ import { useUpdatesStore } from "@/stores/updates";
 const RECENT_ACTIVITY_LIMIT = 6;
 
 export function OverviewPage() {
-  const { result } = useScanStore();
+  const { result, error, scanning, refresh } = useScanStore();
   const views = useAuditStore((s) => s.views);
   // The safety pass is the slowest thing the app does; until it has run
   // once, Home cannot say whether anything needs attention — so it says
@@ -44,129 +44,71 @@ export function OverviewPage() {
   const setPage = useNavStore((s) => s.setPage);
   const goToPackage = useNavStore((s) => s.goToPackage);
   const updateRows = useUpdatesStore((s) => s.rows);
+  // Rows kept from before a failed re-check are last-known, still worth a
+  // line; the failure itself gets its own row below, so their absence
+  // never has to stand in for "couldn't check".
   const editedPackages = updateRows.filter((row) => row.blockedByLocalEdit);
+  const updatesError = useUpdatesStore((s) => s.error);
   const goTo = useNavStore((s) => s.goTo);
   const goToLibrary = useNavStore((s) => s.goToLibrary);
   const goToMarketplaces = useNavStore((s) => s.goToMarketplaces);
   const marketplaceCount = useMarketplacesStore((s) => s.rows.length);
+  // `rows` survives a failed re-read; `rowsCurrent` is whether they are
+  // the answer of the last one. Only a current read may put a number —
+  // above all a zero — on the tile.
+  const marketplacesCurrent = useMarketplacesStore((s) => s.rowsCurrent);
+  const marketplacesError = useMarketplacesStore((s) => s.error);
   const loadMarketplaces = useMarketplacesStore((s) => s.load);
   useEffect(() => {
     void loadMarketplaces();
   }, [loadMarketplaces]);
 
-  const {
-    changes: actionableCount,
-    inTheWay,
-    unmanaged: unmanagedCount,
-    blocked,
-    open,
-  } = auditCounts(views);
-  const missing = result?.missingProjects ?? [];
+  const scanAgain = (
+    <Button
+      size="sm"
+      variant="outline"
+      disabled={scanning}
+      onClick={() => void refresh({ announce: true })}
+    >
+      {SCAN_AGAIN_LABEL}
+    </Button>
+  );
 
-  const rows: AttentionRow[] = [];
-  if (editedPackages.length > 0) {
-    const first = editedPackages[0];
-    rows.push({
-      key: "edited",
-      tone: "warning",
-      title: forkedAttentionTitle(editedPackages.length),
-      detail: FORKED_ATTENTION_DETAIL,
-      action:
-        editedPackages.length === 1 && first
-          ? {
-              label: first.name,
-              onClick: () =>
-                goToPackage({
-                  kind: first.kind,
-                  name: first.name,
-                  scope: first.scope,
-                }),
-            }
-          : { label: "Library", onClick: () => goToLibrary() },
-    });
+  // A first scan that failed is an answer, not a wait. Skeletons here would
+  // say "still checking" for the rest of the session; the page says what
+  // happened instead, with the retry beside it.
+  if (!result && error) {
+    return (
+      <div>
+        <PageHeader title="Home" />
+        <div className={PAGE_BODY}>
+          <div className={cn(CONTENT_WIDTH)}>
+            <StatusNote
+              tone="critical"
+              title={SCAN_FAILED_TITLE}
+              action={scanAgain}
+            >
+              {error}
+            </StatusNote>
+          </div>
+        </div>
+      </div>
+    );
   }
-  if (blocked > 0) {
-    rows.push({
-      key: "safety",
-      tone: "critical",
-      title: blocked === 1 ? "1 problem found" : `${blocked} problems found`,
-      detail: "Held back until you accept them.",
-      action: { label: REVIEW_ACTION_LABEL, onClick: () => setPage("review") },
-    });
-  }
-  if (open > 0) {
-    rows.push({
-      key: "decisions",
-      tone: "warning",
-      title: open === 1 ? "1 finding to review" : `${open} findings to review`,
-      detail: "In content already installed.",
-      action: { label: REVIEW_ACTION_LABEL, onClick: () => setPage("review") },
-    });
-  }
-  if (inTheWay > 0) {
-    rows.push({
-      key: "in-the-way",
-      tone: "warning",
-      title:
-        inTheWay === 1
-          ? "1 item needs your decision"
-          : `${inTheWay} items need your decision`,
-      detail: "Files are already where they go.",
-      action: { label: REVIEW_ACTION_LABEL, onClick: () => setPage("review") },
-    });
-  }
-  if (actionableCount > 0) {
-    rows.push({
-      key: "drift",
-      tone: "info",
-      title:
-        actionableCount === 1
-          ? "1 change ready to apply"
-          : `${actionableCount} changes ready to apply`,
-      action: { label: REVIEW_ACTION_LABEL, onClick: () => setPage("review") },
-    });
-  }
-  if (unmanagedCount > 0) {
-    rows.push({
-      key: "unmanaged",
-      tone: "muted",
-      title:
-        unmanagedCount === 1
-          ? "1 unmanaged item"
-          : `${unmanagedCount} unmanaged items`,
-      detail: "kendex didn't put them there.",
-      action: { label: "Review", onClick: () => goTo("unmanaged") },
-    });
-  }
-  if (missing.length > 0) {
-    rows.push({
-      key: "missing-projects",
-      tone: "warning",
-      title:
-        missing.length === 1
-          ? "1 project folder can't be found"
-          : `${missing.length} project folders can't be found`,
-      detail:
-        missing.length === 1
-          ? `We can't find ${missing[0]}. If you moved it, add it again.`
-          : "If you moved these, add them again from Harnesses & Projects.",
-      action: {
-        label: "Projects",
-        onClick: () => goTo("projects"),
-      },
-    });
-  }
-  if (result && result.warnings.length > 0) {
-    rows.push({
-      key: "warnings",
-      tone: "warning",
-      title:
-        result.warnings.length === 1
-          ? "1 file couldn't be read"
-          : `${result.warnings.length} files couldn't be read`,
-      detail: result.warnings[0],
-    });
-  }
+
+  const rows = attentionRows({
+    editedPackages,
+    views,
+    result,
+    updatesError,
+    onReview: () => setPage("review"),
+    onUnmanaged: () => goTo("unmanaged"),
+    onProjects: () => goTo("projects"),
+    onUpdates: () => setPage("updates"),
+    onLibrary: () => goToLibrary(),
+    onPackage: (row) =>
+      goToPackage({ kind: row.kind, name: row.name, scope: row.scope }),
+  });
 
   const harnessNames = (result?.harnesses ?? [])
     .map((h) => harnessName(h.harness))
@@ -180,6 +122,19 @@ export function OverviewPage() {
       <PageHeader title="Home" />
       <div className={PAGE_BODY}>
         <div className={cn("flex flex-col gap-10", CONTENT_WIDTH)}>
+          {/* The store keeps the last good result so the page does not
+              blank, but a re-scan that failed means everything below
+              answers for an earlier moment — said here once, over all of
+              it, rather than presented as current. */}
+          {result && error ? (
+            <StatusNote
+              tone="warning"
+              title={SCAN_STALE_TITLE}
+              action={scanAgain}
+            >
+              {error}
+            </StatusNote>
+          ) : null}
           {/* Nothing to decide means nothing to say: the section is gone
               rather than standing there reporting its own emptiness. */}
           {!result || stillChecking ? (
@@ -217,9 +172,18 @@ export function OverviewPage() {
                 />
                 <StatTile
                   label="Marketplaces"
-                  value={marketplaceCount}
+                  value={marketplacesCurrent ? marketplaceCount : "—"}
                   detail={
-                    marketplaceCount === 0 ? "browse and subscribe" : undefined
+                    marketplacesCurrent
+                      ? marketplaceCount === 0
+                        ? "browse and subscribe"
+                        : undefined
+                      : // Not current and no error is the first read still on
+                        // its way — the dash alone carries that; the failure
+                        // note is for a read that answered it couldn't.
+                        marketplacesError
+                        ? MARKETPLACES_UNCHECKED_DETAIL
+                        : undefined
                   }
                   onClick={() => goToMarketplaces()}
                 />

--- a/ui/src/pages/overview.tsx
+++ b/ui/src/pages/overview.tsx
@@ -40,9 +40,11 @@ export function OverviewPage() {
   // failed audit is an answer: the section renders what is known, with the
   // failure as a row of its own, instead of a skeleton for the session.
   const stillChecking = useAuditStore(
-    (s) => s.auditedAt === null && s.error === null,
+    (s) => s.auditedAt === null && s.checkError === null,
   );
-  const auditError = useAuditStore((s) => s.error);
+  // `checkError`, not the store's shared `error`: item actions write the
+  // shared field too, and a failed remove or adopt is not a failed audit.
+  const auditError = useAuditStore((s) => s.checkError);
   const auditRefresh = useAuditStore((s) => s.refresh);
   const projectCount = useSettingsStore(
     (s) => s.settings?.projects?.length ?? 0,
@@ -86,7 +88,7 @@ export function OverviewPage() {
   // A first scan that failed is an answer, not a wait. Skeletons here would
   // say "still checking" for the rest of the session; the page says what
   // happened instead, with the retry beside it.
-  if (!result && error) {
+  if (!result && error !== null) {
     return (
       <div>
         <PageHeader title="Home" />
@@ -137,7 +139,7 @@ export function OverviewPage() {
               blank, but a re-scan that failed means everything below
               answers for an earlier moment — said here once, over all of
               it, rather than presented as current. */}
-          {result && error ? (
+          {result && error !== null ? (
             <StatusNote
               tone="warning"
               title={SCAN_STALE_TITLE}

--- a/ui/src/pages/overview.tsx
+++ b/ui/src/pages/overview.tsx
@@ -13,11 +13,11 @@ import { StatTile } from "@/components/stat-tile";
 import { StatusNote } from "@/components/status-note";
 import { Button } from "@/components/ui/button";
 import {
-  MARKETPLACES_UNCHECKED_DETAIL,
   SCAN_AGAIN_LABEL,
   SCAN_FAILED_TITLE,
   SCAN_STALE_TITLE,
 } from "@/lib/copy";
+import { MARKETPLACES_UNCHECKED_DETAIL } from "@/lib/copy-marketplaces";
 import { groupItems, recentItems } from "@/lib/derive";
 import { harnessName } from "@/lib/labels";
 import { CONTENT_WIDTH, PAGE_BODY } from "@/lib/layout";

--- a/ui/src/pages/overview.tsx
+++ b/ui/src/pages/overview.tsx
@@ -34,10 +34,16 @@ const RECENT_ACTIVITY_LIMIT = 6;
 export function OverviewPage() {
   const { result, error, scanning, refresh } = useScanStore();
   const views = useAuditStore((s) => s.views);
-  // The safety pass is the slowest thing the app does; until it has run
-  // once, Home cannot say whether anything needs attention — so it says
-  // that it is still looking rather than showing an empty page.
-  const stillChecking = useAuditStore((s) => s.auditedAt === null);
+  // The safety pass is the slowest thing the app does; until it has
+  // ANSWERED once, Home cannot say whether anything needs attention — so
+  // it says that it is still looking rather than showing an empty page. A
+  // failed audit is an answer: the section renders what is known, with the
+  // failure as a row of its own, instead of a skeleton for the session.
+  const stillChecking = useAuditStore(
+    (s) => s.auditedAt === null && s.error === null,
+  );
+  const auditError = useAuditStore((s) => s.error);
+  const auditRefresh = useAuditStore((s) => s.refresh);
   const projectCount = useSettingsStore(
     (s) => s.settings?.projects?.length ?? 0,
   );
@@ -55,9 +61,12 @@ export function OverviewPage() {
   const marketplaceCount = useMarketplacesStore((s) => s.rows.length);
   // `rows` survives a failed re-read; `rowsCurrent` is whether they are
   // the answer of the last one. Only a current read may put a number —
-  // above all a zero — on the tile.
+  // above all a zero — on the tile. `loaded` is whether any read has
+  // answered at all: answered-but-not-current is the failure to note,
+  // while not-yet-answered is just the dash. The store's shared `error`
+  // field is not consulted — writes clear it without making rows current.
   const marketplacesCurrent = useMarketplacesStore((s) => s.rowsCurrent);
-  const marketplacesError = useMarketplacesStore((s) => s.error);
+  const marketplacesLoaded = useMarketplacesStore((s) => s.loaded);
   const loadMarketplaces = useMarketplacesStore((s) => s.load);
   useEffect(() => {
     void loadMarketplaces();
@@ -101,6 +110,7 @@ export function OverviewPage() {
     views,
     result,
     updatesError,
+    auditError,
     onReview: () => setPage("review"),
     onUnmanaged: () => goTo("unmanaged"),
     onProjects: () => goTo("projects"),
@@ -108,6 +118,7 @@ export function OverviewPage() {
     onLibrary: () => goToLibrary(),
     onPackage: (row) =>
       goToPackage({ kind: row.kind, name: row.name, scope: row.scope }),
+    onAuditRetry: () => void auditRefresh({ force: true }),
   });
 
   const harnessNames = (result?.harnesses ?? [])
@@ -172,16 +183,16 @@ export function OverviewPage() {
                 />
                 <StatTile
                   label="Marketplaces"
-                  value={marketplacesCurrent ? marketplaceCount : "—"}
+                  value={marketplacesCurrent ? marketplaceCount : null}
                   detail={
                     marketplacesCurrent
                       ? marketplaceCount === 0
                         ? "browse and subscribe"
                         : undefined
-                      : // Not current and no error is the first read still on
-                        // its way — the dash alone carries that; the failure
-                        // note is for a read that answered it couldn't.
-                        marketplacesError
+                      : // Answered but not current is a read that failed;
+                        // not yet answered is the first read still on its
+                        // way, and the dash alone carries that.
+                        marketplacesLoaded
                         ? MARKETPLACES_UNCHECKED_DETAIL
                         : undefined
                   }

--- a/ui/src/pages/updates.test.tsx
+++ b/ui/src/pages/updates.test.tsx
@@ -1,0 +1,91 @@
+import { renderToStaticMarkup } from "react-dom/server";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { UpdateRow } from "@/bindings";
+import { updateRow } from "@/components/updates-test-rows";
+import { UPDATES_ATTENTION_TITLE, UPDATES_EMPTY } from "@/lib/copy";
+import {
+  UPDATES_CHECKING,
+  UPDATES_UNCONFIRMED_TITLE,
+} from "@/lib/copy-updates";
+import { UpdatesPage } from "./updates";
+
+// Static markup escapes apostrophes, so a pinned copy token must be
+// escaped the same way before it can be looked for.
+const esc = (copy: string) => copy.replace(/'/g, "&#x27;");
+
+// Static rendering reads a zustand store's initial snapshot, never one set
+// later, so the store is wrapped to let a test stage what the last read
+// left behind.
+const stub = vi.hoisted(() => ({
+  rows: [] as unknown[],
+  loaded: true,
+  error: null as string | null,
+}));
+
+vi.mock("@/stores/updates", async (importOriginal) => {
+  const mod = await importOriginal<typeof import("@/stores/updates")>();
+  const hook = (selector?: (state: unknown) => unknown) => {
+    const state = {
+      ...mod.useUpdatesStore.getState(),
+      rows: stub.rows as UpdateRow[],
+      warnings: [],
+      busy: false,
+      checking: false,
+      loaded: stub.loaded,
+      error: stub.error,
+      load: async () => {},
+    };
+    return selector ? selector(state) : state;
+  };
+  return { ...mod, useUpdatesStore: Object.assign(hook, mod.useUpdatesStore) };
+});
+
+beforeEach(() => {
+  stub.rows = [];
+  stub.loaded = true;
+  stub.error = null;
+});
+
+// Empty rows and no error read as good news, so before the first read
+// answers — and after one that failed — "Everything is up to date" would
+// assert the very thing kendex just said it could not verify.
+describe("the Updates page across its read states", () => {
+  it("says it is checking before the first read answers", () => {
+    stub.loaded = false;
+    const html = renderToStaticMarkup(<UpdatesPage />);
+    expect(html).toContain(UPDATES_CHECKING);
+    expect(html).not.toContain(UPDATES_EMPTY);
+  });
+
+  it("says the check failed and offers the retry, not up-to-dateness", () => {
+    stub.loaded = false;
+    stub.error = "no network";
+    const html = renderToStaticMarkup(<UpdatesPage />);
+    expect(html).toContain(esc(UPDATES_ATTENTION_TITLE));
+    expect(html).toContain("no network");
+    expect(html).toContain("Check for updates");
+    expect(html).not.toContain(UPDATES_EMPTY);
+  });
+
+  it("calls a completed, error-free empty read up to date", () => {
+    expect(renderToStaticMarkup(<UpdatesPage />)).toContain(UPDATES_EMPTY);
+  });
+
+  it("heads rows kept from a better read with the stale note", () => {
+    stub.rows = [updateRow("gh", null)];
+    stub.loaded = false;
+    stub.error = "no network";
+    const html = renderToStaticMarkup(<UpdatesPage />);
+    expect(html).toContain(UPDATES_UNCONFIRMED_TITLE);
+    expect(html).toContain("no network");
+    // The kept rows are still drawn under it.
+    expect(html).toContain("gh");
+  });
+
+  it("carries no stale note over rows from a current read", () => {
+    stub.rows = [updateRow("gh", null)];
+    expect(renderToStaticMarkup(<UpdatesPage />)).not.toContain(
+      UPDATES_UNCONFIRMED_TITLE,
+    );
+  });
+});

--- a/ui/src/pages/updates.test.tsx
+++ b/ui/src/pages/updates.test.tsx
@@ -2,8 +2,14 @@ import { renderToStaticMarkup } from "react-dom/server";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { UpdateRow } from "@/bindings";
 import { updateRow } from "@/components/updates-test-rows";
-import { UPDATES_ATTENTION_TITLE, UPDATES_EMPTY } from "@/lib/copy";
 import {
+  CHECK_FOR_UPDATES_LABEL,
+  UPDATE_ALL_LABEL,
+  UPDATES_ATTENTION_TITLE,
+  UPDATES_EMPTY,
+} from "@/lib/copy";
+import {
+  UPDATE_NEEDS_CHECK_NOTE,
   UPDATES_CHECKING,
   UPDATES_UNCONFIRMED_TITLE,
 } from "@/lib/copy-updates";
@@ -87,5 +93,35 @@ describe("the Updates page across its read states", () => {
     expect(renderToStaticMarkup(<UpdatesPage />)).not.toContain(
       UPDATES_UNCONFIRMED_TITLE,
     );
+  });
+
+  // With every noteworthy row muted, a failed check used to strand the
+  // page: the stale note and error with no way to try again anywhere.
+  it("keeps the retry reachable when only hidden rows remain", () => {
+    stub.rows = [updateRow("gh", null, { ignored: true })];
+    stub.loaded = false;
+    stub.error = "no network";
+    const html = renderToStaticMarkup(<UpdatesPage />);
+    expect(html).toContain(UPDATES_UNCONFIRMED_TITLE);
+    expect(html).toContain(CHECK_FOR_UPDATES_LABEL);
+  });
+
+  it("offers no header check button on a clean page with nothing visible", () => {
+    stub.rows = [updateRow("gh", null, { ignored: true })];
+    const html = renderToStaticMarkup(<UpdatesPage />);
+    expect(html).not.toContain(CHECK_FOR_UPDATES_LABEL);
+  });
+
+  // Stale rows name a `latest` nobody confirmed; the page-wide Update all
+  // waits for a check that succeeds, like the per-row actions.
+  it("holds Update all over rows a failed check left behind", () => {
+    stub.rows = [updateRow("one", null), updateRow("two", null)];
+    stub.loaded = false;
+    stub.error = "no network";
+    const html = renderToStaticMarkup(<UpdatesPage />);
+    expect(html).toMatch(
+      new RegExp(`<button[^>]*disabled=""[^>]*>${UPDATE_ALL_LABEL}<`),
+    );
+    expect(html).toContain(`title="${UPDATE_NEEDS_CHECK_NOTE}"`);
   });
 });

--- a/ui/src/pages/updates.tsx
+++ b/ui/src/pages/updates.tsx
@@ -47,6 +47,11 @@ export function UpdatesPage() {
     useUpdatesStore();
   const loaded = useUpdatesStore((s) => s.loaded);
   const error = useUpdatesStore((s) => s.error);
+  // Anything overview-producing in flight holds Update all, same as the
+  // per-row controls: these rows are about to be replaced.
+  const unconfirmed = useUpdatesStore(
+    (s) => !s.loaded || s.checking || s.overviewInFlight,
+  );
   const load = useUpdatesStore((s) => s.load);
   const [showHidden, setShowHidden] = useState(false);
   const [confirmIgnore, setConfirmIgnore] = useState<UpdateRow | null>(null);
@@ -109,14 +114,9 @@ export function UpdatesPage() {
               <Button
                 size="sm"
                 disabled={
-                  busy ||
-                  !loaded ||
-                  checking ||
-                  updatablePlaces(visible).length === 0
+                  busy || unconfirmed || updatablePlaces(visible).length === 0
                 }
-                title={
-                  !loaded || checking ? UPDATE_NEEDS_CHECK_NOTE : undefined
-                }
+                title={unconfirmed ? UPDATE_NEEDS_CHECK_NOTE : undefined}
                 onClick={() => void updateRows(visible)}
               >
                 {UPDATE_ALL_LABEL}

--- a/ui/src/pages/updates.tsx
+++ b/ui/src/pages/updates.tsx
@@ -9,7 +9,9 @@ import type { UpdateRow } from "@/bindings";
 import { ConfirmDialog } from "@/components/confirm-dialog";
 import { EmptyState } from "@/components/empty-state";
 import { PageHeader } from "@/components/page-header";
+import { StatusNote } from "@/components/status-note";
 import { Button } from "@/components/ui/button";
+import { updatesBeforeList } from "@/components/updates-before-list";
 import { UpdatesTable } from "@/components/updates-table";
 import {
   CHECK_FOR_UPDATES_LABEL,
@@ -22,7 +24,11 @@ import {
   UPDATES_EMPTY_BODY,
   UPDATES_UNCHECKED_TITLE,
 } from "@/lib/copy";
-import { FOLLOW_SOURCE_HELP, updatesSubtitle } from "@/lib/copy-updates";
+import {
+  FOLLOW_SOURCE_HELP,
+  UPDATES_UNCONFIRMED_TITLE,
+  updatesSubtitle,
+} from "@/lib/copy-updates";
 import { PAGE_GUTTER, WIDE_CONTENT_WIDTH } from "@/lib/layout";
 import { packageCount, updatablePlaces } from "@/lib/update-groups";
 import { cn } from "@/lib/utils";
@@ -37,6 +43,8 @@ import {
 export function UpdatesPage() {
   const { rows, warnings, busy, checking, check, updateRows } =
     useUpdatesStore();
+  const loaded = useUpdatesStore((s) => s.loaded);
+  const error = useUpdatesStore((s) => s.error);
   const load = useUpdatesStore((s) => s.load);
   const [showHidden, setShowHidden] = useState(false);
   const [confirmIgnore, setConfirmIgnore] = useState<UpdateRow | null>(null);
@@ -48,31 +56,17 @@ export function UpdatesPage() {
   const visible = visibleUpdates(rows);
   const hidden = hiddenUpdates(rows);
   const HiddenChevron = showHidden ? ChevronDown : ChevronRight;
+  const empty =
+    visible.length === 0 && hidden.length === 0 && warnings.length === 0;
 
-  // With nothing to update there is nothing to introduce: a title and a
-  // sentence explaining a list that isn't there is furniture around good
-  // news. The sidebar already says which page this is.
-  if (visible.length === 0 && hidden.length === 0 && warnings.length === 0) {
-    return (
-      <div className="flex min-h-full items-center justify-center">
-        <EmptyState
-          icon={CheckCircle2}
-          title={UPDATES_EMPTY}
-          action={
-            <Button
-              variant="outline"
-              disabled={checking}
-              onClick={() => void check()}
-            >
-              {CHECK_FOR_UPDATES_LABEL}
-            </Button>
-          }
-        >
-          {UPDATES_EMPTY_BODY}
-        </EmptyState>
-      </div>
-    );
-  }
+  const beforeList = updatesBeforeList({
+    loaded,
+    error,
+    empty,
+    checking,
+    onCheck: () => void check(),
+  });
+  if (beforeList) return beforeList;
 
   return (
     <div className="flex min-h-0 flex-1 flex-col">
@@ -120,10 +114,24 @@ export function UpdatesPage() {
       />
       <div className={cn("min-h-0 flex-1 overflow-y-auto", PAGE_GUTTER)}>
         <div className={cn("pb-8", WIDE_CONTENT_WIDTH)}>
+          {/* Rows kept from before a failed check stay on screen — right —
+              but headed as what they are: the last read that answered, not
+              the current standing. */}
+          {error !== null ? (
+            <StatusNote
+              tone="warning"
+              title={UPDATES_UNCONFIRMED_TITLE}
+              className="mb-6"
+            >
+              {error}
+            </StatusNote>
+          ) : null}
           {visible.length === 0 ? (
-            <EmptyState icon={CheckCircle2} title={UPDATES_EMPTY}>
-              {UPDATES_EMPTY_BODY}
-            </EmptyState>
+            error === null ? (
+              <EmptyState icon={CheckCircle2} title={UPDATES_EMPTY}>
+                {UPDATES_EMPTY_BODY}
+              </EmptyState>
+            ) : null
           ) : (
             <UpdatesTable rows={visible} onIgnore={setConfirmIgnore} />
           )}

--- a/ui/src/pages/updates.tsx
+++ b/ui/src/pages/updates.tsx
@@ -109,9 +109,14 @@ export function UpdatesPage() {
               <Button
                 size="sm"
                 disabled={
-                  busy || !loaded || updatablePlaces(visible).length === 0
+                  busy ||
+                  !loaded ||
+                  checking ||
+                  updatablePlaces(visible).length === 0
                 }
-                title={!loaded ? UPDATE_NEEDS_CHECK_NOTE : undefined}
+                title={
+                  !loaded || checking ? UPDATE_NEEDS_CHECK_NOTE : undefined
+                }
                 onClick={() => void updateRows(visible)}
               >
                 {UPDATE_ALL_LABEL}

--- a/ui/src/pages/updates.tsx
+++ b/ui/src/pages/updates.tsx
@@ -31,13 +31,14 @@ import {
   updatesSubtitle,
 } from "@/lib/copy-updates";
 import { PAGE_GUTTER, WIDE_CONTENT_WIDTH } from "@/lib/layout";
-import { packageCount, updatablePlaces } from "@/lib/update-groups";
-import { cn } from "@/lib/utils";
 import {
   hiddenUpdates,
-  useUpdatesStore,
+  packageCount,
+  updatablePlaces,
   visibleUpdates,
-} from "@/stores/updates";
+} from "@/lib/update-groups";
+import { cn } from "@/lib/utils";
+import { useUpdatesStore } from "@/stores/updates";
 
 /** Which packages have newer versions, what changed, and per-package
  *  control over how loudly to hear about it. */

--- a/ui/src/pages/updates.tsx
+++ b/ui/src/pages/updates.tsx
@@ -26,6 +26,7 @@ import {
 } from "@/lib/copy";
 import {
   FOLLOW_SOURCE_HELP,
+  UPDATE_NEEDS_CHECK_NOTE,
   UPDATES_UNCONFIRMED_TITLE,
   updatesSubtitle,
 } from "@/lib/copy-updates";
@@ -87,7 +88,10 @@ export function UpdatesPage() {
         }
         action={
           <div className="flex gap-2">
-            {visible.length > 0 ? (
+            {/* A failed check always leaves its retry reachable: with no
+                visible rows but hidden ones or warnings keeping the page
+                on, this button is the only way to try again. */}
+            {visible.length > 0 || error !== null ? (
               <Button
                 size="sm"
                 variant="outline"
@@ -103,7 +107,10 @@ export function UpdatesPage() {
             {packageCount(visible) > 1 ? (
               <Button
                 size="sm"
-                disabled={busy || updatablePlaces(visible).length === 0}
+                disabled={
+                  busy || !loaded || updatablePlaces(visible).length === 0
+                }
+                title={!loaded ? UPDATE_NEEDS_CHECK_NOTE : undefined}
                 onClick={() => void updateRows(visible)}
               >
                 {UPDATE_ALL_LABEL}

--- a/ui/src/stores/audit.test.ts
+++ b/ui/src/stores/audit.test.ts
@@ -45,6 +45,7 @@ describe("audit store refresh", () => {
       views: [],
       auditing: false,
       error: null,
+      checkError: null,
       busy: false,
       auditedAt: null,
       backgroundFailureAnnounced: false,
@@ -72,7 +73,24 @@ describe("audit store refresh", () => {
     await useAuditStore.getState().refresh();
 
     expect(useAuditStore.getState().error).toBe("ipc down");
+    expect(useAuditStore.getState().checkError).toBe("ipc down");
     expect(useAuditStore.getState().auditing).toBe(false);
+  });
+
+  it("clears checkError once an audit answers again", async () => {
+    vi.mocked(commands.auditAll).mockResolvedValueOnce({
+      status: "error",
+      error: "boom",
+    });
+    await useAuditStore.getState().refresh();
+    expect(useAuditStore.getState().checkError).toBe("boom");
+
+    vi.mocked(commands.auditAll).mockResolvedValueOnce({
+      status: "ok",
+      data: [],
+    });
+    await useAuditStore.getState().refresh({ force: true });
+    expect(useAuditStore.getState().checkError).toBeNull();
   });
 
   it("re-arms the toast after a successful audit", async () => {
@@ -133,6 +151,7 @@ describe("audit store run() actions", () => {
       views: [emptyView],
       auditing: false,
       error: null,
+      checkError: null,
       busy: false,
       auditedAt: null,
       backgroundFailureAnnounced: false,
@@ -156,6 +175,9 @@ describe("audit store run() actions", () => {
     expect(dialog.title).toBe("Couldn't apply these changes");
     expect(dialog.message).toBe("disk is full");
     expect(useAuditStore.getState().error).toBe("disk is full");
+    // A failed item action is not a failed audit: only refresh may write
+    // the signal Home's couldn't-check row reads.
+    expect(useAuditStore.getState().checkError).toBeNull();
     expect(toast.error).not.toHaveBeenCalled();
   });
 
@@ -208,6 +230,7 @@ describe("applyPlan", () => {
       views: [emptyView],
       auditing: false,
       error: null,
+      checkError: null,
       busy: false,
       auditedAt: null,
       backgroundFailureAnnounced: false,

--- a/ui/src/stores/audit.test.ts
+++ b/ui/src/stores/audit.test.ts
@@ -64,6 +64,17 @@ describe("audit store refresh", () => {
     expect(toast.error).toHaveBeenCalledTimes(1);
   });
 
+  // A rejected call used to escape the store: auditedAt stayed null with
+  // no error, which Home read as an audit still on its way — forever.
+  it("lands a rejected call as a failed audit", async () => {
+    vi.mocked(commands.auditAll).mockRejectedValue(new Error("ipc down"));
+
+    await useAuditStore.getState().refresh();
+
+    expect(useAuditStore.getState().error).toBe("ipc down");
+    expect(useAuditStore.getState().auditing).toBe(false);
+  });
+
   it("re-arms the toast after a successful audit", async () => {
     vi.mocked(commands.auditAll).mockResolvedValueOnce({
       status: "error",

--- a/ui/src/stores/audit.ts
+++ b/ui/src/stores/audit.ts
@@ -15,6 +15,7 @@ import {
   UNDO_LABEL,
 } from "@/lib/copy-decisions";
 import { replacedToastLabel } from "@/lib/copy-in-the-way";
+import { settled } from "@/lib/settled";
 import { auditRunner, replaceView } from "./audit-run";
 import { useProblemsStore } from "./problems";
 
@@ -100,7 +101,10 @@ export const useAuditStore = create<AuditState>((set, get) => {
       if (fresh && !opts?.force) return;
       set({ auditing: true });
       try {
-        const response = await commands.auditAll();
+        // `settled` lands a rejected call as the same failed audit as a
+        // returned refusal, which keeps Home's attention section off its
+        // skeleton, the same as the scan.
+        const response = await settled(commands.auditAll());
         if (response.status === "ok") {
           set({
             views: response.data,

--- a/ui/src/stores/audit.ts
+++ b/ui/src/stores/audit.ts
@@ -23,6 +23,11 @@ interface AuditState {
   views: AuditView[];
   auditing: boolean;
   error: string | null;
+  /** Why the last audit itself failed, or null — written only by
+   *  `refresh`. The shared `error` above is also set by item actions, so a
+   *  failed remove or adopt would otherwise read as a machine that could
+   *  not be checked. */
+  checkError: string | null;
   busy: boolean;
   /** The startup audit has already toasted its failure — suppresses repeat
    * toasts on every silent retry until one succeeds. */
@@ -86,6 +91,7 @@ export const useAuditStore = create<AuditState>((set, get) => {
     auditedAt: null,
     auditing: false,
     error: null,
+    checkError: null,
     busy: false,
     backgroundFailureAnnounced: false,
 
@@ -110,10 +116,11 @@ export const useAuditStore = create<AuditState>((set, get) => {
             views: response.data,
             auditedAt: Date.now(),
             error: null,
+            checkError: null,
             backgroundFailureAnnounced: false,
           });
         } else {
-          set({ error: response.error });
+          set({ error: response.error, checkError: response.error });
           if (!get().backgroundFailureAnnounced) {
             toast.error(response.error);
             set({ backgroundFailureAnnounced: true });

--- a/ui/src/stores/landings.ts
+++ b/ui/src/stores/landings.ts
@@ -1,9 +1,9 @@
 /** Orders the landings of overlapping reads so a slow early one cannot
  *  overwrite a fresher answer. Reads rank by when they BEGIN — of two
- *  answers, the later-begun read saw the newer state — while a mutation's
- *  successful answer ranks by when it LANDS: it reports the state after
- *  its own commit, newer than any read still in flight however early that
- *  read began. */
+ *  answers, the later-begun read saw the newer state — while a
+ *  side-effecting operation's answer ranks by when it LANDS: it reports
+ *  the state its own work produced, newer than any read still in flight
+ *  however early that read began. */
 export function landings() {
   let begun = 0;
   let written = 0;
@@ -17,11 +17,10 @@ export function landings() {
       written = ticket;
       return true;
     },
-    /** Land a mutation's answer: always writes, and outranks every read
-     *  begun before this moment. */
-    landAuthoritative: (): true => {
+    /** Land a side-effecting operation's answer: it always writes, and
+     *  outranks every read begun before this moment. */
+    landAuthoritative: (): void => {
       written = ++begun;
-      return true;
     },
   };
 }

--- a/ui/src/stores/landings.ts
+++ b/ui/src/stores/landings.ts
@@ -1,0 +1,27 @@
+/** Orders the landings of overlapping reads so a slow early one cannot
+ *  overwrite a fresher answer. Reads rank by when they BEGIN — of two
+ *  answers, the later-begun read saw the newer state — while a mutation's
+ *  successful answer ranks by when it LANDS: it reports the state after
+ *  its own commit, newer than any read still in flight however early that
+ *  read began. */
+export function landings() {
+  let begun = 0;
+  let written = 0;
+  return {
+    /** Take a ticket as a read begins. */
+    begin: (): number => ++begun,
+    /** Whether the landing holding this ticket may write — true marks it
+     *  written, false means a fresher landing already did. */
+    land: (ticket: number): boolean => {
+      if (ticket <= written) return false;
+      written = ticket;
+      return true;
+    },
+    /** Land a mutation's answer: always writes, and outranks every read
+     *  begun before this moment. */
+    landAuthoritative: (): true => {
+      written = ++begun;
+      return true;
+    },
+  };
+}

--- a/ui/src/stores/marketplaces-load.test.ts
+++ b/ui/src/stores/marketplaces-load.test.ts
@@ -5,6 +5,7 @@ import { useMarketplacesStore } from "./marketplaces";
 vi.mock("@/bindings", () => ({
   commands: {
     marketplacesOverview: vi.fn(),
+    marketplaceSubscribe: vi.fn(),
   },
 }));
 vi.mock("sonner", () => ({
@@ -35,6 +36,7 @@ describe("the marketplaces overview read failing", () => {
       loaded: true,
       rowsCurrent: true,
       error: null,
+      checkError: null,
     });
     vi.clearAllMocks();
   });
@@ -52,6 +54,47 @@ describe("the marketplaces overview read failing", () => {
     expect(state.rowsCurrent).toBe(false);
     expect(state.loaded).toBe(true);
     expect(state.error).toBe("offline");
+    expect(state.checkError).toBe("offline");
+  });
+
+  // Actions write the shared error field too; only load() may write the
+  // reason the stale-read notices show, or a failed subscribe would
+  // rewrite it while the rows stay stale for the original reason.
+  it("a subscribe refusal does not change the stale-read notice", async () => {
+    vi.mocked(commands.marketplacesOverview).mockResolvedValue({
+      status: "error",
+      error: "offline",
+    });
+    await useMarketplacesStore.getState().load();
+
+    vi.mocked(commands.marketplaceSubscribe).mockResolvedValue({
+      status: "error",
+      error: "bad repo",
+    });
+    await useMarketplacesStore
+      .getState()
+      .subscribe({ scope: "global" }, "acme/kit", null);
+
+    const state = useMarketplacesStore.getState();
+    expect(state.error).toBe("bad repo");
+    expect(state.checkError).toBe("offline");
+    expect(state.rowsCurrent).toBe(false);
+  });
+
+  it("clears the stale-read reason once a read answers again", async () => {
+    vi.mocked(commands.marketplacesOverview).mockResolvedValueOnce({
+      status: "error",
+      error: "offline",
+    });
+    await useMarketplacesStore.getState().load();
+    expect(useMarketplacesStore.getState().checkError).toBe("offline");
+
+    vi.mocked(commands.marketplacesOverview).mockResolvedValueOnce({
+      status: "ok",
+      data: [kept],
+    });
+    await useMarketplacesStore.getState().load();
+    expect(useMarketplacesStore.getState().checkError).toBeNull();
   });
 
   // A rejected call used to escape the store entirely: rowsCurrent stayed

--- a/ui/src/stores/marketplaces-load.test.ts
+++ b/ui/src/stores/marketplaces-load.test.ts
@@ -69,4 +69,55 @@ describe("the marketplaces overview read failing", () => {
     expect(state.loaded).toBe(true);
     expect(state.error).toBe("ipc down");
   });
+
+  // Home's mount-time load overlaps the page's own reads; without ordering
+  // a slow early one landing last would stamp its stale rows current.
+  it("discards a slow load that lands after a fresher one", async () => {
+    let resolveFirst!: (
+      value: Awaited<ReturnType<typeof commands.marketplacesOverview>>,
+    ) => void;
+    vi.mocked(commands.marketplacesOverview).mockReturnValueOnce(
+      new Promise((resolve) => {
+        resolveFirst = resolve;
+      }),
+    );
+    const first = useMarketplacesStore.getState().load();
+
+    const fresh = [{ ...kept, name: "fresh" }];
+    vi.mocked(commands.marketplacesOverview).mockResolvedValue({
+      status: "ok",
+      data: fresh,
+    });
+    await useMarketplacesStore.getState().load();
+
+    resolveFirst({ status: "ok", data: [{ ...kept, name: "stale" }] });
+    await first;
+
+    const state = useMarketplacesStore.getState();
+    expect(state.rows).toEqual(fresh);
+    expect(state.rowsCurrent).toBe(true);
+  });
+
+  it("discards a slow failed load landing after a fresher answer", async () => {
+    let rejectFirst!: (reason: Error) => void;
+    vi.mocked(commands.marketplacesOverview).mockReturnValueOnce(
+      new Promise((_, reject) => {
+        rejectFirst = reject;
+      }),
+    );
+    const first = useMarketplacesStore.getState().load();
+
+    vi.mocked(commands.marketplacesOverview).mockResolvedValue({
+      status: "ok",
+      data: [kept],
+    });
+    await useMarketplacesStore.getState().load();
+
+    rejectFirst(new Error("ipc down"));
+    await first;
+
+    const state = useMarketplacesStore.getState();
+    expect(state.rowsCurrent).toBe(true);
+    expect(state.error).toBeNull();
+  });
 });

--- a/ui/src/stores/marketplaces-load.test.ts
+++ b/ui/src/stores/marketplaces-load.test.ts
@@ -1,0 +1,72 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { commands, type MarketplaceRow } from "@/bindings";
+import { useMarketplacesStore } from "./marketplaces";
+
+vi.mock("@/bindings", () => ({
+  commands: {
+    marketplacesOverview: vi.fn(),
+  },
+}));
+vi.mock("sonner", () => ({
+  toast: { success: vi.fn(), message: vi.fn(), error: vi.fn() },
+}));
+
+const kept: MarketplaceRow = {
+  scope: { scope: "global" },
+  name: "kit",
+  repo: "Acme/Kit",
+  repoKey: "acme/kit",
+  path: null,
+  rev: null,
+  commit: null,
+  enabled: true,
+  counts: null,
+  meta: null,
+  mode: null,
+};
+
+// A failed overview read keeps the rows it had — the page does not blank —
+// but `rowsCurrent` comes down and `loaded` comes up: the read answered
+// that it couldn't, which is not the same news as one still on its way.
+describe("the marketplaces overview read failing", () => {
+  beforeEach(() => {
+    useMarketplacesStore.setState({
+      rows: [kept],
+      loaded: true,
+      rowsCurrent: true,
+      error: null,
+    });
+    vi.clearAllMocks();
+  });
+
+  it("keeps the rows and marks them not current on a returned refusal", async () => {
+    vi.mocked(commands.marketplacesOverview).mockResolvedValue({
+      status: "error",
+      error: "offline",
+    });
+
+    await useMarketplacesStore.getState().load();
+
+    const state = useMarketplacesStore.getState();
+    expect(state.rows).toEqual([kept]);
+    expect(state.rowsCurrent).toBe(false);
+    expect(state.loaded).toBe(true);
+    expect(state.error).toBe("offline");
+  });
+
+  // A rejected call used to escape the store entirely: rowsCurrent stayed
+  // true and the tile kept counting rows nobody could confirm.
+  it("lands a rejected call the same as a returned refusal", async () => {
+    vi.mocked(commands.marketplacesOverview).mockRejectedValue(
+      new Error("ipc down"),
+    );
+
+    await useMarketplacesStore.getState().load();
+
+    const state = useMarketplacesStore.getState();
+    expect(state.rows).toEqual([kept]);
+    expect(state.rowsCurrent).toBe(false);
+    expect(state.loaded).toBe(true);
+    expect(state.error).toBe("ipc down");
+  });
+});

--- a/ui/src/stores/marketplaces-sources.ts
+++ b/ui/src/stores/marketplaces-sources.ts
@@ -1,0 +1,68 @@
+// Acting on a source as a whole — switching it on or off, and fetching
+// what every subscription now offers — kept beside the store the way its
+// cached reads are, so the store body stays the subscription lifecycle.
+import { toast } from "sonner";
+import type {
+  Catalog,
+  CatalogSummary,
+  MarketplaceRow,
+  Scope,
+} from "@/bindings";
+import { commands } from "@/bindings";
+import {
+  cachedRepoCatalogs,
+  dropCatalogCaches,
+  dropSummariesHeldBy,
+  refreshDownstream,
+} from "./marketplaces-shared";
+
+/** What these actions need back from the store. */
+interface Sources {
+  rows: MarketplaceRow[];
+  summaries: Record<string, CatalogSummary>;
+  load: () => Promise<void>;
+  loadSummary: (catalog: Catalog) => Promise<void>;
+}
+
+type Set = (
+  partial:
+    | object
+    | ((state: { summaries: Record<string, CatalogSummary> }) => object),
+) => void;
+
+export function sourceActions(set: Set, get: () => Sources) {
+  return {
+    toggle: async (scope: Scope, source: string, enabled: boolean) => {
+      const response = await commands.sourceToggle(scope, source, enabled);
+      if (response.status === "error") {
+        toast.error(response.error);
+        return;
+      }
+      dropCatalogCaches(set);
+      dropSummariesHeldBy(set, get().rows, scope, source);
+      await get().load();
+      await refreshDownstream();
+    },
+
+    checkForUpdates: async () => {
+      set({ busy: true });
+      try {
+        const response = await commands.sourcesRefresh();
+        if (response.status === "ok") {
+          for (const warning of response.data) toast.message(warning);
+          // A fetch can move any subscription to a new commit; everything
+          // derived from catalog bytes re-reads.
+          dropCatalogCaches(set);
+          await get().load();
+          for (const repo of cachedRepoCatalogs(get().summaries)) {
+            void get().loadSummary(repo);
+          }
+        } else {
+          toast.error(response.error);
+        }
+      } finally {
+        set({ busy: false });
+      }
+    },
+  };
+}

--- a/ui/src/stores/marketplaces-sources.ts
+++ b/ui/src/stores/marketplaces-sources.ts
@@ -9,6 +9,7 @@ import type {
   Scope,
 } from "@/bindings";
 import { commands } from "@/bindings";
+import { MARKETPLACES_NEEDS_CHECK_NOTE } from "@/lib/copy-marketplaces";
 import {
   cachedRepoCatalogs,
   dropCatalogCaches,
@@ -19,6 +20,7 @@ import {
 /** What these actions need back from the store. */
 interface Sources {
   rows: MarketplaceRow[];
+  rowsCurrent: boolean;
   summaries: Record<string, CatalogSummary>;
   load: () => Promise<void>;
   loadSummary: (catalog: Catalog) => Promise<void>;
@@ -33,6 +35,13 @@ type Set = (
 export function sourceActions(set: Set, get: () => Sources) {
   return {
     toggle: async (scope: Scope, source: string, enabled: boolean) => {
+      // The action boundary owns the guarantee: any trigger acting on a
+      // row a failed read left behind is refused here, not just gated in
+      // the component that happens to render it.
+      if (!get().rowsCurrent) {
+        toast.error(MARKETPLACES_NEEDS_CHECK_NOTE);
+        return;
+      }
       const response = await commands.sourceToggle(scope, source, enabled);
       if (response.status === "error") {
         toast.error(response.error);

--- a/ui/src/stores/marketplaces-subscribed.test.ts
+++ b/ui/src/stores/marketplaces-subscribed.test.ts
@@ -1,5 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { commands, type DirectoryRow, type MarketplaceRow } from "@/bindings";
+import { MARKETPLACES_NEEDS_CHECK_NOTE } from "@/lib/copy-marketplaces";
 import { useMarketplacesStore } from "./marketplaces";
 import { rowSubscribed, subscribedKeys } from "./marketplaces-shared";
 
@@ -91,10 +92,32 @@ describe("a Community row's Subscribed marker", () => {
     expect(subscribedKeys([row("", null)]).size).toBe(0);
   });
 
+  // The action boundary owns the guarantee: a dialog opened while rows
+  // were current can still confirm after a failed re-read — the store
+  // refuses the stale source however the confirm got clicked.
+  it("refuses to unsubscribe from rows a failed read left behind", async () => {
+    useMarketplacesStore.setState({
+      rows: [row("Acme/Kit", "acme/kit")],
+      loaded: true,
+      rowsCurrent: false,
+    });
+
+    const ok = await useMarketplacesStore
+      .getState()
+      .unsubscribe({ scope: "global" }, "kit", false, false);
+
+    expect(ok).toBe(false);
+    expect(commands.marketplaceUnsubscribe).not.toHaveBeenCalled();
+    expect(useMarketplacesStore.getState().error).toBe(
+      MARKETPLACES_NEEDS_CHECK_NOTE,
+    );
+  });
+
   it("clears once an unsubscribe lands, whatever the directory snapshot said", async () => {
     useMarketplacesStore.setState({
       rows: [row("Acme/Kit", "acme/kit")],
       loaded: true,
+      rowsCurrent: true,
     });
     vi.mocked(commands.marketplaceUnsubscribe).mockResolvedValue({
       status: "ok",

--- a/ui/src/stores/marketplaces-toggle.test.ts
+++ b/ui/src/stores/marketplaces-toggle.test.ts
@@ -1,7 +1,8 @@
 // A bare repository page's action and what toggling its holder does to
 // the summaries that decide which subscription the page carries on as.
-import { describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import { commands, type MarketplaceRow } from "@/bindings";
+import { MARKETPLACES_NEEDS_CHECK_NOTE } from "@/lib/copy-marketplaces";
 import { useMarketplacesStore } from "./marketplaces";
 import { catalogKey, declaredHolder, repoAction } from "./marketplaces-shared";
 
@@ -35,6 +36,31 @@ const row = (repo: string, repoKey: string | null): MarketplaceRow => ({
   counts: null,
   meta: null,
   mode: null,
+});
+
+// Rows being acted on imply a read that answered; tests staging a failed
+// read set rowsCurrent themselves.
+beforeEach(() => {
+  useMarketplacesStore.setState({ rowsCurrent: true });
+});
+
+// The action boundary owns the guarantee: whatever component triggers a
+// toggle on rows a failed read left behind, the store refuses it.
+describe("toggling from rows a failed read left behind", () => {
+  it("refuses with the needs-check note instead of committing", async () => {
+    const { toast } = await import("sonner");
+    useMarketplacesStore.setState({
+      rows: [row("acme/kit", "acme/kit")],
+      rowsCurrent: false,
+    });
+
+    await useMarketplacesStore
+      .getState()
+      .toggle({ scope: "global" }, "kit", false);
+
+    expect(commands.sourceToggle).not.toHaveBeenCalled();
+    expect(toast.error).toHaveBeenCalledWith(MARKETPLACES_NEEDS_CHECK_NOTE);
+  });
 });
 
 describe("a bare repository page's action", () => {

--- a/ui/src/stores/marketplaces.ts
+++ b/ui/src/stores/marketplaces.ts
@@ -58,6 +58,11 @@ interface MarketplacesState {
   rowsCurrent: boolean;
   busy: boolean;
   error: string | null;
+  /** Why the last overview read failed, or null — written only by `load`.
+   * The shared `error` above is also set by subscribe/unsubscribe/install,
+   * so a failed action would otherwise rewrite the reason the stale-read
+   * notices show. */
+  checkError: string | null;
   load: () => Promise<void>;
   loadPackages: (catalog: Catalog) => Promise<void>;
   loadSummary: (catalog: Catalog) => Promise<void>;
@@ -102,6 +107,7 @@ export const useMarketplacesStore = create<MarketplacesState>((set, get) => ({
   rowsCurrent: false,
   busy: false,
   error: null,
+  checkError: null,
 
   load: async () => {
     // A failed read — refusal or rejection, via `settled` — still answers:
@@ -115,9 +121,15 @@ export const useMarketplacesStore = create<MarketplacesState>((set, get) => ({
         loaded: true,
         rowsCurrent: true,
         error: null,
+        checkError: null,
       });
     } else {
-      set({ loaded: true, rowsCurrent: false, error: response.error });
+      set({
+        loaded: true,
+        rowsCurrent: false,
+        error: response.error,
+        checkError: response.error,
+      });
     }
   },
 

--- a/ui/src/stores/marketplaces.ts
+++ b/ui/src/stores/marketplaces.ts
@@ -1,6 +1,5 @@
 import { toast } from "sonner";
 import { create } from "zustand";
-import type { MarketplaceRow } from "@/bindings";
 import {
   type AboutView,
   type AvailablePackage,
@@ -9,19 +8,20 @@ import {
   type CatalogSummary,
   commands,
   type InstallItem,
+  type MarketplaceRow,
   type Scope,
 } from "@/bindings";
+import { settled } from "@/lib/settled";
 import { catalogReads } from "./marketplaces-reads";
 import {
-  cachedRepoCatalogs,
   catalogKey,
   dropCatalogCaches,
-  dropSummariesHeldBy,
   isRepoKey,
   openLead,
   refreshDownstream,
   subscription,
 } from "./marketplaces-shared";
+import { sourceActions } from "./marketplaces-sources";
 
 export {
   bundleKey,
@@ -97,7 +97,9 @@ export const useMarketplacesStore = create<MarketplacesState>((set, get) => ({
   error: null,
 
   load: async () => {
-    const response = await commands.marketplacesOverview();
+    // A failed read — refusal or rejection, via `settled` — still answers:
+    // `loaded` comes up, `rowsCurrent` does not, and the kept rows stay.
+    const response = await settled(commands.marketplacesOverview());
     if (response.status === "ok") {
       set({
         rows: response.data,
@@ -175,38 +177,7 @@ export const useMarketplacesStore = create<MarketplacesState>((set, get) => ({
     return true;
   },
 
-  toggle: async (scope, source, enabled) => {
-    const response = await commands.sourceToggle(scope, source, enabled);
-    if (response.status === "error") {
-      toast.error(response.error);
-      return;
-    }
-    dropCatalogCaches(set);
-    dropSummariesHeldBy(set, get().rows, scope, source);
-    await get().load();
-    await refreshDownstream();
-  },
-
-  checkForUpdates: async () => {
-    set({ busy: true });
-    try {
-      const response = await commands.sourcesRefresh();
-      if (response.status === "ok") {
-        for (const warning of response.data) toast.message(warning);
-        // A fetch can move any subscription to a new commit; everything
-        // derived from catalog bytes re-reads.
-        dropCatalogCaches(set);
-        await get().load();
-        for (const repo of cachedRepoCatalogs(get().summaries)) {
-          void get().loadSummary(repo);
-        }
-      } else {
-        toast.error(response.error);
-      }
-    } finally {
-      set({ busy: false });
-    }
-  },
+  ...sourceActions(set, get),
 
   install: async ({ scope, source, items, bundle = null, destination }) => {
     set({ busy: true });

--- a/ui/src/stores/marketplaces.ts
+++ b/ui/src/stores/marketplaces.ts
@@ -12,6 +12,7 @@ import {
   type Scope,
 } from "@/bindings";
 import { settled } from "@/lib/settled";
+import { landings } from "./landings";
 import { catalogReads } from "./marketplaces-reads";
 import {
   catalogKey,
@@ -84,6 +85,12 @@ interface MarketplacesState {
   }) => Promise<boolean>;
 }
 
+// Overview reads overlap — Home's mount-time load against the page's own,
+// or a mutation's re-read — and a slow early one landing last would stamp
+// pre-mutation rows current. Every write goes through subscribe/unsubscribe
+// re-reading via load(), so read ordering alone covers it.
+const overviewLandings = landings();
+
 export const useMarketplacesStore = create<MarketplacesState>((set, get) => ({
   rows: [],
   packages: {},
@@ -99,7 +106,9 @@ export const useMarketplacesStore = create<MarketplacesState>((set, get) => ({
   load: async () => {
     // A failed read — refusal or rejection, via `settled` — still answers:
     // `loaded` comes up, `rowsCurrent` does not, and the kept rows stay.
+    const ticket = overviewLandings.begin();
     const response = await settled(commands.marketplacesOverview());
+    if (!overviewLandings.land(ticket)) return;
     if (response.status === "ok") {
       set({
         rows: response.data,

--- a/ui/src/stores/marketplaces.ts
+++ b/ui/src/stores/marketplaces.ts
@@ -11,6 +11,7 @@ import {
   type MarketplaceRow,
   type Scope,
 } from "@/bindings";
+import { MARKETPLACES_NEEDS_CHECK_NOTE } from "@/lib/copy-marketplaces";
 import { settled } from "@/lib/settled";
 import { landings } from "./landings";
 import { catalogReads } from "./marketplaces-reads";
@@ -168,6 +169,13 @@ export const useMarketplacesStore = create<MarketplacesState>((set, get) => ({
   },
 
   unsubscribe: async (scope, source, keep, discardEdits) => {
+    // The action boundary owns the guarantee: a dialog opened while rows
+    // were current can still confirm after a failed re-read left them
+    // stale — refusing here covers every trigger at once.
+    if (!get().rowsCurrent) {
+      set({ error: MARKETPLACES_NEEDS_CHECK_NOTE });
+      return false;
+    }
     set({ busy: true });
     let response: Awaited<ReturnType<typeof commands.marketplaceUnsubscribe>>;
     try {

--- a/ui/src/stores/scan.test.ts
+++ b/ui/src/stores/scan.test.ts
@@ -138,11 +138,17 @@ describe("scan store", () => {
     expect(toast.error).toHaveBeenCalledTimes(2);
   });
 
-  it("lowers the scanning flag when the call itself rejects", async () => {
+  // A rejected call used to escape the store entirely: no error, no
+  // result, and Home read the silence as a scan still on its way.
+  it("lands a rejected call as a failed scan, keeping the last result", async () => {
+    useScanStore.setState({ result: emptyResult });
     vi.mocked(commands.scanMachine).mockRejectedValue(new Error("ipc down"));
 
-    await expect(useScanStore.getState().refresh()).rejects.toThrow("ipc down");
+    await useScanStore.getState().refresh();
 
-    expect(useScanStore.getState().scanning).toBe(false);
+    const state = useScanStore.getState();
+    expect(state.error).toBe("ipc down");
+    expect(state.result).toEqual(emptyResult);
+    expect(state.scanning).toBe(false);
   });
 });

--- a/ui/src/stores/scan.ts
+++ b/ui/src/stores/scan.ts
@@ -1,6 +1,7 @@
 import { toast } from "sonner";
 import { create } from "zustand";
 import { commands, type ScanResult } from "@/bindings";
+import { settled } from "@/lib/settled";
 
 interface ScanState {
   result: ScanResult | null;
@@ -28,7 +29,10 @@ export const useScanStore = create<ScanState>((set, get) => ({
     // The flag comes down however the call ends: a rejected call that left
     // it up would skip every later scan for the session.
     try {
-      const response = await commands.scanMachine();
+      // `settled` lands a rejected call as the same failed scan as a
+      // returned refusal, which keeps Home off its skeletons. The last
+      // good result stays kept either way.
+      const response = await settled(commands.scanMachine());
       if (response.status === "ok") {
         set({
           result: response.data,

--- a/ui/src/stores/updates-apply.ts
+++ b/ui/src/stores/updates-apply.ts
@@ -1,0 +1,61 @@
+// How rows come current: a held place moves its hold, a following place
+// applies its scope, and a bulk run never applies one scope twice — kept
+// beside the store the way its read landing and edit flows are, so the
+// store body stays the state lifecycle.
+import { commands, type UpdateRow } from "@/bindings";
+import { scopeKey } from "@/lib/scope";
+
+type Report = (error: string) => void;
+
+/** Bring one place current. Held packages move by moving the hold;
+ *  following ones come current by applying the scope — which is what
+ *  following means, and brings any other pending changes in that scope
+ *  along. Returns whether it landed; failures go through `report`. */
+export const applyRow = async (
+  row: UpdateRow,
+  report: Report,
+): Promise<boolean> => {
+  const response =
+    row.pinned && row.latest
+      ? await commands.packageSetRev(
+          row.scope,
+          row.kind,
+          row.name,
+          row.latest.commit,
+        )
+      : await commands.applyPlan(row.scope, false, []);
+  if (response.status === "error") {
+    report(response.error);
+    return false;
+  }
+  return true;
+};
+
+/** Bring every place in `rows` current: every hold first — each move
+ *  applies its whole scope, so that scope's followers are already current
+ *  — then one apply per scope no hold touched. Never two applies for one
+ *  scope. Returns whether every step landed. */
+export const applyRows = async (
+  rows: UpdateRow[],
+  report: Report,
+): Promise<boolean> => {
+  let ok = true;
+  const applied = new Set<string>();
+  for (const row of rows.filter((row) => row.pinned)) {
+    if (await applyRow(row, report)) applied.add(scopeKey(row.scope));
+    else ok = false;
+  }
+  const scopes = new Map(
+    rows
+      .filter((row) => !row.pinned && !applied.has(scopeKey(row.scope)))
+      .map((row) => [scopeKey(row.scope), row] as const),
+  );
+  for (const row of scopes.values()) {
+    const response = await commands.applyPlan(row.scope, false, []);
+    if (response.status === "error") {
+      report(response.error);
+      ok = false;
+    }
+  }
+  return ok;
+};

--- a/ui/src/stores/updates-bulk.test.ts
+++ b/ui/src/stores/updates-bulk.test.ts
@@ -53,7 +53,7 @@ function row(overrides: Partial<UpdateRow>): UpdateRow {
 
 describe("updates store: bulk update", () => {
   beforeEach(() => {
-    useUpdatesStore.setState({ rows: [], busy: false, loaded: false });
+    useUpdatesStore.setState({ rows: [], busy: false, loaded: true });
     vi.clearAllMocks();
   });
 

--- a/ui/src/stores/updates-bulk.test.ts
+++ b/ui/src/stores/updates-bulk.test.ts
@@ -3,6 +3,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { UpdateRow } from "@/bindings";
 import { commands } from "@/bindings";
 import { ADOPTABLE } from "@/lib/adoptable";
+import { useProblemsStore } from "./problems";
 import { useUpdatesStore } from "./updates";
 
 vi.mock("@/bindings", () => ({
@@ -54,6 +55,31 @@ describe("updates store: bulk update", () => {
   beforeEach(() => {
     useUpdatesStore.setState({ rows: [], busy: false, loaded: false });
     vi.clearAllMocks();
+  });
+
+  // A transport rejection escapes the apply sequence without recording a
+  // failure — only the applier sees it, and the success toast must not
+  // stand over it.
+  it("claims no success when the transport fails mid-run", async () => {
+    useProblemsStore.setState({
+      dialog: { open: false, title: "", steps: [], actions: [] },
+    });
+    vi.mocked(commands.applyPlan).mockRejectedValue(new Error("ipc down"));
+    vi.mocked(commands.updatesOverview).mockResolvedValue({
+      status: "ok",
+      data: { rows: [], warnings: [] },
+    });
+    vi.mocked(commands.scanMachine).mockResolvedValue({
+      status: "ok",
+      data: { harnesses: [], items: [], missingProjects: [], warnings: [] },
+    });
+    vi.mocked(commands.auditAll).mockResolvedValue({ status: "ok", data: [] });
+
+    await useUpdatesStore.getState().updateRows([row({})]);
+
+    expect(toast.success).not.toHaveBeenCalled();
+    expect(useProblemsStore.getState().dialog.open).toBe(true);
+    expect(useProblemsStore.getState().dialog.message).toBe("ipc down");
   });
 
   it("a bulk update moves holds once each and applies every following scope once", async () => {

--- a/ui/src/stores/updates-edits.test.ts
+++ b/ui/src/stores/updates-edits.test.ts
@@ -2,6 +2,8 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { UpdateRow } from "@/bindings";
 import { commands } from "@/bindings";
 import { ADOPTABLE } from "@/lib/adoptable";
+import { UPDATE_NEEDS_CHECK_NOTE } from "@/lib/copy-updates";
+import { useProblemsStore } from "./problems";
 import { useUpdatesStore } from "./updates";
 import { keepAsOwn, takeNewVersion } from "./updates-edits";
 
@@ -52,8 +54,34 @@ function row(overrides: Partial<UpdateRow>): UpdateRow {
 
 describe("updates store: edited places", () => {
   beforeEach(() => {
-    useUpdatesStore.setState({ rows: [], busy: false, loaded: false });
+    // Rows being acted on imply a read that answered; the stale-refusal
+    // test below stages the opposite itself.
+    useUpdatesStore.setState({ rows: [], busy: false, loaded: true });
     vi.clearAllMocks();
+  });
+
+  // The action boundary owns the guarantee: a confirmation opened before
+  // a check failed still holds a retained row whose latest nobody
+  // confirmed — the store refuses it however the dialog got there.
+  it("refuses to discard edits from rows a failed check left behind", async () => {
+    useUpdatesStore.setState({ loaded: false });
+    useProblemsStore.setState({
+      dialog: { open: false, title: "", steps: [], actions: [] },
+    });
+
+    await takeNewVersion(
+      row({
+        blockedByLocalEdit: true,
+        editedHarnesses: ["claude"],
+        pinned: true,
+      }),
+    );
+
+    expect(commands.applyDiscardEdits).not.toHaveBeenCalled();
+    expect(useProblemsStore.getState().dialog.open).toBe(true);
+    expect(useProblemsStore.getState().dialog.message).toBe(
+      UPDATE_NEEDS_CHECK_NOTE,
+    );
   });
 
   it("use new version on a held place moves the hold to latest in the same apply", async () => {

--- a/ui/src/stores/updates-edits.test.ts
+++ b/ui/src/stores/updates-edits.test.ts
@@ -60,6 +60,54 @@ describe("updates store: edited places", () => {
     vi.clearAllMocks();
   });
 
+  // A transport rejection never assigns work's error — only the applier
+  // sees it, and dropping its return let the fork and discard flows carry
+  // on to their success paths over an IPC failure.
+  it("a fork whose transport failed does not proceed as success", async () => {
+    useProblemsStore.setState({
+      dialog: { open: false, title: "", steps: [], actions: [] },
+    });
+    vi.mocked(commands.packageFork).mockRejectedValue(new Error("ipc down"));
+    vi.mocked(commands.updatesOverview).mockResolvedValue({
+      status: "ok",
+      data: { rows: [], warnings: [] },
+    });
+
+    await keepAsOwn(
+      row({
+        blockedByLocalEdit: true,
+        editedHarnesses: ["claude"],
+        forkableHarness: "claude",
+      }),
+    );
+
+    expect(useProblemsStore.getState().dialog.open).toBe(true);
+    expect(useProblemsStore.getState().dialog.message).toBe("ipc down");
+    // run() stops at the failure instead of refreshing as if it landed.
+    expect(commands.auditAll).not.toHaveBeenCalled();
+  });
+
+  it("a discard whose transport failed surfaces the failure", async () => {
+    useProblemsStore.setState({
+      dialog: { open: false, title: "", steps: [], actions: [] },
+    });
+    vi.mocked(commands.applyDiscardEdits).mockRejectedValue(
+      new Error("ipc down"),
+    );
+    vi.mocked(commands.updatesOverview).mockResolvedValue({
+      status: "ok",
+      data: { rows: [], warnings: [] },
+    });
+
+    await takeNewVersion(
+      row({ blockedByLocalEdit: true, editedHarnesses: ["claude"] }),
+    );
+
+    expect(useProblemsStore.getState().dialog.open).toBe(true);
+    expect(useProblemsStore.getState().dialog.message).toBe("ipc down");
+    expect(commands.auditAll).not.toHaveBeenCalled();
+  });
+
   // The action boundary owns the guarantee: a confirmation opened before
   // a check failed still holds a retained row whose latest nobody
   // confirmed — the store refuses it however the dialog got there.

--- a/ui/src/stores/updates-edits.ts
+++ b/ui/src/stores/updates-edits.ts
@@ -55,11 +55,11 @@ export const keepAsOwn = async (row: UpdateRow): Promise<void> => {
 export const takeNewVersion = async (row: UpdateRow): Promise<void> => {
   // The action boundary owns the guarantee: a confirmation opened before
   // a check failed still holds a retained row, and its latest names a
-  // commit nobody confirmed — the same is true mid-check, when a running
-  // refresh is about to replace the rows. The trigger gates are UX; this
-  // is the stop.
-  const { loaded, checking } = useUpdatesStore.getState();
-  if (!loaded || checking) {
+  // commit nobody confirmed — the same while anything overview-producing
+  // is in flight, about to replace the rows. The trigger gates are UX;
+  // this is the stop.
+  const { loaded, checking, overviewInFlight } = useUpdatesStore.getState();
+  if (!loaded || checking || overviewInFlight) {
     useProblemsStore
       .getState()
       .showError({ title: FORK_ERROR_TITLE, message: UPDATE_NEEDS_CHECK_NOTE });

--- a/ui/src/stores/updates-edits.ts
+++ b/ui/src/stores/updates-edits.ts
@@ -1,6 +1,7 @@
 import { toast } from "sonner";
 import { commands, type UpdateRow } from "@/bindings";
 import { FORK_ERROR_TITLE, forkedToastLabel } from "@/lib/copy";
+import { UPDATE_NEEDS_CHECK_NOTE } from "@/lib/copy-updates";
 import { packageDisplayName } from "@/lib/labels";
 import { useAuditStore } from "./audit";
 import { useProblemsStore } from "./problems";
@@ -52,6 +53,15 @@ export const keepAsOwn = async (row: UpdateRow): Promise<void> => {
 /** Drop an edited place's edits and take the newest version — moving the
  *  hold along when the place is held, in the same apply. */
 export const takeNewVersion = async (row: UpdateRow): Promise<void> => {
+  // The action boundary owns the guarantee: a confirmation opened before
+  // a check failed still holds a retained row, and its latest names a
+  // commit nobody confirmed. The trigger gates are UX; this is the stop.
+  if (!useUpdatesStore.getState().loaded) {
+    useProblemsStore
+      .getState()
+      .showError({ title: FORK_ERROR_TITLE, message: UPDATE_NEEDS_CHECK_NOTE });
+    return;
+  }
   await run(async () => {
     const response = await commands.applyDiscardEdits(
       row.scope,

--- a/ui/src/stores/updates-edits.ts
+++ b/ui/src/stores/updates-edits.ts
@@ -55,8 +55,11 @@ export const keepAsOwn = async (row: UpdateRow): Promise<void> => {
 export const takeNewVersion = async (row: UpdateRow): Promise<void> => {
   // The action boundary owns the guarantee: a confirmation opened before
   // a check failed still holds a retained row, and its latest names a
-  // commit nobody confirmed. The trigger gates are UX; this is the stop.
-  if (!useUpdatesStore.getState().loaded) {
+  // commit nobody confirmed — the same is true mid-check, when a running
+  // refresh is about to replace the rows. The trigger gates are UX; this
+  // is the stop.
+  const { loaded, checking } = useUpdatesStore.getState();
+  if (!loaded || checking) {
     useProblemsStore
       .getState()
       .showError({ title: FORK_ERROR_TITLE, message: UPDATE_NEEDS_CHECK_NOTE });

--- a/ui/src/stores/updates-edits.ts
+++ b/ui/src/stores/updates-edits.ts
@@ -14,14 +14,15 @@ import { useUpdatesStore } from "./updates";
 const run = async (work: () => Promise<string | null>) => {
   useUpdatesStore.setState({ busy: true });
   try {
-    const error = await work();
+    // The commit and the overview that follows ride the updates store's
+    // side-effect chain, in commit order with every other operation.
+    const error = await useUpdatesStore.getState().mutate(work);
     if (error !== null) {
       useProblemsStore
         .getState()
         .showError({ title: FORK_ERROR_TITLE, message: error });
       return;
     }
-    await useUpdatesStore.getState().load();
     await useScanStore.getState().refresh();
     await useAuditStore.getState().refresh({ force: true });
   } finally {

--- a/ui/src/stores/updates-overview.ts
+++ b/ui/src/stores/updates-overview.ts
@@ -1,4 +1,4 @@
-import type { ItemWarning, UpdateRow } from "@/bindings";
+import { commands, type ItemWarning, type UpdateRow } from "@/bindings";
 import { settled } from "@/lib/settled";
 import { landings } from "./landings";
 
@@ -72,7 +72,17 @@ export function overviewApplier(
       if (kind === "refresh") {
         order.landAuthoritative();
         set({ loaded: false, error: response.error });
+        return response.error;
       }
+      // A mutation can commit and then fail building its overview: the
+      // rows on screen may no longer be the truth, so one reconciling
+      // read answers either way — success lands whatever actually
+      // committed, failure marks the retained rows stale under the
+      // operation's own error.
+      const reread = await settled<Overview>(commands.updatesOverview());
+      order.landAuthoritative();
+      if (reread.status === "ok") landOk(reread.data);
+      else set({ loaded: false, error: response.error });
       return response.error;
     });
     // The chain outlives a link that throws; the error still reaches this

--- a/ui/src/stores/updates-overview.ts
+++ b/ui/src/stores/updates-overview.ts
@@ -2,8 +2,9 @@ import type { ItemWarning, UpdateRow } from "@/bindings";
 import { settled } from "@/lib/settled";
 import { landings } from "./landings";
 
+type Overview = { rows: UpdateRow[]; warnings: ItemWarning[] };
 type OverviewResult =
-  | { status: "ok"; data: { rows: UpdateRow[]; warnings: ItemWarning[] } }
+  | { status: "ok"; data: Overview }
   | { status: "error"; error: string };
 
 // The one place a read of the standing lands, however it went. A failure
@@ -14,11 +15,21 @@ type OverviewResult =
 // the fail-open this closes. Returns why the read failed, or null, so
 // callers make their own noise.
 //
-// Landings are ordered (see `landings`): the mount-time load, an explicit
-// check, and a mutation's returned overview can resolve in any order, and
-// a slow early read landing last would overwrite a fresher answer and
-// stamp its stale rows loaded and current. A discarded landing's return
-// value still reports how the operation itself went.
+// Two ordering rules, by what produced the overview:
+//
+// - Plain reads run concurrently and rank by when they began (see
+//   `landings`): a slow early read landing last is discarded rather than
+//   overwriting a fresher answer.
+// - Side-effecting operations — a refresh that fetches every source, a
+//   mutation that commits a change — run one at a time on a chain: the
+//   next command is not sent until the previous answer has landed, so
+//   their landings are in commit order by construction and no rank rule
+//   between them is needed. Each landing is authoritative over every
+//   plain read begun before it, success and refresh-failure alike — an
+//   explicit check that failed is an answer to report, not one a quicker
+//   re-read of old mirrors may bury. Only a failed mutation touches
+//   nothing: it re-read nothing, and the rows on screen are still the
+//   last good read's answer.
 export function overviewApplier(
   set: (partial: {
     rows?: UpdateRow[];
@@ -28,35 +39,45 @@ export function overviewApplier(
   }) => void,
 ) {
   const order = landings();
+  let chain: Promise<unknown> = Promise.resolve();
+
+  const landOk = (data: Overview) =>
+    set({
+      rows: data.rows,
+      warnings: data.warnings,
+      loaded: true,
+      error: null,
+    });
+
   return async (
-    read: Promise<OverviewResult>,
-    // What produced this overview decides how it lands. A plain read ranks
-    // by when it began, success and failure alike. A refresh fetched every
-    // source before answering, and a mutation committed a change: their
-    // successful answers report a state no read still in flight can be
-    // fresher than, so both land authoritatively. On failure a refresh is
-    // just a read that could not answer — it marks the rows stale — while
-    // a failed mutation re-read nothing and touches nothing.
+    read: () => Promise<OverviewResult>,
     kind: "read" | "refresh" | "mutation" = "read",
   ): Promise<string | null> => {
-    const ticket = order.begin();
-    const response = await settled(read);
-    if (response.status === "ok") {
-      const lands =
-        kind === "read" ? order.land(ticket) : order.landAuthoritative();
-      if (lands) {
-        set({
-          rows: response.data.rows,
-          warnings: response.data.warnings,
-          loaded: true,
-          error: null,
-        });
+    if (kind === "read") {
+      const ticket = order.begin();
+      const response = await settled<Overview>(Promise.resolve().then(read));
+      if (order.land(ticket)) {
+        if (response.status === "ok") landOk(response.data);
+        else set({ loaded: false, error: response.error });
       }
-      return null;
+      return response.status === "ok" ? null : response.error;
     }
-    if (kind !== "mutation" && order.land(ticket)) {
-      set({ loaded: false, error: response.error });
-    }
-    return response.error;
+    const turn = chain.then(async (): Promise<string | null> => {
+      const response = await settled<Overview>(Promise.resolve().then(read));
+      if (response.status === "ok") {
+        order.landAuthoritative();
+        landOk(response.data);
+        return null;
+      }
+      if (kind === "refresh") {
+        order.landAuthoritative();
+        set({ loaded: false, error: response.error });
+      }
+      return response.error;
+    });
+    // The chain outlives a link that throws; the error still reaches this
+    // operation's caller through `turn`.
+    chain = turn.catch(() => {});
+    return await turn;
   };
 }

--- a/ui/src/stores/updates-overview.ts
+++ b/ui/src/stores/updates-overview.ts
@@ -87,7 +87,9 @@ export function overviewApplier(
         // rows on screen may no longer be the truth, so one reconciling
         // read answers either way — success lands whatever actually
         // committed, failure marks the retained rows stale under the
-        // operation's own error.
+        // operation's own error. The handed operation's error returns
+        // either way; a caller whose work ran apart from this read
+        // (`mutate`) owns telling a dead read from a failed work.
         const reread = await settled<Overview>(commands.updatesOverview());
         order.landAuthoritative();
         if (reread.status === "ok") landOk(reread.data);

--- a/ui/src/stores/updates-overview.ts
+++ b/ui/src/stores/updates-overview.ts
@@ -1,5 +1,6 @@
 import type { ItemWarning, UpdateRow } from "@/bindings";
 import { settled } from "@/lib/settled";
+import { landings } from "./landings";
 
 type OverviewResult =
   | { status: "ok"; data: { rows: UpdateRow[]; warnings: ItemWarning[] } }
@@ -13,12 +14,11 @@ type OverviewResult =
 // the fail-open this closes. Returns why the read failed, or null, so
 // callers make their own noise.
 //
-// Landings are ordered: the mount-time load, an explicit check, and a
-// mutation's returned overview can resolve in any order, and a slow
-// early read landing last would overwrite a fresher answer and stamp its
-// stale rows loaded and current. Each read takes a ticket when it
-// starts; a landing older than the last one written is discarded — its
-// return value still reports how the operation itself went.
+// Landings are ordered (see `landings`): the mount-time load, an explicit
+// check, and a mutation's returned overview can resolve in any order, and
+// a slow early read landing last would overwrite a fresher answer and
+// stamp its stale rows loaded and current. A discarded landing's return
+// value still reports how the operation itself went.
 export function overviewApplier(
   set: (partial: {
     rows?: UpdateRow[];
@@ -27,20 +27,23 @@ export function overviewApplier(
     error?: string | null;
   }) => void,
 ) {
-  let started = 0;
-  let written = 0;
+  const order = landings();
   return async (
     read: Promise<OverviewResult>,
     // A read that failed leaves the rows on screen unconfirmed; a mutation
     // that failed re-read nothing, so the rows are still the last good
-    // read's answer — only reads may mark them stale.
+    // read's answer — only reads may mark them stale. A mutation that
+    // SUCCEEDED always lands: its overview reports the state after its
+    // commit, which no read still in flight can be fresher than.
     opts?: { mutation?: boolean },
   ): Promise<string | null> => {
-    const ticket = ++started;
+    const ticket = order.begin();
     const response = await settled(read);
     if (response.status === "ok") {
-      if (ticket > written) {
-        written = ticket;
+      const lands = opts?.mutation
+        ? order.landAuthoritative()
+        : order.land(ticket);
+      if (lands) {
         set({
           rows: response.data.rows,
           warnings: response.data.warnings,
@@ -50,8 +53,7 @@ export function overviewApplier(
       }
       return null;
     }
-    if (!opts?.mutation && ticket > written) {
-      written = ticket;
+    if (!opts?.mutation && order.land(ticket)) {
       set({ loaded: false, error: response.error });
     }
     return response.error;

--- a/ui/src/stores/updates-overview.ts
+++ b/ui/src/stores/updates-overview.ts
@@ -36,10 +36,16 @@ export function overviewApplier(
     warnings?: ItemWarning[];
     loaded?: boolean;
     error?: string | null;
+    overviewInFlight?: boolean;
   }) => void,
 ) {
   const order = landings();
   let chain: Promise<unknown> = Promise.resolve();
+  // Every operation this applier runs — plain read, refresh, mutation —
+  // is about to replace the rows on screen: the store's overviewInFlight
+  // says so while any is outstanding, and the commit-applying actions
+  // refuse for as long as it is up.
+  let inFlight = 0;
 
   const landOk = (data: Overview) =>
     set({
@@ -53,41 +59,48 @@ export function overviewApplier(
     read: () => Promise<OverviewResult>,
     kind: "read" | "refresh" | "mutation" = "read",
   ): Promise<string | null> => {
-    if (kind === "read") {
-      const ticket = order.begin();
-      const response = await settled<Overview>(Promise.resolve().then(read));
-      if (order.land(ticket)) {
-        if (response.status === "ok") landOk(response.data);
+    inFlight += 1;
+    set({ overviewInFlight: true });
+    try {
+      if (kind === "read") {
+        const ticket = order.begin();
+        const response = await settled<Overview>(Promise.resolve().then(read));
+        if (order.land(ticket)) {
+          if (response.status === "ok") landOk(response.data);
+          else set({ loaded: false, error: response.error });
+        }
+        return response.status === "ok" ? null : response.error;
+      }
+      const turn = chain.then(async (): Promise<string | null> => {
+        const response = await settled<Overview>(Promise.resolve().then(read));
+        if (response.status === "ok") {
+          order.landAuthoritative();
+          landOk(response.data);
+          return null;
+        }
+        if (kind === "refresh") {
+          order.landAuthoritative();
+          set({ loaded: false, error: response.error });
+          return response.error;
+        }
+        // A mutation can commit and then fail building its overview: the
+        // rows on screen may no longer be the truth, so one reconciling
+        // read answers either way — success lands whatever actually
+        // committed, failure marks the retained rows stale under the
+        // operation's own error.
+        const reread = await settled<Overview>(commands.updatesOverview());
+        order.landAuthoritative();
+        if (reread.status === "ok") landOk(reread.data);
         else set({ loaded: false, error: response.error });
-      }
-      return response.status === "ok" ? null : response.error;
-    }
-    const turn = chain.then(async (): Promise<string | null> => {
-      const response = await settled<Overview>(Promise.resolve().then(read));
-      if (response.status === "ok") {
-        order.landAuthoritative();
-        landOk(response.data);
-        return null;
-      }
-      if (kind === "refresh") {
-        order.landAuthoritative();
-        set({ loaded: false, error: response.error });
         return response.error;
-      }
-      // A mutation can commit and then fail building its overview: the
-      // rows on screen may no longer be the truth, so one reconciling
-      // read answers either way — success lands whatever actually
-      // committed, failure marks the retained rows stale under the
-      // operation's own error.
-      const reread = await settled<Overview>(commands.updatesOverview());
-      order.landAuthoritative();
-      if (reread.status === "ok") landOk(reread.data);
-      else set({ loaded: false, error: response.error });
-      return response.error;
-    });
-    // The chain outlives a link that throws; the error still reaches this
-    // operation's caller through `turn`.
-    chain = turn.catch(() => {});
-    return await turn;
+      });
+      // The chain outlives a link that throws; the error still reaches
+      // this operation's caller through `turn`.
+      chain = turn.catch(() => {});
+      return await turn;
+    } finally {
+      inFlight -= 1;
+      if (inFlight === 0) set({ overviewInFlight: false });
+    }
   };
 }

--- a/ui/src/stores/updates-overview.ts
+++ b/ui/src/stores/updates-overview.ts
@@ -30,19 +30,20 @@ export function overviewApplier(
   const order = landings();
   return async (
     read: Promise<OverviewResult>,
-    // A read that failed leaves the rows on screen unconfirmed; a mutation
-    // that failed re-read nothing, so the rows are still the last good
-    // read's answer — only reads may mark them stale. A mutation that
-    // SUCCEEDED always lands: its overview reports the state after its
-    // commit, which no read still in flight can be fresher than.
-    opts?: { mutation?: boolean },
+    // What produced this overview decides how it lands. A plain read ranks
+    // by when it began, success and failure alike. A refresh fetched every
+    // source before answering, and a mutation committed a change: their
+    // successful answers report a state no read still in flight can be
+    // fresher than, so both land authoritatively. On failure a refresh is
+    // just a read that could not answer — it marks the rows stale — while
+    // a failed mutation re-read nothing and touches nothing.
+    kind: "read" | "refresh" | "mutation" = "read",
   ): Promise<string | null> => {
     const ticket = order.begin();
     const response = await settled(read);
     if (response.status === "ok") {
-      const lands = opts?.mutation
-        ? order.landAuthoritative()
-        : order.land(ticket);
+      const lands =
+        kind === "read" ? order.land(ticket) : order.landAuthoritative();
       if (lands) {
         set({
           rows: response.data.rows,
@@ -53,7 +54,7 @@ export function overviewApplier(
       }
       return null;
     }
-    if (!opts?.mutation && order.land(ticket)) {
+    if (kind !== "mutation" && order.land(ticket)) {
       set({ loaded: false, error: response.error });
     }
     return response.error;

--- a/ui/src/stores/updates-overview.ts
+++ b/ui/src/stores/updates-overview.ts
@@ -1,0 +1,59 @@
+import type { ItemWarning, UpdateRow } from "@/bindings";
+import { settled } from "@/lib/settled";
+
+type OverviewResult =
+  | { status: "ok"; data: { rows: UpdateRow[]; warnings: ItemWarning[] } }
+  | { status: "error"; error: string };
+
+// The one place a read of the standing lands, however it went. A failure
+// — a returned refusal and a rejected call alike, via `settled` — marks
+// the data stale (loaded = false) and keeps why (error) rather than
+// leaving the last-good rows trusted: the package page gates the Update
+// button on `loaded`, and acting on rows we could not refresh is exactly
+// the fail-open this closes. Returns why the read failed, or null, so
+// callers make their own noise.
+//
+// Landings are ordered: the mount-time load, an explicit check, and a
+// mutation's returned overview can resolve in any order, and a slow
+// early read landing last would overwrite a fresher answer and stamp its
+// stale rows loaded and current. Each read takes a ticket when it
+// starts; a landing older than the last one written is discarded — its
+// return value still reports how the operation itself went.
+export function overviewApplier(
+  set: (partial: {
+    rows?: UpdateRow[];
+    warnings?: ItemWarning[];
+    loaded?: boolean;
+    error?: string | null;
+  }) => void,
+) {
+  let started = 0;
+  let written = 0;
+  return async (
+    read: Promise<OverviewResult>,
+    // A read that failed leaves the rows on screen unconfirmed; a mutation
+    // that failed re-read nothing, so the rows are still the last good
+    // read's answer — only reads may mark them stale.
+    opts?: { mutation?: boolean },
+  ): Promise<string | null> => {
+    const ticket = ++started;
+    const response = await settled(read);
+    if (response.status === "ok") {
+      if (ticket > written) {
+        written = ticket;
+        set({
+          rows: response.data.rows,
+          warnings: response.data.warnings,
+          loaded: true,
+          error: null,
+        });
+      }
+      return null;
+    }
+    if (!opts?.mutation && ticket > written) {
+      written = ticket;
+      set({ loaded: false, error: response.error });
+    }
+    return response.error;
+  };
+}

--- a/ui/src/stores/updates-toast.test.ts
+++ b/ui/src/stores/updates-toast.test.ts
@@ -78,7 +78,7 @@ const ready = (remaining: UpdateRow[]) => {
 
 describe("updates store: what the success toast claims", () => {
   beforeEach(() => {
-    useUpdatesStore.setState({ rows: [], busy: false, loaded: false });
+    useUpdatesStore.setState({ rows: [], busy: false, loaded: true });
     vi.clearAllMocks();
   });
 

--- a/ui/src/stores/updates.test.ts
+++ b/ui/src/stores/updates.test.ts
@@ -2,13 +2,13 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { UpdateRow } from "@/bindings";
 import { commands } from "@/bindings";
 import { ADOPTABLE } from "@/lib/adoptable";
-import { useProblemsStore } from "./problems";
 import {
   hiddenUpdates,
-  useUpdatesStore,
   visibleUpdateCount,
   visibleUpdates,
-} from "./updates";
+} from "@/lib/update-groups";
+import { useProblemsStore } from "./problems";
+import { useUpdatesStore } from "./updates";
 
 vi.mock("@/bindings", () => ({
   commands: {
@@ -326,6 +326,57 @@ describe("updates store", () => {
     expect(useUpdatesStore.getState().rows).toEqual(secondState);
   });
 
+  // An update's commit and its follow-up overview ride the same chain as
+  // every other side effect, so a slower mutation answered earlier cannot
+  // land its older rows on top of the update's fresh ones.
+  it("an update's overview is not shadowed by an older mutation's answer", async () => {
+    let resolveMute!: (
+      value: Awaited<ReturnType<typeof commands.updateSetIgnored>>,
+    ) => void;
+    vi.mocked(commands.updateSetIgnored).mockReturnValue(
+      new Promise((resolve) => {
+        resolveMute = resolve;
+      }),
+    );
+    const muting = useUpdatesStore.getState().setIgnored(row({}), true);
+
+    vi.mocked(commands.applyPlan).mockResolvedValue({
+      status: "ok",
+      data: {
+        scope: { scope: "global" },
+        drift: [],
+        plan: [],
+        notes: [],
+        warnings: [],
+        safety: [],
+        adoptable: ADOPTABLE,
+        exits: [],
+        heldBack: [],
+        queued: [],
+      },
+    });
+    const updated: UpdateRow[] = [];
+    vi.mocked(commands.updatesOverview).mockResolvedValue({
+      status: "ok",
+      data: { rows: updated, warnings: [] },
+    });
+    vi.mocked(commands.scanMachine).mockResolvedValue({
+      status: "ok",
+      data: { harnesses: [], items: [], missingProjects: [], warnings: [] },
+    });
+    vi.mocked(commands.auditAll).mockResolvedValue({ status: "ok", data: [] });
+    const updating = useUpdatesStore.getState().updateOne(row({}));
+
+    resolveMute({
+      status: "ok",
+      data: { rows: [row({ ignored: true })], warnings: [] },
+    });
+    await muting;
+    await updating;
+
+    expect(useUpdatesStore.getState().rows).toEqual(updated);
+  });
+
   // An explicit check that failed is an answer to report: a quicker plain
   // load landing in between must not bury it and leave stale rows marked
   // current.
@@ -351,9 +402,9 @@ describe("updates store", () => {
     expect(useUpdatesStore.getState().error).toBe("mirror down");
   });
 
-  // A refused mute re-read nothing: the rows on screen are still the last
-  // good read's answer, and marking them stale would disable Update
-  // buttons over a failure that had nothing to do with checking.
+  // A failed mute may still have committed before erroring, so the store
+  // re-reads rather than trusting either story: here the truth confirms
+  // the kept rows, and nothing is marked stale.
   it("a mute that fails leaves the last good read trusted", async () => {
     const kept = [row({})];
     useUpdatesStore.setState({ rows: kept, loaded: true, error: null });
@@ -364,6 +415,10 @@ describe("updates store", () => {
       status: "error",
       error: "manifest busy",
     });
+    vi.mocked(commands.updatesOverview).mockResolvedValue({
+      status: "ok",
+      data: { rows: kept, warnings: [] },
+    });
 
     await useUpdatesStore.getState().setIgnored(row({}), true);
 
@@ -373,6 +428,45 @@ describe("updates store", () => {
     // The refusal still reaches the person, through the error modal.
     expect(useProblemsStore.getState().dialog.open).toBe(true);
     expect(useProblemsStore.getState().dialog.message).toBe("manifest busy");
+  });
+
+  // The backend can persist the preference and then fail building its
+  // overview: the reconciling read lands what actually committed instead
+  // of leaving the old row marked current.
+  it("a mute that commits but errors re-reads the truth", async () => {
+    useUpdatesStore.setState({ rows: [row({})], loaded: true, error: null });
+    vi.mocked(commands.updateSetIgnored).mockResolvedValue({
+      status: "error",
+      error: "couldn't rebuild the overview",
+    });
+    const muted = [row({ ignored: true })];
+    vi.mocked(commands.updatesOverview).mockResolvedValue({
+      status: "ok",
+      data: { rows: muted, warnings: [] },
+    });
+
+    await useUpdatesStore.getState().setIgnored(row({}), true);
+
+    expect(useUpdatesStore.getState().rows).toEqual(muted);
+    expect(useUpdatesStore.getState().loaded).toBe(true);
+  });
+
+  it("marks the rows stale when the reconciling read also fails", async () => {
+    const kept = [row({})];
+    useUpdatesStore.setState({ rows: kept, loaded: true, error: null });
+    vi.mocked(commands.updateSetIgnored).mockResolvedValue({
+      status: "error",
+      error: "half done",
+    });
+    vi.mocked(commands.updatesOverview).mockRejectedValue(
+      new Error("ipc down"),
+    );
+
+    await useUpdatesStore.getState().setIgnored(row({}), true);
+
+    expect(useUpdatesStore.getState().rows).toEqual(kept);
+    expect(useUpdatesStore.getState().loaded).toBe(false);
+    expect(useUpdatesStore.getState().error).toBe("half done");
   });
 
   it("muting keeps the row, flagged — and unmuting brings it back", async () => {

--- a/ui/src/stores/updates.test.ts
+++ b/ui/src/stores/updates.test.ts
@@ -54,7 +54,12 @@ function row(overrides: Partial<UpdateRow>): UpdateRow {
 
 describe("updates store", () => {
   beforeEach(() => {
-    useUpdatesStore.setState({ rows: [], busy: false, loaded: false });
+    useUpdatesStore.setState({
+      rows: [],
+      busy: false,
+      loaded: false,
+      error: null,
+    });
     vi.clearAllMocks();
   });
 
@@ -84,6 +89,27 @@ describe("updates store", () => {
     expect(visibleUpdates(rows).map((r) => r.name)).toEqual(["gone", "split"]);
     expect(hiddenUpdates(rows).map((r) => r.name)).toEqual(["muted-gone"]);
     expect(visibleUpdateCount(rows)).toBe(2);
+  });
+
+  // A failed read used to leave only `loaded: false` behind —
+  // indistinguishable from a read still on its way, so Home and the badge
+  // had nothing to show for it.
+  it("keeps why a read failed, and a good read clears it", async () => {
+    vi.mocked(commands.updatesOverview).mockResolvedValue({
+      status: "error",
+      error: "no network",
+    });
+    await useUpdatesStore.getState().load();
+    expect(useUpdatesStore.getState().error).toBe("no network");
+    expect(useUpdatesStore.getState().loaded).toBe(false);
+
+    vi.mocked(commands.updatesOverview).mockResolvedValue({
+      status: "ok",
+      data: { rows: [], warnings: [] },
+    });
+    await useUpdatesStore.getState().load();
+    expect(useUpdatesStore.getState().error).toBeNull();
+    expect(useUpdatesStore.getState().loaded).toBe(true);
   });
 
   it("muting keeps the row, flagged — and unmuting brings it back", async () => {

--- a/ui/src/stores/updates.test.ts
+++ b/ui/src/stores/updates.test.ts
@@ -57,10 +57,12 @@ function row(overrides: Partial<UpdateRow>): UpdateRow {
 
 describe("updates store", () => {
   beforeEach(() => {
+    // Rows being acted on imply a read that answered; tests staging the
+    // opposite set loaded themselves.
     useUpdatesStore.setState({
       rows: [],
       busy: false,
-      loaded: false,
+      loaded: true,
       error: null,
     });
     vi.clearAllMocks();
@@ -328,10 +330,9 @@ describe("updates store", () => {
     expect(useUpdatesStore.getState().rows).toEqual(secondState);
   });
 
-  // An update's commit and its follow-up overview ride the same chain as
-  // every other side effect, so a slower mutation answered earlier cannot
-  // land its older rows on top of the update's fresh ones.
-  it("an update's overview is not shadowed by an older mutation's answer", async () => {
+  // A mutation still in flight counts too: its landing will replace these
+  // rows, so an update accepted now would run on captured arguments.
+  it("refuses an update while another mutation is in flight", async () => {
     let resolveMute!: (
       value: Awaited<ReturnType<typeof commands.updateSetIgnored>>,
     ) => void;
@@ -342,41 +343,51 @@ describe("updates store", () => {
     );
     const muting = useUpdatesStore.getState().setIgnored(row({}), true);
 
-    vi.mocked(commands.applyPlan).mockResolvedValue({
-      status: "ok",
-      data: {
-        scope: { scope: "global" },
-        drift: [],
-        plan: [],
-        notes: [],
-        warnings: [],
-        safety: [],
-        adoptable: ADOPTABLE,
-        exits: [],
-        heldBack: [],
-        queued: [],
-      },
+    useProblemsStore.setState({
+      dialog: { open: false, title: "", steps: [], actions: [] },
     });
-    const updated: UpdateRow[] = [];
-    vi.mocked(commands.updatesOverview).mockResolvedValue({
-      status: "ok",
-      data: { rows: updated, warnings: [] },
-    });
-    vi.mocked(commands.scanMachine).mockResolvedValue({
-      status: "ok",
-      data: { harnesses: [], items: [], missingProjects: [], warnings: [] },
-    });
-    vi.mocked(commands.auditAll).mockResolvedValue({ status: "ok", data: [] });
-    const updating = useUpdatesStore.getState().updateOne(row({}));
+    await useUpdatesStore.getState().updateOne(row({ pinned: true }));
 
-    resolveMute({
-      status: "ok",
-      data: { rows: [row({ ignored: true })], warnings: [] },
-    });
+    expect(commands.packageSetRev).not.toHaveBeenCalled();
+    expect(commands.applyPlan).not.toHaveBeenCalled();
+    expect(useProblemsStore.getState().dialog.message).toBe(
+      UPDATE_NEEDS_CHECK_NOTE,
+    );
+
+    const muted = [row({ ignored: true })];
+    resolveMute({ status: "ok", data: { rows: muted, warnings: [] } });
     await muting;
-    await updating;
+    expect(useUpdatesStore.getState().rows).toEqual(muted);
+  });
 
-    expect(useUpdatesStore.getState().rows).toEqual(updated);
+  // The same for a plain read: a focus-triggered load leaves loaded true
+  // and never sets checking, but its landing is about to replace the rows
+  // an update would capture its commit from.
+  it("refuses an update while a focus load is in flight", async () => {
+    let resolveLoad!: (
+      value: Awaited<ReturnType<typeof commands.updatesOverview>>,
+    ) => void;
+    vi.mocked(commands.updatesOverview).mockReturnValue(
+      new Promise((resolve) => {
+        resolveLoad = resolve;
+      }),
+    );
+    const loading = useUpdatesStore.getState().load();
+
+    useProblemsStore.setState({
+      dialog: { open: false, title: "", steps: [], actions: [] },
+    });
+    await useUpdatesStore.getState().updateOne(row({ pinned: true }));
+
+    expect(commands.packageSetRev).not.toHaveBeenCalled();
+    expect(commands.applyPlan).not.toHaveBeenCalled();
+    expect(useProblemsStore.getState().dialog.message).toBe(
+      UPDATE_NEEDS_CHECK_NOTE,
+    );
+
+    resolveLoad({ status: "ok", data: { rows: [], warnings: [] } });
+    await loading;
+    expect(commands.packageSetRev).not.toHaveBeenCalled();
   });
 
   // An explicit check that failed is an answer to report: a quicker plain

--- a/ui/src/stores/updates.test.ts
+++ b/ui/src/stores/updates.test.ts
@@ -2,6 +2,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { UpdateRow } from "@/bindings";
 import { commands } from "@/bindings";
 import { ADOPTABLE } from "@/lib/adoptable";
+import { useProblemsStore } from "./problems";
 import {
   hiddenUpdates,
   useUpdatesStore,
@@ -151,6 +152,110 @@ describe("updates store", () => {
     await useUpdatesStore.getState().check();
     expect(commands.updatesRefresh).not.toHaveBeenCalled();
     useUpdatesStore.setState({ checking: false });
+  });
+
+  // Reads land in any order: without ordering, a slow mount-time load
+  // landing last would overwrite a fresher answer and stamp its stale rows
+  // loaded and current.
+  it("discards a slow load that lands after a fresher check", async () => {
+    let resolveLoad!: (
+      value: Awaited<ReturnType<typeof commands.updatesOverview>>,
+    ) => void;
+    vi.mocked(commands.updatesOverview).mockReturnValue(
+      new Promise((resolve) => {
+        resolveLoad = resolve;
+      }),
+    );
+    const loading = useUpdatesStore.getState().load();
+
+    const fresh = [row({ name: "fresh" })];
+    vi.mocked(commands.updatesRefresh).mockResolvedValue({
+      status: "ok",
+      data: { rows: fresh, warnings: [] },
+    });
+    await useUpdatesStore.getState().check();
+
+    resolveLoad({
+      status: "ok",
+      data: { rows: [row({ name: "stale" })], warnings: [] },
+    });
+    await loading;
+
+    expect(useUpdatesStore.getState().rows).toEqual(fresh);
+    expect(useUpdatesStore.getState().loaded).toBe(true);
+  });
+
+  it("discards a slow failed load landing after a fresher answer", async () => {
+    let rejectLoad!: (reason: Error) => void;
+    vi.mocked(commands.updatesOverview).mockReturnValue(
+      new Promise((_, reject) => {
+        rejectLoad = reject;
+      }),
+    );
+    const loading = useUpdatesStore.getState().load();
+
+    vi.mocked(commands.updatesRefresh).mockResolvedValue({
+      status: "ok",
+      data: { rows: [row({})], warnings: [] },
+    });
+    await useUpdatesStore.getState().check();
+
+    rejectLoad(new Error("ipc down"));
+    await loading;
+
+    expect(useUpdatesStore.getState().loaded).toBe(true);
+    expect(useUpdatesStore.getState().error).toBeNull();
+  });
+
+  it("keeps a mutation's answer over a slower load's", async () => {
+    let resolveLoad!: (
+      value: Awaited<ReturnType<typeof commands.updatesOverview>>,
+    ) => void;
+    vi.mocked(commands.updatesOverview).mockReturnValue(
+      new Promise((resolve) => {
+        resolveLoad = resolve;
+      }),
+    );
+    const loading = useUpdatesStore.getState().load();
+
+    const muted = [row({ ignored: true })];
+    vi.mocked(commands.updateSetIgnored).mockResolvedValue({
+      status: "ok",
+      data: { rows: muted, warnings: [] },
+    });
+    await useUpdatesStore.getState().setIgnored(row({}), true);
+
+    resolveLoad({
+      status: "ok",
+      data: { rows: [row({})], warnings: [] },
+    });
+    await loading;
+
+    expect(useUpdatesStore.getState().rows).toEqual(muted);
+  });
+
+  // A refused mute re-read nothing: the rows on screen are still the last
+  // good read's answer, and marking them stale would disable Update
+  // buttons over a failure that had nothing to do with checking.
+  it("a mute that fails leaves the last good read trusted", async () => {
+    const kept = [row({})];
+    useUpdatesStore.setState({ rows: kept, loaded: true, error: null });
+    useProblemsStore.setState({
+      dialog: { open: false, title: "", steps: [], actions: [] },
+    });
+    vi.mocked(commands.updateSetIgnored).mockResolvedValue({
+      status: "error",
+      error: "manifest busy",
+    });
+
+    await useUpdatesStore.getState().setIgnored(row({}), true);
+
+    expect(useUpdatesStore.getState().rows).toEqual(kept);
+    expect(useUpdatesStore.getState().loaded).toBe(true);
+    expect(useUpdatesStore.getState().error).toBeNull();
+    // The refusal still reaches the person, through the error modal.
+    expect(useProblemsStore.getState().dialog.open).toBe(true);
+    expect(useProblemsStore.getState().dialog.message).toBe("manifest busy");
   });
 
   it("muting keeps the row, flagged — and unmuting brings it back", async () => {

--- a/ui/src/stores/updates.test.ts
+++ b/ui/src/stores/updates.test.ts
@@ -509,6 +509,53 @@ describe("updates store", () => {
     expect(commands.packageSetRev).not.toHaveBeenCalled();
   });
 
+  // An update that commits, fails its first overview read, and reconciles
+  // is a success: the rows land current, and reporting the dead first
+  // read as the update's failure would suppress the toast and skip the
+  // scan and audit refreshes over a change that landed.
+  it("an update whose first re-read fails but reconciles reports success", async () => {
+    useProblemsStore.setState({
+      dialog: { open: false, title: "", steps: [], actions: [] },
+    });
+    vi.mocked(commands.applyPlan).mockResolvedValue({
+      status: "ok",
+      data: {
+        scope: { scope: "global" },
+        drift: [],
+        plan: [],
+        notes: [],
+        warnings: [],
+        safety: [],
+        adoptable: ADOPTABLE,
+        exits: [],
+        heldBack: [],
+        queued: [],
+      },
+    });
+    const landed = [row({ updateAvailable: false })];
+    vi.mocked(commands.updatesOverview)
+      .mockRejectedValueOnce(new Error("overview wedged"))
+      .mockResolvedValueOnce({
+        status: "ok",
+        data: { rows: landed, warnings: [] },
+      });
+    vi.mocked(commands.scanMachine).mockResolvedValue({
+      status: "ok",
+      data: { harnesses: [], items: [], missingProjects: [], warnings: [] },
+    });
+    vi.mocked(commands.auditAll).mockResolvedValue({ status: "ok", data: [] });
+
+    await useUpdatesStore.getState().updateOne(row({}));
+
+    expect(useProblemsStore.getState().dialog.open).toBe(false);
+    expect(toast.success).toHaveBeenCalled();
+    expect(commands.scanMachine).toHaveBeenCalled();
+    expect(commands.auditAll).toHaveBeenCalled();
+    expect(useUpdatesStore.getState().rows).toEqual(landed);
+    expect(useUpdatesStore.getState().loaded).toBe(true);
+    expect(useUpdatesStore.getState().error).toBeNull();
+  });
+
   // The backend can persist the preference and then fail building its
   // overview: the reconciling read lands what actually committed instead
   // of leaving the old row marked current.

--- a/ui/src/stores/updates.test.ts
+++ b/ui/src/stores/updates.test.ts
@@ -234,6 +234,34 @@ describe("updates store", () => {
     expect(useUpdatesStore.getState().rows).toEqual(muted);
   });
 
+  // The symmetric interleaving: the mutation begins first, a read lands
+  // its pre-mutation snapshot in between, and the mutation's overview —
+  // the state after its commit — lands last. Ranking it by when it began
+  // would discard it and leave the screen contradicting the backend.
+  it("a mutation's answer survives a read that lands before it", async () => {
+    let resolveMutation!: (
+      value: Awaited<ReturnType<typeof commands.updateSetIgnored>>,
+    ) => void;
+    vi.mocked(commands.updateSetIgnored).mockReturnValue(
+      new Promise((resolve) => {
+        resolveMutation = resolve;
+      }),
+    );
+    const muting = useUpdatesStore.getState().setIgnored(row({}), true);
+
+    vi.mocked(commands.updatesOverview).mockResolvedValue({
+      status: "ok",
+      data: { rows: [row({})], warnings: [] },
+    });
+    await useUpdatesStore.getState().load();
+
+    const muted = [row({ ignored: true })];
+    resolveMutation({ status: "ok", data: { rows: muted, warnings: [] } });
+    await muting;
+
+    expect(useUpdatesStore.getState().rows).toEqual(muted);
+  });
+
   // A refused mute re-read nothing: the rows on screen are still the last
   // good read's answer, and marking them stale would disable Update
   // buttons over a failure that had nothing to do with checking.

--- a/ui/src/stores/updates.test.ts
+++ b/ui/src/stores/updates.test.ts
@@ -234,6 +234,34 @@ describe("updates store", () => {
     expect(useUpdatesStore.getState().rows).toEqual(muted);
   });
 
+  // A refresh fetches every source before answering, so its result is
+  // fresher than any plain read's however late that read began: a load
+  // started after a slow check reads the old mirrors, and landing first
+  // must not make its staler rows the answer.
+  it("a slow check's fresh answer survives a later-started load", async () => {
+    let resolveCheck!: (
+      value: Awaited<ReturnType<typeof commands.updatesRefresh>>,
+    ) => void;
+    vi.mocked(commands.updatesRefresh).mockReturnValue(
+      new Promise((resolve) => {
+        resolveCheck = resolve;
+      }),
+    );
+    const checking = useUpdatesStore.getState().check();
+
+    vi.mocked(commands.updatesOverview).mockResolvedValue({
+      status: "ok",
+      data: { rows: [row({ name: "stale" })], warnings: [] },
+    });
+    await useUpdatesStore.getState().load();
+
+    const fresh = [row({ name: "fresh" })];
+    resolveCheck({ status: "ok", data: { rows: fresh, warnings: [] } });
+    await checking;
+
+    expect(useUpdatesStore.getState().rows).toEqual(fresh);
+  });
+
   // The symmetric interleaving: the mutation begins first, a read lands
   // its pre-mutation snapshot in between, and the mutation's overview —
   // the state after its commit — lands last. Ranking it by when it began

--- a/ui/src/stores/updates.test.ts
+++ b/ui/src/stores/updates.test.ts
@@ -112,6 +112,47 @@ describe("updates store", () => {
     expect(useUpdatesStore.getState().loaded).toBe(true);
   });
 
+  // A rejected call used to escape the store entirely — no error recorded,
+  // the promise discarded by its callers — while a returned refusal landed.
+  it("lands a rejected read the same as a returned refusal", async () => {
+    const kept = [row({})];
+    useUpdatesStore.setState({ rows: kept, loaded: true });
+    vi.mocked(commands.updatesOverview).mockRejectedValue(
+      new Error("ipc down"),
+    );
+
+    await useUpdatesStore.getState().load();
+
+    expect(useUpdatesStore.getState().error).toBe("ipc down");
+    expect(useUpdatesStore.getState().loaded).toBe(false);
+    expect(useUpdatesStore.getState().rows).toEqual(kept);
+  });
+
+  // The explicit check goes through the same single read-application path:
+  // refusal and rejection both land as the store's one failure state.
+  it("records why a check failed, rejection included", async () => {
+    vi.mocked(commands.updatesRefresh).mockResolvedValue({
+      status: "error",
+      error: "mirror down",
+    });
+    await useUpdatesStore.getState().check();
+    expect(useUpdatesStore.getState().error).toBe("mirror down");
+    expect(useUpdatesStore.getState().loaded).toBe(false);
+    expect(useUpdatesStore.getState().checking).toBe(false);
+
+    vi.mocked(commands.updatesRefresh).mockRejectedValue(new Error("ipc"));
+    await useUpdatesStore.getState().check();
+    expect(useUpdatesStore.getState().error).toBe("ipc");
+    expect(useUpdatesStore.getState().checking).toBe(false);
+  });
+
+  it("ignores a check clicked while one is already running", async () => {
+    useUpdatesStore.setState({ checking: true });
+    await useUpdatesStore.getState().check();
+    expect(commands.updatesRefresh).not.toHaveBeenCalled();
+    useUpdatesStore.setState({ checking: false });
+  });
+
   it("muting keeps the row, flagged — and unmuting brings it back", async () => {
     const muted = [row({ ignored: true })];
     vi.mocked(commands.updateSetIgnored).mockResolvedValue({

--- a/ui/src/stores/updates.test.ts
+++ b/ui/src/stores/updates.test.ts
@@ -1,7 +1,9 @@
+import { toast } from "sonner";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { UpdateRow } from "@/bindings";
 import { commands } from "@/bindings";
 import { ADOPTABLE } from "@/lib/adoptable";
+import { UPDATE_NEEDS_CHECK_NOTE } from "@/lib/copy-updates";
 import {
   hiddenUpdates,
   visibleUpdateCount,
@@ -428,6 +430,72 @@ describe("updates store", () => {
     // The refusal still reaches the person, through the error modal.
     expect(useProblemsStore.getState().dialog.open).toBe(true);
     expect(useProblemsStore.getState().dialog.message).toBe("manifest busy");
+  });
+
+  // A transport failure rejects instead of returning an error result —
+  // only the applier sees it, and dropping its return left updateOne
+  // silent and setAutoUpdate mute about a switch that never happened.
+  it("surfaces an update whose transport failed instead of staying silent", async () => {
+    useProblemsStore.setState({
+      dialog: { open: false, title: "", steps: [], actions: [] },
+    });
+    vi.mocked(commands.applyPlan).mockRejectedValue(new Error("ipc down"));
+    vi.mocked(commands.updatesOverview).mockResolvedValue({
+      status: "ok",
+      data: { rows: [], warnings: [] },
+    });
+
+    await useUpdatesStore.getState().updateOne(row({}));
+
+    expect(useProblemsStore.getState().dialog.open).toBe(true);
+    expect(useProblemsStore.getState().dialog.message).toBe("ipc down");
+    expect(toast.success).not.toHaveBeenCalled();
+  });
+
+  it("surfaces a follow switch whose transport failed", async () => {
+    useProblemsStore.setState({
+      dialog: { open: false, title: "", steps: [], actions: [] },
+    });
+    vi.mocked(commands.packageSetRev).mockRejectedValue(new Error("ipc down"));
+    vi.mocked(commands.updatesOverview).mockResolvedValue({
+      status: "ok",
+      data: { rows: [], warnings: [] },
+    });
+
+    await useUpdatesStore.getState().setAutoUpdate(row({}), false);
+
+    expect(useProblemsStore.getState().dialog.open).toBe(true);
+    expect(useProblemsStore.getState().dialog.message).toBe("ipc down");
+  });
+
+  // A check in flight is about to replace the rows: an update accepted
+  // now would queue behind it on the chain and apply the latest captured
+  // before it — refused at the action boundary, not just on the buttons.
+  it("refuses an update clicked while a check is running", async () => {
+    let resolveCheck!: (
+      value: Awaited<ReturnType<typeof commands.updatesRefresh>>,
+    ) => void;
+    vi.mocked(commands.updatesRefresh).mockReturnValue(
+      new Promise((resolve) => {
+        resolveCheck = resolve;
+      }),
+    );
+    const checking = useUpdatesStore.getState().check();
+
+    useProblemsStore.setState({
+      dialog: { open: false, title: "", steps: [], actions: [] },
+    });
+    await useUpdatesStore.getState().updateOne(row({ pinned: true }));
+
+    expect(commands.packageSetRev).not.toHaveBeenCalled();
+    expect(commands.applyPlan).not.toHaveBeenCalled();
+    expect(useProblemsStore.getState().dialog.message).toBe(
+      UPDATE_NEEDS_CHECK_NOTE,
+    );
+
+    resolveCheck({ status: "ok", data: { rows: [], warnings: [] } });
+    await checking;
+    expect(commands.packageSetRev).not.toHaveBeenCalled();
   });
 
   // The backend can persist the preference and then fail building its

--- a/ui/src/stores/updates.test.ts
+++ b/ui/src/stores/updates.test.ts
@@ -290,6 +290,67 @@ describe("updates store", () => {
     expect(useUpdatesStore.getState().rows).toEqual(muted);
   });
 
+  // Side-effecting operations run one at a time: the second command is
+  // not sent until the first answer has landed, so a first response
+  // arriving late can never overwrite the second commit's newer state.
+  it("lands overlapping mutations in commit order", async () => {
+    let resolveFirst!: (
+      value: Awaited<ReturnType<typeof commands.updateSetIgnored>>,
+    ) => void;
+    const secondState = [row({})];
+    vi.mocked(commands.updateSetIgnored)
+      .mockReturnValueOnce(
+        new Promise((resolve) => {
+          resolveFirst = resolve;
+        }),
+      )
+      .mockResolvedValueOnce({
+        status: "ok",
+        data: { rows: secondState, warnings: [] },
+      });
+
+    const first = useUpdatesStore.getState().setIgnored(row({}), true);
+    const second = useUpdatesStore.getState().setIgnored(row({}), false);
+    await vi.waitFor(() =>
+      expect(commands.updateSetIgnored).toHaveBeenCalledTimes(1),
+    );
+
+    resolveFirst({
+      status: "ok",
+      data: { rows: [row({ ignored: true })], warnings: [] },
+    });
+    await first;
+    await second;
+
+    expect(commands.updateSetIgnored).toHaveBeenCalledTimes(2);
+    expect(useUpdatesStore.getState().rows).toEqual(secondState);
+  });
+
+  // An explicit check that failed is an answer to report: a quicker plain
+  // load landing in between must not bury it and leave stale rows marked
+  // current.
+  it("a slow check's failure still reports after a later-started load", async () => {
+    let rejectCheck!: (reason: Error) => void;
+    vi.mocked(commands.updatesRefresh).mockReturnValue(
+      new Promise((_, reject) => {
+        rejectCheck = reject;
+      }),
+    );
+    const checking = useUpdatesStore.getState().check();
+
+    vi.mocked(commands.updatesOverview).mockResolvedValue({
+      status: "ok",
+      data: { rows: [row({})], warnings: [] },
+    });
+    await useUpdatesStore.getState().load();
+
+    rejectCheck(new Error("mirror down"));
+    await checking;
+
+    expect(useUpdatesStore.getState().loaded).toBe(false);
+    expect(useUpdatesStore.getState().error).toBe("mirror down");
+  });
+
   // A refused mute re-read nothing: the rows on screen are still the last
   // good read's answer, and marking them stale would disable Update
   // buttons over a failure that had nothing to do with checking.

--- a/ui/src/stores/updates.ts
+++ b/ui/src/stores/updates.ts
@@ -8,39 +8,16 @@ import {
 } from "@/lib/copy-updates";
 import { scopeKey } from "@/lib/scope";
 import {
-  packageCount,
   placeName,
   skippedPlaces,
   updatablePlaces,
+  visibleUpdates,
 } from "@/lib/update-groups";
 import { bulkUpdateToast } from "@/lib/update-toasts";
 import { useAuditStore } from "./audit";
 import { useProblemsStore } from "./problems";
 import { useScanStore } from "./scan";
 import { overviewApplier } from "./updates-overview";
-
-/** A row worth a line on the page: a newer version, a package gone from
- *  its source, or installs disagreeing on their version — each a standing
- *  fact someone can act on. */
-const noteworthy = (row: UpdateRow): boolean =>
-  row.updateAvailable || row.removedUpstream || row.mixed;
-
-/** The sidebar badge's number: packages with news someone would want to
- *  hear, counted once however many places they are installed in. Ignored
- *  ones asked not to be counted; held ones still count — a hold is "not
- *  yet", not "never tell me". */
-export const visibleUpdateCount = (rows: UpdateRow[]): number =>
-  packageCount(visibleUpdates(rows));
-
-/** The Updates page's main list: everything noteworthy that has not been
- *  muted. */
-export const visibleUpdates = (rows: UpdateRow[]): UpdateRow[] =>
-  rows.filter((row) => noteworthy(row) && !row.ignored);
-
-/** The collapsed "hidden updates" section: muted packages whose news is
- *  still real — with the way back out. */
-export const hiddenUpdates = (rows: UpdateRow[]): UpdateRow[] =>
-  rows.filter((row) => noteworthy(row) && row.ignored);
 
 interface UpdatesState {
   rows: UpdateRow[];
@@ -57,6 +34,12 @@ interface UpdatesState {
   error: string | null;
   load: () => Promise<void>;
   check: () => Promise<void>;
+  /** Run backend-mutating work on the same chain as every other side
+   *  effect, landing a fresh overview after it — so operations land in
+   *  commit order and none of their answers can shadow a newer one.
+   *  Returns the work's own error, or null; the overview that follows
+   *  reflects whatever actually committed either way. */
+  mutate: (work: () => Promise<string | null>) => Promise<string | null>;
   updateOne: (row: UpdateRow) => Promise<void>;
   /** Bring every updatable place among `rows` current — the page-level
    *  button passes every visible row, a package's button its own places. */
@@ -107,6 +90,15 @@ export const useUpdatesStore = create<UpdatesState>((set, get) => {
       await reload();
     },
 
+    mutate: async (work) => {
+      let failure: string | null = null;
+      await applyOverview(async () => {
+        failure = await work();
+        return commands.updatesOverview();
+      }, "mutation");
+      return failure;
+    },
+
     check: async () => {
       // A check already running answers this click too; a second in flight
       // would land last-write-wins and could overwrite the fresh answer
@@ -127,7 +119,14 @@ export const useUpdatesStore = create<UpdatesState>((set, get) => {
     updateOne: async (row) => {
       set({ busy: true });
       try {
-        if (await apply(row)) {
+        // The commit and its follow-up overview ride the side-effect
+        // chain, so nothing older can land on top of them.
+        let applied = false;
+        await get().mutate(async () => {
+          applied = await apply(row);
+          return null;
+        });
+        if (applied) {
           // A follower comes current by applying its scope, which brings
           // that scope's other followers along — the toast says so rather
           // than letting the extra changes look like a surprise.
@@ -136,7 +135,6 @@ export const useUpdatesStore = create<UpdatesState>((set, get) => {
               ? updatedToastLabel(row.name)
               : updatedWithPlaceToastLabel(row.name, placeName(row.scope)),
           );
-          await reload();
           await useScanStore.getState().refresh();
           await useAuditStore.getState().refresh({ force: true });
         }
@@ -161,26 +159,30 @@ export const useUpdatesStore = create<UpdatesState>((set, get) => {
         }
         // Move every hold first — each move applies its whole scope, so
         // that scope's followers are already current — then one apply per
-        // scope no hold touched. Never two applies for one scope.
+        // scope no hold touched. Never two applies for one scope. The
+        // whole sequence and its follow-up overview ride the side-effect
+        // chain, so nothing older can land on top of them.
         let ok = true;
-        const applied = new Set<string>();
-        for (const row of rows.filter((row) => row.pinned)) {
-          if (await apply(row)) applied.add(scopeKey(row.scope));
-          else ok = false;
-        }
-        const scopes = new Map(
-          rows
-            .filter((row) => !row.pinned && !applied.has(scopeKey(row.scope)))
-            .map((row) => [scopeKey(row.scope), row] as const),
-        );
-        for (const row of scopes.values()) {
-          const response = await commands.applyPlan(row.scope, false, []);
-          if (response.status === "error") {
-            showError(UPDATE_ERROR_TITLE, response.error);
-            ok = false;
+        await get().mutate(async () => {
+          const applied = new Set<string>();
+          for (const row of rows.filter((row) => row.pinned)) {
+            if (await apply(row)) applied.add(scopeKey(row.scope));
+            else ok = false;
           }
-        }
-        await reload();
+          const scopes = new Map(
+            rows
+              .filter((row) => !row.pinned && !applied.has(scopeKey(row.scope)))
+              .map((row) => [scopeKey(row.scope), row] as const),
+          );
+          for (const row of scopes.values()) {
+            const response = await commands.applyPlan(row.scope, false, []);
+            if (response.status === "error") {
+              showError(UPDATE_ERROR_TITLE, response.error);
+              ok = false;
+            }
+          }
+          return null;
+        });
         if (ok)
           toast.success(
             bulkUpdateToast(rows, skipped, visibleUpdates(get().rows)),
@@ -200,16 +202,16 @@ export const useUpdatesStore = create<UpdatesState>((set, get) => {
       if (!auto && hold === null) return;
       set({ busy: true });
       try {
-        const response = await commands.packageSetRev(
-          row.scope,
-          row.kind,
-          row.name,
-          auto ? null : hold,
-        );
-        if (response.status === "error") {
-          showError(UPDATE_ERROR_TITLE, response.error);
-        }
-        await reload();
+        const error = await get().mutate(async () => {
+          const response = await commands.packageSetRev(
+            row.scope,
+            row.kind,
+            row.name,
+            auto ? null : hold,
+          );
+          return response.status === "error" ? response.error : null;
+        });
+        if (error !== null) showError(UPDATE_ERROR_TITLE, error);
       } finally {
         set({ busy: false });
       }

--- a/ui/src/stores/updates.ts
+++ b/ui/src/stores/updates.ts
@@ -114,7 +114,7 @@ export const useUpdatesStore = create<UpdatesState>((set, get) => {
       if (get().checking) return;
       set({ checking: true });
       try {
-        const error = await applyOverview(commands.updatesRefresh());
+        const error = await applyOverview(commands.updatesRefresh(), "refresh");
         if (error !== null) showError(UPDATE_ERROR_TITLE, error);
       } finally {
         set({ checking: false });
@@ -221,7 +221,7 @@ export const useUpdatesStore = create<UpdatesState>((set, get) => {
           row.repo,
           ignored,
         ),
-        { mutation: true },
+        "mutation",
       );
       if (error !== null) showError(UPDATE_ERROR_TITLE, error);
     },

--- a/ui/src/stores/updates.ts
+++ b/ui/src/stores/updates.ts
@@ -7,7 +7,6 @@ import {
   updatedWithPlaceToastLabel,
 } from "@/lib/copy-updates";
 import { scopeKey } from "@/lib/scope";
-import { settled } from "@/lib/settled";
 import {
   packageCount,
   placeName,
@@ -18,6 +17,7 @@ import { bulkUpdateToast } from "@/lib/update-toasts";
 import { useAuditStore } from "./audit";
 import { useProblemsStore } from "./problems";
 import { useScanStore } from "./scan";
+import { overviewApplier } from "./updates-overview";
 
 /** A row worth a line on the page: a newer version, a package gone from
  *  its source, or installs disagreeing on their version — each a standing
@@ -89,29 +89,7 @@ export const useUpdatesStore = create<UpdatesState>((set, get) => {
     return true;
   };
 
-  // The one place a read of the standing lands, however it went. A failure
-  // — a returned refusal and a rejected call alike, via `settled` — marks
-  // the data stale (loaded = false) and keeps why (error) rather than
-  // leaving the last-good rows trusted: the package page gates the Update
-  // button on `loaded`, and acting on rows we could not refresh is exactly
-  // the fail-open this closes. Returns why the read failed, or null, so
-  // callers make their own noise.
-  const applyOverview = async (
-    read: ReturnType<typeof commands.updatesOverview>,
-  ): Promise<string | null> => {
-    const response = await settled(read);
-    if (response.status === "ok") {
-      set({
-        rows: response.data.rows,
-        warnings: response.data.warnings,
-        loaded: true,
-        error: null,
-      });
-      return null;
-    }
-    set({ loaded: false, error: response.error });
-    return response.error;
-  };
+  const applyOverview = overviewApplier(set);
 
   const reload = async () => {
     await applyOverview(commands.updatesOverview());
@@ -243,6 +221,7 @@ export const useUpdatesStore = create<UpdatesState>((set, get) => {
           row.repo,
           ignored,
         ),
+        { mutation: true },
       );
       if (error !== null) showError(UPDATE_ERROR_TITLE, error);
     },

--- a/ui/src/stores/updates.ts
+++ b/ui/src/stores/updates.ts
@@ -28,6 +28,10 @@ interface UpdatesState {
   busy: boolean;
   /** True while a mirror fetch is running — the explicit "check". */
   checking: boolean;
+  /** True while ANY overview-producing operation — a plain load, a check,
+   *  a mutation — is in flight: the rows on screen are about to be
+   *  replaced, so no commit-applying action may trust them. */
+  overviewInFlight: boolean;
   loaded: boolean;
   /** Why the last read of the standing failed, or null. A load runs on its
    *  own at startup, so a failure here is a state for Home and the badge to
@@ -57,6 +61,19 @@ export const useUpdatesStore = create<UpdatesState>((set, get) => {
 
   const applyOverview = overviewApplier(set);
 
+  // One predicate for every commit-applying action: the captured row
+  // arguments are trustworthy only when the rows are a confirmed current
+  // answer and nothing that could replace them is in flight — a failed
+  // read, a running check, and a focus-triggered load are all the same
+  // reason to wait. Returns whether the action was refused, reporting it.
+  const refuseUnsettled = (): boolean => {
+    const state = get();
+    if (state.loaded && !state.checking && !state.overviewInFlight)
+      return false;
+    showError(UPDATE_ERROR_TITLE, UPDATE_NEEDS_CHECK_NOTE);
+    return true;
+  };
+
   const reload = async () => {
     await applyOverview(() => commands.updatesOverview());
   };
@@ -66,6 +83,7 @@ export const useUpdatesStore = create<UpdatesState>((set, get) => {
     warnings: [],
     busy: false,
     checking: false,
+    overviewInFlight: false,
     loaded: false,
     error: null,
 
@@ -103,13 +121,11 @@ export const useUpdatesStore = create<UpdatesState>((set, get) => {
     },
 
     updateOne: async (row) => {
-      // A check in flight is about to replace these rows: an update
-      // queued now would apply the latest captured before it — refuse
-      // rather than commit stale arguments after fresher rows land.
-      if (get().checking) {
-        showError(UPDATE_ERROR_TITLE, UPDATE_NEEDS_CHECK_NOTE);
-        return;
-      }
+      // Anything overview-producing in flight is about to replace these
+      // rows: an update accepted now would apply the latest captured
+      // before it — refuse rather than commit stale arguments after
+      // fresher rows land.
+      if (refuseUnsettled()) return;
       set({ busy: true });
       try {
         // The commit and its follow-up overview ride the side-effect
@@ -139,12 +155,9 @@ export const useUpdatesStore = create<UpdatesState>((set, get) => {
     },
 
     updateRows: async (wanted) => {
-      // Same mid-check refusal as updateOne: these rows are about to be
-      // replaced, and the holds among them would move to captured commits.
-      if (get().checking) {
-        showError(UPDATE_ERROR_TITLE, UPDATE_NEEDS_CHECK_NOTE);
-        return;
-      }
+      // Same refusal as updateOne: the holds among these rows would move
+      // to captured commits.
+      if (refuseUnsettled()) return;
       set({ busy: true });
       try {
         // Edited packages are held by the engine and cannot be updated
@@ -188,12 +201,9 @@ export const useUpdatesStore = create<UpdatesState>((set, get) => {
       // never fall through to null, which means "follow" (the opposite).
       const hold = row.current?.commit ?? null;
       if (!auto && hold === null) return;
-      // Mid-check refusal: the hold would pin a commit captured from rows
-      // a running check is about to replace.
-      if (get().checking) {
-        showError(UPDATE_ERROR_TITLE, UPDATE_NEEDS_CHECK_NOTE);
-        return;
-      }
+      // Same refusal as updateOne: the hold would pin a commit captured
+      // from rows an in-flight read is about to replace.
+      if (refuseUnsettled()) return;
       set({ busy: true });
       try {
         const error = await get().mutate(async () => {

--- a/ui/src/stores/updates.ts
+++ b/ui/src/stores/updates.ts
@@ -4,9 +4,9 @@ import { commands, type ItemWarning, type UpdateRow } from "@/bindings";
 import { UPDATE_ERROR_TITLE, updatedToastLabel } from "@/lib/copy";
 import {
   nothingToUpdateToastLabel,
+  UPDATE_NEEDS_CHECK_NOTE,
   updatedWithPlaceToastLabel,
 } from "@/lib/copy-updates";
-import { scopeKey } from "@/lib/scope";
 import {
   placeName,
   skippedPlaces,
@@ -17,6 +17,7 @@ import { bulkUpdateToast } from "@/lib/update-toasts";
 import { useAuditStore } from "./audit";
 import { useProblemsStore } from "./problems";
 import { useScanStore } from "./scan";
+import { applyRow, applyRows } from "./updates-apply";
 import { overviewApplier } from "./updates-overview";
 
 interface UpdatesState {
@@ -52,25 +53,7 @@ export const useUpdatesStore = create<UpdatesState>((set, get) => {
   const showError = (title: string, message: string) =>
     useProblemsStore.getState().showError({ title, message });
 
-  const apply = async (row: UpdateRow): Promise<boolean> => {
-    // Held packages move by moving the hold; following ones come current
-    // by applying the scope — which is what following means, and brings
-    // any other pending changes in that scope along.
-    const response =
-      row.pinned && row.latest
-        ? await commands.packageSetRev(
-            row.scope,
-            row.kind,
-            row.name,
-            row.latest.commit,
-          )
-        : await commands.applyPlan(row.scope, false, []);
-    if (response.status === "error") {
-      showError(UPDATE_ERROR_TITLE, response.error);
-      return false;
-    }
-    return true;
-  };
+  const reportUpdate = (error: string) => showError(UPDATE_ERROR_TITLE, error);
 
   const applyOverview = overviewApplier(set);
 
@@ -91,12 +74,15 @@ export const useUpdatesStore = create<UpdatesState>((set, get) => {
     },
 
     mutate: async (work) => {
+      // The applier's own error matters too: work() rejecting in transport
+      // never assigns failure, and only the applier saw the rejection —
+      // dropping it would let callers toast success over an IPC failure.
       let failure: string | null = null;
-      await applyOverview(async () => {
+      const applierError = await applyOverview(async () => {
         failure = await work();
         return commands.updatesOverview();
       }, "mutation");
-      return failure;
+      return failure ?? applierError;
     },
 
     check: async () => {
@@ -117,16 +103,25 @@ export const useUpdatesStore = create<UpdatesState>((set, get) => {
     },
 
     updateOne: async (row) => {
+      // A check in flight is about to replace these rows: an update
+      // queued now would apply the latest captured before it — refuse
+      // rather than commit stale arguments after fresher rows land.
+      if (get().checking) {
+        showError(UPDATE_ERROR_TITLE, UPDATE_NEEDS_CHECK_NOTE);
+        return;
+      }
       set({ busy: true });
       try {
         // The commit and its follow-up overview ride the side-effect
         // chain, so nothing older can land on top of them.
         let applied = false;
-        await get().mutate(async () => {
-          applied = await apply(row);
+        const error = await get().mutate(async () => {
+          applied = await applyRow(row, reportUpdate);
           return null;
         });
-        if (applied) {
+        if (error !== null) {
+          showError(UPDATE_ERROR_TITLE, error);
+        } else if (applied) {
           // A follower comes current by applying its scope, which brings
           // that scope's other followers along — the toast says so rather
           // than letting the extra changes look like a surprise.
@@ -144,6 +139,12 @@ export const useUpdatesStore = create<UpdatesState>((set, get) => {
     },
 
     updateRows: async (wanted) => {
+      // Same mid-check refusal as updateOne: these rows are about to be
+      // replaced, and the holds among them would move to captured commits.
+      if (get().checking) {
+        showError(UPDATE_ERROR_TITLE, UPDATE_NEEDS_CHECK_NOTE);
+        return;
+      }
       set({ busy: true });
       try {
         // Edited packages are held by the engine and cannot be updated
@@ -157,32 +158,19 @@ export const useUpdatesStore = create<UpdatesState>((set, get) => {
           toast.info(nothingToUpdateToastLabel(skipped));
           return;
         }
-        // Move every hold first — each move applies its whole scope, so
-        // that scope's followers are already current — then one apply per
-        // scope no hold touched. Never two applies for one scope. The
-        // whole sequence and its follow-up overview ride the side-effect
-        // chain, so nothing older can land on top of them.
+        // The whole sequence and its follow-up overview ride the
+        // side-effect chain, so nothing older can land on top of them.
         let ok = true;
-        await get().mutate(async () => {
-          const applied = new Set<string>();
-          for (const row of rows.filter((row) => row.pinned)) {
-            if (await apply(row)) applied.add(scopeKey(row.scope));
-            else ok = false;
-          }
-          const scopes = new Map(
-            rows
-              .filter((row) => !row.pinned && !applied.has(scopeKey(row.scope)))
-              .map((row) => [scopeKey(row.scope), row] as const),
-          );
-          for (const row of scopes.values()) {
-            const response = await commands.applyPlan(row.scope, false, []);
-            if (response.status === "error") {
-              showError(UPDATE_ERROR_TITLE, response.error);
-              ok = false;
-            }
-          }
+        const error = await get().mutate(async () => {
+          ok = await applyRows(rows, reportUpdate);
           return null;
         });
+        // A rejection escapes the sequence without touching ok — only the
+        // applier saw it, and success must not be claimed over it.
+        if (error !== null) {
+          showError(UPDATE_ERROR_TITLE, error);
+          ok = false;
+        }
         if (ok)
           toast.success(
             bulkUpdateToast(rows, skipped, visibleUpdates(get().rows)),
@@ -200,6 +188,12 @@ export const useUpdatesStore = create<UpdatesState>((set, get) => {
       // never fall through to null, which means "follow" (the opposite).
       const hold = row.current?.commit ?? null;
       if (!auto && hold === null) return;
+      // Mid-check refusal: the hold would pin a commit captured from rows
+      // a running check is about to replace.
+      if (get().checking) {
+        showError(UPDATE_ERROR_TITLE, UPDATE_NEEDS_CHECK_NOTE);
+        return;
+      }
       set({ busy: true });
       try {
         const error = await get().mutate(async () => {

--- a/ui/src/stores/updates.ts
+++ b/ui/src/stores/updates.ts
@@ -7,6 +7,7 @@ import {
   updatedWithPlaceToastLabel,
 } from "@/lib/copy-updates";
 import { scopeKey } from "@/lib/scope";
+import { settled } from "@/lib/settled";
 import {
   packageCount,
   placeName,
@@ -88,20 +89,32 @@ export const useUpdatesStore = create<UpdatesState>((set, get) => {
     return true;
   };
 
-  const reload = async () => {
-    const response = await commands.updatesOverview();
-    // A failed reload marks the data stale (loaded = false) rather than
-    // leaving the last-good rows trusted — the package page gates the
-    // Update button on `loaded`, and acting on rows we could not refresh
-    // is exactly the fail-open this closes.
-    if (response.status === "ok")
+  // The one place a read of the standing lands, however it went. A failure
+  // — a returned refusal and a rejected call alike, via `settled` — marks
+  // the data stale (loaded = false) and keeps why (error) rather than
+  // leaving the last-good rows trusted: the package page gates the Update
+  // button on `loaded`, and acting on rows we could not refresh is exactly
+  // the fail-open this closes. Returns why the read failed, or null, so
+  // callers make their own noise.
+  const applyOverview = async (
+    read: ReturnType<typeof commands.updatesOverview>,
+  ): Promise<string | null> => {
+    const response = await settled(read);
+    if (response.status === "ok") {
       set({
         rows: response.data.rows,
         warnings: response.data.warnings,
         loaded: true,
         error: null,
       });
-    else set({ loaded: false, error: response.error });
+      return null;
+    }
+    set({ loaded: false, error: response.error });
+    return response.error;
+  };
+
+  const reload = async () => {
+    await applyOverview(commands.updatesOverview());
   };
 
   return {
@@ -117,20 +130,14 @@ export const useUpdatesStore = create<UpdatesState>((set, get) => {
     },
 
     check: async () => {
+      // A check already running answers this click too; a second in flight
+      // would land last-write-wins and could overwrite the fresh answer
+      // with a staler one.
+      if (get().checking) return;
       set({ checking: true });
       try {
-        const response = await commands.updatesRefresh();
-        if (response.status === "ok") {
-          set({
-            rows: response.data.rows,
-            warnings: response.data.warnings,
-            loaded: true,
-            error: null,
-          });
-        } else {
-          set({ loaded: false, error: response.error });
-          showError(UPDATE_ERROR_TITLE, response.error);
-        }
+        const error = await applyOverview(commands.updatesRefresh());
+        if (error !== null) showError(UPDATE_ERROR_TITLE, error);
       } finally {
         set({ checking: false });
       }
@@ -228,21 +235,16 @@ export const useUpdatesStore = create<UpdatesState>((set, get) => {
     },
 
     setIgnored: async (row, ignored) => {
-      const response = await commands.updateSetIgnored(
-        row.scope,
-        row.kind,
-        row.name,
-        row.repo,
-        ignored,
+      const error = await applyOverview(
+        commands.updateSetIgnored(
+          row.scope,
+          row.kind,
+          row.name,
+          row.repo,
+          ignored,
+        ),
       );
-      if (response.status === "ok")
-        set({
-          rows: response.data.rows,
-          warnings: response.data.warnings,
-          loaded: true,
-          error: null,
-        });
-      else showError(UPDATE_ERROR_TITLE, response.error);
+      if (error !== null) showError(UPDATE_ERROR_TITLE, error);
     },
   };
 });

--- a/ui/src/stores/updates.ts
+++ b/ui/src/stores/updates.ts
@@ -50,6 +50,10 @@ interface UpdatesState {
   /** True while a mirror fetch is running — the explicit "check". */
   checking: boolean;
   loaded: boolean;
+  /** Why the last read of the standing failed, or null. A load runs on its
+   *  own at startup, so a failure here is a state for Home and the badge to
+   *  show — silence would read as "nothing to update". */
+  error: string | null;
   load: () => Promise<void>;
   check: () => Promise<void>;
   updateOne: (row: UpdateRow) => Promise<void>;
@@ -95,8 +99,9 @@ export const useUpdatesStore = create<UpdatesState>((set, get) => {
         rows: response.data.rows,
         warnings: response.data.warnings,
         loaded: true,
+        error: null,
       });
-    else set({ loaded: false });
+    else set({ loaded: false, error: response.error });
   };
 
   return {
@@ -105,6 +110,7 @@ export const useUpdatesStore = create<UpdatesState>((set, get) => {
     busy: false,
     checking: false,
     loaded: false,
+    error: null,
 
     load: async () => {
       await reload();
@@ -119,9 +125,10 @@ export const useUpdatesStore = create<UpdatesState>((set, get) => {
             rows: response.data.rows,
             warnings: response.data.warnings,
             loaded: true,
+            error: null,
           });
         } else {
-          set({ loaded: false });
+          set({ loaded: false, error: response.error });
           showError(UPDATE_ERROR_TITLE, response.error);
         }
       } finally {
@@ -233,6 +240,7 @@ export const useUpdatesStore = create<UpdatesState>((set, get) => {
           rows: response.data.rows,
           warnings: response.data.warnings,
           loaded: true,
+          error: null,
         });
       else showError(UPDATE_ERROR_TITLE, response.error);
     },

--- a/ui/src/stores/updates.ts
+++ b/ui/src/stores/updates.ts
@@ -92,15 +92,22 @@ export const useUpdatesStore = create<UpdatesState>((set, get) => {
     },
 
     mutate: async (work) => {
-      // The applier's own error matters too: work() rejecting in transport
-      // never assigns failure, and only the applier saw the rejection —
-      // dropping it would let callers toast success over an IPC failure.
+      // The work's failure and the applier's are different news. work()
+      // rejecting in transport never assigns failure and only the applier
+      // saw it — but once work has answered, the applier's error is the
+      // follow-up read's, already told through the store (stale marking,
+      // or cleared by a landed reconcile), and returning it would report
+      // a committed change as failed — suppressing the caller's success
+      // toast and its scan/audit refreshes.
       let failure: string | null = null;
+      let answered = false;
       const applierError = await applyOverview(async () => {
         failure = await work();
+        answered = true;
         return commands.updatesOverview();
       }, "mutation");
-      return failure ?? applierError;
+      if (failure !== null) return failure;
+      return answered ? null : applierError;
     },
 
     check: async () => {

--- a/ui/src/stores/updates.ts
+++ b/ui/src/stores/updates.ts
@@ -92,7 +92,7 @@ export const useUpdatesStore = create<UpdatesState>((set, get) => {
   const applyOverview = overviewApplier(set);
 
   const reload = async () => {
-    await applyOverview(commands.updatesOverview());
+    await applyOverview(() => commands.updatesOverview());
   };
 
   return {
@@ -114,7 +114,10 @@ export const useUpdatesStore = create<UpdatesState>((set, get) => {
       if (get().checking) return;
       set({ checking: true });
       try {
-        const error = await applyOverview(commands.updatesRefresh(), "refresh");
+        const error = await applyOverview(
+          () => commands.updatesRefresh(),
+          "refresh",
+        );
         if (error !== null) showError(UPDATE_ERROR_TITLE, error);
       } finally {
         set({ checking: false });
@@ -214,13 +217,14 @@ export const useUpdatesStore = create<UpdatesState>((set, get) => {
 
     setIgnored: async (row, ignored) => {
       const error = await applyOverview(
-        commands.updateSetIgnored(
-          row.scope,
-          row.kind,
-          row.name,
-          row.repo,
-          ignored,
-        ),
+        () =>
+          commands.updateSetIgnored(
+            row.scope,
+            row.kind,
+            row.name,
+            row.repo,
+            ignored,
+          ),
         "mutation",
       );
       if (error !== null) showError(UPDATE_ERROR_TITLE, error);


### PR DESCRIPTION
## Summary
- Home answers a failed scan instead of skeleton-loading forever, and a stale scan can no longer pose as current: every read store lands transport rejections through a shared `settled()` helper (`error !== null` semantics, empty failure messages backfilled), and each failure mode renders as a visible state with a reachable retry.
- The updates surface stops contradicting itself: rows a failed check left behind head as unconfirmed, the three Update actions (page header, per-package, per-place) gate on `loaded` like the package page, the failure path always carries the retry, and a mute/unmute refusal leaves rows, `loaded`, and `error` untouched.
- Overview landings are ordered: `updates-overview.ts` stamps each read with a ticket taken at start and discards stale landings, so a slow mount-time `load()` can no longer revert a fresher check or a just-applied ignore.
- The Home audit attention row reads a dedicated `checkError` written only by `refresh()` — a failed remove/adopt/toggle no longer plants a persistent "Couldn't check installed content" row.

## Completed Issues
- Closes KEN-508 - Home shows loading skeletons forever when the first scan fails, and draws a stale scan as current when a later one does

## Test Plan
- 477/477 vitest tests green across 82 files; 13 of the new tests fail against the pre-fix code (10 store/lib/page behavioral, 3 UI gating); 14 directed mutants killed (loaded gates, retry predicate both directions, ticket ordering, mutation flag, empty-message backfill, overview truthiness sites, checkError store writes)
- guard green at each commit: cargo tests, tsc, biome; preflight clean over the 28-file diff
- Two full review cycles plus a focused verification pass (correctness, error handling, tests, external) and a QA correctness trace — zero open blockers
