### PR TITLE
fix(KEN-700): an in-place skill is the user's own in the library join

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,9 @@ an outside contributor.
   every Bash call it matches on a host without it — install jq wherever the hook
   runs. Its own parser stopped at the first quote, mis-refusing `cd "$d" && ls`.
 
+- The Library's From column says "Your own" for a skill adopted in place;
+  it read as a marketplace with no repository.
+
 - The `block-bare-cd` hook refuses a bare `cd` with no path. It changes to
   `$HOME` for every later tool call, the move the hook exists to stop, and
   only `cd <path>` was caught before.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,8 +57,9 @@ an outside contributor.
   every Bash call it matches on a host without it — install jq wherever the hook
   runs. Its own parser stopped at the first quote, mis-refusing `cd "$d" && ls`.
 
-- The Library's From column says "Your own" for a skill adopted in place;
-  it read as a marketplace with no repository.
+- The Library's From column says "Your own" for a skill adopted in place
+  (it read as a marketplace with no repository), and the Mine import
+  inventory reads such a skill's bytes from the tree it sits in.
 
 - The `block-bare-cd` hook refuses a bare `cd` with no path. It changes to
   `$HOME` for every later tool call, the move the hook exists to stop, and

--- a/crates/core/src/author/import/origins.rs
+++ b/crates/core/src/author/import/origins.rs
@@ -8,7 +8,7 @@ use std::path::{Path, PathBuf};
 use crate::env::Env;
 use crate::error::{CoreError, Result};
 use crate::library::Origin;
-use crate::manifest::{LOCAL_SOURCE_NAME, Manifest, ManifestFile};
+use crate::manifest::{INPLACE_SOURCE_NAME, Manifest, ManifestFile};
 use crate::model::{ItemKind, Scope};
 use crate::source_read::SealedSource;
 
