### PR TITLE
docs(orch): a recurring finding class closes its generator

### DIFF
--- a/.agents/skills/orch/references/finding-disposition.md
+++ b/.agents/skills/orch/references/finding-disposition.md
@@ -32,7 +32,7 @@ Uncertain about category, prefer `fix` (if related); uncertain about relevance, 
 | Error-handling gaps | `issue` |
 | Security vulnerability | `fix` if quick, else `issue` — never skipped |
 | Data validation gaps | `fix` if quick, else `issue` |
-| The same claim, enumeration, or duplicated copy arriving in two rounds running | `fix` as a structural close — derive, bind, or delete the generator |
+| A finding class arriving in two rounds running (a drifting claim, a re-derived enumeration, a second copy) | `fix` as a structural close — derive, bind, or delete the generator |
 
 ## Filing bar
 

--- a/.agents/skills/orch/references/finding-disposition.md
+++ b/.agents/skills/orch/references/finding-disposition.md
@@ -32,7 +32,7 @@ Uncertain about category, prefer `fix` (if related); uncertain about relevance, 
 | Error-handling gaps | `issue` |
 | Security vulnerability | `fix` if quick, else `issue` — never skipped |
 | Data validation gaps | `fix` if quick, else `issue` |
-| The same claim or enumeration drifting for two rounds running | `fix` as a structural close — derive, bind, or delete the claim |
+| The same claim, enumeration, or duplicated copy arriving in two rounds running | `fix` as a structural close — derive, bind, or delete the generator |
 
 ## Filing bar
 
@@ -44,6 +44,8 @@ An `issue` signal is necessary but not sufficient. Every candidate carries its s
 - **Unexplained anomalies with evidence** — observed and reproducible, cause unknown; filed as an investigation issue whose deliverable is the diagnosis.
 
 Never for a race between two invocations on one machine, a crash between two writes, an input no shipped producer emits, or a hole in a mechanism that itself came from a review round: those are declined, not filed. The one exception is a security or data-loss defect a shipped path reaches, which follows the rows above.
+
+A recurring finding class never files as "improve X": the structural-close row closes its generator in this PR.
 
 The audit pipeline applies project-management's creation bar (its SKILL.md § Disposition) as the final authority; these classes describe what clears it.
 

--- a/.agents/skills/orch/references/finding-disposition.md
+++ b/.agents/skills/orch/references/finding-disposition.md
@@ -45,7 +45,7 @@ An `issue` signal is necessary but not sufficient. Every candidate carries its s
 
 Never for a race between two invocations on one machine, a crash between two writes, an input no shipped producer emits, or a hole in a mechanism that itself came from a review round: those are declined, not filed. The one exception is a security or data-loss defect a shipped path reaches, which follows the rows above.
 
-A recurring finding class never files as "improve X": the structural-close row closes its generator in this PR.
+A recurring finding class the diff introduces or arms never files as "improve X": the structural-close row closes its generator in this PR.
 
 The audit pipeline applies project-management's creation bar (its SKILL.md § Disposition) as the final authority; these classes describe what clears it.
 

--- a/.agents/skills/orch/workflows/dev-fix.md
+++ b/.agents/skills/orch/workflows/dev-fix.md
@@ -58,7 +58,7 @@ Cancel ends the workflow; a selection goes to § 2.
    .agents/skills/orch/scripts/workflow-state get [ISSUE_ID] '.agent // empty'
    ```
 
-2. **Group items by agent domain** when multi-domain, ordered per [SKILL.md § Coordination](../SKILL.md#coordination). Prefer two scoped rounds over one broad round past roughly eight items.
+2. **Group items by agent domain** when multi-domain, ordered per [SKILL.md § Coordination](../SKILL.md#coordination). Prefer two scoped rounds over one broad round past roughly eight items — at 24 items, a round injects 8 new blockers, 2 of them P1.
 
 3. **Gather decision context**:
 

--- a/.agents/skills/orch/workflows/dev-fix.md
+++ b/.agents/skills/orch/workflows/dev-fix.md
@@ -58,7 +58,7 @@ Cancel ends the workflow; a selection goes to § 2.
    .agents/skills/orch/scripts/workflow-state get [ISSUE_ID] '.agent // empty'
    ```
 
