### PR TITLE
fix(KEN-650): agent skill roots follow the native .agents reads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,11 @@ an outside contributor.
 
 ### Fixed
 
+- Agents no longer promise a `{{KENDEX_FAILURE_REF}}` that nothing defines:
+  the failure-routing line now points at `kendex report --help`.
+- OpenCode, Gemini, and Copilot agent renders list required skills at
+  `.agents/skills/…` — the tree those tools read — instead of per-tool
+  directories a default install no longer writes.
 - Preflight no longer flags upstream `TODO` markers in vendored harness
   mirrors, and recognizes `.pi/kendex/` as a managed mirror like the other
   harness trees — repos committing their rendered harness files can pass.

--- a/agents/generalist.md
+++ b/agents/generalist.md
@@ -12,7 +12,7 @@ tags: [docs, refactoring]
 
 Handles cross-cutting maintenance: documentation accuracy, stale references, broken links and lint, and configuration organization.
 
-> ***Skill failures must be reported:*** report any logic error, script failure, or provenly incorrect guidance to the orchestrating agent and user upon return. Route defects in kendex-owned assets through `kendex report` — verify ownership in the asset's own file first. Full routing, attribution, and filing rules: `{{KENDEX_FAILURE_REF}}`.
+> ***Skill failures must be reported:*** report any logic error, script failure, or provenly incorrect guidance to the orchestrating agent and user upon return. Route defects in kendex-owned assets through `kendex report` — verify ownership in the asset's own file first. Filing rules: `kendex report --help`.
 
 ## Scope
 

--- a/agents/iced.md
+++ b/agents/iced.md
@@ -12,7 +12,7 @@ tags: [ui]
 
 Implements the Iced view layer: widget composition, Canvas and Shader rendering, `pane_grid` docking, theming, subscriptions, and Elm-architecture message flow.
 
-> ***Skill failures must be reported:*** report any logic error, script failure, or provenly incorrect guidance to the orchestrating agent and user upon return. Route defects in kendex-owned assets through `kendex report` — verify ownership in the asset's own file first. Full routing, attribution, and filing rules: `{{KENDEX_FAILURE_REF}}`.
+> ***Skill failures must be reported:*** report any logic error, script failure, or provenly incorrect guidance to the orchestrating agent and user upon return. Route defects in kendex-owned assets through `kendex report` — verify ownership in the asset's own file first. Filing rules: `kendex report --help`.
 
 ## Scope
 

--- a/agents/planner.md
+++ b/agents/planner.md
@@ -12,7 +12,7 @@ tags: [planning, research]
 
 Converts requirements, recon findings, and code context into an ordered implementation plan another agent can execute without re-deciding anything.
 
-> ***Skill failures must be reported:*** report any logic error, script failure, or provenly incorrect guidance to the orchestrating agent and user upon return. Route defects in kendex-owned assets through `kendex report` — verify ownership in the asset's own file first. Full routing, attribution, and filing rules: `{{KENDEX_FAILURE_REF}}`.
+> ***Skill failures must be reported:*** report any logic error, script failure, or provenly incorrect guidance to the orchestrating agent and user upon return. Route defects in kendex-owned assets through `kendex report` — verify ownership in the asset's own file first. Filing rules: `kendex report --help`.
 
 ## Modification Boundaries
 

--- a/agents/researcher.md
+++ b/agents/researcher.md
@@ -12,7 +12,7 @@ tags: [research]
 
 Executes delegated research prompts and produces evidence-backed findings reports.
 
-> ***Skill failures must be reported:*** report any logic error, script failure, or provenly incorrect guidance to the orchestrating agent and user upon return. Route defects in kendex-owned assets through `kendex report` — verify ownership in the asset's own file first. Full routing, attribution, and filing rules: `{{KENDEX_FAILURE_REF}}`.
+> ***Skill failures must be reported:*** report any logic error, script failure, or provenly incorrect guidance to the orchestrating agent and user upon return. Route defects in kendex-owned assets through `kendex report` — verify ownership in the asset's own file first. Filing rules: `kendex report --help`.
 
 ## Scope
 

