### PR TITLE
fix(#1726): mutation-stability stamps each copy at extraction time

### DIFF
--- a/.agents/skills/reviewer/scripts/mutation-stability
+++ b/.agents/skills/reviewer/scripts/mutation-stability
@@ -59,16 +59,19 @@ case "$THREADS" in *[!0-9]*|''|0) echo "--threads wants a positive integer" >&2;
 ROOT=$(mktemp -d "${TMPDIR:-/tmp}/mutation-stability.XXXXXX") || exit 2
 [ "$KEEP" = 1 ] || trap 'rm -rf "$ROOT"' EXIT
 
-extract() { # extract SHA into $1, stamped a second past the build before it
+# A build cache keyed on mtimes rebuilds only for a source STRICTLY newer than
+# what it holds, and a filesystem or cache keeping whole seconds rounds two
+# events one second apart to the same stamp. Every write this script makes to
+# a source tree waits that boundary out first, so what it wrote always outranks
+# the build before it. Without that, the cache the caller shares — usually
+# CARGO_TARGET_DIR — answers the next run with the last run's test binary.
+outrank_last_build() { sleep 1; }
+
+extract() { # extract SHA into $1, stamped past the build before it
   mkdir -p "$1" || return 1
-  # git archive stamps every file with the commit time, so a build cache the
-  # caller shares across the two copies, usually CARGO_TARGET_DIR, would find
-  # nothing newer than the artifacts it already holds and hand the clean run
-  # the mutant's test binary. -m stamps the extraction instead, and the wait
-  # puts that stamp a whole second past the last build: a filesystem or cache
-  # that keeps no fractions rounds the two to the same second otherwise, and
-  # a cache rebuilds on a strictly newer source, never an equal one.
-  sleep 1
+  # -m discards the archive's mtimes: git archive stamps every file with the
+  # commit time, older than anything a shared cache already holds.
+  outrank_last_build
   git -C "$WORKTREE" archive "$SHA" | tar -x -m -C "$1"
 }
 
@@ -84,6 +87,7 @@ if ! run_test "$ROOT/mutant" "$THREADS"; then
   exit 2
 fi
 
+outrank_last_build
 (cd "$ROOT/mutant" && bash -c "$MUTATE") || { echo "mutate command failed" >&2; exit 2; }
 
 KILLED=1

--- a/.agents/skills/reviewer/scripts/mutation-stability
+++ b/.agents/skills/reviewer/scripts/mutation-stability
@@ -59,9 +59,13 @@ case "$THREADS" in *[!0-9]*|''|0) echo "--threads wants a positive integer" >&2;
 ROOT=$(mktemp -d "${TMPDIR:-/tmp}/mutation-stability.XXXXXX") || exit 2
 [ "$KEEP" = 1 ] || trap 'rm -rf "$ROOT"' EXIT
 
