### PR TITLE
fix(KEN-649): a bare cd with no path is refused

### DIFF
--- a/.claude/hooks/block-bare-cd.sh
+++ b/.claude/hooks/block-bare-cd.sh
@@ -12,15 +12,16 @@ set -euo pipefail
 INPUT=$(cat)
 COMMAND=$(echo "$INPUT" | grep -o '"command"[[:space:]]*:[[:space:]]*"[^"]*"' | head -1 | sed 's/.*"command"[[:space:]]*:[[:space:]]*"//;s/"$//' 2>/dev/null || true)
 
-# Fast exit if no cd in command
-if ! echo "$COMMAND" | grep -q 'cd '; then
+# Fast exit if no cd in command. A bare `cd` goes to $HOME, the change this
+# hook exists to stop, so end of line counts the same as a following space.
+if ! echo "$COMMAND" | grep -qE 'cd([[:space:]]|$)'; then
   exit 0
 fi
 
 # Check for bare top-level cd (not in subshell or &&-chained with other work)
 # Simple heuristic: if the command is just "cd /path" with nothing else meaningful
 STRIPPED=$(echo "$COMMAND" | sed 's/^[[:space:]]*//')
-if echo "$STRIPPED" | grep -qE '^cd[[:space:]]+[^&|;]+$'; then
+if echo "$STRIPPED" | grep -qE '^cd([[:space:]]+[^&|;]*)?$'; then
   echo "Bare 'cd' changes working directory permanently across tool calls." >&2
   echo "Use a subshell instead: (cd /path && command)" >&2
   exit 2

--- a/.codex/hooks/block-bare-cd.sh
+++ b/.codex/hooks/block-bare-cd.sh
@@ -12,15 +12,16 @@ set -euo pipefail
 INPUT=$(cat)
 COMMAND=$(echo "$INPUT" | grep -o '"command"[[:space:]]*:[[:space:]]*"[^"]*"' | head -1 | sed 's/.*"command"[[:space:]]*:[[:space:]]*"//;s/"$//' 2>/dev/null || true)
 
-# Fast exit if no cd in command
-if ! echo "$COMMAND" | grep -q 'cd '; then
+# Fast exit if no cd in command. A bare `cd` goes to $HOME, the change this
+# hook exists to stop, so end of line counts the same as a following space.
+if ! echo "$COMMAND" | grep -qE 'cd([[:space:]]|$)'; then
   exit 0
 fi
 
 # Check for bare top-level cd (not in subshell or &&-chained with other work)
 # Simple heuristic: if the command is just "cd /path" with nothing else meaningful
 STRIPPED=$(echo "$COMMAND" | sed 's/^[[:space:]]*//')
-if echo "$STRIPPED" | grep -qE '^cd[[:space:]]+[^&|;]+$'; then
+if echo "$STRIPPED" | grep -qE '^cd([[:space:]]+[^&|;]*)?$'; then
   echo "Bare 'cd' changes working directory permanently across tool calls." >&2
   echo "Use a subshell instead: (cd /path && command)" >&2
   exit 2

--- a/.pi/kendex/hooks/block-bare-cd.sh
+++ b/.pi/kendex/hooks/block-bare-cd.sh
@@ -12,15 +12,16 @@ set -euo pipefail
 INPUT=$(cat)
 COMMAND=$(echo "$INPUT" | grep -o '"command"[[:space:]]*:[[:space:]]*"[^"]*"' | head -1 | sed 's/.*"command"[[:space:]]*:[[:space:]]*"//;s/"$//' 2>/dev/null || true)
 
-# Fast exit if no cd in command
-if ! echo "$COMMAND" | grep -q 'cd '; then
+# Fast exit if no cd in command. A bare `cd` goes to $HOME, the change this
+# hook exists to stop, so end of line counts the same as a following space.
+if ! echo "$COMMAND" | grep -qE 'cd([[:space:]]|$)'; then
   exit 0
 fi
 
 # Check for bare top-level cd (not in subshell or &&-chained with other work)
 # Simple heuristic: if the command is just "cd /path" with nothing else meaningful
 STRIPPED=$(echo "$COMMAND" | sed 's/^[[:space:]]*//')
