### PR TITLE
fix(KEN-466): a scoped-path Pi carrier entry counts as registered

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,9 +10,9 @@ an outside contributor.
 
 ### Fixed
 
-- Pi hooks registered through a scoped package path such as
-  `./packages/@vanillagreen/pi-hooks` no longer draw the false "nothing
-  will run it" carrier warning from `kendex apply` and the audit page.
+- A pi-hooks carrier registered through a scoped path such as
+  `./packages/@vanillagreen/pi-hooks` no longer draws the false "nothing
+  will run it" warning from `kendex apply` and the Review & apply page.
 - Customize › Customized packages now lists every package you changed at
   that location, hand-edited and forked ones included, so it matches the
   Library's "Customized in" mark instead of only packages with settings.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ an outside contributor.
 
 ### Fixed
 
+- Pi hooks registered through a scoped package path such as
+  `./packages/@vanillagreen/pi-hooks` no longer draw the false "nothing
+  will run it" carrier warning from `kendex apply` and the audit page.
 - Customize › Customized packages now lists every package you changed at
   that location, hand-edited and forked ones included, so it matches the
   Library's "Customized in" mark instead of only packages with settings.

--- a/crates/core/src/pi_ext/carrier.rs
+++ b/crates/core/src/pi_ext/carrier.rs
@@ -113,6 +113,7 @@ mod tests {
             "@vanillagreen/pi-hooks",
             "./packages/@vanillagreen/pi-hooks",
             "/abs/path/packages/@vanillagreen/pi-hooks",
+            "./cache/foo@1.2.0/pi-hooks",
             "npm:@vanillagreen/pi-hooks@0.4.0",
             "npm:pi-hooks@1.2.3",
             "./packages/pi-hooks/",

--- a/crates/core/src/pi_ext/carrier.rs
+++ b/crates/core/src/pi_ext/carrier.rs
@@ -23,10 +23,13 @@ pub const CARRIER: &str = "pi-hooks";
 fn names_carrier(raw: &str) -> bool {
     let text = raw.strip_prefix("npm:").unwrap_or(raw);
     let text = text.trim_end_matches('/');
-    // A version suffix is the last `@` past position 0 — a scoped name's
-    // leading `@` is identity, not version.
+    // A version suffix is an `@` inside the last path segment, past that
+    // segment's first character — an `@` opening a segment is a scope
+    // (`@vanillagreen/pi-hooks`, `./packages/@vanillagreen/pi-hooks`),
+    // identity rather than version.
+    let segment = text.rfind('/').map_or(0, |slash| slash + 1);
     let text = match text.rfind('@') {
-        Some(at) if at > 0 => &text[..at],
+        Some(at) if at > segment => &text[..at],
         _ => text,
     };
     text == CARRIER || text.ends_with(&format!("/{CARRIER}"))
@@ -108,6 +111,8 @@ mod tests {
             "./packages/pi-hooks",
             "/abs/path/packages/pi-hooks",
             "@vanillagreen/pi-hooks",
+            "./packages/@vanillagreen/pi-hooks",
+            "/abs/path/packages/@vanillagreen/pi-hooks",
             "npm:@vanillagreen/pi-hooks@0.4.0",
             "npm:pi-hooks@1.2.3",
             "./packages/pi-hooks/",

--- a/crates/core/tests/pi_carrier.rs
+++ b/crates/core/tests/pi_carrier.rs
@@ -40,7 +40,7 @@ fn register_carrier(settings_dir: &Path) {
     fs::create_dir_all(settings_dir).unwrap();
     fs::write(
         settings_dir.join("settings.json"),
-        r#"{ "packages": ["./packages/pi-hooks"] }"#,
+        r#"{ "packages": ["./packages/@vanillagreen/pi-hooks"] }"#,
     )
     .unwrap();
 }


### PR DESCRIPTION
## Summary
- `names_carrier` treated the last `@` past position 0 as a version suffix, so a scoped package path like `./packages/@vanillagreen/pi-hooks` truncated to `./packages/` and a registered carrier drew the false "nothing will run it" warning from `kendex apply` and the Review & apply page.
- Version-stripping is now scoped to an `@` inside the last path segment past its first character; an `@` opening a segment is a scope, not a version.
- Unit spelling table gains the scoped-path and earlier-segment (`./cache/foo@1.2.0/pi-hooks`) cases; the `pi_carrier` integration fixture registers the carrier by its real scoped spelling, so the layering tests double as regression coverage.

## Completed Issues
- Closes KEN-466 - Pi carrier check reports "nothing will run it" while the carrier is registered globally

## Created Issues
- KEN-594 - Consolidate the three divergent Pi package-spec parsers — Project: Agent Harness Integrations

## Test Plan
- `cargo test -p kendex-core --lib pi_ext` (24 passed, includes the widened spelling table)
- `cargo test -p kendex-core --test pi_carrier` (6 passed; fixture now uses the scoped spelling and fails against the pre-fix parse)
- preflight and tools/guard clean

https://claude.ai/code/session_01KnnKByWWrorJHAUCWejs94
