### PR TITLE
docs(code-quality): five rules for guards and their instruments

### DIFF
--- a/.agents/skills/code-quality/SKILL.md
+++ b/.agents/skills/code-quality/SKILL.md
@@ -41,8 +41,8 @@ A new or modified check, guard, assertion, or test ships with a must-fail contro
 ### Instruments you did not write
 
 - **A check narrower than the claim can only confirm it, never establish it.** Match the instrument's reach to the assertion's reach before running it, and prefer one that fails visibly on a planted counterexample. A grep over one directory supports no claim about the tree.
-- **Behaviour measured at an interactive prompt is not what scripts get.** `type <cmd>` names the shadow; shadows differ per shell and do not reach a child process. Assert against the real binary, and name the shell and implementation measured.
-- **A guard's failure message is an instrument.** It is what an author acts on. Unescaped backticks inside a double-quoted diagnostic run as command substitutions and expand to empty with no error.
+- **Behaviour measured at an interactive prompt is not what scripts get.** `type <cmd>` names the shadow, which differs per shell and need not reach the script. Measure in the shell the script runs under, assert against the real binary, and name the shell and implementation measured.
+- **A guard's failure message is an instrument.** It is what an author acts on. Unescaped backticks inside a double-quoted diagnostic execute their contents, so the intended text is altered or gone while the surrounding command still succeeds.
 
 ## Language Discipline
 

--- a/.agents/skills/code-quality/SKILL.md
+++ b/.agents/skills/code-quality/SKILL.md
@@ -35,7 +35,7 @@ A loud failure beats a silent wrong answer. Handle every error, check invariants
 
 A new or modified check, guard, assertion, or test ships with a must-fail control: plant the defect it catches (a red-first run or a temporary mutation) and see it go red before its green counts. A guard that pattern-matches source text also gets controls for shapes that satisfy the match without the property: comments, string and template-literal interiors, nested occurrences, alternate quoting, a braceless statement. Reject assertions loose enough to match a skip note, fixtures that never reach the guarded bound, and harness code that keeps alive what the implementation should.
 
-- **A scripted text substitution asserts its match, or it is not an edit.** Assert the pattern's occurrence count and that the file changed, or use an edit tool that errors on no match. Neither assertion holds on a symlink: `sed -i` renames a new file over the link and leaves the original untouched.
+- **A scripted text substitution asserts its match, or it is not an edit.** Assert the pattern's occurrence count and that the file changed, or use an edit tool that errors on no match. Neither assertion holds on a symlink, which `sed -i` replaces with a new file while its target stands: resolve the path first, or refuse a symlink.
 - **A floor alone is not a control.** Derive the expected set from the artifact under test (the flag's own regex, the function's own body), never from a second list in a test file. Floor it, with a message naming the extractor as broken rather than the subject as sparse. Under-inclusion needs the floor plus a required member; over-inclusion needs a forbidden member. State which direction stays open.
 
 ### Instruments you did not write

--- a/.agents/skills/code-quality/SKILL.md
+++ b/.agents/skills/code-quality/SKILL.md
@@ -35,6 +35,15 @@ A loud failure beats a silent wrong answer. Handle every error, check invariants
 
 A new or modified check, guard, assertion, or test ships with a must-fail control: plant the defect it catches (a red-first run or a temporary mutation) and see it go red before its green counts. A guard that pattern-matches source text also gets controls for shapes that satisfy the match without the property: comments, string and template-literal interiors, nested occurrences, alternate quoting, a braceless statement. Reject assertions loose enough to match a skip note, fixtures that never reach the guarded bound, and harness code that keeps alive what the implementation should.
 
