### PR TITLE
test(ui): store-driven component tests mount a DOM (KEN-530)

### DIFF
--- a/ui/src/components/customize/customized-index.test.tsx
+++ b/ui/src/components/customize/customized-index.test.tsx
@@ -1,7 +1,5 @@
 // @vitest-environment jsdom
-import { act } from "react";
-import { createRoot, type Root } from "react-dom/client";
-import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { beforeEach, describe, expect, it } from "vitest";
 import type { Scope } from "@/bindings";
 import {
   CUSTOMIZED_CHECKING,
@@ -13,11 +11,8 @@ import {
 import type { CustomizedHere } from "@/lib/customized-places";
 import type { UpdatesReadState } from "@/lib/updates-read-state";
 import { useScanStore } from "@/stores/scan";
+import { mount } from "@/test/dom";
 import { CustomizedIndex } from "./customized-index";
-
-(
-  globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }
-).IS_REACT_ACT_ENVIRONMENT = true;
 
 const VG: Scope = { scope: "project", root: "/work/vg" };
 
@@ -52,35 +47,18 @@ const row = (over: Partial<CustomizedHere> = {}): CustomizedHere => ({
 // Mounted rather than rendered to a string: a static render reads a
 // zustand store's initial snapshot, and the scan store is what says
 // whether a row's package is installed here.
-const mounted: Root[] = [];
 const render = (
   items: CustomizedHere[],
   updates: UpdatesReadState = "landed",
-): string => {
-  const host = document.createElement("div");
-  document.body.append(host);
-  const root = createRoot(host);
-  mounted.push(root);
-  act(() => {
-    root.render(
-      <CustomizedIndex
-        items={items}
-        scope={VG}
-        updates={updates}
-        onRemove={() => {}}
-      />,
-    );
-  });
-  return host.innerHTML;
-};
-
-afterEach(() => {
-  act(() => {
-    for (const root of mounted) root.unmount();
-  });
-  mounted.length = 0;
-  document.body.replaceChildren();
-});
+): string =>
+  mount(
+    <CustomizedIndex
+      items={items}
+      scope={VG}
+      updates={updates}
+      onRemove={() => {}}
+    />,
+  ).innerHTML;
 
 describe("CustomizedIndex", () => {
   beforeEach(() => {

--- a/ui/src/components/harnesses/harness-row.test.tsx
+++ b/ui/src/components/harnesses/harness-row.test.tsx
@@ -1,11 +1,10 @@
 // @vitest-environment jsdom
 import userEvent from "@testing-library/user-event";
-import { act } from "react";
-import { createRoot, type Root } from "react-dom/client";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { harnessName } from "@/lib/labels";
 import { showEverythingLabel } from "@/lib/show-everything-label";
 import { useNavStore } from "@/stores/nav";
+import { mount as mountTree } from "@/test/dom";
 import { HarnessRow } from "./harness-row";
 
 // The nav store is the real one — whether a click lands the Library on the
@@ -13,34 +12,22 @@ import { HarnessRow } from "./harness-row";
 // page that is not the Library and no pending filter.
 const navHome = { page: "home" as const, libraryFilter: null };
 
-const mounted: Root[] = [];
 afterEach(() => {
-  act(() => {
-    for (const root of mounted) root.unmount();
-  });
-  mounted.length = 0;
-  document.body.replaceChildren();
   vi.restoreAllMocks();
 });
 
 const mount = (detectedRoot: string | null) => {
   useNavStore.setState(navHome);
-  const host = document.body.appendChild(document.createElement("div"));
-  const root = createRoot(host);
-  mounted.push(root);
-  act(() =>
-    root.render(
-      <HarnessRow
-        id="claude"
-        detectedRoot={detectedRoot}
-        version={null}
-        counts={[["skill", 3]]}
-        folder=""
-        onFolderChange={() => {}}
-      />,
-    ),
+  return mountTree(
+    <HarnessRow
+      id="claude"
+      detectedRoot={detectedRoot}
+      version={null}
+      counts={[["skill", 3]]}
+      folder=""
+      onFolderChange={() => {}}
+    />,
   );
-  return host;
 };
 
 const label = showEverythingLabel(harnessName("claude"));

--- a/ui/src/components/library/installed-row.test.tsx
+++ b/ui/src/components/library/installed-row.test.tsx
@@ -76,7 +76,8 @@ afterEach(() => {
 
 const mount = (forkedIn: Scope[] = [], mark: PlaceMark | null = null) => {
   const onOpen = vi.fn();
-  // A tr needs a table around it for the DOM to keep the row a row.
+  // A table host, so the row is mounted inside the structure it renders
+  // for rather than under a div.
   const host = mountTree(
     <tbody>
       <InstalledRow

--- a/ui/src/components/library/installed-row.test.tsx
+++ b/ui/src/components/library/installed-row.test.tsx
@@ -1,13 +1,12 @@
 // @vitest-environment jsdom
 import userEvent from "@testing-library/user-event";
-import { act } from "react";
-import { createRoot, type Root } from "react-dom/client";
 import { renderToStaticMarkup } from "react-dom/server";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import type { Scope } from "@/bindings";
 import { FORKED_BADGE_LABEL } from "@/lib/copy";
 import { groupItems } from "@/lib/derive";
 import type { PlaceMark } from "@/lib/place-marks";
+import { mount as mountTree } from "@/test/dom";
 import { InstalledRow } from "./installed-row";
 
 const VG: Scope = { scope: "project", root: "/work/vg" };
@@ -71,34 +70,24 @@ describe("the row's customized mark", () => {
 
 // Whether a click reaches the row, and what a keypress lands on, are
 // questions about a live DOM that static markup cannot answer.
-const mounted: Root[] = [];
 afterEach(() => {
-  act(() => {
-    for (const root of mounted) root.unmount();
-  });
-  mounted.length = 0;
-  document.body.replaceChildren();
   vi.restoreAllMocks();
 });
 
 const mount = (forkedIn: Scope[] = [], mark: PlaceMark | null = null) => {
   const onOpen = vi.fn();
   // A tr needs a table around it for the DOM to keep the row a row.
-  const host = document.body.appendChild(document.createElement("table"));
-  const root = createRoot(host);
-  mounted.push(root);
-  act(() =>
-    root.render(
-      <tbody>
-        <InstalledRow
-          group={group}
-          origin={null}
-          mark={mark}
-          forkedIn={forkedIn}
-          onOpen={onOpen}
-        />
-      </tbody>,
-    ),
+  const host = mountTree(
+    <tbody>
+      <InstalledRow
+        group={group}
+        origin={null}
+        mark={mark}
+        forkedIn={forkedIn}
+        onOpen={onOpen}
+      />
+    </tbody>,
+    { host: "table" },
   );
   return { host, onOpen };
 };

--- a/ui/src/components/marketplaces/packages-table.test.tsx
+++ b/ui/src/components/marketplaces/packages-table.test.tsx
@@ -1,9 +1,8 @@
 // @vitest-environment jsdom
 import userEvent from "@testing-library/user-event";
 import { act } from "react";
-import { createRoot, type Root } from "react-dom/client";
 import { renderToStaticMarkup } from "react-dom/server";
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import type { AvailablePackage, PackageSafety, Verdict } from "@/bindings";
 import {
   PREINSTALL_SAFETY_CAVEAT,
@@ -13,6 +12,7 @@ import {
 import { subscription } from "@/stores/marketplaces-shared";
 import { useNavStore } from "@/stores/nav";
 import { safetyKey } from "@/stores/preinstall-safety";
+import { mount as mountTree } from "@/test/dom";
 import { PackagesTable } from "./packages-table";
 
 // Static rendering reads a zustand store's initial snapshot, so the score
@@ -124,27 +124,12 @@ describe("the safety dot in the packages list", () => {
 
 // The activation tests need a live DOM: whether a click reaches the row is a
 // question about event propagation, which static markup cannot answer.
-const mounted: Root[] = [];
-// A tooltip left open by one test is in the document the next one reads.
-afterEach(() => {
-  act(() => {
-    for (const root of mounted) root.unmount();
-  });
-  mounted.length = 0;
-  document.body.replaceChildren();
-});
-
 const mount = (safety: PackageSafety | null) => {
   stub.scores = safety ? { [safetyKey(catalog, "skill", "gh")]: safety } : {};
   const goToAvailablePackage = vi.fn();
   useNavStore.setState({ goToAvailablePackage });
-  const host = document.body.appendChild(document.createElement("div"));
-  const root = createRoot(host);
-  mounted.push(root);
-  act(() =>
-    root.render(
-      <PackagesTable entries={[{ catalog, row }]} showMarketplace={false} />,
-    ),
+  const host = mountTree(
+    <PackagesTable entries={[{ catalog, row }]} showMarketplace={false} />,
   );
   const dot = host.querySelector<HTMLButtonElement>(
     '[data-slot="tooltip-trigger"]',

--- a/ui/src/pages/package.test.tsx
+++ b/ui/src/pages/package.test.tsx
@@ -36,15 +36,16 @@ vi.mock("@/bindings", async (importOriginal) => ({
   },
 }));
 
-const VG: Scope = { scope: "project", root: "/work/vg" };
-const HYPR: Scope = { scope: "project", root: "/work/hyprtrade" };
+type Project = Extract<Scope, { scope: "project" }>;
+const VG: Project = { scope: "project", root: "/work/vg" };
+const HYPR: Project = { scope: "project", root: "/work/hyprtrade" };
 
-const installedAt = (scope: Scope): ObservedItem => ({
+const installedAt = (scope: Project): ObservedItem => ({
   kind: "skill",
   name: "gh",
   scope,
   harness: "claude",
-  path: `${scope.scope === "project" ? scope.root : ""}/.claude/skills/gh`,
+  path: `${scope.root}/.claude/skills/gh`,
   fileState: { state: "file" },
   enabled: true,
   origin: null,
@@ -66,8 +67,8 @@ const nothing = { status: "error" as const, error: "not in this test" };
 /** Mount the page about `gh` at `here`, with the package installed in
  *  every place of `installed` and each place's manifest as given. */
 const openPage = async (
-  here: Scope,
-  installed: Scope[],
+  here: Project,
+  installed: Project[],
   manifests: Record<string, Manifest_Serialize>,
 ) => {
   vi.mocked(commands.getManifest).mockImplementation((scope) =>
@@ -98,7 +99,7 @@ const openPage = async (
 
 // What the Customize tab does when its project chip is clicked: the
 // editor's open draft becomes another place's.
-const editElsewhere = (scope: Scope) =>
+const editElsewhere = (scope: Project) =>
   act(() => useEditorStore.getState().setScope(scope));
 
 const title = (host: HTMLElement) => host.querySelector("h1")?.textContent;
@@ -179,6 +180,21 @@ describe("the package page's file actions", () => {
     if (!item) throw new Error(`no "${label}" entry in the open menu`);
     await userEvent.click(item);
   };
+
+  it("leave with the page when this place has no copy", async () => {
+    // Installed elsewhere only. Another place's copy is not a stand-in:
+    // the page describing one place while its buttons work on another is
+    // the fault this page exists to avoid, so it goes back instead.
+    const back = vi.fn();
+    useNavStore.setState({ back });
+    const host = await openPage(VG, [HYPR], {});
+    expect(back).toHaveBeenCalled();
+    expect(
+      Array.from(host.querySelectorAll("button")).some(
+        (button) => button.textContent === OPEN_IN_LABEL,
+      ),
+    ).toBe(false);
+  });
 
   it("open the copy in the place the page names", async () => {
     // hyprtrade's copy is listed first, so a page that took the first

--- a/ui/src/pages/package.test.tsx
+++ b/ui/src/pages/package.test.tsx
@@ -1,0 +1,198 @@
+// @vitest-environment jsdom
+import userEvent from "@testing-library/user-event";
+import { act } from "react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { Manifest_Serialize, ObservedItem, Scope } from "@/bindings";
+import { commands } from "@/bindings";
+import {
+  OPEN_IN_EDITOR_LABEL,
+  OPEN_IN_FILE_BROWSER_LABEL,
+  OPEN_IN_LABEL,
+} from "@/lib/copy";
+import { editorOpenPath } from "@/lib/editor-path";
+import { scopeKey } from "@/lib/scope";
+import { useEditorStore } from "@/stores/editor";
+import { useNavStore } from "@/stores/nav";
+import { useScanStore } from "@/stores/scan";
+import { useUpdatesStore } from "@/stores/updates";
+import { mount, settle } from "@/test/dom";
+import { PackagePage } from "./package";
+
+// The page is mounted against the real stores; only the backend is
+// stubbed. Each command the page or its children call on mount answers
+// with nothing, except the manifest read, which answers per place.
+vi.mock("@/bindings", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("@/bindings")>()),
+  commands: {
+    packageMeta: vi.fn(),
+    packageFiles: vi.fn(),
+    packageVersions: vi.fn(),
+    packageReadme: vi.fn(),
+    getManifest: vi.fn(),
+    editorInventory: vi.fn(),
+    revealPath: vi.fn(),
+    openInEditor: vi.fn(),
+    libraryProvenance: vi.fn(),
+  },
+}));
+
+const VG: Scope = { scope: "project", root: "/work/vg" };
+const HYPR: Scope = { scope: "project", root: "/work/hyprtrade" };
+
+const installedAt = (scope: Scope): ObservedItem => ({
+  kind: "skill",
+  name: "gh",
+  scope,
+  harness: "claude",
+  path: `${scope.scope === "project" ? scope.root : ""}/.claude/skills/gh`,
+  fileState: { state: "file" },
+  enabled: true,
+  origin: null,
+  description: "about gh",
+  tags: [],
+  modifiedAt: null,
+  vendor: null,
+});
+
+const PLAIN: Manifest_Serialize = { schema: 1, install: {} };
+const CUSTOMIZED: Manifest_Serialize = {
+  schema: 1,
+  install: {},
+  "skill-instructions": { gh: "mine" },
+};
+
+const nothing = { status: "error" as const, error: "not in this test" };
+
+/** Mount the page about `gh` at `here`, with the package installed in
+ *  every place of `installed` and each place's manifest as given. */
+const openPage = async (
+  here: Scope,
+  installed: Scope[],
+  manifests: Record<string, Manifest_Serialize>,
+) => {
+  vi.mocked(commands.getManifest).mockImplementation((scope) =>
+    Promise.resolve({
+      status: "ok",
+      data: { manifest: manifests[scopeKey(scope)] ?? null, base: null },
+    }),
+  );
+  useScanStore.setState({
+    result: {
+      harnesses: [],
+      items: installed.map(installedAt),
+      missingProjects: [],
+      warnings: [],
+    },
+  });
+  useNavStore.setState({
+    page: "package",
+    packageRef: { kind: "skill", name: "gh", scope: here },
+    packageView: null,
+  });
+  const host = mount(<PackagePage />);
+  // The page points the editor at its own place on mount, and that read
+  // has to land before the editor can be pointed anywhere else.
+  await settle();
+  return host;
+};
+
+// What the Customize tab does when its project chip is clicked: the
+// editor's open draft becomes another place's.
+const editElsewhere = (scope: Scope) =>
+  act(() => useEditorStore.getState().setScope(scope));
+
+const title = (host: HTMLElement) => host.querySelector("h1")?.textContent;
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  vi.mocked(commands.packageMeta).mockResolvedValue(nothing);
+  vi.mocked(commands.packageFiles).mockResolvedValue(nothing);
+  vi.mocked(commands.packageVersions).mockResolvedValue(nothing);
+  vi.mocked(commands.packageReadme).mockResolvedValue(nothing);
+  vi.mocked(commands.editorInventory).mockResolvedValue(nothing);
+  vi.mocked(commands.libraryProvenance).mockResolvedValue(nothing);
+  vi.mocked(commands.revealPath).mockResolvedValue({
+    status: "ok",
+    data: null,
+  });
+  vi.mocked(commands.openInEditor).mockResolvedValue({
+    status: "ok",
+    data: null,
+  });
+  useEditorStore.setState({
+    scope: { scope: "global" },
+    draft: null,
+    base: null,
+    saved: {},
+    dirty: false,
+  });
+  useUpdatesStore.setState({ rows: [], loaded: true });
+});
+
+// The header names a place, and the editor is pointed wherever the
+// Customize tab was last used. Those are different places the moment the
+// tab's project chip is clicked, and the mark has to keep answering for
+// the one the page is about.
+describe("the package page's header mark", () => {
+  it("still names this place after the editor moves to another", async () => {
+    const host = await openPage(VG, [VG, HYPR], {
+      [scopeKey(VG)]: CUSTOMIZED,
+      [scopeKey(HYPR)]: PLAIN,
+    });
+    expect(title(host)).toContain("Customized in vg");
+
+    await editElsewhere(HYPR);
+    expect(useEditorStore.getState().scope).toEqual(HYPR);
+    expect(title(host)).toContain("Customized in vg");
+  });
+
+  it("does not borrow the mark of the place the editor moved to", async () => {
+    const host = await openPage(VG, [VG, HYPR], {
+      [scopeKey(VG)]: PLAIN,
+      [scopeKey(HYPR)]: CUSTOMIZED,
+    });
+    expect(title(host)).not.toContain("Customized");
+
+    await editElsewhere(HYPR);
+    expect(useEditorStore.getState().draft).toEqual(CUSTOMIZED);
+    expect(title(host)).not.toContain("Customized");
+  });
+});
+
+// A package installed in two places has two copies on disk. The page
+// names one of them, so the actions that open a file open that copy —
+// not whichever installation the scan happened to list first.
+describe("the package page's file actions", () => {
+  const openIn = async (host: HTMLElement, label: string) => {
+    const trigger = Array.from(host.querySelectorAll("button")).find(
+      (button) => button.textContent === OPEN_IN_LABEL,
+    );
+    if (!trigger) throw new Error("no Open in… button rendered");
+    // Opened from the keyboard: the menu's pointer path wants pointer
+    // events jsdom does not deliver, and the item a keyboard reaches is
+    // wired to the same handler a pointer would reach.
+    trigger.focus();
+    await userEvent.keyboard("{ArrowDown}");
+    const item = Array.from(
+      document.querySelectorAll<HTMLElement>('[role="menuitem"]'),
+    ).find((entry) => entry.textContent === label);
+    if (!item) throw new Error(`no "${label}" entry in the open menu`);
+    await userEvent.click(item);
+  };
+
+  it("open the copy in the place the page names", async () => {
+    // hyprtrade's copy is listed first, so a page that took the first
+    // installation would open the wrong project's files.
+    const host = await openPage(VG, [HYPR, VG], {});
+
+    await openIn(host, OPEN_IN_FILE_BROWSER_LABEL);
+    expect(commands.revealPath).toHaveBeenCalledWith(
+      "/work/vg/.claude/skills/gh",
+    );
+
+    await openIn(host, OPEN_IN_EDITOR_LABEL);
+    expect(commands.openInEditor).toHaveBeenCalledWith(
+      editorOpenPath("/work/vg/.claude/skills/gh"),
+    );
+  });
+});

--- a/ui/src/test/dom.tsx
+++ b/ui/src/test/dom.tsx
@@ -1,0 +1,62 @@
+// The DOM harness for tests that read a zustand store through a component.
+//
+// `renderToStaticMarkup` is a server render: zustand's `useSyncExternalStore`
+// serves the store's initial snapshot, so a test that sets store state and
+// then renders sees none of it — and passes, against an empty page. A test
+// of store wiring needs a mounted tree, which is what this gives it.
+//
+// Prop-driven tests stay the default. Reach for this only where the thing
+// under test is the wiring itself: which scope a page passes, what a click
+// lands on, what a store change puts on screen.
+//
+// Every file that imports this carries `// @vitest-environment jsdom` on
+// its first line — the environment is chosen per file before any import
+// runs, so nothing here can choose it.
+import { act, type ReactNode } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach } from "vitest";
+
+if (typeof document === "undefined") {
+  throw new Error(
+    "@/test/dom needs a DOM: put `// @vitest-environment jsdom` on the test file's first line",
+  );
+}
+
+// React warns, and runs effects late, unless told the test drives it.
+(
+  globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }
+).IS_REACT_ACT_ENVIRONMENT = true;
+
+const mounted: Root[] = [];
+
+// A popup, tooltip, or menu left open by one test is in the document the
+// next one reads: every mount comes down, and the body is emptied, after
+// each test in the importing file.
+afterEach(() => {
+  act(() => {
+    for (const root of mounted) root.unmount();
+  });
+  mounted.length = 0;
+  document.body.replaceChildren();
+});
+
+/** Mount a tree into the document and return the element it sits in.
+ *
+ *  `host` is the element the tree renders into — a `table` for a `tr`,
+ *  which the DOM otherwise drops on the floor. */
+export function mount(
+  element: ReactNode,
+  { host = "div" }: { host?: keyof HTMLElementTagNameMap } = {},
+): HTMLElement {
+  const container = document.body.appendChild(document.createElement(host));
+  const root = createRoot(container);
+  mounted.push(root);
+  act(() => root.render(element));
+  return container;
+}
+
+/** Let every effect that awaits a promise land and re-render. A mount
+ *  runs effects synchronously, but an effect that calls a mocked command
+ *  resolves on the microtask queue, and the state it sets is not on
+ *  screen until that has drained. */
+export const settle = (): Promise<void> => act(async () => {});

--- a/ui/src/test/dom.tsx
+++ b/ui/src/test/dom.tsx
@@ -33,17 +33,24 @@ const mounted: Root[] = [];
 // next one reads: every mount comes down, and the body is emptied, after
 // each test in the importing file.
 afterEach(() => {
-  act(() => {
-    for (const root of mounted) root.unmount();
-  });
-  mounted.length = 0;
-  document.body.replaceChildren();
+  try {
+    act(() => {
+      for (const root of mounted) root.unmount();
+    });
+  } finally {
+    // An unmount that throws must not leave its tree, or the list that
+    // would throw again, for the next test to fail on.
+    mounted.length = 0;
+    document.body.replaceChildren();
+  }
 });
 
 /** Mount a tree into the document and return the element it sits in.
  *
- *  `host` is the element the tree renders into — a `table` for a `tr`,
- *  which the DOM otherwise drops on the floor. */
+ *  `host` is the element the tree renders into. It defaults to a `div`;
+ *  a component that renders a `tr` takes a `table`, so the mounted tree
+ *  is the HTML the component was written for rather than a row sitting
+ *  under a block. */
 export function mount(
   element: ReactNode,
   { host = "div" }: { host?: keyof HTMLElementTagNameMap } = {},


### PR DESCRIPTION
## Summary
- Store-driven component tests get a real DOM: `ui/src/test/dom.tsx` is the shared jsdom harness (`mount` through `react-dom/client` inside `act`, `settle` for promise-backed effects, one `afterEach` that unmounts and empties the body). It throws at import without a document, naming the `// @vitest-environment jsdom` pragma, so a file cannot half-adopt it.
- The four suites that each hand-rolled `createRoot`/`act` (customized-index, harness-row, installed-row, packages-table) move onto the harness with their assertions untouched.
- `ui/src/pages/package.test.tsx` covers the two cases #1595 could not: the page's header mark answers for the place the page names (not the editor's open scope), and the installation used for file actions belongs to that place — mounted against the real nav/scan/editor/updates stores with only the generated commands stubbed.
- Prop-driven tests stay on `renderToStaticMarkup`; the harness is for store wiring only (stated in its header).

## Completed Issues
- Closes KEN-530 - Store-driven component tests pass without rendering anything, so page wiring is untestable

## Test Plan
- Must-fail controls, red then restored: the mark asked about the editor's scope; the header reading the editor's draft; `group.installations[0]` as the primary; the mid-#1595 `?? installations[0]` fallback (killed by the no-copy-in-this-place case); importing `@/test/dom` without the pragma.
- reviewer-test mutation pass: 5/5 required mutants killed, stability 10/10 at 64 threads each; safety ran the changed suites 10× fixed order and 3× shuffled; full ui suite 90 files / 558+ tests green; tsc and biome clean.
- Related: KEN-454 tracks running the ui vitest suite in CI (today only the pre-commit guard runs it).
