### PR TITLE
test(ui): the folder-picker suite clears its toast spy (KEN-503)

### DIFF
--- a/ui/src/lib/pick-folder.test.ts
+++ b/ui/src/lib/pick-folder.test.ts
@@ -1,5 +1,5 @@
 import { toast } from "sonner";
-import { describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import { commands } from "@/bindings";
 import { pickFolder } from "./pick-folder";
 
@@ -12,6 +12,12 @@ vi.mock("sonner", () => ({
 }));
 
 describe("pickFolder", () => {
+  // Two cases assert toast.error was never called, so each one needs the spy
+  // clean regardless of which case ran before it.
+  beforeEach(() => {
+    vi.mocked(toast.error).mockClear();
+  });
+
   it("returns the chosen path without a toast", async () => {
     vi.mocked(commands.pickFolder).mockResolvedValue({
       status: "ok",


### PR DESCRIPTION
## Summary

- One case in the folder-picker suite passed only because of the order its file happened to run in. Two cases assert `toast.error` was never called, and they relied on the preceding case leaving the spy clean — so under a shuffled run one of them failed on a dirty spy rather than on anything the picker did.
- The spy is now cleared in the file's own `beforeEach`, so each case is independent of what ran before it.

## Test Plan

Verified in both directions, shuffled six times each with `vitest --sequence.shuffle`:

- **Before the fix** (the pre-change file, in a scratch copy): 3 of 6 runs red — `2 failed | 1 passed`, `1 failed | 2 passed`, `1 failed | 2 passed`, and 3 clean. Order-dependent, exactly as reported.
- **After the fix**: 6 of 6 runs green, `Tests 3 passed (3)` every time.

## Completed Issues

- Closes KEN-503 - A folder-picker test depends on suite order
