### PR TITLE
docs(code-quality): write the derivation, never the count

### DIFF
--- a/.agents/skills/code-quality/SKILL.md
+++ b/.agents/skills/code-quality/SKILL.md
@@ -54,6 +54,7 @@ Don't:
 - Temporal markers ("added", "new", "existing code", "Phase 1") or revision narration.
 - References to AI conversations, review rounds, or issue archaeology.
 - Claims broader than what the adjacent code or assertion actually enforces.
+- A numeral counting things outside the sentence. State the property and the command that enumerates it. A numeral bound to something adjacent — a list in the same paragraph, a constant a check compares against, one a ratchet owns — stays.
 
 Same rules for docs, READMEs, and skill/agent files: state the rule or behavior, never its provenance or justification. Their reader is an agent — write the shortest unambiguous rule and delete sentences nothing acts on.
 

--- a/skills/code-quality/SKILL.md
+++ b/skills/code-quality/SKILL.md
@@ -54,6 +54,7 @@ Don't:
 - Temporal markers ("added", "new", "existing code", "Phase 1") or revision narration.
 - References to AI conversations, review rounds, or issue archaeology.
 - Claims broader than what the adjacent code or assertion actually enforces.
+- A numeral counting things outside the sentence. State the property and the command that enumerates it. A numeral bound to something adjacent — a list in the same paragraph, a constant a check compares against, one a ratchet owns — stays.
 
 Same rules for docs, READMEs, and skill/agent files: state the rule or behavior, never its provenance or justification. Their reader is an agent — write the shortest unambiguous rule and delete sentences nothing acts on.
 


### PR DESCRIPTION
`code-quality` § Comments and Prose bans claims broader than the adjacent code enforces. It did not cover a numeral counting things that live outside the sentence — a repo-wide enumeration nothing re-measures.

One Don't line adds it, with the exemption that makes it usable: a numeral bound to something adjacent — a list in the same paragraph, a constant a check compares against, one a ratchet owns — is self-verifying and stays.

Closes #1731