### PR TITLE
fix(KEN-640): remove --keep-declaration leaves kendex.toml alone

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,9 @@ an outside contributor.
 - A package that changes the repository beyond kendex's own folders says so
   at install and waits for its own yes, good for that run alone. Declining
   installs it unarmed; no terminal declines unless `--allow-repo-effects`.
+- `kendex remove <name> --keep-declaration` takes the files away and leaves
+  kendex.toml alone, so the next `kendex refresh` installs the package again.
+  The remedy for an install gone wrong no longer needs the manifest restored.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,8 +17,8 @@ an outside contributor.
   at install and waits for its own yes, good for that run alone. Declining
   installs it unarmed; no terminal declines unless `--allow-repo-effects`.
 - `kendex remove <name> --keep-declaration` takes the files away and leaves
-  kendex.toml alone, so the next `kendex refresh` installs the package again.
-  The remedy for an install gone wrong no longer needs the manifest restored.
+  kendex.toml untouched, so the next `kendex refresh` installs what it
+  declares again. Fixing a broken install no longer needs the manifest restored.
 
 ### Changed
 

--- a/README.md
+++ b/README.md
@@ -176,7 +176,7 @@ then `kendex guard install`.
 | Verb | Does |
 |---|---|
 | `add` (or bare `kendex <source>`) | declare and install agents/skills from a source |
-| `remove`, `adopt`, `apply` | undeclare, take ownership, reconcile |
+| `remove`, `adopt`, `apply` | undeclare (`--keep-declaration` uninstalls only), take ownership, reconcile |
 | `refresh` | re-resolve sources, regenerate every installation |
 | `verify` | drift check; exit 1 on any failing row |
 | `list` (`ls`), `check` | observe everything; sanity report |

--- a/crates/cli/src/commands/remove.rs
+++ b/crates/cli/src/commands/remove.rs
@@ -31,22 +31,77 @@ pub fn run(env: &Env, names: Vec<String>, filter: ScopeFilter, sweep: Option<boo
         for warning in &report.warnings {
             say(&format!("warning: {}: {}", warning.name, warning.message));
         }
-        let touches_artifacts = report
-            .plan
-            .ops
-            .iter()
-            .any(|op| matches!(op.op, Op::Trash { .. } | Op::WriteLock { .. }));
-        if touches_artifacts {
+        if takes_anything(&report) {
             removed_any = true;
             say_split(&report);
-            kendex_core::apply::execute(env, &report.plan, None)?;
-            for op in &report.plan.ops {
-                say(&format!("  - {}", op.description));
-            }
+            take_away(env, &report)?;
         }
     }
     if !removed_any {
         say("Nothing removed");
+    }
+    Ok(())
+}
+
+/// `--keep-declaration`: the files go, kendex.toml stays as it is, and the
+/// next refresh installs the items again. Nothing to ask about a sweep —
+/// what these items pull in is wanted back with them — and nothing to warn
+/// about: whatever needed them gets them back the same way.
+pub fn uninstall(env: &Env, names: Vec<String>, filter: ScopeFilter) -> CliResult {
+    if names.is_empty() {
+        say("usage: kendex remove <name>… --keep-declaration [--scope project|global|all]");
+        return Ok(());
+    }
+    let mut removed_any = false;
+    for scope in resolve_scopes(env, filter)? {
+        let report = match ops::uninstall(env, &scope, &names) {
+            Ok(report) => report,
+            Err(error) if super::engine_common::is_legacy(&error) => continue,
+            Err(error) => return Err(error.into()),
+        };
+        if !takes_anything(&report) {
+            continue;
+        }
+        removed_any = true;
+        // The planner's reasons read as disowning ("no longer declared
+        // here"); here the declaration stays, so only the kept rows carry
+        // theirs.
+        for change in &report.set_changes {
+            if change.direction == kendex_core::engine::SetDirection::Remove {
+                say(&format!(
+                    "removing {} {} for {}",
+                    change.kind.name(),
+                    change.name,
+                    change.harness.display_name()
+                ));
+            }
+        }
+        say_kept(&report);
+        take_away(env, &report)?;
+        say(&format!(
+            "{}: still declared in kendex.toml; refresh installs it again",
+            scope.label()
+        ));
+    }
+    if !removed_any {
+        say("Nothing removed");
+    }
+    Ok(())
+}
+
+/// Whether the plan takes anything off disk; one that does not is not run.
+fn takes_anything(report: &EngineReport) -> bool {
+    report
+        .plan
+        .ops
+        .iter()
+        .any(|op| matches!(op.op, Op::Trash { .. } | Op::WriteLock { .. }))
+}
+
+fn take_away(env: &Env, report: &EngineReport) -> CliResult {
+    kendex_core::apply::execute(env, &report.plan, None)?;
+    for op in &report.plan.ops {
+        say(&format!("  - {}", op.description));
     }
     Ok(())
 }
@@ -67,6 +122,10 @@ fn say_split(report: &EngineReport) {
             ));
         }
     }
