### PR TITLE
fix(KEN-472): cargo test --workspace flakes on ScopeBusy, gating every PR

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -292,6 +292,13 @@ changes carry a **Breaking** call-out with their migration note inline.
   research deferred as standalone work.
 
 ### Fixed
+- An apply could be refused with "scope is busy: another apply holds ..."
+  while no other apply was running. Releasing the lock relied on closing
+  its file, and a program kendex was launching at that instant (git, a
+  lint tool) held the file open a moment longer while it started, keeping
+  the lock alive past its owner. The lock now releases explicitly the
+  instant an apply finishes. The source cache's download lock had the
+  same flaw and got the same fix.
 - Home no longer shows its loading skeletons forever when the first scan of
   the machine fails: the page says the scan failed, shows why, and offers
   Scan again. When a later scan fails, Home still draws what it had, headed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2177,6 +2177,7 @@ dependencies = [
  "dirs",
  "fd-lock",
  "keyring",
+ "rustix",
  "serde",
  "serde_json",
  "sha2 0.11.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,6 +28,9 @@ sha2 = "0.11"
 similar = "2"
 yaml-rust2 = "0.10"
 fd-lock = "4"
+# Already in the tree under fd-lock; used directly for the explicit unlock
+# that releases a lock's open file description before the fd closes.
+rustix = { version = "1", features = ["fs"] }
 unicode-normalization = "0.1"
 
 [workspace.lints.rust]

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -19,6 +19,9 @@ unicode-normalization.workspace = true
 tempfile.workspace = true
 keyring.workspace = true
 
+[target.'cfg(unix)'.dependencies]
+rustix.workspace = true
+
 [dev-dependencies]
 tempfile.workspace = true
 fd-lock.workspace = true

--- a/crates/core/src/apply/mod.rs
+++ b/crates/core/src/apply/mod.rs
@@ -34,7 +34,31 @@ pub fn scope_key(scope: &Scope) -> String {
 /// a repository's common dir. Held for the whole journal → mutate → clear
 /// window; recovery runs under the same lock.
 pub struct ScopeGuard {
-    _file: fs::File,
+    file: fs::File,
+}
+
+impl Drop for ScopeGuard {
+    fn drop(&mut self) {
+        unlock(&self.file);
+    }
+}
+
+/// Release the OS lock before the fd closes. Close alone is not release:
+/// a child forked by any thread while this fd was open holds a copy of the
+/// open file description until it execs — O_CLOEXEC closes at exec, not at
+/// fork — and flock stays held until every copy is gone. That window turns
+/// an unlock-by-close into ScopeBusy for whoever re-locks the path next,
+/// with no writer actually alive. An explicit unlock frees the description
+/// immediately, no matter who still holds a copy. Windows spawns without
+/// fork, so closing the handle is a complete release there.
+pub(crate) fn unlock(file: &fs::File) {
+    #[cfg(unix)]
+    // Unlocking a valid fd has no failure mode worth surfacing from a
+    // Drop, and the close that follows releases too once stray
+    // description copies are gone; best-effort is honest here.
+    let _ = rustix::fs::flock(file, rustix::fs::FlockOperation::Unlock);
+    #[cfg(not(unix))]
+    let _ = file;
 }
 
 fn lock_scope(env: &Env, scope: &Scope) -> Result<ScopeGuard> {
@@ -54,9 +78,9 @@ pub(crate) fn lock_key(env: &Env, key: &str) -> Result<ScopeGuard> {
     let mut lock = fd_lock::RwLock::new(file);
     // fd-lock ties its guard lifetime to the RwLock borrow; the OS lock is
     // really held by the open fd, so forget the guard and keep the file —
-    // the lock releases when ScopeGuard drops (closing the fd). Only
-    // contention is "busy": a filesystem that cannot lock at all must say
-    // so, or every launch pass would skip recovery there in silence.
+    // ScopeGuard's drop releases the lock explicitly. Only contention is
+    // "busy": a filesystem that cannot lock at all must say so, or every
+    // launch pass would skip recovery there in silence.
     match lock.try_write() {
         Ok(guard) => std::mem::forget(guard),
         Err(error) if error.kind() == std::io::ErrorKind::WouldBlock => {
@@ -65,7 +89,7 @@ pub(crate) fn lock_key(env: &Env, key: &str) -> Result<ScopeGuard> {
         Err(error) => return Err(CoreError::io(&path, error)),
     }
     Ok(ScopeGuard {
-        _file: lock.into_inner(),
+        file: lock.into_inner(),
     })
 }
 
@@ -281,6 +305,26 @@ mod tests {
         assert!(recover(&env, &Scope::Global).unwrap());
         assert_eq!(fs::read_to_string(&target).unwrap(), "before");
         assert!(!recover(&env, &Scope::Global).unwrap());
+    }
+
+    /// A concurrently spawned child holds a copy of every parent fd's open
+    /// file description between fork and exec — O_CLOEXEC closes at exec,
+    /// not at fork — so a release that relied on closing the fd left flock
+    /// held for the length of any other thread's spawn window, and this
+    /// process was refused its own lock back with no writer alive. The
+    /// try_clone here is that fork copy at the description level: dropping
+    /// the guard must release the lock while the copy still exists.
+    #[cfg(unix)]
+    #[test]
+    fn drop_releases_the_lock_while_a_description_copy_exists() {
+        let tmp = tempfile::tempdir().unwrap();
+        let env = env_in(tmp.path());
+        let guard = lock_scope(&env, &Scope::Global).unwrap();
+        let copy = guard.file.try_clone().unwrap();
+        drop(guard);
+        let relock = lock_scope(&env, &Scope::Global);
+        drop(copy);
+        relock.unwrap();
     }
 
     #[test]

--- a/crates/core/src/apply/mod.rs
+++ b/crates/core/src/apply/mod.rs
@@ -34,31 +34,7 @@ pub fn scope_key(scope: &Scope) -> String {
 /// a repository's common dir. Held for the whole journal → mutate → clear
 /// window; recovery runs under the same lock.
 pub struct ScopeGuard {
-    file: fs::File,
-}
-
-impl Drop for ScopeGuard {
-    fn drop(&mut self) {
-        unlock(&self.file);
-    }
-}
-
-/// Release the OS lock before the fd closes. Close alone is not release:
-/// a child forked by any thread while this fd was open holds a copy of the
-/// open file description until it execs — O_CLOEXEC closes at exec, not at
-/// fork — and flock stays held until every copy is gone. That window turns
-/// an unlock-by-close into ScopeBusy for whoever re-locks the path next,
-/// with no writer actually alive. An explicit unlock frees the description
-/// immediately, no matter who still holds a copy. Windows spawns without
-/// fork, so closing the handle is a complete release there.
-pub(crate) fn unlock(file: &fs::File) {
-    #[cfg(unix)]
-    // Unlocking a valid fd has no failure mode worth surfacing from a
-    // Drop, and the close that follows releases too once stray
-    // description copies are gone; best-effort is honest here.
-    let _ = rustix::fs::flock(file, rustix::fs::FlockOperation::Unlock);
-    #[cfg(not(unix))]
-    let _ = file;
+    _file: crate::fs::LockedFile,
 }
 
 fn lock_scope(env: &Env, scope: &Scope) -> Result<ScopeGuard> {
@@ -69,28 +45,13 @@ pub(crate) fn lock_key(env: &Env, key: &str) -> Result<ScopeGuard> {
     let dir = env.scope_locks_dir();
     fs::create_dir_all(&dir).map_err(|e| CoreError::io(&dir, e))?;
     let path = dir.join(format!("{key}.lock"));
-    let file = fs::OpenOptions::new()
-        .create(true)
-        .truncate(false)
-        .write(true)
-        .open(&path)
-        .map_err(|e| CoreError::io(&path, e))?;
-    let mut lock = fd_lock::RwLock::new(file);
-    // fd-lock ties its guard lifetime to the RwLock borrow; the OS lock is
-    // really held by the open fd, so forget the guard and keep the file —
-    // ScopeGuard's drop releases the lock explicitly. Only contention is
-    // "busy": a filesystem that cannot lock at all must say so, or every
-    // launch pass would skip recovery there in silence.
-    match lock.try_write() {
-        Ok(guard) => std::mem::forget(guard),
-        Err(error) if error.kind() == std::io::ErrorKind::WouldBlock => {
-            return Err(CoreError::ScopeBusy { lock: path });
-        }
-        Err(error) => return Err(CoreError::io(&path, error)),
+    // Only contention is "busy": a filesystem that cannot lock at all must
+    // say so, or every launch pass would skip recovery there in silence.
+    match crate::fs::LockedFile::try_exclusive(&path) {
+        Ok(Some(file)) => Ok(ScopeGuard { _file: file }),
+        Ok(None) => Err(CoreError::ScopeBusy { lock: path }),
+        Err(error) => Err(CoreError::io(&path, error)),
     }
-    Ok(ScopeGuard {
-        file: lock.into_inner(),
-    })
 }
 
 /// Recovery under the scope lock, for callers outside an apply (launch
@@ -320,7 +281,7 @@ mod tests {
         let tmp = tempfile::tempdir().unwrap();
         let env = env_in(tmp.path());
         let guard = lock_scope(&env, &Scope::Global).unwrap();
-        let copy = guard.file.try_clone().unwrap();
+        let copy = guard._file.file().try_clone().unwrap();
         drop(guard);
         let relock = lock_scope(&env, &Scope::Global);
         drop(copy);

--- a/crates/core/src/fs.rs
+++ b/crates/core/src/fs.rs
@@ -68,6 +68,70 @@ fn follow_link(path: &Path) -> PathBuf {
     }
 }
 
+/// A file held under the OS's exclusive lock, released on drop. The one
+/// owner of the lock-file ritual: callers hold a `LockedFile` and never
+/// touch fd-lock, `mem::forget`, or the release themselves.
+pub(crate) struct LockedFile {
+    file: fs::File,
+}
+
+impl LockedFile {
+    /// Take the exclusive lock at `path`, creating the file as needed.
+    /// `Ok(None)` is contention — a live holder exists. Any other failure
+    /// is an error: a filesystem that cannot lock at all must say so, or
+    /// every caller would read it as "busy" and wait on nobody.
+    pub(crate) fn try_exclusive(path: &Path) -> std::io::Result<Option<LockedFile>> {
+        let file = fs::OpenOptions::new()
+            .create(true)
+            .truncate(false)
+            .write(true)
+            .open(path)?;
+        // fd-lock ties its guard lifetime to the RwLock borrow; the OS
+        // lock is really held by the open fd, so forget the guard and
+        // keep the file — Drop below releases explicitly.
+        let mut lock = fd_lock::RwLock::new(file);
+        match lock.try_write() {
+            Ok(guard) => std::mem::forget(guard),
+            Err(error) if error.kind() == std::io::ErrorKind::WouldBlock => return Ok(None),
+            Err(error) => return Err(error),
+        }
+        Ok(Some(LockedFile {
+            file: lock.into_inner(),
+        }))
+    }
+
+    /// Test-only view of the fd, for cloning a description copy.
+    #[cfg(test)]
+    pub(crate) fn file(&self) -> &fs::File {
+        &self.file
+    }
+}
+
+/// Release the OS lock before the fd closes. On unix, close alone is not
+/// release: a child forked by any thread while this fd was open holds a
+/// copy of the open file description until it execs — O_CLOEXEC closes at
+/// exec, not at fork — and the lock stays held until every copy is gone.
+/// That window turns an unlock-by-close into a spurious "busy" for whoever
+/// re-locks the path next, with no holder actually alive. An explicit
+/// unlock frees the description immediately, no matter who still holds a
+/// copy. Windows spawns without fork, so no copy outlives the guard; the
+/// handle's close is the release there, which LockFileEx documents may lag
+/// briefly — accepted, since the safe unlock APIs do not reach Windows and
+/// there is no fork window to defend against.
+impl Drop for LockedFile {
+    fn drop(&mut self) {
+        // Unlocking a valid fd has no failure mode worth surfacing from a
+        // Drop, and the close that follows releases too once stray
+        // description copies are gone; best-effort is honest here.
+        // Solaris has no flock in rustix; fd-lock locks there via fcntl,
+        // so the release mirrors it.
+        #[cfg(all(unix, not(target_os = "solaris")))]
+        let _ = rustix::fs::flock(&self.file, rustix::fs::FlockOperation::Unlock);
+        #[cfg(target_os = "solaris")]
+        let _ = rustix::fs::fcntl_lock(&self.file, rustix::fs::FlockOperation::Unlock);
+    }
+}
+
 pub fn read_if_exists(path: &Path) -> Result<Option<String>> {
     match fs::read_to_string(path) {
         Ok(s) => Ok(Some(s)),

--- a/crates/core/src/remote/store.rs
+++ b/crates/core/src/remote/store.rs
@@ -107,12 +107,14 @@ pub use adopt::adopt_cache;
 /// takes it — reading a published checkout needs no lock, because a
 /// published checkout never changes.
 pub struct CacheGuard {
-    file: fs::File,
+    _file: crate::fs::LockedFile,
 }
 
-impl Drop for CacheGuard {
-    fn drop(&mut self) {
-        crate::apply::unlock(&self.file);
+impl CacheGuard {
+    /// Test-only view of the fd, for cloning a description copy.
+    #[cfg(test)]
+    pub(crate) fn file(&self) -> &fs::File {
+        self._file.file()
     }
 }
 
@@ -127,32 +129,18 @@ pub fn lock_repo(env: &Env, key: &str) -> Result<CacheGuard> {
     let dir = env.source_cache_dir().join(LOCKS);
     fs::create_dir_all(&dir).map_err(|e| CoreError::io(&dir, e))?;
     let path = dir.join(format!("{key}.lock"));
-    let file = fs::OpenOptions::new()
-        .create(true)
-        .truncate(false)
-        .write(true)
-        .open(&path)
-        .map_err(|e| CoreError::io(&path, e))?;
-    let mut lock = fd_lock::RwLock::new(file);
     let deadline = Instant::now() + LOCK_WAIT;
-    let acquired = loop {
-        // As in apply's scope lock: the OS lock belongs to the open fd, so
-        // the guard is forgotten and the file kept — CacheGuard's drop
-        // releases the lock explicitly.
-        match lock.try_write() {
-            Ok(guard) => {
-                std::mem::forget(guard);
-                break true;
+    loop {
+        match crate::fs::LockedFile::try_exclusive(&path) {
+            Ok(Some(file)) => return Ok(CacheGuard { _file: file }),
+            Ok(None) if Instant::now() >= deadline => {
+                return Err(CoreError::CacheBusy { lock: path });
             }
-            Err(_) if Instant::now() >= deadline => break false,
-            Err(_) => std::thread::sleep(LOCK_POLL),
+            Ok(None) => std::thread::sleep(LOCK_POLL),
+            // A filesystem that cannot lock at all is its own failure;
+            // waiting out the deadline would misname it "busy".
+            Err(error) => return Err(CoreError::io(&path, error)),
         }
-    };
-    match acquired {
-        true => Ok(CacheGuard {
-            file: lock.into_inner(),
-        }),
-        false => Err(CoreError::CacheBusy { lock: path }),
     }
 }
 

--- a/crates/core/src/remote/store.rs
+++ b/crates/core/src/remote/store.rs
@@ -107,14 +107,19 @@ pub use adopt::adopt_cache;
 /// takes it — reading a published checkout needs no lock, because a
 /// published checkout never changes.
 pub struct CacheGuard {
-    _file: fs::File,
+    file: fs::File,
+}
+
+impl Drop for CacheGuard {
+    fn drop(&mut self) {
+        crate::apply::unlock(&self.file);
+    }
 }
 
 /// How long a resolver waits for the lock before calling the cache busy.
-/// Long enough to ride out a neighbour that is only starting up — a
-/// process being launched holds a copy of every open descriptor for the
-/// instant before it takes over, this lock among them — and far too short
-/// to leave anyone waiting on someone else's download.
+/// Long enough to ride out a neighbour holding it for one quick step — a
+/// fetch stamp, publishing an already-materialized checkout — and far too
+/// short to leave anyone waiting on someone else's download.
 const LOCK_WAIT: Duration = Duration::from_millis(500);
 const LOCK_POLL: Duration = Duration::from_millis(10);
 
@@ -132,8 +137,8 @@ pub fn lock_repo(env: &Env, key: &str) -> Result<CacheGuard> {
     let deadline = Instant::now() + LOCK_WAIT;
     let acquired = loop {
         // As in apply's scope lock: the OS lock belongs to the open fd, so
-        // the guard is forgotten and the file kept — dropping CacheGuard
-        // closes the fd and releases the lock.
+        // the guard is forgotten and the file kept — CacheGuard's drop
+        // releases the lock explicitly.
         match lock.try_write() {
             Ok(guard) => {
                 std::mem::forget(guard);
@@ -145,7 +150,7 @@ pub fn lock_repo(env: &Env, key: &str) -> Result<CacheGuard> {
     };
     match acquired {
         true => Ok(CacheGuard {
-            _file: lock.into_inner(),
+            file: lock.into_inner(),
         }),
         false => Err(CoreError::CacheBusy { lock: path }),
     }

--- a/crates/core/src/remote/tests.rs
+++ b/crates/core/src/remote/tests.rs
@@ -342,3 +342,22 @@ fn the_cache_lock_is_released_with_its_guard() {
     drop(guard);
     store::lock_repo(&env, "catalog").expect("the lock releases with its guard");
 }
+
+/// As with the scope lock: a child forked by any thread holds a copy of
+/// this fd's open file description until it execs, so a release relying on
+/// close alone stays held for the length of that spawn window — here paid
+/// as the full LOCK_WAIT and then a false CacheBusy. The try_clone is that
+/// fork copy at the description level: dropping the guard must release the
+/// lock while the copy still exists.
+#[cfg(unix)]
+#[test]
+fn the_cache_lock_releases_while_a_description_copy_exists() {
+    let tmp = tempfile::tempdir().unwrap();
+    let env = Env::fake(tmp.path(), FakeOs::Linux);
+    let guard = store::lock_repo(&env, "catalog").unwrap();
+    let copy = guard.file().try_clone().unwrap();
+    drop(guard);
+    let relock = store::lock_repo(&env, "catalog");
+    drop(copy);
+    relock.expect("drop released the lock despite the live description copy");
+}

--- a/crates/core/tests/drift_hook_script.rs
+++ b/crates/core/tests/drift_hook_script.rs
@@ -37,12 +37,14 @@ fn run_hook(dir: &Path, stdin: &str, env: &[(&str, &str)], stub: Option<&str>) -
         .stderr(std::process::Stdio::null())
         .spawn()
         .unwrap();
-    child
-        .stdin
-        .take()
-        .unwrap()
-        .write_all(stdin.as_bytes())
-        .unwrap();
+    // A hook that exits before reading stdin closes the pipe early; that
+    // is the script's business, not a harness failure — the contract under
+    // test is the output and exit code.
+    match child.stdin.take().unwrap().write_all(stdin.as_bytes()) {
+        Ok(()) => {}
+        Err(error) if error.kind() == std::io::ErrorKind::BrokenPipe => {}
+        Err(error) => panic!("writing hook stdin: {error}"),
+    }
     let output = child.wait_with_output().unwrap();
     (
         String::from_utf8_lossy(&output.stdout).into_owned(),


### PR DESCRIPTION
## Summary
- Names the KEN-472 ScopeBusy collision: `flock` belongs to the open file description, and every child forked by any thread holds a copy of every fd until it execs (`O_CLOEXEC` closes at exec, not fork) — so releasing the scope lock by closing its fd left it held for the length of any concurrent spawn's fork window, and the next `apply::execute` on the same scope was refused as `ScopeBusy` with no writer alive. Not a two-test collision: any test re-locking its own scope during another thread's spawn window could hit it.
- Fixes it structurally: `crate::fs::LockedFile` now solely owns the lock ritual — `try_exclusive` (open + fd-lock `try_write` + forget), `Drop` (explicit `flock(LOCK_UN)` on unix, `fcntl_lock` on Solaris, close-release on Windows where no fork window exists). `ScopeGuard` and `CacheGuard` hold a `LockedFile`; `lock_repo` now surfaces real filesystem errors immediately instead of retrying them into a false `CacheBusy`.
- Both lock sites carry description-copy release tests proven red against a close-only drop; also fixes the `drift_hook_script.rs` BrokenPipe flake (stdin write to a stub that exits without reading).

## Completed Issues
- Closes KEN-472 - cargo test --workspace flakes on ScopeBusy in most runs, gating every PR

## QA Metrics
- Safety QA (reviewer-safety): pass — mutation killed 2/2 (close-only-drop mutant of `LockedFile::drop` killed independently by each description-copy test), stability 15/15 consecutive green runs, 0 unsafe blocks, no unlink-vs-flock race (lock files are never unlinked), unlock syscall verified against fd-lock 4.0.4's `compatible_unix_lock` per target.
- Panel: 9 internal reviewers + external Codex, two cycles; cycle-1 blocker (missing CacheGuard discriminating test) and three fix items (LockedFile consolidation, Windows comment accuracy, Solaris fcntl split) all fixed in 7d86c5ff; cycle 2 clean across all lanes.

## Test Plan
- `cargo test -p kendex-core --test edits_and_forks -- --test-threads=64`: 100 consecutive green runs (the acceptance loop), no retries or sleeps added.
- 25 rounds of lib + edits_and_forks + install_seam + drift_hook_script at 64 threads green; full `cargo test --workspace` and `tools/guard` green.
- Caveat recorded on the issue: the wild flake no longer reproduces on this host even with the old code (195 runs under load), so attribution rests on the mechanism unit tests (proven red against the old close-only release) plus elimination, rather than a live before/after.
