### PR TITLE
feat(harness-ci): a diff classifier consumers call from their own step

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -66,6 +66,9 @@ an outside contributor.
 
 ### Added
 
+- New optional `harness-ci` skill: a classifier that answers whether a CI diff
+  touches nothing but the kendex render trees, so heavy lanes can stand down.
+  It ships the script and its tests only — the workflow step stays yours.
 - Installing asks where it goes: the app and `kendex add` at a terminal offer
   every supported tool with the ones you have pre-checked, plus symlink or
   copy delivery. `--harness`, `--all-harnesses`, `--method` do it flag-only.

--- a/skills/harness-ci/README.md
+++ b/skills/harness-ci/README.md
@@ -1,0 +1,96 @@
+# harness-ci
+
+A repository that commits its kendex render gets diffs that touch nothing it
+builds, lints, typechecks or tests. This package ships the one function that
+recognises them — changed paths in, `harness_only=true|false` out — plus the
+tests that prove the semantics, run in kendex CI on every change.
+
+Opt-in: running CI over harness directories is a policy choice, and a repo
+that wants it simply does not install this.
+
+## The contract
+
+**This package never touches `.github/`.** The classifier is portable; a
+workflow is not. Installing into a stranger's CI renames jobs, drops
+required contexts, and wedges merge queues.
+
+What a consumer owns is one thin step calling the rendered script, written
+by hand, once. What upstream owns is the answer that step gets. Copy a shape
+from [references/wiring.md](references/wiring.md).
+
+## Usage
+
+```bash
+.agents/skills/harness-ci/scripts/harness-only \
+  --event pull_request --base "$BASE_SHA" --head "$HEAD_SHA"
+```
+
+| Flag | Meaning |
+| --- | --- |
+| `--event` | `pull_request`, `merge_group` or `push`. Any other event answers `false`. |
+| `--base` | The PR base sha, the merge group's base sha, or a push's `before` sha. |
+| `--head` | The head endpoint. Default `HEAD`. |
+| `--repo` | Classify this checkout instead of the working directory. |
+| `--output` | Append the verdict line to this file. Default `$GITHUB_OUTPUT`. |
+
+Checkout with `fetch-depth: 0`: the classifier diffs two real commits, and a
+shallow clone does not hold both.
+
+## Semantics
+
+- **The harness path set**: `.agents/`, `.claude/`, `.codex/`, `.opencode/`,
+  `.cursor/`, `.pi/`, and the root `opencode.json`. Prefixes match on the
+  separator, so `.agentsfoo/x` and `opencode.json.bak` are product paths.
+- **`--no-renames`, always.** Rename detection emits only the post-image, so
+  `git mv src/app.ts .agents/skills/x/app.ts` would list one harness path and
+  nothing else — the deletion of `src/app.ts` would go unjudged. With the
+  flag, both paths are listed and the diff answers `false`.
+- **Merge base on `pull_request`** (`base...head`): the base branch moves
+  under an open PR, and only the merge base isolates what the PR changed.
+- **Two endpoints on `push` and `merge_group`** (`base head`): a force-push
+  leaves the `before` sha off the head's history, and a merge base there is a
+  commit the push already discarded — measuring from it reads a push that
+  dropped product work as render-only. A merge group's base is an ancestor of
+  its head by construction, so the two forms agree there.
+- **Verdict channel**: `stdout` carries `harness_only=true|false` and nothing
+  else. Changed paths and failure reasons go to `stderr`.
+- **Exit codes**: `0` with every verdict; `2` on a wiring error (unknown
+  flag, missing `--event`, unwritable `--output`), which prints no verdict.
+
+## Fail-closed
+
+Anything the classifier cannot prove answers `false`, which runs every lane:
+
+- an unclassified event
+- a missing, empty, or unresolvable endpoint — the all-zero sha a first push
+  sends included
+- a diff git cannot read
+- an empty changed-file set, which is also what a diff that read nothing
+  looks like
+- a path git had to quote (an embedded newline or quote character), which
+  matches no harness prefix
+
+There is no flag that turns any of these into a `true`.
+
+## Tests
+
+`tests/` runs in kendex CI on every change to this repository:
+
+| Suite | Covers |
+| --- | --- |
+| `path-set` | Every render tree, mixed diffs, deletions, the near-miss paths |
+| `rename-into-render` | The `git mv` into a render tree, and the control proving the flag is load-bearing |
+| `event-ranges` | The force-push case, the moving base branch, merge groups |
+| `fail-closed` | Unclassified events, unresolvable endpoints, empty and unreadable diffs |
+| `wiring-errors` | Exit 2 on bad calls, `--output` and `$GITHUB_OUTPUT` behaviour |
+| `bash32-portability` | No Bash 4+ syntax; consumer runners include macOS system Bash |
+
+Run one locally with `bash skills/harness-ci/tests/path-set.test.sh`.
+
+## Upgrades
+
+The script is upstream's. `kendex refresh` rewrites the render tree, and a
+local edit to `.agents/skills/harness-ci/` is drift that the next refresh
+overwrites. Send changes to
+[vanillagreencom/kendex](https://github.com/vanillagreencom/kendex) via
+`kendex report`.

--- a/skills/harness-ci/README.md
+++ b/skills/harness-ci/README.md
@@ -94,7 +94,7 @@ There is no flag that turns any of these into a `true`.
 | `event-ranges` | The force-push case, the moving base branch, merge groups |
 | `fail-closed` | Unclassified events, unresolvable endpoints, an empty diff, a merge-base diff git refuses, a path git had to quote |
 | `wiring-errors` | Exit 2 on bad calls (a flag where a value belongs included), `--output` and `$GITHUB_OUTPUT` behaviour |
-| `wiring-shapes` | Every shape in `references/wiring.md` parses, keeps each expression on one line, and names the shipped script path |
+| `wiring-shapes` | Every shape in `references/wiring.md` keeps each expression on one line, orders the push endpoints, names the shipped script path, and steps its indentation by two |
 | `bash32-portability` | No Bash 4+ syntax; consumer runners include macOS system Bash |
 
 Run one locally with `bash skills/harness-ci/tests/path-set.test.sh`.

--- a/skills/harness-ci/README.md
+++ b/skills/harness-ci/README.md
@@ -46,8 +46,11 @@ those trees it committed.
 ## Semantics
 
 - **The harness path set**: `.agents/`, `.claude/`, `.codex/`, `.opencode/`,
-  `.cursor/`, `.pi/`, and the root `opencode.json`. Prefixes match on the
-  separator, so `.agentsfoo/x` and `opencode.json.bak` are product paths.
+  `.cursor/`, `.pi/`, and the root OpenCode config under either spelling —
+  `opencode.json` or `opencode.jsonc`, which is the file kendex writes when a
+  project carries that one. Prefixes match on the separator and the config
+  names match whole, so `.agentsfoo/x`, `opencode.json.bak` and
+  `ui/opencode.json` are product paths.
 - **`--no-renames`, always.** Rename detection emits only the post-image, so
   `git mv src/app.ts .agents/skills/x/app.ts` would list one harness path and
   nothing else — the deletion of `src/app.ts` would go unjudged. With the

--- a/skills/harness-ci/README.md
+++ b/skills/harness-ci/README.md
@@ -91,6 +91,7 @@ There is no flag that turns any of these into a `true`.
 | `event-ranges` | The force-push case, the moving base branch, merge groups |
 | `fail-closed` | Unclassified events, unresolvable endpoints, an empty diff, a merge-base diff git refuses, a path git had to quote |
 | `wiring-errors` | Exit 2 on bad calls (a flag where a value belongs included), `--output` and `$GITHUB_OUTPUT` behaviour |
+| `wiring-shapes` | Every shape in `references/wiring.md` parses, keeps each expression on one line, and names the shipped script path |
 | `bash32-portability` | No Bash 4+ syntax; consumer runners include macOS system Bash |
 
 Run one locally with `bash skills/harness-ci/tests/path-set.test.sh`.

--- a/skills/harness-ci/README.md
+++ b/skills/harness-ci/README.md
@@ -36,6 +36,13 @@ from [references/wiring.md](references/wiring.md).
 Checkout with `fetch-depth: 0`: the classifier diffs two real commits, and a
 shallow clone does not hold both.
 
+**Install with the default symlink delivery.** That writes the shared
+`.agents/skills/harness-ci/` tree every harness reads, which is the path above
+and the path in every wiring example. `--method copy` writes each tool its own
+tree instead (`.claude/skills/harness-ci/`, and so on) and writes no `.agents`
+tree at all — a repo on copy delivery has to point its step at whichever of
+those trees it committed.
+
 ## Semantics
 
 - **The harness path set**: `.agents/`, `.claude/`, `.codex/`, `.opencode/`,
@@ -54,8 +61,9 @@ shallow clone does not hold both.
   its head by construction, so the two forms agree there.
 - **Verdict channel**: `stdout` carries `harness_only=true|false` and nothing
   else. Changed paths and failure reasons go to `stderr`.
-- **Exit codes**: `0` with every verdict; `2` on a wiring error (unknown
-  flag, missing `--event`, unwritable `--output`), which prints no verdict.
+- **Exit codes**: `0` with every verdict; `2` on a wiring error (unknown flag,
+  missing `--event`, a flag where a value belongs, unwritable `--output`),
+  which prints no verdict.
 
 ## Fail-closed
 
@@ -81,8 +89,8 @@ There is no flag that turns any of these into a `true`.
 | `path-set` | Every render tree, mixed diffs, deletions, the near-miss paths |
 | `rename-into-render` | The `git mv` into a render tree, and the control proving the flag is load-bearing |
 | `event-ranges` | The force-push case, the moving base branch, merge groups |
-| `fail-closed` | Unclassified events, unresolvable endpoints, empty and unreadable diffs |
-| `wiring-errors` | Exit 2 on bad calls, `--output` and `$GITHUB_OUTPUT` behaviour |
+| `fail-closed` | Unclassified events, unresolvable endpoints, an empty diff, a merge-base diff git refuses, a path git had to quote |
+| `wiring-errors` | Exit 2 on bad calls (a flag where a value belongs included), `--output` and `$GITHUB_OUTPUT` behaviour |
 | `bash32-portability` | No Bash 4+ syntax; consumer runners include macOS system Bash |
 
 Run one locally with `bash skills/harness-ci/tests/path-set.test.sh`.

--- a/skills/harness-ci/SKILL.md
+++ b/skills/harness-ci/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: harness-ci
-description: "Classifies a CI diff as harness-only — every changed path under the kendex render trees (.agents, .claude, .codex, .opencode, .cursor, .pi, opencode.json) — so heavy lanes can stand down. Ships the classifier script and its tests; the workflow wiring stays the consumer's. Load to wire, tune, or debug a repo's harness-only skip."
+description: "Classifies a CI diff as harness-only — every changed path under the kendex render trees (.agents, .claude, .codex, .opencode, .cursor, .pi, opencode.json or opencode.jsonc) — so heavy lanes can stand down. Ships the classifier script and its tests; the workflow wiring stays the consumer's. Load to wire, tune, or debug a repo's harness-only skip."
 license: MIT
 user-invocable: true
 metadata:
@@ -20,8 +20,9 @@ tags: [automation]
 output?** The classifier reads a diff's changed-file set and prints
 `harness_only=true` when every path sits under `.agents/`, `.claude/`,
 `.codex/`, `.opencode/`, `.cursor/`, `.pi/`, or is the root
-`opencode.json`. Anything else prints `false`, and so does every diff the
-classifier cannot read.
+`opencode.json` — `opencode.jsonc` where a project carries that spelling.
+Anything else prints `false`, and so does every diff the classifier cannot
+read.
 
 ```bash
 .agents/skills/harness-ci/scripts/harness-only \

--- a/skills/harness-ci/SKILL.md
+++ b/skills/harness-ci/SKILL.md
@@ -1,0 +1,79 @@
+---
+name: harness-ci
+description: "Classifies a CI diff as harness-only — every changed path under the kendex render trees (.agents, .claude, .codex, .opencode, .cursor, .pi, opencode.json) — so heavy lanes can stand down. Ships the classifier script and its tests; the workflow wiring stays the consumer's. Load to wire, tune, or debug a repo's harness-only skip."
+license: MIT
+user-invocable: true
+metadata:
+  author: vanillagreen
+  source: kendex
+  repository: "https://github.com/vanillagreencom/kendex"
+  bugs: "https://github.com/vanillagreencom/kendex/issues"
+  version: "1.0.0"
+tags: [automation]
+---
+
+# Harness CI
+
+> **Problem with this skill?** Run `kendex report` — it files to the owning repo automatically. Do not hand-file.
+
+**One question, one answer: is this diff nothing but kendex render
+output?** The classifier reads a diff's changed-file set and prints
+`harness_only=true` when every path sits under `.agents/`, `.claude/`,
+`.codex/`, `.opencode/`, `.cursor/`, `.pi/`, or is the root
+`opencode.json`. Anything else prints `false`, and so does every diff the
+classifier cannot read.
+
+```bash
+.agents/skills/harness-ci/scripts/harness-only \
+  --event pull_request --base "$BASE_SHA" --head "$HEAD_SHA"
+```
+
+Flags and exit codes: `harness-only --help`. Contract and semantics:
+[README.md](README.md). Workflow shapes to copy:
+[references/wiring.md](references/wiring.md).
+
+## This package never edits a workflow
+
+The classification function is portable; the wiring is not. A package that
+installed itself into `.github/workflows/` would rename jobs, drop required
+contexts, and wedge merge queues in repositories it knows nothing about.
+
+The contract is one thin step the consumer writes and owns, calling the
+rendered script. Adoption edits the consumer's workflow by hand, once.
+
+## The two rules to hold when wiring it
+
+**Classify inside a job, never in `on.<event>.paths`.** A path filter stops
+the workflow from starting, the required context is never created, and a
+merge queue waits forever on a check nothing will report.
+
+**Keep the required-context job unconditional.** Gate the expensive lanes —
+job-level `if:` off a `changes` job's output, or step-level `if:` inside an
+aggregate — and let the aggregate that carries the required name run on
+every event, accepting `skipped` lanes as passes.
+
+## Reading a verdict
+
+`stdout` carries the verdict line alone, so `$(harness-only …)` is safe to
+read directly. The changed paths and the reason behind a `false` go to
+`stderr`, where the job log shows them. `--output FILE` (default
+`$GITHUB_OUTPUT`) appends the same line for a step output.
+
+Exit `0` accompanies every verdict, `true` or `false`. Exit `2` is a wiring
+error — an unknown flag, a missing `--event`, an `--output` the process
+cannot append to — and prints nothing on stdout, turning the step red
+instead of passing a guess off as a classification.
+
+## Fail-closed
+
+Every unprovable case answers `false`, which runs every lane:
+
+- an event outside `pull_request`, `merge_group`, `push`
+- a missing, empty, or unresolvable endpoint, the all-zero sha included
+- a diff git cannot read
+- an empty changed-file set
+- a path git had to quote, which no harness prefix matches
+
+`--no-renames` is not tunable. With rename detection on, a product file
+moved into a render tree lists only its post-image, the diff reads as
+render-only, and the lanes that would have judged the deletion never run.

--- a/skills/harness-ci/SKILL.md
+++ b/skills/harness-ci/SKILL.md
@@ -41,7 +41,7 @@ contexts, and wedge merge queues in repositories it knows nothing about.
 The contract is one thin step the consumer writes and owns, calling the
 rendered script. Adoption edits the consumer's workflow by hand, once.
 
-## The two rules to hold when wiring it
+## The rules to hold when wiring it
 
 **Classify inside a job, never in `on.<event>.paths`.** A path filter stops
 the workflow from starting, the required context is never created, and a
@@ -49,8 +49,14 @@ merge queue waits forever on a check nothing will report.
 
 **Keep the required-context job unconditional.** Gate the expensive lanes —
 job-level `if:` off a `changes` job's output, or step-level `if:` inside an
-aggregate — and let the aggregate that carries the required name run on
-every event, accepting `skipped` lanes as passes.
+aggregate — and let the aggregate that carries the required name run on every
+event.
+
+**A job-level `if:` needs a status function.** Without one it keeps the
+implicit `success()` and skips the lane whenever the classifying job failed,
+which stands the expensive lanes down on exactly the diffs nothing classified.
+An aggregate accepts a `skipped` lane only after checking that the classifier
+ran and cleared the diff.
 
 ## Reading a verdict
 
@@ -60,9 +66,9 @@ read directly. The changed paths and the reason behind a `false` go to
 `$GITHUB_OUTPUT`) appends the same line for a step output.
 
 Exit `0` accompanies every verdict, `true` or `false`. Exit `2` is a wiring
-error — an unknown flag, a missing `--event`, an `--output` the process
-cannot append to — and prints nothing on stdout, turning the step red
-instead of passing a guess off as a classification.
+error — an unknown flag, a missing `--event`, a flag where a value belongs, an
+`--output` the process cannot append to — and prints nothing on stdout,
+turning the step red instead of passing a guess off as a classification.
 
 ## Fail-closed
 

--- a/skills/harness-ci/references/wiring.md
+++ b/skills/harness-ci/references/wiring.md
@@ -54,14 +54,22 @@ jobs:
 
   test:
     needs: changes
-    if: needs.changes.outputs.harness_only != 'true'
+    if: >-
+      ${{ !cancelled()
+          && !(needs.changes.result == 'success'
+               && needs.changes.outputs.harness_only == 'true') }}
     runs-on: ubuntu-latest
     steps:
       # the repository's existing lane, unchanged
 ```
 
-`!= 'true'` and never `== 'false'`: a `changes` job that failed hands
-downstream jobs an empty string, and the lane must run on it.
+**The status function is load-bearing, and the condition names
+`needs.changes.result` on purpose.** A job-level `if:` carrying no status
+function keeps the implicit `success()`, so a plain
+`needs.changes.outputs.harness_only != 'true'` SKIPS the lane whenever the
+`changes` job fails — a checkout error or an `harness-only` exit 2 would stand
+the expensive lanes down rather than run them. `!cancelled()` lifts that, and
+the lane then skips on one condition only: the classifier ran and said `true`.
 
 ## Shape 2 — a step inside an aggregate job
 
@@ -93,8 +101,10 @@ jobs:
         run: make build test
 ```
 
-The job keeps its name, runs on every event, and reports the required
-context whatever the verdict.
+The job keeps its name, runs on every event, and reports the required context
+whatever the verdict. No status function is needed here: a STEP-level `if:` is
+evaluated only after the steps before it succeeded, so a classify step exiting
+2 fails the job outright and the gated steps never run.
 
 ## Shape 3 — merge queues, where the required context must report
 
@@ -105,7 +115,8 @@ the workflow from starting. The required context is never created, and the
 queue waits on a check nothing will report.
 
 **Keep the job that carries the required name unconditional.** Gate the
-lanes; let the aggregate run always and accept a skipped lane as a pass.
+lanes; let the aggregate run always. A skipped lane is a pass only when the
+classifier is the reason it skipped.
 
 ```yaml
   ci-ok:
@@ -114,22 +125,36 @@ lanes; let the aggregate run always and accept a skipped lane as a pass.
     if: always()
     runs-on: ubuntu-latest
     steps:
-      - name: every lane that ran succeeded
+      - name: the classifier ran and every lane that skipped was told to
         env:
+          CHANGES_RESULT: ${{ needs.changes.result }}
+          HARNESS_ONLY: ${{ needs.changes.outputs.harness_only }}
           RESULTS: ${{ needs.test.result }} ${{ needs.build.result }}
         run: |
           set -u
+          if [ "$CHANGES_RESULT" != "success" ]; then
+            echo "changes=$CHANGES_RESULT (required: success)"
+            exit 1
+          fi
           for result in $RESULTS; do
             case "$result" in
-              success | skipped) ;;
+              success) ;;
+              skipped)
+                if [ "$HARNESS_ONLY" != "true" ]; then
+                  echo "a lane skipped on a diff the classifier did not clear"
+                  exit 1
+                fi
+                ;;
               *) echo "lane result: $result"; exit 1 ;;
             esac
           done
 ```
 
-`if: always()` is load-bearing. Without it, a skipped lane skips the
+Both halves close a fail-open. Without `if: always()` a skipped lane skips the
 aggregate too, and a skipped required context satisfies the ruleset with no
-lane having run — the fail-open this shape closes.
+lane having run. Without the `CHANGES_RESULT` and `HARNESS_ONLY` checks the
+aggregate accepts `skipped` from any cause, so a `changes` job that died turns
+the required context green with nothing built.
 
 Every trigger the ruleset requires the context on must appear under `on:`,
 `merge_group` included. A required context that a merge group never produces

--- a/skills/harness-ci/references/wiring.md
+++ b/skills/harness-ci/references/wiring.md
@@ -16,7 +16,7 @@ commits; a shallow clone holds neither endpoint.
 env:
   EVENT: ${{ github.event_name }}
   BASE: ${{ github.event.pull_request.base.sha || github.event.merge_group.base_sha || github.event.before }}
-  HEAD: ${{ github.event.pull_request.head.sha || github.event.merge_group.head_sha || github.sha }}
+  HEAD: ${{ github.event.pull_request.head.sha || github.event.merge_group.head_sha || github.event.after || github.sha }}
 ```
 
 An event outside the three answers `false` on its own — an unset `BASE` needs