+- **A scripted text substitution asserts its match, or it is not an edit.** Assert the pattern's occurrence count and that the file changed, or use an edit tool that errors on no match. Neither assertion holds on a symlink: `sed -i` renames a new file over the link and leaves the original untouched.
+- **A floor alone is not a control.** Derive the expected set from the artifact under test (the flag's own regex, the function's own body), never from a second list in a test file. Floor it, with a message naming the extractor as broken rather than the subject as sparse. Under-inclusion needs the floor plus a required member; over-inclusion needs a forbidden member. State which direction stays open.
+
+### Instruments you did not write
+
+- **A check narrower than the claim can only confirm it, never establish it.** Match the instrument's reach to the assertion's reach before running it, and prefer one that fails visibly on a planted counterexample. A grep over one directory supports no claim about the tree.
+- **Behaviour measured at an interactive prompt is not what scripts get.** `type <cmd>` names the shadow; shadows differ per shell and do not reach a child process. Assert against the real binary, and name the shell and implementation measured.
+- **A guard's failure message is an instrument.** It is what an author acts on. Unescaped backticks inside a double-quoted diagnostic run as command substitutions and expand to empty with no error.
+
 ## Language Discipline
 
 - **Rust**: make illegal states unrepresentable; exhaustive matches (no `_ =>` over enums you own); enums over strings/sentinels/booleans-with-meaning.

--- a/.agents/skills/code-quality/SKILL.md
+++ b/.agents/skills/code-quality/SKILL.md
@@ -41,7 +41,7 @@ A new or modified check, guard, assertion, or test ships with a must-fail contro
 ### Instruments you did not write
 
 - **A check narrower than the claim can only confirm it, never establish it.** Match the instrument's reach to the assertion's reach before running it, and prefer one that fails visibly on a planted counterexample. A grep over one directory supports no claim about the tree.
-- **Behaviour measured at an interactive prompt is not what scripts get.** `type <cmd>` names the shadow, which differs per shell and need not reach the script. Measure in the shell the script runs under, assert against the real binary, and name the shell and implementation measured.
+- **Behaviour measured at an interactive prompt is not what scripts get.** `type <cmd>` names the shadow, which differs per shell. Resolve the command in the script's own shell and PATH, and name the shell and implementation it resolves to.
 - **A guard's failure message is an instrument.** It is what an author acts on. Unescaped backticks inside a double-quoted diagnostic execute their contents, so the intended text is altered or gone while the surrounding command still succeeds.
 
 ## Language Discipline

--- a/skills/code-quality/SKILL.md
+++ b/skills/code-quality/SKILL.md
@@ -41,8 +41,8 @@ A new or modified check, guard, assertion, or test ships with a must-fail contro
 ### Instruments you did not write
 
 - **A check narrower than the claim can only confirm it, never establish it.** Match the instrument's reach to the assertion's reach before running it, and prefer one that fails visibly on a planted counterexample. A grep over one directory supports no claim about the tree.
-- **Behaviour measured at an interactive prompt is not what scripts get.** `type <cmd>` names the shadow; shadows differ per shell and do not reach a child process. Assert against the real binary, and name the shell and implementation measured.
-- **A guard's failure message is an instrument.** It is what an author acts on. Unescaped backticks inside a double-quoted diagnostic run as command substitutions and expand to empty with no error.
+- **Behaviour measured at an interactive prompt is not what scripts get.** `type <cmd>` names the shadow, which differs per shell and need not reach the script. Measure in the shell the script runs under, assert against the real binary, and name the shell and implementation measured.
+- **A guard's failure message is an instrument.** It is what an author acts on. Unescaped backticks inside a double-quoted diagnostic execute their contents, so the intended text is altered or gone while the surrounding command still succeeds.
 
 ## Language Discipline
 

--- a/skills/code-quality/SKILL.md
+++ b/skills/code-quality/SKILL.md
@@ -35,7 +35,7 @@ A loud failure beats a silent wrong answer. Handle every error, check invariants
 
 A new or modified check, guard, assertion, or test ships with a must-fail control: plant the defect it catches (a red-first run or a temporary mutation) and see it go red before its green counts. A guard that pattern-matches source text also gets controls for shapes that satisfy the match without the property: comments, string and template-literal interiors, nested occurrences, alternate quoting, a braceless statement. Reject assertions loose enough to match a skip note, fixtures that never reach the guarded bound, and harness code that keeps alive what the implementation should.
 
-- **A scripted text substitution asserts its match, or it is not an edit.** Assert the pattern's occurrence count and that the file changed, or use an edit tool that errors on no match. Neither assertion holds on a symlink: `sed -i` renames a new file over the link and leaves the original untouched.
+- **A scripted text substitution asserts its match, or it is not an edit.** Assert the pattern's occurrence count and that the file changed, or use an edit tool that errors on no match. Neither assertion holds on a symlink, which `sed -i` replaces with a new file while its target stands: resolve the path first, or refuse a symlink.
 - **A floor alone is not a control.** Derive the expected set from the artifact under test (the flag's own regex, the function's own body), never from a second list in a test file. Floor it, with a message naming the extractor as broken rather than the subject as sparse. Under-inclusion needs the floor plus a required member; over-inclusion needs a forbidden member. State which direction stays open.
 
 ### Instruments you did not write

