### PR TITLE
feat(KEN-688): desktop installs disclose repository effects and ask

### DIFF
--- a/.agents/skills/growth-guards/DEVELOPMENT.md
+++ b/.agents/skills/growth-guards/DEVELOPMENT.md
@@ -92,12 +92,12 @@ away. A delegating line it may not edit (a symlinked hook) keeps the helper
 in place and fails the removal rather than stranding a hook with no guard to
 reach.
 
-Nothing runs this installer on a package lifecycle event today: `kendex guard
-install`, `kendex guard uninstall` and `kendex guard check` are the verbs
-that invoke it, and
+The installer runs on `kendex guard install` and on the separate yes an
+install offers — in the terminal (`kendex add`, a collection add, `kendex
+apply`) and in the app. `kendex guard uninstall` and `kendex guard check`
+invoke it too. `kendex remove` does not run the uninstaller (KEN-674):
 disarming before removing the skill is the caller's to do — shims whose
-scripts are gone block every commit. Wiring `kendex add` / `refresh` /
-`remove` to it arrives with the repo-effects declaration (KEN-663 part 2).
+scripts are gone block every commit.
 
 `--check` is the read-only counterpart: it writes nothing — not even the
 hooks directory — and answers whether the shims are armed. `0`: the helper

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,9 @@ an outside contributor.
 - A package that changes the repository beyond kendex's own folders says so
   at install and waits for its own yes, good for that run alone. Declining
   installs it unarmed; no terminal declines unless `--allow-repo-effects`.
+- The app asks the same question: installing such a package from a
+  marketplace or bundle shows what it changes, writes, and how to undo it,
+  with its own Apply. `kendex apply` asks too for a hand-declared package.
 - `kendex remove <name> --keep-declaration` takes the files away and leaves
   kendex.toml untouched, so the next `kendex refresh` installs what it
   declares again. Fixing a broken install no longer needs the manifest restored.

--- a/crates/app/src/lib.rs
+++ b/crates/app/src/lib.rs
@@ -16,7 +16,7 @@ mod packages;
 mod paths;
 pub mod recovery;
 pub mod repo_effects;
-mod sources;
+pub mod sources;
 mod unsubscribe;
 mod whole_file;
 mod window;

--- a/crates/app/src/lib.rs
+++ b/crates/app/src/lib.rs
@@ -9,12 +9,13 @@ mod editor;
 // and for how the Linux app is packaged.
 #[cfg(target_os = "linux")]
 mod launch_env;
-mod marketplaces;
+pub mod marketplaces;
 mod mine;
 mod native;
 mod packages;
 mod paths;
 pub mod recovery;
+pub mod repo_effects;
 mod sources;
 mod unsubscribe;
 mod whole_file;