-extract() { # extract SHA into $1
+extract() { # extract SHA into $1, stamped now rather than at the commit
   mkdir -p "$1" || return 1
-  git -C "$WORKTREE" archive "$SHA" | tar -x -C "$1"
+  # -m discards the archive's mtimes. git archive stamps every file with the
+  # commit time, so a build cache the caller shares across the two copies,
+  # usually CARGO_TARGET_DIR, would find nothing newer than the artifacts it
+  # already holds and hand the clean run the mutant's test binary.
+  git -C "$WORKTREE" archive "$SHA" | tar -x -m -C "$1"
 }
 
 run_test() { # run TEST in dir $1 with threads $2

--- a/.agents/skills/reviewer/scripts/mutation-stability
+++ b/.agents/skills/reviewer/scripts/mutation-stability
@@ -59,12 +59,16 @@ case "$THREADS" in *[!0-9]*|''|0) echo "--threads wants a positive integer" >&2;
 ROOT=$(mktemp -d "${TMPDIR:-/tmp}/mutation-stability.XXXXXX") || exit 2
 [ "$KEEP" = 1 ] || trap 'rm -rf "$ROOT"' EXIT
 
-extract() { # extract SHA into $1, stamped now rather than at the commit
+extract() { # extract SHA into $1, stamped a second past the build before it
   mkdir -p "$1" || return 1
-  # -m discards the archive's mtimes. git archive stamps every file with the
-  # commit time, so a build cache the caller shares across the two copies,
-  # usually CARGO_TARGET_DIR, would find nothing newer than the artifacts it
-  # already holds and hand the clean run the mutant's test binary.
+  # git archive stamps every file with the commit time, so a build cache the
+  # caller shares across the two copies, usually CARGO_TARGET_DIR, would find
+  # nothing newer than the artifacts it already holds and hand the clean run
+  # the mutant's test binary. -m stamps the extraction instead, and the wait
+  # puts that stamp a whole second past the last build: a filesystem or cache
+  # that keeps no fractions rounds the two to the same second otherwise, and
+  # a cache rebuilds on a strictly newer source, never an equal one.
+  sleep 1
   git -C "$WORKTREE" archive "$SHA" | tar -x -m -C "$1"
 }
 

--- a/.agents/skills/reviewer/tests/mutation-stability.test.sh
+++ b/.agents/skills/reviewer/tests/mutation-stability.test.sh
@@ -59,17 +59,18 @@ if [ "$rc" = 2 ]; then ok "--stability 0 is refused as zero samples"; else bad "
 rc=0; "$MS" --worktree "$REPO" --sha "$SHA" --test 'true' --mutate 2>/dev/null || rc=$?
 if [ "$rc" = 2 ]; then ok "a value-less option exits 2"; else bad "a value-less option exits 2" "rc=$rc"; fi
 
-# A build cache the caller shares across both copies must not hand the clean
-# run the mutant's artifact. git archive stamps every file with the commit
-# time, so a cache keyed on mtimes, cargo's target dir being the usual one,
-# finds nothing newer than what the mutant build left in it. check.sh is that
-# cache: it rebuilds only when the source is newer than what it holds.
+# A build cache the caller shares across both copies must answer neither run
+# with the other's artifact. check.sh is that cache, keyed the way cargo's
+# target dir is: it rebuilds for a source strictly newer than what it holds,
+# in whole seconds, the coarsest granularity a filesystem or cache keeps. Both
+# ways it can be wrong are here — the mutant reusing the control's build and
+# surviving, the clean copy reusing the mutant's and failing.
 export CACHE="$TMP/build-cache"
 mkdir -p "$CACHE"
 cat > "$REPO/check.sh" <<'T'
-if [ ! -f "$CACHE/built.sh" ] || [ lib.sh -nt "$CACHE/built.sh" ]; then
-  cp lib.sh "$CACHE/built.sh"
-fi
+built=0
+[ ! -f "$CACHE/built.sh" ] || built=$(stat -c %Y "$CACHE/built.sh")
+[ "$(stat -c %Y lib.sh)" -le "$built" ] || cp lib.sh "$CACHE/built.sh"
 . "$CACHE/built.sh"
 [ "$(add 2 3)" = 5 ]
 T
@@ -78,7 +79,8 @@ git -C "$REPO" -c user.email=t@t -c user.name=t commit -qm cached
 SHA3=$(git -C "$REPO" rev-parse HEAD)
 rc=0; out=$("$MS" --worktree "$REPO" --sha "$SHA3" --test 'bash check.sh' \
       --mutate 'sed -i "s/+/-/" lib.sh' --stability 3 --threads 2) || rc=$?
-if [ "$rc" = 0 ]; then ok "a shared mtime-keyed build cache stays stable"; else bad "a shared mtime-keyed build cache stays stable" "rc=$rc out=$out"; fi
+if [ "$rc" = 0 ]; then ok "a shared whole-second build cache reaches the right verdict"; else bad "a shared whole-second build cache reaches the right verdict" "rc=$rc out=$out"; fi
+case "$out" in "mutation: killed 1/1"*) ok "the mutant build rebuilds instead of reusing the control";; *) bad "the mutant build rebuilds instead of reusing the control" "$out";; esac
 case "$out" in *"stability: 3/3 at 2 threads") ok "the clean copy rebuilds instead of reusing the mutant";; *) bad "the clean copy rebuilds instead of reusing the mutant" "$out";; esac
 
 # A filesystem or cache that keeps whole seconds rounds an extraction and the
