### PR TITLE
chore(KEN-698): worktree symlinks name only what git does not carry

### DIFF
--- a/.agents/skills/worktree/README.md
+++ b/.agents/skills/worktree/README.md
@@ -53,7 +53,7 @@ WORKTREE_RELATIVE_SYMLINKS = ".claude/CLAUDE.md=../AGENTS.md"
 WORKTREE_MKDIRS = "tmp"
 ```
 
-Point `WORKTREE_SYMLINKS` at paths git does not carry; naming a tree the repo commits links nothing. A directory entry containing tracked files stays a real directory with only its untracked children linked (an untracked `.gitignore` is copied, since git will not read one through a symlink); a tracked file entry is marked assume-unchanged before replacement. Full rules: `scripts/worktree --help` and `scripts/worktree fix-links --help`.
+Point `WORKTREE_SYMLINKS` at paths git does not carry; an entry does nothing when git carries every path under it. A directory entry containing tracked files stays a real directory with only its untracked children linked (an untracked `.gitignore` is copied, since git will not read one through a symlink); a tracked file entry is marked assume-unchanged before replacement. Full rules: `scripts/worktree --help` and `scripts/worktree fix-links --help`.
 
 ### App-created worktrees
 

--- a/.agents/skills/worktree/README.md
+++ b/.agents/skills/worktree/README.md
@@ -48,12 +48,12 @@ Run from the main checkout of a git repo with an `origin` remote. New-work claim
 ```toml
 [env]
 WORKTREE_BASE_DIR = "~/dev/.worktrees/myproject"