-if echo "$STRIPPED" | grep -qE '^cd[[:space:]]+[^&|;]+$'; then
+if echo "$STRIPPED" | grep -qE '^cd([[:space:]]+[^&|;]*)?$'; then
   echo "Bare 'cd' changes working directory permanently across tool calls." >&2
   echo "Use a subshell instead: (cd /path && command)" >&2
   exit 2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,10 @@ an outside contributor.
 
 ### Fixed
 
+- The `block-bare-cd` hook refuses a bare `cd` with no path. It changes to
+  `$HOME` for every later tool call, the move the hook exists to stop, and
+  only `cd <path>` was caught before.
+
 - The settings template no longer seeds `.cursor` into `WORKTREE_SYMLINKS`, so
   `worktree fix-links` passes in repos that do not use Cursor; a repo that
   does adds it back in its own `kendex.settings.toml`.

--- a/hooks/block-bare-cd.sh
+++ b/hooks/block-bare-cd.sh
@@ -12,15 +12,16 @@ set -euo pipefail
 INPUT=$(cat)
 COMMAND=$(echo "$INPUT" | grep -o '"command"[[:space:]]*:[[:space:]]*"[^"]*"' | head -1 | sed 's/.*"command"[[:space:]]*:[[:space:]]*"//;s/"$//' 2>/dev/null || true)
 
-# Fast exit if no cd in command
-if ! echo "$COMMAND" | grep -q 'cd '; then
+# Fast exit if no cd in command. A bare `cd` goes to $HOME, the change this
+# hook exists to stop, so end of line counts the same as a following space.
+if ! echo "$COMMAND" | grep -qE 'cd([[:space:]]|$)'; then
   exit 0
 fi
 
 # Check for bare top-level cd (not in subshell or &&-chained with other work)
 # Simple heuristic: if the command is just "cd /path" with nothing else meaningful
 STRIPPED=$(echo "$COMMAND" | sed 's/^[[:space:]]*//')
-if echo "$STRIPPED" | grep -qE '^cd[[:space:]]+[^&|;]+$'; then
+if echo "$STRIPPED" | grep -qE '^cd([[:space:]]+[^&|;]*)?$'; then
   echo "Bare 'cd' changes working directory permanently across tool calls." >&2
   echo "Use a subshell instead: (cd /path && command)" >&2
   exit 2

