### PR TITLE
feat(review-gate): ship the guidance the review bots read

### DIFF
--- a/.agents/skills/review-gate/DEVELOPMENT.md
+++ b/.agents/skills/review-gate/DEVELOPMENT.md
@@ -185,11 +185,9 @@ the block.
 Verbatim equality is not available here, so the drift check lives where the
 engine does: `tests/review-bots-template.test.sh` strips that block from
 both sides and compares this repo's own root `review-bots.md` against the
-template byte-for-byte. It also asserts that every engine path the guidance
-sends a bot to resolves, so a rename cannot ship a dead pointer to every
-consumer that copied the template. Changing the engine's semantics means
-changing the template in the same commit, and the suite reds until the
-repo's own copy carries it.
+template byte-for-byte. Changing the engine's semantics means changing the
+template in the same commit, and the suite reds until the repo's own copy
+carries it.
 
 The suite discriminates by whether the enclosing repo carries this skill's
 catalog source. Here it does, so a missing root `review-bots.md` is a

--- a/.agents/skills/review-gate/DEVELOPMENT.md
+++ b/.agents/skills/review-gate/DEVELOPMENT.md
@@ -165,3 +165,24 @@ MEANING is asserted, and it runs here, upstream, on every change. A consumer
 asserts nothing about meaning: `validate-workflow.sh` asks only whether its
 copy is still this file. The two questions live in the two places that can
 answer them.
+
+## The reviewer-guidance template
+
+`templates/review-bots.md` is the other half of the gate: the engine reads
+what the bots produce, this file is what the bots read. It carries the
+review economics of a repo pushed at agent speed and the ENGINE's accepted
+residual classes — properties of this package that a bot re-derives and
+proposes a fix for on every repo that ships none.
+
+Consumers copy it to their repository root and name it wherever their bots
+read instructions. It carries no per-repo values, and one marked block —
+`<!-- BEGIN repo-specific accepted residuals -->` — is the consumer's own
+half, preserved across a re-copy.
+
+Verbatim equality is not available here, so the drift check lives where the
+engine does: `tests/review-bots-template.test.sh` strips that block from
+both sides and compares this repo's own root `review-bots.md` against the
+template byte-for-byte. Changing the engine's semantics means changing the
+template in the same commit, and the suite reds until the repo's own copy
+carries it. A consumer checkout has no root copy, and the suite asserts only
+the template's structure there.

--- a/.agents/skills/review-gate/DEVELOPMENT.md
+++ b/.agents/skills/review-gate/DEVELOPMENT.md
@@ -177,12 +177,24 @@ proposes a fix for on every repo that ships none.
 Consumers copy it to their repository root and name it wherever their bots
 read instructions. It carries no per-repo values, and one marked block —
 `<!-- BEGIN repo-specific accepted residuals -->` — is the consumer's own
-half, preserved across a re-copy.
+half. The copy is repo-owned, as the writer workflow is: nothing merges a
+later template into it, so a consumer brings the text outside its block back
+into step by hand, and copying the template over the file would overwrite
+the block.
 
 Verbatim equality is not available here, so the drift check lives where the
 engine does: `tests/review-bots-template.test.sh` strips that block from
 both sides and compares this repo's own root `review-bots.md` against the
-template byte-for-byte. Changing the engine's semantics means changing the
-template in the same commit, and the suite reds until the repo's own copy
-carries it. A consumer checkout has no root copy, and the suite asserts only
-the template's structure there.
+template byte-for-byte. It also asserts that every engine path the guidance
+sends a bot to resolves, so a rename cannot ship a dead pointer to every
+consumer that copied the template. Changing the engine's semantics means
+changing the template in the same commit, and the suite reds until the
+repo's own copy carries it.
+
+The suite discriminates by whether the enclosing repo carries this skill's
+catalog source. Here it does, so a missing root `review-bots.md` is a
+failure — under either spelling of the skill root, since the render beside
+the catalog sits in the same repo. A consumer that has run adoption's
+reviewer-guidance step carries its own root copy and gets the same drift
+comparison against it; a checkout with no root copy at all is a consumer
+before adoption, and gets the structural assertions alone.

--- a/.agents/skills/review-gate/README.md
+++ b/.agents/skills/review-gate/README.md
@@ -55,10 +55,13 @@ those run in the kendex repo, on every change to the engine.
 `.agents/skills/review-gate/templates/review-bots.md` to your repository
 root, verbatim, and name that file wherever your bots read instructions
 (`.github/copilot-instructions.md`, `.github/instructions/`, `AGENTS.md`).
-It tells them the review economics of a repo pushed at agent speed and the
-gate's own settled trade-offs, so they stop proposing a fix for each one.
-Your repo's own settled trade-offs go inside its marked block; the rest is
-the template, re-copied when the engine changes.
+Naming it is a pointer line, not the content: the file is for your bots,
+never for agent sessions. It tells them the review economics of a repo
+pushed at agent speed and the gate's own settled trade-offs, so they stop
+proposing a fix for each one. Your repo's own settled trade-offs go inside
+its marked block, and the file is yours after the copy — when the engine
+changes, bring the text outside the block back into step with the template
+by hand. Copying the template over it again would replace your block.
 
 Wiring, rulesets, merge-queue settings, and what an adoption PR deletes:
 [references/adoption.md](references/adoption.md).

--- a/.agents/skills/review-gate/README.md
+++ b/.agents/skills/review-gate/README.md
@@ -16,7 +16,7 @@ It does **not** run or inspect your tests. That is branch protection's job.
 
 ## What you do
 
-Three things, once.
+Four things, once.
 
 **1. Vendor the skill and commit it.** `kendex refresh` writes
 `.agents/skills/review-gate/`. GitHub Actions checks out only tracked files,
@@ -50,6 +50,15 @@ exclusions still match something in your tree, and your adopted workflow
 still meets the template's contract. One verdict line per check; exit 0 all
 clear, 1 findings, 2 could not run. It never re-runs the engine's own tests —
 those run in the kendex repo, on every change to the engine.
+
+**4. Copy the reviewer guidance.**
+`.agents/skills/review-gate/templates/review-bots.md` to your repository
+root, verbatim, and name that file wherever your bots read instructions
+(`.github/copilot-instructions.md`, `.github/instructions/`, `AGENTS.md`).
+It tells them the review economics of a repo pushed at agent speed and the
+gate's own settled trade-offs, so they stop proposing a fix for each one.
+Your repo's own settled trade-offs go inside its marked block; the rest is
+the template, re-copied when the engine changes.
 
 Wiring, rulesets, merge-queue settings, and what an adoption PR deletes:
 [references/adoption.md](references/adoption.md).

--- a/.agents/skills/review-gate/SKILL.md
+++ b/.agents/skills/review-gate/SKILL.md
@@ -9,7 +9,7 @@ metadata:
   source: kendex
   repository: "https://github.com/vanillagreencom/kendex"
   bugs: "https://github.com/vanillagreencom/kendex/issues"
-  version: "2.1.0"
+  version: "2.2.0"
 tags: [review]
 ---
 
@@ -88,11 +88,15 @@ git add .agents/skills/review-gate
 cp .agents/skills/review-gate/templates/review-gate-writer.yml \
    .github/workflows/review-gate-writer.yml
 
-# 3. seed the repo's settings from the shipped example, then edit the
+# 3. copy the reviewer guidance the bots read, VERBATIM — this repo's own
+#    accepted residuals go inside its marked block, nothing else moves
+cp .agents/skills/review-gate/templates/review-bots.md review-bots.md
+
+# 4. seed the repo's settings from the shipped example, then edit the
 #    handful of values this repo actually decides (table below)
 $EDITOR kendex.settings.toml
 
-# 4. prove the install answers for itself
+# 5. prove the install answers for itself
 .agents/skills/review-gate/scripts/validate.sh
 ```
 

--- a/.agents/skills/review-gate/SKILL.md
+++ b/.agents/skills/review-gate/SKILL.md
@@ -88,15 +88,20 @@ git add .agents/skills/review-gate
 cp .agents/skills/review-gate/templates/review-gate-writer.yml \
    .github/workflows/review-gate-writer.yml
 
-# 3. copy the reviewer guidance the bots read, VERBATIM — this repo's own
-#    accepted residuals go inside its marked block, nothing else moves
+# 3. copy the reviewer guidance the bots read — a FIRST adoption only. The
+#    file is repo-owned after this, and a later copy would overwrite the
+#    marked block this repo's own residuals go in.
 cp .agents/skills/review-gate/templates/review-bots.md review-bots.md
 
-# 4. seed the repo's settings from the shipped example, then edit the
+# 4. name that file wherever this repo's bots read instructions — the copy
+#    alone points no bot at it: references/adoption.md § Reviewer guidance
+$EDITOR .github/copilot-instructions.md
+
+# 5. seed the repo's settings from the shipped example, then edit the
 #    handful of values this repo actually decides (table below)
 $EDITOR kendex.settings.toml
 
-# 5. prove the install answers for itself
+# 6. prove the install answers for itself
 .agents/skills/review-gate/scripts/validate.sh
 ```
 

--- a/.agents/skills/review-gate/references/adoption.md
+++ b/.agents/skills/review-gate/references/adoption.md
@@ -37,6 +37,32 @@ Held-back jobs report `skipped`, and GitHub counts skipped as satisfied.
 7. **Reviewer instruction for the vendored tree** — wire the remedy-locus
    rule from [vendored-paths.md](vendored-paths.md), never a reviewer path
    exclusion.
