### PR TITLE
fix(release): macOS builds are Developer ID signed and notarized (KEN-394)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -63,10 +63,12 @@ jobs:
       - run: cargo build --release -p kendex-cli --target ${{ matrix.target }}
         shell: bash
       # Tauri's bundler signs and notarizes on its own when the APPLE_*
-      # variables are present — and it checks presence, not content, so
+      # variables are present, and it checks presence, not content, so
       # the unset-secret gate must happen before they enter the
-      # environment: each group is exported only when its secret exists.
-      # The key lands on disk because notarytool takes a path.
+      # environment. The seven secrets are one unit: all set exports
+      # them, none set builds unsigned, anything in between fails here
+      # rather than shipping a signed-but-unnotarized bundle. The key
+      # lands on disk because notarytool takes a path.
       - name: Stage macOS signing environment
         if: runner.os == 'macOS'
         shell: bash
@@ -79,22 +81,31 @@ jobs:
           KEY_ID: ${{ secrets.APPLE_API_KEY_ID }}
           KEY_P8: ${{ secrets.APPLE_API_KEY }}
         run: |
-          if [ -n "$CERT" ]; then
-            {
-              echo "APPLE_CERTIFICATE=$CERT"
-              echo "APPLE_CERTIFICATE_PASSWORD=$CERT_PW"
-              echo "APPLE_SIGNING_IDENTITY=$IDENTITY"
-              echo "APPLE_TEAM_ID=$TEAM"
-            } >> "$GITHUB_ENV"
+          missing=""
+          for name in CERT CERT_PW IDENTITY TEAM ISSUER KEY_ID KEY_P8; do
+            [ -z "${!name}" ] && missing="$missing $name"
+          done
+          if [ "$missing" = " CERT CERT_PW IDENTITY TEAM ISSUER KEY_ID KEY_P8" ]; then
+            echo "No APPLE_* secrets: building unsigned."
+            exit 0
           fi
-          if [ -n "$KEY_P8" ]; then
-            printf '%s' "$KEY_P8" > "$RUNNER_TEMP/AuthKey.p8"
-            {
-              echo "APPLE_API_ISSUER=$ISSUER"
-              echo "APPLE_API_KEY=$KEY_ID"
-              echo "APPLE_API_KEY_PATH=$RUNNER_TEMP/AuthKey.p8"
-            } >> "$GITHUB_ENV"
+          if [ -n "$missing" ]; then
+            echo "::error::Partial Apple signing config; missing:$missing. Set all seven APPLE_* secrets or none."
+            exit 1
           fi
+          printf '%s' "$KEY_P8" > "$RUNNER_TEMP/AuthKey.p8"
+          {
+            # The certificate is base64 that may arrive line-wrapped;
+            # GITHUB_ENV's NAME=VALUE form holds one line, and tauri
+            # decodes it whitespace-free either way.
+            echo "APPLE_CERTIFICATE=$(tr -d '[:space:]' <<<"$CERT")"
+            echo "APPLE_CERTIFICATE_PASSWORD=$CERT_PW"
+            echo "APPLE_SIGNING_IDENTITY=$IDENTITY"
+            echo "APPLE_TEAM_ID=$TEAM"
+            echo "APPLE_API_ISSUER=$ISSUER"
+            echo "APPLE_API_KEY=$KEY_ID"
+            echo "APPLE_API_KEY_PATH=$RUNNER_TEMP/AuthKey.p8"
+          } >> "$GITHUB_ENV"
       - name: Bundle the desktop app
         run: cd crates/app && ../../ui/node_modules/.bin/tauri build --target ${{ matrix.target }}
         shell: bash

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -62,6 +62,15 @@ jobs:
       # reads one layout instead of one per runner.
       - run: cargo build --release -p kendex-cli --target ${{ matrix.target }}
         shell: bash
+      # Tauri's bundler signs and notarizes on its own when the APPLE_*
+      # variables are present; the key file has to exist on disk because
+      # notarytool takes a path, not content.
+      - name: Stage the notary key
+        if: runner.os == 'macOS'
+        run: printf '%s' "$APPLE_API_KEY_P8" > "$RUNNER_TEMP/AuthKey.p8"
+        env:
+          APPLE_API_KEY_P8: ${{ secrets.APPLE_API_KEY }}
+        shell: bash
       - name: Bundle the desktop app
         run: cd crates/app && ../../ui/node_modules/.bin/tauri build --target ${{ matrix.target }}
         shell: bash
@@ -69,6 +78,18 @@ jobs:
           # User-supplied gates: unset keys skip updater-artifact signing.
           TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
           TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}
