### PR TITLE
feat(KEN-682): marketplace rows and search read a summary of their own

### DIFF
--- a/.agents/skills/app-deploy/SKILL.md
+++ b/.agents/skills/app-deploy/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: app-deploy
 description: "Load when asked to cut, ship, or release a kendex version."
+summary: "Releases a kendex version: bumps versions, finalizes the changelog, tags per docs/RELEASING.md."
 ---
 
 # Release kendex

--- a/.agents/skills/code-quality/SKILL.md
+++ b/.agents/skills/code-quality/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: code-quality
 description: "Load before writing or modifying code."
+summary: "Code-authoring standards for dev agents: correctness over convenience, no fail-open branches, comment rules, over-engineering limits, prove-your-guards."
 license: MIT
 user-invocable: true
 metadata:

--- a/.agents/skills/decider/SKILL.md
+++ b/.agents/skills/decider/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: decider
 description: "Load to create, search, or supersede an architecture decision record."
+summary: "Architecture decision records: templates, creation, search, supersession tracking, and INDEX maintenance."
 license: MIT
 user-invocable: true
 metadata:

--- a/.agents/skills/deep-research/SKILL.md
+++ b/.agents/skills/deep-research/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: deep-research
 description: "Load for research tasks, architectural investigations, and vendor, library, or technology comparisons."
+summary: "Exa-powered deep research that produces an evidence-backed findings.md report."
 license: MIT
 user-invocable: true
 argument-hint: "report [query] --output findings.md"

--- a/.agents/skills/dep-radar/SKILL.md
+++ b/.agents/skills/dep-radar/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: dep-radar
 description: "Load to run or tune a dependency sweep."
+summary: "Sweeps every pinned version in the repo (deps, SDKs, vendored forks, model weights), checks upstream, and lands upgrades with their fallout in one PR per surface."
 license: MIT
 user-invocable: true
 dependencies:

--- a/.agents/skills/dev/SKILL.md
+++ b/.agents/skills/dev/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: dev
 description: "Load when implementing an issue or applying review fixes as a dev agent."
+summary: "Dev-agent workflows for implementing an issue and applying review fixes, invoked by orch or specialist agents."
 license: MIT
 user-invocable: true
 dependencies:

--- a/.agents/skills/github/SKILL.md
+++ b/.agents/skills/github/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: github
 description: "Load to work a GitHub pull request: threads, comments, reviews, CI logs, merges."
+summary: "GitHub API CLI for pull requests: threads, comments, reviews, CI logs, merging, and cross-PR analysis."
 license: MIT
 user-invocable: true
 metadata:

--- a/.agents/skills/growth-guards/README.md
+++ b/.agents/skills/growth-guards/README.md
@@ -35,12 +35,14 @@ below cover local commits.
 The installer writes a helper into `.git/hooks` plus one marked delegating
 line in `pre-commit` and `commit-msg` — never `core.hooksPath`; an existing
 hook keeps its content and exit status; repeat runs are no-ops and repairs.
-`--uninstall` drops only the helper and our line. `--check` writes nothing:
-`0` armed in `.git/hooks`, `1` drifted, absent, or `core.hooksPath` set and
-empty (which switches git hooks off), `2` could not determine — which any
-`core.hooksPath` naming a directory is, because this package reads
-`.git/hooks` only, whatever that value resolves to. Never a silent pass. `kendex guard install` runs the installer and `kendex guard
-uninstall` runs `--uninstall`.
+`--uninstall` drops only the helper and our line. `kendex guard install` and
+`kendex guard uninstall` invoke those two.
+
+`--check` writes nothing: `0` armed in `.git/hooks`, `1` drifted, absent, or
+`core.hooksPath` set and empty (which switches git hooks off), `2` could not
+determine — which any `core.hooksPath` naming a directory is: this package
+reads `.git/hooks` only, whatever that value resolves to. Never a silent
+pass.
 
 `pre-commit` judges ONE commit snapshot: `size-ratchet --staged` and
 `preflight --staged` when the committing work tree or this install
@@ -54,38 +56,28 @@ shims BLOCK and fail closed — `1` carries the check's remediation text,
 
 Two layers, and only one of them is authoritative.
 
-**The git hooks are the gate.** They run for every committer — a person at a
-terminal, any AI harness, a script, an editor's commit button — because git
-runs them, not because anything asked. They need no kendex binary at commit time: the shim
-execs this skill's committed scripts. Git never clones `.git/hooks`, so a
-fresh clone carries the scripts but no shims — one `kendex guard install`
-arms them, and from then on every commit is gated by committed shell and
-git, on a machine that has never installed kendex. That is the whole reason
-the checks are shell and travel with the repository.
+**The git hooks are the gate.** Git runs them for every committer — a person
+at a terminal, any AI harness, a script, an editor's commit button. They need
+no kendex binary: the shim execs this skill's committed scripts. Git never
+clones `.git/hooks`, so a fresh clone carries the scripts but no shims. One
+`kendex guard install` arms them, and every commit after that is gated by
+committed shell and git on a machine that has never installed kendex.
 
-**kendex only arms and reports.** `kendex guard install` runs the installer
-above; `kendex guard uninstall` runs `--uninstall`; `kendex check` reads the hook files
-itself — armed, not armed, or could not tell — and runs nothing out of a
-checkout, because reading a repository's status must not execute its code.
-kendex implements no check of its own; the verdicts a commit is judged by
-are all this skill's.
+**kendex only arms and reports.** `kendex guard install` and `kendex guard
+uninstall` invoke the installer; `kendex check` reads the hook files and says
+armed, not armed, or could not tell. It runs nothing out of a checkout and
+implements no check of its own — the verdicts a commit is judged by are all
+this skill's.
 
-**The `pre-commit-check` harness hook never stands in.** Where BOTH git
-hooks are armed — this package's marker in `pre-commit` and `commit-msg`,
-both executable — it steps aside: git runs the gate itself, and validating
-twice would only double the wait. Half of it is not a gate: with
-`commit-msg` gone, git checks the content and takes any message. It does one thing the git hook
-cannot — refuse a command that would sidestep an armed hook (`--no-verify`, the
-short flag, or injected git configuration), because git would skip the
-message gate too and nothing can check a message it never sees. And where
-nothing is armed it refuses the commit, naming `kendex guard install`. It
-runs no script of the repository's on anyone's behalf: arming is the local
-act that asks for that, and a fresh clone has no hooks and so no execution
-behind it. It gates its own working directory and no other.
-
-Order, then: git hooks where they exist, and a refusal where they do not. No
-layer ever passes a commit another layer would have blocked, and no layer
-runs a repository's code that nobody armed.
+**The `pre-commit-check` harness hook never stands in.** Where BOTH git hooks
+are armed — this package's marker in `pre-commit` and `commit-msg`, both
+executable — it steps aside and lets git run the gate. Half-armed is not
+armed: with `commit-msg` missing, git takes any message. The hook does the
+one thing a git hook cannot, refusing a command that would sidestep an armed
+hook (`--no-verify`, the short flag, injected git configuration), and where
+nothing is armed it refuses the commit and names `kendex guard install`. It
+gates its own working directory and no other, and runs no script of the
+repository's on anyone's behalf.
 
 ## The checks
 