+8. **Reviewer guidance for the bots themselves** — copy
+   `templates/review-bots.md` to the repository root and name it wherever
+   the repo's bots read instructions (below).
+
+## Reviewer guidance — `review-bots.md`
+
+The gate reads what the bots produce; this file is what the bots read. It
+carries the review economics of a repo pushed at agent speed and the
+engine's own accepted residual classes, which a bot re-derives and proposes
+a fix for on every repo that ships none.
+
+1. Copy `.agents/skills/review-gate/templates/review-bots.md` to the
+   repository root as `review-bots.md`, VERBATIM. It carries no per-repo
+   values.
+2. Name it wherever the repo's bots read instructions — one line in
+   `.github/copilot-instructions.md`, in the repo's
+   `.github/instructions/*.instructions.md`, or in `AGENTS.md`. That line
+   is the whole wiring, and it is the consumer's one-time edit.
+3. Put this repo's own accepted residuals inside the marked block
+   (`<!-- BEGIN repo-specific accepted residuals -->`). Everything outside
+   the block is the template.
+4. Re-copy the template's half whenever the engine changes. A re-copy
+   preserves the block and nothing else.
+
+The file is reviewer context, never agent-session working instructions —
+keep it out of `AGENTS.md` itself.
 
 ## Recommended CI shape — the fast/full split
 
@@ -219,6 +245,9 @@ multi-PR *background* reducer.
 - `.agents/skills/review-gate/scripts/validate.sh` exits 0 from the repo
   root.
 - The consumer's vendored-copy drift check passes.
