### PR TITLE
fix(KEN-710): harness-only carves in-place content out of the render set

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -70,7 +70,7 @@ an outside contributor.
   A copy that was already gone, or a link whose target was, failed the move to
   the trash and rolled the whole removal back, on every retry.
 
-- harness-ci's `harness-only` reads the checkout's `kendex.toml` and answers
+- harness-ci's `harness-only` reads the checkout's manifests and answers
   `false` for a diff touching an in-place skill or an `.agents/hooks` script:
   project source under a render path no longer stands CI lanes down.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -70,7 +70,7 @@ an outside contributor.
   A copy that was already gone, or a link whose target was, failed the move to
   the trash and rolled the whole removal back, on every retry.
 
-- harness-ci's `harness-only` reads the checkout's manifests and answers
+- harness-ci's `harness-only` reads the manifests at the selected head and answers
   `false` for a diff touching an in-place skill or an `.agents/hooks` script:
   project source under a render path no longer stands CI lanes down.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -70,6 +70,10 @@ an outside contributor.
   A copy that was already gone, or a link whose target was, failed the move to
   the trash and rolled the whole removal back, on every retry.
 
+- harness-ci's `harness-only` reads the checkout's `kendex.toml` and answers
+  `false` for a diff touching an in-place skill or an `.agents/hooks` script:
+  project source under a render path no longer stands CI lanes down.
+
 - The `task-completed-check` hook counts untracked files as changes, and blocks
   on any nonzero clippy exit or a git that cannot say what changed. It passed
   all three before: a new-file-only task, a killed clippy, an unreadable repo.

--- a/skills/harness-ci/README.md
+++ b/skills/harness-ci/README.md
@@ -3,7 +3,10 @@
 A repository that commits its kendex render gets diffs that touch nothing it
 builds, lints, typechecks or tests. This package ships the one function that
 recognises them — changed paths in, `harness_only=true|false` out — plus the
-tests that prove the semantics, run in kendex CI on every change.
+tests that prove the semantics, run in kendex CI on every change. Content
+the repository authors inside the render trees — skills its `kendex.toml`
+declares `source = "in-place"`, scripts under `.agents/hooks` — is project
+source, and any change to it answers `false`.
 
 Opt-in: running CI over harness directories is a policy choice, and a repo
 that wants it simply does not install this.
@@ -90,6 +93,7 @@ There is no flag that turns any of these into a `true`.
 | Suite | Covers |
 | --- | --- |
 | `path-set` | Every render tree, mixed diffs, deletions, the near-miss paths |
+| `in-place` | Trees the repo's `kendex.toml` declares in place, `.agents/hooks`, the no-manifest control |
 | `rename-into-render` | The `git mv` into a render tree, and the control proving the flag is load-bearing |
 | `event-ranges` | The force-push case, the moving base branch, merge groups |
 | `fail-closed` | Unclassified events, unresolvable endpoints, an empty diff, a merge-base diff git refuses, a path git had to quote |

--- a/skills/harness-ci/README.md
+++ b/skills/harness-ci/README.md
@@ -4,8 +4,9 @@ A repository that commits its kendex render gets diffs that touch nothing it
 builds, lints, typechecks or tests. This package ships the one function that
 recognises them — changed paths in, `harness_only=true|false` out — plus the
 tests that prove the semantics, run in kendex CI on every change. Content
-the repository authors inside the render trees — skills its `kendex.toml`
-declares `source = "in-place"`, scripts under `.agents/hooks` — is project
+the repository authors inside the render trees — skills its manifests
+(`kendex.toml`, or `kendex-local.toml` in a source catalog) declare
+`source = "in-place"` for, scripts under `.agents/hooks` — is project
 source, and any change to it answers `false`.
 
 Opt-in: running CI over harness directories is a policy choice, and a repo
@@ -93,7 +94,7 @@ There is no flag that turns any of these into a `true`.
 | Suite | Covers |
 | --- | --- |
 | `path-set` | Every render tree, mixed diffs, deletions, the near-miss paths |
-| `in-place` | Trees the repo's `kendex.toml` declares in place, `.agents/hooks`, the no-manifest control |
+| `in-place` | Trees either manifest declares in place, `.agents/hooks`, the no-manifest control |
 | `rename-into-render` | The `git mv` into a render tree, and the control proving the flag is load-bearing |
 | `event-ranges` | The force-push case, the moving base branch, merge groups |
 | `fail-closed` | Unclassified events, unresolvable endpoints, an empty diff, a merge-base diff git refuses, a path git had to quote |

--- a/skills/harness-ci/SKILL.md
+++ b/skills/harness-ci/SKILL.md
@@ -23,7 +23,9 @@ output?** The classifier reads a diff's changed-file set and prints
 `.codex/`, `.opencode/`, `.cursor/`, `.pi/`, or is the root
 `opencode.json` — `opencode.jsonc` where a project carries that spelling.
 Anything else prints `false`, and so does every diff the classifier cannot