--- a/hooks/tests/block-bare-cd.test.sh
+++ b/hooks/tests/block-bare-cd.test.sh
@@ -1,0 +1,68 @@
+#!/usr/bin/env bash
+# Tests for the block-bare-cd hook.
+#
+# The hook refuses a top-level `cd` that would move the working directory for
+# every later tool call, and passes anything that scopes the move — a
+# subshell, an &&-chain doing the real work — or that only mentions cd. The
+# argument is optional on both sides of the check: a bare `cd` goes to $HOME,
+# which is the same permanent move as `cd /tmp`.
+#
+# HOOK_UNDER_TEST overrides the script under test so the must-fail controls
+# (the pre-fix hook, a no-op hook) run against these same assertions.
+set -euo pipefail
+
+TEST_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+HOOK="${HOOK_UNDER_TEST:-$(cd "$TEST_DIR/.." && pwd)/block-bare-cd.sh}"
+
+PASS=0
+FAIL=0
+TMP_ROOT="$(mktemp -d)"
+trap 'rm -rf "$TMP_ROOT"' EXIT
+ERR_FILE="$TMP_ROOT/stderr"
+BASH_BIN="$(command -v bash)"
+
+pass() { PASS=$((PASS + 1)); printf '  ok    %s\n' "$1"; }
+assert_eq() {
+  if [ "$1" = "$2" ]; then pass "$3"; else FAIL=$((FAIL + 1)); printf '  FAIL  %s\n        expected: %s\n        got:      %s\n' "$3" "$2" "$1"; fi
+}
+assert_contains() {
+  if grep -qF -- "$2" "$1"; then pass "$3"; else FAIL=$((FAIL + 1)); printf '  FAIL  %s\n        wanted: %s\n        in:\n%s\n' "$3" "$2" "$(cat "$1")"; fi
+}
+
+# The command reaches the hook JSON-encoded, exactly as the harness sends it.
+json_for() {
+  local c
+  c=$(printf '%s' "$1" | sed 's/\\/\\\\/g; s/"/\\"/g')
+  printf '{"tool_name":"Bash","tool_input":{"command":"%s"}}' "$c"
+}
+
+run_hook() { # command -> rc, stderr in ERR_FILE
+  set +e
+  json_for "$1" | "$BASH_BIN" "$HOOK" >/dev/null 2>"$ERR_FILE"
+  rc=$?
+  set -e
+}
+
+echo "=== block-bare-cd: refused shapes ==="
+run_hook 'cd';            assert_eq "$rc" 2 'a bare cd with no argument is refused'
+run_hook 'cd ';           assert_eq "$rc" 2 'a bare cd with a trailing space is refused'
+run_hook '   cd';         assert_eq "$rc" 2 'leading whitespace does not hide a bare cd'
+run_hook 'cd /tmp';       assert_eq "$rc" 2 'cd with a path is refused'
+run_hook 'cd ~/dev';      assert_eq "$rc" 2 'cd to a home-relative path is refused'
+run_hook 'cd ..';         assert_eq "$rc" 2 'cd .. is refused'
+
+echo "=== block-bare-cd: the refusal names the cause and the rewrite ==="
+run_hook 'cd'
+assert_contains "$ERR_FILE" 'across tool calls' 'the refusal names what it prevents'
+assert_contains "$ERR_FILE" '(cd /path && command)' 'the refusal names the subshell rewrite'
+
+echo "=== block-bare-cd: accepted shapes ==="
+run_hook '(cd /tmp && ls)';   assert_eq "$rc" 0 'a subshell-scoped cd passes'
+run_hook 'cd /tmp && ls';     assert_eq "$rc" 0 'a cd chained with the real work passes'
+run_hook 'echo cd';           assert_eq "$rc" 0 'a command that only mentions cd passes'
+run_hook 'cdr --version';     assert_eq "$rc" 0 'a command whose name merely starts with cd passes'
+run_hook 'ls -la';            assert_eq "$rc" 0 'an unrelated command passes'
+run_hook 'git checkout main'; assert_eq "$rc" 0 'a command with no cd at all passes'
+
+printf '\n%s passed, %s failed\n' "$PASS" "$FAIL"
+[ "$FAIL" -eq 0 ]

--- a/pi-extensions/pi-hooks/CHANGELOG.md
+++ b/pi-extensions/pi-hooks/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Consumer-impacting changes
 
+### 0.6.1
+
+- `blockBareCd` refuses a `cd` with no target. It changes to `$HOME` for every later tool call, the same permanent move as `cd /tmp`, and only the form carrying a path was caught before.
+
 ### 0.6.0
 
 - The session-start drift report no longer opens with "kendex check could not run" when kendex ran and answered. Exit 1 (drift, or packages not yet evaluated) is relayed verbatim. Exit 2 means kendex could not check, in part or at all: a report carrying a "could not check" section is relayed under a "kendex check incomplete (exit 2); some drift status unknown:" line, while output opening with kendex's own `Error:` line or a usage `error:` (nothing was checked) keeps the "kendex check could not run (exit 2)" line. Exit 3+, a non-ENOENT spawn error, an inaccessible session directory, or an unexpected throw read as "could not run"; a missing binary (ENOENT) reads as "skipped". `DriftCheckResult` gains the `incomplete` variant.