+- The repo's `review-bots.md` differs from
+  `.agents/skills/review-gate/templates/review-bots.md` only inside the
+  marked block.
 - The first PURE re-vendor PR after adoption carries a trusted non-author
   review object at head, and on the vendored tree no unresolved thread from a
   summary-capable reviewer, except one raising a carve-out regression (which

--- a/.agents/skills/review-gate/references/adoption.md
+++ b/.agents/skills/review-gate/references/adoption.md
@@ -249,7 +249,8 @@ multi-PR *background* reducer.
 - `.agents/skills/review-gate/scripts/validate.sh` exits 0 from the repo
   root.
 - The consumer's vendored-copy drift check passes.
-- By hand — no script reads it, and `validate.sh` does not: the repo's
+- By hand — the drift check is an ENGINE test and a consumer runs no engine
+  tests, and `validate.sh` does not read this file: the repo's
   `review-bots.md` differs from
   `.agents/skills/review-gate/templates/review-bots.md` only inside the
   marked block.

--- a/.agents/skills/review-gate/references/adoption.md
+++ b/.agents/skills/review-gate/references/adoption.md
@@ -50,19 +50,23 @@ a fix for on every repo that ships none.
 
 1. Copy `.agents/skills/review-gate/templates/review-bots.md` to the
    repository root as `review-bots.md`, VERBATIM. It carries no per-repo
-   values.
-2. Name it wherever the repo's bots read instructions — one line in
+   values, and its marked block arrives holding a placeholder.
+2. **Name** it wherever the repo's bots read instructions — one line in
    `.github/copilot-instructions.md`, in the repo's
-   `.github/instructions/*.instructions.md`, or in `AGENTS.md`. That line
-   is the whole wiring, and it is the consumer's one-time edit.
+   `.github/instructions/*.instructions.md`, or in `AGENTS.md`. A pointer
+   line scoped to review bots is what belongs in `AGENTS.md`; this file's
+   CONTENT is never inlined there, and agent sessions never load it as
+   working instructions. kendex's own line is the allowed form: `Review bots
+   follow review-bots.md`. That line is the whole wiring, and it is the
+   consumer's one-time edit.
 3. Put this repo's own accepted residuals inside the marked block
    (`<!-- BEGIN repo-specific accepted residuals -->`). Everything outside
    the block is the template.
-4. Re-copy the template's half whenever the engine changes. A re-copy
-   preserves the block and nothing else.
-
-The file is reviewer context, never agent-session working instructions —
-keep it out of `AGENTS.md` itself.
+4. **Repo-owned after the copy** — like the writer workflow, it is not an
+   ongoing sync target and `kendex refresh` never writes it. When the engine
+   changes, bring the text OUTSIDE the block back into step with the
+   template by hand. Do NOT copy the template over the file once the block
+   holds entries: that replaces them with the template's placeholder.
 
 ## Recommended CI shape — the fast/full split
 
@@ -245,7 +249,8 @@ multi-PR *background* reducer.
 - `.agents/skills/review-gate/scripts/validate.sh` exits 0 from the repo
   root.
 - The consumer's vendored-copy drift check passes.
-- The repo's `review-bots.md` differs from
+- By hand — no script reads it, and `validate.sh` does not: the repo's
+  `review-bots.md` differs from
   `.agents/skills/review-gate/templates/review-bots.md` only inside the
   marked block.
 - The first PURE re-vendor PR after adoption carries a trusted non-author

--- a/.agents/skills/review-gate/templates/review-bots.md
+++ b/.agents/skills/review-gate/templates/review-bots.md
@@ -85,25 +85,9 @@ code changed since.
 
 ## Accepted residual classes of this repo (decided — do not re-raise)
 
-- **No test-coverage asks for instruction markdown or for `tools/guard`
-  rules in a change that adds no guard test lane.** What a test must
-  cover is `.github/instructions/tests.instructions.md`; sentence-pinning
-  lints on markdown are banned.
-- **The PreToolUse commit hook reads git words, not shell expansion.**
-  Quoted flags, `flag=` assignments, aliases, and other spellings the shell
-  would have to expand are outside its contract; the installed git hook is
-  the guarantee in an armed repo.
-- **The guard arming marker plus execute bit is a consent record, not an
-  integrity check.** It answers "did this package arm this repository",
-  which is what `kendex check` and the PreToolUse lane need. It does not
-  answer whether a hook body still reaches the scripts — an executable hook
-  whose delegating line is commented out reads armed, and that is accepted:
-  `.git/hooks` is never cloned, so reaching that state takes local write
-  access, and anyone with it bypasses any predicate by writing a passing
-  hook outright. Integrity lives in `kendex guard check`, which runs the
-  package's own `--check`. Settled by KEN-670; marker-trust findings are
-  not a finding surface.
-- **Windows-only resolution paths (PATHEXT, `.cmd` shims) are out of
-  scope until a Windows report exists.**
+This repo's own deliberate trade-offs, one bullet each. A repo with none
+yet keeps the section and the placeholder.
+
+- (none recorded)
 
 <!-- END repo-specific accepted residuals -->

--- a/.agents/skills/review-gate/templates/review-bots.md
+++ b/.agents/skills/review-gate/templates/review-bots.md
@@ -1,13 +1,18 @@
 # Reviewer guidance for GitHub review bots
 
 Instructions for automated PR reviewers (Copilot code review, Codex, and
-any successor). This file is reviewer context only — agent sessions must
-not load it as working instructions, which is why it is not in `AGENTS.md`.
+any successor). This file is reviewer context only — agent sessions must not
+load it as working instructions, which is why its content is never inlined
+into `AGENTS.md`. A one-line pointer there, scoped to review bots, is how the
+bots that read `AGENTS.md` find this file.
 
-Everything outside the marked block at the end is the shipped `review-gate`
-template (`.agents/skills/review-gate/templates/review-bots.md`), copied
-verbatim: re-copy it when the engine changes, and keep this repo's own
-entries inside the block.
+Everything outside the marked block at the end came from the shipped
+`review-gate` template
+(`.agents/skills/review-gate/templates/review-bots.md`); this repo's own
+entries go inside the block. Repo-owned after the copy: when the engine
+changes, bring the text outside the block back into step with the template
+BY HAND. Copying the template over this file replaces the block with the
+template's placeholder.
 
 ## Review economics
 
@@ -47,9 +52,10 @@ noise:
   between two reads is corrected on the next convergence pass, at most
   15 minutes later. Do not propose locks for these windows.
 - **A final docs-only push may keep earlier review evidence.** Deliberate
-  wherever `REVIEW_GATE_CARRY_FORWARD` names the `docs` class; policy and
-  instruction files are excluded and always get a fresh review. Do not
-  flag it as a gate hole.
+  wherever `REVIEW_GATE_CARRY_FORWARD` names the `docs` class. Policy and
+  instruction files are excluded wherever `REVIEW_GATE_CARRY_FORWARD_EXCLUDE`
+  names them, and then always get a fresh review. Do not flag the carry
+  itself as a gate hole.
 - **A gate success just before a push is not a fail-open.** The next
   convergence supersedes it, and the merge queue re-checks at admission.
 - **Threads arriving after merge-queue admission are procedural, not a

--- a/.agents/skills/review-gate/templates/review-bots.md
+++ b/.agents/skills/review-gate/templates/review-bots.md
@@ -49,8 +49,10 @@ noise:
   (`.agents/skills/review-gate/scripts/review-predicate.sh`) — check there
   before asserting supersession behavior within a surface.
 - **Transient windows heal by convergence.** A state change landing
-  between two reads is corrected on the next convergence pass, at most
-  15 minutes later. Do not propose locks for these windows.
+  between two reads is corrected on the next convergence pass. That pass is
+  scheduled and best-effort — it can slip under load — so a window standing
+  open is not proof of a defect, and a gate that stays stale is a delivery
+  question, not a locking one. Do not propose locks for these windows.
 - **A final docs-only push may keep earlier review evidence.** Deliberate
   wherever `REVIEW_GATE_CARRY_FORWARD` names the `docs` class. Policy and
   instruction files are excluded wherever `REVIEW_GATE_CARRY_FORWARD_EXCLUDE`

--- a/.agents/skills/review-gate/tests/review-bots-template.test.sh
+++ b/.agents/skills/review-gate/tests/review-bots-template.test.sh
@@ -11,8 +11,14 @@
 #
 # The two files are one artifact outside ONE marked block, which is the
 # consumer's own half: the strip drops that block from both sides and compares
-# the rest byte-for-byte. A consumer checkout has no root copy and gets the
-# template's own structural assertions only.
+# the rest byte-for-byte.
+#
+# WHICH REPO IS RUNNING THIS decides whether a missing root copy is a failure.
+# The repo carrying this skill's catalog source ships the template, and its
+# root copy is the only thing holding the template to current engine
+# semantics — missing there is a FAIL, under either spelling of the skill root.
+# A consumer gets the same drift comparison once adoption has placed its root
+# copy, and the structural assertions alone before that.
 set -euo pipefail
 
 TEST_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
@@ -42,6 +48,22 @@ strip_block() { # FILE
 line_of() { grep -nFx -- "$2" "$1" | cut -d: -f1; }
 count_of() { grep -cFx -- "$2" "$1" || true; }
 
+# Every engine path the guidance sends a bot to, repository-relative to the
+# installed skill. Prose ends a sentence right after a path, so a trailing
+# separator is not part of the name.
+refs_of() { # FILE
+  grep -oE '\.agents/skills/review-gate/[A-Za-z0-9._/-]+' "$1" |
+    sed -e 's#^\.agents/skills/review-gate/##' -e 's/[.,]$//' | sort -u
+}
+
+unresolved_refs() { # FILE, SKILL-ROOT
+  local rel
+  while IFS= read -r rel; do
+    [[ -n "$rel" ]] || continue
+    [[ -e "$2/$rel" ]] || printf '%s\n' "$rel"
+  done < <(refs_of "$1")
+}
+
 # ------------------------------------------------------------- the copies ---
 
 TEMPLATE="$SKILL_ROOT/templates/review-bots.md"
@@ -49,15 +71,24 @@ TEMPLATE="$SKILL_ROOT/templates/review-bots.md"
 # Walk up to the enclosing repo: this skill sits at skills/review-gate/ in the
 # catalog and at .agents/skills/review-gate/ in a consumer, so a fixed ../../
 # resolves to two different places.
-ADOPTED=""
+REPO_ROOT=""
 _dir="$SKILL_ROOT"
 while [[ "$_dir" != "/" ]]; do
   if [[ -e "$_dir/.git" || -d "$_dir/.github" ]]; then
-    ADOPTED="$_dir/review-bots.md"
+    REPO_ROOT="$_dir"
     break
   fi
   _dir="$(dirname "$_dir")"
 done
+
+ADOPTED=""
+[[ -n "$REPO_ROOT" ]] && ADOPTED="$REPO_ROOT/review-bots.md"
+
+# The enclosing repo carries this skill's catalog source, so it is the repo
+# that SHIPS the template — true whether this copy is the catalog tree or the
+# render beside it, and false in any consumer.
+OWNS_ENGINE=0
+[[ -n "$REPO_ROOT" && -f "$REPO_ROOT/skills/review-gate/templates/review-bots.md" ]] && OWNS_ENGINE=1
 
 echo "=== structure ==="
 
@@ -70,8 +101,10 @@ else
 fi
 if [[ -n "$ADOPTED" && -f "$ADOPTED" ]]; then
   FILES+=("$ADOPTED"); LABELS+=("repo copy")
+elif [[ "$OWNS_ENGINE" -eq 1 ]]; then
+  fail "no review-bots.md at ${ADOPTED:-<no enclosing repo root>} — the repo shipping this template must carry the copy that holds it to the engine"
 else
-  printf '  note  %s\n' "no root review-bots.md at ${ADOPTED:-<no enclosing repo root>} — asserting the template only"
+  printf '  note  %s\n' "no root review-bots.md at ${ADOPTED:-<no enclosing repo root>} — a checkout before adoption; asserting the template only"
 fi
 
 for i in "${!FILES[@]}"; do
@@ -92,22 +125,64 @@ for i in "${!FILES[@]}"; do
   fi
 done
 
+echo "=== every engine path the guidance names resolves ==="
+
+for i in "${!FILES[@]}"; do
+  f="${FILES[$i]}"; tag="${LABELS[$i]}"
+  missing="$(unresolved_refs "$f" "$SKILL_ROOT")"
+  if [[ -z "$missing" ]]; then
+    pass "[$tag] every referenced engine path resolves"
+  else
+    fail "[$tag] the guidance sends bots to paths that do not exist:
+$(printf '%s\n' "$missing" | sed 's/^/        /')"
+  fi
+done
+
+# MUST-FAIL CONTROL: a renamed engine file must be reported. Materialize the
+# template's own reference set under a fake root, drop one, and read the arm's
+# answer — the real tree is never touched.
+if [[ -f "$TEMPLATE" ]]; then
+  REFROOT="$TMP_ROOT/refroot"
+  VICTIM=""
+  while IFS= read -r rel; do
+    [[ -n "$rel" ]] || continue
+    case "$rel" in
+      */) mkdir -p "$REFROOT/$rel" ;;
+      *) mkdir -p "$REFROOT/$(dirname "$rel")"; : >"$REFROOT/$rel"; [[ -n "$VICTIM" ]] || VICTIM="$rel" ;;
+    esac
+  done < <(refs_of "$TEMPLATE")
+
+  if [[ -z "$VICTIM" ]]; then
+    fail "control: the template names no engine FILE, so a rename could not be staged"
+  elif [[ -n "$(unresolved_refs "$TEMPLATE" "$REFROOT")" ]]; then
+    fail "control: the staged reference set does not resolve, so the rename below proves nothing"
+  else
+    mv "$REFROOT/$VICTIM" "$REFROOT/$VICTIM.renamed"
+    if [[ "$(unresolved_refs "$TEMPLATE" "$REFROOT")" == "$VICTIM" ]]; then
+      pass "control: renaming $VICTIM is reported, and nothing else is"
+    else
+      fail "control: renaming $VICTIM was not reported as the one unresolved path"
+    fi
+  fi
+fi
+
 echo "=== the repo copy is the template outside its own block ==="
 
 if [[ -n "$ADOPTED" && -f "$ADOPTED" && -f "$TEMPLATE" ]]; then
   if diff -u <(strip_block "$TEMPLATE") <(strip_block "$ADOPTED") >"$TMP_ROOT/drift.diff"; then
     pass "the repo copy carries the shipped template verbatim"
   else
-    fail "the repo copy has drifted from templates/review-bots.md — re-copy it, or move the change into the template
+    fail "the repo copy has drifted from templates/review-bots.md — bring them back into step by hand, taking the template as the source for everything outside the marked block
 $(sed 's/^/        /' "$TMP_ROOT/drift.diff" | head -20)"
   fi
 
-  # MUST-FAIL CONTROLS. The comparison is only worth its verdict if it
-  # rejects the drift it exists for and admits the edit it exists to allow.
+  # MUST-FAIL CONTROLS on the comparison itself. Both read the repo copy as
+  # their baseline, so a copy that has already drifted reports that once,
+  # above, instead of twice more here under the wrong cause.
   MUTATED="$TMP_ROOT/mutated.md"
 
   sed "s/^## Review economics$/## Review economics, reworded/" "$ADOPTED" >"$MUTATED"
-  if diff -q <(strip_block "$TEMPLATE") <(strip_block "$MUTATED") >/dev/null; then
+  if diff -q <(strip_block "$ADOPTED") <(strip_block "$MUTATED") >/dev/null; then
     fail "control: an edit OUTSIDE the block passed the comparison"
   else
     pass "control: an edit outside the block is reported as drift"
@@ -118,7 +193,7 @@ $(sed 's/^/        /' "$TMP_ROOT/drift.diff" | head -20)"
     $0 == e { skip = 0 }
     !skip
   ' "$ADOPTED" >"$MUTATED"
-  if diff -q <(strip_block "$TEMPLATE") <(strip_block "$MUTATED") >/dev/null; then
+  if diff -q <(strip_block "$ADOPTED") <(strip_block "$MUTATED") >/dev/null; then
     pass "control: an edit inside the block is the repo's own and passes"
   else
     fail "control: an edit INSIDE the block was reported as drift"

--- a/.agents/skills/review-gate/tests/review-bots-template.test.sh
+++ b/.agents/skills/review-gate/tests/review-bots-template.test.sh
@@ -1,0 +1,130 @@
+#!/usr/bin/env bash
+# The reviewer-guidance template against the copy the enclosing repo's bots
+# actually read.
+#
+# templates/review-bots.md carries the ENGINE's accepted residual classes.
+# They are claims about this engine, so the only repo that can keep them true
+# is the one that owns the engine — a template asserted nowhere states last
+# year's semantics to every consumer that copied it. The copy at the repo root
+# is the file Copilot and Codex load, so asserting the template alone would
+# prove the contents of a file no bot reads.
+#
+# The two files are one artifact outside ONE marked block, which is the
+# consumer's own half: the strip drops that block from both sides and compares
+# the rest byte-for-byte. A consumer checkout has no root copy and gets the
+# template's own structural assertions only.
+set -euo pipefail
+
+TEST_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SKILL_ROOT="$(cd "$TEST_DIR/.." && pwd)"
+TMP_ROOT="$(mktemp -d)"
+trap 'rm -rf "$TMP_ROOT"' EXIT
+
+PASS=0
+FAIL=0
+
+pass() { PASS=$((PASS + 1)); printf '  ok    %s\n' "$1"; }
+fail() { FAIL=$((FAIL + 1)); printf '  FAIL  %s\n' "$1"; }
+
+BEGIN_MARKER='<!-- BEGIN repo-specific accepted residuals -->'
+END_MARKER='<!-- END repo-specific accepted residuals -->'
+
+# Everything the markers enclose is repo-owned; both markers go with it, so a
+# file that dropped them compares as the whole file and cannot pass silently.
+strip_block() { # FILE
+  awk -v b="$BEGIN_MARKER" -v e="$END_MARKER" '
+    $0 == b { skip = 1 }
+    !skip
+    $0 == e { skip = 0 }
+  ' "$1"
+}
+
+line_of() { grep -nFx -- "$2" "$1" | cut -d: -f1; }
+count_of() { grep -cFx -- "$2" "$1" || true; }
+
+# ------------------------------------------------------------- the copies ---
+
+TEMPLATE="$SKILL_ROOT/templates/review-bots.md"
+
+# Walk up to the enclosing repo: this skill sits at skills/review-gate/ in the
+# catalog and at .agents/skills/review-gate/ in a consumer, so a fixed ../../
+# resolves to two different places.
+ADOPTED=""
+_dir="$SKILL_ROOT"
+while [[ "$_dir" != "/" ]]; do
+  if [[ -e "$_dir/.git" || -d "$_dir/.github" ]]; then
+    ADOPTED="$_dir/review-bots.md"
+    break
+  fi
+  _dir="$(dirname "$_dir")"
+done
+
+echo "=== structure ==="
+
+FILES=()
+LABELS=()
+if [[ -f "$TEMPLATE" ]]; then
+  FILES+=("$TEMPLATE"); LABELS+=("template")
+else
+  fail "the shipped template is missing at $TEMPLATE"
+fi
+if [[ -n "$ADOPTED" && -f "$ADOPTED" ]]; then
+  FILES+=("$ADOPTED"); LABELS+=("repo copy")
+else
+  printf '  note  %s\n' "no root review-bots.md at ${ADOPTED:-<no enclosing repo root>} — asserting the template only"
+fi
+
+for i in "${!FILES[@]}"; do
+  f="${FILES[$i]}"; tag="${LABELS[$i]}"
+  nb="$(count_of "$f" "$BEGIN_MARKER")"
+  ne="$(count_of "$f" "$END_MARKER")"
+  if [[ "$nb" == "1" && "$ne" == "1" ]]; then
+    pass "[$tag] exactly one repo-specific block"
+  else
+    fail "[$tag] expected one BEGIN and one END marker, found $nb and $ne"
+  fi
+  if [[ "$nb" == "1" && "$ne" == "1" ]]; then
+    if [[ "$(line_of "$f" "$BEGIN_MARKER")" -lt "$(line_of "$f" "$END_MARKER")" ]]; then
+      pass "[$tag] the block opens before it closes"
+    else
+      fail "[$tag] the END marker precedes the BEGIN marker"
+    fi
+  fi
+done
+
+echo "=== the repo copy is the template outside its own block ==="
+
+if [[ -n "$ADOPTED" && -f "$ADOPTED" && -f "$TEMPLATE" ]]; then
+  if diff -u <(strip_block "$TEMPLATE") <(strip_block "$ADOPTED") >"$TMP_ROOT/drift.diff"; then
+    pass "the repo copy carries the shipped template verbatim"
+  else
+    fail "the repo copy has drifted from templates/review-bots.md — re-copy it, or move the change into the template
+$(sed 's/^/        /' "$TMP_ROOT/drift.diff" | head -20)"
+  fi
+
+  # MUST-FAIL CONTROLS. The comparison is only worth its verdict if it
+  # rejects the drift it exists for and admits the edit it exists to allow.
+  MUTATED="$TMP_ROOT/mutated.md"
+
+  sed "s/^## Review economics$/## Review economics, reworded/" "$ADOPTED" >"$MUTATED"
+  if diff -q <(strip_block "$TEMPLATE") <(strip_block "$MUTATED") >/dev/null; then
+    fail "control: an edit OUTSIDE the block passed the comparison"
+  else
+    pass "control: an edit outside the block is reported as drift"
+  fi
+
+  awk -v b="$BEGIN_MARKER" -v e="$END_MARKER" '
+    $0 == b { print; print ""; print "- **A residual only this repo has.** Do not re-raise."; skip = 1; next }
+    $0 == e { skip = 0 }
+    !skip
+  ' "$ADOPTED" >"$MUTATED"
+  if diff -q <(strip_block "$TEMPLATE") <(strip_block "$MUTATED") >/dev/null; then
+    pass "control: an edit inside the block is the repo's own and passes"
+  else
+    fail "control: an edit INSIDE the block was reported as drift"
+  fi
+fi
+
+echo
+printf 'passed: %d  failed: %d\n' "$PASS" "$FAIL"
+[[ "$FAIL" -eq 0 ]]

--- a/.agents/skills/review-gate/tests/review-bots-template.test.sh
+++ b/.agents/skills/review-gate/tests/review-bots-template.test.sh
@@ -48,22 +48,6 @@ strip_block() { # FILE
 line_of() { grep -nFx -- "$2" "$1" | cut -d: -f1; }
 count_of() { grep -cFx -- "$2" "$1" || true; }
 
-# Every engine path the guidance sends a bot to, repository-relative to the
-# installed skill. Prose ends a sentence right after a path, so a trailing
-# separator is not part of the name.
-refs_of() { # FILE
-  grep -oE '\.agents/skills/review-gate/[A-Za-z0-9._/-]+' "$1" |
-    sed -e 's#^\.agents/skills/review-gate/##' -e 's/[.,]$//' | sort -u
-}
-
-unresolved_refs() { # FILE, SKILL-ROOT
-  local rel
-  while IFS= read -r rel; do
-    [[ -n "$rel" ]] || continue
-    [[ -e "$2/$rel" ]] || printf '%s\n' "$rel"
-  done < <(refs_of "$1")
-}
-
 # ------------------------------------------------------------- the copies ---
 
 TEMPLATE="$SKILL_ROOT/templates/review-bots.md"
@@ -124,47 +108,6 @@ for i in "${!FILES[@]}"; do
     fi
   fi
 done
-
-echo "=== every engine path the guidance names resolves ==="
-
-for i in "${!FILES[@]}"; do
-  f="${FILES[$i]}"; tag="${LABELS[$i]}"
-  missing="$(unresolved_refs "$f" "$SKILL_ROOT")"
-  if [[ -z "$missing" ]]; then
-    pass "[$tag] every referenced engine path resolves"
-  else
-    fail "[$tag] the guidance sends bots to paths that do not exist:
-$(printf '%s\n' "$missing" | sed 's/^/        /')"
-  fi
-done
-
-# MUST-FAIL CONTROL: a renamed engine file must be reported. Materialize the
-# template's own reference set under a fake root, drop one, and read the arm's
-# answer — the real tree is never touched.
-if [[ -f "$TEMPLATE" ]]; then
-  REFROOT="$TMP_ROOT/refroot"
-  VICTIM=""
-  while IFS= read -r rel; do
-    [[ -n "$rel" ]] || continue
-    case "$rel" in
-      */) mkdir -p "$REFROOT/$rel" ;;
-      *) mkdir -p "$REFROOT/$(dirname "$rel")"; : >"$REFROOT/$rel"; [[ -n "$VICTIM" ]] || VICTIM="$rel" ;;
-    esac
-  done < <(refs_of "$TEMPLATE")
-
-  if [[ -z "$VICTIM" ]]; then
-    fail "control: the template names no engine FILE, so a rename could not be staged"
-  elif [[ -n "$(unresolved_refs "$TEMPLATE" "$REFROOT")" ]]; then
-    fail "control: the staged reference set does not resolve, so the rename below proves nothing"
-  else
-    mv "$REFROOT/$VICTIM" "$REFROOT/$VICTIM.renamed"
-    if [[ "$(unresolved_refs "$TEMPLATE" "$REFROOT")" == "$VICTIM" ]]; then
-      pass "control: renaming $VICTIM is reported, and nothing else is"
-    else
-      fail "control: renaming $VICTIM was not reported as the one unresolved path"
-    fi
-  fi
-fi
 
 echo "=== the repo copy is the template outside its own block ==="
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,9 @@ an outside contributor.
 - `REVIEW_GATE_CARRY_FORWARD` gains a `vendored` class: a `kendex refresh`
   push under the render trees a repo lists in `REVIEW_GATE_VENDORED_PATHS`
   carries the prior review, whatever the files' extensions.
+- review-gate ships `templates/review-bots.md`, the guidance the third-party
+  review bots read: copy it to the repository root, name it wherever the bots
+  read instructions, and keep the repo's own residuals in its marked block.
 
 ### Changed
 

--- a/review-bots.md
+++ b/review-bots.md
@@ -1,13 +1,18 @@
 # Reviewer guidance for GitHub review bots
 
 Instructions for automated PR reviewers (Copilot code review, Codex, and
-any successor). This file is reviewer context only — agent sessions must
-not load it as working instructions, which is why it is not in `AGENTS.md`.
+any successor). This file is reviewer context only — agent sessions must not
+load it as working instructions, which is why its content is never inlined
+into `AGENTS.md`. A one-line pointer there, scoped to review bots, is how the
+bots that read `AGENTS.md` find this file.
 
-Everything outside the marked block at the end is the shipped `review-gate`
-template (`.agents/skills/review-gate/templates/review-bots.md`), copied
-verbatim: re-copy it when the engine changes, and keep this repo's own
-entries inside the block.
+Everything outside the marked block at the end came from the shipped
+`review-gate` template
+(`.agents/skills/review-gate/templates/review-bots.md`); this repo's own
+entries go inside the block. Repo-owned after the copy: when the engine
+changes, bring the text outside the block back into step with the template
+BY HAND. Copying the template over this file replaces the block with the
+template's placeholder.
 
 ## Review economics
 
@@ -47,9 +52,10 @@ noise:
   between two reads is corrected on the next convergence pass, at most
   15 minutes later. Do not propose locks for these windows.
 - **A final docs-only push may keep earlier review evidence.** Deliberate
-  wherever `REVIEW_GATE_CARRY_FORWARD` names the `docs` class; policy and
-  instruction files are excluded and always get a fresh review. Do not
-  flag it as a gate hole.
+  wherever `REVIEW_GATE_CARRY_FORWARD` names the `docs` class. Policy and
+  instruction files are excluded wherever `REVIEW_GATE_CARRY_FORWARD_EXCLUDE`
+  names them, and then always get a fresh review. Do not flag the carry
+  itself as a gate hole.
 - **A gate success just before a push is not a fail-open.** The next
   convergence supersedes it, and the merge queue re-checks at admission.
 - **Threads arriving after merge-queue admission are procedural, not a

--- a/review-bots.md
+++ b/review-bots.md
@@ -49,8 +49,10 @@ noise:
   (`.agents/skills/review-gate/scripts/review-predicate.sh`) — check there
   before asserting supersession behavior within a surface.
 - **Transient windows heal by convergence.** A state change landing
-  between two reads is corrected on the next convergence pass, at most
-  15 minutes later. Do not propose locks for these windows.
+  between two reads is corrected on the next convergence pass. That pass is
+  scheduled and best-effort — it can slip under load — so a window standing
+  open is not proof of a defect, and a gate that stays stale is a delivery
+  question, not a locking one. Do not propose locks for these windows.
 - **A final docs-only push may keep earlier review evidence.** Deliberate
   wherever `REVIEW_GATE_CARRY_FORWARD` names the `docs` class. Policy and
   instruction files are excluded wherever `REVIEW_GATE_CARRY_FORWARD_EXCLUDE`

--- a/skills/review-gate/DEVELOPMENT.md
+++ b/skills/review-gate/DEVELOPMENT.md
@@ -185,11 +185,9 @@ the block.
 Verbatim equality is not available here, so the drift check lives where the
 engine does: `tests/review-bots-template.test.sh` strips that block from
 both sides and compares this repo's own root `review-bots.md` against the
-template byte-for-byte. It also asserts that every engine path the guidance
-sends a bot to resolves, so a rename cannot ship a dead pointer to every
-consumer that copied the template. Changing the engine's semantics means
-changing the template in the same commit, and the suite reds until the
-repo's own copy carries it.
+template byte-for-byte. Changing the engine's semantics means changing the
+template in the same commit, and the suite reds until the repo's own copy
+carries it.
 
 The suite discriminates by whether the enclosing repo carries this skill's
 catalog source. Here it does, so a missing root `review-bots.md` is a

--- a/skills/review-gate/DEVELOPMENT.md
+++ b/skills/review-gate/DEVELOPMENT.md
@@ -165,3 +165,24 @@ MEANING is asserted, and it runs here, upstream, on every change. A consumer
 asserts nothing about meaning: `validate-workflow.sh` asks only whether its
 copy is still this file. The two questions live in the two places that can
 answer them.
+
+## The reviewer-guidance template
+
+`templates/review-bots.md` is the other half of the gate: the engine reads
+what the bots produce, this file is what the bots read. It carries the
+review economics of a repo pushed at agent speed and the ENGINE's accepted
+residual classes — properties of this package that a bot re-derives and
+proposes a fix for on every repo that ships none.
+
+Consumers copy it to their repository root and name it wherever their bots
+read instructions. It carries no per-repo values, and one marked block —
+`<!-- BEGIN repo-specific accepted residuals -->` — is the consumer's own
+half, preserved across a re-copy.
+
+Verbatim equality is not available here, so the drift check lives where the
+engine does: `tests/review-bots-template.test.sh` strips that block from
+both sides and compares this repo's own root `review-bots.md` against the
+template byte-for-byte. Changing the engine's semantics means changing the
+template in the same commit, and the suite reds until the repo's own copy
+carries it. A consumer checkout has no root copy, and the suite asserts only
+the template's structure there.

--- a/skills/review-gate/DEVELOPMENT.md
+++ b/skills/review-gate/DEVELOPMENT.md
@@ -177,12 +177,24 @@ proposes a fix for on every repo that ships none.
 Consumers copy it to their repository root and name it wherever their bots
 read instructions. It carries no per-repo values, and one marked block —
 `<!-- BEGIN repo-specific accepted residuals -->` — is the consumer's own
-half, preserved across a re-copy.
+half. The copy is repo-owned, as the writer workflow is: nothing merges a
+later template into it, so a consumer brings the text outside its block back
+into step by hand, and copying the template over the file would overwrite
+the block.
 
 Verbatim equality is not available here, so the drift check lives where the
 engine does: `tests/review-bots-template.test.sh` strips that block from
 both sides and compares this repo's own root `review-bots.md` against the
-template byte-for-byte. Changing the engine's semantics means changing the
-template in the same commit, and the suite reds until the repo's own copy
-carries it. A consumer checkout has no root copy, and the suite asserts only
-the template's structure there.
+template byte-for-byte. It also asserts that every engine path the guidance
+sends a bot to resolves, so a rename cannot ship a dead pointer to every
+consumer that copied the template. Changing the engine's semantics means
+changing the template in the same commit, and the suite reds until the
+repo's own copy carries it.
+
+The suite discriminates by whether the enclosing repo carries this skill's
+catalog source. Here it does, so a missing root `review-bots.md` is a
+failure — under either spelling of the skill root, since the render beside
+the catalog sits in the same repo. A consumer that has run adoption's
+reviewer-guidance step carries its own root copy and gets the same drift
+comparison against it; a checkout with no root copy at all is a consumer
+before adoption, and gets the structural assertions alone.

--- a/skills/review-gate/README.md
+++ b/skills/review-gate/README.md
@@ -55,10 +55,13 @@ those run in the kendex repo, on every change to the engine.
 `.agents/skills/review-gate/templates/review-bots.md` to your repository
 root, verbatim, and name that file wherever your bots read instructions
 (`.github/copilot-instructions.md`, `.github/instructions/`, `AGENTS.md`).
-It tells them the review economics of a repo pushed at agent speed and the
-gate's own settled trade-offs, so they stop proposing a fix for each one.
-Your repo's own settled trade-offs go inside its marked block; the rest is
-the template, re-copied when the engine changes.
+Naming it is a pointer line, not the content: the file is for your bots,
+never for agent sessions. It tells them the review economics of a repo
+pushed at agent speed and the gate's own settled trade-offs, so they stop
+proposing a fix for each one. Your repo's own settled trade-offs go inside
+its marked block, and the file is yours after the copy — when the engine
+changes, bring the text outside the block back into step with the template
+by hand. Copying the template over it again would replace your block.
 
 Wiring, rulesets, merge-queue settings, and what an adoption PR deletes:
 [references/adoption.md](references/adoption.md).

--- a/skills/review-gate/README.md
+++ b/skills/review-gate/README.md
@@ -16,7 +16,7 @@ It does **not** run or inspect your tests. That is branch protection's job.
 
 ## What you do
 
-Three things, once.
+Four things, once.
 
 **1. Vendor the skill and commit it.** `kendex refresh` writes
 `.agents/skills/review-gate/`. GitHub Actions checks out only tracked files,
@@ -50,6 +50,15 @@ exclusions still match something in your tree, and your adopted workflow
 still meets the template's contract. One verdict line per check; exit 0 all
 clear, 1 findings, 2 could not run. It never re-runs the engine's own tests —
 those run in the kendex repo, on every change to the engine.
+
+**4. Copy the reviewer guidance.**
+`.agents/skills/review-gate/templates/review-bots.md` to your repository
+root, verbatim, and name that file wherever your bots read instructions
+(`.github/copilot-instructions.md`, `.github/instructions/`, `AGENTS.md`).
+It tells them the review economics of a repo pushed at agent speed and the
+gate's own settled trade-offs, so they stop proposing a fix for each one.
+Your repo's own settled trade-offs go inside its marked block; the rest is
+the template, re-copied when the engine changes.
 
 Wiring, rulesets, merge-queue settings, and what an adoption PR deletes:
 [references/adoption.md](references/adoption.md).

--- a/skills/review-gate/SKILL.md
+++ b/skills/review-gate/SKILL.md
@@ -9,7 +9,7 @@ metadata:
   source: kendex
   repository: "https://github.com/vanillagreencom/kendex"
   bugs: "https://github.com/vanillagreencom/kendex/issues"
-  version: "2.1.0"
+  version: "2.2.0"
 tags: [review]
 ---
 
@@ -88,11 +88,15 @@ git add .agents/skills/review-gate
 cp .agents/skills/review-gate/templates/review-gate-writer.yml \
    .github/workflows/review-gate-writer.yml
 
-# 3. seed the repo's settings from the shipped example, then edit the
+# 3. copy the reviewer guidance the bots read, VERBATIM — this repo's own
+#    accepted residuals go inside its marked block, nothing else moves
+cp .agents/skills/review-gate/templates/review-bots.md review-bots.md
+
+# 4. seed the repo's settings from the shipped example, then edit the
 #    handful of values this repo actually decides (table below)
 $EDITOR kendex.settings.toml
 
-# 4. prove the install answers for itself
+# 5. prove the install answers for itself
 .agents/skills/review-gate/scripts/validate.sh
 ```
 

--- a/skills/review-gate/SKILL.md
+++ b/skills/review-gate/SKILL.md
@@ -88,15 +88,20 @@ git add .agents/skills/review-gate
 cp .agents/skills/review-gate/templates/review-gate-writer.yml \
    .github/workflows/review-gate-writer.yml
 
-# 3. copy the reviewer guidance the bots read, VERBATIM — this repo's own
-#    accepted residuals go inside its marked block, nothing else moves
+# 3. copy the reviewer guidance the bots read — a FIRST adoption only. The
+#    file is repo-owned after this, and a later copy would overwrite the
+#    marked block this repo's own residuals go in.
 cp .agents/skills/review-gate/templates/review-bots.md review-bots.md
 
-# 4. seed the repo's settings from the shipped example, then edit the
+# 4. name that file wherever this repo's bots read instructions — the copy
+#    alone points no bot at it: references/adoption.md § Reviewer guidance
+$EDITOR .github/copilot-instructions.md
+
+# 5. seed the repo's settings from the shipped example, then edit the
 #    handful of values this repo actually decides (table below)
 $EDITOR kendex.settings.toml
 
-# 5. prove the install answers for itself
+# 6. prove the install answers for itself
 .agents/skills/review-gate/scripts/validate.sh
 ```
 

--- a/skills/review-gate/references/adoption.md
+++ b/skills/review-gate/references/adoption.md
@@ -37,6 +37,32 @@ Held-back jobs report `skipped`, and GitHub counts skipped as satisfied.
 7. **Reviewer instruction for the vendored tree** — wire the remedy-locus
    rule from [vendored-paths.md](vendored-paths.md), never a reviewer path
    exclusion.
+8. **Reviewer guidance for the bots themselves** — copy
+   `templates/review-bots.md` to the repository root and name it wherever
+   the repo's bots read instructions (below).
+
+## Reviewer guidance — `review-bots.md`
+
+The gate reads what the bots produce; this file is what the bots read. It
+carries the review economics of a repo pushed at agent speed and the
+engine's own accepted residual classes, which a bot re-derives and proposes
+a fix for on every repo that ships none.
+
+1. Copy `.agents/skills/review-gate/templates/review-bots.md` to the
+   repository root as `review-bots.md`, VERBATIM. It carries no per-repo
+   values.
+2. Name it wherever the repo's bots read instructions — one line in
+   `.github/copilot-instructions.md`, in the repo's
+   `.github/instructions/*.instructions.md`, or in `AGENTS.md`. That line
+   is the whole wiring, and it is the consumer's one-time edit.
+3. Put this repo's own accepted residuals inside the marked block
+   (`<!-- BEGIN repo-specific accepted residuals -->`). Everything outside
+   the block is the template.
+4. Re-copy the template's half whenever the engine changes. A re-copy
+   preserves the block and nothing else.
+
+The file is reviewer context, never agent-session working instructions —
+keep it out of `AGENTS.md` itself.
 
 ## Recommended CI shape — the fast/full split
 
@@ -219,6 +245,9 @@ multi-PR *background* reducer.
 - `.agents/skills/review-gate/scripts/validate.sh` exits 0 from the repo
   root.
 - The consumer's vendored-copy drift check passes.
+- The repo's `review-bots.md` differs from
+  `.agents/skills/review-gate/templates/review-bots.md` only inside the
+  marked block.
 - The first PURE re-vendor PR after adoption carries a trusted non-author
   review object at head, and on the vendored tree no unresolved thread from a
   summary-capable reviewer, except one raising a carve-out regression (which

--- a/skills/review-gate/references/adoption.md
+++ b/skills/review-gate/references/adoption.md
@@ -249,7 +249,8 @@ multi-PR *background* reducer.
 - `.agents/skills/review-gate/scripts/validate.sh` exits 0 from the repo
   root.
 - The consumer's vendored-copy drift check passes.
-- By hand — no script reads it, and `validate.sh` does not: the repo's
+- By hand — the drift check is an ENGINE test and a consumer runs no engine
+  tests, and `validate.sh` does not read this file: the repo's
   `review-bots.md` differs from
   `.agents/skills/review-gate/templates/review-bots.md` only inside the
   marked block.

--- a/skills/review-gate/references/adoption.md
+++ b/skills/review-gate/references/adoption.md
@@ -50,19 +50,23 @@ a fix for on every repo that ships none.
 
 1. Copy `.agents/skills/review-gate/templates/review-bots.md` to the
    repository root as `review-bots.md`, VERBATIM. It carries no per-repo
-   values.
-2. Name it wherever the repo's bots read instructions — one line in
+   values, and its marked block arrives holding a placeholder.
+2. **Name** it wherever the repo's bots read instructions — one line in
    `.github/copilot-instructions.md`, in the repo's
-   `.github/instructions/*.instructions.md`, or in `AGENTS.md`. That line
-   is the whole wiring, and it is the consumer's one-time edit.
+   `.github/instructions/*.instructions.md`, or in `AGENTS.md`. A pointer
+   line scoped to review bots is what belongs in `AGENTS.md`; this file's
+   CONTENT is never inlined there, and agent sessions never load it as
+   working instructions. kendex's own line is the allowed form: `Review bots
+   follow review-bots.md`. That line is the whole wiring, and it is the
+   consumer's one-time edit.
 3. Put this repo's own accepted residuals inside the marked block
    (`<!-- BEGIN repo-specific accepted residuals -->`). Everything outside
    the block is the template.
-4. Re-copy the template's half whenever the engine changes. A re-copy
-   preserves the block and nothing else.
-
-The file is reviewer context, never agent-session working instructions —
-keep it out of `AGENTS.md` itself.
+4. **Repo-owned after the copy** — like the writer workflow, it is not an
+   ongoing sync target and `kendex refresh` never writes it. When the engine
+   changes, bring the text OUTSIDE the block back into step with the
+   template by hand. Do NOT copy the template over the file once the block
+   holds entries: that replaces them with the template's placeholder.
 
 ## Recommended CI shape — the fast/full split
 
@@ -245,7 +249,8 @@ multi-PR *background* reducer.
 - `.agents/skills/review-gate/scripts/validate.sh` exits 0 from the repo
   root.
 - The consumer's vendored-copy drift check passes.
-- The repo's `review-bots.md` differs from
+- By hand — no script reads it, and `validate.sh` does not: the repo's
+  `review-bots.md` differs from
   `.agents/skills/review-gate/templates/review-bots.md` only inside the
   marked block.
 - The first PURE re-vendor PR after adoption carries a trusted non-author

--- a/skills/review-gate/templates/review-bots.md
+++ b/skills/review-gate/templates/review-bots.md
@@ -85,25 +85,9 @@ code changed since.
 
 ## Accepted residual classes of this repo (decided — do not re-raise)
 
-- **No test-coverage asks for instruction markdown or for `tools/guard`
-  rules in a change that adds no guard test lane.** What a test must
-  cover is `.github/instructions/tests.instructions.md`; sentence-pinning
-  lints on markdown are banned.
-- **The PreToolUse commit hook reads git words, not shell expansion.**
-  Quoted flags, `flag=` assignments, aliases, and other spellings the shell
-  would have to expand are outside its contract; the installed git hook is
-  the guarantee in an armed repo.
-- **The guard arming marker plus execute bit is a consent record, not an
-  integrity check.** It answers "did this package arm this repository",
-  which is what `kendex check` and the PreToolUse lane need. It does not
-  answer whether a hook body still reaches the scripts — an executable hook
-  whose delegating line is commented out reads armed, and that is accepted:
-  `.git/hooks` is never cloned, so reaching that state takes local write
-  access, and anyone with it bypasses any predicate by writing a passing
-  hook outright. Integrity lives in `kendex guard check`, which runs the
-  package's own `--check`. Settled by KEN-670; marker-trust findings are
-  not a finding surface.
-- **Windows-only resolution paths (PATHEXT, `.cmd` shims) are out of
-  scope until a Windows report exists.**
+This repo's own deliberate trade-offs, one bullet each. A repo with none
+yet keeps the section and the placeholder.
+
+- (none recorded)
 
 <!-- END repo-specific accepted residuals -->

--- a/skills/review-gate/templates/review-bots.md
+++ b/skills/review-gate/templates/review-bots.md
@@ -1,13 +1,18 @@
 # Reviewer guidance for GitHub review bots
 
 Instructions for automated PR reviewers (Copilot code review, Codex, and
-any successor). This file is reviewer context only — agent sessions must
-not load it as working instructions, which is why it is not in `AGENTS.md`.
+any successor). This file is reviewer context only — agent sessions must not
+load it as working instructions, which is why its content is never inlined
+into `AGENTS.md`. A one-line pointer there, scoped to review bots, is how the
+bots that read `AGENTS.md` find this file.
 
-Everything outside the marked block at the end is the shipped `review-gate`
-template (`.agents/skills/review-gate/templates/review-bots.md`), copied
-verbatim: re-copy it when the engine changes, and keep this repo's own
-entries inside the block.
+Everything outside the marked block at the end came from the shipped
+`review-gate` template
+(`.agents/skills/review-gate/templates/review-bots.md`); this repo's own
+entries go inside the block. Repo-owned after the copy: when the engine
+changes, bring the text outside the block back into step with the template
+BY HAND. Copying the template over this file replaces the block with the
+template's placeholder.
 
 ## Review economics
 
@@ -47,9 +52,10 @@ noise:
   between two reads is corrected on the next convergence pass, at most
   15 minutes later. Do not propose locks for these windows.
 - **A final docs-only push may keep earlier review evidence.** Deliberate
-  wherever `REVIEW_GATE_CARRY_FORWARD` names the `docs` class; policy and
-  instruction files are excluded and always get a fresh review. Do not
-  flag it as a gate hole.
+  wherever `REVIEW_GATE_CARRY_FORWARD` names the `docs` class. Policy and
+  instruction files are excluded wherever `REVIEW_GATE_CARRY_FORWARD_EXCLUDE`
+  names them, and then always get a fresh review. Do not flag the carry
+  itself as a gate hole.
 - **A gate success just before a push is not a fail-open.** The next
   convergence supersedes it, and the merge queue re-checks at admission.
 - **Threads arriving after merge-queue admission are procedural, not a

--- a/skills/review-gate/templates/review-bots.md
+++ b/skills/review-gate/templates/review-bots.md
@@ -49,8 +49,10 @@ noise:
   (`.agents/skills/review-gate/scripts/review-predicate.sh`) — check there
   before asserting supersession behavior within a surface.
 - **Transient windows heal by convergence.** A state change landing
-  between two reads is corrected on the next convergence pass, at most
-  15 minutes later. Do not propose locks for these windows.
+  between two reads is corrected on the next convergence pass. That pass is
+  scheduled and best-effort — it can slip under load — so a window standing
+  open is not proof of a defect, and a gate that stays stale is a delivery
+  question, not a locking one. Do not propose locks for these windows.
 - **A final docs-only push may keep earlier review evidence.** Deliberate
   wherever `REVIEW_GATE_CARRY_FORWARD` names the `docs` class. Policy and
   instruction files are excluded wherever `REVIEW_GATE_CARRY_FORWARD_EXCLUDE`

--- a/skills/review-gate/tests/review-bots-template.test.sh
+++ b/skills/review-gate/tests/review-bots-template.test.sh
@@ -11,8 +11,14 @@
 #
 # The two files are one artifact outside ONE marked block, which is the
 # consumer's own half: the strip drops that block from both sides and compares
-# the rest byte-for-byte. A consumer checkout has no root copy and gets the
-# template's own structural assertions only.
+# the rest byte-for-byte.
+#
+# WHICH REPO IS RUNNING THIS decides whether a missing root copy is a failure.
+# The repo carrying this skill's catalog source ships the template, and its
+# root copy is the only thing holding the template to current engine
+# semantics — missing there is a FAIL, under either spelling of the skill root.
+# A consumer gets the same drift comparison once adoption has placed its root
+# copy, and the structural assertions alone before that.
 set -euo pipefail
 
 TEST_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
@@ -42,6 +48,22 @@ strip_block() { # FILE
 line_of() { grep -nFx -- "$2" "$1" | cut -d: -f1; }
 count_of() { grep -cFx -- "$2" "$1" || true; }
 
+# Every engine path the guidance sends a bot to, repository-relative to the
+# installed skill. Prose ends a sentence right after a path, so a trailing
+# separator is not part of the name.
+refs_of() { # FILE
+  grep -oE '\.agents/skills/review-gate/[A-Za-z0-9._/-]+' "$1" |
+    sed -e 's#^\.agents/skills/review-gate/##' -e 's/[.,]$//' | sort -u
+}
+
+unresolved_refs() { # FILE, SKILL-ROOT
+  local rel
+  while IFS= read -r rel; do
+    [[ -n "$rel" ]] || continue
+    [[ -e "$2/$rel" ]] || printf '%s\n' "$rel"
+  done < <(refs_of "$1")
+}
+
 # ------------------------------------------------------------- the copies ---
 
 TEMPLATE="$SKILL_ROOT/templates/review-bots.md"
@@ -49,15 +71,24 @@ TEMPLATE="$SKILL_ROOT/templates/review-bots.md"
 # Walk up to the enclosing repo: this skill sits at skills/review-gate/ in the
 # catalog and at .agents/skills/review-gate/ in a consumer, so a fixed ../../
 # resolves to two different places.
-ADOPTED=""
+REPO_ROOT=""
 _dir="$SKILL_ROOT"
 while [[ "$_dir" != "/" ]]; do
   if [[ -e "$_dir/.git" || -d "$_dir/.github" ]]; then
-    ADOPTED="$_dir/review-bots.md"
+    REPO_ROOT="$_dir"
     break
   fi
   _dir="$(dirname "$_dir")"
 done
+
+ADOPTED=""
+[[ -n "$REPO_ROOT" ]] && ADOPTED="$REPO_ROOT/review-bots.md"
+
+# The enclosing repo carries this skill's catalog source, so it is the repo
+# that SHIPS the template — true whether this copy is the catalog tree or the
+# render beside it, and false in any consumer.
+OWNS_ENGINE=0
+[[ -n "$REPO_ROOT" && -f "$REPO_ROOT/skills/review-gate/templates/review-bots.md" ]] && OWNS_ENGINE=1
 
 echo "=== structure ==="
 
@@ -70,8 +101,10 @@ else
 fi
 if [[ -n "$ADOPTED" && -f "$ADOPTED" ]]; then
   FILES+=("$ADOPTED"); LABELS+=("repo copy")
+elif [[ "$OWNS_ENGINE" -eq 1 ]]; then
+  fail "no review-bots.md at ${ADOPTED:-<no enclosing repo root>} — the repo shipping this template must carry the copy that holds it to the engine"
 else
-  printf '  note  %s\n' "no root review-bots.md at ${ADOPTED:-<no enclosing repo root>} — asserting the template only"
+  printf '  note  %s\n' "no root review-bots.md at ${ADOPTED:-<no enclosing repo root>} — a checkout before adoption; asserting the template only"
 fi
 
 for i in "${!FILES[@]}"; do
@@ -92,22 +125,64 @@ for i in "${!FILES[@]}"; do
   fi
 done
 
+echo "=== every engine path the guidance names resolves ==="
+
+for i in "${!FILES[@]}"; do
+  f="${FILES[$i]}"; tag="${LABELS[$i]}"
+  missing="$(unresolved_refs "$f" "$SKILL_ROOT")"
+  if [[ -z "$missing" ]]; then
+    pass "[$tag] every referenced engine path resolves"
+  else
+    fail "[$tag] the guidance sends bots to paths that do not exist:
+$(printf '%s\n' "$missing" | sed 's/^/        /')"
+  fi
+done
+
+# MUST-FAIL CONTROL: a renamed engine file must be reported. Materialize the
+# template's own reference set under a fake root, drop one, and read the arm's
+# answer — the real tree is never touched.
+if [[ -f "$TEMPLATE" ]]; then
+  REFROOT="$TMP_ROOT/refroot"
+  VICTIM=""
+  while IFS= read -r rel; do
+    [[ -n "$rel" ]] || continue
+    case "$rel" in
+      */) mkdir -p "$REFROOT/$rel" ;;
+      *) mkdir -p "$REFROOT/$(dirname "$rel")"; : >"$REFROOT/$rel"; [[ -n "$VICTIM" ]] || VICTIM="$rel" ;;
+    esac
+  done < <(refs_of "$TEMPLATE")
+
+  if [[ -z "$VICTIM" ]]; then
+    fail "control: the template names no engine FILE, so a rename could not be staged"
+  elif [[ -n "$(unresolved_refs "$TEMPLATE" "$REFROOT")" ]]; then
+    fail "control: the staged reference set does not resolve, so the rename below proves nothing"
+  else
+    mv "$REFROOT/$VICTIM" "$REFROOT/$VICTIM.renamed"
+    if [[ "$(unresolved_refs "$TEMPLATE" "$REFROOT")" == "$VICTIM" ]]; then
+      pass "control: renaming $VICTIM is reported, and nothing else is"
+    else
+      fail "control: renaming $VICTIM was not reported as the one unresolved path"
+    fi
+  fi
+fi
+
 echo "=== the repo copy is the template outside its own block ==="
 
 if [[ -n "$ADOPTED" && -f "$ADOPTED" && -f "$TEMPLATE" ]]; then
   if diff -u <(strip_block "$TEMPLATE") <(strip_block "$ADOPTED") >"$TMP_ROOT/drift.diff"; then
     pass "the repo copy carries the shipped template verbatim"
   else