--- a/.agents/skills/growth-guards/SKILL.md
+++ b/.agents/skills/growth-guards/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: growth-guards
 description: "Load to add, tune, or debug a repo growth guard, its git hooks, or GROWTH_GUARDS_* settings."
+summary: "Five repo growth guards beside size-ratchet (todo-ban, byte-ceiling, suppression-ban, conflict-markers, commit-msg) and the git hook shims that run them."
 license: MIT
 user-invocable: true
 metadata:
@@ -10,6 +11,23 @@ metadata:
   bugs: "https://github.com/vanillagreencom/kendex/issues"
   version: "1.0.0"
 tags: [automation]
+repo-effects:
+  summary: "Arms git pre-commit and commit-msg hooks, so every commit in this repository runs the guard chain — for everyone who commits here, not only for kendex."
+  writes:
+    - ".git/hooks/kendex-guards"
+    - ".git/hooks/pre-commit"
+    - ".git/hooks/commit-msg"
+  installer: "scripts/install-git-hooks"
+  uninstaller: "scripts/install-git-hooks --uninstall"
+  removal: "run the uninstaller before removing this package: it drops only the helper and one marked line, leaving any hook you wrote. kendex remove does not run it for you, so shims left behind would exec scripts that are gone and fail every commit closed"
+  companions:
+    - "size-ratchet"
+    - "preflight"
+  notes:
+    - "An existing pre-commit or commit-msg hook keeps its content and its exit status: one marked line goes in after the shebang and falls through to what was already there. core.hooksPath is never set."
+    - "The chain runs in order: size-ratchet --staged, preflight --staged, the growth-guards batch (todo-ban, byte-ceiling, suppression-ban, conflict-markers), then the repo-root executable named by GROWTH_GUARDS_PRE_COMMIT_LOCAL. A companion that is not installed is an announced skip, never a silently missing check, and one that is installed but cannot run stops the commit rather than skipping it."
+    - "Both hooks block on any nonzero verdict and fail closed on a guard that could not run. Passing git's no-verify flag bypasses one commit, and skips the message gate with it."
+    - "The gate needs no kendex binary once armed: git runs this package's committed scripts, so a machine that never installed kendex still gates commits. Arming does not travel, though — git clones no hooks and this package never sets core.hooksPath — so every clone is armed once, by whoever clones it."
 ---
 
 # Growth Guards
@@ -32,7 +50,7 @@ Each check is also invocable as `scripts/CHECK`.
 | Check | Verdict |
 |---|---|
 | **todo-ban** | Any work marker (TODO, FIXME, HACK, XXX in comment-marker shapes) in a tracked, non-excluded file fails. No baseline. Prose naming a marker word does not fire. |
-| **byte-ceiling** | A file a change puts over the ceiling (default 200 KB) fails. `--staged` (default) gates staged additions, modifications and type changes, with rename detection at exact content only; `--base REF` gates the additions since merge-base; `--all` sweeps every committed file. Lockfiles are exempt built-in. |
+| **byte-ceiling** | A tracked file over the ceiling (default 200 KB) fails. `--staged` (default) gates every file the commit adds, modifies or changes the type of; `--base REF` only the files added since merge-base; `--all` sweeps every tracked file. Lockfiles are exempt built-in. |
 | **suppression-ban** | Blanket lint suppressions fail flat: module-wide rust `allow` inner attributes, file-level ruff/flake8 noqa, the bare `eslint-disable` block form, bare or `all` nolint, biome's `biome-ignore-all` / unscoped `biome-ignore-start` / rule-less `biome-ignore lint` and group forms. Bare rust `allow(dead_code)`/`allow(unused*)` attributes are counted per file against a tighten-only baseline; `--update` lowers/removes rows, never adds or raises one. A per-line suppression naming its lint with a stated reason stays legal. |
 | **conflict-markers** | An unresolved merge-conflict marker in a tracked, non-excluded file fails: the open/base/close trio (seven `<`, seven vertical bars, seven `>`) at column 0, each followed by a space or end of line. No baseline. Indented or quoted occurrences and the bare seven-equals separator do not fire. |
 | **commit-msg** | Header must be `type(scope)!: subject` (scope and `!` optional). Uppercase issue keys (`fix(ABC-123)`) and `#`-number scopes pass; git-generated messages (Merge/Revert/Reapply, fixup!/squash!/amend!) pass unchanged. Takes the message file or stdin. |

--- a/.agents/skills/iced-rs/SKILL.md
+++ b/.agents/skills/iced-rs/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: iced-rs
 description: "Load whenever building or debugging an Iced UI."
+summary: "Iced 0.14 GUI reference: custom widgets via iced::advanced, overlays, Canvas, Shader, pane_grid, theming, subscriptions, Elm architecture, with a bundled full-API reference."
 license: MIT
 user-invocable: true
 metadata:

--- a/.agents/skills/kendex-issues/SKILL.md
+++ b/.agents/skills/kendex-issues/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: kendex-issues
 description: "Load to monitor kendex's issue queue continuously or to run one fix-and-propagate cycle."
+summary: "Stewards the kendex issue queue on a self-paced loop: watches open PRs, polls Linear, triages, fixes defects through orch, merges, propagates with kendex refresh."
 ---
 
 # kendex Issue Steward

--- a/.agents/skills/linear/SKILL.md
+++ b/.agents/skills/linear/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: linear
 description: "Load for any Linear read or write: issues, projects, cycles, milestones, initiatives, labels."
+summary: "Bash CLI over Linear's GraphQL API with a local cache: read, search, create, or update issues, projects, cycles, milestones, initiatives, and labels."
 license: MIT
 user-invocable: true
 metadata:

--- a/.agents/skills/orch/SKILL.md
+++ b/.agents/skills/orch/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: orch
 description: "PRIMARY AGENT ONLY. Load to orchestrate a Linear or GitHub work item from preparation through merge."
+summary: "Work-item orchestration for Linear or GitHub issues: prepare, delegate implementation, review, submit, merge, hand off, and oversee fleets of sessions."
 license: MIT
 user-invocable: true
 dependencies:
@@ -14,19 +15,6 @@ metadata:
   version: "3.0.0"
 tags: [automation]
 ---
-
-<!-- kendex:project-instructions:start -->
-## Project Instructions
-
-## Benchmarking orchestration changes
-
-The orch-drill ablation rig A/B-benchmarks orchestration changes: launch a
-drill per its README and compare wall clock and phase timings against the
-recorded baselines before shipping a workflow change. It is a separate
-repository, `bmethod/orch-drill`, not part of this checkout. Clone it wherever
-you keep repositories and run the drill from there.
-
-<!-- kendex:project-instructions:end -->
 
 # Orchestration
 

