### PR TITLE
fix(KEN-646): refresh takes back the skill links a layout change dropped

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -73,9 +73,9 @@ an outside contributor.
   as it already did for `.gitignore`, from any linked worktree too. That
   rule hides the tree from git status on one machine, so nothing commits it.
 
-- The lock records each skill's tree and links, so a layout change takes the
-  old link back. **Breaking:** on a scope an older kendex set up, delete
-  `.kendex-lock.json`, `.agents/skills` and each tool's skill links, then apply.
+- The lock records each skill's tree and links. **Breaking:** an install an
+  older kendex made is redone by hand: remove that scope's lock file and the
+  skill trees and links kendex wrote, nothing else beside them; then apply.
 
 - On macOS the commit hooks were written but never made executable, so git
   ignored both and an armed repository gated nothing. `guard install` reports

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -73,9 +73,9 @@ an outside contributor.
   as it already did for `.gitignore`, from any linked worktree too. That
   rule hides the tree from git status on one machine, so nothing commits it.
 
-- The lock records where each skill's tree and link landed, so a later layout
-  change takes the old link back on refresh. **Breaking:** skill installs an
-  earlier kendex recorded are reinstalled once; links they left go by hand.
+- The lock records each skill's tree and links, so a layout change takes the
+  old link back. **Breaking:** on a scope an older kendex set up, delete
+  `.kendex-lock.json`, `.agents/skills` and each tool's skill links, then apply.
 
 - On macOS the commit hooks were written but never made executable, so git
   ignored both and an armed repository gated nothing. `guard install` reports

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -73,9 +73,9 @@ an outside contributor.
   as it already did for `.gitignore`, from any linked worktree too. That
   rule hides the tree from git status on one machine, so nothing commits it.
 
-- A refresh takes back a skill link an earlier kendex wrote where the current
-  layout puts none: the lock records where each skill's tree and link landed,
-  and removal reads that instead of deriving today's path.
+- The lock records where each skill's tree and link landed, so a later layout
+  change takes the old link back on refresh. **Breaking:** skill installs an
+  earlier kendex recorded are reinstalled once; links they left go by hand.
 
 - On macOS the commit hooks were written but never made executable, so git
   ignored both and an armed repository gated nothing. `guard install` reports

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -73,6 +73,10 @@ an outside contributor.
   as it already did for `.gitignore`, from any linked worktree too. That
   rule hides the tree from git status on one machine, so nothing commits it.
 
+- A refresh takes back a skill link an earlier kendex wrote where the current
+  layout puts none: the lock records where each skill's tree and link landed,
+  and removal reads that instead of deriving today's path.
+
 - On macOS the commit hooks were written but never made executable, so git
   ignored both and an armed repository gated nothing. `guard install` reports
   armed only when the bit is really there.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -74,8 +74,8 @@ an outside contributor.
   rule hides the tree from git status on one machine, so nothing commits it.
 
 - The lock records each skill's tree and links. **Breaking:** an install an
-  older kendex made is redone by hand: remove that scope's lock file and the
-  skill trees and links kendex wrote, nothing else beside them; then apply.
+  older kendex made is redone by hand: refresh, then remove that scope's lock
+  file and the skill trees and links kendex wrote, nothing else; then apply.
 
 - On macOS the commit hooks were written but never made executable, so git
   ignored both and an armed repository gated nothing. `guard install` reports

--- a/crates/core/src/engine/desired.rs
+++ b/crates/core/src/engine/desired.rs
@@ -35,8 +35,9 @@ pub struct Desired {
     pub recorded_fork: bool,
     pub hash: String,
     pub upstream_skills: Option<Vec<String>>,
-    /// Set when the artifact is not this kind's native form — the lock
-    /// records it so removal targets what was written.
+    /// Set where deriving the place again could name another one — a
+    /// command stored as a skill, a skill's tree and link — so the lock
+    /// records it and removal targets what was written.
     pub emitted: Option<crate::lock::EmittedArtifact>,
     /// Every reason this installation is wanted, derived fresh each pass.
     pub reasons: BTreeSet<crate::lock::Reason>,

--- a/crates/core/src/engine/desired_skill.rs
+++ b/crates/core/src/engine/desired_skill.rs
@@ -2,7 +2,7 @@ use std::path::PathBuf;
 
 use crate::error::Result;
 use crate::hash::{hash_files, installation_hash};
-use crate::lock::entry_key;
+use crate::lock::{EmittedArtifact, entry_key};
 use crate::manifest::Method;
 use crate::model::{HarnessId, ItemKind, Scope};
 use crate::render::skill::render_skill;
@@ -159,6 +159,20 @@ pub(super) fn desired_skill(ctx: &ItemCtx, state: &mut DesiredState) -> Result<(
                 ),
             }
         };
