### PR TITLE
fix(KEN-674): kendex remove disarms the repository before its files go

### DIFF
--- a/.agents/skills/growth-guards/DEVELOPMENT.md
+++ b/.agents/skills/growth-guards/DEVELOPMENT.md
@@ -92,12 +92,15 @@ away. A delegating line it may not edit (a symlinked hook) keeps the helper
 in place and fails the removal rather than stranding a hook with no guard to
 reach.
 
-The installer runs on `kendex guard install` and on the separate yes an
-install offers — in the terminal (`kendex add`, a collection add, `kendex
-apply`) and in the app. `kendex guard uninstall` and `kendex guard check`
-invoke it too. `kendex remove` does not run the uninstaller (KEN-674):
-disarming before removing the skill is the caller's to do — shims whose
-scripts are gone block every commit.
+kendex runs this installer through the `repo-effects` declaration in
+`SKILL.md`: `kendex add --allow-repo-effects`, or a yes at the prompt in the
+terminal or in the app, runs it after the files land. Every CLI verb that
+drops the package — `kendex remove`, an `apply` or `refresh` whose plan takes
+it away, `marketplace unsubscribe --remove-packages` — runs `--uninstall`
+while the scripts are still on disk, because shims whose scripts are gone
+block every commit. `kendex guard install`, `kendex guard uninstall` and
+`kendex guard check` invoke it directly. `kendex check` reads nothing but the
+hook files: it names shims a deleted package left behind.
 
 `--check` is the read-only counterpart: it writes nothing — not even the
 hooks directory — and answers whether the shims are armed. `0`: the helper

--- a/.agents/skills/growth-guards/DEVELOPMENT.md
+++ b/.agents/skills/growth-guards/DEVELOPMENT.md
@@ -98,9 +98,10 @@ terminal or in the app, runs it after the files land. Every CLI verb that
 drops the package — `kendex remove`, an `apply` or `refresh` whose plan takes
 it away, `marketplace unsubscribe --remove-packages` — runs `--uninstall`
 while the scripts are still on disk, because shims whose scripts are gone
-block every commit. `kendex guard install`, `kendex guard uninstall` and
-`kendex guard check` invoke it directly. `kendex check` reads nothing but the
-hook files: it names shims a deleted package left behind.
+block every commit.
+`kendex guard install`, `kendex guard uninstall` and `kendex guard check`
+invoke it directly. `kendex check` runs none of this package's scripts: it
+reads the hook files and names shims a deleted package left behind.
 
 `--check` is the read-only counterpart: it writes nothing — not even the
 hooks directory — and answers whether the shims are armed. `0`: the helper

--- a/.agents/skills/growth-guards/SKILL.md
+++ b/.agents/skills/growth-guards/SKILL.md
@@ -19,13 +19,13 @@ repo-effects:
     - ".git/hooks/commit-msg"
   installer: "scripts/install-git-hooks"
   uninstaller: "scripts/install-git-hooks --uninstall"
-  removal: "run the uninstaller before removing this package: it drops only the helper and one marked line, leaving any hook you wrote. kendex remove does not run it for you, so shims left behind would exec scripts that are gone and fail every commit closed"
+  removal: "kendex guard uninstall, or any kendex CLI verb that drops the package (remove, an apply or refresh that takes it away, marketplace unsubscribe --remove-packages) runs the uninstaller before the files go; it drops only the helper and one marked line, leaving any hook you wrote. Deleting the package any other way leaves shims that exec scripts which are gone and fail every commit closed"
   companions:
     - "size-ratchet"
     - "preflight"
   notes:
     - "An existing pre-commit or commit-msg hook keeps its content and its exit status: one marked line goes in after the shebang and falls through to what was already there. core.hooksPath is never set."
-    - "The chain runs in order: size-ratchet --staged, preflight --staged, the growth-guards batch (todo-ban, byte-ceiling, suppression-ban, conflict-markers), then the repo-root executable named by GROWTH_GUARDS_PRE_COMMIT_LOCAL. A companion that is not installed is an announced skip, never a silently missing check, and one that is installed but cannot run stops the commit rather than skipping it."
+    - "The chain runs in order: size-ratchet --staged, preflight --staged, the growth-guards batch (todo-ban, byte-ceiling, suppression-ban, conflict-markers), then the repo-root executable named by GROWTH_GUARDS_PRE_COMMIT_LOCAL. A companion that is not installed is an announced skip, never a silently missing check, and one that is installed but cannot run stops the commit rather than skipping it; the stated skips are preflight on a repository's first commit and a repo-local size-ratchet that rejects --staged."
     - "Both hooks block on any nonzero verdict and fail closed on a guard that could not run. Passing git's no-verify flag bypasses one commit, and skips the message gate with it."
     - "The gate needs no kendex binary once armed: git runs this package's committed scripts, so a machine that never installed kendex still gates commits. Arming does not travel, though — git clones no hooks and this package never sets core.hooksPath — so every clone is armed once, by whoever clones it."
 ---

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -70,6 +70,10 @@ an outside contributor.
   ancestry into the default branch, or the pull request whose head commit is
   the branch tip. Squash merges collect, and every keep now names its reason.
 
+- `kendex remove` runs a package's declared uninstaller before its files go,
+  so removing `growth-guards` disarms the commit hooks instead of leaving
+  shims that fail every commit. `kendex check` names shims left behind.
+
 - A refresh cuts opencode.json's `kendex-hook-` `instructions` rows down to
   what it renders now, so a row kendex wrote leaves with its render. Every
   other row is untouched; rows a pre-rename tool wrote are removed by hand once.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -70,9 +70,9 @@ an outside contributor.
   ancestry into the default branch, or the pull request whose head commit is
   the branch tip. Squash merges collect, and every keep now names its reason.
 
-- `kendex remove`, and any apply, refresh or unsubscribe that drops a package,
-  runs its declared uninstaller before the files go, so dropping `growth-guards`
-  disarms the commit hooks. `kendex check` names shims a removed package left.
+- `kendex remove`, and any CLI apply, refresh or unsubscribe that drops a
+  package, runs its declared uninstaller before the files go, so dropping
+  `growth-guards` disarms the commit hooks. `kendex check` names shims left behind.
 
 - A refresh cuts opencode.json's `kendex-hook-` `instructions` rows down to
   what it renders now, so a row kendex wrote leaves with its render. Every

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -70,9 +70,9 @@ an outside contributor.
   ancestry into the default branch, or the pull request whose head commit is
   the branch tip. Squash merges collect, and every keep now names its reason.
 
-- `kendex remove` runs a package's declared uninstaller before its files go,
-  so removing `growth-guards` disarms the commit hooks instead of leaving
-  shims that fail every commit. `kendex check` names shims left behind.
+- `kendex remove`, and any apply, refresh or unsubscribe that drops a package,
+  runs its declared uninstaller before the files go, so dropping `growth-guards`
+  disarms the commit hooks. `kendex check` names shims a removed package left.
 
 - A refresh cuts opencode.json's `kendex-hook-` `instructions` rows down to
   what it renders now, so a row kendex wrote leaves with its render. Every

--- a/crates/cli/src/commands/add_collection.rs
+++ b/crates/cli/src/commands/add_collection.rs
@@ -12,7 +12,7 @@ use kendex_core::model::Scope;
 use kendex_core::registry::{CurlFetch, collections};
 use kendex_core::source_ops::{self, SourceAction};
 