-2. **Group items by agent domain** when multi-domain, ordered per [SKILL.md § Coordination](../SKILL.md#coordination). Prefer two scoped rounds over one broad round past roughly eight items — at 24 items, a round injects 8 new blockers, 2 of them P1.
+2. **Group items by agent domain** when multi-domain, ordered per [SKILL.md § Coordination](../SKILL.md#coordination). Prefer two scoped rounds over one broad round past roughly eight items — one 24-item round injected 8 new blockers, 2 of them P1.
 
 3. **Gather decision context**:
 

--- a/skills/orch/references/finding-disposition.md
+++ b/skills/orch/references/finding-disposition.md
@@ -32,7 +32,7 @@ Uncertain about category, prefer `fix` (if related); uncertain about relevance, 
 | Error-handling gaps | `issue` |
 | Security vulnerability | `fix` if quick, else `issue` — never skipped |
 | Data validation gaps | `fix` if quick, else `issue` |
-| The same claim, enumeration, or duplicated copy arriving in two rounds running | `fix` as a structural close — derive, bind, or delete the generator |
+| A finding class arriving in two rounds running (a drifting claim, a re-derived enumeration, a second copy) | `fix` as a structural close — derive, bind, or delete the generator |
 
 ## Filing bar
 

--- a/skills/orch/references/finding-disposition.md
+++ b/skills/orch/references/finding-disposition.md
@@ -32,7 +32,7 @@ Uncertain about category, prefer `fix` (if related); uncertain about relevance, 
 | Error-handling gaps | `issue` |
 | Security vulnerability | `fix` if quick, else `issue` — never skipped |
 | Data validation gaps | `fix` if quick, else `issue` |
-| The same claim or enumeration drifting for two rounds running | `fix` as a structural close — derive, bind, or delete the claim |
+| The same claim, enumeration, or duplicated copy arriving in two rounds running | `fix` as a structural close — derive, bind, or delete the generator |
 
 ## Filing bar
 
@@ -44,6 +44,8 @@ An `issue` signal is necessary but not sufficient. Every candidate carries its s
 - **Unexplained anomalies with evidence** — observed and reproducible, cause unknown; filed as an investigation issue whose deliverable is the diagnosis.
 
 Never for a race between two invocations on one machine, a crash between two writes, an input no shipped producer emits, or a hole in a mechanism that itself came from a review round: those are declined, not filed. The one exception is a security or data-loss defect a shipped path reaches, which follows the rows above.
+
+A recurring finding class never files as "improve X": the structural-close row closes its generator in this PR.
 
 The audit pipeline applies project-management's creation bar (its SKILL.md § Disposition) as the final authority; these classes describe what clears it.
 

--- a/skills/orch/references/finding-disposition.md
+++ b/skills/orch/references/finding-disposition.md
@@ -45,7 +45,7 @@ An `issue` signal is necessary but not sufficient. Every candidate carries its s
 
 Never for a race between two invocations on one machine, a crash between two writes, an input no shipped producer emits, or a hole in a mechanism that itself came from a review round: those are declined, not filed. The one exception is a security or data-loss defect a shipped path reaches, which follows the rows above.
 
-A recurring finding class never files as "improve X": the structural-close row closes its generator in this PR.
+A recurring finding class the diff introduces or arms never files as "improve X": the structural-close row closes its generator in this PR.
 
 The audit pipeline applies project-management's creation bar (its SKILL.md § Disposition) as the final authority; these classes describe what clears it.
 

--- a/skills/orch/workflows/dev-fix.md
+++ b/skills/orch/workflows/dev-fix.md
@@ -58,7 +58,7 @@ Cancel ends the workflow; a selection goes to § 2.
    .agents/skills/orch/scripts/workflow-state get [ISSUE_ID] '.agent // empty'
    ```
 
-2. **Group items by agent domain** when multi-domain, ordered per [SKILL.md § Coordination](../SKILL.md#coordination). Prefer two scoped rounds over one broad round past roughly eight items.
+2. **Group items by agent domain** when multi-domain, ordered per [SKILL.md § Coordination](../SKILL.md#coordination). Prefer two scoped rounds over one broad round past roughly eight items — at 24 items, a round injects 8 new blockers, 2 of them P1.
 
 3. **Gather decision context**:
 

--- a/skills/orch/workflows/dev-fix.md
+++ b/skills/orch/workflows/dev-fix.md
@@ -58,7 +58,7 @@ Cancel ends the workflow; a selection goes to § 2.
    .agents/skills/orch/scripts/workflow-state get [ISSUE_ID] '.agent // empty'
    ```
 
-2. **Group items by agent domain** when multi-domain, ordered per [SKILL.md § Coordination](../SKILL.md#coordination). Prefer two scoped rounds over one broad round past roughly eight items — at 24 items, a round injects 8 new blockers, 2 of them P1.
+2. **Group items by agent domain** when multi-domain, ordered per [SKILL.md § Coordination](../SKILL.md#coordination). Prefer two scoped rounds over one broad round past roughly eight items — one 24-item round injected 8 new blockers, 2 of them P1.
 
 3. **Gather decision context**:
 


### PR DESCRIPTION
Two additions from a consumer running a stricter local version of the filing bar, per #1745.

**Structural closes over filings.** The filing bar now says a recurring finding class never files as "improve X". The verdict is the structural-close row in the category table, which it points at rather than restating.

That row also grew: it covers a duplicated copy alongside a drifting claim or enumeration, and what gets fixed is the generator, not the claim.

**The round-size figures.** `dev-fix.md` § 2 step 2 held the rule without the numbers that produced it. It now carries them: at 24 items, a round injects 8 new blockers, 2 of them P1.

Not taken: the rest of the consumer's section, which the issue itself scopes out as a deliberate project override plus composition detail.

Closes #1745