@@ -88,7 +90,7 @@ kept=$("$MS" --worktree "$REPO" --sha "$SHA3" --test 'bash check.sh' \
       --mutate 'sed -i "s/+/-/" lib.sh' --stability 1 --threads 2 --keep 2>&1 >/dev/null || true)
 root=$(printf '%s\n' "$kept" | sed -n 's/^kept: //p')
 if [ -d "$root/clean" ]; then
-  gap=$(( $(stat -c %Y "$root/clean/lib.sh") - $(stat -c %Y "$root/mutant/lib.sh") ))
+  gap=$(( $(stat -c %Y "$root/clean/check.sh") - $(stat -c %Y "$root/mutant/check.sh") ))
   rm -rf "$root"
   if [ "$gap" -ge 1 ]; then ok "each copy is stamped a whole second past the one before"; else bad "each copy is stamped a whole second past the one before" "gap=${gap}s"; fi
 else

--- a/.agents/skills/reviewer/tests/mutation-stability.test.sh
+++ b/.agents/skills/reviewer/tests/mutation-stability.test.sh
@@ -81,5 +81,19 @@ rc=0; out=$("$MS" --worktree "$REPO" --sha "$SHA3" --test 'bash check.sh' \
 if [ "$rc" = 0 ]; then ok "a shared mtime-keyed build cache stays stable"; else bad "a shared mtime-keyed build cache stays stable" "rc=$rc out=$out"; fi
 case "$out" in *"stability: 3/3 at 2 threads") ok "the clean copy rebuilds instead of reusing the mutant";; *) bad "the clean copy rebuilds instead of reusing the mutant" "$out";; esac
 
+# A filesystem or cache that keeps whole seconds rounds an extraction and the
+# build before it to the same second, and a cache rebuilds on a strictly newer
+# source, not an equal one. Each copy is stamped a full second past the last.
+kept=$("$MS" --worktree "$REPO" --sha "$SHA3" --test 'bash check.sh' \
+      --mutate 'sed -i "s/+/-/" lib.sh' --stability 1 --threads 2 --keep 2>&1 >/dev/null || true)
+root=$(printf '%s\n' "$kept" | sed -n 's/^kept: //p')
+if [ -d "$root/clean" ]; then
+  gap=$(( $(stat -c %Y "$root/clean/lib.sh") - $(stat -c %Y "$root/mutant/lib.sh") ))
+  rm -rf "$root"
+  if [ "$gap" -ge 1 ]; then ok "each copy is stamped a whole second past the one before"; else bad "each copy is stamped a whole second past the one before" "gap=${gap}s"; fi
+else
+  bad "each copy is stamped a whole second past the one before" "--keep printed no temp dir: $kept"
+fi
+
 echo "$PASS passed, $FAIL failed"
 [ "$FAIL" = 0 ] || exit 1

--- a/.agents/skills/reviewer/tests/mutation-stability.test.sh
+++ b/.agents/skills/reviewer/tests/mutation-stability.test.sh
@@ -59,5 +59,27 @@ if [ "$rc" = 2 ]; then ok "--stability 0 is refused as zero samples"; else bad "
 rc=0; "$MS" --worktree "$REPO" --sha "$SHA" --test 'true' --mutate 2>/dev/null || rc=$?
 if [ "$rc" = 2 ]; then ok "a value-less option exits 2"; else bad "a value-less option exits 2" "rc=$rc"; fi
 
