### PR TITLE
fix(skills): worktree push refuses a flag it does not recognize (KEN-570)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -84,6 +84,9 @@ an outside contributor.
 - The Library works from the keyboard: each package name is a button, so
   Tab reaches it and Enter opens it. Dragging across text to copy it no
   longer opens anything in the Library, a marketplace list, or a Projects card.
+- The worktree skill's `push` refuses a flag it does not recognize. A typo
+  such as `--no-rebse` used to be dropped, and the push ran with default
+  behavior nobody asked for.
 - An apply is no longer refused as "scope is busy" while nothing else
   runs: locks release explicitly when an apply finishes instead of waiting
   on a file a just-launched program still held open. Same fix for downloads.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -84,9 +84,9 @@ an outside contributor.
 - The Library works from the keyboard: each package name is a button, so
   Tab reaches it and Enter opens it. Dragging across text to copy it no
   longer opens anything in the Library, a marketplace list, or a Projects card.
-- The worktree skill's `push` refuses a flag it does not recognize. A typo
-  such as `--no-rebse` used to be dropped, and the push ran with default
-  behavior nobody asked for.
+- The worktree skill's `push` refuses a flag it does not recognize and an
+  empty target, rather than pushing the current checkout with default
+  behavior nobody asked for. `push --check-args` validates arguments alone.
 - An apply is no longer refused as "scope is busy" while nothing else
   runs: locks release explicitly when an apply finishes instead of waiting
   on a file a just-launched program still held open. Same fix for downloads.

--- a/kendex-reviews.toml
+++ b/kendex-reviews.toml
@@ -15,12 +15,12 @@ reason = "intended"
 dismissed-at = "2026-08-23T17:07:51Z"
 
 [reviews."skill:orch"]
-review-hash = "c366812363af1257be9d6110b0dcda57234766cc0180c20cc358f6b88bf120fa"
+review-hash = "ab148492f919b0f906e20f5fb6c15183af441dd3afae594f9574758b1b6a5dc2"
 ruleset = 3
 
 [reviews."skill:orch".dismissed.c8e66ac505c95a7a]
 reason = "wrong-call"
-dismissed-at = "2026-08-25T04:40:28Z"
+dismissed-at = "2026-08-25T05:19:07Z"
 
 [reviews."skill:review-gate"]
 review-hash = "ad84d44fcd9bdad9eee80c2df76976be2a0a56c9a2c7ad6fad2e386c26b2d6a8"

--- a/kendex-reviews.toml
+++ b/kendex-reviews.toml
@@ -15,12 +15,12 @@ reason = "intended"
 dismissed-at = "2026-08-23T17:07:51Z"
 
 [reviews."skill:orch"]
-review-hash = "7ff2ff5feda45cee17dbd7e23f71b1a9b69a2cc281901edb9f13a049166b3356"
+review-hash = "c366812363af1257be9d6110b0dcda57234766cc0180c20cc358f6b88bf120fa"
 ruleset = 3
 
 [reviews."skill:orch".dismissed.c8e66ac505c95a7a]
 reason = "wrong-call"
-dismissed-at = "2026-08-25T01:24:05Z"
+dismissed-at = "2026-08-25T04:40:28Z"
 
 [reviews."skill:review-gate"]
 review-hash = "ad84d44fcd9bdad9eee80c2df76976be2a0a56c9a2c7ad6fad2e386c26b2d6a8"

--- a/kendex-reviews.toml
+++ b/kendex-reviews.toml
@@ -15,12 +15,12 @@ reason = "intended"
 dismissed-at = "2026-08-23T17:07:51Z"
 
 [reviews."skill:orch"]
-review-hash = "ab148492f919b0f906e20f5fb6c15183af441dd3afae594f9574758b1b6a5dc2"
+review-hash = "5f4c873e6d128b4aa084a7e7ad6a821309974ac5f4c3cc274f9e997c43a1097b"
 ruleset = 3
 
 [reviews."skill:orch".dismissed.c8e66ac505c95a7a]
 reason = "wrong-call"
-dismissed-at = "2026-08-25T05:19:07Z"
+dismissed-at = "2026-08-25T06:14:29Z"
 
 [reviews."skill:review-gate"]
 review-hash = "ad84d44fcd9bdad9eee80c2df76976be2a0a56c9a2c7ad6fad2e386c26b2d6a8"

--- a/skills/orch/scripts/worktree-push
+++ b/skills/orch/scripts/worktree-push
@@ -37,9 +37,10 @@
 # Usage:
 #   worktree-push --worktree PATH --issue ID [--state-dir DIR] [push flags...]
 #
-# Push flags forwarded to `worktree push`: -u/--set-upstream and --no-rebase.
-# Any other flag is a usage error here — `worktree push` ignores flags it
-# does not know, so forwarding a typo would silently change nothing.
+# Every argument this wrapper does not own (--worktree, --issue, --state-dir,
+# --help) is forwarded verbatim to `worktree push`, which rejects a flag it
+# does not know. The flag vocabulary lives there alone; see `worktree push
+# --help`.
 # The state file resolves exactly like any other workflow-state call:
 # --state-dir, then $ORCH_STATE_DIR, then tmp/ under the caller's working
 # directory.
@@ -116,15 +117,17 @@ while [[ $# -gt 0 ]]; do
 		state_dir="${1#--state-dir=}"
 		shift
 		;;
-	-u | --set-upstream | --no-rebase)
-		push_args+=("$1")
-		shift
-		;;
 	-h | --help)
 		usage
 		exit 0
 		;;
-	*) fail "unknown option: $1 (worktree push ignores unknown flags, so it is refused here)" ;;
+	# Everything this wrapper does not own is `worktree push`'s to accept or
+	# reject; push fails closed on a flag it does not know, so pass-through
+	# here keeps one copy of that vocabulary (KEN-570).
+	*)
+		push_args+=("$1")
+		shift
+		;;
 	esac
 done
 

