### PR TITLE
docs(size-ratchet): --help names RATCHET_RAISE and its two cases

### DIFF
--- a/.agents/skills/size-ratchet/scripts/size-ratchet
+++ b/.agents/skills/size-ratchet/scripts/size-ratchet
@@ -71,10 +71,10 @@ kendex.settings.toml [env] > .env > default):
   SIZE_RATCHET_EXCLUDES    exclusion-list path      (default tools/size-ratchet-excludes)
 Flags override both for the path settings.
 
-RATCHET_RAISE=1 on the commit raises a hand-edited row; the commit gate reads
-it, not this script. Two cases, never for a test row: the added lines are the
-fix and the file has no concept seam, or fragments of one concept are merged
-back into one file.
+A baselined row rises only by a hand edit, in two cases, never for a test
+row: the added lines are the fix and the file has no concept seam, or
+fragments of one concept are merged back into one file. This script does not
+police that; where a repo gates it, the commit carries RATCHET_RAISE=1.
 
 Exit codes: 0 clean; 1 violations; 2 usage/config/collection error.
 EOF

--- a/.agents/skills/size-ratchet/scripts/size-ratchet
+++ b/.agents/skills/size-ratchet/scripts/size-ratchet
@@ -71,6 +71,11 @@ kendex.settings.toml [env] > .env > default):
   SIZE_RATCHET_EXCLUDES    exclusion-list path      (default tools/size-ratchet-excludes)
 Flags override both for the path settings.
 
+RATCHET_RAISE=1 on the commit raises a hand-edited row; the commit gate reads
+it, not this script. Two cases, never for a test row: the added lines are the
+fix and the file has no concept seam, or fragments of one concept are merged
+back into one file.
+
 Exit codes: 0 clean; 1 violations; 2 usage/config/collection error.
 EOF
 }

--- a/.agents/skills/size-ratchet/scripts/size-ratchet
+++ b/.agents/skills/size-ratchet/scripts/size-ratchet
@@ -71,10 +71,12 @@ kendex.settings.toml [env] > .env > default):
   SIZE_RATCHET_EXCLUDES    exclusion-list path      (default tools/size-ratchet-excludes)
 Flags override both for the path settings.
 
-A baselined row rises only by a hand edit, in two cases, never for a test
-row: the added lines are the fix and the file has no concept seam, or
-fragments of one concept are merged back into one file. This script does not
-police that; where a repo gates it, the commit carries RATCHET_RAISE=1.
+A baselined row rises only by a hand edit, in two cases and only for a
+hand-written file: the added lines are the fix and the file has no concept
+seam, or fragments of one concept are merged back into one file. Never for
+tests, docs, comments, or lines a review round asked for; generated and
+vendored content is excluded, not raised. This script does not police that;
+where a repo gates it, the commit carries RATCHET_RAISE=1.
 
 Exit codes: 0 clean; 1 violations; 2 usage/config/collection error.
 EOF

--- a/.agents/skills/size-ratchet/tests/staged-scope.test.sh
+++ b/.agents/skills/size-ratchet/tests/staged-scope.test.sh
@@ -336,6 +336,10 @@ case "$OUT" in
   *--staged*) ok "--help documents --staged" ;;
   *) bad "--help documents --staged" "out=$OUT" ;;
 esac
+case "$OUT" in
+  *RATCHET_RAISE*) ok "--help documents the raise" ;;
+  *) bad "--help documents the raise" "out=$OUT" ;;
+esac
 
 echo "=== a failing HEAD probe cannot hand authority to a recreated source ==="
 # Staged deletion + worktree recreation: the commit carries threshold 100,

--- a/skills/size-ratchet/scripts/size-ratchet
+++ b/skills/size-ratchet/scripts/size-ratchet
@@ -71,10 +71,10 @@ kendex.settings.toml [env] > .env > default):
   SIZE_RATCHET_EXCLUDES    exclusion-list path      (default tools/size-ratchet-excludes)
 Flags override both for the path settings.
 
-RATCHET_RAISE=1 on the commit raises a hand-edited row; the commit gate reads
-it, not this script. Two cases, never for a test row: the added lines are the
-fix and the file has no concept seam, or fragments of one concept are merged
-back into one file.
+A baselined row rises only by a hand edit, in two cases, never for a test
+row: the added lines are the fix and the file has no concept seam, or
+fragments of one concept are merged back into one file. This script does not
+police that; where a repo gates it, the commit carries RATCHET_RAISE=1.
 
 Exit codes: 0 clean; 1 violations; 2 usage/config/collection error.
 EOF