+          # macOS Developer ID signing + notarization (KEN-394). Same
+          # gate: unset secrets skip both, and the non-mac lanes ignore
+          # every APPLE_* variable. APPLE_API_KEY is the key ID in
+          # tauri's vocabulary; the secret holding the .p8 content is
+          # staged to APPLE_API_KEY_PATH above.
+          APPLE_CERTIFICATE: ${{ secrets.APPLE_CERTIFICATE }}
+          APPLE_CERTIFICATE_PASSWORD: ${{ secrets.APPLE_CERTIFICATE_PASSWORD }}
+          APPLE_SIGNING_IDENTITY: ${{ secrets.APPLE_SIGNING_IDENTITY }}
+          APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
+          APPLE_API_ISSUER: ${{ secrets.APPLE_API_ISSUER }}
+          APPLE_API_KEY: ${{ secrets.APPLE_API_KEY_ID }}
+          APPLE_API_KEY_PATH: ${{ runner.temp }}/AuthKey.p8
       - name: Stage release assets
         run: |
           mkdir -p dist

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -63,14 +63,38 @@ jobs:
       - run: cargo build --release -p kendex-cli --target ${{ matrix.target }}
         shell: bash
       # Tauri's bundler signs and notarizes on its own when the APPLE_*
-      # variables are present; the key file has to exist on disk because
-      # notarytool takes a path, not content.
-      - name: Stage the notary key
+      # variables are present — and it checks presence, not content, so
+      # the unset-secret gate must happen before they enter the
+      # environment: each group is exported only when its secret exists.
+      # The key lands on disk because notarytool takes a path.
+      - name: Stage macOS signing environment
         if: runner.os == 'macOS'
-        run: printf '%s' "$APPLE_API_KEY_P8" > "$RUNNER_TEMP/AuthKey.p8"
-        env:
-          APPLE_API_KEY_P8: ${{ secrets.APPLE_API_KEY }}
         shell: bash
+        env:
+          CERT: ${{ secrets.APPLE_CERTIFICATE }}
+          CERT_PW: ${{ secrets.APPLE_CERTIFICATE_PASSWORD }}
+          IDENTITY: ${{ secrets.APPLE_SIGNING_IDENTITY }}
+          TEAM: ${{ secrets.APPLE_TEAM_ID }}
+          ISSUER: ${{ secrets.APPLE_API_ISSUER }}
+          KEY_ID: ${{ secrets.APPLE_API_KEY_ID }}
+          KEY_P8: ${{ secrets.APPLE_API_KEY }}
+        run: |
+          if [ -n "$CERT" ]; then
+            {
+              echo "APPLE_CERTIFICATE=$CERT"
+              echo "APPLE_CERTIFICATE_PASSWORD=$CERT_PW"
+              echo "APPLE_SIGNING_IDENTITY=$IDENTITY"
+              echo "APPLE_TEAM_ID=$TEAM"
+            } >> "$GITHUB_ENV"
+          fi
+          if [ -n "$KEY_P8" ]; then
+            printf '%s' "$KEY_P8" > "$RUNNER_TEMP/AuthKey.p8"
+            {
+              echo "APPLE_API_ISSUER=$ISSUER"
+              echo "APPLE_API_KEY=$KEY_ID"
+              echo "APPLE_API_KEY_PATH=$RUNNER_TEMP/AuthKey.p8"
+            } >> "$GITHUB_ENV"
+          fi
       - name: Bundle the desktop app
         run: cd crates/app && ../../ui/node_modules/.bin/tauri build --target ${{ matrix.target }}
         shell: bash
@@ -78,18 +102,10 @@ jobs:
           # User-supplied gates: unset keys skip updater-artifact signing.
           TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
           TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}
-          # macOS Developer ID signing + notarization (KEN-394). Same
-          # gate: unset secrets skip both, and the non-mac lanes ignore
-          # every APPLE_* variable. APPLE_API_KEY is the key ID in
-          # tauri's vocabulary; the secret holding the .p8 content is
-          # staged to APPLE_API_KEY_PATH above.
-          APPLE_CERTIFICATE: ${{ secrets.APPLE_CERTIFICATE }}
-          APPLE_CERTIFICATE_PASSWORD: ${{ secrets.APPLE_CERTIFICATE_PASSWORD }}
-          APPLE_SIGNING_IDENTITY: ${{ secrets.APPLE_SIGNING_IDENTITY }}
-          APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
-          APPLE_API_ISSUER: ${{ secrets.APPLE_API_ISSUER }}
-          APPLE_API_KEY: ${{ secrets.APPLE_API_KEY_ID }}
-          APPLE_API_KEY_PATH: ${{ runner.temp }}/AuthKey.p8
+          # macOS Developer ID signing + notarization (KEN-394) arrives
+          # from the staging step above via GITHUB_ENV, only when the
+          # secrets exist. APPLE_API_KEY there is the key ID in tauri's
+          # vocabulary; the .p8 content travels by APPLE_API_KEY_PATH.
       - name: Stage release assets
         run: |
           mkdir -p dist

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@ an outside contributor.
 
 ## [Unreleased]
 