+        let artifact = Artifact::Tree {
+            canonical,
+            files: variant.files.clone(),
+            link,
+        };
+        // Where the tree and the link landed goes on the record. A tool's
+        // directory moves between kendex versions, and a pass that derived
+        // the place again would name one this install never wrote — the
+        // link it did write is then findable only through the record.
+        let emitted = Some(EmittedArtifact {
+            kind: ItemKind::Skill,
+            name: group.installed.clone(),
+            paths: artifact.paths(),
+        });
         for harness in &group.members {
             state.items.push(Desired {
                 key: entry_key(ItemKind::Skill, ctx.name, *harness),
@@ -180,13 +194,9 @@ pub(super) fn desired_skill(ctx: &ItemCtx, state: &mut DesiredState) -> Result<(
                     *harness,
                 )?,
                 upstream_skills: None,
-                emitted: None,
+                emitted: emitted.clone(),
                 reasons: ctx.reasons_for(*harness),
-                artifact: Artifact::Tree {
-                    canonical: canonical.clone(),
-                    files: variant.files.clone(),
-                    link: link.clone(),
-                },
+                artifact: artifact.clone(),
             });
         }
     }

--- a/crates/core/src/engine/mod.rs
+++ b/crates/core/src/engine/mod.rs
@@ -179,7 +179,7 @@ fn plan_scope_once(
             notes: &mut moved_notes,
         },
     )?;
-    removal::stale_emitted(&state, lock, &new_lock, &mut guard, &mut ops)?;
+    removal::stale_emitted(lock, &new_lock, &mut guard, &mut ops)?;
 
     let refused_keys = plan_pass::plan_refusals(
         env,

--- a/crates/core/src/engine/mod.rs
+++ b/crates/core/src/engine/mod.rs
@@ -179,7 +179,7 @@ fn plan_scope_once(
             notes: &mut moved_notes,
         },
     )?;
-    removal::stale_emitted(&state, lock, &mut guard, &mut ops)?;
+    removal::stale_emitted(&state, lock, &new_lock, &mut guard, &mut ops)?;
 
     let refused_keys = plan_pass::plan_refusals(
         env,

--- a/crates/core/src/engine/owned.rs
+++ b/crates/core/src/engine/owned.rs
@@ -41,6 +41,12 @@ pub(super) fn installed(env: &Env, scope: &Scope, entry: &LockEntry) -> Owned {
                 files.push(dir.join(file_name(entry.harness, &entry.name)));
             }
         }
