### PR TITLE
docs(KEN-733): the ratchet names the Rust shapes that fake a seam

### DIFF
--- a/.agents/skills/size-ratchet/SKILL.md
+++ b/.agents/skills/size-ratchet/SKILL.md
@@ -52,9 +52,9 @@ only one caller uses, or "part 2 of X" into a second file to duck the
 count is worse than the long file: prefer the raise.
 
 **Three Rust shapes are that move, whatever the seam is called.**
-1. `#[path = "<sibling>.rs"]` on a private `mod` whose only consumer is
-   the file declaring it. The `#[path = "tests.rs"]` form is the
-   test-module idiom and is not this.
+1. `#[path = "<sibling>.rs"]` on a private `mod` that exists to hold the
+   parent's lines. `#[path]` chosen for any other reason, a test module,
+   a `cfg`-selected alternative, names a real seam.
 2. A hub declaring `mod child;` then `use child::*`, with every spoke
    opening `use super::*`. The split is invisible by construction, so no
    seam is load-bearing and every spoke reaches whatever its siblings

--- a/.agents/skills/size-ratchet/SKILL.md
+++ b/.agents/skills/size-ratchet/SKILL.md
@@ -45,9 +45,27 @@ at a concept seam*.
 agent can load and reason about whole: one concept per file, whole
 concept in the file. A *concept seam* is a boundary where the extracted
 file stands alone — its reader never needs the source file open beside
-it. Moving half a function, a helper only one caller uses, or "part 2 of
-X" into a second file to duck the count is worse than the long file:
-prefer the raise.
+it. For a file offered as one, count the names it imports straight from
+its parent (`use super::{...}`): a real seam sits near zero, and
+`use super::*` is an automatic failure. Moving half a function, a helper
+only one caller uses, or "part 2 of X" into a second file to duck the
+count is worse than the long file: prefer the raise.
+
+**Three Rust shapes are that move, whatever the seam is called.**
+1. `#[path = "<sibling>.rs"]` on a private `mod` whose only consumer is
+   the file declaring it. The `#[path = "tests.rs"]` form is the
+   test-module idiom and is not this.
+2. A hub declaring `mod child;` then `use child::*`, with every spoke
+   opening `use super::*`. The split is invisible by construction, so no
+   seam is load-bearing and every spoke reaches whatever its siblings
+   widened for the hub's glob. A hub carries declarations, narrow
+   orchestration, and stable exports. A spoke depends on the hub's shared
+   types or on a lower shared module, never on a sibling's internals.
+3. A file whose only top-level items are inherent `impl` blocks on a type
+   its parent declares. That file is part 2 of the type by construction.
+
+A file header that justifies the file's existence by a line threshold is
+the author writing down that the seam is not real.
 
 **Raising a row** (`RATCHET_RAISE=1`, reason in the commit body) is
 correct in exactly two cases, both for hand-written files:

--- a/skills/size-ratchet/SKILL.md
+++ b/skills/size-ratchet/SKILL.md
@@ -52,9 +52,9 @@ only one caller uses, or "part 2 of X" into a second file to duck the
 count is worse than the long file: prefer the raise.
 
 **Three Rust shapes are that move, whatever the seam is called.**
-1. `#[path = "<sibling>.rs"]` on a private `mod` whose only consumer is
-   the file declaring it. The `#[path = "tests.rs"]` form is the
-   test-module idiom and is not this.
+1. `#[path = "<sibling>.rs"]` on a private `mod` that exists to hold the
+   parent's lines. `#[path]` chosen for any other reason, a test module,
+   a `cfg`-selected alternative, names a real seam.
 2. A hub declaring `mod child;` then `use child::*`, with every spoke
    opening `use super::*`. The split is invisible by construction, so no
    seam is load-bearing and every spoke reaches whatever its siblings

--- a/skills/size-ratchet/SKILL.md
+++ b/skills/size-ratchet/SKILL.md
@@ -45,9 +45,27 @@ at a concept seam*.
 agent can load and reason about whole: one concept per file, whole
 concept in the file. A *concept seam* is a boundary where the extracted
 file stands alone — its reader never needs the source file open beside
-it. Moving half a function, a helper only one caller uses, or "part 2 of
-X" into a second file to duck the count is worse than the long file:
-prefer the raise.
+it. For a file offered as one, count the names it imports straight from
+its parent (`use super::{...}`): a real seam sits near zero, and
+`use super::*` is an automatic failure. Moving half a function, a helper
+only one caller uses, or "part 2 of X" into a second file to duck the
+count is worse than the long file: prefer the raise.
+
+**Three Rust shapes are that move, whatever the seam is called.**
+1. `#[path = "<sibling>.rs"]` on a private `mod` whose only consumer is
+   the file declaring it. The `#[path = "tests.rs"]` form is the
+   test-module idiom and is not this.
+2. A hub declaring `mod child;` then `use child::*`, with every spoke
+   opening `use super::*`. The split is invisible by construction, so no
+   seam is load-bearing and every spoke reaches whatever its siblings
+   widened for the hub's glob. A hub carries declarations, narrow
+   orchestration, and stable exports. A spoke depends on the hub's shared
+   types or on a lower shared module, never on a sibling's internals.
+3. A file whose only top-level items are inherent `impl` blocks on a type
+   its parent declares. That file is part 2 of the type by construction.
+
+A file header that justifies the file's existence by a line threshold is
+the author writing down that the seam is not real.
 
 **Raising a row** (`RATCHET_RAISE=1`, reason in the commit body) is
 correct in exactly two cases, both for hand-written files:


### PR DESCRIPTION
## Summary

- `size-ratchet` SKILL.md § Responding to a failure names the three Rust shapes
  that produce "part 2 of X", beside the sentence already forbidding the class:
  a `#[path]` sibling whose only consumer is the file declaring it, the
  hub/spoke mutual glob, and a file holding only inherent `impl` blocks on a
  type its parent declares.
- A file header that justifies the file by a line threshold is named as the
  tell.
- The existing readability test gets its measure: the count of names the
  extracted file imports straight from its parent.

## Completed Issues

- Closes #1730 - size-ratchet: name the two Rust shapes that produce "part 2 of X", because agents reach for them without recognising them

## Notes

The naming is in SKILL.md rather than a reference on purpose: the issue's
argument is that an agent reaching for `#[path]` under cap pressure has to meet
the rule at that moment, not in a later audit.

Three shapes, not the two in the title — the third comes from the issue's own
comments, where a second consumer's audit calls it the highest-signal query it
ran.

No new reference file. Each shape's tell is a literal token, so the prose is the
pattern; shape 3 has no honest one-line grep, since "only top-level items" needs
a parse, and an unverified command is worse than none.
`references/threshold-change.md` is untouched — it is language-agnostic by
design, and the inherited-fragment note it already carries is not duplicated
here.

Deliberately out of scope, filed separately: checking composition before the
seam (#1740).

## Test Plan

- Both Rust claims were compile-checked during review. The first draft asserted
  the hub/spoke glob reaches "any sibling's private items"; that is false under
  Rust visibility (`E0425`), and the text now says a spoke reaches whatever its
  siblings widened for the hub's glob.
- The seam measure is scoped to a file offered as a concept seam, so it no
  longer contradicts the `#[path = "tests.rs"]` carve-out three lines below it —
  48 test-class files in this repo open a top-level `use super::*`.
- `tools/guard` green. SKILL.md goes 73 to 91 lines against 400; no baseline row
  moved.
- `skills/size-ratchet/**` and the committed `.agents/skills/size-ratchet/**`
  render are byte-identical.
