### PR TITLE
fix(ui): Home's Installed count agrees with the Library (KEN-499)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -299,6 +299,11 @@ changes carry a **Breaking** call-out with their migration note inline.
   the lock alive past its owner. The lock now releases explicitly the
   instant an apply finishes. The source cache's download lock had the
   same flaw and got the same fix.
+- Home's Installed tile now counts what the Library counts: packages, not
+  copies. A package applied to two harnesses used to count twice on the
+  tile and once in the Library table it opens, so the click landed on a
+  smaller total with nothing explaining the gap. Both numbers now come from
+  the same count.
 - Home no longer shows its loading skeletons forever when the first scan of
   the machine fails: the page says the scan failed, shows why, and offers
   Scan again. When a later scan fails, Home still draws what it had, headed

--- a/ui/src/components/library/installed-view.tsx
+++ b/ui/src/components/library/installed-view.tsx
@@ -121,7 +121,7 @@ export function InstalledView() {
   // Home's Installed tile so the two can never disagree.
   const standingsFor = useLibraryStandings(groups);
   const total = useMemo(
-    () => (result ? installedCount(result.items) : 0),
+    () => (result ? installedCount(groupItems(result.items)) : 0),
     [result],
   );
   // The filter's vocabulary is what the join actually says, so a value

--- a/ui/src/components/library/installed-view.tsx
+++ b/ui/src/components/library/installed-view.tsx
@@ -22,6 +22,7 @@ import {
   filterItems,
   groupItems,
   groupScopes,
+  installedCount,
   scopeChoices,
 } from "@/lib/derive";
 import { PAGE_GUTTER, WIDE_CONTENT_WIDTH } from "@/lib/layout";
@@ -116,10 +117,11 @@ export function InstalledView() {
   }, [result, scope, kind, harness, tag, from, search, provenance]);
 
   // The count the filtered total is measured against: every row the table
-  // could show, not the ones left after the current narrowing.
+  // could show, not the ones left after the current narrowing. Shared with
+  // Home's Installed tile so the two can never disagree.
   const standingsFor = useLibraryStandings(groups);
   const total = useMemo(
-    () => (result ? groupItems(result.items).length : 0),
+    () => (result ? installedCount(result.items) : 0),
     [result],
   );
   // The filter's vocabulary is what the join actually says, so a value

--- a/ui/src/lib/derive.test.ts
+++ b/ui/src/lib/derive.test.ts
@@ -8,6 +8,7 @@ import {
   groupScopes,
   groupVendor,
   installationAt,
+  installedCount,
   recentItems,
   scopeMatches,
 } from "./derive";
@@ -116,6 +117,22 @@ describe("groupItems", () => {
 
     const withoutTimes = groupItems([item({ name: "solo" })]);
     expect(withoutTimes.find((g) => g.name === "solo")?.modifiedAt).toBeNull();
+  });
+});
+
+describe("installedCount", () => {
+  it("counts packages, not installations", () => {
+    expect(
+      installedCount([
+        item({ harness: "claude" }),
+        item({ harness: "codex" }),
+        item({ name: "solo" }),
+      ]),
+    ).toBe(2);
+  });
+
+  it("keeps same-named items of different kinds apart", () => {
+    expect(installedCount([item({}), item({ kind: "agent" })])).toBe(2);
   });
 });
 

