### PR TITLE
fix(KEN-685): worktree copies an untracked .gitignore, never links it

### DIFF
--- a/.agents/skills/worktree/README.md
+++ b/.agents/skills/worktree/README.md
@@ -53,7 +53,7 @@ WORKTREE_RELATIVE_SYMLINKS = ".claude/CLAUDE.md=../AGENTS.md"
 WORKTREE_MKDIRS = "tmp"
 ```
 
-Point `WORKTREE_SYMLINKS` at untracked paths. A directory entry containing tracked files stays a real directory with only its untracked children linked; a tracked file entry is marked assume-unchanged before replacement. Full rules: `scripts/worktree --help` and `scripts/worktree fix-links --help`.
+Point `WORKTREE_SYMLINKS` at untracked paths. A directory entry containing tracked files stays a real directory with only its untracked children linked (an untracked `.gitignore` is copied, since git will not read one through a symlink); a tracked file entry is marked assume-unchanged before replacement. Full rules: `scripts/worktree --help` and `scripts/worktree fix-links --help`.
 
 ### App-created worktrees
 

--- a/.agents/skills/worktree/scripts/worktree
+++ b/.agents/skills/worktree/scripts/worktree
@@ -368,10 +368,11 @@ Recovery routing — route by shape, not by whether 'test -L' passes:
   - An untracked-only WORKTREE_SYMLINKS entry must be a symlink. Missing, or
     a real directory instead: fix-links, from the main checkout.
   - An entry with tracked content underneath is a real directory BY DESIGN,
-    holding the tracked files plus one symlink per untracked child. A child
+    holding the tracked files plus one symlink per untracked child, except
+    an untracked .gitignore, which is a copy of main's file. A child
     missing its link, or itself a real path: fix-links (heals per child;
     never overwrites a child holding data git does not track — reported
-    instead).
+    instead; the .gitignore copy is the one child it re-copies on drift).
   - A genuinely modified or corrupt TRACKED file: 'git checkout -- <path>',
     run in the checkout the file really lives in.
   'git checkout -- <entry>' is never the recovery for an untracked-only
@@ -399,12 +400,12 @@ Symlink entries that shadow tracked content:
   symlinked, recursing into children that mix tracked and untracked content.
   A newly installed skill under the entry is linked on the next
   create/fix-links/auto-repair pass. One child is copied instead of linked:
-  an untracked .gitignore, because git refuses to read an ignore file
-  through a symlink ("unable to access ... Too many levels of symbolic
-  links") and would apply none of its rules. The main checkout's file is
-  the source: every pass re-copies it when the content differs, so a
-  change on main reaches the worktree on the next pass and an edit made
-  to the worktree copy is overwritten. Each untracked child goes through the
+  an untracked .gitignore, because git refuses to read .gitignore through
+  a symlink ("unable to access ... Too many levels of symbolic links") and
+  would apply none of its rules. The main checkout's file is the source:
+  every pass re-copies it when the content differs, so a change on main
+  reaches the worktree on the next pass and an edit made to the worktree
+  copy is overwritten. Every other untracked child goes through the
   same quarantine as a top-level entry: a child that has materialized as a
   real file or directory holding data git does not track, or that differs
   from the index, is reported and left in place, never overwritten. A child
@@ -1330,23 +1331,23 @@ atomic_symlink_swap() {
   return 1
 }
 
-# An untracked child named .gitignore is COPIED into the worktree, never
-# symlinked (KEN-685). Git refuses to read an ignore file through a symlink:
-# every command prints "unable to access '<path>/.gitignore': Too many levels
-# of symbolic links" and applies none of its rules, so whatever main's file
-# ignores becomes stageable in every worktree, which is exactly what
-# `git add -A` then commits.
-#
+# The one untracked child COPIED into the worktree, not symlinked (KEN-685):
+# a regular file named .gitignore. Git refuses to read .gitignore through a
+# symlink ("unable to access ...: Too many levels of symbolic links") and
+# applies none of its rules, so whatever main's file ignores becomes stageable
+# and `git add -A` commits it. The repair path and both detectors share this
+# predicate so they agree by construction. $1 is the name, $2 its path in main.
+is_copied_ignore_child() {
+  [[ "$1" == .gitignore && -f "$2" ]]
+}
+
 # Drift policy: main owns the file. Every create/fix-links/auto-repair pass
-# re-copies when the content differs, so a change in the main checkout reaches
-# the worktrees on the next pass, and an edit made to the worktree copy is
-# overwritten by that same pass. The copy is the tool's own artifact, not user
-# data, so the quarantine's never-overwrite rule does not apply to it. A
-# symlink left by an earlier skill version is replaced the same way.
-#
-# The copy gets the same info/exclude entry the symlink used to get: main's
-# file is untracked, so nothing in the index would otherwise keep the copy out
-# of `git status` in a repo whose ignore file does not ignore itself.
+# re-copies when the content differs, so a change on main reaches the
+# worktrees next pass and an edit to the worktree copy is overwritten. The
+# copy is the tool's own artifact, not user data, so the quarantine's
+# never-overwrite rule does not apply; a legacy symlink is replaced the same
+# way. It gets the info/exclude entry the symlink got: main's file is
+# untracked, so nothing else hides the copy when it does not ignore itself.
 ignore_file_copy_matches() {
   local src="$1" dst="$2"
   [[ -f "$dst" && ! -L "$dst" ]] && cmp -s "$src" "$dst"
@@ -1354,25 +1355,28 @@ ignore_file_copy_matches() {
 
 copy_ignore_file_into_worktree() {
   local wt="$1" path="$2"
-  local src="$PROJECT_ROOT/$path" dst="$wt/$path" tmp=""
+  local src="$PROJECT_ROOT/$path" dst="$wt/$path" tmp="" err="" effect=""
   ensure_worktree_path_safe "$wt" "$path" false || return 1
   exclude_from_worktree_index "$wt" "$path" false
   ignore_file_copy_matches "$src" "$dst" && return 0
   if [[ -d "$dst" && ! -L "$dst" ]]; then
-    echo "Warning: '$path' in $wt is a directory where main's ignore file should be copied; leaving it alone." >&2
+    echo "Warning: '$path' in $wt is a directory where main's .gitignore should be copied; leaving it alone." >&2
     return 1
   fi
-  # Built beside the destination and renamed over it, so a reader never finds
-  # the path absent (the same window atomic_symlink_swap closes). rename(2)
-  # replaces a symlink destination itself rather than following it.
+  # Built beside the destination and renamed over it (atomic_symlink_swap's
+  # GNU -T / BSD -h pair, no delete-first fallback), so a reader never finds
+  # the path absent; rename(2) replaces a symlink destination, not its target.
+  # The temp name is cleared first: cp writes THROUGH a stale symlink there.
   tmp="$dst.wt-tmp.$$"
-  if cp "$src" "$tmp" 2>/dev/null &&
-     { mv -T "$tmp" "$dst" 2>/dev/null || mv -h "$tmp" "$dst" 2>/dev/null ||
-       { rm -f "$dst" 2>/dev/null && mv -f "$tmp" "$dst" 2>/dev/null; }; }; then
+  rm -f "$tmp" 2>/dev/null
+  if err="$(cp "$src" "$tmp" 2>&1)" &&
+     { err="$(mv -T "$tmp" "$dst" 2>&1)" || err="$(mv -h "$tmp" "$dst" 2>&1)"; }; then
     return 0
   fi
   rm -f "$tmp" 2>/dev/null
-  echo "Warning: could not copy '$path' into $wt; its ignore rules are not applied there." >&2
+  effect="its ignore rules are not applied there"
+  [[ -f "$dst" && ! -L "$dst" ]] && effect="the previous copy stays in effect, not main's current rules"
+  echo "Warning: could not copy '$path' into $wt (${err:-no diagnostic}); $effect." >&2
   return 1
 }
 
@@ -1496,9 +1500,7 @@ link_untracked_children() {
     classify_index_entry "$PROJECT_ROOT" "$rel"
     [[ -n "$CIE_EXACT" ]] && exact=1
     [[ -n "$CIE_DESCENDANTS" ]] && descendants=1
-    if [[ -z "$exact" && -z "$descendants" && "$name" == .gitignore && -f "$child" ]]; then
-      # Git will not read an ignore file through a symlink; see
-      # copy_ignore_file_into_worktree for the copy and its drift policy.
+    if [[ -z "$exact" && -z "$descendants" ]] && is_copied_ignore_child "$name" "$child"; then
       copy_ignore_file_into_worktree "$wt" "$rel" || unresolved="$unresolved  - $rel (copy failed — see warning above)"$'\n'
     elif [[ -z "$exact" && -z "$descendants" ]]; then
       # Nothing tracked here: ordinary symlink treatment, own exclude entry.
@@ -1669,9 +1671,8 @@ collect_materialized_child_links() {
     [[ -n "$CIE_EXACT" ]] && exact=1
     [[ -n "$CIE_DESCENDANTS" ]] && descendants=1
     if [[ -z "$exact" && -z "$descendants" ]]; then
-      # An untracked .gitignore is a real file BY DESIGN (KEN-685), never a
-      # materialized link; fix-links judges its content, not this detector.
-      [[ "$name" == .gitignore && -f "$child" ]] && continue
+      # A copied child is a real file by design; fix-links judges its content.
+      is_copied_ignore_child "$name" "$child" && continue
       [[ -e "$wt/$rel" && ! -L "$wt/$rel" ]] && printf '%s\n' "$rel"
     elif [[ -z "$exact" ]]; then
       # `|| capped=1`: a depth-capped deeper subtree must not abort this
@@ -1740,15 +1741,14 @@ collect_unhealthy_child_links() {
       collect_unhealthy_child_links "$rel" "$wt" $((depth + 1))
       continue
     fi
-    if [[ "$name" == .gitignore && -f "$child" ]]; then
-      # Healthy is a real file with main's content (KEN-685): a symlink here
-      # is the shape git refuses to read, and stale content is the drift the
-      # repair pass exists to close.
+    if is_copied_ignore_child "$name" "$child"; then
+      # Healthy is a real file with main's content; a symlink is the shape git
+      # refuses to read, stale content the drift the repair pass closes.
       ignore_file_copy_matches "$child" "$wt/$rel" && continue
       if [[ -L "$wt/$rel" ]]; then
-        printf '%s (a symlink, expected a copy of main'"'"'s ignore file)\n' "$rel"
+        printf '%s (a symlink, expected a copy of main'"'"'s .gitignore)\n' "$rel"
       elif [[ -e "$wt/$rel" ]]; then
-        printf '%s (differs from main'"'"'s ignore file)\n' "$rel"
+        printf '%s (differs from main'"'"'s .gitignore)\n' "$rel"
       else
         printf '%s (absent)\n' "$rel"
       fi

--- a/.agents/skills/worktree/scripts/worktree
+++ b/.agents/skills/worktree/scripts/worktree
@@ -398,7 +398,13 @@ Symlink entries that shadow tracked content:
   paths stay real files git owns, and only the untracked children are
   symlinked, recursing into children that mix tracked and untracked content.
   A newly installed skill under the entry is linked on the next
-  create/fix-links/auto-repair pass. Each untracked child goes through the
+  create/fix-links/auto-repair pass. One child is copied instead of linked:
+  an untracked .gitignore, because git refuses to read an ignore file
+  through a symlink ("unable to access ... Too many levels of symbolic
+  links") and would apply none of its rules. The main checkout's file is
+  the source: every pass re-copies it when the content differs, so a
+  change on main reaches the worktree on the next pass and an edit made
+  to the worktree copy is overwritten. Each untracked child goes through the
   same quarantine as a top-level entry: a child that has materialized as a
   real file or directory holding data git does not track, or that differs
   from the index, is reported and left in place, never overwritten. A child
@@ -1324,6 +1330,52 @@ atomic_symlink_swap() {
   return 1
 }
 
+# An untracked child named .gitignore is COPIED into the worktree, never
+# symlinked (KEN-685). Git refuses to read an ignore file through a symlink:
+# every command prints "unable to access '<path>/.gitignore': Too many levels
+# of symbolic links" and applies none of its rules, so whatever main's file
+# ignores becomes stageable in every worktree, which is exactly what
+# `git add -A` then commits.
+#
+# Drift policy: main owns the file. Every create/fix-links/auto-repair pass
+# re-copies when the content differs, so a change in the main checkout reaches
+# the worktrees on the next pass, and an edit made to the worktree copy is
+# overwritten by that same pass. The copy is the tool's own artifact, not user
+# data, so the quarantine's never-overwrite rule does not apply to it. A
+# symlink left by an earlier skill version is replaced the same way.
+#
+# The copy gets the same info/exclude entry the symlink used to get: main's
+# file is untracked, so nothing in the index would otherwise keep the copy out
+# of `git status` in a repo whose ignore file does not ignore itself.
+ignore_file_copy_matches() {
+  local src="$1" dst="$2"
+  [[ -f "$dst" && ! -L "$dst" ]] && cmp -s "$src" "$dst"
+}
+
+copy_ignore_file_into_worktree() {
+  local wt="$1" path="$2"
+  local src="$PROJECT_ROOT/$path" dst="$wt/$path" tmp=""
+  ensure_worktree_path_safe "$wt" "$path" false || return 1
+  exclude_from_worktree_index "$wt" "$path" false
+  ignore_file_copy_matches "$src" "$dst" && return 0
+  if [[ -d "$dst" && ! -L "$dst" ]]; then
+    echo "Warning: '$path' in $wt is a directory where main's ignore file should be copied; leaving it alone." >&2
+    return 1
+  fi
+  # Built beside the destination and renamed over it, so a reader never finds
+  # the path absent (the same window atomic_symlink_swap closes). rename(2)
+  # replaces a symlink destination itself rather than following it.
+  tmp="$dst.wt-tmp.$$"
+  if cp "$src" "$tmp" 2>/dev/null &&
+     { mv -T "$tmp" "$dst" 2>/dev/null || mv -h "$tmp" "$dst" 2>/dev/null ||
+       { rm -f "$dst" 2>/dev/null && mv -f "$tmp" "$dst" 2>/dev/null; }; }; then
+    return 0
+  fi
+  rm -f "$tmp" 2>/dev/null
+  echo "Warning: could not copy '$path' into $wt; its ignore rules are not applied there." >&2
+  return 1
+}
+
 # Sets $CIE_EXACT and $CIE_DESCENDANTS (non-empty = true) for whether $rel is
 # tracked as an exact leaf entry (file, symlink, or gitlink), or has tracked
 # descendants beneath it, in $repo's index.
@@ -1444,7 +1496,11 @@ link_untracked_children() {
     classify_index_entry "$PROJECT_ROOT" "$rel"
     [[ -n "$CIE_EXACT" ]] && exact=1
     [[ -n "$CIE_DESCENDANTS" ]] && descendants=1
-    if [[ -z "$exact" && -z "$descendants" ]]; then
+    if [[ -z "$exact" && -z "$descendants" && "$name" == .gitignore && -f "$child" ]]; then
+      # Git will not read an ignore file through a symlink; see
+      # copy_ignore_file_into_worktree for the copy and its drift policy.
+      copy_ignore_file_into_worktree "$wt" "$rel" || unresolved="$unresolved  - $rel (copy failed — see warning above)"$'\n'
+    elif [[ -z "$exact" && -z "$descendants" ]]; then
       # Nothing tracked here: ordinary symlink treatment, own exclude entry.
       # Quarantine-checked (#1317): this child may have materialized as a real
       # file or directory holding untracked user data since the last repair,
@@ -1613,6 +1669,9 @@ collect_materialized_child_links() {
     [[ -n "$CIE_EXACT" ]] && exact=1
     [[ -n "$CIE_DESCENDANTS" ]] && descendants=1
     if [[ -z "$exact" && -z "$descendants" ]]; then
+      # An untracked .gitignore is a real file BY DESIGN (KEN-685), never a
+      # materialized link; fix-links judges its content, not this detector.
+      [[ "$name" == .gitignore && -f "$child" ]] && continue
       [[ -e "$wt/$rel" && ! -L "$wt/$rel" ]] && printf '%s\n' "$rel"
     elif [[ -z "$exact" ]]; then
       # `|| capped=1`: a depth-capped deeper subtree must not abort this
@@ -1679,6 +1738,20 @@ collect_unhealthy_child_links() {
     fi
     if [[ -n "$descendants" ]]; then
       collect_unhealthy_child_links "$rel" "$wt" $((depth + 1))
+      continue
+    fi
+    if [[ "$name" == .gitignore && -f "$child" ]]; then
+      # Healthy is a real file with main's content (KEN-685): a symlink here
+      # is the shape git refuses to read, and stale content is the drift the
+      # repair pass exists to close.
+      ignore_file_copy_matches "$child" "$wt/$rel" && continue
+      if [[ -L "$wt/$rel" ]]; then
+        printf '%s (a symlink, expected a copy of main'"'"'s ignore file)\n' "$rel"
+      elif [[ -e "$wt/$rel" ]]; then
+        printf '%s (differs from main'"'"'s ignore file)\n' "$rel"
+      else
+        printf '%s (absent)\n' "$rel"
+      fi
       continue
     fi
     report_link_health "$wt" "$rel" "$PROJECT_ROOT/$rel"

--- a/.agents/skills/worktree/tests/worktree_symlink_shadows_tracked.sh
+++ b/.agents/skills/worktree/tests/worktree_symlink_shadows_tracked.sh
@@ -277,21 +277,24 @@ assert_real "$PREDATE_WT/.agents/skills/late.md" "the merge wrote the newly-trac
 
 echo "=== an untracked .gitignore under a tracked-content entry is copied, not linked (KEN-685) ==="
 
-# Git refuses to read an ignore file through a symlink, so a linked
-# .gitignore applies none of its rules in the worktree and prints "unable to
-# access" on every command. drovr's shape: `.opencode/agents` is tracked,
-# `.opencode/.gitignore` is untracked and ignores itself plus bun.lock.
+# Git refuses to read .gitignore through a symlink, so a linked one applies
+# none of its rules in the worktree and prints "unable to access" on every
+# command. drovr's shape: `.opencode/agents` is tracked, `.opencode/.gitignore`
+# is untracked and ignores bun.lock. It does NOT ignore itself: the copy in the
+# worktree is kept out of `git status` only by the info/exclude entry setup
+# writes for it, so the status assertions below prove that entry too.
 IGN_ROOT="$TMP_ROOT/ignore"
 make_repo "$IGN_ROOT"
 mkdir -p "$IGN_ROOT/main/.opencode/agents"
 printf 'agent\n' >"$IGN_ROOT/main/.opencode/agents/dev.md"
-printf 'bun.lock\n.gitignore\n' >"$IGN_ROOT/main/.opencode/.gitignore"
+printf 'bun.lock\n' >"$IGN_ROOT/main/.opencode/.gitignore"
 printf 'lock\n' >"$IGN_ROOT/main/.opencode/bun.lock"
 printf 'WORKTREE_SYMLINKS=".opencode"\n' >"$IGN_ROOT/main/.env"
 git -C "$IGN_ROOT/main" add .opencode/agents/dev.md
 git -C "$IGN_ROOT/main" commit -q -m 'track opencode agents'
 push_main "$IGN_ROOT"
-assert_eq "$(git -C "$IGN_ROOT/main" status --porcelain -- .opencode)" "" "main ignores bun.lock through the untracked .gitignore"
+assert_eq "$(git -C "$IGN_ROOT/main" status --porcelain -- .opencode/bun.lock)" "" "main ignores bun.lock through the untracked .gitignore"
+assert_eq "$(git -C "$IGN_ROOT/main" status --porcelain -- .opencode)" "?? .opencode/.gitignore" "main's .gitignore is untracked and does not hide itself"
 
 set +e
 IGN_WT="$( (cd "$IGN_ROOT/main" && "$WORKTREE_SCRIPT" create ignore-check) 2>"$IGN_ROOT/err" )"
@@ -309,9 +312,18 @@ printf 'lock\n' >"$IGN_WT/.opencode/bun.lock"
 assert_eq "$(git -C "$IGN_WT" status --porcelain 2>&1)" "" "bun.lock is ignored in the worktree"
 assert_lacks "$(git -C "$IGN_WT" status 2>&1)" "unable to access" "git prints no ignore-file access warning"
 
+# push is the one command that runs the materialization detector; the copy
+# must read as the expected shape there, not as a real path where a link belongs.
+set +e
+(cd "$IGN_ROOT/main" && "$WORKTREE_SCRIPT" push ignore-check --no-rebase -u) >/dev/null 2>"$IGN_ROOT/perr"
+ign_push_status=$?
+set -e
+assert_eq "$ign_push_status" "0" "push succeeds from the worktree holding the copy"
+assert_lacks "$(cat "$IGN_ROOT/perr")" "harness paths in this worktree" "push does not report the copy as a materialized link"
+
 echo "=== the .gitignore copy follows main on the next pass, and a legacy link heals to a copy ==="
 
-printf 'bun.lock\n.gitignore\nnode_modules/\n' >"$IGN_ROOT/main/.opencode/.gitignore"
+printf 'bun.lock\nnode_modules/\n' >"$IGN_ROOT/main/.opencode/.gitignore"
 set +e
 (cd "$IGN_ROOT/main" && "$WORKTREE_SCRIPT" fix-links "$IGN_WT") >/dev/null 2>"$IGN_ROOT/err2"
 ign_fix_status=$?

--- a/.agents/skills/worktree/tests/worktree_symlink_shadows_tracked.sh
+++ b/.agents/skills/worktree/tests/worktree_symlink_shadows_tracked.sh
@@ -275,6 +275,69 @@ set -e
 assert_eq "$merge_status2" "0" "the merge that introduces the tracked child succeeds"
 assert_real "$PREDATE_WT/.agents/skills/late.md" "the merge wrote the newly-tracked child as a real file"
 
+echo "=== an untracked .gitignore under a tracked-content entry is copied, not linked (KEN-685) ==="
+
+# Git refuses to read an ignore file through a symlink, so a linked
+# .gitignore applies none of its rules in the worktree and prints "unable to
+# access" on every command. drovr's shape: `.opencode/agents` is tracked,
+# `.opencode/.gitignore` is untracked and ignores itself plus bun.lock.
+IGN_ROOT="$TMP_ROOT/ignore"
+make_repo "$IGN_ROOT"
+mkdir -p "$IGN_ROOT/main/.opencode/agents"
+printf 'agent\n' >"$IGN_ROOT/main/.opencode/agents/dev.md"
+printf 'bun.lock\n.gitignore\n' >"$IGN_ROOT/main/.opencode/.gitignore"
+printf 'lock\n' >"$IGN_ROOT/main/.opencode/bun.lock"
+printf 'WORKTREE_SYMLINKS=".opencode"\n' >"$IGN_ROOT/main/.env"
+git -C "$IGN_ROOT/main" add .opencode/agents/dev.md
+git -C "$IGN_ROOT/main" commit -q -m 'track opencode agents'
+push_main "$IGN_ROOT"
+assert_eq "$(git -C "$IGN_ROOT/main" status --porcelain -- .opencode)" "" "main ignores bun.lock through the untracked .gitignore"
+
+set +e
+IGN_WT="$( (cd "$IGN_ROOT/main" && "$WORKTREE_SCRIPT" create ignore-check) 2>"$IGN_ROOT/err" )"
+ign_status=$?
+set -e
+assert_eq "$ign_status" "0" "create succeeds for the entry holding an untracked .gitignore"
+[[ -n "$IGN_WT" && -d "$IGN_WT" ]] || { echo "FATAL: worktree not created: $(cat "$IGN_ROOT/err")"; exit 1; }
+
+assert_real "$IGN_WT/.opencode/.gitignore" "the .gitignore is a real file in the worktree, not a link"
+assert_eq "$(cat "$IGN_WT/.opencode/.gitignore")" "$(cat "$IGN_ROOT/main/.opencode/.gitignore")" "the copy has main's content"
+assert_real "$IGN_WT/.opencode/agents/dev.md" "the tracked file beside it stays a real file"
+
+# The proof: the worktree ignores what main ignores, and git stops complaining.
+printf 'lock\n' >"$IGN_WT/.opencode/bun.lock"
+assert_eq "$(git -C "$IGN_WT" status --porcelain 2>&1)" "" "bun.lock is ignored in the worktree"
+assert_lacks "$(git -C "$IGN_WT" status 2>&1)" "unable to access" "git prints no ignore-file access warning"
+
+echo "=== the .gitignore copy follows main on the next pass, and a legacy link heals to a copy ==="
+
+printf 'bun.lock\n.gitignore\nnode_modules/\n' >"$IGN_ROOT/main/.opencode/.gitignore"
+set +e
+(cd "$IGN_ROOT/main" && "$WORKTREE_SCRIPT" fix-links "$IGN_WT") >/dev/null 2>"$IGN_ROOT/err2"
+ign_fix_status=$?
+set -e
+assert_eq "$ign_fix_status" "0" "fix-links succeeds after main's .gitignore changed"
+assert_lacks "$(cat "$IGN_ROOT/err2")" "Warning" "fix-links stays quiet while re-copying"
+assert_eq "$(cat "$IGN_WT/.opencode/.gitignore")" "$(cat "$IGN_ROOT/main/.opencode/.gitignore")" "the copy picked up main's change"
+
+# A worktree provisioned by the older skill holds a link where the copy belongs.
+rm -f "$IGN_WT/.opencode/.gitignore"
+ln -s "$IGN_ROOT/main/.opencode/.gitignore" "$IGN_WT/.opencode/.gitignore"
+set +e
+(cd "$IGN_ROOT/main" && "$WORKTREE_SCRIPT" fix-links "$IGN_WT") >/dev/null 2>"$IGN_ROOT/err3"
+ign_legacy_status=$?
+set -e
+assert_eq "$ign_legacy_status" "0" "fix-links succeeds on a legacy linked .gitignore"
+assert_real "$IGN_WT/.opencode/.gitignore" "the legacy link became a copy"
+assert_eq "$(git -C "$IGN_WT" status --porcelain 2>&1)" "" "the healed worktree ignores bun.lock again"
+
+# fix-links judges the copy's content: a worktree edit is drift it closes.
+printf 'edited\n' >"$IGN_WT/.opencode/.gitignore"
+set +e
+(cd "$IGN_ROOT/main" && "$WORKTREE_SCRIPT" fix-links "$IGN_WT") >/dev/null 2>&1
+set -e
+assert_eq "$(cat "$IGN_WT/.opencode/.gitignore")" "$(cat "$IGN_ROOT/main/.opencode/.gitignore")" "a worktree edit to the copy is overwritten by main's file"
+
 echo "=== a locked index during legacy heal reports failure, not a swallowed success (#850) ==="
 
 # The old code discarded failures from --no-assume-unchanged and the missing-

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,9 @@ an outside contributor.
   `$HOME` for every later tool call, the move the hook exists to stop, and
   only `cd <path>` was caught before.
 
+- `worktree`: an untracked `.gitignore` under a tracked-content `WORKTREE_SYMLINKS`
+  entry is copied, not symlinked, so the worktree ignores what the main checkout
+  ignores and git stops warning `unable to access ... Too many levels of symbolic links`.
 - The settings template no longer seeds `.cursor` into `WORKTREE_SYMLINKS`, so
   `worktree fix-links` passes in repos that do not use Cursor; a repo that
   does adds it back in its own `kendex.settings.toml`.

--- a/skills/worktree/README.md
+++ b/skills/worktree/README.md
@@ -53,7 +53,7 @@ WORKTREE_RELATIVE_SYMLINKS = ".claude/CLAUDE.md=../AGENTS.md"
 WORKTREE_MKDIRS = "tmp"
 ```
 
