### PR TITLE
fix(KEN-641): stale opencode instruction rows leave with their files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,9 +52,9 @@ an outside contributor.
 
 ### Fixed
 
-- A refresh cuts opencode.json's `instructions` rows under the instructions
-  directory down to what it renders now, so a row for a file no refresh
-  renders anymore leaves with its file. Rows pointing elsewhere are untouched.
+- A refresh cuts opencode.json's `kendex-hook-` `instructions` rows down to
+  what it renders now, so a row kendex wrote leaves with its render. Every
+  other row is untouched; rows a pre-rename tool wrote are removed by hand once.
 
 - The `task-completed-check` hook counts untracked files as changes, and blocks
   on any nonzero clippy exit or a git that cannot say what changed. It passed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,10 @@ an outside contributor.
 
 ### Fixed
 
+- A refresh cuts opencode.json's `instructions` rows under the instructions
+  directory down to what it renders now, so a row for a file no refresh
+  renders anymore leaves with its file. Rows pointing elsewhere are untouched.
+
 - The `task-completed-check` hook counts untracked files as changes, and blocks
   on any nonzero clippy exit or a git that cannot say what changed. It passed
   all three before: a new-file-only task, a killed clippy, an unreadable repo.

--- a/crates/core/src/configedit/mod.rs
+++ b/crates/core/src/configedit/mod.rs
@@ -82,9 +82,10 @@ pub enum ConfigEdit {
         reference: String,
     },
     /// opencode.json: cut the `instructions[]` rows under `prefix` — the