-    fail "the repo copy has drifted from templates/review-bots.md — re-copy it, or move the change into the template
+    fail "the repo copy has drifted from templates/review-bots.md — bring them back into step by hand, taking the template as the source for everything outside the marked block
 $(sed 's/^/        /' "$TMP_ROOT/drift.diff" | head -20)"
   fi
 
-  # MUST-FAIL CONTROLS. The comparison is only worth its verdict if it
-  # rejects the drift it exists for and admits the edit it exists to allow.
+  # MUST-FAIL CONTROLS on the comparison itself. Both read the repo copy as
+  # their baseline, so a copy that has already drifted reports that once,
+  # above, instead of twice more here under the wrong cause.
   MUTATED="$TMP_ROOT/mutated.md"
 
   sed "s/^## Review economics$/## Review economics, reworded/" "$ADOPTED" >"$MUTATED"
-  if diff -q <(strip_block "$TEMPLATE") <(strip_block "$MUTATED") >/dev/null; then
+  if diff -q <(strip_block "$ADOPTED") <(strip_block "$MUTATED") >/dev/null; then
     fail "control: an edit OUTSIDE the block passed the comparison"
   else
     pass "control: an edit outside the block is reported as drift"
@@ -118,7 +193,7 @@ $(sed 's/^/        /' "$TMP_ROOT/drift.diff" | head -20)"
     $0 == e { skip = 0 }
     !skip
   ' "$ADOPTED" >"$MUTATED"
