### PR TITLE
feat(guard): CHANGELOG entries over three lines fail the commit

### DIFF
--- a/review-bots.md
+++ b/review-bots.md
@@ -48,6 +48,17 @@ These are known, deliberate trade-offs. Raising them again is noise:
 - **Threads arriving after merge-queue admission are procedural, not a
   gate defect.** The handling is dequeue → fix → re-arm.
 
+- **No test-coverage asks for instruction markdown or for `tools/guard`
+  rules in a change that adds no guard test lane.** What a test must
+  cover is `.github/instructions/tests.instructions.md`; sentence-pinning
+  lints on markdown are banned.
+- **The PreToolUse commit hook reads git words, not shell expansion.**
+  Quoted flags, `flag=` assignments, aliases, and other spellings the shell
+  would have to expand are outside its contract; the installed git hook is
+  the guarantee in an armed repo.
+- **Windows-only resolution paths (PATHEXT, `.cmd` shims) are out of
+  scope until a Windows report exists.**
+
 ## Trust model (context, not a finding surface)
 
 Review evidence is formal review objects from trusted logins (or the other

--- a/skills/dev/workflows/dev-fix.md
+++ b/skills/dev/workflows/dev-fix.md
@@ -36,6 +36,8 @@ Evaluate each item in `Review items:` independently.
 
 Update architecture docs when a fix changes documented behavior. For **UI lifecycle or cache fixes** — cached or mirrored UI state, changed window or event handling — trace every invalidation and event-entry path before returning, prefer extending an existing listener over a parallel subscription for the same event family, and add regression coverage for the non-obvious paths you touched.
 
+Before a fix returns, grep for every other reader of the field, caller of the helper, or surface stating the rule the fix changed, and fix each one; name the sweep in the item reasoning. A fix at one site with its sibling untouched comes back as the next round.
+
 Note anything a fix revealed about deeper problems, and cite the decision ID or rule behind every skip.
 
 ---

--- a/skills/reviewer/SKILL.md
+++ b/skills/reviewer/SKILL.md
@@ -32,6 +32,7 @@ Shared contract for every review specialist; each agent's domain and probes live
 - Verify before reporting: if the repo contains the caller, config, test, or doc that settles a suspicion, read it. Never file "maybe X handles this" when X is in the repo.
 - Never trust a green check you have not seen fail: prove every instrument (grep scope, substitution, measurement, assertion) on a control input that must fail before trusting its pass. Zero samples or a nonzero measuring pipeline = instrument failure: declare the top-level `measurement_failed` ([`schemas/review-finding.md`](./schemas/review-finding.md)), cite no numbers. A zero RESULT is a result — `stability: 0/10` is ten measured runs and a finding.
 - **Report the class, not the instance.** When a finding generalizes (the same missing guard at sibling sites), enumerate every affected site in that one finding.
+- **A claim needs the line that makes it true.** For every sentence the diff adds to a `--help`, SKILL.md, CHANGELOG entry, comment, or diagnostic that states an order, a source set, an exit code, or a guarantee, find the code that makes it true. None found is a blocker; the claim is the defect, not the code.
 - Fewer high-conviction findings beat lists of nits.
 - Project decisions and architecture docs outrank generic heuristics. Do not contradict or re-litigate the decisions the delegation lists.
 - Do not re-verify what deterministic gates already enforce (preflight, size-ratchet, project lint/CI); cite gate output instead of re-deriving it.

--- a/tools/guard
+++ b/tools/guard
@@ -107,10 +107,13 @@ done <<<"$prose_files"
 # CHANGELOG entries are for consumers: one outcome each, one to three
 # source lines, a Breaking migration inline. Longer is an essay.
 if [ -f CHANGELOG.md ]; then
+  # An entry runs from its `- ` to the next column-0 line; every indented
+  # line and every blank line with more entry after it counts.
   long_entries=$(awk '
-    function flush() { if (n > 3) printf "  line %d: %d lines\n", start, n; n = 0 }
+    function flush() { if (n > 3) printf "  line %d: %d lines\n", start, n; n = 0; blank = 0 }
     /^- / { flush(); n = 1; start = NR; next }
-    /^  [^ ]/ { if (n) n++; next }
+    /^[ \t]*$/ { if (n) blank++; next }
+    /^[ \t]/ { if (n) { n += blank + 1; blank = 0 }; next }
     { flush() }
     END { flush() }' CHANGELOG.md)
   [ -n "$long_entries" ] && say "CHANGELOG.md entries run past three lines — state the outcome, keep the story out:

--- a/tools/guard
+++ b/tools/guard
@@ -104,6 +104,19 @@ while IFS= read -r f; do
 $(printf '%s\n' "$hits" | head -5 | sed 's/^/  /')"
 done <<<"$prose_files"
 
+# CHANGELOG entries are for consumers: one outcome each, one to three
+# source lines, a Breaking migration inline. Longer is an essay.
+if [ -f CHANGELOG.md ]; then
+  long_entries=$(awk '
+    function flush() { if (n > 3) printf "  line %d: %d lines\n", start, n; n = 0 }
+    /^- / { flush(); n = 1; start = NR; next }
+    /^  [^ ]/ { if (n) n++; next }
+    { flush() }
+    END { flush() }' CHANGELOG.md)
+  [ -n "$long_entries" ] && say "CHANGELOG.md entries run past three lines — state the outcome, keep the story out:
+$long_entries"
+fi
+
 # The size-ratchet baseline only tightens. Raising a row is a decision, not
 # a remedy: RATCHET_RAISE=1 on the commit says so out loud.
 if [ "${RATCHET_RAISE:-}" != "1" ] && git cat-file -e HEAD:tools/size-ratchet-baseline.tsv 2>/dev/null; then

--- a/tools/guard
+++ b/tools/guard
@@ -107,13 +107,15 @@ done <<<"$prose_files"
 # CHANGELOG entries are for consumers: one outcome each, one to three
 # source lines, a Breaking migration inline. Longer is an essay.
 if [ -f CHANGELOG.md ]; then
-  # An entry runs from its `- ` to the next column-0 line; every indented
-  # line and every blank line with more entry after it counts.
+  # An entry is every line from its list marker to the next marker, heading,
+  # or blank-then-unindented paragraph, whatever the indentation.
   long_entries=$(awk '
     function flush() { if (n > 3) printf "  line %d: %d lines\n", start, n; n = 0; blank = 0 }
-    /^- / { flush(); n = 1; start = NR; next }
+    { sub(/\r$/, "") }
+    /^[-*+] / { flush(); n = 1; start = NR; next }
+    /^#/ { flush(); next }
     /^[ \t]*$/ { if (n) blank++; next }
-    /^[ \t]/ { if (n) { n += blank + 1; blank = 0 }; next }
+    /^[ \t]/ || !blank { if (n) { n += blank + 1; blank = 0 }; next }
     { flush() }
     END { flush() }' CHANGELOG.md)
   [ -n "$long_entries" ] && say "CHANGELOG.md entries run past three lines — state the outcome, keep the story out:

--- a/tools/guard
+++ b/tools/guard
@@ -109,7 +109,7 @@ done <<<"$prose_files"
 if [ -f CHANGELOG.md ]; then
   # An entry is every line from its list marker to the next marker, heading,
   # or blank-then-unindented paragraph, whatever the indentation.
-  long_entries=$(awk '
+  if long_entries=$(awk '
     function flush() { if (n > 3) printf "  line %d: %d lines\n", start, n; n = 0; blank = 0 }
     { sub(/\r$/, "") }
     /^[-*+] / { flush(); n = 1; start = NR; next }
@@ -117,9 +117,12 @@ if [ -f CHANGELOG.md ]; then
     /^[ \t]*$/ { if (n) blank++; next }
     /^[ \t]/ || !blank { if (n) { n += blank + 1; blank = 0 }; next }
     { flush() }
-    END { flush() }' CHANGELOG.md)
-  [ -n "$long_entries" ] && say "CHANGELOG.md entries run past three lines — state the outcome, keep the story out:
+    END { flush() }' CHANGELOG.md 2>/dev/null); then
+    [ -n "$long_entries" ] && say "CHANGELOG.md entries run past three lines — state the outcome, keep the story out:
 $long_entries"
+  else
+    say "CHANGELOG.md is unreadable — the entry-length check could not run"
+  fi
 fi
 
 # The size-ratchet baseline only tightens. Raising a row is a decision, not

--- a/tools/tests/guard.test.sh
+++ b/tools/tests/guard.test.sh
@@ -205,6 +205,12 @@ run_guard RATCHET_RAISE=
   && ok "a four-line entry fails, naming its line and count" \
   || bad "a four-line entry fails, naming its line and count" "rc=$RC out=$OUT"
 case "$OUT" in *"line 7:"*) bad "the three-line entry is not named" "$OUT" ;; *) ok "the three-line entry is not named" ;; esac
+printf '# Changelog\n\n## [Unreleased]\n\n### Fixed\n\n- Four-space continuation\n    second\n    third\n    fourth.\n- Tab continuation\n\tsecond\n\tthird\n\tfourth.\n- Two paragraphs\n\n  second paragraph\n  third line.\n' >"$R/CHANGELOG.md"
+git -C "$R" add -A
+run_guard RATCHET_RAISE=
+[ "$RC" -ne 0 ] && case "$OUT" in *"line 7: 4 lines"*"line 11: 4 lines"*"line 15: 4 lines"*) true ;; *) false ;; esac \
+  && ok "deep-indented, tab-indented, and two-paragraph entries are counted whole" \
+  || bad "deep-indented, tab-indented, and two-paragraph entries are counted whole" "rc=$RC out=$OUT"
 printf '# Changelog\n\n## [Unreleased]\n\n### Fixed\n\n- A three-line entry\n  second line\n  third line.\n- One line.\n' >"$R/CHANGELOG.md"
 git -C "$R" add -A
 run_guard RATCHET_RAISE=

--- a/tools/tests/guard.test.sh
+++ b/tools/tests/guard.test.sh
@@ -197,5 +197,19 @@ run_guard RATCHET_RAISE=
 [ "$RC" -eq 0 ] && ok "a HEAD-baselined test row is grandfathered" \
   || bad "a HEAD-baselined test row is grandfathered" "rc=$RC out=$OUT"
 
+echo "=== a CHANGELOG entry past three lines fails; three passes ==="
+printf '# Changelog\n\n## [Unreleased]\n\n### Fixed\n\n- A three-line entry\n  second line\n  third line.\n- A four-line entry\n  second line\n  third line\n  fourth line.\n' >"$R/CHANGELOG.md"
+git -C "$R" add -A
+run_guard RATCHET_RAISE=
+[ "$RC" -ne 0 ] && case "$OUT" in *"CHANGELOG.md entries run past three lines"*"line 10: 4 lines"*) true ;; *) false ;; esac \
+  && ok "a four-line entry fails, naming its line and count" \
+  || bad "a four-line entry fails, naming its line and count" "rc=$RC out=$OUT"
+case "$OUT" in *"line 7:"*) bad "the three-line entry is not named" "$OUT" ;; *) ok "the three-line entry is not named" ;; esac
+printf '# Changelog\n\n## [Unreleased]\n\n### Fixed\n\n- A three-line entry\n  second line\n  third line.\n- One line.\n' >"$R/CHANGELOG.md"
+git -C "$R" add -A
+run_guard RATCHET_RAISE=
+[ "$RC" -eq 0 ] && ok "entries of one and three lines pass" \
+  || bad "entries of one and three lines pass" "rc=$RC out=$OUT"
+
 printf '\n%s passed, %s failed\n' "$PASS" "$FAIL"
 [ "$FAIL" -eq 0 ]