--- a/skills/orch/scripts/worktree-push
+++ b/skills/orch/scripts/worktree-push
@@ -37,10 +37,12 @@
 # Usage:
 #   worktree-push --worktree PATH --issue ID [--state-dir DIR] [push flags...]
 #
-# Every argument this wrapper does not own (--worktree, --issue, --state-dir,
-# --help) is forwarded verbatim to `worktree push`, which rejects a flag it
-# does not know. The flag vocabulary lives there alone; see `worktree push
-# --help`.
+# Every argument outside this wrapper's own namespace (--worktree, --issue,
+# --state-dir, --help) is forwarded verbatim to `worktree push`, which rejects
+# a flag it does not know. The push flag vocabulary lives there alone; see
+# `worktree push --help`. An argument that reads as a misspelling of an owned
+# flag is refused here instead of forwarded, because a mistaken --state-dir
+# would silently resolve, and reconcile, the wrong workflow state.
 # The state file resolves exactly like any other workflow-state call:
 # --state-dir, then $ORCH_STATE_DIR, then tmp/ under the caller's working
 # directory.
@@ -88,6 +90,35 @@ issue=''
 state_dir=''
 push_args=()
 
+# A misspelling of one of this wrapper's own flags must not reach push as a
+# pass-through argument. --worktree and --issue fail closed on their
+# required-flag checks, but --state-dir falls back silently (ORCH_STATE_DIR,
+# then tmp/ under the caller's directory): a typo would resolve some other
+# issue's state, consume this issue's pending sidecar into it, and only then
+# let push reject the flag, with the sidecar already deleted. So an argument
+# that reads as a mangled owned flag is refused here. Comparison is by prefix
+# after folding separators away, and only against the wrapper's own four
+# names: it catches a dropped or underscored separator and a truncation
+# (--statedir, --state_dir, --state-di), and a genuine push flag shares no
+# such name and passes through untouched. A transposition (--sate-dir) is not
+# caught: push refuses it, but only after this run reconciled the default
+# state the caller did not mean.
+OWNED_FLAG_NAMES='worktree issue statedir help'
+
+reads_as_owned_flag() {
+	local arg="${1%%=*}" name owned
+	case "$arg" in
+	--?*) name="${arg#--}" ;;
+	*) return 1 ;;
+	esac
+	name="$(printf '%s' "$name" | tr 'A-Z_' 'a-z-' | tr -d '-')"
+	[[ -n "$name" ]] || return 1
+	for owned in $OWNED_FLAG_NAMES; do
+		[[ "$owned" == "$name"* ]] && return 0
+	done
+	return 1
+}
+
 while [[ $# -gt 0 ]]; do
 	case "$1" in
 	--worktree)
@@ -121,10 +152,12 @@ while [[ $# -gt 0 ]]; do
 		usage
 		exit 0
 		;;
-	# Everything this wrapper does not own is `worktree push`'s to accept or
-	# reject; push fails closed on a flag it does not know, so pass-through
-	# here keeps one copy of that vocabulary (KEN-570).
+	# Everything outside this wrapper's own namespace is `worktree push`'s to
+	# accept or reject; push fails closed on a flag it does not know, so
+	# pass-through here keeps one copy of that vocabulary (KEN-570).
 	*)
+		! reads_as_owned_flag "$1" \
+			|| fail "unrecognized option: $1 (it reads as a misspelling of --worktree, --issue, --state-dir, or --help; a mistaken --state-dir would reconcile the wrong workflow state)"
 		push_args+=("$1")
 		shift
 		;;

--- a/skills/orch/scripts/worktree-push
+++ b/skills/orch/scripts/worktree-push
@@ -40,9 +40,11 @@
 # Every argument outside this wrapper's own namespace (--worktree, --issue,
 # --state-dir, --help) is forwarded verbatim to `worktree push`, which rejects
 # a flag it does not know. The push flag vocabulary lives there alone; see
-# `worktree push --help`. An argument that reads as a misspelling of an owned
-# flag is refused here instead of forwarded, because a mistaken --state-dir
-# would silently resolve, and reconcile, the wrong workflow state.
+# `worktree push --help`. This wrapper validates before it acts: the exact
+# forwarded vector goes to `worktree push --check-args` — push's own parser,
+# doing no git work — before any state is consumed, so a mistyped flag is
+# refused with the pending sidecar still in place. A misspelling of an owned
+# flag needs no separate guess here: push does not know --sate-dir either.
 # The state file resolves exactly like any other workflow-state call:
 # --state-dir, then $ORCH_STATE_DIR, then tmp/ under the caller's working
 # directory.
@@ -90,35 +92,6 @@ issue=''
 state_dir=''
 push_args=()
 
-# A misspelling of one of this wrapper's own flags must not reach push as a
-# pass-through argument. --worktree and --issue fail closed on their
-# required-flag checks, but --state-dir falls back silently (ORCH_STATE_DIR,
-# then tmp/ under the caller's directory): a typo would resolve some other
-# issue's state, consume this issue's pending sidecar into it, and only then
-# let push reject the flag, with the sidecar already deleted. So an argument
-# that reads as a mangled owned flag is refused here. Comparison is by prefix
-# after folding separators away, and only against the wrapper's own four
-# names: it catches a dropped or underscored separator and a truncation
-# (--statedir, --state_dir, --state-di), and a genuine push flag shares no
-# such name and passes through untouched. A transposition (--sate-dir) is not
-# caught: push refuses it, but only after this run reconciled the default
-# state the caller did not mean.
-OWNED_FLAG_NAMES='worktree issue statedir help'
-
-reads_as_owned_flag() {
-	local arg="${1%%=*}" name owned
-	case "$arg" in
-	--?*) name="${arg#--}" ;;
-	*) return 1 ;;
-	esac
-	name="$(printf '%s' "$name" | tr 'A-Z_' 'a-z-' | tr -d '-')"
-	[[ -n "$name" ]] || return 1
-	for owned in $OWNED_FLAG_NAMES; do
-		[[ "$owned" == "$name"* ]] && return 0
-	done
-	return 1
-}
-
 while [[ $# -gt 0 ]]; do
 	case "$1" in
 	--worktree)
@@ -152,12 +125,18 @@ while [[ $# -gt 0 ]]; do
 		usage
 		exit 0
 		;;
+	# push's parse-only mode is this wrapper's own tool, not a mode it can
+	# forward: it would leave the real push a no-op while the sidecar was
+	# already consumed and state reconciled against a rebase that never ran.
+	--check-args | --check-args=*)
+		fail "--check-args is push's parse-only mode and cannot be forwarded through this wrapper: the push would do nothing while workflow state was reconciled anyway"
+		;;
 	# Everything outside this wrapper's own namespace is `worktree push`'s to
 	# accept or reject; push fails closed on a flag it does not know, so
-	# pass-through here keeps one copy of that vocabulary (KEN-570).
+	# pass-through here keeps one copy of that vocabulary (KEN-570). The
+	# forwarded vector is put to push's parser below, before this run
+	# consumes anything.
 	*)
-		! reads_as_owned_flag "$1" \
-			|| fail "unrecognized option: $1 (it reads as a misspelling of --worktree, --issue, --state-dir, or --help; a mistaken --state-dir would reconcile the wrong workflow state)"
 		push_args+=("$1")
 		shift
 		;;
@@ -174,6 +153,23 @@ worktree_abs="$(cd -P -- "$worktree" 2>/dev/null && pwd -P)" \
 	|| fail "not a directory: $worktree"
 git_dir="$(git -C "$worktree_abs" rev-parse --absolute-git-dir 2>/dev/null)" \
 	|| fail "not a git worktree: $worktree_abs"
+
+# Validate before acting. A mistyped --state-dir is the dangerous case: it
+# falls back silently (ORCH_STATE_DIR, then tmp/ under the caller's
+# directory), so a typo would resolve some other issue's state, consume this
+# issue's pending sidecar into it, and only then let push reject the flag,
+# with the sidecar already gone. --check-args runs push's own argument loop —
+# the same code path the real push runs, so the two cannot drift — and does no
+# git work, so a rejection here costs nothing. The vector is the one the real
+# push gets, positional included. The check runs FROM the worktree, already
+# proven a git worktree above: the script resolves its project at startup and
+# exits before parsing anything when the caller's directory is not a
+# repository, which would make a startup failure read as an argument verdict.
+check_rc=0
+(cd "$worktree_abs" && "$WORKTREE_BIN" push --check-args "$worktree_abs" ${push_args[@]+"${push_args[@]}"}) \
+	|| check_rc=$?
+[[ "$check_rc" -eq 0 ]] \
+	|| fail "worktree push refused these arguments (its exit was $check_rc; any diagnostic is above); nothing was consumed and no state was reconciled"
 
 state_flags=()
 [[ -z "$state_dir" ]] || state_flags=(--state-dir "$state_dir")

--- a/skills/orch/tests/worktree_push.sh
+++ b/skills/orch/tests/worktree_push.sh
@@ -133,6 +133,32 @@ STUB_ARGS_LOG="$args_log" STUB_PUSH_EXIT=1 run_push "$work" --worktree "$wt" --i
 assert_eq "$RUN_RC" "1" "a flag push rejects fails the wrapper with push's own exit code"
 assert_contains "$(cat "$args_log")" "push $wt --force" "the rejected flag reached push rather than being screened here"
 
+# Pass-through stops at this wrapper's own namespace. --state-dir falls back
+# silently, so a typo of it would resolve another record, consume this issue's
+# pending sidecar into it, and only then let push reject the flag — with the
+# sidecar already deleted.
+work="$TMP_ROOT/work-owned-typo"
+reset_state "$work"
+owned_before="$(state_json "$work")"
+printf '{"%s":"%s"}\n' "$OLD_A" "$NEW_A" >"$SIDECAR"
+: >"$args_log"
+STUB_ARGS_LOG="$args_log" run_push "$work" --worktree "$wt" --issue KEN-1 "--statedir=$TMP_ROOT/elsewhere"
+assert_eq "$RUN_RC" "1" "a misspelled owned flag is refused instead of forwarded"
+assert_contains "$(cat "$run_err")" "unrecognized option: --statedir=" "the refusal names the misspelled flag"
+assert_eq "$(cat "$args_log")" "" "the refused call never reaches push"
+[[ -f "$SIDECAR" ]] && pass "the pending sidecar survives the refusal" || fail "the pending sidecar survives the refusal"
+assert_eq "$(state_json "$work")" "$owned_before" "the refused call reconciles nothing"
+rm -f "$SIDECAR"
+
+# The same check for the two flags that do fail closed, and for the separator
+# spellings a hand-typed flag actually takes.
+for owned_typo in --worktre --issu --state_dir --hel; do
+  : >"$args_log"
+  STUB_ARGS_LOG="$args_log" run_push "$work" --worktree "$wt" --issue KEN-1 "$owned_typo"
+  assert_eq "$RUN_RC" "1" "$owned_typo is refused as a mangled owned flag"
+  assert_eq "$(cat "$args_log")" "" "$owned_typo never reaches push"
+done
+
 echo
 echo "=== a rebase map is recorded and recorded fix SHAs rewritten ==="
 

--- a/skills/orch/tests/worktree_push.sh
+++ b/skills/orch/tests/worktree_push.sh
@@ -121,9 +121,17 @@ assert_contains "$(cat "$args_log")" "push $wt --set-upstream" "worktree push re
 STUB_PUSH_STDOUT="" run_push "$work" "--worktree=$wt" --issue=KEN-1
 assert_eq "$RUN_RC" "0" "equals-form flags parse"
 
-run_push "$work" --worktree "$wt" --issue KEN-1 --force
-assert_eq "$RUN_RC" "1" "an unknown flag is a usage error, not a silent pass-through"
-assert_contains "$(cat "$run_err")" "unknown option: --force" "the unknown flag is named"
+# KEN-570: the wrapper keeps no copy of push's flag vocabulary. A flag it does
+# not own is forwarded verbatim, and `worktree push` — which fails closed on an
+# unknown flag — is the one that rejects it.
+: >"$args_log"
+STUB_ARGS_LOG="$args_log" STUB_PUSH_STDOUT="" run_push "$work" --worktree "$wt" --issue KEN-1 --no-rebase --future-flag
+assert_contains "$(cat "$args_log")" "push $wt --no-rebase --future-flag" "flags the wrapper does not own are forwarded verbatim, in order"
+
+: >"$args_log"
+STUB_ARGS_LOG="$args_log" STUB_PUSH_EXIT=1 run_push "$work" --worktree "$wt" --issue KEN-1 --force
+assert_eq "$RUN_RC" "1" "a flag push rejects fails the wrapper with push's own exit code"
+assert_contains "$(cat "$args_log")" "push $wt --force" "the rejected flag reached push rather than being screened here"
 
 echo
 echo "=== a rebase map is recorded and recorded fix SHAs rewritten ==="

--- a/skills/orch/tests/worktree_push.sh
+++ b/skills/orch/tests/worktree_push.sh
@@ -44,10 +44,20 @@ assert_contains() {
 }
 
 # Stub worktree script: prints STUB_PUSH_STDOUT, exits STUB_PUSH_EXIT, and
-# logs its argv so pass-through flags can be asserted.
+# logs its argv so pass-through flags can be asserted. `push --check-args` is
+# push's parse-only mode — it accepts what push accepts and does nothing — so
+# the stub answers it from STUB_CHECK_EXIT (0 unless a test says otherwise)
+# and logs it apart from the real push, letting a test reject an argument
+# vector without failing the push itself.
 stub="$TMP_ROOT/worktree-stub"
 cat >"$stub" <<'EOF'
 #!/usr/bin/env bash
+for _a in "$@"; do
+  if [[ "$_a" == "--check-args" ]]; then
+    printf '%s\n' "$*" >>"${STUB_CHECK_LOG:-/dev/null}"
+    exit "${STUB_CHECK_EXIT:-0}"
+  fi
+done
 printf '%s\n' "$*" >>"${STUB_ARGS_LOG:-/dev/null}"
 if [[ -n "${STUB_PUSH_STDOUT:-}" ]]; then
   printf '%s\n' "$STUB_PUSH_STDOUT"
@@ -133,31 +143,61 @@ STUB_ARGS_LOG="$args_log" STUB_PUSH_EXIT=1 run_push "$work" --worktree "$wt" --i
 assert_eq "$RUN_RC" "1" "a flag push rejects fails the wrapper with push's own exit code"
 assert_contains "$(cat "$args_log")" "push $wt --force" "the rejected flag reached push rather than being screened here"
 
-# Pass-through stops at this wrapper's own namespace. --state-dir falls back
-# silently, so a typo of it would resolve another record, consume this issue's
-# pending sidecar into it, and only then let push reject the flag — with the
-# sidecar already deleted.
+# KEN-570: validate before acting. A mangled --state-dir (--sate-dir here, a
+# transposition no prefix guess catches) is push's to reject, but the wrapper
+# used to consume the pending sidecar into whatever state the fallback
+# resolved BEFORE push ever saw the flag. The vector now goes to push's own
+# parser first, so the run stops with the sidecar still on disk.
+check_log="$TMP_ROOT/check.log"
 work="$TMP_ROOT/work-owned-typo"
 reset_state "$work"
 owned_before="$(state_json "$work")"
 printf '{"%s":"%s"}\n' "$OLD_A" "$NEW_A" >"$SIDECAR"
 : >"$args_log"
-STUB_ARGS_LOG="$args_log" run_push "$work" --worktree "$wt" --issue KEN-1 "--statedir=$TMP_ROOT/elsewhere"
-assert_eq "$RUN_RC" "1" "a misspelled owned flag is refused instead of forwarded"
-assert_contains "$(cat "$run_err")" "unrecognized option: --statedir=" "the refusal names the misspelled flag"
-assert_eq "$(cat "$args_log")" "" "the refused call never reaches push"
+: >"$check_log"
+STUB_ARGS_LOG="$args_log" STUB_CHECK_LOG="$check_log" STUB_CHECK_EXIT=1 \
+  run_push "$work" --worktree "$wt" --issue KEN-1 "--sate-dir=$TMP_ROOT/elsewhere"
+assert_eq "$RUN_RC" "1" "arguments push rejects fail the wrapper"
+assert_contains "$(cat "$run_err")" "worktree push refused these arguments" "the refusal points at push's own diagnostic"
+assert_contains "$(cat "$check_log")" "push --check-args $wt --sate-dir=" "the whole forwarded vector is validated, positional included"
+assert_eq "$(cat "$args_log")" "" "the refused call never runs the real push"
 [[ -f "$SIDECAR" ]] && pass "the pending sidecar survives the refusal" || fail "the pending sidecar survives the refusal"
 assert_eq "$(state_json "$work")" "$owned_before" "the refused call reconciles nothing"
 rm -f "$SIDECAR"
 
-# The same check for the two flags that do fail closed, and for the separator
-# spellings a hand-typed flag actually takes.
-for owned_typo in --worktre --issu --state_dir --hel; do
-  : >"$args_log"
-  STUB_ARGS_LOG="$args_log" run_push "$work" --worktree "$wt" --issue KEN-1 "$owned_typo"
-  assert_eq "$RUN_RC" "1" "$owned_typo is refused as a mangled owned flag"
-  assert_eq "$(cat "$args_log")" "" "$owned_typo never reaches push"
-done
+# The validation runs push's parser, so it must precede everything this
+# wrapper consumes — including a valid-looking run, where the check still
+# comes first.
+: >"$check_log"
+STUB_CHECK_LOG="$check_log" STUB_PUSH_STDOUT="" run_push "$work" --worktree "$wt" --issue KEN-1 --no-rebase
+assert_eq "$RUN_RC" "0" "an accepted vector pushes normally"
+assert_contains "$(cat "$check_log")" "push --check-args $wt --no-rebase" "the accepted vector was validated too"
+
+# The stub above stands in for push's verdict; this one case runs the REAL
+# worktree script, so the two scripts' wiring is held: the flag name the
+# wrapper sends, the argument order it sends it in, and push's own refusal.
+# --check-args returns before any git work, so an unregistered checkout is a
+# fine target here.
+reset_state "$work"
+real_before="$(state_json "$work")"
+printf '{"%s":"%s"}\n' "$OLD_A" "$NEW_A" >"$SIDECAR"
+RUN_RC=0
+(cd "$work" && ORCH_WORKTREE_BIN="$REPO_ROOT/skills/worktree/scripts/worktree" \
+  "$PUSH" --worktree "$wt" --issue KEN-1 "--sate-dir=$TMP_ROOT/elsewhere") \
+  >"$run_out" 2>"$run_err" || RUN_RC=$?
+assert_eq "$RUN_RC" "1" "the real push refuses a transposed owned flag through this wrapper"
+assert_contains "$(cat "$run_err")" "unknown option '--sate-dir=$TMP_ROOT/elsewhere' for push" "push's own diagnostic reaches the caller"
+[[ -f "$SIDECAR" ]] && pass "the real refusal leaves the pending sidecar in place" || fail "the real refusal leaves the pending sidecar in place"
+assert_eq "$(state_json "$work")" "$real_before" "the real refusal reconciles nothing"
+rm -f "$SIDECAR"
+
+# --check-args is push's parse-only mode; forwarding it would leave the push a
+# no-op while state was reconciled anyway, so the wrapper refuses it outright.
+: >"$args_log"
+STUB_ARGS_LOG="$args_log" run_push "$work" --worktree "$wt" --issue KEN-1 --check-args
+assert_eq "$RUN_RC" "1" "--check-args cannot be forwarded through the wrapper"
+assert_contains "$(cat "$run_err")" "parse-only mode" "the refusal explains why"
+assert_eq "$(cat "$args_log")" "" "the refused --check-args never runs a push"
 
 echo
 echo "=== a rebase map is recorded and recorded fix SHAs rewritten ==="

--- a/skills/worktree/scripts/worktree
+++ b/skills/worktree/scripts/worktree
@@ -336,6 +336,10 @@ the normal SSH path.
 Options:
   -u, --set-upstream    Set upstream tracking branch
   --no-rebase           Skip auto-rebase
+
+Any other flag is a usage error (exit 1), so a typo cannot quietly become a
+default-behavior push. The ID or path may appear before or after the flags,
+but only once.
 EOF
 }
 
