### PR TITLE
refactor(KEN-416): Extract rotation-safe registry client

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ an outside contributor.
 
 - Simultaneous app and CLI account calls share one token refresh, so they no
   longer invalidate the sign-in by rotating the same refresh token twice.
+- Registry refresh timeouts and rate limits no longer sign the machine out;
+  the app or CLI keeps the credential and can retry.
 - `kendex check` exits 1, not 2, when packages await re-evaluation, so the
   session-start report no longer opens with "kendex check could not run" after
   a completed run. The drift hook script changed; `kendex drift-hook` reinstalls it.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ an outside contributor.
 
 ### Fixed
 
+- Simultaneous app and CLI account calls share one token refresh, so they no
+  longer invalidate the sign-in by rotating the same refresh token twice.
 - `kendex check` exits 1, not 2, when packages await re-evaluation, so the
   session-start report no longer opens with "kendex check could not run" after
   a completed run. The drift hook script changed; `kendex drift-hook` reinstalls it.

--- a/crates/app/src/account.rs
+++ b/crates/app/src/account.rs
@@ -6,7 +6,8 @@
 use std::path::PathBuf;
 
 use kendex_core::author::{self, SubmitPreflight};
-use kendex_core::registry::credentials::{Credential, CredentialStore, KeyringStore};
+use kendex_core::registry::client;
+use kendex_core::registry::credentials::{Credential, KeyringStore};
 use kendex_core::registry::login::{self, Poll};
 use kendex_core::registry::submit::{self, SubmissionRow};
 use kendex_core::registry::{CurlFetch, base_url};
@@ -60,14 +61,16 @@ pub fn account_login_poll(device_code: String) -> Result<String, String> {
         Poll::Pending => Ok("pending".to_owned()),
         Poll::SlowDown => Ok("slow-down".to_owned()),
         Poll::Signed(pair) => {
-            KeyringStore
-                .save(&Credential {
+            client::commit_login(
+                &KeyringStore,
+                &Credential {
                     endpoint: base_url(),
                     access_token: pair.access_token,
                     refresh_token: pair.refresh_token,
                     capabilities: pair.capabilities,
-                })
-                .map_err(|e| e.to_string())?;
+                },
+            )
+            .map_err(|e| e.to_string())?;
             Ok("signed".to_owned())
         }
     }