--- a/skills/code-quality/SKILL.md
+++ b/skills/code-quality/SKILL.md
@@ -35,6 +35,15 @@ A loud failure beats a silent wrong answer. Handle every error, check invariants
 
 A new or modified check, guard, assertion, or test ships with a must-fail control: plant the defect it catches (a red-first run or a temporary mutation) and see it go red before its green counts. A guard that pattern-matches source text also gets controls for shapes that satisfy the match without the property: comments, string and template-literal interiors, nested occurrences, alternate quoting, a braceless statement. Reject assertions loose enough to match a skip note, fixtures that never reach the guarded bound, and harness code that keeps alive what the implementation should.
 
+- **A scripted text substitution asserts its match, or it is not an edit.** Assert the pattern's occurrence count and that the file changed, or use an edit tool that errors on no match. Neither assertion holds on a symlink: `sed -i` renames a new file over the link and leaves the original untouched.
+- **A floor alone is not a control.** Derive the expected set from the artifact under test (the flag's own regex, the function's own body), never from a second list in a test file. Floor it, with a message naming the extractor as broken rather than the subject as sparse. Under-inclusion needs the floor plus a required member; over-inclusion needs a forbidden member. State which direction stays open.
+
+### Instruments you did not write
+
+- **A check narrower than the claim can only confirm it, never establish it.** Match the instrument's reach to the assertion's reach before running it, and prefer one that fails visibly on a planted counterexample. A grep over one directory supports no claim about the tree.
+- **Behaviour measured at an interactive prompt is not what scripts get.** `type <cmd>` names the shadow; shadows differ per shell and do not reach a child process. Assert against the real binary, and name the shell and implementation measured.
+- **A guard's failure message is an instrument.** It is what an author acts on. Unescaped backticks inside a double-quoted diagnostic run as command substitutions and expand to empty with no error.
+
 ## Language Discipline
 
 - **Rust**: make illegal states unrepresentable; exhaustive matches (no `_ =>` over enums you own); enums over strings/sentinels/booleans-with-meaning.

--- a/skills/code-quality/SKILL.md
+++ b/skills/code-quality/SKILL.md
@@ -41,7 +41,7 @@ A new or modified check, guard, assertion, or test ships with a must-fail contro
 ### Instruments you did not write
 
 - **A check narrower than the claim can only confirm it, never establish it.** Match the instrument's reach to the assertion's reach before running it, and prefer one that fails visibly on a planted counterexample. A grep over one directory supports no claim about the tree.
-- **Behaviour measured at an interactive prompt is not what scripts get.** `type <cmd>` names the shadow, which differs per shell and need not reach the script. Measure in the shell the script runs under, assert against the real binary, and name the shell and implementation measured.
+- **Behaviour measured at an interactive prompt is not what scripts get.** `type <cmd>` names the shadow, which differs per shell. Resolve the command in the script's own shell and PATH, and name the shell and implementation it resolves to.
 - **A guard's failure message is an instrument.** It is what an author acts on. Unescaped backticks inside a double-quoted diagnostic execute their contents, so the intended text is altered or gone while the surrounding command still succeeds.
 
 ## Language Discipline


### PR DESCRIPTION
Five portable extensions to § Prove Your Guards from a consumer running the longer version, per #1743.

Two are about guards you author, so they join the section directly:

- A scripted text substitution asserts its match, or it is not an edit. The sharp edge is the symlink case, where neither the count assertion nor the file-changed assertion holds.
- A floor alone is not a control. Derive from the artifact, floor it with a message blaming the extractor, then close under-inclusion with a required member and over-inclusion with a forbidden one, and say which direction stays open.

Three are about instruments you did not write, which is a different job from authoring a guard, so they get their own subsection: scope narrower than the claim, behaviour measured at an interactive prompt, and a diagnostic whose unescaped backticks expand to nothing.

Not taken, as the issue scopes out: the repo-specific remainder of that consumer's section.

Closes #1743
