### PR TITLE
fix(KEN-649): the cd guard reads the whole command

### DIFF
--- a/.claude/hooks/block-bare-cd.sh
+++ b/.claude/hooks/block-bare-cd.sh
@@ -9,6 +9,14 @@
 
 set -euo pipefail
 
+# Every decision below is made by these tools, so a PATH without them would
+# no-op each check in turn and exit clean. Refuse before reading anything.
+if ! command -v cat >/dev/null 2>&1 || ! command -v grep >/dev/null 2>&1 \
+  || ! command -v sed >/dev/null 2>&1 || ! command -v head >/dev/null 2>&1; then
+  echo "block-bare-cd: text tools (cat/grep/sed/head) unavailable to read the payload; refusing rather than skipping the guard" >&2
+  exit 2
+fi
+
 INPUT=$(cat)
 
 # Decode the command the way the sibling guards do. The value carries JSON
@@ -24,8 +32,17 @@ if command -v jq >/dev/null 2>&1; then
   fi
 else
   # Escape-aware fallback: the value may carry \" and \\ inside it.
-  COMMAND=$(printf '%s' "$INPUT" | grep -o '"command"[[:space:]]*:[[:space:]]*"\([^"\\]\|\\.\)*"' | head -1 \
-    | sed 's/^"command"[[:space:]]*:[[:space:]]*"//;s/"$//;s/\\"/"/g;s/\\\\/\\/g' 2>/dev/null || true)
+  RAW=$(printf '%s' "$INPUT" | grep -o '"command"[[:space:]]*:[[:space:]]*"\([^"\\]\|\\.\)*"' | head -1 \
+    | sed 's/^"command"[[:space:]]*:[[:space:]]*"//;s/"$//' 2>/dev/null || true)
+  # Only \" and \\ are decoded here. A \t, \n, or \u escape would have to be
+  # interpreted before the command can be classified, and reading one wrong
+  # is a bare cd that passes, so such a payload is refused instead. jq, when
+  # it is there, decodes them all and never reaches this.
+  if printf '%s' "$RAW" | grep -q '\\[^"\\]'; then
+    echo "block-bare-cd: hook payload carries a JSON escape this fallback does not decode; refusing rather than skipping the guard" >&2
+    exit 2
+  fi
+  COMMAND=$(printf '%s' "$RAW" | sed 's/\\"/"/g;s/\\\\/\\/g')
   # Same fail-closed contract as the jq branch: a payload that names a
   # command the fallback could not decode is refused, not skipped. A
   # decoded-empty command ("command":"") still passes.
@@ -44,9 +61,12 @@ if ! echo "$COMMAND" | grep -qE 'cd([[:space:]]|$)'; then
 fi
 
 # Check for bare top-level cd (not in subshell or &&-chained with other work)
-# Simple heuristic: if the command is just "cd /path" with nothing else meaningful
+# Simple heuristic: if the command is just "cd /path" with nothing else
+# meaningful. Quoted text is an operand, not structure, so it is blanked
+# first — the `;` in `cd "a;b"` separates nothing.
 STRIPPED=$(echo "$COMMAND" | sed 's/^[[:space:]]*//')
-if echo "$STRIPPED" | grep -qE '^cd([[:space:]]+[^&|;]*)?$'; then
+MASKED=$(printf '%s' "$STRIPPED" | sed 's/"[^"]*"/Q/g' | sed "s/'[^']*'/Q/g")
+if echo "$MASKED" | grep -qE '^cd([[:space:]]+[^&|;]*)?$'; then
   echo "Bare 'cd' changes working directory permanently across tool calls." >&2
   echo "Use a subshell instead: (cd /path && command)" >&2
   exit 2

--- a/.claude/hooks/block-bare-cd.sh
+++ b/.claude/hooks/block-bare-cd.sh
@@ -9,49 +9,24 @@
 
 set -euo pipefail
 
-# Every decision below is made by these tools, so a PATH without them would
-# no-op each check in turn and exit clean. Refuse before reading anything.
-if ! command -v cat >/dev/null 2>&1 || ! command -v grep >/dev/null 2>&1 \
-  || ! command -v sed >/dev/null 2>&1 || ! command -v head >/dev/null 2>&1; then
-  echo "block-bare-cd: text tools (cat/grep/sed/head) unavailable to read the payload; refusing rather than skipping the guard" >&2
+# jq is the only reader of the payload, and grep and sed make every decision
+# after it. Without them the command cannot be read, and a command this hook
+# has not read cannot be shown to scope its directory change.
+if ! command -v jq >/dev/null 2>&1 || ! command -v cat >/dev/null 2>&1 \
+  || ! command -v grep >/dev/null 2>&1 || ! command -v sed >/dev/null 2>&1; then
+  echo "block-bare-cd: jq, cat, grep and sed are required to read the hook payload; refusing rather than skipping the guard" >&2
   exit 2
 fi
 
 INPUT=$(cat)
 
-# Decode the command the way the sibling guards do. The value carries JSON
-# escapes, and a parser that stops at the first quote truncates
-# `cd "$repo" && ls` to `cd \`, which the heuristic below then reads as a
-# bare cd and refuses — the opposite of what this hook is for.
-if command -v jq >/dev/null 2>&1; then
-  # A payload that does not parse is refused, not skipped: an unreadable
-  # command cannot be proven scoped, and this guard is fail-closed by design.
-  if ! COMMAND=$(printf '%s' "$INPUT" | jq -r '.tool_input.command // .command // empty' 2>/dev/null); then
-    echo "block-bare-cd: hook payload is not valid JSON; refusing rather than skipping the guard" >&2
-    exit 2
-  fi
-else
-  # Escape-aware fallback: the value may carry \" and \\ inside it.
-  RAW=$(printf '%s' "$INPUT" | grep -o '"command"[[:space:]]*:[[:space:]]*"\([^"\\]\|\\.\)*"' | head -1 \
-    | sed 's/^"command"[[:space:]]*:[[:space:]]*"//;s/"$//' 2>/dev/null || true)
-  # Only \" and \\ are decoded here. A \t, \n, or \u escape would have to be
-  # interpreted before the command can be classified, and reading one wrong
-  # is a bare cd that passes, so such a payload is refused instead. jq, when
-  # it is there, decodes them all and never reaches this.
-  if printf '%s' "$RAW" | grep -q '\\[^"\\]'; then
-    echo "block-bare-cd: hook payload carries a JSON escape this fallback does not decode; refusing rather than skipping the guard" >&2
-    exit 2
-  fi
-  COMMAND=$(printf '%s' "$RAW" | sed 's/\\"/"/g;s/\\\\/\\/g')
-  # Same fail-closed contract as the jq branch: a payload that names a
-  # command the fallback could not decode is refused, not skipped. A
-  # decoded-empty command ("command":"") still passes.
-  if [ -z "$COMMAND" ] \
-    && printf '%s' "$INPUT" | grep -q '"command"' \
-    && ! printf '%s' "$INPUT" | grep -Eq '"command"[[:space:]]*:[[:space:]]*""'; then
-    echo "block-bare-cd: could not decode the command from the hook payload; refusing rather than skipping the guard" >&2
-    exit 2
-  fi
+# A payload that does not parse, or that names a command which is not a
+# string, is refused rather than skipped. An absent command is the empty
+# string and passes.
+if ! COMMAND=$(printf '%s' "$INPUT" \
+  | jq -r '(.tool_input.command // .command // "") | if type == "string" then . else error end' 2>/dev/null); then
+  echo "block-bare-cd: hook payload is not valid JSON, or names a command that is not a string; refusing rather than skipping the guard" >&2
+  exit 2
 fi
 
 # Fast exit if no cd in command. A bare `cd` goes to $HOME, the change this
@@ -61,12 +36,9 @@ if ! echo "$COMMAND" | grep -qE 'cd([[:space:]]|$)'; then
 fi
 
 # Check for bare top-level cd (not in subshell or &&-chained with other work)
-# Simple heuristic: if the command is just "cd /path" with nothing else
-# meaningful. Quoted text is an operand, not structure, so it is blanked
-# first — the `;` in `cd "a;b"` separates nothing.
+# Simple heuristic: if the command is just "cd /path" with nothing else meaningful
 STRIPPED=$(echo "$COMMAND" | sed 's/^[[:space:]]*//')
-MASKED=$(printf '%s' "$STRIPPED" | sed 's/"[^"]*"/Q/g' | sed "s/'[^']*'/Q/g")
-if echo "$MASKED" | grep -qE '^cd([[:space:]]+[^&|;]*)?$'; then
+if echo "$STRIPPED" | grep -qE '^cd([[:space:]]+[^&|;]*)?$'; then
   echo "Bare 'cd' changes working directory permanently across tool calls." >&2
   echo "Use a subshell instead: (cd /path && command)" >&2
   exit 2