--- a/.agents/skills/orch/SKILL.md
+++ b/.agents/skills/orch/SKILL.md
@@ -16,6 +16,19 @@ metadata:
 tags: [automation]
 ---
 
+<!-- kendex:project-instructions:start -->
+## Project Instructions
+
+## Benchmarking orchestration changes
+
+The orch-drill ablation rig A/B-benchmarks orchestration changes: launch a
+drill per its README and compare wall clock and phase timings against the
+recorded baselines before shipping a workflow change. It is a separate
+repository, `bmethod/orch-drill`, not part of this checkout. Clone it wherever
+you keep repositories and run the drill from there.
+
+<!-- kendex:project-instructions:end -->
+
 # Orchestration
 
 > **Problem with this skill?** Run `kendex report` — it files to the owning repo automatically. Do not hand-file.

--- a/.agents/skills/preflight/SKILL.md
+++ b/.agents/skills/preflight/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: preflight
 description: "Load to run, tune, or debug preflight."
+summary: "Diff-scoped deterministic pre-review checks: shell parse and shellcheck errors, fail-open bash, unwired test suites, untrapped scratch dirs, dead path citations, TODO markers, bot attributions, malformed JSON, TOML, and workflows."
 license: MIT
 user-invocable: true
 metadata:

--- a/.agents/skills/price-handling/SKILL.md
+++ b/.agents/skills/price-handling/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: price-handling
 description: "Load when comparing, rounding, formatting, or parsing prices, or designing price types."
+summary: "f64 price patterns for trading systems: comparing prices, rounding to tick size, formatting for display and broker APIs, parsing market feeds, designing price types."
 license: MIT
 user-invocable: true
 metadata:

--- a/.agents/skills/project-management/SKILL.md
+++ b/.agents/skills/project-management/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: project-management
 description: "Load to plan a cycle, audit issues, build a roadmap, or decompose research into issues."
+summary: "TPM planning, audit, roadmap, and research-driven decomposition: the cycle-plan, audit-issues, roadmap and research wrappers and the TPM workflows under them."
 license: MIT
 user-invocable: true
 dependencies:

--- a/.agents/skills/review-gate/SKILL.md
+++ b/.agents/skills/review-gate/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: review-gate
 description: "Load to wire, adopt, tune, or debug a repo's review gate or its REVIEW_GATE_* settings."
+summary: "Org-wide PR review gate: one predicate answers whether this exact head is reviewed, one writer posts the answer as a merge-blocking commit status."
 license: MIT
 user-invocable: true
 metadata:

--- a/.agents/skills/reviewer/SKILL.md
+++ b/.agents/skills/reviewer/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: reviewer
 description: "Load when reviewing a diff, classifying findings, or returning a verdict."
+summary: "Strict review and QA workflows: reviewer ethos, code-review classification, the finding JSON schema, and the QA-label lifecycle."
 license: MIT
 user-invocable: true
 dependencies:

--- a/.agents/skills/second-opinion/SKILL.md
+++ b/.agents/skills/second-opinion/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: second-opinion
 description: "Load for a cross-model review, challenge, audit, or quick consult."
+summary: "Cross-model second opinion: review, challenge, audit, and consult through an external AI CLI (Claude and Codex)."
 license: MIT
 user-invocable: true
 argument-hint: "review [scope] | challenge [description] | audit [path] | quick [question]"

--- a/.agents/skills/size-ratchet/SKILL.md
+++ b/.agents/skills/size-ratchet/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: size-ratchet
 description: "Load to add, tune, or debug the size ratchet, its baseline, or SIZE_RATCHET_* settings."
+summary: "Tighten-only file-size gate: tracked files over their threshold are frozen in a baseline TSV that only moves down."
 license: MIT
 user-invocable: true
 metadata:

--- a/.agents/skills/worktree/SKILL.md
+++ b/.agents/skills/worktree/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: worktree
 description: "Load to create, list, remove, push, or repair a git worktree."
+summary: "Git worktree management: create, list, remove isolated working copies with env and config symlinks."
 license: MIT
 user-invocable: true
 argument-hint: "create <ID> [--base <branch>] [--from <ref>] [--pr <N>] [--reuse|--restack|--recover-local] [--replay] | restack continue|skip|abort <ID|path> | list | remove <ID|path>"

--- a/.kendex-local/skills/app-deploy/SKILL.md
+++ b/.kendex-local/skills/app-deploy/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: app-deploy
 description: "Load when asked to cut, ship, or release a kendex version."
+summary: "Releases a kendex version: bumps versions, finalizes the changelog, tags per docs/RELEASING.md."
 ---
 
 # Release kendex

--- a/.kendex-local/skills/kendex-issues/SKILL.md
+++ b/.kendex-local/skills/kendex-issues/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: kendex-issues
 description: "Load to monitor kendex's issue queue continuously or to run one fix-and-propagate cycle."
+summary: "Stewards the kendex issue queue on a self-paced loop: watches open PRs, polls Linear, triages, fixes defects through orch, merges, propagates with kendex refresh."
 ---
 
 # kendex Issue Steward

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ an outside contributor.
 
 ### Added
 
+- A package header may carry `summary`, the line the Packages tab shows and
+  searches and `kendex index` exports beside `description`; without one the
+  description stands in. Every kendex skill now has one.
 - A package that changes the repository beyond kendex's own folders says so
   at install and waits for its own yes, good for that run alone. Declining
   installs it unarmed; no terminal declines unless `--allow-repo-effects`.