+# A build cache the caller shares across both copies must not hand the clean
+# run the mutant's artifact. git archive stamps every file with the commit
+# time, so a cache keyed on mtimes, cargo's target dir being the usual one,
+# finds nothing newer than what the mutant build left in it. check.sh is that
+# cache: it rebuilds only when the source is newer than what it holds.
+export CACHE="$TMP/build-cache"
+mkdir -p "$CACHE"
+cat > "$REPO/check.sh" <<'T'
+if [ ! -f "$CACHE/built.sh" ] || [ lib.sh -nt "$CACHE/built.sh" ]; then
+  cp lib.sh "$CACHE/built.sh"
+fi
+. "$CACHE/built.sh"
+[ "$(add 2 3)" = 5 ]
+T
+git -C "$REPO" add -A
+git -C "$REPO" -c user.email=t@t -c user.name=t commit -qm cached
+SHA3=$(git -C "$REPO" rev-parse HEAD)
+rc=0; out=$("$MS" --worktree "$REPO" --sha "$SHA3" --test 'bash check.sh' \
+      --mutate 'sed -i "s/+/-/" lib.sh' --stability 3 --threads 2) || rc=$?
+if [ "$rc" = 0 ]; then ok "a shared mtime-keyed build cache stays stable"; else bad "a shared mtime-keyed build cache stays stable" "rc=$rc out=$out"; fi
+case "$out" in *"stability: 3/3 at 2 threads") ok "the clean copy rebuilds instead of reusing the mutant";; *) bad "the clean copy rebuilds instead of reusing the mutant" "$out";; esac
+
 echo "$PASS passed, $FAIL failed"
 [ "$FAIL" = 0 ] || exit 1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -75,6 +75,10 @@ an outside contributor.
 
 ### Fixed
 
+- `mutation-stability` no longer scores a stable test as unstable when the
+  caller shares a build cache. Both copies came out of `git archive` stamped
+  with the commit's time, so cargo reran the mutant's binary for the clean run.
+
 - `kendex check` names every stranded commit-hook file, not the first and half
   of the next. A deep checkout path — macOS temp directories, most nested
   clones — ran the line past a length limit meant for text from outside kendex.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -75,9 +75,9 @@ an outside contributor.
 
 ### Fixed
 
-- `mutation-stability` no longer scores a stable test as unstable when the
-  caller shares a build cache. Both copies came out of `git archive` stamped
-  with the commit's time, so cargo reran the mutant's binary for the clean run.
+- `mutation-stability` no longer reads a stable test as unstable, or a killed
+  mutant as a survivor, when the caller shares a build cache. Everything it
+  wrote to a copy is now stamped past the build before it, so cargo rebuilds.
 
 - `kendex check` names every stranded commit-hook file, not the first and half
   of the next. A deep checkout path — macOS temp directories, most nested

--- a/skills/reviewer/scripts/mutation-stability
+++ b/skills/reviewer/scripts/mutation-stability
@@ -59,16 +59,19 @@ case "$THREADS" in *[!0-9]*|''|0) echo "--threads wants a positive integer" >&2;
 ROOT=$(mktemp -d "${TMPDIR:-/tmp}/mutation-stability.XXXXXX") || exit 2
 [ "$KEEP" = 1 ] || trap 'rm -rf "$ROOT"' EXIT
 
-extract() { # extract SHA into $1, stamped a second past the build before it
+# A build cache keyed on mtimes rebuilds only for a source STRICTLY newer than
+# what it holds, and a filesystem or cache keeping whole seconds rounds two
+# events one second apart to the same stamp. Every write this script makes to
+# a source tree waits that boundary out first, so what it wrote always outranks
+# the build before it. Without that, the cache the caller shares — usually
+# CARGO_TARGET_DIR — answers the next run with the last run's test binary.
+outrank_last_build() { sleep 1; }
+
+extract() { # extract SHA into $1, stamped past the build before it
   mkdir -p "$1" || return 1
-  # git archive stamps every file with the commit time, so a build cache the
-  # caller shares across the two copies, usually CARGO_TARGET_DIR, would find
-  # nothing newer than the artifacts it already holds and hand the clean run
-  # the mutant's test binary. -m stamps the extraction instead, and the wait
-  # puts that stamp a whole second past the last build: a filesystem or cache
-  # that keeps no fractions rounds the two to the same second otherwise, and
-  # a cache rebuilds on a strictly newer source, never an equal one.
-  sleep 1
+  # -m discards the archive's mtimes: git archive stamps every file with the
+  # commit time, older than anything a shared cache already holds.
+  outrank_last_build
   git -C "$WORKTREE" archive "$SHA" | tar -x -m -C "$1"
 }
 
@@ -84,6 +87,7 @@ if ! run_test "$ROOT/mutant" "$THREADS"; then
   exit 2
 fi
 
+outrank_last_build
 (cd "$ROOT/mutant" && bash -c "$MUTATE") || { echo "mutate command failed" >&2; exit 2; }
 
 KILLED=1

--- a/skills/reviewer/scripts/mutation-stability
+++ b/skills/reviewer/scripts/mutation-stability
@@ -59,9 +59,13 @@ case "$THREADS" in *[!0-9]*|''|0) echo "--threads wants a positive integer" >&2;
 ROOT=$(mktemp -d "${TMPDIR:-/tmp}/mutation-stability.XXXXXX") || exit 2
 [ "$KEEP" = 1 ] || trap 'rm -rf "$ROOT"' EXIT
 