--- a/agents/reviewer-arch.md
+++ b/agents/reviewer-arch.md
@@ -14,7 +14,7 @@ tags: [review]
 
 Compliance criteria come from the project's architecture docs — do not invent design rules the project never adopted. Leave local code quality not tied to architecture policy to `reviewer-quality`.
 
-> ***Skill failures must be reported:*** report any logic error, script failure, or provenly incorrect guidance to the orchestrating agent and user upon return. Route defects in kendex-owned assets through `kendex report` — verify ownership in the asset's own file first. Full routing, attribution, and filing rules: `{{KENDEX_FAILURE_REF}}`.
+> ***Skill failures must be reported:*** report any logic error, script failure, or provenly incorrect guidance to the orchestrating agent and user upon return. Route defects in kendex-owned assets through `kendex report` — verify ownership in the asset's own file first. Filing rules: `kendex report --help`.
 
 ## Scope
 

--- a/agents/reviewer-correctness.md
+++ b/agents/reviewer-correctness.md
@@ -14,7 +14,7 @@ tags: [review]
 
 Does the changed code still do what the product intends — for every input, caller, and consumer? Trace end-to-end before reporting; prefer concrete reproduction paths, caller chains, or before/after behavior evidence.
 
-> ***Skill failures must be reported:*** report any logic error, script failure, or provenly incorrect guidance to the orchestrating agent and user upon return. Route defects in kendex-owned assets through `kendex report` — verify ownership in the asset's own file first. Full routing, attribution, and filing rules: `{{KENDEX_FAILURE_REF}}`.
+> ***Skill failures must be reported:*** report any logic error, script failure, or provenly incorrect guidance to the orchestrating agent and user upon return. Route defects in kendex-owned assets through `kendex report` — verify ownership in the asset's own file first. Filing rules: `kendex report --help`.
 
 ## Scope
 

--- a/agents/reviewer-doc.md
+++ b/agents/reviewer-doc.md
@@ -14,7 +14,7 @@ tags: [review, docs]
 
 The method is verification, not proofreading — **open the implementation behind every checkable claim in the changed docs.** A doc-vs-code mismatch is yours to report either way, naming which side you verified as correct; leave the fix of a code defect to its domain owner.
 
-> ***Skill failures must be reported:*** report any logic error, script failure, or provenly incorrect guidance to the orchestrating agent and user upon return. Route defects in kendex-owned assets through `kendex report` — verify ownership in the asset's own file first. Full routing, attribution, and filing rules: `{{KENDEX_FAILURE_REF}}`.
+> ***Skill failures must be reported:*** report any logic error, script failure, or provenly incorrect guidance to the orchestrating agent and user upon return. Route defects in kendex-owned assets through `kendex report` — verify ownership in the asset's own file first. Filing rules: `kendex report --help`.
 
 ## Probes
 

--- a/agents/reviewer-error.md
+++ b/agents/reviewer-error.md
@@ -14,7 +14,7 @@ tags: [review, debugging]
 
 Error paths that quietly convert failure into success. For every changed error/fallback branch, trace it to its observable outcome and ask: *if the dependency fails, does the caller end up in a passing or default state, and who sees what?* "Nobody sees anything and the run continues" is a finding.
 
-> ***Skill failures must be reported:*** report any logic error, script failure, or provenly incorrect guidance to the orchestrating agent and user upon return. Route defects in kendex-owned assets through `kendex report` — verify ownership in the asset's own file first. Full routing, attribution, and filing rules: `{{KENDEX_FAILURE_REF}}`.
+> ***Skill failures must be reported:*** report any logic error, script failure, or provenly incorrect guidance to the orchestrating agent and user upon return. Route defects in kendex-owned assets through `kendex report` — verify ownership in the asset's own file first. Filing rules: `kendex report --help`.
 
 ## Scope
 

