### PR TITLE
chore(harness): kendex render refresh 2026-08-27

### DIFF
--- a/.agents/skills/growth-guards/README.md
+++ b/.agents/skills/growth-guards/README.md
@@ -35,12 +35,14 @@ below cover local commits.
 The installer writes a helper into `.git/hooks` plus one marked delegating
 line in `pre-commit` and `commit-msg` — never `core.hooksPath`; an existing
 hook keeps its content and exit status; repeat runs are no-ops and repairs.
-`--uninstall` drops only the helper and our line. `--check` writes nothing:
-`0` armed in `.git/hooks`, `1` drifted, absent, or `core.hooksPath` set and
-empty (which switches git hooks off), `2` could not determine — which any
-`core.hooksPath` naming a directory is, because this package reads
-`.git/hooks` only, whatever that value resolves to. Never a silent pass. `kendex guard install` runs the installer and `kendex guard
-uninstall` runs `--uninstall`.
+`--uninstall` drops only the helper and our line. `kendex guard install` and
+`kendex guard uninstall` invoke those two.
+
+`--check` writes nothing: `0` armed in `.git/hooks`, `1` drifted, absent, or
+`core.hooksPath` set and empty (which switches git hooks off), `2` could not
+determine — which any `core.hooksPath` naming a directory is: this package
+reads `.git/hooks` only, whatever that value resolves to. Never a silent
+pass.
 
 `pre-commit` judges ONE commit snapshot: `size-ratchet --staged` and
 `preflight --staged` when the committing work tree or this install
@@ -54,38 +56,28 @@ shims BLOCK and fail closed — `1` carries the check's remediation text,
 
 Two layers, and only one of them is authoritative.
 
-**The git hooks are the gate.** They run for every committer — a person at a
-terminal, any AI harness, a script, an editor's commit button — because git
-runs them, not because anything asked. They need no kendex binary at commit time: the shim
-execs this skill's committed scripts. Git never clones `.git/hooks`, so a
-fresh clone carries the scripts but no shims — one `kendex guard install`
-arms them, and from then on every commit is gated by committed shell and
-git, on a machine that has never installed kendex. That is the whole reason
-the checks are shell and travel with the repository.
+**The git hooks are the gate.** Git runs them for every committer — a person
+at a terminal, any AI harness, a script, an editor's commit button. They need
+no kendex binary: the shim execs this skill's committed scripts. Git never
+clones `.git/hooks`, so a fresh clone carries the scripts but no shims. One
+`kendex guard install` arms them, and every commit after that is gated by
+committed shell and git on a machine that has never installed kendex.
 
-**kendex only arms and reports.** `kendex guard install` runs the installer
-above; `kendex guard uninstall` runs `--uninstall`; `kendex check` reads the hook files
-itself — armed, not armed, or could not tell — and runs nothing out of a
-checkout, because reading a repository's status must not execute its code.
-kendex implements no check of its own; the verdicts a commit is judged by
-are all this skill's.
+**kendex only arms and reports.** `kendex guard install` and `kendex guard
+uninstall` invoke the installer; `kendex check` reads the hook files and says
+armed, not armed, or could not tell. It runs nothing out of a checkout and
+implements no check of its own — the verdicts a commit is judged by are all
+this skill's.
 
-**The `pre-commit-check` harness hook never stands in.** Where BOTH git
-hooks are armed — this package's marker in `pre-commit` and `commit-msg`,
-both executable — it steps aside: git runs the gate itself, and validating
-twice would only double the wait. Half of it is not a gate: with
-`commit-msg` gone, git checks the content and takes any message. It does one thing the git hook
-cannot — refuse a command that would sidestep an armed hook (`--no-verify`, the
-short flag, or injected git configuration), because git would skip the
-message gate too and nothing can check a message it never sees. And where
-nothing is armed it refuses the commit, naming `kendex guard install`. It
-runs no script of the repository's on anyone's behalf: arming is the local
-act that asks for that, and a fresh clone has no hooks and so no execution
-behind it. It gates its own working directory and no other.
-
-Order, then: git hooks where they exist, and a refusal where they do not. No
-layer ever passes a commit another layer would have blocked, and no layer
-runs a repository's code that nobody armed.
+**The `pre-commit-check` harness hook never stands in.** Where BOTH git hooks
+are armed — this package's marker in `pre-commit` and `commit-msg`, both
+executable — it steps aside and lets git run the gate. Half-armed is not
+armed: with `commit-msg` missing, git takes any message. The hook does the
+one thing a git hook cannot, refusing a command that would sidestep an armed
+hook (`--no-verify`, the short flag, injected git configuration), and where
+nothing is armed it refuses the commit and names `kendex guard install`. It
+gates its own working directory and no other, and runs no script of the
+repository's on anyone's behalf.
 
 ## The checks
 