@@ -4274,15 +4278,31 @@ case "${1:-}" in
     ;;
 
   push)
-    ARG="${2:-}"
+    ARG=""
     SET_UPSTREAM=""
     AUTO_REBASE=true
-    shift 2 || shift || true
+    shift || true
     while [[ $# -gt 0 ]]; do
       case "$1" in
         -u|--set-upstream) SET_UPSTREAM="-u"; shift ;;
         --no-rebase) AUTO_REBASE=false; shift ;;
-        *) shift ;;
+        # An unknown --flag must fail rather than be dropped. The catch-all
+        # shift this replaces turned a typo like `--no-rebse` into a silent
+        # default-behavior push, and forced callers to pre-screen flags
+        # against a copy of this vocabulary (KEN-570).
+        -*)
+          echo "Error: unknown option '$1' for push" >&2
+          echo "Run: $0 push --help" >&2
+          exit 1
+          ;;
+        *)
+          if [[ -n "$ARG" ]]; then
+            echo "Error: push takes a single issue ID or path (got '$ARG' and '$1')" >&2
+            exit 1
+          fi
+          ARG="$1"
+          shift
+          ;;
       esac
     done
 

--- a/skills/worktree/scripts/worktree
+++ b/skills/worktree/scripts/worktree
@@ -298,6 +298,7 @@ EOF
 print_push_help() {
   cat <<'EOF'
 Usage: worktree push [ID|/path] [--set-upstream|-u] [--no-rebase]
+       worktree push [ID|/path] [flags...] --check-args
 
 Push worktree branch to remote. Auto-rebases onto origin/<default> first.
 Uses BOT_REMOTE_NAME from project config if set, otherwise falls back to
@@ -336,10 +337,18 @@ the normal SSH path.
 Options:
   -u, --set-upstream    Set upstream tracking branch
   --no-rebase           Skip auto-rebase
+  --check-args          Parse the arguments and exit: 0 when this exact
+                        argument vector is one push accepts, 1 with the same
+                        diagnostic when it is not. No resolution, no rebase,
+                        no push. A caller that consumes state before pushing
+                        (orch's worktree-push and its pending rebase-map
+                        sidecar) validates the forwarded vector this way
+                        first, so a bad flag is refused with nothing consumed.
 
 Any other flag is a usage error (exit 1), so a typo cannot quietly become a
 default-behavior push. The ID or path may appear before or after the flags,
-but only once.
+but only once, and it may not be empty: an empty target would fall back to
+the current checkout and push something the caller never named.
 EOF
 }
 