+### Fixed
+
+- macOS builds are Developer ID signed and notarized: installing from any
+  channel no longer ends in "kendex is damaged" or an `xattr -cr` workaround.
+
 ### Removed
 
 - **Breaking:** the `trading-design` skill is no longer offered. Run

--- a/crates/cli/tests/release_workflow.rs
+++ b/crates/cli/tests/release_workflow.rs
@@ -37,6 +37,90 @@ fn step<'a>(workflow: &'a str, first_line_marker: &str) -> Vec<&'a str> {
     body
 }
 
+/// The body of a step's `run: |` block, dedented so bash can run it.
+fn run_script(step_lines: &[&str]) -> String {
+    let mut lines = step_lines
+        .iter()
+        .skip_while(|l| l.trim() != "run: |")
+        .skip(1)
+        .peekable();
+    let indent = lines
+        .peek()
+        .map(|l| l.len() - l.trim_start().len())
+        .unwrap_or_else(|| panic!("step has no run: | body"));
+    lines
+        .map(|l| l.get(indent..).unwrap_or(""))
+        .collect::<Vec<_>>()
+        .join("\n")
+}
+
+const APPLE_SECRETS: [&str; 7] = [
+    "CERT", "CERT_PW", "IDENTITY", "TEAM", "ISSUER", "KEY_ID", "KEY_P8",
+];
+
+/// Runs the macOS signing stage with exactly `set` secrets non-empty and
+/// returns the exit code and what it wrote to GITHUB_ENV.
+#[allow(clippy::unwrap_used)]
+fn stage_signing(set: &[&str]) -> (i32, String) {
+    let dir = tempfile::tempdir().unwrap();
+    let env_file = dir.path().join("github.env");
+    let workflow = workflow();
+    let script = run_script(&step(&workflow, "name: Stage macOS signing environment"));
+    let mut cmd = std::process::Command::new("bash");
+    cmd.arg("-c")
+        .arg(&script)
+        .env_clear()
+        .env("PATH", std::env::var_os("PATH").unwrap_or_default())
+        .env("RUNNER_TEMP", dir.path())
+        .env("GITHUB_ENV", &env_file);
+    for name in APPLE_SECRETS {
+        // A wrapped certificate carries newlines; tauri wants it flat.
+        let value = if name == "CERT" { "abc\ndef\n" } else { "v" };
+        cmd.env(name, if set.contains(&name) { value } else { "" });
+    }
+    let status = cmd.status().unwrap();
+    let exported = fs::read_to_string(&env_file).unwrap_or_default();
+    (status.code().unwrap_or(-1), exported)
+}
+
+#[cfg(unix)]
+#[test]
+fn signing_env_is_exported_only_for_a_complete_secret_set() {
+    let (code, exported) = stage_signing(&APPLE_SECRETS);
+    assert_eq!(code, 0, "all seven secrets set must succeed");
+    for var in [
+        "APPLE_CERTIFICATE=abcdef\n",
+        "APPLE_CERTIFICATE_PASSWORD=",
+        "APPLE_SIGNING_IDENTITY=",
+        "APPLE_TEAM_ID=",
+        "APPLE_API_ISSUER=",
+        "APPLE_API_KEY=",
+        "APPLE_API_KEY_PATH=",
+    ] {
+        assert!(exported.contains(var), "{var} missing from:\n{exported}");
+    }
+
+    let (code, exported) = stage_signing(&[]);
+    assert_eq!(code, 0, "no secrets must build unsigned");
+    assert!(
+        exported.is_empty(),
+        "no secrets exported anything:\n{exported}"
+    );
+
+    for missing in APPLE_SECRETS {
+        let set: Vec<&str> = APPLE_SECRETS
+            .into_iter()
+            .filter(|s| *s != missing)
+            .collect();
+        let (code, exported) = stage_signing(&set);
+        assert_ne!(code, 0, "missing {missing} must fail the lane");
+        assert!(
+            exported.is_empty(),
+            "missing {missing} exported:\n{exported}"
+        );
+    }
+}
+
 fn lane_triples(workflow: &str) -> Vec<&str> {
     workflow
         .lines()

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -29,9 +29,9 @@ revisit Intel support then.
 ## User-supplied gates
 
 - **Updater signing** (`TAURI_SIGNING_PRIVATE_KEY`,
-  `TAURI_SIGNING_PRIVATE_KEY_PASSWORD` repo secrets): without them the
-  desktop bundles build unsigned and no Tauri updater artifacts are
-  produced. CLI self-update is unaffected.
+  `TAURI_SIGNING_PRIVATE_KEY_PASSWORD` repo secrets): without them no
+  Tauri updater artifacts are produced (bundle code signing is the
+  separate macOS gate below). CLI self-update is unaffected.
 - **macOS signing + notarization** (the seven `APPLE_*` repo secrets:
   certificate p12 + password, signing identity, team id, and the App
   Store Connect API issuer/key-id/key): all seven set, the two mac lanes

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -34,8 +34,9 @@ revisit Intel support then.
   produced. CLI self-update is unaffected.
 - **macOS signing + notarization** (the seven `APPLE_*` repo secrets:
   certificate p12 + password, signing identity, team id, and the App
-  Store Connect API issuer/key-id/key): with them set, the two mac lanes
-  Developer-ID-sign and notarize the bundles; unset, they build unsigned.
+  Store Connect API issuer/key-id/key): all seven set, the two mac lanes
+  Developer-ID-sign and notarize the bundles; none set, they build
+  unsigned; a partial set fails the lane before bundling.
   Material and gotchas are recorded in the owner's dotfiles AGENTS.md.
 - **Windows code signing**: not configured; add a certificate before
   distributing outside GitHub Releases.

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -32,8 +32,13 @@ revisit Intel support then.
   `TAURI_SIGNING_PRIVATE_KEY_PASSWORD` repo secrets): without them the
   desktop bundles build unsigned and no Tauri updater artifacts are
   produced. CLI self-update is unaffected.
