### PR TITLE
fix(harness-ci): the wiring guide covers a lane with a second gate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ an outside contributor.
 
 ### Fixed
 
+- The `harness-ci` wiring guide covers a lane that reads a path family beside
+  the render verdict; the single-gate condition it shipped skipped that lane
+  whenever the classifying job died.
 - Agents no longer promise a `{{KENDEX_FAILURE_REF}}` that nothing defines:
   the failure-routing line now points at `kendex report --help`.
 - OpenCode, Gemini, and Copilot agent renders list required skills at

--- a/skills/harness-ci/SKILL.md
+++ b/skills/harness-ci/SKILL.md
@@ -59,6 +59,12 @@ which stands the expensive lanes down on exactly the diffs nothing classified.
 An aggregate accepts a `skipped` lane only after checking that the classifier
 ran and cleared the diff.
 
+**A lane reading a path family beside the verdict needs more than the status
+function.** A dead classifying job publishes no outputs, so the family term
+reads empty and skips the lane on its own. Lift it behind
+`needs.changes.result != 'success'` — the two-gate shape in
+[references/wiring.md](references/wiring.md).
+
 ## Reading a verdict
 
 `stdout` carries the verdict line alone, so `$(harness-only …)` is safe to

--- a/skills/harness-ci/references/wiring.md
+++ b/skills/harness-ci/references/wiring.md
@@ -74,6 +74,35 @@ function keeps the implicit `success()`, so a plain
 the expensive lanes down rather than run them. `!cancelled()` lifts that, and
 the lane then skips on one condition only: the classifier ran and said `true`.
 
+### When the lane has a SECOND gate
+
+The condition above is complete only where the harness verdict is the lane's
+ONLY gate. A repo whose lanes also read a path family — `needs.changes.outputs.
+frontend == 'true'`, a `rust` flag, a `docs` flag — needs a different shape,
+and the one above silently fails open there:
+
+```yaml
+  # WRONG when a family predicate is present
+  if: ${{ !cancelled() && needs.changes.outputs.frontend == 'true' && !(needs.changes.result == 'success' && needs.changes.outputs.harness_only == 'true') }}
+```
+
+A `changes` job that died publishes NO outputs, so `frontend` reads as an
+empty string, the `== 'true'` term is false, and the lane skips exactly when
+nothing classified it. `!cancelled()` cannot lift that — it is the family term
+failing, not the implicit `success()`.
+
+Lift the family term behind the job's result instead:
+
+```yaml
+  # RIGHT: a dead classifier runs the lane, whatever the family says
+  if: ${{ !cancelled() && (needs.changes.result != 'success' || (needs.changes.outputs.frontend == 'true' && needs.changes.outputs.harness_only != 'true')) }}
+```
+
+Read it as: never on a cancelled run; otherwise run whenever the
+classification is missing, and skip only when it arrived and cleared the lane.
+An event term (`github.event_name == 'merge_group'`) stays outside the
+parentheses — it is a tier decision, not a classification.
+
 ## Shape 2 — a step inside an aggregate job
 
 For workflows that already run one job and gate the expensive tail of it.

--- a/skills/harness-ci/tests/wiring-shapes.test.sh
+++ b/skills/harness-ci/tests/wiring-shapes.test.sh
@@ -53,15 +53,31 @@ assert_eq "every HEAD expression tries github.event.after before github.sha" "" 
 # Both lane-condition variants ship, and the one that fails open is labelled
 # as such. A reader who finds only the single-gate form wires it into a lane
 # that also reads a path family and gets a silent skip — the shape memsira hit.
+#
+# Pinned WHOLE, not by prefix or by the comment label beside them. These two
+# lines are the deliverable: a reader copies one and must not copy the other,
+# so a character changed anywhere in either is a different condition, and an
+# assertion that stops at `!= 'success' ||` would not see it.
 doc="$(cat "$WIRING")"
 case "$doc" in
   *"SECOND gate"*) ;;
   *) assert_eq "the two-gate variant is documented" "present" "absent" ;;
 esac
