### PR TITLE
fix(KEN-721): the updater replaces the file kendex judged

### DIFF
--- a/crates/app/src/app_update.rs
+++ b/crates/app/src/app_update.rs
@@ -88,6 +88,29 @@ pub fn app_update_channel() -> Result<InstallChannel, String> {
     ))
 }
 
+/// Somewhere to put the path kendex approved, on whatever will perform the
+/// replacement. The plugin keeps what it was handed private, so this side
+/// of the handoff is the only side a test can watch.
+trait ReplacementTarget: Sized {
+    fn replace_at(self, path: &std::path::Path) -> Self;
+}
+
+impl ReplacementTarget for tauri_plugin_updater::UpdaterBuilder {
+    fn replace_at(self, path: &std::path::Path) -> Self {
+        self.executable_path(path)
+    }
+}
+
+/// Hand over the path [`kendex_core::install_channel::for_app`] judged, so
+/// the path that decides and the path that acts are one file. An install
+/// carrying no path leaves the target on its own fallback.
+fn aim_at_install<T: ReplacementTarget>(target: T, install: &AppInstall) -> T {
+    match install.judged_path() {
+        Some(path) => target.replace_at(path),
+        None => target,
+    }
+}
+
 /// Replace this install with the latest release and relaunch into it. The
 /// separately signed updater manifest is the delivery path and verifies
 /// itself; the discovery feed never supplies an install URL. A failure
@@ -99,13 +122,7 @@ pub async fn app_update_install(app: tauri::AppHandle) -> Result<(), String> {
     // so nothing a caller gets wrong can overwrite a package manager's files.
     let install = app_install()?;
     kendex_core::install_channel::for_app(&install, &Host).allow_replacement()?;
-    // The approved path is handed over so the path that decides and the
-    // path that acts are one file.
-    let mut builder = app.updater_builder();
-    if let Some(path) = install.judged_path() {
-        builder = builder.executable_path(path);
-    }
-    let update = builder
+    let update = aim_at_install(app.updater_builder(), &install)
         .build()
         .map_err(|error| error.to_string())?
         .check()
@@ -142,6 +159,44 @@ mod tests {
             selected_feed(Some(fixture), false),
             kendex_core::update_feed::RELEASE_FEED_URL
         );
+    }
+
+    /// Stands in for the updater builder, which keeps what it was handed
+    /// private. What reaches it is what the plugin would have been given.
+    #[derive(Default)]
+    struct Recorder(Option<std::path::PathBuf>);
+
+    impl ReplacementTarget for Recorder {
+        fn replace_at(self, path: &std::path::Path) -> Self {
+            Self(Some(path.to_owned()))
+        }
+    }
+
+    /// The handoff itself. Everything else about this change can be right
+    /// while the approved path never leaves `app_update_install`, and the
+    /// plugin then falls back to rebuilding its own from the launch
+    /// environment, which is the whole defect.
+    #[test]
+    fn the_approved_path_reaches_whatever_will_replace_it() {
+        for install in [
+            AppInstall::AppImage(Some("/home/pat/Apps/kendex.AppImage".into())),
+            AppInstall::MacBundle("/Applications/kendex.app/Contents/MacOS/kendex".into()),
+        ] {
+            assert_eq!(
+                aim_at_install(Recorder::default(), &install).0.as_deref(),
+                install.judged_path(),
+                "{install:?}"
+            );
+        }
+
+        // Nothing to hand over, so the target keeps its own fallback.
+        for install in [AppInstall::WindowsInstaller, AppInstall::AppImage(None)] {
+            assert_eq!(
+                aim_at_install(Recorder::default(), &install).0,
+                None,
+                "{install:?}"
+            );
+        }
     }
 
     /// Only the bundle is writable, so `for_app` can approve nothing else.