@@ -860,6 +869,51 @@ emit_rebase_map() {
       echo "rebase-map: $old_sha $new_sha"
     fi
     i=$((i + 1))
+  done
+}
+
+# Parse `push`'s arguments. The push dispatch and its parse-only --check-args
+# mode run this one loop, so a caller validating a forwarded argument vector
+# and the real push can never disagree about which flags exist (KEN-570).
+# Sets PUSH_ARG, PUSH_SET_UPSTREAM, PUSH_AUTO_REBASE and PUSH_CHECK_ARGS;
+# returns 1 with the usage error on stderr for anything it does not accept.
+# Seen-ness is tracked separately from the value so an empty first positional
+# — itself refused, since resolution would silently fall back to $PWD and push
+# the current checkout — still counts against the single-target rule.
+parse_push_args() {
+  PUSH_ARG=""
+  PUSH_SET_UPSTREAM=""
+  PUSH_AUTO_REBASE=true
+  PUSH_CHECK_ARGS=false
+  local arg_seen=false
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+      -u|--set-upstream) PUSH_SET_UPSTREAM="-u"; shift ;;
+      --no-rebase) PUSH_AUTO_REBASE=false; shift ;;
+      --check-args) PUSH_CHECK_ARGS=true; shift ;;
+      # An unknown --flag must fail rather than be dropped. The catch-all
+      # shift this replaces turned a typo like `--no-rebse` into a silent
+      # default-behavior push, and forced callers to pre-screen flags
+      # against a copy of this vocabulary (KEN-570).
+      -*)
+        echo "Error: unknown option '$1' for push" >&2
+        echo "Run: $0 push --help" >&2
+        return 1
+        ;;
+      *)
+        if [[ "$arg_seen" == true ]]; then
+          echo "Error: push takes a single issue ID or path (got '$PUSH_ARG' and '$1')" >&2
+          return 1
+        fi
+        if [[ -z "$1" ]]; then
+          echo "Error: push target is empty — pass an issue ID or path, or no argument at all to push the current checkout" >&2
+          return 1
+        fi
+        PUSH_ARG="$1"
+        arg_seen=true
+        shift
+        ;;
+    esac
   done
 }
 
