### PR TITLE
fix(KEN-657): refresh names an exclude rule that hides a managed tree

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,10 @@ an outside contributor.
   a review thread's tracking claim at the gate, and a `Fixed in <sha>` reply
   is never a claim, whatever its prose says.
 
+- `kendex refresh` says when this checkout's `.git/info/exclude` ignores
+  `.agents`, as it already did for `.gitignore`. An exclude rule hides the
+  tree from git status on one machine only, so its changes never commit.
+
 - On macOS the commit hooks were written but never made executable, so git
   ignored both and an armed repository gated nothing. `guard install` reports
   armed only when the bit is really there.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,9 +51,9 @@ an outside contributor.
   a review thread's tracking claim at the gate, and a `Fixed in <sha>` reply
   is never a claim, whatever its prose says.
 
-- `kendex refresh` says when this checkout's `.git/info/exclude` ignores
-  `.agents`, as it already did for `.gitignore`. An exclude rule hides the
-  tree from git status on one machine only, so its changes never commit.
+- `kendex refresh` says when this clone's `info/exclude` ignores `.agents`,
+  as it already did for `.gitignore`, from any linked worktree too. That
+  rule hides the tree from git status on one machine, so nothing commits it.
 
 - On macOS the commit hooks were written but never made executable, so git
   ignored both and an armed repository gated nothing. `guard install` reports

--- a/crates/core/src/engine/posture.rs
+++ b/crates/core/src/engine/posture.rs
@@ -50,6 +50,20 @@ pub(super) fn plan_posture(
             ".gitignore ignores {ignored} — a teammate who clones this repository gets no skills until that line goes"
         ));
     }
+    // The exclude file is this checkout's alone: a line there hides the
+    // tree from git status here and nowhere else, so what kendex changes
+    // in it never reaches a commit and no pull can put that right. A
+    // linked worktree's `.git` is a file naming the main checkout, whose
+    // own refresh reads the exclude file they share.
+    let git = root.join(".git");
+    if git.is_dir() {
+        let exclude = crate::fs::read_if_exists(&git.join("info/exclude"))?.unwrap_or_default();
+        for ignored in ignores_committed(&exclude) {
+            notes.push(format!(
+                ".git/info/exclude ignores {ignored} — changes kendex makes there never show in git status on this machine, so nothing commits them; that line is local to this checkout"
+            ));
+        }
+    }
     let Some(updated) = with_lock_ignored(&text) else {
         return Ok(());
     };
@@ -180,6 +194,29 @@ mod tests {
             with_lock_ignored("!.kendex-lock.json\n").is_some(),
             "a negation on its own leaves it tracked"
         );
+    }
+
+    /// The exclude file hides a tree from this checkout alone, so the note
+    /// names it as the checkout's own. A linked worktree keeps `.git` as a
+    /// file and reads its exclude through the main checkout, which gets the
+    /// note instead.
+    #[test]
+    fn an_exclude_rule_on_the_shared_tree_is_reported_for_this_checkout() {
+        let dir = tempfile::tempdir().unwrap();
+        let root = dir.path().to_path_buf();
+        std::fs::create_dir_all(root.join(".git/info")).unwrap();
+        std::fs::write(root.join(".git/info/exclude"), ".agents/\n").unwrap();
+        let scope = Scope::Project { root: root.clone() };
+        let mut notes = Vec::new();
+        plan_posture(&scope, &mut Vec::new(), &mut notes).unwrap();
+        assert_eq!(notes.len(), 1, "{notes:?}");
+        assert!(notes[0].starts_with(".git/info/exclude ignores .agents —"));
+
+        std::fs::remove_dir_all(root.join(".git")).unwrap();
+        std::fs::write(root.join(".git"), "gitdir: /elsewhere/.git/worktrees/x\n").unwrap();
+        let mut notes = Vec::new();
+        plan_posture(&scope, &mut Vec::new(), &mut notes).unwrap();
+        assert!(notes.is_empty(), "{notes:?}");
     }
 
     #[test]

--- a/crates/core/src/engine/posture.rs
+++ b/crates/core/src/engine/posture.rs
@@ -40,13 +40,10 @@ pub(super) fn plan_posture(
         return Ok(());
     };
     // Nothing to commit to, nothing to ignore for. A project that is not a
