### PR TITLE
fix(hooks): a quoted mention of the bypass flag is data, not a commit (KEN-576)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,9 +10,9 @@ an outside contributor.
 
 ### Fixed
 
-- The `pre-commit-check` hook no longer refuses a command that merely
-  quotes `--no-verify` or `git commit` as text, in an issue description
-  or a commit message. A real bypass is still refused, quoted or not.
+- The `pre-commit-check` hook no longer refuses a command whose quoted
+  prose mentions `--no-verify` or `git commit`. A quoted lone flag, and any
+  line that could execute its quoted text, are still read as shell.
 - macOS builds are Developer ID signed and notarized: installing from any
   channel no longer ends in "kendex is damaged" or an `xattr -cr` workaround.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ an outside contributor.
 
 ### Fixed
 
+- The `pre-commit-check` hook no longer refuses a command that merely
+  quotes `--no-verify` or `git commit` as text, in an issue description
+  or a commit message. A real bypass is still refused, quoted or not.
 - macOS builds are Developer ID signed and notarized: installing from any
   channel no longer ends in "kendex is damaged" or an `xattr -cr` workaround.
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -401,9 +401,11 @@ lives in one capability table read by core and UI.
   is git's question, answered where the target has an armed hook: the
   `pre-commit-check` PreToolUse hook only word-matches for a commit —
   over the command with its quoted multi-word arguments dropped, so an
-  issue description that merely mentions `--no-verify` is data, while a
-  quoted flag, a token split across quotes, and an interpreter's or
-  substitution's script argument are still shell —
+  issue description that merely mentions `--no-verify` is data; a quoted
+  single-word flag is still the flag, and a line carrying any sign that
+  quoted text could be executed (`eval`, a `-c`-style cluster, a pipe, a
+  substitution, a here-string, a heredoc) drops nothing and is scanned
+  whole —
   defers to the armed git pre-commit hook of its own working directory,
   and runs the chain in that directory only where none is armed there;
   sidestepping an armed one (`--no-verify`, `-n`) or injecting git config

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -399,7 +399,11 @@ lives in one capability table read by core and UI.
   scoped per staged file's owning `Cargo.toml`, and see none of the git
   redirects a hook's parent exports. Which repository a commit targets
   is git's question, answered where the target has an armed hook: the
-  `pre-commit-check` PreToolUse hook only word-matches for a commit,
+  `pre-commit-check` PreToolUse hook only word-matches for a commit —
+  over the command with its quoted multi-word arguments dropped, so an
+  issue description that merely mentions `--no-verify` is data, while a
+  quoted flag, a token split across quotes, and an interpreter's or
+  substitution's script argument are still shell —
   defers to the armed git pre-commit hook of its own working directory,
   and runs the chain in that directory only where none is armed there;
   sidestepping an armed one (`--no-verify`, `-n`) or injecting git config

--- a/hooks/pre-commit-check.sh
+++ b/hooks/pre-commit-check.sh
@@ -33,19 +33,22 @@ if [ -z "$COMMAND" ]; then
 fi
 # A quoted multi-word argument is data, not shell: an issue description
 # that merely mentions the no-verify flag is not a commit that uses it.
-# Dropping those regions before the word scan is what separates the two,
-# and every ambiguity resolves the other way — toward keeping the text and
-# paying a refusal to reword. Kept, therefore: a quoted region with no
-# whitespace (a quoted flag, or half a token split across quotes, since
-# `--no-"verify"` is still the flag), a double-quoted region holding a
-# `$(` or a backtick (the shell runs that, so this lane reads it), and any
-# region handed to an interpreter — the argument after `eval` or after a
-# short-flag cluster ending in `c`, as `bash -c` and `sh -lc` spell it. An
-# unterminated quote is kept whole.
+# Dropping those regions before the word scan is what separates the two —
+# but only on a line where nothing could execute quoted text. Any sign
+# that something might — `eval`, an interpreter's short-flag cluster
+# ending in c, a pipe, `$(`, a backtick, a here-string or heredoc (`<<`)
+# — and nothing is dropped at all: the whole command is scanned, as it was
+# before this lane learned to drop anything. The case it does not
+# recognise is therefore the conservative one, and an execution form
+# nobody has thought of yet makes it stricter rather than porous.
+#
+# The deliberate cost: mentioning the flag inside quotes on a line that
+# also carries one of those signs is refused, and rewording is cheap. A
+# quoted region with no whitespace is kept, since `--no-"verify"` is the flag.
 #
 # JSON escapes are decoded first: `\"` is a real quote to the shell below,
