### PR TITLE
docs(KEN-727): a threshold change sweeps the splits it stranded

### DIFF
--- a/.agents/skills/size-ratchet/DEVELOPMENT.md
+++ b/.agents/skills/size-ratchet/DEVELOPMENT.md
@@ -10,6 +10,7 @@ live in README.md.
 - `scripts/lib/settings.sh` — layered settings resolution
 - `SKILL.md` — agent-facing skill definition
 - `README.md` — consumer documentation
+- `references/` — procedures SKILL.md links out to
 - `tests/` — run any file directly; each is self-contained
 
 `bash tests/*.sh` is the lane `tools/validate-changed` derives for a change

--- a/.agents/skills/size-ratchet/SKILL.md
+++ b/.agents/skills/size-ratchet/SKILL.md
@@ -65,3 +65,9 @@ is absent from HEAD's baseline, or lower there, fails whatever the commit
 declares. Rows already at HEAD are grandfathered. Generated
 and vendored content is never raised either: it is excluded (the
 exclusion list, `pattern<TAB>reason`) and leaves the counted set.
+
+**A threshold change requires a fragment sweep.** In either direction it
+strands the splits made under the previous number: a repo that loosens already
+holds those fragments, a repo that tightens is about to create them. A seam
+that fits only the old number is not evidence of a seam.
+[references/threshold-change.md](references/threshold-change.md).

--- a/.agents/skills/size-ratchet/references/threshold-change.md
+++ b/.agents/skills/size-ratchet/references/threshold-change.md
@@ -15,8 +15,8 @@ Each one names a candidate, not a verdict. Read the file before acting.
 1. **One real importer.** A non-barrel source file whose exported names are
    imported by exactly one other file. Separate re-exports from imports before
    counting, or a package index masks every candidate behind itself.
-2. **Mutual imports.** Two files that import each other. A cycle proves the
-   seam was not real; the pair reads as one concept.
+2. **Mutual imports.** Two files that import each other. Read the pair as one
+   file before judging either half.
 3. **`<parent>-<qualifier>` names.** A file named for another file plus a
    suffix (`-shared`, `-helpers`, `-reads`, `-run`, `part2`) with one consumer.
 
@@ -36,6 +36,8 @@ Two shapes defeat the obvious import regex.
 ## Disposition
 
 Open the candidate beside its importer. If its reader needs that file open to
-follow it, it is a fragment: merge it back and raise the merged row per
-[SKILL.md](../SKILL.md) § Responding to a failure, shrinking or deleting the
-emptied rows in the same diff. If it stands alone, it is a module. Leave it.
+follow it, it is a fragment: merge it back. A merged file still over its
+threshold raises its row per [SKILL.md](../SKILL.md) § Responding to a failure;
+one that lands at or under takes no row at all. Shrink or delete the emptied
+files' rows in the same diff either way. If it stands alone, it is a module.
+Leave it.

--- a/.agents/skills/size-ratchet/references/threshold-change.md
+++ b/.agents/skills/size-ratchet/references/threshold-change.md
@@ -5,8 +5,8 @@ entry lands, in either direction. Run it at `--seed` too when the repo already
 had a prose size rule: seeding records no row for an under-threshold fragment,
 so the repo inherits that rule's fragments and nothing else points at them.
 
-Scope the sweep to the tracked files the changed threshold decides
-(`git ls-files`, minus the exclusion list).
+Sweep the tracked files whose deciding threshold differs between the old
+configuration and the new (`git ls-files`, minus the exclusion list).
 
 ## Predicates
 
@@ -36,8 +36,6 @@ Two shapes defeat the obvious import regex.
 ## Disposition
 
 Open the candidate beside its importer. If its reader needs that file open to
-follow it, it is a fragment: merge it back. A merged file still over its
-threshold raises its row per [SKILL.md](../SKILL.md) § Responding to a failure;
-one that lands at or under takes no row at all. Shrink or delete the emptied
-files' rows in the same diff either way. If it stands alone, it is a module.
-Leave it.
+follow it, it is a fragment: merge it back and take every baseline-row
+consequence from [SKILL.md](../SKILL.md) § Responding to a failure. If it
+stands alone, it is a module. Leave it.