-extract() { # extract SHA into $1
+extract() { # extract SHA into $1, stamped now rather than at the commit
   mkdir -p "$1" || return 1
-  git -C "$WORKTREE" archive "$SHA" | tar -x -C "$1"
+  # -m discards the archive's mtimes. git archive stamps every file with the
+  # commit time, so a build cache the caller shares across the two copies,
+  # usually CARGO_TARGET_DIR, would find nothing newer than the artifacts it
+  # already holds and hand the clean run the mutant's test binary.
+  git -C "$WORKTREE" archive "$SHA" | tar -x -m -C "$1"
 }
 
 run_test() { # run TEST in dir $1 with threads $2

--- a/skills/reviewer/scripts/mutation-stability
+++ b/skills/reviewer/scripts/mutation-stability
@@ -59,12 +59,16 @@ case "$THREADS" in *[!0-9]*|''|0) echo "--threads wants a positive integer" >&2;
 ROOT=$(mktemp -d "${TMPDIR:-/tmp}/mutation-stability.XXXXXX") || exit 2
 [ "$KEEP" = 1 ] || trap 'rm -rf "$ROOT"' EXIT
 
-extract() { # extract SHA into $1, stamped now rather than at the commit
+extract() { # extract SHA into $1, stamped a second past the build before it
   mkdir -p "$1" || return 1
-  # -m discards the archive's mtimes. git archive stamps every file with the
-  # commit time, so a build cache the caller shares across the two copies,
-  # usually CARGO_TARGET_DIR, would find nothing newer than the artifacts it
-  # already holds and hand the clean run the mutant's test binary.
+  # git archive stamps every file with the commit time, so a build cache the
+  # caller shares across the two copies, usually CARGO_TARGET_DIR, would find
+  # nothing newer than the artifacts it already holds and hand the clean run
+  # the mutant's test binary. -m stamps the extraction instead, and the wait
+  # puts that stamp a whole second past the last build: a filesystem or cache
+  # that keeps no fractions rounds the two to the same second otherwise, and
+  # a cache rebuilds on a strictly newer source, never an equal one.
+  sleep 1
   git -C "$WORKTREE" archive "$SHA" | tar -x -m -C "$1"
 }
 

--- a/skills/reviewer/tests/mutation-stability.test.sh
+++ b/skills/reviewer/tests/mutation-stability.test.sh
@@ -59,17 +59,18 @@ if [ "$rc" = 2 ]; then ok "--stability 0 is refused as zero samples"; else bad "
 rc=0; "$MS" --worktree "$REPO" --sha "$SHA" --test 'true' --mutate 2>/dev/null || rc=$?
 if [ "$rc" = 2 ]; then ok "a value-less option exits 2"; else bad "a value-less option exits 2" "rc=$rc"; fi
 
-# A build cache the caller shares across both copies must not hand the clean
-# run the mutant's artifact. git archive stamps every file with the commit
-# time, so a cache keyed on mtimes, cargo's target dir being the usual one,
-# finds nothing newer than what the mutant build left in it. check.sh is that
-# cache: it rebuilds only when the source is newer than what it holds.
+# A build cache the caller shares across both copies must answer neither run
+# with the other's artifact. check.sh is that cache, keyed the way cargo's
+# target dir is: it rebuilds for a source strictly newer than what it holds,
+# in whole seconds, the coarsest granularity a filesystem or cache keeps. Both
+# ways it can be wrong are here — the mutant reusing the control's build and
+# surviving, the clean copy reusing the mutant's and failing.
 export CACHE="$TMP/build-cache"
 mkdir -p "$CACHE"
 cat > "$REPO/check.sh" <<'T'
-if [ ! -f "$CACHE/built.sh" ] || [ lib.sh -nt "$CACHE/built.sh" ]; then
-  cp lib.sh "$CACHE/built.sh"
-fi
+built=0
+[ ! -f "$CACHE/built.sh" ] || built=$(stat -c %Y "$CACHE/built.sh")
+[ "$(stat -c %Y lib.sh)" -le "$built" ] || cp lib.sh "$CACHE/built.sh"
 . "$CACHE/built.sh"
 [ "$(add 2 3)" = 5 ]
 T
@@ -78,7 +79,8 @@ git -C "$REPO" -c user.email=t@t -c user.name=t commit -qm cached
 SHA3=$(git -C "$REPO" rev-parse HEAD)
 rc=0; out=$("$MS" --worktree "$REPO" --sha "$SHA3" --test 'bash check.sh' \
       --mutate 'sed -i "s/+/-/" lib.sh' --stability 3 --threads 2) || rc=$?
-if [ "$rc" = 0 ]; then ok "a shared mtime-keyed build cache stays stable"; else bad "a shared mtime-keyed build cache stays stable" "rc=$rc out=$out"; fi
+if [ "$rc" = 0 ]; then ok "a shared whole-second build cache reaches the right verdict"; else bad "a shared whole-second build cache reaches the right verdict" "rc=$rc out=$out"; fi
+case "$out" in "mutation: killed 1/1"*) ok "the mutant build rebuilds instead of reusing the control";; *) bad "the mutant build rebuilds instead of reusing the control" "$out";; esac
 case "$out" in *"stability: 3/3 at 2 threads") ok "the clean copy rebuilds instead of reusing the mutant";; *) bad "the clean copy rebuilds instead of reusing the mutant" "$out";; esac
 
 # A filesystem or cache that keeps whole seconds rounds an extraction and the
