### PR TITLE
fix(KEN-723): macOS runs on pull requests, stranded hooks named in full

### DIFF
--- a/.github/workflows/skill-tests.yml
+++ b/.github/workflows/skill-tests.yml
@@ -5,11 +5,12 @@ name: Skill Tests
 # gating here is what lets consuming repos drop tracked vendoring: quality is
 # proven at the source, not re-proven per consumer.
 #
-# THE FAST/FULL SPLIT: the heavy suite shards and the cargo jobs skip on PR
-# pushes — a PR bills zero heavy runner-minutes through every round of bot
-# review, while the pending "Review gate" status is what actually blocks
+# THE FAST/FULL SPLIT: the heavy suite shards and the Linux cargo job skip
+# on PR pushes — a PR bills few heavy runner-minutes through every round of
+# bot review, while the pending "Review gate" status is what actually blocks
 # merge. The full battery runs once per merged result: in the merge queue
 # before the merge, and again on the push to main as the post-merge record.
+# The macOS cargo lane is the exception, and says why where it stands.
 # The review gate never conditions
 # CI (it answers review-only; see the review-gate skill) — there is no gate
 # job here and nothing reads the predicate.
@@ -383,11 +384,16 @@ jobs:
 
   # The app ships on macOS; nothing before the release tag compiled the
   # workspace there, so a mac-only break (keyring backend, path handling)
-  # surfaced at release time. One queue-time lane closes that. Not a
-  # required context yet — a red run is visible without wedging the queue.
+  # surfaced at release time. This lane closes that, and unlike the heavy
+  # jobs above it runs on pull requests: the fast/full split bills PR
+  # minutes as its reason, and this repository is public, so GitHub-standard
+  # runners cost nothing. Four mac-only failures stood on main for three
+  # merge groups while this lane ran only after a PR looked green (KEN-723).
+  # Informational by decision, not omission: it is no ruleset's required
+  # context, so a red run is visible and wedges neither the PR nor the
+  # queue. Whether it should become one is open, and the owner's to answer.
   cargo-tests-macos:
     name: macOS cargo (workspace tests)
-    if: github.event_name == 'merge_group' || github.event_name == 'push'
     runs-on: macos-latest
     timeout-minutes: 30
     steps:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -75,6 +75,10 @@ an outside contributor.
 
 ### Fixed
 
+- `kendex check` names every stranded commit-hook file, not the first and half
+  of the next. A deep checkout path — macOS temp directories, most nested
+  clones — ran the line past a length limit meant for text from outside kendex.
+
 - A blocked declaration now names every position its take-over empties. A
   tree read through a tool's own link sits at two, and `apply --plan` named
   one while `--replace-unmanaged` moved both.

