### PR TITLE
feat(KEN-460): the Updates page says when it last reached its sources

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -315,6 +315,9 @@ an outside contributor.
   `kendex-git`).
 - The default catalog offers curated bundles and tagged packages:
   orchestration, code-review, research, and commit-guards.
+- The Updates page says when it last reached your sources — "Last checked 3h
+  ago" under the title, and beside "Everything is up to date" — so a standing
+  the page read offline is no longer indistinguishable from a fresh check.
 
 ### Changed
 

--- a/crates/app/src/lib.rs
+++ b/crates/app/src/lib.rs
@@ -18,6 +18,7 @@ pub mod recovery;
 pub mod repo_effects;
 pub mod sources;
 mod unsubscribe;
+mod update_check;
 mod whole_file;
 mod window;
 
@@ -110,9 +111,6 @@ pub fn specta_builder() -> Builder<tauri::Wry> {
             account::mine_submissions,
             packages::package_versions,
             packages::package_update,
-            packages::updates_overview,
-            packages::updates_refresh,
-            packages::update_set_ignored,
             packages::package_set_rev,
             packages::package_diff,
             packages::package_fork,
@@ -123,6 +121,9 @@ pub fn specta_builder() -> Builder<tauri::Wry> {
             packages::package_file,
             packages::package_readme,
             packages::package_meta,
+            update_check::updates_overview,
+            update_check::updates_refresh,
+            update_check::update_set_ignored,
             window::window_set_zoom,
             window::window_zoom_state,
             window::window_minimize,

--- a/crates/app/src/packages.rs
+++ b/crates/app/src/packages.rs
@@ -1,13 +1,13 @@
-//! The package page's and Updates page's commands: versions, diffs, files,
-//! provenance, holds, forks, and the update check — thin shells over core,
-//! like every other command here.
+//! The package page's commands: versions, diffs, files, provenance, holds,
+//! and forks — thin shells over core, like every other command here. The
+//! Updates page's standing is its own module, `update_check`.
 
 use kendex_core::apply;
 use kendex_core::engine;
 use kendex_core::env::Env;
+use kendex_core::manifest;
 use kendex_core::model::{HarnessId, ItemKind, Scope};
-use kendex_core::package::{self, detail, diff, updates};
-use kendex_core::{manifest, remote};
+use kendex_core::package::{self, detail, diff};
 use serde::Serialize;
 use specta::Type;
 
@@ -15,18 +15,6 @@ use crate::audit::{AuditView, view};
 
 fn env() -> Result<Env, String> {
     Env::detect().map_err(|e| e.to_string())
-}
-
-fn all_scopes(env: &Env) -> Result<Vec<Scope>, String> {
-    let settings = kendex_core::settings::load(env).map_err(|e| e.to_string())?;
-    let mut scopes = vec![Scope::Global];
-    scopes.extend(
-        settings
-            .projects
-            .into_iter()
-            .map(|root| Scope::Project { root }),
-    );
-    Ok(scopes)
 }
 
 #[tauri::command(async)]
@@ -38,68 +26,6 @@ pub fn package_versions(
 ) -> Result<Vec<package::VersionRow>, String> {
     let env = env()?;
     package::versions(&env, &scope, kind, &name).map_err(|e| e.to_string())
-}
-
-/// Every scope's update standing in one query — the sidebar badge, the
-/// Updates page, and the Library's fork/edited flags all read this. Rows
-/// carry the facts; warnings carry every package the standing could not be
-/// computed for, which is never silently shown as current.
-#[tauri::command(async)]
-#[specta::specta]
-pub fn updates_overview() -> Result<updates::UpdatesReport, String> {
-    let env = env()?;
-    let mut merged = updates::UpdatesReport {
-        rows: Vec::new(),
-        warnings: Vec::new(),
-    };
-    for scope in all_scopes(&env)? {
-        let report = updates::updates(&env, &scope).map_err(|e| e.to_string())?;
-        // The deep work just ran; the session-start check reads this. A
-        // failure is a warning on the page, never silence — the CLI paths
-        // say the same thing.
-        if let Err(error) = kendex_core::drift::snapshot::record_with(&env, &scope, &report) {
-            merged.warnings.push(kendex_core::engine::ItemWarning {
-                kind: kendex_core::model::ItemKind::Skill,
-                name: scope.label(),
-                harness: None,
-                message: format!("drift snapshot not derived: {error}"),
-                remediation: None,
-            });
-        }
-        merged.rows.extend(report.rows);
-        merged.warnings.extend(report.warnings);
-    }
-    Ok(merged)
-}
-
-/// Fetch every source's mirror — pinned ones included, that is the point —
-/// then answer with the fresh standing. Fetch problems degrade to
-/// warnings; a check for updates is never worth an error dialog.
-#[tauri::command(async)]
-#[specta::specta]
-pub fn updates_refresh() -> Result<updates::UpdatesReport, String> {
-    let env = env()?;
-    for scope in all_scopes(&env)? {
-        let path = manifest::manifest_path(&env, &scope);
-        if let Ok(Some(loaded)) = manifest::load_for_mutation(&path) {
-            let _warnings = remote::fetch_all(&env, &loaded);
-        }
-    }
-    updates_overview()
-}
-
-#[tauri::command(async)]
-#[specta::specta]
-pub fn update_set_ignored(
-    scope: Scope,
-    kind: ItemKind,
-    name: String,
-    repo: String,
-    ignored: bool,
-) -> Result<updates::UpdatesReport, String> {
-    let env = env()?;
-    updates::set_ignored(&env, &scope, kind, &name, &repo, ignored).map_err(|e| e.to_string())?;
-    updates_overview()
 }
 
 /// What a single-package apply did to the package it named, beside the

--- a/crates/app/src/update_check.rs
+++ b/crates/app/src/update_check.rs
@@ -1,0 +1,152 @@
+//! The Updates page's standing: what has a newer version, how old the
+//! reading is, and which packages are muted — thin shells over core, like
+//! every other command here.
+
+use kendex_core::env::Env;
+use kendex_core::model::{ItemKind, Scope};
+use kendex_core::package::updates;
+use kendex_core::{manifest, remote};
+
+fn env() -> Result<Env, String> {
+    Env::detect().map_err(|e| e.to_string())
+}
+
+fn all_scopes(env: &Env) -> Result<Vec<Scope>, String> {
+    let settings = kendex_core::settings::load(env).map_err(|e| e.to_string())?;
+    let mut scopes = vec![Scope::Global];
+    scopes.extend(
+        settings
+            .projects
+            .into_iter()
+            .map(|root| Scope::Project { root }),
+    );
+    Ok(scopes)
+}
+
+/// Every scope's update standing in one query — the sidebar badge, the
+/// Updates page, and the Library's fork/edited flags all read this. Rows
+/// carry the facts; warnings carry every package the standing could not be
+/// computed for, which is never silently shown as current.
+#[tauri::command(async)]
+#[specta::specta]
+pub fn updates_overview() -> Result<updates::UpdatesReport, String> {
+    let env = env()?;
+    let mut reports = Vec::new();
+    for scope in all_scopes(&env)? {
+        let mut report = updates::updates(&env, &scope).map_err(|e| e.to_string())?;
+        // The deep work just ran; the session-start check reads this. A
+        // failure is a warning on the page, never silence — the CLI paths
+        // say the same thing.
+        if let Err(error) = kendex_core::drift::snapshot::record_with(&env, &scope, &report) {
+            report.warnings.push(kendex_core::engine::ItemWarning {
+                kind: kendex_core::model::ItemKind::Skill,
+                name: scope.label(),
+                harness: None,
+                message: format!("drift snapshot not derived: {error}"),
+                remediation: None,
+            });
+        }
+        reports.push(report);
+    }
+    Ok(merge(reports))
+}
+
+/// Fold every scope's standing into the one view the page draws.
+///
+/// One page, one age: the rows are drawn together under a single hint, and
+/// it says when this view last reached the network at all — the newest of
+/// the scopes, the same reading a single scope takes across its own
+/// mirrors. A scope that has never fetched holds no opinion rather than
+/// dragging the whole page to never-checked while another fetched minutes
+/// ago.
+fn merge(reports: impl IntoIterator<Item = updates::UpdatesReport>) -> updates::UpdatesReport {
+    let mut merged = updates::UpdatesReport {
+        rows: Vec::new(),
+        warnings: Vec::new(),
+        last_fetched: None,
+    };
+    for report in reports {
+        merged.last_fetched = merged.last_fetched.max(report.last_fetched);
+        merged.rows.extend(report.rows);
+        merged.warnings.extend(report.warnings);
+    }
+    merged
+}
+
+/// Fetch every source's mirror — pinned ones included, that is the point —
+/// then answer with the fresh standing. Fetch problems degrade to
+/// warnings; a check for updates is never worth an error dialog.
+#[tauri::command(async)]
+#[specta::specta]
+pub fn updates_refresh() -> Result<updates::UpdatesReport, String> {
+    let env = env()?;
+    for scope in all_scopes(&env)? {
+        let path = manifest::manifest_path(&env, &scope);
+        if let Ok(Some(loaded)) = manifest::load_for_mutation(&path) {
+            let _warnings = remote::fetch_all(&env, &loaded);
+        }
+    }
+    updates_overview()
+}
+
+#[tauri::command(async)]
+#[specta::specta]
+pub fn update_set_ignored(
+    scope: Scope,
+    kind: ItemKind,
+    name: String,
+    repo: String,
+    ignored: bool,
+) -> Result<updates::UpdatesReport, String> {
+    let env = env()?;
+    updates::set_ignored(&env, &scope, kind, &name, &repo, ignored).map_err(|e| e.to_string())?;
+    updates_overview()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn dated(last_fetched: Option<u32>) -> updates::UpdatesReport {
+        updates::UpdatesReport {
+            rows: Vec::new(),
+            warnings: Vec::new(),
+            last_fetched,
+        }
+    }
+
+    /// The scopes are drawn together under one hint, so it answers when this
+    /// view last reached the network — the newest of them.
+    #[test]
+    fn the_page_is_dated_by_the_newest_scope() {
+        assert_eq!(
+            merge([dated(Some(1_000)), dated(Some(2_000)), dated(Some(1_500))]).last_fetched,
+            Some(2_000)
+        );
+    }
+
+    /// A project just added, or one whose sources are all local paths, has
+    /// never fetched. Global is folded first, so an oldest-wins rule would
+    /// let that scope drag the header to "Not checked for updates yet" while
+    /// every other scope fetched minutes ago.
+    #[test]
+    fn a_scope_that_never_fetched_does_not_drag_the_page_back() {
+        assert_eq!(
+            merge([dated(Some(2_000)), dated(None)]).last_fetched,
+            Some(2_000)
+        );
+        assert_eq!(
+            merge([dated(None), dated(Some(2_000))]).last_fetched,
+            Some(2_000),
+            "the fold cannot depend on which scope comes first"
+        );
+    }
+
+    /// Nothing anywhere has ever fetched: the page says so rather than
+    /// naming an instant.
+    #[test]
+    fn all_scopes_unfetched_stays_unfetched() {
+        assert_eq!(merge([dated(None), dated(None)]).last_fetched, None);
+        assert_eq!(merge([]).last_fetched, None);
+    }
+}

--- a/crates/core/src/package/updates.rs
+++ b/crates/core/src/package/updates.rs
@@ -106,6 +106,14 @@ pub struct UpdateRow {
 pub struct UpdatesReport {
     pub rows: Vec<UpdateRow>,
     pub warnings: Vec<ItemWarning>,
+    /// When the mirrors behind this standing were last brought current —
+    /// Unix seconds, `None` when nothing has ever fetched. A clean report
+    /// is only as true as the fetch under it, so the age of that fetch
+    /// travels with it rather than being left for the reader to guess.
+    ///
+    /// `u32` for the same reason [`crate::model::ObservedItem::modified_at`]
+    /// is: specta refuses to export a 64-bit int across the IPC boundary.
+    pub last_fetched: Option<u32>,
 }
 
 /// A package whose update notifications are switched off, by everything
@@ -140,6 +148,7 @@ pub fn updates(env: &Env, scope: &Scope) -> Result<UpdatesReport> {
         return Ok(UpdatesReport {
             rows: Vec::new(),
             warnings: Vec::new(),
+            last_fetched: None,
         });
     };
     let lock = crate::lock::load_file(&crate::lock::lock_path(env, scope))?;
@@ -162,6 +171,11 @@ pub fn updates(env: &Env, scope: &Scope) -> Result<UpdatesReport> {
     let mut report = UpdatesReport {
         rows: Vec::new(),
         warnings: Vec::new(),
+        // A stamp that does not fit the narrower type — past 2106, or a
+        // clock artifact from the far future — reads as never checked
+        // rather than wrapping into a plausible-looking wrong instant.
+        last_fetched: crate::remote::last_fetched(env, &manifest)
+            .and_then(|at| u32::try_from(at).ok()),
     };
     for planned in crate::engine::planned_declarations(env, scope, &manifest) {
         eval.standing(&planned, &mut report);

--- a/crates/core/src/remote.rs
+++ b/crates/core/src/remote.rs
@@ -163,7 +163,7 @@ pub fn cached(env: &Env, repo: &str, rev: Option<&str>) -> Result<Option<Resolut
 /// touching the network. Stamp writes are best-effort by design: a stamp
 /// that cannot be written costs staleness detection, never the fetch —
 /// and an unwritable stamp reads as stale, the conservative state.
-fn stamp_fetch(env: &Env, key: &str, mirror: &std::path::Path, fetched: &Result<()>) {
+pub(crate) fn stamp_fetch(env: &Env, key: &str, mirror: &std::path::Path, fetched: &Result<()>) {
     let now = crate::clock::unix_now();
     let _ = match fetched {
         Ok(()) => crate::drift::stamps::record_success(
@@ -209,6 +209,31 @@ pub fn fetch_all(env: &Env, manifest: &Manifest) -> Vec<String> {
         drop(guard);
     }
     warnings
+}
+
+/// When this scope's mirrors were last brought current: Unix seconds of the
+/// most recent successful fetch among the enabled remote sources it installs
+/// from, `None` when none of them has ever fetched. Read straight off the
+/// per-mirror stamps [`stamp_fetch`] writes, so it counts the background
+/// refresh's fetches as well as an explicit check.
+///
+/// The sources in use and no others — the population the standing's rows
+/// are built from. A subscribed source nobody installs from fetches when it
+/// is merely opened, and dating the page from that would call a standing
+/// fresh whose every source had been unreachable for days.
+///
+/// The most recent among those, not the oldest: one source that stays down
+/// would otherwise pin the answer at never-checked for as long as it is
+/// down, hiding a check that reached every other mirror. A failure keeps
+/// the last success ([`crate::drift::stamps::record_failure`] leaves
+/// `fetched_at` alone), so that source goes on reporting the age it last
+/// had rather than erasing the scope's.
+pub fn last_fetched(env: &Env, manifest: &Manifest) -> Option<u64> {
+    let in_use = sources_in_use(manifest);
+    syncable(manifest, |name| in_use.contains(name))
+        .filter_map(|(_, decl)| decl.repo.as_deref())
+        .filter_map(|repo| crate::drift::stamps::load(env, &cache_key(env, repo)).fetched_at)
+        .max()
 }
 
 /// The sources some declaration actually names — items, and the bundles

--- a/crates/core/src/remote.rs
+++ b/crates/core/src/remote.rs
@@ -228,11 +228,19 @@ pub fn fetch_all(env: &Env, manifest: &Manifest) -> Vec<String> {
 /// the last success ([`crate::drift::stamps::record_failure`] leaves
 /// `fetched_at` alone), so that source goes on reporting the age it last
 /// had rather than erasing the scope's.
+///
+/// A stamp ahead of the clock is dropped, the reading
+/// [`crate::drift::stamps::FetchStamp::is_stale`] already takes of one: a
+/// clock that ran backwards certifies no freshness, and taking the maximum
+/// would let it both date the page as current and bury the mirrors that
+/// answered honestly.
 pub fn last_fetched(env: &Env, manifest: &Manifest) -> Option<u64> {
+    let now = crate::clock::unix_now();
     let in_use = sources_in_use(manifest);
     syncable(manifest, |name| in_use.contains(name))
         .filter_map(|(_, decl)| decl.repo.as_deref())
         .filter_map(|repo| crate::drift::stamps::load(env, &cache_key(env, repo)).fetched_at)
+        .filter(|at| *at <= now)
         .max()
 }
 

--- a/crates/core/src/remote/tests.rs
+++ b/crates/core/src/remote/tests.rs
@@ -318,3 +318,82 @@ fn the_cache_lock_releases_while_a_description_copy_exists() {
     drop(copy);
     relock.expect("drop released the lock despite the live description copy");
 }
+
+/// A scope's last check is the newest of its mirrors, never the oldest: a
+/// source that keeps failing must not read as "never checked" over mirrors
+/// that came current minutes ago. Sources with nothing to fetch — a local
+/// path, a disabled declaration — hold no opinion either way.
+#[test]
+fn the_scope_last_fetched_is_the_newest_of_its_mirrors() {
+    let tmp = tempfile::tempdir().unwrap();
+    let env = Env::fake(tmp.path(), FakeOs::Linux);
+    let source = |repo: Option<&str>, enabled: bool| SourceDecl {
+        repo: repo.map(str::to_owned),
+        path: None,
+        rev: None,
+        enabled,
+    };
+    let mut manifest = Manifest {
+        schema: crate::manifest::MANIFEST_SCHEMA,
+        ..Manifest::default()
+    };
+    manifest
+        .sources
+        .insert("cat".into(), source(Some("owner/cat"), true));
+    manifest
+        .sources
+        .insert("dog".into(), source(Some("owner/dog"), true));
+    manifest
+        .sources
+        .insert("off".into(), source(Some("owner/off"), false));
+    manifest.sources.insert("here".into(), source(None, true));
+    // Enabled and remote, but nothing installs from it — a subscription
+    // somebody is only browsing.
+    manifest
+        .sources
+        .insert("shop".into(), source(Some("owner/shop"), true));
+    for (name, from) in [("gh", "cat"), ("jj", "dog"), ("here-one", "here")] {
+        manifest
+            .skills
+            .insert(name.into(), crate::manifest::ItemDecl::from_source(from));
+    }
+
+    assert_eq!(
+        last_fetched(&env, &manifest),
+        None,
+        "no mirror has ever fetched: the scope has never been checked"
+    );
+
+    let stamp = |repo: &str, at: u64| {
+        crate::drift::stamps::record_success(&env, &cache_key(&env, repo), None, at).unwrap();
+    };
+    stamp("owner/cat", 1_000);
+    assert_eq!(last_fetched(&env, &manifest), Some(1_000));
+    stamp("owner/dog", 2_000);
+    assert_eq!(last_fetched(&env, &manifest), Some(2_000));
+    // The older mirror failing since does not move the answer backwards,
+    // and its failure is reported on its own.
+    crate::drift::stamps::record_failure(&env, &cache_key(&env, "owner/cat"), "offline", 3_000)
+        .unwrap();
+    assert_eq!(last_fetched(&env, &manifest), Some(2_000));
+
+    // A disabled source and a local one are not fetched, so a stamp under
+    // one of their names cannot answer for the scope.
+    stamp("owner/off", 9_000);
+    assert_eq!(
+        last_fetched(&env, &manifest),
+        Some(2_000),
+        "a source nothing fetches says nothing about when the scope was checked"
+    );
+
+    // The rows come from the sources the scope installs from. Merely
+    // opening a subscription fetches its mirror, and dating the page from
+    // that would call the standing fresh while every source behind it had
+    // gone unreached for days.
+    stamp("owner/shop", 8_000);
+    assert_eq!(
+        last_fetched(&env, &manifest),
+        Some(2_000),
+        "a source no row comes from cannot date the standing"
+    );
+}

--- a/crates/core/src/remote/tests.rs
+++ b/crates/core/src/remote/tests.rs
@@ -396,4 +396,16 @@ fn the_scope_last_fetched_is_the_newest_of_its_mirrors() {
         Some(2_000),
         "a source no row comes from cannot date the standing"
     );
+
+    // A stamp ahead of the clock is a clock that ran backwards, which the
+    // drift check already refuses to read as fresh. The newest mirror is
+    // now the future one, so an unfiltered maximum would both date the
+    // page as current and bury the one mirror still answering honestly —
+    // cat's last success at 1_000, kept under its later failure.
+    stamp("owner/dog", crate::clock::unix_now() + 86_400);
+    assert_eq!(
+        last_fetched(&env, &manifest),
+        Some(1_000),
+        "a future stamp neither dates the scope nor hides a valid one"
+    );
 }

--- a/crates/core/src/source_ops/subscribe.rs
+++ b/crates/core/src/source_ops/subscribe.rs
@@ -301,6 +301,7 @@ fn normalize_tree(
     // Best-effort fetch: a mirror already downloaded answers offline.
     let fetched = crate::remote::store::ensure_mirror(&mirror, &url)
         .and_then(|()| crate::remote::store::fetch(&mirror));
+    crate::remote::stamp_fetch(env, &key, &mirror, &fetched);
     let refs: Vec<crate::source_ref::MirrorRef> = crate::remote::store::ref_names(&mirror)
         .unwrap_or_default()
         .iter()

--- a/crates/core/tests/drift_check.rs
+++ b/crates/core/tests/drift_check.rs
@@ -199,6 +199,66 @@ fn a_pin_reaching_a_dependency_through_its_parent_reports_held() {
     );
 }
 
+/// The Updates page says how old its answer is, so the fetch that produced
+/// it has to reach the report: the stamp a check writes comes back out of
+/// `updates`, and a scope nothing has fetched says so rather than passing
+/// off an unchecked standing as a fresh one.
+#[test]
+#[allow(clippy::unwrap_used)]
+fn the_report_carries_when_its_mirrors_were_last_fetched() {
+    let w = world();
+    write_skill(&w.upstream, "gh", "One.");
+    commit(&w.upstream, "one");
+    declare(&w, "", "[skills.gh]\nsource = \"cat\"\n");
+
+    assert_eq!(
+        updates::updates(&w.env, &w.scope).unwrap().last_fetched,
+        None,
+        "nothing has fetched yet: the scope has never been checked"
+    );
+
+    sync_and_apply(&w);
+    // The check the Updates page runs, on the same manifest the command
+    // hands it.
+    let before = u32::try_from(kendex_core::clock::unix_now()).unwrap();
+    let loaded = manifest::load_for_mutation(&manifest::manifest_path(&w.env, &w.scope))
+        .unwrap()
+        .unwrap();
+    assert!(remote::fetch_all(&w.env, &loaded).is_empty());
+
+    let at = updates::updates(&w.env, &w.scope)
+        .unwrap()
+        .last_fetched
+        .expect("the fetch a check just ran is what the page dates its answer from");
+    assert!(
+        at >= before,
+        "the report dates from this check, not an older one: {at} < {before}"
+    );
+}
+
+/// The report narrows the stamp to `u32` to cross the IPC boundary. A value
+/// that does not fit — past 2106, or a clock that ran far forward — has to
+/// read as never checked: wrapping it would put a plausible-looking wrong
+/// instant under rows nobody has verified.
+#[test]
+#[allow(clippy::unwrap_used)]
+fn a_stamp_too_large_to_report_reads_as_never_checked() {
+    let w = world();
+    write_skill(&w.upstream, "gh", "One.");
+    commit(&w.upstream, "one");
+    declare(&w, "", "[skills.gh]\nsource = \"cat\"\n");
+    sync_and_apply(&w);
+    assert!(updates::updates(&w.env, &w.scope).unwrap().last_fetched > Some(0));
+
+    let key = remote::cache_key(&w.env, REPO);
+    drift::stamps::record_success(&w.env, &key, None, u64::from(u32::MAX) + 1).unwrap();
+    assert_eq!(
+        updates::updates(&w.env, &w.scope).unwrap().last_fetched,
+        None,
+        "a stamp the report cannot carry is refused, never wrapped"
+    );
+}
+
 #[test]
 #[allow(clippy::unwrap_used)]
 fn a_package_gone_from_its_source_is_a_fact_not_a_silent_skip() {

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -500,23 +500,23 @@ lives in one capability table read by core and UI.
   nothing. A held item hashes clean against its held tree; the Updates page
   asks the mirror (pinned sources too) what newer content exists, its
   timeline listing only commits that touched the package's files,
-  tag-decorated, never tag-replaced. Rows are per package per scope, folded
-  by package and expanded by place; a row's Update applies that package
-  (`PlanOptions::update_only`), apply and refresh a whole place.
-  Flipping Follow source is one row's state change and a write that settles
-  behind it (`ui/src/stores/updates-follow.ts`): the switch carries its new
-  position from the click, while the hold, the scope apply, and the read of
-  every scope's standing after them take seconds. The flip is pending until
-  that read lands — every landing wears it, so a read begun earlier cannot
-  bounce the switch — and it holds its own scope's rows and no others
-  (`lib/updates-read-state.ts::rowUnsettled`), an apply reaching only what
-  is installed there. A refused write stops the flip painting and says so at
-  once, but the rows already wear it, so the scope goes on holding until the
-  read that puts them back lands — and when every read behind it failed too,
-  the flip puts them back itself before letting the scope go. No row wears a
-  position the engine did not take. An edited
-  place is never updated over: its row says so and offers the install
-  beside it where a newer version the source still carries can land, and a
+  tag-decorated, never tag-replaced. `UpdatesReport::last_fetched` dates
+  the standing — the newest successful fetch among the sources the scope
+  installs from, the newest across scopes in the overview — so "Everything
+  is up to date" is dated too. Rows are per package per scope, folded by
+  package and expanded by place; a row's Update applies that package
+  (`PlanOptions::update_only`), apply and refresh a whole place. Flipping
+  Follow source is one row's state change, its write settling behind it
+  (`ui/src/stores/updates-follow.ts`): the switch takes its position from
+  the click, pending until every scope's standing is read again — every
+  landing wears it, so a read begun earlier cannot bounce it — over its own
+  scope's rows only (`lib/updates-read-state.ts::rowUnsettled`), the apply
+  reaching only what is installed there. A refused write says so at once,
+  but the rows already wear it: the scope holds until a read puts them
+  back, or the flip restores them when every read failed. No row wears a
+  position the engine did not take. An edited place is never updated over:
+  its row says so and offers the install beside it where a newer version
+  the source still carries can land, and a
   link to the package page otherwise; the fork-or-discard choice lives on
   the package page. Commit ids stay behind the table's `…` menu. Muting a
   package's update notifications is a machine-local settings entry. Reuse

--- a/ui/src/bindings.ts
+++ b/ui/src/bindings.ts
@@ -255,20 +255,6 @@ export const commands = {
 	 */
 	packageUpdate: (scope: Scope, kind: ItemKind, name: string) => typedError<PackageUpdate_Serialize, string>(__TAURI_INVOKE("package_update", { scope, kind, name })),
 	/**
-	 *  Every scope's update standing in one query — the sidebar badge, the
-	 *  Updates page, and the Library's fork/edited flags all read this. Rows
-	 *  carry the facts; warnings carry every package the standing could not be
-	 *  computed for, which is never silently shown as current.
-	 */
-	updatesOverview: () => typedError<UpdatesReport_Serialize, string>(__TAURI_INVOKE("updates_overview")),
-	/**
-	 *  Fetch every source's mirror — pinned ones included, that is the point —
-	 *  then answer with the fresh standing. Fetch problems degrade to
-	 *  warnings; a check for updates is never worth an error dialog.
-	 */
-	updatesRefresh: () => typedError<UpdatesReport_Serialize, string>(__TAURI_INVOKE("updates_refresh")),
-	updateSetIgnored: (scope: Scope, kind: ItemKind, name: string, repo: string, ignored: boolean) => typedError<UpdatesReport_Serialize, string>(__TAURI_INVOKE("update_set_ignored", { scope, kind, name, repo, ignored })),
-	/**
 	 *  Hold a package at a version (or let it follow again) and apply the
 	 *  change, scoped to the package: every other follower in the scope reads
 	 *  the commit its lock records, so moving one hold does not bring the
@@ -302,6 +288,20 @@ export const commands = {
 	truncated: boolean,
 } | null, string>(__TAURI_INVOKE("package_readme", { scope, kind, name })),
 	packageMeta: (scope: Scope, kind: ItemKind, name: string) => typedError<PackageMeta_Serialize, string>(__TAURI_INVOKE("package_meta", { scope, kind, name })),
+	/**
+	 *  Every scope's update standing in one query — the sidebar badge, the
+	 *  Updates page, and the Library's fork/edited flags all read this. Rows
+	 *  carry the facts; warnings carry every package the standing could not be
+	 *  computed for, which is never silently shown as current.
+	 */
+	updatesOverview: () => typedError<UpdatesReport_Serialize, string>(__TAURI_INVOKE("updates_overview")),
+	/**
+	 *  Fetch every source's mirror — pinned ones included, that is the point —
+	 *  then answer with the fresh standing. Fetch problems degrade to
+	 *  warnings; a check for updates is never worth an error dialog.
+	 */
+	updatesRefresh: () => typedError<UpdatesReport_Serialize, string>(__TAURI_INVOKE("updates_refresh")),
+	updateSetIgnored: (scope: Scope, kind: ItemKind, name: string, repo: string, ignored: boolean) => typedError<UpdatesReport_Serialize, string>(__TAURI_INVOKE("update_set_ignored", { scope, kind, name, repo, ignored })),
 	/**
 	 *  Zoom is set on the webview rather than by restyling the page: it holds
 	 *  across reloads, and it scales the app's own titlebar along with
@@ -2376,6 +2376,16 @@ export type UpdatesReport = UpdatesReport_Serialize | UpdatesReport_Deserialize;
 export type UpdatesReport_Deserialize = {
 	rows: UpdateRow[],
 	warnings: ItemWarning_Deserialize[],
+	/**
+	 *  When the mirrors behind this standing were last brought current —
+	 *  Unix seconds, `None` when nothing has ever fetched. A clean report
+	 *  is only as true as the fetch under it, so the age of that fetch
+	 *  travels with it rather than being left for the reader to guess.
+	 * 
+	 *  `u32` for the same reason [`crate::model::ObservedItem::modified_at`]
+	 *  is: specta refuses to export a 64-bit int across the IPC boundary.
+	 */
+	lastFetched: number | null,
 };
 
 /**
@@ -2386,6 +2396,16 @@ export type UpdatesReport_Deserialize = {
 export type UpdatesReport_Serialize = {
 	rows: UpdateRow[],
 	warnings: ItemWarning_Serialize[],
+	/**
+	 *  When the mirrors behind this standing were last brought current —
+	 *  Unix seconds, `None` when nothing has ever fetched. A clean report
+	 *  is only as true as the fetch under it, so the age of that fetch
+	 *  travels with it rather than being left for the reader to guess.
+	 * 
+	 *  `u32` for the same reason [`crate::model::ObservedItem::modified_at`]
+	 *  is: specta refuses to export a 64-bit int across the IPC boundary.
+	 */
+	lastFetched: number | null,
 };
 
 /**  One version a row points at. */

--- a/ui/src/components/status-footer.tsx
+++ b/ui/src/components/status-footer.tsx
@@ -1,5 +1,4 @@
 import { RefreshCw } from "lucide-react";
-import { useEffect, useState } from "react";
 import { StatusDot } from "@/components/status-dot";
 import {
   SCANNING_LABEL,
@@ -8,11 +7,10 @@ import {
 } from "@/lib/copy-footer";
 import { problemsFooterLabel } from "@/lib/error-copy";
 import { relativeTime } from "@/lib/relative-time";
+import { useNowTick } from "@/lib/use-now-tick";
 import { useNavStore } from "@/stores/nav";
 import { useProblems } from "@/stores/problems";
 import { useScanStore } from "@/stores/scan";
-
-const AGE_TICK_MS = 30_000;
 
 // A persistent strip across the whole window, not just the content pane —
 // scan freshness and problems apply regardless of which page you're looking
@@ -26,11 +24,7 @@ export function StatusFooter() {
 
   // "Scanned Nm ago" goes stale on its own; nothing else re-renders this
   // component often enough to keep it honest.
-  const [now, setNow] = useState(() => Date.now());
-  useEffect(() => {
-    const id = setInterval(() => setNow(Date.now()), AGE_TICK_MS);
-    return () => clearInterval(id);
-  }, []);
+  const now = useNowTick();
 
   return (
     <footer className="flex h-7 shrink-0 items-center border-t bg-background px-4 text-xs text-muted-foreground">

--- a/ui/src/components/update-follow.dom.test.tsx
+++ b/ui/src/components/update-follow.dom.test.tsx
@@ -164,7 +164,7 @@ beforeEach(() => {
   vi.clearAllMocks();
   vi.mocked(commands.updatesOverview).mockResolvedValue({
     status: "ok",
-    data: { rows, warnings: [] },
+    data: { rows, warnings: [], lastFetched: null },
   });
 });
 

--- a/ui/src/components/updates-before-list.tsx
+++ b/ui/src/components/updates-before-list.tsx
@@ -22,12 +22,15 @@ export function updatesBeforeList({
   error,
   empty,
   checking,
+  lastChecked,
   onCheck,
 }: {
   loaded: boolean;
   error: string | null;
   empty: boolean;
   checking: boolean;
+  /** How old the answer behind this page is, already worded. */
+  lastChecked: string;
   onCheck: () => void;
 }): ReactNode | null {
   const retry = (
@@ -67,12 +70,14 @@ export function updatesBeforeList({
   }
   // With nothing to update there is nothing to introduce: a title and a
   // sentence explaining a list that isn't there is furniture around good
-  // news. The sidebar already says which page this is.
+  // news. The sidebar already says which page this is. The age of the
+  // check is the exception — this is the page where a stale answer looks
+  // exactly like a current one, so the good news says how old it is.
   if (empty) {
     return (
       <div className="flex min-h-full items-center justify-center">
         <EmptyState icon={CheckCircle2} title={UPDATES_EMPTY} action={retry}>
-          {UPDATES_EMPTY_BODY}
+          {`${UPDATES_EMPTY_BODY} ${lastChecked}.`}
         </EmptyState>
       </div>
     );

--- a/ui/src/components/updates-table.dom.test.tsx
+++ b/ui/src/components/updates-table.dom.test.tsx
@@ -70,7 +70,7 @@ beforeEach(() => {
   vi.clearAllMocks();
   vi.mocked(commands.updatesOverview).mockResolvedValue({
     status: "ok",
-    data: { rows: [], warnings: [] },
+    data: { rows: [], warnings: [], lastFetched: null },
   });
   vi.mocked(commands.scanMachine).mockResolvedValue({
     status: "ok",
@@ -208,6 +208,7 @@ describe("the table's own menu", () => {
       data: {
         rows: [row("one", null), row("two", null, { ignored: true })],
         warnings: [],
+        lastFetched: null,
       },
     });
     const host = mount(<UpdatesPage />);
@@ -241,7 +242,11 @@ describe("a page with only muted updates", () => {
   it("still carries the `…` menu, on the muted table", async () => {
     vi.mocked(commands.updatesOverview).mockResolvedValue({
       status: "ok",
-      data: { rows: [row("two", null, { ignored: true })], warnings: [] },
+      data: {
+        rows: [row("two", null, { ignored: true })],
+        warnings: [],
+        lastFetched: null,
+      },
     });
     const host = mount(<UpdatesPage />);
     await settle();
@@ -376,6 +381,7 @@ describe("a row of a kind the planner never brings current", () => {
           row("gh", null),
         ],
         warnings: [],
+        lastFetched: null,
       },
     });
     mount(<UpdatesPage />);

--- a/ui/src/dev/mock-packages.ts
+++ b/ui/src/dev/mock-packages.ts
@@ -17,6 +17,14 @@ const SKILL_BODY = [
 
 const README = "# gh\n\nGitHub flows for coding agents.\n";
 
+// The mock fetches nothing, so the standing it answers with is as current
+// as the session reading it.
+const standing = () => ({
+  rows: updateRows(),
+  warnings: [],
+  lastFetched: Math.floor(Date.now() / 1000),
+});
+
 export const packageHandlers: Record<string, Handler> = {
   package_versions: ({ name }: { name: string }) => [
     {
@@ -36,8 +44,11 @@ export const packageHandlers: Record<string, Handler> = {
       newerThanInstalled: false,
     },
   ],
-  updates_overview: () => ({ rows: updateRows(), warnings: [] }),
-  updates_refresh: () => ({ rows: updateRows(), warnings: [] }),
+  // Every update standing carries the age of the fetch under it; a mock
+  // that returns the bare rows leaves the page reading that age off
+  // undefined.
+  updates_overview: () => standing(),
+  updates_refresh: () => standing(),
   update_set_ignored: ({
     kind,
     name,
@@ -51,7 +62,7 @@ export const packageHandlers: Record<string, Handler> = {
       (entry) => !(entry.kind === kind && entry.name === name),
     );
     if (ignored) store.state.ignored.push({ kind, name });
-    return { rows: updateRows(), warnings: [] };
+    return standing();
   },
   package_set_rev: ({ scope }: { scope: Scope }) => view(scope),
   // The single-package apply answers with what it wrote and what a

--- a/ui/src/lib/copy-updates.test.ts
+++ b/ui/src/lib/copy-updates.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from "vitest";
+import { lastCheckedLabel, NEVER_CHECKED } from "./copy-updates";
+
+// The overview reports Unix seconds; every relative wording below has to
+// come off that scale, not off milliseconds read as seconds.
+const SECONDS = 1_700_000_000;
+const at = (offsetMs: number): number => SECONDS * 1000 + offsetMs;
+
+describe("how old the update standing is", () => {
+  it("dates the answer from the last successful fetch", () => {
+    expect(lastCheckedLabel(SECONDS, at(0))).toBe("Last checked just now");
+    expect(lastCheckedLabel(SECONDS, at(3 * 60_000))).toBe(
+      "Last checked 3m ago",
+    );
+    expect(lastCheckedLabel(SECONDS, at(5 * 3_600_000))).toBe(
+      "Last checked 5h ago",
+    );
+    expect(lastCheckedLabel(SECONDS, at(5 * 86_400_000))).toBe(
+      "Last checked 5d ago",
+    );
+  });
+
+  // The whole point of the hint: a scope nothing has fetched must not read
+  // as a check that just ran, which is what an unlabelled clean page does.
+  it("says so when nothing has ever been fetched", () => {
+    expect(lastCheckedLabel(null, at(0))).toBe(NEVER_CHECKED);
+    expect(NEVER_CHECKED).not.toContain("ago");
+  });
+});

--- a/ui/src/lib/copy-updates.ts
+++ b/ui/src/lib/copy-updates.ts
@@ -1,6 +1,23 @@
 // Updates page copy: the table, the edited-copy row, and the toasts that
 // say what a bulk update did — kept apart from the rest so the wording is
 // reviewed in one place.
+import { relativeTime } from "@/lib/relative-time";
+
+export const NEVER_CHECKED = "Not checked for updates yet";
+
+/** How old the standing on this page is. "Everything is up to date" is only
+ *  as true as the fetch under it, and the check runs offline on load, so the
+ *  page says when it last reached a source rather than letting a clean
+ *  answer speak for an age nobody can see. */
+export const lastCheckedLabel = (
+  /** Unix seconds of the last successful fetch, as the overview reports it. */
+  fetchedAt: number | null,
+  nowMs: number,
+): string =>
+  fetchedAt === null
+    ? NEVER_CHECKED
+    : `Last checked ${relativeTime(fetchedAt * 1000, nowMs)}`;
+
 export const FOLLOW_SOURCE_COLUMN = "Follow source";
 export const FOLLOW_SOURCE_HELP =
   "On, this package takes the newest version when you press Update, and moves with everything else here when the place refreshes; off, it stays on this version until you choose one.";

--- a/ui/src/lib/use-now-tick.ts
+++ b/ui/src/lib/use-now-tick.ts
@@ -1,0 +1,17 @@
+import { useEffect, useState } from "react";
+
+/** How often an "N ago" label re-reads the clock. One rate for every age on
+ *  screen, so two of them never disagree about how old the same minute is. */
+export const AGE_TICK_MS = 30_000;
+
+/** Now, re-read on a timer. An age label goes stale on its own — nothing a
+ *  page does re-renders it often enough to keep it honest, and a label that
+ *  froze at mount is worse than none: it reads as a fact. */
+export function useNowTick(): number {
+  const [now, setNow] = useState(() => Date.now());
+  useEffect(() => {
+    const id = setInterval(() => setNow(Date.now()), AGE_TICK_MS);
+    return () => clearInterval(id);
+  }, []);
+  return now;
+}

--- a/ui/src/pages/updates-clock.dom.test.tsx
+++ b/ui/src/pages/updates-clock.dom.test.tsx
@@ -1,0 +1,50 @@
+// @vitest-environment jsdom
+import { act } from "react";
+import { afterEach, beforeEach, expect, it, vi } from "vitest";
+import { updateRow } from "@/components/updates-test-rows";
+import { AGE_TICK_MS } from "@/lib/use-now-tick";
+import { useUpdatesStore } from "@/stores/updates";
+import { mount } from "@/test/dom";
+import { UpdatesPage } from "./updates";
+
+// Only a read of the standing re-renders this page, and reads happen on
+// mount, on a check, and after a mutation. A window left open overnight
+// would otherwise still be showing the age it had when it opened — the
+// same frozen claim the hint exists to remove.
+//
+// The store is real; `load` is stubbed to a no-op so the mount effect
+// reaches no command and the age on screen can only come from the clock.
+beforeEach(() => {
+  vi.useFakeTimers();
+  useUpdatesStore.setState({
+    rows: [updateRow("gh", null)],
+    warnings: [],
+    lastFetched: Math.floor(Date.now() / 1000),
+    busy: false,
+    loaded: true,
+    checking: false,
+    overviewInFlight: false,
+    pendingFollows: [],
+    error: null,
+    load: async () => {},
+  });
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+it("ages the Last checked label on its own, with no read of the standing", () => {
+  const host = mount(<UpdatesPage />);
+  expect(host.textContent).toContain("Last checked just now");
+
+  const before = useUpdatesStore.getState();
+  act(() => {
+    vi.advanceTimersByTime(90_000 + AGE_TICK_MS);
+  });
+
+  expect(host.textContent).toContain("Last checked 2m ago");
+  expect(host.textContent).not.toContain("just now");
+  expect(useUpdatesStore.getState().rows).toBe(before.rows);
+  expect(useUpdatesStore.getState().lastFetched).toBe(before.lastFetched);
+});

--- a/ui/src/pages/updates.test.tsx
+++ b/ui/src/pages/updates.test.tsx
@@ -9,6 +9,7 @@ import {
   UPDATES_EMPTY,
 } from "@/lib/copy";
 import {
+  NEVER_CHECKED,
   UPDATE_NEEDS_CHECK_NOTE,
   UPDATES_CHECKING,
   UPDATES_UNCONFIRMED_TITLE,
@@ -26,6 +27,7 @@ const stub = vi.hoisted(() => ({
   rows: [] as unknown[],
   loaded: true,
   error: null as string | null,
+  lastFetched: null as number | null,
 }));
 
 vi.mock("@/stores/updates", async (importOriginal) => {
@@ -39,6 +41,7 @@ vi.mock("@/stores/updates", async (importOriginal) => {
       checking: false,
       loaded: stub.loaded,
       error: stub.error,
+      lastFetched: stub.lastFetched,
       load: async () => {},
     };
     return selector ? selector(state) : state;
@@ -50,7 +53,12 @@ beforeEach(() => {
   stub.rows = [];
   stub.loaded = true;
   stub.error = null;
+  stub.lastFetched = null;
 });
+
+/** Unix seconds `ago` seconds before now — the shape the overview reports,
+ *  read against the same clock the page renders against. */
+const secondsAgo = (ago: number) => Math.floor(Date.now() / 1000) - ago;
 
 // Empty rows and no error read as good news, so before the first read
 // answers — and after one that failed — "Everything is up to date" would
@@ -123,5 +131,44 @@ describe("the Updates page across its read states", () => {
       new RegExp(`<button[^>]*disabled=""[^>]*>${UPDATE_ALL_LABEL}<`),
     );
     expect(html).toContain(`title="${UPDATE_NEEDS_CHECK_NOTE}"`);
+  });
+});
+
+// The check runs offline on load, so what is on screen can be days old
+// with nothing about it saying so. Every state that presents an answer
+// says how old that answer is.
+describe("how fresh the page says its answer is", () => {
+  it("dates the list from the last fetch behind it", () => {
+    stub.rows = [updateRow("gh", null)];
+    stub.lastFetched = secondsAgo(3 * 3600);
+    expect(renderToStaticMarkup(<UpdatesPage />)).toContain(
+      "Last checked 3h ago",
+    );
+  });
+
+  // The state the hint exists for: "Everything is up to date" looks the
+  // same whether it was checked a minute or a month ago.
+  it("dates the up-to-date state, which is the one that hides its age", () => {
+    stub.lastFetched = secondsAgo(5 * 86_400);
+    const html = renderToStaticMarkup(<UpdatesPage />);
+    expect(html).toContain(UPDATES_EMPTY);
+    expect(html).toContain("Last checked 5d ago");
+  });
+
+  it("never dates an answer no check has produced", () => {
+    stub.rows = [updateRow("gh", null)];
+    const html = renderToStaticMarkup(<UpdatesPage />);
+    expect(html).toContain(NEVER_CHECKED);
+    expect(html).not.toMatch(/Last checked/);
+  });
+
+  // A fresh install on first launch: nothing to update and nothing fetched
+  // yet. The one state where an unqualified "Everything is up to date"
+  // would be pure guess, and the two hint sites cross here.
+  it("does not call a scope it has never checked up to date without saying so", () => {
+    const html = renderToStaticMarkup(<UpdatesPage />);
+    expect(html).toContain(UPDATES_EMPTY);
+    expect(html).toContain(NEVER_CHECKED);
+    expect(html).not.toMatch(/Last checked/);
   });
 });

--- a/ui/src/pages/updates.tsx
+++ b/ui/src/pages/updates.tsx
@@ -25,6 +25,7 @@ import {
   UPDATES_UNCHECKED_TITLE,
 } from "@/lib/copy";
 import {
+  lastCheckedLabel,
   UPDATE_NEEDS_CHECK_NOTE,
   UPDATES_UNCONFIRMED_TITLE,
   updatesSubtitle,
@@ -37,6 +38,7 @@ import {
   visibleUpdates,
 } from "@/lib/update-groups";
 import { rowUnsettled } from "@/lib/updates-read-state";
+import { useNowTick } from "@/lib/use-now-tick";
 import { cn } from "@/lib/utils";
 import { useAuditOnMount } from "@/stores/audit";
 import { useUpdatesStore } from "@/stores/updates";
@@ -57,6 +59,7 @@ export function UpdatesPage() {
     visibleUpdates(s.rows).some((row) => rowUnsettled(s, row)),
   );
   const load = useUpdatesStore((s) => s.load);
+  const lastFetched = useUpdatesStore((s) => s.lastFetched);
   // One choice for every table on the page; the `…` menu lives on the
   // main table, or on the muted one when it is the only table drawn.
   const setShowVersion = useUpdatesView((s) => s.setShowVersion);
@@ -76,11 +79,18 @@ export function UpdatesPage() {
   const empty =
     visible.length === 0 && hidden.length === 0 && warnings.length === 0;
 
+  // On the page's own clock, not the render's. Only a read of the standing
+  // re-renders this — mount, a check, a mutation — so a window left open
+  // would go on claiming the age it had when it opened.
+  const now = useNowTick();
+  const lastChecked = lastCheckedLabel(lastFetched, now);
+
   const beforeList = updatesBeforeList({
     loaded,
     error,
     empty,
     checking,
+    lastChecked,
     onCheck: () => void check(),
   });
   if (beforeList) return beforeList;
@@ -91,9 +101,12 @@ export function UpdatesPage() {
         title="Updates"
         wide
         subtitle={
-          visible.length > 0
-            ? updatesSubtitle(packageCount(visible), visible.length)
-            : undefined
+          <>
+            {visible.length > 0 ? (
+              <p>{updatesSubtitle(packageCount(visible), visible.length)}</p>
+            ) : null}
+            <p className="text-xs">{lastChecked}</p>
+          </>
         }
         action={
           <div className="flex gap-2">

--- a/ui/src/stores/updates-bulk.test.ts
+++ b/ui/src/stores/updates-bulk.test.ts
@@ -70,7 +70,7 @@ describe("updates store: bulk update", () => {
     vi.mocked(commands.packageUpdate).mockRejectedValue(new Error("ipc down"));
     vi.mocked(commands.updatesOverview).mockResolvedValue({
       status: "ok",
-      data: { rows: [], warnings: [] },
+      data: { rows: [], warnings: [], lastFetched: null },
     });
     vi.mocked(commands.scanMachine).mockResolvedValue({
       status: "ok",
@@ -108,7 +108,7 @@ describe("updates store: bulk update", () => {
     });
     vi.mocked(commands.updatesOverview).mockResolvedValue({
       status: "ok",
-      data: { rows: [], warnings: [] },
+      data: { rows: [], warnings: [], lastFetched: null },
     });
     vi.mocked(commands.scanMachine).mockResolvedValue({
       status: "ok",
@@ -170,7 +170,7 @@ describe("updates store: bulk update", () => {
     });
     vi.mocked(commands.updatesOverview).mockResolvedValue({
       status: "ok",
-      data: { rows: [], warnings: [] },
+      data: { rows: [], warnings: [], lastFetched: null },
     });
     vi.mocked(commands.scanMachine).mockResolvedValue({
       status: "ok",
@@ -235,7 +235,7 @@ describe("updates store: bulk update", () => {
     });
     vi.mocked(commands.updatesOverview).mockResolvedValue({
       status: "ok",
-      data: { rows: [], warnings: [] },
+      data: { rows: [], warnings: [], lastFetched: null },
     });
     vi.mocked(commands.scanMachine).mockResolvedValue({
       status: "ok",
@@ -306,7 +306,7 @@ describe("updates store: what a bulk update claims about held-back places", () =
     );
     vi.mocked(commands.updatesOverview).mockResolvedValue({
       status: "ok",
-      data: { rows: [], warnings: [] },
+      data: { rows: [], warnings: [], lastFetched: null },
     });
     vi.mocked(commands.scanMachine).mockResolvedValue({
       status: "ok",
@@ -406,7 +406,7 @@ describe("updates store: a bulk run that took a copy away", () => {
     );
     vi.mocked(commands.updatesOverview).mockResolvedValue({
       status: "ok",
-      data: { rows: [], warnings: [] },
+      data: { rows: [], warnings: [], lastFetched: null },
     });
     vi.mocked(commands.scanMachine).mockResolvedValue({
       status: "ok",
@@ -517,7 +517,7 @@ describe("updates store: a run where one place failed", () => {
     );
     vi.mocked(commands.updatesOverview).mockResolvedValue({
       status: "ok",
-      data: { rows: [], warnings: [] },
+      data: { rows: [], warnings: [], lastFetched: null },
     });
     vi.mocked(commands.scanMachine).mockResolvedValue({
       status: "ok",
@@ -620,7 +620,7 @@ describe("updates store: what a bulk run cannot lose", () => {
     );
     vi.mocked(commands.updatesOverview).mockResolvedValue({
       status: "ok",
-      data: { rows: remaining, warnings: [] },
+      data: { rows: remaining, warnings: [], lastFetched: null },
     });
     vi.mocked(commands.scanMachine).mockResolvedValue({
       status: "ok",

--- a/ui/src/stores/updates-edits.test.ts
+++ b/ui/src/stores/updates-edits.test.ts
@@ -80,7 +80,7 @@ describe("updates store: edited places", () => {
     vi.mocked(commands.packageFork).mockRejectedValue(new Error("ipc down"));
     vi.mocked(commands.updatesOverview).mockResolvedValue({
       status: "ok",
-      data: { rows: [], warnings: [] },
+      data: { rows: [], warnings: [], lastFetched: null },
     });
 
     await keepAsOwn(
@@ -106,7 +106,7 @@ describe("updates store: edited places", () => {
     );
     vi.mocked(commands.updatesOverview).mockResolvedValue({
       status: "ok",
-      data: { rows: [], warnings: [] },
+      data: { rows: [], warnings: [], lastFetched: null },
     });
 
     await takeNewVersion(
@@ -159,7 +159,7 @@ describe("updates store: edited places", () => {
     });
     vi.mocked(commands.updatesOverview).mockResolvedValue({
       status: "ok",
-      data: { rows: [], warnings: [] },
+      data: { rows: [], warnings: [], lastFetched: null },
     });
     vi.mocked(commands.scanMachine).mockResolvedValue({
       status: "ok",
@@ -249,7 +249,7 @@ describe("updates store: installing beside an edited place", () => {
     vi.clearAllMocks();
     vi.mocked(commands.updatesOverview).mockResolvedValue({
       status: "ok",
-      data: { rows: [], warnings: [] },
+      data: { rows: [], warnings: [], lastFetched: null },
     });
     vi.mocked(commands.scanMachine).mockResolvedValue({
       status: "ok",
@@ -449,7 +449,7 @@ describe("updates store: installing beside an edited place", () => {
     });
     vi.mocked(commands.updatesOverview).mockResolvedValue({
       status: "ok",
-      data: { rows: [], warnings: [] },
+      data: { rows: [], warnings: [], lastFetched: null },
     });
     vi.mocked(commands.scanMachine).mockResolvedValue({
       status: "ok",

--- a/ui/src/stores/updates-overview.ts
+++ b/ui/src/stores/updates-overview.ts
@@ -3,7 +3,11 @@ import { settled } from "@/lib/settled";
 import { landings } from "./landings";
 import { type PendingFollow, withPending } from "./updates-follow";
 
-type Overview = { rows: UpdateRow[]; warnings: ItemWarning[] };
+type Overview = {
+  rows: UpdateRow[];
+  warnings: ItemWarning[];
+  lastFetched: number | null;
+};
 type OverviewResult =
   | { status: "ok"; data: Overview }
   | { status: "error"; error: string };
@@ -42,6 +46,7 @@ export function overviewApplier(
     loaded?: boolean;
     error?: string | null;
     overviewInFlight?: boolean;
+    lastFetched?: number | null;
   }) => void,
   /** The follow flips whose writes have not answered — every landing wears
    *  them, so a read that began before a flip cannot bounce the switch. */
@@ -56,10 +61,14 @@ export function overviewApplier(
   // is counted here by the store's pending flips instead.
   let inFlight = 0;
 
+  // A read that failed keeps the age it had along with the rows it had: a
+  // check that could not run fetched nothing, so the last fetch is still
+  // when these rows were last true.
   const landOk = (data: Overview) =>
     set({
       rows: withPending(data.rows, pending()),
       warnings: data.warnings,
+      lastFetched: data.lastFetched,
       loaded: true,
       error: null,
     });

--- a/ui/src/stores/updates-overview.ts
+++ b/ui/src/stores/updates-overview.ts
@@ -1,13 +1,16 @@
-import { commands, type ItemWarning, type UpdateRow } from "@/bindings";
+import {
+  commands,
+  type ItemWarning,
+  type UpdateRow,
+  type UpdatesReport_Serialize,
+} from "@/bindings";
 import { settled } from "@/lib/settled";
 import { landings } from "./landings";
 import { type PendingFollow, withPending } from "./updates-follow";
 
-type Overview = {
-  rows: UpdateRow[];
-  warnings: ItemWarning[];
-  lastFetched: number | null;
-};
+// The command's own answer, as generated. A hand-written twin of it goes
+// out of step the moment the Rust report gains a field.
+type Overview = UpdatesReport_Serialize;
 type OverviewResult =
   | { status: "ok"; data: Overview }
   | { status: "error"; error: string };

--- a/ui/src/stores/updates-toast.test.ts
+++ b/ui/src/stores/updates-toast.test.ts
@@ -71,7 +71,7 @@ const ready = (remaining: UpdateRow[]) => {
   });
   vi.mocked(commands.updatesOverview).mockResolvedValue({
     status: "ok",
-    data: { rows: remaining, warnings: [] },
+    data: { rows: remaining, warnings: [], lastFetched: null },
   });
   vi.mocked(commands.scanMachine).mockResolvedValue({
     status: "ok",

--- a/ui/src/stores/updates.test.ts
+++ b/ui/src/stores/updates.test.ts
@@ -67,8 +67,47 @@ describe("updates store", () => {
       busy: false,
       loaded: true,
       error: null,
+      lastFetched: null,
     });
     vi.clearAllMocks();
+  });
+
+  // The age is the middle link of the round trip: the command reports it,
+  // the store has to carry it, the page draws it. Only `landOk` moves it,
+  // for every landing kind, and a store that quietly dropped it would leave
+  // the page saying "Not checked for updates yet" over a check that ran.
+  const CHECKED_AT = 1_700_000_000;
+
+  it("lands the age a read reports", async () => {
+    vi.mocked(commands.updatesOverview).mockResolvedValue({
+      status: "ok",
+      data: { rows: [row({})], warnings: [], lastFetched: CHECKED_AT },
+    });
+    await useUpdatesStore.getState().load();
+    expect(useUpdatesStore.getState().lastFetched).toBe(CHECKED_AT);
+  });
+
+  // The refresh lands on the side-effect chain rather than the plain-read
+  // path, so it carries the age through different code.
+  it("lands the age a check reports", async () => {
+    vi.mocked(commands.updatesRefresh).mockResolvedValue({
+      status: "ok",
+      data: { rows: [row({})], warnings: [], lastFetched: CHECKED_AT },
+    });
+    await useUpdatesStore.getState().check();
+    expect(useUpdatesStore.getState().lastFetched).toBe(CHECKED_AT);
+  });
+
+  // A check that failed fetched nothing, so the age it had is still when
+  // these rows were last true — dropping it would report a check nobody ran.
+  it("keeps the age it had when a check fails", async () => {
+    useUpdatesStore.setState({ lastFetched: CHECKED_AT });
+    vi.mocked(commands.updatesRefresh).mockResolvedValue({
+      status: "error",
+      error: "no network",
+    });
+    await useUpdatesStore.getState().check();
+    expect(useUpdatesStore.getState().lastFetched).toBe(CHECKED_AT);
   });
 
   it("counts only unmuted updates for the badge — held ones still count", () => {
@@ -113,7 +152,7 @@ describe("updates store", () => {
 
     vi.mocked(commands.updatesOverview).mockResolvedValue({
       status: "ok",
-      data: { rows: [], warnings: [] },
+      data: { rows: [], warnings: [], lastFetched: null },
     });
     await useUpdatesStore.getState().load();
     expect(useUpdatesStore.getState().error).toBeNull();
@@ -178,13 +217,13 @@ describe("updates store", () => {
     const fresh = [row({ name: "fresh" })];
     vi.mocked(commands.updatesRefresh).mockResolvedValue({
       status: "ok",
-      data: { rows: fresh, warnings: [] },
+      data: { rows: fresh, warnings: [], lastFetched: null },
     });
     await useUpdatesStore.getState().check();
 
     resolveLoad({
       status: "ok",
-      data: { rows: [row({ name: "stale" })], warnings: [] },
+      data: { rows: [row({ name: "stale" })], warnings: [], lastFetched: null },
     });
     await loading;
 
@@ -203,7 +242,7 @@ describe("updates store", () => {
 
     vi.mocked(commands.updatesRefresh).mockResolvedValue({
       status: "ok",
-      data: { rows: [row({})], warnings: [] },
+      data: { rows: [row({})], warnings: [], lastFetched: null },
     });
     await useUpdatesStore.getState().check();
 
@@ -228,13 +267,13 @@ describe("updates store", () => {
     const muted = [row({ ignored: true })];
     vi.mocked(commands.updateSetIgnored).mockResolvedValue({
       status: "ok",
-      data: { rows: muted, warnings: [] },
+      data: { rows: muted, warnings: [], lastFetched: null },
     });
     await useUpdatesStore.getState().setIgnored(row({}), true);
 
     resolveLoad({
       status: "ok",
-      data: { rows: [row({})], warnings: [] },
+      data: { rows: [row({})], warnings: [], lastFetched: null },
     });
     await loading;
 
@@ -258,12 +297,15 @@ describe("updates store", () => {
 
     vi.mocked(commands.updatesOverview).mockResolvedValue({
       status: "ok",
-      data: { rows: [row({ name: "stale" })], warnings: [] },
+      data: { rows: [row({ name: "stale" })], warnings: [], lastFetched: null },
     });
     await useUpdatesStore.getState().load();
 
     const fresh = [row({ name: "fresh" })];
-    resolveCheck({ status: "ok", data: { rows: fresh, warnings: [] } });
+    resolveCheck({
+      status: "ok",
+      data: { rows: fresh, warnings: [], lastFetched: null },
+    });
     await checking;
 
     expect(useUpdatesStore.getState().rows).toEqual(fresh);
@@ -286,12 +328,15 @@ describe("updates store", () => {
 
     vi.mocked(commands.updatesOverview).mockResolvedValue({
       status: "ok",
-      data: { rows: [row({})], warnings: [] },
+      data: { rows: [row({})], warnings: [], lastFetched: null },
     });
     await useUpdatesStore.getState().load();
 
     const muted = [row({ ignored: true })];
-    resolveMutation({ status: "ok", data: { rows: muted, warnings: [] } });
+    resolveMutation({
+      status: "ok",
+      data: { rows: muted, warnings: [], lastFetched: null },
+    });
     await muting;
 
     expect(useUpdatesStore.getState().rows).toEqual(muted);
@@ -313,7 +358,7 @@ describe("updates store", () => {
       )
       .mockResolvedValueOnce({
         status: "ok",
-        data: { rows: secondState, warnings: [] },
+        data: { rows: secondState, warnings: [], lastFetched: null },
       });
 
     const first = useUpdatesStore.getState().setIgnored(row({}), true);
@@ -324,7 +369,7 @@ describe("updates store", () => {
 
     resolveFirst({
       status: "ok",
-      data: { rows: [row({ ignored: true })], warnings: [] },
+      data: { rows: [row({ ignored: true })], warnings: [], lastFetched: null },
     });
     await first;
     await second;
@@ -358,7 +403,10 @@ describe("updates store", () => {
     );
 
     const muted = [row({ ignored: true })];
-    resolveMute({ status: "ok", data: { rows: muted, warnings: [] } });
+    resolveMute({
+      status: "ok",
+      data: { rows: muted, warnings: [], lastFetched: null },
+    });
     await muting;
     expect(useUpdatesStore.getState().rows).toEqual(muted);
   });
@@ -388,7 +436,10 @@ describe("updates store", () => {
       UPDATE_NEEDS_CHECK_NOTE,
     );
 
-    resolveLoad({ status: "ok", data: { rows: [], warnings: [] } });
+    resolveLoad({
+      status: "ok",
+      data: { rows: [], warnings: [], lastFetched: null },
+    });
     await loading;
     expect(commands.packageSetRev).not.toHaveBeenCalled();
   });
@@ -407,7 +458,7 @@ describe("updates store", () => {
 
     vi.mocked(commands.updatesOverview).mockResolvedValue({
       status: "ok",
-      data: { rows: [row({})], warnings: [] },
+      data: { rows: [row({})], warnings: [], lastFetched: null },
     });
     await useUpdatesStore.getState().load();
 
@@ -433,7 +484,7 @@ describe("updates store", () => {
     });
     vi.mocked(commands.updatesOverview).mockResolvedValue({
       status: "ok",
-      data: { rows: kept, warnings: [] },
+      data: { rows: kept, warnings: [], lastFetched: null },
     });
 
     await useUpdatesStore.getState().setIgnored(row({}), true);
@@ -456,7 +507,7 @@ describe("updates store", () => {
     vi.mocked(commands.packageUpdate).mockRejectedValue(new Error("ipc down"));
     vi.mocked(commands.updatesOverview).mockResolvedValue({
       status: "ok",
-      data: { rows: [], warnings: [] },
+      data: { rows: [], warnings: [], lastFetched: null },
     });
 
     await useUpdatesStore.getState().updateOne(row({}));
@@ -473,7 +524,7 @@ describe("updates store", () => {
     vi.mocked(commands.packageSetRev).mockRejectedValue(new Error("ipc down"));
     vi.mocked(commands.updatesOverview).mockResolvedValue({
       status: "ok",
-      data: { rows: [], warnings: [] },
+      data: { rows: [], warnings: [], lastFetched: null },
     });
 
     await useUpdatesStore.getState().setAutoUpdate(row({}), false);
@@ -507,7 +558,10 @@ describe("updates store", () => {
       UPDATE_NEEDS_CHECK_NOTE,
     );
 
-    resolveCheck({ status: "ok", data: { rows: [], warnings: [] } });
+    resolveCheck({
+      status: "ok",
+      data: { rows: [], warnings: [], lastFetched: null },
+    });
     await checking;
     expect(commands.packageSetRev).not.toHaveBeenCalled();
   });
@@ -543,7 +597,7 @@ describe("updates store", () => {
       .mockRejectedValueOnce(new Error("overview wedged"))
       .mockResolvedValueOnce({
         status: "ok",
-        data: { rows: landed, warnings: [] },
+        data: { rows: landed, warnings: [], lastFetched: null },
       });
     vi.mocked(commands.scanMachine).mockResolvedValue({
       status: "ok",
@@ -574,7 +628,7 @@ describe("updates store", () => {
     const muted = [row({ ignored: true })];
     vi.mocked(commands.updatesOverview).mockResolvedValue({
       status: "ok",
-      data: { rows: muted, warnings: [] },
+      data: { rows: muted, warnings: [], lastFetched: null },
     });
 
     await useUpdatesStore.getState().setIgnored(row({}), true);
@@ -605,7 +659,7 @@ describe("updates store", () => {
     const muted = [row({ ignored: true })];
     vi.mocked(commands.updateSetIgnored).mockResolvedValue({
       status: "ok",
-      data: { rows: muted, warnings: [] },
+      data: { rows: muted, warnings: [], lastFetched: null },
     });
     useUpdatesStore.setState({ rows: [row({})], loaded: true });
 
@@ -638,7 +692,7 @@ describe("updates store", () => {
     });
     vi.mocked(commands.updatesOverview).mockResolvedValue({
       status: "ok",
-      data: { rows: [], warnings: [] },
+      data: { rows: [], warnings: [], lastFetched: null },
     });
     vi.mocked(commands.scanMachine).mockResolvedValue({
       status: "ok",
@@ -678,7 +732,7 @@ describe("updates store", () => {
     });
     vi.mocked(commands.updatesOverview).mockResolvedValue({
       status: "ok",
-      data: { rows: [], warnings: [] },
+      data: { rows: [], warnings: [], lastFetched: null },
     });
     vi.mocked(commands.scanMachine).mockResolvedValue({
       status: "ok",

--- a/ui/src/stores/updates.ts
+++ b/ui/src/stores/updates.ts
@@ -29,6 +29,11 @@ interface UpdatesState {
   /** Packages whose standing could not be computed — shown, never treated
    *  as current. */
   warnings: ItemWarning[];
+  /** Unix seconds of the last successful mirror fetch behind these rows,
+   *  null when nothing has ever fetched. The page dates its answer from
+   *  this — the check runs offline on load, so "everything is up to date"
+   *  needs the age of the fetch it rests on beside it. */
+  lastFetched: number | null;
   busy: boolean;
   /** True while a mirror fetch is running — the explicit "check". */
   checking: boolean;
@@ -96,6 +101,7 @@ export const useUpdatesStore = create<UpdatesState>((set, get) => {
   return {
     rows: [],
     warnings: [],
+    lastFetched: null,
     busy: false,
     checking: false,
     overviewInFlight: false,


### PR DESCRIPTION
The Updates page's check runs offline on load and fetches only when someone presses Check for updates, so "Everything is up to date" spoke for an age nobody could see — five minutes or five days, the page read the same. The standing now carries the age of the fetch under it and the page prints it: under the title, and beside the good news in the empty state, which is the exact sentence the age question is about.

The age is read off the per-mirror fetch stamps `drift::stamps` already writes rather than recorded a second time. Those survive a restart and count the background refresh's fetches as well as an explicit check, so the hint follows how fresh the data actually is instead of only when the button was last pressed; a second per-scope record would have needed a snapshot schema bump and an ordering rule against the mirrors it describes.

Its population is the sources the scope installs from, narrowed the way `sync_declared_sources` already narrows it. A subscribed source nobody installs from stamps its mirror when it is merely opened, and counting that would call a standing fresh whose every source had been unreachable for days.

Newest and not oldest, within a scope and across them in the overview. `record_failure` leaves `fetched_at` alone, so a source that stays down keeps reporting the age it last had; taking the oldest would let it pin the whole answer at never-checked over mirrors that came current minutes ago. Nothing fetched anywhere reads as "Not checked for updates yet", never a relative time.

Two things came out of it. `normalize_tree` fetched without stamping, the one place breaking the invariant `stamp_fetch`'s own doc states and this feature leans on. And the label is on the clock the status footer already ticks — `useNowTick`, one rate for every age on screen — because only a read of the standing re-renders the page, so a window left open would otherwise go on claiming the age it had when it opened.

`u32` seconds: specta refuses to export a 64-bit int across the IPC boundary, the precedent being `ObservedItem::modified_at`. A stamp that does not fit reads as never-checked rather than wrapping into a plausible-looking wrong instant. The three update-standing commands move out of `packages.rs` into `update_check.rs` at the seam its own doc comment named — the file was at the size gate's threshold with no baseline row.

The branch predates a lot of main and was rebased onto it. The only conflict was `tools/size-ratchet-baseline.tsv`, resolved to main's rows: the original branch raised the `docs/ARCHITECTURE.md` row to fit the new paragraph, which is not how a doc row moves, so the paragraph is reworded instead and the file lands at exactly its unchanged 801-line row.

Verification in the worktree: `tools/guard` clean (fmt, clippy, doc, `cargo test --workspace`, tsc, biome, 653 vitest tests), preflight clean over all 27 changed files, and `committed_bindings_are_current` green so `ui/src/bindings.ts` matches the rebased command set.

Closes KEN-460