@@ -25,6 +25,14 @@ no guard of yours.
 Keep each expression on ONE line. A folded scalar (`>-`) whose continuations
 are indented further than its first line preserves the newlines instead of
 folding them, and what looks like a wrapped expression is a multi-line one.
+
+`github.event.after` sits AHEAD of `github.sha`, never instead of it. On a
+branch-deletion push `after` is the all-zero sha while `github.sha` is the
+default branch tip, so a bare `github.sha` fallback hands the classifier two
+real commits and a verdict on a diff nobody asked about; the all-zero sha
+resolves to no commit and answers `false`. `github.sha` stays last, so an
+event carrying no `after` still resolves a head and fails closed on the event
+rather than on a missing endpoint.
 
 ## Shape 1 — a `changes` job feeding job-level `if:`
 
@@ -45,7 +53,7 @@ jobs:
         env:
           EVENT: ${{ github.event_name }}
           BASE: ${{ github.event.pull_request.base.sha || github.event.merge_group.base_sha || github.event.before }}
-          HEAD: ${{ github.event.pull_request.head.sha || github.event.merge_group.head_sha || github.sha }}
+          HEAD: ${{ github.event.pull_request.head.sha || github.event.merge_group.head_sha || github.event.after || github.sha }}
         run: >-
           .agents/skills/harness-ci/scripts/harness-only
           --event "$EVENT" --base "$BASE" --head "$HEAD"
