### PR TITLE
fix(review-gate): the awaiting status names this repo's eligible reviewers, and the CI packages' docs pass

### DIFF
--- a/.agents/skills/preflight/README.md
+++ b/.agents/skills/preflight/README.md
@@ -2,24 +2,47 @@
 
 A diff-scoped, fail-only checker for the escape classes worth catching
 mechanically: fail-open bash, new suites no runner invokes, scratch
-directories no EXIT trap removes, directories created at hardcoded
-absolute temp paths, docs citing repo paths that do not exist,
-source files citing docs that do not exist, TODO markers with no issue
-behind them, reviewer-bot attributions in durable prose, and data files
-no parser accepts.
-It reports only on lines the change added, and every lane is tuned so a
-finding is worth a hard failure — a false positive costs more than a miss,
-so a lane that cannot decide stays quiet.
+directories no EXIT trap removes, directories created at hardcoded absolute
+temp paths, docs citing repo paths that do not exist, source files citing
+docs that do not exist, TODO markers with no issue behind them, reviewer-bot
+attributions in durable prose, data files no parser accepts, and workflow
+`run:` blocks their own shell cannot parse.
+
+Findings land only on lines a change ADDED, and there is no warnings tier: a
+lane that cannot decide stays quiet, so every finding is worth a hard failure.
 
 ```bash
-.agents/skills/preflight/scripts/preflight --staged
+.agents/skills/preflight/scripts/preflight              # vs the default branch's merge base
+.agents/skills/preflight/scripts/preflight --staged     # the staged index
+.agents/skills/preflight/scripts/preflight --all        # every tracked file, every line
+```
+
+```
 docs/guide.md:41: [docs-cited-paths] cites a path that does not exist: docs/setup.md
 preflight: 1 finding(s) across 3 changed file(s)
 ```
 
-Exit codes: `0` clean, `1` findings, `2` usage or environment error.
-Requirements: `git`, `awk`, and the usual POSIX userland; `shellcheck`,
-`jq`, `taplo` and `python3` (with PyYAML for the workflow lane) are each
-optional and each enable one lane.
-Bash 3.2 compatible. Lane table, scope rules, and wiring into validation,
-hooks and CI: [SKILL.md](SKILL.md).
+`--base REF` sets the comparison point, `--repo PATH` runs against another
+checkout. Exit codes: `0` clean, `1` findings, `2` usage or environment error.
+
+## Wiring it
+
+**Validation.** Run it ahead of the project's own build, lint and test
+command, so a finding lands before a long run does.
+
+**Commit time.** Where `growth-guards` is also installed, its pre-commit
+chain runs `preflight --staged` itself — nothing to wire. Any other hook
+calls the script with `--staged`.
+
+**CI.** `preflight --base origin/<default-branch>` on the PR head. The
+installed skill must be committed: a CI checkout sees tracked files only,
+never a machine-local `.agents` symlink.
+
+## Requirements
+
+`git`, `awk`, and the usual POSIX userland; Bash 3.2 compatible.
+`shellcheck`, `jq`, `taplo` and `python3` (with PyYAML) are each optional and
+each enable one lane; a lane whose tool is missing skips silently.
+
+Lane table, scope rules, and the subtrees each lane skips:
+[SKILL.md](SKILL.md).

--- a/.agents/skills/review-gate/DEVELOPMENT.md
+++ b/.agents/skills/review-gate/DEVELOPMENT.md
@@ -11,7 +11,8 @@ Paths are as installed in a consuming repo, under
 
 | File | What it is |
 |------|------------|
-| `scripts/review-predicate.sh` | Answers "is this head reviewed?" — verdict on stdout, exit 2 means no verdict, take no action. `--check-config` runs its settings-validation phase alone. |
+| `scripts/review-predicate.sh` | Answers "is this head reviewed?" — verdict on stdout, exit 2 means no verdict, take no action. `--check-config` runs its settings-validation phase alone. Resolves which sources could open the gate at this head, and calls the composer below for the awaiting verdict's description. |
+| `scripts/awaiting-detail.sh` | Fits that resolved source list into the 140 characters GitHub keeps of a status description. Decides no eligibility of its own. Required at runtime: the predicate exits 2 with no verdict if it fails. |
 | `scripts/review-writer.sh` | Posts that answer as the commit status. The whole writer. |
 | `scripts/validate.sh` | The consumer-facing tool: is this repo's install sound? Runtime, settings, carry-forward exclusions, then the workflow half below, whose verdicts it relays and counts. |
 | `scripts/validate-workflow.sh` | Is the adopted copy still the shipped template? Equality, not re-derivation: see § Equality, not re-derivation. Usable on its own when only the workflow copy changed. |

--- a/.agents/skills/review-gate/README.md
+++ b/.agents/skills/review-gate/README.md
@@ -12,8 +12,7 @@ gate is disabled, and merge-queue statuses post success unread as
 description — [references/settings.md](references/settings.md) §
 `REVIEW_GATE_MODE`.
 
-It does **not** run or inspect your tests. That is branch protection's job,
-and keeping the two apart is what makes this small enough to trust.
+It does **not** run or inspect your tests. That is branch protection's job.
 
 ## What you do
 

--- a/.agents/skills/review-gate/SKILL.md
+++ b/.agents/skills/review-gate/SKILL.md
@@ -37,10 +37,14 @@ the gate; and merge-group statuses never read the mode, posting green as
 | (exit 2, no verdict) | *unchanged* | A read failed or config is invalid. Take NO action; retry next pass. |
 
 **Reading the gate's own pending text.** `no review evidence at <sha> yet;
-bots re-review each push, not a block on a human` is the `awaiting` verdict:
-the ordinary re-review window after a push, never a wait for a person. If a
-trusted reviewer has already reviewed this head, dispatch the writer instead
-of waiting; wait on a human only where the repo configures one.
+expected from <names>` is the `awaiting` verdict. The names are the repo's
+own configured evidence sources, so the text says who this repo is waiting
+for: bots there means the ordinary re-review window after a push, and a
+person's name means a person. Past 140 characters the sha shortens to 12 and
+the names that do not fit are counted (`and N more`).
+
+Act on the names, not on the pending state: where they are bots and one has
+already reviewed this head, dispatch the writer instead of waiting.
 
 # Working in a consumer repo
 

--- a/.agents/skills/review-gate/SKILL.md
+++ b/.agents/skills/review-gate/SKILL.md
@@ -37,11 +37,14 @@ the gate; and merge-group statuses never read the mode, posting green as
 | (exit 2, no verdict) | *unchanged* | A read failed or config is invalid. Take NO action; retry next pass. |
 
 **Reading the gate's own pending text.** `no review evidence at <sha> yet;
-expected from <names>` is the `awaiting` verdict. The names are the repo's
-own configured evidence sources, so the text says who this repo is waiting
-for: bots there means the ordinary re-review window after a push, and a
-person's name means a person. Past 140 characters the sha shortens to 12 and
-the names that do not fit are counted (`and N more`).
+expected from <names>` is the `awaiting` verdict. The names are the sources
+that could still open the gate at that head, resolved from the repo's own
+settings and filtered the way the evidence read filters them — the PR author
+never appears, and an empty trust list reads as `any non-author review` (or
+`approval` under `REVIEW_GATE_REVIEW_OBJECT_MIN_STATE = "approved"`). Past
+140 characters the sha shortens to 12 and the names that do not fit are
+counted (`and N more`). `no configured source is eligible here` means every
+configured login is the author.
 
 Act on the names, not on the pending state: where they are bots and one has
 already reviewed this head, dispatch the writer instead of waiting.

--- a/.agents/skills/review-gate/SKILL.md
+++ b/.agents/skills/review-gate/SKILL.md
@@ -43,8 +43,9 @@ settings and filtered the way the evidence read filters them — the PR author
 never appears, and an empty trust list reads as `any non-author review` (or
 `approval` under `REVIEW_GATE_REVIEW_OBJECT_MIN_STATE = "approved"`). Past
 140 characters the sha shortens to 12 and the names that do not fit are
-counted (`and N more`). `no configured source is eligible here` means every
-configured login is the author.
+counted (`and N more`). A configured operator override is a source too, and
+is named with the rest. `no configured source is eligible here` means every
+configured login is the author and no override is set.
 
 Act on the names, not on the pending state: where they are bots and one has
 already reviewed this head, dispatch the writer instead of waiting.

--- a/.agents/skills/review-gate/SKILL.md
+++ b/.agents/skills/review-gate/SKILL.md
@@ -36,12 +36,11 @@ the gate; and merge-group statuses never read the mode, posting green as
 | `changes-requested` | `failure` | A reviewer objects. Red means objection — never a build failure. |
 | (exit 2, no verdict) | *unchanged* | A read failed or config is invalid. Take NO action; retry next pass. |
 