@@ -4278,33 +4332,20 @@ case "${1:-}" in
     ;;
 
   push)
-    ARG=""
-    SET_UPSTREAM=""
-    AUTO_REBASE=true
     shift || true
-    while [[ $# -gt 0 ]]; do
-      case "$1" in
-        -u|--set-upstream) SET_UPSTREAM="-u"; shift ;;
-        --no-rebase) AUTO_REBASE=false; shift ;;
-        # An unknown --flag must fail rather than be dropped. The catch-all
-        # shift this replaces turned a typo like `--no-rebse` into a silent
-        # default-behavior push, and forced callers to pre-screen flags
-        # against a copy of this vocabulary (KEN-570).
-        -*)
-          echo "Error: unknown option '$1' for push" >&2
-          echo "Run: $0 push --help" >&2
-          exit 1
-          ;;
-        *)
-          if [[ -n "$ARG" ]]; then
-            echo "Error: push takes a single issue ID or path (got '$ARG' and '$1')" >&2
-            exit 1
-          fi
-          ARG="$1"
-          shift
-          ;;
-      esac
-    done
+    # ${1+"$@"}: under Bash 3.2 with set -u, "$@" with no positional
+    # parameters left is an unbound-variable error, and `push` with no
+    # arguments at all is the ordinary current-checkout call.
+    parse_push_args ${1+"$@"} || exit 1
+    ARG="$PUSH_ARG"
+    SET_UPSTREAM="$PUSH_SET_UPSTREAM"
+    AUTO_REBASE="$PUSH_AUTO_REBASE"
+    # --check-args validates and stops: no resolution, no rebase, no push. A
+    # caller that consumes state before invoking push uses it to learn the
+    # verdict while nothing is consumed yet.
+    if [[ "$PUSH_CHECK_ARGS" == true ]]; then
+      exit 0
+    fi
 
     if [[ -z "$ARG" ]]; then
       WT_PATH="$PWD"

