### PR TITLE
fix(gitignore): .cache is ignored bare so a worktree symlink stays hidden

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,8 +16,10 @@ docs/reviews/
 # `kendex refresh` writes here itself.
 .env.local
 
-# The linear skill's local cache
-.cache/
+# The linear skill's local cache. Bare, not `.cache/`. A trailing-slash
+# pattern matches a real directory but not a symlink pointing at one, and
+# every worktree links this path (WORKTREE_SYMLINKS).
+.cache
 
 # Filled-in local working copies of docs (backed up privately, never committed).
 docs/*-local.md


### PR DESCRIPTION
Part of the KEN-681 fleet sweep. One repo, one small PR.

`.cache` is in `WORKTREE_SYMLINKS`, so every worktree carries it as a symlink. `.cache/` with the trailing slash matches a real directory and not a symlink pointing at one, which left the link untracked and stageable. `git add -A` in a worktree could commit it. Same class as the committed `node_modules` symlink that broke drovr CI.

The bare form matches both, so the link stays hidden wherever it appears, including a checkout that never ran `worktree create` and so has no `info/exclude` entry for it.

kendex's other two dependency ignores (`node_modules`, `/target`) were already bare. The `WORKTREE_SYMLINKS` half of KEN-681 for this repo is #1678.

https://claude.ai/code/session_01KLMjB8Wm8ajnVyph7FRx5t