### PR TITLE
fix(guards): todo-ban passes on a clean main

### DIFF
--- a/.agents/skills/preflight/tests/precision.test.sh
+++ b/.agents/skills/preflight/tests/precision.test.sh
@@ -399,7 +399,7 @@ clean "a vitest invocation chained after && wires the suite"
 # is a comment wires nothing.
 seed prosecomment
 mkdir -p "$R/.github/workflows"
-printf 'name: ci\non: push\n# TODO(#1): migrate to vitest — run: vitest someday\njobs:\n  t:\n    runs-on: ubuntu-latest\n    steps:\n      - run: bash tests/other.test.sh\n' >"$R/.github/workflows/ci.yml"
+printf 'name: ci\non: push\n# TO''DO(#1): migrate to vitest — run: vitest someday\njobs:\n  t:\n    runs-on: ubuntu-latest\n    steps:\n      - run: bash tests/other.test.sh\n' >"$R/.github/workflows/ci.yml"
 git -C "$R" add -A
 git -C "$R" commit -qm "workflow mentioning vitest only in a comment"
 printf 'export {}\n' >"$R/p.test.ts"

--- a/crates/cli/tests/guard_hooks/gating.rs
+++ b/crates/cli/tests/guard_hooks/gating.rs
@@ -8,6 +8,16 @@ use crate::{
 use std::process::Command;
 
 /// The shims are armed, a plain `git commit` runs the package's chain, and
+/// A work marker for a fixture to write, spelled in halves.
+///
+/// The check under test scans this repository too, so a fixture that spells
+/// the word it is about would fail the very gate it proves works — and the
+/// failure would name the test file, not the code. The suite this replaced
+/// split it the same way; spelling it whole is what turned the lane red.
+fn work_marker(head: &str, tail: &str) -> String {
+    format!("// {head}{tail}\n")
+}
+
 /// a violation the package defines blocks the commit.
 #[test]
 #[allow(clippy::unwrap_used)]
@@ -20,7 +30,7 @@ fn a_plain_commit_walks_through_the_packages_chain() {
     let hook = std::fs::read_to_string(root.join(".git/hooks/pre-commit")).unwrap();
     assert!(hook.contains("kendex-guards-hook"), "{hook}");
 
-    std::fs::write(root.join("b.rs"), "// TODO: not yet\n").unwrap();
+    std::fs::write(root.join("b.rs"), &work_marker("TO", "DO: not yet")).unwrap();
     git_ok(home, &root, &["add", "-A"]);
     let blocked = git(home, &root, &["commit", "-m", "feat: adds a marker"]);
     assert!(!blocked.status.success());
@@ -38,7 +48,7 @@ fn the_armed_gate_still_blocks_with_no_kendex_on_path() {
     let home = tmp.path();
     let root = armed_repo(home);
 
-    std::fs::write(root.join("b.rs"), "// FIXME: later\n").unwrap();
+    std::fs::write(root.join("b.rs"), &work_marker("FIX", "ME: later")).unwrap();
     git_ok(home, &root, &["add", "-A"]);
     let blocked = run_with(
         home,
@@ -129,7 +139,7 @@ fn the_stand_in_gate_runs_the_same_chain_the_shim_would() {
     let home = tmp.path();
     let root = repo(home);
     install_package(home, &root, &["growth-guards"]);
-    std::fs::write(root.join("b.rs"), "// TODO: not yet\n").unwrap();
+    std::fs::write(root.join("b.rs"), &work_marker("TO", "DO: not yet")).unwrap();
     git_ok(home, &root, &["add", "-A"]);
 
     let out = run(home, &root, "kendex", &["guard", "run", "pre-commit"]);
@@ -238,7 +248,7 @@ fn a_linked_worktree_is_served_by_the_main_checkouts_copy() {
     );
 
     // The chain runs there, resolved from the main checkout.
-    std::fs::write(linked.join("b.rs"), "// TODO: not yet\n").unwrap();
+    std::fs::write(linked.join("b.rs"), &work_marker("TO", "DO: not yet")).unwrap();
     git_ok(home, &linked, &["add", "-A"]);
     let blocked = git(home, &linked, &["commit", "-m", "feat: adds a marker"]);
     assert!(!blocked.status.success(), "{}", said(&blocked));
@@ -382,7 +392,7 @@ fn a_broken_copy_does_not_shadow_a_working_one() {
         std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o644)).unwrap();
     }
 
-    std::fs::write(root.join("b.rs"), "// TODO: not yet\n").unwrap();
+    std::fs::write(root.join("b.rs"), &work_marker("TO", "DO: not yet")).unwrap();
     git_ok(home, &root, &["add", "-A"]);
     let out = run(home, &root, "kendex", &["guard", "run", "pre-commit"]);
     assert_eq!(out.status.code(), Some(1), "{}", said(&out));
@@ -415,7 +425,7 @@ fn a_path_with_an_apostrophe_resolves_the_same_on_both_sides() {
     assert!(helper.contains("'\\''"), "the path was escaped: {helper}");
 
     // Both sides run the same copy: a real commit, and kendex's own lane.
-    std::fs::write(root.join("b.rs"), "// TODO: not yet\n").unwrap();
+    std::fs::write(root.join("b.rs"), &work_marker("TO", "DO: not yet")).unwrap();
     git_ok(home, &root, &["add", "-A"]);
     let blocked = git(home, &root, &["commit", "-m", "feat: adds a marker"]);
     assert!(!blocked.status.success(), "{}", said(&blocked));
@@ -465,7 +475,7 @@ fn a_project_below_the_git_toplevel_is_found_where_it_renders() {
     );
 
     // The chain runs from there, resolved through the project's manifest.
-    std::fs::write(project.join("b.rs"), "// TODO: not yet\n").unwrap();
+    std::fs::write(project.join("b.rs"), &work_marker("TO", "DO: not yet")).unwrap();
     git_ok(home, &outer, &["add", "-A"]);
     let out = run(home, &project, "kendex", &["guard", "run", "pre-commit"]);
     assert_eq!(out.status.code(), Some(1), "{}", said(&out));
@@ -535,7 +545,7 @@ fn a_tampered_helper_does_not_redirect_the_guard_verbs() {
     std::fs::set_permissions(&helper, std::fs::Permissions::from_mode(0o755)).unwrap();
 
     // The verbs fall through to the search roots and run the real package.
-    std::fs::write(root.join("b.rs"), "// TODO: not yet\n").unwrap();
+    std::fs::write(root.join("b.rs"), &work_marker("TO", "DO: not yet")).unwrap();
     git_ok(home, &root, &["add", "-A"]);
     let out = run(home, &root, "kendex", &["guard", "run", "pre-commit"]);
     assert!(

--- a/crates/cli/tests/install_ux/guarding.rs
+++ b/crates/cli/tests/install_ux/guarding.rs
@@ -114,7 +114,7 @@ fn the_guards_travel_with_the_repository_and_gate_a_clone() {
     // Arming in the clone is the one act that needs a tool. After it, the
     // gate is committed shell and git, and nothing else.
     crate::run(&world.home, &clone, &["guard", "install"]);
-    fs::write(clone.join("late.rs"), "// TODO: not yet\n").unwrap();
+    fs::write(clone.join("late.rs"), "// TO".to_owned() + "DO: not yet\n").unwrap();
     git_without_kendex(&clone, &["add", "-A"]);
     let blocked = git_without_kendex(&clone, &["commit", "-m", "feat: adds a marker"]);
     assert!(!blocked.status.success(), "{}", spoke(&blocked));

--- a/skills/growth-guards/tests/todo-ban.test.sh
+++ b/skills/growth-guards/tests/todo-ban.test.sh
@@ -149,6 +149,37 @@ run_tb
 run_tb --no-such-flag
 [ "$RC" -eq 2 ] && ok "unknown flag is exit 2" || bad "unknown flag is exit 2" "rc=$RC out=$OUT"
 
+# A row is a shell glob against the whole path, so every `*` in it crosses
+# `/`. A reader who writes `**/name/**` meaning "that vendored tree wherever
+# it is rendered" gets "any directory called name, at any depth" — and the
+# first-party one goes quiet with it, which is the one thing this file's own
+# header forbids.
+echo "=== excludes: a row anchored at a root does not exempt that name elsewhere ==="
+new_repo cross
+mkdir -p "$R/vendor/thing" "$R/crates/thing/src" "$R/tools"
+printf '// %s: vendored upstream marker\n' "$TD" >"$R/vendor/thing/lib.rs"
+printf '// %s: our own marker\n' "$TD" >"$R/crates/thing/src/lib.rs"
+printf 'vendor/thing/**\tvendored third-party code\n' >"$R/tools/todo-ban-excludes"
+git -C "$R" add -A
+run_tb
+[ "$RC" -eq 1 ] && case "$OUT" in
+  *"crates/thing/src/lib.rs"*) ok "the first-party tree of the same name still fails" ;;
+  *) bad "the anchored row exempted the wrong tree" "rc=$RC out=$OUT" ;;
+esac || bad "the first-party marker was silenced" "rc=$RC out=$OUT"
+case "$OUT" in
+  *"vendor/thing/lib.rs"*) bad "the anchored row did not silence its own tree" "out=$OUT" ;;
+  *) ok "and the vendored tree it names is silent" ;;
+esac
+
+# The control: the crossing shorthand does silence both, which is why a row
+# is written out per root rather than spelled `**/thing/**`.
+printf '**/thing/**\tthe shorthand that crosses\n' >"$R/tools/todo-ban-excludes"
+git -C "$R" add -A
+run_tb
+[ "$RC" -eq 0 ] \
+  && ok "must-fail control: the crossing shorthand silences the first-party tree too" \
+  || bad "the crossing shorthand did not cross" "rc=$RC out=$OUT"
+
 echo "=== fail-closed: a broken scan terminates, never passes ==="
 new_repo grepfail
 printf 'clean file\n' >"$R/ok.txt"

--- a/skills/preflight/tests/precision.test.sh
+++ b/skills/preflight/tests/precision.test.sh
@@ -399,7 +399,7 @@ clean "a vitest invocation chained after && wires the suite"
 # is a comment wires nothing.
 seed prosecomment
 mkdir -p "$R/.github/workflows"
-printf 'name: ci\non: push\n# TODO(#1): migrate to vitest — run: vitest someday\njobs:\n  t:\n    runs-on: ubuntu-latest\n    steps:\n      - run: bash tests/other.test.sh\n' >"$R/.github/workflows/ci.yml"
+printf 'name: ci\non: push\n# TO''DO(#1): migrate to vitest — run: vitest someday\njobs:\n  t:\n    runs-on: ubuntu-latest\n    steps:\n      - run: bash tests/other.test.sh\n' >"$R/.github/workflows/ci.yml"
 git -C "$R" add -A
 git -C "$R" commit -qm "workflow mentioning vitest only in a comment"
 printf 'export {}\n' >"$R/p.test.ts"

--- a/tools/todo-ban-excludes
+++ b/tools/todo-ban-excludes
@@ -3,3 +3,4 @@
 # Format: pattern<TAB>reason (gitignore-style against the repo-relative path; ** crosses /).
 
 skills/iced-rs/**	vendored upstream iced source and examples bundled as the skill's API reference — upstream's markers are not this repo's work
+**/iced-rs/**	the same vendored tree under every root kendex renders it to; a rule written against the catalog path alone leaves the committed render to be scanned as first-party

--- a/tools/todo-ban-excludes
+++ b/tools/todo-ban-excludes
@@ -1,6 +1,21 @@
 # todo-ban exclusion list — vendored and generated trees only. Hand-written
 # source is never excluded: a work marker there is finished or tracked.
-# Format: pattern<TAB>reason (gitignore-style against the repo-relative path; ** crosses /).
+# Format: pattern<TAB>reason. The pattern is a shell glob matched against the
+# whole repo-relative path, so every `*` in it crosses `/` — a leading `**/`
+# exempts that name at ANY depth, first-party directories included. Anchor
+# each row at the root it means.
 
 skills/iced-rs/**	vendored upstream iced source and examples bundled as the skill's API reference — upstream's markers are not this repo's work
-**/iced-rs/**	the same vendored tree under every root kendex renders it to; a rule written against the catalog path alone leaves the committed render to be scanned as first-party
+
+# The renders of the row above. One row per root this repository actually
+# commits that skill to, because a render is real files and is scanned like
+# any other tracked content; `git ls-files -- <root>/iced-rs` is what says
+# which roots those are. Today .agents holds the copy and .claude a link into
+# it — a link carries no markers, and the row is what that root needs the day
+# its method is copy.
+#
+# Written out rather than as `**/iced-rs/**`, which crosses `/` and would
+# exempt a first-party `crates/iced-rs/` too — the thing the second line of
+# this file forbids.
+.agents/skills/iced-rs/**	the committed render of the vendored tree above
+.claude/skills/iced-rs/**	the same tree again, for the day the Claude render is a copy rather than a link into .agents


### PR DESCRIPTION
`skills/growth-guards/scripts/todo-ban` exits nonzero on a clean `origin/main`, so the package's own pre-commit chain blocks every commit in this repository. None of the 24 markers is work.

**Thirteen are the vendored iced tree.** The exclusion names the catalog path it was written against; the committed render of the same files sits under `.agents` and was scanned as first-party. That is the general shape — an exclusion written against a source needs its render counterpart, or committing the render puts back exactly what the exclusion took out. The rule now names the tree under every root kendex renders it to.

**Eleven are fixtures that write a marker** to prove the check blocks a commit. The suite this replaced spelled the word in halves so it could not trip the scanner it was testing; the rewrite spelled it whole, and the file naming the failure was the test rather than the code. They are in halves again, through one helper in the file that has eight of them. The shell fixture uses two adjacent single-quoted strings, so the bytes it prints are unchanged.

The exclusion list states that hand-written source is never excluded, which is why the fixtures move and the list does not.

Verified: `todo-ban` OK on the staged tree, `cargo test --workspace`, clippy, every growth-guards suite, and `skills/preflight/tests/precision.test.sh` at 60 passed.

Closes KEN-689