-  if diff -q <(strip_block "$TEMPLATE") <(strip_block "$MUTATED") >/dev/null; then
+  if diff -q <(strip_block "$ADOPTED") <(strip_block "$MUTATED") >/dev/null; then
     pass "control: an edit inside the block is the repo's own and passes"
   else
     fail "control: an edit INSIDE the block was reported as drift"

--- a/skills/review-gate/tests/review-bots-template.test.sh
+++ b/skills/review-gate/tests/review-bots-template.test.sh
@@ -1,0 +1,130 @@
+#!/usr/bin/env bash
+# The reviewer-guidance template against the copy the enclosing repo's bots
+# actually read.
+#
+# templates/review-bots.md carries the ENGINE's accepted residual classes.
+# They are claims about this engine, so the only repo that can keep them true
+# is the one that owns the engine — a template asserted nowhere states last
+# year's semantics to every consumer that copied it. The copy at the repo root
+# is the file Copilot and Codex load, so asserting the template alone would
+# prove the contents of a file no bot reads.
+#
+# The two files are one artifact outside ONE marked block, which is the
+# consumer's own half: the strip drops that block from both sides and compares
+# the rest byte-for-byte. A consumer checkout has no root copy and gets the
+# template's own structural assertions only.
+set -euo pipefail
+
+TEST_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SKILL_ROOT="$(cd "$TEST_DIR/.." && pwd)"
+TMP_ROOT="$(mktemp -d)"
+trap 'rm -rf "$TMP_ROOT"' EXIT
+
+PASS=0
+FAIL=0
+
+pass() { PASS=$((PASS + 1)); printf '  ok    %s\n' "$1"; }
+fail() { FAIL=$((FAIL + 1)); printf '  FAIL  %s\n' "$1"; }
+
+BEGIN_MARKER='<!-- BEGIN repo-specific accepted residuals -->'
+END_MARKER='<!-- END repo-specific accepted residuals -->'
+
+# Everything the markers enclose is repo-owned; both markers go with it, so a
+# file that dropped them compares as the whole file and cannot pass silently.
+strip_block() { # FILE
+  awk -v b="$BEGIN_MARKER" -v e="$END_MARKER" '
+    $0 == b { skip = 1 }
+    !skip
+    $0 == e { skip = 0 }
+  ' "$1"
+}
+
+line_of() { grep -nFx -- "$2" "$1" | cut -d: -f1; }
+count_of() { grep -cFx -- "$2" "$1" || true; }
+
+# ------------------------------------------------------------- the copies ---
+
+TEMPLATE="$SKILL_ROOT/templates/review-bots.md"
+
+# Walk up to the enclosing repo: this skill sits at skills/review-gate/ in the
+# catalog and at .agents/skills/review-gate/ in a consumer, so a fixed ../../
+# resolves to two different places.
+ADOPTED=""
+_dir="$SKILL_ROOT"
+while [[ "$_dir" != "/" ]]; do
+  if [[ -e "$_dir/.git" || -d "$_dir/.github" ]]; then
+    ADOPTED="$_dir/review-bots.md"
+    break
+  fi
+  _dir="$(dirname "$_dir")"
+done
+
+echo "=== structure ==="
+
+FILES=()
+LABELS=()
+if [[ -f "$TEMPLATE" ]]; then
+  FILES+=("$TEMPLATE"); LABELS+=("template")
+else
+  fail "the shipped template is missing at $TEMPLATE"
+fi
+if [[ -n "$ADOPTED" && -f "$ADOPTED" ]]; then
+  FILES+=("$ADOPTED"); LABELS+=("repo copy")
+else
+  printf '  note  %s\n' "no root review-bots.md at ${ADOPTED:-<no enclosing repo root>} — asserting the template only"
+fi
+
+for i in "${!FILES[@]}"; do
+  f="${FILES[$i]}"; tag="${LABELS[$i]}"
+  nb="$(count_of "$f" "$BEGIN_MARKER")"
+  ne="$(count_of "$f" "$END_MARKER")"
+  if [[ "$nb" == "1" && "$ne" == "1" ]]; then
+    pass "[$tag] exactly one repo-specific block"
+  else
+    fail "[$tag] expected one BEGIN and one END marker, found $nb and $ne"
+  fi
+  if [[ "$nb" == "1" && "$ne" == "1" ]]; then
+    if [[ "$(line_of "$f" "$BEGIN_MARKER")" -lt "$(line_of "$f" "$END_MARKER")" ]]; then
+      pass "[$tag] the block opens before it closes"
+    else
+      fail "[$tag] the END marker precedes the BEGIN marker"
+    fi
+  fi
+done
+
+echo "=== the repo copy is the template outside its own block ==="
+
+if [[ -n "$ADOPTED" && -f "$ADOPTED" && -f "$TEMPLATE" ]]; then
+  if diff -u <(strip_block "$TEMPLATE") <(strip_block "$ADOPTED") >"$TMP_ROOT/drift.diff"; then
+    pass "the repo copy carries the shipped template verbatim"
+  else
+    fail "the repo copy has drifted from templates/review-bots.md — re-copy it, or move the change into the template
+$(sed 's/^/        /' "$TMP_ROOT/drift.diff" | head -20)"
+  fi
+
+  # MUST-FAIL CONTROLS. The comparison is only worth its verdict if it
+  # rejects the drift it exists for and admits the edit it exists to allow.
+  MUTATED="$TMP_ROOT/mutated.md"
+
+  sed "s/^## Review economics$/## Review economics, reworded/" "$ADOPTED" >"$MUTATED"
+  if diff -q <(strip_block "$TEMPLATE") <(strip_block "$MUTATED") >/dev/null; then
+    fail "control: an edit OUTSIDE the block passed the comparison"
+  else
+    pass "control: an edit outside the block is reported as drift"
+  fi
+
+  awk -v b="$BEGIN_MARKER" -v e="$END_MARKER" '
+    $0 == b { print; print ""; print "- **A residual only this repo has.** Do not re-raise."; skip = 1; next }
+    $0 == e { skip = 0 }
+    !skip
+  ' "$ADOPTED" >"$MUTATED"
+  if diff -q <(strip_block "$TEMPLATE") <(strip_block "$MUTATED") >/dev/null; then
+    pass "control: an edit inside the block is the repo's own and passes"
+  else
+    fail "control: an edit INSIDE the block was reported as drift"
+  fi
+fi
+
+echo
+printf 'passed: %d  failed: %d\n' "$PASS" "$FAIL"
+[[ "$FAIL" -eq 0 ]]

