### PR TITLE
fix(guard): chmod the way both platforms parse it, one spelling per path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,10 @@ an outside contributor.
 
 ### Fixed
 
+- On macOS the commit hooks were written but never made executable, so git
+  ignored both and an armed repository gated nothing. `guard install` reports
+  armed only when the bit is really there.
+
 - `guard` verbs run from a linked worktree find the package under the same
   project path in the main checkout, not only at its top level.
 

--- a/crates/cli/tests/install_ux/main.rs
+++ b/crates/cli/tests/install_ux/main.rs
@@ -96,7 +96,12 @@ impl World {
     /// is what kendex's own detection reads.
     pub fn new(detected: &[&str]) -> World {
         let tmp = tempfile::tempdir().unwrap();
-        let home = tmp.path().to_path_buf();
+        // Canonical once, where the fixture's root enters (invariant 17).
+        // A temporary directory is routinely behind a symlink — macOS
+        // fronts `/var` with `/private/var` — and every path kendex prints
+        // comes back resolved, so a fixture holding the unresolved spelling
+        // compares two names for one directory and reads them as two.
+        let home = tmp.path().canonicalize().unwrap();
         let catalog = home.join("catalog");
         write(
             &catalog.join("skills/deploy/SKILL.md"),

--- a/crates/cli/tests/refresh_ledger/main.rs
+++ b/crates/cli/tests/refresh_ledger/main.rs
@@ -127,7 +127,10 @@ fn pre_rename_project(home: &Path) -> PathBuf {
 #[allow(clippy::unwrap_used)]
 fn a_blocked_refresh_ends_on_a_ledger_naming_every_outcome_and_its_next_step() {
     let tmp = tempfile::tempdir().unwrap();
-    let home = tmp.path();
+    // Canonical once, where the fixture's root enters (invariant 17): the
+    // ledger prints the root kendex resolved, and a temporary directory is
+    // routinely behind a symlink.
+    let home = &tmp.path().canonicalize().unwrap();
     let project = pre_rename_project(home);
 
     let printed = said(&kendex(
@@ -202,7 +205,10 @@ fn a_blocked_refresh_ends_on_a_ledger_naming_every_outcome_and_its_next_step() {
 #[allow(clippy::unwrap_used)]
 fn a_clean_refresh_ends_on_the_count_alone() {
     let tmp = tempfile::tempdir().unwrap();
-    let home = tmp.path();
+    // Canonical once, where the fixture's root enters (invariant 17): the
+    // ledger prints the root kendex resolved, and a temporary directory is
+    // routinely behind a symlink.
+    let home = &tmp.path().canonicalize().unwrap();
     let project = home.join("dev/app");
     let catalog = home.join("catalog");
     skill(&catalog, "tidy", "Nothing alarming here.\n");
@@ -232,7 +238,10 @@ fn a_clean_refresh_ends_on_the_count_alone() {
 #[allow(clippy::unwrap_used)]
 fn a_current_scope_with_findings_still_reads_up_to_date() {
     let tmp = tempfile::tempdir().unwrap();
-    let home = tmp.path();
+    // Canonical once, where the fixture's root enters (invariant 17): the
+    // ledger prints the root kendex resolved, and a temporary directory is
+    // routinely behind a symlink.
+    let home = &tmp.path().canonicalize().unwrap();
     let project = home.join("dev/app");
     let catalog = home.join("catalog");
     skill(&catalog, "tidy", RISKY);
@@ -274,7 +283,10 @@ fn a_current_scope_with_findings_still_reads_up_to_date() {
 #[allow(clippy::unwrap_used)]
 fn an_up_to_date_apply_claims_no_changes() {
     let tmp = tempfile::tempdir().unwrap();
-    let home = tmp.path();
+    // Canonical once, where the fixture's root enters (invariant 17): the
+    // ledger prints the root kendex resolved, and a temporary directory is
+    // routinely behind a symlink.
+    let home = &tmp.path().canonicalize().unwrap();
     let project = home.join("dev/app");
     let catalog = home.join("catalog");
     skill(&catalog, "tidy", "Nothing alarming here.\n");
@@ -311,7 +323,10 @@ fn a_shared_command_is_named_only_where_it_settles_every_skipped_item() {
     // Adopt-only: a folder shared by hand, which the take-over must never
     // write over, so no scope-wide command covers it.
     let tmp = tempfile::tempdir().unwrap();
-    let home = tmp.path();
+    // Canonical once, where the fixture's root enters (invariant 17): the
+    // ledger prints the root kendex resolved, and a temporary directory is
+    // routinely behind a symlink.
+    let home = &tmp.path().canonicalize().unwrap();
     let project = home.join("dev/app");
     let catalog = home.join("catalog");
     skill(&catalog, "deploy", "Upstream.\n");
@@ -345,7 +360,10 @@ fn a_shared_command_is_named_only_where_it_settles_every_skipped_item() {
     // Mixed: one replaceable conflict beside an install the reader edited.
     // The take-over settles the first and never touches the second.
     let tmp = tempfile::tempdir().unwrap();
-    let home = tmp.path();
+    // Canonical once, where the fixture's root enters (invariant 17): the
+    // ledger prints the root kendex resolved, and a temporary directory is
+    // routinely behind a symlink.
+    let home = &tmp.path().canonicalize().unwrap();
     let project = home.join("dev/app");
     let catalog = home.join("catalog");
     skill(&catalog, "tidy", "Upstream.\n");
@@ -413,7 +431,10 @@ fn a_shared_command_is_named_only_where_it_settles_every_skipped_item() {
 #[allow(clippy::unwrap_used)]
 fn a_take_over_that_settles_every_item_still_withholds_the_adopt_half() {
     let tmp = tempfile::tempdir().unwrap();
-    let home = tmp.path();
+    // Canonical once, where the fixture's root enters (invariant 17): the
+    // ledger prints the root kendex resolved, and a temporary directory is
+    // routinely behind a symlink.
+    let home = &tmp.path().canonicalize().unwrap();
     let project = home.join("dev/app");
     let catalog = home.join("catalog");
     // A name a shell would read as more than one argument is never printed
@@ -465,7 +486,10 @@ fn a_take_over_that_settles_every_item_still_withholds_the_adopt_half() {
 #[allow(clippy::unwrap_used)]
 fn the_flagged_count_matches_the_safety_block_above_it() {
     let tmp = tempfile::tempdir().unwrap();
-    let home = tmp.path();
+    // Canonical once, where the fixture's root enters (invariant 17): the
+    // ledger prints the root kendex resolved, and a temporary directory is
+    // routinely behind a symlink.
+    let home = &tmp.path().canonicalize().unwrap();
     let project = home.join("dev/app");
     let catalog = home.join("catalog");
     skill(&catalog, "guard", RISKY);
@@ -509,7 +533,10 @@ fn the_flagged_count_matches_the_safety_block_above_it() {
 #[allow(clippy::unwrap_used)]
 fn a_verbose_refresh_says_everything_the_compact_one_does() {
     let tmp = tempfile::tempdir().unwrap();
-    let home = tmp.path();
+    // Canonical once, where the fixture's root enters (invariant 17): the
+    // ledger prints the root kendex resolved, and a temporary directory is
+    // routinely behind a symlink.
+    let home = &tmp.path().canonicalize().unwrap();
     let project = pre_rename_project(home);
 
     let printed = said(&kendex(

--- a/crates/core/src/engine/adopt.rs
+++ b/crates/core/src/engine/adopt.rs
@@ -52,6 +52,13 @@ pub fn adopt(
     name: &str,
     harnesses: &[HarnessId],
 ) -> Result<Plan> {
+    // A plan entry, so the root is fixed here and nowhere downstream
+    // (invariant 17). Without it this planner met two spellings of one
+    // directory: positions come from the caller's scope while the tree a
+    // link points at comes back resolved off disk, so on a checkout behind
+    // a symlink — macOS fronts `/var` with `/private/var` — a plan trashed
+    // a link under one name and renamed the tree under the other.
+    let scope = &scope.canonical();
     // A hook is a script plus an entry in each tool's registry, not a file
     // at a position — it has its own planner rather than a case inside
     // this one.

--- a/crates/core/src/rename/tests.rs
+++ b/crates/core/src/rename/tests.rs
@@ -69,7 +69,12 @@ fn a_dangling_link_in_the_local_source_dir_moves_with_it() {
 #[test]
 fn a_pipe_in_the_local_source_dir_refuses_planning_by_name() {
     let tmp = tempfile::tempdir().unwrap();
-    let root = tmp.path().join("app");
+    // Canonical where the root enters (invariant 17): `rename_ops` fixes
+    // the scope root itself, so the path it names in the refusal is the
+    // resolved one, and a temporary directory is routinely behind a
+    // symlink.
+    let home = tmp.path().canonicalize().unwrap();
+    let root = home.join("app");
     let old_local = root.join(".vstack-local");
     std::fs::create_dir_all(old_local.join("skills/x")).unwrap();
     std::fs::write(old_local.join("skills/x/SKILL.md"), "v1").unwrap();
@@ -83,7 +88,7 @@ fn a_pipe_in_the_local_source_dir_refuses_planning_by_name() {
     )
     .unwrap();
     std::fs::write(root.join("vstack.toml"), "schema = 5\n").unwrap();
-    let env = Env::fake(tmp.path(), FakeOs::Linux);
+    let env = Env::fake(&home, FakeOs::Linux);
     let scope = Scope::Project { root };
 
     let error = rename_ops(&env, &scope).unwrap_err();

--- a/crates/core/tests/guard_repo_paths.rs
+++ b/crates/core/tests/guard_repo_paths.rs
@@ -65,7 +65,22 @@ fn a_checkout_whose_name_is_not_utf8_is_found() {
     let tmp = tempfile::tempdir().unwrap();
     // 0xFF is not valid UTF-8 in any position.
     let name = OsString::from_vec(b"caf\xffe".to_vec());
-    if std::fs::create_dir(tmp.path().join(&name)).is_err() {
+    // One error means "this filesystem does not have the case at all", and
+    // only that one is a skip. A permission error, a full disk, a missing
+    // parent — those are the fixture failing to be built, and skipping on
+    // them would turn a broken run green instead of red.
+    //
+    // APFS enforces UTF-8 in filenames and answers EILSEQ. Rust has no
+    // ErrorKind for it on every platform (macOS reports it uncategorized),
+    // so the errno is what it is matched on, with InvalidInput taken too for
+    // a platform that does map it.
+    if let Err(error) = std::fs::create_dir(tmp.path().join(&name)) {
+        let unsupported = error.kind() == std::io::ErrorKind::InvalidInput
+            || error.raw_os_error() == rustix::io::Errno::ILSEQ.raw_os_error().into();
+        assert!(
+            unsupported,
+            "the fixture directory is creatable, or the filesystem refuses the name: {error:?}"
+        );
         eprintln!("skipped: this filesystem will not hold a non-UTF-8 filename");
         return;
     }

--- a/crates/core/tests/guard_repo_paths.rs
+++ b/crates/core/tests/guard_repo_paths.rs
@@ -53,12 +53,24 @@ fn repo_named(parent: &Path, name: OsString) -> PathBuf {
 /// `from_utf8_lossy` turns those bytes into U+FFFD, which is a different
 /// filename — so `canonicalize` failed and every verb reported a path
 /// nobody has, for a repository that is perfectly fine.
+///
+/// Only where the filesystem will hold such a name. APFS enforces UTF-8 in
+/// filenames and refuses the byte outright (`EILSEQ`), so on macOS the
+/// fixture cannot be built at all — and a test that cannot build its
+/// subject has nothing to say about it. Skipped there rather than asserted
+/// around: the property still holds on every filesystem that has the case.
 #[test]
 #[allow(clippy::unwrap_used, clippy::expect_used)]
 fn a_checkout_whose_name_is_not_utf8_is_found() {
     let tmp = tempfile::tempdir().unwrap();
     // 0xFF is not valid UTF-8 in any position.
-    let root = repo_named(tmp.path(), OsString::from_vec(b"caf\xffe".to_vec()));
+    let name = OsString::from_vec(b"caf\xffe".to_vec());
+    if std::fs::create_dir(tmp.path().join(&name)).is_err() {
+        eprintln!("skipped: this filesystem will not hold a non-UTF-8 filename");
+        return;
+    }
+    std::fs::remove_dir(tmp.path().join(&name)).unwrap();
+    let root = repo_named(tmp.path(), name);
 
     let repo = Repo::at(&root).expect("the repository is found by its bytes");
     assert_eq!(repo.worktree, root.canonicalize().unwrap());

--- a/skills/growth-guards/scripts/install-git-hooks
+++ b/skills/growth-guards/scripts/install-git-hooks
@@ -173,7 +173,7 @@ write_helper() { # PATH
   helper_body >"$tmp" || { rm -f -- "$tmp"; return 1; }
   # mktemp creates 0600; a hook must be readable and executable by whoever
   # git runs as, which on a shared repository is not only its owner.
-  chmod 0755 "$tmp" 2>/dev/null && mv -f -- "$tmp" "$helper" || {
+  chmod -- 0755 "$tmp" 2>/dev/null && mv -f -- "$tmp" "$helper" || {
     rm -f -- "$tmp"
     return 1
   }
@@ -239,12 +239,12 @@ strip_final_newline() { # FILE — drop one trailing newline byte if present
   mv -f -- "$1.trim" "$1"
 }
 
-# git ignores a hook without the executable bit, so a bit that is not there
-# and cannot be restored is a guard that never runs — never a success.
+# git ignores a hook without the bit, so one that cannot be restored is a
+# guard that never runs. `--` before the mode: bash32-portability has the why.
 ensure_hook_executable() { # HOOK PATH
   local hook="$1" path="$2"
   [ -x "$path" ] && return 0
-  chmod +x -- "$path" 2>/dev/null && [ -x "$path" ] && return 0
+  chmod -- +x "$path" 2>/dev/null && [ -x "$path" ] && return 0
   hook_warn "$path is not executable and could not be made so; git ignores it — the $hook guard is NOT armed"
 }
 

--- a/skills/growth-guards/tests/bash32-portability.test.sh
+++ b/skills/growth-guards/tests/bash32-portability.test.sh
@@ -4,9 +4,17 @@
 # associative arrays, automatic FD-allocation redirections, case-conversion
 # expansions).
 #
-# And the utilities are BSD there, not GNU. A rule that only a macOS run can
-# break belongs in a check every run makes: this file is where the shipped
-# scripts are read for what the other platform does differently.
+# And the utilities are BSD there, not GNU. That half used to be a text scan
+# for the shapes a BSD utility rejects, and it was wrong four times running:
+# each spelling missed an argument form the next reviewer found, because a
+# lint over shell source has no bottom — the same command can be written in
+# more ways than a regex can enumerate, and every round only moved the edge.
+#
+# So it is not read any more, it is RUN. The BSD rule is put in a shim on
+# PATH and the real installer executes under it, which cannot be evaded by
+# spelling: whatever the scripts call chmod with, the shim judges it the way
+# macOS would. The merge-group macOS lane stays the platform proof; this is
+# what every Linux run can say on its own.
 set -euo pipefail
 
 TEST_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
@@ -16,28 +24,6 @@ SCRIPTS_DIR="$(cd "$TEST_DIR/../scripts" && pwd)"
 PATTERN='mapfile|readarray|declare -A|declare -gA|local -A'
 PATTERN="$PATTERN"'|(^|[^$])\{[A-Za-z_][A-Za-z0-9_]*\}[<>]'
 PATTERN="$PATTERN"'|\$\{[A-Za-z_][A-Za-z0-9_]*(\[[^]]*\])?(,,|\^\^)'
-# A `--` anywhere but immediately after the `chmod` word.
-#
-# BSD getopt(3) stops at the first non-option argument, so a `--` that comes
-# after anything is read as a filename and chmod fails on the nonexistent
-# file `--`. GNU permutes and accepts it wherever it lands, which is how the
-# mistake lives through any number of Linux-only runs. `chmod +x -- "$hook"`
-# wrote both hook files and made neither executable on macOS; git ignores a
-# hook it cannot run, so `guard install` reported two armed hooks over a
-# repository that gated nothing.
-#
-# This rule described the mode twice and got it wrong twice. First as "the
-# token that is not a flag", which missed `chmod -x --` because a mode may
-# lead with a minus. Then as GNU's mode grammar, which missed `chmod a= --`
-# and `chmod g=u --` because a symbolic clause may have an empty permission
-# list. A third spelling of the same idea would miss a fourth shape.
-#
-# So there is no grammar here. What is wrong with these lines has nothing to
-# do with what a mode looks like: the `--` is not the first argument. That is
-# the whole rule, and it needs to recognise no mode at all — `chmod`, then a
-# token that is not `--`, then a bare `--` anywhere after it.
-PATTERN="$PATTERN"'|chmod[[:space:]]+(([^-[:space:]]|-[^-[:space:]]|--[^[:space:]])[^[:space:]]*|-)([[:space:]]+[^[:space:]]+)*[[:space:]]+--([[:space:]]|$)'
-
 # grep's status is part of the answer: 0 found, 1 none, anything else is a
 # scan that did not run — and a scan that did not run is not a clean tree.
 violations=""
@@ -53,60 +39,6 @@ if [[ -n "$violations" ]]; then
   exit 1
 fi
 
-# The scan has to be able to see one, in the shape that got past it. A
-# planted line in a scratch copy, run through the same PATTERN: `chmod -x --`
-# leads with a minus, which is what the first spelling of the rule read as an
-# option and let through.
-probe="$(mktemp -d "${TMPDIR:-/tmp}/gg-portability.XXXXXX")"
-trap 'rm -rf "$probe"' EXIT
-{
-  printf '#!/bin/sh\n'
-  printf 'chmod -x -- "$f"\n'
-  printf 'chmod +x -- "$f"\n'
-  printf 'chmod a= -- "$f"\n'
-  printf 'chmod g=u -- "$f"\n'
-  printf '%s\n' 'chmod 0755 -- "$f"'
-  printf '%s\n' 'chmod -R -- 755 "$d"'
-} >"$probe/planted.sh"
-planted=""
-planted_status=0
-planted="$(grep -rnE "$PATTERN" "$probe")" || planted_status=$?
-if [[ "$planted_status" -gt 1 ]]; then
-  echo "FAIL: the scan over the planted probe could not run (grep exited $planted_status)" >&2
-  exit 1
-fi
-for shape in 'chmod -x --' 'chmod +x --' 'chmod a= --' 'chmod g=u --' \
-  'chmod 0755 --' 'chmod -R --'; do
-  case "$planted" in
-    *"$shape"*) ;;
-    *)
-      echo "FAIL: the scan does not see '$shape'; the rule above proves nothing" >&2
-      exit 1
-      ;;
-  esac
-done
-
-# And the right order is not a violation, or the rule would ban the fix.
-# Only the one right shape, plus other commands' `--`, which this rule must
-# never touch.
-{
-  printf '#!/bin/sh\n'
-  printf 'chmod -- +x "$f"\n'
-  printf 'chmod -- 0755 "$f"\n'
-  printf 'chmod -- -x "$f"\n'
-  printf 'chmod +x "$f"\n'
-  printf 'rm -f -- "$f"\n'
-  printf 'mv -f -- "$a" "$b"\n'
-  printf 'cat -- "$f"\n'
-} >"$probe/clean.sh"
-rm -f "$probe/planted.sh"
-clean_status=0
-grep -rnE "$PATTERN" "$probe" >/dev/null || clean_status=$?
-if [[ "$clean_status" -ne 1 ]]; then
-  echo "FAIL: the scan flags a correctly ordered chmod (grep exited $clean_status)" >&2
-  exit 1
-fi
-
 # Syntax-check every shipped script while we are here.
 fail=0
 # Every shipped script, discovered — a new one must not be able to skip the
@@ -119,5 +51,119 @@ for f in "$SCRIPTS_DIR"/* "$SCRIPTS_DIR"/lib/*.sh; do
   fi
 done
 [ "$fail" -eq 0 ] || exit 1
+
+# The BSD argv rule, as a program the installer actually runs.
+#
+# getopt(3) stops at the first non-option argument. For chmod that argument
+# is the mode, so every token after it is a file operand — and a `--` there
+# is a file named `--`, which does not exist. BSD chmod fails on it. GNU
+# permutes its arguments and accepts the same line, which is why this can
+# only be caught by judging the call rather than by reading the source.
+shim="$TMP/shim"
+mkdir -p "$shim"
+cat >"$shim/chmod" <<'SHIM'
+#!/bin/sh
+# Options first, exactly as getopt(3) takes them.
+while [ $# -gt 0 ]; do
+  case "$1" in
+    # `--` here ends option parsing: the mode follows. This is the one
+    # correct shape, and it is passed straight through.
+    --)
+      shift
+      break
+      ;;
+    -[RfhvHLP]*) shift ;;
+    # Anything else is the mode, and option parsing is over.
+    *) break ;;
+  esac
+done
+# From here every argument is a file operand. A `--` among them is a file
+# nobody has.
+mode="${1-}"
+[ $# -gt 0 ] && shift
+for arg in "$@"; do
+  if [ "$arg" = "--" ]; then
+    echo "chmod: --: No such file or directory" >&2
+    exit 1
+  fi
+done
+exec /bin/chmod "$mode" "$@"
+SHIM
+chmod 0755 "$shim/chmod"
+
+# The shim has teeth, and only on the wrong shape.
+: >"$TMP/probe-file"
+if PATH="$shim:$PATH" chmod +x -- "$TMP/probe-file" 2>/dev/null; then
+  echo "FAIL: the shim accepts a trailing --, so it judges nothing" >&2
+  exit 1
+fi
+if ! PATH="$shim:$PATH" chmod -- +x "$TMP/probe-file" 2>/dev/null; then
+  echo "FAIL: the shim rejects the correct order, so it would fail any installer" >&2
+  exit 1
+fi
+[ -x "$TMP/probe-file" ] || {
+  echo "FAIL: the shim did not exec the real chmod" >&2
+  exit 1
+}
+
+# A repository, and the package installed into it the way a consumer has it.
+repo="$TMP/bsd-repo"
+mkdir -p "$repo/.agents/skills"
+git -C "$repo" init -q
+git -C "$repo" config user.email t@t
+git -C "$repo" config user.name t
+cp -R "$SCRIPTS_DIR/.." "$repo/.agents/skills/growth-guards"
+installer="$repo/.agents/skills/growth-guards/scripts/install-git-hooks"
+
+out=""
+status=0
+out="$(PATH="$shim:$PATH" "$installer" --repo "$repo" 2>&1)" || status=$?
+if [ "$status" -ne 0 ]; then
+  echo "FAIL: the install failed under BSD chmod argv rules (exit $status)" >&2
+  printf '%s\n' "$out" >&2
+  exit 1
+fi
+
+# git ignores a hook without the bit, so this is the assertion that matters:
+# not that the installer said armed, but that the files it wrote can run.
+for lane in pre-commit commit-msg kendex-guards; do
+  [ -x "$repo/.git/hooks/$lane" ] || {
+    echo "FAIL: $lane is not executable after an install under BSD chmod" >&2
+    printf '%s\n' "$out" >&2
+    exit 1
+  }
+done
+
+# And the package's own verdict agrees, which is the pair that came apart on
+# macOS: two hooks reported armed over a repository that gated nothing.
+check=""
+check_status=0
+check="$(PATH="$shim:$PATH" "$installer" --repo "$repo" --check 2>&1)" || check_status=$?
+if [ "$check_status" -ne 0 ]; then
+  echo "FAIL: --check does not read the repository as armed (exit $check_status)" >&2
+  printf '%s\n' "$check" >&2
+  exit 1
+fi
+
+# The control: a copy of the package with the wrong order restored must NOT
+# come out armed. Without this the pin passes on any installer, including one
+# that never calls chmod at all.
+broken="$TMP/broken"
+mkdir -p "$broken/.agents/skills"
+git -C "$broken" init -q
+git -C "$broken" config user.email t@t
+git -C "$broken" config user.name t
+cp -R "$SCRIPTS_DIR/.." "$broken/.agents/skills/growth-guards"
+broken_installer="$broken/.agents/skills/growth-guards/scripts/install-git-hooks"
+perl -pi -e 's/chmod -- \+x/chmod +x --/; s/chmod -- 0755/chmod 0755 --/' "$broken_installer"
+grep -q 'chmod +x --' "$broken_installer" || {
+  echo "FAIL: the control could not restore the wrong order; the assertion below proves nothing" >&2
+  exit 1
+}
+PATH="$shim:$PATH" "$broken_installer" --repo "$broken" >/dev/null 2>&1 || true
+if [ -x "$broken/.git/hooks/pre-commit" ] && [ -x "$broken/.git/hooks/commit-msg" ]; then
+  echo "FAIL: must-fail control armed under BSD chmod with the wrong argv order" >&2
+  exit 1
+fi
 
 echo "pass: bash32-portability"

--- a/skills/growth-guards/tests/bash32-portability.test.sh
+++ b/skills/growth-guards/tests/bash32-portability.test.sh
@@ -27,7 +27,15 @@ PATTERN="$PATTERN"'|\$\{[A-Za-z_][A-Za-z0-9_]*(\[[^]]*\])?(,,|\^\^)'
 # macOS. git ignores a hook it cannot run, so `guard install` reported two
 # armed hooks over a repository that gated nothing. size-ratchet found this
 # first and wrote the rule down; the guards had the mistake it describes.
-PATTERN="$PATTERN"'|chmod([[:space:]]+-[^[:space:]]+)*[[:space:]]+[^-[:space:]][^[:space:]]*[[:space:]]+--([[:space:]]|$)'
+#
+# The mode is spelled out rather than described as "the token that is not a
+# flag". A mode may LEAD with a minus — `chmod -x path` removes the bit —
+# and the first spelling of this rule skipped leading-minus tokens as
+# options, so `chmod -x -- path` walked straight through the check meant to
+# catch it. GNU's own grammar is the one to match: octal, or a symbolic
+# clause `[ugoa]*[-+=][rwxXst]+`, comma-separated.
+GG_CHMOD_MODE='([0-7]{3,4}|[ugoa]*[-+=][rwxXst]+(,[ugoa]*[-+=][rwxXst]+)*)'
+PATTERN="$PATTERN"'|chmod([[:space:]]+[^[:space:]]+)*[[:space:]]+'"$GG_CHMOD_MODE"'[[:space:]]+--([[:space:]]|$)'
 
 # grep's status is part of the answer: 0 found, 1 none, anything else is a
 # scan that did not run — and a scan that did not run is not a clean tree.
@@ -41,6 +49,51 @@ fi
 if [[ -n "$violations" ]]; then
   echo "constructs the other platform does not take, in growth-guards scripts:" >&2
   printf '%s\n' "$violations" >&2
+  exit 1
+fi
+
+# The scan has to be able to see one, in the shape that got past it. A
+# planted line in a scratch copy, run through the same PATTERN: `chmod -x --`
+# leads with a minus, which is what the first spelling of the rule read as an
+# option and let through.
+probe="$(mktemp -d "${TMPDIR:-/tmp}/gg-portability.XXXXXX")"
+trap 'rm -rf "$probe"' EXIT
+{
+  printf '#!/bin/sh\n'
+  printf 'chmod -x -- "$f"\n'
+  printf 'chmod +x -- "$f"\n'
+  printf '%s\n' 'chmod 0755 -- "$f"'
+} >"$probe/planted.sh"
+planted=""
+planted_status=0
+planted="$(grep -rnE "$PATTERN" "$probe")" || planted_status=$?
+if [[ "$planted_status" -gt 1 ]]; then
+  echo "FAIL: the scan over the planted probe could not run (grep exited $planted_status)" >&2
+  exit 1
+fi
+for shape in 'chmod -x --' 'chmod +x --' 'chmod 0755 --'; do
+  case "$planted" in
+    *"$shape"*) ;;
+    *)
+      echo "FAIL: the scan does not see '$shape'; the rule above proves nothing" >&2
+      exit 1
+      ;;
+  esac
+done
+
+# And the right order is not a violation, or the rule would ban the fix.
+{
+  printf '#!/bin/sh\n'
+  printf 'chmod -- +x "$f"\n'
+  printf 'chmod -- 0755 "$f"\n'
+  printf 'chmod -R -- 755 "$d"\n'
+  printf 'rm -f -- "$f"\n'
+} >"$probe/clean.sh"
+rm -f "$probe/planted.sh"
+clean_status=0
+grep -rnE "$PATTERN" "$probe" >/dev/null || clean_status=$?
+if [[ "$clean_status" -ne 1 ]]; then
+  echo "FAIL: the scan flags a correctly ordered chmod (grep exited $clean_status)" >&2
   exit 1
 fi
 

--- a/skills/growth-guards/tests/bash32-portability.test.sh
+++ b/skills/growth-guards/tests/bash32-portability.test.sh
@@ -16,26 +16,27 @@ SCRIPTS_DIR="$(cd "$TEST_DIR/../scripts" && pwd)"
 PATTERN='mapfile|readarray|declare -A|declare -gA|local -A'
 PATTERN="$PATTERN"'|(^|[^$])\{[A-Za-z_][A-Za-z0-9_]*\}[<>]'
 PATTERN="$PATTERN"'|\$\{[A-Za-z_][A-Za-z0-9_]*(\[[^]]*\])?(,,|\^\^)'
-# chmod with `--` after the mode, which is the wrong side of it.
+# A `--` anywhere but immediately after the `chmod` word.
 #
-# BSD getopt(3) stops at the first non-option argument — the mode — so a
-# `--` behind it is read as a filename, and chmod fails on the nonexistent
-# file `--`. GNU chmod permutes its arguments and accepts either order,
-# which is how the mistake lives through any number of Linux-only runs.
+# BSD getopt(3) stops at the first non-option argument, so a `--` that comes
+# after anything is read as a filename and chmod fails on the nonexistent
+# file `--`. GNU permutes and accepts it wherever it lands, which is how the
+# mistake lives through any number of Linux-only runs. `chmod +x -- "$hook"`
+# wrote both hook files and made neither executable on macOS; git ignores a
+# hook it cannot run, so `guard install` reported two armed hooks over a
+# repository that gated nothing.
 #
-# `chmod +x -- "$hook"` wrote both hook files and made neither executable on
-# macOS. git ignores a hook it cannot run, so `guard install` reported two
-# armed hooks over a repository that gated nothing. size-ratchet found this
-# first and wrote the rule down; the guards had the mistake it describes.
+# This rule described the mode twice and got it wrong twice. First as "the
+# token that is not a flag", which missed `chmod -x --` because a mode may
+# lead with a minus. Then as GNU's mode grammar, which missed `chmod a= --`
+# and `chmod g=u --` because a symbolic clause may have an empty permission
+# list. A third spelling of the same idea would miss a fourth shape.
 #
-# The mode is spelled out rather than described as "the token that is not a
-# flag". A mode may LEAD with a minus — `chmod -x path` removes the bit —
-# and the first spelling of this rule skipped leading-minus tokens as
-# options, so `chmod -x -- path` walked straight through the check meant to
-# catch it. GNU's own grammar is the one to match: octal, or a symbolic
-# clause `[ugoa]*[-+=][rwxXst]+`, comma-separated.
-GG_CHMOD_MODE='([0-7]{3,4}|[ugoa]*[-+=][rwxXst]+(,[ugoa]*[-+=][rwxXst]+)*)'
-PATTERN="$PATTERN"'|chmod([[:space:]]+[^[:space:]]+)*[[:space:]]+'"$GG_CHMOD_MODE"'[[:space:]]+--([[:space:]]|$)'
+# So there is no grammar here. What is wrong with these lines has nothing to
+# do with what a mode looks like: the `--` is not the first argument. That is
+# the whole rule, and it needs to recognise no mode at all — `chmod`, then a
+# token that is not `--`, then a bare `--` anywhere after it.
+PATTERN="$PATTERN"'|chmod[[:space:]]+(([^-[:space:]]|-[^-[:space:]]|--[^[:space:]])[^[:space:]]*|-)([[:space:]]+[^[:space:]]+)*[[:space:]]+--([[:space:]]|$)'
 
 # grep's status is part of the answer: 0 found, 1 none, anything else is a
 # scan that did not run — and a scan that did not run is not a clean tree.
@@ -62,7 +63,10 @@ trap 'rm -rf "$probe"' EXIT
   printf '#!/bin/sh\n'
   printf 'chmod -x -- "$f"\n'
   printf 'chmod +x -- "$f"\n'
+  printf 'chmod a= -- "$f"\n'
+  printf 'chmod g=u -- "$f"\n'
   printf '%s\n' 'chmod 0755 -- "$f"'
+  printf '%s\n' 'chmod -R -- 755 "$d"'
 } >"$probe/planted.sh"
 planted=""
 planted_status=0
@@ -71,7 +75,8 @@ if [[ "$planted_status" -gt 1 ]]; then
   echo "FAIL: the scan over the planted probe could not run (grep exited $planted_status)" >&2
   exit 1
 fi
-for shape in 'chmod -x --' 'chmod +x --' 'chmod 0755 --'; do
+for shape in 'chmod -x --' 'chmod +x --' 'chmod a= --' 'chmod g=u --' \
+  'chmod 0755 --' 'chmod -R --'; do
   case "$planted" in
     *"$shape"*) ;;
     *)
@@ -82,12 +87,17 @@ for shape in 'chmod -x --' 'chmod +x --' 'chmod 0755 --'; do
 done
 
 # And the right order is not a violation, or the rule would ban the fix.
+# Only the one right shape, plus other commands' `--`, which this rule must
+# never touch.
 {
   printf '#!/bin/sh\n'
   printf 'chmod -- +x "$f"\n'
   printf 'chmod -- 0755 "$f"\n'
-  printf 'chmod -R -- 755 "$d"\n'
+  printf 'chmod -- -x "$f"\n'
+  printf 'chmod +x "$f"\n'
   printf 'rm -f -- "$f"\n'
+  printf 'mv -f -- "$a" "$b"\n'
+  printf 'cat -- "$f"\n'
 } >"$probe/clean.sh"
 rm -f "$probe/planted.sh"
 clean_status=0

--- a/skills/growth-guards/tests/bash32-portability.test.sh
+++ b/skills/growth-guards/tests/bash32-portability.test.sh
@@ -3,6 +3,10 @@
 # shipped scripts may not use Bash 4+ builtins or syntax (mapfile/readarray,
 # associative arrays, automatic FD-allocation redirections, case-conversion
 # expansions).
+#
+# And the utilities are BSD there, not GNU. A rule that only a macOS run can
+# break belongs in a check every run makes: this file is where the shipped
+# scripts are read for what the other platform does differently.
 set -euo pipefail
 
 TEST_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
@@ -12,10 +16,30 @@ SCRIPTS_DIR="$(cd "$TEST_DIR/../scripts" && pwd)"
 PATTERN='mapfile|readarray|declare -A|declare -gA|local -A'
 PATTERN="$PATTERN"'|(^|[^$])\{[A-Za-z_][A-Za-z0-9_]*\}[<>]'
 PATTERN="$PATTERN"'|\$\{[A-Za-z_][A-Za-z0-9_]*(\[[^]]*\])?(,,|\^\^)'
+# chmod with `--` after the mode, which is the wrong side of it.
+#
+# BSD getopt(3) stops at the first non-option argument — the mode — so a
+# `--` behind it is read as a filename, and chmod fails on the nonexistent
+# file `--`. GNU chmod permutes its arguments and accepts either order,
+# which is how the mistake lives through any number of Linux-only runs.
+#
+# `chmod +x -- "$hook"` wrote both hook files and made neither executable on
+# macOS. git ignores a hook it cannot run, so `guard install` reported two
+# armed hooks over a repository that gated nothing. size-ratchet found this
+# first and wrote the rule down; the guards had the mistake it describes.
+PATTERN="$PATTERN"'|chmod([[:space:]]+-[^[:space:]]+)*[[:space:]]+[^-[:space:]][^[:space:]]*[[:space:]]+--([[:space:]]|$)'
 
-violations="$(grep -rnE "$PATTERN" "$SCRIPTS_DIR" || true)"
+# grep's status is part of the answer: 0 found, 1 none, anything else is a
+# scan that did not run — and a scan that did not run is not a clean tree.
+violations=""
+scan_status=0
+violations="$(grep -rnE "$PATTERN" "$SCRIPTS_DIR")" || scan_status=$?
+if [[ "$scan_status" -gt 1 ]]; then
+  echo "the portability scan over $SCRIPTS_DIR could not run (grep exited $scan_status)" >&2
+  exit 1
+fi
 if [[ -n "$violations" ]]; then
-  echo "Bash 4+ constructs found in growth-guards scripts (must run under Bash 3.2):" >&2
+  echo "constructs the other platform does not take, in growth-guards scripts:" >&2
   printf '%s\n' "$violations" >&2
   exit 1
 fi


### PR DESCRIPTION
The macOS lane has been red since #1669, in three unrelated ways. Stacked on #1681, without which nothing in this repository can commit at all.

## `chmod +x --` — 14 tests

BSD `getopt(3)` stops at the first non-option argument, so the `--` after the mode became a filename and chmod failed on it. GNU permutes and takes either order, which is how a Linux-only run never saw it. Both hooks were written and neither was executable; git ignores a hook it cannot run, so `guard install` reported two armed hooks over a repository that gated nothing.

size-ratchet had already found this and written the rule down; the growth guards carried the mistake it describes. Pinned in `bash32-portability.test.sh`, which is where a rule only the other platform can break belongs. That scan had the same `|| true` fail-open #1669 closed next door, so it now refuses a grep status above 1.

## Two spellings of one directory — 6 tests, all pre-existing

`adopt` is a plan entry and never fixed its scope root, so positions came from the caller while a link's target came back resolved off disk. On a checkout behind a symlink the plan trashed a link under one name and renamed the tree under the other. It calls `Scope::canonical` now, like the other plan entries invariant 17 names.

Three fixtures met the same two spellings; each fixes its root once where it enters, rather than canonicalizing at every assertion.

These six are red at `1d31394c` too — they predate #1669. The lane is one lane, so they go together.

## A non-UTF-8 filename — 1 test

APFS enforces UTF-8 in filenames and refuses the byte outright, so the fixture cannot be built on macOS. Skipped where the filesystem will not hold the name, which is honest about what the test can say there.

## Verification

**The Mac test box was not reachable, so no run on real macOS is behind these numbers.** `mbp` shows `offline, last seen 1d ago` in `tailscale status` and SSH times out at the relay. The macOS lane in CI is a real macOS runner and is the check that settles this.

What was run, on Linux:

| Suite | Plain | `TMPDIR` behind a symlink |
| --- | --- | --- |
| `guard_hooks` | 29 passed, 0 failed | 29 passed, 0 failed |
| `install_ux` | 36 passed, 0 failed | 36 passed, 0 failed |
| `refresh_ledger` | 15 passed, 0 failed | 15 passed, 0 failed |
| `bash32-portability.test.sh` | pass | — |
| `cargo test --workspace` | green | green |

The second column is the point. Putting `TMPDIR` behind a symlink gives Linux the shape macOS has permanently, `/var` fronted by `/private/var`. All six of the pre-existing path failures reproduce under it and all six go green; the workspace is green under it and unchanged without it.

The chmod fix is not covered by either column — a Linux `chmod` takes both argument orders, which is the whole defect. It is pinned statically in `bash32-portability.test.sh` instead, so the rule is checked on every platform's run rather than only where it can break.

Closes KEN-690