@@ -83,7 +91,7 @@ jobs:
         env:
           EVENT: ${{ github.event_name }}
           BASE: ${{ github.event.pull_request.base.sha || github.event.merge_group.base_sha || github.event.before }}
-          HEAD: ${{ github.event.pull_request.head.sha || github.event.merge_group.head_sha || github.sha }}
+          HEAD: ${{ github.event.pull_request.head.sha || github.event.merge_group.head_sha || github.event.after || github.sha }}
         run: >-
           .agents/skills/harness-ci/scripts/harness-only
           --event "$EVENT" --base "$BASE" --head "$HEAD"

--- a/skills/harness-ci/references/wiring.md
+++ b/skills/harness-ci/references/wiring.md
@@ -1,0 +1,147 @@
+# Wiring shapes
+
+Three shapes cover the repositories this package targets. Copy one, keep the
+repository's own job names and required contexts, and change nothing else.
+
+Every shape passes the event and the endpoints through `env:` rather than
+interpolating `${{ }}` into the shell — a workflow expression pasted into a
+command line is an injection surface.
+
+Every shape checks out with `fetch-depth: 0`. The classifier diffs two real
+commits; a shallow clone holds neither endpoint.
+
+## The endpoint expressions
+
+```yaml
+env:
+  EVENT: ${{ github.event_name }}
+  BASE: >-
+    ${{ github.event.pull_request.base.sha
+        || github.event.merge_group.base_sha
+        || github.event.before }}
+  HEAD: >-
+    ${{ github.event.pull_request.head.sha
+        || github.event.merge_group.head_sha
+        || github.sha }}
+```
+
+An event outside the three answers `false` on its own — an unset `BASE` needs
+no guard of yours.
+
+## Shape 1 — a `changes` job feeding job-level `if:`
+
+For workflows whose lanes are separate jobs.
+
+```yaml
+jobs:
+  changes:
+    name: Classify the diff
+    runs-on: ubuntu-latest
+    outputs:
+      harness_only: ${{ steps.classify.outputs.harness_only }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - id: classify
+        env:
+          EVENT: ${{ github.event_name }}
+          BASE: ${{ github.event.pull_request.base.sha || github.event.merge_group.base_sha || github.event.before }}
+          HEAD: ${{ github.event.pull_request.head.sha || github.event.merge_group.head_sha || github.sha }}
+        run: >-
+          .agents/skills/harness-ci/scripts/harness-only
+          --event "$EVENT" --base "$BASE" --head "$HEAD"
+
+  test:
+    needs: changes
+    if: needs.changes.outputs.harness_only != 'true'
+    runs-on: ubuntu-latest
+    steps:
+      # the repository's existing lane, unchanged
+```
+
+`!= 'true'` and never `== 'false'`: a `changes` job that failed hands
+downstream jobs an empty string, and the lane must run on it.
+
+## Shape 2 — a step inside an aggregate job
+
+For workflows that already run one job and gate the expensive tail of it.
+
+```yaml
+jobs:
+  ci-ok:
+    name: CI
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - id: classify
+        env:
+          EVENT: ${{ github.event_name }}
+          BASE: ${{ github.event.pull_request.base.sha || github.event.merge_group.base_sha || github.event.before }}
+          HEAD: ${{ github.event.pull_request.head.sha || github.event.merge_group.head_sha || github.sha }}
+        run: >-
+          .agents/skills/harness-ci/scripts/harness-only
+          --event "$EVENT" --base "$BASE" --head "$HEAD"
+
+      # Cheap whole-tree checks stay unconditional.
+      - run: make lint-text
+
+      - name: build and test
+        if: steps.classify.outputs.harness_only != 'true'
+        run: make build test
+```
+
+The job keeps its name, runs on every event, and reports the required
+context whatever the verdict.
+
+## Shape 3 — merge queues, where the required context must report
+
+Two rules, both about a check that never appears.
+
+**Classify inside a job, never in `on.<event>.paths`.** A path filter stops
+the workflow from starting. The required context is never created, and the
+queue waits on a check nothing will report.
+
+**Keep the job that carries the required name unconditional.** Gate the
+lanes; let the aggregate run always and accept a skipped lane as a pass.
+
+```yaml
+  ci-ok:
+    name: CI                      # the ruleset's required context
+    needs: [changes, test, build]
+    if: always()
+    runs-on: ubuntu-latest
+    steps:
+      - name: every lane that ran succeeded
+        env:
+          RESULTS: ${{ needs.test.result }} ${{ needs.build.result }}
+        run: |
+          set -u
+          for result in $RESULTS; do
+            case "$result" in
+              success | skipped) ;;
+              *) echo "lane result: $result"; exit 1 ;;
+            esac
+          done
+```
+
+`if: always()` is load-bearing. Without it, a skipped lane skips the
+aggregate too, and a skipped required context satisfies the ruleset with no
+lane having run — the fail-open this shape closes.
+
+Every trigger the ruleset requires the context on must appear under `on:`,
+`merge_group` included. A required context that a merge group never produces
+blocks the queue forever.
+
+## Verifying an adoption
+
+Two probe PRs against the adopting repository:
+
+1. **Harness-only** — touch one file under `.agents/`. The heavy lanes report
+   `skipped`, and every required context reports green.
+2. **Mixed** — touch one file under `.agents/` and one product file. Every
+   lane runs.
+
+Close both once the checks report.

--- a/skills/harness-ci/references/wiring.md
+++ b/skills/harness-ci/references/wiring.md
@@ -15,18 +15,16 @@ commits; a shallow clone holds neither endpoint.
 ```yaml
 env:
   EVENT: ${{ github.event_name }}
-  BASE: >-
-    ${{ github.event.pull_request.base.sha
-        || github.event.merge_group.base_sha
-        || github.event.before }}
-  HEAD: >-
-    ${{ github.event.pull_request.head.sha
-        || github.event.merge_group.head_sha
-        || github.sha }}
+  BASE: ${{ github.event.pull_request.base.sha || github.event.merge_group.base_sha || github.event.before }}
+  HEAD: ${{ github.event.pull_request.head.sha || github.event.merge_group.head_sha || github.sha }}
 ```
 
 An event outside the three answers `false` on its own — an unset `BASE` needs
 no guard of yours.
+
+Keep each expression on ONE line. A folded scalar (`>-`) whose continuations
+are indented further than its first line preserves the newlines instead of
+folding them, and what looks like a wrapped expression is a multi-line one.
 
 ## Shape 1 — a `changes` job feeding job-level `if:`
 
@@ -54,10 +52,7 @@ jobs:
 
   test:
     needs: changes
-    if: >-
-      ${{ !cancelled()
-          && !(needs.changes.result == 'success'
-               && needs.changes.outputs.harness_only == 'true') }}
+    if: ${{ !cancelled() && !(needs.changes.result == 'success' && needs.changes.outputs.harness_only == 'true') }}
     runs-on: ubuntu-latest
     steps:
       # the repository's existing lane, unchanged

--- a/skills/harness-ci/scripts/harness-only
+++ b/skills/harness-ci/scripts/harness-only
@@ -4,7 +4,7 @@
 # One reader of a diff's changed-file set, answering the one question CI asks
 # about it: may the heavy lanes stand down? A diff whose every path is
 # `kendex refresh` output — .agents/, .claude/, .codex/, .opencode/, .cursor/,
-# .pi/, opencode.json — carries nothing this repository builds, lints,
+# .pi/, opencode.json{,c} — carries nothing this repository builds, lints,
 # typechecks or tests. Those trees are upstream's and are tested in
 # vanillagreencom/kendex.
 #
@@ -168,7 +168,10 @@ harness_only=true
 while IFS= read -r path; do
   [ -n "$path" ] || continue
   case "$path" in
