### PR TITLE
fix(github): a run the EXPECTED rewrite retires is named superseded (KEN-569)

### DIFF
--- a/skills/github/scripts/commands/ci-classify-refusal.sh
+++ b/skills/github/scripts/commands/ci-classify-refusal.sh
@@ -161,9 +161,12 @@ echo "$scoped_json" | jq -r "$CI_RUN_JQ_DEFS$SANITIZE_JQ"'
 
 # Superseded covers both record kinds: workflow runs whose checks were
 # dropped by run selection, and commit-status records that lost the
-# per-name grouping to a newer same-name status.
+# per-name grouping to a newer same-name status. What was kept is head_runs
+# itself, not every run id the scoped records mention: a status the rewrite
+# held EXPECTED still links the run that rewrite retired, and reading that
+# link as kept would leave the retired run on neither list.
 jq -n --argjson raw "$ci_json" --argjson scoped "$scoped_json" "$CI_RUN_JQ_DEFS$SANITIZE_JQ"'
-    ([$scoped[] | runid | select(. != null)] | unique) as $kept
+    ($scoped | head_runs) as $kept
     | (($raw
         | map(select((.workflow // "") != "")
               | {id: ("workflow=" + (.workflow | clean)), run: runid}

--- a/skills/github/scripts/commands/ci-classify-refusal.sh
+++ b/skills/github/scripts/commands/ci-classify-refusal.sh
@@ -22,9 +22,12 @@
 #                          state, workflow, and run id
 #   superseded: ...        (ci_failed only) runs on the head whose checks
 #                          were NOT counted — workflow runs (`workflow=`)
-#                          and older same-name commit statuses (`status=`)
-#                          alike; a failure someone read from raw
-#                          `gh pr checks` output may belong here
+#                          and commit statuses (`status=`) alike. A status
+#                          lands here when a newer same-name status
+#                          replaced it, and also when it is the latest of
+#                          its name but the run it links was retired by the
+#                          stale-status rewrite. A failure someone read
+#                          from raw `gh pr checks` output may belong here
 #
 # Every line reads ONE checks snapshot: pr-merge --check embeds the rollup
 # it classified in its JSON (`checks`), and this script scopes that instead

--- a/skills/github/tests/ci-classify-refusal.sh
+++ b/skills/github/tests/ci-classify-refusal.sh
@@ -112,6 +112,23 @@ assert_contains "$out" "head-run: 29099680623,29099700200" "head-run names the s
 assert_contains "$out" "fail: CI Required state=FAILURE workflow=- run=29099700200" "the mixed-head status failure is run-correlated"
 assert_contains "$out" "superseded: status=CI Required run=29099700100" "an older same-name status run is named as superseded"
 
+# A run retired by the stale-status rewrite is named as superseded. The
+# aggregate `CI Required` status still links run A, but scoping rewrote it to
+# EXPECTED because run B replaced it — so A is correctly out of head-run:,
+# and must land on a superseded: line instead of appearing on neither. Run C
+# is the unrelated failure that makes this a ci_failed refusal.
+checks='[
+  {"name":"Lint","state":"SUCCESS","bucket":"pass","link":"https://github.com/owner/repo/actions/runs/29099700100/job/101","workflow":"CI","startedAt":"2026-07-10T10:00:00Z"},
+  {"name":"Lint","state":"SUCCESS","bucket":"pass","link":"https://github.com/owner/repo/actions/runs/29099700200/job/201","workflow":"CI","startedAt":"2026-07-10T11:00:00Z"},
+  {"name":"CI Required","state":"FAILURE","bucket":"fail","link":"https://github.com/owner/repo/actions/runs/29099700100","workflow":""},
+  {"name":"Docs Build","state":"FAILURE","bucket":"fail","link":"https://github.com/owner/repo/actions/runs/29099700300/job/301","workflow":"Docs","startedAt":"2026-07-10T11:00:00Z"}
+]'
+out=$(STUB_CHECKS="$checks" STUB_CHECKS_EXIT=8 run_classify)
+assert_eq "$(head -1 <<<"$out")" "cause: ci_failed" "the unrelated failure still classifies as ci_failed"
+assert_eq "$(grep '^head-run: ' <<<"$out")" "head-run: 29099700200,29099700300" "the retired run is out of head-run:"
+assert_contains "$out" "superseded: status=CI Required run=29099700100" "the status the rewrite retired names its run as superseded"
+assert_contains "$out" "superseded: workflow=CI run=29099700100" "the retired run's workflow record is named as superseded"
+
 # The verdict and its detail block read ONE snapshot: the ci_failed branch
 # scopes the checks rollup embedded in pr-merge --check's JSON instead of
 # refetching, so a rerun starting between two fetches cannot make cause:

--- a/skills/github/tests/ci-classify-refusal.sh
+++ b/skills/github/tests/ci-classify-refusal.sh
@@ -125,6 +125,8 @@ checks='[
 ]'
 out=$(STUB_CHECKS="$checks" STUB_CHECKS_EXIT=8 run_classify)
 assert_eq "$(head -1 <<<"$out")" "cause: ci_failed" "the unrelated failure still classifies as ci_failed"
+assert_contains "$out" "issue: ci_pending: CI Required (EXPECTED)" "the stale status was rewritten to EXPECTED"
+assert_not_contains "$out" "fail: CI Required" "the rewritten status is not counted as a failure"
 assert_eq "$(grep '^head-run: ' <<<"$out")" "head-run: 29099700200,29099700300" "the retired run is out of head-run:"
 assert_contains "$out" "superseded: status=CI Required run=29099700100" "the status the rewrite retired names its run as superseded"
 assert_contains "$out" "superseded: workflow=CI run=29099700100" "the retired run's workflow record is named as superseded"


### PR DESCRIPTION
## Summary

- `ci-classify-refusal` built its kept-run set from every run id the scoped records mention, while `head_runs` excludes a status the stale-status rewrite held EXPECTED — and that status still links the run the rewrite just retired. The retired run therefore landed on neither `head-run:` nor `superseded:`, so a failure an operator read off raw `gh pr checks` for that run was never named as not-counted.
- `$kept` is now `head_runs` itself, so both lines come from one definition of scope and cannot drift.
- The `--help` contract now says a `status=` record lands on `superseded:` in both cases: a newer same-name status replaced it, or it is the latest of its name but its run was retired.

## Test Plan

New fixture in `skills/github/tests/ci-classify-refusal.sh`: stale EXPECTED status on retired run A (29099700100), replacement run B (29099700200), unrelated failure run C (29099700300). It asserts the rewrite fired, that the rewritten status is not counted as a failure, that A is out of `head-run:`, and that both A's status and workflow records appear on `superseded:` lines.

Restoring the old `$kept` expression fails exactly the two superseded assertions; deleting `head_runs`' EXPECTED exclusion fails three. Suite: 43 pass / 0 fail; the whole `skills/github/tests` set is green.

## Completed Issues

- Closes KEN-569 - Superseded listing omits runs the EXPECTED rewrite retires