-**Reading the gate's own pending text.** `awaiting a non-author review for
-<sha>` means no review evidence exists at that head yet — the ordinary
-re-review window after a push, not a wait for a person. The bots are the
-non-author reviewers: if a trusted one has already reviewed this head,
-dispatch the writer instead of waiting, and wait on a human only where the
-repo configures one.
+**Reading the gate's own pending text.** `no review evidence at <sha> yet;
+bots re-review each push, not a block on a human` is the `awaiting` verdict:
+the ordinary re-review window after a push, never a wait for a person. If a
+trusted reviewer has already reviewed this head, dispatch the writer instead
+of waiting; wait on a human only where the repo configures one.
 
 # Working in a consumer repo
 

--- a/.agents/skills/review-gate/scripts/awaiting-detail.sh
+++ b/.agents/skills/review-gate/scripts/awaiting-detail.sh
@@ -77,10 +77,14 @@ done <<EOF
 $SOURCES
 EOF
 
+# "source", not "reviewer": SOURCES also carries trusted status and check
+# contexts, and one long context is exactly the value that exhausts this
+# budget. Counting it as a reviewer would send a reader looking for a person
+# who is not configured.
 if [ "$kept" = "0" ] && [ "$count" = "1" ]; then
-  printf '%s' "${short_form}1 configured reviewer"
+  printf '%s' "${short_form}1 configured source"
 elif [ "$kept" = "0" ]; then
-  printf '%s' "$short_form$count configured reviewers"
+  printf '%s' "$short_form$count configured sources"
 elif [ "$kept" = "$count" ]; then
   printf '%s' "$short_form$shown"
 else

--- a/.agents/skills/review-gate/scripts/awaiting-detail.sh
+++ b/.agents/skills/review-gate/scripts/awaiting-detail.sh
@@ -43,7 +43,10 @@ if [ "$count" = "0" ]; then
   exit 0
 fi
 
-joined="$(printf '%s\n' "$SOURCES" | tr '\n' ',' | sed 's/,$//; s/,/, /g')"
+# Joined by RECORD, never by character: a status context is free-form and may
+# hold a comma, and rewriting every comma into ", " advertised `lint,build` as
+# the nonexistent `lint, build`.
+joined="$(printf '%s\n' "$SOURCES" | awk 'NR == 1 { printf "%s", $0; next } { printf ", %s", $0 }')"
 detail="$full_form$joined"
 if [ "${#detail}" -le "$RG_STATUS_LIMIT" ]; then
   printf '%s' "$detail"

--- a/.agents/skills/review-gate/scripts/awaiting-detail.sh
+++ b/.agents/skills/review-gate/scripts/awaiting-detail.sh
@@ -1,0 +1,104 @@
+#!/usr/bin/env bash
+# The awaiting verdict's status description, composed from the evidence
+# sources a repo's resolved settings actually enable. review-predicate.sh
+# calls this on its awaiting arm and prints the result as the pending status.
+#
+# The gate is configuration-driven, so the text names what THIS repo is
+# waiting for instead of asserting who reviews: a repo whose trust lists hold
+# only human logins reads those people's names, a repo trusting bots reads the
+# bots. Nothing is resolved here — the caller passes its already-resolved
+# values, and lib/settings.sh stays the one resolver.
+#
+# Inputs (environment): HEAD_SHA, TRUSTED_LOGINS, TRUSTED_CONTEXTS,
+# COMMENT_REVIEWERS. Output: the description on stdout, no trailing newline.
+#
+# GitHub truncates a commit-status description at 140 characters, and a real
+# trust list is longer than that on its own. So the sha shortens to its
+# 12-character prefix before any name is dropped, and the names that still do
+# not fit are counted rather than cut mid-word.
+set -euo pipefail
+
+RG_STATUS_LIMIT=140
+
+HEAD_SHA="${HEAD_SHA:-}"
+TRUSTED_LOGINS="${TRUSTED_LOGINS:-}"
+TRUSTED_CONTEXTS="${TRUSTED_CONTEXTS:-}"
+COMMENT_REVIEWERS="${COMMENT_REVIEWERS:-}"
+
+# A packed list -> one name per line, whitespace trimmed, blanks dropped.
+# SEPARATORS is the tr set for that setting's own packing.
+names_of() { # LIST SEPARATORS
+  local item
+  # printf '%s\n', never '%s': an unterminated last line is not read at all,
+  # which would drop the only entry of a single-name list.
+  printf '%s\n' "$1" | tr "$2" '\n' | while IFS= read -r item; do
+    item="${item#"${item%%[![:space:]]*}"}"
+    item="${item%"${item##*[![:space:]]}"}"
+    [ -n "$item" ] && printf '%s\n' "$item"
+  done
+  return 0
+}
+
+# Every evidence source the settings name, in the decision table's order:
+# trusted review-object logins, trusted status/check contexts, then the
+# comment-form reviewers — their login half only, since the binding pattern is
+# not a name a reader can act on.
+sources() { # -> one name per line, duplicates collapsed
+  {
+    names_of "$TRUSTED_LOGINS" ';,'
+    names_of "$TRUSTED_CONTEXTS" ';'
+    names_of "$COMMENT_REVIEWERS" ';' | sed 's/:.*$//'
+  } | awk '!seen[$0]++'
+}
+
+full_form="no review evidence at $HEAD_SHA yet; expected from "
+short_form="no review evidence at ${HEAD_SHA:0:12} yet; expected from "
+
+names="$(sources)"
+count=0
+[ -n "$names" ] && count="$(printf '%s\n' "$names" | wc -l | tr -d ' ')"
+
+# Empty trust lists mean any non-author review is evidence. That is a source
+# too, so it is named rather than leaving the clause blank.
+if [ "$count" = "0" ]; then
+  detail="${full_form}any non-author review"
+  [ "${#detail}" -le "$RG_STATUS_LIMIT" ] || detail="${short_form}any non-author review"
+  printf '%s' "$detail"
+  exit 0
+fi
+
+joined="$(printf '%s\n' "$names" | tr '\n' ',' | sed 's/,$//; s/,/, /g')"
+detail="$full_form$joined"
+if [ "${#detail}" -le "$RG_STATUS_LIMIT" ]; then
+  printf '%s' "$detail"
+  exit 0
+fi
+
+# The full sha does not fit beside the names. Shorten it once, then fill the
+# remaining budget with whole names and count whatever is left over.
+kept=0
+shown=""
+while IFS= read -r name; do
+  if [ -z "$shown" ]; then candidate="$name"; else candidate="$shown, $name"; fi
+  # Reserve room for the remainder clause (" and N more") before accepting a
+  # name: a clause that no longer fits would be dropped silently, and an
+  # absent count reads as a complete list.
+  if [ $((${#short_form} + ${#candidate} + 10 + ${#count})) -le "$RG_STATUS_LIMIT" ]; then
+    shown="$candidate"
+    kept=$((kept + 1))
+  else
+    break
+  fi
+done <<EOF
+$names
+EOF
+
+if [ "$kept" = "0" ] && [ "$count" = "1" ]; then
+  printf '%s' "${short_form}1 configured reviewer"
+elif [ "$kept" = "0" ]; then
+  printf '%s' "$short_form$count configured reviewers"
+elif [ "$kept" = "$count" ]; then
+  printf '%s' "$short_form$shown"
+else
+  printf '%s' "$short_form$shown and $((count - kept)) more"
+fi

--- a/.agents/skills/review-gate/scripts/awaiting-detail.sh
+++ b/.agents/skills/review-gate/scripts/awaiting-detail.sh
@@ -1,81 +1,65 @@
 #!/usr/bin/env bash
-# The awaiting verdict's status description, composed from the evidence
-# sources a repo's resolved settings actually enable. review-predicate.sh
-# calls this on its awaiting arm and prints the result as the pending status.
+# The awaiting verdict's status description. review-predicate.sh calls this on
+# its awaiting arm and prints the result as the pending status.
 #
-# The gate is configuration-driven, so the text names what THIS repo is
-# waiting for instead of asserting who reviews: a repo whose trust lists hold
-# only human logins reads those people's names, a repo trusting bots reads the
-# bots. Nothing is resolved here — the caller passes its already-resolved
-# values, and lib/settings.sh stays the one resolver.
+# This script decides NOTHING about evidence. Which sources could still open
+# the gate at this head is the predicate's judgment — it resolves the trust
+# settings, applies each source's policy and filters the PR author — and it
+# passes the answer in. All that happens here is fitting that answer into the
+# 140 characters GitHub keeps of a commit-status description.
 #
-# Inputs (environment): HEAD_SHA, TRUSTED_LOGINS, TRUSTED_CONTEXTS,
-# COMMENT_REVIEWERS. Output: the description on stdout, no trailing newline.
+# The text names what THIS repo is waiting for rather than asserting who
+# reviews: a gate whose trust lists hold only human logins reads those
+# people's names, a gate trusting bots reads the bots.
 #
-# GitHub truncates a commit-status description at 140 characters, and a real
-# trust list is longer than that on its own. So the sha shortens to its
-# 12-character prefix before any name is dropped, and the names that still do
-# not fit are counted rather than cut mid-word.
+# Inputs (environment): HEAD_SHA, and SOURCES as one eligible source per line.
+# Output: the description on stdout, no trailing newline.
+#
+# A real trust list is longer than the whole limit on its own, so the sha
+# shortens to its 12-character prefix before any name is dropped, and the
+# names that still do not fit are counted rather than cut mid-word.
 set -euo pipefail
 
 RG_STATUS_LIMIT=140
 
 HEAD_SHA="${HEAD_SHA:-}"
-TRUSTED_LOGINS="${TRUSTED_LOGINS:-}"
-TRUSTED_CONTEXTS="${TRUSTED_CONTEXTS:-}"
-COMMENT_REVIEWERS="${COMMENT_REVIEWERS:-}"
-
-# A packed list -> one name per line, whitespace trimmed, blanks dropped.
-# SEPARATORS is the tr set for that setting's own packing.
-names_of() { # LIST SEPARATORS
-  local item
-  # printf '%s\n', never '%s': an unterminated last line is not read at all,
-  # which would drop the only entry of a single-name list.
-  printf '%s\n' "$1" | tr "$2" '\n' | while IFS= read -r item; do
-    item="${item#"${item%%[![:space:]]*}"}"
-    item="${item%"${item##*[![:space:]]}"}"
-    [ -n "$item" ] && printf '%s\n' "$item"
-  done
-  return 0
-}
-
-# Every evidence source the settings name, in the decision table's order:
-# trusted review-object logins, trusted status/check contexts, then the
-# comment-form reviewers — their login half only, since the binding pattern is
-# not a name a reader can act on.
-sources() { # -> one name per line, duplicates collapsed
-  {
-    names_of "$TRUSTED_LOGINS" ';,'
-    names_of "$TRUSTED_CONTEXTS" ';'
-    names_of "$COMMENT_REVIEWERS" ';' | sed 's/:.*$//'
-  } | awk '!seen[$0]++'
-}
+SOURCES="${SOURCES:-}"
 
 full_form="no review evidence at $HEAD_SHA yet; expected from "
 short_form="no review evidence at ${HEAD_SHA:0:12} yet; expected from "
 
-names="$(sources)"
 count=0
-[ -n "$names" ] && count="$(printf '%s\n' "$names" | wc -l | tr -d ' ')"
+[ -n "$SOURCES" ] && count="$(printf '%s\n' "$SOURCES" | wc -l | tr -d ' ')"
 
-# Empty trust lists mean any non-author review is evidence. That is a source
-# too, so it is named rather than leaving the clause blank.
+# No eligible source at all — a repo whose only trusted login is the PR
+# author reaches this. Saying "expected from" nothing would read as a
+# truncated status, so it names the state instead.
 if [ "$count" = "0" ]; then
-  detail="${full_form}any non-author review"
-  [ "${#detail}" -le "$RG_STATUS_LIMIT" ] || detail="${short_form}any non-author review"
+  detail="no review evidence at $HEAD_SHA yet; no configured source is eligible here"
+  if [ "${#detail}" -gt "$RG_STATUS_LIMIT" ]; then
+    detail="no review evidence at ${HEAD_SHA:0:12} yet; no configured source is eligible here"
+  fi
   printf '%s' "$detail"
   exit 0
 fi
 
-joined="$(printf '%s\n' "$names" | tr '\n' ',' | sed 's/,$//; s/,/, /g')"
+joined="$(printf '%s\n' "$SOURCES" | tr '\n' ',' | sed 's/,$//; s/,/, /g')"
 detail="$full_form$joined"
 if [ "${#detail}" -le "$RG_STATUS_LIMIT" ]; then
   printf '%s' "$detail"
   exit 0
 fi
 
-# The full sha does not fit beside the names. Shorten it once, then fill the
-# remaining budget with whole names and count whatever is left over.
+# The full sha does not fit beside the names. Shorten it and try the whole
+# list again BEFORE reserving room for any remainder clause — reserving first
+# would drop a name that the short form has room for.
+detail="$short_form$joined"
+if [ "${#detail}" -le "$RG_STATUS_LIMIT" ]; then
+  printf '%s' "$detail"
+  exit 0
+fi
+
+# Still over. Fill the remaining budget with whole names and count the rest.
 kept=0
 shown=""
 while IFS= read -r name; do
@@ -90,7 +74,7 @@ while IFS= read -r name; do
     break
   fi
 done <<EOF
-$names
+$SOURCES
 EOF
 
 if [ "$kept" = "0" ] && [ "$count" = "1" ]; then

--- a/.agents/skills/review-gate/scripts/review-predicate-selftest.sh
+++ b/.agents/skills/review-gate/scripts/review-predicate-selftest.sh
@@ -535,25 +535,6 @@ echo "--- mechanism layer (forced configuration)"
 # has become unconditionally true and every case below is meaningless.
 reset
 run "no evidence at all" awaiting
-# The awaiting detail is the one verdict a reader acts on wrongly: read as an
-# approval block, it stalls a PR that only has to wait out the re-review
-# window. Pin the exact line, and its fit inside the status API's 140-char
-# description limit with a full 40-char sha substituted.
-awaiting_detail="$(PATH="$shim:$PATH" GH_SHIM_FIXTURES="$fixtures" \
-  REVIEW_GATE_SETTINGS_FILE=/dev/null REVIEW_GATE_MODE=enforce \
-  GH_REPO="owner/repo" PR_NUMBER=1 HEAD_SHA="$HEAD" PR_AUTHOR="$AUTHOR" \
-  "$predicate" 2>/dev/null)"
-awaiting_detail="${awaiting_detail#verdict=awaiting detail=}"
-cases=$((cases + 1))
-if [ "$awaiting_detail" != "no review evidence at $HEAD yet; bots re-review each push, not a block on a human" ]; then
-  echo "FAIL  awaiting detail drifted: '$awaiting_detail'" >&2
-  failures=$((failures + 1))
-elif [ "${#awaiting_detail}" -gt 140 ]; then
-  echo "FAIL  awaiting detail is ${#awaiting_detail} characters; the status API truncates at 140" >&2
-  failures=$((failures + 1))
-else
-  echo "ok    awaiting: the pending detail is exact and fits the 140-char status limit"
-fi
 
 reset
 export GH_SHIM_FAIL=reviews

--- a/.agents/skills/review-gate/scripts/review-predicate-selftest.sh
+++ b/.agents/skills/review-gate/scripts/review-predicate-selftest.sh
@@ -535,6 +535,25 @@ echo "--- mechanism layer (forced configuration)"
 # has become unconditionally true and every case below is meaningless.
 reset
 run "no evidence at all" awaiting
+# The awaiting detail is the one verdict a reader acts on wrongly: read as an
+# approval block, it stalls a PR that only has to wait out the re-review
+# window. Pin the exact line, and its fit inside the status API's 140-char
+# description limit with a full 40-char sha substituted.
+awaiting_detail="$(PATH="$shim:$PATH" GH_SHIM_FIXTURES="$fixtures" \
+  REVIEW_GATE_SETTINGS_FILE=/dev/null REVIEW_GATE_MODE=enforce \
+  GH_REPO="owner/repo" PR_NUMBER=1 HEAD_SHA="$HEAD" PR_AUTHOR="$AUTHOR" \
+  "$predicate" 2>/dev/null)"
+awaiting_detail="${awaiting_detail#verdict=awaiting detail=}"
+cases=$((cases + 1))
+if [ "$awaiting_detail" != "no review evidence at $HEAD yet; bots re-review each push, not a block on a human" ]; then
+  echo "FAIL  awaiting detail drifted: '$awaiting_detail'" >&2
+  failures=$((failures + 1))
+elif [ "${#awaiting_detail}" -gt 140 ]; then
+  echo "FAIL  awaiting detail is ${#awaiting_detail} characters; the status API truncates at 140" >&2
+  failures=$((failures + 1))
+else
+  echo "ok    awaiting: the pending detail is exact and fits the 140-char status limit"
+fi
 
 reset
 export GH_SHIM_FAIL=reviews

--- a/.agents/skills/review-gate/scripts/review-predicate.sh
+++ b/.agents/skills/review-gate/scripts/review-predicate.sh
@@ -1384,9 +1384,9 @@ awaiting_sources() { # -> one eligible source per line, duplicates collapsed
       # 'approved' a COMMENTED review does not satisfy this source, so the
       # text must not send a reader to leave one.
       if [ "$MIN_STATE" = "approved" ]; then
-        echo "any non-author approval"
+        printf '%s\n' "any non-author approval"
       else
-        echo "any non-author review"
+        printf '%s\n' "any non-author review"
       fi
     else
       aw_eligible "$TRUSTED_LOGINS_N"
@@ -1397,8 +1397,10 @@ awaiting_sources() { # -> one eligible source per line, duplicates collapsed
     # way to open the gate and belongs in the list. Leaving it out told an
     # operator nothing was eligible while the recovery path they own was
     # configured and working. Empty means the source is disabled.
+    # printf, not echo: a status context is free-form, and bash's echo eats a
+    # value like -n or -e as an option and prints no name at all.
     if [ -n "$OUTAGE_CONTEXT" ]; then
-      echo "$OUTAGE_CONTEXT"
+      printf '%s\n' "$OUTAGE_CONTEXT"
     fi
   } | awk '!seen[$0]++'
 }

--- a/.agents/skills/review-gate/scripts/review-predicate.sh
+++ b/.agents/skills/review-gate/scripts/review-predicate.sh
@@ -271,12 +271,24 @@ THREADS_MODE="$(rg_setting REVIEW_GATE_THREADS "enforce")" || exit 2
 # checks, the evidence reads, and the awaiting label. Entry boundaries and
 # emptiness are decided once, so a value like " ; , " cannot be an open trust
 # model to one reader and a named list to another.
+# pipefail inside, checked at every caller: this decides the trust boundary,
+# and the last stage of the pipeline returns 0 on empty output. A `tr` that
+# died would leave a RESTRICTED list looking empty, which the evidence read
+# takes as "any non-author" — the trust list would open the gate it was set
+# to close. A broken pipeline is exit 2 with no verdict instead.
 rg_pack() { # RAW SEPARATORS -> one trimmed, non-empty entry per line
-  printf '%s\n' "$1" | tr "$2" '\n' | sed 's/^[[:space:]]*//;s/[[:space:]]*$//;/^$/d'
+  ( set -o pipefail
+    printf '%s\n' "$1" | tr "$2" '\n' | sed 's/^[[:space:]]*//;s/[[:space:]]*$//;/^$/d' )
 }
-TRUSTED_LOGINS_N="$(rg_pack "$TRUSTED_LOGINS" ';,')"
-TRUSTED_CONTEXTS_N="$(rg_pack "$TRUSTED_CONTEXTS" ';')"
-COMMENT_REVIEWERS_N="$(rg_pack "$COMMENT_REVIEWERS" ';')"
+# Called OUTSIDE the substitutions below: an `exit` inside `$( )` would leave
+# the subshell and the predicate would carry on with the empty value.
+rg_pack_failed() { # KEY
+  echo "::error::review-predicate: could not normalize $1 (broken pipeline) — no verdict" >&2
+  exit 2
+}
+TRUSTED_LOGINS_N="$(rg_pack "$TRUSTED_LOGINS" ';,')" || rg_pack_failed REVIEW_GATE_REVIEW_OBJECT_TRUSTED_LOGINS
+TRUSTED_CONTEXTS_N="$(rg_pack "$TRUSTED_CONTEXTS" ';')" || rg_pack_failed REVIEW_GATE_TRUSTED_STATUS_CONTEXTS
+COMMENT_REVIEWERS_N="$(rg_pack "$COMMENT_REVIEWERS" ';')" || rg_pack_failed REVIEW_GATE_COMMENT_REVIEWERS
 API_ATTEMPTS="$(rg_setting REVIEW_GATE_API_ATTEMPTS "1")" || exit 2
 API_RETRY_DELAY="$(rg_setting REVIEW_GATE_API_RETRY_DELAY_SECONDS "2")" || exit 2
 CARRY_FORWARD="$(rg_setting REVIEW_GATE_CARRY_FORWARD "")" || exit 2

--- a/.agents/skills/review-gate/scripts/review-predicate.sh
+++ b/.agents/skills/review-gate/scripts/review-predicate.sh
@@ -1337,7 +1337,7 @@ if [ "$cr" != "0" ]; then
 elif [ "$untracked" != "0" ]; then
   echo "verdict=untracked-claim detail=$untracked tracking claim(s) name no issue — write Declined: <reason>, or add the tracker/#id"
 elif [ "$got" = "0" ] && [ "$check" = "0" ] && [ "$comment_hits" = "0" ] && [ "$outageok" = "0" ] && [ "$carried" = "0" ]; then
-  echo "verdict=awaiting detail=awaiting a non-author review for $HEAD_SHA"
+  echo "verdict=awaiting detail=no review evidence at $HEAD_SHA yet; bots re-review each push, not a block on a human"
 elif [ "$unresolved" != "0" ]; then
   echo "verdict=threads-open detail=$unresolved unresolved review thread(s)"
 elif [ "$carried" = "1" ]; then

--- a/.agents/skills/review-gate/scripts/review-predicate.sh
+++ b/.agents/skills/review-gate/scripts/review-predicate.sh
@@ -1415,8 +1415,16 @@ elif [ "$got" = "0" ] && [ "$check" = "0" ] && [ "$comment_hits" = "0" ] && [ "$
   # Captured, never interpolated straight into the echo: a composer that
   # failed would otherwise leave an empty description on a verdict that still
   # printed, and a status is the only thing a reader gets.
+  # Captured on its OWN line: as an environment assignment on the composer
+  # command, this substitution's status is discarded and the composer would
+  # format whatever partial list it was handed and exit 0.
   awaiting_rc=0
-  awaiting_detail="$(HEAD_SHA="$HEAD_SHA" SOURCES="$(awaiting_sources)" "$script_dir/awaiting-detail.sh")" || awaiting_rc=$?
+  awaiting_srcs="$(awaiting_sources)" || awaiting_rc=$?
+  if [ "$awaiting_rc" != 0 ]; then
+    echo "::error::review-predicate: could not resolve the awaiting sources (exit $awaiting_rc) — no verdict" >&2
+    exit 2
+  fi
+  awaiting_detail="$(HEAD_SHA="$HEAD_SHA" SOURCES="$awaiting_srcs" "$script_dir/awaiting-detail.sh")" || awaiting_rc=$?
   if [ "$awaiting_rc" != 0 ] || [ -z "$awaiting_detail" ]; then
     echo "::error::review-predicate: scripts/awaiting-detail.sh failed (exit $awaiting_rc) — no verdict" >&2
     exit 2

--- a/.agents/skills/review-gate/scripts/review-predicate.sh
+++ b/.agents/skills/review-gate/scripts/review-predicate.sh
@@ -1337,7 +1337,7 @@ if [ "$cr" != "0" ]; then
 elif [ "$untracked" != "0" ]; then
   echo "verdict=untracked-claim detail=$untracked tracking claim(s) name no issue — write Declined: <reason>, or add the tracker/#id"
 elif [ "$got" = "0" ] && [ "$check" = "0" ] && [ "$comment_hits" = "0" ] && [ "$outageok" = "0" ] && [ "$carried" = "0" ]; then
-  echo "verdict=awaiting detail=no review evidence at $HEAD_SHA yet; bots re-review each push, not a block on a human"
+  echo "verdict=awaiting detail=$(HEAD_SHA="$HEAD_SHA" TRUSTED_LOGINS="$TRUSTED_LOGINS" TRUSTED_CONTEXTS="$TRUSTED_CONTEXTS" COMMENT_REVIEWERS="$COMMENT_REVIEWERS" "$script_dir/awaiting-detail.sh")"
 elif [ "$unresolved" != "0" ]; then
   echo "verdict=threads-open detail=$unresolved unresolved review thread(s)"
 elif [ "$carried" = "1" ]; then

--- a/.agents/skills/review-gate/scripts/review-predicate.sh
+++ b/.agents/skills/review-gate/scripts/review-predicate.sh
@@ -1330,6 +1330,43 @@ while :; do
 done
 fi
 
+# One packed list -> trimmed, non-empty entries, one per line. FILTER_AUTHOR
+# drops the PR author, whose own review and comment are never evidence.
+aw_entries() { # LIST SEPARATORS FILTER_AUTHOR
+  printf '%s\n' "$1" | tr "$2" '\n' | sed 's/^[[:space:]]*//;s/[[:space:]]*$//' |
+    while IFS= read -r aw_item; do
+      [ -z "$aw_item" ] && continue
+      [ "$3" = 1 ] && [ "$aw_item" = "$PR_AUTHOR" ] && continue
+      printf '%s\n' "$aw_item"
+    done
+}
+
+# The sources that could still open the gate at THIS head, under the same
+# rules the evaluation above applied: an empty review-object trust list
+# accepts any non-author review, a named list accepts those logins, and the
+# author is never evidence under either. Trusted status contexts are check
+# names rather than logins, so no author filter applies there. The awaiting
+# status is composed from this list — eligibility is decided here, and
+# awaiting-detail.sh only fits the answer into GitHub's description limit.
+awaiting_sources() { # -> one eligible source per line, duplicates collapsed
+  {
+    if [ -z "$TRUSTED_LOGINS" ]; then
+      # The minimum state is part of the policy, not decoration: under
+      # 'approved' a COMMENTED review does not satisfy this source, so the
+      # text must not send a reader to leave one.
+      if [ "$MIN_STATE" = "approved" ]; then
+        echo "any non-author approval"
+      else
+        echo "any non-author review"
+      fi
+    else
+      aw_entries "$TRUSTED_LOGINS" ';,' 1
+    fi
+    aw_entries "$TRUSTED_CONTEXTS" ';' 0
+    aw_entries "$(printf '%s' "$COMMENT_REVIEWERS" | sed 's/:[^;]*//g')" ';' 1
+  } | awk '!seen[$0]++'
+}
+
 echo "PR #$PR_NUMBER head $HEAD_SHA: reviews=$got clean-analysis=$check comment-form=$comment_hits outage-marker=$outageok carried=$carried changes-requested=$cr unresolved-threads=$unresolved untracked-claims=$untracked (threads=$THREADS_MODE)" >&2
 
 if [ "$cr" != "0" ]; then
@@ -1337,7 +1374,16 @@ if [ "$cr" != "0" ]; then
 elif [ "$untracked" != "0" ]; then
   echo "verdict=untracked-claim detail=$untracked tracking claim(s) name no issue — write Declined: <reason>, or add the tracker/#id"
 elif [ "$got" = "0" ] && [ "$check" = "0" ] && [ "$comment_hits" = "0" ] && [ "$outageok" = "0" ] && [ "$carried" = "0" ]; then
-  echo "verdict=awaiting detail=$(HEAD_SHA="$HEAD_SHA" TRUSTED_LOGINS="$TRUSTED_LOGINS" TRUSTED_CONTEXTS="$TRUSTED_CONTEXTS" COMMENT_REVIEWERS="$COMMENT_REVIEWERS" "$script_dir/awaiting-detail.sh")"
+  # Captured, never interpolated straight into the echo: a composer that
+  # failed would otherwise leave an empty description on a verdict that still
+  # printed, and a status is the only thing a reader gets.
+  awaiting_rc=0
+  awaiting_detail="$(HEAD_SHA="$HEAD_SHA" SOURCES="$(awaiting_sources)" "$script_dir/awaiting-detail.sh")" || awaiting_rc=$?
+  if [ "$awaiting_rc" != 0 ] || [ -z "$awaiting_detail" ]; then
+    echo "::error::review-predicate: scripts/awaiting-detail.sh failed (exit $awaiting_rc) — no verdict" >&2
+    exit 2
+  fi
+  echo "verdict=awaiting detail=$awaiting_detail"
 elif [ "$unresolved" != "0" ]; then
   echo "verdict=threads-open detail=$unresolved unresolved review thread(s)"
 elif [ "$carried" = "1" ]; then

--- a/.agents/skills/review-gate/scripts/review-predicate.sh
+++ b/.agents/skills/review-gate/scripts/review-predicate.sh
@@ -1393,6 +1393,13 @@ awaiting_sources() { # -> one eligible source per line, duplicates collapsed
     fi
     printf '%s\n' "$TRUSTED_CONTEXTS_N" | sed '/^$/d'
     aw_eligible "$COMMENT_REVIEWERS_N" 1
+    # The operator override is evidence this predicate accepts, so it is a
+    # way to open the gate and belongs in the list. Leaving it out told an
+    # operator nothing was eligible while the recovery path they own was
+    # configured and working. Empty means the source is disabled.
+    if [ -n "$OUTAGE_CONTEXT" ]; then
+      echo "$OUTAGE_CONTEXT"
+    fi
   } | awk '!seen[$0]++'
 }
 

--- a/.agents/skills/review-gate/scripts/review-predicate.sh
+++ b/.agents/skills/review-gate/scripts/review-predicate.sh
@@ -265,6 +265,18 @@ TRUSTED_LOGINS="$(rg_setting REVIEW_GATE_REVIEW_OBJECT_TRUSTED_LOGINS "")" || ex
 MIN_STATE="$(rg_setting REVIEW_GATE_REVIEW_OBJECT_MIN_STATE "any")" || exit 2
 ERROR_PATTERNS="$(rg_setting REVIEW_GATE_REVIEW_OBJECT_ERROR_PATTERNS "encountered an error and was unable to review")" || exit 2
 THREADS_MODE="$(rg_setting REVIEW_GATE_THREADS "enforce")" || exit 2
+
+# ONE parse of each packed trust list, here at the single place the settings
+# are resolved. Every consumer below works from these: the configuration
+# checks, the evidence reads, and the awaiting label. Entry boundaries and
+# emptiness are decided once, so a value like " ; , " cannot be an open trust
+# model to one reader and a named list to another.
+rg_pack() { # RAW SEPARATORS -> one trimmed, non-empty entry per line
+  printf '%s\n' "$1" | tr "$2" '\n' | sed 's/^[[:space:]]*//;s/[[:space:]]*$//;/^$/d'
+}
+TRUSTED_LOGINS_N="$(rg_pack "$TRUSTED_LOGINS" ';,')"
+TRUSTED_CONTEXTS_N="$(rg_pack "$TRUSTED_CONTEXTS" ';')"
+COMMENT_REVIEWERS_N="$(rg_pack "$COMMENT_REVIEWERS" ';')"
 API_ATTEMPTS="$(rg_setting REVIEW_GATE_API_ATTEMPTS "1")" || exit 2
 API_RETRY_DELAY="$(rg_setting REVIEW_GATE_API_RETRY_DELAY_SECONDS "2")" || exit 2
 CARRY_FORWARD="$(rg_setting REVIEW_GATE_CARRY_FORWARD "")" || exit 2
@@ -374,14 +386,13 @@ if [ "$OUTAGE_CONTEXT" = "$GATE_CONTEXT_SELF" ]; then
   exit 2
 fi
 while IFS= read -r ctx; do
-  ctx="$(printf '%s' "$ctx" | sed 's/^[[:space:]]*//;s/[[:space:]]*$//')"
   [ -z "$ctx" ] && continue
   if [ "$ctx" = "$GATE_CONTEXT_SELF" ]; then
     echo "::error::review-predicate: REVIEW_GATE_TRUSTED_STATUS_CONTEXTS includes REVIEW_GATE_CONTEXT ('$GATE_CONTEXT_SELF') — the gate's own status cannot be its own review evidence" >&2
     exit 2
   fi
 done <<EOF_GATE_CTX
-$(printf '%s' "$TRUSTED_CONTEXTS" | tr ';' '\n')
+$TRUSTED_CONTEXTS_N
 EOF_GATE_CTX
 
 # The exclusion pattern GRAMMAR, and the one judge of it. Callers that need
@@ -448,7 +459,6 @@ rg_check_patterns REVIEW_GATE_CARRY_FORWARD_EXCLUDE_PROPHYLACTIC "$CARRY_EXCLUDE
 # a PR to evaluate — otherwise --check-config reports a legal configuration
 # that the next live run exits 2 on.
 while IFS= read -r cfg_pair; do
-  cfg_pair="$(printf '%s' "$cfg_pair" | sed 's/^[[:space:]]*//;s/[[:space:]]*$//')"
   [ -z "$cfg_pair" ] && continue
   cfg_login="${cfg_pair%%:*}"
   cfg_pattern="${cfg_pair#*:}"
@@ -457,7 +467,7 @@ while IFS= read -r cfg_pair; do
     exit 2
   fi
 done <<EOF_COMMENT_CFG
-$(printf '%s' "$COMMENT_REVIEWERS" | tr ';' '\n')
+$COMMENT_REVIEWERS_N
 EOF_COMMENT_CFG
 
 # Every configuration rule above has now run, and --check-config stops HERE:
@@ -588,9 +598,9 @@ ATTESTATION_DEF='def not_errored_attestation($mk):
 # by a newer CHANGES_REQUESTED from that same login — a trailing COMMENTED
 # never withdraws an approval.
 got="$(jq --arg sha "$HEAD_SHA" --arg author "$PR_AUTHOR" \
-        --arg trusted "$TRUSTED_LOGINS" --arg minstate "$MIN_STATE" \
+        --arg trusted "$TRUSTED_LOGINS_N" --arg minstate "$MIN_STATE" \
         --arg errmarks "$ERROR_PATTERNS" "$ATTESTATION_DEF"'
-  ($trusted | split("[;,\n]+"; "") | map(gsub("^\\s+|\\s+$"; "")) | map(select(length > 0))) as $t
+  ($trusted | split("\n") | map(gsub("^\\s+|\\s+$"; "")) | map(select(length > 0))) as $t
   | ($errmarks | split(";") | map(gsub("^\\s+|\\s+$"; "")) | map(select(length > 0)) | map(ascii_downcase)) as $mk
   | [ .[]
       | select(.commit_id == $sha and .state != "DISMISSED" and .state != "PENDING" and .user.login != $author)
@@ -716,7 +726,6 @@ else
 fi
 check=0
 while IFS= read -r ctx; do
-  ctx="$(printf '%s' "$ctx" | sed 's/^[[:space:]]*//;s/[[:space:]]*$//')"
   [ -z "$ctx" ] && continue
   ctx_uri="$(jq -rn --arg s "$ctx" '$s|@uri')"
   # --paginate emits one OBJECT per page for this endpoint; jq -s merges the
@@ -883,7 +892,7 @@ while IFS= read -r ctx; do
   }
   check=$((check + check_runs + check_status))
 done <<EOF
-$(printf '%s' "$TRUSTED_CONTEXTS" | tr ';' '\n')
+$TRUSTED_CONTEXTS_N
 EOF
 
 # Comment-form clean-pass evidence: some reviewers post NEITHER a review
@@ -899,7 +908,7 @@ EOF
 # match every head. The trust anchor is the author login plus the LITERAL
 # binding pattern immediately preceding the sha slot, not the quoting.
 comment_hits=0
-if [ -n "$COMMENT_REVIEWERS" ]; then
+if [ -n "$COMMENT_REVIEWERS_N" ]; then
   # Two steps, not a pipe — same pagination/fail-loud/zero-byte reasons as
   # the reviews read above.
   raw_comments="$(gh_read "repos/$GH_REPO/issues/$PR_NUMBER/comments?per_page=100" --paginate)" || {
@@ -921,7 +930,6 @@ if [ -n "$COMMENT_REVIEWERS" ]; then
     exit 2
   }
   while IFS= read -r pair; do
-    pair="$(printf '%s' "$pair" | sed 's/^[[:space:]]*//;s/[[:space:]]*$//')"
     [ -z "$pair" ] && continue
     # Grammar was proved in the configuration phase above, which is the one
     # site for it; this loop only splits what that pass accepted.
@@ -951,7 +959,7 @@ if [ -n "$COMMENT_REVIEWERS" ]; then
     }
     comment_hits=$((comment_hits + hits))
   done <<EOF
-$(printf '%s' "$COMMENT_REVIEWERS" | tr ';' '\n')
+$COMMENT_REVIEWERS_N
 EOF
 fi
 
@@ -1050,9 +1058,9 @@ if [ -n "$CARRY_FORWARD" ] && [ "$got" = "0" ] && [ "$check" = "0" ] \
   # carry could matter), newest-first, distinct, never the head itself,
   # bounded so a force-push-heavy PR cannot turn the walk into an API storm.
   carry_candidates="$(jq -r --arg sha "$HEAD_SHA" --arg author "$PR_AUTHOR" \
-      --arg trusted "$TRUSTED_LOGINS" --arg minstate "$MIN_STATE" \
+      --arg trusted "$TRUSTED_LOGINS_N" --arg minstate "$MIN_STATE" \
       --arg errmarks "$ERROR_PATTERNS" "$ATTESTATION_DEF"'
-    ($trusted | split("[;,\n]+"; "") | map(gsub("^\\s+|\\s+$"; "")) | map(select(length > 0))) as $t
+    ($trusted | split("\n") | map(gsub("^\\s+|\\s+$"; "")) | map(select(length > 0))) as $t
     | ($errmarks | split(";") | map(gsub("^\\s+|\\s+$"; "")) | map(select(length > 0)) | map(ascii_downcase)) as $mk
     | [ .[]
         | select(.state != "DISMISSED" and .state != "PENDING" and .user.login != $author)
@@ -1332,11 +1340,16 @@ fi
 
 # One packed list -> trimmed, non-empty entries, one per line. FILTER_AUTHOR
 # drops the PR author, whose own review and comment are never evidence.
-aw_entries() { # LIST SEPARATORS FILTER_AUTHOR
-  printf '%s\n' "$1" | tr "$2" '\n' | sed 's/^[[:space:]]*//;s/[[:space:]]*$//' |
+# The PR author is never evidence, so a source keyed on their login is not a
+# way to open this gate and must not be named as one. LOGIN_HALF takes what
+# precedes the first colon, which is how the comment-form evidence loop reads
+# a pair — the label names the string that loop matches on.
+aw_eligible() { # LIST [LOGIN_HALF]
+  printf '%s\n' "$1" |
     while IFS= read -r aw_item; do
+      [ "${2:-0}" = 1 ] && aw_item="${aw_item%%:*}"
       [ -z "$aw_item" ] && continue
-      [ "$3" = 1 ] && [ "$aw_item" = "$PR_AUTHOR" ] && continue
+      [ "$aw_item" = "$PR_AUTHOR" ] && continue
       printf '%s\n' "$aw_item"
     done
 }
@@ -1350,7 +1363,11 @@ aw_entries() { # LIST SEPARATORS FILTER_AUTHOR
 # awaiting-detail.sh only fits the answer into GitHub's description limit.
 awaiting_sources() { # -> one eligible source per line, duplicates collapsed
   {
-    if [ -z "$TRUSTED_LOGINS" ]; then
+    # The same normalized list the evidence read is given, so an empty trust
+    # list is empty for both. Emptiness is tested BEFORE the author filter: a
+    # list holding only the author is a named list nothing can satisfy, not
+    # an open one.
+    if [ -z "$TRUSTED_LOGINS_N" ]; then
       # The minimum state is part of the policy, not decoration: under
       # 'approved' a COMMENTED review does not satisfy this source, so the
       # text must not send a reader to leave one.
@@ -1360,10 +1377,10 @@ awaiting_sources() { # -> one eligible source per line, duplicates collapsed
         echo "any non-author review"
       fi
     else
-      aw_entries "$TRUSTED_LOGINS" ';,' 1
+      aw_eligible "$TRUSTED_LOGINS_N"
     fi
-    aw_entries "$TRUSTED_CONTEXTS" ';' 0
-    aw_entries "$(printf '%s' "$COMMENT_REVIEWERS" | sed 's/:[^;]*//g')" ';' 1
+    printf '%s\n' "$TRUSTED_CONTEXTS_N" | sed '/^$/d'
+    aw_eligible "$COMMENT_REVIEWERS_N" 1
   } | awk '!seen[$0]++'
 }
 

--- a/.agents/skills/review-gate/scripts/validate.sh
+++ b/.agents/skills/review-gate/scripts/validate.sh
@@ -115,7 +115,7 @@ group "runtime"
 SKILL_REL="${SKILL_DIR#"$REPO_ROOT"/}"
 for rel in scripts/review-predicate.sh scripts/review-writer.sh \
   scripts/pr-watch.sh scripts/validate.sh scripts/validate-workflow.sh \
-  scripts/lib/settings.sh; do
+  scripts/awaiting-detail.sh scripts/lib/settings.sh; do
   path="$SKILL_DIR/$rel"
   if [ ! -f "$path" ]; then
     bad "$rel is missing from the installed skill ($SKILL_DIR) — re-run \`kendex refresh\` and commit the result"

--- a/.agents/skills/review-gate/tests/awaiting-detail.test.sh
+++ b/.agents/skills/review-gate/tests/awaiting-detail.test.sh
@@ -46,10 +46,23 @@ else
   ok "the composer models no trust setting of its own"
 fi
 
+# One representation, shared. The evidence reads and the label must be given
+# the SAME packed lists, or a value can be an open trust model to one and a
+# named list to the other.
+if grep -q -- '--arg trusted "\$TRUSTED_LOGINS"' "$PRED"; then
+  bad "the evidence read is given the normalized trust list" "it is given the raw value"
+else
+  ok "the evidence read is given the normalized trust list"
+fi
+[ "$(grep -c 'rg_pack "\$TRUSTED_LOGINS" ' "$PRED")" = 1 ] \
+  && ok "the trust list is parsed exactly once" \
+  || bad "the trust list is parsed exactly once" "$(grep -c 'rg_pack "\$TRUSTED_LOGINS" ' "$PRED") parse sites"
+
 # ---------------------------------------------------------------- layer 1 ---
 # The predicate's own resolution, extracted from the script rather than
 # restated, so a rule that changes there changes here.
-eval "$(sed -n '/^aw_entries() {/,/^}/p' "$PRED")"
+eval "$(sed -n '/^rg_pack() {/,/^}/p' "$PRED")"
+eval "$(sed -n '/^aw_eligible() {/,/^}/p' "$PRED")"
 eval "$(sed -n '/^awaiting_sources() {/,/^}/p' "$PRED")"
 if declare -F awaiting_sources >/dev/null; then
   ok "the predicate's source resolution is extractable"
@@ -59,8 +72,15 @@ else
 fi
 
 MIN_STATE="any"
+# Each case is written in the raw settings a repo commits, and packs them
+# through the predicate's own rg_pack — the single parse every consumer of
+# these lists shares.
 sources_are() { # CASE, EXPECTED (comma-joined)
-  local got; got="$(awaiting_sources | tr '\n' ',' | sed 's/,$//')"
+  local got
+  TRUSTED_LOGINS_N="$(rg_pack "$TRUSTED_LOGINS" ';,')"
+  TRUSTED_CONTEXTS_N="$(rg_pack "$TRUSTED_CONTEXTS" ';')"
+  COMMENT_REVIEWERS_N="$(rg_pack "$COMMENT_REVIEWERS" ';')"
+  got="$(awaiting_sources | tr '\n' ',' | sed 's/,$//')"
   [ "$got" = "$2" ] && ok "$1" || bad "$1" "$got"
 }
 
@@ -98,6 +118,25 @@ sources_are "a login reachable two ways is listed once" "alice"
 # must not claim otherwise.
 PR_AUTHOR="alice" TRUSTED_LOGINS="alice" TRUSTED_CONTEXTS="" COMMENT_REVIEWERS="alice:REVIEWED-CLEAN"
 sources_are "an author-only configuration leaves no eligible source" ""
+
+# A delimiter-only trust list is what the evidence jq calls an EMPTY trust
+# list — it splits, trims and drops empties before deciding — so it is the
+# open trust model here too. Testing the raw value said the opposite: no
+# eligible source, on a gate that would accept any non-author review.
+PR_AUTHOR="carol" TRUSTED_LOGINS=" ; , " TRUSTED_CONTEXTS="" COMMENT_REVIEWERS=""
+sources_are "a delimiter-only trust list is the open trust model" \
+  "any non-author review"
+
+PR_AUTHOR="carol" TRUSTED_LOGINS="   " TRUSTED_CONTEXTS="Analysis" COMMENT_REVIEWERS=""
+sources_are "a whitespace-only trust list keeps the open model beside a context" \
+  "any non-author review,Analysis"
+
+# The comment-form evidence loop trims the PAIR and then takes everything
+# before the first colon, so a login with inner whitespace is matched as
+# 'alice ' — the label has to name that same string, not a tidier one.
+PR_AUTHOR="carol" TRUSTED_LOGINS="" TRUSTED_CONTEXTS="" COMMENT_REVIEWERS=" alice :Reviewed commit: "
+sources_are "a comment login is labelled as the evidence loop splits it" \
+  "any non-author review,alice "
 
 # The review-object minimum state is policy, not decoration: under 'approved'
 # a COMMENTED review does not satisfy the open trust model, so the text must

--- a/.agents/skills/review-gate/tests/awaiting-detail.test.sh
+++ b/.agents/skills/review-gate/tests/awaiting-detail.test.sh
@@ -1,0 +1,98 @@
+#!/usr/bin/env bash
+# The awaiting verdict's status description. It is the one verdict a reader
+# acts on wrongly — read as an approval block, it stalls a PR that only has to
+# wait for evidence at the new head — so what it says is pinned here.
+#
+# The text is DERIVED from the repo's resolved evidence settings, never
+# asserted: a gate trusting only human logins must name those people, and a
+# gate trusting bots must name the bots. These cases drive the composer the
+# predicate itself calls, across both sha forms and the 140-character limit
+# GitHub truncates a commit-status description at.
+set -euo pipefail
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PRED="$SCRIPT_DIR/../scripts/review-predicate.sh"
+COMPOSER="$SCRIPT_DIR/../scripts/awaiting-detail.sh"
+PASS=0 FAIL=0
+ok()  { PASS=$((PASS+1)); echo "  ok    $1"; }
+bad() { FAIL=$((FAIL+1)); echo "  FAIL  $1"; echo "        got: $2"; }
+
+SHA='a1b2c3d4e5f60718293a4b5c6d7e8f9012345678'
+TRUSTED_LOGINS="" TRUSTED_CONTEXTS="" COMMENT_REVIEWERS=""
+# GitHub's own cap, restated here so a loosened constant in the composer is a
+# failure rather than a silently wider status the API then truncates.
+RG_STATUS_LIMIT=140
+grep -qx "RG_STATUS_LIMIT=$RG_STATUS_LIMIT" "$COMPOSER" \
+  && ok "the composer caps at $RG_STATUS_LIMIT characters" \
+  || bad "the composer caps at $RG_STATUS_LIMIT characters" "constant drifted"
+
+# The predicate must actually route its awaiting arm through this composer: a
+# copy of the text left in the arm would pass every case below while
+# production said something else.
+grep -q 'verdict=awaiting detail=\$(.*awaiting-detail\.sh' "$PRED" \
+  && ok "the predicate's awaiting arm calls the composer" \
+  || bad "the predicate's awaiting arm calls the composer" "the arm does not call awaiting-detail.sh"
+
+want() { # CASE, EXPECTED
+  local got
+  got="$(HEAD_SHA="$SHA" TRUSTED_LOGINS="$TRUSTED_LOGINS" \
+    TRUSTED_CONTEXTS="$TRUSTED_CONTEXTS" COMMENT_REVIEWERS="$COMMENT_REVIEWERS" \
+    "$COMPOSER")"
+  [ "$got" = "$2" ] && ok "$1" || bad "$1" "$got"
+  if [ "${#got}" -le "$RG_STATUS_LIMIT" ]; then
+    ok "$1 — fits the $RG_STATUS_LIMIT-character status limit (${#got})"
+  else
+    bad "$1 — fits the $RG_STATUS_LIMIT-character status limit" "${#got} characters"
+  fi
+}
+
+# A human-only gate: bot sources empty, one person trusted. The text names that
+# person and never promises automation the configuration does not provide.
+TRUSTED_LOGINS="alice" TRUSTED_CONTEXTS="" COMMENT_REVIEWERS=""
+want "human-only gate names the human" \
+  "no review evidence at $SHA yet; expected from alice"
+
+TRUSTED_LOGINS="alice;bob" TRUSTED_CONTEXTS="" COMMENT_REVIEWERS=""
+want "every trusted login is named" \
+  "no review evidence at $SHA yet; expected from alice, bob"
+
+# Each source kind contributes, and a comment-form entry contributes its login
+# half only — the binding pattern is not a name a reader can act on.
+TRUSTED_LOGINS="alice" TRUSTED_CONTEXTS="Analysis" COMMENT_REVIEWERS="botty[bot]:Reviewed commit:"
+want "status contexts and comment reviewers are named too" \
+  "no review evidence at $SHA yet; expected from alice, Analysis, botty[bot]"
+
+# A name reachable two ways is one source, not two.
+TRUSTED_LOGINS="alice" TRUSTED_CONTEXTS="" COMMENT_REVIEWERS="alice:REVIEWED-CLEAN"
+want "a login named by two settings is listed once" \
+  "no review evidence at $SHA yet; expected from alice"
+
+# Empty trust lists mean any non-author review is evidence. That is a source,
+# so it is named rather than leaving the clause blank.
+TRUSTED_LOGINS="" TRUSTED_CONTEXTS="" COMMENT_REVIEWERS=""
+want "nothing configured names the open trust model" \
+  "no review evidence at $SHA yet; expected from any non-author review"
+
+# Whitespace around packed entries belongs to the settings file, not to a name.
+TRUSTED_LOGINS=" alice ; bob " TRUSTED_CONTEXTS="" COMMENT_REVIEWERS=""
+want "packed entries are trimmed" \
+  "no review evidence at $SHA yet; expected from alice, bob"
+
+# Past the limit: the sha shortens to its 12-character prefix before any name
+# is dropped, and the names that still do not fit are counted.
+TRUSTED_LOGINS="coderabbitai[bot];copilot-pull-request-reviewer[bot];qodo-code-review[bot];chatgpt-codex-connector[bot];bmethod"
+TRUSTED_CONTEXTS="CodeRabbit;copilot-pull-request-reviewer"
+COMMENT_REVIEWERS="chatgpt-codex-connector[bot]:Reviewed commit:;bmethod:REVIEWED-CLEAN"
+want "a list past the limit shortens the sha and counts the remainder" \
+  "no review evidence at ${SHA:0:12} yet; expected from coderabbitai[bot], copilot-pull-request-reviewer[bot] and 5 more"
+
+# One name wider than the whole budget: a count, never a name cut mid-word.
+TRUSTED_LOGINS="$(printf 'x%.0s' $(seq 1 200))" TRUSTED_CONTEXTS="" COMMENT_REVIEWERS=""
+want "a name too wide to show becomes a count" \
+  "no review evidence at ${SHA:0:12} yet; expected from 1 configured reviewer"
+
+TRUSTED_LOGINS="$(printf 'x%.0s' $(seq 1 200));$(printf 'y%.0s' $(seq 1 200))"
+want "the count is plural for more than one" \
+  "no review evidence at ${SHA:0:12} yet; expected from 2 configured reviewers"
+
+echo "$PASS passed, $FAIL failed"
+[ "$FAIL" = 0 ] || exit 1

--- a/.agents/skills/review-gate/tests/awaiting-detail.test.sh
+++ b/.agents/skills/review-gate/tests/awaiting-detail.test.sh
@@ -72,6 +72,9 @@ else
 fi
 
 MIN_STATE="any"
+# The operator override is a source too; cases that are not about it disable
+# it the way a repo does, with an empty context.
+OUTAGE_CONTEXT=""
 # Each case is written in the raw settings a repo commits, and packs them
 # through the predicate's own rg_pack — the single parse every consumer of
 # these lists shares.
@@ -117,7 +120,28 @@ sources_are "a login reachable two ways is listed once" "alice"
 # Every configured source is the author: nothing is eligible, and the status
 # must not claim otherwise.
 PR_AUTHOR="alice" TRUSTED_LOGINS="alice" TRUSTED_CONTEXTS="" COMMENT_REVIEWERS="alice:REVIEWED-CLEAN"
-sources_are "an author-only configuration leaves no eligible source" ""
+sources_are "an author-only configuration with no override leaves nothing eligible" ""
+
+# The operator override is evidence this predicate accepts, so it is a way to
+# open the gate. Reporting nothing eligible while it is configured pointed an
+# operator away from the recovery path they own.
+OUTAGE_CONTEXT="kendex-reviewer-outage"
+PR_AUTHOR="alice" TRUSTED_LOGINS="alice" TRUSTED_CONTEXTS="" COMMENT_REVIEWERS="alice:REVIEWED-CLEAN"
+sources_are "an author-only configuration still names the configured override" \
+  "kendex-reviewer-outage"
+
+PR_AUTHOR="carol" TRUSTED_LOGINS="alice" TRUSTED_CONTEXTS="Analysis" COMMENT_REVIEWERS=""
+sources_are "the override joins the ordinary sources" \
+  "alice,Analysis,kendex-reviewer-outage"
+
+# An override context equal to a trusted status context is one source.
+PR_AUTHOR="carol" TRUSTED_LOGINS="" TRUSTED_CONTEXTS="kendex-reviewer-outage" COMMENT_REVIEWERS=""
+sources_are "an override matching a trusted context is listed once" \
+  "any non-author review,kendex-reviewer-outage"
+
+OUTAGE_CONTEXT=""
+PR_AUTHOR="carol" TRUSTED_LOGINS="alice" TRUSTED_CONTEXTS="" COMMENT_REVIEWERS=""
+sources_are "an empty override context contributes nothing" "alice"
 
 # A delimiter-only trust list is what the evidence jq calls an EMPTY trust
 # list — it splits, trims and drops empties before deciding — so it is the

--- a/.agents/skills/review-gate/tests/awaiting-detail.test.sh
+++ b/.agents/skills/review-gate/tests/awaiting-detail.test.sh
@@ -263,6 +263,15 @@ want "the open trust model is named" "any non-author review" \
 want "every source is listed while they fit" "$(printf 'alice\nAnalysis\nbotty[bot]')" \
   "no review evidence at $SHA yet; expected from alice, Analysis, botty[bot]"
 
+# A status context is free-form and may hold a comma. Joining by character
+# rewrote every comma into ", ", advertising `lint,build` as a context that
+# does not exist.
+want "a comma inside a context survives the join" "$(printf 'lint,build\nalice')" \
+  "no review evidence at $SHA yet; expected from lint,build, alice"
+
+want "a lone comma-bearing context is unchanged" "lint,build" \
+  "no review evidence at $SHA yet; expected from lint,build"
+
 want "no eligible source names the state, never a blank clause" "" \
   "no review evidence at $SHA yet; no configured source is eligible here"
 

--- a/.agents/skills/review-gate/tests/awaiting-detail.test.sh
+++ b/.agents/skills/review-gate/tests/awaiting-detail.test.sh
@@ -139,6 +139,15 @@ PR_AUTHOR="carol" TRUSTED_LOGINS="" TRUSTED_CONTEXTS="kendex-reviewer-outage" CO
 sources_are "an override matching a trusted context is listed once" \
   "any non-author review,kendex-reviewer-outage"
 
+# A status context is free-form, so it can be a string bash's echo takes as
+# an option. Printing it with echo emitted no name at all, which read as no
+# eligible source on an otherwise author-only gate.
+for opt in -n -e -E; do
+  OUTAGE_CONTEXT="$opt"
+  PR_AUTHOR="alice" TRUSTED_LOGINS="alice" TRUSTED_CONTEXTS="" COMMENT_REVIEWERS=""
+  sources_are "an override named '$opt' is still printed" "$opt"
+done
+
 OUTAGE_CONTEXT=""
 PR_AUTHOR="carol" TRUSTED_LOGINS="alice" TRUSTED_CONTEXTS="" COMMENT_REVIEWERS=""
 sources_are "an empty override context contributes nothing" "alice"

--- a/.agents/skills/review-gate/tests/awaiting-detail.test.sh
+++ b/.agents/skills/review-gate/tests/awaiting-detail.test.sh
@@ -149,6 +149,34 @@ MIN_STATE="any"
 PR_AUTHOR="carol" TRUSTED_LOGINS="" TRUSTED_CONTEXTS="" COMMENT_REVIEWERS=""
 sources_are "min_state=any keeps the review wording" "any non-author review"
 
+# The normalization decides the trust boundary, so a broken pipeline must be
+# exit 2 with no verdict. Without pipefail the last stage returns 0 on empty
+# output, and a RESTRICTED trust list would read as "any non-author" — the
+# list would open the gate it was set to close.
+stub_dir="$(mktemp -d)"
+trap 'rm -rf "$stub_dir"' EXIT
+printf '#!/usr/bin/env bash\nexit 1\n' > "$stub_dir/tr"
+chmod +x "$stub_dir/tr"
+broken_rc=0
+broken_out="$(PATH="$stub_dir:$PATH" REVIEW_GATE_SETTINGS_FILE=/dev/null \
+  REVIEW_GATE_REVIEW_OBJECT_TRUSTED_LOGINS="alice" \
+  GH_REPO=owner/repo PR_NUMBER=1 HEAD_SHA="$SHA" PR_AUTHOR=bob \
+  bash "$PRED" --check-config 2>&1)" || broken_rc=$?
+if [ "$broken_rc" = 2 ]; then
+  ok "a broken normalization pipeline exits 2"
+else
+  bad "a broken normalization pipeline exits 2" "exit $broken_rc"
+fi
+case "$broken_out" in
+  *"could not normalize REVIEW_GATE_REVIEW_OBJECT_TRUSTED_LOGINS"*)
+    ok "the failure names the list it could not normalize" ;;
+  *) bad "the failure names the list it could not normalize" "$broken_out" ;;
+esac
+case "$broken_out" in
+  *verdict=*) bad "a broken normalization emits no verdict" "$broken_out" ;;
+  *) ok "a broken normalization emits no verdict" ;;
+esac
+
 # ---------------------------------------------------------------- layer 2 ---
 # The composer, driven by a resolved list exactly as the predicate hands it in.
 want() { # CASE, SOURCES, EXPECTED
@@ -205,12 +233,17 @@ want "a short-form list one character over counts the remainder" "$names" \
   "$short_prefix$(printf '%s' "$names" | head -1) and 1 more"
 
 # One name wider than the whole budget: a count, never a name cut mid-word.
-want "a name too wide to show becomes a count" "$(printf 'x%.0s' $(seq 1 200))" \
-  "no review evidence at ${SHA:0:12} yet; expected from 1 configured reviewer"
+want "a source too wide to show becomes a count" "$(printf 'x%.0s' $(seq 1 200))" \
+  "no review evidence at ${SHA:0:12} yet; expected from 1 configured source"
+
+# A trusted status context is not a reviewer, and it is the value that
+# realistically exhausts the budget — the count must not name a person.
+want "a lone oversized status context is counted as a source" "$(printf 'C%.0s' $(seq 1 200))" \
+  "no review evidence at ${SHA:0:12} yet; expected from 1 configured source"
 
 want "the count is plural for more than one" \
   "$(printf 'x%.0s' $(seq 1 200); echo; printf 'y%.0s' $(seq 1 200))" \
-  "no review evidence at ${SHA:0:12} yet; expected from 2 configured reviewers"
+  "no review evidence at ${SHA:0:12} yet; expected from 2 configured sources"
 
 echo "$PASS passed, $FAIL failed"
 [ "$FAIL" = 0 ] || exit 1

--- a/.agents/skills/review-gate/tests/awaiting-detail.test.sh
+++ b/.agents/skills/review-gate/tests/awaiting-detail.test.sh
@@ -3,11 +3,10 @@
 # acts on wrongly — read as an approval block, it stalls a PR that only has to
 # wait for evidence at the new head — so what it says is pinned here.
 #
-# The text is DERIVED from the repo's resolved evidence settings, never
-# asserted: a gate trusting only human logins must name those people, and a
-# gate trusting bots must name the bots. These cases drive the composer the
-# predicate itself calls, across both sha forms and the 140-character limit
-# GitHub truncates a commit-status description at.
+# Two layers, one judge each. review-predicate.sh decides WHICH sources could
+# still open the gate at this head (its resolution is extracted below, never
+# restated), and awaiting-detail.sh only fits that answer into the 140
+# characters GitHub keeps of a status description.
 set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 PRED="$SCRIPT_DIR/../scripts/review-predicate.sh"
@@ -17,7 +16,7 @@ ok()  { PASS=$((PASS+1)); echo "  ok    $1"; }
 bad() { FAIL=$((FAIL+1)); echo "  FAIL  $1"; echo "        got: $2"; }
 
 SHA='a1b2c3d4e5f60718293a4b5c6d7e8f9012345678'
-TRUSTED_LOGINS="" TRUSTED_CONTEXTS="" COMMENT_REVIEWERS=""
+
 # GitHub's own cap, restated here so a loosened constant in the composer is a
 # failure rather than a silently wider status the API then truncates.
 RG_STATUS_LIMIT=140
@@ -25,19 +24,98 @@ grep -qx "RG_STATUS_LIMIT=$RG_STATUS_LIMIT" "$COMPOSER" \
   && ok "the composer caps at $RG_STATUS_LIMIT characters" \
   || bad "the composer caps at $RG_STATUS_LIMIT characters" "constant drifted"
 
-# The predicate must actually route its awaiting arm through this composer: a
-# copy of the text left in the arm would pass every case below while
-# production said something else.
-grep -q 'verdict=awaiting detail=\$(.*awaiting-detail\.sh' "$PRED" \
-  && ok "the predicate's awaiting arm calls the composer" \
-  || bad "the predicate's awaiting arm calls the composer" "the arm does not call awaiting-detail.sh"
+# The predicate must route its awaiting arm through the composer and hand it
+# the resolved list: a copy of either judgment left elsewhere would pass every
+# case below while production said something else.
+grep -q 'SOURCES="\$(awaiting_sources)".*awaiting-detail\.sh' "$PRED" \
+  && ok "the awaiting arm passes the predicate's resolved sources to the composer" \
+  || bad "the awaiting arm passes the predicate's resolved sources to the composer" "the arm does not"
+grep -q 'verdict=awaiting detail=\$awaiting_detail' "$PRED" \
+  && ok "the arm prints a captured description, not a substitution inside echo" \
+  || bad "the arm prints a captured description, not a substitution inside echo" "still interpolated"
+# A composer that failed must take the verdict with it: `exit 2` inside a
+# command substitution would leave only the subshell, so the guard has to sit
+# outside one.
+grep -q 'awaiting_detail.*|| awaiting_rc=\$?' "$PRED" \
+  && grep -q 'awaiting-detail.sh failed' "$PRED" \
+  && ok "a failed composer is captured and exits 2 before any verdict" \
+  || bad "a failed composer is captured and exits 2 before any verdict" "no failure guard"
+if grep -q 'TRUSTED_LOGINS\|TRUSTED_CONTEXTS\|COMMENT_REVIEWERS' "$COMPOSER"; then
+  bad "the composer models no trust setting of its own" "it reads a trust setting"
+else
+  ok "the composer models no trust setting of its own"
+fi
 
-want() { # CASE, EXPECTED
-  local got
-  got="$(HEAD_SHA="$SHA" TRUSTED_LOGINS="$TRUSTED_LOGINS" \
-    TRUSTED_CONTEXTS="$TRUSTED_CONTEXTS" COMMENT_REVIEWERS="$COMMENT_REVIEWERS" \
-    "$COMPOSER")"
+# ---------------------------------------------------------------- layer 1 ---
+# The predicate's own resolution, extracted from the script rather than
+# restated, so a rule that changes there changes here.
+eval "$(sed -n '/^aw_entries() {/,/^}/p' "$PRED")"
+eval "$(sed -n '/^awaiting_sources() {/,/^}/p' "$PRED")"
+if declare -F awaiting_sources >/dev/null; then
+  ok "the predicate's source resolution is extractable"
+else
+  echo "FAIL: could not extract awaiting_sources from $PRED"
+  exit 1
+fi
+
+MIN_STATE="any"
+sources_are() { # CASE, EXPECTED (comma-joined)
+  local got; got="$(awaiting_sources | tr '\n' ',' | sed 's/,$//')"
   [ "$got" = "$2" ] && ok "$1" || bad "$1" "$got"
+}
+
+# An empty review-object trust list accepts any non-author review, and a
+# configured status context does not withdraw that. Reporting only the context
+# would hide a way to unblock the gate.
+PR_AUTHOR="carol" TRUSTED_LOGINS="" TRUSTED_CONTEXTS="Analysis" COMMENT_REVIEWERS=""
+sources_are "an empty trust list keeps any non-author review beside a context" \
+  "any non-author review,Analysis"
+
+# The author's own review and comment are never evidence, so a trust list that
+# names the author must not send anyone to ask them.
+PR_AUTHOR="alice" TRUSTED_LOGINS="alice;bob" TRUSTED_CONTEXTS="" COMMENT_REVIEWERS=""
+sources_are "a trusted login equal to the author is omitted" "bob"
+
+PR_AUTHOR="alice" TRUSTED_LOGINS="bob" TRUSTED_CONTEXTS="" COMMENT_REVIEWERS="alice:REVIEWED-CLEAN"
+sources_are "a comment reviewer equal to the author is omitted" "bob"
+
+# A status context is a check name, not a login, so it survives an author of
+# the same name.
+PR_AUTHOR="Analysis" TRUSTED_LOGINS="bob" TRUSTED_CONTEXTS="Analysis" COMMENT_REVIEWERS=""
+sources_are "a status context is not author-filtered" "bob,Analysis"
+
+PR_AUTHOR="carol" TRUSTED_LOGINS="alice" TRUSTED_CONTEXTS="Analysis" COMMENT_REVIEWERS="botty[bot]:Reviewed commit:"
+sources_are "every source kind contributes, comment reviewers by login" \
+  "alice,Analysis,botty[bot]"
+
+PR_AUTHOR="carol" TRUSTED_LOGINS=" alice ; bob " TRUSTED_CONTEXTS="" COMMENT_REVIEWERS=""
+sources_are "packed entries are trimmed" "alice,bob"
+
+PR_AUTHOR="carol" TRUSTED_LOGINS="alice" TRUSTED_CONTEXTS="" COMMENT_REVIEWERS="alice:REVIEWED-CLEAN"
+sources_are "a login reachable two ways is listed once" "alice"
+
+# Every configured source is the author: nothing is eligible, and the status
+# must not claim otherwise.
+PR_AUTHOR="alice" TRUSTED_LOGINS="alice" TRUSTED_CONTEXTS="" COMMENT_REVIEWERS="alice:REVIEWED-CLEAN"
+sources_are "an author-only configuration leaves no eligible source" ""
+
+# The review-object minimum state is policy, not decoration: under 'approved'
+# a COMMENTED review does not satisfy the open trust model, so the text must
+# not send a reader to leave one.
+MIN_STATE="approved"
+PR_AUTHOR="carol" TRUSTED_LOGINS="" TRUSTED_CONTEXTS="" COMMENT_REVIEWERS=""
+sources_are "min_state=approved words the open trust model as an approval" \
+  "any non-author approval"
+MIN_STATE="any"
+PR_AUTHOR="carol" TRUSTED_LOGINS="" TRUSTED_CONTEXTS="" COMMENT_REVIEWERS=""
+sources_are "min_state=any keeps the review wording" "any non-author review"
+
+# ---------------------------------------------------------------- layer 2 ---
+# The composer, driven by a resolved list exactly as the predicate hands it in.
+want() { # CASE, SOURCES, EXPECTED
+  local got
+  got="$(HEAD_SHA="$SHA" SOURCES="$2" "$COMPOSER")"
+  [ "$got" = "$3" ] && ok "$1" || bad "$1" "$got"
   if [ "${#got}" -le "$RG_STATUS_LIMIT" ]; then
     ok "$1 — fits the $RG_STATUS_LIMIT-character status limit (${#got})"
   else
@@ -45,53 +123,54 @@ want() { # CASE, EXPECTED
   fi
 }
 
-# A human-only gate: bot sources empty, one person trusted. The text names that
-# person and never promises automation the configuration does not provide.
-TRUSTED_LOGINS="alice" TRUSTED_CONTEXTS="" COMMENT_REVIEWERS=""
-want "human-only gate names the human" \
+want "one human reads as that person's name" "alice" \
   "no review evidence at $SHA yet; expected from alice"
 
-TRUSTED_LOGINS="alice;bob" TRUSTED_CONTEXTS="" COMMENT_REVIEWERS=""
-want "every trusted login is named" \
-  "no review evidence at $SHA yet; expected from alice, bob"
-
-# Each source kind contributes, and a comment-form entry contributes its login
-# half only — the binding pattern is not a name a reader can act on.
-TRUSTED_LOGINS="alice" TRUSTED_CONTEXTS="Analysis" COMMENT_REVIEWERS="botty[bot]:Reviewed commit:"
-want "status contexts and comment reviewers are named too" \
-  "no review evidence at $SHA yet; expected from alice, Analysis, botty[bot]"
-
-# A name reachable two ways is one source, not two.
-TRUSTED_LOGINS="alice" TRUSTED_CONTEXTS="" COMMENT_REVIEWERS="alice:REVIEWED-CLEAN"
-want "a login named by two settings is listed once" \
-  "no review evidence at $SHA yet; expected from alice"
-
-# Empty trust lists mean any non-author review is evidence. That is a source,
-# so it is named rather than leaving the clause blank.
-TRUSTED_LOGINS="" TRUSTED_CONTEXTS="" COMMENT_REVIEWERS=""
-want "nothing configured names the open trust model" \
+want "the open trust model is named" "any non-author review" \
   "no review evidence at $SHA yet; expected from any non-author review"
 
-# Whitespace around packed entries belongs to the settings file, not to a name.
-TRUSTED_LOGINS=" alice ; bob " TRUSTED_CONTEXTS="" COMMENT_REVIEWERS=""
-want "packed entries are trimmed" \
-  "no review evidence at $SHA yet; expected from alice, bob"
+want "every source is listed while they fit" "$(printf 'alice\nAnalysis\nbotty[bot]')" \
+  "no review evidence at $SHA yet; expected from alice, Analysis, botty[bot]"
+
+want "no eligible source names the state, never a blank clause" "" \
+  "no review evidence at $SHA yet; no configured source is eligible here"
 
 # Past the limit: the sha shortens to its 12-character prefix before any name
 # is dropped, and the names that still do not fit are counted.
-TRUSTED_LOGINS="coderabbitai[bot];copilot-pull-request-reviewer[bot];qodo-code-review[bot];chatgpt-codex-connector[bot];bmethod"
-TRUSTED_CONTEXTS="CodeRabbit;copilot-pull-request-reviewer"
-COMMENT_REVIEWERS="chatgpt-codex-connector[bot]:Reviewed commit:;bmethod:REVIEWED-CLEAN"
 want "a list past the limit shortens the sha and counts the remainder" \
+  "$(printf 'coderabbitai[bot]\ncopilot-pull-request-reviewer[bot]\nqodo-code-review[bot]\nchatgpt-codex-connector[bot]\nbmethod\nCodeRabbit\ncopilot-pull-request-reviewer')" \
   "no review evidence at ${SHA:0:12} yet; expected from coderabbitai[bot], copilot-pull-request-reviewer[bot] and 5 more"
 
+# Boundary: a list whose SHORT form lands on the limit keeps every name.
+# Reserving room for a remainder clause before testing that form dropped the
+# last name from a list that fitted.
+short_prefix="no review evidence at ${SHA:0:12} yet; expected from "
+pad() { printf 'n%.0s' $(seq 1 "$1"); }
+two_names() { # TOTAL -> two names whose short form is exactly TOTAL characters
+  local first second rest
+  first="$(pad 20)"
+  rest=$(($1 - ${#short_prefix} - ${#first} - 2))
+  second="$(pad "$rest")"
+  printf '%s\n%s' "$first" "$second"
+}
+for total in 130 139 140; do
+  names="$(two_names "$total")"
+  want "a short-form list of exactly $total characters keeps every name" \
+    "$names" \
+    "$short_prefix$(printf '%s' "$names" | tr '\n' ',' | sed 's/,/, /g')"
+done
+
+# One character past it, and the remainder is counted rather than cut.
+names="$(two_names 141)"
+want "a short-form list one character over counts the remainder" "$names" \
+  "$short_prefix$(printf '%s' "$names" | head -1) and 1 more"
+
 # One name wider than the whole budget: a count, never a name cut mid-word.
-TRUSTED_LOGINS="$(printf 'x%.0s' $(seq 1 200))" TRUSTED_CONTEXTS="" COMMENT_REVIEWERS=""
-want "a name too wide to show becomes a count" \
+want "a name too wide to show becomes a count" "$(printf 'x%.0s' $(seq 1 200))" \
   "no review evidence at ${SHA:0:12} yet; expected from 1 configured reviewer"
 
-TRUSTED_LOGINS="$(printf 'x%.0s' $(seq 1 200));$(printf 'y%.0s' $(seq 1 200))"
 want "the count is plural for more than one" \
+  "$(printf 'x%.0s' $(seq 1 200); echo; printf 'y%.0s' $(seq 1 200))" \
   "no review evidence at ${SHA:0:12} yet; expected from 2 configured reviewers"
 
 echo "$PASS passed, $FAIL failed"

--- a/.agents/skills/review-gate/tests/awaiting-detail.test.sh
+++ b/.agents/skills/review-gate/tests/awaiting-detail.test.sh
@@ -27,7 +27,7 @@ grep -qx "RG_STATUS_LIMIT=$RG_STATUS_LIMIT" "$COMPOSER" \
 # The predicate must route its awaiting arm through the composer and hand it
 # the resolved list: a copy of either judgment left elsewhere would pass every
 # case below while production said something else.
-grep -q 'SOURCES="\$(awaiting_sources)".*awaiting-detail\.sh' "$PRED" \
+grep -q 'SOURCES="\$awaiting_srcs".*awaiting-detail\.sh' "$PRED" \
   && ok "the awaiting arm passes the predicate's resolved sources to the composer" \
   || bad "the awaiting arm passes the predicate's resolved sources to the composer" "the arm does not"
 grep -q 'verdict=awaiting detail=\$awaiting_detail' "$PRED" \
@@ -40,6 +40,18 @@ grep -q 'awaiting_detail.*|| awaiting_rc=\$?' "$PRED" \
   && grep -q 'awaiting-detail.sh failed' "$PRED" \
   && ok "a failed composer is captured and exits 2 before any verdict" \
   || bad "a failed composer is captured and exits 2 before any verdict" "no failure guard"
+# The resolver is captured on its OWN line. As an environment assignment on
+# the composer command its status would be discarded, and the composer would
+# format a partial list and exit 0.
+grep -q 'awaiting_srcs="\$(awaiting_sources)" || awaiting_rc=\$?' "$PRED" \
+  && grep -q 'could not resolve the awaiting sources' "$PRED" \
+  && ok "the resolver is captured and checked before the composer runs" \
+  || bad "the resolver is captured and checked before the composer runs" "no resolver guard"
+if grep -q 'SOURCES="\$(awaiting_sources)"' "$PRED"; then
+  bad "the resolver is not called inside an assignment prefix" "status would be discarded"
+else
+  ok "the resolver is not called inside an assignment prefix"
+fi
 if grep -q 'TRUSTED_LOGINS\|TRUSTED_CONTEXTS\|COMMENT_REVIEWERS' "$COMPOSER"; then
   bad "the composer models no trust setting of its own" "it reads a trust setting"
 else
@@ -209,6 +221,25 @@ case "$broken_out" in
   *verdict=*) bad "a broken normalization emits no verdict" "$broken_out" ;;
   *) ok "a broken normalization emits no verdict" ;;
 esac
+
+# Capturing the resolver's status only means something if the resolver has a
+# status to report. A stubbed failure has to come back as one, not as an
+# empty list the composer would format into a plausible status.
+res_stub="$(mktemp -d)"
+printf '#!/usr/bin/env bash\nexit 1\n' > "$res_stub/awk"
+chmod +x "$res_stub/awk"
+res_rc=0
+OUTAGE_CONTEXT="" PR_AUTHOR="carol" TRUSTED_LOGINS="alice" TRUSTED_CONTEXTS="" COMMENT_REVIEWERS=""
+TRUSTED_LOGINS_N="$(rg_pack "$TRUSTED_LOGINS" ';,')"
+TRUSTED_CONTEXTS_N="$(rg_pack "$TRUSTED_CONTEXTS" ';')"
+COMMENT_REVIEWERS_N="$(rg_pack "$COMMENT_REVIEWERS" ';')"
+( PATH="$res_stub:$PATH"; awaiting_sources ) >/dev/null 2>&1 || res_rc=$?
+rm -rf "$res_stub"
+if [ "$res_rc" != 0 ]; then
+  ok "a broken resolver pipeline reports failure instead of an empty list"
+else
+  bad "a broken resolver pipeline reports failure instead of an empty list" "exit 0"
+fi
 
 # ---------------------------------------------------------------- layer 2 ---
 # The composer, driven by a resolved list exactly as the predicate hands it in.

--- a/.agents/skills/review-gate/tests/review-writer.test.sh
+++ b/.agents/skills/review-gate/tests/review-writer.test.sh
@@ -231,7 +231,7 @@ run_writer() {
 # The pending status text the predicate emits for this verdict. The
 # writer is idempotent on state+description, so the fixture histories
 # below reuse this exact string.
-AWAITING_DETAIL="no review evidence at headsha yet; bots re-review each push, not a block on a human"
+AWAITING_DETAIL="no review evidence at headsha yet; expected from botty[bot]"
 AWAITING="verdict=awaiting detail=$AWAITING_DETAIL"
 APPROVED="verdict=approved detail=reviewed at head with no unresolved threads"
 CR="verdict=changes-requested detail=standing review changes requested (persists across pushes until re-approval or dismissal)"

--- a/.agents/skills/review-gate/tests/review-writer.test.sh
+++ b/.agents/skills/review-gate/tests/review-writer.test.sh
@@ -228,7 +228,11 @@ run_writer() {
     "$@" bash "$TMP_ROOT/scripts/review-writer.sh" 2>&1
 }
 
-AWAITING="verdict=awaiting detail=awaiting a non-author review for headsha"
+# The pending status text the predicate emits for this verdict. The
+# writer is idempotent on state+description, so the fixture histories
+# below reuse this exact string.
+AWAITING_DETAIL="no review evidence at headsha yet; bots re-review each push, not a block on a human"
+AWAITING="verdict=awaiting detail=$AWAITING_DETAIL"
 APPROVED="verdict=approved detail=reviewed at head with no unresolved threads"
 CR="verdict=changes-requested detail=standing review changes requested (persists across pushes until re-approval or dismissal)"
 THREADS="verdict=threads-open detail=2 unresolved review thread(s)"
@@ -255,7 +259,7 @@ assert_contains "$(cat "$POST_LOG")" "context=Review gate" "w1: post carries the
 assert_eq "$(( $(wc -l < "$RERUN_LOG") ))" "0" "w1: no rerun on a downward transition"
 
 rc=0; out=$(run_writer STUB_VERDICT_LINE="$AWAITING" \
-  STUB_GATE_HISTORY='[{"context":"Review gate","state":"pending","description":"awaiting a non-author review for headsha","created_at":"'"$OLD"'"}]') || rc=$?
+  STUB_GATE_HISTORY='[{"context":"Review gate","state":"pending","description":"'"$AWAITING_DETAIL"'","created_at":"'"$OLD"'"}]') || rc=$?
 assert_eq "$rc" "0" "w2: the idempotent no-op exits 0"
 assert_eq "$(( $(wc -l < "$POST_LOG") ))" "0" "w2: second evaluation of an unchanged state posts nothing (one entry total)"
 assert_contains "$out" "nothing to do" "w2: reports the no-op"
@@ -279,7 +283,7 @@ assert_eq "$rc" "0" "w5: approved with the same success entry exits 0"
 assert_eq "$(( $(wc -l < "$POST_LOG") ))" "0" "w5: unchanged success posts nothing (idempotent)"
 
 rc=0; out=$(run_writer STUB_VERDICT_LINE="$APPROVED" \
-  STUB_GATE_HISTORY='[{"context":"Review gate","state":"pending","description":"awaiting a non-author review for headsha","created_at":"'"$OLD"'"}]') || rc=$?
+  STUB_GATE_HISTORY='[{"context":"Review gate","state":"pending","description":"'"$AWAITING_DETAIL"'","created_at":"'"$OLD"'"}]') || rc=$?
 assert_eq "$rc" "0" "w6: approved over pending exits 0"
 assert_contains "$(cat "$POST_LOG")" "state=success" "w6: a reviewed head opens the gate"
 assert_eq "$(( $(wc -l < "$RERUN_LOG") ))" "0" "w6: the writer never re-runs CI (branch protection owns that)"
@@ -290,7 +294,7 @@ assert_contains "$(cat "$POST_LOG")" "state=success" "w7: a dismissed objection 
 
 echo "=== VST-65 ordering guard (success posts only) ==="
 
-PENDING_OLD='[{"context":"Review gate","state":"pending","description":"awaiting a non-author review for headsha","created_at":"'"$OLD"'"}]'
+PENDING_OLD='[{"context":"Review gate","state":"pending","description":"'"$AWAITING_DETAIL"'","created_at":"'"$OLD"'"}]'
 
 rc=0; out=$(run_writer STUB_VERDICT_LINE="$APPROVED" STUB_GATE_HISTORY="$PENDING_OLD" \
   STUB_GUARD_HISTORY='[{"context":"Review gate","state":"pending","description":"newer writer run","created_at":"'"$FUTURE"'"}]') || rc=$?
@@ -509,7 +513,7 @@ assert_eq "$rc" "0" "wp2: paginated projection exits 0"
 assert_contains "$(cat "$POST_LOG")" "state=success" "wp2: the projection merges every page before deciding"
 
 rc=0; out=$(run_writer STUB_VERDICT_LINE="$APPROVED" \
-  STUB_GATE_HISTORY='[{"context":"Review gate","state":"pending","description":"awaiting a non-author review for headsha","created_at":"'"$OLD"'"}]' \
+  STUB_GATE_HISTORY='[{"context":"Review gate","state":"pending","description":"'"$AWAITING_DETAIL"'","created_at":"'"$OLD"'"}]' \
   STUB_GUARD_HISTORY='[]' \
   STUB_GUARD_HISTORY_PAGE2='[{"context":"Review gate","state":"failure","description":"newer","created_at":"'"$FUTURE"'"}]') || rc=$?
 assert_eq "$rc" "0" "wp3: paginated guard re-read exits 0"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,9 +17,9 @@ an outside contributor.
   baseline does not carry or carries lower. Rows already at HEAD keep; a
   test that outgrew its class threshold is split, never frozen.
 
-- The review gate's pending status now reads `no review evidence at <sha>
-  yet; bots re-review each push, not a block on a human`, so the awaiting
-  verdict is no longer read as a wait for someone's approval.
+- The review gate's pending status now names the repo's own configured
+  evidence sources — `no review evidence at <sha> yet; expected from <names>`
+  — instead of reading as a block on someone's approval.
 
 - **Breaking:** a `core.hooksPath` naming a directory answers "could not
   determine" from `kendex guard check`; the stand-down prints git's own

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,11 @@ an outside contributor.
 - **Breaking:** `size-ratchet` refuses a test-class baseline row that HEAD's
   baseline does not carry or carries lower. Rows already at HEAD keep; a
   test that outgrew its class threshold is split, never frozen.
+
+- The review gate's pending status now reads `no review evidence at <sha>
+  yet; bots re-review each push, not a block on a human`, so the awaiting
+  verdict is no longer read as a wait for someone's approval.
+
 - **Breaking:** a `core.hooksPath` naming a directory answers "could not
   determine" from `kendex guard check`; the stand-down prints git's own
   report of where it is set, then says to clear it at its source and arm.

--- a/skills/growth-guards/README.md
+++ b/skills/growth-guards/README.md
@@ -35,12 +35,14 @@ below cover local commits.
 The installer writes a helper into `.git/hooks` plus one marked delegating
 line in `pre-commit` and `commit-msg` — never `core.hooksPath`; an existing
 hook keeps its content and exit status; repeat runs are no-ops and repairs.
-`--uninstall` drops only the helper and our line. `--check` writes nothing:
-`0` armed in `.git/hooks`, `1` drifted, absent, or `core.hooksPath` set and
-empty (which switches git hooks off), `2` could not determine — which any
-`core.hooksPath` naming a directory is, because this package reads
-`.git/hooks` only, whatever that value resolves to. Never a silent pass. `kendex guard install` runs the installer and `kendex guard
-uninstall` runs `--uninstall`.
+`--uninstall` drops only the helper and our line. `kendex guard install` and
+`kendex guard uninstall` invoke those two.
+
+`--check` writes nothing: `0` armed in `.git/hooks`, `1` drifted, absent, or
+`core.hooksPath` set and empty (which switches git hooks off), `2` could not
+determine — which any `core.hooksPath` naming a directory is: this package
+reads `.git/hooks` only, whatever that value resolves to. Never a silent
+pass.
 
 `pre-commit` judges ONE commit snapshot: `size-ratchet --staged` and
 `preflight --staged` when the committing work tree or this install
@@ -54,38 +56,28 @@ shims BLOCK and fail closed — `1` carries the check's remediation text,
 
 Two layers, and only one of them is authoritative.
 
-**The git hooks are the gate.** They run for every committer — a person at a
-terminal, any AI harness, a script, an editor's commit button — because git
-runs them, not because anything asked. They need no kendex binary at commit time: the shim
-execs this skill's committed scripts. Git never clones `.git/hooks`, so a
-fresh clone carries the scripts but no shims — one `kendex guard install`
-arms them, and from then on every commit is gated by committed shell and
-git, on a machine that has never installed kendex. That is the whole reason
-the checks are shell and travel with the repository.
+**The git hooks are the gate.** Git runs them for every committer — a person
+at a terminal, any AI harness, a script, an editor's commit button. They need
+no kendex binary: the shim execs this skill's committed scripts. Git never
+clones `.git/hooks`, so a fresh clone carries the scripts but no shims. One
+`kendex guard install` arms them, and every commit after that is gated by
+committed shell and git on a machine that has never installed kendex.
 
-**kendex only arms and reports.** `kendex guard install` runs the installer
-above; `kendex guard uninstall` runs `--uninstall`; `kendex check` reads the hook files
-itself — armed, not armed, or could not tell — and runs nothing out of a
-checkout, because reading a repository's status must not execute its code.
-kendex implements no check of its own; the verdicts a commit is judged by
-are all this skill's.
+**kendex only arms and reports.** `kendex guard install` and `kendex guard
+uninstall` invoke the installer; `kendex check` reads the hook files and says
+armed, not armed, or could not tell. It runs nothing out of a checkout and
+implements no check of its own — the verdicts a commit is judged by are all
+this skill's.
 
-**The `pre-commit-check` harness hook never stands in.** Where BOTH git
-hooks are armed — this package's marker in `pre-commit` and `commit-msg`,
-both executable — it steps aside: git runs the gate itself, and validating
-twice would only double the wait. Half of it is not a gate: with
-`commit-msg` gone, git checks the content and takes any message. It does one thing the git hook
-cannot — refuse a command that would sidestep an armed hook (`--no-verify`, the
-short flag, or injected git configuration), because git would skip the
-message gate too and nothing can check a message it never sees. And where
-nothing is armed it refuses the commit, naming `kendex guard install`. It
-runs no script of the repository's on anyone's behalf: arming is the local
-act that asks for that, and a fresh clone has no hooks and so no execution
-behind it. It gates its own working directory and no other.
-
-Order, then: git hooks where they exist, and a refusal where they do not. No
-layer ever passes a commit another layer would have blocked, and no layer
-runs a repository's code that nobody armed.
+**The `pre-commit-check` harness hook never stands in.** Where BOTH git hooks
+are armed — this package's marker in `pre-commit` and `commit-msg`, both
+executable — it steps aside and lets git run the gate. Half-armed is not
+armed: with `commit-msg` missing, git takes any message. The hook does the
+one thing a git hook cannot, refusing a command that would sidestep an armed
+hook (`--no-verify`, the short flag, injected git configuration), and where
+nothing is armed it refuses the commit and names `kendex guard install`. It
+gates its own working directory and no other, and runs no script of the
+repository's on anyone's behalf.
 
 ## The checks
 

--- a/skills/growth-guards/SKILL.md
+++ b/skills/growth-guards/SKILL.md
@@ -55,30 +55,31 @@ tree's copy wins; a first commit skips preflight with a note; a size-ratchet
 that rejects `--staged` in its first-line parser diagnostic is a stated skip —
 any other failure blocks); the batch over staged content; then the
 repo-root-relative executable named by `GROWTH_GUARDS_PRE_COMMIT_LOCAL`.
-`commit-msg` runs the message gate. Both BLOCK on the exit contract, fail
+`commit-msg` runs the message gate. Both BLOCK on the exit contract and fail
 closed on a guard that could not run; `git commit --no-verify` is the bypass.
-The `kendex guard` verbs invoke this installer: `install`, `uninstall`
-(`--uninstall`) and `check` (`--check`). Arming and disarming are
-repository-level: every work tree and nested project shares one hooks
-directory, so an uninstall from any of them disarms the repository. Disarm
-before removing this skill: shims whose scripts are gone block every commit. `kendex check` invokes
-nothing — it reads the hook files for this package's marker and the execute
-bit git needs, and says armed or not armed. The `--check` verdicts below are
-the fuller vocabulary, for a person or a verb that asks for it:
-(0 armed in `.git/hooks`; 1 drifted, absent, or `core.hooksPath` set and
-empty, which switches git hooks off; 2 could not determine — an unreadable
-hooks directory, or any `core.hooksPath` naming a directory, which is
-outside this verifier's contract: it reads `.git/hooks` only). Repeat runs
-are no-ops and repairs; `core.hooksPath` is never set; existing hooks keep
-their content and exit status. Full install and refusal behaviour:
-[DEVELOPMENT.md](DEVELOPMENT.md).
 
-The git hooks are the authoritative gate: they run for every committer, and
-they need no kendex binary — the shim execs this skill's committed scripts.
-kendex arms and reports, and implements no check of its own. The
-`pre-commit-check` harness hook stands aside where BOTH git hooks are armed,
-refuses commands that would sidestep them, and refuses the commit otherwise — it never runs these scripts on a repository's behalf.
-Layering and reasoning: [README](README.md).
+The `kendex guard` verbs invoke this installer: `install`, `uninstall`
+(`--uninstall`) and `check` (`--check`). Repeat runs are no-ops and repairs,
+`core.hooksPath` is never set, and existing hooks keep their content and exit
+status. Arming and disarming are repository-level: every work tree and nested
+project shares one hooks directory, so an uninstall from any of them disarms
+the repository. Disarm before removing this skill — shims whose scripts are
+gone block every commit.
+
+`kendex check` reads the hook files for this package's marker and the execute
+bit git needs, and says armed or not armed; it invokes nothing. `--check` is
+the fuller vocabulary for a caller that asks for it: `0` armed in
+`.git/hooks`, `1` drifted, absent, or `core.hooksPath` set and empty (which
+switches git hooks off), `2` could not determine — an unreadable hooks
+directory, or any `core.hooksPath` naming a directory, which is outside this
+verifier's contract: it reads `.git/hooks` only. Full install and refusal
+behaviour: [DEVELOPMENT.md](DEVELOPMENT.md).
+
+The git hooks are the authoritative gate and need no kendex binary; kendex
+arms and reports, and implements no check of its own. The `pre-commit-check`
+harness hook stands aside where BOTH git hooks are armed, refuses commands
+that would sidestep them, and refuses the commit otherwise. It never runs
+these scripts on a repository's behalf. Layering: [README](README.md).
 
 ## Configuration
 
@@ -106,6 +107,7 @@ full repo-relative path; `*` crosses `/`); a pattern without a reason is a
 config error. **Baseline format** — `path<TAB>count`, `LC_ALL=C` sorted,
 unique paths, positive counts.
 
-What each check bans and how it is scoped: [CHECKS.md](CHECKS.md). Seeding
-a first baseline and CI wiring: [README.md](README.md). Marker shapes, per-language suppression patterns,
-and the hook install and removal contract: [DEVELOPMENT.md](DEVELOPMENT.md).
+What each check bans and how it is scoped: [CHECKS.md](CHECKS.md). Seeding a
+first baseline and CI wiring: [README.md](README.md). Marker shapes,
+per-language suppression patterns, and the hook install and removal contract:
+[DEVELOPMENT.md](DEVELOPMENT.md).

--- a/skills/preflight/README.md
+++ b/skills/preflight/README.md
@@ -2,24 +2,47 @@
 
 A diff-scoped, fail-only checker for the escape classes worth catching
 mechanically: fail-open bash, new suites no runner invokes, scratch
-directories no EXIT trap removes, directories created at hardcoded
-absolute temp paths, docs citing repo paths that do not exist,
-source files citing docs that do not exist, TODO markers with no issue
-behind them, reviewer-bot attributions in durable prose, and data files
-no parser accepts.
-It reports only on lines the change added, and every lane is tuned so a
-finding is worth a hard failure — a false positive costs more than a miss,
-so a lane that cannot decide stays quiet.
+directories no EXIT trap removes, directories created at hardcoded absolute
+temp paths, docs citing repo paths that do not exist, source files citing
+docs that do not exist, TODO markers with no issue behind them, reviewer-bot
+attributions in durable prose, data files no parser accepts, and workflow
+`run:` blocks their own shell cannot parse.
+
+Findings land only on lines a change ADDED, and there is no warnings tier: a
+lane that cannot decide stays quiet, so every finding is worth a hard failure.
 
 ```bash
