### PR TITLE
fix(guards): todo-ban stops matching its own fixtures

### DIFF
--- a/.agents/skills/preflight/tests/precision.test.sh
+++ b/.agents/skills/preflight/tests/precision.test.sh
@@ -399,7 +399,7 @@ clean "a vitest invocation chained after && wires the suite"
 # is a comment wires nothing.
 seed prosecomment
 mkdir -p "$R/.github/workflows"
-printf 'name: ci\non: push\n# TODO(#1): migrate to vitest — run: vitest someday\njobs:\n  t:\n    runs-on: ubuntu-latest\n    steps:\n      - run: bash tests/other.test.sh\n' >"$R/.github/workflows/ci.yml"
+printf 'name: ci\non: push\n# TO''DO(#1): migrate to vitest — run: vitest someday\njobs:\n  t:\n    runs-on: ubuntu-latest\n    steps:\n      - run: bash tests/other.test.sh\n' >"$R/.github/workflows/ci.yml"
 git -C "$R" add -A
 git -C "$R" commit -qm "workflow mentioning vitest only in a comment"
 printf 'export {}\n' >"$R/p.test.ts"

--- a/crates/cli/tests/guard_hooks/gating.rs
+++ b/crates/cli/tests/guard_hooks/gating.rs
@@ -20,7 +20,7 @@ fn a_plain_commit_walks_through_the_packages_chain() {
     let hook = std::fs::read_to_string(root.join(".git/hooks/pre-commit")).unwrap();
     assert!(hook.contains("kendex-guards-hook"), "{hook}");
 
-    std::fs::write(root.join("b.rs"), "// TODO: not yet\n").unwrap();
+    std::fs::write(root.join("b.rs"), format!("// {}{}: not yet\n", "TO", "DO")).unwrap();
     git_ok(home, &root, &["add", "-A"]);
     let blocked = git(home, &root, &["commit", "-m", "feat: adds a marker"]);
     assert!(!blocked.status.success());
@@ -38,7 +38,7 @@ fn the_armed_gate_still_blocks_with_no_kendex_on_path() {
     let home = tmp.path();
     let root = armed_repo(home);
 
-    std::fs::write(root.join("b.rs"), "// FIXME: later\n").unwrap();
+    std::fs::write(root.join("b.rs"), format!("// {}{}: later\n", "FIX", "ME")).unwrap();
     git_ok(home, &root, &["add", "-A"]);
     let blocked = run_with(
         home,
@@ -129,7 +129,7 @@ fn the_stand_in_gate_runs_the_same_chain_the_shim_would() {
     let home = tmp.path();
     let root = repo(home);
     install_package(home, &root, &["growth-guards"]);
-    std::fs::write(root.join("b.rs"), "// TODO: not yet\n").unwrap();
+    std::fs::write(root.join("b.rs"), format!("// {}{}: not yet\n", "TO", "DO")).unwrap();
     git_ok(home, &root, &["add", "-A"]);
 
     let out = run(home, &root, "kendex", &["guard", "run", "pre-commit"]);
@@ -238,7 +238,11 @@ fn a_linked_worktree_is_served_by_the_main_checkouts_copy() {
     );
 
     // The chain runs there, resolved from the main checkout.
-    std::fs::write(linked.join("b.rs"), "// TODO: not yet\n").unwrap();
+    std::fs::write(
+        linked.join("b.rs"),
+        format!("// {}{}: not yet\n", "TO", "DO"),
+    )
+    .unwrap();
     git_ok(home, &linked, &["add", "-A"]);
     let blocked = git(home, &linked, &["commit", "-m", "feat: adds a marker"]);
     assert!(!blocked.status.success(), "{}", said(&blocked));
@@ -382,7 +386,7 @@ fn a_broken_copy_does_not_shadow_a_working_one() {
         std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o644)).unwrap();
     }
 
-    std::fs::write(root.join("b.rs"), "// TODO: not yet\n").unwrap();
+    std::fs::write(root.join("b.rs"), format!("// {}{}: not yet\n", "TO", "DO")).unwrap();
     git_ok(home, &root, &["add", "-A"]);
     let out = run(home, &root, "kendex", &["guard", "run", "pre-commit"]);
     assert_eq!(out.status.code(), Some(1), "{}", said(&out));
@@ -415,7 +419,7 @@ fn a_path_with_an_apostrophe_resolves_the_same_on_both_sides() {
     assert!(helper.contains("'\\''"), "the path was escaped: {helper}");
 
     // Both sides run the same copy: a real commit, and kendex's own lane.
-    std::fs::write(root.join("b.rs"), "// TODO: not yet\n").unwrap();
+    std::fs::write(root.join("b.rs"), format!("// {}{}: not yet\n", "TO", "DO")).unwrap();
     git_ok(home, &root, &["add", "-A"]);
     let blocked = git(home, &root, &["commit", "-m", "feat: adds a marker"]);
     assert!(!blocked.status.success(), "{}", said(&blocked));
@@ -465,7 +469,11 @@ fn a_project_below_the_git_toplevel_is_found_where_it_renders() {
     );
 
     // The chain runs from there, resolved through the project's manifest.
-    std::fs::write(project.join("b.rs"), "// TODO: not yet\n").unwrap();
+    std::fs::write(
+        project.join("b.rs"),
+        format!("// {}{}: not yet\n", "TO", "DO"),
+    )
+    .unwrap();
     git_ok(home, &outer, &["add", "-A"]);
     let out = run(home, &project, "kendex", &["guard", "run", "pre-commit"]);
     assert_eq!(out.status.code(), Some(1), "{}", said(&out));
@@ -535,7 +543,7 @@ fn a_tampered_helper_does_not_redirect_the_guard_verbs() {
     std::fs::set_permissions(&helper, std::fs::Permissions::from_mode(0o755)).unwrap();
 
     // The verbs fall through to the search roots and run the real package.
-    std::fs::write(root.join("b.rs"), "// TODO: not yet\n").unwrap();
+    std::fs::write(root.join("b.rs"), format!("// {}{}: not yet\n", "TO", "DO")).unwrap();
     git_ok(home, &root, &["add", "-A"]);
     let out = run(home, &root, "kendex", &["guard", "run", "pre-commit"]);
     assert!(

--- a/crates/cli/tests/install_ux/guarding.rs
+++ b/crates/cli/tests/install_ux/guarding.rs
@@ -114,7 +114,11 @@ fn the_guards_travel_with_the_repository_and_gate_a_clone() {
     // Arming in the clone is the one act that needs a tool. After it, the
     // gate is committed shell and git, and nothing else.
     crate::run(&world.home, &clone, &["guard", "install"]);
-    fs::write(clone.join("late.rs"), "// TODO: not yet\n").unwrap();
+    fs::write(
+        clone.join("late.rs"),
+        format!("// {}{}: not yet\n", "TO", "DO"),
+    )
+    .unwrap();
     git_without_kendex(&clone, &["add", "-A"]);
     let blocked = git_without_kendex(&clone, &["commit", "-m", "feat: adds a marker"]);
     assert!(!blocked.status.success(), "{}", spoke(&blocked));

--- a/skills/preflight/tests/precision.test.sh
+++ b/skills/preflight/tests/precision.test.sh
@@ -399,7 +399,7 @@ clean "a vitest invocation chained after && wires the suite"
 # is a comment wires nothing.
 seed prosecomment
 mkdir -p "$R/.github/workflows"
-printf 'name: ci\non: push\n# TODO(#1): migrate to vitest — run: vitest someday\njobs:\n  t:\n    runs-on: ubuntu-latest\n    steps:\n      - run: bash tests/other.test.sh\n' >"$R/.github/workflows/ci.yml"
+printf 'name: ci\non: push\n# TO''DO(#1): migrate to vitest — run: vitest someday\njobs:\n  t:\n    runs-on: ubuntu-latest\n    steps:\n      - run: bash tests/other.test.sh\n' >"$R/.github/workflows/ci.yml"
 git -C "$R" add -A
 git -C "$R" commit -qm "workflow mentioning vitest only in a comment"
 printf 'export {}\n' >"$R/p.test.ts"

--- a/tools/todo-ban-excludes
+++ b/tools/todo-ban-excludes
@@ -3,3 +3,4 @@
 # Format: pattern<TAB>reason (gitignore-style against the repo-relative path; ** crosses /).
 
 skills/iced-rs/**	vendored upstream iced source and examples bundled as the skill's API reference — upstream's markers are not this repo's work
+.agents/skills/iced-rs/**	the committed render of the row above — the same vendored source, scanned again where kendex writes it


### PR DESCRIPTION
Closes KEN-689. Unblocks every commit in this repo.

`skills/growth-guards/scripts/todo-ban` fails on a clean `main` (072dd584) with 24 work markers, so the package's own pre-commit chain refuses every commit. Reproduced in a detached worktree at `origin/main`, with no local changes, before touching anything here. None of the 24 is work anyone owes.

## Eleven fixtures the check wrote about itself

`crates/cli/tests/guard_hooks/gating.rs` (8), `crates/cli/tests/install_ux/guarding.rs` (1), and `skills/preflight/tests/precision.test.sh` with its render (2) write marker strings to prove the check blocks a commit — then the check reads them back as first-party work.

The suite these replaced already had the answer. `crates/cli/tests/guard_env.rs` wrote its fixture as `format!("// {}{}: not yet\n", "TO", "DO")`, split so the test data could not trip the scanner under test. The rewrite spelled it literally, and that is what turned the lane red. The split is restored, in the Rust suites and in the shell fixture, where two adjacent quoted strings do the same job.

## Thirteen from a render nobody excluded

`.agents/skills/iced-rs/**` is the committed render of a vendored tree `tools/todo-ban-excludes` already covers at `skills/iced-rs/**`. The render is scanned as though it were this repo's own source.

That is the general shape worth naming: an exclusion written against a catalog source needs its render counterpart, or the committed-render posture scans the same vendored bytes a second time under a different path. The row is added beside the one it mirrors, with that reason.

## Verification

`skills/growth-guards/scripts/todo-ban` exits 0 on this branch and 1 on its parent. Full commit chain green — size-ratchet (2388 files), preflight, all four growth-guards lanes, `tools/guard`. `cargo test --workspace` green; `guard_hooks` 29 and `install_ux` 36 pass with the rewritten fixtures, and `skills/preflight/tests/precision.test.sh` passes 60. The edited shell fixture and its render are byte-identical, so the next `kendex refresh` is a no-op over them.

Found while rebasing #1671 (KEN-669) over #1669; that branch does not touch any file here.