--- a/.claude/hooks/block-bare-cd.sh
+++ b/.claude/hooks/block-bare-cd.sh
@@ -22,9 +22,12 @@ INPUT=$(cat)
 
 # A payload that does not parse, or that names a command which is not a
 # string, is refused rather than skipped. An absent command is the empty
-# string and passes.
+# string and passes. The null tests are spelled out because jq's `//` reads
+# `false` as absent, and `false` is not a command either.
 if ! COMMAND=$(printf '%s' "$INPUT" \
-  | jq -r '(.tool_input.command // .command // "") | if type == "string" then . else error end' 2>/dev/null); then
+  | jq -r 'if .tool_input.command == null then (if .command == null then "" else .command end)
+           else .tool_input.command end
+           | if type == "string" then . else error end' 2>/dev/null); then
   echo "block-bare-cd: hook payload is not valid JSON, or names a command that is not a string; refusing rather than skipping the guard" >&2
   exit 2
 fi

--- a/.claude/hooks/block-bare-cd.sh
+++ b/.claude/hooks/block-bare-cd.sh
@@ -10,7 +10,32 @@
 set -euo pipefail
 
 INPUT=$(cat)
-COMMAND=$(echo "$INPUT" | grep -o '"command"[[:space:]]*:[[:space:]]*"[^"]*"' | head -1 | sed 's/.*"command"[[:space:]]*:[[:space:]]*"//;s/"$//' 2>/dev/null || true)
+
+# Decode the command the way the sibling guards do. The value carries JSON
+# escapes, and a parser that stops at the first quote truncates
+# `cd "$repo" && ls` to `cd \`, which the heuristic below then reads as a
+# bare cd and refuses — the opposite of what this hook is for.
+if command -v jq >/dev/null 2>&1; then
+  # A payload that does not parse is refused, not skipped: an unreadable
+  # command cannot be proven scoped, and this guard is fail-closed by design.
+  if ! COMMAND=$(printf '%s' "$INPUT" | jq -r '.tool_input.command // .command // empty' 2>/dev/null); then
+    echo "block-bare-cd: hook payload is not valid JSON; refusing rather than skipping the guard" >&2
+    exit 2
+  fi
+else
+  # Escape-aware fallback: the value may carry \" and \\ inside it.
+  COMMAND=$(printf '%s' "$INPUT" | grep -o '"command"[[:space:]]*:[[:space:]]*"\([^"\\]\|\\.\)*"' | head -1 \
+    | sed 's/^"command"[[:space:]]*:[[:space:]]*"//;s/"$//;s/\\"/"/g;s/\\\\/\\/g' 2>/dev/null || true)
+  # Same fail-closed contract as the jq branch: a payload that names a
+  # command the fallback could not decode is refused, not skipped. A
+  # decoded-empty command ("command":"") still passes.
+  if [ -z "$COMMAND" ] \
+    && printf '%s' "$INPUT" | grep -q '"command"' \
+    && ! printf '%s' "$INPUT" | grep -Eq '"command"[[:space:]]*:[[:space:]]*""'; then
+    echo "block-bare-cd: could not decode the command from the hook payload; refusing rather than skipping the guard" >&2
+    exit 2
+  fi
+fi
 
 # Fast exit if no cd in command. A bare `cd` goes to $HOME, the change this
 # hook exists to stop, so end of line counts the same as a following space.

--- a/.codex/hooks/block-bare-cd.sh
+++ b/.codex/hooks/block-bare-cd.sh
@@ -9,6 +9,14 @@
 
 set -euo pipefail
 
+# Every decision below is made by these tools, so a PATH without them would
+# no-op each check in turn and exit clean. Refuse before reading anything.
+if ! command -v cat >/dev/null 2>&1 || ! command -v grep >/dev/null 2>&1 \
+  || ! command -v sed >/dev/null 2>&1 || ! command -v head >/dev/null 2>&1; then
+  echo "block-bare-cd: text tools (cat/grep/sed/head) unavailable to read the payload; refusing rather than skipping the guard" >&2
+  exit 2
+fi
+
 INPUT=$(cat)
 
 # Decode the command the way the sibling guards do. The value carries JSON
@@ -24,8 +32,17 @@ if command -v jq >/dev/null 2>&1; then
   fi
 else
   # Escape-aware fallback: the value may carry \" and \\ inside it.
-  COMMAND=$(printf '%s' "$INPUT" | grep -o '"command"[[:space:]]*:[[:space:]]*"\([^"\\]\|\\.\)*"' | head -1 \
-    | sed 's/^"command"[[:space:]]*:[[:space:]]*"//;s/"$//;s/\\"/"/g;s/\\\\/\\/g' 2>/dev/null || true)
+  RAW=$(printf '%s' "$INPUT" | grep -o '"command"[[:space:]]*:[[:space:]]*"\([^"\\]\|\\.\)*"' | head -1 \
+    | sed 's/^"command"[[:space:]]*:[[:space:]]*"//;s/"$//' 2>/dev/null || true)
+  # Only \" and \\ are decoded here. A \t, \n, or \u escape would have to be
+  # interpreted before the command can be classified, and reading one wrong
+  # is a bare cd that passes, so such a payload is refused instead. jq, when
+  # it is there, decodes them all and never reaches this.
+  if printf '%s' "$RAW" | grep -q '\\[^"\\]'; then
+    echo "block-bare-cd: hook payload carries a JSON escape this fallback does not decode; refusing rather than skipping the guard" >&2
+    exit 2
+  fi
+  COMMAND=$(printf '%s' "$RAW" | sed 's/\\"/"/g;s/\\\\/\\/g')
   # Same fail-closed contract as the jq branch: a payload that names a
   # command the fallback could not decode is refused, not skipped. A
   # decoded-empty command ("command":"") still passes.
@@ -44,9 +61,12 @@ if ! echo "$COMMAND" | grep -qE 'cd([[:space:]]|$)'; then
 fi
 
 # Check for bare top-level cd (not in subshell or &&-chained with other work)
-# Simple heuristic: if the command is just "cd /path" with nothing else meaningful
+# Simple heuristic: if the command is just "cd /path" with nothing else
+# meaningful. Quoted text is an operand, not structure, so it is blanked
+# first — the `;` in `cd "a;b"` separates nothing.
 STRIPPED=$(echo "$COMMAND" | sed 's/^[[:space:]]*//')
-if echo "$STRIPPED" | grep -qE '^cd([[:space:]]+[^&|;]*)?$'; then
+MASKED=$(printf '%s' "$STRIPPED" | sed 's/"[^"]*"/Q/g' | sed "s/'[^']*'/Q/g")
+if echo "$MASKED" | grep -qE '^cd([[:space:]]+[^&|;]*)?$'; then
   echo "Bare 'cd' changes working directory permanently across tool calls." >&2
   echo "Use a subshell instead: (cd /path && command)" >&2
   exit 2

--- a/.codex/hooks/block-bare-cd.sh
+++ b/.codex/hooks/block-bare-cd.sh
@@ -9,49 +9,24 @@
 
 set -euo pipefail
 
-# Every decision below is made by these tools, so a PATH without them would
-# no-op each check in turn and exit clean. Refuse before reading anything.
-if ! command -v cat >/dev/null 2>&1 || ! command -v grep >/dev/null 2>&1 \
-  || ! command -v sed >/dev/null 2>&1 || ! command -v head >/dev/null 2>&1; then
-  echo "block-bare-cd: text tools (cat/grep/sed/head) unavailable to read the payload; refusing rather than skipping the guard" >&2
+# jq is the only reader of the payload, and grep and sed make every decision
+# after it. Without them the command cannot be read, and a command this hook
+# has not read cannot be shown to scope its directory change.
+if ! command -v jq >/dev/null 2>&1 || ! command -v cat >/dev/null 2>&1 \
+  || ! command -v grep >/dev/null 2>&1 || ! command -v sed >/dev/null 2>&1; then
+  echo "block-bare-cd: jq, cat, grep and sed are required to read the hook payload; refusing rather than skipping the guard" >&2
   exit 2
 fi
 
 INPUT=$(cat)
 