-Point `WORKTREE_SYMLINKS` at untracked paths. A directory entry containing tracked files stays a real directory with only its untracked children linked; a tracked file entry is marked assume-unchanged before replacement. Full rules: `scripts/worktree --help` and `scripts/worktree fix-links --help`.
+Point `WORKTREE_SYMLINKS` at untracked paths. A directory entry containing tracked files stays a real directory with only its untracked children linked (an untracked `.gitignore` is copied, since git will not read one through a symlink); a tracked file entry is marked assume-unchanged before replacement. Full rules: `scripts/worktree --help` and `scripts/worktree fix-links --help`.
 
 ### App-created worktrees
 

--- a/skills/worktree/scripts/worktree
+++ b/skills/worktree/scripts/worktree
@@ -368,10 +368,11 @@ Recovery routing — route by shape, not by whether 'test -L' passes:
   - An untracked-only WORKTREE_SYMLINKS entry must be a symlink. Missing, or
     a real directory instead: fix-links, from the main checkout.
   - An entry with tracked content underneath is a real directory BY DESIGN,
-    holding the tracked files plus one symlink per untracked child. A child
+    holding the tracked files plus one symlink per untracked child, except
+    an untracked .gitignore, which is a copy of main's file. A child
     missing its link, or itself a real path: fix-links (heals per child;
     never overwrites a child holding data git does not track — reported
-    instead).
+    instead; the .gitignore copy is the one child it re-copies on drift).
   - A genuinely modified or corrupt TRACKED file: 'git checkout -- <path>',
     run in the checkout the file really lives in.
   'git checkout -- <entry>' is never the recovery for an untracked-only