--- a/agents/reviewer-perf.md
+++ b/agents/reviewer-perf.md
@@ -14,7 +14,7 @@ tags: [review, performance]
 
 Validate performance with evidence: benchmarks against baselines, project-defined thresholds and budgets, percentiles over averages. Thresholds and hot/cold-path definitions come from the project's docs — never fabricate budgets; when docs are silent, report evidence-based risk instead. Classify every regression — silent omission is forbidden. Leave style and architecture to their owners unless perf impact is demonstrated.
 
-> ***Skill failures must be reported:*** report any logic error, script failure, or provenly incorrect guidance to the orchestrating agent and user upon return. Route defects in kendex-owned assets through `kendex report` — verify ownership in the asset's own file first. Full routing, attribution, and filing rules: `{{KENDEX_FAILURE_REF}}`.
+> ***Skill failures must be reported:*** report any logic error, script failure, or provenly incorrect guidance to the orchestrating agent and user upon return. Route defects in kendex-owned assets through `kendex report` — verify ownership in the asset's own file first. Filing rules: `kendex report --help`.
 
 ## Scope
 

--- a/agents/reviewer-quality.md
+++ b/agents/reviewer-quality.md
@@ -14,7 +14,7 @@ tags: [review]
 
 Is the changed implementation simple, direct, easy to reason about, and aligned with the codebase? Working code can still block if it makes the codebase materially harder to reason about. Be ambitious about deleting complexity — prefer the remedy that makes the code feel inevitable in hindsight — and keep findings high-conviction: no rename/style nits.
 
-> ***Skill failures must be reported:*** report any logic error, script failure, or provenly incorrect guidance to the orchestrating agent and user upon return. Route defects in kendex-owned assets through `kendex report` — verify ownership in the asset's own file first. Full routing, attribution, and filing rules: `{{KENDEX_FAILURE_REF}}`.
+> ***Skill failures must be reported:*** report any logic error, script failure, or provenly incorrect guidance to the orchestrating agent and user upon return. Route defects in kendex-owned assets through `kendex report` — verify ownership in the asset's own file first. Filing rules: `kendex report --help`.
 
 ## Scope
 

--- a/agents/reviewer-safety.md
+++ b/agents/reviewer-safety.md
@@ -14,7 +14,7 @@ tags: [review, security]
 
 Memory and thread safety in compiled code, AND concurrency of processes and files — scripts and orchestration race too. Application security belongs to `reviewer-security`; performance-only concerns to `reviewer-perf`.
 
-> ***Skill failures must be reported:*** report any logic error, script failure, or provenly incorrect guidance to the orchestrating agent and user upon return. Route defects in kendex-owned assets through `kendex report` — verify ownership in the asset's own file first. Full routing, attribution, and filing rules: `{{KENDEX_FAILURE_REF}}`.
+> ***Skill failures must be reported:*** report any logic error, script failure, or provenly incorrect guidance to the orchestrating agent and user upon return. Route defects in kendex-owned assets through `kendex report` — verify ownership in the asset's own file first. Filing rules: `kendex report --help`.
 
 ## Scope
 

--- a/agents/reviewer-security.md
+++ b/agents/reviewer-security.md
@@ -14,7 +14,7 @@ tags: [review, security]
 
 Application security and trust boundaries (memory/thread safety belongs to `reviewer-safety`; general correctness to `reviewer-correctness` unless security impact is central). Project security policies outrank generic standards; include a CWE reference when applicable.
 
-> ***Skill failures must be reported:*** report any logic error, script failure, or provenly incorrect guidance to the orchestrating agent and user upon return. Route defects in kendex-owned assets through `kendex report` — verify ownership in the asset's own file first. Full routing, attribution, and filing rules: `{{KENDEX_FAILURE_REF}}`.
+> ***Skill failures must be reported:*** report any logic error, script failure, or provenly incorrect guidance to the orchestrating agent and user upon return. Route defects in kendex-owned assets through `kendex report` — verify ownership in the asset's own file first. Filing rules: `kendex report --help`.
 
 ## Scope
 