-WORKTREE_SYMLINKS = ".env.local .claude/agents .claude/hooks .claude/skills"
+WORKTREE_SYMLINKS = ".env.local .cache node_modules"
 WORKTREE_RELATIVE_SYMLINKS = ".claude/CLAUDE.md=../AGENTS.md"
 WORKTREE_MKDIRS = "tmp"
 ```
 
-Point `WORKTREE_SYMLINKS` at untracked paths. A directory entry containing tracked files stays a real directory with only its untracked children linked (an untracked `.gitignore` is copied, since git will not read one through a symlink); a tracked file entry is marked assume-unchanged before replacement. Full rules: `scripts/worktree --help` and `scripts/worktree fix-links --help`.
+Point `WORKTREE_SYMLINKS` at paths git does not carry; naming a tree the repo commits links nothing. A directory entry containing tracked files stays a real directory with only its untracked children linked (an untracked `.gitignore` is copied, since git will not read one through a symlink); a tracked file entry is marked assume-unchanged before replacement. Full rules: `scripts/worktree --help` and `scripts/worktree fix-links --help`.
 
 ### App-created worktrees
 

--- a/.agents/skills/worktree/SKILL.md
+++ b/.agents/skills/worktree/SKILL.md
@@ -81,4 +81,4 @@ No worktree command runs a package-manager install: installs run only in the mai
 
 ## Configuration
 
-Set non-sensitive defaults in committed `kendex.settings.toml` under `[env]`; existing `.env` and `.env.local` variables still work, and `.env.local` wins for secrets or personal overrides. **Symlink only what git does not carry** — an entry naming a committed tree links nothing: a directory holding tracked content stays a real directory, with only its untracked children linked, bar an untracked `.gitignore`, which is copied (`fix-links --help`). Variable semantics and setup-path hardening: `worktree --help`.
+Set non-sensitive defaults in committed `kendex.settings.toml` under `[env]`; existing `.env` and `.env.local` variables still work, and `.env.local` wins for secrets or personal overrides. **Symlink only what git does not carry** — an entry does nothing when git carries every path under it, and a directory holding tracked content stays a real directory with its untracked children linked, bar an untracked `.gitignore`, which is copied (`fix-links --help`). Variable semantics and setup-path hardening: `worktree --help`.

--- a/.agents/skills/worktree/SKILL.md
+++ b/.agents/skills/worktree/SKILL.md
@@ -81,4 +81,4 @@ No worktree command runs a package-manager install: installs run only in the mai
 
 ## Configuration
 
-Set non-sensitive defaults in committed `kendex.settings.toml` under `[env]`; existing `.env` and `.env.local` variables still work, and `.env.local` wins for secrets or personal overrides. **Symlink untracked paths only** — an entry that shadows tracked files is linked per untracked child instead, bar an untracked `.gitignore`, which is copied (`fix-links --help`). Variable semantics and setup-path hardening: `worktree --help`.
+Set non-sensitive defaults in committed `kendex.settings.toml` under `[env]`; existing `.env` and `.env.local` variables still work, and `.env.local` wins for secrets or personal overrides. **Symlink only what git does not carry** — an entry naming a committed tree links nothing: a directory holding tracked content stays a real directory, with only its untracked children linked, bar an untracked `.gitignore`, which is copied (`fix-links --help`). Variable semantics and setup-path hardening: `worktree --help`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,10 @@ an outside contributor.
 
 ### Changed
 
+- The seeded `WORKTREE_SYMLINKS` default now lists only paths git does not
+  carry. Naming a committed tree links nothing, so drop such entries from
+  your own value.
+
 - **Breaking:** the worktree skill no longer installs JS dependencies. Run
   installs in the main checkout and link its `node_modules` via
   `WORKTREE_SYMLINKS`; an unlinked JS worktree warns, naming the main checkout.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,8 +29,8 @@ an outside contributor.
 ### Changed
 
 - The seeded `WORKTREE_SYMLINKS` default now lists only paths git does not
-  carry. Naming a committed tree links nothing, so drop such entries from
-  your own value.
+  carry. An entry does nothing when git carries every path under it, so drop
+  those from your own value; one with untracked children still links them.
 
 - **Breaking:** the worktree skill no longer installs JS dependencies. Run
   installs in the main checkout and link its `node_modules` via

--- a/kendex.settings.toml
+++ b/kendex.settings.toml
@@ -249,17 +249,13 @@ ORCH_STATE_DIR = "tmp"
 SIZE_RATCHET_CLASSES = "*/README.md=120;*/tests/*=800;*/test/*=800;*/__tests__/*=800;*/tests.rs=800;*test_util.rs=800;*.test.*=800;ui/*.ts=250;ui/*.tsx=250"
 
 # ── Worktrees ────────────────────────────────────────────────────────────
-# What a fresh issue worktree gets from this checkout. Symlink untracked
-# paths only: an entry over tracked files makes git refuse writes in that
-# worktree while `git status` still reports clean.
-#
-# .codex and .opencode are named whole: nothing under them is tracked.
-# .claude and .pi are named child by child: they hold tracked files
-# (.claude/CLAUDE.md, .pi/prompts) beside kendex-rendered, gitignored ones.
-# A DIRECTORY entry over tracked content is safe — worktree setup keeps it a
-# real directory and links only the untracked children. A single tracked FILE
-# is not: it becomes a link git cannot write through, so .claude/settings.json
-# is absent here and each worktree carries git's own copy.
+# What a fresh issue worktree gets from this checkout: only paths git does
+# not carry. The harness trees (.agents, .claude, .codex, .pi) are committed,
+# so a worktree gets them from the branch and naming one here links nothing:
+# setup keeps an entry holding tracked content a real directory and finds no
+# untracked child to link. A single tracked FILE is the opposite hazard — it
+# becomes a link git cannot write through, so .claude/settings.json is absent
+# here and each worktree carries git's own copy.
 WORKTREE_BASE_DIR = "~/dev/.worktrees/kendex"
 WORKTREE_COPIES = ".kendex-lock.json"
 WORKTREE_DEFAULT_BRANCH = "main"
@@ -273,7 +269,7 @@ WORKTREE_MKDIRS = "tmp"
 # the changed manifests — never in a linked worktree, whose install would
 # write through the link. .gitignore's bare `node_modules` pattern covers
 # the symlink.
-WORKTREE_SYMLINKS = ".env.local .agents .cache .codex .opencode .pi/agents .pi/kendex .claude/agents .claude/hooks .claude/skills ui/node_modules"
+WORKTREE_SYMLINKS = ".env.local .cache ui/node_modules"
 
 # Nothing needs one: .claude/CLAUDE.md is a tracked symlink, so it arrives
 # through git, and naming it here would shadow tracked content.

--- a/kendex.settings.toml
+++ b/kendex.settings.toml
@@ -250,12 +250,14 @@ SIZE_RATCHET_CLASSES = "*/README.md=120;*/tests/*=800;*/test/*=800;*/__tests__/*
 
 # ── Worktrees ────────────────────────────────────────────────────────────
 # What a fresh issue worktree gets from this checkout: only paths git does
-# not carry. The harness trees (.agents, .claude, .codex, .pi) are committed,
-# so a worktree gets them from the branch and naming one here links nothing:
-# setup keeps an entry holding tracked content a real directory and finds no
-# untracked child to link. A single tracked FILE is the opposite hazard — it
-# becomes a link git cannot write through, so .claude/settings.json is absent
-# here and each worktree carries git's own copy.
+# not carry. An entry does nothing when git carries every path under it, and
+# links the untracked children when it does not. The harness trees (.agents,
+# .claude, .codex, .pi) are committed whole, so a worktree gets them from its
+# own branch. A render installed in the main checkout and left uncommitted is
+# deliberately not linked in: a worktree's harness matches its branch, and
+# commit the render to hand it to every worktree. A single tracked FILE is
+# the opposite hazard — it becomes a link git cannot write through, so
+# .claude/settings.json is absent here and each worktree carries git's own copy.
 #
 # .opencode is absent for a different reason: kendex-local.toml's [install]
 # harnesses names claude, codex and pi, not opencode, so nothing renders

--- a/kendex.settings.toml
+++ b/kendex.settings.toml
@@ -256,6 +256,10 @@ SIZE_RATCHET_CLASSES = "*/README.md=120;*/tests/*=800;*/test/*=800;*/__tests__/*
 # untracked child to link. A single tracked FILE is the opposite hazard — it
 # becomes a link git cannot write through, so .claude/settings.json is absent
 # here and each worktree carries git's own copy.
+#
+# .opencode is absent for a different reason: kendex-local.toml's [install]
+# harnesses names claude, codex and pi, not opencode, so nothing renders
+# there. The tree holds no files, and an entry would link an empty directory.
 WORKTREE_BASE_DIR = "~/dev/.worktrees/kendex"
 WORKTREE_COPIES = ".kendex-lock.json"
 WORKTREE_DEFAULT_BRANCH = "main"

--- a/kendex.settings.toml.example
+++ b/kendex.settings.toml.example
@@ -14,9 +14,10 @@ WORKTREE_DEFAULT_BRANCH = "main"
 # Never point it inside the repo root — watched build outputs exhaust inotify.
 # WORKTREE_BASE_DIR = "~/dev/.worktrees/myproject"
 
-# Paths symlinked into every worktree. Include `.env.local` only when
+# Paths symlinked into every worktree: list only what git does not carry,
+# since naming a committed tree links nothing. Include `.env.local` only when
 # worktrees should share local secrets.
-WORKTREE_SYMLINKS = ".env.local opencode.json .agents .codex .opencode .pi .claude/settings.json .claude/agents .claude/hooks .claude/skills"
+WORKTREE_SYMLINKS = ".env.local .cache node_modules"
 
 # link=target pairs; each target resolves from the LINK's own directory
 # (`.claude/CLAUDE.md=../AGENTS.md` reaches the worktree root's AGENTS.md).

--- a/kendex.settings.toml.example
+++ b/kendex.settings.toml.example
@@ -14,8 +14,9 @@ WORKTREE_DEFAULT_BRANCH = "main"
 # Never point it inside the repo root — watched build outputs exhaust inotify.
 # WORKTREE_BASE_DIR = "~/dev/.worktrees/myproject"
 
-# Paths symlinked into every worktree: list only what git does not carry,
-# since naming a committed tree links nothing. Include `.env.local` only when
+# Paths symlinked into every worktree: list only what git does not carry. An
+# entry does nothing when git carries every path under it; one with untracked
+# children still links those children. Include `.env.local` only when
 # worktrees should share local secrets.
 WORKTREE_SYMLINKS = ".env.local .cache node_modules"
 

--- a/skills/worktree/README.md
+++ b/skills/worktree/README.md
@@ -53,7 +53,7 @@ WORKTREE_RELATIVE_SYMLINKS = ".claude/CLAUDE.md=../AGENTS.md"
 WORKTREE_MKDIRS = "tmp"
 ```
 