-    // repository gets no file it never had. git says where the repository
-    // is: guessing `<root>/.git` misses a linked worktree, whose `.git` is
-    // a file, and a `--separate-git-dir` layout, whose `.git` is one
-    // everywhere.
-    let Ok(repo) = Repo::at(root) else {
+    // repository gets no file it never had.
+    if !root.join(".git").exists() {
         return Ok(());
-    };
+    }
     let path = root.join(".gitignore");
     let text = crate::fs::read_if_exists(&path)?.unwrap_or_default();
     for ignored in ignores_committed(&text) {
@@ -57,14 +54,25 @@ pub(super) fn plan_posture(
     // The exclude file lives in this clone's git dir, shared by its linked
     // worktrees and nobody else: a line there hides the tree from git
     // status on this machine, so what kendex changes in it never reaches a
-    // commit, and no pull can put that right.
-    let exclude = repo.common_dir.join("info/exclude");
-    let rules = crate::fs::read_if_exists(&exclude)?.unwrap_or_default();
-    for ignored in ignores_committed(&rules) {
-        notes.push(format!(
-            "{} ignores {ignored} — git status on this machine never shows what kendex changes there, and no commit or pull carries that rule; remove it from this clone's git dir",
-            exclude.display()
-        ));
+    // commit, and no pull can put that right. git says where that dir is:
+    // guessing `<root>/.git` misses a linked worktree, whose `.git` is a
+    // file, and a `--separate-git-dir` layout, whose `.git` is one
+    // everywhere. Where git cannot answer, the file goes unchecked and the
+    // note says so; the lock line below is still owed.
+    match Repo::at(root) {
+        Ok(repo) => {
+            let exclude = repo.common_dir.join("info/exclude");
+            let rules = crate::fs::read_if_exists(&exclude)?.unwrap_or_default();
+            for ignored in ignores_committed(&rules) {
+                notes.push(format!(
+                    "{} ignores {ignored} — git status on this machine never shows what kendex changes there, and no commit or pull carries that rule; remove it from this clone's git dir",
+                    exclude.display()
+                ));
+            }
+        }
+        Err(e) => notes.push(format!(
+            "git could not open this repository, so its info/exclude was not checked: {e}"
+        )),
     }
     let Some(updated) = with_lock_ignored(&text) else {
         return Ok(());

--- a/crates/core/src/engine/posture.rs
+++ b/crates/core/src/engine/posture.rs
@@ -254,19 +254,6 @@ mod tests {
         }
     }
 
-    /// A directory outside any repository gets no ignore line and no note.
-    #[test]
-    fn a_directory_that_is_not_a_repository_is_left_alone() {
-        let dir = tempfile::tempdir().unwrap();
-        let mut ops = Vec::new();
-        let mut notes = Vec::new();
-        let scope = Scope::Project {
-            root: dir.path().to_path_buf(),
-        };
-        plan_posture(&scope, &mut ops, &mut notes).unwrap();
-        assert!(ops.is_empty() && notes.is_empty(), "{notes:?}");
-    }
-
     #[test]
     fn ignoring_the_shared_tree_is_reported() {
         assert_eq!(ignores_committed(".agents/\nnode_modules\n"), [".agents"]);

--- a/crates/core/src/engine/posture.rs
+++ b/crates/core/src/engine/posture.rs
@@ -11,6 +11,7 @@
 
 use crate::apply::{Op, PlannedOp, Pre};
 use crate::error::Result;
+use crate::guard::Repo;
 use crate::model::Scope;
 
 /// The line kendex owns, anchored to the project root so a same-named file
@@ -39,10 +40,13 @@ pub(super) fn plan_posture(
         return Ok(());
     };
     // Nothing to commit to, nothing to ignore for. A project that is not a
-    // repository gets no file it never had.
-    if !root.join(".git").exists() {
+    // repository gets no file it never had. git says where the repository
+    // is: guessing `<root>/.git` misses a linked worktree, whose `.git` is
+    // a file, and a `--separate-git-dir` layout, whose `.git` is one
+    // everywhere.
+    let Ok(repo) = Repo::at(root) else {
         return Ok(());
-    }
+    };
     let path = root.join(".gitignore");
     let text = crate::fs::read_if_exists(&path)?.unwrap_or_default();
     for ignored in ignores_committed(&text) {
@@ -50,19 +54,17 @@ pub(super) fn plan_posture(
             ".gitignore ignores {ignored} — a teammate who clones this repository gets no skills until that line goes"
         ));
     }
-    // The exclude file is this checkout's alone: a line there hides the
-    // tree from git status here and nowhere else, so what kendex changes
-    // in it never reaches a commit and no pull can put that right. A
-    // linked worktree's `.git` is a file naming the main checkout, whose
-    // own refresh reads the exclude file they share.
-    let git = root.join(".git");
-    if git.is_dir() {
-        let exclude = crate::fs::read_if_exists(&git.join("info/exclude"))?.unwrap_or_default();
-        for ignored in ignores_committed(&exclude) {
-            notes.push(format!(
-                ".git/info/exclude ignores {ignored} — changes kendex makes there never show in git status on this machine, so nothing commits them; that line is local to this checkout"
-            ));
-        }
+    // The exclude file lives in this clone's git dir, shared by its linked
+    // worktrees and nobody else: a line there hides the tree from git
+    // status on this machine, so what kendex changes in it never reaches a
+    // commit, and no pull can put that right.
+    let exclude = repo.common_dir.join("info/exclude");
+    let rules = crate::fs::read_if_exists(&exclude)?.unwrap_or_default();
+    for ignored in ignores_committed(&rules) {
+        notes.push(format!(
+            "{} ignores {ignored} — git status on this machine never shows what kendex changes there, and no commit or pull carries that rule; remove it from this clone's git dir",
+            exclude.display()
+        ));
     }
     let Some(updated) = with_lock_ignored(&text) else {
         return Ok(());
@@ -196,27 +198,73 @@ mod tests {
         );
     }
 
-    /// The exclude file hides a tree from this checkout alone, so the note
-    /// names it as the checkout's own. A linked worktree keeps `.git` as a
-    /// file and reads its exclude through the main checkout, which gets the
-    /// note instead.
-    #[test]
-    fn an_exclude_rule_on_the_shared_tree_is_reported_for_this_checkout() {
-        let dir = tempfile::tempdir().unwrap();
-        let root = dir.path().to_path_buf();
-        std::fs::create_dir_all(root.join(".git/info")).unwrap();
-        std::fs::write(root.join(".git/info/exclude"), ".agents/\n").unwrap();
-        let scope = Scope::Project { root: root.clone() };
-        let mut notes = Vec::new();
-        plan_posture(&scope, &mut Vec::new(), &mut notes).unwrap();
-        assert_eq!(notes.len(), 1, "{notes:?}");
-        assert!(notes[0].starts_with(".git/info/exclude ignores .agents —"));
+    /// git in a fixture: a HOME of its own so no real global config reaches
+    /// it, and an identity so it can commit.
+    fn git(dir: &std::path::Path, args: &[&str]) {
+        let home = dir.to_str().expect("fixture paths are text");
+        let out = crate::process::Hardened::git(args, Some(dir))
+            .env("HOME", home)
+            .env("GIT_AUTHOR_NAME", "t")
+            .env("GIT_AUTHOR_EMAIL", "t@t")
+            .env("GIT_COMMITTER_NAME", "t")
+            .env("GIT_COMMITTER_EMAIL", "t@t")
+            .run()
+            .expect("git runs");
+        assert!(
+            out.status.success(),
+            "git {args:?}: {}",
+            String::from_utf8_lossy(&out.stderr)
+        );
+    }
 
-        std::fs::remove_dir_all(root.join(".git")).unwrap();
-        std::fs::write(root.join(".git"), "gitdir: /elsewhere/.git/worktrees/x\n").unwrap();
+    fn posture_notes(root: &std::path::Path) -> Vec<String> {
+        let scope = Scope::Project {
+            root: root.to_path_buf(),
+        };
         let mut notes = Vec::new();
         plan_posture(&scope, &mut Vec::new(), &mut notes).unwrap();
-        assert!(notes.is_empty(), "{notes:?}");
+        notes
+    }
+
+    /// The exclude file is read where git keeps it. A linked worktree has
+    /// `.git` as a file and shares the main checkout's exclude, so the same
+    /// rule is reported from both, naming the one file to edit.
+    #[test]
+    fn an_exclude_rule_on_the_shared_tree_is_reported_from_every_checkout() {
+        let dir = tempfile::tempdir().unwrap();
+        let main = dir.path().join("main");
+        std::fs::create_dir_all(&main).unwrap();
+        git(&main, &["init", "-q", "-b", "main"]);
+        git(&main, &["commit", "-q", "--allow-empty", "-m", "start"]);
+        git(&main, &["worktree", "add", "-q", "../linked"]);
+        let linked = dir.path().join("linked");
+        assert!(linked.join(".git").is_file());
+        assert!(posture_notes(&main).is_empty());
+        assert!(posture_notes(&linked).is_empty());
+
+        std::fs::write(main.join(".git/info/exclude"), ".agents/\n").unwrap();
+        for root in [&main, &linked] {
+            let notes = posture_notes(root);
+            assert_eq!(notes.len(), 1, "{notes:?}");
+            assert!(
+                notes[0].contains("info/exclude ignores .agents —"),
+                "{notes:?}"
+            );
+            assert!(!notes[0].contains("linked"), "{notes:?}");
+        }
+    }
+
+    /// A directory outside any repository gets no ignore line and no note.
+    #[test]
+    fn a_directory_that_is_not_a_repository_is_left_alone() {
+        let dir = tempfile::tempdir().unwrap();
+        let mut ops = Vec::new();
+        let mut notes = Vec::new();
+        let scope = Scope::Project {
+            root: dir.path().to_path_buf(),
+        };
+        plan_posture(&scope, &mut ops, &mut notes).unwrap();
+        assert!(ops.is_empty() && notes.is_empty(), "{notes:?}");
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- `kendex refresh` now says when this clone's `info/exclude` ignores `.agents` or `.agents/skills`, the way it already did for `.gitignore`. That rule hides the tree from `git status` on one machine, so nothing commits what kendex changes there and no pull carries the fix.
- The exclude file is read where git keeps it (`Repo::at(root).common_dir`), so a linked worktree gets the note too; the note names the one file to edit. Where git cannot open the repository the note says the check was skipped and the lock-ignore line is still written.

## Completed Issues
- Closes KEN-657 - kendex check is blind to .git/info/exclude hiding managed trees

## Test Plan
- `cargo test -p kendex-core posture`: a real `git init` plus `git worktree add` fixture shows the note from both the main checkout and the linked worktree once `.git/info/exclude` ignores `.agents/`, and no note before.
- `tools/guard` green.
