### PR TITLE
fix(ui): the Customize index lists hand-edited and forked packages (KEN-468)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ an outside contributor.
 
 ### Fixed
 
+- Customize › Customized packages now lists every package you changed at
+  that location, hand-edited and forked ones included, so it matches the
+  Library's "Customized in" mark instead of showing only saved settings.
 - macOS builds are Developer ID signed and notarized: installing from any
   channel no longer ends in "kendex is damaged" or an `xattr -cr` workaround.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ an outside contributor.
 
 - Customize › Customized packages now lists every package you changed at
   that location, hand-edited and forked ones included, so it matches the
-  Library's "Customized in" mark instead of showing only saved settings.
+  Library's "Customized in" mark instead of only packages with settings.
 - macOS builds are Developer ID signed and notarized: installing from any
   channel no longer ends in "kendex is damaged" or an `xattr -cr` workaround.
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -240,25 +240,18 @@ lives in one capability table read by core and UI.
   a Customize tab beside Overview — instructions, the skills an agent gets,
   per-tool settings. The Customize page keeps only what is not about one
   package (the `all` row, custom hooks, a project's skills folder) plus an
-  index of everything customized, each row opening its package.
-- Both surfaces edit one draft of one manifest per scope, in
-  `stores/editor.ts`. The Customize page reloads only when nothing is
-  unsaved; `lib/customization.ts` slices that draft per package.
-- A place is customized when its manifest overlay holds something, its
-  installed files were edited by hand, or its copy is a fork.
-  `lib/customized-places.ts::placeStandings` is the one answer to that
-  question. Three readers, no other: the Library row's mark
-  (`lib/library-standings.ts`), the package header's mark
-  (`lib/package-mark.ts`), and the Customize page's index
-  (`customizedHere`, via `lib/customized-here.ts`). Each builds its
-  `PlacesSource` through `placesSource`, never by hand. The index lists
-  every package the Library marks for the place being edited, reading the
-  open draft in place of that place's saved manifest
-  (`manifestsForEditing`) so an unsaved removal leaves the list at once.
-  It says nothing is customized only after the update read has landed
-  (`lib/updates-read-state.ts`, the same three-way answer the Updates
-  page reads): while the read is pending it says it is checking, and
-  after a failure that hand-edited and forked packages may be missing.
+  index of everything customized there, each row opening its package. Both
+  surfaces edit one draft of one manifest per scope (`stores/editor.ts`;
+  the Customize page reloads only when nothing is unsaved), and
+  `lib/customization.ts` slices that draft per package.
+- A place is customized by settings, a hand edit, or a fork, and
+  `lib/customized-places.ts::placeStandings` is the one answer, over a
+  `PlacesSource` that only `placesSource` builds. Its three readers: the
+  Library row's mark (`lib/library-standings.ts`), the package header's
+  (`lib/package-mark.ts`), and the Customize index (`lib/customized-here.ts`),
+  which reads the open draft for its place and says nothing is customized
+  only once the update read has landed (`lib/updates-read-state.ts`:
+  pending says it is checking, failed that packages may be missing).
 - Hook events have one vocabulary — Claude Code's names, in
   `core/hook.rs::EVENTS`; every other harness's map is keyed by it. The
   picker offers that list, the validator rejects anything outside it, the

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -244,6 +244,16 @@ lives in one capability table read by core and UI.
 - Both surfaces edit one draft of one manifest per scope, in
   `stores/editor.ts`. The Customize page reloads only when nothing is
   unsaved; `lib/customization.ts` slices that draft per package.
+- A place is customized when its manifest overlay holds something, its
+  installed files were edited by hand, or its copy is a fork.
+  `lib/customized-places.ts::placeStandings` is the one answer to that
+  question. Three readers, no other: the Library row's mark
+  (`lib/library-standings.ts`), the package header's mark
+  (`lib/package-mark.ts`), and the Customize page's index
+  (`customizedHere`, via `lib/customized-here.ts`). The index lists every
+  package the Library marks for the place being edited, reading the open
+  draft in place of that place's saved manifest so an unsaved removal
+  leaves the list at once.
 - Hook events have one vocabulary — Claude Code's names, in
   `core/hook.rs::EVENTS`; every other harness's map is keyed by it. The
   picker offers that list, the validator rejects anything outside it, the

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -254,9 +254,11 @@ lives in one capability table read by core and UI.
   `PlacesSource` through `placesSource`, never by hand. The index lists
   every package the Library marks for the place being edited, reading the
   open draft in place of that place's saved manifest
-  (`manifestsForEditing`) so an unsaved removal leaves the list at once;
-  when the update read failed with nothing landed it says hand-edited
-  packages cannot be listed rather than calling the place clean.
+  (`manifestsForEditing`) so an unsaved removal leaves the list at once.
+  It says nothing is customized only after the update read has landed
+  (`lib/updates-read-state.ts`, the same three-way answer the Updates
+  page reads): while the read is pending it says it is checking, and
+  after a failure that hand-edited and forked packages may be missing.
 - Hook events have one vocabulary — Claude Code's names, in
   `core/hook.rs::EVENTS`; every other harness's map is keyed by it. The
   picker offers that list, the validator rejects anything outside it, the

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -250,10 +250,13 @@ lives in one capability table read by core and UI.
   question. Three readers, no other: the Library row's mark
   (`lib/library-standings.ts`), the package header's mark
   (`lib/package-mark.ts`), and the Customize page's index
-  (`customizedHere`, via `lib/customized-here.ts`). The index lists every
-  package the Library marks for the place being edited, reading the open
-  draft in place of that place's saved manifest so an unsaved removal
-  leaves the list at once.
+  (`customizedHere`, via `lib/customized-here.ts`). Each builds its
+  `PlacesSource` through `placesSource`, never by hand. The index lists
+  every package the Library marks for the place being edited, reading the
+  open draft in place of that place's saved manifest
+  (`manifestsForEditing`) so an unsaved removal leaves the list at once;
+  when the update read failed with nothing landed it says hand-edited
+  packages cannot be listed rather than calling the place clean.
 - Hook events have one vocabulary — Claude Code's names, in
   `core/hook.rs::EVENTS`; every other harness's map is keyed by it. The
   picker offers that list, the validator rejects anything outside it, the

--- a/tools/size-ratchet-baseline.tsv
+++ b/tools/size-ratchet-baseline.tsv
@@ -7,7 +7,7 @@ crates/core/src/engine/ops/add.rs	549
 crates/core/src/error.rs	429
 crates/core/src/quality/author.rs	458
 crates/core/src/remote/store.rs	420
-docs/ARCHITECTURE.md	911
+docs/ARCHITECTURE.md	919
 hooks/block-repo-copy.sh	511
 pi-extensions/pi-agents-tmux/extensions/subagent/browser.ts	650
 pi-extensions/pi-agents-tmux/extensions/subagent/dashboard.ts	431

--- a/ui/src/components/customize/customized-index.test.tsx
+++ b/ui/src/components/customize/customized-index.test.tsx
@@ -4,12 +4,14 @@ import { createRoot, type Root } from "react-dom/client";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import type { Scope } from "@/bindings";
 import {
+  CUSTOMIZED_CHECKING,
   CUSTOMIZED_UPDATES_UNCHECKED,
   NOT_INSTALLED_HERE,
   NOTHING_CUSTOMIZED,
   REMOVE_CUSTOMIZATION,
 } from "@/lib/copy-customize";
 import type { CustomizedHere } from "@/lib/customized-places";
+import type { UpdatesReadState } from "@/lib/updates-read-state";
 import { useScanStore } from "@/stores/scan";
 import { CustomizedIndex } from "./customized-index";
 
@@ -51,7 +53,10 @@ const row = (over: Partial<CustomizedHere> = {}): CustomizedHere => ({
 // zustand store's initial snapshot, and the scan store is what says
 // whether a row's package is installed here.
 const mounted: Root[] = [];
-const render = (items: CustomizedHere[], updatesFailed = false): string => {
+const render = (
+  items: CustomizedHere[],
+  updates: UpdatesReadState = "landed",
+): string => {
   const host = document.createElement("div");
   document.body.append(host);
   const root = createRoot(host);
@@ -61,7 +66,7 @@ const render = (items: CustomizedHere[], updatesFailed = false): string => {
       <CustomizedIndex
         items={items}
         scope={VG}
-        updatesFailed={updatesFailed}
+        updates={updates}
         onRemove={() => {}}
       />,
     );
@@ -112,16 +117,23 @@ describe("CustomizedIndex", () => {
     expect(withSettings).toContain(REMOVE_CUSTOMIZATION);
   });
 
-  // With the update read failed, an empty list is not "nothing customized":
-  // the hand-edit facts never arrived. The note replaces that claim, and
-  // sits under whatever the manifest alone could list.
-  it("says hand edits cannot be listed after a failed update read", () => {
-    const empty = render([], true);
-    expect(empty).toContain(CUSTOMIZED_UPDATES_UNCHECKED);
-    expect(empty).not.toContain(NOTHING_CUSTOMIZED);
-    const some = render([row({ edited: false })], true);
+  // "Nothing yet" is a claim about the place, and the hand-edit facts it
+  // rests on arrive with the update read. Before that read lands the list
+  // is the manifest's alone, so the section says it is checking; after a
+  // failure, that packages may be missing. Either note sits under
+  // whatever the manifest alone could list.
+  it("claims nothing is customized only after the update read lands", () => {
+    const pending = render([], "pending");
+    expect(pending).toContain(CUSTOMIZED_CHECKING);
+    expect(pending).not.toContain(NOTHING_CUSTOMIZED);
+    const failed = render([], "failed");
+    expect(failed).toContain(CUSTOMIZED_UPDATES_UNCHECKED);
+    expect(failed).not.toContain(NOTHING_CUSTOMIZED);
+    const some = render([row({ edited: false })], "failed");
     expect(some).toContain("gh");
     expect(some).toContain(CUSTOMIZED_UPDATES_UNCHECKED);
-    expect(render([], false)).toContain(NOTHING_CUSTOMIZED);
+    const landed = render([], "landed");
+    expect(landed).toContain(NOTHING_CUSTOMIZED);
+    expect(landed).not.toContain(CUSTOMIZED_CHECKING);
   });
 });

--- a/ui/src/components/customize/customized-index.test.tsx
+++ b/ui/src/components/customize/customized-index.test.tsx
@@ -1,0 +1,103 @@
+// @vitest-environment jsdom
+import { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import type { Scope } from "@/bindings";
+import { NOT_INSTALLED_HERE, REMOVE_CUSTOMIZATION } from "@/lib/copy-customize";
+import type { CustomizedHere } from "@/lib/customized-places";
+import { useScanStore } from "@/stores/scan";
+import { CustomizedIndex } from "./customized-index";
+
+(
+  globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }
+).IS_REACT_ACT_ENVIRONMENT = true;
+
+const VG: Scope = { scope: "project", root: "/work/vg" };
+
+const installed = (scope: Scope) => ({
+  kind: "skill",
+  name: "gh",
+  scope,
+  harness: "claude",
+  path: "/work/vg/.claude/skills/gh",
+  fileState: "file",
+  enabled: true,
+  origin: null,
+  description: "about gh",
+  tags: [],
+});
+
+const row = (over: Partial<CustomizedHere> = {}): CustomizedHere => ({
+  kind: "skill",
+  name: "gh",
+  why: "edited",
+  customization: {
+    launch: null,
+    additional: null,
+    instructions: null,
+    skills: null,
+    frontmatter: [],
+  },
+  ...over,
+});
+
+// Mounted rather than rendered to a string: a static render reads a
+// zustand store's initial snapshot, and the scan store is what says
+// whether a row's package is installed here.
+const mounted: Root[] = [];
+const render = (items: CustomizedHere[]): string => {
+  const host = document.createElement("div");
+  document.body.append(host);
+  const root = createRoot(host);
+  mounted.push(root);
+  act(() => {
+    root.render(
+      <CustomizedIndex items={items} scope={VG} onRemove={() => {}} />,
+    );
+  });
+  return host.innerHTML;
+};
+
+afterEach(() => {
+  act(() => {
+    for (const root of mounted) root.unmount();
+  });
+  mounted.length = 0;
+  document.body.replaceChildren();
+});
+
+describe("CustomizedIndex", () => {
+  beforeEach(() => {
+    useScanStore.setState({
+      result: {
+        harnesses: [],
+        items: [installed(VG)],
+        missingProjects: [],
+        warnings: [],
+      } as never,
+    });
+  });
+
+  it("says how a hand-edited package was customized and opens it", () => {
+    const html = render([row()]);
+    expect(html).toContain("Skill · Edited by you");
+    expect(html).toContain("Open");
+    expect(html).not.toContain(NOT_INSTALLED_HERE);
+  });
+
+  // Remove clears the settings overlay and nothing else, so a row with no
+  // settings to clear does not offer it.
+  it("offers Remove only where settings exist to remove", () => {
+    useScanStore.setState({ result: null });
+    const bare = render([row({ why: "forked" })]);
+    expect(bare).toContain(NOT_INSTALLED_HERE);
+    expect(bare).not.toContain(REMOVE_CUSTOMIZATION);
+    const withSettings = render([
+      row({
+        why: "settings",
+        customization: { ...row().customization, instructions: "x" },
+      }),
+    ]);
+    expect(withSettings).toContain(REMOVE_CUSTOMIZATION);
+  });
+});

--- a/ui/src/components/customize/customized-index.test.tsx
+++ b/ui/src/components/customize/customized-index.test.tsx
@@ -3,7 +3,12 @@ import { act } from "react";
 import { createRoot, type Root } from "react-dom/client";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import type { Scope } from "@/bindings";
-import { NOT_INSTALLED_HERE, REMOVE_CUSTOMIZATION } from "@/lib/copy-customize";
+import {
+  CUSTOMIZED_UPDATES_UNCHECKED,
+  NOT_INSTALLED_HERE,
+  NOTHING_CUSTOMIZED,
+  REMOVE_CUSTOMIZATION,
+} from "@/lib/copy-customize";
 import type { CustomizedHere } from "@/lib/customized-places";
 import { useScanStore } from "@/stores/scan";
 import { CustomizedIndex } from "./customized-index";
@@ -30,7 +35,8 @@ const installed = (scope: Scope) => ({
 const row = (over: Partial<CustomizedHere> = {}): CustomizedHere => ({
   kind: "skill",
   name: "gh",
-  why: "edited",
+  edited: true,
+  forked: false,
   customization: {
     launch: null,
     additional: null,
@@ -45,14 +51,19 @@ const row = (over: Partial<CustomizedHere> = {}): CustomizedHere => ({
 // zustand store's initial snapshot, and the scan store is what says
 // whether a row's package is installed here.
 const mounted: Root[] = [];
-const render = (items: CustomizedHere[]): string => {
+const render = (items: CustomizedHere[], updatesFailed = false): string => {
   const host = document.createElement("div");
   document.body.append(host);
   const root = createRoot(host);
   mounted.push(root);
   act(() => {
     root.render(
-      <CustomizedIndex items={items} scope={VG} onRemove={() => {}} />,
+      <CustomizedIndex
+        items={items}
+        scope={VG}
+        updatesFailed={updatesFailed}
+        onRemove={() => {}}
+      />,
     );
   });
   return host.innerHTML;
@@ -89,15 +100,28 @@ describe("CustomizedIndex", () => {
   // settings to clear does not offer it.
   it("offers Remove only where settings exist to remove", () => {
     useScanStore.setState({ result: null });
-    const bare = render([row({ why: "forked" })]);
+    const bare = render([row({ edited: false, forked: true })]);
     expect(bare).toContain(NOT_INSTALLED_HERE);
     expect(bare).not.toContain(REMOVE_CUSTOMIZATION);
     const withSettings = render([
       row({
-        why: "settings",
+        edited: false,
         customization: { ...row().customization, instructions: "x" },
       }),
     ]);
     expect(withSettings).toContain(REMOVE_CUSTOMIZATION);
+  });
+
+  // With the update read failed, an empty list is not "nothing customized":
+  // the hand-edit facts never arrived. The note replaces that claim, and
+  // sits under whatever the manifest alone could list.
+  it("says hand edits cannot be listed after a failed update read", () => {
+    const empty = render([], true);
+    expect(empty).toContain(CUSTOMIZED_UPDATES_UNCHECKED);
+    expect(empty).not.toContain(NOTHING_CUSTOMIZED);
+    const some = render([row({ edited: false })], true);
+    expect(some).toContain("gh");
+    expect(some).toContain(CUSTOMIZED_UPDATES_UNCHECKED);
+    expect(render([], false)).toContain(NOTHING_CUSTOMIZED);
   });
 });

--- a/ui/src/components/customize/customized-index.tsx
+++ b/ui/src/components/customize/customized-index.tsx
@@ -1,7 +1,9 @@
 import { ChevronRight } from "lucide-react";
 import type { ItemKind, Scope } from "@/bindings";
+import { DotSpinner } from "@/components/loading";
 import { Button } from "@/components/ui/button";
 import {
+  CUSTOMIZED_CHECKING,
   CUSTOMIZED_UPDATES_UNCHECKED,
   customizedLine,
   NOT_INSTALLED_HERE,
@@ -13,6 +15,7 @@ import type { CustomizedHere } from "@/lib/customized-places";
 import { kindIcon } from "@/lib/kind-icon";
 import { kindLabel } from "@/lib/labels";
 import { sameScope } from "@/lib/scope";
+import type { UpdatesReadState } from "@/lib/updates-read-state";
 import { useNavStore } from "@/stores/nav";
 import { useScanStore } from "@/stores/scan";
 
@@ -23,15 +26,17 @@ import { useScanStore } from "@/stores/scan";
 export function CustomizedIndex({
   items,
   scope,
-  updatesFailed,
+  updates,
   onRemove,
 }: {
   items: CustomizedHere[];
   scope: Scope;
-  /** The update read failed with nothing landed. Hand edits are read from
-   *  it, so a package missing here may be missing for that reason, and
-   *  the section says so rather than calling the place clean. */
-  updatesFailed: boolean;
+  /** Hand edits, and forks the manifest does not yet record, are read
+   *  from the update rows. Until that read lands the list is the
+   *  manifest's alone, so "nothing customized" is said only after it has;
+   *  before, the section says it is checking, and after a failure that
+   *  packages may be missing. */
+  updates: UpdatesReadState;
   onRemove: (kind: ItemKind, name: string) => void;
 }) {
   const goToPackage = useNavStore((s) => s.goToPackage);
@@ -39,15 +44,21 @@ export function CustomizedIndex({
   // is a new snapshot every render, and React re-renders until it is not.
   const installed = useScanStore((s) => s.result)?.items ?? [];
 
-  const unchecked = updatesFailed ? (
-    <p className="pt-1 text-sm text-muted-foreground">
-      {CUSTOMIZED_UPDATES_UNCHECKED}
-    </p>
-  ) : null;
+  const note =
+    updates === "pending" ? (
+      <p className="flex items-center gap-2 pt-1 text-sm text-muted-foreground">
+        <DotSpinner />
+        {CUSTOMIZED_CHECKING}
+      </p>
+    ) : updates === "failed" ? (
+      <p className="pt-1 text-sm text-muted-foreground">
+        {CUSTOMIZED_UPDATES_UNCHECKED}
+      </p>
+    ) : null;
 
   if (items.length === 0) {
     return (
-      unchecked ?? (
+      note ?? (
         <p className="pt-1 text-sm text-muted-foreground">
           {NOTHING_CUSTOMIZED}
         </p>
@@ -105,7 +116,7 @@ export function CustomizedIndex({
           </div>
         );
       })}
-      {unchecked}
+      {note}
     </div>
   );
 }

--- a/ui/src/components/customize/customized-index.tsx
+++ b/ui/src/components/customize/customized-index.tsx
@@ -2,6 +2,7 @@ import { ChevronRight } from "lucide-react";
 import type { ItemKind, Scope } from "@/bindings";
 import { Button } from "@/components/ui/button";
 import {
+  CUSTOMIZED_UPDATES_UNCHECKED,
   customizedLine,
   NOT_INSTALLED_HERE,
   NOTHING_CUSTOMIZED,
@@ -22,10 +23,15 @@ import { useScanStore } from "@/stores/scan";
 export function CustomizedIndex({
   items,
   scope,
+  updatesFailed,
   onRemove,
 }: {
   items: CustomizedHere[];
   scope: Scope;
+  /** The update read failed with nothing landed. Hand edits are read from
+   *  it, so a package missing here may be missing for that reason, and
+   *  the section says so rather than calling the place clean. */
+  updatesFailed: boolean;
   onRemove: (kind: ItemKind, name: string) => void;
 }) {
   const goToPackage = useNavStore((s) => s.goToPackage);
@@ -33,15 +39,25 @@ export function CustomizedIndex({
   // is a new snapshot every render, and React re-renders until it is not.
   const installed = useScanStore((s) => s.result)?.items ?? [];
 
+  const unchecked = updatesFailed ? (
+    <p className="pt-1 text-sm text-muted-foreground">
+      {CUSTOMIZED_UPDATES_UNCHECKED}
+    </p>
+  ) : null;
+
   if (items.length === 0) {
     return (
-      <p className="pt-1 text-sm text-muted-foreground">{NOTHING_CUSTOMIZED}</p>
+      unchecked ?? (
+        <p className="pt-1 text-sm text-muted-foreground">
+          {NOTHING_CUSTOMIZED}
+        </p>
+      )
     );
   }
 
   return (
     <div className="flex flex-col divide-y">
-      {items.map(({ kind, name, why, customization }) => {
+      {items.map(({ kind, name, edited, forked, customization }) => {
         const Icon = kindIcon(kind);
         // Installed *here*: a row that opened a page for another scope's
         // copy would show version and files that belong to somewhere else.
@@ -57,7 +73,8 @@ export function CustomizedIndex({
             <div className="min-w-0 flex-1">
               <p className="truncate text-sm font-medium">{name}</p>
               <p className="truncate text-[13px] text-muted-foreground">
-                {kindLabel(kind)} · {customizedLine(why, customization)}
+                {kindLabel(kind)} ·{" "}
+                {customizedLine({ edited, forked }, customization)}
               </p>
             </div>
             {here ? (
@@ -88,6 +105,7 @@ export function CustomizedIndex({
           </div>
         );
       })}
+      {unchecked}
     </div>
   );
 }

--- a/ui/src/components/customize/customized-index.tsx
+++ b/ui/src/components/customize/customized-index.tsx
@@ -2,32 +2,36 @@ import { ChevronRight } from "lucide-react";
 import type { ItemKind, Scope } from "@/bindings";
 import { Button } from "@/components/ui/button";
 import {
-  customizationSummary,
+  customizedLine,
   NOT_INSTALLED_HERE,
   NOTHING_CUSTOMIZED,
   REMOVE_CUSTOMIZATION,
 } from "@/lib/copy-customize";
-import type { CustomizedItem } from "@/lib/customization";
+import { isCustomized } from "@/lib/customization";
+import type { CustomizedHere } from "@/lib/customized-places";
 import { kindIcon } from "@/lib/kind-icon";
 import { kindLabel } from "@/lib/labels";
 import { sameScope } from "@/lib/scope";
 import { useNavStore } from "@/stores/nav";
 import { useScanStore } from "@/stores/scan";
 
-/** Every package customized at this scope. A row opens that package's own
- *  page, which is where its edits are made; a row for something no longer
- *  installed can only be dropped, since there is no page to open. */
+/** Every package customized at this scope: settings, a hand edit, or a
+ *  fork. A row opens that package's own page, which is where its edits are
+ *  made; a row for something no longer installed has no page to open, so
+ *  it offers only to drop the settings, where there are any to drop. */
 export function CustomizedIndex({
   items,
   scope,
   onRemove,
 }: {
-  items: CustomizedItem[];
+  items: CustomizedHere[];
   scope: Scope;
   onRemove: (kind: ItemKind, name: string) => void;
 }) {
   const goToPackage = useNavStore((s) => s.goToPackage);
-  const installed = useScanStore((s) => s.result?.items ?? []);
+  // Selects the result, not a fallback array: a fresh `[]` from a selector
+  // is a new snapshot every render, and React re-renders until it is not.
+  const installed = useScanStore((s) => s.result)?.items ?? [];
 
   if (items.length === 0) {
     return (
@@ -37,7 +41,7 @@ export function CustomizedIndex({
 
   return (
     <div className="flex flex-col divide-y">
-      {items.map(({ kind, name, customization }) => {
+      {items.map(({ kind, name, why, customization }) => {
         const Icon = kindIcon(kind);
         // Installed *here*: a row that opened a page for another scope's
         // copy would show version and files that belong to somewhere else.
@@ -53,7 +57,7 @@ export function CustomizedIndex({
             <div className="min-w-0 flex-1">
               <p className="truncate text-sm font-medium">{name}</p>
               <p className="truncate text-[13px] text-muted-foreground">
-                {kindLabel(kind)} · {customizationSummary(customization)}
+                {kindLabel(kind)} · {customizedLine(why, customization)}
               </p>
             </div>
             {here ? (
@@ -70,13 +74,15 @@ export function CustomizedIndex({
                 <span className="text-[13px] text-muted-foreground">
                   {NOT_INSTALLED_HERE}
                 </span>
-                <Button
-                  variant="ghost"
-                  size="sm"
-                  onClick={() => onRemove(kind, name)}
-                >
-                  {REMOVE_CUSTOMIZATION}
-                </Button>
+                {isCustomized(customization) ? (
+                  <Button
+                    variant="ghost"
+                    size="sm"
+                    onClick={() => onRemove(kind, name)}
+                  >
+                    {REMOVE_CUSTOMIZATION}
+                  </Button>
+                ) : null}
               </>
             )}
           </div>

--- a/ui/src/components/updates-before-list.tsx
+++ b/ui/src/components/updates-before-list.tsx
@@ -10,6 +10,7 @@ import {
   UPDATES_EMPTY_BODY,
 } from "@/lib/copy";
 import { UPDATES_CHECKING } from "@/lib/copy-updates";
+import { updatesReadState } from "@/lib/updates-read-state";
 
 /** What the Updates page shows while there is no list to show, or null
  *  once there is one. Three different answers that must never blur: a
@@ -37,7 +38,8 @@ export function updatesBeforeList({
   // Before the first read answers there is nothing to report either way —
   // "Everything is up to date" here would assert an up-to-dateness nobody
   // has checked yet.
-  if (!loaded && error === null) {
+  const state = updatesReadState({ loaded, error });
+  if (state === "pending") {
     return (
       <div className="flex min-h-full items-center justify-center">
         <p className="flex items-center gap-2 text-sm text-muted-foreground">
@@ -50,7 +52,7 @@ export function updatesBeforeList({
   // A read that failed with nothing kept from a better one: the page says
   // so and offers the retry — the same claim Home's attention row makes,
   // answered here where the row sends people.
-  if (error !== null && empty) {
+  if (state === "failed" && empty) {
     return (
       <div className="flex min-h-full items-center justify-center">
         <EmptyState

--- a/ui/src/lib/copy-customize.test.ts
+++ b/ui/src/lib/copy-customize.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 import type { HookDelivery } from "@/bindings";
-import { hookDeliverySummary } from "@/lib/copy-customize";
+import { customizedLine, hookDeliverySummary } from "@/lib/copy-customize";
+import type { ItemCustomization } from "@/lib/customization";
 
 // The line under a hook is built from delivery rows the engine computed —
 // these tests pin the composition, so no string literal in the UI can
@@ -36,5 +37,31 @@ describe("hookDeliverySummary", () => {
 
   it("says nothing for an empty set", () => {
     expect(hookDeliverySummary([])).toBe("");
+  });
+});
+
+describe("customizedLine", () => {
+  const nothing: ItemCustomization = {
+    launch: null,
+    additional: null,
+    instructions: null,
+    skills: null,
+    frontmatter: [],
+  };
+
+  it("names a hand edit on its own", () => {
+    expect(customizedLine("edited", nothing)).toBe("Edited by you");
+  });
+
+  it("names a fork and the settings set on top of it", () => {
+    expect(customizedLine("forked", { ...nothing, instructions: "x" })).toBe(
+      "Forked · Extra instructions",
+    );
+  });
+
+  it("lists only the settings for a settings row", () => {
+    expect(customizedLine("settings", { ...nothing, launch: "x" })).toBe(
+      "Launch instructions",
+    );
   });
 });

--- a/ui/src/lib/copy-customize.test.ts
+++ b/ui/src/lib/copy-customize.test.ts
@@ -49,19 +49,27 @@ describe("customizedLine", () => {
     frontmatter: [],
   };
 
+  const facts = (edited: boolean, forked: boolean) => ({ edited, forked });
+
   it("names a hand edit on its own", () => {
-    expect(customizedLine("edited", nothing)).toBe("Edited by you");
+    expect(customizedLine(facts(true, false), nothing)).toBe("Edited by you");
   });
 
   it("names a fork and the settings set on top of it", () => {
-    expect(customizedLine("forked", { ...nothing, instructions: "x" })).toBe(
-      "Forked · Extra instructions",
+    expect(
+      customizedLine(facts(false, true), { ...nothing, instructions: "x" }),
+    ).toBe("Forked · Extra instructions");
+  });
+
+  it("names a fork edited since, then its settings", () => {
+    expect(customizedLine(facts(true, true), { ...nothing, launch: "x" })).toBe(
+      "Forked · Edited by you · Launch instructions",
     );
   });
 
   it("lists only the settings for a settings row", () => {
-    expect(customizedLine("settings", { ...nothing, launch: "x" })).toBe(
-      "Launch instructions",
-    );
+    expect(
+      customizedLine(facts(false, false), { ...nothing, launch: "x" }),
+    ).toBe("Launch instructions");
   });
 });

--- a/ui/src/lib/copy-customize.ts
+++ b/ui/src/lib/copy-customize.ts
@@ -1,7 +1,7 @@
 import type { HookDelivery } from "@/bindings";
 import { EDITED_UPDATE_TAG, FORKED_BADGE_LABEL } from "@/lib/copy";
 import type { ItemCustomization } from "@/lib/customization";
-import type { Why } from "@/lib/customized-places";
+import type { CustomizedHere } from "@/lib/customized-places";
 import type { GroupStatus } from "@/lib/derive";
 import { harnessName } from "@/lib/labels";
 
@@ -101,6 +101,8 @@ export const CUSTOMIZED_SECTION_HELP =
 export const NOTHING_CUSTOMIZED =
   "Nothing yet — open a package from the Library to customize it.";
 export const NOT_INSTALLED_HERE = "Not installed here";
+export const CUSTOMIZED_UPDATES_UNCHECKED =
+  "Packages edited by hand aren't listed: the check for updates failed. Try it again from Updates.";
 export const REMOVE_CUSTOMIZATION = "Remove";
 
 // What a package's row is marked with, in the Library's legend and on it.
@@ -130,12 +132,15 @@ export function customizationSummary(one: ItemCustomization): string {
 }
 
 /** The line under an index row: how this place made the package its own.
- *  A hand edit or a fork is named as such, with any settings set on top of
- *  it after; a settings-only row lists just those. */
-export function customizedLine(why: Why, one: ItemCustomization): string {
+ *  A fork and a hand edit are each named when they hold, then whatever
+ *  settings sit on top; a settings-only row lists just those. */
+export function customizedLine(
+  facts: Pick<CustomizedHere, "edited" | "forked">,
+  one: ItemCustomization,
+): string {
   const parts: string[] = [];
-  if (why === "edited") parts.push(EDITED_UPDATE_TAG);
-  if (why === "forked") parts.push(FORKED_BADGE_LABEL);
+  if (facts.forked) parts.push(FORKED_BADGE_LABEL);
+  if (facts.edited) parts.push(EDITED_UPDATE_TAG);
   const settings = customizationSummary(one);
   if (settings) parts.push(settings);
   return parts.join(" · ");

--- a/ui/src/lib/copy-customize.ts
+++ b/ui/src/lib/copy-customize.ts
@@ -101,8 +101,9 @@ export const CUSTOMIZED_SECTION_HELP =
 export const NOTHING_CUSTOMIZED =
   "Nothing yet — open a package from the Library to customize it.";
 export const NOT_INSTALLED_HERE = "Not installed here";
+export const CUSTOMIZED_CHECKING = "Checking for hand edits and forks…";
 export const CUSTOMIZED_UPDATES_UNCHECKED =
-  "Packages edited by hand aren't listed: the check for updates failed. Try it again from Updates.";
+  "Hand-edited and forked packages may be missing: the check for updates failed. Try it again from Updates.";
 export const REMOVE_CUSTOMIZATION = "Remove";
 
 // What a package's row is marked with, in the Library's legend and on it.

--- a/ui/src/lib/copy-customize.ts
+++ b/ui/src/lib/copy-customize.ts
@@ -1,5 +1,7 @@
 import type { HookDelivery } from "@/bindings";
+import { EDITED_UPDATE_TAG, FORKED_BADGE_LABEL } from "@/lib/copy";
 import type { ItemCustomization } from "@/lib/customization";
+import type { Why } from "@/lib/customized-places";
 import type { GroupStatus } from "@/lib/derive";
 import { harnessName } from "@/lib/labels";
 
@@ -124,5 +126,17 @@ export function customizationSummary(one: ItemCustomization): string {
   for (const [harness] of one.frontmatter) {
     parts.push(`${harnessName(harness)} settings`);
   }
+  return parts.join(" · ");
+}
+
+/** The line under an index row: how this place made the package its own.
+ *  A hand edit or a fork is named as such, with any settings set on top of
+ *  it after; a settings-only row lists just those. */
+export function customizedLine(why: Why, one: ItemCustomization): string {
+  const parts: string[] = [];
+  if (why === "edited") parts.push(EDITED_UPDATE_TAG);
+  if (why === "forked") parts.push(FORKED_BADGE_LABEL);
+  const settings = customizationSummary(one);
+  if (settings) parts.push(settings);
   return parts.join(" · ");
 }

--- a/ui/src/lib/customized-here.ts
+++ b/ui/src/lib/customized-here.ts
@@ -3,20 +3,16 @@ import type { Scope } from "@/bindings";
 import {
   type CustomizedHere,
   customizedHere,
-  indexCustomized,
-  indexRows,
+  manifestsForEditing,
+  placesSource,
 } from "@/lib/customized-places";
 import type { Draft } from "@/lib/editor-draft";
-import { scopeKey } from "@/lib/scope";
 import { useEditorStore } from "@/stores/editor";
 import { useUpdatesStore } from "@/stores/updates";
 
-/** The Customize page's index for the place it is editing.
- *
- *  The open draft stands in for that place's saved manifest: a setting
- *  removed here and not yet saved leaves the list at once, as the Remove
- *  control promises, and one typed on a package's own page joins it. Hand
- *  edits and forks are read from the same rows the Library reads. */
+/** The Customize page's index for the place it is editing: the open draft
+ *  for settings, the same update rows the Library reads for hand edits
+ *  and forks. */
 export function useCustomizedHere(
   draft: Draft | null,
   scope: Scope,
@@ -24,16 +20,16 @@ export function useCustomizedHere(
   const saved = useEditorStore((s) => s.saved);
   const rows = useUpdatesStore((s) => s.rows);
   const updatesLoaded = useUpdatesStore((s) => s.loaded);
-  return useMemo(() => {
-    const manifests = draft ? { ...saved, [scopeKey(scope)]: draft } : saved;
-    return customizedHere(
-      {
-        manifests,
-        rows: indexRows(rows),
-        updatesLoaded,
-        settings: indexCustomized(manifests),
-      },
-      scope,
-    );
-  }, [draft, saved, rows, updatesLoaded, scope]);
+  return useMemo(
+    () =>
+      customizedHere(
+        placesSource(
+          manifestsForEditing(saved, draft, scope),
+          rows,
+          updatesLoaded,
+        ),
+        scope,
+      ),
+    [draft, saved, rows, updatesLoaded, scope],
+  );
 }

--- a/ui/src/lib/customized-here.ts
+++ b/ui/src/lib/customized-here.ts
@@ -1,0 +1,39 @@
+import { useMemo } from "react";
+import type { Scope } from "@/bindings";
+import {
+  type CustomizedHere,
+  customizedHere,
+  indexCustomized,
+  indexRows,
+} from "@/lib/customized-places";
+import type { Draft } from "@/lib/editor-draft";
+import { scopeKey } from "@/lib/scope";
+import { useEditorStore } from "@/stores/editor";
+import { useUpdatesStore } from "@/stores/updates";
+
+/** The Customize page's index for the place it is editing.
+ *
+ *  The open draft stands in for that place's saved manifest: a setting
+ *  removed here and not yet saved leaves the list at once, as the Remove
+ *  control promises, and one typed on a package's own page joins it. Hand
+ *  edits and forks are read from the same rows the Library reads. */
+export function useCustomizedHere(
+  draft: Draft | null,
+  scope: Scope,
+): CustomizedHere[] {
+  const saved = useEditorStore((s) => s.saved);
+  const rows = useUpdatesStore((s) => s.rows);
+  const updatesLoaded = useUpdatesStore((s) => s.loaded);
+  return useMemo(() => {
+    const manifests = draft ? { ...saved, [scopeKey(scope)]: draft } : saved;
+    return customizedHere(
+      {
+        manifests,
+        rows: indexRows(rows),
+        updatesLoaded,
+        settings: indexCustomized(manifests),
+      },
+      scope,
+    );
+  }, [draft, saved, rows, updatesLoaded, scope]);
+}

--- a/ui/src/lib/customized-places.test.ts
+++ b/ui/src/lib/customized-places.test.ts
@@ -98,6 +98,18 @@ describe("placeStandings", () => {
     expect(only.why).toBe("forked");
   });
 
+  // The Library's Forked badge reads `why`, and a fork with an instruction
+  // typed on top is still a fork: settings must not outrank it.
+  it("says forked over settings when both hold", () => {
+    const forkedWithSetting: Draft = {
+      ...withSetting(),
+      forks: { skill: { gh: { source: "local", "forked-at": "2026-01-01" } } },
+    };
+    const s = source({ manifests: { "/work/vg": forkedWithSetting } });
+    const [only] = placeStandings(s, "skill", "gh", [VG]);
+    expect(only.why).toBe("forked");
+  });
+
   // A place the app never read must not be reported as the author wrote
   // it: not knowing and knowing it is clean are different answers.
   it("leaves a place whose manifest was never read unknown", () => {
@@ -226,18 +238,24 @@ describe("customizedHere", () => {
 
   // Before the update read lands, a hand edit is not a fact anyone holds;
   // the list is the manifest's until it does, never a guess.
-  it("holds a hand edit back until the update read has landed", () => {
+  // A row's fork fact is held back the same way: rows kept from before a
+  // failed re-read are last-known, and a fork discarded since would still
+  // be on them.
+  it("holds a hand edit and a row's fork back until the update read has landed", () => {
     const s = source({
       manifests: { "/work/vg": withSetting() },
       rows: [
         row(VG, { blockedByLocalEdit: true }),
         row(VG, { kind: "agent", name: "orch", blockedByLocalEdit: true }),
+        row(VG, { name: "zed", forked: true }),
       ],
       updatesLoaded: false,
     });
     expect(customizedHere(s, VG)).toMatchObject([
       { kind: "skill", name: "gh", edited: false },
     ]);
+    const [zed] = placeStandings(s, "skill", "zed", [VG]);
+    expect(zed.standing).toBe("unknown");
   });
 
   it("orders agents before skills, each by name", () => {

--- a/ui/src/lib/customized-places.test.ts
+++ b/ui/src/lib/customized-places.test.ts
@@ -1,7 +1,9 @@
 import { describe, expect, it } from "vitest";
 import type { Scope, UpdateRow } from "@/bindings";
 import type { Draft } from "@/lib/editor-draft";
+import { libraryMark } from "@/lib/place-marks";
 import {
+  customizedHere,
   indexCustomized,
   indexRows,
   type PlacesSource,
@@ -129,5 +131,85 @@ describe("placeStandings", () => {
     const [only] = placeStandings(s, "skill", "gh", [VG]);
     expect(only.standing).toBe("customized");
     expect(only.why).toBe("forked");
+  });
+});
+
+describe("customizedHere", () => {
+  // The Library marks a hand-edited package "Customized in vg"; the page
+  // headed "Customized packages" for vg has to list it, or the mark leads
+  // to a page that denies it.
+  it("lists a hand-edit-only package the Library row marks", () => {
+    const s = source({
+      manifests: { "/work/vg": empty() },
+      rows: indexRows([row(VG, { blockedByLocalEdit: true })]),
+    });
+    expect(libraryMark(placeStandings(s, "skill", "gh", [VG]))?.label).toBe(
+      "Customized in vg",
+    );
+    expect(customizedHere(s, VG)).toMatchObject([
+      { kind: "skill", name: "gh", why: "edited" },
+    ]);
+  });
+
+  it("lists a fork recorded in the manifest, with its settings", () => {
+    const manifest: Draft = {
+      ...withSetting(),
+      forks: { skill: { gh: { source: "cat", repo: "o/r" } as never } },
+    };
+    const s = source({ manifests: { "/work/vg": manifest } });
+    expect(customizedHere(s, VG)).toMatchObject([
+      {
+        kind: "skill",
+        name: "gh",
+        why: "forked",
+        customization: { instructions: "mine" },
+      },
+    ]);
+  });
+
+  it("lists a settings-only package with what was set", () => {
+    const s = source({ manifests: { "/work/vg": withSetting() } });
+    expect(customizedHere(s, VG)).toMatchObject([
+      { kind: "skill", name: "gh", why: "settings" },
+    ]);
+  });
+
+  it("leaves out stock rows and other places' settings", () => {
+    const s = source({
+      manifests: { "/work/vg": empty(), "/work/hyprtrade": withSetting() },
+      rows: indexRows([row(VG), row(HYPR, { blockedByLocalEdit: true })]),
+    });
+    expect(customizedHere(s, VG)).toEqual([]);
+  });
+
+  // Before the update read lands, a hand edit is not a fact anyone holds;
+  // the list is the manifest's until it does, never a guess.
+  it("holds a hand edit back until the update read has landed", () => {
+    const s = source({
+      manifests: { "/work/vg": withSetting() },
+      rows: indexRows([
+        row(VG, { blockedByLocalEdit: true }),
+        row(VG, { kind: "agent", name: "orch", blockedByLocalEdit: true }),
+      ]),
+      updatesLoaded: false,
+    });
+    expect(customizedHere(s, VG)).toMatchObject([
+      { kind: "skill", name: "gh", why: "settings" },
+    ]);
+  });
+
+  it("orders agents before skills, each by name", () => {
+    const s = source({
+      manifests: { "/work/vg": withSetting() },
+      rows: indexRows([
+        row(VG, { name: "zed", blockedByLocalEdit: true }),
+        row(VG, { kind: "agent", name: "orch", forked: true }),
+      ]),
+    });
+    expect(customizedHere(s, VG).map((r) => `${r.kind}:${r.name}`)).toEqual([
+      "agent:orch",
+      "skill:gh",
+      "skill:zed",
+    ]);
   });
 });

--- a/ui/src/lib/customized-places.test.ts
+++ b/ui/src/lib/customized-places.test.ts
@@ -1,13 +1,13 @@
 import { describe, expect, it } from "vitest";
 import type { Scope, UpdateRow } from "@/bindings";
+import { customizedLine } from "@/lib/copy-customize";
 import type { Draft } from "@/lib/editor-draft";
 import { libraryMark } from "@/lib/place-marks";
 import {
   customizedHere,
-  indexCustomized,
-  indexRows,
-  type PlacesSource,
+  manifestsForEditing,
   placeStandings,
+  placesSource,
 } from "./customized-places";
 
 const GLOBAL: Scope = { scope: "global" };
@@ -45,15 +45,16 @@ function row(scope: Scope, over: Partial<UpdateRow> = {}): UpdateRow {
   } as UpdateRow;
 }
 
-function source(over: Partial<PlacesSource> = {}): PlacesSource {
-  const manifests = over.manifests ?? {};
-  return {
-    manifests,
-    rows: new Map(),
-    updatesLoaded: true,
-    settings: indexCustomized(manifests),
-    ...over,
-  };
+function source({
+  manifests = {},
+  rows = [],
+  updatesLoaded = true,
+}: {
+  manifests?: Record<string, Draft>;
+  rows?: UpdateRow[];
+  updatesLoaded?: boolean;
+} = {}) {
+  return placesSource(manifests, rows, updatesLoaded);
 }
 
 describe("placeStandings", () => {
@@ -64,7 +65,7 @@ describe("placeStandings", () => {
         "/work/vg": withSetting(),
         "/work/hyprtrade": empty(),
       },
-      rows: indexRows([row(GLOBAL), row(VG), row(HYPR)]),
+      rows: [row(GLOBAL), row(VG), row(HYPR)],
     });
     const got = placeStandings(s, "skill", "gh", [GLOBAL, VG, HYPR]);
     expect(got.map((p) => p.standing)).toEqual([
@@ -78,7 +79,7 @@ describe("placeStandings", () => {
   it("counts a hand-edited place even when nothing is out of date", () => {
     const s = source({
       manifests: { "/work/vg": empty() },
-      rows: indexRows([row(VG, { blockedByLocalEdit: true })]),
+      rows: [row(VG, { blockedByLocalEdit: true })],
     });
     const [only] = placeStandings(s, "skill", "gh", [VG]);
     expect(only.standing).toBe("customized");
@@ -100,13 +101,13 @@ describe("placeStandings", () => {
   // A place the app never read must not be reported as the author wrote
   // it: not knowing and knowing it is clean are different answers.
   it("leaves a place whose manifest was never read unknown", () => {
-    const s = source({ manifests: {}, rows: indexRows([row(VG)]) });
+    const s = source({ manifests: {}, rows: [row(VG)] });
     const [only] = placeStandings(s, "skill", "gh", [VG]);
     expect(only.standing).toBe("unknown");
   });
 
   it("leaves a local-source place unknown: the engine has no row for it", () => {
-    const s = source({ manifests: { "/work/vg": empty() }, rows: new Map() });
+    const s = source({ manifests: { "/work/vg": empty() }, rows: [] });
     const [only] = placeStandings(s, "skill", "gh", [VG]);
     expect(only.standing).toBe("unknown");
   });
@@ -114,7 +115,7 @@ describe("placeStandings", () => {
   it("does not call a place stock before the update read has landed", () => {
     const s = source({
       manifests: { "/work/vg": empty() },
-      rows: new Map(),
+      rows: [],
       updatesLoaded: false,
     });
     const [only] = placeStandings(s, "skill", "gh", [VG]);
@@ -126,7 +127,7 @@ describe("placeStandings", () => {
   it("takes a fork the row knows about but the saved manifest predates", () => {
     const s = source({
       manifests: { "/work/vg": empty() },
-      rows: indexRows([row(VG, { forked: true })]),
+      rows: [row(VG, { forked: true })],
     });
     const [only] = placeStandings(s, "skill", "gh", [VG]);
     expect(only.standing).toBe("customized");
@@ -141,14 +142,55 @@ describe("customizedHere", () => {
   it("lists a hand-edit-only package the Library row marks", () => {
     const s = source({
       manifests: { "/work/vg": empty() },
-      rows: indexRows([row(VG, { blockedByLocalEdit: true })]),
+      rows: [row(VG, { blockedByLocalEdit: true })],
     });
-    expect(libraryMark(placeStandings(s, "skill", "gh", [VG]))?.label).toBe(
-      "Customized in vg",
-    );
+    const mark = libraryMark(placeStandings(s, "skill", "gh", [VG]));
+    expect(mark?.label).toBe("Customized in vg");
+    expect(mark?.why).toBe("edited");
     expect(customizedHere(s, VG)).toMatchObject([
-      { kind: "skill", name: "gh", why: "edited" },
+      { kind: "skill", name: "gh", edited: true, forked: false },
     ]);
+  });
+
+  // A fork is in the manifest before any update row says so, and a local
+  // source never gets a row at all: the forks table alone has to carry it.
+  it("lists a fork the manifest alone records", () => {
+    const manifest: Draft = {
+      ...empty(),
+      forks: { skill: { gh: { source: "cat", repo: "o/r" } as never } },
+    };
+    for (const updatesLoaded of [true, false]) {
+      const s = source({ manifests: { "/work/vg": manifest }, updatesLoaded });
+      expect(customizedHere(s, VG)).toMatchObject([
+        {
+          kind: "skill",
+          name: "gh",
+          forked: true,
+          edited: false,
+          customization: {
+            launch: null,
+            additional: null,
+            instructions: null,
+            skills: null,
+            frontmatter: [],
+          },
+        },
+      ]);
+    }
+  });
+
+  // Settings outrank a hand edit for where a click lands, but the row's
+  // line names both: the edit is what holds updates back.
+  it("names a hand edit under a package that also has settings", () => {
+    const s = source({
+      manifests: { "/work/vg": withSetting() },
+      rows: [row(VG, { blockedByLocalEdit: true })],
+    });
+    const [only] = customizedHere(s, VG);
+    expect(only).toMatchObject({ edited: true, forked: false });
+    expect(customizedLine(only, only.customization)).toBe(
+      "Edited by you · Extra instructions",
+    );
   });
 
   it("lists a fork recorded in the manifest, with its settings", () => {
@@ -161,7 +203,7 @@ describe("customizedHere", () => {
       {
         kind: "skill",
         name: "gh",
-        why: "forked",
+        forked: true,
         customization: { instructions: "mine" },
       },
     ]);
@@ -170,14 +212,14 @@ describe("customizedHere", () => {
   it("lists a settings-only package with what was set", () => {
     const s = source({ manifests: { "/work/vg": withSetting() } });
     expect(customizedHere(s, VG)).toMatchObject([
-      { kind: "skill", name: "gh", why: "settings" },
+      { kind: "skill", name: "gh", edited: false, forked: false },
     ]);
   });
 
   it("leaves out stock rows and other places' settings", () => {
     const s = source({
       manifests: { "/work/vg": empty(), "/work/hyprtrade": withSetting() },
-      rows: indexRows([row(VG), row(HYPR, { blockedByLocalEdit: true })]),
+      rows: [row(VG), row(HYPR, { blockedByLocalEdit: true })],
     });
     expect(customizedHere(s, VG)).toEqual([]);
   });
@@ -187,29 +229,47 @@ describe("customizedHere", () => {
   it("holds a hand edit back until the update read has landed", () => {
     const s = source({
       manifests: { "/work/vg": withSetting() },
-      rows: indexRows([
+      rows: [
         row(VG, { blockedByLocalEdit: true }),
         row(VG, { kind: "agent", name: "orch", blockedByLocalEdit: true }),
-      ]),
+      ],
       updatesLoaded: false,
     });
     expect(customizedHere(s, VG)).toMatchObject([
-      { kind: "skill", name: "gh", why: "settings" },
+      { kind: "skill", name: "gh", edited: false },
     ]);
   });
 
   it("orders agents before skills, each by name", () => {
     const s = source({
       manifests: { "/work/vg": withSetting() },
-      rows: indexRows([
+      rows: [
         row(VG, { name: "zed", blockedByLocalEdit: true }),
         row(VG, { kind: "agent", name: "orch", forked: true }),
-      ]),
+      ],
     });
     expect(customizedHere(s, VG).map((r) => `${r.kind}:${r.name}`)).toEqual([
       "agent:orch",
       "skill:gh",
       "skill:zed",
     ]);
+  });
+});
+
+describe("manifestsForEditing", () => {
+  // Remove edits the draft, and the row it removes has to go with it
+  // before a save; the saved manifest still holds the setting until then.
+  it("reads the open draft in place of that place's saved manifest", () => {
+    const saved = { "/work/vg": withSetting(), global: withSetting() };
+    const manifests = manifestsForEditing(saved, empty(), VG);
+    expect(customizedHere(placesSource(manifests, [], true), VG)).toEqual([]);
+    expect(
+      customizedHere(placesSource(manifests, [], true), GLOBAL),
+    ).toHaveLength(1);
+  });
+
+  it("leaves the saved manifests alone while there is no draft", () => {
+    const saved = { "/work/vg": withSetting() };
+    expect(manifestsForEditing(saved, null, VG)).toBe(saved);
   });
 });

--- a/ui/src/lib/customized-places.ts
+++ b/ui/src/lib/customized-places.ts
@@ -7,63 +7,100 @@ import {
 import type { Draft } from "@/lib/editor-draft";
 import { sameScope, scopeKey } from "@/lib/scope";
 
+/** Why a place counts as customized, which decides where a click lands. */
+export type Why = "settings" | "edited" | "forked";
+
 /** What one place holds for one package.
  *
  *  Three answers, not two. A place whose manifest was read and holds
  *  nothing is not the same as a place nobody could read: the first is
  *  "yours is the stock copy", the second is "nobody knows", and printing
- *  the first over the second is the badge lying in a new way. */
-export type Standing = "customized" | "stock" | "unknown";
+ *  the first over the second is the badge lying in a new way. A
+ *  customized place always says why; the other two never do. */
+export type PlaceStanding =
+  | { scope: Scope; standing: "customized"; why: Why }
+  | { scope: Scope; standing: "stock" | "unknown"; why: null };
 
-/** Why a place counts as customized, which decides where a click lands. */
-export type Why = "settings" | "edited" | "forked";
-
-export interface PlaceStanding {
-  scope: Scope;
-  standing: Standing;
-  why: Why | null;
-}
-
-/** Everything the standings are read from, gathered once per screen. */
+/** Everything the standings are read from, gathered once per screen.
+ *  Built through {@link placesSource}, never by hand: {@link settings} is
+ *  an index over {@link manifests}, and the two must not drift apart. */
 export interface PlacesSource {
-  /** Each place's saved manifest, keyed by scope. A place absent here has
-   *  not been read — which is the whole reason this is a record and not a
+  /** Each place's manifest, keyed by scope. A place absent here has not
+   *  been read — which is the whole reason this is a record and not a
    *  list of the customized ones. */
   manifests: Record<string, Draft>;
-  /** Update rows keyed by {@link placeKey}: the per-place hand-edit and
+  /** Update rows keyed by place and package: the per-place hand-edit and
    *  fork facts, absent for places the engine cannot speak about. */
   rows: Map<string, UpdateRow>;
   /** Whether the update read has landed. Hand edits are known only after
    *  it has; before, a place with no row is unread rather than clean. */
   updatesLoaded: boolean;
-  /** {@link indexCustomized} over {@link manifests}, built once. */
+  /** Every package each place's manifest holds settings for, keyed
+   *  `scope|kind:name`. Built once: `customizedItems` walks a whole
+   *  manifest, and asking it per package per place walks every manifest
+   *  again for every row on the Library. */
   settings: ReadonlySet<string>;
 }
 
 const placeKey = (kind: ItemKind, name: string, scope: Scope): string =>
   `${kind}:${name}:${scopeKey(scope)}`;
 
-export function indexRows(rows: UpdateRow[]): Map<string, UpdateRow> {
-  const out = new Map<string, UpdateRow>();
-  for (const row of rows) out.set(placeKey(row.kind, row.name, row.scope), row);
-  return out;
-}
-
-/** Every package each place holds something for, keyed by place and
- *  package.
- *
- *  Built once per screen rather than per row: `customizedItems` walks a
- *  whole manifest, and asking it per package per place walks every
- *  manifest again for every row on the Library. */
-export function indexCustomized(
+export function placesSource(
   manifests: Record<string, Draft>,
-): ReadonlySet<string> {
-  const keys = new Set<string>();
+  rows: UpdateRow[],
+  updatesLoaded: boolean,
+): PlacesSource {
+  const byPlace = new Map<string, UpdateRow>();
+  for (const row of rows)
+    byPlace.set(placeKey(row.kind, row.name, row.scope), row);
+  const settings = new Set<string>();
   for (const [where, manifest] of Object.entries(manifests))
     for (const item of customizedItems(manifest))
-      keys.add(`${where}|${item.kind}:${item.name}`);
-  return keys;
+      settings.add(`${where}|${item.kind}:${item.name}`);
+  return { manifests, rows: byPlace, updatesLoaded, settings };
 }
+
+/** The manifests a page editing one place reads: its open draft in place
+ *  of that place's saved manifest, so a setting removed and not yet saved
+ *  leaves the index at once, as the Remove control promises, and one
+ *  typed on a package's own page joins it. */
+export function manifestsForEditing(
+  saved: Record<string, Draft>,
+  draft: Draft | null,
+  scope: Scope,
+): Record<string, Draft> {
+  return draft ? { ...saved, [scopeKey(scope)]: draft } : saved;
+}
+
+/** Whether this place's copy is a fork, or null when nobody can say.
+ *
+ *  Two readers of one fact, and either saying yes is a yes. Preferring
+ *  the manifest outright loses a fork this app has just made: the row is
+ *  re-read with the write and the saved manifest is not, so the mark goes
+ *  missing at the one moment the reader is certain it is theirs. The cost
+ *  of taking either is a mark that outlives a discard until the next read
+ *  — the mark being late rather than the mark being missing. */
+function forkedAt(
+  manifest: Draft | undefined,
+  row: UpdateRow | undefined,
+  updatesLoaded: boolean,
+  kind: ItemKind,
+  name: string,
+): boolean | null {
+  const inManifest = manifest ? manifest.forks?.[kind]?.[name] != null : null;
+  const inRow = updatesLoaded && row ? row.forked : null;
+  if (inManifest || inRow) return true;
+  return inManifest === null && inRow === null ? null : false;
+}
+
+/** Whether this place's files were edited by hand, or null when nobody
+ *  can say. A place with no row after the read has landed is one the
+ *  engine cannot speak about — a local source has no version to compare
+ *  against — so its hand-edit state stays unknown rather than false. */
+const editedAt = (
+  row: UpdateRow | undefined,
+  updatesLoaded: boolean,
+): boolean | null => (updatesLoaded && row ? row.blockedByLocalEdit : null);
 
 /** How each place stands, in the order the scopes were given.
  *
@@ -80,27 +117,11 @@ export function placeStandings(
   return scopes.map((scope) => {
     const manifest = source.manifests[scopeKey(scope)];
     const row = source.rows.get(placeKey(kind, name, scope));
-    // Two readers of one fact, and either saying yes is a yes. Preferring
-    // the manifest outright loses a fork this app has just made: the row
-    // is re-read with the write and the saved manifest is not, so the mark
-    // goes missing at the one moment the reader is certain it is theirs.
-    // The cost of taking either is a mark that outlives a discard until the
-    // next read — the mark being late rather than the mark being missing.
-    const inManifest = manifest ? manifest.forks?.[kind]?.[name] != null : null;
-    const inRow = source.updatesLoaded && row ? row.forked : null;
-    const forked =
-      inManifest || inRow
-        ? true
-        : inManifest === null && inRow === null
-          ? null
-          : false;
+    const forked = forkedAt(manifest, row, source.updatesLoaded, kind, name);
     const settings = manifest
       ? source.settings.has(`${scopeKey(scope)}|${kind}:${name}`)
       : null;
-    // A place with no row after the read has landed is one the engine
-    // cannot speak about — a local source has no version to compare
-    // against — so its hand-edit state stays unknown rather than false.
-    const edited = source.updatesLoaded && row ? row.blockedByLocalEdit : null;
+    const edited = editedAt(row, source.updatesLoaded);
     if (forked) return { scope, standing: "customized", why: "forked" };
     if (settings) return { scope, standing: "customized", why: "settings" };
     if (edited) return { scope, standing: "customized", why: "edited" };
@@ -122,11 +143,12 @@ export function standingIn(
 }
 
 /** One row of the Customize page's index: a package this place holds
- *  something for, why it counts, and what its overlay sets. */
+ *  something for, every fact that makes it so, and what its overlay sets. */
 export interface CustomizedHere {
   kind: ItemKind;
   name: string;
-  why: Why;
+  edited: boolean;
+  forked: boolean;
   customization: ItemCustomization;
 }
 
@@ -139,11 +161,12 @@ export function customizedHere(
   source: PlacesSource,
   scope: Scope,
 ): CustomizedHere[] {
-  const manifest = source.manifests[scopeKey(scope)] ?? null;
+  const manifest = source.manifests[scopeKey(scope)];
   const candidates = new Map<string, [ItemKind, string]>();
   const add = (kind: ItemKind, name: string) =>
     candidates.set(`${kind}:${name}`, [kind, name]);
-  for (const item of customizedItems(manifest)) add(item.kind, item.name);
+  for (const item of customizedItems(manifest ?? null))
+    add(item.kind, item.name);
   for (const [kind, byName] of Object.entries(manifest?.forks ?? {}))
     for (const name of Object.keys(byName ?? {})) add(kind as ItemKind, name);
   for (const row of source.rows.values())
@@ -153,13 +176,14 @@ export function customizedHere(
   for (const [kind, name] of candidates.values()) {
     const [standing] = placeStandings(source, kind, name, [scope]);
     if (standing.standing !== "customized") continue;
-    if (standing.why === null)
-      throw new Error(`customized place ${kind}:${name} names no reason`);
+    const row = source.rows.get(placeKey(kind, name, scope));
     out.push({
       kind,
       name,
-      why: standing.why,
-      customization: itemCustomization(manifest, kind, name),
+      edited: editedAt(row, source.updatesLoaded) === true,
+      forked:
+        forkedAt(manifest, row, source.updatesLoaded, kind, name) === true,
+      customization: itemCustomization(manifest ?? null, kind, name),
     });
   }
   return out.sort(

--- a/ui/src/lib/customized-places.ts
+++ b/ui/src/lib/customized-places.ts
@@ -1,7 +1,11 @@
 import type { ItemKind, Scope, UpdateRow } from "@/bindings";
-import { customizedItems } from "@/lib/customization";
+import {
+  customizedItems,
+  type ItemCustomization,
+  itemCustomization,
+} from "@/lib/customization";
 import type { Draft } from "@/lib/editor-draft";
-import { scopeKey } from "@/lib/scope";
+import { sameScope, scopeKey } from "@/lib/scope";
 
 /** What one place holds for one package.
  *
@@ -115,4 +119,50 @@ export function standingIn(
 ): PlaceStanding | undefined {
   const key = scopeKey(scope);
   return standings.find((s) => scopeKey(s.scope) === key);
+}
+
+/** One row of the Customize page's index: a package this place holds
+ *  something for, why it counts, and what its overlay sets. */
+export interface CustomizedHere {
+  kind: ItemKind;
+  name: string;
+  why: Why;
+  customization: ItemCustomization;
+}
+
+/** Every package customized at one place, by the rule the Library's mark
+ *  reads. Candidates come from wherever each fact is recorded (the
+ *  manifest's overlay and forks tables, and this place's update rows),
+ *  and each is put to {@link placeStandings}, so this list and the mark
+ *  on a Library row cannot answer differently about the same package. */
+export function customizedHere(
+  source: PlacesSource,
+  scope: Scope,
+): CustomizedHere[] {
+  const manifest = source.manifests[scopeKey(scope)] ?? null;
+  const candidates = new Map<string, [ItemKind, string]>();
+  const add = (kind: ItemKind, name: string) =>
+    candidates.set(`${kind}:${name}`, [kind, name]);
+  for (const item of customizedItems(manifest)) add(item.kind, item.name);
+  for (const [kind, byName] of Object.entries(manifest?.forks ?? {}))
+    for (const name of Object.keys(byName ?? {})) add(kind as ItemKind, name);
+  for (const row of source.rows.values())
+    if (sameScope(row.scope, scope) && (row.blockedByLocalEdit || row.forked))
+      add(row.kind, row.name);
+  const out: CustomizedHere[] = [];
+  for (const [kind, name] of candidates.values()) {
+    const [standing] = placeStandings(source, kind, name, [scope]);
+    if (standing.standing !== "customized") continue;
+    if (standing.why === null)
+      throw new Error(`customized place ${kind}:${name} names no reason`);
+    out.push({
+      kind,
+      name,
+      why: standing.why,
+      customization: itemCustomization(manifest, kind, name),
+    });
+  }
+  return out.sort(
+    (a, b) => a.kind.localeCompare(b.kind) || a.name.localeCompare(b.name),
+  );
 }

--- a/ui/src/lib/customized-places.ts
+++ b/ui/src/lib/customized-places.ts
@@ -72,66 +72,73 @@ export function manifestsForEditing(
   return draft ? { ...saved, [scopeKey(scope)]: draft } : saved;
 }
 
-/** Whether this place's copy is a fork, or null when nobody can say.
- *
- *  Two readers of one fact, and either saying yes is a yes. Preferring
- *  the manifest outright loses a fork this app has just made: the row is
- *  re-read with the write and the saved manifest is not, so the mark goes
- *  missing at the one moment the reader is certain it is theirs. The cost
- *  of taking either is a mark that outlives a discard until the next read
- *  — the mark being late rather than the mark being missing. */
-function forkedAt(
-  manifest: Draft | undefined,
-  row: UpdateRow | undefined,
-  updatesLoaded: boolean,
-  kind: ItemKind,
-  name: string,
-): boolean | null {
-  const inManifest = manifest ? manifest.forks?.[kind]?.[name] != null : null;
-  const inRow = updatesLoaded && row ? row.forked : null;
-  if (inManifest || inRow) return true;
-  return inManifest === null && inRow === null ? null : false;
+/** The three facts about one package at one place, each null when nobody
+ *  can say. Null is a real answer: a manifest that was not read and a
+ *  place with no update row both leave the question open, and reading
+ *  either as false is the mark lying in a new way. */
+export interface PlaceFacts {
+  forked: boolean | null;
+  settings: boolean | null;
+  edited: boolean | null;
 }
 
-/** Whether this place's files were edited by hand, or null when nobody
- *  can say. A place with no row after the read has landed is one the
- *  engine cannot speak about — a local source has no version to compare
- *  against — so its hand-edit state stays unknown rather than false. */
-const editedAt = (
-  row: UpdateRow | undefined,
-  updatesLoaded: boolean,
-): boolean | null => (updatesLoaded && row ? row.blockedByLocalEdit : null);
+export function placeFacts(
+  source: PlacesSource,
+  kind: ItemKind,
+  name: string,
+  scope: Scope,
+): PlaceFacts {
+  const manifest = source.manifests[scopeKey(scope)];
+  const row = source.rows.get(placeKey(kind, name, scope));
+  // Two readers of the fork fact, and either saying yes is a yes.
+  // Preferring the manifest outright loses a fork this app has just made:
+  // the row is re-read with the write and the saved manifest is not, so
+  // the mark goes missing at the one moment the reader is certain it is
+  // theirs. The cost of taking either is a mark that outlives a discard
+  // until the next read — the mark being late rather than missing.
+  const inManifest = manifest ? manifest.forks?.[kind]?.[name] != null : null;
+  const inRow = source.updatesLoaded && row ? row.forked : null;
+  const forked =
+    inManifest || inRow
+      ? true
+      : inManifest === null && inRow === null
+        ? null
+        : false;
+  const settings = manifest
+    ? source.settings.has(`${scopeKey(scope)}|${kind}:${name}`)
+    : null;
+  // A place with no row after the read has landed is one the engine
+  // cannot speak about — a local source has no version to compare
+  // against — so its hand-edit state stays unknown rather than false.
+  const edited = source.updatesLoaded && row ? row.blockedByLocalEdit : null;
+  return { forked, settings, edited };
+}
 
-/** How each place stands, in the order the scopes were given.
- *
- *  One word, three sources: what the person set on the Customize tab, what
- *  they edited in the installed files, and whether the copy is their own
- *  fork. Any of them makes the place theirs — the badge answers "is this
- *  place mine", and all three are ways of saying yes. */
+/** One word from three facts. Any of them makes the place theirs — the
+ *  badge answers "is this place mine", and all three are ways of saying
+ *  yes. The order decides where a click lands when more than one holds. */
+export function standingOf(scope: Scope, facts: PlaceFacts): PlaceStanding {
+  if (facts.forked) return { scope, standing: "customized", why: "forked" };
+  if (facts.settings) return { scope, standing: "customized", why: "settings" };
+  if (facts.edited) return { scope, standing: "customized", why: "edited" };
+  // Every source has to have spoken before a place can be called stock.
+  // One silent source is enough to leave the question open: the mark
+  // that is missing is indistinguishable from the mark that is false.
+  if (facts.settings === null || facts.edited === null || facts.forked === null)
+    return { scope, standing: "unknown", why: null };
+  return { scope, standing: "stock", why: null };
+}
+
+/** How each place stands, in the order the scopes were given. */
 export function placeStandings(
   source: PlacesSource,
   kind: ItemKind,
   name: string,
   scopes: Scope[],
 ): PlaceStanding[] {
-  return scopes.map((scope) => {
-    const manifest = source.manifests[scopeKey(scope)];
-    const row = source.rows.get(placeKey(kind, name, scope));
-    const forked = forkedAt(manifest, row, source.updatesLoaded, kind, name);
-    const settings = manifest
-      ? source.settings.has(`${scopeKey(scope)}|${kind}:${name}`)
-      : null;
-    const edited = editedAt(row, source.updatesLoaded);
-    if (forked) return { scope, standing: "customized", why: "forked" };
-    if (settings) return { scope, standing: "customized", why: "settings" };
-    if (edited) return { scope, standing: "customized", why: "edited" };
-    // Every source has to have spoken before a place can be called stock.
-    // One silent source is enough to leave the question open: the mark
-    // that is missing is indistinguishable from the mark that is false.
-    if (settings === null || edited === null || forked === null)
-      return { scope, standing: "unknown", why: null };
-    return { scope, standing: "stock", why: null };
-  });
+  return scopes.map((scope) =>
+    standingOf(scope, placeFacts(source, kind, name, scope)),
+  );
 }
 
 export function standingIn(
@@ -161,12 +168,11 @@ export function customizedHere(
   source: PlacesSource,
   scope: Scope,
 ): CustomizedHere[] {
-  const manifest = source.manifests[scopeKey(scope)];
+  const manifest = source.manifests[scopeKey(scope)] ?? null;
   const candidates = new Map<string, [ItemKind, string]>();
   const add = (kind: ItemKind, name: string) =>
     candidates.set(`${kind}:${name}`, [kind, name]);
-  for (const item of customizedItems(manifest ?? null))
-    add(item.kind, item.name);
+  for (const item of customizedItems(manifest)) add(item.kind, item.name);
   for (const [kind, byName] of Object.entries(manifest?.forks ?? {}))
     for (const name of Object.keys(byName ?? {})) add(kind as ItemKind, name);
   for (const row of source.rows.values())
@@ -174,16 +180,14 @@ export function customizedHere(
       add(row.kind, row.name);
   const out: CustomizedHere[] = [];
   for (const [kind, name] of candidates.values()) {
-    const [standing] = placeStandings(source, kind, name, [scope]);
-    if (standing.standing !== "customized") continue;
-    const row = source.rows.get(placeKey(kind, name, scope));
+    const facts = placeFacts(source, kind, name, scope);
+    if (standingOf(scope, facts).standing !== "customized") continue;
     out.push({
       kind,
       name,
-      edited: editedAt(row, source.updatesLoaded) === true,
-      forked:
-        forkedAt(manifest, row, source.updatesLoaded, kind, name) === true,
-      customization: itemCustomization(manifest ?? null, kind, name),
+      edited: facts.edited === true,
+      forked: facts.forked === true,
+      customization: itemCustomization(manifest, kind, name),
     });
   }
   return out.sort(

--- a/ui/src/lib/library-standings.ts
+++ b/ui/src/lib/library-standings.ts
@@ -1,9 +1,8 @@
 import { useMemo } from "react";
 import {
-  indexCustomized,
-  indexRows,
   type PlaceStanding,
   placeStandings,
+  placesSource,
 } from "@/lib/customized-places";
 import type { ItemGroup } from "@/lib/derive";
 import { groupScopes } from "@/lib/derive";
@@ -22,12 +21,7 @@ export function useLibraryStandings(
   const updateRows = useUpdatesStore((s) => s.rows);
   const updatesLoaded = useUpdatesStore((s) => s.loaded);
   const places = useMemo(
-    () => ({
-      manifests: saved,
-      rows: indexRows(updateRows),
-      updatesLoaded,
-      settings: indexCustomized(saved),
-    }),
+    () => placesSource(saved, updateRows, updatesLoaded),
     [saved, updateRows, updatesLoaded],
   );
   const byKey = useMemo(() => {

--- a/ui/src/lib/package-mark.ts
+++ b/ui/src/lib/package-mark.ts
@@ -1,9 +1,5 @@
 import type { Scope, UpdateRow } from "@/bindings";
-import {
-  indexCustomized,
-  indexRows,
-  placeStandings,
-} from "@/lib/customized-places";
+import { placeStandings, placesSource } from "@/lib/customized-places";
 import type { ItemGroup } from "@/lib/derive";
 import { groupScopes } from "@/lib/derive";
 import type { Draft } from "@/lib/editor-draft";
@@ -25,12 +21,7 @@ export function markFor(
 ): PlaceMark | null {
   return headerMark(
     placeStandings(
-      {
-        manifests: saved,
-        rows: indexRows(rows),
-        updatesLoaded,
-        settings: indexCustomized(saved),
-      },
+      placesSource(saved, rows, updatesLoaded),
       group.kind,
       group.name,
       groupScopes(group),

--- a/ui/src/lib/updates-read-state.test.ts
+++ b/ui/src/lib/updates-read-state.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from "vitest";
+import { updatesReadState } from "./updates-read-state";
+
+describe("updatesReadState", () => {
+  it("is pending before the first read answers", () => {
+    expect(updatesReadState({ loaded: false, error: null })).toBe("pending");
+  });
+
+  it("is landed once a read has answered", () => {
+    expect(updatesReadState({ loaded: true, error: null })).toBe("landed");
+  });
+
+  // A failed re-read keeps the rows it had and drops `loaded`: the rows
+  // are last-known, and the state has to say so rather than "pending".
+  it("is failed when the read said why, whatever is still on screen", () => {
+    expect(updatesReadState({ loaded: false, error: "no network" })).toBe(
+      "failed",
+    );
+  });
+});

--- a/ui/src/lib/updates-read-state.ts
+++ b/ui/src/lib/updates-read-state.ts
@@ -1,0 +1,14 @@
+/** How the read of the update standing stands. Three answers that must
+ *  never blur: a first read still on its way, a read that failed, and a
+ *  read that landed. Only the last may say "nothing here". A failed
+ *  re-read keeps the rows it had, but `loaded` drops with it, so those
+ *  rows are last-known rather than facts and the state is `failed`. */
+export type UpdatesReadState = "pending" | "landed" | "failed";
+
+export function updatesReadState(state: {
+  loaded: boolean;
+  error: string | null;
+}): UpdatesReadState {
+  if (state.error !== null) return "failed";
+  return state.loaded ? "landed" : "pending";
+}

--- a/ui/src/pages/customize.tsx
+++ b/ui/src/pages/customize.tsx
@@ -33,6 +33,7 @@ import { CONTENT_WIDTH, PAGE_BODY } from "@/lib/layout";
 import { cn } from "@/lib/utils";
 import { useEditorStore } from "@/stores/editor";
 import { useSettingsStore } from "@/stores/settings";
+import { useUpdatesStore } from "@/stores/updates";
 
 /** What you have changed that isn't about one package — instructions every
  *  agent and skill gets, hooks of your own, where a project keeps its
@@ -54,6 +55,10 @@ export function CustomizePage() {
   } = useEditorStore();
   const projects = useSettingsStore((s) => s.settings?.projects ?? []);
   const customized = useCustomizedHere(draft, scope);
+  // Rows kept from before a failed re-read are last-known and do not count
+  // as hand-edit facts, so this is the case where the index cannot list
+  // an edited package: nothing landed and the read said why.
+  const updatesFailed = useUpdatesStore((s) => !s.loaded && s.error !== null);
 
   // Unsaved edits made on a package's own page live in this same draft;
   // reloading over them here would throw away work with nothing said.
@@ -128,6 +133,7 @@ export function CustomizePage() {
                 <CustomizedIndex
                   items={customized}
                   scope={scope}
+                  updatesFailed={updatesFailed}
                   onRemove={(kind, name) =>
                     edit((current) =>
                       clearItemCustomization(current, kind, name),

--- a/ui/src/pages/customize.tsx
+++ b/ui/src/pages/customize.tsx
@@ -30,6 +30,7 @@ import {
 } from "@/lib/customization";
 import { useCustomizedHere } from "@/lib/customized-here";
 import { CONTENT_WIDTH, PAGE_BODY } from "@/lib/layout";
+import { updatesReadState } from "@/lib/updates-read-state";
 import { cn } from "@/lib/utils";
 import { useEditorStore } from "@/stores/editor";
 import { useSettingsStore } from "@/stores/settings";
@@ -55,10 +56,7 @@ export function CustomizePage() {
   } = useEditorStore();
   const projects = useSettingsStore((s) => s.settings?.projects ?? []);
   const customized = useCustomizedHere(draft, scope);
-  // Rows kept from before a failed re-read are last-known and do not count
-  // as hand-edit facts, so this is the case where the index cannot list
-  // an edited package: nothing landed and the read said why.
-  const updatesFailed = useUpdatesStore((s) => !s.loaded && s.error !== null);
+  const updates = useUpdatesStore(updatesReadState);
 
   // Unsaved edits made on a package's own page live in this same draft;
   // reloading over them here would throw away work with nothing said.
@@ -133,7 +131,7 @@ export function CustomizePage() {
                 <CustomizedIndex
                   items={customized}
                   scope={scope}
-                  updatesFailed={updatesFailed}
+                  updates={updates}
                   onRemove={(kind, name) =>
                     edit((current) =>
                       clearItemCustomization(current, kind, name),

--- a/ui/src/pages/customize.tsx
+++ b/ui/src/pages/customize.tsx
@@ -26,9 +26,9 @@ import {
 } from "@/lib/copy-customize";
 import {
   clearItemCustomization,
-  customizedItems,
   sharedCustomization,
 } from "@/lib/customization";
+import { useCustomizedHere } from "@/lib/customized-here";
 import { CONTENT_WIDTH, PAGE_BODY } from "@/lib/layout";
 import { cn } from "@/lib/utils";
 import { useEditorStore } from "@/stores/editor";
@@ -53,6 +53,7 @@ export function CustomizePage() {
     save,
   } = useEditorStore();
   const projects = useSettingsStore((s) => s.settings?.projects ?? []);
+  const customized = useCustomizedHere(draft, scope);
 
   // Unsaved edits made on a package's own page live in this same draft;
   // reloading over them here would throw away work with nothing said.
@@ -125,7 +126,7 @@ export function CustomizePage() {
                 description={CUSTOMIZED_SECTION_HELP}
               >
                 <CustomizedIndex
-                  items={customizedItems(draft)}
+                  items={customized}
                   scope={scope}
                   onRemove={(kind, name) =>
                     edit((current) =>


### PR DESCRIPTION
## Summary
- The Customize page's "Customized packages" index now reads the same per-place standing the Library row and package header read, so hand-edited and forked packages appear there like they do in the Library. `customizedHere` gathers candidates from the overlay, the manifest's forks, and this place's update rows and puts each through `placeStandings`; the open draft stands in for the place's saved manifest so an unsaved Remove leaves the list at once.
- Rows say why they are there — Forked, Edited by you, the settings, or a combination — and Remove appears only where settings exist to remove.
- The index's empty state is honest about its reads: a pending update check shows "Checking…", a failed one says hand-edited and forked packages may be missing, and "Nothing yet" appears only after a landed read (`updatesReadState`, shared with the Updates page).
- Structural: one `placesSource` constructor for every reader, `placeFacts`/`standingOf` as the single owner of per-place facts, `PlaceStanding` as a discriminated union, `manifestsForEditing` as a pure helper. Also fixed: a zustand selector returning a fresh `[]` re-rendered the index without end.

## Completed Issues
- Closes KEN-468 - The Customize page index omits hand-edited and forked packages it calls "Customized packages"

## Created Issues
- KEN-590 - A hand-edited package whose update standing could not be evaluated vanishes from the Customize index and the Library mark — Project: Tech Debt & Bugs

## Test Plan
- `customized-places.test.ts` pins Library-mark vs index agreement for a hand-edit-only package, every candidate source as sole nominator (settings, manifest fork, row edit, row fork), the fork-over-settings precedence the Library's Forked badge depends on, and rows held back until the update read lands.
- `customized-index.test.tsx` (jsdom): pending, failed (empty and populated), and landed states; `updates-read-state.test.ts` pins the three-way predicate; `copy-customize.test.ts` pins "Edited by you · Extra instructions".
- reviewer-test mutation passes: cycle 2 killed 10/10, cycle 3 7/10 (one equivalent mutant, two pre-existing gaps then pinned), final round both pins red under their mutants. tools/guard green (546 vitest, tsc, biome, cargo).
