### PR TITLE
chore(worktree): fresh worktrees link ui/node_modules

### DIFF
--- a/kendex.settings.toml
+++ b/kendex.settings.toml
@@ -244,9 +244,11 @@ WORKTREE_DEFAULT_BRANCH = "main"
 WORKTREE_MKDIRS = "tmp"
 # ui/node_modules: tools/guard's UI lanes run `npx --no-install` in ui/, so a
 # worktree without it fails guard on its first commit. The link shares the
-# main checkout's store; a branch that changes ui/ dependencies must replace
-# the link with a real `pnpm install` or it writes through into the main
-# checkout. .gitignore's bare `node_modules` pattern covers the symlink.
+# main checkout's real install (npm — ui/package-lock.json), and worktree
+# setup re-creates it on every pass, replacing anything materialized at this
+# path. So change ui/ dependencies from the main checkout, where
+# `npm ci --prefix ui` operates on the real store — never from a linked
+# worktree. .gitignore's bare `node_modules` pattern covers the symlink.
 WORKTREE_SYMLINKS = ".env.local .agents .cache .codex .opencode .pi/agents .pi/kendex .claude/agents .claude/hooks .claude/skills .claude/settings.json ui/node_modules"
 
 # Nothing needs one: .claude/CLAUDE.md is a tracked symlink, so it arrives

--- a/kendex.settings.toml
+++ b/kendex.settings.toml
@@ -246,9 +246,11 @@ WORKTREE_MKDIRS = "tmp"
 # worktree without it fails guard on its first commit. The link shares the
 # main checkout's real install (npm — ui/package-lock.json), and worktree
 # setup re-creates it on every pass, replacing anything materialized at this
-# path. So change ui/ dependencies from the main checkout, where
-# `npm ci --prefix ui` operates on the real store — never from a linked
-# worktree. .gitignore's bare `node_modules` pattern covers the symlink.
+# path. So a ui/ dependency change is made with the branch checked out in
+# the MAIN checkout, where `npm ci --prefix ui` rebuilds the real store from
+# the changed manifests — never in a linked worktree, whose install would
+# write through the link. .gitignore's bare `node_modules` pattern covers
+# the symlink.
 WORKTREE_SYMLINKS = ".env.local .agents .cache .codex .opencode .pi/agents .pi/kendex .claude/agents .claude/hooks .claude/skills .claude/settings.json ui/node_modules"
 
 # Nothing needs one: .claude/CLAUDE.md is a tracked symlink, so it arrives

--- a/kendex.settings.toml
+++ b/kendex.settings.toml
@@ -242,7 +242,12 @@ WORKTREE_BASE_DIR = "~/dev/.worktrees/kendex"
 WORKTREE_COPIES = ".kendex-lock.json"
 WORKTREE_DEFAULT_BRANCH = "main"
 WORKTREE_MKDIRS = "tmp"
-WORKTREE_SYMLINKS = ".env.local .agents .cache .codex .opencode .pi/agents .pi/kendex .claude/agents .claude/hooks .claude/skills .claude/settings.json"
+# ui/node_modules: tools/guard's UI lanes run `npx --no-install` in ui/, so a
+# worktree without it fails guard on its first commit. The link shares the
+# main checkout's store; a branch that changes ui/ dependencies must replace
+# the link with a real `pnpm install` or it writes through into the main
+# checkout. .gitignore's bare `node_modules` pattern covers the symlink.
+WORKTREE_SYMLINKS = ".env.local .agents .cache .codex .opencode .pi/agents .pi/kendex .claude/agents .claude/hooks .claude/skills .claude/settings.json ui/node_modules"
 
 # Nothing needs one: .claude/CLAUDE.md is a tracked symlink, so it arrives
 # through git, and naming it here would shadow tracked content.


### PR DESCRIPTION
Adds `ui/node_modules` to `WORKTREE_SYMLINKS` so fresh worktrees pass `tools/guard` without hand setup. The pnpm-install write-through caveat is a comment beside the setting; `.gitignore`'s bare `node_modules` pattern already covers the symlink, so it cannot be committed.

https://claude.ai/code/session_019L1bqoELMZT8sVNtouWNjx