--- a/skills/worktree/tests/worktree_push_rebase.sh
+++ b/skills/worktree/tests/worktree_push_rebase.sh
@@ -272,9 +272,44 @@ assert_contains "$(cat "$NOREBASE_ROOT/typo.err")" "unknown option '--no-rebse' 
 assert_eq "$(git -C "$NOREBASE_ROOT/trees/issue-norebase" rev-parse HEAD)" "$typo_pre_head" "a rejected flag pushes and rebases nothing"
 
 # The known flags still parse ahead of the positional, so a flag-first call is
-# not mistaken for an issue ID.
-run_push_args flagfirst --no-rebase "$NOREBASE_ROOT/trees/issue-norebase"
-assert_eq "$PUSH_ARGS_RC" "0" "flags may precede the ID or path"
+# not mistaken for an issue ID. Exit 0 alone proves nothing here: dropping the
+# positional falls back to $PWD, the main checkout, whose push also succeeds.
+# The branch must arrive on the remote at the named tree's head, which only
+# happens if the trailing positional became the target.
+FLAGFIRST_ROOT="$TMP_ROOT/flag-first"
+make_repo "$FLAGFIRST_ROOT/main"
+git init -q --bare "$FLAGFIRST_ROOT/origin.git"
+git -C "$FLAGFIRST_ROOT/main" remote add origin "$FLAGFIRST_ROOT/origin.git"
+git -C "$FLAGFIRST_ROOT/main" push -q -u origin main
+git -C "$FLAGFIRST_ROOT/main" worktree add -q -b issue-flagfirst "$FLAGFIRST_ROOT/trees/issue-flagfirst" main
+printf 'advanced\n' > "$FLAGFIRST_ROOT/main/main-advanced.txt"
+git -C "$FLAGFIRST_ROOT/main" add main-advanced.txt
+git -C "$FLAGFIRST_ROOT/main" commit -q -m 'advance main'
+git -C "$FLAGFIRST_ROOT/main" push -q origin main
+printf 'fix\n' > "$FLAGFIRST_ROOT/trees/issue-flagfirst/fix.txt"
+git -C "$FLAGFIRST_ROOT/trees/issue-flagfirst" add fix.txt
+git -C "$FLAGFIRST_ROOT/trees/issue-flagfirst" commit -q -m 'flag-first fix'
+flagfirst_pre_head="$(git -C "$FLAGFIRST_ROOT/trees/issue-flagfirst" rev-parse HEAD)"
+set +e
+(
+  cd "$FLAGFIRST_ROOT/main" && \
+    "$WORKTREE_SCRIPT" push --no-rebase --set-upstream "$FLAGFIRST_ROOT/trees/issue-flagfirst" \
+      >"$FLAGFIRST_ROOT/push.out" 2>"$FLAGFIRST_ROOT/push.err"
+)
+flagfirst_code=$?
+set -e
+assert_eq "$flagfirst_code" "0" "flags may precede the ID or path"
+assert_eq "$(git --git-dir="$FLAGFIRST_ROOT/origin.git" rev-parse refs/heads/issue-flagfirst)" "$flagfirst_pre_head" "the trailing positional is the pushed target, not \$PWD"
+assert_eq "$(git -C "$FLAGFIRST_ROOT/trees/issue-flagfirst" rev-parse HEAD)" "$flagfirst_pre_head" "the flag-first --no-rebase left HEAD unchanged"
+assert_path_absent "$FLAGFIRST_ROOT/trees/issue-flagfirst/main-advanced.txt" "the flag-first --no-rebase did not pull in advanced main"
+
+# The rejection arm shares its loop with --help, and the error it prints
+# advertises `push --help` as the recovery. That the global pre-scan answers
+# --help before this case is what keeps the advice true; nothing else here
+# holds it.
+run_push_args help --help
+assert_eq "$PUSH_ARGS_RC" "0" "the advertised recovery command still exits 0"
+assert_contains "$(cat "$NOREBASE_ROOT/help.out")" "Usage: worktree push" "push --help prints the push usage"
 
 run_push_args twoargs "$NOREBASE_ROOT/trees/issue-norebase" issue-norebase
 assert_eq "$PUSH_ARGS_RC" "1" "a second positional is a usage error"