-    /// directory kendex renders instruction files into — down to `keep`,
-    /// the rows the current pass renders. A row pointing anywhere else is
-    /// the person's and stays.
+    /// spelling every reference kendex renders starts with, directory and
+    /// filename marker both — down to `keep`, the rows the current pass
+    /// renders. A row not carrying that spelling is somebody else's and
+    /// stays, whoever put it in the directory.
     OpencodePruneInstructions {
         prefix: String,
         keep: Vec<String>,

--- a/crates/core/src/configedit/mod.rs
+++ b/crates/core/src/configedit/mod.rs
@@ -81,6 +81,14 @@ pub enum ConfigEdit {
     OpencodeRemoveInstruction {
         reference: String,
     },
+    /// opencode.json: cut the `instructions[]` rows under `prefix` — the
+    /// directory kendex renders instruction files into — down to `keep`,
+    /// the rows the current pass renders. A row pointing anywhere else is
+    /// the person's and stays.
+    OpencodePruneInstructions {
+        prefix: String,
+        keep: Vec<String>,
+    },
     /// codex config.toml: text-level `[features] hooks = true` merge that
     /// preserves comments and ordering.
     CodexEnableHooksFeature,
@@ -188,6 +196,19 @@ impl ConfigEdit {
             ConfigEdit::OpencodeRemoveInstruction { reference } => {
                 if let Some(list) = object.get_mut("instructions").and_then(Value::as_array_mut) {
                     list.retain(|v| v.as_str() != Some(reference));
+                    if list.is_empty() {
+                        object.shift_remove("instructions");
+                    }
+                }
+                Ok(())
+            }
+            ConfigEdit::OpencodePruneInstructions { prefix, keep } => {
+                if let Some(list) = object.get_mut("instructions").and_then(Value::as_array_mut) {
+                    list.retain(|v| {
+                        v.as_str().is_none_or(|row| {
+                            !row.starts_with(prefix) || keep.iter().any(|k| k == row)
+                        })
+                    });
                     if list.is_empty() {
                         object.shift_remove("instructions");
                     }

--- a/crates/core/src/configedit/tests.rs
+++ b/crates/core/src/configedit/tests.rs
@@ -71,23 +71,27 @@ fn opencode_instruction_and_codex_feature_edits() {
     assert_eq!(value["permission"]["bash"]["*"], "ask");
 
     let prune = ConfigEdit::OpencodePruneInstructions {
-        prefix: ".opencode/instructions/".into(),
+        prefix: ".opencode/instructions/kendex-hook-".into(),
         keep: vec![".opencode/instructions/kendex-hook-guard.md".into()],
     };
-    let doc = r#"{"instructions": [".opencode/instructions/kendex-hook-guard.md", ".opencode/instructions/vstack-hook-old.md", "AGENTS.md"]}"#;
+    let doc = r#"{"instructions": [".opencode/instructions/kendex-hook-guard.md", ".opencode/instructions/kendex-hook-old.md", ".opencode/instructions/my-notes.md", "AGENTS.md"]}"#;
     let pruned = prune.apply(doc).unwrap();
     assert_eq!(prune.apply(&pruned).unwrap(), pruned);
     let value: Value = serde_json::from_str(&pruned).unwrap();
     assert_eq!(
         value["instructions"],
-        serde_json::json!([".opencode/instructions/kendex-hook-guard.md", "AGENTS.md"]),
-        "rows under the render directory are cut to the render set; the person's stay"
+        serde_json::json!([
+            ".opencode/instructions/kendex-hook-guard.md",
+            ".opencode/instructions/my-notes.md",
+            "AGENTS.md"
+        ]),
+        "marker-named rows are cut to the render set; everything else stays"
     );
     let emptied = ConfigEdit::OpencodePruneInstructions {
-        prefix: ".opencode/instructions/".into(),
+        prefix: ".opencode/instructions/kendex-hook-".into(),
         keep: Vec::new(),
     }
-    .apply(r#"{"instructions": [".opencode/instructions/vstack-hook-old.md"]}"#)
+    .apply(r#"{"instructions": [".opencode/instructions/kendex-hook-old.md"]}"#)
     .unwrap();
     let value: Value = serde_json::from_str(&emptied).unwrap();
     assert!(

--- a/crates/core/src/configedit/tests.rs
+++ b/crates/core/src/configedit/tests.rs
@@ -70,6 +70,31 @@ fn opencode_instruction_and_codex_feature_edits() {
     assert_eq!(value["mcp"]["db"]["type"], "local");
     assert_eq!(value["permission"]["bash"]["*"], "ask");
 
+    let prune = ConfigEdit::OpencodePruneInstructions {
+        prefix: ".opencode/instructions/".into(),
+        keep: vec![".opencode/instructions/kendex-hook-guard.md".into()],
+    };
+    let doc = r#"{"instructions": [".opencode/instructions/kendex-hook-guard.md", ".opencode/instructions/vstack-hook-old.md", "AGENTS.md"]}"#;
+    let pruned = prune.apply(doc).unwrap();
+    assert_eq!(prune.apply(&pruned).unwrap(), pruned);
+    let value: Value = serde_json::from_str(&pruned).unwrap();
+    assert_eq!(
+        value["instructions"],
+        serde_json::json!([".opencode/instructions/kendex-hook-guard.md", "AGENTS.md"]),
+        "rows under the render directory are cut to the render set; the person's stay"
+    );
+    let emptied = ConfigEdit::OpencodePruneInstructions {
+        prefix: ".opencode/instructions/".into(),
+        keep: Vec::new(),
+    }
+    .apply(r#"{"instructions": [".opencode/instructions/vstack-hook-old.md"]}"#)
+    .unwrap();
+    let value: Value = serde_json::from_str(&emptied).unwrap();
+    assert!(
+        value.get("instructions").is_none(),
+        "an emptied array is a key the user never wrote"
+    );
+
     let toml = "# my config\nmodel = \"gpt\"\n\n[features]\nexperimental = true\n";
     let enabled = ConfigEdit::CodexEnableHooksFeature.apply(toml).unwrap();
     assert!(enabled.contains("# my config"));

--- a/crates/core/src/engine/mod.rs
+++ b/crates/core/src/engine/mod.rs
@@ -44,6 +44,7 @@ mod removal;
 mod scope_writes;
 mod scoring;
 mod set_change;
+mod stale;
 mod takeover;
 mod targets;
 mod tree_plan;
@@ -180,7 +181,7 @@ fn plan_scope_once(
             notes: &mut moved_notes,
         },
     )?;
-    removal::stale_emitted(lock, &new_lock, &mut guard, &mut ops)?;
+    stale::stale_emitted(lock, &new_lock, &mut guard, &mut ops)?;
 
     let refused_keys = plan_pass::plan_refusals(
         env,
@@ -214,6 +215,7 @@ fn plan_scope_once(
     // Written here and nowhere else: every entry this pass keeps is in
     // the record by now, the sweep's carry-forwards included.
     pi_hooks_move::record_finished(&mut new_lock, &moved_out);
+    stale::stale_instruction_rows(env, scope, lock, &new_lock, &mut config_edits)?;
     plan_config_edits(env, scope, config_edits, &mut ops)?;
     let set_changes = set_changes(scope, lock, &new_lock);
     let kept = kept_members(scope, lock, &new_lock, &options.uninstalled_bundles);

--- a/crates/core/src/engine/removal.rs
+++ b/crates/core/src/engine/removal.rs
@@ -164,64 +164,6 @@ impl TrashGuard {
     }
 }
 
-/// An earlier install of a still-declared item wrote somewhere this one will
-/// not: a codex command whose emitted name changed when a skill claimed it,
-/// a skill whose link a later layout no longer produces. What it left is
-/// ours and nobody wants it now — without this it stays on disk forever,
-/// offered by the tool under a name nobody declared, or absolute and
-/// committed.
-///
-/// Judged by the record this pass writes, not by what it rendered. An
-/// item held or refused carries its old record forward and plans no
-/// replacement, so the paths it recorded are still what runs; taking them
-/// off would leave the tool disconnected from a tree that stayed.
-pub(super) fn stale_emitted(
-    lock: &Lock,
-    new_lock: &Lock,
-    guard: &mut TrashGuard,
-    ops: &mut Vec<PlannedOp>,
-) -> Result<()> {
-    for (key, recorded) in &new_lock.entries {
-        let Some(entry) = lock.entries.get(key) else {
-            continue;
-        };
-        let Some(previous) = entry.emitted.as_ref() else {
-            continue;
-        };
-        let current = recorded.emitted.iter().flat_map(|e| e.paths.iter());
-        for path in &previous.paths {
-            if current.clone().any(|kept| kept == path) {
-                continue;
-            }
-            if !path.exists() && !path.is_symlink() {
-                continue;
-            }
-            // Bytes that cannot be proven ours stay put — a re-shaped
-            // artifact must not cost the user an edit they made under the
-            // old shape.
-            if !path.is_symlink()
-                && entry.rendered_hash.as_ref().is_none_or(|rendered| {
-                    crate::hash::hash_tree(path)
-                        .map(|disk| &disk != rendered)
-                        .unwrap_or(true)
-                })
-            {
-                continue;
-            }
-            let planned = trash(
-                format!(
-                    "Move {} {}'s old files to the trash",
-                    recorded.kind.name(),
-                    recorded.name
-                ),
-                path.clone(),
-            )?;
-            guard.extend(ops, [planned]);
-        }
-    }
-    Ok(())
-}
-
 #[allow(clippy::too_many_arguments)]
 pub(super) fn orphans(
     env: &Env,

--- a/crates/core/src/engine/stale.rs
+++ b/crates/core/src/engine/stale.rs
@@ -1,0 +1,134 @@
+//! What an earlier install left that the record this pass writes no longer
+//! accounts for: files under positions nothing renders anymore, and config
+//! rows pointing at them. Both sweeps judge by the new lock, never by what
+//! this pass happened to render.
+
+use crate::apply::PlannedOp;
+use crate::env::Env;
+use crate::error::Result;
+use crate::lock::{Lock, LockEntry};
+use crate::model::{ItemKind, Scope};
+
+use super::config_edits::ConfigEditPlan;
+use super::removal::{TrashGuard, trash};
+
+/// An earlier install of a still-declared item wrote somewhere this one will
+/// not: a codex command whose emitted name changed when a skill claimed it,
+/// a skill whose link a later layout no longer produces. What it left is
+/// ours and nobody wants it now — without this it stays on disk forever,
+/// offered by the tool under a name nobody declared, or absolute and
+/// committed.
+///
+/// Judged by the record this pass writes, not by what it rendered. An
+/// item held or refused carries its old record forward and plans no
+/// replacement, so the paths it recorded are still what runs; taking them
+/// off would leave the tool disconnected from a tree that stayed.
+pub(super) fn stale_emitted(
+    lock: &Lock,
+    new_lock: &Lock,
+    guard: &mut TrashGuard,
+    ops: &mut Vec<PlannedOp>,
+) -> Result<()> {
+    for (key, recorded) in &new_lock.entries {
+        let Some(entry) = lock.entries.get(key) else {
+            continue;
+        };
+        let Some(previous) = entry.emitted.as_ref() else {
+            continue;
+        };
+        let current = recorded.emitted.iter().flat_map(|e| e.paths.iter());
+        for path in &previous.paths {
+            if current.clone().any(|kept| kept == path) {
+                continue;
+            }
+            if !path.exists() && !path.is_symlink() {
+                continue;
+            }
+            // Bytes that cannot be proven ours stay put — a re-shaped
+            // artifact must not cost the user an edit they made under the
+            // old shape.
+            if !path.is_symlink()
+                && entry.rendered_hash.as_ref().is_none_or(|rendered| {
+                    crate::hash::hash_tree(path)
+                        .map(|disk| &disk != rendered)
+                        .unwrap_or(true)
+                })
+            {
+                continue;
+            }
+            let planned = trash(
+                format!(
+                    "Move {} {}'s old files to the trash",
+                    recorded.kind.name(),
+                    recorded.name
+                ),
+                path.clone(),
+            )?;
+            guard.extend(ops, [planned]);
+        }
+    }
+    Ok(())
+}
+
+/// The instructions rows in opencode's config that point into the
+/// directory kendex renders instruction files into, cut down to what the
+/// record this pass writes still renders — `stale_emitted` for rows
+/// instead of files. An entry-by-entry removal only finds rows a record
+/// leads to; a row an older render spelled differently, or one whose
+/// record a reinstall dropped, stays in the file forever, naming a file
+/// that is gone. Rows pointing anywhere else are the person's and stay.
+///
+/// Planned only where the lock — old or new — shows kendex registering
+/// instruction rows at this scope: a config kendex never wrote into holds
+/// nothing of ours to sweep. A config that cannot be read back is skipped,
+/// not failed: every registration into it already reports that conflict,
+/// and this sweep must not turn that row into a scope error.
+pub(super) fn stale_instruction_rows(
+    env: &Env,
+    scope: &Scope,
+    lock: &Lock,
+    new_lock: &Lock,
+    config_edits: &mut ConfigEditPlan,
+) -> Result<()> {
+    let opencode_hook = |entry: &&LockEntry| {
+        entry.kind == ItemKind::Hook && entry.harness == crate::model::HarnessId::Opencode
+    };
+    if !lock.entries.values().any(|e| opencode_hook(&e))
+        && !new_lock.entries.values().any(|e| opencode_hook(&e))
+    {
+        return Ok(());
+    }
+    let keep: Vec<String> = new_lock
+        .entries
+        .values()
+        .filter(opencode_hook)
+        .filter(|entry| entry.enabled)
+        .filter_map(|entry| {
+            match super::targets::hook_target(
+                env,
+                scope,
+                crate::model::HarnessId::Opencode,
+                &entry.name,
+            ) {
+                Some(super::targets::HookTarget::Instruction { reference, .. }) => Some(reference),
+                _ => None,
+            }
+        })
+        .collect();
+    let config = crate::harness::opencode::config_file(env, scope);
+    let Some(current) = crate::fs::read_if_exists(&config)? else {
+        return Ok(());
+    };
+    let edit = crate::configedit::ConfigEdit::OpencodePruneInstructions {
+        prefix: super::targets::opencode_instruction_prefix(scope).to_owned(),
+        keep,
+    };
+    let Ok(updated) = edit.apply(&current) else {
+        return Ok(());
+    };
+    if updated == current {
+        return Ok(());
+    }
+    config_edits.push(config, "drop instruction rows nothing renders".into(), edit);
+    Ok(())
+}

--- a/crates/core/src/engine/stale.rs
+++ b/crates/core/src/engine/stale.rs
@@ -70,13 +70,15 @@ pub(super) fn stale_emitted(
     Ok(())
 }
 
-/// The instructions rows in opencode's config that point into the
-/// directory kendex renders instruction files into, cut down to what the
-/// record this pass writes still renders — `stale_emitted` for rows
-/// instead of files. An entry-by-entry removal only finds rows a record
-/// leads to; a row an older render spelled differently, or one whose
-/// record a reinstall dropped, stays in the file forever, naming a file
-/// that is gone. Rows pointing anywhere else are the person's and stay.
+/// The instructions rows carrying kendex's own filename marker under the
+/// directory it renders into, cut down to what the record this pass
+/// writes still renders — `stale_emitted` for rows instead of files. An
+/// entry-by-entry removal only finds rows a record leads to; a row whose
+/// record a reinstall dropped stays in the file forever, naming a file
+/// that is gone. The marker is the claim: the directory is a shared
+/// surface, so a row without it — the person's own file there, or a
+/// pre-rename tool's render — is not this sweep's to take, exactly as the
+/// scan surface observes only marker-named files there.
 ///
 /// Planned only where the lock — old or new — shows kendex registering
 /// instruction rows at this scope: a config kendex never wrote into holds
@@ -120,7 +122,11 @@ pub(super) fn stale_instruction_rows(
         return Ok(());
     };
     let edit = crate::configedit::ConfigEdit::OpencodePruneInstructions {
-        prefix: super::targets::opencode_instruction_prefix(scope).to_owned(),
+        prefix: format!(
+            "{}{}",
+            super::targets::opencode_instruction_prefix(scope),
+            crate::harness::opencode::HOOK_INSTRUCTION_MARKER
+        ),
         keep,
     };
     let Ok(updated) = edit.apply(&current) else {

--- a/crates/core/src/engine/targets.rs
+++ b/crates/core/src/engine/targets.rs
@@ -76,6 +76,17 @@ pub(crate) enum HookTarget {
     Rule { path: PathBuf },
 }
 
+/// How an instructions row spells the directory kendex renders opencode
+/// instruction files into, at this scope. The rows hook_target writes and
+/// the rows the stale-row sweep claims both read this, so the spelling
+/// written and the spelling swept can never disagree.
+pub(super) fn opencode_instruction_prefix(scope: &Scope) -> &'static str {
+    match scope {
+        Scope::Global => "instructions/",
+        Scope::Project { .. } => ".opencode/instructions/",
+    }
+}
+
 pub(crate) fn hook_target(
     env: &Env,
     scope: &Scope,
@@ -135,10 +146,7 @@ pub(crate) fn hook_target(
             };
             let dir = base.join("instructions");
             let file = format!("kendex-hook-{name}.md");
-            let reference = match scope {
-                Scope::Global => format!("instructions/{file}"),
-                Scope::Project { .. } => format!(".opencode/instructions/{file}"),
-            };
+            let reference = format!("{}{file}", opencode_instruction_prefix(scope));
             Some(HookTarget::Instruction {
                 path: dir.join(&file),
                 config: crate::harness::opencode::config_file(env, scope),

--- a/crates/core/src/engine/targets.rs
+++ b/crates/core/src/engine/targets.rs
@@ -145,7 +145,10 @@ pub(crate) fn hook_target(
                 Scope::Project { root } => root.join(".opencode"),
             };
             let dir = base.join("instructions");
-            let file = format!("kendex-hook-{name}.md");
+            let file = format!(
+                "{}{name}.md",
+                crate::harness::opencode::HOOK_INSTRUCTION_MARKER
+            );
             let reference = format!("{}{file}", opencode_instruction_prefix(scope));
             Some(HookTarget::Instruction {
                 path: dir.join(&file),

--- a/crates/core/src/harness/opencode.rs
+++ b/crates/core/src/harness/opencode.rs
@@ -8,6 +8,12 @@ pub struct Opencode;
 
 const PLUGIN_EXTS: &[&str] = &["js", "ts", "mjs", "cjs"];
 
+/// The filename marker every instruction file kendex renders carries. The
+/// render (`hook_target`), the scan surface below, and the stale-row sweep
+/// all read this one spelling, so what is written, observed, and claimed
+/// as kendex's can never diverge.
+pub(crate) const HOOK_INSTRUCTION_MARKER: &str = "kendex-hook-";
+
 fn global_config_file(root: &Path, env: &Env) -> PathBuf {
     if let Some(explicit) = env.var("OPENCODE_CONFIG") {
         return PathBuf::from(explicit);
@@ -99,7 +105,7 @@ fn surfaces(kind: ItemKind, base: &Path, config: PathBuf, shared: Option<&Path>)
         ItemKind::Hook => vec![Surface::FileDir {
             dir: base.join("instructions"),
             exts: &["md"],
-            prefixes: &["kendex-hook-"],
+            prefixes: &[HOOK_INSTRUCTION_MARKER],
         }],
         ItemKind::Command => vec![
             Surface::files(base.join("commands"), &["md"]),

--- a/crates/core/tests/byte_faithful.rs
+++ b/crates/core/tests/byte_faithful.rs
@@ -40,8 +40,8 @@ fn every_config_edit_is_byte_stable_on_reapply() {
             bash_permission: true,
         },
         ConfigEdit::OpencodePruneInstructions {
-            prefix: "instructions/".into(),
-            keep: vec!["instructions/x.md".into()],
+            prefix: "instructions/kendex-hook-".into(),
+            keep: vec!["instructions/kendex-hook-x.md".into()],
         },
         ConfigEdit::CodexEnableHooksFeature,
         ConfigEdit::UpsertMarkerBlock {

--- a/crates/core/tests/byte_faithful.rs
+++ b/crates/core/tests/byte_faithful.rs
@@ -39,6 +39,10 @@ fn every_config_edit_is_byte_stable_on_reapply() {
             reference: "instructions/x.md".into(),
             bash_permission: true,
         },
+        ConfigEdit::OpencodePruneInstructions {
+            prefix: "instructions/".into(),
+            keep: vec!["instructions/x.md".into()],
+        },
         ConfigEdit::CodexEnableHooksFeature,
         ConfigEdit::UpsertMarkerBlock {
             name: "pi".into(),

--- a/crates/core/tests/kinds/config_files.rs
+++ b/crates/core/tests/kinds/config_files.rs
@@ -51,10 +51,12 @@ fn another_writers_key_order_is_kept_and_is_not_drift() {
     assert!(is_clean(&f), "a key another tool appended is not drift");
 }
 
-/// The instructions rows under kendex's render directory are the current
-/// render set, no more: a row left by a render nothing records — an older
-/// naming, a dropped lock — leaves with its file, while the person's own
-/// rows ride through untouched.
+/// The marker-named instructions rows are the current render set, no
+/// more: a row a dropped lock stopped accounting for leaves with its
+/// file. The instructions directory itself is a shared surface, so a row
+/// there without kendex's filename marker — the person's own file, a
+/// pre-rename tool's render — rides through untouched, like every row
+/// pointing anywhere else.
 #[test]
 fn stale_instruction_rows_leave_with_the_files_nothing_renders() {
     let f = fixture("[hooks.audit]\nsource = \"cat\"\nharnesses = [\"opencode\"]\n");
@@ -63,7 +65,8 @@ fn stale_instruction_rows_leave_with_the_files_nothing_renders() {
     let config = f.project.join("opencode.json");
     let mut doc = json(&config);
     let rows = doc["instructions"].as_array_mut().unwrap();
-    rows.push(".opencode/instructions/vstack-hook-old.md".into());
+    rows.push(".opencode/instructions/kendex-hook-old.md".into());
+    rows.push(".opencode/instructions/my-notes.md".into());
     rows.push("AGENTS.md".into());
     fs::write(&config, serde_json::to_string_pretty(&doc).unwrap() + "\n").unwrap();
 
@@ -71,10 +74,61 @@ fn stale_instruction_rows_leave_with_the_files_nothing_renders() {
     let refreshed = json(&config);
     assert_eq!(
         refreshed["instructions"],
-        serde_json::json!([".opencode/instructions/kendex-hook-audit.md", "AGENTS.md"]),
-        "the stale row goes with its file; the person's row stays"
+        serde_json::json!([
+            ".opencode/instructions/kendex-hook-audit.md",
+            ".opencode/instructions/my-notes.md",
+            "AGENTS.md"
+        ]),
+        "the marker-named stale row goes; unmarked rows stay wherever they point"
     );
     assert!(is_clean(&f));
+}
+
+/// The sweep runs only where the lock shows kendex registering opencode
+/// instruction rows. A scope with no opencode hooks holds nothing of
+/// kendex's in that config — even a marker-named row is not the sweep's
+/// to take, because no record says kendex wrote it.
+#[test]
+fn a_scope_with_no_opencode_hooks_never_edits_the_instructions_rows() {
+    let f = fixture("[hooks.guard]\nsource = \"cat\"\n");
+    let config = f.project.join("opencode.json");
+    let doc = serde_json::json!({
+        "instructions": [".opencode/instructions/kendex-hook-stray.md", "AGENTS.md"]
+    });
+    let written = serde_json::to_string_pretty(&doc).unwrap() + "\n";
+    fs::write(&config, &written).unwrap();
+
+    apply_now(&f);
+    apply_now(&f);
+    assert_eq!(
+        fs::read_to_string(&config).unwrap(),
+        written,
+        "a config kendex has no opencode-hook record for is never edited"
+    );
+}
+
+/// An opencode config the sweep cannot read back is skipped, never a
+/// scope error: the registration into it already reports the conflict,
+/// named with the file, while the rest of the scope still plans.
+#[test]
+fn an_unreadable_opencode_config_is_the_registrations_conflict_not_a_sweep_error() {
+    let f = fixture("[hooks.audit]\nsource = \"cat\"\nharnesses = [\"opencode\"]\n");
+    apply_now(&f);
+    let config = f.project.join("opencode.json");
+    fs::write(&config, "{ // my note\n  \"instructions\": []\n}\n").unwrap();
+
+    let report = audit(&f.env, &f.scope).expect("an unreadable config must not fail the scope");
+    let conflict = report
+        .drift
+        .iter()
+        .find(|row| row.name == "audit")
+        .expect("the hook is reported");
+    assert_eq!(conflict.state, DriftState::Conflict);
+    assert!(
+        conflict.detail.contains("opencode.json"),
+        "{}",
+        conflict.detail
+    );
 }
 
 /// A settings file kendex cannot read back blocks that registration alone

--- a/crates/core/tests/kinds/config_files.rs
+++ b/crates/core/tests/kinds/config_files.rs
@@ -51,6 +51,32 @@ fn another_writers_key_order_is_kept_and_is_not_drift() {
     assert!(is_clean(&f), "a key another tool appended is not drift");
 }
 
+/// The instructions rows under kendex's render directory are the current
+/// render set, no more: a row left by a render nothing records — an older
+/// naming, a dropped lock — leaves with its file, while the person's own
+/// rows ride through untouched.
+#[test]
+fn stale_instruction_rows_leave_with_the_files_nothing_renders() {
+    let f = fixture("[hooks.audit]\nsource = \"cat\"\nharnesses = [\"opencode\"]\n");
+    apply_now(&f);
+
+    let config = f.project.join("opencode.json");
+    let mut doc = json(&config);
+    let rows = doc["instructions"].as_array_mut().unwrap();
+    rows.push(".opencode/instructions/vstack-hook-old.md".into());
+    rows.push("AGENTS.md".into());
+    fs::write(&config, serde_json::to_string_pretty(&doc).unwrap() + "\n").unwrap();
+
+    apply_now(&f);
+    let refreshed = json(&config);
+    assert_eq!(
+        refreshed["instructions"],
+        serde_json::json!([".opencode/instructions/kendex-hook-audit.md", "AGENTS.md"]),
+        "the stale row goes with its file; the person's row stays"
+    );
+    assert!(is_clean(&f));
+}
+
 /// A settings file kendex cannot read back blocks that registration alone
 /// — named, with the file — while the rest of the scope still plans.
 #[test]

--- a/docs/adapters/opencode.md
+++ b/docs/adapters/opencode.md
@@ -79,7 +79,11 @@ A `PreToolUse` hook matching `Bash` additionally sets
 
 The plan preview, the report and the tool's card all carry an advisory
 notice (`advisory_notice`, `crates/core/src/engine/targets.rs`). Disabling renames
-the instruction file to `.disabled` and removes the config reference.
+the instruction file to `.disabled` and removes the config reference. The
+rows under the instructions directory are the current render set, no more:
+a refresh cuts rows there that nothing renders anymore, and never touches
+rows pointing anywhere else (`stale_instruction_rows`,
+`crates/core/src/engine/stale.rs`).
 
 ## Validation
 

--- a/docs/adapters/opencode.md
+++ b/docs/adapters/opencode.md
@@ -80,10 +80,12 @@ A `PreToolUse` hook matching `Bash` additionally sets
 The plan preview, the report and the tool's card all carry an advisory
 notice (`advisory_notice`, `crates/core/src/engine/targets.rs`). Disabling renames
 the instruction file to `.disabled` and removes the config reference. The
-rows under the instructions directory are the current render set, no more:
-a refresh cuts rows there that nothing renders anymore, and never touches
-rows pointing anywhere else (`stale_instruction_rows`,
-`crates/core/src/engine/stale.rs`).
+rows named with the `kendex-hook-` marker are the current render set, no
+more: a refresh cuts marker-named rows that nothing renders anymore, and
+never touches any other row — a person's own file in the instructions
+directory included (`stale_instruction_rows`,
+`crates/core/src/engine/stale.rs`). Rows a pre-rename tool wrote carry
+another marker and are removed by hand once.
 
 ## Validation
 


### PR DESCRIPTION
## Summary
- A refresh cuts opencode.json's `instructions` rows for kendex-rendered hook files down to the current render set, so a row for a file no refresh renders anymore leaves with its file (seen live as five stale rows after the org convergence).
- The prune claims only rows carrying the kendex filename marker, spelled once (`HOOK_INSTRUCTION_MARKER`) and shared by the renderer, the scan surface, and the sweep; every other row — a person's own file in the same directory included — stays, with tests pinning that.
- The sweep judges by the lock the pass writes (the KEN-646 mechanism) and lives beside `stale_emitted` in a new `engine/stale.rs`.

## Completed Issues
- Closes KEN-641 - Rendered opencode.json keeps instruction rows for files a refresh no longer renders

## Test Plan
- `cargo test -p kendex-core --test kinds` (new: stale marker row leaves with its file; unmarked in-directory row and `AGENTS.md` survive; a no-hook scope leaves opencode.json byte-identical; a jsonc config reports the registration conflict, not a scope error) — the guard tests were shown red against their guard removals
- `tools/guard` clean on the head commit; preflight clean against `origin/main`
- Internal review: 9 reviewers plus codex external, 2 cycles; mutation runs killed 4/4 mutants, stability 20/20
