### PR TITLE
docs(skills): a description is a load trigger, nothing else

### DIFF
--- a/.agents/skills/app-deploy/SKILL.md
+++ b/.agents/skills/app-deploy/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: app-deploy
-description: Release a new kendex version — bump versions, finalize the changelog, tag per docs/RELEASING.md. Use when asked to cut, ship, or release a version.
+description: "Load when asked to cut, ship, or release a kendex version."
 ---
 
 # Release kendex

--- a/.agents/skills/code-quality/SKILL.md
+++ b/.agents/skills/code-quality/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: code-quality
-description: "Generic code-authoring standards for dev agents: correctness over convenience, no fail-open branches, comment rules, over-engineering limits, prove-your-guards. Load before writing or modifying code."
+description: "Load before writing or modifying code."
 license: MIT
 user-invocable: true
 metadata:

--- a/.agents/skills/decider/SKILL.md
+++ b/.agents/skills/decider/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: decider
-description: "Architecture Decision Record (ADR) and architectural decision document management: templates, creation, search, supersession tracking, and INDEX maintenance."
+description: "Load to create, search, or supersede an architecture decision record."
 license: MIT
 user-invocable: true
 metadata:

--- a/.agents/skills/deep-research/SKILL.md
+++ b/.agents/skills/deep-research/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: deep-research
-description: "Exa-powered deep research producing an evidence-backed findings.md report. Load for research tasks, architectural investigations, and vendor, library, or technology comparisons."
+description: "Load for research tasks, architectural investigations, and vendor, library, or technology comparisons."
 license: MIT
 user-invocable: true
 argument-hint: "report [query] --output findings.md"

--- a/.agents/skills/dep-radar/SKILL.md
+++ b/.agents/skills/dep-radar/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: dep-radar
-description: "Sweeps every pinned version in the repo — deps, SDKs, vendored forks, model weights — checks upstream, and lands upgrades with their fallout in one PR per surface. Load to run or tune a dependency sweep."
+description: "Load to run or tune a dependency sweep."
 license: MIT
 user-invocable: true
 dependencies:

--- a/.agents/skills/dev/SKILL.md
+++ b/.agents/skills/dev/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: dev
-description: "Dev-agent workflows for issue implementation and review-fix delegation, invoked by orch or specialist agents."
+description: "Load when implementing an issue or applying review fixes as a dev agent."
 license: MIT
 user-invocable: true
 dependencies:

--- a/.agents/skills/github/SKILL.md
+++ b/.agents/skills/github/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: github
-description: "GitHub API CLI for PR operations: threads, comments, reviews, CI logs, merging, and cross-PR analysis."
+description: "Load to work a GitHub pull request: threads, comments, reviews, CI logs, merges."
 license: MIT
 user-invocable: true
 metadata:

--- a/.agents/skills/iced-rs/SKILL.md
+++ b/.agents/skills/iced-rs/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: iced-rs
-description: "Iced 0.14 GUI expert: custom widgets via iced::advanced, overlays, Canvas, Shader, pane_grid, theming, subscriptions, Elm architecture, with a bundled full-API reference. Load whenever building or debugging an Iced UI."
+description: "Load whenever building or debugging an Iced UI."
 license: MIT
 user-invocable: true
 metadata:

--- a/.agents/skills/kendex-issues/SKILL.md
+++ b/.agents/skills/kendex-issues/SKILL.md
@@ -1,11 +1,6 @@
 ---
 name: kendex-issues
-description: >
-  Steward the vanillagreencom/kendex issue queue on a self-paced loop: watch
-  open PRs, poll Linear (team KEN), triage, fix genuine kendex defects through
-  the orch skill, merge, propagate with kendex refresh, reschedule. A thin
-  wrapper over orch, github, review-gate and linear. Use when asked to monitor
-  kendex's issues continuously or to run one fix-and-propagate cycle.
+description: "Load to monitor kendex's issue queue continuously or to run one fix-and-propagate cycle."
 ---
 
 # kendex Issue Steward

--- a/.agents/skills/linear/SKILL.md
+++ b/.agents/skills/linear/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: linear
-description: "Bash CLI over Linear's GraphQL API with a local cache. Load for ANY Linear interaction: reading, searching, creating, or updating an issue, project, cycle, milestone, initiative, or label."
+description: "Load for any Linear read or write: issues, projects, cycles, milestones, initiatives, labels."
 license: MIT
 user-invocable: true
 metadata:

--- a/.agents/skills/orch/SKILL.md
+++ b/.agents/skills/orch/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: orch
-description: "PRIMARY AGENT ONLY — work-item orchestration for Linear or GitHub issues: prepare, delegate implementation, review, submit, merge, hand off, and oversee fleets of sessions."
+description: "PRIMARY AGENT ONLY. Load to orchestrate a Linear or GitHub work item from preparation through merge."
 license: MIT
 user-invocable: true
 dependencies:

--- a/.agents/skills/preflight/SKILL.md
+++ b/.agents/skills/preflight/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: preflight
-description: "Diff-scoped deterministic pre-review checks: shell parse/shellcheck errors, fail-open bash, unwired test suites, untrapped scratch dirs, directory creation at hardcoded temp paths, dead path citations, TODO markers, bot attributions, malformed JSON/TOML/workflows. Load to run, tune, or debug preflight."
+description: "Load to run, tune, or debug preflight."
 license: MIT
 user-invocable: true
 metadata:

--- a/.agents/skills/price-handling/SKILL.md
+++ b/.agents/skills/price-handling/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: price-handling
-description: "f64 price patterns for trading systems. Load when: comparing prices, rounding to tick size, formatting for display/broker APIs, parsing market feeds, designing price types or SymbolSpec structs."
+description: "Load when comparing, rounding, formatting, or parsing prices, or designing price types."
 license: MIT
 user-invocable: true
 metadata:

--- a/.agents/skills/project-management/SKILL.md
+++ b/.agents/skills/project-management/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: project-management
-description: "TPM-orchestrated planning, audit, roadmap, and research-driven decomposition. Owns the user-facing wrappers (cycle-plan, audit-issues, roadmap-*, research-*) and the underlying TPM execution workflows."
+description: "Load to plan a cycle, audit issues, build a roadmap, or decompose research into issues."
 license: MIT
 user-invocable: true
 dependencies:

--- a/.agents/skills/review-gate/SKILL.md
+++ b/.agents/skills/review-gate/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: review-gate
-description: "Org-wide PR review gate: one predicate answers 'is this exact head reviewed?', one writer posts the answer as a merge-blocking commit status. Load to wire, adopt, tune, or debug a repo's gate or its REVIEW_GATE_* settings."
+description: "Load to wire, adopt, tune, or debug a repo's review gate or its REVIEW_GATE_* settings."
 license: MIT
 user-invocable: true
 metadata:

--- a/.agents/skills/reviewer/SKILL.md
+++ b/.agents/skills/reviewer/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: reviewer
-description: "Strict review and QA workflows: reviewer ethos, code-review classification, the finding JSON schema, and the QA-label lifecycle. Load when reviewing a diff, classifying findings, or returning a verdict."
+description: "Load when reviewing a diff, classifying findings, or returning a verdict."
 license: MIT
 user-invocable: true
 dependencies:

--- a/.agents/skills/second-opinion/SKILL.md
+++ b/.agents/skills/second-opinion/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: second-opinion
-description: "Cross-model second opinion: review, challenge, audit, and consult via an external AI CLI (Claude ↔ Codex)."
+description: "Load for a cross-model review, challenge, audit, or quick consult."
 license: MIT
 user-invocable: true
 argument-hint: "review [scope] | challenge [description] | audit [path] | quick [question]"

--- a/.agents/skills/size-ratchet/SKILL.md
+++ b/.agents/skills/size-ratchet/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: size-ratchet
-description: "Tighten-only file-size gate: tracked files over their threshold (default 400, per-class via SIZE_RATCHET_CLASSES) are frozen in a baseline TSV that only moves down. Load to add, tune, or debug the ratchet, its baseline, or SIZE_RATCHET_* settings."
+description: "Load to add, tune, or debug the size ratchet, its baseline, or SIZE_RATCHET_* settings."
 license: MIT
 user-invocable: true
 metadata:

--- a/.agents/skills/worktree/SKILL.md
+++ b/.agents/skills/worktree/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: worktree
-description: "Git worktree management: create, list, remove isolated working copies with env/config symlinks."
+description: "Load to create, list, remove, push, or repair a git worktree."
 license: MIT
 user-invocable: true
 argument-hint: "create <ID> [--base <branch>] [--from <ref>] [--pr <N>] [--reuse|--restack|--recover-local] [--replay] | restack continue|skip|abort <ID|path> | list | remove <ID|path>"

--- a/.kendex-local/skills/app-deploy/SKILL.md
+++ b/.kendex-local/skills/app-deploy/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: app-deploy
-description: Release a new kendex version — bump versions, finalize the changelog, tag per docs/RELEASING.md. Use when asked to cut, ship, or release a version.
+description: "Load when asked to cut, ship, or release a kendex version."
 ---
 
 # Release kendex

--- a/.kendex-local/skills/kendex-issues/SKILL.md
+++ b/.kendex-local/skills/kendex-issues/SKILL.md
@@ -1,11 +1,6 @@
 ---
 name: kendex-issues
-description: >
-  Steward the vanillagreencom/kendex issue queue on a self-paced loop: watch
-  open PRs, poll Linear (team KEN), triage, fix genuine kendex defects through
-  the orch skill, merge, propagate with kendex refresh, reschedule. A thin
-  wrapper over orch, github, review-gate and linear. Use when asked to monitor
-  kendex's issues continuously or to run one fix-and-propagate cycle.
+description: "Load to monitor kendex's issue queue continuously or to run one fix-and-propagate cycle."
 ---
 
 # kendex Issue Steward

--- a/skills/code-quality/SKILL.md
+++ b/skills/code-quality/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: code-quality
-description: "Generic code-authoring standards for dev agents: correctness over convenience, no fail-open branches, comment rules, over-engineering limits, prove-your-guards. Load before writing or modifying code."
+description: "Load before writing or modifying code."
 license: MIT
 user-invocable: true
 metadata:

--- a/skills/decider/SKILL.md
+++ b/skills/decider/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: decider
-description: "Architecture Decision Record (ADR) and architectural decision document management: templates, creation, search, supersession tracking, and INDEX maintenance."
+description: "Load to create, search, or supersede an architecture decision record."
 license: MIT
 user-invocable: true
 metadata:

--- a/skills/deep-research/SKILL.md
+++ b/skills/deep-research/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: deep-research
-description: "Exa-powered deep research producing an evidence-backed findings.md report. Load for research tasks, architectural investigations, and vendor, library, or technology comparisons."
+description: "Load for research tasks, architectural investigations, and vendor, library, or technology comparisons."
 license: MIT
 user-invocable: true
 argument-hint: "report [query] --output findings.md"

--- a/skills/dep-radar/SKILL.md
+++ b/skills/dep-radar/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: dep-radar
-description: "Sweeps every pinned version in the repo — deps, SDKs, vendored forks, model weights — checks upstream, and lands upgrades with their fallout in one PR per surface. Load to run or tune a dependency sweep."
+description: "Load to run or tune a dependency sweep."
 license: MIT
 user-invocable: true
 dependencies:

--- a/skills/dev/SKILL.md
+++ b/skills/dev/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: dev
-description: "Dev-agent workflows for issue implementation and review-fix delegation, invoked by orch or specialist agents."
+description: "Load when implementing an issue or applying review fixes as a dev agent."
 license: MIT
 user-invocable: true
 dependencies:

--- a/skills/github/SKILL.md
+++ b/skills/github/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: github
-description: "GitHub API CLI for PR operations: threads, comments, reviews, CI logs, merging, and cross-PR analysis."
+description: "Load to work a GitHub pull request: threads, comments, reviews, CI logs, merges."
 license: MIT
 user-invocable: true
 metadata:

--- a/skills/growth-guards/SKILL.md
+++ b/skills/growth-guards/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: growth-guards
-description: "Five repo growth guards beside size-ratchet — todo-ban, byte-ceiling, suppression-ban, conflict-markers, commit-msg — and the git hook shims that run them. Load to add, tune, or debug a check, the hooks, or GROWTH_GUARDS_* settings."
+description: "Load to add, tune, or debug a repo growth guard, its git hooks, or GROWTH_GUARDS_* settings."
 license: MIT
 user-invocable: true
 metadata:

--- a/skills/harness-ci/SKILL.md
+++ b/skills/harness-ci/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: harness-ci
-description: "Classifies a CI diff as harness-only — every changed path under the kendex render trees (.agents, .claude, .codex, .opencode, .cursor, .pi, opencode.json or opencode.jsonc) — so heavy lanes can stand down. Ships the classifier script and its tests; the workflow wiring stays the consumer's. Load to wire, tune, or debug a repo's harness-only skip."
+description: "Load to wire, tune, or debug a repo's harness-only skip."
 license: MIT
 user-invocable: true
 metadata:

--- a/skills/iced-rs/SKILL.md
+++ b/skills/iced-rs/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: iced-rs
-description: "Iced 0.14 GUI expert: custom widgets via iced::advanced, overlays, Canvas, Shader, pane_grid, theming, subscriptions, Elm architecture, with a bundled full-API reference. Load whenever building or debugging an Iced UI."
+description: "Load whenever building or debugging an Iced UI."
 license: MIT
 user-invocable: true
 metadata:

--- a/skills/linear/SKILL.md
+++ b/skills/linear/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: linear
-description: "Bash CLI over Linear's GraphQL API with a local cache. Load for ANY Linear interaction: reading, searching, creating, or updating an issue, project, cycle, milestone, initiative, or label."
+description: "Load for any Linear read or write: issues, projects, cycles, milestones, initiatives, labels."
 license: MIT
 user-invocable: true
 metadata:

--- a/skills/orch/SKILL.md
+++ b/skills/orch/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: orch
-description: "PRIMARY AGENT ONLY — work-item orchestration for Linear or GitHub issues: prepare, delegate implementation, review, submit, merge, hand off, and oversee fleets of sessions."
+description: "PRIMARY AGENT ONLY. Load to orchestrate a Linear or GitHub work item from preparation through merge."
 license: MIT
 user-invocable: true
 dependencies:

--- a/skills/preflight/SKILL.md
+++ b/skills/preflight/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: preflight
-description: "Diff-scoped deterministic pre-review checks: shell parse/shellcheck errors, fail-open bash, unwired test suites, untrapped scratch dirs, directory creation at hardcoded temp paths, dead path citations, TODO markers, bot attributions, malformed JSON/TOML/workflows. Load to run, tune, or debug preflight."
+description: "Load to run, tune, or debug preflight."
 license: MIT
 user-invocable: true
 metadata:

--- a/skills/price-handling/SKILL.md
+++ b/skills/price-handling/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: price-handling
-description: "f64 price patterns for trading systems. Load when: comparing prices, rounding to tick size, formatting for display/broker APIs, parsing market feeds, designing price types or SymbolSpec structs."
+description: "Load when comparing, rounding, formatting, or parsing prices, or designing price types."
 license: MIT
 user-invocable: true
 metadata:

--- a/skills/project-management/SKILL.md
+++ b/skills/project-management/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: project-management
-description: "TPM-orchestrated planning, audit, roadmap, and research-driven decomposition. Owns the user-facing wrappers (cycle-plan, audit-issues, roadmap-*, research-*) and the underlying TPM execution workflows."
+description: "Load to plan a cycle, audit issues, build a roadmap, or decompose research into issues."
 license: MIT
 user-invocable: true
 dependencies:

--- a/skills/review-gate/SKILL.md
+++ b/skills/review-gate/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: review-gate
-description: "Org-wide PR review gate: one predicate answers 'is this exact head reviewed?', one writer posts the answer as a merge-blocking commit status. Load to wire, adopt, tune, or debug a repo's gate or its REVIEW_GATE_* settings."
+description: "Load to wire, adopt, tune, or debug a repo's review gate or its REVIEW_GATE_* settings."
 license: MIT
 user-invocable: true
 metadata:

--- a/skills/reviewer/SKILL.md
+++ b/skills/reviewer/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: reviewer
-description: "Strict review and QA workflows: reviewer ethos, code-review classification, the finding JSON schema, and the QA-label lifecycle. Load when reviewing a diff, classifying findings, or returning a verdict."
+description: "Load when reviewing a diff, classifying findings, or returning a verdict."
 license: MIT
 user-invocable: true
 dependencies:

--- a/skills/second-opinion/SKILL.md
+++ b/skills/second-opinion/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: second-opinion
-description: "Cross-model second opinion: review, challenge, audit, and consult via an external AI CLI (Claude ↔ Codex)."
+description: "Load for a cross-model review, challenge, audit, or quick consult."
 license: MIT
 user-invocable: true
 argument-hint: "review [scope] | challenge [description] | audit [path] | quick [question]"

--- a/skills/size-ratchet/SKILL.md
+++ b/skills/size-ratchet/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: size-ratchet
-description: "Tighten-only file-size gate: tracked files over their threshold (default 400, per-class via SIZE_RATCHET_CLASSES) are frozen in a baseline TSV that only moves down. Load to add, tune, or debug the ratchet, its baseline, or SIZE_RATCHET_* settings."
+description: "Load to add, tune, or debug the size ratchet, its baseline, or SIZE_RATCHET_* settings."
 license: MIT
 user-invocable: true
 metadata:

--- a/skills/worktree/SKILL.md
+++ b/skills/worktree/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: worktree
-description: "Git worktree management: create, list, remove isolated working copies with env/config symlinks."
+description: "Load to create, list, remove, push, or repair a git worktree."
 license: MIT
 user-invocable: true
 argument-hint: "create <ID> [--base <branch>] [--from <ref>] [--pr <N>] [--reuse|--restack|--recover-local] [--replay] | restack continue|skip|abort <ID|path> | list | remove <ID|path>"


### PR DESCRIPTION
A skill's `description:` is the only text an agent reads before deciding
whether to open the skill. Content summaries there cost tokens at exactly
the moment they cannot be acted on. Every description is now one short
sentence naming when to load.

| Skill | Description |
|---|---|
| code-quality | Load before writing or modifying code. |
| decider | Load to create, search, or supersede an architecture decision record. |
| deep-research | Load for research tasks, architectural investigations, and vendor, library, or technology comparisons. |
| dep-radar | Load to run or tune a dependency sweep. |
| dev | Load when implementing an issue or applying review fixes as a dev agent. |
| github | Load to work a GitHub pull request: threads, comments, reviews, CI logs, merges. |
| growth-guards | Load to add, tune, or debug a repo growth guard, its git hooks, or GROWTH_GUARDS_* settings. |
| harness-ci | Load to wire, tune, or debug a repo's harness-only skip. |
| iced-rs | Load whenever building or debugging an Iced UI. |
| linear | Load for any Linear read or write: issues, projects, cycles, milestones, initiatives, labels. |
| orch | PRIMARY AGENT ONLY. Load to orchestrate a Linear or GitHub work item from preparation through merge. |
| preflight | Load to run, tune, or debug preflight. |
| price-handling | Load when comparing, rounding, formatting, or parsing prices, or designing price types. |
| project-management | Load to plan a cycle, audit issues, build a roadmap, or decompose research into issues. |
| reviewer | Load when reviewing a diff, classifying findings, or returning a verdict. |
| review-gate | Load to wire, adopt, tune, or debug a repo's review gate or its REVIEW_GATE_* settings. |
| second-opinion | Load for a cross-model review, challenge, audit, or quick consult. |
| size-ratchet | Load to add, tune, or debug the size ratchet, its baseline, or SIZE_RATCHET_* settings. |
| worktree | Load to create, list, remove, push, or repair a git worktree. |
| app-deploy | Load when asked to cut, ship, or release a kendex version. |
| kendex-issues | Load to monitor kendex's issue queue continuously or to run one fix-and-propagate cycle. |

The last two live under `.kendex-local/skills`, not `skills/`. The
Done-when names `skills/*/SKILL.md`; leaving the two repo-local skills on
the old style would half-convert the set an agent in this repo actually
sees, so they follow the same rule. Say the word and I will drop them
from the diff.

Body text and every other frontmatter field are untouched. The `.agents`
render carries the same frontmatter, mirrored in the same commit.

One consequence, tracked as KEN-682: `description:` is also what
`kendex index` exports as the package description, and the marketplace
Packages tab searches nothing else. Short triggers cost search recall
there, so marketplace rows and search need a field of their own. Package
pages are unaffected; they render the package's own README/SKILL body.

`kendex check --catalog .` exits 0 with 0 breakage and 0 advisory;
`tools/guard` is clean.

Closes KEN-678

https://claude.ai/code/session_01TKMNpovyKAZY3dmofvaR9E