--- a/skills/worktree/tests/worktree_push_rebase.sh
+++ b/skills/worktree/tests/worktree_push_rebase.sh
@@ -315,6 +315,50 @@ run_push_args twoargs "$NOREBASE_ROOT/trees/issue-norebase" issue-norebase
 assert_eq "$PUSH_ARGS_RC" "1" "a second positional is a usage error"
 assert_contains "$(cat "$NOREBASE_ROOT/twoargs.err")" "takes a single issue ID or path" "the duplicate positional is reported"
 
+# An EMPTY positional is not "no target": resolution would fall back to $PWD
+# and push the current checkout — the unintended default push this parser
+# exists to prevent, one unset caller variable away. Seen-ness is tracked
+# apart from the value, so an empty first argument still counts against the
+# single-target rule.
+empty_pre_head="$(git -C "$NOREBASE_ROOT/trees/issue-norebase" rev-parse HEAD)"
+run_push_args emptyarg ""
+assert_eq "$PUSH_ARGS_RC" "1" "an empty positional is a usage error, not a fallback to \$PWD"
+assert_contains "$(cat "$NOREBASE_ROOT/emptyarg.err")" "push target is empty" "the empty target is reported"
+
+run_push_args emptythenreal "" "$NOREBASE_ROOT/trees/issue-norebase"
+assert_eq "$PUSH_ARGS_RC" "1" "an empty positional followed by a real one is still refused"
+
+run_push_args realthenempty "$NOREBASE_ROOT/trees/issue-norebase" ""
+assert_eq "$PUSH_ARGS_RC" "1" "a real positional followed by an empty one is a duplicate, not a silent second target"
+assert_contains "$(cat "$NOREBASE_ROOT/realthenempty.err")" "takes a single issue ID or path" "the empty second positional is reported as a duplicate"
+assert_eq "$(git -C "$NOREBASE_ROOT/trees/issue-norebase" rev-parse HEAD)" "$empty_pre_head" "an empty-target refusal pushes and rebases nothing"
+
+# --- KEN-570: --check-args validates without acting ---------------------------
+# orch's worktree-push consumes a pending rebase-map sidecar before it pushes,
+# so it must learn push's verdict on the forwarded argument vector while
+# nothing is consumed yet. --check-args runs THIS loop — the same code path,
+# so a validation run and the real push cannot drift — and stops: no
+# resolution, no rebase, no push.
+check_pre_head="$(git -C "$NOREBASE_ROOT/trees/issue-norebase" rev-parse HEAD)"
+check_pre_remote="$(git --git-dir="$NOREBASE_ROOT/origin.git" rev-parse refs/heads/issue-norebase)"
+run_push_args checkok "$NOREBASE_ROOT/trees/issue-norebase" --no-rebase --check-args
+assert_eq "$PUSH_ARGS_RC" "0" "--check-args accepts a vector push accepts"
+assert_eq "$(cat "$NOREBASE_ROOT/checkok.out")" "" "--check-args prints nothing on acceptance"
+assert_eq "$(git -C "$NOREBASE_ROOT/trees/issue-norebase" rev-parse HEAD)" "$check_pre_head" "--check-args rebases nothing"
+assert_eq "$(git --git-dir="$NOREBASE_ROOT/origin.git" rev-parse refs/heads/issue-norebase)" "$check_pre_remote" "--check-args pushes nothing"
+
+# The transposition a prefix heuristic could never catch. push does not know
+# --sate-dir, so the real parser refuses it; the wrapper needs no guess of its
+# own about which typos of ITS flags exist.
+run_push_args checktransposed "$NOREBASE_ROOT/trees/issue-norebase" --check-args "--sate-dir=/nowhere"
+assert_eq "$PUSH_ARGS_RC" "1" "--check-args refuses a transposed flag push does not know"
+assert_contains "$(cat "$NOREBASE_ROOT/checktransposed.err")" "unknown option '--sate-dir=/nowhere' for push" "the check reports the same diagnostic the real push would"
+
+run_push_args checkempty --check-args ""
+assert_eq "$PUSH_ARGS_RC" "1" "--check-args refuses an empty positional too"
+assert_contains "$(cat "$NOREBASE_ROOT/checkempty.err")" "push target is empty" "the check reports the empty target"
+assert_eq "$(git --git-dir="$NOREBASE_ROOT/origin.git" rev-parse refs/heads/issue-norebase)" "$check_pre_remote" "a refused check pushes nothing"
+
 # --- kendex#728: a commit dropped by the rebase maps to "dropped" --------------
 # The branch carries a commit whose patch main already merged (different SHA,
 # same patch-id) plus its own fix. The rebase drops the duplicated commit, so