@@ -50,9 +50,19 @@ pub(super) fn origins_of(
     observed: &BTreeMap<(Scope, ItemKind, String), PathBuf>,
 ) -> Vec<OriginRead> {
     match &row.origin {
-        Origin::Own { .. } => {
-            let root = crate::source::local_source_root(env, &row.scope);
-            match catalog_bytes(&root, LOCAL_SOURCE_NAME, row) {
+        Origin::Own { source, .. } => {
+            // The reserved source names where the bytes live: the local
+            // capture, or the shared tree an in-place skill is read from
+            // (a scope with no such tree holds no in-place rows).
+            let root = if source == INPLACE_SOURCE_NAME {
+                match crate::source::inplace_source_root(&row.scope) {
+                    Some(root) => root,
+                    None => return Vec::new(),
+                }
+            } else {
+                crate::source::local_source_root(env, &row.scope)
+            };
+            match catalog_bytes(&root, source, row) {
                 Some((bytes, location, read_from)) => {
                     vec![(CandidateGroup::Own, bytes, location, Some(read_from))]
                 }

--- a/crates/core/src/author/import/tests.rs
+++ b/crates/core/src/author/import/tests.rs
@@ -1,3 +1,4 @@
+use std::collections::BTreeMap;
 use std::collections::BTreeSet;
 use std::fs;
 use std::path::Path;
@@ -249,3 +250,51 @@ fn a_stale_hash_refuses_instead_of_copying_moved_bytes() {
 }
 
 mod review;
+
+/// A skill adopted in place: its bytes live under the project's shared
+/// `.agents` tree, and the owned row reads from there — before KEN-700 the
+/// read went to the local source, found nothing, and the only claim left
+/// was whatever an unlocked harness happened to observe.
+#[test]
+#[allow(clippy::unwrap_used)]
+fn an_in_place_skill_is_an_own_candidate_read_from_its_tree() {
+    let tmp = tempfile::tempdir().unwrap();
+    let env = Env::fake(tmp.path(), FakeOs::Linux);
+    let project = tmp.path().join("app");
+    skill(&project.join(".agents/skills"), "here", "in place bytes");
+    fs::write(
+        project.join("kendex.toml"),
+        "schema = 6\n[skills.here]\nsource = \"in-place\"\n",
+    )
+    .unwrap();
+    let project = project.canonicalize().unwrap();
+    let scope = Scope::Project { root: project };
+    let mut lock = Lock {
+        version: crate::lock::LOCK_VERSION,
+        ..Lock::default()
+    };
+    lock.entries.insert(
+        crate::lock::entry_key(ItemKind::Skill, "here", HarnessId::Claude),
+        entry(ItemKind::Skill, "here", "in-place", ""),
+    );
+    crate::lock::save(&crate::lock::lock_path(&env, &scope), &lock).unwrap();
+
+    let rows = crate::library::provenance(&env, std::slice::from_ref(&scope)).unwrap();
+    let own_row = rows
+        .iter()
+        .find(|r| r.name == "here" && matches!(r.origin, crate::library::Origin::Own { .. }))
+        .unwrap_or_else(|| panic!("no own row: {rows:?}"));
+    let reads = origins_of(&env, own_row, &BTreeMap::new());
+    let [(group, bytes, location, _)] = reads.as_slice() else {
+        panic!("one owned read expected, got {}", reads.len());
+    };
+    assert!(matches!(group, CandidateGroup::Own));
+    assert!(bytes.is_some());
+    assert!(location.contains(".agents/skills/here"), "{location}");
+
+    // The candidate the wizard lists carries those bytes, so the skill is
+    // importable; identical observed claims may still govern its group.
+    let candidates = inventory(&env, &[scope]).unwrap();
+    let here = find(&candidates, "here");
+    assert!(here.origins.iter().any(|o| !o.hash.is_empty()));
+}

--- a/crates/core/src/library.rs
+++ b/crates/core/src/library.rs
@@ -2,9 +2,10 @@
 //! table reads for its From column.
 //!
 //! The lock is the durable provenance record (invariant 4), so it decides:
-//! an entry from the reserved `local` source is the user's own content —
-//! forked, when `[forks]` says what it replaced — and any other entry names
-//! the subscription it installed from. What the scanner observes and the
+//! an entry from a reserved source — `local`, or `in-place` for a project
+//! skill adopted where it sits — is the user's own content, forked when
+//! `[forks]` says what it replaced, and any other entry names the
+//! subscription it installed from. What the scanner observes and the
 //! lock cannot account for is unmanaged, reported and never touched.
 
 use std::collections::BTreeMap;
@@ -15,7 +16,7 @@ use specta::Type;
 use crate::env::Env;
 use crate::error::Result;
 use crate::lock::LockFile;
-use crate::manifest::{LOCAL_SOURCE_NAME, Manifest, ManifestFile};
+use crate::manifest::{INPLACE_SOURCE_NAME, LOCAL_SOURCE_NAME, Manifest, ManifestFile};
 use crate::model::{HarnessId, ItemKind, Scope};
 
 /// Where one installation came from.
@@ -95,7 +96,7 @@ pub fn provenance(env: &Env, scopes: &[Scope]) -> Result<Vec<ProvenanceRow>> {
 }
 
 fn origin_of(manifest: &Manifest, entry: &crate::lock::LockEntry) -> Origin {
-    if entry.source == LOCAL_SOURCE_NAME {
+    if entry.source == LOCAL_SOURCE_NAME || entry.source == INPLACE_SOURCE_NAME {
         return Origin::Own {
             forked_from: manifest
                 .forks

--- a/crates/core/src/library.rs
+++ b/crates/core/src/library.rs
@@ -30,9 +30,13 @@ pub enum Origin {
     /// Installed from a subscription: its declared alias and its repository
     /// (or path) as the lock recorded them.
     Marketplace { source: String, repo: String },
-    /// The user's own content in the local source — adopted, or forked off
-    /// a marketplace item, in which case this names what it replaced.
-    Own { forked_from: Option<String> },
+    /// The user's own content — adopted or forked (`forked_from` names what
+    /// a fork replaced), with `source` naming the reserved source that holds
+    /// it: `local` for a capture, `in-place` for a tree read where it sits.
+    Own {
+        forked_from: Option<String>,
+        source: String,
+    },
     /// On disk and observed, managed by nothing.
     Unmanaged,
 }
@@ -98,6 +102,7 @@ pub fn provenance(env: &Env, scopes: &[Scope]) -> Result<Vec<ProvenanceRow>> {
 fn origin_of(manifest: &Manifest, entry: &crate::lock::LockEntry) -> Origin {
     if entry.source == LOCAL_SOURCE_NAME || entry.source == INPLACE_SOURCE_NAME {
         return Origin::Own {
+            source: entry.source.clone(),
             forked_from: manifest
                 .forks
                 .get(&entry.kind)

--- a/crates/core/src/library/tests.rs
+++ b/crates/core/src/library/tests.rs
@@ -96,11 +96,16 @@ fn origins_are_read_off_the_lock_manifest_and_scan() {
     assert_eq!(
         origin("fk"),
         Origin::Own {
-            forked_from: Some("owner/repo".to_owned())
+            forked_from: Some("owner/repo".to_owned()),
+            source: "local".to_owned()
         }
     );
-    assert_eq!(origin("mine"), Origin::Own { forked_from: None });
-    assert_eq!(origin("here"), Origin::Own { forked_from: None });
+    let own = |source: &str| Origin::Own {
+        forked_from: None,
+        source: source.to_owned(),
+    };
+    assert_eq!(origin("mine"), own("local"));
+    assert_eq!(origin("here"), own("in-place"));
     assert_eq!(origin("stray"), Origin::Unmanaged);
     let stray = rows
         .iter()

--- a/crates/core/src/library/tests.rs
+++ b/crates/core/src/library/tests.rs
@@ -61,9 +61,15 @@ fn origins_are_read_off_the_lock_manifest_and_scan() {
         version: crate::lock::LOCK_VERSION,
         ..Lock::default()
     };
-    for (name, source) in [("gh", "cat"), ("fk", "local"), ("mine", "local")] {
+    for (name, source) in [
+        ("gh", "cat"),
+        ("fk", "local"),
+        ("mine", "local"),
+        ("here", "in-place"),
+    ] {
         let repo = match source {
             "cat" => "owner/repo",
+            "in-place" => "",
             _ => "local",
         };
         lock.entries.insert(
@@ -94,6 +100,7 @@ fn origins_are_read_off_the_lock_manifest_and_scan() {
         }
     );
     assert_eq!(origin("mine"), Origin::Own { forked_from: None });
+    assert_eq!(origin("here"), Origin::Own { forked_from: None });
     assert_eq!(origin("stray"), Origin::Unmanaged);
     let stray = rows
         .iter()

--- a/crates/core/src/source/config.rs
+++ b/crates/core/src/source/config.rs
@@ -131,7 +131,12 @@ pub fn source_config(sealed: &SealedSource, display: &str) -> Result<SourceConfi
 /// discovered third-party repo's never do.
 pub fn source_config_for(sealed: &SealedSource, provenance: &str) -> Result<SourceConfig> {
     let mut config = source_config(sealed, crate::source::repo_leaf(provenance))?;
-    if provenance == crate::manifest::LOCAL_SOURCE_NAME && config.mode == CatalogMode::Discovered {
+    // The reserved sources share one shape — `skills/<name>` under the
+    // root — so both read explicitly rather than by discovery.
+    if (provenance == crate::manifest::LOCAL_SOURCE_NAME
+        || provenance == crate::manifest::INPLACE_SOURCE_NAME)
+        && config.mode == CatalogMode::Discovered
+    {
         config.mode = CatalogMode::Explicit;
     }
     Ok(config)

--- a/ui/src/bindings.ts
+++ b/ui/src/bindings.ts
@@ -1673,10 +1673,11 @@ export type Origin =
  */
 { origin: "marketplace"; source: string; repo: string } | 
 /**
- *  The user's own content in the local source — adopted, or forked off
- *  a marketplace item, in which case this names what it replaced.
+ *  The user's own content — adopted or forked (`forked_from` names what
+ *  a fork replaced), with `source` naming the reserved source that holds
+ *  it: `local` for a capture, `in-place` for a tree read where it sits.
  */
-{ origin: "own"; forkedFrom: string | null } | 
+{ origin: "own"; forkedFrom: string | null; source: string } | 
 /**  On disk and observed, managed by nothing. */
 { origin: "unmanaged" };
 

--- a/ui/src/dev/fixture-provenance.ts
+++ b/ui/src/dev/fixture-provenance.ts
@@ -33,7 +33,7 @@ export function provenance(): ProvenanceRow[] {
       kind: "skill",
       name: "release-notes",
       harness: "claude",
-      origin: { origin: "own", forkedFrom: KENDEX_REPO },
+      origin: { origin: "own", forkedFrom: KENDEX_REPO, source: "local" },
     },
     {
       scope: GLOBAL,

--- a/ui/src/stores/provenance.test.ts
+++ b/ui/src/stores/provenance.test.ts
@@ -15,7 +15,7 @@ const ROWS: ProvenanceRow[] = [
     kind: "skill",
     name: "gh",
     harness: "claude",
-    origin: { origin: "own", forkedFrom: "kendex" },
+    origin: { origin: "own", forkedFrom: "kendex", source: "local" },
   },
   {
     scope: { scope: "global" },
@@ -38,7 +38,7 @@ describe("the From column's join", () => {
     // a fork there does not relabel the global install.
     expect(
       originFor(ROWS, "skill", "gh", [{ scope: "project", root: "/work/app" }]),
-    ).toEqual({ origin: "own", forkedFrom: "kendex" });
+    ).toEqual({ origin: "own", forkedFrom: "kendex", source: "local" });
     // A same-named item of another kind never borrows this one's origin.
     expect(originFor(ROWS, "hook", "gh", [{ scope: "global" }])).toBeNull();
   });
@@ -50,13 +50,15 @@ describe("the From column's join", () => {
     expect(
       originTitle({ origin: "marketplace", source: "kendex", repo: "r" }),
     ).toBe("r");
-    expect(originLabel({ origin: "own", forkedFrom: "kendex" })).toBe(
-      "Your own",
-    );
-    expect(originTitle({ origin: "own", forkedFrom: "kendex" })).toBe(
-      "forked from kendex",
-    );
-    expect(originTitle({ origin: "own", forkedFrom: null })).toBeUndefined();
+    expect(
+      originLabel({ origin: "own", forkedFrom: "kendex", source: "local" }),
+    ).toBe("Your own");
+    expect(
+      originTitle({ origin: "own", forkedFrom: "kendex", source: "local" }),
+    ).toBe("forked from kendex");
+    expect(
+      originTitle({ origin: "own", forkedFrom: null, source: "local" }),
+    ).toBeUndefined();
     expect(originLabel({ origin: "unmanaged" })).toBe("Not managed");
     expect(originLabel(null)).toBe("");
   });


### PR DESCRIPTION
Closes KEN-700

The Library From column read a skill adopted in place as a marketplace with no repository: `origin_of` only treated the reserved `local` source as the user's own. `in-place` is the same thing (invariant 6), so it now answers `Own` too, and `library/tests.rs` pins it beside the `local` case.

Found on the hyprtrade in-place migration: four project skills adopted with `kendex adopt skill <name>`, then the provenance the app calls.

https://claude.ai/code/session_01EadfQCVMnyCtyvK2t3kc5n