-.agents/skills/preflight/scripts/preflight --staged
+.agents/skills/preflight/scripts/preflight              # vs the default branch's merge base
+.agents/skills/preflight/scripts/preflight --staged     # the staged index
+.agents/skills/preflight/scripts/preflight --all        # every tracked file, every line
+```
+
+```
 docs/guide.md:41: [docs-cited-paths] cites a path that does not exist: docs/setup.md
 preflight: 1 finding(s) across 3 changed file(s)
 ```
 
-Exit codes: `0` clean, `1` findings, `2` usage or environment error.
-Requirements: `git`, `awk`, and the usual POSIX userland; `shellcheck`,
-`jq`, `taplo` and `python3` (with PyYAML for the workflow lane) are each
-optional and each enable one lane.
-Bash 3.2 compatible. Lane table, scope rules, and wiring into validation,
-hooks and CI: [SKILL.md](SKILL.md).
+`--base REF` sets the comparison point, `--repo PATH` runs against another
+checkout. Exit codes: `0` clean, `1` findings, `2` usage or environment error.
+
+## Wiring it
+
+**Validation.** Run it ahead of the project's own build, lint and test
+command, so a finding lands before a long run does.
+
+**Commit time.** Where `growth-guards` is also installed, its pre-commit
+chain runs `preflight --staged` itself — nothing to wire. Any other hook
+calls the script with `--staged`.
+
+**CI.** `preflight --base origin/<default-branch>` on the PR head. The
+installed skill must be committed: a CI checkout sees tracked files only,
+never a machine-local `.agents` symlink.
+
+## Requirements
+
+`git`, `awk`, and the usual POSIX userland; Bash 3.2 compatible.
+`shellcheck`, `jq`, `taplo` and `python3` (with PyYAML) are each optional and
+each enable one lane; a lane whose tool is missing skips silently.
+
+Lane table, scope rules, and the subtrees each lane skips:
+[SKILL.md](SKILL.md).

--- a/skills/review-gate/DEVELOPMENT.md
+++ b/skills/review-gate/DEVELOPMENT.md
@@ -11,7 +11,8 @@ Paths are as installed in a consuming repo, under
 
 | File | What it is |
 |------|------------|
-| `scripts/review-predicate.sh` | Answers "is this head reviewed?" — verdict on stdout, exit 2 means no verdict, take no action. `--check-config` runs its settings-validation phase alone. |
+| `scripts/review-predicate.sh` | Answers "is this head reviewed?" — verdict on stdout, exit 2 means no verdict, take no action. `--check-config` runs its settings-validation phase alone. Resolves which sources could open the gate at this head, and calls the composer below for the awaiting verdict's description. |
+| `scripts/awaiting-detail.sh` | Fits that resolved source list into the 140 characters GitHub keeps of a status description. Decides no eligibility of its own. Required at runtime: the predicate exits 2 with no verdict if it fails. |
 | `scripts/review-writer.sh` | Posts that answer as the commit status. The whole writer. |
 | `scripts/validate.sh` | The consumer-facing tool: is this repo's install sound? Runtime, settings, carry-forward exclusions, then the workflow half below, whose verdicts it relays and counts. |
 | `scripts/validate-workflow.sh` | Is the adopted copy still the shipped template? Equality, not re-derivation: see § Equality, not re-derivation. Usable on its own when only the workflow copy changed. |

--- a/skills/review-gate/README.md
+++ b/skills/review-gate/README.md
@@ -12,8 +12,7 @@ gate is disabled, and merge-queue statuses post success unread as
 description — [references/settings.md](references/settings.md) §
 `REVIEW_GATE_MODE`.
 
-It does **not** run or inspect your tests. That is branch protection's job,
-and keeping the two apart is what makes this small enough to trust.
+It does **not** run or inspect your tests. That is branch protection's job.
 
 ## What you do
 

--- a/skills/review-gate/SKILL.md
+++ b/skills/review-gate/SKILL.md
@@ -37,10 +37,14 @@ the gate; and merge-group statuses never read the mode, posting green as
 | (exit 2, no verdict) | *unchanged* | A read failed or config is invalid. Take NO action; retry next pass. |
 
 **Reading the gate's own pending text.** `no review evidence at <sha> yet;