--- a/ui/src/lib/derive.test.ts
+++ b/ui/src/lib/derive.test.ts
@@ -123,16 +123,20 @@ describe("groupItems", () => {
 describe("installedCount", () => {
   it("counts packages, not installations", () => {
     expect(
-      installedCount([
-        item({ harness: "claude" }),
-        item({ harness: "codex" }),
-        item({ name: "solo" }),
-      ]),
+      installedCount(
+        groupItems([
+          item({ harness: "claude" }),
+          item({ harness: "codex" }),
+          item({ name: "solo" }),
+        ]),
+      ),
     ).toBe(2);
   });
 
   it("keeps same-named items of different kinds apart", () => {
-    expect(installedCount([item({}), item({ kind: "agent" })])).toBe(2);
+    expect(
+      installedCount(groupItems([item({}), item({ kind: "agent" })])),
+    ).toBe(2);
   });
 });
 

--- a/ui/src/lib/derive.ts
+++ b/ui/src/lib/derive.ts
@@ -118,12 +118,14 @@ export function groupItems(items: ObservedItem[]): ItemGroup[] {
   return [...groups.values()].sort((a, b) => a.key.localeCompare(b.key));
 }
 
-/** How many packages are installed — one per kind+name group, the unit the
- *  Library shows a row per. Home's Installed tile and the Library's total
- *  both count with this, so the tile can never disagree with the table it
- *  opens: a package applied to two harnesses is one package, not two. */
-export function installedCount(items: ObservedItem[]): number {
-  return groupItems(items).length;
+/** How many packages a grouped scan holds — one per kind+name group, the
+ *  unit the Library shows a row per. Home's Installed tile and the
+ *  Library's total both count through this, so the tile can never disagree
+ *  with the table it opens: a package applied to two harnesses is one
+ *  package, not two. Takes the groups a caller already has, so counting
+ *  never costs a second grouping pass. */
+export function installedCount(groups: ItemGroup[]): number {
+  return groups.length;
 }
 
 /** The installation belonging to one place, where the group has one.

--- a/ui/src/lib/derive.ts
+++ b/ui/src/lib/derive.ts
@@ -118,6 +118,14 @@ export function groupItems(items: ObservedItem[]): ItemGroup[] {
   return [...groups.values()].sort((a, b) => a.key.localeCompare(b.key));
 }
 
+/** How many packages are installed — one per kind+name group, the unit the
+ *  Library shows a row per. Home's Installed tile and the Library's total
+ *  both count with this, so the tile can never disagree with the table it
+ *  opens: a package applied to two harnesses is one package, not two. */
+export function installedCount(items: ObservedItem[]): number {
+  return groupItems(items).length;
+}
+
 /** The installation belonging to one place, where the group has one.
  *
  *  A package can be installed in several places and a page names one of

--- a/ui/src/pages/overview.test.tsx
+++ b/ui/src/pages/overview.test.tsx
@@ -1,6 +1,6 @@
 import { renderToStaticMarkup } from "react-dom/server";
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import type { ScanResult } from "@/bindings";
+import type { ObservedItem, ScanResult } from "@/bindings";
 import {
   AUDIT_ATTENTION_TITLE,
   SCAN_AGAIN_LABEL,
@@ -82,6 +82,22 @@ const scanned: ScanResult = {
   missingProjects: [],
   warnings: [],
 };
+
+const installed = (overrides: Partial<ObservedItem>): ObservedItem => ({
+  kind: "skill",
+  name: "deploy",
+  harness: "claude",
+  scope: { scope: "global" },
+  path: "/h/.claude/skills/deploy",
+  fileState: { state: "dir" },
+  enabled: true,
+  origin: null,
+  description: null,
+  tags: [],
+  modifiedAt: null,
+  vendor: null,
+  ...overrides,
+});
 
 beforeEach(() => {
   stub.scan = { result: null, error: null, scanning: false };
@@ -227,6 +243,28 @@ describe("Home when the audit fails", () => {
     expect(renderToStaticMarkup(<OverviewPage />)).not.toContain(
       esc(AUDIT_ATTENTION_TITLE),
     );
+  });
+});
+
+// The tile opens the Library, whose table shows one row per package however
+// many harnesses carry it; counting installations here made the tile's
+// number exceed the total on the page it lands on.
+describe("the Installed tile", () => {
+  it("counts packages the way the Library it opens does, not installations", () => {
+    stub.scan = {
+      result: {
+        ...scanned,
+        items: [
+          installed({ harness: "claude" }),
+          installed({ harness: "codex" }),
+        ],
+      },
+      error: null,
+      scanning: false,
+    };
+    const html = renderToStaticMarkup(<OverviewPage />);
+    expect(html).toContain(">1<");
+    expect(html).not.toContain(">2<");
   });
 });
 

--- a/ui/src/pages/overview.tsx
+++ b/ui/src/pages/overview.tsx
@@ -1,4 +1,4 @@
-import { useEffect } from "react";
+import { useEffect, useMemo } from "react";
 import { attentionRows } from "@/components/home/attention-rows";
 import { AttentionSection } from "@/components/home/attention-section";
 import {
@@ -18,7 +18,7 @@ import {
   SCAN_STALE_TITLE,
 } from "@/lib/copy";
 import { MARKETPLACES_UNCHECKED_DETAIL } from "@/lib/copy-marketplaces";
-import { groupItems, installedCount, recentItems } from "@/lib/derive";
+import { groupItems, recentItems } from "@/lib/derive";
 import { harnessName } from "@/lib/labels";
 import { CONTENT_WIDTH, PAGE_BODY } from "@/lib/layout";
 import { cn } from "@/lib/utils";
@@ -73,6 +73,12 @@ export function OverviewPage() {
   useEffect(() => {
     void loadMarketplaces();
   }, [loadMarketplaces]);
+  // Grouped once per scan: Recently changed and the Installed tile both
+  // read these, and the page re-renders on six stores' writes.
+  const groups = useMemo(
+    () => (result ? groupItems(result.items) : []),
+    [result],
+  );
 
   const scanAgain = (
     <Button
@@ -126,9 +132,7 @@ export function OverviewPage() {
   const harnessNames = (result?.harnesses ?? [])
     .map((h) => harnessName(h.harness))
     .join(", ");
-  const recent = result
-    ? recentItems(groupItems(result.items), RECENT_ACTIVITY_LIMIT)
-    : [];
+  const recent = recentItems(groups, RECENT_ACTIVITY_LIMIT);
 
   return (
     <div>
@@ -178,7 +182,7 @@ export function OverviewPage() {
                     click lands on. */}
                 <StatTile
                   label="Installed"
-                  value={installedCount(result.items)}
+                  value={groups.length}
                   onClick={() => goToLibrary()}
                 />
                 <StatTile

--- a/ui/src/pages/overview.tsx
+++ b/ui/src/pages/overview.tsx
@@ -18,7 +18,7 @@ import {
   SCAN_STALE_TITLE,
 } from "@/lib/copy";
 import { MARKETPLACES_UNCHECKED_DETAIL } from "@/lib/copy-marketplaces";
-import { groupItems, recentItems } from "@/lib/derive";
+import { groupItems, installedCount, recentItems } from "@/lib/derive";
 import { harnessName } from "@/lib/labels";
 import { CONTENT_WIDTH, PAGE_BODY } from "@/lib/layout";
 import { cn } from "@/lib/utils";
@@ -182,7 +182,7 @@ export function OverviewPage() {
                     click lands on. */}
                 <StatTile
                   label="Installed"
-                  value={groups.length}
+                  value={installedCount(groups)}
                   onClick={() => goToLibrary()}
                 />
                 <StatTile

--- a/ui/src/pages/overview.tsx
+++ b/ui/src/pages/overview.tsx
@@ -18,7 +18,7 @@ import {
   SCAN_STALE_TITLE,
 } from "@/lib/copy";
 import { MARKETPLACES_UNCHECKED_DETAIL } from "@/lib/copy-marketplaces";
-import { groupItems, recentItems } from "@/lib/derive";
+import { groupItems, installedCount, recentItems } from "@/lib/derive";
 import { harnessName } from "@/lib/labels";
 import { CONTENT_WIDTH, PAGE_BODY } from "@/lib/layout";
 import { cn } from "@/lib/utils";
@@ -173,9 +173,12 @@ export function OverviewPage() {
                   detail={harnessNames || undefined}
                   onClick={() => goTo("harnesses")}
                 />
+                {/* Counted in the Library's unit — packages, not
+                    installations — so the number matches the table the
+                    click lands on. */}
                 <StatTile
                   label="Installed"
-                  value={result.items.length}
+                  value={installedCount(result.items)}
                   onClick={() => goToLibrary()}
                 />
                 <StatTile


### PR DESCRIPTION
## Summary
- Home's Installed tile now counts packages grouped by kind+name — the Library's row unit — instead of one per installation, so the tile and the table it opens show the same number.
- Both surfaces derive from one helper, `installedCount` in `ui/src/lib/derive.ts`, so they cannot drift again.
- `OverviewPage` groups items once per scan in a `useMemo`; the Recently changed list and the tile both derive from it.

## Completed Issues
- Closes KEN-499 - Home's Installed count disagrees with the Library

## Created Issues
- KEN-577 - Harness and project kind badges still count installations — Project: Tech Debt & Bugs

## Test Plan
- `ui`: vitest — `derive.test.ts` pins installedCount's grouping (two-harness install counts once); `overview.test.tsx` pins the tile against the reverted installations count (red on revert, green on fix).
- reviewer-test mutation pass: 4/4 planted mutants killed (tile revert, helper degrade, kind-blind grouping, hardcoded zero).
- Visual check in the VITE_MOCK dev app: tile and Library both read 49.
