### PR TITLE
fix(KEN-648): the completion gate sees new files and clippy's status

### DIFF
--- a/.claude/hooks/task-completed-check.sh
+++ b/.claude/hooks/task-completed-check.sh
@@ -14,10 +14,24 @@ set -euo pipefail
 # Consume stdin
 cat > /dev/null
 
-# Check for changed source files
-CHANGED=$(git diff --name-only 2>/dev/null || true)
-STAGED=$(git diff --cached --name-only 2>/dev/null || true)
-ALL_CHANGED=$(printf '%s\n%s' "$CHANGED" "$STAGED" | sort -u | grep -v '^$' || true)
+# No repository, nothing to gate. Every later git call is asked inside one,
+# so a failure there is a broken run, not an absent one.
+REPO_ROOT=$(git rev-parse --show-toplevel 2>/dev/null) || exit 0
+
+git_failed() { # SUBCOMMAND OUTPUT — an unreadable changed set is not an empty one
+  echo "task-completed-check: git $1 failed, so what changed is unknown:" >&2
+  printf '%s\n' "$2" >&2
+  exit 2
+}
+
+# What counts as changed: the worktree, the index, and untracked non-ignored
+# paths. Without that last set a task whose only work is a new file presents
+# an empty changed set and skips the gate entirely.
+CHANGED=$(git diff --name-only 2>&1) || git_failed 'diff' "$CHANGED"
+STAGED=$(git diff --cached --name-only 2>&1) || git_failed 'diff --cached' "$STAGED"
+UNTRACKED=$(git ls-files --others --exclude-standard --full-name -- :/ 2>&1) ||
+  git_failed 'ls-files' "$UNTRACKED"
+ALL_CHANGED=$(printf '%s\n%s\n%s' "$CHANGED" "$STAGED" "$UNTRACKED" | sort -u | sed '/^$/d')
 
 if [ -z "$ALL_CHANGED" ]; then
   exit 0
@@ -31,8 +45,7 @@ if echo "$ALL_CHANGED" | grep -qE '\.rs$'; then
   # clippy` from cwd unconditionally and surfaced "could not find
   # Cargo.toml" as a clippy error.
   MANIFEST_ARGS=()