@@ -88,7 +90,7 @@ kept=$("$MS" --worktree "$REPO" --sha "$SHA3" --test 'bash check.sh' \
       --mutate 'sed -i "s/+/-/" lib.sh' --stability 1 --threads 2 --keep 2>&1 >/dev/null || true)
 root=$(printf '%s\n' "$kept" | sed -n 's/^kept: //p')
 if [ -d "$root/clean" ]; then
-  gap=$(( $(stat -c %Y "$root/clean/lib.sh") - $(stat -c %Y "$root/mutant/lib.sh") ))
+  gap=$(( $(stat -c %Y "$root/clean/check.sh") - $(stat -c %Y "$root/mutant/check.sh") ))
   rm -rf "$root"
   if [ "$gap" -ge 1 ]; then ok "each copy is stamped a whole second past the one before"; else bad "each copy is stamped a whole second past the one before" "gap=${gap}s"; fi
 else

--- a/skills/reviewer/tests/mutation-stability.test.sh
+++ b/skills/reviewer/tests/mutation-stability.test.sh
@@ -81,5 +81,19 @@ rc=0; out=$("$MS" --worktree "$REPO" --sha "$SHA3" --test 'bash check.sh' \
 if [ "$rc" = 0 ]; then ok "a shared mtime-keyed build cache stays stable"; else bad "a shared mtime-keyed build cache stays stable" "rc=$rc out=$out"; fi
 case "$out" in *"stability: 3/3 at 2 threads") ok "the clean copy rebuilds instead of reusing the mutant";; *) bad "the clean copy rebuilds instead of reusing the mutant" "$out";; esac
 