@@ -76,14 +79,9 @@ pub fn account_login_poll(device_code: String) -> Result<String, String> {
 #[tauri::command(async)]
 #[specta::specta]
 pub fn account_logout() -> Result<(), String> {
-    let store = KeyringStore;
-    let Some(credential) = store.load().map_err(|e| e.to_string())? else {
-        return Ok(());
-    };
-    // Server first: if revocation cannot be recorded, the local copy stays
-    // so a retry still has something to revoke.
-    login::revoke(&CurlFetch, &credential.refresh_token).map_err(|e| e.to_string())?;
-    store.clear().map_err(|e| e.to_string())
+    client::logout(&CurlFetch, &KeyringStore)
+        .map(|_| ())
+        .map_err(|e| e.to_string())
 }
 
 #[tauri::command(async)]

--- a/crates/cli/src/commands/login.rs
+++ b/crates/cli/src/commands/login.rs
@@ -3,7 +3,8 @@
 //! and the credential lives in the OS keychain or nowhere.
 
 use super::say;
-use kendex_core::error::{CoreError, Result};
+use kendex_core::error::Result;
+use kendex_core::registry::client;
 use kendex_core::registry::credentials::{Credential, CredentialStore, KeyringStore};
 use kendex_core::registry::login::{self, Poll};
 use kendex_core::registry::{CurlFetch, base_url};
@@ -37,12 +38,15 @@ pub fn login() -> Result<()> {
             Poll::Pending => {}
             Poll::SlowDown => interval += 5,
             Poll::Signed(pair) => {
-                store.save(&Credential {
-                    endpoint: base_url(),
-                    access_token: pair.access_token,
-                    refresh_token: pair.refresh_token,
-                    capabilities: pair.capabilities,
-                })?;
+                client::commit_login(
+                    &store,
+                    &Credential {
+                        endpoint: base_url(),
+                        access_token: pair.access_token,
+                        refresh_token: pair.refresh_token,
+                        capabilities: pair.capabilities,
+                    },
+                )?;
                 say("Signed in. The credential is in your system keychain.");
                 return Ok(());
             }
@@ -51,19 +55,10 @@ pub fn login() -> Result<()> {
 }
 
 pub fn logout() -> Result<()> {
-    let store = KeyringStore;
-    let Some(credential) = store.load()? else {
+    if !client::logout(&CurlFetch, &KeyringStore)? {
         say("Not signed in.");
         return Ok(());
-    };
-    // Server first: if revocation cannot be recorded, the local copy
-    // stays so a retry still has something to revoke.
-    login::revoke(&CurlFetch, &credential.refresh_token).map_err(|error| {
-        CoreError::RegistryUnavailable {
-            why: format!("{error} — the local credential was kept so you can retry"),
-        }
-    })?;
-    store.clear()?;
+    }
     say("Signed out — every device credential in that sign-in is now dead.");
     Ok(())
 }

--- a/crates/core/src/env.rs
+++ b/crates/core/src/env.rs
@@ -240,6 +240,11 @@ impl Env {
         self.data_dir.join(APP_DIR).join("locks")
     }
 
+    /// Cross-process lock for one credential refresh and token rotation.
+    pub fn credential_refresh_lock_file(&self) -> PathBuf {
+        self.scope_locks_dir().join("credential-refresh.lock")
+    }
+
     /// Per-scope drift snapshots — derived, machine-local, rebuildable. The
     /// session-start check reads these instead of doing the deep work.
     pub fn drift_dir(&self) -> PathBuf {

--- a/crates/core/src/env.rs
+++ b/crates/core/src/env.rs
@@ -240,11 +240,6 @@ impl Env {
         self.data_dir.join(APP_DIR).join("locks")
     }
 
-    /// Cross-process lock for one credential refresh and token rotation.
-    pub fn credential_refresh_lock_file(&self) -> PathBuf {
-        self.scope_locks_dir().join("credential-refresh.lock")
-    }
-
     /// Per-scope drift snapshots — derived, machine-local, rebuildable. The
     /// session-start check reads these instead of doing the deep work.
     pub fn drift_dir(&self) -> PathBuf {

--- a/crates/core/src/error.rs
+++ b/crates/core/src/error.rs
@@ -129,6 +129,9 @@ pub enum CoreError {
     #[error("settings are busy: another kendex process holds {lock}")]
     SettingsBusy { lock: PathBuf },
 
+    #[error("credential refresh is busy: another kendex process holds {lock}")]
+    CredentialRefreshBusy { lock: PathBuf },
+
     #[error("app update check is busy: another kendex process holds {lock}")]
     AppUpdateBusy { lock: PathBuf },
 

--- a/crates/core/src/registry.rs
+++ b/crates/core/src/registry.rs
@@ -3,6 +3,7 @@
 //! with an ETag, and honest about staleness when the network is away.
 
 pub mod cache;
+pub mod client;
 pub mod collections;
 pub mod credentials;
 pub mod index;

--- a/crates/core/src/registry/client.rs
+++ b/crates/core/src/registry/client.rs
@@ -1,0 +1,111 @@
+//! Rotation-safe bearer calls shared by every authenticated registry API.
+
+use serde::Deserialize;
+
+use crate::error::{CoreError, Result};
+use crate::registry::credentials::{Credential, CredentialStore};
+use crate::registry::login::TokenPair;
+use crate::registry::{Fetch, FetchResponse, base_url};
+
+/// Run one authenticated call, refreshing a rejected access token once.
+/// Refresh rotation is locked across processes and saved before retry.
+pub fn with_access(
+    fetch: &dyn Fetch,
+    store: &dyn CredentialStore,
+    call: impl Fn(&str) -> Result<FetchResponse>,
+) -> Result<FetchResponse> {
+    let mut credential = store.load()?.ok_or_else(|| CoreError::Authoring {
+        message: "not signed in — run `kendex login` first".to_owned(),
+    })?;
+    let first = call(&credential.access_token)?;
+    if first.status != 401 {
+        return Ok(first);
+    }
+
+    let refresh_guard = store.refresh_guard()?;
+    let locked = store.load()?.ok_or_else(|| CoreError::Authoring {
+        message: "not signed in — run `kendex login` first".to_owned(),
+    })?;
+    if locked.access_token != credential.access_token {
+        credential = locked;
+        let retried = call(&credential.access_token)?;
+        if retried.status != 401 {
+            return Ok(retried);
+        }
+    } else {
+        credential = locked;
+    }
+
+    let pair = match refresh(fetch, &credential.refresh_token) {
+        Ok(pair) => pair,
+        Err(Refused::Definitive(why)) => {
+            let ours = store
+                .load()?
+                .is_none_or(|kept| kept.refresh_token == credential.refresh_token);
+            if ours {
+                store.clear()?;
+            }
+            return Err(CoreError::Authoring {
+                message: format!("your sign-in has expired ({why}) — run `kendex login` again"),
+            });
+        }
+        Err(Refused::Transient(error)) => return Err(error),
+    };
+    let rotated = Credential {
+        endpoint: base_url(),
+        access_token: pair.access_token,
+        refresh_token: pair.refresh_token,
+        capabilities: pair.capabilities,
+    };
+    store.save(&rotated)?;
+    drop(refresh_guard);
+
+    let second = call(&rotated.access_token)?;
+    if second.status == 401 {
+        return Err(CoreError::Authoring {
+            message: "the server does not accept this sign-in — run `kendex login` again"
+                .to_owned(),
+        });
+    }
+    Ok(second)
+}
+
+enum Refused {
+    Definitive(String),
+    Transient(CoreError),
+}
+
+fn refresh(fetch: &dyn Fetch, refresh_token: &str) -> std::result::Result<TokenPair, Refused> {
+    let body = serde_json::json!({
+        "grant_type": "refresh_token",
+        "refresh_token": refresh_token,
+    })
+    .to_string();
+    let response = fetch
+        .post_json(&format!("{}/api/v1/device/token", base_url()), &body)
+        .map_err(Refused::Transient)?;
+    if (400..500).contains(&response.status) {
+        return Err(Refused::Definitive(server_message(&response)));
+    }
+    if response.status != 200 {
+        return Err(Refused::Transient(CoreError::RegistryUnavailable {
+            why: server_message(&response),
+        }));
+    }
+    serde_json::from_slice(&response.body).map_err(|error| {
+        Refused::Transient(CoreError::RegistryMalformed {
+            why: error.to_string(),
+        })
+    })
+}
+
+#[derive(Deserialize)]
+struct WireError {
+    error: String,
+}
+
+pub(super) fn server_message(response: &FetchResponse) -> String {
+    serde_json::from_slice::<WireError>(&response.body)
+        .map(|wire| wire.error)
+        .unwrap_or_else(|_| format!("status {}", response.status))
+}

--- a/crates/core/src/registry/client.rs
+++ b/crates/core/src/registry/client.rs
@@ -14,28 +14,48 @@ pub fn with_access(
     store: &dyn CredentialStore,
     call: impl Fn(&str) -> Result<FetchResponse>,
 ) -> Result<FetchResponse> {
-    let mut credential = store.load()?.ok_or_else(|| CoreError::Authoring {
-        message: "not signed in — run `kendex login` first".to_owned(),
-    })?;
+    let credential = required(store.load()?)?;
     let first = call(&credential.access_token)?;
     if first.status != 401 {
         return Ok(first);
     }
+    rotate_after_rejection(fetch, store, &call, credential)
+}
 
-    let refresh_guard = store.refresh_guard()?;
-    let locked = store.load()?.ok_or_else(|| CoreError::Authoring {
-        message: "not signed in — run `kendex login` first".to_owned(),
-    })?;
-    if locked.access_token != credential.access_token {
-        credential = locked;
-        let retried = call(&credential.access_token)?;
-        if retried.status != 401 {
-            return Ok(retried);
+fn rotate_after_rejection(
+    fetch: &dyn Fetch,
+    store: &dyn CredentialStore,
+    call: &impl Fn(&str) -> Result<FetchResponse>,
+    mut rejected: Credential,
+) -> Result<FetchResponse> {
+    let mut newer_retries = 0;
+    loop {
+        let refresh_guard = store.refresh_guard()?;
+        let locked = required(store.load()?)?;
+        if locked.access_token != rejected.access_token {
+            drop(refresh_guard);
+            let retried = call(&locked.access_token)?;
+            if retried.status != 401 {
+                return Ok(retried);
+            }
+            if newer_retries == 1 {
+                return Err(rejected_access());
+            }
+            newer_retries += 1;
+            rejected = locked;
+            continue;
         }
-    } else {
-        credential = locked;
+        return rotate_locked(fetch, store, call, locked, refresh_guard);
     }
+}
 
+fn rotate_locked(
+    fetch: &dyn Fetch,
+    store: &dyn CredentialStore,
+    call: &impl Fn(&str) -> Result<FetchResponse>,
+    credential: Credential,
+    refresh_guard: Box<dyn crate::registry::credentials::CredentialRefreshGuard + '_>,
+) -> Result<FetchResponse> {
     let pair = match refresh(fetch, &credential.refresh_token) {
         Ok(pair) => pair,
         Err(Refused::Definitive(why)) => {
@@ -57,17 +77,63 @@ pub fn with_access(
         refresh_token: pair.refresh_token,
         capabilities: pair.capabilities,
     };
+    let current = required(store.load()?)?;
+    if current.refresh_token != credential.refresh_token {
+        drop(refresh_guard);
+        let retried = call(&current.access_token)?;
+        return match retried.status {
+            401 => Err(rejected_access()),
+            _ => Ok(retried),
+        };
+    }
     store.save(&rotated)?;
     drop(refresh_guard);
 
     let second = call(&rotated.access_token)?;
     if second.status == 401 {
-        return Err(CoreError::Authoring {
-            message: "the server does not accept this sign-in — run `kendex login` again"
-                .to_owned(),
-        });
+        return Err(rejected_access());
     }
     Ok(second)
+}
+
+/// Commit a completed device login without racing refresh or logout.
+pub fn commit_login(store: &dyn CredentialStore, credential: &Credential) -> Result<()> {
+    let _guard = store.refresh_guard()?;
+    store.save(credential)
+}
+
+/// Revoke and clear the current sign-in under the credential transaction lock.
+/// Returns false when the machine was already signed out.
+pub fn logout(fetch: &dyn Fetch, store: &dyn CredentialStore) -> Result<bool> {
+    let _guard = store.refresh_guard()?;
+    let Some(credential) = store.load()? else {
+        return Ok(false);
+    };
+    crate::registry::login::revoke(fetch, &credential.refresh_token).map_err(|error| {
+        CoreError::RegistryUnavailable {
+            why: format!("{error} — the local credential was kept so you can retry"),
+        }
+    })?;
+    let current = required(store.load()?)?;
+    if current.refresh_token != credential.refresh_token {
+        return Err(CoreError::RegistryUnavailable {
+            why: "the sign-in changed during logout; retry against the current sign-in".to_owned(),
+        });
+    }
+    store.clear()?;
+    Ok(true)
+}
+
+fn required(credential: Option<Credential>) -> Result<Credential> {
+    credential.ok_or_else(|| CoreError::Authoring {
+        message: "not signed in — run `kendex login` first".to_owned(),
+    })
+}
+
+fn rejected_access() -> CoreError {
+    CoreError::Authoring {
+        message: "the server does not accept this sign-in — run `kendex login` again".to_owned(),
+    }
 }
 
 enum Refused {
@@ -84,7 +150,7 @@ fn refresh(fetch: &dyn Fetch, refresh_token: &str) -> std::result::Result<TokenP
     let response = fetch
         .post_json(&format!("{}/api/v1/device/token", base_url()), &body)
         .map_err(Refused::Transient)?;
-    if (400..500).contains(&response.status) {
+    if matches!(response.status, 400 | 401 | 403) {
         return Err(Refused::Definitive(server_message(&response)));
     }
     if response.status != 200 {

--- a/crates/core/src/registry/client.rs
+++ b/crates/core/src/registry/client.rs
@@ -158,6 +158,8 @@ fn refresh(fetch: &dyn Fetch, refresh_token: &str) -> std::result::Result<TokenP
     let response = fetch
         .post_json(&format!("{}/api/v1/device/token", base_url()), &body)
         .map_err(Refused::Transient)?;
+    // Only these statuses prove the refresh grant is dead. Timeouts, rate
+    // limits, and server failures keep the credential available for retry.
     if matches!(response.status, 400 | 401 | 403) {
         return Err(Refused::Definitive(server_message(&response)));
     }

--- a/crates/core/src/registry/client.rs
+++ b/crates/core/src/registry/client.rs
@@ -59,11 +59,14 @@ fn rotate_locked(
     let pair = match refresh(fetch, &credential.refresh_token) {
         Ok(pair) => pair,
         Err(Refused::Definitive(why)) => {
-            let ours = store
-                .load()?
-                .is_none_or(|kept| kept.refresh_token == credential.refresh_token);
-            if ours {
-                store.clear()?;
+            // Older installed clients do not take this guard. A network call
+            // gives one time to replace the family, so re-read before clearing.
+            match store.load()? {
+                Some(kept) if kept.refresh_token != credential.refresh_token => {
+                    return Err(sign_in_changed("refreshing"));
+                }
+                Some(_) => store.clear()?,
+                None => {}
             }
             return Err(CoreError::Authoring {
                 message: format!("your sign-in has expired ({why}) — run `kendex login` again"),
@@ -77,14 +80,11 @@ fn rotate_locked(
         refresh_token: pair.refresh_token,
         capabilities: pair.capabilities,
     };
+    // Mixed-version writers do not know this guard. Never replace a family
+    // an older client committed during the refresh request.
     let current = required(store.load()?)?;
     if current.refresh_token != credential.refresh_token {
-        drop(refresh_guard);
-        let retried = call(&current.access_token)?;
-        return match retried.status {
-            401 => Err(rejected_access()),
-            _ => Ok(retried),
-        };
+        return Err(sign_in_changed("refreshing"));
     }
     store.save(&rotated)?;
     drop(refresh_guard);
@@ -114,11 +114,13 @@ pub fn logout(fetch: &dyn Fetch, store: &dyn CredentialStore) -> Result<bool> {
             why: format!("{error} — the local credential was kept so you can retry"),
         }
     })?;
-    let current = required(store.load()?)?;
+    // An older client can commit another family without taking this guard.
+    // Re-read after revocation so logout cannot clear that newer sign-in.
+    let Some(current) = store.load()? else {
+        return Ok(true);
+    };
     if current.refresh_token != credential.refresh_token {
-        return Err(CoreError::RegistryUnavailable {
-            why: "the sign-in changed during logout; retry against the current sign-in".to_owned(),
-        });
+        return Err(sign_in_changed("logging out"));
     }
     store.clear()?;
     Ok(true)
@@ -133,6 +135,12 @@ fn required(credential: Option<Credential>) -> Result<Credential> {
 fn rejected_access() -> CoreError {
     CoreError::Authoring {
         message: "the server does not accept this sign-in — run `kendex login` again".to_owned(),
+    }
+}
+
+fn sign_in_changed(action: &str) -> CoreError {
+    CoreError::RegistryUnavailable {
+        why: format!("the sign-in changed while {action}; retry the request"),
     }
 }
 

--- a/crates/core/src/registry/credentials.rs
+++ b/crates/core/src/registry/credentials.rs
@@ -7,6 +7,7 @@
 //! says so and offers session-only auth.
 
 use crate::error::{CoreError, Result};
+use crate::fs::LockedFile;
 use crate::registry::base_url;
 use serde::{Deserialize, Serialize};
 
@@ -38,7 +39,13 @@ pub trait CredentialStore {
     fn save(&self, credential: &Credential) -> Result<()>;
     fn load(&self) -> Result<Option<Credential>>;
     fn clear(&self) -> Result<()>;
+    fn refresh_guard(&self) -> Result<Box<dyn CredentialRefreshGuard + '_>>;
 }
+
+/// Held for the load-refresh-save credential transaction; dropping releases it.
+pub trait CredentialRefreshGuard {}
+
+impl CredentialRefreshGuard for LockedFile {}
 
 pub struct KeyringStore;
 
@@ -99,6 +106,26 @@ impl CredentialStore for KeyringStore {
             Err(error) => Err(CoreError::RegistryUnavailable {
                 why: format!("the credential store refused the removal: {error}"),
             }),
+        }
+    }
+
+    fn refresh_guard(&self) -> Result<Box<dyn CredentialRefreshGuard + '_>> {
+        let env = crate::env::Env::detect()?;
+        let path = env.credential_refresh_lock_file();
+        let parent = path
+            .parent()
+            .ok_or_else(|| CoreError::io(&path, std::io::Error::other("path has no parent")))?;
+        std::fs::create_dir_all(parent).map_err(|error| CoreError::io(parent, error))?;
+        let deadline = std::time::Instant::now() + std::time::Duration::from_secs(30);
+        loop {
+            match LockedFile::try_exclusive_no_follow(&path) {
+                Ok(Some(lock)) => return Ok(Box::new(lock)),
+                Ok(None) if std::time::Instant::now() < deadline => {
+                    std::thread::sleep(std::time::Duration::from_millis(10));
+                }
+                Ok(None) => return Err(CoreError::CredentialRefreshBusy { lock: path }),
+                Err(error) => return Err(CoreError::io(&path, error)),
+            }
         }
     }
 }

--- a/crates/core/src/registry/credentials.rs
+++ b/crates/core/src/registry/credentials.rs
@@ -49,15 +49,32 @@ impl CredentialRefreshGuard for LockedFile {}
 
 pub struct KeyringStore;
 
-/// The service this build reaches. `entry` holds no decision of its own, so
-/// what a build signs in as is settled here and nowhere else.
-fn active_service() -> &'static str {
-    service(crate::env::sandboxed())
+struct CredentialIdentity {
+    service: &'static str,
+    endpoint: String,
+}
+
+/// The named keychain entry and its transaction lock share this identity.
+fn active_identity() -> CredentialIdentity {
+    CredentialIdentity {
+        service: service(crate::env::sandboxed()),
+        endpoint: base_url(),
+    }
+}
+
+fn transaction_lock_file(
+    env: &crate::env::Env,
+    identity: &CredentialIdentity,
+) -> std::path::PathBuf {
+    let material = format!("{}\0{}", identity.service, identity.endpoint);
+    let digest = crate::hash::hash_bytes(material.as_bytes());
+    env.real_home()
+        .join(format!(".kendex-credential-{digest}.lock"))
 }
 
 fn entry() -> Result<keyring::Entry> {
-    let endpoint = base_url();
-    keyring::Entry::new(active_service(), &endpoint).map_err(|error| {
+    let identity = active_identity();
+    keyring::Entry::new(identity.service, &identity.endpoint).map_err(|error| {
         CoreError::RegistryUnavailable {
             why: format!("no usable credential store: {error}"),
         }
@@ -111,7 +128,7 @@ impl CredentialStore for KeyringStore {
 
     fn refresh_guard(&self) -> Result<Box<dyn CredentialRefreshGuard + '_>> {
         let env = crate::env::Env::detect()?;
-        let path = env.credential_refresh_lock_file();
+        let path = transaction_lock_file(&env, &active_identity());
         let parent = path
             .parent()
             .ok_or_else(|| CoreError::io(&path, std::io::Error::other("path has no parent")))?;
@@ -147,12 +164,39 @@ mod tests {
     /// naming one itself; which service that yields is the case above.
     #[test]
     fn the_entry_takes_its_service_from_the_sandbox() {
-        assert_eq!(active_service(), service(crate::env::sandboxed()));
+        assert_eq!(active_identity().service, service(crate::env::sandboxed()));
     }
 
     #[test]
     fn only_a_sandboxed_build_gets_the_sandbox_entry() {
         assert_eq!(service(false), SERVICE);
         assert_eq!(service(true), DEV_SERVICE);
+    }
+
+    #[test]
+    fn transaction_lock_uses_named_identity_not_data_root() {
+        let first = crate::env::Env::fake("/data/one", crate::env::FakeOs::Linux)
+            .with_real_home("/home/pat");
+        let second = crate::env::Env::fake("/data/two", crate::env::FakeOs::Linux)
+            .with_real_home("/home/pat");
+        let identity = CredentialIdentity {
+            service: SERVICE,
+            endpoint: "https://kendex.ai".to_owned(),
+        };
+
+        assert_eq!(
+            transaction_lock_file(&first, &identity),
+            transaction_lock_file(&second, &identity)
+        );
+        assert_ne!(
+            transaction_lock_file(
+                &first,
+                &CredentialIdentity {
+                    service: DEV_SERVICE,
+                    endpoint: identity.endpoint.clone(),
+                }
+            ),
+            transaction_lock_file(&first, &identity)
+        );
     }
 }

--- a/crates/core/src/registry/submit.rs
+++ b/crates/core/src/registry/submit.rs
@@ -7,8 +7,8 @@
 use serde::Deserialize;
 
 use crate::error::{CoreError, Result};
-use crate::registry::credentials::{Credential, CredentialStore};
-use crate::registry::login::TokenPair;
+use crate::registry::client::{server_message, with_access};
+use crate::registry::credentials::CredentialStore;
 use crate::registry::{Fetch, FetchResponse, base_url};
 
 /// What POST /api/v1/submissions answered.
@@ -27,11 +27,6 @@ pub struct SubmissionRow {
     pub status_reason: Option<String>,
     pub head_commit: Option<String>,
     pub indexed_at: Option<String>,
-}
-
-#[derive(Deserialize)]
-struct WireError {
-    error: String,
 }
 
 #[derive(Deserialize)]
@@ -75,112 +70,6 @@ pub fn submissions(fetch: &dyn Fetch, store: &dyn CredentialStore) -> Result<Vec
 /// surfaces ask before offering submit.
 pub fn signed_in(store: &dyn CredentialStore) -> Result<bool> {
     Ok(store.load()?.is_some())
-}
-
-/// Run one authenticated call, refreshing a rejected access token once.
-/// The rotated pair is saved before the retry, so a crash between the two
-/// still leaves the newest credential in the keychain.
-fn with_access(
-    fetch: &dyn Fetch,
-    store: &dyn CredentialStore,
-    call: impl Fn(&str) -> Result<FetchResponse>,
-) -> Result<FetchResponse> {
-    let credential = store.load()?.ok_or_else(|| CoreError::Authoring {
-        message: "not signed in — run `kendex login` first".to_owned(),
-    })?;
-    let first = call(&credential.access_token)?;
-    if first.status != 401 {
-        return Ok(first);
-    }
-    // Another kendex process may have refreshed meanwhile — a rotation is
-    // one-use, so presenting the old refresh token would burn the family.
-    // Reload and prefer any newer credential before refreshing ourselves.
-    if let Some(newer) = store.load()?
-        && newer.access_token != credential.access_token
-    {
-        let retried = call(&newer.access_token)?;
-        if retried.status != 401 {
-            return Ok(retried);
-        }
-    }
-    let pair = match refresh(fetch, &credential.refresh_token) {
-        Ok(pair) => pair,
-        // Only the server definitively refusing (a 4xx) means the sign-in
-        // is over — a network failure or a 5xx is transient and must not
-        // sign the machine out. The definitive case clears the stale
-        // credential so the next attempt asks for a fresh login instead of
-        // retrying a dead one forever, and only while it is still the token
-        // we presented — a concurrent process's fresh rotation must survive.
-        Err(Refused::Definitive(why)) => {
-            let ours = store
-                .load()
-                .ok()
-                .flatten()
-                .is_none_or(|kept| kept.refresh_token == credential.refresh_token);
-            if ours {
-                let _ = store.clear();
-            }
-            return Err(CoreError::Authoring {
-                message: format!("your sign-in has expired ({why}) — run `kendex login` again"),
-            });
-        }
-        Err(Refused::Transient(error)) => return Err(error),
-    };
-    let rotated = Credential {
-        endpoint: base_url(),
-        access_token: pair.access_token,
-        refresh_token: pair.refresh_token,
-        capabilities: pair.capabilities,
-    };
-    store.save(&rotated)?;
-    let second = call(&rotated.access_token)?;
-    if second.status == 401 {
-        return Err(CoreError::Authoring {
-            message: "the server does not accept this sign-in — run `kendex login` again"
-                .to_owned(),
-        });
-    }
-    Ok(second)
-}
-
-/// Why a refresh did not yield a token — the two cases the caller must
-/// treat differently.
-enum Refused {
-    /// The server refused this token (4xx): the sign-in is over.
-    Definitive(String),
-    /// Network away, or a 5xx: retry later, keep the credential.
-    Transient(CoreError),
-}
-
-fn refresh(fetch: &dyn Fetch, refresh_token: &str) -> std::result::Result<TokenPair, Refused> {
-    let body = serde_json::json!({
-        "grant_type": "refresh_token",
-        "refresh_token": refresh_token,
-    })
-    .to_string();
-    let response = fetch
-        .post_json(&format!("{}/api/v1/device/token", base_url()), &body)
-        .map_err(Refused::Transient)?;
-    if (400..500).contains(&response.status) {
-        return Err(Refused::Definitive(server_message(&response)));
-    }
-    if response.status != 200 {
-        return Err(Refused::Transient(CoreError::RegistryUnavailable {
-            why: server_message(&response),
-        }));
-    }
-    serde_json::from_slice(&response.body).map_err(|error| {
-        Refused::Transient(CoreError::RegistryMalformed {
-            why: error.to_string(),
-        })
-    })
-}
-
-/// The server's own `error` sentence when it wrote one, else the status.
-fn server_message(response: &FetchResponse) -> String {
-    serde_json::from_slice::<WireError>(&response.body)
-        .map(|wire| wire.error)
-        .unwrap_or_else(|_| format!("status {}", response.status))
 }
 
 fn server_said(response: &FetchResponse) -> CoreError {

--- a/crates/core/src/registry/submit.rs
+++ b/crates/core/src/registry/submit.rs
@@ -1,8 +1,6 @@
 //! The submissions client: submit a repository to the community directory
-//! and read back the caller's rows. Every call is bearer-authenticated
-//! from the keychain credential; a rejected access token is refreshed
-//! once (rotation saved before the retry), and a refresh the server
-//! refuses signs this machine out honestly rather than looping.
+//! and read back the caller's rows. Authentication, refresh rotation, and
+//! the dead-grant sign-out rules belong to [`crate::registry::client`].
 
 use serde::Deserialize;
 

--- a/crates/core/tests/credential_lock_process.rs
+++ b/crates/core/tests/credential_lock_process.rs
@@ -1,0 +1,131 @@
+//! The production credential lock across app and CLI processes.
+
+#[cfg(target_os = "linux")]
+use std::path::Path;
+#[cfg(target_os = "linux")]
+use std::sync::mpsc;
+#[cfg(target_os = "linux")]
+use std::time::{Duration, Instant};
+
+#[cfg(target_os = "linux")]
+use kendex_core::registry::credentials::{CredentialStore, KeyringStore};
+
+#[cfg(not(target_os = "linux"))]
+#[test]
+#[ignore = "divergent XDG data roots are a Linux credential-lock contract"]
+fn production_keyring_guard_blocks_across_divergent_data_roots() {}
+
+#[cfg(target_os = "linux")]
+const CHILD_ROOT: &str = "KENDEX_REFRESH_LOCK_CHILD_ROOT";
+#[cfg(target_os = "linux")]
+const CHILD_ROLE: &str = "KENDEX_REFRESH_LOCK_CHILD_ROLE";
+
+#[cfg(target_os = "linux")]
+fn wait_for(path: &Path, why: &str) {
+    let deadline = Instant::now() + Duration::from_secs(5);
+    while !path.exists() {
+        assert!(Instant::now() < deadline, "{why}");
+        std::thread::sleep(Duration::from_millis(10));
+    }
+}
+
+#[cfg(target_os = "linux")]
+#[allow(clippy::unwrap_used)]
+fn run_holder(root: &Path) {
+    let guard = KeyringStore.refresh_guard().unwrap();
+    let critical = root.join("critical");
+    let marker = std::fs::OpenOptions::new()
+        .write(true)
+        .create_new(true)
+        .open(&critical)
+        .expect("two processes entered the credential transaction together");
+    std::fs::write(root.join("holder-locked"), b"locked").unwrap();
+    wait_for(&root.join("release-holder"), "parent never released holder");
+    drop(marker);
+    std::fs::remove_file(critical).unwrap();
+    drop(guard);
+}
+
+#[cfg(target_os = "linux")]
+#[allow(clippy::unwrap_used)]
+fn run_waiter(root: &Path) {
+    let (attempted, saw_attempt) = mpsc::channel();
+    let (acquired, saw_acquire) = mpsc::channel();
+    let worker_root = root.to_owned();
+    let worker = std::thread::spawn(move || {
+        attempted.send(()).unwrap();
+        let guard = KeyringStore.refresh_guard().unwrap();
+        acquired.send(()).unwrap();
+        let critical = worker_root.join("critical");
+        let marker = std::fs::OpenOptions::new()
+            .write(true)
+            .create_new(true)
+            .open(&critical)
+            .expect("two processes entered the credential transaction together");
+        std::fs::write(worker_root.join("waiter-acquired"), b"acquired").unwrap();
+        drop(marker);
+        std::fs::remove_file(critical).unwrap();
+        drop(guard);
+    });
+
+    saw_attempt.recv().unwrap();
+    match saw_acquire.recv_timeout(Duration::from_millis(250)) {
+        Err(mpsc::RecvTimeoutError::Timeout) => {
+            std::fs::write(root.join("waiter-blocked"), b"blocked").unwrap();
+        }
+        Ok(()) => panic!("the waiter acquired before the holder released"),
+        Err(error) => panic!("waiter acquisition channel failed: {error}"),
+    }
+    worker.join().unwrap();
+}
+
+#[cfg(target_os = "linux")]
+#[test]
+#[allow(clippy::unwrap_used)]
+fn production_keyring_guard_blocks_across_divergent_data_roots() {
+    if let (Some(root), Ok(role)) = (std::env::var_os(CHILD_ROOT), std::env::var(CHILD_ROLE)) {
+        let root = std::path::PathBuf::from(root);
+        match role.as_str() {
+            "holder" => run_holder(&root),
+            "waiter" => run_waiter(&root),
+            other => panic!("unknown credential-lock child role: {other}"),
+        }
+        return;
+    }
+
+    let fixture = tempfile::tempdir().unwrap();
+    let root = fixture.path();
+    let executable = std::env::current_exe().unwrap();
+    let spawn = |role: &str, data_root: &str| {
+        std::process::Command::new(&executable)
+            .arg("--exact")
+            .arg("production_keyring_guard_blocks_across_divergent_data_roots")
+            .arg("--nocapture")
+            .env(CHILD_ROOT, root)
+            .env(CHILD_ROLE, role)
+            .env("HOME", root)
+            .env("KENDEX_REAL_HOME", "1")
+            .env("XDG_DATA_HOME", root.join(data_root))
+            .env("XDG_CACHE_HOME", root.join("cache"))
+            .env("XDG_CONFIG_HOME", root.join("config"))
+            .spawn()
+            .unwrap()
+    };
+
+    let mut holder = spawn("holder", "data-a");
+    wait_for(
+        &root.join("holder-locked"),
+        "holder never acquired the credential lock",
+    );
+    let mut waiter = spawn("waiter", "data-b");
+    wait_for(
+        &root.join("waiter-blocked"),
+        "waiter never proved it was blocked",
+    );
+    assert!(!root.join("waiter-acquired").exists());
+    std::fs::write(root.join("release-holder"), b"release").unwrap();
+
+    assert!(holder.wait().unwrap().success());
+    assert!(waiter.wait().unwrap().success());
+    assert!(root.join("waiter-acquired").exists());
+}

--- a/crates/core/tests/credential_transactions.rs
+++ b/crates/core/tests/credential_transactions.rs
@@ -1,0 +1,245 @@
+//! Mixed-version logout safety and bounded concurrent-token retries.
+
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::{Arc, Mutex, MutexGuard, mpsc};
+
+use kendex_core::error::{CoreError, Result};
+use kendex_core::registry::client;
+use kendex_core::registry::credentials::{Credential, CredentialRefreshGuard, CredentialStore};
+use kendex_core::registry::submit::submit;
+use kendex_core::registry::{Fetch, FetchResponse};
+
+struct Store {
+    credential: Mutex<Option<Credential>>,
+    transaction: Mutex<()>,
+}
+
+impl Store {
+    fn signed_in() -> Self {
+        Self {
+            credential: Mutex::new(Some(credential("old"))),
+            transaction: Mutex::new(()),
+        }
+    }
+}
+
+struct Guard<'a> {
+    _guard: MutexGuard<'a, ()>,
+}
+impl CredentialRefreshGuard for Guard<'_> {}
+
+fn lock_error() -> CoreError {
+    CoreError::RegistryUnavailable {
+        why: "test credential lock poisoned".to_owned(),
+    }
+}
+
+impl CredentialStore for Store {
+    fn save(&self, credential: &Credential) -> Result<()> {
+        *self.credential.lock().map_err(|_| lock_error())? = Some(credential.clone());
+        Ok(())
+    }
+
+    fn load(&self) -> Result<Option<Credential>> {
+        Ok(self.credential.lock().map_err(|_| lock_error())?.clone())
+    }
+
+    fn clear(&self) -> Result<()> {
+        *self.credential.lock().map_err(|_| lock_error())? = None;
+        Ok(())
+    }
+
+    fn refresh_guard(&self) -> Result<Box<dyn CredentialRefreshGuard + '_>> {
+        Ok(Box::new(Guard {
+            _guard: self.transaction.lock().map_err(|_| lock_error())?,
+        }))
+    }
+}
+
+fn credential(name: &str) -> Credential {
+    Credential {
+        endpoint: "https://kendex.ai".to_owned(),
+        access_token: format!("kxa_{name}"),
+        refresh_token: format!("kxr_{name}"),
+        capabilities: vec!["submission:write".to_owned()],
+    }
+}
+
+fn response(status: u16, body: &str) -> Result<FetchResponse> {
+    Ok(FetchResponse {
+        status,
+        etag: None,
+        body: body.as_bytes().to_vec(),
+    })
+}
+
+struct BlockingRevoke {
+    started: mpsc::Sender<()>,
+    proceed: Mutex<mpsc::Receiver<()>>,
+}
+
+impl Fetch for BlockingRevoke {
+    fn get_auth(
+        &self,
+        _url: &str,
+        _etag: Option<&str>,
+        _bearer: Option<&str>,
+    ) -> Result<FetchResponse> {
+        Err(CoreError::RegistryUnavailable {
+            why: "unexpected GET".to_owned(),
+        })
+    }
+
+    fn post_json_auth(&self, url: &str, body: &str, bearer: Option<&str>) -> Result<FetchResponse> {
+        assert!(url.ends_with("/api/v1/tokens/revoke"), "{url}");
+        assert_eq!(bearer, None);
+        assert!(body.contains("kxr_old"), "{body}");
+        self.started
+            .send(())
+            .map_err(|error| CoreError::RegistryUnavailable {
+                why: error.to_string(),
+            })?;
+        self.proceed
+            .lock()
+            .map_err(|_| lock_error())?
+            .recv()
+            .map_err(|error| CoreError::RegistryUnavailable {
+                why: error.to_string(),
+            })?;
+        response(200, r#"{"ok":true}"#)
+    }
+}
+
+fn logout_fixture() -> (
+    Arc<Store>,
+    Arc<BlockingRevoke>,
+    mpsc::Receiver<()>,
+    mpsc::Sender<()>,
+) {
+    let (started, observed) = mpsc::channel();
+    let (allow, proceed) = mpsc::channel();
+    (
+        Arc::new(Store::signed_in()),
+        Arc::new(BlockingRevoke {
+            started,
+            proceed: Mutex::new(proceed),
+        }),
+        observed,
+        allow,
+    )
+}
+
+fn spawn_logout(
+    fetch: &Arc<BlockingRevoke>,
+    store: &Arc<Store>,
+) -> std::thread::JoinHandle<Result<bool>> {
+    let fetch = Arc::clone(fetch);
+    let store = Arc::clone(store);
+    std::thread::spawn(move || client::logout(fetch.as_ref(), store.as_ref()))
+}
+
+#[test]
+#[allow(clippy::unwrap_used)]
+fn an_older_login_during_revoke_is_preserved() {
+    let (store, fetch, revoke_started, allow_revoke) = logout_fixture();
+    let logout = spawn_logout(&fetch, &store);
+    revoke_started.recv().unwrap();
+
+    store.save(&credential("replacement")).unwrap();
+    allow_revoke.send(()).unwrap();
+
+    let refused = logout.join().unwrap().unwrap_err().to_string();
+    assert!(refused.contains("sign-in changed"), "{refused}");
+    assert!(refused.contains("retry the request"), "{refused}");
+    let kept = store.load().unwrap().unwrap();
+    assert_eq!(kept.access_token, "kxa_replacement");
+    assert_eq!(kept.refresh_token, "kxr_replacement");
+}
+
+#[test]
+#[allow(clippy::unwrap_used)]
+fn an_older_logout_during_revoke_stays_signed_out() {
+    let (store, fetch, revoke_started, allow_revoke) = logout_fixture();
+    let logout = spawn_logout(&fetch, &store);
+    revoke_started.recv().unwrap();
+
+    store.clear().unwrap();
+    allow_revoke.send(()).unwrap();
+
+    assert!(logout.join().unwrap().unwrap());
+    assert!(store.load().unwrap().is_none());
+}
+
+struct RejectingNewerTokens {
+    store: Arc<Store>,
+    bearers: Mutex<Vec<String>>,
+    refresh_calls: AtomicUsize,
+}
+
+impl Fetch for RejectingNewerTokens {
+    fn get_auth(
+        &self,
+        _url: &str,
+        _etag: Option<&str>,
+        _bearer: Option<&str>,
+    ) -> Result<FetchResponse> {
+        Err(CoreError::RegistryUnavailable {
+            why: "unexpected GET".to_owned(),
+        })
+    }
+
+    fn post_json_auth(
+        &self,
+        _url: &str,
+        _body: &str,
+        bearer: Option<&str>,
+    ) -> Result<FetchResponse> {
+        let Some(bearer) = bearer else {
+            self.refresh_calls.fetch_add(1, Ordering::SeqCst);
+            return Err(CoreError::RegistryUnavailable {
+                why: "the bounded retry unexpectedly refreshed".to_owned(),
+            });
+        };
+        self.bearers
+            .lock()
+            .map_err(|_| lock_error())?
+            .push(bearer.to_owned());
+        match bearer {
+            "kxa_old" => self.store.save(&credential("newer-one"))?,
+            "kxa_newer-one" => self.store.save(&credential("newer-two"))?,
+            "kxa_newer-two" => {}
+            other => {
+                return Err(CoreError::RegistryUnavailable {
+                    why: format!("unexpected bearer {other}"),
+                });
+            }
+        }
+        response(401, r#"{"error":"invalid_token"}"#)
+    }
+}
+
+#[test]
+#[allow(clippy::unwrap_used)]
+fn two_rejected_concurrent_tokens_end_the_bounded_retry() {
+    let store = Arc::new(Store::signed_in());
+    let fetch = RejectingNewerTokens {
+        store: Arc::clone(&store),
+        bearers: Mutex::new(Vec::new()),
+        refresh_calls: AtomicUsize::new(0),
+    };
+
+    let refused = submit(&fetch, store.as_ref(), "jane/skills")
+        .unwrap_err()
+        .to_string();
+
+    assert!(
+        refused.contains("server does not accept this sign-in"),
+        "{refused}"
+    );
+    assert_eq!(
+        fetch.bearers.lock().unwrap().as_slice(),
+        ["kxa_old", "kxa_newer-one", "kxa_newer-two"]
+    );
+    assert_eq!(fetch.refresh_calls.load(Ordering::SeqCst), 0);
+    assert_eq!(store.load().unwrap().unwrap().access_token, "kxa_newer-two");
+}

--- a/crates/core/tests/submit_client.rs
+++ b/crates/core/tests/submit_client.rs
@@ -2,7 +2,7 @@
 //! refresh on a rejected access token (rotation saved before the retry),
 //! and an honest sign-out when the refresh itself is refused.
 
-use std::cell::RefCell;
+use std::cell::{Cell, RefCell};
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::{Arc, Barrier, Mutex, MutexGuard, mpsc};
 use std::time::{Duration, Instant};
@@ -248,20 +248,14 @@ fn rate_limit_and_timeout_refresh_failures_keep_the_credential() {
 struct ConcurrentStore {
     credential: Mutex<Option<Credential>>,
     refresh: Mutex<()>,
-    held: Arc<AtomicUsize>,
     guard_observer: Mutex<Option<mpsc::Sender<()>>>,
 }
 
 impl ConcurrentStore {
     fn signed_in() -> Self {
-        Self::signed_in_with_observer(Arc::new(AtomicUsize::new(0)))
-    }
-
-    fn signed_in_with_observer(held: Arc<AtomicUsize>) -> Self {
         Self {
             credential: Mutex::new(MemoryStore::signed_in().0.into_inner()),
             refresh: Mutex::new(()),
-            held,
             guard_observer: Mutex::new(None),
         }
     }
@@ -273,13 +267,20 @@ impl ConcurrentStore {
 
 struct ConcurrentGuard<'a> {
     _guard: MutexGuard<'a, ()>,
-    held: Arc<AtomicUsize>,
 }
 impl CredentialRefreshGuard for ConcurrentGuard<'_> {}
 
+thread_local! {
+    static REFRESH_GUARD_DEPTH: Cell<usize> = const { Cell::new(0) };
+}
+
+fn current_thread_holds_refresh_guard() -> bool {
+    REFRESH_GUARD_DEPTH.get() != 0
+}
+
 impl Drop for ConcurrentGuard<'_> {
     fn drop(&mut self) {
-        self.held.fetch_sub(1, Ordering::SeqCst);
+        REFRESH_GUARD_DEPTH.set(REFRESH_GUARD_DEPTH.get() - 1);
     }
 }
 
@@ -313,11 +314,8 @@ impl CredentialStore for ConcurrentStore {
                 })?;
         }
         let guard = self.refresh.lock().map_err(|_| lock_error())?;
-        self.held.fetch_add(1, Ordering::SeqCst);
-        Ok(Box::new(ConcurrentGuard {
-            _guard: guard,
-            held: Arc::clone(&self.held),
-        }))
+        REFRESH_GUARD_DEPTH.set(REFRESH_GUARD_DEPTH.get() + 1);
+        Ok(Box::new(ConcurrentGuard { _guard: guard }))
     }
 }
 
@@ -326,7 +324,6 @@ struct ConcurrentFetch {
     old_calls: AtomicUsize,
     refresh_calls: AtomicUsize,
     new_calls: AtomicUsize,
-    refresh_lock_held: Arc<AtomicUsize>,
     new_calls_under_lock: AtomicUsize,
 }
 
@@ -366,7 +363,7 @@ impl Fetch for ConcurrentFetch {
             }
             Some("kxa_new") => {
                 self.new_calls.fetch_add(1, Ordering::SeqCst);
-                if self.refresh_lock_held.load(Ordering::SeqCst) != 0 {
+                if current_thread_holds_refresh_guard() {
                     self.new_calls_under_lock.fetch_add(1, Ordering::SeqCst);
                 }
                 Self::response(201, r#"{"repo":"jane/skills","status":"listed"}"#)
@@ -388,16 +385,14 @@ impl Fetch for ConcurrentFetch {
 #[test]
 #[allow(clippy::unwrap_used)]
 fn concurrent_cli_and_app_calls_rotate_one_refresh_token_once() {
-    let refresh_lock_held = Arc::new(AtomicUsize::new(0));
     let fetch = Arc::new(ConcurrentFetch {
         old_access: Arc::new(Barrier::new(2)),
         old_calls: AtomicUsize::new(0),
         refresh_calls: AtomicUsize::new(0),
         new_calls: AtomicUsize::new(0),
-        refresh_lock_held: Arc::clone(&refresh_lock_held),
         new_calls_under_lock: AtomicUsize::new(0),
     });
-    let store = Arc::new(ConcurrentStore::signed_in_with_observer(refresh_lock_held));
+    let store = Arc::new(ConcurrentStore::signed_in());
     let run = || {
         let fetch = Arc::clone(&fetch);
         let store = Arc::clone(&store);
@@ -496,6 +491,7 @@ fn logout_while_waiting_for_refresh_does_not_resurrect_the_credential() {
 struct TransactionFetch {
     refresh_started: mpsc::Sender<()>,
     allow_refresh: Mutex<mpsc::Receiver<()>>,
+    refresh_answer: (u16, &'static str),
     revoked: Mutex<Vec<String>>,
     login_access_calls: AtomicUsize,
 }
@@ -541,10 +537,7 @@ impl Fetch for TransactionFetch {
                     .map_err(|error| CoreError::RegistryUnavailable {
                         why: error.to_string(),
                     })?;
-                Self::response(
-                    200,
-                    r#"{"access_token":"kxa_rotated","refresh_token":"kxr_rotated","capabilities":["submission:write"]}"#,
-                )
+                Self::response(self.refresh_answer.0, self.refresh_answer.1)
             }
             None if url.ends_with("/api/v1/tokens/revoke") => {
                 self.revoked
@@ -569,6 +562,20 @@ fn transaction_fixture() -> (
     mpsc::Receiver<()>,
     mpsc::Sender<()>,
 ) {
+    transaction_fixture_with_refresh((
+        200,
+        r#"{"access_token":"kxa_rotated","refresh_token":"kxr_rotated","capabilities":["submission:write"]}"#,
+    ))
+}
+
+fn transaction_fixture_with_refresh(
+    refresh_answer: (u16, &'static str),
+) -> (
+    Arc<ConcurrentStore>,
+    Arc<TransactionFetch>,
+    mpsc::Receiver<()>,
+    mpsc::Sender<()>,
+) {
     let (refresh_started, observed) = mpsc::channel();
     let (allow, allow_refresh) = mpsc::channel();
     (
@@ -576,6 +583,7 @@ fn transaction_fixture() -> (
         Arc::new(TransactionFetch {
             refresh_started,
             allow_refresh: Mutex::new(allow_refresh),
+            refresh_answer,
             revoked: Mutex::new(Vec::new()),
             login_access_calls: AtomicUsize::new(0),
         }),
@@ -593,6 +601,15 @@ fn spawn_refresh(
     std::thread::spawn(move || submit(fetch.as_ref(), store.as_ref(), "jane/skills"))
 }
 
+fn replacement_login() -> Credential {
+    Credential {
+        endpoint: "https://kendex.ai".to_owned(),
+        access_token: "kxa_login".to_owned(),
+        refresh_token: "kxr_login".to_owned(),
+        capabilities: vec!["submission:write".to_owned()],
+    }
+}
+
 #[test]
 #[allow(clippy::unwrap_used)]
 fn a_login_waiting_for_refresh_commits_the_new_family_last() {
@@ -604,15 +621,7 @@ fn a_login_waiting_for_refresh_commits_the_new_family_last() {
     store.observe_next_guard(guard_attempted);
     let login_store = Arc::clone(&store);
     let login = std::thread::spawn(move || {
-        client::commit_login(
-            login_store.as_ref(),
-            &Credential {
-                endpoint: "https://kendex.ai".to_owned(),
-                access_token: "kxa_login".to_owned(),
-                refresh_token: "kxr_login".to_owned(),
-                capabilities: vec!["submission:write".to_owned()],
-            },
-        )
+        client::commit_login(login_store.as_ref(), &replacement_login())
     });
     observed_guard.recv_timeout(Duration::from_secs(1)).unwrap();
     allow_refresh.send(()).unwrap();
@@ -627,6 +636,45 @@ fn a_login_waiting_for_refresh_commits_the_new_family_last() {
         0,
         "login must wait for the in-flight refresh transaction"
     );
+}
+
+#[test]
+#[allow(clippy::unwrap_used)]
+fn a_mixed_version_login_during_refresh_is_preserved() {
+    let (store, fetch, refresh_started, allow_refresh) = transaction_fixture();
+    let refresh = spawn_refresh(&fetch, &store);
+    refresh_started.recv().unwrap();
+
+    // Models an older installed client that does not know the transaction lock.
+    store.save(&replacement_login()).unwrap();
+    allow_refresh.send(()).unwrap();
+
+    let refused = refresh.join().unwrap().unwrap_err().to_string();
+    assert!(refused.contains("sign-in changed"), "{refused}");
+    assert!(refused.contains("retry the request"), "{refused}");
+    let kept = store.load().unwrap().unwrap();
+    assert_eq!(kept.access_token, "kxa_login");
+    assert_eq!(kept.refresh_token, "kxr_login");
+    assert_eq!(fetch.login_access_calls.load(Ordering::SeqCst), 0);
+}
+
+#[test]
+#[allow(clippy::unwrap_used)]
+fn a_mixed_version_login_survives_a_refused_old_refresh() {
+    let (store, fetch, refresh_started, allow_refresh) =
+        transaction_fixture_with_refresh((401, r#"{"error":"invalid_grant"}"#));
+    let refresh = spawn_refresh(&fetch, &store);
+    refresh_started.recv().unwrap();
+
+    store.save(&replacement_login()).unwrap();
+    allow_refresh.send(()).unwrap();
+
+    let refused = refresh.join().unwrap().unwrap_err().to_string();
+    assert!(refused.contains("sign-in changed"), "{refused}");
+    assert!(refused.contains("retry the request"), "{refused}");
+    let kept = store.load().unwrap().unwrap();
+    assert_eq!(kept.access_token, "kxa_login");
+    assert_eq!(kept.refresh_token, "kxr_login");
 }
 
 #[test]
@@ -655,7 +703,7 @@ fn a_logout_waiting_for_refresh_revokes_the_rotated_family_last() {
 
 #[test]
 #[allow(clippy::unwrap_used)]
-fn production_keyring_refresh_guard_serializes_processes() {
+fn production_keyring_guard_ignores_divergent_data_roots() {
     const CHILD_ROOT: &str = "KENDEX_REFRESH_LOCK_CHILD_ROOT";
     if let Some(root) = std::env::var_os(CHILD_ROOT) {
         let root = std::path::PathBuf::from(root);
@@ -685,22 +733,22 @@ fn production_keyring_refresh_guard_serializes_processes() {
     let fixture = tempfile::tempdir().unwrap();
     let root = fixture.path();
     let executable = std::env::current_exe().unwrap();
-    let spawn = || {
+    let spawn = |data_root: &str| {
         std::process::Command::new(&executable)
             .arg("--exact")
-            .arg("production_keyring_refresh_guard_serializes_processes")
+            .arg("production_keyring_guard_ignores_divergent_data_roots")
             .arg("--nocapture")
             .env(CHILD_ROOT, root)
             .env("HOME", root)
             .env("KENDEX_REAL_HOME", "1")
-            .env("XDG_DATA_HOME", root.join("data"))
+            .env("XDG_DATA_HOME", root.join(data_root))
             .env("XDG_CACHE_HOME", root.join("cache"))
             .env("XDG_CONFIG_HOME", root.join("config"))
             .spawn()
             .unwrap()
     };
-    let mut first = spawn();
-    let mut second = spawn();
+    let mut first = spawn("data-a");
+    let mut second = spawn("data-b");
     let deadline = Instant::now() + Duration::from_secs(5);
     while std::fs::read_dir(root)
         .unwrap()

--- a/crates/core/tests/submit_client.rs
+++ b/crates/core/tests/submit_client.rs
@@ -5,9 +5,13 @@
 use std::cell::RefCell;
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::{Arc, Barrier, Mutex, MutexGuard, mpsc};
+use std::time::{Duration, Instant};
 
 use kendex_core::error::{CoreError, Result};
-use kendex_core::registry::credentials::{Credential, CredentialRefreshGuard, CredentialStore};
+use kendex_core::registry::client;
+use kendex_core::registry::credentials::{
+    Credential, CredentialRefreshGuard, CredentialStore, KeyringStore,
+};
 use kendex_core::registry::submit::{submissions, submit};
 use kendex_core::registry::{Fetch, FetchResponse};
 
@@ -217,24 +221,67 @@ fn a_transient_refresh_failure_keeps_the_credential() {
     );
 }
 
+#[test]
+#[allow(clippy::unwrap_used)]
+fn rate_limit_and_timeout_refresh_failures_keep_the_credential() {
+    for status in [408, 429] {
+        let fetch = Canned::new(vec![
+            (401, r#"{"error":"invalid_token"}"#),
+            (status, r#"{"error":"try again later"}"#),
+        ]);
+        let store = MemoryStore::signed_in();
+        let refused = submit(&fetch, &store, "jane/skills")
+            .unwrap_err()
+            .to_string();
+
+        assert!(
+            !refused.contains("run `kendex login`"),
+            "{status}: {refused}"
+        );
+        assert!(
+            store.load().unwrap().is_some(),
+            "status {status} must not discard a live refresh grant"
+        );
+    }
+}
+
 struct ConcurrentStore {
     credential: Mutex<Option<Credential>>,
     refresh: Mutex<()>,
+    held: Arc<AtomicUsize>,
+    guard_observer: Mutex<Option<mpsc::Sender<()>>>,
 }
 
 impl ConcurrentStore {
     fn signed_in() -> Self {
+        Self::signed_in_with_observer(Arc::new(AtomicUsize::new(0)))
+    }
+
+    fn signed_in_with_observer(held: Arc<AtomicUsize>) -> Self {
         Self {
             credential: Mutex::new(MemoryStore::signed_in().0.into_inner()),
             refresh: Mutex::new(()),
+            held,
+            guard_observer: Mutex::new(None),
         }
+    }
+
+    fn observe_next_guard(&self, observer: mpsc::Sender<()>) {
+        *self.guard_observer.lock().expect("test observer lock") = Some(observer);
     }
 }
 
 struct ConcurrentGuard<'a> {
     _guard: MutexGuard<'a, ()>,
+    held: Arc<AtomicUsize>,
 }
 impl CredentialRefreshGuard for ConcurrentGuard<'_> {}
+
+impl Drop for ConcurrentGuard<'_> {
+    fn drop(&mut self) {
+        self.held.fetch_sub(1, Ordering::SeqCst);
+    }
+}
 
 fn lock_error() -> CoreError {
     CoreError::RegistryUnavailable {
@@ -258,8 +305,18 @@ impl CredentialStore for ConcurrentStore {
     }
 
     fn refresh_guard(&self) -> Result<Box<dyn CredentialRefreshGuard + '_>> {
+        if let Some(observer) = self.guard_observer.lock().map_err(|_| lock_error())?.take() {
+            observer
+                .send(())
+                .map_err(|error| CoreError::RegistryUnavailable {
+                    why: error.to_string(),
+                })?;
+        }
+        let guard = self.refresh.lock().map_err(|_| lock_error())?;
+        self.held.fetch_add(1, Ordering::SeqCst);
         Ok(Box::new(ConcurrentGuard {
-            _guard: self.refresh.lock().map_err(|_| lock_error())?,
+            _guard: guard,
+            held: Arc::clone(&self.held),
         }))
     }
 }
@@ -269,6 +326,8 @@ struct ConcurrentFetch {
     old_calls: AtomicUsize,
     refresh_calls: AtomicUsize,
     new_calls: AtomicUsize,
+    refresh_lock_held: Arc<AtomicUsize>,
+    new_calls_under_lock: AtomicUsize,
 }
 
 impl ConcurrentFetch {
@@ -307,6 +366,9 @@ impl Fetch for ConcurrentFetch {
             }
             Some("kxa_new") => {
                 self.new_calls.fetch_add(1, Ordering::SeqCst);
+                if self.refresh_lock_held.load(Ordering::SeqCst) != 0 {
+                    self.new_calls_under_lock.fetch_add(1, Ordering::SeqCst);
+                }
                 Self::response(201, r#"{"repo":"jane/skills","status":"listed"}"#)
             }
             None => {
@@ -326,13 +388,16 @@ impl Fetch for ConcurrentFetch {
 #[test]
 #[allow(clippy::unwrap_used)]
 fn concurrent_cli_and_app_calls_rotate_one_refresh_token_once() {
+    let refresh_lock_held = Arc::new(AtomicUsize::new(0));
     let fetch = Arc::new(ConcurrentFetch {
         old_access: Arc::new(Barrier::new(2)),
         old_calls: AtomicUsize::new(0),
         refresh_calls: AtomicUsize::new(0),
         new_calls: AtomicUsize::new(0),
+        refresh_lock_held: Arc::clone(&refresh_lock_held),
+        new_calls_under_lock: AtomicUsize::new(0),
     });
-    let store = Arc::new(ConcurrentStore::signed_in());
+    let store = Arc::new(ConcurrentStore::signed_in_with_observer(refresh_lock_held));
     let run = || {
         let fetch = Arc::clone(&fetch);
         let store = Arc::clone(&store);
@@ -346,6 +411,11 @@ fn concurrent_cli_and_app_calls_rotate_one_refresh_token_once() {
     assert_eq!(fetch.old_calls.load(Ordering::SeqCst), 2);
     assert_eq!(fetch.refresh_calls.load(Ordering::SeqCst), 1);
     assert_eq!(fetch.new_calls.load(Ordering::SeqCst), 2);
+    assert_eq!(
+        fetch.new_calls_under_lock.load(Ordering::SeqCst),
+        0,
+        "remote retries must not hold the credential transaction lock"
+    );
     let kept = store.load().unwrap().unwrap();
     assert_eq!(kept.access_token, "kxa_new");
     assert_eq!(kept.refresh_token, "kxr_new");
@@ -421,4 +491,228 @@ fn logout_while_waiting_for_refresh_does_not_resurrect_the_credential() {
     assert!(refused.contains("not signed in"), "{refused}");
     assert_eq!(fetch.refresh_calls.load(Ordering::SeqCst), 0);
     assert!(store.load().unwrap().is_none());
+}
+
+struct TransactionFetch {
+    refresh_started: mpsc::Sender<()>,
+    allow_refresh: Mutex<mpsc::Receiver<()>>,
+    revoked: Mutex<Vec<String>>,
+    login_access_calls: AtomicUsize,
+}
+
+impl TransactionFetch {
+    fn response(status: u16, body: &str) -> Result<FetchResponse> {
+        ConcurrentFetch::response(status, body)
+    }
+}
+
+impl Fetch for TransactionFetch {
+    fn get_auth(
+        &self,
+        _url: &str,
+        _etag: Option<&str>,
+        _bearer: Option<&str>,
+    ) -> Result<FetchResponse> {
+        Err(CoreError::RegistryUnavailable {
+            why: "unexpected GET".to_owned(),
+        })
+    }
+
+    fn post_json_auth(&self, url: &str, body: &str, bearer: Option<&str>) -> Result<FetchResponse> {
+        match bearer {
+            Some("kxa_old") => Self::response(401, r#"{"error":"invalid_token"}"#),
+            Some("kxa_rotated") => {
+                Self::response(201, r#"{"repo":"jane/skills","status":"listed"}"#)
+            }
+            Some("kxa_login") => {
+                self.login_access_calls.fetch_add(1, Ordering::SeqCst);
+                Self::response(201, r#"{"repo":"jane/skills","status":"listed"}"#)
+            }
+            None if url.ends_with("/api/v1/device/token") => {
+                self.refresh_started
+                    .send(())
+                    .map_err(|error| CoreError::RegistryUnavailable {
+                        why: error.to_string(),
+                    })?;
+                self.allow_refresh
+                    .lock()
+                    .map_err(|_| lock_error())?
+                    .recv()
+                    .map_err(|error| CoreError::RegistryUnavailable {
+                        why: error.to_string(),
+                    })?;
+                Self::response(
+                    200,
+                    r#"{"access_token":"kxa_rotated","refresh_token":"kxr_rotated","capabilities":["submission:write"]}"#,
+                )
+            }
+            None if url.ends_with("/api/v1/tokens/revoke") => {
+                self.revoked
+                    .lock()
+                    .map_err(|_| lock_error())?
+                    .push(body.to_owned());
+                Self::response(200, r#"{"ok":true}"#)
+            }
+            Some(other) => Err(CoreError::RegistryUnavailable {
+                why: format!("unexpected bearer {other}"),
+            }),
+            None => Err(CoreError::RegistryUnavailable {
+                why: format!("unexpected unauthenticated POST {url}"),
+            }),
+        }
+    }
+}
+
+fn transaction_fixture() -> (
+    Arc<ConcurrentStore>,
+    Arc<TransactionFetch>,
+    mpsc::Receiver<()>,
+    mpsc::Sender<()>,
+) {
+    let (refresh_started, observed) = mpsc::channel();
+    let (allow, allow_refresh) = mpsc::channel();
+    (
+        Arc::new(ConcurrentStore::signed_in()),
+        Arc::new(TransactionFetch {
+            refresh_started,
+            allow_refresh: Mutex::new(allow_refresh),
+            revoked: Mutex::new(Vec::new()),
+            login_access_calls: AtomicUsize::new(0),
+        }),
+        observed,
+        allow,
+    )
+}
+
+fn spawn_refresh(
+    fetch: &Arc<TransactionFetch>,
+    store: &Arc<ConcurrentStore>,
+) -> std::thread::JoinHandle<Result<kendex_core::registry::submit::Submitted>> {
+    let fetch = Arc::clone(fetch);
+    let store = Arc::clone(store);
+    std::thread::spawn(move || submit(fetch.as_ref(), store.as_ref(), "jane/skills"))
+}
+
+#[test]
+#[allow(clippy::unwrap_used)]
+fn a_login_waiting_for_refresh_commits_the_new_family_last() {
+    let (store, fetch, refresh_started, allow_refresh) = transaction_fixture();
+    let refresh = spawn_refresh(&fetch, &store);
+    refresh_started.recv().unwrap();
+
+    let (guard_attempted, observed_guard) = mpsc::channel();
+    store.observe_next_guard(guard_attempted);
+    let login_store = Arc::clone(&store);
+    let login = std::thread::spawn(move || {
+        client::commit_login(
+            login_store.as_ref(),
+            &Credential {
+                endpoint: "https://kendex.ai".to_owned(),
+                access_token: "kxa_login".to_owned(),
+                refresh_token: "kxr_login".to_owned(),
+                capabilities: vec!["submission:write".to_owned()],
+            },
+        )
+    });
+    observed_guard.recv_timeout(Duration::from_secs(1)).unwrap();
+    allow_refresh.send(()).unwrap();
+
+    assert_eq!(refresh.join().unwrap().unwrap().status, "listed");
+    login.join().unwrap().unwrap();
+    let kept = store.load().unwrap().unwrap();
+    assert_eq!(kept.access_token, "kxa_login");
+    assert_eq!(kept.refresh_token, "kxr_login");
+    assert_eq!(
+        fetch.login_access_calls.load(Ordering::SeqCst),
+        0,
+        "login must wait for the in-flight refresh transaction"
+    );
+}
+
+#[test]
+#[allow(clippy::unwrap_used)]
+fn a_logout_waiting_for_refresh_revokes_the_rotated_family_last() {
+    let (store, fetch, refresh_started, allow_refresh) = transaction_fixture();
+    let refresh = spawn_refresh(&fetch, &store);
+    refresh_started.recv().unwrap();
+
+    let (guard_attempted, observed_guard) = mpsc::channel();
+    store.observe_next_guard(guard_attempted);
+    let logout_store = Arc::clone(&store);
+    let logout_fetch = Arc::clone(&fetch);
+    let logout =
+        std::thread::spawn(move || client::logout(logout_fetch.as_ref(), logout_store.as_ref()));
+    observed_guard.recv_timeout(Duration::from_secs(1)).unwrap();
+    allow_refresh.send(()).unwrap();
+
+    assert_eq!(refresh.join().unwrap().unwrap().status, "listed");
+    assert!(logout.join().unwrap().unwrap());
+    assert!(store.load().unwrap().is_none());
+    let revoked = fetch.revoked.lock().unwrap();
+    assert_eq!(revoked.len(), 1);
+    assert!(revoked[0].contains("kxr_rotated"), "{}", revoked[0]);
+}
+
+#[test]
+#[allow(clippy::unwrap_used)]
+fn production_keyring_refresh_guard_serializes_processes() {
+    const CHILD_ROOT: &str = "KENDEX_REFRESH_LOCK_CHILD_ROOT";
+    if let Some(root) = std::env::var_os(CHILD_ROOT) {
+        let root = std::path::PathBuf::from(root);
+        let ready = root.join(format!("ready-{}", std::process::id()));
+        std::fs::write(&ready, b"ready").unwrap();
+        let start = root.join("start");
+        let deadline = Instant::now() + Duration::from_secs(5);
+        while !start.exists() {
+            assert!(Instant::now() < deadline, "parent never released child");
+            std::thread::sleep(Duration::from_millis(10));
+        }
+
+        let guard = KeyringStore.refresh_guard().unwrap();
+        let critical = root.join("critical");
+        let marker = std::fs::OpenOptions::new()
+            .write(true)
+            .create_new(true)
+            .open(&critical)
+            .expect("two processes entered the credential transaction together");
+        std::thread::sleep(Duration::from_millis(250));
+        drop(marker);
+        std::fs::remove_file(critical).unwrap();
+        drop(guard);
+        return;
+    }
+
+    let fixture = tempfile::tempdir().unwrap();
+    let root = fixture.path();
+    let executable = std::env::current_exe().unwrap();
+    let spawn = || {
+        std::process::Command::new(&executable)
+            .arg("--exact")
+            .arg("production_keyring_refresh_guard_serializes_processes")
+            .arg("--nocapture")
+            .env(CHILD_ROOT, root)
+            .env("HOME", root)
+            .env("KENDEX_REAL_HOME", "1")
+            .env("XDG_DATA_HOME", root.join("data"))
+            .env("XDG_CACHE_HOME", root.join("cache"))
+            .env("XDG_CONFIG_HOME", root.join("config"))
+            .spawn()
+            .unwrap()
+    };
+    let mut first = spawn();
+    let mut second = spawn();
+    let deadline = Instant::now() + Duration::from_secs(5);
+    while std::fs::read_dir(root)
+        .unwrap()
+        .filter_map(|entry| entry.ok())
+        .filter(|entry| entry.file_name().to_string_lossy().starts_with("ready-"))
+        .count()
+        != 2
+    {
+        assert!(Instant::now() < deadline, "children did not become ready");
+        std::thread::sleep(Duration::from_millis(10));
+    }
+    std::fs::write(root.join("start"), b"start").unwrap();
+    assert!(first.wait().unwrap().success());
+    assert!(second.wait().unwrap().success());
 }

--- a/crates/core/tests/submit_client.rs
+++ b/crates/core/tests/submit_client.rs
@@ -1,17 +1,15 @@
 //! The submissions client: bearer auth from the stored credential, one
 //! refresh on a rejected access token (rotation saved before the retry),
-//! and an honest sign-out when the refresh itself is refused.
+//! and separate outcomes for dead grants and retriable refresh failures.
 
 use std::cell::{Cell, RefCell};
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::{Arc, Barrier, Mutex, MutexGuard, mpsc};
-use std::time::{Duration, Instant};
+use std::time::Duration;
 
 use kendex_core::error::{CoreError, Result};
 use kendex_core::registry::client;
-use kendex_core::registry::credentials::{
-    Credential, CredentialRefreshGuard, CredentialStore, KeyringStore,
-};
+use kendex_core::registry::credentials::{Credential, CredentialRefreshGuard, CredentialStore};
 use kendex_core::registry::submit::{submissions, submit};
 use kendex_core::registry::{Fetch, FetchResponse};
 
@@ -142,7 +140,7 @@ fn an_hour_old_rejected_access_token_refreshes_once_and_saves_the_rotation() {
 
 #[test]
 #[allow(clippy::unwrap_used)]
-fn a_refused_refresh_signs_this_machine_out() {
+fn a_dead_refresh_grant_signs_this_machine_out() {
     let fetch = Canned::new(vec![
         (401, r#"{"error":"invalid_token"}"#),
         (401, r#"{"error":"invalid_grant"}"#),
@@ -699,68 +697,4 @@ fn a_logout_waiting_for_refresh_revokes_the_rotated_family_last() {
     let revoked = fetch.revoked.lock().unwrap();
     assert_eq!(revoked.len(), 1);
     assert!(revoked[0].contains("kxr_rotated"), "{}", revoked[0]);
-}
-
-#[test]
-#[allow(clippy::unwrap_used)]
-fn production_keyring_guard_ignores_divergent_data_roots() {
-    const CHILD_ROOT: &str = "KENDEX_REFRESH_LOCK_CHILD_ROOT";
-    if let Some(root) = std::env::var_os(CHILD_ROOT) {
-        let root = std::path::PathBuf::from(root);
-        let ready = root.join(format!("ready-{}", std::process::id()));
-        std::fs::write(&ready, b"ready").unwrap();
-        let start = root.join("start");
-        let deadline = Instant::now() + Duration::from_secs(5);
-        while !start.exists() {
-            assert!(Instant::now() < deadline, "parent never released child");
-            std::thread::sleep(Duration::from_millis(10));
-        }
-
-        let guard = KeyringStore.refresh_guard().unwrap();
-        let critical = root.join("critical");
-        let marker = std::fs::OpenOptions::new()
-            .write(true)
-            .create_new(true)
-            .open(&critical)
-            .expect("two processes entered the credential transaction together");
-        std::thread::sleep(Duration::from_millis(250));
-        drop(marker);
-        std::fs::remove_file(critical).unwrap();
-        drop(guard);
-        return;
-    }
-
-    let fixture = tempfile::tempdir().unwrap();
-    let root = fixture.path();
-    let executable = std::env::current_exe().unwrap();
-    let spawn = |data_root: &str| {
-        std::process::Command::new(&executable)
-            .arg("--exact")
-            .arg("production_keyring_guard_ignores_divergent_data_roots")
-            .arg("--nocapture")
-            .env(CHILD_ROOT, root)
-            .env("HOME", root)
-            .env("KENDEX_REAL_HOME", "1")
-            .env("XDG_DATA_HOME", root.join(data_root))
-            .env("XDG_CACHE_HOME", root.join("cache"))
-            .env("XDG_CONFIG_HOME", root.join("config"))
-            .spawn()
-            .unwrap()
-    };
-    let mut first = spawn("data-a");
-    let mut second = spawn("data-b");
-    let deadline = Instant::now() + Duration::from_secs(5);
-    while std::fs::read_dir(root)
-        .unwrap()
-        .filter_map(|entry| entry.ok())
-        .filter(|entry| entry.file_name().to_string_lossy().starts_with("ready-"))
-        .count()
-        != 2
-    {
-        assert!(Instant::now() < deadline, "children did not become ready");
-        std::thread::sleep(Duration::from_millis(10));
-    }
-    std::fs::write(root.join("start"), b"start").unwrap();
-    assert!(first.wait().unwrap().success());
-    assert!(second.wait().unwrap().success());
 }

--- a/crates/core/tests/submit_client.rs
+++ b/crates/core/tests/submit_client.rs
@@ -3,9 +3,11 @@
 //! and an honest sign-out when the refresh itself is refused.
 
 use std::cell::RefCell;
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::{Arc, Barrier, Mutex, MutexGuard, mpsc};
 
-use kendex_core::error::Result;
-use kendex_core::registry::credentials::{Credential, CredentialStore};
+use kendex_core::error::{CoreError, Result};
+use kendex_core::registry::credentials::{Credential, CredentialRefreshGuard, CredentialStore};
 use kendex_core::registry::submit::{submissions, submit};
 use kendex_core::registry::{Fetch, FetchResponse};
 
@@ -83,7 +85,13 @@ impl CredentialStore for MemoryStore {
         *self.0.borrow_mut() = None;
         Ok(())
     }
+    fn refresh_guard(&self) -> Result<Box<dyn CredentialRefreshGuard + '_>> {
+        Ok(Box::new(MemoryGuard))
+    }
 }
+
+struct MemoryGuard;
+impl CredentialRefreshGuard for MemoryGuard {}
 
 #[test]
 #[allow(clippy::unwrap_used)]
@@ -103,7 +111,7 @@ fn a_fresh_credential_submits_in_one_call() {
 
 #[test]
 #[allow(clippy::unwrap_used)]
-fn a_rejected_access_token_refreshes_once_and_saves_the_rotation() {
+fn an_hour_old_rejected_access_token_refreshes_once_and_saves_the_rotation() {
     let fetch = Canned::new(vec![
         (401, r#"{"error":"invalid_token"}"#),
         (
@@ -207,4 +215,210 @@ fn a_transient_refresh_failure_keeps_the_credential() {
         store.load().unwrap().is_some(),
         "a transient refresh failure must keep the credential"
     );
+}
+
+struct ConcurrentStore {
+    credential: Mutex<Option<Credential>>,
+    refresh: Mutex<()>,
+}
+
+impl ConcurrentStore {
+    fn signed_in() -> Self {
+        Self {
+            credential: Mutex::new(MemoryStore::signed_in().0.into_inner()),
+            refresh: Mutex::new(()),
+        }
+    }
+}
+
+struct ConcurrentGuard<'a> {
+    _guard: MutexGuard<'a, ()>,
+}
+impl CredentialRefreshGuard for ConcurrentGuard<'_> {}
+
+fn lock_error() -> CoreError {
+    CoreError::RegistryUnavailable {
+        why: "test credential lock poisoned".to_owned(),
+    }
+}
+
+impl CredentialStore for ConcurrentStore {
+    fn save(&self, credential: &Credential) -> Result<()> {
+        *self.credential.lock().map_err(|_| lock_error())? = Some(credential.clone());
+        Ok(())
+    }
+
+    fn load(&self) -> Result<Option<Credential>> {
+        Ok(self.credential.lock().map_err(|_| lock_error())?.clone())
+    }
+
+    fn clear(&self) -> Result<()> {
+        *self.credential.lock().map_err(|_| lock_error())? = None;
+        Ok(())
+    }
+
+    fn refresh_guard(&self) -> Result<Box<dyn CredentialRefreshGuard + '_>> {
+        Ok(Box::new(ConcurrentGuard {
+            _guard: self.refresh.lock().map_err(|_| lock_error())?,
+        }))
+    }
+}
+
+struct ConcurrentFetch {
+    old_access: Arc<Barrier>,
+    old_calls: AtomicUsize,
+    refresh_calls: AtomicUsize,
+    new_calls: AtomicUsize,
+}
+
+impl ConcurrentFetch {
+    fn response(status: u16, body: &str) -> Result<FetchResponse> {
+        Ok(FetchResponse {
+            status,
+            etag: None,
+            body: body.as_bytes().to_vec(),
+        })
+    }
+}
+
+impl Fetch for ConcurrentFetch {
+    fn get_auth(
+        &self,
+        _url: &str,
+        _etag: Option<&str>,
+        _bearer: Option<&str>,
+    ) -> Result<FetchResponse> {
+        Err(CoreError::RegistryUnavailable {
+            why: "unexpected GET".to_owned(),
+        })
+    }
+
+    fn post_json_auth(
+        &self,
+        _url: &str,
+        _body: &str,
+        bearer: Option<&str>,
+    ) -> Result<FetchResponse> {
+        match bearer {
+            Some("kxa_old") => {
+                self.old_calls.fetch_add(1, Ordering::SeqCst);
+                self.old_access.wait();
+                Self::response(401, r#"{"error":"invalid_token"}"#)
+            }
+            Some("kxa_new") => {
+                self.new_calls.fetch_add(1, Ordering::SeqCst);
+                Self::response(201, r#"{"repo":"jane/skills","status":"listed"}"#)
+            }
+            None => {
+                self.refresh_calls.fetch_add(1, Ordering::SeqCst);
+                Self::response(
+                    200,
+                    r#"{"access_token":"kxa_new","refresh_token":"kxr_new","capabilities":["submission:write"]}"#,
+                )
+            }
+            Some(other) => Err(CoreError::RegistryUnavailable {
+                why: format!("unexpected bearer {other}"),
+            }),
+        }
+    }
+}
+
+#[test]
+#[allow(clippy::unwrap_used)]
+fn concurrent_cli_and_app_calls_rotate_one_refresh_token_once() {
+    let fetch = Arc::new(ConcurrentFetch {
+        old_access: Arc::new(Barrier::new(2)),
+        old_calls: AtomicUsize::new(0),
+        refresh_calls: AtomicUsize::new(0),
+        new_calls: AtomicUsize::new(0),
+    });
+    let store = Arc::new(ConcurrentStore::signed_in());
+    let run = || {
+        let fetch = Arc::clone(&fetch);
+        let store = Arc::clone(&store);
+        std::thread::spawn(move || submit(fetch.as_ref(), store.as_ref(), "jane/skills"))
+    };
+    let first = run();
+    let second = run();
+
+    assert_eq!(first.join().unwrap().unwrap().status, "listed");
+    assert_eq!(second.join().unwrap().unwrap().status, "listed");
+    assert_eq!(fetch.old_calls.load(Ordering::SeqCst), 2);
+    assert_eq!(fetch.refresh_calls.load(Ordering::SeqCst), 1);
+    assert_eq!(fetch.new_calls.load(Ordering::SeqCst), 2);
+    let kept = store.load().unwrap().unwrap();
+    assert_eq!(kept.access_token, "kxa_new");
+    assert_eq!(kept.refresh_token, "kxr_new");
+}
+
+struct LogoutFetch {
+    old_seen: mpsc::Sender<()>,
+    refresh_calls: AtomicUsize,
+}
+
+impl Fetch for LogoutFetch {
+    fn get_auth(
+        &self,
+        _url: &str,
+        _etag: Option<&str>,
+        _bearer: Option<&str>,
+    ) -> Result<FetchResponse> {
+        Err(CoreError::RegistryUnavailable {
+            why: "unexpected GET".to_owned(),
+        })
+    }
+
+    fn post_json_auth(
+        &self,
+        _url: &str,
+        _body: &str,
+        bearer: Option<&str>,
+    ) -> Result<FetchResponse> {
+        match bearer {
+            Some("kxa_old") => {
+                self.old_seen
+                    .send(())
+                    .map_err(|error| CoreError::RegistryUnavailable {
+                        why: error.to_string(),
+                    })?;
+                ConcurrentFetch::response(401, r#"{"error":"invalid_token"}"#)
+            }
+            None => {
+                self.refresh_calls.fetch_add(1, Ordering::SeqCst);
+                ConcurrentFetch::response(
+                    200,
+                    r#"{"access_token":"kxa_new","refresh_token":"kxr_new","capabilities":[]}"#,
+                )
+            }
+            Some(other) => Err(CoreError::RegistryUnavailable {
+                why: format!("unexpected bearer {other}"),
+            }),
+        }
+    }
+}
+
+#[test]
+#[allow(clippy::unwrap_used)]
+fn logout_while_waiting_for_refresh_does_not_resurrect_the_credential() {
+    let store = Arc::new(ConcurrentStore::signed_in());
+    let held = store.refresh_guard().unwrap();
+    let (old_seen, observed) = mpsc::channel();
+    let fetch = Arc::new(LogoutFetch {
+        old_seen,
+        refresh_calls: AtomicUsize::new(0),
+    });
+    let worker_store = Arc::clone(&store);
+    let worker_fetch = Arc::clone(&fetch);
+    let worker = std::thread::spawn(move || {
+        submit(worker_fetch.as_ref(), worker_store.as_ref(), "jane/skills")
+    });
+
+    observed.recv().unwrap();
+    store.clear().unwrap();
+    drop(held);
+    let refused = worker.join().unwrap().unwrap_err().to_string();
+
+    assert!(refused.contains("not signed in"), "{refused}");
+    assert_eq!(fetch.refresh_calls.load(Ordering::SeqCst), 0);
+    assert!(store.load().unwrap().is_none());
 }

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -714,7 +714,7 @@ lives in one capability table read by core and UI.
   its real fetch time. All reads go through the `Fetch` trait (curl via
   `Hardened`, plain http only under `KENDEX_API`); tests inject transports.
   Bearer calls route through `registry/client.rs`: one cross-process lock
-  serializes refresh rotation, saving the rotated pair before retry.
+  serializes login, logout, and refresh rotation, saving rotations before retry.
   `skillssh.rs` pins its public wire schema and kill switch
   (`KENDEX_SKILLSSH=off`); a hit is a lead, never an identity, and installs
   through the same subscribe path. Collections and deep links arrive with W3/W4.

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -177,12 +177,14 @@ lives in one capability table read by core and UI.
     policy file are kept. `KENDEX_REAL_HOME=1`, and only that value, opts
     back out.
 
-    Two things ask `env/sandbox.rs` directly: the OS credential store's
-    service name carries the sandbox (keyed by name, not path), and the
-    real home stays reachable as `Env::real_home()` — project discovery
-    stops there, and a typed `~` means the person's home. Anything new
-    that is keyed by name, or that answers a question about the person
-    rather than this build's state, belongs on that list.
+    Three things ask `env/sandbox.rs` directly: the OS credential store's
+    service name carries the sandbox (keyed by name, not path); its
+    transaction lock uses the same service-plus-endpoint identity under
+    the real home, so XDG relocation cannot split one credential family;
+    and the real home stays reachable as `Env::real_home()`. Project
+    discovery stops there, and a typed `~` means the person's home.
+    Anything new that is keyed by name, or that answers a question about
+    the person rather than this build's state, belongs on that list.
 
     Three things sit outside the boundary: a project path handed to a
     debug build is still that project (`--scope project` reads and writes
@@ -713,8 +715,9 @@ lives in one capability table read by core and UI.
   one-hour TTL; a failed refresh serves the last fetch labeled stale with
   its real fetch time. All reads go through the `Fetch` trait (curl via
   `Hardened`, plain http only under `KENDEX_API`); tests inject transports.
-  Bearer calls route through `registry/client.rs`: one cross-process lock
-  serializes login, logout, and refresh rotation, saving rotations before retry.
+  Bearer calls route through `registry/client.rs`: one named cross-process
+  lock serializes login, logout, and refresh rotation, saving rotations
+  before retry.
   `skillssh.rs` pins its public wire schema and kill switch
   (`KENDEX_SKILLSSH=off`); a hit is a lead, never an identity, and installs
   through the same subscribe path. Collections and deep links arrive with W3/W4.

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -712,12 +712,12 @@ lives in one capability table read by core and UI.
   meta line on disk (`Env::registry_cache_dir`) behind an ETag and a
   one-hour TTL; a failed refresh serves the last fetch labeled stale with
   its real fetch time. All reads go through the `Fetch` trait (curl via
-  `Hardened`, plain http only under an explicit `KENDEX_API` override);
-  tests inject canned transports. `skillssh.rs` is the versioned adapter
-  over their public search: pinned wire schema refused on mismatch,
-  capped, kill-switched (`KENDEX_SKILLSSH=off`); a hit is a lead, never an
-  identity, installing through the same subscribe path. Sign-in,
-  collections and deep links arrive with W3/W4.
+  `Hardened`, plain http only under `KENDEX_API`); tests inject transports.
+  Bearer calls route through `registry/client.rs`: one cross-process lock
+  serializes refresh rotation, saving the rotated pair before retry.
+  `skillssh.rs` pins its public wire schema and kill switch
+  (`KENDEX_SKILLSSH=off`); a hit is a lead, never an identity, and installs
+  through the same subscribe path. Collections and deep links arrive with W3/W4.
 - **Intent in the manifest, closure in the plan, edges in the lock.** The
   manifest records choices, never consequences: items asked for, bundles
   installed, optional dependencies taken, what stays removed. A bundle's

--- a/tools/size-ratchet-baseline.tsv
+++ b/tools/size-ratchet-baseline.tsv
@@ -8,7 +8,7 @@ crates/core/src/engine/pi_hooks_move/mod.rs	508
 crates/core/src/engine/pi_hooks_move/preflight.rs	765
 crates/core/src/error.rs	419
 crates/core/src/remote/store.rs	420
-docs/ARCHITECTURE.md	842
+docs/ARCHITECTURE.md	845
 hooks/block-repo-copy.sh	511
 pi-extensions/pi-agents-tmux/extensions/subagent/browser.ts	650
 pi-extensions/pi-agents-tmux/extensions/subagent/dashboard.ts	431

--- a/tools/size-ratchet-baseline.tsv
+++ b/tools/size-ratchet-baseline.tsv
@@ -6,7 +6,7 @@ crates/core/src/engine/ops/add.rs	539
 crates/core/src/engine/pi_hooks_move/migrated.rs	540
 crates/core/src/engine/pi_hooks_move/mod.rs	508
 crates/core/src/engine/pi_hooks_move/preflight.rs	765
-crates/core/src/error.rs	416
+crates/core/src/error.rs	419
 crates/core/src/remote/store.rs	420
 docs/ARCHITECTURE.md	842
 hooks/block-repo-copy.sh	511


### PR DESCRIPTION
## Summary
- Extract bearer refresh and rotation into one shared registry client.
- Serialize refresh, login, and logout across app and CLI with one stable credential lock identity.
- Preserve credentials on transient refresh failures and prove process, mixed-version, and retry ordering.

## Completed Issues
- Closes KEN-416 - Extract rotation-safe bearer helper into registry/client.rs

## Test Plan
- `tools/guard`
- Process-level credential lock tests with divergent data roots
- Mutation and stability controls for refresh, login, logout, mixed-version writers, and bounded retries