--- a/tools/tests/guard.test.sh
+++ b/tools/tests/guard.test.sh
@@ -205,12 +205,13 @@ run_guard RATCHET_RAISE=
   && ok "a four-line entry fails, naming its line and count" \
   || bad "a four-line entry fails, naming its line and count" "rc=$RC out=$OUT"
 case "$OUT" in *"line 7:"*) bad "the three-line entry is not named" "$OUT" ;; *) ok "the three-line entry is not named" ;; esac
-printf '# Changelog\n\n## [Unreleased]\n\n### Fixed\n\n- Four-space continuation\n    second\n    third\n    fourth.\n- Tab continuation\n\tsecond\n\tthird\n\tfourth.\n- Two paragraphs\n\n  second paragraph\n  third line.\n' >"$R/CHANGELOG.md"
+printf '# Changelog\n\n## [Unreleased]\n\n### Fixed\n\n- Four-space continuation\n    second\n    third\n    fourth.\n* Tab continuation\n\tsecond\n\tthird\n\tfourth.\n- Two paragraphs\r\n\r\n  second paragraph\r\n  third line.\r\n+ Lazy continuation\nsecond\nthird\nfourth.\n\nA paragraph after the list is not an entry.\n' >"$R/CHANGELOG.md"
 git -C "$R" add -A
 run_guard RATCHET_RAISE=