--- a/crates/cli/src/commands/marketplace_browse.rs
+++ b/crates/cli/src/commands/marketplace_browse.rs
@@ -70,12 +70,12 @@ pub fn run_browse(
         return Ok(());
     }
     for (scope, marketplace, package) in rows {
-        let description = package
-            .description
-            .map(|d| format!("  — {d}"))
+        let summary = package
+            .summary
+            .map(|text| format!("  — {text}"))
             .unwrap_or_default();
         out(&format!(
-            "{}  {marketplace}::{}  ({}) [{}]{description}",
+            "{}  {marketplace}::{}  ({}) [{}]{summary}",
             scope.label(),
             package.name,
             package.kind.name(),

--- a/crates/cli/tests/index_cli.rs
+++ b/crates/cli/tests/index_cli.rs
@@ -54,7 +54,11 @@ fn a_discovered_layout_indexes_with_descriptions_and_tags() {
     let tmp = tempfile::tempdir().unwrap();
     let root = tmp.path().join("tools");
     fs::create_dir_all(&root).unwrap();
-    skill(&root, "gh", "tags: [git]\n");
+    skill(
+        &root,
+        "gh",
+        "tags: [git]\nsummary: Work with GitHub from the terminal\n",
+    );
     skill(&root, "deploy", "");
 
     let json = index_json(tmp.path(), &root);
@@ -68,7 +72,11 @@ fn a_discovered_layout_indexes_with_descriptions_and_tags() {
     let gh = packages.iter().find(|p| p["name"] == "gh").unwrap();
     assert_eq!(gh["kind"], "skill");
     assert_eq!(gh["description"], "about gh");
+    assert_eq!(gh["summary"], "Work with GitHub from the terminal");
     assert_eq!(gh["tags"], serde_json::json!(["git"]));
+    // A package without a summary is listed by its description, never blank.
+    let deploy = packages.iter().find(|p| p["name"] == "deploy").unwrap();
+    assert_eq!(deploy["summary"], "about deploy");
     assert!(gh["safety"]["score"].as_u64().unwrap() <= 100);
     let found = json["found"].as_array().unwrap();
     assert!(

--- a/crates/cli/tests/marketplace_cli.rs
+++ b/crates/cli/tests/marketplace_cli.rs
@@ -32,7 +32,7 @@ fn fixture_home() -> tempfile::TempDir {
     fs::create_dir_all(home.join("catalog/skills/gh")).unwrap();
     fs::write(
         home.join("catalog/skills/gh/SKILL.md"),
-        "---\nname: gh\n---\nBody.\n",
+        "---\nname: gh\nsummary: Work with GitHub from the terminal\n---\nBody.\n",
     )
     .unwrap();
     fs::create_dir_all(home.join("catalog/agents")).unwrap();
@@ -158,6 +158,20 @@ fn marketplace_browse_lists_a_subscriptions_packages() {
         .collect();
     assert!(names.contains(&"gh"), "{listed:#}");
     assert!(names.contains(&"helper"), "{listed:#}");
+
+    // The text listing shows each package's summary beside its name, the
+    // same line the app's Packages row shows.
+    let text = kendex(
+        home,
+        &project,
+        &["marketplace", "browse", "cat", "--scope", "project"],
+    );
+    assert!(text.status.success());
+    let stdout = String::from_utf8_lossy(&text.stdout);
+    assert!(
+        stdout.contains("cat::gh  (skill) [available]  — Work with GitHub from the terminal"),
+        "{stdout}"
+    );
 
     // The community directory is not built yet and says so instead of
     // pretending it is empty.

--- a/crates/core/src/scan/metadata.rs
+++ b/crates/core/src/scan/metadata.rs
@@ -150,20 +150,18 @@ pub fn from_markdown(text: &str) -> Metadata {
     let Ok(parsed) = frontmatter::parse_tolerant(yaml) else {
         return Metadata::default();
     };
+    let prose = |key: &str| {
+        parsed
+            .map
+            .get(key)
+            .and_then(Value::as_str)
+            .map(str::to_owned)
+    };
     from_words(
-        prose(&parsed.map, "description"),
-        prose(&parsed.map, "summary"),
+        prose("description"),
+        prose("summary"),
         parsed.map.string_list("tags").unwrap_or_default(),
     )
-}
-
-/// One prose field, trimmed; blank is the same as absent.
-fn prose(map: &frontmatter::Map, key: &str) -> Option<String> {
-    map.get(key)
-        .and_then(Value::as_str)
-        .map(str::trim)
-        .filter(|text| !text.is_empty())
-        .map(str::to_owned)
 }
 
 /// Like [`from_markdown`], for the TOML kinds.
@@ -191,12 +189,15 @@ pub fn from_toml(text: &str) -> Metadata {
 }
 
 /// Sorts and dedupes so two files listing the same tags in different orders
-/// describe themselves identically.
+/// describe themselves identically, and trims the prose fields so a blank
+/// one is absent, whichever header format wrote it.
 fn from_words(
     description: Option<String>,
     summary: Option<String>,
     words: Vec<String>,
 ) -> Metadata {
+    let description = description.as_deref().and_then(prose);
+    let summary = summary.as_deref().and_then(prose);
     let mut tags: Vec<Tag> = Vec::new();
     let mut unknown_tags: Vec<String> = Vec::new();
     for word in words {
@@ -227,6 +228,12 @@ fn from_words(
         tags,
         unknown_tags,
     }
+}
+
+/// One prose field, trimmed; blank is the same as absent.
+fn prose(text: &str) -> Option<String> {
+    let text = text.trim();
+    (!text.is_empty()).then(|| text.to_owned())
 }
 
 #[cfg(test)]

--- a/crates/core/src/scan/metadata.rs
+++ b/crates/core/src/scan/metadata.rs
@@ -1,5 +1,5 @@
-//! What an item says about itself in its own header: a description, and the
-//! tags naming what it is for.
+//! What an item says about itself in its own header: a description, a
+//! summary, and the tags naming what it is for.
 //!
 //! The reading is `crate::frontmatter`'s job, not this module's. A header is
 //! YAML, and YAML has comments, block sequences, quoting and folded scalars
@@ -19,7 +19,11 @@ const HEADER_BYTES: usize = 64 * 1024;
 /// The header of one item.
 #[derive(Debug, Clone, Default, PartialEq, Eq)]
 pub struct Metadata {
+    /// The line an agent reads to decide whether to load the item.
     pub description: Option<String>,
+    /// The line a marketplace row shows and search reads: what the item
+    /// does, written for a person browsing.
+    pub summary: Option<String>,
     /// Recognised tags, deduped, in vocabulary order.
     pub tags: Vec<Tag>,
     /// Words written where a tag belonged that are not tags.
@@ -27,6 +31,13 @@ pub struct Metadata {
 }
 
 impl Metadata {
+    /// What a marketplace row says about the item. A package that writes no
+    /// summary is shown its description: the load trigger says less than a
+    /// summary would, and more than a blank row.
+    pub fn summary_or_description(&self) -> Option<&str> {
+        self.summary.as_deref().or(self.description.as_deref())
+    }
+
     /// One line naming what could not be understood and the nearest thing
     /// that would have worked. `None` when everything parsed.
     ///
@@ -139,17 +150,20 @@ pub fn from_markdown(text: &str) -> Metadata {
     let Ok(parsed) = frontmatter::parse_tolerant(yaml) else {
         return Metadata::default();
     };
-    let description = parsed
-        .map
-        .get("description")
+    from_words(
+        prose(&parsed.map, "description"),
+        prose(&parsed.map, "summary"),
+        parsed.map.string_list("tags").unwrap_or_default(),
+    )
+}
+
+/// One prose field, trimmed; blank is the same as absent.
+fn prose(map: &frontmatter::Map, key: &str) -> Option<String> {
+    map.get(key)
         .and_then(Value::as_str)
         .map(str::trim)
         .filter(|text| !text.is_empty())
-        .map(str::to_owned);
-    from_words(
-        description,
-        parsed.map.string_list("tags").unwrap_or_default(),
-    )
+        .map(str::to_owned)
 }
 
 /// Like [`from_markdown`], for the TOML kinds.
@@ -167,18 +181,22 @@ pub fn from_toml(text: &str) -> Metadata {
                 .collect()
         })
         .unwrap_or_default();
-    from_words(
+    let prose = |key: &str| {
         table
-            .get("description")
-            .and_then(|d| d.as_str())
-            .map(str::to_owned),
-        words,
-    )
+            .get(key)
+            .and_then(|value| value.as_str())
+            .map(str::to_owned)
+    };
+    from_words(prose("description"), prose("summary"), words)
 }
 
 /// Sorts and dedupes so two files listing the same tags in different orders
 /// describe themselves identically.
-fn from_words(description: Option<String>, words: Vec<String>) -> Metadata {
+fn from_words(
+    description: Option<String>,
+    summary: Option<String>,
+    words: Vec<String>,
+) -> Metadata {
     let mut tags: Vec<Tag> = Vec::new();
     let mut unknown_tags: Vec<String> = Vec::new();
     for word in words {
@@ -205,6 +223,7 @@ fn from_words(description: Option<String>, words: Vec<String>) -> Metadata {
     });
     Metadata {
         description,
+        summary,
         tags,
         unknown_tags,
     }

--- a/crates/core/src/scan/metadata/tests.rs
+++ b/crates/core/src/scan/metadata/tests.rs
@@ -43,6 +43,11 @@ fn a_summary_is_read_beside_the_description_and_stands_in_for_it() {
         from_toml("command = \"db\"\n").summary_or_description(),
         None
     );
+    // A blank summary in TOML is absent too, the same rule as the markdown
+    // header, so the row falls back to the description.
+    let blank = from_toml("description = \"a db\"\nsummary = \"  \"\n");
+    assert_eq!(blank.summary, None);
+    assert_eq!(blank.summary_or_description(), Some("a db"));
 }
 
 #[test]

--- a/crates/core/src/scan/metadata/tests.rs
+++ b/crates/core/src/scan/metadata/tests.rs
@@ -12,6 +12,39 @@ fn reads_a_description_and_an_inline_tag_list() {
     assert_eq!(meta.tags, vec![Tag::Review, Tag::Testing]);
 }
 
+/// The summary is the marketplace's line and the description the agent's;
+/// a package that writes only the description is shown that one.
+#[test]
+fn a_summary_is_read_beside_the_description_and_stands_in_for_it() {
+    let both = frontmatter(
+        "description: Load to run preflight.\nsummary: Diff-scoped shellcheck and TOML checks.",
+    );
+    assert_eq!(
+        both.summary.as_deref(),
+        Some("Diff-scoped shellcheck and TOML checks.")
+    );
+    assert_eq!(
+        both.summary_or_description(),
+        Some("Diff-scoped shellcheck and TOML checks.")
+    );
+
+    let only = frontmatter("description: Load to run preflight.\nsummary: \"  \"");
+    assert_eq!(only.summary, None);
+    assert_eq!(
+        only.summary_or_description(),
+        Some("Load to run preflight.")
+    );
+
+    let toml = from_toml(
+        "description = \"a db\"\nsummary = \"Query the app database\"\ncommand = \"db\"\n",
+    );
+    assert_eq!(toml.summary.as_deref(), Some("Query the app database"));
+    assert_eq!(
+        from_toml("command = \"db\"\n").summary_or_description(),
+        None
+    );
+}
+
 #[test]
 fn reads_a_block_tag_list() {
     let meta = frontmatter("tags:\n  - review\n  - security");

--- a/crates/core/src/source/browse.rs
+++ b/crates/core/src/source/browse.rs
@@ -58,6 +58,9 @@ pub struct AvailablePackage {
     pub kind: ItemKind,
     pub name: String,
     pub description: Option<String>,
+    /// What the row shows and search reads: the header's `summary`, else
+    /// its `description`.
+    pub summary: Option<String>,
     pub tags: Vec<Tag>,
     /// The curated sets of this catalog that carry it.
     pub bundles: Vec<String>,
@@ -117,6 +120,7 @@ pub fn packages(env: &Env, catalog: &Catalog) -> Result<Vec<AvailablePackage>> {
                 state: browsed.state(kind, &name),
                 collision: browsed.collision(kind, &name),
                 description: header.description.as_deref().map(names::shown),
+                summary: header.summary_or_description().map(names::shown),
                 tags: header.tags,
                 bundles,
                 kind,
@@ -177,8 +181,9 @@ pub fn bundle(env: &Env, catalog: &Catalog, bundle_name: &str) -> Result<BundleD
     })
 }
 
-/// The description and tags an item writes in its own header, read through
-/// the sealed source with the same vocabulary reading the scanner uses.
+/// The description, summary and tags an item writes in its own header, read
+/// through the sealed source with the same vocabulary reading the scanner
+/// uses.
 fn item_header(browsed: &Browsed, kind: ItemKind, name: &str) -> crate::scan::metadata::Metadata {
     let Some(path) = super::find_item(&browsed.sealed, &browsed.config, kind, name) else {
         return Default::default();

--- a/crates/core/src/source/browse/tests.rs
+++ b/crates/core/src/source/browse/tests.rs
@@ -94,10 +94,38 @@ fn packages_listed_for_a_plain_discovered_marketplace() {
     let gh = rows.iter().find(|row| row.name == "gh").expect("gh listed");
     assert_eq!(gh.kind, ItemKind::Skill);
     assert_eq!(gh.description.as_deref(), Some("does gh things"));
+    assert_eq!(gh.summary.as_deref(), Some("does gh things"));
     assert_eq!(gh.tags, vec![Tag::Review]);
     assert_eq!(gh.state, InstallState::Available);
     assert_eq!(gh.collision, None);
     assert!(rows.iter().any(|row| row.name == "extra"));
+}
+
+/// The Packages row shows the summary when the header writes one and the
+/// description when it does not.
+#[test]
+fn a_package_row_reads_the_summary_over_the_description() {
+    let tmp = tempfile::tempdir().unwrap();
+    let catalog = tmp.path().join("catalog");
+    let dir = catalog.join("skills/gh");
+    fs::create_dir_all(&dir).unwrap();
+    fs::write(
+        dir.join("SKILL.md"),
+        "---\nname: gh\ndescription: Load to work a pull request.\nsummary: Threads, reviews, CI logs, merges.\n---\nbody\n",
+    )
+    .unwrap();
+    let (env, scope) = project(tmp.path(), &sources_decl(&catalog));
+
+    let rows = packages(&env, &cat(&scope)).unwrap();
+    let gh = rows.iter().find(|row| row.name == "gh").unwrap();
+    assert_eq!(
+        gh.description.as_deref(),
+        Some("Load to work a pull request.")
+    );
+    assert_eq!(
+        gh.summary.as_deref(),
+        Some("Threads, reviews, CI logs, merges.")
+    );
 }
 
 #[test]

--- a/crates/core/src/source/index.rs
+++ b/crates/core/src/source/index.rs
@@ -13,6 +13,7 @@ use serde::Serialize;
 use crate::check_catalog;
 use crate::error::Result;
 use crate::model::ItemKind;
+use crate::scan::metadata::Metadata;
 use crate::source_read::SealedSource;
 use crate::tags::Tag;
 
@@ -62,6 +63,9 @@ pub struct IndexPackage {
     pub kind: &'static str,
     pub name: String,
     pub description: Option<String>,
+    /// What a directory row shows: the header's `summary`, else its
+    /// `description`.
+    pub summary: Option<String>,
     pub tags: Vec<Tag>,
     pub safety: IndexSafety,
 }
@@ -127,12 +131,18 @@ pub fn index(sealed: &SealedSource, display: &str) -> Result<MarketplaceIndex> {
     let mut packages = Vec::new();
     for item in &report.items {
         let path = sealed.root().join(&item.file);
-        let (description, tags) = describe(sealed, item.kind, &path)?;
+        let header = header(sealed, item.kind, &path)?;
         packages.push(IndexPackage {
             kind: item.kind.name(),
             name: safe_text(&item.name, MAX_TEXT),
-            description,
-            tags,
+            description: header
+                .description
+                .as_deref()
+                .map(|text| safe_text(text, MAX_DESCRIPTION)),
+            summary: header
+                .summary_or_description()
+                .map(|text| safe_text(text, MAX_DESCRIPTION)),
+            tags: header.tags,
             safety: IndexSafety {
                 score: item.advisory.safety.score,
             },
@@ -189,31 +199,21 @@ fn bundle_rows(sealed: &SealedSource, config: &super::SourceConfig) -> Result<Ve
         .collect())
 }
 
-/// What the item says about itself: a description and the tags its header
-/// carries. Read through the sealed source, decoded lossily — a header is
-/// worth reading even beside one bad byte, and the safety pass has already
-/// reported that byte.
-fn describe(
-    sealed: &SealedSource,
-    kind: ItemKind,
-    path: &std::path::Path,
-) -> Result<(Option<String>, Vec<Tag>)> {
+/// What the item says about itself in its own header. Read through the
+/// sealed source, decoded lossily — a header is worth reading even beside
+/// one bad byte, and the safety pass has already reported that byte.
+fn header(sealed: &SealedSource, kind: ItemKind, path: &std::path::Path) -> Result<Metadata> {
     let file = match kind {
         ItemKind::Skill => path.join("SKILL.md"),
         ItemKind::Agent | ItemKind::Command | ItemKind::McpServer => path.to_path_buf(),
-        _ => return Ok((None, Vec::new())),
+        _ => return Ok(Metadata::default()),
     };
     if !sealed.is_file(&file) {
-        return Ok((None, Vec::new()));
+        return Ok(Metadata::default());
     }
     let text = String::from_utf8_lossy(&sealed.read(&file)?).into_owned();
-    let meta = match kind {
+    Ok(match kind {
         ItemKind::McpServer => crate::scan::metadata::from_toml(&text),
         _ => crate::scan::metadata::from_markdown(&text),
-    };
-    Ok((
-        meta.description
-            .map(|text| safe_text(&text, MAX_DESCRIPTION)),
-        meta.tags,
-    ))
+    })
 }

--- a/crates/core/src/source/index.rs
+++ b/crates/core/src/source/index.rs
@@ -63,8 +63,8 @@ pub struct IndexPackage {
     pub kind: &'static str,
     pub name: String,
     pub description: Option<String>,
-    /// What a directory row shows: the header's `summary`, else its
-    /// `description`.
+    /// The header's `summary`, else its `description`, so a consumer reads
+    /// one field for the line beside the name.
     pub summary: Option<String>,
     pub tags: Vec<Tag>,
     pub safety: IndexSafety,

--- a/docs/authoring/README.md
+++ b/docs/authoring/README.md
@@ -75,6 +75,10 @@ catalog.
 
 - Skill: `skills/<name>/SKILL.md` with frontmatter `name` (matching the folder)
   and `description`. Extra files in the folder ship with it.
+- Any kind with a header may add `summary`: the line a marketplace row shows
+  and search reads. `description` is what an agent reads to decide whether to
+  load the item; the two read differently. Without a `summary` the row shows
+  the `description`.
 - Agent: `agents/<name>.md` with frontmatter `name` and `description`; optional
   `model`, `color`, and tool allow and deny lists.
 - Hook: `hooks/<name>.sh` with a comment header naming `event` (for example

--- a/docs/authoring/README.md
+++ b/docs/authoring/README.md
@@ -75,10 +75,9 @@ catalog.
 
 - Skill: `skills/<name>/SKILL.md` with frontmatter `name` (matching the folder)
   and `description`. Extra files in the folder ship with it.
-- Any kind with a header may add `summary`: the line a marketplace row shows
-  and search reads. `description` is what an agent reads to decide whether to
-  load the item; the two read differently. Without a `summary` the row shows
-  the `description`.
+- A skill, command, or MCP server may add `summary`: the line a marketplace
+  row shows and search reads, where `description` is what an agent reads to
+  decide whether to load the item. Without one the row shows the `description`.
 - Agent: `agents/<name>.md` with frontmatter `name` and `description`; optional
   `model`, `color`, and tool allow and deny lists.
 - Hook: `hooks/<name>.sh` with a comment header naming `event` (for example

--- a/docs/authoring/templates/SKILL.md
+++ b/docs/authoring/templates/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: my-skill
-description: What this skill does and when to use it. Agents read this line to decide when to load the skill, so be specific.
+description: When to load this skill. Agents read this line to decide whether to load it, so be specific.
+summary: What this skill does. Marketplace rows show this line and search reads it.
 license: MIT
 metadata:
   author: your-name

--- a/skills/code-quality/SKILL.md
+++ b/skills/code-quality/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: code-quality
 description: "Load before writing or modifying code."
+summary: "Code-authoring standards for dev agents: correctness over convenience, no fail-open branches, comment rules, over-engineering limits, prove-your-guards."
 license: MIT
 user-invocable: true
 metadata:

--- a/skills/decider/SKILL.md
+++ b/skills/decider/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: decider
 description: "Load to create, search, or supersede an architecture decision record."
+summary: "Architecture decision records: templates, creation, search, supersession tracking, and INDEX maintenance."
 license: MIT
 user-invocable: true
 metadata:

--- a/skills/deep-research/SKILL.md
+++ b/skills/deep-research/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: deep-research
 description: "Load for research tasks, architectural investigations, and vendor, library, or technology comparisons."
+summary: "Exa-powered deep research that produces an evidence-backed findings.md report."
 license: MIT
 user-invocable: true
 argument-hint: "report [query] --output findings.md"

--- a/skills/dep-radar/SKILL.md
+++ b/skills/dep-radar/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: dep-radar
 description: "Load to run or tune a dependency sweep."
+summary: "Sweeps every pinned version in the repo (deps, SDKs, vendored forks, model weights), checks upstream, and lands upgrades with their fallout in one PR per surface."
 license: MIT
 user-invocable: true
 dependencies:

--- a/skills/dev/SKILL.md
+++ b/skills/dev/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: dev
 description: "Load when implementing an issue or applying review fixes as a dev agent."
+summary: "Dev-agent workflows for implementing an issue and applying review fixes, invoked by orch or specialist agents."
 license: MIT
 user-invocable: true
 dependencies:

--- a/skills/github/SKILL.md
+++ b/skills/github/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: github
 description: "Load to work a GitHub pull request: threads, comments, reviews, CI logs, merges."
+summary: "GitHub API CLI for pull requests: threads, comments, reviews, CI logs, merging, and cross-PR analysis."
 license: MIT
 user-invocable: true
 metadata:

--- a/skills/growth-guards/SKILL.md
+++ b/skills/growth-guards/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: growth-guards
 description: "Load to add, tune, or debug a repo growth guard, its git hooks, or GROWTH_GUARDS_* settings."
+summary: "Five repo growth guards beside size-ratchet (todo-ban, byte-ceiling, suppression-ban, conflict-markers, commit-msg) and the git hook shims that run them."
 license: MIT
 user-invocable: true
 metadata:

--- a/skills/harness-ci/SKILL.md
+++ b/skills/harness-ci/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: harness-ci
 description: "Load to wire, tune, or debug a repo's harness-only skip."
+summary: "Classifies a CI diff as harness-only, every changed path under a kendex render tree, so heavy lanes can stand down; ships the classifier script and its tests."
 license: MIT
 user-invocable: true
 metadata:

--- a/skills/iced-rs/SKILL.md
+++ b/skills/iced-rs/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: iced-rs
 description: "Load whenever building or debugging an Iced UI."
+summary: "Iced 0.14 GUI reference: custom widgets via iced::advanced, overlays, Canvas, Shader, pane_grid, theming, subscriptions, Elm architecture, with a bundled full-API reference."
 license: MIT
 user-invocable: true
 metadata:

--- a/skills/linear/SKILL.md
+++ b/skills/linear/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: linear
 description: "Load for any Linear read or write: issues, projects, cycles, milestones, initiatives, labels."
+summary: "Bash CLI over Linear's GraphQL API with a local cache: read, search, create, or update issues, projects, cycles, milestones, initiatives, and labels."
 license: MIT
 user-invocable: true
 metadata:

--- a/skills/orch/SKILL.md
+++ b/skills/orch/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: orch
 description: "PRIMARY AGENT ONLY. Load to orchestrate a Linear or GitHub work item from preparation through merge."
+summary: "Work-item orchestration for Linear or GitHub issues: prepare, delegate implementation, review, submit, merge, hand off, and oversee fleets of sessions."
 license: MIT
 user-invocable: true
 dependencies:

--- a/skills/preflight/SKILL.md
+++ b/skills/preflight/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: preflight
 description: "Load to run, tune, or debug preflight."
+summary: "Diff-scoped deterministic pre-review checks: shell parse and shellcheck errors, fail-open bash, unwired test suites, untrapped scratch dirs, dead path citations, TODO markers, bot attributions, malformed JSON, TOML, and workflows."
 license: MIT
 user-invocable: true
 metadata:

--- a/skills/price-handling/SKILL.md
+++ b/skills/price-handling/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: price-handling
 description: "Load when comparing, rounding, formatting, or parsing prices, or designing price types."
+summary: "f64 price patterns for trading systems: comparing prices, rounding to tick size, formatting for display and broker APIs, parsing market feeds, designing price types."
 license: MIT
 user-invocable: true
 metadata:

--- a/skills/project-management/SKILL.md
+++ b/skills/project-management/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: project-management
 description: "Load to plan a cycle, audit issues, build a roadmap, or decompose research into issues."
+summary: "TPM planning, audit, roadmap, and research-driven decomposition: the cycle-plan, audit-issues, roadmap and research wrappers and the TPM workflows under them."
 license: MIT
 user-invocable: true
 dependencies:

--- a/skills/review-gate/SKILL.md
+++ b/skills/review-gate/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: review-gate
 description: "Load to wire, adopt, tune, or debug a repo's review gate or its REVIEW_GATE_* settings."
+summary: "Org-wide PR review gate: one predicate answers whether this exact head is reviewed, one writer posts the answer as a merge-blocking commit status."
 license: MIT
 user-invocable: true
 metadata:

--- a/skills/reviewer/SKILL.md
+++ b/skills/reviewer/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: reviewer
 description: "Load when reviewing a diff, classifying findings, or returning a verdict."
+summary: "Strict review and QA workflows: reviewer ethos, code-review classification, the finding JSON schema, and the QA-label lifecycle."
 license: MIT
 user-invocable: true
 dependencies:

--- a/skills/second-opinion/SKILL.md
+++ b/skills/second-opinion/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: second-opinion
 description: "Load for a cross-model review, challenge, audit, or quick consult."
+summary: "Cross-model second opinion: review, challenge, audit, and consult through an external AI CLI (Claude and Codex)."
 license: MIT
 user-invocable: true
 argument-hint: "review [scope] | challenge [description] | audit [path] | quick [question]"

--- a/skills/size-ratchet/SKILL.md
+++ b/skills/size-ratchet/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: size-ratchet
 description: "Load to add, tune, or debug the size ratchet, its baseline, or SIZE_RATCHET_* settings."
+summary: "Tighten-only file-size gate: tracked files over their threshold are frozen in a baseline TSV that only moves down."
 license: MIT
 user-invocable: true
 metadata:

--- a/skills/worktree/SKILL.md
+++ b/skills/worktree/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: worktree
 description: "Load to create, list, remove, push, or repair a git worktree."
+summary: "Git worktree management: create, list, remove isolated working copies with env and config symlinks."
 license: MIT
 user-invocable: true
 argument-hint: "create <ID> [--base <branch>] [--from <ref>] [--pr <N>] [--reuse|--restack|--recover-local] [--replay] | restack continue|skip|abort <ID|path> | list | remove <ID|path>"

--- a/ui/src/bindings.ts
+++ b/ui/src/bindings.ts
@@ -526,6 +526,11 @@ export type AvailablePackage = {
 	kind: ItemKind,
 	name: string,
 	description: string | null,
+	/**
+	 *  What the row shows and search reads: the header's `summary`, else
+	 *  its `description`.
+	 */
+	summary: string | null,
 	tags: Tag[],
 	/**  The curated sets of this catalog that carry it. */
 	bundles: string[],

--- a/ui/src/components/marketplaces/packages-tab.test.tsx
+++ b/ui/src/components/marketplaces/packages-tab.test.tsx
@@ -1,0 +1,93 @@
+// @vitest-environment jsdom
+import userEvent from "@testing-library/user-event";
+import { beforeEach, describe, expect, it } from "vitest";
+import type { AvailablePackage, MarketplaceRow } from "@/bindings";
+import { marketKey, useMarketplacesStore } from "@/stores/marketplaces";
+import { usePreinstallSafety } from "@/stores/preinstall-safety";
+import { mount } from "@/test/dom";
+import { PackagesTab } from "./packages-tab";
+
+const kit: MarketplaceRow = {
+  scope: { scope: "global" },
+  name: "kit",
+  repo: "Acme/Kit",
+  repoKey: "acme/kit",
+  path: null,
+  rev: null,
+  commit: null,
+  enabled: true,
+  counts: null,
+  meta: null,
+  mode: null,
+};
+
+const skill = (
+  name: string,
+  description: string,
+  summary: string,
+): AvailablePackage => ({
+  kind: "skill",
+  name,
+  description,
+  summary,
+  tags: [],
+  bundles: [],
+  state: "available",
+  collision: null,
+});
+
+// The description is the agent's load trigger, so a word found there and
+// nowhere else is one a person browsing never typed for.
+const offered = [
+  skill(
+    "preflight",
+    "Load to run, tune, or debug preflight.",
+    "Diff-scoped shellcheck and TOML checks.",
+  ),
+  skill(
+    "worktree",
+    "Load to create or repair a git worktree.",
+    "Isolated working copies with config symlinks.",
+  ),
+];
+
+beforeEach(() => {
+  useMarketplacesStore.setState({
+    rows: [kit],
+    packages: { [marketKey(kit.scope, kit.name)]: offered },
+    readErrors: {},
+    loadPackages: async () => {},
+  });
+  // A mounted row asks for its safety score, and no backend answers here.
+  usePreinstallSafety.setState({ want: () => {} });
+});
+
+const listed = async (needle: string): Promise<string[]> => {
+  const host = mount(<PackagesTab />);
+  const input = host.querySelector<HTMLInputElement>(
+    'input[placeholder="Search packages"]',
+  );
+  if (!input) throw new Error("no search input rendered");
+  if (needle) await userEvent.type(input, needle);
+  return [...host.querySelectorAll("tbody tr")].map(
+    (row) => row.querySelector("td")?.textContent ?? "",
+  );
+};
+
+describe("searching the packages list", () => {
+  it("lists every package until something is typed", async () => {
+    const rows = await listed("");
+    expect(rows).toHaveLength(2);
+  });
+
+  it("matches a word from the summary", async () => {
+    const rows = await listed("shellcheck");
+    expect(rows).toHaveLength(1);
+    expect(rows[0]).toContain("preflight");
+  });
+
+  it("does not match a word found only in the description", async () => {
+    const rows = await listed("debug");
+    expect(rows).toHaveLength(0);
+  });
+});

--- a/ui/src/components/marketplaces/packages-tab.tsx
+++ b/ui/src/components/marketplaces/packages-tab.tsx
@@ -81,7 +81,7 @@ export function PackagesTab() {
         if (
           needle &&
           !pkg.name.toLowerCase().includes(needle) &&
-          !(pkg.description ?? "").toLowerCase().includes(needle)
+          !(pkg.summary ?? "").toLowerCase().includes(needle)
         )
           continue;
         out.push({ catalog: subscription(row.scope, row.name), row: pkg });

--- a/ui/src/components/marketplaces/packages-table.test.tsx
+++ b/ui/src/components/marketplaces/packages-table.test.tsx
@@ -43,6 +43,7 @@ const row: AvailablePackage = {
   kind: "skill",
   name: "gh",
   description: null,
+  summary: null,
   tags: [],
   bundles: [],
   state: "available",
@@ -84,6 +85,31 @@ const trigger = (html: string): string =>
   html.match(
     /<button[^>]*data-slot="tooltip-trigger"[^>]*>(.*?)<\/button>/,
   )?.[1] ?? "";
+
+// The description is the agent's load trigger; the row is for a person, so
+// it shows the summary and never the trigger beside it.
+describe("the line under the package name", () => {
+  it("is the summary, not the description", () => {
+    stub.scores = {};
+    const html = renderToStaticMarkup(
+      <PackagesTable
+        entries={[
+          {
+            catalog,
+            row: {
+              ...row,
+              description: "Load to work a pull request.",
+              summary: "Threads, reviews, CI logs, merges.",
+            },
+          },
+        ]}
+        showMarketplace={false}
+      />,
+    );
+    expect(html).toContain("Threads, reviews, CI logs, merges.");
+    expect(html).not.toContain("Load to work a pull request.");
+  });
+});
 
 describe("the safety dot in the packages list", () => {
   it("carries the caveat beside the number, since this row installs here", () => {

--- a/ui/src/components/marketplaces/packages-table.tsx
+++ b/ui/src/components/marketplaces/packages-table.tsx
@@ -111,9 +111,9 @@ function PackageRow({
             <div className="truncate font-medium">
               {packageDisplayName(row)}
             </div>
-            {row.description ? (
+            {row.summary ? (
               <div className="truncate text-xs text-muted-foreground">
-                {row.description}
+                {row.summary}
               </div>
             ) : null}
           </div>

--- a/ui/src/dev/fixture-marketplaces.ts
+++ b/ui/src/dev/fixture-marketplaces.ts
@@ -30,6 +30,7 @@ const packageList = (offered: Offered[], installed: string[]) =>
       kind: pkg.kind,
       name: pkg.name,
       description: pkg.description,
+      summary: pkg.description,
       tags: pkg.tags,
       bundles: pkg.bundles,
       state: installed.includes(`${pkg.kind} ${pkg.name}`)

--- a/ui/src/stores/marketplaces-reads.test.ts
+++ b/ui/src/stores/marketplaces-reads.test.ts
@@ -22,6 +22,7 @@ const offered = (name: string) => [
     kind: "skill" as const,
     name,
     description: null,
+    summary: null,
     tags: [],
     bundles: [],
     state: "available" as const,


### PR DESCRIPTION
## Summary
- A package header may carry `summary:`, read by the shared header parser for markdown and TOML kinds; a package without one is shown its `description`, resolved once in core (`Metadata::summary_or_description`).
- `kendex index` exports `summary` beside `description`; `AvailablePackage` carries it; the app's Packages tab and the CLI `marketplace browse` text row show it, and Packages search reads name and summary.
- Every kendex skill carries a summary; `.agents/` is the renderer's output (`kendex refresh`), so the orch render keeps the project-instructions block `kendex-local.toml` declares.

## Completed Issues
- Closes KEN-682 - Marketplace rows and search need a summary field of their own

## Test Plan
- `cargo test -p kendex-core` (scan::metadata, source::browse, source::index): summary read beside description for markdown and TOML, blank summary falls back to description, row reads summary over description.
- `cargo test -p kendex-cli --test index_cli --test marketplace_cli`: index exports `summary` with the description fallback; browse text row prints the summary.
- `vitest` `packages-table` and `packages-tab`: row shows summary; search matches a summary-only word, not a description-only word, and an empty needle lists every row.
- `tools/guard` green on eb9d6c1c (pre-rebase 12a44405).
