### PR TITLE
fix(ui): Library rows get a keyboard path and a drag guard (KEN-496)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -76,6 +76,13 @@ an outside contributor.
   and dialogs ask in the words of the button that opened them.
 
 ### Fixed
+- The Library can now be worked from the keyboard: each row's package name
+  is a real button, so Tab reaches every package and Enter opens it. The
+  rows used to react only to a mouse click. Dragging across a row's
+  description to copy it no longer opens the package and loses the
+  selection — in the Library, in a marketplace's package list, and on the
+  Projects page's cards, which share one guard. A name's own button always
+  opens, mouse or keyboard.
 - An apply is no longer refused as "scope is busy" while nothing else
   runs: locks release explicitly when an apply finishes instead of waiting
   on a file a just-launched program still held open. Same fix for downloads.

--- a/ui/src/components/harnesses/harness-row.test.tsx
+++ b/ui/src/components/harnesses/harness-row.test.tsx
@@ -2,7 +2,7 @@
 import userEvent from "@testing-library/user-event";
 import { act } from "react";
 import { createRoot, type Root } from "react-dom/client";
-import { afterEach, describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import { harnessName } from "@/lib/labels";
 import { showEverythingLabel } from "@/lib/show-everything-label";
 import { useNavStore } from "@/stores/nav";
@@ -20,6 +20,7 @@ afterEach(() => {
   });
   mounted.length = 0;
   document.body.replaceChildren();
+  vi.restoreAllMocks();
 });
 
 const mount = (detectedRoot: string | null) => {
@@ -61,6 +62,34 @@ describe("the harness row's name", () => {
     expect(nav.libraryFilter?.harness).toBe("claude");
     expect(nav.libraryFilter?.kind).toBeUndefined();
     expect(nav.libraryFilter?.scope).toBeUndefined();
+  });
+
+  it("lets a drag across the name keep its selection", async () => {
+    const host = mount("/home/u/.claude");
+    const name = host.querySelector<HTMLButtonElement>(
+      `button[aria-label="${label}"]`,
+    );
+    if (!name) throw new Error("no show-everything button rendered");
+    // What a copy-drag leaves behind at mouse-up: an uncollapsed selection.
+    vi.spyOn(window, "getSelection").mockReturnValue({
+      isCollapsed: false,
+    } as Selection);
+    await userEvent.click(name);
+    expect(useNavStore.getState().page).toBe("home");
+  });
+
+  it("still opens from the keyboard while a selection stands", async () => {
+    const host = mount("/home/u/.claude");
+    const name = host.querySelector<HTMLButtonElement>(
+      `button[aria-label="${label}"]`,
+    );
+    if (!name) throw new Error("no show-everything button rendered");
+    vi.spyOn(window, "getSelection").mockReturnValue({
+      isCollapsed: false,
+    } as Selection);
+    name.focus();
+    await userEvent.keyboard("{Enter}");
+    expect(useNavStore.getState().page).toBe("library");
   });
 
   // One phrase for one affordance: the project card announces its name

--- a/ui/src/components/harnesses/harness-row.test.tsx
+++ b/ui/src/components/harnesses/harness-row.test.tsx
@@ -64,18 +64,20 @@ describe("the harness row's name", () => {
     expect(nav.libraryFilter?.scope).toBeUndefined();
   });
 
-  it("lets a drag across the name keep its selection", async () => {
+  it("opens on a click while a selection stands elsewhere", async () => {
     const host = mount("/home/u/.claude");
     const name = host.querySelector<HTMLButtonElement>(
       `button[aria-label="${label}"]`,
     );
     if (!name) throw new Error("no show-everything button rendered");
-    // What a copy-drag leaves behind at mouse-up: an uncollapsed selection.
+    // A completed click on the button is intent to open even while text
+    // stands selected somewhere — on WebKit a button click leaves the
+    // selection be, and a guard here made this a dead click.
     vi.spyOn(window, "getSelection").mockReturnValue({
       isCollapsed: false,
     } as Selection);
     await userEvent.click(name);
-    expect(useNavStore.getState().page).toBe("home");
+    expect(useNavStore.getState().page).toBe("library");
   });
 
   it("still opens from the keyboard while a selection stands", async () => {

--- a/ui/src/components/harnesses/project-card.tsx
+++ b/ui/src/components/harnesses/project-card.tsx
@@ -4,6 +4,7 @@ import { ShowEverythingButton } from "@/components/harnesses/show-everything-but
 import { KindCountBadges } from "@/components/kind-count-badges";
 import { Badge } from "@/components/ui/badge";
 import { Card } from "@/components/ui/card";
+import { clickAsksToOpen } from "@/lib/click-asks-to-open";
 
 /**
  * One place a setup applies — Personal, or a project folder. Personal and a
@@ -44,13 +45,9 @@ export function ProjectCard({
     <Card
       // A shortcut for the mouse, on top of the name's own button: the card
       // reads as one target, so clicking its empty space should do what the
-      // card is for. Every control inside it means something else and has
-      // already answered the click; a drag that ends here was someone
-      // keeping the path, not asking to leave the page.
+      // card is for.
       onClick={(event) => {
-        if ((event.target as HTMLElement).closest("button")) return;
-        if (window.getSelection()?.isCollapsed === false) return;
-        onOpen();
+        if (clickAsksToOpen(event)) onOpen();
       }}
       className="cursor-pointer gap-3 py-4 hover:bg-accent/40"
     >

--- a/ui/src/components/harnesses/show-everything-button.tsx
+++ b/ui/src/components/harnesses/show-everything-button.tsx
@@ -1,3 +1,4 @@
+import { clickEndedSelection } from "@/lib/click-asks-to-open";
 import { showEverythingLabel } from "@/lib/show-everything-label";
 
 /**
@@ -22,7 +23,11 @@ export function ShowEverythingButton({
   return (
     <button
       type="button"
-      onClick={onOpen}
+      // Fires before any surface guard around it, so it declines a
+      // selection-ending drag itself.
+      onClick={(event) => {
+        if (!clickEndedSelection(event)) onOpen();
+      }}
       aria-label={showEverythingLabel(name, path)}
       className="truncate text-sm font-medium hover:underline"
     >

--- a/ui/src/components/harnesses/show-everything-button.tsx
+++ b/ui/src/components/harnesses/show-everything-button.tsx
@@ -1,4 +1,3 @@
-import { clickEndedSelection } from "@/lib/click-asks-to-open";
 import { showEverythingLabel } from "@/lib/show-everything-label";
 
 /**
@@ -23,11 +22,7 @@ export function ShowEverythingButton({
   return (
     <button
       type="button"
-      // Fires before any surface guard around it, so it declines a
-      // selection-ending drag itself.
-      onClick={(event) => {
-        if (!clickEndedSelection(event)) onOpen();
-      }}
+      onClick={onOpen}
       aria-label={showEverythingLabel(name, path)}
       className="truncate text-sm font-medium hover:underline"
     >

--- a/ui/src/components/library/installed-row.test.tsx
+++ b/ui/src/components/library/installed-row.test.tsx
@@ -81,7 +81,7 @@ afterEach(() => {
   vi.restoreAllMocks();
 });
 
-const mount = (forkedIn: Scope[] = []) => {
+const mount = (forkedIn: Scope[] = [], mark: PlaceMark | null = null) => {
   const onOpen = vi.fn();
   // A tr needs a table around it for the DOM to keep the row a row.
   const host = document.body.appendChild(document.createElement("table"));
@@ -93,7 +93,7 @@ const mount = (forkedIn: Scope[] = []) => {
         <InstalledRow
           group={group}
           origin={null}
-          mark={null}
+          mark={mark}
           forkedIn={forkedIn}
           onOpen={onOpen}
         />
@@ -134,6 +134,17 @@ describe("opening a package from its Library row", () => {
     expect(onOpen).toHaveBeenCalledWith();
   });
 
+  it("lets a drag across the name keep its selection", async () => {
+    const { host, onOpen } = mount();
+    // The name button fires before the row's guard, so it has to decline
+    // the selection-ending click itself, not rely on the row.
+    vi.spyOn(window, "getSelection").mockReturnValue({
+      isCollapsed: false,
+    } as Selection);
+    await userEvent.click(nameButton(host));
+    expect(onOpen).not.toHaveBeenCalled();
+  });
+
   it("lets a drag across the row keep its selection", async () => {
     const { host, onOpen } = mount();
     // What a copy-drag leaves behind at mouse-up: an uncollapsed selection.
@@ -142,6 +153,21 @@ describe("opening a package from its Library row", () => {
     } as Selection);
     await userEvent.click(host.querySelectorAll("td")[1]);
     expect(onOpen).not.toHaveBeenCalled();
+  });
+
+  it("opens the mark's own place from its button, and only that", async () => {
+    const { host, onOpen } = mount([], {
+      label: "Customized in vg · 1 of 2 places",
+      goTo: VG,
+      why: "settings",
+    });
+    const markButton = Array.from(host.querySelectorAll("button")).find((b) =>
+      b.textContent?.startsWith("Customized"),
+    );
+    if (!markButton) throw new Error("no mark button rendered");
+    await userEvent.click(markButton);
+    expect(onOpen).toHaveBeenCalledTimes(1);
+    expect(onOpen).toHaveBeenCalledWith(VG);
   });
 
   it("opens the fork's own place from its badge, and only that", async () => {

--- a/ui/src/components/library/installed-row.test.tsx
+++ b/ui/src/components/library/installed-row.test.tsx
@@ -1,6 +1,11 @@
+// @vitest-environment jsdom
+import userEvent from "@testing-library/user-event";
+import { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
 import { renderToStaticMarkup } from "react-dom/server";
-import { describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import type { Scope } from "@/bindings";
+import { FORKED_BADGE_LABEL } from "@/lib/copy";
 import { groupItems } from "@/lib/derive";
 import type { PlaceMark } from "@/lib/place-marks";
 import { InstalledRow } from "./installed-row";
@@ -61,5 +66,92 @@ describe("the row's customized mark", () => {
   it("names the place each fork belongs to", () => {
     const shown = render(null, [VG]);
     expect(shown).toContain("in vg");
+  });
+});
+
+// Whether a click reaches the row, and what a keypress lands on, are
+// questions about a live DOM that static markup cannot answer.
+const mounted: Root[] = [];
+afterEach(() => {
+  act(() => {
+    for (const root of mounted) root.unmount();
+  });
+  mounted.length = 0;
+  document.body.replaceChildren();
+  vi.restoreAllMocks();
+});
+
+const mount = (forkedIn: Scope[] = []) => {
+  const onOpen = vi.fn();
+  // A tr needs a table around it for the DOM to keep the row a row.
+  const host = document.body.appendChild(document.createElement("table"));
+  const root = createRoot(host);
+  mounted.push(root);
+  act(() =>
+    root.render(
+      <tbody>
+        <InstalledRow
+          group={group}
+          origin={null}
+          mark={null}
+          forkedIn={forkedIn}
+          onOpen={onOpen}
+        />
+      </tbody>,
+    ),
+  );
+  return { host, onOpen };
+};
+
+const nameButton = (host: HTMLElement) => {
+  const name = Array.from(host.querySelectorAll("button")).find(
+    (b) => b.textContent === "gh",
+  );
+  if (!name) throw new Error("the package name is not a button");
+  return name;
+};
+
+describe("opening a package from its Library row", () => {
+  it("reaches the keyboard: the name is a button and Enter opens it", async () => {
+    const { host, onOpen } = mount();
+    nameButton(host).focus();
+    await userEvent.keyboard("{Enter}");
+    expect(onOpen).toHaveBeenCalledTimes(1);
+    expect(onOpen).toHaveBeenCalledWith();
+  });
+
+  it("opens once from the name, not a second time from the row under it", async () => {
+    const { host, onOpen } = mount();
+    await userEvent.click(nameButton(host));
+    expect(onOpen).toHaveBeenCalledTimes(1);
+  });
+
+  it("keeps the whole row as the mouse shortcut", async () => {
+    const { host, onOpen } = mount();
+    const typeCell = host.querySelectorAll("td")[1];
+    await userEvent.click(typeCell);
+    expect(onOpen).toHaveBeenCalledTimes(1);
+    expect(onOpen).toHaveBeenCalledWith();
+  });
+
+  it("lets a drag across the row keep its selection", async () => {
+    const { host, onOpen } = mount();
+    // What a copy-drag leaves behind at mouse-up: an uncollapsed selection.
+    vi.spyOn(window, "getSelection").mockReturnValue({
+      isCollapsed: false,
+    } as Selection);
+    await userEvent.click(host.querySelectorAll("td")[1]);
+    expect(onOpen).not.toHaveBeenCalled();
+  });
+
+  it("opens the fork's own place from its badge, and only that", async () => {
+    const { host, onOpen } = mount([VG]);
+    const badge = Array.from(host.querySelectorAll("button")).find((b) =>
+      b.textContent?.startsWith(FORKED_BADGE_LABEL),
+    );
+    if (!badge) throw new Error("no forked badge rendered");
+    await userEvent.click(badge);
+    expect(onOpen).toHaveBeenCalledTimes(1);
+    expect(onOpen).toHaveBeenCalledWith(VG);
   });
 });

--- a/ui/src/components/library/installed-row.test.tsx
+++ b/ui/src/components/library/installed-row.test.tsx
@@ -134,6 +134,18 @@ describe("opening a package from its Library row", () => {
     expect(onOpen).toHaveBeenCalledWith();
   });
 
+  it("keeps Enter working while a selection stands elsewhere", async () => {
+    const { host, onOpen } = mount();
+    // Keyboard activation arrives as a click with detail 0 and leaves the
+    // document's selection standing — it is always asking to open.
+    vi.spyOn(window, "getSelection").mockReturnValue({
+      isCollapsed: false,
+    } as Selection);
+    nameButton(host).focus();
+    await userEvent.keyboard("{Enter}");
+    expect(onOpen).toHaveBeenCalledTimes(1);
+  });
+
   it("lets a drag across the name keep its selection", async () => {
     const { host, onOpen } = mount();
     // The name button fires before the row's guard, so it has to decline

--- a/ui/src/components/library/installed-row.test.tsx
+++ b/ui/src/components/library/installed-row.test.tsx
@@ -146,15 +146,16 @@ describe("opening a package from its Library row", () => {
     expect(onOpen).toHaveBeenCalledTimes(1);
   });
 
-  it("lets a drag across the name keep its selection", async () => {
+  it("opens from the name while a selection stands elsewhere", async () => {
     const { host, onOpen } = mount();
-    // The name button fires before the row's guard, so it has to decline
-    // the selection-ending click itself, not rely on the row.
+    // A completed click on the button is intent to open even while text
+    // stands selected somewhere — on WebKit a button click leaves the
+    // selection be, and a guard here made this a dead click.
     vi.spyOn(window, "getSelection").mockReturnValue({
       isCollapsed: false,
     } as Selection);
     await userEvent.click(nameButton(host));
-    expect(onOpen).not.toHaveBeenCalled();
+    expect(onOpen).toHaveBeenCalledTimes(1);
   });
 
   it("lets a drag across the row keep its selection", async () => {

--- a/ui/src/components/library/installed-row.tsx
+++ b/ui/src/components/library/installed-row.tsx
@@ -9,6 +9,7 @@ import {
   TooltipContent,
   TooltipTrigger,
 } from "@/components/ui/tooltip";
+import { clickAsksToOpen } from "@/lib/click-asks-to-open";
 import { bundledWithLabel, FORKED_BADGE_LABEL, vendorHelp } from "@/lib/copy";
 import { STATUS_LABELS } from "@/lib/copy-customize";
 import {
@@ -69,7 +70,15 @@ export function InstalledRow({
     .join(", ");
 
   return (
-    <TableRow onClick={() => onOpen()} className="cursor-pointer">
+    <TableRow
+      // A shortcut for the mouse, on top of the name's own button: the row
+      // reads as one target, so clicking any of its cells should open the
+      // package.
+      onClick={(event) => {
+        if (clickAsksToOpen(event)) onOpen();
+      }}
+      className="cursor-pointer"
+    >
       {/* Cells are nowrap by default; the description is the one column that
           wants to wrap rather than run out of the row and get cut mid-word. */}
       <TableCell className="max-w-[22rem] font-medium whitespace-normal">
@@ -87,7 +96,16 @@ export function InstalledRow({
           </span>
           <span className="min-w-0">
             <span className="flex items-center gap-1.5">
-              <span className="block truncate">{displayName}</span>
+              {/* The keyboard's one way into the row: a row is not
+                  focusable, so without a real control here every package
+                  in the Library is mouse-only. */}
+              <button
+                type="button"
+                onClick={() => onOpen()}
+                className="block min-w-0 truncate text-left hover:underline"
+              >
+                {displayName}
+              </button>
               {/* One badge per place. A single "Forked" over several tells
                   the reader it happened and not where, and leaves nothing
                   to open — a fork belongs to the place it was made in. */}
@@ -97,13 +115,7 @@ export function InstalledRow({
                   variant="outline"
                   className="cursor-pointer"
                   render={
-                    <button
-                      type="button"
-                      onClick={(event) => {
-                        event.stopPropagation();
-                        onOpen(where);
-                      }}
-                    >
+                    <button type="button" onClick={() => onOpen(where)}>
                       {`${FORKED_BADGE_LABEL} in ${placeName(where, scopes)}`}
                     </button>
                   }
@@ -122,10 +134,7 @@ export function InstalledRow({
             {mark?.goTo ? (
               <button
                 type="button"
-                onClick={(event) => {
-                  event.stopPropagation();
-                  onOpen(mark.goTo ?? undefined);
-                }}
+                onClick={() => onOpen(mark.goTo ?? undefined)}
                 className="mt-0.5 block text-left text-xs text-customized hover:underline"
               >
                 {mark.label}

--- a/ui/src/components/library/installed-row.tsx
+++ b/ui/src/components/library/installed-row.tsx
@@ -9,7 +9,7 @@ import {
   TooltipContent,
   TooltipTrigger,
 } from "@/components/ui/tooltip";
-import { clickAsksToOpen } from "@/lib/click-asks-to-open";
+import { clickAsksToOpen, clickEndedSelection } from "@/lib/click-asks-to-open";
 import { bundledWithLabel, FORKED_BADGE_LABEL, vendorHelp } from "@/lib/copy";
 import { STATUS_LABELS } from "@/lib/copy-customize";
 import {
@@ -97,11 +97,15 @@ export function InstalledRow({
           <span className="min-w-0">
             <span className="flex items-center gap-1.5">
               {/* The keyboard's one way into the row: a row is not
-                  focusable, so without a real control here every package
-                  in the Library is mouse-only. */}
+                  focusable, so without a real control here the row's
+                  default open — and any package without a fork badge or
+                  mark — is mouse-only. Its click fires before the row's
+                  guard, so it declines a selection-ending drag itself. */}
               <button
                 type="button"
-                onClick={() => onOpen()}
+                onClick={() => {
+                  if (!clickEndedSelection()) onOpen();
+                }}
                 className="block min-w-0 truncate text-left hover:underline"
               >
                 {displayName}

--- a/ui/src/components/library/installed-row.tsx
+++ b/ui/src/components/library/installed-row.tsx
@@ -103,8 +103,8 @@ export function InstalledRow({
                   guard, so it declines a selection-ending drag itself. */}
               <button
                 type="button"
-                onClick={() => {
-                  if (!clickEndedSelection()) onOpen();
+                onClick={(event) => {
+                  if (!clickEndedSelection(event)) onOpen();
                 }}
                 className="block min-w-0 truncate text-left hover:underline"
               >

--- a/ui/src/components/library/installed-row.tsx
+++ b/ui/src/components/library/installed-row.tsx
@@ -9,7 +9,7 @@ import {
   TooltipContent,
   TooltipTrigger,
 } from "@/components/ui/tooltip";
-import { clickAsksToOpen, clickEndedSelection } from "@/lib/click-asks-to-open";
+import { clickAsksToOpen } from "@/lib/click-asks-to-open";
 import { bundledWithLabel, FORKED_BADGE_LABEL, vendorHelp } from "@/lib/copy";
 import { STATUS_LABELS } from "@/lib/copy-customize";
 import {
@@ -99,13 +99,12 @@ export function InstalledRow({
               {/* The keyboard's one way into the row: a row is not
                   focusable, so without a real control here the row's
                   default open — and any package without a fork badge or
-                  mark — is mouse-only. Its click fires before the row's
-                  guard, so it declines a selection-ending drag itself. */}
+                  mark — is mouse-only. No selection guard here: a
+                  completed click on a button is always intent, and the
+                  row's own guard declines the drags. */}
               <button
                 type="button"
-                onClick={(event) => {
-                  if (!clickEndedSelection(event)) onOpen();
-                }}
+                onClick={() => onOpen()}
                 className="block min-w-0 truncate text-left hover:underline"
               >
                 {displayName}

--- a/ui/src/components/marketplaces/packages-table.tsx
+++ b/ui/src/components/marketplaces/packages-table.tsx
@@ -16,6 +16,7 @@ import {
   TooltipContent,
   TooltipTrigger,
 } from "@/components/ui/tooltip";
+import { clickAsksToOpen } from "@/lib/click-asks-to-open";
 import { SAFETY_DOT_UNCHECKED, safetyDotWords } from "@/lib/copy-safety";
 import { kindIcon } from "@/lib/kind-icon";
 import { kindLabel, packageDisplayName } from "@/lib/labels";
@@ -38,13 +39,6 @@ const VERDICT_TONES: Record<Verdict, "good" | "warning" | "critical"> = {
   warn: "warning",
   block: "critical",
 };
-
-/** What a row click means something other than "open this package". A row is
- *  a shortcut to the page, so it carries only what the row itself says; every
- *  control in it has already answered the click with its own meaning. A
- *  tooltip popup counts as one of them wherever the browser draws it, because
- *  React sends its clicks back through the row that owns it. */
-const ROW_CONTROLS = 'a, button, input, [data-slot="tooltip-content"]';
 
 /** The one table of offered packages — the Packages tab across every
  * subscription and a marketplace detail's own list are both this. */
@@ -106,7 +100,7 @@ function PackageRow({
   }, [want, catalog, row.kind, row.name]);
 
   const open = (event: MouseEvent<HTMLTableRowElement>) => {
-    if ((event.target as HTMLElement).closest(ROW_CONTROLS)) return;
+    if (!clickAsksToOpen(event)) return;
     goToAvailablePackage({ catalog, kind: row.kind, name: row.name });
   };
 

--- a/ui/src/lib/click-asks-to-open.ts
+++ b/ui/src/lib/click-asks-to-open.ts
@@ -10,25 +10,19 @@ const CONTROLS =
  * Whether a click on a whole-surface shortcut — a project card, a Library
  * row, a marketplace row — is asking to open it. False when a control
  * inside the surface already answered the click, and false when the click
- * ended a text selection: a drag across the name was someone keeping the
- * text, not asking to leave the page. One predicate for every such surface,
- * so the guards cannot drift apart.
+ * ended a text selection: a drag across the surface's text was someone
+ * keeping the text, not asking to leave the page. Keyboard and assistive
+ * activation arrive as clicks with detail 0 and leave any standing
+ * selection untouched, so they always ask. One predicate for every such
+ * surface, so the guards cannot drift apart.
+ *
+ * Surfaces only, never a control inside one: a completed click on a real
+ * button — mousedown and mouseup both on it — is unambiguous intent to
+ * activate, and guarding it turns a standing selection elsewhere into a
+ * dead click on WebKit, where a button click leaves the selection be.
  */
 export function clickAsksToOpen(event: MouseEvent<HTMLElement>): boolean {
   if ((event.target as HTMLElement).closest(CONTROLS)) return false;
-  return !clickEndedSelection(event);
-}
-
-/**
- * Whether the click that just landed ended a text selection. Keyboard and
- * assistive activation arrive as clicks too, with detail 0, and they leave
- * any standing selection untouched — those always ask to open; only a
- * mouse click that left an uncollapsed selection is someone keeping the
- * text. A control inside the surface needs this half of the guard on its
- * own: its click is always its answer, but it fires before the surface's
- * guard can decline.
- */
-export function clickEndedSelection(event: MouseEvent<HTMLElement>): boolean {
-  if (event.detail === 0) return false;
-  return window.getSelection()?.isCollapsed === false;
+  if (event.detail === 0) return true;
+  return window.getSelection()?.isCollapsed !== false;
 }

--- a/ui/src/lib/click-asks-to-open.ts
+++ b/ui/src/lib/click-asks-to-open.ts
@@ -1,0 +1,15 @@
+import type { MouseEvent } from "react";
+
+/**
+ * Whether a click on a whole-surface shortcut — a project card, a Library
+ * row — is asking to open it. False when a control inside the surface
+ * already answered the click, and false when the click ended a text
+ * selection: a drag across the name was someone keeping the text, not
+ * asking to leave the page. One predicate for every such surface, so the
+ * two guards cannot drift apart.
+ */
+export function clickAsksToOpen(event: MouseEvent<HTMLElement>): boolean {
+  if ((event.target as HTMLElement).closest("button")) return false;
+  if (window.getSelection()?.isCollapsed === false) return false;
+  return true;
+}

--- a/ui/src/lib/click-asks-to-open.ts
+++ b/ui/src/lib/click-asks-to-open.ts
@@ -16,15 +16,19 @@ const CONTROLS =
  */
 export function clickAsksToOpen(event: MouseEvent<HTMLElement>): boolean {
   if ((event.target as HTMLElement).closest(CONTROLS)) return false;
-  return !clickEndedSelection();
+  return !clickEndedSelection(event);
 }
 
 /**
- * Whether the click that just landed ended a text selection. A control
- * inside the surface needs this half of the guard on its own: its click is
- * always its answer, but a drag across its label was someone keeping the
- * text, and the control fires before the surface's guard can decline.
+ * Whether the click that just landed ended a text selection. Keyboard and
+ * assistive activation arrive as clicks too, with detail 0, and they leave
+ * any standing selection untouched — those always ask to open; only a
+ * mouse click that left an uncollapsed selection is someone keeping the
+ * text. A control inside the surface needs this half of the guard on its
+ * own: its click is always its answer, but it fires before the surface's
+ * guard can decline.
  */
-export function clickEndedSelection(): boolean {
+export function clickEndedSelection(event: MouseEvent<HTMLElement>): boolean {
+  if (event.detail === 0) return false;
   return window.getSelection()?.isCollapsed === false;
 }

--- a/ui/src/lib/click-asks-to-open.ts
+++ b/ui/src/lib/click-asks-to-open.ts
@@ -1,15 +1,30 @@
 import type { MouseEvent } from "react";
 
+/** What answers a click before the surface may: any real control, plus a
+ *  tooltip popup, which counts wherever the browser draws it because React
+ *  sends its clicks back through the surface that owns it. */
+const CONTROLS =
+  'a, button, input, select, textarea, [role="button"], [data-slot="tooltip-content"]';
+
 /**
  * Whether a click on a whole-surface shortcut — a project card, a Library
- * row — is asking to open it. False when a control inside the surface
- * already answered the click, and false when the click ended a text
- * selection: a drag across the name was someone keeping the text, not
- * asking to leave the page. One predicate for every such surface, so the
- * two guards cannot drift apart.
+ * row, a marketplace row — is asking to open it. False when a control
+ * inside the surface already answered the click, and false when the click
+ * ended a text selection: a drag across the name was someone keeping the
+ * text, not asking to leave the page. One predicate for every such surface,
+ * so the guards cannot drift apart.
  */
 export function clickAsksToOpen(event: MouseEvent<HTMLElement>): boolean {
-  if ((event.target as HTMLElement).closest("button")) return false;
-  if (window.getSelection()?.isCollapsed === false) return false;
-  return true;
+  if ((event.target as HTMLElement).closest(CONTROLS)) return false;
+  return !clickEndedSelection();
+}
+
+/**
+ * Whether the click that just landed ended a text selection. A control
+ * inside the surface needs this half of the guard on its own: its click is
+ * always its answer, but a drag across its label was someone keeping the
+ * text, and the control fires before the surface's guard can decline.
+ */
+export function clickEndedSelection(): boolean {
+  return window.getSelection()?.isCollapsed === false;
 }


### PR DESCRIPTION
## Summary
- Every Library row's package name is a real button: Tab reaches every package and Enter opens it. Rows used to react only to a mouse click.
- Whole-surface click shortcuts — Library rows, marketplace package lists, and the Projects page's cards — share one guard, `clickAsksToOpen`: a click that ended a text selection or landed on an inner control no longer opens the surface. The marketplace table's hand-rolled guard is deleted.
- The guard is event-aware in one place: keyboard activation (`detail === 0`) always opens, and a name's own button always opens, mouse or keyboard, even while text is selected elsewhere (buttons never dead-click on a standing selection — WebKit preserves selections across button clicks).

## Completed Issues
- Closes KEN-496 - Library rows need a keyboard path and a drag guard

## Test Plan
- `installed-row.test.tsx` (10) and `packages-table.test.tsx`: live-DOM jsdom tests — Enter opens, name click fires once, drag-ending clicks on the surface don't open, standing-selection clicks on buttons do open (WebKit dead-click regression), fork badge and mark open only their own place.
- reviewer-test mutation passes: cycle 1 4/4, cycle 2 6/6, cycle 4 guard-reinstatement mutant killed; stability 10/10 at 64 threads each round.
- tools/guard green on the restacked tree (tsc, biome, 523 vitest); real-browser check in the mock app: Enter on a focused name navigates with a selection standing.
