### PR TITLE
fix(KEN-701): fork refuses content that is already yours

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,6 +64,10 @@ an outside contributor.
   (it read as a marketplace with no repository), and the Mine import
   inventory reads such a skill's bytes from the tree it sits in.
 
+- `kendex fork` refuses an item that is already yours — `local`, or a skill
+  adopted `in-place`, whose tree of record a fork would quietly demote to a
+  render of a hidden copy.
+
 - The `block-bare-cd` hook refuses a bare `cd` with no path. It changes to
   `$HOME` for every later tool call, the move the hook exists to stop, and
   only `cd <path>` was caught before.

--- a/crates/core/src/engine/fork.rs
+++ b/crates/core/src/engine/fork.rs
@@ -12,7 +12,7 @@ use super::ops::manifest_for_mutation;
 use crate::apply::{Op, Plan, PlannedOp, Pre};
 use crate::env::Env;
 use crate::error::{CoreError, Result};
-use crate::manifest::{self, ForkProvenance, LOCAL_SOURCE_NAME};
+use crate::manifest::{self, ForkProvenance, INPLACE_SOURCE_NAME, LOCAL_SOURCE_NAME};
 use crate::model::{HarnessId, ItemKind, Scope};
 use crate::source::local_source_root;
 
@@ -50,6 +50,12 @@ pub fn fork(
             name: name.to_owned(),
         });
     };
+    if decl.source == LOCAL_SOURCE_NAME || decl.source == INPLACE_SOURCE_NAME {
+        return Err(CoreError::AlreadyOwn {
+            name: name.to_owned(),
+            origin: decl.source.clone(),
+        });
+    }
     let edited = edited_rendering(env, scope, kind, name, harness)?;
     let captured = capture(kind, &edited)?;
     let mut ops = capture_ops(env, scope, kind, name, &edited, captured)?;

--- a/crates/core/src/error.rs
+++ b/crates/core/src/error.rs
@@ -188,6 +188,13 @@ pub enum CoreError {
     #[error("'{name}' not found in source '{source_name}'")]
     ItemNotInSource { name: String, source_name: String },
 
+    /// A fork of content already the user's own: forking an in-place tree
+    /// would demote the content of record to a render of a hidden copy.
+    #[error(
+        "'{name}' is already yours — it comes from the {origin} source, so there is nothing to fork"
+    )]
+    AlreadyOwn { name: String, origin: String },
+
     /// A tree carrying both `SKILL.md` and `SKILL.md.disabled` has two
     /// claims on one file; a fork keeps neither until it is told which.
     #[error(

--- a/crates/core/tests/edits_and_forks/forks.rs
+++ b/crates/core/tests/edits_and_forks/forks.rs
@@ -265,3 +265,45 @@ fn forking_a_skill_whose_native_link_was_repointed_reads_the_managed_tree() {
     );
     assert!(foreign.join("secret.md").is_file());
 }
+
+/// Content that is already the user's own has nothing to fork: a local
+/// fork forked again, and a skill declared in place — where a fork would
+/// turn the tree of record into a render of a hidden copy.
+#[test]
+#[allow(clippy::unwrap_used)]
+fn forking_the_users_own_content_is_refused() {
+    let w = world();
+    write_skill(&w.upstream, "gh", "Upstream.");
+    commit(&w.upstream, "one");
+    declare(&w, "[skills.gh]\nsource = \"cat\"\n");
+    sync_and_apply(&w);
+    fs::write(
+        skill_file(&w),
+        "---\nname: gh\ndescription: mine\n---\nMine.\n",
+    )
+    .unwrap();
+    let plan = fork::fork(&w.env, &w.scope, ItemKind::Skill, "gh", HarnessId::Claude).unwrap();
+    apply::execute(&w.env, &plan, None).unwrap();
+    let err = fork::fork(&w.env, &w.scope, ItemKind::Skill, "gh", HarnessId::Claude).unwrap_err();
+    assert!(
+        matches!(&err, CoreError::AlreadyOwn { name, origin } if name == "gh" && origin == "local"),
+        "{err}"
+    );
+
+    let here = w.home.join("app/.agents/skills/here");
+    fs::create_dir_all(&here).unwrap();
+    fs::write(
+        here.join("SKILL.md"),
+        "---\nname: here\ndescription: mine\n---\nHere.\n",
+    )
+    .unwrap();
+    declare(&w, "[skills.here]\nsource = \"in-place\"\n");
+    let before = manifest_text(&w);
+    let err = fork::fork(&w.env, &w.scope, ItemKind::Skill, "here", HarnessId::Claude).unwrap_err();
+    assert!(
+        matches!(&err, CoreError::AlreadyOwn { name, origin } if name == "here" && origin == "in-place"),
+        "{err}"
+    );
+    assert_eq!(manifest_text(&w), before);
+    assert!(!w.home.join("app/.kendex-local/skills/here").exists());
+}

--- a/tools/size-ratchet-baseline.tsv
+++ b/tools/size-ratchet-baseline.tsv
@@ -5,7 +5,7 @@ crates/core/src/engine/detach.rs	603
 crates/core/src/engine/pi_hooks_move/migrated.rs	540
 crates/core/src/engine/pi_hooks_move/mod.rs	502
 crates/core/src/engine/pi_hooks_move/preflight.rs	765
-crates/core/src/error.rs	416
+crates/core/src/error.rs	423
 crates/core/src/remote/store.rs	405
 docs/ARCHITECTURE.md	801
 hooks/block-repo-copy.sh	511


### PR DESCRIPTION
Closes KEN-701

`kendex fork` on a skill declared `source = "in-place"` captured the tree of record into `.kendex-local/skills/<name>`, rebound the declaration to `local` with fork provenance, and re-rendered the tree as a copy — the drift in-place exists to rule out. A fork of a `local` item likewise copied it over itself. Both now refuse before anything is written: `AlreadyOwn`, naming the reserved source that already holds the content. Pinned in `edits_and_forks/forks.rs` for both sources, including that the manifest and local source are untouched by the refused in-place fork.

Found on the hyprtrade in-place migration (hyprtrade#612), in the fork/edit proof.

https://claude.ai/code/session_01EadfQCVMnyCtyvK2t3kc5n