### PR TITLE
docs(review-gate): a reviewer instruction for the harness render

### DIFF
--- a/.agents/skills/review-gate/SKILL.md
+++ b/.agents/skills/review-gate/SKILL.md
@@ -279,4 +279,8 @@ ENGINE's proofs and run in the kendex repo, not in a consumer's CI:
 
 For re-vendor PRs, suppress duplicate findings with the remedy-locus reviewer
 instruction, never a reviewer path exclusion:
-[references/vendored-paths.md](references/vendored-paths.md).
+[references/vendored-paths.md](references/vendored-paths.md). A committed
+`kendex refresh` tree is the same problem with no pin over it and a blast
+radius of every consuming repo; it routes every finding over the render
+upstream, with no carve-out:
+[references/rendered-paths.md](references/rendered-paths.md).

--- a/.agents/skills/review-gate/references/rendered-paths.md
+++ b/.agents/skills/review-gate/references/rendered-paths.md
@@ -12,9 +12,9 @@ break**, **The trap: reviewer path exclusion**, and **Reviewer classes**.
 
 | | Byte-pinned vendored tree | Harness render |
 |---|---|---|
-| What reverts a local edit | Nothing automatic; the pin turns red | The next `kendex refresh`, wholesale and silently |
-| A pin or checksum manifest | Exists, and is the point | Does not exist |
-| A local fix | Wrong, and visible | Reads as closed while the bytes go back |
+| What a local edit meets | Nothing automatic; the pin turns red | The next `kendex refresh` holds the item as a conflict and plans no write |
+| A pin or checksum manifest | Exists, and is the point | Does not exist — the refresh's own conflict row is the red |
+| A local fix | Wrong, and visible | Wedges that item's refresh until someone forks it or discards the edit |
 | The upstream remedy | Re-vendor | An issue in the catalog repo, then re-render |
 | Blast radius of one thread | This repo | Every consuming repo on its next refresh |
 
@@ -106,7 +106,7 @@ Four shapes the glob must not take:
   output, and — outside every dot-directory, so the candidate list cannot see
   it — the root `opencode.json` or `opencode.jsonc`. This is the shape that
   most needs keeping out. The template asserts that nothing under the glob is
-  edited here and that a refresh overwrites it wholesale; over a merged path
+  edited here and that an edit wedges the next refresh; over a merged path
   both are false, and the flat no-carve-out rule would then forbid raising a
   correctness or security defect over content this repo owns and can fix.
 

--- a/.agents/skills/review-gate/references/rendered-paths.md
+++ b/.agents/skills/review-gate/references/rendered-paths.md
@@ -51,12 +51,13 @@ candidate list to check against that PR.
 # including .vscode, .devcontainer, .husky and the rest.
 git ls-files | grep -oE '^\.[a-z]+/' | sort -u
 
-# Items whose content this repo owns. Subtract the UNION of both lists: the
-# manifest is the declaration, the lock is what the last apply recorded, and
-# an item kendex refused to install keeps its old lock entry verbatim through
-# every later refresh — where they disagree, the manifest settles it.
-awk -F'[].[]' '/^\[/ { t = $2; n = $3 } /^[[:space:]]*source[[:space:]]*=[[:space:]]*.in-place./ { print t "/" n }' kendex.toml
-jq -r '.entries | to_entries[] | select(.value.source == "in-place") | .value.name' .kendex-lock.json | sort -u
+# Skills whose content this repo owns, as bare names from both sides so the
+# two lists subtract. Take the UNION: the manifest is the declaration, the
+# lock is what the last apply recorded, and an item kendex refused to install
+# keeps its old lock entry verbatim through every later refresh — where they
+# disagree, the manifest settles it.
+awk -F'[].[]' '/^\[skills\./ { n = $3 } /^[[:space:]]*source[[:space:]]*=[[:space:]]*.in-place./ { if (n != "") print n; n = "" }' kendex.toml
+jq -r '.entries[] | select(.source == "in-place" and .kind == "skill") | .name' .kendex-lock.json | sort -u
 
 # Recorded render destinations, as absolute paths to strip the repo root
 # from. The lock carries this field for skills and commands only, so it names
@@ -64,6 +65,21 @@ jq -r '.entries | to_entries[] | select(.value.source == "in-place") | .value.na
 # exact paths and never completes the list.
 jq -r '.entries[] | select(.emitted != null) | .emitted.paths[]' .kendex-lock.json | sort -u
 ```
+
+That awk reads top-level `[skills.<name>]` tables in `kendex.toml` and
+nothing else. It does not see a `[skills]` table holding inline entries,
+dotted or quoted keys, an indented declaration, or `kendex-local.toml`, which
+a source catalog keeps its own install state in. A repo wanting a mechanical
+answer over those has a worked precedent in the harness-ci skill's
+`harness-only` script, § `manifest_carves`: it reads both manifests from the
+head tree and fails closed, carving every skill path when a manifest exists
+and will not parse. Do not build a second one here.
+
+What backstops the gap is the section's own authority: an in-place skill's
+content tree at `.agents/skills/<name>` is bytes kendex reads and never
+writes, so a refresh PR never touches it. The per-harness link or copy into
+`.claude/skills/<name>` and its siblings IS written, and does appear in the PR
+that creates it.
 
 Four shapes the glob must not take:
 
@@ -128,25 +144,26 @@ on ONE consumer PR, collect the findings over the render and file them where
 the render is written. Do not fix it locally, and do not file the same finding
 from each consumer.
 
-`kendex report --title [TITLE] --body-file [PATH]` files it, with one selector
-and exactly one of `--body` or `--body-file`. `--dry-run` prints the route it
-would take. What the route resolves to today, verified against
-`crates/core/src/report.rs`:
+```bash
+kendex report --skill [NAME] --title [TITLE] --body-file [PATH] --dry-run
+```
 
-- **`--agent`, `--hook`, and a `--asset` naming either** route on the lock
-  entry's `source_repo`. That is the working path.
-- **`--skill` and a `--asset` naming a skill route to this repo, not
-  upstream.** Skill ownership is read from the installed `SKILL.md`
-  frontmatter alone, and it accepts exactly two values: `source: kendex`, or a
-  `repository:` equal to the built-in `vanillagreencom/kendex` — never what
-  `--upstream` names, which only the lock branch compares against. Neither can
-  match: the reader takes `source:` and `repository:` only at column zero,
-  where a kendex skill nests both under `metadata:`, and renders `repository:`
-  as a URL rather than the slug. Open the issue in the catalog repo by hand,
-  or report it under the agent or hook that carries the skill.
-- **With no selector** the CLI warns once and files against this repo.
+`--skill`, `--agent`, `--hook`, and `--asset` are the selectors; pass one, and
+exactly one of `--body` or `--body-file`. `--dry-run` prints the decision and
+the `gh` command it would run.
 
-Confirm with `--dry-run` before relying on any of it.
+The lock is the one judge, and it records provenance for every kind — skills,
+agents, hooks and Pi extensions alike. A name routes to the catalog repo when
+the lock holds at least one entry for it, narrowed to the kind the selector
+names, and EVERY matching entry's `source_repo` is that repo. One entry
+recorded from somewhere else makes the name ambiguous and keeps the report
+here, which is also what an unlocked name gets. How the manifest spelled the
+repo does not decide it: a shorthand, an https URL and a `git@` reference fold
+to one identity.
+
+With no selector at all the CLI warns once that ownership could not be
+determined and files against this repo. Confirm with `--dry-run` before
+relying on any of it.
 
 ## Verifying on a real refresh PR
 

--- a/.agents/skills/review-gate/references/rendered-paths.md
+++ b/.agents/skills/review-gate/references/rendered-paths.md
@@ -42,25 +42,27 @@ hook's own script into `.agents/hooks` and rewrites the registration around
 it, and that script is the repo's. Each of the rest can also hold files kendex
 never writes.
 
-Start by listing candidates, then subtract:
+**The file list of a real refresh PR is the authority.** kendex exposes no
+single answer to what it renders here, and the commands below only build a
+candidate list to check against that PR.
 
 ```bash
 # Candidates only — this lists every tracked lowercase dot-directory,
-# including .vscode, .devcontainer, .husky and the rest. It is not an answer.
+# including .vscode, .devcontainer, .husky and the rest.
 git ls-files | grep -oE '^\.[a-z]+/' | sort -u
 
-# Items whose content this repo owns. The manifest is the declaration; the
-# lock is what the last apply recorded, and the two disagree until a refresh
-# rewrites the lock, so read both.
+# Items whose content this repo owns. Subtract the UNION of both lists: the
+# manifest is the declaration, the lock is what the last apply recorded, and
+# an item kendex refused to install keeps its old lock entry verbatim through
+# every later refresh — where they disagree, the manifest settles it.
 awk -F'[].[]' '/^\[/ { t = $2; n = $3 } /^[[:space:]]*source[[:space:]]*=[[:space:]]*.in-place./ { print t "/" n }' kendex.toml
 jq -r '.entries | to_entries[] | select(.value.source == "in-place") | .value.name' .kendex-lock.json | sort -u
 
-# Exact render destinations, where the lock recorded them, as absolute paths
-# to strip the repo root from. Absent on entries written before the field
-# existed, so this narrows the list and never completes it — compare the
-# count against the entry count.
+# Recorded render destinations, as absolute paths to strip the repo root
+# from. The lock carries this field for skills and commands only, so it names
+# no agent file, no hook script, and nothing for the other kinds — it adds
+# exact paths and never completes the list.
 jq -r '.entries[] | select(.emitted != null) | .emitted.paths[]' .kendex-lock.json | sort -u