-[ "$RC" -ne 0 ] && case "$OUT" in *"line 7: 4 lines"*"line 11: 4 lines"*"line 15: 4 lines"*) true ;; *) false ;; esac \
-  && ok "deep-indented, tab-indented, and two-paragraph entries are counted whole" \
-  || bad "deep-indented, tab-indented, and two-paragraph entries are counted whole" "rc=$RC out=$OUT"
+[ "$RC" -ne 0 ] && case "$OUT" in *"line 7: 4 lines"*"line 11: 4 lines"*"line 15: 4 lines"*"line 19: 4 lines"*) true ;; *) false ;; esac \
+  && ok "deep-indented, tab-indented, CRLF two-paragraph, and lazy entries under any marker are counted whole" \
+  || bad "deep-indented, tab-indented, CRLF two-paragraph, and lazy entries under any marker are counted whole" "rc=$RC out=$OUT"
+case "$OUT" in *"line 19: 6 lines"*|*"line 24"*) bad "a paragraph after the list is not counted into the last entry" "$OUT" ;; *) ok "a paragraph after the list is not counted into the last entry" ;; esac
 printf '# Changelog\n\n## [Unreleased]\n\n### Fixed\n\n- A three-line entry\n  second line\n  third line.\n- One line.\n' >"$R/CHANGELOG.md"
 git -C "$R" add -A
 run_guard RATCHET_RAISE=