-- **macOS notarization / Windows code signing**: not configured; add
-  certificates before distributing outside GitHub Releases.
+- **macOS signing + notarization** (the seven `APPLE_*` repo secrets:
+  certificate p12 + password, signing identity, team id, and the App
+  Store Connect API issuer/key-id/key): with them set, the two mac lanes
+  Developer-ID-sign and notarize the bundles; unset, they build unsigned.
+  Material and gotchas are recorded in the owner's dotfiles AGENTS.md.
+- **Windows code signing**: not configured; add a certificate before
+  distributing outside GitHub Releases.
 
 ## Local packaging
 

--- a/packaging/README.md
+++ b/packaging/README.md
@@ -62,9 +62,10 @@ build time from the cloned commit.
 
 ## Caveats
 
-- The macOS `.app` is not yet notarized, so Gatekeeper calls it "damaged" on
-  first launch until signing is added to the release. The cask's caveat tells
-  users to clear the quarantine flag once: `xattr -cr /Applications/kendex.app`.
+- Releases through v5.0.1 predate Apple notarization, so Gatekeeper calls
+  those "damaged" on first launch; the cask's caveat gives the one-time fix
+  (`xattr -cr /Applications/kendex.app`). Later releases are Developer ID
+  signed and notarized by the release workflow.
 - The Linux AppImage needs FUSE (`fuse2`) to run.
 - The release workflow publishes as a **draft**, and `install.sh` resolves
   `--version latest` through GitHub's latest-release API, which skips drafts.

--- a/packaging/homebrew/kendex-cask.rb
+++ b/packaging/homebrew/kendex-cask.rb
@@ -23,12 +23,14 @@ cask "kendex" do
   app "kendex.app"
 
   caveats <<~EOS
-    kendex is not notarized by Apple yet, so macOS may say the app is
-    "damaged" on first launch. Clear the quarantine flag once:
+    Releases through v5.0.1 predate Apple notarization; on those, macOS
+    may say the app is "damaged" on first launch. Clear the quarantine
+    flag once:
 
       xattr -cr /Applications/kendex.app
 
-    The kendex command is installed by the formula and is unaffected.
+    Later releases are signed and notarized, and the kendex command is
+    unaffected either way.
   EOS
 
   zap trash: [


### PR DESCRIPTION
macOS installs from every channel end in Gatekeeper's "kendex is damaged" because release builds are ad-hoc signed. Tauri's bundler signs and notarizes on its own once the APPLE_* environment is present, so the lane is one staged key file plus env wiring — no new scripts.

Validated before landing, on a real Mac (mbp): p12 imports into a fresh keychain, `security find-identity` reports the identity valid, `codesign --options runtime --timestamp` + `--verify --strict` pass, and `notarytool history` authenticates with the staged API key. The seven APPLE_* repo secrets are set. Full end-to-end proof is the next tagged release (tag-push-only workflow); if notarization fails there, the lane fails loudly — unset secrets skip signing entirely, same gate as the updater keys.

Closes KEN-394.

https://claude.ai/code/session_019NErZGDXiEGLVudjU3i9zN