--- a/skills/review-gate/tests/review-bots-template.test.sh
+++ b/skills/review-gate/tests/review-bots-template.test.sh
@@ -48,22 +48,6 @@ strip_block() { # FILE
 line_of() { grep -nFx -- "$2" "$1" | cut -d: -f1; }
 count_of() { grep -cFx -- "$2" "$1" || true; }
 
-# Every engine path the guidance sends a bot to, repository-relative to the
-# installed skill. Prose ends a sentence right after a path, so a trailing
-# separator is not part of the name.
-refs_of() { # FILE
-  grep -oE '\.agents/skills/review-gate/[A-Za-z0-9._/-]+' "$1" |
-    sed -e 's#^\.agents/skills/review-gate/##' -e 's/[.,]$//' | sort -u
-}
-
-unresolved_refs() { # FILE, SKILL-ROOT
-  local rel
-  while IFS= read -r rel; do
-    [[ -n "$rel" ]] || continue
-    [[ -e "$2/$rel" ]] || printf '%s\n' "$rel"
-  done < <(refs_of "$1")
-}
-
 # ------------------------------------------------------------- the copies ---
 
 TEMPLATE="$SKILL_ROOT/templates/review-bots.md"
@@ -124,47 +108,6 @@ for i in "${!FILES[@]}"; do
     fi
   fi
 done
-
-echo "=== every engine path the guidance names resolves ==="
-
-for i in "${!FILES[@]}"; do
-  f="${FILES[$i]}"; tag="${LABELS[$i]}"
-  missing="$(unresolved_refs "$f" "$SKILL_ROOT")"
-  if [[ -z "$missing" ]]; then
-    pass "[$tag] every referenced engine path resolves"
-  else
-    fail "[$tag] the guidance sends bots to paths that do not exist:
-$(printf '%s\n' "$missing" | sed 's/^/        /')"
-  fi
-done
-
-# MUST-FAIL CONTROL: a renamed engine file must be reported. Materialize the
-# template's own reference set under a fake root, drop one, and read the arm's
-# answer — the real tree is never touched.
-if [[ -f "$TEMPLATE" ]]; then
-  REFROOT="$TMP_ROOT/refroot"
-  VICTIM=""
-  while IFS= read -r rel; do
-    [[ -n "$rel" ]] || continue
-    case "$rel" in
-      */) mkdir -p "$REFROOT/$rel" ;;
-      *) mkdir -p "$REFROOT/$(dirname "$rel")"; : >"$REFROOT/$rel"; [[ -n "$VICTIM" ]] || VICTIM="$rel" ;;
-    esac
-  done < <(refs_of "$TEMPLATE")
-
-  if [[ -z "$VICTIM" ]]; then
-    fail "control: the template names no engine FILE, so a rename could not be staged"
-  elif [[ -n "$(unresolved_refs "$TEMPLATE" "$REFROOT")" ]]; then
-    fail "control: the staged reference set does not resolve, so the rename below proves nothing"
-  else
-    mv "$REFROOT/$VICTIM" "$REFROOT/$VICTIM.renamed"
-    if [[ "$(unresolved_refs "$TEMPLATE" "$REFROOT")" == "$VICTIM" ]]; then
-      pass "control: renaming $VICTIM is reported, and nothing else is"
-    else
-      fail "control: renaming $VICTIM was not reported as the one unresolved path"
-    fi
-  fi
-fi
 
 echo "=== the repo copy is the template outside its own block ==="
 


