### PR TITLE
fix(skills): fix-links exits non-zero for a path it did not restore (KEN-464)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -93,6 +93,9 @@ an outside contributor.
 - The worktree skill's `push` refuses a flag it does not recognize and an
   empty target, rather than pushing the current checkout with default
   behavior nobody asked for. `push --check-args` validates arguments alone.
+- The worktree skill's `fix-links` no longer reports "Restored symlinks" for
+  a path it did not restore: it names every configured entry left unhealthy
+  — including one absent from the main checkout — and exits non-zero.
 - An apply is no longer refused as "scope is busy" while nothing else
   runs: locks release explicitly when an apply finishes instead of waiting
   on a file a just-launched program still held open. Same fix for downloads.

--- a/skills/worktree/SKILL.md
+++ b/skills/worktree/SKILL.md
@@ -54,7 +54,9 @@ Broken `.agents` in a worktree (missing, or a real directory): from the MAIN che
 and never `git checkout -- .agents` (the path holds no tracked content, so the command
 changes nothing while the link stays broken). A genuinely corrupt tracked file is the other
 case: `git checkout -- <path>`, run in the checkout the file really lives in (the main
-checkout when the path sits under a configured symlink).
+checkout when the path sits under a configured symlink). `fix-links` reports success only
+when every configured entry ended healthy; a non-zero exit names the paths it did not
+restore, so read them rather than re-running the same command.
 ```
 
 ## Session guard (ownership leases)

--- a/skills/worktree/scripts/worktree
+++ b/skills/worktree/scripts/worktree
@@ -378,6 +378,15 @@ Recovery routing — route by shape, not by whether 'test -L' passes:
   entry: the path holds no tracked content, so the command changes nothing
   while the link stays broken.
 
+Exit status:
+  fix-links judges the RESULT of its pass, not the repair's return codes:
+  'Restored symlinks' and exit 0 only when every configured entry ended
+  healthy. Anything still unhealthy is named and the exit is non-zero — a
+  path the quarantine left in place, or an entry with no such path in the
+  MAIN checkout, which setup skips outright. The errors that name fix-links
+  as their remediation are re-triggered by exactly those paths, so claiming
+  success for one loops the operator on a command that changed nothing.
+
 Symlink entries that shadow tracked content:
   When a configured symlink path is a tracked FILE in the worktree branch,
   setup marks that file assume-unchanged before replacing it so 'git status'
@@ -1610,6 +1619,59 @@ collect_materialized_child_links() {
     fi
   done
   [[ -z "$capped" ]]
+}
+
+# Postcondition for `fix-links` (KEN-464): name every configured entry that is
+# NOT in its healthy shape, one per line. Reporting only — it changes nothing,
+# and is silent when everything is healthy.
+#
+# The repair path's return codes proved too weak to gate the success message:
+# an entry can be skipped before any repair is attempted (no such path in the
+# main checkout), and a quarantined entry is left materialized on purpose.
+# fix-links printed "Restored symlinks" and exited 0 through both, so the sync
+# error naming fix-links as its remediation kept firing and the operator looped
+# on it. Judging the RESULT covers whatever mechanism left a path unrestored,
+# not only the two known ones.
+collect_unrestored_links() {
+  local wt="$1" path="" rel="" child_damage=""
+  [[ -n "$wt" && -d "$wt" ]] || return 0
+  validate_worktree_setup_config >/dev/null 2>&1 || return 0
+
+  split_worktree_config_words "${WORKTREE_SYMLINKS:-}"
+  for path in ${WORKTREE_CONFIG_WORDS[@]+"${WORKTREE_CONFIG_WORDS[@]}"}; do
+    path="$(normalize_worktree_config_path WORKTREE_SYMLINKS "$path" 2>/dev/null)" || continue
+    if [[ ! -e "$PROJECT_ROOT/$path" ]]; then
+      # setup skips this entry entirely, so the link is absent afterwards with
+      # nothing printed. Only the main checkout can resolve it.
+      printf '%s (no such path in the main checkout — create it there, or drop it from WORKTREE_SYMLINKS)\n' "$path"
+      continue
+    fi
+    if [[ -L "$wt/$path" ]]; then
+      [[ "$(readlink "$wt/$path" 2>/dev/null || true)" == "$PROJECT_ROOT/$path" ]] ||
+        printf '%s (a symlink, but not to the main checkout)\n' "$path"
+      continue
+    fi
+    if [[ ! -e "$wt/$path" ]]; then
+      printf '%s (absent)\n' "$path"
+      continue
+    fi
+    # An entry with tracked content underneath is a real directory BY DESIGN
+    # (VST-37); its untracked children are what must be links. Both indexes,
+    # main authoritative, matching how the repair path decides the shape.
+    if [[ -d "$wt/$path" ]] &&
+       { [[ -n "$(git -C "$wt" ls-files -- ":(literal)$path/" 2>/dev/null)" ]] ||
+         [[ -n "$(git -C "$PROJECT_ROOT" ls-files -- ":(literal)$path/" 2>/dev/null || true)" ]]; }; then
+      # `|| true`: a nonzero return means a depth-capped subtree went
+      # uninspected, which the collector already emitted as its own line.
+      child_damage="$(collect_materialized_child_links "$path" "$wt")" || true
+      while IFS= read -r rel; do
+        [[ -n "$rel" ]] || continue
+        printf '%s\n' "$rel"
+      done <<<"$child_damage"
+      continue
+    fi
+    printf '%s (still a real path, not a link)\n' "$path"
+  done
 }
 
 warn_if_links_materialized() {
@@ -4446,10 +4508,31 @@ case "${1:-}" in
     if ! require_non_main_project_worktree "$WT_PATH" "restore links in it"; then
       exit 1
     fi
-    setup_worktree_links "$WT_PATH"
+    # A failed pass must still be REPORTED, not aborted by set -e with no
+    # word about which path is unhealthy — the postcondition below is what
+    # names them, so let the repair run to completion either way.
+    LINKS_SETUP_OK=true
+    setup_worktree_links "$WT_PATH" || LINKS_SETUP_OK=false
     # Re-assert the shared auto-repair hooks too (#1032): a fix-links run is
     # the natural refresh point after upgrading the skill or the config.
     install_worktree_autorepair_hooks
+    # Never claim success for a path this run did not restore (KEN-464): the
+    # sync errors that name fix-links as their remediation are re-triggered by
+    # exactly these paths, so a success message here loops the operator.
+    UNRESTORED="$(collect_unrestored_links "$WT_PATH")"
+    if [[ -n "$UNRESTORED" || "$LINKS_SETUP_OK" != true ]]; then
+      {
+        echo "Error: fix-links did not restore every configured path in $WT_PATH."
+        if [[ -n "$UNRESTORED" ]]; then
+          echo "  Still unhealthy:"
+          sed 's/^/    - /' <<<"$UNRESTORED"
+        fi
+        echo "  Any warning above names why. A path holding data git does not track is"
+        echo "  left in place deliberately: move it into '$PROJECT_ROOT' (or delete it),"
+        echo "  then re-run this command."
+      } >&2
+      exit 1
+    fi
     echo "Restored symlinks in $WT_PATH"
     ;;
 

--- a/skills/worktree/scripts/worktree
+++ b/skills/worktree/scripts/worktree
@@ -1715,11 +1715,19 @@ collect_unrestored_links() {
       continue
     fi
     # An entry with tracked content underneath is a real directory BY DESIGN
-    # (VST-37); its untracked children are what must be links. Both indexes,
-    # main authoritative, matching how the repair path decides the shape.
-    if [[ ! -L "$wt/$path" && -d "$wt/$path" ]] &&
-       { [[ -n "$(git -C "$wt" ls-files -- ":(literal)$path/" 2>/dev/null)" ]] ||
-         [[ -n "$(git -C "$PROJECT_ROOT" ls-files -- ":(literal)$path/" 2>/dev/null || true)" ]]; }; then
+    # (VST-37); its untracked children are what must be links. The layout is
+    # decided from the INDEX alone — both, main authoritative, matching how the
+    # repair path decides it — never from what the destination happens to be
+    # right now. Reading the destination first would let a legacy parent
+    # symlink still shadowing the tracked subtree answer as a plain-symlink
+    # entry, and a symlink to exactly $PROJECT_ROOT/$path is what that check
+    # calls healthy: the unrestored path would drop out of this diagnostic.
+    if [[ -n "$(git -C "$wt" ls-files -- ":(literal)$path/" 2>/dev/null)" ]] ||
+       [[ -n "$(git -C "$PROJECT_ROOT" ls-files -- ":(literal)$path/" 2>/dev/null || true)" ]]; then
+      if [[ -L "$wt/$path" || ! -d "$wt/$path" ]]; then
+        printf '%s (must be a real directory holding per-child links, tracked content lives under it)\n' "$path"
+        continue
+      fi
       collect_unhealthy_child_links "$path" "$wt"
       continue
     fi

--- a/skills/worktree/scripts/worktree
+++ b/skills/worktree/scripts/worktree
@@ -380,12 +380,15 @@ Recovery routing — route by shape, not by whether 'test -L' passes:
 
 Exit status:
   fix-links judges the RESULT of its pass, not the repair's return codes:
-  'Restored symlinks' and exit 0 only when every configured entry ended
-  healthy. Anything still unhealthy is named and the exit is non-zero — a
-  path the quarantine left in place, or an entry with no such path in the
-  MAIN checkout, which setup skips outright. The errors that name fix-links
-  as their remediation are re-triggered by exactly those paths, so claiming
-  success for one loops the operator on a command that changed nothing.
+  'Restored symlinks' and exit 0 only when every WORKTREE_SYMLINKS and
+  WORKTREE_RELATIVE_SYMLINKS entry ended healthy — present, a symlink, and
+  resolving to the target this command gives it. Anything else is named and
+  the exit is non-zero: a path the quarantine left in place, an entry with
+  no such path in the MAIN checkout (setup skips those outright), a link
+  that never got created, or one pointing somewhere else. The errors that
+  name fix-links as their remediation are re-triggered by exactly those
+  paths, so claiming success for one loops the operator on a command that
+  changed nothing.
 
 Symlink entries that shadow tracked content:
   When a configured symlink path is a tracked FILE in the worktree branch,
@@ -1621,6 +1624,67 @@ collect_materialized_child_links() {
   [[ -z "$capped" ]]
 }
 
+# One expected symlink, judged by its actual SHAPE: it must be a symlink and it
+# must resolve to the target this command would have given it. Absent and
+# wrong-target are unhealthy too — those are exactly the states that re-trigger
+# the sync error naming fix-links as its remediation.
+report_link_health() {
+  local wt="$1" rel="$2" want="$3" actual=""
+  if [[ -L "$wt/$rel" ]]; then
+    actual="$(readlink "$wt/$rel" 2>/dev/null || true)"
+    [[ "$actual" == "$want" ]] && return 0
+    printf '%s (a symlink to %s, expected %s)\n' "$rel" "${actual:-<unreadable>}" "$want"
+    return 0
+  fi
+  if [[ -e "$wt/$rel" ]]; then
+    printf '%s (still a real path, not a link)\n' "$rel"
+  else
+    printf '%s (absent)\n' "$rel"
+  fi
+}
+
+# Health check for the untracked children of a tracked-content WORKTREE_SYMLINKS
+# entry, which VST-37 keeps as a real directory with per-child links. Mirrors
+# link_untracked_children's index classification so this agrees with what the
+# repair path actually creates.
+#
+# collect_materialized_child_links cannot serve here: it is a MATERIALIZATION
+# detector, emitting an untracked child only when one exists as a non-symlink.
+# An absent child and a child linked somewhere wrong both read healthy through
+# it, which is the same false success this postcondition exists to stop.
+collect_unhealthy_child_links() {
+  local path="$1" wt="$2" depth="${3:-0}"
+  local src="$PROJECT_ROOT/$path" child="" name="" rel="" exact="" descendants=""
+  # Depth-capped like link_untracked_children (#846). Reporting the cap rather
+  # than returning silently: an uninspected subtree is not a healthy one.
+  if [[ "$depth" -ge 8 ]]; then
+    printf '%s (nests deeper than 8 levels — not inspected)\n' "$path"
+    return 0
+  fi
+  for child in "$src"/* "$src"/.[!.]* "$src"/..?*; do
+    [[ -e "$child" || -L "$child" ]] || continue
+    name="${child##*/}"
+    rel="$path/$name"
+    # Literal-equal, BOTH indexes — see link_untracked_children (#856, #964).
+    # Classifying differently from the repair path would make this diagnostic
+    # disagree with the shape that path just created.
+    classify_index_entry "$wt" "$rel"
+    exact="$CIE_EXACT"; descendants="$CIE_DESCENDANTS"
+    classify_index_entry "$PROJECT_ROOT" "$rel"
+    [[ -n "$CIE_EXACT" ]] && exact=1
+    [[ -n "$CIE_DESCENDANTS" ]] && descendants=1
+    if [[ -n "$exact" ]]; then
+      # A tracked leaf: git owns it and no link belongs here.
+      continue
+    fi
+    if [[ -n "$descendants" ]]; then
+      collect_unhealthy_child_links "$rel" "$wt" $((depth + 1))
+      continue
+    fi
+    report_link_health "$wt" "$rel" "$PROJECT_ROOT/$rel"
+  done
+}
+
 # Postcondition for `fix-links` (KEN-464): name every configured entry that is
 # NOT in its healthy shape, one per line. Reporting only — it changes nothing,
 # and is silent when everything is healthy.
@@ -1632,8 +1696,12 @@ collect_materialized_child_links() {
 # error naming fix-links as its remediation kept firing and the operator looped
 # on it. Judging the RESULT covers whatever mechanism left a path unrestored,
 # not only the two known ones.
+#
+# Scope: the link shapes this command creates — WORKTREE_SYMLINKS and
+# WORKTREE_RELATIVE_SYMLINKS. WORKTREE_MKDIRS and WORKTREE_COPIES are not link
+# shapes and are left to setup_worktree_links' own (now checked) return.
 collect_unrestored_links() {
-  local wt="$1" path="" rel="" child_damage=""
+  local wt="$1" path="" spec="" target=""
   [[ -n "$wt" && -d "$wt" ]] || return 0
   validate_worktree_setup_config >/dev/null 2>&1 || return 0
 
@@ -1646,31 +1714,30 @@ collect_unrestored_links() {
       printf '%s (no such path in the main checkout — create it there, or drop it from WORKTREE_SYMLINKS)\n' "$path"
       continue
     fi
-    if [[ -L "$wt/$path" ]]; then
-      [[ "$(readlink "$wt/$path" 2>/dev/null || true)" == "$PROJECT_ROOT/$path" ]] ||
-        printf '%s (a symlink, but not to the main checkout)\n' "$path"
-      continue
-    fi
-    if [[ ! -e "$wt/$path" ]]; then
-      printf '%s (absent)\n' "$path"
-      continue
-    fi
     # An entry with tracked content underneath is a real directory BY DESIGN
     # (VST-37); its untracked children are what must be links. Both indexes,
     # main authoritative, matching how the repair path decides the shape.
-    if [[ -d "$wt/$path" ]] &&
+    if [[ ! -L "$wt/$path" && -d "$wt/$path" ]] &&
        { [[ -n "$(git -C "$wt" ls-files -- ":(literal)$path/" 2>/dev/null)" ]] ||
          [[ -n "$(git -C "$PROJECT_ROOT" ls-files -- ":(literal)$path/" 2>/dev/null || true)" ]]; }; then
-      # `|| true`: a nonzero return means a depth-capped subtree went
-      # uninspected, which the collector already emitted as its own line.
-      child_damage="$(collect_materialized_child_links "$path" "$wt")" || true
-      while IFS= read -r rel; do
-        [[ -n "$rel" ]] || continue
-        printf '%s\n' "$rel"
-      done <<<"$child_damage"
+      collect_unhealthy_child_links "$path" "$wt"
       continue
     fi
-    printf '%s (still a real path, not a link)\n' "$path"
+    report_link_health "$wt" "$path" "$PROJECT_ROOT/$path"
+  done
+
+  # Relative-target entries this command also creates. Same postcondition, with
+  # the expected target read from the config verbatim: it resolves from inside
+  # the worktree, not from the main checkout.
+  split_worktree_config_words "${WORKTREE_RELATIVE_SYMLINKS:-}"
+  for spec in ${WORKTREE_CONFIG_WORDS[@]+"${WORKTREE_CONFIG_WORDS[@]}"}; do
+    # Malformed entries: setup warns and ignores them, so there is no link to
+    # expect here and nothing for this check to say.
+    [[ "$spec" == *=* ]] || continue
+    path="${spec%%=*}"
+    target="${spec#*=}"
+    path="$(normalize_worktree_config_path WORKTREE_RELATIVE_SYMLINKS "$path" 2>/dev/null)" || continue
+    report_link_health "$wt" "$path" "$target"
   done
 }
 
@@ -2246,8 +2313,15 @@ setup_worktree_links() {
     if [[ -f "$PROJECT_ROOT/$path" ]]; then
       ensure_worktree_path_safe "$wt" "$path" true || return 1
       exclude_from_worktree_index "$wt" "$path"
-      mkdir -p "$(dirname "$wt/$path")"
-      cp "$PROJECT_ROOT/$path" "$wt/$path"
+      # Checked, not left to implicit set -e (KEN-464): fix-links calls this
+      # function on the left of ||, which disables errexit for everything
+      # inside it. An unchecked failure here returned whatever the next
+      # command returned, and the caller read that as a clean pass.
+      if ! mkdir -p "$(dirname "$wt/$path")" 2>/dev/null ||
+         ! cp "$PROJECT_ROOT/$path" "$wt/$path" 2>/dev/null; then
+        echo "Error: could not copy WORKTREE_COPIES entry '$path' into $wt." >&2
+        return 1
+      fi
     fi
   done
 
@@ -2269,13 +2343,27 @@ setup_worktree_links() {
       echo "Error: refusing to replace non-file worktree path '$path' with a relative symlink." >&2
       return 1
     fi
-    mkdir -p "$(dirname "$wt/$path")"
+    # Same reason as WORKTREE_COPIES above (KEN-464). A relative entry nested
+    # below a tracked regular file fails both the mkdir and the ln; unchecked,
+    # the exclude update that follows supplied the function's exit status and
+    # fix-links reported success with the link absent.
+    if ! mkdir -p "$(dirname "$wt/$path")" 2>/dev/null; then
+      echo "Error: could not create the parent directory for relative symlink '$path' in $wt." >&2
+      return 1
+    fi
     if [[ -L "$wt/$path" || -f "$wt/$path" ]]; then
       rm -f "$wt/$path"
     fi
-    ln -s "$target" "$wt/$path"
+    if ! ln -s "$target" "$wt/$path" 2>/dev/null; then
+      echo "Error: could not create relative symlink '$path' -> '$target' in $wt." >&2
+      return 1
+    fi
     exclude_from_worktree_index "$wt" "$path"
   done
+
+  # Explicit: the last loop's trailing command must not decide this function's
+  # exit status — every failure above returns 1 on its own.
+  return 0
 }
 
 configure_worktree_git() {

--- a/skills/worktree/tests/worktree_fix_links_unrestored.sh
+++ b/skills/worktree/tests/worktree_fix_links_unrestored.sh
@@ -1,0 +1,111 @@
+#!/usr/bin/env bash
+# KEN-464: `fix-links` printed "Restored symlinks" and exited 0 for paths it had
+# not restored. The sync errors that name fix-links as their remediation are
+# re-triggered by exactly those paths, so the operator looped on a command that
+# reported success and changed nothing.
+#
+# Two ways a path survives a pass unrestored, both silent before this:
+#   1. no such path in the MAIN checkout — setup skips the entry outright;
+#   2. a materialized child holding data git does not track — the quarantine
+#      refuses to destroy it and leaves the real path in place.
+# Both must now name the path and exit non-zero, and a healthy worktree must
+# still report success (the must-fail control for the check itself).
+set -euo pipefail
+
+TEST_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SKILL_DIR="$(cd "$TEST_DIR/.." && pwd)"
+WORKTREE_SCRIPT="${WORKTREE_SCRIPT:-$SKILL_DIR/scripts/worktree}"
+TMP_ROOT="$(cd "$(mktemp -d)" && pwd -P)"
+trap 'rm -rf "$TMP_ROOT"' EXIT
+
+PASS=0
+FAIL=0
+ok() { PASS=$((PASS + 1)); printf '  ok    %s\n' "$1"; }
+bad() { FAIL=$((FAIL + 1)); printf '  FAIL  %s\n        %s\n' "$1" "${2:-}"; }
+
+assert_contains() {
+  local haystack="$1" needle="$2" name="$3"
+  if grep -qF -- "$needle" <<<"$haystack"; then ok "$name"; else bad "$name" "wanted: $needle"; fi
+}
+assert_lacks() {
+  local haystack="$1" needle="$2" name="$3"
+  if grep -qF -- "$needle" <<<"$haystack"; then bad "$name" "unexpected: $needle"; else ok "$name"; fi
+}
+
+mkdir -p "$TMP_ROOT/bin"
+printf '#!/usr/bin/env bash\nexit 0\n' >"$TMP_ROOT/bin/gh"
+chmod +x "$TMP_ROOT/bin/gh"
+export PATH="$TMP_ROOT/bin:$PATH"
+
+ROOT="$TMP_ROOT/repo"
+MAIN="$ROOT/main"
+mkdir -p "$MAIN"
+git -C "$MAIN" init -q -b main
+git -C "$MAIN" config user.email test@example.com
+git -C "$MAIN" config user.name Test
+git -C "$MAIN" config commit.gpgsign false
+printf 'base\n' >"$MAIN/base.txt"
+git -C "$MAIN" add base.txt
+git -C "$MAIN" commit -q -m base
+git init -q --bare "$ROOT/origin.git"
+git -C "$MAIN" remote add origin "$ROOT/origin.git"
+git -C "$MAIN" push -q -u origin main
+
+# harness/ mixes untracked kendex-installed content with a tracked file, so it
+# is provisioned as a real directory with per-child links (VST-37); runtime/ is
+# untracked-only, a plain parent symlink. absent-here is configured further
+# down but never created in the main checkout.
+mkdir -p "$MAIN/harness/skills" "$MAIN/runtime"
+printf 'harness/**\n!harness/tracked.md\nruntime/\n' >"$MAIN/.gitignore"
+printf 'installed\n' >"$MAIN/harness/skills/installed.txt"
+printf 'tracked\n' >"$MAIN/harness/tracked.md"
+printf 'state\n' >"$MAIN/runtime/state.json"
+printf 'WORKTREE_SYMLINKS="harness runtime"\n' >"$MAIN/.env"
+git -C "$MAIN" add .gitignore harness/tracked.md
+git -C "$MAIN" commit -q -m harness
+git -C "$MAIN" push -q origin main
+
+WT="$(cd "$MAIN" && "$WORKTREE_SCRIPT" create fix-links-check 2>/dev/null | tail -1)"
+
+run_fix_links() {
+  set +e
+  OUT="$( (cd "$MAIN" && "$WORKTREE_SCRIPT" fix-links "$WT") 2>&1 )"
+  RC=$?
+  set -e
+}
+
+echo "=== a healthy worktree still reports success ==="
+run_fix_links
+if [[ "$RC" == 0 ]]; then ok "exit 0 when every entry is healthy"; else bad "exit 0 when every entry is healthy" "rc=$RC: $OUT"; fi
+assert_contains "$OUT" "Restored symlinks in $WT" "success message on a healthy worktree"
+
+echo "=== an entry with no source in the main checkout is named, not skipped ==="
+printf 'WORKTREE_SYMLINKS="harness runtime absent-here"\n' >"$MAIN/.env"
+run_fix_links
+if [[ "$RC" != 0 ]]; then ok "nonzero exit for an entry missing from the main checkout"; else bad "nonzero exit for an entry missing from the main checkout" "rc=0: $OUT"; fi
+assert_contains "$OUT" "absent-here" "names the skipped entry"
+assert_contains "$OUT" "no such path in the main checkout" "explains why it was skipped"
+assert_lacks "$OUT" "Restored symlinks" "no success message when an entry was skipped"
+printf 'WORKTREE_SYMLINKS="harness runtime"\n' >"$MAIN/.env"
+
+echo "=== a child left materialized by the quarantine is named ==="
+# Replace the per-child link with a real directory holding a file git does not
+# track: the quarantine refuses to destroy it and leaves the path real.
+rm -f "$WT/harness/skills"
+mkdir -p "$WT/harness/skills"
+printf 'work in progress\n' >"$WT/harness/skills/untracked-work.txt"
+run_fix_links
+if [[ "$RC" != 0 ]]; then ok "nonzero exit for a quarantine-blocked child"; else bad "nonzero exit for a quarantine-blocked child" "rc=0: $OUT"; fi
+assert_contains "$OUT" "harness/skills" "names the blocked child"
+assert_lacks "$OUT" "Restored symlinks" "no success message while a path stays materialized"
+if [[ -f "$WT/harness/skills/untracked-work.txt" ]]; then ok "untracked data is left intact"; else bad "untracked data is left intact"; fi
+
+echo "=== clearing the blocker makes the same command succeed ==="
+rm -rf "$WT/harness/skills"
+run_fix_links
+if [[ "$RC" == 0 ]]; then ok "exit 0 once the blocker is cleared"; else bad "exit 0 once the blocker is cleared" "rc=$RC: $OUT"; fi
+assert_contains "$OUT" "Restored symlinks in $WT" "success message once every entry is healthy"
+if [[ -L "$WT/harness/skills" ]]; then ok "the child link is restored"; else bad "the child link is restored"; fi
+
+printf '\n%s passed, %s failed\n' "$PASS" "$FAIL"
+[[ "$FAIL" == 0 ]]

--- a/skills/worktree/tests/worktree_fix_links_unrestored.sh
+++ b/skills/worktree/tests/worktree_fix_links_unrestored.sh
@@ -4,12 +4,19 @@
 # re-triggered by exactly those paths, so the operator looped on a command that
 # reported success and changed nothing.
 #
-# Two ways a path survives a pass unrestored, both silent before this:
+# Ways a path survives a pass unrestored, all silent before this:
 #   1. no such path in the MAIN checkout — setup skips the entry outright;
 #   2. a materialized child holding data git does not track — the quarantine
-#      refuses to destroy it and leaves the real path in place.
-# Both must now name the path and exit non-zero, and a healthy worktree must
+#      refuses to destroy it and leaves the real path in place;
+#   3. a WORKTREE_RELATIVE_SYMLINKS entry the pass could not create at all;
+#   4. a link that exists but resolves somewhere other than its configured
+#      target.
+# Each must now name the path and exit non-zero, and a healthy worktree must
 # still report success (the must-fail control for the check itself).
+#
+# 3 and 4 are also the two shapes a materialization detector cannot see: it
+# reports an untracked child only when one EXISTS as a non-symlink, so an
+# absent link and a wrong-target link both read healthy through it.
 set -euo pipefail
 
 TEST_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
@@ -30,6 +37,12 @@ assert_contains() {
 assert_lacks() {
   local haystack="$1" needle="$2" name="$3"
   if grep -qF -- "$needle" <<<"$haystack"; then bad "$name" "unexpected: $needle"; else ok "$name"; fi
+}
+
+write_base_env() {
+  printf '%s\n%s\n' \
+    'WORKTREE_SYMLINKS="harness runtime"' \
+    'WORKTREE_RELATIVE_SYMLINKS=".claude/CLAUDE.md=../AGENTS.md"' >"$MAIN/.env"
 }
 
 mkdir -p "$TMP_ROOT/bin"
@@ -60,8 +73,13 @@ printf 'harness/**\n!harness/tracked.md\nruntime/\n' >"$MAIN/.gitignore"
 printf 'installed\n' >"$MAIN/harness/skills/installed.txt"
 printf 'tracked\n' >"$MAIN/harness/tracked.md"
 printf 'state\n' >"$MAIN/runtime/state.json"
-printf 'WORKTREE_SYMLINKS="harness runtime"\n' >"$MAIN/.env"
-git -C "$MAIN" add .gitignore harness/tracked.md
+# AGENTS.md is the relative entry's target, resolved from inside the worktree.
+# notes.md is a tracked regular FILE, used further down as a parent no link can
+# be created under.
+printf 'agents\n' >"$MAIN/AGENTS.md"
+printf 'notes\n' >"$MAIN/notes.md"
+write_base_env
+git -C "$MAIN" add .gitignore harness/tracked.md AGENTS.md notes.md
 git -C "$MAIN" commit -q -m harness
 git -C "$MAIN" push -q origin main
 
@@ -78,15 +96,22 @@ echo "=== a healthy worktree still reports success ==="
 run_fix_links
 if [[ "$RC" == 0 ]]; then ok "exit 0 when every entry is healthy"; else bad "exit 0 when every entry is healthy" "rc=$RC: $OUT"; fi
 assert_contains "$OUT" "Restored symlinks in $WT" "success message on a healthy worktree"
+if [[ "$(readlink "$WT/.claude/CLAUDE.md" 2>/dev/null || true)" == "../AGENTS.md" ]]; then
+  ok "the relative entry is set up, and reads healthy"
+else
+  bad "the relative entry is set up, and reads healthy" "readlink: $(readlink "$WT/.claude/CLAUDE.md" 2>/dev/null || echo absent)"
+fi
 
 echo "=== an entry with no source in the main checkout is named, not skipped ==="
-printf 'WORKTREE_SYMLINKS="harness runtime absent-here"\n' >"$MAIN/.env"
+printf '%s\n%s\n' \
+  'WORKTREE_SYMLINKS="harness runtime absent-here"' \
+  'WORKTREE_RELATIVE_SYMLINKS=".claude/CLAUDE.md=../AGENTS.md"' >"$MAIN/.env"
 run_fix_links
 if [[ "$RC" != 0 ]]; then ok "nonzero exit for an entry missing from the main checkout"; else bad "nonzero exit for an entry missing from the main checkout" "rc=0: $OUT"; fi
 assert_contains "$OUT" "absent-here" "names the skipped entry"
 assert_contains "$OUT" "no such path in the main checkout" "explains why it was skipped"
 assert_lacks "$OUT" "Restored symlinks" "no success message when an entry was skipped"
-printf 'WORKTREE_SYMLINKS="harness runtime"\n' >"$MAIN/.env"
+write_base_env
 
 echo "=== a child left materialized by the quarantine is named ==="
 # Replace the per-child link with a real directory holding a file git does not
@@ -106,6 +131,48 @@ run_fix_links
 if [[ "$RC" == 0 ]]; then ok "exit 0 once the blocker is cleared"; else bad "exit 0 once the blocker is cleared" "rc=$RC: $OUT"; fi
 assert_contains "$OUT" "Restored symlinks in $WT" "success message once every entry is healthy"
 if [[ -L "$WT/harness/skills" ]]; then ok "the child link is restored"; else bad "the child link is restored"; fi
+
+echo "=== a relative entry the pass could not create is named ==="
+# notes.md is a tracked regular file, so notes.md/link cannot be created: the
+# mkdir and the ln both fail. Those two calls were unchecked, and fix-links
+# invokes setup on the left of || — which disables errexit inside it — so the
+# exclude update that followed supplied the exit status and the run read as
+# clean. The postcondition inspected WORKTREE_SYMLINKS only, so it said nothing
+# either.
+printf '%s\n%s\n' \
+  'WORKTREE_SYMLINKS="harness runtime"' \
+  'WORKTREE_RELATIVE_SYMLINKS="notes.md/link=../base.txt"' >"$MAIN/.env"
+run_fix_links
+if [[ "$RC" != 0 ]]; then ok "nonzero exit for a relative entry that could not be created"; else bad "nonzero exit for a relative entry that could not be created" "rc=0: $OUT"; fi
+assert_contains "$OUT" "notes.md/link" "names the relative entry"
+assert_lacks "$OUT" "Restored symlinks" "no success message for an uncreated relative entry"
+write_base_env
+
+echo "=== a link resolving somewhere other than its configured target is named ==="
+if [[ "${EUID:-$(id -u)}" == 0 ]]; then
+  echo "  skip  wrong-target case needs an unwritable directory (running as root)"
+else
+  # Point the link at the wrong target and take write permission off its
+  # parent so the pass cannot rewrite it. Without the read-only parent setup
+  # simply relinks and the state is healthy again — what is being proved is
+  # that a wrong-target link is JUDGED unhealthy, not that fix-links fails to
+  # repair one.
+  rm -f "$WT/.claude/CLAUDE.md"
+  ln -s ../notes.md "$WT/.claude/CLAUDE.md"
+  chmod a-w "$WT/.claude"
+  run_fix_links
+  chmod u+w "$WT/.claude"
+  if [[ "$RC" != 0 ]]; then ok "nonzero exit for a link with the wrong target"; else bad "nonzero exit for a link with the wrong target" "rc=0: $OUT"; fi
+  assert_contains "$OUT" ".claude/CLAUDE.md" "names the wrong-target link"
+  assert_contains "$OUT" "expected ../AGENTS.md" "states the target it expected"
+  assert_lacks "$OUT" "Restored symlinks" "no success message for a wrong-target link"
+  rm -f "$WT/.claude/CLAUDE.md"
+fi
+
+echo "=== the worktree is healthy again once nothing blocks the pass ==="
+run_fix_links
+if [[ "$RC" == 0 ]]; then ok "exit 0 after the blockers are cleared"; else bad "exit 0 after the blockers are cleared" "rc=$RC: $OUT"; fi
+assert_contains "$OUT" "Restored symlinks in $WT" "success message once every entry is healthy again"
 
 printf '\n%s passed, %s failed\n' "$PASS" "$FAIL"
 [[ "$FAIL" == 0 ]]

--- a/tools/size-ratchet-baseline.tsv
+++ b/tools/size-ratchet-baseline.tsv
@@ -126,7 +126,7 @@ skills/second-opinion/tests/cli-failure-gate.test.sh	1211
 skills/second-opinion/tests/lane-scratch-durability.test.sh	999
 skills/second-opinion/tests/review-dual-model.test.sh	1516
 skills/size-ratchet/scripts/size-ratchet	1026
-skills/worktree/scripts/worktree	4780
+skills/worktree/scripts/worktree	4788
 skills/worktree/scripts/worktree-session-guard	1197
 skills/worktree/tests/worktree_session_guard.sh	1282
 ui/src/stores/audit.ts	292

--- a/tools/size-ratchet-baseline.tsv
+++ b/tools/size-ratchet-baseline.tsv
@@ -126,7 +126,7 @@ skills/second-opinion/tests/cli-failure-gate.test.sh	1211
 skills/second-opinion/tests/lane-scratch-durability.test.sh	999
 skills/second-opinion/tests/review-dual-model.test.sh	1516
 skills/size-ratchet/scripts/size-ratchet	1026
-skills/worktree/scripts/worktree	4609
+skills/worktree/scripts/worktree	4692
 skills/worktree/scripts/worktree-session-guard	1197
 skills/worktree/tests/worktree_session_guard.sh	1282
 ui/src/stores/audit.ts	292

--- a/tools/size-ratchet-baseline.tsv
+++ b/tools/size-ratchet-baseline.tsv
@@ -126,7 +126,7 @@ skills/second-opinion/tests/cli-failure-gate.test.sh	1211
 skills/second-opinion/tests/lane-scratch-durability.test.sh	999
 skills/second-opinion/tests/review-dual-model.test.sh	1516
 skills/size-ratchet/scripts/size-ratchet	1026
-skills/worktree/scripts/worktree	4692
+skills/worktree/scripts/worktree	4780
 skills/worktree/scripts/worktree-session-guard	1197
 skills/worktree/tests/worktree_session_guard.sh	1282
 ui/src/stores/audit.ts	292


### PR DESCRIPTION
## Summary

- `worktree fix-links` printed `Restored symlinks` and exited 0 whether or not the configured paths ended up linked. Two entries survive a pass unrestored: one the quarantine refuses to overwrite because it holds data git does not track, and one with no such path in the main checkout, which setup skips outright without a word.
- Those are exactly the paths that re-trigger the sync error naming `fix-links` as its remediation — so the operator ran it, read success, ran the sync again, and got the identical refusal.
- It now judges the **result** of its own pass rather than the repair's return codes: every configured entry is re-inspected afterwards, anything still unhealthy is named, and the exit is non-zero with no success line. Checking the state covers whatever mechanism left a path behind, not only the two known ones.

## Test Plan

New `skills/worktree/tests/worktree_fix_links_unrestored.sh`, 13 assertions: a quarantined entry holding untracked data is named and the exit is non-zero; an entry with no such path in the main checkout is named rather than silently skipped; the success line appears only once every entry is healthy; a materialized child link is restored.

Every existing worktree suite stays green (`worktree_remove` 96, `worktree_restack_replay` 83, `worktree_recover_local` 73, `worktree_session_guard_lifecycle` 66, `worktree_remove_live_lease` 62, `worktree_push_rebase` 51, `worktree_path_safety` 47, and the rest). size-ratchet, catalog check and preflight all clean.

`RATCHET_RAISE=1` on the `skills/worktree/scripts/worktree` row: the added lines are the postcondition check and the help text for the contract it establishes, inside a single command dispatcher with no seam to split on.

## Completed Issues

- Closes KEN-464 - worktree fix-links reports success while leaving .cache materialized, so the sync's own remediation loops
