### PR TITLE
fix(KEN-722): order the app half only where there is one

### DIFF
--- a/crates/cli/tests/compat.rs
+++ b/crates/cli/tests/compat.rs
@@ -366,6 +366,11 @@ fn update_replaces_the_binary_from_a_local_feed() {
 /// app goes first and a refusal there stops the run with the old command
 /// still on disk — which is what lets the next run try both halves again,
 /// with no --force and nothing said about one.
+///
+/// Only a target whose release publishes an AppImage has an app half to
+/// order against. Where none is published the command is the whole
+/// install and the opposite has to hold: it updates itself, and it leaves
+/// alone and says nothing about an app it never installed.
 #[test]
 #[allow(clippy::unwrap_used)]
 fn a_desktop_app_that_cannot_be_replaced_leaves_the_command_alone() {
@@ -380,13 +385,6 @@ fn a_desktop_app_that_cannot_be_replaced_leaves_the_command_alone() {
     let app_dir = home.join(".local/share/kendex");
     fs::create_dir_all(&app_dir).unwrap();
     fs::write(app_dir.join("kendex.AppImage"), "old app").unwrap();
-    fs::set_permissions(&app_dir, fs::Permissions::from_mode(0o555)).unwrap();
-    // Root writes through the mode bits, so the refusal this test needs
-    // never happens there.
-    if fs::write(app_dir.join("probe"), "").is_ok() {
-        fs::set_permissions(&app_dir, fs::Permissions::from_mode(0o755)).unwrap();
-        return;
-    }
 
     fs::write(home.join("new-binary"), "#!/bin/sh\necho v9\n").unwrap();
     let target = env!("KENDEX_TARGET");
@@ -409,6 +407,34 @@ fn a_desktop_app_that_cannot_be_replaced_leaves_the_command_alone() {
             )],
         )
     };
+    // Read as text: the real binary is not UTF-8, so only a command that
+    // moved reads back as the replacement, and a failure prints that line
+    // rather than a megabyte of ELF.
+    let command_moved = || fs::read_to_string(&me).is_ok_and(|got| got == "#!/bin/sh\necho v9\n");
+    let still_old_app = || fs::read_to_string(app_dir.join("kendex.AppImage")).unwrap();
+
+    if !publishes_an_app_image() {
+        let only = update();
+        let said = format!("{}{}", stderr(&only), stdout(&only));
+        assert!(only.status.success(), "{said}");
+        assert!(command_moved(), "the command did not update itself: {said}");
+        // An AppImage sitting here is not this platform's install, so the
+        // command neither touches it nor mentions one.
+        assert_eq!(still_old_app(), "old app", "{said}");
+        assert!(
+            !said.contains("desktop app"),
+            "claimed something about an app it never installed: {said}"
+        );
+        return;
+    }
+
+    fs::set_permissions(&app_dir, fs::Permissions::from_mode(0o555)).unwrap();
+    // Root writes through the mode bits, so the refusal this test needs
+    // never happens there.
+    if fs::write(app_dir.join("probe"), "").is_ok() {
+        fs::set_permissions(&app_dir, fs::Permissions::from_mode(0o755)).unwrap();
+        return;
+    }
 
     let first = update();
     // The second run is the whole point: with the command still on its old
@@ -416,21 +442,11 @@ fn a_desktop_app_that_cannot_be_replaced_leaves_the_command_alone() {
     let second = update();
     fs::set_permissions(&app_dir, fs::Permissions::from_mode(0o755)).unwrap();
 
-    // Read as text: the real binary is not UTF-8, so only a command that
-    // moved reads back as the replacement, and a failure prints that line
-    // rather than a megabyte of ELF.
-    let moved = fs::read_to_string(&me).is_ok_and(|got| got == "#!/bin/sh\necho v9\n");
-    assert!(!moved, "the command moved before the app it depends on");
-    assert_eq!(
-        fs::read_to_string(app_dir.join("kendex.AppImage")).unwrap(),
-        "old app"
+    assert!(
+        !command_moved(),
+        "the command moved before the app it depends on"
     );
-    if !publishes_an_app_image() {
-        // No AppImage is published for this target, so there is nothing to
-        // replace and nothing to refuse.
-        assert!(first.status.success(), "{}", stderr(&first));
-        return;
-    }
+    assert_eq!(still_old_app(), "old app");
     for (which, output) in [("first", &first), ("second", &second)] {
         let said = format!("{}{}", stderr(output), stdout(output));
         assert!(!output.status.success(), "{which}: {said}");

--- a/crates/cli/tests/compat.rs
+++ b/crates/cli/tests/compat.rs
@@ -70,10 +70,15 @@ fn stdout(output: &Output) -> String {
     String::from_utf8_lossy(&output.stdout).into_owned()
 }
 
+/// Whether this target's release carries an app for the command to
+/// replace, asked of the helper the command itself asks. Restating the
+/// mapping here would let the test hold one contract while the code holds
+/// another, and agree again only by luck. The version is any valid SemVer:
+/// it is parsed and then plays no part in the answer.
 fn publishes_an_app_image() -> bool {
     matches!(
-        env!("KENDEX_TARGET"),
-        "x86_64-unknown-linux-gnu" | "aarch64-unknown-linux-gnu"
+        kendex_core::update_feed::app_image_url("9.9.9", env!("KENDEX_TARGET")),
+        Ok(Some(_))
     )
 }
 


### PR DESCRIPTION
`a_desktop_app_that_cannot_be_replaced_leaves_the_command_alone` has been failing on macOS since #1721 landed.

The test asserted that the command had not moved before it asked whether the target publishes a desktop app at all. macOS publishes none, so #1721's own "return silently where there is no AppImage" fires, the command updates as it should, and the assertion blows.

The platform question is asked first now, and each answer carries a real guarantee rather than a skip. Where an AppImage is published the ordering is the point and its coverage is unchanged — the old-ordering control is still red. Where none is, the command *is* the whole install and the opposite has to hold: it updates itself, leaves a stray AppImage at that path alone, and says nothing about an app the platform never installed. That second branch is red under two mutants, so it asserts behavior rather than filling space.

The diagnosis was reproduced, not inferred: the host was made to behave like a target that publishes no AppImage, the old assertion order restored, and the identical panic message reproduced locally.

**Why this reached main.** The `macOS cargo (workspace tests)` lane runs only on `merge_group`, is skipped on pull requests, and is not a required check — so it went green through every push on #1721 and did not block the merge. KEN-723 covers that gap and the four older failures in the same lane, which are untouched here.

Closes KEN-722