--- a/agents/reviewer-test.md
+++ b/agents/reviewer-test.md
@@ -14,7 +14,7 @@ tags: [review, testing]
 
 The highest-value question is not "is there a test?" but "**can this test still fail?**" — hunt for tests that stay green when the behavior they guard is weakened, inverted, or deleted.
 
-> ***Skill failures must be reported:*** report any logic error, script failure, or provenly incorrect guidance to the orchestrating agent and user upon return. Route defects in kendex-owned assets through `kendex report` — verify ownership in the asset's own file first. Full routing, attribution, and filing rules: `{{KENDEX_FAILURE_REF}}`.
+> ***Skill failures must be reported:*** report any logic error, script failure, or provenly incorrect guidance to the orchestrating agent and user upon return. Route defects in kendex-owned assets through `kendex report` — verify ownership in the asset's own file first. Filing rules: `kendex report --help`.
 
 ## Scope
 

--- a/agents/rust.md
+++ b/agents/rust.md
@@ -12,7 +12,7 @@ tags: [performance]
 
 Implements performance-critical Rust: zero-allocation hot paths, lock-free data structures, SIMD, and measurable latency targets.
 
-> ***Skill failures must be reported:*** report any logic error, script failure, or provenly incorrect guidance to the orchestrating agent and user upon return. Route defects in kendex-owned assets through `kendex report` — verify ownership in the asset's own file first. Full routing, attribution, and filing rules: `{{KENDEX_FAILURE_REF}}`.
+> ***Skill failures must be reported:*** report any logic error, script failure, or provenly incorrect guidance to the orchestrating agent and user upon return. Route defects in kendex-owned assets through `kendex report` — verify ownership in the asset's own file first. Filing rules: `kendex report --help`.
 
 ## Scope
 

--- a/agents/scout.md
+++ b/agents/scout.md
@@ -12,7 +12,7 @@ tags: [research]
 
 Reconnaissance specialist. Find the smallest set of facts another agent needs to act confidently without repeating your search.
 
-> ***Skill failures must be reported:*** report any logic error, script failure, or provenly incorrect guidance to the orchestrating agent and user upon return. Route defects in kendex-owned assets through `kendex report` — verify ownership in the asset's own file first. Full routing, attribution, and filing rules: `{{KENDEX_FAILURE_REF}}`.
+> ***Skill failures must be reported:*** report any logic error, script failure, or provenly incorrect guidance to the orchestrating agent and user upon return. Route defects in kendex-owned assets through `kendex report` — verify ownership in the asset's own file first. Filing rules: `kendex report --help`.
 
 ## Report-Only Contract
 

--- a/agents/tpm.md
+++ b/agents/tpm.md
@@ -12,7 +12,7 @@ tags: [planning]
 
 Analyzes roadmaps, cycles, backlogs, and cross-project dependencies. Recommends; never executes.
 
-> ***Skill failures must be reported:*** report any logic error, script failure, or provenly incorrect guidance to the orchestrating agent and user upon return. Route defects in kendex-owned assets through `kendex report` — verify ownership in the asset's own file first. Full routing, attribution, and filing rules: `{{KENDEX_FAILURE_REF}}`.
+> ***Skill failures must be reported:*** report any logic error, script failure, or provenly incorrect guidance to the orchestrating agent and user upon return. Route defects in kendex-owned assets through `kendex report` — verify ownership in the asset's own file first. Filing rules: `kendex report --help`.
 
 ## Scope
 