--- a/skills/worktree/tests/worktree_push_rebase.sh
+++ b/skills/worktree/tests/worktree_push_rebase.sh
@@ -246,6 +246,40 @@ assert_eq "$norebase_post_head" "$norebase_pre_head" "--no-rebase leaves HEAD un
 assert_path_absent "$NOREBASE_ROOT/trees/issue-norebase/main-advanced.txt" "--no-rebase does not pull in advanced main"
 assert_not_contains "$(cat "$NOREBASE_ROOT/push.out")" "rebase-map:" "--no-rebase emits no rebase-map lines"
 
+# --- KEN-570: push rejects unknown flags --------------------------------------
+# The argument loop used to end in a catch-all shift, so a typo'd flag was
+# dropped and the caller got a default-behavior push it never asked for. An
+# unrecognized flag must now be a usage error, which is what lets orch's
+# worktree-push wrapper pass flags through instead of keeping its own copy of
+# this vocabulary.
+run_push_args() {
+  local label="$1"
+  shift
+  set +e
+  (
+    cd "$NOREBASE_ROOT/main" && \
+      "$WORKTREE_SCRIPT" push "$@" \
+        >"$NOREBASE_ROOT/$label.out" 2>"$NOREBASE_ROOT/$label.err"
+  )
+  PUSH_ARGS_RC=$?
+  set -e
+}
+
+typo_pre_head="$(git -C "$NOREBASE_ROOT/trees/issue-norebase" rev-parse HEAD)"
+run_push_args typo "$NOREBASE_ROOT/trees/issue-norebase" --no-rebse
+assert_eq "$PUSH_ARGS_RC" "1" "a typo'd flag is a usage error, not a silent default push"
+assert_contains "$(cat "$NOREBASE_ROOT/typo.err")" "unknown option '--no-rebse' for push" "the rejected flag is named"
+assert_eq "$(git -C "$NOREBASE_ROOT/trees/issue-norebase" rev-parse HEAD)" "$typo_pre_head" "a rejected flag pushes and rebases nothing"
+
+# The known flags still parse ahead of the positional, so a flag-first call is
+# not mistaken for an issue ID.
+run_push_args flagfirst --no-rebase "$NOREBASE_ROOT/trees/issue-norebase"
+assert_eq "$PUSH_ARGS_RC" "0" "flags may precede the ID or path"
+
+run_push_args twoargs "$NOREBASE_ROOT/trees/issue-norebase" issue-norebase
+assert_eq "$PUSH_ARGS_RC" "1" "a second positional is a usage error"
+assert_contains "$(cat "$NOREBASE_ROOT/twoargs.err")" "takes a single issue ID or path" "the duplicate positional is reported"
+
 # --- kendex#728: a commit dropped by the rebase maps to "dropped" --------------
 # The branch carries a commit whose patch main already merged (different SHA,
 # same patch-id) plus its own fix. The rebase drops the duplicated commit, so

--- a/tools/size-ratchet-baseline.tsv
+++ b/tools/size-ratchet-baseline.tsv
@@ -125,7 +125,7 @@ skills/second-opinion/tests/cli-failure-gate.test.sh	1211
 skills/second-opinion/tests/lane-scratch-durability.test.sh	999
 skills/second-opinion/tests/review-dual-model.test.sh	1516
 skills/size-ratchet/scripts/size-ratchet	1026
-skills/worktree/scripts/worktree	4568
+skills/worktree/scripts/worktree	4609
 skills/worktree/scripts/worktree-session-guard	1197
 skills/worktree/tests/worktree_session_guard.sh	1282
 ui/src/stores/audit.ts	292

--- a/tools/size-ratchet-baseline.tsv
+++ b/tools/size-ratchet-baseline.tsv
@@ -125,7 +125,7 @@ skills/second-opinion/tests/cli-failure-gate.test.sh	1211
 skills/second-opinion/tests/lane-scratch-durability.test.sh	999
 skills/second-opinion/tests/review-dual-model.test.sh	1516
 skills/size-ratchet/scripts/size-ratchet	1026
-skills/worktree/scripts/worktree	4548
+skills/worktree/scripts/worktree	4568
 skills/worktree/scripts/worktree-session-guard	1197
 skills/worktree/tests/worktree_session_guard.sh	1282
 ui/src/stores/audit.ts	292


### PR DESCRIPTION
## Summary

- `worktree push`'s argument loop ended in a catch-all `shift`, so a typo like `--no-rebse` was dropped and the caller got a default-behavior push it never asked for. An unrecognized flag now exits 1 naming the flag; the ID or path is captured in the same loop, so it may precede the flags and may appear only once.
- With push failing closed, orch's `worktree-push` wrapper no longer carries a second copy of the push flag vocabulary — anything outside the wrapper's own namespace is forwarded verbatim.
- The wrapper still guards its *own* namespace: an argument that reads as a mangled `--worktree` / `--issue` / `--state-dir` / `--help` is refused rather than forwarded. `--worktree` and `--issue` fail closed on their required-flag checks, but `--state-dir` falls back silently, so a typo would have resolved another issue's state and consumed this issue's pending sidecar into it before push ever rejected the flag.

## Test Plan

`skills/worktree/tests/worktree_push_rebase.sh` 36 pass / 0 fail, `skills/orch/tests/worktree_push.sh` 91 pass / 0 fail, full orch suite 45/45 files.

New coverage: an unknown flag exits 1 and names it; the ID or path may precede the flags (asserted by pushing a branch of its own and checking the remote lands at that tree's head, not just exit 0); a second positional is refused; `push --help` still works past the new reject arm, since the error advertises it; a mangled `--state-dir` is refused by the wrapper and the pending sidecar survives.

Mutation-checked: restoring the catch-all `*) shift ;;` kills 6 assertions; making the wrapper swallow unknown flags kills 3; re-adding the wrapper's old allowlist kills 2.

## Completed Issues

- Closes KEN-570 - worktree push silently ignores unknown flags

## Created Issues

- KEN-585 - orch worktree-push pass-through fails open against a pre-KEN-570 worktree skill — Project: Skills & Agents Library
