### PR TITLE
feat(KEN-420): the app knows who is signed in

### DIFF
--- a/crates/app/src/account.rs
+++ b/crates/app/src/account.rs
@@ -7,7 +7,6 @@ use std::path::PathBuf;
 
 use kendex_core::author::{self, SubmitPreflight};
 use kendex_core::env::Env;
-use kendex_core::registry::client;
 use kendex_core::registry::credentials::{Credential, KeyringStore};
 use kendex_core::registry::login::{self, Poll};
 use kendex_core::registry::me::{self, AccountState};
@@ -64,7 +63,9 @@ pub fn account_login_poll(device_code: String) -> Result<String, String> {
         Poll::Pending => Ok("pending".to_owned()),
         Poll::SlowDown => Ok("slow-down".to_owned()),
         Poll::Signed(pair) => {
-            client::commit_login(
+            let env = Env::detect().map_err(|e| e.to_string())?;
+            me::commit_sign_in(
+                &env,
                 &KeyringStore,
                 &Credential {
                     endpoint: base_url(),
@@ -82,9 +83,10 @@ pub fn account_login_poll(device_code: String) -> Result<String, String> {
 #[tauri::command(async)]
 #[specta::specta]
 pub fn account_logout() -> Result<(), String> {
-    client::logout(&CurlFetch, &KeyringStore).map_err(|e| e.to_string())?;
     let env = Env::detect().map_err(|e| e.to_string())?;
-    me::forget(&env).map_err(|e| e.to_string())
+    me::sign_out(&env, &CurlFetch, &KeyringStore)
+        .map(|_| ())
+        .map_err(|e| e.to_string())
 }
 
 #[tauri::command(async)]

--- a/crates/app/src/account.rs
+++ b/crates/app/src/account.rs
@@ -6,9 +6,11 @@
 use std::path::PathBuf;
 
 use kendex_core::author::{self, SubmitPreflight};
+use kendex_core::env::Env;
 use kendex_core::registry::client;
 use kendex_core::registry::credentials::{Credential, KeyringStore};
 use kendex_core::registry::login::{self, Poll};
+use kendex_core::registry::me::{self, AccountState};
 use kendex_core::registry::submit::{self, SubmissionRow};
 use kendex_core::registry::{CurlFetch, base_url};
 use serde::{Deserialize, Serialize};
@@ -17,16 +19,17 @@ use specta::Type;
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Type)]
 #[serde(rename_all = "camelCase")]
 pub struct AccountStatus {
-    pub signed_in: bool,
+    pub state: AccountState,
     pub endpoint: String,
 }
 
 #[tauri::command(async)]
 #[specta::specta]
 pub fn account_status() -> Result<AccountStatus, String> {
-    let signed_in = submit::signed_in(&KeyringStore).map_err(|e| e.to_string())?;
+    let env = Env::detect().map_err(|e| e.to_string())?;
+    let state = me::load(&env, &CurlFetch, &KeyringStore).map_err(|e| e.to_string())?;
     Ok(AccountStatus {
-        signed_in,
+        state,
         endpoint: base_url(),
     })
 }
@@ -44,7 +47,7 @@ pub struct LoginStart {
 #[tauri::command(async)]
 #[specta::specta]
 pub fn account_login_start() -> Result<LoginStart, String> {
-    let started = login::start(&CurlFetch).map_err(|e| e.to_string())?;
+    let started = login::start(&CurlFetch, "kendex app").map_err(|e| e.to_string())?;
     Ok(LoginStart {
         verification_url: format!("{}?code={}", started.verification_url, started.user_code),
         device_code: started.device_code,
@@ -79,9 +82,9 @@ pub fn account_login_poll(device_code: String) -> Result<String, String> {
 #[tauri::command(async)]
 #[specta::specta]
 pub fn account_logout() -> Result<(), String> {
-    client::logout(&CurlFetch, &KeyringStore)
-        .map(|_| ())
-        .map_err(|e| e.to_string())
+    client::logout(&CurlFetch, &KeyringStore).map_err(|e| e.to_string())?;
+    let env = Env::detect().map_err(|e| e.to_string())?;
+    me::forget(&env).map_err(|e| e.to_string())
 }
 
 #[tauri::command(async)]

--- a/crates/cli/src/commands/login.rs
+++ b/crates/cli/src/commands/login.rs
@@ -3,8 +3,8 @@
 //! and the credential lives in the OS keychain or nowhere.
 
 use super::say;
+use kendex_core::env::Env;
 use kendex_core::error::Result;
-use kendex_core::registry::client;
 use kendex_core::registry::credentials::{Credential, CredentialStore, KeyringStore};
 use kendex_core::registry::login::{self, Poll};
 use kendex_core::registry::me;
@@ -39,7 +39,8 @@ pub fn login() -> Result<()> {
             Poll::Pending => {}
             Poll::SlowDown => interval += 5,
             Poll::Signed(pair) => {
-                client::commit_login(
+                me::commit_sign_in(
+                    &Env::detect()?,
                     &store,
                     &Credential {
                         endpoint: base_url(),
@@ -56,9 +57,7 @@ pub fn login() -> Result<()> {
 }
 
 pub fn logout() -> Result<()> {
-    let was_signed_in = client::logout(&CurlFetch, &KeyringStore)?;
-    me::forget(&kendex_core::env::Env::detect()?)?;
-    if !was_signed_in {
+    if !me::sign_out(&Env::detect()?, &CurlFetch, &KeyringStore)? {
         say("Not signed in.");
         return Ok(());
     }

--- a/crates/cli/src/commands/login.rs
+++ b/crates/cli/src/commands/login.rs
@@ -7,6 +7,7 @@ use kendex_core::error::Result;
 use kendex_core::registry::client;
 use kendex_core::registry::credentials::{Credential, CredentialStore, KeyringStore};
 use kendex_core::registry::login::{self, Poll};
+use kendex_core::registry::me;
 use kendex_core::registry::{CurlFetch, base_url};
 
 pub fn login() -> Result<()> {
@@ -19,7 +20,7 @@ pub fn login() -> Result<()> {
         ));
         return Ok(());
     }
-    let started = login::start(&fetch)?;
+    let started = login::start(&fetch, "kendex CLI")?;
     say(&format!(
         "First, open:  {}?code={}",
         started.verification_url, started.user_code
@@ -55,7 +56,9 @@ pub fn login() -> Result<()> {
 }
 
 pub fn logout() -> Result<()> {
-    if !client::logout(&CurlFetch, &KeyringStore)? {
+    let was_signed_in = client::logout(&CurlFetch, &KeyringStore)?;
+    me::forget(&kendex_core::env::Env::detect()?)?;
+    if !was_signed_in {
         say("Not signed in.");
         return Ok(());
     }

--- a/crates/core/src/error.rs
+++ b/crates/core/src/error.rs
@@ -409,6 +409,15 @@ pub enum CoreError {
     /// including what to do instead.
     #[error("{message}")]
     Authoring { message: String },
+
+    /// No credential is stored on this machine — signing in is the fix.
+    #[error("not signed in — run `kendex login` first")]
+    NotSignedIn,
+
+    /// The stored sign-in is dead for good: the server refused its refresh
+    /// grant or keeps rejecting freshly rotated access tokens.
+    #[error("{why} — run `kendex login` again")]
+    SignInExpired { why: String },
 }
 
 impl CoreError {

--- a/crates/core/src/registry.rs
+++ b/crates/core/src/registry.rs
@@ -6,6 +6,7 @@ pub mod cache;
 pub mod client;
 pub mod collections;
 pub mod credentials;
+mod generation;
 pub mod index;
 pub mod login;
 pub mod me;

--- a/crates/core/src/registry.rs
+++ b/crates/core/src/registry.rs
@@ -8,6 +8,7 @@ pub mod collections;
 pub mod credentials;
 pub mod index;
 pub mod login;
+pub mod me;
 pub mod skillssh;
 pub mod submit;
 pub mod view;

--- a/crates/core/src/registry/cache.rs
+++ b/crates/core/src/registry/cache.rs
@@ -1,17 +1,15 @@
-//! The directory on disk: one file holding body, ETag and fetch time as a
-//! single generation — written atomically, so no crash can pair one
-//! fetch's body with another's ETag. Within the TTL the network is never
-//! touched; past it a conditional GET revalidates for the cost of a 304;
-//! with the network away the last fetch is served and labeled stale — the
-//! Community tab is never blank because a train has no wifi.
+//! The directory cache: within the TTL the network is never touched;
+//! past it a conditional GET revalidates for the cost of a 304; with the
+//! network away the last fetch is served and labeled stale — the
+//! Community tab is never blank because a train has no wifi. Storage and
+//! the fresh/stale/refused ladder are [`super::generation`]'s.
 
 use crate::clock;
 use crate::env::Env;
 use crate::error::{CoreError, Result};
-use crate::fs::{atomic_write, read_if_exists};
+use crate::registry::generation::GenerationFile;
 use crate::registry::index::{self, DirectoryIndex};
-use crate::registry::{Fetch, MAX_RESPONSE_BYTES, base_url};
-use serde::{Deserialize, Serialize};
+use crate::registry::{Fetch, base_url};
 
 pub const DEFAULT_TTL_SECS: u64 = 3600;
 const CACHE_FILE: &str = "index.cache.json";
@@ -25,20 +23,12 @@ pub struct DirectoryLoad {
     pub stale: bool,
 }
 
-/// One fetch, whole: the ETag belongs to exactly this body because they
-/// are one write.
-#[derive(Serialize, Deserialize)]
-struct Generation {
-    etag: Option<String>,
-    fetched_at: u64,
-    body: String,
-}
-
 /// Read the directory: disk within the TTL, a conditional GET past it,
 /// the stale copy when the network fails, an error only with nothing to
 /// serve at all.
 pub fn load(env: &Env, fetch: &dyn Fetch, force_refresh: bool) -> Result<DirectoryLoad> {
-    let cached = read_cached(env);
+    let store = GenerationFile::new(env, CACHE_FILE);
+    let cached = store.read(index::parse);
     let now = clock::unix_now();
     if let Some((generation, index)) = &cached
         && !force_refresh
@@ -55,86 +45,17 @@ pub fn load(env: &Env, fetch: &dyn Fetch, force_refresh: bool) -> Result<Directo
         .as_ref()
         .and_then(|(generation, _)| generation.etag.clone());
     let url = format!("{}/api/v1/index", base_url());
-    match fetch.get(&url, etag.as_deref()) {
-        Ok(response) if response.status == 304 => {
-            let (generation, index) = cached.ok_or_else(|| CoreError::RegistryMalformed {
-                why: "the server said 'unchanged' but nothing is cached".into(),
-            })?;
-            write_generation(
-                env,
-                &Generation {
-                    fetched_at: now,
-                    ..generation
-                },
-            )?;
-            Ok(DirectoryLoad {
-                index,
-                fetched_at: now,
-                stale: false,
-            })
-        }
-        Ok(response) if response.status == 200 => match index::parse(&response.body) {
-            Ok(index) => {
-                write_generation(
-                    env,
-                    &Generation {
-                        etag: response.etag,
-                        fetched_at: now,
-                        body: String::from_utf8_lossy(&response.body).into_owned(),
-                    },
-                )?;
-                Ok(DirectoryLoad {
-                    index,
-                    fetched_at: now,
-                    stale: false,
-                })
-            }
-            Err(error) => stale_or(cached, error),
+    let loaded = store.settle(
+        cached,
+        fetch.get(&url, etag.as_deref()),
+        index::parse,
+        |response| CoreError::RegistryUnavailable {
+            why: format!("the directory answered {}", response.status),
         },
-        Ok(response) => stale_or(
-            cached,
-            CoreError::RegistryUnavailable {
-                why: format!("the directory answered {}", response.status),
-            },
-        ),
-        Err(error) => stale_or(cached, error),
-    }
-}
-
-fn stale_or(
-    cached: Option<(Generation, DirectoryIndex)>,
-    error: CoreError,
-) -> Result<DirectoryLoad> {
-    match cached {
-        Some((generation, index)) => Ok(DirectoryLoad {
-            index,
-            fetched_at: generation.fetched_at,
-            stale: true,
-        }),
-        None => Err(error),
-    }
-}
-
-fn read_cached(env: &Env) -> Option<(Generation, DirectoryIndex)> {
-    let path = env.registry_cache_dir().join(CACHE_FILE);
-    // The cache lives on this machine, but "on this machine" is not
-    // "trusted to be well-formed": a replaced or corrupt file must not be
-    // read past the same cap the network honors, and must re-pass the
-    // same strict parse.
-    let size = std::fs::metadata(&path).ok()?.len();
-    if size > MAX_RESPONSE_BYTES as u64 * 2 {
-        return None;
-    }
-    let generation: Generation = serde_json::from_str(&read_if_exists(&path).ok()??).ok()?;
-    let index = index::parse(generation.body.as_bytes()).ok()?;
-    Some((generation, index))
-}
-
-fn write_generation(env: &Env, generation: &Generation) -> Result<()> {
-    let dir = env.registry_cache_dir();
-    std::fs::create_dir_all(&dir).map_err(|error| CoreError::io(&dir, error))?;
-    let json = serde_json::to_string(generation).map_err(|error| CoreError::RegistryMalformed {
-        why: error.to_string(),
-    })?;
-    atomic_write(&dir.join(CACHE_FILE), &json)
+    )?;
+    Ok(DirectoryLoad {
+        index: loaded.value,
+        fetched_at: loaded.fetched_at,
+        stale: loaded.stale,
+    })
 }

--- a/crates/core/src/registry/client.rs
+++ b/crates/core/src/registry/client.rs
@@ -68,8 +68,8 @@ fn rotate_locked(
                 Some(_) => store.clear()?,
                 None => {}
             }
-            return Err(CoreError::Authoring {
-                message: format!("your sign-in has expired ({why}) — run `kendex login` again"),
+            return Err(CoreError::SignInExpired {
+                why: format!("your sign-in has expired ({why})"),
             });
         }
         Err(Refused::Transient(error)) => return Err(error),
@@ -127,14 +127,12 @@ pub fn logout(fetch: &dyn Fetch, store: &dyn CredentialStore) -> Result<bool> {
 }
 
 fn required(credential: Option<Credential>) -> Result<Credential> {
-    credential.ok_or_else(|| CoreError::Authoring {
-        message: "not signed in — run `kendex login` first".to_owned(),
-    })
+    credential.ok_or(CoreError::NotSignedIn)
 }
 
 fn rejected_access() -> CoreError {
-    CoreError::Authoring {
-        message: "the server does not accept this sign-in — run `kendex login` again".to_owned(),
+    CoreError::SignInExpired {
+        why: "the server does not accept this sign-in".to_owned(),
     }
 }
 

--- a/crates/core/src/registry/client.rs
+++ b/crates/core/src/registry/client.rs
@@ -97,13 +97,16 @@ fn rotate_locked(
 }
 
 /// Commit a completed device login without racing refresh or logout.
+/// Surfaces call `me::commit_sign_in`, which drops the previous
+/// account's cached identity around this.
 pub fn commit_login(store: &dyn CredentialStore, credential: &Credential) -> Result<()> {
     let _guard = store.refresh_guard()?;
     store.save(credential)
 }
 
 /// Revoke and clear the current sign-in under the credential transaction lock.
-/// Returns false when the machine was already signed out.
+/// Returns false when the machine was already signed out. Surfaces call
+/// `me::sign_out`, which forgets the cached identity around this.
 pub fn logout(fetch: &dyn Fetch, store: &dyn CredentialStore) -> Result<bool> {
     let _guard = store.refresh_guard()?;
     let Some(credential) = store.load()? else {

--- a/crates/core/src/registry/generation.rs
+++ b/crates/core/src/registry/generation.rs
@@ -3,14 +3,22 @@
 //! fetches and no other endpoint's answer is ever served. The directory
 //! index and the signed-in identity both cache through this mechanism;
 //! each caller keeps its own transport, parser, and refusal message.
+//! The file is kendex's own and never a user-managed link, so a final
+//! symlink at the path is replaced on write and refused on read.
+
+use std::io::Read;
 
 use serde::{Deserialize, Serialize};
 
 use crate::clock;
 use crate::env::Env;
 use crate::error::{CoreError, Result};
-use crate::fs::{atomic_write, read_if_exists};
+use crate::fs::{atomic_write_no_follow, open_read_no_follow};
 use crate::registry::{FetchResponse, MAX_RESPONSE_BYTES, base_url};
+
+/// A cached generation is one response plus its meta, so the cap is the
+/// response cap with room for the wrapper.
+const MAX_CACHE_BYTES: u64 = MAX_RESPONSE_BYTES as u64 * 2;
 
 #[derive(Serialize, Deserialize)]
 pub(super) struct Generation {
@@ -42,18 +50,21 @@ impl<'e> GenerationFile<'e> {
         self.env.registry_cache_dir().join(self.file)
     }
 
-    /// The cached generation, or `None`: absent, over the size cap,
-    /// unreadable, another endpoint's, or a body the caller's strict
-    /// parse refuses. The cache lives on this machine, but "on this
-    /// machine" is not "trusted to be well-formed": the same cap and the
-    /// same parse the network response passed.
+    /// The cached generation, or `None`: absent, a symlink or anything
+    /// but a plain file, over the size cap, unreadable, another
+    /// endpoint's, or a body the caller's strict parse refuses. The
+    /// cache lives on this machine, but "on this machine" is not
+    /// "trusted to be well-formed": the same cap and the same parse the
+    /// network response passed.
     pub fn read<T>(&self, parse: impl Fn(&[u8]) -> Result<T>) -> Option<(Generation, T)> {
-        let path = self.path();
-        let size = std::fs::metadata(&path).ok()?.len();
-        if size > MAX_RESPONSE_BYTES as u64 * 2 {
+        let file = open_read_no_follow(&self.path()).ok()?;
+        let metadata = file.metadata().ok()?;
+        if !metadata.is_file() || metadata.len() > MAX_CACHE_BYTES {
             return None;
         }
-        let generation: Generation = serde_json::from_str(&read_if_exists(&path).ok()??).ok()?;
+        let mut text = String::new();
+        file.take(MAX_CACHE_BYTES).read_to_string(&mut text).ok()?;
+        let generation: Generation = serde_json::from_str(&text).ok()?;
         if generation.endpoint != base_url() {
             return None;
         }
@@ -130,7 +141,7 @@ impl<'e> GenerationFile<'e> {
             serde_json::to_string(generation).map_err(|error| CoreError::RegistryMalformed {
                 why: error.to_string(),
             })?;
-        atomic_write(&dir.join(self.file), &json)
+        atomic_write_no_follow(&dir.join(self.file), &json)
     }
 }
 

--- a/crates/core/src/registry/generation.rs
+++ b/crates/core/src/registry/generation.rs
@@ -1,0 +1,146 @@
+//! One fetch, held whole: a generation file pairs body, ETag, endpoint
+//! and fetch time in a single atomic write, so no crash can mix two
+//! fetches and no other endpoint's answer is ever served. The directory
+//! index and the signed-in identity both cache through this mechanism;
+//! each caller keeps its own transport, parser, and refusal message.
+
+use serde::{Deserialize, Serialize};
+
+use crate::clock;
+use crate::env::Env;
+use crate::error::{CoreError, Result};
+use crate::fs::{atomic_write, read_if_exists};
+use crate::registry::{FetchResponse, MAX_RESPONSE_BYTES, base_url};
+
+#[derive(Serialize, Deserialize)]
+pub(super) struct Generation {
+    pub endpoint: String,
+    pub etag: Option<String>,
+    pub fetched_at: u64,
+    pub body: String,
+}
+
+/// A settled load: the parsed value, when its body was really fetched,
+/// and whether the network stood behind it or the last fetch stood in.
+pub(super) struct Loaded<T> {
+    pub value: T,
+    pub fetched_at: u64,
+    pub stale: bool,
+}
+
+pub(super) struct GenerationFile<'e> {
+    env: &'e Env,
+    file: &'static str,
+}
+
+impl<'e> GenerationFile<'e> {
+    pub fn new(env: &'e Env, file: &'static str) -> GenerationFile<'e> {
+        GenerationFile { env, file }
+    }
+
+    fn path(&self) -> std::path::PathBuf {
+        self.env.registry_cache_dir().join(self.file)
+    }
+
+    /// The cached generation, or `None`: absent, over the size cap,
+    /// unreadable, another endpoint's, or a body the caller's strict
+    /// parse refuses. The cache lives on this machine, but "on this
+    /// machine" is not "trusted to be well-formed": the same cap and the
+    /// same parse the network response passed.
+    pub fn read<T>(&self, parse: impl Fn(&[u8]) -> Result<T>) -> Option<(Generation, T)> {
+        let path = self.path();
+        let size = std::fs::metadata(&path).ok()?.len();
+        if size > MAX_RESPONSE_BYTES as u64 * 2 {
+            return None;
+        }
+        let generation: Generation = serde_json::from_str(&read_if_exists(&path).ok()??).ok()?;
+        if generation.endpoint != base_url() {
+            return None;
+        }
+        let value = parse(generation.body.as_bytes()).ok()?;
+        Some((generation, value))
+    }
+
+    /// Remove the cached generation; already-gone is fine.
+    pub fn forget(&self) -> Result<()> {
+        let path = self.path();
+        match std::fs::remove_file(&path) {
+            Ok(()) => Ok(()),
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(()),
+            Err(error) => Err(CoreError::io(&path, error)),
+        }
+    }
+
+    /// Settle one fetch against the cache: a 200 replaces the generation,
+    /// a 304 re-dates the cached one, and any failure — transport error,
+    /// refused status, unparseable body — serves the cached value as
+    /// stale, erring only with nothing to serve. `refused` words the
+    /// error for a status that is neither 200 nor 304.
+    pub fn settle<T>(
+        &self,
+        cached: Option<(Generation, T)>,
+        fetched: Result<FetchResponse>,
+        parse: impl Fn(&[u8]) -> Result<T>,
+        refused: impl Fn(&FetchResponse) -> CoreError,
+    ) -> Result<Loaded<T>> {
+        let now = clock::unix_now();
+        let response = match fetched {
+            Ok(response) => response,
+            Err(error) => return stale_or(cached, error),
+        };
+        match response.status {
+            200 => match parse(&response.body) {
+                Ok(value) => {
+                    self.write(&Generation {
+                        endpoint: base_url(),
+                        etag: response.etag,
+                        fetched_at: now,
+                        body: String::from_utf8_lossy(&response.body).into_owned(),
+                    })?;
+                    Ok(Loaded {
+                        value,
+                        fetched_at: now,
+                        stale: false,
+                    })
+                }
+                Err(error) => stale_or(cached, error),
+            },
+            304 => {
+                let (generation, value) = cached.ok_or_else(|| CoreError::RegistryMalformed {
+                    why: "the server said 'unchanged' but nothing is cached".into(),
+                })?;
+                self.write(&Generation {
+                    fetched_at: now,
+                    ..generation
+                })?;
+                Ok(Loaded {
+                    value,
+                    fetched_at: now,
+                    stale: false,
+                })
+            }
+            _ => stale_or(cached, refused(&response)),
+        }
+    }
+
+    fn write(&self, generation: &Generation) -> Result<()> {
+        let dir = self.env.registry_cache_dir();
+        std::fs::create_dir_all(&dir).map_err(|error| CoreError::io(&dir, error))?;
+        let json =
+            serde_json::to_string(generation).map_err(|error| CoreError::RegistryMalformed {
+                why: error.to_string(),
+            })?;
+        atomic_write(&dir.join(self.file), &json)
+    }
+}
+
+fn stale_or<T>(cached: Option<(Generation, T)>, error: CoreError) -> Result<Loaded<T>> {
+    match cached {
+        Some((generation, value)) => Ok(Loaded {
+            value,
+            fetched_at: generation.fetched_at,
+            stale: true,
+        }),
+        None => Err(error),
+    }
+}

--- a/crates/core/src/registry/login.rs
+++ b/crates/core/src/registry/login.rs
@@ -45,8 +45,14 @@ struct WireError {
     error: String,
 }
 
-pub fn start(fetch: &dyn Fetch) -> Result<DeviceStart> {
-    let body = serde_json::json!({ "capabilities": DEFAULT_CAPABILITIES }).to_string();
+/// `client_label` names the asking surface ("kendex app", "kendex CLI") so
+/// the approval page can say which one is asking.
+pub fn start(fetch: &dyn Fetch, client_label: &str) -> Result<DeviceStart> {
+    let body = serde_json::json!({
+        "capabilities": DEFAULT_CAPABILITIES,
+        "client": client_label,
+    })
+    .to_string();
     let response = fetch.post_json(&format!("{}/api/v1/device/code", base_url()), &body)?;
     if response.status != 200 {
         return Err(CoreError::RegistryUnavailable {

--- a/crates/core/src/registry/login.rs
+++ b/crates/core/src/registry/login.rs
@@ -45,8 +45,8 @@ struct WireError {
     error: String,
 }
 
-/// `client_label` names the asking surface ("kendex app", "kendex CLI") so
-/// the approval page can say which one is asking.
+/// `client_label` names the asking surface ("kendex app", "kendex CLI") in
+/// the request. The server does not read the field yet.
 pub fn start(fetch: &dyn Fetch, client_label: &str) -> Result<DeviceStart> {
     let body = serde_json::json!({
         "capabilities": DEFAULT_CAPABILITIES,

--- a/crates/core/src/registry/me.rs
+++ b/crates/core/src/registry/me.rs
@@ -1,19 +1,17 @@
 //! Who is signed in: GET /api/v1/me through the rotation-safe bearer
-//! client. The last good answer is cached like the directory index —
-//! one atomically-written generation, revalidated by ETag — but with no
-//! TTL, because "signed in", "offline" and "expired" can only be told
-//! apart by asking the server. The account page can still say who you
-//! are on a train with no wifi; it just says "offline" next to it.
+//! client. The last good answer is cached through [`super::generation`]
+//! with no TTL, because "signed in", "offline" and "expired" can only be
+//! told apart by asking the server; when the network is away the cached
+//! identity is served as the offline state instead of nothing.
 
 use serde::{Deserialize, Serialize};
 
-use crate::clock;
 use crate::env::Env;
 use crate::error::{CoreError, Result};
-use crate::fs::{atomic_write, read_if_exists};
 use crate::registry::client::{self, server_message};
-use crate::registry::credentials::CredentialStore;
-use crate::registry::{Fetch, MAX_RESPONSE_BYTES, base_url};
+use crate::registry::credentials::{Credential, CredentialStore};
+use crate::registry::generation::GenerationFile;
+use crate::registry::{Fetch, base_url};
 
 const CACHE_FILE: &str = "me.cache.json";
 
@@ -50,86 +48,72 @@ struct WireMe {
     github_login: Option<String>,
 }
 
-/// One fetch, whole, keyed to the endpoint it came from so switching
-/// `KENDEX_API` can never serve another server's identity.
-#[derive(Serialize, Deserialize)]
-struct Generation {
-    endpoint: String,
-    etag: Option<String>,
-    fetched_at: u64,
-    body: String,
-}
-
 /// Ask who is signed in. No credential is `SignedOut` without a network
-/// call; a dead credential is `Expired`; an unreachable or misbehaving
-/// server serves the cached identity as `Offline`, and errors only with
-/// nothing cached to serve.
+/// call; a dead credential is `Expired` and its cached identity is
+/// dropped; an unreachable or misbehaving server serves the cached
+/// identity as `Offline`, and errors only with nothing cached to serve.
 pub fn load(env: &Env, fetch: &dyn Fetch, store: &dyn CredentialStore) -> Result<AccountState> {
     if store.load()?.is_none() {
         return Ok(AccountState::SignedOut);
     }
-    let cached = read_cached(env);
+    let cache = cache(env);
+    let cached = cache.read(parse);
     let etag = cached
         .as_ref()
         .and_then(|(generation, _)| generation.etag.clone());
     let url = format!("{}/api/v1/me", base_url());
-    let response = match client::with_access(fetch, store, |access| {
+    let fetched = match client::with_access(fetch, store, |access| {
         fetch.get_auth(&url, etag.as_deref(), Some(access))
     }) {
-        Ok(response) => response,
         // Logout won a race with this read: the re-login state without
         // refreshing, exactly as if the credential had been gone up front.
         Err(CoreError::NotSignedIn) => return Ok(AccountState::SignedOut),
-        Err(CoreError::SignInExpired { .. }) => return Ok(AccountState::Expired),
-        Err(error) => return offline_or(cached, error),
-    };
-    let now = clock::unix_now();
-    match response.status {
-        200 => match parse(&response.body) {
-            Ok(identity) => {
-                write_generation(
-                    env,
-                    &Generation {
-                        endpoint: base_url(),
-                        etag: response.etag,
-                        fetched_at: now,
-                        body: String::from_utf8_lossy(&response.body).into_owned(),
-                    },
-                )?;
-                Ok(AccountState::SignedIn { identity })
-            }
-            Err(error) => offline_or(cached, error),
-        },
-        304 => {
-            let (generation, identity) = cached.ok_or_else(|| CoreError::RegistryMalformed {
-                why: "the server said 'unchanged' but nothing is cached".into(),
-            })?;
-            write_generation(
-                env,
-                &Generation {
-                    fetched_at: now,
-                    ..generation
-                },
-            )?;
-            Ok(AccountState::SignedIn { identity })
+        // The credential is dead and the client cleared it; a cached
+        // identity kept here could resurface as another account's
+        // "offline" after the next sign-in.
+        Err(CoreError::SignInExpired { .. }) => {
+            cache.forget()?;
+            return Ok(AccountState::Expired);
         }
-        _ => offline_or(
-            cached,
-            CoreError::RegistryUnavailable {
-                why: server_message(&response),
-            },
-        ),
-    }
+        fetched => fetched,
+    };
+    let loaded = cache.settle(cached, fetched, parse, |response| {
+        CoreError::RegistryUnavailable {
+            why: server_message(response),
+        }
+    })?;
+    Ok(match loaded.stale {
+        false => AccountState::SignedIn {
+            identity: loaded.value,
+        },
+        true => AccountState::Offline {
+            identity: loaded.value,
+        },
+    })
 }
 
-/// Forget the cached identity — the other half of logout.
-pub fn forget(env: &Env) -> Result<()> {
-    let path = env.registry_cache_dir().join(CACHE_FILE);
-    match std::fs::remove_file(&path) {
-        Ok(()) => Ok(()),
-        Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(()),
-        Err(error) => Err(CoreError::io(&path, error)),
-    }
+/// Commit a fresh sign-in and drop the previous account's cached
+/// identity, so the new credential never pairs with the old name.
+pub fn commit_sign_in(
+    env: &Env,
+    store: &dyn CredentialStore,
+    credential: &Credential,
+) -> Result<()> {
+    cache(env).forget()?;
+    client::commit_login(store, credential)
+}
+
+/// Revoke, clear, and forget the cached identity — the one sign-out
+/// every surface calls. When revocation fails the credential is kept for
+/// retry, and so is the cache. Returns false when already signed out.
+pub fn sign_out(env: &Env, fetch: &dyn Fetch, store: &dyn CredentialStore) -> Result<bool> {
+    let was_signed_in = client::logout(fetch, store)?;
+    cache(env).forget()?;
+    Ok(was_signed_in)
+}
+
+fn cache(env: &Env) -> GenerationFile<'_> {
+    GenerationFile::new(env, CACHE_FILE)
 }
 
 fn parse(body: &[u8]) -> Result<Identity> {
@@ -141,36 +125,4 @@ fn parse(body: &[u8]) -> Result<Identity> {
         name: wire.name,
         github_login: wire.github_login,
     })
-}
-
-fn offline_or(cached: Option<(Generation, Identity)>, error: CoreError) -> Result<AccountState> {
-    match cached {
-        Some((_, identity)) => Ok(AccountState::Offline { identity }),
-        None => Err(error),
-    }
-}
-
-fn read_cached(env: &Env) -> Option<(Generation, Identity)> {
-    let path = env.registry_cache_dir().join(CACHE_FILE);
-    // Local, but not trusted to be well-formed: the same size cap and the
-    // same strict parse the network response passed.
-    let size = std::fs::metadata(&path).ok()?.len();
-    if size > MAX_RESPONSE_BYTES as u64 * 2 {
-        return None;
-    }
-    let generation: Generation = serde_json::from_str(&read_if_exists(&path).ok()??).ok()?;
-    if generation.endpoint != base_url() {
-        return None;
-    }
-    let identity = parse(generation.body.as_bytes()).ok()?;
-    Some((generation, identity))
-}
-
-fn write_generation(env: &Env, generation: &Generation) -> Result<()> {
-    let dir = env.registry_cache_dir();
-    std::fs::create_dir_all(&dir).map_err(|error| CoreError::io(&dir, error))?;
-    let json = serde_json::to_string(generation).map_err(|error| CoreError::RegistryMalformed {
-        why: error.to_string(),
-    })?;
-    atomic_write(&dir.join(CACHE_FILE), &json)
 }

--- a/crates/core/src/registry/me.rs
+++ b/crates/core/src/registry/me.rs
@@ -1,0 +1,176 @@
+//! Who is signed in: GET /api/v1/me through the rotation-safe bearer
+//! client. The last good answer is cached like the directory index —
+//! one atomically-written generation, revalidated by ETag — but with no
+//! TTL, because "signed in", "offline" and "expired" can only be told
+//! apart by asking the server. The account page can still say who you
+//! are on a train with no wifi; it just says "offline" next to it.
+
+use serde::{Deserialize, Serialize};
+
+use crate::clock;
+use crate::env::Env;
+use crate::error::{CoreError, Result};
+use crate::fs::{atomic_write, read_if_exists};
+use crate::registry::client::{self, server_message};
+use crate::registry::credentials::CredentialStore;
+use crate::registry::{Fetch, MAX_RESPONSE_BYTES, base_url};
+
+const CACHE_FILE: &str = "me.cache.json";
+
+/// Who the credential belongs to, as the identity endpoint answers it.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, specta::Type)]
+#[serde(rename_all = "camelCase")]
+pub struct Identity {
+    pub name: String,
+    /// The linked GitHub provider's immutable account id; `None` after unlink.
+    pub github_login: Option<String>,
+}
+
+/// What the account surfaces render, every one of them settled: the UI
+/// holds its own "not read yet" until the first answer comes back.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, specta::Type)]
+#[serde(tag = "state", rename_all = "kebab-case")]
+pub enum AccountState {
+    SignedOut,
+    SignedIn {
+        identity: Identity,
+    },
+    /// The server could not be asked; the identity is the last good fetch.
+    Offline {
+        identity: Identity,
+    },
+    /// The credential is dead server-side — signing in again is the fix.
+    Expired,
+}
+
+/// The wire shape of GET /api/v1/me, exactly as the contract fixture says.
+#[derive(Deserialize)]
+struct WireMe {
+    name: String,
+    github_login: Option<String>,
+}
+
+/// One fetch, whole, keyed to the endpoint it came from so switching
+/// `KENDEX_API` can never serve another server's identity.
+#[derive(Serialize, Deserialize)]
+struct Generation {
+    endpoint: String,
+    etag: Option<String>,
+    fetched_at: u64,
+    body: String,
+}
+
+/// Ask who is signed in. No credential is `SignedOut` without a network
+/// call; a dead credential is `Expired`; an unreachable or misbehaving
+/// server serves the cached identity as `Offline`, and errors only with
+/// nothing cached to serve.
+pub fn load(env: &Env, fetch: &dyn Fetch, store: &dyn CredentialStore) -> Result<AccountState> {
+    if store.load()?.is_none() {
+        return Ok(AccountState::SignedOut);
+    }
+    let cached = read_cached(env);
+    let etag = cached
+        .as_ref()
+        .and_then(|(generation, _)| generation.etag.clone());
+    let url = format!("{}/api/v1/me", base_url());
+    let response = match client::with_access(fetch, store, |access| {
+        fetch.get_auth(&url, etag.as_deref(), Some(access))
+    }) {
+        Ok(response) => response,
+        // Logout won a race with this read: the re-login state without
+        // refreshing, exactly as if the credential had been gone up front.
+        Err(CoreError::NotSignedIn) => return Ok(AccountState::SignedOut),
+        Err(CoreError::SignInExpired { .. }) => return Ok(AccountState::Expired),
+        Err(error) => return offline_or(cached, error),
+    };
+    let now = clock::unix_now();
+    match response.status {
+        200 => match parse(&response.body) {
+            Ok(identity) => {
+                write_generation(
+                    env,
+                    &Generation {
+                        endpoint: base_url(),
+                        etag: response.etag,
+                        fetched_at: now,
+                        body: String::from_utf8_lossy(&response.body).into_owned(),
+                    },
+                )?;
+                Ok(AccountState::SignedIn { identity })
+            }
+            Err(error) => offline_or(cached, error),
+        },
+        304 => {
+            let (generation, identity) = cached.ok_or_else(|| CoreError::RegistryMalformed {
+                why: "the server said 'unchanged' but nothing is cached".into(),
+            })?;
+            write_generation(
+                env,
+                &Generation {
+                    fetched_at: now,
+                    ..generation
+                },
+            )?;
+            Ok(AccountState::SignedIn { identity })
+        }
+        _ => offline_or(
+            cached,
+            CoreError::RegistryUnavailable {
+                why: server_message(&response),
+            },
+        ),
+    }
+}
+
+/// Forget the cached identity — the other half of logout.
+pub fn forget(env: &Env) -> Result<()> {
+    let path = env.registry_cache_dir().join(CACHE_FILE);
+    match std::fs::remove_file(&path) {
+        Ok(()) => Ok(()),
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(()),
+        Err(error) => Err(CoreError::io(&path, error)),
+    }
+}
+
+fn parse(body: &[u8]) -> Result<Identity> {
+    let wire: WireMe =
+        serde_json::from_slice(body).map_err(|error| CoreError::RegistryMalformed {
+            why: error.to_string(),
+        })?;
+    Ok(Identity {
+        name: wire.name,
+        github_login: wire.github_login,
+    })
+}
+
+fn offline_or(cached: Option<(Generation, Identity)>, error: CoreError) -> Result<AccountState> {
+    match cached {
+        Some((_, identity)) => Ok(AccountState::Offline { identity }),
+        None => Err(error),
+    }
+}
+
+fn read_cached(env: &Env) -> Option<(Generation, Identity)> {
+    let path = env.registry_cache_dir().join(CACHE_FILE);
+    // Local, but not trusted to be well-formed: the same size cap and the
+    // same strict parse the network response passed.
+    let size = std::fs::metadata(&path).ok()?.len();
+    if size > MAX_RESPONSE_BYTES as u64 * 2 {
+        return None;
+    }
+    let generation: Generation = serde_json::from_str(&read_if_exists(&path).ok()??).ok()?;
+    if generation.endpoint != base_url() {
+        return None;
+    }
+    let identity = parse(generation.body.as_bytes()).ok()?;
+    Some((generation, identity))
+}
+
+fn write_generation(env: &Env, generation: &Generation) -> Result<()> {
+    let dir = env.registry_cache_dir();
+    std::fs::create_dir_all(&dir).map_err(|error| CoreError::io(&dir, error))?;
+    let json = serde_json::to_string(generation).map_err(|error| CoreError::RegistryMalformed {
+        why: error.to_string(),
+    })?;
+    atomic_write(&dir.join(CACHE_FILE), &json)
+}

--- a/crates/core/src/registry/me.rs
+++ b/crates/core/src/registry/me.rs
@@ -51,7 +51,9 @@ struct WireMe {
 /// Ask who is signed in. No credential is `SignedOut` without a network
 /// call; a dead credential is `Expired` and its cached identity is
 /// dropped; an unreachable or misbehaving server serves the cached
-/// identity as `Offline`, and errors only with nothing cached to serve.
+/// identity as `Offline`, and errors only with nothing cached to serve. A
+/// credential gone by the time the answer lands is `SignedOut` too, and
+/// nothing is written back over the sign-out.
 pub fn load(env: &Env, fetch: &dyn Fetch, store: &dyn CredentialStore) -> Result<AccountState> {
     if store.load()?.is_none() {
         return Ok(AccountState::SignedOut);
@@ -77,6 +79,12 @@ pub fn load(env: &Env, fetch: &dyn Fetch, store: &dyn CredentialStore) -> Result
         }
         fetched => fetched,
     };
+    // A sign-out that landed while this read was in flight already forgot
+    // the cache; settling now would write the identity straight back. The
+    // module's rule throughout: a missing credential means logout won.
+    if store.load()?.is_none() {
+        return Ok(AccountState::SignedOut);
+    }
     let loaded = cache.settle(cached, fetched, parse, |response| {
         CoreError::RegistryUnavailable {
             why: server_message(response),

--- a/crates/core/src/registry/submit.rs
+++ b/crates/core/src/registry/submit.rs
@@ -64,12 +64,6 @@ pub fn submissions(fetch: &dyn Fetch, store: &dyn CredentialStore) -> Result<Vec
     Err(server_said(&response))
 }
 
-/// Whether a usable credential exists at all — the "signed in?" question
-/// surfaces ask before offering submit.
-pub fn signed_in(store: &dyn CredentialStore) -> Result<bool> {
-    Ok(store.load()?.is_some())
-}
-
 fn server_said(response: &FetchResponse) -> CoreError {
     CoreError::Authoring {
         message: server_message(response),

--- a/crates/core/tests/fixtures/api-v1-me.json
+++ b/crates/core/tests/fixtures/api-v1-me.json
@@ -1,0 +1,43 @@
+{
+  "authentication": {
+    "browser_session": true,
+    "device_bearer": {
+      "rule": "A live device token can read its own identity.",
+      "required_capabilities": []
+    }
+  },
+  "success": {
+    "status": 200,
+    "body": {
+      "name": "Ada Lovelace",
+      "github_login": "1234567"
+    }
+  },
+  "unlinked_github": {
+    "status": 200,
+    "body": {
+      "name": "Ada Lovelace",
+      "github_login": null
+    }
+  },
+  "errors": {
+    "unauthenticated": {
+      "status": 401,
+      "body": {
+        "error": "sign in first"
+      }
+    },
+    "database_unavailable": {
+      "status": 503,
+      "body": {
+        "error": "no database configured"
+      }
+    },
+    "missing_user": {
+      "status": 500,
+      "body": {
+        "error": "account identity is incomplete"
+      }
+    }
+  }
+}

--- a/crates/core/tests/me_client.rs
+++ b/crates/core/tests/me_client.rs
@@ -1,0 +1,387 @@
+//! The identity client: GET /api/v1/me against the contract fixture,
+//! the five account states, the offline cache ladder, and the cache's
+//! endpoint key. The fixture is a byte copy of kendex-web's
+//! `contracts/api/v1/me.json` — drift between the repos is a `cmp` away.
+
+use std::cell::RefCell;
+use std::path::Path;
+
+use kendex_core::env::{Env, FakeOs};
+use kendex_core::error::{CoreError, Result};
+use kendex_core::registry::credentials::{Credential, CredentialRefreshGuard, CredentialStore};
+use kendex_core::registry::me::{self, AccountState};
+use kendex_core::registry::{Fetch, FetchResponse};
+
+const FIXTURE: &str = include_str!("fixtures/api-v1-me.json");
+
+/// A canned transport: each call pops the next scripted answer and
+/// records what rode along with it.
+struct Canned {
+    answers: RefCell<Vec<Result<FetchResponse>>>,
+    calls: RefCell<u32>,
+    saw_etag: RefCell<Option<String>>,
+    bearers: RefCell<Vec<Option<String>>>,
+}
+
+impl Canned {
+    fn new(answers: Vec<Result<FetchResponse>>) -> Canned {
+        Canned {
+            answers: RefCell::new(answers),
+            calls: RefCell::new(0),
+            saw_etag: RefCell::new(None),
+            bearers: RefCell::new(Vec::new()),
+        }
+    }
+
+    fn next(&self, bearer: Option<&str>) -> Result<FetchResponse> {
+        *self.calls.borrow_mut() += 1;
+        self.bearers.borrow_mut().push(bearer.map(str::to_owned));
+        if self.answers.borrow().is_empty() {
+            panic!("the test scripted fewer answers than the code asked for");
+        }
+        self.answers.borrow_mut().remove(0)
+    }
+}
+
+impl Fetch for Canned {
+    fn get_auth(
+        &self,
+        _url: &str,
+        if_none_match: Option<&str>,
+        bearer: Option<&str>,
+    ) -> Result<FetchResponse> {
+        *self.saw_etag.borrow_mut() = if_none_match.map(str::to_owned);
+        self.next(bearer)
+    }
+
+    fn post_json_auth(
+        &self,
+        _url: &str,
+        _body: &str,
+        bearer: Option<&str>,
+    ) -> Result<FetchResponse> {
+        self.next(bearer)
+    }
+}
+
+fn ok(status: u16, etag: Option<&str>, body: &str) -> Result<FetchResponse> {
+    Ok(FetchResponse {
+        status,
+        etag: etag.map(str::to_string),
+        body: body.as_bytes().to_vec(),
+    })
+}
+
+fn away() -> Result<FetchResponse> {
+    Err(CoreError::RegistryUnavailable {
+        why: "no route".into(),
+    })
+}
+
+struct MemoryStore(RefCell<Option<Credential>>);
+
+impl MemoryStore {
+    fn signed_in() -> MemoryStore {
+        MemoryStore(RefCell::new(Some(Credential {
+            endpoint: "https://kendex.ai".to_owned(),
+            access_token: "kxa_old".to_owned(),
+            refresh_token: "kxr_old".to_owned(),
+            capabilities: vec!["submission:write".to_owned()],
+        })))
+    }
+
+    fn signed_out() -> MemoryStore {
+        MemoryStore(RefCell::new(None))
+    }
+}
+
+impl CredentialStore for MemoryStore {
+    fn save(&self, credential: &Credential) -> Result<()> {
+        *self.0.borrow_mut() = Some(credential.clone());
+        Ok(())
+    }
+    fn load(&self) -> Result<Option<Credential>> {
+        Ok(self.0.borrow().clone())
+    }
+    fn clear(&self) -> Result<()> {
+        *self.0.borrow_mut() = None;
+        Ok(())
+    }
+    fn refresh_guard(&self) -> Result<Box<dyn CredentialRefreshGuard + '_>> {
+        Ok(Box::new(MemoryGuard))
+    }
+}
+
+struct MemoryGuard;
+impl CredentialRefreshGuard for MemoryGuard {}
+
+/// A store whose credential disappears after N loads — logout winning a
+/// race against the read.
+struct VanishingStore {
+    loads_before_gone: RefCell<u32>,
+    credential: Credential,
+}
+
+impl CredentialStore for VanishingStore {
+    fn save(&self, _credential: &Credential) -> Result<()> {
+        Ok(())
+    }
+    fn load(&self) -> Result<Option<Credential>> {
+        let mut left = self.loads_before_gone.borrow_mut();
+        if *left == 0 {
+            return Ok(None);
+        }
+        *left -= 1;
+        Ok(Some(self.credential.clone()))
+    }
+    fn clear(&self) -> Result<()> {
+        Ok(())
+    }
+    fn refresh_guard(&self) -> Result<Box<dyn CredentialRefreshGuard + '_>> {
+        Ok(Box::new(MemoryGuard))
+    }
+}
+
+fn env_in(dir: &Path) -> Env {
+    Env::fake(dir, FakeOs::Linux)
+}
+
+fn fixture() -> serde_json::Value {
+    serde_json::from_str(FIXTURE).expect("fixture parses")
+}
+
+fn fixture_node(path: &[&str]) -> serde_json::Value {
+    let mut node = fixture();
+    for key in path {
+        node = node[*key].clone();
+    }
+    assert!(!node.is_null(), "fixture has no {}", path.join("."));
+    node
+}
+
+fn fixture_body(path: &[&str]) -> String {
+    fixture_node(path).to_string()
+}
+
+fn fixture_status(path: &[&str]) -> u16 {
+    let status = fixture_node(path).as_u64().expect("status is a number");
+    u16::try_from(status).expect("status fits")
+}
+
+#[test]
+fn no_credential_answers_signed_out_without_the_network() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let fetch = Canned::new(vec![]);
+    let state = me::load(&env_in(dir.path()), &fetch, &MemoryStore::signed_out()).expect("load");
+    assert_eq!(state, AccountState::SignedOut);
+    assert_eq!(*fetch.calls.borrow(), 0);
+}
+
+#[test]
+fn the_fixture_success_body_reads_as_signed_in() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let env = env_in(dir.path());
+    let status = fixture_status(&["success", "status"]);
+    let fetch = Canned::new(vec![ok(status, None, &fixture_body(&["success", "body"]))]);
+    let state = me::load(&env, &fetch, &MemoryStore::signed_in()).expect("load");
+    match state {
+        AccountState::SignedIn { identity } => {
+            assert_eq!(identity.name, "Ada Lovelace");
+            assert_eq!(identity.github_login.as_deref(), Some("1234567"));
+        }
+        other => panic!("expected signed-in, got {other:?}"),
+    }
+    assert_eq!(
+        fetch.bearers.borrow().as_slice(),
+        [Some("kxa_old".to_owned())]
+    );
+}
+
+#[test]
+fn the_fixture_unlinked_body_reads_as_no_github_login() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let fetch = Canned::new(vec![ok(
+        fixture_status(&["unlinked_github", "status"]),
+        None,
+        &fixture_body(&["unlinked_github", "body"]),
+    )]);
+    let state = me::load(&env_in(dir.path()), &fetch, &MemoryStore::signed_in()).expect("load");
+    match state {
+        AccountState::SignedIn { identity } => assert_eq!(identity.github_login, None),
+        other => panic!("expected signed-in, got {other:?}"),
+    }
+}
+
+#[test]
+fn network_away_serves_the_cached_identity_as_offline() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let env = env_in(dir.path());
+    let store = MemoryStore::signed_in();
+    let first = Canned::new(vec![ok(200, None, &fixture_body(&["success", "body"]))]);
+    me::load(&env, &first, &store).expect("first load");
+
+    let down = Canned::new(vec![away()]);
+    let state = me::load(&env, &down, &store).expect("offline load");
+    match state {
+        AccountState::Offline { identity } => assert_eq!(identity.name, "Ada Lovelace"),
+        other => panic!("expected offline, got {other:?}"),
+    }
+}
+
+#[test]
+fn network_away_with_nothing_cached_is_an_error() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let down = Canned::new(vec![away()]);
+    assert!(me::load(&env_in(dir.path()), &down, &MemoryStore::signed_in()).is_err());
+}
+
+#[test]
+fn the_fixture_database_status_rides_the_offline_ladder() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let env = env_in(dir.path());
+    let store = MemoryStore::signed_in();
+    let first = Canned::new(vec![ok(200, None, &fixture_body(&["success", "body"]))]);
+    me::load(&env, &first, &store).expect("first load");
+
+    let hurt = Canned::new(vec![ok(
+        fixture_status(&["errors", "database_unavailable", "status"]),
+        None,
+        &fixture_body(&["errors", "database_unavailable", "body"]),
+    )]);
+    assert!(matches!(
+        me::load(&env, &hurt, &store).expect("load"),
+        AccountState::Offline { .. }
+    ));
+}
+
+#[test]
+fn a_dead_refresh_grant_reads_as_expired() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let store = MemoryStore::signed_in();
+    let fetch = Canned::new(vec![
+        ok(
+            fixture_status(&["errors", "unauthenticated", "status"]),
+            None,
+            &fixture_body(&["errors", "unauthenticated", "body"]),
+        ),
+        ok(400, None, r#"{"error":"invalid_grant"}"#),
+    ]);
+    let state = me::load(&env_in(dir.path()), &fetch, &store).expect("load");
+    assert_eq!(state, AccountState::Expired);
+    assert!(
+        store.load().expect("load").is_none(),
+        "a dead credential is not kept for endless retries"
+    );
+}
+
+#[test]
+fn a_rotation_the_server_still_rejects_reads_as_expired() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let fetch = Canned::new(vec![
+        ok(401, None, r#"{"error":"invalid_token"}"#),
+        ok(
+            200,
+            None,
+            r#"{"access_token":"kxa_new","refresh_token":"kxr_new","capabilities":["submission:write"]}"#,
+        ),
+        ok(401, None, r#"{"error":"invalid_token"}"#),
+    ]);
+    let state = me::load(&env_in(dir.path()), &fetch, &MemoryStore::signed_in()).expect("load");
+    assert_eq!(state, AccountState::Expired);
+}
+
+#[test]
+fn logout_winning_the_race_reads_as_signed_out() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    // The guard's read and with_access's first read still see the
+    // credential; the locked re-read after the 401 finds it gone.
+    let store = VanishingStore {
+        loads_before_gone: RefCell::new(2),
+        credential: Credential {
+            endpoint: "https://kendex.ai".to_owned(),
+            access_token: "kxa_old".to_owned(),
+            refresh_token: "kxr_old".to_owned(),
+            capabilities: vec![],
+        },
+    };
+    let fetch = Canned::new(vec![ok(401, None, r#"{"error":"invalid_token"}"#)]);
+    let state = me::load(&env_in(dir.path()), &fetch, &store).expect("load");
+    assert_eq!(state, AccountState::SignedOut);
+    assert_eq!(
+        *fetch.calls.borrow(),
+        1,
+        "no refresh is attempted once logout won"
+    );
+}
+
+#[test]
+fn revalidation_sends_the_etag_and_304_keeps_the_identity() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let env = env_in(dir.path());
+    let store = MemoryStore::signed_in();
+    let first = Canned::new(vec![ok(
+        200,
+        Some("\"v1\""),
+        &fixture_body(&["success", "body"]),
+    )]);
+    me::load(&env, &first, &store).expect("first load");
+
+    let revalidate = Canned::new(vec![ok(304, None, "")]);
+    let state = me::load(&env, &revalidate, &store).expect("revalidated");
+    assert_eq!(revalidate.saw_etag.borrow().as_deref(), Some("\"v1\""));
+    assert!(matches!(state, AccountState::SignedIn { .. }));
+}
+
+#[test]
+fn a_malformed_answer_serves_the_cache_as_offline() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let env = env_in(dir.path());
+    let store = MemoryStore::signed_in();
+    let first = Canned::new(vec![ok(200, None, &fixture_body(&["success", "body"]))]);
+    me::load(&env, &first, &store).expect("first load");
+
+    let garbled = Canned::new(vec![ok(200, None, "<!doctype html>")]);
+    assert!(matches!(
+        me::load(&env, &garbled, &store).expect("load"),
+        AccountState::Offline { .. }
+    ));
+}
+
+#[test]
+fn a_cache_from_another_endpoint_is_never_served() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let env = env_in(dir.path());
+    let registry_dir = env.registry_cache_dir();
+    std::fs::create_dir_all(&registry_dir).expect("mkdir");
+    std::fs::write(
+        registry_dir.join("me.cache.json"),
+        r#"{"endpoint":"https://somewhere.else","etag":null,"fetched_at":1,"body":"{\"name\":\"Stranger\",\"github_login\":null}"}"#,
+    )
+    .expect("write");
+    let down = Canned::new(vec![away()]);
+    assert!(
+        me::load(&env, &down, &MemoryStore::signed_in()).is_err(),
+        "another endpoint's identity must not stand in"
+    );
+}
+
+#[test]
+fn forget_removes_the_cached_identity_and_is_idempotent() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let env = env_in(dir.path());
+    let store = MemoryStore::signed_in();
+    let first = Canned::new(vec![ok(200, None, &fixture_body(&["success", "body"]))]);
+    me::load(&env, &first, &store).expect("first load");
+    let cache = env.registry_cache_dir().join("me.cache.json");
+    assert!(cache.exists(), "a successful read caches the identity");
+
+    me::forget(&env).expect("forget");
+    assert!(!cache.exists());
+    me::forget(&env).expect("forgetting nothing is fine");
+
+    let down = Canned::new(vec![away()]);
+    assert!(
+        me::load(&env, &down, &store).is_err(),
+        "after forget the network is the only source"
+    );
+}

--- a/crates/core/tests/me_client.rs
+++ b/crates/core/tests/me_client.rs
@@ -341,6 +341,32 @@ fn logout_winning_the_race_reads_as_signed_out() {
 }
 
 #[test]
+fn a_sign_out_landing_mid_read_is_never_written_back() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let env = env_in(dir.path());
+    // The opening check and with_access both still see the credential; by
+    // the time the answer is settled, sign-out has cleared it.
+    let store = VanishingStore {
+        loads_before_gone: RefCell::new(2),
+        credential: Credential {
+            endpoint: "https://kendex.ai".to_owned(),
+            access_token: "kxa_old".to_owned(),
+            refresh_token: "kxr_old".to_owned(),
+            capabilities: vec![],
+        },
+    };
+    let fetch = Canned::new(vec![ok(200, None, &fixture_body(&["success", "body"]))]);
+    assert_eq!(
+        me::load(&env, &fetch, &store).expect("load"),
+        AccountState::SignedOut
+    );
+    assert!(
+        !env.registry_cache_dir().join("me.cache.json").exists(),
+        "a read finishing after sign-out must leave no identity on disk"
+    );
+}
+
+#[test]
 fn revalidation_sends_the_etag_and_304_keeps_the_identity() {
     let dir = tempfile::tempdir().expect("tempdir");
     let env = env_in(dir.path());
@@ -479,8 +505,27 @@ fn an_oversized_identity_cache_reads_as_no_cache() {
     let env = env_in(dir.path());
     let registry_dir = env.registry_cache_dir();
     std::fs::create_dir_all(&registry_dir).expect("mkdir");
-    // Past the cap the file is not even read, whatever it claims to hold.
-    std::fs::write(registry_dir.join("me.cache.json"), "x".repeat(41_000_000)).expect("write");
+    // This endpoint's own generation, holding an identity that parses:
+    // the size is the only thing left to refuse it, so the cap is what
+    // this test measures. A padded body keeps that honest.
+    let body = format!(
+        r#"{{"name":"Ada Lovelace","github_login":null,"pad":"{}"}}"#,
+        "x".repeat(41_000_000)
+    );
+    let generation = serde_json::json!({
+        "endpoint": "https://kendex.ai",
+        "etag": serde_json::Value::Null,
+        "fetched_at": 1,
+        "body": body,
+    });
+    std::fs::write(
+        registry_dir.join("me.cache.json"),
+        serde_json::to_string(&generation).expect("generation"),
+    )
+    .expect("write");
     let down = Canned::new(vec![away()]);
-    assert!(me::load(&env, &down, &MemoryStore::signed_in()).is_err());
+    assert!(
+        me::load(&env, &down, &MemoryStore::signed_in()).is_err(),
+        "a cache past the cap is never read, however well-formed"
+    );
 }

--- a/crates/core/tests/me_client.rs
+++ b/crates/core/tests/me_client.rs
@@ -1,6 +1,8 @@
 //! The identity client: GET /api/v1/me against the contract fixture,
-//! the five account states, the offline cache ladder, and the cache's
-//! endpoint key. The fixture is a byte copy of kendex-web's
+//! every account state, all of them settled and all of them `load`'s
+//! answers, the offline cache ladder, and the cache's endpoint key. The
+//! UI holds its own "not read yet" and never gets it here. The fixture is
+//! a byte copy of kendex-web's
 //! `contracts/api/v1/me.json` — drift between the repos is a `cmp` away.
 
 use std::cell::RefCell;
@@ -275,6 +277,30 @@ fn a_dead_refresh_grant_reads_as_expired() {
 }
 
 #[test]
+fn an_expired_credential_drops_the_cached_identity() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let env = env_in(dir.path());
+    let store = MemoryStore::signed_in();
+    let first = Canned::new(vec![ok(200, None, &fixture_body(&["success", "body"]))]);
+    me::load(&env, &first, &store).expect("first load");
+    let cache = env.registry_cache_dir().join("me.cache.json");
+    assert!(cache.exists());
+
+    let dead = Canned::new(vec![
+        ok(401, None, r#"{"error":"invalid_token"}"#),
+        ok(400, None, r#"{"error":"invalid_grant"}"#),
+    ]);
+    assert_eq!(
+        me::load(&env, &dead, &store).expect("load"),
+        AccountState::Expired
+    );
+    assert!(
+        !cache.exists(),
+        "the next sign-in must not inherit this account's identity"
+    );
+}
+
+#[test]
 fn a_rotation_the_server_still_rejects_reads_as_expired() {
     let dir = tempfile::tempdir().expect("tempdir");
     let fetch = Canned::new(vec![
@@ -366,7 +392,7 @@ fn a_cache_from_another_endpoint_is_never_served() {
 }
 
 #[test]
-fn forget_removes_the_cached_identity_and_is_idempotent() {
+fn sign_out_revokes_and_forgets_the_cached_identity() {
     let dir = tempfile::tempdir().expect("tempdir");
     let env = env_in(dir.path());
     let store = MemoryStore::signed_in();
@@ -375,13 +401,86 @@ fn forget_removes_the_cached_identity_and_is_idempotent() {
     let cache = env.registry_cache_dir().join("me.cache.json");
     assert!(cache.exists(), "a successful read caches the identity");
 
-    me::forget(&env).expect("forget");
+    let revoke = Canned::new(vec![ok(200, None, "{}")]);
+    assert!(me::sign_out(&env, &revoke, &store).expect("sign out"));
+    assert!(store.load().expect("load").is_none());
     assert!(!cache.exists());
-    me::forget(&env).expect("forgetting nothing is fine");
 
-    let down = Canned::new(vec![away()]);
+    let quiet = Canned::new(vec![]);
     assert!(
-        me::load(&env, &down, &store).is_err(),
-        "after forget the network is the only source"
+        !me::sign_out(&env, &quiet, &store).expect("already out"),
+        "signing out twice is fine and asks the network nothing"
     );
+}
+
+#[test]
+fn a_failed_revocation_keeps_credential_and_cache_for_retry() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let env = env_in(dir.path());
+    let store = MemoryStore::signed_in();
+    let first = Canned::new(vec![ok(200, None, &fixture_body(&["success", "body"]))]);
+    me::load(&env, &first, &store).expect("first load");
+    let cache = env.registry_cache_dir().join("me.cache.json");
+
+    let refused = Canned::new(vec![ok(503, None, r#"{"error":"down"}"#)]);
+    assert!(me::sign_out(&env, &refused, &store).is_err());
+    assert!(store.load().expect("load").is_some());
+    assert!(cache.exists(), "still signed in, so still remembered");
+}
+
+#[test]
+fn a_fresh_sign_in_never_inherits_the_previous_identity() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let env = env_in(dir.path());
+    let store = MemoryStore::signed_in();
+    let first = Canned::new(vec![ok(200, None, &fixture_body(&["success", "body"]))]);
+    me::load(&env, &first, &store).expect("first load");
+    let cache = env.registry_cache_dir().join("me.cache.json");
+    assert!(cache.exists());
+
+    me::commit_sign_in(
+        &env,
+        &store,
+        &Credential {
+            endpoint: "https://kendex.ai".to_owned(),
+            access_token: "kxa_next".to_owned(),
+            refresh_token: "kxr_next".to_owned(),
+            capabilities: vec![],
+        },
+    )
+    .expect("commit");
+    assert!(!cache.exists(), "the old account's identity is gone");
+    assert_eq!(
+        store
+            .load()
+            .expect("load")
+            .expect("credential")
+            .access_token,
+        "kxa_next"
+    );
+}
+
+#[test]
+fn a_304_with_nothing_cached_is_refused() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let unchanged = Canned::new(vec![ok(304, None, "")]);
+    assert!(
+        matches!(
+            me::load(&env_in(dir.path()), &unchanged, &MemoryStore::signed_in()),
+            Err(CoreError::RegistryMalformed { .. })
+        ),
+        "an identity cannot be fabricated from 'unchanged'"
+    );
+}
+
+#[test]
+fn an_oversized_identity_cache_reads_as_no_cache() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let env = env_in(dir.path());
+    let registry_dir = env.registry_cache_dir();
+    std::fs::create_dir_all(&registry_dir).expect("mkdir");
+    // Past the cap the file is not even read, whatever it claims to hold.
+    std::fs::write(registry_dir.join("me.cache.json"), "x".repeat(41_000_000)).expect("write");
+    let down = Canned::new(vec![away()]);
+    assert!(me::load(&env, &down, &MemoryStore::signed_in()).is_err());
 }

--- a/crates/core/tests/registry.rs
+++ b/crates/core/tests/registry.rs
@@ -13,6 +13,7 @@ struct Canned {
     answers: RefCell<Vec<kendex_core::error::Result<FetchResponse>>>,
     calls: RefCell<u32>,
     saw_etag: RefCell<Option<String>>,
+    saw_body: RefCell<Option<String>>,
 }
 
 impl Canned {
@@ -21,6 +22,7 @@ impl Canned {
             answers: RefCell::new(answers),
             calls: RefCell::new(0),
             saw_etag: RefCell::new(None),
+            saw_body: RefCell::new(None),
         }
     }
 }
@@ -29,9 +31,10 @@ impl Fetch for Canned {
     fn post_json_auth(
         &self,
         url: &str,
-        _body: &str,
+        body: &str,
         _bearer: Option<&str>,
     ) -> kendex_core::error::Result<FetchResponse> {
+        *self.saw_body.borrow_mut() = Some(body.to_owned());
         self.get(url, None)
     }
 
@@ -312,9 +315,14 @@ fn login_start_and_poll_speak_the_device_protocol() {
         None,
         r#"{"device_code":"kxd_x","user_code":"AAAA-BBBB","verification_url":"https://kendex.ai/device","interval":5,"expires_in":900}"#,
     )]);
-    let started = kendex_core::registry::login::start(&canned).expect("start");
+    let started = kendex_core::registry::login::start(&canned, "kendex CLI").expect("start");
     assert_eq!(started.user_code, "AAAA-BBBB");
     assert_eq!(started.interval_seconds, 5);
+    let asked = canned.saw_body.borrow().clone().expect("a body was sent");
+    assert!(
+        asked.contains(r#""client":"kendex CLI""#),
+        "the approval page needs to know which surface is asking: {asked}"
+    );
 
     use kendex_core::registry::login::{Poll, poll_once};
     let pending = Canned::new(vec![ok(400, None, r#"{"error":"authorization_pending"}"#)]);

--- a/crates/core/tests/registry.rs
+++ b/crates/core/tests/registry.rs
@@ -256,21 +256,6 @@ fn skillssh_refuses_names_its_install_url_cannot_carry() {
 }
 
 #[test]
-fn an_oversized_cache_file_reads_as_no_cache() {
-    let dir = tempfile::tempdir().expect("tempdir");
-    let env = env_in(dir.path());
-    let registry_dir = env.registry_cache_dir();
-    std::fs::create_dir_all(&registry_dir).expect("mkdir");
-    // Past the cap the file is not even read, whatever it claims to hold.
-    let oversized = "x".repeat(41_000_000);
-    std::fs::write(registry_dir.join("index.cache.json"), oversized).expect("write");
-    let down = Canned::new(vec![Err(CoreError::RegistryUnavailable {
-        why: "no route".into(),
-    })]);
-    assert!(cache::load(&env, &down, false).is_err());
-}
-
-#[test]
 fn etag_and_body_are_one_generation_on_disk() {
     let dir = tempfile::tempdir().expect("tempdir");
     let env = env_in(dir.path());
@@ -321,7 +306,7 @@ fn login_start_and_poll_speak_the_device_protocol() {
     let asked = canned.saw_body.borrow().clone().expect("a body was sent");
     assert!(
         asked.contains(r#""client":"kendex CLI""#),
-        "the approval page needs to know which surface is asking: {asked}"
+        "the request names the asking surface: {asked}"
     );
 
     use kendex_core::registry::login::{Poll, poll_once};

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -663,18 +663,18 @@ lives in one capability table read by core and UI.
   (Codex renders a command as a skill tree). A digest standing in for
   unprintable content is always `DIGEST_CHARS` wide.
 - **The community directory is read like any remote: strictly, capped,
-  honest about staleness.** `registry/` (core) consumes what
-  `source/index.rs` producers feed kendex.ai: `index.rs` re-parses the
-  schema-1 payload under the site's own caps, refusing structural problems
-  whole and dropping only unusable rows; `cache.rs` holds one body and one
-  meta line on disk (`Env::registry_cache_dir`) behind an ETag and a
-  one-hour TTL; a failed refresh serves the last fetch labeled stale with
-  its real fetch time. All reads go through the `Fetch` trait (curl via
-  `Hardened`, plain http only under `KENDEX_API`); tests inject transports.
-  Bearer calls route through `registry/client.rs`: one named cross-process
-  lock serializes login, logout, and refresh rotation, saving rotations
-  before retry.
-  `skillssh.rs` pins its public wire schema and kill switch
+  honest about staleness.** `index.rs` re-parses the schema-1 payload
+  `source/index.rs` feeds kendex.ai under the site's own caps, refusing
+  structural problems whole, dropping only unusable rows. `generation.rs`
+  is the one cache mechanism: an endpoint-keyed generation written
+  atomically under `Env::registry_cache_dir`, a failed refresh serving the
+  last fetch labeled stale. `cache.rs` adds the directory's one-hour TTL;
+  the identity (`me.rs`) has none and is forgotten on sign-in and
+  sign-out. All reads go through the `Fetch` trait (curl via `Hardened`,
+  plain http only under `KENDEX_API`); tests inject transports. Bearer
+  calls route through `registry/client.rs`: one named cross-process lock
+  serializes login, logout, and refresh rotation, saving rotations before
+  retry. `skillssh.rs` pins its public wire schema and kill switch
   (`KENDEX_SKILLSSH=off`); a hit is a lead, never an identity, and installs
   through the same subscribe path. Collections and deep links arrive with W3/W4.
 - **Intent in the manifest, closure in the plan, edges in the lock.** The

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -669,8 +669,8 @@ lives in one capability table read by core and UI.
   is the one cache mechanism: an endpoint-keyed generation written
   atomically under `Env::registry_cache_dir`, a failed refresh serving the
   last fetch labeled stale. `cache.rs` adds the directory's one-hour TTL;
-  the identity (`me.rs`) has none and is forgotten on sign-in and
-  sign-out. All reads go through the `Fetch` trait (curl via `Hardened`,
+  the identity (`me.rs`) has none and is forgotten on sign-in, sign-out,
+  and expiry. All reads go through the `Fetch` trait (curl via `Hardened`,
   plain http only under `KENDEX_API`); tests inject transports. Bearer
   calls route through `registry/client.rs`: one named cross-process lock
   serializes login, logout, and refresh rotation, saving rotations before

--- a/tools/size-ratchet-baseline.tsv
+++ b/tools/size-ratchet-baseline.tsv
@@ -5,7 +5,7 @@ crates/core/src/engine/detach.rs	603
 crates/core/src/engine/pi_hooks_move/migrated.rs	540
 crates/core/src/engine/pi_hooks_move/mod.rs	503
 crates/core/src/engine/pi_hooks_move/preflight.rs	765
-crates/core/src/error.rs	423
+crates/core/src/error.rs	432
 crates/core/src/remote/store.rs	405
 docs/ARCHITECTURE.md	801
 hooks/block-repo-copy.sh	511

--- a/ui/src/bindings.ts
+++ b/ui/src/bindings.ts
@@ -352,8 +352,18 @@ export type AboutView = {
 	findings: CatalogFinding[],
 };
 
+/**
+ *  What the account surfaces render, every one of them settled: the UI
+ *  holds its own "not read yet" until the first answer comes back.
+ */
+export type AccountState = { state: "signed-out" } | { state: "signed-in"; identity: Identity } | 
+/**  The server could not be asked; the identity is the last good fetch. */
+{ state: "offline"; identity: Identity } | 
+/**  The credential is dead server-side — signing in again is the fix. */
+{ state: "expired" };
+
 export type AccountStatus = {
-	signedIn: boolean,
+	state: AccountState,
 	endpoint: string,
 };
 
@@ -1239,6 +1249,13 @@ export type HookEvent = {
 export type Hunk = {
 	header: string,
 	lines: Line[],
+};
+
+/**  Who the credential belongs to, as the identity endpoint answers it. */
+export type Identity = {
+	name: string,
+	/**  The linked GitHub provider's immutable account id; `None` after unlink. */
+	githubLogin: string | null,
 };
 
 /**

--- a/ui/src/components/marketplaces/mine-submit-dialog.dom.test.tsx
+++ b/ui/src/components/marketplaces/mine-submit-dialog.dom.test.tsx
@@ -1,0 +1,105 @@
+// @vitest-environment jsdom
+// Signed in from the terminal, first launch with kendex.ai unreachable:
+// the read fails with no identity to fall back on, so the account is
+// still unknown and the dialog offers a sign-in. The reason it is
+// offering one has to be on screen with it.
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { commands, type MineRow, type SubmitPreflight } from "@/bindings";
+import { useAccountStore } from "@/stores/account";
+import { mount, settle } from "@/test/dom";
+import { MineSubmitDialog } from "./mine-submit-dialog";
+
+vi.mock("@/bindings", () => ({
+  commands: {
+    mineSubmit: vi.fn(),
+    mineSubmitPreflight: vi.fn(),
+    openUrl: vi.fn(),
+  },
+}));
+
+const row: MineRow = {
+  path: "/home/jane/dev/team-skills",
+  name: "team-skills",
+  description: null,
+  license: "MIT",
+  counts: { skill: 1 },
+  bundles: 0,
+  declared: true,
+  breakage: 0,
+  advisory: 0,
+  safetyFindings: 0,
+  findings: [],
+  git: {
+    repository: true,
+    clean: true,
+    remote: "git@github.com:jane/team-skills.git",
+    candidate: "jane/team-skills",
+    ahead: 0,
+  },
+};
+
+const preflight: SubmitPreflight = {
+  row,
+  checks: [
+    { ok: true, label: "A git repository with a GitHub remote", fix: null },
+  ],
+  candidate: "jane/team-skills",
+  ready: true,
+};
+
+const UNREACHABLE = "kendex.ai could not be reached";
+
+describe("the submit dialog when the account could not be read", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(commands.mineSubmitPreflight).mockResolvedValue({
+      status: "ok",
+      data: preflight,
+    } as never);
+    useAccountStore.setState({
+      account: { kind: "loading" },
+      error: null,
+      readError: null,
+      submissions: null,
+      signingIn: false,
+      userCode: null,
+    });
+  });
+
+  it("names the failure that left the account unknown", async () => {
+    useAccountStore.setState({ readError: UNREACHABLE });
+    mount(
+      <MineSubmitDialog
+        path={row.path}
+        open={true}
+        onOpenChange={() => {}}
+        onSubmitted={() => {}}
+      />,
+    );
+    await settle();
+
+    const alert = document.body.querySelector('[role="alert"]');
+    expect(alert?.textContent).toBe(UNREACHABLE);
+  });
+
+  it("keeps the device flow's own failure ahead of it", async () => {
+    // A denied approval is the person's explanation for what just
+    // happened; a read that failed behind it must not take its place.
+    useAccountStore.setState({
+      readError: UNREACHABLE,
+      error: "the approval was denied",
+    });
+    mount(
+      <MineSubmitDialog
+        path={row.path}
+        open={true}
+        onOpenChange={() => {}}
+        onSubmitted={() => {}}
+      />,
+    );
+    await settle();
+
+    const alert = document.body.querySelector('[role="alert"]');
+    expect(alert?.textContent).toBe("the approval was denied");
+  });
+});

--- a/ui/src/components/marketplaces/mine-submit-dialog.tsx
+++ b/ui/src/components/marketplaces/mine-submit-dialog.tsx
@@ -33,6 +33,10 @@ export function MineSubmitDialog({
   const signIn = useAccountStore((s) => s.signIn);
   const cancelSignIn = useAccountStore((s) => s.cancelSignIn);
   const accountError = useAccountStore((s) => s.error);
+  // A read that failed is why the account is unknown, and unknown is what
+  // this dialog offers a sign-in for. Without it the offer has no reason
+  // on screen and points at a server that is already out of reach.
+  const readError = useAccountStore((s) => s.readError);
   const [preflight, setPreflight] = useState<SubmitPreflight | null>(null);
   const [busy, setBusy] = useState(false);
   const [error, setError] = useState<string | null>(null);
@@ -122,9 +126,9 @@ export function MineSubmitDialog({
             it there and this dialog finishes on its own.
           </p>
         ) : null}
-        {(error ?? accountError) ? (
+        {(error ?? accountError ?? readError) ? (
           <p className="text-sm text-critical" role="alert">
-            {error ?? accountError}
+            {error ?? accountError ?? readError}
           </p>
         ) : null}
         <DialogFooter>

--- a/ui/src/dev/mock-account.test.ts
+++ b/ui/src/dev/mock-account.test.ts
@@ -1,9 +1,15 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import { type SettledAccount, useAccountStore } from "@/stores/account";
+import type { AccountStatus } from "@/bindings";
+import {
+  hasCredential,
+  type SettledAccount,
+  useAccountStore,
+} from "@/stores/account";
 // Importing the bridge is what points the store's read at the harness.
 import { mockInvoke } from "./mock";
 import {
   accountFromUrl,
+  isSignedIn,
   MOCK_ACCOUNT_NAMES,
   MOCK_ACCOUNTS,
   setMockAccount,
@@ -16,8 +22,9 @@ const read = async () => {
   return useAccountStore.getState();
 };
 
-const stored = async () =>
-  ((await mockInvoke("account_status")) as { signedIn: boolean }).signedIn;
+/** The state the command reports, as its own tag names it. */
+const commandState = async () =>
+  ((await mockInvoke("account_status")) as AccountStatus).state.state;
 
 // Every state the store can settle on has to be reachable in the dev
 // harness, or the pages that draw them are only ever seen in one.
@@ -45,15 +52,14 @@ describe("the account states the dev bridge can answer as", () => {
     await expect(mockInvoke("account_status")).rejects.toBeTruthy();
   });
 
-  it("holds a credential while signed in or offline, and not otherwise", async () => {
-    setMockAccount({ ok: MOCK_ACCOUNTS["signed-in"] });
-    expect(await stored()).toBe(true);
-    setMockAccount({ ok: MOCK_ACCOUNTS.offline });
-    expect(await stored()).toBe(true);
-    setMockAccount({ ok: MOCK_ACCOUNTS.expired });
-    expect(await stored()).toBe(false);
-    setMockAccount({ ok: MOCK_ACCOUNTS["signed-out"] });
-    expect(await stored()).toBe(false);
+  // One answer in one place: the command and the reader are the same
+  // state, so the harness cannot say two things at once.
+  it("answers the command with the state the reader serves", async () => {
+    for (const [name, state] of Object.entries(MOCK_ACCOUNTS)) {
+      setMockAccount({ ok: state as SettledAccount });
+      expect(await commandState(), name).toBe(state.kind);
+      expect(isSignedIn(), name).toBe(hasCredential(state as SettledAccount));
+    }
   });
 
   it("signs in through the device flow and out again", async () => {

--- a/ui/src/dev/mock-account.ts
+++ b/ui/src/dev/mock-account.ts
@@ -7,6 +7,7 @@
 // that could not be confirmed, one that was rejected, a read that fails —
 // reach the store through its dev reader, which the backend takes over
 // once it can reach the server. `?account=` on the dev URL picks one.
+import type { AccountStatus } from "@/bindings";
 import {
   type AccountRead,
   hasCredential,
@@ -74,20 +75,37 @@ export function isSignedIn(): boolean {
   return "ok" in served && hasCredential(served.ok);
 }
 
-/** Points the store's account read here, in place of the command that
- *  cannot answer with a name. */
+/** Points the store's account read here, so `?account=` picks a state
+ *  without a server to ask. */
 export function installAccountReader(): void {
   setAccountReader(async () => served);
 }
 
+/** `served` in the shape the real command answers. A signed-in credential
+ *  always has a name here, as it does from the server; the nameless one
+ *  belongs to the moment just after approval, which is the store's own and
+ *  is never served from here. */
+const wire = (account: SettledAccount): AccountStatus["state"] => {
+  switch (account.kind) {
+    case "signed-out":
+      return { state: "signed-out" };
+    case "expired":
+      return { state: "expired" };
+    case "offline":
+      return { state: "offline", identity: account.identity };
+    case "signed-in":
+      return { state: "signed-in", identity: account.identity ?? IDENTITY };
+  }
+};
+
 export const accountHandlers: Record<string, Handler> = {
-  // The command the store no longer calls, kept because the command
-  // exists and mock-mine asks the same question. It answers from `served`,
-  // so it can never disagree with the reader.
+  // The harness points the store at the reader above, so this answers
+  // mock-mine's question. It reports from `served` too, so the two can
+  // never disagree.
   account_status: () =>
     "error" in served
       ? Promise.reject(served.error)
-      : { signedIn: isSignedIn(), endpoint: "https://kendex.ai" },
+      : { state: wire(served.ok), endpoint: "https://kendex.ai" },
   account_login_start: () => {
     polls = 0;
     return {

--- a/ui/src/stores/account-startup.dom.test.tsx
+++ b/ui/src/stores/account-startup.dom.test.tsx
@@ -42,7 +42,7 @@ describe("who reads the account", () => {
     useAccountStore.setState({ account: { kind: "loading" }, error: null });
     vi.mocked(commands.accountStatus).mockResolvedValue({
       status: "ok",
-      data: { signedIn: false, endpoint: "https://kendex.ai" },
+      data: { state: { state: "signed-out" }, endpoint: "https://kendex.ai" },
     } as Awaited<ReturnType<typeof commands.accountStatus>>);
     vi.mocked(commands.getSettings).mockResolvedValue({
       status: "ok",

--- a/ui/src/stores/account.test.ts
+++ b/ui/src/stores/account.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { commands } from "@/bindings";
+import { type AccountStatus, commands } from "@/bindings";
 import {
   type AccountRead,
   hasCredential,
@@ -21,11 +21,11 @@ vi.mock("@/bindings", () => ({
 
 const ADA = { name: "Ada Lovelace", githubLogin: "ada" };
 
-/** What the real command answers: a credential is stored, or is not. */
-const stored = (signedIn: boolean) =>
+/** What the real command answers: the state the backend settled on. */
+const answers = (state: AccountStatus["state"]) =>
   vi.mocked(commands.accountStatus).mockResolvedValue({
     status: "ok",
-    data: { signedIn, endpoint: "https://kendex.ai" },
+    data: { state, endpoint: "https://kendex.ai" },
   } as Awaited<ReturnType<typeof commands.accountStatus>>);
 
 const unreadable = (why = "keychain locked") =>
@@ -64,15 +64,38 @@ describe("the account state a read settles on", () => {
   });
 
   it("is signed out when no credential is stored", async () => {
-    stored(false);
+    answers({ state: "signed-out" });
     await load();
     expect(account()).toEqual({ kind: "signed-out" });
   });
 
-  it("is signed in without a name until the backend has one", async () => {
-    stored(true);
+  it("carries every state the command settles on", async () => {
+    answers({ state: "signed-in", identity: ADA });
     await load();
-    expect(account()).toEqual({ kind: "signed-in", identity: null });
+    expect(account()).toEqual({ kind: "signed-in", identity: ADA });
+
+    answers({ state: "offline", identity: ADA });
+    await load();
+    expect(account()).toEqual({ kind: "offline", identity: ADA });
+
+    answers({ state: "expired" });
+    await load();
+    expect(account()).toEqual({ kind: "expired" });
+  });
+
+  it("keeps the expired explanation on the read that follows it", async () => {
+    answers({ state: "expired" });
+    await load();
+    // Answering expired is what clears the credential, so the next read
+    // finds none. The explanation has to outlive that read.
+    answers({ state: "signed-out" });
+    await load();
+    expect(account()).toEqual({ kind: "expired" });
+
+    // Signing in is what takes it off the screen.
+    answers({ state: "signed-in", identity: ADA });
+    await load();
+    expect(account()).toEqual({ kind: "signed-in", identity: ADA });
   });
 
   it("carries the identity the backend names", async () => {
@@ -124,7 +147,7 @@ describe("a read that could not be made", () => {
   it("settles on the next read that lands", async () => {
     unreadable();
     await load();
-    stored(false);
+    answers({ state: "signed-out" });
     await load();
     expect(account()).toEqual({ kind: "signed-out" });
     expect(useAccountStore.getState().readError).toBeNull();
@@ -222,7 +245,7 @@ describe("a read racing a deliberate change", () => {
 
     // Coming back to the window is the flow's own last step, and the read
     // it triggers must not wipe the only explanation on screen.
-    stored(false);
+    answers({ state: "signed-out" });
     await load();
     expect(account()).toEqual({ kind: "signed-out" });
     expect(useAccountStore.getState().error).toBe("the approval was denied");
@@ -308,7 +331,7 @@ describe("a read racing a deliberate change", () => {
     const out = () => useAccountStore.getState().signOut();
     expect(await arrivingAfter(out)).toBeNull();
     const observed = async () => {
-      stored(false);
+      answers({ state: "signed-out" });
       await load();
     };
     expect(await arrivingAfter(observed)).toBeNull();
@@ -321,7 +344,7 @@ describe("a read racing a deliberate change", () => {
       account: { kind: "signed-in", identity: ADA },
       submissions: [],
     });
-    stored(false);
+    answers({ state: "signed-out" });
     await load();
     expect(useAccountStore.getState().submissions).toBeNull();
   });

--- a/ui/src/stores/account.ts
+++ b/ui/src/stores/account.ts
@@ -4,12 +4,13 @@
 // Startup makes the one account read; every surface reads `account` from
 // here rather than asking again.
 import { create } from "zustand";
-import { commands, type SubmissionRow } from "@/bindings";
+import { type AccountStatus, commands, type SubmissionRow } from "@/bindings";
 
-/** Who the account belongs to, as the server names them. */
+/** Who the account belongs to, as the server names them. The linked
+ * GitHub account is null once it has been unlinked. */
 export interface AccountIdentity {
-  name: string | null;
-  githubLogin: string;
+  name: string;
+  githubLogin: string | null;
 }
 
 /** What is known about the account right now.
@@ -44,19 +45,29 @@ export type AccountRead = { ok: SettledAccount } | { error: string };
 
 export type ReadAccount = () => Promise<AccountRead>;
 
-/** The command reports whether a credential is stored and nothing more,
- * which settles signed in without a name, or signed out. A name, a
- * credential that could not be confirmed and one the server has rejected
- * all need a backend that has reached the server. */
+/** The wire answers every settled state this store keeps; the unread one
+ * is the UI's own, so the mapping is a rename. */
+const settled = (wire: AccountStatus["state"]): SettledAccount => {
+  switch (wire.state) {
+    case "signed-out":
+      return { kind: "signed-out" };
+    case "signed-in":
+      return { kind: "signed-in", identity: wire.identity };
+    case "offline":
+      return { kind: "offline", identity: wire.identity };
+    case "expired":
+      return { kind: "expired" };
+  }
+};
+
+/** The command asks the server who the credential belongs to, so it can
+ * answer with a name, with the last name it knew when the server is away,
+ * and with the rejection when the credential is dead. */
 const fromBridge: ReadAccount = async () => {
   try {
     const status = await commands.accountStatus();
     if (status.status === "error") return { error: status.error };
-    return {
-      ok: status.data.signedIn
-        ? { kind: "signed-in", identity: null }
-        : { kind: "signed-out" },
-    };
+    return { ok: settled(status.data.state) };
   } catch (error: unknown) {
     // A bridge that throws and a reply that says no are the same answer
     // here: the account could not be read. Letting the throw out would
@@ -152,7 +163,16 @@ export const useAccountStore = create<AccountStore>((set, get) => ({
       // Losing the credential by observation changes hands as surely as
       // signing out does, so work already out for the old one is stale.
       handover += 1;
-      set({ account: answer.ok, readError: null, submissions: null });
+      // The server says expired once: answering it clears the credential,
+      // so the next read says signed out. The explanation outlives that
+      // read — only signing in or out takes it off the screen.
+      const held = get().account;
+      const keep = held.kind === "expired" && answer.ok.kind === "signed-out";
+      set({
+        account: keep ? held : answer.ok,
+        readError: null,
+        submissions: null,
+      });
     }
   },
 


### PR DESCRIPTION
The app knew only whether a credential existed. A keyring entry alone rendered as signed in, even when every request came back 401.

`registry/me.rs` now reads `GET /api/v1/me` through the KEN-416 rotation-safe bearer client and answers with an account state: signed out, signed in, offline (the last confirmed identity, labeled as such), or expired. The identity caches as one generation beside the directory index — endpoint-keyed, ETag-revalidated, no TTL, because those states can only be told apart by asking the server — and is forgotten on sign-in, sign-out, and expiry.

Along the way `registry/generation.rs` became the one cache mechanism both the directory index and the identity read through, so the size cap, the strict re-parse, and the atomic no-follow write live in a single place instead of two copies that had already drifted. Sign-out is one core call that revokes and forgets together, rather than a pairing each surface reassembled. Device-code requests name the asking surface, ahead of a server that reads it.

`AccountState` no longer carries `Loading`: `load` never returned it, and the UI owns that state.

The contract fixture is a byte copy of kendex-web's `contracts/api/v1/me.json`, and every test reads its statuses and bodies from that file. Nothing yet compares the copy against the original, so drift is caught by running `cmp`, not by CI — KEN-740.

Closes KEN-420

## On top of #1722

KEN-435 landed first and built the store this backs, against a mock of it. Restacking onto it kept its store whole: it already had the read-error split, the failed-read handling, the counter separation, and the credential gate, several done better than the versions here, which were dropped. What survived that merge is expired stickiness, one line so the submit dialog names a failed read, and two corrections to what it had guessed at — `AccountIdentity` matches the wire (`name` present, `githubLogin` null after unlink) rather than the inverse, and the dev mock answers the real shape.

No CHANGELOG entry: with the section rewrite dropped, nothing user-visible changes here that #1722 has not already described.

## Review

Three rounds across ten reviewer lanes plus an external cross-model pass. Two findings worth naming:

- The oversized-cache tests were vacuous, proven by mutation: the fixture died on a JSON parse error and never reached the size cap, so the only guard against reading a 40MB cache file whole could have been deleted with the suite still green. Rewritten to a fixture only the cap refuses.
- Reviewing that surfaced a defect in the review tooling itself — `mutation-stability` reuses the mutant's binary under a shared `CARGO_TARGET_DIR`, so its stability numbers could not be trusted. Filed as #1726 and worked around for the measurements above.

Held out deliberately, each with the reason on its thread: binding a cache generation to the credential that produced it (KEN-739), expiry never reaching the Expired state on the submit and submissions paths (KEN-736), and the contract drift check above (KEN-740).