--- a/crates/core/src/render/agent/copilot.rs
+++ b/crates/core/src/render/agent/copilot.rs
@@ -69,7 +69,7 @@ pub fn generate(agent: &EffectiveAgent) -> RenderedAgent {
     // as prose the agent's own instructions carry (matrix §2).
     let skill_root = match agent.scope {
         Scope::Global => "~/.copilot/skills",
-        Scope::Project { .. } => ".github/skills",
+        Scope::Project { .. } => ".agents/skills",
     };
     if let Some(skills) = skills_prose(agent, skill_root) {
         body.push_str(&format!("\n{skills}"));
@@ -132,7 +132,7 @@ mod tests {
             "{}",
             rendered.text
         );
-        assert!(rendered.text.contains("- dev: .github/skills/dev/SKILL.md"));
+        assert!(rendered.text.contains("- dev: .agents/skills/dev/SKILL.md"));
     }
 
     #[test]

--- a/crates/core/src/render/agent/gemini.rs
+++ b/crates/core/src/render/agent/gemini.rs
@@ -75,7 +75,7 @@ pub fn generate(agent: &EffectiveAgent) -> RenderedAgent {
     // both travel as prose the system prompt carries (matrix §1).
     let skill_root = match agent.scope {
         Scope::Global => "~/.gemini/skills",
-        Scope::Project { .. } => ".gemini/skills",
+        Scope::Project { .. } => ".agents/skills",
     };
     if let Some(skills) = skills_prose(agent, skill_root) {
         body.push_str(&format!("\n{skills}"));
@@ -132,7 +132,7 @@ mod tests {
             "---\nname: rust\ndescription: \"Rust \\\"systems\\\" engineer\"\nkind: local\nmodel: gemini-3-pro-preview\n---\n"
         ));
         assert!(rendered.text.contains("Use the grep_search tool."));
-        assert!(rendered.text.contains("- dev: .gemini/skills/dev/SKILL.md"));
+        assert!(rendered.text.contains("- dev: .agents/skills/dev/SKILL.md"));
         assert!(rendered.warnings.iter().any(|w| w.message.contains("Grep")));
     }
 

--- a/crates/core/src/render/agent/opencode.rs
+++ b/crates/core/src/render/agent/opencode.rs
@@ -163,7 +163,7 @@ fn body(agent: &EffectiveAgent, warnings: &mut Vec<crate::render::RenderWarning>
     out.push('\n');
     let skill_root = match agent.scope {
         Scope::Global => "~/.config/opencode/skills",
-        Scope::Project { .. } => ".opencode/skills",
+        Scope::Project { .. } => ".agents/skills",
     };
     if let Some(skills) = skills_prose(agent, skill_root) {
         out.push_str(&format!("\n{skills}"));
@@ -376,7 +376,7 @@ mod tests {
         agent.skills = vec!["dev".into()];
         agent.additional_instructions = Some("end here".into());
         let text = generate(&agent).text;
-        assert!(text.contains("- dev: .opencode/skills/dev/SKILL.md"));
+        assert!(text.contains("- dev: .agents/skills/dev/SKILL.md"));
         assert!(text.trim_end().ends_with("end here"));
     }
 }


### PR DESCRIPTION
Fixes KEN-650 and KEN-647, both seen live on the fleet-migration PRs (vg#40, hyprtrade-io#65) as review findings against the committed renders.

- The OpenCode, Gemini, and Copilot agent renders hardcoded per-tool project skill roots (`.opencode/skills`, `.gemini/skills`, `.github/skills`). After KEN-643's native-read alignment those directories are not written by a default install — the skills live at `.agents/skills`, which all three tools read natively — so every rendered agent's Required Skills list pointed at nonexistent files on a fresh clone. The project-scope arms now match Codex and Pi at `.agents/skills`; global arms are untouched (KEN-645 owns global alignment).
- The sixteen agent sources carried `{{KENDEX_FAILURE_REF}}`, a template token nothing ever substituted (inherited verbatim from vstack, broken there too). The sentence now ends with the concrete pointer: `kendex report --help`.

Tests: the three render pins move to the shared root; full workspace suite green.

https://claude.ai/code/session_0144GnaLXfxmewiWY6CBPZZo
