### PR TITLE
feat(KEN-437): the sidebar foot says what the account read found

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,9 +34,9 @@ an outside contributor.
 - `REVIEW_GATE_CARRY_FORWARD` gains a `vendored` class: a `kendex refresh`
   push under the render trees a repo lists in `REVIEW_GATE_VENDORED_PATHS`
   carries the prior review, whatever the files' extensions.
-- The foot of the app's sidebar shows your kendex.ai account: the GitHub
-  handle when the server confirms it, Offline when it could not be reached,
-  and a quiet Sign in when there is nothing to show. Clicking opens Settings.
+- The foot of the app's sidebar says whether you are signed in to kendex.ai,
+  and clicking it opens Settings. It offers a quiet Sign in when you are not,
+  and says so with nothing to press when the check did not land.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,9 +34,9 @@ an outside contributor.
 - `REVIEW_GATE_CARRY_FORWARD` gains a `vendored` class: a `kendex refresh`
   push under the render trees a repo lists in `REVIEW_GATE_VENDORED_PATHS`
   carries the prior review, whatever the files' extensions.
-- The foot of the app's sidebar says whether you are signed in to kendex.ai,
-  and clicking it opens Settings. It offers a quiet Sign in when you are not,
-  and says so with nothing to press when the check did not land.
+- The foot of the app's sidebar names the kendex.ai account you are signed
+  in to, says Offline when the server could not be reached, and offers Sign
+  in or Sign in again as the credential needs. Clicking opens Settings.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,9 @@ an outside contributor.
 - `REVIEW_GATE_CARRY_FORWARD` gains a `vendored` class: a `kendex refresh`
   push under the render trees a repo lists in `REVIEW_GATE_VENDORED_PATHS`
   carries the prior review, whatever the files' extensions.
+- The foot of the app's sidebar shows your kendex.ai account: the GitHub
+  handle when the server confirms it, Offline when it could not be reached,
+  and a quiet Sign in when there is nothing to show. Clicking opens Settings.
 
 ### Changed
 

--- a/ui/src/components/sidebar-account.dom.test.tsx
+++ b/ui/src/components/sidebar-account.dom.test.tsx
@@ -25,6 +25,22 @@ const show = (account: AccountState, readError: string | null = null) => {
   return mount(<SidebarAccount />);
 };
 