--- a/.agents/skills/size-ratchet/references/threshold-change.md
+++ b/.agents/skills/size-ratchet/references/threshold-change.md
@@ -1,0 +1,41 @@
+# Threshold change sweep
+
+Run this before a changed `SIZE_RATCHET_THRESHOLD` or `SIZE_RATCHET_CLASSES`
+entry lands, in either direction. Run it at `--seed` too when the repo already
+had a prose size rule: seeding records no row for an under-threshold fragment,
+so the repo inherits that rule's fragments and nothing else points at them.
+
+Scope the sweep to the tracked files the changed threshold decides
+(`git ls-files`, minus the exclusion list).
+
+## Predicates
+
+Each one names a candidate, not a verdict. Read the file before acting.
+
+1. **One real importer.** A non-barrel source file whose exported names are
+   imported by exactly one other file. Separate re-exports from imports before
+   counting, or a package index masks every candidate behind itself.
+2. **Mutual imports.** Two files that import each other. A cycle proves the
+   seam was not real; the pair reads as one concept.
+3. **`<parent>-<qualifier>` names.** A file named for another file plus a
+   suffix (`-shared`, `-helpers`, `-reads`, `-run`, `part2`) with one consumer.
+
+Predicate 1 alone is too noisy to act on. A large tree yields hundreds of
+single-importer files that are real modules. Predicates 2 and 3 are what
+separate a line move from a seam.
+
+## Parsing caveats
+
+Two shapes defeat the obvious import regex.
+
+- **A multi-line import whose closing brace sits at column 0** escapes a
+  line-anchored pattern. Match the whole statement.
+- **A path inside a comment** (`{@link import("./x.ts")}`) reads as a real
+  edge. Strip comments before the cycle pass.
+
+## Disposition
+
+Open the candidate beside its importer. If its reader needs that file open to
+follow it, it is a fragment: merge it back and raise the merged row per
+[SKILL.md](../SKILL.md) § Responding to a failure, shrinking or deleting the
+emptied rows in the same diff. If it stands alone, it is a module. Leave it.

--- a/skills/size-ratchet/DEVELOPMENT.md
+++ b/skills/size-ratchet/DEVELOPMENT.md
@@ -10,6 +10,7 @@ live in README.md.
 - `scripts/lib/settings.sh` — layered settings resolution
 - `SKILL.md` — agent-facing skill definition
 - `README.md` — consumer documentation
+- `references/` — procedures SKILL.md links out to
 - `tests/` — run any file directly; each is self-contained
 
 `bash tests/*.sh` is the lane `tools/validate-changed` derives for a change

--- a/skills/size-ratchet/SKILL.md
+++ b/skills/size-ratchet/SKILL.md
@@ -65,3 +65,9 @@ is absent from HEAD's baseline, or lower there, fails whatever the commit
 declares. Rows already at HEAD are grandfathered. Generated
 and vendored content is never raised either: it is excluded (the
 exclusion list, `pattern<TAB>reason`) and leaves the counted set.
+
+**A threshold change requires a fragment sweep.** In either direction it
+strands the splits made under the previous number: a repo that loosens already
+holds those fragments, a repo that tightens is about to create them. A seam
+that fits only the old number is not evidence of a seam.
+[references/threshold-change.md](references/threshold-change.md).

--- a/skills/size-ratchet/references/threshold-change.md
+++ b/skills/size-ratchet/references/threshold-change.md
@@ -15,8 +15,8 @@ Each one names a candidate, not a verdict. Read the file before acting.
 1. **One real importer.** A non-barrel source file whose exported names are
    imported by exactly one other file. Separate re-exports from imports before
    counting, or a package index masks every candidate behind itself.
-2. **Mutual imports.** Two files that import each other. A cycle proves the
-   seam was not real; the pair reads as one concept.
+2. **Mutual imports.** Two files that import each other. Read the pair as one
+   file before judging either half.
 3. **`<parent>-<qualifier>` names.** A file named for another file plus a
    suffix (`-shared`, `-helpers`, `-reads`, `-run`, `part2`) with one consumer.
 
@@ -36,6 +36,8 @@ Two shapes defeat the obvious import regex.
 ## Disposition
 
 Open the candidate beside its importer. If its reader needs that file open to
-follow it, it is a fragment: merge it back and raise the merged row per
-[SKILL.md](../SKILL.md) § Responding to a failure, shrinking or deleting the
-emptied rows in the same diff. If it stands alone, it is a module. Leave it.
+follow it, it is a fragment: merge it back. A merged file still over its
+threshold raises its row per [SKILL.md](../SKILL.md) § Responding to a failure;
+one that lands at or under takes no row at all. Shrink or delete the emptied
+files' rows in the same diff either way. If it stands alone, it is a module.
+Leave it.

--- a/skills/size-ratchet/references/threshold-change.md
+++ b/skills/size-ratchet/references/threshold-change.md
@@ -5,8 +5,8 @@ entry lands, in either direction. Run it at `--seed` too when the repo already
 had a prose size rule: seeding records no row for an under-threshold fragment,
 so the repo inherits that rule's fragments and nothing else points at them.
 
