### PR TITLE
docs(KEN-741): the ratchet checks composition before the seam

### DIFF
--- a/.agents/skills/size-ratchet/SKILL.md
+++ b/.agents/skills/size-ratchet/SKILL.md
@@ -41,6 +41,13 @@ Every diagnostic names the file, its count, the baseline row it violated,
 the deciding threshold (class pattern or default), and the remedy: *split
 at a concept seam*.
 
+**Check composition before the seam.** A file over its cap whose bulk is
+inline tests needs those tests moved to the language's separate-test
+convention, not its concepts split; that move has no seam in it. In Rust
+the measure is every line inside `#[cfg(test)]`, under any module name,
+and past roughly 300 of them extraction is the whole remedy. Find a seam
+only in what remains.
+
 **The ratchet serves cohesion, never defeats it.** The goal is files an
 agent can load and reason about whole: one concept per file, whole
 concept in the file. A *concept seam* is a boundary where the extracted

--- a/.agents/skills/size-ratchet/SKILL.md
+++ b/.agents/skills/size-ratchet/SKILL.md
@@ -45,8 +45,8 @@ at a concept seam*.
 inline tests needs those tests moved to the language's separate-test
 convention, not its concepts split; that move has no seam in it. In Rust
 the measure is every line inside `#[cfg(test)]`, under any module name,
-and past roughly 300 of them extraction is the whole remedy. Find a seam
-only in what remains.
+and past roughly 300 of them extraction comes first. Find a seam only if
+what remains is still over.
 
 **The ratchet serves cohesion, never defeats it.** The goal is files an
 agent can load and reason about whole: one concept per file, whole

--- a/skills/size-ratchet/SKILL.md
+++ b/skills/size-ratchet/SKILL.md
@@ -41,6 +41,13 @@ Every diagnostic names the file, its count, the baseline row it violated,
 the deciding threshold (class pattern or default), and the remedy: *split
 at a concept seam*.
 
+**Check composition before the seam.** A file over its cap whose bulk is
+inline tests needs those tests moved to the language's separate-test
+convention, not its concepts split; that move has no seam in it. In Rust
+the measure is every line inside `#[cfg(test)]`, under any module name,
+and past roughly 300 of them extraction is the whole remedy. Find a seam
+only in what remains.
+
 **The ratchet serves cohesion, never defeats it.** The goal is files an
 agent can load and reason about whole: one concept per file, whole
 concept in the file. A *concept seam* is a boundary where the extracted

--- a/skills/size-ratchet/SKILL.md
+++ b/skills/size-ratchet/SKILL.md
@@ -45,8 +45,8 @@ at a concept seam*.
 inline tests needs those tests moved to the language's separate-test
 convention, not its concepts split; that move has no seam in it. In Rust
 the measure is every line inside `#[cfg(test)]`, under any module name,
-and past roughly 300 of them extraction is the whole remedy. Find a seam
-only in what remains.
+and past roughly 300 of them extraction comes first. Find a seam only if
+what remains is still over.
 
 **The ratchet serves cohesion, never defeats it.** The goal is files an
 agent can load and reason about whole: one concept per file, whole


### PR DESCRIPTION
## Summary

- `size-ratchet` SKILL.md § Responding to a failure states the composition check
  ahead of the seam guidance: a file over its cap whose bulk is inline tests
  needs those tests moved, not its concepts split, and that move has no seam in
  it. The ordering is the content — an agent that reads "split at a concept
  seam" on a file that is 80% tests invents a seam.

## Completed Issues

- Closes #1740 - size-ratchet: check composition before seam — 12% of one consumer's production source is inline test modules

## Notes

Rust is the only language whose tell is named. The issue offers Python and JS
tells too, but both are heuristics that need an "unless the file is already a
test file" carve-out to be correct — and a rule needing a carve-out is stated
wrong, which this section has now proved across three PRs. The general rule
stays language-neutral and the Rust measure is stated by its discriminator,
`#[cfg(test)]` under any module name, so the already-extracted
`#[path = "..."] mod tests;` form cannot fire: it ends at the semicolon with no
body.

Deliberately not here: the per-class code-line counting mode raised in the
issue's comment (`*.sh=400:code`, which would let a consumer retire a duplicate
line gate). It needs a new config surface plus a per-language comment
classifier that the comment itself calls the hard part — a product decision, not
this issue's Ask.

## Test Plan

- `tools/guard` green. SKILL.md goes 91 to 98 lines against 400; no baseline row
  moved.
- Review confirmed the premise against the script: `wc -l` counts inline test
  lines and `scripts/size-ratchet` has no `cfg(test)` awareness, so the
  distortion the paragraph describes is real.
- `skills/size-ratchet/**` and the committed `.agents/skills/size-ratchet/**`
  render are byte-identical.