-# Decode the command the way the sibling guards do. The value carries JSON
-# escapes, and a parser that stops at the first quote truncates
-# `cd "$repo" && ls` to `cd \`, which the heuristic below then reads as a
-# bare cd and refuses — the opposite of what this hook is for.
-if command -v jq >/dev/null 2>&1; then
-  # A payload that does not parse is refused, not skipped: an unreadable
-  # command cannot be proven scoped, and this guard is fail-closed by design.
-  if ! COMMAND=$(printf '%s' "$INPUT" | jq -r '.tool_input.command // .command // empty' 2>/dev/null); then
-    echo "block-bare-cd: hook payload is not valid JSON; refusing rather than skipping the guard" >&2
-    exit 2
-  fi
-else
-  # Escape-aware fallback: the value may carry \" and \\ inside it.
-  RAW=$(printf '%s' "$INPUT" | grep -o '"command"[[:space:]]*:[[:space:]]*"\([^"\\]\|\\.\)*"' | head -1 \
-    | sed 's/^"command"[[:space:]]*:[[:space:]]*"//;s/"$//' 2>/dev/null || true)
-  # Only \" and \\ are decoded here. A \t, \n, or \u escape would have to be
-  # interpreted before the command can be classified, and reading one wrong
-  # is a bare cd that passes, so such a payload is refused instead. jq, when
-  # it is there, decodes them all and never reaches this.
-  if printf '%s' "$RAW" | grep -q '\\[^"\\]'; then
-    echo "block-bare-cd: hook payload carries a JSON escape this fallback does not decode; refusing rather than skipping the guard" >&2
-    exit 2
-  fi
-  COMMAND=$(printf '%s' "$RAW" | sed 's/\\"/"/g;s/\\\\/\\/g')
-  # Same fail-closed contract as the jq branch: a payload that names a
-  # command the fallback could not decode is refused, not skipped. A
-  # decoded-empty command ("command":"") still passes.
-  if [ -z "$COMMAND" ] \
-    && printf '%s' "$INPUT" | grep -q '"command"' \
-    && ! printf '%s' "$INPUT" | grep -Eq '"command"[[:space:]]*:[[:space:]]*""'; then
-    echo "block-bare-cd: could not decode the command from the hook payload; refusing rather than skipping the guard" >&2
-    exit 2
-  fi
+# A payload that does not parse, or that names a command which is not a
+# string, is refused rather than skipped. An absent command is the empty
+# string and passes.
+if ! COMMAND=$(printf '%s' "$INPUT" \
+  | jq -r '(.tool_input.command // .command // "") | if type == "string" then . else error end' 2>/dev/null); then
+  echo "block-bare-cd: hook payload is not valid JSON, or names a command that is not a string; refusing rather than skipping the guard" >&2
+  exit 2
 fi
 
 # Fast exit if no cd in command. A bare `cd` goes to $HOME, the change this
@@ -61,12 +36,9 @@ if ! echo "$COMMAND" | grep -qE 'cd([[:space:]]|$)'; then
 fi
 
 # Check for bare top-level cd (not in subshell or &&-chained with other work)
-# Simple heuristic: if the command is just "cd /path" with nothing else
-# meaningful. Quoted text is an operand, not structure, so it is blanked
-# first — the `;` in `cd "a;b"` separates nothing.
+# Simple heuristic: if the command is just "cd /path" with nothing else meaningful
 STRIPPED=$(echo "$COMMAND" | sed 's/^[[:space:]]*//')
-MASKED=$(printf '%s' "$STRIPPED" | sed 's/"[^"]*"/Q/g' | sed "s/'[^']*'/Q/g")
-if echo "$MASKED" | grep -qE '^cd([[:space:]]+[^&|;]*)?$'; then
+if echo "$STRIPPED" | grep -qE '^cd([[:space:]]+[^&|;]*)?$'; then
   echo "Bare 'cd' changes working directory permanently across tool calls." >&2
   echo "Use a subshell instead: (cd /path && command)" >&2
   exit 2

--- a/.codex/hooks/block-bare-cd.sh
+++ b/.codex/hooks/block-bare-cd.sh
@@ -22,9 +22,12 @@ INPUT=$(cat)
 
 # A payload that does not parse, or that names a command which is not a
 # string, is refused rather than skipped. An absent command is the empty
-# string and passes.
+# string and passes. The null tests are spelled out because jq's `//` reads
+# `false` as absent, and `false` is not a command either.
 if ! COMMAND=$(printf '%s' "$INPUT" \
-  | jq -r '(.tool_input.command // .command // "") | if type == "string" then . else error end' 2>/dev/null); then
+  | jq -r 'if .tool_input.command == null then (if .command == null then "" else .command end)
+           else .tool_input.command end
+           | if type == "string" then . else error end' 2>/dev/null); then
   echo "block-bare-cd: hook payload is not valid JSON, or names a command that is not a string; refusing rather than skipping the guard" >&2
   exit 2
 fi

--- a/.codex/hooks/block-bare-cd.sh
+++ b/.codex/hooks/block-bare-cd.sh
@@ -10,7 +10,32 @@
 set -euo pipefail
 
 INPUT=$(cat)
-COMMAND=$(echo "$INPUT" | grep -o '"command"[[:space:]]*:[[:space:]]*"[^"]*"' | head -1 | sed 's/.*"command"[[:space:]]*:[[:space:]]*"//;s/"$//' 2>/dev/null || true)
+
+# Decode the command the way the sibling guards do. The value carries JSON
+# escapes, and a parser that stops at the first quote truncates
+# `cd "$repo" && ls` to `cd \`, which the heuristic below then reads as a
+# bare cd and refuses — the opposite of what this hook is for.
+if command -v jq >/dev/null 2>&1; then
+  # A payload that does not parse is refused, not skipped: an unreadable
+  # command cannot be proven scoped, and this guard is fail-closed by design.
+  if ! COMMAND=$(printf '%s' "$INPUT" | jq -r '.tool_input.command // .command // empty' 2>/dev/null); then
+    echo "block-bare-cd: hook payload is not valid JSON; refusing rather than skipping the guard" >&2
+    exit 2
+  fi
+else
+  # Escape-aware fallback: the value may carry \" and \\ inside it.
+  COMMAND=$(printf '%s' "$INPUT" | grep -o '"command"[[:space:]]*:[[:space:]]*"\([^"\\]\|\\.\)*"' | head -1 \
+    | sed 's/^"command"[[:space:]]*:[[:space:]]*"//;s/"$//;s/\\"/"/g;s/\\\\/\\/g' 2>/dev/null || true)
+  # Same fail-closed contract as the jq branch: a payload that names a
+  # command the fallback could not decode is refused, not skipped. A
+  # decoded-empty command ("command":"") still passes.
+  if [ -z "$COMMAND" ] \
+    && printf '%s' "$INPUT" | grep -q '"command"' \
+    && ! printf '%s' "$INPUT" | grep -Eq '"command"[[:space:]]*:[[:space:]]*""'; then
+    echo "block-bare-cd: could not decode the command from the hook payload; refusing rather than skipping the guard" >&2
+    exit 2
+  fi
+fi
 
 # Fast exit if no cd in command. A bare `cd` goes to $HOME, the change this
 # hook exists to stop, so end of line counts the same as a following space.

--- a/.pi/kendex/hooks/block-bare-cd.sh
+++ b/.pi/kendex/hooks/block-bare-cd.sh
@@ -9,6 +9,14 @@
 
 set -euo pipefail
 
+# Every decision below is made by these tools, so a PATH without them would
+# no-op each check in turn and exit clean. Refuse before reading anything.
+if ! command -v cat >/dev/null 2>&1 || ! command -v grep >/dev/null 2>&1 \
+  || ! command -v sed >/dev/null 2>&1 || ! command -v head >/dev/null 2>&1; then
+  echo "block-bare-cd: text tools (cat/grep/sed/head) unavailable to read the payload; refusing rather than skipping the guard" >&2
+  exit 2
+fi
+
 INPUT=$(cat)
 
 # Decode the command the way the sibling guards do. The value carries JSON
@@ -24,8 +32,17 @@ if command -v jq >/dev/null 2>&1; then
   fi
 else
   # Escape-aware fallback: the value may carry \" and \\ inside it.
-  COMMAND=$(printf '%s' "$INPUT" | grep -o '"command"[[:space:]]*:[[:space:]]*"\([^"\\]\|\\.\)*"' | head -1 \
-    | sed 's/^"command"[[:space:]]*:[[:space:]]*"//;s/"$//;s/\\"/"/g;s/\\\\/\\/g' 2>/dev/null || true)
+  RAW=$(printf '%s' "$INPUT" | grep -o '"command"[[:space:]]*:[[:space:]]*"\([^"\\]\|\\.\)*"' | head -1 \
+    | sed 's/^"command"[[:space:]]*:[[:space:]]*"//;s/"$//' 2>/dev/null || true)
+  # Only \" and \\ are decoded here. A \t, \n, or \u escape would have to be
+  # interpreted before the command can be classified, and reading one wrong
+  # is a bare cd that passes, so such a payload is refused instead. jq, when
+  # it is there, decodes them all and never reaches this.
+  if printf '%s' "$RAW" | grep -q '\\[^"\\]'; then
+    echo "block-bare-cd: hook payload carries a JSON escape this fallback does not decode; refusing rather than skipping the guard" >&2
+    exit 2
+  fi
+  COMMAND=$(printf '%s' "$RAW" | sed 's/\\"/"/g;s/\\\\/\\/g')
   # Same fail-closed contract as the jq branch: a payload that names a
   # command the fallback could not decode is refused, not skipped. A
   # decoded-empty command ("command":"") still passes.