@@ -79,6 +80,7 @@ pub fn specta_builder() -> Builder<tauri::Wry> {
             marketplaces::marketplace_package_file,
             marketplaces::install::marketplace_install,
             marketplaces::install::install_targets,
+            repo_effects::repo_effects_apply,
             marketplaces::marketplace_subscribe,
             unsubscribe::marketplace_unsubscribe_preview,
             unsubscribe::marketplace_unsubscribe,

--- a/crates/app/src/marketplaces/install.rs
+++ b/crates/app/src/marketplaces/install.rs
@@ -8,14 +8,16 @@
 
 use kendex_core::apply;
 use kendex_core::engine::ops::{self as engine_ops, AddRequest};
+use kendex_core::env::Env;
 use kendex_core::manifest::Method;
 use kendex_core::model::{HarnessId, ItemKind, Scope};
+use kendex_core::repo_effects::Offers;
 use kendex_core::source_ops;
 use serde::{Deserialize, Serialize};
 use specta::Type;
 
-use super::{AvailablePackage, env, marketplace_packages};
-use kendex_core::source::browse::Catalog;
+use super::{AvailablePackage, env};
+use kendex_core::source::browse::{self, Catalog};
 
 /// One row of the install picker: a tool the scope can install to, whether
 /// this machine has it, and whether it reads the shared `.agents` tree
@@ -68,6 +70,16 @@ pub struct InstallItem {
     pub name: String,
 }
 
+/// What an install hands back: the subscription's packages as they stand
+/// now, and the repository effects the install brought — read and asked
+/// about in the window, because nothing here ran them.
+#[derive(Debug, Clone, Serialize, Type)]
+#[serde(rename_all = "camelCase")]
+pub struct Installed {
+    pub packages: Vec<AvailablePackage>,
+    pub repo_effects: Offers,
+}
+
 /// Install packages or a curated set from one subscription. `destination`
 /// redirects the install from the scope being browsed into a project: the
 /// project gains the personal subscription first (§4.1), then the add runs
@@ -86,11 +98,37 @@ pub fn marketplace_install(
     hold: bool,
     harnesses: Option<Vec<HarnessId>>,
     method: Option<Method>,
-) -> Result<Vec<AvailablePackage>, String> {
+) -> Result<Installed, String> {
+    let env = env()?;
+    install(
+        &env,
+        scope,
+        source,
+        items,
+        bundle,
+        destination,
+        hold,
+        harnesses,
+        method,
+    )
+}
+
+/// The install itself, against the environment it is given.
+#[allow(clippy::too_many_arguments)]
+pub fn install(
+    env: &Env,
+    scope: Scope,
+    source: String,
+    items: Vec<InstallItem>,
+    bundle: Option<String>,
+    destination: Option<Scope>,
+    hold: bool,
+    harnesses: Option<Vec<HarnessId>>,
+    method: Option<Method>,
+) -> Result<Installed, String> {
     if items.is_empty() && bundle.is_none() {
         return Err("nothing selected to install".to_owned());
     }
-    let env = env()?;
     let target = destination.unwrap_or_else(|| scope.clone());
     let redirected = target != scope;
     if redirected {
@@ -129,14 +167,25 @@ pub fn marketplace_install(
     // plan: a refused install leaves the project subscribed to nothing.
     let report = match &target {
         Scope::Project { root } if redirected => {
-            source_ops::install_project_from_personal(&env, root, &source, &request)
+            source_ops::install_project_from_personal(env, root, &source, &request)
         }
-        _ => engine_ops::add(&env, &target, &request),
+        _ => engine_ops::add(env, &target, &request),
     }
     .map_err(|e| e.to_string())?;
-    apply::execute(&env, &report.plan, None).map_err(|e| e.to_string())?;
-    marketplace_packages(Catalog::Subscription {
-        scope: target,
-        source,
+    apply::execute(env, &report.plan, None).map_err(|e| e.to_string())?;
+    // After the write, because the script an effect runs is the one this
+    // install just put on disk.
+    let repo_effects = crate::repo_effects::offers(env, &target, &report)?;
+    let packages = browse::packages(
+        env,
+        &Catalog::Subscription {
+            scope: target,
+            source,
+        },
+    )
+    .map_err(|e| e.to_string())?;
+    Ok(Installed {
+        packages,
+        repo_effects,
     })
 }

--- a/crates/app/src/marketplaces/install.rs
+++ b/crates/app/src/marketplaces/install.rs
@@ -175,7 +175,8 @@ pub fn install(
     apply::execute(env, &report.plan, None).map_err(|e| e.to_string())?;
     // After the write, because the script an effect runs is the one this
     // install just put on disk.
-    let repo_effects = crate::repo_effects::offers(env, &target, &report)?;
+    let repo_effects = kendex_core::repo_effects::offers_for(env, &target, &report.repo_effects)
+        .map_err(|e| e.to_string())?;
     let packages = browse::packages(
         env,
         &Catalog::Subscription {

--- a/crates/app/src/repo_effects.rs
+++ b/crates/app/src/repo_effects.rs
@@ -12,10 +12,23 @@ use kendex_core::env::Env;
 use kendex_core::model::Scope;
 use kendex_core::repo_effects::{ArmError, DeclaredEffects};
 
+/// What an installer said, kept by channel.
+///
+/// Both of them, on a clean exit as much as a failed one. growth-guards
+/// exits 0 when `core.hooksPath` is configured and puts its summary on
+/// stdout and the warning, the value it found, and the remedy on stderr —
+/// so stdout alone is the half of the account that does not say what to do.
+#[derive(Debug, Clone, serde::Serialize, specta::Type)]
+#[serde(rename_all = "camelCase")]
+pub struct Said {
+    pub stdout: Vec<String>,
+    pub stderr: Vec<String>,
+}
+
 /// Run one package's declared installer, here and now, and hand back what
-/// it printed: an installer that deliberately arms nothing says so on
-/// stdout and exits 0, and the window shows its words rather than a
-/// verdict of its own.
+/// it printed: an installer that deliberately arms nothing says so and
+/// exits 0, and the window shows its words rather than a verdict of its
+/// own.
 ///
 /// The declaration comes back from the window exactly as the install handed
 /// it over, the way the terminal keeps it in hand between the block and the
@@ -29,7 +42,7 @@ use kendex_core::repo_effects::{ArmError, DeclaredEffects};
 /// The rest of the declaration is used as passed. It decides what runs
 /// under a root kendex chose, which is the same ground the disclosure was
 /// written on.
-pub fn apply(env: &Env, scope: &Scope, declared: &DeclaredEffects) -> Result<Vec<String>, String> {
+pub fn apply(env: &Env, scope: &Scope, declared: &DeclaredEffects) -> Result<Said, String> {
     let recorded = kendex_core::repo_effects::recorded_roots(env, scope, &declared.name)
         .map_err(|error| error.to_string())?;
     if !recorded.contains(&declared.root) {
@@ -39,7 +52,10 @@ pub fn apply(env: &Env, scope: &Scope, declared: &DeclaredEffects) -> Result<Vec
         ));
     }
     match kendex_core::repo_effects::arm(scope, declared) {
-        Ok(report) => Ok(report.stdout),
+        Ok(report) => Ok(Said {
+            stdout: report.stdout,
+            stderr: report.stderr,
+        }),
         // The one wording, with the package's own lines under it where the
         // installer got far enough to say anything — the account of a
         // possibly half-written repository has to reach the person whole.
@@ -63,7 +79,7 @@ pub fn apply(env: &Env, scope: &Scope, declared: &DeclaredEffects) -> Result<Vec
 
 #[tauri::command(async)]
 #[specta::specta]
-pub fn repo_effects_apply(scope: Scope, declared: DeclaredEffects) -> Result<Vec<String>, String> {
+pub fn repo_effects_apply(scope: Scope, declared: DeclaredEffects) -> Result<Said, String> {
     let env = Env::detect().map_err(|error| error.to_string())?;
     apply(&env, &scope, &declared)
 }

--- a/crates/app/src/repo_effects.rs
+++ b/crates/app/src/repo_effects.rs
@@ -19,30 +19,29 @@ use kendex_core::repo_effects::{ArmError, DeclaredEffects};
 /// The declaration comes back from the window exactly as the install handed
 /// it over, the way the terminal keeps it in hand between the block and the
 /// prompt. Its root is confined the way every scope root the window passes
-/// is: `run_script` resolves the program under it and refuses one that
-/// leaves it.
+/// is: arming resolves the program under it and refuses one that leaves
+/// it.
 pub fn apply(scope: &Scope, declared: &DeclaredEffects) -> Result<Vec<String>, String> {
     match kendex_core::repo_effects::arm(scope, declared) {
         Ok(report) => Ok(report.stdout),
-        // The one wording, with the package's own lines under it — the
-        // account of a possibly half-written repository has to reach the
-        // person whole.
-        Err(error @ ArmError::Failed { .. }) => {
-            let ArmError::Failed { report, .. } = &error else {
-                unreachable!("matched above");
+        // The one wording, with the package's own lines under it where the
+        // installer got far enough to say anything — the account of a
+        // possibly half-written repository has to reach the person whole.
+        Err(error) => {
+            let said: Vec<&str> = match &error {
+                ArmError::Failed { report, .. } => report
+                    .stderr
+                    .iter()
+                    .chain(&report.stdout)
+                    .map(String::as_str)
+                    .collect(),
+                _ => Vec::new(),
             };
-            let said: Vec<&str> = report
-                .stderr
-                .iter()
-                .chain(&report.stdout)
-                .map(String::as_str)
-                .collect();
             Err(match said.is_empty() {
                 true => error.to_string(),
                 false => format!("{error}\n{}", said.join("\n")),
             })
         }
-        Err(error) => Err(error.to_string()),
     }
 }
 

--- a/crates/app/src/repo_effects.rs
+++ b/crates/app/src/repo_effects.rs
@@ -8,6 +8,7 @@
 //! run and no other — a refresh repairs files and arms nothing, the same
 //! as the terminal.
 
+use kendex_core::env::Env;
 use kendex_core::model::Scope;
 use kendex_core::repo_effects::{ArmError, DeclaredEffects};
 
@@ -18,10 +19,25 @@ use kendex_core::repo_effects::{ArmError, DeclaredEffects};
 ///
 /// The declaration comes back from the window exactly as the install handed
 /// it over, the way the terminal keeps it in hand between the block and the
-/// prompt. Its root is confined the way every scope root the window passes
-/// is: arming resolves the program under it and refuses one that leaves
-/// it.
-pub fn apply(scope: &Scope, declared: &DeclaredEffects) -> Result<Vec<String>, String> {
+/// prompt — but the root it names is checked against what this scope
+/// recorded installing, not taken on trust. Arming confines the program to
+/// the root it is given, so a root the caller chose is a check against the
+/// caller's own answer: `/` passes it with any program underneath. The
+/// terminal has no such gap, because its declaration never leaves the
+/// process that built it.
+///
+/// The rest of the declaration is used as passed. It decides what runs
+/// under a root kendex chose, which is the same ground the disclosure was
+/// written on.
+pub fn apply(env: &Env, scope: &Scope, declared: &DeclaredEffects) -> Result<Vec<String>, String> {
+    let recorded = kendex_core::repo_effects::recorded_roots(env, scope, &declared.name)
+        .map_err(|error| error.to_string())?;
+    if !recorded.contains(&declared.root) {
+        return Err(format!(
+            "{}: nothing was run — this scope has no record of installing it there",
+            kendex_core::names::shown(&declared.name)
+        ));
+    }
     match kendex_core::repo_effects::arm(scope, declared) {
         Ok(report) => Ok(report.stdout),
         // The one wording, with the package's own lines under it where the
@@ -48,5 +64,6 @@ pub fn apply(scope: &Scope, declared: &DeclaredEffects) -> Result<Vec<String>, S
 #[tauri::command(async)]
 #[specta::specta]
 pub fn repo_effects_apply(scope: Scope, declared: DeclaredEffects) -> Result<Vec<String>, String> {
-    apply(&scope, &declared)
+    let env = Env::detect().map_err(|error| error.to_string())?;
+    apply(&env, &scope, &declared)
 }

--- a/crates/app/src/repo_effects.rs
+++ b/crates/app/src/repo_effects.rs
@@ -1,79 +1,53 @@
-//! The desktop's half of a package's repository effects: what an install
-//! hands the window to read, and the command that runs an effect once the
-//! window has a yes.
+//! The desktop's half of a package's repository effects: the command that
+//! runs an effect once the window has a yes.
 //!
 //! An install is one command that plans and writes. The effect is not in
-//! it: the report carries the declarations, this turns them into the
-//! offers the window shows, and the window comes back with a separate
-//! command for the one it got a yes for. Nothing between those two calls
-//! is written down, so the yes is good for that run and no other — a
-//! refresh repairs files and arms nothing, the same as the terminal.
+//! it: the report's declarations become the offers the window shows, and
+//! the window comes back here with the one it got a yes for. Nothing
+//! between those two calls is written down, so the yes is good for that
+//! run and no other — a refresh repairs files and arms nothing, the same
+//! as the terminal.
 
-use kendex_core::engine::EngineReport;
-use kendex_core::env::Env;
 use kendex_core::model::Scope;
-use kendex_core::repo_effects::{DeclaredEffects, Offers};
+use kendex_core::repo_effects::{ArmError, DeclaredEffects};
 
-/// The offers an applied plan's effects earn: read after the write, so a
-/// companion that landed in the same plan counts as installed.
-pub fn offers(env: &Env, scope: &Scope, report: &EngineReport) -> Result<Offers, String> {
-    if report.repo_effects.is_empty() {
-        return Ok(Offers::default());
-    }
-    let installed =
-        kendex_core::repo_effects::installed_skills(env, scope).map_err(|e| e.to_string())?;
-    Ok(kendex_core::repo_effects::offers(
-        scope,
-        &report.repo_effects,
-        &installed,
-    ))
-}
-
-/// Run one package's declared installer, here and now.
+/// Run one package's declared installer, here and now, and hand back what
+/// it printed: an installer that deliberately arms nothing says so on
+/// stdout and exits 0, and the window shows its words rather than a
+/// verdict of its own.
 ///
 /// The declaration comes back from the window exactly as the install handed
 /// it over, the way the terminal keeps it in hand between the block and the
 /// prompt. Its root is confined the way every scope root the window passes
 /// is: `run_script` resolves the program under it and refuses one that
 /// leaves it.
-pub fn apply(scope: &Scope, declared: &DeclaredEffects) -> Result<(), String> {
-    let Some(installer) = &declared.effects.installer else {
-        return Err(format!(
-            "{} declares nothing kendex can run — arm it yourself when you are ready",
-            declared.name
-        ));
-    };
-    let report = kendex_core::repo_effects::run_script(scope, &declared.root, installer)
-        .map_err(|e| e.to_string())?;
-    if report.code != 0 {
-        // Not "the repository is unchanged". kendex takes no pre-image and
-        // rolls nothing back, so an installer that wrote three files and
-        // failed on the fourth leaves three files. The declaration names
-        // what the package writes, which is where to look.
-        let said = report
-            .stderr
-            .iter()
-            .chain(&report.stdout)
-            .cloned()
-            .collect::<Vec<_>>()
-            .join("\n");
-        return Err(format!(
-            "{} exited {} — anything it wrote before that is still there; \
-             {} is what the package says undoes it\n{said}",
-            installer,
-            report.code,
-            declared
-                .effects
-                .uninstaller
-                .as_deref()
-                .unwrap_or("its uninstaller")
-        ));
+pub fn apply(scope: &Scope, declared: &DeclaredEffects) -> Result<Vec<String>, String> {
+    match kendex_core::repo_effects::arm(scope, declared) {
+        Ok(report) => Ok(report.stdout),
+        // The one wording, with the package's own lines under it — the
+        // account of a possibly half-written repository has to reach the
+        // person whole.
+        Err(error @ ArmError::Failed { .. }) => {
+            let ArmError::Failed { report, .. } = &error else {
+                unreachable!("matched above");
+            };
+            let said: Vec<&str> = report
+                .stderr
+                .iter()
+                .chain(&report.stdout)
+                .map(String::as_str)
+                .collect();
+            Err(match said.is_empty() {
+                true => error.to_string(),
+                false => format!("{error}\n{}", said.join("\n")),
+            })
+        }
+        Err(error) => Err(error.to_string()),
     }
-    Ok(())
 }
 
 #[tauri::command(async)]
 #[specta::specta]
-pub fn repo_effects_apply(scope: Scope, declared: DeclaredEffects) -> Result<(), String> {
+pub fn repo_effects_apply(scope: Scope, declared: DeclaredEffects) -> Result<Vec<String>, String> {
     apply(&scope, &declared)
 }

--- a/crates/app/src/repo_effects.rs
+++ b/crates/app/src/repo_effects.rs
@@ -1,0 +1,79 @@
+//! The desktop's half of a package's repository effects: what an install
+//! hands the window to read, and the command that runs an effect once the
+//! window has a yes.
+//!
+//! An install is one command that plans and writes. The effect is not in
+//! it: the report carries the declarations, this turns them into the
+//! offers the window shows, and the window comes back with a separate
+//! command for the one it got a yes for. Nothing between those two calls
+//! is written down, so the yes is good for that run and no other — a
+//! refresh repairs files and arms nothing, the same as the terminal.
+
+use kendex_core::engine::EngineReport;
+use kendex_core::env::Env;
+use kendex_core::model::Scope;
+use kendex_core::repo_effects::{DeclaredEffects, Offers};
+
+/// The offers an applied plan's effects earn: read after the write, so a
+/// companion that landed in the same plan counts as installed.
+pub fn offers(env: &Env, scope: &Scope, report: &EngineReport) -> Result<Offers, String> {
+    if report.repo_effects.is_empty() {
+        return Ok(Offers::default());
+    }
+    let installed =
+        kendex_core::repo_effects::installed_skills(env, scope).map_err(|e| e.to_string())?;
+    Ok(kendex_core::repo_effects::offers(
+        scope,
+        &report.repo_effects,
+        &installed,
+    ))
+}
+
+/// Run one package's declared installer, here and now.
+///
+/// The declaration comes back from the window exactly as the install handed
+/// it over, the way the terminal keeps it in hand between the block and the
+/// prompt. Its root is confined the way every scope root the window passes
+/// is: `run_script` resolves the program under it and refuses one that
+/// leaves it.
+pub fn apply(scope: &Scope, declared: &DeclaredEffects) -> Result<(), String> {
+    let Some(installer) = &declared.effects.installer else {
+        return Err(format!(
+            "{} declares nothing kendex can run — arm it yourself when you are ready",
+            declared.name
+        ));
+    };
+    let report = kendex_core::repo_effects::run_script(scope, &declared.root, installer)
+        .map_err(|e| e.to_string())?;
+    if report.code != 0 {
+        // Not "the repository is unchanged". kendex takes no pre-image and
+        // rolls nothing back, so an installer that wrote three files and
+        // failed on the fourth leaves three files. The declaration names
+        // what the package writes, which is where to look.
+        let said = report
+            .stderr
+            .iter()
+            .chain(&report.stdout)
+            .cloned()
+            .collect::<Vec<_>>()
+            .join("\n");
+        return Err(format!(
+            "{} exited {} — anything it wrote before that is still there; \
+             {} is what the package says undoes it\n{said}",
+            installer,
+            report.code,
+            declared
+                .effects
+                .uninstaller
+                .as_deref()
+                .unwrap_or("its uninstaller")
+        ));
+    }
+    Ok(())
+}
+
+#[tauri::command(async)]
+#[specta::specta]
+pub fn repo_effects_apply(scope: Scope, declared: DeclaredEffects) -> Result<(), String> {
+    apply(&scope, &declared)
+}

--- a/crates/app/src/sources.rs
+++ b/crates/app/src/sources.rs
@@ -99,6 +99,17 @@ pub fn bundle_install(
     hold: bool,
 ) -> Result<BundleInstalled, String> {
     let env = env()?;
+    install_bundle(&env, &scope, source, name, hold)
+}
+
+/// The bundle install itself, against the environment it is given.
+pub fn install_bundle(
+    env: &Env,
+    scope: &Scope,
+    source: String,
+    name: String,
+    hold: bool,
+) -> Result<BundleInstalled, String> {
     let request = AddRequest {
         source: Some(source),
         bundles: vec![name],
@@ -106,11 +117,16 @@ pub fn bundle_install(
         hold,
         ..AddRequest::default()
     };
-    let report = engine_ops::add(&env, &scope, &request).map_err(|e| e.to_string())?;
-    apply::execute(&env, &report.plan, None).map_err(|e| e.to_string())?;
-    let repo_effects = crate::repo_effects::offers(&env, &scope, &report)?;
+    let report = engine_ops::add(env, scope, &request).map_err(|e| e.to_string())?;
+    apply::execute(env, &report.plan, None).map_err(|e| e.to_string())?;
+    let repo_effects = kendex_core::repo_effects::offers_for(env, scope, &report.repo_effects)
+        .map_err(|e| e.to_string())?;
+    let mut bundles = Vec::new();
+    for scope in all_scopes(env)? {
+        bundles.extend(source_ops::list_bundles(env, &scope).map_err(|e| e.to_string())?);
+    }
     Ok(BundleInstalled {
-        bundles: bundles_overview()?,
+        bundles,
         repo_effects,
     })
 }

--- a/crates/app/src/sources.rs
+++ b/crates/app/src/sources.rs
@@ -66,17 +66,20 @@ pub fn source_toggle(scope: Scope, name: String, enabled: bool) -> Result<Vec<So
     run_and_list(&env, report)
 }
 
-/// Every curated set every catalog offers, across every scope — what the
-/// Catalogs page lists under each source.
+/// Every curated set every catalog offers, across every scope.
+fn list_all_bundles(env: &Env) -> Result<Vec<BundleRow>, String> {
+    let mut rows = Vec::new();
+    for scope in all_scopes(env)? {
+        rows.extend(source_ops::list_bundles(env, &scope).map_err(|e| e.to_string())?);
+    }
+    Ok(rows)
+}
+
+/// What the Catalogs page lists under each source — one query.
 #[tauri::command(async)]
 #[specta::specta]
 pub fn bundles_overview() -> Result<Vec<BundleRow>, String> {
-    let env = env()?;
-    let mut rows = Vec::new();
-    for scope in all_scopes(&env)? {
-        rows.extend(source_ops::list_bundles(&env, &scope).map_err(|e| e.to_string())?);
-    }
-    Ok(rows)
+    list_all_bundles(&env()?)
 }
 
 /// What a bundle install hands back: every set as it stands now, and the
@@ -121,12 +124,8 @@ pub fn install_bundle(
     apply::execute(env, &report.plan, None).map_err(|e| e.to_string())?;
     let repo_effects = kendex_core::repo_effects::offers_for(env, scope, &report.repo_effects)
         .map_err(|e| e.to_string())?;
-    let mut bundles = Vec::new();
-    for scope in all_scopes(env)? {
-        bundles.extend(source_ops::list_bundles(env, &scope).map_err(|e| e.to_string())?);
-    }
     Ok(BundleInstalled {
-        bundles,
+        bundles: list_all_bundles(env)?,
         repo_effects,
     })
 }

--- a/crates/app/src/sources.rs
+++ b/crates/app/src/sources.rs
@@ -79,6 +79,15 @@ pub fn bundles_overview() -> Result<Vec<BundleRow>, String> {
     Ok(rows)
 }
 
+/// What a bundle install hands back: every set as it stands now, and the
+/// repository effects its members brought for the window to ask about.
+#[derive(Debug, Clone, serde::Serialize, specta::Type)]
+#[serde(rename_all = "camelCase")]
+pub struct BundleInstalled {
+    pub bundles: Vec<BundleRow>,
+    pub repo_effects: kendex_core::repo_effects::Offers,
+}
+
 /// Install a set whole. Its members derive from the catalog, so this declares
 /// one name and applies the plan that follows from it.
 #[tauri::command(async)]
@@ -88,7 +97,7 @@ pub fn bundle_install(
     source: String,
     name: String,
     hold: bool,
-) -> Result<Vec<BundleRow>, String> {
+) -> Result<BundleInstalled, String> {
     let env = env()?;
     let request = AddRequest {
         source: Some(source),
@@ -99,7 +108,11 @@ pub fn bundle_install(
     };
     let report = engine_ops::add(&env, &scope, &request).map_err(|e| e.to_string())?;
     apply::execute(&env, &report.plan, None).map_err(|e| e.to_string())?;
-    bundles_overview()
+    let repo_effects = crate::repo_effects::offers(&env, &scope, &report)?;
+    Ok(BundleInstalled {
+        bundles: bundles_overview()?,
+        repo_effects,
+    })
 }
 
 /// Re-resolve every enabled remote across every scope. Returns warnings

--- a/crates/app/tests/repo_effects.rs
+++ b/crates/app/tests/repo_effects.rs
@@ -173,9 +173,17 @@ fn the_effect_comes_back_unrun_and_a_separate_yes_arms_it() {
     );
     assert!(offer.writes.iter().all(|w| w.shared), "{:?}", offer.writes);
     assert!(!companion(offer, "size-ratchet").installed);
-    assert!(offer.removal.is_some());
+    // The declared uninstaller, resolved where it really sits and quoted
+    // as a command — not the package's removal prose, which says to run it.
+    assert_eq!(
+        offer.undo.as_deref(),
+        Some(
+            "run `'.agents/skills/growth-guards/scripts/install-git-hooks' '--uninstall'` \
+             from the repository root"
+        )
+    );
 
-    let said = kendex_app::repo_effects::apply(&f.scope, &offer.declared).unwrap();
+    let said = kendex_app::repo_effects::apply(&f.env, &f.scope, &offer.declared).unwrap();
     assert!(
         f.project.join(".git/hooks/kendex-guards").is_file(),
         "the yes did not arm the hooks"
@@ -184,6 +192,37 @@ fn the_effect_comes_back_unrun_and_a_separate_yes_arms_it() {
     assert!(
         said.last().is_some_and(|line| line.contains("armed")),
         "{said:?}"
+    );
+}
+
+/// The yes is for the package the window was shown, not for whatever root
+/// comes back with it. Arming confines a program to the root it is handed,
+/// so a root the caller chose would confine nothing.
+#[test]
+#[allow(clippy::unwrap_used)]
+fn a_root_this_scope_never_installed_is_refused() {
+    let f = fixture();
+    let installed = install_skills(&f, &["growth-guards"], None);
+    let [offer] = installed.repo_effects.shown.as_slice() else {
+        panic!("one offer: {:?}", installed.repo_effects);
+    };
+
+    let forged = kendex_core::repo_effects::DeclaredEffects {
+        root: PathBuf::from("/"),
+        effects: kendex_core::repo_effects::RepoEffects {
+            installer: Some("bin/sh -c id".to_owned()),
+            ..offer.declared.effects.clone()
+        },
+        ..offer.declared.clone()
+    };
+    let error = kendex_app::repo_effects::apply(&f.env, &f.scope, &forged).unwrap_err();
+    assert!(
+        error.contains("no record of installing it there"),
+        "{error}"
+    );
+    assert!(
+        !f.project.join(".git/hooks/kendex-guards").exists(),
+        "the forged root armed the hooks"
     );
 }
 

--- a/crates/app/tests/repo_effects.rs
+++ b/crates/app/tests/repo_effects.rs
@@ -8,6 +8,7 @@
 #![cfg(unix)]
 
 use std::fs;
+use std::os::unix::fs::PermissionsExt;
 use std::path::{Path, PathBuf};
 
 use kendex_app::marketplaces::install::{InstallItem, Installed, install};
@@ -75,6 +76,25 @@ fn fixture() -> Fixture {
         "---\nname: deploy\ndescription: ship the service\n---\nRun the deploy.\n",
     )
     .unwrap();
+    // A package whose installer exits clean and writes to both channels —
+    // the shipped shape of growth-guards skipping its work: the summary on
+    // stdout, the reason and the remedy on stderr.
+    let noisy = catalog.join("skills/noisy/scripts");
+    fs::create_dir_all(&noisy).unwrap();
+    fs::write(
+        catalog.join("skills/noisy/SKILL.md"),
+        "---\nname: noisy\ndescription: says something on both channels\n\
+         repo-effects:\n  summary: \"arms nothing here\"\n  \
+         installer: \"scripts/arm\"\n---\nBody.\n",
+    )
+    .unwrap();
+    fs::write(
+        noisy.join("arm"),
+        "#!/bin/sh\necho 'core.hooksPath is set; unset it and run this again' >&2\n\
+         echo 'hooks: skipped'\n",
+    )
+    .unwrap();
+    fs::set_permissions(noisy.join("arm"), fs::Permissions::from_mode(0o755)).unwrap();
     fs::write(
         catalog.join("kendex.toml"),
         "[bundles.guards]\ndescription = \"the commit gate\"\nskills = [\"growth-guards\"]\n",
@@ -190,8 +210,30 @@ fn the_effect_comes_back_unrun_and_a_separate_yes_arms_it() {
     );
     // The installer's own last word is what the window shows.
     assert!(
-        said.last().is_some_and(|line| line.contains("armed")),
+        said.stdout
+            .last()
+            .is_some_and(|line| line.contains("armed")),
         "{said:?}"
+    );
+}
+
+/// A clean exit is not a silent one. An installer that skipped its work
+/// says why on stderr, and stdout alone is the half of that account which
+/// does not say what to do about it.
+#[test]
+#[allow(clippy::unwrap_used)]
+fn a_clean_exit_carries_both_channels() {
+    let f = fixture();
+    let installed = install_skills(&f, &["noisy"], None);
+    let [offer] = installed.repo_effects.shown.as_slice() else {
+        panic!("one offer: {:?}", installed.repo_effects);
+    };
+
+    let said = kendex_app::repo_effects::apply(&f.env, &f.scope, &offer.declared).unwrap();
+    assert_eq!(said.stdout, vec!["hooks: skipped".to_owned()]);
+    assert_eq!(
+        said.stderr,
+        vec!["core.hooksPath is set; unset it and run this again".to_owned()]
     );
 }
 

--- a/crates/app/tests/repo_effects.rs
+++ b/crates/app/tests/repo_effects.rs
@@ -1,0 +1,180 @@
+//! The desktop's account of what a package does to the repository, and the
+//! yes that is separate from installing it.
+//!
+//! An install from the window is one command that plans and writes. The
+//! effect a package declares must come back out of it unrun, with what a
+//! person needs in order to decide — and arming is a second command, so a
+//! window that closes the dialog leaves the repository as it was.
+#![cfg(unix)]
+
+use std::fs;
+use std::path::{Path, PathBuf};
+
+use kendex_app::marketplaces::install::{InstallItem, install};
+use kendex_core::env::{Env, FakeOs};
+use kendex_core::model::{ItemKind, Scope};
+
+struct Fixture {
+    _tmp: tempfile::TempDir,
+    env: Env,
+    scope: Scope,
+    project: PathBuf,
+}
+
+#[allow(clippy::unwrap_used)]
+fn git(dir: &Path, args: &[&str]) {
+    let output = std::process::Command::new("git")
+        .args(["-c", "user.email=t@t", "-c", "user.name=t"])
+        .args(args)
+        .current_dir(dir)
+        .env_remove("GIT_DIR")
+        .env_remove("GIT_WORK_TREE")
+        .env_remove("GIT_INDEX_FILE")
+        .output()
+        .unwrap();
+    assert!(
+        output.status.success(),
+        "git {args:?}: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+}
+
+#[allow(clippy::unwrap_used)]
+fn copy_tree(from: &Path, to: &Path) {
+    fs::create_dir_all(to).unwrap();
+    for entry in fs::read_dir(from).unwrap() {
+        let entry = entry.unwrap();
+        let target = to.join(entry.file_name());
+        if entry.file_type().unwrap().is_dir() {
+            copy_tree(&entry.path(), &target);
+        } else {
+            fs::copy(entry.path(), &target).unwrap();
+        }
+    }
+}
+
+/// A git project subscribed to a catalog that offers the repository's own
+/// growth-guards package beside an inert one, with Claude on the machine.
+#[allow(clippy::unwrap_used)]
+fn fixture() -> Fixture {
+    let tmp = tempfile::tempdir().unwrap();
+    let home = tmp.path().canonicalize().unwrap();
+    let project = home.join("dev/app");
+    let catalog = home.join("catalog");
+    let shipped = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("../../skills/growth-guards")
+        .canonicalize()
+        .unwrap();
+    copy_tree(&shipped, &catalog.join("skills/growth-guards"));
+    fs::create_dir_all(catalog.join("skills/deploy")).unwrap();
+    fs::write(
+        catalog.join("skills/deploy/SKILL.md"),
+        "---\nname: deploy\ndescription: ship the service\n---\nRun the deploy.\n",
+    )
+    .unwrap();
+    fs::create_dir_all(home.join(".claude")).unwrap();
+    fs::create_dir_all(project.join(".agents")).unwrap();
+    git(&project, &["init", "--quiet", "-b", "main"]);
+    fs::write(project.join("README.md"), "the app\n").unwrap();
+    git(&project, &["add", "."]);
+    git(&project, &["commit", "--quiet", "-m", "start"]);
+    fs::write(
+        project.join("kendex.toml"),
+        format!(
+            "schema = 6\n\n[sources.cat]\npath = \"{}\"\n",
+            catalog.display()
+        ),
+    )
+    .unwrap();
+    Fixture {
+        env: Env::fake(&home, FakeOs::Linux),
+        scope: Scope::Project {
+            root: project.clone(),
+        },
+        project,
+        _tmp: tmp,
+    }
+}
+
+fn install_skill(f: &Fixture, name: &str) -> kendex_app::marketplaces::install::Installed {
+    install(
+        &f.env,
+        f.scope.clone(),
+        "cat".to_owned(),
+        vec![InstallItem {
+            kind: ItemKind::Skill,
+            name: name.to_owned(),
+        }],
+        None,
+        None,
+        false,
+        None,
+        None,
+    )
+    .unwrap_or_else(|error| panic!("install {name}: {error}"))
+}
+
+/// Installing writes the package and hands back its account — what
+/// changes, where it writes, which companions are here, how to undo it —
+/// with the repository untouched. The separate yes is what arms it.
+#[test]
+#[allow(clippy::unwrap_used)]
+fn the_effect_comes_back_unrun_and_a_separate_yes_arms_it() {
+    let f = fixture();
+    let installed = install_skill(&f, "growth-guards");
+
+    assert!(
+        f.project
+            .join(".agents/skills/growth-guards/scripts/install-git-hooks")
+            .is_file(),
+        "the package did not install"
+    );
+    assert!(
+        !f.project.join(".git/hooks/kendex-guards").exists(),
+        "the install armed the hooks with nobody asked"
+    );
+    assert!(
+        installed.repo_effects.withheld.is_empty(),
+        "{:?}",
+        installed.repo_effects.withheld
+    );
+    let [offer] = installed.repo_effects.shown.as_slice() else {
+        panic!("one offer: {:?}", installed.repo_effects);
+    };
+    assert_eq!(offer.declared.name, "growth-guards");
+    assert!(offer.declared.effects.summary.contains("every commit"));
+    let hooks = f.project.join(".git/hooks");
+    let written: Vec<&str> = offer.writes.iter().map(|w| w.path.as_str()).collect();
+    assert!(
+        written.contains(&hooks.join("pre-commit").to_str().unwrap()),
+        "{written:?}"
+    );
+    assert!(offer.writes.iter().all(|w| w.shared), "{:?}", offer.writes);
+    let size_ratchet = offer
+        .companions
+        .iter()
+        .find(|c| c.name == "size-ratchet")
+        .unwrap();
+    assert!(!size_ratchet.installed, "{:?}", offer.companions);
+    assert!(offer.declared.effects.removal.is_some());
+
+    kendex_app::repo_effects::apply(&f.scope, &offer.declared).unwrap();
+    assert!(
+        f.project.join(".git/hooks/kendex-guards").is_file(),
+        "the yes did not arm the hooks"
+    );
+}
+
+/// A package with no declaration adds nothing to the install: no offer,
+/// no notice, and the window has nothing to open.
+#[test]
+fn an_inert_package_brings_no_offer() {
+    let f = fixture();
+    let installed = install_skill(&f, "deploy");
+    assert!(
+        installed.repo_effects.is_empty(),
+        "{:?}",
+        installed.repo_effects
+    );
+    assert!(installed.packages.iter().any(|p| p.name == "deploy"));
+}

--- a/crates/app/tests/repo_effects.rs
+++ b/crates/app/tests/repo_effects.rs
@@ -10,7 +10,7 @@
 use std::fs;
 use std::path::{Path, PathBuf};
 
-use kendex_app::marketplaces::install::{InstallItem, install};
+use kendex_app::marketplaces::install::{InstallItem, Installed, install};
 use kendex_core::env::{Env, FakeOs};
 use kendex_core::model::{ItemKind, Scope};
 
@@ -54,7 +54,8 @@ fn copy_tree(from: &Path, to: &Path) {
 }
 
 /// A git project subscribed to a catalog that offers the repository's own
-/// growth-guards package beside an inert one, with Claude on the machine.
+/// growth-guards and size-ratchet packages beside an inert one, plus a
+/// bundle carrying growth-guards, with Claude on the machine.
 #[allow(clippy::unwrap_used)]
 fn fixture() -> Fixture {
     let tmp = tempfile::tempdir().unwrap();
@@ -62,14 +63,21 @@ fn fixture() -> Fixture {
     let project = home.join("dev/app");
     let catalog = home.join("catalog");
     let shipped = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
-        .join("../../skills/growth-guards")
+        .join("../../skills")
         .canonicalize()
         .unwrap();
-    copy_tree(&shipped, &catalog.join("skills/growth-guards"));
+    for skill in ["growth-guards", "size-ratchet"] {
+        copy_tree(&shipped.join(skill), &catalog.join("skills").join(skill));
+    }
     fs::create_dir_all(catalog.join("skills/deploy")).unwrap();
     fs::write(
         catalog.join("skills/deploy/SKILL.md"),
         "---\nname: deploy\ndescription: ship the service\n---\nRun the deploy.\n",
+    )
+    .unwrap();
+    fs::write(
+        catalog.join("kendex.toml"),
+        "[bundles.guards]\ndescription = \"the commit gate\"\nskills = [\"growth-guards\"]\n",
     )
     .unwrap();
     fs::create_dir_all(home.join(".claude")).unwrap();
@@ -96,22 +104,36 @@ fn fixture() -> Fixture {
     }
 }
 
-fn install_skill(f: &Fixture, name: &str) -> kendex_app::marketplaces::install::Installed {
+fn install_skills(f: &Fixture, names: &[&str], bundle: Option<&str>) -> Installed {
     install(
         &f.env,
         f.scope.clone(),
         "cat".to_owned(),
-        vec![InstallItem {
-            kind: ItemKind::Skill,
-            name: name.to_owned(),
-        }],
-        None,
+        names
+            .iter()
+            .map(|name| InstallItem {
+                kind: ItemKind::Skill,
+                name: (*name).to_owned(),
+            })
+            .collect(),
+        bundle.map(str::to_owned),
         None,
         false,
         None,
         None,
     )
-    .unwrap_or_else(|error| panic!("install {name}: {error}"))
+    .unwrap_or_else(|error| panic!("install {names:?} {bundle:?}: {error}"))
+}
+
+fn companion<'a>(
+    offer: &'a kendex_core::repo_effects::Disclosure,
+    name: &str,
+) -> &'a kendex_core::repo_effects::Companion {
+    offer
+        .companions
+        .iter()
+        .find(|c| c.name == name)
+        .unwrap_or_else(|| panic!("no companion {name}: {:?}", offer.companions))
 }
 
 /// Installing writes the package and hands back its account — what
@@ -121,7 +143,7 @@ fn install_skill(f: &Fixture, name: &str) -> kendex_app::marketplaces::install::
 #[allow(clippy::unwrap_used)]
 fn the_effect_comes_back_unrun_and_a_separate_yes_arms_it() {
     let f = fixture();
-    let installed = install_skill(&f, "growth-guards");
+    let installed = install_skills(&f, &["growth-guards"], None);
 
     assert!(
         f.project
@@ -141,8 +163,8 @@ fn the_effect_comes_back_unrun_and_a_separate_yes_arms_it() {
     let [offer] = installed.repo_effects.shown.as_slice() else {
         panic!("one offer: {:?}", installed.repo_effects);
     };
-    assert_eq!(offer.declared.name, "growth-guards");
-    assert!(offer.declared.effects.summary.contains("every commit"));
+    assert_eq!(offer.name, "growth-guards");
+    assert!(offer.summary.contains("every commit"));
     let hooks = f.project.join(".git/hooks");
     let written: Vec<&str> = offer.writes.iter().map(|w| w.path.as_str()).collect();
     assert!(
@@ -150,18 +172,68 @@ fn the_effect_comes_back_unrun_and_a_separate_yes_arms_it() {
         "{written:?}"
     );
     assert!(offer.writes.iter().all(|w| w.shared), "{:?}", offer.writes);
-    let size_ratchet = offer
-        .companions
-        .iter()
-        .find(|c| c.name == "size-ratchet")
-        .unwrap();
-    assert!(!size_ratchet.installed, "{:?}", offer.companions);
-    assert!(offer.declared.effects.removal.is_some());
+    assert!(!companion(offer, "size-ratchet").installed);
+    assert!(offer.removal.is_some());
 
-    kendex_app::repo_effects::apply(&f.scope, &offer.declared).unwrap();
+    let said = kendex_app::repo_effects::apply(&f.scope, &offer.declared).unwrap();
     assert!(
         f.project.join(".git/hooks/kendex-guards").is_file(),
         "the yes did not arm the hooks"
+    );
+    // The installer's own last word is what the window shows.
+    assert!(
+        said.last().is_some_and(|line| line.contains("armed")),
+        "{said:?}"
+    );
+}
+
+/// A companion already in the scope is reported as installed — the one
+/// fact about companions kendex answers rather than the package.
+#[test]
+fn a_companion_already_here_reads_as_installed() {
+    let f = fixture();
+    let first = install_skills(&f, &["size-ratchet"], None);
+    assert!(first.repo_effects.is_empty(), "{:?}", first.repo_effects);
+    let installed = install_skills(&f, &["growth-guards"], None);
+    let [offer] = installed.repo_effects.shown.as_slice() else {
+        panic!("one offer: {:?}", installed.repo_effects);
+    };
+    assert!(companion(offer, "size-ratchet").installed);
+    assert!(!companion(offer, "preflight").installed);
+}
+
+/// A set that carries a declaring package brings the same offer, on both
+/// of the app's bundle routes.
+#[test]
+fn a_bundle_carrying_the_package_brings_its_offer() {
+    let f = fixture();
+    let installed = install_skills(&f, &[], Some("guards"));
+    assert_eq!(
+        installed.repo_effects.shown.len(),
+        1,
+        "{:?}",
+        installed.repo_effects
+    );
+    assert_eq!(installed.repo_effects.shown[0].name, "growth-guards");
+
+    let g = fixture();
+    let installed = kendex_app::sources::install_bundle(
+        &g.env,
+        &g.scope,
+        "cat".to_owned(),
+        "guards".to_owned(),
+        false,
+    )
+    .unwrap_or_else(|error| panic!("bundle_install: {error}"));
+    assert_eq!(
+        installed.repo_effects.shown.len(),
+        1,
+        "{:?}",
+        installed.repo_effects
+    );
+    assert!(
+        !g.project.join(".git/hooks/kendex-guards").exists(),
+        "the bundle install armed the hooks with nobody asked"
     );
 }
 
@@ -170,7 +242,7 @@ fn the_effect_comes_back_unrun_and_a_separate_yes_arms_it() {
 #[test]
 fn an_inert_package_brings_no_offer() {
     let f = fixture();
-    let installed = install_skill(&f, "deploy");
+    let installed = install_skills(&f, &["deploy"], None);
     assert!(
         installed.repo_effects.is_empty(),
         "{:?}",

--- a/crates/cli/src/commands/add.rs
+++ b/crates/cli/src/commands/add.rs
@@ -146,11 +146,10 @@ pub fn run(env: &Env, args: AddArgs) -> CliResult {
         other => other?,
     };
     print_report(env, &report);
-    let pending = super::repo_effects::pending(&scope, &report);
     confirm_and_execute(env, &report, args.yes)?;
     // Disclosed after the write, because the script an effect runs is the
     // one this install just put on disk.
-    let shown_to_them = super::repo_effects::disclose(&scope, &pending);
+    let shown_to_them = super::repo_effects::disclose(env, &scope, &report.repo_effects)?;
     super::repo_effects::walkthrough(&scope, &shown_to_them, args.allow_repo_effects)?;
     say("done");
     Ok(())

--- a/crates/cli/src/commands/add_collection.rs
+++ b/crates/cli/src/commands/add_collection.rs
@@ -81,12 +81,13 @@ pub fn run(env: &Env, scope: &Scope, id: &str, yes: bool, allow_effects: bool) -
     let mut once: std::collections::BTreeMap<&str, &kendex_core::repo_effects::DeclaredEffects> =
         std::collections::BTreeMap::new();
     for report in &settled {
-        for effect in super::repo_effects::pending(scope, report) {
+        for effect in &report.repo_effects {
             once.entry(effect.name.as_str()).or_insert(effect);
         }
     }
-    let pending: Vec<&kendex_core::repo_effects::DeclaredEffects> = once.into_values().collect();
-    let shown_to_them = super::repo_effects::disclose(scope, &pending);
+    let pending: Vec<kendex_core::repo_effects::DeclaredEffects> =
+        once.into_values().cloned().collect();
+    let shown_to_them = super::repo_effects::disclose(env, scope, &pending)?;
     super::repo_effects::walkthrough(scope, &shown_to_them, allow_effects)?;
     Ok(())
 }

--- a/crates/cli/src/commands/apply_cmd.rs
+++ b/crates/cli/src/commands/apply_cmd.rs
@@ -34,6 +34,9 @@ pub struct ApplyArgs {
     /// installs in this scope — the old files move to the trash
     #[arg(long)]
     replace_unmanaged: bool,
+    /// Say yes to the repository changes a newly installed package declares
+    #[arg(long)]
+    allow_repo_effects: bool,
 }
 
 pub fn run(env: &Env, args: ApplyArgs) -> CliResult {
@@ -72,6 +75,10 @@ pub fn run(env: &Env, args: ApplyArgs) -> CliResult {
         print_unmanaged(&report.drift);
         if !args.plan {
             confirm_and_execute(env, &report, args.yes)?;
+            // A declaration written by hand installs here, and it gets the
+            // same account and the same separate yes an `add` gives it.
+            let shown_to_them = super::repo_effects::disclose(env, &scope, &report.repo_effects)?;
+            super::repo_effects::walkthrough(&scope, &shown_to_them, args.allow_repo_effects)?;
             // The deep work just ran; record it for the session-start check.
             if let Err(error) = kendex_core::drift::snapshot::record(env, &scope) {
                 say(&format!("warning: snapshot not derived ({error})"));

--- a/crates/cli/src/commands/project.rs
+++ b/crates/cli/src/commands/project.rs
@@ -119,7 +119,7 @@ fn offer_to_manage(env: &Env, root: &std::path::Path) {
             item.kind.name(),
             kendex_core::names::shown(&item.name),
             item.tools.join(", "),
-            quoted(root),
+            kendex_core::names::quoted(&root.display().to_string()),
             item.kind.name(),
             kendex_core::names::shown(&item.name),
         ));
@@ -162,11 +162,4 @@ fn grouped(rows: &[kendex_core::engine::DriftRow]) -> Vec<Offer> {
         }
     }
     items.into_iter().map(|(_, offer)| offer).collect()
-}
-
-/// A path a shell reads back as the one path it names. Single quotes take
-/// everything literally, and the only character they cannot hold is the
-/// single quote itself, which closes and reopens around an escaped one.
-fn quoted(path: &std::path::Path) -> String {
-    format!("'{}'", path.display().to_string().replace('\'', "'\\''"))
 }

--- a/crates/cli/src/commands/repo_effects.rs
+++ b/crates/cli/src/commands/repo_effects.rs
@@ -97,11 +97,8 @@ pub fn apply(scope: &Scope, declared: &DeclaredEffects) -> CliResult {
             relay(&report);
             Ok(())
         }
-        Err(kendex_core::repo_effects::ArmError::NothingToRun { .. }) => {
-            say(&kendex_core::repo_effects::ArmError::NothingToRun {
-                name: declared.name.clone(),
-            }
-            .to_string());
+        Err(error @ kendex_core::repo_effects::ArmError::NothingToRun { .. }) => {
+            say(&error.to_string());
             Ok(())
         }
         Err(error) => {

--- a/crates/cli/src/commands/repo_effects.rs
+++ b/crates/cli/src/commands/repo_effects.rs
@@ -25,32 +25,14 @@
 
 use std::io::{IsTerminal, Write};
 
-use kendex_core::engine::EngineReport;
 use kendex_core::model::Scope;
 use kendex_core::names::shown;
-use kendex_core::repo_effects::DeclaredEffects;
+use kendex_core::repo_effects::{DeclaredEffects, Disclosure};
 
 use super::{CliResult, out, say};
 
 mod disclose;
 pub use disclose::disclose;
-
-/// The repository effects this plan brings — the ones this run has to
-/// disclose and ask about, because no earlier run's answer carries.
-///
-/// Empty outside a project. A repository effect is a change to a
-/// repository, and the global scope is not one: `run_script` refuses it, so
-/// an effect offered there is a question whose yes cannot be honoured.
-/// Filtered here, at the one place the list is built, rather than in the
-/// disclosure — that skipped the block and left the same list to be asked
-/// about, so a global install prompted for an effect it had not named and
-/// `--allow-repo-effects` wrote the files before the refusal landed.
-pub fn pending<'a>(scope: &Scope, report: &'a EngineReport) -> Vec<&'a DeclaredEffects> {
-    match scope {
-        Scope::Project { .. } => report.repo_effects.iter().collect(),
-        _ => Vec::new(),
-    }
-}
 
 /// Ask about the disclosed effects and apply the ones that get a yes.
 ///
@@ -62,17 +44,17 @@ pub fn pending<'a>(scope: &Scope, report: &'a EngineReport) -> Vec<&'a DeclaredE
 /// Only that. A second `add` of an installed package adds nothing to what
 /// the scope carries, so it brings no effect to offer — naming `add` here
 /// sent people to a command that would do nothing and say nothing.
-pub fn walkthrough(scope: &Scope, pending: &[&DeclaredEffects], allowed: bool) -> CliResult {
-    if confirm(pending, allowed)? {
-        for declared in pending {
-            apply(scope, declared)?;
+pub fn walkthrough(scope: &Scope, shown_to_them: &[Disclosure], allowed: bool) -> CliResult {
+    if confirm(shown_to_them, allowed)? {
+        for disclosure in shown_to_them {
+            apply(scope, &disclosure.declared)?;
         }
         return Ok(());
     }
-    for declared in pending {
+    for disclosure in shown_to_them {
         say(&format!(
             "{}: installed; its repository changes were not applied",
-            shown(&declared.name)
+            shown(&disclosure.declared.name)
         ));
     }
     Ok(())
@@ -82,7 +64,7 @@ pub fn walkthrough(scope: &Scope, pending: &[&DeclaredEffects], allowed: bool) -
 /// needs `--allow-repo-effects` said out loud: a scripted install or a CI
 /// run must never arm a repository's hooks because nobody was there to
 /// decline.
-pub fn confirm(pending: &[&DeclaredEffects], allowed: bool) -> Result<bool, String> {
+pub fn confirm(pending: &[Disclosure], allowed: bool) -> Result<bool, String> {
     if pending.is_empty() {
         return Ok(false);
     }
@@ -96,7 +78,7 @@ pub fn confirm(pending: &[&DeclaredEffects], allowed: bool) -> Result<bool, Stri
     let question = match pending.len() {
         1 => format!(
             "apply {}'s repository changes? [y/N] ",
-            shown(&pending[0].name)
+            shown(&pending[0].declared.name)
         ),
         n => format!("apply the repository changes of {n} packages? [y/N] "),
     };

--- a/crates/cli/src/commands/repo_effects.rs
+++ b/crates/cli/src/commands/repo_effects.rs
@@ -26,7 +26,6 @@
 use std::io::{IsTerminal, Write};
 
 use kendex_core::model::Scope;
-use kendex_core::names::shown;
 use kendex_core::repo_effects::{DeclaredEffects, Disclosure};
 
 use super::{CliResult, out, say};
@@ -54,7 +53,7 @@ pub fn walkthrough(scope: &Scope, shown_to_them: &[Disclosure], allowed: bool) -
     for disclosure in shown_to_them {
         say(&format!(
             "{}: installed; its repository changes were not applied",
-            shown(&disclosure.declared.name)
+            disclosure.name
         ));
     }
     Ok(())
@@ -76,10 +75,7 @@ pub fn confirm(pending: &[Disclosure], allowed: bool) -> Result<bool, String> {
         return Ok(false);
     }
     let question = match pending.len() {
-        1 => format!(
-            "apply {}'s repository changes? [y/N] ",
-            shown(&pending[0].declared.name)
-        ),
+        1 => format!("apply {}'s repository changes? [y/N] ", pending[0].name),
         n => format!("apply the repository changes of {n} packages? [y/N] "),
     };
     let _ = write!(std::io::stderr(), "{question}");
@@ -90,47 +86,38 @@ pub fn confirm(pending: &[Disclosure], allowed: bool) -> Result<bool, String> {
     Ok(matches!(answer.trim(), "y" | "Y" | "yes"))
 }
 
-/// Run one package's installer, here and now. The run is the whole of it:
-/// what it wrote is on disk for anyone to look at, and nothing kendex
-/// stores decides what a later run does.
+/// Run one package's installer, here and now, and relay what it said.
+///
+/// Each of the package's streams goes out on its own channel, the way the
+/// package wrote them: its summary is what a caller pipes for. A package
+/// with nothing to run is a state to name, not a failure.
 pub fn apply(scope: &Scope, declared: &DeclaredEffects) -> CliResult {
-    let Some(installer) = &declared.effects.installer else {
-        say(&format!(
-            "{}: no installer to run — arm it yourself when you are ready",
-            shown(&declared.name)
-        ));
-        return Ok(());
-    };
-    let report = kendex_core::repo_effects::run_script(scope, &declared.root, installer)?;
-    // Each of the package's streams on its own channel, the way the package
-    // wrote them: its summary is what a caller pipes for.
+    match kendex_core::repo_effects::arm(scope, declared) {
+        Ok(report) => {
+            relay(&report);
+            Ok(())
+        }
+        Err(kendex_core::repo_effects::ArmError::NothingToRun { .. }) => {
+            say(&kendex_core::repo_effects::ArmError::NothingToRun {
+                name: declared.name.clone(),
+            }
+            .to_string());
+            Ok(())
+        }
+        Err(error) => {
+            if let kendex_core::repo_effects::ArmError::Failed { report, .. } = &error {
+                relay(report);
+            }
+            Err(error.to_string().into())
+        }
+    }
+}
+
+fn relay(report: &kendex_core::guard::GuardReport) {
     for line in &report.stderr {
         say(line);
     }
     for line in &report.stdout {
         out(line);
     }
-    if report.code != 0 {
-        // Not "the repository is unchanged". kendex takes no pre-image and
-        // rolls nothing back, so an installer that wrote three files and
-        // failed on the fourth leaves three files — and a message promising
-        // otherwise is the one thing that would stop somebody looking. The
-        // declaration names what the package writes, which is where to look.
-        return Err(format!(
-            "{}: {} exited {} — anything it wrote before that is still \
-             there; `{}` is what the package says undoes it",
-            shown(&declared.name),
-            shown(installer),
-            report.code,
-            shown(
-                declared
-                    .effects
-                    .uninstaller
-                    .as_deref()
-                    .unwrap_or("its uninstaller")
-            )
-        )
-        .into());
-    }
-    Ok(())
 }

--- a/crates/cli/src/commands/repo_effects/disclose.rs
+++ b/crates/cli/src/commands/repo_effects/disclose.rs
@@ -1,13 +1,16 @@
 //! The block a person reads, and the seal taken as they read it.
 //!
 //! Its own file because it is one concept with one edge: everything here
-//! turns a declaration into what is on the screen, and hands back exactly
-//! what was shown. The consent that follows is next door and reads nothing
-//! else.
+//! turns an offer into what is on the screen, and hands back exactly what
+//! was shown. The consent that follows is next door and reads nothing
+//! else. What a declaration means for THIS repository — where a path
+//! lands, who shares it, which companions are here — is core's answer,
+//! and this only prints it.
 
+use kendex_core::env::Env;
 use kendex_core::model::Scope;
 use kendex_core::names::shown;
-use kendex_core::repo_effects::DeclaredEffects;
+use kendex_core::repo_effects::{DeclaredEffects, Disclosure};
 
 use super::super::say;
 
@@ -24,125 +27,79 @@ use super::super::say;
 /// prompt writes to stderr. Sending the block to stdout meant
 /// `kendex add ... > log` asked the question with the reasons for it in the
 /// file, which is a consent prompt with nothing to consent to.
-pub fn disclose<'a>(scope: &Scope, pending: &[&'a DeclaredEffects]) -> Vec<&'a DeclaredEffects> {
-    // `pending` is empty outside a project, so this only names the root.
-    let Scope::Project { root } = scope else {
-        return Vec::new();
-    };
-    // Where `.git/...` actually is. The installer writes through
-    // `--git-common-dir`, so in a linked worktree the hooks are the MAIN
-    // checkout's and in a `--separate-git-dir` layout they are outside the
-    // project entirely. Rendering a declared `.git/hooks/pre-commit` against
-    // the project root named a path that does not exist and hid the one that
-    // does — and this block is a person's only account of what is about to
-    // change.
-    // Where `.git/...` actually is, or nothing at all.
-    //
-    // Guessing `<root>/.git` was wrong in the case the guess exists for: a
-    // linked worktree or a `--separate-git-dir` layout puts the hooks
-    // somewhere else, and a repository whose common dir cannot be resolved
-    // is exactly the one whose layout kendex has not understood. A block
-    // naming a path that does not exist, immediately before asking somebody
-    // to authorize writing to it, is worse than no block.
-    let git_dir = kendex_core::guard::Repo::at(root).map(|repo| repo.common_dir);
-    let mut shown_to_them = Vec::new();
-    for declared in pending {
-        // An effect that writes into `.git` is not disclosed where the
-        // repository could not be read: nothing here can say where those
-        // files land. One that writes nowhere near it is unaffected.
-        let touches_git = effects_touch_git(&declared.effects);
-        if touches_git && git_dir.is_err() {
-            say(&format!(
-                "{}: not disclosed — this repository's git directory could \
-                 not be resolved, so where it writes cannot be named; \
-                 nothing was offered or run",
-                shown(&declared.name)
-            ));
-            continue;
-        }
-        let effects = &declared.effects;
-        let name = shown(&declared.name);
-        say("");
+pub fn disclose(
+    env: &Env,
+    scope: &Scope,
+    effects: &[DeclaredEffects],
+) -> Result<Vec<Disclosure>, Box<dyn std::error::Error>> {
+    if effects.is_empty() {
+        return Ok(Vec::new());
+    }
+    let installed = kendex_core::repo_effects::installed_skills(env, scope)?;
+    let offers = kendex_core::repo_effects::offers(scope, effects, &installed);
+    for withheld in &offers.withheld {
         say(&format!(
-            "{name} changes how this repository works, beyond the files above:"
+            "{}: not disclosed — {}",
+            shown(&withheld.name),
+            withheld.reason
         ));
-        say(&format!("  {}", shown(&effects.summary)));
-        if !effects.writes.is_empty() {
-            say("");
-            say("  writes");
-            let mut shared = false;
-            for path in &effects.writes {
-                let target = lands_at(root, git_dir.as_ref().ok(), path);
-                // By path components, not by text. A string prefix reads
-                // `<root>/.github/config` as sitting under `<root>/.git`,
-                // and the line it decides is a claim about who else sees
-                // these files.
-                shared |= git_dir.as_ref().is_ok_and(|dir| target.starts_with(dir));
-                say(&format!("    {}", shown(&target.display().to_string())));
-            }
-            if shared {
-                say("");
-                say("  that directory is the repository's, not this checkout's:");
-                say("  every work tree of it shares these files");
-            }
-        }
-        if !effects.companions.is_empty() {
-            say("");
-            say("  companion packages");
-            for companion in &effects.companions {
-                say(&format!("    {}", shown(companion)));
-            }
-            // The names, and nothing about what they mean. What a
-            // companion's presence or absence does is the package's own
-            // contract, and kendex stating it here stated growth-guards'
-            // for every package that declares any. A package with something
-            // to say about its companions says it in `notes`.
-        }
-        for note in &effects.notes {
-            say("");
-            say(&format!("  {}", shown(note)));
-        }
+    }
+    for disclosure in &offers.shown {
+        print(disclosure);
+    }
+    Ok(offers.shown)
+}
+
+fn print(disclosure: &Disclosure) {
+    let effects = &disclosure.declared.effects;
+    let name = shown(&disclosure.declared.name);
+    say("");
+    say(&format!(
+        "{name} changes how this repository works, beyond the files above:"
+    ));
+    say(&format!("  {}", shown(&effects.summary)));
+    if !disclosure.writes.is_empty() {
         say("");
-        match &effects.removal {
-            Some(removal) => say(&format!("  to undo: {}", shown(removal))),
-            // Not "remove the package". Removing it takes the scripts away
-            // and leaves the effect: shims in .git/hooks outlive the tree
-            // they point at, and then fail every commit closed. What is true
-            // is that the package said nothing about undoing this.
-            None => say("  to undo: the package declares no removal instructions"),
+        say("  writes");
+        for written in &disclosure.writes {
+            say(&format!("    {}", shown(&written.path)));
         }
-        shown_to_them.push(*declared);
+        if disclosure.writes.iter().any(|written| written.shared) {
+            say("");
+            say("  that directory is the repository's, not this checkout's:");
+            say("  every work tree of it shares these files");
+        }
     }
-    shown_to_them
-}
-
-/// A declared target, as the absolute path it really lands at.
-///
-/// `.git/...` goes to the repository's common git directory; everything else
-/// is under the project. Absolute either way, because the whole value of the
-/// line is that a reader can go and look.
-fn lands_at(
-    root: &std::path::Path,
-    git_dir: Option<&std::path::PathBuf>,
-    declared: &str,
-) -> std::path::PathBuf {
-    match (under_git(declared), git_dir) {
-        (Some(rest), Some(dir)) => dir.join(rest),
-        // Unreachable while a package with any `.git` target is refused
-        // above; a path is still the honest answer if that ever changes.
-        (Some(_), None) => root.join(declared),
-        (None, _) => root.join(declared),
+    if !disclosure.companions.is_empty() {
+        say("");
+        say("  companion packages");
+        for companion in &disclosure.companions {
+            say(&format!(
+                "    {} ({})",
+                shown(&companion.name),
+                match companion.installed {
+                    true => "installed",
+                    false => "not installed",
+                }
+            ));
+        }
+        // The names and whether each is here, and nothing about what that
+        // means. What a companion's presence or absence does is the
+        // package's own contract, and kendex stating it here stated
+        // growth-guards' for every package that declares any. A package
+        // with something to say about its companions says it in `notes`.
     }
-}
-
-/// The part of a declared path that sits under the git directory.
-fn under_git(declared: &str) -> Option<&str> {
-    declared
-        .strip_prefix(".git/")
-        .or_else(|| declared.strip_prefix("./.git/"))
-}
-
-/// Whether anything this package declares lands in the git directory.
-fn effects_touch_git(effects: &kendex_core::repo_effects::RepoEffects) -> bool {
-    effects.writes.iter().any(|path| under_git(path).is_some())
+    for note in &effects.notes {
+        say("");
+        say(&format!("  {}", shown(note)));
+    }
+    say("");
+    match &effects.removal {
+        Some(removal) => say(&format!("  to undo: {}", shown(removal))),
+        // Not "remove the package". Removing it takes the scripts away
+        // and leaves the effect: shims in .git/hooks outlive the tree
+        // they point at, and then fail every commit closed. What is true
+        // is that the package said nothing about undoing this.
+        None => say("  to undo: the package declares no removal instructions"),
+    }
 }

--- a/crates/cli/src/commands/repo_effects/disclose.rs
+++ b/crates/cli/src/commands/repo_effects/disclose.rs
@@ -54,13 +54,21 @@ fn print(disclosure: &Disclosure) {
     if !disclosure.writes.is_empty() {
         say("");
         say("  writes");
+        // Marked one by one. A package that writes into `.git/hooks` and
+        // into `.github` writes one file every work tree sees and one only
+        // this checkout has, and a sentence under the whole list claimed
+        // the first about both.
         for written in &disclosure.writes {
-            say(&format!("    {}", written.path));
+            let mark = match written.shared {
+                true => "  (shared)",
+                false => "",
+            };
+            say(&format!("    {}{mark}", written.path));
         }
         if disclosure.writes.iter().any(|written| written.shared) {
             say("");
-            say("  that directory is the repository's, not this checkout's:");
-            say("  every work tree of it shares these files");
+            say("  the paths marked shared are the repository's, not this");
+            say("  checkout's: every work tree of it sees those files");
         }
     }
     if !disclosure.companions.is_empty() {
@@ -87,12 +95,12 @@ fn print(disclosure: &Disclosure) {
         say(&format!("  {note}"));
     }
     say("");
-    match &disclosure.removal {
-        Some(removal) => say(&format!("  to undo: {removal}")),
+    match &disclosure.undo {
+        Some(undo) => say(&format!("  to undo: {undo}")),
         // Not "remove the package". Removing it takes the scripts away
         // and leaves the effect: shims in .git/hooks outlive the tree
         // they point at, and then fail every commit closed. What is true
         // is that the package said nothing about undoing this.
-        None => say("  to undo: the package declares no removal instructions"),
+        None => say("  to undo: the package declares no way to undo it"),
     }
 }

--- a/crates/cli/src/commands/repo_effects/disclose.rs
+++ b/crates/cli/src/commands/repo_effects/disclose.rs
@@ -5,11 +5,10 @@
 //! was shown. The consent that follows is next door and reads nothing
 //! else. What a declaration means for THIS repository — where a path
 //! lands, who shares it, which companions are here — is core's answer,
-//! and this only prints it.
+//! already shown through `names::shown` there, and this only prints it.
 
 use kendex_core::env::Env;
 use kendex_core::model::Scope;
-use kendex_core::names::shown;
 use kendex_core::repo_effects::{DeclaredEffects, Disclosure};
 
 use super::super::say;
@@ -32,16 +31,11 @@ pub fn disclose(
     scope: &Scope,
     effects: &[DeclaredEffects],
 ) -> Result<Vec<Disclosure>, Box<dyn std::error::Error>> {
-    if effects.is_empty() {
-        return Ok(Vec::new());
-    }
-    let installed = kendex_core::repo_effects::installed_skills(env, scope)?;
-    let offers = kendex_core::repo_effects::offers(scope, effects, &installed);
+    let offers = kendex_core::repo_effects::offers_for(env, scope, effects)?;
     for withheld in &offers.withheld {
         say(&format!(
             "{}: not disclosed — {}",
-            shown(&withheld.name),
-            withheld.reason
+            withheld.name, withheld.reason
         ));
     }
     for disclosure in &offers.shown {
@@ -51,18 +45,17 @@ pub fn disclose(
 }
 
 fn print(disclosure: &Disclosure) {
-    let effects = &disclosure.declared.effects;
-    let name = shown(&disclosure.declared.name);
+    let name = &disclosure.name;
     say("");
     say(&format!(
         "{name} changes how this repository works, beyond the files above:"
     ));
-    say(&format!("  {}", shown(&effects.summary)));
+    say(&format!("  {}", disclosure.summary));
     if !disclosure.writes.is_empty() {
         say("");
         say("  writes");
         for written in &disclosure.writes {
-            say(&format!("    {}", shown(&written.path)));
+            say(&format!("    {}", written.path));
         }
         if disclosure.writes.iter().any(|written| written.shared) {
             say("");
@@ -76,7 +69,7 @@ fn print(disclosure: &Disclosure) {
         for companion in &disclosure.companions {
             say(&format!(
                 "    {} ({})",
-                shown(&companion.name),
+                companion.name,
                 match companion.installed {
                     true => "installed",
                     false => "not installed",
@@ -89,13 +82,13 @@ fn print(disclosure: &Disclosure) {
         // growth-guards' for every package that declares any. A package
         // with something to say about its companions says it in `notes`.
     }
-    for note in &effects.notes {
+    for note in &disclosure.notes {
         say("");
-        say(&format!("  {}", shown(note)));
+        say(&format!("  {note}"));
     }
     say("");
-    match &effects.removal {
-        Some(removal) => say(&format!("  to undo: {}", shown(removal))),
+    match &disclosure.removal {
+        Some(removal) => say(&format!("  to undo: {removal}")),
         // Not "remove the package". Removing it takes the scripts away
         // and leaves the effect: shims in .git/hooks outlive the tree
         // they point at, and then fail every commit closed. What is true

--- a/crates/cli/tests/install_ux/disclosing.rs
+++ b/crates/cli/tests/install_ux/disclosing.rs
@@ -140,3 +140,51 @@ fn the_yes_to_a_repository_effect_is_spent_where_it_is_given() {
         spoke(&passes)
     );
 }
+
+/// What a person writes into `kendex.toml` to declare the package without
+/// an `add`: where it installs to, and the package itself.
+const DECLARED_BY_HAND: &str =
+    "\n[install]\nharnesses = [\"claude\"]\n\n[skills.growth-guards]\nsource = \"cat\"\n";
+
+/// A declaration written by hand installs through `kendex apply`, and the
+/// package it installs gets the same account and the same separate yes an
+/// `add` would have given it — the walkthrough belongs to the install, not
+/// to the verb that started it.
+#[test]
+#[allow(clippy::unwrap_used)]
+fn apply_discloses_a_hand_declared_package_and_waits_for_its_own_yes() {
+    let world = World::new(&["claude"]);
+    world.declare_catalog();
+    offer(&world, "growth-guards");
+    fs::write(world.at("kendex.toml"), world.manifest() + DECLARED_BY_HAND).unwrap();
+
+    let spoken = world.try_run(&["apply", "-y"]);
+    assert!(spoken.status.success(), "{}", spoke(&spoken));
+    let out = spoke(&spoken);
+    assert!(
+        out.contains("changes how this repository works"),
+        "apply installed the package without its account:\n{out}"
+    );
+    assert!(out.contains("--allow-repo-effects"), "{out}");
+    assert!(
+        world
+            .at(".agents/skills/growth-guards/scripts/install-git-hooks")
+            .is_file(),
+        "the package did not install:\n{out}"
+    );
+    assert!(
+        !world.at(".git/hooks/kendex-guards").exists(),
+        "apply armed the hooks with nobody there to say yes:\n{out}"
+    );
+
+    // The same flag means yes here too, in a repository that never said it.
+    let armed = World::new(&["claude"]);
+    armed.declare_catalog();
+    offer(&armed, "growth-guards");
+    fs::write(armed.at("kendex.toml"), armed.manifest() + DECLARED_BY_HAND).unwrap();
+    let out = armed.run(&["apply", "-y", "--allow-repo-effects"]);
+    assert!(
+        armed.at(".git/hooks/kendex-guards").is_file(),
+        "the yes did not arm the hooks:\n{out}"
+    );
+}

--- a/crates/cli/tests/install_ux/disclosing.rs
+++ b/crates/cli/tests/install_ux/disclosing.rs
@@ -24,6 +24,18 @@ fn the_repository_effect_is_disclosed_and_not_applied_without_a_yes() {
     let world = World::new(&["claude"]);
     world.declare_catalog();
     offer(&world, "growth-guards");
+    // One declared write outside `.git`, so the block carries both kinds.
+    // The shared claim is about the repository's own directory, and a file
+    // that lives in this checkout must not be swept into it.
+    let declaration = world.catalog.join("skills/growth-guards/SKILL.md");
+    let text = fs::read_to_string(&declaration).unwrap();
+    let anchor = "    - \".git/hooks/commit-msg\"\n";
+    assert!(text.contains(anchor), "the declaration moved");
+    fs::write(
+        &declaration,
+        text.replace(anchor, &format!("{anchor}    - \".github/x\"\n")),
+    )
+    .unwrap();
     let spoken = world.try_run(&["add", "cat", "--skill", "growth-guards", "-y"]);
     assert!(spoken.status.success(), "{}", spoke(&spoken));
     let asked = String::from_utf8_lossy(&spoken.stderr).into_owned();
@@ -51,6 +63,19 @@ fn the_repository_effect_is_disclosed_and_not_applied_without_a_yes() {
         "no companion line:\n{out}"
     );
     assert!(out.contains("to undo:"), "{out}");
+
+    // Marked path by path. A sentence under the whole list said the
+    // repository shares every file in it, including the checkout-local one.
+    assert!(out.contains(".git/hooks/pre-commit  (shared)"), "{out}");
+    assert!(
+        out.lines()
+            .any(|line| line.trim_end().ends_with(".github/x")),
+        "the checkout-local path was marked shared:\n{out}"
+    );
+    assert!(
+        out.contains("the paths marked shared are the repository's"),
+        "{out}"
+    );
 
     // The refusal names the flag rather than leaving the reader to find it.
     assert!(

--- a/crates/cli/tests/install_ux/disclosing.rs
+++ b/crates/cli/tests/install_ux/disclosing.rs
@@ -46,7 +46,10 @@ fn the_repository_effect_is_disclosed_and_not_applied_without_a_yes() {
     assert!(out.contains("every commit in this repository"), "{out}");
     assert!(out.contains(".git/hooks/pre-commit"), "{out}");
     assert!(out.contains(".git/hooks/commit-msg"), "{out}");
-    assert!(out.contains("size-ratchet"), "no companion line:\n{out}");
+    assert!(
+        out.contains("size-ratchet (not installed)"),
+        "no companion line:\n{out}"
+    );
     assert!(out.contains("to undo:"), "{out}");
 
     // The refusal names the flag rather than leaving the reader to find it.
@@ -187,4 +190,20 @@ fn apply_discloses_a_hand_declared_package_and_waits_for_its_own_yes() {
         armed.at(".git/hooks/kendex-guards").is_file(),
         "the yes did not arm the hooks:\n{out}"
     );
+}
+
+/// Which companions are here is kendex's answer, not the package's: one
+/// installed before the declaring package reads as installed in its block.
+#[test]
+fn a_companion_already_here_reads_as_installed() {
+    let world = World::new(&["claude"]);
+    world.declare_catalog();
+    offer(&world, "size-ratchet");
+    offer(&world, "growth-guards");
+    world.run(&["add", "cat", "--skill", "size-ratchet", "-y"]);
+    let spoken = world.try_run(&["add", "cat", "--skill", "growth-guards", "-y"]);
+    let out = spoke(&spoken);
+    assert!(spoken.status.success(), "{out}");
+    assert!(out.contains("size-ratchet (installed)"), "{out}");
+    assert!(out.contains("preflight (not installed)"), "{out}");
 }

--- a/crates/core/src/engine/repo_effects.rs
+++ b/crates/core/src/engine/repo_effects.rs
@@ -60,12 +60,7 @@ pub(super) fn run(
     // out — and an unrelated `add` then armed a package whose effect had
     // been declined. The effect belongs to the package, so the question is
     // about the package: was this name anywhere in the scope before.
-    let already_here: BTreeSet<&str> = before
-        .entries
-        .values()
-        .filter(|entry| entry.kind == ItemKind::Skill)
-        .map(|entry| entry.name.as_str())
-        .collect();
+    let already_here = crate::lock::skill_names(before);
     let installed: BTreeSet<&str> = added
         .iter()
         .filter(|change| {

--- a/crates/core/src/lock.rs
+++ b/crates/core/src/lock.rs
@@ -233,13 +233,9 @@ pub fn parse_entry_key(key: &str) -> Option<(ItemKind, &str, HarnessId)> {
     Some((kind, name, HarnessId::parse(harness)?))
 }
 
-/// Where this scope's lock lives. Off the canonical root, like every
-/// scope-path derivation (`manifest::manifest_path`): the path must
-/// compare equal to the ones the engine's plan speaks, whatever spelling
-/// the scope arrived under.
-/// The skills a lock carries, by name. A lock row is per installation, so a
-/// skill fanned out to three tools is one name here — the shape every
-/// question about "is this package in the scope" wants.
+/// The skills a lock carries, by name. A lock row is per harness, so a
+/// skill fanned out to three tools has three rows and one name here — the
+/// shape every question about "is this package in the scope" wants.
 pub fn skill_names(lock: &Lock) -> std::collections::BTreeSet<String> {
     lock.entries
         .values()
@@ -248,6 +244,10 @@ pub fn skill_names(lock: &Lock) -> std::collections::BTreeSet<String> {
         .collect()
 }
 
+/// Where this scope's lock lives. Off the canonical root, like every
+/// scope-path derivation (`manifest::manifest_path`): the path must
+/// compare equal to the ones the engine's plan speaks, whatever spelling
+/// the scope arrived under.
 pub fn lock_path(env: &Env, scope: &Scope) -> PathBuf {
     match &scope.canonical() {
         Scope::Global => env.global_lock_file(),

--- a/crates/core/src/lock.rs
+++ b/crates/core/src/lock.rs
@@ -237,6 +237,17 @@ pub fn parse_entry_key(key: &str) -> Option<(ItemKind, &str, HarnessId)> {
 /// scope-path derivation (`manifest::manifest_path`): the path must
 /// compare equal to the ones the engine's plan speaks, whatever spelling
 /// the scope arrived under.
+/// The skills a lock carries, by name. A lock row is per installation, so a
+/// skill fanned out to three tools is one name here — the shape every
+/// question about "is this package in the scope" wants.
+pub fn skill_names(lock: &Lock) -> std::collections::BTreeSet<String> {
+    lock.entries
+        .values()
+        .filter(|entry| entry.kind == ItemKind::Skill)
+        .map(|entry| entry.name.clone())
+        .collect()
+}
+
 pub fn lock_path(env: &Env, scope: &Scope) -> PathBuf {
     match &scope.canonical() {
         Scope::Global => env.global_lock_file(),

--- a/crates/core/src/names.rs
+++ b/crates/core/src/names.rs
@@ -4,6 +4,9 @@
 //! cannot be one is refused where it is written down rather than where it
 //! fails. Plugin-registry-shaped catalogs add a second rule: a name may carry
 //! one `<plugin>/<leaf>` segment pair, and nothing more.
+//!
+//! And what catalog text looks like on its way out: `shown` for a screen,
+//! `quoted` for a command a person is going to paste.
 
 /// Room for the separator a namespaced name expands to, the `.disabled`
 /// parking suffix, and Copilot's `.agent.md` — inside the 255-byte
@@ -125,6 +128,17 @@ fn is_deceptive(c: char) -> bool {
         | '\u{2066}'..='\u{2069}' // bidi isolates
         | '\u{FEFF}'              // zero-width no-break space (BOM)
     )
+}
+
+/// A word a shell reads back as the one word it names. Single quotes take
+/// everything literally, and the only character they cannot hold is the
+/// single quote itself, which closes and reopens around an escaped one.
+///
+/// Every word, not the ones that look dangerous. Which characters are live
+/// is the shell's judgement and not this function's, and anything kendex
+/// prints as a command to paste is a command somebody runs.
+pub fn quoted(word: &str) -> String {
+    format!("'{}'", word.replace('\'', "'\\''"))
 }
 
 /// Why this item name cannot be installed. A name from a plugin-registry-shaped

--- a/crates/core/src/repo_effects.rs
+++ b/crates/core/src/repo_effects.rs
@@ -36,17 +36,27 @@ use specta::Type;
 /// The frontmatter key a package declares its effects under.
 pub const KEY: &str = "repo-effects";
 
-/// Run one package's declared script, from the repository root.
+/// One package's declared script, ready to run: the repository to run it
+/// in, the program, and its arguments.
 ///
 /// The program is resolved under `root`, the installed package's own
 /// directory, and canonicalized back into it: a symlink placed inside the
 /// package after install must not reach a program outside it. Arguments are
 /// passed as words, never through a shell.
-pub fn run_script(
-    scope: &crate::model::Scope,
+///
+/// Split from the launch on purpose. Nothing here starts a process, so a
+/// failure at this stage is one where the script provably never ran — and
+/// that is the only thing that lets `arm` tell "could not run it" apart
+/// from "ran, and may have written something".
+fn resolve_script<'a>(
+    scope: &'a crate::model::Scope,
     root: &std::path::Path,
     spec: &str,
-) -> crate::error::Result<crate::guard::GuardReport> {
+) -> crate::error::Result<(
+    &'a std::path::Path,
+    std::path::PathBuf,
+    Vec<std::ffi::OsString>,
+)> {
     let crate::model::Scope::Project { root: repo } = scope else {
         return Err(err(
             "repository effects apply to a project, not the global scope",
@@ -68,14 +78,23 @@ pub fn run_script(
             root.display()
         )));
     }
-    // Run from the repository root and pass only the package's own
-    // arguments. kendex injects nothing: a declared script that needed a
-    // flag kendex invented would be a script only kendex could run, and the
-    // point of the declaration is that a person can run it too.
+    // Only the package's own arguments. kendex injects nothing: a declared
+    // script that needed a flag kendex invented would be a script only
+    // kendex could run, and the point of the declaration is that a person
+    // can run it too.
     // The declaration is text, so its arguments are text; paths that reach
     // the child as bytes are the ones kendex resolves, not these.
-    let argv: Vec<std::ffi::OsString> = args.into_iter().map(Into::into).collect();
-    let output = crate::process::Hardened::guard_script(&resolved, argv, repo)
+    let argv = args.into_iter().map(Into::into).collect();
+    Ok((repo.as_path(), resolved, argv))
+}
+
+/// Run a resolved script from the repository root and relay what it said.
+fn launch_script(
+    repo: &std::path::Path,
+    program: &std::path::Path,
+    argv: Vec<std::ffi::OsString>,
+) -> crate::error::Result<crate::guard::GuardReport> {
+    let output = crate::process::Hardened::guard_script(program, argv, repo)
         .run()
         .map_err(|error| err(error.to_string()))?;
     Ok(crate::guard::relay(&output))
@@ -103,13 +122,23 @@ pub fn arm(
             name: declared.name.clone(),
         });
     };
-    let report = run_script(scope, &declared.root, installer)?;
+    let (repo, program, argv) = resolve_script(scope, &declared.root, installer)?;
+    // Past this line the installer has been handed to the operating system,
+    // so every failure is one where it may already have written something —
+    // a kill, a timeout, an exec that failed for a reason nobody can see
+    // from here. That reads like a nonzero exit, not like "could not run".
+    let report = launch_script(repo, &program, argv).map_err(|error| ArmError::Unfinished {
+        name: declared.name.clone(),
+        installer: installer.clone(),
+        undo: declared.undo(),
+        error: Box::new(error),
+    })?;
     if report.code != 0 {
         return Err(ArmError::Failed {
             name: declared.name.clone(),
             installer: installer.clone(),
             code: report.code,
-            undo: declared.effects.undo(),
+            undo: declared.undo(),
             report: Box::new(report),
         });
     }
@@ -136,8 +165,22 @@ pub enum ArmError {
         undo: Option<String>,
         report: Box<crate::guard::GuardReport>,
     },
-    /// The installer could not be run at all. Boxed: the error is a rare
-    /// path and the common `Ok` should not pay for its size.
+    /// The installer was handed to the operating system and no exit status
+    /// came back — a timeout, a kill, an exec that failed after the fork.
+    /// Whether it wrote anything is unknowable from here, so this says what
+    /// `Failed` says: what it wrote is still there, and here is the undo.
+    Unfinished {
+        name: String,
+        installer: String,
+        undo: Option<String>,
+        /// Boxed for the same reason as `Run`.
+        error: Box<crate::error::CoreError>,
+    },
+    /// The installer could not be run at all: the scope is not a project,
+    /// or the program does not resolve inside the package. Every one of
+    /// those is settled before anything is launched, so nothing ran and
+    /// nothing was written. Boxed: the error is a rare path and the common
+    /// `Ok` should not pay for its size.
     Run(Box<crate::error::CoreError>),
 }
 
@@ -157,16 +200,22 @@ impl std::fmt::Display for ArmError {
                 undo,
                 ..
             } => {
+                write!(f, "{}: {} exited {code}", shown(name), shown(installer))?;
+                aftermath(f, undo.as_deref())
+            }
+            ArmError::Unfinished {
+                name,
+                installer,
+                undo,
+                error,
+            } => {
                 write!(
                     f,
-                    "{}: {} exited {code} — anything it wrote before that is still there; ",
+                    "{}: {} did not finish ({error})",
                     shown(name),
                     shown(installer)
                 )?;
-                match undo {
-                    Some(undo) => write!(f, "to undo: {}", shown(undo)),
-                    None => write!(f, "the package declares no way to undo it"),
-                }
+                aftermath(f, undo.as_deref())
             }
             ArmError::Run(error) => write!(f, "{error}"),
         }
@@ -175,20 +224,46 @@ impl std::fmt::Display for ArmError {
 
 impl std::error::Error for ArmError {}
 
+/// The tail every outcome that may have written something carries: nothing
+/// was rolled back, and what the package itself says undoes it.
+fn aftermath(f: &mut std::fmt::Formatter<'_>, undo: Option<&str>) -> std::fmt::Result {
+    use crate::names::shown;
+    write!(f, " — anything it wrote before that is still there; ")?;
+    match undo {
+        Some(undo) => write!(f, "to undo: {}", shown(undo)),
+        None => write!(f, "the package declares no way to undo it"),
+    }
+}
+
 impl From<crate::error::CoreError> for ArmError {
     fn from(error: crate::error::CoreError) -> Self {
         ArmError::Run(Box::new(error))
     }
 }
 
-impl RepoEffects {
+impl DeclaredEffects {
     /// What the package says undoes its effect: the uninstaller it declared
     /// where there is one, else its removal text, else nothing.
-    pub fn undo(&self) -> Option<String> {
-        self.uninstaller
+    ///
+    /// The uninstaller is resolved under the package the way `arm` resolves
+    /// the installer, because a declared script is package-relative and this
+    /// line sends a person to the repository root, where that relative path
+    /// names nothing. Only the program is resolved; the declared arguments
+    /// go out as the package wrote them, and the cwd the line asks for is
+    /// still the one kendex would have run it in.
+    fn undo(&self) -> Option<String> {
+        self.effects
+            .uninstaller
             .as_ref()
-            .map(|script| format!("run `{script}` from the repository root"))
-            .or_else(|| self.removal.clone())
+            .map(|script| {
+                let (program, args) = split_script(script);
+                let command = std::iter::once(self.root.join(program).display().to_string())
+                    .chain(args.into_iter().map(str::to_owned))
+                    .collect::<Vec<_>>()
+                    .join(" ");
+                format!("run `{command}` from the repository root")
+            })
+            .or_else(|| self.effects.removal.clone())
     }
 }
 

--- a/crates/core/src/repo_effects.rs
+++ b/crates/core/src/repo_effects.rs
@@ -23,8 +23,10 @@
 //! and rendering it as a warning teaches people to click past the one
 //! notice they most need to read.
 mod declaration;
+pub mod disclosure;
 use declaration::split_script;
 pub use declaration::{RepoEffects, declared};
+pub use disclosure::{Companion, Disclosure, Offers, Withheld, Written, installed_skills, offers};
 
 use serde::{Deserialize, Serialize};
 use specta::Type;

--- a/crates/core/src/repo_effects.rs
+++ b/crates/core/src/repo_effects.rs
@@ -131,6 +131,36 @@ pub fn arm(
     Ok(report)
 }
 
+/// Where this scope recorded one installed skill's tree, as the install
+/// wrote it down.
+///
+/// What a surface asks before arming a declaration it took back from
+/// something it does not control. `arm` checks only that the program sits
+/// inside the root it was handed, which is the caller's answer checked
+/// against itself: a root of `/` passes it with any program underneath.
+///
+/// Read off the lock rather than derived. A copy delivery puts the tree in
+/// the harness's own directory instead of the shared one, so a derivation
+/// naming `.agents/skills/<name>` would refuse a package that is installed
+/// perfectly well — the same reason removal and refresh read the record
+/// instead of deriving a path the install never took.
+pub fn recorded_roots(
+    env: &crate::env::Env,
+    scope: &crate::model::Scope,
+    name: &str,
+) -> crate::error::Result<std::collections::BTreeSet<std::path::PathBuf>> {
+    let lock = crate::lock::load(&crate::lock::lock_path(env, scope))?;
+    Ok(lock
+        .entries
+        .values()
+        .filter(|entry| entry.kind == crate::model::ItemKind::Skill && entry.name == name)
+        .filter_map(|entry| entry.emitted.as_ref())
+        // The tree, never the link beside it: a link is where a tool reads
+        // the package through, not a directory its scripts live in.
+        .filter_map(|emitted| emitted.paths.first().cloned())
+        .collect())
+}
+
 /// Why a yes did not arm the repository.
 #[derive(Debug)]
 pub enum ArmError {
@@ -212,10 +242,11 @@ impl DeclaredEffects {
     /// package is `arm`'s question, settled in `resolve_script` for the
     /// program it is about to run; this one is a line to read.
     ///
-    /// Either spelling is quoted where it carries whitespace: this is a
-    /// command to paste, and a checkout at `~/My Project` would otherwise
-    /// name a program ending at `My` with an argument after it. Only the
-    /// program; the declared arguments go out as the package wrote them.
+    /// Every word goes out through `names::quoted`, the program and each
+    /// declared argument alike. This is a command to paste: a checkout at
+    /// `~/My Project` would otherwise name a program ending at `My`, and a
+    /// `;` or a backtick a package declared would be live in the shell it
+    /// is pasted into rather than the argument kendex itself passes.
     fn undo(&self, repo: &std::path::Path) -> Option<String> {
         self.effects
             .uninstaller
@@ -228,12 +259,8 @@ impl DeclaredEffects {
                     .unwrap_or(whole.as_path())
                     .display()
                     .to_string();
-                let quoted = match path.contains(char::is_whitespace) {
-                    true => format!("'{path}'"),
-                    false => path,
-                };
-                let command = std::iter::once(quoted)
-                    .chain(args.into_iter().map(str::to_owned))
+                let command = std::iter::once(crate::names::quoted(&path))
+                    .chain(args.into_iter().map(crate::names::quoted))
                     .collect::<Vec<_>>()
                     .join(" ");
                 format!("run `{command}` from the repository root")

--- a/crates/core/src/repo_effects.rs
+++ b/crates/core/src/repo_effects.rs
@@ -43,11 +43,6 @@ pub const KEY: &str = "repo-effects";
 /// directory, and canonicalized back into it: a symlink placed inside the
 /// package after install must not reach a program outside it. Arguments are
 /// passed as words, never through a shell.
-///
-/// Split from the launch on purpose. Nothing here starts a process, so a
-/// failure at this stage is one where the script provably never ran — and
-/// that is the only thing that lets `arm` tell "could not run it" apart
-/// from "ran, and may have written something".
 fn resolve_script<'a>(
     scope: &'a crate::model::Scope,
     root: &std::path::Path,
@@ -123,22 +118,13 @@ pub fn arm(
         });
     };
     let (repo, program, argv) = resolve_script(scope, &declared.root, installer)?;
-    // Past this line the installer has been handed to the operating system,
-    // so every failure is one where it may already have written something —
-    // a kill, a timeout, an exec that failed for a reason nobody can see
-    // from here. That reads like a nonzero exit, not like "could not run".
-    let report = launch_script(repo, &program, argv).map_err(|error| ArmError::Unfinished {
-        name: declared.name.clone(),
-        installer: installer.clone(),
-        undo: declared.undo(),
-        error: Box::new(error),
-    })?;
+    let report = launch_script(repo, &program, argv)?;
     if report.code != 0 {
         return Err(ArmError::Failed {
             name: declared.name.clone(),
             installer: installer.clone(),
             code: report.code,
-            undo: declared.undo(),
+            undo: declared.undo(repo),
             report: Box::new(report),
         });
     }
@@ -165,22 +151,8 @@ pub enum ArmError {
         undo: Option<String>,
         report: Box<crate::guard::GuardReport>,
     },
-    /// The installer was handed to the operating system and no exit status
-    /// came back — a timeout, a kill, an exec that failed after the fork.
-    /// Whether it wrote anything is unknowable from here, so this says what
-    /// `Failed` says: what it wrote is still there, and here is the undo.
-    Unfinished {
-        name: String,
-        installer: String,
-        undo: Option<String>,
-        /// Boxed for the same reason as `Run`.
-        error: Box<crate::error::CoreError>,
-    },
-    /// The installer could not be run at all: the scope is not a project,
-    /// or the program does not resolve inside the package. Every one of
-    /// those is settled before anything is launched, so nothing ran and
-    /// nothing was written. Boxed: the error is a rare path and the common
-    /// `Ok` should not pay for its size.
+    /// The installer could not be run at all. Boxed: the error is a rare
+    /// path and the common `Ok` should not pay for its size.
     Run(Box<crate::error::CoreError>),
 }
 
@@ -200,22 +172,16 @@ impl std::fmt::Display for ArmError {
                 undo,
                 ..
             } => {
-                write!(f, "{}: {} exited {code}", shown(name), shown(installer))?;
-                aftermath(f, undo.as_deref())
-            }
-            ArmError::Unfinished {
-                name,
-                installer,
-                undo,
-                error,
-            } => {
                 write!(
                     f,
-                    "{}: {} did not finish ({error})",
+                    "{}: {} exited {code} — anything it wrote before that is still there; ",
                     shown(name),
                     shown(installer)
                 )?;
-                aftermath(f, undo.as_deref())
+                match undo {
+                    Some(undo) => write!(f, "to undo: {}", shown(undo)),
+                    None => write!(f, "the package declares no way to undo it"),
+                }
             }
             ArmError::Run(error) => write!(f, "{error}"),
         }
@@ -223,17 +189,6 @@ impl std::fmt::Display for ArmError {
 }
 
 impl std::error::Error for ArmError {}
-
-/// The tail every outcome that may have written something carries: nothing
-/// was rolled back, and what the package itself says undoes it.
-fn aftermath(f: &mut std::fmt::Formatter<'_>, undo: Option<&str>) -> std::fmt::Result {
-    use crate::names::shown;
-    write!(f, " — anything it wrote before that is still there; ")?;
-    match undo {
-        Some(undo) => write!(f, "to undo: {}", shown(undo)),
-        None => write!(f, "the package declares no way to undo it"),
-    }
-}
 
 impl From<crate::error::CoreError> for ArmError {
     fn from(error: crate::error::CoreError) -> Self {
@@ -245,19 +200,39 @@ impl DeclaredEffects {
     /// What the package says undoes its effect: the uninstaller it declared
     /// where there is one, else its removal text, else nothing.
     ///
-    /// The uninstaller is resolved under the package the way `arm` resolves
-    /// the installer, because a declared script is package-relative and this
-    /// line sends a person to the repository root, where that relative path
-    /// names nothing. Only the program is resolved; the declared arguments
-    /// go out as the package wrote them, and the cwd the line asks for is
-    /// still the one kendex would have run it in.
-    fn undo(&self) -> Option<String> {
+    /// The uninstaller is a package-relative script and this line sends a
+    /// person to `repo` to run it, where that relative path names nothing.
+    /// So the declared program is joined onto the package directory and
+    /// written relative to `repo`, which is where the sentence already tells
+    /// them to stand — the spelling a project install always has, since the
+    /// package sits under the project. A program somewhere else is written
+    /// whole.
+    ///
+    /// The join is all of it. Whether that path exists and stays inside the
+    /// package is `arm`'s question, settled in `resolve_script` for the
+    /// program it is about to run; this one is a line to read.
+    ///
+    /// Either spelling is quoted where it carries whitespace: this is a
+    /// command to paste, and a checkout at `~/My Project` would otherwise
+    /// name a program ending at `My` with an argument after it. Only the
+    /// program; the declared arguments go out as the package wrote them.
+    fn undo(&self, repo: &std::path::Path) -> Option<String> {
         self.effects
             .uninstaller
             .as_ref()
             .map(|script| {
                 let (program, args) = split_script(script);
-                let command = std::iter::once(self.root.join(program).display().to_string())
+                let whole = self.root.join(program);
+                let path = whole
+                    .strip_prefix(repo)
+                    .unwrap_or(whole.as_path())
+                    .display()
+                    .to_string();
+                let quoted = match path.contains(char::is_whitespace) {
+                    true => format!("'{path}'"),
+                    false => path,
+                };
+                let command = std::iter::once(quoted)
                     .chain(args.into_iter().map(str::to_owned))
                     .collect::<Vec<_>>()
                     .join(" ");

--- a/crates/core/src/repo_effects.rs
+++ b/crates/core/src/repo_effects.rs
@@ -26,7 +26,9 @@ mod declaration;
 pub mod disclosure;
 use declaration::split_script;
 pub use declaration::{RepoEffects, declared};
-pub use disclosure::{Companion, Disclosure, Offers, Withheld, Written, installed_skills, offers};
+pub use disclosure::{
+    Companion, Disclosure, Offers, Withheld, Written, installed_skills, offers, offers_for,
+};
 
 use serde::{Deserialize, Serialize};
 use specta::Type;
@@ -85,6 +87,113 @@ fn err(message: impl Into<String>) -> crate::error::CoreError {
         message: message.into(),
     }
 }
+
+/// Run one package's declared installer, here and now, and judge its exit.
+///
+/// The run is the whole of it: what it wrote is on disk for anyone to look
+/// at, and nothing kendex stores decides what a later run does. Every
+/// surface that has a yes calls this, so a package with nothing to run and
+/// an installer that failed read the same on each of them.
+pub fn arm(
+    scope: &crate::model::Scope,
+    declared: &DeclaredEffects,
+) -> std::result::Result<crate::guard::GuardReport, ArmError> {
+    let Some(installer) = &declared.effects.installer else {
+        return Err(ArmError::NothingToRun {
+            name: declared.name.clone(),
+        });
+    };
+    let report = run_script(scope, &declared.root, installer)?;
+    if report.code != 0 {
+        return Err(ArmError::Failed {
+            name: declared.name.clone(),
+            installer: installer.clone(),
+            code: report.code,
+            undo: declared.effects.undo(),
+            report: Box::new(report),
+        });
+    }
+    Ok(report)
+}
+
+/// Why a yes did not arm the repository.
+#[derive(Debug)]
+pub enum ArmError {
+    /// The package declared no installer: the disclosure ends with what the
+    /// reader runs themselves, and kendex has nothing to launch.
+    NothingToRun { name: String },
+    /// The installer ran and exited nonzero. kendex takes no pre-image and
+    /// rolls nothing back, so an installer that wrote three files and
+    /// failed on the fourth leaves three files, and a message promising
+    /// otherwise is the one thing that would stop somebody looking. The
+    /// package's own lines are carried so a surface can show them.
+    Failed {
+        name: String,
+        installer: String,
+        code: u8,
+        /// How the package says to undo it, or nothing where it said
+        /// nothing — never a claim the package did not make.
+        undo: Option<String>,
+        report: Box<crate::guard::GuardReport>,
+    },
+    /// The installer could not be run at all. Boxed: the error is a rare
+    /// path and the common `Ok` should not pay for its size.
+    Run(Box<crate::error::CoreError>),
+}
+
+impl std::fmt::Display for ArmError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        use crate::names::shown;
+        match self {
+            ArmError::NothingToRun { name } => write!(
+                f,
+                "{}: no installer to run — arm it yourself when you are ready",
+                shown(name)
+            ),
+            ArmError::Failed {
+                name,
+                installer,
+                code,
+                undo,
+                ..
+            } => {
+                write!(
+                    f,
+                    "{}: {} exited {code} — anything it wrote before that is still there; ",
+                    shown(name),
+                    shown(installer)
+                )?;
+                match undo {
+                    Some(undo) => write!(f, "to undo: {}", shown(undo)),
+                    None => write!(f, "the package declares no way to undo it"),
+                }
+            }
+            ArmError::Run(error) => write!(f, "{error}"),
+        }
+    }
+}
+
+impl std::error::Error for ArmError {}
+
+impl From<crate::error::CoreError> for ArmError {
+    fn from(error: crate::error::CoreError) -> Self {
+        ArmError::Run(Box::new(error))
+    }
+}
+
+impl RepoEffects {
+    /// What the package says undoes its effect: the uninstaller it declared
+    /// where there is one, else its removal text, else nothing.
+    pub fn undo(&self) -> Option<String> {
+        self.uninstaller
+            .as_ref()
+            .map(|script| format!("run `{script}` from the repository root"))
+            .or_else(|| self.removal.clone())
+    }
+}
+
+#[cfg(test)]
+mod tests;
 
 /// One package's declaration, with the package it came from — what a plan
 /// carries out to the surfaces that disclose it.

--- a/crates/core/src/repo_effects/declaration.rs
+++ b/crates/core/src/repo_effects/declaration.rs
@@ -19,12 +19,10 @@ pub struct RepoEffects {
     /// One line: what installing this changes about the repository.
     pub summary: String,
     /// Repo-relative paths the package writes outside the managed trees.
-    #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub writes: Vec<String>,
     /// The script, relative to the package directory, that applies the
     /// effect. Absent means kendex has nothing to run and the disclosure
     /// ends with what the reader should run themselves.
-    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub installer: Option<String>,
     /// The script that undoes the effect.
     ///
@@ -32,21 +30,17 @@ pub struct RepoEffects {
     /// takes the package's files away with the effect still applied. The
     /// disclosure names it so a person can run it themselves, which is the
     /// whole of what it does today. KEN-674 carries wiring it into removal.
-    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub uninstaller: Option<String>,
     /// How to undo the effect by hand, for the disclosure's last line.
-    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub removal: Option<String>,
     /// Lines the package wants read before anyone says yes — what its
     /// effect actually does, in its own words. The package writes these
     /// because only it knows them; kendex supplies the parts it owns, the
     /// paths and the authorization and the removal command.
-    #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub notes: Vec<String>,
     /// Packages whose presence changes what this one does. Whether each is
     /// installed here is a fact about this repository rather than about the
     /// package, so the declaration names them and kendex answers.
-    #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub companions: Vec<String>,
 }
 

--- a/crates/core/src/repo_effects/disclosure.rs
+++ b/crates/core/src/repo_effects/disclosure.rs
@@ -6,6 +6,14 @@
 //! here. Those facts are settled once, here, and every surface that asks
 //! for a yes — the terminal, the app — shows the same answer.
 //!
+//! Settled as what goes on the screen, too. Every value a package chose is
+//! catalog text read immediately before a consent prompt: a summary
+//! carrying an escape sequence repaints the terminal lines above it, and a
+//! path carrying a direction-flipping character reads as a different file
+//! from the one being authorized in the app. So the display fields here
+//! have been through `names::shown` once, and a surface prints them as
+//! they are. The raw declaration rides beside them for the yes to run.
+//!
 //! Nothing here explains what a declaration MEANS. That is the package's
 //! contract, and kendex is not a party to it.
 
@@ -16,7 +24,8 @@ use serde::{Deserialize, Serialize};
 use specta::Type;
 
 use crate::env::Env;
-use crate::model::{ItemKind, Scope};
+use crate::model::Scope;
+use crate::names::shown;
 
 use super::{DeclaredEffects, RepoEffects};
 
@@ -25,7 +34,7 @@ use super::{DeclaredEffects, RepoEffects};
 #[serde(rename_all = "camelCase")]
 pub struct Written {
     /// Absolute, because the whole value of the line is that a reader can
-    /// go and look.
+    /// go and look. Display text: shown once, printed as it is.
     pub path: String,
     /// Inside the repository's common git directory, which every work tree
     /// of the repository shares — so this file is the repository's, not
@@ -38,24 +47,34 @@ pub struct Written {
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize, Type)]
 #[serde(rename_all = "camelCase")]
 pub struct Companion {
+    /// Display text: shown once, printed as it is.
     pub name: String,
     pub installed: bool,
 }
 
 /// What a person reads before saying yes to one package's effect, and the
 /// declaration that yes runs.
+///
+/// The display fields are the declaration's own words as they go on the
+/// screen; `declared` is the same words untouched, for the command that
+/// runs the effect. A surface reads the former and hands back the latter.
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize, Type)]
 #[serde(rename_all = "camelCase")]
 pub struct Disclosure {
     pub declared: DeclaredEffects,
+    pub name: String,
+    pub summary: String,
     pub writes: Vec<Written>,
     pub companions: Vec<Companion>,
+    pub notes: Vec<String>,
+    pub removal: Option<String>,
 }
 
 /// An effect that was neither shown nor offered, and why.
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize, Type)]
 #[serde(rename_all = "camelCase")]
 pub struct Withheld {
+    /// Display text: shown once, printed as it is.
     pub name: String,
     pub reason: String,
 }
@@ -75,58 +94,74 @@ impl Offers {
     }
 }
 
+/// The offers an applied plan's effects earn, against the scope as it
+/// stands now — read after the write, so a companion that landed in the
+/// same plan counts as installed. What every surface calls.
+pub fn offers_for(
+    env: &Env,
+    scope: &Scope,
+    effects: &[DeclaredEffects],
+) -> crate::error::Result<Offers> {
+    if effects.is_empty() {
+        return Ok(Offers::default());
+    }
+    let installed = installed_skills(env, scope)?;
+    Ok(offers(scope, effects, &installed))
+}
+
 /// The offers a plan's effects earn in this scope.
 ///
 /// Empty outside a project. A repository effect is a change to a
 /// repository, and the global scope is not one: `run_script` refuses it, so
 /// an effect offered there is a question whose yes cannot be honoured.
 ///
-/// `installed` names the skills the scope carries now — read after the
-/// plan is applied, so a companion that arrived in the same plan counts.
+/// `installed` names the skills the scope carries now.
 pub fn offers(scope: &Scope, effects: &[DeclaredEffects], installed: &BTreeSet<String>) -> Offers {
     let Scope::Project { root } = scope else {
         return Offers::default();
     };
-    // Where `.git/...` actually is, or nothing at all.
+    // Where `.git/...` actually is, or why that cannot be said.
     //
     // Guessing `<root>/.git` was wrong in the case the guess exists for: a
     // linked worktree or a `--separate-git-dir` layout puts the hooks
     // somewhere else, and a repository whose common dir cannot be resolved
     // is exactly the one whose layout kendex has not understood. A block
     // naming a path that does not exist, immediately before asking somebody
-    // to authorize writing to it, is worse than no block.
-    let git_dir = crate::guard::Repo::at(root)
-        .ok()
-        .map(|repo| repo.common_dir);
+    // to authorize writing to it, is worse than no block. The error is
+    // kept whole: not inside a repository, a bare one, and git failing to
+    // run each want a different remedy.
+    let git_dir = crate::guard::Repo::at(root).map(|repo| repo.common_dir);
     let mut offers = Offers::default();
     for declared in effects {
         // An effect that writes into `.git` is not disclosed where the
         // repository could not be read: nothing here can say where those
         // files land. One that writes nowhere near it is unaffected.
-        if git_dir.is_none() && touches_git(&declared.effects) {
+        if let Err(error) = &git_dir
+            && touches_git(&declared.effects)
+        {
             offers.withheld.push(Withheld {
-                name: declared.name.clone(),
-                reason: "this repository's git directory could not be resolved, so where \
-                         it writes cannot be named; nothing was offered or run"
-                    .to_owned(),
+                name: shown(&declared.name),
+                reason: format!(
+                    "this repository's git directory could not be resolved, so where \
+                     it writes cannot be named; nothing was offered or run ({error})"
+                ),
             });
             continue;
         }
+        let git_dir = git_dir.as_deref().ok();
         let writes = declared
             .effects
             .writes
             .iter()
             .map(|path| {
-                let target = lands_at(root, git_dir.as_deref(), path);
+                let target = lands_at(root, git_dir, path);
                 Written {
                     // By path components, not by text. A string prefix
                     // reads `<root>/.github/config` as sitting under
                     // `<root>/.git`, and this flag is a claim about who
                     // else sees the file.
-                    shared: git_dir
-                        .as_deref()
-                        .is_some_and(|dir| target.starts_with(dir)),
-                    path: target.display().to_string(),
+                    shared: git_dir.is_some_and(|dir| target.starts_with(dir)),
+                    path: shown(&target.display().to_string()),
                 }
             })
             .collect();
@@ -136,10 +171,14 @@ pub fn offers(scope: &Scope, effects: &[DeclaredEffects], installed: &BTreeSet<S
             .iter()
             .map(|name| Companion {
                 installed: installed.contains(name),
-                name: name.clone(),
+                name: shown(name),
             })
             .collect();
         offers.shown.push(Disclosure {
+            name: shown(&declared.name),
+            summary: shown(&declared.effects.summary),
+            notes: declared.effects.notes.iter().map(|n| shown(n)).collect(),
+            removal: declared.effects.removal.as_deref().map(shown),
             declared: declared.clone(),
             writes,
             companions,
@@ -149,16 +188,10 @@ pub fn offers(scope: &Scope, effects: &[DeclaredEffects], installed: &BTreeSet<S
 }
 
 /// The skills a scope carries, by name — what `offers` answers companion
-/// presence from. Read off the lock, which is per installation: a skill
-/// fanned out to three tools is one name here.
+/// presence from.
 pub fn installed_skills(env: &Env, scope: &Scope) -> crate::error::Result<BTreeSet<String>> {
     let lock = crate::lock::load(&crate::lock::lock_path(env, scope))?;
-    Ok(lock
-        .entries
-        .into_values()
-        .filter(|entry| entry.kind == ItemKind::Skill)
-        .map(|entry| entry.name)
-        .collect())
+    Ok(crate::lock::skill_names(&lock))
 }
 
 /// A declared target, as the absolute path it really lands at.

--- a/crates/core/src/repo_effects/disclosure.rs
+++ b/crates/core/src/repo_effects/disclosure.rs
@@ -18,7 +18,7 @@
 //! contract, and kendex is not a party to it.
 
 use std::collections::BTreeSet;
-use std::path::{Path, PathBuf};
+use std::path::{Component, Path, PathBuf};
 
 use serde::{Deserialize, Serialize};
 use specta::Type;
@@ -204,7 +204,11 @@ pub fn installed_skills(env: &Env, scope: &Scope) -> crate::error::Result<BTreeS
 /// is under the project.
 fn lands_at(root: &Path, git_dir: Option<&Path>, declared: &str) -> PathBuf {
     match (under_git(declared), git_dir) {
-        (Some(rest), Some(dir)) => dir.join(rest),
+        (Some(rest), Some(dir)) => match rest.as_os_str().is_empty() {
+            // The git directory itself, named on its own.
+            true => dir.to_path_buf(),
+            false => dir.join(rest),
+        },
         // Unreachable while a package with any `.git` target is withheld
         // above; a path is still the honest answer if that ever changes.
         (Some(_), None) | (None, _) => root.join(declared),
@@ -212,10 +216,25 @@ fn lands_at(root: &Path, git_dir: Option<&Path>, declared: &str) -> PathBuf {
 }
 
 /// The part of a declared path that sits under the git directory.
-fn under_git(declared: &str) -> Option<&str> {
-    declared
-        .strip_prefix(".git/")
-        .or_else(|| declared.strip_prefix("./.git/"))
+///
+/// Read as components, not as a text prefix. `writes` accepts a path
+/// spelled `.git//hooks/pre-commit` or `.git/./hooks/pre-commit` — a
+/// doubled separator and a `.` are both ordinary in a path somebody typed —
+/// and stripping the text `.git/` off those left a remainder beginning with
+/// `/`, which `lands_at` joined as an absolute path. The file was then
+/// disclosed as this checkout's when it is the whole repository's, on the
+/// one screen where that distinction is what is being authorized. `.git`
+/// alone matched nothing and landed under the project.
+fn under_git(declared: &str) -> Option<PathBuf> {
+    let mut components = Path::new(declared)
+        .components()
+        .filter(|component| !matches!(component, Component::CurDir));
+    match components.next() {
+        Some(Component::Normal(first)) if first == std::ffi::OsStr::new(".git") => {
+            Some(components.collect())
+        }
+        _ => None,
+    }
 }
 
 /// Whether anything this package declares lands in the git directory.

--- a/crates/core/src/repo_effects/disclosure.rs
+++ b/crates/core/src/repo_effects/disclosure.rs
@@ -67,7 +67,11 @@ pub struct Disclosure {
     pub writes: Vec<Written>,
     pub companions: Vec<Companion>,
     pub notes: Vec<String>,
-    pub removal: Option<String>,
+    /// How the package says to undo the effect: the uninstaller it declared
+    /// where there is one, else its removal text, else nothing. The same
+    /// answer the failure message gives, so a person who reads the block
+    /// and a person whose installer failed are told the same command.
+    pub undo: Option<String>,
 }
 
 /// An effect that was neither shown nor offered, and why.
@@ -178,7 +182,7 @@ pub fn offers(scope: &Scope, effects: &[DeclaredEffects], installed: &BTreeSet<S
             name: shown(&declared.name),
             summary: shown(&declared.effects.summary),
             notes: declared.effects.notes.iter().map(|n| shown(n)).collect(),
-            removal: declared.effects.removal.as_deref().map(shown),
+            undo: declared.undo(root).as_deref().map(shown),
             declared: declared.clone(),
             writes,
             companions,

--- a/crates/core/src/repo_effects/disclosure.rs
+++ b/crates/core/src/repo_effects/disclosure.rs
@@ -1,0 +1,190 @@
+//! A declaration mapped onto the repository it is about to change.
+//!
+//! The block a person reads is the package's own words plus facts only
+//! kendex knows about this machine: where a declared path really lands,
+//! whether every work tree shares it, and which companions are installed
+//! here. Those facts are settled once, here, and every surface that asks
+//! for a yes — the terminal, the app — shows the same answer.
+//!
+//! Nothing here explains what a declaration MEANS. That is the package's
+//! contract, and kendex is not a party to it.
+
+use std::collections::BTreeSet;
+use std::path::{Path, PathBuf};
+
+use serde::{Deserialize, Serialize};
+use specta::Type;
+
+use crate::env::Env;
+use crate::model::{ItemKind, Scope};
+
+use super::{DeclaredEffects, RepoEffects};
+
+/// One path the package writes, where it actually lands.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, Type)]
+#[serde(rename_all = "camelCase")]
+pub struct Written {
+    /// Absolute, because the whole value of the line is that a reader can
+    /// go and look.
+    pub path: String,
+    /// Inside the repository's common git directory, which every work tree
+    /// of the repository shares — so this file is the repository's, not
+    /// this checkout's.
+    pub shared: bool,
+}
+
+/// A package whose presence changes what this one does, and whether it is
+/// installed in this scope.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, Type)]
+#[serde(rename_all = "camelCase")]
+pub struct Companion {
+    pub name: String,
+    pub installed: bool,
+}
+
+/// What a person reads before saying yes to one package's effect, and the
+/// declaration that yes runs.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, Type)]
+#[serde(rename_all = "camelCase")]
+pub struct Disclosure {
+    pub declared: DeclaredEffects,
+    pub writes: Vec<Written>,
+    pub companions: Vec<Companion>,
+}
+
+/// An effect that was neither shown nor offered, and why.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, Type)]
+#[serde(rename_all = "camelCase")]
+pub struct Withheld {
+    pub name: String,
+    pub reason: String,
+}
+
+/// Everything a run has to say about repository effects: the blocks to
+/// read and ask about, and the packages it could not account for.
+#[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize, Type)]
+#[serde(rename_all = "camelCase")]
+pub struct Offers {
+    pub shown: Vec<Disclosure>,
+    pub withheld: Vec<Withheld>,
+}
+
+impl Offers {
+    pub fn is_empty(&self) -> bool {
+        self.shown.is_empty() && self.withheld.is_empty()
+    }
+}
+
+/// The offers a plan's effects earn in this scope.
+///
+/// Empty outside a project. A repository effect is a change to a
+/// repository, and the global scope is not one: `run_script` refuses it, so
+/// an effect offered there is a question whose yes cannot be honoured.
+///
+/// `installed` names the skills the scope carries now — read after the
+/// plan is applied, so a companion that arrived in the same plan counts.
+pub fn offers(scope: &Scope, effects: &[DeclaredEffects], installed: &BTreeSet<String>) -> Offers {
+    let Scope::Project { root } = scope else {
+        return Offers::default();
+    };
+    // Where `.git/...` actually is, or nothing at all.
+    //
+    // Guessing `<root>/.git` was wrong in the case the guess exists for: a
+    // linked worktree or a `--separate-git-dir` layout puts the hooks
+    // somewhere else, and a repository whose common dir cannot be resolved
+    // is exactly the one whose layout kendex has not understood. A block
+    // naming a path that does not exist, immediately before asking somebody
+    // to authorize writing to it, is worse than no block.
+    let git_dir = crate::guard::Repo::at(root)
+        .ok()
+        .map(|repo| repo.common_dir);
+    let mut offers = Offers::default();
+    for declared in effects {
+        // An effect that writes into `.git` is not disclosed where the
+        // repository could not be read: nothing here can say where those
+        // files land. One that writes nowhere near it is unaffected.
+        if git_dir.is_none() && touches_git(&declared.effects) {
+            offers.withheld.push(Withheld {
+                name: declared.name.clone(),
+                reason: "this repository's git directory could not be resolved, so where \
+                         it writes cannot be named; nothing was offered or run"
+                    .to_owned(),
+            });
+            continue;
+        }
+        let writes = declared
+            .effects
+            .writes
+            .iter()
+            .map(|path| {
+                let target = lands_at(root, git_dir.as_deref(), path);
+                Written {
+                    // By path components, not by text. A string prefix
+                    // reads `<root>/.github/config` as sitting under
+                    // `<root>/.git`, and this flag is a claim about who
+                    // else sees the file.
+                    shared: git_dir
+                        .as_deref()
+                        .is_some_and(|dir| target.starts_with(dir)),
+                    path: target.display().to_string(),
+                }
+            })
+            .collect();
+        let companions = declared
+            .effects
+            .companions
+            .iter()
+            .map(|name| Companion {
+                installed: installed.contains(name),
+                name: name.clone(),
+            })
+            .collect();
+        offers.shown.push(Disclosure {
+            declared: declared.clone(),
+            writes,
+            companions,
+        });
+    }
+    offers
+}
+
+/// The skills a scope carries, by name — what `offers` answers companion
+/// presence from. Read off the lock, which is per installation: a skill
+/// fanned out to three tools is one name here.
+pub fn installed_skills(env: &Env, scope: &Scope) -> crate::error::Result<BTreeSet<String>> {
+    let lock = crate::lock::load(&crate::lock::lock_path(env, scope))?;
+    Ok(lock
+        .entries
+        .into_values()
+        .filter(|entry| entry.kind == ItemKind::Skill)
+        .map(|entry| entry.name)
+        .collect())
+}
+
+/// A declared target, as the absolute path it really lands at.
+///
+/// `.git/...` goes to the repository's common git directory; everything else
+/// is under the project.
+fn lands_at(root: &Path, git_dir: Option<&Path>, declared: &str) -> PathBuf {
+    match (under_git(declared), git_dir) {
+        (Some(rest), Some(dir)) => dir.join(rest),
+        // Unreachable while a package with any `.git` target is withheld
+        // above; a path is still the honest answer if that ever changes.
+        (Some(_), None) | (None, _) => root.join(declared),
+    }
+}
+
+/// The part of a declared path that sits under the git directory.
+fn under_git(declared: &str) -> Option<&str> {
+    declared
+        .strip_prefix(".git/")
+        .or_else(|| declared.strip_prefix("./.git/"))
+}
+
+/// Whether anything this package declares lands in the git directory.
+fn touches_git(effects: &RepoEffects) -> bool {
+    effects.writes.iter().any(|path| under_git(path).is_some())
+}
+
+#[cfg(test)]
+mod tests;

--- a/crates/core/src/repo_effects/disclosure.rs
+++ b/crates/core/src/repo_effects/disclosure.rs
@@ -112,7 +112,7 @@ pub fn offers_for(
 /// The offers a plan's effects earn in this scope.
 ///
 /// Empty outside a project. A repository effect is a change to a
-/// repository, and the global scope is not one: `run_script` refuses it, so
+/// repository, and the global scope is not one: `arm` refuses it, so
 /// an effect offered there is a question whose yes cannot be honoured.
 ///
 /// `installed` names the skills the scope carries now.

--- a/crates/core/src/repo_effects/disclosure/tests.rs
+++ b/crates/core/src/repo_effects/disclosure/tests.rs
@@ -92,6 +92,38 @@ fn git_paths_land_in_the_common_dir_and_read_as_shared() {
     assert!(!workflow.shared, "{workflow:?}");
 }
 
+/// The block names the command that undoes the effect, not only the prose
+/// a package may have written about it. A package declaring an uninstaller
+/// and no removal text used to read as declaring no way to undo it.
+#[test]
+fn a_declared_uninstaller_is_what_the_block_says_to_run() {
+    let root = PathBuf::from("/repo");
+    let mut effects = declared(&[], &[]);
+    effects.root = root.join(".agents/skills/guards");
+    effects.effects.uninstaller = Some("scripts/arm --off".to_owned());
+
+    let undo = |declared: DeclaredEffects| {
+        offers(&project(&root), &[declared], &BTreeSet::new()).shown[0]
+            .undo
+            .clone()
+    };
+    assert_eq!(
+        undo(effects.clone()).as_deref(),
+        Some("run `'.agents/skills/guards/scripts/arm' '--off'` from the repository root")
+    );
+
+    // No uninstaller: the package's own removal text, as before.
+    let mut prose = effects.clone();
+    prose.effects.uninstaller = None;
+    prose.effects.removal = Some("delete the hooks by hand".to_owned());
+    assert_eq!(undo(prose).as_deref(), Some("delete the hooks by hand"));
+
+    // Neither: no claim is invented for the package.
+    let mut silent = effects;
+    silent.effects.uninstaller = None;
+    assert_eq!(undo(silent), None);
+}
+
 /// Where the repository cannot be read, a package that writes into `.git`
 /// is withheld — a block naming a path that does not exist is worse than
 /// none — while one that writes nowhere near it is still shown.

--- a/crates/core/src/repo_effects/disclosure/tests.rs
+++ b/crates/core/src/repo_effects/disclosure/tests.rs
@@ -92,6 +92,56 @@ fn git_paths_land_in_the_common_dir_and_read_as_shared() {
     assert!(!workflow.shared, "{workflow:?}");
 }
 
+/// A `.git` path spelled the ways a person spells paths still lands in the
+/// git directory. A doubled separator, a `.` hop, and the directory named
+/// on its own all used to read as the checkout's own files.
+#[test]
+#[allow(clippy::unwrap_used)]
+fn a_git_path_is_read_by_components_not_by_prefix() {
+    let tmp = tempfile::tempdir().unwrap();
+    let repo = tmp.path().canonicalize().unwrap().join("repo");
+    fs::create_dir_all(&repo).unwrap();
+    git(&repo, &["init", "--quiet", "-b", "main"]);
+    let common = crate::guard::Repo::at(&repo).unwrap().common_dir;
+
+    let spellings = [
+        ".git//hooks/pre-commit",
+        ".git/./hooks/pre-commit",
+        "./.git/hooks/pre-commit",
+    ];
+    for spelling in spellings {
+        let offers = offers(
+            &project(&repo),
+            &[declared(&[spelling], &[])],
+            &BTreeSet::new(),
+        );
+        let [disclosure] = offers.shown.as_slice() else {
+            panic!("{spelling}: one disclosure: {offers:?}");
+        };
+        let [written] = disclosure.writes.as_slice() else {
+            panic!("{spelling}: one path: {disclosure:?}");
+        };
+        assert_eq!(
+            written.path,
+            common.join("hooks/pre-commit").display().to_string(),
+            "{spelling}"
+        );
+        assert!(written.shared, "{spelling}: {written:?}");
+    }
+
+    // The git directory named on its own, with nothing under it.
+    let offers = offers(
+        &project(&repo),
+        &[declared(&[".git"], &[])],
+        &BTreeSet::new(),
+    );
+    let [written] = offers.shown[0].writes.as_slice() else {
+        panic!("one path: {offers:?}");
+    };
+    assert_eq!(written.path, common.display().to_string());
+    assert!(written.shared, "{written:?}");
+}
+
 /// The block names the command that undoes the effect, not only the prose
 /// a package may have written about it. A package declaring an uninstaller
 /// and no removal text used to read as declaring no way to undo it.

--- a/crates/core/src/repo_effects/disclosure/tests.rs
+++ b/crates/core/src/repo_effects/disclosure/tests.rs
@@ -73,11 +73,11 @@ fn git_paths_land_in_the_common_dir_and_read_as_shared() {
         &BTreeSet::new(),
     );
     assert!(offers.withheld.is_empty(), "{offers:?}");
-    let [shown] = offers.shown.as_slice() else {
+    let [disclosure] = offers.shown.as_slice() else {
         panic!("one disclosure: {offers:?}");
     };
-    let [hook, workflow] = shown.writes.as_slice() else {
-        panic!("two paths: {shown:?}");
+    let [hook, workflow] = disclosure.writes.as_slice() else {
+        panic!("two paths: {disclosure:?}");
     };
     assert_eq!(
         hook.path,
@@ -114,6 +114,15 @@ fn without_a_repository_only_git_writers_are_withheld() {
     );
     assert_eq!(offers.withheld.len(), 1, "{offers:?}");
     assert_eq!(offers.withheld[0].name, "guards");
+    // The reason carries git's own answer: not being in a repository wants
+    // a different remedy from a bare one or a git that could not run.
+    assert!(
+        offers.withheld[0]
+            .reason
+            .contains("not inside a git repository"),
+        "{}",
+        offers.withheld[0].reason
+    );
     assert_eq!(offers.shown.len(), 1, "{offers:?}");
     assert_eq!(offers.shown[0].declared.name, "linter");
     assert!(!offers.shown[0].writes[0].shared);
@@ -132,6 +141,8 @@ fn nothing_is_offered_outside_a_project() {
 
 /// Companion presence is answered from what the scope carries, in the
 /// order the package named them.
+/// Every value the package chose reaches the screen through `shown`: a
+/// direction-flipping character in a name is printed as its escape.
 #[test]
 #[allow(clippy::unwrap_used)]
 fn companions_are_answered_from_the_installed_set() {
@@ -156,4 +167,18 @@ fn companions_are_answered_from_the_installed_set() {
             },
         ]
     );
+
+    let mut forged = declared(&["tools/\u{202e}tnil"], &["pre\u{200b}flight"]);
+    forged.effects.summary = "arms\u{1b}[2Jhooks".to_owned();
+    let escaped = super::offers(&project(tmp.path()), &[forged], &installed);
+    let block = &escaped.shown[0];
+    assert!(
+        block.writes[0].path.ends_with("tools/\\u{202e}tnil"),
+        "{}",
+        block.writes[0].path
+    );
+    assert_eq!(block.companions[0].name, "pre\\u{200b}flight");
+    assert_eq!(block.summary, "arms\\u{1b}[2Jhooks");
+    // And the raw declaration is untouched, for the yes to run.
+    assert_eq!(block.declared.effects.summary, "arms\u{1b}[2Jhooks");
 }

--- a/crates/core/src/repo_effects/disclosure/tests.rs
+++ b/crates/core/src/repo_effects/disclosure/tests.rs
@@ -1,0 +1,159 @@
+//! The facts kendex adds to a declaration are about this repository, and
+//! every one of them has to be true of the repository as it is laid out.
+
+use std::collections::BTreeSet;
+use std::fs;
+use std::path::Path;
+
+use super::*;
+use crate::process::Hardened;
+
+#[allow(clippy::unwrap_used)]
+fn git(dir: &Path, args: &[&str]) {
+    let output = Hardened::git(args, Some(dir)).run().unwrap();
+    assert!(output.status.success(), "git {args:?}");
+}
+
+fn declared(writes: &[&str], companions: &[&str]) -> DeclaredEffects {
+    DeclaredEffects {
+        name: "guards".to_owned(),
+        root: PathBuf::from("/pkg/guards"),
+        effects: RepoEffects {
+            summary: "arms hooks".to_owned(),
+            writes: writes.iter().map(|s| (*s).to_owned()).collect(),
+            installer: Some("scripts/arm".to_owned()),
+            uninstaller: None,
+            removal: None,
+            notes: Vec::new(),
+            companions: companions.iter().map(|s| (*s).to_owned()).collect(),
+        },
+    }
+}
+
+fn project(root: &Path) -> Scope {
+    Scope::Project {
+        root: root.to_path_buf(),
+    }
+}
+
+/// A declared `.git/...` path is named where git keeps it — in a linked
+/// worktree that is the main checkout's directory, not this one's — and
+/// flagged as shared; a path under the project is neither.
+#[test]
+#[allow(clippy::unwrap_used)]
+fn git_paths_land_in_the_common_dir_and_read_as_shared() {
+    let tmp = tempfile::tempdir().unwrap();
+    let main = tmp.path().canonicalize().unwrap().join("main");
+    fs::create_dir_all(&main).unwrap();
+    git(&main, &["init", "--quiet", "-b", "main"]);
+    fs::write(main.join("README"), "x").unwrap();
+    git(&main, &["add", "-A"]);
+    git(
+        &main,
+        &[
+            "-c",
+            "user.email=t@t",
+            "-c",
+            "user.name=t",
+            "commit",
+            "-q",
+            "-m",
+            "one",
+        ],
+    );
+    let linked = tmp.path().canonicalize().unwrap().join("linked");
+    git(
+        &main,
+        &["worktree", "add", "--quiet", linked.to_str().unwrap()],
+    );
+
+    let offers = offers(
+        &project(&linked),
+        &[declared(&[".git/hooks/pre-commit", ".github/x"], &[])],
+        &BTreeSet::new(),
+    );
+    assert!(offers.withheld.is_empty(), "{offers:?}");
+    let [shown] = offers.shown.as_slice() else {
+        panic!("one disclosure: {offers:?}");
+    };
+    let [hook, workflow] = shown.writes.as_slice() else {
+        panic!("two paths: {shown:?}");
+    };
+    assert_eq!(
+        hook.path,
+        main.join(".git/hooks/pre-commit").display().to_string()
+    );
+    assert!(hook.shared, "{hook:?}");
+    // `.github` shares a prefix with `.git` as text and nothing else.
+    assert_eq!(
+        workflow.path,
+        linked.join(".github/x").display().to_string()
+    );
+    assert!(!workflow.shared, "{workflow:?}");
+}
+
+/// Where the repository cannot be read, a package that writes into `.git`
+/// is withheld — a block naming a path that does not exist is worse than
+/// none — while one that writes nowhere near it is still shown.
+#[test]
+#[allow(clippy::unwrap_used)]
+fn without_a_repository_only_git_writers_are_withheld() {
+    let tmp = tempfile::tempdir().unwrap();
+    let root = tmp.path().join("plain");
+    fs::create_dir_all(&root).unwrap();
+    let offers = offers(
+        &project(&root),
+        &[
+            declared(&[".git/hooks/pre-commit"], &[]),
+            DeclaredEffects {
+                name: "linter".to_owned(),
+                ..declared(&["tools/lint"], &[])
+            },
+        ],
+        &BTreeSet::new(),
+    );
+    assert_eq!(offers.withheld.len(), 1, "{offers:?}");
+    assert_eq!(offers.withheld[0].name, "guards");
+    assert_eq!(offers.shown.len(), 1, "{offers:?}");
+    assert_eq!(offers.shown[0].declared.name, "linter");
+    assert!(!offers.shown[0].writes[0].shared);
+}
+
+/// The global scope is not a repository, so nothing is offered there.
+#[test]
+fn nothing_is_offered_outside_a_project() {
+    let offers = offers(
+        &Scope::Global,
+        &[declared(&["tools/lint"], &[])],
+        &BTreeSet::new(),
+    );
+    assert!(offers.is_empty(), "{offers:?}");
+}
+
+/// Companion presence is answered from what the scope carries, in the
+/// order the package named them.
+#[test]
+#[allow(clippy::unwrap_used)]
+fn companions_are_answered_from_the_installed_set() {
+    let tmp = tempfile::tempdir().unwrap();
+    let installed: BTreeSet<String> = ["preflight".to_owned()].into_iter().collect();
+    let offers = offers(
+        &project(tmp.path()),
+        &[declared(&[], &["size-ratchet", "preflight"])],
+        &installed,
+    );
+    let companions = &offers.shown[0].companions;
+    assert_eq!(
+        companions,
+        &[
+            Companion {
+                name: "size-ratchet".to_owned(),
+                installed: false
+            },
+            Companion {
+                name: "preflight".to_owned(),
+                installed: true
+            },
+        ]
+    );
+}

--- a/crates/core/src/repo_effects/tests.rs
+++ b/crates/core/src/repo_effects/tests.rs
@@ -34,7 +34,7 @@ fn arm_settled(
 ) -> std::result::Result<crate::guard::GuardReport, ArmError> {
     for _ in 0..50 {
         match arm(scope, declared) {
-            Err(error) if error.to_string().contains("Text file busy") => {
+            Err(ArmError::Run(error)) if error.to_string().contains("Text file busy") => {
                 std::thread::sleep(std::time::Duration::from_millis(20));
             }
             outcome => return outcome,
@@ -77,10 +77,12 @@ fn a_package_with_no_installer_has_nothing_to_run() {
 #[allow(clippy::unwrap_used)]
 fn a_failed_installer_reports_the_exit_and_the_declared_undo() {
     let tmp = tempfile::tempdir().unwrap();
-    let repo = tmp.path().join("repo");
+    // A checkout path with a space in it, which is where an absolute
+    // program word would split into a program and an argument.
+    let repo = tmp.path().join("My Project");
+    let root = repo.join(".agents/skills/guards");
     fs::create_dir_all(&repo).unwrap();
     let scope = Scope::Project { root: repo };
-    let root = tmp.path().join("pkg");
     script(&root, "arm", "echo 'could not write hooks' >&2\nexit 1");
 
     let error = arm_settled(&scope, &package(&root, Some("arm"), Some("arm --off"))).unwrap_err();
@@ -90,15 +92,13 @@ fn a_failed_installer_reports_the_exit_and_the_declared_undo() {
     assert_eq!(*code, 1);
     assert_eq!(report.stderr, vec!["could not write hooks".to_owned()]);
     let said = error.to_string();
-    // The uninstaller resolved under the package, not the relative path the
-    // declaration wrote: read from the repository root, that names nothing.
+    // Where the uninstaller really is, spelled from where the sentence
+    // tells the reader to stand — not the relative path the declaration
+    // wrote, which names nothing from the repository root.
     assert_eq!(
         said,
-        format!(
-            "guards: arm exited 1 — anything it wrote before that is still there; \
-             to undo: run `{} --off` from the repository root",
-            root.join("arm").display()
-        )
+        "guards: arm exited 1 — anything it wrote before that is still there; \
+         to undo: run `.agents/skills/guards/arm --off` from the repository root"
     );
 
     // No uninstaller: the removal text is what the package said instead.
@@ -107,6 +107,20 @@ fn a_failed_installer_reports_the_exit_and_the_declared_undo() {
         error
             .to_string()
             .ends_with("to undo: delete the hooks by hand"),
+        "{error}"
+    );
+
+    // A package that does not sit under the project is written whole, and
+    // the space in it is quoted rather than left to split the word.
+    let outside = tmp.path().join("some where");
+    script(&outside, "arm", "exit 1");
+    let error =
+        arm_settled(&scope, &package(&outside, Some("arm"), Some("arm --off"))).unwrap_err();
+    assert!(
+        error.to_string().ends_with(&format!(
+            "to undo: run `'{}' --off` from the repository root",
+            outside.join("arm").display()
+        )),
         "{error}"
     );
 
@@ -119,40 +133,6 @@ fn a_failed_installer_reports_the_exit_and_the_declared_undo() {
             .to_string()
             .ends_with("the package declares no way to undo it"),
         "{error}"
-    );
-}
-
-/// An installer kendex could not get an exit status from reads like a
-/// failed one, not like a script that never ran: it was handed to the
-/// operating system, so what it wrote — if anything — is still there.
-#[cfg(unix)]
-#[test]
-#[allow(clippy::unwrap_used)]
-fn an_installer_that_never_reported_still_names_the_undo() {
-    let tmp = tempfile::tempdir().unwrap();
-    let repo = tmp.path().join("repo");
-    fs::create_dir_all(&repo).unwrap();
-    let scope = Scope::Project { root: repo };
-    let root = tmp.path().join("pkg");
-    // Present and inside the package, so it resolves; not executable, so
-    // the failure lands where kendex can no longer say what happened.
-    fs::create_dir_all(&root).unwrap();
-    fs::write(root.join("arm"), "#!/bin/sh\nexit 0\n").unwrap();
-
-    let error = arm(&scope, &package(&root, Some("arm"), Some("arm --off"))).unwrap_err();
-    assert!(
-        matches!(&error, ArmError::Unfinished { name, .. } if name == "guards"),
-        "{error}"
-    );
-    let said = error.to_string();
-    assert!(said.starts_with("guards: arm did not finish ("), "{said}");
-    assert!(
-        said.ends_with(&format!(
-            " — anything it wrote before that is still there; \
-             to undo: run `{} --off` from the repository root",
-            root.join("arm").display()
-        )),
-        "{said}"
     );
 }
 

--- a/crates/core/src/repo_effects/tests.rs
+++ b/crates/core/src/repo_effects/tests.rs
@@ -78,9 +78,10 @@ fn a_package_with_no_installer_has_nothing_to_run() {
 fn a_failed_installer_reports_the_exit_and_the_declared_undo() {
     let tmp = tempfile::tempdir().unwrap();
     // A checkout path with a space in it, which is where an absolute
-    // program word would split into a program and an argument.
+    // program word would split into a program and an argument, and a
+    // package directory carrying the characters a shell acts on.
     let repo = tmp.path().join("My Project");
-    let root = repo.join(".agents/skills/guards");
+    let root = repo.join(".agents/skills/gu'ards $x;");
     fs::create_dir_all(&repo).unwrap();
     let scope = Scope::Project { root: repo };
     script(&root, "arm", "echo 'could not write hooks' >&2\nexit 1");
@@ -98,7 +99,8 @@ fn a_failed_installer_reports_the_exit_and_the_declared_undo() {
     assert_eq!(
         said,
         "guards: arm exited 1 — anything it wrote before that is still there; \
-         to undo: run `.agents/skills/guards/arm --off` from the repository root"
+         to undo: run `'.agents/skills/gu'\\''ards $x;/arm' '--off'` \
+         from the repository root"
     );
 
     // No uninstaller: the removal text is what the package said instead.
@@ -118,7 +120,7 @@ fn a_failed_installer_reports_the_exit_and_the_declared_undo() {
         arm_settled(&scope, &package(&outside, Some("arm"), Some("arm --off"))).unwrap_err();
     assert!(
         error.to_string().ends_with(&format!(
-            "to undo: run `'{}' --off` from the repository root",
+            "to undo: run `'{}' '--off'` from the repository root",
             outside.join("arm").display()
         )),
         "{error}"

--- a/crates/core/src/repo_effects/tests.rs
+++ b/crates/core/src/repo_effects/tests.rs
@@ -34,7 +34,7 @@ fn arm_settled(
 ) -> std::result::Result<crate::guard::GuardReport, ArmError> {
     for _ in 0..50 {
         match arm(scope, declared) {
-            Err(ArmError::Run(error)) if error.to_string().contains("Text file busy") => {
+            Err(error) if error.to_string().contains("Text file busy") => {
                 std::thread::sleep(std::time::Duration::from_millis(20));
             }
             outcome => return outcome,
@@ -90,10 +90,15 @@ fn a_failed_installer_reports_the_exit_and_the_declared_undo() {
     assert_eq!(*code, 1);
     assert_eq!(report.stderr, vec!["could not write hooks".to_owned()]);
     let said = error.to_string();
+    // The uninstaller resolved under the package, not the relative path the
+    // declaration wrote: read from the repository root, that names nothing.
     assert_eq!(
         said,
-        "guards: arm exited 1 — anything it wrote before that is still there; \
-         to undo: run `arm --off` from the repository root"
+        format!(
+            "guards: arm exited 1 — anything it wrote before that is still there; \
+             to undo: run `{} --off` from the repository root",
+            root.join("arm").display()
+        )
     );
 
     // No uninstaller: the removal text is what the package said instead.
@@ -115,6 +120,58 @@ fn a_failed_installer_reports_the_exit_and_the_declared_undo() {
             .ends_with("the package declares no way to undo it"),
         "{error}"
     );
+}
+
+/// An installer kendex could not get an exit status from reads like a
+/// failed one, not like a script that never ran: it was handed to the
+/// operating system, so what it wrote — if anything — is still there.
+#[cfg(unix)]
+#[test]
+#[allow(clippy::unwrap_used)]
+fn an_installer_that_never_reported_still_names_the_undo() {
+    let tmp = tempfile::tempdir().unwrap();
+    let repo = tmp.path().join("repo");
+    fs::create_dir_all(&repo).unwrap();
+    let scope = Scope::Project { root: repo };
+    let root = tmp.path().join("pkg");
+    // Present and inside the package, so it resolves; not executable, so
+    // the failure lands where kendex can no longer say what happened.
+    fs::create_dir_all(&root).unwrap();
+    fs::write(root.join("arm"), "#!/bin/sh\nexit 0\n").unwrap();
+
+    let error = arm(&scope, &package(&root, Some("arm"), Some("arm --off"))).unwrap_err();
+    assert!(
+        matches!(&error, ArmError::Unfinished { name, .. } if name == "guards"),
+        "{error}"
+    );
+    let said = error.to_string();
+    assert!(said.starts_with("guards: arm did not finish ("), "{said}");
+    assert!(
+        said.ends_with(&format!(
+            " — anything it wrote before that is still there; \
+             to undo: run `{} --off` from the repository root",
+            root.join("arm").display()
+        )),
+        "{said}"
+    );
+}
+
+/// A program that resolves to nothing never ran, and says so: no partial
+/// write to warn about and no undo to offer.
+#[cfg(unix)]
+#[test]
+#[allow(clippy::unwrap_used)]
+fn a_program_that_does_not_resolve_reports_only_that() {
+    let tmp = tempfile::tempdir().unwrap();
+    let repo = tmp.path().join("repo");
+    fs::create_dir_all(&repo).unwrap();
+    let scope = Scope::Project { root: repo };
+    let root = tmp.path().join("pkg");
+    fs::create_dir_all(&root).unwrap();
+
+    let error = arm(&scope, &package(&root, Some("arm"), Some("arm --off"))).unwrap_err();
+    assert!(matches!(&error, ArmError::Run(_)), "{error}");
+    assert!(!error.to_string().contains("still there"), "{error}");
 }
 
 /// A clean exit hands the installer's own lines back, so the surface can

--- a/crates/core/src/repo_effects/tests.rs
+++ b/crates/core/src/repo_effects/tests.rs
@@ -1,0 +1,138 @@
+//! A yes runs the declared installer and reports in one wording, whatever
+//! surface gave the yes.
+
+use std::fs;
+use std::path::Path;
+
+use super::*;
+use crate::model::Scope;
+
+fn package(root: &Path, installer: Option<&str>, uninstaller: Option<&str>) -> DeclaredEffects {
+    DeclaredEffects {
+        name: "guards".to_owned(),
+        root: root.to_path_buf(),
+        effects: RepoEffects {
+            summary: "arms hooks".to_owned(),
+            writes: Vec::new(),
+            installer: installer.map(str::to_owned),
+            uninstaller: uninstaller.map(str::to_owned),
+            removal: Some("delete the hooks by hand".to_owned()),
+            notes: Vec::new(),
+            companions: Vec::new(),
+        },
+    }
+}
+
+/// `arm`, retried past ETXTBSY. Tests run in parallel threads, and a
+/// sibling that forks a child between this file's open-for-write and its
+/// close hands that child the write descriptor until its own exec — so the
+/// first exec here can find the script "busy" through no fault of its own.
+/// The script is complete on disk either way; only the timing is off.
+fn arm_settled(
+    scope: &Scope,
+    declared: &DeclaredEffects,
+) -> std::result::Result<crate::guard::GuardReport, ArmError> {
+    for _ in 0..50 {
+        match arm(scope, declared) {
+            Err(ArmError::Run(error)) if error.to_string().contains("Text file busy") => {
+                std::thread::sleep(std::time::Duration::from_millis(20));
+            }
+            outcome => return outcome,
+        }
+    }
+    arm(scope, declared)
+}
+
+#[cfg(unix)]
+#[allow(clippy::unwrap_used)]
+fn script(root: &Path, name: &str, body: &str) {
+    use std::os::unix::fs::PermissionsExt;
+    fs::create_dir_all(root).unwrap();
+    let path = root.join(name);
+    fs::write(&path, format!("#!/bin/sh\n{body}\n")).unwrap();
+    fs::set_permissions(&path, fs::Permissions::from_mode(0o755)).unwrap();
+}
+
+/// A package with no installer is a state the surface names, not a run.
+#[test]
+#[allow(clippy::unwrap_used)]
+fn a_package_with_no_installer_has_nothing_to_run() {
+    let tmp = tempfile::tempdir().unwrap();
+    let scope = Scope::Project {
+        root: tmp.path().to_path_buf(),
+    };
+    let error = arm(&scope, &package(tmp.path(), None, None)).unwrap_err();
+    assert!(matches!(&error, ArmError::NothingToRun { name } if name == "guards"));
+    assert_eq!(
+        error.to_string(),
+        "guards: no installer to run — arm it yourself when you are ready"
+    );
+}
+
+/// A failed installer names what ran, how it exited, that nothing was
+/// rolled back, and the undo the package itself declared — the uninstaller
+/// where there is one, else its removal text — with its own lines kept.
+#[cfg(unix)]
+#[test]
+#[allow(clippy::unwrap_used)]
+fn a_failed_installer_reports_the_exit_and_the_declared_undo() {
+    let tmp = tempfile::tempdir().unwrap();
+    let repo = tmp.path().join("repo");
+    fs::create_dir_all(&repo).unwrap();
+    let scope = Scope::Project { root: repo };
+    let root = tmp.path().join("pkg");
+    script(&root, "arm", "echo 'could not write hooks' >&2\nexit 1");
+
+    let error = arm_settled(&scope, &package(&root, Some("arm"), Some("arm --off"))).unwrap_err();
+    let ArmError::Failed { code, report, .. } = &error else {
+        panic!("{error}");
+    };
+    assert_eq!(*code, 1);
+    assert_eq!(report.stderr, vec!["could not write hooks".to_owned()]);
+    let said = error.to_string();
+    assert_eq!(
+        said,
+        "guards: arm exited 1 — anything it wrote before that is still there; \
+         to undo: run `arm --off` from the repository root"
+    );
+
+    // No uninstaller: the removal text is what the package said instead.
+    let error = arm_settled(&scope, &package(&root, Some("arm"), None)).unwrap_err();
+    assert!(
+        error
+            .to_string()
+            .ends_with("to undo: delete the hooks by hand"),
+        "{error}"
+    );
+
+    // Neither: no claim is invented for the package.
+    let mut silent = package(&root, Some("arm"), None);
+    silent.effects.removal = None;
+    let error = arm_settled(&scope, &silent).unwrap_err();
+    assert!(
+        error
+            .to_string()
+            .ends_with("the package declares no way to undo it"),
+        "{error}"
+    );
+}
+
+/// A clean exit hands the installer's own lines back, so the surface can
+/// show what it said — an installer that deliberately armed nothing says
+/// so on stdout and exits 0.
+#[cfg(unix)]
+#[test]
+#[allow(clippy::unwrap_used)]
+fn a_clean_exit_carries_the_installer_own_words() {
+    let tmp = tempfile::tempdir().unwrap();
+    let repo = tmp.path().join("repo");
+    fs::create_dir_all(&repo).unwrap();
+    let scope = Scope::Project { root: repo };
+    let root = tmp.path().join("pkg");
+    script(&root, "arm", "echo 'hooks: skipped — already armed'");
+    let report = arm_settled(&scope, &package(&root, Some("arm"), None)).unwrap();
+    assert_eq!(
+        report.stdout,
+        vec!["hooks: skipped — already armed".to_owned()]
+    );
+}

--- a/skills/growth-guards/DEVELOPMENT.md
+++ b/skills/growth-guards/DEVELOPMENT.md
@@ -92,12 +92,12 @@ away. A delegating line it may not edit (a symlinked hook) keeps the helper
 in place and fails the removal rather than stranding a hook with no guard to
 reach.
 
-Nothing runs this installer on a package lifecycle event today: `kendex guard
-install`, `kendex guard uninstall` and `kendex guard check` are the verbs
-that invoke it, and
+The installer runs on `kendex guard install` and on the separate yes an
+install offers — in the terminal (`kendex add`, a collection add, `kendex
+apply`) and in the app. `kendex guard uninstall` and `kendex guard check`
+invoke it too. `kendex remove` does not run the uninstaller (KEN-674):
 disarming before removing the skill is the caller's to do — shims whose
-scripts are gone block every commit. Wiring `kendex add` / `refresh` /
-`remove` to it arrives with the repo-effects declaration (KEN-663 part 2).
+scripts are gone block every commit.
 
 `--check` is the read-only counterpart: it writes nothing — not even the
 hooks directory — and answers whether the shims are armed. `0`: the helper

--- a/tools/size-ratchet-baseline.tsv
+++ b/tools/size-ratchet-baseline.tsv
@@ -135,5 +135,5 @@ skills/size-ratchet/scripts/size-ratchet	1092
 skills/worktree/scripts/worktree	4803
 skills/worktree/scripts/worktree-session-guard	1197
 skills/worktree/tests/worktree_session_guard.sh	1282
-ui/src/stores/marketplaces.ts	283
+ui/src/stores/marketplaces.ts	282
 ui/src/stores/settings.ts	521

--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -2,6 +2,7 @@ import { useEffect } from "react";
 import { Toaster } from "sonner";
 import { commands } from "@/bindings";
 import { ErrorDialog } from "@/components/error-dialog";
+import { RepoEffectsDialog } from "@/components/marketplaces/repo-effects-dialog";
 import { NavBar } from "@/components/nav-bar";
 import { Sidebar } from "@/components/sidebar";
 import { StatusFooter } from "@/components/status-footer";
@@ -161,6 +162,7 @@ export default function App() {
           }}
         />
         <ErrorDialog />
+        <RepoEffectsDialog />
         <div className="flex flex-1 overflow-hidden">
           <Sidebar />
           <main className="relative flex flex-1 flex-col overflow-hidden">

--- a/ui/src/bindings.ts
+++ b/ui/src/bindings.ts
@@ -127,10 +127,7 @@ export const commands = {
 	 *  (offline caches keep serving); hard failures surface as the error.
 	 */
 	sourcesRefresh: () => typedError<string[], string>(__TAURI_INVOKE("sources_refresh")),
-	/**
-	 *  Every curated set every catalog offers, across every scope — what the
-	 *  Catalogs page lists under each source.
-	 */
+	/**  What the Catalogs page lists under each source — one query. */
 	bundlesOverview: () => typedError<BundleRow[], string>(__TAURI_INVOKE("bundles_overview")),
 	/**
 	 *  Install a set whole. Its members derive from the catalog, so this declares

--- a/ui/src/bindings.ts
+++ b/ui/src/bindings.ts
@@ -881,7 +881,13 @@ export type Disclosure = {
 	writes: Written[],
 	companions: Companion[],
 	notes: string[],
-	removal: string | null,
+	/**
+	 *  How the package says to undo the effect: the uninstaller it declared
+	 *  where there is one, else its removal text, else nothing. The same
+	 *  answer the failure message gives, so a person who reads the block
+	 *  and a person whose installer failed are told the same command.
+	 */
+	undo: string | null,
 };
 
 /**

--- a/ui/src/bindings.ts
+++ b/ui/src/bindings.ts
@@ -136,7 +136,7 @@ export const commands = {
 	 *  Install a set whole. Its members derive from the catalog, so this declares
 	 *  one name and applies the plan that follows from it.
 	 */
-	bundleInstall: (scope: Scope, source: string, name: string, hold: boolean) => typedError<BundleRow[], string>(__TAURI_INVOKE("bundle_install", { scope, source, name, hold })),
+	bundleInstall: (scope: Scope, source: string, name: string, hold: boolean) => typedError<BundleInstalled, string>(__TAURI_INVOKE("bundle_install", { scope, source, name, hold })),
 	/**
 	 *  Every subscription across every scope — the Marketplaces page's one
 	 *  query.
@@ -169,7 +169,7 @@ export const commands = {
 	 *  carry the picker's answer; absent, the scope's own install defaults
 	 *  decide, brought up to date against this machine by the add itself.
 	 */
-	marketplaceInstall: (scope: Scope, source: string, items: InstallItem[], bundle: string | null, destination: { scope: "global" } | { scope: "project"; root: string } | null, hold: boolean, harnesses: HarnessId[] | null, method: "symlink" | "copy" | null) => typedError<AvailablePackage[], string>(__TAURI_INVOKE("marketplace_install", { scope, source, items, bundle, destination, hold, harnesses, method })),
+	marketplaceInstall: (scope: Scope, source: string, items: InstallItem[], bundle: string | null, destination: { scope: "global" } | { scope: "project"; root: string } | null, hold: boolean, harnesses: HarnessId[] | null, method: "symlink" | "copy" | null) => typedError<Installed, string>(__TAURI_INVOKE("marketplace_install", { scope, source, items, bundle, destination, hold, harnesses, method })),
 	/**
 	 *  Where an install of these kinds could land, for the picker the install
 	 *  flow draws. Two filters, both read from core: which tools can take the
@@ -180,6 +180,7 @@ export const commands = {
 	 *  to be offerable, and one removed since must not read as present.
 	 */
 	installTargets: (scope: Scope, kinds: ItemKind[]) => typedError<InstallTarget[], string>(__TAURI_INVOKE("install_targets", { scope, kinds })),
+	repoEffectsApply: (scope: Scope, declared: DeclaredEffects) => typedError<null, string>(__TAURI_INVOKE("repo_effects_apply", { scope, declared })),
 	/**
 	 *  Subscribe a scope to a marketplace: `owner/repo[@rev]`, a git URL, a
 	 *  GitHub tree URL, a skills.sh package URL, or a local folder.
@@ -573,6 +574,15 @@ export type BundleDetail = {
 	collision: string | null,
 };
 
+/**
+ *  What a bundle install hands back: every set as it stands now, and the
+ *  repository effects its members brought for the window to ask about.
+ */
+export type BundleInstalled = {
+	bundles: BundleRow[],
+	repoEffects: Offers,
+};
+
 /**  One member of a curated set, with where it stands here. */
 export type BundleMemberRow = {
 	kind: ItemKind,
@@ -695,6 +705,15 @@ export type CatalogSummary = {
 	subscription: SubscriptionRef | null,
 };
 
+/**
+ *  A package whose presence changes what this one does, and whether it is
+ *  installed in this scope.
+ */
+export type Companion = {
+	name: string,
+	installed: boolean,
+};
+
 /**  How the content in the way compares with the install it blocks. */
 export type Comparison = {
 	/**
@@ -766,6 +785,24 @@ export type CustomHook_Serialize = {
 	agents: HookAgents,
 };
 
+/**
+ *  One package's declaration, with the package it came from — what a plan
+ *  carries out to the surfaces that disclose it.
+ */
+export type DeclaredEffects = {
+	name: string,
+	/**
+	 *  The package directory the scripts resolve against, once installed.
+	 * 
+	 *  A path, not a string of one. `display().to_string()` turns any byte
+	 *  that is not UTF-8 into U+FFFD, which is a different filename — so an
+	 *  authorized effect resolved a path nobody has, for a package that had
+	 *  just landed perfectly well. The same class #1669 closed on the guard
+	 *  side, here for the same reason.
+	 */
+	root: string,
+} & RepoEffects;
+
 /**  One rule firing once, and what it cost. */
 export type Deduction = {
 	rule: string,
@@ -829,6 +866,16 @@ export type DirectoryView = {
 	 */
 	fetchedAt: string,
 	stale: boolean,
+};
+
+/**
+ *  What a person reads before saying yes to one package's effect, and the
+ *  declaration that yes runs.
+ */
+export type Disclosure = {
+	declared: DeclaredEffects,
+	writes: Written[],
+	companions: Companion[],
 };
 
 /**
@@ -1257,6 +1304,16 @@ export type InstallTarget = {
 	sharesTheUniversalTree: boolean,
 };
 
+/**
+ *  What an install hands back: the subscription's packages as they stand
+ *  now, and the repository effects the install brought — read and asked
+ *  about in the window, because nothing here ran them.
+ */
+export type Installed = {
+	packages: AvailablePackage[],
+	repoEffects: Offers,
+};
+
 /**  One declared item: `[agents.<name>]` / `[skills.<name>]`. */
 export type ItemDecl = ItemDecl_Serialize | ItemDecl_Deserialize;
 
@@ -1660,6 +1717,15 @@ export type OfferPreview = {
 	bytes: string,
 };
 
+/**
+ *  Everything a run has to say about repository effects: the blocks to
+ *  read and ask about, and the packages it could not account for.
+ */
+export type Offers = {
+	shown: Disclosure[],
+	withheld: Withheld[],
+};
+
 export type OpSupport = {
 	project: boolean,
 	global: boolean,
@@ -1892,6 +1958,44 @@ export type QualityScore = {
 	 *  replace it.
 	 */
 	penaltyPercent: number,
+};
+
+/**  A package's declared effects on the repository it installs into. */
+export type RepoEffects = {
+	/**  One line: what installing this changes about the repository. */
+	summary: string,
+	/**  Repo-relative paths the package writes outside the managed trees. */
+	writes: string[],
+	/**
+	 *  The script, relative to the package directory, that applies the
+	 *  effect. Absent means kendex has nothing to run and the disclosure
+	 *  ends with what the reader should run themselves.
+	 */
+	installer: string | null,
+	/**
+	 *  The script that undoes the effect.
+	 * 
+	 *  Declared, not yet run: nothing in kendex executes it, and `remove`
+	 *  takes the package's files away with the effect still applied. The
+	 *  disclosure names it so a person can run it themselves, which is the
+	 *  whole of what it does today. KEN-674 carries wiring it into removal.
+	 */
+	uninstaller: string | null,
+	/**  How to undo the effect by hand, for the disclosure's last line. */
+	removal: string | null,
+	/**
+	 *  Lines the package wants read before anyone says yes — what its
+	 *  effect actually does, in its own words. The package writes these
+	 *  because only it knows them; kendex supplies the parts it owns, the
+	 *  paths and the authorization and the removal command.
+	 */
+	notes: string[],
+	/**
+	 *  Packages whose presence changes what this one does. Whether each is
+	 *  installed here is a fact about this repository rather than about the
+	 *  package, so the declaration names them and kendex answers.
+	 */
+	companions: string[],
 };
 
 export type ReportRouteView = {
@@ -2295,6 +2399,12 @@ export type VersionSel =
 /**  What is installed on disk right now. */
 { at: "installed" };
 
+/**  An effect that was neither shown nor offered, and why. */
+export type Withheld = {
+	name: string,
+	reason: string,
+};
+
 /**
  *  Why a whole-file write did not happen. Refusing is a normal answer
  *  here, not a failure, so it is a shape the page can act on rather than
@@ -2307,6 +2417,21 @@ export type WriteRefused =
  *  writing this copy would put that back.
  */
 { kind: "stale" } | { kind: "failed"; message: string };
+
+/**  One path the package writes, where it actually lands. */
+export type Written = {
+	/**
+	 *  Absolute, because the whole value of the line is that a reader can
+	 *  go and look.
+	 */
+	path: string,
+	/**
+	 *  Inside the repository's common git directory, which every work tree
+	 *  of the repository shares — so this file is the repository's, not
+	 *  this checkout's.
+	 */
+	shared: boolean,
+};
 
 export type ZoomState = {
 	/**

--- a/ui/src/bindings.ts
+++ b/ui/src/bindings.ts
@@ -177,7 +177,7 @@ export const commands = {
 	 *  to be offerable, and one removed since must not read as present.
 	 */
 	installTargets: (scope: Scope, kinds: ItemKind[]) => typedError<InstallTarget[], string>(__TAURI_INVOKE("install_targets", { scope, kinds })),
-	repoEffectsApply: (scope: Scope, declared: DeclaredEffects) => typedError<string[], string>(__TAURI_INVOKE("repo_effects_apply", { scope, declared })),
+	repoEffectsApply: (scope: Scope, declared: DeclaredEffects) => typedError<Said, string>(__TAURI_INVOKE("repo_effects_apply", { scope, declared })),
 	/**
 	 *  Subscribe a scope to a marketplace: `owner/repo[@rev]`, a git URL, a
 	 *  GitHub tree URL, a skills.sh package URL, or a local folder.
@@ -2069,6 +2069,19 @@ export type RowExits = {
 export type SafetyScore = {
 	score: number,
 	deductions: Deduction[],
+};
+
+/**
+ *  What an installer said, kept by channel.
+ * 
+ *  Both of them, on a clean exit as much as a failed one. growth-guards
+ *  exits 0 when `core.hooksPath` is configured and puts its summary on
+ *  stdout and the warning, the value it found, and the remedy on stderr —
+ *  so stdout alone is the half of the account that does not say what to do.
+ */
+export type Said = {
+	stdout: string[],
+	stderr: string[],
 };
 
 export type ScanResult = {

--- a/ui/src/bindings.ts
+++ b/ui/src/bindings.ts
@@ -180,7 +180,7 @@ export const commands = {
 	 *  to be offerable, and one removed since must not read as present.
 	 */
 	installTargets: (scope: Scope, kinds: ItemKind[]) => typedError<InstallTarget[], string>(__TAURI_INVOKE("install_targets", { scope, kinds })),
-	repoEffectsApply: (scope: Scope, declared: DeclaredEffects) => typedError<null, string>(__TAURI_INVOKE("repo_effects_apply", { scope, declared })),
+	repoEffectsApply: (scope: Scope, declared: DeclaredEffects) => typedError<string[], string>(__TAURI_INVOKE("repo_effects_apply", { scope, declared })),
 	/**
 	 *  Subscribe a scope to a marketplace: `owner/repo[@rev]`, a git URL, a
 	 *  GitHub tree URL, a skills.sh package URL, or a local folder.
@@ -710,6 +710,7 @@ export type CatalogSummary = {
  *  installed in this scope.
  */
 export type Companion = {
+	/**  Display text: shown once, printed as it is. */
 	name: string,
 	installed: boolean,
 };
@@ -871,11 +872,19 @@ export type DirectoryView = {
 /**
  *  What a person reads before saying yes to one package's effect, and the
  *  declaration that yes runs.
+ * 
+ *  The display fields are the declaration's own words as they go on the
+ *  screen; `declared` is the same words untouched, for the command that
+ *  runs the effect. A surface reads the former and hands back the latter.
  */
 export type Disclosure = {
 	declared: DeclaredEffects,
+	name: string,
+	summary: string,
 	writes: Written[],
 	companions: Companion[],
+	notes: string[],
+	removal: string | null,
 };
 
 /**
@@ -2401,6 +2410,7 @@ export type VersionSel =
 
 /**  An effect that was neither shown nor offered, and why. */
 export type Withheld = {
+	/**  Display text: shown once, printed as it is. */
 	name: string,
 	reason: string,
 };
@@ -2422,7 +2432,7 @@ export type WriteRefused =
 export type Written = {
 	/**
 	 *  Absolute, because the whole value of the line is that a reader can
-	 *  go and look.
+	 *  go and look. Display text: shown once, printed as it is.
 	 */
 	path: string,
 	/**

--- a/ui/src/components/marketplaces/repo-effects-dialog.dom.test.tsx
+++ b/ui/src/components/marketplaces/repo-effects-dialog.dom.test.tsx
@@ -12,8 +12,9 @@ import {
   REPO_EFFECTS_APPLY_LABEL,
   REPO_EFFECTS_DECLINE_LABEL,
   REPO_EFFECTS_DONE_LABEL,
-  REPO_EFFECTS_NO_REMOVAL,
+  REPO_EFFECTS_NO_UNDO,
   REPO_EFFECTS_NOTHING_TO_RUN,
+  REPO_EFFECTS_SHARED_MARK,
   REPO_EFFECTS_SHARED_NOTE,
   repoEffectsTitle,
 } from "@/lib/copy-repo-effects";
@@ -50,7 +51,7 @@ const guards: Disclosure = {
     { name: "preflight", installed: false },
   ],
   notes: ["core.hooksPath is never set."],
-  removal: "run the uninstaller before removing this package",
+  undo: "run `'.agents/skills/growth-guards/scripts/install-git-hooks' '--uninstall'` from the repository root",
 };
 
 const show = (queue: Disclosure[], busy = false) => {
@@ -79,13 +80,33 @@ describe("the account a person reads", () => {
     expect(text).toContain(COMPANION_INSTALLED);
     expect(text).toContain(COMPANION_NOT_INSTALLED);
     expect(text).toContain("core.hooksPath is never set.");
-    expect(text).toContain("run the uninstaller before removing this package");
+    expect(text).toContain(guards.undo ?? "");
     expect(text).not.toContain(REPO_EFFECTS_NOTHING_TO_RUN);
   });
 
-  it("never promises a removal the package did not declare", () => {
-    const body = show([{ ...guards, removal: null }]);
-    expect(body.textContent).toContain(REPO_EFFECTS_NO_REMOVAL);
+  it("never promises an undo the package did not declare", () => {
+    const body = show([{ ...guards, undo: null }]);
+    expect(body.textContent).toContain(REPO_EFFECTS_NO_UNDO);
+  });
+
+  it("marks the shared paths one by one, never the checkout-local ones", () => {
+    // A package writing into `.git/hooks` and into `.github` writes one
+    // file every work tree sees and one only this checkout has.
+    const body = show([
+      {
+        ...guards,
+        writes: [
+          { path: "/home/me/app/.git/hooks/pre-commit", shared: true },
+          { path: "/home/me/app/.github/x", shared: false },
+        ],
+      },
+    ]);
+    const marked = Array.from(body.querySelectorAll("li")).filter((li) =>
+      li.textContent?.includes(REPO_EFFECTS_SHARED_MARK),
+    );
+    expect(marked).toHaveLength(1);
+    expect(marked[0].textContent).toContain("~/app/.git/hooks/pre-commit");
+    expect(body.textContent).toContain(REPO_EFFECTS_SHARED_NOTE);
   });
 
   it("renders the display text as core escaped it, never the raw declaration", () => {

--- a/ui/src/components/marketplaces/repo-effects-dialog.dom.test.tsx
+++ b/ui/src/components/marketplaces/repo-effects-dialog.dom.test.tsx
@@ -42,28 +42,37 @@ const guards: Disclosure = {
     notes: ["core.hooksPath is never set."],
     companions: ["size-ratchet", "preflight"],
   },
+  name: "growth-guards",
+  summary: "Arms git hooks, so every commit runs the guard chain.",
   writes: [{ path: "/home/me/app/.git/hooks/pre-commit", shared: true }],
   companions: [
     { name: "size-ratchet", installed: true },
     { name: "preflight", installed: false },
   ],
+  notes: ["core.hooksPath is never set."],
+  removal: "run the uninstaller before removing this package",
 };
 
-const show = (queue: Disclosure[]) => {
+const show = (queue: Disclosure[], busy = false) => {
   useMarketplacesStore.setState({
     pendingEffects: { scope: PROJECT, queue },
-    busy: false,
+    busy,
   });
   mount(<RepoEffectsDialog />);
   return document.body;
 };
+
+const button = (body: HTMLElement, label: string) =>
+  Array.from(body.querySelectorAll("button")).find(
+    (b) => b.textContent === label,
+  );
 
 describe("the account a person reads", () => {
   it("carries what changes, where, who takes part, and how to undo it", () => {
     const body = show([guards]);
     const text = body.textContent ?? "";
     expect(text).toContain(repoEffectsTitle("growth-guards"));
-    expect(text).toContain(guards.declared.summary);
+    expect(text).toContain(guards.summary);
     expect(text).toContain("~/app/.git/hooks/pre-commit");
     expect(text).toContain(REPO_EFFECTS_SHARED_NOTE);
     expect(text).toContain("size-ratchet");
@@ -75,10 +84,29 @@ describe("the account a person reads", () => {
   });
 
   it("never promises a removal the package did not declare", () => {
-    const body = show([
-      { ...guards, declared: { ...guards.declared, removal: null } },
-    ]);
+    const body = show([{ ...guards, removal: null }]);
     expect(body.textContent).toContain(REPO_EFFECTS_NO_REMOVAL);
+  });
+
+  it("renders the display text as core escaped it, never the raw declaration", () => {
+    // Core hands the path through `shown`, so a direction-flipping
+    // character arrives as its escape; the raw declaration beside it
+    // still carries the character, and must not be what renders.
+    const body = show([
+      {
+        ...guards,
+        declared: {
+          ...guards.declared,
+          writes: [".git/hooks/‮pre-commit"],
+        },
+        writes: [
+          { path: "/home/me/app/.git/hooks/\\u{202e}pre-commit", shared: true },
+        ],
+      },
+    ]);
+    const text = body.textContent ?? "";
+    expect(text).toContain("\\u{202e}pre-commit");
+    expect(text).not.toContain("‮");
   });
 
   it("renders nothing when nothing is waiting", () => {
@@ -92,14 +120,12 @@ describe("the answer", () => {
   it("a yes runs exactly the declaration on screen", async () => {
     vi.mocked(commands.repoEffectsApply).mockResolvedValue({
       status: "ok",
-      data: null,
+      data: [],
     });
     const body = show([guards]);
-    const button = Array.from(body.querySelectorAll("button")).find(
-      (b) => b.textContent === REPO_EFFECTS_APPLY_LABEL,
-    );
-    expect(button).toBeDefined();
-    await userEvent.click(button as HTMLButtonElement);
+    const apply = button(body, REPO_EFFECTS_APPLY_LABEL);
+    expect(apply).toBeDefined();
+    await userEvent.click(apply as HTMLButtonElement);
     await settle();
     expect(commands.repoEffectsApply).toHaveBeenCalledWith(
       PROJECT,
@@ -111,13 +137,38 @@ describe("the answer", () => {
   it("a no runs nothing and closes", async () => {
     vi.mocked(commands.repoEffectsApply).mockClear();
     const body = show([guards]);
-    const button = Array.from(body.querySelectorAll("button")).find(
-      (b) => b.textContent === REPO_EFFECTS_DECLINE_LABEL,
+    await userEvent.click(
+      button(body, REPO_EFFECTS_DECLINE_LABEL) as HTMLButtonElement,
     );
-    await userEvent.click(button as HTMLButtonElement);
     await settle();
     expect(commands.repoEffectsApply).not.toHaveBeenCalled();
     expect(useMarketplacesStore.getState().pendingEffects).toBeNull();
+  });
+
+  it("closing the dialog is a no", async () => {
+    vi.mocked(commands.repoEffectsApply).mockClear();
+    show([guards]);
+    await userEvent.keyboard("{Escape}");
+    await settle();
+    expect(commands.repoEffectsApply).not.toHaveBeenCalled();
+    expect(useMarketplacesStore.getState().pendingEffects).toBeNull();
+  });
+
+  it("while an answer is running, neither button nor Escape answers again", async () => {
+    vi.mocked(commands.repoEffectsApply).mockClear();
+    const body = show([guards], true);
+    expect(
+      (button(body, REPO_EFFECTS_APPLY_LABEL) as HTMLButtonElement).disabled,
+    ).toBe(true);
+    expect(
+      (button(body, REPO_EFFECTS_DECLINE_LABEL) as HTMLButtonElement).disabled,
+    ).toBe(true);
+    await userEvent.keyboard("{Escape}");
+    await settle();
+    expect(useMarketplacesStore.getState().pendingEffects?.queue).toEqual([
+      guards,
+    ]);
+    expect(commands.repoEffectsApply).not.toHaveBeenCalled();
   });
 
   it("a package with nothing to run gets no button that would run it", () => {

--- a/ui/src/components/marketplaces/repo-effects-dialog.dom.test.tsx
+++ b/ui/src/components/marketplaces/repo-effects-dialog.dom.test.tsx
@@ -74,7 +74,10 @@ describe("the account a person reads", () => {
     const text = body.textContent ?? "";
     expect(text).toContain(repoEffectsTitle("growth-guards"));
     expect(text).toContain(guards.summary);
-    expect(text).toContain("~/app/.git/hooks/pre-commit");
+    // The path as core settled it, never an abbreviation: a guess at the
+    // home directory names a location other than the one being authorized.
+    expect(text).toContain("/home/me/app/.git/hooks/pre-commit");
+    expect(text).not.toContain("~/app");
     expect(text).toContain(REPO_EFFECTS_SHARED_NOTE);
     expect(text).toContain("size-ratchet");
     expect(text).toContain(COMPANION_INSTALLED);
@@ -105,7 +108,9 @@ describe("the account a person reads", () => {
       li.textContent?.includes(REPO_EFFECTS_SHARED_MARK),
     );
     expect(marked).toHaveLength(1);
-    expect(marked[0].textContent).toContain("~/app/.git/hooks/pre-commit");
+    expect(marked[0].textContent).toContain(
+      "/home/me/app/.git/hooks/pre-commit",
+    );
     expect(body.textContent).toContain(REPO_EFFECTS_SHARED_NOTE);
   });
 
@@ -141,7 +146,7 @@ describe("the answer", () => {
   it("a yes runs exactly the declaration on screen", async () => {
     vi.mocked(commands.repoEffectsApply).mockResolvedValue({
       status: "ok",
-      data: [],
+      data: { stdout: [], stderr: [] },
     });
     const body = show([guards]);
     const apply = button(body, REPO_EFFECTS_APPLY_LABEL);

--- a/ui/src/components/marketplaces/repo-effects-dialog.dom.test.tsx
+++ b/ui/src/components/marketplaces/repo-effects-dialog.dom.test.tsx
@@ -1,0 +1,134 @@
+// @vitest-environment jsdom
+// The block a person reads before a package changes how their repository
+// works, and the two buttons under it. What is on screen is what the yes
+// is for, so every part of the account has to be there — and a package
+// with nothing kendex can run gets no button that promises to run it.
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it, vi } from "vitest";
+import { commands, type Disclosure } from "@/bindings";
+import {
+  COMPANION_INSTALLED,
+  COMPANION_NOT_INSTALLED,
+  REPO_EFFECTS_APPLY_LABEL,
+  REPO_EFFECTS_DECLINE_LABEL,
+  REPO_EFFECTS_DONE_LABEL,
+  REPO_EFFECTS_NO_REMOVAL,
+  REPO_EFFECTS_NOTHING_TO_RUN,
+  REPO_EFFECTS_SHARED_NOTE,
+  repoEffectsTitle,
+} from "@/lib/copy-repo-effects";
+import { useMarketplacesStore } from "@/stores/marketplaces";
+import { mount, settle } from "@/test/dom";
+import { RepoEffectsDialog } from "./repo-effects-dialog";
+
+vi.mock("@/bindings", () => ({
+  commands: { repoEffectsApply: vi.fn() },
+}));
+vi.mock("sonner", () => ({
+  toast: { success: vi.fn(), info: vi.fn(), error: vi.fn() },
+}));
+
+const PROJECT = { scope: "project" as const, root: "/home/me/app" };
+
+const guards: Disclosure = {
+  declared: {
+    name: "growth-guards",
+    root: "/home/me/app/.agents/skills/growth-guards",
+    summary: "Arms git hooks, so every commit runs the guard chain.",
+    writes: [".git/hooks/pre-commit"],
+    installer: "scripts/install-git-hooks",
+    uninstaller: "scripts/install-git-hooks --uninstall",
+    removal: "run the uninstaller before removing this package",
+    notes: ["core.hooksPath is never set."],
+    companions: ["size-ratchet", "preflight"],
+  },
+  writes: [{ path: "/home/me/app/.git/hooks/pre-commit", shared: true }],
+  companions: [
+    { name: "size-ratchet", installed: true },
+    { name: "preflight", installed: false },
+  ],
+};
+
+const show = (queue: Disclosure[]) => {
+  useMarketplacesStore.setState({
+    pendingEffects: { scope: PROJECT, queue },
+    busy: false,
+  });
+  mount(<RepoEffectsDialog />);
+  return document.body;
+};
+
+describe("the account a person reads", () => {
+  it("carries what changes, where, who takes part, and how to undo it", () => {
+    const body = show([guards]);
+    const text = body.textContent ?? "";
+    expect(text).toContain(repoEffectsTitle("growth-guards"));
+    expect(text).toContain(guards.declared.summary);
+    expect(text).toContain("~/app/.git/hooks/pre-commit");
+    expect(text).toContain(REPO_EFFECTS_SHARED_NOTE);
+    expect(text).toContain("size-ratchet");
+    expect(text).toContain(COMPANION_INSTALLED);
+    expect(text).toContain(COMPANION_NOT_INSTALLED);
+    expect(text).toContain("core.hooksPath is never set.");
+    expect(text).toContain("run the uninstaller before removing this package");
+    expect(text).not.toContain(REPO_EFFECTS_NOTHING_TO_RUN);
+  });
+
+  it("never promises a removal the package did not declare", () => {
+    const body = show([
+      { ...guards, declared: { ...guards.declared, removal: null } },
+    ]);
+    expect(body.textContent).toContain(REPO_EFFECTS_NO_REMOVAL);
+  });
+
+  it("renders nothing when nothing is waiting", () => {
+    useMarketplacesStore.setState({ pendingEffects: null });
+    mount(<RepoEffectsDialog />);
+    expect(document.body.textContent).toBe("");
+  });
+});
+
+describe("the answer", () => {
+  it("a yes runs exactly the declaration on screen", async () => {
+    vi.mocked(commands.repoEffectsApply).mockResolvedValue({
+      status: "ok",
+      data: null,
+    });
+    const body = show([guards]);
+    const button = Array.from(body.querySelectorAll("button")).find(
+      (b) => b.textContent === REPO_EFFECTS_APPLY_LABEL,
+    );
+    expect(button).toBeDefined();
+    await userEvent.click(button as HTMLButtonElement);
+    await settle();
+    expect(commands.repoEffectsApply).toHaveBeenCalledWith(
+      PROJECT,
+      guards.declared,
+    );
+    expect(useMarketplacesStore.getState().pendingEffects).toBeNull();
+  });
+
+  it("a no runs nothing and closes", async () => {
+    vi.mocked(commands.repoEffectsApply).mockClear();
+    const body = show([guards]);
+    const button = Array.from(body.querySelectorAll("button")).find(
+      (b) => b.textContent === REPO_EFFECTS_DECLINE_LABEL,
+    );
+    await userEvent.click(button as HTMLButtonElement);
+    await settle();
+    expect(commands.repoEffectsApply).not.toHaveBeenCalled();
+    expect(useMarketplacesStore.getState().pendingEffects).toBeNull();
+  });
+
+  it("a package with nothing to run gets no button that would run it", () => {
+    const body = show([
+      { ...guards, declared: { ...guards.declared, installer: null } },
+    ]);
+    const labels = Array.from(body.querySelectorAll("button")).map(
+      (b) => b.textContent,
+    );
+    expect(labels).not.toContain(REPO_EFFECTS_APPLY_LABEL);
+    expect(labels).toContain(REPO_EFFECTS_DONE_LABEL);
+    expect(body.textContent).toContain(REPO_EFFECTS_NOTHING_TO_RUN);
+  });
+});

--- a/ui/src/components/marketplaces/repo-effects-dialog.tsx
+++ b/ui/src/components/marketplaces/repo-effects-dialog.tsx
@@ -1,0 +1,146 @@
+import type { Disclosure } from "@/bindings";
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import {
+  COMPANION_INSTALLED,
+  COMPANION_NOT_INSTALLED,
+  REPO_EFFECTS_APPLY_LABEL,
+  REPO_EFFECTS_COMPANIONS_LABEL,
+  REPO_EFFECTS_DECLINE_LABEL,
+  REPO_EFFECTS_DONE_LABEL,
+  REPO_EFFECTS_NO_REMOVAL,
+  REPO_EFFECTS_NOTHING_TO_RUN,
+  REPO_EFFECTS_SHARED_NOTE,
+  REPO_EFFECTS_STANDING,
+  REPO_EFFECTS_UNDO_LABEL,
+  REPO_EFFECTS_WRITES_LABEL,
+  repoEffectsTitle,
+} from "@/lib/copy-repo-effects";
+import { abbreviateHome } from "@/lib/drift-merge";
+import { useMarketplacesStore } from "@/stores/marketplaces";
+
+/** The second question an install can ask, rendered once in App.tsx: what
+ *  a package does to the repository beyond the files kendex manages, and
+ *  whether to let it. One package at a time, each with its own yes, in the
+ *  order the install reported them. The package's files are already in;
+ *  closing this leaves them in and the repository as it was. */
+export function RepoEffectsDialog() {
+  const pending = useMarketplacesStore((s) => s.pendingEffects);
+  const busy = useMarketplacesStore((s) => s.busy);
+  const apply = useMarketplacesStore((s) => s.applyRepoEffect);
+  const decline = useMarketplacesStore((s) => s.declineRepoEffect);
+  if (!pending) return null;
+  const disclosure = pending.queue[0];
+  const runnable = disclosure.declared.installer !== null;
+  return (
+    <Dialog
+      open
+      onOpenChange={(next) => {
+        // Dismissing is declining: nothing runs without the button.
+        if (!next && !busy) decline();
+      }}
+    >
+      <DialogContent className="max-h-[85vh] overflow-y-auto sm:max-w-xl">
+        <DialogHeader>
+          <DialogTitle>
+            {repoEffectsTitle(disclosure.declared.name)}
+          </DialogTitle>
+          <DialogDescription>{REPO_EFFECTS_STANDING}</DialogDescription>
+        </DialogHeader>
+        <DisclosureBody disclosure={disclosure} />
+        <DialogFooter>
+          {runnable ? (
+            <>
+              <Button variant="outline" disabled={busy} onClick={decline}>
+                {REPO_EFFECTS_DECLINE_LABEL}
+              </Button>
+              <Button disabled={busy} onClick={() => void apply()}>
+                {REPO_EFFECTS_APPLY_LABEL}
+              </Button>
+            </>
+          ) : (
+            <Button disabled={busy} onClick={decline}>
+              {REPO_EFFECTS_DONE_LABEL}
+            </Button>
+          )}
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+/** The block, in the order a reader needs it: what changes, what is
+ *  written, which packages take part, whatever the package itself wants
+ *  read, and how to undo it. Every line is the package's own words or a
+ *  fact kendex knows about this machine; nothing here explains what a
+ *  declaration means, because that is the package's contract. */
+function DisclosureBody({ disclosure }: { disclosure: Disclosure }) {
+  const effects = disclosure.declared;
+  const shared = disclosure.writes.some((written) => written.shared);
+  return (
+    <div className="space-y-4 text-sm">
+      <p className="font-medium">{effects.summary}</p>
+      {disclosure.writes.length > 0 ? (
+        <section className="space-y-1.5">
+          <h3 className="text-xs font-medium text-muted-foreground uppercase tracking-wide">
+            {REPO_EFFECTS_WRITES_LABEL}
+          </h3>
+          <ul className="space-y-0.5">
+            {disclosure.writes.map((written) => (
+              <li key={written.path} className="break-all font-mono text-xs">
+                {abbreviateHome(written.path)}
+              </li>
+            ))}
+          </ul>
+          {shared ? (
+            <p className="text-muted-foreground">{REPO_EFFECTS_SHARED_NOTE}</p>
+          ) : null}
+        </section>
+      ) : null}
+      {disclosure.companions.length > 0 ? (
+        <section className="space-y-1.5">
+          <h3 className="text-xs font-medium text-muted-foreground uppercase tracking-wide">
+            {REPO_EFFECTS_COMPANIONS_LABEL}
+          </h3>
+          <ul className="space-y-0.5">
+            {disclosure.companions.map((companion) => (
+              <li key={companion.name} className="flex items-baseline gap-2">
+                <span className="font-mono text-xs">{companion.name}</span>
+                <span className="text-xs text-muted-foreground">
+                  {companion.installed
+                    ? COMPANION_INSTALLED
+                    : COMPANION_NOT_INSTALLED}
+                </span>
+              </li>
+            ))}
+          </ul>
+        </section>
+      ) : null}
+      {effects.notes.map((note) => (
+        <p key={note} className="text-muted-foreground">
+          {note}
+        </p>
+      ))}
+      <section className="space-y-1">
+        <h3 className="text-xs font-medium text-muted-foreground uppercase tracking-wide">
+          {REPO_EFFECTS_UNDO_LABEL}
+        </h3>
+        {/* Never "remove the package": removing it takes the scripts away
+            and leaves the effect. What is true is what the package said. */}
+        <p className="text-muted-foreground">
+          {effects.removal ?? REPO_EFFECTS_NO_REMOVAL}
+        </p>
+      </section>
+      {effects.installer === null ? (
+        <p className="text-muted-foreground">{REPO_EFFECTS_NOTHING_TO_RUN}</p>
+      ) : null}
+    </div>
+  );
+}

--- a/ui/src/components/marketplaces/repo-effects-dialog.tsx
+++ b/ui/src/components/marketplaces/repo-effects-dialog.tsx
@@ -30,7 +30,13 @@ import { useMarketplacesStore } from "@/stores/marketplaces";
  *  a package does to the repository beyond the files kendex manages, and
  *  whether to let it. One package at a time, each with its own yes, in the
  *  order the install reported them. The package's files are already in;
- *  closing this leaves them in and the repository as it was. */
+ *  closing this leaves them in and the repository as it was.
+ *
+ *  Every word of the package's on screen is core's display text, already
+ *  escaped once there: a direction-flipping character in a declared path
+ *  would otherwise read as a different file from the one being
+ *  authorized. Nothing here reads the raw declaration except to hand it
+ *  back. */
 export function RepoEffectsDialog() {
   const pending = useMarketplacesStore((s) => s.pendingEffects);
   const busy = useMarketplacesStore((s) => s.busy);
@@ -49,9 +55,7 @@ export function RepoEffectsDialog() {
     >
       <DialogContent className="max-h-[85vh] overflow-y-auto sm:max-w-xl">
         <DialogHeader>
-          <DialogTitle>
-            {repoEffectsTitle(disclosure.declared.name)}
-          </DialogTitle>
+          <DialogTitle>{repoEffectsTitle(disclosure.name)}</DialogTitle>
           <DialogDescription>{REPO_EFFECTS_STANDING}</DialogDescription>
         </DialogHeader>
         <DisclosureBody disclosure={disclosure} />
@@ -82,11 +86,10 @@ export function RepoEffectsDialog() {
  *  fact kendex knows about this machine; nothing here explains what a
  *  declaration means, because that is the package's contract. */
 function DisclosureBody({ disclosure }: { disclosure: Disclosure }) {
-  const effects = disclosure.declared;
   const shared = disclosure.writes.some((written) => written.shared);
   return (
     <div className="space-y-4 text-sm">
-      <p className="font-medium">{effects.summary}</p>
+      <p className="font-medium">{disclosure.summary}</p>
       {disclosure.writes.length > 0 ? (
         <section className="space-y-1.5">
           <h3 className="text-xs font-medium text-muted-foreground uppercase tracking-wide">
@@ -123,7 +126,7 @@ function DisclosureBody({ disclosure }: { disclosure: Disclosure }) {
           </ul>
         </section>
       ) : null}
-      {effects.notes.map((note) => (
+      {disclosure.notes.map((note) => (
         <p key={note} className="text-muted-foreground">
           {note}
         </p>
@@ -135,10 +138,10 @@ function DisclosureBody({ disclosure }: { disclosure: Disclosure }) {
         {/* Never "remove the package": removing it takes the scripts away
             and leaves the effect. What is true is what the package said. */}
         <p className="text-muted-foreground">
-          {effects.removal ?? REPO_EFFECTS_NO_REMOVAL}
+          {disclosure.removal ?? REPO_EFFECTS_NO_REMOVAL}
         </p>
       </section>
-      {effects.installer === null ? (
+      {disclosure.declared.installer === null ? (
         <p className="text-muted-foreground">{REPO_EFFECTS_NOTHING_TO_RUN}</p>
       ) : null}
     </div>

--- a/ui/src/components/marketplaces/repo-effects-dialog.tsx
+++ b/ui/src/components/marketplaces/repo-effects-dialog.tsx
@@ -15,8 +15,9 @@ import {
   REPO_EFFECTS_COMPANIONS_LABEL,
   REPO_EFFECTS_DECLINE_LABEL,
   REPO_EFFECTS_DONE_LABEL,
-  REPO_EFFECTS_NO_REMOVAL,
+  REPO_EFFECTS_NO_UNDO,
   REPO_EFFECTS_NOTHING_TO_RUN,
+  REPO_EFFECTS_SHARED_MARK,
   REPO_EFFECTS_SHARED_NOTE,
   REPO_EFFECTS_STANDING,
   REPO_EFFECTS_UNDO_LABEL,
@@ -97,8 +98,15 @@ function DisclosureBody({ disclosure }: { disclosure: Disclosure }) {
           </h3>
           <ul className="space-y-0.5">
             {disclosure.writes.map((written) => (
-              <li key={written.path} className="break-all font-mono text-xs">
-                {abbreviateHome(written.path)}
+              <li key={written.path} className="flex items-baseline gap-2">
+                <span className="break-all font-mono text-xs">
+                  {abbreviateHome(written.path)}
+                </span>
+                {written.shared ? (
+                  <span className="text-xs text-muted-foreground">
+                    {REPO_EFFECTS_SHARED_MARK}
+                  </span>
+                ) : null}
               </li>
             ))}
           </ul>
@@ -138,7 +146,7 @@ function DisclosureBody({ disclosure }: { disclosure: Disclosure }) {
         {/* Never "remove the package": removing it takes the scripts away
             and leaves the effect. What is true is what the package said. */}
         <p className="text-muted-foreground">
-          {disclosure.removal ?? REPO_EFFECTS_NO_REMOVAL}
+          {disclosure.undo ?? REPO_EFFECTS_NO_UNDO}
         </p>
       </section>
       {disclosure.declared.installer === null ? (

--- a/ui/src/components/marketplaces/repo-effects-dialog.tsx
+++ b/ui/src/components/marketplaces/repo-effects-dialog.tsx
@@ -35,8 +35,8 @@ import { useMarketplacesStore } from "@/stores/marketplaces";
  *  Every word of the package's on screen is core's display text, already
  *  escaped once there: a direction-flipping character in a declared path
  *  would otherwise read as a different file from the one being
- *  authorized. Nothing here reads the raw declaration except to hand it
- *  back. */
+ *  authorized. Nothing here displays the raw declaration; it is read only
+ *  for whether an installer exists, and handed back untouched. */
 export function RepoEffectsDialog() {
   const pending = useMarketplacesStore((s) => s.pendingEffects);
   const busy = useMarketplacesStore((s) => s.busy);

--- a/ui/src/components/marketplaces/repo-effects-dialog.tsx
+++ b/ui/src/components/marketplaces/repo-effects-dialog.tsx
@@ -24,7 +24,6 @@ import {
   REPO_EFFECTS_WRITES_LABEL,
   repoEffectsTitle,
 } from "@/lib/copy-repo-effects";
-import { abbreviateHome } from "@/lib/drift-merge";
 import { useMarketplacesStore } from "@/stores/marketplaces";
 
 /** The second question an install can ask, rendered once in App.tsx: what
@@ -99,8 +98,14 @@ function DisclosureBody({ disclosure }: { disclosure: Disclosure }) {
           <ul className="space-y-0.5">
             {disclosure.writes.map((written) => (
               <li key={written.path} className="flex items-baseline gap-2">
-                <span className="break-all font-mono text-xs">
-                  {abbreviateHome(written.path)}
+                {/* The path core settled, character for character. An
+                    abbreviation guesses at a home directory, so a project
+                    under another account read as one under this one — a
+                    different location from the one being authorized, and a
+                    different string from the terminal's for the same
+                    declaration. Length is the layout's problem. */}
+                <span className="min-w-0 break-all font-mono text-xs">
+                  {written.path}
                 </span>
                 {written.shared ? (
                   <span className="text-xs text-muted-foreground">

--- a/ui/src/dev/mock-install.ts
+++ b/ui/src/dev/mock-install.ts
@@ -137,32 +137,39 @@ export const installHandlers: Record<string, Handler> = {
     if (declared.installer === null) {
       return Promise.reject(`${declared.name} declares nothing kendex can run`);
     }
-    return null;
+    return [
+      "growth-guards git hooks: pre-commit and commit-msg armed in .git/hooks",
+    ];
   },
 };
 
 function guardDisclosure(root: string, testsInstalled: boolean): Disclosure {
+  const declared: Disclosure["declared"] = {
+    name: "guard",
+    root: `${root}/.agents/skills/guard`,
+    summary:
+      "Arms git pre-commit and commit-msg hooks, so every commit in this repository runs the guard chain — for everyone who commits here, not only for kendex.",
+    writes: [
+      ".git/hooks/kendex-guards",
+      ".git/hooks/pre-commit",
+      ".git/hooks/commit-msg",
+    ],
+    installer: "scripts/install-git-hooks",
+    uninstaller: "scripts/install-git-hooks --uninstall",
+    removal:
+      "run the uninstaller before removing this package: it drops only the helper and one marked line, leaving any hook you wrote.",
+    notes: [
+      "An existing pre-commit or commit-msg hook keeps its content and its exit status: one marked line goes in after the shebang and falls through to what was already there.",
+      "Both hooks block on any nonzero verdict and fail closed on a guard that could not run.",
+    ],
+    companions: ["tests", "size-ratchet"],
+  };
   return {
-    declared: {
-      name: "guard",
-      root: `${root}/.agents/skills/guard`,
-      summary:
-        "Arms git pre-commit and commit-msg hooks, so every commit in this repository runs the guard chain — for everyone who commits here, not only for kendex.",
-      writes: [
-        ".git/hooks/kendex-guards",
-        ".git/hooks/pre-commit",
-        ".git/hooks/commit-msg",
-      ],
-      installer: "scripts/install-git-hooks",
-      uninstaller: "scripts/install-git-hooks --uninstall",
-      removal:
-        "run the uninstaller before removing this package: it drops only the helper and one marked line, leaving any hook you wrote.",
-      notes: [
-        "An existing pre-commit or commit-msg hook keeps its content and its exit status: one marked line goes in after the shebang and falls through to what was already there.",
-        "Both hooks block on any nonzero verdict and fail closed on a guard that could not run.",
-      ],
-      companions: ["tests", "size-ratchet"],
-    },
+    declared,
+    name: declared.name,
+    summary: declared.summary,
+    notes: declared.notes,
+    removal: declared.removal,
     writes: [
       { path: `${root}/.git/hooks/kendex-guards`, shared: true },
       { path: `${root}/.git/hooks/pre-commit`, shared: true },

--- a/ui/src/dev/mock-install.ts
+++ b/ui/src/dev/mock-install.ts
@@ -169,7 +169,7 @@ function guardDisclosure(root: string, testsInstalled: boolean): Disclosure {
     name: declared.name,
     summary: declared.summary,
     notes: declared.notes,
-    removal: declared.removal,
+    undo: "run `'.agents/skills/guard/scripts/install-git-hooks' '--uninstall'` from the repository root",
     writes: [
       { path: `${root}/.git/hooks/kendex-guards`, shared: true },
       { path: `${root}/.git/hooks/pre-commit`, shared: true },

--- a/ui/src/dev/mock-install.ts
+++ b/ui/src/dev/mock-install.ts
@@ -1,6 +1,12 @@
 // Installing from a subscription: a bundle or loose items, optionally
 // redirected into a project that gains the subscription on the way.
-import type { HarnessId, InstallItem, ItemKind, Scope } from "@/bindings";
+import type {
+  Disclosure,
+  HarnessId,
+  InstallItem,
+  ItemKind,
+  Scope,
+} from "@/bindings";
 import { BUNDLE_SPECS } from "./fixture-catalog";
 import { packagesKey } from "./fixture-marketplaces";
 import { marketplaceRow, offeredHere } from "./mock-catalog";
@@ -114,6 +120,57 @@ export const installHandlers: Record<string, Handler> = {
       }
       pkg.state = "installed";
     }
-    return offered;
+    // The mock catalog's guard package declares what it does to the
+    // repository, so the dev app asks the second question for it — and,
+    // installed into a project, answers which companion is already here.
+    const shown = wanted
+      .filter((want) => want.name === "guard")
+      .map(() =>
+        guardDisclosure(
+          target.scope === "project" ? target.root : "/home/me",
+          offered.some((p) => p.name === "tests" && p.state === "installed"),
+        ),
+      );
+    return { packages: offered, repoEffects: { shown, withheld: [] } };
+  },
+  repo_effects_apply: ({ declared }: { declared: Disclosure["declared"] }) => {
+    if (declared.installer === null) {
+      return Promise.reject(`${declared.name} declares nothing kendex can run`);
+    }
+    return null;
   },
 };
+
+function guardDisclosure(root: string, testsInstalled: boolean): Disclosure {
+  return {
+    declared: {
+      name: "guard",
+      root: `${root}/.agents/skills/guard`,
+      summary:
+        "Arms git pre-commit and commit-msg hooks, so every commit in this repository runs the guard chain — for everyone who commits here, not only for kendex.",
+      writes: [
+        ".git/hooks/kendex-guards",
+        ".git/hooks/pre-commit",
+        ".git/hooks/commit-msg",
+      ],
+      installer: "scripts/install-git-hooks",
+      uninstaller: "scripts/install-git-hooks --uninstall",
+      removal:
+        "run the uninstaller before removing this package: it drops only the helper and one marked line, leaving any hook you wrote.",
+      notes: [
+        "An existing pre-commit or commit-msg hook keeps its content and its exit status: one marked line goes in after the shebang and falls through to what was already there.",
+        "Both hooks block on any nonzero verdict and fail closed on a guard that could not run.",
+      ],
+      companions: ["tests", "size-ratchet"],
+    },
+    writes: [
+      { path: `${root}/.git/hooks/kendex-guards`, shared: true },
+      { path: `${root}/.git/hooks/pre-commit`, shared: true },
+      { path: `${root}/.git/hooks/commit-msg`, shared: true },
+    ],
+    companions: [
+      { name: "tests", installed: testsInstalled },
+      { name: "size-ratchet", installed: false },
+    ],
+  };
+}

--- a/ui/src/dev/mock-install.ts
+++ b/ui/src/dev/mock-install.ts
@@ -137,9 +137,12 @@ export const installHandlers: Record<string, Handler> = {
     if (declared.installer === null) {
       return Promise.reject(`${declared.name} declares nothing kendex can run`);
     }
-    return [
-      "growth-guards git hooks: pre-commit and commit-msg armed in .git/hooks",
-    ];
+    return {
+      stdout: [
+        "growth-guards git hooks: pre-commit and commit-msg armed in .git/hooks",
+      ],
+      stderr: [],
+    };
   },
 };
 

--- a/ui/src/dev/mock-sources.ts
+++ b/ui/src/dev/mock-sources.ts
@@ -75,7 +75,10 @@ export const sourceHandlers: Record<string, Handler> = {
     );
     if (!row) return Promise.reject(`no bundle named '${name}' here`);
     row.installed = true;
-    return store.state.bundles;
+    return {
+      bundles: store.state.bundles,
+      repoEffects: { shown: [], withheld: [] },
+    };
   },
   sources_refresh: () => {
     for (const row of store.state.sources) {

--- a/ui/src/lib/copy-repo-effects.ts
+++ b/ui/src/lib/copy-repo-effects.ts
@@ -1,0 +1,35 @@
+// Repository-effects copy: the block a person reads before a package
+// changes how their repository works, and the two answers. Kept in one
+// place so the wording is reviewed beside the terminal's, which says the
+// same things in the same order.
+
+export const repoEffectsTitle = (name: string) =>
+  `${name} changes how this repository works`;
+
+/** Under the title: the files are in, the effect is what waits. */
+export const REPO_EFFECTS_STANDING =
+  "The package's own files are installed. This is the part removing it does not undo, and it waits for your yes.";
+
+export const REPO_EFFECTS_WRITES_LABEL = "Writes";
+export const REPO_EFFECTS_SHARED_NOTE =
+  "That directory belongs to the repository, not this checkout: every work tree shares these files.";
+export const REPO_EFFECTS_COMPANIONS_LABEL = "Companion packages";
+export const COMPANION_INSTALLED = "installed";
+export const COMPANION_NOT_INSTALLED = "not installed";
+export const REPO_EFFECTS_UNDO_LABEL = "To undo";
+export const REPO_EFFECTS_NO_REMOVAL =
+  "The package declares no removal instructions.";
+
+export const REPO_EFFECTS_APPLY_LABEL = "Apply repository changes";
+export const REPO_EFFECTS_DECLINE_LABEL = "Not now";
+/** A declaration with no installer: nothing for kendex to run. */
+export const REPO_EFFECTS_NOTHING_TO_RUN =
+  "kendex has nothing to run for this. Arm it yourself when you are ready.";
+export const REPO_EFFECTS_DONE_LABEL = "Done";
+
+export const repoEffectsAppliedToast = (name: string) =>
+  `Applied ${name}'s repository changes`;
+export const repoEffectsDeclinedToast = (name: string) =>
+  `${name} is installed; its repository changes were not applied`;
+export const repoEffectsWithheldToast = (name: string, reason: string) =>
+  `${name} is installed but its repository changes were not disclosed: ${reason}`;

--- a/ui/src/lib/copy-repo-effects.ts
+++ b/ui/src/lib/copy-repo-effects.ts
@@ -27,8 +27,12 @@ export const REPO_EFFECTS_NOTHING_TO_RUN =
   "kendex has nothing to run for this. Arm it yourself when you are ready.";
 export const REPO_EFFECTS_DONE_LABEL = "Done";
 
+/** Shown only when the installer said nothing itself; its own last line
+ * is preferred, so a deliberate skip reads as a skip. */
 export const repoEffectsAppliedToast = (name: string) =>
   `Applied ${name}'s repository changes`;
+export const repoEffectsFailedTitle = (name: string) =>
+  `${name}'s repository changes failed`;
 export const repoEffectsDeclinedToast = (name: string) =>
   `${name} is installed; its repository changes were not applied`;
 export const repoEffectsWithheldToast = (name: string, reason: string) =>

--- a/ui/src/lib/copy-repo-effects.ts
+++ b/ui/src/lib/copy-repo-effects.ts
@@ -35,6 +35,10 @@ export const repoEffectsAppliedToast = (name: string) =>
   `Applied ${name}'s repository changes`;
 export const repoEffectsFailedTitle = (name: string) =>
   `${name}'s repository changes failed`;
+/** A clean exit with something on stderr: the installer skipped its work,
+ * or did it with a caveat, and said so on the channel a toast drops. */
+export const repoEffectsSaidTitle = (name: string) =>
+  `What ${name}'s installer said`;
 export const repoEffectsDeclinedToast = (name: string) =>
   `${name} is installed; its repository changes were not applied`;
 export const repoEffectsWithheldToast = (name: string, reason: string) =>

--- a/ui/src/lib/copy-repo-effects.ts
+++ b/ui/src/lib/copy-repo-effects.ts
@@ -11,14 +11,16 @@ export const REPO_EFFECTS_STANDING =
   "The package's own files are installed. This is the part removing it does not undo, and it waits for your yes.";
 
 export const REPO_EFFECTS_WRITES_LABEL = "Writes";
+/** Marks one written path, so a package writing both into `.git` and into
+ * the checkout does not have the first claimed about the second. */
+export const REPO_EFFECTS_SHARED_MARK = "shared";
 export const REPO_EFFECTS_SHARED_NOTE =
-  "That directory belongs to the repository, not this checkout: every work tree shares these files.";
+  "The paths marked shared belong to the repository, not this checkout: every work tree sees those files.";
 export const REPO_EFFECTS_COMPANIONS_LABEL = "Companion packages";
 export const COMPANION_INSTALLED = "installed";
 export const COMPANION_NOT_INSTALLED = "not installed";
 export const REPO_EFFECTS_UNDO_LABEL = "To undo";
-export const REPO_EFFECTS_NO_REMOVAL =
-  "The package declares no removal instructions.";
+export const REPO_EFFECTS_NO_UNDO = "The package declares no way to undo it.";
 
 export const REPO_EFFECTS_APPLY_LABEL = "Apply repository changes";
 export const REPO_EFFECTS_DECLINE_LABEL = "Not now";

--- a/ui/src/stores/marketplaces-install.test.ts
+++ b/ui/src/stores/marketplaces-install.test.ts
@@ -8,6 +8,7 @@ import {
   repoEffectsAppliedToast,
   repoEffectsDeclinedToast,
   repoEffectsFailedTitle,
+  repoEffectsSaidTitle,
   repoEffectsWithheldToast,
 } from "@/lib/copy-repo-effects";
 import { useMarketplacesStore } from "./marketplaces";
@@ -103,6 +104,9 @@ describe("what an install leaves waiting", () => {
 
 describe("answering", () => {
   beforeEach(() => {
+    // The dialog is module state: a case that asserts none opened has to
+    // start from none open.
+    useProblemsStore.getState().closeError();
     useMarketplacesStore.setState({
       pendingEffects: {
         scope: PROJECT,
@@ -115,7 +119,10 @@ describe("answering", () => {
     const { toast } = await import("sonner");
     vi.mocked(commands.repoEffectsApply).mockResolvedValue({
       status: "ok",
-      data: ["writing helper", "hooks: skipped — core.hooksPath is set"],
+      data: {
+        stdout: ["writing helper", "hooks: skipped — core.hooksPath is set"],
+        stderr: [],
+      },
     });
     expect(await useMarketplacesStore.getState().applyRepoEffect()).toBe(true);
     expect(commands.repoEffectsApply).toHaveBeenCalledWith(
@@ -136,7 +143,7 @@ describe("answering", () => {
     const { toast } = await import("sonner");
     vi.mocked(commands.repoEffectsApply).mockResolvedValue({
       status: "ok",
-      data: [],
+      data: { stdout: [], stderr: [] },
     });
     await useMarketplacesStore.getState().applyRepoEffect();
     expect(toast.success).toHaveBeenCalledWith(
@@ -148,7 +155,7 @@ describe("answering", () => {
     const { toast } = await import("sonner");
     vi.mocked(commands.repoEffectsApply).mockResolvedValue({
       status: "ok",
-      data: ["hooks armed", "", "  "],
+      data: { stdout: ["hooks armed", "", "  "], stderr: [] },
     });
     await useMarketplacesStore.getState().applyRepoEffect();
     expect(toast.success).toHaveBeenCalledWith("hooks armed");
@@ -158,12 +165,41 @@ describe("answering", () => {
     const { toast } = await import("sonner");
     vi.mocked(commands.repoEffectsApply).mockResolvedValue({
       status: "ok",
-      data: ["", ""],
+      data: { stdout: ["", ""], stderr: [] },
     });
     await useMarketplacesStore.getState().applyRepoEffect();
     expect(toast.success).toHaveBeenCalledWith(
       repoEffectsAppliedToast("guards"),
     );
+  });
+
+  it("a clean exit with something on stderr still reaches the person", async () => {
+    const { toast } = await import("sonner");
+    vi.mocked(commands.repoEffectsApply).mockResolvedValue({
+      status: "ok",
+      data: {
+        stdout: ["hooks: skipped"],
+        stderr: ["core.hooksPath is set", "unset it and run this again"],
+      },
+    });
+    expect(await useMarketplacesStore.getState().applyRepoEffect()).toBe(true);
+    // The summary is the headline; the remedy is the part a toast drops.
+    expect(toast.success).toHaveBeenCalledWith("hooks: skipped");
+    const { dialog } = useProblemsStore.getState();
+    expect(dialog.open).toBe(true);
+    expect(dialog.title).toBe(repoEffectsSaidTitle("guards"));
+    expect(dialog.message).toBe(
+      "core.hooksPath is set\nunset it and run this again\nhooks: skipped",
+    );
+  });
+
+  it("a clean exit with nothing on stderr opens no dialog", async () => {
+    vi.mocked(commands.repoEffectsApply).mockResolvedValue({
+      status: "ok",
+      data: { stdout: ["hooks armed"], stderr: ["", "  "] },
+    });
+    await useMarketplacesStore.getState().applyRepoEffect();
+    expect(useProblemsStore.getState().dialog.open).toBe(false);
   });
 
   it("a no runs nothing and says the package is installed unarmed", async () => {

--- a/ui/src/stores/marketplaces-install.test.ts
+++ b/ui/src/stores/marketplaces-install.test.ts
@@ -144,6 +144,28 @@ describe("answering", () => {
     );
   });
 
+  it("a trailing blank line is not the installer's last word", async () => {
+    const { toast } = await import("sonner");
+    vi.mocked(commands.repoEffectsApply).mockResolvedValue({
+      status: "ok",
+      data: ["hooks armed", "", "  "],
+    });
+    await useMarketplacesStore.getState().applyRepoEffect();
+    expect(toast.success).toHaveBeenCalledWith("hooks armed");
+  });
+
+  it("an installer that printed only blank lines gets the canned line", async () => {
+    const { toast } = await import("sonner");
+    vi.mocked(commands.repoEffectsApply).mockResolvedValue({
+      status: "ok",
+      data: ["", ""],
+    });
+    await useMarketplacesStore.getState().applyRepoEffect();
+    expect(toast.success).toHaveBeenCalledWith(
+      repoEffectsAppliedToast("guards"),
+    );
+  });
+
   it("a no runs nothing and says the package is installed unarmed", async () => {
     const { toast } = await import("sonner");
     useMarketplacesStore.getState().declineRepoEffect();

--- a/ui/src/stores/marketplaces-install.test.ts
+++ b/ui/src/stores/marketplaces-install.test.ts
@@ -1,0 +1,154 @@
+// An install can leave a second question behind — what a package does to
+// the repository — and the store is where that question lives: queued
+// from the install's answer, asked one package at a time, and spent on
+// the answer it gets.
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { commands, type Disclosure, type Scope } from "@/bindings";
+import {
+  repoEffectsAppliedToast,
+  repoEffectsDeclinedToast,
+  repoEffectsWithheldToast,
+} from "@/lib/copy-repo-effects";
+import { useMarketplacesStore } from "./marketplaces";
+
+vi.mock("@/bindings", () => ({
+  commands: {
+    marketplaceInstall: vi.fn(),
+    repoEffectsApply: vi.fn(),
+  },
+}));
+vi.mock("sonner", () => ({
+  toast: { success: vi.fn(), info: vi.fn(), error: vi.fn() },
+}));
+vi.mock("./audit", () => ({
+  useAuditStore: { getState: () => ({ refresh: vi.fn() }) },
+}));
+vi.mock("./scan", () => ({
+  useScanStore: { getState: () => ({ refresh: vi.fn() }) },
+}));
+
+const PROJECT: Scope = { scope: "project", root: "/home/me/app" };
+
+const disclosure = (name: string): Disclosure => ({
+  declared: {
+    name,
+    root: `/home/me/app/.agents/skills/${name}`,
+    summary: `${name} arms hooks`,
+    writes: [".git/hooks/pre-commit"],
+    installer: "scripts/arm",
+    uninstaller: null,
+    removal: null,
+    notes: [],
+    companions: [],
+  },
+  writes: [{ path: "/home/me/app/.git/hooks/pre-commit", shared: true }],
+  companions: [],
+});
+
+const installed = (shown: Disclosure[], withheld = []) => ({
+  status: "ok" as const,
+  data: { packages: [], repoEffects: { shown, withheld } },
+});
+
+const install = (destination?: Scope) =>
+  useMarketplacesStore.getState().install({
+    scope: { scope: "global" },
+    source: "cat",
+    items: [{ kind: "skill", name: "guards" }],
+    destination,
+  });
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  useMarketplacesStore.setState({ pendingEffects: null, busy: false });
+});
+
+describe("what an install leaves waiting", () => {
+  it("queues the effects against the scope the files landed in", async () => {
+    vi.mocked(commands.marketplaceInstall).mockResolvedValue(
+      installed([disclosure("guards")]),
+    );
+    await install(PROJECT);
+    expect(useMarketplacesStore.getState().pendingEffects).toEqual({
+      scope: PROJECT,
+      queue: [disclosure("guards")],
+    });
+  });
+
+  it("asks nothing for a package that declares nothing", async () => {
+    vi.mocked(commands.marketplaceInstall).mockResolvedValue(installed([]));
+    await install();
+    expect(useMarketplacesStore.getState().pendingEffects).toBeNull();
+  });
+
+  it("says which package could not be disclosed, and why", async () => {
+    const { toast } = await import("sonner");
+    vi.mocked(commands.marketplaceInstall).mockResolvedValue(
+      installed([], [{ name: "guards", reason: "no git directory" }] as never),
+    );
+    await install();
+    expect(toast.info).toHaveBeenCalledWith(
+      repoEffectsWithheldToast("guards", "no git directory"),
+    );
+    expect(useMarketplacesStore.getState().pendingEffects).toBeNull();
+  });
+});
+
+describe("answering", () => {
+  beforeEach(() => {
+    useMarketplacesStore.setState({
+      pendingEffects: {
+        scope: PROJECT,
+        queue: [disclosure("guards"), disclosure("linter")],
+      },
+    });
+  });
+
+  it("a yes runs the declaration that was shown, in that scope, and moves on", async () => {
+    const { toast } = await import("sonner");
+    vi.mocked(commands.repoEffectsApply).mockResolvedValue({
+      status: "ok",
+      data: null,
+    });
+    expect(await useMarketplacesStore.getState().applyRepoEffect()).toBe(true);
+    expect(commands.repoEffectsApply).toHaveBeenCalledWith(
+      PROJECT,
+      disclosure("guards").declared,
+    );
+    expect(toast.success).toHaveBeenCalledWith(
+      repoEffectsAppliedToast("guards"),
+    );
+    expect(useMarketplacesStore.getState().pendingEffects?.queue).toEqual([
+      disclosure("linter"),
+    ]);
+  });
+
+  it("a no runs nothing and says the package is installed unarmed", async () => {
+    const { toast } = await import("sonner");
+    useMarketplacesStore.getState().declineRepoEffect();
+    expect(commands.repoEffectsApply).not.toHaveBeenCalled();
+    expect(toast.info).toHaveBeenCalledWith(repoEffectsDeclinedToast("guards"));
+    expect(useMarketplacesStore.getState().pendingEffects?.queue).toEqual([
+      disclosure("linter"),
+    ]);
+  });
+
+  it("the last answer closes the question", () => {
+    useMarketplacesStore.getState().declineRepoEffect();
+    useMarketplacesStore.getState().declineRepoEffect();
+    expect(useMarketplacesStore.getState().pendingEffects).toBeNull();
+  });
+
+  it("a failed installer is reported and the line still moves on", async () => {
+    const { toast } = await import("sonner");
+    vi.mocked(commands.repoEffectsApply).mockResolvedValue({
+      status: "error",
+      error: "scripts/arm exited 1",
+    });
+    expect(await useMarketplacesStore.getState().applyRepoEffect()).toBe(false);
+    expect(toast.error).toHaveBeenCalledWith("scripts/arm exited 1");
+    expect(useMarketplacesStore.getState().pendingEffects?.queue).toEqual([
+      disclosure("linter"),
+    ]);
+  });
+});

--- a/ui/src/stores/marketplaces-install.test.ts
+++ b/ui/src/stores/marketplaces-install.test.ts
@@ -7,9 +7,11 @@ import { commands, type Disclosure, type Scope } from "@/bindings";
 import {
   repoEffectsAppliedToast,
   repoEffectsDeclinedToast,
+  repoEffectsFailedTitle,
   repoEffectsWithheldToast,
 } from "@/lib/copy-repo-effects";
 import { useMarketplacesStore } from "./marketplaces";
+import { useProblemsStore } from "./problems";
 
 vi.mock("@/bindings", () => ({
   commands: {
@@ -41,8 +43,12 @@ const disclosure = (name: string): Disclosure => ({
     notes: [],
     companions: [],
   },
+  name,
+  summary: `${name} arms hooks`,
   writes: [{ path: "/home/me/app/.git/hooks/pre-commit", shared: true }],
   companions: [],
+  notes: [],
+  removal: null,
 });
 
 const installed = (shown: Disclosure[], withheld = []) => ({
@@ -61,6 +67,7 @@ const install = (destination?: Scope) =>
 beforeEach(() => {
   vi.clearAllMocks();
   useMarketplacesStore.setState({ pendingEffects: null, busy: false });
+  useProblemsStore.getState().closeError();
 });
 
 describe("what an install leaves waiting", () => {
@@ -104,23 +111,37 @@ describe("answering", () => {
     });
   });
 
-  it("a yes runs the declaration that was shown, in that scope, and moves on", async () => {
+  it("a yes runs the declaration that was shown, in that scope, and shows the installer's own last word", async () => {
     const { toast } = await import("sonner");
     vi.mocked(commands.repoEffectsApply).mockResolvedValue({
       status: "ok",
-      data: null,
+      data: ["writing helper", "hooks: skipped — core.hooksPath is set"],
     });
     expect(await useMarketplacesStore.getState().applyRepoEffect()).toBe(true);
     expect(commands.repoEffectsApply).toHaveBeenCalledWith(
       PROJECT,
       disclosure("guards").declared,
     );
+    // Not "Applied": the installer said it armed nothing, and that is
+    // what the person reads.
     expect(toast.success).toHaveBeenCalledWith(
-      repoEffectsAppliedToast("guards"),
+      "hooks: skipped — core.hooksPath is set",
     );
     expect(useMarketplacesStore.getState().pendingEffects?.queue).toEqual([
       disclosure("linter"),
     ]);
+  });
+
+  it("a silent installer gets the canned line", async () => {
+    const { toast } = await import("sonner");
+    vi.mocked(commands.repoEffectsApply).mockResolvedValue({
+      status: "ok",
+      data: [],
+    });
+    await useMarketplacesStore.getState().applyRepoEffect();
+    expect(toast.success).toHaveBeenCalledWith(
+      repoEffectsAppliedToast("guards"),
+    );
   });
 
   it("a no runs nothing and says the package is installed unarmed", async () => {
@@ -139,14 +160,20 @@ describe("answering", () => {
     expect(useMarketplacesStore.getState().pendingEffects).toBeNull();
   });
 
-  it("a failed installer is reported and the line still moves on", async () => {
+  it("a failed installer opens the error dialog with the whole account, and the line still moves on", async () => {
     const { toast } = await import("sonner");
+    const account =
+      "guards: scripts/arm exited 1 — anything it wrote before that is still there; the package declares no way to undo it\ncould not write hooks";
     vi.mocked(commands.repoEffectsApply).mockResolvedValue({
       status: "error",
-      error: "scripts/arm exited 1",
+      error: account,
     });
     expect(await useMarketplacesStore.getState().applyRepoEffect()).toBe(false);
-    expect(toast.error).toHaveBeenCalledWith("scripts/arm exited 1");
+    expect(toast.error).not.toHaveBeenCalled();
+    const { dialog } = useProblemsStore.getState();
+    expect(dialog.open).toBe(true);
+    expect(dialog.title).toBe(repoEffectsFailedTitle("guards"));
+    expect(dialog.message).toBe(account);
     expect(useMarketplacesStore.getState().pendingEffects?.queue).toEqual([
       disclosure("linter"),
     ]);

--- a/ui/src/stores/marketplaces-install.test.ts
+++ b/ui/src/stores/marketplaces-install.test.ts
@@ -48,7 +48,7 @@ const disclosure = (name: string): Disclosure => ({
   writes: [{ path: "/home/me/app/.git/hooks/pre-commit", shared: true }],
   companions: [],
   notes: [],
-  removal: null,
+  undo: null,
 });
 
 const installed = (shown: Disclosure[], withheld = []) => ({

--- a/ui/src/stores/marketplaces-install.ts
+++ b/ui/src/stores/marketplaces-install.ts
@@ -15,6 +15,7 @@ import {
   repoEffectsAppliedToast,
   repoEffectsDeclinedToast,
   repoEffectsFailedTitle,
+  repoEffectsSaidTitle,
   repoEffectsWithheldToast,
 } from "@/lib/copy-repo-effects";
 import {
@@ -69,6 +70,10 @@ export interface InstallActions {
 
 type Set = (partial: object | ((state: Installed) => object)) => void;
 type Get = () => { pendingEffects: PendingEffects | null };
+
+/** The last line with anything in it, or nothing said at all. */
+const spoken = (lines: string[]) =>
+  lines.filter((line) => line.trim() !== "").at(-1);
 
 export function installActions(set: Set, get: Get): InstallActions {
   /** Take the package at the head of the line off it, closing the dialog
@@ -171,10 +176,21 @@ export function installActions(set: Set, get: Get): InstallActions {
         return false;
       }
       advance();
+      const { stdout, stderr } = response.data;
       // The last line it printed, not the last element: relay keeps the
       // installer's trailing blank lines, and an empty toast says nothing.
-      const said = response.data.filter((line) => line.trim() !== "").at(-1);
-      toast.success(said ?? repoEffectsAppliedToast(head.name));
+      const summary = spoken(stdout) ?? spoken(stderr);
+      toast.success(summary ?? repoEffectsAppliedToast(head.name));
+      // An installer can exit clean and still have skipped its work — the
+      // reason, and what to do about it, go to stderr while the summary
+      // goes to stdout. A toast is one line, so the account a person has
+      // to act on gets the dialog the app opens for exactly that.
+      if (spoken(stderr) !== undefined) {
+        useProblemsStore.getState().showError({
+          title: repoEffectsSaidTitle(head.name),
+          message: [...stderr, ...stdout].join("\n"),
+        });
+      }
       return true;
     },
 

--- a/ui/src/stores/marketplaces-install.ts
+++ b/ui/src/stores/marketplaces-install.ts
@@ -1,14 +1,21 @@
 // Installing from a subscription: the one action that writes packages into
 // a scope, kept beside the store so the store body stays the subscription
-// lifecycle.
+// lifecycle — and the second question an install can leave behind, about
+// what a package does to the repository.
 import { toast } from "sonner";
 import type {
   AvailablePackage,
+  Disclosure,
   HarnessId,
   InstallItem,
   Scope,
 } from "@/bindings";
 import { commands } from "@/bindings";
+import {
+  repoEffectsAppliedToast,
+  repoEffectsDeclinedToast,
+  repoEffectsWithheldToast,
+} from "@/lib/copy-repo-effects";
 import {
   catalogKey,
   refreshDownstream,
@@ -32,15 +39,50 @@ export interface InstallRequest {
   };
 }
 
+/** The repository effects an install brought, waiting on their own yes:
+ * the scope they would change, and the packages still to be asked about,
+ * first in line first. Each one is asked on its own and answered on its
+ * own, and the answer is spent there — nothing stores it. */
+export interface PendingEffects {
+  scope: Scope;
+  queue: Disclosure[];
+}
+
 /** What this action writes back into the store. */
 interface Installed {
   packages: Record<string, AvailablePackage[]>;
+  pendingEffects: PendingEffects | null;
+}
+
+/** The install half of the marketplaces store: the write, and the second
+ * question it can leave behind. */
+export interface InstallActions {
+  install: (request: InstallRequest) => Promise<boolean>;
+  /** The repository effects the last install left waiting on a yes, or
+   * null — what the effects dialog reads. */
+  pendingEffects: PendingEffects | null;
+  applyRepoEffect: () => Promise<boolean>;
+  declineRepoEffect: () => void;
 }
 
 type Set = (partial: object | ((state: Installed) => object)) => void;
+type Get = () => { pendingEffects: PendingEffects | null };
 
-export function installActions(set: Set) {
+export function installActions(set: Set, get: Get): InstallActions {
+  /** Take the package at the head of the line off it, closing the dialog
+   *  when nobody is left. */
+  const advance = () => {
+    const pending = get().pendingEffects;
+    if (!pending) return;
+    const queue = pending.queue.slice(1);
+    set({
+      pendingEffects: queue.length > 0 ? { ...pending, queue } : null,
+    });
+  };
+
   return {
+    pendingEffects: null,
+
     install: async ({
       scope,
       source,
@@ -69,14 +111,20 @@ export function installActions(set: Set) {
         toast.error(response.error);
         return false;
       }
+      const target = destination ?? scope;
       // The command answers with the refreshed package list for this
       // subscription, so the table flips to Installed without a second query.
-      const key = catalogKey(subscription(destination ?? scope, source));
+      const key = catalogKey(subscription(target, source));
+      const { shown, withheld } = response.data.repoEffects;
       set((state) => ({
-        packages: { ...state.packages, [key]: response.data },
+        packages: { ...state.packages, [key]: response.data.packages },
         // Member states in every open set moved with this install.
         bundles: {},
         error: null,
+        // The files are in; what a package does to the repository is a
+        // second question, asked once the install is reported.
+        pendingEffects:
+          shown.length > 0 ? { scope: target, queue: shown } : null,
       }));
       const what = bundle
         ? `the ${bundle} bundle`
@@ -84,8 +132,46 @@ export function installActions(set: Set) {
           ? items[0].name
           : `${items.length} packages`;
       toast.success(`Installed ${what}`);
+      for (const held of withheld) {
+        toast.info(repoEffectsWithheldToast(held.name, held.reason));
+      }
       await refreshDownstream();
       return true;
+    },
+
+    /** Run the installer of the package at the head of the line, here and
+     *  now. A failure is reported and the line moves on: the package stays
+     *  installed either way, and the declaration says where to look. */
+    applyRepoEffect: async () => {
+      const pending = get().pendingEffects;
+      if (!pending) return false;
+      const [head] = pending.queue;
+      set({ busy: true });
+      let response: Awaited<ReturnType<typeof commands.repoEffectsApply>>;
+      try {
+        response = await commands.repoEffectsApply(
+          pending.scope,
+          head.declared,
+        );
+      } finally {
+        set({ busy: false });
+      }
+      advance();
+      if (response.status === "error") {
+        toast.error(response.error);
+        return false;
+      }
+      toast.success(repoEffectsAppliedToast(head.declared.name));
+      return true;
+    },
+
+    /** Leave the package installed and its effect unapplied — a state,
+     *  not a failure. */
+    declineRepoEffect: () => {
+      const pending = get().pendingEffects;
+      if (!pending) return;
+      toast.info(repoEffectsDeclinedToast(pending.queue[0].declared.name));
+      advance();
     },
   };
 }

--- a/ui/src/stores/marketplaces-install.ts
+++ b/ui/src/stores/marketplaces-install.ts
@@ -171,7 +171,10 @@ export function installActions(set: Set, get: Get): InstallActions {
         return false;
       }
       advance();
-      toast.success(response.data.at(-1) ?? repoEffectsAppliedToast(head.name));
+      // The last line it printed, not the last element: relay keeps the
+      // installer's trailing blank lines, and an empty toast says nothing.
+      const said = response.data.filter((line) => line.trim() !== "").at(-1);
+      toast.success(said ?? repoEffectsAppliedToast(head.name));
       return true;
     },
 

--- a/ui/src/stores/marketplaces-install.ts
+++ b/ui/src/stores/marketplaces-install.ts
@@ -14,6 +14,7 @@ import { commands } from "@/bindings";
 import {
   repoEffectsAppliedToast,
   repoEffectsDeclinedToast,
+  repoEffectsFailedTitle,
   repoEffectsWithheldToast,
 } from "@/lib/copy-repo-effects";
 import {
@@ -21,6 +22,7 @@ import {
   refreshDownstream,
   subscription,
 } from "./marketplaces-shared";
+import { useProblemsStore } from "./problems";
 
 /** One install: what to put where, and — when the picker was used — which
  * tools it lands on and how the files get there. Each half of `delivery` is
@@ -140,8 +142,12 @@ export function installActions(set: Set, get: Get): InstallActions {
     },
 
     /** Run the installer of the package at the head of the line, here and
-     *  now. A failure is reported and the line moves on: the package stays
-     *  installed either way, and the declaration says where to look. */
+     *  now, and show its own last word: an installer that deliberately
+     *  armed nothing says so and exits clean, and a canned "Applied" over
+     *  it would tell the person the repository is armed when it is not.
+     *  A failure is the one account of a possibly half-written repository,
+     *  so it opens the error dialog rather than flashing past in a toast;
+     *  the line moves on either way, the package staying installed. */
     applyRepoEffect: async () => {
       const pending = get().pendingEffects;
       if (!pending) return false;
@@ -156,12 +162,16 @@ export function installActions(set: Set, get: Get): InstallActions {
       } finally {
         set({ busy: false });
       }
-      advance();
       if (response.status === "error") {
-        toast.error(response.error);
+        useProblemsStore.getState().showError({
+          title: repoEffectsFailedTitle(head.name),
+          message: response.error,
+        });
+        advance();
         return false;
       }
-      toast.success(repoEffectsAppliedToast(head.declared.name));
+      advance();
+      toast.success(response.data.at(-1) ?? repoEffectsAppliedToast(head.name));
       return true;
     },
 
@@ -170,7 +180,7 @@ export function installActions(set: Set, get: Get): InstallActions {
     declineRepoEffect: () => {
       const pending = get().pendingEffects;
       if (!pending) return;
-      toast.info(repoEffectsDeclinedToast(pending.queue[0].declared.name));
+      toast.info(repoEffectsDeclinedToast(pending.queue[0].name));
       advance();
     },
   };

--- a/ui/src/stores/marketplaces.ts
+++ b/ui/src/stores/marketplaces.ts
@@ -13,7 +13,7 @@ import {
 import { MARKETPLACES_NEEDS_CHECK_NOTE } from "@/lib/copy-marketplaces";
 import { settled } from "@/lib/settled";
 import { landings } from "./landings";
-import { type InstallRequest, installActions } from "./marketplaces-install";
+import { type InstallActions, installActions } from "./marketplaces-install";
 import {
   bundleKey,
   catalogKey,
@@ -116,7 +116,7 @@ async function settle<F extends Exclude<keyof ReadCaches, "readErrors">>(
   }
 }
 
-interface MarketplacesState {
+interface MarketplacesState extends InstallActions {
   rows: MarketplaceRow[];
   /** Each opened catalog's offered packages, by [catalogKey]. */
   packages: Record<string, AvailablePackage[]>;
@@ -160,7 +160,6 @@ interface MarketplacesState {
   ) => Promise<boolean>;
   toggle: (scope: Scope, source: string, enabled: boolean) => Promise<void>;
   checkForUpdates: () => Promise<void>;
-  install: (request: InstallRequest) => Promise<boolean>;
 }
 
 // Overview reads overlap — Home's mount-time load against the page's own,
@@ -279,5 +278,5 @@ export const useMarketplacesStore = create<MarketplacesState>((set, get) => ({
   },
 
   ...sourceActions(set, get),
-  ...installActions(set),
+  ...installActions(set, get),
 }));


### PR DESCRIPTION
## Summary

- The desktop's two install routes and `kendex apply` now disclose what a package does to the repository and take their own separate yes, the way `kendex add` has since #1674.
- Core settles every fact the disclosure states — where a declared path lands, whether every work tree shares it, which companions are installed, and the display-safe text — so the terminal and the window cannot disagree.
- Declining installs the package unarmed, and the yes is spent on the run that gave it.

## Context

`#1674` shipped the terminal half of KEN-663's install-time walkthrough. The desktop did neither half: `marketplace_install` and the bundle install called `apply::execute` and dropped `report.repo_effects`, so installing growth-guards from the window wrote the package and said nothing about what it does to every commit in the repository.

Nothing was armed without consent — the app never ran an effect script, which is the safe half of being wrong. What was missing is the disclosure, and with it the offer.

The install now hands the window what to read, and a second command runs the effect once the window has a yes.

```
┌─ install ─────────────┐        ┌─ RepoEffectsDialog ─────┐
│ plan + write files    │  ───▶  │ what changes            │
│ report.repo_effects   │ offers │ what it writes (shared) │
└───────────────────────┘        │ companions, present?    │
                                 │ how to undo it          │
                                 └───────┬─────────────────┘
                                  Not now │ Apply
                                          ▼
                                 repo_effects_apply → core arm()
```

Nothing between the two commands is written down, so a refresh arms nothing and a repository someone disarmed stays disarmed. One dialog per package, each with its own yes. Declining, or closing the dialog, leaves the package installed and the repository as it was. A package that declares no installer gets no button promising to run one.

Both app routes carry it, marketplace and bundle installs, and so does `kendex apply` for a package declared by hand in `kendex.toml`, with `--allow-repo-effects` meaning yes the way it does for `add`.

### Notes for review

`RepoEffects` drops `skip_serializing_if` so specta emits one TypeScript type rather than serialize and deserialize twins; nothing persists it.

`Disclosure` carries display fields produced once through `names::shown`, and the raw declaration rides beside them only to be handed back to the apply command. The CLI prints those fields verbatim.

Review rounds moved two judgments into core so neither surface re-answers them: `offers_for` (report to offers) and `arm` (run one declaration, and what a nonzero exit means). The failure message names the resolved uninstaller path, since a declared script is package-relative while the child's cwd is the repository.

`repo_effects::revoke` is still absent — removing an armed package leaves shims pointing at deleted scripts. That is KEN-674, and the frontmatter's `removal:` line says so plainly rather than promising a cleanup that does not happen.

## Completed Issues

- Closes KEN-688 - Desktop installs disclose a package's repository effects and ask for their own yes

## Created Issues

- KEN-711 - process_guard_env tests race on the hook they write — Project: Tech Debt & Bugs

## Test Plan

- `cargo test -p kendex-core repo_effects` — disclosure (path landing, shared flag, companion presence, withheld reason, display-safe text) and `arm` (nothing to run, nonzero exit and its undo line, clean exit carrying its lines)
- `cargo test -p kendex-app --test repo_effects` — against the real growth-guards installer: install leaves it unarmed, a companion already installed reads as present, the bundle route carries offers, and the separate yes arms the hooks
- `cargo test -p kendex-cli --test install_ux` — `add`, collection `add`, and `apply` disclosure and consent
- `vitest run` — the install store's queue and the dialog's Apply, decline, dismiss-as-decline, and busy guard
- `tools/guard` green on the rebased branch
