### PR TITLE
refactor(KEN-671): drop the pre-2.0 remote cache read

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,10 @@ an outside contributor.
 
 ### Changed
 
+- **Breaking:** kendex no longer reads the pre-2.0 mutable clone in the
+  source cache. Nothing has written that layout since 2.0, so a scope whose
+  only copy is there reads as Pending until `kendex refresh` fetches it.
+
 - **Breaking:** `byte-ceiling`'s staged lane now judges a file a commit
   changes, not only one it adds, and reads type changes and moved-and-grown
   files too. A repo that edits an oversized file needs a row for it.

--- a/crates/core/src/remote.rs
+++ b/crates/core/src/remote.rs
@@ -96,17 +96,15 @@ pub fn sync(env: &Env, repo: &str, rev: Option<&str>) -> Result<Resolution> {
     };
     let Some(commit) = store::resolve_ref(&mirror, selector) else {
         // The mirror cannot name this selector: nothing was fetched, or the
-        // branch or tag is gone upstream. The pre-2.0 clone is the last
-        // thing left that might hold content.
-        return match (legacy_resolution(env, repo), fetched) {
-            (Some(resolution), _) => Ok(resolution),
+        // branch or tag is gone upstream.
+        return match fetched {
             // Nothing was ever fetched: the fetch failure is the whole
             // story, and "pinned" or "cached" would both be untrue.
-            (None, Err(error)) => Err(CoreError::FetchFailed {
+            Err(error) => Err(CoreError::FetchFailed {
                 repo: repo.to_owned(),
                 reason: error.to_string(),
             }),
-            (None, Ok(())) => Err(CoreError::PinUnavailable {
+            Ok(()) => Err(CoreError::PinUnavailable {
                 repo: repo.to_owned(),
                 pin: selector.to_owned(),
                 reason: "no such branch or tag".to_owned(),
@@ -157,13 +155,7 @@ pub fn cached(env: &Env, repo: &str, rev: Option<&str>) -> Result<Option<Resolut
             }
         }
     }
-    // A pin is answered by that commit or not at all. The pre-2.0 clone
-    // sits on whatever it last reset to, which is a different commit's
-    // content under a name that promised one.
-    match store::is_pin(selector) {
-        true => Ok(None),
-        false => Ok(legacy_resolution(env, repo)),
-    }
+    Ok(None)
 }
 
 /// Every fetch stamps its mirror, success or failure, so freshness and
@@ -182,21 +174,6 @@ fn stamp_fetch(env: &Env, key: &str, mirror: &std::path::Path, fetched: &Result<
         ),
         Err(error) => crate::drift::stamps::record_failure(env, key, &error.to_string(), now),
     };
-}
-
-/// The v0.1 mutable clone, read where the new layout has nothing yet: an
-/// offline first run after an update still resolves. Nothing writes to it
-/// and nothing deletes it — the first successful refresh publishes a
-/// per-commit checkout and this stops being consulted.
-fn legacy_resolution(env: &Env, repo: &str) -> Option<Resolution> {
-    let legacy = store::legacy_clone(env, repo);
-    store::legacy_head(&legacy).map(|commit| Resolution {
-        commit,
-        root: legacy,
-        warning: Some(format!(
-            "{repo}: reading the pre-2.0 cache; the next refresh replaces it"
-        )),
-    })
 }
 
 /// Fetch every enabled remote source's mirror, pins included. `sync`
@@ -312,8 +289,7 @@ pub fn cache_head(env: &Env, repo: &str, rev: Option<&str>) -> Option<String> {
     let key = cache_key(env, repo);
     let commit = match rev.filter(|rev| store::is_pin(rev)) {
         Some(pin) => pin.to_owned(),
-        None => store::resolve_ref(&store::mirror_dir(env, &key), rev.unwrap_or("HEAD"))
-            .or_else(|| legacy_resolution(env, repo).map(|resolution| resolution.commit))?,
+        None => store::resolve_ref(&store::mirror_dir(env, &key), rev.unwrap_or("HEAD"))?,
     };
     Some(commit.chars().take(7).collect())
 }

--- a/crates/core/src/remote/store.rs
+++ b/crates/core/src/remote/store.rs
@@ -76,12 +76,6 @@ fn receipt_path(env: &Env, key: &str, commit: &str) -> PathBuf {
         .join(format!("{commit}.published"))
 }
 
-/// The v0.1 mutable clone for a repository, kept readable for as long as it
-/// exists: an offline first run after an update still has content to serve.
-pub fn legacy_clone(env: &Env, repo: &str) -> PathBuf {
-    env.source_cache_dir().join(repo.replace('/', "_"))
-}
-
 /// Where cached safety scores for one published commit live — beside the
 /// commit's receipt, never inside its tree: a write into the checkout would
 /// break the tree signature the receipt vouches for.
@@ -245,15 +239,6 @@ pub fn has_commit(mirror: &Path, commit: &str) -> bool {
     Hardened::git_bare(mirror, &["cat-file", "-e", &format!("{commit}^{{commit}}")])
         .run()
         .is_ok_and(|output| output.status.success())
-}
-
-/// The commit a v0.1 mutable clone is sitting on.
-pub fn legacy_head(clone: &Path) -> Option<String> {
-    clone
-        .join(".git")
-        .is_dir()
-        .then(|| stdout(Hardened::git_in(clone, &["rev-parse", "HEAD"])))
-        .flatten()
 }
 
 /// A published checkout, if the cache holds this commit unmodified. A

--- a/crates/core/src/remote/tests.rs
+++ b/crates/core/src/remote/tests.rs
@@ -288,49 +288,6 @@ fn one_repository_spelled_three_ways_keeps_one_cache_entry() {
     assert_ne!(key, store::repo_key("https://other.test/owner/repo"));
 }
 
-/// The v0.1 mutable clone still answers while the new layout has nothing,
-/// so an offline first run after an update is not a dead end. Nothing
-/// deletes it; the first successful refresh simply stops needing it.
-#[test]
-fn the_pre_2_0_clone_is_read_until_a_refresh_replaces_it() {
-    let f = fixture();
-    let legacy = store::legacy_clone(&f.env, REPO);
-    fs::create_dir_all(legacy.parent().unwrap()).unwrap();
-    git(
-        f.env.source_cache_dir().as_path(),
-        &[
-            "clone",
-            "--quiet",
-            &clone_url(&f.env, REPO),
-            &legacy.display().to_string(),
-        ],
-    );
-
-    let migrated = cached(&f.env, REPO, None).unwrap().unwrap();
-    assert_eq!(migrated.root, legacy);
-    assert!(migrated.warning.unwrap().contains("pre-2.0"));
-
-    // A pin is answered by its own commit or not at all: the old clone
-    // sits on whatever it last reset to, which is not what was pinned.
-    assert!(
-        cached(&f.env, REPO, Some(&"b".repeat(40)))
-            .unwrap()
-            .is_none()
-    );
-
-    let refreshed = sync(&f.env, REPO, None).unwrap();
-    assert!(
-        refreshed
-            .root
-            .starts_with(f.env.source_cache_dir().join("commits"))
-    );
-    assert!(legacy.is_dir(), "a user's cache is never deleted for them");
-    assert_eq!(
-        cached(&f.env, REPO, None).unwrap().unwrap().root,
-        refreshed.root
-    );
-}
-
 /// The lock lives as long as its guard and not a moment longer — an
 /// abandoned lock file would wedge a repository until someone deleted it.
 #[test]

--- a/tools/size-ratchet-baseline.tsv
+++ b/tools/size-ratchet-baseline.tsv
@@ -6,7 +6,7 @@ crates/core/src/engine/pi_hooks_move/migrated.rs	540
 crates/core/src/engine/pi_hooks_move/mod.rs	502
 crates/core/src/engine/pi_hooks_move/preflight.rs	765
 crates/core/src/error.rs	416
-crates/core/src/remote/store.rs	420
+crates/core/src/remote/store.rs	405
 docs/ARCHITECTURE.md	801
 hooks/block-repo-copy.sh	511
 pi-extensions/pi-agents-tmux/extensions/subagent/browser.ts	650


### PR DESCRIPTION
Closes KEN-671.

KEN-669 purged the vstack/v1 read paths and left this one, because its
inventory was grep-derived from `vstack` and nothing here carries that
string: `remote::legacy_resolution` reading `store::legacy_clone` and
`store::legacy_head`, the v0.1 mutable-clone layout, consulted wherever the
per-commit store had nothing yet.

No build since 2.0 writes that layout, so under the zero-consumer assumption
the only thing the read could ever find is a directory a pre-2.0 install left
behind. Keeping it means carrying a resolution path, a warning nobody can
trigger, and a fixture that builds the old layout by hand to have something
to read.

It goes whole rather than shrinking. `sync` now answers the fetch it actually
made when the mirror cannot name a selector, `cached` returns `None`, and
`cache_head` reads the mirror or nothing.

Removing the read changes offline resolution, which is the breaking line in
the changelog: a scope whose only cached copy is the old layout reads as
Pending until a refresh fetches it, rather than resolving to whatever commit
that clone was last reset to.

The `crates/core/src/remote/store.rs` baseline row moves down 420 → 405; the
ratchet only moves down.