@@ -44,9 +61,12 @@ if ! echo "$COMMAND" | grep -qE 'cd([[:space:]]|$)'; then
 fi
 
 # Check for bare top-level cd (not in subshell or &&-chained with other work)
-# Simple heuristic: if the command is just "cd /path" with nothing else meaningful
+# Simple heuristic: if the command is just "cd /path" with nothing else
+# meaningful. Quoted text is an operand, not structure, so it is blanked
+# first — the `;` in `cd "a;b"` separates nothing.
 STRIPPED=$(echo "$COMMAND" | sed 's/^[[:space:]]*//')
-if echo "$STRIPPED" | grep -qE '^cd([[:space:]]+[^&|;]*)?$'; then
+MASKED=$(printf '%s' "$STRIPPED" | sed 's/"[^"]*"/Q/g' | sed "s/'[^']*'/Q/g")
+if echo "$MASKED" | grep -qE '^cd([[:space:]]+[^&|;]*)?$'; then
   echo "Bare 'cd' changes working directory permanently across tool calls." >&2
   echo "Use a subshell instead: (cd /path && command)" >&2
   exit 2

--- a/.pi/kendex/hooks/block-bare-cd.sh
+++ b/.pi/kendex/hooks/block-bare-cd.sh
@@ -9,49 +9,24 @@
 
 set -euo pipefail
 
-# Every decision below is made by these tools, so a PATH without them would
-# no-op each check in turn and exit clean. Refuse before reading anything.
-if ! command -v cat >/dev/null 2>&1 || ! command -v grep >/dev/null 2>&1 \
-  || ! command -v sed >/dev/null 2>&1 || ! command -v head >/dev/null 2>&1; then
-  echo "block-bare-cd: text tools (cat/grep/sed/head) unavailable to read the payload; refusing rather than skipping the guard" >&2
+# jq is the only reader of the payload, and grep and sed make every decision
+# after it. Without them the command cannot be read, and a command this hook
+# has not read cannot be shown to scope its directory change.
+if ! command -v jq >/dev/null 2>&1 || ! command -v cat >/dev/null 2>&1 \
+  || ! command -v grep >/dev/null 2>&1 || ! command -v sed >/dev/null 2>&1; then
+  echo "block-bare-cd: jq, cat, grep and sed are required to read the hook payload; refusing rather than skipping the guard" >&2
   exit 2
 fi
 
 INPUT=$(cat)
 
-# Decode the command the way the sibling guards do. The value carries JSON
-# escapes, and a parser that stops at the first quote truncates
-# `cd "$repo" && ls` to `cd \`, which the heuristic below then reads as a
-# bare cd and refuses — the opposite of what this hook is for.
-if command -v jq >/dev/null 2>&1; then
-  # A payload that does not parse is refused, not skipped: an unreadable
-  # command cannot be proven scoped, and this guard is fail-closed by design.
-  if ! COMMAND=$(printf '%s' "$INPUT" | jq -r '.tool_input.command // .command // empty' 2>/dev/null); then
-    echo "block-bare-cd: hook payload is not valid JSON; refusing rather than skipping the guard" >&2
-    exit 2
-  fi
-else
-  # Escape-aware fallback: the value may carry \" and \\ inside it.
-  RAW=$(printf '%s' "$INPUT" | grep -o '"command"[[:space:]]*:[[:space:]]*"\([^"\\]\|\\.\)*"' | head -1 \
-    | sed 's/^"command"[[:space:]]*:[[:space:]]*"//;s/"$//' 2>/dev/null || true)
-  # Only \" and \\ are decoded here. A \t, \n, or \u escape would have to be
-  # interpreted before the command can be classified, and reading one wrong
-  # is a bare cd that passes, so such a payload is refused instead. jq, when
-  # it is there, decodes them all and never reaches this.
-  if printf '%s' "$RAW" | grep -q '\\[^"\\]'; then
-    echo "block-bare-cd: hook payload carries a JSON escape this fallback does not decode; refusing rather than skipping the guard" >&2
-    exit 2
-  fi
-  COMMAND=$(printf '%s' "$RAW" | sed 's/\\"/"/g;s/\\\\/\\/g')
-  # Same fail-closed contract as the jq branch: a payload that names a
-  # command the fallback could not decode is refused, not skipped. A
-  # decoded-empty command ("command":"") still passes.
-  if [ -z "$COMMAND" ] \
-    && printf '%s' "$INPUT" | grep -q '"command"' \
-    && ! printf '%s' "$INPUT" | grep -Eq '"command"[[:space:]]*:[[:space:]]*""'; then
-    echo "block-bare-cd: could not decode the command from the hook payload; refusing rather than skipping the guard" >&2
-    exit 2
-  fi
+# A payload that does not parse, or that names a command which is not a
+# string, is refused rather than skipped. An absent command is the empty
+# string and passes.
+if ! COMMAND=$(printf '%s' "$INPUT" \
+  | jq -r '(.tool_input.command // .command // "") | if type == "string" then . else error end' 2>/dev/null); then
+  echo "block-bare-cd: hook payload is not valid JSON, or names a command that is not a string; refusing rather than skipping the guard" >&2
+  exit 2
 fi
 
 # Fast exit if no cd in command. A bare `cd` goes to $HOME, the change this
@@ -61,12 +36,9 @@ if ! echo "$COMMAND" | grep -qE 'cd([[:space:]]|$)'; then
 fi
 
 # Check for bare top-level cd (not in subshell or &&-chained with other work)
-# Simple heuristic: if the command is just "cd /path" with nothing else
-# meaningful. Quoted text is an operand, not structure, so it is blanked
-# first — the `;` in `cd "a;b"` separates nothing.
+# Simple heuristic: if the command is just "cd /path" with nothing else meaningful
 STRIPPED=$(echo "$COMMAND" | sed 's/^[[:space:]]*//')
-MASKED=$(printf '%s' "$STRIPPED" | sed 's/"[^"]*"/Q/g' | sed "s/'[^']*'/Q/g")
-if echo "$MASKED" | grep -qE '^cd([[:space:]]+[^&|;]*)?$'; then
+if echo "$STRIPPED" | grep -qE '^cd([[:space:]]+[^&|;]*)?$'; then
   echo "Bare 'cd' changes working directory permanently across tool calls." >&2
   echo "Use a subshell instead: (cd /path && command)" >&2
   exit 2

--- a/.pi/kendex/hooks/block-bare-cd.sh
+++ b/.pi/kendex/hooks/block-bare-cd.sh
@@ -22,9 +22,12 @@ INPUT=$(cat)
 
 # A payload that does not parse, or that names a command which is not a
 # string, is refused rather than skipped. An absent command is the empty
-# string and passes.
+# string and passes. The null tests are spelled out because jq's `//` reads
+# `false` as absent, and `false` is not a command either.
 if ! COMMAND=$(printf '%s' "$INPUT" \
-  | jq -r '(.tool_input.command // .command // "") | if type == "string" then . else error end' 2>/dev/null); then
+  | jq -r 'if .tool_input.command == null then (if .command == null then "" else .command end)
+           else .tool_input.command end
+           | if type == "string" then . else error end' 2>/dev/null); then
   echo "block-bare-cd: hook payload is not valid JSON, or names a command that is not a string; refusing rather than skipping the guard" >&2
   exit 2
 fi

--- a/.pi/kendex/hooks/block-bare-cd.sh
+++ b/.pi/kendex/hooks/block-bare-cd.sh
@@ -10,7 +10,32 @@
 set -euo pipefail
 
 INPUT=$(cat)