-    .agents/* | .claude/* | .codex/* | .opencode/* | .cursor/* | .pi/* | opencode.json) continue ;;
+    .agents/* | .claude/* | .codex/* | .opencode/* | .cursor/* | .pi/*) continue ;;
+    # Both spellings of the one OpenCode config: kendex writes the .jsonc file
+    # when a project carries that one instead, and it is the same artifact.
+    opencode.json | opencode.jsonc) continue ;;
   esac
   harness_only=false
   break

--- a/skills/harness-ci/scripts/harness-only
+++ b/skills/harness-ci/scripts/harness-only
@@ -24,8 +24,9 @@
 # log shows them.
 #
 # Exit 0 on any verdict. Exit 2 on a WIRING error — an unknown flag, a missing
-# --event, an unwritable --output. Those are never transient, so they must not
-# be absorbed as a classification: the step goes red and the caller sees it.
+# --event, a flag where a value belongs, an unwritable --output. Those are
+# never transient, so they must not be absorbed as a classification: the step
+# goes red and the caller sees it.
 #
 # Fail-closed everywhere. An unknown event, a missing or unresolvable
 # endpoint, an unreadable diff and an empty diff all answer false, which runs
@@ -66,17 +67,25 @@ die() { # MESSAGE — a wiring error, never a verdict
 # `shift 2` past the end of "$@" returns non-zero and shifts nothing. Every
 # value-taking flag proves its value is there first, rather than leaving the
 # argument loop to exit on a shift.
-need_value() { # FLAG REMAINING
+#
+# A flag-shaped value is the same wiring error one step later: `--event --base`
+# would take `--base` as the event, classify it as unrecognised, and hand back
+# a verdict for a call that named no event at all. No option here takes a value
+# that starts with a dash; a path that does is reachable as `./-name`.
+need_value() { # FLAG REMAINING NEXT
   [ "$2" -ge 2 ] || die "$1 needs a value"
+  case "$3" in
+    -?*) die "$1 needs a value, got the flag '$3'" ;;
+  esac
 }
 
 while [ "$#" -gt 0 ]; do
   case "$1" in
-    --event) need_value "$1" "$#"; event="$2"; shift 2 ;;
-    --base) need_value "$1" "$#"; base="$2"; shift 2 ;;
-    --head) need_value "$1" "$#"; head="$2"; shift 2 ;;
-    --repo) need_value "$1" "$#"; repo="$2"; shift 2 ;;
-    --output) need_value "$1" "$#"; output="$2"; shift 2 ;;
+    --event) need_value "$1" "$#" "${2:-}"; event="$2"; shift 2 ;;
+    --base) need_value "$1" "$#" "${2:-}"; base="$2"; shift 2 ;;
+    --head) need_value "$1" "$#" "${2:-}"; head="$2"; shift 2 ;;
+    --repo) need_value "$1" "$#" "${2:-}"; repo="$2"; shift 2 ;;
+    --output) need_value "$1" "$#" "${2:-}"; output="$2"; shift 2 ;;
     -h | --help) usage; exit 0 ;;
     *) die "unknown argument '$1'" ;;
   esac

--- a/skills/harness-ci/scripts/harness-only
+++ b/skills/harness-ci/scripts/harness-only
@@ -94,22 +94,20 @@ done
 [ -n "$event" ] || die "--event is required"
 [ -n "$head" ] || die "--head cannot be empty"
 
-# Prove the output file is appendable before classifying anything, so a
-# caller who named a file they cannot write learns it from an exit 2 with an
-# empty stdout rather than from a verdict that reached nobody.
-if [ -n "$output" ]; then
-  printf '' >>"$output" || die "cannot append to '$output'"
-fi
 
+# The output FILE is written before stdout, never after. A zero-length probe
+# proves only that the file opens — /dev/full and a full filesystem both accept
+# it and fail the real write — so a verdict printed first would already be on
+# stdout when the append died, and exit 2 is documented to carry no verdict.
 verdict() { # true|false [REASON]
   if [ "$#" -gt 1 ]; then
     echo "harness-only: $2; running every lane" >&2
   fi
-  printf 'harness_only=%s\n' "$1"
   if [ -n "$output" ]; then
     printf 'harness_only=%s\n' "$1" >>"$output" ||
       die "could not append the verdict to '$output'"
   fi
+  printf 'harness_only=%s\n' "$1"
   exit 0
 }
 

--- a/skills/harness-ci/scripts/harness-only
+++ b/skills/harness-ci/scripts/harness-only
@@ -1,0 +1,170 @@
+#!/usr/bin/env bash
+# harness-only — is this diff nothing but kendex render output?
+#
+# One reader of a diff's changed-file set, answering the one question CI asks
+# about it: may the heavy lanes stand down? A diff whose every path is
+# `kendex refresh` output — .agents/, .claude/, .codex/, .opencode/, .cursor/,
+# .pi/, opencode.json — carries nothing this repository builds, lints,
+# typechecks or tests. Those trees are upstream's and are tested in
+# vanillagreencom/kendex.
+#
+# Usage:
+#   harness-only --event EVENT [--base REF] [--head REF]
+#                [--repo DIR] [--output FILE]
+#
+#   --event   pull_request | merge_group | push. Any other event answers false.
+#   --base    the base endpoint: the PR base sha, the merge group's base sha,
+#             or a push's `before` sha.
+#   --head    the head endpoint. Default HEAD.
+#   --repo    classify this checkout instead of the working directory.
+#   --output  append the verdict line to this file. Default $GITHUB_OUTPUT.
+#
+# stdout carries the verdict line and nothing else: harness_only=true|false.
+# The changed paths and the reason behind a false go to stderr, where the job
+# log shows them.
+#
+# Exit 0 on any verdict. Exit 2 on a WIRING error — an unknown flag, a missing
+# --event, an unwritable --output. Those are never transient, so they must not
+# be absorbed as a classification: the step goes red and the caller sees it.
+#
+# Fail-closed everywhere. An unknown event, a missing or unresolvable
+# endpoint, an unreadable diff and an empty diff all answer false, which runs
+# every lane.
+#
+# Strict mode throughout. Every failure a verdict can be read from is handled
+# on the spot with an explicit `||`; anything left over is a defect in this
+# script, and a red step is the honest report of one.
+set -euo pipefail
+
+event=""
+base=""
+head="HEAD"
+repo="."
+output="${GITHUB_OUTPUT:-}"
+
+usage() {
+  cat <<'USAGE'
+Usage: harness-only --event EVENT [--base REF] [--head REF]
+                    [--repo DIR] [--output FILE]
+
+  --event   pull_request | merge_group | push. Any other event answers false.
+  --base    the base endpoint: the PR base sha, the merge group's base sha,
+            or a push's `before` sha.
+  --head    the head endpoint. Default HEAD.
+  --repo    classify this checkout instead of the working directory.
+  --output  append the verdict line to this file. Default $GITHUB_OUTPUT.
+
+Prints harness_only=true|false on stdout. Exit 2 on a wiring error.
+USAGE
+}
+
+die() { # MESSAGE — a wiring error, never a verdict
+  echo "harness-only: $1" >&2
+  exit 2
+}
+
+# `shift 2` past the end of "$@" returns non-zero and shifts nothing. Every
+# value-taking flag proves its value is there first, rather than leaving the
+# argument loop to exit on a shift.
+need_value() { # FLAG REMAINING
+  [ "$2" -ge 2 ] || die "$1 needs a value"
+}
+
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --event) need_value "$1" "$#"; event="$2"; shift 2 ;;
+    --base) need_value "$1" "$#"; base="$2"; shift 2 ;;
+    --head) need_value "$1" "$#"; head="$2"; shift 2 ;;
+    --repo) need_value "$1" "$#"; repo="$2"; shift 2 ;;
+    --output) need_value "$1" "$#"; output="$2"; shift 2 ;;
+    -h | --help) usage; exit 0 ;;
+    *) die "unknown argument '$1'" ;;
+  esac
+done
+
+[ -n "$event" ] || die "--event is required"
+[ -n "$head" ] || die "--head cannot be empty"
+
+# Prove the output file is appendable before classifying anything, so a
+# caller who named a file they cannot write learns it from an exit 2 with an
+# empty stdout rather than from a verdict that reached nobody.
+if [ -n "$output" ]; then
+  printf '' >>"$output" || die "cannot append to '$output'"
+fi
+
+verdict() { # true|false [REASON]
+  if [ "$#" -gt 1 ]; then
+    echo "harness-only: $2; running every lane" >&2
+  fi
+  printf 'harness_only=%s\n' "$1"
+  if [ -n "$output" ]; then
+    printf 'harness_only=%s\n' "$1" >>"$output" ||
+      die "could not append the verdict to '$output'"
+  fi
+  exit 0
+}
+
+# core.quotePath=false keeps non-ASCII paths raw instead of C-quoted. git still
+# quotes a path holding a newline or a double quote, and a quoted path starts
+# with `"`, matches no harness prefix, and answers false — fail-closed, which is
+# the right answer for a path this line-oriented reader cannot represent.
+git_repo() { git -C "$repo" -c core.quotePath=false "$@"; }
+
+# Three-dot on pull_request: the base branch moves under an open PR, and only
+# the merge base isolates what the PR itself changed.
+#
+# Two endpoints, no dots, on push and merge_group. A force-push leaves the
+# `before` sha off HEAD's history, and three-dot would then measure from a
+# merge base where the product files the push discarded never existed, reading
+# the whole push as render-only. A merge group's base is an ancestor of its
+# head by construction, so the two forms agree there; the endpoint form is
+# what stays correct if that ever stops holding.
+case "$event" in
+  pull_request) range_style=merge_base ;;
+  merge_group | push) range_style=endpoints ;;
+  *) verdict false "no diff endpoints are defined for event '$event'" ;;
+esac
+
+[ -n "$base" ] || verdict false "no base endpoint was given for event '$event'"
+
+for endpoint in "$base" "$head"; do
+  git_repo cat-file -e "${endpoint}^{commit}" 2>/dev/null ||
+    verdict false "endpoint '$endpoint' does not resolve to a commit"
+done
+
+if [ "$range_style" = merge_base ]; then
+  range="$base...$head"
+  changed="$(git_repo diff --name-only --no-renames "$range")" ||
+    verdict false "the diff '$range' is unreadable"
+else
+  changed="$(git_repo diff --name-only --no-renames "$base" "$head")" ||
+    verdict false "the diff '$base' '$head' is unreadable"
+fi
+
+# An empty list is not "nothing to run": it is also what a diff that silently
+# read nothing looks like, and neither answer is worth a waiver.
+[ -n "$changed" ] ||
+  verdict false "the diff between '$base' and '$head' is empty"
+
+printf '%s\n' "$changed" | sed -e 's/^/harness-only: changed: /' >&2
+
+# --no-renames, and it is load-bearing. With rename detection on,
+# `git diff --name-only` emits only the POST-image path, so moving a product
+# file INTO a render tree lists one harness path and nothing else — the diff
+# classifies harness-only and the lanes that would have judged the deletion
+# never run.
+#
+# Matched with bash's own `case` rather than by piping into grep. Every
+# external matcher here has a failure mode whose signature is empty output,
+# and empty output is indistinguishable from "every path was a harness path".
+harness_only=true
+while IFS= read -r path; do
+  [ -n "$path" ] || continue
+  case "$path" in
+    .agents/* | .claude/* | .codex/* | .opencode/* | .cursor/* | .pi/* | opencode.json) continue ;;
+  esac
+  harness_only=false
+  break
+done <<<"$changed"
+
+verdict "$harness_only"

--- a/skills/harness-ci/tests/bash32-portability.test.sh
+++ b/skills/harness-ci/tests/bash32-portability.test.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+# The classifier runs on whatever image a consumer's CI uses, macOS system
+# Bash 3.2 included, so shipped scripts may not use Bash 4+ builtins or syntax
+# (mapfile/readarray, associative arrays, automatic FD-allocation
+# redirections, case-conversion expansions).
+set -euo pipefail
+
+TEST_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SCRIPTS_DIR="$(cd "$TEST_DIR/../scripts" && pwd)"
+
+PATTERN='mapfile|readarray|declare -A|declare -gA|local -A'
+PATTERN="$PATTERN"'|(^|[^$])\{[A-Za-z_][A-Za-z0-9_]*\}[<>]'
+PATTERN="$PATTERN"'|\$\{[A-Za-z_][A-Za-z0-9_]*(\[[^]]*\])?(,,|\^\^)'
+
+violations="$(grep -rnE "$PATTERN" "$SCRIPTS_DIR" || true)"
+if [ -n "$violations" ]; then
+  echo "Bash 4+ constructs found in harness-ci scripts (must run under Bash 3.2):" >&2
+  printf '%s\n' "$violations" >&2
+  exit 1
+fi
+
+fail=0
+for f in "$SCRIPTS_DIR"/*; do
+  [ -f "$f" ] || continue
+  if ! bash -n "$f"; then
+    echo "FAIL: syntax check on $f"
+    fail=1
+  fi
+done
+[ "$fail" -eq 0 ] || exit 1
+
+echo "pass: bash32-portability"

--- a/skills/harness-ci/tests/event-ranges.test.sh
+++ b/skills/harness-ci/tests/event-ranges.test.sh
@@ -1,0 +1,68 @@
+#!/usr/bin/env bash
+# Which range each event measures. pull_request takes the merge base, because
+# the base branch moves under an open PR. push and merge_group take the two
+# endpoints, because a force-push leaves the `before` sha off the head's
+# history and a merge base there is a commit the push already discarded.
+set -euo pipefail
+# shellcheck source=lib/sandbox.sh
+. "$(dirname "${BASH_SOURCE[0]}")/lib/sandbox.sh"
+
+# --- push: the force-push case ------------------------------------------
+repo="$(new_repo force-push)"
+commit_paths "$repo" "baseline" README.md
+fork="$(git -C "$repo" rev-parse HEAD)"
+
+git -C "$repo" checkout -q -b topic
+commit_paths "$repo" "product work" src/feature.rs
+before="$(git -C "$repo" rev-parse HEAD)"
+
+# The force-push: the product commit is dropped and replaced by a render-only
+# one, so the endpoints share only the fork point.
+git -C "$repo" reset -q --hard "$fork"
+commit_paths "$repo" "render only" .agents/skills/orch/SKILL.md
+after="$(git -C "$repo" rev-parse HEAD)"
+
+assert_verdict "a force-push that discards product work answers false" false \
+  --repo "$repo" --event push --base "$before" --head "$after"
+
+merge_base_view="$(git -C "$repo" diff --name-only --no-renames "$before...$after")"
+assert_eq "the merge-base range would have seen only the render" \
+  ".agents/skills/orch/SKILL.md" "$merge_base_view"
+
+# --- pull_request: the moving base branch --------------------------------
+pr="$(new_repo moving-base)"
+commit_paths "$pr" "baseline" README.md
+
+git -C "$pr" checkout -q -b feature
+commit_paths "$pr" "render only" .claude/agents/rust.md
+pr_head="$(git -C "$pr" rev-parse HEAD)"
+
+git -C "$pr" checkout -q main
+commit_paths "$pr" "unrelated product work on main" src/other.rs
+pr_base="$(git -C "$pr" rev-parse HEAD)"
+
+assert_verdict "a render-only PR is unaffected by base-branch commits" true \
+  --repo "$pr" --event pull_request --base "$pr_base" --head "$pr_head"
+
+assert_verdict "the same endpoints read end-to-end pick up the base's work" false \
+  --repo "$pr" --event push --base "$pr_base" --head "$pr_head"
+
+# --- merge_group: the endpoint form ---------------------------------------
+mg="$(new_repo merge-group)"
+commit_paths "$mg" "baseline" README.md
+mg_base="$(git -C "$mg" rev-parse HEAD)"
+commit_paths "$mg" "render only" .codex/agents/rust.md
+mg_head="$(git -C "$mg" rev-parse HEAD)"
+
+assert_verdict "a render-only merge group answers true" true \
+  --repo "$mg" --event merge_group --base "$mg_base" --head "$mg_head"
+
+commit_paths "$mg" "product work" src/main.rs
+assert_verdict "a mixed merge group answers false" false \
+  --repo "$mg" --event merge_group --base "$mg_base" --head HEAD
+
+# --head defaults to HEAD rather than requiring the caller to name it.
+assert_verdict "--head defaults to HEAD" false \
+  --repo "$mg" --event merge_group --base "$mg_base"
+
+report event-ranges

--- a/skills/harness-ci/tests/fail-closed.test.sh
+++ b/skills/harness-ci/tests/fail-closed.test.sh
@@ -36,6 +36,9 @@ closed "an empty base endpoint" \
 closed "the all-zero base a first push sends" \
   --repo "$repo" --event push \
   --base 0000000000000000000000000000000000000000 --head "$head"
+closed "the all-zero head a branch-deletion push sends" \
+  --repo "$repo" --event push \
+  --base "$base" --head 0000000000000000000000000000000000000000
 closed "a base that names no object" \
   --repo "$repo" --event push --base 1234567890123456789012345678901234567890 --head "$head"
 closed "a head that names no object" \

--- a/skills/harness-ci/tests/fail-closed.test.sh
+++ b/skills/harness-ci/tests/fail-closed.test.sh
@@ -53,6 +53,38 @@ closed "a --repo that does not exist" \
 empty="$(new_repo empty)"
 closed "a checkout with no commits" --repo "$empty" --event push --base HEAD
 
+# A diff git REFUSES rather than one it answers empty. Two roots share no
+# ancestor, so the three-dot form has no merge base to measure from and exits
+# non-zero with both endpoints perfectly readable.
+orphan="$(new_repo unrelated-histories)"
+commit_paths "$orphan" "first root" README.md
+root_a="$(git -C "$orphan" rev-parse HEAD)"
+git -C "$orphan" checkout -q --orphan second
+git -C "$orphan" rm -q -rf .
+commit_paths "$orphan" "second root" .agents/skills/orch/SKILL.md
+root_b="$(git -C "$orphan" rev-parse HEAD)"
+git -C "$orphan" merge-base "$root_a" "$root_b" >/dev/null 2>&1 &&
+  { echo "FAIL: the fixture roots share a merge base" >&2; exit 1; }
+closed "a merge-base diff git refuses" \
+  --repo "$orphan" --event pull_request --base "$root_a" --head "$root_b"
+
+# A path git has to quote arrives wrapped in double quotes, matches no harness
+# prefix, and answers false — the right answer for a path this line-oriented
+# reader cannot represent. The rest of the diff is render output, so only the
+# quoting decides the verdict.
+quoted="$(new_repo quoted-path)"
+commit_paths "$quoted" "baseline" README.md
+quoted_base="$(git -C "$quoted" rev-parse HEAD)"
+commit_paths "$quoted" "a render path git must quote" \
+  '.agents/skills/orch/we"ird.md' .agents/skills/orch/SKILL.md
+listed="$(git -C "$quoted" -c core.quotePath=false diff --name-only --no-renames "$quoted_base" HEAD)"
+case "$listed" in
+  *'"'*) : ;;
+  *) echo "FAIL: git did not quote the fixture path" >&2; exit 1 ;;
+esac
+closed "a path git had to quote" \
+  --repo "$quoted" --event push --base "$quoted_base"
+
 # The reason reaches stderr, where the job log shows it.
 reason="$("$HARNESS_ONLY" --repo "$repo" --event schedule --base "$base" 2>&1 >/dev/null)"
 case "$reason" in

--- a/skills/harness-ci/tests/fail-closed.test.sh
+++ b/skills/harness-ci/tests/fail-closed.test.sh
@@ -1,0 +1,64 @@
+#!/usr/bin/env bash
+# Everything the classifier cannot prove answers false, and answers it with a
+# clean exit so the caller's step stays green while every lane runs.
+set -euo pipefail
+# shellcheck source=lib/sandbox.sh
+. "$(dirname "${BASH_SOURCE[0]}")/lib/sandbox.sh"
+
+repo="$(new_repo fail-closed)"
+commit_paths "$repo" "baseline" README.md
+base="$(git -C "$repo" rev-parse HEAD)"
+commit_paths "$repo" "render only" .agents/skills/orch/SKILL.md
+head="$(git -C "$repo" rev-parse HEAD)"
+
+# The control: these endpoints classify true, so every case below fails closed
+# on its own defect rather than on a diff that was never harness-only.
+assert_verdict "the control endpoints classify true" true \
+  --repo "$repo" --event push --base "$base" --head "$head"
+
+closed() { # LABEL ARGS...
+  local label="$1" out status
+  shift
+  set +e
+  out="$("$HARNESS_ONLY" "$@" 2>/dev/null)"
+  status=$?
+  set -e
+  assert_eq "$label" "harness_only=false exit 0" "$out exit $status"
+}
+
+closed "an unclassified event" \
+  --repo "$repo" --event schedule --base "$base" --head "$head"
+closed "workflow_dispatch is not a classified event" \
+  --repo "$repo" --event workflow_dispatch --base "$base" --head "$head"
+closed "no base endpoint" --repo "$repo" --event push --head "$head"
+closed "an empty base endpoint" \
+  --repo "$repo" --event push --base "" --head "$head"
+closed "the all-zero base a first push sends" \
+  --repo "$repo" --event push \
+  --base 0000000000000000000000000000000000000000 --head "$head"
+closed "a base that names no object" \
+  --repo "$repo" --event push --base 1234567890123456789012345678901234567890 --head "$head"
+closed "a head that names no object" \
+  --repo "$repo" --event pull_request --base "$base" --head 1234567890123456789012345678901234567890
+closed "a base that is not a commit" \
+  --repo "$repo" --event push --base "$(git -C "$repo" rev-parse "HEAD^{tree}")" --head "$head"
+closed "an empty diff between identical endpoints" \
+  --repo "$repo" --event push --base "$head" --head "$head"
+closed "a --repo that is not a checkout" \
+  --repo "$SANDBOX" --event push --base "$base" --head "$head"
+closed "a --repo that does not exist" \
+  --repo "$SANDBOX/absent" --event push --base "$base" --head "$head"
+
+# A repository with no commits at all: HEAD resolves to nothing.
+empty="$(new_repo empty)"
+closed "a checkout with no commits" --repo "$empty" --event push --base HEAD
+
+# The reason reaches stderr, where the job log shows it.
+reason="$("$HARNESS_ONLY" --repo "$repo" --event schedule --base "$base" 2>&1 >/dev/null)"
+case "$reason" in
+  *"event 'schedule'"*"running every lane"*)
+    assert_eq "the reason names the event and the consequence" pass pass ;;
+  *) assert_eq "the reason names the event and the consequence" pass "$reason" ;;
+esac
+
+report fail-closed

--- a/skills/harness-ci/tests/lib/sandbox.sh
+++ b/skills/harness-ci/tests/lib/sandbox.sh
@@ -1,0 +1,73 @@
+#!/usr/bin/env bash
+# Shared scaffolding for the harness-ci suites: a disposable git sandbox, the
+# path to the script under test, and the two assertions every suite makes.
+#
+# Sourced, never run. It sets the strict mode it needs rather than trusting the
+# sourcing suite to have set it, which is also what every suite here sets.
+set -euo pipefail
+
+TEST_DIR="$(cd "$(dirname "${BASH_SOURCE[1]}")" && pwd)"
+HARNESS_ONLY="$(cd "$TEST_DIR/../scripts" && pwd)/harness-only"
+
+PASS=0
+FAIL=0
+
+# Checked on the spot: a failed mktemp leaves the variable empty, and an empty
+# SANDBOX would send the cleanup trap at the filesystem root.
+SANDBOX="$(mktemp -d -t harness-ci-XXXXXX)" || SANDBOX=""
+if [ -z "$SANDBOX" ] || [ ! -d "$SANDBOX" ]; then
+  echo "harness-ci tests: could not create a sandbox directory" >&2
+  exit 1
+fi
+cleanup() { rm -rf "$SANDBOX" 2>/dev/null || true; }
+trap cleanup EXIT
+
+# Fixture repositories carry their own identity and default branch so the
+# suite reads the same on a runner with no global git config.
+new_repo() { # NAME -> prints the repo path
+  local repo="$SANDBOX/$1"
+  mkdir -p "$repo"
+  git -C "$repo" init -q -b main
+  git -C "$repo" config user.email harness-ci@example.invalid
+  git -C "$repo" config user.name "harness-ci tests"
+  printf '%s' "$repo"
+}
+
+# One commit per call: write every path, then record them together.
+commit_paths() { # REPO MESSAGE PATH...
+  local repo="$1" message="$2" path
+  shift 2
+  for path in "$@"; do
+    mkdir -p "$repo/$(dirname "$path")"
+    printf 'content for %s\n' "$path" >>"$repo/$path"
+  done
+  git -C "$repo" add -A
+  git -C "$repo" commit -q -m "$message"
+}
+
+# The verdict line alone. stderr is dropped here on purpose: these assertions
+# are about what a caller reads from stdout.
+classify() { # ARGS... -> the harness_only= line
+  "$HARNESS_ONLY" "$@" 2>/dev/null
+}
+
+assert_eq() { # LABEL EXPECTED ACTUAL
+  if [ "$2" = "$3" ]; then
+    printf '  PASS: %s\n' "$1"
+    PASS=$((PASS + 1))
+  else
+    printf '  FAIL: %s\n    expected: %s\n    actual:   %s\n' "$1" "$2" "$3" >&2
+    FAIL=$((FAIL + 1))
+  fi
+}
+
+assert_verdict() { # LABEL true|false ARGS...
+  local label="$1" expected="$2"
+  shift 2
+  assert_eq "$label" "harness_only=$expected" "$(classify "$@")"
+}
+
+report() { # SUITE
+  printf '%s: %d passed, %d failed\n' "$1" "$PASS" "$FAIL"
+  [ "$FAIL" -eq 0 ]
+}

--- a/skills/harness-ci/tests/path-set.test.sh
+++ b/skills/harness-ci/tests/path-set.test.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+# The path set: every render tree answers true, anything beside one answers
+# false, and the near misses that merely start with a render tree's name are
+# product paths like any other.
+set -euo pipefail
+# shellcheck source=lib/sandbox.sh
+. "$(dirname "${BASH_SOURCE[0]}")/lib/sandbox.sh"
+
+repo="$(new_repo path-set)"
+commit_paths "$repo" "baseline" README.md
+base="$(git -C "$repo" rev-parse HEAD)"
+
+# One commit per case, each measured against the same baseline, so a case
+# never inherits another's paths.
+case_verdict() { # LABEL EXPECTED PATH...
+  local label="$1" expected="$2"
+  shift 2
+  git -C "$repo" checkout -q -B "case" "$base"
+  git -C "$repo" clean -qfd
+  commit_paths "$repo" "$label" "$@"
+  assert_verdict "$label" "$expected" --repo "$repo" --event push --base "$base" --head HEAD
+}
+
+case_verdict "every render tree at once" true \
+  .agents/skills/orch/SKILL.md \
+  .claude/agents/rust.md \
+  .codex/agents/rust.md \
+  .opencode/agent/rust.md \
+  .cursor/rules/rust.mdc \
+  .pi/kendex/hooks/guard.ts \
+  opencode.json
+
+case_verdict "a render path beside a product path" false \
+  .agents/skills/orch/SKILL.md src/main.rs
+
+case_verdict "product paths alone" false src/main.rs
+
+case_verdict "deeply nested render output" true \
+  .agents/skills/review-gate/scripts/lib/settings.sh
+
+# The near misses. A prefix match without the separator is a different path,
+# and a suffix past the filename is a different file.
+case_verdict ".agentsfoo is not .agents/" false .agentsfoo/notes.md
+case_verdict ".agents-old is not .agents/" false .agents-old/notes.md
+case_verdict "opencode.json.bak is not opencode.json" false opencode.json.bak
+case_verdict "a nested opencode.json is not the root one" false ui/opencode.json
+case_verdict ".claudefoo is not .claude/" false .claudefoo
+case_verdict "a bare .agents file is not the tree" false .agents
+
+# A deletion is a change like any other: removing a product file cannot read
+# as harness-only just because nothing was added outside the render.
+git -C "$repo" checkout -q -B "case" "$base"
+git -C "$repo" rm -q README.md
+git -C "$repo" commit -q -m "delete the product file"
+assert_verdict "a product deletion answers false" false \
+  --repo "$repo" --event push --base "$base" --head HEAD
+
+report path-set

--- a/skills/harness-ci/tests/path-set.test.sh
+++ b/skills/harness-ci/tests/path-set.test.sh
@@ -30,6 +30,11 @@ case_verdict "every render tree at once" true \
   .pi/kendex/hooks/guard.ts \
   opencode.json
 
+# kendex writes opencode.jsonc where a project carries that spelling instead,
+# so both names are the one OpenCode config.
+case_verdict "the jsonc spelling of the config" true opencode.jsonc
+case_verdict "both spellings side by side" true opencode.json opencode.jsonc
+
 case_verdict "a render path beside a product path" false \
   .agents/skills/orch/SKILL.md src/main.rs
 
@@ -44,6 +49,9 @@ case_verdict ".agentsfoo is not .agents/" false .agentsfoo/notes.md
 case_verdict ".agents-old is not .agents/" false .agents-old/notes.md
 case_verdict "opencode.json.bak is not opencode.json" false opencode.json.bak
 case_verdict "a nested opencode.json is not the root one" false ui/opencode.json
+case_verdict "opencode.jsonc.bak is not opencode.jsonc" false opencode.jsonc.bak
+case_verdict "a nested opencode.jsonc is not the root one" false ui/opencode.jsonc
+case_verdict "opencode.jsonc5 is not opencode.jsonc" false opencode.jsonc5
 case_verdict ".claudefoo is not .claude/" false .claudefoo
 case_verdict "a bare .agents file is not the tree" false .agents
 

--- a/skills/harness-ci/tests/rename-into-render.test.sh
+++ b/skills/harness-ci/tests/rename-into-render.test.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+# --no-renames is load-bearing. Moving a product file INTO a render tree
+# deletes source; with rename detection on, git lists only the post-image and
+# the diff reads as render-only, so the lanes that would have judged the
+# deletion never run.
+set -euo pipefail
+# shellcheck source=lib/sandbox.sh
+. "$(dirname "${BASH_SOURCE[0]}")/lib/sandbox.sh"
+
+repo="$(new_repo rename)"
+commit_paths "$repo" "baseline" src/app.ts .agents/skills/orch/SKILL.md
+base="$(git -C "$repo" rev-parse HEAD)"
+
+mkdir -p "$repo/.agents/skills/orch"
+git -C "$repo" mv src/app.ts .agents/skills/orch/app.ts
+git -C "$repo" commit -q -m "move a product file into the render"
+
+assert_verdict "a product file moved into the render answers false" false \
+  --repo "$repo" --event push --base "$base" --head HEAD
+
+# The control: with rename detection left on, the same diff lists one path and
+# every path it lists is a render path. That is the wrong answer this flag
+# exists to prevent, so the suite pins it rather than trusting the comment.
+detected="$(git -C "$repo" diff --name-only "$base" HEAD)"
+assert_eq "rename detection alone would list only the post-image" \
+  ".agents/skills/orch/app.ts" "$detected"
+
+undetected="$(git -C "$repo" diff --name-only --no-renames "$base" HEAD | sort | tr '\n' ' ')"
+assert_eq "--no-renames lists the deletion too" \
+  ".agents/skills/orch/app.ts src/app.ts " "$undetected"
+
+# A move that stays inside the render is still render-only.
+inside_base="$(git -C "$repo" rev-parse HEAD)"
+git -C "$repo" mv .agents/skills/orch/app.ts .agents/skills/orch/renamed.ts
+git -C "$repo" commit -q -m "move inside the render"
+assert_verdict "a move within the render stays true" true \
+  --repo "$repo" --event push --base "$inside_base" --head HEAD
+
+# And a render file moved OUT to a product path is a product change.
+out_base="$(git -C "$repo" rev-parse HEAD)"
+mkdir -p "$repo/src"
+git -C "$repo" mv .agents/skills/orch/renamed.ts src/renamed.ts
+git -C "$repo" commit -q -m "move out of the render"
+assert_verdict "a move out of the render answers false" false \
+  --repo "$repo" --event push --base "$out_base" --head HEAD
+
+report rename-into-render

--- a/skills/harness-ci/tests/wiring-errors.test.sh
+++ b/skills/harness-ci/tests/wiring-errors.test.sh
@@ -43,6 +43,21 @@ wiring "--repo with no value" --event push --base "$base" --repo
 wiring "--output with no value" --repo "$repo" --event push --base "$base" --output
 wiring "an empty --head" --repo "$repo" --event push --base "$base" --head ""
 
+# A flag where a value belongs. Consuming it would classify '--base' as an
+# unrecognised event and hand back a verdict for a call that named no event.
+wiring "--event followed by another flag" --repo "$repo" --event --base "$base"
+wiring "--base followed by another flag" --repo "$repo" --event push --base --head
+wiring "--head followed by another flag" \
+  --repo "$repo" --event push --base "$base" --head --output
+wiring "--repo followed by another flag" --repo --event push --base "$base"
+wiring "--output followed by another flag" \
+  --repo "$repo" --event push --base "$base" --output --head
+
+# A lone dash and a dash-led path are values, not flags: only a flag shape
+# (a dash with something after it) is refused.
+verdict_dash="$(classify --repo "$repo" --event push --base "$base" --head "-" || true)"
+assert_eq "a lone dash is taken as a value" "harness_only=false" "$verdict_dash"
+
 # An --output the process cannot append to is wiring, not data: the caller
 # asked for a file and would otherwise get silence.
 unwritable="$SANDBOX/no-such-dir/out.txt"

--- a/skills/harness-ci/tests/wiring-errors.test.sh
+++ b/skills/harness-ci/tests/wiring-errors.test.sh
@@ -64,6 +64,16 @@ unwritable="$SANDBOX/no-such-dir/out.txt"
 wiring "an unwritable --output" \
   --repo "$repo" --event push --base "$base" --output "$unwritable"
 
+# A file that OPENS and then refuses the write. A zero-length probe passes on
+# /dev/full, so this is the case that proves the verdict reaches the file
+# before stdout rather than after. Linux only; announced when absent.
+if [ -c /dev/full ]; then
+  wiring "an --output that accepts the open and fails the write" \
+    --repo "$repo" --event push --base "$base" --output /dev/full
+else
+  echo "  SKIP: no /dev/full, the full-device case did not run"
+fi
+
 # --output appends beside stdout and keeps what the file already held.
 out_file="$SANDBOX/github_output"
 printf 'other_key=kept\n' >"$out_file"

--- a/skills/harness-ci/tests/wiring-errors.test.sh
+++ b/skills/harness-ci/tests/wiring-errors.test.sh
@@ -1,0 +1,95 @@
+#!/usr/bin/env bash
+# A wiring error is not a verdict. A bad call exits 2 with nothing on stdout,
+# so the caller's step goes red instead of quietly running every lane forever.
+# And the verdict reaches the file the caller named, beside stdout.
+set -euo pipefail
+# shellcheck source=lib/sandbox.sh
+. "$(dirname "${BASH_SOURCE[0]}")/lib/sandbox.sh"
+
+repo="$(new_repo wiring)"
+commit_paths "$repo" "baseline" README.md
+base="$(git -C "$repo" rev-parse HEAD)"
+commit_paths "$repo" "render only" .agents/skills/orch/SKILL.md
+
+# Bounded: an argument loop that fails to consume its input hangs rather than
+# exits, and a hung CI step is the failure this catches. macOS ships no
+# timeout, and the suite still runs there without the bound.
+bounded() { # ARGS...
+  if command -v timeout >/dev/null 2>&1; then
+    timeout 30 "$@"
+  else
+    "$@"
+  fi
+}
+
+wiring() { # LABEL ARGS...
+  local label="$1" out status
+  shift
+  set +e
+  out="$(bounded "$HARNESS_ONLY" "$@" 2>/dev/null)"
+  status=$?
+  set -e
+  assert_eq "$label" "exit 2 stdout=''" "exit $status stdout='$out'"
+}
+
+wiring "an unknown flag" --repo "$repo" --event push --base "$base" --nope
+wiring "a positional argument" --repo "$repo" --event push "$base"
+wiring "no --event at all" --repo "$repo" --base "$base"
+wiring "an empty --event" --repo "$repo" --event "" --base "$base"
+wiring "--event with no value" --repo "$repo" --base "$base" --event
+wiring "--base with no value" --repo "$repo" --event push --base
+wiring "--head with no value" --repo "$repo" --event push --base "$base" --head
+wiring "--repo with no value" --event push --base "$base" --repo
+wiring "--output with no value" --repo "$repo" --event push --base "$base" --output
+wiring "an empty --head" --repo "$repo" --event push --base "$base" --head ""
+
+# An --output the process cannot append to is wiring, not data: the caller
+# asked for a file and would otherwise get silence.
+unwritable="$SANDBOX/no-such-dir/out.txt"
+wiring "an unwritable --output" \
+  --repo "$repo" --event push --base "$base" --output "$unwritable"
+
+# --output appends beside stdout and keeps what the file already held.
+out_file="$SANDBOX/github_output"
+printf 'other_key=kept\n' >"$out_file"
+verdict="$("$HARNESS_ONLY" --repo "$repo" --event push --base "$base" --output "$out_file" 2>/dev/null)"
+assert_eq "--output leaves the verdict on stdout too" "harness_only=true" "$verdict"
+assert_eq "--output appends without clobbering" \
+  "other_key=kept harness_only=true" "$(tr '\n' ' ' <"$out_file" | sed -e 's/ $//')"
+
+# With no --output, the file is $GITHUB_OUTPUT — what a workflow step sets.
+env_file="$SANDBOX/env_output"
+: >"$env_file"
+GITHUB_OUTPUT="$env_file" "$HARNESS_ONLY" --repo "$repo" --event push --base "$base" >/dev/null 2>&1
+assert_eq "GITHUB_OUTPUT receives the verdict" "harness_only=true" "$(cat "$env_file")"
+
+override="$SANDBOX/override_output"
+: >"$override"
+: >"$env_file"
+GITHUB_OUTPUT="$env_file" "$HARNESS_ONLY" --repo "$repo" --event push --base "$base" \
+  --output "$override" >/dev/null 2>&1
+assert_eq "--output wins over GITHUB_OUTPUT" "harness_only=true" "$(cat "$override")"
+assert_eq "--output leaves GITHUB_OUTPUT untouched" "" "$(cat "$env_file")"
+
+# With neither, stdout is the whole contract and nothing is written anywhere.
+lone="$(env -u GITHUB_OUTPUT "$HARNESS_ONLY" --repo "$repo" --event push --base "$base" 2>/dev/null)"
+assert_eq "no output file is required" "harness_only=true" "$lone"
+
+# stdout carries the verdict line and nothing else; the changed paths are
+# stderr's, so `$(harness-only …)` is safe to read directly.
+assert_eq "stdout is the verdict line alone" "1" \
+  "$(printf '%s\n' "$lone" | wc -l | tr -d ' ')"
+paths="$("$HARNESS_ONLY" --repo "$repo" --event push --base "$base" 2>&1 >/dev/null)"
+case "$paths" in
+  *"changed: .agents/skills/orch/SKILL.md"*)
+    assert_eq "the changed paths reach stderr" pass pass ;;
+  *) assert_eq "the changed paths reach stderr" pass "$paths" ;;
+esac
+
+help_out="$("$HARNESS_ONLY" --help)"
+case "$help_out" in
+  "Usage: harness-only"*) assert_eq "--help prints the usage" pass pass ;;
+  *) assert_eq "--help prints the usage" pass "$help_out" ;;
+esac
+
+report wiring-errors

--- a/skills/harness-ci/tests/wiring-shapes.test.sh
+++ b/skills/harness-ci/tests/wiring-shapes.test.sh
@@ -41,6 +41,15 @@ for flag in $(printf '%s\n' "$blocks" | grep -oE '(^|[[:space:]])--[a-z-]+' | tr
 done
 assert_eq "the shapes pass only flags the script accepts" "" "$unknown_flags"
 
+# The push endpoints come from the event payload, with `github.sha` LAST. On a
+# branch-deletion push `github.event.after` is the all-zero sha and
+# `github.sha` is the default branch tip, so a HEAD expression reaching
+# `github.sha` before `after` would hand the classifier two real commits.
+heads="$(printf '%s\n' "$blocks" | grep -F 'HEAD:' || true)"
+assert_eq "the shapes carry a HEAD expression" "3" "$(printf '%s\n' "$heads" | grep -c 'HEAD:')"
+misordered="$(printf '%s\n' "$heads" | grep -vE 'github\.event\.after[^|]*\|\|[^|]*github\.sha' || true)"
+assert_eq "every HEAD expression tries github.event.after before github.sha" "" "$misordered"
+
 # The parser is a REQUIREMENT, not a convenience. Announcing a skip and then
 # reporting the suite green is the fail-open this file exists to close: the
 # check that catches a malformed block is the one that would not have run.

--- a/skills/harness-ci/tests/wiring-shapes.test.sh
+++ b/skills/harness-ci/tests/wiring-shapes.test.sh
@@ -41,10 +41,15 @@ for flag in $(printf '%s\n' "$blocks" | grep -oE '(^|[[:space:]])--[a-z-]+' | tr
 done
 assert_eq "the shapes pass only flags the script accepts" "" "$unknown_flags"
 
-# Parse the blocks when PyYAML is on the runner; skipping is announced rather
-# than silent, so a missing dependency never reads as a pass.
-if python3 -c 'import yaml' 2>/dev/null; then
-  parsed="$(python3 - "$WIRING" <<'PY'
+# The parser is a REQUIREMENT, not a convenience. Announcing a skip and then
+# reporting the suite green is the fail-open this file exists to close: the
+# check that catches a malformed block is the one that would not have run.
+if ! python3 -c 'import yaml' 2>/dev/null; then
+  echo "harness-ci wiring-shapes needs python3 with PyYAML (pip install pyyaml)" >&2
+  exit 1
+fi
+
+parsed="$(python3 - "$WIRING" <<'PY'
 import re, sys, yaml
 src = open(sys.argv[1]).read()
 for i, block in enumerate(re.findall(r"```yaml\n(.*?)```", src, re.S), 1):
@@ -57,9 +62,6 @@ for i, block in enumerate(re.findall(r"```yaml\n(.*?)```", src, re.S), 1):
 print("ok")
 PY
 )"
-  assert_eq "every shape parses as YAML" "ok" "$parsed"
-else
-  echo "  SKIP: PyYAML absent, the parse check did not run"
-fi
+assert_eq "every shape parses as YAML" "ok" "$parsed"
 
 report wiring-shapes

--- a/skills/harness-ci/tests/wiring-shapes.test.sh
+++ b/skills/harness-ci/tests/wiring-shapes.test.sh
@@ -1,0 +1,65 @@
+#!/usr/bin/env bash
+# The wiring shapes are the deliverable a consumer copies, so they are checked
+# rather than trusted: every workflow expression stays on one line, and the
+# script path they name is the path this package ships.
+set -euo pipefail
+# shellcheck source=lib/sandbox.sh
+. "$(dirname "${BASH_SOURCE[0]}")/lib/sandbox.sh"
+
+WIRING="$TEST_DIR/../references/wiring.md"
+[ -f "$WIRING" ] || { echo "missing $WIRING" >&2; exit 1; }
+
+# Only the fenced yaml blocks, with the fences dropped.
+yaml_lines() {
+  awk '/^```yaml$/ { inblock = 1; next } /^```$/ { inblock = 0; next } inblock' "$WIRING"
+}
+
+blocks="$(yaml_lines)"
+[ -n "$blocks" ] || { echo "no yaml blocks found in $WIRING" >&2; exit 1; }
+
+# A folded scalar whose continuations are indented past its first line keeps
+# the newlines instead of folding them, turning a wrapped expression into a
+# multi-line one. One line per expression removes the trap outright.
+unclosed="$(printf '%s\n' "$blocks" | grep -F '${{' | grep -vF '}}' || true)"
+assert_eq "every workflow expression closes on its own line" "" "$unclosed"
+
+# The path the shapes tell a consumer to run is the path this package ships.
+# EVERY citation, not only the ones already ending in the script's name: a
+# rename that reached one call site and not the rest has to fail here.
+cited="$(printf '%s\n' "$blocks" | grep -oE '\.agents/skills/[A-Za-z0-9_/.-]+' | sort -u)"
+assert_eq "the shapes name one script path" ".agents/skills/harness-ci/scripts/harness-only" "$cited"
+assert_eq "that path is the one this package ships" "yes" \
+  "$([ -x "$TEST_DIR/../scripts/harness-only" ] && echo yes || echo no)"
+
+# Every flag the shapes pass is one the script accepts.
+unknown_flags=""
+for flag in $(printf '%s\n' "$blocks" | grep -oE '(^|[[:space:]])--[a-z-]+' | tr -d ' ' | sort -u); do
+  case "$flag" in
+    --event | --base | --head | --repo | --output) ;;
+    *) unknown_flags="$unknown_flags $flag" ;;
+  esac
+done
+assert_eq "the shapes pass only flags the script accepts" "" "$unknown_flags"
+
+# Parse the blocks when PyYAML is on the runner; skipping is announced rather
+# than silent, so a missing dependency never reads as a pass.
+if python3 -c 'import yaml' 2>/dev/null; then
+  parsed="$(python3 - "$WIRING" <<'PY'
+import re, sys, yaml
+src = open(sys.argv[1]).read()
+for i, block in enumerate(re.findall(r"```yaml\n(.*?)```", src, re.S), 1):
+    body = block if block.lstrip().startswith(("env:", "jobs:")) else "jobs:\n" + block
+    try:
+        yaml.safe_load(body)
+    except Exception as exc:
+        print(f"block {i}: {exc}")
+        sys.exit(0)
+print("ok")
+PY
+)"
+  assert_eq "every shape parses as YAML" "ok" "$parsed"
+else
+  echo "  SKIP: PyYAML absent, the parse check did not run"
+fi
+
+report wiring-shapes

--- a/skills/harness-ci/tests/wiring-shapes.test.sh
+++ b/skills/harness-ci/tests/wiring-shapes.test.sh
@@ -50,27 +50,17 @@ assert_eq "the shapes carry a HEAD expression" "3" "$(printf '%s\n' "$heads" | g
 misordered="$(printf '%s\n' "$heads" | grep -vE 'github\.event\.after[^|]*\|\|[^|]*github\.sha' || true)"
 assert_eq "every HEAD expression tries github.event.after before github.sha" "" "$misordered"
 
-# The parser is a REQUIREMENT, not a convenience. Announcing a skip and then
-# reporting the suite green is the fail-open this file exists to close: the
-# check that catches a malformed block is the one that would not have run.
-if ! python3 -c 'import yaml' 2>/dev/null; then
-  echo "harness-ci wiring-shapes needs python3 with PyYAML (pip install pyyaml)" >&2
-  exit 1
-fi
-
-parsed="$(python3 - "$WIRING" <<'PY'
-import re, sys, yaml
-src = open(sys.argv[1]).read()
-for i, block in enumerate(re.findall(r"```yaml\n(.*?)```", src, re.S), 1):
-    body = block if block.lstrip().startswith(("env:", "jobs:")) else "jobs:\n" + block
-    try:
-        yaml.safe_load(body)
-    except Exception as exc:
-        print(f"block {i}: {exc}")
-        sys.exit(0)
-print("ok")
-PY
-)"
-assert_eq "every shape parses as YAML" "ok" "$parsed"
+# Indentation is checked structurally rather than by parsing: every block here
+# steps by two spaces, so an odd indent or a tab is hand-edit damage. This
+# needs no YAML library, which the shell shard does not install and this suite
+# must not depend on being there — a check that cannot run must not be the
+# difference between a green suite and a red one. What it does NOT prove is
+# that a block is valid YAML; a malformed one fails at the copier's first
+# workflow run, loudly, which is not the fail-closed concern this file guards.
+TAB="$(printf '\t')"
+odd="$(printf '%s\n' "$blocks" | grep -nE '^( {2})* [^ ]' || true)"
+assert_eq "every block line steps by two spaces" "" "$odd"
+tabbed="$(printf '%s\n' "$blocks" | grep -nE "^ *$TAB" || true)"
+assert_eq "no block line indents with a tab" "" "$tabbed"
 
 report wiring-shapes


### PR DESCRIPTION
Phase 1 of KEN-672. Six repos each grew their own copy of one function — is this diff nothing but kendex render output, so the heavy lanes may stand down — differing only in CI shape, each carrying its own proof suite for semantics that belong in one place. This is that place.

## What ships

`skills/harness-ci`, an optional package in no bundle:

- **`scripts/harness-only`** — event kind and diff endpoints in, `harness_only=true|false` out. The harness path set is `.agents/`, `.claude/`, `.codex/`, `.opencode/`, `.cursor/`, `.pi/` and the root `opencode.json`. `--no-renames` always; merge base on `pull_request`; two endpoints on `push` and `merge_group`. `stdout` carries the verdict line alone, `stderr` the changed paths and the reason behind a `false`, and `--output` (default `$GITHUB_OUTPUT`) appends the same line for a step output.
- **`tests/`** — six suites, picked up by the existing `skills/*/tests/*.sh` glob in the skill-tests shard, so the semantics are proven upstream on every change to this repo.
- **`README.md`** — the consumer contract. **`references/wiring.md`** — the three workflow shapes to copy.
- A CHANGELOG entry under Unreleased → Added.

## The two design points

**Fail-closed, with no flag that turns it off.** An unclassified event, a missing or unresolvable endpoint (the all-zero sha a first push sends included), a diff git cannot read, an empty changed-file set, and a path git had to quote all answer `false`, which runs every lane. Exit 0 accompanies every verdict; exit 2 is a wiring error (unknown flag, missing `--event`, unwritable `--output`) and prints no verdict, turning the step red rather than passing a guess off as a classification.

**The package never touches `.github/`.** A package that installed itself into a stranger's CI would rename jobs, drop required contexts and wedge merge queues. What a consumer owns is one thin step calling the rendered script; what upstream owns is the answer that step gets. `references/wiring.md` also carries the two merge-queue rules — classify inside a job rather than in `on.<event>.paths`, and keep the job carrying the required name unconditional.

Optional and unbundled is deliberate: running CI over harness directories is a policy choice, and a repo that wants it installs nothing. Registration is the ordinary one — the catalog discovers `skills/`, and membership in a bundle or a role mapping is what would make it non-optional.

## Test coverage

| Suite | Covers |
| --- | --- |
| `path-set` | Every render tree, mixed diffs, a product deletion, and the near misses — `.agentsfoo/`, `.agents-old/`, `opencode.json.bak`, `ui/opencode.json`, a bare `.agents` file |
| `rename-into-render` | `git mv src/app.ts .agents/…` answers `false`, plus the control pinning that rename detection alone would list only the post-image |
| `event-ranges` | The force-push that discards product work, a base branch moving under an open PR, merge groups, the `--head` default |
| `fail-closed` | Unclassified events, empty/all-zero/non-commit endpoints, a `--repo` that is not a checkout, an empty diff, a checkout with no commits |
| `wiring-errors` | Exit 2 with an empty stdout on every bad call, `--output` vs `$GITHUB_OUTPUT` precedence, the stdout/stderr split |
| `bash32-portability` | No Bash 4+ syntax; consumer runners include macOS system Bash |

Locally: all six suites green, `tools/guard` green, preflight clean, `kendex check --catalog .` reports 0 breakage and 0 advisory with the skill scoring 100/100.

## Scope

Adoption of the six CI repos and deletion of their hand-rolled classifiers and per-repo proof suites is the rest of KEN-672, one PR per repo, after this lands. Nothing in this PR touches a consumer.

https://claude.ai/code/session_01AKPnSfnhWv6xoPcUSU8Vgw
