### PR TITLE
fix(KEN-730): a skill's lock entry routes its report to kendex

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -88,6 +88,10 @@ an outside contributor.
 - In the app, a row you just settled no longer comes back. A machine-wide
   check that started before the change and landed after it overwrote the
   newer reading, and kept it for the freshness window.
+- `kendex report --skill` files against kendex, like `--agent` and `--hook`
+  already did; a skill installed from anywhere else still files against your
+  own repo.
+
 - `worktree cleanup` and `worktree remove` prove a merge two ways and no other:
   ancestry into the default branch, or the pull request whose head commit is
   the branch tip. Squash merges collect, and every keep now names its reason.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -91,6 +91,9 @@ an outside contributor.
 - `kendex report --skill` files against kendex, like `--agent` and `--hook`
   already did; a skill installed from anywhere else still files against your
   own repo.
+- `kendex report --upstream` takes a GitHub repo spelled any way — shorthand,
+  https URL or `git@` — and files against it when your lock records the asset
+  from that repo.
 - `worktree cleanup` and `worktree remove` prove a merge two ways and no other:
   ancestry into the default branch, or the pull request whose head commit is
   the branch tip. Squash merges collect, and every keep now names its reason.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -91,7 +91,6 @@ an outside contributor.
 - `kendex report --skill` files against kendex, like `--agent` and `--hook`
   already did; a skill installed from anywhere else still files against your
   own repo.
-
 - `worktree cleanup` and `worktree remove` prove a merge two ways and no other:
   ancestry into the default branch, or the pull request whose head commit is
   the branch tip. Squash merges collect, and every keep now names its reason.

--- a/crates/app/src/commands.rs
+++ b/crates/app/src/commands.rs
@@ -119,14 +119,8 @@ pub fn report_route(
             kendex_core::lock::Lock::default()
         }
     };