-Point `WORKTREE_SYMLINKS` at paths git does not carry; naming a tree the repo commits links nothing. A directory entry containing tracked files stays a real directory with only its untracked children linked (an untracked `.gitignore` is copied, since git will not read one through a symlink); a tracked file entry is marked assume-unchanged before replacement. Full rules: `scripts/worktree --help` and `scripts/worktree fix-links --help`.
+Point `WORKTREE_SYMLINKS` at paths git does not carry; an entry does nothing when git carries every path under it. A directory entry containing tracked files stays a real directory with only its untracked children linked (an untracked `.gitignore` is copied, since git will not read one through a symlink); a tracked file entry is marked assume-unchanged before replacement. Full rules: `scripts/worktree --help` and `scripts/worktree fix-links --help`.
 
 ### App-created worktrees
 

--- a/skills/worktree/README.md
+++ b/skills/worktree/README.md
@@ -48,12 +48,12 @@ Run from the main checkout of a git repo with an `origin` remote. New-work claim
 ```toml
 [env]
 WORKTREE_BASE_DIR = "~/dev/.worktrees/myproject"
-WORKTREE_SYMLINKS = ".env.local .claude/agents .claude/hooks .claude/skills"
+WORKTREE_SYMLINKS = ".env.local .cache node_modules"
 WORKTREE_RELATIVE_SYMLINKS = ".claude/CLAUDE.md=../AGENTS.md"
 WORKTREE_MKDIRS = "tmp"
 ```
 
