### PR TITLE
fix(KEN-596): one path spelling rule turns the macOS cargo lane green

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,9 @@ an outside contributor.
 - A hook found in a settings file is safety-checked on its own entry, not
   the whole file: a `permissions.ask` guard naming `mkfs` no longer flags
   every hook beside it, and a hook whose own entry carries it still scores.
+- A project reached through a symlinked path no longer misreports an
+  editor save conflict as a plain failure or loses package update
+  timelines to a "history could not be read" warning.
 - A pi-hooks carrier registered through a scoped path such as
   `./packages/@vanillagreen/pi-hooks` no longer draws the false "nothing
   will run it" warning from `kendex apply` and the Review & apply page.

--- a/crates/app/src/editor/save/tests.rs
+++ b/crates/app/src/editor/save/tests.rs
@@ -149,6 +149,56 @@ fn a_legacy_scope_refusal_names_the_old_file_and_the_writer_survives() {
     assert!(!targets[0].exists(), "nothing may land at the new name");
 }
 
+/// The mid-apply refusal with the scope root reached through a symlink:
+/// the plan speaks the canonical spelling, so the targets a caller matches
+/// the refusal against must speak it too, whatever spelling the scope
+/// arrived under. macOS reaches every temp directory through `/var` →
+/// `/private/var` and runs the tests above this way; the link reproduces
+/// that shape on every platform.
+#[cfg(unix)]
+#[test]
+fn a_refusal_through_a_symlinked_root_is_still_the_stale_choice() {
+    let tmp = tempfile::tempdir().unwrap();
+    let env = Env::fake(tmp.path(), kendex_core::env::FakeOs::Linux);
+    let real = tmp.path().join("dev/app");
+    std::fs::create_dir_all(real.join(".claude")).unwrap();
+    std::fs::write(
+        real.join("kendex.toml"),
+        "schema = 4\n\n[install]\nharnesses = [\"claude\"]\n",
+    )
+    .unwrap();
+    std::os::unix::fs::symlink(tmp.path().join("dev"), tmp.path().join("via")).unwrap();
+    let scope = Scope::Project {
+        root: tmp.path().join("via/app"),
+    };
+
+    let path = manifest::manifest_path(&env, &scope);
+    let (read, base) = manifest::read_for_mutation(&path).unwrap();
+    let mut editor_copy = read.unwrap();
+    // The old schema keeps the upgrade in the plan — the manifest write
+    // the base binds to, exactly as in the direct-spelling test above.
+    editor_copy.schema = 4;
+    let lock = load_lock(&lock_path(&env, &scope)).unwrap();
+    let options = PlanOptions {
+        manifest_base: Some(base),
+        ..PlanOptions::default()
+    };
+    let report = engine::plan_scope(&env, &scope, &editor_copy, &lock, &options).unwrap();
+
+    // The writer in between, landing through the same link.
+    std::fs::write(
+        &path,
+        "schema = 4\n\n[skill-instructions]\nall = \"kept\"\n",
+    )
+    .unwrap();
+
+    let error = apply::execute(&env, &report.plan, None).unwrap_err();
+    assert!(
+        stale_at(&error, &manifest::manifest_paths(&env, &scope)),
+        "{error:?}"
+    );
+}
+
 #[test]
 fn a_save_carrying_the_base_of_the_file_it_read_lands() {
     let (_tmp, env, scope) = scope_with_manifest();

--- a/crates/cli/tests/unmanaged_exits/refusals.rs
+++ b/crates/cli/tests/unmanaged_exits/refusals.rs
@@ -86,6 +86,11 @@ fn an_exit_read_in_the_global_scope_says_so() {
         "---\nname: deploy\ndescription: ship it\n---\nUpstream.\n",
     )
     .unwrap();
+    // The platform config root the binary itself resolves: macOS reads
+    // Library/Application Support and ignores XDG variables entirely.
+    #[cfg(target_os = "macos")]
+    let global = home.join("Library/Application Support/kendex");
+    #[cfg(not(target_os = "macos"))]
     let global = home.join(".config/kendex");
     fs::create_dir_all(&global).unwrap();
     fs::write(

--- a/crates/core/src/hash/tests.rs
+++ b/crates/core/src/hash/tests.rs
@@ -68,8 +68,10 @@ fn as_is_hash_cannot_be_forged_by_bytes_that_spell_a_boundary() {
 
 /// Names go in as the bytes the OS holds, so two names that are not
 /// UTF-8 stay two names instead of collapsing into one replacement
-/// character.
-#[cfg(unix)]
+/// character. Only Linux can create such names — APFS refuses filenames
+/// that are not valid UTF-8 — so the case is built there and the property
+/// holds by the same code path everywhere.
+#[cfg(target_os = "linux")]
 #[test]
 fn as_is_hash_keeps_distinct_non_utf8_names_distinct() {
     use std::os::unix::ffi::OsStrExt as _;

--- a/crates/core/src/import_v1/migrate.rs
+++ b/crates/core/src/import_v1/migrate.rs
@@ -19,9 +19,12 @@ fn err(scope: &Scope, message: impl std::fmt::Display) -> CoreError {
 }
 
 /// Where v1 kept this scope's lock. A project shares the v2 path; the
-/// global scopes differ.
+/// global scopes differ. Off the canonical root, like every scope-path
+/// derivation (`rename::manifest_pair`): `migrate_scope` compares this
+/// against `lock::lock_path` to detect the shared-path case, and two
+/// spellings of one file must not read as two files.
 pub fn v1_lock_path(env: &Env, scope: &Scope) -> PathBuf {
-    match scope {
+    match &scope.canonical() {
         Scope::Global => env.platform_config_dir().join("vstack/.vstack-lock.json"),
         Scope::Project { root } => root.join(".vstack-lock.json"),
     }

--- a/crates/core/src/import_v1/tests.rs
+++ b/crates/core/src/import_v1/tests.rs
@@ -214,3 +214,27 @@ fn contested_settings_seeds_import_legacy_owned() {
         outcome.notes
     );
 }
+
+/// A symlinked project's v1 lock is the shared-path case whatever spelling
+/// the scope arrived under: both lock paths derive from the canonical root,
+/// so the same file can never compare unequal and be refused as a foreign
+/// v1 record sitting at the v2 path (macOS reaches every temp directory
+/// through the `/var` → `/private/var` link).
+#[cfg(unix)]
+#[test]
+#[allow(clippy::unwrap_used)]
+fn a_symlinked_project_migrates_its_v1_lock() {
+    let tmp = tempfile::tempdir().unwrap();
+    let env = crate::env::Env::fake(tmp.path(), crate::env::FakeOs::Linux);
+    let real = tmp.path().join("dev/app");
+    std::fs::create_dir_all(real.join(".claude")).unwrap();
+    std::fs::write(real.join("vstack.toml"), V1_MANIFEST).unwrap();
+    std::fs::write(real.join(".vstack-lock.json"), V1_LOCK).unwrap();
+    std::os::unix::fs::symlink(tmp.path().join("dev"), tmp.path().join("via")).unwrap();
+    let scope = crate::model::Scope::Project {
+        root: tmp.path().join("via/app"),
+    };
+
+    let migration = super::migrate::migrate_scope(&env, &scope).unwrap();
+    assert!(migration.migrated.is_some(), "{:?}", migration.notes);
+}

--- a/crates/core/src/lock.rs
+++ b/crates/core/src/lock.rs
@@ -231,7 +231,10 @@ pub fn parse_entry_key(key: &str) -> Option<(ItemKind, &str, HarnessId)> {
 /// when only it exists — the rename op moves it (the global lock is
 /// `lock.json` in both generations, so only projects have two spellings).
 pub fn lock_path(env: &Env, scope: &Scope) -> PathBuf {
-    match scope {
+    // Off the canonical root, like every scope-path derivation
+    // (`rename::manifest_pair`): the path must compare equal to the ones
+    // the engine's plan speaks, whatever spelling the scope arrived under.
+    match &scope.canonical() {
         Scope::Global => env.global_lock_file(),
         Scope::Project { root } => crate::rename::existing_or_new(
             Env::project_lock_file(root),

--- a/crates/core/src/package/mod.rs
+++ b/crates/core/src/package/mod.rs
@@ -114,13 +114,17 @@ pub(crate) fn package_ref_for(
         let crate::source::SourceState::Ready(ready) = state else {
             return None;
         };
-        let sealed = SealedSource::open(&ready.root).ok()?;
+        let effective = SealedSource::open(&ready.root).ok()?;
         let config =
-            crate::source::source_config(&sealed, crate::source::repo_leaf(&ready.provenance))
+            crate::source::source_config(&effective, crate::source::repo_leaf(&ready.provenance))
                 .ok()?;
-        crate::source::find_item(&sealed, &config, kind, name)
-            .and_then(|path| path.strip_prefix(&ready.root).ok().map(Path::to_path_buf))
-            .map(|rel| root.join(rel))
+        crate::source::find_item(&effective, &config, kind, name)
+            .and_then(|path| {
+                path.strip_prefix(effective.root())
+                    .ok()
+                    .map(Path::to_path_buf)
+            })
+            .map(|rel| sealed.root().join(rel))
     });
     let Some(item_path) = item_path else {
         return Err(CoreError::ItemNotInSource {
@@ -128,10 +132,20 @@ pub(crate) fn package_ref_for(
             source_name,
         });
     };
+    // Both arms above speak the seal's canonical spelling, so the strip is
+    // against `sealed.root()`, never the spelling `published` handed back —
+    // under a symlinked checkout root (macOS's `/var` → `/private/var`) the
+    // two differ, and a miss must refuse rather than hand git an absolute
+    // pathspec it reads as outside the mirror.
     let subtree = item_path
-        .strip_prefix(&root)
+        .strip_prefix(sealed.root())
         .map(Path::to_path_buf)
-        .unwrap_or_else(|_| item_path.clone());
+        .map_err(|_| {
+            CoreError::io(
+                &item_path,
+                std::io::Error::other("item path is not under the sealed checkout root"),
+            )
+        })?;
     Ok(PackageRef {
         repo,
         mirror,

--- a/crates/core/src/rename/mod.rs
+++ b/crates/core/src/rename/mod.rs
@@ -87,8 +87,14 @@ pub fn refuse_both_generations(path: &Path) -> Result<()> {
     Ok(())
 }
 
+/// Every scope-derived manifest path is born here, off the canonical root
+/// ([`Scope::canonical`]): the engine plans against canonical spellings, so
+/// a caller matching a plan's refusal against paths derived here must hear
+/// the same spelling — under a symlinked root (macOS's `/var` →
+/// `/private/var` temp layout, a linked project directory) the two would
+/// otherwise name one file two ways.
 pub(crate) fn manifest_pair(env: &Env, scope: &Scope) -> (PathBuf, PathBuf) {
-    match scope {
+    match &scope.canonical() {
         Scope::Global => (
             env.global_manifest_file(),
             env.legacy_global_manifest_file(),

--- a/crates/core/src/rename/mod.rs
+++ b/crates/core/src/rename/mod.rs
@@ -117,6 +117,9 @@ pub(crate) fn manifest_pair(env: &Env, scope: &Scope) -> (PathBuf, PathBuf) {
 /// `.gitignore` line and the local-source directory ride along because
 /// kendex wrote both under the old name.
 pub fn rename_ops(env: &Env, scope: &Scope) -> Result<Vec<PlannedOp>> {
+    // Ops speak the canonical spelling whatever the caller's scope holds,
+    // like every scope-path derivation here (see `manifest_pair`).
+    let scope = &scope.canonical();
     let mut ops = Vec::new();
     // For a source catalog `manifest_pair` names the sibling install file;
     // its kendex.toml is the definition, which moves on its own op below.
@@ -257,6 +260,10 @@ pub fn rename_prefix_len(ops: &[PlannedOp]) -> usize {
 /// observed at the old path still holds at the new one — and an on-disk
 /// symlink keeps its old target until the op itself relinks it.
 pub fn retarget(env: &Env, scope: &Scope, ops: &mut [PlannedOp]) {
+    // The remapped pairs must speak the spelling the ops carry — canonical,
+    // like every scope-path derivation here (see `manifest_pair`) — or a
+    // strip miss would leave an op silently pointed at the old name.
+    let scope = &scope.canonical();
     let (new_manifest, old_manifest) = manifest_pair(env, scope);
     let mut pairs = vec![(old_manifest, new_manifest)];
     if let Scope::Project { root } = scope {

--- a/crates/core/src/source/browse/tests/summary.rs
+++ b/crates/core/src/source/browse/tests/summary.rs
@@ -7,10 +7,15 @@ use super::{cat, project, skill, sources_decl};
 #[test]
 fn a_subscription_summary_answers_with_itself_and_counts_its_offer() {
     let tmp = tempfile::tempdir().unwrap();
-    let catalog = tmp.path().join("catalog");
+    // Provenance speaks the canonical spelling `resolve` fixes where a
+    // declared path enters, so the fixture enters canonical space once —
+    // macOS reaches its temp directories through a `/var` → `/private/var`
+    // symlink, and a declared spelling would compare unequal to it.
+    let root = tmp.path().canonicalize().unwrap();
+    let catalog = root.join("catalog");
     skill(&catalog, "skills", "gh", "body");
     skill(&catalog, "skills", "extra", "body");
-    let (env, scope) = project(tmp.path(), &sources_decl(&catalog));
+    let (env, scope) = project(&root, &sources_decl(&catalog));
 
     let report = summary(&env, &cat(&scope)).unwrap();
     assert_eq!(

--- a/crates/core/tests/edits_and_forks/edited_harness.rs
+++ b/crates/core/tests/edits_and_forks/edited_harness.rs
@@ -383,3 +383,36 @@ fn a_source_level_hold_names_the_source_as_owner() {
     let row = report.rows.iter().find(|row| row.name == "gh").unwrap();
     assert_eq!(row.hold_owner, Some(HoldOwner::Package));
 }
+
+/// The updates chain read through a symlinked home: the published checkout
+/// is reached under the link's spelling while the seal speaks the canonical
+/// one, and the package's subtree must still resolve against the mirror —
+/// a mixed spelling hands git an absolute pathspec it refuses, and the row
+/// silently loses its timeline. macOS runs every test this way (`/var` →
+/// `/private/var`); the link makes the same shape hold on every platform.
+#[test]
+#[allow(clippy::unwrap_used)]
+fn updates_still_read_history_under_a_symlinked_home() {
+    let w = world_via_link();
+    write_skill(&w.upstream, "gh", "One.");
+    commit(&w.upstream, "one");
+    declare(&w, "[skills.gh]\nsource = \"cat\"\n");
+    sync_and_apply(&w);
+    write_skill(&w.upstream, "gh", "Two.");
+    commit(&w.upstream, "two");
+    let loaded = manifest::load_for_mutation(&manifest::manifest_path(&w.env, &w.scope))
+        .unwrap()
+        .unwrap();
+    remote::sync_sources(&w.env, &loaded).unwrap();
+
+    let report = kendex_core::package::updates::updates(&w.env, &w.scope).unwrap();
+    assert_eq!(report.warnings, Vec::new(), "history must read cleanly");
+    let row = report
+        .rows
+        .iter()
+        .find(|row| row.kind == ItemKind::Skill && row.name == "gh")
+        .unwrap();
+    assert!(row.update_available, "{row:?}");
+    assert!(row.can_take_latest, "{row:?}");
+    assert!(row.latest.is_some(), "{row:?}");
+}

--- a/crates/core/tests/edits_and_forks/edited_harness.rs
+++ b/crates/core/tests/edits_and_forks/edited_harness.rs
@@ -92,25 +92,10 @@ fn discarding_edits_can_move_a_hold_in_the_same_apply() {
     let w = world();
     write_skill(&w.upstream, "gh", "One.");
     commit(&w.upstream, "one");
-    // Run from a commit hook, GIT_DIR and friends point at the repository
-    // being committed to; dropped, so HEAD is the fixture's.
-    let one = String::from_utf8(
-        std::process::Command::new("git")
-            .args(["rev-parse", "HEAD"])
-            .current_dir(&w.upstream)
-            .env_remove("GIT_DIR")
-            .env_remove("GIT_WORK_TREE")
-            .env_remove("GIT_INDEX_FILE")
-            .env_remove("GIT_OBJECT_DIRECTORY")
-            .env_remove("GIT_PREFIX")
-            .output()
-            .unwrap()
-            .stdout,
-    )
-    .unwrap();
+    let one = head_commit(&w.upstream);
     declare(
         &w,
-        &format!("[skills.gh]\nsource = \"cat\"\nrev = \"{}\"\n", one.trim()),
+        &format!("[skills.gh]\nsource = \"cat\"\nrev = \"{one}\"\n"),
     );
     sync_and_apply(&w);
     write_skill(&w.upstream, "gh", "Two.");
@@ -183,26 +168,10 @@ fn a_held_bundle_member_with_newer_upstream_can_discard_but_not_move() {
     )
     .unwrap();
     commit(&w.upstream, "one");
-    let one = String::from_utf8(
-        std::process::Command::new("git")
-            .args(["rev-parse", "HEAD"])
-            .current_dir(&w.upstream)
-            .env_remove("GIT_DIR")
-            .env_remove("GIT_WORK_TREE")
-            .env_remove("GIT_INDEX_FILE")
-            .env_remove("GIT_OBJECT_DIRECTORY")
-            .env_remove("GIT_PREFIX")
-            .output()
-            .unwrap()
-            .stdout,
-    )
-    .unwrap();
+    let one = head_commit(&w.upstream);
     declare(
         &w,
-        &format!(
-            "[bundles.starter]\nsource = \"cat\"\nrev = \"{}\"\n",
-            one.trim()
-        ),
+        &format!("[bundles.starter]\nsource = \"cat\"\nrev = \"{one}\"\n"),
     );
     sync_and_apply(&w);
     write_skill(&w.upstream, "gh", "Two.");
@@ -334,27 +303,13 @@ fn a_source_level_hold_names_the_source_as_owner() {
     let w = world();
     write_skill(&w.upstream, "gh", "Upstream.");
     commit(&w.upstream, "one");
-    let one = String::from_utf8(
-        std::process::Command::new("git")
-            .args(["rev-parse", "HEAD"])
-            .current_dir(&w.upstream)
-            .env_remove("GIT_DIR")
-            .env_remove("GIT_WORK_TREE")
-            .env_remove("GIT_INDEX_FILE")
-            .env_remove("GIT_OBJECT_DIRECTORY")
-            .env_remove("GIT_PREFIX")
-            .output()
-            .unwrap()
-            .stdout,
-    )
-    .unwrap();
+    let one = head_commit(&w.upstream);
     let path = manifest::manifest_path(&w.env, &w.scope);
     fs::create_dir_all(path.parent().unwrap()).unwrap();
     fs::write(
         &path,
         format!(
-            "schema = 5\n\n[sources.cat]\nrepo = \"{REPO}\"\nrev = \"{}\"\n\n[install]\nharnesses = [\"claude\"]\nmethod = \"symlink\"\n\n[skills.gh]\nsource = \"cat\"\n",
-            one.trim()
+            "schema = 5\n\n[sources.cat]\nrepo = \"{REPO}\"\nrev = \"{one}\"\n\n[install]\nharnesses = [\"claude\"]\nmethod = \"symlink\"\n\n[skills.gh]\nsource = \"cat\"\n"
         ),
     )
     .unwrap();
@@ -377,7 +332,7 @@ fn a_source_level_hold_names_the_source_as_owner() {
     // A package's own hold is its own to release.
     declare(
         &w,
-        &format!("[skills.gh]\nsource = \"cat\"\nrev = \"{}\"\n", one.trim()),
+        &format!("[skills.gh]\nsource = \"cat\"\nrev = \"{one}\"\n"),
     );
     let report = kendex_core::package::updates::updates(&w.env, &w.scope).unwrap();
     let row = report.rows.iter().find(|row| row.name == "gh").unwrap();
@@ -428,23 +383,10 @@ fn a_pinned_package_gone_at_tip_keeps_its_timeline_under_a_symlinked_home() {
     let w = world_via_link();
     write_skill(&w.upstream, "gh", "One.");
     commit(&w.upstream, "one");
-    let one = String::from_utf8(
-        std::process::Command::new("git")
-            .args(["rev-parse", "HEAD"])
-            .current_dir(&w.upstream)
-            .env_remove("GIT_DIR")
-            .env_remove("GIT_WORK_TREE")
-            .env_remove("GIT_INDEX_FILE")
-            .env_remove("GIT_OBJECT_DIRECTORY")
-            .env_remove("GIT_PREFIX")
-            .output()
-            .unwrap()
-            .stdout,
-    )
-    .unwrap();
+    let one = head_commit(&w.upstream);
     declare(
         &w,
-        &format!("[skills.gh]\nsource = \"cat\"\nrev = \"{}\"\n", one.trim()),
+        &format!("[skills.gh]\nsource = \"cat\"\nrev = \"{one}\"\n"),
     );
     sync_and_apply(&w);
     fs::remove_dir_all(w.upstream.join("skills/gh")).unwrap();

--- a/crates/core/tests/edits_and_forks/edited_harness.rs
+++ b/crates/core/tests/edits_and_forks/edited_harness.rs
@@ -416,3 +416,56 @@ fn updates_still_read_history_under_a_symlinked_home() {
     assert!(row.can_take_latest, "{row:?}");
     assert!(row.latest.is_some(), "{row:?}");
 }
+
+/// The fallback that binds a package the tip no longer offers: the pin's
+/// own revision still carries it, and the rel that revision yields must
+/// land under the tip seal's spelling — through a symlinked home the
+/// published roots and the seals disagree, and a strip against the wrong
+/// one silently reads the package as removed upstream, timeline and all.
+#[test]
+#[allow(clippy::unwrap_used)]
+fn a_pinned_package_gone_at_tip_keeps_its_timeline_under_a_symlinked_home() {
+    let w = world_via_link();
+    write_skill(&w.upstream, "gh", "One.");
+    commit(&w.upstream, "one");
+    let one = String::from_utf8(
+        std::process::Command::new("git")
+            .args(["rev-parse", "HEAD"])
+            .current_dir(&w.upstream)
+            .env_remove("GIT_DIR")
+            .env_remove("GIT_WORK_TREE")
+            .env_remove("GIT_INDEX_FILE")
+            .env_remove("GIT_OBJECT_DIRECTORY")
+            .env_remove("GIT_PREFIX")
+            .output()
+            .unwrap()
+            .stdout,
+    )
+    .unwrap();
+    declare(
+        &w,
+        &format!("[skills.gh]\nsource = \"cat\"\nrev = \"{}\"\n", one.trim()),
+    );
+    sync_and_apply(&w);
+    fs::remove_dir_all(w.upstream.join("skills/gh")).unwrap();
+    commit(&w.upstream, "two");
+    let loaded = manifest::load_for_mutation(&manifest::manifest_path(&w.env, &w.scope))
+        .unwrap()
+        .unwrap();
+    remote::sync_sources(&w.env, &loaded).unwrap();
+
+    let report = kendex_core::package::updates::updates(&w.env, &w.scope).unwrap();
+    assert_eq!(
+        report.warnings,
+        Vec::new(),
+        "the fallback must bind cleanly"
+    );
+    let row = report
+        .rows
+        .iter()
+        .find(|row| row.kind == ItemKind::Skill && row.name == "gh")
+        .unwrap();
+    assert!(!row.removed_upstream, "{row:?}");
+    assert!(row.current.is_some(), "{row:?}");
+    assert!(row.latest.is_some(), "{row:?}");
+}

--- a/crates/core/tests/edits_and_forks/main.rs
+++ b/crates/core/tests/edits_and_forks/main.rs
@@ -36,6 +36,18 @@ fn git(dir: &Path, args: &[&str]) {
     assert!(output.status.success(), "git {args:?}");
 }
 
+/// HEAD's commit id, through the same hardened runner every fixture git
+/// call uses — run from a commit hook, GIT_DIR and friends would point at
+/// the repository being committed to; scrubbed, HEAD is the fixture's.
+#[allow(clippy::unwrap_used)]
+fn head_commit(dir: &Path) -> String {
+    let output = Hardened::git(&["rev-parse", "HEAD"], Some(dir))
+        .run()
+        .unwrap();
+    assert!(output.status.success(), "git rev-parse HEAD");
+    String::from_utf8(output.stdout).unwrap().trim().to_owned()
+}
+
 #[allow(clippy::unwrap_used)]
 fn commit(dir: &Path, message: &str) {
     git(dir, &["add", "-A"]);

--- a/crates/core/tests/edits_and_forks/main.rs
+++ b/crates/core/tests/edits_and_forks/main.rs
@@ -69,21 +69,7 @@ fn write_skill(dir: &Path, name: &str, body: &str) {
 fn world() -> World {
     let tmp = tempfile::tempdir().unwrap();
     let home = tmp.path().to_path_buf();
-    let upstream = home.join("git").join(REPO);
-    fs::create_dir_all(&upstream).unwrap();
-    git(&upstream, &["init", "--quiet", "-b", "main"]);
-    fs::create_dir_all(home.join(".claude")).unwrap();
-    fs::create_dir_all(home.join("app/.claude")).unwrap();
-    let base = format!("file://{}", home.join("git").display());
-    World {
-        env: Env::fake(&home, FakeOs::Linux).with_var("KENDEX_GIT_BASE", &base),
-        scope: Scope::Project {
-            root: home.join("app"),
-        },
-        home,
-        upstream,
-        _tmp: tmp,
-    }
+    world_at(tmp, home)
 }
 
 /// [`world`], with every path reaching the home through a symlink — the
@@ -97,6 +83,13 @@ fn world_via_link() -> World {
     fs::create_dir_all(&real).unwrap();
     let home = tmp.path().join("via");
     std::os::unix::fs::symlink(&real, &home).unwrap();
+    world_at(tmp, home)
+}
+
+/// The fixture body both worlds share; `home` is the spelling every path
+/// in the World speaks.
+#[allow(clippy::unwrap_used)]
+fn world_at(tmp: tempfile::TempDir, home: PathBuf) -> World {
     let upstream = home.join("git").join(REPO);
     fs::create_dir_all(&upstream).unwrap();
     git(&upstream, &["init", "--quiet", "-b", "main"]);

--- a/crates/core/tests/edits_and_forks/main.rs
+++ b/crates/core/tests/edits_and_forks/main.rs
@@ -86,6 +86,34 @@ fn world() -> World {
     }
 }
 
+/// [`world`], with every path reaching the home through a symlink — the
+/// spelling macOS hands every test anyway (`/var` → `/private/var` fronts
+/// its temp directories), reproduced here so the one-spelling rule stays
+/// covered on every platform.
+#[allow(clippy::unwrap_used)]
+fn world_via_link() -> World {
+    let tmp = tempfile::tempdir().unwrap();
+    let real = tmp.path().join("real");
+    fs::create_dir_all(&real).unwrap();
+    let home = tmp.path().join("via");
+    std::os::unix::fs::symlink(&real, &home).unwrap();
+    let upstream = home.join("git").join(REPO);
+    fs::create_dir_all(&upstream).unwrap();
+    git(&upstream, &["init", "--quiet", "-b", "main"]);
+    fs::create_dir_all(home.join(".claude")).unwrap();
+    fs::create_dir_all(home.join("app/.claude")).unwrap();
+    let base = format!("file://{}", home.join("git").display());
+    World {
+        env: Env::fake(&home, FakeOs::Linux).with_var("KENDEX_GIT_BASE", &base),
+        scope: Scope::Project {
+            root: home.join("app"),
+        },
+        home,
+        upstream,
+        _tmp: tmp,
+    }
+}
+
 #[allow(clippy::unwrap_used)]
 fn declare(w: &World, body: &str) {
     let path = manifest::manifest_path(&w.env, &w.scope);

--- a/crates/core/tests/rename_collisions.rs
+++ b/crates/core/tests/rename_collisions.rs
@@ -22,7 +22,10 @@ struct Fixture {
 #[allow(clippy::unwrap_used)]
 fn fixture() -> Fixture {
     let tmp = tempfile::tempdir().unwrap();
-    let home = tmp.path().to_path_buf();
+    // Plan ops speak the canonical spelling; the fixture enters canonical
+    // space once so op paths compare equal to fixture-derived ones (macOS
+    // fronts its temp directories with a `/var` → `/private/var` symlink).
+    let home = tmp.path().canonicalize().unwrap();
     let env = Env::fake(&home, FakeOs::Linux);
     let project = home.join("dev/app");
     fs::create_dir_all(project.join(".claude")).unwrap();

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -155,13 +155,11 @@ lives in one capability table read by core and UI.
     core (`core/parallel.rs`), returning in the order given; two runs over
     one disk give byte-identical output. Phrase matching skips to the next
     byte that could begin a match; all-ASCII text takes no normalizing pass.
-
 15. An item says what it is for in its own header, from a closed
     vocabulary (`core/tags.rs`). Kind says what a thing *is*; a tag says
     what job it helps with — the only axis. Tags are never inferred from
     a name: an untagged item is untagged. A word outside the vocabulary
     is a scan warning naming the real one (`tests` for `testing`).
-
 16. A debug build gets its own machine. Every root `core/env.rs` resolves
     hangs off `Env::home`; a build with `debug_assertions` roots that at
     `<data>/kendex-dev`. Inherited vars naming a harness root are dropped
@@ -182,20 +180,13 @@ lives in one capability table read by core and UI.
     absolute path is used as written; a child process inherits this
     process's environment (`process/mod.rs`), so `npm` run for a Pi
     package sees the real home.
-
-17. One spelling per path. A root is canonicalized once, where it enters —
-    a scope's root wherever paths are derived from it (`Scope::canonical`,
-    rebound at each derivation helper: `rename::manifest_pair`,
-    `rename::rename_ops`, `rename::retarget`, `lock::lock_path`, and the
-    engine's plan entry points), a source root at `SealedSource::open`, a
-    declared source path at `source::resolve` — and every path derived
-    from it carries that canonical spelling. Nothing re-canonicalizes
-    downstream, and nothing may compare two spellings of one file: under a
-    symlinked root (macOS fronts its temp tree with `/var` →
-    `/private/var`; a user links a project directory) a plan's refusal and
-    the targets a caller derives must already agree, and a path handed to
-    git must speak the same spelling as the repository it is resolved
-    against.
+17. One spelling per path, fixed once where the root enters: a scope root
+    at each derivation helper (`Scope::canonical` in `manifest_pair`,
+    `rename_ops`, `retarget`, `lock_path`, and the engine's plan entries),
+    a source root at `SealedSource::open`, a declared path at
+    `source::resolve`. Nothing re-canonicalizes downstream, no comparison
+    may meet two spellings of one file (macOS fronts `/var` with
+    `/private/var`), and a path handed to git speaks the repository's own.
 
 ## Decisions
 
@@ -399,39 +390,38 @@ lives in one capability table read by core and UI.
   both repo spellings as kendex-owned.
 - **Commits walk through the guards whatever tool makes them.** The guard
   family (`core/guard/`) — size-ratchet, todo-ban, byte-ceiling,
-  suppression-ban, commit-msg, and the lint lanes rust-fmt, rust-clippy
-  and biome — judges the index git names for the commit
-  (`GIT_INDEX_FILE`, captured once and threaded through a validated
-  context; the one sanctioned redirect past invariant 13). Policy is read
-  from the commit: the `[guards]` tables in `kendex.settings.toml`,
-  baselines, and excludes all resolve from the staged copy — a file staged
-  for deletion, or never staged, governs as absent. The process
-  environment is the only machine-local override; the chain's local
-  extension point is configured machine-locally only, never from a
-  committed file. Unmerged entries and intent-to-add are refused loudly;
-  paths travel NUL-delimited end to end; a name the configuration format
-  cannot carry is a refusal. Every enabled check runs before the verdict;
-  exit 1 (violations) and 2 (could not run) both block. Baseline TSVs read
-  as-is; legacy env-style settings convert once through `guard import-v1`;
-  imported excludes keep v1's legacy-glob dialect, marked as such; a
-  pattern outside the documented dialect is a refusal. The lint lanes
-  take the staged list from that index but run the project's toolchain
-  (cargo, biome — well-known names or the project's untracked
-  `node_modules/.bin`, never a committed command) over the working tree,
-  scoped per staged file's owning `Cargo.toml`, and see none of the git
-  redirects a hook's parent exports. Which repository a commit targets
-  is git's question, answered where the target has an armed hook: the
-  `pre-commit-check` PreToolUse hook only word-matches for a commit,
-  defers to the armed git pre-commit hook of its own working directory,
-  and runs the chain in that directory only where none is armed there;
+  suppression-ban, commit-msg, and the lint lanes rust-fmt, rust-clippy and
+  biome — judges the index git names for the commit (`GIT_INDEX_FILE`,
+  captured once and threaded through a validated context; the one
+  sanctioned redirect past invariant 13). Policy is read from the commit:
+  the `[guards]` tables in `kendex.settings.toml`, baselines, and excludes
+  all resolve from the staged copy — a file staged for deletion, or never
+  staged, governs as absent. The process environment is the only
+  machine-local override; the chain's local extension point is configured
+  machine-locally only, never from a committed file. Unmerged entries and
+  intent-to-add are refused loudly; paths travel NUL-delimited end to end;
+  a name the configuration format cannot carry is a refusal. Every enabled
+  check runs before the verdict; exit 1 (violations) and 2 (could not run)
+  both block. Baseline TSVs read as-is; legacy env-style settings convert
+  once through `guard import-v1`; imported excludes keep v1's legacy-glob
+  dialect, marked as such; a pattern outside the documented dialect is a
+  refusal. The lint lanes take the staged list from that index but run the
+  project's toolchain (cargo, biome — well-known names or the project's
+  untracked `node_modules/.bin`, never a committed command) over the
+  working tree, scoped per staged file's owning `Cargo.toml`, and see none
+  of the git redirects a hook's parent exports. Which repository a commit
+  targets is git's question, answered where the target has an armed hook:
+  the `pre-commit-check` PreToolUse hook only word-matches for a commit,
+  defers to the armed git pre-commit hook of its own working directory, and
+  runs the chain in that directory only where none is armed there;
   sidestepping an armed one (`--no-verify`, `-n`) or injecting git config
   (`-c`, `--config-env`, `GIT_CONFIG_*`) is refused — git would skip
-  commit-msg too, unjudgeable here. It gates its
-  working directory only: a commit aimed elsewhere from an unarmed or
-  non-repository directory is not gated by it (a stderr notice says so),
-  and it never parses the target. A payload whose command the hook
-  cannot read is a refusal, and the chain's own refusals (unconverted v1
-  settings, a lint tool that could not run) block through it.
+  commit-msg too, unjudgeable here. It gates its working directory only: a
+  commit aimed elsewhere from an unarmed or non-repository directory is not
+  gated by it (a stderr notice says so), and it never parses the target. A
+  payload whose command the hook cannot read is a refusal, and the chain's
+  own refusals (unconverted v1 settings, a lint tool that could not run)
+  block through it.
 - **kendex owns its hooks directory — provably.** The guards reach git
   through `<git-common-dir>/kendex-hooks/`, two entrypoints whose call
   surface (`kendex guard run <hook>`) is a stable contract, with
@@ -635,16 +625,16 @@ lives in one capability table read by core and UI.
   names that install. The walk stops at its skill cap. `source/about.rs`
   renders the one typed report the About tab and `kendex index` consume.
 - **Browsing is a read-side join; installed state is derived, never
-  stored.** Every `source/browse.rs` read takes a `Catalog`,
-  `Subscription { scope, source }` or `Repo { repo }`, so a listed
-  marketplace opens before anyone subscribes. Each row's state is joined
-  from the scope's manifest and lock on every call — installed is a lock
-  entry from this subscription, held-back-by-safety is content the gate
-  refuses, "partly installed (2 of 6)" is counted from a bundle's members;
-  with no subscription the join answers Available and judges name clashes
-  against the personal scope. A name another source holds is surfaced on
-  the row (`collision`); the refusal stays in the engine (invariant 4). A
-  bare repository is fetched by `remote::sync` into the store under the
+  stored.** Every `source/browse.rs` read takes a `Catalog`, `Subscription
+  { scope, source }` or `Repo { repo }`, so a listed marketplace opens
+  before anyone subscribes. Each row's state is joined from the scope's
+  manifest and lock on every call — installed is a lock entry from this
+  subscription, held-back-by-safety is content the gate refuses, "partly
+  installed (2 of 6)" is counted from a bundle's members; with no
+  subscription the join answers Available and judges name clashes against
+  the personal scope. A name another source holds is surfaced on the row
+  (`collision`); the refusal stays in the engine (invariant 4). A bare
+  repository is fetched by `remote::sync` into the store under the
   canonical `owner/repo` every GitHub spelling folds to — the key Subscribe
   is prefilled with; only GitHub opens blind (`NotBrowsable` otherwise); a
   root skill's file list and reads are confined to the skill tree.
@@ -652,17 +642,16 @@ lives in one capability table read by core and UI.
   copy) and names an enabled, readable subscription this machine holds;
   `useCatalog` moves the page onto it. Installing needs a subscription;
   `RepoAction` offers the one step: Subscribe when none declares the
-  repository, Turn on when a declared one is off, Refresh when declared
-  but unreadable, neutral until the live list has loaded. Pre-install
-  safety (`browse/safety.rs`) scores catalog bytes with the rules an
-  install runs and caches **findings and scores only**
-  (`<key>/<commit>.safety/…`, never inside the receipt-signed checkout),
-  keyed by content hash plus rule-set, discovery-table and record-format
-  versions, each verified before reuse; the warn/block verdict is derived
-  from current thresholds at read time. Browse is a preview of the
-  verdict, never a second gate. `library.rs` is the same join for the
-  Library table: subscription, local content (with what a fork replaced),
-  or observed-and-unmanaged.
+  repository, Turn on when a declared one is off, Refresh when declared but
+  unreadable, neutral until the live list has loaded. Pre-install safety
+  (`browse/safety.rs`) scores catalog bytes with the rules an install runs
+  and caches **findings and scores only** (`<key>/<commit>.safety/…`, never
+  inside the receipt-signed checkout), keyed by content hash plus rule-set,
+  discovery-table and record-format versions, each verified before reuse;
+  the warn/block verdict is derived from current thresholds at read time.
+  Browse is a preview of the verdict, never a second gate. `library.rs` is
+  the same join for the Library table: subscription, local content (with
+  what a fork replaced), or observed-and-unmanaged.
 - **A subscription's closure is derived by re-expansion; unsubscribing
   removes or keeps exactly it.** `engine/detach.rs` expands the installed
   set with the source present and again with its declarations gone, then
@@ -670,17 +659,16 @@ lives in one capability table read by core and UI.
   while the source cannot be read. **Remove** drops the closure's
   declarations and sweeps their installations (orphan removal filtered to
   exact kind+name pairs); an edited installation is never swept without
-  `--discard-edits`. **Keep** copies each
-  installation's *source-form* bytes — read through the sealed catalog at
-  the exact commit it installed from, a parent skill excluding any nested
-  child skill — into the scope's local source, flips the declaration to
-  `local` with fork provenance, and removes the subscription; local writes
-  are ordered before the manifest flip in one plan (invariant 11). Keep
-  refuses an edited package (fork or discard first; hooks are compared to
-  what apply wrote) and preflights the local target: a symlink, a
-  case/composition-folding sibling, or different bytes there is a refusal
-  (invariants 4 and 6). The local source lists a `plugin/item` name beside
-  a plain `plugin`.
+  `--discard-edits`. **Keep** copies each installation's *source-form*
+  bytes — read through the sealed catalog at the exact commit it installed
+  from, a parent skill excluding any nested child skill — into the scope's
+  local source, flips the declaration to `local` with fork provenance, and
+  removes the subscription; local writes are ordered before the manifest
+  flip in one plan (invariant 11). Keep refuses an edited package (fork or
+  discard first; hooks are compared to what apply wrote) and preflights the
+  local target: a symlink, a case/composition-folding sibling, or different
+  bytes there is a refusal (invariants 4 and 6). The local source lists a
+  `plugin/item` name beside a plain `plugin`.
 - **The machine seam reads through the same core installing reads
   through.** `check_catalog.rs` (core) owns the two authoring passes —
   structural (would each harness's loader hold this item) and safety (the
@@ -694,8 +682,8 @@ lives in one capability table read by core and UI.
   packages from `list_items` (pinned by test), safety scores from the check
   passes, bundles with members, About rows, findings. Field order in both
   JSON shapes is the schema — serde structs, no maps. `kendex marketplace
-  check` aliases `check --catalog --strict`, same exit codes.
-  A maintainer's reviewed findings live in a committed `kendex-reviews.toml`
+  check` aliases `check --catalog --strict`, same exit codes. A
+  maintainer's reviewed findings live in a committed `kendex-reviews.toml`
   at the catalog root (`check_catalog/dismissals.rs`): content-hash-bound
   records keyed `kind:name`, written by `dismiss --catalog` from the tokens
   `check --catalog` prints, for every kind but a hook. The check refuses
@@ -707,39 +695,38 @@ lives in one capability table read by core and UI.
   record binds to bytes — the item's own plus all its rendering reads
   (`SourceConfig::rendering_inputs`); settles the publisher's own
   occurrences only, at the weight the scored artifact gives each; and
-  carries only reasons an author can give — `trusted-source` and
-  timestamps refused on read and write.
-  **The record never travels in a file this project commits.** The lock
-  carries none; the audit rebuilds (`engine::desired::desired_as_installed`)
-  the plan that produced what is on disk, each installation at its lock
-  entry's revision, and reads the record out of *that* catalog. One item
-  can sit at two revisions; an installation answers for itself — one row,
-  one entry, one revision, one record. An item no rebuild covers carries no
-  review; there is no signing scheme. A hook records none: refused where
-  read, and neither `dismiss --catalog` nor `check --catalog` produces one.
-  The audit matches an entry to an observation by kind and name (or those
-  of the artifact it emitted), then by a review hash sealed by what is on
-  disk. Every settled finding is shown with publisher and reason — under
-  the line in the CLI, in its own row on a scope and in the held-back
-  panel, and on a marketplace package's page (via `browse/safety.rs`). Two
-  decisions differing in reason or date stay two rows. A record that
-  settles nothing here is a note, never silence.
-  Finding identity is the rule and the sentence it fired with
+  carries only reasons an author can give — `trusted-source` and timestamps
+  refused on read and write. **The record never travels in a file this
+  project commits.** The lock carries none; the audit rebuilds
+  (`engine::desired::desired_as_installed`) the plan that produced what is
+  on disk, each installation at its lock entry's revision, and reads the
+  record out of *that* catalog. One item can sit at two revisions; an
+  installation answers for itself — one row, one entry, one revision, one
+  record. An item no rebuild covers carries no review; there is no signing
+  scheme. A hook records none: refused where read, and neither `dismiss
+  --catalog` nor `check --catalog` produces one. The audit matches an entry
+  to an observation by kind and name (or those of the artifact it emitted),
+  then by a review hash sealed by what is on disk. Every settled finding is
+  shown with publisher and reason — under the line in the CLI, in its own
+  row on a scope and in the held-back panel, and on a marketplace package's
+  page (via `browse/safety.rs`). Two decisions differing in reason or date
+  stay two rows. A record that settles nothing here is a note, never
+  silence. Finding identity is the rule and the sentence it fired with
   (`Finding::fingerprint`): the message says what the rule fired *on*,
   never where. A digest standing in for unprintable content is always
   `DIGEST_CHARS` wide. Every location a decision covers is listed under it.
   Line, file (Codex renders a command as a skill tree) and severity (one
-  step less in a supporting file) are out of the fingerprint. A fingerprint is read only within one
-  item's records, bound to the content hash and, for a publisher's record,
-  to which occurrences are theirs (`quality::publishers`). **A boundary is
-  carried from the code that drew it, never found again in the finished
-  text**: the renderer hands the tree and its offsets down as one value,
-  and every location is composed rather than matched. For an artifact
-  generated from inputs, a rendering from the publisher's inputs alone is
-  walked beside the real one, both in the one deobfuscated space; prose
-  the project supplied is skipped and asked of the person; a finding
-  naming a whole document is the publisher's only where their own
-  rendering produces it.
+  step less in a supporting file) are out of the fingerprint. A fingerprint
+  is read only within one item's records, bound to the content hash and,
+  for a publisher's record, to which occurrences are theirs
+  (`quality::publishers`). **A boundary is carried from the code that drew
+  it, never found again in the finished text**: the renderer hands the tree
+  and its offsets down as one value, and every location is composed rather
+  than matched. For an artifact generated from inputs, a rendering from the
+  publisher's inputs alone is walked beside the real one, both in the one
+  deobfuscated space; prose the project supplied is skipped and asked of
+  the person; a finding naming a whole document is the publisher's only
+  where their own rendering produces it.
 - **The community directory is read like any remote: strictly, capped,
   honest about staleness.** `registry/` (core) consumes what
   `source/index.rs` producers feed kendex.ai: `index.rs` re-parses the
@@ -898,25 +885,24 @@ lives in one capability table read by core and UI.
   decisions; `kendex decisions` / Recorded decisions reads every record
   against what is installed now — active, stale with the reason, or
   obsolete. An app undo takes back exactly the record it was shown; the
-  CLI's revoke names the record by key.
-  Composition: held-back item → findings never offered for dismissal, shown
-  in full; active acceptance → every finding reads accepted, no dismissal
-  on top; then the person's live dismissal; then the publisher's record (a
-  stale personal dismissal falls through to it); else open. Warning→block
-  by threshold change keeps dismissals and shows the item held back;
-  block→warning keeps the acceptance until withdrawn; withdrawing uncovers
-  the findings and prior dismissals apply again. What still needs a person
-  is one derivation (`lib/reviewable.ts`): held-back items once each, plus
-  open findings once per distinct evidence (same bytes, same finding,
-  several tools = one decision). Every count — sidebar, Home, footer, scope
-  summary, Review page done — reads that number. A dismissal is about
-  installed bytes, never a plan; rows a plan would install with findings
-  travel with the view as `queued`, so the apply preview says how many
-  decisions will be waiting. A concern row collapses one rule across
-  everything it touched; a decision is per piece of evidence — one piece
-  carries the verb on its row, several each get their own, walked one at a
-  time, worst first. No rule-level mute, no time-based snooze, no
-  cross-scope action.
+  CLI's revoke names the record by key. Composition: held-back item →
+  findings never offered for dismissal, shown in full; active acceptance →
+  every finding reads accepted, no dismissal on top; then the person's live
+  dismissal; then the publisher's record (a stale personal dismissal falls
+  through to it); else open. Warning→block by threshold change keeps
+  dismissals and shows the item held back; block→warning keeps the
+  acceptance until withdrawn; withdrawing uncovers the findings and prior
+  dismissals apply again. What still needs a person is one derivation
+  (`lib/reviewable.ts`): held-back items once each, plus open findings once
+  per distinct evidence (same bytes, same finding, several tools = one
+  decision). Every count — sidebar, Home, footer, scope summary, Review
+  page done — reads that number. A dismissal is about installed bytes,
+  never a plan; rows a plan would install with findings travel with the
+  view as `queued`, so the apply preview says how many decisions will be
+  waiting. A concern row collapses one rule across everything it touched; a
+  decision is per piece of evidence — one piece carries the verb on its
+  row, several each get their own, walked one at a time, worst first. No
+  rule-level mute, no time-based snooze, no cross-scope action.
 - **Rule severities are calibrated against real catalogs.** Deobfuscation
   reports only what has no typographic use — invisible and bidirectional
   characters, letters imitating other letters — while normalizing emoji

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -185,7 +185,9 @@ lives in one capability table read by core and UI.
 
 17. One spelling per path. A root is canonicalized once, where it enters —
     a scope's root wherever paths are derived from it (`Scope::canonical`,
-    `rename::manifest_pair`), a source root at `SealedSource::open`, a
+    rebound at each derivation helper: `rename::manifest_pair`,
+    `rename::rename_ops`, `rename::retarget`, `lock::lock_path`, and the
+    engine's plan entry points), a source root at `SealedSource::open`, a
     declared source path at `source::resolve` — and every path derived
     from it carries that canonical spelling. Nothing re-canonicalizes
     downstream, and nothing may compare two spellings of one file: under a

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -183,6 +183,18 @@ lives in one capability table read by core and UI.
     process's environment (`process/mod.rs`), so `npm` run for a Pi
     package sees the real home.
 
+17. One spelling per path. A root is canonicalized once, where it enters —
+    a scope's root wherever paths are derived from it (`Scope::canonical`,
+    `rename::manifest_pair`), a source root at `SealedSource::open`, a
+    declared source path at `source::resolve` — and every path derived
+    from it carries that canonical spelling. Nothing re-canonicalizes
+    downstream, and nothing may compare two spellings of one file: under a
+    symlinked root (macOS fronts its temp tree with `/var` →
+    `/private/var`; a user links a project directory) a plan's refusal and
+    the targets a caller derives must already agree, and a path handed to
+    git must speak the same spelling as the repository it is resolved
+    against.
+
 ## Decisions
 
 - Tauri 2 · React 19 · Vite · Tailwind v4 · shadcn/ui · zustand ·


### PR DESCRIPTION
## Summary
- The macOS cargo lane has been red on every main push since 2026-08-21 (8 tests). Root cause for six of them: macOS's temp dir lives behind a symlink (`/var` → `/private/var`), and two sites derived paths from the caller's raw spelling while the engine plans against the canonical one — `rename::manifest_pair` missed stale-plan refusals, and `package_ref_for` stripped a canonical item path against the raw root, silently degrading update timelines via a git "outside repository" pathspec refusal.
- One rule closes the class: a scope root canonicalizes once where paths enter (`Scope::canonical`), and every sibling derivation helper (`manifest_pair`, `rename_ops`, `retarget`, `lock_path`, `v1_lock_path`) now self-enforces it — stated as ARCHITECTURE.md invariant 17, which KEN-474 builds on. The `package_ref_for` strip now fails closed instead of handing git an absolute pathspec.
- The two remaining failures were test bugs: the non-UTF-8 filename hash test is Linux-only (APFS refuses such names), and the global-scope unmanaged-exit test now writes to the platform config root.
- Symlinked-root regression tests (editor save, pinned-package fallback, v1 lock migration) reproduce the macOS shape on Linux CI; each was verified red against the unfixed code.
- Verified on the owner's mac box: all 8 failures reproduced at origin/main, then `cargo test --workspace` fully green with the fix (123 suites). Linux workspace green.

## Completed Issues
- Closes KEN-596 - macOS cargo lane red since Aug 21: one path-spelling rule at the boundary

## Test Plan
- macOS (`ssh user@mbp`): 8 failures reproduced at origin/main; full workspace green with the fix
- Linux: `cargo test --workspace --no-fail-fast` 0 failures; new symlink-shape tests mutation-verified (revert → red)
- preflight and tools/guard clean

Once the macOS cargo job is green on the main push after this merges, it can be made a required check (issue Done-when).

https://claude.ai/code/session_01KnnKByWWrorJHAUCWejs94