-COMMAND=$(echo "$INPUT" | grep -o '"command"[[:space:]]*:[[:space:]]*"[^"]*"' | head -1 | sed 's/.*"command"[[:space:]]*:[[:space:]]*"//;s/"$//' 2>/dev/null || true)
+
+# Decode the command the way the sibling guards do. The value carries JSON
+# escapes, and a parser that stops at the first quote truncates
+# `cd "$repo" && ls` to `cd \`, which the heuristic below then reads as a
+# bare cd and refuses — the opposite of what this hook is for.
+if command -v jq >/dev/null 2>&1; then
+  # A payload that does not parse is refused, not skipped: an unreadable
+  # command cannot be proven scoped, and this guard is fail-closed by design.
+  if ! COMMAND=$(printf '%s' "$INPUT" | jq -r '.tool_input.command // .command // empty' 2>/dev/null); then
+    echo "block-bare-cd: hook payload is not valid JSON; refusing rather than skipping the guard" >&2
+    exit 2
+  fi
+else
+  # Escape-aware fallback: the value may carry \" and \\ inside it.
+  COMMAND=$(printf '%s' "$INPUT" | grep -o '"command"[[:space:]]*:[[:space:]]*"\([^"\\]\|\\.\)*"' | head -1 \
+    | sed 's/^"command"[[:space:]]*:[[:space:]]*"//;s/"$//;s/\\"/"/g;s/\\\\/\\/g' 2>/dev/null || true)
+  # Same fail-closed contract as the jq branch: a payload that names a
+  # command the fallback could not decode is refused, not skipped. A
+  # decoded-empty command ("command":"") still passes.
+  if [ -z "$COMMAND" ] \
+    && printf '%s' "$INPUT" | grep -q '"command"' \
+    && ! printf '%s' "$INPUT" | grep -Eq '"command"[[:space:]]*:[[:space:]]*""'; then
+    echo "block-bare-cd: could not decode the command from the hook payload; refusing rather than skipping the guard" >&2
+    exit 2
+  fi
+fi
 
 # Fast exit if no cd in command. A bare `cd` goes to $HOME, the change this
 # hook exists to stop, so end of line counts the same as a following space.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,10 @@ an outside contributor.
   on any nonzero clippy exit or a git that cannot say what changed. It passed
   all three before: a new-file-only task, a killed clippy, an unreadable repo.
 
+- The `block-bare-cd` hook reads the command with jq, and refuses a payload it
+  cannot read. Its own parser stopped at the first quote, so `cd "$repo" && ls`
+  truncated to `cd \` and the hook refused the scoped form it tells you to use.
+
 - The `block-bare-cd` hook refuses a bare `cd` with no path. It changes to
   `$HOME` for every later tool call, the move the hook exists to stop, and
   only `cd <path>` was caught before.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,9 +46,9 @@ an outside contributor.
   on any nonzero clippy exit or a git that cannot say what changed. It passed
   all three before: a new-file-only task, a killed clippy, an unreadable repo.
 
-- The `block-bare-cd` hook reads the command with jq, and refuses a payload it
-  cannot read. Its own parser stopped at the first quote, so `cd "$repo" && ls`
-  truncated to `cd \` and the hook refused the scoped form it tells you to use.
+- **Breaking:** the `block-bare-cd` hook reads the command with `jq` and refuses
+  every Bash call it matches on a host without it — install jq wherever the hook
+  runs. Its own parser stopped at the first quote, mis-refusing `cd "$d" && ls`.
 
 - The `block-bare-cd` hook refuses a bare `cd` with no path. It changes to
   `$HOME` for every later tool call, the move the hook exists to stop, and

--- a/hooks/block-bare-cd.sh
+++ b/hooks/block-bare-cd.sh
@@ -9,6 +9,14 @@
 
 set -euo pipefail
 
+# Every decision below is made by these tools, so a PATH without them would
+# no-op each check in turn and exit clean. Refuse before reading anything.
+if ! command -v cat >/dev/null 2>&1 || ! command -v grep >/dev/null 2>&1 \
+  || ! command -v sed >/dev/null 2>&1 || ! command -v head >/dev/null 2>&1; then
+  echo "block-bare-cd: text tools (cat/grep/sed/head) unavailable to read the payload; refusing rather than skipping the guard" >&2
+  exit 2
+fi
+
 INPUT=$(cat)
 
 # Decode the command the way the sibling guards do. The value carries JSON
@@ -24,8 +32,17 @@ if command -v jq >/dev/null 2>&1; then
   fi
 else
   # Escape-aware fallback: the value may carry \" and \\ inside it.
-  COMMAND=$(printf '%s' "$INPUT" | grep -o '"command"[[:space:]]*:[[:space:]]*"\([^"\\]\|\\.\)*"' | head -1 \
-    | sed 's/^"command"[[:space:]]*:[[:space:]]*"//;s/"$//;s/\\"/"/g;s/\\\\/\\/g' 2>/dev/null || true)
+  RAW=$(printf '%s' "$INPUT" | grep -o '"command"[[:space:]]*:[[:space:]]*"\([^"\\]\|\\.\)*"' | head -1 \
+    | sed 's/^"command"[[:space:]]*:[[:space:]]*"//;s/"$//' 2>/dev/null || true)
+  # Only \" and \\ are decoded here. A \t, \n, or \u escape would have to be
+  # interpreted before the command can be classified, and reading one wrong
+  # is a bare cd that passes, so such a payload is refused instead. jq, when
+  # it is there, decodes them all and never reaches this.
+  if printf '%s' "$RAW" | grep -q '\\[^"\\]'; then
+    echo "block-bare-cd: hook payload carries a JSON escape this fallback does not decode; refusing rather than skipping the guard" >&2
+    exit 2
+  fi
+  COMMAND=$(printf '%s' "$RAW" | sed 's/\\"/"/g;s/\\\\/\\/g')
   # Same fail-closed contract as the jq branch: a payload that names a
   # command the fallback could not decode is refused, not skipped. A
   # decoded-empty command ("command":"") still passes.
@@ -44,9 +61,12 @@ if ! echo "$COMMAND" | grep -qE 'cd([[:space:]]|$)'; then
 fi
 
 # Check for bare top-level cd (not in subshell or &&-chained with other work)
-# Simple heuristic: if the command is just "cd /path" with nothing else meaningful
+# Simple heuristic: if the command is just "cd /path" with nothing else
+# meaningful. Quoted text is an operand, not structure, so it is blanked
+# first — the `;` in `cd "a;b"` separates nothing.
 STRIPPED=$(echo "$COMMAND" | sed 's/^[[:space:]]*//')
-if echo "$STRIPPED" | grep -qE '^cd([[:space:]]+[^&|;]*)?$'; then
+MASKED=$(printf '%s' "$STRIPPED" | sed 's/"[^"]*"/Q/g' | sed "s/'[^']*'/Q/g")
+if echo "$MASKED" | grep -qE '^cd([[:space:]]+[^&|;]*)?$'; then
   echo "Bare 'cd' changes working directory permanently across tool calls." >&2
   echo "Use a subshell instead: (cd /path && command)" >&2
   exit 2

--- a/hooks/block-bare-cd.sh
+++ b/hooks/block-bare-cd.sh
@@ -9,49 +9,24 @@
 
 set -euo pipefail
 
-# Every decision below is made by these tools, so a PATH without them would
-# no-op each check in turn and exit clean. Refuse before reading anything.
-if ! command -v cat >/dev/null 2>&1 || ! command -v grep >/dev/null 2>&1 \
-  || ! command -v sed >/dev/null 2>&1 || ! command -v head >/dev/null 2>&1; then
-  echo "block-bare-cd: text tools (cat/grep/sed/head) unavailable to read the payload; refusing rather than skipping the guard" >&2
+# jq is the only reader of the payload, and grep and sed make every decision
+# after it. Without them the command cannot be read, and a command this hook
+# has not read cannot be shown to scope its directory change.
+if ! command -v jq >/dev/null 2>&1 || ! command -v cat >/dev/null 2>&1 \
+  || ! command -v grep >/dev/null 2>&1 || ! command -v sed >/dev/null 2>&1; then
+  echo "block-bare-cd: jq, cat, grep and sed are required to read the hook payload; refusing rather than skipping the guard" >&2
   exit 2
 fi
 
 INPUT=$(cat)
 
-# Decode the command the way the sibling guards do. The value carries JSON
-# escapes, and a parser that stops at the first quote truncates
-# `cd "$repo" && ls` to `cd \`, which the heuristic below then reads as a
-# bare cd and refuses — the opposite of what this hook is for.
-if command -v jq >/dev/null 2>&1; then
-  # A payload that does not parse is refused, not skipped: an unreadable
-  # command cannot be proven scoped, and this guard is fail-closed by design.
-  if ! COMMAND=$(printf '%s' "$INPUT" | jq -r '.tool_input.command // .command // empty' 2>/dev/null); then
-    echo "block-bare-cd: hook payload is not valid JSON; refusing rather than skipping the guard" >&2
-    exit 2
-  fi
-else
-  # Escape-aware fallback: the value may carry \" and \\ inside it.
-  RAW=$(printf '%s' "$INPUT" | grep -o '"command"[[:space:]]*:[[:space:]]*"\([^"\\]\|\\.\)*"' | head -1 \
-    | sed 's/^"command"[[:space:]]*:[[:space:]]*"//;s/"$//' 2>/dev/null || true)
-  # Only \" and \\ are decoded here. A \t, \n, or \u escape would have to be
-  # interpreted before the command can be classified, and reading one wrong
-  # is a bare cd that passes, so such a payload is refused instead. jq, when
-  # it is there, decodes them all and never reaches this.
-  if printf '%s' "$RAW" | grep -q '\\[^"\\]'; then
-    echo "block-bare-cd: hook payload carries a JSON escape this fallback does not decode; refusing rather than skipping the guard" >&2
-    exit 2
-  fi
-  COMMAND=$(printf '%s' "$RAW" | sed 's/\\"/"/g;s/\\\\/\\/g')
-  # Same fail-closed contract as the jq branch: a payload that names a
-  # command the fallback could not decode is refused, not skipped. A
-  # decoded-empty command ("command":"") still passes.
-  if [ -z "$COMMAND" ] \
-    && printf '%s' "$INPUT" | grep -q '"command"' \
-    && ! printf '%s' "$INPUT" | grep -Eq '"command"[[:space:]]*:[[:space:]]*""'; then
-    echo "block-bare-cd: could not decode the command from the hook payload; refusing rather than skipping the guard" >&2
-    exit 2
-  fi
+# A payload that does not parse, or that names a command which is not a
+# string, is refused rather than skipped. An absent command is the empty
+# string and passes.
+if ! COMMAND=$(printf '%s' "$INPUT" \
+  | jq -r '(.tool_input.command // .command // "") | if type == "string" then . else error end' 2>/dev/null); then
+  echo "block-bare-cd: hook payload is not valid JSON, or names a command that is not a string; refusing rather than skipping the guard" >&2
+  exit 2
 fi
 
 # Fast exit if no cd in command. A bare `cd` goes to $HOME, the change this
@@ -61,12 +36,9 @@ if ! echo "$COMMAND" | grep -qE 'cd([[:space:]]|$)'; then
 fi
 
 # Check for bare top-level cd (not in subshell or &&-chained with other work)
-# Simple heuristic: if the command is just "cd /path" with nothing else
-# meaningful. Quoted text is an operand, not structure, so it is blanked
-# first — the `;` in `cd "a;b"` separates nothing.
+# Simple heuristic: if the command is just "cd /path" with nothing else meaningful
 STRIPPED=$(echo "$COMMAND" | sed 's/^[[:space:]]*//')
-MASKED=$(printf '%s' "$STRIPPED" | sed 's/"[^"]*"/Q/g' | sed "s/'[^']*'/Q/g")
-if echo "$MASKED" | grep -qE '^cd([[:space:]]+[^&|;]*)?$'; then
+if echo "$STRIPPED" | grep -qE '^cd([[:space:]]+[^&|;]*)?$'; then
   echo "Bare 'cd' changes working directory permanently across tool calls." >&2
   echo "Use a subshell instead: (cd /path && command)" >&2
   exit 2

--- a/hooks/block-bare-cd.sh
+++ b/hooks/block-bare-cd.sh
@@ -22,9 +22,12 @@ INPUT=$(cat)
 
 # A payload that does not parse, or that names a command which is not a
 # string, is refused rather than skipped. An absent command is the empty
-# string and passes.
+# string and passes. The null tests are spelled out because jq's `//` reads
+# `false` as absent, and `false` is not a command either.
 if ! COMMAND=$(printf '%s' "$INPUT" \
-  | jq -r '(.tool_input.command // .command // "") | if type == "string" then . else error end' 2>/dev/null); then
+  | jq -r 'if .tool_input.command == null then (if .command == null then "" else .command end)
+           else .tool_input.command end
+           | if type == "string" then . else error end' 2>/dev/null); then
   echo "block-bare-cd: hook payload is not valid JSON, or names a command that is not a string; refusing rather than skipping the guard" >&2
   exit 2
 fi