@@ -399,12 +400,12 @@ Symlink entries that shadow tracked content:
   symlinked, recursing into children that mix tracked and untracked content.
   A newly installed skill under the entry is linked on the next
   create/fix-links/auto-repair pass. One child is copied instead of linked:
-  an untracked .gitignore, because git refuses to read an ignore file
-  through a symlink ("unable to access ... Too many levels of symbolic
-  links") and would apply none of its rules. The main checkout's file is
-  the source: every pass re-copies it when the content differs, so a
-  change on main reaches the worktree on the next pass and an edit made
-  to the worktree copy is overwritten. Each untracked child goes through the
+  an untracked .gitignore, because git refuses to read .gitignore through
+  a symlink ("unable to access ... Too many levels of symbolic links") and
+  would apply none of its rules. The main checkout's file is the source:
+  every pass re-copies it when the content differs, so a change on main
+  reaches the worktree on the next pass and an edit made to the worktree
+  copy is overwritten. Every other untracked child goes through the
   same quarantine as a top-level entry: a child that has materialized as a
   real file or directory holding data git does not track, or that differs
   from the index, is reported and left in place, never overwritten. A child
@@ -1330,23 +1331,23 @@ atomic_symlink_swap() {
   return 1
 }
 
-# An untracked child named .gitignore is COPIED into the worktree, never
-# symlinked (KEN-685). Git refuses to read an ignore file through a symlink:
-# every command prints "unable to access '<path>/.gitignore': Too many levels
-# of symbolic links" and applies none of its rules, so whatever main's file
-# ignores becomes stageable in every worktree, which is exactly what
-# `git add -A` then commits.
-#
+# The one untracked child COPIED into the worktree, not symlinked (KEN-685):
+# a regular file named .gitignore. Git refuses to read .gitignore through a
+# symlink ("unable to access ...: Too many levels of symbolic links") and
+# applies none of its rules, so whatever main's file ignores becomes stageable
+# and `git add -A` commits it. The repair path and both detectors share this
+# predicate so they agree by construction. $1 is the name, $2 its path in main.
+is_copied_ignore_child() {
+  [[ "$1" == .gitignore && -f "$2" ]]
+}
+
 # Drift policy: main owns the file. Every create/fix-links/auto-repair pass
-# re-copies when the content differs, so a change in the main checkout reaches
-# the worktrees on the next pass, and an edit made to the worktree copy is
-# overwritten by that same pass. The copy is the tool's own artifact, not user
-# data, so the quarantine's never-overwrite rule does not apply to it. A
-# symlink left by an earlier skill version is replaced the same way.
-#
-# The copy gets the same info/exclude entry the symlink used to get: main's
-# file is untracked, so nothing in the index would otherwise keep the copy out
-# of `git status` in a repo whose ignore file does not ignore itself.
+# re-copies when the content differs, so a change on main reaches the
+# worktrees next pass and an edit to the worktree copy is overwritten. The
+# copy is the tool's own artifact, not user data, so the quarantine's
+# never-overwrite rule does not apply; a legacy symlink is replaced the same
+# way. It gets the info/exclude entry the symlink got: main's file is
+# untracked, so nothing else hides the copy when it does not ignore itself.
 ignore_file_copy_matches() {
   local src="$1" dst="$2"
   [[ -f "$dst" && ! -L "$dst" ]] && cmp -s "$src" "$dst"
@@ -1354,25 +1355,28 @@ ignore_file_copy_matches() {
 
 copy_ignore_file_into_worktree() {
   local wt="$1" path="$2"
-  local src="$PROJECT_ROOT/$path" dst="$wt/$path" tmp=""
+  local src="$PROJECT_ROOT/$path" dst="$wt/$path" tmp="" err="" effect=""
   ensure_worktree_path_safe "$wt" "$path" false || return 1
   exclude_from_worktree_index "$wt" "$path" false
   ignore_file_copy_matches "$src" "$dst" && return 0
   if [[ -d "$dst" && ! -L "$dst" ]]; then
-    echo "Warning: '$path' in $wt is a directory where main's ignore file should be copied; leaving it alone." >&2
+    echo "Warning: '$path' in $wt is a directory where main's .gitignore should be copied; leaving it alone." >&2
     return 1
   fi
-  # Built beside the destination and renamed over it, so a reader never finds
-  # the path absent (the same window atomic_symlink_swap closes). rename(2)
-  # replaces a symlink destination itself rather than following it.
+  # Built beside the destination and renamed over it (atomic_symlink_swap's
+  # GNU -T / BSD -h pair, no delete-first fallback), so a reader never finds
+  # the path absent; rename(2) replaces a symlink destination, not its target.
+  # The temp name is cleared first: cp writes THROUGH a stale symlink there.
   tmp="$dst.wt-tmp.$$"
-  if cp "$src" "$tmp" 2>/dev/null &&
-     { mv -T "$tmp" "$dst" 2>/dev/null || mv -h "$tmp" "$dst" 2>/dev/null ||
-       { rm -f "$dst" 2>/dev/null && mv -f "$tmp" "$dst" 2>/dev/null; }; }; then
+  rm -f "$tmp" 2>/dev/null
+  if err="$(cp "$src" "$tmp" 2>&1)" &&
+     { err="$(mv -T "$tmp" "$dst" 2>&1)" || err="$(mv -h "$tmp" "$dst" 2>&1)"; }; then
     return 0
   fi
   rm -f "$tmp" 2>/dev/null
-  echo "Warning: could not copy '$path' into $wt; its ignore rules are not applied there." >&2
+  effect="its ignore rules are not applied there"
+  [[ -f "$dst" && ! -L "$dst" ]] && effect="the previous copy stays in effect, not main's current rules"
+  echo "Warning: could not copy '$path' into $wt (${err:-no diagnostic}); $effect." >&2
   return 1
 }
 
@@ -1496,9 +1500,7 @@ link_untracked_children() {
     classify_index_entry "$PROJECT_ROOT" "$rel"
     [[ -n "$CIE_EXACT" ]] && exact=1
     [[ -n "$CIE_DESCENDANTS" ]] && descendants=1
-    if [[ -z "$exact" && -z "$descendants" && "$name" == .gitignore && -f "$child" ]]; then
-      # Git will not read an ignore file through a symlink; see
-      # copy_ignore_file_into_worktree for the copy and its drift policy.
+    if [[ -z "$exact" && -z "$descendants" ]] && is_copied_ignore_child "$name" "$child"; then
       copy_ignore_file_into_worktree "$wt" "$rel" || unresolved="$unresolved  - $rel (copy failed — see warning above)"$'\n'
     elif [[ -z "$exact" && -z "$descendants" ]]; then
       # Nothing tracked here: ordinary symlink treatment, own exclude entry.
@@ -1669,9 +1671,8 @@ collect_materialized_child_links() {
     [[ -n "$CIE_EXACT" ]] && exact=1
     [[ -n "$CIE_DESCENDANTS" ]] && descendants=1
     if [[ -z "$exact" && -z "$descendants" ]]; then
-      # An untracked .gitignore is a real file BY DESIGN (KEN-685), never a
-      # materialized link; fix-links judges its content, not this detector.
-      [[ "$name" == .gitignore && -f "$child" ]] && continue
+      # A copied child is a real file by design; fix-links judges its content.
+      is_copied_ignore_child "$name" "$child" && continue
       [[ -e "$wt/$rel" && ! -L "$wt/$rel" ]] && printf '%s\n' "$rel"
     elif [[ -z "$exact" ]]; then
       # `|| capped=1`: a depth-capped deeper subtree must not abort this
@@ -1740,15 +1741,14 @@ collect_unhealthy_child_links() {
       collect_unhealthy_child_links "$rel" "$wt" $((depth + 1))
       continue
     fi
-    if [[ "$name" == .gitignore && -f "$child" ]]; then
-      # Healthy is a real file with main's content (KEN-685): a symlink here
-      # is the shape git refuses to read, and stale content is the drift the
-      # repair pass exists to close.
+    if is_copied_ignore_child "$name" "$child"; then
+      # Healthy is a real file with main's content; a symlink is the shape git
+      # refuses to read, stale content the drift the repair pass closes.
       ignore_file_copy_matches "$child" "$wt/$rel" && continue
       if [[ -L "$wt/$rel" ]]; then
-        printf '%s (a symlink, expected a copy of main'"'"'s ignore file)\n' "$rel"
+        printf '%s (a symlink, expected a copy of main'"'"'s .gitignore)\n' "$rel"
       elif [[ -e "$wt/$rel" ]]; then
-        printf '%s (differs from main'"'"'s ignore file)\n' "$rel"
+        printf '%s (differs from main'"'"'s .gitignore)\n' "$rel"
       else
         printf '%s (absent)\n' "$rel"
       fi

--- a/skills/worktree/scripts/worktree
+++ b/skills/worktree/scripts/worktree
@@ -398,7 +398,13 @@ Symlink entries that shadow tracked content:
   paths stay real files git owns, and only the untracked children are
   symlinked, recursing into children that mix tracked and untracked content.
   A newly installed skill under the entry is linked on the next
-  create/fix-links/auto-repair pass. Each untracked child goes through the
+  create/fix-links/auto-repair pass. One child is copied instead of linked:
+  an untracked .gitignore, because git refuses to read an ignore file
+  through a symlink ("unable to access ... Too many levels of symbolic
+  links") and would apply none of its rules. The main checkout's file is
+  the source: every pass re-copies it when the content differs, so a
+  change on main reaches the worktree on the next pass and an edit made
+  to the worktree copy is overwritten. Each untracked child goes through the
   same quarantine as a top-level entry: a child that has materialized as a
   real file or directory holding data git does not track, or that differs
   from the index, is reported and left in place, never overwritten. A child
@@ -1324,6 +1330,52 @@ atomic_symlink_swap() {
   return 1
 }
 
+# An untracked child named .gitignore is COPIED into the worktree, never
+# symlinked (KEN-685). Git refuses to read an ignore file through a symlink:
+# every command prints "unable to access '<path>/.gitignore': Too many levels
+# of symbolic links" and applies none of its rules, so whatever main's file
+# ignores becomes stageable in every worktree, which is exactly what
+# `git add -A` then commits.
+#
+# Drift policy: main owns the file. Every create/fix-links/auto-repair pass
+# re-copies when the content differs, so a change in the main checkout reaches
+# the worktrees on the next pass, and an edit made to the worktree copy is
+# overwritten by that same pass. The copy is the tool's own artifact, not user
+# data, so the quarantine's never-overwrite rule does not apply to it. A
+# symlink left by an earlier skill version is replaced the same way.
+#
+# The copy gets the same info/exclude entry the symlink used to get: main's
+# file is untracked, so nothing in the index would otherwise keep the copy out
+# of `git status` in a repo whose ignore file does not ignore itself.
+ignore_file_copy_matches() {
+  local src="$1" dst="$2"
+  [[ -f "$dst" && ! -L "$dst" ]] && cmp -s "$src" "$dst"
+}
+
+copy_ignore_file_into_worktree() {
+  local wt="$1" path="$2"
+  local src="$PROJECT_ROOT/$path" dst="$wt/$path" tmp=""
+  ensure_worktree_path_safe "$wt" "$path" false || return 1
+  exclude_from_worktree_index "$wt" "$path" false
+  ignore_file_copy_matches "$src" "$dst" && return 0
+  if [[ -d "$dst" && ! -L "$dst" ]]; then
+    echo "Warning: '$path' in $wt is a directory where main's ignore file should be copied; leaving it alone." >&2
+    return 1
+  fi
+  # Built beside the destination and renamed over it, so a reader never finds
+  # the path absent (the same window atomic_symlink_swap closes). rename(2)
+  # replaces a symlink destination itself rather than following it.
+  tmp="$dst.wt-tmp.$$"
+  if cp "$src" "$tmp" 2>/dev/null &&
+     { mv -T "$tmp" "$dst" 2>/dev/null || mv -h "$tmp" "$dst" 2>/dev/null ||
+       { rm -f "$dst" 2>/dev/null && mv -f "$tmp" "$dst" 2>/dev/null; }; }; then
+    return 0
+  fi
+  rm -f "$tmp" 2>/dev/null
+  echo "Warning: could not copy '$path' into $wt; its ignore rules are not applied there." >&2
+  return 1
+}
+
 # Sets $CIE_EXACT and $CIE_DESCENDANTS (non-empty = true) for whether $rel is
 # tracked as an exact leaf entry (file, symlink, or gitlink), or has tracked
 # descendants beneath it, in $repo's index.
@@ -1444,7 +1496,11 @@ link_untracked_children() {
     classify_index_entry "$PROJECT_ROOT" "$rel"
     [[ -n "$CIE_EXACT" ]] && exact=1
     [[ -n "$CIE_DESCENDANTS" ]] && descendants=1
-    if [[ -z "$exact" && -z "$descendants" ]]; then
+    if [[ -z "$exact" && -z "$descendants" && "$name" == .gitignore && -f "$child" ]]; then
+      # Git will not read an ignore file through a symlink; see
+      # copy_ignore_file_into_worktree for the copy and its drift policy.
+      copy_ignore_file_into_worktree "$wt" "$rel" || unresolved="$unresolved  - $rel (copy failed — see warning above)"$'\n'
+    elif [[ -z "$exact" && -z "$descendants" ]]; then
       # Nothing tracked here: ordinary symlink treatment, own exclude entry.
       # Quarantine-checked (#1317): this child may have materialized as a real
       # file or directory holding untracked user data since the last repair,
@@ -1613,6 +1669,9 @@ collect_materialized_child_links() {
     [[ -n "$CIE_EXACT" ]] && exact=1
     [[ -n "$CIE_DESCENDANTS" ]] && descendants=1
     if [[ -z "$exact" && -z "$descendants" ]]; then
+      # An untracked .gitignore is a real file BY DESIGN (KEN-685), never a
+      # materialized link; fix-links judges its content, not this detector.
+      [[ "$name" == .gitignore && -f "$child" ]] && continue
       [[ -e "$wt/$rel" && ! -L "$wt/$rel" ]] && printf '%s\n' "$rel"
     elif [[ -z "$exact" ]]; then
       # `|| capped=1`: a depth-capped deeper subtree must not abort this
@@ -1679,6 +1738,20 @@ collect_unhealthy_child_links() {
     fi
     if [[ -n "$descendants" ]]; then
       collect_unhealthy_child_links "$rel" "$wt" $((depth + 1))
+      continue
+    fi
+    if [[ "$name" == .gitignore && -f "$child" ]]; then
+      # Healthy is a real file with main's content (KEN-685): a symlink here
+      # is the shape git refuses to read, and stale content is the drift the
+      # repair pass exists to close.
+      ignore_file_copy_matches "$child" "$wt/$rel" && continue
+      if [[ -L "$wt/$rel" ]]; then
+        printf '%s (a symlink, expected a copy of main'"'"'s ignore file)\n' "$rel"
+      elif [[ -e "$wt/$rel" ]]; then
+        printf '%s (differs from main'"'"'s ignore file)\n' "$rel"
+      else
+        printf '%s (absent)\n' "$rel"
+      fi
       continue
     fi
     report_link_health "$wt" "$rel" "$PROJECT_ROOT/$rel"

--- a/skills/worktree/tests/worktree_symlink_shadows_tracked.sh
+++ b/skills/worktree/tests/worktree_symlink_shadows_tracked.sh
@@ -277,21 +277,24 @@ assert_real "$PREDATE_WT/.agents/skills/late.md" "the merge wrote the newly-trac
 
 echo "=== an untracked .gitignore under a tracked-content entry is copied, not linked (KEN-685) ==="
 
-# Git refuses to read an ignore file through a symlink, so a linked
-# .gitignore applies none of its rules in the worktree and prints "unable to
-# access" on every command. drovr's shape: `.opencode/agents` is tracked,
-# `.opencode/.gitignore` is untracked and ignores itself plus bun.lock.
+# Git refuses to read .gitignore through a symlink, so a linked one applies
+# none of its rules in the worktree and prints "unable to access" on every
+# command. drovr's shape: `.opencode/agents` is tracked, `.opencode/.gitignore`
+# is untracked and ignores bun.lock. It does NOT ignore itself: the copy in the
+# worktree is kept out of `git status` only by the info/exclude entry setup
+# writes for it, so the status assertions below prove that entry too.
 IGN_ROOT="$TMP_ROOT/ignore"
 make_repo "$IGN_ROOT"
 mkdir -p "$IGN_ROOT/main/.opencode/agents"
 printf 'agent\n' >"$IGN_ROOT/main/.opencode/agents/dev.md"
-printf 'bun.lock\n.gitignore\n' >"$IGN_ROOT/main/.opencode/.gitignore"
+printf 'bun.lock\n' >"$IGN_ROOT/main/.opencode/.gitignore"
 printf 'lock\n' >"$IGN_ROOT/main/.opencode/bun.lock"
 printf 'WORKTREE_SYMLINKS=".opencode"\n' >"$IGN_ROOT/main/.env"
 git -C "$IGN_ROOT/main" add .opencode/agents/dev.md
 git -C "$IGN_ROOT/main" commit -q -m 'track opencode agents'
 push_main "$IGN_ROOT"
-assert_eq "$(git -C "$IGN_ROOT/main" status --porcelain -- .opencode)" "" "main ignores bun.lock through the untracked .gitignore"
+assert_eq "$(git -C "$IGN_ROOT/main" status --porcelain -- .opencode/bun.lock)" "" "main ignores bun.lock through the untracked .gitignore"
+assert_eq "$(git -C "$IGN_ROOT/main" status --porcelain -- .opencode)" "?? .opencode/.gitignore" "main's .gitignore is untracked and does not hide itself"
 
 set +e
 IGN_WT="$( (cd "$IGN_ROOT/main" && "$WORKTREE_SCRIPT" create ignore-check) 2>"$IGN_ROOT/err" )"
@@ -309,9 +312,18 @@ printf 'lock\n' >"$IGN_WT/.opencode/bun.lock"
 assert_eq "$(git -C "$IGN_WT" status --porcelain 2>&1)" "" "bun.lock is ignored in the worktree"
 assert_lacks "$(git -C "$IGN_WT" status 2>&1)" "unable to access" "git prints no ignore-file access warning"
 
+# push is the one command that runs the materialization detector; the copy
+# must read as the expected shape there, not as a real path where a link belongs.
+set +e
+(cd "$IGN_ROOT/main" && "$WORKTREE_SCRIPT" push ignore-check --no-rebase -u) >/dev/null 2>"$IGN_ROOT/perr"
+ign_push_status=$?
+set -e
+assert_eq "$ign_push_status" "0" "push succeeds from the worktree holding the copy"
+assert_lacks "$(cat "$IGN_ROOT/perr")" "harness paths in this worktree" "push does not report the copy as a materialized link"
+
 echo "=== the .gitignore copy follows main on the next pass, and a legacy link heals to a copy ==="
 
-printf 'bun.lock\n.gitignore\nnode_modules/\n' >"$IGN_ROOT/main/.opencode/.gitignore"
+printf 'bun.lock\nnode_modules/\n' >"$IGN_ROOT/main/.opencode/.gitignore"
 set +e
 (cd "$IGN_ROOT/main" && "$WORKTREE_SCRIPT" fix-links "$IGN_WT") >/dev/null 2>"$IGN_ROOT/err2"
 ign_fix_status=$?

--- a/skills/worktree/tests/worktree_symlink_shadows_tracked.sh
+++ b/skills/worktree/tests/worktree_symlink_shadows_tracked.sh
@@ -275,6 +275,69 @@ set -e
 assert_eq "$merge_status2" "0" "the merge that introduces the tracked child succeeds"
 assert_real "$PREDATE_WT/.agents/skills/late.md" "the merge wrote the newly-tracked child as a real file"
 
+echo "=== an untracked .gitignore under a tracked-content entry is copied, not linked (KEN-685) ==="
+
+# Git refuses to read an ignore file through a symlink, so a linked
+# .gitignore applies none of its rules in the worktree and prints "unable to
+# access" on every command. drovr's shape: `.opencode/agents` is tracked,
+# `.opencode/.gitignore` is untracked and ignores itself plus bun.lock.
+IGN_ROOT="$TMP_ROOT/ignore"
+make_repo "$IGN_ROOT"
+mkdir -p "$IGN_ROOT/main/.opencode/agents"
+printf 'agent\n' >"$IGN_ROOT/main/.opencode/agents/dev.md"
+printf 'bun.lock\n.gitignore\n' >"$IGN_ROOT/main/.opencode/.gitignore"
+printf 'lock\n' >"$IGN_ROOT/main/.opencode/bun.lock"
+printf 'WORKTREE_SYMLINKS=".opencode"\n' >"$IGN_ROOT/main/.env"
+git -C "$IGN_ROOT/main" add .opencode/agents/dev.md
+git -C "$IGN_ROOT/main" commit -q -m 'track opencode agents'
+push_main "$IGN_ROOT"
+assert_eq "$(git -C "$IGN_ROOT/main" status --porcelain -- .opencode)" "" "main ignores bun.lock through the untracked .gitignore"
+
+set +e
+IGN_WT="$( (cd "$IGN_ROOT/main" && "$WORKTREE_SCRIPT" create ignore-check) 2>"$IGN_ROOT/err" )"
+ign_status=$?
+set -e
+assert_eq "$ign_status" "0" "create succeeds for the entry holding an untracked .gitignore"
+[[ -n "$IGN_WT" && -d "$IGN_WT" ]] || { echo "FATAL: worktree not created: $(cat "$IGN_ROOT/err")"; exit 1; }
+
+assert_real "$IGN_WT/.opencode/.gitignore" "the .gitignore is a real file in the worktree, not a link"
+assert_eq "$(cat "$IGN_WT/.opencode/.gitignore")" "$(cat "$IGN_ROOT/main/.opencode/.gitignore")" "the copy has main's content"
+assert_real "$IGN_WT/.opencode/agents/dev.md" "the tracked file beside it stays a real file"
+
+# The proof: the worktree ignores what main ignores, and git stops complaining.
+printf 'lock\n' >"$IGN_WT/.opencode/bun.lock"
+assert_eq "$(git -C "$IGN_WT" status --porcelain 2>&1)" "" "bun.lock is ignored in the worktree"
+assert_lacks "$(git -C "$IGN_WT" status 2>&1)" "unable to access" "git prints no ignore-file access warning"
+
+echo "=== the .gitignore copy follows main on the next pass, and a legacy link heals to a copy ==="
+
+printf 'bun.lock\n.gitignore\nnode_modules/\n' >"$IGN_ROOT/main/.opencode/.gitignore"
+set +e
+(cd "$IGN_ROOT/main" && "$WORKTREE_SCRIPT" fix-links "$IGN_WT") >/dev/null 2>"$IGN_ROOT/err2"
+ign_fix_status=$?
+set -e
+assert_eq "$ign_fix_status" "0" "fix-links succeeds after main's .gitignore changed"
+assert_lacks "$(cat "$IGN_ROOT/err2")" "Warning" "fix-links stays quiet while re-copying"
+assert_eq "$(cat "$IGN_WT/.opencode/.gitignore")" "$(cat "$IGN_ROOT/main/.opencode/.gitignore")" "the copy picked up main's change"
+
+# A worktree provisioned by the older skill holds a link where the copy belongs.
+rm -f "$IGN_WT/.opencode/.gitignore"
+ln -s "$IGN_ROOT/main/.opencode/.gitignore" "$IGN_WT/.opencode/.gitignore"
+set +e
+(cd "$IGN_ROOT/main" && "$WORKTREE_SCRIPT" fix-links "$IGN_WT") >/dev/null 2>"$IGN_ROOT/err3"
+ign_legacy_status=$?
+set -e
+assert_eq "$ign_legacy_status" "0" "fix-links succeeds on a legacy linked .gitignore"
+assert_real "$IGN_WT/.opencode/.gitignore" "the legacy link became a copy"
+assert_eq "$(git -C "$IGN_WT" status --porcelain 2>&1)" "" "the healed worktree ignores bun.lock again"
+
+# fix-links judges the copy's content: a worktree edit is drift it closes.
+printf 'edited\n' >"$IGN_WT/.opencode/.gitignore"
+set +e
+(cd "$IGN_ROOT/main" && "$WORKTREE_SCRIPT" fix-links "$IGN_WT") >/dev/null 2>&1
+set -e
+assert_eq "$(cat "$IGN_WT/.opencode/.gitignore")" "$(cat "$IGN_ROOT/main/.opencode/.gitignore")" "a worktree edit to the copy is overwritten by main's file"
+
 echo "=== a locked index during legacy heal reports failure, not a swallowed success (#850) ==="
 
 # The old code discarded failures from --no-assume-unchanged and the missing-

--- a/tools/size-ratchet-baseline.tsv
+++ b/tools/size-ratchet-baseline.tsv
@@ -133,7 +133,7 @@ skills/second-opinion/tests/cli-failure-gate.test.sh	1211
 skills/second-opinion/tests/lane-scratch-durability.test.sh	999
 skills/second-opinion/tests/review-dual-model.test.sh	1516
 skills/size-ratchet/scripts/size-ratchet	1092
-skills/worktree/scripts/worktree	4788
+skills/worktree/scripts/worktree	4861
 skills/worktree/scripts/worktree-session-guard	1197
 skills/worktree/tests/worktree_session_guard.sh	1282
 ui/src/stores/marketplaces.ts	283


### PR DESCRIPTION
## Summary
- When a `WORKTREE_SYMLINKS` entry holds tracked content, its untracked children are linked one by one; an untracked `.gitignore` among them is now copied instead of symlinked, because git refuses to read an ignore file through a symlink (`unable to access ... Too many levels of symbolic links`) and applies none of its rules, so anything main ignored became stageable in every worktree.
- Drift policy, stated in the code and in `fix-links --help`: main owns the file; every create/fix-links/auto-repair pass re-copies on content difference, and a worktree edit to the copy is overwritten. A legacy symlink heals to a copy. One predicate (`is_copied_ignore_child`) drives the repair path and both detectors.
- Fleet sweep for the shape: only drovr (`.opencode/.gitignore` under tracked `.opencode`) has it; verified there on a fresh worktree (bun.lock ignored, no warning, fix-links quiet).

## Completed Issues
- Closes KEN-685 - worktree: a symlinked .gitignore stops working, so a worktree ignores less than the main checkout

## Test Plan
- New section in `skills/worktree/tests/worktree_symlink_shadows_tracked.sh`: copy shape and content, tracked sibling untouched, bun.lock ignored with no access warning, re-copy after main changes, legacy link healed, worktree edit overwritten, push path reports no materialized link, fixture's ignore file does not self-ignore so the info/exclude entry is observable. Red on the old script at the defect assertions; 56/56 green now; six mutants killed.
- `tools/guard` exit 0 (all worktree suites, vitest, cargo); `preflight --base origin/main` clean; size-ratchet row for the script raised 4788 → 4861 for the new helper.

https://claude.ai/code/session_01VNE5GQLr4mHQ4SDxxEyLXL