### PR DESCRIPTION
## Summary

- `review-gate` ships `templates/review-bots.md`, the guidance addressed to the third-party review bots themselves. It carries review economics, the engine's own accepted residual classes, the trust model, and the reply contract, plus one `<!-- BEGIN/END repo-specific accepted residuals -->` block the consumer fills with its own. Copied verbatim like `templates/review-gate-writer.yml` — no placeholders, and repo-owned after the copy.
- Adoption wires it: `adoption.md` gains the copy step, a § Reviewer guidance section and a verification bullet; `SKILL.md` § 2 gains the copy and the naming step; `README.md` and `DEVELOPMENT.md` follow. Skill 2.1.0 → 2.2.0.
- kendex's own root `review-bots.md` is rebuilt from the template, with this repo's four residuals moved inside the block. `tests/review-bots-template.test.sh` compares the two byte-for-byte outside the block, so the shipped template cannot drift from the file this repo's bots actually read.

## Context

The engine's residual classes drifting out of step with the engine is the failure this prevents. memsira has carried a hand-written `review-bots.md` since the gate landed, and its accuracy has been a manual chore; every other consumer writes its own version or writes none.

One correction rides along: the old root file stated the docs-only carry-forward residual unconditionally, while `REVIEW_GATE_CARRY_FORWARD` is empty here. The template states it as conditional on that key, and the instruction-file half as conditional on `REVIEW_GATE_CARRY_FORWARD_EXCLUDE`.