--- a/.agents/skills/growth-guards/SKILL.md
+++ b/.agents/skills/growth-guards/SKILL.md
@@ -10,6 +10,23 @@ metadata:
   bugs: "https://github.com/vanillagreencom/kendex/issues"
   version: "1.0.0"
 tags: [automation]
+repo-effects:
+  summary: "Arms git pre-commit and commit-msg hooks, so every commit in this repository runs the guard chain — for everyone who commits here, not only for kendex."
+  writes:
+    - ".git/hooks/kendex-guards"
+    - ".git/hooks/pre-commit"
+    - ".git/hooks/commit-msg"
+  installer: "scripts/install-git-hooks"
+  uninstaller: "scripts/install-git-hooks --uninstall"
+  removal: "run the uninstaller before removing this package: it drops only the helper and one marked line, leaving any hook you wrote. kendex remove does not run it for you, so shims left behind would exec scripts that are gone and fail every commit closed"
+  companions:
+    - "size-ratchet"
+    - "preflight"
+  notes:
+    - "An existing pre-commit or commit-msg hook keeps its content and its exit status: one marked line goes in after the shebang and falls through to what was already there. core.hooksPath is never set."
+    - "The chain runs in order: size-ratchet --staged, preflight --staged, the growth-guards batch (todo-ban, byte-ceiling, suppression-ban, conflict-markers), then the repo-root executable named by GROWTH_GUARDS_PRE_COMMIT_LOCAL. A companion that is not installed is an announced skip, never a silently missing check, and one that is installed but cannot run stops the commit rather than skipping it."
+    - "Both hooks block on any nonzero verdict and fail closed on a guard that could not run. Passing git's no-verify flag bypasses one commit, and skips the message gate with it."
+    - "The gate needs no kendex binary once armed: git runs this package's committed scripts, so a machine that never installed kendex still gates commits. Arming does not travel, though — git clones no hooks and this package never sets core.hooksPath — so every clone is armed once, by whoever clones it."
 ---
 
 # Growth Guards
@@ -32,7 +49,7 @@ Each check is also invocable as `scripts/CHECK`.
 | Check | Verdict |
 |---|---|
 | **todo-ban** | Any work marker (TODO, FIXME, HACK, XXX in comment-marker shapes) in a tracked, non-excluded file fails. No baseline. Prose naming a marker word does not fire. |
-| **byte-ceiling** | A file a change puts over the ceiling (default 200 KB) fails. `--staged` (default) gates staged additions, modifications and type changes, with rename detection at exact content only; `--base REF` gates the additions since merge-base; `--all` sweeps every committed file. Lockfiles are exempt built-in. |
+| **byte-ceiling** | A tracked file over the ceiling (default 200 KB) fails. `--staged` (default) gates every file the commit adds, modifies or changes the type of; `--base REF` only the files added since merge-base; `--all` sweeps every tracked file. Lockfiles are exempt built-in. |
 | **suppression-ban** | Blanket lint suppressions fail flat: module-wide rust `allow` inner attributes, file-level ruff/flake8 noqa, the bare `eslint-disable` block form, bare or `all` nolint, biome's `biome-ignore-all` / unscoped `biome-ignore-start` / rule-less `biome-ignore lint` and group forms. Bare rust `allow(dead_code)`/`allow(unused*)` attributes are counted per file against a tighten-only baseline; `--update` lowers/removes rows, never adds or raises one. A per-line suppression naming its lint with a stated reason stays legal. |
 | **conflict-markers** | An unresolved merge-conflict marker in a tracked, non-excluded file fails: the open/base/close trio (seven `<`, seven vertical bars, seven `>`) at column 0, each followed by a space or end of line. No baseline. Indented or quoted occurrences and the bare seven-equals separator do not fire. |
 | **commit-msg** | Header must be `type(scope)!: subject` (scope and `!` optional). Uppercase issue keys (`fix(ABC-123)`) and `#`-number scopes pass; git-generated messages (Merge/Revert/Reapply, fixup!/squash!/amend!) pass unchanged. Takes the message file or stdin. |


### PR DESCRIPTION
Renders from kendex main after #1669, #1674, #1681, #1682, #1685, #1686, #1687. The harness-ci render replaces the pre-record copy; the guard hooks were re-armed on this machine from the new installer.

https://claude.ai/code/session_01YMdDBjvjpv1qCSuFr69eS7