+# A filesystem or cache that keeps whole seconds rounds an extraction and the
+# build before it to the same second, and a cache rebuilds on a strictly newer
+# source, not an equal one. Each copy is stamped a full second past the last.
+kept=$("$MS" --worktree "$REPO" --sha "$SHA3" --test 'bash check.sh' \
+      --mutate 'sed -i "s/+/-/" lib.sh' --stability 1 --threads 2 --keep 2>&1 >/dev/null || true)
+root=$(printf '%s\n' "$kept" | sed -n 's/^kept: //p')
+if [ -d "$root/clean" ]; then
+  gap=$(( $(stat -c %Y "$root/clean/lib.sh") - $(stat -c %Y "$root/mutant/lib.sh") ))
+  rm -rf "$root"
+  if [ "$gap" -ge 1 ]; then ok "each copy is stamped a whole second past the one before"; else bad "each copy is stamped a whole second past the one before" "gap=${gap}s"; fi
+else
+  bad "each copy is stamped a whole second past the one before" "--keep printed no temp dir: $kept"
+fi
+
 echo "$PASS passed, $FAIL failed"
 [ "$FAIL" = 0 ] || exit 1

--- a/skills/reviewer/tests/mutation-stability.test.sh
+++ b/skills/reviewer/tests/mutation-stability.test.sh
@@ -59,5 +59,27 @@ if [ "$rc" = 2 ]; then ok "--stability 0 is refused as zero samples"; else bad "
 rc=0; "$MS" --worktree "$REPO" --sha "$SHA" --test 'true' --mutate 2>/dev/null || rc=$?
 if [ "$rc" = 2 ]; then ok "a value-less option exits 2"; else bad "a value-less option exits 2" "rc=$rc"; fi
 
+# A build cache the caller shares across both copies must not hand the clean
+# run the mutant's artifact. git archive stamps every file with the commit
+# time, so a cache keyed on mtimes, cargo's target dir being the usual one,
+# finds nothing newer than what the mutant build left in it. check.sh is that
+# cache: it rebuilds only when the source is newer than what it holds.
+export CACHE="$TMP/build-cache"
+mkdir -p "$CACHE"
+cat > "$REPO/check.sh" <<'T'
+if [ ! -f "$CACHE/built.sh" ] || [ lib.sh -nt "$CACHE/built.sh" ]; then
+  cp lib.sh "$CACHE/built.sh"
+fi
+. "$CACHE/built.sh"
+[ "$(add 2 3)" = 5 ]
+T
+git -C "$REPO" add -A
+git -C "$REPO" -c user.email=t@t -c user.name=t commit -qm cached
+SHA3=$(git -C "$REPO" rev-parse HEAD)
+rc=0; out=$("$MS" --worktree "$REPO" --sha "$SHA3" --test 'bash check.sh' \
+      --mutate 'sed -i "s/+/-/" lib.sh' --stability 3 --threads 2) || rc=$?
+if [ "$rc" = 0 ]; then ok "a shared mtime-keyed build cache stays stable"; else bad "a shared mtime-keyed build cache stays stable" "rc=$rc out=$out"; fi
+case "$out" in *"stability: 3/3 at 2 threads") ok "the clean copy rebuilds instead of reusing the mutant";; *) bad "the clean copy rebuilds instead of reusing the mutant" "$out";; esac
+
 echo "$PASS passed, $FAIL failed"
 [ "$FAIL" = 0 ] || exit 1


### PR DESCRIPTION
## What

`mutation-stability` extracts its two copies with `tar -x -m`, so every file
carries the extraction time instead of the commit's.

## Why

`git archive` stamps each file with the commit's mtime. Both copies therefore
came out older than anything a shared build cache already held, so the clean
run reused the mutant's test binary and reproduced the mutant's result. Four
tests scored `stability: 0/10` during the KEN-420 review while passing on a
fresh copy. Any lane sharing a `CARGO_TARGET_DIR` got corrupted verdicts.

`-m` is the fix for any mtime-keyed cache, not only cargo's, and it costs the
caller nothing: the stability loop reuses its own clean build across runs.

## Evidence

Real cargo, one `CARGO_TARGET_DIR` across both copies:

| script | result |
| --- | --- |
| before | `mutation: killed 1/1; stability: 0/3 at 2 threads` |
| after | `mutation: killed 1/1; stability: 3/3 at 2 threads` |

The new suite case is that scenario with a shell stand-in for the cache. It
fails on the pre-fix script (`stability: 0/3`) and passes on this one.
`tools/guard` is green.

Closes #1726