--- a/hooks/block-bare-cd.sh
+++ b/hooks/block-bare-cd.sh
@@ -10,7 +10,32 @@
 set -euo pipefail
 
 INPUT=$(cat)
-COMMAND=$(echo "$INPUT" | grep -o '"command"[[:space:]]*:[[:space:]]*"[^"]*"' | head -1 | sed 's/.*"command"[[:space:]]*:[[:space:]]*"//;s/"$//' 2>/dev/null || true)
+
+# Decode the command the way the sibling guards do. The value carries JSON
+# escapes, and a parser that stops at the first quote truncates
+# `cd "$repo" && ls` to `cd \`, which the heuristic below then reads as a
+# bare cd and refuses — the opposite of what this hook is for.
+if command -v jq >/dev/null 2>&1; then
+  # A payload that does not parse is refused, not skipped: an unreadable
+  # command cannot be proven scoped, and this guard is fail-closed by design.
+  if ! COMMAND=$(printf '%s' "$INPUT" | jq -r '.tool_input.command // .command // empty' 2>/dev/null); then
+    echo "block-bare-cd: hook payload is not valid JSON; refusing rather than skipping the guard" >&2
+    exit 2
+  fi
+else
+  # Escape-aware fallback: the value may carry \" and \\ inside it.
+  COMMAND=$(printf '%s' "$INPUT" | grep -o '"command"[[:space:]]*:[[:space:]]*"\([^"\\]\|\\.\)*"' | head -1 \
+    | sed 's/^"command"[[:space:]]*:[[:space:]]*"//;s/"$//;s/\\"/"/g;s/\\\\/\\/g' 2>/dev/null || true)
+  # Same fail-closed contract as the jq branch: a payload that names a
+  # command the fallback could not decode is refused, not skipped. A
+  # decoded-empty command ("command":"") still passes.
+  if [ -z "$COMMAND" ] \
+    && printf '%s' "$INPUT" | grep -q '"command"' \
+    && ! printf '%s' "$INPUT" | grep -Eq '"command"[[:space:]]*:[[:space:]]*""'; then
+    echo "block-bare-cd: could not decode the command from the hook payload; refusing rather than skipping the guard" >&2
+    exit 2
+  fi
+fi
 
 # Fast exit if no cd in command. A bare `cd` goes to $HOME, the change this
 # hook exists to stop, so end of line counts the same as a following space.

--- a/hooks/tests/block-bare-cd.test.sh
+++ b/hooks/tests/block-bare-cd.test.sh
@@ -91,6 +91,8 @@ assert_eq "$rc" 2 'a truncated JSON payload refuses rather than skipping the gua
 assert_contains "$ERR_FILE" 'not valid JSON' 'the parse refusal names the cause'
 run_payload '{"tool_input":{"command":123}}'
 assert_eq "$rc" 2 'a command that is not a string refuses'
+run_payload '{"tool_input":{"command":false}}'
+assert_eq "$rc" 2 'a command of false refuses, not read as an absent one'
 run_payload '{"tool_input":"cd /tmp"}'
 assert_eq "$rc" 2 'a tool_input that is not an object refuses'
 run_payload '{"tool_input":{"command":""}}'