-use super::engine_common::{print_report, print_safety};
+use super::engine_common::{apply_report, print_report, print_safety};
 use super::{CliResult, say};
 
 pub fn run(env: &Env, scope: &Scope, id: &str, yes: bool, allow_effects: bool) -> CliResult {
@@ -105,7 +105,7 @@ fn install_step(
         SourceAction::Reuse { name } => name,
         SourceAction::Subscribe { reference } => {
             let subscribed = source_ops::subscribe(env, scope, &reference, None)?;
-            kendex_core::apply::execute(env, &subscribed.report.plan, None)?;
+            apply_report(env, &subscribed.report)?;
             say(&format!(
                 "{}: subscribed to '{}'",
                 scope.label(),
@@ -154,12 +154,12 @@ fn install_step(
         },
     )?;
     print_report(env, &report);
-    kendex_core::apply::execute(env, &report.plan, None)?;
+    apply_report(env, &report)?;
     if reused && let Some(commit) = &step.commit {
         for (kind, name) in &members {
             let pinned = kendex_core::package::set_rev(env, scope, *kind, name, Some(commit))?;
             print_safety(&pinned);
-            kendex_core::apply::execute(env, &pinned.plan, None)?;
+            apply_report(env, &pinned)?;
         }
     }
     // The step's own plan goes back to the caller, which discloses over the

--- a/crates/cli/src/commands/adopt.rs
+++ b/crates/cli/src/commands/adopt.rs
@@ -2,7 +2,7 @@ use kendex_core::engine::{adopt, audit};
 use kendex_core::env::Env;
 use kendex_core::model::{HarnessId, ItemKind};
 
-use super::engine_common::print_safety;
+use super::engine_common::{apply_report, print_safety};
 use super::{CliResult, resolve_scopes, say};
 use crate::scope::ScopeFilter;
 
@@ -46,7 +46,7 @@ pub fn run(
     // beside the write, like every other write path.
     let report = audit(env, &scope)?;
     print_safety(&report);
-    kendex_core::apply::execute(env, &report.plan, None)?;
+    apply_report(env, &report)?;
     say(&format!("adopted {} '{}'", kind.name(), name));
     Ok(())
 }

--- a/crates/cli/src/commands/check.rs
+++ b/crates/cli/src/commands/check.rs
@@ -95,10 +95,11 @@ fn fold_commit_hooks(env: &Env, checked: &mut CheckReport, scopes: &[kendex_core
                     (
                         Class::Drift,
                         format!(
-                            "{} armed the commit hooks and is installed in no project of this repository, so every commit fails — delete {} or strip the lines marked `{}` from the hooks (a hook the marker says it created can go whole)",
+                            "{} armed the commit hooks and is installed in no project of this repository, so every commit fails until {} are dealt with — strip the lines marked `{}` from each hook, and delete a whole file only where it carries `{}` or is the helper kendex wrote beside the hooks",
                             kendex_core::guard::SKILL,
                             files.join(", "),
-                            kendex_core::guard::MARKER
+                            kendex_core::guard::MARKER,
+                            kendex_core::guard::CREATED_MARKER
                         ),
                     )
                 }

--- a/crates/cli/src/commands/check.rs
+++ b/crates/cli/src/commands/check.rs
@@ -61,54 +61,60 @@ fn fold_commit_hooks(env: &Env, checked: &mut CheckReport, scopes: &[kendex_core
         let Scope::Project { root } = scope.canonical() else {
             continue;
         };
-        // Before the install record is consulted: a package that was
-        // removed is in no record, and what it left armed is the one
-        // state here that stops every commit. Named by file, because the
-        // remedy is by hand — the uninstaller that would strip these went
-        // with the package.
-        match kendex_core::guard::stranded(&root) {
-            Ok(files) if files.is_empty() => {}
-            Ok(files) => {
-                let files: Vec<String> = files
-                    .iter()
-                    .map(|path| path.display().to_string())
-                    .collect();
-                report::fold(
-                    checked,
-                    "commit hooks",
-                    Class::Drift,
-                    format!(
-                        "{} armed the commit hooks and is installed nowhere in this repository, so every commit fails — delete {} or strip the lines marked `{}` from the hooks (a hook the marker says it created can go whole)",
-                        kendex_core::guard::SKILL,
-                        files.join(", "),
-                        kendex_core::guard::MARKER
-                    ),
-                );
-                continue;
-            }
+        // One probe per scope, shared by both reads below: each costs git
+        // processes, and this runs at every session start.
+        //
+        // No repository here is no verdict: there is nothing to arm and no
+        // drift to report. Folding it into "not armed" told a scope with no
+        // work tree to run `kendex guard install`, which exits 2 there —
+        // advice that cannot be taken, every session.
+        let repo = match kendex_core::guard::Repo::probe(&root) {
+            Ok(Some(repo)) => repo,
+            Ok(None) => continue,
             Err(error) => {
                 report::fold(checked, "commit hooks", Class::Unknown, error.to_string());
                 continue;
             }
-        }
+        };
         // A checkout that merely carries the files is not missing an
         // arming nobody asked for, so only a project whose own install
-        // record declares the package hears about this at all.
-        if !installed_here(env, scope) {
-            continue;
-        }
-        let (class, text) = match kendex_core::guard::armed(&root) {
-            // Armed, or no repository at all: neither is something a
-            // reader can act on, and the second has no remedy to offer.
-            Ok(None | Some(true)) => continue,
-            Ok(Some(false)) => (
-                Class::Drift,
-                format!(
-                    "commit hooks are not armed in {} — `kendex guard install` arms them, and `kendex guard check` says more",
-                    root.display()
+        // record declares the package hears about unarmed hooks. One whose
+        // record does NOT is where a removal may have left shims behind:
+        // the package is in no record, and what it left armed is the one
+        // state here that stops every commit. Named by file, because the
+        // remedy is by hand — the uninstaller that would strip these went
+        // with the package.
+        let (class, text) = match installed_here(env, scope) {
+            false => match kendex_core::guard::stranded(&repo) {
+                Ok(files) if files.is_empty() => continue,
+                Ok(files) => {
+                    let files: Vec<String> = files
+                        .iter()
+                        .map(|path| path.display().to_string())
+                        .collect();
+                    (
+                        Class::Drift,
+                        format!(
+                            "{} armed the commit hooks and is installed in no project of this repository, so every commit fails — delete {} or strip the lines marked `{}` from the hooks (a hook the marker says it created can go whole)",
+                            kendex_core::guard::SKILL,
+                            files.join(", "),
+                            kendex_core::guard::MARKER
+                        ),
+                    )
+                }
+                Err(error) => (Class::Unknown, error.to_string()),
+            },
+            true => match kendex_core::guard::armed(&repo) {
+                Ok(true) => continue,
+                Ok(false) => (
+                    Class::Drift,
+                    format!(
+                        "commit hooks are not armed in {} — `kendex guard install` arms them, and `kendex guard check` says more",
+                        root.display()
+                    ),
                 ),
-            ),
-            Err(error) => (Class::Unknown, error.to_string()),
+                Err(error) => (Class::Unknown, error.to_string()),
+            },
         };
         report::fold(checked, "commit hooks", class, text);
     }

--- a/crates/cli/src/commands/check.rs
+++ b/crates/cli/src/commands/check.rs
@@ -61,6 +61,36 @@ fn fold_commit_hooks(env: &Env, checked: &mut CheckReport, scopes: &[kendex_core
         let Scope::Project { root } = scope.canonical() else {
             continue;
         };
+        // Before the install record is consulted: a package that was
+        // removed is in no record, and what it left armed is the one
+        // state here that stops every commit. Named by file, because the
+        // remedy is by hand — the uninstaller that would strip these went
+        // with the package.
+        match kendex_core::guard::stranded(&root) {
+            Ok(files) if files.is_empty() => {}
+            Ok(files) => {
+                let files: Vec<String> = files
+                    .iter()
+                    .map(|path| path.display().to_string())
+                    .collect();
+                report::fold(
+                    checked,
+                    "commit hooks",
+                    Class::Drift,
+                    format!(
+                        "{} armed the commit hooks and is installed nowhere in this repository, so every commit fails — delete {} or strip the lines marked `{}` from the hooks (a hook the marker says it created can go whole)",
+                        kendex_core::guard::SKILL,
+                        files.join(", "),
+                        kendex_core::guard::MARKER
+                    ),
+                );
+                continue;
+            }
+            Err(error) => {
+                report::fold(checked, "commit hooks", Class::Unknown, error.to_string());
+                continue;
+            }
+        }
         // A checkout that merely carries the files is not missing an
         // arming nobody asked for, so only a project whose own install
         // record declares the package hears about this at all.

--- a/crates/cli/src/commands/drift_hook.rs
+++ b/crates/cli/src/commands/drift_hook.rs
@@ -31,6 +31,7 @@ pub fn install(env: &Env, scope: &Scope, yes: bool) -> CliResult {
         }
         let report = kendex_core::engine::EngineReport {
             repo_effects: Vec::new(),
+            repo_effects_leaving: Vec::new(),
             drift: Vec::new(),
             plan,
             notes: Vec::new(),

--- a/crates/cli/src/commands/engine_common.rs
+++ b/crates/cli/src/commands/engine_common.rs
@@ -223,6 +223,10 @@ pub fn confirm_and_apply(
             return Err("apply cancelled".into());
         }
     }
+    // A plan can take a package away without `remove` being the verb —
+    // a manifest edited by hand, a sweep — and its uninstaller has to run
+    // while the scripts are still there.
+    super::repo_effects::undo(&report.plan.scope, report)?;
     Ok(kendex_core::apply::execute(env, &report.plan, None)?.applied)
 }
 

--- a/crates/cli/src/commands/engine_common.rs
+++ b/crates/cli/src/commands/engine_common.rs
@@ -223,9 +223,20 @@ pub fn confirm_and_apply(
             return Err("apply cancelled".into());
         }
     }
-    // A plan can take a package away without `remove` being the verb —
-    // a manifest edited by hand, a sweep — and its uninstaller has to run
-    // while the scripts are still there.
+    apply_report(env, report)
+}
+
+/// Execute a report's plan — the one way a CLI verb holding an
+/// `EngineReport` writes it.
+///
+/// A plan can take a package away whatever the verb — `remove`, a manifest
+/// edited by hand and applied, a sweep, an unsubscribe that drops its
+/// packages — and the package's declared uninstaller has to run while the
+/// scripts it names are still on disk. Executing `report.plan` directly
+/// skips that, so no verb does: every report goes through here, and only a
+/// bare `Plan` with no report behind it (a fork's move, an adopt's) is
+/// executed on its own.
+pub fn apply_report(env: &Env, report: &EngineReport) -> Result<usize, Box<dyn std::error::Error>> {
     super::repo_effects::undo(&report.plan.scope, report)?;
     Ok(kendex_core::apply::execute(env, &report.plan, None)?.applied)
 }

--- a/crates/cli/src/commands/engine_common.rs
+++ b/crates/cli/src/commands/engine_common.rs
@@ -234,8 +234,8 @@ pub fn confirm_and_apply(
 /// packages — and the package's declared uninstaller has to run while the
 /// scripts it names are still on disk. Executing `report.plan` directly
 /// skips that, so no verb does: every report goes through here, and only a
-/// bare `Plan` with no report behind it (a fork's move, an adopt's) is
-/// executed on its own.
+/// bare `Plan` with no report behind it, which by construction drops no
+/// package, is executed on its own.
 pub fn apply_report(env: &Env, report: &EngineReport) -> Result<usize, Box<dyn std::error::Error>> {
     super::repo_effects::undo(&report.plan.scope, report)?;
     Ok(kendex_core::apply::execute(env, &report.plan, None)?.applied)

--- a/crates/cli/src/commands/fork_cmd.rs
+++ b/crates/cli/src/commands/fork_cmd.rs
@@ -4,7 +4,7 @@ use kendex_core::engine::audit;
 use kendex_core::env::Env;
 use kendex_core::model::HarnessId;
 
-use super::engine_common::print_safety;
+use super::engine_common::{apply_report, print_safety};
 use super::pin::parse_kind;
 use super::{CliResult, resolve_scopes, say};
 use crate::scope::ScopeFilter;
@@ -69,7 +69,7 @@ pub fn run(env: &Env, args: ForkArgs) -> CliResult {
         None => audit(env, &scope)?,
     };
     print_safety(&report);
-    kendex_core::apply::execute(env, &report.plan, None)?;
+    apply_report(env, &report)?;
     match args.rename {
         Some(new) => say(&format!("fork renamed to {new}")),
         None => say(&format!(

--- a/crates/cli/src/commands/marketplace_cmd.rs
+++ b/crates/cli/src/commands/marketplace_cmd.rs
@@ -2,6 +2,7 @@ use clap::Subcommand;
 use kendex_core::env::Env;
 use kendex_core::source_ops;
 
+use super::engine_common::apply_report;
 use super::{CliResult, out, resolve_scopes, say};
 use crate::scope::ScopeFilter;
 
@@ -169,12 +170,12 @@ fn run_unsubscribe(
     // Nothing installed: a plain confirm, whichever flag (or none) was passed.
     if closure.items.is_empty() {
         let report = kendex_core::source_ops::remove_source(env, &scope, name)?;
-        kendex_core::apply::execute(env, &report.plan, None)?;
+        apply_report(env, &report)?;
         say(&format!("{}: unsubscribed from '{name}'", scope.label()));
         return Ok(());
     }
 
-    let plan = match (remove_packages, keep_packages) {
+    match (remove_packages, keep_packages) {
         (false, false) => {
             return Err(format!(
                 "'{name}' has {} package(s) installed — pass --remove-packages to uninstall them or --keep-packages to keep them as your own",
@@ -182,10 +183,16 @@ fn run_unsubscribe(
             )
             .into());
         }
-        (_, true) => detach::source(env, &scope, name)?,
-        (true, _) => detach::remove(env, &scope, name, discard_edits)?.plan,
-    };
-    kendex_core::apply::execute(env, &plan, None)?;
+        // A bare plan: keeping moves tables, and takes no package away.
+        (_, true) => {
+            let plan = detach::source(env, &scope, name)?;
+            kendex_core::apply::execute(env, &plan, None)?;
+        }
+        (true, _) => {
+            let report = detach::remove(env, &scope, name, discard_edits)?;
+            apply_report(env, &report)?;
+        }
+    }
     if keep_packages {
         // Keeping moved the catalog's mapping tables into the manifest, so
         // the install records are re-synced here — otherwise every kept
@@ -195,7 +202,7 @@ fn run_unsubscribe(
             &scope,
             &kendex_core::engine::PlanOptions::default(),
         )?;
-        kendex_core::apply::execute(env, &resync.plan, None)?;
+        apply_report(env, &resync)?;
     }
     let kept = if keep_packages { "kept" } else { "removed" };
     say(&format!(
@@ -252,7 +259,7 @@ fn run_subscribe(
     for note in &subscribed.report.notes {
         say(note);
     }
-    kendex_core::apply::execute(env, &subscribed.report.plan, None)?;
+    apply_report(env, &subscribed.report)?;
     // Subscribing fetches so counts can land; a failure costs the
     // counts, never the subscription.
     if let Ok(Some(manifest)) =

--- a/crates/cli/src/commands/refresh.rs
+++ b/crates/cli/src/commands/refresh.rs
@@ -3,7 +3,8 @@ use kendex_core::env::Env;
 use kendex_core::lock::{load as load_lock, lock_path};
 
 use super::engine_common::{
-    confirm_and_apply, print_conflicts, print_drift, print_notes, print_safety, refresh_failures,
+    apply_report, confirm_and_apply, print_conflicts, print_drift, print_notes, print_safety,
+    refresh_failures,
 };
 use super::ledger::say_ledger;
 use super::{CliResult, resolve_scopes, say};
@@ -121,9 +122,7 @@ pub fn run(
         // what it installs still ends on the same ledger, since the
         // outcomes it has to report are the same either way.
         let applied: Result<usize, String> = match report.set_changes.is_empty() {
-            true => kendex_core::apply::execute(env, &report.plan, None)
-                .map(|outcome| outcome.applied)
-                .map_err(|error| error.to_string()),
+            true => apply_report(env, &report).map_err(|error| error.to_string()),
             false => {
                 print_set_changes(&scope, &report);
                 confirm_and_apply(env, &report, yes).map_err(|error| error.to_string())

--- a/crates/cli/src/commands/remove.rs
+++ b/crates/cli/src/commands/remove.rs
@@ -55,6 +55,8 @@ pub fn run(env: &Env, names: Vec<String>, filter: ScopeFilter, mode: Removal) ->
         }
         removed_any = true;
         say_split(&report, mode);
+        // While the scripts are still there to run.
+        super::repo_effects::undo(&scope, &report)?;
         kendex_core::apply::execute(env, &report.plan, None)?;
         for op in &report.plan.ops {
             say(&format!("  - {}", op.description));

--- a/crates/cli/src/commands/remove.rs
+++ b/crates/cli/src/commands/remove.rs
@@ -55,9 +55,7 @@ pub fn run(env: &Env, names: Vec<String>, filter: ScopeFilter, mode: Removal) ->
         }
         removed_any = true;
         say_split(&report, mode);
-        // While the scripts are still there to run.
-        super::repo_effects::undo(&scope, &report)?;
-        kendex_core::apply::execute(env, &report.plan, None)?;
+        super::engine_common::apply_report(env, &report)?;
         for op in &report.plan.ops {
             say(&format!("  - {}", op.description));
         }

--- a/crates/cli/src/commands/repo_effects.rs
+++ b/crates/cli/src/commands/repo_effects.rs
@@ -164,24 +164,28 @@ pub fn undo(scope: &Scope, report: &EngineReport) -> CliResult {
     let Scope::Project { root } = scope else {
         return Ok(());
     };
-    let mut repo: Option<bool> = None;
-    for declared in &report.repo_effects_leaving {
+    let leaving = &report.repo_effects_leaving;
+    // Asked once, and only when something leaving would need the answer:
+    // the probe is git processes, and a package that writes nowhere near
+    // `.git` never asks. `touches_git` is core's, the same reading the
+    // disclosure was made under, so an effect is armed and disarmed on one
+    // answer rather than two spellings of one.
+    //
+    // `probe`, not the disclosure's `at`: that one withholds an offer where
+    // git will not answer, because it is about to ask somebody to authorize
+    // a path it cannot name. This side only asks whether the work tree that
+    // could have been armed is here.
+    let git_here = leaving
+        .iter()
+        .any(|declared| kendex_core::repo_effects::touches_git(&declared.effects))
+        && kendex_core::guard::Repo::probe(root)?.is_some();
+    for declared in leaving {
         let name = shown(&declared.name);
-        if kendex_core::repo_effects::touches_git(&declared.effects) {
-            let here = match repo {
-                Some(here) => here,
-                None => {
-                    let here = kendex_core::guard::Repo::probe(root)?.is_some();
-                    repo = Some(here);
-                    here
-                }
-            };
-            if !here {
-                say(&format!(
-                    "{name}: not inside a git work tree, so nothing it armed is here to undo"
-                ));
-                continue;
-            }
+        if kendex_core::repo_effects::touches_git(&declared.effects) && !git_here {
+            say(&format!(
+                "{name}: not inside a git work tree, so nothing it armed is here to undo"
+            ));
+            continue;
         }
         let Some(uninstaller) = &declared.effects.uninstaller else {
             say(&format!(

--- a/crates/cli/src/commands/repo_effects.rs
+++ b/crates/cli/src/commands/repo_effects.rs
@@ -122,6 +122,21 @@ fn relay(report: &kendex_core::guard::GuardReport) {
     }
 }
 
+/// Run one of a package's declared scripts and hand its words on as they
+/// came. The verdict is the caller's to read; what it means differs by
+/// which script ran — `arm` settles the installer's in core, because a
+/// half-written repository has one account to give, and a caller undoing
+/// an effect reads the same exit against a plan it can still stop.
+fn run(
+    scope: &Scope,
+    declared: &DeclaredEffects,
+    spec: &str,
+) -> Result<kendex_core::guard::GuardReport, Box<dyn std::error::Error>> {
+    let report = kendex_core::repo_effects::run_script(scope, &declared.root, spec)?;
+    relay(&report);
+    Ok(report)
+}
+
 /// Run the uninstaller of every package this plan takes away, before the
 /// plan takes it.
 ///
@@ -139,9 +154,35 @@ fn relay(report: &kendex_core::guard::GuardReport) {
 /// A package that declares no uninstaller has nothing to run, and the
 /// removal goes ahead with that said — its files were going either way,
 /// and the disclosure named this the day it was installed.
+///
+/// The same stand-down as the disclosure's: an effect that writes into
+/// `.git` was never offered where the project has no git work tree, so
+/// there is nothing armed to undo and the uninstaller — which exits 2
+/// outside a repository — is not run. Otherwise removing a package from a
+/// plain directory failed every time, over hooks it could never have had.
 pub fn undo(scope: &Scope, report: &EngineReport) -> CliResult {
+    let Scope::Project { root } = scope else {
+        return Ok(());
+    };
+    let mut repo: Option<bool> = None;
     for declared in &report.repo_effects_leaving {
         let name = shown(&declared.name);
+        if kendex_core::repo_effects::touches_git(&declared.effects) {
+            let here = match repo {
+                Some(here) => here,
+                None => {
+                    let here = kendex_core::guard::Repo::probe(root)?.is_some();
+                    repo = Some(here);
+                    here
+                }
+            };
+            if !here {
+                say(&format!(
+                    "{name}: not inside a git work tree, so nothing it armed is here to undo"
+                ));
+                continue;
+            }
+        }
         let Some(uninstaller) = &declared.effects.uninstaller else {
             say(&format!(
                 "{name}: declares no uninstaller — what it changed about this repository stays{}",
@@ -153,17 +194,14 @@ pub fn undo(scope: &Scope, report: &EngineReport) -> CliResult {
             continue;
         };
         say(&format!("{name}: running {}", shown(uninstaller)));
-        let report = kendex_core::repo_effects::run_script(scope, &declared.root, uninstaller)?;
-        for line in &report.stderr {
-            say(line);
-        }
-        for line in &report.stdout {
-            out(line);
-        }
+        let report = run(scope, declared, uninstaller)?;
         if report.code != 0 {
+            // No verb named: under an apply or a refresh the package is
+            // already out of the manifest, and "remove it again" would
+            // answer "Nothing removed".
             return Err(format!(
-                "{name}: {} exited {} — the package stays installed; \
-                 fix what it reported and remove it again",
+                "{name}: {} exited {} — its files stay in place; \
+                 fix what it reported and run this again",
                 shown(uninstaller),
                 report.code
             )

--- a/crates/cli/src/commands/repo_effects.rs
+++ b/crates/cli/src/commands/repo_effects.rs
@@ -4,8 +4,9 @@
 //! Not before anything is written. The package's own files land first — they
 //! go where kendex manages, and removing the package undoes them — and what
 //! stays pending is the repository effect: the thing that changes what
-//! happens on every commit, for everyone who commits here, and that removing
-//! the package does not undo.
+//! happens on every commit, for everyone who commits here, and that trashing
+//! the package's files does not undo. Undoing it is the package's declared
+//! uninstaller, which `undo` runs when the package leaves.
 //!
 //! Separate on purpose. `apply? [y/N]` is a question about files landing in
 //! tool folders, and it never asked about any of that. Declining the effect
@@ -25,7 +26,9 @@
 
 use std::io::{IsTerminal, Write};
 
+use kendex_core::engine::EngineReport;
 use kendex_core::model::Scope;
+use kendex_core::names::shown;
 use kendex_core::repo_effects::{DeclaredEffects, Disclosure};
 
 use super::{CliResult, out, say};
@@ -117,4 +120,55 @@ fn relay(report: &kendex_core::guard::GuardReport) {
     for line in &report.stdout {
         out(line);
     }
+}
+
+/// Run the uninstaller of every package this plan takes away, before the
+/// plan takes it.
+///
+/// Before, because the uninstaller is one of the files going: after the
+/// plan there is nothing to run, and the effect outlives its package as
+/// shims that exec a script that is not there and fail every commit
+/// closed. Not asked about — removing the package is the ask — and said
+/// out loud, so the person knows what ran in their repository.
+///
+/// A package whose uninstaller fails stays installed: the plan stops here
+/// with the files still in place and the package's own words on the
+/// failure, so the person can run it by hand and remove again. The other
+/// order leaves the repository in the state this exists to prevent.
+///
+/// A package that declares no uninstaller has nothing to run, and the
+/// removal goes ahead with that said — its files were going either way,
+/// and the disclosure named this the day it was installed.
+pub fn undo(scope: &Scope, report: &EngineReport) -> CliResult {
+    for declared in &report.repo_effects_leaving {
+        let name = shown(&declared.name);
+        let Some(uninstaller) = &declared.effects.uninstaller else {
+            say(&format!(
+                "{name}: declares no uninstaller — what it changed about this repository stays{}",
+                match &declared.effects.removal {
+                    Some(removal) => format!("; to undo: {}", shown(removal)),
+                    None => String::new(),
+                }
+            ));
+            continue;
+        };
+        say(&format!("{name}: running {}", shown(uninstaller)));
+        let report = kendex_core::repo_effects::run_script(scope, &declared.root, uninstaller)?;
+        for line in &report.stderr {
+            say(line);
+        }
+        for line in &report.stdout {
+            out(line);
+        }
+        if report.code != 0 {
+            return Err(format!(
+                "{name}: {} exited {} — the package stays installed; \
+                 fix what it reported and remove it again",
+                shown(uninstaller),
+                report.code
+            )
+            .into());
+        }
+    }
+    Ok(())
 }

--- a/crates/cli/src/commands/repo_effects/disclose.rs
+++ b/crates/cli/src/commands/repo_effects/disclose.rs
@@ -97,10 +97,12 @@ fn print(disclosure: &Disclosure) {
     say("");
     match &disclosure.undo {
         Some(undo) => say(&format!("  to undo: {undo}")),
-        // Not "remove the package". Removing it takes the scripts away
-        // and leaves the effect: shims in .git/hooks outlive the tree
-        // they point at, and then fail every commit closed. What is true
-        // is that the package said nothing about undoing this.
+        // Not "remove the package". Removal runs whatever uninstaller
+        // the package declared, and this one declared none: its files
+        // would go and the effect would stay — shims in .git/hooks
+        // outlive the tree they point at, and then fail every commit
+        // closed. What is true is that the package said nothing about
+        // undoing this.
         None => say("  to undo: the package declares no way to undo it"),
     }
 }

--- a/crates/cli/src/commands/source_cmd.rs
+++ b/crates/cli/src/commands/source_cmd.rs
@@ -2,6 +2,7 @@ use clap::Subcommand;
 use kendex_core::env::Env;
 use kendex_core::{remote, source_ops};
 
+use super::engine_common::apply_report;
 use super::{CliResult, out, resolve_scopes, say};
 use crate::scope::ScopeFilter;
 
@@ -58,18 +59,18 @@ pub fn run(env: &Env, command: SourceCommand, filter: ScopeFilter) -> CliResult 
             }
             SourceCommand::Add { name, reference } => {
                 let report = source_ops::add_source(env, &scope, name, reference)?;
-                kendex_core::apply::execute(env, &report.plan, None)?;
+                apply_report(env, &report)?;
                 say(&format!("{}: declared source '{name}'", scope.label()));
             }
             SourceCommand::Remove { name } => {
                 let report = source_ops::remove_source(env, &scope, name)?;
-                kendex_core::apply::execute(env, &report.plan, None)?;
+                apply_report(env, &report)?;
                 say(&format!("{}: removed source '{name}'", scope.label()));
             }
             SourceCommand::Enable { name } | SourceCommand::Disable { name } => {
                 let enabled = matches!(command, SourceCommand::Enable { .. });
                 let report = source_ops::toggle_source(env, &scope, name, enabled)?;
-                kendex_core::apply::execute(env, &report.plan, None)?;
+                apply_report(env, &report)?;
                 say(&format!(
                     "{}: source '{name}' {}",
                     scope.label(),

--- a/crates/cli/tests/guard_hooks/arming.rs
+++ b/crates/cli/tests/guard_hooks/arming.rs
@@ -198,6 +198,47 @@ fn check_reads_the_hooks_and_runs_nothing() {
     assert!(!marker.exists(), "check ran the repository's script");
 }
 
+/// Shims that outlived their package are named, file by file.
+///
+/// The state the install record cannot see: the package is in no lock and
+/// under no skills directory, so the drift report has nothing to compare
+/// and `guard check` has no installer to ask — while every commit execs a
+/// script that is gone. The marker in the hook files is the whole test.
+#[test]
+#[allow(clippy::unwrap_used)]
+fn check_names_the_shims_a_removed_package_left_behind() {
+    let tmp = tempfile::tempdir().unwrap();
+    let home = tmp.path();
+    let root = repo(home);
+    std::fs::write(root.join("kendex.toml"), "schema = 6\n").unwrap();
+    install_package_undeclared(&root, &["growth-guards"]);
+    arm_by_hand(&root);
+    std::fs::remove_dir_all(root.join(".agents/skills/growth-guards")).unwrap();
+
+    // The state is real: nothing can be committed here.
+    std::fs::write(root.join("b.txt"), "later\n").unwrap();
+    git_ok(home, &root, &["add", "-A"]);
+    let blocked = crate::git(home, &root, &["commit", "-m", "feat: stranded"]);
+    assert!(!blocked.status.success(), "{}", said(&blocked));
+
+    let out = run(home, &root, "kendex", &["check"]);
+    assert_eq!(out.status.code(), Some(1), "{}", said(&out));
+    let text = said(&out);
+    assert!(text.contains("commit hooks"), "{text}");
+    assert!(text.contains("installed nowhere"), "{text}");
+    let hooks = root.canonicalize().unwrap().join(".git/hooks");
+    for file in ["pre-commit", "commit-msg", "kendex-guards"] {
+        assert!(
+            text.contains(&hooks.join(file).display().to_string()),
+            "{file} was not named:\n{text}"
+        );
+    }
+    assert!(
+        !text.contains("guard install"),
+        "a leftover was reported as an unarmed install:\n{text}"
+    );
+}
+
 /// Arm through the package's own installer.
 ///
 /// Not a hand-written approximation: the check compares against the exact

--- a/crates/cli/tests/guard_hooks/arming.rs
+++ b/crates/cli/tests/guard_hooks/arming.rs
@@ -265,6 +265,88 @@ fn check_names_the_shims_a_removed_package_left_behind() {
         "a lone helper with unmarked hooks was reported as stranded:\n{}",
         said(&out)
     );
+
+    // A hook that MENTIONS the marker mid-line is a consumer's own comment.
+    // The installer's owned-line rule is the marker closing a line, so its
+    // removal would leave this file exactly as it is — and advice to strip
+    // it would eat somebody else's line.
+    for lane in ["pre-commit", "commit-msg"] {
+        std::fs::write(
+            root.join(".git/hooks").join(lane),
+            "#!/bin/sh\n# lines ending in # kendex-guards-hook belong to kendex\nexit 0\n",
+        )
+        .unwrap();
+    }
+    let out = run(home, &root, "kendex", &["check"]);
+    assert!(
+        !said(&out).contains("commit hooks"),
+        "a hook that merely mentions the marker was reported as stranded:\n{}",
+        said(&out)
+    );
+
+    // Owned lanes again — the disabled spelling, which the installer still
+    // owns because the marker closes the line — beside a file of the
+    // helper's name carrying no helper marker. The uninstaller refuses to
+    // remove that file, so the lanes are named and it is not.
+    for lane in ["pre-commit", "commit-msg"] {
+        std::fs::write(
+            root.join(".git/hooks").join(lane),
+            format!("#!/bin/sh\n# \"$kendex_gg_h\" {lane} || exit $?; # kendex-guards-hook\n"),
+        )
+        .unwrap();
+    }
+    let helper = hooks.join("kendex-guards");
+    std::fs::write(&helper, "#!/bin/sh\necho somebody else's\n").unwrap();
+    let out = run(home, &root, "kendex", &["check"]);
+    let text = said(&out);
+    assert!(text.contains("commit hooks"), "{text}");
+    for lane in ["pre-commit", "commit-msg"] {
+        assert!(
+            text.contains(&hooks.join(lane).display().to_string()),
+            "{lane} was not named:\n{text}"
+        );
+    }
+    assert!(
+        !text.contains(&helper.display().to_string()),
+        "a foreign file of the helper's name was named for deletion:\n{text}"
+    );
+}
+
+/// The ownership markers kendex reads are the installer's own.
+///
+/// Three constants in two languages, and this branch already lost one of
+/// them: the helper marker was dropped from the crate on the reasoning that
+/// the helper's fixed name identified it, which is not the predicate the
+/// uninstaller uses — it requires the marker, and preserves a foreign file
+/// of that name. So the values come out of the script rather than beside
+/// it.
+#[test]
+#[allow(clippy::unwrap_used)]
+fn the_ownership_markers_match_the_installers_own() {
+    let installer = std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("../../skills/growth-guards/scripts/install-git-hooks")
+        .canonicalize()
+        .unwrap();
+    let text = std::fs::read_to_string(&installer).unwrap();
+    let declared = |name: &str| -> String {
+        let prefix = format!("{name}=\"");
+        text.lines()
+            .find_map(|line| line.strip_prefix(&prefix))
+            .and_then(|rest| rest.strip_suffix('"'))
+            .unwrap_or_else(|| panic!("the installer declares {name} as one quoted string"))
+            .to_owned()
+    };
+    for (name, ours) in [
+        ("HOOK_SENTINEL", kendex_core::guard::MARKER),
+        ("CREATED_MARKER", kendex_core::guard::CREATED_MARKER),
+        ("HELPER_MARKER", kendex_core::guard::HELPER_MARKER),
+    ] {
+        assert_eq!(
+            declared(name),
+            ours,
+            "the installer's {name} and the one kendex reads by have drifted"
+        );
+    }
 }
 
 /// One repository, two kendex projects, one hooks directory. The project

--- a/crates/cli/tests/guard_hooks/arming.rs
+++ b/crates/cli/tests/guard_hooks/arming.rs
@@ -225,7 +225,10 @@ fn check_names_the_shims_a_removed_package_left_behind() {
     assert_eq!(out.status.code(), Some(1), "{}", said(&out));
     let text = said(&out);
     assert!(text.contains("commit hooks"), "{text}");
-    assert!(text.contains("installed nowhere"), "{text}");
+    assert!(
+        text.contains("installed in no project of this repository"),
+        "{text}"
+    );
     let hooks = root.canonicalize().unwrap().join(".git/hooks");
     for file in ["pre-commit", "commit-msg", "kendex-guards"] {
         assert!(
@@ -237,6 +240,56 @@ fn check_names_the_shims_a_removed_package_left_behind() {
         !text.contains("guard install"),
         "a leftover was reported as an unarmed install:\n{text}"
     );
+
+    // With hooks redirected git reads none of these, so no commit fails
+    // and nothing is claimed about one.
+    git_ok(home, &root, &["config", "core.hooksPath", ".husky"]);
+    let out = run(home, &root, "kendex", &["check"]);
+    assert!(
+        !said(&out).contains("commit hooks"),
+        "a redirected repository was reported as failing every commit:\n{}",
+        said(&out)
+    );
+}
+
+/// One repository, two kendex projects, one hooks directory. The project
+/// without the package is gated by the one that armed it — not stranded —
+/// and the advice to delete the shims would have disarmed its neighbour.
+#[test]
+#[allow(clippy::unwrap_used)]
+fn a_neighbouring_project_carrying_the_package_is_not_a_leftover() {
+    let tmp = tempfile::tempdir().unwrap();
+    let home = tmp.path();
+    std::fs::create_dir_all(home.join(".claude")).unwrap();
+    let root = home.join("mono");
+    let api = root.join("apps/api");
+    let web = root.join("apps/web");
+    std::fs::create_dir_all(api.join(".agents")).unwrap();
+    std::fs::create_dir_all(web.join(".agents")).unwrap();
+    git_ok(home, &root, &["init", "--quiet", "-b", "main"]);
+    git_ok(home, &root, &["config", "user.email", "t@t"]);
+    git_ok(home, &root, &["config", "user.name", "t"]);
+    std::fs::write(root.join("a.txt"), "hi\n").unwrap();
+    git_ok(home, &root, &["add", "-A"]);
+    git_ok(home, &root, &["commit", "--quiet", "-m", "feat: base"]);
+    install_package(home, &api, &["growth-guards"]);
+    let armed = run(home, &api, "kendex", &["guard", "install"]);
+    assert!(armed.status.success(), "{}", said(&armed));
+    std::fs::write(web.join("kendex.toml"), "schema = 6\n").unwrap();
+
+    let out = run(home, &web, "kendex", &["check"]);
+    assert!(
+        !said(&out).contains("commit hooks"),
+        "a gated repository was reported as stranded:\n{}",
+        said(&out)
+    );
+    assert_eq!(out.status.code(), Some(0), "{}", said(&out));
+
+    // The control: a commit from the project without the package runs the
+    // neighbour's chain and passes.
+    std::fs::write(web.join("b.txt"), "fine\n").unwrap();
+    git_ok(home, &web, &["add", "-A"]);
+    git_ok(home, &web, &["commit", "--quiet", "-m", "feat: from web"]);
 }
 
 /// Arm through the package's own installer.

--- a/crates/cli/tests/guard_hooks/arming.rs
+++ b/crates/cli/tests/guard_hooks/arming.rs
@@ -250,11 +250,30 @@ fn check_names_the_shims_a_removed_package_left_behind() {
         "a redirected repository was reported as failing every commit:\n{}",
         said(&out)
     );
+
+    // A file of the helper's name beside hooks that carry no marker execs
+    // on no commit: the installer leaves such a file alone, and so does
+    // the report.
+    git_ok(home, &root, &["config", "--unset", "core.hooksPath"]);
+    for lane in ["pre-commit", "commit-msg"] {
+        std::fs::write(root.join(".git/hooks").join(lane), "#!/bin/sh\nexit 0\n").unwrap();
+    }
+    assert!(root.join(".git/hooks/kendex-guards").is_file());
+    let out = run(home, &root, "kendex", &["check"]);
+    assert!(
+        !said(&out).contains("commit hooks"),
+        "a lone helper with unmarked hooks was reported as stranded:\n{}",
+        said(&out)
+    );
 }
 
 /// One repository, two kendex projects, one hooks directory. The project
 /// without the package is gated by the one that armed it — not stranded —
 /// and the advice to delete the shims would have disarmed its neighbour.
+///
+/// The repository root is itself a project, which is the ordinary shape: a
+/// `.claude/CLAUDE.md` at the top marks it as one. A search that stops at
+/// the first project it meets stops there and never sees `apps/api`.
 #[test]
 #[allow(clippy::unwrap_used)]
 fn a_neighbouring_project_carrying_the_package_is_not_a_leftover() {
@@ -264,6 +283,8 @@ fn a_neighbouring_project_carrying_the_package_is_not_a_leftover() {
     let root = home.join("mono");
     let api = root.join("apps/api");
     let web = root.join("apps/web");
+    std::fs::create_dir_all(root.join(".claude")).unwrap();
+    std::fs::write(root.join(".claude/CLAUDE.md"), "the monorepo\n").unwrap();
     std::fs::create_dir_all(api.join(".agents")).unwrap();
     std::fs::create_dir_all(web.join(".agents")).unwrap();
     git_ok(home, &root, &["init", "--quiet", "-b", "main"]);
@@ -277,13 +298,16 @@ fn a_neighbouring_project_carrying_the_package_is_not_a_leftover() {
     assert!(armed.status.success(), "{}", said(&armed));
     std::fs::write(web.join("kendex.toml"), "schema = 6\n").unwrap();
 
-    let out = run(home, &web, "kendex", &["check"]);
-    assert!(
-        !said(&out).contains("commit hooks"),
-        "a gated repository was reported as stranded:\n{}",
-        said(&out)
-    );
-    assert_eq!(out.status.code(), Some(0), "{}", said(&out));
+    for from in [&web, &root] {
+        let out = run(home, from, "kendex", &["check"]);
+        assert!(
+            !said(&out).contains("commit hooks"),
+            "a gated repository was reported as stranded from {}:\n{}",
+            from.display(),
+            said(&out)
+        );
+        assert_eq!(out.status.code(), Some(0), "{}", said(&out));
+    }
 
     // The control: a commit from the project without the package runs the
     // neighbour's chain and passes.

--- a/crates/cli/tests/guard_hooks/arming.rs
+++ b/crates/cli/tests/guard_hooks/arming.rs
@@ -537,3 +537,128 @@ fn each_of_the_packages_streams_is_relayed_on_its_own() {
         "stdout is the summary and nothing else: {stdout:?}"
     );
 }
+
+/// A copy in a SIBLING work tree gates this one, and is not a leftover.
+///
+/// `.git/hooks` lives in the common git directory, so one copy of it runs
+/// for every work tree attached to that directory — not just this one and
+/// the main checkout. A search that looks only at those two calls the
+/// shared shims stranded from any third work tree and tells the reader to
+/// delete files the sibling's copy is still using, on a repository where
+/// every commit is gated perfectly well.
+#[test]
+#[allow(clippy::unwrap_used)]
+fn a_copy_in_a_sibling_work_tree_is_not_a_leftover() {
+    let tmp = tempfile::tempdir().unwrap();
+    let home = tmp.path();
+    let root = repo(home);
+    git_ok(home, &root, &["worktree", "add", "--quiet", "../armer"]);
+    git_ok(home, &root, &["worktree", "add", "--quiet", "../reader"]);
+    let armer = home.join("armer");
+    let reader = home.join("reader");
+
+    // The package is installed and armed in one linked work tree. Neither
+    // the main checkout nor the other work tree carries a copy.
+    std::fs::create_dir_all(armer.join(".agents")).unwrap();
+    install_package(home, &armer, &["growth-guards"]);
+    let armed = run(home, &armer, "kendex", &["guard", "install"]);
+    assert!(armed.status.success(), "{}", said(&armed));
+
+    // The reader is a project of its own with no copy and no record of one
+    // — everything the diagnosis sees short of the sibling.
+    std::fs::create_dir_all(reader.join(".agents")).unwrap();
+    std::fs::write(reader.join("kendex.toml"), "schema = 6\n").unwrap();
+    assert!(!root.join(".agents/skills/growth-guards").exists());
+    assert!(!reader.join(".agents/skills/growth-guards").exists());
+
+    let out = run(home, &reader, "kendex", &["check"]);
+    assert_eq!(
+        out.status.code(),
+        Some(0),
+        "the sibling's copy went unfound: {}",
+        said(&out)
+    );
+    assert!(!said(&out).contains("commit hooks"), "{}", said(&out));
+
+    // The must-fail control: with every copy gone the shims really are
+    // stranded, and the same reader says so by file. Every skills root and
+    // links as well as trees, because an install fans out to each tool
+    // directory the work tree has and links the rest at the first.
+    for base in kendex_core::guard::SEARCH_ROOTS {
+        let copy = armer.join(base).join(kendex_core::guard::SKILL);
+        match copy.is_symlink() {
+            true => std::fs::remove_file(&copy).unwrap(),
+            false if copy.exists() => std::fs::remove_dir_all(&copy).unwrap(),
+            false => {}
+        }
+    }
+    let out = run(home, &reader, "kendex", &["check"]);
+    assert_eq!(out.status.code(), Some(1), "{}", said(&out));
+    let text = said(&out);
+    assert!(
+        text.contains("installed in no project of this repository"),
+        "{text}"
+    );
+    let hooks = root.canonicalize().unwrap().join(".git/hooks");
+    for file in ["pre-commit", "commit-msg", "kendex-guards"] {
+        assert!(
+            text.contains(&hooks.join(file).display().to_string()),
+            "{file} was not named:\n{text}"
+        );
+    }
+}
+
+/// A search domain that could not be read in full is a verdict that could
+/// not be taken, never a leftover.
+///
+/// "No copy anywhere" is the premise behind advice to delete a
+/// repository's hook files. A directory the walk cannot open holds an
+/// unknown number of copies, so folding it into "nothing here" makes the
+/// destructive half of the diagnosis fire on a repository nobody has
+/// looked at.
+#[cfg(unix)]
+#[test]
+#[allow(clippy::unwrap_used)]
+fn a_search_domain_it_cannot_read_is_could_not_check_not_a_leftover() {
+    use std::os::unix::fs::PermissionsExt;
+    let tmp = tempfile::tempdir().unwrap();
+    let home = tmp.path();
+    let root = repo(home);
+    std::fs::write(root.join("kendex.toml"), "schema = 6\n").unwrap();
+    install_package_undeclared(&root, &["growth-guards"]);
+    arm_by_hand(&root);
+    std::fs::remove_dir_all(root.join(".agents/skills/growth-guards")).unwrap();
+
+    // The control: with the whole tree readable, this is the drift verdict
+    // that names the files to delete.
+    let out = said(&run(home, &root, "kendex", &["check"]));
+    assert!(
+        out.contains("installed in no project of this repository"),
+        "{out}"
+    );
+
+    // One directory of the domain, unopenable. Nothing else changes.
+    let locked = root.join("locked");
+    std::fs::create_dir(&locked).unwrap();
+    std::fs::set_permissions(&locked, std::fs::Permissions::from_mode(0o000)).unwrap();
+    if std::fs::read_dir(&locked).is_ok() {
+        // Permission bits do not stop this process — running as root, where
+        // there is no unreadable directory to build.
+        std::fs::set_permissions(&locked, std::fs::Permissions::from_mode(0o755)).unwrap();
+        return;
+    }
+    let out = run(home, &root, "kendex", &["check"]);
+    let text = said(&out);
+    let code = out.status.code();
+    std::fs::set_permissions(&locked, std::fs::Permissions::from_mode(0o755)).unwrap();
+
+    assert_eq!(code, Some(2), "could-not-check was not reported: {text}");
+    assert!(
+        !text.contains("installed in no project of this repository"),
+        "an unreadable directory read as a repository with no copy:\n{text}"
+    );
+    assert!(
+        text.contains(&locked.display().to_string()),
+        "the directory it could not read is not named:\n{text}"
+    );
+}

--- a/crates/cli/tests/install_ux/guarding.rs
+++ b/crates/cli/tests/install_ux/guarding.rs
@@ -199,6 +199,177 @@ fn removing_the_package_disarms_the_repository_first() {
     assert!(ok.status.success(), "{}", spoke(&ok));
 }
 
+/// A project that is not a git work tree has nothing armed to undo, and
+/// removing the package from it does not run an uninstaller that would
+/// refuse the directory.
+///
+/// The disclosure already stands down there — an effect writing into `.git`
+/// is not offered where the git directory cannot be resolved — so the
+/// removal has to stand down the same way, or every removal from a plain
+/// directory fails over hooks it never had.
+#[test]
+#[allow(clippy::unwrap_used)]
+fn removing_from_a_plain_directory_runs_no_uninstaller() {
+    let world = World::new(&["claude"]);
+    world.declare_catalog();
+    offer(&world, "growth-guards");
+    fs::remove_dir_all(world.at(".git")).unwrap();
+    let added = world.try_run(&["add", "cat", "--skill", "growth-guards", "-y"]);
+    assert!(added.status.success(), "{}", spoke(&added));
+
+    let removed = world.try_run(&["remove", "growth-guards"]);
+    let out = spoke(&removed);
+    assert!(removed.status.success(), "{out}");
+    assert!(!out.contains("running scripts/install-git-hooks"), "{out}");
+    assert!(out.contains("not inside a git work tree"), "{out}");
+    assert!(
+        !world.at(".agents/skills/growth-guards").exists(),
+        "the package stayed:\n{out}"
+    );
+}
+
+/// A copy delivery writes the package into the tool's own directory and
+/// the shared tree may not exist at all; the removal still finds the
+/// declaration and disarms.
+#[test]
+#[allow(clippy::unwrap_used)]
+fn removing_a_copied_package_disarms_the_repository_too() {
+    let world = World::new(&["claude"]);
+    world.declare_catalog();
+    offer(&world, "growth-guards");
+    let out = world.run(&[
+        "add",
+        "cat",
+        "--skill",
+        "growth-guards",
+        "-y",
+        "--copy",
+        "--allow-repo-effects",
+    ]);
+    assert!(
+        world.at(".claude/skills/growth-guards/SKILL.md").is_file(),
+        "no copy in the tool's directory:\n{out}"
+    );
+    assert!(world.at(".git/hooks/kendex-guards").is_file(), "{out}");
+
+    let out = world.run(&["remove", "growth-guards"]);
+    assert!(
+        out.contains("growth-guards: running scripts/install-git-hooks --uninstall"),
+        "{out}"
+    );
+    assert!(!world.at(".claude/skills/growth-guards").exists(), "{out}");
+    assert!(!world.at(".git/hooks/kendex-guards").exists(), "{out}");
+    fs::write(world.at("late.txt"), "fine\n").unwrap();
+    git_without_kendex(&world.project, &["add", "-A"]);
+    let ok = git_without_kendex(&world.project, &["commit", "-m", "feat: after removal"]);
+    assert!(ok.status.success(), "{}", spoke(&ok));
+}
+
+/// An uninstaller that fails stops the removal with the package still
+/// installed: the other order trashes the scripts and leaves exactly the
+/// stranded state this exists to prevent.
+#[test]
+#[allow(clippy::unwrap_used)]
+fn a_failing_uninstaller_keeps_the_package_installed() {
+    use std::os::unix::fs::PermissionsExt;
+    let world = World::new(&["claude"]);
+    world.declare_catalog();
+    offer(&world, "growth-guards");
+    // The catalog's installer, wrapped: everything passes through except
+    // the uninstall, which refuses.
+    let installer = world
+        .catalog
+        .join("skills/growth-guards/scripts/install-git-hooks");
+    let real = installer.with_file_name("install-git-hooks.real");
+    fs::rename(&installer, &real).unwrap();
+    fs::write(
+        &installer,
+        "#!/usr/bin/env bash\ncase \" $* \" in *\" --uninstall \"*) echo 'refusing to disarm' >&2; exit 1;; esac\nexec \"$(dirname \"$0\")/install-git-hooks.real\" \"$@\"\n",
+    )
+    .unwrap();
+    fs::set_permissions(&installer, fs::Permissions::from_mode(0o755)).unwrap();
+    world.run(&[
+        "add",
+        "cat",
+        "--skill",
+        "growth-guards",
+        "-y",
+        "--allow-repo-effects",
+    ]);
+    assert!(world.at(".git/hooks/kendex-guards").is_file());
+
+    let removed = world.try_run(&["remove", "growth-guards"]);
+    let out = spoke(&removed);
+    assert!(!removed.status.success(), "the removal went ahead:\n{out}");
+    assert!(out.contains("refusing to disarm"), "{out}");
+    assert!(out.contains("exited 1"), "{out}");
+    assert!(out.contains("its files stay in place"), "{out}");
+    assert!(
+        world.at(".agents/skills/growth-guards").is_dir(),
+        "the scripts were trashed:\n{out}"
+    );
+    assert!(
+        world.manifest().contains("[skills.growth-guards]"),
+        "the declaration went:\n{}",
+        world.manifest()
+    );
+    assert!(
+        world.at(".git/hooks/kendex-guards").is_file(),
+        "the helper went while the uninstall refused:\n{out}"
+    );
+}
+
+/// A package can leave without `remove` being the verb. A manifest edited
+/// by hand and applied takes the package away, and the uninstaller runs
+/// there too, while the scripts are still on disk.
+#[test]
+#[allow(clippy::unwrap_used)]
+fn applying_a_manifest_without_the_package_disarms_first() {
+    let world = World::new(&["claude"]);
+    world.declare_catalog();
+    offer(&world, "growth-guards");
+    world.run(&[
+        "add",
+        "cat",
+        "--skill",
+        "growth-guards",
+        "-y",
+        "--allow-repo-effects",
+    ]);
+    assert!(world.at(".git/hooks/kendex-guards").is_file());
+
+    let manifest = world.manifest();
+    assert!(manifest.contains("[skills.growth-guards]"), "{manifest}");
+    let mut kept = String::new();
+    let mut dropping = false;
+    for line in manifest.lines() {
+        if line.trim() == "[skills.growth-guards]" {
+            dropping = true;
+            continue;
+        }
+        if dropping && line.starts_with('[') {
+            dropping = false;
+        }
+        if !dropping {
+            kept.push_str(line);
+            kept.push('\n');
+        }
+    }
+    fs::write(world.at("kendex.toml"), kept).unwrap();
+
+    let out = world.run(&["apply", "-y"]);
+    assert!(
+        out.contains("growth-guards: running scripts/install-git-hooks --uninstall"),
+        "{out}"
+    );
+    assert!(!world.at(".agents/skills/growth-guards").exists(), "{out}");
+    assert!(!world.at(".git/hooks/kendex-guards").exists(), "{out}");
+    fs::write(world.at("late.txt"), "fine\n").unwrap();
+    git_without_kendex(&world.project, &["add", "-A"]);
+    let ok = git_without_kendex(&world.project, &["commit", "-m", "feat: after apply"]);
+    assert!(ok.status.success(), "{}", spoke(&ok));
+}
+
 /// `kendex check` names an unarmed repository, in the package's own words,
 /// and says nothing once it is armed.
 #[test]

--- a/crates/cli/tests/install_ux/guarding.rs
+++ b/crates/cli/tests/install_ux/guarding.rs
@@ -149,6 +149,56 @@ fn disarming_before_removal_leaves_the_repository_committable() {
     assert!(ok.status.success(), "{}", spoke(&ok));
 }
 
+/// `kendex remove` disarms the repository itself, before the package's
+/// files go, and says what it ran.
+///
+/// The package declares an uninstaller, and the only moment it can run is
+/// while the script is still on disk. Removing the files first left the
+/// shims pointing at nothing, and a repository nobody could commit to until
+/// they found two files under `.git/hooks` by hand.
+#[test]
+#[allow(clippy::unwrap_used)]
+fn removing_the_package_disarms_the_repository_first() {
+    let world = World::new(&["claude"]);
+    world.declare_catalog();
+    offer(&world, "growth-guards");
+    world.run(&[
+        "add",
+        "cat",
+        "--skill",
+        "growth-guards",
+        "-y",
+        "--allow-repo-effects",
+    ]);
+    assert!(world.at(".git/hooks/kendex-guards").is_file());
+
+    let out = world.run(&["remove", "growth-guards"]);
+    assert!(
+        out.contains("growth-guards: running scripts/install-git-hooks --uninstall"),
+        "the removal did not say what it ran:\n{out}"
+    );
+    assert!(
+        !world.at(".agents/skills/growth-guards").exists(),
+        "the package stayed:\n{out}"
+    );
+    assert!(
+        !world.at(".git/hooks/kendex-guards").exists(),
+        "the helper was left behind:\n{out}"
+    );
+    let hook = world.at(".git/hooks/pre-commit");
+    assert!(
+        !hook.exists() || !read(&hook).contains("kendex-guards-hook"),
+        "the delegating line was left behind:\n{out}"
+    );
+
+    // What the leftover would have cost: a commit, with no kendex in the
+    // picture.
+    fs::write(world.at("late.txt"), "fine\n").unwrap();
+    git_without_kendex(&world.project, &["add", "-A"]);
+    let ok = git_without_kendex(&world.project, &["commit", "-m", "feat: after removal"]);
+    assert!(ok.status.success(), "{}", spoke(&ok));
+}
+
 /// `kendex check` names an unarmed repository, in the package's own words,
 /// and says nothing once it is armed.
 #[test]

--- a/crates/cli/tests/install_ux/guarding.rs
+++ b/crates/cli/tests/install_ux/guarding.rs
@@ -265,6 +265,64 @@ fn removing_a_copied_package_disarms_the_repository_too() {
     assert!(ok.status.success(), "{}", spoke(&ok));
 }
 
+/// Switching an installation off renames its declaration and disarms
+/// nothing, so a package that was installed, armed, then disabled still
+/// has live shims — and removing it has to run the uninstaller like any
+/// other removal.
+///
+/// Probing only `SKILL.md` read this package as one that declares
+/// nothing, and the removal took the scripts out from under the shims.
+#[test]
+#[allow(clippy::unwrap_used)]
+fn removing_a_disabled_package_disarms_the_repository_too() {
+    let world = World::new(&["claude"]);
+    world.declare_catalog();
+    offer(&world, "growth-guards");
+    world.run(&[
+        "add",
+        "cat",
+        "--skill",
+        "growth-guards",
+        "-y",
+        "--allow-repo-effects",
+    ]);
+    assert!(world.at(".git/hooks/kendex-guards").is_file());
+
+    // Switch it off, the way the manifest says it: the declaration is
+    // renamed and the shims are left exactly where they were.
+    world.declare_no_items(&["claude"]);
+    let off_manifest = format!(
+        "{}\n[skills.growth-guards]\nsource = \"cat\"\nenabled = false\n",
+        world.manifest()
+    );
+    fs::write(world.at("kendex.toml"), off_manifest).unwrap();
+    let off = world.run(&["apply", "-y"]);
+    let tree = world.at(".agents/skills/growth-guards");
+    assert!(
+        tree.join("SKILL.md.disabled").is_file() && !tree.join("SKILL.md").exists(),
+        "the switch did not rename the declaration:\n{off}"
+    );
+    assert!(
+        world.at(".git/hooks/kendex-guards").is_file(),
+        "nothing disarms on the switch:\n{off}"
+    );
+
+    let out = world.run(&["remove", "growth-guards"]);
+    assert!(
+        out.contains("growth-guards: running scripts/install-git-hooks --uninstall"),
+        "the removal did not say what it ran:\n{out}"
+    );
+    assert!(!world.at(".agents/skills/growth-guards").exists(), "{out}");
+    assert!(
+        !world.at(".git/hooks/kendex-guards").exists(),
+        "the helper was left behind:\n{out}"
+    );
+    fs::write(world.at("late.txt"), "fine\n").unwrap();
+    git_without_kendex(&world.project, &["add", "-A"]);
+    let ok = git_without_kendex(&world.project, &["commit", "-m", "feat: after removal"]);
+    assert!(ok.status.success(), "{}", spoke(&ok));
+}
+
 /// An uninstaller that fails stops the removal with the package still
 /// installed: the other order trashes the scripts and leaves exactly the
 /// stranded state this exists to prevent.
@@ -338,24 +396,14 @@ fn applying_a_manifest_without_the_package_disarms_first() {
     ]);
     assert!(world.at(".git/hooks/kendex-guards").is_file());
 
-    let manifest = world.manifest();
-    assert!(manifest.contains("[skills.growth-guards]"), "{manifest}");
-    let mut kept = String::new();
-    let mut dropping = false;
-    for line in manifest.lines() {
-        if line.trim() == "[skills.growth-guards]" {
-            dropping = true;
-            continue;
-        }
-        if dropping && line.starts_with('[') {
-            dropping = false;
-        }
-        if !dropping {
-            kept.push_str(line);
-            kept.push('\n');
-        }
-    }
-    fs::write(world.at("kendex.toml"), kept).unwrap();
+    assert!(
+        world.manifest().contains("[skills.growth-guards]"),
+        "{}",
+        world.manifest()
+    );
+    // The manifest a hand edit arrives at: the source and the tools the
+    // add wrote, and no package.
+    world.declare_no_items(&["claude"]);
 
     let out = world.run(&["apply", "-y"]);
     assert!(

--- a/crates/cli/tests/install_ux/main.rs
+++ b/crates/cli/tests/install_ux/main.rs
@@ -143,6 +143,27 @@ impl World {
         );
     }
 
+    /// The manifest with the catalog and the tools, and no items — what a
+    /// hand edit that drops every package arrives at.
+    ///
+    /// Built here rather than by editing the generated text: dropping a
+    /// table line by line reads a multiline string's contents as structure.
+    pub fn declare_no_items(&self, harnesses: &[&str]) {
+        let tools = harnesses
+            .iter()
+            .map(|harness| format!("\"{harness}\""))
+            .collect::<Vec<_>>()
+            .join(", ");
+        write(
+            &self.project.join("kendex.toml"),
+            &format!(
+                "schema = 6\n\n[sources.cat]\npath = \"{}\"\nenabled = true\n\n\
+                 [install]\nharnesses = [{tools}]\nmethod = \"symlink\"\n",
+                self.catalog.display()
+            ),
+        );
+    }
+
     pub fn run(&self, args: &[&str]) -> String {
         run(&self.home, &self.project, args)
     }

--- a/crates/core/src/discover.rs
+++ b/crates/core/src/discover.rs
@@ -70,6 +70,37 @@ pub fn discover_projects(root: &Path) -> Result<Vec<PathBuf>> {
     Ok(found.into_iter().collect())
 }
 
+/// Whether any directory under `root` satisfies `found`, `root` included.
+///
+/// The same pruning as the project walk — hidden directories, the build
+/// and dependency trees in `SKIP_DIRS`, symlinked directories — and none
+/// of its stopping rules: it does not stop at a project, because what it
+/// looks for may sit inside one (a nested project's skills directory under
+/// a repository whose root is itself a project), and it has no depth cap,
+/// because a copy at depth six is a copy. `found` is asked before the
+/// descent, so the first hit ends the walk.
+pub fn any_dir(root: &Path, found: &mut dyn FnMut(&Path) -> bool) -> bool {
+    if found(root) {
+        return true;
+    }
+    let Ok(entries) = fs::read_dir(root) else {
+        return false;
+    };
+    for entry in entries.flatten() {
+        let path = entry.path();
+        let Some(name) = path.file_name().and_then(|n| n.to_str()) else {
+            continue;
+        };
+        if name.starts_with('.') || SKIP_DIRS.contains(&name) {
+            continue;
+        }
+        if path.is_dir() && !path.is_symlink() && any_dir(&path, found) {
+            return true;
+        }
+    }
+    false
+}
+
 fn walk(dir: &Path, depth: usize, found: &mut BTreeSet<PathBuf>) {
     if is_project(dir) {
         if let Ok(canonical) = dir.canonicalize() {

--- a/crates/core/src/discover.rs
+++ b/crates/core/src/discover.rs
@@ -94,7 +94,10 @@ pub fn any_dir(root: &Path, found: &mut dyn FnMut(&Path) -> bool) -> bool {
         if name.starts_with('.') || SKIP_DIRS.contains(&name) {
             continue;
         }
-        if path.is_dir() && !path.is_symlink() && any_dir(&path, found) {
+        // `file_type` does not follow the link, so a symlinked directory
+        // reads as not-a-directory and is pruned by the same test — one
+        // stat off the entry rather than two off the path.
+        if entry.file_type().is_ok_and(|kind| kind.is_dir()) && any_dir(&path, found) {
             return true;
         }
     }

--- a/crates/core/src/discover.rs
+++ b/crates/core/src/discover.rs
@@ -79,14 +79,57 @@ pub fn discover_projects(root: &Path) -> Result<Vec<PathBuf>> {
 /// a repository whose root is itself a project), and it has no depth cap,
 /// because a copy at depth six is a copy. `found` is asked before the
 /// descent, so the first hit ends the walk.
-pub fn any_dir(root: &Path, found: &mut dyn FnMut(&Path) -> bool) -> bool {
-    if found(root) {
+///
+/// A part of the domain that could not be traversed is reported, never
+/// counted as empty. `guard::stranded` turns "found nothing" into advice to
+/// delete a repository's hook files, and a directory that would not open is
+/// not a directory with nothing in it — so the negative is returned only
+/// where the whole domain was actually looked at, and a caller that folds
+/// the error tells its reader the state could not be determined instead.
+///
+/// A hit still wins: the walk carries the first failure along rather than
+/// stopping on it, so a copy behind a readable branch is found whatever
+/// else in the tree could not be read.
+pub fn any_dir(root: &Path, found: &mut dyn FnMut(&Path) -> bool) -> Result<bool> {
+    let mut unreadable = None;
+    if walk_any(root, found, &mut unreadable) {
+        return Ok(true);
+    }
+    match unreadable {
+        Some(error) => Err(error),
+        None => Ok(false),
+    }
+}
+
+/// The walk itself: `true` at the first hit, with the first thing it could
+/// not read left in `unreadable`. The first and not all of them, because
+/// one unreadable directory and twenty are the same answer to the caller —
+/// the domain was not fully seen — and one path is what a reader acts on.
+fn walk_any(
+    dir: &Path,
+    found: &mut dyn FnMut(&Path) -> bool,
+    unreadable: &mut Option<CoreError>,
+) -> bool {
+    if found(dir) {
         return true;
     }
-    let Ok(entries) = fs::read_dir(root) else {
-        return false;
+    let entries = match fs::read_dir(dir) {
+        Ok(entries) => entries,
+        Err(error) => {
+            unreadable.get_or_insert_with(|| CoreError::io(dir, error));
+            return false;
+        }
     };
-    for entry in entries.flatten() {
+    for entry in entries {
+        // A directory that opened and then failed mid-iteration is as
+        // unseen as one that never opened.
+        let entry = match entry {
+            Ok(entry) => entry,
+            Err(error) => {
+                unreadable.get_or_insert_with(|| CoreError::io(dir, error));
+                continue;
+            }
+        };
         let path = entry.path();
         let Some(name) = path.file_name().and_then(|n| n.to_str()) else {
             continue;
@@ -96,9 +139,20 @@ pub fn any_dir(root: &Path, found: &mut dyn FnMut(&Path) -> bool) -> bool {
         }
         // `file_type` does not follow the link, so a symlinked directory
         // reads as not-a-directory and is pruned by the same test — one
-        // stat off the entry rather than two off the path.
-        if entry.file_type().is_ok_and(|kind| kind.is_dir()) && any_dir(&path, found) {
-            return true;
+        // stat off the entry rather than two off the path. An entry whose
+        // type could not be read might have been a directory holding what
+        // is being looked for, so it counts as unseen rather than as a
+        // file.
+        match entry.file_type() {
+            Ok(kind) if kind.is_dir() => {
+                if walk_any(&path, found, unreadable) {
+                    return true;
+                }
+            }
+            Ok(_) => {}
+            Err(error) => {
+                unreadable.get_or_insert_with(|| CoreError::io(&path, error));
+            }
         }
     }
     false

--- a/crates/core/src/engine/mod.rs
+++ b/crates/core/src/engine/mod.rs
@@ -219,6 +219,7 @@ fn plan_scope_once(
     plan_config_edits(env, scope, config_edits, &mut ops)?;
     let set_changes = set_changes(scope, lock, &new_lock);
     let kept = kept_members(scope, lock, &new_lock, &options.uninstalled_bundles);
+    let repo_effects_leaving = repo_effects::leaving(env, scope, lock, &new_lock);
     plan_lock_write(env, scope, disk_lock, new_lock, &mut ops)?;
     moved_notes.extend(scope_wide(scope, &mut ops)?);
 
@@ -227,6 +228,7 @@ fn plan_scope_once(
         // moves in: an effect belongs to a package this pass adds to what
         // the scope carries, and to no other.
         repo_effects: repo_effects::run(&state, &drift, &set_changes, lock),
+        repo_effects_leaving,
         drift,
         plan: Plan {
             scope: scope.clone(),
@@ -358,6 +360,7 @@ pub fn plan_apply(env: &Env, scope: &Scope, options: &PlanOptions) -> Result<Eng
         kept: Vec::new(),
         safety: Vec::new(),
         repo_effects: Vec::new(),
+        repo_effects_leaving: Vec::new(),
     };
     // One fact, said once: files this build will read but not write. Which
     // of the two is legacy is kendex's problem, not the reader's.

--- a/crates/core/src/engine/mod.rs
+++ b/crates/core/src/engine/mod.rs
@@ -219,7 +219,7 @@ fn plan_scope_once(
     plan_config_edits(env, scope, config_edits, &mut ops)?;
     let set_changes = set_changes(scope, lock, &new_lock);
     let kept = kept_members(scope, lock, &new_lock, &options.uninstalled_bundles);
-    let repo_effects_leaving = repo_effects::leaving(env, scope, lock, &new_lock);
+    let repo_effects_leaving = repo_effects::leaving(env, scope, lock, &new_lock)?;
     plan_lock_write(env, scope, disk_lock, new_lock, &mut ops)?;
     moved_notes.extend(scope_wide(scope, &mut ops)?);
 

--- a/crates/core/src/engine/repo_effects.rs
+++ b/crates/core/src/engine/repo_effects.rs
@@ -18,7 +18,7 @@ use crate::env::Env;
 use crate::model::{ItemKind, Scope};
 use crate::repo_effects::{DeclaredEffects, declared};
 
-use super::desired::{Artifact, DesiredState, skill_canonical};
+use super::desired::{Artifact, DesiredState, read_dirs, skill_canonical};
 use super::report_types::{DriftCause, DriftRow};
 use super::set_change::{SetChange, SetDirection};
 
@@ -148,10 +148,10 @@ fn blocked(drift: &[DriftRow], name: &str) -> bool {
 /// Read off the tree on disk, not off the desired state, because the
 /// desired state no longer has the item — that is what leaving means. The
 /// tree is still there while this plan is only planned, which is the whole
-/// window a removal has to run the uninstaller in: once the plan executes
-/// the scripts are gone, and shims that exec a script that is not there
-/// fail every commit closed. A tree already missing declares nothing here;
-/// what it left armed is `guard::stranded`'s to report.
+/// window the CLI has to run the uninstaller in: once the plan executes the
+/// scripts are gone, and shims that exec a script that is not there fail
+/// every commit closed. A tree already missing declares nothing here; what
+/// it left armed is `guard::stranded`'s to report.
 ///
 /// Empty outside a project. An effect is a change to a repository, and the
 /// global scope is not one; `run_script` refuses it.
@@ -164,31 +164,66 @@ pub(super) fn leaving(
     if !matches!(scope, Scope::Project { .. }) {
         return Vec::new();
     }
-    let skills = |lock: &crate::lock::Lock| -> BTreeSet<String> {
-        lock.entries
-            .values()
-            .filter(|entry| entry.kind == ItemKind::Skill)
-            .map(|entry| entry.name.clone())
-            .collect()
-    };
-    let staying = skills(after);
+    let staying = skill_names(after);
     let mut found: BTreeMap<String, DeclaredEffects> = BTreeMap::new();
-    for name in skills(before).difference(&staying) {
-        let root = skill_canonical(env, scope, name);
-        let Ok(Some(text)) = crate::fs::read_if_exists(&root.join("SKILL.md")) else {
+    for name in skill_names(before).difference(&staying) {
+        let Some((root, text)) = installed_tree(env, scope, before, name) else {
             continue;
         };
         let Some(effects) = declared(&text) else {
             continue;
         };
         found.insert(
-            name.clone(),
+            (*name).to_owned(),
             DeclaredEffects {
-                name: name.clone(),
+                name: (*name).to_owned(),
                 root,
                 effects,
             },
         );
     }
     found.into_values().collect()
+}
+
+/// The packages a lock carries, by name: the package, not any tool's copy
+/// of it. A lock row is per harness, and an effect belongs to the package —
+/// so both directions ask whether the NAME is in the scope, never whether
+/// one tool's row is.
+fn skill_names(lock: &crate::lock::Lock) -> BTreeSet<&str> {
+    lock.entries
+        .values()
+        .filter(|entry| entry.kind == ItemKind::Skill)
+        .map(|entry| entry.name.as_str())
+        .collect()
+}
+
+/// Where a departing package's tree sits on disk, and its `SKILL.md`.
+///
+/// The shared tree first, then every directory the departing rows' own
+/// tools read skills from: a copy delivery writes the package into the
+/// tool's own directory and the shared tree may not exist at all, so
+/// reading only `.agents/skills` found no declaration for exactly the
+/// install whose scripts were about to be trashed. The first copy that
+/// carries a `SKILL.md` is the one whose scripts run.
+fn installed_tree(
+    env: &Env,
+    scope: &Scope,
+    before: &crate::lock::Lock,
+    name: &str,
+) -> Option<(std::path::PathBuf, String)> {
+    let canonical = crate::harness::canonical_name(name);
+    let mut candidates = vec![skill_canonical(env, scope, name)];
+    for entry in before
+        .entries
+        .values()
+        .filter(|entry| entry.kind == ItemKind::Skill && entry.name == name)
+    {
+        for dir in read_dirs(env, scope, entry.harness, ItemKind::Skill) {
+            candidates.push(dir.join(&canonical));
+        }
+    }
+    candidates.into_iter().find_map(|root| {
+        let text = crate::fs::read_if_exists(&root.join("SKILL.md")).ok()??;
+        Some((root, text))
+    })
 }

--- a/crates/core/src/engine/repo_effects.rs
+++ b/crates/core/src/engine/repo_effects.rs
@@ -14,10 +14,11 @@
 
 use std::collections::{BTreeMap, BTreeSet};
 
-use crate::model::ItemKind;
+use crate::env::Env;
+use crate::model::{ItemKind, Scope};
 use crate::repo_effects::{DeclaredEffects, declared};
 
-use super::desired::{Artifact, DesiredState};
+use super::desired::{Artifact, DesiredState, skill_canonical};
 use super::report_types::{DriftCause, DriftRow};
 use super::set_change::{SetChange, SetDirection};
 
@@ -134,4 +135,60 @@ fn blocked(drift: &[DriftRow], name: &str) -> bool {
         .iter()
         .filter(|row| row.kind == ItemKind::Skill && row.name == name)
         .any(|row| row.dead_stop() || row.cause.is_some_and(DriftCause::holds_the_write))
+}
+
+/// Every declared effect this plan takes out of the scope, once per
+/// package — the other direction of [`run`].
+///
+/// A package leaves when no harness's copy of it survives in the lock this
+/// pass writes. That is the package-level question, the same one the add
+/// side asks: a copy dropped for one tool while another keeps it is a
+/// package still installed, and its effect still wanted.
+///
+/// Read off the tree on disk, not off the desired state, because the
+/// desired state no longer has the item — that is what leaving means. The
+/// tree is still there while this plan is only planned, which is the whole
+/// window a removal has to run the uninstaller in: once the plan executes
+/// the scripts are gone, and shims that exec a script that is not there
+/// fail every commit closed. A tree already missing declares nothing here;
+/// what it left armed is `guard::stranded`'s to report.
+///
+/// Empty outside a project. An effect is a change to a repository, and the
+/// global scope is not one; `run_script` refuses it.
+pub(super) fn leaving(
+    env: &Env,
+    scope: &Scope,
+    before: &crate::lock::Lock,
+    after: &crate::lock::Lock,
+) -> Vec<DeclaredEffects> {
+    if !matches!(scope, Scope::Project { .. }) {
+        return Vec::new();
+    }
+    let skills = |lock: &crate::lock::Lock| -> BTreeSet<String> {
+        lock.entries
+            .values()
+            .filter(|entry| entry.kind == ItemKind::Skill)
+            .map(|entry| entry.name.clone())
+            .collect()
+    };
+    let staying = skills(after);
+    let mut found: BTreeMap<String, DeclaredEffects> = BTreeMap::new();
+    for name in skills(before).difference(&staying) {
+        let root = skill_canonical(env, scope, name);
+        let Ok(Some(text)) = crate::fs::read_if_exists(&root.join("SKILL.md")) else {
+            continue;
+        };
+        let Some(effects) = declared(&text) else {
+            continue;
+        };
+        found.insert(
+            name.clone(),
+            DeclaredEffects {
+                name: name.clone(),
+                root,
+                effects,
+            },
+        );
+    }
+    found.into_values().collect()
 }

--- a/crates/core/src/engine/repo_effects.rs
+++ b/crates/core/src/engine/repo_effects.rs
@@ -258,15 +258,20 @@ fn installed_tree(
     before: &crate::lock::Lock,
     name: &str,
 ) -> Result<Option<Installed>> {
-    let canonical = crate::harness::canonical_name(name);
     let mut candidates = vec![skill_canonical(env, scope, name)];
     for entry in before
         .entries
         .values()
         .filter(|entry| entry.kind == ItemKind::Skill && entry.name == name)
     {
+        // The name a harness's own directory holds is that harness's, not
+        // the shared tree's: `rendered_name` joins a namespaced name with
+        // the separator this tool will load, which is a hyphen wherever
+        // names must be lower-kebab. Probing every directory under the
+        // canonical spelling found nothing for exactly those installs.
+        let rendered = crate::harness::rendered_name(entry.harness, name);
         for dir in read_dirs(env, scope, entry.harness, ItemKind::Skill) {
-            candidates.push(dir.join(&canonical));
+            candidates.push(dir.join(&rendered));
         }
     }
     for root in candidates {
@@ -285,82 +290,4 @@ fn installed_tree(
 }
 
 #[cfg(all(test, unix))]
-mod tests {
-    use std::fs;
-    use std::os::unix::fs::PermissionsExt;
-
-    use super::*;
-    use crate::env::FakeOs;
-
-    /// A switched-off installation keeps its declaration under the
-    /// `.disabled` name, and it is the same declaration: the removal that
-    /// finds it is the one that runs the uninstaller before the scripts go.
-    #[test]
-    #[allow(clippy::unwrap_used)]
-    fn a_switched_off_installation_still_declares_what_it_armed() {
-        let tmp = tempfile::tempdir().unwrap();
-        let home = tmp.path().to_path_buf();
-        let env = Env::fake(&home, FakeOs::Linux);
-        let root = home.join("dev/app");
-        let scope = Scope::Project { root: root.clone() };
-        let lock = crate::lock::Lock::default();
-
-        let tree = root.join(".agents/skills/armer");
-        fs::create_dir_all(&tree).unwrap();
-        fs::write(
-            tree.join("SKILL.md.disabled"),
-            "---\nname: armer\n---\nBody.\n",
-        )
-        .unwrap();
-
-        let found = installed_tree(&env, &scope, &lock, "armer").unwrap();
-        let found = found.expect("the disabled declaration was read as an absent one");
-        assert_eq!(found.root, tree);
-        assert_eq!(found.declaration, tree.join("SKILL.md.disabled"));
-        assert!(found.text.contains("name: armer"), "{}", found.text);
-    }
-
-    /// A candidate with no `SKILL.md` is a candidate to move past; a
-    /// candidate whose `SKILL.md` will not read is the end of the search.
-    ///
-    /// Swallowing the read spelled the second case as the first, and the
-    /// caller reads that as "this package declares nothing" — which is how
-    /// a removal takes a package's scripts away with its hook shims still
-    /// delegating to them. The lock is empty, so the canonical tree is the
-    /// only candidate and the answer is about the read, nothing else.
-    #[test]
-    #[allow(clippy::unwrap_used)]
-    fn an_unreadable_declaration_is_an_error_not_an_absent_one() {
-        let tmp = tempfile::tempdir().unwrap();
-        let home = tmp.path().to_path_buf();
-        let env = Env::fake(&home, FakeOs::Linux);
-        let root = home.join("dev/app");
-        let scope = Scope::Project { root: root.clone() };
-        let lock = crate::lock::Lock::default();
-
-        assert!(
-            installed_tree(&env, &scope, &lock, "armer")
-                .unwrap()
-                .is_none(),
-            "a tree that is not there declares nothing"
-        );
-
-        let tree = root.join(".agents/skills/armer");
-        fs::create_dir_all(&tree).unwrap();
-        let declaration = tree.join("SKILL.md");
-        fs::write(&declaration, "---\nname: armer\n---\nBody.\n").unwrap();
-        let readable = installed_tree(&env, &scope, &lock, "armer").unwrap();
-        assert_eq!(readable.map(|found| found.root), Some(tree));
-
-        fs::set_permissions(&declaration, fs::Permissions::from_mode(0o000)).unwrap();
-        // Root reads a mode-000 file, so there is no unreadable file to make.
-        if fs::read_to_string(&declaration).is_ok() {
-            return;
-        }
-        let err = installed_tree(&env, &scope, &lock, "armer").unwrap_err();
-        assert!(
-            err.to_string().contains("SKILL.md"),
-            "the error did not name the file it could not read: {err}"
-        );
-    }
-}
+mod tests;

--- a/crates/core/src/engine/repo_effects.rs
+++ b/crates/core/src/engine/repo_effects.rs
@@ -201,18 +201,31 @@ fn skill_names(lock: &crate::lock::Lock) -> BTreeSet<&str> {
         .collect()
 }
 
-/// Where a departing package's tree sits on disk, and its `SKILL.md`.
+/// The two names an installed skill's declaration can sit under: the
+/// second is what a switched-off installation keeps its content as.
+const DECLARATION_NAMES: [&str; 2] = ["SKILL.md", "SKILL.md.disabled"];
+
+/// Where a departing package's tree sits on disk, and its declaration.
 ///
 /// The shared tree first, then every directory the departing rows' own
 /// tools read skills from: a copy delivery writes the package into the
 /// tool's own directory and the shared tree may not exist at all, so
 /// reading only `.agents/skills` found no declaration for exactly the
 /// install whose scripts were about to be trashed. The first copy that
-/// carries a `SKILL.md` is the one whose scripts run.
+/// carries a declaration is the one whose scripts run.
 ///
-/// A candidate with no `SKILL.md` is skipped; a candidate whose `SKILL.md`
-/// will not read is an error, because the alternative is to call a package
-/// that declares an uninstaller a package that declares nothing.
+/// Both spellings, because switching an installation off renames its
+/// `SKILL.md` to `SKILL.md.disabled` and nothing disarms on that switch:
+/// probing the enabled name alone read a package that was installed,
+/// armed, then disabled as a package that declares nothing, and the
+/// removal took its scripts out from under shims still delegating to
+/// them. A tree carrying both names never installs — `desired_skill`
+/// refuses it — so which one is read is not a question here.
+///
+/// A candidate with neither name is skipped; a candidate whose
+/// declaration will not read is an error, because the alternative is to
+/// call a package that declares an uninstaller a package that declares
+/// nothing.
 fn installed_tree(
     env: &Env,
     scope: &Scope,
@@ -231,8 +244,10 @@ fn installed_tree(
         }
     }
     for root in candidates {
-        if let Some(text) = crate::fs::read_if_exists(&root.join("SKILL.md"))? {
-            return Ok(Some((root, text)));
+        for file in DECLARATION_NAMES {
+            if let Some(text) = crate::fs::read_if_exists(&root.join(file))? {
+                return Ok(Some((root, text)));
+            }
         }
     }
     Ok(None)
@@ -245,6 +260,33 @@ mod tests {
 
     use super::*;
     use crate::env::FakeOs;
+
+    /// A switched-off installation keeps its declaration under the
+    /// `.disabled` name, and it is the same declaration: the removal that
+    /// finds it is the one that runs the uninstaller before the scripts go.
+    #[test]
+    #[allow(clippy::unwrap_used)]
+    fn a_switched_off_installation_still_declares_what_it_armed() {
+        let tmp = tempfile::tempdir().unwrap();
+        let home = tmp.path().to_path_buf();
+        let env = Env::fake(&home, FakeOs::Linux);
+        let root = home.join("dev/app");
+        let scope = Scope::Project { root: root.clone() };
+        let lock = crate::lock::Lock::default();
+
+        let tree = root.join(".agents/skills/armer");
+        fs::create_dir_all(&tree).unwrap();
+        fs::write(
+            tree.join("SKILL.md.disabled"),
+            "---\nname: armer\n---\nBody.\n",
+        )
+        .unwrap();
+
+        let found = installed_tree(&env, &scope, &lock, "armer").unwrap();
+        let (at, text) = found.expect("the disabled declaration was read as an absent one");
+        assert_eq!(at, tree);
+        assert!(text.contains("name: armer"), "{text}");
+    }
 
     /// A candidate with no `SKILL.md` is a candidate to move past; a
     /// candidate whose `SKILL.md` will not read is the end of the search.

--- a/crates/core/src/engine/repo_effects.rs
+++ b/crates/core/src/engine/repo_effects.rs
@@ -15,6 +15,7 @@
 use std::collections::{BTreeMap, BTreeSet};
 
 use crate::env::Env;
+use crate::error::Result;
 use crate::model::{ItemKind, Scope};
 use crate::repo_effects::{DeclaredEffects, declared};
 
@@ -151,7 +152,10 @@ fn blocked(drift: &[DriftRow], name: &str) -> bool {
 /// window the CLI has to run the uninstaller in: once the plan executes the
 /// scripts are gone, and shims that exec a script that is not there fail
 /// every commit closed. A tree already missing declares nothing here; what
-/// it left armed is `guard::stranded`'s to report.
+/// it left armed is `guard::stranded`'s to report. A tree that is there and
+/// cannot be read is neither: the error stops the plan with the package
+/// still installed, rather than reporting a declaration of nothing and
+/// letting the removal take the scripts out from under armed shims.
 ///
 /// Empty outside a project. An effect is a change to a repository, and the
 /// global scope is not one; `run_script` refuses it.
@@ -160,14 +164,14 @@ pub(super) fn leaving(
     scope: &Scope,
     before: &crate::lock::Lock,
     after: &crate::lock::Lock,
-) -> Vec<DeclaredEffects> {
+) -> Result<Vec<DeclaredEffects>> {
     if !matches!(scope, Scope::Project { .. }) {
-        return Vec::new();
+        return Ok(Vec::new());
     }
     let staying = skill_names(after);
     let mut found: BTreeMap<String, DeclaredEffects> = BTreeMap::new();
     for name in skill_names(before).difference(&staying) {
-        let Some((root, text)) = installed_tree(env, scope, before, name) else {
+        let Some((root, text)) = installed_tree(env, scope, before, name)? else {
             continue;
         };
         let Some(effects) = declared(&text) else {
@@ -182,7 +186,7 @@ pub(super) fn leaving(
             },
         );
     }
-    found.into_values().collect()
+    Ok(found.into_values().collect())
 }
 
 /// The packages a lock carries, by name: the package, not any tool's copy
@@ -205,12 +209,16 @@ fn skill_names(lock: &crate::lock::Lock) -> BTreeSet<&str> {
 /// reading only `.agents/skills` found no declaration for exactly the
 /// install whose scripts were about to be trashed. The first copy that
 /// carries a `SKILL.md` is the one whose scripts run.
+///
+/// A candidate with no `SKILL.md` is skipped; a candidate whose `SKILL.md`
+/// will not read is an error, because the alternative is to call a package
+/// that declares an uninstaller a package that declares nothing.
 fn installed_tree(
     env: &Env,
     scope: &Scope,
     before: &crate::lock::Lock,
     name: &str,
-) -> Option<(std::path::PathBuf, String)> {
+) -> Result<Option<(std::path::PathBuf, String)>> {
     let canonical = crate::harness::canonical_name(name);
     let mut candidates = vec![skill_canonical(env, scope, name)];
     for entry in before
@@ -222,8 +230,63 @@ fn installed_tree(
             candidates.push(dir.join(&canonical));
         }
     }
-    candidates.into_iter().find_map(|root| {
-        let text = crate::fs::read_if_exists(&root.join("SKILL.md")).ok()??;
-        Some((root, text))
-    })
+    for root in candidates {
+        if let Some(text) = crate::fs::read_if_exists(&root.join("SKILL.md"))? {
+            return Ok(Some((root, text)));
+        }
+    }
+    Ok(None)
+}
+
+#[cfg(all(test, unix))]
+mod tests {
+    use std::fs;
+    use std::os::unix::fs::PermissionsExt;
+
+    use super::*;
+    use crate::env::FakeOs;
+
+    /// A candidate with no `SKILL.md` is a candidate to move past; a
+    /// candidate whose `SKILL.md` will not read is the end of the search.
+    ///
+    /// Swallowing the read spelled the second case as the first, and the
+    /// caller reads that as "this package declares nothing" — which is how
+    /// a removal takes a package's scripts away with its hook shims still
+    /// delegating to them. The lock is empty, so the canonical tree is the
+    /// only candidate and the answer is about the read, nothing else.
+    #[test]
+    #[allow(clippy::unwrap_used)]
+    fn an_unreadable_declaration_is_an_error_not_an_absent_one() {
+        let tmp = tempfile::tempdir().unwrap();
+        let home = tmp.path().to_path_buf();
+        let env = Env::fake(&home, FakeOs::Linux);
+        let root = home.join("dev/app");
+        let scope = Scope::Project { root: root.clone() };
+        let lock = crate::lock::Lock::default();
+
+        assert!(
+            installed_tree(&env, &scope, &lock, "armer")
+                .unwrap()
+                .is_none(),
+            "a tree that is not there declares nothing"
+        );
+
+        let tree = root.join(".agents/skills/armer");
+        fs::create_dir_all(&tree).unwrap();
+        let declaration = tree.join("SKILL.md");
+        fs::write(&declaration, "---\nname: armer\n---\nBody.\n").unwrap();
+        let readable = installed_tree(&env, &scope, &lock, "armer").unwrap();
+        assert_eq!(readable.map(|(at, _)| at), Some(tree));
+
+        fs::set_permissions(&declaration, fs::Permissions::from_mode(0o000)).unwrap();
+        // Root reads a mode-000 file, so there is no unreadable file to make.
+        if fs::read_to_string(&declaration).is_ok() {
+            return;
+        }
+        let err = installed_tree(&env, &scope, &lock, "armer").unwrap_err();
+        assert!(
+            err.to_string().contains("SKILL.md"),
+            "the error did not name the file it could not read: {err}"
+        );
+    }
 }

--- a/crates/core/src/engine/repo_effects.rs
+++ b/crates/core/src/engine/repo_effects.rs
@@ -17,7 +17,7 @@ use std::collections::{BTreeMap, BTreeSet};
 use crate::env::Env;
 use crate::error::Result;
 use crate::model::{ItemKind, Scope};
-use crate::repo_effects::{DeclaredEffects, declared};
+use crate::repo_effects::{Declaration, DeclaredEffects, declaration, declared};
 
 use super::desired::{Artifact, DesiredState, read_dirs, skill_canonical};
 use super::report_types::{DriftCause, DriftRow};
@@ -153,9 +153,10 @@ fn blocked(drift: &[DriftRow], name: &str) -> bool {
 /// scripts are gone, and shims that exec a script that is not there fail
 /// every commit closed. A tree already missing declares nothing here; what
 /// it left armed is `guard::stranded`'s to report. A tree that is there and
-/// cannot be read is neither: the error stops the plan with the package
-/// still installed, rather than reporting a declaration of nothing and
-/// letting the removal take the scripts out from under armed shims.
+/// cannot be read is neither, and neither is one whose declaration will not
+/// parse: either error stops the plan with the package still installed,
+/// rather than reporting a declaration of nothing and letting the removal
+/// take the scripts out from under armed shims.
 ///
 /// Empty outside a project. An effect is a change to a repository, and the
 /// global scope is not one; `run_script` refuses it.
@@ -171,17 +172,20 @@ pub(super) fn leaving(
     let staying = skill_names(after);
     let mut found: BTreeMap<String, DeclaredEffects> = BTreeMap::new();
     for name in skill_names(before).difference(&staying) {
-        let Some((root, text)) = installed_tree(env, scope, before, name)? else {
+        let Some(installed) = installed_tree(env, scope, before, name)? else {
             continue;
         };
-        let Some(effects) = declared(&text) else {
-            continue;
+        let effects = match declaration(&installed.text) {
+            Declaration::Effects(effects) => effects,
+            // A package that declares nothing has nothing to undo.
+            Declaration::Absent => continue,
+            Declaration::Unreadable => return Err(unreadable(&installed.declaration)),
         };
         found.insert(
             (*name).to_owned(),
             DeclaredEffects {
                 name: (*name).to_owned(),
-                root,
+                root: installed.root,
                 effects,
             },
         );
@@ -204,6 +208,28 @@ fn skill_names(lock: &crate::lock::Lock) -> BTreeSet<&str> {
 /// The two names an installed skill's declaration can sit under: the
 /// second is what a switched-off installation keeps its content as.
 const DECLARATION_NAMES: [&str; 2] = ["SKILL.md", "SKILL.md.disabled"];
+
+/// A departing package's installed tree, and the declaration file read out
+/// of it — a path rather than the two names, because it is what an error
+/// about the declaration has to name for anyone to go and fix it.
+#[derive(Debug)]
+struct Installed {
+    root: std::path::PathBuf,
+    declaration: std::path::PathBuf,
+    text: String,
+}
+
+/// A declaration that will not read stops the plan with the package still
+/// installed, the same as a file that will not read at all. Calling it a
+/// package that declares nothing is what leaves hook shims delegating to
+/// scripts the removal has taken away, and the plan that does it previews
+/// as an ordinary removal.
+fn unreadable(at: &std::path::Path) -> crate::error::CoreError {
+    crate::repo_effects::err(format!(
+        "{}: this package's repo-effects declaration will not read, so kendex cannot tell whether it has an uninstaller to run — repair the frontmatter, then remove the package",
+        at.display()
+    ))
+}
 
 /// Where a departing package's tree sits on disk, and its declaration.
 ///
@@ -231,7 +257,7 @@ fn installed_tree(
     scope: &Scope,
     before: &crate::lock::Lock,
     name: &str,
-) -> Result<Option<(std::path::PathBuf, String)>> {
+) -> Result<Option<Installed>> {
     let canonical = crate::harness::canonical_name(name);
     let mut candidates = vec![skill_canonical(env, scope, name)];
     for entry in before
@@ -245,8 +271,13 @@ fn installed_tree(
     }
     for root in candidates {
         for file in DECLARATION_NAMES {
-            if let Some(text) = crate::fs::read_if_exists(&root.join(file))? {
-                return Ok(Some((root, text)));
+            let declaration = root.join(file);
+            if let Some(text) = crate::fs::read_if_exists(&declaration)? {
+                return Ok(Some(Installed {
+                    root,
+                    declaration,
+                    text,
+                }));
             }
         }
     }
@@ -283,9 +314,10 @@ mod tests {
         .unwrap();
 
         let found = installed_tree(&env, &scope, &lock, "armer").unwrap();
-        let (at, text) = found.expect("the disabled declaration was read as an absent one");
-        assert_eq!(at, tree);
-        assert!(text.contains("name: armer"), "{text}");
+        let found = found.expect("the disabled declaration was read as an absent one");
+        assert_eq!(found.root, tree);
+        assert_eq!(found.declaration, tree.join("SKILL.md.disabled"));
+        assert!(found.text.contains("name: armer"), "{}", found.text);
     }
 
     /// A candidate with no `SKILL.md` is a candidate to move past; a
@@ -318,7 +350,7 @@ mod tests {
         let declaration = tree.join("SKILL.md");
         fs::write(&declaration, "---\nname: armer\n---\nBody.\n").unwrap();
         let readable = installed_tree(&env, &scope, &lock, "armer").unwrap();
-        assert_eq!(readable.map(|(at, _)| at), Some(tree));
+        assert_eq!(readable.map(|found| found.root), Some(tree));
 
         fs::set_permissions(&declaration, fs::Permissions::from_mode(0o000)).unwrap();
         // Root reads a mode-000 file, so there is no unreadable file to make.

--- a/crates/core/src/engine/repo_effects/tests.rs
+++ b/crates/core/src/engine/repo_effects/tests.rs
@@ -1,0 +1,149 @@
+use std::fs;
+use std::os::unix::fs::PermissionsExt;
+
+use super::*;
+use crate::env::FakeOs;
+
+/// A switched-off installation keeps its declaration under the
+/// `.disabled` name, and it is the same declaration: the removal that
+/// finds it is the one that runs the uninstaller before the scripts go.
+#[test]
+#[allow(clippy::unwrap_used)]
+fn a_switched_off_installation_still_declares_what_it_armed() {
+    let tmp = tempfile::tempdir().unwrap();
+    let home = tmp.path().to_path_buf();
+    let env = Env::fake(&home, FakeOs::Linux);
+    let root = home.join("dev/app");
+    let scope = Scope::Project { root: root.clone() };
+    let lock = crate::lock::Lock::default();
+
+    let tree = root.join(".agents/skills/armer");
+    fs::create_dir_all(&tree).unwrap();
+    fs::write(
+        tree.join("SKILL.md.disabled"),
+        "---\nname: armer\n---\nBody.\n",
+    )
+    .unwrap();
+
+    let found = installed_tree(&env, &scope, &lock, "armer").unwrap();
+    let found = found.expect("the disabled declaration was read as an absent one");
+    assert_eq!(found.root, tree);
+    assert_eq!(found.declaration, tree.join("SKILL.md.disabled"));
+    assert!(found.text.contains("name: armer"), "{}", found.text);
+}
+
+/// A namespaced package delivered by copy lives under the harness's
+/// own spelling of its name, not the shared tree's.
+///
+/// `rendered_name` joins the plugin and the item with the separator
+/// that harness will load — a hyphen where names must be lower-kebab —
+/// while the canonical tree joins them with two underscores. Probing
+/// the canonical spelling in a harness's own directory found nothing,
+/// so the package read as declaring nothing and the removal went ahead
+/// without running the uninstaller it had.
+#[test]
+#[allow(clippy::unwrap_used)]
+fn a_namespaced_copy_declares_what_it_armed() {
+    let tmp = tempfile::tempdir().unwrap();
+    let home = tmp.path().to_path_buf();
+    let env = Env::fake(&home, FakeOs::Linux);
+    let root = home.join("dev/app");
+    let scope = Scope::Project { root: root.clone() };
+    let name = "plugin/armer";
+    let harness = crate::model::HarnessId::Opencode;
+
+    let mut before = crate::lock::Lock::default();
+    before.entries.insert(
+        "opencode:skill:plugin/armer".to_owned(),
+        entry(name, harness),
+    );
+    let after = crate::lock::Lock::default();
+
+    let dir = crate::engine::desired::own_dir(&env, &scope, harness, ItemKind::Skill)
+        .expect("opencode reads skills from a directory of its own");
+    let tree = dir.join(crate::harness::rendered_name(harness, name));
+    assert_ne!(
+        tree,
+        dir.join(crate::harness::canonical_name(name)),
+        "this harness spells a namespaced name the way the shared tree does, so it cannot show the gap"
+    );
+    fs::create_dir_all(&tree).unwrap();
+    fs::write(
+        tree.join("SKILL.md"),
+        "---\nname: plugin/armer\nrepo-effects:\n  summary: Arms git hooks.\n  uninstaller: scripts/off\n---\nBody.\n",
+    )
+    .unwrap();
+
+    let leaving = leaving(&env, &scope, &before, &after).unwrap();
+    assert_eq!(leaving.len(), 1, "the departing package declared nothing");
+    assert_eq!(leaving[0].root, tree);
+    assert_eq!(
+        leaving[0].effects.uninstaller.as_deref(),
+        Some("scripts/off")
+    );
+}
+
+fn entry(name: &str, harness: crate::model::HarnessId) -> crate::lock::LockEntry {
+    crate::lock::LockEntry {
+        name: name.to_owned(),
+        kind: ItemKind::Skill,
+        harness,
+        source: "cat".to_owned(),
+        source_repo: "owner/catalog".to_owned(),
+        method: crate::manifest::Method::Copy,
+        installed_at: "2026-01-01T00:00:00Z".to_owned(),
+        source_hash: "x".to_owned(),
+        source_commit: None,
+        rendered_hash: None,
+        enabled: true,
+        upstream_skills: None,
+        emitted: None,
+        registration: None,
+        left_pi_reserved_name: false,
+        reasons: Default::default(),
+    }
+}
+
+/// A candidate with no `SKILL.md` is a candidate to move past; a
+/// candidate whose `SKILL.md` will not read is the end of the search.
+///
+/// Swallowing the read spelled the second case as the first, and the
+/// caller reads that as "this package declares nothing" — which is how
+/// a removal takes a package's scripts away with its hook shims still
+/// delegating to them. The lock is empty, so the canonical tree is the
+/// only candidate and the answer is about the read, nothing else.
+#[test]
+#[allow(clippy::unwrap_used)]
+fn an_unreadable_declaration_is_an_error_not_an_absent_one() {
+    let tmp = tempfile::tempdir().unwrap();
+    let home = tmp.path().to_path_buf();
+    let env = Env::fake(&home, FakeOs::Linux);
+    let root = home.join("dev/app");
+    let scope = Scope::Project { root: root.clone() };
+    let lock = crate::lock::Lock::default();
+
+    assert!(
+        installed_tree(&env, &scope, &lock, "armer")
+            .unwrap()
+            .is_none(),
+        "a tree that is not there declares nothing"
+    );
+
+    let tree = root.join(".agents/skills/armer");
+    fs::create_dir_all(&tree).unwrap();
+    let declaration = tree.join("SKILL.md");
+    fs::write(&declaration, "---\nname: armer\n---\nBody.\n").unwrap();
+    let readable = installed_tree(&env, &scope, &lock, "armer").unwrap();
+    assert_eq!(readable.map(|found| found.root), Some(tree));
+
+    fs::set_permissions(&declaration, fs::Permissions::from_mode(0o000)).unwrap();
+    // Root reads a mode-000 file, so there is no unreadable file to make.
+    if fs::read_to_string(&declaration).is_ok() {
+        return;
+    }
+    let err = installed_tree(&env, &scope, &lock, "armer").unwrap_err();
+    assert!(
+        err.to_string().contains("SKILL.md"),
+        "the error did not name the file it could not read: {err}"
+    );
+}

--- a/crates/core/src/engine/report_types.rs
+++ b/crates/core/src/engine/report_types.rs
@@ -168,6 +168,11 @@ pub struct EngineReport {
     /// land with the rest, and the effect stays pending until it is
     /// authorized on its own.
     pub repo_effects: Vec<crate::repo_effects::DeclaredEffects>,
+    /// Packages this plan takes out of the scope that declared an effect
+    /// on the repository. Trashing their files undoes none of it, so the
+    /// declared uninstaller has to run before the plan does — while the
+    /// script it names is still there to run.
+    pub repo_effects_leaving: Vec<crate::repo_effects::DeclaredEffects>,
 }
 
 #[derive(Debug, Clone, Default)]

--- a/crates/core/src/frontmatter/mod.rs
+++ b/crates/core/src/frontmatter/mod.rs
@@ -211,6 +211,12 @@ pub fn name_value_span(text: &str) -> Result<std::ops::Range<usize>, NameProblem
 pub struct Parsed {
     pub map: Map,
     pub warnings: Vec<String>,
+    /// Top-level lines that opened no entry, verbatim. A warning says the
+    /// same thing in prose; this says it in a form a reader can act on,
+    /// because "the key is absent" and "the key lost its colon" are the
+    /// same missing key to [`Map::get`] and different answers to anything
+    /// deciding what a package declares.
+    pub ignored: Vec<String>,
 }
 
 /// Parse frontmatter entry by entry: strict YAML wherever the value has
@@ -230,6 +236,7 @@ pub fn parse_tolerant(yaml: &str) -> Result<Parsed, String> {
             parsed
                 .warnings
                 .push(format!("frontmatter line without a key ignored: `{first}`"));
+            parsed.ignored.push(first.to_owned());
             continue;
         };
         let key = key.trim().to_owned();
@@ -332,67 +339,3 @@ pub use strict::parse;
 
 #[cfg(test)]
 mod tests;
-
-#[cfg(test)]
-mod name_span_tests {
-    use super::{NameProblem, name_value_span};
-
-    fn span_of(text: &str) -> Result<&str, NameProblem> {
-        name_value_span(text).map(|span| &text[span])
-    }
-
-    #[test]
-    fn finds_the_inline_value_and_only_it() {
-        assert_eq!(span_of("---\nname: gh\n---\nBody.\n"), Ok("gh"));
-        assert_eq!(span_of("---\nname : gh\n---\n"), Ok("gh"));
-        assert_eq!(span_of("---\nname:   gh  \n---\n"), Ok("gh"));
-        assert_eq!(span_of("---\r\nname: gh\r\n---\r\n"), Ok("gh"));
-        assert_eq!(span_of("---\nname: gh #edited\n...\n"), Ok("gh #edited"));
-        assert_eq!(span_of("---\nname: \"gh\"\n---\n"), Ok("\"gh\""));
-        assert_eq!(span_of("---\nname: 'gh'\n---\n"), Ok("'gh'"));
-        // A comment after a quoted value belongs to the line, not the
-        // value; an escaped quote does not close the scalar.
-        assert_eq!(span_of("---\nname: \"gh\" # package\n---\n"), Ok("\"gh\""));
-        assert_eq!(span_of("---\nname: 'it''s' # x\n---\n"), Ok("'it''s'"));
-        assert_eq!(
-            span_of("---\nname: \"a\\\"b\" # c\n---\n"),
-            Ok("\"a\\\"b\"")
-        );
-        // A comment-only or blank line after the entry is not a
-        // continuation of its value, indented or not.
-        assert_eq!(span_of("---\nname: gh\n  # note\n---\n"), Ok("gh"));
-        assert_eq!(span_of("---\nname: gh\n\ndesc: d\n---\n"), Ok("gh"));
-        // Not a top-level entry, and not the `name` key.
-        assert_eq!(
-            span_of("---\nmeta:\n  name: inner\nname: outer\n---\n"),
-            Ok("outer")
-        );
-        assert_eq!(
-            span_of("---\nnames: many\n---\n"),
-            Err(NameProblem::Missing { insert_at: 4 })
-        );
-    }
-
-    #[test]
-    fn refuses_what_is_not_one_scalar() {
-        assert_eq!(span_of("Body.\n"), Err(NameProblem::NoFrontmatter));
-        assert_eq!(
-            span_of("---\nname: a\nname: b\n---\n"),
-            Err(NameProblem::Twice)
-        );
-        for text in [
-            "---\nname: [copy]\n---\n",
-            "---\nname: |\n  gh\n---\n",
-            "---\nname: >\n  gh\n---\n",
-            "---\nname: &anchor gh\n---\n",
-            "---\nname: gh\n  continued\n---\n",
-            "---\nname: gh\n  # note\n  continued\n---\n",
-            "---\nname:\n---\n",
-            "---\nname: \"gh\n---\n",
-            "---\nname: \"gh\" trailing\n---\n",
-            "---\nname: \"gh\"#glued\n---\n",
-        ] {
-            assert_eq!(span_of(text), Err(NameProblem::NotAScalar), "{text:?}");
-        }
-    }
-}

--- a/crates/core/src/frontmatter/mod.rs
+++ b/crates/core/src/frontmatter/mod.rs
@@ -87,16 +87,29 @@ impl Map {
     }
 }
 
-/// Split a `---` frontmatter block from the body. The terminator is a line
-/// holding exactly `---` (or `...`) plus optional trailing whitespace.
-pub fn split(text: &str) -> Result<(&str, &str), String> {
-    let after_marker = text.strip_prefix("---").ok_or("file has no frontmatter")?;
+/// The text after a frontmatter opener line, or `None` where the file
+/// opens no block. Its own step because "no block at all" and "a block
+/// that never ends" are different answers for a reader deciding whether a
+/// declaration is absent or unreadable, and [`split`] reports one error
+/// for both.
+fn opened(text: &str) -> Option<&str> {
+    let after_marker = text.strip_prefix("---")?;
     let opener_rest = after_marker.trim_start_matches([' ', '\t']);
-    let rest = opener_rest
+    opener_rest
         .strip_prefix('\r')
         .unwrap_or(opener_rest)
         .strip_prefix('\n')
-        .ok_or("file has no frontmatter")?;
+}
+
+/// Whether the file opens a frontmatter block, whatever follows it.
+pub fn opens(text: &str) -> bool {
+    opened(text).is_some()
+}
+
+/// Split a `---` frontmatter block from the body. The terminator is a line
+/// holding exactly `---` (or `...`) plus optional trailing whitespace.
+pub fn split(text: &str) -> Result<(&str, &str), String> {
+    let rest = opened(text).ok_or("file has no frontmatter")?;
     let mut offset = 0;
     for line in rest.split_inclusive('\n') {
         let trimmed = line.trim_end();

--- a/crates/core/src/frontmatter/tests.rs
+++ b/crates/core/src/frontmatter/tests.rs
@@ -106,3 +106,62 @@ fn scalars_stay_strings_and_null_forms_collapse() {
     assert_eq!(map.get("c"), Some(&Value::Null));
     assert_eq!(map.get("d").and_then(Value::as_str), Some("007"));
 }
+
+fn span_of(text: &str) -> Result<&str, NameProblem> {
+    name_value_span(text).map(|span| &text[span])
+}
+
+#[test]
+fn finds_the_inline_value_and_only_it() {
+    assert_eq!(span_of("---\nname: gh\n---\nBody.\n"), Ok("gh"));
+    assert_eq!(span_of("---\nname : gh\n---\n"), Ok("gh"));
+    assert_eq!(span_of("---\nname:   gh  \n---\n"), Ok("gh"));
+    assert_eq!(span_of("---\r\nname: gh\r\n---\r\n"), Ok("gh"));
+    assert_eq!(span_of("---\nname: gh #edited\n...\n"), Ok("gh #edited"));
+    assert_eq!(span_of("---\nname: \"gh\"\n---\n"), Ok("\"gh\""));
+    assert_eq!(span_of("---\nname: 'gh'\n---\n"), Ok("'gh'"));
+    // A comment after a quoted value belongs to the line, not the
+    // value; an escaped quote does not close the scalar.
+    assert_eq!(span_of("---\nname: \"gh\" # package\n---\n"), Ok("\"gh\""));
+    assert_eq!(span_of("---\nname: 'it''s' # x\n---\n"), Ok("'it''s'"));
+    assert_eq!(
+        span_of("---\nname: \"a\\\"b\" # c\n---\n"),
+        Ok("\"a\\\"b\"")
+    );
+    // A comment-only or blank line after the entry is not a
+    // continuation of its value, indented or not.
+    assert_eq!(span_of("---\nname: gh\n  # note\n---\n"), Ok("gh"));
+    assert_eq!(span_of("---\nname: gh\n\ndesc: d\n---\n"), Ok("gh"));
+    // Not a top-level entry, and not the `name` key.
+    assert_eq!(
+        span_of("---\nmeta:\n  name: inner\nname: outer\n---\n"),
+        Ok("outer")
+    );
+    assert_eq!(
+        span_of("---\nnames: many\n---\n"),
+        Err(NameProblem::Missing { insert_at: 4 })
+    );
+}
+
+#[test]
+fn refuses_what_is_not_one_scalar() {
+    assert_eq!(span_of("Body.\n"), Err(NameProblem::NoFrontmatter));
+    assert_eq!(
+        span_of("---\nname: a\nname: b\n---\n"),
+        Err(NameProblem::Twice)
+    );
+    for text in [
+        "---\nname: [copy]\n---\n",
+        "---\nname: |\n  gh\n---\n",
+        "---\nname: >\n  gh\n---\n",
+        "---\nname: &anchor gh\n---\n",
+        "---\nname: gh\n  continued\n---\n",
+        "---\nname: gh\n  # note\n  continued\n---\n",
+        "---\nname:\n---\n",
+        "---\nname: \"gh\n---\n",
+        "---\nname: \"gh\" trailing\n---\n",
+        "---\nname: \"gh\"#glued\n---\n",
+    ] {
+        assert_eq!(span_of(text), Err(NameProblem::NotAScalar), "{text:?}");
+    }
+}

--- a/crates/core/src/guard/mod.rs
+++ b/crates/core/src/guard/mod.rs
@@ -21,7 +21,7 @@
 //! nonzero verdicts block a commit.
 
 use std::ffi::OsString;
-use std::path::Path;
+use std::path::{Path, PathBuf};
 use std::time::Duration;
 
 use crate::error::{CoreError, Result};
@@ -47,6 +47,12 @@ pub const SKILL: &str = "growth-guards";
 /// means not armed, which is the safe answer for all of them and needs no
 /// taxonomy to reach.
 pub const MARKER: &str = "# kendex-guards-hook";
+
+/// The helper the installer writes beside the hooks, and the line inside
+/// it that says the installer wrote it. Read for one purpose: naming the
+/// file when the package that owns it is gone.
+const HELPER: &str = "kendex-guards";
+const HELPER_MARKER: &str = "kendex growth-guards git hooks";
 
 /// The installer the package ships, relative to its own directory.
 const INSTALLER: &str = "scripts/install-git-hooks";
@@ -238,4 +244,42 @@ pub fn armed(dir: &Path) -> Result<Option<bool>> {
         }
     }
     Ok(Some(true))
+}
+
+/// The hook files this package left behind in a repository that no longer
+/// carries the package anywhere.
+///
+/// The same read as [`armed`] — the marker, in the directory git reads —
+/// with the opposite precondition: no copy of the package under any search
+/// root, in this checkout or the main one. A shim that survives its package
+/// execs a script that is not there, so every commit in the repository
+/// fails closed, and nothing else reports it: the lock no longer names the
+/// package, so the drift report has nothing to compare, and `guard check`
+/// cannot run an installer that is gone.
+///
+/// Each path that carries the marker, so the report can say which files to
+/// clean up. Empty where there is no repository, where the package is
+/// present (a broken copy is `guard check`'s to describe), or where nothing
+/// carries the marker. The execute bit is not consulted: a leftover git
+/// happens to skip is still a leftover.
+pub fn stranded(dir: &Path) -> Result<Vec<PathBuf>> {
+    let Some(repo) = Repo::probe(dir)? else {
+        return Ok(Vec::new());
+    };
+    if Installed::present(&repo).is_some() {
+        return Ok(Vec::new());
+    }
+    let hooks = repo.default_hooks_dir();
+    let mut files = Vec::new();
+    for (name, marker) in LANES
+        .iter()
+        .map(|lane| (*lane, MARKER))
+        .chain([(HELPER, HELPER_MARKER)])
+    {
+        let path = hooks.join(name);
+        if crate::fs::read_if_exists(&path)?.is_some_and(|text| text.contains(marker)) {
+            files.push(path);
+        }
+    }
+    Ok(files)
 }

--- a/crates/core/src/guard/mod.rs
+++ b/crates/core/src/guard/mod.rs
@@ -263,11 +263,15 @@ pub fn armed(repo: &Repo) -> Result<bool> {
 /// here, followed, would have disarmed the gate the other project asked
 /// for.
 ///
-/// Each path that carries the marker, or the helper by its name, so the
-/// report can say which files to clean up. Empty where `core.hooksPath` is
-/// set: git reads no hook here, so nothing fails, and what a redirected
-/// directory means is a grammar this module does not have. The execute bit
-/// is not consulted: a leftover git happens to skip is still a leftover.
+/// Each lane that carries the marker, and the helper by its name beside
+/// them, so the report can say which files to clean up. The marker is the
+/// whole test: a lane hook carrying it is what execs the helper, and a
+/// file of the helper's name with no such lane runs on no commit — the
+/// installer leaves a foreign file of that name alone, and so does this.
+/// Empty where `core.hooksPath` is set: git reads no hook here, so nothing
+/// fails, and what a redirected directory means is a grammar this module
+/// does not have. The execute bit is not consulted: a leftover git happens
+/// to skip is still a leftover.
 pub fn stranded(repo: &Repo) -> Result<Vec<PathBuf>> {
     let hooks = repo.default_hooks_dir();
     let mut files = Vec::new();
@@ -277,12 +281,12 @@ pub fn stranded(repo: &Repo) -> Result<Vec<PathBuf>> {
             files.push(path);
         }
     }
+    if files.is_empty() || repo.hooks_redirected()? || Installed::anywhere(repo) {
+        return Ok(Vec::new());
+    }
     let helper = hooks.join(HELPER);
     if helper.is_file() {
         files.push(helper);
-    }
-    if files.is_empty() || repo.hooks_redirected()? || Installed::anywhere(repo)? {
-        return Ok(Vec::new());
     }
     Ok(files)
 }

--- a/crates/core/src/guard/mod.rs
+++ b/crates/core/src/guard/mod.rs
@@ -244,12 +244,13 @@ pub fn armed(repo: &Repo) -> Result<bool> {
 /// carries the package anywhere.
 ///
 /// The same read as [`armed`] — the marker, in the directory git reads —
-/// with the opposite precondition: no copy of the package under any kendex
-/// project in the work tree, nor in the main checkout's. A shim that
-/// survives its package execs a script that is not there, so every commit
-/// in the repository fails closed, and nothing else reports it: the lock no
-/// longer names the package, so the drift report has nothing to compare,
-/// and `guard check` cannot run an installer that is gone.
+/// with the opposite precondition: no copy of the package anywhere the
+/// shared hooks gate, which is every work tree attached to this common git
+/// dir. A shim that survives its package execs a script that is not there,
+/// so every commit in the repository fails closed, and nothing else reports
+/// it: the lock no longer names the package, so the drift report has
+/// nothing to compare, and `guard check` cannot run an installer that is
+/// gone.
 ///
 /// Cheapest question first. The hook files are read before anything is
 /// spawned, because a repository with no marker in them is the ordinary
@@ -257,11 +258,16 @@ pub fn armed(repo: &Repo) -> Result<bool> {
 /// process behind `hooks_redirected` and the search behind
 /// `Installed::anywhere`.
 ///
-/// Repository-wide, not project-wide. Every project in a work tree shares
-/// one hooks directory, so a project without the package beside one that
-/// armed it is a gated repository, not a stranded one — and the advice
-/// here, followed, would have disarmed the gate the other project asked
-/// for.
+/// Hooks-directory-wide, not project-wide and not work-tree-wide. Every
+/// project in a work tree shares one hooks directory, and so does every
+/// work tree attached to the same common git dir — so a project or a work
+/// tree without the package beside one that armed it is a gated
+/// repository, not a stranded one, and the advice here, followed, would
+/// have disarmed the gate that other copy asked for.
+///
+/// A domain that could not be read in full yields the error rather than an
+/// empty list: the caller reports "could not check" instead of telling a
+/// reader to delete hook files that may be gating a copy nobody could see.
 ///
 /// Each lane that carries the marker, and the helper by its name beside
 /// them, so the report can say which files to clean up. The marker is the
@@ -281,7 +287,7 @@ pub fn stranded(repo: &Repo) -> Result<Vec<PathBuf>> {
             files.push(path);
         }
     }
-    if files.is_empty() || repo.hooks_redirected()? || Installed::anywhere(repo) {
+    if files.is_empty() || repo.hooks_redirected()? || Installed::anywhere(repo)? {
         return Ok(Vec::new());
     }
     let helper = hooks.join(HELPER);

--- a/crates/core/src/guard/mod.rs
+++ b/crates/core/src/guard/mod.rs
@@ -46,10 +46,25 @@ pub const SKILL: &str = "growth-guards";
 /// a foreign hook, no file at all, a `core.hooksPath` pointing elsewhere —
 /// means not armed, which is the safe answer for all of them and needs no
 /// taxonomy to reach.
+///
+/// Where it has to be is the installer's rule, not this module's: see
+/// [`hook_is_ours`].
 pub const MARKER: &str = "# kendex-guards-hook";
 
-/// The helper the installer writes beside the hooks. Nothing else writes a
-/// file of this name under `.git/hooks`, so the path alone identifies it.
+/// The whole line the installer writes into a hook file it CREATED, which
+/// is how removal tells one from a consumer's own shebang-only hook. It
+/// mentions the marker without ending in it, so it is owned by name.
+pub const CREATED_MARKER: &str = "# kendex-guards-hook created this file";
+
+/// The marker inside the helper the installer writes.
+///
+/// The name is not the identity: the installer refuses to overwrite a file
+/// of the helper's name that does not carry this, and the uninstaller
+/// refuses to remove one, so a report that named such a file by its name
+/// alone would tell a reader to delete what the package itself leaves.
+pub const HELPER_MARKER: &str = "kendex growth-guards git hooks";
+
+/// The helper the installer writes beside the hooks.
 const HELPER: &str = "kendex-guards";
 
 /// The installer the package ships, relative to its own directory.
@@ -194,6 +209,39 @@ fn installer(dir: &Path, args: &[&str]) -> Result<GuardReport> {
     Ok(relay(&output))
 }
 
+/// Whether a hook file carries a line this package wrote.
+///
+/// The installer's own `gg_owned_lines_re`, which is the predicate its
+/// removal deletes by and its `--check` reads by: a line the marker CLOSES,
+/// or a line that is exactly the created marker. Matching the marker
+/// anywhere is wider than that on purpose — it would claim a consumer's own
+/// comment that quotes the marker mid-sentence, and both readers here would
+/// then describe a gate nothing installed. Pinned to the script by
+/// `guard_hooks::the_ownership_markers_match_the_installers_own`.
+///
+/// Split on `\n` and not [`str::lines`], which also eats a `\r`: grep does
+/// not, so a CRLF hook whose line ends in `marker\r` is not owned there and
+/// must not be owned here.
+fn hook_is_ours(text: &str) -> bool {
+    text.split('\n')
+        .any(|line| line.ends_with(MARKER) || line == CREATED_MARKER)
+}
+
+/// Whether the file at the helper's path is the helper this package wrote.
+///
+/// The uninstaller's own predicate: a regular file, not a symlink, whose
+/// bytes carry [`HELPER_MARKER`]. It deliberately preserves anything else
+/// of that name, so naming one here would advise a deletion the package
+/// refuses to make. A path that cannot be stat'ed is not ours either — a
+/// helper left beside no lane hook of ours execs on no commit, so the
+/// unsure answer costs a stray file and never a lost one.
+fn helper_is_ours(path: &Path) -> Result<bool> {
+    if !std::fs::symlink_metadata(path).is_ok_and(|meta| meta.is_file()) {
+        return Ok(false);
+    }
+    Ok(crate::fs::read_if_exists(path)?.is_some_and(|text| text.contains(HELPER_MARKER)))
+}
+
 /// Whether this package armed this repository's commit hooks, read off the
 /// hook files and nothing else.
 ///
@@ -202,10 +250,11 @@ fn installer(dir: &Path, args: &[&str]) -> Result<GuardReport> {
 /// its status ran code its author chose. So this executes nothing, and it
 /// asks the smallest question that is safe to answer from bytes alone.
 ///
-/// The marker and the execute bit. Both lanes have to carry the marker, in
-/// the directory git reads with no redirect in the way, and both have to be
-/// files git will actually run — git skips a hook without `+x` in silence,
-/// so a marker in a file it ignores describes a gate that is not there.
+/// The marker and the execute bit. Both lanes have to carry a line the
+/// installer owns ([`hook_is_ours`]), in the directory git reads with no
+/// redirect in the way, and both have to be files git will actually run —
+/// git skips a hook without `+x` in silence, so an owned line in a file it
+/// ignores describes a gate that is not there.
 /// Executability is git's own rule about hook files rather than anything
 /// this package puts in them, which is why reading it is not the grammar
 /// this module deliberately no longer has.
@@ -233,7 +282,7 @@ pub fn armed(repo: &Repo) -> Result<bool> {
         let Some(text) = crate::fs::read_if_exists(&path)? else {
             return Ok(false);
         };
-        if !text.contains(MARKER) || !is_executable(&path) {
+        if !hook_is_ours(&text) || !is_executable(&path) {
             return Ok(false);
         }
     }
@@ -243,7 +292,7 @@ pub fn armed(repo: &Repo) -> Result<bool> {
 /// The hook files this package left behind in a repository that no longer
 /// carries the package anywhere.
 ///
-/// The same read as [`armed`] — the marker, in the directory git reads —
+/// The same read as [`armed`] — an owned line, in the directory git reads —
 /// with the opposite precondition: no copy of the package anywhere the
 /// shared hooks gate, which is every work tree attached to this common git
 /// dir. A shim that survives its package execs a script that is not there,
@@ -253,9 +302,9 @@ pub fn armed(repo: &Repo) -> Result<bool> {
 /// gone.
 ///
 /// Cheapest question first. The hook files are read before anything is
-/// spawned, because a repository with no marker in them is the ordinary
-/// case and this runs at every session start; only a marker earns the git
-/// process behind `hooks_redirected` and the search behind
+/// spawned, because a repository with no owned line in them is the ordinary
+/// case and this runs at every session start; only an owned line earns the
+/// git process behind `hooks_redirected` and the search behind
 /// `Installed::anywhere`.
 ///
 /// Hooks-directory-wide, not project-wide and not work-tree-wide. Every
@@ -269,11 +318,14 @@ pub fn armed(repo: &Repo) -> Result<bool> {
 /// empty list: the caller reports "could not check" instead of telling a
 /// reader to delete hook files that may be gating a copy nobody could see.
 ///
-/// Each lane that carries the marker, and the helper by its name beside
-/// them, so the report can say which files to clean up. The marker is the
-/// whole test: a lane hook carrying it is what execs the helper, and a
-/// file of the helper's name with no such lane runs on no commit — the
-/// installer leaves a foreign file of that name alone, and so does this.
+/// Each lane carrying a line the installer owns, and the helper beside
+/// them when it carries the installer's helper marker, so the report can
+/// say which files to clean up. Both predicates are the installer's own
+/// ([`hook_is_ours`], [`helper_is_ours`]) rather than an approximation of
+/// them, because the advice here is a deletion: a lane hook the installer
+/// would not strip and a helper it would not remove are somebody else's
+/// files. A helper with no owned lane beside it runs on no commit, so it
+/// is named only where one is.
 /// Empty where `core.hooksPath` is set: git reads no hook here, so nothing
 /// fails, and what a redirected directory means is a grammar this module
 /// does not have. The execute bit is not consulted: a leftover git happens
@@ -283,7 +335,7 @@ pub fn stranded(repo: &Repo) -> Result<Vec<PathBuf>> {
     let mut files = Vec::new();
     for lane in LANES {
         let path = hooks.join(lane);
-        if crate::fs::read_if_exists(&path)?.is_some_and(|text| text.contains(MARKER)) {
+        if crate::fs::read_if_exists(&path)?.is_some_and(|text| hook_is_ours(&text)) {
             files.push(path);
         }
     }
@@ -291,7 +343,7 @@ pub fn stranded(repo: &Repo) -> Result<Vec<PathBuf>> {
         return Ok(Vec::new());
     }
     let helper = hooks.join(HELPER);
-    if helper.is_file() {
+    if helper_is_ours(&helper)? {
         files.push(helper);
     }
     Ok(files)

--- a/crates/core/src/guard/mod.rs
+++ b/crates/core/src/guard/mod.rs
@@ -48,11 +48,9 @@ pub const SKILL: &str = "growth-guards";
 /// taxonomy to reach.
 pub const MARKER: &str = "# kendex-guards-hook";
 
-/// The helper the installer writes beside the hooks, and the line inside
-/// it that says the installer wrote it. Read for one purpose: naming the
-/// file when the package that owns it is gone.
+/// The helper the installer writes beside the hooks. Nothing else writes a
+/// file of this name under `.git/hooks`, so the path alone identifies it.
 const HELPER: &str = "kendex-guards";
-const HELPER_MARKER: &str = "kendex growth-guards git hooks";
 
 /// The installer the package ships, relative to its own directory.
 const INSTALLER: &str = "scripts/install-git-hooks";
@@ -219,67 +217,72 @@ fn installer(dir: &Path, args: &[&str]) -> Result<GuardReport> {
 /// Every uncertainty inside a repository lands on "not armed", whose remedy
 /// is a command that is safe to run twice.
 ///
-/// `None` is the state that is not a verdict: there is no repository here at
-/// all, so there is nothing to arm and no drift to report. Folding it into
-/// "not armed" told a scope with no work tree to run `kendex guard install`,
-/// which exits 2 there — advice that cannot be taken, every session.
+/// Over a repository the caller already probed: whether there is one here
+/// at all is the caller's question, and probing it again for every read
+/// spends three git processes per answer.
 ///
 /// A person who wants the full vocabulary runs `kendex guard check`, which
 /// asks the package. That is an invocation, and an invocation is consent.
-pub fn armed(dir: &Path) -> Result<Option<bool>> {
-    let Some(repo) = Repo::probe(dir)? else {
-        return Ok(None);
-    };
+pub fn armed(repo: &Repo) -> Result<bool> {
     if repo.hooks_redirected()? {
-        return Ok(Some(false));
+        return Ok(false);
     }
     let hooks = repo.default_hooks_dir();
     for lane in LANES {
         let path = hooks.join(lane);
         let Some(text) = crate::fs::read_if_exists(&path)? else {
-            return Ok(Some(false));
+            return Ok(false);
         };
         if !text.contains(MARKER) || !is_executable(&path) {
-            return Ok(Some(false));
+            return Ok(false);
         }
     }
-    Ok(Some(true))
+    Ok(true)
 }
 
 /// The hook files this package left behind in a repository that no longer
 /// carries the package anywhere.
 ///
 /// The same read as [`armed`] — the marker, in the directory git reads —
-/// with the opposite precondition: no copy of the package under any search
-/// root, in this checkout or the main one. A shim that survives its package
-/// execs a script that is not there, so every commit in the repository
-/// fails closed, and nothing else reports it: the lock no longer names the
-/// package, so the drift report has nothing to compare, and `guard check`
-/// cannot run an installer that is gone.
+/// with the opposite precondition: no copy of the package under any kendex
+/// project in the work tree, nor in the main checkout's. A shim that
+/// survives its package execs a script that is not there, so every commit
+/// in the repository fails closed, and nothing else reports it: the lock no
+/// longer names the package, so the drift report has nothing to compare,
+/// and `guard check` cannot run an installer that is gone.
 ///
-/// Each path that carries the marker, so the report can say which files to
-/// clean up. Empty where there is no repository, where the package is
-/// present (a broken copy is `guard check`'s to describe), or where nothing
-/// carries the marker. The execute bit is not consulted: a leftover git
-/// happens to skip is still a leftover.
-pub fn stranded(dir: &Path) -> Result<Vec<PathBuf>> {
-    let Some(repo) = Repo::probe(dir)? else {
-        return Ok(Vec::new());
-    };
-    if Installed::present(&repo).is_some() {
-        return Ok(Vec::new());
-    }
+/// Cheapest question first. The hook files are read before anything is
+/// spawned, because a repository with no marker in them is the ordinary
+/// case and this runs at every session start; only a marker earns the git
+/// process behind `hooks_redirected` and the search behind
+/// `Installed::anywhere`.
+///
+/// Repository-wide, not project-wide. Every project in a work tree shares
+/// one hooks directory, so a project without the package beside one that
+/// armed it is a gated repository, not a stranded one — and the advice
+/// here, followed, would have disarmed the gate the other project asked
+/// for.
+///
+/// Each path that carries the marker, or the helper by its name, so the
+/// report can say which files to clean up. Empty where `core.hooksPath` is
+/// set: git reads no hook here, so nothing fails, and what a redirected
+/// directory means is a grammar this module does not have. The execute bit
+/// is not consulted: a leftover git happens to skip is still a leftover.
+pub fn stranded(repo: &Repo) -> Result<Vec<PathBuf>> {
     let hooks = repo.default_hooks_dir();
     let mut files = Vec::new();
-    for (name, marker) in LANES
-        .iter()
-        .map(|lane| (*lane, MARKER))
-        .chain([(HELPER, HELPER_MARKER)])
-    {
-        let path = hooks.join(name);
-        if crate::fs::read_if_exists(&path)?.is_some_and(|text| text.contains(marker)) {
+    for lane in LANES {
+        let path = hooks.join(lane);
+        if crate::fs::read_if_exists(&path)?.is_some_and(|text| text.contains(MARKER)) {
             files.push(path);
         }
+    }
+    let helper = hooks.join(HELPER);
+    if helper.is_file() {
+        files.push(helper);
+    }
+    if files.is_empty() || repo.hooks_redirected()? || Installed::anywhere(repo)? {
+        return Ok(Vec::new());
     }
     Ok(files)
 }

--- a/crates/core/src/guard/repo.rs
+++ b/crates/core/src/guard/repo.rs
@@ -73,22 +73,33 @@ fn one_path(dir: &Path, flag: &str) -> Result<Option<PathBuf>> {
     if bytes.is_empty() {
         return Ok(None);
     }
+    path_from(bytes, flag).map(Some)
+}
+
+/// The bytes git wrote, as a path.
+///
+/// On unix a filename is bytes and travels as bytes. Elsewhere it has to be
+/// text, and bytes that are not are an error rather than a lossy conversion:
+/// `from_utf8_lossy` turns any byte that is not UTF-8 into U+FFFD, which is
+/// not a filename, so every verb would then name a path nobody has for a
+/// repository that is perfectly fine.
+fn path_from(bytes: Vec<u8>, what: &str) -> Result<PathBuf> {
     #[cfg(unix)]
-    let path = {
+    {
         use std::os::unix::ffi::OsStringExt;
-        PathBuf::from(std::ffi::OsString::from_vec(bytes))
-    };
+        let _ = what;
+        Ok(PathBuf::from(std::ffi::OsString::from_vec(bytes)))
+    }
     #[cfg(not(unix))]
-    let path = {
+    {
         let text = String::from_utf8(bytes).map_err(|_| {
             guard_err(
                 "hooks",
-                format!("git answered {flag} with bytes that are not text"),
+                format!("git answered {what} with bytes that are not text"),
             )
         })?;
-        PathBuf::from(text)
-    };
-    Ok(Some(path))
+        Ok(PathBuf::from(text))
+    }
 }
 
 impl Repo {
@@ -188,6 +199,63 @@ impl Repo {
     /// The hooks directory git reads with no redirect in the way.
     pub fn default_hooks_dir(&self) -> PathBuf {
         self.common_dir.join("hooks")
+    }
+
+    /// Every work tree attached to this repository's common git directory,
+    /// canonical and deduplicated, in git's own order — the main checkout
+    /// first, then the linked ones.
+    ///
+    /// The domain of "does this repository carry the package". The hooks
+    /// directory lives in the common git dir, so one copy of it gates every
+    /// work tree attached to that dir, and a sibling work tree is reachable
+    /// from no path under this one. git is the only thing that knows the
+    /// whole set.
+    ///
+    /// `-z` rather than plain porcelain, because a path is bytes. The plain
+    /// format writes one per line, so a checkout whose name contains a
+    /// newline — legal on unix, and a name a person can create — becomes two
+    /// records naming two directories that do not exist. `-z` terminates
+    /// each field with NUL and leaves the bytes alone.
+    ///
+    /// A registration whose directory is gone is dropped rather than
+    /// reported: git prunes those lazily, and a work tree that is not there
+    /// holds no copy of anything. That is a definite answer, unlike a
+    /// directory that is there and cannot be read, which is why only the
+    /// first is silent.
+    pub fn worktrees(&self) -> Result<Vec<PathBuf>> {
+        let output = Hardened::git(
+            &["worktree", "list", "--porcelain", "-z"],
+            Some(&self.worktree),
+        )
+        .run()?;
+        if !output.status.success() {
+            return Err(guard_err(
+                "hooks",
+                format!(
+                    "could not list the work trees of {} (git exited {:?}): {}",
+                    self.worktree.display(),
+                    output.status.code(),
+                    String::from_utf8_lossy(&output.stderr).trim()
+                ),
+            ));
+        }
+        let mut trees = Vec::new();
+        for field in output.stdout.split(|byte| *byte == b'\0') {
+            let Some(path) = field.strip_prefix(b"worktree ") else {
+                continue;
+            };
+            let path = path_from(path.to_vec(), "worktree list")?;
+            match path.canonicalize() {
+                Ok(path) => {
+                    if !trees.contains(&path) {
+                        trees.push(path);
+                    }
+                }
+                Err(error) if error.kind() == std::io::ErrorKind::NotFound => {}
+                Err(error) => return Err(CoreError::io(&path, error)),
+            }
+        }
+        Ok(trees)
     }
 
     /// Whether `core.hooksPath` is set to anything at all.

--- a/crates/core/src/guard/resolve.rs
+++ b/crates/core/src/guard/resolve.rs
@@ -85,6 +85,36 @@ impl Installed {
         None
     }
 
+    /// Whether any kendex project in this repository carries the package.
+    ///
+    /// The question `stranded` asks, and a wider one than [`present`]: that
+    /// searches from where the caller stands, which is the right copy to
+    /// RUN, while a hooks directory is shared by every project in the work
+    /// tree and by every linked work tree of it. So every project under
+    /// this work tree and under the main checkout is searched — a copy in
+    /// any of them is what the shared shims run.
+    ///
+    /// [`present`]: Installed::present
+    pub fn anywhere(repo: &super::Repo) -> Result<bool> {
+        if Installed::present(repo).is_some() {
+            return Ok(true);
+        }
+        let mut trees = vec![repo.worktree.clone()];
+        trees.extend(main_checkout(repo));
+        for tree in trees {
+            for project in crate::discover::discover_projects(&tree)? {
+                if SKILL_ROOTS
+                    .iter()
+                    .map(|base| project.join(base).join(SKILL))
+                    .any(|dir| dir.exists() || dir.is_symlink())
+                {
+                    return Ok(true);
+                }
+            }
+        }
+        Ok(false)
+    }
+
     /// Whether any copy of the package is here at all, for a message that
     /// tells "no package installed" from "a package whose scripts are
     /// broken" — two different things to do something about.

--- a/crates/core/src/guard/resolve.rs
+++ b/crates/core/src/guard/resolve.rs
@@ -91,15 +91,20 @@ impl Installed {
     /// searches from where the caller stands, which is the right copy to
     /// RUN, while a hooks directory is shared by every project in the work
     /// tree and by every linked work tree of it. So the whole work tree and
-    /// the whole main checkout are walked, every directory asked for a
-    /// skills root holding the package — a copy anywhere in them is what
-    /// the shared shims run.
+    /// the whole main checkout are walked — every directory the project
+    /// walk's pruning leaves — each asked for a skills root holding the
+    /// package, because a copy anywhere in them is what the shared shims
+    /// run.
     ///
     /// Every directory, not every discovered project: a repository whose
     /// root carries a harness marker IS a project to the discovery walk,
     /// which stops there and never sees the nested project that armed the
     /// hooks. The main checkout is resolved once, for the roots `present`
-    /// searches and for the walk alike — it costs two git processes.
+    /// searches and for the walk alike — it costs two git processes, and
+    /// the trees are deduplicated before the walk for the same reason
+    /// `search_roots_with` deduplicates its roots: in an ordinary clone the
+    /// main checkout IS this work tree, and walking it twice is the whole
+    /// exhaustive walk paid over again for the same answer.
     ///
     /// [`present`]: Installed::present
     pub fn anywhere(repo: &super::Repo) -> bool {
@@ -116,8 +121,12 @@ impl Installed {
         {
             return true;
         }
-        std::iter::once(&repo.worktree)
-            .chain(main.iter())
+        let mut trees = vec![repo.worktree.clone()];
+        if let Some(main) = main.filter(|main| *main != repo.worktree) {
+            trees.push(main);
+        }
+        trees
+            .iter()
             .any(|tree| crate::discover::any_dir(tree, &mut carries))
     }
 

--- a/crates/core/src/guard/resolve.rs
+++ b/crates/core/src/guard/resolve.rs
@@ -85,49 +85,59 @@ impl Installed {
         None
     }
 
-    /// Whether anything in this repository carries the package.
+    /// Whether anything gated by this repository's hooks carries the
+    /// package.
     ///
     /// The question `stranded` asks, and a wider one than [`present`]: that
     /// searches from where the caller stands, which is the right copy to
-    /// RUN, while a hooks directory is shared by every project in the work
-    /// tree and by every linked work tree of it. So the whole work tree and
-    /// the whole main checkout are walked — every directory the project
-    /// walk's pruning leaves — each asked for a skills root holding the
-    /// package, because a copy anywhere in them is what the shared shims
-    /// run.
+    /// RUN. A hooks directory is not that narrow. It lives in the common
+    /// git dir, so it is shared by every project in a work tree AND by
+    /// every work tree attached to that dir — and the domain of "is this
+    /// package installed for these hooks" is that whole set, which
+    /// [`Repo::worktrees`] enumerates exactly. A copy in a sibling work
+    /// tree is what the shared shims run, and a search that never looked
+    /// there reports it as a leftover to delete.
     ///
-    /// Every directory, not every discovered project: a repository whose
-    /// root carries a harness marker IS a project to the discovery walk,
-    /// which stops there and never sees the nested project that armed the
-    /// hooks. The main checkout is resolved once, for the roots `present`
-    /// searches and for the walk alike — it costs two git processes, and
-    /// the trees are deduplicated before the walk for the same reason
-    /// `search_roots_with` deduplicates its roots: in an ordinary clone the
-    /// main checkout IS this work tree, and walking it twice is the whole
-    /// exhaustive walk paid over again for the same answer.
+    /// Every directory of every one of those trees, not every discovered
+    /// project: a repository whose root carries a harness marker IS a
+    /// project to the discovery walk, which stops there and never sees the
+    /// nested project that armed the hooks.
+    ///
+    /// The cheap probe comes first, because the roots `present` searches
+    /// are where the copy nearly always is and answering from them skips
+    /// every walk. The trees are deduplicated for the same reason
+    /// [`search_roots`] deduplicates its roots: walking one twice is the
+    /// whole exhaustive walk paid again for the same answer.
+    ///
+    /// A domain that could not be read in full is an error, not a no: the
+    /// caller turns a no into advice to delete the hook files.
     ///
     /// [`present`]: Installed::present
-    pub fn anywhere(repo: &super::Repo) -> bool {
-        let main = main_checkout(repo);
+    /// [`Repo::worktrees`]: super::Repo::worktrees
+    pub fn anywhere(repo: &super::Repo) -> Result<bool> {
         let mut carries = |dir: &Path| {
             SKILL_ROOTS
                 .iter()
                 .map(|base| dir.join(base).join(SKILL))
                 .any(|dir| dir.exists() || dir.is_symlink())
         };
-        if search_roots_with(repo, main.clone())
-            .iter()
-            .any(|root| carries(root))
-        {
-            return true;
+        if search_roots(repo).iter().any(|root| carries(root)) {
+            return Ok(true);
         }
-        let mut trees = vec![repo.worktree.clone()];
-        if let Some(main) = main.filter(|main| *main != repo.worktree) {
-            trees.push(main);
+        let mut trees = repo.worktrees()?;
+        // The tree the caller is standing in is in the domain whatever git
+        // listed: it is attached to this common dir by definition, and an
+        // answer of "no copy anywhere" that never looked here would be the
+        // worst one to be wrong about.
+        if !trees.contains(&repo.worktree) {
+            trees.push(repo.worktree.clone());
         }
-        trees
-            .iter()
-            .any(|tree| crate::discover::any_dir(tree, &mut carries))
+        for tree in &trees {
+            if crate::discover::any_dir(tree, &mut carries)? {
+                return Ok(true);
+            }
+        }
+        Ok(false)
     }
 
     /// Whether any copy of the package is here at all, for a message that
@@ -164,12 +174,7 @@ impl Installed {
 /// Duplicates are dropped rather than avoided: in an ordinary single-project
 /// clone every one of these is the same directory.
 fn search_roots(repo: &super::Repo) -> Vec<PathBuf> {
-    search_roots_with(repo, main_checkout(repo))
-}
-
-/// The same roots, with the main checkout already resolved by a caller
-/// that needs it for something else too.
-fn search_roots_with(repo: &super::Repo, main: Option<PathBuf>) -> Vec<PathBuf> {
+    let main = main_checkout(repo);
     let project = project_root(repo);
     // The project path carried across, and only when it IS a path under this
     // work tree: a project root that is not below it has no counterpart to

--- a/crates/core/src/guard/resolve.rs
+++ b/crates/core/src/guard/resolve.rs
@@ -98,10 +98,10 @@ impl Installed {
     /// tree is what the shared shims run, and a search that never looked
     /// there reports it as a leftover to delete.
     ///
-    /// Every directory of every one of those trees, not every discovered
-    /// project: a repository whose root carries a harness marker IS a
-    /// project to the discovery walk, which stops there and never sees the
-    /// nested project that armed the hooks.
+    /// Every directory the project walk's pruning leaves in every one of
+    /// those trees, not every discovered project: a repository whose root
+    /// carries a harness marker IS a project to the discovery walk, which
+    /// stops there and never sees the nested project that armed the hooks.
     ///
     /// The cheap probe comes first, because the roots `present` searches
     /// are where the copy nearly always is and answering from them skips

--- a/crates/core/src/guard/resolve.rs
+++ b/crates/core/src/guard/resolve.rs
@@ -85,34 +85,40 @@ impl Installed {
         None
     }
 
-    /// Whether any kendex project in this repository carries the package.
+    /// Whether anything in this repository carries the package.
     ///
     /// The question `stranded` asks, and a wider one than [`present`]: that
     /// searches from where the caller stands, which is the right copy to
     /// RUN, while a hooks directory is shared by every project in the work
-    /// tree and by every linked work tree of it. So every project under
-    /// this work tree and under the main checkout is searched — a copy in
-    /// any of them is what the shared shims run.
+    /// tree and by every linked work tree of it. So the whole work tree and
+    /// the whole main checkout are walked, every directory asked for a
+    /// skills root holding the package — a copy anywhere in them is what
+    /// the shared shims run.
+    ///
+    /// Every directory, not every discovered project: a repository whose
+    /// root carries a harness marker IS a project to the discovery walk,
+    /// which stops there and never sees the nested project that armed the
+    /// hooks. The main checkout is resolved once, for the roots `present`
+    /// searches and for the walk alike — it costs two git processes.
     ///
     /// [`present`]: Installed::present
-    pub fn anywhere(repo: &super::Repo) -> Result<bool> {
-        if Installed::present(repo).is_some() {
-            return Ok(true);
+    pub fn anywhere(repo: &super::Repo) -> bool {
+        let main = main_checkout(repo);
+        let mut carries = |dir: &Path| {
+            SKILL_ROOTS
+                .iter()
+                .map(|base| dir.join(base).join(SKILL))
+                .any(|dir| dir.exists() || dir.is_symlink())
+        };
+        if search_roots_with(repo, main.clone())
+            .iter()
+            .any(|root| carries(root))
+        {
+            return true;
         }
-        let mut trees = vec![repo.worktree.clone()];
-        trees.extend(main_checkout(repo));
-        for tree in trees {
-            for project in crate::discover::discover_projects(&tree)? {
-                if SKILL_ROOTS
-                    .iter()
-                    .map(|base| project.join(base).join(SKILL))
-                    .any(|dir| dir.exists() || dir.is_symlink())
-                {
-                    return Ok(true);
-                }
-            }
-        }
-        Ok(false)
+        std::iter::once(&repo.worktree)
+            .chain(main.iter())
+            .any(|tree| crate::discover::any_dir(tree, &mut carries))
     }
 
     /// Whether any copy of the package is here at all, for a message that
@@ -149,8 +155,13 @@ impl Installed {
 /// Duplicates are dropped rather than avoided: in an ordinary single-project
 /// clone every one of these is the same directory.
 fn search_roots(repo: &super::Repo) -> Vec<PathBuf> {
+    search_roots_with(repo, main_checkout(repo))
+}
+
+/// The same roots, with the main checkout already resolved by a caller
+/// that needs it for something else too.
+fn search_roots_with(repo: &super::Repo, main: Option<PathBuf>) -> Vec<PathBuf> {
     let project = project_root(repo);
-    let main = main_checkout(repo);
     // The project path carried across, and only when it IS a path under this
     // work tree: a project root that is not below it has no counterpart to
     // map, and joining an absolute path would silently replace the checkout.

--- a/crates/core/src/repo_effects.rs
+++ b/crates/core/src/repo_effects.rs
@@ -28,6 +28,7 @@ use declaration::split_script;
 pub use declaration::{RepoEffects, declared};
 pub use disclosure::{
     Companion, Disclosure, Offers, Withheld, Written, installed_skills, offers, offers_for,
+    touches_git,
 };
 
 use serde::{Deserialize, Serialize};

--- a/crates/core/src/repo_effects.rs
+++ b/crates/core/src/repo_effects.rs
@@ -95,6 +95,21 @@ fn launch_script(
     Ok(crate::guard::relay(&output))
 }
 
+/// Run one of a package's declared scripts and hand back what it said.
+///
+/// Whichever script it is: `arm` is the installer's path and judges the
+/// exit itself, because a failed install is a half-written repository with
+/// one account to give. A caller undoing an effect reads the same verdict
+/// against a different plan, so it takes the report and decides.
+pub fn run_script(
+    scope: &crate::model::Scope,
+    root: &std::path::Path,
+    spec: &str,
+) -> crate::error::Result<crate::guard::GuardReport> {
+    let (repo, program, argv) = resolve_script(scope, root, spec)?;
+    launch_script(repo, &program, argv)
+}
+
 fn err(message: impl Into<String>) -> crate::error::CoreError {
     crate::error::CoreError::Guard {
         check: "repo-effects".to_owned(),

--- a/crates/core/src/repo_effects.rs
+++ b/crates/core/src/repo_effects.rs
@@ -25,7 +25,7 @@
 mod declaration;
 pub mod disclosure;
 use declaration::split_script;
-pub use declaration::{RepoEffects, declared};
+pub use declaration::{Declaration, RepoEffects, declaration, declared};
 pub use disclosure::{
     Companion, Disclosure, Offers, Withheld, Written, installed_skills, offers, offers_for,
     touches_git,
@@ -111,7 +111,7 @@ pub fn run_script(
     launch_script(repo, &program, argv)
 }
 
-fn err(message: impl Into<String>) -> crate::error::CoreError {
+pub(crate) fn err(message: impl Into<String>) -> crate::error::CoreError {
     crate::error::CoreError::Guard {
         check: "repo-effects".to_owned(),
         message: message.into(),

--- a/crates/core/src/repo_effects/declaration.rs
+++ b/crates/core/src/repo_effects/declaration.rs
@@ -80,7 +80,16 @@ pub fn declaration(skill_md: &str) -> Declaration {
         return Declaration::Unreadable;
     };
     let Some(value) = parsed.map.get(KEY) else {
-        return Declaration::Absent;
+        // A top-level line carrying no colon opens no entry at all: it is
+        // dropped whole, warned about, and the block indented under it goes
+        // with it. So `repo-effects:` typed without its colon reaches here
+        // looking exactly like a package that declares nothing, while the
+        // uninstaller it named is still on disk under armed hooks. Ask what
+        // the parser said it skipped rather than reading the text again.
+        return match parsed.ignored.iter().any(|line| names_key(line)) {
+            true => Declaration::Unreadable,
+            false => Declaration::Absent,
+        };
     };
     let Value::Map(map) = value else {
         return Declaration::Unreadable;
@@ -105,6 +114,16 @@ pub fn declared(skill_md: &str) -> Option<RepoEffects> {
         Declaration::Effects(effects) => Some(effects),
         Declaration::Absent | Declaration::Unreadable => None,
     }
+}
+
+/// Whether a line the parser skipped is this declaration's key, mistyped.
+///
+/// The first word, because that is as much as the line has: it opened no
+/// entry, so there is no value to weigh — anything starting `repo-effects`
+/// and going on without a colon is the key written wrong, never a package
+/// with nothing to declare.
+fn names_key(line: &str) -> bool {
+    line.split_whitespace().next() == Some(KEY)
 }
 
 /// The block's fields, or `None` where any one of them will not read.

--- a/crates/core/src/repo_effects/declaration.rs
+++ b/crates/core/src/repo_effects/declaration.rs
@@ -24,7 +24,7 @@ pub struct RepoEffects {
     /// effect. Absent means kendex has nothing to run and the disclosure
     /// ends with what the reader should run themselves.
     pub installer: Option<String>,
-    /// The script that undoes the effect. A plan that takes the package
+    /// The script that undoes the effect. A CLI verb that takes the package
     /// out of a scope runs it first, while the file is still there.
     pub uninstaller: Option<String>,
     /// How to undo the effect by hand, for the disclosure's last line.

--- a/crates/core/src/repo_effects/declaration.rs
+++ b/crates/core/src/repo_effects/declaration.rs
@@ -24,12 +24,8 @@ pub struct RepoEffects {
     /// effect. Absent means kendex has nothing to run and the disclosure
     /// ends with what the reader should run themselves.
     pub installer: Option<String>,
-    /// The script that undoes the effect.
-    ///
-    /// Declared, not yet run: nothing in kendex executes it, and `remove`
-    /// takes the package's files away with the effect still applied. The
-    /// disclosure names it so a person can run it themselves, which is the
-    /// whole of what it does today. KEN-674 carries wiring it into removal.
+    /// The script that undoes the effect. A plan that takes the package
+    /// out of a scope runs it first, while the file is still there.
     pub uninstaller: Option<String>,
     /// How to undo the effect by hand, for the disclosure's last line.
     pub removal: Option<String>,

--- a/crates/core/src/repo_effects/declaration.rs
+++ b/crates/core/src/repo_effects/declaration.rs
@@ -40,25 +40,80 @@ pub struct RepoEffects {
     pub companions: Vec<String>,
 }
 
+/// What a package's `SKILL.md` says about the repository: three answers,
+/// not two.
+///
+/// A caller ARMING an effect can collapse the last two — a declaration it
+/// cannot read names an installer it will not run either way. A caller
+/// DISARMING one cannot: a package that declares nothing has no
+/// uninstaller and the removal proceeds, while a declaration that will not
+/// read may name one, and calling that nothing takes a package's scripts
+/// out from under shims still delegating to them.
+#[derive(Debug, Clone, PartialEq)]
+pub enum Declaration {
+    /// No `repo-effects` block. The ordinary case, never an error.
+    Absent,
+    /// A declaration that is there and will not read.
+    Unreadable,
+    /// The declaration, read whole.
+    Effects(RepoEffects),
+}
+
+/// Read one package's declaration out of its `SKILL.md`.
+pub fn declaration(skill_md: &str) -> Declaration {
+    let Ok((yaml, _)) = crate::frontmatter::split(skill_md) else {
+        // A file that opens no frontmatter carries no declaration: there is
+        // no YAML for one to sit in, and nothing reads a block out of
+        // prose. A block that opens and never closes is the other case —
+        // frontmatter kendex could not read, which may well declare.
+        return match crate::frontmatter::opens(skill_md) {
+            true => Declaration::Unreadable,
+            false => Declaration::Absent,
+        };
+    };
+    // Frontmatter that will not parse is a declaration kendex could not
+    // read, never one that is not there: `parse_tolerant` fails the whole
+    // block for any multi-line entry whose YAML is broken, and a
+    // `repo-effects` block is always multi-line — so a missing key here is
+    // a key that was never looked for.
+    let Ok(parsed) = crate::frontmatter::parse_tolerant(yaml) else {
+        return Declaration::Unreadable;
+    };
+    let Some(value) = parsed.map.get(KEY) else {
+        return Declaration::Absent;
+    };
+    let Value::Map(map) = value else {
+        return Declaration::Unreadable;
+    };
+    match effects(map) {
+        Some(effects) => Declaration::Effects(effects),
+        None => Declaration::Unreadable,
+    }
+}
+
 /// The declaration in one package's `SKILL.md`, or `None` where there is
 /// none — which is the ordinary case and never an error.
 ///
 /// A malformed declaration is also `None`: a package whose effects cannot
 /// be read is treated as declaring none, and its installer is therefore
 /// never run. Failing that way round is the safe one — the alternative is
-/// running a script whose disclosure kendex could not show.
+/// running a script whose disclosure kendex could not show. The reading for
+/// a caller that undoes an effect instead of arming one is
+/// [`declaration`], which keeps the two apart.
 pub fn declared(skill_md: &str) -> Option<RepoEffects> {
-    let (yaml, _) = crate::frontmatter::split(skill_md).ok()?;
-    let parsed = crate::frontmatter::parse_tolerant(yaml).ok()?;
-    let Some(Value::Map(map)) = parsed.map.get(KEY) else {
-        return None;
-    };
+    match declaration(skill_md) {
+        Declaration::Effects(effects) => Some(effects),
+        Declaration::Absent | Declaration::Unreadable => None,
+    }
+}
+
+/// The block's fields, or `None` where any one of them will not read.
+fn effects(map: &Map) -> Option<RepoEffects> {
     if !only_known(map) {
         return None;
     }
-    let summary = scalar(map, "summary")?;
     Some(RepoEffects {
-        summary,
+        summary: scalar(map, "summary")?,
         writes: writes(map)?,
         installer: script(map, "installer")?,
         uninstaller: script(map, "uninstaller")?,

--- a/crates/core/src/repo_effects/declaration/tests.rs
+++ b/crates/core/src/repo_effects/declaration/tests.rs
@@ -47,6 +47,10 @@ fn an_unreadable_declaration_is_not_an_absent_one() {
         // Frontmatter that opens and never closes is frontmatter kendex
         // could not read, whatever it says.
         "---\nname: x\nrepo-effects:\n  summary: s\n  uninstaller: scripts/off\nbody\n",
+        // The key lost its colon, so the whole block was ignored as a line
+        // carrying no key. Nothing else in the frontmatter fails, and the
+        // package still has the uninstaller it declared.
+        "---\nname: x\nrepo-effects\n  summary: s\n  uninstaller: scripts/off\n---\nbody\n",
     ];
     for text in unreadable {
         assert_eq!(

--- a/crates/core/src/repo_effects/declaration/tests.rs
+++ b/crates/core/src/repo_effects/declaration/tests.rs
@@ -18,6 +18,49 @@ fn a_package_declaring_nothing_reads_as_nothing() {
     assert!(declared("no frontmatter at all\n").is_none());
 }
 
+/// Absent and unreadable are the same `None` to a caller that arms an
+/// effect and different answers to one that undoes it: the first package
+/// has no uninstaller, the second may have one kendex could not read, and
+/// removing the second as though it were the first strands whatever it
+/// armed.
+#[test]
+fn an_unreadable_declaration_is_not_an_absent_one() {
+    assert_eq!(
+        declaration(DECLARED),
+        Declaration::Effects(declared(DECLARED).expect("declared"))
+    );
+    for absent in ["---\nname: deploy\n---\nbody\n", "no frontmatter at all\n"] {
+        assert_eq!(
+            declaration(absent),
+            Declaration::Absent,
+            "a package that declares nothing: {absent}"
+        );
+    }
+    let unreadable = [
+        // The block is there and its YAML is broken — the whole
+        // frontmatter fails to parse, so the key is never even looked for.
+        "---\nname: x\nrepo-effects:\n  summary: s\n installer: \"scripts/run\n---\nbody\n",
+        // The block is there and is not a block.
+        "---\nname: x\nrepo-effects: arms things\n---\nbody\n",
+        // The block is there and one field will not read.
+        "---\nname: x\nrepo-effects:\n  summary: s\n  writes:\n    a: b\n---\nbody\n",
+        // Frontmatter that opens and never closes is frontmatter kendex
+        // could not read, whatever it says.
+        "---\nname: x\nrepo-effects:\n  summary: s\n  uninstaller: scripts/off\nbody\n",
+    ];
+    for text in unreadable {
+        assert_eq!(
+            declaration(text),
+            Declaration::Unreadable,
+            "read as an answer about the package: {text}"
+        );
+        assert!(
+            declared(text).is_none(),
+            "arming reads it as nothing: {text}"
+        );
+    }
+}
+
 /// A summary is what the disclosure is made of; without one there is
 /// nothing to show, so there is nothing to authorize either.
 #[test]

--- a/crates/core/src/repo_effects/disclosure.rs
+++ b/crates/core/src/repo_effects/disclosure.rs
@@ -238,7 +238,13 @@ fn under_git(declared: &str) -> Option<PathBuf> {
 }
 
 /// Whether anything this package declares lands in the git directory.
-fn touches_git(effects: &RepoEffects) -> bool {
+///
+/// Public because undoing an effect asks it too: a package that writes
+/// nowhere near `.git` was offered in a plain directory and has something
+/// to undo there, and one that writes into `.git` was never offered at all.
+/// The same reading on both sides, so an effect is armed and disarmed under
+/// one test rather than two spellings of one.
+pub fn touches_git(effects: &RepoEffects) -> bool {
     effects.writes.iter().any(|path| under_git(path).is_some())
 }
 

--- a/crates/core/tests/discover_any_dir.rs
+++ b/crates/core/tests/discover_any_dir.rs
@@ -1,0 +1,104 @@
+//! `discover::any_dir` walks what its own rustdoc says it walks.
+//!
+//! Every claim there is load-bearing for `guard::stranded`, which asks the
+//! walk whether any copy of the growth-guards package is left in the work
+//! tree before calling a marker in the hook files a leftover. A wrong no
+//! tells someone to delete the shims a neighbouring project is arming, so
+//! each rule the walk states is pinned here rather than inferred from the
+//! one caller: that it stops at no project, caps no depth, and prunes
+//! hidden directories, `SKIP_DIRS` and symlinked directories.
+//!
+//! `crates/cli/tests/guard_hooks/arming.rs` covers the verdict this feeds;
+//! these are the walk's own terms, which a refactor routing it back through
+//! the capped project walk would break with that test still green.
+
+use std::fs;
+use std::path::{Path, PathBuf};
+
+use kendex_core::discover::any_dir;
+
+/// A package copy as `anywhere` looks for it: a skills root under the
+/// directory being asked about.
+const PACKAGE: &str = ".agents/skills/growth-guards";
+
+#[allow(clippy::unwrap_used)]
+fn tree(dirs: &[&str]) -> tempfile::TempDir {
+    let tmp = tempfile::tempdir().unwrap();
+    for dir in dirs {
+        fs::create_dir_all(tmp.path().join(dir)).unwrap();
+    }
+    tmp
+}
+
+fn carries(dir: &Path) -> bool {
+    dir.join(PACKAGE).is_dir()
+}
+
+/// "It has no depth cap, because a copy at depth six is a copy." The walk
+/// this replaced stopped at `MAX_DEPTH` of 5.
+#[test]
+fn a_copy_at_depth_six_is_found() {
+    let tmp = tree(&[&format!("one/two/three/four/five/six/{PACKAGE}")]);
+    assert!(any_dir(tmp.path(), &mut carries));
+}
+
+/// "It does not stop at a project": a repository whose own root carries a
+/// harness marker is a project to the discovery walk, which would stop
+/// there and never reach the nested project that armed the hooks.
+#[test]
+fn a_project_marker_at_the_root_does_not_stop_the_walk() {
+    let tmp = tree(&[".claude/skills", &format!("apps/web/{PACKAGE}")]);
+    assert!(any_dir(tmp.path(), &mut carries));
+}
+
+/// "The same pruning as the project walk — hidden directories, the build
+/// and dependency trees in `SKIP_DIRS`". A copy behind one of those is not
+/// what the shared shims run, so it must not answer for them.
+#[test]
+fn a_copy_behind_a_pruned_directory_is_not_found() {
+    for pruned in [
+        "node_modules",
+        "target",
+        ".git",
+        "dist",
+        "build",
+        ".venv",
+        ".cache",
+        ".kendex-local",
+    ] {
+        let tmp = tree(&[&format!("{pruned}/nested/{PACKAGE}")]);
+        assert!(
+            !any_dir(tmp.path(), &mut carries),
+            "walked into {pruned}, which the pruning rules exclude"
+        );
+    }
+}
+
+/// "Symlinked directories" are pruned, which is the only thing keeping the
+/// uncapped walk finite. A link back at an ancestor would otherwise recurse
+/// until the stack ran out.
+#[cfg(unix)]
+#[test]
+#[allow(clippy::unwrap_used)]
+fn a_symlink_to_an_ancestor_is_not_descended() {
+    let tmp = tree(&["a/b"]);
+    std::os::unix::fs::symlink(tmp.path(), tmp.path().join("a/up")).unwrap();
+
+    let mut asked: Vec<PathBuf> = Vec::new();
+    let found = any_dir(tmp.path(), &mut |dir| {
+        asked.push(dir.to_path_buf());
+        false
+    });
+
+    assert!(!found);
+    // Three real directories and no fourth: the link was never entered, so
+    // the walk terminated instead of circling through it.
+    asked.sort();
+    let mut want = vec![
+        tmp.path().to_path_buf(),
+        tmp.path().join("a"),
+        tmp.path().join("a/b"),
+    ];
+    want.sort();
+    assert_eq!(asked, want);
+}

--- a/crates/core/tests/discover_any_dir.rs
+++ b/crates/core/tests/discover_any_dir.rs
@@ -34,12 +34,20 @@ fn carries(dir: &Path) -> bool {
     dir.join(PACKAGE).is_dir()
 }
 
+/// The walk over a whole tree, asserted to have seen all of it. A test
+/// about which directories are reached has nothing to say if part of the
+/// tree could not be read.
+#[allow(clippy::unwrap_used)]
+fn found(tmp: &tempfile::TempDir, carries: &mut dyn FnMut(&Path) -> bool) -> bool {
+    any_dir(tmp.path(), carries).unwrap()
+}
+
 /// "It has no depth cap, because a copy at depth six is a copy." The walk
 /// this replaced stopped at `MAX_DEPTH` of 5.
 #[test]
 fn a_copy_at_depth_six_is_found() {
     let tmp = tree(&[&format!("one/two/three/four/five/six/{PACKAGE}")]);
-    assert!(any_dir(tmp.path(), &mut carries));
+    assert!(found(&tmp, &mut carries));
 }
 
 /// "It does not stop at a project": a repository whose own root carries a
@@ -48,7 +56,7 @@ fn a_copy_at_depth_six_is_found() {
 #[test]
 fn a_project_marker_at_the_root_does_not_stop_the_walk() {
     let tmp = tree(&[".claude/skills", &format!("apps/web/{PACKAGE}")]);
-    assert!(any_dir(tmp.path(), &mut carries));
+    assert!(found(&tmp, &mut carries));
 }
 
 /// "The same pruning as the project walk — hidden directories, the build
@@ -68,7 +76,7 @@ fn a_copy_behind_a_pruned_directory_is_not_found() {
     ] {
         let tmp = tree(&[&format!("{pruned}/nested/{PACKAGE}")]);
         assert!(
-            !any_dir(tmp.path(), &mut carries),
+            !found(&tmp, &mut carries),
             "walked into {pruned}, which the pruning rules exclude"
         );
     }
@@ -85,12 +93,13 @@ fn a_symlink_to_an_ancestor_is_not_descended() {
     std::os::unix::fs::symlink(tmp.path(), tmp.path().join("a/up")).unwrap();
 
     let mut asked: Vec<PathBuf> = Vec::new();
-    let found = any_dir(tmp.path(), &mut |dir| {
+    let hit = any_dir(tmp.path(), &mut |dir| {
         asked.push(dir.to_path_buf());
         false
-    });
+    })
+    .unwrap();
 
-    assert!(!found);
+    assert!(!hit);
     // Three real directories and no fourth: the link was never entered, so
     // the walk terminated instead of circling through it.
     asked.sort();
@@ -101,4 +110,71 @@ fn a_symlink_to_an_ancestor_is_not_descended() {
     ];
     want.sort();
     assert_eq!(asked, want);
+}
+
+/// "A part of the domain that could not be traversed is reported, never
+/// counted as empty." A directory the walk cannot open is not a directory
+/// with nothing in it, and `guard::stranded` turns "nothing anywhere" into
+/// advice to delete a repository's hook files.
+#[cfg(unix)]
+#[test]
+#[allow(clippy::unwrap_used)]
+fn a_directory_that_cannot_be_read_is_not_an_absence() {
+    let Some(tmp) = with_a_locked_dir() else {
+        return;
+    };
+    let error = any_dir(tmp.path(), &mut carries)
+        .expect_err("an unreadable directory read as a tree holding no copy");
+    unlock(&tmp);
+    assert!(
+        error.to_string().contains("locked"),
+        "the failure does not name the directory: {error}"
+    );
+}
+
+/// "A hit still wins": the walk carries the failure along instead of
+/// stopping on it, so a copy in a readable part of the tree is found
+/// whatever else could not be read. Anything less would report a repository
+/// that plainly carries the package as one whose state is unknown.
+#[cfg(unix)]
+#[test]
+#[allow(clippy::unwrap_used)]
+fn a_copy_beside_an_unreadable_directory_is_still_found() {
+    let Some(tmp) = with_a_locked_dir() else {
+        return;
+    };
+    fs::create_dir_all(tmp.path().join("readable").join(PACKAGE)).unwrap();
+    let hit = any_dir(tmp.path(), &mut carries);
+    unlock(&tmp);
+    assert!(
+        hit.unwrap(),
+        "a readable copy was lost to an unreadable peer"
+    );
+}
+
+/// A tree with one directory this process cannot open, or `None` where the
+/// permission bits do not stop this process — running as root, where there
+/// is no unreadable directory to build.
+#[cfg(unix)]
+#[allow(clippy::unwrap_used)]
+fn with_a_locked_dir() -> Option<tempfile::TempDir> {
+    use std::os::unix::fs::PermissionsExt;
+    let tmp = tree(&["locked/nested"]);
+    let locked = tmp.path().join("locked");
+    fs::set_permissions(&locked, fs::Permissions::from_mode(0o000)).unwrap();
+    match fs::read_dir(&locked).is_err() {
+        true => Some(tmp),
+        false => {
+            unlock(&tmp);
+            None
+        }
+    }
+}
+
+/// Readable again, so the temporary directory can be removed.
+#[cfg(unix)]
+#[allow(clippy::unwrap_used)]
+fn unlock(tmp: &tempfile::TempDir) {
+    use std::os::unix::fs::PermissionsExt;
+    fs::set_permissions(tmp.path().join("locked"), fs::Permissions::from_mode(0o755)).unwrap();
 }

--- a/crates/core/tests/repo_effects_leaving.rs
+++ b/crates/core/tests/repo_effects_leaving.rs
@@ -121,3 +121,59 @@ fn a_removal_carries_the_effects_of_what_it_takes_away() {
         after.repo_effects_leaving
     );
 }
+
+/// A declaration that will not read stops the removal, with everything the
+/// package left behind still in place.
+///
+/// The armed shim is the reason. Reading a malformed declaration as "this
+/// package declares nothing" is a removal that runs no uninstaller and
+/// takes the scripts away regardless, and every commit in the repository
+/// then fails on a hook delegating to a file that is gone. A locally
+/// edited `SKILL.md` gets there: the frontmatter no longer parses, and the
+/// removal discards the edit anyway.
+#[test]
+#[allow(clippy::unwrap_used)]
+fn a_declaration_that_will_not_read_stops_the_removal() {
+    let f = fixture();
+    let install = audit(&f.env, &f.scope).unwrap();
+    apply::execute(&f.env, &install.plan, None).unwrap();
+
+    let tree = f.project.join(".agents/skills/armer");
+    let hooks = f.project.join(".git/hooks");
+    fs::create_dir_all(&hooks).unwrap();
+    let shim = hooks.join("pre-commit");
+    fs::write(&shim, "#!/bin/sh\nexec .agents/skills/armer/scripts/arm\n").unwrap();
+
+    // The declaration is edited on disk into frontmatter that will not
+    // parse — the block is still there, and kendex can no longer read it.
+    let declaration = tree.join("SKILL.md");
+    let edited = fs::read_to_string(&declaration)
+        .unwrap()
+        .replace("  installer:", " installer: \"unclosed\n  quoted:");
+    fs::write(&declaration, &edited).unwrap();
+
+    let error = ops::remove(&f.env, &f.scope, &["armer".to_owned()], None, false)
+        .expect_err("a declaration kendex cannot read was read as declaring nothing");
+    let said = error.to_string();
+    assert!(
+        said.contains("SKILL.md") && said.contains("repo-effects"),
+        "the error names neither the file nor why: {said}"
+    );
+
+    assert!(
+        tree.join("scripts/arm").is_file(),
+        "the scripts the shim delegates to are gone"
+    );
+    assert!(shim.is_file(), "the armed hook outlived its script");
+    assert!(
+        fs::read_to_string(f.project.join("kendex.toml"))
+            .unwrap()
+            .contains("[skills.armer]"),
+        "the manifest forgot a package that is still installed"
+    );
+    let lock = kendex_core::lock::load(&kendex_core::lock::lock_path(&f.env, &f.scope)).unwrap();
+    assert!(
+        lock.entries.values().any(|entry| entry.name == "armer"),
+        "the lock forgot a package that is still installed"
+    );
+}

--- a/crates/core/tests/repo_effects_leaving.rs
+++ b/crates/core/tests/repo_effects_leaving.rs
@@ -1,0 +1,123 @@
+//! What a plan says about the packages it takes away that declared an
+//! effect on the repository.
+//!
+//! The add side reads declarations off the bytes it is about to write. A
+//! removal has no such bytes — the item is gone from the desired state —
+//! so the declaration is read off the tree still on disk, and the report
+//! carries it for the one window in which the uninstaller can still run.
+#![cfg(unix)]
+
+use std::fs;
+use std::path::PathBuf;
+
+use kendex_core::apply;
+use kendex_core::engine::{audit, ops};
+use kendex_core::env::{Env, FakeOs};
+use kendex_core::model::Scope;
+
+struct Fixture {
+    _tmp: tempfile::TempDir,
+    env: Env,
+    scope: Scope,
+    project: PathBuf,
+}
+
+#[allow(clippy::unwrap_used)]
+fn fixture() -> Fixture {
+    let tmp = tempfile::tempdir().unwrap();
+    let home = tmp.path().to_path_buf();
+    let env = Env::fake(&home, FakeOs::Linux);
+    let project = home.join("dev/app");
+    fs::create_dir_all(project.join(".claude")).unwrap();
+
+    let source = home.join("catalog");
+    let armer = source.join("skills/armer");
+    fs::create_dir_all(armer.join("scripts")).unwrap();
+    fs::write(
+        armer.join("SKILL.md"),
+        "---\nname: armer\ndescription: arms something\nrepo-effects:\n  summary: \"arms the repository\"\n  installer: \"scripts/arm\"\n  uninstaller: \"scripts/arm --off\"\n---\nBody.\n",
+    )
+    .unwrap();
+    fs::write(armer.join("scripts/arm"), "#!/bin/sh\nexit 0\n").unwrap();
+    let quiet = source.join("skills/quiet");
+    fs::create_dir_all(&quiet).unwrap();
+    fs::write(
+        quiet.join("SKILL.md"),
+        "---\nname: quiet\ndescription: changes nothing\n---\nBody.\n",
+    )
+    .unwrap();
+
+    fs::write(
+        project.join("kendex.toml"),
+        format!(
+            "schema = 6\n\n[sources.cat]\npath = \"{}\"\n\n[install]\nharnesses = [\"claude\"]\nmethod = \"symlink\"\n\n[skills.armer]\nsource = \"cat\"\n\n[skills.quiet]\nsource = \"cat\"\n",
+            source.display()
+        ),
+    )
+    .unwrap();
+
+    Fixture {
+        env,
+        scope: Scope::Project {
+            root: project.clone(),
+        },
+        project,
+        _tmp: tmp,
+    }
+}
+
+/// The removal carries the declaration, read off the installed tree,
+/// rooted where the uninstaller resolves — and only for a package that
+/// declared one.
+#[test]
+#[allow(clippy::unwrap_used)]
+fn a_removal_carries_the_effects_of_what_it_takes_away() {
+    let f = fixture();
+    let install = audit(&f.env, &f.scope).unwrap();
+    assert_eq!(install.repo_effects.len(), 1, "{:?}", install.repo_effects);
+    assert!(
+        install.repo_effects_leaving.is_empty(),
+        "an install has nothing leaving: {:?}",
+        install.repo_effects_leaving
+    );
+    apply::execute(&f.env, &install.plan, None).unwrap();
+
+    let quiet = ops::remove(&f.env, &f.scope, &["quiet".to_owned()], None, false).unwrap();
+    assert!(
+        quiet.repo_effects_leaving.is_empty(),
+        "a package that declared nothing has nothing to undo: {:?}",
+        quiet.repo_effects_leaving
+    );
+
+    let removal = ops::remove(&f.env, &f.scope, &["armer".to_owned()], None, false).unwrap();
+    assert!(
+        removal.repo_effects.is_empty(),
+        "a removal offers nothing to arm: {:?}",
+        removal.repo_effects
+    );
+    let [leaving] = removal.repo_effects_leaving.as_slice() else {
+        panic!(
+            "expected one leaving effect: {:?}",
+            removal.repo_effects_leaving
+        );
+    };
+    assert_eq!(leaving.name, "armer");
+    assert_eq!(leaving.root, f.project.join(".agents/skills/armer"));
+    assert_eq!(
+        leaving.effects.uninstaller.as_deref(),
+        Some("scripts/arm --off")
+    );
+    assert!(
+        leaving.root.join("scripts/arm").is_file(),
+        "the script is still there to run while the plan is only planned"
+    );
+
+    // Once the plan has executed there is nothing left to leave.
+    apply::execute(&f.env, &removal.plan, None).unwrap();
+    let after = audit(&f.env, &f.scope).unwrap();
+    assert!(
+        after.repo_effects_leaving.is_empty(),
+        "{:?}",
+        after.repo_effects_leaving
+    );
+}

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -387,8 +387,8 @@ lives in one capability table read by core and UI.
   that drops a package runs its declared uninstaller before the files go (`engine_common::apply_report`, the one
   executor of an `EngineReport`), and `guard run <hook>` execs its script with git's redirects passed through, the
   one child not scrubbed because it is a hook body naming the snapshot judged. `guard check` asks the package too.
-  `kendex check` executes nothing: our marker in both hook files, both executable, hooksPath unset, or not armed —
-  and the marker with the package under no project of the repository is a leftover it names by file (`guard::stranded`).
+  `kendex check` executes nothing: our marker in both hook files, both executable, hooksPath unset, or not armed — and the
+  marker with no copy of the package anywhere in this work tree or the main checkout is a leftover it names by file (`guard::stranded`).
   So there is one implementation of every verdict and one policy dialect:
   the flat `GROWTH_GUARDS_*` / `SIZE_RATCHET_*` keys, baselines and
   excludes the scripts read from the commit. Every enabled check runs

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -388,7 +388,7 @@ lives in one capability table read by core and UI.
   executor of an `EngineReport`), and `guard run <hook>` execs its script with git's redirects passed through, the
   one child not scrubbed because it is a hook body naming the snapshot judged. `guard check` asks the package too.
   `kendex check` executes nothing: our marker in both hook files, both executable, hooksPath unset, or not armed — and the
-  marker with no copy of the package anywhere in this work tree or the main checkout is a leftover it names by file (`guard::stranded`).
+  marker with no copy of the package in any work tree sharing those hooks is a leftover it names by file (`guard::stranded`).
   So there is one implementation of every verdict and one policy dialect:
   the flat `GROWTH_GUARDS_*` / `SIZE_RATCHET_*` keys, baselines and
   excludes the scripts read from the commit. Every enabled check runs

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -383,12 +383,12 @@ lives in one capability table read by core and UI.
   `.agents/skills` — size-ratchet, todo-ban, byte-ceiling, suppression-ban, conflict-markers,
   commit-msg, and preflight's staged lanes. git's own `.git/hooks` shims run them: no kendex binary is in the
   path at commit time, and since git clones no hooks, a clone carries the scripts and one `guard install`
-  arms them. kendex implements no check — `guard install`/`guard uninstall` run the installer, a plan that
-  takes a package out of a scope runs its declared uninstaller before the files go (`engine::repo_effects::leaving`),
-  and `guard run <hook>` execs its script with git's redirects passed through, the one child not scrubbed
-  because it is a hook body naming the snapshot judged. `guard check` asks the package too. `kendex check`
-  executes nothing: our marker in both hook files, both executable, hooksPath unset, or not armed — and the
-  marker with no package under any skills root is a leftover it names by file (`guard::stranded`).
+  arms them. kendex implements no check — `guard install`/`guard uninstall` run the installer, every CLI verb
+  that drops a package runs its declared uninstaller before the files go (`engine_common::apply_report`, the one
+  executor of an `EngineReport`), and `guard run <hook>` execs its script with git's redirects passed through, the
+  one child not scrubbed because it is a hook body naming the snapshot judged. `guard check` asks the package too.
+  `kendex check` executes nothing: our marker in both hook files, both executable, hooksPath unset, or not armed —
+  and the marker with the package under no project of the repository is a leftover it names by file (`guard::stranded`).
   So there is one implementation of every verdict and one policy dialect:
   the flat `GROWTH_GUARDS_*` / `SIZE_RATCHET_*` keys, baselines and
   excludes the scripts read from the commit. Every enabled check runs

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -380,15 +380,15 @@ lives in one capability table read by core and UI.
   so two hosts serving one `owner/repo` never share a mirror.
 - **Commits walk through the guards whatever tool makes them.** The checks
   are the growth-guards package's shell scripts, committed under
-  `.agents/skills` — size-ratchet, todo-ban, byte-ceiling, suppression-ban,
-  conflict-markers, commit-msg, and preflight's staged lanes. git's own `.git/hooks` shims run them: no kendex binary is in the
-  path at commit time, and since git clones no hooks, a clone carries the
-  scripts and one `guard install` arms them. kendex implements
-  no check — `guard install`/`guard uninstall` run the installer and `guard
-  run <hook>` execs its script with git's redirects passed through, the one
-  child not scrubbed because it is a hook body naming the snapshot judged.
-  `guard check` asks the package too. `kendex check` executes nothing: our
-  marker in both hook files, both executable, hooksPath unset, or not armed.
+  `.agents/skills` — size-ratchet, todo-ban, byte-ceiling, suppression-ban, conflict-markers,
+  commit-msg, and preflight's staged lanes. git's own `.git/hooks` shims run them: no kendex binary is in the
+  path at commit time, and since git clones no hooks, a clone carries the scripts and one `guard install`
+  arms them. kendex implements no check — `guard install`/`guard uninstall` run the installer, a plan that
+  takes a package out of a scope runs its declared uninstaller before the files go (`engine::repo_effects::leaving`),
+  and `guard run <hook>` execs its script with git's redirects passed through, the one child not scrubbed
+  because it is a hook body naming the snapshot judged. `guard check` asks the package too. `kendex check`
+  executes nothing: our marker in both hook files, both executable, hooksPath unset, or not armed — and the
+  marker with no package under any skills root is a leftover it names by file (`guard::stranded`).
   So there is one implementation of every verdict and one policy dialect:
   the flat `GROWTH_GUARDS_*` / `SIZE_RATCHET_*` keys, baselines and
   excludes the scripts read from the commit. Every enabled check runs

--- a/skills/growth-guards/DEVELOPMENT.md
+++ b/skills/growth-guards/DEVELOPMENT.md
@@ -92,12 +92,15 @@ away. A delegating line it may not edit (a symlinked hook) keeps the helper
 in place and fails the removal rather than stranding a hook with no guard to
 reach.
 
-The installer runs on `kendex guard install` and on the separate yes an
-install offers — in the terminal (`kendex add`, a collection add, `kendex
-apply`) and in the app. `kendex guard uninstall` and `kendex guard check`
-invoke it too. `kendex remove` does not run the uninstaller (KEN-674):
-disarming before removing the skill is the caller's to do — shims whose
-scripts are gone block every commit.
+kendex runs this installer through the `repo-effects` declaration in
+`SKILL.md`: `kendex add --allow-repo-effects`, or a yes at the prompt in the
+terminal or in the app, runs it after the files land. Every CLI verb that
+drops the package — `kendex remove`, an `apply` or `refresh` whose plan takes
+it away, `marketplace unsubscribe --remove-packages` — runs `--uninstall`
+while the scripts are still on disk, because shims whose scripts are gone
+block every commit. `kendex guard install`, `kendex guard uninstall` and
+`kendex guard check` invoke it directly. `kendex check` reads nothing but the
+hook files: it names shims a deleted package left behind.
 
 `--check` is the read-only counterpart: it writes nothing — not even the
 hooks directory — and answers whether the shims are armed. `0`: the helper

--- a/skills/growth-guards/DEVELOPMENT.md
+++ b/skills/growth-guards/DEVELOPMENT.md
@@ -98,9 +98,10 @@ terminal or in the app, runs it after the files land. Every CLI verb that
 drops the package — `kendex remove`, an `apply` or `refresh` whose plan takes
 it away, `marketplace unsubscribe --remove-packages` — runs `--uninstall`
 while the scripts are still on disk, because shims whose scripts are gone
-block every commit. `kendex guard install`, `kendex guard uninstall` and
-`kendex guard check` invoke it directly. `kendex check` reads nothing but the
-hook files: it names shims a deleted package left behind.
+block every commit.
+`kendex guard install`, `kendex guard uninstall` and `kendex guard check`
+invoke it directly. `kendex check` runs none of this package's scripts: it
+reads the hook files and names shims a deleted package left behind.
 
 `--check` is the read-only counterpart: it writes nothing — not even the
 hooks directory — and answers whether the shims are armed. `0`: the helper

--- a/skills/growth-guards/SKILL.md
+++ b/skills/growth-guards/SKILL.md
@@ -19,7 +19,7 @@ repo-effects:
     - ".git/hooks/commit-msg"
   installer: "scripts/install-git-hooks"
   uninstaller: "scripts/install-git-hooks --uninstall"
-  removal: "run the uninstaller before removing this package: it drops only the helper and one marked line, leaving any hook you wrote. kendex remove does not run it for you, so shims left behind would exec scripts that are gone and fail every commit closed"
+  removal: "kendex guard uninstall, or kendex remove growth-guards, which runs the uninstaller before the files go; either drops only the helper and one marked line, leaving any hook you wrote. Deleting the package any other way leaves shims that exec scripts which are gone and fail every commit closed"
   companions:
     - "size-ratchet"
     - "preflight"

--- a/skills/growth-guards/SKILL.md
+++ b/skills/growth-guards/SKILL.md
@@ -19,7 +19,7 @@ repo-effects:
     - ".git/hooks/commit-msg"
   installer: "scripts/install-git-hooks"
   uninstaller: "scripts/install-git-hooks --uninstall"
-  removal: "kendex guard uninstall, or any kendex verb that drops the package (remove, an apply or refresh that takes it away, marketplace unsubscribe --remove-packages) runs the uninstaller before the files go; it drops only the helper and one marked line, leaving any hook you wrote. Deleting the package any other way leaves shims that exec scripts which are gone and fail every commit closed"
+  removal: "kendex guard uninstall, or any kendex CLI verb that drops the package (remove, an apply or refresh that takes it away, marketplace unsubscribe --remove-packages) runs the uninstaller before the files go; it drops only the helper and one marked line, leaving any hook you wrote. Deleting the package any other way leaves shims that exec scripts which are gone and fail every commit closed"
   companions:
     - "size-ratchet"
     - "preflight"

--- a/skills/growth-guards/SKILL.md
+++ b/skills/growth-guards/SKILL.md
@@ -19,7 +19,7 @@ repo-effects:
     - ".git/hooks/commit-msg"
   installer: "scripts/install-git-hooks"
   uninstaller: "scripts/install-git-hooks --uninstall"
-  removal: "kendex guard uninstall, or kendex remove growth-guards, which runs the uninstaller before the files go; either drops only the helper and one marked line, leaving any hook you wrote. Deleting the package any other way leaves shims that exec scripts which are gone and fail every commit closed"
+  removal: "kendex guard uninstall, or any kendex verb that drops the package (remove, an apply or refresh that takes it away, marketplace unsubscribe --remove-packages) runs the uninstaller before the files go; it drops only the helper and one marked line, leaving any hook you wrote. Deleting the package any other way leaves shims that exec scripts which are gone and fail every commit closed"
   companions:
     - "size-ratchet"
     - "preflight"

--- a/ui/src/bindings.ts
+++ b/ui/src/bindings.ts
@@ -1985,12 +1985,8 @@ export type RepoEffects = {
 	 */
 	installer: string | null,
 	/**
-	 *  The script that undoes the effect.
-	 * 
-	 *  Declared, not yet run: nothing in kendex executes it, and `remove`
-	 *  takes the package's files away with the effect still applied. The
-	 *  disclosure names it so a person can run it themselves, which is the
-	 *  whole of what it does today. KEN-674 carries wiring it into removal.
+	 *  The script that undoes the effect. A plan that takes the package
+	 *  out of a scope runs it first, while the file is still there.
 	 */
 	uninstaller: string | null,
 	/**  How to undo the effect by hand, for the disclosure's last line. */

--- a/ui/src/bindings.ts
+++ b/ui/src/bindings.ts
@@ -1985,7 +1985,7 @@ export type RepoEffects = {
 	 */
 	installer: string | null,
 	/**
-	 *  The script that undoes the effect. A plan that takes the package
+	 *  The script that undoes the effect. A CLI verb that takes the package
 	 *  out of a scope runs it first, while the file is still there.
 	 */
 	uninstaller: string | null,


### PR DESCRIPTION
## Summary

- `kendex remove` runs a leaving package's declared uninstaller while its scripts are still on disk, so removing `growth-guards` disarms the repository instead of leaving hook shims that exec files which are gone. A nonzero uninstaller exit stops the plan with the package still installed.
- One CLI executor owns that ordering: every `EngineReport` goes through `engine_common::apply_report` (uninstall, then apply), so `remove`, `apply`, `refresh`, `marketplace unsubscribe --remove-packages`, source removal and fork rename all disarm. A bare `Plan` with no report behind it drops no package and is executed on its own.
- `kendex check` names the leftover once it exists: a hook file carrying the package's marker in a repository where no project under any skills root holds the package is reported as drift, naming the files to remove. It runs none of the package's scripts.

## Completed Issues

- Closes KEN-674 - kendex remove leaves armed git hooks behind, and the repo cannot commit

## Created Issues

- KEN-709 - Desktop removal leaves a package's armed git hooks behind — Project: CLI & Distribution (blocked by KEN-674, KEN-688)

## Test Plan

- `crates/core/tests/repo_effects_leaving.rs` — the engine reports what leaves a plan, read off the installed tree, including a copy-delivered package
- `crates/cli/tests/install_ux/guarding.rs` — removal disarms first; a failing uninstaller keeps the package installed; applying a manifest without the package disarms first; removal from a plain directory runs no uninstaller
- `crates/cli/tests/guard_hooks/arming.rs` — `check` names the shims a removed package left behind; a neighbouring project carrying the package is not a leftover; a redirected `core.hooksPath` is not reported
- Every new behavior was mutation-checked: each guard's mutant leaves the suite red
- `tools/guard` exits 0
