### PR TITLE
docs(changelog): who refuses a hook bypass, how v1 settings convert (KEN-575)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,9 +50,9 @@ an outside contributor.
 - **Breaking:** the default Homebrew formula installs the app; CLI-only
   moved to `kendex-cli`. Migrate with `brew uninstall kendex && brew
   install vanillagreencom/kendex/kendex-cli`.
-- Commit checks moved into the git pre-commit hook, which now also runs
-  rust-fmt, rust-clippy, and biome; commands that sidestep the armed hook
-  (`--no-verify`, hook-skipping git config) are refused.
+- Commit checks moved into the git pre-commit hook, which also runs rust-fmt,
+  rust-clippy, and biome; kendex's harness hook refuses `--no-verify` and
+  hook-skipping git config. v1 guard settings convert with `kendex guard import-v1`.
 - **Breaking:** `KENDEX_PRE_COMMIT_RUST_CLIPPY` is gone. To disable the
   lane, set `enabled = false` under `[guards.rust-clippy]` in
   `kendex.settings.toml`; a custom command moves to `KENDEX_GUARD_PRE_COMMIT_LOCAL`.


### PR DESCRIPTION
## Summary

Two fidelity fixes to the Unreleased commit-checks entry, both frozen out of #1619 rather than taken as a sixth patch round there.

- **Who refuses a bypass.** The entry said commands that sidestep the armed hook "are refused", unqualified. That is kendex's harness-level hook, not the installed git hook — a direct `git commit` with the flag outside a harness still bypasses. The actor is now named.
- **How v1 settings convert.** A repo with v1 `SIZE_RATCHET_*` / `GROWTH_GUARDS_*` settings and no `[guards]` tables fails closed after the move, and the entry no longer said what the conversion is. `kendex guard import-v1` is back.

## Test Plan

`tools/guard` exits 0 — including its new rule capping a CHANGELOG entry at three lines, which the amended entry stays within. preflight and size-ratchet clean.

## Completed Issues

- Closes KEN-575 - Changelog rewrite: residual condensation-fidelity findings (frozen out of #1619)
