### PR TITLE
fix(KEN-574): the Follow source switch moves before its write lands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@ an outside contributor.
   longer invalidate the sign-in by rotating the same refresh token twice.
 - Registry refresh timeouts and rate limits no longer sign the machine out;
   the app or CLI keeps the credential and can retry.
+- Switching a package's Follow source off moves the switch at once instead of
+  freezing the Updates table for the seconds its write takes. Rows in other
+  places stay live while it settles; the flipped package's place waits.
 - `kendex check` exits 1, not 2, when packages await re-evaluation, so the
   session-start report no longer opens with "kendex check could not run" after
   a completed run. The drift hook script changed; `kendex drift-hook` reinstalls it.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ an outside contributor.
   longer invalidate the sign-in by rotating the same refresh token twice.
 - Registry refresh timeouts and rate limits no longer sign the machine out;
   the app or CLI keeps the credential and can retry.
-- Switching a package's Follow source off moves the switch at once instead of
+- A package's Follow source switch moves at once, on or off, instead of
   freezing the Updates table for the seconds its write takes. Rows in other
   places stay live while it settles; the flipped package's place waits.
 - `kendex check` exits 1, not 2, when packages await re-evaluation, so the

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -568,8 +568,9 @@ lives in one capability table read by core and UI.
   (`lib/updates-read-state.ts::rowUnsettled`), an apply reaching only what
   is installed there. A refused write stops the flip painting and says so at
   once, but the rows already wear it, so the scope goes on holding until the
-  read that puts them back lands: no row wears a position the engine did not
-  take while reporting itself safe to act on. An edited
+  read that puts them back lands — and when every read behind it failed too,
+  the flip puts them back itself before letting the scope go. No row wears a
+  position the engine did not take. An edited
   place is never updated over: its row says so and offers the install
   beside it where a newer version the source still carries can land, and a
   link to the package page otherwise; the fork-or-discard choice lives on

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -558,7 +558,15 @@ lives in one capability table read by core and UI.
   timeline listing only commits that touched the package's files,
   tag-decorated, never tag-replaced. Rows are per package per scope, folded
   by package and expanded by place; a row's Update applies that package
-  (`PlanOptions::update_only`), apply and refresh a whole place. An edited
+  (`PlanOptions::update_only`), apply and refresh a whole place.
+  Flipping Follow source is one row's state change and a write that settles
+  behind it (`ui/src/stores/updates-follow.ts`): the switch carries its new
+  position from the click, while the hold, the scope apply, and the read of
+  every scope's standing after them take seconds. The flip is pending until
+  that read lands — every landing wears it, so a read begun earlier cannot
+  bounce the switch — and it holds its own scope's rows and no others
+  (`lib/updates-read-state.ts::rowUnsettled`), an apply reaching only what
+  is installed there. An edited
   place is never updated over: its row says so and offers the install
   beside it where a newer version the source still carries can land, and a
   link to the package page otherwise; the fork-or-discard choice lives on

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -566,7 +566,10 @@ lives in one capability table read by core and UI.
   that read lands — every landing wears it, so a read begun earlier cannot
   bounce the switch — and it holds its own scope's rows and no others
   (`lib/updates-read-state.ts::rowUnsettled`), an apply reaching only what
-  is installed there. An edited
+  is installed there. A refused write stops the flip painting and says so at
+  once, but the rows already wear it, so the scope goes on holding until the
+  read that puts them back lands: no row wears a position the engine did not
+  take while reporting itself safe to act on. An edited
   place is never updated over: its row says so and offers the install
   beside it where a newer version the source still carries can land, and a
   link to the package page otherwise; the fork-or-discard choice lives on

--- a/tools/size-ratchet-baseline.tsv
+++ b/tools/size-ratchet-baseline.tsv
@@ -8,7 +8,7 @@ crates/core/src/engine/pi_hooks_move/mod.rs	508
 crates/core/src/engine/pi_hooks_move/preflight.rs	765
 crates/core/src/error.rs	419
 crates/core/src/remote/store.rs	420
-docs/ARCHITECTURE.md	845
+docs/ARCHITECTURE.md	857
 hooks/block-repo-copy.sh	511
 pi-extensions/pi-agents-tmux/extensions/subagent/browser.ts	650
 pi-extensions/pi-agents-tmux/extensions/subagent/dashboard.ts	431

--- a/ui/src/components/package/fork-notice.test.tsx
+++ b/ui/src/components/package/fork-notice.test.tsx
@@ -6,18 +6,32 @@ import { EditedNotice } from "./fork-notice";
 
 // Static rendering reads a zustand store's initial snapshot, so the store
 // hook is wrapped to let each test seed the rows it needs.
-const stub = vi.hoisted(() => ({ rows: [] as unknown[] }));
+const stub = vi.hoisted(() => ({
+  rows: [] as unknown[],
+  settling: [] as { scope: { scope: string; root?: string } }[],
+}));
 vi.mock("@/stores/updates", async (importOriginal) => {
   const mod = await importOriginal<typeof import("@/stores/updates")>();
   const hook = (selector?: (state: unknown) => unknown) => {
-    const state = { ...mod.useUpdatesStore.getState(), rows: stub.rows };
+    // A row to act on implies a read that landed; without that every
+    // control here reads as held and the gates under test say nothing.
+    const state = {
+      ...mod.useUpdatesStore.getState(),
+      rows: stub.rows,
+      pendingFollows: stub.settling,
+      loaded: true,
+    };
     return selector ? selector(state) : state;
   };
   return { ...mod, useUpdatesStore: Object.assign(hook, mod.useUpdatesStore) };
 });
 
-const render = (rows: UpdateRow[]) => {
+const render = (
+  rows: UpdateRow[],
+  settling: { scope: { scope: string; root?: string } }[] = [],
+) => {
   stub.rows = rows;
+  stub.settling = settling;
   return renderToStaticMarkup(
     <EditedNotice
       scope={{ scope: "global" }}
@@ -99,5 +113,28 @@ describe("package page edited notice", () => {
     ]);
     expect(html).not.toContain(">Discard edits…<");
     expect(html).toContain(">View changes<");
+  });
+
+  // Discarding applies the row's latest commit off a `pinned` a settling
+  // flip may have painted, so takeNewVersion refuses for that scope. The
+  // button says so rather than inviting a click that only errors.
+  it("holds Discard edits while a flip settles in this scope", () => {
+    const rows = [
+      edited({ editedHarnesses: ["claude"], forkableHarness: "claude" }),
+    ];
+    const discardHeld = (html: string): boolean => {
+      const tag = html.match(/<button[^>]*>Discard edits…<\/button>/)?.[0];
+      if (!tag) throw new Error("no Discard edits button");
+      return tag.includes('disabled=""');
+    };
+    expect(discardHeld(render(rows))).toBe(false);
+    expect(discardHeld(render(rows, [{ scope: { scope: "global" } }]))).toBe(
+      true,
+    );
+    expect(
+      discardHeld(
+        render(rows, [{ scope: { scope: "project", root: "/home/me/app" } }]),
+      ),
+    ).toBe(false);
   });
 });

