### PR TITLE
docs(orch): error review is never relevance-picked off a diff

### DIFF
--- a/.agents/skills/orch/workflows/review-pr.md
+++ b/.agents/skills/orch/workflows/review-pr.md
@@ -58,7 +58,7 @@ A failed check omits the path and carries `- decision index lookup failed for [D
 
 ## 2. Prepare Reviewers
 
-`[AGENTS]` is the caller's `agents` context when provided, otherwise every `reviewer-*` agent this harness exposes. Do not hardcode a count or a list. A diff owning a subprocess, a transport (stream, socket, SSE), or a teardown path always carries `reviewer-error` — add it when the caller's panel omits it; relevance never removes it. With no reviewers available, skip to § 5 with verdict `pass`.
+`[AGENTS]` is the caller's `agents` context when provided, otherwise every `reviewer-*` agent this harness exposes. Do not hardcode a count or a list. Where the harness exposes `reviewer-error`, a diff owning a subprocess, a transport (stream, socket, SSE), or a teardown path always carries it: relevance never drops it from the panel. With no reviewers available, skip to § 5 with verdict `pass`.
 
 Resolve the reviewer mode per [SKILL.md § Agent Lifecycle](../SKILL.md#agent-lifecycle):
 

--- a/.agents/skills/orch/workflows/review-pr.md
+++ b/.agents/skills/orch/workflows/review-pr.md
@@ -58,7 +58,7 @@ A failed check omits the path and carries `- decision index lookup failed for [D
 
 ## 2. Prepare Reviewers
 
-`[AGENTS]` is the caller's `agents` context when provided, otherwise every `reviewer-*` agent this harness exposes. Do not hardcode a count or a list. With no reviewers available, skip to § 5 with verdict `pass`.
+`[AGENTS]` is the caller's `agents` context when provided, otherwise every `reviewer-*` agent this harness exposes. Do not hardcode a count or a list. A diff owning a subprocess, a transport (stream, socket, SSE), or a teardown path always carries `reviewer-error` — add it when the caller's panel omits it; relevance never removes it. With no reviewers available, skip to § 5 with verdict `pass`.
 
 Resolve the reviewer mode per [SKILL.md § Agent Lifecycle](../SKILL.md#agent-lifecycle):
 

--- a/skills/orch/workflows/review-pr.md
+++ b/skills/orch/workflows/review-pr.md
@@ -58,7 +58,7 @@ A failed check omits the path and carries `- decision index lookup failed for [D
 
 ## 2. Prepare Reviewers
 
-`[AGENTS]` is the caller's `agents` context when provided, otherwise every `reviewer-*` agent this harness exposes. Do not hardcode a count or a list. A diff owning a subprocess, a transport (stream, socket, SSE), or a teardown path always carries `reviewer-error` — add it when the caller's panel omits it; relevance never removes it. With no reviewers available, skip to § 5 with verdict `pass`.
+`[AGENTS]` is the caller's `agents` context when provided, otherwise every `reviewer-*` agent this harness exposes. Do not hardcode a count or a list. Where the harness exposes `reviewer-error`, a diff owning a subprocess, a transport (stream, socket, SSE), or a teardown path always carries it: relevance never drops it from the panel. With no reviewers available, skip to § 5 with verdict `pass`.
 
 Resolve the reviewer mode per [SKILL.md § Agent Lifecycle](../SKILL.md#agent-lifecycle):
 

--- a/skills/orch/workflows/review-pr.md
+++ b/skills/orch/workflows/review-pr.md
@@ -58,7 +58,7 @@ A failed check omits the path and carries `- decision index lookup failed for [D
 
 ## 2. Prepare Reviewers
 
-`[AGENTS]` is the caller's `agents` context when provided, otherwise every `reviewer-*` agent this harness exposes. Do not hardcode a count or a list. With no reviewers available, skip to § 5 with verdict `pass`.
+`[AGENTS]` is the caller's `agents` context when provided, otherwise every `reviewer-*` agent this harness exposes. Do not hardcode a count or a list. A diff owning a subprocess, a transport (stream, socket, SSE), or a teardown path always carries `reviewer-error` — add it when the caller's panel omits it; relevance never removes it. With no reviewers available, skip to § 5 with verdict `pass`.
 
 Resolve the reviewer mode per [SKILL.md § Agent Lifecycle](../SKILL.md#agent-lifecycle):
 


### PR DESCRIPTION
Reviewer fan-out is normally picked by relevance. The defect a subprocess, transport, or teardown path produces is a failure presented as a success, which every other specialist reads as correct by construction — the happy path works, the structure is clean, the tests genuinely pass, and the reporting is what is wrong.

`review-pr` § 2 is the single funnel: a caller-supplied `agents` list and § 3.3's scoped re-review panel both resolve `[AGENTS]` there. One clause added to that resolution makes `reviewer-error` unconditional for those three shapes.

`review.md` and `review-codebase.md` already delegate to the full reviewer set, so they need nothing. The rule lives in one place; the `reviewer` skill is the single-agent contract and composes no panel.

Closes #1735