+/** The row itself, which is the gutter wrapper's only child. */
+const rowOf = (host: HTMLElement): HTMLElement => {
+  const row = host.firstElementChild?.firstElementChild;
+  if (!(row instanceof HTMLElement))
+    throw new Error("no account row on screen");
+  return row;
+};
+
+/** The states a read can settle on, each named for the message it fails in. */
+const SETTLED: [string, AccountState][] = [
+  ["signed-in", { kind: "signed-in", identity: ADA }],
+  ["signed-out", { kind: "signed-out" }],
+  ["expired", { kind: "expired" }],
+  ["offline", { kind: "offline", identity: ADA }],
+];
+
 beforeEach(() => {
   useAccountStore.setState({ account: { kind: "loading" }, readError: null });
   useNavStore.setState({ page: "home", history: [], future: [] });
@@ -36,11 +52,14 @@ describe("what the account row draws", () => {
   });
 
   it("says a read failed rather than showing a signed-out row", () => {
-    const row = show({ kind: "loading" }, "no network");
-    expect(row.textContent).toContain(ACCOUNT_UNREADABLE_LABEL);
-    expect(row.textContent).not.toContain(ACCOUNT_SIGN_IN_LABEL);
-    // The retry for a failed read belongs to Settings, not to this row.
-    expect(row.querySelector("button")).toBeNull();
+    const host = show({ kind: "loading" }, "no network");
+    expect(host.textContent).toContain(ACCOUNT_UNREADABLE_LABEL);
+    expect(host.textContent).not.toContain(ACCOUNT_SIGN_IN_LABEL);
+    // Nothing here retries a read: the startup effect does that on focus.
+    expect(host.querySelector("button")).toBeNull();
+    // The label says a read failed; the tooltip is the only place the
+    // reason for it reaches a person.
+    expect(rowOf(host).title).toBe("no network");
   });
 
   it("offers a quiet sign-in when signed out", () => {
@@ -78,20 +97,28 @@ describe("what the account row draws", () => {
 });
 
 describe("where the row leads", () => {
-  it("opens the settings page from a signed-in row", async () => {
-    const row = show({ kind: "signed-in", identity: ADA });
-    const button = row.querySelector("button");
-    if (!button) throw new Error("the signed-in row is not clickable");
-    await userEvent.click(button);
-    expect(useNavStore.getState().page).toBe("settings");
-  });
+  it.each(SETTLED)(
+    "opens the settings page from the %s row",
+    async (_state, account) => {
+      const host = show(account);
+      const button = host.querySelector("button");
+      if (!button) throw new Error("the row is not clickable");
+      await userEvent.click(button);
+      expect(useNavStore.getState().page).toBe("settings");
+    },
+  );
+});
 
-  it("opens the settings page from a signed-out row", async () => {
-    const row = show({ kind: "signed-out" });
-    const button = row.querySelector("button");
-    if (!button) throw new Error("the signed-out row is not clickable");
-    await userEvent.click(button);
-    expect(useNavStore.getState().page).toBe("settings");
+// A read that fails after one that landed changes no state: it leaves the
+// account exactly as the last good answer left it and records only why it
+// could not be repeated. Without the cause on the row, the same failure
+// would be loud before the first answer and silent ever after.
+describe("a read that failed after one that landed", () => {
+  it.each(SETTLED)("marks the %s row with the cause", (_state, account) => {
+    const clean = rowOf(show(account)).title;
+    const failed = rowOf(show(account, "keychain locked")).title;
+    expect(failed).toBe("keychain locked");
+    expect(failed).not.toBe(clean);
   });
 });
 
@@ -112,6 +139,15 @@ describe("the letter on the avatar", () => {
 
   it("has no letter for an account with no identity", () => {
     expect(accountInitial(null)).toBeNull();
+  });
+
+  // The circle wants a glyph, not text cased in whatever locale the app is
+  // running under: a Turkish locale cases an "i" into a dotted capital,
+  // which is not the letter this avatar is for.
+  it("uppercases the same letter whatever locale the app runs under", () => {
+    const initial = accountInitial({ name: "ilhan", githubLogin: "x" });
+    expect(initial).toBe("I");
+    expect(initial).not.toBe("i".toLocaleUpperCase("tr"));
   });
 
   it("keeps a first character that is a surrogate pair whole", () => {

--- a/ui/src/components/sidebar-account.dom.test.tsx
+++ b/ui/src/components/sidebar-account.dom.test.tsx
@@ -162,6 +162,24 @@ describe("how the sentence behind a row reaches a person", () => {
     expect(document.activeElement).toBe(row);
   });
 
+  // A button announces something to press. The failed read has nothing to
+  // press, so the row that reports it must not claim otherwise while still
+  // being the only place its sentence lives.
+  it("offers no button to press from a failed read", () => {
+    const host = show({ kind: "loading" }, "no network");
+    expect(rowOf(host).tagName).not.toBe("BUTTON");
+    expect(rowOf(host).getAttribute("role")).not.toBe("button");
+    expect(host.querySelector("button")).toBeNull();
+    expect(spoken(host)).toBe("no network");
+  });
+
+  it.each(SETTLED)(
+    "keeps the %s row a button, since it acts",
+    (_s, account) => {
+      expect(rowOf(show(account)).tagName).toBe("BUTTON");
+    },
+  );
+
   it.each(SETTLED)("leaves no native tooltip on the %s row", (_s, account) => {
     const host = show(account, "keychain locked");
     expect(host.querySelectorAll("[title]")).toHaveLength(0);
@@ -210,8 +228,28 @@ describe("a read that failed after one that landed", () => {
 });
 
 describe("the letter on the avatar", () => {
+  const named = (name: string) => accountInitial({ name, githubLogin: null });
+
   it("takes the name's first letter", () => {
     expect(accountInitial(ADA)).toBe("A");
+  });
+
+  // The accent is part of the letter a reader sees, whether the server sent
+  // one character or a base letter and a combining mark.
+  it("keeps a combining mark with the letter it belongs to", () => {
+    expect(named("e\u0301lodie")).toBe("E\u0301");
+    expect(named("élodie")).toBe("É");
+  });
+
+  // Casing can widen what it is given: this one letter uppercases to two,
+  // and the circle holds one.
+  it("keeps one letter when casing expands it", () => {
+    expect(named("ßeta")).toBe("S");
+  });
+
+  // Every part of the sequence or none: half an emoji is a different emoji.
+  it("keeps a multi-part emoji whole", () => {
+    expect(named("👩‍🚀 crew")).toBe("👩‍🚀");
   });
 
   // A name the server sent as blank is no name at all, and the provider id
@@ -225,6 +263,6 @@ describe("the letter on the avatar", () => {
   });
 
   it("keeps a first character that is a surrogate pair whole", () => {
-    expect(accountInitial({ name: "𝔄da", githubLogin: null })).toBe("𝔄");
+    expect(named("𝔄da")).toBe("𝔄");
   });
 });

--- a/ui/src/components/sidebar-account.dom.test.tsx
+++ b/ui/src/components/sidebar-account.dom.test.tsx
@@ -1,0 +1,120 @@
+// @vitest-environment jsdom
+// The account row says what the last read settled on and nothing more. What
+// these tests hold to is the difference between a stored credential and a
+// confirmed one, and between a read that has not landed and one that failed.
+import userEvent from "@testing-library/user-event";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  ACCOUNT_OFFLINE_LABEL,
+  ACCOUNT_SIGN_IN_AGAIN_LABEL,
+  ACCOUNT_SIGN_IN_LABEL,
+  ACCOUNT_SIGNED_IN_LABEL,
+  ACCOUNT_UNREADABLE_LABEL,
+} from "@/lib/copy";
+import { type AccountState, useAccountStore } from "@/stores/account";
+import { useNavStore } from "@/stores/nav";
+import { mount } from "@/test/dom";
+import { accountInitial, SidebarAccount } from "./sidebar-account";
+
+vi.mock("@/bindings", () => ({ commands: {} }));
+
+const ADA = { name: "Ada Lovelace", githubLogin: "ada" };
+
+const show = (account: AccountState, readError: string | null = null) => {
+  useAccountStore.setState({ account, readError });
+  return mount(<SidebarAccount />);
+};
+
+beforeEach(() => {
+  useAccountStore.setState({ account: { kind: "loading" }, readError: null });
+  useNavStore.setState({ page: "home", history: [], future: [] });
+});
+
+describe("what the account row draws", () => {
+  it("draws nothing while the first read is still out", () => {
+    expect(show({ kind: "loading" }).textContent).toBe("");
+  });
+
+  it("says a read failed rather than showing a signed-out row", () => {
+    const row = show({ kind: "loading" }, "no network");
+    expect(row.textContent).toContain(ACCOUNT_UNREADABLE_LABEL);
+    expect(row.textContent).not.toContain(ACCOUNT_SIGN_IN_LABEL);
+    // The retry for a failed read belongs to Settings, not to this row.
+    expect(row.querySelector("button")).toBeNull();
+  });
+
+  it("offers a quiet sign-in when signed out", () => {
+    expect(show({ kind: "signed-out" }).textContent).toBe(
+      ACCOUNT_SIGN_IN_LABEL,
+    );
+  });
+
+  it("asks for a fresh sign-in when the credential is expired", () => {
+    expect(show({ kind: "expired" }).textContent).toBe(
+      ACCOUNT_SIGN_IN_AGAIN_LABEL,
+    );
+  });
+
+  it("shows the handle and its initial when signed in", () => {
+    const row = show({ kind: "signed-in", identity: ADA });
+    expect(row.textContent).toContain("ada");
+    expect(row.textContent).toContain("A");
+    expect(row.textContent).not.toContain(ACCOUNT_OFFLINE_LABEL);
+  });
+
+  // A credential in the keychain is not a person: the row may say it is
+  // signed in, but it must not put a name or a letter to an account the
+  // server has not named.
+  it("names nobody when the credential has no identity yet", () => {
+    const row = show({ kind: "signed-in", identity: null });
+    expect(row.textContent).toBe(ACCOUNT_SIGNED_IN_LABEL);
+  });
+
+  it("reads as offline when the credential could not be confirmed", () => {
+    const row = show({ kind: "offline", identity: ADA });
+    expect(row.textContent).toContain("ada");
+    expect(row.textContent).toContain(ACCOUNT_OFFLINE_LABEL);
+  });
+});
+
+describe("where the row leads", () => {
+  it("opens the settings page from a signed-in row", async () => {
+    const row = show({ kind: "signed-in", identity: ADA });
+    const button = row.querySelector("button");
+    if (!button) throw new Error("the signed-in row is not clickable");
+    await userEvent.click(button);
+    expect(useNavStore.getState().page).toBe("settings");
+  });
+
+  it("opens the settings page from a signed-out row", async () => {
+    const row = show({ kind: "signed-out" });
+    const button = row.querySelector("button");
+    if (!button) throw new Error("the signed-out row is not clickable");
+    await userEvent.click(button);
+    expect(useNavStore.getState().page).toBe("settings");
+  });
+});
+
+describe("the letter on the avatar", () => {
+  it("takes the name's first letter", () => {
+    expect(accountInitial(ADA)).toBe("A");
+  });
+
+  it("falls back to the handle when there is no name", () => {
+    expect(accountInitial({ name: null, githubLogin: "ada" })).toBe("A");
+  });
+
+  // A name the server sent as blank is no name at all, so it falls through
+  // rather than putting a space on the circle.
+  it("falls back to the handle when the name is blank", () => {
+    expect(accountInitial({ name: "   ", githubLogin: "grace" })).toBe("G");
+  });
+
+  it("has no letter for an account with no identity", () => {
+    expect(accountInitial(null)).toBeNull();
+  });
+
+  it("keeps a first character that is a surrogate pair whole", () => {
+    expect(accountInitial({ name: "𝔄da", githubLogin: "ada" })).toBe("𝔄");
+  });
+});

--- a/ui/src/components/sidebar-account.dom.test.tsx
+++ b/ui/src/components/sidebar-account.dom.test.tsx
@@ -5,7 +5,9 @@
 import userEvent from "@testing-library/user-event";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import {
+  ACCOUNT_EXPIRED_TITLE,
   ACCOUNT_OFFLINE_LABEL,
+  ACCOUNT_OFFLINE_TITLE,
   ACCOUNT_SIGN_IN_AGAIN_LABEL,
   ACCOUNT_SIGN_IN_LABEL,
   ACCOUNT_SIGNED_IN_LABEL,
@@ -32,6 +34,20 @@ const rowOf = (host: HTMLElement): HTMLElement => {
     throw new Error("no account row on screen");
   return row;
 };
+
+/** The row's text column, which is the second thing in the row. */
+const labelOf = (host: HTMLElement): HTMLElement => {
+  const label = rowOf(host).children[1];
+  if (!(label instanceof HTMLElement))
+    throw new Error("no label in the account row");
+  return label;
+};
+
+/** The two rows that show a handle, and so have a tooltip of their own. */
+const WITH_HANDLE: [string, AccountState][] = [
+  ["signed-in", { kind: "signed-in", identity: ADA }],
+  ["offline", { kind: "offline", identity: ADA }],
+];
 
 /** The states a read can settle on, each named for the message it fails in. */
 const SETTLED: [string, AccountState][] = [
@@ -117,9 +133,34 @@ describe("a read that failed after one that landed", () => {
   it.each(SETTLED)("marks the %s row with the cause", (_state, account) => {
     const clean = rowOf(show(account)).title;
     const failed = rowOf(show(account, "keychain locked")).title;
-    expect(failed).toBe("keychain locked");
+    expect(failed).toContain("keychain locked");
     expect(failed).not.toBe(clean);
   });
+
+  // A rejected credential and a read that could not be made are different
+  // answers. Where the row's own sentence is the only thing explaining what
+  // it draws, a later failure joins it rather than taking its place.
+  it.each([
+    ["expired", { kind: "expired" }, ACCOUNT_EXPIRED_TITLE],
+    ["offline", { kind: "offline", identity: ADA }, ACCOUNT_OFFLINE_TITLE],
+  ] as [string, AccountState, string][])(
+    "keeps the %s row's own explanation beside the cause",
+    (_state, account, sentence) => {
+      const title = rowOf(show(account, "keychain locked")).title;
+      expect(title).toContain(sentence);
+      expect(title).toContain("keychain locked");
+    },
+  );
+
+  // The label covers most of the row, so its own tooltip would answer the
+  // hover with the handle and the cause would reach nobody.
+  it.each(WITH_HANDLE)(
+    "drops the %s row's handle tooltip while a read has failed",
+    (_state, account) => {
+      expect(labelOf(show(account)).title).toBe(ADA.githubLogin);
+      expect(labelOf(show(account, "keychain locked")).title).toBe("");
+    },
+  );
 });
 
 describe("the letter on the avatar", () => {
@@ -139,15 +180,6 @@ describe("the letter on the avatar", () => {
 
   it("has no letter for an account with no identity", () => {
     expect(accountInitial(null)).toBeNull();
-  });
-
-  // The circle wants a glyph, not text cased in whatever locale the app is
-  // running under: a Turkish locale cases an "i" into a dotted capital,
-  // which is not the letter this avatar is for.
-  it("uppercases the same letter whatever locale the app runs under", () => {
-    const initial = accountInitial({ name: "ilhan", githubLogin: "x" });
-    expect(initial).toBe("I");
-    expect(initial).not.toBe("i".toLocaleUpperCase("tr"));
   });
 
   it("keeps a first character that is a surrogate pair whole", () => {

--- a/ui/src/components/sidebar-account.dom.test.tsx
+++ b/ui/src/components/sidebar-account.dom.test.tsx
@@ -8,6 +8,7 @@ import {
   ACCOUNT_EXPIRED_TITLE,
   ACCOUNT_OFFLINE_LABEL,
   ACCOUNT_OFFLINE_TITLE,
+  ACCOUNT_ROW_TITLE,
   ACCOUNT_SIGN_IN_AGAIN_LABEL,
   ACCOUNT_SIGN_IN_LABEL,
   ACCOUNT_SIGNED_IN_LABEL,
@@ -20,7 +21,9 @@ import { accountInitial, SidebarAccount } from "./sidebar-account";
 
 vi.mock("@/bindings", () => ({ commands: {} }));
 
-const ADA = { name: "Ada Lovelace", githubLogin: "ada" };
+// The provider's account id is an opaque number, not a handle. Every
+// fixture spells it that way so a test cannot pass by showing one.
+const ADA = { name: "Ada Lovelace", githubLogin: "1234567" };
 
 const show = (account: AccountState, readError: string | null = null) => {
   useAccountStore.setState({ account, readError });
@@ -35,19 +38,18 @@ const rowOf = (host: HTMLElement): HTMLElement => {
   return row;
 };
 
-/** The row's text column, which is the second thing in the row. */
-const labelOf = (host: HTMLElement): HTMLElement => {
-  const label = rowOf(host).children[1];
-  if (!(label instanceof HTMLElement))
-    throw new Error("no label in the account row");
-  return label;
-};
+/** What the row puts on screen, without the sentence written for a screen
+ *  reader. */
+const seen = (host: HTMLElement): string =>
+  [...rowOf(host).children]
+    .filter((child) => !child.classList.contains("sr-only"))
+    .map((child) => child.textContent)
+    .join("");
 
-/** The two rows that show a handle, and so have a tooltip of their own. */
-const WITH_HANDLE: [string, AccountState][] = [
-  ["signed-in", { kind: "signed-in", identity: ADA }],
-  ["offline", { kind: "offline", identity: ADA }],
-];
+/** The sentence behind the row: the tooltip's words, which the trigger also
+ *  carries as its own text so a screen reader reaches them. */
+const spoken = (host: HTMLElement): string =>
+  rowOf(host).querySelector(".sr-only")?.textContent ?? "";
 
 /** The states a read can settle on, each named for the message it fails in. */
 const SETTLED: [string, AccountState][] = [
@@ -69,46 +71,65 @@ describe("what the account row draws", () => {
 
   it("says a read failed rather than showing a signed-out row", () => {
     const host = show({ kind: "loading" }, "no network");
-    expect(host.textContent).toContain(ACCOUNT_UNREADABLE_LABEL);
-    expect(host.textContent).not.toContain(ACCOUNT_SIGN_IN_LABEL);
-    // Nothing here retries a read: the startup effect does that on focus.
-    expect(host.querySelector("button")).toBeNull();
-    // The label says a read failed; the tooltip is the only place the
-    // reason for it reaches a person.
-    expect(rowOf(host).title).toBe("no network");
+    expect(seen(host)).toContain(ACCOUNT_UNREADABLE_LABEL);
+    expect(seen(host)).not.toContain(ACCOUNT_SIGN_IN_LABEL);
+    expect(spoken(host)).toBe("no network");
+  });
+
+  // Nothing here retries a read, and nothing here routes to a page that
+  // would claim to know an account state this row could not read.
+  it("goes nowhere from a failed read", async () => {
+    const host = show({ kind: "loading" }, "no network");
+    await userEvent.click(rowOf(host));
+    expect(useNavStore.getState().page).toBe("home");
   });
 
   it("offers a quiet sign-in when signed out", () => {
-    expect(show({ kind: "signed-out" }).textContent).toBe(
-      ACCOUNT_SIGN_IN_LABEL,
-    );
+    expect(seen(show({ kind: "signed-out" }))).toBe(ACCOUNT_SIGN_IN_LABEL);
   });
 
   it("asks for a fresh sign-in when the credential is expired", () => {
-    expect(show({ kind: "expired" }).textContent).toBe(
-      ACCOUNT_SIGN_IN_AGAIN_LABEL,
-    );
+    expect(seen(show({ kind: "expired" }))).toBe(ACCOUNT_SIGN_IN_AGAIN_LABEL);
   });
 
-  it("shows the handle and its initial when signed in", () => {
-    const row = show({ kind: "signed-in", identity: ADA });
-    expect(row.textContent).toContain("ada");
-    expect(row.textContent).toContain("A");
-    expect(row.textContent).not.toContain(ACCOUNT_OFFLINE_LABEL);
+  it("shows the name and its initial when signed in", () => {
+    const host = show({ kind: "signed-in", identity: ADA });
+    expect(seen(host)).toContain(ADA.name);
+    expect(seen(host)).toContain("A");
+    expect(seen(host)).not.toContain(ACCOUNT_OFFLINE_LABEL);
   });
+
+  // The field is the provider's immutable account id, not a handle. It is
+  // nobody's name and belongs nowhere a person can read it.
+  it.each(SETTLED)(
+    "never shows the %s row's provider id",
+    (_state, account) => {
+      expect(show(account).textContent).not.toContain(ADA.githubLogin);
+    },
+  );
 
   // A credential in the keychain is not a person: the row may say it is
   // signed in, but it must not put a name or a letter to an account the
   // server has not named.
   it("names nobody when the credential has no identity yet", () => {
-    const row = show({ kind: "signed-in", identity: null });
-    expect(row.textContent).toBe(ACCOUNT_SIGNED_IN_LABEL);
+    expect(seen(show({ kind: "signed-in", identity: null }))).toBe(
+      ACCOUNT_SIGNED_IN_LABEL,
+    );
+  });
+
+  // The server answers with a String, so a blank one is a name it does not
+  // have rather than a field it did not send.
+  it("names nobody when the server sent a blank name", () => {
+    const blank = { name: "  ", githubLogin: "1234567" };
+    expect(seen(show({ kind: "signed-in", identity: blank }))).toBe(
+      ACCOUNT_SIGNED_IN_LABEL,
+    );
   });
 
   it("reads as offline when the credential could not be confirmed", () => {
-    const row = show({ kind: "offline", identity: ADA });
-    expect(row.textContent).toContain("ada");
-    expect(row.textContent).toContain(ACCOUNT_OFFLINE_LABEL);
+    const host = show({ kind: "offline", identity: ADA });
+    expect(seen(host)).toContain(ADA.name);
+    expect(seen(host)).toContain(ACCOUNT_OFFLINE_LABEL);
   });
 });
 
@@ -125,14 +146,36 @@ describe("where the row leads", () => {
   );
 });
 
+// The reason a row reads the way it does must reach a keyboard and a screen
+// reader, not a pointer alone: the trigger takes focus and carries the words
+// as its own text, and no row leaves them to a native tooltip.
+describe("how the sentence behind a row reaches a person", () => {
+  it.each(SETTLED)("focuses the %s row", (_state, account) => {
+    const row = rowOf(show(account));
+    row.focus();
+    expect(document.activeElement).toBe(row);
+  });
+
+  it("focuses the row a failed read leaves", () => {
+    const row = rowOf(show({ kind: "loading" }, "no network"));
+    row.focus();
+    expect(document.activeElement).toBe(row);
+  });
+
+  it.each(SETTLED)("leaves no native tooltip on the %s row", (_s, account) => {
+    const host = show(account, "keychain locked");
+    expect(host.querySelectorAll("[title]")).toHaveLength(0);
+  });
+});
+
 // A read that fails after one that landed changes no state: it leaves the
 // account exactly as the last good answer left it and records only why it
 // could not be repeated. Without the cause on the row, the same failure
 // would be loud before the first answer and silent ever after.
 describe("a read that failed after one that landed", () => {
   it.each(SETTLED)("marks the %s row with the cause", (_state, account) => {
-    const clean = rowOf(show(account)).title;
-    const failed = rowOf(show(account, "keychain locked")).title;
+    const clean = spoken(show(account));
+    const failed = spoken(show(account, "keychain locked"));
     expect(failed).toContain("keychain locked");
     expect(failed).not.toBe(clean);
   });
@@ -146,19 +189,22 @@ describe("a read that failed after one that landed", () => {
   ] as [string, AccountState, string][])(
     "keeps the %s row's own explanation beside the cause",
     (_state, account, sentence) => {
-      const title = rowOf(show(account, "keychain locked")).title;
-      expect(title).toContain(sentence);
-      expect(title).toContain("keychain locked");
+      const words = spoken(show(account, "keychain locked"));
+      expect(words).toContain(sentence);
+      expect(words).toContain("keychain locked");
     },
   );
 
-  // The label covers most of the row, so its own tooltip would answer the
-  // hover with the handle and the cause would reach nobody.
-  it.each(WITH_HANDLE)(
-    "drops the %s row's handle tooltip while a read has failed",
+  // The other two rows explain nothing beyond the click they offer, so the
+  // cause takes that hint's place rather than trailing it.
+  it.each([
+    ["signed-in", { kind: "signed-in", identity: ADA }],
+    ["signed-out", { kind: "signed-out" }],
+  ] as [string, AccountState][])(
+    "replaces the %s row's affordance hint with the cause",
     (_state, account) => {
-      expect(labelOf(show(account)).title).toBe(ADA.githubLogin);
-      expect(labelOf(show(account, "keychain locked")).title).toBe("");
+      expect(spoken(show(account))).toBe(ACCOUNT_ROW_TITLE);
+      expect(spoken(show(account, "keychain locked"))).toBe("keychain locked");
     },
   );
 });
@@ -168,14 +214,10 @@ describe("the letter on the avatar", () => {
     expect(accountInitial(ADA)).toBe("A");
   });
 
-  it("falls back to the handle when there is no name", () => {
-    expect(accountInitial({ name: null, githubLogin: "ada" })).toBe("A");
-  });
-
-  // A name the server sent as blank is no name at all, so it falls through
-  // rather than putting a space on the circle.
-  it("falls back to the handle when the name is blank", () => {
-    expect(accountInitial({ name: "   ", githubLogin: "grace" })).toBe("G");
+  // A name the server sent as blank is no name at all, and the provider id
+  // is not a stand-in for one: the circle stays empty.
+  it("has no letter for a blank name", () => {
+    expect(accountInitial({ name: "   ", githubLogin: "1234567" })).toBeNull();
   });
 
   it("has no letter for an account with no identity", () => {
@@ -183,6 +225,6 @@ describe("the letter on the avatar", () => {
   });
 
   it("keeps a first character that is a surrogate pair whole", () => {
-    expect(accountInitial({ name: "𝔄da", githubLogin: "ada" })).toBe("𝔄");
+    expect(accountInitial({ name: "𝔄da", githubLogin: null })).toBe("𝔄");
   });
 });

--- a/ui/src/components/sidebar-account.tsx
+++ b/ui/src/components/sidebar-account.tsx
@@ -31,16 +31,30 @@ import { useNavStore } from "@/stores/nav";
 const displayName = (identity: AccountIdentity | null): string =>
   identity?.name.trim() ?? "";
 
+/** What a reader would call the first character: a base letter with the
+ *  marks that belong to it, an emoji with every part of its sequence, and a
+ *  character outside the BMP whole rather than halved. Grapheme breaking
+ *  does not turn on the locale, so the default one answers the same
+ *  everywhere. */
+const graphemes = new Intl.Segmenter(undefined, { granularity: "grapheme" });
+
+const firstGrapheme = (text: string): string => {
+  for (const { segment } of graphemes.segment(text)) return segment;
+  return "";
+};
+
 /** The letter on the avatar, and nothing where there is no name to take it
- *  from. Split by code point so a first character outside the BMP survives
- *  being taken apart, and cased by the plain call rather than the
- *  locale-aware one, whose no-argument form is host-dependent by
- *  specification: the circle wants one glyph, the same everywhere. */
+ *  from.
+ *
+ *  Cased by the plain call rather than the locale-aware one, whose
+ *  no-argument form is host-dependent by specification. Segmented again
+ *  after casing because a case mapping can widen what it is given: the
+ *  German sharp s uppercases to two letters, and the circle holds one. */
 export function accountInitial(
   identity: AccountIdentity | null,
 ): string | null {
-  const [first] = [...displayName(identity)];
-  return first ? first.toUpperCase() : null;
+  const first = firstGrapheme(displayName(identity));
+  return first ? firstGrapheme(first.toUpperCase()) : null;
 }
 
 /** The circle in the icon lane. It carries a letter once the server has
@@ -64,8 +78,9 @@ function Avatar({ identity }: { identity: AccountIdentity | null }) {
  *  a screen reader. A native title reaches none of the last two, and on the
  *  failed-read row the sentence is the only place the reason lives.
  *
- *  A row with nowhere to go is still a trigger. It presses to nothing, which
- *  is the honest answer while the account cannot be read at all. */
+ *  A row with nowhere to go is still a trigger, and it is not a button:
+ *  a button that presses to nothing is an offer the app cannot keep, so the
+ *  inert row is a focusable line of text instead. */
 function Row({
   onClick,
   tip,
@@ -75,16 +90,26 @@ function Row({
   tip: string;
   children: ReactNode;
 }) {
+  const shape = cn(
+    SIDEBAR_ROW,
+    "w-full text-sm text-muted-foreground outline-none focus-visible:ring-[3px] focus-visible:ring-ring/50",
+    onClick &&
+      "transition-colors hover:bg-sidebar-accent/40 hover:text-foreground",
+  );
   return (
     <Tooltip>
       <TooltipTrigger
         onClick={onClick}
-        className={cn(
-          SIDEBAR_ROW,
-          "w-full text-sm text-muted-foreground outline-none focus-visible:ring-[3px] focus-visible:ring-ring/50",
-          onClick &&
-            "transition-colors hover:bg-sidebar-accent/40 hover:text-foreground",
-        )}
+        className={shape}
+        // The trigger's default element is a button, which is right for the
+        // rows that navigate and wrong for the one that does not. Focus is
+        // what the inert row needs, and a tab stop is not a press.
+        render={
+          onClick ? undefined : (
+            // biome-ignore lint/a11y/noNoninteractiveTabindex: a tooltip trigger is reached by keyboard or its sentence reaches nobody, and ARIA has no interactive role for one that does not act
+            <div tabIndex={0} />
+          )
+        }
       >
         {children}
         <span className="sr-only">{tip}</span>

--- a/ui/src/components/sidebar-account.tsx
+++ b/ui/src/components/sidebar-account.tsx
@@ -1,0 +1,191 @@
+import { CircleAlert, LogIn } from "lucide-react";
+import type { ReactNode } from "react";
+import {
+  ACCOUNT_EXPIRED_TITLE,
+  ACCOUNT_OFFLINE_LABEL,
+  ACCOUNT_OFFLINE_TITLE,
+  ACCOUNT_ROW_TITLE,
+  ACCOUNT_SIGN_IN_AGAIN_LABEL,
+  ACCOUNT_SIGN_IN_LABEL,
+  ACCOUNT_SIGNED_IN_LABEL,
+  ACCOUNT_UNREADABLE_LABEL,
+} from "@/lib/copy";
+import { SIDEBAR_ROW } from "@/lib/layout";
+import { cn } from "@/lib/utils";
+import {
+  type AccountIdentity,
+  type AccountState,
+  useAccountStore,
+} from "@/stores/account";
+import { useNavStore } from "@/stores/nav";
+
+/** The letter on the avatar: the name's first, the handle's where there is
+ *  no name, and nothing where the account has neither. A blank name is no
+ *  name, which is why the fallback runs on the empty string as well as on a
+ *  missing one. Split by code point so a first character outside the BMP
+ *  survives being taken apart. */
+export function accountInitial(
+  identity: AccountIdentity | null,
+): string | null {
+  const source = identity?.name?.trim() || identity?.githubLogin.trim() || "";
+  const [first] = [...source];
+  return first ? first.toLocaleUpperCase() : null;
+}
+
+/** The circle in the icon lane. It carries a letter once the server has
+ *  named the account and stays empty until then: a stored credential is not
+ *  a person, and inventing an initial for one would claim it is. */
+function Avatar({ identity }: { identity: AccountIdentity | null }) {
+  return (
+    <span
+      aria-hidden
+      className="flex size-[18px] shrink-0 items-center justify-center rounded-full bg-foreground/[0.12] text-[10px] font-semibold leading-none"
+    >
+      {accountInitial(identity)}
+    </span>
+  );
+}
+
+/** One account row. A button wherever there is somewhere to go, plain text
+ *  where the app has nothing to offer. */
+function Row({
+  onClick,
+  title,
+  children,
+}: {
+  onClick?: () => void;
+  title?: string;
+  children: ReactNode;
+}) {
+  const shape = cn(SIDEBAR_ROW, "w-full text-sm text-muted-foreground");
+  if (!onClick)
+    return (
+      <div className={shape} title={title}>
+        {children}
+      </div>
+    );
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      title={title}
+      className={cn(
+        shape,
+        "transition-colors hover:bg-sidebar-accent/40 hover:text-foreground",
+      )}
+    >
+      {children}
+    </button>
+  );
+}
+
+/** The text column. It takes whatever the icon lane leaves and cuts a long
+ *  handle off rather than pushing the row wider than the sidebar. */
+function Label({
+  mono,
+  title,
+  className,
+  children,
+}: {
+  mono?: boolean;
+  /** What a truncated line says in full. A handle wide enough to be cut is
+   *  the only line here long enough to need it. */
+  title?: string;
+  className?: string;
+  children: ReactNode;
+}) {
+  return (
+    <span
+      title={title}
+      className={cn(
+        "min-w-0 flex-1 truncate text-left",
+        mono && "font-mono",
+        className,
+      )}
+    >
+      {children}
+    </span>
+  );
+}
+
+/** Which row each account state draws.
+ *
+ *  The state decides on its own: a credential in the keychain is not a
+ *  confirmed sign-in, so an unconfirmed one reads as offline and one the
+ *  server has rejected asks to sign in again. `readError` only separates the
+ *  two ways a read can have failed to land. */
+function accountRow(
+  account: AccountState,
+  readError: string | null,
+  open: () => void,
+): ReactNode {
+  if (account.kind === "loading")
+    // A read that failed says that much. One still on its way draws no row
+    // rather than guessing which of the four answers is coming.
+    return readError === null ? null : (
+      <Row title={readError}>
+        <CircleAlert className="size-[18px] shrink-0 opacity-70" />
+        {/* The only line long enough to need the smaller step: at the nav's
+            size it would truncate inside a 224px column, and half a
+            sentence about a failure is worse than none. */}
+        <Label className="text-xs">{ACCOUNT_UNREADABLE_LABEL}</Label>
+      </Row>
+    );
+
+  switch (account.kind) {
+    case "signed-out":
+      return (
+        <Row onClick={open} title={ACCOUNT_ROW_TITLE}>
+          <LogIn className="size-[18px] shrink-0 opacity-70" />
+          <Label>{ACCOUNT_SIGN_IN_LABEL}</Label>
+        </Row>
+      );
+    case "expired":
+      return (
+        <Row onClick={open} title={ACCOUNT_EXPIRED_TITLE}>
+          <LogIn className="size-[18px] shrink-0 opacity-70" />
+          <Label>{ACCOUNT_SIGN_IN_AGAIN_LABEL}</Label>
+        </Row>
+      );
+    case "signed-in": {
+      const handle = account.identity?.githubLogin.trim();
+      return (
+        <Row onClick={open} title={ACCOUNT_ROW_TITLE}>
+          <Avatar identity={account.identity} />
+          <Label mono={Boolean(handle)} title={handle}>
+            {handle || ACCOUNT_SIGNED_IN_LABEL}
+          </Label>
+        </Row>
+      );
+    }
+    case "offline":
+      return (
+        <Row onClick={open} title={ACCOUNT_OFFLINE_TITLE}>
+          <Avatar identity={account.identity} />
+          <Label mono title={account.identity.githubLogin}>
+            {account.identity.githubLogin}
+          </Label>
+          <span className="shrink-0 text-xs">{ACCOUNT_OFFLINE_LABEL}</span>
+        </Row>
+      );
+  }
+
+  // A sixth account state has to be drawn above before this compiles.
+  const undrawn: never = account;
+  return undrawn;
+}
+
+/**
+ * The foot of the sidebar: who the last account read found, and the way in
+ * to the account settings. The retry for a read that failed belongs to that
+ * page, not to this row.
+ */
+export function SidebarAccount() {
+  const account = useAccountStore((s) => s.account);
+  const readError = useAccountStore((s) => s.readError);
+  const goTo = useNavStore((s) => s.goTo);
+
+  const row = accountRow(account, readError, () => goTo("settings"));
+  if (row === null) return null;
+  return <div className="px-2 pb-2">{row}</div>;
+}

--- a/ui/src/components/sidebar-account.tsx
+++ b/ui/src/components/sidebar-account.tsx
@@ -23,13 +23,15 @@ import { useNavStore } from "@/stores/nav";
  *  no name, and nothing where the account has neither. A blank name is no
  *  name, which is why the fallback runs on the empty string as well as on a
  *  missing one. Split by code point so a first character outside the BMP
- *  survives being taken apart. */
+ *  survives being taken apart, and cased without the runtime's locale: the
+ *  circle wants one glyph, and a Turkish locale cases an 'i' into a
+ *  dotted capital instead. */
 export function accountInitial(
   identity: AccountIdentity | null,
 ): string | null {
   const source = identity?.name?.trim() || identity?.githubLogin.trim() || "";
   const [first] = [...source];
-  return first ? first.toLocaleUpperCase() : null;
+  return first ? first.toUpperCase() : null;
 }
 
 /** The circle in the icon lane. It carries a letter once the server has
@@ -112,8 +114,13 @@ function Label({
  *
  *  The state decides on its own: a credential in the keychain is not a
  *  confirmed sign-in, so an unconfirmed one reads as offline and one the
- *  server has rejected asks to sign in again. `readError` only separates the
- *  two ways a read can have failed to land. */
+ *  server has rejected asks to sign in again.
+ *
+ *  `readError` is why the last read did not land, and it outlives that read:
+ *  a failure after an answer that worked leaves the settled state exactly as
+ *  it was. Every row therefore says the cause in place of the sentence it
+ *  would otherwise carry, or the failure would be visible before the first
+ *  answer and invisible after it. */
 function accountRow(
   account: AccountState,
   readError: string | null,
@@ -135,14 +142,14 @@ function accountRow(
   switch (account.kind) {
     case "signed-out":
       return (
-        <Row onClick={open} title={ACCOUNT_ROW_TITLE}>
+        <Row onClick={open} title={readError ?? ACCOUNT_ROW_TITLE}>
           <LogIn className="size-[18px] shrink-0 opacity-70" />
           <Label>{ACCOUNT_SIGN_IN_LABEL}</Label>
         </Row>
       );
     case "expired":
       return (
-        <Row onClick={open} title={ACCOUNT_EXPIRED_TITLE}>
+        <Row onClick={open} title={readError ?? ACCOUNT_EXPIRED_TITLE}>
           <LogIn className="size-[18px] shrink-0 opacity-70" />
           <Label>{ACCOUNT_SIGN_IN_AGAIN_LABEL}</Label>
         </Row>
@@ -150,7 +157,7 @@ function accountRow(
     case "signed-in": {
       const handle = account.identity?.githubLogin.trim();
       return (
-        <Row onClick={open} title={ACCOUNT_ROW_TITLE}>
+        <Row onClick={open} title={readError ?? ACCOUNT_ROW_TITLE}>
           <Avatar identity={account.identity} />
           <Label mono={Boolean(handle)} title={handle}>
             {handle || ACCOUNT_SIGNED_IN_LABEL}
@@ -160,7 +167,7 @@ function accountRow(
     }
     case "offline":
       return (
-        <Row onClick={open} title={ACCOUNT_OFFLINE_TITLE}>
+        <Row onClick={open} title={readError ?? ACCOUNT_OFFLINE_TITLE}>
           <Avatar identity={account.identity} />
           <Label mono title={account.identity.githubLogin}>
             {account.identity.githubLogin}
@@ -177,8 +184,11 @@ function accountRow(
 
 /**
  * The foot of the sidebar: who the last account read found, and the way in
- * to the account settings. The retry for a read that failed belongs to that
- * page, not to this row.
+ * to the account settings.
+ *
+ * Nothing here retries a read. The startup effect in `App.tsx` owns that,
+ * reading again every time the window comes back, so a failure that was the
+ * network's clears itself when the person returns to the app.
  */
 export function SidebarAccount() {
   const account = useAccountStore((s) => s.account);

--- a/ui/src/components/sidebar-account.tsx
+++ b/ui/src/components/sidebar-account.tsx
@@ -23,9 +23,9 @@ import { useNavStore } from "@/stores/nav";
  *  no name, and nothing where the account has neither. A blank name is no
  *  name, which is why the fallback runs on the empty string as well as on a
  *  missing one. Split by code point so a first character outside the BMP
- *  survives being taken apart, and cased without the runtime's locale: the
- *  circle wants one glyph, and a Turkish locale cases an 'i' into a
- *  dotted capital instead. */
+ *  survives being taken apart, and cased by the plain call rather than the
+ *  locale-aware one, whose no-argument form is host-dependent by
+ *  specification: the circle wants one glyph, the same everywhere. */
 export function accountInitial(
   identity: AccountIdentity | null,
 ): string | null {
@@ -110,6 +110,11 @@ function Label({
   );
 }
 
+/** A row's tooltip where the state's own sentence has to survive a later
+ *  failed read. */
+const explained = (sentence: string, readError: string | null): string =>
+  readError === null ? sentence : `${sentence} ${readError}`;
+
 /** Which row each account state draws.
  *
  *  The state decides on its own: a credential in the keychain is not a
@@ -118,9 +123,13 @@ function Label({
  *
  *  `readError` is why the last read did not land, and it outlives that read:
  *  a failure after an answer that worked leaves the settled state exactly as
- *  it was. Every row therefore says the cause in place of the sentence it
- *  would otherwise carry, or the failure would be visible before the first
- *  answer and invisible after it. */
+ *  it was. Every row therefore carries the cause, or the failure would be
+ *  visible before the first answer and invisible after it. Where the row's
+ *  own sentence is the only explanation of what it draws, the cause joins it
+ *  rather than replacing it: a rejected credential and a read that could not
+ *  be made are different answers, and swapping one for the other would say
+ *  the wrong thing about both. */
+
 function accountRow(
   account: AccountState,
   readError: string | null,
@@ -149,7 +158,7 @@ function accountRow(
       );
     case "expired":
       return (
-        <Row onClick={open} title={readError ?? ACCOUNT_EXPIRED_TITLE}>
+        <Row onClick={open} title={explained(ACCOUNT_EXPIRED_TITLE, readError)}>
           <LogIn className="size-[18px] shrink-0 opacity-70" />
           <Label>{ACCOUNT_SIGN_IN_AGAIN_LABEL}</Label>
         </Row>
@@ -159,7 +168,10 @@ function accountRow(
       return (
         <Row onClick={open} title={readError ?? ACCOUNT_ROW_TITLE}>
           <Avatar identity={account.identity} />
-          <Label mono={Boolean(handle)} title={handle}>
+          {/* The handle's own tooltip stands down while a read has
+              failed: the label covers most of the row, and a nearer title
+              would answer the hover with the handle instead of the cause. */}
+          <Label mono={Boolean(handle)} title={readError ? undefined : handle}>
             {handle || ACCOUNT_SIGNED_IN_LABEL}
           </Label>
         </Row>
@@ -167,9 +179,12 @@ function accountRow(
     }
     case "offline":
       return (
-        <Row onClick={open} title={readError ?? ACCOUNT_OFFLINE_TITLE}>
+        <Row onClick={open} title={explained(ACCOUNT_OFFLINE_TITLE, readError)}>
           <Avatar identity={account.identity} />
-          <Label mono title={account.identity.githubLogin}>
+          <Label
+            mono
+            title={readError ? undefined : account.identity.githubLogin}
+          >
             {account.identity.githubLogin}
           </Label>
           <span className="shrink-0 text-xs">{ACCOUNT_OFFLINE_LABEL}</span>

--- a/ui/src/components/sidebar-account.tsx
+++ b/ui/src/components/sidebar-account.tsx
@@ -205,5 +205,5 @@ export function SidebarAccount() {
 
   const row = accountRow(account, readError, () => goTo("settings"));
   if (row === null) return null;
-  return <div className="px-2 pb-2">{row}</div>;
+  return <div className="shrink-0 px-2 pb-2">{row}</div>;
 }

--- a/ui/src/components/sidebar-account.tsx
+++ b/ui/src/components/sidebar-account.tsx
@@ -1,6 +1,11 @@
 import { CircleAlert, LogIn } from "lucide-react";
 import type { ReactNode } from "react";
 import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
+import {
   ACCOUNT_EXPIRED_TITLE,
   ACCOUNT_OFFLINE_LABEL,
   ACCOUNT_OFFLINE_TITLE,
@@ -19,18 +24,22 @@ import {
 } from "@/stores/account";
 import { useNavStore } from "@/stores/nav";
 
-/** The letter on the avatar: the name's first, the handle's where there is
- *  no name, and nothing where the account has neither. A blank name is no
- *  name, which is why the fallback runs on the empty string as well as on a
- *  missing one. Split by code point so a first character outside the BMP
- *  survives being taken apart, and cased by the plain call rather than the
+/** What the row calls the account: the name the server answered with, or
+ *  nothing where it has answered with none. `githubLogin` is not a second
+ *  choice for it — the field is the provider's opaque account id, not a
+ *  handle, and it is never shown. */
+const displayName = (identity: AccountIdentity | null): string =>
+  identity?.name.trim() ?? "";
+
+/** The letter on the avatar, and nothing where there is no name to take it
+ *  from. Split by code point so a first character outside the BMP survives
+ *  being taken apart, and cased by the plain call rather than the
  *  locale-aware one, whose no-argument form is host-dependent by
  *  specification: the circle wants one glyph, the same everywhere. */
 export function accountInitial(
   identity: AccountIdentity | null,
 ): string | null {
-  const source = identity?.name?.trim() || identity?.githubLogin.trim() || "";
-  const [first] = [...source];
+  const [first] = [...displayName(identity)];
   return first ? first.toUpperCase() : null;
 }
 
@@ -48,70 +57,63 @@ function Avatar({ identity }: { identity: AccountIdentity | null }) {
   );
 }
 
-/** One account row. A button wherever there is somewhere to go, plain text
- *  where the app has nothing to offer. */
+/** One account row, and the one sentence behind it.
+ *
+ *  `tip` is the sentence: a popup for a pointer, the same popup for a
+ *  keyboard because the trigger takes focus, and the trigger's own text for
+ *  a screen reader. A native title reaches none of the last two, and on the
+ *  failed-read row the sentence is the only place the reason lives.
+ *
+ *  A row with nowhere to go is still a trigger. It presses to nothing, which
+ *  is the honest answer while the account cannot be read at all. */
 function Row({
   onClick,
-  title,
+  tip,
   children,
 }: {
   onClick?: () => void;
-  title?: string;
+  tip: string;
   children: ReactNode;
 }) {
-  const shape = cn(SIDEBAR_ROW, "w-full text-sm text-muted-foreground");
-  if (!onClick)
-    return (
-      <div className={shape} title={title}>
-        {children}
-      </div>
-    );
   return (
-    <button
-      type="button"
-      onClick={onClick}
-      title={title}
-      className={cn(
-        shape,
-        "transition-colors hover:bg-sidebar-accent/40 hover:text-foreground",
-      )}
-    >
-      {children}
-    </button>
+    <Tooltip>
+      <TooltipTrigger
+        onClick={onClick}
+        className={cn(
+          SIDEBAR_ROW,
+          "w-full text-sm text-muted-foreground outline-none focus-visible:ring-[3px] focus-visible:ring-ring/50",
+          onClick &&
+            "transition-colors hover:bg-sidebar-accent/40 hover:text-foreground",
+        )}
+      >
+        {children}
+        <span className="sr-only">{tip}</span>
+      </TooltipTrigger>
+      <TooltipContent side="top" className="max-w-56">
+        {tip}
+      </TooltipContent>
+    </Tooltip>
   );
 }
 
 /** The text column. It takes whatever the icon lane leaves and cuts a long
- *  handle off rather than pushing the row wider than the sidebar. */
+ *  name off rather than pushing the row wider than the sidebar. */
 function Label({
-  mono,
-  title,
   className,
   children,
 }: {
-  mono?: boolean;
-  /** What a truncated line says in full. A handle wide enough to be cut is
-   *  the only line here long enough to need it. */
-  title?: string;
   className?: string;
   children: ReactNode;
 }) {
   return (
-    <span
-      title={title}
-      className={cn(
-        "min-w-0 flex-1 truncate text-left",
-        mono && "font-mono",
-        className,
-      )}
-    >
+    <span className={cn("min-w-0 flex-1 truncate text-left", className)}>
       {children}
     </span>
   );
 }
 
-/** A row's tooltip where the state's own sentence has to survive a later
- *  failed read. */
+/** A row's sentence where the state's own explanation has to survive a
+ *  later failed read. */
 const explained = (sentence: string, readError: string | null): string =>
   readError === null ? sentence : `${sentence} ${readError}`;
 
@@ -129,7 +131,6 @@ const explained = (sentence: string, readError: string | null): string =>
  *  rather than replacing it: a rejected credential and a read that could not
  *  be made are different answers, and swapping one for the other would say
  *  the wrong thing about both. */
-
 function accountRow(
   account: AccountState,
   readError: string | null,
@@ -139,7 +140,7 @@ function accountRow(
     // A read that failed says that much. One still on its way draws no row
     // rather than guessing which of the four answers is coming.
     return readError === null ? null : (
-      <Row title={readError}>
+      <Row tip={readError}>
         <CircleAlert className="size-[18px] shrink-0 opacity-70" />
         {/* The only line long enough to need the smaller step: at the nav's
             size it would truncate inside a 224px column, and half a
@@ -151,41 +152,33 @@ function accountRow(
   switch (account.kind) {
     case "signed-out":
       return (
-        <Row onClick={open} title={readError ?? ACCOUNT_ROW_TITLE}>
+        <Row onClick={open} tip={readError ?? ACCOUNT_ROW_TITLE}>
           <LogIn className="size-[18px] shrink-0 opacity-70" />
           <Label>{ACCOUNT_SIGN_IN_LABEL}</Label>
         </Row>
       );
     case "expired":
       return (
-        <Row onClick={open} title={explained(ACCOUNT_EXPIRED_TITLE, readError)}>
+        <Row onClick={open} tip={explained(ACCOUNT_EXPIRED_TITLE, readError)}>
           <LogIn className="size-[18px] shrink-0 opacity-70" />
           <Label>{ACCOUNT_SIGN_IN_AGAIN_LABEL}</Label>
         </Row>
       );
-    case "signed-in": {
-      const handle = account.identity?.githubLogin.trim();
+    case "signed-in":
       return (
-        <Row onClick={open} title={readError ?? ACCOUNT_ROW_TITLE}>
+        <Row onClick={open} tip={readError ?? ACCOUNT_ROW_TITLE}>
           <Avatar identity={account.identity} />
-          {/* The handle's own tooltip stands down while a read has
-              failed: the label covers most of the row, and a nearer title
-              would answer the hover with the handle instead of the cause. */}
-          <Label mono={Boolean(handle)} title={readError ? undefined : handle}>
-            {handle || ACCOUNT_SIGNED_IN_LABEL}
+          <Label>
+            {displayName(account.identity) || ACCOUNT_SIGNED_IN_LABEL}
           </Label>
         </Row>
       );
-    }
     case "offline":
       return (
-        <Row onClick={open} title={explained(ACCOUNT_OFFLINE_TITLE, readError)}>
+        <Row onClick={open} tip={explained(ACCOUNT_OFFLINE_TITLE, readError)}>
           <Avatar identity={account.identity} />
-          <Label
-            mono
-            title={readError ? undefined : account.identity.githubLogin}
-          >
-            {account.identity.githubLogin}
+          <Label>
+            {displayName(account.identity) || ACCOUNT_SIGNED_IN_LABEL}
           </Label>
           <span className="shrink-0 text-xs">{ACCOUNT_OFFLINE_LABEL}</span>
         </Row>

--- a/ui/src/components/sidebar.test.tsx
+++ b/ui/src/components/sidebar.test.tsx
@@ -1,6 +1,7 @@
 import { renderToStaticMarkup } from "react-dom/server";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { UPDATES_ATTENTION_TITLE } from "@/lib/copy";
+import { SIDEBAR_ROW } from "@/lib/layout";
 import { Sidebar } from "./sidebar";
 import { updateRow } from "./updates-test-rows";
 
@@ -54,5 +55,24 @@ describe("the Updates badge after a failed check", () => {
     expect(html).not.toContain(">?<");
     expect(html).toContain("text-warning");
     expect(html).toContain(esc(UPDATES_ATTENTION_TITLE));
+  });
+});
+
+// A 900x600 window at 200% zoom, both of which this app allows, leaves the
+// sidebar shorter than its nav rows need. The nav has to give way there:
+// without room to shrink it pushes the notice slot and the account row past
+// the clip, where nothing can scroll to them.
+describe("a sidebar column too short for its nav", () => {
+  it("lets the nav shrink and scroll rather than growing the column", () => {
+    const nav = renderToStaticMarkup(<Sidebar />).match(/<nav class="([^"]*)"/);
+    if (!nav) throw new Error("no nav in the sidebar");
+    expect(nav[1]).toContain("min-h-0");
+    expect(nav[1]).toContain("overflow-y-auto");
+  });
+
+  // A squashed row is not a smaller sidebar, it is a broken one: the rows
+  // keep their height and the nav scrolls past them instead.
+  it("keeps every row at its own height", () => {
+    expect(SIDEBAR_ROW).toContain("shrink-0");
   });
 });

--- a/ui/src/components/sidebar.tsx
+++ b/ui/src/components/sidebar.tsx
@@ -85,7 +85,13 @@ export function Sidebar() {
           <RefreshCw className={cn("size-4", scanning && "animate-spin")} />
         </Button>
       </div>
-      <nav className="flex flex-1 flex-col gap-0.5 px-2">
+      {/* The nav gives way rather than pushing its siblings out of a
+          clipped column: `min-h-0` lets the flex child shrink below the
+          height its rows want, and the scrollbar appears only once it has.
+          Without it, a short window — 900x600 at 200% zoom, both of which
+          this app allows — puts the foot of the sidebar past the clip with
+          nothing able to scroll to it. */}
+      <nav className="flex min-h-0 flex-1 flex-col gap-0.5 overflow-y-auto px-2">
         {NAV.map(({ page: target, label, icon: Icon }) => (
           <button
             key={target}

--- a/ui/src/components/sidebar.tsx
+++ b/ui/src/components/sidebar.tsx
@@ -24,10 +24,8 @@ import { type Page, useNavStore } from "@/stores/nav";
 import { useScanStore } from "@/stores/scan";
 import { useUpdatesStore } from "@/stores/updates";
 
-// A nav item is the shared sidebar row in the nav's own typeface. The
-// transparent border is load-bearing: the selected row shows one, and
-// without it here every other row would shift a pixel when selection moved.
-const NAV_ROW = `${SIDEBAR_ROW} border border-transparent font-mono text-sm`;
+// A nav item is the shared sidebar row in the nav's own typeface.
+const NAV_ROW = `${SIDEBAR_ROW} font-mono text-sm`;
 
 const NAV: { page: Page; label: string; icon: typeof Home }[] = [
   { page: "home", label: "Home", icon: Home },

--- a/ui/src/components/sidebar.tsx
+++ b/ui/src/components/sidebar.tsx
@@ -11,9 +11,11 @@ import {
 } from "lucide-react";
 import { useEffect } from "react";
 import { commands } from "@/bindings";
+import { SidebarAccount } from "@/components/sidebar-account";
 import { SidebarNotice } from "@/components/sidebar-notice";
 import { Button } from "@/components/ui/button";
 import { UPDATES_ATTENTION_TITLE } from "@/lib/copy";
+import { SIDEBAR_ROW } from "@/lib/layout";
 import { rescanEverything } from "@/lib/rescan";
 import { isSearchShortcutKey } from "@/lib/search-shortcut";
 import { visibleUpdateCount } from "@/lib/update-groups";
@@ -22,12 +24,10 @@ import { type Page, useNavStore } from "@/stores/nav";
 import { useScanStore } from "@/stores/scan";
 import { useUpdatesStore } from "@/stores/updates";
 
-// One row shape for every nav item, so the icon column and the text column
-// line up down the whole sidebar. The transparent border is load-bearing:
-// the selected row shows one, and without it here every other row would
-// shift a pixel when selection moved.
-const NAV_ROW =
-  "flex h-9 items-center gap-2.5 rounded-lg border border-transparent px-2 font-mono text-sm";
+// A nav item is the shared sidebar row in the nav's own typeface. The
+// transparent border is load-bearing: the selected row shows one, and
+// without it here every other row would shift a pixel when selection moved.
+const NAV_ROW = `${SIDEBAR_ROW} border border-transparent font-mono text-sm`;
 
 const NAV: { page: Page; label: string; icon: typeof Home }[] = [
   { page: "home", label: "Home", icon: Home },
@@ -125,6 +125,7 @@ export function Sidebar() {
         ))}
       </nav>
       <SidebarNotice />
+      <SidebarAccount />
     </aside>
   );
 }

--- a/ui/src/dev/mock-account.ts
+++ b/ui/src/dev/mock-account.ts
@@ -16,7 +16,9 @@ import {
 } from "@/stores/account";
 import type { Handler } from "./mock-state";
 
-const IDENTITY = { name: "Ada Lovelace", githubLogin: "ada" };
+// The provider's account id is an opaque number the server hands back, not
+// a handle. Spelt as one here so nothing in the app can pass by showing it.
+const IDENTITY = { name: "Ada Lovelace", githubLogin: "1234567" };
 
 const SIGNED_OUT: SettledAccount = { kind: "signed-out" };
 const SIGNED_IN: SettledAccount = { kind: "signed-in", identity: IDENTITY };

--- a/ui/src/lib/copy.ts
+++ b/ui/src/lib/copy.ts
@@ -215,3 +215,20 @@ export const APP_UPDATE_UNKNOWN_NOTE =
 // it. Said wherever a change is one field and the retry is to press again.
 export const SETTINGS_MOVED_MESSAGE =
   "Your settings changed in another window. Try again.";
+
+// The account row at the foot of the sidebar. Each line says what the last
+// read settled on: a credential the server has not confirmed reads as
+// offline, and a read that never landed says that rather than picking a
+// state for it.
+export const ACCOUNT_SIGN_IN_LABEL = "Sign in";
+export const ACCOUNT_SIGN_IN_AGAIN_LABEL = "Sign in again";
+export const ACCOUNT_EXPIRED_TITLE =
+  "kendex.ai no longer accepts this sign-in.";
+// A credential is stored but the server has not put a name to it yet, so
+// the row shows no handle and claims nothing about who it belongs to.
+export const ACCOUNT_SIGNED_IN_LABEL = "Signed in";
+export const ACCOUNT_OFFLINE_LABEL = "Offline";
+export const ACCOUNT_OFFLINE_TITLE =
+  "Signed in as this account when kendex.ai was last reached.";
+export const ACCOUNT_UNREADABLE_LABEL = "Couldn't check your account";
+export const ACCOUNT_ROW_TITLE = "Open account settings";

--- a/ui/src/lib/layout.ts
+++ b/ui/src/lib/layout.ts
@@ -27,3 +27,8 @@ const WIDE_PAGES = new Set([
 export function isWidePage(page: string): boolean {
   return WIDE_PAGES.has(page);
 }
+
+// One row lane for the sidebar. Nav items and the account row share the
+// height, the gutters and the gap, so their icon column and their text
+// column line up from the top of the column to the bottom.
+export const SIDEBAR_ROW = "flex h-9 items-center gap-2.5 rounded-lg px-2";

--- a/ui/src/lib/layout.ts
+++ b/ui/src/lib/layout.ts
@@ -33,6 +33,8 @@ export function isWidePage(page: string): boolean {
 // column line up from the top of the column to the bottom. The transparent
 // border is load-bearing and belongs to the lane rather than to either
 // consumer: the selected nav row shows one, and a row without it would sit
-// a pixel across from every row that has it.
+// a pixel across from every row that has it. A row keeps its height in a
+// column too short for all of them: squashed rows are not a smaller
+// sidebar, they are a broken one, so the column scrolls instead.
 export const SIDEBAR_ROW =
-  "flex h-9 items-center gap-2.5 rounded-lg border border-transparent px-2";
+  "flex h-9 shrink-0 items-center gap-2.5 rounded-lg border border-transparent px-2";

--- a/ui/src/lib/layout.ts
+++ b/ui/src/lib/layout.ts
@@ -30,5 +30,9 @@ export function isWidePage(page: string): boolean {
 
 // One row lane for the sidebar. Nav items and the account row share the
 // height, the gutters and the gap, so their icon column and their text
-// column line up from the top of the column to the bottom.
-export const SIDEBAR_ROW = "flex h-9 items-center gap-2.5 rounded-lg px-2";
+// column line up from the top of the column to the bottom. The transparent
+// border is load-bearing and belongs to the lane rather than to either
+// consumer: the selected nav row shows one, and a row without it would sit
+// a pixel across from every row that has it.
+export const SIDEBAR_ROW =
+  "flex h-9 items-center gap-2.5 rounded-lg border border-transparent px-2";


### PR DESCRIPTION
## Summary

- The foot of the sidebar says what the account read found. `ui/src/components/sidebar-account.tsx` renders one row per `AccountState`: an initial-letter avatar and handle when signed in, a quiet Sign in when not, "Sign in again" for a rejected sign-in, an Offline tag beside the handle when the server could not be reached, and a line saying the check did not land. Clicking opens Settings; the failed-read row is deliberately inert.
- Every row comes from `account.kind` alone, never `hasCredential`, so a keychain credential on its own never renders as a confirmed sign-in.
- `SIDEBAR_ROW` in `ui/src/lib/layout.ts` is the row lane the nav and the account row share, so their icon and text columns line up; the nav row builds on it. Copy lives in `ui/src/lib/copy.ts`, design tokens throughout, no raw colour.
- A read that failed marks the row it settled on: the cause rides in the row's tooltip, joined to the state's own sentence where that sentence is what explains the row.

Identity, `offline` and `expired` reach the store through the dev reader until the account backend lands, so a shipped build today shows signed in, signed out, or that the check did not land. The CHANGELOG entry claims only that.

## Context

- **Research**: Sidebar notices + app updates, and the account surface — `docs/plans/update-notice-and-account.md`

## Completed Issues

- Closes KEN-437 - Add: sidebar account row (signed-in / signed-out / offline / expired)

## Test Plan

- `tools/guard` — 103 files, 747 tests, clean tsc and biome.
- `ui/src/components/sidebar-account.dom.test.tsx` covers every state, click-through to Settings from all four settled rows, the blank-name and nameless-credential fallbacks, the failed-read row and its cause, and a failed re-read marking a settled row.
- Agent-browser pass in Chromium against the dev harness, dark and light, one capture per state: `?account=signed-in|signed-out|expired|offline|unreadable` plus the still-loading case, a 27-character handle, and the row sitting under the notice card.
