### PR TITLE
docs(KEN-583): the changelog says what becomes of a recorded decision

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -254,7 +254,10 @@ an outside contributor.
   turning them off broke every session start.
 - **Breaking:** safety is advisory: nothing holds an install or update back.
   The app's Review & apply page, `kendex findings`/`dismiss`/`decisions` and
-  `apply --allow-unsafe` are gone; kendex.toml drops recorded decisions.
+  `apply --allow-unsafe` are gone.
+- **Breaking:** kendex.toml's `[safety-overrides]` and `[safety-reviews]`
+  records decide nothing and are no longer read. The first apply on such a
+  file deletes both tables and leaves every other byte of it as you wrote it.
 - **Breaking:** the `trading-design` skill is no longer offered. Run
   `kendex remove trading-design --scope all` wherever it is installed (or
   drop its `[skills.trading-design]` entries and run `kendex apply --scope all`).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -256,8 +256,8 @@ an outside contributor.
   The app's Review & apply page, `kendex findings`/`dismiss`/`decisions` and
   `apply --allow-unsafe` are gone.
 - **Breaking:** kendex.toml's `[safety-overrides]` and `[safety-reviews]`
-  records decide nothing and are no longer read. The first apply on such a
-  file deletes both tables and leaves every other byte of it as you wrote it.
+  records decide nothing and are no longer read. The next apply removes both
+  tables from the file.
 - **Breaking:** the `trading-design` skill is no longer offered. Run
   `kendex remove trading-design --scope all` wherever it is installed (or
   drop its `[skills.trading-design]` entries and run `kendex apply --scope all`).

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -21,7 +21,7 @@ Four verbs over one model: **scan → declare → diff → apply**.
   a place's card on Projects — the app's one mention of unmanaged content —
   and behind `kendex adopt`. Taking over files already sitting where a
   declared item goes is `kendex apply --replace-unmanaged`, scope-wide; the
-  app has no exit for that conflict until KEN-625 attaches one, and
+  app has no exit for that conflict until KEN-621 attaches one, and
   `replace_unmanaged_item` (per item, revalidated against a fresh read,
   running the scope's whole plan) is the command it will wire.
 
@@ -105,7 +105,7 @@ lives in one capability table read by core and UI.
      place holding it; the sweep fails, naming those, only when nothing
      settles. One refused at every link is not held: its rows stand,
      nothing replaced. The app offers adopt for unmanaged items, and a
-     declared item's conflict has no app exit until KEN-625 attaches one.
+     declared item's conflict has no app exit until KEN-621 attaches one.
    The row states which files are in the way, which exits apply, and — where that
    position can be read in full — how it compares with the install it blocks.
    The CLI names the verb and flag under it. A foreign link pointing at a real


### PR DESCRIPTION
## Summary

- The advisory removal's Breaking entry said kendex.toml "drops recorded
  decisions" without saying when or what the reader has to do. It gets its own
  entry naming the two retired tables and the behaviour: nothing reads
  `[safety-overrides]` or `[safety-reviews]`, and the first apply on such a file
  cuts both blocks out and keeps every other byte, comments and spacing
  included (`crates/core/src/engine/scope_writes/manifest_text.rs`, pinned by
  `crates/app/tests/apply_migration.rs`).
- `docs/ARCHITECTURE.md` pointed twice at KEN-625 as the issue that will attach
  the app's take-over exit for a conflicted declared item. That issue is
  canceled; the live one is KEN-621. The sentences stand as they are, since
  attaching the exit is KEN-621's own scope.
- The rest of the coherence pass found nothing to change. Nothing under `docs/`,
  `README.md` or `skills/` names `allow-unsafe`, the removed verbs, Review &
  apply or `kendex-reviews.toml`, and the safety text in `docs/ARCHITECTURE.md`
  already reads as advisory — #1649 and #1663 amended it in change, as the repo
  rule asks. CHANGELOG entries for released versions are history and stay put.

## Completed Issues

- Closes KEN-583 - Docs and CHANGELOG: the advisory model is what the docs describe

## Test Plan

- `rg -i 'allow-unsafe|kendex dismiss|kendex findings|kendex decisions|Review & apply|kendex-reviews' docs README.md skills` returns nothing.
- The behaviour the new entry claims is the one `manifest_text.rs` implements and
  `apply_migration.rs` asserts.
- preflight clean.
