### PR TITLE
feat(KEN-443): Settings > Account draws the five states apart

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,9 @@ an outside contributor.
 - The foot of the app's sidebar names the kendex.ai account you are signed
   in to, says Offline when the server could not be reached, and offers Sign
   in or Sign in again as the credential needs. Clicking opens Settings.
+- Settings > Account names the kendex.ai account and offers Sign out; it reads
+  Offline when the server could not be reached, and asks for a fresh sign-in
+  when the credential was rejected. A failed check says why, with Try again.
 - The review-gate skill ships a reviewer instruction for a repo that commits
   its `kendex refresh` output: a finding over the render goes upstream rather
   than into a thread the repo cannot act on.

--- a/ui/src/components/account-avatar.test.ts
+++ b/ui/src/components/account-avatar.test.ts
@@ -2,7 +2,8 @@
 // that it is one character a reader would recognise as the first one, and
 // that an account the server has not named gets none.
 import { describe, expect, it } from "vitest";
-import { accountInitial, displayName } from "./account-avatar";
+import { ACCOUNT_SIGNED_IN_LABEL } from "@/lib/copy-account";
+import { accountInitial, accountLabel } from "./account-avatar";
 
 // The provider's account id is an opaque number, not a handle. Every
 // fixture spells it that way so a test cannot pass by showing one.