--- a/skills/size-ratchet/scripts/size-ratchet
+++ b/skills/size-ratchet/scripts/size-ratchet
@@ -71,6 +71,11 @@ kendex.settings.toml [env] > .env > default):
   SIZE_RATCHET_EXCLUDES    exclusion-list path      (default tools/size-ratchet-excludes)
 Flags override both for the path settings.
 
+RATCHET_RAISE=1 on the commit raises a hand-edited row; the commit gate reads
+it, not this script. Two cases, never for a test row: the added lines are the
+fix and the file has no concept seam, or fragments of one concept are merged
+back into one file.
+
 Exit codes: 0 clean; 1 violations; 2 usage/config/collection error.
 EOF
 }

--- a/skills/size-ratchet/scripts/size-ratchet
+++ b/skills/size-ratchet/scripts/size-ratchet
@@ -71,10 +71,12 @@ kendex.settings.toml [env] > .env > default):
   SIZE_RATCHET_EXCLUDES    exclusion-list path      (default tools/size-ratchet-excludes)
 Flags override both for the path settings.
 
-A baselined row rises only by a hand edit, in two cases, never for a test
-row: the added lines are the fix and the file has no concept seam, or
-fragments of one concept are merged back into one file. This script does not
-police that; where a repo gates it, the commit carries RATCHET_RAISE=1.
+A baselined row rises only by a hand edit, in two cases and only for a
+hand-written file: the added lines are the fix and the file has no concept
+seam, or fragments of one concept are merged back into one file. Never for
+tests, docs, comments, or lines a review round asked for; generated and
+vendored content is excluded, not raised. This script does not police that;
+where a repo gates it, the commit carries RATCHET_RAISE=1.
 
 Exit codes: 0 clean; 1 violations; 2 usage/config/collection error.
 EOF

--- a/skills/size-ratchet/tests/staged-scope.test.sh
+++ b/skills/size-ratchet/tests/staged-scope.test.sh
@@ -336,6 +336,10 @@ case "$OUT" in
   *--staged*) ok "--help documents --staged" ;;
   *) bad "--help documents --staged" "out=$OUT" ;;
 esac
+case "$OUT" in
+  *RATCHET_RAISE*) ok "--help documents the raise" ;;
+  *) bad "--help documents the raise" "out=$OUT" ;;
+esac
 
 echo "=== a failing HEAD probe cannot hand authority to a recreated source ==="
 # Staged deletion + worktree recreation: the commit carries threshold 100,

--- a/tools/size-ratchet-baseline.tsv
+++ b/tools/size-ratchet-baseline.tsv
@@ -131,7 +131,7 @@ skills/second-opinion/scripts/second-opinion	2602
 skills/second-opinion/tests/cli-failure-gate.test.sh	1211
 skills/second-opinion/tests/lane-scratch-durability.test.sh	999
 skills/second-opinion/tests/review-dual-model.test.sh	1516
-skills/size-ratchet/scripts/size-ratchet	1092
+skills/size-ratchet/scripts/size-ratchet	1097
 skills/worktree/scripts/worktree	4980
 skills/worktree/scripts/worktree-session-guard	1197
 skills/worktree/tests/worktree_session_guard.sh	1282

--- a/tools/size-ratchet-baseline.tsv
+++ b/tools/size-ratchet-baseline.tsv
@@ -131,7 +131,7 @@ skills/second-opinion/scripts/second-opinion	2602
 skills/second-opinion/tests/cli-failure-gate.test.sh	1211
 skills/second-opinion/tests/lane-scratch-durability.test.sh	999
 skills/second-opinion/tests/review-dual-model.test.sh	1516
-skills/size-ratchet/scripts/size-ratchet	1097
+skills/size-ratchet/scripts/size-ratchet	1099
 skills/worktree/scripts/worktree	4980
 skills/worktree/scripts/worktree-session-guard	1197
 skills/worktree/tests/worktree_session_guard.sh	1282


### PR DESCRIPTION
`--help` listed the four `SIZE_RATCHET_*` keys and nothing about raising a
row, so an agent planning work read it, concluded the baseline only ever
tightens, and split a file instead of merging fragments back into one. The
remedy existed only in `SKILL.md` and in the failure diagnostic, which an
agent sees only after it has already failed the gate.

`--help` now carries the same two-case rule, and says the commit gate reads
`RATCHET_RAISE`, not this script, so nobody exports it and waits for the
check to behave differently. `SKILL.md` is untouched (#1753 owns it).

The baseline row for the script rises 1092 -> 1097: the added lines are the
fix for the reported symptom and a `--help` heredoc has no concept seam.

Closes #1746