--- a/ui/src/components/package/fork-notice.tsx
+++ b/ui/src/components/package/fork-notice.tsx
@@ -22,7 +22,7 @@ import {
 import { UPDATE_NEEDS_CHECK_NOTE } from "@/lib/copy-updates";
 import { harnessName } from "@/lib/labels";
 import { sameScope } from "@/lib/scope";
-import { unsettled } from "@/lib/updates-read-state";
+import { rowUnsettled } from "@/lib/updates-read-state";
 import { useUpdatesStore } from "@/stores/updates";
 import { keepAsOwn, takeNewVersion } from "@/stores/updates-edits";
 
@@ -47,7 +47,7 @@ export function ForkNotice({
   // is about to replace, that pins an old version — so the discard waits
   // for a check. Keeping the files as a fork copies what is on disk and
   // stays live.
-  const held = useUpdatesStore(unsettled);
+  const held = useUpdatesStore((s) => rowUnsettled(s, row));
   const [confirmDiscard, setConfirmDiscard] = useState(false);
   const several = row.editedHarnesses.length > 1;
   const whyNoFork = row.derived

--- a/ui/src/components/package/use-manifest-busy.test.tsx
+++ b/ui/src/components/package/use-manifest-busy.test.tsx
@@ -44,12 +44,12 @@ vi.mock("@/stores/editor", async (importOriginal) => {
 const GLOBAL: Scope = { scope: "global" };
 const PROJECT: Scope = { scope: "project", root: "/home/me/app" };
 
-function Probe({ switching, scope }: { switching: boolean; scope: Scope }) {
-  return <span>{useManifestBusy(switching, scope) ? "busy" : "idle"}</span>;
+function Probe({ switching, scopes }: { switching: boolean; scopes: Scope[] }) {
+  return <span>{useManifestBusy(switching, scopes) ? "busy" : "idle"}</span>;
 }
 
-const render = (switching: boolean, scope: Scope = GLOBAL) =>
-  renderToStaticMarkup(<Probe switching={switching} scope={scope} />);
+const render = (switching: boolean, scopes: Scope[] = [GLOBAL]) =>
+  renderToStaticMarkup(<Probe switching={switching} scopes={scopes} />);
 
 describe("useManifestBusy", () => {
   it("is one gate over the audit apply, a version switch, updates-store work, and a save", () => {
@@ -71,9 +71,20 @@ describe("useManifestBusy", () => {
   // both read it before either applies lose one of the two edits.
   it("holds while a Follow source flip settles in this package's scope", () => {
     stub.settling = [{ scope: { scope: "global" } }];
-    expect(render(false, GLOBAL)).toContain("busy");
-    expect(render(false, PROJECT)).toContain("idle");
+    expect(render(false, [GLOBAL])).toContain("busy");
+    expect(render(false, [PROJECT])).toContain("idle");
     stub.settling = [];
-    expect(render(false, GLOBAL)).toContain("idle");
+    expect(render(false, [GLOBAL])).toContain("idle");
+  });
+
+  // Remove and the enable/disable toggle write every place the package is
+  // installed in, not only the one the page was opened at, and a settling
+  // flip is rewriting one of those manifests.
+  it("holds for a flip in any scope the page's controls write", () => {
+    stub.settling = [{ scope: { scope: "project", root: "/home/me/app" } }];
+    expect(render(false, [GLOBAL])).toContain("idle");
+    expect(render(false, [GLOBAL, PROJECT])).toContain("busy");
+    stub.settling = [];
+    expect(render(false, [GLOBAL, PROJECT])).toContain("idle");
   });
 });

--- a/ui/src/components/package/use-manifest-busy.test.tsx
+++ b/ui/src/components/package/use-manifest-busy.test.tsx
@@ -1,5 +1,6 @@
 import { renderToStaticMarkup } from "react-dom/server";
 import { describe, expect, it, vi } from "vitest";
+import type { Scope } from "@/bindings";
 import { useManifestBusy } from "./use-package-data";
 
 // Static rendering reads each store's initial snapshot, so both store hooks
@@ -8,11 +9,16 @@ const stub = vi.hoisted(() => ({
   audit: false,
   updates: false,
   saving: false,
+  settling: [] as { scope: { scope: string; root?: string } }[],
 }));
 vi.mock("@/stores/updates", async (importOriginal) => {
   const mod = await importOriginal<typeof import("@/stores/updates")>();
   const hook = (selector?: (state: unknown) => unknown) => {
-    const state = { ...mod.useUpdatesStore.getState(), busy: stub.updates };
+    const state = {
+      ...mod.useUpdatesStore.getState(),
+      busy: stub.updates,
+      pendingFollows: stub.settling,
+    };
     return selector ? selector(state) : state;
   };
   return { ...mod, useUpdatesStore: Object.assign(hook, mod.useUpdatesStore) };
@@ -35,12 +41,15 @@ vi.mock("@/stores/editor", async (importOriginal) => {
   return { ...mod, useEditorStore: Object.assign(hook, mod.useEditorStore) };
 });
 
-function Probe({ switching }: { switching: boolean }) {
-  return <span>{useManifestBusy(switching) ? "busy" : "idle"}</span>;
+const GLOBAL: Scope = { scope: "global" };
+const PROJECT: Scope = { scope: "project", root: "/home/me/app" };
+
+function Probe({ switching, scope }: { switching: boolean; scope: Scope }) {
+  return <span>{useManifestBusy(switching, scope) ? "busy" : "idle"}</span>;
 }
 
-const render = (switching: boolean) =>
-  renderToStaticMarkup(<Probe switching={switching} />);
+const render = (switching: boolean, scope: Scope = GLOBAL) =>
+  renderToStaticMarkup(<Probe switching={switching} scope={scope} />);
 
 describe("useManifestBusy", () => {
   it("is one gate over the audit apply, a version switch, updates-store work, and a save", () => {
@@ -55,5 +64,16 @@ describe("useManifestBusy", () => {
     stub.saving = true;
     expect(render(false)).toContain("busy");
     stub.saving = false;
+  });
+
+  // These controls command the engine directly, outside the updates store's
+  // chain, and a flip's apply rewrites the same manifest — two commands that
+  // both read it before either applies lose one of the two edits.
+  it("holds while a Follow source flip settles in this package's scope", () => {
+    stub.settling = [{ scope: { scope: "global" } }];
+    expect(render(false, GLOBAL)).toContain("busy");
+    expect(render(false, PROJECT)).toContain("idle");
+    stub.settling = [];
+    expect(render(false, GLOBAL)).toContain("idle");
   });
 });

--- a/ui/src/components/package/use-package-data.ts
+++ b/ui/src/components/package/use-package-data.ts
@@ -193,22 +193,23 @@ export function packageVersionActions(
 
 /** One gate for every control that rewrites this package's manifest: the
  *  audit store's apply, a version switch in flight, the updates store's
- *  fork or discard, a Follow source flip settling in this scope, and the
- *  editor's save all touch the same file. The controls here command the
- *  engine directly rather than through the updates store's chain, and two
- *  commands that both read the manifest before either applies leave the
- *  second saving its stale copy over the first — so this gate, not
- *  ordering, is what keeps them apart. */
-export function useManifestBusy(
-  switching: boolean,
-  scope: Scope | null,
-): boolean {
+ *  fork or discard, a Follow source flip settling, and the editor's save
+ *  all touch the same file. The controls here command the engine directly
+ *  rather than through the updates store's chain, and two commands that
+ *  both read a manifest before either applies leave the second saving its
+ *  stale copy over the first — so this gate, not ordering, is what keeps
+ *  them apart.
+ *
+ *  `scopes` is every scope the page's controls can write, not only the one
+ *  it was opened at: Remove and the enable/disable toggle run over each
+ *  place the package is installed in. */
+export function useManifestBusy(switching: boolean, scopes: Scope[]): boolean {
   const auditBusy = useAuditStore((s) => s.busy);
   const updatesBusy = useUpdatesStore((s) => s.busy);
   const settling = useUpdatesStore((s) =>
-    scope === null
-      ? false
-      : s.pendingFollows.some((one) => sameScope(one.scope, scope)),
+    s.pendingFollows.some((one) =>
+      scopes.some((scope) => sameScope(one.scope, scope)),
+    ),
   );
   const saving = useEditorStore((s) => s.saving);
   return auditBusy || switching || updatesBusy || settling || saving;

--- a/ui/src/components/package/use-package-data.ts
+++ b/ui/src/components/package/use-package-data.ts
@@ -6,6 +6,7 @@ import {
   type PackageDiff,
   type PackageFile,
   type PackageMeta_Serialize,
+  type Scope,
   type VersionRow,
 } from "@/bindings";
 import {
@@ -13,6 +14,7 @@ import {
   updatedToastLabel,
   VERSION_ERROR_TITLE,
 } from "@/lib/copy";
+import { sameScope } from "@/lib/scope";
 import { showUpdateOutcome } from "@/lib/update-outcome";
 import { versionRowLabel } from "@/lib/versions";
 import { useAuditStore } from "@/stores/audit";
@@ -191,10 +193,23 @@ export function packageVersionActions(
 
 /** One gate for every control that rewrites this package's manifest: the
  *  audit store's apply, a version switch in flight, the updates store's
- *  fork or discard, and the editor's save all touch the same file. */
-export function useManifestBusy(switching: boolean): boolean {
+ *  fork or discard, a Follow source flip settling in this scope, and the
+ *  editor's save all touch the same file. The controls here command the
+ *  engine directly rather than through the updates store's chain, and two
+ *  commands that both read the manifest before either applies leave the
+ *  second saving its stale copy over the first — so this gate, not
+ *  ordering, is what keeps them apart. */
+export function useManifestBusy(
+  switching: boolean,
+  scope: Scope | null,
+): boolean {
   const auditBusy = useAuditStore((s) => s.busy);
   const updatesBusy = useUpdatesStore((s) => s.busy);
+  const settling = useUpdatesStore((s) =>
+    scope === null
+      ? false
+      : s.pendingFollows.some((one) => sameScope(one.scope, scope)),
+  );
   const saving = useEditorStore((s) => s.saving);
-  return auditBusy || switching || updatesBusy || saving;
+  return auditBusy || switching || updatesBusy || settling || saving;
 }

--- a/ui/src/components/update-follow.dom.test.tsx
+++ b/ui/src/components/update-follow.dom.test.tsx
@@ -8,17 +8,19 @@
 // safe to act on.
 import userEvent from "@testing-library/user-event";
 import { act } from "react";
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { commands } from "@/bindings";
 import { ADOPTABLE } from "@/lib/adoptable";
 import { UPDATE_ALL_LABEL } from "@/lib/copy";
 import {
   followSourceLabel,
   placesLabel,
+  UPDATE_NEEDS_CHECK_NOTE,
   UPDATE_PACKAGE_EVERYWHERE_LABEL,
   USER_LEVEL_PLACE,
 } from "@/lib/copy-updates";
 import { UpdatesPage } from "@/pages/updates";
+import { useProblemsStore } from "@/stores/problems";
 import { useUpdatesStore } from "@/stores/updates";
 import { useUpdatesView } from "@/stores/updates-view";
 import { mount, settle } from "@/test/dom";
@@ -46,16 +48,22 @@ const APP = "/home/me/app";
 // landing's row matching do any work: name alone would identify every row.
 const rows = [row("gh", null), row("gh", APP), row("orch", APP)];
 
-const auditView = {
-  scope: { scope: "global" as const },
-  drift: [],
-  plan: [],
-  notes: [],
-  warnings: [],
-  safety: [],
-  adoptable: ADOPTABLE,
-  exits: [],
+/** What the two held commands answer with: the flip's own apply, and the
+ *  read of the standing that reconciles it. */
+const ok = {
+  status: "ok" as const,
+  data: {
+    scope: { scope: "global" as const },
+    drift: [],
+    plan: [],
+    notes: [],
+    warnings: [],
+    safety: [],
+    adoptable: ADOPTABLE,
+    exits: [],
+  },
 };
+const landed = { status: "ok" as const, data: { rows, warnings: [] as [] } };
 
 /** The table drawn from the store, the way the page draws it: a flip that
  *  only reaches `rows` is a flip nobody sees. */
@@ -101,12 +109,25 @@ const holding = (element: HTMLElement): boolean =>
   element.getAttribute("aria-disabled") === "true" ||
   element.hasAttribute("data-disabled");
 
+const outstanding: (() => void)[] = [];
+
 /** A command that has been called but has not answered, so a test can read
- *  the page mid-write — where the freeze used to be. */
-function pending<T>() {
+ *  the page mid-write — where the freeze used to be. `fallback` answers it
+ *  whatever the test did: the applier's chain and its in-flight count are
+ *  made once with the store module and no reset here can reach them, so a
+ *  command left hanging by a failed assertion fails the tests after it too,
+ *  for a reason that is not theirs. */
+function pending<T>(fallback: T) {
+  let answered = false;
   let answer!: (value: T) => void;
   const promise = new Promise<T>((resolve) => {
-    answer = resolve;
+    answer = (value) => {
+      answered = true;
+      resolve(value);
+    };
+  });
+  outstanding.push(() => {
+    if (!answered) answer(fallback);
   });
   return { promise, answer };
 }
@@ -116,7 +137,17 @@ const openPlaces = async () => {
   await userEvent.click(button(placesLabel(2)));
 };
 
+afterEach(async () => {
+  for (const release of outstanding.splice(0)) release();
+  await act(async () => {});
+});
+
+/** Every failure the page announces, so a test can count them: the dialog
+ *  itself keeps only the last. */
+const showError = vi.fn();
+
 beforeEach(() => {
+  useProblemsStore.setState({ showError });
   useUpdatesStore.setState({
     rows,
     busy: false,
@@ -136,7 +167,7 @@ beforeEach(() => {
 
 describe("the Follow source switch", () => {
   it("moves before the write behind it answers, holding only its scope", async () => {
-    const write = pending<{ status: "ok"; data: typeof auditView }>();
+    const write = pending<typeof ok>(ok);
     vi.mocked(commands.packageSetRev).mockReturnValue(write.promise as never);
     mount(<Live />);
     await openPlaces();
@@ -165,13 +196,13 @@ describe("the Follow source switch", () => {
     expect(holding(followSwitch("gh", "app"))).toBe(false);
     expect(holding(followSwitch("orch", "app"))).toBe(false);
 
-    write.answer({ status: "ok", data: auditView });
+    write.answer(ok);
     await settle();
     expect(commands.updatesOverview).toHaveBeenCalled();
   });
 
   it("keeps its new position under a read that lands mid-write", async () => {
-    const write = pending<{ status: "ok"; data: typeof auditView }>();
+    const write = pending<typeof ok>(ok);
     vi.mocked(commands.packageSetRev).mockReturnValue(write.promise as never);
     mount(<Live />);
     await openPlaces();
@@ -191,7 +222,7 @@ describe("the Follow source switch", () => {
     // The landing carries the flip onto the flipped place alone.
     expect(following(followSwitch("gh", "app"))).toBe(true);
 
-    write.answer({ status: "ok", data: auditView });
+    write.answer(ok);
     await settle();
   });
 
@@ -203,10 +234,7 @@ describe("the Follow source switch", () => {
       status: "error",
       error: "manifest busy",
     });
-    const reread = pending<{
-      status: "ok";
-      data: { rows: typeof rows; warnings: [] };
-    }>();
+    const reread = pending<typeof landed>(landed);
     vi.mocked(commands.updatesOverview).mockReturnValue(
       reread.promise as never,
     );
@@ -218,26 +246,63 @@ describe("the Follow source switch", () => {
     });
     await settle();
 
-    expect(commands.packageSetRev).toHaveBeenCalledTimes(1);
     expect(commands.updatesOverview).toHaveBeenCalledTimes(1);
     expect(holding(followSwitch("gh", USER_LEVEL_PLACE))).toBe(true);
 
     // The refusal is news now, not when the read finishes.
+    expect(showError).toHaveBeenCalledTimes(1);
+    expect(showError.mock.calls[0][0].message).toBe("manifest busy");
+
+    // The reverting flip keeps this scope's commit-applying actions out.
     const store = useUpdatesStore.getState();
     await act(async () => {
       void store.updateOne(store.rows[0]);
     });
-    expect(commands.packageSetRev).toHaveBeenCalledTimes(1);
-    expect(commands.applyPlan).not.toHaveBeenCalled();
+    expect(showError).toHaveBeenLastCalledWith(
+      expect.objectContaining({ message: UPDATE_NEEDS_CHECK_NOTE }),
+    );
 
-    reread.answer({ status: "ok", data: { rows, warnings: [] } });
+    reread.answer(landed);
     await settle();
+    expect(following(followSwitch("gh", USER_LEVEL_PLACE))).toBe(true);
+    expect(useUpdatesStore.getState().pendingFollows).toEqual([]);
+    // And said once. The second announcement arrived when the read
+    // finished, re-opening a dialog the person had already dismissed.
+    expect(
+      showError.mock.calls.filter(
+        (call) => call[0].message === "manifest busy",
+      ),
+    ).toHaveLength(1);
+  });
+
+  // Every read behind a refused write failed, so nothing is coming to
+  // replace the rows the flip painted. The page is held under its own
+  // "couldn't confirm" banner, but the switch must still not sit in a
+  // position the engine never took.
+  it("puts the switch back when nothing lands to replace the flip", async () => {
+    vi.mocked(commands.packageSetRev).mockResolvedValue({
+      status: "error",
+      error: "manifest busy",
+    });
+    vi.mocked(commands.updatesOverview).mockResolvedValue({
+      status: "error",
+      error: "standing unreadable",
+    });
+    mount(<Live />);
+    await openPlaces();
+
+    await act(async () => {
+      followSwitch("gh", USER_LEVEL_PLACE).click();
+    });
+    await settle();
+
+    expect(useUpdatesStore.getState().loaded).toBe(false);
     expect(following(followSwitch("gh", USER_LEVEL_PLACE))).toBe(true);
     expect(useUpdatesStore.getState().pendingFollows).toEqual([]);
   });
 
   it("refuses a second place in the settling scope, and takes another", async () => {
-    const write = pending<{ status: "ok"; data: typeof auditView }>();
+    const write = pending<typeof ok>(ok);
     vi.mocked(commands.packageSetRev).mockReturnValue(write.promise as never);
     mount(<Live />);
     await openPlaces();
@@ -257,12 +322,12 @@ describe("the Follow source switch", () => {
       useUpdatesStore.getState().pendingFollows.map((one) => one.name),
     ).toEqual(["gh", "orch"]);
 
-    write.answer({ status: "ok", data: auditView });
+    write.answer(ok);
     await settle();
   });
 
   it("holds the package-wide Update for a package whose places include the settling scope", async () => {
-    const write = pending<{ status: "ok"; data: typeof auditView }>();
+    const write = pending<typeof ok>(ok);
     vi.mocked(commands.packageSetRev).mockReturnValue(write.promise as never);
     mount(<Live />);
     await openPlaces();
@@ -275,13 +340,13 @@ describe("the Follow source switch", () => {
     expect(button(UPDATE_PACKAGE_EVERYWHERE_LABEL).disabled).toBe(true);
     expect(holding(followSwitch("orch", "app"))).toBe(false);
 
-    write.answer({ status: "ok", data: auditView });
+    write.answer(ok);
     await settle();
     expect(button(UPDATE_PACKAGE_EVERYWHERE_LABEL).disabled).toBe(false);
   });
 
   it("holds Update all while a flip settles", async () => {
-    const write = pending<{ status: "ok"; data: typeof auditView }>();
+    const write = pending<typeof ok>(ok);
     vi.mocked(commands.packageSetRev).mockReturnValue(write.promise as never);
     mount(<UpdatesPage />);
     await settle();
@@ -296,7 +361,7 @@ describe("the Follow source switch", () => {
     // scope being applied.
     expect(updateAll().disabled).toBe(true);
 
-    write.answer({ status: "ok", data: auditView });
+    write.answer(ok);
     await settle();
     expect(updateAll().disabled).toBe(false);
   });

--- a/ui/src/components/update-follow.dom.test.tsx
+++ b/ui/src/components/update-follow.dom.test.tsx
@@ -27,7 +27,10 @@ import { mount, settle } from "@/test/dom";
 import { UpdatesTable } from "./updates-table";
 import { updateRow as row } from "./updates-test-rows";
 
-vi.mock("@/bindings", () => ({
+vi.mock("@/bindings", async (importOriginal) => ({
+  // The generated constants stay real — the update rules read core's own
+  // kind list through them, and a copy kept here could go stale unseen.
+  ...(await importOriginal<typeof import("@/bindings")>()),
   commands: {
     updatesOverview: vi.fn(),
     updatesRefresh: vi.fn(),

--- a/ui/src/components/update-follow.dom.test.tsx
+++ b/ui/src/components/update-follow.dom.test.tsx
@@ -3,11 +3,22 @@
 // settles behind it. The backend chain a flip starts — move the hold,
 // apply the scope, read every scope's standing again — takes seconds, so
 // what these tests hold to is what the page does while it is still
-// running: the switch has moved, and only the flipped scope is holding.
+// running: the switch has moved, only the flipped scope is holding, and no
+// row ever wears a position the engine did not take while saying it is
+// safe to act on.
+import userEvent from "@testing-library/user-event";
 import { act } from "react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { commands } from "@/bindings";
 import { ADOPTABLE } from "@/lib/adoptable";
+import { UPDATE_ALL_LABEL } from "@/lib/copy";
+import {
+  followSourceLabel,
+  placesLabel,
+  UPDATE_PACKAGE_EVERYWHERE_LABEL,
+  USER_LEVEL_PLACE,
+} from "@/lib/copy-updates";
+import { UpdatesPage } from "@/pages/updates";
 import { useUpdatesStore } from "@/stores/updates";
 import { useUpdatesView } from "@/stores/updates-view";
 import { mount, settle } from "@/test/dom";
@@ -17,6 +28,7 @@ import { updateRow as row } from "./updates-test-rows";
 vi.mock("@/bindings", () => ({
   commands: {
     updatesOverview: vi.fn(),
+    updatesRefresh: vi.fn(),
     packageSetRev: vi.fn(),
     applyPlan: vi.fn(),
     scanMachine: vi.fn(),
@@ -28,7 +40,11 @@ vi.mock("sonner", () => ({
   toast: { error: vi.fn(), success: vi.fn(), info: vi.fn() },
 }));
 
-const rows = [row("gh", null), row("dev", null), row("orch", "/home/me/app")];
+const APP = "/home/me/app";
+
+// One package in two places, which is what makes the scope term in the
+// landing's row matching do any work: name alone would identify every row.
+const rows = [row("gh", null), row("gh", APP), row("orch", APP)];
 
 const auditView = {
   scope: { scope: "global" as const },
@@ -48,21 +64,42 @@ const Live = () => {
   return <UpdatesTable rows={live} onIgnore={() => {}} />;
 };
 
-const switches = () => [
-  ...document.querySelectorAll<HTMLElement>('[role="switch"]'),
-];
-
-const following = (index: number): boolean =>
-  switches()[index].getAttribute("aria-checked") === "true";
-
-const holding = (index: number): boolean => {
-  const control = switches()[index];
-  return (
-    control.hasAttribute("disabled") ||
-    control.getAttribute("aria-disabled") === "true" ||
-    control.hasAttribute("data-disabled")
-  );
+const control = (label: string): HTMLElement => {
+  const found = document.querySelector<HTMLElement>(`[aria-label="${label}"]`);
+  if (!found) throw new Error(`no control "${label}"`);
+  return found;
 };
+
+/** One place's switch, by the package and place it names. */
+const followSwitch = (name: string, place: string): HTMLElement =>
+  control(followSourceLabel(name, place));
+
+const buttons = (label: string): HTMLButtonElement[] =>
+  [...document.querySelectorAll("button")].filter(
+    (one) => one.textContent === label,
+  );
+
+const button = (label: string): HTMLButtonElement => {
+  const found = buttons(label)[0];
+  if (!found) throw new Error(`no button "${label}"`);
+  return found;
+};
+
+/** The page header's Update all, not a package row's — the two carry the
+ *  same words, and only the table's sits inside it. */
+const updateAll = (): HTMLButtonElement => {
+  const found = buttons(UPDATE_ALL_LABEL).find((one) => !one.closest("table"));
+  if (!found) throw new Error("no page-level Update all");
+  return found;
+};
+
+const following = (element: HTMLElement): boolean =>
+  element.getAttribute("aria-checked") === "true";
+
+const holding = (element: HTMLElement): boolean =>
+  element.hasAttribute("disabled") ||
+  element.getAttribute("aria-disabled") === "true" ||
+  element.hasAttribute("data-disabled");
 
 /** A command that has been called but has not answered, so a test can read
  *  the page mid-write — where the freeze used to be. */
@@ -73,6 +110,11 @@ function pending<T>() {
   });
   return { promise, answer };
 }
+
+/** gh sits in two places, so its places open behind the expander. */
+const openPlaces = async () => {
+  await userEvent.click(button(placesLabel(2)));
+};
 
 beforeEach(() => {
   useUpdatesStore.setState({
@@ -97,15 +139,17 @@ describe("the Follow source switch", () => {
     const write = pending<{ status: "ok"; data: typeof auditView }>();
     vi.mocked(commands.packageSetRev).mockReturnValue(write.promise as never);
     mount(<Live />);
-    expect(following(0)).toBe(true);
+    await openPlaces();
+    const flipped = followSwitch("gh", USER_LEVEL_PLACE);
+    expect(following(flipped)).toBe(true);
 
     await act(async () => {
-      switches()[0].click();
+      flipped.click();
     });
 
     // The click path awaits nothing: the switch is off, and the write it
     // started has not answered.
-    expect(following(0)).toBe(false);
+    expect(following(followSwitch("gh", USER_LEVEL_PLACE))).toBe(false);
     expect(commands.packageSetRev).toHaveBeenCalledWith(
       { scope: "global" },
       "skill",
@@ -113,26 +157,28 @@ describe("the Follow source switch", () => {
       "1111111111",
     );
     expect(commands.updatesOverview).not.toHaveBeenCalled();
+    // The same package in another place is a different declaration: the
+    // flip is not its.
+    expect(following(followSwitch("gh", "app"))).toBe(true);
     // The scope being applied holds; the project scope is untouched by it
     // and stays live.
-    expect(holding(1)).toBe(true);
-    expect(holding(2)).toBe(false);
+    expect(holding(followSwitch("gh", "app"))).toBe(false);
+    expect(holding(followSwitch("orch", "app"))).toBe(false);
 
     write.answer({ status: "ok", data: auditView });
     await settle();
     expect(commands.updatesOverview).toHaveBeenCalled();
-    expect(holding(1)).toBe(false);
   });
 
   it("keeps its new position under a read that lands mid-write", async () => {
     const write = pending<{ status: "ok"; data: typeof auditView }>();
     vi.mocked(commands.packageSetRev).mockReturnValue(write.promise as never);
     mount(<Live />);
+    await openPlaces();
 
     await act(async () => {
-      switches()[0].click();
+      followSwitch("gh", USER_LEVEL_PLACE).click();
     });
-    expect(following(0)).toBe(false);
 
     // The window regaining focus rescans, and that read can reach the
     // manifest before the write does — it carries the switch's old
@@ -141,25 +187,52 @@ describe("the Follow source switch", () => {
       await useUpdatesStore.getState().load();
     });
 
-    expect(following(0)).toBe(false);
+    expect(following(followSwitch("gh", USER_LEVEL_PLACE))).toBe(false);
+    // The landing carries the flip onto the flipped place alone.
+    expect(following(followSwitch("gh", "app"))).toBe(true);
 
     write.answer({ status: "ok", data: auditView });
     await settle();
   });
 
-  it("puts the switch back when the write is refused", async () => {
+  // The engine wrote nothing, but the rows already wear the flip. Until the
+  // read that puts them back lands, the place goes on holding: a row that
+  // said it was settled here would hand updateOne a pin that never landed.
+  it("goes on holding a refused flip until the read behind it lands", async () => {
     vi.mocked(commands.packageSetRev).mockResolvedValue({
       status: "error",
       error: "manifest busy",
     });
+    const reread = pending<{
+      status: "ok";
+      data: { rows: typeof rows; warnings: [] };
+    }>();
+    vi.mocked(commands.updatesOverview).mockReturnValue(
+      reread.promise as never,
+    );
     mount(<Live />);
+    await openPlaces();
 
     await act(async () => {
-      switches()[0].click();
+      followSwitch("gh", USER_LEVEL_PLACE).click();
     });
     await settle();
 
-    expect(following(0)).toBe(true);
+    expect(commands.packageSetRev).toHaveBeenCalledTimes(1);
+    expect(commands.updatesOverview).toHaveBeenCalledTimes(1);
+    expect(holding(followSwitch("gh", USER_LEVEL_PLACE))).toBe(true);
+
+    // The refusal is news now, not when the read finishes.
+    const store = useUpdatesStore.getState();
+    await act(async () => {
+      void store.updateOne(store.rows[0]);
+    });
+    expect(commands.packageSetRev).toHaveBeenCalledTimes(1);
+    expect(commands.applyPlan).not.toHaveBeenCalled();
+
+    reread.answer({ status: "ok", data: { rows, warnings: [] } });
+    await settle();
+    expect(following(followSwitch("gh", USER_LEVEL_PLACE))).toBe(true);
     expect(useUpdatesStore.getState().pendingFollows).toEqual([]);
   });
 
@@ -167,25 +240,64 @@ describe("the Follow source switch", () => {
     const write = pending<{ status: "ok"; data: typeof auditView }>();
     vi.mocked(commands.packageSetRev).mockReturnValue(write.promise as never);
     mount(<Live />);
+    await openPlaces();
     await act(async () => {
-      switches()[0].click();
+      followSwitch("gh", USER_LEVEL_PLACE).click();
     });
 
     // The apply behind the first flip can move what is installed in its
     // scope, so a second hold captured there would pin a commit about to
     // go stale. Another scope's is untouched by it.
     await act(async () => {
-      void useUpdatesStore.getState().setAutoUpdate(rows[1], false);
+      void useUpdatesStore.getState().setAutoUpdate(rows[0], true);
       void useUpdatesStore.getState().setAutoUpdate(rows[2], false);
     });
 
-    expect(following(1)).toBe(true);
-    expect(following(2)).toBe(false);
     expect(
       useUpdatesStore.getState().pendingFollows.map((one) => one.name),
     ).toEqual(["gh", "orch"]);
 
     write.answer({ status: "ok", data: auditView });
     await settle();
+  });
+
+  it("holds the package-wide Update for a package whose places include the settling scope", async () => {
+    const write = pending<{ status: "ok"; data: typeof auditView }>();
+    vi.mocked(commands.packageSetRev).mockReturnValue(write.promise as never);
+    mount(<Live />);
+    await openPlaces();
+    await act(async () => {
+      followSwitch("gh", USER_LEVEL_PLACE).click();
+    });
+
+    // gh has a place in the settling scope; orch's single place does not,
+    // and its own Update stays live.
+    expect(button(UPDATE_PACKAGE_EVERYWHERE_LABEL).disabled).toBe(true);
+    expect(holding(followSwitch("orch", "app"))).toBe(false);
+
+    write.answer({ status: "ok", data: auditView });
+    await settle();
+    expect(button(UPDATE_PACKAGE_EVERYWHERE_LABEL).disabled).toBe(false);
+  });
+
+  it("holds Update all while a flip settles", async () => {
+    const write = pending<{ status: "ok"; data: typeof auditView }>();
+    vi.mocked(commands.packageSetRev).mockReturnValue(write.promise as never);
+    mount(<UpdatesPage />);
+    await settle();
+    await openPlaces();
+    expect(updateAll().disabled).toBe(false);
+
+    await act(async () => {
+      followSwitch("gh", USER_LEVEL_PLACE).click();
+    });
+
+    // Update all acts on every visible row, and one of them is in the
+    // scope being applied.
+    expect(updateAll().disabled).toBe(true);
+
+    write.answer({ status: "ok", data: auditView });
+    await settle();
+    expect(updateAll().disabled).toBe(false);
   });
 });

--- a/ui/src/components/update-follow.dom.test.tsx
+++ b/ui/src/components/update-follow.dom.test.tsx
@@ -1,0 +1,191 @@
+// @vitest-environment jsdom
+// The Follow source switch is one row's state change plus a write that
+// settles behind it. The backend chain a flip starts — move the hold,
+// apply the scope, read every scope's standing again — takes seconds, so
+// what these tests hold to is what the page does while it is still
+// running: the switch has moved, and only the flipped scope is holding.
+import { act } from "react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { commands } from "@/bindings";
+import { ADOPTABLE } from "@/lib/adoptable";
+import { useUpdatesStore } from "@/stores/updates";
+import { useUpdatesView } from "@/stores/updates-view";
+import { mount, settle } from "@/test/dom";
+import { UpdatesTable } from "./updates-table";
+import { updateRow as row } from "./updates-test-rows";
+
+vi.mock("@/bindings", () => ({
+  commands: {
+    updatesOverview: vi.fn(),
+    packageSetRev: vi.fn(),
+    applyPlan: vi.fn(),
+    scanMachine: vi.fn(),
+    auditAll: vi.fn(),
+  },
+}));
+
+vi.mock("sonner", () => ({
+  toast: { error: vi.fn(), success: vi.fn(), info: vi.fn() },
+}));
+
+const rows = [row("gh", null), row("dev", null), row("orch", "/home/me/app")];
+
+const auditView = {
+  scope: { scope: "global" as const },
+  drift: [],
+  plan: [],
+  notes: [],
+  warnings: [],
+  safety: [],
+  adoptable: ADOPTABLE,
+  exits: [],
+};
+
+/** The table drawn from the store, the way the page draws it: a flip that
+ *  only reaches `rows` is a flip nobody sees. */
+const Live = () => {
+  const live = useUpdatesStore((s) => s.rows);
+  return <UpdatesTable rows={live} onIgnore={() => {}} />;
+};
+
+const switches = () => [
+  ...document.querySelectorAll<HTMLElement>('[role="switch"]'),
+];
+
+const following = (index: number): boolean =>
+  switches()[index].getAttribute("aria-checked") === "true";
+
+const holding = (index: number): boolean => {
+  const control = switches()[index];
+  return (
+    control.hasAttribute("disabled") ||
+    control.getAttribute("aria-disabled") === "true" ||
+    control.hasAttribute("data-disabled")
+  );
+};
+
+/** A command that has been called but has not answered, so a test can read
+ *  the page mid-write — where the freeze used to be. */
+function pending<T>() {
+  let answer!: (value: T) => void;
+  const promise = new Promise<T>((resolve) => {
+    answer = resolve;
+  });
+  return { promise, answer };
+}
+
+beforeEach(() => {
+  useUpdatesStore.setState({
+    rows,
+    busy: false,
+    loaded: true,
+    checking: false,
+    overviewInFlight: false,
+    pendingFollows: [],
+    error: null,
+  });
+  useUpdatesView.setState({ showVersion: false });
+  vi.clearAllMocks();
+  vi.mocked(commands.updatesOverview).mockResolvedValue({
+    status: "ok",
+    data: { rows, warnings: [] },
+  });
+});
+
+describe("the Follow source switch", () => {
+  it("moves before the write behind it answers, holding only its scope", async () => {
+    const write = pending<{ status: "ok"; data: typeof auditView }>();
+    vi.mocked(commands.packageSetRev).mockReturnValue(write.promise as never);
+    mount(<Live />);
+    expect(following(0)).toBe(true);
+
+    await act(async () => {
+      switches()[0].click();
+    });
+
+    // The click path awaits nothing: the switch is off, and the write it
+    // started has not answered.
+    expect(following(0)).toBe(false);
+    expect(commands.packageSetRev).toHaveBeenCalledWith(
+      { scope: "global" },
+      "skill",
+      "gh",
+      "1111111111",
+    );
+    expect(commands.updatesOverview).not.toHaveBeenCalled();
+    // The scope being applied holds; the project scope is untouched by it
+    // and stays live.
+    expect(holding(1)).toBe(true);
+    expect(holding(2)).toBe(false);
+
+    write.answer({ status: "ok", data: auditView });
+    await settle();
+    expect(commands.updatesOverview).toHaveBeenCalled();
+    expect(holding(1)).toBe(false);
+  });
+
+  it("keeps its new position under a read that lands mid-write", async () => {
+    const write = pending<{ status: "ok"; data: typeof auditView }>();
+    vi.mocked(commands.packageSetRev).mockReturnValue(write.promise as never);
+    mount(<Live />);
+
+    await act(async () => {
+      switches()[0].click();
+    });
+    expect(following(0)).toBe(false);
+
+    // The window regaining focus rescans, and that read can reach the
+    // manifest before the write does — it carries the switch's old
+    // position, and landing it raw would bounce the switch back.
+    await act(async () => {
+      await useUpdatesStore.getState().load();
+    });
+
+    expect(following(0)).toBe(false);
+
+    write.answer({ status: "ok", data: auditView });
+    await settle();
+  });
+
+  it("puts the switch back when the write is refused", async () => {
+    vi.mocked(commands.packageSetRev).mockResolvedValue({
+      status: "error",
+      error: "manifest busy",
+    });
+    mount(<Live />);
+
+    await act(async () => {
+      switches()[0].click();
+    });
+    await settle();
+
+    expect(following(0)).toBe(true);
+    expect(useUpdatesStore.getState().pendingFollows).toEqual([]);
+  });
+
+  it("refuses a second place in the settling scope, and takes another", async () => {
+    const write = pending<{ status: "ok"; data: typeof auditView }>();
+    vi.mocked(commands.packageSetRev).mockReturnValue(write.promise as never);
+    mount(<Live />);
+    await act(async () => {
+      switches()[0].click();
+    });
+
+    // The apply behind the first flip can move what is installed in its
+    // scope, so a second hold captured there would pin a commit about to
+    // go stale. Another scope's is untouched by it.
+    await act(async () => {
+      void useUpdatesStore.getState().setAutoUpdate(rows[1], false);
+      void useUpdatesStore.getState().setAutoUpdate(rows[2], false);
+    });
+
+    expect(following(1)).toBe(true);
+    expect(following(2)).toBe(false);
+    expect(
+      useUpdatesStore.getState().pendingFollows.map((one) => one.name),
+    ).toEqual(["gh", "orch"]);
+
+    write.answer({ status: "ok", data: auditView });
+    await settle();
+  });
+});

--- a/ui/src/components/update-place-cells.tsx
+++ b/ui/src/components/update-place-cells.tsx
@@ -30,7 +30,7 @@ import {
 } from "@/lib/copy-updates";
 import { packageDisplayName } from "@/lib/labels";
 import { heldByOwner, placeName, switchLockedBy } from "@/lib/update-groups";
-import { unsettled } from "@/lib/updates-read-state";
+import { rowUnsettled } from "@/lib/updates-read-state";
 import { hasPerPackageUpdate, versionLabel } from "@/lib/versions";
 import { useNavStore } from "@/stores/nav";
 import { useUpdatesStore } from "@/stores/updates";
@@ -52,10 +52,10 @@ export function PlaceCells({
   onIgnore?: (row: UpdateRow) => void;
 }) {
   const { busy, updateOne, setAutoUpdate, setIgnored } = useUpdatesStore();
-  // Anything overview-producing in flight is about to replace these rows;
-  // the store actions refuse regardless, and the controls say so instead
-  // of inviting the click.
-  const held = useUpdatesStore(unsettled);
+  // Anything about to replace this place's row — an overview-producing
+  // read, a follow switch settling in its scope — holds its controls; the
+  // store refuses regardless, and they say so rather than invite a click.
+  const held = useUpdatesStore((s) => rowUnsettled(s, row));
   const showVersion = useUpdatesView((s) => s.showVersion);
   const goToPackage = useNavStore((s) => s.goToPackage);
   const name = packageDisplayName(row);

--- a/ui/src/components/updates-table.tsx
+++ b/ui/src/components/updates-table.tsx
@@ -32,7 +32,7 @@ import {
   type UpdateGroup,
   updatablePlaces,
 } from "@/lib/update-groups";
-import { unsettled } from "@/lib/updates-read-state";
+import { rowUnsettled } from "@/lib/updates-read-state";
 import { useUpdatesStore } from "@/stores/updates";
 import { useUpdatesView } from "@/stores/updates-view";
 
@@ -82,14 +82,17 @@ export function PackageRows({
   const [open, setOpen] = useState(defaultOpen);
   const placesId = useId();
   const busy = useUpdatesStore((s) => s.busy);
-  // Not loaded, mid-check, and mid-load hold Update alike: either way
-  // these rows are not the rows an update would act on.
-  const unconfirmed = useUpdatesStore(unsettled);
+  const places = group.places;
+  // Not loaded, mid-check, mid-load, and a follow switch settling in any of
+  // these places' scopes hold Update alike: either way these are not the
+  // rows an update would act on.
+  const unconfirmed = useUpdatesStore((s) =>
+    places.some((place) => rowUnsettled(s, place)),
+  );
   const showVersion = useUpdatesView((s) => s.showVersion);
   const updateRows = useUpdatesStore((s) => s.updateRows);
   const Icon = kindIcon(group.kind);
   const name = packageDisplayName(group);
-  const places = group.places;
   const scopes = places.map((place) => place.scope);
   const only = places.length === 1 ? places[0] : null;
   const Chevron = open ? ChevronDown : ChevronRight;

--- a/ui/src/lib/updates-read-state.ts
+++ b/ui/src/lib/updates-read-state.ts
@@ -1,3 +1,14 @@
+import type { Scope } from "@/bindings";
+import { sameScope } from "@/lib/scope";
+
+/** What every predicate here reads: how the last read of the standing went,
+ *  and whether one that would replace it is running. */
+interface PageState {
+  loaded: boolean;
+  checking: boolean;
+  overviewInFlight: boolean;
+}
+
 /** How the read of the update standing stands. Three answers that must
  *  never blur: a first read still on its way, a read that failed, and a
  *  read that landed. Only the last may say "nothing here". A failed
@@ -17,8 +28,22 @@ export function updatesReadState(state: {
  *  not answered or the last one failed, a check is running, or anything
  *  overview-producing is in flight and about to replace them. One
  *  predicate for every control that holds and every action that refuses. */
-export const unsettled = (state: {
-  loaded: boolean;
-  checking: boolean;
-  overviewInFlight: boolean;
-}): boolean => !state.loaded || state.checking || state.overviewInFlight;
+export const unsettled = (state: PageState): boolean =>
+  !state.loaded || state.checking || state.overviewInFlight;
+
+/** Whether one row's facts are not to be acted on: everything `unsettled`
+ *  answers for the page, and a follow switch still settling in that row's
+ *  scope. The apply behind a flip moves what is installed in that scope and
+ *  nowhere else, so every other row stays live while it runs. */
+export const rowUnsettled = (
+  state: PageState & { pendingFollows: { scope: Scope }[] },
+  row: { scope: Scope },
+): boolean =>
+  unsettled(state) ||
+  state.pendingFollows.some((one) => sameScope(one.scope, row.scope));
+
+/** `unsettled` for an action that spans every scope — "Update all" acts on
+ *  rows wherever they live, so any settling flip is one of them. */
+export const anyUnsettled = (
+  state: PageState & { pendingFollows: unknown[] },
+): boolean => unsettled(state) || state.pendingFollows.length > 0;

--- a/ui/src/lib/updates-read-state.ts
+++ b/ui/src/lib/updates-read-state.ts
@@ -24,10 +24,11 @@ export function updatesReadState(state: {
   return state.loaded ? "landed" : "pending";
 }
 
-/** Whether the rows on screen are not to be acted on: the first read has
- *  not answered or the last one failed, a check is running, or anything
- *  overview-producing is in flight and about to replace them. One
- *  predicate for every control that holds and every action that refuses. */
+/** Whether the rows on screen are not to be acted on, page-wide: the first
+ *  read has not answered or the last one failed, a check is running, or an
+ *  operation that replaces every row is in flight. A settling follow flip
+ *  is not here — it replaces every row too but holds only its own scope, so
+ *  ask `rowUnsettled` whether a given row may be acted on. */
 export const unsettled = (state: PageState): boolean =>
   !state.loaded || state.checking || state.overviewInFlight;
 
@@ -41,9 +42,3 @@ export const rowUnsettled = (
 ): boolean =>
   unsettled(state) ||
   state.pendingFollows.some((one) => sameScope(one.scope, row.scope));
-
-/** `unsettled` for an action that spans every scope — "Update all" acts on
- *  rows wherever they live, so any settling flip is one of them. */
-export const anyUnsettled = (
-  state: PageState & { pendingFollows: unknown[] },
-): boolean => unsettled(state) || state.pendingFollows.length > 0;

--- a/ui/src/pages/package.tsx
+++ b/ui/src/pages/package.tsx
@@ -56,7 +56,7 @@ export function PackagePage() {
   );
   const [confirmRemove, setConfirmRemove] = useState(false);
   const [switching, setSwitching] = useState(false);
-  const mutating = useManifestBusy(switching);
+  const mutating = useManifestBusy(switching, ref?.scope ?? null);
   useEffect(() => {
     if (initialView) clearPackageView();
   }, [initialView, clearPackageView]);

--- a/ui/src/pages/package.tsx
+++ b/ui/src/pages/package.tsx
@@ -56,7 +56,6 @@ export function PackagePage() {
   );
   const [confirmRemove, setConfirmRemove] = useState(false);
   const [switching, setSwitching] = useState(false);
-  const mutating = useManifestBusy(switching, ref?.scope ?? null);
   useEffect(() => {
     if (initialView) clearPackageView();
   }, [initialView, clearPackageView]);
@@ -75,6 +74,12 @@ export function PackagePage() {
     return groupItems(matching)[0] ?? null;
   }, [ref, result]);
 
+  // Every manifest this page's controls can write: the place it was opened
+  // at, and each place Remove and the enable/disable toggle reach.
+  const mutating = useManifestBusy(switching, [
+    ...(ref ? [ref.scope] : []),
+    ...(group ? groupScopes(group) : []),
+  ]);
   const { meta, files, versions, load: reload } = usePackageData(ref);
   const diff = usePackageDiff(
     ref,

--- a/ui/src/pages/updates.tsx
+++ b/ui/src/pages/updates.tsx
@@ -36,7 +36,7 @@ import {
   updatablePlaces,
   visibleUpdates,
 } from "@/lib/update-groups";
-import { unsettled } from "@/lib/updates-read-state";
+import { anyUnsettled } from "@/lib/updates-read-state";
 import { cn } from "@/lib/utils";
 import { useUpdatesStore } from "@/stores/updates";
 import { useUpdatesView } from "@/stores/updates-view";
@@ -49,8 +49,9 @@ export function UpdatesPage() {
   const loaded = useUpdatesStore((s) => s.loaded);
   const error = useUpdatesStore((s) => s.error);
   // Anything overview-producing in flight holds Update all, same as the
-  // per-row controls: these rows are about to be replaced.
-  const unconfirmed = useUpdatesStore(unsettled);
+  // per-row controls: these rows are about to be replaced. So does a
+  // follow switch still settling anywhere — Update all spans every scope.
+  const unconfirmed = useUpdatesStore(anyUnsettled);
   const load = useUpdatesStore((s) => s.load);
   // One choice for every table on the page; the `…` menu lives on the
   // main table, or on the muted one when it is the only table drawn.

--- a/ui/src/pages/updates.tsx
+++ b/ui/src/pages/updates.tsx
@@ -36,7 +36,7 @@ import {
   updatablePlaces,
   visibleUpdates,
 } from "@/lib/update-groups";
-import { anyUnsettled } from "@/lib/updates-read-state";
+import { rowUnsettled } from "@/lib/updates-read-state";
 import { cn } from "@/lib/utils";
 import { useUpdatesStore } from "@/stores/updates";
 import { useUpdatesView } from "@/stores/updates-view";
@@ -48,10 +48,13 @@ export function UpdatesPage() {
     useUpdatesStore();
   const loaded = useUpdatesStore((s) => s.loaded);
   const error = useUpdatesStore((s) => s.error);
-  // Anything overview-producing in flight holds Update all, same as the
-  // per-row controls: these rows are about to be replaced. So does a
-  // follow switch still settling anywhere — Update all spans every scope.
-  const unconfirmed = useUpdatesStore(anyUnsettled);
+  // Update all holds on exactly what it would act on, so the button and
+  // updateRows answer to one predicate: any visible row about to be
+  // replaced, by an overview-producing read or by a flip settling in its
+  // scope.
+  const unconfirmed = useUpdatesStore((s) =>
+    visibleUpdates(s.rows).some((row) => rowUnsettled(s, row)),
+  );
   const load = useUpdatesStore((s) => s.load);
   // One choice for every table on the page; the `…` menu lives on the
   // main table, or on the muted one when it is the only table drawn.

--- a/ui/src/stores/updates-edits.test.ts
+++ b/ui/src/stores/updates-edits.test.ts
@@ -61,7 +61,12 @@ describe("updates store: edited places", () => {
   beforeEach(() => {
     // Rows being acted on imply a read that answered; the stale-refusal
     // test below stages the opposite itself.
-    useUpdatesStore.setState({ rows: [], busy: false, loaded: true });
+    useUpdatesStore.setState({
+      rows: [],
+      busy: false,
+      loaded: true,
+      pendingFollows: [],
+    });
     vi.clearAllMocks();
   });
 
@@ -232,7 +237,12 @@ describe("updates store: installing beside an edited place", () => {
   };
 
   beforeEach(() => {
-    useUpdatesStore.setState({ rows: [], busy: false, loaded: true });
+    useUpdatesStore.setState({
+      rows: [],
+      busy: false,
+      loaded: true,
+      pendingFollows: [],
+    });
     useProblemsStore.setState({
       dialog: { open: false, title: "", steps: [], actions: [] },
     });
@@ -373,5 +383,84 @@ describe("updates store: installing beside an edited place", () => {
       UPDATE_NEEDS_CHECK_NOTE,
     );
     expect(commands.packageForkBeside).not.toHaveBeenCalled();
+  });
+
+  // Both of these send row.latest.commit off a row.pinned the settling flip
+  // may have painted, and stale(row) is their only guard: the scope the
+  // flip is applying holds, and every other scope carries on.
+  it("holds a discard and an install-beside while a flip settles in that scope", async () => {
+    useProblemsStore.setState({
+      dialog: { open: false, title: "", steps: [], actions: [] },
+    });
+    useUpdatesStore.setState({
+      pendingFollows: [
+        {
+          id: 1,
+          scope: { scope: "global" },
+          kind: "skill",
+          name: "other",
+          pinned: true,
+          reverting: false,
+        },
+      ],
+    });
+    const edited = row({
+      blockedByLocalEdit: true,
+      editedHarnesses: ["claude"],
+      forkableHarness: "claude",
+    });
+
+    await takeNewVersion(edited);
+    expect(commands.applyDiscardEdits).not.toHaveBeenCalled();
+    expect(useProblemsStore.getState().dialog.message).toBe(
+      UPDATE_NEEDS_CHECK_NOTE,
+    );
+    expect(await installAsNew(edited, "claude", "gh-mine")).toBe(
+      UPDATE_NEEDS_CHECK_NOTE,
+    );
+    expect(commands.packageForkBeside).not.toHaveBeenCalled();
+  });
+
+  it("lets a discard through while the flip settles in another scope", async () => {
+    useUpdatesStore.setState({
+      pendingFollows: [
+        {
+          id: 1,
+          scope: { scope: "project", root: "/home/me/app" },
+          kind: "skill",
+          name: "gh",
+          pinned: true,
+          reverting: false,
+        },
+      ],
+    });
+    vi.mocked(commands.applyDiscardEdits).mockResolvedValue({
+      status: "ok",
+      data: {
+        scope: { scope: "global" },
+        drift: [],
+        plan: [],
+        notes: [],
+        warnings: [],
+        safety: [],
+        adoptable: ADOPTABLE,
+        exits: [],
+      },
+    });
+    vi.mocked(commands.updatesOverview).mockResolvedValue({
+      status: "ok",
+      data: { rows: [], warnings: [] },
+    });
+    vi.mocked(commands.scanMachine).mockResolvedValue({
+      status: "ok",
+      data: { harnesses: [], items: [], missingProjects: [], warnings: [] },
+    });
+    vi.mocked(commands.auditAll).mockResolvedValue({ status: "ok", data: [] });
+
+    await takeNewVersion(
+      row({ blockedByLocalEdit: true, editedHarnesses: ["claude"] }),
+    );
+
+    expect(commands.applyDiscardEdits).toHaveBeenCalled();
   });
 });

--- a/ui/src/stores/updates-edits.ts
+++ b/ui/src/stores/updates-edits.ts
@@ -7,7 +7,7 @@ import {
   UPDATE_NEEDS_CHECK_NOTE,
 } from "@/lib/copy-updates";
 import { packageDisplayName } from "@/lib/labels";
-import { unsettled } from "@/lib/updates-read-state";
+import { rowUnsettled } from "@/lib/updates-read-state";
 import { useAuditStore } from "./audit";
 import { useProblemsStore } from "./problems";
 import { useScanStore } from "./scan";
@@ -49,10 +49,12 @@ const report = (outcome: Outcome<unknown>) => {
       .showError({ title: FORK_ERROR_TITLE, message: outcome.error });
 };
 
-/** Rows kept from a failed check, or about to be replaced by a running
- *  one, name a `latest` nobody confirmed — an action that may move a hold
- *  to it stops here, whatever the trigger looked like. */
-const stale = (): boolean => unsettled(useUpdatesStore.getState());
+/** Rows kept from a failed check, about to be replaced by a running one,
+ *  or waiting on a follow switch settling in their scope name a `latest`
+ *  nobody confirmed — an action that may move a hold to it stops here,
+ *  whatever the trigger looked like. */
+const stale = (row: UpdateRow): boolean =>
+  rowUnsettled(useUpdatesStore.getState(), row);
 
 /** Keep an edited place's files as a local fork of its own. Only some
  *  tools' renderings read back as source; the row names the edited one a
@@ -78,7 +80,7 @@ export const keepAsOwn = async (row: UpdateRow): Promise<void> => {
 /** Drop an edited place's edits and take the newest version — moving the
  *  hold along when the place is held, in the same apply. */
 export const takeNewVersion = async (row: UpdateRow): Promise<void> => {
-  if (stale()) {
+  if (stale(row)) {
     report({ error: UPDATE_NEEDS_CHECK_NOTE });
     return;
   }
@@ -115,7 +117,7 @@ export const installAsNew = async (
   harness: HarnessId,
   own: string,
 ): Promise<string | null> => {
-  if (stale()) return UPDATE_NEEDS_CHECK_NOTE;
+  if (stale(row)) return UPDATE_NEEDS_CHECK_NOTE;
   const name = packageDisplayName(row);
   const outcome = await run<string | null>(async () => {
     const response = await commands.packageForkBeside(

--- a/ui/src/stores/updates-follow.ts
+++ b/ui/src/stores/updates-follow.ts
@@ -54,13 +54,26 @@ export const withPending = (
         one.name === row.name &&
         sameScope(one.scope, row.scope),
     );
-    return flip ? { ...row, pinned: flip.pinned } : row;
+    if (!flip) return row;
+    // The engine derives one from the other — a row is pinned exactly when
+    // something holds it — so painting `pinned` alone would be a shape no
+    // overview can return. The owner is always this declaration's own: a
+    // hold a source or a parent owns locks the switch, so those rows never
+    // accept a flip.
+    return {
+      ...row,
+      pinned: flip.pinned,
+      holdOwner: flip.pinned ? { kind: "package" as const } : null,
+    };
   });
 };
 
 interface FollowStore {
   rows: UpdateRow[];
   pendingFollows: PendingFollow[];
+  /** False when no read has landed since the flip — the rows still wear it
+   *  and nothing is coming to replace them. */
+  loaded: boolean;
   mutate: (
     work: () => Promise<string | null>,
     kind?: "mutation" | "settle",
@@ -138,7 +151,16 @@ export function followSwitch({
       }, "settle");
       if (error !== null && !refused) report(error);
     } finally {
-      // The read behind the write has landed; it is the truth from here.
+      // A refusal whose reads all failed leaves the rows as the flip
+      // painted them with nothing coming to replace them: put the switch
+      // back where the engine still has it before letting the scope go.
+      if (refused && !get().loaded) {
+        set({
+          rows: withPending(get().rows, [
+            { ...flip, pinned: row.pinned, reverting: false },
+          ]),
+        });
+      }
       retire();
     }
   };

--- a/ui/src/stores/updates-follow.ts
+++ b/ui/src/stores/updates-follow.ts
@@ -18,38 +18,43 @@ import { settled } from "@/lib/settled";
 /** A follow switch moved but not yet answered for: the place it was moved
  *  in, and the position it was moved to. */
 export interface PendingFollow {
+  /** This flip, apart from any other — what retires the right entry once a
+   *  reverting one has been replaced. */
+  id: number;
   scope: Scope;
   kind: ItemKind;
   name: string;
   /** True when the switch went off — the package is held at what is
    *  installed now. */
   pinned: boolean;
+  /** The write came back refused. The flip stops painting onto landings,
+   *  but the rows already wear it, so the entry stays until the read that
+   *  replaces them lands: a row must never wear a position the engine did
+   *  not take while reporting itself settled. */
+  reverting: boolean;
 }
 
-/** `rows` wearing every pending flip. A read that began before a flip
- *  carries the switch's old position; landing it raw would bounce the
- *  switch back under the hand that moved it. */
+let flips = 0;
+
+/** `rows` wearing every pending flip the engine may still take. A read that
+ *  began before a flip carries the switch's old position; landing it raw
+ *  would bounce the switch back under the hand that moved it. A reverting
+ *  flip paints nothing — the landing it is waiting for is the one that puts
+ *  the switch back. */
 export const withPending = (
   rows: UpdateRow[],
   pending: PendingFollow[],
 ): UpdateRow[] => {
-  if (pending.length === 0) return rows;
+  const painting = pending.filter((one) => !one.reverting);
+  if (painting.length === 0) return rows;
   return rows.map((row) => {
-    const flip = pending.find(
+    const flip = painting.find(
       (one) =>
         one.kind === row.kind &&
         one.name === row.name &&
         sameScope(one.scope, row.scope),
     );
-    if (!flip) return row;
-    // A hold the source or a parent owns is not this switch's to move —
-    // those rows never accept a flip, so a pending one is always this
-    // declaration's own.
-    return {
-      ...row,
-      pinned: flip.pinned,
-      holdOwner: flip.pinned ? { kind: "package" as const } : null,
-    };
+    return flip ? { ...row, pinned: flip.pinned } : row;
   });
 };
 
@@ -86,20 +91,31 @@ export function followSwitch({
     // Same refusal as updateOne: the hold would pin a commit captured from
     // rows an in-flight read is about to replace.
     if (refuse(row)) return;
-    const pending: PendingFollow = {
+    flips += 1;
+    const flip: PendingFollow = {
+      id: flips,
       scope: row.scope,
       kind: row.kind,
       name: row.name,
       pinned: !auto,
+      reverting: false,
     };
+    const update = (
+      change: (pending: PendingFollow[]) => PendingFollow[],
+    ): void => set({ pendingFollows: change(get().pendingFollows) });
+    const revert = () =>
+      update((pending) =>
+        pending.map((one) =>
+          one.id === flip.id ? { ...one, reverting: true } : one,
+        ),
+      );
     const retire = () =>
-      set({
-        pendingFollows: get().pendingFollows.filter((one) => one !== pending),
-      });
+      update((pending) => pending.filter((one) => one.id !== flip.id));
     set({
-      rows: withPending(get().rows, [pending]),
-      pendingFollows: [...get().pendingFollows, pending],
+      rows: withPending(get().rows, [flip]),
+      pendingFollows: [...get().pendingFollows, flip],
     });
+    let refused = false;
     try {
       const error = await get().mutate(async () => {
         const response = await settled(
@@ -111,14 +127,18 @@ export function followSwitch({
           ),
         );
         if (response.status === "ok") return null;
-        // Nothing committed, so the read that follows carries the switch's
-        // old position — a flip that never happened must not paint over it.
-        retire();
+        // Nothing committed. The rows still wear a position the engine did
+        // not take, so the scope goes on holding until the read behind this
+        // puts them right — and the refusal is news now, not in the seconds
+        // that read takes.
+        refused = true;
+        revert();
+        report(response.error);
         return response.error;
       }, "settle");
-      if (error !== null) report(error);
+      if (error !== null && !refused) report(error);
     } finally {
-      // The write landed; the read behind it is the truth from here.
+      // The read behind the write has landed; it is the truth from here.
       retire();
     }
   };

--- a/ui/src/stores/updates-follow.ts
+++ b/ui/src/stores/updates-follow.ts
@@ -1,0 +1,125 @@
+// The Follow source switch: one row's state change, then a write that
+// settles behind it. The chain a flip starts — move the hold, apply the
+// scope, then read every scope's standing again — takes seconds of git and
+// planning, and awaiting it before the switch moved held the whole page for
+// as long as it ran. The flip is recorded here as pending, worn by the rows
+// on screen until the read that follows the write lands, and its scope
+// holds while it is outstanding: an apply moves what is installed there,
+// and nowhere else.
+import {
+  commands,
+  type ItemKind,
+  type Scope,
+  type UpdateRow,
+} from "@/bindings";
+import { sameScope } from "@/lib/scope";
+import { settled } from "@/lib/settled";
+
+/** A follow switch moved but not yet answered for: the place it was moved
+ *  in, and the position it was moved to. */
+export interface PendingFollow {
+  scope: Scope;
+  kind: ItemKind;
+  name: string;
+  /** True when the switch went off — the package is held at what is
+   *  installed now. */
+  pinned: boolean;
+}
+
+/** `rows` wearing every pending flip. A read that began before a flip
+ *  carries the switch's old position; landing it raw would bounce the
+ *  switch back under the hand that moved it. */
+export const withPending = (
+  rows: UpdateRow[],
+  pending: PendingFollow[],
+): UpdateRow[] => {
+  if (pending.length === 0) return rows;
+  return rows.map((row) => {
+    const flip = pending.find(
+      (one) =>
+        one.kind === row.kind &&
+        one.name === row.name &&
+        sameScope(one.scope, row.scope),
+    );
+    if (!flip) return row;
+    // A hold the source or a parent owns is not this switch's to move —
+    // those rows never accept a flip, so a pending one is always this
+    // declaration's own.
+    return {
+      ...row,
+      pinned: flip.pinned,
+      holdOwner: flip.pinned ? { kind: "package" as const } : null,
+    };
+  });
+};
+
+interface FollowStore {
+  rows: UpdateRow[];
+  pendingFollows: PendingFollow[];
+  mutate: (
+    work: () => Promise<string | null>,
+    kind?: "mutation" | "settle",
+  ) => Promise<string | null>;
+}
+
+/** The store's `setAutoUpdate`: record the flip, then let the write and the
+ *  read that reconciles it settle. Nothing on the click path awaits them —
+ *  the rows carry the new position before the first command is sent. */
+export function followSwitch({
+  set,
+  get,
+  refuse,
+  report,
+}: {
+  set: (partial: Partial<Pick<FollowStore, "rows" | "pendingFollows">>) => void;
+  get: () => FollowStore;
+  /** Whether this row's facts are too unsettled to act on, said so. */
+  refuse: (row: UpdateRow) => boolean;
+  report: (error: string) => void;
+}) {
+  return async (row: UpdateRow, auto: boolean): Promise<void> => {
+    // Switching following OFF holds the package at what is installed now.
+    // With nothing installed to hold at, there is nothing to switch —
+    // never fall through to null, which means "follow" (the opposite).
+    const hold = row.current?.commit ?? null;
+    if (!auto && hold === null) return;
+    // Same refusal as updateOne: the hold would pin a commit captured from
+    // rows an in-flight read is about to replace.
+    if (refuse(row)) return;
+    const pending: PendingFollow = {
+      scope: row.scope,
+      kind: row.kind,
+      name: row.name,
+      pinned: !auto,
+    };
+    const retire = () =>
+      set({
+        pendingFollows: get().pendingFollows.filter((one) => one !== pending),
+      });
+    set({
+      rows: withPending(get().rows, [pending]),
+      pendingFollows: [...get().pendingFollows, pending],
+    });
+    try {
+      const error = await get().mutate(async () => {
+        const response = await settled(
+          commands.packageSetRev(
+            row.scope,
+            row.kind,
+            row.name,
+            auto ? null : hold,
+          ),
+        );
+        if (response.status === "ok") return null;
+        // Nothing committed, so the read that follows carries the switch's
+        // old position — a flip that never happened must not paint over it.
+        retire();
+        return response.error;
+      }, "settle");
+      if (error !== null) report(error);
+    } finally {
+      // The write landed; the read behind it is the truth from here.
+      retire();
+    }
+  };
+}

--- a/ui/src/stores/updates-overview.ts
+++ b/ui/src/stores/updates-overview.ts
@@ -49,10 +49,11 @@ export function overviewApplier(
 ) {
   const order = landings();
   let chain: Promise<unknown> = Promise.resolve();
-  // Every operation this applier runs — plain read, refresh, mutation —
-  // is about to replace the rows on screen: the store's overviewInFlight
-  // says so while any is outstanding, and the commit-applying actions
-  // refuse for as long as it is up.
+  // A plain read, a refresh, and a mutation are each about to replace
+  // every row on screen: the store's overviewInFlight says so while any is
+  // outstanding, and the commit-applying actions refuse for as long as it
+  // is up. A settle replaces them too but holds only its own scope, so it
+  // is counted here by the store's pending flips instead.
   let inFlight = 0;
 
   const landOk = (data: Overview) =>

--- a/ui/src/stores/updates-overview.ts
+++ b/ui/src/stores/updates-overview.ts
@@ -1,6 +1,7 @@
 import { commands, type ItemWarning, type UpdateRow } from "@/bindings";
 import { settled } from "@/lib/settled";
 import { landings } from "./landings";
+import { type PendingFollow, withPending } from "./updates-follow";
 
 type Overview = { rows: UpdateRow[]; warnings: ItemWarning[] };
 type OverviewResult =
@@ -30,6 +31,10 @@ type OverviewResult =
 //   re-read of old mirrors may bury. Only a failed mutation touches
 //   nothing: it re-read nothing, and the rows on screen are still the
 //   last good read's answer.
+//
+// A `settle` is a mutation that holds one scope instead of the page: the
+// Follow source switch has already moved, the store marks that scope as
+// settling, and every other row stays live for as long as the write runs.
 export function overviewApplier(
   set: (partial: {
     rows?: UpdateRow[];
@@ -38,6 +43,9 @@ export function overviewApplier(
     error?: string | null;
     overviewInFlight?: boolean;
   }) => void,
+  /** The follow flips whose writes have not answered — every landing wears
+   *  them, so a read that began before a flip cannot bounce the switch. */
+  pending: () => PendingFollow[],
 ) {
   const order = landings();
   let chain: Promise<unknown> = Promise.resolve();
@@ -49,7 +57,7 @@ export function overviewApplier(
 
   const landOk = (data: Overview) =>
     set({
-      rows: data.rows,
+      rows: withPending(data.rows, pending()),
       warnings: data.warnings,
       loaded: true,
       error: null,
@@ -57,10 +65,16 @@ export function overviewApplier(
 
   return async (
     read: () => Promise<OverviewResult>,
-    kind: "read" | "refresh" | "mutation" = "read",
+    kind: "read" | "refresh" | "mutation" | "settle" = "read",
   ): Promise<string | null> => {
-    inFlight += 1;
-    set({ overviewInFlight: true });
+    // A settle's own scope holds through the store's pending flips; raising
+    // the page-wide flag too would disable every unrelated row for the
+    // whole of the write it is running in the background.
+    const holdsPage = kind !== "settle";
+    if (holdsPage) {
+      inFlight += 1;
+      set({ overviewInFlight: true });
+    }
     try {
       if (kind === "read") {
         const ticket = order.begin();
@@ -101,8 +115,10 @@ export function overviewApplier(
       chain = turn.catch(() => {});
       return await turn;
     } finally {
-      inFlight -= 1;
-      if (inFlight === 0) set({ overviewInFlight: false });
+      if (holdsPage) {
+        inFlight -= 1;
+        if (inFlight === 0) set({ overviewInFlight: false });
+      }
     }
   };
 }

--- a/ui/src/stores/updates.ts
+++ b/ui/src/stores/updates.ts
@@ -32,9 +32,13 @@ interface UpdatesState {
   busy: boolean;
   /** True while a mirror fetch is running — the explicit "check". */
   checking: boolean;
-  /** True while ANY overview-producing operation — a plain load, a check,
-   *  a mutation — is in flight: the rows on screen are about to be
-   *  replaced, so no commit-applying action may trust them. */
+  /** True while a plain load, a check, or a mutation is in flight: those
+   *  replace every row on screen, so no commit-applying action anywhere
+   *  may trust them. A settling follow flip is overview-producing too and
+   *  deliberately leaves this down — the apply behind it reaches only its
+   *  own scope, so `pendingFollows` holds that scope's rows and the rest
+   *  of the page stays live. Read `rowUnsettled`, not this field, to ask
+   *  whether one row may be acted on. */
   overviewInFlight: boolean;
   /** Follow switches already moved on screen whose write has not answered.
    *  Their scopes hold; every other row stays live. */

--- a/ui/src/stores/updates.ts
+++ b/ui/src/stores/updates.ts
@@ -16,11 +16,12 @@ import {
   showUpdateOutcome,
   startBulk,
 } from "@/lib/update-outcome";
-import { unsettled } from "@/lib/updates-read-state";
+import { rowUnsettled, unsettled } from "@/lib/updates-read-state";
 import { useAuditStore } from "./audit";
 import { useProblemsStore } from "./problems";
 import { useScanStore } from "./scan";
 import { type ApplyOutcome, applyRow, applyRows } from "./updates-apply";
+import { followSwitch, type PendingFollow } from "./updates-follow";
 import { overviewApplier } from "./updates-overview";
 
 interface UpdatesState {
@@ -35,6 +36,9 @@ interface UpdatesState {
    *  a mutation — is in flight: the rows on screen are about to be
    *  replaced, so no commit-applying action may trust them. */
   overviewInFlight: boolean;
+  /** Follow switches already moved on screen whose write has not answered.
+   *  Their scopes hold; every other row stays live. */
+  pendingFollows: PendingFollow[];
   loaded: boolean;
   /** Why the last read of the standing failed, or null. A load runs on its
    *  own at startup, so a failure here is a state for Home and the badge to
@@ -47,7 +51,10 @@ interface UpdatesState {
    *  commit order and none of their answers can shadow a newer one.
    *  Returns the work's own error, or null; the overview that follows
    *  reflects whatever actually committed either way. */
-  mutate: (work: () => Promise<string | null>) => Promise<string | null>;
+  mutate: (
+    work: () => Promise<string | null>,
+    kind?: "mutation" | "settle",
+  ) => Promise<string | null>;
   updateOne: (row: UpdateRow) => Promise<void>;
   /** Bring every updatable place among `rows` current — the page-level
    *  button passes every visible row, a package's button its own places. */
@@ -62,15 +69,18 @@ export const useUpdatesStore = create<UpdatesState>((set, get) => {
 
   const reportUpdate = (error: string) => showError(UPDATE_ERROR_TITLE, error);
 
-  const applyOverview = overviewApplier(set);
+  const applyOverview = overviewApplier(set, () => get().pendingFollows);
 
   // One predicate for every commit-applying action: the captured row
   // arguments are trustworthy only when the rows are a confirmed current
   // answer and nothing that could replace them is in flight — a failed
   // read, a running check, and a focus-triggered load are all the same
-  // reason to wait. Returns whether the action was refused, reporting it.
-  const refuseUnsettled = (): boolean => {
-    if (!unsettled(get())) return false;
+  // reason to wait, and so is a follow switch still settling in the scope
+  // the action would apply. Returns whether it was refused, reporting it.
+  const refuseUnsettled = (rows: UpdateRow[]): boolean => {
+    const state = get();
+    if (!unsettled(state) && !rows.some((row) => rowUnsettled(state, row)))
+      return false;
     showError(UPDATE_ERROR_TITLE, UPDATE_NEEDS_CHECK_NOTE);
     return true;
   };
@@ -85,6 +95,7 @@ export const useUpdatesStore = create<UpdatesState>((set, get) => {
     busy: false,
     checking: false,
     overviewInFlight: false,
+    pendingFollows: [],
     loaded: false,
     error: null,
 
@@ -92,7 +103,7 @@ export const useUpdatesStore = create<UpdatesState>((set, get) => {
       await reload();
     },
 
-    mutate: async (work) => {
+    mutate: async (work, kind = "mutation") => {
       // The work's failure and the applier's are different news. work()
       // rejecting in transport never assigns failure and only the applier
       // saw it — but once work has answered, the applier's error is the
@@ -106,7 +117,7 @@ export const useUpdatesStore = create<UpdatesState>((set, get) => {
         failure = await work();
         answered = true;
         return commands.updatesOverview();
-      }, "mutation");
+      }, kind);
       if (failure !== null) return failure;
       return answered ? null : applierError;
     },
@@ -133,7 +144,7 @@ export const useUpdatesStore = create<UpdatesState>((set, get) => {
       // rows: an update accepted now would apply the latest captured
       // before it — refuse rather than commit stale arguments after
       // fresher rows land.
-      if (refuseUnsettled()) return;
+      if (refuseUnsettled([row])) return;
       set({ busy: true });
       try {
         // The commit and its follow-up overview ride the side-effect
@@ -162,7 +173,7 @@ export const useUpdatesStore = create<UpdatesState>((set, get) => {
     updateRows: async (wanted) => {
       // Same refusal as updateOne: the holds among these rows would move
       // to captured commits.
-      if (refuseUnsettled()) return;
+      if (refuseUnsettled(wanted)) return;
       set({ busy: true });
       try {
         // Edited packages are held by the engine and cannot be updated
@@ -203,31 +214,12 @@ export const useUpdatesStore = create<UpdatesState>((set, get) => {
       }
     },
 
-    setAutoUpdate: async (row, auto) => {
-      // Switching following OFF holds the package at what is installed now.
-      // With nothing installed to hold at, there is nothing to switch —
-      // never fall through to null, which means "follow" (the opposite).
-      const hold = row.current?.commit ?? null;
-      if (!auto && hold === null) return;
-      // Same refusal as updateOne: the hold would pin a commit captured
-      // from rows an in-flight read is about to replace.
-      if (refuseUnsettled()) return;
-      set({ busy: true });
-      try {
-        const error = await get().mutate(async () => {
-          const response = await commands.packageSetRev(
-            row.scope,
-            row.kind,
-            row.name,
-            auto ? null : hold,
-          );
-          return response.status === "error" ? response.error : null;
-        });
-        if (error !== null) showError(UPDATE_ERROR_TITLE, error);
-      } finally {
-        set({ busy: false });
-      }
-    },
+    setAutoUpdate: followSwitch({
+      set,
+      get,
+      refuse: (row) => refuseUnsettled([row]),
+      report: (error) => showError(UPDATE_ERROR_TITLE, error),
+    }),
 
     setIgnored: async (row, ignored) => {
       const error = await applyOverview(


### PR DESCRIPTION
## Summary
- Flipping a package's **Follow source** switch used to hang the whole Updates table. The switch now moves at once and the write settles behind it: rows carry the new position before the first command is sent, and every landing wears the pending flip so a read that began earlier cannot bounce the switch back under the hand that moved it.
- A settle holds only its own scope's rows, not the page — a scope apply reaches only what is installed there — so a flip in one place leaves every other place live.
- A refused write stops painting and says so at once, while its scope goes on holding until the reconciling read puts the rows back. If that read and its retry both fail, the flip restores the position it moved from rather than leaving a switch the engine never moved.

## Why it was slow
`updates_overview` alone, timed through the release CLI on four configured scopes: global 1.62s, hyprtrade 8.19s, kendex 2.08s, vg 6.73s — about **18.6s**, before `package_set_rev`'s own apply and `view()`. The interaction awaited all of it with the page-wide busy and overview-in-flight flags up. Making that chain fast is a separate job (KEN-614, KEN-615); this change takes it off the interaction path.

Measured, jsdom harness with each backend leg mocked at 500ms (1/20 of the real chain): the switch shows its new position in **14ms, from 1024ms**, and rows in other scopes stay interactive instead of being disabled for the whole chain.

## Completed Issues
- Closes KEN-574 - Toggling Follow source off freezes the Updates table for ~10 seconds

## Created Issues
- KEN-613 - A command that never answers wedges the Updates applier for every later mutation — Project: Tech Debt & Bugs
- KEN-614 - package_set_rev computes an AuditView the Updates page discards — Project: Tech Debt & Bugs
- KEN-615 - updates_overview recomputes every scope after a change to one — Project: Tech Debt & Bugs
- KEN-617 - Marketplaces store tests carry state between cases and fail under shuffle — Project: Tech Debt & Bugs
- KEN-620 - fork-notice tests leave five terms unpinned, including both busy gates — Project: Tech Debt & Bugs

## Test Plan
- `ui/src/components/update-follow.dom.test.tsx` drives the real component tree off the store: the switch moves before the write answers holding only its scope; it keeps its position under a read that lands mid-write; a refused write puts it back and is announced exactly once; a second place in the settling scope is refused while another scope's is taken; a flip on a package installed in two scopes lands on one row alone; both reads failing restores the pre-flip position.
- `ui/src/stores/updates-edits.test.ts`: `takeNewVersion` and `installAsNew` refuse with the needs-check note and call nothing while a flip settles in the row's scope, and still go through when the flip is in another scope.
- `ui/src/components/package/use-manifest-busy.test.tsx`: the page's gate holds for a flip in any scope its controls write, not just the one it was opened at.
- Every guard in the change carries a must-fail control that was run red: the optimistic flip, the landing overlay, the per-scope narrowing, `withPending`'s scope match, the revert-on-refusal, the double-report suppression, and each widened call site.