--- a/crates/app/src/app_update.rs
+++ b/crates/app/src/app_update.rs
@@ -100,9 +100,11 @@ pub async fn app_update_install(app: tauri::AppHandle) -> Result<(), String> {
     let install = app_install()?;
     kendex_core::install_channel::for_app(&install, &Host).allow_replacement()?;
     // Left to itself the plugin rebuilds the install path from the launch
-    // environment, unresolved, and replaces whatever that name reaches.
-    // One value answers both halves, so the file approved above is the file
-    // renamed below.
+    // environment. On Linux it rewrites the exported APPIMAGE name itself,
+    // so a link there leaves the image approved above untouched; on macOS
+    // it refuses a link anywhere in the launch path before replacing
+    // anything. Where the plugin gets that far, handing it the approved
+    // path puts both halves on one file.
     let mut builder = app.updater_builder();
     if let Some(path) = install.judged_path() {
         builder = builder.executable_path(path);
@@ -144,5 +146,69 @@ mod tests {
             selected_feed(Some(fixture), false),
             kendex_core::update_feed::RELEASE_FEED_URL
         );
+    }
+
+    /// Only the bundle is writable, so `for_app` can approve nothing else.
+    struct OnlyWritable(&'static str);
+
+    impl kendex_core::install_channel::HostProbe for OnlyWritable {
+        fn replaceable(&self, path: &std::path::Path) -> bool {
+            path == std::path::Path::new(self.0)
+        }
+
+        fn exists(&self, _: &std::path::Path) -> bool {
+            false
+        }
+
+        fn resolve(&self, path: &std::path::Path) -> std::path::PathBuf {
+            path.to_owned()
+        }
+
+        fn on_path(&self, _: &str) -> bool {
+            false
+        }
+
+        fn os_release(&self) -> Option<String> {
+            None
+        }
+    }
+
+    /// The plugin decides for itself what to replace, deriving it from the
+    /// path it is handed, so nothing kendex asserts about that path proves
+    /// the two agree. This asks the plugin.
+    ///
+    /// Getting it wrong is not a failed update. The derived path is what the
+    /// macOS installer removes before moving the new bundle in, escalating a
+    /// permission error to a shell `rm -rf` under `with administrator
+    /// privileges`. Hand over the bundle instead of the executable inside it
+    /// and the plugin climbs one level further, to the directory holding
+    /// every other app on the machine. The dependency is a caret range, so a
+    /// minor bump can move this derivation under an unchanged kendex.
+    #[test]
+    fn the_plugin_derives_the_unit_for_app_approved() {
+        let exe = "/Applications/kendex.app/Contents/MacOS/kendex";
+        let bundle = "/Applications/kendex.app";
+        let probe = OnlyWritable(bundle);
+        let install = AppInstall::mac_bundle(&probe, std::path::Path::new(exe));
+        assert_eq!(
+            kendex_core::install_channel::for_app(&install, &probe),
+            InstallChannel::Direct
+        );
+
+        let handed = install.judged_path().expect("a mac bundle carries a path");
+        let derived = tauri_plugin_updater::extract_path_from_executable(handed)
+            .expect("the plugin derives a path from an executable inside a bundle");
+        // True on every platform the function compiles for, and the property
+        // that matters: what the plugin acts on never escapes what kendex
+        // approved.
+        assert!(
+            derived.starts_with(bundle),
+            "plugin derived {} from {handed}, outside the approved {bundle}",
+            derived.display(),
+            handed = handed.display()
+        );
+        // Where the derivation runs for real it lands on the bundle exactly.
+        #[cfg(target_os = "macos")]
+        assert_eq!(derived, std::path::Path::new(bundle));
     }
 }

--- a/crates/app/src/app_update.rs
+++ b/crates/app/src/app_update.rs
@@ -97,9 +97,18 @@ pub fn app_update_channel() -> Result<InstallChannel, String> {
 pub async fn app_update_install(app: tauri::AppHandle) -> Result<(), String> {
     // The notice offers this on no other channel; the command asks anyway,
     // so nothing a caller gets wrong can overwrite a package manager's files.
-    kendex_core::install_channel::for_app(&app_install()?, &Host).allow_replacement()?;
-    let update = app
-        .updater()
+    let install = app_install()?;
+    kendex_core::install_channel::for_app(&install, &Host).allow_replacement()?;
+    // Left to itself the plugin rebuilds the install path from the launch
+    // environment, unresolved, and replaces whatever that name reaches.
+    // One value answers both halves, so the file approved above is the file
+    // renamed below.
+    let mut builder = app.updater_builder();
+    if let Some(path) = install.judged_path() {
+        builder = builder.executable_path(path);
+    }
+    let update = builder
+        .build()
         .map_err(|error| error.to_string())?
         .check()
         .await

--- a/crates/app/src/app_update.rs
+++ b/crates/app/src/app_update.rs
@@ -99,12 +99,8 @@ pub async fn app_update_install(app: tauri::AppHandle) -> Result<(), String> {
     // so nothing a caller gets wrong can overwrite a package manager's files.
     let install = app_install()?;
     kendex_core::install_channel::for_app(&install, &Host).allow_replacement()?;
-    // Left to itself the plugin rebuilds the install path from the launch
-    // environment. On Linux it rewrites the exported APPIMAGE name itself,
-    // so a link there leaves the image approved above untouched; on macOS
-    // it refuses a link anywhere in the launch path before replacing
-    // anything. Where the plugin gets that far, handing it the approved
-    // path puts both halves on one file.
+    // The approved path is handed over so the path that decides and the
+    // path that acts are one file.
     let mut builder = app.updater_builder();
     if let Some(path) = install.judged_path() {
         builder = builder.executable_path(path);

--- a/crates/core/src/install_channel.rs
+++ b/crates/core/src/install_channel.rs
@@ -69,6 +69,24 @@ pub enum AppInstall {
 }
 
 impl AppInstall {
+    /// The resolved path this install is judged by, for whatever will do
+    /// the replacing.
+    ///
+    /// An updater handed nothing builds its own path from the launch
+    /// environment — the `APPIMAGE` variable as exported, the current
+    /// executable as exec'd — and where either is a link it renames a file
+    /// [`for_app`] never saw. Handed this, it acts on the file that was
+    /// approved: the image itself on Linux, and on macOS the executable
+    /// whose bundle is the one [`for_app`] probed. Windows carries no path
+    /// because no path decides it.
+    pub fn judged_path(&self) -> Option<&Path> {
+        match self {
+            Self::AppImage(image) => image.as_deref(),
+            Self::MacBundle(exe) => Some(exe),
+            Self::WindowsInstaller => None,
+        }
+    }
+
     /// The macOS app, resolved: a Homebrew cask links `/Applications` at
     /// its Caskroom, and a process is handed the path it was launched
     /// under rather than the bundle behind it.

--- a/crates/core/src/install_channel.rs
+++ b/crates/core/src/install_channel.rs
@@ -69,16 +69,24 @@ pub enum AppInstall {
 }
 
 impl AppInstall {
-    /// The resolved path this install is judged by, for whatever will do
-    /// the replacing.
+    /// The path to hand whatever performs the replacement.
     ///
-    /// An updater handed nothing builds its own path from the launch
-    /// environment — the `APPIMAGE` variable as exported, the current
-    /// executable as exec'd — and where either is a link it renames a file
-    /// [`for_app`] never saw. Handed this, it acts on the file that was
-    /// approved: the image itself on Linux, and on macOS the executable
-    /// whose bundle is the one [`for_app`] probed. Windows carries no path
-    /// because no path decides it.
+    /// Each platform derives the unit [`for_app`] judged from this, so this
+    /// is not that unit. On macOS it has to stay the executable, because
+    /// the consumer climbs from it to the surrounding bundle; hand the
+    /// bundle over and it climbs one level too far, to the directory the
+    /// bundle sits in.
+    ///
+    /// Left to itself the updater plugin rebuilds this path from the launch
+    /// environment, and the two platforms go wrong differently. Linux takes
+    /// `APPIMAGE` exactly as exported and rewrites that name, so where the
+    /// name is a link it becomes a regular file and the image [`for_app`]
+    /// approved is never touched. macOS canonicalizes the running
+    /// executable and refuses outright when any ancestor of the launch path
+    /// is a link, so what is handed here decides only where that refusal
+    /// does not fire.
+    ///
+    /// Windows carries no path because no path decides it.
     pub fn judged_path(&self) -> Option<&Path> {
         match self {
             Self::AppImage(image) => image.as_deref(),

--- a/crates/core/src/install_channel.rs
+++ b/crates/core/src/install_channel.rs
@@ -69,24 +69,13 @@ pub enum AppInstall {
 }
 
 impl AppInstall {
-    /// The path to hand whatever performs the replacement.
+    /// The path to hand whatever performs the replacement, so that the path
+    /// [`for_app`] judged and the path acted on are one file. `None` where
+    /// no path decides the install.
     ///
-    /// Each platform derives the unit [`for_app`] judged from this, so this
-    /// is not that unit. On macOS it has to stay the executable, because
-    /// the consumer climbs from it to the surrounding bundle; hand the
-    /// bundle over and it climbs one level too far, to the directory the
-    /// bundle sits in.
-    ///
-    /// Left to itself the updater plugin rebuilds this path from the launch
-    /// environment, and the two platforms go wrong differently. Linux takes
-    /// `APPIMAGE` exactly as exported and rewrites that name, so where the
-    /// name is a link it becomes a regular file and the image [`for_app`]
-    /// approved is never touched. macOS canonicalizes the running
-    /// executable and refuses outright when any ancestor of the launch path
-    /// is a link, so what is handed here decides only where that refusal
-    /// does not fire.
-    ///
-    /// Windows carries no path because no path decides it.
+    /// On macOS this has to stay the executable: the consumer climbs from
+    /// it to the surrounding bundle, and handed the bundle it climbs one
+    /// level further, to the directory the bundle sits in.
     pub fn judged_path(&self) -> Option<&Path> {
         match self {
             Self::AppImage(image) => image.as_deref(),

--- a/crates/core/src/install_channel/tests.rs
+++ b/crates/core/src/install_channel/tests.rs
@@ -508,3 +508,40 @@ fn a_mac_bundle_is_the_one_behind_the_name_it_was_launched_under() {
     assert_eq!(install, AppInstall::MacBundle(PathBuf::from(caskroom)));
     assert_eq!(for_app(&install, &probe), InstallChannel::Direct);
 }
+
+/// Approving one file and replacing another is the whole failure this
+/// guards. The updater is handed [`AppInstall::judged_path`], and on each
+/// platform the path it derives from that is the path `for_app` probed:
+/// the image itself on Linux, the bundle behind the executable on macOS.
+/// Both installs here are reached through a link the resolver follows, and
+/// only the file behind it is writable — approval and replacement have to
+/// meet there or not at all.
+#[test]
+fn what_the_updater_replaces_is_what_the_link_resolves_to() {
+    let link = "/home/pat/.local/share/kendex/kendex.AppImage";
+    let image = "/home/pat/Apps/kendex-5.0.1.AppImage";
+    let probe = Fake::default().links(link, image).replaceable(image);
+    let install = AppInstall::from_appimage_env(
+        &probe,
+        Some(OsStr::new(link)),
+        Some(OsStr::new("/tmp/.mount_kendexAbc")),
+        Some(Path::new("/tmp/.mount_kendexAbc/usr/bin/kendex-app")),
+    );
+    assert_eq!(for_app(&install, &probe), InstallChannel::Direct);
+    // Linux takes the handed path as the file to replace, unchanged.
+    assert_eq!(install.judged_path(), Some(Path::new(image)));
+
+    let linked = "/Applications/kendex.app/Contents/MacOS/kendex";
+    let caskroom = "/Users/pat/Library/Caskroom/kendex/5.0.1/kendex.app/Contents/MacOS/kendex";
+    let bundle = "/Users/pat/Library/Caskroom/kendex/5.0.1/kendex.app";
+    let probe = Fake::default().links(linked, caskroom).replaceable(bundle);
+    let install = AppInstall::mac_bundle(&probe, Path::new(linked));
+    assert_eq!(for_app(&install, &probe), InstallChannel::Direct);
+    // macOS takes the bundle around the handed executable, the same way
+    // `for_app` did to reach the directory it just approved.
+    assert_eq!(install.judged_path(), Some(Path::new(caskroom)));
+    assert_eq!(
+        install.judged_path().and_then(bundle_root),
+        Some(Path::new(bundle))
+    );
+}

--- a/crates/core/src/install_channel/tests.rs
+++ b/crates/core/src/install_channel/tests.rs
@@ -509,13 +509,14 @@ fn a_mac_bundle_is_the_one_behind_the_name_it_was_launched_under() {
     assert_eq!(for_app(&install, &probe), InstallChannel::Direct);
 }
 
-/// What `judged_path` hands over, per platform. The resolving is pinned by
-/// the two link tests above; what is new here is the accessor, and on macOS
-/// that the value stays the executable rather than the bundle around it.
-/// `for_app` reaches the directory it approves by the same `bundle_root`
-/// asserted here, so the two meet at one unit. That the updater plugin then
-/// derives that same unit is a dependency of this design, not something
-/// this test establishes: the app crate pins it against the plugin itself.
+/// What `judged_path` hands over. The resolving behind these values is
+/// pinned above by the two link tests,
+/// `an_appimage_reached_through_a_link_belongs_to_whatever_it_points_at`
+/// and `a_mac_bundle_is_the_one_behind_the_name_it_was_launched_under`.
+/// New here is the accessor, and on macOS that it stays the executable:
+/// `for_app` reaches the bundle from it by the same `bundle_root` asserted
+/// here. Whether the updater plugin derives that same bundle is the app
+/// crate's test, not this one's.
 #[test]
 fn judged_path_hands_over_the_file_for_app_approved() {
     let image = "/home/pat/Apps/kendex-5.0.1.AppImage";
@@ -530,9 +531,6 @@ fn judged_path_hands_over_the_file_for_app_approved() {
         Some(Path::new(bundle))
     );
 
-    // Neither carries a path, and neither may start: an updater handed
-    // nothing keeps its own fallback, which is the whole of the Windows
-    // channel and is all a Linux launch outside an AppImage can offer.
     assert_eq!(AppInstall::WindowsInstaller.judged_path(), None);
     assert_eq!(AppInstall::AppImage(None).judged_path(), None);
 }

--- a/crates/core/src/install_channel/tests.rs
+++ b/crates/core/src/install_channel/tests.rs
@@ -509,39 +509,30 @@ fn a_mac_bundle_is_the_one_behind_the_name_it_was_launched_under() {
     assert_eq!(for_app(&install, &probe), InstallChannel::Direct);
 }
 
-/// Approving one file and replacing another is the whole failure this
-/// guards. The updater is handed [`AppInstall::judged_path`], and on each
-/// platform the path it derives from that is the path `for_app` probed:
-/// the image itself on Linux, the bundle behind the executable on macOS.
-/// Both installs here are reached through a link the resolver follows, and
-/// only the file behind it is writable — approval and replacement have to
-/// meet there or not at all.
+/// What `judged_path` hands over, per platform. The resolving is pinned by
+/// the two link tests above; what is new here is the accessor, and on macOS
+/// that the value stays the executable rather than the bundle around it.
+/// `for_app` reaches the directory it approves by the same `bundle_root`
+/// asserted here, so the two meet at one unit. That the updater plugin then
+/// derives that same unit is a dependency of this design, not something
+/// this test establishes: the app crate pins it against the plugin itself.
 #[test]
-fn what_the_updater_replaces_is_what_the_link_resolves_to() {
-    let link = "/home/pat/.local/share/kendex/kendex.AppImage";
+fn judged_path_hands_over_the_file_for_app_approved() {
     let image = "/home/pat/Apps/kendex-5.0.1.AppImage";
-    let probe = Fake::default().links(link, image).replaceable(image);
-    let install = AppInstall::from_appimage_env(
-        &probe,
-        Some(OsStr::new(link)),
-        Some(OsStr::new("/tmp/.mount_kendexAbc")),
-        Some(Path::new("/tmp/.mount_kendexAbc/usr/bin/kendex-app")),
-    );
-    assert_eq!(for_app(&install, &probe), InstallChannel::Direct);
-    // Linux takes the handed path as the file to replace, unchanged.
-    assert_eq!(install.judged_path(), Some(Path::new(image)));
+    assert_eq!(app_image(image).judged_path(), Some(Path::new(image)));
 
-    let linked = "/Applications/kendex.app/Contents/MacOS/kendex";
-    let caskroom = "/Users/pat/Library/Caskroom/kendex/5.0.1/kendex.app/Contents/MacOS/kendex";
+    let exe = "/Users/pat/Library/Caskroom/kendex/5.0.1/kendex.app/Contents/MacOS/kendex";
     let bundle = "/Users/pat/Library/Caskroom/kendex/5.0.1/kendex.app";
-    let probe = Fake::default().links(linked, caskroom).replaceable(bundle);
-    let install = AppInstall::mac_bundle(&probe, Path::new(linked));
-    assert_eq!(for_app(&install, &probe), InstallChannel::Direct);
-    // macOS takes the bundle around the handed executable, the same way
-    // `for_app` did to reach the directory it just approved.
-    assert_eq!(install.judged_path(), Some(Path::new(caskroom)));
+    let install = AppInstall::MacBundle(PathBuf::from(exe));
+    assert_eq!(install.judged_path(), Some(Path::new(exe)));
     assert_eq!(
         install.judged_path().and_then(bundle_root),
         Some(Path::new(bundle))
     );
+
+    // Neither carries a path, and neither may start: an updater handed
+    // nothing keeps its own fallback, which is the whole of the Windows
+    // channel and is all a Linux launch outside an AppImage can offer.
+    assert_eq!(AppInstall::WindowsInstaller.judged_path(), None);
+    assert_eq!(AppInstall::AppImage(None).judged_path(), None);
 }


### PR DESCRIPTION
`app_update_install` authorized a resolved path and then let the updater plugin build its own from the launch environment. Where those differ, kendex approves one file and the plugin acts on another.

`AppInstall` already carries the resolved path `for_app` judged. It now hands that path out, and the command builds the updater with it instead of taking the plugin's default, so the path that decides and the path that acts are one file.

This is the third review round on one root cause, so it is fixed at the seam rather than patched again: round one canonicalized inside `for_cli`, round two moved every resolve to its shell's boundary, and this closes the split where it actually lives — between kendex's decision and the plugin's action.

## The control

`crates/app/src/app_update.rs` asks the plugin rather than imitating it: it calls `tauri_plugin_updater::extract_path_from_executable` on `judged_path()` and asserts what the plugin derives never escapes what `for_app` approved. That assertion runs on every platform; the exact macOS equality is gated to the macOS lane.

Getting this wrong is not a failed update. The derived path is what the macOS installer removes before moving the new bundle in, escalating a permission error to a privileged shell delete. Handing over the bundle instead of the executable inside it makes the plugin climb one level further, to the directory holding every other app on the machine. Five must-fail controls were run red once and reverted, including that one.

## Deliberately not here

A macOS Homebrew cask install cannot run this button at all, and that is filed as KEN-753. `UpdaterBuilder::build` evaluates `current_exe()?` as an eager `unwrap_or` argument, and tauri refuses a macOS launch path with a symlinked ancestor, so it fails before reading any override. It fails the same way on `main` — this change neither introduces nor arms it — and every remedy is a product decision this issue does not carry.

No CHANGELOG entry: the Update action is still under `[Unreleased]`, so the consumer line already there stays true and no released behavior needs correcting.

Closes KEN-721