--- a/pi-extensions/pi-hooks/extensions/bash-guards.ts
+++ b/pi-extensions/pi-hooks/extensions/bash-guards.ts
@@ -5,14 +5,14 @@ import { dirname, isAbsolute, join, relative, resolve } from "node:path";
 import { findCargoWorkspaceRootResultAsync, runCargoAsync, runWorkspaceClippyAsync } from "./cargo.js";
 
 /**
- * Match a bash command that is exactly `cd <target>` with no shell operators
- * that would scope the directory change (no `&&`, `||`, `|`, `;`, parens,
- * backticks, `$(...)`, or embedded newlines). Such commands change Pi's CWD
- * across subsequent tool calls and leak state between unrelated tools.
+ * Match a bash command that is exactly `cd` or `cd <target>` with no shell
+ * operators that would scope the directory change (no `&&`, `||`, `|`, `;`,
+ * parens, backticks, `$(...)`, or newlines). Such commands change Pi's CWD
+ * across tool calls; a bare `cd` goes to $HOME, the same permanent move.
  *
  * Mirrors `hooks/block-bare-cd.sh`.
  */
-const BARE_CD = /^cd\s+[^&|;()`$\n]+$/;
+const BARE_CD = /^cd(\s+[^&|;()`$\n]+)?$/;
 
 export function isBareCd(command: string): boolean {
 	return BARE_CD.test(command.trim());

--- a/pi-extensions/pi-hooks/package.json
+++ b/pi-extensions/pi-hooks/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vanillagreen/pi-hooks",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "description": "First-class Pi port of the kendex safety hooks: bare-cd blocking, pre-commit fmt+clippy, post-edit clippy, end-of-turn lint, session-start kendex drift report. Per-hook toggles via pi-extension-manager.",
   "license": "MIT",
   "keywords": [

--- a/pi-extensions/pi-hooks/tests/bash-guards.test.ts
+++ b/pi-extensions/pi-hooks/tests/bash-guards.test.ts
@@ -388,6 +388,13 @@ describe("bare cd detection", () => {
 		expect(isBareCd("cd /tmp && ls")).toBe(false);
 	});
 
+	test("a cd with no target is the same permanent move", () => {
+		expect(isBareCd("cd")).toBe(true);
+		expect(isBareCd("  cd  ")).toBe(true);
+		expect(isBareCd("cdr --version")).toBe(false);
+		expect(isBareCd("echo cd")).toBe(false);
+	});
+
 	test("read-only searches with backtick-bearing patterns are never bare cd (kendex#668)", () => {
 		expect(isBareCd('rg -n "`kendex refresh`" skills/')).toBe(false);
 		expect(isBareCd("rg -n '`kendex refresh`' skills/")).toBe(false);

--- a/pi-extensions/pi-hooks/tests/hooks.test.ts
+++ b/pi-extensions/pi-hooks/tests/hooks.test.ts
@@ -414,10 +414,12 @@ describe("pi-hooks bash guard passthrough", () => {
 		const project = initCleanRustRepo("pi-hooks-project-");
 		try {
 			const handler = installToolCallHandler();
-			expect(await handler({ toolName: "bash", input: { command: "cd /tmp" } }, { cwd: project })).toEqual({
+			const blocked = {
 				block: true,
 				reason: "Bare 'cd' changes working directory permanently across tool calls. Use a subshell instead: (cd /path && command)",
-			});
+			};
+			expect(await handler({ toolName: "bash", input: { command: "cd /tmp" } }, { cwd: project })).toEqual(blocked);
+			expect(await handler({ toolName: "bash", input: { command: "cd" } }, { cwd: project })).toEqual(blocked);
 		} finally {
 			rmSync(project, { recursive: true, force: true });
 		}


### PR DESCRIPTION
The `block-bare-cd` hook's fast path tested for the literal `cd ` with a trailing space, and the check behind it required a path operand. So `cd` alone passed the hook while `cd /tmp` was refused, even though the bare form changes to `$HOME` for every later tool call. That is exactly the move the hook exists to stop.

Both tests now read end of command the way they read a following space, and take the path as optional.

`hooks/tests/block-bare-cd.test.sh` pins the refused shapes (`cd`, `cd `, leading whitespace, `cd /tmp`, `cd ..`) and the accepted ones (a subshell, an &&-chain, `echo cd`, `cdr`). 5 of its 14 assertions fail against the pre-change hook.

Source plus its three renders (`.claude`, `.codex`, `.pi/kendex`).

Closes KEN-649

https://claude.ai/code/session_013tEwaQPxSLwzS1ig1XQ8M1