-Scope the sweep to the tracked files the changed threshold decides
-(`git ls-files`, minus the exclusion list).
+Sweep the tracked files whose deciding threshold differs between the old
+configuration and the new (`git ls-files`, minus the exclusion list).
 
 ## Predicates
 
@@ -36,8 +36,6 @@ Two shapes defeat the obvious import regex.
 ## Disposition
 
 Open the candidate beside its importer. If its reader needs that file open to
-follow it, it is a fragment: merge it back. A merged file still over its
-threshold raises its row per [SKILL.md](../SKILL.md) § Responding to a failure;
-one that lands at or under takes no row at all. Shrink or delete the emptied
-files' rows in the same diff either way. If it stands alone, it is a module.
-Leave it.
+follow it, it is a fragment: merge it back and take every baseline-row
+consequence from [SKILL.md](../SKILL.md) § Responding to a failure. If it
+stands alone, it is a module. Leave it.

--- a/skills/size-ratchet/references/threshold-change.md
+++ b/skills/size-ratchet/references/threshold-change.md
@@ -1,0 +1,41 @@
+# Threshold change sweep
+
+Run this before a changed `SIZE_RATCHET_THRESHOLD` or `SIZE_RATCHET_CLASSES`
+entry lands, in either direction. Run it at `--seed` too when the repo already
+had a prose size rule: seeding records no row for an under-threshold fragment,
+so the repo inherits that rule's fragments and nothing else points at them.
+
+Scope the sweep to the tracked files the changed threshold decides
+(`git ls-files`, minus the exclusion list).
+
+## Predicates
+
+Each one names a candidate, not a verdict. Read the file before acting.
+
+1. **One real importer.** A non-barrel source file whose exported names are
+   imported by exactly one other file. Separate re-exports from imports before
+   counting, or a package index masks every candidate behind itself.
+2. **Mutual imports.** Two files that import each other. A cycle proves the
+   seam was not real; the pair reads as one concept.
+3. **`<parent>-<qualifier>` names.** A file named for another file plus a
+   suffix (`-shared`, `-helpers`, `-reads`, `-run`, `part2`) with one consumer.
+
+Predicate 1 alone is too noisy to act on. A large tree yields hundreds of
+single-importer files that are real modules. Predicates 2 and 3 are what
+separate a line move from a seam.
+
+## Parsing caveats
+
+Two shapes defeat the obvious import regex.
+
+- **A multi-line import whose closing brace sits at column 0** escapes a
+  line-anchored pattern. Match the whole statement.
+- **A path inside a comment** (`{@link import("./x.ts")}`) reads as a real
+  edge. Strip comments before the cycle pass.
+
+## Disposition
+
+Open the candidate beside its importer. If its reader needs that file open to
+follow it, it is a fragment: merge it back and raise the merged row per
+[SKILL.md](../SKILL.md) § Responding to a failure, shrinking or deleting the
+emptied rows in the same diff. If it stands alone, it is a module. Leave it.


### PR DESCRIPTION
## Summary

- `size-ratchet` SKILL.md § Responding to a failure names the obligation a
  threshold change creates: in either direction it strands the splits made under
  the previous number, because a seam that fits only the old number is not
  evidence of a seam.
- New `references/threshold-change.md` gives the sweep a mechanical shape — the
  three predicates two independent consumer audits converged on, the two parsing
  caveats that cost them real time, and how to dispose of a candidate.

## Completed Issues

- Closes #1725 - size-ratchet: raising a threshold strands the splits made under the old one

## Notes

The issue asked for the obligation as "a raise"; the reporter's own follow-up
generalises it to a change in either direction — a repo that loosens already
holds the fragments, one that tightens is about to create them. That
generalisation is what ships.

The recipe stays language-agnostic. Two shapes raised in this issue's comments
are deliberately not here because they are separately filed and stand on their
own: the Rust idioms that produce "part 2 of X" (#1730) and checking composition
before the seam (#1740). A `--fragments` mode is likewise not here; the issue
offers a documented recipe as sufficient.

`references/` is a new directory for this skill, so `DEVELOPMENT.md` § Structure
carries it.

## Test Plan

- `tools/guard` green, size ratchet included. No baseline row moved: SKILL.md
  goes 67 to 73 lines against 400, and the new reference is 41. `README.md` is
  untouched — it sits at exactly its `*/README.md=120` class threshold, so the
  recipe could not go there without raising a doc row.
- `skills/size-ratchet/**` and the committed `.agents/skills/size-ratchet/**`
  render are byte-identical.