-Point `WORKTREE_SYMLINKS` at untracked paths. A directory entry containing tracked files stays a real directory with only its untracked children linked (an untracked `.gitignore` is copied, since git will not read one through a symlink); a tracked file entry is marked assume-unchanged before replacement. Full rules: `scripts/worktree --help` and `scripts/worktree fix-links --help`.
+Point `WORKTREE_SYMLINKS` at paths git does not carry; naming a tree the repo commits links nothing. A directory entry containing tracked files stays a real directory with only its untracked children linked (an untracked `.gitignore` is copied, since git will not read one through a symlink); a tracked file entry is marked assume-unchanged before replacement. Full rules: `scripts/worktree --help` and `scripts/worktree fix-links --help`.
 
 ### App-created worktrees
 

--- a/skills/worktree/SKILL.md
+++ b/skills/worktree/SKILL.md
@@ -81,4 +81,4 @@ No worktree command runs a package-manager install: installs run only in the mai
 
 ## Configuration
 
-Set non-sensitive defaults in committed `kendex.settings.toml` under `[env]`; existing `.env` and `.env.local` variables still work, and `.env.local` wins for secrets or personal overrides. **Symlink only what git does not carry** — an entry naming a committed tree links nothing: a directory holding tracked content stays a real directory, with only its untracked children linked, bar an untracked `.gitignore`, which is copied (`fix-links --help`). Variable semantics and setup-path hardening: `worktree --help`.
+Set non-sensitive defaults in committed `kendex.settings.toml` under `[env]`; existing `.env` and `.env.local` variables still work, and `.env.local` wins for secrets or personal overrides. **Symlink only what git does not carry** — an entry does nothing when git carries every path under it, and a directory holding tracked content stays a real directory with its untracked children linked, bar an untracked `.gitignore`, which is copied (`fix-links --help`). Variable semantics and setup-path hardening: `worktree --help`.

--- a/skills/worktree/SKILL.md
+++ b/skills/worktree/SKILL.md
@@ -81,4 +81,4 @@ No worktree command runs a package-manager install: installs run only in the mai
 
 ## Configuration
 
-Set non-sensitive defaults in committed `kendex.settings.toml` under `[env]`; existing `.env` and `.env.local` variables still work, and `.env.local` wins for secrets or personal overrides. **Symlink untracked paths only** — an entry that shadows tracked files is linked per untracked child instead, bar an untracked `.gitignore`, which is copied (`fix-links --help`). Variable semantics and setup-path hardening: `worktree --help`.
+Set non-sensitive defaults in committed `kendex.settings.toml` under `[env]`; existing `.env` and `.env.local` variables still work, and `.env.local` wins for secrets or personal overrides. **Symlink only what git does not carry** — an entry naming a committed tree links nothing: a directory holding tracked content stays a real directory, with only its untracked children linked, bar an untracked `.gitignore`, which is copied (`fix-links --help`). Variable semantics and setup-path hardening: `worktree --help`.


### PR DESCRIPTION
## Summary
- Under the committed-harness posture a worktree gets `.agents`, `.claude`, `.codex` and `.pi` from git, so listing them in `WORKTREE_SYMLINKS` did nothing: the script keeps a tracked-content entry as a real directory, and the entries read as if links were missing. kendex's list is now `.env.local .cache ui/node_modules` — only what git does not carry.
- The seeded default in `kendex.settings.toml.example` says the same, and the rule is one sentence in the worktree skill's SKILL.md and README.
- Each dropped entry was verified to be a genuine no-op rather than taken from a list: every one is a real directory in the worktree holding tracked content, and the main checkout has no untracked children under any of them, so setup had no child to link.

## Completed Issues
- Closes KEN-698 - WORKTREE_SYMLINKS names tracked harness trees; list only what git does not carry

## Notes
`.opencode` is dropped rather than replaced. kendex's `kendex-local.toml` declares `claude, codex, pi` as its install harnesses and never declares opencode, so nothing renders there: the tree holds one empty `skills/` directory and zero files, and the entry linked an empty directory. Consumers carry `.opencode` because they declare that harness. The cause is recorded in `kendex.settings.toml` beside the list so the entry is not added back.

Worktree setup reads `WORKTREE_SYMLINKS` from the main checkout, not from a worktree's branch, so while main still lists `.opencode` it keeps writing that path's `.git/info/exclude` row and its symlinks. Both stop being regenerated once this merges; the machine is not clean before then.

Whether kendex should target the opencode harness at all, as every consumer repo does, is a separate question raised on the issue rather than decided here.

## Test Plan
- Config and documentation only, no logic change. `tools/guard` exit 0; `preflight --base origin/main` clean; `skills/worktree` and its committed `.agents` render byte-identical.
- The four consumer repos (drovr, memsira, vg, vgs) take the same trim as their own PRs.

https://claude.ai/code/session_01VNE5GQLr4mHQ4SDxxEyLXL