--- a/hooks/tests/block-bare-cd.test.sh
+++ b/hooks/tests/block-bare-cd.test.sh
@@ -51,9 +51,11 @@ run_hook() { # command -> rc, stderr in ERR_FILE
 # A PATH without jq exercises the escape-aware fallback decoder.
 NOJQ_BIN="$TMP_ROOT/nojq"
 mkdir -p "$NOJQ_BIN"
+# type -P, not command -v: grep and friends are shell functions in some
+# interactive environments, and a function name symlinks to nothing.
 for tool in cat sed grep head; do
-  real="$(command -v "$tool" 2>/dev/null || true)"
-  [ -n "$real" ] || continue
+  real="$(type -P "$tool" 2>/dev/null || true)"
+  [ -n "$real" ] && [ -x "$real" ] || continue
   ln -sf "$real" "$NOJQ_BIN/$tool"
 done
 run_hook_nojq() { # command -> rc, stderr in ERR_FILE
@@ -96,6 +98,32 @@ run_hook_nojq 'cd "$repo" && ls';  assert_eq "$rc" 0 'without jq, the escape-awa
 run_hook_nojq 'cd "$repo"';        assert_eq "$rc" 2 'without jq, a quoted bare cd is still refused'
 run_hook_nojq 'cd';                assert_eq "$rc" 2 'without jq, a bare cd with no target is refused'
 run_hook_nojq 'ls -la';            assert_eq "$rc" 0 'without jq, an unrelated command passes'
+
+echo "=== block-bare-cd: a quoted operator is an operand, not a separator ==="
+run_hook 'cd "a;b"';               assert_eq "$rc" 2 'a quoted ; does not turn a bare cd into a chain'
+run_hook "cd 'a&b'";               assert_eq "$rc" 2 'a single-quoted & does not either'
+run_hook 'cd "a|b" && ls';         assert_eq "$rc" 0 'a real chain after a quoted | still passes'
+
+echo "=== block-bare-cd: both decoders agree on JSON escapes ==="
+# The fallback decodes only \" and \\. Anything it would have to interpret is
+# refused, so it can never pass what jq refuses.
+for payload in '{"tool_input":{"command":"cd\t/tmp"}}' '{"tool_input":{"command":"ls\ncd"}}'; do
+  set +e
+  printf '%s' "$payload" | "$BASH_BIN" "$HOOK" >/dev/null 2>&1; with_jq=$?
+  printf '%s' "$payload" | env -i HOME="$HOME" PWD="$PWD" PATH="$NOJQ_BIN" "$BASH_BIN" "$HOOK" \
+    >/dev/null 2>"$ERR_FILE"; rc=$?
+  set -e
+  assert_eq "$rc" 2 "without jq, an escape it cannot decode refuses: $payload"
+  assert_eq "$with_jq" 2 "jq decodes the same escape to a bare cd: $payload"
+done
+
+echo "=== block-bare-cd: no text tools ==="
+set +e
+printf '%s' '{"tool_input":{"command":"cd /tmp"}}' \
+  | env -i PATH=/nonexistent "$BASH_BIN" "$HOOK" >/dev/null 2>"$ERR_FILE"; rc=$?
+set -e
+assert_eq "$rc" 2 'a PATH with no text tools refuses rather than no-opping every check'
+assert_contains "$ERR_FILE" 'unavailable to read the payload' 'the refusal names the missing tools'
 
 echo "=== block-bare-cd: an undecodable payload refuses ==="
 set +e

--- a/hooks/tests/block-bare-cd.test.sh
+++ b/hooks/tests/block-bare-cd.test.sh
@@ -7,10 +7,11 @@
 # argument is optional on both sides of the check: a bare `cd` goes to $HOME,
 # which is the same permanent move as `cd /tmp`.
 #
-# The command reaches the hook JSON-encoded, so the decode is pinned too: a
-# quoted operand carries \" escapes, and a parser that stops at the first
-# quote truncates the chain that scopes the move. Both decode paths are
-# exercised — jq, and the fallback on a PATH without it.
+# The command reaches the hook JSON-encoded, and jq is the only thing that
+# reads it: a quoted operand carries \" escapes, and the parser this replaced
+# stopped at the first one, truncating the chain that scopes the move. A
+# payload jq cannot read, or one naming a command that is not a string, is
+# refused rather than skipped.
 #
 # HOOK_UNDER_TEST overrides the script under test so the must-fail controls
 # (the pre-fix hook, a no-op hook) run against these same assertions.
@@ -48,20 +49,14 @@ run_hook() { # command -> rc, stderr in ERR_FILE
   set -e
 }
 
-# A PATH without jq exercises the escape-aware fallback decoder.
-NOJQ_BIN="$TMP_ROOT/nojq"
-mkdir -p "$NOJQ_BIN"
-# type -P, not command -v: grep and friends are shell functions in some
-# interactive environments, and a function name symlinks to nothing.
-for tool in cat sed grep head; do
-  real="$(type -P "$tool" 2>/dev/null || true)"
-  [ -n "$real" ] && [ -x "$real" ] || continue
-  ln -sf "$real" "$NOJQ_BIN/$tool"
-done
-run_hook_nojq() { # command -> rc, stderr in ERR_FILE
+run_payload() { # raw-json [PATH] -> rc, stderr in ERR_FILE
   set +e
-  json_for "$1" | env -i HOME="$HOME" PWD="$PWD" PATH="$NOJQ_BIN" "$BASH_BIN" "$HOOK" \
-    >/dev/null 2>"$ERR_FILE"
+  if [ -n "${2:-}" ]; then
+    printf '%s' "$1" | env -i HOME="$HOME" PWD="$PWD" PATH="$2" "$BASH_BIN" "$HOOK" \
+      >/dev/null 2>"$ERR_FILE"
+  else
+    printf '%s' "$1" | "$BASH_BIN" "$HOOK" >/dev/null 2>"$ERR_FILE"
+  fi
   rc=$?
   set -e
 }
@@ -73,6 +68,7 @@ run_hook '   cd';         assert_eq "$rc" 2 'leading whitespace does not hide a 
 run_hook 'cd /tmp';       assert_eq "$rc" 2 'cd with a path is refused'
 run_hook 'cd ~/dev';      assert_eq "$rc" 2 'cd to a home-relative path is refused'
 run_hook 'cd ..';         assert_eq "$rc" 2 'cd .. is refused'
+run_hook 'cd "$repo"';    assert_eq "$rc" 2 'a quoted operand alone is still a bare cd'
 
 echo "=== block-bare-cd: the refusal names the cause and the rewrite ==="
 run_hook 'cd'
@@ -82,65 +78,41 @@ assert_contains "$ERR_FILE" '(cd /path && command)' 'the refusal names the subsh
 echo "=== block-bare-cd: accepted shapes ==="
 run_hook '(cd /tmp && ls)';   assert_eq "$rc" 0 'a subshell-scoped cd passes'
 run_hook 'cd /tmp && ls';     assert_eq "$rc" 0 'a cd chained with the real work passes'
+run_hook 'cd "$repo" && ls';  assert_eq "$rc" 0 'a quoted operand does not truncate the chain behind it'
+run_hook 'cd "/a b" && make'; assert_eq "$rc" 0 'a quoted path with a space keeps its chain'
 run_hook 'echo cd';           assert_eq "$rc" 0 'a command that only mentions cd passes'
 run_hook 'cdr --version';     assert_eq "$rc" 0 'a command whose name merely starts with cd passes'
 run_hook 'ls -la';            assert_eq "$rc" 0 'an unrelated command passes'
 run_hook 'git checkout main'; assert_eq "$rc" 0 'a command with no cd at all passes'
 
-echo "=== block-bare-cd: a quoted operand does not truncate the command ==="
-run_hook 'cd "$repo" && ls';       assert_eq "$rc" 0 'cd "$repo" && ls is scoped work, not a bare cd'
-run_hook 'cd "$repo"';             assert_eq "$rc" 2 'cd "$repo" alone is still a bare cd'
-run_hook 'cd "/a b" && make';      assert_eq "$rc" 0 'a quoted path with a space does not hide the chain'
-run_hook 'echo "cd \"x\"" > note'; assert_eq "$rc" 0 'a quoted cd inside a string is not a bare cd'
-
-echo "=== block-bare-cd: the same decisions without jq ==="
-run_hook_nojq 'cd "$repo" && ls';  assert_eq "$rc" 0 'without jq, the escape-aware fallback keeps the chain'
-run_hook_nojq 'cd "$repo"';        assert_eq "$rc" 2 'without jq, a quoted bare cd is still refused'
-run_hook_nojq 'cd';                assert_eq "$rc" 2 'without jq, a bare cd with no target is refused'
-run_hook_nojq 'ls -la';            assert_eq "$rc" 0 'without jq, an unrelated command passes'
-
-echo "=== block-bare-cd: a quoted operator is an operand, not a separator ==="
-run_hook 'cd "a;b"';               assert_eq "$rc" 2 'a quoted ; does not turn a bare cd into a chain'
-run_hook "cd 'a&b'";               assert_eq "$rc" 2 'a single-quoted & does not either'
-run_hook 'cd "a|b" && ls';         assert_eq "$rc" 0 'a real chain after a quoted | still passes'
-
-echo "=== block-bare-cd: both decoders agree on JSON escapes ==="
-# The fallback decodes only \" and \\. Anything it would have to interpret is
-# refused, so it can never pass what jq refuses.
-for payload in '{"tool_input":{"command":"cd\t/tmp"}}' '{"tool_input":{"command":"ls\ncd"}}'; do
-  set +e
-  printf '%s' "$payload" | "$BASH_BIN" "$HOOK" >/dev/null 2>&1; with_jq=$?
-  printf '%s' "$payload" | env -i HOME="$HOME" PWD="$PWD" PATH="$NOJQ_BIN" "$BASH_BIN" "$HOOK" \
-    >/dev/null 2>"$ERR_FILE"; rc=$?
-  set -e
-  assert_eq "$rc" 2 "without jq, an escape it cannot decode refuses: $payload"
-  assert_eq "$with_jq" 2 "jq decodes the same escape to a bare cd: $payload"
-done
-
-echo "=== block-bare-cd: no text tools ==="
-set +e
-printf '%s' '{"tool_input":{"command":"cd /tmp"}}' \
-  | env -i PATH=/nonexistent "$BASH_BIN" "$HOOK" >/dev/null 2>"$ERR_FILE"; rc=$?
-set -e
-assert_eq "$rc" 2 'a PATH with no text tools refuses rather than no-opping every check'
-assert_contains "$ERR_FILE" 'unavailable to read the payload' 'the refusal names the missing tools'
-
-echo "=== block-bare-cd: an undecodable payload refuses ==="
-set +e
-printf '%s' '{"tool_input":{"command":"cd /tmp"' | "$BASH_BIN" "$HOOK" >/dev/null 2>"$ERR_FILE"; rc=$?
-set -e
+echo "=== block-bare-cd: a payload it cannot read refuses ==="
+run_payload '{"tool_input":{"command":"cd /tmp"'
 assert_eq "$rc" 2 'a truncated JSON payload refuses rather than skipping the guard'
 assert_contains "$ERR_FILE" 'not valid JSON' 'the parse refusal names the cause'
-set +e
-printf '%s' '{"tool_input":{"command":"cd /tmp' \
-  | env -i HOME="$HOME" PWD="$PWD" PATH="$NOJQ_BIN" "$BASH_BIN" "$HOOK" >/dev/null 2>"$ERR_FILE"; rc=$?
-set -e
-assert_eq "$rc" 2 'without jq, an unterminated command string refuses'
-assert_contains "$ERR_FILE" 'could not decode' 'the no-jq refusal names the cause'
-set +e
-printf '%s' '{"tool_input":{"command":""}}' | "$BASH_BIN" "$HOOK" >/dev/null 2>"$ERR_FILE"; rc=$?
-set -e
-assert_eq "$rc" 0 'an empty command is decoded, not a decode failure'
+run_payload '{"tool_input":{"command":123}}'
+assert_eq "$rc" 2 'a command that is not a string refuses'
+run_payload '{"tool_input":"cd /tmp"}'
+assert_eq "$rc" 2 'a tool_input that is not an object refuses'
+run_payload '{"tool_input":{"command":""}}'
+assert_eq "$rc" 0 'an empty command is read, not a read failure'
+run_payload '{"tool_name":"Bash","tool_input":{}}'
+assert_eq "$rc" 0 'a payload naming no command passes'
+
+echo "=== block-bare-cd: without the tools that read the payload ==="
+NOJQ_BIN="$TMP_ROOT/nojq"
+mkdir -p "$NOJQ_BIN"
+# type -P, not command -v: grep and friends are shell functions in some
+# interactive environments, and a function name symlinks to nothing.
+for tool in cat sed grep; do
+  real="$(type -P "$tool" 2>/dev/null || true)"
+  [ -n "$real" ] && [ -x "$real" ] || continue
+  ln -sf "$real" "$NOJQ_BIN/$tool"
+done
+run_payload '{"tool_input":{"command":"cd /tmp"}}' "$NOJQ_BIN"
+assert_eq "$rc" 2 'no jq refuses rather than guessing at the payload'
+assert_contains "$ERR_FILE" 'required to read the hook payload' 'the refusal names what is missing'
+run_payload '{"tool_input":{"command":"cd /tmp"}}' /nonexistent
+assert_eq "$rc" 2 'no text tools at all refuses too'
 
 printf '\n%s passed, %s failed\n' "$PASS" "$FAIL"
 [ "$FAIL" -eq 0 ]

--- a/hooks/tests/block-bare-cd.test.sh
+++ b/hooks/tests/block-bare-cd.test.sh
@@ -7,6 +7,11 @@
 # argument is optional on both sides of the check: a bare `cd` goes to $HOME,
 # which is the same permanent move as `cd /tmp`.
 #
+# The command reaches the hook JSON-encoded, so the decode is pinned too: a
+# quoted operand carries \" escapes, and a parser that stops at the first
+# quote truncates the chain that scopes the move. Both decode paths are
+# exercised — jq, and the fallback on a PATH without it.
+#
 # HOOK_UNDER_TEST overrides the script under test so the must-fail controls
 # (the pre-fix hook, a no-op hook) run against these same assertions.
 set -euo pipefail
@@ -43,6 +48,22 @@ run_hook() { # command -> rc, stderr in ERR_FILE
   set -e
 }
 
+# A PATH without jq exercises the escape-aware fallback decoder.
+NOJQ_BIN="$TMP_ROOT/nojq"
+mkdir -p "$NOJQ_BIN"
+for tool in cat sed grep head; do
+  real="$(command -v "$tool" 2>/dev/null || true)"
+  [ -n "$real" ] || continue
+  ln -sf "$real" "$NOJQ_BIN/$tool"
+done
+run_hook_nojq() { # command -> rc, stderr in ERR_FILE
+  set +e
+  json_for "$1" | env -i HOME="$HOME" PWD="$PWD" PATH="$NOJQ_BIN" "$BASH_BIN" "$HOOK" \
+    >/dev/null 2>"$ERR_FILE"
+  rc=$?
+  set -e
+}
+
 echo "=== block-bare-cd: refused shapes ==="
 run_hook 'cd';            assert_eq "$rc" 2 'a bare cd with no argument is refused'
 run_hook 'cd ';           assert_eq "$rc" 2 'a bare cd with a trailing space is refused'
@@ -63,6 +84,35 @@ run_hook 'echo cd';           assert_eq "$rc" 0 'a command that only mentions cd
 run_hook 'cdr --version';     assert_eq "$rc" 0 'a command whose name merely starts with cd passes'
 run_hook 'ls -la';            assert_eq "$rc" 0 'an unrelated command passes'
 run_hook 'git checkout main'; assert_eq "$rc" 0 'a command with no cd at all passes'
+
+echo "=== block-bare-cd: a quoted operand does not truncate the command ==="
+run_hook 'cd "$repo" && ls';       assert_eq "$rc" 0 'cd "$repo" && ls is scoped work, not a bare cd'
+run_hook 'cd "$repo"';             assert_eq "$rc" 2 'cd "$repo" alone is still a bare cd'
+run_hook 'cd "/a b" && make';      assert_eq "$rc" 0 'a quoted path with a space does not hide the chain'
+run_hook 'echo "cd \"x\"" > note'; assert_eq "$rc" 0 'a quoted cd inside a string is not a bare cd'
+
+echo "=== block-bare-cd: the same decisions without jq ==="
+run_hook_nojq 'cd "$repo" && ls';  assert_eq "$rc" 0 'without jq, the escape-aware fallback keeps the chain'
+run_hook_nojq 'cd "$repo"';        assert_eq "$rc" 2 'without jq, a quoted bare cd is still refused'
+run_hook_nojq 'cd';                assert_eq "$rc" 2 'without jq, a bare cd with no target is refused'
+run_hook_nojq 'ls -la';            assert_eq "$rc" 0 'without jq, an unrelated command passes'
+
+echo "=== block-bare-cd: an undecodable payload refuses ==="
+set +e
+printf '%s' '{"tool_input":{"command":"cd /tmp"' | "$BASH_BIN" "$HOOK" >/dev/null 2>"$ERR_FILE"; rc=$?
+set -e
+assert_eq "$rc" 2 'a truncated JSON payload refuses rather than skipping the guard'
+assert_contains "$ERR_FILE" 'not valid JSON' 'the parse refusal names the cause'
+set +e
+printf '%s' '{"tool_input":{"command":"cd /tmp' \
+  | env -i HOME="$HOME" PWD="$PWD" PATH="$NOJQ_BIN" "$BASH_BIN" "$HOOK" >/dev/null 2>"$ERR_FILE"; rc=$?
+set -e
+assert_eq "$rc" 2 'without jq, an unterminated command string refuses'
+assert_contains "$ERR_FILE" 'could not decode' 'the no-jq refusal names the cause'
+set +e
+printf '%s' '{"tool_input":{"command":""}}' | "$BASH_BIN" "$HOOK" >/dev/null 2>"$ERR_FILE"; rc=$?
+set -e
+assert_eq "$rc" 0 'an empty command is decoded, not a decode failure'
 
 printf '\n%s passed, %s failed\n' "$PASS" "$FAIL"
 [ "$FAIL" -eq 0 ]


### PR DESCRIPTION
The second defect KEN-649 names, in the same hook. #1693 shipped the first.

`block-bare-cd` decoded the command with a hand-rolled parser whose pattern stopped at the first `"`, escaped or not. A payload carrying `cd "$repo" && ls` therefore decoded to `cd \`, and the anchored heuristic read that as a bare cd and refused it — blocking exactly the scoped form the hook's own message tells you to write.

jq now reads the payload, or the hook refuses. One branch, no hand-rolled decoding: a payload that does not parse, or that names a command which is not a string, is refused rather than skipped; an absent command is the empty string and passes. The classifier behind it is the heuristic that was already there, run on the decoded string — no quote masking, no shell quoting parsed. An operand carrying a literal quote or backslash is classified exactly as it was before this change.

`jq` is now required for the hook to run at all. Without it the hook refuses rather than guessing at the payload.

Source plus the `.claude`, `.codex`, and `.pi/kendex` renders. The Pi extension needs nothing: it receives `input.command` structurally and never parses JSON, and its classifier matches what remains here.

`hooks/tests/block-bare-cd.test.sh` pins the refused and accepted shapes, the quoted-operand chain, and the payloads the hook will not read. 8 of its 26 assertions fail against main.

Closes KEN-649

https://claude.ai/code/session_013tEwaQPxSLwzS1ig1XQ8M1