-jq -r '"emitted on \([.entries[] | select(.emitted != null)] | length) of \(.entries | length) entries"' .kendex-lock.json
 ```
 
 Four shapes the glob must not take:
@@ -75,22 +77,26 @@ Four shapes the glob must not take:
   edited here. The subtraction is a name list, from the two commands above.
   The item's per-harness copies are still render output.
 - **The harness memory files** — `CLAUDE.md`, `AGENTS.md`, `GEMINI.md`.
-  kendex writes none of them; they are project markers it reads. A repo
-  keeping `.claude/CLAUDE.md` has one inside a `.claude/**` glob.
-- **Structured config and settings files kendex merges into.** It writes its
-  own entries and leaves the rest of the file alone: `.claude/settings.json`
-  and `settings.local.json`, `.codex/config.toml`, `.codex/hooks.json`,
-  `.cursor/hooks.json`, `.cursor/mcp.json`, `.gemini/settings.json`,
-  `.mcp.json`, the Copilot files above, and — outside every dot-directory, so
-  the candidate list above cannot see it — the root `opencode.json` or
-  `opencode.jsonc`. This is the shape that most needs keeping out. The
-  template asserts that nothing under the glob is edited here and that a
-  refresh overwrites it wholesale; over a merged file both are false, and the
-  flat no-carve-out rule would then forbid raising a correctness or security
-  defect over content this repo owns and can fix.
+  kendex writes none of them. A repo keeping `.claude/CLAUDE.md` has one
+  inside a `.claude/**` glob.
+- **Anything kendex merges into rather than writes whole.** This is a class,
+  not a list: where kendex writes its own entries into a file or directory the
+  repo owns the rest of, that path is repo-owned and stays out. Named
+  instances, which are examples and not the whole set —
+  `.claude/settings.json` and `settings.local.json`, `.codex/config.toml`,
+  `.codex/hooks.json`, `.cursor/hooks.json`, `.cursor/mcp.json`,
+  `.gemini/settings.json`, `.pi/settings.json`, `.mcp.json`, the Copilot files
+  above, `.opencode/instructions/` where only `kendex-hook-*.md` is render
+  output, and — outside every dot-directory, so the candidate list cannot see
+  it — the root `opencode.json` or `opencode.jsonc`. This is the shape that
+  most needs keeping out. The template asserts that nothing under the glob is
+  edited here and that a refresh overwrites it wholesale; over a merged path
+  both are false, and the flat no-carve-out rule would then forbid raising a
+  correctness or security defect over content this repo owns and can fix.
 
-Check the result against the file list of a real refresh PR before relying on
-it.
+Read the shapes as the rule and the file list of a real refresh PR as the
+check. A path that appears in neither the candidate list nor that PR does not
+belong in the glob.
 
 ## Wiring a repo
 

--- a/.agents/skills/review-gate/references/rendered-paths.md
+++ b/.agents/skills/review-gate/references/rendered-paths.md
@@ -15,7 +15,7 @@ break**, **The trap: reviewer path exclusion**, and **Reviewer classes**.
 | What reverts a local edit | Nothing automatic; the pin turns red | The next `kendex refresh`, wholesale and silently |
 | A pin or checksum manifest | Exists, and is the point | Does not exist |
 | A local fix | Wrong, and visible | Reads as closed while the bytes go back |
-| The upstream remedy | Re-vendor | `kendex report`, then re-render |
+| The upstream remedy | Re-vendor | An issue in the catalog repo, then re-render |
 | Blast radius of one thread | This repo | Every consuming repo on its next refresh |
 
 The last row is what changes the rule. The vendored template routes
@@ -23,33 +23,71 @@ upstream-remedy findings to the review summary body and keeps one carve-out: a
 correctness, security, or data-loss regression the bump introduces gets an
 inline comment and blocks.
 
-**Over a render the carve-out goes.** It is the clause a reviewer argues with,
-and a bot that believes it found a security defect in rendered output takes it
-every time. The thread it opens blocks the merge until answered, in several
-consuming repos at once, for a fix that can land in none of them. The rule
-here is flat on every surface, and the remedy is `kendex report`.
+**Over a render the carve-out goes, and so does the summary-body route.** The
+carve-out is the clause a reviewer argues with, and a bot that believes it
+found a security defect in rendered output takes it every time. The thread it
+opens blocks the merge until answered, in several consuming repos at once, for
+a fix that can land in none of them. The rule here is flat on every surface,
+which also removes the reason the vendored template gives a location-bound
+reviewer a consolidated-comment fallback: under a flat rule there is no
+on-PR surface to fall back to.
 
 ## Deriving the glob
 
-Two commands, run in the consumer repo:
+The trees kendex writes into a project are `.agents/skills`, `.claude`,
+`.codex`, `.cursor`, `.gemini`, `.opencode`, `.pi`, and for Copilot the
+`agents`, `hooks`, and `skills` subtrees of `.github`. The shared tree is
+scoped to `skills` rather than all of `.agents`: adoption moves a custom
+hook's own script into `.agents/hooks` and rewrites the registration around
+it, and that script is the repo's. Each of the rest can also hold files kendex
+never writes.
+
+Start by listing candidates, then subtract:
 
 ```bash
-# 1. The harness trees this repo commits.
+# Candidates only — this lists every tracked lowercase dot-directory,
+# including .vscode, .devcontainer, .husky and the rest. It is not an answer.
 git ls-files | grep -oE '^\.[a-z]+/' | sort -u
 
-# 2. Items whose content this repo owns — their .agents subtree is NOT
-#    render output and gets an ordinary review.
-grep -E '^\[|^source = ' kendex.toml | grep -B1 '^source = "in-place"'
+# Items whose content this repo owns. The manifest is the declaration; the
+# lock is what the last apply recorded, and the two disagree until a refresh
+# rewrites the lock, so read both.
+awk -F'[].[]' '/^\[/ { t = $2; n = $3 } /^[[:space:]]*source[[:space:]]*=[[:space:]]*.in-place./ { print t "/" n }' kendex.toml
+jq -r '.entries | to_entries[] | select(.value.source == "in-place") | .value.name' .kendex-lock.json | sort -u
+
+# Exact render destinations, where the lock recorded them, as absolute paths
+# to strip the repo root from. Absent on entries written before the field
+# existed, so this narrows the list and never completes it — compare the
+# count against the entry count.
+jq -r '.entries[] | select(.emitted != null) | .emitted.paths[]' .kendex-lock.json | sort -u
+jq -r '"emitted on \([.entries[] | select(.emitted != null)] | length) of \(.entries | length) entries"' .kendex-lock.json
 ```
 
-Two shapes the glob must not take:
+Four shapes the glob must not take:
 
 - **`.github/**`.** Copilot renders into `.github/agents`, `.github/hooks`,
-  and `.github/skills`; the rest of `.github` — workflows, this instruction
-  directory, issue templates — is repo-owned and gets an ordinary review.
-- **A whole `.agents/**` in a repo holding in-place items.** An item declared
-  `source = "in-place"` keeps its content of record at `.agents/<kind>/<name>`
-  and is edited here. Its per-harness copies are still render output.
+  and `.github/skills`. The rest of `.github` — workflows, this instruction
+  directory, issue templates — is repo-owned. `.github/mcp.json` and
+  `.github/copilot/settings.json` plus `settings.local.json` are a third
+  thing, covered by the last shape below.
+- **Every `.agents/skills/<name>` an item declares in-place.** An item
+  declared `source = "in-place"` keeps its content of record there and is
+  edited here. The subtraction is a name list, from the two commands above.
+  The item's per-harness copies are still render output.
+- **The harness memory files** — `CLAUDE.md`, `AGENTS.md`, `GEMINI.md`.
+  kendex writes none of them; they are project markers it reads. A repo
+  keeping `.claude/CLAUDE.md` has one inside a `.claude/**` glob.
+- **Structured config and settings files kendex merges into.** It writes its
+  own entries and leaves the rest of the file alone: `.claude/settings.json`
+  and `settings.local.json`, `.codex/config.toml`, `.codex/hooks.json`,
+  `.cursor/hooks.json`, `.cursor/mcp.json`, `.gemini/settings.json`,
+  `.mcp.json`, the Copilot files above, and — outside every dot-directory, so
+  the candidate list above cannot see it — the root `opencode.json` or
+  `opencode.jsonc`. This is the shape that most needs keeping out. The
+  template asserts that nothing under the glob is edited here and that a
+  refresh overwrites it wholesale; over a merged file both are false, and the
+  flat no-carve-out rule would then forbid raising a correctness or security
+  defect over content this repo owns and can fix.
 
 Check the result against the file list of a real refresh PR before relying on
 it.
@@ -65,9 +103,11 @@ it.
    alongside it.** Merge any repo-specific carve-ins the old clause held into
    the new body.
 3. Classify each reviewer the repo runs as summary-capable or location-bound
-   ([vendored-paths.md](vendored-paths.md) § Reviewer classes). A repo whose
-   reviewers are ALL location-bound gets the one-consolidated-comment bound,
-   not silence.
+   ([vendored-paths.md](vendored-paths.md) § Reviewer classes). The flat rule
+   asks the same thing of both: no finding over the render on any surface of
+   this PR, and a submitted review either way. The residual that section
+   records still holds — a reviewer whose schema binds one finding to one
+   location emits a thread anyway, and that is answered, not graded.
 4. Mirror the rule in the repo's reviewer-guidance file, for reviewers that do
    not read path-scoped instructions.
 5. Change no gate settings. A render tree carries evidence only through the
@@ -75,32 +115,41 @@ it.
    ([settings.md](settings.md)), and hand-edited policy markdown under it
    belongs in `REVIEW_GATE_CARRY_FORWARD_EXCLUDE`, which wins.
 
-## Reporting a finding upstream
+## Filing the finding against the catalog repo
 
-`kendex report --skill [NAME] --title [TITLE] --body-file [PATH]` routes the
-issue to the repo that owns the item. `--agent`, `--hook`, and `--asset` are
-the other selectors; pass at most one, and pass exactly one of `--body` or
-`--body-file`. Two preconditions decide the route:
+This is the refresh session's half, not a reviewer's. Once per refresh train,
+on ONE consumer PR, collect the findings over the render and file them where
+the render is written. Do not fix it locally, and do not file the same finding
+from each consumer.
 
-- **A skill routes on its installed `SKILL.md` frontmatter alone** — `source:
-  kendex`, or a `repository:` naming the upstream slug. A committed render
-  carries that frontmatter at the install path, which is what a scripts-only
-  vendor lacks.
-- **An agent, hook, or Pi extension routes on the lock entry** — its
-  `source_repo` must match the upstream the report targets.
+`kendex report --title [TITLE] --body-file [PATH]` files it, with one selector
+and exactly one of `--body` or `--body-file`. `--dry-run` prints the route it
+would take. What the route resolves to today, verified against
+`crates/core/src/report.rs`:
 
-With no selector the CLI warns once and files against this repo. Verify the
-route before relying on it, or open the upstream issue by hand.
+- **`--agent`, `--hook`, and a `--asset` naming either** route on the lock
+  entry's `source_repo`. That is the working path.
+- **`--skill` and a `--asset` naming a skill route to this repo, not
+  upstream.** Skill ownership is read from the installed `SKILL.md`
+  frontmatter alone, and it accepts exactly two values: `source: kendex`, or a
+  `repository:` equal to the built-in `vanillagreencom/kendex` — never what
+  `--upstream` names, which only the lock branch compares against. Neither can
+  match: the reader takes `source:` and `repository:` only at column zero,
+  where a kendex skill nests both under `metadata:`, and renders `repository:`
+  as a URL rather than the slug. Open the issue in the catalog repo by hand,
+  or report it under the agent or hook that carries the skill.
+- **With no selector** the CLI warns once and files against this repo.
 
-Do not fix it locally, and do not file the same finding from each consumer.
+Confirm with `--dry-run` before relying on any of it.
 
 ## Verifying on a real refresh PR
 
 Run [vendored-paths.md](vendored-paths.md) § Verifying on a real re-vendor PR
 against the first refresh PR after the change, reading `pr-threads` over the
-render trees rather than the vendored one. **Pass** for a render is stricter:
-a trusted non-author review object at the current head, gate `success`, and no
-unresolved thread over the render from a summary-capable reviewer — including
-none raising a correctness, security, or data-loss defect, which the flat rule
-routes upstream. Threads from a location-bound reviewer are counted and
-recorded, not graded.
+render trees rather than the vendored one. **Pass** for a render is stricter
+in one term: a trusted non-author review object at the current head, gate
+`success`, and no unresolved thread over the render from a summary-capable
+reviewer — including none raising a correctness, security, or data-loss
+defect, which the flat rule routes to the catalog repo and the vendored
+carve-out would have admitted. Threads from a location-bound reviewer are
+counted and recorded, not graded.

--- a/.agents/skills/review-gate/references/rendered-paths.md
+++ b/.agents/skills/review-gate/references/rendered-paths.md
@@ -153,13 +153,18 @@ exactly one of `--body` or `--body-file`. `--dry-run` prints the decision and
 the `gh` command it would run.
 
 The lock is the one judge, and it records provenance for every kind — skills,
-agents, hooks and Pi extensions alike. A name routes to the catalog repo when
-the lock holds at least one entry for it, narrowed to the kind the selector
-names, and EVERY matching entry's `source_repo` is that repo. One entry
-recorded from somewhere else makes the name ambiguous and keeps the report
-here, which is also what an unlocked name gets. How the manifest spelled the
-repo does not decide it: a shorthand, an https URL and a `git@` reference fold
-to one identity.
+agents, hooks and Pi extensions alike. A name routes upstream when the lock
+holds at least one entry for it, narrowed to the kind the selector names, and
+EVERY matching entry's `source_repo` is kendex's own repo, the one candidate
+the comparison holds. One entry recorded from somewhere else makes the name
+ambiguous and keeps the report here, which is also what an unlocked name gets.
+How the manifest spelled the repo does not decide it: a shorthand, an https URL
+and a `git@` reference fold to one identity.
+
+**Kendex is the only destination the route reaches.** An item rendered from a
+third-party catalog carries that catalog in its lock entries, never the
+candidate, and its report files against this repo — open the issue in that
+catalog by hand.
 
 With no selector at all the CLI warns once that ownership could not be
 determined and files against this repo. Confirm with `--dry-run` before

--- a/.agents/skills/review-gate/references/rendered-paths.md
+++ b/.agents/skills/review-gate/references/rendered-paths.md
@@ -1,0 +1,106 @@
+# Reviewing the committed harness render
+
+For consumers that commit `kendex refresh` output and merge refresh PRs.
+Suppressing duplicate findings over that tree is a reviewer-instruction
+problem; configuration answers break the gate.
+
+The byte-pinned sibling is [vendored-paths.md](vendored-paths.md). Three of its
+sections apply here unchanged and are not restated: **What suppression must not
+break**, **The trap: reviewer path exclusion**, and **Reviewer classes**.
+
+## What is different from a byte-pinned tree
+
+| | Byte-pinned vendored tree | Harness render |
+|---|---|---|
+| What reverts a local edit | Nothing automatic; the pin turns red | The next `kendex refresh`, wholesale and silently |
+| A pin or checksum manifest | Exists, and is the point | Does not exist |
+| A local fix | Wrong, and visible | Reads as closed while the bytes go back |
+| The upstream remedy | Re-vendor | `kendex report`, then re-render |
+| Blast radius of one thread | This repo | Every consuming repo on its next refresh |
+
+The last row is what changes the rule. The vendored template routes
+upstream-remedy findings to the review summary body and keeps one carve-out: a
+correctness, security, or data-loss regression the bump introduces gets an
+inline comment and blocks.
+
+**Over a render the carve-out goes.** It is the clause a reviewer argues with,
+and a bot that believes it found a security defect in rendered output takes it
+every time. The thread it opens blocks the merge until answered, in several
+consuming repos at once, for a fix that can land in none of them. The rule
+here is flat on every surface, and the remedy is `kendex report`.
+
+## Deriving the glob
+
+Two commands, run in the consumer repo:
+
+```bash
+# 1. The harness trees this repo commits.
+git ls-files | grep -oE '^\.[a-z]+/' | sort -u
+
+# 2. Items whose content this repo owns — their .agents subtree is NOT
+#    render output and gets an ordinary review.
+grep -E '^\[|^source = ' kendex.toml | grep -B1 '^source = "in-place"'
+```
+
+Two shapes the glob must not take:
+
+- **`.github/**`.** Copilot renders into `.github/agents`, `.github/hooks`,
+  and `.github/skills`; the rest of `.github` — workflows, this instruction
+  directory, issue templates — is repo-owned and gets an ordinary review.
+- **A whole `.agents/**` in a repo holding in-place items.** An item declared
+  `source = "in-place"` keeps its content of record at `.agents/<kind>/<name>`
+  and is edited here. Its per-harness copies are still render output.
+
+Check the result against the file list of a real refresh PR before relying on
+it.
+
+## Wiring a repo
+
+1. Copy [`../templates/rendered-paths.instructions.md`](../templates/rendered-paths.instructions.md)
+   into the repo's path-scoped reviewer instruction directory —
+   `.github/instructions/`, as a `*.instructions.md` file — set `applyTo` to
+   the glob derived above, and delete the fill comment. Repo-owned after the
+   copy.
+2. **Replace any existing instruction scoped to the same tree — do not add
+   alongside it.** Merge any repo-specific carve-ins the old clause held into
+   the new body.
+3. Classify each reviewer the repo runs as summary-capable or location-bound
+   ([vendored-paths.md](vendored-paths.md) § Reviewer classes). A repo whose
+   reviewers are ALL location-bound gets the one-consolidated-comment bound,
+   not silence.
+4. Mirror the rule in the repo's reviewer-guidance file, for reviewers that do
+   not read path-scoped instructions.
+5. Change no gate settings. A render tree carries evidence only through the
+   `vendored` class and `REVIEW_GATE_VENDORED_PATHS`
+   ([settings.md](settings.md)), and hand-edited policy markdown under it
+   belongs in `REVIEW_GATE_CARRY_FORWARD_EXCLUDE`, which wins.
+
+## Reporting a finding upstream
+
+`kendex report --skill [NAME] --title [TITLE] --body-file [PATH]` routes the
+issue to the repo that owns the item. `--agent`, `--hook`, and `--asset` are
+the other selectors; pass at most one, and pass exactly one of `--body` or
+`--body-file`. Two preconditions decide the route:
+
+- **A skill routes on its installed `SKILL.md` frontmatter alone** — `source:
+  kendex`, or a `repository:` naming the upstream slug. A committed render
+  carries that frontmatter at the install path, which is what a scripts-only
+  vendor lacks.
+- **An agent, hook, or Pi extension routes on the lock entry** — its
+  `source_repo` must match the upstream the report targets.
+
+With no selector the CLI warns once and files against this repo. Verify the
+route before relying on it, or open the upstream issue by hand.
+
+Do not fix it locally, and do not file the same finding from each consumer.
+
+## Verifying on a real refresh PR
+
+Run [vendored-paths.md](vendored-paths.md) § Verifying on a real re-vendor PR
+against the first refresh PR after the change, reading `pr-threads` over the
+render trees rather than the vendored one. **Pass** for a render is stricter:
+a trusted non-author review object at the current head, gate `success`, and no
+unresolved thread over the render from a summary-capable reviewer — including
+none raising a correctness, security, or data-loss defect, which the flat rule
+routes upstream. Threads from a location-bound reviewer are counted and
+recorded, not graded.

--- a/.agents/skills/review-gate/references/vendored-paths.md
+++ b/.agents/skills/review-gate/references/vendored-paths.md
@@ -96,20 +96,27 @@ Once per re-vendor train, on ONE consumer PR, collect upstream-remedy findings
 from BOTH surfaces: the review bodies, AND EVERY vendored-path thread a
 location-bound reviewer left.
 
-`kendex report --skill review-gate --title [TITLE] --body-file [PATH]` routes
-the report upstream. The command is non-interactive: `--title` is required,
-and exactly one of `--body` or `--body-file` must be given — with neither (or
-both) it exits without filing. Two further preconditions, each silent when
-unmet:
+`kendex report --title [TITLE] --body-file [PATH]` files the report. The
+command is non-interactive: `--title` is required, and exactly one of `--body`
+or `--body-file` must be given — with neither (or both) it exits without
+filing. `--dry-run` prints the route it would take. Where the route lands,
+verified against `crates/core/src/report.rs`:
 
-- **The selector is required.** With no `--skill`/`--agent`/`--hook`/`--asset`,
-  the CLI warns once that ownership could not be determined and files against
-  the LOCAL repo.
-- **For a skill, only the installed `SKILL.md` frontmatter decides.** Routing
-  needs the vendored `SKILL.md` present at the install path and carrying
-  `source: kendex` (or the upstream `repository` slug). A repo that vendored
-  only the scripts subtree files locally. Check before relying on it, or open
-  the upstream issue by hand.
+- **`--agent`, `--hook`, and a `--asset` naming either** route on the lock
+  entry's `source_repo`. That is the working path upstream.
+- **`--skill` and a `--asset` naming a skill route to the LOCAL repo.** Skill
+  ownership is read from the installed `SKILL.md` frontmatter alone, and it
+  accepts exactly two values: `source: kendex`, or a `repository:` equal to
+  the built-in `vanillagreencom/kendex` — never what `--upstream` names, which
+  only the lock branch compares against. Neither can match: the reader takes
+  `source:` and `repository:` only at column zero, where a kendex skill nests
+  both under `metadata:`, and renders `repository:` as a URL rather than the
+  slug. Open the upstream issue by hand, or report it under the agent or hook
+  that carries the skill.
+- **With no selector** the CLI warns once that ownership could not be
+  determined and files against the LOCAL repo.
+
+Confirm with `--dry-run` before relying on any of it.
 
 Do not fix it locally, and do not file the same finding from each consumer.
 

--- a/.agents/skills/review-gate/references/vendored-paths.md
+++ b/.agents/skills/review-gate/references/vendored-paths.md
@@ -96,27 +96,26 @@ Once per re-vendor train, on ONE consumer PR, collect upstream-remedy findings
 from BOTH surfaces: the review bodies, AND EVERY vendored-path thread a
 location-bound reviewer left.
 
-`kendex report --title [TITLE] --body-file [PATH]` files the report. The
-command is non-interactive: `--title` is required, and exactly one of `--body`
-or `--body-file` must be given — with neither (or both) it exits without
-filing. `--dry-run` prints the route it would take. Where the route lands,
-verified against `crates/core/src/report.rs`:
+`kendex report --skill [NAME] --title [TITLE] --body-file [PATH]` files the
+report. The command is non-interactive: `--title` is required, and exactly one
+of `--body` or `--body-file` must be given — with neither (or both) it exits
+without filing. `--dry-run` prints the decision and the `gh` command it would
+run.
 
-- **`--agent`, `--hook`, and a `--asset` naming either** route on the lock
-  entry's `source_repo`. That is the working path upstream.
-- **`--skill` and a `--asset` naming a skill route to the LOCAL repo.** Skill
-  ownership is read from the installed `SKILL.md` frontmatter alone, and it
-  accepts exactly two values: `source: kendex`, or a `repository:` equal to
-  the built-in `vanillagreencom/kendex` — never what `--upstream` names, which
-  only the lock branch compares against. Neither can match: the reader takes
-  `source:` and `repository:` only at column zero, where a kendex skill nests
-  both under `metadata:`, and renders `repository:` as a URL rather than the
-  slug. Open the upstream issue by hand, or report it under the agent or hook
-  that carries the skill.
-- **With no selector** the CLI warns once that ownership could not be
-  determined and files against the LOCAL repo.
+The lock is the one judge, and it records provenance for every kind — skills,
+agents, hooks and Pi extensions alike. A name routes upstream when the lock
+holds at least one entry for it, narrowed to the kind the selector names, and
+EVERY matching entry's `source_repo` is the upstream. One entry recorded from
+somewhere else makes the name ambiguous and keeps the report local, which is
+also what an unlocked name gets. How the manifest spelled the repo does not
+decide it: a shorthand, an https URL and a `git@` reference fold to one
+identity. `--skill`, `--agent`, `--hook` and `--asset` are the selectors; with
+none of them the CLI warns once that ownership could not be determined and
+files against the LOCAL repo.
 
-Confirm with `--dry-run` before relying on any of it.
+A repo that vendored only a scripts subtree, with no lock entry over it, has
+no name to select — open the upstream issue by hand. Confirm with `--dry-run`
+before relying on any of it.
 
 Do not fix it locally, and do not file the same finding from each consumer.
 

--- a/.agents/skills/review-gate/references/vendored-paths.md
+++ b/.agents/skills/review-gate/references/vendored-paths.md
@@ -4,10 +4,10 @@ For consumers that vendor an upstream tree byte-for-byte and merge re-vendor
 PRs. Suppressing duplicate upstream findings is a reviewer-instruction
 problem; configuration answers break the gate.
 
-A committed `kendex refresh` tree is the other case: no pin covers it, the
-next refresh overwrites it, and the rule there is flat with no carve-out —
-[rendered-paths.md](rendered-paths.md), which reuses three sections of this
-one.
+A committed `kendex refresh` tree is the other case: no pin covers it, an edit
+under it wedges the next refresh rather than landing, and the rule there is
+flat with no carve-out — [rendered-paths.md](rendered-paths.md), which reuses
+three sections of this one.
 
 ## What suppression must not break
 

--- a/.agents/skills/review-gate/references/vendored-paths.md
+++ b/.agents/skills/review-gate/references/vendored-paths.md
@@ -105,13 +105,15 @@ run.
 The lock is the one judge, and it records provenance for every kind — skills,
 agents, hooks and Pi extensions alike. A name routes upstream when the lock
 holds at least one entry for it, narrowed to the kind the selector names, and
-EVERY matching entry's `source_repo` is the upstream. One entry recorded from
-somewhere else makes the name ambiguous and keeps the report local, which is
-also what an unlocked name gets. How the manifest spelled the repo does not
-decide it: a shorthand, an https URL and a `git@` reference fold to one
-identity. `--skill`, `--agent`, `--hook` and `--asset` are the selectors; with
-none of them the CLI warns once that ownership could not be determined and
-files against the LOCAL repo.
+EVERY matching entry's `source_repo` is kendex's own repo, the one candidate
+the comparison holds — an item vendored from anywhere else files against the
+LOCAL repo, and its issue is opened by hand. One entry recorded from somewhere
+else makes the name ambiguous and keeps the report local, which is also what an
+unlocked name gets. How the manifest spelled the repo does not decide it: a
+shorthand, an https URL and a `git@` reference fold to one identity. `--skill`,
+`--agent`, `--hook` and `--asset` are the selectors; with none of them the CLI
+warns once that ownership could not be determined and files against the LOCAL
+repo.
 
 A repo that vendored only a scripts subtree, with no lock entry over it, has
 no name to select — open the upstream issue by hand. Confirm with `--dry-run`

--- a/.agents/skills/review-gate/references/vendored-paths.md
+++ b/.agents/skills/review-gate/references/vendored-paths.md
@@ -4,6 +4,11 @@ For consumers that vendor an upstream tree byte-for-byte and merge re-vendor
 PRs. Suppressing duplicate upstream findings is a reviewer-instruction
 problem; configuration answers break the gate.
 
+A committed `kendex refresh` tree is the other case: no pin covers it, the
+next refresh overwrites it, and the rule there is flat with no carve-out —
+[rendered-paths.md](rendered-paths.md), which reuses three sections of this
+one.
+
 ## What suppression must not break
 
 **Evidence.** The gate's evidence term needs a trusted non-author review object

--- a/.agents/skills/review-gate/templates/rendered-paths.instructions.md
+++ b/.agents/skills/review-gate/templates/rendered-paths.instructions.md
@@ -40,8 +40,8 @@ that.**
   kind): comment inline as normal, correctness and security defects included.
   On a refresh PR that is the most valuable finding there is.
 - **The fix lands in these rendered bytes**: do not raise it on this PR, on
-  any surface. It is filed against the catalog repo by the session that runs
-  the refresh, and the fix arrives here as a later render.
+  any surface. The session that runs the refresh files it against the catalog
+  repo with `kendex report`, and the fix arrives here as a later render.
 - **The fix lands in the catalog repo's own docs, config, or conventions**
   (its README, its settings tables, its test layout): same route.
 

--- a/.agents/skills/review-gate/templates/rendered-paths.instructions.md
+++ b/.agents/skills/review-gate/templates/rendered-paths.instructions.md
@@ -22,12 +22,14 @@ This tree is `kendex refresh` OUTPUT, rendered from the catalogs `kendex.toml`
 names. The same reviewers see this content in the catalog repo before it
 arrives here.
 
-Nothing under this glob is edited in this repo. The next refresh overwrites
-these files wholesale, so a local fix reads as closed while the bytes go back.
-No pin covers them and nothing turns red on drift. Both statements are about
-the files this glob names and nothing else — a settings or config file kendex
-merges its own entries into is repo-owned, and the rules below never apply to
-one.
+Nothing under this glob is edited in this repo, and an edit here does not
+land. The next refresh reads the disk, finds bytes no apply wrote, and holds
+that item as a conflict — "edited on disk since install — keep it as a fork,
+or apply with edits discarded" — planning no write until someone takes one of
+those exits. A local fix does not reach the repos that share this render; it
+wedges this one's next refresh. That is what this glob names and nothing else:
+a settings or config file kendex merges its own entries into is repo-owned,
+and the rules below never apply to one.
 
 **Route every finding by where its fix would land, and pick the surface from
 that.**

--- a/.agents/skills/review-gate/templates/rendered-paths.instructions.md
+++ b/.agents/skills/review-gate/templates/rendered-paths.instructions.md
@@ -1,0 +1,66 @@
+---
+applyTo: "[RENDERED_GLOB]"
+---
+
+<!-- Copy to .github/instructions/ as a *.instructions.md file, and fill:
+     [RENDERED_GLOB] — the harness trees this repo commits as `kendex refresh`
+     output. Start from the project trees kendex writes: `.agents/**`,
+     `.claude/**`, `.codex/**`, `.cursor/**`, `.gemini/**`, `.opencode/**`,
+     `.pi/**`, and for Copilot `.github/agents/**`, `.github/hooks/**`,
+     `.github/skills/**`. Drop what this repo does not commit, then check the
+     rest against a real refresh PR's file list. Two things this glob must NOT
+     cover: `.github/**` past those three subtrees, and the `.agents` subtree
+     of any item `kendex.toml` marks `source = "in-place"` — that content is
+     this repo's own. Delete this comment.
+     Wiring protocol: review-gate references/rendered-paths.md. -->
+
+This tree is `kendex refresh` OUTPUT, rendered from the catalogs `kendex.toml`
+names. The same reviewers see this content in the catalog repo before it
+arrives here.
+
+Nothing here is edited in this repo. The next refresh overwrites the tree
+wholesale, so a local fix reads as closed while the bytes go back. No pin
+covers it and nothing turns red on drift.
+
+**Route every finding by where its fix would land, and pick the surface from
+that.**
+
+- **The fix lands in a repo-owned file** — settings (`kendex.settings.toml`),
+  `kendex.toml`, the workflow that runs the refresh, CI wiring, adoption glue:
+  comment inline as normal. On a refresh PR that is the most valuable finding
+  there is.
+- **The fix lands in these rendered bytes**: do not raise it on this PR. The
+  remedy is `kendex report`, which files it against the repo that owns the
+  item, and the fix arrives here as a later render.
+- **The fix lands in the catalog repo's own docs, config, or conventions**
+  (its README, its settings tables, its test layout): same route.
+
+**No carve-out.** Not inline, not in a review summary body, and not for a
+correctness, security, or data-loss defect the render would ship here — report
+that one upstream and tell the PR author out of band. The rule is flat so the
+route is the same in every consuming repo, and a defect in a render is fixable
+only where the render is written. A finding whose fix lands in a repo-owned
+file is a different thing and stays an ordinary inline comment.
+
+One refresh lands in several repos at once. Every inline comment opens a
+thread that blocks the merge until someone answers it, so one finding over
+these bytes costs one blocking thread per reviewer per repo, over content
+nobody here can change.
+
+**If every finding you emit is anchored to a file location** — you have no
+review body you author, only a fixed template — do not drop the finding and do
+not spread it. Post ONE consolidated comment for this PR carrying every such
+finding together, anchored anywhere in this tree, and say in it that the
+remedy is upstream and that no local edit is wanted. One thread per reviewer
+per PR is the bound.
+
+**Do not stay silent instead.** Review whatever else the PR touches and submit
+a review: the merge gate needs a review object at this head, so a skipped
+review blocks the merge as hard as an unanswered thread does. A PR touching
+only this tree gets a review with no findings.
+
+Also out of scope here, on any surface: local restructuring of this tree
+(splitting files, style or naming changes, line-count limits, test
+reorganization), requests for repo-local test suites over it, and refresh
+timing — an upstream fix not yet rendered is a coordination note, never a
+merge blocker.

--- a/.agents/skills/review-gate/templates/rendered-paths.instructions.md
+++ b/.agents/skills/review-gate/templates/rendered-paths.instructions.md
@@ -4,43 +4,54 @@ applyTo: "[RENDERED_GLOB]"
 
 <!-- Copy to .github/instructions/ as a *.instructions.md file, and fill:
      [RENDERED_GLOB] — the harness trees this repo commits as `kendex refresh`
-     output. Start from the project trees kendex writes: `.agents/**`,
-     `.claude/**`, `.codex/**`, `.cursor/**`, `.gemini/**`, `.opencode/**`,
-     `.pi/**`, and for Copilot `.github/agents/**`, `.github/hooks/**`,
-     `.github/skills/**`. Drop what this repo does not commit, then check the
-     rest against a real refresh PR's file list. Two things this glob must NOT
-     cover: `.github/**` past those three subtrees, and the `.agents` subtree
-     of any item `kendex.toml` marks `source = "in-place"` — that content is
-     this repo's own. Delete this comment.
-     Wiring protocol: review-gate references/rendered-paths.md. -->
+     output. Start from the project trees kendex writes into:
+     `.agents/skills/**`, `.claude/**`, `.codex/**`, `.cursor/**`,
+     `.gemini/**`, `.opencode/**`, `.pi/**`, and for Copilot
+     `.github/agents/**`, `.github/hooks/**`, `.github/skills/**`. The shared
+     tree is scoped to `skills` on purpose: `.agents/hooks` holds the repo's
+     own adopted hook scripts. Those trees still hold files kendex never
+     writes, and a glob covering one tells this repo's reviewers to skip its
+     own content. Keep OUT: `.github/**` past those three subtrees; the
+     harness memory files CLAUDE.md, AGENTS.md, GEMINI.md; every
+     `.agents/skills/<name>` an item declares in-place; and every structured
+     config or settings file kendex merges into rather than owns.
+     § Deriving the glob in review-gate references/rendered-paths.md names
+     each one and how to derive it here. Delete this comment. -->
 
 This tree is `kendex refresh` OUTPUT, rendered from the catalogs `kendex.toml`
 names. The same reviewers see this content in the catalog repo before it
 arrives here.
 
-Nothing here is edited in this repo. The next refresh overwrites the tree
-wholesale, so a local fix reads as closed while the bytes go back. No pin
-covers it and nothing turns red on drift.
+Nothing under this glob is edited in this repo. The next refresh overwrites
+these files wholesale, so a local fix reads as closed while the bytes go back.
+No pin covers them and nothing turns red on drift. Both statements are about
+the files this glob names and nothing else — a settings or config file kendex
+merges its own entries into is repo-owned, and the rules below never apply to
+one.
 
 **Route every finding by where its fix would land, and pick the surface from
 that.**
 
 - **The fix lands in a repo-owned file** — settings (`kendex.settings.toml`),
-  `kendex.toml`, the workflow that runs the refresh, CI wiring, adoption glue:
-  comment inline as normal. On a refresh PR that is the most valuable finding
-  there is.
-- **The fix lands in these rendered bytes**: do not raise it on this PR. The
-  remedy is `kendex report`, which files it against the repo that owns the
-  item, and the fix arrives here as a later render.
+  `kendex.toml`, the workflow that runs the refresh, CI wiring, adoption glue,
+  and any config or settings file kendex merges entries into while the repo
+  owns the rest (`.claude/settings.json`, `.codex/config.toml`,
+  `.codex/hooks.json`, `.cursor/hooks.json`, `.cursor/mcp.json` and their
+  kind): comment inline as normal, correctness and security defects included.
+  On a refresh PR that is the most valuable finding there is.
+- **The fix lands in these rendered bytes**: do not raise it on this PR, on
+  any surface. It is filed against the catalog repo by the session that runs
+  the refresh, and the fix arrives here as a later render.
 - **The fix lands in the catalog repo's own docs, config, or conventions**
   (its README, its settings tables, its test layout): same route.
 
 **No carve-out.** Not inline, not in a review summary body, and not for a
-correctness, security, or data-loss defect the render would ship here — report
-that one upstream and tell the PR author out of band. The rule is flat so the
-route is the same in every consuming repo, and a defect in a render is fixable
-only where the render is written. A finding whose fix lands in a repo-owned
-file is a different thing and stays an ordinary inline comment.
+correctness, security, or data-loss defect the render would ship here — that
+one goes to the catalog repo too, and to the PR author out of band. The rule
+is flat so the route is the same in every consuming repo, and a defect in a
+render is fixable only where the render is written. A finding whose fix lands
+in a repo-owned file is a different thing and stays an ordinary inline
+comment.
 
 One refresh lands in several repos at once. Every inline comment opens a
 thread that blocks the merge until someone answers it, so one finding over
@@ -48,11 +59,10 @@ these bytes costs one blocking thread per reviewer per repo, over content
 nobody here can change.
 
 **If every finding you emit is anchored to a file location** — you have no
-review body you author, only a fixed template — do not drop the finding and do
-not spread it. Post ONE consolidated comment for this PR carrying every such
-finding together, anchored anywhere in this tree, and say in it that the
-remedy is upstream and that no local edit is wanted. One thread per reviewer
-per PR is the bound.
+review body you author, only a fixed template — the rule does not soften. A
+finding over this tree is not yours to place anywhere on this PR; it goes to
+the catalog repo, and the review you submit carries no finding over the
+render.
 
 **Do not stay silent instead.** Review whatever else the PR touches and submit
 a review: the merge gate needs a review object at this head, so a skipped

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,9 +37,9 @@ an outside contributor.
 - The foot of the app's sidebar names the kendex.ai account you are signed
   in to, says Offline when the server could not be reached, and offers Sign
   in or Sign in again as the credential needs. Clicking opens Settings.
-- The review-gate skill ships a reviewer instruction for the harness trees a
-  repo commits as `kendex refresh` output: a finding over the render goes to
-  the catalog repo, never to a merge-blocking thread the repo cannot act on.
+- The review-gate skill ships a reviewer instruction for a repo that commits
+  its `kendex refresh` output: a finding over the render goes to the catalog
+  repo via `kendex report`, never to a thread the repo cannot act on.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,7 +39,7 @@ an outside contributor.
   in or Sign in again as the credential needs. Clicking opens Settings.
 - The review-gate skill ships a reviewer instruction for the harness trees a
   repo commits as `kendex refresh` output: a finding over the render goes to
-  `kendex report`, never to a merge-blocking thread the repo cannot act on.
+  the catalog repo, never to a merge-blocking thread the repo cannot act on.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,8 +38,8 @@ an outside contributor.
   in to, says Offline when the server could not be reached, and offers Sign
   in or Sign in again as the credential needs. Clicking opens Settings.
 - The review-gate skill ships a reviewer instruction for a repo that commits
-  its `kendex refresh` output: a finding over the render goes to the catalog
-  repo via `kendex report`, never to a thread the repo cannot act on.
+  its `kendex refresh` output: a finding over the render goes upstream rather
+  than into a thread the repo cannot act on.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,9 @@ an outside contributor.
 - The foot of the app's sidebar names the kendex.ai account you are signed
   in to, says Offline when the server could not be reached, and offers Sign
   in or Sign in again as the credential needs. Clicking opens Settings.
+- The review-gate skill ships a reviewer instruction for the harness trees a
+  repo commits as `kendex refresh` output: a finding over the render goes to
+  `kendex report`, never to a merge-blocking thread the repo cannot act on.
 
 ### Changed
 

--- a/skills/review-gate/SKILL.md
+++ b/skills/review-gate/SKILL.md
@@ -279,4 +279,8 @@ ENGINE's proofs and run in the kendex repo, not in a consumer's CI:
 
 For re-vendor PRs, suppress duplicate findings with the remedy-locus reviewer
 instruction, never a reviewer path exclusion:
-[references/vendored-paths.md](references/vendored-paths.md).
+[references/vendored-paths.md](references/vendored-paths.md). A committed
+`kendex refresh` tree is the same problem with no pin over it and a blast
+radius of every consuming repo; it routes every finding over the render
+upstream, with no carve-out:
+[references/rendered-paths.md](references/rendered-paths.md).

--- a/skills/review-gate/references/rendered-paths.md
+++ b/skills/review-gate/references/rendered-paths.md
@@ -12,9 +12,9 @@ break**, **The trap: reviewer path exclusion**, and **Reviewer classes**.
 
 | | Byte-pinned vendored tree | Harness render |
 |---|---|---|
-| What reverts a local edit | Nothing automatic; the pin turns red | The next `kendex refresh`, wholesale and silently |
-| A pin or checksum manifest | Exists, and is the point | Does not exist |
-| A local fix | Wrong, and visible | Reads as closed while the bytes go back |
+| What a local edit meets | Nothing automatic; the pin turns red | The next `kendex refresh` holds the item as a conflict and plans no write |
+| A pin or checksum manifest | Exists, and is the point | Does not exist — the refresh's own conflict row is the red |
+| A local fix | Wrong, and visible | Wedges that item's refresh until someone forks it or discards the edit |
 | The upstream remedy | Re-vendor | An issue in the catalog repo, then re-render |
 | Blast radius of one thread | This repo | Every consuming repo on its next refresh |
 
@@ -106,7 +106,7 @@ Four shapes the glob must not take:
   output, and — outside every dot-directory, so the candidate list cannot see
   it — the root `opencode.json` or `opencode.jsonc`. This is the shape that
   most needs keeping out. The template asserts that nothing under the glob is
-  edited here and that a refresh overwrites it wholesale; over a merged path
+  edited here and that an edit wedges the next refresh; over a merged path
   both are false, and the flat no-carve-out rule would then forbid raising a
   correctness or security defect over content this repo owns and can fix.
 

--- a/skills/review-gate/references/rendered-paths.md
+++ b/skills/review-gate/references/rendered-paths.md
@@ -51,12 +51,13 @@ candidate list to check against that PR.
 # including .vscode, .devcontainer, .husky and the rest.
 git ls-files | grep -oE '^\.[a-z]+/' | sort -u
 
-# Items whose content this repo owns. Subtract the UNION of both lists: the
-# manifest is the declaration, the lock is what the last apply recorded, and
-# an item kendex refused to install keeps its old lock entry verbatim through
-# every later refresh — where they disagree, the manifest settles it.
-awk -F'[].[]' '/^\[/ { t = $2; n = $3 } /^[[:space:]]*source[[:space:]]*=[[:space:]]*.in-place./ { print t "/" n }' kendex.toml
-jq -r '.entries | to_entries[] | select(.value.source == "in-place") | .value.name' .kendex-lock.json | sort -u
+# Skills whose content this repo owns, as bare names from both sides so the
+# two lists subtract. Take the UNION: the manifest is the declaration, the
+# lock is what the last apply recorded, and an item kendex refused to install
+# keeps its old lock entry verbatim through every later refresh — where they
+# disagree, the manifest settles it.
+awk -F'[].[]' '/^\[skills\./ { n = $3 } /^[[:space:]]*source[[:space:]]*=[[:space:]]*.in-place./ { if (n != "") print n; n = "" }' kendex.toml
+jq -r '.entries[] | select(.source == "in-place" and .kind == "skill") | .name' .kendex-lock.json | sort -u
 
 # Recorded render destinations, as absolute paths to strip the repo root
 # from. The lock carries this field for skills and commands only, so it names
@@ -64,6 +65,21 @@ jq -r '.entries | to_entries[] | select(.value.source == "in-place") | .value.na
 # exact paths and never completes the list.
 jq -r '.entries[] | select(.emitted != null) | .emitted.paths[]' .kendex-lock.json | sort -u
 ```
+
+That awk reads top-level `[skills.<name>]` tables in `kendex.toml` and
+nothing else. It does not see a `[skills]` table holding inline entries,
+dotted or quoted keys, an indented declaration, or `kendex-local.toml`, which
+a source catalog keeps its own install state in. A repo wanting a mechanical
+answer over those has a worked precedent in the harness-ci skill's
+`harness-only` script, § `manifest_carves`: it reads both manifests from the
+head tree and fails closed, carving every skill path when a manifest exists
+and will not parse. Do not build a second one here.
+
+What backstops the gap is the section's own authority: an in-place skill's
+content tree at `.agents/skills/<name>` is bytes kendex reads and never
+writes, so a refresh PR never touches it. The per-harness link or copy into
+`.claude/skills/<name>` and its siblings IS written, and does appear in the PR
+that creates it.
 
 Four shapes the glob must not take:
 
@@ -128,25 +144,26 @@ on ONE consumer PR, collect the findings over the render and file them where
 the render is written. Do not fix it locally, and do not file the same finding
 from each consumer.
 
-`kendex report --title [TITLE] --body-file [PATH]` files it, with one selector
-and exactly one of `--body` or `--body-file`. `--dry-run` prints the route it
-would take. What the route resolves to today, verified against
-`crates/core/src/report.rs`:
+```bash
+kendex report --skill [NAME] --title [TITLE] --body-file [PATH] --dry-run
+```
 
-- **`--agent`, `--hook`, and a `--asset` naming either** route on the lock
-  entry's `source_repo`. That is the working path.
-- **`--skill` and a `--asset` naming a skill route to this repo, not
-  upstream.** Skill ownership is read from the installed `SKILL.md`
-  frontmatter alone, and it accepts exactly two values: `source: kendex`, or a
-  `repository:` equal to the built-in `vanillagreencom/kendex` — never what
-  `--upstream` names, which only the lock branch compares against. Neither can
-  match: the reader takes `source:` and `repository:` only at column zero,
-  where a kendex skill nests both under `metadata:`, and renders `repository:`
-  as a URL rather than the slug. Open the issue in the catalog repo by hand,
-  or report it under the agent or hook that carries the skill.
-- **With no selector** the CLI warns once and files against this repo.
+`--skill`, `--agent`, `--hook`, and `--asset` are the selectors; pass one, and
+exactly one of `--body` or `--body-file`. `--dry-run` prints the decision and
+the `gh` command it would run.
 
-Confirm with `--dry-run` before relying on any of it.
+The lock is the one judge, and it records provenance for every kind — skills,
+agents, hooks and Pi extensions alike. A name routes to the catalog repo when
+the lock holds at least one entry for it, narrowed to the kind the selector
+names, and EVERY matching entry's `source_repo` is that repo. One entry
+recorded from somewhere else makes the name ambiguous and keeps the report
+here, which is also what an unlocked name gets. How the manifest spelled the
+repo does not decide it: a shorthand, an https URL and a `git@` reference fold
+to one identity.
+
+With no selector at all the CLI warns once that ownership could not be
+determined and files against this repo. Confirm with `--dry-run` before
+relying on any of it.
 
 ## Verifying on a real refresh PR
 

--- a/skills/review-gate/references/rendered-paths.md
+++ b/skills/review-gate/references/rendered-paths.md
@@ -42,25 +42,27 @@ hook's own script into `.agents/hooks` and rewrites the registration around
 it, and that script is the repo's. Each of the rest can also hold files kendex
 never writes.
 
-Start by listing candidates, then subtract:
+**The file list of a real refresh PR is the authority.** kendex exposes no
+single answer to what it renders here, and the commands below only build a
+candidate list to check against that PR.
 
 ```bash
 # Candidates only — this lists every tracked lowercase dot-directory,
-# including .vscode, .devcontainer, .husky and the rest. It is not an answer.
+# including .vscode, .devcontainer, .husky and the rest.
 git ls-files | grep -oE '^\.[a-z]+/' | sort -u
 
-# Items whose content this repo owns. The manifest is the declaration; the
-# lock is what the last apply recorded, and the two disagree until a refresh
-# rewrites the lock, so read both.
+# Items whose content this repo owns. Subtract the UNION of both lists: the
+# manifest is the declaration, the lock is what the last apply recorded, and
+# an item kendex refused to install keeps its old lock entry verbatim through
+# every later refresh — where they disagree, the manifest settles it.
 awk -F'[].[]' '/^\[/ { t = $2; n = $3 } /^[[:space:]]*source[[:space:]]*=[[:space:]]*.in-place./ { print t "/" n }' kendex.toml
 jq -r '.entries | to_entries[] | select(.value.source == "in-place") | .value.name' .kendex-lock.json | sort -u
 
-# Exact render destinations, where the lock recorded them, as absolute paths
-# to strip the repo root from. Absent on entries written before the field
-# existed, so this narrows the list and never completes it — compare the
-# count against the entry count.
+# Recorded render destinations, as absolute paths to strip the repo root
+# from. The lock carries this field for skills and commands only, so it names
+# no agent file, no hook script, and nothing for the other kinds — it adds
+# exact paths and never completes the list.
 jq -r '.entries[] | select(.emitted != null) | .emitted.paths[]' .kendex-lock.json | sort -u
-jq -r '"emitted on \([.entries[] | select(.emitted != null)] | length) of \(.entries | length) entries"' .kendex-lock.json
 ```
 
 Four shapes the glob must not take:
@@ -75,22 +77,26 @@ Four shapes the glob must not take:
   edited here. The subtraction is a name list, from the two commands above.
   The item's per-harness copies are still render output.
 - **The harness memory files** — `CLAUDE.md`, `AGENTS.md`, `GEMINI.md`.
-  kendex writes none of them; they are project markers it reads. A repo
-  keeping `.claude/CLAUDE.md` has one inside a `.claude/**` glob.
-- **Structured config and settings files kendex merges into.** It writes its
-  own entries and leaves the rest of the file alone: `.claude/settings.json`
-  and `settings.local.json`, `.codex/config.toml`, `.codex/hooks.json`,
-  `.cursor/hooks.json`, `.cursor/mcp.json`, `.gemini/settings.json`,
-  `.mcp.json`, the Copilot files above, and — outside every dot-directory, so
-  the candidate list above cannot see it — the root `opencode.json` or
-  `opencode.jsonc`. This is the shape that most needs keeping out. The
-  template asserts that nothing under the glob is edited here and that a
-  refresh overwrites it wholesale; over a merged file both are false, and the
-  flat no-carve-out rule would then forbid raising a correctness or security
-  defect over content this repo owns and can fix.
+  kendex writes none of them. A repo keeping `.claude/CLAUDE.md` has one
+  inside a `.claude/**` glob.
+- **Anything kendex merges into rather than writes whole.** This is a class,
+  not a list: where kendex writes its own entries into a file or directory the
+  repo owns the rest of, that path is repo-owned and stays out. Named
+  instances, which are examples and not the whole set —
+  `.claude/settings.json` and `settings.local.json`, `.codex/config.toml`,
+  `.codex/hooks.json`, `.cursor/hooks.json`, `.cursor/mcp.json`,
+  `.gemini/settings.json`, `.pi/settings.json`, `.mcp.json`, the Copilot files
+  above, `.opencode/instructions/` where only `kendex-hook-*.md` is render
+  output, and — outside every dot-directory, so the candidate list cannot see
+  it — the root `opencode.json` or `opencode.jsonc`. This is the shape that
+  most needs keeping out. The template asserts that nothing under the glob is
+  edited here and that a refresh overwrites it wholesale; over a merged path
+  both are false, and the flat no-carve-out rule would then forbid raising a
+  correctness or security defect over content this repo owns and can fix.
 
-Check the result against the file list of a real refresh PR before relying on
-it.
+Read the shapes as the rule and the file list of a real refresh PR as the
+check. A path that appears in neither the candidate list nor that PR does not
+belong in the glob.
 
 ## Wiring a repo
 

--- a/skills/review-gate/references/rendered-paths.md
+++ b/skills/review-gate/references/rendered-paths.md
@@ -15,7 +15,7 @@ break**, **The trap: reviewer path exclusion**, and **Reviewer classes**.
 | What reverts a local edit | Nothing automatic; the pin turns red | The next `kendex refresh`, wholesale and silently |
 | A pin or checksum manifest | Exists, and is the point | Does not exist |
 | A local fix | Wrong, and visible | Reads as closed while the bytes go back |
-| The upstream remedy | Re-vendor | `kendex report`, then re-render |
+| The upstream remedy | Re-vendor | An issue in the catalog repo, then re-render |
 | Blast radius of one thread | This repo | Every consuming repo on its next refresh |
 
 The last row is what changes the rule. The vendored template routes
@@ -23,33 +23,71 @@ upstream-remedy findings to the review summary body and keeps one carve-out: a
 correctness, security, or data-loss regression the bump introduces gets an
 inline comment and blocks.
 
-**Over a render the carve-out goes.** It is the clause a reviewer argues with,
-and a bot that believes it found a security defect in rendered output takes it
-every time. The thread it opens blocks the merge until answered, in several
-consuming repos at once, for a fix that can land in none of them. The rule
-here is flat on every surface, and the remedy is `kendex report`.
+**Over a render the carve-out goes, and so does the summary-body route.** The
+carve-out is the clause a reviewer argues with, and a bot that believes it
+found a security defect in rendered output takes it every time. The thread it
+opens blocks the merge until answered, in several consuming repos at once, for
+a fix that can land in none of them. The rule here is flat on every surface,
+which also removes the reason the vendored template gives a location-bound
+reviewer a consolidated-comment fallback: under a flat rule there is no
+on-PR surface to fall back to.
 
 ## Deriving the glob
 
-Two commands, run in the consumer repo:
+The trees kendex writes into a project are `.agents/skills`, `.claude`,
+`.codex`, `.cursor`, `.gemini`, `.opencode`, `.pi`, and for Copilot the
+`agents`, `hooks`, and `skills` subtrees of `.github`. The shared tree is
+scoped to `skills` rather than all of `.agents`: adoption moves a custom
+hook's own script into `.agents/hooks` and rewrites the registration around
+it, and that script is the repo's. Each of the rest can also hold files kendex
+never writes.
+
+Start by listing candidates, then subtract:
 
 ```bash
-# 1. The harness trees this repo commits.
+# Candidates only — this lists every tracked lowercase dot-directory,
+# including .vscode, .devcontainer, .husky and the rest. It is not an answer.
 git ls-files | grep -oE '^\.[a-z]+/' | sort -u
 
-# 2. Items whose content this repo owns — their .agents subtree is NOT
-#    render output and gets an ordinary review.
-grep -E '^\[|^source = ' kendex.toml | grep -B1 '^source = "in-place"'
+# Items whose content this repo owns. The manifest is the declaration; the
+# lock is what the last apply recorded, and the two disagree until a refresh
+# rewrites the lock, so read both.
+awk -F'[].[]' '/^\[/ { t = $2; n = $3 } /^[[:space:]]*source[[:space:]]*=[[:space:]]*.in-place./ { print t "/" n }' kendex.toml
+jq -r '.entries | to_entries[] | select(.value.source == "in-place") | .value.name' .kendex-lock.json | sort -u
+
+# Exact render destinations, where the lock recorded them, as absolute paths
+# to strip the repo root from. Absent on entries written before the field
+# existed, so this narrows the list and never completes it — compare the
+# count against the entry count.
+jq -r '.entries[] | select(.emitted != null) | .emitted.paths[]' .kendex-lock.json | sort -u
+jq -r '"emitted on \([.entries[] | select(.emitted != null)] | length) of \(.entries | length) entries"' .kendex-lock.json
 ```
 
-Two shapes the glob must not take:
+Four shapes the glob must not take:
 
 - **`.github/**`.** Copilot renders into `.github/agents`, `.github/hooks`,
-  and `.github/skills`; the rest of `.github` — workflows, this instruction
-  directory, issue templates — is repo-owned and gets an ordinary review.
-- **A whole `.agents/**` in a repo holding in-place items.** An item declared
-  `source = "in-place"` keeps its content of record at `.agents/<kind>/<name>`
-  and is edited here. Its per-harness copies are still render output.
+  and `.github/skills`. The rest of `.github` — workflows, this instruction
+  directory, issue templates — is repo-owned. `.github/mcp.json` and
+  `.github/copilot/settings.json` plus `settings.local.json` are a third
+  thing, covered by the last shape below.
+- **Every `.agents/skills/<name>` an item declares in-place.** An item
+  declared `source = "in-place"` keeps its content of record there and is
+  edited here. The subtraction is a name list, from the two commands above.
+  The item's per-harness copies are still render output.
+- **The harness memory files** — `CLAUDE.md`, `AGENTS.md`, `GEMINI.md`.
+  kendex writes none of them; they are project markers it reads. A repo
+  keeping `.claude/CLAUDE.md` has one inside a `.claude/**` glob.
+- **Structured config and settings files kendex merges into.** It writes its
+  own entries and leaves the rest of the file alone: `.claude/settings.json`
+  and `settings.local.json`, `.codex/config.toml`, `.codex/hooks.json`,
+  `.cursor/hooks.json`, `.cursor/mcp.json`, `.gemini/settings.json`,
+  `.mcp.json`, the Copilot files above, and — outside every dot-directory, so
+  the candidate list above cannot see it — the root `opencode.json` or
+  `opencode.jsonc`. This is the shape that most needs keeping out. The
+  template asserts that nothing under the glob is edited here and that a
+  refresh overwrites it wholesale; over a merged file both are false, and the
+  flat no-carve-out rule would then forbid raising a correctness or security
+  defect over content this repo owns and can fix.
 
 Check the result against the file list of a real refresh PR before relying on
 it.
@@ -65,9 +103,11 @@ it.
    alongside it.** Merge any repo-specific carve-ins the old clause held into
    the new body.
 3. Classify each reviewer the repo runs as summary-capable or location-bound
-   ([vendored-paths.md](vendored-paths.md) § Reviewer classes). A repo whose
-   reviewers are ALL location-bound gets the one-consolidated-comment bound,
-   not silence.
+   ([vendored-paths.md](vendored-paths.md) § Reviewer classes). The flat rule
+   asks the same thing of both: no finding over the render on any surface of
+   this PR, and a submitted review either way. The residual that section
+   records still holds — a reviewer whose schema binds one finding to one
+   location emits a thread anyway, and that is answered, not graded.
 4. Mirror the rule in the repo's reviewer-guidance file, for reviewers that do
    not read path-scoped instructions.
 5. Change no gate settings. A render tree carries evidence only through the
@@ -75,32 +115,41 @@ it.
    ([settings.md](settings.md)), and hand-edited policy markdown under it
    belongs in `REVIEW_GATE_CARRY_FORWARD_EXCLUDE`, which wins.
 
-## Reporting a finding upstream
+## Filing the finding against the catalog repo
 
-`kendex report --skill [NAME] --title [TITLE] --body-file [PATH]` routes the
-issue to the repo that owns the item. `--agent`, `--hook`, and `--asset` are
-the other selectors; pass at most one, and pass exactly one of `--body` or
-`--body-file`. Two preconditions decide the route:
+This is the refresh session's half, not a reviewer's. Once per refresh train,
+on ONE consumer PR, collect the findings over the render and file them where
+the render is written. Do not fix it locally, and do not file the same finding
+from each consumer.
 
-- **A skill routes on its installed `SKILL.md` frontmatter alone** — `source:
-  kendex`, or a `repository:` naming the upstream slug. A committed render
-  carries that frontmatter at the install path, which is what a scripts-only
-  vendor lacks.
-- **An agent, hook, or Pi extension routes on the lock entry** — its
-  `source_repo` must match the upstream the report targets.
+`kendex report --title [TITLE] --body-file [PATH]` files it, with one selector
+and exactly one of `--body` or `--body-file`. `--dry-run` prints the route it
+would take. What the route resolves to today, verified against
+`crates/core/src/report.rs`:
 
-With no selector the CLI warns once and files against this repo. Verify the
-route before relying on it, or open the upstream issue by hand.
+- **`--agent`, `--hook`, and a `--asset` naming either** route on the lock
+  entry's `source_repo`. That is the working path.
+- **`--skill` and a `--asset` naming a skill route to this repo, not
+  upstream.** Skill ownership is read from the installed `SKILL.md`
+  frontmatter alone, and it accepts exactly two values: `source: kendex`, or a
+  `repository:` equal to the built-in `vanillagreencom/kendex` — never what
+  `--upstream` names, which only the lock branch compares against. Neither can
+  match: the reader takes `source:` and `repository:` only at column zero,
+  where a kendex skill nests both under `metadata:`, and renders `repository:`
+  as a URL rather than the slug. Open the issue in the catalog repo by hand,
+  or report it under the agent or hook that carries the skill.
+- **With no selector** the CLI warns once and files against this repo.
 
-Do not fix it locally, and do not file the same finding from each consumer.
+Confirm with `--dry-run` before relying on any of it.
 
 ## Verifying on a real refresh PR
 
 Run [vendored-paths.md](vendored-paths.md) § Verifying on a real re-vendor PR
 against the first refresh PR after the change, reading `pr-threads` over the
-render trees rather than the vendored one. **Pass** for a render is stricter:
-a trusted non-author review object at the current head, gate `success`, and no
-unresolved thread over the render from a summary-capable reviewer — including
-none raising a correctness, security, or data-loss defect, which the flat rule
-routes upstream. Threads from a location-bound reviewer are counted and
-recorded, not graded.
+render trees rather than the vendored one. **Pass** for a render is stricter
+in one term: a trusted non-author review object at the current head, gate
+`success`, and no unresolved thread over the render from a summary-capable
+reviewer — including none raising a correctness, security, or data-loss
+defect, which the flat rule routes to the catalog repo and the vendored
+carve-out would have admitted. Threads from a location-bound reviewer are
+counted and recorded, not graded.

--- a/skills/review-gate/references/rendered-paths.md
+++ b/skills/review-gate/references/rendered-paths.md
@@ -153,13 +153,18 @@ exactly one of `--body` or `--body-file`. `--dry-run` prints the decision and
 the `gh` command it would run.
 
 The lock is the one judge, and it records provenance for every kind — skills,
-agents, hooks and Pi extensions alike. A name routes to the catalog repo when
-the lock holds at least one entry for it, narrowed to the kind the selector
-names, and EVERY matching entry's `source_repo` is that repo. One entry
-recorded from somewhere else makes the name ambiguous and keeps the report
-here, which is also what an unlocked name gets. How the manifest spelled the
-repo does not decide it: a shorthand, an https URL and a `git@` reference fold
-to one identity.
+agents, hooks and Pi extensions alike. A name routes upstream when the lock
+holds at least one entry for it, narrowed to the kind the selector names, and
+EVERY matching entry's `source_repo` is kendex's own repo, the one candidate
+the comparison holds. One entry recorded from somewhere else makes the name
+ambiguous and keeps the report here, which is also what an unlocked name gets.
+How the manifest spelled the repo does not decide it: a shorthand, an https URL
+and a `git@` reference fold to one identity.
+
+**Kendex is the only destination the route reaches.** An item rendered from a
+third-party catalog carries that catalog in its lock entries, never the
+candidate, and its report files against this repo — open the issue in that
+catalog by hand.
 
 With no selector at all the CLI warns once that ownership could not be
 determined and files against this repo. Confirm with `--dry-run` before

--- a/skills/review-gate/references/rendered-paths.md
+++ b/skills/review-gate/references/rendered-paths.md
@@ -1,0 +1,106 @@
+# Reviewing the committed harness render
+
+For consumers that commit `kendex refresh` output and merge refresh PRs.
+Suppressing duplicate findings over that tree is a reviewer-instruction
+problem; configuration answers break the gate.
+
+The byte-pinned sibling is [vendored-paths.md](vendored-paths.md). Three of its
+sections apply here unchanged and are not restated: **What suppression must not
+break**, **The trap: reviewer path exclusion**, and **Reviewer classes**.
+
+## What is different from a byte-pinned tree
+
+| | Byte-pinned vendored tree | Harness render |
+|---|---|---|
+| What reverts a local edit | Nothing automatic; the pin turns red | The next `kendex refresh`, wholesale and silently |
+| A pin or checksum manifest | Exists, and is the point | Does not exist |
+| A local fix | Wrong, and visible | Reads as closed while the bytes go back |
+| The upstream remedy | Re-vendor | `kendex report`, then re-render |
+| Blast radius of one thread | This repo | Every consuming repo on its next refresh |
+
+The last row is what changes the rule. The vendored template routes
+upstream-remedy findings to the review summary body and keeps one carve-out: a
+correctness, security, or data-loss regression the bump introduces gets an
+inline comment and blocks.
+
+**Over a render the carve-out goes.** It is the clause a reviewer argues with,
+and a bot that believes it found a security defect in rendered output takes it
+every time. The thread it opens blocks the merge until answered, in several
+consuming repos at once, for a fix that can land in none of them. The rule
+here is flat on every surface, and the remedy is `kendex report`.
+
+## Deriving the glob
+
+Two commands, run in the consumer repo:
+
+```bash
+# 1. The harness trees this repo commits.
+git ls-files | grep -oE '^\.[a-z]+/' | sort -u
+
+# 2. Items whose content this repo owns — their .agents subtree is NOT
+#    render output and gets an ordinary review.
+grep -E '^\[|^source = ' kendex.toml | grep -B1 '^source = "in-place"'
+```
+
+Two shapes the glob must not take:
+
+- **`.github/**`.** Copilot renders into `.github/agents`, `.github/hooks`,
+  and `.github/skills`; the rest of `.github` — workflows, this instruction
+  directory, issue templates — is repo-owned and gets an ordinary review.
+- **A whole `.agents/**` in a repo holding in-place items.** An item declared
+  `source = "in-place"` keeps its content of record at `.agents/<kind>/<name>`
+  and is edited here. Its per-harness copies are still render output.
+
+Check the result against the file list of a real refresh PR before relying on
+it.
+
+## Wiring a repo
+
+1. Copy [`../templates/rendered-paths.instructions.md`](../templates/rendered-paths.instructions.md)
+   into the repo's path-scoped reviewer instruction directory —
+   `.github/instructions/`, as a `*.instructions.md` file — set `applyTo` to
+   the glob derived above, and delete the fill comment. Repo-owned after the
+   copy.
+2. **Replace any existing instruction scoped to the same tree — do not add
+   alongside it.** Merge any repo-specific carve-ins the old clause held into
+   the new body.
+3. Classify each reviewer the repo runs as summary-capable or location-bound
+   ([vendored-paths.md](vendored-paths.md) § Reviewer classes). A repo whose
+   reviewers are ALL location-bound gets the one-consolidated-comment bound,
+   not silence.
+4. Mirror the rule in the repo's reviewer-guidance file, for reviewers that do
+   not read path-scoped instructions.
+5. Change no gate settings. A render tree carries evidence only through the
+   `vendored` class and `REVIEW_GATE_VENDORED_PATHS`
+   ([settings.md](settings.md)), and hand-edited policy markdown under it
+   belongs in `REVIEW_GATE_CARRY_FORWARD_EXCLUDE`, which wins.
+
+## Reporting a finding upstream
+
+`kendex report --skill [NAME] --title [TITLE] --body-file [PATH]` routes the
+issue to the repo that owns the item. `--agent`, `--hook`, and `--asset` are
+the other selectors; pass at most one, and pass exactly one of `--body` or
+`--body-file`. Two preconditions decide the route:
+
+- **A skill routes on its installed `SKILL.md` frontmatter alone** — `source:
+  kendex`, or a `repository:` naming the upstream slug. A committed render
+  carries that frontmatter at the install path, which is what a scripts-only
+  vendor lacks.
+- **An agent, hook, or Pi extension routes on the lock entry** — its
+  `source_repo` must match the upstream the report targets.
+
+With no selector the CLI warns once and files against this repo. Verify the
+route before relying on it, or open the upstream issue by hand.
+
+Do not fix it locally, and do not file the same finding from each consumer.
+
+## Verifying on a real refresh PR
+
+Run [vendored-paths.md](vendored-paths.md) § Verifying on a real re-vendor PR
+against the first refresh PR after the change, reading `pr-threads` over the
+render trees rather than the vendored one. **Pass** for a render is stricter:
+a trusted non-author review object at the current head, gate `success`, and no
+unresolved thread over the render from a summary-capable reviewer — including
+none raising a correctness, security, or data-loss defect, which the flat rule
+routes upstream. Threads from a location-bound reviewer are counted and
+recorded, not graded.

--- a/skills/review-gate/references/vendored-paths.md
+++ b/skills/review-gate/references/vendored-paths.md
@@ -96,20 +96,27 @@ Once per re-vendor train, on ONE consumer PR, collect upstream-remedy findings
 from BOTH surfaces: the review bodies, AND EVERY vendored-path thread a
 location-bound reviewer left.
 
-`kendex report --skill review-gate --title [TITLE] --body-file [PATH]` routes
-the report upstream. The command is non-interactive: `--title` is required,
-and exactly one of `--body` or `--body-file` must be given — with neither (or
-both) it exits without filing. Two further preconditions, each silent when
-unmet:
+`kendex report --title [TITLE] --body-file [PATH]` files the report. The
+command is non-interactive: `--title` is required, and exactly one of `--body`
+or `--body-file` must be given — with neither (or both) it exits without
+filing. `--dry-run` prints the route it would take. Where the route lands,
+verified against `crates/core/src/report.rs`:
 
-- **The selector is required.** With no `--skill`/`--agent`/`--hook`/`--asset`,
-  the CLI warns once that ownership could not be determined and files against
-  the LOCAL repo.
-- **For a skill, only the installed `SKILL.md` frontmatter decides.** Routing
-  needs the vendored `SKILL.md` present at the install path and carrying
-  `source: kendex` (or the upstream `repository` slug). A repo that vendored
-  only the scripts subtree files locally. Check before relying on it, or open
-  the upstream issue by hand.
+- **`--agent`, `--hook`, and a `--asset` naming either** route on the lock
+  entry's `source_repo`. That is the working path upstream.
+- **`--skill` and a `--asset` naming a skill route to the LOCAL repo.** Skill
+  ownership is read from the installed `SKILL.md` frontmatter alone, and it
+  accepts exactly two values: `source: kendex`, or a `repository:` equal to
+  the built-in `vanillagreencom/kendex` — never what `--upstream` names, which
+  only the lock branch compares against. Neither can match: the reader takes
+  `source:` and `repository:` only at column zero, where a kendex skill nests
+  both under `metadata:`, and renders `repository:` as a URL rather than the
+  slug. Open the upstream issue by hand, or report it under the agent or hook
+  that carries the skill.
+- **With no selector** the CLI warns once that ownership could not be
+  determined and files against the LOCAL repo.
+
+Confirm with `--dry-run` before relying on any of it.
 
 Do not fix it locally, and do not file the same finding from each consumer.
 

--- a/skills/review-gate/references/vendored-paths.md
+++ b/skills/review-gate/references/vendored-paths.md
@@ -96,27 +96,26 @@ Once per re-vendor train, on ONE consumer PR, collect upstream-remedy findings
 from BOTH surfaces: the review bodies, AND EVERY vendored-path thread a
 location-bound reviewer left.
 
-`kendex report --title [TITLE] --body-file [PATH]` files the report. The
-command is non-interactive: `--title` is required, and exactly one of `--body`
-or `--body-file` must be given — with neither (or both) it exits without
-filing. `--dry-run` prints the route it would take. Where the route lands,
-verified against `crates/core/src/report.rs`:
+`kendex report --skill [NAME] --title [TITLE] --body-file [PATH]` files the
+report. The command is non-interactive: `--title` is required, and exactly one
+of `--body` or `--body-file` must be given — with neither (or both) it exits
+without filing. `--dry-run` prints the decision and the `gh` command it would
+run.
 
-- **`--agent`, `--hook`, and a `--asset` naming either** route on the lock
-  entry's `source_repo`. That is the working path upstream.
-- **`--skill` and a `--asset` naming a skill route to the LOCAL repo.** Skill
-  ownership is read from the installed `SKILL.md` frontmatter alone, and it
-  accepts exactly two values: `source: kendex`, or a `repository:` equal to
-  the built-in `vanillagreencom/kendex` — never what `--upstream` names, which
-  only the lock branch compares against. Neither can match: the reader takes
-  `source:` and `repository:` only at column zero, where a kendex skill nests
-  both under `metadata:`, and renders `repository:` as a URL rather than the
-  slug. Open the upstream issue by hand, or report it under the agent or hook
-  that carries the skill.
-- **With no selector** the CLI warns once that ownership could not be
-  determined and files against the LOCAL repo.
+The lock is the one judge, and it records provenance for every kind — skills,
+agents, hooks and Pi extensions alike. A name routes upstream when the lock
+holds at least one entry for it, narrowed to the kind the selector names, and
+EVERY matching entry's `source_repo` is the upstream. One entry recorded from
+somewhere else makes the name ambiguous and keeps the report local, which is
+also what an unlocked name gets. How the manifest spelled the repo does not
+decide it: a shorthand, an https URL and a `git@` reference fold to one
+identity. `--skill`, `--agent`, `--hook` and `--asset` are the selectors; with
+none of them the CLI warns once that ownership could not be determined and
+files against the LOCAL repo.
 
-Confirm with `--dry-run` before relying on any of it.
+A repo that vendored only a scripts subtree, with no lock entry over it, has
+no name to select — open the upstream issue by hand. Confirm with `--dry-run`
+before relying on any of it.
 
 Do not fix it locally, and do not file the same finding from each consumer.
 

--- a/skills/review-gate/references/vendored-paths.md
+++ b/skills/review-gate/references/vendored-paths.md
@@ -4,10 +4,10 @@ For consumers that vendor an upstream tree byte-for-byte and merge re-vendor
 PRs. Suppressing duplicate upstream findings is a reviewer-instruction
 problem; configuration answers break the gate.
 
-A committed `kendex refresh` tree is the other case: no pin covers it, the
-next refresh overwrites it, and the rule there is flat with no carve-out —
-[rendered-paths.md](rendered-paths.md), which reuses three sections of this
-one.
+A committed `kendex refresh` tree is the other case: no pin covers it, an edit
+under it wedges the next refresh rather than landing, and the rule there is
+flat with no carve-out — [rendered-paths.md](rendered-paths.md), which reuses
+three sections of this one.
 
 ## What suppression must not break
 

--- a/skills/review-gate/references/vendored-paths.md
+++ b/skills/review-gate/references/vendored-paths.md
@@ -105,13 +105,15 @@ run.
 The lock is the one judge, and it records provenance for every kind — skills,
 agents, hooks and Pi extensions alike. A name routes upstream when the lock
 holds at least one entry for it, narrowed to the kind the selector names, and
-EVERY matching entry's `source_repo` is the upstream. One entry recorded from
-somewhere else makes the name ambiguous and keeps the report local, which is
-also what an unlocked name gets. How the manifest spelled the repo does not
-decide it: a shorthand, an https URL and a `git@` reference fold to one
-identity. `--skill`, `--agent`, `--hook` and `--asset` are the selectors; with
-none of them the CLI warns once that ownership could not be determined and
-files against the LOCAL repo.
+EVERY matching entry's `source_repo` is kendex's own repo, the one candidate
+the comparison holds — an item vendored from anywhere else files against the
+LOCAL repo, and its issue is opened by hand. One entry recorded from somewhere
+else makes the name ambiguous and keeps the report local, which is also what an
+unlocked name gets. How the manifest spelled the repo does not decide it: a
+shorthand, an https URL and a `git@` reference fold to one identity. `--skill`,
+`--agent`, `--hook` and `--asset` are the selectors; with none of them the CLI
+warns once that ownership could not be determined and files against the LOCAL
+repo.
 
 A repo that vendored only a scripts subtree, with no lock entry over it, has
 no name to select — open the upstream issue by hand. Confirm with `--dry-run`

--- a/skills/review-gate/references/vendored-paths.md
+++ b/skills/review-gate/references/vendored-paths.md
@@ -4,6 +4,11 @@ For consumers that vendor an upstream tree byte-for-byte and merge re-vendor
 PRs. Suppressing duplicate upstream findings is a reviewer-instruction
 problem; configuration answers break the gate.
 
+A committed `kendex refresh` tree is the other case: no pin covers it, the
+next refresh overwrites it, and the rule there is flat with no carve-out —
+[rendered-paths.md](rendered-paths.md), which reuses three sections of this
+one.
+
 ## What suppression must not break
 
 **Evidence.** The gate's evidence term needs a trusted non-author review object

--- a/skills/review-gate/templates/rendered-paths.instructions.md
+++ b/skills/review-gate/templates/rendered-paths.instructions.md
@@ -40,8 +40,8 @@ that.**
   kind): comment inline as normal, correctness and security defects included.
   On a refresh PR that is the most valuable finding there is.
 - **The fix lands in these rendered bytes**: do not raise it on this PR, on
-  any surface. It is filed against the catalog repo by the session that runs
-  the refresh, and the fix arrives here as a later render.
+  any surface. The session that runs the refresh files it against the catalog
+  repo with `kendex report`, and the fix arrives here as a later render.
 - **The fix lands in the catalog repo's own docs, config, or conventions**
   (its README, its settings tables, its test layout): same route.
 

--- a/skills/review-gate/templates/rendered-paths.instructions.md
+++ b/skills/review-gate/templates/rendered-paths.instructions.md
@@ -22,12 +22,14 @@ This tree is `kendex refresh` OUTPUT, rendered from the catalogs `kendex.toml`
 names. The same reviewers see this content in the catalog repo before it
 arrives here.
 
-Nothing under this glob is edited in this repo. The next refresh overwrites
-these files wholesale, so a local fix reads as closed while the bytes go back.
-No pin covers them and nothing turns red on drift. Both statements are about
-the files this glob names and nothing else — a settings or config file kendex
-merges its own entries into is repo-owned, and the rules below never apply to
-one.
+Nothing under this glob is edited in this repo, and an edit here does not
+land. The next refresh reads the disk, finds bytes no apply wrote, and holds
+that item as a conflict — "edited on disk since install — keep it as a fork,
+or apply with edits discarded" — planning no write until someone takes one of
+those exits. A local fix does not reach the repos that share this render; it
+wedges this one's next refresh. That is what this glob names and nothing else:
+a settings or config file kendex merges its own entries into is repo-owned,
+and the rules below never apply to one.
 
 **Route every finding by where its fix would land, and pick the surface from
 that.**

--- a/skills/review-gate/templates/rendered-paths.instructions.md
+++ b/skills/review-gate/templates/rendered-paths.instructions.md
@@ -1,0 +1,66 @@
+---
+applyTo: "[RENDERED_GLOB]"
+---
+
+<!-- Copy to .github/instructions/ as a *.instructions.md file, and fill:
+     [RENDERED_GLOB] — the harness trees this repo commits as `kendex refresh`
+     output. Start from the project trees kendex writes: `.agents/**`,
+     `.claude/**`, `.codex/**`, `.cursor/**`, `.gemini/**`, `.opencode/**`,
+     `.pi/**`, and for Copilot `.github/agents/**`, `.github/hooks/**`,
+     `.github/skills/**`. Drop what this repo does not commit, then check the
+     rest against a real refresh PR's file list. Two things this glob must NOT
+     cover: `.github/**` past those three subtrees, and the `.agents` subtree
+     of any item `kendex.toml` marks `source = "in-place"` — that content is
+     this repo's own. Delete this comment.
+     Wiring protocol: review-gate references/rendered-paths.md. -->
+
+This tree is `kendex refresh` OUTPUT, rendered from the catalogs `kendex.toml`
+names. The same reviewers see this content in the catalog repo before it
+arrives here.
+
+Nothing here is edited in this repo. The next refresh overwrites the tree
+wholesale, so a local fix reads as closed while the bytes go back. No pin
+covers it and nothing turns red on drift.
+
+**Route every finding by where its fix would land, and pick the surface from
+that.**
+
+- **The fix lands in a repo-owned file** — settings (`kendex.settings.toml`),
+  `kendex.toml`, the workflow that runs the refresh, CI wiring, adoption glue:
+  comment inline as normal. On a refresh PR that is the most valuable finding
+  there is.
+- **The fix lands in these rendered bytes**: do not raise it on this PR. The
+  remedy is `kendex report`, which files it against the repo that owns the
+  item, and the fix arrives here as a later render.
+- **The fix lands in the catalog repo's own docs, config, or conventions**
+  (its README, its settings tables, its test layout): same route.
+
+**No carve-out.** Not inline, not in a review summary body, and not for a
+correctness, security, or data-loss defect the render would ship here — report
+that one upstream and tell the PR author out of band. The rule is flat so the
+route is the same in every consuming repo, and a defect in a render is fixable
+only where the render is written. A finding whose fix lands in a repo-owned
+file is a different thing and stays an ordinary inline comment.
+
+One refresh lands in several repos at once. Every inline comment opens a
+thread that blocks the merge until someone answers it, so one finding over
+these bytes costs one blocking thread per reviewer per repo, over content
+nobody here can change.
+
+**If every finding you emit is anchored to a file location** — you have no
+review body you author, only a fixed template — do not drop the finding and do
+not spread it. Post ONE consolidated comment for this PR carrying every such
+finding together, anchored anywhere in this tree, and say in it that the
+remedy is upstream and that no local edit is wanted. One thread per reviewer
+per PR is the bound.
+
+**Do not stay silent instead.** Review whatever else the PR touches and submit
+a review: the merge gate needs a review object at this head, so a skipped
+review blocks the merge as hard as an unanswered thread does. A PR touching
+only this tree gets a review with no findings.
+
+Also out of scope here, on any surface: local restructuring of this tree
+(splitting files, style or naming changes, line-count limits, test
+reorganization), requests for repo-local test suites over it, and refresh
+timing — an upstream fix not yet rendered is a coordination note, never a
+merge blocker.

--- a/skills/review-gate/templates/rendered-paths.instructions.md
+++ b/skills/review-gate/templates/rendered-paths.instructions.md
@@ -4,43 +4,54 @@ applyTo: "[RENDERED_GLOB]"
 
 <!-- Copy to .github/instructions/ as a *.instructions.md file, and fill:
      [RENDERED_GLOB] — the harness trees this repo commits as `kendex refresh`
-     output. Start from the project trees kendex writes: `.agents/**`,
-     `.claude/**`, `.codex/**`, `.cursor/**`, `.gemini/**`, `.opencode/**`,
-     `.pi/**`, and for Copilot `.github/agents/**`, `.github/hooks/**`,
-     `.github/skills/**`. Drop what this repo does not commit, then check the
-     rest against a real refresh PR's file list. Two things this glob must NOT
-     cover: `.github/**` past those three subtrees, and the `.agents` subtree
-     of any item `kendex.toml` marks `source = "in-place"` — that content is
-     this repo's own. Delete this comment.
-     Wiring protocol: review-gate references/rendered-paths.md. -->
+     output. Start from the project trees kendex writes into:
+     `.agents/skills/**`, `.claude/**`, `.codex/**`, `.cursor/**`,
+     `.gemini/**`, `.opencode/**`, `.pi/**`, and for Copilot
+     `.github/agents/**`, `.github/hooks/**`, `.github/skills/**`. The shared
+     tree is scoped to `skills` on purpose: `.agents/hooks` holds the repo's
+     own adopted hook scripts. Those trees still hold files kendex never
+     writes, and a glob covering one tells this repo's reviewers to skip its
+     own content. Keep OUT: `.github/**` past those three subtrees; the
+     harness memory files CLAUDE.md, AGENTS.md, GEMINI.md; every
+     `.agents/skills/<name>` an item declares in-place; and every structured
+     config or settings file kendex merges into rather than owns.
+     § Deriving the glob in review-gate references/rendered-paths.md names
+     each one and how to derive it here. Delete this comment. -->
 
 This tree is `kendex refresh` OUTPUT, rendered from the catalogs `kendex.toml`
 names. The same reviewers see this content in the catalog repo before it
 arrives here.
 
-Nothing here is edited in this repo. The next refresh overwrites the tree
-wholesale, so a local fix reads as closed while the bytes go back. No pin
-covers it and nothing turns red on drift.
+Nothing under this glob is edited in this repo. The next refresh overwrites
+these files wholesale, so a local fix reads as closed while the bytes go back.
+No pin covers them and nothing turns red on drift. Both statements are about
+the files this glob names and nothing else — a settings or config file kendex
+merges its own entries into is repo-owned, and the rules below never apply to
+one.
 
 **Route every finding by where its fix would land, and pick the surface from
 that.**
 
 - **The fix lands in a repo-owned file** — settings (`kendex.settings.toml`),
-  `kendex.toml`, the workflow that runs the refresh, CI wiring, adoption glue:
-  comment inline as normal. On a refresh PR that is the most valuable finding
-  there is.
-- **The fix lands in these rendered bytes**: do not raise it on this PR. The
-  remedy is `kendex report`, which files it against the repo that owns the
-  item, and the fix arrives here as a later render.
+  `kendex.toml`, the workflow that runs the refresh, CI wiring, adoption glue,
+  and any config or settings file kendex merges entries into while the repo
+  owns the rest (`.claude/settings.json`, `.codex/config.toml`,
+  `.codex/hooks.json`, `.cursor/hooks.json`, `.cursor/mcp.json` and their
+  kind): comment inline as normal, correctness and security defects included.
+  On a refresh PR that is the most valuable finding there is.
+- **The fix lands in these rendered bytes**: do not raise it on this PR, on
+  any surface. It is filed against the catalog repo by the session that runs
+  the refresh, and the fix arrives here as a later render.
 - **The fix lands in the catalog repo's own docs, config, or conventions**
   (its README, its settings tables, its test layout): same route.
 
 **No carve-out.** Not inline, not in a review summary body, and not for a
-correctness, security, or data-loss defect the render would ship here — report
-that one upstream and tell the PR author out of band. The rule is flat so the
-route is the same in every consuming repo, and a defect in a render is fixable
-only where the render is written. A finding whose fix lands in a repo-owned
-file is a different thing and stays an ordinary inline comment.
+correctness, security, or data-loss defect the render would ship here — that
+one goes to the catalog repo too, and to the PR author out of band. The rule
+is flat so the route is the same in every consuming repo, and a defect in a
+render is fixable only where the render is written. A finding whose fix lands
+in a repo-owned file is a different thing and stays an ordinary inline
+comment.
 
 One refresh lands in several repos at once. Every inline comment opens a
 thread that blocks the merge until someone answers it, so one finding over
@@ -48,11 +59,10 @@ these bytes costs one blocking thread per reviewer per repo, over content
 nobody here can change.
 
 **If every finding you emit is anchored to a file location** — you have no
-review body you author, only a fixed template — do not drop the finding and do
-not spread it. Post ONE consolidated comment for this PR carrying every such
-finding together, anchored anywhere in this tree, and say in it that the
-remedy is upstream and that no local edit is wanted. One thread per reviewer
-per PR is the bound.
+review body you author, only a fixed template — the rule does not soften. A
+finding over this tree is not yours to place anywhere on this PR; it goes to
+the catalog repo, and the review you submit carries no finding over the
+render.
 
 **Do not stay silent instead.** Review whatever else the PR touches and submit
 a review: the merge gate needs a review object at this head, so a skipped


### PR DESCRIPTION
## Summary

- `review-gate` ships `templates/rendered-paths.instructions.md`, the sibling of `vendored-paths.instructions.md` for the tree a repo commits as `kendex refresh` output. One placeholder (`[RENDERED_GLOB]`), no pin placeholder, the flat no-carve-out rule with the erased-by-the-next-refresh reason stated, and the repo-owned carve-in kept: a finding whose fix lands in settings, the refresh workflow, or CI wiring is an ordinary inline comment and is the most valuable finding on a refresh PR.
- `references/rendered-paths.md` carries the wiring protocol: the difference table against the byte-pinned case, how to derive the glob, the reporting route, and verification on a real refresh PR. `vendored-paths.md` and `SKILL.md` gain cross-links.
- Template only. No consuming repo changes, and kendex's own `.github/instructions/` is not wired to it.

## Context

Per the issue's scope note, `vendored-paths.instructions.md` is unchanged except for a cross-link — byte-pinned vendoring is a real and different case and that template is correct for it.

**One deviation from the issue, flagged for the owner.** The issue asked to keep two paragraphs from the vendored template verbatim: the one-consolidated-comment fallback for location-bound reviewers, and *do not stay silent instead*. Under a flat no-carve-out rule those contradict — a consolidated comment anchored in the tree *is* the merge-blocking thread the rule exists to remove. In the vendored sibling the paragraph is coherent because the normal route there is a review body, so a reviewer without one needs a fallback; under a flat rule there is nothing to fall back from. drovr's `vendored-engine.instructions.md`, the prior art the issue says to lift from, resolved it the same way and has no such paragraph. So it is dropped and location-bound reviewers are told the rule does not soften; *do not stay silent instead* is kept verbatim. Say the word and it goes back.

**Two premises the issue states turned out to be false about the code, and both are corrected here.**

*A local edit is not silently overwritten.* The issue's difference table says the next `kendex refresh` reverts a local edit "wholesale and silently", and the first draft of this template said the same. `engine/holds.rs::hold_local_edit` compares the artifact's disk hash against the wanted hash and, on a mismatch no apply provably wrote at that path, pushes a `DriftRow` with state `Conflict` — *"edited on disk since install — keep it as a fork, or apply with edits discarded"* — and reinserts the existing lock entry without planning a write. `plan_pass.rs` calls it under a `!discard` guard and `continue`s, so an overwrite happens only when the caller asked for edits to be discarded. Drift does turn red, and that conflict row is the red. The premise now says what happens: an edit does not land, it wedges this repo's next refresh until someone forks it or discards it. The rule is untouched — it rests on its other two legs, that a render defect is fixable only where the render is written, and that one thread over these bytes blocks the merge in every consuming repo at once. The true reason is the stronger one.

*`kendex report` routes a skill upstream.* Earlier drafts of both references claimed a skill routes on its installed `SKILL.md` frontmatter and so files locally. That was true when this branch started and is not true now: `fix(KEN-730): a skill's lock entry routes its report to kendex` (#1739) landed on `main` during this work and the rebase brought it in. `installed_frontmatter` no longer exists; `report.rs::route` decides from matching lock entries' `source_repo` for every kind, with a test asserting Hook, Skill and Agent all route upstream. Both references now describe lock-based routing and the example commands carry a selector. There is no separate CLI defect — an earlier revision of this description claimed one, and that claim was wrong.

## Completed Issues

- Closes #1734 - review-gate: no instructions template for the harness render, only for byte-pinned vendored trees

## Review

Three internal cycles, doc-accuracy plus a cross-model external review, every factual claim checked against `crates/core` rather than the issue text.

The default glob is derived from the harness adapters, not from the issue's list — which omits `.gemini` and Copilot's three `.github` subtrees. Review then found the glob swallowing content kendex never writes: the harness memory files (`CLAUDE.md`, `AGENTS.md`, `GEMINI.md` have no writer anywhere in `crates/core`), adopted custom-hook scripts under `.agents/hooks/`, and the structured files kendex merges entries into rather than owning. The shared tree is now scoped to `.agents/skills/**` minus in-place names.

`§ Deriving the glob` produced findings in two consecutive rounds, both omissions from an enumeration, so the third round changed the rule instead of extending the list: the merged-config case is a class — *a file kendex merges entries into, rather than writes whole, is repo-owned* — with named but explicitly non-exhaustive examples, and the refresh-PR file list is the authority. Insertions went 527 → 539 across that rewrite. The point of the change is that the section no longer claims to compute the answer: kendex exposes no single query for what it renders into a repo, so a later gap in the examples is a doc improvement rather than a wrong instruction.

Also corrected: `emitted` is a skills-and-commands field, not a vintage artifact, so the old "compare the count against the entry count" advice sent readers chasing a ratio the schema forbids; and the manifest/lock disagreement on in-place items resolves by subtracting the union, since a conflicted item keeps its stale lock source through every refresh.

Declined: restoring a blocking carve-out for correctness, security or data-loss findings in rendered bytes, raised by the external review and again on the PR. The mechanism named is real — the flat rule plus *do not stay silent* means the gate can go green over bytes a reviewer believes are bad. It is also the accepted cost of the issue's recorded decision, which spells out this exact case and anticipates this exact argument. Reversing it is the owner's call rather than this PR's, and it has been put to them.

## Test Plan

- `tools/guard` clean on every commit's own pre-commit chain and on a full run per round; `preflight` clean.
- Every derivation command run as written against a real consumer (`~/dev/hyprtrade`), which is where the manifest/lock disagreement on in-place items surfaced.
- `kendex report --dry-run` run per selector in that consumer to establish the routing the docs now describe.

## SHA remap

A rebase after the first review round rewrote the branch. Four thread replies
name `bb9b75a10`, which is no longer in the branch — it is now `5d0b19256`.
Current commits: `044939618`, `5d0b19256`, `c147c9f02`.