-assert_eq "the two-gate form is spelled out" 1 \
-  "$(printf '%s\n' "$doc" | grep -cF "needs.changes.result != 'success' ||")"
-assert_eq "the fail-open form is labelled WRONG" 1 \
-  "$(printf '%s\n' "$doc" | grep -cF '# WRONG when a family predicate is present')"
+
+wrong_if="  if: \${{ !cancelled() && needs.changes.outputs.frontend == 'true' && !(needs.changes.result == 'success' && needs.changes.outputs.harness_only == 'true') }}"
+right_if="  if: \${{ !cancelled() && (needs.changes.result != 'success' || (needs.changes.outputs.frontend == 'true' && needs.changes.outputs.harness_only != 'true')) }}"
+
+assert_eq "the fail-open form is shown verbatim, exactly once" 1 \
+  "$(printf '%s\n' "$doc" | grep -cxF "$wrong_if")"
+assert_eq "the working form is shown verbatim, exactly once" 1 \
+  "$(printf '%s\n' "$doc" | grep -cxF "$right_if")"
+
+# The label has to stay ON the fail-open block. Both lines are legal YAML and
+# a reader tells them apart by that comment alone, so its position is part of
+# what is pinned, not just its presence somewhere in the file.
+assert_eq "the WRONG label sits on the line above the fail-open form" \
+  "  # WRONG when a family predicate is present" \
+  "$(printf '%s\n' "$doc" | grep -B1 -xF "$wrong_if" | head -1)"
 
 # Indentation is checked structurally rather than by parsing: every block here
 # steps by two spaces, so an odd indent or a tab is hand-edit damage. This

--- a/skills/harness-ci/tests/wiring-shapes.test.sh
+++ b/skills/harness-ci/tests/wiring-shapes.test.sh
@@ -50,6 +50,19 @@ assert_eq "the shapes carry a HEAD expression" "3" "$(printf '%s\n' "$heads" | g
 misordered="$(printf '%s\n' "$heads" | grep -vE 'github\.event\.after[^|]*\|\|[^|]*github\.sha' || true)"
 assert_eq "every HEAD expression tries github.event.after before github.sha" "" "$misordered"
 
+# Both lane-condition variants ship, and the one that fails open is labelled
+# as such. A reader who finds only the single-gate form wires it into a lane
+# that also reads a path family and gets a silent skip — the shape memsira hit.
+doc="$(cat "$WIRING")"
+case "$doc" in
+  *"SECOND gate"*) ;;
+  *) assert_eq "the two-gate variant is documented" "present" "absent" ;;
+esac
+assert_eq "the two-gate form is spelled out" 1 \
+  "$(printf '%s\n' "$doc" | grep -cF "needs.changes.result != 'success' ||")"
+assert_eq "the fail-open form is labelled WRONG" 1 \
+  "$(printf '%s\n' "$doc" | grep -cF '# WRONG when a family predicate is present')"
+
 # Indentation is checked structurally rather than by parsing: every block here
 # steps by two spaces, so an odd indent or a tab is hand-edit damage. This
 # needs no YAML library, which the shell shard does not install and this suite


### PR DESCRIPTION
Closes KEN-677. The package shipped one job-level lane condition:

```yaml
if: ${{ !cancelled() && !(needs.changes.result == 'success' && needs.changes.outputs.harness_only == 'true') }}
```

That is complete only where the harness verdict is the lane's **only** gate — true for vg and hyprtrade-io. A repo whose lanes also read a path family gets a silent skip from it: a classifying job that died publishes no outputs, the family term reads empty, and the lane stands down on exactly the diff nothing classified. `!cancelled()` cannot lift that, because it is the family term failing, not the implicit `success()`.

**memsira followed this guide verbatim into that hole**, on lanes feeding a required context, where a skipped check satisfies the ruleset. Caught in review on memsira#497 and fixed there; this is the upstream half, so the next repo does not repeat it.

## What changed

- `references/wiring.md` gains a **When the lane has a SECOND gate** section: the fail-open form shown and labelled `# WRONG when a family predicate is present`, beside the working one, with the reading spelled out — never on a cancelled run, otherwise run whenever the classification is missing, and skip only when it arrived and cleared the lane. An event term stays outside the parentheses, since a tier decision is not a classification.
- `SKILL.md`'s rules section gains the pointer. The rule already there — *a job-level `if:` needs a status function* — is exactly what a reader follows into this, so leaving it alone would have been the trap.
- `wiring-shapes` pins both forms and the WRONG label. Planted defects confirm it catches the label going away and the working form being altered.

## Verification

All six harness-ci suites green, `tools/guard` clean, preflight clean, `kendex check --catalog .` at 0 breakage / 0 advisory with the skill scoring 100/100.

Consumer state: memsira#497 already runs the two-gate form; vg#44 and hyprtrade-io#69 are single-gate and unaffected.

https://claude.ai/code/session_01AKPnSfnhWv6xoPcUSU8Vgw