### PR TITLE
fix(KEN-684): stop seeding .cursor into WORKTREE_SYMLINKS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,10 @@ an outside contributor.
 
 ### Fixed
 
+- The settings template no longer seeds `.cursor` into `WORKTREE_SYMLINKS`, so
+  `worktree fix-links` passes in repos that do not use Cursor; a repo that
+  does adds it back in its own `kendex.settings.toml`.
+
 - On macOS the commit hooks were written but never made executable, so git
   ignored both and an armed repository gated nothing. `guard install` reports
   armed only when the bit is really there.

--- a/kendex.settings.toml.example
+++ b/kendex.settings.toml.example
@@ -16,7 +16,7 @@ WORKTREE_DEFAULT_BRANCH = "main"
 
 # Paths symlinked into every worktree. Include `.env.local` only when
 # worktrees should share local secrets.
-WORKTREE_SYMLINKS = ".env.local opencode.json .agents .cursor .codex .opencode .pi .claude/settings.json .claude/agents .claude/hooks .claude/skills"
+WORKTREE_SYMLINKS = ".env.local opencode.json .agents .codex .opencode .pi .claude/settings.json .claude/agents .claude/hooks .claude/skills"
 
 # link=target pairs; each target resolves from the LINK's own directory
 # (`.claude/CLAUDE.md=../AGENTS.md` reaches the worktree root's AGENTS.md).


### PR DESCRIPTION
## Summary
- Drop `.cursor` from the `WORKTREE_SYMLINKS` line in `kendex.settings.toml.example`. Consumers copy that line verbatim, and in a repo with no `.cursor` directory `worktree fix-links` exits nonzero on every worktree with `no such path in the main checkout`.
- The script's refusal is unchanged; a repo that uses Cursor adds `.cursor` back in its own `kendex.settings.toml`.

## Completed Issues
- Closes KEN-684 - worktree: the seeded WORKTREE_SYMLINKS default names .cursor, so fix-links fails on every worktree in three repos

## Test Plan
- `tools/guard` exit 0 in the worktree (82 test files, 546 tests).
- `preflight --base origin/main` clean.
- The consumer half (drovr, vg, vgs each drop `.cursor` from their own `kendex.settings.toml`) lands as one PR per repo; memsira keeps its entry because it tracks a real `.cursor` tree.

https://claude.ai/code/session_01VNE5GQLr4mHQ4SDxxEyLXL