--- a/crates/cli/src/commands/check.rs
+++ b/crates/cli/src/commands/check.rs
@@ -55,7 +55,7 @@ pub fn run(
 /// Only project scopes have a work tree to ask about. A verdict that could
 /// not be taken is `could not check`, never a silent pass.
 fn fold_commit_hooks(env: &Env, checked: &mut CheckReport, scopes: &[kendex_core::model::Scope]) {
-    use kendex_core::drift::report::Class;
+    use kendex_core::drift::report::{Class, Text};
     use kendex_core::model::Scope;
     for scope in scopes {
         let Scope::Project { root } = scope.canonical() else {
@@ -72,7 +72,12 @@ fn fold_commit_hooks(env: &Env, checked: &mut CheckReport, scopes: &[kendex_core
             Ok(Some(repo)) => repo,
             Ok(None) => continue,
             Err(error) => {
-                report::fold(checked, "commit hooks", Class::Unknown, error.to_string());
+                report::fold(
+                    checked,
+                    "commit hooks",
+                    Class::Unknown,
+                    Text::Foreign(error.to_string()),
+                );
                 continue;
             }
         };
@@ -83,7 +88,11 @@ fn fold_commit_hooks(env: &Env, checked: &mut CheckReport, scopes: &[kendex_core
         // the package is in no record, and what it left armed is the one
         // state here that stops every commit. Named by file, because the
         // remedy is by hand — the uninstaller that would strip these went
-        // with the package.
+        // with the package, so a name half spelled is advice nobody can
+        // take. That is why the sentence is `Text::Own`: kendex composed
+        // it, over at most the two hook lanes and their helper, and the
+        // report bounds it by dropping the line whole rather than cutting
+        // a path in half.
         let (class, text) = match installed_here(env, scope) {
             false => match kendex_core::guard::stranded(&repo) {
                 Ok(files) if files.is_empty() => continue,
@@ -94,27 +103,27 @@ fn fold_commit_hooks(env: &Env, checked: &mut CheckReport, scopes: &[kendex_core
                         .collect();
                     (
                         Class::Drift,
-                        format!(
+                        Text::Own(format!(
                             "{} armed the commit hooks and is installed in no project of this repository, so every commit fails until {} are dealt with — strip the lines marked `{}` from each hook, and delete a whole file only where it carries `{}` or is the helper kendex wrote beside the hooks",
                             kendex_core::guard::SKILL,
                             files.join(", "),
                             kendex_core::guard::MARKER,
                             kendex_core::guard::CREATED_MARKER
-                        ),
+                        )),
                     )
                 }
-                Err(error) => (Class::Unknown, error.to_string()),
+                Err(error) => (Class::Unknown, Text::Foreign(error.to_string())),
             },
             true => match kendex_core::guard::armed(&repo) {
                 Ok(true) => continue,
                 Ok(false) => (
                     Class::Drift,
-                    format!(
+                    Text::Own(format!(
                         "commit hooks are not armed in {} — `kendex guard install` arms them, and `kendex guard check` says more",
                         root.display()
-                    ),
+                    )),
                 ),
-                Err(error) => (Class::Unknown, error.to_string()),
+                Err(error) => (Class::Unknown, Text::Foreign(error.to_string())),
             },
         };
         report::fold(checked, "commit hooks", class, text);

--- a/crates/cli/tests/guard_hooks/arming.rs
+++ b/crates/cli/tests/guard_hooks/arming.rs
@@ -705,7 +705,11 @@ fn a_search_domain_it_cannot_read_is_could_not_check_not_a_leftover() {
     use std::os::unix::fs::PermissionsExt;
     let tmp = tempfile::tempdir().unwrap();
     let home = tmp.path();
-    let root = repo(home);
+    // Resolved, like the hooks path the two leftover cases below build:
+    // the report names the directory as the walk resolved it, and on a
+    // system where the temp root is reached through a symlink the
+    // unresolved spelling is a different string.
+    let root = repo(home).canonicalize().unwrap();
     std::fs::write(root.join("kendex.toml"), "schema = 6\n").unwrap();
     install_package_undeclared(&root, &["growth-guards"]);
     arm_by_hand(&root);

--- a/crates/core/src/drift/report.rs
+++ b/crates/core/src/drift/report.rs
@@ -227,47 +227,6 @@ impl Sections {
     }
 }
 
-/// Fold in a verdict this module will not take itself. [`check`] launches
-/// no subprocess: it runs at every session start. The commit-hook verdict
-/// costs one and belongs to the package owning the shims, so the command
-/// layer takes it and hands the answer here. The section lands last and the
-/// status rises to meet it: a check reporting "all clear" while nothing
-/// gates commits is worse than no check.
-pub fn fold(report: &mut CheckReport, title: &str, class: Class, text: String) {
-    let line = Line {
-        class,
-        text: shown(&text),
-        remedy: None,
-    };
-    match report
-        .sections
-        .iter_mut()
-        .find(|section| section.title == title)
-    {
-        Some(section) => section.lines.push(line),
-        None => report.sections.push(Section {
-            title: title.to_owned(),
-            lines: vec![line],
-        }),
-    }
-    let raised = match class {
-        Class::Drift | Class::Unevaluated => CheckStatus::Drift,
-        Class::Unknown => CheckStatus::Unknown,
-    };
-    report.status = report.status.max(raised);
-}
-
-/// Foreign text on its way into the report: control characters become
-/// spaces, credentials become fingerprints, length is bounded.
-fn shown(raw: &str) -> String {
-    let cleaned: String = raw
-        .chars()
-        .take(300)
-        .map(|c| if c.is_control() { ' ' } else { c })
-        .collect();
-    crate::quality::redact(cleaned.trim())
-}
-
 fn drift(text: String, remedy: Option<Remedy>) -> Line {
     Line {
         class: Class::Drift,
@@ -395,6 +354,8 @@ mod tests;
 mod tests_evidence;
 #[cfg(test)]
 mod tests_render;
+mod text;
 
 pub use render::render_plain;
 use scope::check_scope;
+pub use text::{Text, fold};

--- a/crates/core/src/drift/report/scope.rs
+++ b/crates/core/src/drift/report/scope.rs
@@ -1,6 +1,7 @@
 //! One scope's contribution to the report: the sub-checks over manifest,
 //! lock, snapshot, and stamps, each emitting classified lines.
 
+use super::text::shown;
 use super::*;
 
 pub(super) fn check_scope(

--- a/crates/core/src/drift/report/tests_render.rs
+++ b/crates/core/src/drift/report/tests_render.rs
@@ -4,6 +4,7 @@
 use super::tests::{
     env_in, manifest_with_remote, package, project_scope, snapshot_with, write_manifest,
 };
+use super::text::{FOREIGN_CHARS, shown};
 use super::*;
 use crate::drift::snapshot::PackageSnapshot;
 
@@ -125,4 +126,80 @@ fn v1_manifest_reads_as_could_not_check() {
     let report = check(&env, std::slice::from_ref(&scope));
     assert_eq!(report.status, CheckStatus::Unknown);
     assert!(render_plain(&report).contains("v1 manifest"));
+}
+
+/// A folded line kendex composed itself is spelled whole.
+///
+/// The `commit hooks` leftover line exists to name the hook files a person
+/// must edit by hand. It ran past the foreign-text cut on macOS, where the
+/// temp root resolves through `/private/var`, and named the first file and
+/// half the second — advice about files it then declined to name. Length
+/// is not what makes a line foreign, so a longer path must not bring the
+/// cut back.
+#[test]
+fn a_line_kendex_composed_is_named_in_full() {
+    let deep = format!("/private/var/folders/{}/proj/.git/hooks", "d".repeat(200));
+    let text = format!(
+        "growth-guards armed the commit hooks, so every commit fails until {deep}/pre-commit, {deep}/commit-msg are dealt with"
+    );
+    let mut report = check_report();
+    fold(&mut report, "commit hooks", Class::Drift, Text::Own(text));
+
+    let rendered = render_plain(&report);
+    assert!(
+        rendered.contains(&format!("{deep}/commit-msg")),
+        "the second file lost its name:\n{rendered}"
+    );
+    assert_eq!(report.status, CheckStatus::Drift);
+}
+
+/// What kendex composed still cannot carry a control character or a
+/// credential: a path is read off a disk, and a newline in one would forge
+/// a second report line.
+#[test]
+fn a_composed_line_is_scrubbed_even_though_it_is_not_cut() {
+    let mut report = check_report();
+    fold(
+        &mut report,
+        "commit hooks",
+        Class::Drift,
+        Text::Own(
+            "hooks at /repo/\x1b[2J\nevil with sk-ant-api03-abcdefghijklmnopqrstuvwxyz012345 inside"
+                .to_owned(),
+        ),
+    );
+
+    let line = &report.sections[0].lines[0].text;
+    assert!(!line.contains('\x1b') && !line.contains('\n'), "{line}");
+    assert!(
+        !line.contains("sk-ant-api03-abcdefghijklmnopqrstuvwxyz012345"),
+        "{line}"
+    );
+}
+
+/// Foreign text keeps its cut. Nothing outside bounds how much an error
+/// may say, so the report does.
+#[test]
+fn foreign_text_folded_in_is_still_bounded() {
+    let mut report = check_report();
+    fold(
+        &mut report,
+        "commit hooks",
+        Class::Unknown,
+        Text::Foreign("e".repeat(4000)),
+    );
+
+    let line = &report.sections[0].lines[0].text;
+    assert_eq!(line.chars().count(), FOREIGN_CHARS, "{}", line.len());
+    assert_eq!(report.status, CheckStatus::Unknown);
+}
+
+/// A clean report to fold a verdict into — what `check` returns for a
+/// scope with nothing to say.
+fn check_report() -> CheckReport {
+    CheckReport {
+        status: CheckStatus::Clean,
+        sections: Vec::new(),
+        snapshot_age_secs: None,
+    }
 }

--- a/crates/core/src/drift/report/text.rs
+++ b/crates/core/src/drift/report/text.rs
@@ -1,0 +1,88 @@
+//! What a folded line may say, and how much of it.
+//!
+//! A report line is composed here from two kinds of words: kendex's own,
+//! over sets this crate bounds, and words from outside that nothing bounds
+//! until this module does. Telling them apart is the whole job — the same
+//! cut that keeps an error's 4 KB out of an agent's context spelled a
+//! `commit hooks` line's second file half way and told a reader to fix
+//! files it then declined to name.
+
+use super::*;
+
+/// Where a folded line's words came from, which is what decides the
+/// bounding they need. Every caller of [`fold`] says which it is holding,
+/// because the two need different treatment and neither reading is safe to
+/// guess.
+pub enum Text {
+    /// Kendex's own sentence, over a set this code bounds — the two hook
+    /// lanes and their helper, a scope root. Scrubbed and redacted, never
+    /// cut: the whole point of such a line is to name files a person then
+    /// edits by hand, so half of one is not a shorter report but a wrong
+    /// one. What bounds it is [`render_plain`]'s whole-report budget, which
+    /// drops a line entire rather than leaving part of a path behind.
+    Own(String),
+    /// Words from outside — an error's message, a source's own text.
+    /// Nothing here bounds how much of it there may be, so [`shown`] does.
+    Foreign(String),
+}
+
+/// Fold in a verdict this module will not take itself. [`check`] launches
+/// no subprocess: it runs at every session start. The commit-hook verdict
+/// costs one and belongs to the package owning the shims, so the command
+/// layer takes it and hands the answer here. The section lands last and the
+/// status rises to meet it: a check reporting "all clear" while nothing
+/// gates commits is worse than no check.
+pub fn fold(report: &mut CheckReport, title: &str, class: Class, text: Text) {
+    let line = Line {
+        class,
+        text: match text {
+            Text::Own(text) => printable(&text),
+            Text::Foreign(text) => shown(&text),
+        },
+        remedy: None,
+    };
+    match report
+        .sections
+        .iter_mut()
+        .find(|section| section.title == title)
+    {
+        Some(section) => section.lines.push(line),
+        None => report.sections.push(Section {
+            title: title.to_owned(),
+            lines: vec![line],
+        }),
+    }
+    let raised = match class {
+        Class::Drift | Class::Unevaluated => CheckStatus::Drift,
+        Class::Unknown => CheckStatus::Unknown,
+    };
+    report.status = report.status.max(raised);
+}
+
+/// How much of a foreign string the report will spell. Nothing outside
+/// bounds it, so this does — and raising it is not the answer to a line
+/// that came out short, because the next path is longer again.
+pub(super) const FOREIGN_CHARS: usize = 300;
+
+/// Foreign text on its way into the report: control characters become
+/// spaces, credentials become fingerprints, length is bounded.
+///
+/// A fragment bounder, not a line one. It goes around each piece that came
+/// from outside — an error's message, a name off a source — and the line is
+/// composed around the results. Wrapped around a whole composed line it
+/// cuts kendex's own prose instead, which is what left a `commit hooks`
+/// line naming files to delete with the second one spelled half way.
+pub(super) fn shown(raw: &str) -> String {
+    printable(&raw.chars().take(FOREIGN_CHARS).collect::<String>())
+}
+
+/// The same scrubbing with no cut: control characters become spaces so
+/// nothing a path carries can forge a second report line, and credentials
+/// become fingerprints. For text whose length this crate already bounds.
+fn printable(raw: &str) -> String {
+    let cleaned: String = raw
+        .chars()
+        .map(|c| if c.is_control() { ' ' } else { c })
+        .collect();
+    crate::quality::redact(cleaned.trim())
+}

--- a/crates/core/tests/repo_effects_leaving.rs
+++ b/crates/core/tests/repo_effects_leaving.rs
@@ -25,7 +25,12 @@ struct Fixture {
 #[allow(clippy::unwrap_used)]
 fn fixture() -> Fixture {
     let tmp = tempfile::tempdir().unwrap();
-    let home = tmp.path().to_path_buf();
+    // Resolved, because every engine entry point resolves the scope root
+    // it is handed and then reports the paths it read. On macOS the temp
+    // directory is reached through `/var -> private/var`, so an unresolved
+    // fixture path is a second spelling of the same place and every
+    // path equality here compares the two.
+    let home = tmp.path().canonicalize().unwrap();
     let env = Env::fake(&home, FakeOs::Linux);
     let project = home.join("dev/app");
     fs::create_dir_all(project.join(".claude")).unwrap();

--- a/crates/core/tests/skill_records.rs
+++ b/crates/core/tests/skill_records.rs
@@ -32,7 +32,11 @@ fn put(path: &Path, text: &str) {
 #[allow(clippy::unwrap_used)]
 fn fixture() -> Fixture {
     let tmp = tempfile::tempdir().unwrap();
-    let home = tmp.path().to_path_buf();
+    // Resolved: the lock records the paths an install wrote, and the
+    // engine resolves the scope root before writing any of them. On macOS
+    // the temp directory is reached through `/var -> private/var`, so an
+    // unresolved fixture path never equals what the record holds.
+    let home = tmp.path().canonicalize().unwrap();
     let project = home.join("dev/app");
     let source = home.join("catalog");
     put(

--- a/tools/size-ratchet-baseline.tsv
+++ b/tools/size-ratchet-baseline.tsv
@@ -1,5 +1,5 @@
 .github/workflows/review-gate-writer.yml	662
-.github/workflows/skill-tests.yml	402
+.github/workflows/skill-tests.yml	408
 crates/core/src/engine/desired_agent.rs	404
 crates/core/src/engine/detach.rs	603
 crates/core/src/engine/pi_hooks_move/migrated.rs	540


### PR DESCRIPTION
Four tests had failed on every macOS run for three merge groups. The lane runs only in the merge queue, so nothing surfaced them — and that same invisibility let a fifth failure reach main last night (KEN-722).

Two causes, and the first is a real defect rather than a test artifact.

**The `commit hooks` line stopped naming the files it tells you to fix.** When a removed package leaves hook shims armed, every commit fails until they are dealt with by hand, so the line names each file. It went through a 300-character cut meant for text from *outside* kendex. On macOS the temp root resolves through `/private/var`, the line ran past the cut, and the second file was spelled half way — telling a reader to fix files it then declined to name. Any deep checkout path hits it; macOS just gets there first.

Provenance is explicit at the fold boundary now. `Text::Own` is kendex's own sentence over a set this code bounds — scrubbed and redacted, never cut. `Text::Foreign` keeps the cut it was designed for. Every caller says which it is holding, because guessing is what produced the bug. Raising the limit was rejected: the same defect returns with a deeper path. An `Own` line is still bounded, by the report's whole-report budget, which drops a line entire and says how many it dropped rather than leaving half a path behind.

**The other two are test defects.** The engine resolves a scope root before it records anything, so the lock holds `/private/var` paths while the fixtures compared against the `/var` spelling they never resolved. Both resolve now, which `arming.rs` already did. A third test in `arming.rs` was passing on macOS *only* because `/var/…` is a substring of `/private/var/…` — passing for the wrong reason, and it would have kept passing through any fix. It resolves too.

**The lane now runs on pull requests, informational only.** The fast/full split bills PR minutes as its reason and this repository is public, so GitHub-standard runners cost nothing.

**Required-ness stays with the owner.** This lane is no ruleset's required context, by decision rather than omission, so a red run wedges neither the PR nor the queue. Whether it should become required is an open owner decision — recommended twice, still unanswered — and no ruleset was touched here. The workflow comment records it as an open question rather than pending work.

## Verification

There is no macOS to test on (`ssh user@mbp` times out), so this PR's own lane is the proof — which is why the lane change and the fixes ship together.

Locally, all four failures were reproduced on Linux under a symlinked `TMPDIR` at macOS path length, and the whole workspace passes after. That reproduces the mechanism; only the macOS lane on this PR can confirm the platform.

The workflow's size-ratchet baseline rises 6 lines for the comment recording why the lane is PR-visible and what would make it blocking. `drift/report.rs` was at its 400-line threshold, so the text bounding moved to `report/text.rs`.

Closes KEN-723