-bots re-review each push, not a block on a human` is the `awaiting` verdict:
-the ordinary re-review window after a push, never a wait for a person. If a
-trusted reviewer has already reviewed this head, dispatch the writer instead
-of waiting; wait on a human only where the repo configures one.
+expected from <names>` is the `awaiting` verdict. The names are the repo's
+own configured evidence sources, so the text says who this repo is waiting
+for: bots there means the ordinary re-review window after a push, and a
+person's name means a person. Past 140 characters the sha shortens to 12 and
+the names that do not fit are counted (`and N more`).
+
+Act on the names, not on the pending state: where they are bots and one has
+already reviewed this head, dispatch the writer instead of waiting.
 
 # Working in a consumer repo
 

--- a/skills/review-gate/SKILL.md
+++ b/skills/review-gate/SKILL.md
@@ -37,11 +37,14 @@ the gate; and merge-group statuses never read the mode, posting green as
 | (exit 2, no verdict) | *unchanged* | A read failed or config is invalid. Take NO action; retry next pass. |
 
 **Reading the gate's own pending text.** `no review evidence at <sha> yet;
-expected from <names>` is the `awaiting` verdict. The names are the repo's
-own configured evidence sources, so the text says who this repo is waiting
-for: bots there means the ordinary re-review window after a push, and a
-person's name means a person. Past 140 characters the sha shortens to 12 and
-the names that do not fit are counted (`and N more`).
+expected from <names>` is the `awaiting` verdict. The names are the sources
+that could still open the gate at that head, resolved from the repo's own
+settings and filtered the way the evidence read filters them — the PR author
+never appears, and an empty trust list reads as `any non-author review` (or
+`approval` under `REVIEW_GATE_REVIEW_OBJECT_MIN_STATE = "approved"`). Past
+140 characters the sha shortens to 12 and the names that do not fit are
+counted (`and N more`). `no configured source is eligible here` means every
+configured login is the author.
 
 Act on the names, not on the pending state: where they are bots and one has
 already reviewed this head, dispatch the writer instead of waiting.