-# and the whitespace escapes separate words — `cargo fmt\ngit commit` is
-# two commands, not one word `ngit`.
+# and the whitespace escapes separate words rather than welding the
+# commands they stand between into one.
 #
 # Without awk the command cannot be read at all — the same case as a
 # payload this lane cannot parse, and refused for the same reason.
@@ -55,14 +58,6 @@ if ! command -v awk >/dev/null 2>&1; then
 fi
 BODY=$(printf '%s' "$COMMAND" | sed 's/^"command"[[:space:]]*:[[:space:]]*"//; s/"$//')
 SANITIZED=$(printf '%s\n' "$BODY" | awk '
-function keep(body, quote, sofar,   prev) {
-  if (body !~ /[ \t]/) return 1
-  if (quote == "\"" && (index(body, "$(") > 0 || index(body, "`") > 0)) return 1
-  sub(/[ \t]+$/, "", sofar)
-  prev = sofar
-  sub(/^.*[ \t]/, "", prev)
-  return (prev == "eval" || prev ~ /^-[a-zA-Z]*c$/)
-}
 {
   # 1. JSON unescape. A \uXXXX escape becomes a space: this lane reads
   #    shell syntax, and no harness spells its syntax that way.
@@ -77,9 +72,14 @@ function keep(body, quote, sofar,   prev) {
     else if (e == "u") { i += 4; cmd = cmd " " }
     else cmd = cmd e
   }
-  # 2. Drop the quoted data regions, keeping the shell around them. A
-  #    backslash outside quotes escapes one character, which stays: the
-  #    shell reads `--no\-verify` as the flag, and so must this lane.
+  # 2. Where quoted text could be executed, drop nothing.
+  if (index(cmd, "$(") || index(cmd, "`") || index(cmd, "<<") || index(cmd, "|") \
+      || (" " cmd " ") ~ /[^a-zA-Z0-9_.\/-]eval[^a-zA-Z0-9_.\/-]/ \
+      || cmd ~ /(^|[ \t])-[a-zA-Z]*c([ \t]|$)/) { print cmd; next }
+  # 3. Otherwise drop the quoted data regions, keeping the shell around
+  #    them. A backslash outside quotes escapes one character, which
+  #    stays: the shell reads a backslash inside the flag as the flag,
+  #    and so must this lane.
   out = ""
   n = length(cmd)
   i = 1
@@ -97,7 +97,7 @@ function keep(body, quote, sofar,   prev) {
       j++
     }
     if (j > n) { out = out substr(cmd, i); break }
-    out = out (keep(body, c, out) ? body : " ")
+    out = out (body ~ /[ \t]/ ? " " : body)
     i = j + 1
   }
   print out

--- a/hooks/pre-commit-check.sh
+++ b/hooks/pre-commit-check.sh
@@ -31,9 +31,78 @@ if [ -z "$COMMAND" ]; then
   echo "pre-commit-check: could not read the command out of the hook payload" >&2
   exit 2
 fi
-# JSON's whitespace escapes separate words too: `cargo fmt\ngit commit`
-# is two commands, not one word `ngit`.
-WORDS=" $(printf '%s' "$COMMAND" | sed 's/\\[ntr]/ /g' | tr -c 'a-zA-Z0-9_=-' ' ') "
+# A quoted multi-word argument is data, not shell: an issue description
+# that merely mentions the no-verify flag is not a commit that uses it.
+# Dropping those regions before the word scan is what separates the two,
+# and every ambiguity resolves the other way — toward keeping the text and
+# paying a refusal to reword. Kept, therefore: a quoted region with no
+# whitespace (a quoted flag, or half a token split across quotes, since
+# `--no-"verify"` is still the flag), a double-quoted region holding a
+# `$(` or a backtick (the shell runs that, so this lane reads it), and any
+# region handed to an interpreter — the argument after `eval` or after a
+# short-flag cluster ending in `c`, as `bash -c` and `sh -lc` spell it. An
+# unterminated quote is kept whole.
+#
+# JSON escapes are decoded first: `\"` is a real quote to the shell below,
+# and the whitespace escapes separate words — `cargo fmt\ngit commit` is
+# two commands, not one word `ngit`.
+#
+# Without awk the command cannot be read at all — the same case as a
+# payload this lane cannot parse, and refused for the same reason.
+if ! command -v awk >/dev/null 2>&1; then
+  echo "pre-commit-check: awk is not on PATH, so the command cannot be read — nothing here can judge this commit" >&2
+  exit 2
+fi
+BODY=$(printf '%s' "$COMMAND" | sed 's/^"command"[[:space:]]*:[[:space:]]*"//; s/"$//')
+SANITIZED=$(printf '%s\n' "$BODY" | awk '
+function keep(body, quote, sofar,   prev) {
+  if (body !~ /[ \t]/) return 1
+  if (quote == "\"" && (index(body, "$(") > 0 || index(body, "`") > 0)) return 1
+  sub(/[ \t]+$/, "", sofar)
+  prev = sofar
+  sub(/^.*[ \t]/, "", prev)
+  return (prev == "eval" || prev ~ /^-[a-zA-Z]*c$/)
+}
+{
+  # 1. JSON unescape. A \uXXXX escape becomes a space: this lane reads
+  #    shell syntax, and no harness spells its syntax that way.
+  cmd = ""
+  n = length($0)
+  for (i = 1; i <= n; i++) {
+    c = substr($0, i, 1)
+    if (c != "\\" || i == n) { cmd = cmd c; continue }
+    i++
+    e = substr($0, i, 1)
+    if (e ~ /^[ntrbf]$/) cmd = cmd " "
+    else if (e == "u") { i += 4; cmd = cmd " " }
+    else cmd = cmd e
+  }
+  # 2. Drop the quoted data regions, keeping the shell around them. A
+  #    backslash outside quotes escapes one character, which stays: the
+  #    shell reads `--no\-verify` as the flag, and so must this lane.
+  out = ""
+  n = length(cmd)
+  i = 1
+  while (i <= n) {
+    c = substr(cmd, i, 1)
+    if (c == "\\" && i < n) { out = out substr(cmd, i + 1, 1); i += 2; continue }
+    if (c != "\"" && c != "\047") { out = out c; i++; continue }
+    body = ""
+    j = i + 1
+    while (j <= n) {
+      d = substr(cmd, j, 1)
+      if (c == "\"" && d == "\\" && j < n) { body = body substr(cmd, j + 1, 1); j += 2; continue }
+      if (d == c) break
+      body = body d
+      j++
+    }
+    if (j > n) { out = out substr(cmd, i); break }
+    out = out (keep(body, c, out) ? body : " ")
+    i = j + 1
+  }
+  print out
+}')
+WORDS=" $(printf '%s' "$SANITIZED" | tr -c 'a-zA-Z0-9_=-' ' ') "
 printf '%s' "$WORDS" | grep -qE ' git( .*)? commit ' || exit 0
 
 # Repository-moving words (-C, --git-dir, --work-tree, cd, a GIT_DIR or

--- a/hooks/tests/pre-commit-check.test.sh
+++ b/hooks/tests/pre-commit-check.test.sh
@@ -54,7 +54,7 @@ chmod +x "$BIN_DIR/kendex"
 # fail-closed case. The shim dir is deliberately absent.
 NO_KENDEX_BIN="$TMP_ROOT/no-kendex-bin"
 mkdir -p "$NO_KENDEX_BIN"
-for tool in git grep tr sed head bash cat; do
+for tool in git grep tr sed head bash cat awk; do
   ln -s "$(command -v "$tool")" "$NO_KENDEX_BIN/$tool"
 done
 
@@ -76,6 +76,13 @@ run_hook() {
 
 payload() {
   printf '{"tool_input":{"command":"%s"}}' "$1"
+}
+
+# payload() for a command that itself contains quotes or backslashes:
+# escapes them the way the harness's JSON encoder does.
+jpayload() {
+  printf '{"tool_input":{"command":"%s"}}' \
+    "$(printf '%s' "$1" | sed 's/\\/\\\\/g; s/"/\\"/g')"
 }
 
 assert_eq() {
@@ -319,6 +326,66 @@ assert_eq "$rc" "0" "a quoted path with a space is not a refusal"
 
 run_hook "$UNARMED" '{"tool_input":{"command":"git -C \"/tmp/my repo\" commit -m x"}}' KENDEX_EXIT=1
 assert_eq "$rc" "2" "the quoted-path commit still reaches the fallback gate"
+
+echo
+echo "a quoted mention is data, not a command"
+
+# The reported defect: an issue description that merely names the bypass
+# flag is not a commit that uses it. In each of these the words git,
+# commit and the flag live only inside a quoted multi-word argument to
+# some other tool, so nothing here is a commit and nothing is refused.
+MENTION='the hook refuses a git commit --no-verify'
+for form in \
+  "linear.sh issues create --description \"$MENTION\"" \
+  "linear.sh issues create --description '$MENTION'" \
+  "linear.sh issues create --description 'run \`git commit --no-verify\` to skip'" \
+  'echo "do not run git commit -n here"'; do
+  run_hook "$ARMED" "$(jpayload "$form")" KENDEX_EXIT=1
+  assert_eq "$rc" "0" "quoted data is not a commit: $form"
+  assert_not_contains "$err" "bypasses" "no bypass refusal for quoted data: $form"
+  run_hook "$UNARMED" "$(jpayload "$form")" KENDEX_EXIT=1
+  assert_eq "$rc" "0" "quoted data runs no fallback chain either: $form"
+  assert_not_contains "$log" "kendex" "no guard run for quoted data: $form"
+done
+
+# A real commit whose message quotes the flag: the commit is still
+# detected and gated, the mention inside the message is still not a bypass.
+run_hook "$UNARMED" "$(jpayload "git commit -m \"KEN-576: $MENTION\"")" KENDEX_EXIT=1
+assert_eq "$rc" "2" "a real commit is detected through a quoted message"
+assert_contains "$log" "kendex guard run pre-commit" "the chain ran for the real commit"
+assert_not_contains "$err" "bypasses this repository's armed git hooks" "the flag named in the message is not a bypass"
+
+run_hook "$ARMED" "$(jpayload "git commit -m \"KEN-576: $MENTION\"")" KENDEX_EXIT=0
+assert_eq "$rc" "0" "the same commit defers to the armed hook, unrefused"
+
+echo
+echo "quoting does not launder a real bypass"
+
+# Quotes that carry shell rather than prose: a quoted flag is still the
+# flag, a token split across quotes is still the token, an interpreter's
+# script argument is still shell, and so is a command substitution.
+for form in \
+  'git commit "--no-verify" -m x' \
+  'git commit --no-"verify" -m x' \
+  'git commit --no\-verify -m x' \
+  'git commit -m "wip message" --no-verify' \
+  'git -c "core.hooksPath=/dev/null" commit -m x' \
+  'bash -c "git commit --no-verify -m x"' \
+  'sh -lc "git commit -n -m x"' \
+  'eval "git commit --no-verify -m x"' \
+  'echo "$(git commit --no-verify -m x)"' \
+  'git commit --no-verify -m "unterminated'; do
+  run_hook "$ARMED" "$(jpayload "$form")" KENDEX_EXIT=0
+  assert_eq "$rc" "2" "still refused: $form"
+  assert_contains "$err" "bypasses this repository's armed git hooks" "the refusal names the bypass: $form"
+  assert_not_contains "$log" "kendex" "no chain stands in for the bypassed hooks: $form"
+done
+
+# Detection survives an interpreter's quotes too: no bypass, but the
+# commit inside still reaches the fallback gate.
+run_hook "$UNARMED" "$(jpayload 'bash -c "git commit -m x"')" KENDEX_EXIT=1
+assert_eq "$rc" "2" "a commit inside an interpreter argument reaches the fallback gate"
+assert_contains "$log" "kendex guard run pre-commit" "the chain ran for the interpreter's commit"
 
 echo
 echo "fail closed without kendex"

--- a/hooks/tests/pre-commit-check.test.sh
+++ b/hooks/tests/pre-commit-check.test.sh
@@ -338,7 +338,6 @@ MENTION='the hook refuses a git commit --no-verify'
 for form in \
   "linear.sh issues create --description \"$MENTION\"" \
   "linear.sh issues create --description '$MENTION'" \
-  "linear.sh issues create --description 'run \`git commit --no-verify\` to skip'" \
   'echo "do not run git commit -n here"'; do
   run_hook "$ARMED" "$(jpayload "$form")" KENDEX_EXIT=1
   assert_eq "$rc" "0" "quoted data is not a commit: $form"
@@ -362,8 +361,11 @@ echo
 echo "quoting does not launder a real bypass"
 
 # Quotes that carry shell rather than prose: a quoted flag is still the
-# flag, a token split across quotes is still the token, an interpreter's
-# script argument is still shell, and so is a command substitution.
+# flag, and a token split across quotes is still the token. Past those,
+# nothing here decides which quoted region an interpreter will run — any
+# sign that one might (eval, a -c cluster whatever separates it from its
+# script, a pipe, a substitution, a here-string, a heredoc) drops nothing
+# at all, so a form this list does not name is scanned rather than missed.
 for form in \
   'git commit "--no-verify" -m x' \
   'git commit --no-"verify" -m x' \
@@ -374,12 +376,31 @@ for form in \
   'sh -lc "git commit -n -m x"' \
   'eval "git commit --no-verify -m x"' \
   'echo "$(git commit --no-verify -m x)"' \
-  'git commit --no-verify -m "unterminated'; do
+  'git commit --no-verify -m "unterminated' \
+  'bash -c -- "git commit --no-verify -m x"' \
+  'sh -c -- "git commit --no-verify -m x"' \
+  'eval -- "git commit --no-verify -m x"' \
+  "eval 'x=1;' 'git commit --no-verify -m x'" \
+  "bash <<< 'git commit --no-verify -m x'" \
+  'printf "git commit --no-verify -m x" | bash'; do
   run_hook "$ARMED" "$(jpayload "$form")" KENDEX_EXIT=0
   assert_eq "$rc" "2" "still refused: $form"
   assert_contains "$err" "bypasses this repository's armed git hooks" "the refusal names the bypass: $form"
   assert_not_contains "$log" "kendex" "no chain stands in for the bypassed hooks: $form"
 done
+
+# A heredoc, whose newlines arrive as \n escapes in the payload.
+run_hook "$ARMED" "$(payload 'bash <<EOF\ngit commit --no-verify -m x\nEOF')" KENDEX_EXIT=0
+assert_eq "$rc" "2" "a heredoc feeding an interpreter is refused"
+assert_contains "$err" "bypasses this repository's armed git hooks" "the refusal names the heredoc's bypass"
+
+# The deliberate trade for that: prose quoting the flag is data only while
+# nothing on the line could execute it. A backtick anywhere — inert inside
+# single quotes, but this lane does not parse quoting to prove it — costs a
+# refusal, and rewording the description is the fix.
+run_hook "$ARMED" "$(jpayload "linear.sh issues create --description 'run \`git commit --no-verify\` to skip'")" KENDEX_EXIT=0
+assert_eq "$rc" "2" "a backtick on the line keeps the quoted mention in the scan"
+assert_contains "$err" "bypasses this repository's armed git hooks" "and that mention reads as the bypass it spells"
 
 # Detection survives an interpreter's quotes too: no bypass, but the
 # commit inside still reaches the fallback gate.

--- a/tools/size-ratchet-baseline.tsv
+++ b/tools/size-ratchet-baseline.tsv
@@ -7,7 +7,7 @@ crates/core/src/engine/ops/add.rs	549
 crates/core/src/error.rs	429
 crates/core/src/quality/author.rs	458
 crates/core/src/remote/store.rs	420
-docs/ARCHITECTURE.md	911
+docs/ARCHITECTURE.md	917
 hooks/block-repo-copy.sh	511
 pi-extensions/pi-agents-tmux/extensions/subagent/browser.ts	650
 pi-extensions/pi-agents-tmux/extensions/subagent/dashboard.ts	431


### PR DESCRIPTION
## Summary

- The `pre-commit-check` PreToolUse hook matched the bypass flag string anywhere in a command's text, so it refused a `linear.sh issues create` whose quoted issue description merely mentioned the flag. (It refused this PR's own probe script for the same reason.)
- The word scan now runs over the command with its quoted multi-word arguments dropped, so a mention inside quoted data is data. Everything the shell would actually execute stays in scope.

Deliberately kept as shell, not data, because the shell treats it that way:

- a quoted region with no whitespace — a quoted flag, or half a token split across quotes
- a double-quoted region containing `$(` or a backtick
- the argument handed to an interpreter: after `eval`, or after a short-flag cluster ending in `c`, as `bash -c` and `sh -lc` spell it
- an unterminated quote, kept whole

Every ambiguity resolves toward keeping the text and paying a refusal to reword. Without `awk` the command cannot be read at all, which is refused like any unparseable payload.

## Test Plan

`hooks/tests/pre-commit-check.test.sh` 154 pass / 0 fail; full `tools/guard` green.

I probed the built hook adversarially outside its own suite — 14 cases, all correct. Refused: the long flag, the short form, the flag placed after the message, chained after `&&` and after `;`, inside `$(...)`, `git -c core.hooksPath=` injection, a quoted flag, and `bash -c` / `sh -lc` / `eval` wrappers. Allowed: a quoted prose mention, a plain commit, an unrelated command.

`RATCHET_RAISE=1` on the `docs/ARCHITECTURE.md` row: four lines recording what the word match now runs over, which is the contract this change establishes.

## Completed Issues

- Closes KEN-576 - pre-commit-check hook refuses any Bash command containing the bypass flag string, not just git commits
