### PR TITLE
fix(KEN-476): whole-file writes go through one checked path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -81,6 +81,12 @@ an outside contributor.
   and dialogs ask in the words of the button that opened them.
 
 ### Fixed
+- A settings or `kendex.toml` save from a copy something else wrote since —
+  another window, a resize, the CLI — no longer puts the older file back: it
+  is refused and retried on a fresh copy, or offered Reload in the editor.
+- A refused apply's rollback keeps the hand edit that refused it — a
+  `kendex.toml` change landing mid-apply — instead of restoring the older
+  copy over it.
 - The Library works from the keyboard: each package name is a button, so
   Tab reaches it and Enter opens it. Dragging across text to copy it no
   longer opens anything in the Library, a marketplace list, or a Projects card.

--- a/crates/app/src/app_settings.rs
+++ b/crates/app/src/app_settings.rs
@@ -1,5 +1,7 @@
-//! The app-settings surface: `kendex.settings.toml` reads and writes,
-//! and the project registry kept in it.
+//! The app-settings surface: reads and writes of the app's `settings.toml`
+//! (the machine-local preferences file under the app config dir, distinct
+//! from a project's committed `kendex.settings.toml`), and the project
+//! registry kept in it.
 //!
 //! Two kinds of write, and no third: `settings::mutate` for a targeted
 //! change made server-side in one breath, and the whole-file

--- a/crates/app/src/app_settings.rs
+++ b/crates/app/src/app_settings.rs
@@ -1,0 +1,330 @@
+//! The app-settings surface: `kendex.settings.toml` reads and writes,
+//! and the project registry kept in it.
+//!
+//! Two kinds of write, and no third: `settings::mutate` for a targeted
+//! change made server-side in one breath, and the whole-file
+//! `update_settings`, which must present the base of the file its copy
+//! was read from.
+
+use kendex_core::base::Base;
+use kendex_core::discover;
+use kendex_core::env::Env;
+use kendex_core::settings::{self, AppSettings};
+use serde::Serialize;
+use specta::Type;
+
+use crate::whole_file::{WriteRefused, refusal};
+
+fn env() -> Result<Env, String> {
+    Env::detect().map_err(|e| e.to_string())
+}
+
+/// The settings and the base of the exact file they describe — paired by
+/// one read, or handed back by the write that produced the file. One
+/// value, because a copy without its base cannot be written back safely,
+/// and the two obtained apart could describe different files.
+#[derive(Debug, Serialize, Type)]
+#[serde(rename_all = "camelCase")]
+pub struct SettingsRead {
+    pub settings: AppSettings,
+    pub base: Base,
+}
+
+impl From<(AppSettings, Base)> for SettingsRead {
+    fn from((settings, base): (AppSettings, Base)) -> SettingsRead {
+        SettingsRead { settings, base }
+    }
+}
+
+#[tauri::command(async)]
+#[specta::specta]
+pub fn get_settings() -> Result<SettingsRead, String> {
+    let pair = settings::read_for_mutation(&env()?).map_err(|e| e.to_string())?;
+    Ok(pair.into())
+}
+
+fn update_settings_at(
+    env: &Env,
+    mut settings: AppSettings,
+    held: &Base,
+) -> Result<SettingsRead, WriteRefused> {
+    // A harness root is where this build applies packages, so its `~` is
+    // this build's home — a sandboxed one included. The two calls that take
+    // a path to a repository on the machine read the real home instead.
+    for root in settings.harness_roots.values_mut() {
+        *root = crate::paths::expand_tilde(&env.home, &root.to_string_lossy());
+    }
+    // An accepted copy is provably the file — the zoom it carries is the
+    // zoom on disk, so a resize the copy predates refuses here instead of
+    // being written back, and no field needs patching over from disk.
+    let base = settings::replace(env, &settings, held).map_err(refusal)?;
+    Ok(SettingsRead { settings, base })
+}
+
+/// Write the whole settings object back.
+///
+/// `base` is what the file was when this copy was read. Every settings
+/// action sends the whole object, so a copy read before some other
+/// surface wrote the file — a resize, a project registered in another
+/// window — would put the older file back over it. A copy of a file that
+/// is no longer there is refused, never applied.
+#[tauri::command(async)]
+#[specta::specta]
+pub fn update_settings(
+    settings: AppSettings,
+    base: Option<String>,
+) -> Result<SettingsRead, WriteRefused> {
+    // The bytes behind this base were read on the settings page, so it
+    // arrives as a claim and is only ever compared, never believed.
+    update_settings_at(&env()?, settings, &Base::claimed(base))
+}
+
+fn save_zoom_at(env: &Env, percent: u16) -> Result<u16, String> {
+    let clamped = settings::clamp_zoom(percent);
+    settings::mutate(env, |settings| {
+        settings.zoom = clamped;
+        Ok(())
+    })
+    .map_err(|e| e.to_string())?;
+    Ok(clamped)
+}
+
+/// The size on screen, written on its own. Nothing else in the file moves
+/// with it, and nothing else can move it: a size the person is looking at
+/// survives whatever else is being saved at the same moment.
+#[tauri::command(async)]
+#[specta::specta]
+pub fn save_zoom(percent: u16) -> Result<u16, String> {
+    save_zoom_at(&env()?, percent)
+}
+
+fn register_project_at(env: &Env, path: &str) -> Result<SettingsRead, String> {
+    let expanded = crate::paths::expand_tilde(env.real_home(), path);
+    settings::register_project(env, &expanded)
+        .map(SettingsRead::from)
+        .map_err(|e| e.to_string())
+}
+
+#[tauri::command(async)]
+#[specta::specta]
+pub fn register_project(path: String) -> Result<SettingsRead, String> {
+    register_project_at(&env()?, &path)
+}
+
+#[tauri::command(async)]
+#[specta::specta]
+pub fn unregister_project(path: String) -> Result<SettingsRead, String> {
+    settings::unregister_project(&env()?, path.as_ref())
+        .map(SettingsRead::from)
+        .map_err(|e| e.to_string())
+}
+
+fn discover_projects_at(env: &Env, root: &str) -> Result<Vec<String>, String> {
+    let expanded = crate::paths::expand_tilde(env.real_home(), root);
+    Ok(discover::discover_projects(&expanded)
+        .map_err(|e| e.to_string())?
+        .into_iter()
+        .map(|p| p.display().to_string())
+        .collect())
+}
+
+#[tauri::command(async)]
+#[specta::specta]
+pub fn discover_projects(root: String) -> Result<Vec<String>, String> {
+    discover_projects_at(&env()?, &root)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use kendex_core::env::FakeOs;
+
+    fn env_in(dir: &std::path::Path) -> Env {
+        Env::fake(dir, FakeOs::Linux)
+    }
+
+    /// A debug build's shape: state under a sandbox home, the person still
+    /// living in the real one. A fixture where the two coincide cannot tell
+    /// a `~` read against the wrong one from a `~` read against the right
+    /// one — both answers look the same.
+    fn sandboxed_env_in(real_home: &std::path::Path) -> Env {
+        let sandbox = real_home.join(".local/share/kendex-dev");
+        std::fs::create_dir_all(&sandbox).unwrap();
+        Env::fake(&sandbox, FakeOs::Linux).with_real_home(real_home)
+    }
+
+    #[test]
+    fn register_project_expands_a_typed_tilde_path() {
+        let tmp = tempfile::tempdir().unwrap();
+        let env = env_in(tmp.path());
+        std::fs::create_dir_all(tmp.path().join("dev/hyprtrade")).unwrap();
+
+        let settings = register_project_at(&env, "~/dev/hyprtrade")
+            .unwrap()
+            .settings;
+        assert_eq!(
+            settings.projects,
+            [tmp.path().join("dev/hyprtrade").canonicalize().unwrap()]
+        );
+    }
+
+    /// A `~` is where the person lives, and a sandbox does not move that.
+    /// Resolving it against the build's own home names a directory nobody
+    /// has, so the repository they picked never registers.
+    #[test]
+    fn register_project_reads_a_typed_tilde_against_the_real_home() {
+        let tmp = tempfile::tempdir().unwrap();
+        let env = sandboxed_env_in(tmp.path());
+        std::fs::create_dir_all(tmp.path().join("dev/hyprtrade")).unwrap();
+
+        let settings = register_project_at(&env, "~/dev/hyprtrade")
+            .unwrap()
+            .settings;
+        assert_eq!(
+            settings.projects,
+            [tmp.path().join("dev/hyprtrade").canonicalize().unwrap()]
+        );
+    }
+
+    #[test]
+    fn discover_projects_expands_a_typed_tilde_root() {
+        let tmp = tempfile::tempdir().unwrap();
+        let env = env_in(tmp.path());
+        std::fs::create_dir_all(tmp.path().join("dev/app/.claude")).unwrap();
+
+        let found = discover_projects_at(&env, "~/dev").unwrap();
+        assert_eq!(
+            found,
+            [tmp.path()
+                .join("dev/app")
+                .canonicalize()
+                .unwrap()
+                .display()
+                .to_string()]
+        );
+    }
+
+    #[test]
+    fn discover_projects_reads_a_typed_tilde_against_the_real_home() {
+        let tmp = tempfile::tempdir().unwrap();
+        let env = sandboxed_env_in(tmp.path());
+        std::fs::create_dir_all(tmp.path().join("dev/app/.claude")).unwrap();
+
+        let found = discover_projects_at(&env, "~/dev").unwrap();
+        assert_eq!(
+            found,
+            [tmp.path()
+                .join("dev/app")
+                .canonicalize()
+                .unwrap()
+                .display()
+                .to_string()]
+        );
+    }
+
+    /// The UI cannot ask for a size outside the range, but the command is
+    /// reachable with any number, and an out-of-range one reaching the file
+    /// would open a window nobody can read or use.
+    #[test]
+    fn an_out_of_range_zoom_is_clamped_before_it_reaches_the_file() {
+        let tmp = tempfile::tempdir().unwrap();
+        let env = env_in(tmp.path());
+
+        let saved = save_zoom_at(&env, 5000).unwrap();
+
+        assert_eq!(saved, kendex_core::settings::ZOOM.max);
+        assert_eq!(
+            settings::load(&env).unwrap().zoom,
+            kendex_core::settings::ZOOM.max
+        );
+    }
+
+    /// The loss this surface used to allow: a copy read before the person
+    /// resized, written back, would put the older size over the one on
+    /// disk. It is refused as stale now — never applied — and the file
+    /// keeps everything the copy predates.
+    #[test]
+    fn a_copy_from_before_a_resize_is_refused_not_applied() {
+        let tmp = tempfile::tempdir().unwrap();
+        let env = env_in(tmp.path());
+        let (_, held) = settings::read_for_mutation(&env).unwrap();
+        save_zoom_at(&env, 150).unwrap();
+
+        let stale = AppSettings {
+            zoom: 100,
+            appearance: kendex_core::settings::Appearance::Dark,
+            ..AppSettings::default()
+        };
+        let refused = update_settings_at(&env, stale, &held).unwrap_err();
+
+        assert!(matches!(refused, WriteRefused::Stale), "{refused:?}");
+        let stored = settings::load(&env).unwrap();
+        assert_eq!(stored.zoom, 150);
+        assert_eq!(stored.appearance, kendex_core::settings::Appearance::System);
+    }
+
+    /// The way out of the refusal: re-read, carry the change onto the
+    /// fresh copy, write with the fresh base. Nothing the copy predated is
+    /// reverted.
+    #[test]
+    fn a_fresh_copy_carries_the_change_without_reverting_anything() {
+        let tmp = tempfile::tempdir().unwrap();
+        let env = env_in(tmp.path());
+        save_zoom_at(&env, 150).unwrap();
+
+        let (fresh, held) = settings::read_for_mutation(&env).unwrap();
+        let saved = update_settings_at(
+            &env,
+            AppSettings {
+                appearance: kendex_core::settings::Appearance::Dark,
+                ..fresh
+            },
+            &held,
+        )
+        .unwrap();
+
+        assert_eq!(saved.settings.zoom, 150);
+        let stored = settings::load(&env).unwrap();
+        assert_eq!(stored.zoom, 150);
+        assert_eq!(stored.appearance, kendex_core::settings::Appearance::Dark);
+
+        // And the base handed back is the file just written: the next
+        // save from this copy needs no re-read.
+        update_settings_at(&env, saved.settings, &saved.base).unwrap();
+    }
+
+    /// Writing the size must not roll back whatever else was saved since
+    /// this size was read.
+    #[test]
+    fn saving_the_size_leaves_every_other_setting_alone() {
+        let tmp = tempfile::tempdir().unwrap();
+        let env = env_in(tmp.path());
+        let settings = AppSettings {
+            appearance: kendex_core::settings::Appearance::Dark,
+            ..AppSettings::default()
+        };
+        update_settings_at(&env, settings, &kendex_core::base::Base::absent()).unwrap();
+
+        save_zoom_at(&env, 150).unwrap();
+
+        let stored = settings::load(&env).unwrap();
+        assert_eq!(stored.zoom, 150);
+        assert_eq!(stored.appearance, kendex_core::settings::Appearance::Dark);
+    }
+
+    #[test]
+    fn harness_root_overrides_expand_a_typed_tilde() {
+        let tmp = tempfile::tempdir().unwrap();
+        let env = env_in(tmp.path());
+        let mut settings = AppSettings::default();
+        settings
+            .harness_roots
+            .insert("claude".into(), "~/elsewhere/.claude".into());
+
+        let saved = update_settings_at(&env, settings, &kendex_core::base::Base::absent()).unwrap();
+        assert_eq!(
+            saved.settings.harness_roots.get("claude"),
+            Some(&tmp.path().join("elsewhere/.claude"))
+        );
+    }
+}

--- a/crates/app/src/commands.rs
+++ b/crates/app/src/commands.rs
@@ -1,9 +1,9 @@
 use kendex_core::env::Env;
 use kendex_core::harness::{KindCaps, capabilities};
 use kendex_core::model::{HarnessId, ItemKind};
+use kendex_core::scan;
 use kendex_core::scan::ScanResult;
-use kendex_core::settings::{self, AppSettings};
-use kendex_core::{discover, scan};
+use kendex_core::settings;
 use serde::Serialize;
 use specta::Type;
 
@@ -23,67 +23,6 @@ pub fn scan_machine() -> Result<ScanResult, String> {
     let env = env()?;
     let app_settings = settings::load(&env).map_err(|e| e.to_string())?;
     Ok(scan::scan(&env, &app_settings))
-}
-
-#[tauri::command(async)]
-#[specta::specta]
-pub fn get_settings() -> Result<AppSettings, String> {
-    settings::load(&env()?).map_err(|e| e.to_string())
-}
-
-fn update_settings_at(env: &Env, mut settings: AppSettings) -> Result<AppSettings, String> {
-    // A harness root is where this build applies packages, so its `~` is
-    // this build's home — a sandboxed one included. The two calls that take
-    // a path to a repository on the machine read the real home instead.
-    for root in settings.harness_roots.values_mut() {
-        *root = crate::paths::expand_tilde(&env.home, &root.to_string_lossy());
-    }
-    // The size on screen is the window's, not this call's. Every settings
-    // action sends the whole object, and a copy of it read before the person
-    // last resized would put back a size they have moved past, so what the
-    // file already holds wins and `save_zoom` is the only way to change it.
-    settings.zoom = settings::load(env).map_err(|e| e.to_string())?.zoom;
-    settings::save(env, &settings).map_err(|e| e.to_string())?;
-    Ok(settings)
-}
-
-#[tauri::command(async)]
-#[specta::specta]
-pub fn update_settings(settings: AppSettings) -> Result<AppSettings, String> {
-    update_settings_at(&env()?, settings)
-}
-
-fn save_zoom_at(env: &Env, percent: u16) -> Result<u16, String> {
-    let mut settings = settings::load(env).map_err(|e| e.to_string())?;
-    settings.zoom = settings::clamp_zoom(percent);
-    settings::save(env, &settings).map_err(|e| e.to_string())?;
-    Ok(settings.zoom)
-}
-
-/// The size on screen, written on its own. Nothing else in the file moves
-/// with it, and nothing else can move it: a size the person is looking at
-/// survives whatever else is being saved at the same moment.
-#[tauri::command(async)]
-#[specta::specta]
-pub fn save_zoom(percent: u16) -> Result<u16, String> {
-    save_zoom_at(&env()?, percent)
-}
-
-fn register_project_at(env: &Env, path: &str) -> Result<AppSettings, String> {
-    let expanded = crate::paths::expand_tilde(env.real_home(), path);
-    settings::register_project(env, &expanded).map_err(|e| e.to_string())
-}
-
-#[tauri::command(async)]
-#[specta::specta]
-pub fn register_project(path: String) -> Result<AppSettings, String> {
-    register_project_at(&env()?, &path)
-}
-
-#[tauri::command(async)]
-#[specta::specta]
-pub fn unregister_project(path: String) -> Result<AppSettings, String> {
-    settings::unregister_project(&env()?, path.as_ref()).map_err(|e| e.to_string())
 }
 
 /// Install the session-start drift report hook for a scope: script into the
@@ -111,21 +50,6 @@ pub fn install_drift_hook(scope: kendex_core::model::Scope) -> Result<bool, Stri
         kendex_core::engine::plan_apply(&env, &scope, &options).map_err(|e| e.to_string())?;
     kendex_core::apply::execute(&env, &report.plan, None).map_err(|e| e.to_string())?;
     Ok(true)
-}
-
-fn discover_projects_at(env: &Env, root: &str) -> Result<Vec<String>, String> {
-    let expanded = crate::paths::expand_tilde(env.real_home(), root);
-    Ok(discover::discover_projects(&expanded)
-        .map_err(|e| e.to_string())?
-        .into_iter()
-        .map(|p| p.display().to_string())
-        .collect())
-}
-
-#[tauri::command(async)]
-#[specta::specta]
-pub fn discover_projects(root: String) -> Result<Vec<String>, String> {
-    discover_projects_at(&env()?, &root)
 }
 
 #[derive(Serialize, Type)]
@@ -219,166 +143,4 @@ pub fn report_route(
         label: route.label,
         issue_url,
     })
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-    use kendex_core::env::FakeOs;
-
-    fn env_in(dir: &std::path::Path) -> Env {
-        Env::fake(dir, FakeOs::Linux)
-    }
-
-    /// A debug build's shape: state under a sandbox home, the person still
-    /// living in the real one. A fixture where the two coincide cannot tell
-    /// a `~` read against the wrong one from a `~` read against the right
-    /// one — both answers look the same.
-    fn sandboxed_env_in(real_home: &std::path::Path) -> Env {
-        let sandbox = real_home.join(".local/share/kendex-dev");
-        std::fs::create_dir_all(&sandbox).unwrap();
-        Env::fake(&sandbox, FakeOs::Linux).with_real_home(real_home)
-    }
-
-    #[test]
-    fn register_project_expands_a_typed_tilde_path() {
-        let tmp = tempfile::tempdir().unwrap();
-        let env = env_in(tmp.path());
-        std::fs::create_dir_all(tmp.path().join("dev/hyprtrade")).unwrap();
-
-        let settings = register_project_at(&env, "~/dev/hyprtrade").unwrap();
-        assert_eq!(
-            settings.projects,
-            [tmp.path().join("dev/hyprtrade").canonicalize().unwrap()]
-        );
-    }
-
-    /// A `~` is where the person lives, and a sandbox does not move that.
-    /// Resolving it against the build's own home names a directory nobody
-    /// has, so the repository they picked never registers.
-    #[test]
-    fn register_project_reads_a_typed_tilde_against_the_real_home() {
-        let tmp = tempfile::tempdir().unwrap();
-        let env = sandboxed_env_in(tmp.path());
-        std::fs::create_dir_all(tmp.path().join("dev/hyprtrade")).unwrap();
-
-        let settings = register_project_at(&env, "~/dev/hyprtrade").unwrap();
-        assert_eq!(
-            settings.projects,
-            [tmp.path().join("dev/hyprtrade").canonicalize().unwrap()]
-        );
-    }
-
-    #[test]
-    fn discover_projects_expands_a_typed_tilde_root() {
-        let tmp = tempfile::tempdir().unwrap();
-        let env = env_in(tmp.path());
-        std::fs::create_dir_all(tmp.path().join("dev/app/.claude")).unwrap();
-
-        let found = discover_projects_at(&env, "~/dev").unwrap();
-        assert_eq!(
-            found,
-            [tmp.path()
-                .join("dev/app")
-                .canonicalize()
-                .unwrap()
-                .display()
-                .to_string()]
-        );
-    }
-
-    #[test]
-    fn discover_projects_reads_a_typed_tilde_against_the_real_home() {
-        let tmp = tempfile::tempdir().unwrap();
-        let env = sandboxed_env_in(tmp.path());
-        std::fs::create_dir_all(tmp.path().join("dev/app/.claude")).unwrap();
-
-        let found = discover_projects_at(&env, "~/dev").unwrap();
-        assert_eq!(
-            found,
-            [tmp.path()
-                .join("dev/app")
-                .canonicalize()
-                .unwrap()
-                .display()
-                .to_string()]
-        );
-    }
-
-    /// The UI cannot ask for a size outside the range, but the command is
-    /// reachable with any number, and an out-of-range one reaching the file
-    /// would open a window nobody can read or use.
-    #[test]
-    fn an_out_of_range_zoom_is_clamped_before_it_reaches_the_file() {
-        let tmp = tempfile::tempdir().unwrap();
-        let env = env_in(tmp.path());
-
-        let saved = save_zoom_at(&env, 5000).unwrap();
-
-        assert_eq!(saved, kendex_core::settings::ZOOM.max);
-        assert_eq!(
-            settings::load(&env).unwrap().zoom,
-            kendex_core::settings::ZOOM.max
-        );
-    }
-
-    /// A settings action sends the whole object, and it may have read that
-    /// object before the person last resized. Writing the size it carries
-    /// would undo the resize, and the next launch would open at the size
-    /// the person had already moved past.
-    #[test]
-    fn a_settings_save_leaves_the_size_the_window_set() {
-        let tmp = tempfile::tempdir().unwrap();
-        let env = env_in(tmp.path());
-        save_zoom_at(&env, 150).unwrap();
-
-        let stale = AppSettings {
-            zoom: 100,
-            appearance: kendex_core::settings::Appearance::Dark,
-            ..AppSettings::default()
-        };
-        let saved = update_settings_at(&env, stale).unwrap();
-
-        assert_eq!(saved.zoom, 150);
-        assert_eq!(settings::load(&env).unwrap().zoom, 150);
-        assert_eq!(
-            settings::load(&env).unwrap().appearance,
-            kendex_core::settings::Appearance::Dark
-        );
-    }
-
-    /// The reverse: writing the size must not roll back whatever else was
-    /// saved since this size was read.
-    #[test]
-    fn saving_the_size_leaves_every_other_setting_alone() {
-        let tmp = tempfile::tempdir().unwrap();
-        let env = env_in(tmp.path());
-        let settings = AppSettings {
-            appearance: kendex_core::settings::Appearance::Dark,
-            ..AppSettings::default()
-        };
-        update_settings_at(&env, settings).unwrap();
-
-        save_zoom_at(&env, 150).unwrap();
-
-        let stored = settings::load(&env).unwrap();
-        assert_eq!(stored.zoom, 150);
-        assert_eq!(stored.appearance, kendex_core::settings::Appearance::Dark);
-    }
-
-    #[test]
-    fn harness_root_overrides_expand_a_typed_tilde() {
-        let tmp = tempfile::tempdir().unwrap();
-        let env = env_in(tmp.path());
-        let mut settings = AppSettings::default();
-        settings
-            .harness_roots
-            .insert("claude".into(), "~/elsewhere/.claude".into());
-
-        let saved = update_settings_at(&env, settings).unwrap();
-        assert_eq!(
-            saved.harness_roots.get("claude"),
-            Some(&tmp.path().join("elsewhere/.claude"))
-        );
-    }
 }

--- a/crates/app/src/editor.rs
+++ b/crates/app/src/editor.rs
@@ -1,15 +1,16 @@
-use kendex_core::apply::{Op, PlannedOp, Pre};
-use kendex_core::engine::{self, ItemSource, PlanOptions, ops};
+use kendex_core::engine::{self, ItemSource};
 use kendex_core::env::Env;
-use kendex_core::lock::{load as load_lock, lock_path};
-use kendex_core::manifest::{self, Finding, Manifest};
+use kendex_core::manifest::LOCAL_SOURCE_NAME;
+use kendex_core::manifest::{self};
 use kendex_core::model::{HarnessId, ItemKind, Scope};
 use kendex_core::source::{self, SourceState};
-use kendex_core::{apply, manifest::LOCAL_SOURCE_NAME};
 use serde::Serialize;
 use specta::Type;
 
-use crate::audit::{AuditView, view};
+mod save;
+// Glob, not named items: the command macros generate hidden siblings
+// (`__cmd__*`) that `collect_commands!` resolves through this module.
+pub use save::*;
 
 fn env() -> Result<Env, String> {
     Env::detect().map_err(|e| e.to_string())
@@ -115,80 +116,6 @@ pub fn custom_hook_deliveries(
 
 #[tauri::command(async)]
 #[specta::specta]
-pub fn get_manifest(scope: Scope) -> Result<Option<Manifest>, String> {
-    let env = env()?;
-    manifest::load_for_mutation(&manifest::manifest_path(&env, &scope)).map_err(|e| e.to_string())
-}
-
-/// Validate an edited manifest the way a hand-written file is validated, so
-/// the editor rejects exactly the same things — fix strings included.
-fn check(manifest: &Manifest) -> Result<(), String> {
-    let text = toml::to_string_pretty(manifest).map_err(|e| e.to_string())?;
-    let table: toml::Table = text.parse().map_err(|e: toml::de::Error| e.to_string())?;
-    let findings = manifest::validate(&table);
-    if findings.is_empty() {
-        return Ok(());
-    }
-    Err(findings
-        .iter()
-        .map(Finding::to_string)
-        .collect::<Vec<_>>()
-        .join("\n"))
-}
-
-/// The editor can create the first manifest for a scope, and first creation
-/// is where the default source is seeded — skipping it here would drop it
-/// for good, since later reconciliation never re-adds it.
-fn on_first_creation(mut manifest: Manifest, seed: Manifest) -> Manifest {
-    if manifest.sources.is_empty() {
-        manifest.sources = seed.sources;
-        if manifest.install.harnesses.is_empty() {
-            manifest.install.harnesses = seed.install.harnesses;
-        }
-    }
-    manifest
-}
-
-/// Write an edited manifest and reconcile the scope to it.
-#[tauri::command(async)]
-#[specta::specta]
-pub fn update_manifest(scope: Scope, manifest: Manifest) -> Result<AuditView, String> {
-    let env = env()?;
-    let path = manifest::manifest_path(&env, &scope);
-    let mut manifest = match manifest::load_for_mutation(&path).map_err(|e| e.to_string())? {
-        Some(_) => manifest,
-        None => on_first_creation(
-            manifest,
-            ops::manifest_for_mutation(&env, &scope).map_err(|e| e.to_string())?,
-        ),
-    };
-    // A custom hook's name is its identity everywhere downstream; saving is
-    // when a derived one stops being derived.
-    kendex_core::hook::name_custom_hooks(&mut manifest);
-    check(&manifest)?;
-    let lock = load_lock(&lock_path(&env, &scope)).map_err(|e| e.to_string())?;
-    let mut report = engine::plan_scope(&env, &scope, &manifest, &lock, &PlanOptions::default())
-        .map_err(|e| e.to_string())?;
-    let persisted = engine::persists_manifest(&report.plan.ops);
-    if !persisted {
-        report.plan.ops.insert(
-            0,
-            PlannedOp {
-                description: "Save kendex.toml".into(),
-                op: Op::WriteManifest {
-                    pre: Pre::observed(&path).map_err(|e| e.to_string())?,
-                    path: path.clone(),
-                    manifest: Box::new(manifest),
-                },
-            },
-        );
-    }
-    apply::execute(&env, &report.plan, None).map_err(|e| e.to_string())?;
-    Ok(view(&env, &scope))
-}
-
-#[tauri::command(async)]
-#[specta::specta]
 pub fn editor_inventory(scope: Scope) -> Result<EditorInventory, String> {
     let env = env()?;
     let loaded = manifest::load_for_mutation(&manifest::manifest_path(&env, &scope))
@@ -255,80 +182,4 @@ pub fn item_source(
     harness: HarnessId,
 ) -> Result<ItemSource, String> {
     engine::item_source(&env()?, &scope, kind, &name, harness).map_err(|e| e.to_string())
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-    use kendex_core::manifest::{
-        DEFAULT_SOURCE_NAME, DEFAULT_SOURCE_REPO, ItemDecl, MANIFEST_SCHEMA, SourceDecl,
-    };
-    use std::collections::BTreeMap;
-
-    fn manifest() -> Manifest {
-        Manifest {
-            schema: MANIFEST_SCHEMA,
-            sources: BTreeMap::from([(
-                DEFAULT_SOURCE_NAME.to_owned(),
-                SourceDecl {
-                    repo: Some(DEFAULT_SOURCE_REPO.to_owned()),
-                    path: None,
-                    rev: None,
-                    enabled: true,
-                },
-            )]),
-            ..Manifest::default()
-        }
-    }
-
-    #[test]
-    fn customization_tables_pass_the_same_check_a_file_gets() {
-        let mut edited = manifest();
-        edited
-            .agent_skills
-            .insert("orch".to_owned(), vec!["github".to_owned()]);
-        edited
-            .agent_launch_instructions
-            .insert("all".to_owned(), "read the plan".to_owned());
-        edited.custom_hooks.push(kendex_core::manifest::CustomHook {
-            name: None,
-            event: "PreToolUse".to_owned(),
-            matcher: Some("Bash".to_owned()),
-            command: "./guard.sh".to_owned(),
-            description: None,
-            timeout: None,
-            harnesses: None,
-            enabled: true,
-            agents: kendex_core::manifest::HookAgents::One("all".to_owned()),
-        });
-        assert_eq!(check(&edited), Ok(()));
-    }
-
-    #[test]
-    fn creating_a_manifest_here_still_seeds_the_default_source() {
-        let seeded = on_first_creation(
-            Manifest {
-                schema: MANIFEST_SCHEMA,
-                ..Manifest::default()
-            },
-            manifest::seed(&[HarnessId::Claude]),
-        );
-        assert!(seeded.sources.contains_key("kendex"));
-        assert_eq!(seeded.install.harnesses, [HarnessId::Claude]);
-
-        let declared = on_first_creation(manifest(), manifest::seed(&[HarnessId::Pi]));
-        assert_eq!(declared.sources.len(), 1);
-        assert!(declared.install.harnesses.is_empty());
-    }
-
-    #[test]
-    fn rejected_edits_come_back_with_their_fix_string() {
-        let mut edited = manifest();
-        edited
-            .skills
-            .insert("github".to_owned(), ItemDecl::from_source("gone"));
-        let error = check(&edited).expect_err("undeclared source must be rejected");
-        assert!(error.contains("skills.github"), "{error}");
-        assert!(error.contains("fix: declare [sources.gone]"), "{error}");
-    }
 }

--- a/crates/app/src/editor/save.rs
+++ b/crates/app/src/editor/save.rs
@@ -18,7 +18,7 @@ use specta::Type;
 
 use super::env;
 use crate::audit::{AuditView, view};
-use crate::whole_file::{WriteRefused, stale_at, targets};
+use crate::whole_file::{WriteRefused, stale_at};
 
 /// A place's manifest and what the file it came from was at that moment.
 /// One value, because a copy without its base cannot be written back
@@ -150,7 +150,8 @@ fn write_manifest(
     // Where this write ends up, which is not always where it was aimed: a
     // rename generation retargets every write planned against the old name,
     // and a refusal from one of those names the file it was retargeted to.
-    let targets = targets(&report.plan, &path);
+    // Core names both, so this cannot drift from how the retargeting works.
+    let targets = manifest::manifest_paths(env, &scope);
     // The bound precondition refuses a file that moved between the check
     // above and the write itself, and that refusal is the same answer the
     // check gives — so it reaches the editor as the same choice.
@@ -225,11 +226,12 @@ mod tests {
             .insert("all".into(), "older edit".into());
 
         // The writer in between — the write refusing exists to protect.
+        // Written raw, the way a hand edit or another process lands.
         let mut newer = manifest::load_for_mutation(&path).unwrap().unwrap();
         newer
             .agent_launch_instructions
             .insert("all".into(), "kept".into());
-        manifest::save(&path, &newer).unwrap();
+        std::fs::write(&path, toml::to_string_pretty(&newer).unwrap()).unwrap();
 
         let Err(refused) = write_manifest(&env, scope, stale, base) else {
             panic!("a stale save must be refused");

--- a/crates/app/src/editor/save.rs
+++ b/crates/app/src/editor/save.rs
@@ -1,0 +1,331 @@
+//! The Customize tab's whole-manifest read and write.
+//!
+//! Every other write in the app is a targeted operation that loads,
+//! changes and saves in one breath. This one hands a person the whole
+//! file, waits while they type, and writes all of it back — so it is the
+//! one write that can put an older file over a newer one, and the only
+//! one that carries the base of the file its copy came from to stop that.
+
+use kendex_core::apply::{self, Op, PlannedOp, Pre};
+use kendex_core::base::Base;
+use kendex_core::engine::{self, PlanOptions, ops};
+use kendex_core::env::Env;
+use kendex_core::lock::{load as load_lock, lock_path};
+use kendex_core::manifest::{self, Finding, Manifest};
+use kendex_core::model::Scope;
+use serde::Serialize;
+use specta::Type;
+
+use super::env;
+use crate::audit::{AuditView, view};
+use crate::whole_file::{WriteRefused, stale_at, targets};
+
+/// A place's manifest and what the file it came from was at that moment.
+/// One value, because a copy without its base cannot be written back
+/// safely, and the two read apart could describe different files.
+#[derive(Serialize, Type)]
+#[serde(rename_all = "camelCase")]
+pub struct ManifestRead {
+    /// Absent where the place has no manifest yet — the editor still
+    /// opens, on an empty one.
+    pub manifest: Option<Manifest>,
+    /// The file these bytes came from, read with them and never apart.
+    pub base: Base,
+}
+
+#[tauri::command(async)]
+#[specta::specta]
+pub fn get_manifest(scope: Scope) -> Result<ManifestRead, String> {
+    let env = env()?;
+    let (manifest, base) = manifest::read_for_mutation(&manifest::manifest_path(&env, &scope))
+        .map_err(|e| e.to_string())?;
+    Ok(ManifestRead { manifest, base })
+}
+
+/// Validate an edited manifest the way a hand-written file is validated, so
+/// the editor rejects exactly the same things — fix strings included.
+fn check(manifest: &Manifest) -> Result<(), String> {
+    let text = toml::to_string_pretty(manifest).map_err(|e| e.to_string())?;
+    let table: toml::Table = text.parse().map_err(|e: toml::de::Error| e.to_string())?;
+    let findings = manifest::validate(&table);
+    if findings.is_empty() {
+        return Ok(());
+    }
+    Err(findings
+        .iter()
+        .map(Finding::to_string)
+        .collect::<Vec<_>>()
+        .join("\n"))
+}
+
+/// The editor can create the first manifest for a scope, and first creation
+/// is where the default source is seeded — skipping it here would drop it
+/// for good, since later reconciliation never re-adds it.
+fn on_first_creation(mut manifest: Manifest, seed: Manifest) -> Manifest {
+    if manifest.sources.is_empty() {
+        manifest.sources = seed.sources;
+        if manifest.install.harnesses.is_empty() {
+            manifest.install.harnesses = seed.install.harnesses;
+        }
+    }
+    manifest
+}
+
+/// Write an edited manifest and reconcile the scope to it.
+///
+/// `base` is what the file was when this copy was read. A whole manifest
+/// goes back with every save, so a copy read before something else wrote
+/// the file would put that back — and the caller cannot be relied on to
+/// notice. Refusing here needs no caller to remember anything.
+#[tauri::command(async)]
+#[specta::specta]
+pub fn update_manifest(
+    scope: Scope,
+    manifest: Manifest,
+    base: Option<String>,
+) -> Result<AuditView, WriteRefused> {
+    // The bytes behind this base were read in the editor, so it arrives
+    // as a claim and is only ever compared, never believed.
+    write_manifest(&env()?, scope, manifest, Base::claimed(base))
+}
+
+/// The write itself, against a given environment — which is what makes it
+/// reachable from a test. The command above only finds the environment.
+fn write_manifest(
+    env: &Env,
+    scope: Scope,
+    manifest: Manifest,
+    claimed: Base,
+) -> Result<AuditView, WriteRefused> {
+    let path = manifest::manifest_path(env, &scope);
+    // One read answers both questions: whether the file is still the one
+    // the copy came from, and whether there is a file at all — the moment
+    // first-creation seeding happens. A file that cannot be read is a
+    // failure to say out loud, not a stale copy: the reload cannot fix a
+    // permission or an encoding, and offering it would hide what did.
+    let (current, now) = manifest::read_for_mutation(&path).map_err(|e| e.to_string())?;
+    if now != claimed {
+        return Err(WriteRefused::Stale);
+    }
+    let mut manifest = match current {
+        Some(_) => manifest,
+        None => on_first_creation(
+            manifest,
+            ops::manifest_for_mutation(env, &scope).map_err(|e| e.to_string())?,
+        ),
+    };
+    // A custom hook's name is its identity everywhere downstream; saving is
+    // when a derived one stops being derived.
+    kendex_core::hook::name_custom_hooks(&mut manifest);
+    check(&manifest)?;
+    let lock = load_lock(&lock_path(env, &scope)).map_err(|e| e.to_string())?;
+    // The plan binds its own manifest write to the file this copy came
+    // from, so a writer landing after the check above is refused by the
+    // apply rather than overwritten.
+    let options = PlanOptions {
+        manifest_base: Some(claimed.clone()),
+        ..PlanOptions::default()
+    };
+    let mut report =
+        engine::plan_scope(env, &scope, &manifest, &lock, &options).map_err(|e| e.to_string())?;
+    let persisted = engine::persists_manifest(&report.plan.ops);
+    if !persisted {
+        report.plan.ops.insert(
+            0,
+            PlannedOp {
+                description: "Save kendex.toml".into(),
+                op: Op::WriteManifest {
+                    pre: Pre::from(&claimed),
+                    // First in the plan: a scope still under the old
+                    // product name renames the file further down, which
+                    // carries this write to the new name with the bytes it
+                    // just put there. Written after the rename it would
+                    // recreate the old file.
+                    path: path.clone(),
+                    manifest: Box::new(manifest),
+                },
+            },
+        );
+    }
+    // Where this write ends up, which is not always where it was aimed: a
+    // rename generation retargets every write planned against the old name,
+    // and a refusal from one of those names the file it was retargeted to.
+    let targets = targets(&report.plan, &path);
+    // The bound precondition refuses a file that moved between the check
+    // above and the write itself, and that refusal is the same answer the
+    // check gives — so it reaches the editor as the same choice.
+    apply::execute(env, &report.plan, None).map_err(|error| match stale_at(&error, &targets) {
+        true => WriteRefused::Stale,
+        false => WriteRefused::Failed {
+            message: error.to_string(),
+        },
+    })?;
+    Ok(view(env, &scope))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use kendex_core::manifest::{
+        DEFAULT_SOURCE_NAME, DEFAULT_SOURCE_REPO, ItemDecl, MANIFEST_SCHEMA, SourceDecl,
+    };
+    use kendex_core::model::HarnessId;
+    use std::collections::BTreeMap;
+
+    /// A project scope with a manifest already on disk, under a sandboxed
+    /// home, so a save runs the real plan-and-apply.
+    fn scope_with_manifest() -> (tempfile::TempDir, Env, Scope) {
+        let tmp = tempfile::tempdir().unwrap();
+        let env = Env::fake(tmp.path(), kendex_core::env::FakeOs::Linux);
+        let project = tmp.path().join("dev/app");
+        std::fs::create_dir_all(project.join(".claude")).unwrap();
+        std::fs::write(
+            project.join("kendex.toml"),
+            "schema = 5\n\n[install]\nharnesses = [\"claude\"]\n",
+        )
+        .unwrap();
+        (tmp, env, Scope::Project { root: project })
+    }
+
+    #[test]
+    fn a_save_carrying_the_base_of_the_file_it_read_lands() {
+        let (_tmp, env, scope) = scope_with_manifest();
+        let path = manifest::manifest_path(&env, &scope);
+        let (read, base) = manifest::read_for_mutation(&path).unwrap();
+
+        let mut edited = read.unwrap();
+        edited
+            .skill_instructions
+            .insert("all".into(), "read the plan".into());
+        write_manifest(&env, scope, edited, base).unwrap();
+
+        let (saved, _) = manifest::read_for_mutation(&path).unwrap();
+        assert_eq!(
+            saved
+                .unwrap()
+                .skill_instructions
+                .get("all")
+                .map(String::as_str),
+            Some("read the plan")
+        );
+    }
+
+    /// The loss this command used to allow: a copy read before something
+    /// else wrote the file, saved wholesale, would put the older file back
+    /// over the writer in between. It is refused now, and the newer file
+    /// stands untouched.
+    #[test]
+    fn a_save_from_a_stale_copy_is_refused_and_the_newer_file_stands() {
+        let (_tmp, env, scope) = scope_with_manifest();
+        let path = manifest::manifest_path(&env, &scope);
+        let (read, base) = manifest::read_for_mutation(&path).unwrap();
+        let mut stale = read.unwrap();
+        stale
+            .skill_instructions
+            .insert("all".into(), "older edit".into());
+
+        // The writer in between — the write refusing exists to protect.
+        let mut newer = manifest::load_for_mutation(&path).unwrap().unwrap();
+        newer
+            .agent_launch_instructions
+            .insert("all".into(), "kept".into());
+        manifest::save(&path, &newer).unwrap();
+
+        let Err(refused) = write_manifest(&env, scope, stale, base) else {
+            panic!("a stale save must be refused");
+        };
+
+        assert!(matches!(refused, WriteRefused::Stale), "{refused:?}");
+        let (kept, _) = manifest::read_for_mutation(&path).unwrap();
+        let kept = kept.unwrap();
+        assert_eq!(
+            kept.agent_launch_instructions
+                .get("all")
+                .map(String::as_str),
+            Some("kept")
+        );
+        assert!(kept.skill_instructions.is_empty());
+    }
+
+    /// The other refusal direction: a copy that remembers "there was no
+    /// file" arrives after a first save created one.
+    #[test]
+    fn a_copy_predating_the_first_save_is_refused_once_a_file_exists() {
+        let (_tmp, env, scope) = scope_with_manifest();
+        let empty = Manifest {
+            schema: MANIFEST_SCHEMA,
+            ..Manifest::default()
+        };
+        let Err(refused) = write_manifest(&env, scope, empty, Base::absent()) else {
+            panic!("a no-file claim against an existing file must be refused");
+        };
+        assert!(matches!(refused, WriteRefused::Stale), "{refused:?}");
+    }
+
+    fn manifest() -> Manifest {
+        Manifest {
+            schema: MANIFEST_SCHEMA,
+            sources: BTreeMap::from([(
+                DEFAULT_SOURCE_NAME.to_owned(),
+                SourceDecl {
+                    repo: Some(DEFAULT_SOURCE_REPO.to_owned()),
+                    path: None,
+                    rev: None,
+                    enabled: true,
+                },
+            )]),
+            ..Manifest::default()
+        }
+    }
+
+    #[test]
+    fn customization_tables_pass_the_same_check_a_file_gets() {
+        let mut edited = manifest();
+        edited
+            .agent_skills
+            .insert("orch".to_owned(), vec!["github".to_owned()]);
+        edited
+            .agent_launch_instructions
+            .insert("all".to_owned(), "read the plan".to_owned());
+        edited.custom_hooks.push(kendex_core::manifest::CustomHook {
+            name: None,
+            event: "PreToolUse".to_owned(),
+            matcher: Some("Bash".to_owned()),
+            command: "./guard.sh".to_owned(),
+            description: None,
+            timeout: None,
+            harnesses: None,
+            enabled: true,
+            agents: kendex_core::manifest::HookAgents::One("all".to_owned()),
+        });
+        assert_eq!(check(&edited), Ok(()));
+    }
+
+    #[test]
+    fn creating_a_manifest_here_still_seeds_the_default_source() {
+        let seeded = on_first_creation(
+            Manifest {
+                schema: MANIFEST_SCHEMA,
+                ..Manifest::default()
+            },
+            manifest::seed(&[HarnessId::Claude]),
+        );
+        assert!(seeded.sources.contains_key("kendex"));
+        assert_eq!(seeded.install.harnesses, [HarnessId::Claude]);
+
+        let declared = on_first_creation(manifest(), manifest::seed(&[HarnessId::Pi]));
+        assert_eq!(declared.sources.len(), 1);
+        assert!(declared.install.harnesses.is_empty());
+    }
+
+    #[test]
+    fn rejected_edits_come_back_with_their_fix_string() {
+        let mut edited = manifest();
+        edited
+            .skills
+            .insert("github".to_owned(), ItemDecl::from_source("gone"));
+        let error = check(&edited).expect_err("undeclared source must be rejected");
+        assert!(error.contains("skills.github"), "{error}");
+        assert!(error.contains("fix: declare [sources.gone]"), "{error}");
+    }
+}

--- a/crates/app/src/editor/save.rs
+++ b/crates/app/src/editor/save.rs
@@ -128,30 +128,37 @@ fn write_manifest(
     };
     let mut report =
         engine::plan_scope(env, &scope, &manifest, &lock, &options).map_err(|e| e.to_string())?;
-    let persisted = engine::persists_manifest(&report.plan.ops);
-    if !persisted {
-        report.plan.ops.insert(
-            0,
-            PlannedOp {
-                description: "Save kendex.toml".into(),
-                op: Op::WriteManifest {
-                    pre: Pre::from(&claimed),
-                    // First in the plan: a scope still under the old
-                    // product name renames the file further down, which
-                    // carries this write to the new name with the bytes it
-                    // just put there. Written after the rename it would
-                    // recreate the old file.
-                    path: path.clone(),
-                    manifest: Box::new(manifest),
-                },
-            },
-        );
-    }
     // Where this write ends up, which is not always where it was aimed: a
     // rename generation retargets every write planned against the old name,
     // and a refusal from one of those names the file it was retargeted to.
     // Core names both, so this cannot drift from how the retargeting works.
     let targets = manifest::manifest_paths(env, &scope);
+    let persisted = engine::persists_manifest(&report.plan.ops);
+    if !persisted {
+        // After any rename-generation prefix, at the name the prefix
+        // leaves the file under. Planned before the rename this write
+        // would change the old file and stale the rename's own source
+        // precondition; planned at the old name after it, it would
+        // recreate the old file. The base still holds across the move —
+        // a rename preserves bytes, so the file at the new name is the
+        // one the copy was read from.
+        let index = kendex_core::rename::rename_prefix_len(&report.plan.ops);
+        let write_path = match index {
+            0 => path.clone(),
+            _ => targets[0].clone(),
+        };
+        report.plan.ops.insert(
+            index,
+            PlannedOp {
+                description: "Save kendex.toml".into(),
+                op: Op::WriteManifest {
+                    pre: Pre::from(&claimed),
+                    path: write_path,
+                    manifest: Box::new(manifest),
+                },
+            },
+        );
+    }
     // The bound precondition refuses a file that moved between the check
     // above and the write itself, and that refusal is the same answer the
     // check gives — so it reaches the editor as the same choice.
@@ -165,169 +172,4 @@ fn write_manifest(
 }
 
 #[cfg(test)]
-mod tests {
-    use super::*;
-    use kendex_core::manifest::{
-        DEFAULT_SOURCE_NAME, DEFAULT_SOURCE_REPO, ItemDecl, MANIFEST_SCHEMA, SourceDecl,
-    };
-    use kendex_core::model::HarnessId;
-    use std::collections::BTreeMap;
-
-    /// A project scope with a manifest already on disk, under a sandboxed
-    /// home, so a save runs the real plan-and-apply.
-    fn scope_with_manifest() -> (tempfile::TempDir, Env, Scope) {
-        let tmp = tempfile::tempdir().unwrap();
-        let env = Env::fake(tmp.path(), kendex_core::env::FakeOs::Linux);
-        let project = tmp.path().join("dev/app");
-        std::fs::create_dir_all(project.join(".claude")).unwrap();
-        std::fs::write(
-            project.join("kendex.toml"),
-            "schema = 5\n\n[install]\nharnesses = [\"claude\"]\n",
-        )
-        .unwrap();
-        (tmp, env, Scope::Project { root: project })
-    }
-
-    #[test]
-    fn a_save_carrying_the_base_of_the_file_it_read_lands() {
-        let (_tmp, env, scope) = scope_with_manifest();
-        let path = manifest::manifest_path(&env, &scope);
-        let (read, base) = manifest::read_for_mutation(&path).unwrap();
-
-        let mut edited = read.unwrap();
-        edited
-            .skill_instructions
-            .insert("all".into(), "read the plan".into());
-        write_manifest(&env, scope, edited, base).unwrap();
-
-        let (saved, _) = manifest::read_for_mutation(&path).unwrap();
-        assert_eq!(
-            saved
-                .unwrap()
-                .skill_instructions
-                .get("all")
-                .map(String::as_str),
-            Some("read the plan")
-        );
-    }
-
-    /// The loss this command used to allow: a copy read before something
-    /// else wrote the file, saved wholesale, would put the older file back
-    /// over the writer in between. It is refused now, and the newer file
-    /// stands untouched.
-    #[test]
-    fn a_save_from_a_stale_copy_is_refused_and_the_newer_file_stands() {
-        let (_tmp, env, scope) = scope_with_manifest();
-        let path = manifest::manifest_path(&env, &scope);
-        let (read, base) = manifest::read_for_mutation(&path).unwrap();
-        let mut stale = read.unwrap();
-        stale
-            .skill_instructions
-            .insert("all".into(), "older edit".into());
-
-        // The writer in between — the write refusing exists to protect.
-        // Written raw, the way a hand edit or another process lands.
-        let mut newer = manifest::load_for_mutation(&path).unwrap().unwrap();
-        newer
-            .agent_launch_instructions
-            .insert("all".into(), "kept".into());
-        std::fs::write(&path, toml::to_string_pretty(&newer).unwrap()).unwrap();
-
-        let Err(refused) = write_manifest(&env, scope, stale, base) else {
-            panic!("a stale save must be refused");
-        };
-
-        assert!(matches!(refused, WriteRefused::Stale), "{refused:?}");
-        let (kept, _) = manifest::read_for_mutation(&path).unwrap();
-        let kept = kept.unwrap();
-        assert_eq!(
-            kept.agent_launch_instructions
-                .get("all")
-                .map(String::as_str),
-            Some("kept")
-        );
-        assert!(kept.skill_instructions.is_empty());
-    }
-
-    /// The other refusal direction: a copy that remembers "there was no
-    /// file" arrives after a first save created one.
-    #[test]
-    fn a_copy_predating_the_first_save_is_refused_once_a_file_exists() {
-        let (_tmp, env, scope) = scope_with_manifest();
-        let empty = Manifest {
-            schema: MANIFEST_SCHEMA,
-            ..Manifest::default()
-        };
-        let Err(refused) = write_manifest(&env, scope, empty, Base::absent()) else {
-            panic!("a no-file claim against an existing file must be refused");
-        };
-        assert!(matches!(refused, WriteRefused::Stale), "{refused:?}");
-    }
-
-    fn manifest() -> Manifest {
-        Manifest {
-            schema: MANIFEST_SCHEMA,
-            sources: BTreeMap::from([(
-                DEFAULT_SOURCE_NAME.to_owned(),
-                SourceDecl {
-                    repo: Some(DEFAULT_SOURCE_REPO.to_owned()),
-                    path: None,
-                    rev: None,
-                    enabled: true,
-                },
-            )]),
-            ..Manifest::default()
-        }
-    }
-
-    #[test]
-    fn customization_tables_pass_the_same_check_a_file_gets() {
-        let mut edited = manifest();
-        edited
-            .agent_skills
-            .insert("orch".to_owned(), vec!["github".to_owned()]);
-        edited
-            .agent_launch_instructions
-            .insert("all".to_owned(), "read the plan".to_owned());
-        edited.custom_hooks.push(kendex_core::manifest::CustomHook {
-            name: None,
-            event: "PreToolUse".to_owned(),
-            matcher: Some("Bash".to_owned()),
-            command: "./guard.sh".to_owned(),
-            description: None,
-            timeout: None,
-            harnesses: None,
-            enabled: true,
-            agents: kendex_core::manifest::HookAgents::One("all".to_owned()),
-        });
-        assert_eq!(check(&edited), Ok(()));
-    }
-
-    #[test]
-    fn creating_a_manifest_here_still_seeds_the_default_source() {
-        let seeded = on_first_creation(
-            Manifest {
-                schema: MANIFEST_SCHEMA,
-                ..Manifest::default()
-            },
-            manifest::seed(&[HarnessId::Claude]),
-        );
-        assert!(seeded.sources.contains_key("kendex"));
-        assert_eq!(seeded.install.harnesses, [HarnessId::Claude]);
-
-        let declared = on_first_creation(manifest(), manifest::seed(&[HarnessId::Pi]));
-        assert_eq!(declared.sources.len(), 1);
-        assert!(declared.install.harnesses.is_empty());
-    }
-
-    #[test]
-    fn rejected_edits_come_back_with_their_fix_string() {
-        let mut edited = manifest();
-        edited
-            .skills
-            .insert("github".to_owned(), ItemDecl::from_source("gone"));
-        let error = check(&edited).expect_err("undeclared source must be rejected");
-        assert!(error.contains("skills.github"), "{error}");
-        assert!(error.contains("fix: declare [sources.gone]"), "{error}");
-    }
-}
+mod tests;

--- a/crates/app/src/editor/save/tests.rs
+++ b/crates/app/src/editor/save/tests.rs
@@ -1,0 +1,293 @@
+use super::*;
+use kendex_core::manifest::{
+    DEFAULT_SOURCE_NAME, DEFAULT_SOURCE_REPO, ItemDecl, MANIFEST_SCHEMA, SourceDecl,
+};
+use kendex_core::model::HarnessId;
+use std::collections::BTreeMap;
+
+/// A project scope with a manifest already on disk, under a sandboxed
+/// home, so a save runs the real plan-and-apply.
+fn scope_with_manifest() -> (tempfile::TempDir, Env, Scope) {
+    let tmp = tempfile::tempdir().unwrap();
+    let env = Env::fake(tmp.path(), kendex_core::env::FakeOs::Linux);
+    let project = tmp.path().join("dev/app");
+    std::fs::create_dir_all(project.join(".claude")).unwrap();
+    std::fs::write(
+        project.join("kendex.toml"),
+        "schema = 5\n\n[install]\nharnesses = [\"claude\"]\n",
+    )
+    .unwrap();
+    (tmp, env, Scope::Project { root: project })
+}
+
+/// A scope still under the old product name, with its manifest at
+/// `vstack.toml`. The rename generation is planned into the same save
+/// that edits it.
+fn legacy_scope() -> (tempfile::TempDir, Env, Scope) {
+    let tmp = tempfile::tempdir().unwrap();
+    let env = Env::fake(tmp.path(), kendex_core::env::FakeOs::Linux);
+    let project = tmp.path().join("dev/app");
+    std::fs::create_dir_all(project.join(".claude")).unwrap();
+    std::fs::write(
+        project.join("vstack.toml"),
+        "schema = 5\n\n[install]\nharnesses = [\"claude\"]\n",
+    )
+    .unwrap();
+    (tmp, env, Scope::Project { root: project })
+}
+
+/// A save on a legacy-named scope rides the rename generation: the
+/// rename moves the old file's bytes to the new name, and the save —
+/// planned after it, bound to the base the copy was read from — lands
+/// at the new name. Planned before the rename it would change the old
+/// file and stale the rename's own source precondition, so no legacy
+/// scope could ever save.
+#[test]
+fn a_save_on_a_legacy_named_scope_lands_at_the_new_name() {
+    let (_tmp, env, scope) = legacy_scope();
+    let path = manifest::manifest_path(&env, &scope);
+    assert!(path.ends_with("vstack.toml"), "{path:?}");
+    let (read, base) = manifest::read_for_mutation(&path).unwrap();
+
+    let mut edited = read.unwrap();
+    edited
+        .skill_instructions
+        .insert("all".into(), "read the plan".into());
+    write_manifest(&env, scope.clone(), edited, base).unwrap();
+
+    let renamed = manifest::manifest_path(&env, &scope);
+    assert!(renamed.ends_with("kendex.toml"), "{renamed:?}");
+    let (saved, _) = manifest::read_for_mutation(&renamed).unwrap();
+    assert_eq!(
+        saved
+            .unwrap()
+            .skill_instructions
+            .get("all")
+            .map(String::as_str),
+        Some("read the plan")
+    );
+}
+
+/// The chain that turns a mid-apply refusal into the stale choice,
+/// exercised whole: the plan's own manifest write binds to the editor
+/// copy's base (`PlanOptions::manifest_base`), a writer lands after
+/// the copy was read, and the apply refuses in a way `stale_at`
+/// recognises while the writer's bytes stand. A plan observing the
+/// file instead of taking the base would accept this writer.
+#[test]
+fn a_writer_landing_after_the_editor_read_is_refused_mid_apply() {
+    let (_tmp, env, scope) = scope_with_manifest();
+    let path = manifest::manifest_path(&env, &scope);
+    std::fs::write(&path, "schema = 4\n\n[install]\nharnesses = [\"claude\"]\n").unwrap();
+    let (read, base) = manifest::read_for_mutation(&path).unwrap();
+    let mut editor_copy = read.unwrap();
+    // Reading for mutation normalizes the schema; the engine plans the
+    // upgrade write when the copy it is handed still carries the old
+    // one — and must bind that write to the base when one is given.
+    editor_copy.schema = 4;
+
+    // The writer in between: lands after the editor copy left, before
+    // the plan is made.
+    std::fs::write(
+        &path,
+        "schema = 4\n\n[install]\nharnesses = [\"claude\"]\n\n[skill-instructions]\nall = \"kept\"\n",
+    )
+    .unwrap();
+
+    let lock = load_lock(&lock_path(&env, &scope)).unwrap();
+    let options = PlanOptions {
+        manifest_base: Some(base),
+        ..PlanOptions::default()
+    };
+    let report = engine::plan_scope(&env, &scope, &editor_copy, &lock, &options).unwrap();
+    assert!(
+        report
+            .plan
+            .ops
+            .iter()
+            .any(|op| op.description.contains("Upgrade")),
+        "the schema upgrade is the plan's manifest write: {:?}",
+        report.plan.ops
+    );
+
+    let error = apply::execute(&env, &report.plan, None).unwrap_err();
+    assert!(
+        stale_at(&error, &manifest::manifest_paths(&env, &scope)),
+        "{error:?}"
+    );
+    let kept = std::fs::read_to_string(&path).unwrap();
+    assert!(kept.contains("all = \"kept\""), "{kept}");
+}
+
+/// The legacy variant pins the two names a refusal can arrive under:
+/// the writer lands on vstack.toml after the plan bound the rename to
+/// its bytes, the rename refuses at the old name, and `stale_at` must
+/// match it — a target list knowing only the new name would misread
+/// this as a plain failure. The refused rename also proves the writer
+/// survives: nothing moved, nothing was restored over it.
+#[test]
+fn a_legacy_scope_refusal_names_the_old_file_and_the_writer_survives() {
+    let (_tmp, env, scope) = legacy_scope();
+    let path = manifest::manifest_path(&env, &scope);
+    let (read, base) = manifest::read_for_mutation(&path).unwrap();
+    let editor_copy = read.unwrap();
+    let lock = load_lock(&lock_path(&env, &scope)).unwrap();
+    let options = PlanOptions {
+        manifest_base: Some(base),
+        ..PlanOptions::default()
+    };
+    let report = engine::plan_scope(&env, &scope, &editor_copy, &lock, &options).unwrap();
+
+    // The writer in between: lands after the plan observed the old
+    // file, before the apply moves it.
+    std::fs::write(&path, "external edit").unwrap();
+
+    let error = apply::execute(&env, &report.plan, None).unwrap_err();
+    let targets = manifest::manifest_paths(&env, &scope);
+    assert!(stale_at(&error, &targets), "{error:?}");
+    assert_eq!(std::fs::read_to_string(&path).unwrap(), "external edit");
+    assert!(!targets[0].exists(), "nothing may land at the new name");
+}
+
+#[test]
+fn a_save_carrying_the_base_of_the_file_it_read_lands() {
+    let (_tmp, env, scope) = scope_with_manifest();
+    let path = manifest::manifest_path(&env, &scope);
+    let (read, base) = manifest::read_for_mutation(&path).unwrap();
+
+    let mut edited = read.unwrap();
+    edited
+        .skill_instructions
+        .insert("all".into(), "read the plan".into());
+    write_manifest(&env, scope, edited, base).unwrap();
+
+    let (saved, _) = manifest::read_for_mutation(&path).unwrap();
+    assert_eq!(
+        saved
+            .unwrap()
+            .skill_instructions
+            .get("all")
+            .map(String::as_str),
+        Some("read the plan")
+    );
+}
+
+/// The loss this command used to allow: a copy read before something
+/// else wrote the file, saved wholesale, would put the older file back
+/// over the writer in between. It is refused now, and the newer file
+/// stands untouched.
+#[test]
+fn a_save_from_a_stale_copy_is_refused_and_the_newer_file_stands() {
+    let (_tmp, env, scope) = scope_with_manifest();
+    let path = manifest::manifest_path(&env, &scope);
+    let (read, base) = manifest::read_for_mutation(&path).unwrap();
+    let mut stale = read.unwrap();
+    stale
+        .skill_instructions
+        .insert("all".into(), "older edit".into());
+
+    // The writer in between — the write refusing exists to protect.
+    // Written raw, the way a hand edit or another process lands.
+    let mut newer = manifest::load_for_mutation(&path).unwrap().unwrap();
+    newer
+        .agent_launch_instructions
+        .insert("all".into(), "kept".into());
+    std::fs::write(&path, toml::to_string_pretty(&newer).unwrap()).unwrap();
+
+    let Err(refused) = write_manifest(&env, scope, stale, base) else {
+        panic!("a stale save must be refused");
+    };
+
+    assert!(matches!(refused, WriteRefused::Stale), "{refused:?}");
+    let (kept, _) = manifest::read_for_mutation(&path).unwrap();
+    let kept = kept.unwrap();
+    assert_eq!(
+        kept.agent_launch_instructions
+            .get("all")
+            .map(String::as_str),
+        Some("kept")
+    );
+    assert!(kept.skill_instructions.is_empty());
+}
+
+/// The other refusal direction: a copy that remembers "there was no
+/// file" arrives after a first save created one.
+#[test]
+fn a_copy_predating_the_first_save_is_refused_once_a_file_exists() {
+    let (_tmp, env, scope) = scope_with_manifest();
+    let empty = Manifest {
+        schema: MANIFEST_SCHEMA,
+        ..Manifest::default()
+    };
+    let Err(refused) = write_manifest(&env, scope, empty, Base::absent()) else {
+        panic!("a no-file claim against an existing file must be refused");
+    };
+    assert!(matches!(refused, WriteRefused::Stale), "{refused:?}");
+}
+
+fn manifest() -> Manifest {
+    Manifest {
+        schema: MANIFEST_SCHEMA,
+        sources: BTreeMap::from([(
+            DEFAULT_SOURCE_NAME.to_owned(),
+            SourceDecl {
+                repo: Some(DEFAULT_SOURCE_REPO.to_owned()),
+                path: None,
+                rev: None,
+                enabled: true,
+            },
+        )]),
+        ..Manifest::default()
+    }
+}
+
+#[test]
+fn customization_tables_pass_the_same_check_a_file_gets() {
+    let mut edited = manifest();
+    edited
+        .agent_skills
+        .insert("orch".to_owned(), vec!["github".to_owned()]);
+    edited
+        .agent_launch_instructions
+        .insert("all".to_owned(), "read the plan".to_owned());
+    edited.custom_hooks.push(kendex_core::manifest::CustomHook {
+        name: None,
+        event: "PreToolUse".to_owned(),
+        matcher: Some("Bash".to_owned()),
+        command: "./guard.sh".to_owned(),
+        description: None,
+        timeout: None,
+        harnesses: None,
+        enabled: true,
+        agents: kendex_core::manifest::HookAgents::One("all".to_owned()),
+    });
+    assert_eq!(check(&edited), Ok(()));
+}
+
+#[test]
+fn creating_a_manifest_here_still_seeds_the_default_source() {
+    let seeded = on_first_creation(
+        Manifest {
+            schema: MANIFEST_SCHEMA,
+            ..Manifest::default()
+        },
+        manifest::seed(&[HarnessId::Claude]),
+    );
+    assert!(seeded.sources.contains_key("kendex"));
+    assert_eq!(seeded.install.harnesses, [HarnessId::Claude]);
+
+    let declared = on_first_creation(manifest(), manifest::seed(&[HarnessId::Pi]));
+    assert_eq!(declared.sources.len(), 1);
+    assert!(declared.install.harnesses.is_empty());
+}
+
+#[test]
+fn rejected_edits_come_back_with_their_fix_string() {
+    let mut edited = manifest();
+    edited
+        .skills
+        .insert("github".to_owned(), ItemDecl::from_source("gone"));
+    let error = check(&edited).expect_err("undeclared source must be rejected");
+    assert!(error.contains("skills.github"), "{error}");
+    assert!(error.contains("fix: declare [sources.gone]"), "{error}");
+}

--- a/crates/app/src/lib.rs
+++ b/crates/app/src/lib.rs
@@ -1,4 +1,5 @@
 mod account;
+mod app_settings;
 pub mod audit;
 mod commands;
 mod community;
@@ -16,6 +17,7 @@ mod paths;
 pub mod recovery;
 mod sources;
 mod unsubscribe;
+mod whole_file;
 mod window;
 
 use tauri_specta::{Builder, collect_commands};
@@ -29,13 +31,13 @@ pub fn specta_builder() -> Builder<tauri::Wry> {
         .commands(collect_commands![
             commands::app_version,
             commands::scan_machine,
-            commands::get_settings,
-            commands::update_settings,
-            commands::save_zoom,
-            commands::register_project,
-            commands::unregister_project,
+            app_settings::get_settings,
+            app_settings::update_settings,
+            app_settings::save_zoom,
+            app_settings::register_project,
+            app_settings::unregister_project,
             commands::install_drift_hook,
-            commands::discover_projects,
+            app_settings::discover_projects,
             commands::capability_table,
             commands::report_route,
             audit::audit_all,

--- a/crates/app/src/whole_file.rs
+++ b/crates/app/src/whole_file.rs
@@ -1,15 +1,14 @@
 //! The one answer shape for a whole-file write that did not happen.
 //!
 //! Two whole-file surfaces exist — the Customize tab's manifest and the
-//! Settings page's `kendex.settings.toml` — and both refuse a copy of a
+//! Settings page's app-settings file — and both refuse a copy of a
 //! file that is no longer there. The refusal is one type so the pages
 //! render one choice for it, and so the next whole-file surface returns
 //! it too instead of inventing a message the UI would have to recognise
 //! by its words.
 
-use std::path::{Path, PathBuf};
+use std::path::PathBuf;
 
-use kendex_core::apply::Op;
 use kendex_core::error::CoreError;
 use serde::Serialize;
 use specta::Type;
@@ -51,20 +50,6 @@ pub fn refusal(error: CoreError) -> WriteRefused {
     }
 }
 
-/// Every name this plan's manifest write may answer to: the one the caller
-/// read, and the one a rename generation moves it to. A scope still under
-/// the old product name renames first and retargets every write planned
-/// against the old name, so a refusal from one of them names a file the
-/// caller never asked about.
-pub fn targets(plan: &kendex_core::apply::Plan, read_at: &Path) -> Vec<PathBuf> {
-    let mut targets = vec![read_at.to_path_buf()];
-    targets.extend(plan.ops.iter().filter_map(|planned| match &planned.op {
-        Op::Rename { from, to, .. } if from == read_at => Some(to.clone()),
-        _ => None,
-    }));
-    targets
-}
-
 /// Whether an apply refused because this file moved under it. The write is
 /// bound to the file the copy on screen came from, so a rollback with that
 /// precondition underneath is the same answer the base check gives a
@@ -81,8 +66,6 @@ pub fn stale_at(error: &CoreError, targets: &[PathBuf]) -> bool {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use kendex_core::apply::{Plan, PlannedOp, Pre};
-    use kendex_core::model::Scope;
 
     #[test]
     fn a_stale_base_is_the_reload_choice_and_any_other_failure_is_not() {
@@ -118,32 +101,21 @@ mod tests {
         ));
     }
 
-    /// A scope still under the old product name renames its manifest first
-    /// and the write planned against the old name is retargeted with it.
-    /// The refusal then names a file the caller never asked about, and
-    /// matched against only the name it started from it would read as some
-    /// other failure — so the reload would not be offered.
+    /// A scope still under the old product name retargets its manifest
+    /// write to the renamed file, so a refusal can name either of the two
+    /// paths core lists for the scope — and nothing else.
     #[test]
-    fn a_refusal_after_the_rename_is_still_this_file_moving() {
-        let legacy = PathBuf::from("/w/app/vstack.toml");
-        let renamed = PathBuf::from("/w/app/kendex.toml");
-        let plan = Plan {
-            scope: Scope::Project {
-                root: "/w/app".into(),
-            },
-            ops: vec![PlannedOp {
-                description: "Rename vstack.toml to kendex.toml".into(),
-                op: Op::Rename {
-                    from: legacy.clone(),
-                    to: renamed.clone(),
-                    to_pre: Pre::Absent,
-                },
-            }],
-        };
-        let targets = targets(&plan, &legacy);
-
-        assert!(stale_at(&CoreError::PlanStale { path: renamed }, &targets));
-        assert!(stale_at(&CoreError::PlanStale { path: legacy }, &targets));
+    fn a_refusal_matches_either_name_the_scope_manifest_answers_to() {
+        let targets = [
+            PathBuf::from("/w/app/kendex.toml"),
+            PathBuf::from("/w/app/vstack.toml"),
+        ];
+        for name in &targets {
+            assert!(stale_at(
+                &CoreError::PlanStale { path: name.clone() },
+                &targets
+            ));
+        }
         assert!(!stale_at(
             &CoreError::PlanStale {
                 path: "/w/app/.claude/settings.json".into()

--- a/crates/app/src/whole_file.rs
+++ b/crates/app/src/whole_file.rs
@@ -1,0 +1,154 @@
+//! The one answer shape for a whole-file write that did not happen.
+//!
+//! Two whole-file surfaces exist — the Customize tab's manifest and the
+//! Settings page's `kendex.settings.toml` — and both refuse a copy of a
+//! file that is no longer there. The refusal is one type so the pages
+//! render one choice for it, and so the next whole-file surface returns
+//! it too instead of inventing a message the UI would have to recognise
+//! by its words.
+
+use std::path::{Path, PathBuf};
+
+use kendex_core::apply::Op;
+use kendex_core::error::CoreError;
+use serde::Serialize;
+use specta::Type;
+
+/// Why a whole-file write did not happen. Refusing is a normal answer
+/// here, not a failure, so it is a shape the page can act on rather than
+/// a message it would have to recognise by its words.
+#[derive(Debug, Serialize, Type)]
+#[serde(tag = "kind", rename_all = "kebab-case")]
+pub enum WriteRefused {
+    /// The file is no longer the one this copy was read from. Something
+    /// else wrote it — a fork, a hold, a dismissal, an install, another
+    /// window — and writing this copy would put that back.
+    Stale,
+    Failed {
+        message: String,
+    },
+}
+
+impl From<String> for WriteRefused {
+    fn from(message: String) -> WriteRefused {
+        WriteRefused::Failed { message }
+    }
+}
+
+/// What a failed base check means to the person holding the copy.
+///
+/// A file that became something else is a stale copy, and the reload is
+/// the way out. A file that could not be read at all is neither: offering
+/// the reload for a permission or an encoding sends them to a remedy that
+/// cannot fix it, and hides the one thing that would have told them what
+/// went wrong.
+pub fn refusal(error: CoreError) -> WriteRefused {
+    match error {
+        CoreError::PlanStale { .. } => WriteRefused::Stale,
+        other => WriteRefused::Failed {
+            message: other.to_string(),
+        },
+    }
+}
+
+/// Every name this plan's manifest write may answer to: the one the caller
+/// read, and the one a rename generation moves it to. A scope still under
+/// the old product name renames first and retargets every write planned
+/// against the old name, so a refusal from one of them names a file the
+/// caller never asked about.
+pub fn targets(plan: &kendex_core::apply::Plan, read_at: &Path) -> Vec<PathBuf> {
+    let mut targets = vec![read_at.to_path_buf()];
+    targets.extend(plan.ops.iter().filter_map(|planned| match &planned.op {
+        Op::Rename { from, to, .. } if from == read_at => Some(to.clone()),
+        _ => None,
+    }));
+    targets
+}
+
+/// Whether an apply refused because this file moved under it. The write is
+/// bound to the file the copy on screen came from, so a rollback with that
+/// precondition underneath is the same answer the base check gives a
+/// moment earlier — and it reaches the person the same way, as a reload to
+/// take, rather than as an apply error they can do nothing with.
+pub fn stale_at(error: &CoreError, targets: &[PathBuf]) -> bool {
+    match error {
+        CoreError::PlanStale { path: moved } => targets.contains(moved),
+        CoreError::RolledBack { cause, .. } => stale_at(cause, targets),
+        _ => false,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use kendex_core::apply::{Plan, PlannedOp, Pre};
+    use kendex_core::model::Scope;
+
+    #[test]
+    fn a_stale_base_is_the_reload_choice_and_any_other_failure_is_not() {
+        let path = PathBuf::from("/w/app/kendex.toml");
+        assert!(matches!(
+            refusal(CoreError::PlanStale { path }),
+            WriteRefused::Stale
+        ));
+        assert!(matches!(
+            refusal(CoreError::LegacyManifest {
+                path: PathBuf::from("/w/app/kendex.toml")
+            }),
+            WriteRefused::Failed { .. }
+        ));
+    }
+
+    /// The write is bound to the file the copy on screen came from, so a
+    /// rollback with that precondition underneath is the same refusal the
+    /// check gives — and the page already knows what to do with it. Told
+    /// as an apply failure it reaches the person as a message with no
+    /// choice in it.
+    #[test]
+    fn a_rollback_on_this_file_is_the_refusal_the_page_can_offer() {
+        let path = PathBuf::from("/w/app/kendex.toml");
+        let moved = CoreError::PlanStale { path: path.clone() };
+        assert!(stale_at(&moved, std::slice::from_ref(&path)));
+        assert!(stale_at(
+            &CoreError::RolledBack {
+                reason: "'Save kendex.toml' failed".into(),
+                cause: Box::new(moved),
+            },
+            &[path]
+        ));
+    }
+
+    /// A scope still under the old product name renames its manifest first
+    /// and the write planned against the old name is retargeted with it.
+    /// The refusal then names a file the caller never asked about, and
+    /// matched against only the name it started from it would read as some
+    /// other failure — so the reload would not be offered.
+    #[test]
+    fn a_refusal_after_the_rename_is_still_this_file_moving() {
+        let legacy = PathBuf::from("/w/app/vstack.toml");
+        let renamed = PathBuf::from("/w/app/kendex.toml");
+        let plan = Plan {
+            scope: Scope::Project {
+                root: "/w/app".into(),
+            },
+            ops: vec![PlannedOp {
+                description: "Rename vstack.toml to kendex.toml".into(),
+                op: Op::Rename {
+                    from: legacy.clone(),
+                    to: renamed.clone(),
+                    to_pre: Pre::Absent,
+                },
+            }],
+        };
+        let targets = targets(&plan, &legacy);
+
+        assert!(stale_at(&CoreError::PlanStale { path: renamed }, &targets));
+        assert!(stale_at(&CoreError::PlanStale { path: legacy }, &targets));
+        assert!(!stale_at(
+            &CoreError::PlanStale {
+                path: "/w/app/.claude/settings.json".into()
+            },
+            &targets
+        ));
+    }
+}

--- a/crates/app/tests/decisions_registry.rs
+++ b/crates/app/tests/decisions_registry.rs
@@ -23,9 +23,11 @@ fn an_unreadable_scope_is_reported_beside_the_decisions_it_hides() {
         "schema = 5\n[nonsense]\nx = 1\n",
     )
     .unwrap();
-    let mut settings = kendex_core::settings::load(&env).unwrap();
-    settings.projects.push(project);
-    kendex_core::settings::save(&env, &settings).unwrap();
+    kendex_core::settings::mutate(&env, |settings| {
+        settings.projects.push(project);
+        Ok(())
+    })
+    .unwrap();
 
     let view = decisions_view(&env).unwrap();
     assert!(view.decisions.is_empty());

--- a/crates/core/src/apply/journal.rs
+++ b/crates/core/src/apply/journal.rs
@@ -139,6 +139,14 @@ pub fn rollback(dir: &Path) -> Result<()> {
 /// durable before the first path is touched, so a crash mid-restore
 /// recovers with the same filter instead of falling back to a full
 /// restore that would destroy those protected bytes after all.
+///
+/// One exception the filter does not cover: a journaled directory root
+/// the transaction created (`PreState::Absent`, above a mutated path) is
+/// removed whole, and anything a writer outside the transaction placed
+/// beneath it after the journal was taken goes with it — a first install
+/// into a fresh `.codex/` while the Codex CLI writes its config there.
+/// The restore does not yet verify a root's post-image before removing
+/// it.
 pub fn rollback_mutated(dir: &Path, mutated: &[PathBuf]) -> Result<()> {
     // The persisted set is a crash guard for the restore below, never a
     // gate in front of it. When this write fails (ENOSPC can fail the op
@@ -233,6 +241,19 @@ fn rollback_where(dir: &Path, restore: impl Fn(&Path) -> bool) -> Result<()> {
 }
 
 pub fn clear(dir: &Path) -> Result<()> {
+    // meta.json is what makes a journal pending, and it goes first, on
+    // its own, made durable before the sweep: `remove_dir_all` deletes
+    // in no promised order, and a crash that had taken restore.json but
+    // not meta.json would leave a pending journal with no restore set,
+    // for a recovery that restores every snapshot — over the paths the
+    // filter left alone. With meta gone the dir is a leftover the next
+    // recovery pass sweeps, never a journal it replays.
+    let meta = dir.join("meta.json");
+    match fs::remove_file(&meta) {
+        Ok(()) => sync_dir(dir),
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => {}
+        Err(e) => return Err(CoreError::io(&meta, e)),
+    }
     if dir.exists() {
         fs::remove_dir_all(dir).map_err(|e| CoreError::io(dir, e))?;
     }

--- a/crates/core/src/apply/journal.rs
+++ b/crates/core/src/apply/journal.rs
@@ -127,9 +127,29 @@ fn sync_tree(root: &Path) -> Result<()> {
     Ok(())
 }
 
-/// Restore every pre-image. Used both for in-process rollback and for
-/// crash recovery on the next run.
+/// Restore every pre-image. Used both for in-process rollback after a
+/// mid-mutation failure and for crash recovery on the next run, where
+/// nothing can know which ops ran.
 pub fn rollback(dir: &Path) -> Result<()> {
+    rollback_where(dir, |_| true)
+}
+
+/// Restore only the pre-images of paths this transaction actually mutated:
+/// a path in `mutated`, or a journaled directory root above one (the top
+/// of a chain the transaction created). In-process rollback knows exactly
+/// which ops ran; restoring the rest would put the journal's snapshot over
+/// bytes a writer outside the transaction landed after the journal was
+/// taken — the precondition that stopped the apply refused to overwrite
+/// those bytes, so the rollback must not either. A crash between this
+/// restore and the journal clearing still recovers with the full
+/// [`rollback`], which cannot make that distinction.
+pub fn rollback_mutated(dir: &Path, mutated: &[PathBuf]) -> Result<()> {
+    rollback_where(dir, |path| {
+        mutated.iter().any(|m| m == path || m.starts_with(path))
+    })
+}
+
+fn rollback_where(dir: &Path, restore: impl Fn(&Path) -> bool) -> Result<()> {
     let meta_path = dir.join("meta.json");
     let Some(text) = crate::fs::read_if_exists(&meta_path)? else {
         // Mutation never started (no meta written): nothing to restore.
@@ -144,6 +164,9 @@ pub fn rollback(dir: &Path) -> Result<()> {
     };
     let store = dir.join("store");
     for entry in &journal.entries {
+        if !restore(&entry.path) {
+            continue;
+        }
         remove_any(&entry.path)?;
         match &entry.state {
             PreState::Absent => {}
@@ -240,6 +263,53 @@ pub fn make_symlink(target: &Path, link: &Path) -> Result<()> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// The filtered restore is what keeps a refused apply from destroying
+    /// the very bytes the refusal protected: a path whose op never ran
+    /// keeps whatever a writer outside the transaction put there after the
+    /// journal was taken.
+    #[test]
+    fn a_filtered_rollback_leaves_unmutated_paths_as_the_world_left_them() {
+        let tmp = tempfile::tempdir().unwrap();
+        let work = tmp.path().join("work");
+        fs::create_dir_all(&work).unwrap();
+        let a = work.join("a.md");
+        let b = work.join("kendex.toml");
+        fs::write(&a, "a0").unwrap();
+        fs::write(&b, "b0").unwrap();
+
+        let journal_dir = tmp.path().join("journal/global");
+        write(&journal_dir, &[a.clone(), b.clone()]).unwrap();
+        // The transaction mutates `a`; a writer outside it lands on `b`
+        // before `b`'s own op refuses its precondition.
+        fs::write(&a, "a1").unwrap();
+        fs::write(&b, "external edit").unwrap();
+
+        rollback_mutated(&journal_dir, std::slice::from_ref(&a)).unwrap();
+
+        assert_eq!(fs::read_to_string(&a).unwrap(), "a0");
+        assert_eq!(fs::read_to_string(&b).unwrap(), "external edit");
+        assert!(!pending(&journal_dir));
+    }
+
+    /// A journaled directory root above a mutated path is part of the
+    /// transaction's footprint: the chain it created comes down with the
+    /// rollback even though only the leaf is named as mutated.
+    #[test]
+    fn a_filtered_rollback_still_removes_the_chain_above_a_mutated_path() {
+        let tmp = tempfile::tempdir().unwrap();
+        let root = tmp.path().join("work/.codex");
+        let leaf = root.join("skills/x.md");
+
+        let journal_dir = tmp.path().join("journal/global");
+        write(&journal_dir, &[leaf.clone(), root.clone()]).unwrap();
+        fs::create_dir_all(leaf.parent().unwrap()).unwrap();
+        fs::write(&leaf, "installed").unwrap();
+
+        rollback_mutated(&journal_dir, std::slice::from_ref(&leaf)).unwrap();
+
+        assert!(!root.exists());
+    }
 
     #[test]
     fn rollback_restores_files_dirs_symlinks_and_absence() {

--- a/crates/core/src/apply/journal.rs
+++ b/crates/core/src/apply/journal.rs
@@ -112,12 +112,18 @@ fn restore_set_path(dir: &Path) -> PathBuf {
 /// first, so recovery re-runs exactly that filter; with no persisted set,
 /// nothing can know which ops ran and every pre-image is restored.
 pub fn rollback(dir: &Path) -> Result<()> {
-    // The set is written atomically, so it is complete or absent; a parse
-    // failure is outside corruption, and the full restore below is the
-    // only set recovery can still justify.
-    if let Some(text) = crate::fs::read_if_exists(&restore_set_path(dir))?
-        && let Ok(mutated) = serde_json::from_str::<Vec<PathBuf>>(&text)
-    {
+    if let Some(text) = crate::fs::read_if_exists(&restore_set_path(dir))? {
+        // The file's presence proves a filtered restore was in flight, so
+        // some journaled paths hold bytes the filter protects. It is
+        // written atomically — complete or absent, never torn — so content
+        // that does not parse is outside interference, and widening to the
+        // full restore would destroy exactly those protected bytes. Refuse
+        // instead, leaving the journal pending for inspection.
+        let mutated: Vec<PathBuf> =
+            serde_json::from_str(&text).map_err(|e| CoreError::JsonParse {
+                path: restore_set_path(dir),
+                message: e.to_string(),
+            })?;
         return rollback_filtered(dir, &mutated);
     }
     rollback_where(dir, |_| true)
@@ -134,8 +140,27 @@ pub fn rollback(dir: &Path) -> Result<()> {
 /// recovers with the same filter instead of falling back to a full
 /// restore that would destroy those protected bytes after all.
 pub fn rollback_mutated(dir: &Path, mutated: &[PathBuf]) -> Result<()> {
-    persist_restore_set(dir, mutated)?;
-    rollback_filtered(dir, mutated)
+    // The persisted set is a crash guard for the restore below, never a
+    // gate in front of it. When this write fails (ENOSPC can fail the op
+    // and then fail this write to the same volume), the restore must still
+    // run: completed, it clears the journal and needs no filter afterwards,
+    // while skipping it would leave the journal pending for a recovery
+    // that, finding no set, restores every snapshot — the loss the filter
+    // exists to prevent. Only a crash between a failed persist and the end
+    // of the restore still reaches that full recovery.
+    let persisted = persist_restore_set(dir, mutated);
+    match (rollback_filtered(dir, mutated), persisted) {
+        (Ok(()), _) => Ok(()),
+        (Err(restore), Ok(())) => Err(restore),
+        // Both failed: the journal is pending with no filter on disk, so
+        // the recovery that clears it will restore every snapshot. Named
+        // together — the restore error alone reads as a retry of the same
+        // filtered restore, which is not what recovery will run.
+        (Err(restore), Err(persist)) => Err(CoreError::RestoreSetLost {
+            restore: Box::new(restore),
+            persist: Box::new(persist),
+        }),
+    }
 }
 
 fn persist_restore_set(dir: &Path, mutated: &[PathBuf]) -> Result<()> {
@@ -219,125 +244,4 @@ pub fn pending(dir: &Path) -> bool {
 }
 
 #[cfg(test)]
-mod tests {
-    use super::*;
-
-    /// The filtered restore is what keeps a refused apply from destroying
-    /// the very bytes the refusal protected: a path whose op never ran
-    /// keeps whatever a writer outside the transaction put there after the
-    /// journal was taken.
-    #[test]
-    fn a_filtered_rollback_leaves_unmutated_paths_as_the_world_left_them() {
-        let tmp = tempfile::tempdir().unwrap();
-        let work = tmp.path().join("work");
-        fs::create_dir_all(&work).unwrap();
-        let a = work.join("a.md");
-        let b = work.join("kendex.toml");
-        fs::write(&a, "a0").unwrap();
-        fs::write(&b, "b0").unwrap();
-
-        let journal_dir = tmp.path().join("journal/global");
-        write(&journal_dir, &[a.clone(), b.clone()]).unwrap();
-        // The transaction mutates `a`; a writer outside it lands on `b`
-        // before `b`'s own op refuses its precondition.
-        fs::write(&a, "a1").unwrap();
-        fs::write(&b, "external edit").unwrap();
-
-        rollback_mutated(&journal_dir, std::slice::from_ref(&a)).unwrap();
-
-        assert_eq!(fs::read_to_string(&a).unwrap(), "a0");
-        assert_eq!(fs::read_to_string(&b).unwrap(), "external edit");
-        assert!(!pending(&journal_dir));
-    }
-
-    /// A crash mid filtered restore must not widen the restore set: the
-    /// filter was persisted before the first path was touched, recovery
-    /// re-runs exactly it, and the external bytes it left alone survive
-    /// the second pass too.
-    #[test]
-    fn crash_recovery_honors_the_persisted_restore_filter() {
-        let tmp = tempfile::tempdir().unwrap();
-        let work = tmp.path().join("work");
-        fs::create_dir_all(&work).unwrap();
-        let a = work.join("a.md");
-        let b = work.join("kendex.toml");
-        fs::write(&a, "a0").unwrap();
-        fs::write(&b, "b0").unwrap();
-
-        let journal_dir = tmp.path().join("journal/global");
-        write(&journal_dir, &[a.clone(), b.clone()]).unwrap();
-        fs::write(&a, "a1").unwrap();
-        fs::write(&b, "external edit").unwrap();
-        // The filtered restore persisted its set, then the process died
-        // before restoring anything: the journal is still pending.
-        persist_restore_set(&journal_dir, std::slice::from_ref(&a)).unwrap();
-        assert!(pending(&journal_dir));
-
-        rollback(&journal_dir).unwrap();
-
-        assert_eq!(fs::read_to_string(&a).unwrap(), "a0");
-        assert_eq!(fs::read_to_string(&b).unwrap(), "external edit");
-        assert!(!pending(&journal_dir));
-    }
-
-    /// A journaled directory root above a mutated path is part of the
-    /// transaction's footprint: the chain it created comes down with the
-    /// rollback even though only the leaf is named as mutated.
-    #[test]
-    fn a_filtered_rollback_still_removes_the_chain_above_a_mutated_path() {
-        let tmp = tempfile::tempdir().unwrap();
-        let root = tmp.path().join("work/.codex");
-        let leaf = root.join("skills/x.md");
-
-        let journal_dir = tmp.path().join("journal/global");
-        write(&journal_dir, &[leaf.clone(), root.clone()]).unwrap();
-        fs::create_dir_all(leaf.parent().unwrap()).unwrap();
-        fs::write(&leaf, "installed").unwrap();
-
-        rollback_mutated(&journal_dir, std::slice::from_ref(&leaf)).unwrap();
-
-        assert!(!root.exists());
-    }
-
-    #[test]
-    fn rollback_restores_files_dirs_symlinks_and_absence() {
-        let tmp = tempfile::tempdir().unwrap();
-        let work = tmp.path().join("work");
-        fs::create_dir_all(work.join("tree/sub")).unwrap();
-        fs::write(work.join("file.md"), "original").unwrap();
-        fs::write(work.join("tree/sub/x"), "x").unwrap();
-        make_symlink(Path::new("/nowhere"), &work.join("link")).unwrap();
-        let absent = work.join("was-absent");
-
-        let journal_dir = tmp.path().join("journal/global");
-        write(
-            &journal_dir,
-            &[
-                work.join("file.md"),
-                work.join("tree"),
-                work.join("link"),
-                absent.clone(),
-            ],
-        )
-        .unwrap();
-
-        fs::write(work.join("file.md"), "clobbered").unwrap();
-        fs::remove_dir_all(work.join("tree")).unwrap();
-        fs::remove_file(work.join("link")).unwrap();
-        fs::write(&absent, "should vanish").unwrap();
-
-        rollback(&journal_dir).unwrap();
-
-        assert_eq!(
-            fs::read_to_string(work.join("file.md")).unwrap(),
-            "original"
-        );
-        assert_eq!(fs::read_to_string(work.join("tree/sub/x")).unwrap(), "x");
-        assert_eq!(
-            fs::read_link(work.join("link")).unwrap(),
-            Path::new("/nowhere")
-        );
-        assert!(!absent.exists());
-        assert!(!pending(&journal_dir));
-    }
-}
+mod tests;

--- a/crates/core/src/apply/journal.rs
+++ b/crates/core/src/apply/journal.rs
@@ -179,7 +179,12 @@ fn persist_restore_set(dir: &Path, mutated: &[PathBuf]) -> Result<()> {
         path: path.clone(),
         message: e.to_string(),
     })?;
-    crate::fs::atomic_write_durable(&path, &json)
+    crate::fs::atomic_write_durable(&path, &json)?;
+    // The atomic write syncs the file and only tries the directory: the
+    // set is a crash guard, so its name must be on disk before the first
+    // restore touches anything, and a directory sync that fails is a
+    // persist that failed.
+    sync_dir_durable(dir)
 }
 
 fn rollback_filtered(dir: &Path, mutated: &[PathBuf]) -> Result<()> {

--- a/crates/core/src/apply/journal.rs
+++ b/crates/core/src/apply/journal.rs
@@ -4,6 +4,7 @@ use std::path::{Path, PathBuf};
 use serde::{Deserialize, Serialize};
 
 use crate::error::{CoreError, Result};
+use crate::fs::{copy_tree, make_symlink, remove_any, sync_dir, sync_file, sync_tree};
 
 /// Pre-images of everything an apply is about to touch. Restore is
 /// idempotent, so a crash mid-rollback recovers by rolling back again.
@@ -97,40 +98,28 @@ pub fn write(dir: &Path, paths: &[PathBuf]) -> Result<()> {
     Ok(())
 }
 
-fn sync_file(path: &Path) -> Result<()> {
-    fs::File::open(path)
-        .and_then(|f| f.sync_all())
-        .map_err(|e| CoreError::io(path, e))
+/// Where a filtered restore persists its filter before touching anything.
+/// Crash recovery must re-run the same filter, not widen to every
+/// snapshot: the paths the filter excludes hold bytes a writer outside
+/// the transaction landed, the very bytes whose refusal triggered the
+/// restore.
+fn restore_set_path(dir: &Path) -> PathBuf {
+    dir.join("restore.json")
 }
 
-/// Directory fsync is a no-op on platforms where directories cannot be
-/// opened (Windows); rename durability there rides on the volume flush.
-fn sync_dir(path: &Path) {
-    #[cfg(unix)]
-    if let Ok(dir) = fs::File::open(path) {
-        let _ = dir.sync_all();
-    }
-    #[cfg(not(unix))]
-    let _ = path;
-}
-
-fn sync_tree(root: &Path) -> Result<()> {
-    if root.is_file() {
-        return sync_file(root);
-    }
-    if let Ok(entries) = fs::read_dir(root) {
-        for entry in entries.flatten() {
-            sync_tree(&entry.path())?;
-        }
-        sync_dir(root);
-    }
-    Ok(())
-}
-
-/// Restore every pre-image. Used both for in-process rollback after a
-/// mid-mutation failure and for crash recovery on the next run, where
-/// nothing can know which ops ran.
+/// Crash recovery: restore pre-images for a journal an interrupted apply
+/// left behind. An interrupted filtered restore persisted its restore set
+/// first, so recovery re-runs exactly that filter; with no persisted set,
+/// nothing can know which ops ran and every pre-image is restored.
 pub fn rollback(dir: &Path) -> Result<()> {
+    // The set is written atomically, so it is complete or absent; a parse
+    // failure is outside corruption, and the full restore below is the
+    // only set recovery can still justify.
+    if let Some(text) = crate::fs::read_if_exists(&restore_set_path(dir))?
+        && let Ok(mutated) = serde_json::from_str::<Vec<PathBuf>>(&text)
+    {
+        return rollback_filtered(dir, &mutated);
+    }
     rollback_where(dir, |_| true)
 }
 
@@ -140,10 +129,25 @@ pub fn rollback(dir: &Path) -> Result<()> {
 /// which ops ran; restoring the rest would put the journal's snapshot over
 /// bytes a writer outside the transaction landed after the journal was
 /// taken — the precondition that stopped the apply refused to overwrite
-/// those bytes, so the rollback must not either. A crash between this
-/// restore and the journal clearing still recovers with the full
-/// [`rollback`], which cannot make that distinction.
+/// those bytes, so the rollback must not either. The restore set is made
+/// durable before the first path is touched, so a crash mid-restore
+/// recovers with the same filter instead of falling back to a full
+/// restore that would destroy those protected bytes after all.
 pub fn rollback_mutated(dir: &Path, mutated: &[PathBuf]) -> Result<()> {
+    persist_restore_set(dir, mutated)?;
+    rollback_filtered(dir, mutated)
+}
+
+fn persist_restore_set(dir: &Path, mutated: &[PathBuf]) -> Result<()> {
+    let path = restore_set_path(dir);
+    let json = serde_json::to_string_pretty(mutated).map_err(|e| CoreError::JsonParse {
+        path: path.clone(),
+        message: e.to_string(),
+    })?;
+    crate::fs::atomic_write_durable(&path, &json)
+}
+
+fn rollback_filtered(dir: &Path, mutated: &[PathBuf]) -> Result<()> {
     rollback_where(dir, |path| {
         mutated.iter().any(|m| m == path || m.starts_with(path))
     })
@@ -214,52 +218,6 @@ pub fn pending(dir: &Path) -> bool {
     dir.join("meta.json").is_file()
 }
 
-pub fn remove_any(path: &Path) -> Result<()> {
-    if path.is_symlink() || path.is_file() {
-        fs::remove_file(path).map_err(|e| CoreError::io(path, e))?;
-    } else if path.is_dir() {
-        fs::remove_dir_all(path).map_err(|e| CoreError::io(path, e))?;
-    }
-    Ok(())
-}
-
-pub fn copy_tree(from: &Path, to: &Path) -> Result<()> {
-    fs::create_dir_all(to).map_err(|e| CoreError::io(to, e))?;
-    for entry in fs::read_dir(from)
-        .map_err(|e| CoreError::io(from, e))?
-        .flatten()
-    {
-        let source = entry.path();
-        let Some(name) = source.file_name() else {
-            continue;
-        };
-        let dest = to.join(name);
-        if source.is_symlink() {
-            let target = fs::read_link(&source).map_err(|e| CoreError::io(&source, e))?;
-            make_symlink(&target, &dest)?;
-        } else if source.is_dir() {
-            copy_tree(&source, &dest)?;
-        } else {
-            fs::copy(&source, &dest).map_err(|e| CoreError::io(&source, e))?;
-        }
-    }
-    Ok(())
-}
-
-#[cfg(unix)]
-pub fn make_symlink(target: &Path, link: &Path) -> Result<()> {
-    std::os::unix::fs::symlink(target, link).map_err(|e| CoreError::io(link, e))
-}
-
-#[cfg(windows)]
-pub fn make_symlink(target: &Path, link: &Path) -> Result<()> {
-    if target.is_dir() {
-        std::os::windows::fs::symlink_dir(target, link).map_err(|e| CoreError::io(link, e))
-    } else {
-        std::os::windows::fs::symlink_file(target, link).map_err(|e| CoreError::io(link, e))
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -286,6 +244,36 @@ mod tests {
         fs::write(&b, "external edit").unwrap();
 
         rollback_mutated(&journal_dir, std::slice::from_ref(&a)).unwrap();
+
+        assert_eq!(fs::read_to_string(&a).unwrap(), "a0");
+        assert_eq!(fs::read_to_string(&b).unwrap(), "external edit");
+        assert!(!pending(&journal_dir));
+    }
+
+    /// A crash mid filtered restore must not widen the restore set: the
+    /// filter was persisted before the first path was touched, recovery
+    /// re-runs exactly it, and the external bytes it left alone survive
+    /// the second pass too.
+    #[test]
+    fn crash_recovery_honors_the_persisted_restore_filter() {
+        let tmp = tempfile::tempdir().unwrap();
+        let work = tmp.path().join("work");
+        fs::create_dir_all(&work).unwrap();
+        let a = work.join("a.md");
+        let b = work.join("kendex.toml");
+        fs::write(&a, "a0").unwrap();
+        fs::write(&b, "b0").unwrap();
+
+        let journal_dir = tmp.path().join("journal/global");
+        write(&journal_dir, &[a.clone(), b.clone()]).unwrap();
+        fs::write(&a, "a1").unwrap();
+        fs::write(&b, "external edit").unwrap();
+        // The filtered restore persisted its set, then the process died
+        // before restoring anything: the journal is still pending.
+        persist_restore_set(&journal_dir, std::slice::from_ref(&a)).unwrap();
+        assert!(pending(&journal_dir));
+
+        rollback(&journal_dir).unwrap();
 
         assert_eq!(fs::read_to_string(&a).unwrap(), "a0");
         assert_eq!(fs::read_to_string(&b).unwrap(), "external edit");

--- a/crates/core/src/apply/journal.rs
+++ b/crates/core/src/apply/journal.rs
@@ -4,7 +4,9 @@ use std::path::{Path, PathBuf};
 use serde::{Deserialize, Serialize};
 
 use crate::error::{CoreError, Result};
-use crate::fs::{copy_tree, make_symlink, remove_any, sync_dir, sync_file, sync_tree};
+use crate::fs::{
+    copy_tree, make_symlink, remove_any, sync_dir, sync_dir_durable, sync_file, sync_tree,
+};
 
 /// Pre-images of everything an apply is about to touch. Restore is
 /// idempotent, so a crash mid-rollback recovers by rolling back again.
@@ -247,10 +249,12 @@ pub fn clear(dir: &Path) -> Result<()> {
     // not meta.json would leave a pending journal with no restore set,
     // for a recovery that restores every snapshot — over the paths the
     // filter left alone. With meta gone the dir is a leftover the next
-    // recovery pass sweeps, never a journal it replays.
+    // recovery pass sweeps, never a journal it replays. A sync that fails
+    // stops here: the sweep may not run while meta's removal is still
+    // only in memory.
     let meta = dir.join("meta.json");
     match fs::remove_file(&meta) {
-        Ok(()) => sync_dir(dir),
+        Ok(()) => sync_dir_durable(dir)?,
         Err(e) if e.kind() == std::io::ErrorKind::NotFound => {}
         Err(e) => return Err(CoreError::io(&meta, e)),
     }

--- a/crates/core/src/apply/journal/tests.rs
+++ b/crates/core/src/apply/journal/tests.rs
@@ -171,6 +171,62 @@ fn a_restore_failing_with_its_set_unsaved_names_both_failures() {
     assert!(pending(&journal_dir));
 }
 
+/// With meta.json gone the dir is a leftover, not a journal: recovery
+/// reads it as non-pending and sweeps it instead of replaying it.
+#[test]
+fn a_journal_without_meta_is_not_pending_and_is_swept() {
+    let tmp = tempfile::tempdir().unwrap();
+    let a = tmp.path().join("work/a.md");
+    fs::create_dir_all(a.parent().unwrap()).unwrap();
+    fs::write(&a, "a0").unwrap();
+    let journal_dir = tmp.path().join("journal/global");
+    write(&journal_dir, std::slice::from_ref(&a)).unwrap();
+    persist_restore_set(&journal_dir, std::slice::from_ref(&a)).unwrap();
+    fs::write(&a, "a1").unwrap();
+
+    fs::remove_file(journal_dir.join("meta.json")).unwrap();
+    assert!(!pending(&journal_dir));
+    clear(&journal_dir).unwrap();
+    assert!(!journal_dir.exists());
+    assert_eq!(fs::read_to_string(&a).unwrap(), "a1");
+}
+
+/// `clear` takes meta.json down before anything else: a sweep that dies
+/// midway leaves a leftover the next pass finishes, never a pending
+/// journal whose restore set already went. Pinned by a sweep that cannot
+/// finish — a subdirectory nothing may unlink from — after which meta is
+/// gone and the journal reads as non-pending.
+#[cfg(unix)]
+#[test]
+fn clear_takes_meta_down_before_the_sweep() {
+    use std::os::unix::fs::PermissionsExt as _;
+    let tmp = tempfile::tempdir().unwrap();
+    let a = tmp.path().join("work/a.md");
+    fs::create_dir_all(a.parent().unwrap()).unwrap();
+    fs::write(&a, "a0").unwrap();
+    let journal_dir = tmp.path().join("journal/global");
+    write(&journal_dir, std::slice::from_ref(&a)).unwrap();
+    persist_restore_set(&journal_dir, std::slice::from_ref(&a)).unwrap();
+
+    let locked = journal_dir.join("store/locked");
+    fs::create_dir(&locked).unwrap();
+    fs::write(locked.join("held"), "").unwrap();
+    fs::set_permissions(&locked, fs::Permissions::from_mode(0o500)).unwrap();
+    let unlock = || fs::set_permissions(&locked, fs::Permissions::from_mode(0o700)).unwrap();
+    if fs::write(locked.join("probe"), "").is_ok() {
+        // Permissions do not bind this user (root): the sweep cannot be
+        // made to fail here, so the order cannot be observed.
+        unlock();
+        return;
+    }
+
+    let error = clear(&journal_dir).unwrap_err();
+    assert!(matches!(error, CoreError::Io { .. }), "{error:?}");
+    assert!(!journal_dir.join("meta.json").exists());
+    assert!(!pending(&journal_dir));
+    unlock();
+}
+
 /// A journaled directory root above a mutated path is part of the
 /// transaction's footprint: the chain it created comes down with the
 /// rollback even though only the leaf is named as mutated.

--- a/crates/core/src/apply/journal/tests.rs
+++ b/crates/core/src/apply/journal/tests.rs
@@ -257,6 +257,30 @@ fn a_restore_set_whose_directory_cannot_be_synced_is_not_persisted() {
     unlock();
 }
 
+/// A directory holding a link back into itself journals and restores:
+/// the snapshot copies the link as a link, and syncing the copy treats it
+/// as a leaf instead of walking the same directory through it again.
+#[cfg(unix)]
+#[test]
+fn a_dir_linking_to_itself_journals_and_restores() {
+    let tmp = tempfile::tempdir().unwrap();
+    let dir = tmp.path().join("work/skill");
+    fs::create_dir_all(&dir).unwrap();
+    fs::write(dir.join("SKILL.md"), "v1").unwrap();
+    std::os::unix::fs::symlink(".", dir.join("loop")).unwrap();
+
+    let journal_dir = tmp.path().join("journal/global");
+    write(&journal_dir, std::slice::from_ref(&dir)).unwrap();
+    fs::write(dir.join("SKILL.md"), "v2").unwrap();
+    fs::remove_file(dir.join("loop")).unwrap();
+
+    rollback(&journal_dir).unwrap();
+    assert_eq!(fs::read_to_string(dir.join("SKILL.md")).unwrap(), "v1");
+    assert!(dir.join("loop").is_symlink());
+    assert_eq!(fs::read_link(dir.join("loop")).unwrap().as_os_str(), ".");
+    assert!(!pending(&journal_dir));
+}
+
 /// A journaled directory root above a mutated path is part of the
 /// transaction's footprint: the chain it created comes down with the
 /// rollback even though only the leaf is named as mutated.

--- a/crates/core/src/apply/journal/tests.rs
+++ b/crates/core/src/apply/journal/tests.rs
@@ -1,0 +1,233 @@
+use super::*;
+
+/// The filtered restore is what keeps a refused apply from destroying
+/// the very bytes the refusal protected: a path whose op never ran
+/// keeps whatever a writer outside the transaction put there after the
+/// journal was taken.
+#[test]
+fn a_filtered_rollback_leaves_unmutated_paths_as_the_world_left_them() {
+    let tmp = tempfile::tempdir().unwrap();
+    let work = tmp.path().join("work");
+    fs::create_dir_all(&work).unwrap();
+    let a = work.join("a.md");
+    let b = work.join("kendex.toml");
+    fs::write(&a, "a0").unwrap();
+    fs::write(&b, "b0").unwrap();
+
+    let journal_dir = tmp.path().join("journal/global");
+    write(&journal_dir, &[a.clone(), b.clone()]).unwrap();
+    // The transaction mutates `a`; a writer outside it lands on `b`
+    // before `b`'s own op refuses its precondition.
+    fs::write(&a, "a1").unwrap();
+    fs::write(&b, "external edit").unwrap();
+
+    rollback_mutated(&journal_dir, std::slice::from_ref(&a)).unwrap();
+
+    assert_eq!(fs::read_to_string(&a).unwrap(), "a0");
+    assert_eq!(fs::read_to_string(&b).unwrap(), "external edit");
+    assert!(!pending(&journal_dir));
+}
+
+/// A crash mid filtered restore must not widen the restore set: the
+/// filter was persisted before the first path was touched, recovery
+/// re-runs exactly it, and the external bytes it left alone survive
+/// the second pass too.
+#[test]
+fn crash_recovery_honors_the_persisted_restore_filter() {
+    let tmp = tempfile::tempdir().unwrap();
+    let work = tmp.path().join("work");
+    fs::create_dir_all(&work).unwrap();
+    let a = work.join("a.md");
+    let b = work.join("kendex.toml");
+    fs::write(&a, "a0").unwrap();
+    fs::write(&b, "b0").unwrap();
+
+    let journal_dir = tmp.path().join("journal/global");
+    write(&journal_dir, &[a.clone(), b.clone()]).unwrap();
+    fs::write(&a, "a1").unwrap();
+    fs::write(&b, "external edit").unwrap();
+    // The filtered restore persisted its set, then the process died
+    // before restoring anything: the journal is still pending.
+    persist_restore_set(&journal_dir, std::slice::from_ref(&a)).unwrap();
+    assert!(pending(&journal_dir));
+
+    rollback(&journal_dir).unwrap();
+
+    assert_eq!(fs::read_to_string(&a).unwrap(), "a0");
+    assert_eq!(fs::read_to_string(&b).unwrap(), "external edit");
+    assert!(!pending(&journal_dir));
+}
+
+/// The persisted set guards a crash; it must never gate the restore.
+/// With the persist failing (a directory squatting on its path forces
+/// the atomic rename to fail), the filtered restore still runs and
+/// clears the journal — skipping it would hand recovery an unfiltered
+/// full restore over the external bytes.
+#[test]
+fn a_failed_restore_set_persist_does_not_skip_the_filtered_restore() {
+    let tmp = tempfile::tempdir().unwrap();
+    let work = tmp.path().join("work");
+    fs::create_dir_all(&work).unwrap();
+    let a = work.join("a.md");
+    let b = work.join("kendex.toml");
+    fs::write(&a, "a0").unwrap();
+    fs::write(&b, "b0").unwrap();
+
+    let journal_dir = tmp.path().join("journal/global");
+    write(&journal_dir, &[a.clone(), b.clone()]).unwrap();
+    fs::write(&a, "a1").unwrap();
+    fs::write(&b, "external edit").unwrap();
+    fs::create_dir(restore_set_path(&journal_dir)).unwrap();
+
+    rollback_mutated(&journal_dir, std::slice::from_ref(&a)).unwrap();
+
+    assert_eq!(fs::read_to_string(&a).unwrap(), "a0");
+    assert_eq!(fs::read_to_string(&b).unwrap(), "external edit");
+    assert!(!pending(&journal_dir));
+}
+
+/// A restore set that exists but does not parse is outside
+/// interference over a file the atomic write cannot tear. Falling back
+/// to the full restore would destroy the bytes the filter protects, so
+/// recovery refuses loudly and the journal stays pending.
+#[test]
+fn a_corrupt_restore_set_refuses_recovery_instead_of_widening_it() {
+    let tmp = tempfile::tempdir().unwrap();
+    let work = tmp.path().join("work");
+    fs::create_dir_all(&work).unwrap();
+    let b = work.join("kendex.toml");
+    fs::write(&b, "b0").unwrap();
+
+    let journal_dir = tmp.path().join("journal/global");
+    write(&journal_dir, std::slice::from_ref(&b)).unwrap();
+    fs::write(&b, "external edit").unwrap();
+    fs::write(restore_set_path(&journal_dir), "not json").unwrap();
+
+    let error = rollback(&journal_dir).unwrap_err();
+    assert!(matches!(error, CoreError::JsonParse { .. }), "{error:?}");
+    assert_eq!(fs::read_to_string(&b).unwrap(), "external edit");
+    assert!(pending(&journal_dir));
+}
+
+/// A restore that fails midway leaves the persisted filter behind for
+/// recovery: the set goes down before the first path is touched, so
+/// the re-run restores the same paths and no more.
+#[test]
+fn a_restore_failing_midway_leaves_the_filter_for_recovery() {
+    let tmp = tempfile::tempdir().unwrap();
+    let work = tmp.path().join("work");
+    fs::create_dir_all(&work).unwrap();
+    let a = work.join("a.md");
+    let b = work.join("kendex.toml");
+    fs::write(&a, "a0").unwrap();
+    fs::write(&b, "b0").unwrap();
+
+    let journal_dir = tmp.path().join("journal/global");
+    write(&journal_dir, &[a.clone(), b.clone()]).unwrap();
+    fs::write(&a, "a1").unwrap();
+    fs::write(&b, "external edit").unwrap();
+    // The pre-image slot for `a` is gone, so its copy-back fails after
+    // the filter was persisted and `a` was already removed.
+    let slot = journal_dir.join("store/0");
+    fs::remove_file(&slot).unwrap();
+
+    rollback_mutated(&journal_dir, std::slice::from_ref(&a)).unwrap_err();
+    assert!(restore_set_path(&journal_dir).is_file());
+    assert!(pending(&journal_dir));
+
+    // With the slot repaired, recovery re-runs the persisted filter:
+    // `a` comes back, and the external bytes at `b` still stand.
+    fs::write(&slot, "a0").unwrap();
+    rollback(&journal_dir).unwrap();
+    assert_eq!(fs::read_to_string(&a).unwrap(), "a0");
+    assert_eq!(fs::read_to_string(&b).unwrap(), "external edit");
+    assert!(!pending(&journal_dir));
+}
+
+/// Both halves failing is the one path that reaches an unfiltered
+/// recovery, and the error says so with both failures in it: the restore
+/// error alone would read as a retry of the same filtered restore.
+#[test]
+fn a_restore_failing_with_its_set_unsaved_names_both_failures() {
+    let tmp = tempfile::tempdir().unwrap();
+    let work = tmp.path().join("work");
+    fs::create_dir_all(&work).unwrap();
+    let a = work.join("a.md");
+    fs::write(&a, "a0").unwrap();
+
+    let journal_dir = tmp.path().join("journal/global");
+    write(&journal_dir, std::slice::from_ref(&a)).unwrap();
+    fs::write(&a, "a1").unwrap();
+    fs::create_dir(restore_set_path(&journal_dir)).unwrap();
+    fs::remove_file(journal_dir.join("store/0")).unwrap();
+
+    let error = rollback_mutated(&journal_dir, std::slice::from_ref(&a)).unwrap_err();
+    assert!(
+        matches!(&error, CoreError::RestoreSetLost { restore, persist }
+            if matches!(**restore, CoreError::Io { .. })
+                && matches!(**persist, CoreError::Io { .. })),
+        "{error:?}"
+    );
+    assert!(pending(&journal_dir));
+}
+
+/// A journaled directory root above a mutated path is part of the
+/// transaction's footprint: the chain it created comes down with the
+/// rollback even though only the leaf is named as mutated.
+#[test]
+fn a_filtered_rollback_still_removes_the_chain_above_a_mutated_path() {
+    let tmp = tempfile::tempdir().unwrap();
+    let root = tmp.path().join("work/.codex");
+    let leaf = root.join("skills/x.md");
+
+    let journal_dir = tmp.path().join("journal/global");
+    write(&journal_dir, &[leaf.clone(), root.clone()]).unwrap();
+    fs::create_dir_all(leaf.parent().unwrap()).unwrap();
+    fs::write(&leaf, "installed").unwrap();
+
+    rollback_mutated(&journal_dir, std::slice::from_ref(&leaf)).unwrap();
+
+    assert!(!root.exists());
+}
+
+#[test]
+fn rollback_restores_files_dirs_symlinks_and_absence() {
+    let tmp = tempfile::tempdir().unwrap();
+    let work = tmp.path().join("work");
+    fs::create_dir_all(work.join("tree/sub")).unwrap();
+    fs::write(work.join("file.md"), "original").unwrap();
+    fs::write(work.join("tree/sub/x"), "x").unwrap();
+    make_symlink(Path::new("/nowhere"), &work.join("link")).unwrap();
+    let absent = work.join("was-absent");
+
+    let journal_dir = tmp.path().join("journal/global");
+    write(
+        &journal_dir,
+        &[
+            work.join("file.md"),
+            work.join("tree"),
+            work.join("link"),
+            absent.clone(),
+        ],
+    )
+    .unwrap();
+
+    fs::write(work.join("file.md"), "clobbered").unwrap();
+    fs::remove_dir_all(work.join("tree")).unwrap();
+    fs::remove_file(work.join("link")).unwrap();
+    fs::write(&absent, "should vanish").unwrap();
+
+    rollback(&journal_dir).unwrap();
+
+    assert_eq!(
+        fs::read_to_string(work.join("file.md")).unwrap(),
+        "original"
+    );
+    assert_eq!(fs::read_to_string(work.join("tree/sub/x")).unwrap(), "x");
+    assert_eq!(
+        fs::read_link(work.join("link")).unwrap(),
+        Path::new("/nowhere")
+    );
+    assert!(!absent.exists());
+    assert!(!pending(&journal_dir));
+}

--- a/crates/core/src/apply/journal/tests.rs
+++ b/crates/core/src/apply/journal/tests.rs
@@ -227,6 +227,36 @@ fn clear_takes_meta_down_before_the_sweep() {
     unlock();
 }
 
+/// The persisted set is only persisted once its name is on disk: a
+/// journal directory that cannot be synced makes the persist fail, where
+/// the write itself, file synced and renamed into place, would have
+/// reported success. Pinned with a directory that takes new files but
+/// cannot be opened to sync.
+#[cfg(unix)]
+#[test]
+fn a_restore_set_whose_directory_cannot_be_synced_is_not_persisted() {
+    use std::os::unix::fs::PermissionsExt as _;
+    let tmp = tempfile::tempdir().unwrap();
+    let a = tmp.path().join("work/a.md");
+    fs::create_dir_all(a.parent().unwrap()).unwrap();
+    fs::write(&a, "a0").unwrap();
+    let journal_dir = tmp.path().join("journal/global");
+    write(&journal_dir, std::slice::from_ref(&a)).unwrap();
+
+    fs::set_permissions(&journal_dir, fs::Permissions::from_mode(0o300)).unwrap();
+    let unlock = || fs::set_permissions(&journal_dir, fs::Permissions::from_mode(0o700)).unwrap();
+    if fs::File::open(&journal_dir).is_ok() {
+        // Permissions do not bind this user (root): the sync cannot be
+        // made to fail here.
+        unlock();
+        return;
+    }
+
+    let error = persist_restore_set(&journal_dir, std::slice::from_ref(&a)).unwrap_err();
+    assert!(matches!(error, CoreError::Io { .. }), "{error:?}");
+    unlock();
+}
+
 /// A journaled directory root above a mutated path is part of the
 /// transaction's footprint: the chain it created comes down with the
 /// rollback even though only the leaf is named as mutated.

--- a/crates/core/src/apply/mod.rs
+++ b/crates/core/src/apply/mod.rs
@@ -1,5 +1,4 @@
 use std::fs;
-use std::path::PathBuf;
 
 use crate::env::Env;
 use crate::error::{CoreError, Result};
@@ -9,9 +8,11 @@ mod common;
 pub mod journal;
 mod op;
 mod pre;
+mod transaction;
 
 pub use common::{common_key, execute_common, recover_common_journals};
 pub use op::{Op, Plan, PlannedOp, Pre, read_git_config};
+use transaction::run_journaled;
 
 /// Filesystem-safe key naming a scope's journal dir and lock file. Keys off
 /// the canonical scope so two spellings of one root can never hold two
@@ -108,131 +109,14 @@ pub fn execute(env: &Env, plan: &Plan, fail_after: Option<usize>) -> Result<Appl
     })
 }
 
-/// The one transaction engine, under a lock the caller already holds for
-/// `key` and after it recovered: journal every pre-image, run the ops in
-/// order, roll back on the first failure. Returns how many ops ran.
-fn run_journaled(
-    env: &Env,
-    ops: &[PlannedOp],
-    key: &str,
-    fail_after: Option<usize>,
-) -> Result<usize> {
-    // Nothing to do leaves nothing behind: an empty journal would read as
-    // an interrupted apply to the next recovery pass.
-    if ops.is_empty() {
-        return Ok(0);
-    }
-    let journal_dir = journal::journal_dir_for(&env.journal_dir(), key);
-    let mut touched: Vec<PathBuf> = ops.iter().flat_map(|p| p.op.touched()).collect();
-    touched.extend(created_dir_roots(&touched));
-    journal::write(&journal_dir, &touched)?;
-
-    for (index, planned) in ops.iter().enumerate() {
-        if fail_after == Some(index) {
-            // The injected fault lands before the op runs, so it mutated
-            // nothing — same restore set as a precondition refusal.
-            let error = CoreError::Injected;
-            journal::rollback_mutated(&journal_dir, &mutated_before_failure(ops, index, &error))?;
-            return Err(CoreError::RolledBack {
-                reason: format!("injected fault before '{}'", planned.description),
-                cause: Box::new(error),
-            });
-        }
-        if let Err(error) = planned.op.run(env) {
-            journal::rollback_mutated(&journal_dir, &mutated_before_failure(ops, index, &error))?;
-            return Err(CoreError::RolledBack {
-                reason: format!("'{}' failed: {error}", planned.description),
-                cause: Box::new(error),
-            });
-        }
-    }
-    journal::clear(&journal_dir)?;
-    Ok(ops.len())
-}
-
-/// The paths this transaction mutated by the time op `index` failed with
-/// `error` — the restore set for the in-process rollback. Every op checks
-/// its precondition before touching anything, so a `PlanStale` failure
-/// (and the test-only injected fault, which fires before the op runs)
-/// means op `index` mutated nothing: restoring its paths anyway would put
-/// the journal's snapshot over the very bytes the refusal protected, when
-/// a writer outside the transaction landed them after the journal was
-/// taken. Any other failure may have left op `index` half-done, so its
-/// paths are restored too.
-fn mutated_before_failure(ops: &[PlannedOp], index: usize, error: &CoreError) -> Vec<PathBuf> {
-    let ran = match error {
-        CoreError::PlanStale { .. } | CoreError::Injected => &ops[..index],
-        _ => &ops[..=index],
-    };
-    ran.iter().flat_map(|p| p.op.touched()).collect()
-}
-
-/// The top of every directory chain the plan's `create_dir_all` calls will
-/// bring into being. Journaled as absent, so rollback deletes the whole
-/// chain — an empty `.codex/` left behind is not cosmetic, it is what
-/// harness and project detection read as "installed here".
-fn created_dir_roots(touched: &[PathBuf]) -> Vec<PathBuf> {
-    let mut roots: Vec<PathBuf> = Vec::new();
-    for path in touched {
-        let mut topmost_missing = None;
-        let mut ancestor = path.parent();
-        while let Some(dir) = ancestor {
-            if dir.as_os_str().is_empty() || dir.exists() {
-                break;
-            }
-            topmost_missing = Some(dir.to_path_buf());
-            ancestor = dir.parent();
-        }
-        if let Some(root) = topmost_missing
-            && !touched.contains(&root)
-            && !roots.contains(&root)
-        {
-            roots.push(root);
-        }
-    }
-    roots
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
     use crate::env::FakeOs;
-    use std::path::Path;
+    use std::path::{Path, PathBuf};
 
     fn env_in(dir: &Path) -> Env {
         Env::fake(dir, FakeOs::Linux)
-    }
-
-    /// The restore-set split behind the filtered rollback: a refusal that
-    /// provably mutated nothing keeps its own paths out of the restore, so
-    /// the bytes it refused to overwrite survive the rollback too; a
-    /// failure that may have half-run restores them.
-    #[test]
-    fn a_refusal_keeps_its_own_paths_out_of_the_restore_set() {
-        let a = PathBuf::from("/w/a.md");
-        let b = PathBuf::from("/w/kendex.toml");
-        let op = |path: &PathBuf| PlannedOp {
-            description: "write".into(),
-            op: Op::WriteFile {
-                pre: Pre::Any,
-                path: path.clone(),
-                bytes: Vec::new(),
-            },
-        };
-        let ops = [op(&a), op(&b)];
-
-        let refused = CoreError::PlanStale { path: b.clone() };
-        assert_eq!(
-            mutated_before_failure(&ops, 1, &refused),
-            std::slice::from_ref(&a)
-        );
-        assert_eq!(
-            mutated_before_failure(&ops, 1, &CoreError::Injected),
-            std::slice::from_ref(&a)
-        );
-
-        let half_done = CoreError::io(&b, std::io::Error::other("disk full"));
-        assert_eq!(mutated_before_failure(&ops, 1, &half_done), [a, b]);
     }
 
     fn write_plan(scope: Scope, path: PathBuf, content: &str, pre: Pre) -> Plan {

--- a/crates/core/src/apply/mod.rs
+++ b/crates/core/src/apply/mod.rs
@@ -132,12 +132,14 @@ fn run_journaled(
             journal::rollback(&journal_dir)?;
             return Err(CoreError::RolledBack {
                 reason: format!("injected fault before '{}'", planned.description),
+                cause: Box::new(CoreError::Injected),
             });
         }
         if let Err(error) = planned.op.run(env) {
             journal::rollback(&journal_dir)?;
             return Err(CoreError::RolledBack {
                 reason: format!("'{}' failed: {error}", planned.description),
+                cause: Box::new(error),
             });
         }
     }

--- a/crates/core/src/apply/mod.rs
+++ b/crates/core/src/apply/mod.rs
@@ -129,14 +129,17 @@ fn run_journaled(
 
     for (index, planned) in ops.iter().enumerate() {
         if fail_after == Some(index) {
-            journal::rollback(&journal_dir)?;
+            // The injected fault lands before the op runs, so it mutated
+            // nothing — same restore set as a precondition refusal.
+            let error = CoreError::Injected;
+            journal::rollback_mutated(&journal_dir, &mutated_before_failure(ops, index, &error))?;
             return Err(CoreError::RolledBack {
                 reason: format!("injected fault before '{}'", planned.description),
-                cause: Box::new(CoreError::Injected),
+                cause: Box::new(error),
             });
         }
         if let Err(error) = planned.op.run(env) {
-            journal::rollback(&journal_dir)?;
+            journal::rollback_mutated(&journal_dir, &mutated_before_failure(ops, index, &error))?;
             return Err(CoreError::RolledBack {
                 reason: format!("'{}' failed: {error}", planned.description),
                 cause: Box::new(error),
@@ -145,6 +148,23 @@ fn run_journaled(
     }
     journal::clear(&journal_dir)?;
     Ok(ops.len())
+}
+
+/// The paths this transaction mutated by the time op `index` failed with
+/// `error` — the restore set for the in-process rollback. Every op checks
+/// its precondition before touching anything, so a `PlanStale` failure
+/// (and the test-only injected fault, which fires before the op runs)
+/// means op `index` mutated nothing: restoring its paths anyway would put
+/// the journal's snapshot over the very bytes the refusal protected, when
+/// a writer outside the transaction landed them after the journal was
+/// taken. Any other failure may have left op `index` half-done, so its
+/// paths are restored too.
+fn mutated_before_failure(ops: &[PlannedOp], index: usize, error: &CoreError) -> Vec<PathBuf> {
+    let ran = match error {
+        CoreError::PlanStale { .. } | CoreError::Injected => &ops[..index],
+        _ => &ops[..=index],
+    };
+    ran.iter().flat_map(|p| p.op.touched()).collect()
 }
 
 /// The top of every directory chain the plan's `create_dir_all` calls will
@@ -181,6 +201,38 @@ mod tests {
 
     fn env_in(dir: &Path) -> Env {
         Env::fake(dir, FakeOs::Linux)
+    }
+
+    /// The restore-set split behind the filtered rollback: a refusal that
+    /// provably mutated nothing keeps its own paths out of the restore, so
+    /// the bytes it refused to overwrite survive the rollback too; a
+    /// failure that may have half-run restores them.
+    #[test]
+    fn a_refusal_keeps_its_own_paths_out_of_the_restore_set() {
+        let a = PathBuf::from("/w/a.md");
+        let b = PathBuf::from("/w/kendex.toml");
+        let op = |path: &PathBuf| PlannedOp {
+            description: "write".into(),
+            op: Op::WriteFile {
+                pre: Pre::Any,
+                path: path.clone(),
+                bytes: Vec::new(),
+            },
+        };
+        let ops = [op(&a), op(&b)];
+
+        let refused = CoreError::PlanStale { path: b.clone() };
+        assert_eq!(
+            mutated_before_failure(&ops, 1, &refused),
+            std::slice::from_ref(&a)
+        );
+        assert_eq!(
+            mutated_before_failure(&ops, 1, &CoreError::Injected),
+            std::slice::from_ref(&a)
+        );
+
+        let half_done = CoreError::io(&b, std::io::Error::other("disk full"));
+        assert_eq!(mutated_before_failure(&ops, 1, &half_done), [a, b]);
     }
 
     fn write_plan(scope: Scope, path: PathBuf, content: &str, pre: Pre) -> Plan {

--- a/crates/core/src/apply/op.rs
+++ b/crates/core/src/apply/op.rs
@@ -1,7 +1,6 @@
 use std::fs;
 use std::path::{Path, PathBuf};
 
-use super::journal;
 pub use super::pre::Pre;
 use crate::env::Env;
 use crate::error::{CoreError, Result};
@@ -30,6 +29,13 @@ pub enum Op {
     Rename {
         from: PathBuf,
         to: PathBuf,
+        /// Checked against `from`: the bytes the plan proved it may move.
+        /// A writer outside the transaction landing on the source after
+        /// the journal snapshot must abort the move — a completed rename
+        /// puts its paths in the restore set, so a later refusal's
+        /// rollback would delete the moved bytes and restore the old
+        /// snapshot over the source.
+        from_pre: Pre,
         /// Checked against `to`: rename(2) replaces its destination
         /// silently, so a file that appeared since planning must abort.
         to_pre: Pre,
@@ -97,6 +103,10 @@ impl Op {
         }
     }
 
+    /// Contract for every arm: `PlanStale` may only be returned before the
+    /// op has mutated anything, because the in-process rollback takes that
+    /// error as proof the failing op ran nothing and leaves its paths out
+    /// of the restore set (see `mutated_before_failure`).
     pub(super) fn run(&self, env: &Env) -> Result<()> {
         match self {
             Op::WriteFile { path, bytes, pre } => {
@@ -115,9 +125,15 @@ impl Op {
                 if link.is_symlink() {
                     fs::remove_file(link).map_err(|e| CoreError::io(link, e))?;
                 }
-                journal::make_symlink(target, link)
+                crate::fs::make_symlink(target, link)
             }
-            Op::Rename { from, to, to_pre } => {
+            Op::Rename {
+                from,
+                to,
+                from_pre,
+                to_pre,
+            } => {
+                from_pre.check(from)?;
                 to_pre.check(to)?;
                 fs::rename(from, to).map_err(|e| CoreError::io(from, e))
             }
@@ -133,11 +149,11 @@ impl Op {
                 if fs::rename(path, &dest).is_err() {
                     // Cross-device: copy then remove.
                     if path.is_dir() {
-                        journal::copy_tree(path, &dest)?;
+                        crate::fs::copy_tree(path, &dest)?;
                     } else {
                         fs::copy(path, &dest).map_err(|e| CoreError::io(path, e))?;
                     }
-                    journal::remove_any(path)?;
+                    crate::fs::remove_any(path)?;
                 }
                 Ok(())
             }
@@ -193,7 +209,7 @@ impl Op {
 
 fn write_tree(root: &Path, files: &[(PathBuf, Vec<u8>)], pre: &Pre) -> Result<()> {
     pre.check(root)?;
-    journal::remove_any(root)?;
+    crate::fs::remove_any(root)?;
     for (rel, bytes) in files {
         let dest = root.join(rel);
         if let Some(parent) = dest.parent() {

--- a/crates/core/src/apply/pre.rs
+++ b/crates/core/src/apply/pre.rs
@@ -40,7 +40,10 @@ pub enum Pre {
         target: PathBuf,
     },
     /// The entries at and beneath the path, as they sit: files by bytes,
-    /// links by target, no link followed. What a directory move binds to
+    /// links by target, directories by presence, no link followed. What
+    /// every rename source binds to, a single file included — a file
+    /// swapped for a link to the same bytes is not the file the plan
+    /// looked at. What a directory move binds to
     /// — a rename carries the entries themselves, so a dangling link is
     /// part of what the plan proved it may move, never a reason to refuse
     /// the scope. A pipe, socket or device is refused at planning, named:

--- a/crates/core/src/apply/pre.rs
+++ b/crates/core/src/apply/pre.rs
@@ -40,10 +40,11 @@ pub enum Pre {
         target: PathBuf,
     },
     /// The entries at and beneath the path, as they sit: files by bytes,
-    /// links by target, anything else by kind, no link followed. What a
-    /// directory move binds to — a rename carries the entries themselves,
-    /// so a dangling link is part of what the plan proved it may move,
-    /// never a reason to refuse the scope.
+    /// links by target, no link followed. What a directory move binds to
+    /// — a rename carries the entries themselves, so a dangling link is
+    /// part of what the plan proved it may move, never a reason to refuse
+    /// the scope. A pipe, socket or device is refused at planning, named:
+    /// the journal could not snapshot the move.
     TreeIs {
         hash: String,
     },

--- a/crates/core/src/apply/pre.rs
+++ b/crates/core/src/apply/pre.rs
@@ -11,7 +11,7 @@ use serde::{Deserialize, Serialize};
 use specta::Type;
 
 use crate::error::{CoreError, Result};
-use crate::hash::hash_tree;
+use crate::hash::{hash_tree, hash_tree_as_is};
 
 /// A precondition every mutation revalidates immediately before running —
 /// plans bind to the observed state they were computed from (invariant 7).
@@ -38,6 +38,14 @@ pub enum Pre {
     },
     SymlinkTo {
         target: PathBuf,
+    },
+    /// The entries at and beneath the path, as they sit: files by bytes,
+    /// links by target, anything else by kind, no link followed. What a
+    /// directory move binds to — a rename carries the entries themselves,
+    /// so a dangling link is part of what the plan proved it may move,
+    /// never a reason to refuse the scope.
+    TreeIs {
+        hash: String,
     },
     Any,
 }
@@ -71,6 +79,14 @@ impl Pre {
         }
     }
 
+    /// What a plan that moves `path` whole binds to: the entries as they
+    /// sit now. The one pairing of `TreeIs` with the hash that checks it.
+    pub fn tree_as_is(path: &Path) -> Result<Pre> {
+        Ok(Pre::TreeIs {
+            hash: hash_tree_as_is(path)?,
+        })
+    }
+
     pub(super) fn check(&self, path: &Path) -> Result<()> {
         let ok = match self {
             Pre::Any => true,
@@ -84,6 +100,7 @@ impl Pre {
             Pre::SymlinkTo { target } => {
                 path.is_symlink() && fs::read_link(path).ok().as_deref() == Some(target)
             }
+            Pre::TreeIs { hash } => hash_tree_as_is(path).map(|h| h == *hash).unwrap_or(false),
         };
         if ok {
             Ok(())

--- a/crates/core/src/apply/transaction.rs
+++ b/crates/core/src/apply/transaction.rs
@@ -1,0 +1,172 @@
+//! The one transaction engine: journal every pre-image, run the ops in
+//! order, roll back on the first failure — restoring only what this
+//! transaction actually mutated. Who may run it, and under which lock, is
+//! the parent module's concern.
+
+use std::path::PathBuf;
+
+use super::{PlannedOp, journal};
+use crate::env::Env;
+use crate::error::{CoreError, Result};
+
+/// Execute ops under a lock the caller already holds for `key` and after
+/// it recovered. Returns how many ops ran. `fail_after` is test-only
+/// fault injection: simulate a crash after N ops to exercise every
+/// boundary.
+pub(super) fn run_journaled(
+    env: &Env,
+    ops: &[PlannedOp],
+    key: &str,
+    fail_after: Option<usize>,
+) -> Result<usize> {
+    // Nothing to do leaves nothing behind: an empty journal would read as
+    // an interrupted apply to the next recovery pass.
+    if ops.is_empty() {
+        return Ok(0);
+    }
+    let journal_dir = journal::journal_dir_for(&env.journal_dir(), key);
+    let mut touched: Vec<PathBuf> = ops.iter().flat_map(|p| p.op.touched()).collect();
+    touched.extend(created_dir_roots(&touched));
+    journal::write(&journal_dir, &touched)?;
+
+    for (index, planned) in ops.iter().enumerate() {
+        if fail_after == Some(index) {
+            // The injected fault lands before the op runs, so it mutated
+            // nothing — same restore set as a precondition refusal.
+            let error = CoreError::Injected;
+            journal::rollback_mutated(&journal_dir, &mutated_before_failure(ops, index, &error))?;
+            return Err(CoreError::RolledBack {
+                reason: format!("injected fault before '{}'", planned.description),
+                cause: Box::new(error),
+            });
+        }
+        if let Err(error) = planned.op.run(env) {
+            journal::rollback_mutated(&journal_dir, &mutated_before_failure(ops, index, &error))?;
+            return Err(CoreError::RolledBack {
+                reason: format!("'{}' failed: {error}", planned.description),
+                cause: Box::new(error),
+            });
+        }
+    }
+    journal::clear(&journal_dir)?;
+    Ok(ops.len())
+}
+
+/// The paths this transaction mutated by the time op `index` failed with
+/// `error` — the restore set for the in-process rollback. Every op checks
+/// its precondition before touching anything, so a `PlanStale` failure
+/// (and the test-only injected fault, which fires before the op runs)
+/// means op `index` mutated nothing: restoring its paths anyway would put
+/// the journal's snapshot over the very bytes the refusal protected, when
+/// a writer outside the transaction landed them after the journal was
+/// taken. Any other failure may have left op `index` half-done, so its
+/// paths are restored too.
+fn mutated_before_failure(ops: &[PlannedOp], index: usize, error: &CoreError) -> Vec<PathBuf> {
+    let ran = match error {
+        CoreError::PlanStale { .. } | CoreError::Injected => &ops[..index],
+        _ => &ops[..=index],
+    };
+    ran.iter().flat_map(|p| p.op.touched()).collect()
+}
+
+/// The top of every directory chain the plan's `create_dir_all` calls will
+/// bring into being. Journaled as absent, so rollback deletes the whole
+/// chain — an empty `.codex/` left behind is not cosmetic, it is what
+/// harness and project detection read as "installed here".
+fn created_dir_roots(touched: &[PathBuf]) -> Vec<PathBuf> {
+    let mut roots: Vec<PathBuf> = Vec::new();
+    for path in touched {
+        let mut topmost_missing = None;
+        let mut ancestor = path.parent();
+        while let Some(dir) = ancestor {
+            if dir.as_os_str().is_empty() || dir.exists() {
+                break;
+            }
+            topmost_missing = Some(dir.to_path_buf());
+            ancestor = dir.parent();
+        }
+        if let Some(root) = topmost_missing
+            && !touched.contains(&root)
+            && !roots.contains(&root)
+        {
+            roots.push(root);
+        }
+    }
+    roots
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::apply::{Op, Pre};
+    use crate::env::FakeOs;
+    use std::fs;
+
+    /// The restore-set split behind the filtered rollback: a refusal that
+    /// provably mutated nothing keeps its own paths out of the restore, so
+    /// the bytes it refused to overwrite survive the rollback too; a
+    /// failure that may have half-run restores them.
+    #[test]
+    fn a_refusal_keeps_its_own_paths_out_of_the_restore_set() {
+        let a = PathBuf::from("/w/a.md");
+        let b = PathBuf::from("/w/kendex.toml");
+        let op = |path: &PathBuf| PlannedOp {
+            description: "write".into(),
+            op: Op::WriteFile {
+                pre: Pre::Any,
+                path: path.clone(),
+                bytes: Vec::new(),
+            },
+        };
+        let ops = [op(&a), op(&b)];
+
+        let refused = CoreError::PlanStale { path: b.clone() };
+        assert_eq!(
+            mutated_before_failure(&ops, 1, &refused),
+            std::slice::from_ref(&a)
+        );
+        assert_eq!(
+            mutated_before_failure(&ops, 1, &CoreError::Injected),
+            std::slice::from_ref(&a)
+        );
+
+        let half_done = CoreError::io(&b, std::io::Error::other("disk full"));
+        assert_eq!(mutated_before_failure(&ops, 1, &half_done), [a, b]);
+    }
+
+    /// The legacy-manifest hazard: the journal snapshots the rename's
+    /// source, a writer outside the transaction lands on it, and a
+    /// completed rename would carry those bytes to the destination — where
+    /// a later refusal's rollback would delete them and put the old
+    /// snapshot back over the source. The source precondition refuses
+    /// before the move, so the outside edit stands untouched.
+    #[test]
+    fn a_rename_source_edited_after_journal_capture_refuses_before_moving() {
+        let tmp = tempfile::tempdir().unwrap();
+        let env = Env::fake(tmp.path(), FakeOs::Linux);
+        let old = tmp.path().join("vstack.toml");
+        let new = tmp.path().join("kendex.toml");
+        fs::write(&old, "planned bytes").unwrap();
+        let ops = [PlannedOp {
+            description: "Rename to kendex: vstack.toml becomes kendex.toml".into(),
+            op: Op::Rename {
+                from_pre: Pre::observed(&old).unwrap(),
+                from: old.clone(),
+                to: new.clone(),
+                to_pre: Pre::Absent,
+            },
+        }];
+        let journal_dir = journal::journal_dir_for(&env.journal_dir(), "global");
+        journal::write(&journal_dir, &[old.clone(), new.clone()]).unwrap();
+        // The outside edit lands after the journal captured its snapshot
+        // and before the rename runs.
+        fs::write(&old, "external edit").unwrap();
+
+        let error = ops[0].op.run(&env).unwrap_err();
+        assert!(matches!(error, CoreError::PlanStale { .. }));
+        journal::rollback_mutated(&journal_dir, &mutated_before_failure(&ops, 0, &error)).unwrap();
+
+        assert_eq!(fs::read_to_string(&old).unwrap(), "external edit");
+        assert!(!new.exists());
+    }
+}

--- a/crates/core/src/base.rs
+++ b/crates/core/src/base.rs
@@ -1,0 +1,139 @@
+//! What a copy of a whole file remembers about the file it came from.
+//!
+//! Most writes load, change one thing, and save in one breath — a stale
+//! copy cannot reach them. A whole-file surface is different: it hands a
+//! person the entire file, waits while they work, and writes all of it
+//! back, so an older copy can land on top of a newer file and silently
+//! undo whatever else wrote it. The base is the defence: the hash of the
+//! exact bytes the copy was read from, sent back with the write, refused
+//! when the file on disk is no longer those bytes.
+
+use std::path::Path;
+
+use serde::{Deserialize, Serialize};
+use specta::Type;
+
+use crate::apply::Pre;
+use crate::error::{CoreError, Result};
+use crate::fs::read_if_exists;
+
+/// The base of one whole-file copy.
+///
+/// There is one way to derive one — [`Base::of`], over the bytes it
+/// describes — because the failure this exists to prevent is a base paired
+/// with content nobody read together. A base taken by a read separate from
+/// the content it answers for describes a different moment: a writer
+/// landing between the two hands the caller old content under the new
+/// file's name, and the write that follows is accepted over that writer.
+/// Nothing here takes a path and hands back a base, deliberately — a path
+/// is not the bytes, and reading them apart is how the two come adrift.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Type)]
+#[serde(transparent)]
+pub struct Base(Option<String>);
+
+impl Base {
+    /// The base of exactly these bytes.
+    pub fn of(text: &str) -> Base {
+        Base(Some(crate::hash::hash_bytes(text.as_bytes())))
+    }
+
+    /// Nothing was there, which is an answer a copy can hold: a write
+    /// carrying it says "there was no file", and is refused if there is
+    /// one now.
+    pub fn absent() -> Base {
+        Base(None)
+    }
+
+    /// What a caller in another process says its copy came from.
+    ///
+    /// The bytes are behind an IPC boundary, so they cannot be read here
+    /// and this is the one base not derived from content in hand. It is
+    /// never trusted: its only use is to be compared with a base this
+    /// process derived, and anything but equal refuses.
+    pub fn claimed(value: Option<String>) -> Base {
+        Base(value)
+    }
+
+    /// Refuse this claim unless the file's current base is exactly it.
+    /// The current base is compared and dropped, never handed back — a
+    /// caller holding it would be holding a base for content it never
+    /// read, which is the pairing this type exists to keep unspellable.
+    pub fn verify(&self, path: &Path) -> Result<()> {
+        let now = match read_if_exists(path)? {
+            Some(text) => Base::of(&text),
+            None => Base::absent(),
+        };
+        match now == *self {
+            true => Ok(()),
+            false => Err(CoreError::PlanStale {
+                path: path.to_path_buf(),
+            }),
+        }
+    }
+}
+
+/// The precondition a write against this base binds to: the same
+/// comparison [`Base::verify`] makes, re-made by the apply immediately
+/// before the bytes go down — so a file that moves between the check and
+/// the write is refused with the same answer, not overwritten.
+impl From<&Base> for Pre {
+    fn from(base: &Base) -> Pre {
+        match &base.0 {
+            Some(hash) => Pre::HashIs { hash: hash.clone() },
+            None => Pre::Absent,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// `Pre::HashIs` compares `hash_tree` of the path; a base is
+    /// `hash_bytes` of the text. The two must be the same function of a
+    /// lone file's bytes, or every bound write would refuse a file its
+    /// own check just accepted.
+    #[test]
+    fn a_base_matches_the_tree_hash_of_the_file_it_describes() {
+        let tmp = tempfile::tempdir().unwrap();
+        let path = tmp.path().join("kendex.toml");
+        std::fs::write(&path, "schema = 2\n").unwrap();
+
+        assert_eq!(
+            Pre::from(&Base::of("schema = 2\n")),
+            Pre::HashIs {
+                hash: crate::hash::hash_tree(&path).unwrap()
+            }
+        );
+    }
+
+    #[test]
+    fn a_copy_of_the_current_file_verifies_and_a_stale_one_refuses() {
+        let tmp = tempfile::tempdir().unwrap();
+        let path = tmp.path().join("kendex.toml");
+        std::fs::write(&path, "schema = 2\n").unwrap();
+
+        let held = Base::of("schema = 2\n");
+        assert!(held.verify(&path).is_ok());
+
+        std::fs::write(&path, "schema = 2\nzoom = 150\n").unwrap();
+        assert!(matches!(
+            held.verify(&path),
+            Err(CoreError::PlanStale { path: at }) if at == path
+        ));
+    }
+
+    #[test]
+    fn an_absent_claim_verifies_only_while_nothing_is_there() {
+        let tmp = tempfile::tempdir().unwrap();
+        let path = tmp.path().join("kendex.toml");
+
+        assert!(Base::absent().verify(&path).is_ok());
+
+        std::fs::write(&path, "schema = 2\n").unwrap();
+        assert!(Base::absent().verify(&path).is_err());
+        // And the reverse: a copy of a file that has since been deleted.
+        std::fs::remove_file(&path).unwrap();
+        assert!(Base::of("schema = 2\n").verify(&path).is_err());
+    }
+}

--- a/crates/core/src/engine/file_plan.rs
+++ b/crates/core/src/engine/file_plan.rs
@@ -154,10 +154,15 @@ fn plan_absent_file(
             ops.push(install(env, scope, item, path, bytes, Pre::Absent));
             return Planned::Drift(DriftState::Missing, TAKEN_OVER.into());
         }
+        let hash = match hash_tree(&alternate) {
+            Ok(hash) => hash,
+            Err(error) => return uncomparable(&alternate, &error),
+        };
         let flip = if item.enabled { "on" } else { "off" };
         ops.push(PlannedOp {
             description: format!("Turn {} {flip}", item.name),
             op: Op::Rename {
+                from_pre: Pre::HashIs { hash },
                 from: alternate,
                 to: path.to_path_buf(),
                 to_pre: Pre::Absent,

--- a/crates/core/src/engine/file_plan.rs
+++ b/crates/core/src/engine/file_plan.rs
@@ -154,15 +154,17 @@ fn plan_absent_file(
             ops.push(install(env, scope, item, path, bytes, Pre::Absent));
             return Planned::Drift(DriftState::Missing, TAKEN_OVER.into());
         }
-        let hash = match hash_tree(&alternate) {
-            Ok(hash) => hash,
+        // As it sits, not as it reads: a link to the same bytes put where
+        // the file was is not the file the plan looked at.
+        let from_pre = match Pre::tree_as_is(&alternate) {
+            Ok(pre) => pre,
             Err(error) => return uncomparable(&alternate, &error),
         };
         let flip = if item.enabled { "on" } else { "off" };
         ops.push(PlannedOp {
             description: format!("Turn {} {flip}", item.name),
             op: Op::Rename {
-                from_pre: Pre::HashIs { hash },
+                from_pre,
                 from: alternate,
                 to: path.to_path_buf(),
                 to_pre: Pre::Absent,

--- a/crates/core/src/engine/fork.rs
+++ b/crates/core/src/engine/fork.rs
@@ -264,9 +264,10 @@ pub fn rename_fork(env: &Env, scope: &Scope, kind: ItemKind, old: &str, new: &st
         ops.push(PlannedOp {
             description: format!("rename the fork's files to {new}"),
             op: Op::Rename {
-                from_pre: Pre::HashIs {
-                    hash: crate::hash::hash_tree(&from)?,
-                },
+                // The fork moves whole, whatever sits in it: a dangling
+                // link the person left there is carried along, not a
+                // reason to refuse the rename.
+                from_pre: Pre::tree_as_is(&from)?,
                 from,
                 to,
                 to_pre: Pre::Absent,

--- a/crates/core/src/engine/fork.rs
+++ b/crates/core/src/engine/fork.rs
@@ -264,6 +264,9 @@ pub fn rename_fork(env: &Env, scope: &Scope, kind: ItemKind, old: &str, new: &st
         ops.push(PlannedOp {
             description: format!("rename the fork's files to {new}"),
             op: Op::Rename {
+                from_pre: Pre::HashIs {
+                    hash: crate::hash::hash_tree(&from)?,
+                },
                 from,
                 to,
                 to_pre: Pre::Absent,

--- a/crates/core/src/engine/mod.rs
+++ b/crates/core/src/engine/mod.rs
@@ -134,7 +134,8 @@ fn plan_scope_once(
     let mut written = written::Written::default();
     let mut config_edits = config_edits::ConfigEditPlan::default();
 
-    plan_manifest_write(env, scope, repo_moved, manifest, &state, &mut ops)?;
+    let base = options.manifest_base.as_ref();
+    plan_manifest_write(env, scope, repo_moved, manifest, base, &state, &mut ops)?;
 
     // Answered before anything is planned, and read again when the move is
     // planned: a pi hook whose copy under the name pi reserved is not this
@@ -269,15 +270,16 @@ fn plan_manifest_write(
     scope: &Scope,
     repo_moved: bool,
     manifest: &Manifest,
+    base: Option<&crate::base::Base>,
     state: &desired::DesiredState,
     ops: &mut Vec<PlannedOp>,
 ) -> Result<()> {
     let Some(update) = &state.manifest_update else {
         if repo_moved {
-            return plan_repo_move_write(env, scope, manifest, ops);
+            return plan_repo_move_write(env, scope, manifest, base, ops);
         }
         if manifest.schema < manifest::MANIFEST_SCHEMA {
-            plan_schema_upgrade(env, scope, manifest, ops)?;
+            plan_schema_upgrade(env, scope, manifest, base, ops)?;
         }
         return Ok(());
     };
@@ -292,7 +294,7 @@ fn plan_manifest_write(
             (false, false) => "Add new catalog skills to kendex.toml".into(),
         },
         op: Op::WriteManifest {
-            pre: crate::apply::Pre::observed(&path)?,
+            pre: scope_writes::manifest_pre(base, &path)?,
             path,
             manifest: Box::new(updated),
         },

--- a/crates/core/src/engine/report_types.rs
+++ b/crates/core/src/engine/report_types.rs
@@ -195,6 +195,14 @@ pub struct PlanOptions {
     /// "discard" the app offers, which must never take a neighbour's
     /// edits with it, even one that shares a name across kinds.
     pub overwrite_edited_names: Option<Vec<(ItemKind, String)>>,
+    /// The base of the manifest copy this plan reconciles to, where the
+    /// manifest arrived whole from an editor rather than being read here.
+    /// The plan's manifest write binds its precondition to it, so a file
+    /// that moved after the copy was read is refused by the apply rather
+    /// than overwritten. Binding by path after planning cannot do this: a
+    /// scope still under the old product name retargets its writes to the
+    /// renamed file, and the path the caller knew no longer names them.
+    pub manifest_base: Option<crate::base::Base>,
 }
 
 impl PlanOptions {

--- a/crates/core/src/engine/scope_writes.rs
+++ b/crates/core/src/engine/scope_writes.rs
@@ -3,8 +3,10 @@
 //! format line, and the settings a project's skills seed.
 
 use std::collections::BTreeMap;
+use std::path::Path;
 
-use crate::apply::{Op, PlannedOp};
+use crate::apply::{Op, PlannedOp, Pre};
+use crate::base::Base;
 use crate::env::Env;
 use crate::error::Result;
 use crate::lock::{Lock, SourceRev, lock_path};
@@ -25,6 +27,18 @@ pub fn persists_manifest(ops: &[PlannedOp]) -> bool {
             || (op.description == crate::repo_move::MOVE_DESCRIPTION
                 && matches!(op.op, Op::WriteFile { .. }))
     })
+}
+
+/// The precondition the plan's one manifest write binds to: the base of
+/// the editor copy when the manifest arrived whole from one, otherwise
+/// the file as it is now. An editor copy's write must bind to the file
+/// that copy was read from — observing the path here instead would accept
+/// a writer that landed after the copy left the editor.
+pub(super) fn manifest_pre(base: Option<&Base>, path: &Path) -> Result<Pre> {
+    match base {
+        Some(base) => Ok(base.into()),
+        None => Pre::observed(path),
+    }
 }
 
 /// One mutation per config file, whatever asked for it — a single
@@ -156,6 +170,7 @@ pub(super) fn plan_schema_upgrade(
     env: &Env,
     scope: &Scope,
     manifest: &Manifest,
+    base: Option<&Base>,
     ops: &mut Vec<PlannedOp>,
 ) -> Result<()> {
     let path = manifest::manifest_path(env, scope);
@@ -195,7 +210,7 @@ pub(super) fn plan_schema_upgrade(
     }
     let op = match rewritten {
         true => Op::WriteFile {
-            pre: crate::apply::Pre::observed(&path)?,
+            pre: manifest_pre(base, &path)?,
             path,
             bytes: upgraded_text.into_bytes(),
         },
@@ -203,7 +218,7 @@ pub(super) fn plan_schema_upgrade(
             let mut upgraded = manifest.clone();
             upgraded.schema = manifest::MANIFEST_SCHEMA;
             Op::WriteManifest {
-                pre: crate::apply::Pre::observed(&path)?,
+                pre: manifest_pre(base, &path)?,
                 path,
                 manifest: Box::new(upgraded),
             }
@@ -249,6 +264,7 @@ pub(super) fn plan_repo_move_write(
     env: &Env,
     scope: &Scope,
     migrated: &Manifest,
+    base: Option<&Base>,
     ops: &mut Vec<PlannedOp>,
 ) -> Result<()> {
     let path = manifest::manifest_path(env, scope);
@@ -285,12 +301,12 @@ pub(super) fn plan_repo_move_write(
     let reproduced = toml::from_str::<Manifest>(&edited).is_ok_and(|parsed| parsed == expected);
     let op = match reproduced {
         true => Op::WriteFile {
-            pre: crate::apply::Pre::observed(&path)?,
+            pre: manifest_pre(base, &path)?,
             path,
             bytes: edited.into_bytes(),
         },
         false => Op::WriteManifest {
-            pre: crate::apply::Pre::observed(&path)?,
+            pre: manifest_pre(base, &path)?,
             path,
             manifest: Box::new(expected),
         },

--- a/crates/core/src/error.rs
+++ b/crates/core/src/error.rs
@@ -126,6 +126,9 @@ pub enum CoreError {
     #[error("scope is busy: another apply holds {lock}")]
     ScopeBusy { lock: PathBuf },
 
+    #[error("settings are busy: another kendex process holds {lock}")]
+    SettingsBusy { lock: PathBuf },
+
     #[error("source cache is busy: another download holds {lock}")]
     CacheBusy { lock: PathBuf },
 

--- a/crates/core/src/error.rs
+++ b/crates/core/src/error.rs
@@ -337,6 +337,19 @@ pub enum CoreError {
         cause: Box<CoreError>,
     },
 
+    /// A filtered rollback stopped midway and its filter never reached
+    /// disk: the journal is pending, and the recovery that clears it
+    /// restores every snapshot, external bytes included. Both failures
+    /// are kept — the restore is what stopped, the persist is why
+    /// recovery will not run the same restore.
+    #[error(
+        "rollback stopped: {restore}; its restore set was not saved ({persist}), so recovery will restore every journaled path"
+    )]
+    RestoreSetLost {
+        restore: Box<CoreError>,
+        persist: Box<CoreError>,
+    },
+
     #[error("{path}: structured edit failed: {message}")]
     ConfigEdit { path: PathBuf, message: String },
 

--- a/crates/core/src/error.rs
+++ b/crates/core/src/error.rs
@@ -318,8 +318,21 @@ pub enum CoreError {
     #[error("source '{source_name}' offers no bundle called '{name}'")]
     NoSuchBundle { name: String, source_name: String },
 
+    /// Test-only fault injection stopped the apply. Never reached in a
+    /// real run: `fail_after` is how the rollback boundaries are exercised.
+    #[error("injected fault")]
+    Injected,
+
+    /// Nothing was left behind, and `cause` is the failure that stopped it
+    /// — kept whole rather than flattened into `reason`, because what a
+    /// caller does about a rollback depends on why: a precondition that
+    /// found the file changed is a reload to offer, and a disk that would
+    /// not take the write is not.
     #[error("apply failed and was rolled back: {reason}")]
-    RolledBack { reason: String },
+    RolledBack {
+        reason: String,
+        cause: Box<CoreError>,
+    },
 
     #[error("{path}: structured edit failed: {message}")]
     ConfigEdit { path: PathBuf, message: String },

--- a/crates/core/src/fs.rs
+++ b/crates/core/src/fs.rs
@@ -157,6 +157,23 @@ pub(crate) fn sync_dir(path: &Path) {
     let _ = path;
 }
 
+/// `sync_dir` with the outcome kept: for a transition that must be on
+/// disk before the next step may run. Unix only; elsewhere the volume
+/// flush is all there is, and the call reports nothing.
+pub(crate) fn sync_dir_durable(path: &Path) -> Result<()> {
+    #[cfg(unix)]
+    {
+        fs::File::open(path)
+            .and_then(|dir| dir.sync_all())
+            .map_err(|e| CoreError::io(path, e))
+    }
+    #[cfg(not(unix))]
+    {
+        let _ = path;
+        Ok(())
+    }
+}
+
 pub(crate) fn sync_tree(root: &Path) -> Result<()> {
     if root.is_file() {
         return sync_file(root);

--- a/crates/core/src/fs.rs
+++ b/crates/core/src/fs.rs
@@ -140,6 +140,82 @@ pub fn read_if_exists(path: &Path) -> Result<Option<String>> {
     }
 }
 
+pub(crate) fn sync_file(path: &Path) -> Result<()> {
+    fs::File::open(path)
+        .and_then(|f| f.sync_all())
+        .map_err(|e| CoreError::io(path, e))
+}
+
+/// Directory fsync is a no-op on platforms where directories cannot be
+/// opened (Windows); rename durability there rides on the volume flush.
+pub(crate) fn sync_dir(path: &Path) {
+    #[cfg(unix)]
+    if let Ok(dir) = fs::File::open(path) {
+        let _ = dir.sync_all();
+    }
+    #[cfg(not(unix))]
+    let _ = path;
+}
+
+pub(crate) fn sync_tree(root: &Path) -> Result<()> {
+    if root.is_file() {
+        return sync_file(root);
+    }
+    if let Ok(entries) = fs::read_dir(root) {
+        for entry in entries.flatten() {
+            sync_tree(&entry.path())?;
+        }
+        sync_dir(root);
+    }
+    Ok(())
+}
+
+pub(crate) fn remove_any(path: &Path) -> Result<()> {
+    if path.is_symlink() || path.is_file() {
+        fs::remove_file(path).map_err(|e| CoreError::io(path, e))?;
+    } else if path.is_dir() {
+        fs::remove_dir_all(path).map_err(|e| CoreError::io(path, e))?;
+    }
+    Ok(())
+}
+
+pub(crate) fn copy_tree(from: &Path, to: &Path) -> Result<()> {
+    fs::create_dir_all(to).map_err(|e| CoreError::io(to, e))?;
+    for entry in fs::read_dir(from)
+        .map_err(|e| CoreError::io(from, e))?
+        .flatten()
+    {
+        let source = entry.path();
+        let Some(name) = source.file_name() else {
+            continue;
+        };
+        let dest = to.join(name);
+        if source.is_symlink() {
+            let target = fs::read_link(&source).map_err(|e| CoreError::io(&source, e))?;
+            make_symlink(&target, &dest)?;
+        } else if source.is_dir() {
+            copy_tree(&source, &dest)?;
+        } else {
+            fs::copy(&source, &dest).map_err(|e| CoreError::io(&source, e))?;
+        }
+    }
+    Ok(())
+}
+
+#[cfg(unix)]
+pub(crate) fn make_symlink(target: &Path, link: &Path) -> Result<()> {
+    std::os::unix::fs::symlink(target, link).map_err(|e| CoreError::io(link, e))
+}
+
+#[cfg(windows)]
+pub(crate) fn make_symlink(target: &Path, link: &Path) -> Result<()> {
+    if target.is_dir() {
+        std::os::windows::fs::symlink_dir(target, link).map_err(|e| CoreError::io(link, e))
+    } else {
+        std::os::windows::fs::symlink_file(target, link).map_err(|e| CoreError::io(link, e))
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/crates/core/src/fs.rs
+++ b/crates/core/src/fs.rs
@@ -174,8 +174,19 @@ pub(crate) fn sync_dir_durable(path: &Path) -> Result<()> {
     }
 }
 
+/// Sync a tree's files and directories, a link treated as a leaf: the
+/// parent's sync persists the entry itself, and what it points at is not
+/// this tree's — following it would sync files outside the tree, or the
+/// same tree again through a link back into it until the kernel refuses
+/// the path. The same reading of a link as `hash_tree_as_is`.
 pub(crate) fn sync_tree(root: &Path) -> Result<()> {
-    if root.is_file() {
+    let Ok(kind) = fs::symlink_metadata(root).map(|meta| meta.file_type()) else {
+        return Ok(());
+    };
+    if kind.is_symlink() {
+        return Ok(());
+    }
+    if kind.is_file() {
         return sync_file(root);
     }
     if let Ok(entries) = fs::read_dir(root) {
@@ -236,6 +247,38 @@ pub(crate) fn make_symlink(target: &Path, link: &Path) -> Result<()> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// A link is a leaf of the tree it sits in: its parent's sync persists
+    /// the entry, and nothing on the far side is this tree's to touch.
+    /// Pinned with a link to a directory outside the tree holding a file
+    /// nobody may open — followed, the sync would fail on it.
+    #[cfg(unix)]
+    #[test]
+    fn sync_tree_never_follows_a_link() {
+        use std::os::unix::fs::PermissionsExt as _;
+        let tmp = tempfile::tempdir().unwrap();
+        let outside = tmp.path().join("outside");
+        fs::create_dir_all(&outside).unwrap();
+        let sealed = outside.join("sealed");
+        fs::write(&sealed, "x").unwrap();
+        fs::set_permissions(&sealed, fs::Permissions::from_mode(0o000)).unwrap();
+        let unlock = || fs::set_permissions(&sealed, fs::Permissions::from_mode(0o600)).unwrap();
+        if fs::File::open(&sealed).is_ok() {
+            // Permissions do not bind this user (root): following the link
+            // cannot be made to fail here.
+            unlock();
+            return;
+        }
+        let tree = tmp.path().join("tree");
+        fs::create_dir_all(&tree).unwrap();
+        fs::write(tree.join("a"), "a").unwrap();
+        std::os::unix::fs::symlink(&outside, tree.join("out")).unwrap();
+        std::os::unix::fs::symlink(".", tree.join("loop")).unwrap();
+
+        let result = sync_tree(&tree);
+        unlock();
+        result.unwrap();
+    }
 
     /// The app saves settings from a Tokio thread pool, so a slider drag can
     /// put several writes of one file in flight at once. Sharing a temp name

--- a/crates/core/src/hash.rs
+++ b/crates/core/src/hash.rs
@@ -55,14 +55,16 @@ fn hash_into(hasher: &mut Sha256, path: &Path, rel: &Path, depth: usize) -> Resu
     Ok(())
 }
 
-/// SHA-256 over a tree as it sits, never following a link and never
-/// failing on what it finds: a plain file by relative path and bytes, a
-/// link by relative path and target, anything else by relative path and
-/// kind. What a directory move binds to — a rename carries the entries
-/// themselves, a dangling link included, so the precondition names
-/// exactly those and never the bytes a link points at. The byte after
-/// the path says which kind wrote the record, so a file whose bytes spell
-/// a target never hashes like a link to it.
+/// SHA-256 over a tree as it sits, never following a link: a plain file
+/// by relative path and bytes, a link by relative path and target,
+/// dangling or not. What a directory move binds to — a rename carries
+/// the entries themselves, a dangling link included, so the precondition
+/// names exactly those and never the bytes a link points at. The byte
+/// after the path says which kind wrote the record, so a file whose
+/// bytes spell a target never hashes like a link to it. Anything else (a
+/// pipe, a socket, a device) is an error naming the entry, as in
+/// `hash_tree`: the journal snapshots a moved directory by copying it,
+/// and a copy of a reader-less pipe never returns.
 pub fn hash_tree_as_is(path: &Path) -> Result<String> {
     let mut hasher = Sha256::new();
     hash_as_is_into(&mut hasher, path, Path::new(""))?;
@@ -70,6 +72,7 @@ pub fn hash_tree_as_is(path: &Path) -> Result<String> {
 }
 
 fn hash_as_is_into(hasher: &mut Sha256, path: &Path, rel: &Path) -> Result<()> {
+    let refuse = |why: &str| CoreError::io(path, std::io::Error::other(why.to_owned()));
     let kind = fs::symlink_metadata(path)
         .map_err(|e| CoreError::io(path, e))?
         .file_type();
@@ -99,9 +102,7 @@ fn hash_as_is_into(hasher: &mut Sha256, path: &Path, rel: &Path) -> Result<()> {
         hasher.update(&bytes);
         hasher.update([0]);
     } else {
-        hasher.update(rel.to_string_lossy().as_bytes());
-        hasher.update([2]);
-        hasher.update([0]);
+        return Err(refuse("not a regular file, directory or link"));
     }
     Ok(())
 }

--- a/crates/core/src/hash.rs
+++ b/crates/core/src/hash.rs
@@ -57,7 +57,9 @@ fn hash_into(hasher: &mut Sha256, path: &Path, rel: &Path, depth: usize) -> Resu
 
 /// SHA-256 over a tree as it sits, never following a link: a plain file
 /// by relative path and bytes, a link by relative path and target,
-/// dangling or not. What a directory move binds to — a rename carries
+/// dangling or not, a directory by relative path before its entries, so
+/// an empty one added or removed is a change. What a directory move
+/// binds to — a rename carries
 /// the entries themselves, a dangling link included, so the precondition
 /// names exactly those and never the bytes a link points at. The byte
 /// after the path says which kind wrote the record, so a file whose
@@ -83,6 +85,9 @@ fn hash_as_is_into(hasher: &mut Sha256, path: &Path, rel: &Path) -> Result<()> {
         hasher.update(target.to_string_lossy().as_bytes());
         hasher.update([0]);
     } else if kind.is_dir() {
+        hasher.update(rel.to_string_lossy().as_bytes());
+        hasher.update([2]);
+        hasher.update([0]);
         let mut entries: Vec<_> = fs::read_dir(path)
             .map_err(|e| CoreError::io(path, e))?
             .flatten()
@@ -275,6 +280,13 @@ mod tests {
         assert_ne!(
             resolving, file,
             "a file spelling the target is not the link"
+        );
+
+        std::fs::create_dir(root.join("empty")).unwrap();
+        let with_dir = hash_tree_as_is(&root).unwrap();
+        assert_ne!(
+            file, with_dir,
+            "an empty directory is an entry the move carries"
         );
     }
 

--- a/crates/core/src/hash.rs
+++ b/crates/core/src/hash.rs
@@ -59,11 +59,11 @@ fn hash_into(hasher: &mut Sha256, path: &Path, rel: &Path, depth: usize) -> Resu
 /// by relative path and bytes, a link by relative path and target,
 /// dangling or not, a directory by relative path before its entries, so
 /// an empty one added or removed is a change. What a directory move
-/// binds to — a rename carries
-/// the entries themselves, a dangling link included, so the precondition
-/// names exactly those and never the bytes a link points at. The byte
-/// after the path says which kind wrote the record, so a file whose
-/// bytes spell a target never hashes like a link to it. Anything else (a
+/// binds to — a rename carries the entries themselves, a dangling link
+/// included, so the precondition names exactly those and never the bytes
+/// a link points at. Every record is framed: a kind byte, then each field
+/// as its length and its raw OS bytes, so no file content can spell a
+/// record boundary and no two names collapse into one. Anything else (a
 /// pipe, a socket, a device) is an error naming the entry, as in
 /// `hash_tree`: the journal snapshots a moved directory by copying it,
 /// and a copy of a reader-less pipe never returns.
@@ -73,21 +73,30 @@ pub fn hash_tree_as_is(path: &Path) -> Result<String> {
     Ok(hex(&hasher.finalize()))
 }
 
+const AS_IS_FILE: u8 = 0;
+const AS_IS_LINK: u8 = 1;
+const AS_IS_DIR: u8 = 2;
+
+/// One field of an as-is record: its length, fixed width, then its bytes.
+fn frame(hasher: &mut Sha256, bytes: &[u8]) {
+    hasher.update((bytes.len() as u64).to_le_bytes());
+    hasher.update(bytes);
+}
+
 fn hash_as_is_into(hasher: &mut Sha256, path: &Path, rel: &Path) -> Result<()> {
     let refuse = |why: &str| CoreError::io(path, std::io::Error::other(why.to_owned()));
     let kind = fs::symlink_metadata(path)
         .map_err(|e| CoreError::io(path, e))?
         .file_type();
+    let name = rel.as_os_str().as_encoded_bytes();
     if kind.is_symlink() {
         let target = fs::read_link(path).map_err(|e| CoreError::io(path, e))?;
-        hasher.update(rel.to_string_lossy().as_bytes());
-        hasher.update([1]);
-        hasher.update(target.to_string_lossy().as_bytes());
-        hasher.update([0]);
+        hasher.update([AS_IS_LINK]);
+        frame(hasher, name);
+        frame(hasher, target.as_os_str().as_encoded_bytes());
     } else if kind.is_dir() {
-        hasher.update(rel.to_string_lossy().as_bytes());
-        hasher.update([2]);
-        hasher.update([0]);
+        hasher.update([AS_IS_DIR]);
+        frame(hasher, name);
         let mut entries: Vec<_> = fs::read_dir(path)
             .map_err(|e| CoreError::io(path, e))?
             .flatten()
@@ -102,10 +111,9 @@ fn hash_as_is_into(hasher: &mut Sha256, path: &Path, rel: &Path) -> Result<()> {
         }
     } else if kind.is_file() {
         let bytes = fs::read(path).map_err(|e| CoreError::io(path, e))?;
-        hasher.update(rel.to_string_lossy().as_bytes());
-        hasher.update([0]);
-        hasher.update(&bytes);
-        hasher.update([0]);
+        hasher.update([AS_IS_FILE]);
+        frame(hasher, name);
+        frame(hasher, &bytes);
     } else {
         return Err(refuse("not a regular file, directory or link"));
     }
@@ -240,131 +248,4 @@ pub fn fnv1a_hex(bytes: &[u8]) -> String {
 }
 
 #[cfg(test)]
-mod tests {
-    use super::*;
-    use crate::manifest::MANIFEST_SCHEMA;
-
-    #[cfg(unix)]
-    #[test]
-    fn a_link_looping_into_its_own_tree_is_an_error_not_a_crash() {
-        let tmp = tempfile::tempdir().unwrap();
-        let root = tmp.path().join("skill");
-        std::fs::create_dir_all(&root).unwrap();
-        std::fs::write(root.join("SKILL.md"), "hello").unwrap();
-        std::os::unix::fs::symlink(&root, root.join("loop")).unwrap();
-        assert!(hash_tree(&root).is_err());
-    }
-
-    /// The as-is hash names the entries a move carries: a dangling link
-    /// is one of them, by its target, where the content hash has nothing
-    /// to read and refuses the tree.
-    #[cfg(unix)]
-    #[test]
-    fn as_is_hash_names_a_link_by_its_target_and_never_follows_it() {
-        let tmp = tempfile::tempdir().unwrap();
-        let root = tmp.path().join("dir");
-        std::fs::create_dir_all(&root).unwrap();
-        std::fs::write(root.join("a"), "bytes").unwrap();
-        std::os::unix::fs::symlink("nowhere", root.join("gone")).unwrap();
-        assert!(hash_tree(&root).is_err());
-
-        let dangling = hash_tree_as_is(&root).unwrap();
-        std::fs::remove_file(root.join("gone")).unwrap();
-        std::os::unix::fs::symlink("a", root.join("gone")).unwrap();
-        let resolving = hash_tree_as_is(&root).unwrap();
-        assert_ne!(dangling, resolving, "the target is part of the record");
-
-        std::fs::remove_file(root.join("gone")).unwrap();
-        std::fs::write(root.join("gone"), "a").unwrap();
-        let file = hash_tree_as_is(&root).unwrap();
-        assert_ne!(
-            resolving, file,
-            "a file spelling the target is not the link"
-        );
-
-        std::fs::create_dir(root.join("empty")).unwrap();
-        let with_dir = hash_tree_as_is(&root).unwrap();
-        assert_ne!(
-            file, with_dir,
-            "an empty directory is an entry the move carries"
-        );
-    }
-
-    #[test]
-    fn tree_hash_is_content_and_layout_sensitive() {
-        let tmp = tempfile::tempdir().unwrap();
-        let a = tmp.path().join("a");
-        std::fs::create_dir_all(a.join("sub")).unwrap();
-        std::fs::write(a.join("SKILL.md"), "hello").unwrap();
-        std::fs::write(a.join("sub/x.sh"), "x").unwrap();
-        let first = hash_tree(&a).unwrap();
-        assert_eq!(first, hash_tree(&a).unwrap());
-
-        std::fs::write(a.join("sub/x.sh"), "y").unwrap();
-        assert_ne!(first, hash_tree(&a).unwrap());
-    }
-
-    #[test]
-    fn editing_a_shared_key_invalidates_dependents() {
-        let tmp = tempfile::tempdir().unwrap();
-        let skill = tmp.path().join("skill");
-        std::fs::create_dir_all(&skill).unwrap();
-        std::fs::write(skill.join("SKILL.md"), "content").unwrap();
-
-        let mut manifest = Manifest {
-            schema: MANIFEST_SCHEMA,
-            ..Manifest::default()
-        };
-        let sealed = crate::source_read::SealedSource::open(tmp.path()).unwrap();
-        let skill = sealed.root().join("skill");
-        let before = installation_hash(
-            &sealed,
-            &skill,
-            &manifest,
-            ItemKind::Skill,
-            "github",
-            HarnessId::Claude,
-        )
-        .unwrap();
-
-        manifest
-            .skill_instructions
-            .insert("all".into(), "shared instruction".into());
-        let after = installation_hash(
-            &sealed,
-            &skill,
-            &manifest,
-            ItemKind::Skill,
-            "github",
-            HarnessId::Claude,
-        )
-        .unwrap();
-        assert_ne!(before, after);
-
-        let unrelated = installation_hash(
-            &sealed,
-            &skill,
-            &manifest,
-            ItemKind::Command,
-            "github",
-            HarnessId::Claude,
-        )
-        .unwrap();
-        let unrelated_before = {
-            let clean = Manifest {
-                schema: MANIFEST_SCHEMA,
-                ..Manifest::default()
-            };
-            installation_hash(
-                &sealed,
-                &skill,
-                &clean,
-                ItemKind::Command,
-                "github",
-                HarnessId::Claude,
-            )
-            .unwrap()
-        };
-        assert_eq!(unrelated, unrelated_before);
-    }
-}
+mod tests;

--- a/crates/core/src/hash.rs
+++ b/crates/core/src/hash.rs
@@ -55,6 +55,57 @@ fn hash_into(hasher: &mut Sha256, path: &Path, rel: &Path, depth: usize) -> Resu
     Ok(())
 }
 
+/// SHA-256 over a tree as it sits, never following a link and never
+/// failing on what it finds: a plain file by relative path and bytes, a
+/// link by relative path and target, anything else by relative path and
+/// kind. What a directory move binds to — a rename carries the entries
+/// themselves, a dangling link included, so the precondition names
+/// exactly those and never the bytes a link points at. The byte after
+/// the path says which kind wrote the record, so a file whose bytes spell
+/// a target never hashes like a link to it.
+pub fn hash_tree_as_is(path: &Path) -> Result<String> {
+    let mut hasher = Sha256::new();
+    hash_as_is_into(&mut hasher, path, Path::new(""))?;
+    Ok(hex(&hasher.finalize()))
+}
+
+fn hash_as_is_into(hasher: &mut Sha256, path: &Path, rel: &Path) -> Result<()> {
+    let kind = fs::symlink_metadata(path)
+        .map_err(|e| CoreError::io(path, e))?
+        .file_type();
+    if kind.is_symlink() {
+        let target = fs::read_link(path).map_err(|e| CoreError::io(path, e))?;
+        hasher.update(rel.to_string_lossy().as_bytes());
+        hasher.update([1]);
+        hasher.update(target.to_string_lossy().as_bytes());
+        hasher.update([0]);
+    } else if kind.is_dir() {
+        let mut entries: Vec<_> = fs::read_dir(path)
+            .map_err(|e| CoreError::io(path, e))?
+            .flatten()
+            .map(|e| e.path())
+            .collect();
+        entries.sort();
+        for entry in entries {
+            let Some(name) = entry.file_name() else {
+                continue;
+            };
+            hash_as_is_into(hasher, &entry, &rel.join(name))?;
+        }
+    } else if kind.is_file() {
+        let bytes = fs::read(path).map_err(|e| CoreError::io(path, e))?;
+        hasher.update(rel.to_string_lossy().as_bytes());
+        hasher.update([0]);
+        hasher.update(&bytes);
+        hasher.update([0]);
+    } else {
+        hasher.update(rel.to_string_lossy().as_bytes());
+        hasher.update([2]);
+        hasher.update([0]);
+    }
+    Ok(())
+}
+
 /// The hash a single-file artifact will have once written — mirrors
 /// `hash_tree` applied to a lone file.
 pub fn hash_bytes(bytes: &[u8]) -> String {
@@ -196,6 +247,34 @@ mod tests {
         std::fs::write(root.join("SKILL.md"), "hello").unwrap();
         std::os::unix::fs::symlink(&root, root.join("loop")).unwrap();
         assert!(hash_tree(&root).is_err());
+    }
+
+    /// The as-is hash names the entries a move carries: a dangling link
+    /// is one of them, by its target, where the content hash has nothing
+    /// to read and refuses the tree.
+    #[cfg(unix)]
+    #[test]
+    fn as_is_hash_names_a_link_by_its_target_and_never_follows_it() {
+        let tmp = tempfile::tempdir().unwrap();
+        let root = tmp.path().join("dir");
+        std::fs::create_dir_all(&root).unwrap();
+        std::fs::write(root.join("a"), "bytes").unwrap();
+        std::os::unix::fs::symlink("nowhere", root.join("gone")).unwrap();
+        assert!(hash_tree(&root).is_err());
+
+        let dangling = hash_tree_as_is(&root).unwrap();
+        std::fs::remove_file(root.join("gone")).unwrap();
+        std::os::unix::fs::symlink("a", root.join("gone")).unwrap();
+        let resolving = hash_tree_as_is(&root).unwrap();
+        assert_ne!(dangling, resolving, "the target is part of the record");
+
+        std::fs::remove_file(root.join("gone")).unwrap();
+        std::fs::write(root.join("gone"), "a").unwrap();
+        let file = hash_tree_as_is(&root).unwrap();
+        assert_ne!(
+            resolving, file,
+            "a file spelling the target is not the link"
+        );
     }
 
     #[test]

--- a/crates/core/src/hash/tests.rs
+++ b/crates/core/src/hash/tests.rs
@@ -1,0 +1,165 @@
+use super::*;
+use crate::manifest::MANIFEST_SCHEMA;
+
+#[cfg(unix)]
+#[test]
+fn a_link_looping_into_its_own_tree_is_an_error_not_a_crash() {
+    let tmp = tempfile::tempdir().unwrap();
+    let root = tmp.path().join("skill");
+    std::fs::create_dir_all(&root).unwrap();
+    std::fs::write(root.join("SKILL.md"), "hello").unwrap();
+    std::os::unix::fs::symlink(&root, root.join("loop")).unwrap();
+    assert!(hash_tree(&root).is_err());
+}
+
+/// The as-is hash names the entries a move carries: a dangling link
+/// is one of them, by its target, where the content hash has nothing
+/// to read and refuses the tree.
+#[cfg(unix)]
+#[test]
+fn as_is_hash_names_a_link_by_its_target_and_never_follows_it() {
+    let tmp = tempfile::tempdir().unwrap();
+    let root = tmp.path().join("dir");
+    std::fs::create_dir_all(&root).unwrap();
+    std::fs::write(root.join("a"), "bytes").unwrap();
+    std::os::unix::fs::symlink("nowhere", root.join("gone")).unwrap();
+    assert!(hash_tree(&root).is_err());
+
+    let dangling = hash_tree_as_is(&root).unwrap();
+    std::fs::remove_file(root.join("gone")).unwrap();
+    std::os::unix::fs::symlink("a", root.join("gone")).unwrap();
+    let resolving = hash_tree_as_is(&root).unwrap();
+    assert_ne!(dangling, resolving, "the target is part of the record");
+
+    std::fs::remove_file(root.join("gone")).unwrap();
+    std::fs::write(root.join("gone"), "a").unwrap();
+    let file = hash_tree_as_is(&root).unwrap();
+    assert_ne!(
+        resolving, file,
+        "a file spelling the target is not the link"
+    );
+
+    std::fs::create_dir(root.join("empty")).unwrap();
+    let with_dir = hash_tree_as_is(&root).unwrap();
+    assert_ne!(
+        file, with_dir,
+        "an empty directory is an entry the move carries"
+    );
+}
+
+/// The encoding frames every field: bytes inside a file that spell a
+/// record boundary never read as one, so one file holding `x\0b\0y`
+/// is not two files holding `x` and `y`.
+#[test]
+fn as_is_hash_cannot_be_forged_by_bytes_that_spell_a_boundary() {
+    let tmp = tempfile::tempdir().unwrap();
+    let one = tmp.path().join("one");
+    std::fs::create_dir_all(&one).unwrap();
+    std::fs::write(one.join("a"), b"x\0b\0y").unwrap();
+    let two = tmp.path().join("two");
+    std::fs::create_dir_all(&two).unwrap();
+    std::fs::write(two.join("a"), b"x").unwrap();
+    std::fs::write(two.join("b"), b"y").unwrap();
+    assert_ne!(
+        hash_tree_as_is(&one).unwrap(),
+        hash_tree_as_is(&two).unwrap()
+    );
+}
+
+/// Names go in as the bytes the OS holds, so two names that are not
+/// UTF-8 stay two names instead of collapsing into one replacement
+/// character.
+#[cfg(unix)]
+#[test]
+fn as_is_hash_keeps_distinct_non_utf8_names_distinct() {
+    use std::os::unix::ffi::OsStrExt as _;
+    let tmp = tempfile::tempdir().unwrap();
+    let one = tmp.path().join("one");
+    std::fs::create_dir_all(&one).unwrap();
+    std::fs::write(one.join(std::ffi::OsStr::from_bytes(b"\xff")), "same").unwrap();
+    let two = tmp.path().join("two");
+    std::fs::create_dir_all(&two).unwrap();
+    std::fs::write(two.join(std::ffi::OsStr::from_bytes(b"\xfe")), "same").unwrap();
+    assert_ne!(
+        hash_tree_as_is(&one).unwrap(),
+        hash_tree_as_is(&two).unwrap()
+    );
+}
+
+#[test]
+fn tree_hash_is_content_and_layout_sensitive() {
+    let tmp = tempfile::tempdir().unwrap();
+    let a = tmp.path().join("a");
+    std::fs::create_dir_all(a.join("sub")).unwrap();
+    std::fs::write(a.join("SKILL.md"), "hello").unwrap();
+    std::fs::write(a.join("sub/x.sh"), "x").unwrap();
+    let first = hash_tree(&a).unwrap();
+    assert_eq!(first, hash_tree(&a).unwrap());
+
+    std::fs::write(a.join("sub/x.sh"), "y").unwrap();
+    assert_ne!(first, hash_tree(&a).unwrap());
+}
+
+#[test]
+fn editing_a_shared_key_invalidates_dependents() {
+    let tmp = tempfile::tempdir().unwrap();
+    let skill = tmp.path().join("skill");
+    std::fs::create_dir_all(&skill).unwrap();
+    std::fs::write(skill.join("SKILL.md"), "content").unwrap();
+
+    let mut manifest = Manifest {
+        schema: MANIFEST_SCHEMA,
+        ..Manifest::default()
+    };
+    let sealed = crate::source_read::SealedSource::open(tmp.path()).unwrap();
+    let skill = sealed.root().join("skill");
+    let before = installation_hash(
+        &sealed,
+        &skill,
+        &manifest,
+        ItemKind::Skill,
+        "github",
+        HarnessId::Claude,
+    )
+    .unwrap();
+
+    manifest
+        .skill_instructions
+        .insert("all".into(), "shared instruction".into());
+    let after = installation_hash(
+        &sealed,
+        &skill,
+        &manifest,
+        ItemKind::Skill,
+        "github",
+        HarnessId::Claude,
+    )
+    .unwrap();
+    assert_ne!(before, after);
+
+    let unrelated = installation_hash(
+        &sealed,
+        &skill,
+        &manifest,
+        ItemKind::Command,
+        "github",
+        HarnessId::Claude,
+    )
+    .unwrap();
+    let unrelated_before = {
+        let clean = Manifest {
+            schema: MANIFEST_SCHEMA,
+            ..Manifest::default()
+        };
+        installation_hash(
+            &sealed,
+            &skill,
+            &clean,
+            ItemKind::Command,
+            "github",
+            HarnessId::Claude,
+        )
+        .unwrap()
+    };
+    assert_eq!(unrelated, unrelated_before);
+}

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -1,5 +1,6 @@
 pub mod apply;
 pub mod author;
+pub mod base;
 pub mod check_catalog;
 pub mod clock;
 pub mod configedit;

--- a/crates/core/src/manifest/file.rs
+++ b/crates/core/src/manifest/file.rs
@@ -4,6 +4,7 @@
 
 use std::path::Path;
 
+use crate::base::Base;
 use crate::env::Env;
 use crate::error::{CoreError, Result};
 use crate::fs::{atomic_write, read_if_exists};
@@ -96,6 +97,31 @@ pub fn load_for_mutation(path: &Path) -> Result<Option<Manifest>> {
         ManifestFile::Current(mut manifest) => {
             manifest.schema = MANIFEST_SCHEMA;
             Ok(Some(*manifest))
+        }
+    }
+}
+
+/// A manifest and the base of the file it came from, from one read.
+///
+/// Two reads would pair a manifest with the base of whatever replaced it:
+/// a writer landing between them hands the caller old content under the
+/// new file's name, and the write that follows is accepted over that
+/// writer — the one thing a base exists to prevent. So the text is read
+/// once and both answers come from it.
+pub fn read_for_mutation(path: &Path) -> Result<(Option<Manifest>, Base)> {
+    crate::rename::refuse_both_generations(path)?;
+    let Some(text) = read_if_exists(path)? else {
+        return Ok((None, Base::absent()));
+    };
+    let base = Base::of(&text);
+    match parse_text(path, &text)? {
+        ManifestFile::Absent => Ok((None, base)),
+        ManifestFile::Legacy { .. } => Err(CoreError::LegacyManifest {
+            path: path.to_path_buf(),
+        }),
+        ManifestFile::Current(mut manifest) => {
+            manifest.schema = MANIFEST_SCHEMA;
+            Ok((Some(*manifest), base))
         }
     }
 }

--- a/crates/core/src/manifest/file.rs
+++ b/crates/core/src/manifest/file.rs
@@ -32,6 +32,16 @@ pub fn manifest_path(env: &Env, scope: &Scope) -> std::path::PathBuf {
     crate::rename::existing_or_new(new, old)
 }
 
+/// Every name this scope's manifest can answer to: the current one, and
+/// the old product name while a scope is still under it. A rename
+/// generation retargets writes planned against the old name, so a refusal
+/// out of an apply can name either — a caller matching refusals against
+/// only the name it read from would misread the retargeted one.
+pub fn manifest_paths(env: &Env, scope: &Scope) -> [std::path::PathBuf; 2] {
+    let (new, old) = crate::rename::manifest_pair(env, scope);
+    [new, old]
+}
+
 pub fn load(path: &Path) -> Result<ManifestFile> {
     crate::rename::refuse_both_generations(path)?;
     let Some(text) = read_if_exists(path)? else {
@@ -88,17 +98,9 @@ pub fn save(path: &Path, manifest: &Manifest) -> Result<()> {
 /// Load for mutation: a legacy file is a hard error, never a write target.
 /// Whatever schema was read, a mutation writes the current one — every
 /// write path upgrades as a side effect of writing at all.
+/// [`read_for_mutation`] with the base dropped, so the two cannot drift.
 pub fn load_for_mutation(path: &Path) -> Result<Option<Manifest>> {
-    match load(path)? {
-        ManifestFile::Absent => Ok(None),
-        ManifestFile::Legacy { .. } => Err(CoreError::LegacyManifest {
-            path: path.to_path_buf(),
-        }),
-        ManifestFile::Current(mut manifest) => {
-            manifest.schema = MANIFEST_SCHEMA;
-            Ok(Some(*manifest))
-        }
-    }
+    Ok(read_for_mutation(path)?.0)
 }
 
 /// A manifest and the base of the file it came from, from one read.

--- a/crates/core/src/manifest/mod.rs
+++ b/crates/core/src/manifest/mod.rs
@@ -8,7 +8,9 @@ use crate::model::HarnessId;
 mod decisions;
 mod file;
 mod validate;
-pub use file::{ManifestFile, load, load_for_mutation, manifest_path, parse_text, save, seed};
+pub use file::{
+    ManifestFile, load, load_for_mutation, manifest_path, parse_text, read_for_mutation, save, seed,
+};
 pub use validate::{Finding, validate};
 
 /// Current manifest schema. Schema 1 (v0.1) still loads; the first apply

--- a/crates/core/src/manifest/mod.rs
+++ b/crates/core/src/manifest/mod.rs
@@ -9,8 +9,13 @@ mod decisions;
 mod file;
 mod validate;
 pub use file::{
-    ManifestFile, load, load_for_mutation, manifest_path, parse_text, read_for_mutation, save, seed,
+    ManifestFile, load, load_for_mutation, manifest_path, manifest_paths, parse_text,
+    read_for_mutation, seed,
 };
+// Crate-only: the apply op is `save`'s one sanctioned caller — it checks
+// its precondition first. Anywhere else, a direct save is a whole-file
+// write with no base check, the exact door `read_for_mutation` closes.
+pub(crate) use file::save;
 pub use validate::{Finding, validate};
 
 /// Current manifest schema. Schema 1 (v0.1) still loads; the first apply

--- a/crates/core/src/package/updates.rs
+++ b/crates/core/src/package/updates.rs
@@ -289,29 +289,31 @@ pub fn set_ignored(
     repo: &str,
     ignored: bool,
 ) -> Result<()> {
-    let mut current = settings::load(env)?;
     let entry = IgnoredUpdate {
         scope: scope_key(scope),
         kind,
         name: name.to_owned(),
         repo: repo.to_owned(),
     };
-    // A record written before the repository move identifies the same
-    // package: replacing or clearing it must find it under either spelling,
-    // or an un-mute would leave the old record muting forever.
-    current.ignored_updates.retain(|existing| {
-        existing.scope != entry.scope
-            || existing.kind != entry.kind
-            || existing.name != entry.name
-            || !crate::repo_move::same_repo(&existing.repo, &entry.repo)
-    });
-    if ignored {
-        current.ignored_updates.push(entry);
-        current.ignored_updates.sort_by(|a, b| {
-            (&a.scope, a.kind.name(), &a.name).cmp(&(&b.scope, b.kind.name(), &b.name))
+    settings::mutate(env, |current| {
+        // A record written before the repository move identifies the same
+        // package: replacing or clearing it must find it under either
+        // spelling, or an un-mute would leave the old record muting forever.
+        current.ignored_updates.retain(|existing| {
+            existing.scope != entry.scope
+                || existing.kind != entry.kind
+                || existing.name != entry.name
+                || !crate::repo_move::same_repo(&existing.repo, &entry.repo)
         });
-    }
-    settings::save(env, &current)
+        if ignored {
+            current.ignored_updates.push(entry);
+            current.ignored_updates.sort_by(|a, b| {
+                (&a.scope, a.kind.name(), &a.name).cmp(&(&b.scope, b.kind.name(), &b.name))
+            });
+        }
+        Ok(())
+    })?;
+    Ok(())
 }
 
 fn load_current(env: &Env, scope: &Scope) -> Result<Option<crate::manifest::Manifest>> {

--- a/crates/core/src/pi_ext/files.rs
+++ b/crates/core/src/pi_ext/files.rs
@@ -1,8 +1,8 @@
 use std::path::{Path, PathBuf};
 
-use crate::apply::journal::{copy_tree, remove_any};
 use crate::env::Env;
 use crate::error::{CoreError, Result};
+use crate::fs::{copy_tree, remove_any};
 use crate::hash::hash_files;
 
 /// Never copied or hashed: dependency trees and build output are recreated

--- a/crates/core/src/pi_ext/mod.rs
+++ b/crates/core/src/pi_ext/mod.rs
@@ -11,10 +11,10 @@ use std::time::Duration;
 use serde::Deserialize;
 use serde_json::Value;
 
-use crate::apply::journal::make_symlink;
 use crate::configedit::{remove_marker_block, upsert_marker_block};
 use crate::env::Env;
 use crate::error::{CoreError, Result};
+use crate::fs::make_symlink;
 use crate::fs::{atomic_write, read_if_exists};
 use crate::process::Hardened;
 

--- a/crates/core/src/rename/mod.rs
+++ b/crates/core/src/rename/mod.rs
@@ -331,6 +331,39 @@ mod tests {
     use super::*;
     use crate::env::{Env, FakeOs};
 
+    /// The local-source dir rename binds to the tree as it was when the
+    /// plan was made. An edit landing inside it after planning refuses
+    /// the move, the edit survives, and the renames before it roll back.
+    #[test]
+    fn a_local_source_edit_after_planning_refuses_the_dir_rename() {
+        let tmp = tempfile::tempdir().unwrap();
+        let root = tmp.path().join("app");
+        let skill = root.join(".vstack-local/skills/x/SKILL.md");
+        std::fs::create_dir_all(skill.parent().unwrap()).unwrap();
+        std::fs::write(&skill, "v1").unwrap();
+        std::fs::write(root.join("vstack.toml"), "schema = 5\n").unwrap();
+        let env = Env::fake(tmp.path(), FakeOs::Linux);
+        let scope = Scope::Project { root: root.clone() };
+
+        let ops = rename_ops(&env, &scope).unwrap();
+        std::fs::write(&skill, "edited after planning").unwrap();
+
+        let error = crate::apply::execute(&env, &Plan { scope, ops }, None).unwrap_err();
+        assert!(
+            matches!(&error, CoreError::RolledBack { cause, .. }
+                if matches!(**cause, CoreError::PlanStale { .. })),
+            "{error:?}"
+        );
+        assert_eq!(
+            std::fs::read_to_string(&skill).unwrap(),
+            "edited after planning"
+        );
+        assert!(!root.join(".kendex-local").exists());
+        // The manifest rename ahead of it rolled back to the old name.
+        assert!(root.join("vstack.toml").is_file());
+        assert!(!root.join("kendex.toml").exists());
+    }
+
     #[test]
     fn source_catalog_migration_renames_both_definition_and_install_state() {
         let tmp = tempfile::tempdir().unwrap();

--- a/crates/core/src/rename/mod.rs
+++ b/crates/core/src/rename/mod.rs
@@ -174,9 +174,10 @@ pub fn rename_ops(env: &Env, scope: &Scope) -> Result<Vec<PlannedOp>> {
                 "{RENAME_PREFIX}: {LEGACY_LOCAL_SOURCE_DIR} becomes {LOCAL_SOURCE_DIR}"
             ),
             op: Op::Rename {
-                from_pre: Pre::HashIs {
-                    hash: crate::hash::hash_tree(&old_local)?,
-                },
+                // The dir moves whole, whatever sits in it: a dangling
+                // link kendex never wrote is carried along, not a reason
+                // to leave the scope unplannable.
+                from_pre: Pre::tree_as_is(&old_local)?,
                 from: old_local,
                 to: root.join(LOCAL_SOURCE_DIR),
                 to_pre: Pre::Absent,
@@ -327,65 +328,4 @@ pub(crate) fn insert_manifest_save(
 }
 
 #[cfg(test)]
-mod tests {
-    use super::*;
-    use crate::env::{Env, FakeOs};
-
-    /// The local-source dir rename binds to the tree as it was when the
-    /// plan was made. An edit landing inside it after planning refuses
-    /// the move, the edit survives, and the renames before it roll back.
-    #[test]
-    fn a_local_source_edit_after_planning_refuses_the_dir_rename() {
-        let tmp = tempfile::tempdir().unwrap();
-        let root = tmp.path().join("app");
-        let skill = root.join(".vstack-local/skills/x/SKILL.md");
-        std::fs::create_dir_all(skill.parent().unwrap()).unwrap();
-        std::fs::write(&skill, "v1").unwrap();
-        std::fs::write(root.join("vstack.toml"), "schema = 5\n").unwrap();
-        let env = Env::fake(tmp.path(), FakeOs::Linux);
-        let scope = Scope::Project { root: root.clone() };
-
-        let ops = rename_ops(&env, &scope).unwrap();
-        std::fs::write(&skill, "edited after planning").unwrap();
-
-        let error = crate::apply::execute(&env, &Plan { scope, ops }, None).unwrap_err();
-        assert!(
-            matches!(&error, CoreError::RolledBack { cause, .. }
-                if matches!(**cause, CoreError::PlanStale { .. })),
-            "{error:?}"
-        );
-        assert_eq!(
-            std::fs::read_to_string(&skill).unwrap(),
-            "edited after planning"
-        );
-        assert!(!root.join(".kendex-local").exists());
-        // The manifest rename ahead of it rolled back to the old name.
-        assert!(root.join("vstack.toml").is_file());
-        assert!(!root.join("kendex.toml").exists());
-    }
-
-    #[test]
-    fn source_catalog_migration_renames_both_definition_and_install_state() {
-        let tmp = tempfile::tempdir().unwrap();
-        let root = tmp.path();
-        std::fs::write(root.join("vstack.toml"), "is_source_catalog = true\n").unwrap();
-        std::fs::write(root.join("vstack-local.toml"), "schema = 5\n").unwrap();
-        let env = Env::fake(root, FakeOs::Linux);
-        let scope = Scope::Project {
-            root: root.to_path_buf(),
-        };
-
-        let ops = rename_ops(&env, &scope).unwrap();
-        let said: Vec<&str> = ops.iter().map(|o| o.description.as_str()).collect();
-        assert!(
-            said.iter()
-                .any(|d| d.contains("vstack-local.toml becomes kendex-local.toml")),
-            "install state must move: {said:?}",
-        );
-        assert!(
-            said.iter()
-                .any(|d| d.contains("vstack.toml becomes kendex.toml")),
-            "the catalog definition must move too: {said:?}",
-        );
-    }
-}
+mod tests;

--- a/crates/core/src/rename/mod.rs
+++ b/crates/core/src/rename/mod.rs
@@ -206,7 +206,9 @@ fn file_rename_op(
     ops.push(PlannedOp {
         description: format!("{RENAME_PREFIX}: {old_name} becomes {new_name}"),
         op: Op::Rename {
-            from_pre: Pre::observed(&old)?,
+            // As it sits, not as it reads: a link to the same bytes put
+            // where the file was is not the file the plan looked at.
+            from_pre: Pre::tree_as_is(&old)?,
             from: old,
             to: new,
             to_pre: Pre::Absent,

--- a/crates/core/src/rename/mod.rs
+++ b/crates/core/src/rename/mod.rs
@@ -174,6 +174,9 @@ pub fn rename_ops(env: &Env, scope: &Scope) -> Result<Vec<PlannedOp>> {
                 "{RENAME_PREFIX}: {LEGACY_LOCAL_SOURCE_DIR} becomes {LOCAL_SOURCE_DIR}"
             ),
             op: Op::Rename {
+                from_pre: Pre::HashIs {
+                    hash: crate::hash::hash_tree(&old_local)?,
+                },
                 from: old_local,
                 to: root.join(LOCAL_SOURCE_DIR),
                 to_pre: Pre::Absent,
@@ -202,6 +205,7 @@ fn file_rename_op(
     ops.push(PlannedOp {
         description: format!("{RENAME_PREFIX}: {old_name} becomes {new_name}"),
         op: Op::Rename {
+            from_pre: Pre::observed(&old)?,
             from: old,
             to: new,
             to_pre: Pre::Absent,

--- a/crates/core/src/rename/tests.rs
+++ b/crates/core/src/rename/tests.rs
@@ -61,6 +61,38 @@ fn a_dangling_link_in_the_local_source_dir_moves_with_it() {
     assert!(!old_local.exists());
 }
 
+/// A pipe under the old local-source dir refuses the scope at planning,
+/// naming the pipe: the journal snapshots a moved directory by copying
+/// it, and a copy of a reader-less pipe never returns — under the scope
+/// lock. Refused here, the person learns which entry to remove.
+#[cfg(target_os = "linux")]
+#[test]
+fn a_pipe_in_the_local_source_dir_refuses_planning_by_name() {
+    let tmp = tempfile::tempdir().unwrap();
+    let root = tmp.path().join("app");
+    let old_local = root.join(".vstack-local");
+    std::fs::create_dir_all(old_local.join("skills/x")).unwrap();
+    std::fs::write(old_local.join("skills/x/SKILL.md"), "v1").unwrap();
+    let pipe = old_local.join("skills/x/pipe");
+    rustix::fs::mknodat(
+        rustix::fs::CWD,
+        &pipe,
+        rustix::fs::FileType::Fifo,
+        rustix::fs::Mode::RWXU,
+        0,
+    )
+    .unwrap();
+    std::fs::write(root.join("vstack.toml"), "schema = 5\n").unwrap();
+    let env = Env::fake(tmp.path(), FakeOs::Linux);
+    let scope = Scope::Project { root };
+
+    let error = rename_ops(&env, &scope).unwrap_err();
+    assert!(
+        matches!(&error, CoreError::Io { path, .. } if *path == pipe),
+        "{error:?}"
+    );
+}
+
 #[test]
 fn source_catalog_migration_renames_both_definition_and_install_state() {
     let tmp = tempfile::tempdir().unwrap();

--- a/crates/core/src/rename/tests.rs
+++ b/crates/core/src/rename/tests.rs
@@ -1,0 +1,87 @@
+use super::*;
+use crate::env::{Env, FakeOs};
+
+/// The local-source dir rename binds to the tree as it was when the
+/// plan was made. An edit landing inside it after planning refuses
+/// the move, the edit survives, and the renames before it roll back.
+#[test]
+fn a_local_source_edit_after_planning_refuses_the_dir_rename() {
+    let tmp = tempfile::tempdir().unwrap();
+    let root = tmp.path().join("app");
+    let skill = root.join(".vstack-local/skills/x/SKILL.md");
+    std::fs::create_dir_all(skill.parent().unwrap()).unwrap();
+    std::fs::write(&skill, "v1").unwrap();
+    std::fs::write(root.join("vstack.toml"), "schema = 5\n").unwrap();
+    let env = Env::fake(tmp.path(), FakeOs::Linux);
+    let scope = Scope::Project { root: root.clone() };
+
+    let ops = rename_ops(&env, &scope).unwrap();
+    std::fs::write(&skill, "edited after planning").unwrap();
+
+    let error = crate::apply::execute(&env, &Plan { scope, ops }, None).unwrap_err();
+    assert!(
+        matches!(&error, CoreError::RolledBack { cause, .. }
+            if matches!(**cause, CoreError::PlanStale { .. })),
+        "{error:?}"
+    );
+    assert_eq!(
+        std::fs::read_to_string(&skill).unwrap(),
+        "edited after planning"
+    );
+    assert!(!root.join(".kendex-local").exists());
+    // The manifest rename ahead of it rolled back to the old name.
+    assert!(root.join("vstack.toml").is_file());
+    assert!(!root.join("kendex.toml").exists());
+}
+
+/// A dangling link under the old local-source dir is kendex's to carry,
+/// not a reason to refuse the scope: the dir moves whole, and the link
+/// arrives at the new name still pointing where it pointed. Bound to the
+/// bytes a link resolves to, this rename would fail planning — and with
+/// it every audit, apply and save for the scope.
+#[cfg(unix)]
+#[test]
+fn a_dangling_link_in_the_local_source_dir_moves_with_it() {
+    let tmp = tempfile::tempdir().unwrap();
+    let root = tmp.path().join("app");
+    let old_local = root.join(".vstack-local");
+    std::fs::create_dir_all(old_local.join("skills/x")).unwrap();
+    std::fs::write(old_local.join("skills/x/SKILL.md"), "v1").unwrap();
+    std::os::unix::fs::symlink("nowhere", old_local.join("skills/x/gone")).unwrap();
+    std::fs::write(root.join("vstack.toml"), "schema = 5\n").unwrap();
+    let env = Env::fake(tmp.path(), FakeOs::Linux);
+    let scope = Scope::Project { root: root.clone() };
+
+    let ops = rename_ops(&env, &scope).unwrap();
+    crate::apply::execute(&env, &Plan { scope, ops }, None).unwrap();
+
+    let moved = root.join(".kendex-local/skills/x/gone");
+    assert!(moved.is_symlink(), "{moved:?}");
+    assert_eq!(std::fs::read_link(&moved).unwrap().as_os_str(), "nowhere");
+    assert!(!old_local.exists());
+}
+
+#[test]
+fn source_catalog_migration_renames_both_definition_and_install_state() {
+    let tmp = tempfile::tempdir().unwrap();
+    let root = tmp.path();
+    std::fs::write(root.join("vstack.toml"), "is_source_catalog = true\n").unwrap();
+    std::fs::write(root.join("vstack-local.toml"), "schema = 5\n").unwrap();
+    let env = Env::fake(root, FakeOs::Linux);
+    let scope = Scope::Project {
+        root: root.to_path_buf(),
+    };
+
+    let ops = rename_ops(&env, &scope).unwrap();
+    let said: Vec<&str> = ops.iter().map(|o| o.description.as_str()).collect();
+    assert!(
+        said.iter()
+            .any(|d| d.contains("vstack-local.toml becomes kendex-local.toml")),
+        "install state must move: {said:?}",
+    );
+    assert!(
+        said.iter()
+            .any(|d| d.contains("vstack.toml becomes kendex.toml")),
+        "the catalog definition must move too: {said:?}",
+    );
+}

--- a/crates/core/src/rename/tests.rs
+++ b/crates/core/src/rename/tests.rs
@@ -93,6 +93,65 @@ fn a_pipe_in_the_local_source_dir_refuses_planning_by_name() {
     );
 }
 
+/// An empty directory added under the old local-source dir after planning
+/// is an entry the plan never saw: the move refuses, so a later rollback
+/// cannot delete it as part of a tree it restores from the snapshot.
+#[test]
+fn an_empty_dir_added_after_planning_refuses_the_local_source_move() {
+    let tmp = tempfile::tempdir().unwrap();
+    let root = tmp.path().join("app");
+    let old_local = root.join(".vstack-local");
+    std::fs::create_dir_all(old_local.join("skills/x")).unwrap();
+    std::fs::write(old_local.join("skills/x/SKILL.md"), "v1").unwrap();
+    std::fs::write(root.join("vstack.toml"), "schema = 5\n").unwrap();
+    let env = Env::fake(tmp.path(), FakeOs::Linux);
+    let scope = Scope::Project { root: root.clone() };
+
+    let ops = rename_ops(&env, &scope).unwrap();
+    let added = old_local.join("skills/new");
+    std::fs::create_dir(&added).unwrap();
+
+    let error = crate::apply::execute(&env, &Plan { scope, ops }, None).unwrap_err();
+    assert!(
+        matches!(&error, CoreError::RolledBack { cause, .. }
+            if matches!(**cause, CoreError::PlanStale { .. })),
+        "{error:?}"
+    );
+    assert!(added.is_dir());
+    assert!(!root.join(".kendex-local").exists());
+}
+
+/// The manifest rename binds to the file as it sits. A link to the same
+/// bytes put where the file was after planning reads identically but is
+/// not that file: the move refuses, the link stays, nothing lands at the
+/// new name — run anyway, a later rollback would restore the snapshot's
+/// regular file over the link.
+#[cfg(unix)]
+#[test]
+fn a_manifest_swapped_for_a_same_bytes_link_after_planning_refuses_the_rename() {
+    let tmp = tempfile::tempdir().unwrap();
+    let root = tmp.path().join("app");
+    std::fs::create_dir_all(&root).unwrap();
+    let old = root.join("vstack.toml");
+    std::fs::write(&old, "schema = 5\n").unwrap();
+    std::fs::write(tmp.path().join("elsewhere.toml"), "schema = 5\n").unwrap();
+    let env = Env::fake(tmp.path(), FakeOs::Linux);
+    let scope = Scope::Project { root: root.clone() };
+
+    let ops = rename_ops(&env, &scope).unwrap();
+    std::fs::remove_file(&old).unwrap();
+    std::os::unix::fs::symlink(tmp.path().join("elsewhere.toml"), &old).unwrap();
+
+    let error = crate::apply::execute(&env, &Plan { scope, ops }, None).unwrap_err();
+    assert!(
+        matches!(&error, CoreError::RolledBack { cause, .. }
+            if matches!(**cause, CoreError::PlanStale { .. })),
+        "{error:?}"
+    );
+    assert!(old.is_symlink());
+    assert!(!root.join("kendex.toml").exists());
+}
+
 #[test]
 fn source_catalog_migration_renames_both_definition_and_install_state() {
     let tmp = tempfile::tempdir().unwrap();

--- a/crates/core/src/settings.rs
+++ b/crates/core/src/settings.rs
@@ -1,9 +1,11 @@
 use std::collections::BTreeMap;
 use std::path::{Path, PathBuf};
+use std::sync::Mutex;
 
 use serde::{Deserialize, Serialize};
 use specta::Type;
 
+use crate::base::Base;
 use crate::env::Env;
 use crate::error::{CoreError, Result};
 use crate::fs::{atomic_write, read_if_exists};
@@ -122,60 +124,119 @@ pub fn load(env: &Env) -> Result<AppSettings> {
     let path = env.settings_file();
     match read_if_exists(&path)? {
         None => Ok(AppSettings::default()),
-        Some(text) => {
-            let mut document = text
-                .parse::<toml::Table>()
-                .map_err(|e| CoreError::TomlParse {
-                    path: path.clone(),
-                    message: e.to_string(),
-                })?;
-            bring_zoom_into_range(&mut document);
-            toml::Value::Table(document)
-                .try_into()
-                .map_err(|e: toml::de::Error| CoreError::TomlParse {
-                    path,
-                    message: e.to_string(),
-                })
-        }
+        Some(text) => parse(&path, &text),
     }
 }
 
-pub fn save(env: &Env, settings: &AppSettings) -> Result<()> {
+/// The settings and the base of the file they came from, from one read.
+/// Read apart, the settings could be the old file's and the base the new
+/// one's, and the write that follows would be accepted over the writer in
+/// between.
+pub fn read_for_mutation(env: &Env) -> Result<(AppSettings, Base)> {
+    let path = env.settings_file();
+    match read_if_exists(&path)? {
+        None => Ok((AppSettings::default(), Base::absent())),
+        Some(text) => Ok((parse(&path, &text)?, Base::of(&text))),
+    }
+}
+
+fn parse(path: &Path, text: &str) -> Result<AppSettings> {
+    let mut document = text
+        .parse::<toml::Table>()
+        .map_err(|e| CoreError::TomlParse {
+            path: path.to_path_buf(),
+            message: e.to_string(),
+        })?;
+    bring_zoom_into_range(&mut document);
+    toml::Value::Table(document)
+        .try_into()
+        .map_err(|e: toml::de::Error| CoreError::TomlParse {
+            path: path.to_path_buf(),
+            message: e.to_string(),
+        })
+}
+
+/// One writer at a time. The app saves settings from a thread pool, so a
+/// zoom commit and an appearance toggle really do overlap; unserialized,
+/// whichever load ran first writes last and puts back what the other one
+/// just changed. Process-wide, not cross-process: a stale copy from
+/// another process is what [`replace`]'s base check refuses.
+static WRITE: Mutex<()> = Mutex::new(());
+
+fn write_lock() -> std::sync::MutexGuard<'static, ()> {
+    // A panic under the lock leaves no partial state behind (the write is
+    // atomic), so the poison carries no information — clearing it beats
+    // failing every later save for a wound that already healed.
+    WRITE
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner)
+}
+
+fn save(env: &Env, settings: &AppSettings) -> Result<String> {
     let text = toml::to_string_pretty(settings).map_err(|e| CoreError::TomlParse {
         path: env.settings_file(),
         message: e.to_string(),
     })?;
-    atomic_write(&env.settings_file(), &text)
+    atomic_write(&env.settings_file(), &text)?;
+    Ok(text)
+}
+
+/// Load, change, save — one breath, under the write lock. The targeted
+/// write path: a stale copy cannot reach it because the copy never leaves
+/// this function. Returns what was written and the base of the written
+/// bytes, so a caller holding the result holds a current pair.
+pub fn mutate(
+    env: &Env,
+    change: impl FnOnce(&mut AppSettings) -> Result<()>,
+) -> Result<(AppSettings, Base)> {
+    let _guard = write_lock();
+    let mut settings = load(env)?;
+    change(&mut settings)?;
+    let base = Base::of(&save(env, &settings)?);
+    Ok((settings, base))
+}
+
+/// The whole-file write path: replace everything with a copy something
+/// held, refusing a copy of a file that is no longer there. Returns the
+/// base of the bytes written — the base for the next write from the same
+/// copy. There is no way to write a whole settings object without
+/// presenting the base its copy was read from.
+pub fn replace(env: &Env, settings: &AppSettings, held: &Base) -> Result<Base> {
+    let _guard = write_lock();
+    held.verify(&env.settings_file())?;
+    Ok(Base::of(&save(env, settings)?))
 }
 
 /// Canonicalizes, rejects non-directories and duplicates, persists.
-pub fn register_project(env: &Env, path: &Path) -> Result<AppSettings> {
+pub fn register_project(env: &Env, path: &Path) -> Result<(AppSettings, Base)> {
     let canonical = path.canonicalize().map_err(|e| CoreError::io(path, e))?;
     if !canonical.is_dir() {
         return Err(CoreError::NotADirectory { path: canonical });
     }
-    let mut settings = load(env)?;
-    if settings.projects.contains(&canonical) {
-        return Err(CoreError::ProjectAlreadyRegistered { path: canonical });
-    }
-    settings.projects.push(canonical);
-    settings.projects.sort();
-    save(env, &settings)?;
-    Ok(settings)
+    mutate(env, |settings| {
+        if settings.projects.contains(&canonical) {
+            return Err(CoreError::ProjectAlreadyRegistered { path: canonical });
+        }
+        settings.projects.push(canonical);
+        settings.projects.sort();
+        Ok(())
+    })
 }
 
 /// Removes by canonical path when resolvable, else by the recorded path —
 /// a registered project whose directory vanished must still be removable.
-pub fn unregister_project(env: &Env, path: &Path) -> Result<AppSettings> {
+pub fn unregister_project(env: &Env, path: &Path) -> Result<(AppSettings, Base)> {
     let target = path.canonicalize().unwrap_or_else(|_| path.to_path_buf());
-    let mut settings = load(env)?;
-    let before = settings.projects.len();
-    settings.projects.retain(|p| *p != target);
-    if settings.projects.len() == before {
-        return Err(CoreError::ProjectNotRegistered { path: target });
-    }
-    save(env, &settings)?;
-    Ok(settings)
+    mutate(env, |settings| {
+        let before = settings.projects.len();
+        settings.projects.retain(|p| *p != target);
+        match settings.projects.len() == before {
+            true => Err(CoreError::ProjectNotRegistered {
+                path: target.clone(),
+            }),
+            false => Ok(()),
+        }
+    })
 }
 
 #[cfg(test)]
@@ -222,14 +283,17 @@ mod tests {
         let project = tmp.path().join("proj");
         std::fs::create_dir(&project).unwrap();
 
-        let settings = register_project(&env, &project).unwrap();
+        let (settings, base) = register_project(&env, &project).unwrap();
         assert_eq!(settings.projects.len(), 1);
+        // The pair handed back is current: presenting it to the
+        // whole-file path writes without a re-read in between.
+        replace(&env, &settings, &base).unwrap();
         assert!(matches!(
             register_project(&env, &project),
             Err(CoreError::ProjectAlreadyRegistered { .. })
         ));
 
-        let settings = unregister_project(&env, &project).unwrap();
+        let (settings, _) = unregister_project(&env, &project).unwrap();
         assert!(settings.projects.is_empty());
         assert!(matches!(
             unregister_project(&env, &project),
@@ -306,10 +370,10 @@ mod tests {
         let env = env_in(tmp.path());
         let project = tmp.path().join("gone");
         std::fs::create_dir(&project).unwrap();
-        let registered = register_project(&env, &project).unwrap().projects[0].clone();
+        let registered = register_project(&env, &project).unwrap().0.projects[0].clone();
         std::fs::remove_dir(&project).unwrap();
 
-        let settings = unregister_project(&env, &registered).unwrap();
+        let (settings, _) = unregister_project(&env, &registered).unwrap();
         assert!(settings.projects.is_empty());
     }
 }

--- a/crates/core/src/settings/mod.rs
+++ b/crates/core/src/settings/mod.rs
@@ -1,6 +1,5 @@
 use std::collections::BTreeMap;
 use std::path::{Path, PathBuf};
-use std::sync::Mutex;
 
 use serde::{Deserialize, Serialize};
 use specta::Type;
@@ -9,6 +8,10 @@ use crate::base::Base;
 use crate::env::Env;
 use crate::error::{CoreError, Result};
 use crate::fs::{atomic_write, read_if_exists};
+
+mod zoom;
+use zoom::bring_zoom_into_range;
+pub use zoom::{ZOOM, ZoomRange, clamp_zoom, zoom_scale};
 
 /// App preferences and the project registry — one settings file, nothing else.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Type)]
@@ -44,37 +47,6 @@ fn default_zoom() -> u16 {
     ZOOM.default
 }
 
-/// The zoom the app offers, in percent — the number stored is the number on
-/// the slider, so the settings file reads the way the control does.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Type)]
-pub struct ZoomRange {
-    pub min: u16,
-    pub max: u16,
-    /// What one press of the zoom shortcut moves.
-    pub step: u16,
-    pub default: u16,
-}
-
-pub const ZOOM: ZoomRange = ZoomRange {
-    min: 50,
-    max: 200,
-    step: 10,
-    default: 100,
-};
-
-/// Below the floor the app is unreadable and above the ceiling its controls
-/// stop fitting the window, so neither is offered and neither is honoured: a
-/// hand-edited settings file is the only way a value outside the range gets
-/// this far.
-pub fn clamp_zoom(percent: u16) -> u16 {
-    percent.clamp(ZOOM.min, ZOOM.max)
-}
-
-/// The webview scale factor a stored zoom percent means.
-pub fn zoom_scale(percent: u16) -> f64 {
-    f64::from(clamp_zoom(percent)) / 100.0
-}
-
 impl Default for AppSettings {
     fn default() -> Self {
         AppSettings {
@@ -96,28 +68,6 @@ pub enum Appearance {
     System,
     Light,
     Dark,
-}
-
-/// Bring a hand-edited zoom into range before the document is read as
-/// settings. `zoom` is a percent and a `u16`, so `-1` or `999999` would
-/// fail the field's own type — and the file is one document, so that one
-/// number would cost the person their theme, their projects and their
-/// safety thresholds along with it.
-///
-/// Only a whole number is moved. `zoom = 1.5` is left exactly where it is
-/// and the read refuses it: that is not a size out of range, it is not a
-/// size, and guessing which number was meant is worse than saying the line
-/// is wrong.
-fn bring_zoom_into_range(document: &mut toml::Table) {
-    let Some(toml::Value::Integer(percent)) = document.get("zoom") else {
-        return;
-    };
-    let in_range = match u16::try_from(*percent) {
-        Ok(percent) => clamp_zoom(percent),
-        Err(_) if percent.is_negative() => ZOOM.min,
-        Err(_) => ZOOM.max,
-    };
-    document.insert("zoom".to_owned(), toml::Value::Integer(in_range.into()));
 }
 
 pub fn load(env: &Env) -> Result<AppSettings> {
@@ -156,20 +106,39 @@ fn parse(path: &Path, text: &str) -> Result<AppSettings> {
         })
 }
 
-/// One writer at a time. The app saves settings from a thread pool, so a
-/// zoom commit and an appearance toggle really do overlap; unserialized,
-/// whichever load ran first writes last and puts back what the other one
-/// just changed. Process-wide, not cross-process: a stale copy from
-/// another process is what [`replace`]'s base check refuses.
-static WRITE: Mutex<()> = Mutex::new(());
+/// How long a writer waits for the settings lock before giving up. A
+/// settings write is a parse and one small file, so a holder alive past
+/// this is stuck, and waiting on it forever would hang the caller too.
+const LOCK_WAIT: std::time::Duration = std::time::Duration::from_secs(2);
 
-fn write_lock() -> std::sync::MutexGuard<'static, ()> {
-    // A panic under the lock leaves no partial state behind (the write is
-    // atomic), so the poison carries no information — clearing it beats
-    // failing every later save for a wound that already healed.
-    WRITE
-        .lock()
-        .unwrap_or_else(std::sync::PoisonError::into_inner)
+/// One writer at a time, across every kendex process. The app saves
+/// settings from a thread pool, and the CLI registers projects into the
+/// same file from its own process; unserialized, whichever load ran first
+/// writes last and puts back what the other one just changed. An OS file
+/// lock beside the settings file is what both can share — it also holds
+/// [`replace`]'s base check and its write together, so nothing can land
+/// between the two. Distinct fds conflict under the OS lock, so it
+/// serializes this process's threads as well as other processes.
+fn write_lock(env: &Env) -> Result<crate::fs::LockedFile> {
+    let settings = env.settings_file();
+    let parent = settings
+        .parent()
+        .ok_or_else(|| CoreError::io(&settings, std::io::Error::other("path has no parent")))?;
+    std::fs::create_dir_all(parent).map_err(|e| CoreError::io(parent, e))?;
+    let mut path = settings.into_os_string();
+    path.push(".lock");
+    let path = PathBuf::from(path);
+    let deadline = std::time::Instant::now() + LOCK_WAIT;
+    loop {
+        match crate::fs::LockedFile::try_exclusive(&path) {
+            Ok(Some(lock)) => return Ok(lock),
+            Ok(None) if std::time::Instant::now() < deadline => {
+                std::thread::sleep(std::time::Duration::from_millis(10));
+            }
+            Ok(None) => return Err(CoreError::SettingsBusy { lock: path }),
+            Err(error) => return Err(CoreError::io(&path, error)),
+        }
+    }
 }
 
 fn save(env: &Env, settings: &AppSettings) -> Result<String> {
@@ -181,15 +150,17 @@ fn save(env: &Env, settings: &AppSettings) -> Result<String> {
     Ok(text)
 }
 
-/// Load, change, save — one breath, under the write lock. The targeted
-/// write path: a stale copy cannot reach it because the copy never leaves
-/// this function. Returns what was written and the base of the written
-/// bytes, so a caller holding the result holds a current pair.
+/// Load, change, save — one breath, under the cross-process write lock.
+/// The targeted write path: a stale copy cannot reach it because the copy
+/// never leaves this function, and no other writer — thread or process —
+/// can land between its load and its save. Returns what was written and
+/// the base of the written bytes, so a caller holding the result holds a
+/// current pair.
 pub fn mutate(
     env: &Env,
     change: impl FnOnce(&mut AppSettings) -> Result<()>,
 ) -> Result<(AppSettings, Base)> {
-    let _guard = write_lock();
+    let _guard = write_lock(env)?;
     let mut settings = load(env)?;
     change(&mut settings)?;
     let base = Base::of(&save(env, &settings)?);
@@ -202,7 +173,9 @@ pub fn mutate(
 /// copy. There is no way to write a whole settings object without
 /// presenting the base its copy was read from.
 pub fn replace(env: &Env, settings: &AppSettings, held: &Base) -> Result<Base> {
-    let _guard = write_lock();
+    // The lock spans the check and the write, so the file the base was
+    // verified against is the file the write replaces.
+    let _guard = write_lock(env)?;
     held.verify(&env.settings_file())?;
     Ok(Base::of(&save(env, settings)?))
 }
@@ -240,15 +213,15 @@ pub fn unregister_project(env: &Env, path: &Path) -> Result<(AppSettings, Base)>
 }
 
 #[cfg(test)]
-mod tests {
+pub(crate) mod tests {
     use super::*;
     use crate::env::FakeOs;
 
-    fn env_in(dir: &Path) -> Env {
+    pub(crate) fn env_in(dir: &Path) -> Env {
         Env::fake(dir, FakeOs::Linux)
     }
 
-    fn write_settings(env: &Env, text: &str) {
+    pub(crate) fn write_settings(env: &Env, text: &str) {
         let path = env.settings_file();
         std::fs::create_dir_all(path.parent().unwrap()).unwrap();
         std::fs::write(path, text).unwrap();
@@ -276,6 +249,45 @@ mod tests {
         assert_eq!(load(&env).unwrap(), settings);
     }
 
+    /// The lost update the write lock exists to prevent: overlapping
+    /// load-change-save rounds, each writing the whole file. Every writer
+    /// here opens its own lock fd — distinct file descriptions conflict
+    /// under the OS lock exactly the way two processes do, so this is the
+    /// cross-process interleaving, not just the thread-pool one.
+    #[test]
+    fn overlapping_mutates_all_survive() {
+        let tmp = tempfile::tempdir().unwrap();
+        let env = env_in(tmp.path());
+        let writers: Vec<_> = (0..8)
+            .map(|n| {
+                let env = env.clone();
+                std::thread::spawn(move || {
+                    mutate(&env, |settings| {
+                        settings.projects.push(PathBuf::from(format!("/p{n}")));
+                        Ok(())
+                    })
+                    .unwrap();
+                })
+            })
+            .collect();
+        for writer in writers {
+            writer.join().unwrap();
+        }
+        assert_eq!(load(&env).unwrap().projects.len(), 8);
+    }
+
+    /// A holder that never lets go turns into a loud refusal, not a hang.
+    #[test]
+    fn a_stuck_lock_holder_is_reported_not_waited_on_forever() {
+        let tmp = tempfile::tempdir().unwrap();
+        let env = env_in(tmp.path());
+        let _held = write_lock(&env).unwrap();
+        assert!(matches!(
+            write_lock(&env),
+            Err(CoreError::SettingsBusy { .. })
+        ));
+    }
+
     #[test]
     fn register_rejects_duplicates_and_unregister_removes() {
         let tmp = tempfile::tempdir().unwrap();
@@ -299,69 +311,6 @@ mod tests {
             unregister_project(&env, &project),
             Err(CoreError::ProjectNotRegistered { .. })
         ));
-    }
-
-    #[test]
-    fn a_settings_file_without_zoom_reads_as_full_size() {
-        let tmp = tempfile::tempdir().unwrap();
-        let env = env_in(tmp.path());
-        write_settings(&env, "schema = 1\n");
-        assert_eq!(load(&env).unwrap().zoom, 100);
-    }
-
-    #[test]
-    fn a_hand_edited_zoom_outside_the_range_loads_clamped() {
-        let tmp = tempfile::tempdir().unwrap();
-        let env = env_in(tmp.path());
-        write_settings(&env, "schema = 1\nzoom = 5000\n");
-        assert_eq!(load(&env).unwrap().zoom, ZOOM.max);
-        write_settings(&env, "schema = 1\nzoom = 1\n");
-        assert_eq!(load(&env).unwrap().zoom, ZOOM.min);
-    }
-
-    /// A number the field's own type cannot hold fails the parse, and the
-    /// file is one document, so a mistyped zoom would take the theme, the
-    /// projects and the safety thresholds down with it.
-    #[test]
-    fn a_hand_edited_zoom_too_big_for_a_percent_clamps_without_losing_the_file() {
-        let tmp = tempfile::tempdir().unwrap();
-        let env = env_in(tmp.path());
-        let rest = "schema = 1\nappearance = \"dark\"\n";
-
-        write_settings(&env, &format!("{rest}zoom = 999999\n"));
-        let settings = load(&env).unwrap();
-        assert_eq!(settings.zoom, ZOOM.max);
-        assert_eq!(settings.appearance, Appearance::Dark);
-
-        write_settings(&env, &format!("{rest}zoom = -1\n"));
-        let settings = load(&env).unwrap();
-        assert_eq!(settings.zoom, ZOOM.min);
-        assert_eq!(settings.appearance, Appearance::Dark);
-    }
-
-    /// The line between the two: a number outside the range is a size the
-    /// app will not give you, and anything that is not a whole number is
-    /// not a size at all.
-    #[test]
-    fn a_zoom_that_is_not_a_whole_number_is_refused() {
-        let tmp = tempfile::tempdir().unwrap();
-        let env = env_in(tmp.path());
-        for line in ["zoom = 1.5", "zoom = \"big\"", "zoom = true"] {
-            write_settings(&env, &format!("schema = 1\n{line}\n"));
-            assert!(
-                matches!(load(&env), Err(CoreError::TomlParse { .. })),
-                "expected {line} to be refused as the wrong kind of value"
-            );
-        }
-    }
-
-    #[test]
-    fn zoom_scales_the_webview_by_the_percent_shown() {
-        assert_eq!(zoom_scale(100), 1.0);
-        assert_eq!(zoom_scale(150), 1.5);
-        assert_eq!(zoom_scale(50), 0.5);
-        // Out of range never reaches the window.
-        assert_eq!(zoom_scale(5000), 2.0);
     }
 
     #[test]

--- a/crates/core/src/settings/zoom.rs
+++ b/crates/core/src/settings/zoom.rs
@@ -1,0 +1,130 @@
+//! The zoom the app offers: the range every control and the settings file
+//! are held to, and the clamp a hand-edited value passes through before
+//! the document is read as settings.
+
+use serde::{Deserialize, Serialize};
+use specta::Type;
+
+/// The zoom the app offers, in percent — the number stored is the number on
+/// the slider, so the settings file reads the way the control does.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Type)]
+pub struct ZoomRange {
+    pub min: u16,
+    pub max: u16,
+    /// What one press of the zoom shortcut moves.
+    pub step: u16,
+    pub default: u16,
+}
+
+pub const ZOOM: ZoomRange = ZoomRange {
+    min: 50,
+    max: 200,
+    step: 10,
+    default: 100,
+};
+
+/// Below the floor the app is unreadable and above the ceiling its controls
+/// stop fitting the window, so neither is offered and neither is honoured: a
+/// hand-edited settings file is the only way a value outside the range gets
+/// this far.
+pub fn clamp_zoom(percent: u16) -> u16 {
+    percent.clamp(ZOOM.min, ZOOM.max)
+}
+
+/// The webview scale factor a stored zoom percent means.
+pub fn zoom_scale(percent: u16) -> f64 {
+    f64::from(clamp_zoom(percent)) / 100.0
+}
+
+/// Bring a hand-edited zoom into range before the document is read as
+/// settings. `zoom` is a percent and a `u16`, so `-1` or `999999` would
+/// fail the field's own type — and the file is one document, so that one
+/// number would cost the person their theme, their projects and their
+/// safety thresholds along with it.
+///
+/// Only a whole number is moved. `zoom = 1.5` is left exactly where it is
+/// and the read refuses it: that is not a size out of range, it is not a
+/// size, and guessing which number was meant is worse than saying the line
+/// is wrong.
+pub(super) fn bring_zoom_into_range(document: &mut toml::Table) {
+    let Some(toml::Value::Integer(percent)) = document.get("zoom") else {
+        return;
+    };
+    let in_range = match u16::try_from(*percent) {
+        Ok(percent) => clamp_zoom(percent),
+        Err(_) if percent.is_negative() => ZOOM.min,
+        Err(_) => ZOOM.max,
+    };
+    document.insert("zoom".to_owned(), toml::Value::Integer(in_range.into()));
+}
+
+#[cfg(test)]
+mod tests {
+    use super::super::tests::{env_in, write_settings};
+    use super::super::{Appearance, load};
+    use super::*;
+    use crate::error::CoreError;
+
+    #[test]
+    fn a_settings_file_without_zoom_reads_as_full_size() {
+        let tmp = tempfile::tempdir().unwrap();
+        let env = env_in(tmp.path());
+        write_settings(&env, "schema = 1\n");
+        assert_eq!(load(&env).unwrap().zoom, 100);
+    }
+
+    #[test]
+    fn a_hand_edited_zoom_outside_the_range_loads_clamped() {
+        let tmp = tempfile::tempdir().unwrap();
+        let env = env_in(tmp.path());
+        write_settings(&env, "schema = 1\nzoom = 5000\n");
+        assert_eq!(load(&env).unwrap().zoom, ZOOM.max);
+        write_settings(&env, "schema = 1\nzoom = 1\n");
+        assert_eq!(load(&env).unwrap().zoom, ZOOM.min);
+    }
+
+    /// A number the field's own type cannot hold fails the parse, and the
+    /// file is one document, so a mistyped zoom would take the theme, the
+    /// projects and the safety thresholds down with it.
+    #[test]
+    fn a_hand_edited_zoom_too_big_for_a_percent_clamps_without_losing_the_file() {
+        let tmp = tempfile::tempdir().unwrap();
+        let env = env_in(tmp.path());
+        let rest = "schema = 1\nappearance = \"dark\"\n";
+
+        write_settings(&env, &format!("{rest}zoom = 999999\n"));
+        let settings = load(&env).unwrap();
+        assert_eq!(settings.zoom, ZOOM.max);
+        assert_eq!(settings.appearance, Appearance::Dark);
+
+        write_settings(&env, &format!("{rest}zoom = -1\n"));
+        let settings = load(&env).unwrap();
+        assert_eq!(settings.zoom, ZOOM.min);
+        assert_eq!(settings.appearance, Appearance::Dark);
+    }
+
+    /// The line between the two: a number outside the range is a size the
+    /// app will not give you, and anything that is not a whole number is
+    /// not a size at all.
+    #[test]
+    fn a_zoom_that_is_not_a_whole_number_is_refused() {
+        let tmp = tempfile::tempdir().unwrap();
+        let env = env_in(tmp.path());
+        for line in ["zoom = 1.5", "zoom = \"big\"", "zoom = true"] {
+            write_settings(&env, &format!("schema = 1\n{line}\n"));
+            assert!(
+                matches!(load(&env), Err(CoreError::TomlParse { .. })),
+                "expected {line} to be refused as the wrong kind of value"
+            );
+        }
+    }
+
+    #[test]
+    fn zoom_scales_the_webview_by_the_percent_shown() {
+        assert_eq!(zoom_scale(100), 1.0);
+        assert_eq!(zoom_scale(150), 1.5);
+        assert_eq!(zoom_scale(50), 0.5);
+        // Out of range never reaches the window.
+        assert_eq!(zoom_scale(5000), 2.0);
+    }
+}

--- a/crates/core/src/source/browse/tests/safety_cache.rs
+++ b/crates/core/src/source/browse/tests/safety_cache.rs
@@ -172,9 +172,11 @@ fn thresholds_move_the_verdict_without_touching_the_cache() {
     let written = fs::read_to_string(&path).unwrap();
     let modified = fs::metadata(&path).unwrap().modified().unwrap();
 
-    let mut settings = crate::settings::load(&env).unwrap();
-    settings.safety.block_below = first.safety.score + 1;
-    crate::settings::save(&env, &settings).unwrap();
+    crate::settings::mutate(&env, |settings| {
+        settings.safety.block_below = first.safety.score + 1;
+        Ok(())
+    })
+    .unwrap();
 
     let judged = score(&env, &scope);
     assert_eq!(judged.verdict, Verdict::Block);

--- a/crates/core/tests/edits_and_forks/disabled.rs
+++ b/crates/core/tests/edits_and_forks/disabled.rs
@@ -62,6 +62,69 @@ fn an_edit_made_while_disabled_survives_being_re_enabled() {
     assert_eq!(content, "my edited disabled agent");
 }
 
+/// The re-enable toggle binds to the disabled file as it was when the
+/// plan was made. An edit landing after planning refuses the move: run
+/// anyway, the rename would put the edit at the enabled name for the
+/// install op behind it — planned against the unedited bytes — to
+/// overwrite.
+#[test]
+#[allow(clippy::unwrap_used)]
+fn an_edit_landing_after_the_enable_was_planned_refuses_the_toggle() {
+    let w = world();
+    let dir = w.upstream.join("agents");
+    fs::create_dir_all(&dir).unwrap();
+    fs::write(
+        dir.join("rev.md"),
+        "---\nname: rev\ndescription: reviewer\n---\nReview.\n",
+    )
+    .unwrap();
+    commit(&w.upstream, "one");
+    let path = manifest::manifest_path(&w.env, &w.scope);
+    fs::create_dir_all(path.parent().unwrap()).unwrap();
+    let manifest_with = |item: &str| {
+        format!(
+            "schema = 5\n\n[sources.cat]\nrepo = \"{REPO}\"\n\n[install]\nharnesses = [\"claude\"]\nmethod = \"copy\"\n\n{item}"
+        )
+    };
+    fs::write(&path, manifest_with("[agents.rev]\nsource = \"cat\"\n")).unwrap();
+    sync_and_apply(&w);
+
+    fs::write(
+        &path,
+        manifest_with("[agents.rev]\nsource = \"cat\"\nenabled = false\n"),
+    )
+    .unwrap();
+    let report = audit(&w.env, &w.scope).unwrap();
+    apply::execute(&w.env, &report.plan, None).unwrap();
+    let disabled = w.home.join("app/.claude/agents/rev.md.disabled");
+    assert!(disabled.is_file());
+
+    fs::write(&path, manifest_with("[agents.rev]\nsource = \"cat\"\n")).unwrap();
+    let report = audit(&w.env, &w.scope).unwrap();
+    assert!(
+        report
+            .plan
+            .ops
+            .iter()
+            .any(|op| op.description.contains("Turn rev on")),
+        "{:?}",
+        report.plan.ops
+    );
+    fs::write(&disabled, "edited after planning").unwrap();
+
+    let error = apply::execute(&w.env, &report.plan, None).unwrap_err();
+    assert!(
+        matches!(&error, CoreError::RolledBack { cause, .. }
+            if matches!(**cause, CoreError::PlanStale { .. })),
+        "{error:?}"
+    );
+    assert_eq!(
+        fs::read_to_string(&disabled).unwrap(),
+        "edited after planning"
+    );
+    assert!(!w.home.join("app/.claude/agents/rev.md").exists());
+}
+
 #[test]
 #[allow(clippy::unwrap_used)]
 fn upstream_changing_while_disabled_is_not_a_false_edit() {

--- a/crates/core/tests/edits_and_forks/forks.rs
+++ b/crates/core/tests/edits_and_forks/forks.rs
@@ -133,6 +133,38 @@ fn a_fork_edited_after_the_rename_was_planned_refuses_the_move() {
     assert!(!w.home.join("app/.kendex-local/skills/my-gh").exists());
 }
 
+/// A dangling link inside a fork is the person's to keep: the rename
+/// carries the fork's files whole, link included, instead of refusing
+/// the fork because one entry has no bytes to hash.
+#[cfg(unix)]
+#[test]
+#[allow(clippy::unwrap_used)]
+fn a_fork_holding_a_dangling_link_still_renames() {
+    let w = world();
+    write_skill(&w.upstream, "gh", "Upstream.");
+    commit(&w.upstream, "one");
+    declare(&w, "[skills.gh]\nsource = \"cat\"\n");
+    sync_and_apply(&w);
+    fs::write(
+        skill_file(&w),
+        "---\nname: gh\ndescription: mine\n---\nMine.\n",
+    )
+    .unwrap();
+    let plan = fork::fork(&w.env, &w.scope, ItemKind::Skill, "gh", HarnessId::Claude).unwrap();
+    apply::execute(&w.env, &plan, None).unwrap();
+    let report = audit(&w.env, &w.scope).unwrap();
+    apply::execute(&w.env, &report.plan, None).unwrap();
+
+    let source = w.home.join("app/.kendex-local/skills/gh");
+    std::os::unix::fs::symlink("nowhere", source.join("notes")).unwrap();
+
+    let plan = fork::rename_fork(&w.env, &w.scope, ItemKind::Skill, "gh", "my-gh").unwrap();
+    apply::execute(&w.env, &plan, None).unwrap();
+    let moved = w.home.join("app/.kendex-local/skills/my-gh/notes");
+    assert!(moved.is_symlink(), "{moved:?}");
+    assert!(!source.exists());
+}
+
 #[test]
 #[allow(clippy::unwrap_used)]
 fn forking_a_codex_agent_is_refused_with_the_fix_named() {

--- a/crates/core/tests/edits_and_forks/forks.rs
+++ b/crates/core/tests/edits_and_forks/forks.rs
@@ -2,6 +2,8 @@
 
 use std::fs;
 
+use kendex_core::error::CoreError;
+
 use super::*;
 
 #[test]
@@ -90,6 +92,45 @@ fn rename_fork_moves_the_declaration_and_refuses_depended_on_names() {
             .join("app/.kendex-local/skills/my-gh/SKILL.md")
             .is_file()
     );
+}
+
+/// The rename plan binds to the fork's files as they were when it was
+/// made. An edit landing on them after planning refuses the move — run
+/// anyway, the rename would carry the edit to the new name, where a later
+/// refusal's rollback could restore the old snapshot over it.
+#[test]
+#[allow(clippy::unwrap_used)]
+fn a_fork_edited_after_the_rename_was_planned_refuses_the_move() {
+    let w = world();
+    write_skill(&w.upstream, "gh", "Upstream.");
+    commit(&w.upstream, "one");
+    declare(&w, "[skills.gh]\nsource = \"cat\"\n");
+    sync_and_apply(&w);
+    fs::write(
+        skill_file(&w),
+        "---\nname: gh\ndescription: mine\n---\nMine.\n",
+    )
+    .unwrap();
+    let plan = fork::fork(&w.env, &w.scope, ItemKind::Skill, "gh", HarnessId::Claude).unwrap();
+    apply::execute(&w.env, &plan, None).unwrap();
+    let report = audit(&w.env, &w.scope).unwrap();
+    apply::execute(&w.env, &report.plan, None).unwrap();
+
+    let plan = fork::rename_fork(&w.env, &w.scope, ItemKind::Skill, "gh", "my-gh").unwrap();
+    let source = w.home.join("app/.kendex-local/skills/gh/SKILL.md");
+    fs::write(&source, "edited after planning").unwrap();
+
+    let error = apply::execute(&w.env, &plan, None).unwrap_err();
+    assert!(
+        matches!(&error, CoreError::RolledBack { cause, .. }
+            if matches!(**cause, CoreError::PlanStale { .. })),
+        "{error:?}"
+    );
+    assert_eq!(
+        fs::read_to_string(&source).unwrap(),
+        "edited after planning"
+    );
+    assert!(!w.home.join("app/.kendex-local/skills/my-gh").exists());
 }
 
 #[test]

--- a/crates/core/tests/invariants.rs
+++ b/crates/core/tests/invariants.rs
@@ -13,6 +13,15 @@ use kendex_core::manifest;
 use kendex_core::model::Scope;
 use kendex_core::{apply, hash};
 
+/// Writes a manifest the way an editor outside kendex would: raw bytes,
+/// no base, no plan — production writes go through the apply, which is
+/// why `manifest::save` is not public.
+#[allow(clippy::unwrap_used)]
+fn save_manifest(path: &std::path::Path, manifest: &manifest::Manifest) {
+    fs::create_dir_all(path.parent().unwrap()).unwrap();
+    fs::write(path, toml::to_string_pretty(manifest).unwrap()).unwrap();
+}
+
 struct Fixture {
     _tmp: tempfile::TempDir,
     env: Env,
@@ -153,7 +162,7 @@ fn invariant_1_generated_artifacts_regenerate_but_never_over_an_edit() {
     let mut m = manifest::load_for_mutation(&path).unwrap().unwrap();
     m.skill_instructions
         .insert("gh".into(), "prefer gh cli".into());
-    manifest::save(&path, &m).unwrap();
+    save_manifest(&path, &m);
     apply_now(&f);
     let text = fs::read_to_string(canonical_skill(&f).join("SKILL.md")).unwrap();
     assert!(text.contains("prefer gh cli") && text.contains("Author text."));
@@ -169,7 +178,7 @@ fn invariant_2_never_readd_a_user_removal() {
     let global_path = manifest::manifest_path(&f.env, &Scope::Global);
     let mut stripped = seeded.clone();
     stripped.sources.clear();
-    manifest::save(&global_path, &stripped).unwrap();
+    save_manifest(&global_path, &stripped);
     let reloaded = ops::manifest_for_mutation(&f.env, &Scope::Global).unwrap();
     assert!(reloaded.sources.is_empty());
 
@@ -178,7 +187,7 @@ fn invariant_2_never_readd_a_user_removal() {
     let path = manifest::manifest_path(&f.env, &f.scope);
     let mut m = manifest::load_for_mutation(&path).unwrap().unwrap();
     m.agent_skills.insert("rust".into(), vec![]);
-    manifest::save(&path, &m).unwrap();
+    save_manifest(&path, &m);
     apply_now(&f);
 
     // Upstream gains a prefix-matching skill after the removal.
@@ -205,7 +214,7 @@ fn invariant_3_shared_key_edits_invalidate_dependents() {
     let path = manifest::manifest_path(&f.env, &f.scope);
     let mut m = manifest::load_for_mutation(&path).unwrap().unwrap();
     m.skill_instructions.insert("all".into(), "shared".into());
-    manifest::save(&path, &m).unwrap();
+    save_manifest(&path, &m);
     let drift = drift_states(&f);
     assert!(drift.contains(&("gh".to_owned(), DriftState::Stale)));
 }

--- a/crates/core/tests/quality/decisions.rs
+++ b/crates/core/tests/quality/decisions.rs
@@ -137,7 +137,7 @@ fn a_dismissal_goes_stale_when_the_rules_move() {
     let path = manifest::manifest_path(&f.env, &f.scope);
     let mut recorded = manifest_of(&f);
     recorded.safety_reviews.get_mut(MILD_KEY).unwrap().ruleset += 1;
-    manifest::save(&path, &recorded).unwrap();
+    super::fixture::save_manifest(&path, &recorded);
 
     match &row(&f, "mild").decisions[0].state {
         DecisionState::Open { earlier: Some(why) } => {

--- a/crates/core/tests/quality/decisions_refuse.rs
+++ b/crates/core/tests/quality/decisions_refuse.rs
@@ -169,7 +169,7 @@ fn a_concurrent_manifest_write_makes_the_dismissal_stale() {
     recorded
         .skill_instructions
         .insert("all".to_owned(), "someone else's edit".to_owned());
-    manifest::save(&path, &recorded).unwrap();
+    super::fixture::save_manifest(&path, &recorded);
 
     let executed = apply::execute(&f.env, &planned, None);
     let message = executed

--- a/crates/core/tests/quality/fixture.rs
+++ b/crates/core/tests/quality/fixture.rs
@@ -18,6 +18,16 @@ pub struct Fixture {
     pub source: PathBuf,
 }
 
+/// Writes a manifest the way an editor outside kendex would: raw bytes,
+/// no base, no plan. Tests use it to stand in for that outside writer;
+/// production code goes through the apply, which is why
+/// `manifest::save` is not public.
+#[allow(clippy::unwrap_used)]
+pub fn save_manifest(path: &Path, manifest: &kendex_core::manifest::Manifest) {
+    fs::create_dir_all(path.parent().unwrap()).unwrap();
+    fs::write(path, toml::to_string_pretty(manifest).unwrap()).unwrap();
+}
+
 #[allow(clippy::unwrap_used)]
 pub fn skill(source: &Path, name: &str, body: &str) {
     let dir = source.join("skills").join(name);

--- a/crates/core/tests/quality/overrides.rs
+++ b/crates/core/tests/quality/overrides.rs
@@ -216,7 +216,7 @@ fn an_override_goes_stale_when_the_rule_set_moves() {
         .get_mut("skill:hostile:claude")
         .unwrap();
     entry.ruleset = kendex_core::quality::RULESET_VERSION + 1;
-    manifest::save(&path, &manifest).unwrap();
+    super::fixture::save_manifest(&path, &manifest);
 
     let after = audit(&f.env, &f.scope).unwrap();
     let row = after
@@ -255,7 +255,7 @@ fn an_override_does_not_cover_a_problem_nobody_reviewed() {
         .get_mut("skill:hostile:claude")
         .unwrap();
     entry.review_hash = hash;
-    manifest::save(&path, &manifest).unwrap();
+    super::fixture::save_manifest(&path, &manifest);
 
     let after = audit(&f.env, &f.scope).unwrap();
     let row = after

--- a/crates/core/tests/quality/review_hash.rs
+++ b/crates/core/tests/quality/review_hash.rs
@@ -51,7 +51,7 @@ fn accept(env: &Env, scope: &Scope, name: &str) {
         .safety_overrides
         .insert(key, mint(&review_hash, &observed.findings, None));
     fs::create_dir_all(manifest_path.parent().unwrap()).unwrap();
-    manifest::save(&manifest_path, &manifest).unwrap();
+    super::fixture::save_manifest(&manifest_path, &manifest);
     assert_eq!(
         row(env, scope, name).override_state,
         OverrideState::Active,
@@ -198,7 +198,7 @@ fn a_decision_with_nothing_to_read_stops_applying() {
         mint(&observed.content_hash, &observed.findings, None),
     );
     fs::create_dir_all(manifest_path.parent().unwrap()).unwrap();
-    manifest::save(&manifest_path, &manifest).unwrap();
+    super::fixture::save_manifest(&manifest_path, &manifest);
 
     assert_stale(&f.env, &f.scope, "ghost@mkt");
 }

--- a/crates/core/tests/review_fixes/roots.rs
+++ b/crates/core/tests/review_fixes/roots.rs
@@ -13,11 +13,13 @@ use super::{put, world};
 fn a_relocated_tool_folder_is_still_scanned_for_unmanaged_items() {
     let w = world();
     let elsewhere = w.home.join("elsewhere/claude");
-    let mut settings = kendex_core::settings::load(&w.env).unwrap();
-    settings
-        .harness_roots
-        .insert("claude".into(), elsewhere.clone());
-    kendex_core::settings::save(&w.env, &settings).unwrap();
+    kendex_core::settings::mutate(&w.env, |settings| {
+        settings
+            .harness_roots
+            .insert("claude".into(), elsewhere.clone());
+        Ok(())
+    })
+    .unwrap();
 
     put(
         &elsewhere.join("skills/handmade/SKILL.md"),

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -310,8 +310,9 @@ lives in one capability table read by core and UI.
   for an in-flight write.
 - **A whole-file write carries the base of the file its copy came from.**
   Two surfaces hand a person an entire file and write all of it back — the
-  Customize tab's `kendex.toml` and the Settings page's
-  `kendex.settings.toml`. Each read pairs content with a `Base`
+  Customize tab's `kendex.toml` and the Settings page's app `settings.toml`
+  (the machine-local preferences file, not a project's committed
+  `kendex.settings.toml`). Each read pairs content with a `Base`
   (`kendex_core::base`, the hash of the exact bytes read — one derivation,
   never taken from a path apart from its bytes); the write presents it, and
   a file holding different bytes refuses the write as `stale`
@@ -320,11 +321,13 @@ lives in one capability table read by core and UI.
   the field-level change onto a fresh copy once and only then asks. The
   manifest write also binds the base into its plan op's precondition
   (`PlanOptions::manifest_base`), re-checked by the apply under the scope
-  lock just before the bytes go down. Targeted settings writes
-  (`save_zoom`, project registration, update mutes) go through
-  `settings::mutate` — load, change, save under one process-wide write
-  lock — so a stale copy cannot reach them, and no public path writes the
-  settings file without one of the two.
+  lock just before the bytes go down. Every settings write — the
+  whole-file `replace` and the targeted `settings::mutate` behind
+  `save_zoom`, project registration, and update mutes — runs under one OS
+  file lock beside the settings file, shared by the app's threads and the
+  CLI's separate process alike, so no two writers interleave and the base
+  check and its write cannot be split. No public path writes the settings
+  file outside those two doors.
 - **Every atomic write gets its own temp file.** `write_then_rename` names
   its temp file per write, not per process.
 - GUI + CLI are equal thin shells over `crates/core`; every core operation

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -302,32 +302,21 @@ lives in one capability table read by core and UI.
   the window has taken (on the window's reply), what the settings object
   holds (when the file does); the first two stay out of the settings
   object. The size reaches the file through its own command carrying only
-  a percent; a whole-settings copy read before a resize fails its base
-  check rather than carrying the older size back. At most one
+  a percent; a copy read before a resize is refused as stale. At most one
   save in flight; asks during it collapse into one follow-up writing
   whatever is on screen. A write waits for the resize before reading what
   to write; a size the file refuses stays on screen. The close is not held
   for an in-flight write.
 - **A whole-file write carries the base of the file its copy came from.**
-  Two surfaces hand a person an entire file and write all of it back — the
-  Customize tab's `kendex.toml` and the Settings page's app `settings.toml`
-  (the machine-local preferences file, not a project's committed
-  `kendex.settings.toml`). Each read pairs content with a `Base`
-  (`kendex_core::base`, the hash of the exact bytes read — one derivation,
-  never taken from a path apart from its bytes); the write presents it, and
-  a file holding different bytes refuses the write as `stale`
-  (`WriteRefused`, one shape for every such surface), which the page
-  renders as a choice: the editor offers Reload, the settings store carries
-  the field-level change onto a fresh copy once and only then asks. The
-  manifest write also binds the base into its plan op's precondition
-  (`PlanOptions::manifest_base`), re-checked by the apply under the scope
-  lock just before the bytes go down. Every settings write — the
-  whole-file `replace` and the targeted `settings::mutate` behind
-  `save_zoom`, project registration, and update mutes — runs under one OS
-  file lock beside the settings file, shared by the app's threads and the
-  CLI's separate process alike, so no two writers interleave and the base
-  check and its write cannot be split. No public path writes the settings
-  file outside those two doors.
+  The Customize tab's `kendex.toml` and the Settings page's app
+  `settings.toml` are read as content plus a `Base` (`kendex_core::base`,
+  the hash of the bytes read) and written back with it; different bytes on
+  disk refuse the write as `stale` (`WriteRefused`), which the page renders
+  as a choice, never a silent overwrite. The manifest write binds the base
+  into its plan op's precondition (`PlanOptions::manifest_base`); every
+  settings write, whole-file or targeted, runs under one OS file lock
+  shared by the app's threads and the CLI, so the check and the write
+  cannot be split.
 - **Every atomic write gets its own temp file.** `write_then_rename` names
   its temp file per write, not per process.
 - GUI + CLI are equal thin shells over `crates/core`; every core operation

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -302,11 +302,29 @@ lives in one capability table read by core and UI.
   the window has taken (on the window's reply), what the settings object
   holds (when the file does); the first two stay out of the settings
   object. The size reaches the file through its own command carrying only
-  a percent; `update_settings` leaves the stored size as found. At most one
+  a percent; a whole-settings copy read before a resize fails its base
+  check rather than carrying the older size back. At most one
   save in flight; asks during it collapse into one follow-up writing
   whatever is on screen. A write waits for the resize before reading what
   to write; a size the file refuses stays on screen. The close is not held
   for an in-flight write.
+- **A whole-file write carries the base of the file its copy came from.**
+  Two surfaces hand a person an entire file and write all of it back — the
+  Customize tab's `kendex.toml` and the Settings page's
+  `kendex.settings.toml`. Each read pairs content with a `Base`
+  (`kendex_core::base`, the hash of the exact bytes read — one derivation,
+  never taken from a path apart from its bytes); the write presents it, and
+  a file holding different bytes refuses the write as `stale`
+  (`WriteRefused`, one shape for every such surface), which the page
+  renders as a choice: the editor offers Reload, the settings store carries
+  the field-level change onto a fresh copy once and only then asks. The
+  manifest write also binds the base into its plan op's precondition
+  (`PlanOptions::manifest_base`), re-checked by the apply under the scope
+  lock just before the bytes go down. Targeted settings writes
+  (`save_zoom`, project registration, update mutes) go through
+  `settings::mutate` — load, change, save under one process-wide write
+  lock — so a stale copy cannot reach them, and no public path writes the
+  settings file without one of the two.
 - **Every atomic write gets its own temp file.** `write_then_rename` names
   its temp file per write, not per process.
 - GUI + CLI are equal thin shells over `crates/core`; every core operation

--- a/tools/size-ratchet-baseline.tsv
+++ b/tools/size-ratchet-baseline.tsv
@@ -1,6 +1,6 @@
 .github/workflows/review-gate-writer.yml	652
 crates/core/src/error.rs	429
-docs/ARCHITECTURE.md	901
+docs/ARCHITECTURE.md	911
 hooks/block-repo-copy.sh	511
 pi-extensions/pi-agents-tmux/extensions/subagent/browser.ts	650
 pi-extensions/pi-agents-tmux/extensions/subagent/dashboard.ts	431

--- a/tools/size-ratchet-baseline.tsv
+++ b/tools/size-ratchet-baseline.tsv
@@ -1,4 +1,5 @@
 .github/workflows/review-gate-writer.yml	652
+crates/core/src/error.rs	413
 docs/ARCHITECTURE.md	901
 hooks/block-repo-copy.sh	511
 pi-extensions/pi-agents-tmux/extensions/subagent/browser.ts	650
@@ -130,4 +131,4 @@ skills/worktree/scripts/worktree-session-guard	1197
 skills/worktree/tests/worktree_session_guard.sh	1282
 ui/src/stores/audit.ts	292
 ui/src/stores/marketplaces.ts	327
-ui/src/stores/settings.ts	438
+ui/src/stores/settings.ts	510

--- a/tools/size-ratchet-baseline.tsv
+++ b/tools/size-ratchet-baseline.tsv
@@ -1,5 +1,5 @@
 .github/workflows/review-gate-writer.yml	652
-crates/core/src/error.rs	413
+crates/core/src/error.rs	416
 docs/ARCHITECTURE.md	901
 hooks/block-repo-copy.sh	511
 pi-extensions/pi-agents-tmux/extensions/subagent/browser.ts	650

--- a/tools/size-ratchet-baseline.tsv
+++ b/tools/size-ratchet-baseline.tsv
@@ -1,5 +1,5 @@
 .github/workflows/review-gate-writer.yml	652
-crates/core/src/error.rs	416
+crates/core/src/error.rs	429
 docs/ARCHITECTURE.md	901
 hooks/block-repo-copy.sh	511
 pi-extensions/pi-agents-tmux/extensions/subagent/browser.ts	650
@@ -131,4 +131,4 @@ skills/worktree/scripts/worktree-session-guard	1197
 skills/worktree/tests/worktree_session_guard.sh	1282
 ui/src/stores/audit.ts	292
 ui/src/stores/marketplaces.ts	327
-ui/src/stores/settings.ts	510
+ui/src/stores/settings.ts	549

--- a/ui/src/bindings.ts
+++ b/ui/src/bindings.ts
@@ -7,16 +7,25 @@ import { invoke as __TAURI_INVOKE } from "@tauri-apps/api/core";
 export const commands = {
 	appVersion: () => __TAURI_INVOKE<string>("app_version"),
 	scanMachine: () => typedError<ScanResult, string>(__TAURI_INVOKE("scan_machine")),
-	getSettings: () => typedError<AppSettings, string>(__TAURI_INVOKE("get_settings")),
-	updateSettings: (settings: AppSettings) => typedError<AppSettings, string>(__TAURI_INVOKE("update_settings", { settings })),
+	getSettings: () => typedError<SettingsRead, string>(__TAURI_INVOKE("get_settings")),
+	/**
+	 *  Write the whole settings object back.
+	 * 
+	 *  `base` is what the file was when this copy was read. Every settings
+	 *  action sends the whole object, so a copy read before some other
+	 *  surface wrote the file — a resize, a project registered in another
+	 *  window — would put the older file back over it. A copy of a file that
+	 *  is no longer there is refused, never applied.
+	 */
+	updateSettings: (settings: AppSettings, base: string | null) => typedError<SettingsRead, WriteRefused>(__TAURI_INVOKE("update_settings", { settings, base })),
 	/**
 	 *  The size on screen, written on its own. Nothing else in the file moves
 	 *  with it, and nothing else can move it: a size the person is looking at
 	 *  survives whatever else is being saved at the same moment.
 	 */
 	saveZoom: (percent: number) => typedError<number, string>(__TAURI_INVOKE("save_zoom", { percent })),
-	registerProject: (path: string) => typedError<AppSettings, string>(__TAURI_INVOKE("register_project", { path })),
-	unregisterProject: (path: string) => typedError<AppSettings, string>(__TAURI_INVOKE("unregister_project", { path })),
+	registerProject: (path: string) => typedError<SettingsRead, string>(__TAURI_INVOKE("register_project", { path })),
+	unregisterProject: (path: string) => typedError<SettingsRead, string>(__TAURI_INVOKE("unregister_project", { path })),
 	/**
 	 *  Install the session-start drift report hook for a scope: script into the
 	 *  scope's local source, declaration into its manifest, then the ordinary
@@ -63,69 +72,16 @@ export const commands = {
 	 */
 	revokeDismissal: (scope: Scope, key: string, fingerprint: string, dismissedAt: string) => typedError<AuditView_Serialize, string>(__TAURI_INVOKE("revoke_dismissal", { scope, key, fingerprint, dismissedAt })),
 	revokeSafetyOverride: (scope: Scope, key: string) => typedError<AuditView_Serialize, string>(__TAURI_INVOKE("revoke_safety_override", { scope, key })),
-	getManifest: (scope: Scope) => typedError<{
-	schema: number,
-	sources?: { [key in string]: SourceDecl_Serialize },
-	install: InstallDefaults,
-	agents?: { [key in string]: ItemDecl_Serialize },
-	skills?: { [key in string]: ItemDecl_Serialize },
-	hooks?: { [key in string]: ItemDecl_Serialize },
-	commands?: { [key in string]: ItemDecl_Serialize },
-	"mcp-servers"?: { [key in string]: ItemDecl_Serialize },
+	getManifest: (scope: Scope) => typedError<ManifestRead_Serialize, string>(__TAURI_INVOKE("get_manifest", { scope })),
 	/**
-	 *  Plugins are observe + enable/disable only; the key is
-	 *  `name@marketplace`, provenance lives in the lock.
+	 *  Write an edited manifest and reconcile the scope to it.
+	 * 
+	 *  `base` is what the file was when this copy was read. A whole manifest
+	 *  goes back with every save, so a copy read before something else wrote
+	 *  the file would put that back — and the caller cannot be relied on to
+	 *  notice. Refusing here needs no caller to remember anything.
 	 */
-	plugins?: { [key in string]: PluginDecl },
-	/**
-	 *  Installed bundles: a curated set the catalog offers under one name.
-	 *  What the set holds is the catalog's to say and derives on every plan;
-	 *  this records only that the set is installed, and how its members
-	 *  install — the same choices any declaration makes.
-	 */
-	bundles?: { [key in string]: ItemDecl_Serialize },
-	"pi-extensions"?: { [key in string]: ItemDecl_Serialize },
-	/**
-	 *  Items the user removed and wants kept removed, by kind: a dependency
-	 *  another item requires, or a member of an installed bundle. A refresh
-	 *  honors these instead of re-deriving what was taken away, and the item
-	 *  that wanted them says so in the audit.
-	 */
-	suppressed?: Partial<{ [key in ItemKind]: string[] }>,
-	/**
-	 *  Optional dependencies taken at install time, per item that offers
-	 *  them. A choice, so it belongs here and survives refresh, cache loss,
-	 *  and other machines; what those choices pull in does not.
-	 */
-	"optional-dependencies"?: { [key in string]: string[] },
-	/**
-	 *  Reviews of content the safety gate blocked, keyed by installation.
-	 *  Each one binds to the content, the rule set and the findings it was
-	 *  granted against, so it stops applying the moment any of them moves.
-	 */
-	"safety-overrides"?: { [key in string]: SafetyOverride_Serialize },
-	/**
-	 *  Findings judged not to be problems, keyed by installation, one
-	 *  snapshot of the reviewed content per installation with each
-	 *  dismissal beneath it. A dismissal settles a question and never
-	 *  unblocks anything.
-	 */
-	"safety-reviews"?: { [key in string]: SafetyReview_Serialize },
-	"agent-skills"?: { [key in string]: string[] },
-	"agent-launch-instructions"?: { [key in string]: string },
-	"agent-additional-instructions"?: { [key in string]: string },
-	"skill-instructions"?: { [key in string]: string },
-	/**  `[agent-frontmatter.<harness>.<agent>]`. */
-	"agent-frontmatter"?: { [key in string]: { [key in string]: FrontmatterOverrides_Serialize } },
-	"custom-hooks"?: CustomHook_Serialize[],
-	/**
-	 *  Forked items by kind and name — `[forks.skill.<name>]`. The name is
-	 *  the item's installed name, unchanged by forking.
-	 */
-	forks?: Partial<{ [key in ItemKind]: { [key in string]: ForkProvenance_Serialize } }>,
-} | null, string>(__TAURI_INVOKE("get_manifest", { scope })),
-	/**  Write an edited manifest and reconcile the scope to it. */
-	updateManifest: (scope: Scope, manifest: Manifest_Deserialize) => typedError<AuditView_Serialize, string>(__TAURI_INVOKE("update_manifest", { scope, manifest })),
+	updateManifest: (scope: Scope, manifest: Manifest_Deserialize, base: string | null) => typedError<AuditView_Serialize, WriteRefused>(__TAURI_INVOKE("update_manifest", { scope, manifest, base })),
 	editorInventory: (scope: Scope) => typedError<EditorInventory, string>(__TAURI_INVOKE("editor_inventory", { scope })),
 	/**
 	 *  Per-hook, per-harness delivery for the hooks as currently drafted in the
@@ -536,6 +492,20 @@ export type AvailablePackage = {
 	 */
 	collision: string | null,
 };
+
+/**
+ *  The base of one whole-file copy.
+ * 
+ *  There is one way to derive one — [`Base::of`], over the bytes it
+ *  describes — because the failure this exists to prevent is a base paired
+ *  with content nobody read together. A base taken by a read separate from
+ *  the content it answers for describes a different moment: a writer
+ *  landing between the two hands the caller old content under the new
+ *  file's name, and the write that follows is accepted over that writer.
+ *  Nothing here takes a path and hands back a base, deliberately — a path
+ *  is not the bytes, and reading them apart is how the two come adrift.
+ */
+export type Base = string | null;
 
 /**
  *  A curated set with per-member state. Partly-installed is the derived
@@ -1655,6 +1625,43 @@ export type LoginStart = {
 
 export type Manifest = Manifest_Serialize | Manifest_Deserialize;
 
+/**
+ *  A place's manifest and what the file it came from was at that moment.
+ *  One value, because a copy without its base cannot be written back
+ *  safely, and the two read apart could describe different files.
+ */
+export type ManifestRead = ManifestRead_Serialize | ManifestRead_Deserialize;
+
+/**
+ *  A place's manifest and what the file it came from was at that moment.
+ *  One value, because a copy without its base cannot be written back
+ *  safely, and the two read apart could describe different files.
+ */
+export type ManifestRead_Deserialize = {
+	/**
+	 *  Absent where the place has no manifest yet — the editor still
+	 *  opens, on an empty one.
+	 */
+	manifest: Manifest_Deserialize | null,
+	/**  The file these bytes came from, read with them and never apart. */
+	base: Base,
+};
+
+/**
+ *  A place's manifest and what the file it came from was at that moment.
+ *  One value, because a copy without its base cannot be written back
+ *  safely, and the two read apart could describe different files.
+ */
+export type ManifestRead_Serialize = {
+	/**
+	 *  Absent where the place has no manifest yet — the editor still
+	 *  opens, on an empty one.
+	 */
+	manifest: Manifest_Serialize | null,
+	/**  The file these bytes came from, read with them and never apart. */
+	base: Base,
+};
+
 export type Manifest_Deserialize = {
 	schema: number,
 	sources?: { [key in string]: SourceDecl_Deserialize },
@@ -2311,6 +2318,17 @@ export type ScopeErrorKind =
 /**  The manifest parses but fails validation. */
 "manifest-invalid" | "other";
 
+/**
+ *  The settings and the base of the exact file they describe — paired by
+ *  one read, or handed back by the write that produced the file. One
+ *  value, because a copy without its base cannot be written back safely,
+ *  and the two obtained apart could describe different files.
+ */
+export type SettingsRead = {
+	settings: AppSettings,
+	base: Base,
+};
+
 export type Severity = "low" | "medium" | "high" | "critical";
 
 export type SkillsShHit = {
@@ -2627,6 +2645,19 @@ export type VersionSel =
 { at: "commit"; commit: string } | 
 /**  What is installed on disk right now. */
 { at: "installed" };
+
+/**
+ *  Why a whole-file write did not happen. Refusing is a normal answer
+ *  here, not a failure, so it is a shape the page can act on rather than
+ *  a message it would have to recognise by its words.
+ */
+export type WriteRefused = 
+/**
+ *  The file is no longer the one this copy was read from. Something
+ *  else wrote it — a fork, a hold, a dismissal, an install, another
+ *  window — and writing this copy would put that back.
+ */
+{ kind: "stale" } | { kind: "failed"; message: string };
 
 export type ZoomState = {
 	/**

--- a/ui/src/components/customize/item-customize.tsx
+++ b/ui/src/components/customize/item-customize.tsx
@@ -2,6 +2,7 @@ import type { HarnessId, ItemKind, Scope } from "@/bindings";
 import { InstructionBox } from "@/components/customize/instruction-box";
 import { ItemSettings } from "@/components/customize/item-settings";
 import { ItemSkills } from "@/components/customize/item-skills";
+import { StaleNote } from "@/components/customize/stale-note";
 import { Pill } from "@/components/pill";
 import { Section } from "@/components/section";
 import { StatusNote } from "@/components/status-note";
@@ -38,7 +39,7 @@ export function ItemCustomize({
   scopes: Scope[];
   harnesses: HarnessId[];
 }) {
-  const { scope, draft, inventory, dirty, error, setScope, edit } =
+  const { scope, draft, inventory, dirty, error, stale, setScope, load, edit } =
     useEditorStore();
 
   const mine = itemCustomization(draft, kind, name);
@@ -49,6 +50,7 @@ export function ItemCustomize({
 
   return (
     <div className="flex flex-col gap-8 pt-2">
+      {stale ? <StaleNote onReload={() => void load()} /> : null}
       {error ? (
         <StatusNote tone="critical" title="That change couldn't be saved">
           <span className="whitespace-pre-wrap">{error}</span>

--- a/ui/src/components/customize/stale-note.tsx
+++ b/ui/src/components/customize/stale-note.tsx
@@ -1,0 +1,25 @@
+import { StatusNote } from "@/components/status-note";
+import { Button } from "@/components/ui/button";
+
+/** The refusal a stale draft gets, rendered as the choice out of it. The
+ *  manifest changed outside this draft — saving the draft would put the
+ *  older file back over whatever wrote it — so the one way forward is the
+ *  re-read, and taking it discards the edits held here. That cost is the
+ *  person's to accept, which is why this is a button and not automatic. */
+export function StaleNote({ onReload }: { onReload: () => void }) {
+  return (
+    <StatusNote
+      tone="warning"
+      title="This file changed while you were editing"
+      action={
+        <Button size="sm" variant="outline" onClick={onReload}>
+          Reload
+        </Button>
+      }
+    >
+      Something else saved kendex.toml — another window, an install, an update.
+      Saving this copy would undo that, so it wasn't saved. Reload picks up
+      those changes and discards your unsaved edits here.
+    </StatusNote>
+  );
+}

--- a/ui/src/pages/customize.tsx
+++ b/ui/src/pages/customize.tsx
@@ -3,6 +3,7 @@ import { CustomHooks } from "@/components/customize/custom-hooks";
 import { CustomizedIndex } from "@/components/customize/customized-index";
 import { SaveBar } from "@/components/customize/save-bar";
 import { SharedInstructions } from "@/components/customize/shared-instructions";
+import { StaleNote } from "@/components/customize/stale-note";
 import { DotSpinner } from "@/components/loading";
 import { PageHeader } from "@/components/page-header";
 import { Section } from "@/components/section";
@@ -45,6 +46,7 @@ export function CustomizePage() {
     loading,
     saving,
     error,
+    stale,
     setScope,
     load,
     edit,
@@ -98,6 +100,7 @@ export function CustomizePage() {
       />
       <div className={cn("flex-1", PAGE_BODY)}>
         <div className={cn("flex flex-col gap-10", CONTENT_WIDTH)}>
+          {stale ? <StaleNote onReload={() => void load()} /> : null}
           {error ? (
             <StatusNote tone="critical" title="That change couldn't be saved">
               <span className="whitespace-pre-wrap">{error}</span>

--- a/ui/src/stores/editor.test.ts
+++ b/ui/src/stores/editor.test.ts
@@ -1,0 +1,116 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { AuditView_Serialize, EditorInventory } from "@/bindings";
+import { commands } from "@/bindings";
+import { emptyDraft } from "@/lib/editor-draft";
+import { useEditorStore } from "./editor";
+
+vi.mock("@/bindings", () => ({
+  commands: {
+    getManifest: vi.fn(),
+    editorInventory: vi.fn(),
+    updateManifest: vi.fn(),
+  },
+}));
+
+vi.mock("./audit", () => ({
+  useAuditStore: { getState: () => ({ refresh: vi.fn() }) },
+}));
+vi.mock("./scan", () => ({
+  useScanStore: { getState: () => ({ refresh: vi.fn() }) },
+}));
+vi.mock("./settings", () => ({
+  useSettingsStore: { getState: () => ({ settings: null, load: vi.fn() }) },
+}));
+
+const inventory = () => ({
+  status: "ok" as const,
+  data: {} as EditorInventory,
+});
+
+describe("editor store", () => {
+  beforeEach(() => {
+    useEditorStore.setState({
+      scope: { scope: "global" },
+      draft: null,
+      base: null,
+      inventory: null,
+      saved: {},
+      dirty: false,
+      loading: false,
+      saving: false,
+      error: null,
+      stale: false,
+    });
+    vi.clearAllMocks();
+    vi.mocked(commands.editorInventory).mockResolvedValue(inventory());
+  });
+
+  /// The base is what makes an existing manifest saveable at all: read
+  /// with the copy, presented with the save. Sent null, every save of an
+  /// existing file would be refused as a copy that predates it.
+  it("holds the base it read and presents it with the save", async () => {
+    vi.mocked(commands.getManifest).mockResolvedValue({
+      status: "ok",
+      data: { manifest: null, base: "b1" },
+    });
+    await useEditorStore.getState().load();
+    expect(useEditorStore.getState().base).toBe("b1");
+
+    vi.mocked(commands.updateManifest).mockResolvedValue({
+      status: "ok",
+      data: {} as AuditView_Serialize,
+    });
+    await useEditorStore.getState().save();
+    expect(commands.updateManifest).toHaveBeenCalledWith(
+      { scope: "global" },
+      emptyDraft(),
+      "b1",
+    );
+  });
+
+  /// A stale refusal is a choice, not a failure: it must reach the page
+  /// as the reload offer, never as a raw error — and a real failure must
+  /// stay an error, never the reload offer.
+  it("renders a stale refusal as the reload choice and a failure as an error", async () => {
+    useEditorStore.setState({ draft: emptyDraft(), base: "b1" });
+    vi.mocked(commands.updateManifest).mockResolvedValue({
+      status: "error",
+      error: { kind: "stale" },
+    });
+    await useEditorStore.getState().save();
+    expect(useEditorStore.getState().stale).toBe(true);
+    expect(useEditorStore.getState().error).toBeNull();
+
+    vi.mocked(commands.updateManifest).mockResolvedValue({
+      status: "error",
+      error: { kind: "failed", message: "disk is full" },
+    });
+    await useEditorStore.getState().save();
+    expect(useEditorStore.getState().stale).toBe(false);
+    expect(useEditorStore.getState().error).toBe("disk is full");
+  });
+
+  /// The reload is the way out of a stale refusal: it replaces the copy
+  /// and its base together and clears the refusal, so the next save
+  /// presents the base of the file it will actually be compared against.
+  it("reload after a stale refusal takes the fresh copy and clears the refusal", async () => {
+    useEditorStore.setState({
+      draft: { schema: 1, "skill-instructions": { all: "unsaved edit" } },
+      base: "b1",
+      dirty: true,
+      stale: true,
+    });
+    vi.mocked(commands.getManifest).mockResolvedValue({
+      status: "ok",
+      data: { manifest: null, base: "b2" },
+    });
+
+    await useEditorStore.getState().load();
+
+    const state = useEditorStore.getState();
+    expect(state.stale).toBe(false);
+    expect(state.base).toBe("b2");
+    expect(state.draft).toEqual(emptyDraft());
+    expect(state.dirty).toBe(false);
+  });
+});

--- a/ui/src/stores/editor.ts
+++ b/ui/src/stores/editor.ts
@@ -10,6 +10,10 @@ interface EditorState {
   /** The single scope being edited — deliberately not the sidebar filter. */
   scope: Scope;
   draft: Draft | null;
+  /** What the manifest file was when `draft` was read from it — sent back
+   *  with every save, so a copy of a file something else has since written
+   *  is refused instead of putting the older file back. */
+  base: string | null;
   inventory: EditorInventory | null;
   /** Every scope's saved manifest, keyed by scope. What the Library and the
    *  Customize index read to mark what has been customized; `draft` above is
@@ -19,6 +23,9 @@ interface EditorState {
   loading: boolean;
   saving: boolean;
   error: string | null;
+  /** The save was refused because the file changed outside this draft.
+   *  The way out is the reload the page offers, not a retry. */
+  stale: boolean;
   setScope: (scope: Scope) => Promise<void>;
   /** Point the editor at a scope without discarding edits already in hand. */
   openScope: (scope: Scope) => Promise<void>;
@@ -44,36 +51,54 @@ export const useEditorStore = create<EditorState>((set, get) => {
       set({ loading: false });
     }
     if (manifest.status === "error") {
-      set({ draft: null, dirty: false, error: manifest.error });
+      set({
+        draft: null,
+        base: null,
+        dirty: false,
+        stale: false,
+        error: manifest.error,
+      });
       return;
     }
     // With no manifest here yet the editor still opens, on an empty one:
     // asking someone to press "create" before they can type is a step that
     // decides nothing. Saving is what writes the file.
-    const draft = manifest.data ? toDraft(manifest.data) : emptyDraft();
+    const draft = manifest.data.manifest
+      ? toDraft(manifest.data.manifest)
+      : emptyDraft();
     set((state) => ({
       draft,
+      base: manifest.data.base,
       inventory: inventory.status === "ok" ? inventory.data : state.inventory,
       saved: { ...state.saved, [scopeKey(scope)]: draft },
       dirty: false,
+      stale: false,
       error: inventory.status === "ok" ? null : inventory.error,
     }));
   };
 
   const write = async (draft: Draft) => {
-    const { scope } = get();
+    const { scope, base } = get();
     set({ saving: true });
     let response: Awaited<ReturnType<typeof commands.updateManifest>>;
     try {
-      response = await commands.updateManifest(scope, draft);
+      response = await commands.updateManifest(scope, draft, base);
     } finally {
       set({ saving: false });
     }
     if (response.status === "error") {
-      set({ error: response.error });
+      // Stale is a refusal, not a failure: the file changed outside this
+      // draft, and writing the draft would put the older file back. The
+      // draft cannot be merged, so the page offers the reload as a choice
+      // rather than taking the person's edits on its own.
+      if (response.error.kind === "stale") {
+        set({ stale: true, error: null });
+      } else {
+        set({ error: response.error.message, stale: false });
+      }
       return;
     }
-    set({ error: null });
+    set({ error: null, stale: false });
     await load();
     await useAuditStore.getState().refresh();
     await useScanStore.getState().refresh();
@@ -82,15 +107,24 @@ export const useEditorStore = create<EditorState>((set, get) => {
   return {
     scope: { scope: "global" },
     draft: null,
+    base: null,
     inventory: null,
     saved: {},
     dirty: false,
     loading: false,
     saving: false,
     error: null,
+    stale: false,
 
     setScope: async (scope) => {
-      set({ scope, draft: null, dirty: false, error: null });
+      set({
+        scope,
+        draft: null,
+        base: null,
+        dirty: false,
+        error: null,
+        stale: false,
+      });
       await load();
     },
 
@@ -118,8 +152,8 @@ export const useEditorStore = create<EditorState>((set, get) => {
       const saved: Record<string, Draft> = {};
       for (const [index, response] of loaded.entries()) {
         if (response.status !== "ok") continue;
-        saved[scopeKey(scopes[index])] = response.data
-          ? toDraft(response.data)
+        saved[scopeKey(scopes[index])] = response.data.manifest
+          ? toDraft(response.data.manifest)
           : emptyDraft();
       }
       set({ saved });

--- a/ui/src/stores/settings-zoom-save.test.ts
+++ b/ui/src/stores/settings-zoom-save.test.ts
@@ -165,7 +165,12 @@ describe("zoom, on disk", () => {
     // person zooms.
     const themed = useSettingsStore.getState().setAppearance("dark");
     await useSettingsStore.getState().setZoom(150);
-    theme.settle(ok({ ...settings, appearance: "dark", zoom: 100 }));
+    theme.settle(
+      ok({
+        settings: { ...settings, appearance: "dark", zoom: 100 },
+        base: "b2",
+      }),
+    );
     await themed;
 
     expect(stored()).toBe(100);

--- a/ui/src/stores/settings-zoom.test.ts
+++ b/ui/src/stores/settings-zoom.test.ts
@@ -54,7 +54,7 @@ describe("zoom, on screen", () => {
   it("reads the size a launch that could not zoom actually opened at", async () => {
     useSettingsStore.setState({ settings: null, tookZoom: null });
     vi.mocked(commands.getSettings).mockResolvedValue(
-      ok({ ...settings, zoom: 150 }),
+      ok({ settings: { ...settings, zoom: 150 }, base: "file" }),
     );
     vi.mocked(commands.capabilityTable).mockResolvedValue([]);
     vi.mocked(commands.windowZoomState).mockResolvedValue({
@@ -96,7 +96,7 @@ describe("zoom, on screen", () => {
       tookZoom: null,
     });
     vi.mocked(commands.getSettings).mockResolvedValue(
-      ok({ ...settings, zoom: 150 }),
+      ok({ settings: { ...settings, zoom: 150 }, base: "file" }),
     );
     vi.mocked(commands.capabilityTable).mockResolvedValue([]);
 

--- a/ui/src/stores/settings.test.ts
+++ b/ui/src/stores/settings.test.ts
@@ -152,17 +152,26 @@ describe("settings store", () => {
   });
 
   /// Contention that survives the re-read reaches the person as a message,
-  /// not as a silent loop — and never as a write of the stale copy.
-  it("stops after one retry and tells the person when the file keeps moving", async () => {
+  /// not as a silent loop — and never as a write of the stale copy. The
+  /// claim that the latest settings are shown is earned by one final
+  /// read-only refresh, because the second refusal proved the previous
+  /// re-read is already behind the file.
+  it("stops after one retry, refreshes read-only, and tells the person when the file keeps moving", async () => {
     useSettingsStore.setState({ settings, base: "old" });
+    const moved = { ...settings, zoom: 150 };
     vi.mocked(commands.updateSettings).mockResolvedValue({
       status: "error",
       error: { kind: "stale" },
     });
-    vi.mocked(commands.getSettings).mockResolvedValue({
-      status: "ok",
-      data: { settings, base: "fresh" },
-    });
+    vi.mocked(commands.getSettings)
+      .mockResolvedValueOnce({
+        status: "ok",
+        data: { settings, base: "fresh" },
+      })
+      .mockResolvedValueOnce({
+        status: "ok",
+        data: { settings: moved, base: "moved" },
+      });
 
     await useSettingsStore.getState().setAppearance("dark");
 
@@ -170,6 +179,37 @@ describe("settings store", () => {
     const dialog = useProblemsStore.getState().dialog;
     expect(dialog.open).toBe(true);
     expect(dialog.title).toBe("Couldn't change the appearance");
+    expect(dialog.message).toContain("the latest settings are shown now");
+    // The store holds what the final refresh read, not the copy the second
+    // write was refused over — that is what makes the claim true.
+    expect(useSettingsStore.getState().settings).toEqual(moved);
+    expect(useSettingsStore.getState().base).toBe("moved");
+  });
+
+  /// When the final refresh cannot be read, the message stops claiming the
+  /// displayed settings are current — a claim nothing verified.
+  it("drops the currency claim when the final refresh fails after a second stale refusal", async () => {
+    useSettingsStore.setState({ settings, base: "old" });
+    vi.mocked(commands.updateSettings).mockResolvedValue({
+      status: "error",
+      error: { kind: "stale" },
+    });
+    vi.mocked(commands.getSettings)
+      .mockResolvedValueOnce({
+        status: "ok",
+        data: { settings, base: "fresh" },
+      })
+      .mockResolvedValueOnce({
+        status: "error",
+        error: "cannot read the settings file",
+      });
+
+    await useSettingsStore.getState().setAppearance("dark");
+
+    const dialog = useProblemsStore.getState().dialog;
+    expect(dialog.open).toBe(true);
+    expect(dialog.message).not.toContain("shown now");
+    expect(dialog.message).toContain("cannot read the settings file");
   });
 
   it("toasts success naming the folder when a project is added, and resolves true", async () => {

--- a/ui/src/stores/settings.test.ts
+++ b/ui/src/stores/settings.test.ts
@@ -124,6 +124,33 @@ describe("settings store", () => {
     expect(useSettingsStore.getState().base).toBe("written");
   });
 
+  /// The re-read is the way out of a stale refusal; when it fails, the
+  /// dialog names the failed read — not contention, which would claim a
+  /// refresh that never happened and invite retries of a path that
+  /// cannot progress.
+  it("names the failed re-read when stale recovery cannot read the settings", async () => {
+    useSettingsStore.setState({ settings, base: "old" });
+    vi.mocked(commands.updateSettings).mockResolvedValue({
+      status: "error",
+      error: { kind: "stale" },
+    });
+    vi.mocked(commands.getSettings).mockResolvedValue({
+      status: "error",
+      error: "cannot read the settings file",
+    });
+
+    await useSettingsStore.getState().setAppearance("dark");
+
+    expect(commands.updateSettings).toHaveBeenCalledTimes(1);
+    const dialog = useProblemsStore.getState().dialog;
+    expect(dialog.open).toBe(true);
+    expect(dialog.message).toContain("cannot read the settings file");
+    expect(dialog.message).not.toContain("another window");
+    // The store still holds the copy it had — nothing pretended to refresh.
+    expect(useSettingsStore.getState().settings).toBe(settings);
+    expect(useSettingsStore.getState().base).toBe("old");
+  });
+
   /// Contention that survives the re-read reaches the person as a message,
   /// not as a silent loop — and never as a write of the stale copy.
   it("stops after one retry and tells the person when the file keeps moving", async () => {

--- a/ui/src/stores/settings.test.ts
+++ b/ui/src/stores/settings.test.ts
@@ -212,6 +212,38 @@ describe("settings store", () => {
     expect(dialog.message).toContain("cannot read the settings file");
   });
 
+  /// The backend serializes the writes, but replies arrive in any order:
+  /// a whole-file save resolving after a later project registration must
+  /// not put its older settings/base pair back over the newer one.
+  it("drops a reply that arrives after a newer one was held", async () => {
+    useSettingsStore.setState({ settings, base: "b0" });
+    let resolveUpdate: (value: {
+      status: "ok";
+      data: { settings: AppSettings; base: string };
+    }) => void = () => {};
+    vi.mocked(commands.updateSettings).mockReturnValue(
+      new Promise((resolve) => {
+        resolveUpdate = resolve;
+      }),
+    );
+    const registered = { ...settings, projects: ["/home/x/acme-web"] };
+    vi.mocked(commands.registerProject).mockResolvedValue({
+      status: "ok",
+      data: { settings: registered, base: "b2" },
+    });
+
+    const older = useSettingsStore.getState().setAppearance("dark");
+    await useSettingsStore.getState().registerProject("/home/x/acme-web");
+    resolveUpdate({
+      status: "ok",
+      data: { settings: { ...settings, appearance: "dark" }, base: "b1" },
+    });
+    await older;
+
+    expect(useSettingsStore.getState().base).toBe("b2");
+    expect(useSettingsStore.getState().settings).toEqual(registered);
+  });
+
   it("toasts success naming the folder when a project is added, and resolves true", async () => {
     vi.mocked(commands.registerProject).mockResolvedValue({
       status: "ok",

--- a/ui/src/stores/settings.test.ts
+++ b/ui/src/stores/settings.test.ts
@@ -37,7 +37,7 @@ const settings: AppSettings = {
 
 describe("settings store", () => {
   beforeEach(() => {
-    useSettingsStore.setState({ settings: null, capabilities: [] });
+    useSettingsStore.setState({ settings: null, base: null, capabilities: [] });
     useScanStore.setState({
       result: null,
       scanning: false,
@@ -63,7 +63,7 @@ describe("settings store", () => {
     useSettingsStore.setState({ settings });
     vi.mocked(commands.updateSettings).mockResolvedValue({
       status: "error",
-      error: "disk is full",
+      error: { kind: "failed", message: "disk is full" },
     });
 
     await useSettingsStore.getState().setAppearance("dark");
@@ -80,7 +80,7 @@ describe("settings store", () => {
     useSettingsStore.setState({ settings });
     vi.mocked(commands.updateSettings).mockResolvedValue({
       status: "ok",
-      data: updated,
+      data: { settings: updated, base: "b1" },
     });
 
     await useSettingsStore.getState().setAppearance("dark");
@@ -90,10 +90,68 @@ describe("settings store", () => {
     expect(useSettingsStore.getState().settings).toEqual(updated);
   });
 
+  /// The refusal that closes the class: a copy read before something else
+  /// wrote the file is never applied. The change is a field-level intent,
+  /// so it is carried onto a freshly read copy and written again — nothing
+  /// the stale copy predated is reverted, and the person sees no error.
+  it("re-reads and re-applies the change when the copy in hand is stale", async () => {
+    useSettingsStore.setState({ settings, base: "old" });
+    const onDisk = { ...settings, projects: ["/home/x/acme-web"], zoom: 150 };
+    vi.mocked(commands.updateSettings)
+      .mockResolvedValueOnce({ status: "error", error: { kind: "stale" } })
+      .mockImplementationOnce(async (next) => ({
+        status: "ok",
+        data: { settings: next, base: "written" },
+      }));
+    vi.mocked(commands.getSettings).mockResolvedValue({
+      status: "ok",
+      data: { settings: onDisk, base: "fresh" },
+    });
+
+    await useSettingsStore.getState().setAppearance("dark");
+
+    // The second write carried the fresh copy — project and zoom kept —
+    // with only the intended field changed, under the fresh base.
+    expect(commands.updateSettings).toHaveBeenLastCalledWith(
+      { ...onDisk, appearance: "dark" },
+      "fresh",
+    );
+    expect(useProblemsStore.getState().dialog.open).toBe(false);
+    expect(useSettingsStore.getState().settings).toEqual({
+      ...onDisk,
+      appearance: "dark",
+    });
+    expect(useSettingsStore.getState().base).toBe("written");
+  });
+
+  /// Contention that survives the re-read reaches the person as a message,
+  /// not as a silent loop — and never as a write of the stale copy.
+  it("stops after one retry and tells the person when the file keeps moving", async () => {
+    useSettingsStore.setState({ settings, base: "old" });
+    vi.mocked(commands.updateSettings).mockResolvedValue({
+      status: "error",
+      error: { kind: "stale" },
+    });
+    vi.mocked(commands.getSettings).mockResolvedValue({
+      status: "ok",
+      data: { settings, base: "fresh" },
+    });
+
+    await useSettingsStore.getState().setAppearance("dark");
+
+    expect(commands.updateSettings).toHaveBeenCalledTimes(2);
+    const dialog = useProblemsStore.getState().dialog;
+    expect(dialog.open).toBe(true);
+    expect(dialog.title).toBe("Couldn't change the appearance");
+  });
+
   it("toasts success naming the folder when a project is added, and resolves true", async () => {
     vi.mocked(commands.registerProject).mockResolvedValue({
       status: "ok",
-      data: { ...settings, projects: ["/home/x/acme-web"] },
+      data: {
+        settings: { ...settings, projects: ["/home/x/acme-web"] },
+        base: "b1",
+      },
     });
 
     const ok = await useSettingsStore

--- a/ui/src/stores/settings.ts
+++ b/ui/src/stores/settings.ts
@@ -368,17 +368,27 @@ export const useSettingsStore = create<SettingsState>((set, get) => {
     change: (current: AppSettings) => AppSettings,
   ): Promise<WriteOutcome> => {
     const { settings, base } = get();
-    if (!settings) return { ok: true };
+    // A write with no copy in hand never happened; reporting it saved
+    // would teach a caller to trust a change that was dropped.
+    if (!settings)
+      return { ok: false, message: "Your settings haven't loaded yet." };
     let response = await commands.updateSettings(change(settings), base);
     if (response.status === "error" && response.error.kind === "stale") {
       const fresh = await commands.getSettings();
-      if (fresh.status === "ok") {
-        hold(fresh.data);
-        response = await commands.updateSettings(
-          change(fresh.data.settings),
-          fresh.data.base,
-        );
-      }
+      // The re-read is the way out of a stale refusal. Failing, the fault
+      // to name is the read itself — the contention wording would send
+      // the person retrying a path that cannot progress, and would claim
+      // a refresh that never happened.
+      if (fresh.status === "error")
+        return {
+          ok: false,
+          message: `Couldn't re-read your settings to retry: ${fresh.error}`,
+        };
+      hold(fresh.data);
+      response = await commands.updateSettings(
+        change(fresh.data.settings),
+        fresh.data.base,
+      );
     }
     if (response.status === "ok") {
       hold(response.data);

--- a/ui/src/stores/settings.ts
+++ b/ui/src/stores/settings.ts
@@ -224,7 +224,6 @@ function zoomActions(
 
 interface ProjectFields {
   settings: AppSettings | null;
-  base: string | null;
 }
 
 interface ProjectsSlice {
@@ -236,14 +235,16 @@ interface ProjectsSlice {
 /** The project registry's actions. Registration and removal are targeted
  *  server-side writes, so they carry no base — but each reply is a written
  *  settings-plus-base pair, and holding it keeps the store's copy current
- *  for the next whole-file save. */
+ *  for the next whole-file save. The hold comes from the store so every
+ *  settings-holding reply shares one ticket order: a reply older than the
+ *  newest one held is dropped, wherever it came from. */
 function projectActions(
-  set: (fields: Partial<ProjectFields>) => void,
   get: () => ProjectFields,
+  ordered: {
+    ticket: () => number;
+    hold: (read: SettingsRead, at: number) => void;
+  },
 ): ProjectsSlice {
-  const hold = (read: SettingsRead) =>
-    set({ settings: read.settings, base: read.base });
-
   const rescan = async () => {
     await useScanStore.getState().refresh();
   };
@@ -251,9 +252,10 @@ function projectActions(
   return {
     registerProject: async (path) => {
       const before = get().settings?.projects ?? [];
+      const at = ordered.ticket();
       const response = await commands.registerProject(path);
       if (response.status === "ok") {
-        hold(response.data);
+        ordered.hold(response.data, at);
         // Registration is where the drift report is offered: agents in this
         // project start blind until the session-start hook is installed. An
         // offer, never an auto-install — it injects into agent context.
@@ -302,9 +304,10 @@ function projectActions(
     },
 
     unregisterProject: async (path) => {
+      const at = ordered.ticket();
       const response = await commands.unregisterProject(path);
       if (response.status === "ok") {
-        hold(response.data);
+        ordered.hold(response.data, at);
         await rescan();
       } else {
         useProblemsStore.getState().showError({
@@ -352,11 +355,24 @@ async function rescan() {
 type WriteOutcome = { ok: true } | { ok: false; message: string };
 
 export const useSettingsStore = create<SettingsState>((set, get) => {
+  // The backend serializes the writes; the replies arrive in any order. A
+  // ticket taken as each request leaves orders them again on arrival: a
+  // reply whose ticket predates the newest one held is a view of the file
+  // something newer has already replaced, and holding it would walk the
+  // store backwards until the next reload.
+  let issued = 0;
+  let newest = 0;
+  const ticket = () => ++issued;
+
   /** Keep the copy and its base together — one never moves without the
    *  other, or the next save would present a base for bytes it does not
-   *  hold. */
-  const hold = (read: SettingsRead) =>
+   *  hold. Held only while `at` is the newest ticket seen: an older
+   *  request's late reply is dropped, not applied. */
+  const hold = (read: SettingsRead, at: number) => {
+    if (at < newest) return;
+    newest = at;
     set({ settings: read.settings, base: read.base });
+  };
 
   /** One change, written as the whole file with the base its copy was read
    *  from. A stale refusal means something else wrote the file since the
@@ -372,8 +388,10 @@ export const useSettingsStore = create<SettingsState>((set, get) => {
     // would teach a caller to trust a change that was dropped.
     if (!settings)
       return { ok: false, message: "Your settings haven't loaded yet." };
+    let at = ticket();
     let response = await commands.updateSettings(change(settings), base);
     if (response.status === "error" && response.error.kind === "stale") {
+      const reread = ticket();
       const fresh = await commands.getSettings();
       // The re-read is the way out of a stale refusal. Failing, the fault
       // to name is the read itself — the contention wording would send
@@ -384,14 +402,15 @@ export const useSettingsStore = create<SettingsState>((set, get) => {
           ok: false,
           message: `Couldn't re-read your settings to retry: ${fresh.error}`,
         };
-      hold(fresh.data);
+      hold(fresh.data, reread);
+      at = ticket();
       response = await commands.updateSettings(
         change(fresh.data.settings),
         fresh.data.base,
       );
     }
     if (response.status === "ok") {
-      hold(response.data);
+      hold(response.data, at);
       return { ok: true };
     }
     if (response.error.kind === "failed")
@@ -400,9 +419,10 @@ export const useSettingsStore = create<SettingsState>((set, get) => {
     // so the copy in hand is behind it. One read-only refresh earns the
     // claim that the latest settings are shown; when even that read fails,
     // the claim goes with it.
+    const refresh = ticket();
     const last = await commands.getSettings();
     if (last.status === "ok") {
-      hold(last.data);
+      hold(last.data, refresh);
       return {
         ok: false,
         message:
@@ -420,24 +440,21 @@ export const useSettingsStore = create<SettingsState>((set, get) => {
     base: null,
     capabilities: [],
     ...zoomActions(set, get),
-    ...projectActions(set, get),
+    ...projectActions(get, { ticket, hold }),
 
     load: async () => {
       // The size comes from the window, not from the file: the file holds
       // what the person asked for, and the zoom outlives the page, so a page
       // that has just reloaded is the one least able to work it out itself.
+      const at = ticket();
       const [settings, capabilities, webview] = await Promise.all([
         commands.getSettings(),
         commands.capabilityTable(),
         commands.windowZoomState(),
       ]);
       if (settings.status === "ok") {
-        set({
-          settings: settings.data.settings,
-          base: settings.data.base,
-          capabilities,
-          tookZoom: webview.percent,
-        });
+        hold(settings.data, at);
+        set({ capabilities, tookZoom: webview.percent });
         // The opening had no UI to say this in, so it is said here rather
         // than leaving the person with an app that quietly ignored their
         // size. Both halves are needed: the refusal stands for the whole

--- a/ui/src/stores/settings.ts
+++ b/ui/src/stores/settings.ts
@@ -394,12 +394,24 @@ export const useSettingsStore = create<SettingsState>((set, get) => {
       hold(response.data);
       return { ok: true };
     }
+    if (response.error.kind === "failed")
+      return { ok: false, message: response.error.message };
+    // A second stale refusal means the file moved again after the re-read,
+    // so the copy in hand is behind it. One read-only refresh earns the
+    // claim that the latest settings are shown; when even that read fails,
+    // the claim goes with it.
+    const last = await commands.getSettings();
+    if (last.status === "ok") {
+      hold(last.data);
+      return {
+        ok: false,
+        message:
+          "Your settings changed in another window while this was saving. The change wasn't applied — the latest settings are shown now.",
+      };
+    }
     return {
       ok: false,
-      message:
-        response.error.kind === "failed"
-          ? response.error.message
-          : "Your settings changed in another window while this was saving. The change wasn't applied — the latest settings are shown now.",
+      message: `Your settings changed in another window while this was saving. The change wasn't applied, and re-reading the file failed: ${last.error}`,
     };
   };
 

--- a/ui/src/stores/settings.ts
+++ b/ui/src/stores/settings.ts
@@ -5,6 +5,7 @@ import {
   type AppSettings,
   type CapabilityRow,
   commands,
+  type SettingsRead,
   ZOOM,
 } from "@/bindings";
 import { useProblemsStore } from "./problems";
@@ -221,218 +222,289 @@ function zoomActions(
   return { shownZoom: null, tookZoom: null, onScreen, setZoom, saveZoom };
 }
 
-interface SettingsState extends ZoomSlice {
+interface ProjectFields {
   settings: AppSettings | null;
+  base: string | null;
+}
+
+interface ProjectsSlice {
+  registerProject: (path: string) => Promise<boolean>;
+  unregisterProject: (path: string) => Promise<void>;
+  discoverProjects: (root: string) => Promise<string[]>;
+}
+
+/** The project registry's actions. Registration and removal are targeted
+ *  server-side writes, so they carry no base — but each reply is a written
+ *  settings-plus-base pair, and holding it keeps the store's copy current
+ *  for the next whole-file save. */
+function projectActions(
+  set: (fields: Partial<ProjectFields>) => void,
+  get: () => ProjectFields,
+): ProjectsSlice {
+  const hold = (read: SettingsRead) =>
+    set({ settings: read.settings, base: read.base });
+
+  const rescan = async () => {
+    await useScanStore.getState().refresh();
+  };
+
+  return {
+    registerProject: async (path) => {
+      const before = get().settings?.projects ?? [];
+      const response = await commands.registerProject(path);
+      if (response.status === "ok") {
+        hold(response.data);
+        // Registration is where the drift report is offered: agents in this
+        // project start blind until the session-start hook is installed. An
+        // offer, never an auto-install — it injects into agent context.
+        const root =
+          (response.data.settings.projects ?? []).find(
+            (p) => !before.includes(p),
+          ) ?? path;
+        toast.success(`Added ${path.split("/").pop()}`, {
+          action: {
+            label: "Add session drift report",
+            onClick: () => {
+              void commands
+                .installDriftHook({ scope: "project", root })
+                .then((result) => {
+                  if (result.status === "ok") {
+                    // False: the scope had other pending changes, so only the
+                    // declaration landed — nothing is applied unreviewed.
+                    toast.success(
+                      result.data
+                        ? "Drift report installed"
+                        : "Drift report added — finish by applying changes in Review",
+                    );
+                    void rescan();
+                  } else {
+                    useProblemsStore.getState().showError({
+                      title: "Couldn't install the drift report",
+                      message: result.error,
+                    });
+                  }
+                });
+            },
+          },
+        });
+        await rescan();
+        return true;
+      }
+      useProblemsStore.getState().showError({
+        title: "Couldn't add the project",
+        message: response.error,
+        steps: [
+          "Check the folder path is correct",
+          "Make sure it isn't already added",
+        ],
+      });
+      return false;
+    },
+
+    unregisterProject: async (path) => {
+      const response = await commands.unregisterProject(path);
+      if (response.status === "ok") {
+        hold(response.data);
+        await rescan();
+      } else {
+        useProblemsStore.getState().showError({
+          title: "Couldn't stop tracking the project",
+          message: response.error,
+          steps: ["Try again"],
+        });
+      }
+    },
+
+    discoverProjects: async (root) => {
+      const response = await commands.discoverProjects(root);
+      if (response.status === "ok") return response.data;
+      useProblemsStore.getState().showError({
+        title: "Couldn't search that folder",
+        message: response.error,
+        steps: [
+          "Check the folder path is correct",
+          "Make sure kendex can read it",
+        ],
+      });
+      return [];
+    },
+  };
+}
+
+interface SettingsState extends ZoomSlice, ProjectsSlice {
+  settings: AppSettings | null;
+  /** What the settings file was when `settings` was read from it — sent
+   *  back with every whole-settings write, so a copy of a file something
+   *  else has since written is refused instead of putting the older file
+   *  back over it. */
+  base: string | null;
   capabilities: CapabilityRow[];
   load: () => Promise<void>;
   setAppearance: (appearance: Appearance) => Promise<void>;
   setSafety: (warnBelow: number, blockBelow: number) => Promise<void>;
   setHarnessRoot: (harness: string, root: string) => Promise<void>;
-  registerProject: (path: string) => Promise<boolean>;
-  unregisterProject: (path: string) => Promise<void>;
-  discoverProjects: (root: string) => Promise<string[]>;
 }
 
 async function rescan() {
   await useScanStore.getState().refresh();
 }
 
-export const useSettingsStore = create<SettingsState>((set, get) => ({
-  settings: null,
-  capabilities: [],
-  ...zoomActions(set, get),
+type WriteOutcome = { ok: true } | { ok: false; message: string };
 
-  load: async () => {
-    // The size comes from the window, not from the file: the file holds
-    // what the person asked for, and the zoom outlives the page, so a page
-    // that has just reloaded is the one least able to work it out itself.
-    const [settings, capabilities, webview] = await Promise.all([
-      commands.getSettings(),
-      commands.capabilityTable(),
-      commands.windowZoomState(),
-    ]);
-    if (settings.status === "ok") {
-      set({
-        settings: settings.data,
-        capabilities,
-        tookZoom: webview.percent,
-      });
-      // The opening had no UI to say this in, so it is said here rather
-      // than leaving the person with an app that quietly ignored their
-      // size. Both halves are needed: the refusal stands for the whole
-      // session, so on its own it would go on complaining after a resize
-      // put the person back where they wanted to be.
-      const asked = settings.data.zoom ?? ZOOM.default;
-      if (webview.launchRefused && webview.percent !== asked) {
+export const useSettingsStore = create<SettingsState>((set, get) => {
+  /** Keep the copy and its base together — one never moves without the
+   *  other, or the next save would present a base for bytes it does not
+   *  hold. */
+  const hold = (read: SettingsRead) =>
+    set({ settings: read.settings, base: read.base });
+
+  /** One change, written as the whole file with the base its copy was read
+   *  from. A stale refusal means something else wrote the file since the
+   *  copy was read — a resize, another window. The change is a field-level
+   *  intent, so it is carried onto a freshly read copy and written once
+   *  more; that reverts nothing, because the fresh copy holds everything
+   *  the stale one predated. Only a second refusal reaches the person. */
+  const write = async (
+    change: (current: AppSettings) => AppSettings,
+  ): Promise<WriteOutcome> => {
+    const { settings, base } = get();
+    if (!settings) return { ok: true };
+    let response = await commands.updateSettings(change(settings), base);
+    if (response.status === "error" && response.error.kind === "stale") {
+      const fresh = await commands.getSettings();
+      if (fresh.status === "ok") {
+        hold(fresh.data);
+        response = await commands.updateSettings(
+          change(fresh.data.settings),
+          fresh.data.base,
+        );
+      }
+    }
+    if (response.status === "ok") {
+      hold(response.data);
+      return { ok: true };
+    }
+    return {
+      ok: false,
+      message:
+        response.error.kind === "failed"
+          ? response.error.message
+          : "Your settings changed in another window while this was saving. The change wasn't applied — the latest settings are shown now.",
+    };
+  };
+
+  return {
+    settings: null,
+    base: null,
+    capabilities: [],
+    ...zoomActions(set, get),
+    ...projectActions(set, get),
+
+    load: async () => {
+      // The size comes from the window, not from the file: the file holds
+      // what the person asked for, and the zoom outlives the page, so a page
+      // that has just reloaded is the one least able to work it out itself.
+      const [settings, capabilities, webview] = await Promise.all([
+        commands.getSettings(),
+        commands.capabilityTable(),
+        commands.windowZoomState(),
+      ]);
+      if (settings.status === "ok") {
+        set({
+          settings: settings.data.settings,
+          base: settings.data.base,
+          capabilities,
+          tookZoom: webview.percent,
+        });
+        // The opening had no UI to say this in, so it is said here rather
+        // than leaving the person with an app that quietly ignored their
+        // size. Both halves are needed: the refusal stands for the whole
+        // session, so on its own it would go on complaining after a resize
+        // put the person back where they wanted to be.
+        const asked = settings.data.settings.zoom ?? ZOOM.default;
+        if (webview.launchRefused && webview.percent !== asked) {
+          useProblemsStore.getState().showError({
+            title: "Couldn't open at your saved zoom",
+            message: `kendex is at ${webview.percent}% instead of the ${asked}% you saved. Your saved zoom is unchanged.`,
+            steps: ["Try again", "If it keeps happening, restart kendex"],
+            actions: [
+              { label: "Retry", onClick: () => void get().setZoom(asked) },
+            ],
+          });
+        }
+      } else {
         useProblemsStore.getState().showError({
-          title: "Couldn't open at your saved zoom",
-          message: `kendex is at ${webview.percent}% instead of the ${asked}% you saved. Your saved zoom is unchanged.`,
+          title: "Couldn't load your settings",
+          message: settings.error,
           steps: ["Try again", "If it keeps happening, restart kendex"],
+          actions: [{ label: "Retry", onClick: () => void get().load() }],
+        });
+      }
+    },
+
+    // Theme, safety threshold, and tool folder saves are instant and their
+    // effect is visible immediately on screen — a toast on top would just be
+    // noise, so success here stays silent and only failure speaks up.
+    setAppearance: async (appearance) => {
+      const result = await write((current) => ({ ...current, appearance }));
+      if (!result.ok)
+        useProblemsStore.getState().showError({
+          title: "Couldn't change the appearance",
+          message: result.message,
+          steps: ["Try again"],
           actions: [
-            { label: "Retry", onClick: () => void get().setZoom(asked) },
+            {
+              label: "Retry",
+              onClick: () => void get().setAppearance(appearance),
+            },
+          ],
+        });
+    },
+
+    setSafety: async (warnBelow, blockBelow) => {
+      const result = await write((current) => ({
+        ...current,
+        safety: { "warn-below": warnBelow, "block-below": blockBelow },
+      }));
+      if (!result.ok)
+        useProblemsStore.getState().showError({
+          title: "Couldn't update safety settings",
+          message: result.message,
+          steps: ["Try again"],
+          actions: [
+            {
+              label: "Retry",
+              onClick: () => void get().setSafety(warnBelow, blockBelow),
+            },
+          ],
+        });
+    },
+
+    setHarnessRoot: async (harness, root) => {
+      const result = await write((current) => {
+        const roots = { ...current["harness-roots"] };
+        if (root.trim() === "") delete roots[harness];
+        else roots[harness] = root;
+        return { ...current, "harness-roots": roots };
+      });
+      if (result.ok) {
+        await rescan();
+      } else {
+        useProblemsStore.getState().showError({
+          title: "Couldn't update the tool folder",
+          message: result.message,
+          steps: [
+            "Check that the folder exists and kendex can read it",
+            "Try again",
+          ],
+          actions: [
+            {
+              label: "Retry",
+              onClick: () => void get().setHarnessRoot(harness, root),
+            },
           ],
         });
       }
-    } else {
-      useProblemsStore.getState().showError({
-        title: "Couldn't load your settings",
-        message: settings.error,
-        steps: ["Try again", "If it keeps happening, restart kendex"],
-        actions: [{ label: "Retry", onClick: () => void get().load() }],
-      });
-    }
-  },
-
-  // Theme, safety threshold, and tool folder saves are instant and their
-  // effect is visible immediately on screen — a toast on top would just be
-  // noise, so success here stays silent and only failure speaks up.
-  setAppearance: async (appearance) => {
-    const current = get().settings;
-    if (!current) return;
-    const response = await commands.updateSettings({ ...current, appearance });
-    if (response.status === "ok") set({ settings: response.data });
-    else
-      useProblemsStore.getState().showError({
-        title: "Couldn't change the appearance",
-        message: response.error,
-        steps: ["Try again"],
-        actions: [
-          {
-            label: "Retry",
-            onClick: () => void get().setAppearance(appearance),
-          },
-        ],
-      });
-  },
-
-  setSafety: async (warnBelow, blockBelow) => {
-    const current = get().settings;
-    if (!current) return;
-    const response = await commands.updateSettings({
-      ...current,
-      safety: { "warn-below": warnBelow, "block-below": blockBelow },
-    });
-    if (response.status === "ok") set({ settings: response.data });
-    else
-      useProblemsStore.getState().showError({
-        title: "Couldn't update safety settings",
-        message: response.error,
-        steps: ["Try again"],
-        actions: [
-          {
-            label: "Retry",
-            onClick: () => void get().setSafety(warnBelow, blockBelow),
-          },
-        ],
-      });
-  },
-
-  setHarnessRoot: async (harness, root) => {
-    const current = get().settings;
-    if (!current) return;
-    const roots = { ...current["harness-roots"] };
-    if (root.trim() === "") delete roots[harness];
-    else roots[harness] = root;
-    const response = await commands.updateSettings({
-      ...current,
-      "harness-roots": roots,
-    });
-    if (response.status === "ok") {
-      set({ settings: response.data });
-      await rescan();
-    } else {
-      useProblemsStore.getState().showError({
-        title: "Couldn't update the tool folder",
-        message: response.error,
-        steps: [
-          "Check that the folder exists and kendex can read it",
-          "Try again",
-        ],
-        actions: [
-          {
-            label: "Retry",
-            onClick: () => void get().setHarnessRoot(harness, root),
-          },
-        ],
-      });
-    }
-  },
-
-  registerProject: async (path) => {
-    const before = get().settings?.projects ?? [];
-    const response = await commands.registerProject(path);
-    if (response.status === "ok") {
-      set({ settings: response.data });
-      // Registration is where the drift report is offered: agents in this
-      // project start blind until the session-start hook is installed. An
-      // offer, never an auto-install — it injects into agent context.
-      const root =
-        (response.data.projects ?? []).find((p) => !before.includes(p)) ?? path;
-      toast.success(`Added ${path.split("/").pop()}`, {
-        action: {
-          label: "Add session drift report",
-          onClick: () => {
-            void commands
-              .installDriftHook({ scope: "project", root })
-              .then((result) => {
-                if (result.status === "ok") {
-                  // False: the scope had other pending changes, so only the
-                  // declaration landed — nothing is applied unreviewed.
-                  toast.success(
-                    result.data
-                      ? "Drift report installed"
-                      : "Drift report added — finish by applying changes in Review",
-                  );
-                  void rescan();
-                } else {
-                  useProblemsStore.getState().showError({
-                    title: "Couldn't install the drift report",
-                    message: result.error,
-                  });
-                }
-              });
-          },
-        },
-      });
-      await rescan();
-      return true;
-    }
-    useProblemsStore.getState().showError({
-      title: "Couldn't add the project",
-      message: response.error,
-      steps: [
-        "Check the folder path is correct",
-        "Make sure it isn't already added",
-      ],
-    });
-    return false;
-  },
-
-  unregisterProject: async (path) => {
-    const response = await commands.unregisterProject(path);
-    if (response.status === "ok") {
-      set({ settings: response.data });
-      await rescan();
-    } else {
-      useProblemsStore.getState().showError({
-        title: "Couldn't stop tracking the project",
-        message: response.error,
-        steps: ["Try again"],
-      });
-    }
-  },
-
-  discoverProjects: async (root) => {
-    const response = await commands.discoverProjects(root);
-    if (response.status === "ok") return response.data;
-    useProblemsStore.getState().showError({
-      title: "Couldn't search that folder",
-      message: response.error,
-      steps: [
-        "Check the folder path is correct",
-        "Make sure kendex can read it",
-      ],
-    });
-    return [];
-  },
-}));
+    },
+  };
+});

--- a/ui/src/stores/zoom-fixture.ts
+++ b/ui/src/stores/zoom-fixture.ts
@@ -1,5 +1,5 @@
 import { expect, vi } from "vitest";
-import type { AppSettings } from "@/bindings";
+import type { AppSettings, SettingsRead, WriteRefused } from "@/bindings";
 import { commands } from "@/bindings";
 import { useProblemsStore } from "./problems";
 import { useSettingsStore } from "./settings";
@@ -17,8 +17,8 @@ export const settings: AppSettings = {
 };
 
 export type Reply =
-  | { status: "ok"; data: AppSettings }
-  | { status: "error"; error: string };
+  | { status: "ok"; data: SettingsRead }
+  | { status: "error"; error: WriteRefused };
 export type WindowReply =
   | { status: "ok"; data: null }
   | { status: "error"; error: string };
@@ -73,8 +73,8 @@ export function freshZoomStore() {
     percent: webviewAt,
     launchRefused: false,
   }));
-  vi.mocked(commands.updateSettings).mockImplementation(async (next) =>
-    ok(next),
+  vi.mocked(commands.updateSettings).mockImplementation(async (next, base) =>
+    ok({ settings: next, base }),
   );
   vi.mocked(commands.saveZoom).mockImplementation(async (percent) =>
     ok(percent),


### PR DESCRIPTION
## Summary
- Both whole-file surfaces — the Customize manifest save and the app settings page — now read content paired with a `Base` (`kendex_core::base`, one derivation: the hash of the exact bytes read) and present it on write. A copy of a file that is no longer those bytes is refused as `WriteRefused::Stale` — one shape for every such surface — and each page renders the refusal as a choice: Customize offers Reload; the settings store re-applies the field-level change to a fresh copy once, then asks. The `zoom` hand-patch in `update_settings` is gone: an accepted copy is provably the file.
- Targeted settings writes (`save_zoom`, project registration, mutes) go through `settings::mutate` under a cross-process OS file lock beside `settings.toml` (bounded wait, loud `SettingsBusy`); `settings::save` is private and `manifest::save` is `pub(crate)`, so no public path writes either file unchecked. The manifest write binds its base into the plan op's precondition, re-checked by the apply under the scope lock.
- Rollback keeps a refused writer's bytes: journal rollback restores only paths of ops that ran, persists that restore set durably before restoring so crash recovery honors it, refuses recovery loudly on a corrupt set, and `Op::Rename` carries a source precondition (as-is tree hash, tolerant of dangling links, refusing pipes/sockets at planning) bound at every planner. Legacy `vstack.toml` saves land after the rename prefix.

## Completed Issues
- Closes KEN-476 - Whole-file writes go through one checked path

## QA Metrics
- Safety QA (two passes): pass — settings lock spans check+write on one fd; every `Op::run` arm returns `PlanStale` only before mutating (verified arm by arm); `clear()` unlinks `meta.json` before the sweep with the fsync result propagated; as-is tree hash never follows links.
- Correctness QA (three passes): pass — all four acceptance criteria verified end to end; `Pre::TreeIs` discriminates file edits, link retargets, and kind changes; a FIFO under a renamed dir refuses at planning instead of hanging the journal.
- Review panel: 9 internal reviewers + external Codex over four cycles plus QA; mutation-stability evidence on the rollback filter, `Base::verify`, the settings lock, the UI stale-retry path, and every new discriminating test (six planted UI mutants and the `RolledBack` cause mutant killed).

## Test Plan
- `cargo test --workspace`, clippy, `tsc --noEmit`, biome, vitest (518), preflight, `tools/guard` green on every commit.
- Must-fail controls run red for: both refusal guards, the filtered rollback, the persisted restore set, the rename source precondition, the legacy-save insertion point, and the FIFO planning refusal.
- Tracked follow-ups (frozen out under the scope-freeze rule; filed via the TPM audit): post-image-verified journal restore (incl. created dir roots), backend-revision ordering of settings replies, package-page stale-note visibility, `authored.toml` lock.