--- a/tools/tests/guard.test.sh
+++ b/tools/tests/guard.test.sh
@@ -217,6 +217,14 @@ git -C "$R" add -A
 run_guard RATCHET_RAISE=
 [ "$RC" -eq 0 ] && ok "entries of one and three lines pass" \
   || bad "entries of one and three lines pass" "rc=$RC out=$OUT"
+if [ "$(id -u)" -ne 0 ]; then
+  chmod 000 "$R/CHANGELOG.md"
+  run_guard RATCHET_RAISE=
+  chmod 644 "$R/CHANGELOG.md"
+  [ "$RC" -ne 0 ] && case "$OUT" in *"CHANGELOG.md is unreadable"*) true ;; *) false ;; esac \
+    && ok "an unreadable CHANGELOG fails closed, naming the check that could not run" \
+    || bad "an unreadable CHANGELOG fails closed, naming the check that could not run" "rc=$RC out=$OUT"
+fi
 
 printf '\n%s passed, %s failed\n' "$PASS" "$FAIL"
 [ "$FAIL" -eq 0 ]


### PR DESCRIPTION
From a classification of ~113 bot findings across the last 15 merged PRs (top accepted classes: a doc claim the code contradicts, 18; CHANGELOG entry wrong or over-long, 14 fixed + 5 tracked; a fix at one site with its sibling missed, 15).

- `tools/guard`: a CHANGELOG entry running past three source lines fails the commit, naming the line. One awk predicate; the whole current file passes. This alone would have pre-empted the 24-entry round on #1619. Must-fail and must-pass cases in `tools/tests/guard.test.sh`.
- reviewer ethos: one line — a sentence the diff adds to help/SKILL/CHANGELOG/comment/diagnostic that states an order, source set, exit code, or guarantee needs the line of code that makes it true (the class #1626 just repeated).
- dev-fix: one line — sweep every sibling reader/caller/surface before returning a fix, name the sweep in the reasoning (13 of #1617's 28 findings were this).
- review-bots.md: three repeatedly declined classes named under accepted residuals (coverage asks on instruction markdown / guard rules, shell-expansion bypass spellings, Windows-only paths) so the bots stop raising them.

No new machinery beyond the one predicate.

https://claude.ai/code/session_01KgYaaoowACnzrRR7quwHrD