+    say_kept(report);
+}
+
+fn say_kept(report: &EngineReport) {
     for kept in &report.kept {
         say(&format!(
             "keeping {} {} for {} — {}",

--- a/crates/cli/src/commands/remove.rs
+++ b/crates/cli/src/commands/remove.rs
@@ -8,80 +8,63 @@ use kendex_core::model::Scope;
 use super::{CliResult, resolve_scopes, say};
 use crate::scope::ScopeFilter;
 
-/// `sweep` is the answer to "and the things only these items needed?" —
-/// `None` means nobody has answered yet.
-pub fn run(env: &Env, names: Vec<String>, filter: ScopeFilter, sweep: Option<bool>) -> CliResult {
+/// What a removal does with the declaration.
+#[derive(Clone, Copy)]
+pub enum Removal {
+    /// Drop it. `sweep` is the answer to "and the things only these items
+    /// needed?" — `None` means nobody has answered yet.
+    Disown { sweep: Option<bool> },
+    /// Keep it: the files go, kendex.toml stays as it is, and the next
+    /// refresh installs what it declares again. Nothing to ask about a
+    /// sweep — what these items pull in is wanted back with them.
+    KeepDeclaration,
+}
+
+pub fn run(env: &Env, names: Vec<String>, filter: ScopeFilter, mode: Removal) -> CliResult {
     if names.is_empty() {
-        say("usage: kendex remove <name>… [--scope project|global|all]");
+        say("usage: kendex remove <name>… [--keep-declaration] [--scope project|global|all]");
         return Ok(());
     }
     let mut removed_any = false;
     for scope in resolve_scopes(env, filter)? {
-        let report = match ops::remove(env, &scope, &names, None, sweep.unwrap_or(false)) {
+        let planned = match mode {
+            Removal::Disown { sweep } => {
+                ops::remove(env, &scope, &names, None, sweep.unwrap_or(false))
+            }
+            Removal::KeepDeclaration => ops::uninstall(env, &scope, &names),
+        };
+        let report = match planned {
             Ok(report) => report,
             // A scope without a v2 manifest has nothing of ours to remove.
             Err(error) if super::engine_common::is_legacy(&error) => continue,
             Err(error) => return Err(error.into()),
         };
-        let report = match answer(env, &scope, &names, report, sweep)? {
-            Some(report) => report,
-            None => continue,
+        let report = match mode {
+            Removal::Disown { sweep } => answer(env, &scope, &names, report, sweep)?,
+            Removal::KeepDeclaration => report,
         };
-        // What still wants a removed item says so now, not on the next audit.
+        // What still wants a removed item says so now, not on the next
+        // audit. Kept declared, a dependency's "kept removed" is true only
+        // until the refresh the closing line names; the warning carries no
+        // type to tell it from the rest, so it prints with them.
         for warning in &report.warnings {
             say(&format!("warning: {}: {}", warning.name, warning.message));
         }
-        if takes_anything(&report) {
-            removed_any = true;
-            say_split(&report);
-            take_away(env, &report)?;
-        }
-    }
-    if !removed_any {
-        say("Nothing removed");
-    }
-    Ok(())
-}
-
-/// `--keep-declaration`: the files go, kendex.toml stays as it is, and the
-/// next refresh installs the items again. Nothing to ask about a sweep —
-/// what these items pull in is wanted back with them — and nothing to warn
-/// about: whatever needed them gets them back the same way.
-pub fn uninstall(env: &Env, names: Vec<String>, filter: ScopeFilter) -> CliResult {
-    if names.is_empty() {
-        say("usage: kendex remove <name>… --keep-declaration [--scope project|global|all]");
-        return Ok(());
-    }
-    let mut removed_any = false;
-    for scope in resolve_scopes(env, filter)? {
-        let report = match ops::uninstall(env, &scope, &names) {
-            Ok(report) => report,
-            Err(error) if super::engine_common::is_legacy(&error) => continue,
-            Err(error) => return Err(error.into()),
-        };
         if !takes_anything(&report) {
             continue;
         }
         removed_any = true;
-        // The planner's reasons read as disowning ("no longer declared
-        // here"); here the declaration stays, so only the kept rows carry
-        // theirs.
-        for change in &report.set_changes {
-            if change.direction == kendex_core::engine::SetDirection::Remove {
-                say(&format!(
-                    "removing {} {} for {}",
-                    change.kind.name(),
-                    change.name,
-                    change.harness.display_name()
-                ));
-            }
+        say_split(&report, mode);
+        kendex_core::apply::execute(env, &report.plan, None)?;
+        for op in &report.plan.ops {
+            say(&format!("  - {}", op.description));
         }
-        say_kept(&report);
-        take_away(env, &report)?;
-        say(&format!(
-            "{}: still declared in kendex.toml; refresh installs it again",
-            scope.label()
-        ));
+        if matches!(mode, Removal::KeepDeclaration) {
+            say(&format!(
+                "{}: kendex.toml unchanged; refresh installs what it declares again",
+                scope.label()
+            ));
+        }
     }
     if !removed_any {
         say("Nothing removed");
@@ -98,34 +81,27 @@ fn takes_anything(report: &EngineReport) -> bool {
         .any(|op| matches!(op.op, Op::Trash { .. } | Op::WriteLock { .. }))
 }
 
-fn take_away(env: &Env, report: &EngineReport) -> CliResult {
-    kendex_core::apply::execute(env, &report.plan, None)?;
-    for op in &report.plan.ops {
-        say(&format!("  - {}", op.description));
-    }
-    Ok(())
-}
-
 /// What the removal decided. Taking a bundle away takes some of what it
 /// carried and leaves the rest, so both halves are said out loud, each with
 /// what accounts for it — otherwise the user is left guessing which members
-/// survived and why.
-fn say_split(report: &EngineReport) {
+/// survived and why. The planner's reason for a removal reads as disowning
+/// ("no longer declared here"), so with the declaration kept only the kept
+/// rows carry theirs.
+fn say_split(report: &EngineReport, mode: Removal) {
     for change in &report.set_changes {
         if change.direction == kendex_core::engine::SetDirection::Remove {
+            let reason = match mode {
+                Removal::Disown { .. } => format!(" — {}", change.reason),
+                Removal::KeepDeclaration => String::new(),
+            };
             say(&format!(
-                "removing {} {} for {} — {}",
+                "removing {} {} for {}{reason}",
                 change.kind.name(),
                 change.name,
-                change.harness.display_name(),
-                change.reason
+                change.harness.display_name()
             ));
         }
     }
-    say_kept(report);
-}
-
-fn say_kept(report: &EngineReport) {
     for kept in &report.kept {
         say(&format!(
             "keeping {} {} for {} — {}",
@@ -147,9 +123,9 @@ fn answer(
     names: &[String],
     report: EngineReport,
     sweep: Option<bool>,
-) -> Result<Option<EngineReport>, Box<dyn std::error::Error>> {
+) -> Result<EngineReport, Box<dyn std::error::Error>> {
     if sweep.is_some() || report.sweepable.is_empty() {
-        return Ok(Some(report));
+        return Ok(report);
     }
     let leftovers: Vec<String> = report
         .sweepable
@@ -171,7 +147,7 @@ fn answer(
     let mut answer = String::new();
     std::io::stdin().read_line(&mut answer)?;
     match matches!(answer.trim(), "y" | "Y" | "yes") {
-        true => Ok(Some(ops::remove(env, scope, names, None, true)?)),
-        false => Ok(Some(report)),
+        true => Ok(ops::remove(env, scope, names, None, true)?),
+        false => Ok(report),
     }
 }

--- a/crates/cli/src/dispatch_args.rs
+++ b/crates/cli/src/dispatch_args.rs
@@ -1,11 +1,13 @@
 //! The two dispatch helpers whose flag-untangling outgrew the command
-//! table: `check` (catalog vs. scope) and `remove` (sweep resolution).
+//! table: `check` (catalog vs. scope) and `remove` (what happens to the
+//! declaration, and the sweep answer).
 
 use crate::scope::ScopeFilter;
 use kendex_core::env::Env;
 use std::process::ExitCode;
 
 use crate::commands;
+use crate::commands::remove::Removal;
 
 pub(crate) fn check(
     env: &Env,
@@ -37,13 +39,11 @@ pub(crate) fn remove(
     keep_declaration: bool,
 ) -> Result<(), Box<dyn std::error::Error>> {
     let filter = ScopeFilter::resolve(scope.as_deref(), global, ScopeFilter::Project)?;
-    if keep_declaration {
-        return commands::remove::uninstall(env, names, filter);
-    }
-    let sweep = match (sweep, no_sweep) {
-        (true, _) => Some(true),
-        (_, true) => Some(false),
-        _ => None,
+    let mode = match (keep_declaration, sweep, no_sweep) {
+        (true, _, _) => Removal::KeepDeclaration,
+        (_, true, _) => Removal::Disown { sweep: Some(true) },
+        (_, _, true) => Removal::Disown { sweep: Some(false) },
+        _ => Removal::Disown { sweep: None },
     };
-    commands::remove::run(env, names, filter, sweep)
+    commands::remove::run(env, names, filter, mode)
 }

--- a/crates/cli/src/dispatch_args.rs
+++ b/crates/cli/src/dispatch_args.rs
@@ -34,8 +34,12 @@ pub(crate) fn remove(
     scope: Option<String>,
     sweep: bool,
     no_sweep: bool,
+    keep_declaration: bool,
 ) -> Result<(), Box<dyn std::error::Error>> {
     let filter = ScopeFilter::resolve(scope.as_deref(), global, ScopeFilter::Project)?;
+    if keep_declaration {
+        return commands::remove::uninstall(env, names, filter);
+    }
     let sweep = match (sweep, no_sweep) {
         (true, _) => Some(true),
         (_, true) => Some(false),

--- a/crates/cli/src/lib.rs
+++ b/crates/cli/src/lib.rs
@@ -64,7 +64,7 @@ enum Command {
         /// Keep what nothing needs anymore
         #[arg(long, conflicts_with = "sweep")]
         no_sweep: bool,
-        /// Take the files away but leave kendex.toml alone; refresh installs them again
+        /// Take the files away and leave kendex.toml untouched; refresh installs what it declares again
         #[arg(long, conflicts_with_all = ["sweep", "no_sweep"])]
         keep_declaration: bool,
     },

--- a/crates/cli/src/lib.rs
+++ b/crates/cli/src/lib.rs
@@ -64,6 +64,9 @@ enum Command {
         /// Keep what nothing needs anymore
         #[arg(long, conflicts_with = "sweep")]
         no_sweep: bool,
+        /// Take the files away but leave kendex.toml alone; refresh installs them again
+        #[arg(long, conflicts_with_all = ["sweep", "no_sweep"])]
+        keep_declaration: bool,
     },
     /// Regenerate every declared installation from its source
     Refresh(commands::refresh::RefreshArgs),
@@ -249,7 +252,16 @@ fn run(cli: Cli) -> Result<ExitCode, Box<dyn std::error::Error>> {
             scope,
             sweep,
             no_sweep,
-        } => remove(&env, names, global, scope, sweep, no_sweep)?,
+            keep_declaration,
+        } => remove(
+            &env,
+            names,
+            global,
+            scope,
+            sweep,
+            no_sweep,
+            keep_declaration,
+        )?,
         Command::Refresh(args) => commands::refresh::run_args(&env, args)?,
         Command::Verify {
             names,

--- a/crates/cli/tests/deps_cli.rs
+++ b/crates/cli/tests/deps_cli.rs
@@ -255,3 +255,71 @@ fn an_optional_dependency_is_taken_only_when_it_is_asked_for() {
     assert!(output.status.success());
     assert!(project.join(".claude/skills/linear").exists());
 }
+
+/// `--keep-declaration` takes the files and leaves kendex.toml alone, so a
+/// refresh puts them back — the remedy for an install gone wrong. A
+/// dependency named this way comes off too, and comes back the same way,
+/// with nothing written down to hold it back.
+#[test]
+#[allow(clippy::unwrap_used)]
+fn keeping_the_declaration_lets_a_refresh_install_it_again() {
+    let tmp = tempfile::tempdir().unwrap();
+    let home = tmp.path();
+    let project = project(&tmp);
+    let before = fs::read_to_string(project.join("kendex.toml")).unwrap();
+    assert!(before.contains("[skills.dev]"), "{before}");
+
+    let output = kendex(home, &project, &["remove", "dev", "--keep-declaration"]);
+    assert!(
+        output.status.success(),
+        "{}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let said = String::from_utf8_lossy(&output.stderr).into_owned();
+    assert!(said.contains("refresh installs it again"), "{said}");
+    assert!(!project.join(".claude/skills/dev").exists());
+    assert!(
+        project.join(".claude/skills/github").exists(),
+        "nothing is swept when the declaration stays"
+    );
+    assert_eq!(
+        fs::read_to_string(project.join("kendex.toml")).unwrap(),
+        before,
+        "the manifest was written"
+    );
+
+    let output = kendex(home, &project, &["refresh", "--yes"]);
+    assert!(
+        output.status.success(),
+        "{}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert!(project.join(".claude/skills/dev").exists());
+
+    let output = kendex(home, &project, &["remove", "github", "--keep-declaration"]);
+    assert!(
+        output.status.success(),
+        "{}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert!(!project.join(".claude/skills/github").exists());
+    assert_eq!(
+        fs::read_to_string(project.join("kendex.toml")).unwrap(),
+        before,
+        "a dependency taken this way is not held back"
+    );
+    let output = kendex(home, &project, &["refresh", "--yes"]);
+    assert!(
+        output.status.success(),
+        "{}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert!(project.join(".claude/skills/github").exists());
+
+    let output = kendex(
+        home,
+        &project,
+        &["remove", "dev", "--keep-declaration", "--sweep"],
+    );
+    assert!(!output.status.success(), "a sweep contradicts keeping");
+}

--- a/crates/cli/tests/deps_cli.rs
+++ b/crates/cli/tests/deps_cli.rs
@@ -276,7 +276,10 @@ fn keeping_the_declaration_lets_a_refresh_install_it_again() {
         String::from_utf8_lossy(&output.stderr)
     );
     let said = String::from_utf8_lossy(&output.stderr).into_owned();
-    assert!(said.contains("refresh installs it again"), "{said}");
+    assert!(
+        said.contains("refresh installs what it declares again"),
+        "{said}"
+    );
     assert!(!project.join(".claude/skills/dev").exists());
     assert!(
         project.join(".claude/skills/github").exists(),
@@ -286,6 +289,11 @@ fn keeping_the_declaration_lets_a_refresh_install_it_again() {
         fs::read_to_string(project.join("kendex.toml")).unwrap(),
         before,
         "the manifest was written"
+    );
+    let lock = fs::read_to_string(project.join(".kendex-lock.json")).unwrap();
+    assert!(
+        !lock.contains("skill:dev:"),
+        "the record still holds dev: {lock}"
     );
 
     let output = kendex(home, &project, &["refresh", "--yes"]);
@@ -308,6 +316,8 @@ fn keeping_the_declaration_lets_a_refresh_install_it_again() {
         before,
         "a dependency taken this way is not held back"
     );
+    let lock = fs::read_to_string(project.join(".kendex-lock.json")).unwrap();
+    assert!(!lock.contains("skill:github:"), "{lock}");
     let output = kendex(home, &project, &["refresh", "--yes"]);
     assert!(
         output.status.success(),
@@ -316,10 +326,14 @@ fn keeping_the_declaration_lets_a_refresh_install_it_again() {
     );
     assert!(project.join(".claude/skills/github").exists());
 
-    let output = kendex(
-        home,
-        &project,
-        &["remove", "dev", "--keep-declaration", "--sweep"],
-    );
-    assert!(!output.status.success(), "a sweep contradicts keeping");
+    for flag in ["--sweep", "--no-sweep"] {
+        let output = kendex(
+            home,
+            &project,
+            &["remove", "dev", "--keep-declaration", flag],
+        );
+        let said = String::from_utf8_lossy(&output.stderr).into_owned();
+        assert!(!output.status.success(), "{flag} contradicts keeping");
+        assert!(said.contains("cannot be used with"), "{said}");
+    }
 }

--- a/crates/cli/tests/deps_cli.rs
+++ b/crates/cli/tests/deps_cli.rs
@@ -305,11 +305,9 @@ fn keeping_the_declaration_lets_a_refresh_install_it_again() {
     assert!(project.join(".claude/skills/dev").exists());
 
     let output = kendex(home, &project, &["remove", "github", "--keep-declaration"]);
-    assert!(
-        output.status.success(),
-        "{}",
-        String::from_utf8_lossy(&output.stderr)
-    );
+    let said = String::from_utf8_lossy(&output.stderr).into_owned();
+    assert!(output.status.success(), "{said}");
+    assert!(said.contains("dev requires github"), "{said}");
     assert!(!project.join(".claude/skills/github").exists());
     assert_eq!(
         fs::read_to_string(project.join("kendex.toml")).unwrap(),

--- a/crates/core/src/engine/agent_skills.rs
+++ b/crates/core/src/engine/agent_skills.rs
@@ -1,0 +1,73 @@
+//! An agent's skill list: what the declaration holds, merged with what
+//! upstream added since the last sync, and where that merge is written.
+
+use crate::lock::entry_key;
+use crate::manifest::Manifest;
+use crate::mapping::{EffectiveSkills, effective_skills};
+use crate::model::ItemKind;
+use crate::render::agent::Role;
+use crate::source::list_items;
+
+use super::desired::ItemCtx;
+
+/// The agent's skill list, merging anything upstream added since the last
+/// sync back into the manifest so the declaration keeps saying what the
+/// agent actually renders with. Held (`PlanOptions::hold_upstream_skills`),
+/// nothing merges: the list is the declaration's, and `upstream_now`
+/// carries the recorded list instead — it is what renders where nothing is
+/// declared and what the lock keeps, both exactly as they were.
+pub(super) fn assigned_skills(
+    ctx: &ItemCtx,
+    role: Option<Role>,
+    updated_manifest: &mut Manifest,
+    manifest_changed: &mut bool,
+) -> EffectiveSkills {
+    let available = list_items(ctx.sealed, ctx.config, ItemKind::Skill);
+    let recorded = ctx.harnesses.iter().find_map(|h| {
+        ctx.lock
+            .entries
+            .get(&entry_key(ItemKind::Agent, ctx.name, *h))
+            .and_then(|entry| entry.upstream_skills.clone())
+    });
+    let held = ctx.hold_upstream_skills;
+    let mut skills = effective_skills(
+        ctx.name,
+        role,
+        ctx.manifest,
+        ctx.config,
+        &available,
+        recorded.as_deref().filter(|_| !held),
+    );
+    if held {
+        skills.upstream_now = recorded.unwrap_or(skills.upstream_now);
+        return skills;
+    }
+    if skills.manifest_additions.is_empty() {
+        return skills;
+    }
+    let entry = updated_manifest
+        .agent_skills
+        .entry(merge_key(ctx.manifest, ctx.name))
+        .or_default();
+    for skill in &skills.manifest_additions {
+        if !entry.contains(skill) {
+            entry.push(skill.clone());
+        }
+    }
+    *manifest_changed = true;
+    skills
+}
+
+/// The `agent_skills` key the effective list was read from. Writing
+/// additions anywhere else creates an entry that shadows the one being read,
+/// and the shadowed skills silently vanish from the next rendering.
+fn merge_key(manifest: &Manifest, name: &str) -> String {
+    if manifest.agent_skills.contains_key(name) {
+        return name.to_owned();
+    }
+    let stripped = crate::mapping::skill_match_prefix(name);
+    match manifest.agent_skills.contains_key(stripped) {
+        true => stripped.to_owned(),
+        false => name.to_owned(),
+    }
+}

--- a/crates/core/src/engine/desired.rs
+++ b/crates/core/src/engine/desired.rs
@@ -206,17 +206,24 @@ pub fn desired_state(
     scope: &Scope,
     manifest: &Manifest,
     lock: &Lock,
+    hold_upstream_skills: bool,
 ) -> Result<DesiredState> {
-    let first = compute(env, scope, manifest, lock)?;
+    let first = compute(env, scope, manifest, lock, hold_upstream_skills)?;
     let Some(merged) = first.manifest_update else {
         return Ok(first);
     };
-    let mut second = compute(env, scope, &merged, lock)?;
+    let mut second = compute(env, scope, &merged, lock, hold_upstream_skills)?;
     second.manifest_update = Some(merged);
     Ok(second)
 }
 
-fn compute(env: &Env, scope: &Scope, manifest: &Manifest, lock: &Lock) -> Result<DesiredState> {
+fn compute(
+    env: &Env,
+    scope: &Scope,
+    manifest: &Manifest,
+    lock: &Lock,
+    hold_upstream_skills: bool,
+) -> Result<DesiredState> {
     let mut state = DesiredState::default();
     let mut updated_manifest = manifest.clone();
     let mut manifest_changed = false;
@@ -258,6 +265,7 @@ fn compute(env: &Env, scope: &Scope, manifest: &Manifest, lock: &Lock) -> Result
                 scope,
                 manifest,
                 lock,
+                hold_upstream_skills,
                 config: &config,
                 sealed: &sealed,
                 name,
@@ -304,6 +312,7 @@ pub(super) struct ItemCtx<'a> {
     pub(super) scope: &'a Scope,
     pub(super) manifest: &'a Manifest,
     pub(super) lock: &'a Lock,
+    pub(super) hold_upstream_skills: bool,
     pub(super) config: &'a crate::source::SourceConfig,
     pub(super) sealed: &'a SealedSource,
     pub(super) name: &'a str,

--- a/crates/core/src/engine/desired_agent.rs
+++ b/crates/core/src/engine/desired_agent.rs
@@ -2,7 +2,7 @@ use crate::error::Result;
 use crate::hash::installation_hash;
 use crate::lock::entry_key;
 use crate::manifest::{CustomHook, FrontmatterOverrides, HookAgents, Manifest, Method};
-use crate::mapping::{EffectiveSkills, effective_skills};
+use crate::mapping::EffectiveSkills;
 use crate::model::{HarnessId, ItemKind};
 use crate::render::agent::{
     EffectiveAgent, RenderedAgent, Role, SourceAgent, file_name, generate, hooks_for_agent,
@@ -10,63 +10,8 @@ use crate::render::agent::{
 };
 use crate::render::permission::PermissionIntent;
 use crate::render::validate::validate_agent;
-use crate::source::list_items;
 
 use super::desired::{Artifact, Desired, DesiredState, ItemCtx, native_dir};
-
-/// The agent's skill list, merging anything upstream added since the last
-/// sync back into the manifest so the declaration keeps saying what the
-/// agent actually renders with.
-fn assigned_skills(
-    ctx: &ItemCtx,
-    role: Option<Role>,
-    updated_manifest: &mut Manifest,
-    manifest_changed: &mut bool,
-) -> EffectiveSkills {
-    let available = list_items(ctx.sealed, ctx.config, ItemKind::Skill);
-    let recorded = ctx.harnesses.iter().find_map(|h| {
-        ctx.lock
-            .entries
-            .get(&entry_key(ItemKind::Agent, ctx.name, *h))
-            .and_then(|entry| entry.upstream_skills.clone())
-    });
-    let skills = effective_skills(
-        ctx.name,
-        role,
-        ctx.manifest,
-        ctx.config,
-        &available,
-        recorded.as_deref(),
-    );
-    if skills.manifest_additions.is_empty() {
-        return skills;
-    }
-    let entry = updated_manifest
-        .agent_skills
-        .entry(merge_key(ctx.manifest, ctx.name))
-        .or_default();
-    for skill in &skills.manifest_additions {
-        if !entry.contains(skill) {
-            entry.push(skill.clone());
-        }
-    }
-    *manifest_changed = true;
-    skills
-}
-
-/// The `agent_skills` key the effective list was read from. Writing
-/// additions anywhere else creates an entry that shadows the one being read,
-/// and the shadowed skills silently vanish from the next rendering.
-fn merge_key(manifest: &Manifest, name: &str) -> String {
-    if manifest.agent_skills.contains_key(name) {
-        return name.to_owned();
-    }
-    let stripped = crate::mapping::skill_match_prefix(name);
-    match manifest.agent_skills.contains_key(stripped) {
-        true => stripped.to_owned(),
-        false => name.to_owned(),
-    }
-}
 
 /// The agent as this tool will know it, or `None` where that is the agent
 /// the catalog already wrote. Each tool answers to the name the rendered
@@ -182,7 +127,8 @@ pub(super) fn desired_agent(
             remediation: None,
         });
     }
-    let skills = assigned_skills(ctx, parsed.role, updated_manifest, manifest_changed);
+    let skills =
+        super::agent_skills::assigned_skills(ctx, parsed.role, updated_manifest, manifest_changed);
     for harness in ctx.harnesses.clone() {
         let Some(native) = native_dir(ctx.env, ctx.scope, harness, ItemKind::Agent) else {
             continue;

--- a/crates/core/src/engine/mod.rs
+++ b/crates/core/src/engine/mod.rs
@@ -72,7 +72,7 @@ pub fn installed_paths(
 }
 
 use desired::desired_state;
-pub use scope_writes::persists_manifest;
+pub use scope_writes::{persists_manifest, writes_manifest};
 use scope_writes::{
     plan_config_edits, plan_lock_write, plan_manifest_write, plan_settings_seed, source_revisions,
 };

--- a/crates/core/src/engine/mod.rs
+++ b/crates/core/src/engine/mod.rs
@@ -73,7 +73,7 @@ pub fn installed_paths(
 }
 
 use desired::desired_state;
-pub use scope_writes::{persists_manifest, writes_manifest};
+pub use scope_writes::persists_manifest;
 use scope_writes::{
     plan_config_edits, plan_lock_write, plan_manifest_write, plan_settings_seed, source_revisions,
 };

--- a/crates/core/src/engine/mod.rs
+++ b/crates/core/src/engine/mod.rs
@@ -8,6 +8,7 @@ use crate::manifest::{self, Manifest, ManifestFile};
 use crate::model::Scope;
 
 pub mod adopt;
+mod agent_skills;
 pub(crate) mod bundles;
 mod catalog;
 mod config_edits;
@@ -268,7 +269,13 @@ fn desired_pass<'a>(
     options: &PlanOptions,
 ) -> Result<(std::borrow::Cow<'a, Manifest>, desired::DesiredState)> {
     let (planning, held_pins) = desired::hold::planning_manifest(declared, lock, options);
-    let mut state = desired_state(env, scope, planning.as_ref(), lock)?;
+    let mut state = desired_state(
+        env,
+        scope,
+        planning.as_ref(),
+        lock,
+        options.hold_upstream_skills,
+    )?;
     if let (Some(pins), Some(update)) = (&held_pins, state.manifest_update.as_mut()) {
         pins.unpin(update);
     }

--- a/crates/core/src/engine/ops.rs
+++ b/crates/core/src/engine/ops.rs
@@ -110,8 +110,8 @@ pub fn uninstall(env: &Env, scope: &Scope, names: &[String]) -> Result<EngineRep
 
 /// The removal both verbs share. The plan is made against a manifest
 /// without the declarations either way; `disown` is whether that manifest
-/// becomes the file. Kept declared, the planner's own save — it carries
-/// the same undeclared copy — comes out of the plan.
+/// becomes the file. Kept declared, the planner is given no reason of its
+/// own to write one: the upstream skill merge waits for the refresh.
 fn removal(
     env: &Env,
     scope: &Scope,
@@ -183,19 +183,15 @@ fn removal(
             removal_filter: Some(removing),
             sweep_unneeded: sweep,
             uninstalled_bundles: bundles,
+            hold_upstream_skills: !disown,
             ..PlanOptions::default()
         },
     )?;
-    report.notes.extend(unreadable_origins(
-        env, scope, &manifest, &lock, names, disown,
-    ));
     if disown {
-        ensure_manifest_persisted(env, scope, &manifest, &mut report)?;
-    } else {
         report
-            .plan
-            .ops
-            .retain(|op| !crate::engine::writes_manifest(op));
+            .notes
+            .extend(unreadable_origins(env, scope, &manifest, &lock, names));
+        ensure_manifest_persisted(env, scope, &manifest, &mut report)?;
     }
     Ok(report)
 }
@@ -276,16 +272,14 @@ fn still_derived(
 /// The catalogs behind what is going away that cannot be read right now.
 /// What else still wants an item is written in its catalog, so an unreadable
 /// one means the preview cannot show the whole consequence of the removal.
-/// The removal itself stands either way: disowning, the record already says
-/// what has to stay removed; keeping the declaration, nothing is recorded,
-/// and the refresh that puts things back cannot read that catalog either.
+/// The removal itself stands either way — the record already says what has
+/// to stay removed.
 fn unreadable_origins(
     env: &Env,
     scope: &Scope,
     manifest: &Manifest,
     lock: &Lock,
     names: &[String],
-    disown: bool,
 ) -> Vec<String> {
     let mut sources: Vec<String> = lock
         .entries
@@ -304,12 +298,8 @@ fn unreadable_origins(
             )
         })
         .map(|source| {
-            let stands = match disown {
-                true => "the removal stands, and what has to stay removed is recorded",
-                false => "the removal stands, and refresh cannot install anything from that catalog until it reads again",
-            };
             format!(
-                "the catalog '{source}' cannot be read right now, so this preview cannot show everything that still wants what is going — {stands}"
+                "the catalog '{source}' cannot be read right now, so this preview cannot show everything that still wants what is going — the removal stands, and what has to stay removed is recorded"
             )
         })
         .collect()

--- a/crates/core/src/engine/ops.rs
+++ b/crates/core/src/engine/ops.rs
@@ -155,7 +155,10 @@ fn removal(
         if kinds.contains(&ItemKind::Plugin) {
             manifest.plugins.remove(name);
         }
-        if kinds.contains(&ItemKind::Agent) {
+        // A reviewer agent reads its base agent's skill list by prefix, so
+        // the entry outlives the agent while the declaration is kept:
+        // surviving agents render from the file that stays.
+        if disown && kinds.contains(&ItemKind::Agent) {
             manifest.agent_skills.remove(name);
         }
         if kinds.contains(&ItemKind::Skill) {

--- a/crates/core/src/engine/ops.rs
+++ b/crates/core/src/engine/ops.rs
@@ -110,8 +110,8 @@ pub fn uninstall(env: &Env, scope: &Scope, names: &[String]) -> Result<EngineRep
 
 /// The removal both verbs share. The plan is made against a manifest
 /// without the declarations either way; `disown` is whether that manifest
-/// becomes the file. Kept declared, nothing in the plan may write the
-/// manifest: the planner's own save carries the same undeclared copy.
+/// becomes the file. Kept declared, the planner's own save — it carries
+/// the same undeclared copy — comes out of the plan.
 fn removal(
     env: &Env,
     scope: &Scope,
@@ -186,18 +186,16 @@ fn removal(
             ..PlanOptions::default()
         },
     )?;
-    report
-        .notes
-        .extend(unreadable_origins(env, scope, &manifest, &lock, names));
+    report.notes.extend(unreadable_origins(
+        env, scope, &manifest, &lock, names, disown,
+    ));
     if disown {
         ensure_manifest_persisted(env, scope, &manifest, &mut report)?;
     } else {
-        let manifest_path = manifest::manifest_path(env, scope);
-        report.plan.ops.retain(|op| match &op.op {
-            Op::WriteManifest { .. } => false,
-            Op::WriteFile { path, .. } => *path != manifest_path,
-            _ => true,
-        });
+        report
+            .plan
+            .ops
+            .retain(|op| !crate::engine::writes_manifest(op));
     }
     Ok(report)
 }
@@ -278,14 +276,16 @@ fn still_derived(
 /// The catalogs behind what is going away that cannot be read right now.
 /// What else still wants an item is written in its catalog, so an unreadable
 /// one means the preview cannot show the whole consequence of the removal.
-/// The removal itself stands either way — the record already says what has
-/// to stay removed.
+/// The removal itself stands either way: disowning, the record already says
+/// what has to stay removed; keeping the declaration, nothing is recorded,
+/// and the refresh that puts things back cannot read that catalog either.
 fn unreadable_origins(
     env: &Env,
     scope: &Scope,
     manifest: &Manifest,
     lock: &Lock,
     names: &[String],
+    disown: bool,
 ) -> Vec<String> {
     let mut sources: Vec<String> = lock
         .entries
@@ -304,8 +304,12 @@ fn unreadable_origins(
             )
         })
         .map(|source| {
+            let stands = match disown {
+                true => "the removal stands, and what has to stay removed is recorded",
+                false => "the removal stands, and refresh cannot install anything from that catalog until it reads again",
+            };
             format!(
-                "the catalog '{source}' cannot be read right now, so this preview cannot show everything that still wants what is going — the removal stands, and what has to stay removed is recorded"
+                "the catalog '{source}' cannot be read right now, so this preview cannot show everything that still wants what is going — {stands}"
             )
         })
         .collect()

--- a/crates/core/src/engine/ops.rs
+++ b/crates/core/src/engine/ops.rs
@@ -94,6 +94,32 @@ pub fn remove(
     kind: Option<ItemKind>,
     sweep: bool,
 ) -> Result<EngineReport> {
+    removal(env, scope, names, kind, sweep, true)
+}
+
+/// Take these items' installations away and keep their declarations. The
+/// files come off disk and the record forgets them, exactly as `remove`
+/// would, but kendex.toml is not touched — the next refresh installs them
+/// again from their source. This is the remedy for an install that went
+/// wrong, and what the manifest says is what makes it a remedy rather than
+/// a removal. Never a sweep: what these items pull in is wanted again the
+/// moment they are.
+pub fn uninstall(env: &Env, scope: &Scope, names: &[String]) -> Result<EngineReport> {
+    removal(env, scope, names, None, false, false)
+}
+
+/// The removal both verbs share. The plan is made against a manifest
+/// without the declarations either way; `disown` is whether that manifest
+/// becomes the file. Kept declared, nothing in the plan may write the
+/// manifest: the planner's own save carries the same undeclared copy.
+fn removal(
+    env: &Env,
+    scope: &Scope,
+    names: &[String],
+    kind: Option<ItemKind>,
+    sweep: bool,
+    disown: bool,
+) -> Result<EngineReport> {
     let mut manifest = manifest_for_mutation(env, scope)?;
     let lock = crate::lock::load(&lock_path(env, scope))?;
     let bundles: Vec<String> = names
@@ -163,7 +189,16 @@ pub fn remove(
     report
         .notes
         .extend(unreadable_origins(env, scope, &manifest, &lock, names));
-    ensure_manifest_persisted(env, scope, &manifest, &mut report)?;
+    if disown {
+        ensure_manifest_persisted(env, scope, &manifest, &mut report)?;
+    } else {
+        let manifest_path = manifest::manifest_path(env, scope);
+        report.plan.ops.retain(|op| match &op.op {
+            Op::WriteManifest { .. } => false,
+            Op::WriteFile { path, .. } => *path != manifest_path,
+            _ => true,
+        });
+    }
     Ok(report)
 }
 

--- a/crates/core/src/engine/report_types.rs
+++ b/crates/core/src/engine/report_types.rs
@@ -172,6 +172,12 @@ pub struct EngineReport {
 
 #[derive(Debug, Clone, Default)]
 pub struct PlanOptions {
+    /// Render each agent with the skills its declaration holds and keep the
+    /// lock's upstream record as it is, leaving what upstream added since
+    /// for the next refresh to merge into kendex.toml. The removal that
+    /// keeps declarations sets this: its plan writes no manifest, so a merge
+    /// rendered and recorded here would never reach the file.
+    pub hold_upstream_skills: bool,
     /// Remove orphaned (locked-but-undeclared) artifacts. Refresh keeps
     /// them (v1 semantics); reconcile and `remove` clean them up.
     pub remove_orphans: bool,

--- a/crates/core/src/engine/scope_writes.rs
+++ b/crates/core/src/engine/scope_writes.rs
@@ -20,7 +20,8 @@ use super::{DriftRow, DriftState, config_edits};
 mod manifest_text;
 pub(super) use manifest_text::plan_schema_upgrade;
 
-/// Whether this op is the manifest's write.
+/// Whether this op is the manifest's full-rewrite save. The surgical
+/// schema edit is a plain `WriteFile` and is not one.
 pub fn writes_manifest(op: &PlannedOp) -> bool {
     matches!(op.op, Op::WriteManifest { .. })
 }

--- a/crates/core/src/engine/scope_writes.rs
+++ b/crates/core/src/engine/scope_writes.rs
@@ -20,12 +20,16 @@ use super::{DriftRow, DriftState, config_edits};
 mod manifest_text;
 pub(super) use manifest_text::plan_schema_upgrade;
 
+/// Whether this op is the manifest's write.
+pub fn writes_manifest(op: &PlannedOp) -> bool {
+    matches!(op.op, Op::WriteManifest { .. })
+}
+
 /// Whether a plan already persists the manifest. A caller about to insert
 /// its own save must know: a second write to the same file binds to bytes
 /// the first one replaces and could never run.
 pub fn persists_manifest(ops: &[PlannedOp]) -> bool {
-    ops.iter()
-        .any(|op| matches!(op.op, Op::WriteManifest { .. }))
+    ops.iter().any(writes_manifest)
 }
 
 /// The precondition the plan's one manifest write binds to: the base of

--- a/crates/core/src/engine/scope_writes.rs
+++ b/crates/core/src/engine/scope_writes.rs
@@ -20,17 +20,12 @@ use super::{DriftRow, DriftState, config_edits};
 mod manifest_text;
 pub(super) use manifest_text::plan_schema_upgrade;
 
-/// Whether this op is the manifest's full-rewrite save. The surgical
-/// schema edit is a plain `WriteFile` and is not one.
-pub fn writes_manifest(op: &PlannedOp) -> bool {
-    matches!(op.op, Op::WriteManifest { .. })
-}
-
 /// Whether a plan already persists the manifest. A caller about to insert
 /// its own save must know: a second write to the same file binds to bytes
 /// the first one replaces and could never run.
 pub fn persists_manifest(ops: &[PlannedOp]) -> bool {
-    ops.iter().any(writes_manifest)
+    ops.iter()
+        .any(|op| matches!(op.op, Op::WriteManifest { .. }))
 }
 
 /// The precondition the plan's one manifest write binds to: the base of

--- a/crates/core/tests/review_fixes/agent_skills.rs
+++ b/crates/core/tests/review_fixes/agent_skills.rs
@@ -75,10 +75,11 @@ fn a_declaration_under_the_base_agents_key_holds_on_the_first_apply() {
     );
 }
 
-/// Keeping the declaration means the plan writes the manifest nowhere —
-/// not even the planner's own save, which carries the undeclared copy the
-/// removal was planned against. An agent whose upstream skill list grew is
-/// what makes the planner want that save.
+/// Keeping the declaration means the plan writes the manifest nowhere, so
+/// the upstream skill merge that would want a save waits for the refresh:
+/// the agent renders and records as it stands, and the refresh merges what
+/// upstream added. An agent whose upstream skill list grew is what makes
+/// the planner want that save.
 #[test]
 #[allow(clippy::unwrap_used)]
 fn keeping_the_declaration_drops_the_planners_own_manifest_save() {
@@ -93,6 +94,19 @@ fn keeping_the_declaration_drops_the_planners_own_manifest_save() {
     add_skill(&w.source, "rust-perf");
     let path = super::manifest::manifest_path(&w.env, &scope);
     let before = fs::read_to_string(&path).unwrap();
+    let rendered = w.home.join("dev/app/.claude/agents/rust.md");
+    let rendered_before = fs::read_to_string(&rendered).unwrap();
+    let recorded = |w: &super::World| {
+        super::load_lock(&super::lock_path(&w.env, &scope))
+            .unwrap()
+            .entries
+            .values()
+            .find(|entry| entry.name == "rust")
+            .unwrap()
+            .upstream_skills
+            .clone()
+    };
+    let recorded_before = recorded(&w);
     assert!(
         super::persists_manifest(&super::audit(&w.env, &scope).unwrap().plan.ops),
         "the fixture must make the planner save the manifest on its own"
@@ -108,4 +122,16 @@ fn keeping_the_declaration_drops_the_planners_own_manifest_save() {
     assert_eq!(fs::read_to_string(&path).unwrap(), before);
     assert!(before.contains("[skills.gh]"));
     assert!(!w.home.join("dev/app/.claude/skills/gh").exists());
+    assert_eq!(fs::read_to_string(&rendered).unwrap(), rendered_before);
+    assert_eq!(recorded(&w), recorded_before);
+
+    // The refresh after it still sees the addition and merges it.
+    let next = super::audit(&w.env, &scope).unwrap();
+    let merged = next.plan.ops.iter().find_map(|op| match &op.op {
+        super::apply::Op::WriteManifest { manifest, .. } => {
+            Some(manifest.agent_skills["rust"].clone())
+        }
+        _ => None,
+    });
+    assert_eq!(merged.unwrap(), ["gh", "rust-perf"]);
 }

--- a/crates/core/tests/review_fixes/agent_skills.rs
+++ b/crates/core/tests/review_fixes/agent_skills.rs
@@ -135,3 +135,40 @@ fn keeping_the_declaration_drops_the_planners_own_manifest_save() {
     });
     assert_eq!(merged.unwrap(), ["gh", "rust-perf"]);
 }
+
+/// A reviewer agent reads its base agent's `[agent-skills]` entry by
+/// prefix. Taking the base agent away with the declaration kept must leave
+/// that entry in the transient manifest, or the reviewer is re-rendered
+/// from its upstream list and its record rewritten for nothing.
+#[test]
+#[allow(clippy::unwrap_used)]
+fn keeping_the_declaration_leaves_a_reviewers_skill_list_alone() {
+    let w = world();
+    let scope = project(&w);
+    put(
+        &w.source.join("agents/reviewer-rust.md"),
+        "---\nname: reviewer-rust\ndescription: Rust reviewer\nmodel: opus\nrole: reviewer\n---\n\nBody.\n",
+    );
+    declare(
+        &w,
+        &scope,
+        "[skills.gh]\nsource = \"cat\"\n\n[agents.rust]\nsource = \"cat\"\n\n[agents.reviewer-rust]\nsource = \"cat\"\n\n[agent-skills]\nrust = [\"gh\"]\n",
+    );
+    apply_now(&w, &scope);
+    let reviewer = w.home.join("dev/app/.claude/agents/reviewer-rust.md");
+    let rendered_before = fs::read_to_string(&reviewer).unwrap();
+    let entry = |w: &super::World| {
+        super::load_lock(&super::lock_path(&w.env, &scope))
+            .unwrap()
+            .entries
+            .remove("agent:reviewer-rust:claude")
+            .unwrap()
+    };
+    let entry_before = entry(&w);
+
+    let report = super::ops::uninstall(&w.env, &scope, &["rust".to_owned()]).unwrap();
+    super::apply::execute(&w.env, &report.plan, None).unwrap();
+    assert!(!w.home.join("dev/app/.claude/agents/rust.md").exists());
+    assert_eq!(fs::read_to_string(&reviewer).unwrap(), rendered_before);
+    assert_eq!(entry(&w), entry_before);
+}

--- a/crates/core/tests/review_fixes/agent_skills.rs
+++ b/crates/core/tests/review_fixes/agent_skills.rs
@@ -74,3 +74,38 @@ fn a_declaration_under_the_base_agents_key_holds_on_the_first_apply() {
         "the prefix match the declaration replaced does not come back: {rendered}"
     );
 }
+
+/// Keeping the declaration means the plan writes the manifest nowhere —
+/// not even the planner's own save, which carries the undeclared copy the
+/// removal was planned against. An agent whose upstream skill list grew is
+/// what makes the planner want that save.
+#[test]
+#[allow(clippy::unwrap_used)]
+fn keeping_the_declaration_drops_the_planners_own_manifest_save() {
+    let w = world();
+    let scope = project(&w);
+    declare(
+        &w,
+        &scope,
+        "[skills.gh]\nsource = \"cat\"\n\n[agents.rust]\nsource = \"cat\"\n\n[agent-skills]\nrust = [\"gh\"]\n",
+    );
+    apply_now(&w, &scope);
+    add_skill(&w.source, "rust-perf");
+    let path = super::manifest::manifest_path(&w.env, &scope);
+    let before = fs::read_to_string(&path).unwrap();
+    assert!(
+        super::persists_manifest(&super::audit(&w.env, &scope).unwrap().plan.ops),
+        "the fixture must make the planner save the manifest on its own"
+    );
+
+    let report = super::ops::uninstall(&w.env, &scope, &["gh".to_owned()]).unwrap();
+    assert!(
+        !super::persists_manifest(&report.plan.ops),
+        "{:?}",
+        report.plan.ops
+    );
+    super::apply::execute(&w.env, &report.plan, None).unwrap();
+    assert_eq!(fs::read_to_string(&path).unwrap(), before);
+    assert!(before.contains("[skills.gh]"));
+    assert!(!w.home.join("dev/app/.claude/skills/gh").exists());
+}

--- a/crates/core/tests/review_fixes/main.rs
+++ b/crates/core/tests/review_fixes/main.rs
@@ -6,7 +6,9 @@ use std::fs;
 use std::path::{Path, PathBuf};
 
 use kendex_core::apply;
-use kendex_core::engine::{DriftState, PlanOptions, adopt::adopt, audit, ops, plan_scope};
+use kendex_core::engine::{
+    DriftState, PlanOptions, adopt::adopt, audit, ops, persists_manifest, plan_scope,
+};
 use kendex_core::env::{Env, FakeOs};
 use kendex_core::error::CoreError;
 use kendex_core::lock::{load as load_lock, lock_path};

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -686,12 +686,12 @@ lives in one capability table read by core and UI.
   a bundle: members whose only edges came from it go; members also
   requested, required by a survivor, or carried by another installed bundle
   stay — the preview names both halves and the reason. A member the user
-  removes is a suppression, the same durable removal a dependency gets:
-  refresh honors it; the audit reports the bundle installed with members
-  held back. Writing it asks both the lock and the catalogs, recording
-  anything either names. A removal naming an installation goes even with
-  its catalog unreadable; one nobody named is kept. Declaring the item
-  outranks a suppression: it installs and the contradiction is reported.
+  removes is a suppression, as a dependency's is: refresh honors it, while
+  `--keep-declaration` writes none and refresh puts it back; the audit
+  reports the bundle with members held back. Writing it asks the lock and
+  the catalogs, recording anything either names. A removal naming an
+  installation goes even with its catalog unreadable; one nobody named is
+  kept. Declaring the item outranks a suppression: it installs, reported.
   Two sets carrying one member and asking for it differently: the tools are
   both, a set switched on installs it switched on, anything else is a
   finding naming both sets. Authoring lives with the catalog —

--- a/tools/size-ratchet-baseline.tsv
+++ b/tools/size-ratchet-baseline.tsv
@@ -1,6 +1,6 @@
 .github/workflows/review-gate-writer.yml	662
 .github/workflows/skill-tests.yml	402
-crates/core/src/engine/desired_agent.rs	458
+crates/core/src/engine/desired_agent.rs	404
 crates/core/src/engine/detach.rs	603
 crates/core/src/engine/pi_hooks_move/migrated.rs	540
 crates/core/src/engine/pi_hooks_move/mod.rs	502


### PR DESCRIPTION
## Summary
- `kendex remove <name> --keep-declaration` takes the files and lock entries away and leaves kendex.toml byte-identical, so the next `kendex refresh` installs what it declares again. This is the remove-then-refresh conflict remedy without the `git checkout kendex.toml` workaround.
- Core: one shared `removal` behind `ops::remove` and `ops::uninstall`; `disown` decides whether the undeclared manifest becomes the file. Keep mode also holds the upstream skill merge (`PlanOptions::hold_upstream_skills`) and leaves `agent_skills` entries alone, so nothing unrelated re-renders and the refresh performs the merge.
- CLI: one `remove` loop over a typed `Removal` mode; `--keep-declaration` conflicts with `--sweep`/`--no-sweep`.

## Completed Issues
- Closes KEN-640 - kendex remove deletes the [skills.X] declaration even in the remove-then-refresh conflict flow

## Test Plan
- `crates/cli/tests/deps_cli.rs`: declared skill and a derived dependency both come off and come back on refresh with kendex.toml byte-identical; lock forgets them in between; `--sweep`/`--no-sweep` alongside are refused by clap.
- `crates/core/tests/review_fixes/agent_skills.rs`: a planner that wants its own manifest save (agent upstream skills grew) plans no manifest write in keep mode, the agent render and its lock `upstream_skills` are untouched, and the following audit merges the addition; removing a base agent in keep mode leaves `reviewer-<base>` bytes and lock entry unchanged.
- `tools/guard` green on every commit.