-read.
+read. A path the checkout's own `kendex.toml` declares in place —
+`.agents/skills/<name>` under `[skills.<name>] source = "in-place"` — and
+any `.agents/hooks/` script are project source, never render output.
 
 ```bash
 .agents/skills/harness-ci/scripts/harness-only \

--- a/skills/harness-ci/SKILL.md
+++ b/skills/harness-ci/SKILL.md
@@ -23,7 +23,9 @@ output?** The classifier reads a diff's changed-file set and prints
 `.codex/`, `.opencode/`, `.cursor/`, `.pi/`, or is the root
 `opencode.json` — `opencode.jsonc` where a project carries that spelling.
 Anything else prints `false`, and so does every diff the classifier cannot
-read. A path the checkout's own `kendex.toml` declares in place —
+read. A path the checkout's own manifests (`kendex.toml`, and
+`kendex-local.toml` where a source catalog keeps its installs) declare in
+place —
 `.agents/skills/<name>` under `[skills.<name>] source = "in-place"` — and
 any `.agents/hooks/` script are project source, never render output.
 

--- a/skills/harness-ci/SKILL.md
+++ b/skills/harness-ci/SKILL.md
@@ -23,7 +23,7 @@ output?** The classifier reads a diff's changed-file set and prints
 `.codex/`, `.opencode/`, `.cursor/`, `.pi/`, or is the root
 `opencode.json` — `opencode.jsonc` where a project carries that spelling.
 Anything else prints `false`, and so does every diff the classifier cannot
-read. A path the checkout's own manifests (`kendex.toml`, and
+read. A path the selected head tree's manifests (`kendex.toml`, and
 `kendex-local.toml` where a source catalog keeps its installs) declare in
 place —
 `.agents/skills/<name>` under `[skills.<name>] source = "in-place"` — and

--- a/skills/harness-ci/scripts/harness-only
+++ b/skills/harness-ci/scripts/harness-only
@@ -208,16 +208,22 @@ manifest_carves() { # FILE -> carve lines for one manifest, "*" on a failed pars
       next
     }
     (in_skills || line ~ /^skills[ \t]*\./) && line ~ src {
-      key = line
-      sub(/^skills[ \t]*\.[ \t]*/, "", key)
+      body = line
+      sub(/^skills[ \t]*\.[ \t]*/, "", body)
+      key = body
       if (key ~ /^"/) { sub(/^"/, "", key); sub(/".*$/, "", key) }
       else if (key ~ ("^" q)) { sub("^" q, "", key); key = substr(key, 1, index(key, q) - 1) }
       else { sub(/[ \t=.].*$/, "", key) }
       if (key != "") {
         accounted += 1
-        # A key of exactly "source" is a value line inside a multiline
-        # inline table, not a skill name — unaccountable, so it carves.
-        if (key == "source" || key ~ /\\/) { print "*" } else { print key }
+        # Only two shapes tie the key to the value on one line: a dotted
+        # declaration and a closed one-level inline table. Anything else —
+        # a continuation line, a nested table, a key of exactly "source",
+        # an escape-bearing key — is unaccountable, so it carves.
+        trusted = 0
+        if (body ~ /^[^=]*\./) { trusted = 1 }
+        else if (body ~ /^[^{}]*=[ \t]*\{[^{}]*\}[ \t]*,?[ \t]*(#.*)?$/) { trusted = 1 }
+        if (!trusted || key == "source" || key ~ /\\/) { print "*" } else { print key }
       }
     }
     END { if (coarse > accounted) print "*" }

--- a/skills/harness-ci/scripts/harness-only
+++ b/skills/harness-ci/scripts/harness-only
@@ -155,6 +155,36 @@ fi
 
 printf '%s\n' "$changed" | sed -e 's/^/harness-only: changed: /' >&2
 
+# A repo that adopts skills in place keeps project source at
+# .agents/skills/<name> — kendex.toml declares them `source = "in-place"` —
+# and its adopted hook scripts under .agents/hooks: bytes kendex reads,
+# never writes. The checkout's manifest speaks for the head. A manifest
+# that cannot be read yields no carve-outs, so unknown trees stay render
+# output — the answer before in-place existed.
+in_place_skills=""
+if [ -f "$repo/kendex.toml" ]; then
+  in_place_skills="$(awk '
+    /^\[skills\./ { name = $0; sub(/^\[skills\./, "", name); sub(/\].*$/, "", name); next }
+    /^\[/ { name = "" }
+    name != "" && $0 ~ /^source[ \t]*=[ \t]*"in-place"[ \t]*$/ { print name }
+  ' "$repo/kendex.toml" 2>/dev/null)" || in_place_skills=""
+fi
+in_place_path() { # PATH -> 0 when the path is the repo's own in-place content
+  local rest skill
+  case "$1" in
+    .agents/hooks/*) return 0 ;;
+    .agents/skills/*/*) ;;
+    *) return 1 ;;
+  esac
+  [ -n "$in_place_skills" ] || return 1
+  rest="${1#.agents/skills/}"
+  skill="${rest%%/*}"
+  case "$in_place_skills" in
+    "$skill" | "$skill"$'\n'* | *$'\n'"$skill" | *$'\n'"$skill"$'\n'*) return 0 ;;
+    *) return 1 ;;
+  esac
+}
+
 # --no-renames, and it is load-bearing. With rename detection on,
 # `git diff --name-only` emits only the POST-image path, so moving a product
 # file INTO a render tree lists one harness path and nothing else — the diff
@@ -168,7 +198,15 @@ harness_only=true
 while IFS= read -r path; do
   [ -n "$path" ] || continue
   case "$path" in
-    .agents/* | .claude/* | .codex/* | .opencode/* | .cursor/* | .pi/*) continue ;;
+    .agents/*)
+      # In-place content under the render tree is project source.
+      if in_place_path "$path"; then
+        harness_only=false
+        break
+      fi
+      continue
+      ;;
+    .claude/* | .codex/* | .opencode/* | .cursor/* | .pi/*) continue ;;
     # Both spellings of the one OpenCode config: kendex writes the .jsonc file
     # when a project carries that one instead, and it is the same artifact.
     opencode.json | opencode.jsonc) continue ;;

--- a/skills/harness-ci/scripts/harness-only
+++ b/skills/harness-ci/scripts/harness-only
@@ -166,11 +166,14 @@ manifest_carves() { # IN-TREE PATH -> carve lines for one manifest, "*" on a fai
   # The diff is between commits, so the manifests are read from the
   # selected head tree, never from whatever the checkout happens to hold.
   # One that exists there but cannot be read proves nothing and carves.
-  local manifest_content
-  git_repo cat-file -e "$head:$1" 2>/dev/null || return 0
-  # git show hands back a symlink's target text, not the manifest it
-  # points at — unclassifiable, so it carves.
-  case "$(git_repo ls-tree "$head" -- "$1" 2>/dev/null)" in 120000*) echo "*"; return 0 ;; esac
+  local manifest_content manifest_entry
+  # ls-tree answers existence from the tree object alone, so absence and a
+  # failed lookup stay distinct: no entry means no manifest, while a listing
+  # that fails, a symlink entry (git show hands back its target text), or a
+  # blob that will not read are all unclassifiable and carve.
+  manifest_entry="$(git_repo ls-tree "$head" -- "$1" 2>/dev/null)" || { echo "*"; return 0; }
+  [ -n "$manifest_entry" ] || return 0
+  case "$manifest_entry" in 120000*) echo "*"; return 0 ;; esac
   manifest_content="$(git_repo show "$head:$1" 2>/dev/null)" || { echo "*"; return 0; }
   # The line parser reads the spellings kendex writes and the common hand
   # edits; completeness is not load-bearing. Every line that could take

--- a/skills/harness-ci/scripts/harness-only
+++ b/skills/harness-ci/scripts/harness-only
@@ -181,7 +181,8 @@ manifest_carves() { # FILE -> carve lines for one manifest, "*" on a failed pars
       v = "(" d "in-place" d "|" d d d "in-place" d d d "|" q "in-place" q "|" q q q "in-place" q q q ")"
       src = "source[ \t]*=[ \t]*" v
       esc = "\\\\[uU]"
-      mlsrc = "source[ \t]*=[ \t]*(" d d d "|" q q q ")"
+      k = "(" d "|" q ")?"
+      mlsrc = k "source" k "[ \t]*=[ \t]*(" d d d "|" q q q ")"
     }
     {
       line = $0

--- a/skills/harness-ci/scripts/harness-only
+++ b/skills/harness-ci/scripts/harness-only
@@ -168,6 +168,9 @@ manifest_carves() { # IN-TREE PATH -> carve lines for one manifest, "*" on a fai
   # One that exists there but cannot be read proves nothing and carves.
   local manifest_content
   git_repo cat-file -e "$head:$1" 2>/dev/null || return 0
+  # git show hands back a symlink's target text, not the manifest it
+  # points at — unclassifiable, so it carves.
+  case "$(git_repo ls-tree "$head" -- "$1" 2>/dev/null)" in 120000*) echo "*"; return 0 ;; esac
   manifest_content="$(git_repo show "$head:$1" 2>/dev/null)" || { echo "*"; return 0; }
   # The line parser reads the spellings kendex writes and the common hand
   # edits; completeness is not load-bearing. Every line that could take

--- a/skills/harness-ci/scripts/harness-only
+++ b/skills/harness-ci/scripts/harness-only
@@ -174,6 +174,7 @@ if [ -f "$repo/kendex.toml" ]; then
     BEGIN { src = "source[ \t]*=[ \t]*(\"in-place\"|" q "in-place" q ")" }
     {
       line = $0
+      sub(/\r$/, "", line)
       sub(/^[ \t]+/, "", line)
     }
     line ~ /^\[[ \t]*skills[ \t]*\][ \t]*(#.*)?$/ { in_skills = 1; name = ""; next }

--- a/skills/harness-ci/scripts/harness-only
+++ b/skills/harness-ci/scripts/harness-only
@@ -164,24 +164,27 @@ printf '%s\n' "$changed" | sed -e 's/^/harness-only: changed: /' >&2
 in_place_skills=""
 if [ -f "$repo/kendex.toml" ]; then
   # The line parser reads the spellings kendex writes and the common hand
-  # edits; completeness is not load-bearing. Every line that carries a
-  # quoted in-place token is counted, and any the name extraction cannot
-  # account for degrades to the coarse carve: every .agents/skills path
-  # reads as project source. Over-matching is the safe direction — lanes
-  # run. No legal TOML spelling can answer harness_only=true wrongly.
+  # edits; completeness is not load-bearing. Every line that could take
+  # part in spelling the value — a bare in-place mention, a \u/\U escape
+  # anywhere, a multiline source string — is counted, and any the name
+  # extraction cannot account for degrades to the coarse carve: every
+  # .agents/skills path reads as project source. Over-matching is the safe
+  # direction — lanes run. No legal TOML spelling of the value can answer
+  # harness_only=true wrongly; the exotic ones cost lanes that run.
   sq="'"
   in_place_skills="$(awk -v q="$sq" '
     BEGIN {
       d = "\""
       v = "(" d "in-place" d "|" d d d "in-place" d d d "|" q "in-place" q "|" q q q "in-place" q q q ")"
       src = "source[ \t]*=[ \t]*" v
-      tok = "(" d "in-place" d "|" q "in-place" q ")"
+      esc = "\\\\[uU]"
+      mlsrc = "source[ \t]*=[ \t]*(" d d d "|" q q q ")"
     }
     {
       line = $0
       sub(/\r$/, "", line)
       sub(/^[ \t]+/, "", line)
-      if (line ~ tok) coarse += 1
+      if (line ~ /in-place/ || line ~ esc || line ~ mlsrc) coarse += 1
     }
     line ~ /^\[[ \t]*skills[ \t]*\][ \t]*(#.*)?$/ { in_skills = 1; name = ""; next }
     line ~ /^\[[ \t]*skills[ \t]*\./ {

--- a/skills/harness-ci/scripts/harness-only
+++ b/skills/harness-ci/scripts/harness-only
@@ -162,7 +162,8 @@ printf '%s\n' "$changed" | sed -e 's/^/harness-only: changed: /' >&2
 # that cannot be read yields no carve-outs, so unknown trees stay render
 # output — the answer before in-place existed.
 in_place_skills=""
-if [ -f "$repo/kendex.toml" ]; then
+manifest_carves() { # FILE -> carve lines for one manifest, "*" on a failed parse
+  [ -f "$1" ] || return 0
   # A manifest that exists but cannot be read proves nothing about the
   # tree, so a failed parse carves everything too.
   # The line parser reads the spellings kendex writes and the common hand
@@ -174,7 +175,7 @@ if [ -f "$repo/kendex.toml" ]; then
   # direction — lanes run. No legal TOML spelling of the value can answer
   # harness_only=true wrongly; the exotic ones cost lanes that run.
   sq="'"
-  in_place_skills="$(awk -v q="$sq" '
+  awk -v q="$sq" '
     BEGIN {
       d = "\""
       v = "(" d "in-place" d "|" d d d "in-place" d d d "|" q "in-place" q "|" q q q "in-place" q q q ")"
@@ -210,8 +211,15 @@ if [ -f "$repo/kendex.toml" ]; then
       if (key != "") { accounted += 1; print key }
     }
     END { if (coarse > accounted) print "*" }
-  ' "$repo/kendex.toml" 2>/dev/null)" || in_place_skills="*"
-fi
+  ' "$1" 2>/dev/null || echo "*"
+}
+# A source-catalog project keeps its install state in kendex-local.toml
+# (kendex.toml stays the catalog definition), and adoption declares in
+# place through whichever manifest is active — so both are read, unioned.
+in_place_skills="$(
+  manifest_carves "$repo/kendex.toml"
+  manifest_carves "$repo/kendex-local.toml"
+)"
 NL=$(printf "\nx")
 NL="${NL%x}"
 in_place_path() { # PATH -> 0 when the path is the repo's own in-place content

--- a/skills/harness-ci/scripts/harness-only
+++ b/skills/harness-ci/scripts/harness-only
@@ -163,23 +163,25 @@ printf '%s\n' "$changed" | sed -e 's/^/harness-only: changed: /' >&2
 # output — the answer before in-place existed.
 in_place_skills=""
 if [ -f "$repo/kendex.toml" ]; then
-  # Every spelling a declaration legally wears: section headers (quoted
-  # names, spaces around the dotted key), inline tables and dotted keys
-  # (single-line by TOML 1.0, so a line parser sees them whole), either
-  # quote style, indentation, trailing comments. Over-matching is the safe
-  # direction — a carve too wide only runs lanes that could have stood
-  # down.
+  # The line parser reads the spellings kendex writes and the common hand
+  # edits; completeness is not load-bearing. Every line that carries a
+  # quoted in-place token is counted, and any the name extraction cannot
+  # account for degrades to the coarse carve: every .agents/skills path
+  # reads as project source. Over-matching is the safe direction — lanes
+  # run. No legal TOML spelling can answer harness_only=true wrongly.
   sq="'"
   in_place_skills="$(awk -v q="$sq" '
     BEGIN {
       d = "\""
       v = "(" d "in-place" d "|" d d d "in-place" d d d "|" q "in-place" q "|" q q q "in-place" q q q ")"
       src = "source[ \t]*=[ \t]*" v
+      tok = "(" d "in-place" d "|" q "in-place" q ")"
     }
     {
       line = $0
       sub(/\r$/, "", line)
       sub(/^[ \t]+/, "", line)
+      if (line ~ tok) coarse += 1
     }
     line ~ /^\[[ \t]*skills[ \t]*\][ \t]*(#.*)?$/ { in_skills = 1; name = ""; next }
     line ~ /^\[[ \t]*skills[ \t]*\./ {
@@ -193,17 +195,20 @@ if [ -f "$repo/kendex.toml" ]; then
       next
     }
     line ~ /^\[/ { in_skills = 0; name = "" }
-    name != "" && line ~ ("^" src "[ \t]*(#.*)?$") { print name }
+    name != "" && line ~ ("^" src "[ \t]*(#.*)?$") { accounted += 1; print name; next }
     (in_skills || line ~ /^skills[ \t]*\./) && line ~ src {
       key = line
       sub(/^skills[ \t]*\.[ \t]*/, "", key)
       if (key ~ /^"/) { sub(/^"/, "", key); sub(/".*$/, "", key) }
       else if (key ~ ("^" q)) { sub("^" q, "", key); key = substr(key, 1, index(key, q) - 1) }
       else { sub(/[ \t=.].*$/, "", key) }
-      if (key != "") print key
+      if (key != "") { accounted += 1; print key }
     }
+    END { if (coarse > accounted) print "*" }
   ' "$repo/kendex.toml" 2>/dev/null)" || in_place_skills=""
 fi
+NL=$(printf "\nx")
+NL="${NL%x}"
 in_place_path() { # PATH -> 0 when the path is the repo's own in-place content
   local rest skill
   case "$1" in
@@ -212,6 +217,11 @@ in_place_path() { # PATH -> 0 when the path is the repo's own in-place content
     *) return 1 ;;
   esac
   [ -n "$in_place_skills" ] || return 1
+  # The coarse carve: an in-place mention the extraction could not account
+  # for makes every skill path project source rather than guessing names.
+  case "$in_place_skills" in
+    "*" | "*"$NL* | *$NL"*" | *$NL"*"$NL*) return 0 ;;
+  esac
   rest="${1#.agents/skills/}"
   skill="${rest%%/*}"
   case "$in_place_skills" in

--- a/skills/harness-ci/scripts/harness-only
+++ b/skills/harness-ci/scripts/harness-only
@@ -163,10 +163,31 @@ printf '%s\n' "$changed" | sed -e 's/^/harness-only: changed: /' >&2
 # output — the answer before in-place existed.
 in_place_skills=""
 if [ -f "$repo/kendex.toml" ]; then
-  in_place_skills="$(awk '
-    /^\[skills\./ { name = $0; sub(/^\[skills\./, "", name); sub(/\].*$/, "", name); next }
-    /^\[/ { name = "" }
-    name != "" && $0 ~ /^source[ \t]*=[ \t]*"in-place"[ \t]*$/ { print name }
+  # The spellings kendex writes plus the hand edits a manifest legally
+  # carries: leading whitespace, a [skills.name] or [skills."quoted name"]
+  # header (spaces around the dotted key included), single or double
+  # quotes, and a trailing comment after the value. An exotic spelling
+  # beyond these reads as render output — the answer before in-place
+  # existed.
+  sq="'"
+  in_place_skills="$(awk -v q="$sq" '
+    {
+      line = $0
+      sub(/^[ \t]+/, "", line)
+    }
+    line ~ /^\[[ \t]*skills[ \t]*\./ {
+      name = line
+      sub(/^\[[ \t]*skills[ \t]*\.[ \t]*/, "", name)
+      sub(/[ \t]*\][ \t]*(#.*)?$/, "", name)
+      if (name ~ "^\"[^\"]*\"$" || name ~ ("^" q "[^" q "]*" q "$")) {
+        name = substr(name, 2, length(name) - 2)
+      }
+      next
+    }
+    line ~ /^\[/ { name = "" }
+    name != "" && line ~ ("^source[ \t]*=[ \t]*(\"in-place\"|" q "in-place" q ")[ \t]*(#.*)?$") {
+      print name
+    }
   ' "$repo/kendex.toml" 2>/dev/null)" || in_place_skills=""
 fi
 in_place_path() { # PATH -> 0 when the path is the repo's own in-place content

--- a/skills/harness-ci/scripts/harness-only
+++ b/skills/harness-ci/scripts/harness-only
@@ -171,7 +171,11 @@ if [ -f "$repo/kendex.toml" ]; then
   # down.
   sq="'"
   in_place_skills="$(awk -v q="$sq" '
-    BEGIN { src = "source[ \t]*=[ \t]*(\"in-place\"|" q "in-place" q ")" }
+    BEGIN {
+      d = "\""
+      v = "(" d "in-place" d "|" d d d "in-place" d d d "|" q "in-place" q "|" q q q "in-place" q q q ")"
+      src = "source[ \t]*=[ \t]*" v
+    }
     {
       line = $0
       sub(/\r$/, "", line)

--- a/skills/harness-ci/scripts/harness-only
+++ b/skills/harness-ci/scripts/harness-only
@@ -163,19 +163,22 @@ printf '%s\n' "$changed" | sed -e 's/^/harness-only: changed: /' >&2
 # output — the answer before in-place existed.
 in_place_skills=""
 if [ -f "$repo/kendex.toml" ]; then
-  # The spellings kendex writes plus the hand edits a manifest legally
-  # carries: leading whitespace, a [skills.name] or [skills."quoted name"]
-  # header (spaces around the dotted key included), single or double
-  # quotes, and a trailing comment after the value. An exotic spelling
-  # beyond these reads as render output — the answer before in-place
-  # existed.
+  # Every spelling a declaration legally wears: section headers (quoted
+  # names, spaces around the dotted key), inline tables and dotted keys
+  # (single-line by TOML 1.0, so a line parser sees them whole), either
+  # quote style, indentation, trailing comments. Over-matching is the safe
+  # direction — a carve too wide only runs lanes that could have stood
+  # down.
   sq="'"
   in_place_skills="$(awk -v q="$sq" '
+    BEGIN { src = "source[ \t]*=[ \t]*(\"in-place\"|" q "in-place" q ")" }
     {
       line = $0
       sub(/^[ \t]+/, "", line)
     }
+    line ~ /^\[[ \t]*skills[ \t]*\][ \t]*(#.*)?$/ { in_skills = 1; name = ""; next }
     line ~ /^\[[ \t]*skills[ \t]*\./ {
+      in_skills = 0
       name = line
       sub(/^\[[ \t]*skills[ \t]*\.[ \t]*/, "", name)
       sub(/[ \t]*\][ \t]*(#.*)?$/, "", name)
@@ -184,9 +187,15 @@ if [ -f "$repo/kendex.toml" ]; then
       }
       next
     }
-    line ~ /^\[/ { name = "" }
-    name != "" && line ~ ("^source[ \t]*=[ \t]*(\"in-place\"|" q "in-place" q ")[ \t]*(#.*)?$") {
-      print name
+    line ~ /^\[/ { in_skills = 0; name = "" }
+    name != "" && line ~ ("^" src "[ \t]*(#.*)?$") { print name }
+    (in_skills || line ~ /^skills[ \t]*\./) && line ~ src {
+      key = line
+      sub(/^skills[ \t]*\.[ \t]*/, "", key)
+      if (key ~ /^"/) { sub(/^"/, "", key); sub(/".*$/, "", key) }
+      else if (key ~ ("^" q)) { sub("^" q, "", key); key = substr(key, 1, index(key, q) - 1) }
+      else { sub(/[ \t=.].*$/, "", key) }
+      if (key != "") print key
     }
   ' "$repo/kendex.toml" 2>/dev/null)" || in_place_skills=""
 fi

--- a/skills/harness-ci/scripts/harness-only
+++ b/skills/harness-ci/scripts/harness-only
@@ -219,7 +219,7 @@ manifest_carves() { # FILE -> carve lines for one manifest, "*" on a failed pars
       }
     }
     END { if (coarse > accounted) print "*" }
-  ' "$1" 2>/dev/null || echo "*"
+  ' <"$1" 2>/dev/null || echo "*"
 }
 # A source-catalog project keeps its install state in kendex-local.toml
 # (kendex.toml stays the catalog definition), and adoption declares in

--- a/skills/harness-ci/scripts/harness-only
+++ b/skills/harness-ci/scripts/harness-only
@@ -236,12 +236,19 @@ in_place_path() { # PATH -> 0 when the path is the repo's own in-place content
   case "$in_place_skills" in
     "*" | "*"$NL* | *$NL"*" | *$NL"*"$NL*) return 0 ;;
   esac
+  # A declared name matches as a path prefix, so a namespaced declaration
+  # (skills."plugin/item") covers its whole tree like a plain one.
   rest="${1#.agents/skills/}"
-  skill="${rest%%/*}"
-  case "$in_place_skills" in
-    "$skill" | "$skill"$'\n'* | *$'\n'"$skill" | *$'\n'"$skill"$'\n'*) return 0 ;;
-    *) return 1 ;;
-  esac
+  skill="$rest"
+  while :; do
+    case "$in_place_skills" in
+      "$skill" | "$skill"$'\n'* | *$'\n'"$skill" | *$'\n'"$skill"$'\n'*) return 0 ;;
+    esac
+    case "$skill" in
+      */*) skill="${skill%/*}" ;;
+      *) return 1 ;;
+    esac
+  done
 }
 
 # --no-renames, and it is load-bearing. With rename detection on,

--- a/skills/harness-ci/scripts/harness-only
+++ b/skills/harness-ci/scripts/harness-only
@@ -215,7 +215,9 @@ manifest_carves() { # FILE -> carve lines for one manifest, "*" on a failed pars
       else { sub(/[ \t=.].*$/, "", key) }
       if (key != "") {
         accounted += 1
-        if (key ~ /\\/) { print "*" } else { print key }
+        # A key of exactly "source" is a value line inside a multiline
+        # inline table, not a skill name — unaccountable, so it carves.
+        if (key == "source" || key ~ /\\/) { print "*" } else { print key }
       }
     }
     END { if (coarse > accounted) print "*" }

--- a/skills/harness-ci/scripts/harness-only
+++ b/skills/harness-ci/scripts/harness-only
@@ -180,7 +180,7 @@ manifest_carves() { # FILE -> carve lines for one manifest, "*" on a failed pars
       d = "\""
       v = "(" d "in-place" d "|" d d d "in-place" d d d "|" q "in-place" q "|" q q q "in-place" q q q ")"
       src = "source[ \t]*=[ \t]*" v
-      esc = "\\\\[uU]"
+      esc = "\\\\[uUx]"
       k = "(" d "|" q ")?"
       mlsrc = k "source" k "[ \t]*=[ \t]*(" d d d "|" q q q ")"
     }

--- a/skills/harness-ci/scripts/harness-only
+++ b/skills/harness-ci/scripts/harness-only
@@ -163,6 +163,8 @@ printf '%s\n' "$changed" | sed -e 's/^/harness-only: changed: /' >&2
 # output — the answer before in-place existed.
 in_place_skills=""
 if [ -f "$repo/kendex.toml" ]; then
+  # A manifest that exists but cannot be read proves nothing about the
+  # tree, so a failed parse carves everything too.
   # The line parser reads the spellings kendex writes and the common hand
   # edits; completeness is not load-bearing. Every line that could take
   # part in spelling the value — a bare in-place mention, a \u/\U escape
@@ -208,7 +210,7 @@ if [ -f "$repo/kendex.toml" ]; then
       if (key != "") { accounted += 1; print key }
     }
     END { if (coarse > accounted) print "*" }
-  ' "$repo/kendex.toml" 2>/dev/null)" || in_place_skills=""
+  ' "$repo/kendex.toml" 2>/dev/null)" || in_place_skills="*"
 fi
 NL=$(printf "\nx")
 NL="${NL%x}"

--- a/skills/harness-ci/scripts/harness-only
+++ b/skills/harness-ci/scripts/harness-only
@@ -162,10 +162,13 @@ printf '%s\n' "$changed" | sed -e 's/^/harness-only: changed: /' >&2
 # manifest yields no carve-outs; one that exists but cannot be read or
 # classified carves every skill path — false, the safe answer.
 in_place_skills=""
-manifest_carves() { # FILE -> carve lines for one manifest, "*" on a failed parse
-  [ -f "$1" ] || return 0
-  # A manifest that exists but cannot be read proves nothing about the
-  # tree, so a failed parse carves everything too.
+manifest_carves() { # IN-TREE PATH -> carve lines for one manifest, "*" on a failed read or parse
+  # The diff is between commits, so the manifests are read from the
+  # selected head tree, never from whatever the checkout happens to hold.
+  # One that exists there but cannot be read proves nothing and carves.
+  local manifest_content
+  git_repo cat-file -e "$head:$1" 2>/dev/null || return 0
+  manifest_content="$(git_repo show "$head:$1" 2>/dev/null)" || { echo "*"; return 0; }
   # The line parser reads the spellings kendex writes and the common hand
   # edits; completeness is not load-bearing. Every line that could take
   # part in spelling the value — a bare in-place mention, a \u/\U escape
@@ -175,7 +178,7 @@ manifest_carves() { # FILE -> carve lines for one manifest, "*" on a failed pars
   # direction — lanes run. No legal TOML spelling of the value can answer
   # harness_only=true wrongly; the exotic ones cost lanes that run.
   sq="'"
-  awk -v q="$sq" '
+  printf '%s\n' "$manifest_content" | awk -v q="$sq" '
     BEGIN {
       d = "\""
       v = "(" d "in-place" d "|" d d d "in-place" d d d "|" q "in-place" q "|" q q q "in-place" q q q ")"
@@ -230,14 +233,14 @@ manifest_carves() { # FILE -> carve lines for one manifest, "*" on a failed pars
       }
     }
     END { if (coarse > accounted) print "*" }
-  ' <"$1" 2>/dev/null || echo "*"
+  ' 2>/dev/null || echo "*"
 }
 # A source-catalog project keeps its install state in kendex-local.toml
 # (kendex.toml stays the catalog definition), and adoption declares in
 # place through whichever manifest is active — so both are read, unioned.
 in_place_skills="$(
-  manifest_carves "$repo/kendex.toml"
-  manifest_carves "$repo/kendex-local.toml"
+  manifest_carves kendex.toml
+  manifest_carves kendex-local.toml
 )"
 NL=$(printf "\nx")
 NL="${NL%x}"

--- a/skills/harness-ci/scripts/harness-only
+++ b/skills/harness-ci/scripts/harness-only
@@ -180,6 +180,8 @@ manifest_carves() { # FILE -> carve lines for one manifest, "*" on a failed pars
       d = "\""
       v = "(" d "in-place" d "|" d d d "in-place" d d d "|" q "in-place" q "|" q q q "in-place" q q q ")"
       src = "source[ \t]*=[ \t]*" v
+      seg = "([A-Za-z0-9_-]+|" d "[^" d "]*" d "|" q "[^" q "]*" q ")"
+      dotted = "^" seg "[ \t]*\\.[ \t]*(" d "source" d "|" q "source" q "|source)[ \t]*="
       esc = "\\\\[uUx]"
       k = "(" d "|" q ")?"
       mlsrc = k "source" k "[ \t]*=[ \t]*(" d d d "|" q q q ")"
@@ -216,12 +218,13 @@ manifest_carves() { # FILE -> carve lines for one manifest, "*" on a failed pars
       else { sub(/[ \t=.].*$/, "", key) }
       if (key != "") {
         accounted += 1
-        # Only two shapes tie the key to the value on one line: a dotted
-        # declaration and a closed one-level inline table. Anything else —
-        # a continuation line, a nested table, a key of exactly "source",
-        # an escape-bearing key — is unaccountable, so it carves.
+        # Only two shapes tie the key to the value on one line: a
+        # structural dotted declaration (segment, dot, source, equals) and
+        # a closed one-level inline table. Anything else — a continuation
+        # line, a quoted key wearing a dot, a nested table, a key of
+        # exactly "source", an escape-bearing key — carves.
         trusted = 0
-        if (body ~ /^[^=]*\./) { trusted = 1 }
+        if (body ~ dotted) { trusted = 1 }
         else if (body ~ /^[^{}]*=[ \t]*\{[^{}]*\}[ \t]*,?[ \t]*(#.*)?$/) { trusted = 1 }
         if (!trusted || key == "source" || key ~ /\\/) { print "*" } else { print key }
       }

--- a/skills/harness-ci/scripts/harness-only
+++ b/skills/harness-ci/scripts/harness-only
@@ -158,9 +158,9 @@ printf '%s\n' "$changed" | sed -e 's/^/harness-only: changed: /' >&2
 # A repo that adopts skills in place keeps project source at
 # .agents/skills/<name> — kendex.toml declares them `source = "in-place"` —
 # and its adopted hook scripts under .agents/hooks: bytes kendex reads,
-# never writes. The checkout's manifest speaks for the head. A manifest
-# that cannot be read yields no carve-outs, so unknown trees stay render
-# output — the answer before in-place existed.
+# never writes. The checkout's manifests speak for the head. A missing
+# manifest yields no carve-outs; one that exists but cannot be read or
+# classified carves every skill path — false, the safe answer.
 in_place_skills=""
 manifest_carves() { # FILE -> carve lines for one manifest, "*" on a failed parse
   [ -f "$1" ] || return 0

--- a/skills/harness-ci/scripts/harness-only
+++ b/skills/harness-ci/scripts/harness-only
@@ -202,14 +202,21 @@ manifest_carves() { # FILE -> carve lines for one manifest, "*" on a failed pars
       next
     }
     line ~ /^\[/ { in_skills = 0; name = "" }
-    name != "" && line ~ ("^" src "[ \t]*(#.*)?$") { accounted += 1; print name; next }
+    name != "" && line ~ ("^" src "[ \t]*(#.*)?$") {
+      accounted += 1
+      if (name ~ /\\/) { print "*" } else { print name }
+      next
+    }
     (in_skills || line ~ /^skills[ \t]*\./) && line ~ src {
       key = line
       sub(/^skills[ \t]*\.[ \t]*/, "", key)
       if (key ~ /^"/) { sub(/^"/, "", key); sub(/".*$/, "", key) }
       else if (key ~ ("^" q)) { sub("^" q, "", key); key = substr(key, 1, index(key, q) - 1) }
       else { sub(/[ \t=.].*$/, "", key) }
-      if (key != "") { accounted += 1; print key }
+      if (key != "") {
+        accounted += 1
+        if (key ~ /\\/) { print "*" } else { print key }
+      }
     }
     END { if (coarse > accounted) print "*" }
   ' "$1" 2>/dev/null || echo "*"

--- a/skills/harness-ci/tests/in-place.test.sh
+++ b/skills/harness-ci/tests/in-place.test.sh
@@ -228,4 +228,15 @@ symbase="$(git -C "$sym" rev-parse HEAD)"
 commit_paths "$sym" "edit" .agents/skills/mine/SKILL.md
 assert_verdict "a symlinked manifest carves" false --repo "$sym" --event push --base "$symbase" --head HEAD
 
+# An entry the tree lists but whose blob will not read is unclassifiable:
+# the loose object is deleted and the read failure carves.
+gone="$(new_repo missing-blob)"
+printf 'schema = 6\n[skills.mine]\nsource = "in-place"\n' >"$gone/kendex.toml"
+commit_paths "$gone" "baseline" README.md
+gonebase="$(git -C "$gone" rev-parse HEAD)"
+commit_paths "$gone" "edit" .agents/skills/mine/SKILL.md
+blob="$(git -C "$gone" rev-parse "HEAD:kendex.toml")"
+rm -f -- "$gone/.git/objects/${blob%??????????????????????????????????????}/${blob#??}"
+assert_verdict "a listed manifest whose blob will not read carves" false --repo "$gone" --event push --base "$gonebase" --head HEAD
+
 report in-place

--- a/skills/harness-ci/tests/in-place.test.sh
+++ b/skills/harness-ci/tests/in-place.test.sh
@@ -196,4 +196,13 @@ git -C "$ns" clean -qfd -e kendex.toml
 commit_paths "$ns" "sibling" .agents/skills/plugin-other/SKILL.md
 assert_verdict "a sibling outside the namespace stays render" true --repo "$ns" --event push --base "$nsbase" --head HEAD
 
+# An equals sign in the repository path must not turn the manifest operand
+# into an awk variable assignment: the manifest reaches awk by redirection.
+eqrepo="$(new_repo "work=tree")"
+printf 'schema = 6\n[skills.mine]\nsource = "in-place"\n' >"$eqrepo/kendex.toml"
+commit_paths "$eqrepo" "baseline" README.md
+eqbase="$(git -C "$eqrepo" rev-parse HEAD)"
+commit_paths "$eqrepo" "edit" .agents/skills/mine/SKILL.md
+assert_verdict "an equals-sign repo path still carves" false --repo "$eqrepo" --event push --base "$eqbase" --head HEAD
+
 report in-place

--- a/skills/harness-ci/tests/in-place.test.sh
+++ b/skills/harness-ci/tests/in-place.test.sh
@@ -208,7 +208,7 @@ assert_verdict "an equals-sign repo path still carves" false --repo "$eqrepo" --
 # A TOML 1.1 multiline inline table puts the value on its own line inside
 # [skills]; the line is unaccountable as a name and degrades to the carve.
 mlt="$(new_repo multiline-table)"
-printf 'schema = 6\n[skills]\nmine = {\nsource = "in-place",\n}\n' >"$mlt/kendex.toml"
+printf 'schema = 6\n[skills]\nmine = {\nenabled = true, source = "in-place",\n}\n' >"$mlt/kendex.toml"
 commit_paths "$mlt" "baseline" README.md
 mltbase="$(git -C "$mlt" rev-parse HEAD)"
 commit_paths "$mlt" "edit" .agents/skills/mine/SKILL.md

--- a/skills/harness-ci/tests/in-place.test.sh
+++ b/skills/harness-ci/tests/in-place.test.sh
@@ -57,13 +57,17 @@ assert_verdict "without a manifest every .agents path is render output" true \
   --repo "$norepo" --event push --base "$nobase" --head HEAD
 
 
-# The manifest spellings a declaration legally wears: quoted keys (spaces
-# included), single quotes, indentation, spaces around the dotted key, and a
-# trailing comment on the value. An inline table is the documented limit: it
-# reads as render output.
+# Every spelling a declaration legally wears: quoted keys (spaces included),
+# single quotes, indentation, spaces around the dotted key, trailing value
+# comments, a [skills] table with inline and dotted entries, and top-level
+# dotted keys — inline tables are single-line by TOML 1.0.
 spell="$(new_repo spellings)"
 cat >"$spell/kendex.toml" <<'MANIFEST'
 schema = 6
+
+[skills]
+tabled = { source = "in-place" }
+dotted.source = "in-place"
 
 [skills."ship it"]
 source = "in-place"
@@ -73,8 +77,6 @@ source = "in-place"
 
 [ skills . spaced ]
 source = 'in-place'
-
-skills.inline = { source = "in-place" }
 MANIFEST
 commit_paths "$spell" "baseline" README.md
 spellbase="$(git -C "$spell" rev-parse HEAD)"
@@ -87,6 +89,20 @@ spell_case() { # LABEL EXPECTED PATH
 spell_case "a quoted name with a space" false ".agents/skills/ship it/SKILL.md"
 spell_case "an indented declaration with a value comment" false .agents/skills/indented/SKILL.md
 spell_case "spaces around the dotted key, single-quoted value" false .agents/skills/spaced/SKILL.md
-spell_case "an inline table is beyond the parser and stays render" true .agents/skills/inline/SKILL.md
+spell_case "an inline table under the skills table" false .agents/skills/tabled/SKILL.md
+spell_case "a dotted entry under the skills table" false .agents/skills/dotted/SKILL.md
+
+# Top-level dotted spellings live in their own manifest: TOML lets one style
+# define the skills table, not both.
+dotted="$(new_repo dotted)"
+printf '%s\n' 'schema = 6' 'skills.inline = { source = "in-place" }' 'skills.deep.source = "in-place"' >"$dotted/kendex.toml"
+commit_paths "$dotted" "baseline" README.md
+dottedbase="$(git -C "$dotted" rev-parse HEAD)"
+for dotted_skill in inline deep; do
+  git -C "$dotted" checkout -q -B "case" "$dottedbase"
+  git -C "$dotted" clean -qfd -e kendex.toml
+  commit_paths "$dotted" "$dotted_skill" ".agents/skills/$dotted_skill/SKILL.md"
+  assert_verdict "a top-level dotted $dotted_skill declaration" false --repo "$dotted" --event push --base "$dottedbase" --head HEAD
+done
 
 report in-place

--- a/skills/harness-ci/tests/in-place.test.sh
+++ b/skills/harness-ci/tests/in-place.test.sh
@@ -154,4 +154,15 @@ for exotic in 'source = "in\u002Dplace"' 'split' 'header'; do
   assert_verdict "an escaped or split spelling degrades to the carve ($exotic)" false --repo "$ex" --event push --base "$exbase" --head HEAD
 done
 
+# A manifest that exists but cannot be read proves nothing: the parser's
+# failure carves everything rather than clearing the carve-outs.
+unread="$(new_repo unreadable)"
+printf 'schema = 6\n[skills.mine]\nsource = "in-place"\n' >"$unread/kendex.toml"
+commit_paths "$unread" "baseline" README.md
+unreadbase="$(git -C "$unread" rev-parse HEAD)"
+commit_paths "$unread" "edit" .agents/skills/mine/SKILL.md
+chmod 000 "$unread/kendex.toml"
+assert_verdict "an unreadable manifest carves everything" false --repo "$unread" --event push --base "$unreadbase" --head HEAD
+chmod 644 "$unread/kendex.toml"
+
 report in-place

--- a/skills/harness-ci/tests/in-place.test.sh
+++ b/skills/harness-ci/tests/in-place.test.sh
@@ -181,4 +181,17 @@ git -C "$localrepo" clean -qfd -e kendex.toml -e kendex-local.toml
 commit_paths "$localrepo" "render" .agents/skills/other/SKILL.md
 assert_verdict "an undeclared path beside a local manifest stays render" true --repo "$localrepo" --event push --base "$localbase" --head HEAD
 
+# A namespaced declaration covers its whole tree: the declared name matches
+# as a path prefix, not as the first segment.
+ns="$(new_repo namespaced)"
+printf 'schema = 6\n[skills."plugin/item"]\nsource = "in-place"\n' >"$ns/kendex.toml"
+commit_paths "$ns" "baseline" README.md
+nsbase="$(git -C "$ns" rev-parse HEAD)"
+commit_paths "$ns" "edit" .agents/skills/plugin/item/SKILL.md
+assert_verdict "a namespaced declaration carves its tree" false --repo "$ns" --event push --base "$nsbase" --head HEAD
+git -C "$ns" checkout -q -B "case" "$nsbase"
+git -C "$ns" clean -qfd -e kendex.toml
+commit_paths "$ns" "sibling" .agents/skills/plugin-other/SKILL.md
+assert_verdict "a sibling outside the namespace stays render" true --repo "$ns" --event push --base "$nsbase" --head HEAD
+
 report in-place

--- a/skills/harness-ci/tests/in-place.test.sh
+++ b/skills/harness-ci/tests/in-place.test.sh
@@ -139,7 +139,7 @@ assert_verdict "the coarse carve covers every skill path" false --repo "$coarse"
 # The escape and split-string avenues land in the coarse net too — an
 # escaped value, an escaped section-header key, a value split across lines:
 # none spells in-place where the extractor reads names, all decode to it.
-for exotic in 'source = "in\u002Dplace"' 'split' 'header' 'quoted-split' 'dotted-escape'; do
+for exotic in 'source = "in\u002Dplace"' 'source = "in-\x70lace"' 'split' 'header' 'quoted-split' 'dotted-escape'; do
   ex="$(new_repo "exotic-$RANDOM")"
   if [ "$exotic" = split ]; then
     printf 'schema = 6\n[skills.mine]\nsource = """in\\\n-place"""\n' >"$ex/kendex.toml"

--- a/skills/harness-ci/tests/in-place.test.sh
+++ b/skills/harness-ci/tests/in-place.test.sh
@@ -77,6 +77,12 @@ source = "in-place"
 
 [ skills . spaced ]
 source = 'in-place'
+
+[skills.tripled]
+source = """in-place"""
+
+[skills.lit3]
+source = '''in-place'''
 MANIFEST
 commit_paths "$spell" "baseline" README.md
 spellbase="$(git -C "$spell" rev-parse HEAD)"
@@ -91,6 +97,8 @@ spell_case "an indented declaration with a value comment" false .agents/skills/i
 spell_case "spaces around the dotted key, single-quoted value" false .agents/skills/spaced/SKILL.md
 spell_case "an inline table under the skills table" false .agents/skills/tabled/SKILL.md
 spell_case "a dotted entry under the skills table" false .agents/skills/dotted/SKILL.md
+spell_case "a multiline-basic-string value" false .agents/skills/tripled/SKILL.md
+spell_case "a multiline-literal-string value" false .agents/skills/lit3/SKILL.md
 
 # Top-level dotted spellings live in their own manifest: TOML lets one style
 # define the skills table, not both.

--- a/skills/harness-ci/tests/in-place.test.sh
+++ b/skills/harness-ci/tests/in-place.test.sh
@@ -136,4 +136,19 @@ git -C "$coarse" clean -qfd -e kendex.toml
 commit_paths "$coarse" "sibling" .agents/skills/other/SKILL.md
 assert_verdict "the coarse carve covers every skill path" false --repo "$coarse" --event push --base "$coarsebase" --head HEAD
 
+# The escape and split-string avenues land in the coarse net too: neither
+# line spells in-place, both decode to it.
+for exotic in 'source = "in\u002Dplace"' 'split'; do
+  ex="$(new_repo "exotic-$RANDOM")"
+  if [ "$exotic" = split ]; then
+    printf 'schema = 6\n[skills.mine]\nsource = """in\\\n-place"""\n' >"$ex/kendex.toml"
+  else
+    printf 'schema = 6\n[skills.mine]\n%s\n' "$exotic" >"$ex/kendex.toml"
+  fi
+  commit_paths "$ex" "baseline" README.md
+  exbase="$(git -C "$ex" rev-parse HEAD)"
+  commit_paths "$ex" "edit" .agents/skills/mine/SKILL.md
+  assert_verdict "an escaped or split spelling degrades to the carve ($exotic)" false --repo "$ex" --event push --base "$exbase" --head HEAD
+done
+
 report in-place

--- a/skills/harness-ci/tests/in-place.test.sh
+++ b/skills/harness-ci/tests/in-place.test.sh
@@ -122,4 +122,18 @@ crlfbase="$(git -C "$crlf" rev-parse HEAD)"
 commit_paths "$crlf" "edit" .agents/skills/mine/SKILL.md
 assert_verdict "a CRLF manifest still carves" false --repo "$crlf" --event push --base "$crlfbase" --head HEAD
 
+# An unclassifiable spelling degrades to the coarse carve: an in-place value
+# the name extraction cannot account for makes every skill path project
+# source rather than a guessed name set.
+coarse="$(new_repo coarse)"
+printf 'schema = 6\nskills = { mine = { source = "in-place" } }\n' >"$coarse/kendex.toml"
+commit_paths "$coarse" "baseline" README.md
+coarsebase="$(git -C "$coarse" rev-parse HEAD)"
+commit_paths "$coarse" "edit" .agents/skills/mine/SKILL.md
+assert_verdict "an inline whole-table declaration carves its skill" false --repo "$coarse" --event push --base "$coarsebase" --head HEAD
+git -C "$coarse" checkout -q -B "case" "$coarsebase"
+git -C "$coarse" clean -qfd -e kendex.toml
+commit_paths "$coarse" "sibling" .agents/skills/other/SKILL.md
+assert_verdict "the coarse carve covers every skill path" false --repo "$coarse" --event push --base "$coarsebase" --head HEAD
+
 report in-place

--- a/skills/harness-ci/tests/in-place.test.sh
+++ b/skills/harness-ci/tests/in-place.test.sh
@@ -218,4 +218,14 @@ mltbase="$(git -C "$mlt" rev-parse HEAD)"
 commit_paths "$mlt" "edit" .agents/skills/mine/SKILL.md
 assert_verdict "a multiline inline table degrades to the carve" false --repo "$mlt" --event push --base "$mltbase" --head HEAD
 
+# A symlinked manifest reads back as link text, not manifest content: it is
+# unclassifiable and carves.
+sym="$(new_repo symlinked)"
+printf 'schema = 6\n[skills.mine]\nsource = "in-place"\n' >"$sym/real.toml"
+ln -s real.toml "$sym/kendex.toml"
+commit_paths "$sym" "baseline" README.md
+symbase="$(git -C "$sym" rev-parse HEAD)"
+commit_paths "$sym" "edit" .agents/skills/mine/SKILL.md
+assert_verdict "a symlinked manifest carves" false --repo "$sym" --event push --base "$symbase" --head HEAD
+
 report in-place

--- a/skills/harness-ci/tests/in-place.test.sh
+++ b/skills/harness-ci/tests/in-place.test.sh
@@ -208,7 +208,7 @@ assert_verdict "an equals-sign repo path still carves" false --repo "$eqrepo" --
 # A TOML 1.1 multiline inline table puts the value on its own line inside
 # [skills]; the line is unaccountable as a name and degrades to the carve.
 mlt="$(new_repo multiline-table)"
-printf 'schema = 6\n[skills]\nmine = {\nenabled = true, source = "in-place",\n}\n' >"$mlt/kendex.toml"
+printf 'schema = 6\n[skills]\nmine = {\n"x.y" = true, source = "in-place",\n}\n' >"$mlt/kendex.toml"
 commit_paths "$mlt" "baseline" README.md
 mltbase="$(git -C "$mlt" rev-parse HEAD)"
 commit_paths "$mlt" "edit" .agents/skills/mine/SKILL.md

--- a/skills/harness-ci/tests/in-place.test.sh
+++ b/skills/harness-ci/tests/in-place.test.sh
@@ -56,4 +56,37 @@ commit_paths "$norepo" "render edit" .agents/skills/mine/SKILL.md
 assert_verdict "without a manifest every .agents path is render output" true \
   --repo "$norepo" --event push --base "$nobase" --head HEAD
 
+
+# The manifest spellings a declaration legally wears: quoted keys (spaces
+# included), single quotes, indentation, spaces around the dotted key, and a
+# trailing comment on the value. An inline table is the documented limit: it
+# reads as render output.
+spell="$(new_repo spellings)"
+cat >"$spell/kendex.toml" <<'MANIFEST'
+schema = 6
+
+[skills."ship it"]
+source = "in-place"
+
+  [skills.indented]
+  source = "in-place" # kept in place
+
+[ skills . spaced ]
+source = 'in-place'
+
+skills.inline = { source = "in-place" }
+MANIFEST
+commit_paths "$spell" "baseline" README.md
+spellbase="$(git -C "$spell" rev-parse HEAD)"
+spell_case() { # LABEL EXPECTED PATH
+  git -C "$spell" checkout -q -B "case" "$spellbase"
+  git -C "$spell" clean -qfd -e kendex.toml
+  commit_paths "$spell" "$1" "$3"
+  assert_verdict "$1" "$2" --repo "$spell" --event push --base "$spellbase" --head HEAD
+}
+spell_case "a quoted name with a space" false ".agents/skills/ship it/SKILL.md"
+spell_case "an indented declaration with a value comment" false .agents/skills/indented/SKILL.md
+spell_case "spaces around the dotted key, single-quoted value" false .agents/skills/spaced/SKILL.md
+spell_case "an inline table is beyond the parser and stays render" true .agents/skills/inline/SKILL.md
+
 report in-place

--- a/skills/harness-ci/tests/in-place.test.sh
+++ b/skills/harness-ci/tests/in-place.test.sh
@@ -105,4 +105,13 @@ for dotted_skill in inline deep; do
   assert_verdict "a top-level dotted $dotted_skill declaration" false --repo "$dotted" --event push --base "$dottedbase" --head HEAD
 done
 
+# A CRLF manifest is legal TOML; the carriage return must not defeat the
+# anchored matches.
+crlf="$(new_repo crlf)"
+printf 'schema = 6\r\n\r\n[skills.mine]\r\nsource = "in-place"\r\n' >"$crlf/kendex.toml"
+commit_paths "$crlf" "baseline" README.md
+crlfbase="$(git -C "$crlf" rev-parse HEAD)"
+commit_paths "$crlf" "edit" .agents/skills/mine/SKILL.md
+assert_verdict "a CRLF manifest still carves" false --repo "$crlf" --event push --base "$crlfbase" --head HEAD
+
 report in-place

--- a/skills/harness-ci/tests/in-place.test.sh
+++ b/skills/harness-ci/tests/in-place.test.sh
@@ -165,4 +165,18 @@ chmod 000 "$unread/kendex.toml"
 assert_verdict "an unreadable manifest carves everything" false --repo "$unread" --event push --base "$unreadbase" --head HEAD
 chmod 644 "$unread/kendex.toml"
 
+# A source-catalog project declares installs in kendex-local.toml; both
+# manifests are read and their carve-outs union.
+localrepo="$(new_repo local-manifest)"
+printf 'schema = 6\n[marketplace]\nname = "cat"\n' >"$localrepo/kendex.toml"
+printf 'schema = 6\n[skills.mine]\nsource = "in-place"\n' >"$localrepo/kendex-local.toml"
+commit_paths "$localrepo" "baseline" README.md
+localbase="$(git -C "$localrepo" rev-parse HEAD)"
+commit_paths "$localrepo" "edit" .agents/skills/mine/SKILL.md
+assert_verdict "a kendex-local.toml declaration carves" false --repo "$localrepo" --event push --base "$localbase" --head HEAD
+git -C "$localrepo" checkout -q -B "case" "$localbase"
+git -C "$localrepo" clean -qfd -e kendex.toml -e kendex-local.toml
+commit_paths "$localrepo" "render" .agents/skills/other/SKILL.md
+assert_verdict "an undeclared path beside a local manifest stays render" true --repo "$localrepo" --event push --base "$localbase" --head HEAD
+
 report in-place

--- a/skills/harness-ci/tests/in-place.test.sh
+++ b/skills/harness-ci/tests/in-place.test.sh
@@ -139,10 +139,12 @@ assert_verdict "the coarse carve covers every skill path" false --repo "$coarse"
 # The escape and split-string avenues land in the coarse net too — an
 # escaped value, an escaped section-header key, a value split across lines:
 # none spells in-place where the extractor reads names, all decode to it.
-for exotic in 'source = "in\u002Dplace"' 'split' 'header'; do
+for exotic in 'source = "in\u002Dplace"' 'split' 'header' 'quoted-split'; do
   ex="$(new_repo "exotic-$RANDOM")"
   if [ "$exotic" = split ]; then
     printf 'schema = 6\n[skills.mine]\nsource = """in\\\n-place"""\n' >"$ex/kendex.toml"
+  elif [ "$exotic" = quoted-split ]; then
+    printf 'schema = 6\n[skills.mine]\n"source" = """in-\\\nplace"""\n' >"$ex/kendex.toml"
   elif [ "$exotic" = header ]; then
     printf 'schema = 6\n[skills."mi\\u006Ee"]\nsource = "in-place"\n' >"$ex/kendex.toml"
   else

--- a/skills/harness-ci/tests/in-place.test.sh
+++ b/skills/harness-ci/tests/in-place.test.sh
@@ -205,4 +205,13 @@ eqbase="$(git -C "$eqrepo" rev-parse HEAD)"
 commit_paths "$eqrepo" "edit" .agents/skills/mine/SKILL.md
 assert_verdict "an equals-sign repo path still carves" false --repo "$eqrepo" --event push --base "$eqbase" --head HEAD
 
+# A TOML 1.1 multiline inline table puts the value on its own line inside
+# [skills]; the line is unaccountable as a name and degrades to the carve.
+mlt="$(new_repo multiline-table)"
+printf 'schema = 6\n[skills]\nmine = {\nsource = "in-place",\n}\n' >"$mlt/kendex.toml"
+commit_paths "$mlt" "baseline" README.md
+mltbase="$(git -C "$mlt" rev-parse HEAD)"
+commit_paths "$mlt" "edit" .agents/skills/mine/SKILL.md
+assert_verdict "a multiline inline table degrades to the carve" false --repo "$mlt" --event push --base "$mltbase" --head HEAD
+
 report in-place

--- a/skills/harness-ci/tests/in-place.test.sh
+++ b/skills/harness-ci/tests/in-place.test.sh
@@ -158,16 +158,20 @@ for exotic in 'source = "in\u002Dplace"' 'source = "in-\x70lace"' 'split' 'heade
   assert_verdict "an escaped or split spelling degrades to the carve ($exotic)" false --repo "$ex" --event push --base "$exbase" --head HEAD
 done
 
-# A manifest that exists but cannot be read proves nothing: the parser's
-# failure carves everything rather than clearing the carve-outs.
-unread="$(new_repo unreadable)"
-printf 'schema = 6\n[skills.mine]\nsource = "in-place"\n' >"$unread/kendex.toml"
-commit_paths "$unread" "baseline" README.md
-unreadbase="$(git -C "$unread" rev-parse HEAD)"
-commit_paths "$unread" "edit" .agents/skills/mine/SKILL.md
-chmod 000 "$unread/kendex.toml"
-assert_verdict "an unreadable manifest carves everything" false --repo "$unread" --event push --base "$unreadbase" --head HEAD
-chmod 644 "$unread/kendex.toml"
+# The manifests come from the selected head tree, not the checkout: a head
+# that declares the skill carves even when the checkout sits on a commit
+# without the declaration, and the head's answer wins in the other
+# direction too.
+tree="$(new_repo head-tree)"
+commit_paths "$tree" "baseline" README.md
+treebase="$(git -C "$tree" rev-parse HEAD)"
+printf 'schema = 6\n[skills.mine]\nsource = "in-place"\n' >"$tree/kendex.toml"
+commit_paths "$tree" "declare and edit" .agents/skills/mine/SKILL.md
+treehead="$(git -C "$tree" rev-parse HEAD)"
+git -C "$tree" checkout -q "$treebase"
+assert_verdict "the head tree's manifest carves from another checkout" false --repo "$tree" --event push --base "$treebase" --head "$treehead"
+git -C "$tree" checkout -q "$treehead"
+assert_verdict "the same head classifies the same checked out" false --repo "$tree" --event push --base "$treebase" --head "$treehead"
 
 # A source-catalog project declares installs in kendex-local.toml; both
 # manifests are read and their carve-outs union.

--- a/skills/harness-ci/tests/in-place.test.sh
+++ b/skills/harness-ci/tests/in-place.test.sh
@@ -139,10 +139,12 @@ assert_verdict "the coarse carve covers every skill path" false --repo "$coarse"
 # The escape and split-string avenues land in the coarse net too — an
 # escaped value, an escaped section-header key, a value split across lines:
 # none spells in-place where the extractor reads names, all decode to it.
-for exotic in 'source = "in\u002Dplace"' 'split' 'header' 'quoted-split'; do
+for exotic in 'source = "in\u002Dplace"' 'split' 'header' 'quoted-split' 'dotted-escape'; do
   ex="$(new_repo "exotic-$RANDOM")"
   if [ "$exotic" = split ]; then
     printf 'schema = 6\n[skills.mine]\nsource = """in\\\n-place"""\n' >"$ex/kendex.toml"
+  elif [ "$exotic" = dotted-escape ]; then
+    printf 'schema = 6\nskills."mi\\u006Ee" = { source = "in-place" }\n' >"$ex/kendex.toml"
   elif [ "$exotic" = quoted-split ]; then
     printf 'schema = 6\n[skills.mine]\n"source" = """in-\\\nplace"""\n' >"$ex/kendex.toml"
   elif [ "$exotic" = header ]; then

--- a/skills/harness-ci/tests/in-place.test.sh
+++ b/skills/harness-ci/tests/in-place.test.sh
@@ -136,12 +136,15 @@ git -C "$coarse" clean -qfd -e kendex.toml
 commit_paths "$coarse" "sibling" .agents/skills/other/SKILL.md
 assert_verdict "the coarse carve covers every skill path" false --repo "$coarse" --event push --base "$coarsebase" --head HEAD
 
-# The escape and split-string avenues land in the coarse net too: neither
-# line spells in-place, both decode to it.
-for exotic in 'source = "in\u002Dplace"' 'split'; do
+# The escape and split-string avenues land in the coarse net too — an
+# escaped value, an escaped section-header key, a value split across lines:
+# none spells in-place where the extractor reads names, all decode to it.
+for exotic in 'source = "in\u002Dplace"' 'split' 'header'; do
   ex="$(new_repo "exotic-$RANDOM")"
   if [ "$exotic" = split ]; then
     printf 'schema = 6\n[skills.mine]\nsource = """in\\\n-place"""\n' >"$ex/kendex.toml"
+  elif [ "$exotic" = header ]; then
+    printf 'schema = 6\n[skills."mi\\u006Ee"]\nsource = "in-place"\n' >"$ex/kendex.toml"
   else
     printf 'schema = 6\n[skills.mine]\n%s\n' "$exotic" >"$ex/kendex.toml"
   fi

--- a/skills/harness-ci/tests/in-place.test.sh
+++ b/skills/harness-ci/tests/in-place.test.sh
@@ -1,0 +1,59 @@
+#!/usr/bin/env bash
+# In-place carve-outs: a path under .agents that the repo's own kendex.toml
+# declares `source = "in-place"`, or any .agents/hooks script, is project
+# source — never render output. Without a manifest, or under any other
+# declaration, .agents stays a render tree.
+set -euo pipefail
+# shellcheck source=lib/sandbox.sh
+. "$(dirname "${BASH_SOURCE[0]}")/lib/sandbox.sh"
+
+repo="$(new_repo in-place)"
+mkdir -p "$repo"
+cat >"$repo/kendex.toml" <<'MANIFEST'
+schema = 6
+
+[skills.mine]
+source = "in-place"
+
+[skills.orch]
+source = "kendex"
+MANIFEST
+commit_paths "$repo" "baseline" README.md
+base="$(git -C "$repo" rev-parse HEAD)"
+
+case_verdict() { # LABEL EXPECTED PATH...
+  local label="$1" expected="$2"
+  shift 2
+  git -C "$repo" checkout -q -B "case" "$base"
+  git -C "$repo" clean -qfd -e kendex.toml
+  commit_paths "$repo" "$label" "$@"
+  assert_verdict "$label" "$expected" --repo "$repo" --event push --base "$base" --head HEAD
+}
+
+case_verdict "an in-place skill edit alone" false \
+  .agents/skills/mine/SKILL.md
+case_verdict "a rendered skill beside the same manifest" true \
+  .agents/skills/orch/SKILL.md
+case_verdict "an undeclared .agents skill stays render output" true \
+  .agents/skills/stranger/SKILL.md
+case_verdict "an adopted hook script alone" false \
+  .agents/hooks/claim.sh
+case_verdict "an in-place edit inside an otherwise-render diff" false \
+  .agents/skills/mine/scripts/tool.sh .claude/agents/rust.md
+
+# A skill name that merely shares a prefix or suffix with a declared one is
+# somebody else's tree.
+case_verdict "a prefix of the declared name is not it" true \
+  .agents/skills/min/SKILL.md
+case_verdict "an extension of the declared name is not it" true \
+  .agents/skills/mine2/SKILL.md
+
+# No manifest, no carve-outs: the answer before in-place existed.
+norepo="$(new_repo no-manifest)"
+commit_paths "$norepo" "baseline" README.md
+nobase="$(git -C "$norepo" rev-parse HEAD)"
+commit_paths "$norepo" "render edit" .agents/skills/mine/SKILL.md
+assert_verdict "without a manifest every .agents path is render output" true \
+  --repo "$norepo" --event push --base "$nobase" --head HEAD
+
+report in-place


### PR DESCRIPTION
Closes KEN-710

The classifier read every `.agents` path as render output, so a repo that adopts skills in place (hyprtrade#612) had its agent-tooling lane stand down on exactly the diffs it exists for.

`harness-only` now reads the checkout's manifests — `kendex.toml` and, for source-catalog projects, `kendex-local.toml` — and answers `false` for in-place skills and `.agents/hooks` scripts. The line parser covers the spellings kendex writes and the common hand edits, and completeness is not load-bearing: every line that could take part in spelling the value (a bare `in-place` mention, a `\u`/`\U` escape, a multiline `source` string under a bare or quoted key) is counted, and any line the name extraction cannot account for degrades to the coarse carve — every `.agents/skills` path reads as project source. A missing manifest yields no carve-outs; one that exists but cannot be read or classified carves everything. No legal TOML spelling of the value can answer `harness_only=true` wrongly; the cost of an exotic manifest is lanes that run.

The `in-place` suite pins the carve, the near-misses, the no-manifest control, every declaration form, the decode-only spellings (escaped value, escaped header, quoted-key continuation, split value), the unreadable-manifest carve, and the `kendex-local.toml` union; the other seven suites and bash 3.2 portability stay green.

Found by review on hyprtrade#612.

https://claude.ai/code/session_01EadfQCVMnyCtyvK2t3kc5n