--- a/skills/review-gate/SKILL.md
+++ b/skills/review-gate/SKILL.md
@@ -43,8 +43,9 @@ settings and filtered the way the evidence read filters them — the PR author
 never appears, and an empty trust list reads as `any non-author review` (or
 `approval` under `REVIEW_GATE_REVIEW_OBJECT_MIN_STATE = "approved"`). Past
 140 characters the sha shortens to 12 and the names that do not fit are
-counted (`and N more`). `no configured source is eligible here` means every
-configured login is the author.
+counted (`and N more`). A configured operator override is a source too, and
+is named with the rest. `no configured source is eligible here` means every
+configured login is the author and no override is set.
 
 Act on the names, not on the pending state: where they are bots and one has
 already reviewed this head, dispatch the writer instead of waiting.

--- a/skills/review-gate/SKILL.md
+++ b/skills/review-gate/SKILL.md
@@ -36,12 +36,11 @@ the gate; and merge-group statuses never read the mode, posting green as
 | `changes-requested` | `failure` | A reviewer objects. Red means objection — never a build failure. |
 | (exit 2, no verdict) | *unchanged* | A read failed or config is invalid. Take NO action; retry next pass. |
 
-**Reading the gate's own pending text.** `awaiting a non-author review for
-<sha>` means no review evidence exists at that head yet — the ordinary
-re-review window after a push, not a wait for a person. The bots are the
-non-author reviewers: if a trusted one has already reviewed this head,
-dispatch the writer instead of waiting, and wait on a human only where the
-repo configures one.
+**Reading the gate's own pending text.** `no review evidence at <sha> yet;
+bots re-review each push, not a block on a human` is the `awaiting` verdict:
+the ordinary re-review window after a push, never a wait for a person. If a
+trusted reviewer has already reviewed this head, dispatch the writer instead
+of waiting; wait on a human only where the repo configures one.
 
 # Working in a consumer repo
 

--- a/skills/review-gate/scripts/awaiting-detail.sh
+++ b/skills/review-gate/scripts/awaiting-detail.sh
@@ -77,10 +77,14 @@ done <<EOF
 $SOURCES
 EOF
 
+# "source", not "reviewer": SOURCES also carries trusted status and check
+# contexts, and one long context is exactly the value that exhausts this
+# budget. Counting it as a reviewer would send a reader looking for a person
+# who is not configured.
 if [ "$kept" = "0" ] && [ "$count" = "1" ]; then
-  printf '%s' "${short_form}1 configured reviewer"
+  printf '%s' "${short_form}1 configured source"
 elif [ "$kept" = "0" ]; then
-  printf '%s' "$short_form$count configured reviewers"
+  printf '%s' "$short_form$count configured sources"
 elif [ "$kept" = "$count" ]; then
   printf '%s' "$short_form$shown"
 else

--- a/skills/review-gate/scripts/awaiting-detail.sh
+++ b/skills/review-gate/scripts/awaiting-detail.sh
@@ -43,7 +43,10 @@ if [ "$count" = "0" ]; then
   exit 0
 fi
 
-joined="$(printf '%s\n' "$SOURCES" | tr '\n' ',' | sed 's/,$//; s/,/, /g')"
+# Joined by RECORD, never by character: a status context is free-form and may
+# hold a comma, and rewriting every comma into ", " advertised `lint,build` as
+# the nonexistent `lint, build`.
+joined="$(printf '%s\n' "$SOURCES" | awk 'NR == 1 { printf "%s", $0; next } { printf ", %s", $0 }')"
 detail="$full_form$joined"
 if [ "${#detail}" -le "$RG_STATUS_LIMIT" ]; then
   printf '%s' "$detail"

--- a/skills/review-gate/scripts/awaiting-detail.sh
+++ b/skills/review-gate/scripts/awaiting-detail.sh
@@ -1,0 +1,104 @@
+#!/usr/bin/env bash
+# The awaiting verdict's status description, composed from the evidence
+# sources a repo's resolved settings actually enable. review-predicate.sh
+# calls this on its awaiting arm and prints the result as the pending status.
+#
+# The gate is configuration-driven, so the text names what THIS repo is
+# waiting for instead of asserting who reviews: a repo whose trust lists hold
+# only human logins reads those people's names, a repo trusting bots reads the
+# bots. Nothing is resolved here — the caller passes its already-resolved
+# values, and lib/settings.sh stays the one resolver.
+#
+# Inputs (environment): HEAD_SHA, TRUSTED_LOGINS, TRUSTED_CONTEXTS,
+# COMMENT_REVIEWERS. Output: the description on stdout, no trailing newline.
+#
+# GitHub truncates a commit-status description at 140 characters, and a real
+# trust list is longer than that on its own. So the sha shortens to its
+# 12-character prefix before any name is dropped, and the names that still do
+# not fit are counted rather than cut mid-word.
+set -euo pipefail
+
+RG_STATUS_LIMIT=140
+
+HEAD_SHA="${HEAD_SHA:-}"
+TRUSTED_LOGINS="${TRUSTED_LOGINS:-}"
+TRUSTED_CONTEXTS="${TRUSTED_CONTEXTS:-}"
+COMMENT_REVIEWERS="${COMMENT_REVIEWERS:-}"
+
+# A packed list -> one name per line, whitespace trimmed, blanks dropped.
+# SEPARATORS is the tr set for that setting's own packing.
+names_of() { # LIST SEPARATORS
+  local item
+  # printf '%s\n', never '%s': an unterminated last line is not read at all,
+  # which would drop the only entry of a single-name list.
+  printf '%s\n' "$1" | tr "$2" '\n' | while IFS= read -r item; do
+    item="${item#"${item%%[![:space:]]*}"}"
+    item="${item%"${item##*[![:space:]]}"}"
+    [ -n "$item" ] && printf '%s\n' "$item"
+  done
+  return 0
+}
+
+# Every evidence source the settings name, in the decision table's order:
+# trusted review-object logins, trusted status/check contexts, then the
+# comment-form reviewers — their login half only, since the binding pattern is
+# not a name a reader can act on.
+sources() { # -> one name per line, duplicates collapsed
+  {
+    names_of "$TRUSTED_LOGINS" ';,'
+    names_of "$TRUSTED_CONTEXTS" ';'
+    names_of "$COMMENT_REVIEWERS" ';' | sed 's/:.*$//'
+  } | awk '!seen[$0]++'
+}
+
+full_form="no review evidence at $HEAD_SHA yet; expected from "
+short_form="no review evidence at ${HEAD_SHA:0:12} yet; expected from "
+
+names="$(sources)"
+count=0
+[ -n "$names" ] && count="$(printf '%s\n' "$names" | wc -l | tr -d ' ')"
+
+# Empty trust lists mean any non-author review is evidence. That is a source
+# too, so it is named rather than leaving the clause blank.
+if [ "$count" = "0" ]; then
+  detail="${full_form}any non-author review"
+  [ "${#detail}" -le "$RG_STATUS_LIMIT" ] || detail="${short_form}any non-author review"
+  printf '%s' "$detail"
+  exit 0
+fi
+
+joined="$(printf '%s\n' "$names" | tr '\n' ',' | sed 's/,$//; s/,/, /g')"
+detail="$full_form$joined"
+if [ "${#detail}" -le "$RG_STATUS_LIMIT" ]; then
+  printf '%s' "$detail"
+  exit 0
+fi
+
+# The full sha does not fit beside the names. Shorten it once, then fill the
+# remaining budget with whole names and count whatever is left over.
+kept=0
+shown=""
+while IFS= read -r name; do
+  if [ -z "$shown" ]; then candidate="$name"; else candidate="$shown, $name"; fi
+  # Reserve room for the remainder clause (" and N more") before accepting a
+  # name: a clause that no longer fits would be dropped silently, and an
+  # absent count reads as a complete list.
+  if [ $((${#short_form} + ${#candidate} + 10 + ${#count})) -le "$RG_STATUS_LIMIT" ]; then
+    shown="$candidate"
+    kept=$((kept + 1))
+  else
+    break
+  fi
+done <<EOF
+$names
+EOF
+
+if [ "$kept" = "0" ] && [ "$count" = "1" ]; then
+  printf '%s' "${short_form}1 configured reviewer"
+elif [ "$kept" = "0" ]; then
+  printf '%s' "$short_form$count configured reviewers"
+elif [ "$kept" = "$count" ]; then
+  printf '%s' "$short_form$shown"
+else
+  printf '%s' "$short_form$shown and $((count - kept)) more"
+fi

--- a/skills/review-gate/scripts/awaiting-detail.sh
+++ b/skills/review-gate/scripts/awaiting-detail.sh
@@ -1,81 +1,65 @@
 #!/usr/bin/env bash
-# The awaiting verdict's status description, composed from the evidence
-# sources a repo's resolved settings actually enable. review-predicate.sh
-# calls this on its awaiting arm and prints the result as the pending status.
+# The awaiting verdict's status description. review-predicate.sh calls this on
+# its awaiting arm and prints the result as the pending status.
 #
-# The gate is configuration-driven, so the text names what THIS repo is
-# waiting for instead of asserting who reviews: a repo whose trust lists hold
-# only human logins reads those people's names, a repo trusting bots reads the
-# bots. Nothing is resolved here — the caller passes its already-resolved
-# values, and lib/settings.sh stays the one resolver.
+# This script decides NOTHING about evidence. Which sources could still open
+# the gate at this head is the predicate's judgment — it resolves the trust
+# settings, applies each source's policy and filters the PR author — and it
+# passes the answer in. All that happens here is fitting that answer into the
+# 140 characters GitHub keeps of a commit-status description.
 #
-# Inputs (environment): HEAD_SHA, TRUSTED_LOGINS, TRUSTED_CONTEXTS,
-# COMMENT_REVIEWERS. Output: the description on stdout, no trailing newline.
+# The text names what THIS repo is waiting for rather than asserting who
+# reviews: a gate whose trust lists hold only human logins reads those
+# people's names, a gate trusting bots reads the bots.
 #
-# GitHub truncates a commit-status description at 140 characters, and a real
-# trust list is longer than that on its own. So the sha shortens to its
-# 12-character prefix before any name is dropped, and the names that still do
-# not fit are counted rather than cut mid-word.
+# Inputs (environment): HEAD_SHA, and SOURCES as one eligible source per line.
+# Output: the description on stdout, no trailing newline.
+#
+# A real trust list is longer than the whole limit on its own, so the sha
+# shortens to its 12-character prefix before any name is dropped, and the
+# names that still do not fit are counted rather than cut mid-word.
 set -euo pipefail
 
 RG_STATUS_LIMIT=140
 
 HEAD_SHA="${HEAD_SHA:-}"
-TRUSTED_LOGINS="${TRUSTED_LOGINS:-}"
-TRUSTED_CONTEXTS="${TRUSTED_CONTEXTS:-}"
-COMMENT_REVIEWERS="${COMMENT_REVIEWERS:-}"
-
-# A packed list -> one name per line, whitespace trimmed, blanks dropped.
-# SEPARATORS is the tr set for that setting's own packing.
-names_of() { # LIST SEPARATORS
-  local item
-  # printf '%s\n', never '%s': an unterminated last line is not read at all,
-  # which would drop the only entry of a single-name list.
-  printf '%s\n' "$1" | tr "$2" '\n' | while IFS= read -r item; do
-    item="${item#"${item%%[![:space:]]*}"}"
-    item="${item%"${item##*[![:space:]]}"}"
-    [ -n "$item" ] && printf '%s\n' "$item"
-  done
-  return 0
-}
-
-# Every evidence source the settings name, in the decision table's order:
-# trusted review-object logins, trusted status/check contexts, then the
-# comment-form reviewers — their login half only, since the binding pattern is
-# not a name a reader can act on.
-sources() { # -> one name per line, duplicates collapsed
-  {
-    names_of "$TRUSTED_LOGINS" ';,'
-    names_of "$TRUSTED_CONTEXTS" ';'
-    names_of "$COMMENT_REVIEWERS" ';' | sed 's/:.*$//'
-  } | awk '!seen[$0]++'
-}
+SOURCES="${SOURCES:-}"
 
 full_form="no review evidence at $HEAD_SHA yet; expected from "
 short_form="no review evidence at ${HEAD_SHA:0:12} yet; expected from "
 
-names="$(sources)"
 count=0
-[ -n "$names" ] && count="$(printf '%s\n' "$names" | wc -l | tr -d ' ')"
+[ -n "$SOURCES" ] && count="$(printf '%s\n' "$SOURCES" | wc -l | tr -d ' ')"
 
-# Empty trust lists mean any non-author review is evidence. That is a source
-# too, so it is named rather than leaving the clause blank.
+# No eligible source at all — a repo whose only trusted login is the PR
+# author reaches this. Saying "expected from" nothing would read as a
+# truncated status, so it names the state instead.
 if [ "$count" = "0" ]; then
-  detail="${full_form}any non-author review"
-  [ "${#detail}" -le "$RG_STATUS_LIMIT" ] || detail="${short_form}any non-author review"
+  detail="no review evidence at $HEAD_SHA yet; no configured source is eligible here"
+  if [ "${#detail}" -gt "$RG_STATUS_LIMIT" ]; then
+    detail="no review evidence at ${HEAD_SHA:0:12} yet; no configured source is eligible here"
+  fi
   printf '%s' "$detail"
   exit 0
 fi
 
-joined="$(printf '%s\n' "$names" | tr '\n' ',' | sed 's/,$//; s/,/, /g')"
+joined="$(printf '%s\n' "$SOURCES" | tr '\n' ',' | sed 's/,$//; s/,/, /g')"
 detail="$full_form$joined"
 if [ "${#detail}" -le "$RG_STATUS_LIMIT" ]; then
   printf '%s' "$detail"
   exit 0
 fi
 
-# The full sha does not fit beside the names. Shorten it once, then fill the
-# remaining budget with whole names and count whatever is left over.
+# The full sha does not fit beside the names. Shorten it and try the whole
+# list again BEFORE reserving room for any remainder clause — reserving first
+# would drop a name that the short form has room for.
+detail="$short_form$joined"
+if [ "${#detail}" -le "$RG_STATUS_LIMIT" ]; then
+  printf '%s' "$detail"
+  exit 0
+fi
+
+# Still over. Fill the remaining budget with whole names and count the rest.
 kept=0
 shown=""
 while IFS= read -r name; do
@@ -90,7 +74,7 @@ while IFS= read -r name; do
     break
   fi
 done <<EOF
-$names
+$SOURCES
 EOF
 
 if [ "$kept" = "0" ] && [ "$count" = "1" ]; then

--- a/skills/review-gate/scripts/review-predicate-selftest.sh
+++ b/skills/review-gate/scripts/review-predicate-selftest.sh
@@ -535,25 +535,6 @@ echo "--- mechanism layer (forced configuration)"
 # has become unconditionally true and every case below is meaningless.
 reset
 run "no evidence at all" awaiting
-# The awaiting detail is the one verdict a reader acts on wrongly: read as an
-# approval block, it stalls a PR that only has to wait out the re-review
-# window. Pin the exact line, and its fit inside the status API's 140-char
-# description limit with a full 40-char sha substituted.
-awaiting_detail="$(PATH="$shim:$PATH" GH_SHIM_FIXTURES="$fixtures" \
-  REVIEW_GATE_SETTINGS_FILE=/dev/null REVIEW_GATE_MODE=enforce \
-  GH_REPO="owner/repo" PR_NUMBER=1 HEAD_SHA="$HEAD" PR_AUTHOR="$AUTHOR" \
-  "$predicate" 2>/dev/null)"
-awaiting_detail="${awaiting_detail#verdict=awaiting detail=}"
-cases=$((cases + 1))
-if [ "$awaiting_detail" != "no review evidence at $HEAD yet; bots re-review each push, not a block on a human" ]; then
-  echo "FAIL  awaiting detail drifted: '$awaiting_detail'" >&2
-  failures=$((failures + 1))
-elif [ "${#awaiting_detail}" -gt 140 ]; then
-  echo "FAIL  awaiting detail is ${#awaiting_detail} characters; the status API truncates at 140" >&2
-  failures=$((failures + 1))
-else
-  echo "ok    awaiting: the pending detail is exact and fits the 140-char status limit"
-fi
 
 reset
 export GH_SHIM_FAIL=reviews

--- a/skills/review-gate/scripts/review-predicate-selftest.sh
+++ b/skills/review-gate/scripts/review-predicate-selftest.sh
@@ -535,6 +535,25 @@ echo "--- mechanism layer (forced configuration)"
 # has become unconditionally true and every case below is meaningless.
 reset
 run "no evidence at all" awaiting
+# The awaiting detail is the one verdict a reader acts on wrongly: read as an
+# approval block, it stalls a PR that only has to wait out the re-review
+# window. Pin the exact line, and its fit inside the status API's 140-char
+# description limit with a full 40-char sha substituted.
+awaiting_detail="$(PATH="$shim:$PATH" GH_SHIM_FIXTURES="$fixtures" \
+  REVIEW_GATE_SETTINGS_FILE=/dev/null REVIEW_GATE_MODE=enforce \
+  GH_REPO="owner/repo" PR_NUMBER=1 HEAD_SHA="$HEAD" PR_AUTHOR="$AUTHOR" \
+  "$predicate" 2>/dev/null)"
+awaiting_detail="${awaiting_detail#verdict=awaiting detail=}"
+cases=$((cases + 1))
+if [ "$awaiting_detail" != "no review evidence at $HEAD yet; bots re-review each push, not a block on a human" ]; then
+  echo "FAIL  awaiting detail drifted: '$awaiting_detail'" >&2
+  failures=$((failures + 1))
+elif [ "${#awaiting_detail}" -gt 140 ]; then
+  echo "FAIL  awaiting detail is ${#awaiting_detail} characters; the status API truncates at 140" >&2
+  failures=$((failures + 1))
+else
+  echo "ok    awaiting: the pending detail is exact and fits the 140-char status limit"
+fi
 
 reset
 export GH_SHIM_FAIL=reviews

--- a/skills/review-gate/scripts/review-predicate.sh
+++ b/skills/review-gate/scripts/review-predicate.sh
@@ -1384,9 +1384,9 @@ awaiting_sources() { # -> one eligible source per line, duplicates collapsed
       # 'approved' a COMMENTED review does not satisfy this source, so the
       # text must not send a reader to leave one.
       if [ "$MIN_STATE" = "approved" ]; then
-        echo "any non-author approval"
+        printf '%s\n' "any non-author approval"
       else
-        echo "any non-author review"
+        printf '%s\n' "any non-author review"
       fi
     else
       aw_eligible "$TRUSTED_LOGINS_N"
@@ -1397,8 +1397,10 @@ awaiting_sources() { # -> one eligible source per line, duplicates collapsed
     # way to open the gate and belongs in the list. Leaving it out told an
     # operator nothing was eligible while the recovery path they own was
     # configured and working. Empty means the source is disabled.
+    # printf, not echo: a status context is free-form, and bash's echo eats a
+    # value like -n or -e as an option and prints no name at all.
     if [ -n "$OUTAGE_CONTEXT" ]; then
-      echo "$OUTAGE_CONTEXT"
+      printf '%s\n' "$OUTAGE_CONTEXT"
     fi
   } | awk '!seen[$0]++'
 }

--- a/skills/review-gate/scripts/review-predicate.sh
+++ b/skills/review-gate/scripts/review-predicate.sh
@@ -271,12 +271,24 @@ THREADS_MODE="$(rg_setting REVIEW_GATE_THREADS "enforce")" || exit 2
 # checks, the evidence reads, and the awaiting label. Entry boundaries and
 # emptiness are decided once, so a value like " ; , " cannot be an open trust
 # model to one reader and a named list to another.
+# pipefail inside, checked at every caller: this decides the trust boundary,
+# and the last stage of the pipeline returns 0 on empty output. A `tr` that
+# died would leave a RESTRICTED list looking empty, which the evidence read
+# takes as "any non-author" — the trust list would open the gate it was set
+# to close. A broken pipeline is exit 2 with no verdict instead.
 rg_pack() { # RAW SEPARATORS -> one trimmed, non-empty entry per line
-  printf '%s\n' "$1" | tr "$2" '\n' | sed 's/^[[:space:]]*//;s/[[:space:]]*$//;/^$/d'
+  ( set -o pipefail
+    printf '%s\n' "$1" | tr "$2" '\n' | sed 's/^[[:space:]]*//;s/[[:space:]]*$//;/^$/d' )
 }
-TRUSTED_LOGINS_N="$(rg_pack "$TRUSTED_LOGINS" ';,')"
-TRUSTED_CONTEXTS_N="$(rg_pack "$TRUSTED_CONTEXTS" ';')"
-COMMENT_REVIEWERS_N="$(rg_pack "$COMMENT_REVIEWERS" ';')"
+# Called OUTSIDE the substitutions below: an `exit` inside `$( )` would leave
+# the subshell and the predicate would carry on with the empty value.
+rg_pack_failed() { # KEY
+  echo "::error::review-predicate: could not normalize $1 (broken pipeline) — no verdict" >&2
+  exit 2
+}
+TRUSTED_LOGINS_N="$(rg_pack "$TRUSTED_LOGINS" ';,')" || rg_pack_failed REVIEW_GATE_REVIEW_OBJECT_TRUSTED_LOGINS
+TRUSTED_CONTEXTS_N="$(rg_pack "$TRUSTED_CONTEXTS" ';')" || rg_pack_failed REVIEW_GATE_TRUSTED_STATUS_CONTEXTS
+COMMENT_REVIEWERS_N="$(rg_pack "$COMMENT_REVIEWERS" ';')" || rg_pack_failed REVIEW_GATE_COMMENT_REVIEWERS
 API_ATTEMPTS="$(rg_setting REVIEW_GATE_API_ATTEMPTS "1")" || exit 2
 API_RETRY_DELAY="$(rg_setting REVIEW_GATE_API_RETRY_DELAY_SECONDS "2")" || exit 2
 CARRY_FORWARD="$(rg_setting REVIEW_GATE_CARRY_FORWARD "")" || exit 2

--- a/skills/review-gate/scripts/review-predicate.sh
+++ b/skills/review-gate/scripts/review-predicate.sh
@@ -1337,7 +1337,7 @@ if [ "$cr" != "0" ]; then
 elif [ "$untracked" != "0" ]; then
   echo "verdict=untracked-claim detail=$untracked tracking claim(s) name no issue — write Declined: <reason>, or add the tracker/#id"
 elif [ "$got" = "0" ] && [ "$check" = "0" ] && [ "$comment_hits" = "0" ] && [ "$outageok" = "0" ] && [ "$carried" = "0" ]; then
-  echo "verdict=awaiting detail=awaiting a non-author review for $HEAD_SHA"
+  echo "verdict=awaiting detail=no review evidence at $HEAD_SHA yet; bots re-review each push, not a block on a human"
 elif [ "$unresolved" != "0" ]; then
   echo "verdict=threads-open detail=$unresolved unresolved review thread(s)"
 elif [ "$carried" = "1" ]; then

--- a/skills/review-gate/scripts/review-predicate.sh
+++ b/skills/review-gate/scripts/review-predicate.sh
@@ -1415,8 +1415,16 @@ elif [ "$got" = "0" ] && [ "$check" = "0" ] && [ "$comment_hits" = "0" ] && [ "$
   # Captured, never interpolated straight into the echo: a composer that
   # failed would otherwise leave an empty description on a verdict that still
   # printed, and a status is the only thing a reader gets.
+  # Captured on its OWN line: as an environment assignment on the composer
+  # command, this substitution's status is discarded and the composer would
+  # format whatever partial list it was handed and exit 0.
   awaiting_rc=0
-  awaiting_detail="$(HEAD_SHA="$HEAD_SHA" SOURCES="$(awaiting_sources)" "$script_dir/awaiting-detail.sh")" || awaiting_rc=$?
+  awaiting_srcs="$(awaiting_sources)" || awaiting_rc=$?
+  if [ "$awaiting_rc" != 0 ]; then
+    echo "::error::review-predicate: could not resolve the awaiting sources (exit $awaiting_rc) — no verdict" >&2
+    exit 2
+  fi
+  awaiting_detail="$(HEAD_SHA="$HEAD_SHA" SOURCES="$awaiting_srcs" "$script_dir/awaiting-detail.sh")" || awaiting_rc=$?
   if [ "$awaiting_rc" != 0 ] || [ -z "$awaiting_detail" ]; then
     echo "::error::review-predicate: scripts/awaiting-detail.sh failed (exit $awaiting_rc) — no verdict" >&2
     exit 2

--- a/skills/review-gate/scripts/review-predicate.sh
+++ b/skills/review-gate/scripts/review-predicate.sh
@@ -1337,7 +1337,7 @@ if [ "$cr" != "0" ]; then
 elif [ "$untracked" != "0" ]; then
   echo "verdict=untracked-claim detail=$untracked tracking claim(s) name no issue — write Declined: <reason>, or add the tracker/#id"
 elif [ "$got" = "0" ] && [ "$check" = "0" ] && [ "$comment_hits" = "0" ] && [ "$outageok" = "0" ] && [ "$carried" = "0" ]; then
-  echo "verdict=awaiting detail=no review evidence at $HEAD_SHA yet; bots re-review each push, not a block on a human"
+  echo "verdict=awaiting detail=$(HEAD_SHA="$HEAD_SHA" TRUSTED_LOGINS="$TRUSTED_LOGINS" TRUSTED_CONTEXTS="$TRUSTED_CONTEXTS" COMMENT_REVIEWERS="$COMMENT_REVIEWERS" "$script_dir/awaiting-detail.sh")"
 elif [ "$unresolved" != "0" ]; then
   echo "verdict=threads-open detail=$unresolved unresolved review thread(s)"
 elif [ "$carried" = "1" ]; then

--- a/skills/review-gate/scripts/review-predicate.sh
+++ b/skills/review-gate/scripts/review-predicate.sh
@@ -1330,6 +1330,43 @@ while :; do
 done
 fi
 
+# One packed list -> trimmed, non-empty entries, one per line. FILTER_AUTHOR
+# drops the PR author, whose own review and comment are never evidence.
+aw_entries() { # LIST SEPARATORS FILTER_AUTHOR
+  printf '%s\n' "$1" | tr "$2" '\n' | sed 's/^[[:space:]]*//;s/[[:space:]]*$//' |
+    while IFS= read -r aw_item; do
+      [ -z "$aw_item" ] && continue
+      [ "$3" = 1 ] && [ "$aw_item" = "$PR_AUTHOR" ] && continue
+      printf '%s\n' "$aw_item"
+    done
+}
+
+# The sources that could still open the gate at THIS head, under the same
+# rules the evaluation above applied: an empty review-object trust list
+# accepts any non-author review, a named list accepts those logins, and the
+# author is never evidence under either. Trusted status contexts are check
+# names rather than logins, so no author filter applies there. The awaiting
+# status is composed from this list — eligibility is decided here, and
+# awaiting-detail.sh only fits the answer into GitHub's description limit.
+awaiting_sources() { # -> one eligible source per line, duplicates collapsed
+  {
+    if [ -z "$TRUSTED_LOGINS" ]; then
+      # The minimum state is part of the policy, not decoration: under
+      # 'approved' a COMMENTED review does not satisfy this source, so the
+      # text must not send a reader to leave one.
+      if [ "$MIN_STATE" = "approved" ]; then
+        echo "any non-author approval"
+      else
+        echo "any non-author review"
+      fi
+    else
+      aw_entries "$TRUSTED_LOGINS" ';,' 1
+    fi
+    aw_entries "$TRUSTED_CONTEXTS" ';' 0
+    aw_entries "$(printf '%s' "$COMMENT_REVIEWERS" | sed 's/:[^;]*//g')" ';' 1
+  } | awk '!seen[$0]++'
+}
+
 echo "PR #$PR_NUMBER head $HEAD_SHA: reviews=$got clean-analysis=$check comment-form=$comment_hits outage-marker=$outageok carried=$carried changes-requested=$cr unresolved-threads=$unresolved untracked-claims=$untracked (threads=$THREADS_MODE)" >&2
 
 if [ "$cr" != "0" ]; then
@@ -1337,7 +1374,16 @@ if [ "$cr" != "0" ]; then
 elif [ "$untracked" != "0" ]; then
   echo "verdict=untracked-claim detail=$untracked tracking claim(s) name no issue — write Declined: <reason>, or add the tracker/#id"
 elif [ "$got" = "0" ] && [ "$check" = "0" ] && [ "$comment_hits" = "0" ] && [ "$outageok" = "0" ] && [ "$carried" = "0" ]; then
-  echo "verdict=awaiting detail=$(HEAD_SHA="$HEAD_SHA" TRUSTED_LOGINS="$TRUSTED_LOGINS" TRUSTED_CONTEXTS="$TRUSTED_CONTEXTS" COMMENT_REVIEWERS="$COMMENT_REVIEWERS" "$script_dir/awaiting-detail.sh")"
+  # Captured, never interpolated straight into the echo: a composer that
+  # failed would otherwise leave an empty description on a verdict that still
+  # printed, and a status is the only thing a reader gets.
+  awaiting_rc=0
+  awaiting_detail="$(HEAD_SHA="$HEAD_SHA" SOURCES="$(awaiting_sources)" "$script_dir/awaiting-detail.sh")" || awaiting_rc=$?
+  if [ "$awaiting_rc" != 0 ] || [ -z "$awaiting_detail" ]; then
+    echo "::error::review-predicate: scripts/awaiting-detail.sh failed (exit $awaiting_rc) — no verdict" >&2
+    exit 2
+  fi
+  echo "verdict=awaiting detail=$awaiting_detail"
 elif [ "$unresolved" != "0" ]; then
   echo "verdict=threads-open detail=$unresolved unresolved review thread(s)"
 elif [ "$carried" = "1" ]; then

--- a/skills/review-gate/scripts/review-predicate.sh
+++ b/skills/review-gate/scripts/review-predicate.sh
@@ -1393,6 +1393,13 @@ awaiting_sources() { # -> one eligible source per line, duplicates collapsed
     fi
     printf '%s\n' "$TRUSTED_CONTEXTS_N" | sed '/^$/d'
     aw_eligible "$COMMENT_REVIEWERS_N" 1
+    # The operator override is evidence this predicate accepts, so it is a
+    # way to open the gate and belongs in the list. Leaving it out told an
+    # operator nothing was eligible while the recovery path they own was
+    # configured and working. Empty means the source is disabled.
+    if [ -n "$OUTAGE_CONTEXT" ]; then
+      echo "$OUTAGE_CONTEXT"
+    fi
   } | awk '!seen[$0]++'
 }
 

--- a/skills/review-gate/scripts/review-predicate.sh
+++ b/skills/review-gate/scripts/review-predicate.sh
@@ -265,6 +265,18 @@ TRUSTED_LOGINS="$(rg_setting REVIEW_GATE_REVIEW_OBJECT_TRUSTED_LOGINS "")" || ex
 MIN_STATE="$(rg_setting REVIEW_GATE_REVIEW_OBJECT_MIN_STATE "any")" || exit 2
 ERROR_PATTERNS="$(rg_setting REVIEW_GATE_REVIEW_OBJECT_ERROR_PATTERNS "encountered an error and was unable to review")" || exit 2
 THREADS_MODE="$(rg_setting REVIEW_GATE_THREADS "enforce")" || exit 2
+
+# ONE parse of each packed trust list, here at the single place the settings
+# are resolved. Every consumer below works from these: the configuration
+# checks, the evidence reads, and the awaiting label. Entry boundaries and
+# emptiness are decided once, so a value like " ; , " cannot be an open trust
+# model to one reader and a named list to another.
+rg_pack() { # RAW SEPARATORS -> one trimmed, non-empty entry per line
+  printf '%s\n' "$1" | tr "$2" '\n' | sed 's/^[[:space:]]*//;s/[[:space:]]*$//;/^$/d'
+}
+TRUSTED_LOGINS_N="$(rg_pack "$TRUSTED_LOGINS" ';,')"
+TRUSTED_CONTEXTS_N="$(rg_pack "$TRUSTED_CONTEXTS" ';')"
+COMMENT_REVIEWERS_N="$(rg_pack "$COMMENT_REVIEWERS" ';')"
 API_ATTEMPTS="$(rg_setting REVIEW_GATE_API_ATTEMPTS "1")" || exit 2
 API_RETRY_DELAY="$(rg_setting REVIEW_GATE_API_RETRY_DELAY_SECONDS "2")" || exit 2
 CARRY_FORWARD="$(rg_setting REVIEW_GATE_CARRY_FORWARD "")" || exit 2
@@ -374,14 +386,13 @@ if [ "$OUTAGE_CONTEXT" = "$GATE_CONTEXT_SELF" ]; then
   exit 2
 fi
 while IFS= read -r ctx; do
-  ctx="$(printf '%s' "$ctx" | sed 's/^[[:space:]]*//;s/[[:space:]]*$//')"
   [ -z "$ctx" ] && continue
   if [ "$ctx" = "$GATE_CONTEXT_SELF" ]; then
     echo "::error::review-predicate: REVIEW_GATE_TRUSTED_STATUS_CONTEXTS includes REVIEW_GATE_CONTEXT ('$GATE_CONTEXT_SELF') — the gate's own status cannot be its own review evidence" >&2
     exit 2
   fi
 done <<EOF_GATE_CTX
-$(printf '%s' "$TRUSTED_CONTEXTS" | tr ';' '\n')
+$TRUSTED_CONTEXTS_N
 EOF_GATE_CTX
 
 # The exclusion pattern GRAMMAR, and the one judge of it. Callers that need
@@ -448,7 +459,6 @@ rg_check_patterns REVIEW_GATE_CARRY_FORWARD_EXCLUDE_PROPHYLACTIC "$CARRY_EXCLUDE
 # a PR to evaluate — otherwise --check-config reports a legal configuration
 # that the next live run exits 2 on.
 while IFS= read -r cfg_pair; do
-  cfg_pair="$(printf '%s' "$cfg_pair" | sed 's/^[[:space:]]*//;s/[[:space:]]*$//')"
   [ -z "$cfg_pair" ] && continue
   cfg_login="${cfg_pair%%:*}"
   cfg_pattern="${cfg_pair#*:}"
@@ -457,7 +467,7 @@ while IFS= read -r cfg_pair; do
     exit 2
   fi
 done <<EOF_COMMENT_CFG
-$(printf '%s' "$COMMENT_REVIEWERS" | tr ';' '\n')
+$COMMENT_REVIEWERS_N
 EOF_COMMENT_CFG
 
 # Every configuration rule above has now run, and --check-config stops HERE:
@@ -588,9 +598,9 @@ ATTESTATION_DEF='def not_errored_attestation($mk):
 # by a newer CHANGES_REQUESTED from that same login — a trailing COMMENTED
 # never withdraws an approval.
 got="$(jq --arg sha "$HEAD_SHA" --arg author "$PR_AUTHOR" \
-        --arg trusted "$TRUSTED_LOGINS" --arg minstate "$MIN_STATE" \
+        --arg trusted "$TRUSTED_LOGINS_N" --arg minstate "$MIN_STATE" \
         --arg errmarks "$ERROR_PATTERNS" "$ATTESTATION_DEF"'
-  ($trusted | split("[;,\n]+"; "") | map(gsub("^\\s+|\\s+$"; "")) | map(select(length > 0))) as $t
+  ($trusted | split("\n") | map(gsub("^\\s+|\\s+$"; "")) | map(select(length > 0))) as $t
   | ($errmarks | split(";") | map(gsub("^\\s+|\\s+$"; "")) | map(select(length > 0)) | map(ascii_downcase)) as $mk
   | [ .[]
       | select(.commit_id == $sha and .state != "DISMISSED" and .state != "PENDING" and .user.login != $author)
@@ -716,7 +726,6 @@ else
 fi
 check=0
 while IFS= read -r ctx; do
-  ctx="$(printf '%s' "$ctx" | sed 's/^[[:space:]]*//;s/[[:space:]]*$//')"
   [ -z "$ctx" ] && continue
   ctx_uri="$(jq -rn --arg s "$ctx" '$s|@uri')"
   # --paginate emits one OBJECT per page for this endpoint; jq -s merges the
@@ -883,7 +892,7 @@ while IFS= read -r ctx; do
   }
   check=$((check + check_runs + check_status))
 done <<EOF
-$(printf '%s' "$TRUSTED_CONTEXTS" | tr ';' '\n')
+$TRUSTED_CONTEXTS_N
 EOF
 
 # Comment-form clean-pass evidence: some reviewers post NEITHER a review
@@ -899,7 +908,7 @@ EOF
 # match every head. The trust anchor is the author login plus the LITERAL
 # binding pattern immediately preceding the sha slot, not the quoting.
 comment_hits=0
-if [ -n "$COMMENT_REVIEWERS" ]; then
+if [ -n "$COMMENT_REVIEWERS_N" ]; then
   # Two steps, not a pipe — same pagination/fail-loud/zero-byte reasons as
   # the reviews read above.
   raw_comments="$(gh_read "repos/$GH_REPO/issues/$PR_NUMBER/comments?per_page=100" --paginate)" || {
@@ -921,7 +930,6 @@ if [ -n "$COMMENT_REVIEWERS" ]; then
     exit 2
   }
   while IFS= read -r pair; do
-    pair="$(printf '%s' "$pair" | sed 's/^[[:space:]]*//;s/[[:space:]]*$//')"
     [ -z "$pair" ] && continue
     # Grammar was proved in the configuration phase above, which is the one
     # site for it; this loop only splits what that pass accepted.
@@ -951,7 +959,7 @@ if [ -n "$COMMENT_REVIEWERS" ]; then
     }
     comment_hits=$((comment_hits + hits))
   done <<EOF
-$(printf '%s' "$COMMENT_REVIEWERS" | tr ';' '\n')
+$COMMENT_REVIEWERS_N
 EOF
 fi
 
@@ -1050,9 +1058,9 @@ if [ -n "$CARRY_FORWARD" ] && [ "$got" = "0" ] && [ "$check" = "0" ] \
   # carry could matter), newest-first, distinct, never the head itself,
   # bounded so a force-push-heavy PR cannot turn the walk into an API storm.
   carry_candidates="$(jq -r --arg sha "$HEAD_SHA" --arg author "$PR_AUTHOR" \
-      --arg trusted "$TRUSTED_LOGINS" --arg minstate "$MIN_STATE" \
+      --arg trusted "$TRUSTED_LOGINS_N" --arg minstate "$MIN_STATE" \
       --arg errmarks "$ERROR_PATTERNS" "$ATTESTATION_DEF"'
-    ($trusted | split("[;,\n]+"; "") | map(gsub("^\\s+|\\s+$"; "")) | map(select(length > 0))) as $t
+    ($trusted | split("\n") | map(gsub("^\\s+|\\s+$"; "")) | map(select(length > 0))) as $t
     | ($errmarks | split(";") | map(gsub("^\\s+|\\s+$"; "")) | map(select(length > 0)) | map(ascii_downcase)) as $mk
     | [ .[]
         | select(.state != "DISMISSED" and .state != "PENDING" and .user.login != $author)
@@ -1332,11 +1340,16 @@ fi
 
 # One packed list -> trimmed, non-empty entries, one per line. FILTER_AUTHOR
 # drops the PR author, whose own review and comment are never evidence.
-aw_entries() { # LIST SEPARATORS FILTER_AUTHOR
-  printf '%s\n' "$1" | tr "$2" '\n' | sed 's/^[[:space:]]*//;s/[[:space:]]*$//' |
+# The PR author is never evidence, so a source keyed on their login is not a
+# way to open this gate and must not be named as one. LOGIN_HALF takes what
+# precedes the first colon, which is how the comment-form evidence loop reads
+# a pair — the label names the string that loop matches on.
+aw_eligible() { # LIST [LOGIN_HALF]
+  printf '%s\n' "$1" |
     while IFS= read -r aw_item; do
+      [ "${2:-0}" = 1 ] && aw_item="${aw_item%%:*}"
       [ -z "$aw_item" ] && continue
-      [ "$3" = 1 ] && [ "$aw_item" = "$PR_AUTHOR" ] && continue
+      [ "$aw_item" = "$PR_AUTHOR" ] && continue
       printf '%s\n' "$aw_item"
     done
 }
@@ -1350,7 +1363,11 @@ aw_entries() { # LIST SEPARATORS FILTER_AUTHOR
 # awaiting-detail.sh only fits the answer into GitHub's description limit.
 awaiting_sources() { # -> one eligible source per line, duplicates collapsed
   {
-    if [ -z "$TRUSTED_LOGINS" ]; then
+    # The same normalized list the evidence read is given, so an empty trust
+    # list is empty for both. Emptiness is tested BEFORE the author filter: a
+    # list holding only the author is a named list nothing can satisfy, not
+    # an open one.
+    if [ -z "$TRUSTED_LOGINS_N" ]; then
       # The minimum state is part of the policy, not decoration: under
       # 'approved' a COMMENTED review does not satisfy this source, so the
       # text must not send a reader to leave one.
@@ -1360,10 +1377,10 @@ awaiting_sources() { # -> one eligible source per line, duplicates collapsed
         echo "any non-author review"
       fi
     else
-      aw_entries "$TRUSTED_LOGINS" ';,' 1
+      aw_eligible "$TRUSTED_LOGINS_N"
     fi
-    aw_entries "$TRUSTED_CONTEXTS" ';' 0
-    aw_entries "$(printf '%s' "$COMMENT_REVIEWERS" | sed 's/:[^;]*//g')" ';' 1
+    printf '%s\n' "$TRUSTED_CONTEXTS_N" | sed '/^$/d'
+    aw_eligible "$COMMENT_REVIEWERS_N" 1
   } | awk '!seen[$0]++'
 }
 

--- a/skills/review-gate/scripts/validate.sh
+++ b/skills/review-gate/scripts/validate.sh
@@ -115,7 +115,7 @@ group "runtime"
 SKILL_REL="${SKILL_DIR#"$REPO_ROOT"/}"
 for rel in scripts/review-predicate.sh scripts/review-writer.sh \
   scripts/pr-watch.sh scripts/validate.sh scripts/validate-workflow.sh \
-  scripts/lib/settings.sh; do
+  scripts/awaiting-detail.sh scripts/lib/settings.sh; do
   path="$SKILL_DIR/$rel"
   if [ ! -f "$path" ]; then
     bad "$rel is missing from the installed skill ($SKILL_DIR) — re-run \`kendex refresh\` and commit the result"

--- a/skills/review-gate/tests/awaiting-detail.test.sh
+++ b/skills/review-gate/tests/awaiting-detail.test.sh
@@ -46,10 +46,23 @@ else
   ok "the composer models no trust setting of its own"
 fi
 
+# One representation, shared. The evidence reads and the label must be given
+# the SAME packed lists, or a value can be an open trust model to one and a
+# named list to the other.
+if grep -q -- '--arg trusted "\$TRUSTED_LOGINS"' "$PRED"; then
+  bad "the evidence read is given the normalized trust list" "it is given the raw value"
+else
+  ok "the evidence read is given the normalized trust list"
+fi
+[ "$(grep -c 'rg_pack "\$TRUSTED_LOGINS" ' "$PRED")" = 1 ] \
+  && ok "the trust list is parsed exactly once" \
+  || bad "the trust list is parsed exactly once" "$(grep -c 'rg_pack "\$TRUSTED_LOGINS" ' "$PRED") parse sites"
+
 # ---------------------------------------------------------------- layer 1 ---
 # The predicate's own resolution, extracted from the script rather than
 # restated, so a rule that changes there changes here.
-eval "$(sed -n '/^aw_entries() {/,/^}/p' "$PRED")"
+eval "$(sed -n '/^rg_pack() {/,/^}/p' "$PRED")"
+eval "$(sed -n '/^aw_eligible() {/,/^}/p' "$PRED")"
 eval "$(sed -n '/^awaiting_sources() {/,/^}/p' "$PRED")"
 if declare -F awaiting_sources >/dev/null; then
   ok "the predicate's source resolution is extractable"
@@ -59,8 +72,15 @@ else
 fi
 
 MIN_STATE="any"
+# Each case is written in the raw settings a repo commits, and packs them
+# through the predicate's own rg_pack — the single parse every consumer of
+# these lists shares.
 sources_are() { # CASE, EXPECTED (comma-joined)
-  local got; got="$(awaiting_sources | tr '\n' ',' | sed 's/,$//')"
+  local got
+  TRUSTED_LOGINS_N="$(rg_pack "$TRUSTED_LOGINS" ';,')"
+  TRUSTED_CONTEXTS_N="$(rg_pack "$TRUSTED_CONTEXTS" ';')"
+  COMMENT_REVIEWERS_N="$(rg_pack "$COMMENT_REVIEWERS" ';')"
+  got="$(awaiting_sources | tr '\n' ',' | sed 's/,$//')"
   [ "$got" = "$2" ] && ok "$1" || bad "$1" "$got"
 }
 
@@ -98,6 +118,25 @@ sources_are "a login reachable two ways is listed once" "alice"
 # must not claim otherwise.
 PR_AUTHOR="alice" TRUSTED_LOGINS="alice" TRUSTED_CONTEXTS="" COMMENT_REVIEWERS="alice:REVIEWED-CLEAN"
 sources_are "an author-only configuration leaves no eligible source" ""
+
+# A delimiter-only trust list is what the evidence jq calls an EMPTY trust
+# list — it splits, trims and drops empties before deciding — so it is the
+# open trust model here too. Testing the raw value said the opposite: no
+# eligible source, on a gate that would accept any non-author review.
+PR_AUTHOR="carol" TRUSTED_LOGINS=" ; , " TRUSTED_CONTEXTS="" COMMENT_REVIEWERS=""
+sources_are "a delimiter-only trust list is the open trust model" \
+  "any non-author review"
+
+PR_AUTHOR="carol" TRUSTED_LOGINS="   " TRUSTED_CONTEXTS="Analysis" COMMENT_REVIEWERS=""
+sources_are "a whitespace-only trust list keeps the open model beside a context" \
+  "any non-author review,Analysis"
+
+# The comment-form evidence loop trims the PAIR and then takes everything
+# before the first colon, so a login with inner whitespace is matched as
+# 'alice ' — the label has to name that same string, not a tidier one.
+PR_AUTHOR="carol" TRUSTED_LOGINS="" TRUSTED_CONTEXTS="" COMMENT_REVIEWERS=" alice :Reviewed commit: "
+sources_are "a comment login is labelled as the evidence loop splits it" \
+  "any non-author review,alice "
 
 # The review-object minimum state is policy, not decoration: under 'approved'
 # a COMMENTED review does not satisfy the open trust model, so the text must

--- a/skills/review-gate/tests/awaiting-detail.test.sh
+++ b/skills/review-gate/tests/awaiting-detail.test.sh
@@ -1,0 +1,98 @@
+#!/usr/bin/env bash
+# The awaiting verdict's status description. It is the one verdict a reader
+# acts on wrongly — read as an approval block, it stalls a PR that only has to
+# wait for evidence at the new head — so what it says is pinned here.
+#
+# The text is DERIVED from the repo's resolved evidence settings, never
+# asserted: a gate trusting only human logins must name those people, and a
+# gate trusting bots must name the bots. These cases drive the composer the
+# predicate itself calls, across both sha forms and the 140-character limit
+# GitHub truncates a commit-status description at.
+set -euo pipefail
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PRED="$SCRIPT_DIR/../scripts/review-predicate.sh"
+COMPOSER="$SCRIPT_DIR/../scripts/awaiting-detail.sh"
+PASS=0 FAIL=0
+ok()  { PASS=$((PASS+1)); echo "  ok    $1"; }
+bad() { FAIL=$((FAIL+1)); echo "  FAIL  $1"; echo "        got: $2"; }
+
+SHA='a1b2c3d4e5f60718293a4b5c6d7e8f9012345678'
+TRUSTED_LOGINS="" TRUSTED_CONTEXTS="" COMMENT_REVIEWERS=""
+# GitHub's own cap, restated here so a loosened constant in the composer is a
+# failure rather than a silently wider status the API then truncates.
+RG_STATUS_LIMIT=140
+grep -qx "RG_STATUS_LIMIT=$RG_STATUS_LIMIT" "$COMPOSER" \
+  && ok "the composer caps at $RG_STATUS_LIMIT characters" \
+  || bad "the composer caps at $RG_STATUS_LIMIT characters" "constant drifted"
+
+# The predicate must actually route its awaiting arm through this composer: a
+# copy of the text left in the arm would pass every case below while
+# production said something else.
+grep -q 'verdict=awaiting detail=\$(.*awaiting-detail\.sh' "$PRED" \
+  && ok "the predicate's awaiting arm calls the composer" \
+  || bad "the predicate's awaiting arm calls the composer" "the arm does not call awaiting-detail.sh"
+
+want() { # CASE, EXPECTED
+  local got
+  got="$(HEAD_SHA="$SHA" TRUSTED_LOGINS="$TRUSTED_LOGINS" \
+    TRUSTED_CONTEXTS="$TRUSTED_CONTEXTS" COMMENT_REVIEWERS="$COMMENT_REVIEWERS" \
+    "$COMPOSER")"
+  [ "$got" = "$2" ] && ok "$1" || bad "$1" "$got"
+  if [ "${#got}" -le "$RG_STATUS_LIMIT" ]; then
+    ok "$1 — fits the $RG_STATUS_LIMIT-character status limit (${#got})"
+  else
+    bad "$1 — fits the $RG_STATUS_LIMIT-character status limit" "${#got} characters"
+  fi
+}
+
+# A human-only gate: bot sources empty, one person trusted. The text names that
+# person and never promises automation the configuration does not provide.
+TRUSTED_LOGINS="alice" TRUSTED_CONTEXTS="" COMMENT_REVIEWERS=""
+want "human-only gate names the human" \
+  "no review evidence at $SHA yet; expected from alice"
+
+TRUSTED_LOGINS="alice;bob" TRUSTED_CONTEXTS="" COMMENT_REVIEWERS=""
+want "every trusted login is named" \
+  "no review evidence at $SHA yet; expected from alice, bob"
+
+# Each source kind contributes, and a comment-form entry contributes its login
+# half only — the binding pattern is not a name a reader can act on.
+TRUSTED_LOGINS="alice" TRUSTED_CONTEXTS="Analysis" COMMENT_REVIEWERS="botty[bot]:Reviewed commit:"
+want "status contexts and comment reviewers are named too" \
+  "no review evidence at $SHA yet; expected from alice, Analysis, botty[bot]"
+
+# A name reachable two ways is one source, not two.
+TRUSTED_LOGINS="alice" TRUSTED_CONTEXTS="" COMMENT_REVIEWERS="alice:REVIEWED-CLEAN"
+want "a login named by two settings is listed once" \
+  "no review evidence at $SHA yet; expected from alice"
+
+# Empty trust lists mean any non-author review is evidence. That is a source,
+# so it is named rather than leaving the clause blank.
+TRUSTED_LOGINS="" TRUSTED_CONTEXTS="" COMMENT_REVIEWERS=""
+want "nothing configured names the open trust model" \
+  "no review evidence at $SHA yet; expected from any non-author review"
+
+# Whitespace around packed entries belongs to the settings file, not to a name.
+TRUSTED_LOGINS=" alice ; bob " TRUSTED_CONTEXTS="" COMMENT_REVIEWERS=""
+want "packed entries are trimmed" \
+  "no review evidence at $SHA yet; expected from alice, bob"
+
+# Past the limit: the sha shortens to its 12-character prefix before any name
+# is dropped, and the names that still do not fit are counted.
+TRUSTED_LOGINS="coderabbitai[bot];copilot-pull-request-reviewer[bot];qodo-code-review[bot];chatgpt-codex-connector[bot];bmethod"
+TRUSTED_CONTEXTS="CodeRabbit;copilot-pull-request-reviewer"
+COMMENT_REVIEWERS="chatgpt-codex-connector[bot]:Reviewed commit:;bmethod:REVIEWED-CLEAN"
+want "a list past the limit shortens the sha and counts the remainder" \
+  "no review evidence at ${SHA:0:12} yet; expected from coderabbitai[bot], copilot-pull-request-reviewer[bot] and 5 more"
+
+# One name wider than the whole budget: a count, never a name cut mid-word.
+TRUSTED_LOGINS="$(printf 'x%.0s' $(seq 1 200))" TRUSTED_CONTEXTS="" COMMENT_REVIEWERS=""
+want "a name too wide to show becomes a count" \
+  "no review evidence at ${SHA:0:12} yet; expected from 1 configured reviewer"
+
+TRUSTED_LOGINS="$(printf 'x%.0s' $(seq 1 200));$(printf 'y%.0s' $(seq 1 200))"
+want "the count is plural for more than one" \
+  "no review evidence at ${SHA:0:12} yet; expected from 2 configured reviewers"
+
+echo "$PASS passed, $FAIL failed"
+[ "$FAIL" = 0 ] || exit 1

--- a/skills/review-gate/tests/awaiting-detail.test.sh
+++ b/skills/review-gate/tests/awaiting-detail.test.sh
@@ -72,6 +72,9 @@ else
 fi
 
 MIN_STATE="any"
+# The operator override is a source too; cases that are not about it disable
+# it the way a repo does, with an empty context.
+OUTAGE_CONTEXT=""
 # Each case is written in the raw settings a repo commits, and packs them
 # through the predicate's own rg_pack — the single parse every consumer of
 # these lists shares.
@@ -117,7 +120,28 @@ sources_are "a login reachable two ways is listed once" "alice"
 # Every configured source is the author: nothing is eligible, and the status
 # must not claim otherwise.
 PR_AUTHOR="alice" TRUSTED_LOGINS="alice" TRUSTED_CONTEXTS="" COMMENT_REVIEWERS="alice:REVIEWED-CLEAN"
-sources_are "an author-only configuration leaves no eligible source" ""
+sources_are "an author-only configuration with no override leaves nothing eligible" ""
+
+# The operator override is evidence this predicate accepts, so it is a way to
+# open the gate. Reporting nothing eligible while it is configured pointed an
+# operator away from the recovery path they own.
+OUTAGE_CONTEXT="kendex-reviewer-outage"
+PR_AUTHOR="alice" TRUSTED_LOGINS="alice" TRUSTED_CONTEXTS="" COMMENT_REVIEWERS="alice:REVIEWED-CLEAN"
+sources_are "an author-only configuration still names the configured override" \
+  "kendex-reviewer-outage"
+
+PR_AUTHOR="carol" TRUSTED_LOGINS="alice" TRUSTED_CONTEXTS="Analysis" COMMENT_REVIEWERS=""
+sources_are "the override joins the ordinary sources" \
+  "alice,Analysis,kendex-reviewer-outage"
+
+# An override context equal to a trusted status context is one source.
+PR_AUTHOR="carol" TRUSTED_LOGINS="" TRUSTED_CONTEXTS="kendex-reviewer-outage" COMMENT_REVIEWERS=""
+sources_are "an override matching a trusted context is listed once" \
+  "any non-author review,kendex-reviewer-outage"
+
+OUTAGE_CONTEXT=""
+PR_AUTHOR="carol" TRUSTED_LOGINS="alice" TRUSTED_CONTEXTS="" COMMENT_REVIEWERS=""
+sources_are "an empty override context contributes nothing" "alice"
 
 # A delimiter-only trust list is what the evidence jq calls an EMPTY trust
 # list — it splits, trims and drops empties before deciding — so it is the

--- a/skills/review-gate/tests/awaiting-detail.test.sh
+++ b/skills/review-gate/tests/awaiting-detail.test.sh
@@ -263,6 +263,15 @@ want "the open trust model is named" "any non-author review" \
 want "every source is listed while they fit" "$(printf 'alice\nAnalysis\nbotty[bot]')" \
   "no review evidence at $SHA yet; expected from alice, Analysis, botty[bot]"
 
+# A status context is free-form and may hold a comma. Joining by character
+# rewrote every comma into ", ", advertising `lint,build` as a context that
+# does not exist.
+want "a comma inside a context survives the join" "$(printf 'lint,build\nalice')" \
+  "no review evidence at $SHA yet; expected from lint,build, alice"
+
+want "a lone comma-bearing context is unchanged" "lint,build" \
+  "no review evidence at $SHA yet; expected from lint,build"
+
 want "no eligible source names the state, never a blank clause" "" \
   "no review evidence at $SHA yet; no configured source is eligible here"
 

--- a/skills/review-gate/tests/awaiting-detail.test.sh
+++ b/skills/review-gate/tests/awaiting-detail.test.sh
@@ -139,6 +139,15 @@ PR_AUTHOR="carol" TRUSTED_LOGINS="" TRUSTED_CONTEXTS="kendex-reviewer-outage" CO
 sources_are "an override matching a trusted context is listed once" \
   "any non-author review,kendex-reviewer-outage"
 
+# A status context is free-form, so it can be a string bash's echo takes as
+# an option. Printing it with echo emitted no name at all, which read as no
+# eligible source on an otherwise author-only gate.
+for opt in -n -e -E; do
+  OUTAGE_CONTEXT="$opt"
+  PR_AUTHOR="alice" TRUSTED_LOGINS="alice" TRUSTED_CONTEXTS="" COMMENT_REVIEWERS=""
+  sources_are "an override named '$opt' is still printed" "$opt"
+done
+
 OUTAGE_CONTEXT=""
 PR_AUTHOR="carol" TRUSTED_LOGINS="alice" TRUSTED_CONTEXTS="" COMMENT_REVIEWERS=""
 sources_are "an empty override context contributes nothing" "alice"

--- a/skills/review-gate/tests/awaiting-detail.test.sh
+++ b/skills/review-gate/tests/awaiting-detail.test.sh
@@ -149,6 +149,34 @@ MIN_STATE="any"
 PR_AUTHOR="carol" TRUSTED_LOGINS="" TRUSTED_CONTEXTS="" COMMENT_REVIEWERS=""
 sources_are "min_state=any keeps the review wording" "any non-author review"
 
+# The normalization decides the trust boundary, so a broken pipeline must be
+# exit 2 with no verdict. Without pipefail the last stage returns 0 on empty
+# output, and a RESTRICTED trust list would read as "any non-author" — the
+# list would open the gate it was set to close.
+stub_dir="$(mktemp -d)"
+trap 'rm -rf "$stub_dir"' EXIT
+printf '#!/usr/bin/env bash\nexit 1\n' > "$stub_dir/tr"
+chmod +x "$stub_dir/tr"
+broken_rc=0
+broken_out="$(PATH="$stub_dir:$PATH" REVIEW_GATE_SETTINGS_FILE=/dev/null \
+  REVIEW_GATE_REVIEW_OBJECT_TRUSTED_LOGINS="alice" \
+  GH_REPO=owner/repo PR_NUMBER=1 HEAD_SHA="$SHA" PR_AUTHOR=bob \
+  bash "$PRED" --check-config 2>&1)" || broken_rc=$?
+if [ "$broken_rc" = 2 ]; then
+  ok "a broken normalization pipeline exits 2"
+else
+  bad "a broken normalization pipeline exits 2" "exit $broken_rc"
+fi
+case "$broken_out" in
+  *"could not normalize REVIEW_GATE_REVIEW_OBJECT_TRUSTED_LOGINS"*)
+    ok "the failure names the list it could not normalize" ;;
+  *) bad "the failure names the list it could not normalize" "$broken_out" ;;
+esac
+case "$broken_out" in
+  *verdict=*) bad "a broken normalization emits no verdict" "$broken_out" ;;
+  *) ok "a broken normalization emits no verdict" ;;
+esac
+
 # ---------------------------------------------------------------- layer 2 ---
 # The composer, driven by a resolved list exactly as the predicate hands it in.
 want() { # CASE, SOURCES, EXPECTED
@@ -205,12 +233,17 @@ want "a short-form list one character over counts the remainder" "$names" \
   "$short_prefix$(printf '%s' "$names" | head -1) and 1 more"
 
 # One name wider than the whole budget: a count, never a name cut mid-word.
-want "a name too wide to show becomes a count" "$(printf 'x%.0s' $(seq 1 200))" \
-  "no review evidence at ${SHA:0:12} yet; expected from 1 configured reviewer"
+want "a source too wide to show becomes a count" "$(printf 'x%.0s' $(seq 1 200))" \
+  "no review evidence at ${SHA:0:12} yet; expected from 1 configured source"
+
+# A trusted status context is not a reviewer, and it is the value that
+# realistically exhausts the budget — the count must not name a person.
+want "a lone oversized status context is counted as a source" "$(printf 'C%.0s' $(seq 1 200))" \
+  "no review evidence at ${SHA:0:12} yet; expected from 1 configured source"
 
 want "the count is plural for more than one" \
   "$(printf 'x%.0s' $(seq 1 200); echo; printf 'y%.0s' $(seq 1 200))" \
-  "no review evidence at ${SHA:0:12} yet; expected from 2 configured reviewers"
+  "no review evidence at ${SHA:0:12} yet; expected from 2 configured sources"
 
 echo "$PASS passed, $FAIL failed"
 [ "$FAIL" = 0 ] || exit 1

--- a/skills/review-gate/tests/awaiting-detail.test.sh
+++ b/skills/review-gate/tests/awaiting-detail.test.sh
@@ -3,11 +3,10 @@
 # acts on wrongly — read as an approval block, it stalls a PR that only has to
 # wait for evidence at the new head — so what it says is pinned here.
 #
-# The text is DERIVED from the repo's resolved evidence settings, never
-# asserted: a gate trusting only human logins must name those people, and a
-# gate trusting bots must name the bots. These cases drive the composer the
-# predicate itself calls, across both sha forms and the 140-character limit
-# GitHub truncates a commit-status description at.
+# Two layers, one judge each. review-predicate.sh decides WHICH sources could
+# still open the gate at this head (its resolution is extracted below, never
+# restated), and awaiting-detail.sh only fits that answer into the 140
+# characters GitHub keeps of a status description.
 set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 PRED="$SCRIPT_DIR/../scripts/review-predicate.sh"
@@ -17,7 +16,7 @@ ok()  { PASS=$((PASS+1)); echo "  ok    $1"; }
 bad() { FAIL=$((FAIL+1)); echo "  FAIL  $1"; echo "        got: $2"; }
 
 SHA='a1b2c3d4e5f60718293a4b5c6d7e8f9012345678'
-TRUSTED_LOGINS="" TRUSTED_CONTEXTS="" COMMENT_REVIEWERS=""
+
 # GitHub's own cap, restated here so a loosened constant in the composer is a
 # failure rather than a silently wider status the API then truncates.
 RG_STATUS_LIMIT=140
@@ -25,19 +24,98 @@ grep -qx "RG_STATUS_LIMIT=$RG_STATUS_LIMIT" "$COMPOSER" \
   && ok "the composer caps at $RG_STATUS_LIMIT characters" \
   || bad "the composer caps at $RG_STATUS_LIMIT characters" "constant drifted"
 
-# The predicate must actually route its awaiting arm through this composer: a
-# copy of the text left in the arm would pass every case below while
-# production said something else.
-grep -q 'verdict=awaiting detail=\$(.*awaiting-detail\.sh' "$PRED" \
-  && ok "the predicate's awaiting arm calls the composer" \
-  || bad "the predicate's awaiting arm calls the composer" "the arm does not call awaiting-detail.sh"
+# The predicate must route its awaiting arm through the composer and hand it
+# the resolved list: a copy of either judgment left elsewhere would pass every
+# case below while production said something else.
+grep -q 'SOURCES="\$(awaiting_sources)".*awaiting-detail\.sh' "$PRED" \
+  && ok "the awaiting arm passes the predicate's resolved sources to the composer" \
+  || bad "the awaiting arm passes the predicate's resolved sources to the composer" "the arm does not"
+grep -q 'verdict=awaiting detail=\$awaiting_detail' "$PRED" \
+  && ok "the arm prints a captured description, not a substitution inside echo" \
+  || bad "the arm prints a captured description, not a substitution inside echo" "still interpolated"
+# A composer that failed must take the verdict with it: `exit 2` inside a
+# command substitution would leave only the subshell, so the guard has to sit
+# outside one.
+grep -q 'awaiting_detail.*|| awaiting_rc=\$?' "$PRED" \
+  && grep -q 'awaiting-detail.sh failed' "$PRED" \
+  && ok "a failed composer is captured and exits 2 before any verdict" \
+  || bad "a failed composer is captured and exits 2 before any verdict" "no failure guard"
+if grep -q 'TRUSTED_LOGINS\|TRUSTED_CONTEXTS\|COMMENT_REVIEWERS' "$COMPOSER"; then
+  bad "the composer models no trust setting of its own" "it reads a trust setting"
+else
+  ok "the composer models no trust setting of its own"
+fi
 
-want() { # CASE, EXPECTED
-  local got
-  got="$(HEAD_SHA="$SHA" TRUSTED_LOGINS="$TRUSTED_LOGINS" \
-    TRUSTED_CONTEXTS="$TRUSTED_CONTEXTS" COMMENT_REVIEWERS="$COMMENT_REVIEWERS" \
-    "$COMPOSER")"
+# ---------------------------------------------------------------- layer 1 ---
+# The predicate's own resolution, extracted from the script rather than
+# restated, so a rule that changes there changes here.
+eval "$(sed -n '/^aw_entries() {/,/^}/p' "$PRED")"
+eval "$(sed -n '/^awaiting_sources() {/,/^}/p' "$PRED")"
+if declare -F awaiting_sources >/dev/null; then
+  ok "the predicate's source resolution is extractable"
+else
+  echo "FAIL: could not extract awaiting_sources from $PRED"
+  exit 1
+fi
+
+MIN_STATE="any"
+sources_are() { # CASE, EXPECTED (comma-joined)
+  local got; got="$(awaiting_sources | tr '\n' ',' | sed 's/,$//')"
   [ "$got" = "$2" ] && ok "$1" || bad "$1" "$got"
+}
+
+# An empty review-object trust list accepts any non-author review, and a
+# configured status context does not withdraw that. Reporting only the context
+# would hide a way to unblock the gate.
+PR_AUTHOR="carol" TRUSTED_LOGINS="" TRUSTED_CONTEXTS="Analysis" COMMENT_REVIEWERS=""
+sources_are "an empty trust list keeps any non-author review beside a context" \
+  "any non-author review,Analysis"
+
+# The author's own review and comment are never evidence, so a trust list that
+# names the author must not send anyone to ask them.
+PR_AUTHOR="alice" TRUSTED_LOGINS="alice;bob" TRUSTED_CONTEXTS="" COMMENT_REVIEWERS=""
+sources_are "a trusted login equal to the author is omitted" "bob"
+
+PR_AUTHOR="alice" TRUSTED_LOGINS="bob" TRUSTED_CONTEXTS="" COMMENT_REVIEWERS="alice:REVIEWED-CLEAN"
+sources_are "a comment reviewer equal to the author is omitted" "bob"
+
+# A status context is a check name, not a login, so it survives an author of
+# the same name.
+PR_AUTHOR="Analysis" TRUSTED_LOGINS="bob" TRUSTED_CONTEXTS="Analysis" COMMENT_REVIEWERS=""
+sources_are "a status context is not author-filtered" "bob,Analysis"
+
+PR_AUTHOR="carol" TRUSTED_LOGINS="alice" TRUSTED_CONTEXTS="Analysis" COMMENT_REVIEWERS="botty[bot]:Reviewed commit:"
+sources_are "every source kind contributes, comment reviewers by login" \
+  "alice,Analysis,botty[bot]"
+
+PR_AUTHOR="carol" TRUSTED_LOGINS=" alice ; bob " TRUSTED_CONTEXTS="" COMMENT_REVIEWERS=""
+sources_are "packed entries are trimmed" "alice,bob"
+
+PR_AUTHOR="carol" TRUSTED_LOGINS="alice" TRUSTED_CONTEXTS="" COMMENT_REVIEWERS="alice:REVIEWED-CLEAN"
+sources_are "a login reachable two ways is listed once" "alice"
+
+# Every configured source is the author: nothing is eligible, and the status
+# must not claim otherwise.
+PR_AUTHOR="alice" TRUSTED_LOGINS="alice" TRUSTED_CONTEXTS="" COMMENT_REVIEWERS="alice:REVIEWED-CLEAN"
+sources_are "an author-only configuration leaves no eligible source" ""
+
+# The review-object minimum state is policy, not decoration: under 'approved'
+# a COMMENTED review does not satisfy the open trust model, so the text must
+# not send a reader to leave one.
+MIN_STATE="approved"
+PR_AUTHOR="carol" TRUSTED_LOGINS="" TRUSTED_CONTEXTS="" COMMENT_REVIEWERS=""
+sources_are "min_state=approved words the open trust model as an approval" \
+  "any non-author approval"
+MIN_STATE="any"
+PR_AUTHOR="carol" TRUSTED_LOGINS="" TRUSTED_CONTEXTS="" COMMENT_REVIEWERS=""
+sources_are "min_state=any keeps the review wording" "any non-author review"
+
+# ---------------------------------------------------------------- layer 2 ---
+# The composer, driven by a resolved list exactly as the predicate hands it in.
+want() { # CASE, SOURCES, EXPECTED
+  local got
+  got="$(HEAD_SHA="$SHA" SOURCES="$2" "$COMPOSER")"
+  [ "$got" = "$3" ] && ok "$1" || bad "$1" "$got"
   if [ "${#got}" -le "$RG_STATUS_LIMIT" ]; then
     ok "$1 — fits the $RG_STATUS_LIMIT-character status limit (${#got})"
   else
@@ -45,53 +123,54 @@ want() { # CASE, EXPECTED
   fi
 }
 
-# A human-only gate: bot sources empty, one person trusted. The text names that
-# person and never promises automation the configuration does not provide.
-TRUSTED_LOGINS="alice" TRUSTED_CONTEXTS="" COMMENT_REVIEWERS=""
-want "human-only gate names the human" \
+want "one human reads as that person's name" "alice" \
   "no review evidence at $SHA yet; expected from alice"
 
-TRUSTED_LOGINS="alice;bob" TRUSTED_CONTEXTS="" COMMENT_REVIEWERS=""
-want "every trusted login is named" \
-  "no review evidence at $SHA yet; expected from alice, bob"
-
-# Each source kind contributes, and a comment-form entry contributes its login
-# half only — the binding pattern is not a name a reader can act on.
-TRUSTED_LOGINS="alice" TRUSTED_CONTEXTS="Analysis" COMMENT_REVIEWERS="botty[bot]:Reviewed commit:"
-want "status contexts and comment reviewers are named too" \
-  "no review evidence at $SHA yet; expected from alice, Analysis, botty[bot]"
-
-# A name reachable two ways is one source, not two.
-TRUSTED_LOGINS="alice" TRUSTED_CONTEXTS="" COMMENT_REVIEWERS="alice:REVIEWED-CLEAN"
-want "a login named by two settings is listed once" \
-  "no review evidence at $SHA yet; expected from alice"
-
-# Empty trust lists mean any non-author review is evidence. That is a source,
-# so it is named rather than leaving the clause blank.
-TRUSTED_LOGINS="" TRUSTED_CONTEXTS="" COMMENT_REVIEWERS=""
-want "nothing configured names the open trust model" \
+want "the open trust model is named" "any non-author review" \
   "no review evidence at $SHA yet; expected from any non-author review"
 
-# Whitespace around packed entries belongs to the settings file, not to a name.
-TRUSTED_LOGINS=" alice ; bob " TRUSTED_CONTEXTS="" COMMENT_REVIEWERS=""
-want "packed entries are trimmed" \
-  "no review evidence at $SHA yet; expected from alice, bob"
+want "every source is listed while they fit" "$(printf 'alice\nAnalysis\nbotty[bot]')" \
+  "no review evidence at $SHA yet; expected from alice, Analysis, botty[bot]"
+
+want "no eligible source names the state, never a blank clause" "" \
+  "no review evidence at $SHA yet; no configured source is eligible here"
 
 # Past the limit: the sha shortens to its 12-character prefix before any name
 # is dropped, and the names that still do not fit are counted.
-TRUSTED_LOGINS="coderabbitai[bot];copilot-pull-request-reviewer[bot];qodo-code-review[bot];chatgpt-codex-connector[bot];bmethod"
-TRUSTED_CONTEXTS="CodeRabbit;copilot-pull-request-reviewer"
-COMMENT_REVIEWERS="chatgpt-codex-connector[bot]:Reviewed commit:;bmethod:REVIEWED-CLEAN"
 want "a list past the limit shortens the sha and counts the remainder" \
+  "$(printf 'coderabbitai[bot]\ncopilot-pull-request-reviewer[bot]\nqodo-code-review[bot]\nchatgpt-codex-connector[bot]\nbmethod\nCodeRabbit\ncopilot-pull-request-reviewer')" \
   "no review evidence at ${SHA:0:12} yet; expected from coderabbitai[bot], copilot-pull-request-reviewer[bot] and 5 more"
 
+# Boundary: a list whose SHORT form lands on the limit keeps every name.
+# Reserving room for a remainder clause before testing that form dropped the
+# last name from a list that fitted.
+short_prefix="no review evidence at ${SHA:0:12} yet; expected from "
+pad() { printf 'n%.0s' $(seq 1 "$1"); }
+two_names() { # TOTAL -> two names whose short form is exactly TOTAL characters
+  local first second rest
+  first="$(pad 20)"
+  rest=$(($1 - ${#short_prefix} - ${#first} - 2))
+  second="$(pad "$rest")"
+  printf '%s\n%s' "$first" "$second"
+}
+for total in 130 139 140; do
+  names="$(two_names "$total")"
+  want "a short-form list of exactly $total characters keeps every name" \
+    "$names" \
+    "$short_prefix$(printf '%s' "$names" | tr '\n' ',' | sed 's/,/, /g')"
+done
+
+# One character past it, and the remainder is counted rather than cut.
+names="$(two_names 141)"
+want "a short-form list one character over counts the remainder" "$names" \
+  "$short_prefix$(printf '%s' "$names" | head -1) and 1 more"
+
 # One name wider than the whole budget: a count, never a name cut mid-word.
-TRUSTED_LOGINS="$(printf 'x%.0s' $(seq 1 200))" TRUSTED_CONTEXTS="" COMMENT_REVIEWERS=""
-want "a name too wide to show becomes a count" \
+want "a name too wide to show becomes a count" "$(printf 'x%.0s' $(seq 1 200))" \
   "no review evidence at ${SHA:0:12} yet; expected from 1 configured reviewer"
 
-TRUSTED_LOGINS="$(printf 'x%.0s' $(seq 1 200));$(printf 'y%.0s' $(seq 1 200))"
 want "the count is plural for more than one" \
+  "$(printf 'x%.0s' $(seq 1 200); echo; printf 'y%.0s' $(seq 1 200))" \
   "no review evidence at ${SHA:0:12} yet; expected from 2 configured reviewers"
 
 echo "$PASS passed, $FAIL failed"

--- a/skills/review-gate/tests/awaiting-detail.test.sh
+++ b/skills/review-gate/tests/awaiting-detail.test.sh
@@ -27,7 +27,7 @@ grep -qx "RG_STATUS_LIMIT=$RG_STATUS_LIMIT" "$COMPOSER" \
 # The predicate must route its awaiting arm through the composer and hand it
 # the resolved list: a copy of either judgment left elsewhere would pass every
 # case below while production said something else.
-grep -q 'SOURCES="\$(awaiting_sources)".*awaiting-detail\.sh' "$PRED" \
+grep -q 'SOURCES="\$awaiting_srcs".*awaiting-detail\.sh' "$PRED" \
   && ok "the awaiting arm passes the predicate's resolved sources to the composer" \
   || bad "the awaiting arm passes the predicate's resolved sources to the composer" "the arm does not"
 grep -q 'verdict=awaiting detail=\$awaiting_detail' "$PRED" \
@@ -40,6 +40,18 @@ grep -q 'awaiting_detail.*|| awaiting_rc=\$?' "$PRED" \
   && grep -q 'awaiting-detail.sh failed' "$PRED" \
   && ok "a failed composer is captured and exits 2 before any verdict" \
   || bad "a failed composer is captured and exits 2 before any verdict" "no failure guard"
+# The resolver is captured on its OWN line. As an environment assignment on
+# the composer command its status would be discarded, and the composer would
+# format a partial list and exit 0.
+grep -q 'awaiting_srcs="\$(awaiting_sources)" || awaiting_rc=\$?' "$PRED" \
+  && grep -q 'could not resolve the awaiting sources' "$PRED" \
+  && ok "the resolver is captured and checked before the composer runs" \
+  || bad "the resolver is captured and checked before the composer runs" "no resolver guard"
+if grep -q 'SOURCES="\$(awaiting_sources)"' "$PRED"; then
+  bad "the resolver is not called inside an assignment prefix" "status would be discarded"
+else
+  ok "the resolver is not called inside an assignment prefix"
+fi
 if grep -q 'TRUSTED_LOGINS\|TRUSTED_CONTEXTS\|COMMENT_REVIEWERS' "$COMPOSER"; then
   bad "the composer models no trust setting of its own" "it reads a trust setting"
 else
@@ -209,6 +221,25 @@ case "$broken_out" in
   *verdict=*) bad "a broken normalization emits no verdict" "$broken_out" ;;
   *) ok "a broken normalization emits no verdict" ;;
 esac
+
+# Capturing the resolver's status only means something if the resolver has a
+# status to report. A stubbed failure has to come back as one, not as an
+# empty list the composer would format into a plausible status.
+res_stub="$(mktemp -d)"
+printf '#!/usr/bin/env bash\nexit 1\n' > "$res_stub/awk"
+chmod +x "$res_stub/awk"
+res_rc=0
+OUTAGE_CONTEXT="" PR_AUTHOR="carol" TRUSTED_LOGINS="alice" TRUSTED_CONTEXTS="" COMMENT_REVIEWERS=""
+TRUSTED_LOGINS_N="$(rg_pack "$TRUSTED_LOGINS" ';,')"
+TRUSTED_CONTEXTS_N="$(rg_pack "$TRUSTED_CONTEXTS" ';')"
+COMMENT_REVIEWERS_N="$(rg_pack "$COMMENT_REVIEWERS" ';')"
+( PATH="$res_stub:$PATH"; awaiting_sources ) >/dev/null 2>&1 || res_rc=$?
+rm -rf "$res_stub"
+if [ "$res_rc" != 0 ]; then
+  ok "a broken resolver pipeline reports failure instead of an empty list"
+else
+  bad "a broken resolver pipeline reports failure instead of an empty list" "exit 0"
+fi
 
 # ---------------------------------------------------------------- layer 2 ---
 # The composer, driven by a resolved list exactly as the predicate hands it in.

--- a/skills/review-gate/tests/review-writer.test.sh
+++ b/skills/review-gate/tests/review-writer.test.sh
@@ -231,7 +231,7 @@ run_writer() {
 # The pending status text the predicate emits for this verdict. The
 # writer is idempotent on state+description, so the fixture histories
 # below reuse this exact string.
-AWAITING_DETAIL="no review evidence at headsha yet; bots re-review each push, not a block on a human"
+AWAITING_DETAIL="no review evidence at headsha yet; expected from botty[bot]"
 AWAITING="verdict=awaiting detail=$AWAITING_DETAIL"
 APPROVED="verdict=approved detail=reviewed at head with no unresolved threads"
 CR="verdict=changes-requested detail=standing review changes requested (persists across pushes until re-approval or dismissal)"

--- a/skills/review-gate/tests/review-writer.test.sh
+++ b/skills/review-gate/tests/review-writer.test.sh
@@ -228,7 +228,11 @@ run_writer() {
     "$@" bash "$TMP_ROOT/scripts/review-writer.sh" 2>&1
 }
 
-AWAITING="verdict=awaiting detail=awaiting a non-author review for headsha"
+# The pending status text the predicate emits for this verdict. The
+# writer is idempotent on state+description, so the fixture histories
+# below reuse this exact string.
+AWAITING_DETAIL="no review evidence at headsha yet; bots re-review each push, not a block on a human"
+AWAITING="verdict=awaiting detail=$AWAITING_DETAIL"
 APPROVED="verdict=approved detail=reviewed at head with no unresolved threads"
 CR="verdict=changes-requested detail=standing review changes requested (persists across pushes until re-approval or dismissal)"
 THREADS="verdict=threads-open detail=2 unresolved review thread(s)"
@@ -255,7 +259,7 @@ assert_contains "$(cat "$POST_LOG")" "context=Review gate" "w1: post carries the
 assert_eq "$(( $(wc -l < "$RERUN_LOG") ))" "0" "w1: no rerun on a downward transition"
 
 rc=0; out=$(run_writer STUB_VERDICT_LINE="$AWAITING" \
-  STUB_GATE_HISTORY='[{"context":"Review gate","state":"pending","description":"awaiting a non-author review for headsha","created_at":"'"$OLD"'"}]') || rc=$?
+  STUB_GATE_HISTORY='[{"context":"Review gate","state":"pending","description":"'"$AWAITING_DETAIL"'","created_at":"'"$OLD"'"}]') || rc=$?
 assert_eq "$rc" "0" "w2: the idempotent no-op exits 0"
 assert_eq "$(( $(wc -l < "$POST_LOG") ))" "0" "w2: second evaluation of an unchanged state posts nothing (one entry total)"
 assert_contains "$out" "nothing to do" "w2: reports the no-op"
@@ -279,7 +283,7 @@ assert_eq "$rc" "0" "w5: approved with the same success entry exits 0"
 assert_eq "$(( $(wc -l < "$POST_LOG") ))" "0" "w5: unchanged success posts nothing (idempotent)"
 
 rc=0; out=$(run_writer STUB_VERDICT_LINE="$APPROVED" \
-  STUB_GATE_HISTORY='[{"context":"Review gate","state":"pending","description":"awaiting a non-author review for headsha","created_at":"'"$OLD"'"}]') || rc=$?
+  STUB_GATE_HISTORY='[{"context":"Review gate","state":"pending","description":"'"$AWAITING_DETAIL"'","created_at":"'"$OLD"'"}]') || rc=$?
 assert_eq "$rc" "0" "w6: approved over pending exits 0"
 assert_contains "$(cat "$POST_LOG")" "state=success" "w6: a reviewed head opens the gate"
 assert_eq "$(( $(wc -l < "$RERUN_LOG") ))" "0" "w6: the writer never re-runs CI (branch protection owns that)"
@@ -290,7 +294,7 @@ assert_contains "$(cat "$POST_LOG")" "state=success" "w7: a dismissed objection 
 
 echo "=== VST-65 ordering guard (success posts only) ==="
 
-PENDING_OLD='[{"context":"Review gate","state":"pending","description":"awaiting a non-author review for headsha","created_at":"'"$OLD"'"}]'
+PENDING_OLD='[{"context":"Review gate","state":"pending","description":"'"$AWAITING_DETAIL"'","created_at":"'"$OLD"'"}]'
 
 rc=0; out=$(run_writer STUB_VERDICT_LINE="$APPROVED" STUB_GATE_HISTORY="$PENDING_OLD" \
   STUB_GUARD_HISTORY='[{"context":"Review gate","state":"pending","description":"newer writer run","created_at":"'"$FUTURE"'"}]') || rc=$?
@@ -509,7 +513,7 @@ assert_eq "$rc" "0" "wp2: paginated projection exits 0"
 assert_contains "$(cat "$POST_LOG")" "state=success" "wp2: the projection merges every page before deciding"
 
 rc=0; out=$(run_writer STUB_VERDICT_LINE="$APPROVED" \
-  STUB_GATE_HISTORY='[{"context":"Review gate","state":"pending","description":"awaiting a non-author review for headsha","created_at":"'"$OLD"'"}]' \
+  STUB_GATE_HISTORY='[{"context":"Review gate","state":"pending","description":"'"$AWAITING_DETAIL"'","created_at":"'"$OLD"'"}]' \
   STUB_GUARD_HISTORY='[]' \
   STUB_GUARD_HISTORY_PAGE2='[{"context":"Review gate","state":"failure","description":"newer","created_at":"'"$FUTURE"'"}]') || rc=$?
 assert_eq "$rc" "0" "wp3: paginated guard re-read exits 0"

--- a/tools/size-ratchet-baseline.tsv
+++ b/tools/size-ratchet-baseline.tsv
@@ -121,7 +121,7 @@ skills/orch/workflows/review-pr.md	452
 skills/preflight/scripts/preflight	1061
 skills/review-gate/scripts/pr-watch.sh	854
 skills/review-gate/scripts/review-predicate-selftest.sh	2638
-skills/review-gate/scripts/review-predicate.sh	1427
+skills/review-gate/scripts/review-predicate.sh	1434
 skills/review-gate/scripts/validate.sh	494
 skills/review-gate/templates/review-gate-writer.yml	658
 skills/review-gate/tests/e2e-sandbox.sh	898

--- a/tools/size-ratchet-baseline.tsv
+++ b/tools/size-ratchet-baseline.tsv
@@ -121,7 +121,7 @@ skills/orch/workflows/review-pr.md	452
 skills/preflight/scripts/preflight	1061
 skills/review-gate/scripts/pr-watch.sh	854
 skills/review-gate/scripts/review-predicate-selftest.sh	2638
-skills/review-gate/scripts/review-predicate.sh	1415
+skills/review-gate/scripts/review-predicate.sh	1427
 skills/review-gate/scripts/validate.sh	494
 skills/review-gate/templates/review-gate-writer.yml	658
 skills/review-gate/tests/e2e-sandbox.sh	898

--- a/tools/size-ratchet-baseline.tsv
+++ b/tools/size-ratchet-baseline.tsv
@@ -120,7 +120,7 @@ skills/orch/tests/queue_wait.sh	920
 skills/orch/workflows/review-pr.md	452
 skills/preflight/scripts/preflight	1061
 skills/review-gate/scripts/pr-watch.sh	854
-skills/review-gate/scripts/review-predicate-selftest.sh	2657
+skills/review-gate/scripts/review-predicate-selftest.sh	2638
 skills/review-gate/scripts/review-predicate.sh	1352
 skills/review-gate/scripts/validate.sh	494
 skills/review-gate/templates/review-gate-writer.yml	658

--- a/tools/size-ratchet-baseline.tsv
+++ b/tools/size-ratchet-baseline.tsv
@@ -121,7 +121,7 @@ skills/orch/workflows/review-pr.md	452
 skills/preflight/scripts/preflight	1061
 skills/review-gate/scripts/pr-watch.sh	854
 skills/review-gate/scripts/review-predicate-selftest.sh	2638
-skills/review-gate/scripts/review-predicate.sh	1398
+skills/review-gate/scripts/review-predicate.sh	1415
 skills/review-gate/scripts/validate.sh	494
 skills/review-gate/templates/review-gate-writer.yml	658
 skills/review-gate/tests/e2e-sandbox.sh	898

--- a/tools/size-ratchet-baseline.tsv
+++ b/tools/size-ratchet-baseline.tsv
@@ -121,7 +121,7 @@ skills/orch/workflows/review-pr.md	452
 skills/preflight/scripts/preflight	1061
 skills/review-gate/scripts/pr-watch.sh	854
 skills/review-gate/scripts/review-predicate-selftest.sh	2638
-skills/review-gate/scripts/review-predicate.sh	1436
+skills/review-gate/scripts/review-predicate.sh	1444
 skills/review-gate/scripts/validate.sh	494
 skills/review-gate/templates/review-gate-writer.yml	658
 skills/review-gate/tests/e2e-sandbox.sh	898

--- a/tools/size-ratchet-baseline.tsv
+++ b/tools/size-ratchet-baseline.tsv
@@ -121,7 +121,7 @@ skills/orch/workflows/review-pr.md	452
 skills/preflight/scripts/preflight	1061
 skills/review-gate/scripts/pr-watch.sh	854
 skills/review-gate/scripts/review-predicate-selftest.sh	2638
-skills/review-gate/scripts/review-predicate.sh	1352
+skills/review-gate/scripts/review-predicate.sh	1398
 skills/review-gate/scripts/validate.sh	494
 skills/review-gate/templates/review-gate-writer.yml	658
 skills/review-gate/tests/e2e-sandbox.sh	898

--- a/tools/size-ratchet-baseline.tsv
+++ b/tools/size-ratchet-baseline.tsv
@@ -120,7 +120,7 @@ skills/orch/tests/queue_wait.sh	920
 skills/orch/workflows/review-pr.md	452
 skills/preflight/scripts/preflight	1061
 skills/review-gate/scripts/pr-watch.sh	854
-skills/review-gate/scripts/review-predicate-selftest.sh	2638
+skills/review-gate/scripts/review-predicate-selftest.sh	2657
 skills/review-gate/scripts/review-predicate.sh	1352
 skills/review-gate/scripts/validate.sh	494
 skills/review-gate/templates/review-gate-writer.yml	658

--- a/tools/size-ratchet-baseline.tsv
+++ b/tools/size-ratchet-baseline.tsv
@@ -121,7 +121,7 @@ skills/orch/workflows/review-pr.md	452
 skills/preflight/scripts/preflight	1061
 skills/review-gate/scripts/pr-watch.sh	854
 skills/review-gate/scripts/review-predicate-selftest.sh	2638
-skills/review-gate/scripts/review-predicate.sh	1434
+skills/review-gate/scripts/review-predicate.sh	1436
 skills/review-gate/scripts/validate.sh	494
 skills/review-gate/templates/review-gate-writer.yml	658
 skills/review-gate/tests/e2e-sandbox.sh	898


### PR DESCRIPTION
Two halves: the KEN-676 awaiting-status fix, and the outstanding KEN-668
phase B docs pass over the CI-touching packages.

## KEN-676 — the awaiting status says what this repo is waiting for

`awaiting a non-author review for <sha>` was read as a require-approvals
block. Agents stalled or escalated through the ordinary re-review window that
follows every push (audit lane on drovr#644, and recurring).

The replacement is **derived from the repo's own settings, not asserted**:

```
no review evidence at <sha> yet; expected from <names>
```

`<names>` are the sources that could still open the gate at that head.
`review-predicate.sh` resolves them — it owns the judgment — and
`scripts/awaiting-detail.sh` decides nothing, only fitting the answer into
the 140 characters GitHub keeps of a status description.

- A gate trusting only human logins reads that person's name. A gate
  trusting bots reads the bots. This repo reads
  `coderabbitai[bot], copilot-pull-request-reviewer[bot] and 5 more`.
- The PR author never appears: their own review and comment are never
  evidence, so naming them would send readers to an impossible reviewer.
- An empty trust list is `any non-author review`, or `any non-author
  approval` under `REVIEW_GATE_REVIEW_OBJECT_MIN_STATE = "approved"`, where a
  COMMENTED review would not satisfy it.
- Where every configured login is the author, nothing is eligible and the
  status says so rather than printing an empty clause.
- Past the limit the sha shortens to 12 characters before any name is
  dropped, and names that still do not fit are counted (`and N more`).

Each packed trust list is parsed **once**, where the settings are resolved,
and every consumer takes that one representation: the configuration checks,
both trusted-context reads, the comment-form evidence loop, the review-object
jq on both call sites, and the awaiting label. A value like `" ; , "` is an
empty trust list to all of them or to none.

A composer that fails takes the verdict with it — the arm captures its output
and exits 2 rather than printing an empty description — and
`scripts/awaiting-detail.sh` is in `validate.sh`'s runtime inventory, so an
install missing it fails validation instead of at the first awaiting
evaluation.

`tests/awaiting-detail.test.sh` covers both layers: the predicate's
resolution (extracted from the script, never restated) and the composer's
fitting, including the 130/139/140/141-character boundary.

## KEN-668 phase B — the CI packages' docs

Over review-gate, harness-ci, preflight, size-ratchet and growth-guards.
harness-ci and size-ratchet already met the bar and are untouched.

- **preflight** had a README of one paragraph and a call. It now carries the
  three call sites a consumer wires — validation, commit time, CI — and the
  requirement that the installed skill be committed, which is how a CI run
  ends up checking out nothing.
- **growth-guards** states each layering rule once, in the words an agent
  acts on. The SKILL splits its hook section at the seam it already had:
  what the installer does, then what reads it back.
- **review-gate** drops a clause that sold the split with branch protection
  rather than stating it.

## Validation

`tools/guard` clean, `preflight --base origin/main` clean, `size-ratchet` OK.
Every `skills/*/tests/*.sh` suite for the five packages passes, and the
review-gate selftest is 255 cases green — unchanged across the shared-parse
refactor, which is what says the evidence paths behave identically on packed
input.

One baseline row rises: `skills/review-gate/scripts/review-predicate.sh`,
1352 → 1444 (`tools/size-ratchet-baseline.tsv` in the diff is the authority
on the current number). The predicate holds the source resolution, the single
parse of each trust list, and the guards on both, because it owns those
judgments; the formatting seam is already extracted to `awaiting-detail.sh`,
so there is no second seam to split at, and the added lines are the fix for
the reported symptom.

Note on this PR's own gate status: it is written by the engine vendored on
the base branch, so #1685 is judged by main's copy and still shows the old
text. The new wording appears on PRs opened after this merges.

Closes KEN-676.

https://claude.ai/code/session_01URHsY48SMqzBpGbaiJjQko