-  REPO_ROOT=$(git rev-parse --show-toplevel 2>/dev/null || true)
-  if [ -n "$REPO_ROOT" ] && [ ! -f "$REPO_ROOT/Cargo.toml" ]; then
+  if [ ! -f "$REPO_ROOT/Cargo.toml" ]; then
     MANIFEST=$(echo "$ALL_CHANGED" | grep -E '\.rs$' | while IFS= read -r path; do
       dir=$(dirname "$path")
       while [ -n "$dir" ] && [ "$dir" != "." ] && [ "$dir" != "/" ]; do
@@ -48,13 +61,14 @@ if echo "$ALL_CHANGED" | grep -qE '\.rs$'; then
     fi
   fi
 
-  OUTPUT=$(cargo clippy "${MANIFEST_ARGS[@]}" --workspace --all-targets -- -D warnings 2>&1 || true)
-  # grep no-match exits 1 — swallow under pipefail so an empty result is success.
-  ISSUES=$(echo "$OUTPUT" | grep -E '^error' | head -15 || true)
-
-  if [ -n "$ISSUES" ]; then
-    echo "Clippy errors found — fix before completing task:" >&2
-    echo "$ISSUES" >&2
+  if ! OUTPUT=$(cargo clippy "${MANIFEST_ARGS[@]}" --workspace --all-targets -- -D warnings 2>&1); then
+    # The exit status is the verdict. Diagnostic lines are only how the
+    # failure is reported, so a run that produced none — a missing cargo, a
+    # killed build — falls back to the tail of whatever it did print.
+    ISSUES=$(printf '%s\n' "$OUTPUT" | grep -E '^error' | head -15 || true)
+    [ -n "$ISSUES" ] || ISSUES=$(printf '%s\n' "$OUTPUT" | tail -15)
+    echo "Clippy failed — fix before completing task:" >&2
+    printf '%s\n' "$ISSUES" >&2
     exit 2
   fi
 fi

--- a/.claude/hooks/task-completed-check.sh
+++ b/.claude/hooks/task-completed-check.sh
@@ -20,15 +20,10 @@ git_failed() { # SUBCOMMAND OUTPUT — an unreadable changed set is not an empty
   exit 2
 }
 
-# No repository, nothing to gate. Exit 128 is the one failure that says so.
-# A git that will not execute exits 126 or 127, and every later git call is
-# asked inside a repository, where a failure is a broken run.
-PROBE_RC=0
-REPO_ROOT=$(git rev-parse --show-toplevel 2>&1) || PROBE_RC=$?
-if [ "$PROBE_RC" -ne 0 ]; then
-  [ "$PROBE_RC" -eq 128 ] || git_failed 'rev-parse' "$REPO_ROOT"
-  exit 0
-fi
+# A git that cannot answer blocks, with no reading of the failure that means
+# "nothing to gate": rev-parse exits 128 outside a repository and inside one
+# whose metadata it cannot read, and the hook has no way to tell which.
+REPO_ROOT=$(git rev-parse --show-toplevel 2>&1) || git_failed 'rev-parse' "$REPO_ROOT"
 
 # What counts as changed: the worktree, the index, and untracked non-ignored
 # paths. Without that last set a task whose only work is a new file presents

--- a/.claude/hooks/task-completed-check.sh
+++ b/.claude/hooks/task-completed-check.sh
@@ -14,15 +14,21 @@ set -euo pipefail
 # Consume stdin
 cat > /dev/null
 
-# No repository, nothing to gate. Every later git call is asked inside one,
-# so a failure there is a broken run, not an absent one.
-REPO_ROOT=$(git rev-parse --show-toplevel 2>/dev/null) || exit 0
-
 git_failed() { # SUBCOMMAND OUTPUT — an unreadable changed set is not an empty one
   echo "task-completed-check: git $1 failed, so what changed is unknown:" >&2
   printf '%s\n' "$2" >&2
   exit 2
 }
+
+# No repository, nothing to gate. Exit 128 is the one failure that says so.
+# A git that will not execute exits 126 or 127, and every later git call is
+# asked inside a repository, where a failure is a broken run.
+PROBE_RC=0
+REPO_ROOT=$(git rev-parse --show-toplevel 2>&1) || PROBE_RC=$?
+if [ "$PROBE_RC" -ne 0 ]; then
+  [ "$PROBE_RC" -eq 128 ] || git_failed 'rev-parse' "$REPO_ROOT"
+  exit 0
+fi
 
 # What counts as changed: the worktree, the index, and untracked non-ignored
 # paths. Without that last set a task whose only work is a new file presents
@@ -40,8 +46,11 @@ if [ -z "$ALL_CHANGED" ]; then
   exit 0
 fi
 
-# Check for Rust files
-if echo "$ALL_CHANGED" | grep -qE '\.rs$'; then
+# Check for Rust files. Neither filter may stop reading early: `grep -q` and
+# `head -1` exit at their first match, and under pipefail the SIGPIPE that
+# kills the producer becomes the pipeline's status — 141, read as no match.
+RUST_CHANGED=$(printf '%s\n' "$ALL_CHANGED" | sed -n '/\.rs$/p')
+if [ -n "$RUST_CHANGED" ]; then
   # Locate Cargo.toml so the hook works when the manifest is nested
   # (kendex's own `cli/Cargo.toml` is the canonical case) and when the
   # hook is invoked from a subdirectory. Earlier versions ran `cargo
@@ -49,7 +58,7 @@ if echo "$ALL_CHANGED" | grep -qE '\.rs$'; then
   # Cargo.toml" as a clippy error.
   MANIFEST_ARGS=()
   if [ ! -f "$REPO_ROOT/Cargo.toml" ]; then
-    MANIFEST=$(echo "$ALL_CHANGED" | grep -E '\.rs$' | while IFS= read -r path; do
+    MANIFEST=$(printf '%s\n' "$RUST_CHANGED" | while IFS= read -r path; do
       dir=$(dirname "$path")
       while [ -n "$dir" ] && [ "$dir" != "." ] && [ "$dir" != "/" ]; do
         if [ -f "$REPO_ROOT/$dir/Cargo.toml" ]; then
@@ -58,7 +67,7 @@ if echo "$ALL_CHANGED" | grep -qE '\.rs$'; then
         fi
         dir=$(dirname "$dir")
       done
-    done | head -1)
+    done | sed -n 1p)
     if [ -n "$MANIFEST" ]; then
       MANIFEST_ARGS=(--manifest-path "$MANIFEST")
     fi

--- a/.claude/hooks/task-completed-check.sh
+++ b/.claude/hooks/task-completed-check.sh
@@ -26,10 +26,13 @@ git_failed() { # SUBCOMMAND OUTPUT — an unreadable changed set is not an empty
 
 # What counts as changed: the worktree, the index, and untracked non-ignored
 # paths. Without that last set a task whose only work is a new file presents
-# an empty changed set and skips the gate entirely.
-CHANGED=$(git diff --name-only 2>&1) || git_failed 'diff' "$CHANGED"
-STAGED=$(git diff --cached --name-only 2>&1) || git_failed 'diff --cached' "$STAGED"
-UNTRACKED=$(git ls-files --others --exclude-standard --full-name -- :/ 2>&1) ||
+# an empty changed set and skips the gate entirely. `-z` asks for the paths
+# themselves. Line-oriented git output C-quotes a non-ASCII path, and a
+# quoted path ends in a quote rather than in .rs.
+CHANGED=$(git diff --name-only -z 2>&1 | tr '\0' '\n') || git_failed 'diff' "$CHANGED"
+STAGED=$(git diff --cached --name-only -z 2>&1 | tr '\0' '\n') ||
+  git_failed 'diff --cached' "$STAGED"
+UNTRACKED=$(git ls-files --others --exclude-standard --full-name -z -- :/ 2>&1 | tr '\0' '\n') ||
   git_failed 'ls-files' "$UNTRACKED"
 ALL_CHANGED=$(printf '%s\n%s\n%s' "$CHANGED" "$STAGED" "$UNTRACKED" | sort -u | sed '/^$/d')
 
@@ -61,7 +64,10 @@ if echo "$ALL_CHANGED" | grep -qE '\.rs$'; then
     fi
   fi
 
-  if ! OUTPUT=$(cargo clippy "${MANIFEST_ARGS[@]}" --workspace --all-targets -- -D warnings 2>&1); then
+  # A repository whose root holds Cargo.toml leaves MANIFEST_ARGS empty, and
+  # bash 3.2 under `set -u` reads an empty array as an unbound variable.
+  # Hence the guarded expansion.
+  if ! OUTPUT=$(cargo clippy ${MANIFEST_ARGS[@]+"${MANIFEST_ARGS[@]}"} --workspace --all-targets -- -D warnings 2>&1); then
     # The exit status is the verdict. Diagnostic lines are only how the
     # failure is reported, so a run that produced none — a missing cargo, a
     # killed build — falls back to the tail of whatever it did print.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,9 +39,9 @@ an outside contributor.
 
 ### Fixed
 
-- The `task-completed-check` hook counts untracked files as changes, so a task
-  whose only work is a new Rust file still runs clippy, and it now blocks on
-  any nonzero clippy exit rather than only on output lines starting `error`.
+- The `task-completed-check` hook counts untracked files as changes, and blocks
+  on any nonzero clippy exit or a git that cannot say what changed. It passed
+  all three before: a new-file-only task, a killed clippy, an unreadable repo.
 
 - The `block-bare-cd` hook refuses a bare `cd` with no path. It changes to
   `$HOME` for every later tool call, the move the hook exists to stop, and

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,10 @@ an outside contributor.
 
 ### Fixed
 
+- The `task-completed-check` hook counts untracked files as changes, so a task
+  whose only work is a new Rust file still runs clippy, and it now blocks on
+  any nonzero clippy exit rather than only on output lines starting `error`.
+
 - The `block-bare-cd` hook refuses a bare `cd` with no path. It changes to
   `$HOME` for every later tool call, the move the hook exists to stop, and
   only `cd <path>` was caught before.

--- a/hooks/task-completed-check.sh
+++ b/hooks/task-completed-check.sh
@@ -14,10 +14,24 @@ set -euo pipefail
 # Consume stdin
 cat > /dev/null
 
-# Check for changed source files
-CHANGED=$(git diff --name-only 2>/dev/null || true)
-STAGED=$(git diff --cached --name-only 2>/dev/null || true)
-ALL_CHANGED=$(printf '%s\n%s' "$CHANGED" "$STAGED" | sort -u | grep -v '^$' || true)
+# No repository, nothing to gate. Every later git call is asked inside one,
+# so a failure there is a broken run, not an absent one.
+REPO_ROOT=$(git rev-parse --show-toplevel 2>/dev/null) || exit 0
+
+git_failed() { # SUBCOMMAND OUTPUT — an unreadable changed set is not an empty one
+  echo "task-completed-check: git $1 failed, so what changed is unknown:" >&2
+  printf '%s\n' "$2" >&2
+  exit 2
+}
+
+# What counts as changed: the worktree, the index, and untracked non-ignored
+# paths. Without that last set a task whose only work is a new file presents
+# an empty changed set and skips the gate entirely.
+CHANGED=$(git diff --name-only 2>&1) || git_failed 'diff' "$CHANGED"
+STAGED=$(git diff --cached --name-only 2>&1) || git_failed 'diff --cached' "$STAGED"
+UNTRACKED=$(git ls-files --others --exclude-standard --full-name -- :/ 2>&1) ||
+  git_failed 'ls-files' "$UNTRACKED"
+ALL_CHANGED=$(printf '%s\n%s\n%s' "$CHANGED" "$STAGED" "$UNTRACKED" | sort -u | sed '/^$/d')
 
 if [ -z "$ALL_CHANGED" ]; then
   exit 0
@@ -31,8 +45,7 @@ if echo "$ALL_CHANGED" | grep -qE '\.rs$'; then
   # clippy` from cwd unconditionally and surfaced "could not find
   # Cargo.toml" as a clippy error.
   MANIFEST_ARGS=()
-  REPO_ROOT=$(git rev-parse --show-toplevel 2>/dev/null || true)
-  if [ -n "$REPO_ROOT" ] && [ ! -f "$REPO_ROOT/Cargo.toml" ]; then
+  if [ ! -f "$REPO_ROOT/Cargo.toml" ]; then
     MANIFEST=$(echo "$ALL_CHANGED" | grep -E '\.rs$' | while IFS= read -r path; do
       dir=$(dirname "$path")
       while [ -n "$dir" ] && [ "$dir" != "." ] && [ "$dir" != "/" ]; do
@@ -48,13 +61,14 @@ if echo "$ALL_CHANGED" | grep -qE '\.rs$'; then
     fi
   fi
 
-  OUTPUT=$(cargo clippy "${MANIFEST_ARGS[@]}" --workspace --all-targets -- -D warnings 2>&1 || true)
-  # grep no-match exits 1 — swallow under pipefail so an empty result is success.
-  ISSUES=$(echo "$OUTPUT" | grep -E '^error' | head -15 || true)
-
-  if [ -n "$ISSUES" ]; then
-    echo "Clippy errors found — fix before completing task:" >&2
-    echo "$ISSUES" >&2
+  if ! OUTPUT=$(cargo clippy "${MANIFEST_ARGS[@]}" --workspace --all-targets -- -D warnings 2>&1); then
+    # The exit status is the verdict. Diagnostic lines are only how the
+    # failure is reported, so a run that produced none — a missing cargo, a
+    # killed build — falls back to the tail of whatever it did print.
+    ISSUES=$(printf '%s\n' "$OUTPUT" | grep -E '^error' | head -15 || true)
+    [ -n "$ISSUES" ] || ISSUES=$(printf '%s\n' "$OUTPUT" | tail -15)
+    echo "Clippy failed — fix before completing task:" >&2
+    printf '%s\n' "$ISSUES" >&2
     exit 2
   fi
 fi

--- a/hooks/task-completed-check.sh
+++ b/hooks/task-completed-check.sh
@@ -20,15 +20,10 @@ git_failed() { # SUBCOMMAND OUTPUT — an unreadable changed set is not an empty
   exit 2
 }
 
-# No repository, nothing to gate. Exit 128 is the one failure that says so.
-# A git that will not execute exits 126 or 127, and every later git call is
-# asked inside a repository, where a failure is a broken run.
-PROBE_RC=0
-REPO_ROOT=$(git rev-parse --show-toplevel 2>&1) || PROBE_RC=$?
-if [ "$PROBE_RC" -ne 0 ]; then
-  [ "$PROBE_RC" -eq 128 ] || git_failed 'rev-parse' "$REPO_ROOT"
-  exit 0
-fi
+# A git that cannot answer blocks, with no reading of the failure that means
+# "nothing to gate": rev-parse exits 128 outside a repository and inside one
+# whose metadata it cannot read, and the hook has no way to tell which.
+REPO_ROOT=$(git rev-parse --show-toplevel 2>&1) || git_failed 'rev-parse' "$REPO_ROOT"
 
 # What counts as changed: the worktree, the index, and untracked non-ignored
 # paths. Without that last set a task whose only work is a new file presents

--- a/hooks/task-completed-check.sh
+++ b/hooks/task-completed-check.sh
@@ -14,15 +14,21 @@ set -euo pipefail
 # Consume stdin
 cat > /dev/null
 
-# No repository, nothing to gate. Every later git call is asked inside one,
-# so a failure there is a broken run, not an absent one.
-REPO_ROOT=$(git rev-parse --show-toplevel 2>/dev/null) || exit 0
-
 git_failed() { # SUBCOMMAND OUTPUT — an unreadable changed set is not an empty one
   echo "task-completed-check: git $1 failed, so what changed is unknown:" >&2
   printf '%s\n' "$2" >&2
   exit 2
 }
+
+# No repository, nothing to gate. Exit 128 is the one failure that says so.
+# A git that will not execute exits 126 or 127, and every later git call is
+# asked inside a repository, where a failure is a broken run.
+PROBE_RC=0
+REPO_ROOT=$(git rev-parse --show-toplevel 2>&1) || PROBE_RC=$?
+if [ "$PROBE_RC" -ne 0 ]; then
+  [ "$PROBE_RC" -eq 128 ] || git_failed 'rev-parse' "$REPO_ROOT"
+  exit 0
+fi
 
 # What counts as changed: the worktree, the index, and untracked non-ignored
 # paths. Without that last set a task whose only work is a new file presents
@@ -40,8 +46,11 @@ if [ -z "$ALL_CHANGED" ]; then
   exit 0
 fi
 
-# Check for Rust files
-if echo "$ALL_CHANGED" | grep -qE '\.rs$'; then
+# Check for Rust files. Neither filter may stop reading early: `grep -q` and
+# `head -1` exit at their first match, and under pipefail the SIGPIPE that
+# kills the producer becomes the pipeline's status — 141, read as no match.
+RUST_CHANGED=$(printf '%s\n' "$ALL_CHANGED" | sed -n '/\.rs$/p')
+if [ -n "$RUST_CHANGED" ]; then
   # Locate Cargo.toml so the hook works when the manifest is nested
   # (kendex's own `cli/Cargo.toml` is the canonical case) and when the
   # hook is invoked from a subdirectory. Earlier versions ran `cargo
@@ -49,7 +58,7 @@ if echo "$ALL_CHANGED" | grep -qE '\.rs$'; then
   # Cargo.toml" as a clippy error.
   MANIFEST_ARGS=()
   if [ ! -f "$REPO_ROOT/Cargo.toml" ]; then
-    MANIFEST=$(echo "$ALL_CHANGED" | grep -E '\.rs$' | while IFS= read -r path; do
+    MANIFEST=$(printf '%s\n' "$RUST_CHANGED" | while IFS= read -r path; do
       dir=$(dirname "$path")
       while [ -n "$dir" ] && [ "$dir" != "." ] && [ "$dir" != "/" ]; do
         if [ -f "$REPO_ROOT/$dir/Cargo.toml" ]; then
@@ -58,7 +67,7 @@ if echo "$ALL_CHANGED" | grep -qE '\.rs$'; then
         fi
         dir=$(dirname "$dir")
       done
-    done | head -1)
+    done | sed -n 1p)
     if [ -n "$MANIFEST" ]; then
       MANIFEST_ARGS=(--manifest-path "$MANIFEST")
     fi

--- a/hooks/task-completed-check.sh
+++ b/hooks/task-completed-check.sh
@@ -26,10 +26,13 @@ git_failed() { # SUBCOMMAND OUTPUT — an unreadable changed set is not an empty
 
 # What counts as changed: the worktree, the index, and untracked non-ignored
 # paths. Without that last set a task whose only work is a new file presents
-# an empty changed set and skips the gate entirely.
-CHANGED=$(git diff --name-only 2>&1) || git_failed 'diff' "$CHANGED"
-STAGED=$(git diff --cached --name-only 2>&1) || git_failed 'diff --cached' "$STAGED"
-UNTRACKED=$(git ls-files --others --exclude-standard --full-name -- :/ 2>&1) ||
+# an empty changed set and skips the gate entirely. `-z` asks for the paths
+# themselves. Line-oriented git output C-quotes a non-ASCII path, and a
+# quoted path ends in a quote rather than in .rs.
+CHANGED=$(git diff --name-only -z 2>&1 | tr '\0' '\n') || git_failed 'diff' "$CHANGED"
+STAGED=$(git diff --cached --name-only -z 2>&1 | tr '\0' '\n') ||
+  git_failed 'diff --cached' "$STAGED"
+UNTRACKED=$(git ls-files --others --exclude-standard --full-name -z -- :/ 2>&1 | tr '\0' '\n') ||
   git_failed 'ls-files' "$UNTRACKED"
 ALL_CHANGED=$(printf '%s\n%s\n%s' "$CHANGED" "$STAGED" "$UNTRACKED" | sort -u | sed '/^$/d')
 
@@ -61,7 +64,10 @@ if echo "$ALL_CHANGED" | grep -qE '\.rs$'; then
     fi
   fi
 
-  if ! OUTPUT=$(cargo clippy "${MANIFEST_ARGS[@]}" --workspace --all-targets -- -D warnings 2>&1); then
+  # A repository whose root holds Cargo.toml leaves MANIFEST_ARGS empty, and
+  # bash 3.2 under `set -u` reads an empty array as an unbound variable.
+  # Hence the guarded expansion.
+  if ! OUTPUT=$(cargo clippy ${MANIFEST_ARGS[@]+"${MANIFEST_ARGS[@]}"} --workspace --all-targets -- -D warnings 2>&1); then
     # The exit status is the verdict. Diagnostic lines are only how the
     # failure is reported, so a run that produced none — a missing cargo, a
     # killed build — falls back to the tail of whatever it did print.

--- a/hooks/tests/task-completed-check.test.sh
+++ b/hooks/tests/task-completed-check.test.sh
@@ -118,6 +118,15 @@ echo "task-completed-check: an untracked file seen from a subdirectory"
 run_hook "$REPO/src" FAKE_RC=0
 assert_contains "$(cat "$ARGS_LOG")" "clippy" "the whole repository is scanned from a subdirectory"
 
+echo "task-completed-check: a non-ASCII path is still a Rust file"
+REPO="$(new_repo unicode)"
+printf 'pub fn added() {}\n' >"$REPO/src/über.rs"
+run_hook "$REPO" FAKE_RC=0
+assert_contains "$(cat "$ARGS_LOG")" "clippy" "an untracked src/über.rs reaches the gate"
+fgit -C "$REPO" add -A
+run_hook "$REPO" FAKE_RC=0
+assert_contains "$(cat "$ARGS_LOG")" "clippy" "a staged src/über.rs reaches the gate"
+
 echo "task-completed-check: ignored paths stay out of the changed set"
 REPO="$(new_repo ignored)"
 printf 'target/\n' >"$REPO/.gitignore"
@@ -190,7 +199,7 @@ REPO="$(new_repo nocargo)"
 printf 'pub fn added() {}\n' >"$REPO/src/added.rs"
 NOCARGO_BIN="$TMP_ROOT/nocargo"
 mkdir -p "$NOCARGO_BIN"
-for tool in bash cat git grep sed sort head tail dirname; do
+for tool in bash cat git grep sed sort head tail tr dirname; do
   real="$(command -v "$tool" 2>/dev/null || true)"
   [ -n "$real" ] && [ -f "$real" ] && ln -sf "$real" "$NOCARGO_BIN/$tool"
 done

--- a/hooks/tests/task-completed-check.test.sh
+++ b/hooks/tests/task-completed-check.test.sh
@@ -1,0 +1,207 @@
+#!/usr/bin/env bash
+# Tests for the task-completed-check hook.
+#
+# The hook gates task completion on `cargo clippy` whenever the working tree
+# carries a changed Rust file. Two halves are pinned here: what counts as
+# changed — worktree, index, and untracked non-ignored paths, so a task whose
+# only work is a new file still reaches the gate — and the verdict, which is
+# clippy's exit status alone, so a run that dies without printing a
+# diagnostic blocks rather than passes.
+#
+# Fixtures are throwaway git repositories built under a HOME of their own;
+# clippy is a fake `cargo` on PATH replaying a scripted exit code and output.
+#
+# HOOK_UNDER_TEST overrides the script under test so the must-fail controls
+# (a no-op hook, an always-block hook) can be run against these same
+# assertions.
+set -euo pipefail
+
+TEST_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+HOOK="${HOOK_UNDER_TEST:-$(cd "$TEST_DIR/.." && pwd)/task-completed-check.sh}"
+
+PASS=0
+FAIL=0
+TMP_ROOT="$(mktemp -d)"
+trap 'rm -rf -- "${TMP_ROOT:?}"' EXIT
+
+BIN_DIR="$TMP_ROOT/bin"
+mkdir -p "$BIN_DIR"
+ARGS_LOG="$TMP_ROOT/cargo.args"
+
+# Fake cargo: records its argv, prints $FAKE_OUT, exits $FAKE_RC.
+cat >"$BIN_DIR/cargo" <<'EOF'
+#!/usr/bin/env bash
+printf '%s\n' "$*" >>"$FAKE_ARGS_LOG"
+if [ -n "${FAKE_OUT:-}" ]; then
+  printf '%s\n' "$FAKE_OUT"
+fi
+exit "${FAKE_RC:-0}"
+EOF
+chmod +x "$BIN_DIR/cargo"
+
+# Fixture git runs under the throwaway HOME so the caller's own git
+# configuration cannot decide what a fixture repository does.
+fgit() {
+  env HOME="$TMP_ROOT" git "$@"
+}
+
+# A fresh repository with one committed Rust file, so every case starts from
+# a clean tree and states its own change.
+new_repo() {
+  local repo="$TMP_ROOT/repo.$1"
+  mkdir -p "$repo/src"
+  fgit init -q "$repo"
+  fgit -C "$repo" config user.email t@example.com
+  fgit -C "$repo" config user.name t
+  printf '[package]\nname = "f"\nversion = "0.1.0"\n' >"$repo/Cargo.toml"
+  printf 'fn main() {}\n' >"$repo/src/main.rs"
+  fgit -C "$repo" add -A
+  fgit -C "$repo" commit -q -m init
+  printf '%s' "$repo"
+}
+
+# Run the hook inside $1 with a TaskCompleted payload on stdin. Extra
+# VAR=value args are passed through the environment. Captures stderr in $err
+# and the exit code in $rc.
+run_hook() {
+  local dir="$1"
+  shift
+  : >"$ARGS_LOG"
+  set +e
+  ( cd "$dir" && env HOME="$TMP_ROOT" PATH="$BIN_DIR:$PATH" FAKE_ARGS_LOG="$ARGS_LOG" "$@" \
+    bash "$HOOK" <<<'{"hook_event_name":"TaskCompleted"}' ) \
+    >/dev/null 2>"$TMP_ROOT/stderr"
+  rc=$?
+  set -e
+  err="$(cat "$TMP_ROOT/stderr")"
+}
+
+assert_eq() {
+  local got="$1" want="$2" name="$3"
+  if [[ "$got" == "$want" ]]; then
+    PASS=$((PASS + 1))
+    printf '  ok    %s\n' "$name"
+  else
+    FAIL=$((FAIL + 1))
+    printf '  FAIL  %s\n        expected: %s\n        got:      %s\n' "$name" "$want" "$got"
+  fi
+}
+
+assert_contains() {
+  local got="$1" needle="$2" name="$3"
+  if [[ "$got" == *"$needle"* ]]; then
+    PASS=$((PASS + 1))
+    printf '  ok    %s\n' "$name"
+  else
+    FAIL=$((FAIL + 1))
+    printf '  FAIL  %s\n        expected to contain: %s\n        got:      %s\n' "$name" "$needle" "$got"
+  fi
+}
+
+echo "task-completed-check: nothing changed"
+REPO="$(new_repo clean)"
+run_hook "$REPO" FAKE_RC=0
+assert_eq "$rc" 0 "a clean tree exits 0"
+assert_eq "$(cat "$ARGS_LOG")" "" "a clean tree never invokes cargo"
+
+echo "task-completed-check: an untracked new file is a change"
+REPO="$(new_repo untracked)"
+printf 'pub fn added() {}\n' >"$REPO/src/added.rs"
+run_hook "$REPO" FAKE_RC=0
+assert_eq "$rc" 0 "a passing clippy exits 0"
+assert_contains "$(cat "$ARGS_LOG")" "clippy" "a new file alone still runs clippy"
+run_hook "$REPO" FAKE_RC=101 FAKE_OUT="error: unused variable"
+assert_eq "$rc" 2 "a new file alone can still block the task"
+assert_contains "$err" "error: unused variable" "carries clippy's own diagnostic"
+
+echo "task-completed-check: an untracked file seen from a subdirectory"
+run_hook "$REPO/src" FAKE_RC=0
+assert_contains "$(cat "$ARGS_LOG")" "clippy" "the whole repository is scanned from a subdirectory"
+
+echo "task-completed-check: ignored paths stay out of the changed set"
+REPO="$(new_repo ignored)"
+printf 'target/\n' >"$REPO/.gitignore"
+fgit -C "$REPO" add .gitignore
+fgit -C "$REPO" commit -q -m ignore
+mkdir -p "$REPO/target"
+printf 'fn generated() {}\n' >"$REPO/target/generated.rs"
+run_hook "$REPO" FAKE_RC=0
+assert_eq "$(cat "$ARGS_LOG")" "" "an ignored Rust file is not a change"
+
+echo "task-completed-check: tracked edits still gate"
+REPO="$(new_repo tracked)"
+printf 'fn main() { let x = 1; }\n' >"$REPO/src/main.rs"
+run_hook "$REPO" FAKE_RC=101 FAKE_OUT="error: unused variable"
+assert_eq "$rc" 2 "an unstaged edit blocks on a failing clippy"
+fgit -C "$REPO" add -A
+run_hook "$REPO" FAKE_RC=101 FAKE_OUT="error: unused variable"
+assert_eq "$rc" 2 "a staged edit blocks on a failing clippy"
+
+echo "task-completed-check: the exit status is the verdict"
+REPO="$(new_repo status)"
+printf 'pub fn added() {}\n' >"$REPO/src/added.rs"
+run_hook "$REPO" FAKE_RC=101 FAKE_OUT="warning: build failed, waiting for other jobs"
+assert_eq "$rc" 2 "a failure printing no error: line still blocks"
+assert_contains "$err" "waiting for other jobs" "reports what the failed run did print"
+run_hook "$REPO" FAKE_RC=1 FAKE_OUT=""
+assert_eq "$rc" 2 "a failure printing nothing at all still blocks"
+assert_contains "$err" "Clippy failed" "names the failure when there is no output to quote"
+run_hook "$REPO" FAKE_RC=0 FAKE_OUT="error: this line is not a verdict"
+assert_eq "$rc" 0 "a successful run is not blocked by the word error in its output"
+
+echo "task-completed-check: outside a repository"
+NOREPO="$TMP_ROOT/norepo"
+mkdir -p "$NOREPO"
+printf 'pub fn added() {}\n' >"$NOREPO/added.rs"
+run_hook "$NOREPO" FAKE_RC=0
+assert_eq "$rc" 0 "no repository to ask means nothing to gate"
+assert_eq "$(cat "$ARGS_LOG")" "" "no repository never invokes cargo"
+
+echo "task-completed-check: git cannot answer what changed"
+REPO="$(new_repo brokengit)"
+printf 'pub fn added() {}\n' >"$REPO/src/added.rs"
+BROKEN_BIN="$TMP_ROOT/brokengit"
+mkdir -p "$BROKEN_BIN"
+REAL_GIT="$(command -v git)"
+# Passes every subcommand through except the untracked listing, which dies
+# the way a git too old for the flags or a broken index would.
+cat >"$BROKEN_BIN/git" <<EOF
+#!/usr/bin/env bash
+for a in "\$@"; do
+  if [ "\$a" = "ls-files" ]; then
+    echo "fatal: unable to read index" >&2
+    exit 128
+  fi
+done
+exec "$REAL_GIT" "\$@"
+EOF
+chmod +x "$BROKEN_BIN/git"
+set +e
+( cd "$REPO" && env HOME="$TMP_ROOT" PATH="$BROKEN_BIN:$BIN_DIR:$PATH" \
+  FAKE_ARGS_LOG="$ARGS_LOG" FAKE_RC=0 bash "$HOOK" <<<'{}' ) \
+  >/dev/null 2>"$TMP_ROOT/stderr"
+rc=$?
+set -e
+assert_eq "$rc" 2 "an unreadable changed set blocks rather than passing"
+assert_contains "$(cat "$TMP_ROOT/stderr")" "unable to read index" "carries git's own failure"
+
+echo "task-completed-check: no cargo on PATH"
+REPO="$(new_repo nocargo)"
+printf 'pub fn added() {}\n' >"$REPO/src/added.rs"
+NOCARGO_BIN="$TMP_ROOT/nocargo"
+mkdir -p "$NOCARGO_BIN"
+for tool in bash cat git grep sed sort head tail dirname; do
+  real="$(command -v "$tool" 2>/dev/null || true)"
+  [ -n "$real" ] && [ -f "$real" ] && ln -sf "$real" "$NOCARGO_BIN/$tool"
+done
+set +e
+( cd "$REPO" && env -i HOME="$TMP_ROOT" PATH="$NOCARGO_BIN" "$NOCARGO_BIN/bash" "$HOOK" <<<'{}' ) \
+  >/dev/null 2>"$TMP_ROOT/stderr"
+rc=$?
+set -e
+assert_eq "$rc" 2 "a missing cargo blocks rather than passing"
+assert_contains "$(cat "$TMP_ROOT/stderr")" "Clippy failed" "says the lint run failed"
+
+echo
+echo "passed: $PASS  failed: $FAIL"
+[ "$FAIL" -eq 0 ]

--- a/hooks/tests/task-completed-check.test.sh
+++ b/hooks/tests/task-completed-check.test.sh
@@ -158,13 +158,21 @@ assert_contains "$err" "Clippy failed" "names the failure when there is no outpu
 run_hook "$REPO" FAKE_RC=0 FAKE_OUT="error: this line is not a verdict"
 assert_eq "$rc" 0 "a successful run is not blocked by the word error in its output"
 
-echo "task-completed-check: outside a repository"
+echo "task-completed-check: the repository probe has no passing failure"
 NOREPO="$TMP_ROOT/norepo"
 mkdir -p "$NOREPO"
 printf 'pub fn added() {}\n' >"$NOREPO/added.rs"
 run_hook "$NOREPO" FAKE_RC=0
-assert_eq "$rc" 0 "no repository to ask means nothing to gate"
-assert_eq "$(cat "$ARGS_LOG")" "" "no repository never invokes cargo"
+assert_eq "$rc" 2 "a directory that is not a repository blocks"
+assert_eq "$(cat "$ARGS_LOG")" "" "a failed probe never invokes cargo"
+# The same 128 from inside a checkout git cannot read. Nothing in the status
+# or the message separates the two, so neither may stand the gate down.
+REPO="$(new_repo badconfig)"
+printf 'pub fn added() {}\n' >"$REPO/src/added.rs"
+printf 'this is not a config line\n' >"$REPO/.git/config"
+run_hook "$REPO" FAKE_RC=0
+assert_eq "$rc" 2 "an unreadable .git/config blocks"
+assert_contains "$err" "rev-parse failed" "names the probe that could not answer"
 
 echo "task-completed-check: a changed set larger than the pipe buffer"
 REPO="$(new_repo bigset)"
@@ -222,7 +230,7 @@ set +e
   >/dev/null 2>"$TMP_ROOT/stderr"
 rc=$?
 set -e
-assert_eq "$rc" 2 "a git that will not run blocks rather than standing down"
+assert_eq "$rc" 2 "a git that will not run blocks too"
 
 echo "task-completed-check: no cargo on PATH"
 REPO="$(new_repo nocargo)"

--- a/hooks/tests/task-completed-check.test.sh
+++ b/hooks/tests/task-completed-check.test.sh
@@ -166,6 +166,20 @@ run_hook "$NOREPO" FAKE_RC=0
 assert_eq "$rc" 0 "no repository to ask means nothing to gate"
 assert_eq "$(cat "$ARGS_LOG")" "" "no repository never invokes cargo"
 
+echo "task-completed-check: a changed set larger than the pipe buffer"
+REPO="$(new_repo bigset)"
+printf 'pub fn added() {}\n' >"$REPO/src/added.rs"
+# Sorts after src/, and long enough that the filter cannot have read it all
+# before an early-exiting reader would have quit on src/added.rs.
+mkdir -p "$REPO/zpad"
+i=0
+while [ "$i" -lt 1200 ]; do
+  : >"$REPO/zpad/padding-$i-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+  i=$((i + 1))
+done
+run_hook "$REPO" FAKE_RC=0
+assert_contains "$(cat "$ARGS_LOG")" "clippy" "an early .rs path is still found past the pipe buffer"
+
 echo "task-completed-check: git cannot answer what changed"
 REPO="$(new_repo brokengit)"
 printf 'pub fn added() {}\n' >"$REPO/src/added.rs"
@@ -193,6 +207,22 @@ rc=$?
 set -e
 assert_eq "$rc" 2 "an unreadable changed set blocks rather than passing"
 assert_contains "$(cat "$TMP_ROOT/stderr")" "unable to read index" "carries git's own failure"
+
+echo "task-completed-check: no git on PATH"
+REPO="$(new_repo nogit)"
+printf 'pub fn added() {}\n' >"$REPO/src/added.rs"
+NOGIT_BIN="$TMP_ROOT/nogit"
+mkdir -p "$NOGIT_BIN"
+for tool in bash cat sed sort head tail tr dirname; do
+  real="$(command -v "$tool" 2>/dev/null || true)"
+  [ -n "$real" ] && [ -f "$real" ] && ln -sf "$real" "$NOGIT_BIN/$tool"
+done
+set +e
+( cd "$REPO" && env -i HOME="$TMP_ROOT" PATH="$NOGIT_BIN" "$NOGIT_BIN/bash" "$HOOK" <<<'{}' ) \
+  >/dev/null 2>"$TMP_ROOT/stderr"
+rc=$?
+set -e
+assert_eq "$rc" 2 "a git that will not run blocks rather than standing down"
 
 echo "task-completed-check: no cargo on PATH"
 REPO="$(new_repo nocargo)"


### PR DESCRIPTION
The `task-completed-check` hook had two fail-open paths.

The changed set came from `git diff` alone, so a task whose only work was a new `.rs` file presented an empty set and the hook exited clean without linting anything. And the clippy run ended in `|| true`, with the verdict read off output lines starting `error`, so a missing cargo, a killed build, or a diagnostic in any other shape passed the gate.

Now:

- Untracked non-ignored paths join the changed set. `-z` on all three listings, so a non-ASCII path arrives as itself rather than C-quoted, where `src/über.rs` would end in a quote and never match `.rs$`.
- Clippy's exit status is the verdict. A failure with no `error:` line to quote reports the tail of what it did print. The invocation takes the guarded empty-array expansion, since bash 3.2 under `set -u` reads an empty `MANIFEST_ARGS` as unbound.
- Neither Rust-file filter stops reading early. `grep -q` and `head -1` quit at their first match, and under `pipefail` the SIGPIPE that kills the producer becomes the pipeline's status, read as no match — reachable now that untracked paths can push the changed set past the pipe buffer.
- Git that cannot answer blocks. There is no failure that means "nothing to gate": `rev-parse` exits 128 outside a repository and inside one whose metadata it cannot read, with the same words. So a directory that is not a repository blocks too, which is the same answer to the same question.

`hooks/tests/task-completed-check.test.sh` covers both halves against fixture repositories and a scripted fake cargo. Six of its 27 assertions fail against the pre-change hook.

Review raised that in a repository with no root `Cargo.toml` and more than one nested workspace, only the first manifest is linted. Declined under the creation bar (kendex#1688): no shipped repository has that layout, the hook is advisory, and the guard chain and CI catch the clippy failure anyway.

Closes KEN-648

https://claude.ai/code/session_013tEwaQPxSLwzS1ig1XQ8M1