@@ -52,11 +53,15 @@ describe("the letter on the avatar", () => {
 // may fall back to it: it is nobody's name.
 describe("what the app calls the account", () => {
   it("is the name the server answered with", () => {
-    expect(displayName(ADA)).toBe(ADA.name);
+    expect(accountLabel(ADA)).toBe(ADA.name);
   });
 
-  it("is nothing when the server named nobody", () => {
-    expect(displayName({ name: "  ", githubLogin: "1234567" })).toBe("");
-    expect(displayName(null)).toBe("");
+  // A name the server sent as blank is no name at all, so the label says
+  // the credential is signed in rather than printing whitespace or an id.
+  it("says only that it is signed in when the server named nobody", () => {
+    expect(accountLabel({ name: "  ", githubLogin: "1234567" })).toBe(
+      ACCOUNT_SIGNED_IN_LABEL,
+    );
+    expect(accountLabel(null)).toBe(ACCOUNT_SIGNED_IN_LABEL);
   });
 });

--- a/ui/src/components/account-avatar.test.ts
+++ b/ui/src/components/account-avatar.test.ts
@@ -1,0 +1,62 @@
+// The letter both account surfaces put in the circle. What these hold to is
+// that it is one character a reader would recognise as the first one, and
+// that an account the server has not named gets none.
+import { describe, expect, it } from "vitest";
+import { accountInitial, displayName } from "./account-avatar";
+
+// The provider's account id is an opaque number, not a handle. Every
+// fixture spells it that way so a test cannot pass by showing one.
+const ADA = { name: "Ada Lovelace", githubLogin: "1234567" };
+
+describe("the letter on the avatar", () => {
+  const named = (name: string) => accountInitial({ name, githubLogin: null });
+
+  it("takes the name's first letter", () => {
+    expect(accountInitial(ADA)).toBe("A");
+  });
+
+  // The accent is part of the letter a reader sees, whether the server sent
+  // one character or a base letter and a combining mark.
+  it("keeps a combining mark with the letter it belongs to", () => {
+    expect(named("e\u0301lodie")).toBe("E\u0301");
+    expect(named("élodie")).toBe("É");
+  });
+
+  // Casing can widen what it is given: this one letter uppercases to two,
+  // and the circle holds one.
+  it("keeps one letter when casing expands it", () => {
+    expect(named("ßeta")).toBe("S");
+  });
+
+  // Every part of the sequence or none: half an emoji is a different emoji.
+  it("keeps a multi-part emoji whole", () => {
+    expect(named("👩‍🚀 crew")).toBe("👩‍🚀");
+  });
+
+  // A name the server sent as blank is no name at all, and the provider id
+  // is not a stand-in for one: the circle stays empty.
+  it("has no letter for a blank name", () => {
+    expect(accountInitial({ name: "   ", githubLogin: "1234567" })).toBeNull();
+  });
+
+  it("has no letter for an account with no identity", () => {
+    expect(accountInitial(null)).toBeNull();
+  });
+
+  it("keeps a first character that is a surrogate pair whole", () => {
+    expect(named("𝔄da")).toBe("𝔄");
+  });
+});
+
+// The field is the provider's immutable account id, not a handle. Nothing
+// may fall back to it: it is nobody's name.
+describe("what the app calls the account", () => {
+  it("is the name the server answered with", () => {
+    expect(displayName(ADA)).toBe(ADA.name);
+  });
+
+  it("is nothing when the server named nobody", () => {
+    expect(displayName({ name: "  ", githubLogin: "1234567" })).toBe("");
+    expect(displayName(null)).toBe("");
+  });
+});

--- a/ui/src/components/account-avatar.tsx
+++ b/ui/src/components/account-avatar.tsx
@@ -3,14 +3,21 @@
 // Two surfaces draw an account — the sidebar's foot and Settings → Account —
 // and one account must not read as two people, so the name and the letter
 // are decided here rather than at each drawing.
+import { ACCOUNT_SIGNED_IN_LABEL } from "@/lib/copy-account";
 import { cn } from "@/lib/utils";
 import type { AccountIdentity } from "@/stores/account";
 
 /** The name the server answered with, or nothing where it has answered with
  *  none. `githubLogin` is not a second choice for it — the field is the
  *  provider's opaque account id, not a handle, and it is never shown. */
-export const displayName = (identity: AccountIdentity | null): string =>
+const displayName = (identity: AccountIdentity | null): string =>
   identity?.name.trim() ?? "";
+
+/** What a row calls the account: the name, or that it is signed in where
+ *  the server has answered with none. Every surface asks here, so a
+ *  credential with no name behind it reads the same wherever it is drawn. */
+export const accountLabel = (identity: AccountIdentity | null): string =>
+  displayName(identity) || ACCOUNT_SIGNED_IN_LABEL;
 
 /** What a reader would call the first character: a base letter with the
  *  marks that belong to it, an emoji with every part of its sequence, and a

--- a/ui/src/components/account-avatar.tsx
+++ b/ui/src/components/account-avatar.tsx
@@ -1,0 +1,65 @@
+// What the app calls the account, and the letter that stands for it.
+//
+// Two surfaces draw an account — the sidebar's foot and Settings → Account —
+// and one account must not read as two people, so the name and the letter
+// are decided here rather than at each drawing.
+import { cn } from "@/lib/utils";
+import type { AccountIdentity } from "@/stores/account";
+
+/** The name the server answered with, or nothing where it has answered with
+ *  none. `githubLogin` is not a second choice for it — the field is the
+ *  provider's opaque account id, not a handle, and it is never shown. */
+export const displayName = (identity: AccountIdentity | null): string =>
+  identity?.name.trim() ?? "";
+
+/** What a reader would call the first character: a base letter with the
+ *  marks that belong to it, an emoji with every part of its sequence, and a
+ *  character outside the BMP whole rather than halved. Grapheme breaking
+ *  does not turn on the locale, so the default one answers the same
+ *  everywhere. */
+const graphemes = new Intl.Segmenter(undefined, { granularity: "grapheme" });
+
+const firstGrapheme = (text: string): string => {
+  for (const { segment } of graphemes.segment(text)) return segment;
+  return "";
+};
+
+/** The letter on the avatar, and nothing where there is no name to take it
+ *  from.
+ *
+ *  Cased by the plain call rather than the locale-aware one, whose
+ *  no-argument form is host-dependent by specification. Segmented again
+ *  after casing because a case mapping can widen what it is given: the
+ *  German sharp s uppercases to two letters, and the circle holds one. */
+export function accountInitial(
+  identity: AccountIdentity | null,
+): string | null {
+  const first = firstGrapheme(displayName(identity));
+  return first ? firstGrapheme(first.toUpperCase()) : null;
+}
+
+/** The circle. It carries a letter once the server has named the account and
+ *  stays empty until then: a stored credential is not a person, and
+ *  inventing an initial for one would claim it is.
+ *
+ *  Size and type step come from the caller, because the two surfaces draw it
+ *  at two sizes; everything that makes it the same circle stays here. */
+export function AccountAvatar({
+  identity,
+  className,
+}: {
+  identity: AccountIdentity | null;
+  className?: string;
+}) {
+  return (
+    <span
+      aria-hidden
+      className={cn(
+        "flex shrink-0 items-center justify-center rounded-full bg-foreground/[0.12] font-semibold leading-none",
+        className,
+      )}
+    >
+      {accountInitial(identity)}
+    </span>
+  );
+}

--- a/ui/src/components/account-section.dom.test.tsx
+++ b/ui/src/components/account-section.dom.test.tsx
@@ -1,0 +1,295 @@
+// @vitest-environment jsdom
+// Settings > Account draws the five things a read can leave behind, and it
+// draws them apart. What these hold to is that a credential the server has
+// not confirmed is not a confirmed sign-in, that a credential the server
+// rejected is not a signed-out account, and that a read which never landed
+// says so and offers the retry rather than collapsing into either.
+import userEvent from "@testing-library/user-event";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  ACCOUNT_CANCEL_SIGN_IN_LABEL,
+  ACCOUNT_CHECK_LABEL,
+  ACCOUNT_CHECKING_NOTE,
+  ACCOUNT_EXPIRED_TITLE,
+  ACCOUNT_OFFLINE_LABEL,
+  ACCOUNT_OFFLINE_TITLE,
+  ACCOUNT_RETRY_LABEL,
+  ACCOUNT_SIGN_IN_AGAIN_LABEL,
+  ACCOUNT_SIGN_IN_GITHUB_LABEL,
+  ACCOUNT_SIGN_OUT_LABEL,
+  ACCOUNT_SIGNED_IN_LABEL,
+  ACCOUNT_SIGNED_IN_NOTE,
+  ACCOUNT_SIGNED_OUT_NOTE,
+  ACCOUNT_SIGNING_IN_NOTE,
+  ACCOUNT_UNCHECKED_NOTE,
+  ACCOUNT_UNREADABLE_LABEL,
+  ACCOUNT_UNREADABLE_NOTE,
+} from "@/lib/copy-account";
+import { type AccountState, useAccountStore } from "@/stores/account";
+import { mount } from "@/test/dom";
+import { AccountSection } from "./account-section";
+
+vi.mock("@/bindings", () => ({ commands: {} }));
+
+// The provider's account id is an opaque number, not a handle. Every
+// fixture spells it that way so a test cannot pass by showing one.
+const ADA = { name: "Ada Lovelace", githubLogin: "1234567" };
+
+/** The store's actions, stood in for so a press is checked where it lands
+ *  rather than through the bridge it would reach. */
+const acts = () => ({
+  signIn: vi.fn(async () => {}),
+  signOut: vi.fn(async () => {}),
+  cancelSignIn: vi.fn(),
+  load: vi.fn(async () => {}),
+});
+
+let act: ReturnType<typeof acts>;
+
+interface Read {
+  account?: AccountState;
+  reading?: boolean;
+  readError?: string | null;
+  signingIn?: boolean;
+  userCode?: string | null;
+  error?: string | null;
+}
+
+beforeEach(() => {
+  act = acts();
+  useAccountStore.setState({
+    account: { kind: "loading" },
+    reading: false,
+    readError: null,
+    signingIn: false,
+    userCode: null,
+    error: null,
+    ...act,
+  });
+});
+
+const show = (state: Read = {}): HTMLElement => {
+  useAccountStore.setState(state);
+  return mount(<AccountSection />);
+};
+
+/** The letter in the circle, which is drawn for the eye alone. */
+const initial = (host: HTMLElement): string =>
+  host.querySelector("[aria-hidden]")?.textContent ?? "";
+
+/** Every button the section offers, by the words on it. */
+const offered = (host: HTMLElement): string[] =>
+  [...host.querySelectorAll("button")].map((b) => b.textContent ?? "");
+
+const press = async (host: HTMLElement, label: string) => {
+  const button = [...host.querySelectorAll("button")].find(
+    (b) => b.textContent === label,
+  );
+  if (!button)
+    throw new Error(
+      `no "${label}" button — the section offers ${offered(host)}`,
+    );
+  await userEvent.click(button);
+  return button;
+};
+
+const SETTLED: [string, AccountState][] = [
+  ["signed-in", { kind: "signed-in", identity: ADA }],
+  ["signed-out", { kind: "signed-out" }],
+  ["expired", { kind: "expired" }],
+  ["offline", { kind: "offline", identity: ADA }],
+];
+
+describe("the state the section draws", () => {
+  it("names the account and offers a sign-out when signed in", () => {
+    const host = show({ account: { kind: "signed-in", identity: ADA } });
+    expect(host.textContent).toContain(ADA.name);
+    expect(initial(host)).toBe("A");
+    expect(offered(host)).toEqual([ACCOUNT_SIGN_OUT_LABEL]);
+  });
+
+  // A credential in the keychain is not a person: the section may say it is
+  // signed in, but it must not put a name to an account nobody has named.
+  it("names nobody when the credential has no identity yet", () => {
+    const host = show({ account: { kind: "signed-in", identity: null } });
+    expect(host.textContent).toContain(ACCOUNT_SIGNED_IN_LABEL);
+    expect(host.textContent).not.toContain(ADA.name);
+    expect(initial(host)).toBe("");
+  });
+
+  // The server answers with a String, so a blank one is a name it does not
+  // have rather than a field it did not send. The provider id is no
+  // stand-in: falling back to it would print an opaque number as a person.
+  it("names nobody when the server sent a blank name", () => {
+    const blank = { name: "  ", githubLogin: "1234567" };
+    const host = show({ account: { kind: "signed-in", identity: blank } });
+    expect(host.textContent).toContain(ACCOUNT_SIGNED_IN_LABEL);
+    expect(host.textContent).not.toContain(blank.githubLogin);
+    expect(initial(host)).toBe("");
+  });
+
+  // The bug this section had: `hasCredential` is true for offline, so an
+  // unconfirmed credential drew as a confirmed sign-in.
+  it("marks an unconfirmed credential offline, not signed in", () => {
+    const host = show({ account: { kind: "offline", identity: ADA } });
+    expect(host.textContent).toContain(ADA.name);
+    expect(host.textContent).toContain(ACCOUNT_OFFLINE_LABEL);
+    expect(host.textContent).toContain(ACCOUNT_OFFLINE_TITLE);
+    expect(host.textContent).not.toContain(ACCOUNT_SIGNED_IN_NOTE);
+  });
+
+  // The credential is still this machine's to drop, and dropping it is what
+  // stops the app asking the server about it.
+  it("still offers a sign-out while offline", () => {
+    const host = show({ account: { kind: "offline", identity: ADA } });
+    expect(offered(host)).toEqual([ACCOUNT_SIGN_OUT_LABEL]);
+  });
+
+  // The other half of that bug: `hasCredential` is false for expired, so a
+  // rejected credential drew as a plain signed-out account.
+  it("says a rejected credential was rejected, not signed out", () => {
+    const host = show({ account: { kind: "expired" } });
+    expect(host.textContent).toContain(ACCOUNT_EXPIRED_TITLE);
+    expect(host.textContent).not.toContain(ACCOUNT_SIGNED_OUT_NOTE);
+    expect(offered(host)).toEqual([ACCOUNT_SIGN_IN_AGAIN_LABEL]);
+  });
+
+  it("offers the device flow when signed out", () => {
+    const host = show({ account: { kind: "signed-out" } });
+    expect(host.textContent).toContain(ACCOUNT_SIGNED_OUT_NOTE);
+    expect(offered(host)).toEqual([ACCOUNT_SIGN_IN_GITHUB_LABEL]);
+  });
+
+  // The field is the provider's immutable account id, not a handle. It is
+  // nobody's name and belongs nowhere a person can read it.
+  it.each(SETTLED)("never shows the provider id when %s", (_state, account) => {
+    expect(show({ account }).textContent).not.toContain(ADA.githubLogin);
+  });
+});
+
+// A read still out, a read that failed and a read never made are three
+// different things, and none of them is a signed-out account.
+describe("before any read has landed", () => {
+  it("says a read is on its way and offers nothing to press", () => {
+    const host = show({ reading: true });
+    expect(host.textContent).toContain(ACCOUNT_CHECKING_NOTE);
+    expect(offered(host)).toEqual([]);
+  });
+
+  it("asks for the read that was never made", async () => {
+    const host = show({});
+    expect(host.textContent).toContain(ACCOUNT_UNCHECKED_NOTE);
+    await press(host, ACCOUNT_CHECK_LABEL);
+    expect(act.load).toHaveBeenCalledTimes(1);
+  });
+
+  it("reports the failure rather than drawing a signed-out account", () => {
+    const host = show({ readError: "keychain locked" });
+    expect(host.textContent).toContain(ACCOUNT_UNREADABLE_NOTE);
+    expect(host.textContent).not.toContain(ACCOUNT_SIGNED_OUT_NOTE);
+    expect(offered(host)).toEqual([ACCOUNT_RETRY_LABEL]);
+  });
+});
+
+// docs/ARCHITECTURE.md: a failed read shows its error with a retry. This is
+// the only retry in the app, and the only place the cause is written out.
+describe("the retry a failed read gets", () => {
+  it("shows the cause the read gave", () => {
+    const host = show({ readError: "keychain locked" });
+    expect(host.textContent).toContain(ACCOUNT_UNREADABLE_LABEL);
+    expect(host.textContent).toContain("keychain locked");
+  });
+
+  it("retries through the store's one read", async () => {
+    const host = show({ readError: "keychain locked" });
+    await press(host, ACCOUNT_RETRY_LABEL);
+    expect(act.load).toHaveBeenCalledTimes(1);
+  });
+
+  // A read that failed after one that landed leaves the state alone, so the
+  // state keeps its own row and the failure gets a second one.
+  it("sits beside a state that did land", () => {
+    const host = show({
+      account: { kind: "offline", identity: ADA },
+      readError: "keychain locked",
+    });
+    expect(host.textContent).toContain("keychain locked");
+    expect(offered(host)).toEqual([
+      ACCOUNT_SIGN_OUT_LABEL,
+      ACCOUNT_RETRY_LABEL,
+    ]);
+  });
+
+  // Pressing again while the last press is still out would ask twice for
+  // one answer.
+  it("cannot be pressed while a read is out", () => {
+    const host = show({ readError: "keychain locked", reading: true });
+    const retry = [...host.querySelectorAll("button")].find(
+      (b) => b.textContent === ACCOUNT_RETRY_LABEL,
+    );
+    expect(retry?.disabled).toBe(true);
+  });
+
+  it("is announced when it appears", () => {
+    const host = show({ readError: "keychain locked" });
+    expect(host.querySelector("[role='alert']")?.textContent).toContain(
+      "keychain locked",
+    );
+  });
+});
+
+describe("signing in and out", () => {
+  it("signs out from the row that names the account", async () => {
+    const host = show({ account: { kind: "signed-in", identity: ADA } });
+    await press(host, ACCOUNT_SIGN_OUT_LABEL);
+    expect(act.signOut).toHaveBeenCalledTimes(1);
+  });
+
+  it("starts the device flow from a signed-out account", async () => {
+    const host = show({ account: { kind: "signed-out" } });
+    await press(host, ACCOUNT_SIGN_IN_GITHUB_LABEL);
+    expect(act.signIn).toHaveBeenCalledTimes(1);
+  });
+
+  it("starts it again from a credential the server rejected", async () => {
+    const host = show({ account: { kind: "expired" } });
+    await press(host, ACCOUNT_SIGN_IN_AGAIN_LABEL);
+    expect(act.signIn).toHaveBeenCalledTimes(1);
+  });
+
+  // While the flow is out the section is about the flow: the state it began
+  // from is the one it is trying to leave.
+  it("shows the code and the way out while the flow is waiting", async () => {
+    const host = show({
+      account: { kind: "signed-out" },
+      signingIn: true,
+      userCode: "ABCD-2345",
+    });
+    expect(host.textContent).toContain("ABCD-2345");
+    expect(host.textContent).not.toContain(ACCOUNT_SIGNED_OUT_NOTE);
+    expect(offered(host)).toEqual([ACCOUNT_CANCEL_SIGN_IN_LABEL]);
+    await press(host, ACCOUNT_CANCEL_SIGN_IN_LABEL);
+    expect(act.cancelSignIn).toHaveBeenCalledTimes(1);
+  });
+
+  // The code arrives one round trip after the flow starts. Until it does the
+  // row says what is being waited on rather than showing an empty code.
+  it("says what it is waiting for before the code arrives", () => {
+    const host = show({ account: { kind: "signed-out" }, signingIn: true });
+    expect(host.textContent).toContain(ACCOUNT_SIGNING_IN_NOTE);
+    expect(offered(host)).toEqual([ACCOUNT_CANCEL_SIGN_IN_LABEL]);
+  });
+
+  // The two failures have their own fields because they answer different
+  // questions. A person who came back from denying an approval must still
+  // find that explanation, whatever the read went on to say.
+  it("keeps a denied approval's reason beside a failed read's", () => {
+    const host = show({
+      account: { kind: "signed-out" },
+      error: "the approval was denied",
+      readError: "keychain locked",
+    });
+    expect(host.textContent).toContain("the approval was denied");
+    expect(host.textContent).toContain("keychain locked");
+  });
+});

--- a/ui/src/components/account-section.dom.test.tsx
+++ b/ui/src/components/account-section.dom.test.tsx
@@ -106,6 +106,25 @@ describe("the state the section draws", () => {
     expect(host.textContent).toContain(ADA.name);
     expect(initial(host)).toBe("A");
     expect(offered(host)).toEqual([ACCOUNT_SIGN_OUT_LABEL]);
+    // A confirmed sign-in and an unconfirmed credential are the pair the
+    // old `hasCredential` read collapsed, and the name, the letter and the
+    // button are the same on both. The sentence and the marker are not.
+    expect(host.textContent).toContain(ACCOUNT_SIGNED_IN_NOTE);
+    expect(host.textContent).not.toContain(ACCOUNT_OFFLINE_LABEL);
+  });
+
+  // Nothing in the row's lane may be pushed out by a name: the name is the
+  // one part of unbounded length, so it is the part that is cut off.
+  it("cuts a long name off rather than widening the row", () => {
+    const long = { name: "A".repeat(200), githubLogin: "1234567" };
+    const host = show({ account: { kind: "signed-in", identity: long } });
+    // jsdom lays nothing out, so the class carrying the rule is what can be
+    // checked: the element holding the name is the one that gives.
+    const named = [...host.querySelectorAll("span")].find(
+      (el) => el.textContent === long.name,
+    );
+    expect(named?.className).toContain("truncate");
+    expect(named?.className).toContain("min-w-0");
   });
 
   // A credential in the keychain is not a person: the section may say it is
@@ -181,6 +200,14 @@ describe("before any read has landed", () => {
     expect(host.textContent).toContain(ACCOUNT_UNCHECKED_NOTE);
     await press(host, ACCOUNT_CHECK_LABEL);
     expect(act.load).toHaveBeenCalledTimes(1);
+  });
+
+  // The order the unread arm checks in: a retry still out is a read on its
+  // way, not the failure it was sent to repeat.
+  it("says a read is on its way while the retry it started is out", () => {
+    const host = show({ reading: true, readError: "keychain locked" });
+    expect(host.textContent).toContain(ACCOUNT_CHECKING_NOTE);
+    expect(host.textContent).not.toContain(ACCOUNT_UNREADABLE_NOTE);
   });
 
   it("reports the failure rather than drawing a signed-out account", () => {

--- a/ui/src/components/account-section.tsx
+++ b/ui/src/components/account-section.tsx
@@ -1,52 +1,237 @@
+import type { ReactNode } from "react";
+import { AccountAvatar, displayName } from "@/components/account-avatar";
 import { Section, SettingRow } from "@/components/section";
 import { Button } from "@/components/ui/button";
-import { hasCredential, useAccountStore } from "@/stores/account";
+import {
+  ACCOUNT_CANCEL_SIGN_IN_LABEL,
+  ACCOUNT_CHECK_LABEL,
+  ACCOUNT_CHECKING_NOTE,
+  ACCOUNT_EXPIRED_TITLE,
+  ACCOUNT_OFFLINE_LABEL,
+  ACCOUNT_OFFLINE_TITLE,
+  ACCOUNT_RETRY_LABEL,
+  ACCOUNT_SIGN_IN_AGAIN_LABEL,
+  ACCOUNT_SIGN_IN_GITHUB_LABEL,
+  ACCOUNT_SIGN_OUT_LABEL,
+  ACCOUNT_SIGNED_IN_LABEL,
+  ACCOUNT_SIGNED_IN_NOTE,
+  ACCOUNT_SIGNED_OUT_NOTE,
+  ACCOUNT_SIGNING_IN_NOTE,
+  ACCOUNT_UNCHECKED_NOTE,
+  ACCOUNT_UNREADABLE_LABEL,
+  ACCOUNT_UNREADABLE_NOTE,
+} from "@/lib/copy-account";
+import {
+  type AccountIdentity,
+  type AccountState,
+  useAccountStore,
+} from "@/stores/account";
 
-/** Settings → Account: the one place sign-in state lives. Signing in is
- * the device flow — a code, a browser tab, done; signing out kills every
- * credential from that sign-in on the very next request. */
+/** The service the account belongs to, for the states that know no person
+ *  to name instead. */
+const ENDPOINT = "kendex.ai";
+
+/** What the store offers this section. Gathered into one shape so the row
+ *  below stays a function of the state rather than of the store. */
+interface Acts {
+  signIn: () => void;
+  signOut: () => void;
+  load: () => void;
+}
+
+/** Whose account it is: the letter and the name, or "Signed in" where the
+ *  server holds a credential it has not yet put a name to. */
+function Whose({
+  identity,
+  marker,
+}: {
+  identity: AccountIdentity | null;
+  marker?: string;
+}) {
+  return (
+    <span className="flex items-center gap-2">
+      <AccountAvatar identity={identity} className="size-6 text-[11px]" />
+      {displayName(identity) || ACCOUNT_SIGNED_IN_LABEL}
+      {marker ? (
+        <span className="text-xs font-normal text-muted-foreground">
+          {marker}
+        </span>
+      ) : null}
+    </span>
+  );
+}
+
+/** What the section says before any read has landed.
+ *
+ *  A read still out, a read that failed and a read never made are three
+ *  different things. Only the last is worth asking for: the first is
+ *  already on its way, and the second is retried from the notice that
+ *  carries its reason, so neither offers a button here. */
+function beforeAnyAnswer(
+  reading: boolean,
+  readError: string | null,
+  load: () => void,
+): ReactNode {
+  if (reading)
+    return <SettingRow label={ENDPOINT} description={ACCOUNT_CHECKING_NOTE} />;
+  if (readError !== null)
+    return (
+      <SettingRow label={ENDPOINT} description={ACCOUNT_UNREADABLE_NOTE} />
+    );
+  return (
+    <SettingRow label={ENDPOINT} description={ACCOUNT_UNCHECKED_NOTE}>
+      <Button variant="outline" onClick={load}>
+        {ACCOUNT_CHECK_LABEL}
+      </Button>
+    </SettingRow>
+  );
+}
+
+/** The one row for the account, drawn from the state alone.
+ *
+ *  The five states are five rows: a credential in the keychain is not a
+ *  confirmed sign-in, so an unconfirmed one reads as offline and one the
+ *  server has rejected asks to sign in again rather than showing either a
+ *  sign-out or a plain signed-out row. */
+function accountRow(
+  account: AccountState,
+  reading: boolean,
+  readError: string | null,
+  act: Acts,
+): ReactNode {
+  if (account.kind === "loading")
+    return beforeAnyAnswer(reading, readError, act.load);
+
+  switch (account.kind) {
+    case "signed-out":
+      return (
+        <SettingRow label={ENDPOINT} description={ACCOUNT_SIGNED_OUT_NOTE}>
+          <Button onClick={act.signIn}>{ACCOUNT_SIGN_IN_GITHUB_LABEL}</Button>
+        </SettingRow>
+      );
+    case "expired":
+      return (
+        <SettingRow label={ENDPOINT} description={ACCOUNT_EXPIRED_TITLE}>
+          <Button onClick={act.signIn}>{ACCOUNT_SIGN_IN_AGAIN_LABEL}</Button>
+        </SettingRow>
+      );
+    case "signed-in":
+      return (
+        <SettingRow
+          label={<Whose identity={account.identity} />}
+          description={ACCOUNT_SIGNED_IN_NOTE}
+        >
+          <Button variant="outline" onClick={act.signOut}>
+            {ACCOUNT_SIGN_OUT_LABEL}
+          </Button>
+        </SettingRow>
+      );
+    case "offline":
+      // The credential is still ours to drop, so signing out stays offered:
+      // it clears what this machine holds, and the server hears about it on
+      // the next request either way.
+      return (
+        <SettingRow
+          label={
+            <Whose identity={account.identity} marker={ACCOUNT_OFFLINE_LABEL} />
+          }
+          description={ACCOUNT_OFFLINE_TITLE}
+        >
+          <Button variant="outline" onClick={act.signOut}>
+            {ACCOUNT_SIGN_OUT_LABEL}
+          </Button>
+        </SettingRow>
+      );
+  }
+
+  // A sixth account state has to be drawn above before this compiles.
+  const undrawn: never = account;
+  return undrawn;
+}
+
+/** Settings → Account: the one place sign-in state lives, and the one place
+ * a failed account read is explained.
+ *
+ * Signing in is the device flow — a code, a browser tab, done; signing out
+ * kills every credential from that sign-in on the very next request.
+ *
+ * The sidebar row says which state the last read settled on and opens this
+ * page. The reason a read did not land, and the retry for it, live here
+ * alone: two surfaces explaining one failure would drift, and only this one
+ * has the room to say it in words.
+ */
 export function AccountSection() {
-  const signedIn = useAccountStore((s) => hasCredential(s.account));
+  const account = useAccountStore((s) => s.account);
+  const reading = useAccountStore((s) => s.reading);
+  const readError = useAccountStore((s) => s.readError);
   const signingIn = useAccountStore((s) => s.signingIn);
   const userCode = useAccountStore((s) => s.userCode);
   const error = useAccountStore((s) => s.error);
   const signIn = useAccountStore((s) => s.signIn);
   const cancelSignIn = useAccountStore((s) => s.cancelSignIn);
   const signOut = useAccountStore((s) => s.signOut);
+  const load = useAccountStore((s) => s.load);
 
   return (
     <Section title="Account">
-      <SettingRow
-        label="kendex.ai"
-        description={
-          signedIn
-            ? "Signed in. Submitting marketplaces uses this account; the credential lives in your system keychain."
-            : "Sign in with GitHub to submit marketplaces to the community directory. Nothing else needs it."
-        }
-      >
-        {signedIn ? (
-          <Button variant="outline" onClick={() => void signOut()}>
-            Sign out
-          </Button>
-        ) : signingIn ? (
+      {/* A device flow that is out is what the section is about until it
+          lands or is called off: the state it began from is the state it
+          is trying to leave. */}
+      {signingIn ? (
+        <SettingRow
+          label={ENDPOINT}
+          // The code belongs to the row it is waiting on, not to a line
+          // under it: the browser tab is already open, and the sentence is
+          // what to do in it.
+          description={
+            userCode ? (
+              <>
+                A kendex.ai page just opened with the code{" "}
+                <span className="font-mono font-medium text-foreground">
+                  {userCode}
+                </span>{" "}
+                — approve it there and this page updates on its own.
+              </>
+            ) : (
+              ACCOUNT_SIGNING_IN_NOTE
+            )
+          }
+        >
           <Button variant="outline" onClick={cancelSignIn}>
-            Cancel
+            {ACCOUNT_CANCEL_SIGN_IN_LABEL}
           </Button>
-        ) : (
-          <Button onClick={() => void signIn()}>Sign in with GitHub</Button>
-        )}
-      </SettingRow>
-      {signingIn && userCode ? (
-        <p className="text-sm text-muted-foreground">
-          A kendex.ai page just opened with the code{" "}
-          <span className="font-mono font-medium">{userCode}</span> — approve it
-          there and this page updates on its own.
-        </p>
-      ) : null}
+        </SettingRow>
+      ) : (
+        accountRow(account, reading, readError, {
+          signIn: () => void signIn(),
+          signOut: () => void signOut(),
+          load: () => void load(),
+        })
+      )}
+      {/* The device flow's failure and the read's are two different things:
+          a person who came back from denying an approval still has that
+          explanation, whatever the read went on to say. */}
       {error ? (
         <p className="text-sm text-critical" role="alert">
           {error}
         </p>
+      ) : null}
+      {readError !== null ? (
+        <SettingRow
+          role="alert"
+          label={
+            <span className="text-critical">{ACCOUNT_UNREADABLE_LABEL}</span>
+          }
+          description={readError}
+        >
+          <Button
+            variant="outline"
+            disabled={reading}
+            onClick={() => void load()}
+          >
+            {ACCOUNT_RETRY_LABEL}
+          </Button>
+        </SettingRow>
       ) : null}
     </Section>
   );

--- a/ui/src/components/account-section.tsx
+++ b/ui/src/components/account-section.tsx
@@ -1,5 +1,5 @@
 import type { ReactNode } from "react";
-import { AccountAvatar, displayName } from "@/components/account-avatar";
+import { AccountAvatar, accountLabel } from "@/components/account-avatar";
 import { Section, SettingRow } from "@/components/section";
 import { Button } from "@/components/ui/button";
 import {
@@ -13,7 +13,6 @@ import {
   ACCOUNT_SIGN_IN_AGAIN_LABEL,
   ACCOUNT_SIGN_IN_GITHUB_LABEL,
   ACCOUNT_SIGN_OUT_LABEL,
-  ACCOUNT_SIGNED_IN_LABEL,
   ACCOUNT_SIGNED_IN_NOTE,
   ACCOUNT_SIGNED_OUT_NOTE,
   ACCOUNT_SIGNING_IN_NOTE,
@@ -40,7 +39,11 @@ interface Acts {
 }
 
 /** Whose account it is: the letter and the name, or "Signed in" where the
- *  server holds a credential it has not yet put a name to. */
+ *  server holds a credential it has not yet put a name to.
+ *
+ *  The name is the one part that can be any length, so it is the one part
+ *  that gives: a long name is cut off rather than pushing the control out
+ *  of the row's lane. Everything either side of it keeps its size. */
 function Whose({
   identity,
   marker,
@@ -49,11 +52,11 @@ function Whose({
   marker?: string;
 }) {
   return (
-    <span className="flex items-center gap-2">
+    <span className="flex min-w-0 items-center gap-2">
       <AccountAvatar identity={identity} className="size-6 text-[11px]" />
-      {displayName(identity) || ACCOUNT_SIGNED_IN_LABEL}
+      <span className="min-w-0 truncate">{accountLabel(identity)}</span>
       {marker ? (
-        <span className="text-xs font-normal text-muted-foreground">
+        <span className="shrink-0 text-xs font-normal text-muted-foreground">
           {marker}
         </span>
       ) : null}
@@ -156,9 +159,9 @@ function accountRow(
  * kills every credential from that sign-in on the very next request.
  *
  * The sidebar row says which state the last read settled on and opens this
- * page. The reason a read did not land, and the retry for it, live here
- * alone: two surfaces explaining one failure would drift, and only this one
- * has the room to say it in words.
+ * page. Of those two the row states the state and this page carries the
+ * reason and the retry: a one-line row has no room for a cause, and one
+ * sentence written on both surfaces would drift.
  */
 export function AccountSection() {
   const account = useAccountStore((s) => s.account);

--- a/ui/src/components/section.tsx
+++ b/ui/src/components/section.tsx
@@ -78,6 +78,7 @@ export function SettingRow({
   label,
   description,
   htmlFor,
+  role,
   children,
   className,
 }: {
@@ -85,12 +86,16 @@ export function SettingRow({
   description?: ReactNode;
   /** Set when the control is a real form field, so the label focuses it. */
   htmlFor?: string;
+  /** Set where the row is an announcement rather than a setting — a read
+   *  that failed, say — so a screen reader is told when it appears. */
+  role?: string;
   children?: ReactNode;
   className?: string;
 }) {
   const Label = htmlFor ? "label" : "span";
   return (
     <div
+      role={role}
       className={cn(
         "flex items-start justify-between gap-8 py-3.5 first:pt-0",
         className,

--- a/ui/src/components/sidebar-account.dom.test.tsx
+++ b/ui/src/components/sidebar-account.dom.test.tsx
@@ -13,11 +13,11 @@ import {
   ACCOUNT_SIGN_IN_LABEL,
   ACCOUNT_SIGNED_IN_LABEL,
   ACCOUNT_UNREADABLE_LABEL,
-} from "@/lib/copy";
+} from "@/lib/copy-account";
 import { type AccountState, useAccountStore } from "@/stores/account";
 import { useNavStore } from "@/stores/nav";
 import { mount } from "@/test/dom";
-import { accountInitial, SidebarAccount } from "./sidebar-account";
+import { SidebarAccount } from "./sidebar-account";
 
 vi.mock("@/bindings", () => ({ commands: {} }));
 
@@ -73,15 +73,15 @@ describe("what the account row draws", () => {
     const host = show({ kind: "loading" }, "no network");
     expect(seen(host)).toContain(ACCOUNT_UNREADABLE_LABEL);
     expect(seen(host)).not.toContain(ACCOUNT_SIGN_IN_LABEL);
-    expect(spoken(host)).toBe("no network");
+    expect(spoken(host)).toBe(ACCOUNT_ROW_TITLE);
   });
 
-  // Nothing here retries a read, and nothing here routes to a page that
-  // would claim to know an account state this row could not read.
-  it("goes nowhere from a failed read", async () => {
+  // The reason and the retry live in Settings > Account, so the row that
+  // reports the failure is the way to them.
+  it("opens the settings page from a failed read", async () => {
     const host = show({ kind: "loading" }, "no network");
     await userEvent.click(rowOf(host));
-    expect(useNavStore.getState().page).toBe("home");
+    expect(useNavStore.getState().page).toBe("settings");
   });
 
   it("offers a quiet sign-in when signed out", () => {
@@ -162,15 +162,10 @@ describe("how the sentence behind a row reaches a person", () => {
     expect(document.activeElement).toBe(row);
   });
 
-  // A button announces something to press. The failed read has nothing to
-  // press, so the row that reports it must not claim otherwise while still
-  // being the only place its sentence lives.
-  it("offers no button to press from a failed read", () => {
-    const host = show({ kind: "loading" }, "no network");
-    expect(rowOf(host).tagName).not.toBe("BUTTON");
-    expect(rowOf(host).getAttribute("role")).not.toBe("button");
-    expect(host.querySelector("button")).toBeNull();
-    expect(spoken(host)).toBe("no network");
+  it("keeps the failed-read row a button, since it acts too", () => {
+    expect(rowOf(show({ kind: "loading" }, "no network")).tagName).toBe(
+      "BUTTON",
+    );
   });
 
   it.each(SETTLED)(
@@ -186,83 +181,38 @@ describe("how the sentence behind a row reaches a person", () => {
   });
 });
 
-// A read that fails after one that landed changes no state: it leaves the
-// account exactly as the last good answer left it and records only why it
-// could not be repeated. Without the cause on the row, the same failure
-// would be loud before the first answer and silent ever after.
-describe("a read that failed after one that landed", () => {
-  it.each(SETTLED)("marks the %s row with the cause", (_state, account) => {
-    const clean = spoken(show(account));
-    const failed = spoken(show(account, "keychain locked"));
-    expect(failed).toContain("keychain locked");
-    expect(failed).not.toBe(clean);
-  });
-
-  // A rejected credential and a read that could not be made are different
-  // answers. Where the row's own sentence is the only thing explaining what
-  // it draws, a later failure joins it rather than taking its place.
+// Each row's sentence is its own: what the state means for the two that
+// mean something the row cannot show, and where the click goes for the rest.
+describe("the sentence behind each row", () => {
   it.each([
+    ["signed-in", { kind: "signed-in", identity: ADA }, ACCOUNT_ROW_TITLE],
+    ["signed-out", { kind: "signed-out" }, ACCOUNT_ROW_TITLE],
     ["expired", { kind: "expired" }, ACCOUNT_EXPIRED_TITLE],
     ["offline", { kind: "offline", identity: ADA }, ACCOUNT_OFFLINE_TITLE],
   ] as [string, AccountState, string][])(
-    "keeps the %s row's own explanation beside the cause",
+    "says what the %s row means",
     (_state, account, sentence) => {
-      const words = spoken(show(account, "keychain locked"));
-      expect(words).toContain(sentence);
-      expect(words).toContain("keychain locked");
-    },
-  );
-
-  // The other two rows explain nothing beyond the click they offer, so the
-  // cause takes that hint's place rather than trailing it.
-  it.each([
-    ["signed-in", { kind: "signed-in", identity: ADA }],
-    ["signed-out", { kind: "signed-out" }],
-  ] as [string, AccountState][])(
-    "replaces the %s row's affordance hint with the cause",
-    (_state, account) => {
-      expect(spoken(show(account))).toBe(ACCOUNT_ROW_TITLE);
-      expect(spoken(show(account, "keychain locked"))).toBe("keychain locked");
+      expect(spoken(show(account))).toBe(sentence);
     },
   );
 });
 
-describe("the letter on the avatar", () => {
-  const named = (name: string) => accountInitial({ name, githubLogin: null });
-
-  it("takes the name's first letter", () => {
-    expect(accountInitial(ADA)).toBe("A");
+// A read that fails after one that landed changes no state: it leaves the
+// account exactly as the last good answer left it. The row therefore reads
+// the same either way, and the cause it does not carry is on the page every
+// row opens.
+describe("a read that failed after one that landed", () => {
+  it.each(SETTLED)("leaves the %s row as it was", (_state, account) => {
+    const clean = show(account);
+    expect(spoken(show(account, "keychain locked"))).toBe(spoken(clean));
+    expect(seen(show(account, "keychain locked"))).toBe(seen(clean));
   });
 
-  // The accent is part of the letter a reader sees, whether the server sent
-  // one character or a base letter and a combining mark.
-  it("keeps a combining mark with the letter it belongs to", () => {
-    expect(named("e\u0301lodie")).toBe("E\u0301");
-    expect(named("élodie")).toBe("É");
-  });
-
-  // Casing can widen what it is given: this one letter uppercases to two,
-  // and the circle holds one.
-  it("keeps one letter when casing expands it", () => {
-    expect(named("ßeta")).toBe("S");
-  });
-
-  // Every part of the sequence or none: half an emoji is a different emoji.
-  it("keeps a multi-part emoji whole", () => {
-    expect(named("👩‍🚀 crew")).toBe("👩‍🚀");
-  });
-
-  // A name the server sent as blank is no name at all, and the provider id
-  // is not a stand-in for one: the circle stays empty.
-  it("has no letter for a blank name", () => {
-    expect(accountInitial({ name: "   ", githubLogin: "1234567" })).toBeNull();
-  });
-
-  it("has no letter for an account with no identity", () => {
-    expect(accountInitial(null)).toBeNull();
-  });
-
-  it("keeps a first character that is a surrogate pair whole", () => {
-    expect(named("𝔄da")).toBe("𝔄");
-  });
+  it.each(SETTLED)(
+    "keeps the cause off the %s row, on either surface",
+    (_state, account) => {
+      const host = show(account, "keychain locked");
+      expect(host.textContent).not.toContain("keychain locked");
+    },
+  );
 });

--- a/ui/src/components/sidebar-account.tsx
+++ b/ui/src/components/sidebar-account.tsx
@@ -1,6 +1,6 @@
 import { CircleAlert, LogIn } from "lucide-react";
 import type { ReactNode } from "react";
-import { AccountAvatar, displayName } from "@/components/account-avatar";
+import { AccountAvatar, accountLabel } from "@/components/account-avatar";
 import {
   Tooltip,
   TooltipContent,
@@ -13,12 +13,15 @@ import {
   ACCOUNT_ROW_TITLE,
   ACCOUNT_SIGN_IN_AGAIN_LABEL,
   ACCOUNT_SIGN_IN_LABEL,
-  ACCOUNT_SIGNED_IN_LABEL,
   ACCOUNT_UNREADABLE_LABEL,
 } from "@/lib/copy-account";
 import { SIDEBAR_ROW } from "@/lib/layout";
 import { cn } from "@/lib/utils";
-import { type AccountState, useAccountStore } from "@/stores/account";
+import {
+  type AccountIdentity,
+  type AccountState,
+  useAccountStore,
+} from "@/stores/account";
 import { useNavStore } from "@/stores/nav";
 
 /** One account row, and the one sentence behind it.
@@ -74,6 +77,30 @@ function Label({
   );
 }
 
+/** The row for a state that knows whose account it is. Both such states
+ *  draw the same line — a circle, the name, and what the state adds to it —
+ *  so what separates them is the sentence behind the row and the marker one
+ *  of them carries. */
+function IdentityRow({
+  identity,
+  tip,
+  marker,
+  open,
+}: {
+  identity: AccountIdentity | null;
+  tip: string;
+  marker?: string;
+  open: () => void;
+}) {
+  return (
+    <Row onClick={open} tip={tip}>
+      <AccountAvatar identity={identity} className="size-[18px] text-[10px]" />
+      <Label>{accountLabel(identity)}</Label>
+      {marker ? <span className="shrink-0 text-xs">{marker}</span> : null}
+    </Row>
+  );
+}
+
 /** Which row each account state draws.
  *
  *  The state decides on its own: a credential in the keychain is not a
@@ -121,28 +148,20 @@ function accountRow(
       );
     case "signed-in":
       return (
-        <Row onClick={open} tip={ACCOUNT_ROW_TITLE}>
-          <AccountAvatar
-            identity={account.identity}
-            className="size-[18px] text-[10px]"
-          />
-          <Label>
-            {displayName(account.identity) || ACCOUNT_SIGNED_IN_LABEL}
-          </Label>
-        </Row>
+        <IdentityRow
+          identity={account.identity}
+          tip={ACCOUNT_ROW_TITLE}
+          open={open}
+        />
       );
     case "offline":
       return (
-        <Row onClick={open} tip={ACCOUNT_OFFLINE_TITLE}>
-          <AccountAvatar
-            identity={account.identity}
-            className="size-[18px] text-[10px]"
-          />
-          <Label>
-            {displayName(account.identity) || ACCOUNT_SIGNED_IN_LABEL}
-          </Label>
-          <span className="shrink-0 text-xs">{ACCOUNT_OFFLINE_LABEL}</span>
-        </Row>
+        <IdentityRow
+          identity={account.identity}
+          tip={ACCOUNT_OFFLINE_TITLE}
+          marker={ACCOUNT_OFFLINE_LABEL}
+          open={open}
+        />
       );
   }
 

--- a/ui/src/components/sidebar-account.tsx
+++ b/ui/src/components/sidebar-account.tsx
@@ -1,5 +1,6 @@
 import { CircleAlert, LogIn } from "lucide-react";
 import type { ReactNode } from "react";
+import { AccountAvatar, displayName } from "@/components/account-avatar";
 import {
   Tooltip,
   TooltipContent,
@@ -14,102 +15,38 @@ import {
   ACCOUNT_SIGN_IN_LABEL,
   ACCOUNT_SIGNED_IN_LABEL,
   ACCOUNT_UNREADABLE_LABEL,
-} from "@/lib/copy";
+} from "@/lib/copy-account";
 import { SIDEBAR_ROW } from "@/lib/layout";
 import { cn } from "@/lib/utils";
-import {
-  type AccountIdentity,
-  type AccountState,
-  useAccountStore,
-} from "@/stores/account";
+import { type AccountState, useAccountStore } from "@/stores/account";
 import { useNavStore } from "@/stores/nav";
-
-/** What the row calls the account: the name the server answered with, or
- *  nothing where it has answered with none. `githubLogin` is not a second
- *  choice for it — the field is the provider's opaque account id, not a
- *  handle, and it is never shown. */
-const displayName = (identity: AccountIdentity | null): string =>
-  identity?.name.trim() ?? "";
-
-/** What a reader would call the first character: a base letter with the
- *  marks that belong to it, an emoji with every part of its sequence, and a
- *  character outside the BMP whole rather than halved. Grapheme breaking
- *  does not turn on the locale, so the default one answers the same
- *  everywhere. */
-const graphemes = new Intl.Segmenter(undefined, { granularity: "grapheme" });
-
-const firstGrapheme = (text: string): string => {
-  for (const { segment } of graphemes.segment(text)) return segment;
-  return "";
-};
-
-/** The letter on the avatar, and nothing where there is no name to take it
- *  from.
- *
- *  Cased by the plain call rather than the locale-aware one, whose
- *  no-argument form is host-dependent by specification. Segmented again
- *  after casing because a case mapping can widen what it is given: the
- *  German sharp s uppercases to two letters, and the circle holds one. */
-export function accountInitial(
-  identity: AccountIdentity | null,
-): string | null {
-  const first = firstGrapheme(displayName(identity));
-  return first ? firstGrapheme(first.toUpperCase()) : null;
-}
-
-/** The circle in the icon lane. It carries a letter once the server has
- *  named the account and stays empty until then: a stored credential is not
- *  a person, and inventing an initial for one would claim it is. */
-function Avatar({ identity }: { identity: AccountIdentity | null }) {
-  return (
-    <span
-      aria-hidden
-      className="flex size-[18px] shrink-0 items-center justify-center rounded-full bg-foreground/[0.12] text-[10px] font-semibold leading-none"
-    >
-      {accountInitial(identity)}
-    </span>
-  );
-}
 
 /** One account row, and the one sentence behind it.
  *
  *  `tip` is the sentence: a popup for a pointer, the same popup for a
  *  keyboard because the trigger takes focus, and the trigger's own text for
- *  a screen reader. A native title reaches none of the last two, and on the
- *  failed-read row the sentence is the only place the reason lives.
+ *  a screen reader. A native title reaches none of the last two.
  *
- *  A row with nowhere to go is still a trigger, and it is not a button:
- *  a button that presses to nothing is an offer the app cannot keep, so the
- *  inert row is a focusable line of text instead. */
+ *  Every row acts, including the one a failed read leaves: what it opens is
+ *  the page carrying the reason and the retry. */
 function Row({
   onClick,
   tip,
   children,
 }: {
-  onClick?: () => void;
+  onClick: () => void;
   tip: string;
   children: ReactNode;
 }) {
-  const shape = cn(
-    SIDEBAR_ROW,
-    "w-full text-sm text-muted-foreground outline-none focus-visible:ring-[3px] focus-visible:ring-ring/50",
-    onClick &&
-      "transition-colors hover:bg-sidebar-accent/40 hover:text-foreground",
-  );
   return (
     <Tooltip>
       <TooltipTrigger
         onClick={onClick}
-        className={shape}
-        // The trigger's default element is a button, which is right for the
-        // rows that navigate and wrong for the one that does not. Focus is
-        // what the inert row needs, and a tab stop is not a press.
-        render={
-          onClick ? undefined : (
-            // biome-ignore lint/a11y/noNoninteractiveTabindex: a tooltip trigger is reached by keyboard or its sentence reaches nobody, and ARIA has no interactive role for one that does not act
-            <div tabIndex={0} />
-          )
-        }
+        className={cn(
+          SIDEBAR_ROW,
+          "w-full text-sm text-muted-foreground outline-none focus-visible:ring-[3px] focus-visible:ring-ring/50",
+          "transition-colors hover:bg-sidebar-accent/40 hover:text-foreground",
+        )}
       >
         {children}
         <span className="sr-only">{tip}</span>
@@ -137,25 +74,18 @@ function Label({
   );
 }
 
-/** A row's sentence where the state's own explanation has to survive a
- *  later failed read. */
-const explained = (sentence: string, readError: string | null): string =>
-  readError === null ? sentence : `${sentence} ${readError}`;
-
 /** Which row each account state draws.
  *
  *  The state decides on its own: a credential in the keychain is not a
  *  confirmed sign-in, so an unconfirmed one reads as offline and one the
  *  server has rejected asks to sign in again.
  *
- *  `readError` is why the last read did not land, and it outlives that read:
- *  a failure after an answer that worked leaves the settled state exactly as
- *  it was. Every row therefore carries the cause, or the failure would be
- *  visible before the first answer and invisible after it. Where the row's
- *  own sentence is the only explanation of what it draws, the cause joins it
- *  rather than replacing it: a rejected credential and a read that could not
- *  be made are different answers, and swapping one for the other would say
- *  the wrong thing about both. */
+ *  `readError` is why the last read did not land, and the row reports only
+ *  that it happened. The reason and the retry belong to Settings > Account,
+ *  which every row opens: a sidebar row is one line wide, and a failure
+ *  explained in two places is a failure explained differently in two
+ *  places. A read that fails after one that landed leaves the settled state
+ *  exactly as it was, so those rows go on saying what they said. */
 function accountRow(
   account: AccountState,
   readError: string | null,
@@ -165,7 +95,7 @@ function accountRow(
     // A read that failed says that much. One still on its way draws no row
     // rather than guessing which of the four answers is coming.
     return readError === null ? null : (
-      <Row tip={readError}>
+      <Row onClick={open} tip={ACCOUNT_ROW_TITLE}>
         <CircleAlert className="size-[18px] shrink-0 opacity-70" />
         {/* The only line long enough to need the smaller step: at the nav's
             size it would truncate inside a 224px column, and half a
@@ -177,22 +107,25 @@ function accountRow(
   switch (account.kind) {
     case "signed-out":
       return (
-        <Row onClick={open} tip={readError ?? ACCOUNT_ROW_TITLE}>
+        <Row onClick={open} tip={ACCOUNT_ROW_TITLE}>
           <LogIn className="size-[18px] shrink-0 opacity-70" />
           <Label>{ACCOUNT_SIGN_IN_LABEL}</Label>
         </Row>
       );
     case "expired":
       return (
-        <Row onClick={open} tip={explained(ACCOUNT_EXPIRED_TITLE, readError)}>
+        <Row onClick={open} tip={ACCOUNT_EXPIRED_TITLE}>
           <LogIn className="size-[18px] shrink-0 opacity-70" />
           <Label>{ACCOUNT_SIGN_IN_AGAIN_LABEL}</Label>
         </Row>
       );
     case "signed-in":
       return (
-        <Row onClick={open} tip={readError ?? ACCOUNT_ROW_TITLE}>
-          <Avatar identity={account.identity} />
+        <Row onClick={open} tip={ACCOUNT_ROW_TITLE}>
+          <AccountAvatar
+            identity={account.identity}
+            className="size-[18px] text-[10px]"
+          />
           <Label>
             {displayName(account.identity) || ACCOUNT_SIGNED_IN_LABEL}
           </Label>
@@ -200,8 +133,11 @@ function accountRow(
       );
     case "offline":
       return (
-        <Row onClick={open} tip={explained(ACCOUNT_OFFLINE_TITLE, readError)}>
-          <Avatar identity={account.identity} />
+        <Row onClick={open} tip={ACCOUNT_OFFLINE_TITLE}>
+          <AccountAvatar
+            identity={account.identity}
+            className="size-[18px] text-[10px]"
+          />
           <Label>
             {displayName(account.identity) || ACCOUNT_SIGNED_IN_LABEL}
           </Label>
@@ -217,10 +153,11 @@ function accountRow(
 
 /**
  * The foot of the sidebar: who the last account read found, and the way in
- * to the account settings.
+ * to the account settings, which is where a failed read is explained and
+ * retried.
  *
- * Nothing here retries a read. The startup effect in `App.tsx` owns that,
- * reading again every time the window comes back, so a failure that was the
+ * Nothing here retries a read on its own. The startup effect in `App.tsx`
+ * reads again every time the window comes back, so a failure that was the
  * network's clears itself when the person returns to the app.
  */
 export function SidebarAccount() {

--- a/ui/src/dev/mock-account.ts
+++ b/ui/src/dev/mock-account.ts
@@ -8,12 +8,8 @@
 // reach the store through its dev reader, which the backend takes over
 // once it can reach the server. `?account=` on the dev URL picks one.
 import type { AccountStatus } from "@/bindings";
-import {
-  type AccountRead,
-  hasCredential,
-  type SettledAccount,
-  setAccountReader,
-} from "@/stores/account";
+import { hasCredential, type SettledAccount } from "@/stores/account";
+import { type AccountRead, setAccountReader } from "@/stores/account-read";
 import type { Handler } from "./mock-state";
 
 // The provider's account id is an opaque number the server hands back, not

--- a/ui/src/lib/copy-account.ts
+++ b/ui/src/lib/copy-account.ts
@@ -1,0 +1,45 @@
+// The prose of the two account surfaces: the sidebar's foot and Settings >
+// Account. Kept together because the two say the same things about one
+// account, and a sentence that drifts between them describes two.
+//
+// House style is copy.ts's, applied throughout.
+// The account row at the foot of the sidebar. Each line says what the last
+// read settled on: a credential the server has not confirmed reads as
+// offline, and a read that never landed says that rather than picking a
+// state for it.
+export const ACCOUNT_SIGN_IN_LABEL = "Sign in";
+export const ACCOUNT_SIGN_IN_AGAIN_LABEL = "Sign in again";
+export const ACCOUNT_EXPIRED_TITLE =
+  "kendex.ai no longer accepts this sign-in.";
+// A credential is stored but the server has not put a name to it yet, so
+// the row shows no handle and claims nothing about who it belongs to.
+export const ACCOUNT_SIGNED_IN_LABEL = "Signed in";
+export const ACCOUNT_OFFLINE_LABEL = "Offline";
+export const ACCOUNT_OFFLINE_TITLE =
+  "Signed in as this account when kendex.ai was last reached.";
+export const ACCOUNT_UNREADABLE_LABEL = "Couldn't check your account";
+export const ACCOUNT_ROW_TITLE = "Open account settings";
+
+// Settings → Account. One row says which of the five things the last read
+// found, and the notice under it says why a read did not land — the only
+// retry on the page sits there, so a failure is explained in one place
+// however the state it interrupted reads.
+export const ACCOUNT_SIGNED_IN_NOTE =
+  "Signed in to kendex.ai. Submitting marketplaces uses this account; the credential lives in your system keychain.";
+export const ACCOUNT_SIGNED_OUT_NOTE =
+  "Sign in with GitHub to submit marketplaces to the community directory. Nothing else needs it.";
+export const ACCOUNT_SIGN_IN_GITHUB_LABEL = "Sign in with GitHub";
+export const ACCOUNT_SIGN_OUT_LABEL = "Sign out";
+// The three things "not read yet" can mean. Each says what kendex did, not
+// what it found, because it has found nothing.
+export const ACCOUNT_CHECKING_NOTE = "Checking whether you are signed in.";
+export const ACCOUNT_UNREADABLE_NOTE =
+  "kendex could not tell whether you are signed in.";
+export const ACCOUNT_UNCHECKED_NOTE =
+  "kendex has not checked whether you are signed in.";
+export const ACCOUNT_CHECK_LABEL = "Check now";
+export const ACCOUNT_RETRY_LABEL = "Try again";
+// The device flow, between the browser tab opening and the approval.
+export const ACCOUNT_SIGNING_IN_NOTE =
+  "Waiting for you to approve this sign-in.";
+export const ACCOUNT_CANCEL_SIGN_IN_LABEL = "Cancel";

--- a/ui/src/lib/copy-account.ts
+++ b/ui/src/lib/copy-account.ts
@@ -21,9 +21,9 @@ export const ACCOUNT_UNREADABLE_LABEL = "Couldn't check your account";
 export const ACCOUNT_ROW_TITLE = "Open account settings";
 
 // Settings → Account. One row says which of the five things the last read
-// found, and the notice under it says why a read did not land — the only
-// retry on the page sits there, so a failure is explained in one place
-// however the state it interrupted reads.
+// found, and the notice under it says why a read did not land — the page's
+// retry sits there, beside the reason, rather than on the row the failure
+// interrupted.
 export const ACCOUNT_SIGNED_IN_NOTE =
   "Signed in to kendex.ai. Submitting marketplaces uses this account; the credential lives in your system keychain.";
 export const ACCOUNT_SIGNED_OUT_NOTE =

--- a/ui/src/lib/copy.ts
+++ b/ui/src/lib/copy.ts
@@ -215,20 +215,3 @@ export const APP_UPDATE_UNKNOWN_NOTE =
 // it. Said wherever a change is one field and the retry is to press again.
 export const SETTINGS_MOVED_MESSAGE =
   "Your settings changed in another window. Try again.";
-
-// The account row at the foot of the sidebar. Each line says what the last
-// read settled on: a credential the server has not confirmed reads as
-// offline, and a read that never landed says that rather than picking a
-// state for it.
-export const ACCOUNT_SIGN_IN_LABEL = "Sign in";
-export const ACCOUNT_SIGN_IN_AGAIN_LABEL = "Sign in again";
-export const ACCOUNT_EXPIRED_TITLE =
-  "kendex.ai no longer accepts this sign-in.";
-// A credential is stored but the server has not put a name to it yet, so
-// the row shows no handle and claims nothing about who it belongs to.
-export const ACCOUNT_SIGNED_IN_LABEL = "Signed in";
-export const ACCOUNT_OFFLINE_LABEL = "Offline";
-export const ACCOUNT_OFFLINE_TITLE =
-  "Signed in as this account when kendex.ai was last reached.";
-export const ACCOUNT_UNREADABLE_LABEL = "Couldn't check your account";
-export const ACCOUNT_ROW_TITLE = "Open account settings";

--- a/ui/src/stores/account-read.ts
+++ b/ui/src/stores/account-read.ts
@@ -1,0 +1,58 @@
+// How the account is read, and who answers when it is.
+//
+// The store keeps what the last read settled on; this is the read itself —
+// the command, the rename from its wire shape, and the seam the dev harness
+// takes over so `?account=` can serve a state no server is behind.
+import { type AccountStatus, commands } from "@/bindings";
+import type { SettledAccount } from "./account";
+
+/** What a read of the account answers: the state it settled on, or why it
+ * could not be read. */
+export type AccountRead = { ok: SettledAccount } | { error: string };
+
+export type ReadAccount = () => Promise<AccountRead>;
+
+/** The wire answers every settled state this store keeps; the unread one
+ * is the UI's own, so the mapping is a rename. */
+const settled = (wire: AccountStatus["state"]): SettledAccount => {
+  switch (wire.state) {
+    case "signed-out":
+      return { kind: "signed-out" };
+    case "signed-in":
+      return { kind: "signed-in", identity: wire.identity };
+    case "offline":
+      return { kind: "offline", identity: wire.identity };
+    case "expired":
+      return { kind: "expired" };
+  }
+};
+
+/** The command asks the server who the credential belongs to, so it can
+ * answer with a name, with the last name it knew when the server is away,
+ * and with the rejection when the credential is dead. */
+const fromBridge: ReadAccount = async () => {
+  try {
+    const status = await commands.accountStatus();
+    if (status.status === "error") return { error: status.error };
+    return { ok: settled(status.data.state) };
+  } catch (error: unknown) {
+    // A bridge that throws and a reply that says no are the same answer
+    // here: the account could not be read. Letting the throw out would
+    // leave the read with nothing recorded and nothing to retry from.
+    return { error: String(error) };
+  }
+};
+
+let reader: ReadAccount = fromBridge;
+
+/** Dev only, called by the mock bridge: the harness answers as the states
+ * the backend will report once it can reach the server. Null puts the
+ * command back. */
+export function setAccountReader(read: ReadAccount | null): void {
+  reader = read ?? fromBridge;
+}
+
+/** One read of the account, through whoever is answering. Called through
+ * rather than exported directly, so a harness installed after the store was
+ * imported is still the one asked. */
+export const readAccount: ReadAccount = () => reader();

--- a/ui/src/stores/account-read.ts
+++ b/ui/src/stores/account-read.ts
@@ -31,16 +31,9 @@ const settled = (wire: AccountStatus["state"]): SettledAccount => {
  * answer with a name, with the last name it knew when the server is away,
  * and with the rejection when the credential is dead. */
 const fromBridge: ReadAccount = async () => {
-  try {
-    const status = await commands.accountStatus();
-    if (status.status === "error") return { error: status.error };
-    return { ok: settled(status.data.state) };
-  } catch (error: unknown) {
-    // A bridge that throws and a reply that says no are the same answer
-    // here: the account could not be read. Letting the throw out would
-    // leave the read with nothing recorded and nothing to retry from.
-    return { error: String(error) };
-  }
+  const status = await commands.accountStatus();
+  if (status.status === "error") return { error: status.error };
+  return { ok: settled(status.data.state) };
 };
 
 let reader: ReadAccount = fromBridge;
@@ -54,5 +47,18 @@ export function setAccountReader(read: ReadAccount | null): void {
 
 /** One read of the account, through whoever is answering. Called through
  * rather than exported directly, so a harness installed after the store was
- * imported is still the one asked. */
-export const readAccount: ReadAccount = () => reader();
+ * imported is still the one asked.
+ *
+ * The throw is caught here rather than in each reader: a bridge that throws
+ * and a reply that says no are the same answer, the account could not be
+ * read, and this is the one place every reader passes through. Letting a
+ * throw out would leave the read with nothing recorded, nothing to retry
+ * from, and an unhandled rejection wherever the store is loaded as
+ * `void load()`. */
+export const readAccount: ReadAccount = async () => {
+  try {
+    return await reader();
+  } catch (error: unknown) {
+    return { error: String(error) };
+  }
+};

--- a/ui/src/stores/account.test.ts
+++ b/ui/src/stores/account.test.ts
@@ -160,6 +160,22 @@ describe("a read that could not be made", () => {
       "ipc channel closed",
     );
   });
+
+  // The seam every reader passes through is what holds them to the answer
+  // their type promises. A reader that throws instead would otherwise leave
+  // the read with nothing recorded, nothing to retry from, and a rejection
+  // nobody catches: every caller of load says `void load()`.
+  it("records any reader that threw rather than answered", async () => {
+    setAccountReader(async () => {
+      throw new Error("the harness reader threw");
+    });
+    await load();
+    expect(account()).toEqual({ kind: "loading" });
+    expect(useAccountStore.getState().readError).toContain(
+      "the harness reader threw",
+    );
+    expect(useAccountStore.getState().reading).toBe(false);
+  });
 });
 
 // A surface offering the retry has to tell a read still on its way from one

--- a/ui/src/stores/account.test.ts
+++ b/ui/src/stores/account.test.ts
@@ -1,12 +1,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { type AccountStatus, commands } from "@/bindings";
-import {
-  type AccountRead,
-  hasCredential,
-  type SettledAccount,
-  setAccountReader,
-  useAccountStore,
-} from "./account";
+import { hasCredential, type SettledAccount, useAccountStore } from "./account";
+import { type AccountRead, setAccountReader } from "./account-read";
 
 vi.mock("@/bindings", () => ({
   commands: {
@@ -49,6 +44,7 @@ const fresh = () =>
     submissions: null,
     signingIn: false,
     userCode: null,
+    reading: false,
   });
 
 beforeEach(() => {
@@ -163,6 +159,73 @@ describe("a read that could not be made", () => {
     expect(useAccountStore.getState().readError).toContain(
       "ipc channel closed",
     );
+  });
+});
+
+// A surface offering the retry has to tell a read still on its way from one
+// that was never made, and only the store knows which it is.
+describe("whether a read is out", () => {
+  /** A reader whose answer is released by hand. */
+  const staged = () => {
+    const gates: ((answer: AccountRead) => void)[] = [];
+    setAccountReader(() => new Promise<AccountRead>((r) => gates.push(r)));
+    return gates;
+  };
+
+  const reading = () => useAccountStore.getState().reading;
+
+  // Read off the store's own initial state, not the one a test set up: a
+  // store that opens claiming a read is out grays the retry out before
+  // startup has asked for anything.
+  it("is false until a read begins", () => {
+    expect(useAccountStore.getInitialState().reading).toBe(false);
+  });
+
+  it("is true while the read is out and false once it lands", async () => {
+    const gates = staged();
+    const out = load();
+    expect(reading()).toBe(true);
+    gates[0]?.({ ok: { kind: "signed-out" } });
+    await out;
+    expect(reading()).toBe(false);
+  });
+
+  it("is false once a read that could not be made comes back", async () => {
+    unreadable();
+    await load();
+    expect(reading()).toBe(false);
+    expect(useAccountStore.getState().readError).toBe("keychain locked");
+  });
+
+  // The flag belongs to the newest read. An older one landing first must
+  // not say the account is settled while the read that speaks is still out.
+  it("stays true while a newer read is still out", async () => {
+    const gates = staged();
+    const startup = load();
+    const focus = load();
+    gates[0]?.({ ok: { kind: "signed-out" } });
+    await startup;
+    expect(reading()).toBe(true);
+    gates[1]?.({ ok: { kind: "signed-out" } });
+    await focus;
+    expect(reading()).toBe(false);
+  });
+
+  // A read the account outran is dropped, but it was still the last read
+  // out: leaving the flag up would disable a retry with nothing to wait for.
+  it("is false when the read it dropped was the last one out", async () => {
+    useAccountStore.setState({ account: { kind: "signed-in", identity: ADA } });
+    const gates = staged();
+    const out = load();
+    vi.mocked(commands.accountLogout).mockResolvedValue({
+      status: "ok",
+      data: null,
+    } as Awaited<ReturnType<typeof commands.accountLogout>>);
+    await useAccountStore.getState().signOut();
+    gates[0]?.({ ok: { kind: "signed-in", identity: ADA } });
+    await out;
+    expect(reading()).toBe(false);
+    expect(account()).toEqual({ kind: "signed-out" });
   });
 });
 

--- a/ui/src/stores/account.ts
+++ b/ui/src/stores/account.ts
@@ -4,7 +4,8 @@
 // Startup makes the one account read; every surface reads `account` from
 // here rather than asking again.
 import { create } from "zustand";
-import { type AccountStatus, commands, type SubmissionRow } from "@/bindings";
+import { commands, type SubmissionRow } from "@/bindings";
+import { readAccount } from "./account-read";
 
 /** Who the account belongs to, as the server names them. The linked
  * GitHub account is null once it has been unlinked. */
@@ -39,52 +40,6 @@ export const hasCredential = (account: AccountState): account is WithIdentity =>
 const cachedIdentity = (account: AccountState): AccountIdentity | null =>
   hasCredential(account) ? account.identity : null;
 
-/** What a read of the account answers: the state it settled on, or why it
- * could not be read. */
-export type AccountRead = { ok: SettledAccount } | { error: string };
-
-export type ReadAccount = () => Promise<AccountRead>;
-
-/** The wire answers every settled state this store keeps; the unread one
- * is the UI's own, so the mapping is a rename. */
-const settled = (wire: AccountStatus["state"]): SettledAccount => {
-  switch (wire.state) {
-    case "signed-out":
-      return { kind: "signed-out" };
-    case "signed-in":
-      return { kind: "signed-in", identity: wire.identity };
-    case "offline":
-      return { kind: "offline", identity: wire.identity };
-    case "expired":
-      return { kind: "expired" };
-  }
-};
-
-/** The command asks the server who the credential belongs to, so it can
- * answer with a name, with the last name it knew when the server is away,
- * and with the rejection when the credential is dead. */
-const fromBridge: ReadAccount = async () => {
-  try {
-    const status = await commands.accountStatus();
-    if (status.status === "error") return { error: status.error };
-    return { ok: settled(status.data.state) };
-  } catch (error: unknown) {
-    // A bridge that throws and a reply that says no are the same answer
-    // here: the account could not be read. Letting the throw out would
-    // leave the read with nothing recorded and nothing to retry from.
-    return { error: String(error) };
-  }
-};
-
-let readAccount: ReadAccount = fromBridge;
-
-/** Dev only, called by the mock bridge: the harness answers as the states
- * the backend will report once it can reach the server. Null puts the
- * command back. */
-export function setAccountReader(read: ReadAccount | null): void {
-  readAccount = read ?? fromBridge;
-}
-
 interface AccountStore {
   account: AccountState;
   /** The in-flight device flow, when one is showing. */
@@ -97,6 +52,10 @@ interface AccountStore {
   error: string | null;
   /** Why the last account read failed, or null when it landed. */
   readError: string | null;
+  /** True while a read is out. A surface that offers the retry needs to
+   *  tell a read still on its way from one that was never made: the first
+   *  has nothing to ask for again, and the second has never asked. */
+  reading: boolean;
   submissions: SubmissionRow[] | null;
 
   /** The account read. Startup makes it, a return to the window repeats
@@ -132,16 +91,22 @@ export const useAccountStore = create<AccountStore>((set, get) => ({
   signingIn: false,
   error: null,
   readError: null,
+  reading: false,
   submissions: null,
 
   load: async () => {
     reads += 1;
     const mine = reads;
     const before = handover;
+    set({ reading: true });
     const answer = await readAccount();
-    // An older read and a read overtaken by a sign-in or sign-out are the
-    // same thing: news about an account that has already moved on.
-    if (mine !== reads || before !== handover) return;
+    // A read a newer one overtook says nothing and clears nothing: the
+    // newer read is still out, and the flag is its to lower.
+    if (mine !== reads) return;
+    set({ reading: false });
+    // A read overtaken by a sign-in or sign-out is news about an account
+    // that has already moved on.
+    if (before !== handover) return;
     if ("error" in answer) {
       // A read that failed knows nothing new, so it never takes anything
       // away. With an identity already in hand the failure is exactly


### PR DESCRIPTION
## Summary

- Settings > Account draws the five account states apart instead of collapsing them through `hasCredential`, which was true for `signed-in` and `offline` and false for everything else — so an offline session read as a confirmed sign-in and an expired one read as signed out. Each state now has its own row: the account name with an initial-letter avatar and Sign out, the same with an Offline marker where the server could not be reached, Sign in again for a rejected credential, the device flow when signed out, and a three-way for a read that has not landed.
- A read that failed shows its cause and the page's only Try again, wired to `load()`, per the failed-read rule in `docs/ARCHITECTURE.md`. No surface reads on mount; startup still owns the only load.
- The two account surfaces divide the work: the sidebar row states which state the last read settled on and opens this page; Settings owns the explanation and the retry. That removed the read-failure machinery the sidebar had grown — `explained`, the cause joined onto every tooltip, and the inert-div trigger branch.
- `accountLabel` and the avatar letter live in `ui/src/components/account-avatar.tsx`, so one account cannot read as two people across the two surfaces, and the account prose is in `ui/src/lib/copy-account.ts`.

The display value is `identity.name`. `githubLogin` is the linked provider's immutable account id and is never rendered.

## Context

- **Research**: Sidebar notices + app updates, and the account surface — `docs/plans/update-notice-and-account.md`

## Completed Issues

- Closes KEN-443 - Settings > Account shows identity, sign out, and device-flow sign-in

## Test Plan

- `tools/guard` green in the foreground, `tsc --noEmit -p ui/tsconfig.json` clean in the same pass, 816 UI tests across 106 files.
- `ui/src/components/account-section.dom.test.tsx` covers every state's own copy — including that a signed-in row says so and carries no Offline marker — the retry's disabled state and its `role="alert"`, the device-flow code, and a long name truncating.
- `ui/src/components/account-avatar.test.ts` covers the name fallback and the avatar letter; `ui/src/stores/account.test.ts` covers the read flag under an overtaken read and a reader that throws.
- 28 must-fail controls planted across the two rounds, each run red before counting green.