-    let route = kendex_core::report::route(
-        &env,
-        &scope,
-        &lock,
-        &name,
-        kind,
-        kendex_core::report::DEFAULT_UPSTREAM,
-    );
+    let route =
+        kendex_core::report::route(&lock, &name, kind, kendex_core::report::DEFAULT_UPSTREAM);
     let issue_url = route.repo.as_ref().map(|repo| {
         let mut url = format!(
             "https://github.com/{repo}/issues/new?title={}",

--- a/crates/cli/src/commands/report.rs
+++ b/crates/cli/src/commands/report.rs
@@ -104,12 +104,18 @@ pub fn run(env: &Env, args: ReportArgs) -> CliResult {
     let route = selector
         .as_ref()
         .map(|(name, kind)| kendex_core::report::route(&lock, name, *kind, &upstream));
-    let kendex_owned = route.as_ref().is_some_and(|r| r.kendex_owned);
+    // The judge names the destination as well as the decision: `gh --repo`
+    // takes `owner/repo`, not the URL `--upstream` may be spelled with.
+    let target = route
+        .as_ref()
+        .filter(|r| r.kendex_owned)
+        .and_then(|r| r.repo.clone());
+    let kendex_owned = target.is_some();
 
     let mut gh_args = vec!["issue".to_owned(), "create".to_owned()];
     let mut sent_body = body.clone();
     let mut area = None;
-    if kendex_owned {
+    if let Some(target) = &target {
         let name = selector.as_ref().map_or("unknown", |(n, _)| n.as_str());
         // The kind the route resolved, so `--asset` on a skill stamps the
         // same marker `--skill` would.
@@ -120,7 +126,7 @@ pub fn run(env: &Env, args: ReportArgs) -> CliResult {
         sent_body.push_str(&format!(
             "\n\n<!-- kendex-report:v1 asset={name} kind={kind_label} ownership=kendex -->"
         ));
-        gh_args.extend(["--repo".to_owned(), upstream.clone()]);
+        gh_args.extend(["--repo".to_owned(), target.clone()]);
         // Routing labels exist only on the canonical repo; a fork override
         // must not carry one or gh fails with "label not found".
         if let Some(derived) =
@@ -142,11 +148,7 @@ pub fn run(env: &Env, args: ReportArgs) -> CliResult {
         say(&format!("ownership: {ownership}"));
         say(&format!(
             "target: {}",
-            if kendex_owned {
-                upstream.as_str()
-            } else {
-                "current repo origin"
-            }
+            target.as_deref().unwrap_or("current repo origin")
         ));
         if let Some(area) = area {
             say(&format!("label: {area}"));

--- a/crates/cli/src/commands/report.rs
+++ b/crates/cli/src/commands/report.rs
@@ -103,18 +103,20 @@ pub fn run(env: &Env, args: ReportArgs) -> CliResult {
     }
     let route = selector
         .as_ref()
-        .map(|(name, kind)| kendex_core::report::route(env, &scope, &lock, name, *kind, &upstream));
+        .map(|(name, kind)| kendex_core::report::route(&lock, name, *kind, &upstream));
     let kendex_owned = route.as_ref().is_some_and(|r| r.kendex_owned);
 
     let mut gh_args = vec!["issue".to_owned(), "create".to_owned()];
     let mut sent_body = body.clone();
     let mut area = None;
     if kendex_owned {
-        let (name, kind) = selector
+        let name = selector.as_ref().map_or("unknown", |(n, _)| n.as_str());
+        // The kind the route resolved, so `--asset` on a skill stamps the
+        // same marker `--skill` would.
+        let kind_label = route
             .as_ref()
-            .map(|(n, k)| (n.as_str(), *k))
-            .unwrap_or(("unknown", None));
-        let kind_label = kind.map(ItemKind::name).unwrap_or("asset");
+            .and_then(|r| r.kind)
+            .map_or("asset", ItemKind::name);
         sent_body.push_str(&format!(
             "\n\n<!-- kendex-report:v1 asset={name} kind={kind_label} ownership=kendex -->"
         ));

--- a/crates/cli/tests/compat.rs
+++ b/crates/cli/tests/compat.rs
@@ -237,6 +237,32 @@ fn report_dry_run_routes_by_ownership_and_rejects_scope_all() {
     assert!(text.contains("ownership: project-local"), "{text}");
     assert!(!text.contains("someone/else"), "{text}");
 
+    // A subscription spells the upstream however it likes, and the report
+    // still files at the one place gh accepts: `owner/repo`, never the URL.
+    let spelled = kendex_in(
+        home,
+        &proj,
+        &[
+            "report",
+            "--skill",
+            "size-ratchet",
+            "--upstream",
+            "git@github.com:vanillagreencom/kendex.git",
+            "--title",
+            "T",
+            "--body",
+            "B",
+            "--dry-run",
+        ],
+        &[],
+    );
+    assert!(spelled.status.success());
+    let text = String::from_utf8_lossy(&spelled.stderr);
+    assert!(text.contains("ownership: kendex"), "{text}");
+    assert!(text.contains("target: vanillagreencom/kendex"), "{text}");
+    assert!(text.contains("--repo vanillagreencom/kendex"), "{text}");
+    assert!(!text.contains("git@github.com"), "{text}");
+
     let rejected = kendex_in(
         home,
         &proj,

--- a/crates/cli/tests/compat.rs
+++ b/crates/cli/tests/compat.rs
@@ -122,10 +122,11 @@ fn report_dry_run_routes_by_ownership_and_rejects_scope_all() {
     let tmp = sandbox_with_catalog();
     let home = tmp.path();
     let proj = home.join("proj");
-    // A locked agent from the canonical upstream routes to it.
+    // Locked assets from the canonical upstream route to it. The skill is
+    // symlinked, as every installed skill is; delivery is not ownership.
     fs::write(
         proj.join(".kendex-lock.json"),
-        r#"{"version":1,"entries":{"agent:orch:claude":{"name":"orch","kind":"agent","harness":"claude","source":"kendex","sourceRepo":"vanillagreencom/kendex","method":"copy","installedAt":"2026-01-01T00:00:00Z","sourceHash":"x","enabled":true}}}"#,
+        r#"{"version":1,"entries":{"agent:orch:claude":{"name":"orch","kind":"agent","harness":"claude","source":"kendex","sourceRepo":"vanillagreencom/kendex","method":"copy","installedAt":"2026-01-01T00:00:00Z","sourceHash":"x","enabled":true},"skill:size-ratchet:claude":{"name":"size-ratchet","kind":"skill","harness":"claude","source":"kendex","sourceRepo":"vanillagreencom/kendex","method":"symlink","installedAt":"2026-01-01T00:00:00Z","sourceHash":"x","enabled":true}}}"#,
     )
     .unwrap();
 
@@ -150,6 +151,27 @@ fn report_dry_run_routes_by_ownership_and_rejects_scope_all() {
     assert!(text.contains("--repo vanillagreencom/kendex"), "{text}");
     assert!(text.contains("--label skills"), "{text}");
 
+    let skill = kendex_in(
+        home,
+        &proj,
+        &[
+            "report",
+            "--skill",
+            "size-ratchet",
+            "--title",
+            "T",
+            "--body",
+            "B",
+            "--dry-run",
+        ],
+        &[],
+    );
+    assert!(skill.status.success());
+    let text = String::from_utf8_lossy(&skill.stderr);
+    assert!(text.contains("ownership: kendex"), "{text}");
+    assert!(text.contains("--repo vanillagreencom/kendex"), "{text}");
+    assert!(text.contains("--label skills"), "{text}");
+
     let local = kendex_in(
         home,
         &proj,
@@ -168,6 +190,52 @@ fn report_dry_run_routes_by_ownership_and_rejects_scope_all() {
     let text = String::from_utf8_lossy(&local.stderr);
     assert!(text.contains("ownership: project-local"), "{text}");
     assert!(!text.contains("--label"), "{text}");
+
+    // Naming a kind lets the lock resolve it: the label and the body marker
+    // are the ones `--skill` would stamp.
+    let asset = kendex_in(
+        home,
+        &proj,
+        &[
+            "report",
+            "--asset",
+            "size-ratchet",
+            "--title",
+            "T",
+            "--body",
+            "B",
+            "--dry-run",
+        ],
+        &[],
+    );
+    assert!(asset.status.success());
+    let text = String::from_utf8_lossy(&asset.stderr);
+    assert!(text.contains("ownership: kendex"), "{text}");
+    assert!(text.contains("--label skills"), "{text}");
+    assert!(text.contains("kind=skill"), "{text}");
+
+    // A named upstream the lock never recorded is not proof of ownership.
+    let forked = kendex_in(
+        home,
+        &proj,
+        &[
+            "report",
+            "--skill",
+            "size-ratchet",
+            "--upstream",
+            "someone/else",
+            "--title",
+            "T",
+            "--body",
+            "B",
+            "--dry-run",
+        ],
+        &[],
+    );
+    assert!(forked.status.success());
+    let text = String::from_utf8_lossy(&forked.stderr);
+    assert!(text.contains("ownership: project-local"), "{text}");
+    assert!(!text.contains("someone/else"), "{text}");
 
     let rejected = kendex_in(
         home,

--- a/crates/core/src/report.rs
+++ b/crates/core/src/report.rs
@@ -8,18 +8,23 @@
 //! A lock entry keeps the manifest's repo declaration verbatim, so the same
 //! repository arrives here spelled as a shorthand, an https URL or an scp
 //! `git@` one. Every comparison runs over `source_ref::repo_identity`, which
-//! folds those to one string, so a spelling never decides ownership.
+//! folds those to one string, so a spelling never decides ownership. The
+//! judge names the destination too, in the shape a caller can file against:
+//! `gh issue create --repo` and a `github.com/<repo>/issues/new` URL both
+//! take `owner/repo`, never the URL a subscription may be spelled with.
 
 use crate::lock::{Lock, LockEntry};
 use crate::model::ItemKind;
-use crate::source_ref::repo_identity;
+use crate::source_ref::{owner_repo, repo_identity};
 
 pub const DEFAULT_UPSTREAM: &str = crate::manifest::DEFAULT_SOURCE_REPO;
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct Route {
     pub kendex_owned: bool,
-    /// Upstream `owner/repo` to file against — only when kendex-owned.
+    /// Where to file, and the only string a caller should file against:
+    /// `owner/repo` for a GitHub reference however the manifest spelled it,
+    /// another host's reference as it stands. Only when kendex-owned.
     pub repo: Option<String>,
     /// Routing label — only on the canonical upstream, where it exists.
     pub label: Option<String>,
@@ -58,11 +63,18 @@ pub fn route(lock: &Lock, name: &str, kind: Option<ItemKind>, upstream: &str) ->
     let kind = kind.or_else(|| agreed_kind(&matching));
     Route {
         kendex_owned: owned,
-        repo: owned.then(|| upstream.to_owned()),
+        repo: owned.then(|| filing_target(upstream)),
         label: (owned && wanted == repo_identity(DEFAULT_UPSTREAM))
             .then(|| derive_label(name, kind).to_owned()),
         kind,
     }
+}
+
+/// The upstream as something to file against: a GitHub reference folded to
+/// the bare `owner/repo` that `gh --repo` and an issue URL take, anything
+/// else left as the caller spelled it.
+fn filing_target(upstream: &str) -> String {
+    owner_repo(upstream).unwrap_or_else(|| upstream.to_owned())
 }
 
 /// The one kind the matching entries are, when they are all one kind.
@@ -155,20 +167,17 @@ mod tests {
             "vanillagreencom/kendex.git",
         ] {
             let lock = lock_of(&[("guard", ItemKind::Skill, spelling)]);
-            let route = route(&lock, "guard", Some(ItemKind::Skill), DEFAULT_UPSTREAM);
-            assert!(route.kendex_owned, "{spelling}");
-            assert_eq!(route.label.as_deref(), Some("skills"), "{spelling}");
-        }
+            let recorded = route(&lock, "guard", Some(ItemKind::Skill), DEFAULT_UPSTREAM);
+            assert!(recorded.kendex_owned, "{spelling}");
+            assert_eq!(recorded.label.as_deref(), Some("skills"), "{spelling}");
 
-        let lock = lock_of(&[("guard", ItemKind::Skill, DEFAULT_UPSTREAM)]);
-        let named = route(
-            &lock,
-            "guard",
-            Some(ItemKind::Skill),
-            "git@github.com:vanillagreencom/kendex.git",
-        );
-        assert!(named.kendex_owned);
-        assert_eq!(named.label.as_deref(), Some("skills"));
+            // However the caller spells it, what comes back is what `gh
+            // --repo` and an issue URL take.
+            let named = route(&lock, "guard", Some(ItemKind::Skill), spelling);
+            assert!(named.kendex_owned, "{spelling}");
+            assert_eq!(named.repo.as_deref(), Some(DEFAULT_UPSTREAM), "{spelling}");
+            assert_eq!(named.label.as_deref(), Some("skills"), "{spelling}");
+        }
 
         let elsewhere = lock_of(&[(
             "guard",
@@ -176,6 +185,29 @@ mod tests {
             "https://gitlab.com/vanillagreencom/kendex",
         )]);
         assert!(!route(&elsewhere, "guard", Some(ItemKind::Skill), DEFAULT_UPSTREAM).kendex_owned);
+    }
+
+    /// Only a GitHub reference folds to `owner/repo`; another host has no
+    /// shorthand, so the report files against the reference as spelled.
+    #[test]
+    fn another_hosts_upstream_is_the_target_as_spelled() {
+        let lock = lock_of(&[(
+            "guard",
+            ItemKind::Skill,
+            "https://gitlab.com/team/catalog.git",
+        )]);
+        let route = route(
+            &lock,
+            "guard",
+            Some(ItemKind::Skill),
+            "https://gitlab.com/team/catalog",
+        );
+        assert!(route.kendex_owned);
+        assert_eq!(
+            route.repo.as_deref(),
+            Some("https://gitlab.com/team/catalog")
+        );
+        assert_eq!(route.label, None);
     }
 
     /// A named upstream routes there only when the lock recorded the asset

--- a/crates/core/src/report.rs
+++ b/crates/core/src/report.rs
@@ -1,12 +1,12 @@
 //! Report routing: which repo an issue about an installed item belongs to.
-//! kendex-owned assets file upstream; everything else files against the
-//! user's own repo — the safe default. Skills never route upstream via the
-//! lock (distribution is not ownership); only their own frontmatter can
-//! opt them in.
+//! The lock is the one judge, and it records where every kind of asset came
+//! from, skills included. An item whose every lock entry was recorded from
+//! the upstream files there; everything else files against the user's own
+//! repo, the safe default. A name whose entries disagree about their origin
+//! is ambiguous, and an ambiguous name stays local.
 
-use crate::env::Env;
-use crate::lock::Lock;
-use crate::model::{ItemKind, Scope};
+use crate::lock::{Lock, LockEntry};
+use crate::model::ItemKind;
 
 pub const DEFAULT_UPSTREAM: &str = crate::manifest::DEFAULT_SOURCE_REPO;
 
@@ -17,6 +17,9 @@ pub struct Route {
     pub repo: Option<String>,
     /// Routing label — only on the canonical upstream, where it exists.
     pub label: Option<String>,
+    /// The kind the report is about: the one the caller named, or the one
+    /// the matching lock entries agree on when the caller named none.
+    pub kind: Option<ItemKind>,
 }
 
 /// The routing label for a kendex-owned asset, by what it is.
@@ -31,135 +34,145 @@ pub fn derive_label(name: &str, kind: Option<ItemKind>) -> &'static str {
     }
 }
 
-pub fn route(
-    env: &Env,
-    scope: &Scope,
-    lock: &Lock,
-    name: &str,
-    kind: Option<ItemKind>,
-    upstream: &str,
-) -> Route {
-    let (fm_source, fm_repo) = installed_frontmatter(env, scope, name);
-    let owned = is_kendex_owned(
-        lock,
-        name,
-        kind,
-        fm_source.as_deref(),
-        fm_repo.as_deref(),
-        upstream,
-    );
+pub fn route(lock: &Lock, name: &str, kind: Option<ItemKind>, upstream: &str) -> Route {
+    let matching: Vec<&LockEntry> = lock
+        .entries
+        .values()
+        .filter(|entry| entry.name == name && kind.is_none_or(|k| k == entry.kind))
+        .collect();
+    // Provenance, not delivery. One entry recorded from anywhere else — a
+    // second marketplace, a path, `local` — means the name does not name a
+    // kendex asset on its own, and the report stays with the user's repo
+    // rather than going to a stranger's.
+    let owned = !matching.is_empty() && matching.iter().all(|e| e.source_repo == upstream);
+    let kind = kind.or_else(|| agreed_kind(&matching));
     Route {
         kendex_owned: owned,
         repo: owned.then(|| upstream.to_owned()),
         label: (owned && upstream == DEFAULT_UPSTREAM).then(|| derive_label(name, kind).to_owned()),
+        kind,
     }
 }
 
-fn is_kendex_owned(
-    lock: &Lock,
-    name: &str,
-    kind: Option<ItemKind>,
-    frontmatter_source: Option<&str>,
-    frontmatter_repo: Option<&str>,
-    upstream: &str,
-) -> bool {
-    if frontmatter_source == Some("kendex") || frontmatter_repo.is_some_and(is_default_repo) {
-        return true;
-    }
-    lock.entries.values().any(|entry| {
-        entry.name == name
-            && kind.is_none_or(|k| k == entry.kind)
-            && entry.kind != ItemKind::Skill
-            && entry.source_repo == upstream
-    })
-}
-
-fn is_default_repo(repo: &str) -> bool {
-    repo == DEFAULT_UPSTREAM
-}
-
-/// `source:`/`repository:` from the installed skill's frontmatter — the one
-/// place a skill can claim kendex ownership.
-fn installed_frontmatter(env: &Env, scope: &Scope, name: &str) -> (Option<String>, Option<String>) {
-    let path = crate::engine::desired::skill_canonical(env, scope, name).join("SKILL.md");
-    let Ok(text) = std::fs::read_to_string(&path) else {
-        return (None, None);
-    };
-    let Some(front) = text
-        .strip_prefix("---")
-        .and_then(|rest| rest.find("\n---").map(|end| rest[..end].to_owned()))
-    else {
-        return (None, None);
-    };
-    let field = |key: &str| {
-        front.lines().find_map(|line| {
-            line.strip_prefix(key)
-                .map(|v| v.trim().trim_matches('"').to_owned())
-                .filter(|v| !v.is_empty())
-        })
-    };
-    (field("source:"), field("repository:"))
+/// The one kind the matching entries are, when they are all one kind.
+fn agreed_kind(matching: &[&LockEntry]) -> Option<ItemKind> {
+    let first = matching.first()?.kind;
+    matching.iter().all(|e| e.kind == first).then_some(first)
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
 
-    /// A skill's frontmatter is the one place it can claim kendex
-    /// ownership itself.
-    #[test]
-    fn the_source_token_claims_ownership() {
-        let lock = Lock::default();
-        let owned = |source: Option<&str>| {
-            is_kendex_owned(&lock, "s", None, source, None, DEFAULT_UPSTREAM)
-        };
-        assert!(owned(Some("kendex")));
-        assert!(!owned(Some("someone-else")));
-        assert!(!owned(None));
+    fn entry(name: &str, kind: ItemKind, source_repo: &str) -> LockEntry {
+        LockEntry {
+            name: name.to_owned(),
+            kind,
+            harness: crate::model::HarnessId::Claude,
+            source: "kendex".to_owned(),
+            source_repo: source_repo.to_owned(),
+            method: crate::manifest::Method::Copy,
+            installed_at: "2026-01-01T00:00:00Z".to_owned(),
+            source_hash: "x".to_owned(),
+            source_commit: None,
+            rendered_hash: None,
+            enabled: true,
+            upstream_skills: None,
+            emitted: None,
+            registration: None,
+            left_pi_reserved_name: false,
+            reasons: std::collections::BTreeSet::from([crate::lock::Reason::Requested]),
+        }
     }
 
-    /// A lock entry recorded from the default repository claims the
-    /// upstream a report routes to.
-    #[test]
-    fn a_default_repo_entry_claims_ownership() {
+    fn lock_of(entries: &[(&str, ItemKind, &str)]) -> Lock {
         let mut lock = Lock::default();
-        lock.entries.insert(
-            "hook:guard:claude".to_owned(),
-            crate::lock::LockEntry {
-                name: "guard".to_owned(),
-                kind: ItemKind::Hook,
-                harness: crate::model::HarnessId::Claude,
-                source: "kendex".to_owned(),
-                source_repo: DEFAULT_UPSTREAM.to_owned(),
-                method: crate::manifest::Method::Copy,
-                installed_at: "2026-01-01T00:00:00Z".to_owned(),
-                source_hash: "x".to_owned(),
-                source_commit: None,
-                rendered_hash: None,
-                enabled: true,
-                upstream_skills: None,
-                emitted: None,
-                registration: None,
-                left_pi_reserved_name: false,
-                reasons: std::collections::BTreeSet::from([crate::lock::Reason::Requested]),
-            },
+        for (name, kind, source_repo) in entries {
+            lock.entries.insert(
+                format!("{}:{name}:{source_repo}", kind.name()),
+                entry(name, *kind, source_repo),
+            );
+        }
+        lock
+    }
+
+    /// The lock records provenance for every kind of asset alike, so a skill
+    /// recorded from the default repo routes upstream like an agent or hook.
+    #[test]
+    fn a_default_repo_entry_routes_upstream() {
+        for (kind, label) in [
+            (ItemKind::Hook, "harness"),
+            (ItemKind::Skill, "skills"),
+            (ItemKind::Agent, "skills"),
+        ] {
+            let lock = lock_of(&[("guard", kind, DEFAULT_UPSTREAM)]);
+            let route = route(&lock, "guard", Some(kind), DEFAULT_UPSTREAM);
+            assert!(route.kendex_owned, "{kind:?} from the default repo");
+            assert_eq!(route.repo.as_deref(), Some(DEFAULT_UPSTREAM));
+            assert_eq!(route.label.as_deref(), Some(label));
+        }
+    }
+
+    /// Nothing in the lock says nothing about ownership, and the safe answer
+    /// is the user's own repo.
+    #[test]
+    fn an_unlocked_name_stays_project_local() {
+        let route = route(&Lock::default(), "mystery", None, DEFAULT_UPSTREAM);
+        assert!(!route.kendex_owned);
+        assert_eq!(route.repo, None);
+        assert_eq!(route.label, None);
+    }
+
+    /// A skill installed from another marketplace keeps filing against the
+    /// consumer's own repo.
+    #[test]
+    fn a_third_party_entry_stays_project_local() {
+        let lock = lock_of(&[("guard", ItemKind::Skill, "someone/else")]);
+        assert!(!route(&lock, "guard", Some(ItemKind::Skill), DEFAULT_UPSTREAM).kendex_owned);
+    }
+
+    /// A named upstream routes there only when the lock recorded the asset
+    /// from it; naming a repo is not by itself proof of ownership.
+    #[test]
+    fn a_named_upstream_must_match_recorded_provenance() {
+        let lock = lock_of(&[("guard", ItemKind::Skill, "someone/else")]);
+        let matched = route(&lock, "guard", Some(ItemKind::Skill), "someone/else");
+        assert!(matched.kendex_owned);
+        assert_eq!(matched.repo.as_deref(), Some("someone/else"));
+        // Labels exist only on the canonical repo.
+        assert_eq!(matched.label, None);
+        assert!(!route(&Lock::default(), "guard", None, "someone/else").kendex_owned);
+    }
+
+    /// `--asset <name>` names no kind, so entries of every kind match it. A
+    /// name shared with something from elsewhere is ambiguous and stays
+    /// local; naming the kind resolves it.
+    #[test]
+    fn a_name_shared_with_another_origin_is_ambiguous() {
+        let lock = lock_of(&[
+            ("dev", ItemKind::Skill, DEFAULT_UPSTREAM),
+            ("dev", ItemKind::Hook, "someone/else"),
+        ]);
+        assert!(!route(&lock, "dev", None, DEFAULT_UPSTREAM).kendex_owned);
+        assert!(route(&lock, "dev", Some(ItemKind::Skill), DEFAULT_UPSTREAM).kendex_owned);
+    }
+
+    /// A kind-less report takes the kind its entries agree on, so it carries
+    /// the same label a named kind would; disagreement leaves it unresolved.
+    #[test]
+    fn a_kindless_report_takes_the_kind_its_entries_agree_on() {
+        let one_kind = lock_of(&[("dev", ItemKind::Skill, DEFAULT_UPSTREAM)]);
+        let resolved = route(&one_kind, "dev", None, DEFAULT_UPSTREAM);
+        assert_eq!(resolved.kind, Some(ItemKind::Skill));
+        assert_eq!(resolved.label.as_deref(), Some("skills"));
+
+        let mut two_kinds = one_kind;
+        two_kinds.entries.insert(
+            "hook:dev:claude".to_owned(),
+            entry("dev", ItemKind::Hook, DEFAULT_UPSTREAM),
         );
-        assert!(is_kendex_owned(
-            &lock,
-            "guard",
-            Some(ItemKind::Hook),
-            None,
-            None,
-            DEFAULT_UPSTREAM
-        ));
-        // A repo the user pointed reports at explicitly stays exact.
-        assert!(!is_kendex_owned(
-            &lock,
-            "guard",
-            Some(ItemKind::Hook),
-            None,
-            None,
-            "someone/else"
-        ));
+        let unresolved = route(&two_kinds, "dev", None, DEFAULT_UPSTREAM);
+        assert_eq!(unresolved.kind, None);
+        assert_eq!(unresolved.label.as_deref(), Some("cli"));
     }
 }

--- a/crates/core/src/report.rs
+++ b/crates/core/src/report.rs
@@ -4,9 +4,15 @@
 //! the upstream files there; everything else files against the user's own
 //! repo, the safe default. A name whose entries disagree about their origin
 //! is ambiguous, and an ambiguous name stays local.
+//!
+//! A lock entry keeps the manifest's repo declaration verbatim, so the same
+//! repository arrives here spelled as a shorthand, an https URL or an scp
+//! `git@` one. Every comparison runs over `source_ref::repo_identity`, which
+//! folds those to one string, so a spelling never decides ownership.
 
 use crate::lock::{Lock, LockEntry};
 use crate::model::ItemKind;
+use crate::source_ref::repo_identity;
 
 pub const DEFAULT_UPSTREAM: &str = crate::manifest::DEFAULT_SOURCE_REPO;
 
@@ -44,12 +50,17 @@ pub fn route(lock: &Lock, name: &str, kind: Option<ItemKind>, upstream: &str) ->
     // second marketplace, a path, `local` — means the name does not name a
     // kendex asset on its own, and the report stays with the user's repo
     // rather than going to a stranger's.
-    let owned = !matching.is_empty() && matching.iter().all(|e| e.source_repo == upstream);
+    let wanted = repo_identity(upstream);
+    let owned = !matching.is_empty()
+        && matching
+            .iter()
+            .all(|e| repo_identity(&e.source_repo) == wanted);
     let kind = kind.or_else(|| agreed_kind(&matching));
     Route {
         kendex_owned: owned,
         repo: owned.then(|| upstream.to_owned()),
-        label: (owned && upstream == DEFAULT_UPSTREAM).then(|| derive_label(name, kind).to_owned()),
+        label: (owned && wanted == repo_identity(DEFAULT_UPSTREAM))
+            .then(|| derive_label(name, kind).to_owned()),
         kind,
     }
 }
@@ -129,6 +140,42 @@ mod tests {
     fn a_third_party_entry_stays_project_local() {
         let lock = lock_of(&[("guard", ItemKind::Skill, "someone/else")]);
         assert!(!route(&lock, "guard", Some(ItemKind::Skill), DEFAULT_UPSTREAM).kendex_owned);
+    }
+
+    /// A subscription spells its repo however it likes and the lock keeps
+    /// that spelling, so ownership compares folded identities: the scp-style
+    /// and `.git`-suffixed entries are the same repository as the shorthand,
+    /// and a `--upstream` spelled either way matches too. Another host with
+    /// the same path is another repository.
+    #[test]
+    fn a_differently_spelled_upstream_is_the_same_repository() {
+        for spelling in [
+            "git@github.com:vanillagreencom/kendex.git",
+            "https://github.com/VanillaGreenCom/kendex",
+            "vanillagreencom/kendex.git",
+        ] {
+            let lock = lock_of(&[("guard", ItemKind::Skill, spelling)]);
+            let route = route(&lock, "guard", Some(ItemKind::Skill), DEFAULT_UPSTREAM);
+            assert!(route.kendex_owned, "{spelling}");
+            assert_eq!(route.label.as_deref(), Some("skills"), "{spelling}");
+        }
+
+        let lock = lock_of(&[("guard", ItemKind::Skill, DEFAULT_UPSTREAM)]);
+        let named = route(
+            &lock,
+            "guard",
+            Some(ItemKind::Skill),
+            "git@github.com:vanillagreencom/kendex.git",
+        );
+        assert!(named.kendex_owned);
+        assert_eq!(named.label.as_deref(), Some("skills"));
+
+        let elsewhere = lock_of(&[(
+            "guard",
+            ItemKind::Skill,
+            "https://gitlab.com/vanillagreencom/kendex",
+        )]);
+        assert!(!route(&elsewhere, "guard", Some(ItemKind::Skill), DEFAULT_UPSTREAM).kendex_owned);
     }
 
     /// A named upstream routes there only when the lock recorded the asset

--- a/ui/src/dev/mock-core.ts
+++ b/ui/src/dev/mock-core.ts
@@ -1,4 +1,10 @@
-import type { AppSettings, HarnessId, ItemKind, Scope } from "@/bindings";
+import type {
+  AppSettings,
+  HarnessId,
+  ItemKind,
+  ProvenanceRow,
+  Scope,
+} from "@/bindings";
 import { capabilityTable } from "./caps";
 import { type Handler, label, same, store, view } from "./mock-state";
 
@@ -162,16 +168,22 @@ export const coreHandlers: Record<string, Handler> = {
   }) => {
     const upstream = "vanillagreencom/kendex";
     // Mirrors the engine's rule: the recorded origin decides, for every kind
-    // alike, and one entry from anywhere else makes the name ambiguous.
-    const matching = store.state.items.filter(
-      (it) =>
-        it.name === name &&
-        same(it.scope, scope) &&
-        (kind === null || it.kind === kind),
+    // alike, and one row from anywhere else makes the name ambiguous. The
+    // provenance table is the mock's lock — an observed item's origin is the
+    // git origin of wherever its file sits, which for a skill installed by
+    // link is the consuming repository.
+    const matching = store.state.provenance.filter(
+      (row) =>
+        row.name === name &&
+        same(row.scope, scope) &&
+        (kind === null || row.kind === kind),
     );
+    const recorded = (row: ProvenanceRow) =>
+      row.origin.origin === "marketplace" ? row.origin.repo : null;
     const owned =
-      matching.length > 0 && matching.every((it) => it.origin === upstream);
-    const agreed = matching.every((it) => it.kind === matching[0]?.kind)
+      matching.length > 0 &&
+      matching.every((row) => recorded(row) === upstream);
+    const agreed = matching.every((row) => row.kind === matching[0]?.kind)
       ? matching[0]?.kind
       : undefined;
     const resolved = kind ?? agreed;

--- a/ui/src/dev/mock-core.ts
+++ b/ui/src/dev/mock-core.ts
@@ -151,25 +151,40 @@ export const coreHandlers: Record<string, Handler> = {
     ["acme-web", "api-server", "demo-app"].map(
       (name) => `${root.replace(/\/+$/, "")}/${name}`,
     ),
-  report_route: ({ scope, name }: { scope: Scope; name: string }) => {
+  report_route: ({
+    scope,
+    name,
+    kind,
+  }: {
+    scope: Scope;
+    name: string;
+    kind: ItemKind | null;
+  }) => {
     const upstream = "vanillagreencom/kendex";
-    // Mirrors the engine's rule: skills never route upstream through
-    // provenance alone, everything else from the catalog does.
-    const owned = store.state.items.some(
+    // Mirrors the engine's rule: the recorded origin decides, for every kind
+    // alike, and one entry from anywhere else makes the name ambiguous.
+    const matching = store.state.items.filter(
       (it) =>
         it.name === name &&
         same(it.scope, scope) &&
-        it.kind !== "skill" &&
-        it.origin === upstream,
+        (kind === null || it.kind === kind),
     );
-    const kind = store.state.items.find((it) => it.name === name)?.kind;
+    const owned =
+      matching.length > 0 && matching.every((it) => it.origin === upstream);
+    const agreed = matching.every((it) => it.kind === matching[0]?.kind)
+      ? matching[0]?.kind
+      : undefined;
+    const resolved = kind ?? agreed;
+    // Mirrors derive_label.
     const label = !owned
       ? null
-      : kind === "hook" || kind === "pi-extension"
-        ? "harness"
-        : kind === "agent"
-          ? "skills"
-          : "cli";
+      : name.includes("review-gate")
+        ? "ci-infra"
+        : resolved === "hook" || resolved === "pi-extension"
+          ? "harness"
+          : resolved === "skill" || resolved === "agent"
+            ? "skills"
+            : "cli";
     return {
       kendexOwned: owned,
       repo: owned ? upstream : null,

--- a/ui/src/dev/mock.test.ts
+++ b/ui/src/dev/mock.test.ts
@@ -4,6 +4,7 @@ import type {
   HarnessId,
   ItemKind,
   PackageUpdate_Serialize,
+  ReportRouteView,
   ScanResult,
   SourceRow,
 } from "@/bindings";
@@ -122,6 +123,19 @@ describe("mock bridge", () => {
 // The browser mock hand-mirrors crates/core/src/harness/caps.rs. Where it
 // drifts, dev mode shows a tool as unmanageable that the app manages.
 describe("mock capability table", () => {
+  // The dev app must answer the report dialog the way the engine does, or
+  // the preview tells you a kendex skill belongs to your own project.
+  it("routes a catalog skill to kendex, with the label the engine derives", async () => {
+    const route = (await mockInvoke("report_route", {
+      scope: acme,
+      name: "github",
+      kind: "skill" as ItemKind,
+    })) as ReportRouteView;
+    expect(route.kendexOwned).toBe(true);
+    expect(route.repo).toBe("vanillagreencom/kendex");
+    expect(route.label).toBe("skills");
+  });
+
   const caps = (harness: HarnessId, kind: ItemKind) =>
     capabilityTable().find((r) => r.harness === harness && r.kind === kind)
       ?.caps;

--- a/ui/src/dev/mock.test.ts
+++ b/ui/src/dev/mock.test.ts
@@ -6,6 +6,7 @@ import type {
   PackageUpdate_Serialize,
   ReportRouteView,
   ScanResult,
+  Scope,
   SourceRow,
 } from "@/bindings";
 import { showUpdateOutcome } from "@/lib/update-outcome";
@@ -120,22 +121,55 @@ describe("mock bridge", () => {
   });
 });
 
-// The browser mock hand-mirrors crates/core/src/harness/caps.rs. Where it
-// drifts, dev mode shows a tool as unmanageable that the app manages.
-describe("mock capability table", () => {
-  // The dev app must answer the report dialog the way the engine does, or
-  // the preview tells you a kendex skill belongs to your own project.
-  it("routes a catalog skill to kendex, with the label the engine derives", async () => {
-    const route = (await mockInvoke("report_route", {
-      scope: acme,
-      name: "github",
-      kind: "skill" as ItemKind,
+// The dev app must answer the report dialog the way the engine does, or the
+// preview tells you a kendex skill belongs to your own project. The engine
+// judges the lock, and the mock's stand-in for it is the provenance table:
+// an observed item's origin is the git origin of wherever its file sits,
+// which for a skill installed by link is the consuming repository.
+describe("mock report routing", () => {
+  beforeEach(resetMock);
+
+  const globalScope = { scope: "global" } as const;
+  const routeOf = async (scope: Scope, name: string, kind: ItemKind | null) =>
+    (await mockInvoke("report_route", {
+      scope,
+      name,
+      kind,
     })) as ReportRouteView;
+
+  it("routes a skill recorded from the kendex marketplace to kendex", async () => {
+    const route = await routeOf(acme, "github", "skill");
     expect(route.kendexOwned).toBe(true);
     expect(route.repo).toBe("vanillagreencom/kendex");
     expect(route.label).toBe("skills");
   });
 
+  it("keeps a name nothing recorded local, whatever the scan says", async () => {
+    // Observed with the upstream as its origin and in no provenance row: a
+    // mock reading items would file this against kendex.
+    const scan = (await mockInvoke("scan_machine")) as ScanResult;
+    expect(
+      scan.items.some(
+        (it) =>
+          it.name === "pi-hooks" && it.origin === "vanillagreencom/kendex",
+      ),
+    ).toBe(true);
+    const route = await routeOf(globalScope, "pi-hooks", "pi-extension");
+    expect(route.kendexOwned).toBe(false);
+    expect(route.repo).toBe(null);
+    expect(route.label).toBe(null);
+  });
+
+  it("keeps a fork of a kendex skill local", async () => {
+    const route = await routeOf(globalScope, "release-notes", "skill");
+    expect(route.kendexOwned).toBe(false);
+    expect(route.repo).toBe(null);
+  });
+});
+
+// The browser mock hand-mirrors crates/core/src/harness/caps.rs. Where it
+// drifts, dev mode shows a tool as unmanageable that the app manages.
+describe("mock capability table", () => {
   const caps = (harness: HarnessId, kind: ItemKind) =>
     capabilityTable().find((r) => r.harness === harness && r.kind === kind)
       ?.caps;


### PR DESCRIPTION
## Summary

- The ownership judge no longer excludes skills from lock-based ownership, so
  `kendex report --skill` files against kendex the way `--agent` and `--hook`
  already did. Recorded provenance is what keeps a third-party or project-local
  asset out, and it does that for skills too.
- The lock is now the only judge. The SKILL.md frontmatter probe beside it never
  fired for any shipped asset — it wanted `source:` at column 0 while every
  shipped skill nests it two spaces under `metadata:`, and it compared a bare
  `owner/repo` against a full https URL. It also keyed on name alone, so an
  `--agent` or `--hook` report read a same-named skill's file.
- `--asset <name>` names no kind, so lock entries of any kind match it, and
  dropping the skill exclusion widened that collision set to every entry. A name
  whose entries do not all come from the upstream is now ambiguous and stays with
  the user's own repo; when they agree on one kind, that kind sets the routing
  label and the body marker, so `--asset size-ratchet` stamps what `--skill`
  would.
- The dev app's mock backend implemented the rule this change deletes; it now
  mirrors the engine, including the `review-gate` label case it never had.

## Completed Issues

- Closes #1727 - kendex report --skill misroutes every installed skill to the consuming repo

## Test Plan

- `crates/core/src/report.rs` unit tests cover the routing rule per kind, a
  third-party entry staying local, an ambiguous name staying local, and the kind
  the label is derived from.
- `crates/cli/tests/compat.rs` covers the dry-run end to end: a symlinked skill
  routing to kendex with the `skills` label, `--asset` on that skill giving the
  same answer, and `--upstream` naming a repo the lock never recorded staying
  project-local.
- `ui/src/dev/mock.test.ts` covers a fixture skill routing to kendex.
- `tools/guard` green.

## Notes

The issue's suggested fix had a second half: an explicitly passed `--upstream`
overriding the ownership decision. That shipped in the first draft and was cut —
an unchecked destination makes any caller-supplied string proof of kendex
ownership for any asset, so a typo silently posts a project-local report to a
public repo, and `kendex report` is the command every SKILL.md instructs agents
to run. A named upstream still routes there when the lock recorded the asset from
it, which is what the reporter's own `--upstream vanillagreencom/kendex` case
needed. The unconditional override was not required for the defect.