+        // The tree and the link this install recorded landing at. A tool's
+        // directory moves between kendex versions, and the place derived
+        // today is then one this install never wrote.
+        ItemKind::Skill if entry.emitted.is_some() => {
+            files.extend(entry.emitted.iter().flat_map(|e| e.paths.iter().cloned()));
+        }
         ItemKind::Skill => {
             // The directory this entry's method actually wrote. A tool that
             // reads the shared tree as well as one of its own has two, and

--- a/crates/core/src/engine/owned.rs
+++ b/crates/core/src/engine/owned.rs
@@ -35,59 +35,31 @@ pub(super) struct Owned {
 pub(super) fn installed(env: &Env, scope: &Scope, entry: &LockEntry) -> Owned {
     let mut files: Vec<PathBuf> = Vec::new();
     let mut edits: Vec<(PathBuf, ConfigEdit)> = Vec::new();
-    match entry.kind {
-        ItemKind::Agent => {
+    match (&entry.emitted, entry.kind) {
+        // What an install recorded landing at beats deriving a place it
+        // never took: a codex command stored as a skill tree under a name
+        // the collision rules may have changed, a skill's tree and the
+        // link a tool's directory has since moved away from.
+        (Some(emitted), _) => files.extend(emitted.paths.iter().cloned()),
+        (None, ItemKind::Agent) => {
             if let Some(dir) = native_dir(env, scope, entry.harness, ItemKind::Agent) {
                 files.push(dir.join(file_name(entry.harness, &entry.name)));
             }
         }
-        // The tree and the link this install recorded landing at. A tool's
-        // directory moves between kendex versions, and the place derived
-        // today is then one this install never wrote.
-        ItemKind::Skill if entry.emitted.is_some() => {
-            files.extend(entry.emitted.iter().flat_map(|e| e.paths.iter().cloned()));
-        }
-        ItemKind::Skill => {
-            // The directory this entry's method actually wrote. A tool that
-            // reads the shared tree as well as one of its own has two, and
-            // reading the wrong one leaves a copy install's real tree
-            // unremovable and protects a path nothing wrote.
-            let copies = entry.method == crate::manifest::Method::Copy;
-            let dir = match copies {
-                true => super::desired::own_dir(env, scope, entry.harness, ItemKind::Skill),
-                false => native_dir(env, scope, entry.harness, ItemKind::Skill),
-            };
-            if let Some(dir) = dir {
-                files.push(dir.join(crate::harness::rendered_name(entry.harness, &entry.name)));
-            }
-            // Only a shared install has a shared tree. A copy install put
-            // its bytes in the tool's own directory and never wrote that
-            // tree, so claiming it here would call somebody else's content
-            // ours — and what protects unmanaged bytes is exactly not being
-            // called ours.
-            if !copies {
-                let canonical = super::desired::skill_canonical(env, scope, &entry.name);
-                if !files.contains(&canonical) {
-                    files.push(canonical);
-                }
+        // A skill owns exactly what it recorded, and a record naming
+        // nothing owns nothing: deriving today's place for it would claim
+        // a position this install may never have written.
+        (None, ItemKind::Skill) => {}
+        (None, ItemKind::Command) => {
+            if let Some(dir) = native_dir(env, scope, entry.harness, ItemKind::Command) {
+                files.push(dir.join(super::desired_command::command_file(
+                    entry.harness,
+                    &entry.name,
+                )));
             }
         }
-        // A codex command was written as a skill tree, under a name the
-        // collision rules may have changed: the record of what landed
-        // beats deriving a path this install never took.
-        ItemKind::Command => match &entry.emitted {
-            Some(emitted) => files.extend(emitted.paths.iter().cloned()),
-            None => {
-                if let Some(dir) = native_dir(env, scope, entry.harness, ItemKind::Command) {
-                    files.push(dir.join(super::desired_command::command_file(
-                        entry.harness,
-                        &entry.name,
-                    )));
-                }
-            }
-        },
-        ItemKind::Hook => hook_owned(env, scope, entry, &mut files, &mut edits),
-        ItemKind::McpServer => {
+        (None, ItemKind::Hook) => hook_owned(env, scope, entry, &mut files, &mut edits),
+        (None, ItemKind::McpServer) => {
             if let Some(registry) = mcp_registry(env, scope, entry.harness) {
                 edits.push((
                     registry,
@@ -112,7 +84,7 @@ pub(super) fn installed(env: &Env, scope: &Scope, entry: &LockEntry) -> Owned {
                 ));
             }
         }
-        ItemKind::Plugin => {
+        (None, ItemKind::Plugin) => {
             if let Some(settings) = plugin_settings(env, scope, entry.harness) {
                 edits.push((
                     settings,
@@ -123,7 +95,7 @@ pub(super) fn installed(env: &Env, scope: &Scope, entry: &LockEntry) -> Owned {
                 ));
             }
         }
-        ItemKind::PiExtension => {}
+        (None, ItemKind::PiExtension) => {}
     }
     Owned { files, edits }
 }

--- a/crates/core/src/engine/removal.rs
+++ b/crates/core/src/engine/removal.rs
@@ -176,20 +176,16 @@ impl TrashGuard {
 /// replacement, so the paths it recorded are still what runs; taking them
 /// off would leave the tool disconnected from a tree that stayed.
 pub(super) fn stale_emitted(
-    state: &desired::DesiredState,
     lock: &Lock,
     new_lock: &Lock,
     guard: &mut TrashGuard,
     ops: &mut Vec<PlannedOp>,
 ) -> Result<()> {
-    for item in &state.items {
-        let Some(entry) = lock.entries.get(&item.key) else {
+    for (key, recorded) in &new_lock.entries {
+        let Some(entry) = lock.entries.get(key) else {
             continue;
         };
         let Some(previous) = entry.emitted.as_ref() else {
-            continue;
-        };
-        let Some(recorded) = new_lock.entries.get(&item.key) else {
             continue;
         };
         let current = recorded.emitted.iter().flat_map(|e| e.paths.iter());
@@ -215,8 +211,8 @@ pub(super) fn stale_emitted(
             let planned = trash(
                 format!(
                     "Move {} {}'s old files to the trash",
-                    item.kind.name(),
-                    item.name
+                    recorded.kind.name(),
+                    recorded.name
                 ),
                 path.clone(),
             )?;

--- a/crates/core/src/engine/removal.rs
+++ b/crates/core/src/engine/removal.rs
@@ -165,12 +165,20 @@ impl TrashGuard {
 }
 
 /// An earlier install of a still-declared item wrote somewhere this one will
-/// not: a codex command whose emitted name changed when a skill claimed it.
-/// The tree it left is ours and nobody wants it now — without this it stays
-/// on disk forever, offered by the tool under a name nobody declared.
+/// not: a codex command whose emitted name changed when a skill claimed it,
+/// a skill whose link a later layout no longer produces. What it left is
+/// ours and nobody wants it now — without this it stays on disk forever,
+/// offered by the tool under a name nobody declared, or absolute and
+/// committed.
+///
+/// Judged by the record this pass writes, not by what it rendered. An
+/// item held or refused carries its old record forward and plans no
+/// replacement, so the paths it recorded are still what runs; taking them
+/// off would leave the tool disconnected from a tree that stayed.
 pub(super) fn stale_emitted(
     state: &desired::DesiredState,
     lock: &Lock,
+    new_lock: &Lock,
     guard: &mut TrashGuard,
     ops: &mut Vec<PlannedOp>,
 ) -> Result<()> {
@@ -181,7 +189,10 @@ pub(super) fn stale_emitted(
         let Some(previous) = entry.emitted.as_ref() else {
             continue;
         };
-        let current = item.emitted.iter().flat_map(|e| e.paths.iter());
+        let Some(recorded) = new_lock.entries.get(&item.key) else {
+            continue;
+        };
+        let current = recorded.emitted.iter().flat_map(|e| e.paths.iter());
         for path in &previous.paths {
             if current.clone().any(|kept| kept == path) {
                 continue;

--- a/crates/core/src/lock.rs
+++ b/crates/core/src/lock.rs
@@ -156,9 +156,9 @@ pub struct LockEntry {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub upstream_skills: Option<Vec<String>>,
     /// Where the artifact landed: a command a harness stores as another
-    /// kind, a skill's tree and the link a tool reads it through. Removal
-    /// and refresh read it instead of deriving a path the install never
-    /// took.
+    /// kind, a skill's tree plus the link where the tool reads it through
+    /// one. Removal and refresh read it instead of deriving a path the
+    /// install never took.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub emitted: Option<EmittedArtifact>,
     /// The registry entry this hook registered, as the registry keys it.
@@ -210,7 +210,7 @@ pub struct HookRegistration {
 
 /// The artifact one installation actually put on disk, in the harness's own
 /// terms: a codex command lands as a skill, under a name the user types; a
-/// skill lands as one tree plus the link a tool reads it through.
+/// skill lands as one tree, plus the link where the tool reads it through one.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Type)]
 #[serde(rename_all = "camelCase")]
 pub struct EmittedArtifact {

--- a/crates/core/src/lock.rs
+++ b/crates/core/src/lock.rs
@@ -155,9 +155,10 @@ pub struct LockEntry {
     /// across cache loss and machines.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub upstream_skills: Option<Vec<String>>,
-    /// What was written, when the harness stores this kind as another one.
-    /// Removal and refresh read it instead of deriving a path the install
-    /// never took.
+    /// Where the artifact landed: a command a harness stores as another
+    /// kind, a skill's tree and the link a tool reads it through. Removal
+    /// and refresh read it instead of deriving a path the install never
+    /// took.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub emitted: Option<EmittedArtifact>,
     /// The registry entry this hook registered, as the registry keys it.
@@ -208,7 +209,8 @@ pub struct HookRegistration {
 }
 
 /// The artifact one installation actually put on disk, in the harness's own
-/// terms: a codex command lands as a skill, under a name the user types.
+/// terms: a codex command lands as a skill, under a name the user types; a
+/// skill lands as one tree plus the link a tool reads it through.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Type)]
 #[serde(rename_all = "camelCase")]
 pub struct EmittedArtifact {

--- a/crates/core/tests/hook_records.rs
+++ b/crates/core/tests/hook_records.rs
@@ -389,3 +389,61 @@ fn a_recorded_entry_moved_by_hand_does_not_hold_the_hook() {
     let settled = audit(&f.env, &f.scope).unwrap();
     assert!(settled.plan.ops.is_empty(), "{:?}", settled.plan.ops);
 }
+
+/// A render that changes the command's spelling — the machine's own path
+/// giving way to one a clone can follow — is a move like any other: the
+/// entry the record names comes out, and the new spelling goes in alone.
+/// Keyed on the rendered command, the upsert would find nothing to replace
+/// and the hook would fire twice on the machine that installed it.
+#[test]
+#[allow(clippy::unwrap_used)]
+fn a_command_spelled_another_way_replaces_the_entry_it_left() {
+    let f = fixture("[hooks.guard]\nsource = \"cat\"\n");
+    let manifest = f.project.join("kendex.toml");
+    let text = fs::read_to_string(&manifest).unwrap();
+    fs::write(
+        &manifest,
+        text.replace("harnesses = [\"claude\"]", "harnesses = [\"codex\"]"),
+    )
+    .unwrap();
+    apply_now(&f);
+
+    let registry = f.project.join(".codex/hooks.json");
+    let commands = || -> Vec<String> {
+        let value: serde_json::Value =
+            serde_json::from_str(&fs::read_to_string(&registry).unwrap()).unwrap();
+        value["hooks"]["PreToolUse"]
+            .as_array()
+            .unwrap_or(&Vec::new())
+            .iter()
+            .flat_map(|group| group["hooks"].as_array().cloned().unwrap_or_default())
+            .map(|handler| handler["command"].as_str().unwrap().to_owned())
+            .collect()
+    };
+    let portable = commands();
+    assert_eq!(portable.len(), 1);
+    assert!(portable[0].contains("git rev-parse"), "{portable:?}");
+
+    // What an older kendex left: the machine's path, in the document and
+    // in the record alike.
+    let absolute = format!("bash {}", f.project.join(".codex/hooks/guard.sh").display());
+    fs::write(
+        &registry,
+        fs::read_to_string(&registry)
+            .unwrap()
+            .replace(&portable[0].replace('"', "\\\""), &absolute),
+    )
+    .unwrap();
+    assert_eq!(commands(), vec![absolute.clone()], "the rewrite took");
+    let lock_path = f.project.join(".kendex-lock.json");
+    let mut lock: serde_json::Value =
+        serde_json::from_str(&fs::read_to_string(&lock_path).unwrap()).unwrap();
+    lock["entries"]["hook:guard:codex"]["registration"]["command"] =
+        serde_json::Value::String(absolute);
+    fs::write(&lock_path, serde_json::to_string_pretty(&lock).unwrap()).unwrap();
+    apply_now(&f);
+
+    assert_eq!(commands(), portable, "one entry, spelled the new way");
+    let settled = audit(&f.env, &f.scope).unwrap();
+    assert!(settled.plan.ops.is_empty(), "{:?}", settled.plan.ops);
+}

--- a/crates/core/tests/skill_records.rs
+++ b/crates/core/tests/skill_records.rs
@@ -92,8 +92,9 @@ fn recorded_paths(f: &Fixture, key: &str) -> Vec<PathBuf> {
         .unwrap_or_default()
 }
 
-/// The layout an older kendex wrote: a link at a place the current render
-/// never produces, recorded by that install as its own.
+/// The record a kendex from this version on writes, after a layout change:
+/// a link at a place the current render never produces, recorded by the
+/// install that wrote it.
 #[allow(clippy::unwrap_used)]
 fn as_written_under_the_old_layout(f: &Fixture, key: &str, link: &Path) {
     fs::create_dir_all(link.parent().unwrap()).unwrap();
@@ -129,7 +130,10 @@ fn a_link_the_render_stopped_producing_comes_off_by_its_record() {
     as_written_under_the_old_layout(&f, "skill:ship:claude", &old);
     apply_now(&f);
 
-    assert!(!old.is_symlink(), "the link nothing produces anymore stays");
+    assert!(
+        !old.is_symlink(),
+        "the link nothing produces anymore is still on disk"
+    );
     assert!(link.is_symlink() && shared.is_dir());
     assert_eq!(recorded_paths(&f, "skill:ship:claude"), vec![shared, link]);
     assert!(settled(&f));
@@ -158,8 +162,45 @@ fn an_orphaned_install_comes_off_by_the_paths_it_recorded() {
     .unwrap();
     apply::execute(&f.env, &report.plan, None).unwrap();
 
-    assert!(!old.is_symlink(), "the link nothing produces anymore stays");
+    assert!(
+        !old.is_symlink(),
+        "the link nothing produces anymore is still on disk"
+    );
     assert!(!f.project.join(".claude/skills/ship").is_symlink());
     assert!(f.project.join(".agents/skills/ship").is_dir());
     assert!(settled(&f));
+}
+
+/// An install this pass holds plans no replacement, so what it recorded
+/// is still what runs. Judged by the render instead, the old link came off
+/// while the tree it connected stayed held, and nothing was written after.
+#[test]
+#[allow(clippy::unwrap_used)]
+fn a_held_install_keeps_the_link_it_recorded() {
+    let f = fixture();
+    declare(&f, "\"claude\"");
+    apply_now(&f);
+    let old = f.project.join(".claude/rules/ship");
+    as_written_under_the_old_layout(&f, "skill:ship:claude", &old);
+    fs::write(
+        f.project.join(".agents/skills/ship/SKILL.md"),
+        "edited by hand\n",
+    )
+    .unwrap();
+
+    let report = audit(&f.env, &f.scope).unwrap();
+    assert!(
+        report
+            .drift
+            .iter()
+            .any(|row| row.state == DriftState::Conflict),
+        "the edit holds the install: {:?}",
+        report.drift
+    );
+    apply::execute(&f.env, &report.plan, None).unwrap();
+
+    assert!(
+        old.is_symlink(),
+        "the held install's link came off with nothing replacing it"
+    );
 }

--- a/crates/core/tests/skill_records.rs
+++ b/crates/core/tests/skill_records.rs
@@ -1,0 +1,165 @@
+//! What the lock keeps about where a skill landed, and what that buys.
+//!
+//! A tool's skill directory moves between kendex versions. A pass that
+//! derived the place again would name one this install never wrote, and
+//! the link it did write would then outlive every refresh — absolute,
+//! and committed under the shared posture. The record is where a later
+//! pass finds it.
+#![cfg(unix)]
+
+use std::fs;
+use std::path::{Path, PathBuf};
+
+use kendex_core::apply;
+use kendex_core::engine::{DriftState, PlanOptions, audit, plan_apply};
+use kendex_core::env::{Env, FakeOs};
+use kendex_core::model::Scope;
+
+struct Fixture {
+    _tmp: tempfile::TempDir,
+    env: Env,
+    scope: Scope,
+    project: PathBuf,
+    source: PathBuf,
+}
+
+#[allow(clippy::unwrap_used)]
+fn put(path: &Path, text: &str) {
+    fs::create_dir_all(path.parent().unwrap()).unwrap();
+    fs::write(path, text).unwrap();
+}
+
+#[allow(clippy::unwrap_used)]
+fn fixture() -> Fixture {
+    let tmp = tempfile::tempdir().unwrap();
+    let home = tmp.path().to_path_buf();
+    let project = home.join("dev/app");
+    let source = home.join("catalog");
+    put(
+        &source.join("skills/ship/SKILL.md"),
+        "---\nname: ship\ndescription: ship\n---\n\nShip the branch.\n",
+    );
+    Fixture {
+        env: Env::fake(&home, FakeOs::Linux),
+        scope: Scope::Project {
+            root: project.clone(),
+        },
+        project,
+        source,
+        _tmp: tmp,
+    }
+}
+
+fn declare(f: &Fixture, harnesses: &str) {
+    put(
+        &f.project.join("kendex.toml"),
+        &format!(
+            "schema = 6\n\n[sources.cat]\npath = \"{}\"\n\n[install]\nharnesses = [{harnesses}]\nmethod = \"symlink\"\n\n[skills.ship]\nsource = \"cat\"\n",
+            f.source.display()
+        ),
+    );
+}
+
+#[allow(clippy::unwrap_used)]
+fn apply_now(f: &Fixture) {
+    let report = audit(&f.env, &f.scope).unwrap();
+    apply::execute(&f.env, &report.plan, None).unwrap();
+}
+
+#[allow(clippy::unwrap_used)]
+fn settled(f: &Fixture) -> bool {
+    let report = audit(&f.env, &f.scope).unwrap();
+    report.plan.ops.is_empty()
+        && !report
+            .drift
+            .iter()
+            .any(|row| row.state == DriftState::Conflict)
+}
+
+#[allow(clippy::unwrap_used)]
+fn recorded_paths(f: &Fixture, key: &str) -> Vec<PathBuf> {
+    let lock: serde_json::Value =
+        serde_json::from_str(&fs::read_to_string(f.project.join(".kendex-lock.json")).unwrap())
+            .unwrap();
+    lock["entries"][key]["emitted"]["paths"]
+        .as_array()
+        .map(|paths| {
+            paths
+                .iter()
+                .map(|p| PathBuf::from(p.as_str().unwrap()))
+                .collect()
+        })
+        .unwrap_or_default()
+}
+
+/// The layout an older kendex wrote: a link at a place the current render
+/// never produces, recorded by that install as its own.
+#[allow(clippy::unwrap_used)]
+fn as_written_under_the_old_layout(f: &Fixture, key: &str, link: &Path) {
+    fs::create_dir_all(link.parent().unwrap()).unwrap();
+    std::os::unix::fs::symlink(f.project.join(".agents/skills/ship"), link).unwrap();
+    let path = f.project.join(".kendex-lock.json");
+    let mut lock: serde_json::Value =
+        serde_json::from_str(&fs::read_to_string(&path).unwrap()).unwrap();
+    lock["entries"][key]["emitted"]["paths"]
+        .as_array_mut()
+        .unwrap()
+        .push(serde_json::Value::String(link.display().to_string()));
+    fs::write(&path, serde_json::to_string_pretty(&lock).unwrap()).unwrap();
+}
+
+/// A refresh takes the link the desired state stopped producing, and only
+/// that: the tree and the link it still produces stay. Without the record,
+/// the pass derives today's link and never learns of the old one.
+#[test]
+#[allow(clippy::unwrap_used)]
+fn a_link_the_render_stopped_producing_comes_off_by_its_record() {
+    let f = fixture();
+    declare(&f, "\"claude\"");
+    apply_now(&f);
+    let shared = f.project.join(".agents/skills/ship");
+    let link = f.project.join(".claude/skills/ship");
+    assert_eq!(
+        recorded_paths(&f, "skill:ship:claude"),
+        vec![shared.clone(), link.clone()],
+        "the record names the tree and the link this install wrote"
+    );
+
+    let old = f.project.join(".claude/rules/ship");
+    as_written_under_the_old_layout(&f, "skill:ship:claude", &old);
+    apply_now(&f);
+
+    assert!(!old.is_symlink(), "the link nothing produces anymore stays");
+    assert!(link.is_symlink() && shared.is_dir());
+    assert_eq!(recorded_paths(&f, "skill:ship:claude"), vec![shared, link]);
+    assert!(settled(&f));
+}
+
+/// An install nothing declares anymore comes off by the paths it recorded,
+/// the shared tree another tool still reads excepted.
+#[test]
+#[allow(clippy::unwrap_used)]
+fn an_orphaned_install_comes_off_by_the_paths_it_recorded() {
+    let f = fixture();
+    declare(&f, "\"claude\", \"codex\"");
+    apply_now(&f);
+    let old = f.project.join(".claude/rules/ship");
+    as_written_under_the_old_layout(&f, "skill:ship:claude", &old);
+
+    declare(&f, "\"codex\"");
+    let report = plan_apply(
+        &f.env,
+        &f.scope,
+        &PlanOptions {
+            remove_orphans: true,
+            ..PlanOptions::default()
+        },
+    )
+    .unwrap();
+    apply::execute(&f.env, &report.plan, None).unwrap();
+
+    assert!(!old.is_symlink(), "the link nothing produces anymore stays");
+    assert!(!f.project.join(".claude/skills/ship").is_symlink());
+    assert!(f.project.join(".agents/skills/ship").is_dir());
+    assert!(settled(&f));
+}

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -116,7 +116,7 @@ lives in one capability table read by core and UI.
    restores the sharing from kendex's copy; the confirm names the folder and every
    tool reading it. A link at anything else stays a conflict.
    Ownership is what kendex wrote, read from the positions lock entries
-   actually wrote (including paths recorded under another kind's name) —
+   recorded writing (a skill's tree and link, a command's tree as a skill) —
    never from the lock key alone, and never from an entry merely being on
    the books. A link the user put at a shared config file or a manifest
    (dotfiles) is not foreign: the edit goes through it, link kept, and the

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -116,7 +116,7 @@ lives in one capability table read by core and UI.
    restores the sharing from kendex's copy; the confirm names the folder and every
    tool reading it. A link at anything else stays a conflict.
    Ownership is what kendex wrote, read from the positions lock entries
-   recorded writing (a skill's tree and link, a command's tree as a skill) —
+   wrote (recorded for skills and codex commands, derived elsewhere) —
    never from the lock key alone, and never from an entry merely being on
    the books. A link the user put at a shared config file or a manifest
    (dotfiles) is not foreign: the edit goes through it, link kept, and the


### PR DESCRIPTION
## Summary
- A skill install records the tree and the link it writes in the lock's existing `EmittedArtifact`; ownership and the stale sweep read that record instead of deriving today's layout, so a link a later layout stops producing comes off on refresh instead of surviving absolute and committed.
- The stale sweep judges by the record the pass writes, so an install the pass holds or refuses keeps the link it recorded.
- No migration: a skill entry without a record owns nothing. The CHANGELOG carries the one-time manual reinstall for scopes an older kendex set up. The hook half needed no engine change; a test pins that a re-spelled hook command replaces its old `.codex/hooks.json` entry rather than joining it.

## Completed Issues
- Closes KEN-646 - KEN-643 migration leaves absolute links and duplicate hook entries behind; the committed posture then commits them

## Test Plan
- `cargo test -p kendex-core --test skill_records --test hook_records` (new: dropped link comes off by its record; orphan comes off by recorded paths; held install keeps its link; re-spelled hook replaces its entry)
- `tools/guard` clean on the head commit; preflight clean against `origin/main`
- Internal review: 9 reviewers plus codex external over 3 cycles; doc reviewer ran the Breaking step with the built CLI on project/global, symlink/copy scratch scopes