`validate.sh` deliberately gains no check. A file with a consumer-owned block cannot be judged by equality, and the claim the template makes is about the engine, so the check lives in the engine's suite — the same split the template's own `validate-workflow.sh` residual describes.

## Completed Issues

- Closes #1729 - review-gate: ship the guidance addressed to the third-party review bots, not just the gate that reads them

## Review

Three internal cycles, two reviewer domains plus a cross-model external review. Nine findings fixed in `08e855148`, then one mechanism cut in `2fd1ccf1f`.

The cut is the notable one. A reference-resolution arm was added in cycle 1 to assert every engine path the guidance names resolves. In cycle 2 both reviewers independently showed the claim was false: it matched only the fully-prefixed `.agents/skills/review-gate/…` spelling, so a rename of `templates/review-gate-writer.yml` or `validate-workflow.sh` survived, and a reference respelled to the catalog form left the set rather than failing. Rather than widen the pattern a second time, the arm and its claim are gone. Both copies carry the correct `.agents/…` spelling today; a guard against respelling is a docs-lint rule spanning every engine reference doc, not an arm bolted onto one suite.

What survives is mutation-proven at killed 1/1 from both the catalog and the `.agents` spelling: the structure arms, the `OWNS_ENGINE` presence check (a missing root copy fails in the engine repo, notes in a consumer), the drift comparison, and both must-fail controls.

Declined: a block-preserving refresh script. The docs no longer claim a re-copy preserves the block — they state the manual contract instead, matching the `review-gate-writer.yml` precedent of repo-owned-after-copy.

## Test Plan

- `skills/review-gate/tests/review-bots-template.test.sh` — 7 assertions, green from both the catalog tree and the `.agents` render.
- Verified in a simulated consumer layout: before adoption, note plus 4 passed; after copying the template to its root, the full comparison at 7 passed, still green with a repo-specific residual added inside the block.
- `tools/guard` clean on each commit's own pre-commit chain; `preflight` clean; `kendex check --catalog .` 0 breakage, 0 advisory.

Note for the fleet: `crates/core/tests/process_guard_env.rs::a_guard_hook_relays_its_verdict` flakes with `ETXTBSY` when several worktrees run `tools/guard` at once (shared `/var/tmp/agents`). It failed twice here and passed 2/2 in isolation both times. Unrelated to this diff, which is markdown plus one shell test.
