### PR TITLE
fix(KEN-624): a changelog entry is a file, not a shared line

### DIFF
--- a/.agents/skills/app-deploy/SKILL.md
+++ b/.agents/skills/app-deploy/SKILL.md
@@ -9,9 +9,12 @@ summary: "Releases a kendex version: bumps versions, finalizes the changelog, ta
 1. Bump the workspace `version` in `Cargo.toml` and the version in
    `crates/app/tauri.conf.json` — both must equal the tag minus the `v`,
    or the update feed no-ops or loops.
-2. In `CHANGELOG.md`, move the `Unreleased` entries under a new
+2. Run `tools/changelog-collate` to fold the `changelog.d` fragments into
+   `CHANGELOG.md`'s `Unreleased`, then move those entries under a new
    `## [<version>] - <date>` heading; confirm every breaking change
-   carries its **Breaking** call-out and migration note.
+   carries its **Breaking** call-out and migration note. Run `tools/guard`
+   and the commit under `CHANGELOG_COLLATE=1`, which releases the rule that
+   refuses `Unreleased` lines no fragment produced.
 3. Commit, tag `v<version>`, push the tag. CI builds each target and
    publishes a draft GitHub Release with CLI binaries, app bundles, and
    `feed.json` (details: `docs/RELEASING.md`).

--- a/.agents/skills/app-deploy/SKILL.md
+++ b/.agents/skills/app-deploy/SKILL.md
@@ -10,11 +10,11 @@ summary: "Releases a kendex version: bumps versions, finalizes the changelog, ta
    `crates/app/tauri.conf.json` — both must equal the tag minus the `v`,
    or the update feed no-ops or loops.
 2. Run `tools/changelog-collate` to fold the `changelog.d` fragments into
-   `CHANGELOG.md`'s `Unreleased`, then move those entries under a new
-   `## [<version>] - <date>` heading; confirm every breaking change
-   carries its **Breaking** call-out and migration note. Run `tools/guard`
-   and the commit under `CHANGELOG_COLLATE=1`, which releases the rule that
-   refuses `Unreleased` lines no fragment produced.
+   `CHANGELOG.md`'s `Unreleased`. A nonzero exit halts the release: read its
+   message, fix the fragment or `CHANGELOG.md`, run it again. Then move those
+   entries under a new `## [<version>] - <date>` heading, leaving an empty
+   `## [Unreleased]` above it; confirm every breaking change carries its
+   **Breaking** call-out and migration note.
 3. Commit, tag `v<version>`, push the tag. CI builds each target and
    publishes a draft GitHub Release with CLI binaries, app bundles, and
    `feed.json` (details: `docs/RELEASING.md`).

--- a/.pi/prompts/gh-release.md
+++ b/.pi/prompts/gh-release.md
@@ -24,10 +24,10 @@ Added entry; major only when asked).
 2. `git log --oneline <last-tag>..HEAD` — confirm there is something to
    ship; finalize `CHANGELOG.md`: run `tools/changelog-collate` to fold the
    `changelog.d` fragments into `## [Unreleased]`, rename that heading to
-   `## [X.Y.Z] - YYYY-MM-DD`, and open a fresh empty `## [Unreleased]`.
-3. Bump the three version sites; `cargo build -q`; `tools/guard`. Both the
-   guard run and the commit go under `CHANGELOG_COLLATE=1`, which releases
-   the rule that refuses `Unreleased` lines no fragment produced.
+   `## [X.Y.Z] - YYYY-MM-DD`, and open a fresh empty `## [Unreleased]`. A
+   nonzero exit from the collator halts the release: read its message, fix
+   the fragment or `CHANGELOG.md`, run it again.
+3. Bump the three version sites; `cargo build -q`; `tools/guard`.
 4. Commit `chore(release): vX.Y.Z` with exactly `Cargo.toml Cargo.lock
    crates/app/tauri.conf.json CHANGELOG.md changelog.d`; push through the
    normal PR flow if branch protection requires it, else push `main`.

--- a/.pi/prompts/gh-release.md
+++ b/.pi/prompts/gh-release.md
@@ -3,7 +3,8 @@ description: Cut a kendex release — version bump, tag, draft review — per do
 argument-hint: "[patch|minor|major]"
 ---
 Cut a kendex release. Optional bump: `$ARGUMENTS` (default: patch; minor when
-CHANGELOG's Unreleased section has an Added entry; major only when asked).
+`changelog.d/added/` holds a fragment or CHANGELOG's Unreleased section has an
+Added entry; major only when asked).
 
 `docs/RELEASING.md` is the procedure; this prompt only sequences it.
 
@@ -21,12 +22,15 @@ CHANGELOG's Unreleased section has an Added entry; major only when asked).
 1. `git fetch origin && git status --short` — must be clean and at
    `origin/main`. `gh release list --limit 1` — the last tag.
 2. `git log --oneline <last-tag>..HEAD` — confirm there is something to
-   ship; finalize `CHANGELOG.md`: rename `## [Unreleased]` to
-   `## [X.Y.Z] - YYYY-MM-DD` and open a fresh empty `## [Unreleased]`.
-3. Bump the three version sites; `cargo build -q`; `tools/guard`.
+   ship; finalize `CHANGELOG.md`: run `tools/changelog-collate` to fold the
+   `changelog.d` fragments into `## [Unreleased]`, rename that heading to
+   `## [X.Y.Z] - YYYY-MM-DD`, and open a fresh empty `## [Unreleased]`.
+3. Bump the three version sites; `cargo build -q`; `tools/guard`. Both the
+   guard run and the commit go under `CHANGELOG_COLLATE=1`, which releases
+   the rule that refuses `Unreleased` lines no fragment produced.
 4. Commit `chore(release): vX.Y.Z` with exactly `Cargo.toml Cargo.lock
-   crates/app/tauri.conf.json CHANGELOG.md`; push through the normal PR
-   flow if branch protection requires it, else push `main`.
+   crates/app/tauri.conf.json CHANGELOG.md changelog.d`; push through the
+   normal PR flow if branch protection requires it, else push `main`.
 5. Tag the MERGED commit, never the local branch: after the bump is on
    `origin/main`, run `git fetch origin`, confirm `git log -1 origin/main`
    is the bump commit, then `git tag vX.Y.Z origin/main && git push

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,6 +9,7 @@ Repo-specific rules:
 - `crates/core` is pure domain logic — no Tauri, no IPC, no UI concerns.
 - `ui/` renders state and invokes commands; domain logic and types live in Rust, and TS bindings are generated, never hand-written.
 - The CHANGELOG is for consumers (Keep a Changelog): document app, CLI, and package changes; keep engine-internal and maintainer-only details out. An entry is 1–3 lines — the outcome, a **Breaking:** migration inline, `— thanks @name` for outside contributors — never an essay.
+- An entry is a file, never a `CHANGELOG.md` line: write `changelog.d/<section>/<name>.md` holding the list item it becomes, per `changelog.d/README.md`. `tools/changelog-collate` folds them in at release.
 
 `tools/guard` enforces the rest — read the script; it is the list. It is the last lane of the package's commit chain, named by `GROWTH_GUARDS_PRE_COMMIT_LOCAL`; `tools/setup` arms that chain in a fresh clone.
 

--- a/changelog.d/README.md
+++ b/changelog.d/README.md
@@ -7,10 +7,10 @@ One CHANGELOG entry per file. Two branches never write the same
   The section is one of `added`, `changed`, `deprecated`, `removed`, `fixed`,
   `security`. Name the file after the issue: `changelog.d/fixed/<issue>.md`.
 - **Content**: exactly one Markdown list item — the first non-blank line opens
-  with `- `, every later line indents under it, and the whole entry runs at
-  most three lines. Everything `AGENTS.md` says about a CHANGELOG entry holds:
-  it is for consumers, it states an outcome, a **Breaking:** change carries
-  its migration note inline.
+  with `- ` and says something, every later line indents under it, and the
+  whole entry runs at most three lines. Everything `AGENTS.md` says about a
+  CHANGELOG entry holds: it is for consumers, it states an outcome, and a
+  **Breaking:** change carries its migration note inline.
 - **Release**: `tools/changelog-collate` folds every fragment git carries into
   `## [Unreleased]` in `CHANGELOG.md` under its section heading, in Keep a
   Changelog order and filename order within a section, then deletes the

--- a/changelog.d/README.md
+++ b/changelog.d/README.md
@@ -5,7 +5,7 @@ One CHANGELOG entry per file. Two branches never write the same
 
 - **Path**: `changelog.d/<section>/<name>.md`, a real file and not a symlink.
   The section is one of `added`, `changed`, `deprecated`, `removed`, `fixed`,
-  `security`. Name the file after the issue: `changelog.d/fixed/ken-624.md`.
+  `security`. Name the file after the issue: `changelog.d/fixed/<issue>.md`.
 - **Content**: exactly one Markdown list item — the first non-blank line opens
   with `- `, every later line indents under it, and the whole entry runs at
   most three lines. Everything `AGENTS.md` says about a CHANGELOG entry holds:
@@ -14,12 +14,14 @@ One CHANGELOG entry per file. Two branches never write the same
 - **Release**: `tools/changelog-collate` folds every fragment git carries into
   `## [Unreleased]` in `CHANGELOG.md` under its section heading, in Keep a
   Changelog order and filename order within a section, then deletes the
-  fragments. Repeated headings for one section merge into the first.
+  fragments. Two headings for one section collapse into a single heading,
+  emitted in Keep a Changelog order and carrying their blocks in file order.
 
 `tools/changelog-collate --check` judges the fragments and writes nothing;
 `tools/guard` runs it, so the format has one judge. Exit codes follow the
 guard family: 0 clean, 1 a fragment the format refuses, 2 could not run.
 
-`tools/guard` also refuses a hand-written line under `## [Unreleased]`.
-`CHANGELOG_COLLATE=1` releases that rule for the release commit that carries
-the collator's write.
+`tools/guard` refuses any line under `## [Unreleased]` that HEAD does not
+already carry. `CHANGELOG_COLLATE=1` declares a deliberate write there,
+needed only when the guard or the commit runs while collated entries are
+still under that heading.

--- a/changelog.d/README.md
+++ b/changelog.d/README.md
@@ -3,18 +3,23 @@
 One CHANGELOG entry per file. Two branches never write the same
 `CHANGELOG.md` line, so neither is ejected from the merge queue by the other.
 
-- **Path**: `changelog.d/<section>/<name>.md`. The section is one of `added`,
-  `changed`, `deprecated`, `removed`, `fixed`, `security`. Name the file after
-  the issue: `changelog.d/fixed/ken-624.md`.
-- **Content**: the Markdown list item the entry becomes — a leading `- `,
-  continuation lines indented, at most three lines. Everything `AGENTS.md`
-  says about a CHANGELOG entry holds: it is for consumers, it states an
-  outcome, a **Breaking:** change carries its migration note inline.
-- **Release**: `tools/changelog-collate` folds every fragment into
+- **Path**: `changelog.d/<section>/<name>.md`, a real file and not a symlink.
+  The section is one of `added`, `changed`, `deprecated`, `removed`, `fixed`,
+  `security`. Name the file after the issue: `changelog.d/fixed/ken-624.md`.
+- **Content**: exactly one Markdown list item — the first non-blank line opens
+  with `- `, every later line indents under it, and the whole entry runs at
+  most three lines. Everything `AGENTS.md` says about a CHANGELOG entry holds:
+  it is for consumers, it states an outcome, a **Breaking:** change carries
+  its migration note inline.
+- **Release**: `tools/changelog-collate` folds every fragment git carries into
   `## [Unreleased]` in `CHANGELOG.md` under its section heading, in Keep a
   Changelog order and filename order within a section, then deletes the
   fragments. Repeated headings for one section merge into the first.
 
-`tools/guard` refuses a hand-written line under `## [Unreleased]`.
+`tools/changelog-collate --check` judges the fragments and writes nothing;
+`tools/guard` runs it, so the format has one judge. Exit codes follow the
+guard family: 0 clean, 1 a fragment the format refuses, 2 could not run.
+
+`tools/guard` also refuses a hand-written line under `## [Unreleased]`.
 `CHANGELOG_COLLATE=1` releases that rule for the release commit that carries
 the collator's write.

--- a/changelog.d/README.md
+++ b/changelog.d/README.md
@@ -1,0 +1,20 @@
+# changelog.d
+
+One CHANGELOG entry per file. Two branches never write the same
+`CHANGELOG.md` line, so neither is ejected from the merge queue by the other.
+
+- **Path**: `changelog.d/<section>/<name>.md`. The section is one of `added`,
+  `changed`, `deprecated`, `removed`, `fixed`, `security`. Name the file after
+  the issue: `changelog.d/fixed/ken-624.md`.
+- **Content**: the Markdown list item the entry becomes — a leading `- `,
+  continuation lines indented, at most three lines. Everything `AGENTS.md`
+  says about a CHANGELOG entry holds: it is for consumers, it states an
+  outcome, a **Breaking:** change carries its migration note inline.
+- **Release**: `tools/changelog-collate` folds every fragment into
+  `## [Unreleased]` in `CHANGELOG.md` under its section heading, in Keep a
+  Changelog order and filename order within a section, then deletes the
+  fragments. Repeated headings for one section merge into the first.
+
+`tools/guard` refuses a hand-written line under `## [Unreleased]`.
+`CHANGELOG_COLLATE=1` releases that rule for the release commit that carries
+the collator's write.

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -70,9 +70,11 @@ carries into `## [Unreleased]` under its section heading, in Keep a Changelog
 order and filename order within a section, then deletes the fragments; no
 fragments is a no-op. Exit codes follow the guard family: 0 clean, 1 a
 fragment the format refuses, 2 could not run — and nothing is written until
-every fragment passes, so `CHANGELOG.md` is replaced whole or not at all. A
-nonzero exit halts the release: read the message, fix the fragment or
-`CHANGELOG.md`, run it again. Then rename `## [Unreleased]` to
+every fragment passes, so `CHANGELOG.md` is replaced whole or not at all. It
+reads each fragment from the working tree, so it also refuses a `changelog.d`
+the index and the disk disagree about, rather than publishing an unstaged
+edit and deleting it. A nonzero exit halts the release: read the message, fix
+the fragment or `CHANGELOG.md`, run it again. Then rename `## [Unreleased]` to
 `## [X.Y.Z] - YYYY-MM-DD` and open a fresh empty one, which leaves the guard
 nothing gained to refuse.
 

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -70,11 +70,15 @@ carries into `## [Unreleased]` under its section heading, in Keep a Changelog
 order and filename order within a section, then deletes the fragments; no
 fragments is a no-op. Exit codes follow the guard family: 0 clean, 1 a
 fragment the format refuses, 2 could not run — and nothing is written until
-every fragment passes, so `CHANGELOG.md` is replaced whole or not at all.
-Rename
-`## [Unreleased]` to `## [X.Y.Z] - YYYY-MM-DD`, open a fresh empty one, and
-run the guard and the release commit under `CHANGELOG_COLLATE=1` — the flag
-releases the `[Unreleased]` rule for the collator's write.
+every fragment passes, so `CHANGELOG.md` is replaced whole or not at all. A
+nonzero exit halts the release: read the message, fix the fragment or
+`CHANGELOG.md`, run it again. Then rename `## [Unreleased]` to
+`## [X.Y.Z] - YYYY-MM-DD` and open a fresh empty one, which leaves the guard
+nothing gained to refuse.
+
+`CHANGELOG_COLLATE=1` declares a deliberate write under `## [Unreleased]`.
+It is needed only when the guard or the commit runs while the collated
+entries are still under that heading.
 
 ## Version bumps
 

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -58,6 +58,21 @@ deb/rpm anywhere; the AppImage step needs FUSE2 for linuxdeploy and may
 fail on non-Debian hosts — the release runner covers it. Bundling signs
 updater artifacts, so set `TAURI_SIGNING_PRIVATE_KEY` or pass `--no-sign`.
 
+## Changelog
+
+Entries are written one file at a time, under
+`changelog.d/<section>/<name>.md` (`changelog.d/README.md` has the format).
+Nothing edits `CHANGELOG.md` by hand: `tools/guard` refuses a line under
+`## [Unreleased]` that HEAD does not already carry.
+
+Before tagging, run `tools/changelog-collate`. It folds every fragment into
+`## [Unreleased]` under its section heading, in Keep a Changelog order and
+filename order within a section, then deletes the fragments; no fragments is
+a no-op, and it replaces `CHANGELOG.md` whole or not at all (exit 2). Rename
+`## [Unreleased]` to `## [X.Y.Z] - YYYY-MM-DD`, open a fresh empty one, and
+run the guard and the release commit under `CHANGELOG_COLLATE=1` — the flag
+releases the `[Unreleased]` rule for the collator's write.
+
 ## Version bumps
 
 The workspace version in `Cargo.toml` and `crates/app/tauri.conf.json`

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -65,10 +65,13 @@ Entries are written one file at a time, under
 Nothing edits `CHANGELOG.md` by hand: `tools/guard` refuses a line under
 `## [Unreleased]` that HEAD does not already carry.
 
-Before tagging, run `tools/changelog-collate`. It folds every fragment into
-`## [Unreleased]` under its section heading, in Keep a Changelog order and
-filename order within a section, then deletes the fragments; no fragments is
-a no-op, and it replaces `CHANGELOG.md` whole or not at all (exit 2). Rename
+Before tagging, run `tools/changelog-collate`. It folds every fragment git
+carries into `## [Unreleased]` under its section heading, in Keep a Changelog
+order and filename order within a section, then deletes the fragments; no
+fragments is a no-op. Exit codes follow the guard family: 0 clean, 1 a
+fragment the format refuses, 2 could not run — and nothing is written until
+every fragment passes, so `CHANGELOG.md` is replaced whole or not at all.
+Rename
 `## [Unreleased]` to `## [X.Y.Z] - YYYY-MM-DD`, open a fresh empty one, and
 run the guard and the release commit under `CHANGELOG_COLLATE=1` — the flag
 releases the `[Unreleased]` rule for the collator's write.

--- a/tools/changelog-collate
+++ b/tools/changelog-collate
@@ -8,9 +8,10 @@
 # at commit time, so the fragment format has one judge rather than two
 # spellings that can drift.
 #
-# The fragments are the ones git carries under changelog.d, not the files on
-# disk: guard judges the same set, and an untracked stray nobody wrote cannot
-# stop a release.
+# The fragments are the ones git carries under changelog.d, not whatever is
+# on disk: guard judges the same set, and an untracked stray nobody wrote
+# cannot stop a release. Their content is read from the working tree, so a
+# changelog.d the index and the disk disagree about stops the write.
 #
 # Exit codes follow the guard family: 0 clean, 1 a fragment the format
 # refuses, 2 could not run. CHANGELOG.md is replaced whole or not at all.
@@ -61,6 +62,7 @@ trap cleanup EXIT
 # be a second entry, or would end the [Unreleased] section it is folded into.
 fragment_shape() { # FILE — the complaint, empty when the file is one entry
   awk '
+    BEGIN { empty = "has no entry in it — a fragment is the Markdown list item it becomes" }
     { sub(/\r$/, "") }
     /^[[:space:]]*$/ { next }
     !seen {
@@ -69,13 +71,19 @@ fragment_shape() { # FILE — the complaint, empty when the file is one entry
         print "does not open with a list marker — a fragment is the Markdown list item it becomes, opening with a hyphen and a space"
         exit
       }
+      # A marker with nothing after it is an entry that says nothing, which
+      # is the same defect as a file with no marker at all.
+      if ($0 !~ /^- [[:space:]]*[^[:space:]]/) {
+        print empty
+        exit
+      }
       next
     }
     !/^[ \t]/ {
       print "holds more than the one entry it becomes — every line after the first indents under it"
       exit
     }
-    END { if (!seen) print "has no entry in it — a fragment is the Markdown list item it becomes" }
+    END { if (!seen) print empty }
   ' "$1"
 }
 
@@ -125,6 +133,18 @@ done <"$TMP/index"
 # or it has not begun.
 [ "$refused" -eq 0 ] || exit 1
 if [ "$CHECK" -eq 1 ]; then exit 0; fi
+
+# Past here the run reads the working-tree file at each path git named, folds
+# it in and deletes it. An unstaged edit would be published and then erased
+# with nothing left carrying it, so a changelog.d that git and the disk
+# disagree about stops the run. --check never reaches this: it writes and
+# deletes nothing, and guard runs it over the tree about to be committed.
+dirty="$(git diff --name-only -- changelog.d)" ||
+  die "could not compare changelog.d against the index — the collation could not run"
+if [ -n "$dirty" ]; then
+  die "changelog.d differs between git and the working tree; the collation folds in the file on disk and then deletes it — stage or restore these first:
+$(printf '%s\n' "$dirty" | sed 's/^/  /')"
+fi
 
 LC_ALL=C sort -o "$TMP/frags" "$TMP/frags" || die "could not order the fragment list — the collation could not run"
 count=$(wc -l <"$TMP/frags") || die "could not count the fragments — the collation could not run"

--- a/tools/changelog-collate
+++ b/tools/changelog-collate
@@ -120,7 +120,14 @@ while IFS= read -r -d '' rec; do
       continue
       ;;
   esac
-  [ -f "$path" ] || die "$path is in the index but not a file on disk — the collation could not run"
+  # A path the index carries and the disk does not is a deletion, staged or
+  # about to be — including the one a successful collation just made. There
+  # is no body to judge, so check mode passes over it; the writing mode needs
+  # the file it is about to fold in.
+  if [ ! -f "$path" ]; then
+    if [ "$CHECK" -eq 1 ]; then continue; fi
+    die "$path is in the index but not a file on disk — the collation could not run"
+  fi
   shape="$(fragment_shape "$path")" || die "could not read $path — the collation could not run"
   if [ -n "$shape" ]; then
     refuse "$path $shape"

--- a/tools/changelog-collate
+++ b/tools/changelog-collate
@@ -4,26 +4,48 @@
 # same CHANGELOG line; this is the step that turns the files back into
 # sections, and only the release commit runs it.
 #
-# Exit codes follow the guard family: 0 collated or nothing to collate,
-# 2 could not run. CHANGELOG.md is replaced whole or not at all.
+# --check judges the fragments and writes nothing. tools/guard runs that mode
+# at commit time, so the fragment format has one judge rather than two
+# spellings that can drift.
+#
+# The fragments are the ones git carries under changelog.d, not the files on
+# disk: guard judges the same set, and an untracked stray nobody wrote cannot
+# stop a release.
+#
+# Exit codes follow the guard family: 0 clean, 1 a fragment the format
+# refuses, 2 could not run. CHANGELOG.md is replaced whole or not at all.
 set -euo pipefail
 
 # The Keep a Changelog sections, in the order they are emitted. The directory
 # name and the heading are both written out: nothing here case-converts.
 SECTIONS="added:Added changed:Changed deprecated:Deprecated removed:Removed fixed:Fixed security:Security"
+KNOWN=" added changed deprecated removed fixed security "
 
-die() {
+CHECK=0
+if [ "${1:-}" = --check ]; then
+  CHECK=1
+  shift
+fi
+if [ $# -ne 0 ]; then
+  echo "changelog-collate: usage: changelog-collate [--check]" >&2
+  exit 2
+fi
+
+die() { # an environment the run cannot work in
   echo "changelog-collate: $1" >&2
   exit 2
+}
+refused=0
+refuse() { # a fragment the format will not take; every one is reported
+  echo "changelog-collate: $1" >&2
+  refused=1
+}
+note() { # progress, silenced in the mode guard runs
+  if [ "$CHECK" -eq 0 ]; then echo "changelog-collate: $1"; fi
 }
 
 ROOT="$(git rev-parse --show-toplevel)" || die "not inside a git work tree — the collation could not run"
 cd "$ROOT" || die "could not enter $ROOT — the collation could not run"
-
-[ -d changelog.d ] || {
-  echo "changelog-collate: no changelog.d directory — nothing to collate"
-  exit 0
-}
 
 TMP="$(mktemp -d)" || die "could not create a work directory — the collation could not run"
 OUT=""
@@ -34,34 +56,83 @@ cleanup() {
 }
 trap cleanup EXIT
 
-# Every file under changelog.d is a fragment or the README. Anything else
-# would be collated into nothing, so it stops the run rather than vanishing.
-find changelog.d -type f -print >"$TMP/all" || die "could not list changelog.d — the collation could not run"
-LC_ALL=C sort -o "$TMP/all" "$TMP/all" || die "could not order the fragment list — the collation could not run"
+# A fragment is one Markdown list item: it opens with a hyphen and a space,
+# and every later line indents under it. A second marker or a heading would
+# be a second entry, or would end the [Unreleased] section it is folded into.
+fragment_shape() { # FILE — the complaint, empty when the file is one entry
+  awk '
+    { sub(/\r$/, "") }
+    /^[[:space:]]*$/ { next }
+    !seen {
+      seen = 1
+      if ($0 !~ /^- /) {
+        print "does not open with a list marker — a fragment is the Markdown list item it becomes, opening with a hyphen and a space"
+        exit
+      }
+      next
+    }
+    !/^[ \t]/ {
+      print "holds more than the one entry it becomes — every line after the first indents under it"
+      exit
+    }
+    END { if (!seen) print "has no entry in it — a fragment is the Markdown list item it becomes" }
+  ' "$1"
+}
 
+# git's own index entries: mode 100644/100755 for a file, 120000 for a
+# symlink the collator would follow out of the tree.
+git ls-files -s -z -- changelog.d >"$TMP/index" ||
+  die "could not list changelog.d from the index — the collation could not run"
 : >"$TMP/frags"
-while IFS= read -r f; do
-  if [ "$f" = changelog.d/README.md ]; then continue; fi
-  case "$f" in
-    changelog.d/*/*/*) die "$f sits below a section directory — a fragment is changelog.d/<section>/<name>.md" ;;
+while IFS= read -r -d '' rec; do
+  mode=${rec%% *}
+  path=${rec#*$'\t'}
+  if [ "$path" = changelog.d/README.md ]; then continue; fi
+  if [ "$mode" = 120000 ]; then
+    refuse "$path is a symlink — a fragment is a file of its own"
+    continue
+  fi
+  case "$path" in
+    changelog.d/*/*/*)
+      refuse "$path sits below a section directory — a fragment is changelog.d/<section>/<name>.md"
+      continue
+      ;;
     changelog.d/*/*.md) : ;;
-    *) die "$f is not a changelog fragment — a fragment is changelog.d/<section>/<name>.md" ;;
+    *)
+      refuse "$path is not a changelog fragment — a fragment is changelog.d/<section>/<name>.md"
+      continue
+      ;;
   esac
-  rel=${f#changelog.d/}
-  sec=${rel%%/*}
-  case " added changed deprecated removed fixed security " in
+  sec=${path#changelog.d/}
+  sec=${sec%%/*}
+  case "$KNOWN" in
     *" $sec "*) : ;;
-    *) die "$f names no known section — one of: added changed deprecated removed fixed security" ;;
+    *)
+      refuse "$path names no known section — one of:${KNOWN% }"
+      continue
+      ;;
   esac
-  printf '%s\n' "$f" >>"$TMP/frags"
-done <"$TMP/all"
+  [ -f "$path" ] || die "$path is in the index but not a file on disk — the collation could not run"
+  shape="$(fragment_shape "$path")" || die "could not read $path — the collation could not run"
+  if [ -n "$shape" ]; then
+    refuse "$path $shape"
+    continue
+  fi
+  printf '%s\n' "$path" >>"$TMP/frags"
+done <"$TMP/index"
 
+# Nothing is written while a fragment stands refused: the collation is whole
+# or it has not begun.
+[ "$refused" -eq 0 ] || exit 1
+if [ "$CHECK" -eq 1 ]; then exit 0; fi
+
+LC_ALL=C sort -o "$TMP/frags" "$TMP/frags" || die "could not order the fragment list — the collation could not run"
 count=$(wc -l <"$TMP/frags") || die "could not count the fragments — the collation could not run"
 count=$((count))
-[ "$count" -gt 0 ] || {
-  echo "changelog-collate: no fragments — nothing to collate"
+if [ "$count" -eq 0 ]; then
+  note "no fragments — nothing to collate"
   exit 0
-}
+fi
 
 # awk normalizes a fragment that ends without a newline, which would
 # otherwise glue two entries into one line.
@@ -147,33 +218,49 @@ trim() { # FILE — its content, edge blank lines dropped, interior runs capped 
   ' "$1"
 }
 
-OUT="$(mktemp ./CHANGELOG.md.XXXXXX)" || die "could not create the replacement file — the collation could not run"
-cp -p CHANGELOG.md "$OUT" || die "could not take CHANGELOG.md's mode — the collation could not run"
-{
-  cat "$TMP/pre"
-  trim "$TMP/lead"
+# Every part carries its own failure out. The caller runs this as the left
+# operand of ||, where the shell suppresses errexit and would otherwise pass
+# off the last command's status as the whole file's.
+assemble() {
+  cat "$TMP/pre" || return 1
+  trim "$TMP/lead" || return 1
   for pair in $SECTIONS; do
     low=${pair%%:*}
     name=${pair#*:}
-    [ -s "$TMP/sec.$low" ] || [ -s "$TMP/frag.$low" ] || continue
-    printf '\n### %s\n\n' "$name"
-    cat "$TMP/sec.$low"
-    cat "$TMP/frag.$low"
+    if [ -s "$TMP/sec.$low" ] || [ -s "$TMP/frag.$low" ]; then
+      printf '\n### %s\n\n' "$name" || return 1
+      cat "$TMP/sec.$low" || return 1
+      cat "$TMP/frag.$low" || return 1
+    fi
   done
-  if [ -s "$TMP/post" ]; then printf '\n'; fi
-  cat "$TMP/post"
-} >"$OUT" || die "could not write the collated changelog — CHANGELOG.md is untouched"
+  if [ -s "$TMP/post" ]; then
+    printf '\n' || return 1
+  fi
+  cat "$TMP/post" || return 1
+}
+
+OUT="$(mktemp ./CHANGELOG.md.XXXXXX)" || die "could not create the replacement file — the collation could not run"
+cp -p CHANGELOG.md "$OUT" || die "could not take CHANGELOG.md's mode — the collation could not run"
+assemble >"$OUT" || die "could not write the collated changelog — CHANGELOG.md is untouched"
 mv -- "$OUT" CHANGELOG.md || die "could not replace CHANGELOG.md — the collation could not run"
 OUT=""
 
+# Past the move, every fragment is in CHANGELOG.md. Deleting stops for none of
+# them: one left behind folds in a second time on the next run, so the refusal
+# has to name every survivor, not the first.
+survivors=""
 while IFS= read -r f; do
-  rm -f -- "$f" || die "could not delete $f — CHANGELOG.md is collated; remove the fragment by hand"
+  rm -f -- "$f" || survivors="$survivors  $f"$'\n'
 done <"$TMP/frags"
+if [ -n "$survivors" ]; then
+  die "CHANGELOG.md is collated, but these fragments survived and would fold in a second time — delete them by hand:
+${survivors%$'\n'}"
+fi
 # A section directory the collation emptied goes with it. Not-empty and
 # not-found are both ordinary here, and neither leaves anything to act on.
 for pair in $SECTIONS; do
   rmdir "changelog.d/${pair%%:*}" 2>/dev/null || true
 done
 
-if [ "$count" -eq 1 ]; then noun=fragment; else noun=fragments; fi
-echo "changelog-collate: folded $count $noun into CHANGELOG.md's [Unreleased] section"
+if [ "$count" -eq 1 ]; then noun=entry; else noun=entries; fi
+note "folded $count $noun into CHANGELOG.md's [Unreleased] section"

--- a/tools/changelog-collate
+++ b/tools/changelog-collate
@@ -1,0 +1,179 @@
+#!/usr/bin/env bash
+# Folds the changelog.d fragments into CHANGELOG.md's [Unreleased] section
+# and deletes them. One entry is one file, so no two branches ever write the
+# same CHANGELOG line; this is the step that turns the files back into
+# sections, and only the release commit runs it.
+#
+# Exit codes follow the guard family: 0 collated or nothing to collate,
+# 2 could not run. CHANGELOG.md is replaced whole or not at all.
+set -euo pipefail
+
+# The Keep a Changelog sections, in the order they are emitted. The directory
+# name and the heading are both written out: nothing here case-converts.
+SECTIONS="added:Added changed:Changed deprecated:Deprecated removed:Removed fixed:Fixed security:Security"
+
+die() {
+  echo "changelog-collate: $1" >&2
+  exit 2
+}
+
+ROOT="$(git rev-parse --show-toplevel)" || die "not inside a git work tree — the collation could not run"
+cd "$ROOT" || die "could not enter $ROOT — the collation could not run"
+
+[ -d changelog.d ] || {
+  echo "changelog-collate: no changelog.d directory — nothing to collate"
+  exit 0
+}
+
+TMP="$(mktemp -d)" || die "could not create a work directory — the collation could not run"
+OUT=""
+cleanup() {
+  rm -rf "$TMP"
+  if [ -n "$OUT" ]; then rm -f -- "$OUT"; fi
+  return 0
+}
+trap cleanup EXIT
+
+# Every file under changelog.d is a fragment or the README. Anything else
+# would be collated into nothing, so it stops the run rather than vanishing.
+find changelog.d -type f -print >"$TMP/all" || die "could not list changelog.d — the collation could not run"
+LC_ALL=C sort -o "$TMP/all" "$TMP/all" || die "could not order the fragment list — the collation could not run"
+
+: >"$TMP/frags"
+while IFS= read -r f; do
+  if [ "$f" = changelog.d/README.md ]; then continue; fi
+  case "$f" in
+    changelog.d/*/*/*) die "$f sits below a section directory — a fragment is changelog.d/<section>/<name>.md" ;;
+    changelog.d/*/*.md) : ;;
+    *) die "$f is not a changelog fragment — a fragment is changelog.d/<section>/<name>.md" ;;
+  esac
+  rel=${f#changelog.d/}
+  sec=${rel%%/*}
+  case " added changed deprecated removed fixed security " in
+    *" $sec "*) : ;;
+    *) die "$f names no known section — one of: added changed deprecated removed fixed security" ;;
+  esac
+  printf '%s\n' "$f" >>"$TMP/frags"
+done <"$TMP/all"
+
+count=$(wc -l <"$TMP/frags") || die "could not count the fragments — the collation could not run"
+count=$((count))
+[ "$count" -gt 0 ] || {
+  echo "changelog-collate: no fragments — nothing to collate"
+  exit 0
+}
+
+# awk normalizes a fragment that ends without a newline, which would
+# otherwise glue two entries into one line.
+for pair in $SECTIONS; do
+  low=${pair%%:*}
+  : >"$TMP/frag.$low"
+  : >"$TMP/sec.$low"
+  # grep exit 1 is "this section has no fragments"; anything higher is an
+  # unreadable list, which is a refusal, not an empty section.
+  gs=0
+  grep -E "^changelog\.d/$low/" "$TMP/frags" >"$TMP/sel" || gs=$?
+  [ "$gs" -le 1 ] || die "could not select the $low fragments — the collation could not run"
+  while IFS= read -r f; do
+    awk 1 "$f" >>"$TMP/frag.$low" || die "could not read $f — the collation could not run"
+  done <"$TMP/sel"
+done
+
+[ -f CHANGELOG.md ] || die "CHANGELOG.md is missing — the collation could not run"
+: >"$TMP/pre"
+: >"$TMP/lead"
+: >"$TMP/post"
+
+# Split CHANGELOG.md into the part above [Unreleased], that section's lead
+# and per-section bodies, and the released versions below it. A body keeps one
+# blank line between its entries and none at its edges, so a section the file
+# spells under two headings comes out as one list.
+rc=0
+awk -v tmp="$TMP" -v known="added changed deprecated removed fixed security" '
+  BEGIN {
+    n = split(known, k, " ")
+    for (i = 1; i <= n; i++) is[k[i]] = 1
+    out = tmp "/pre"
+    state = 0
+  }
+  state == 0 && /^## \[Unreleased\]/ { print > out; state = 1; out = tmp "/lead"; insec = 0; next }
+  state == 1 && /^## / { state = 2; out = tmp "/post"; insec = 0 }
+  state == 1 && /^###[[:space:]]/ {
+    sec = $0
+    sub(/^###[[:space:]]+/, "", sec)
+    sub(/[[:space:]]+$/, "", sec)
+    low = tolower(sec)
+    if (!(low in is)) {
+      print sec > "/dev/stderr"
+      exit 3
+    }
+    out = tmp "/sec." low
+    insec = 1
+    started = 0
+    held = 0
+    next
+  }
+  insec {
+    if ($0 ~ /[^[:space:]]/) {
+      if (held) print "" > out
+      held = 0
+      print > out
+      started = 1
+    } else if (started) {
+      held = 1
+    }
+    next
+  }
+  { print > out }
+  END { if (state == 0) exit 4 }
+' CHANGELOG.md 2>"$TMP/err" || rc=$?
+case "$rc" in
+  0) : ;;
+  3) die "CHANGELOG.md names '$(cat "$TMP/err")' under [Unreleased], which is not a Keep a Changelog section — the collation could not run" ;;
+  4) die "CHANGELOG.md has no '## [Unreleased]' heading — the collation could not run" ;;
+  *) die "CHANGELOG.md could not be read — the collation could not run" ;;
+esac
+
+trim() { # FILE — its content, edge blank lines dropped, interior runs capped at one
+  awk '
+    /[^[:space:]]/ {
+      if (held) print ""
+      held = 0
+      print
+      started = 1
+      next
+    }
+    started { held = 1 }
+  ' "$1"
+}
+
+OUT="$(mktemp ./CHANGELOG.md.XXXXXX)" || die "could not create the replacement file — the collation could not run"
+cp -p CHANGELOG.md "$OUT" || die "could not take CHANGELOG.md's mode — the collation could not run"
+{
+  cat "$TMP/pre"
+  trim "$TMP/lead"
+  for pair in $SECTIONS; do
+    low=${pair%%:*}
+    name=${pair#*:}
+    [ -s "$TMP/sec.$low" ] || [ -s "$TMP/frag.$low" ] || continue
+    printf '\n### %s\n\n' "$name"
+    cat "$TMP/sec.$low"
+    cat "$TMP/frag.$low"
+  done
+  if [ -s "$TMP/post" ]; then printf '\n'; fi
+  cat "$TMP/post"
+} >"$OUT" || die "could not write the collated changelog — CHANGELOG.md is untouched"
+mv -- "$OUT" CHANGELOG.md || die "could not replace CHANGELOG.md — the collation could not run"
+OUT=""
+
+while IFS= read -r f; do
+  rm -f -- "$f" || die "could not delete $f — CHANGELOG.md is collated; remove the fragment by hand"
+done <"$TMP/frags"
+# A section directory the collation emptied goes with it. Not-empty and
+# not-found are both ordinary here, and neither leaves anything to act on.
+for pair in $SECTIONS; do
+  rmdir "changelog.d/${pair%%:*}" 2>/dev/null || true
+done
+
+if [ "$count" -eq 1 ]; then noun=fragment; else noun=fragments; fi
+echo "changelog-collate: folded $count $noun into CHANGELOG.md's [Unreleased] section"

--- a/tools/commit-msg
+++ b/tools/commit-msg
@@ -64,12 +64,13 @@ gg_git_generated_header "$subject" ||
   [ "${#subject}" -le 72 ] ||
   say "subject is ${#subject} characters (max 72) — move the detail into the body"
 
-# Code changes ship with a changelog entry; [no-changelog] is the escape
-# hatch for pure refactors.
+# Code changes ship with a changelog entry: a changelog.d fragment, or
+# CHANGELOG.md itself on the release commit that collates them.
+# [no-changelog] is the escape hatch for pure refactors.
 if echo "$staged" | grep -qE '^(crates|ui)/' &&
-  ! echo "$staged" | grep -qx 'CHANGELOG.md' &&
+  ! echo "$staged" | grep -qE '^(CHANGELOG\.md$|changelog\.d/[^/]+/[^/]+\.md$)' &&
   ! printf '%s' "$subject" | grep -qF '[no-changelog]'; then
-  say "crates/ or ui/ changed without a CHANGELOG.md entry — add one or put [no-changelog] in the subject"
+  say "crates/ or ui/ changed without a changelog entry — add changelog.d/<section>/<name>.md or put [no-changelog] in the subject"
 fi
 
 exit $fail

--- a/tools/commit-msg
+++ b/tools/commit-msg
@@ -48,6 +48,13 @@ staged=$(git diff --cached --name-only) || {
   echo "commit-msg: could not read the staged file list — the changelog rule could not run"
   exit 2
 }
+# Deleting a fragment is not writing one, and the staged list does not say
+# which it was. Evidence of an entry comes from the additions and
+# modifications alone.
+written=$(git diff --cached --name-only --diff-filter=AM) || {
+  echo "commit-msg: could not read the staged additions — the changelog rule could not run"
+  exit 2
+}
 gg_commit_header "$MSG"
 subject="$GG_COMMIT_HEADER"
 
@@ -66,9 +73,12 @@ gg_git_generated_header "$subject" ||
 
 # Code changes ship with a changelog entry: a changelog.d fragment, or
 # CHANGELOG.md itself on the release commit that collates them.
-# [no-changelog] is the escape hatch for pure refactors.
+# [no-changelog] is the escape hatch for pure refactors. Which section names
+# are real and what a fragment must contain are tools/guard's judgment, run
+# in the same commit chain; a path inside some section directory is all this
+# lane needs to see.
 if echo "$staged" | grep -qE '^(crates|ui)/' &&
-  ! echo "$staged" | grep -qE '^(CHANGELOG\.md$|changelog\.d/[^/]+/[^/]+\.md$)' &&
+  ! echo "$written" | grep -qE '^(CHANGELOG\.md|changelog\.d/[^/]+/[^/]+\.md)$' &&
   ! printf '%s' "$subject" | grep -qF '[no-changelog]'; then
   say "crates/ or ui/ changed without a changelog entry — add changelog.d/<section>/<name>.md or put [no-changelog] in the subject"
 fi

--- a/tools/guard
+++ b/tools/guard
@@ -57,11 +57,12 @@ $(printf '%s\n' "$hits" | head -5 | sed 's/^/  /')"
 done <<<"$prose_files"
 
 # CHANGELOG entries are for consumers: one outcome each, one to three
-# source lines, a Breaking migration inline. Longer is an essay.
-if [ -f CHANGELOG.md ]; then
-  # An entry is every line from its list marker to the next marker, heading,
-  # or blank-then-unindented paragraph, whatever the indentation.
-  if long_entries=$(awk '
+# source lines, a Breaking migration inline. Longer is an essay. A
+# changelog.d fragment is one such entry, so the same rule judges it.
+# An entry is every line from its list marker to the next marker, heading,
+# or blank-then-unindented paragraph, whatever the indentation.
+long_entries() { # FILE — "  line N: M lines" per entry past three
+  awk '
     function flush() { if (n > 3) printf "  line %d: %d lines\n", start, n; n = 0; blank = 0 }
     { sub(/\r$/, "") }
     /^[-*+] / { flush(); n = 1; start = NR; next }
@@ -69,11 +70,51 @@ if [ -f CHANGELOG.md ]; then
     /^[ \t]*$/ { if (n) blank++; next }
     /^[ \t]/ || !blank { if (n) { n += blank + 1; blank = 0 }; next }
     { flush() }
-    END { flush() }' CHANGELOG.md 2>/dev/null); then
-    [ -n "$long_entries" ] && say "CHANGELOG.md entries run past three lines — state the outcome, keep the story out:
-$long_entries"
+    END { flush() }' "$1" 2>/dev/null
+}
+while IFS= read -r f; do
+  [ -f "$f" ] || continue
+  if long=$(long_entries "$f"); then
+    [ -n "$long" ] && say "$f entries run past three lines — state the outcome, keep the story out:
+$long"
   else
-    say "CHANGELOG.md is unreadable — the entry-length check could not run"
+    say "$f is unreadable — the entry-length check could not run"
+  fi
+done < <({ echo CHANGELOG.md; printf '%s\n' "$files" | grep -E '^changelog\.d/[^/]+/[^/]+\.md$'; })
+
+# An entry is a file: changelog.d/<section>/<name>.md holding the Markdown
+# list item it becomes. The collator looks nowhere else, so a fragment filed
+# anywhere else is an entry that ships nothing.
+while IFS= read -r f; do
+  [ -n "$f" ] || continue
+  [ -f "$f" ] || continue
+  [ "$f" = changelog.d/README.md ] && continue
+  if [[ ! "$f" =~ ^changelog\.d/(added|changed|deprecated|removed|fixed|security)/[^/]+\.md$ ]]; then
+    say "$f is not a changelog fragment — name it changelog.d/<section>/<name>.md, section one of: added changed deprecated removed fixed security"
+    continue
+  fi
+  first=$(sed -n '/[^[:space:]]/{p;q;}' "$f" 2>/dev/null) || {
+    say "$f is unreadable — the fragment shape check could not run"
+    continue
+  }
+  case "$first" in
+    [-*+]\ *) : ;;
+    *) say "$f is not the list item it becomes — a fragment opens with '- ', continuation lines indented" ;;
+  esac
+done < <(printf '%s\n' "$files" | grep -E '^changelog\.d/')
+
+# Two branches that both write CHANGELOG.md's [Unreleased] list insert at the
+# same line, and the merge queue ejects the trailing one. Entries go to
+# changelog.d instead. CHANGELOG_COLLATE=1 is the release commit saying the
+# new lines are the collator's, the way RATCHET_RAISE=1 declares a baseline.
+if [ "${CHANGELOG_COLLATE:-}" != "1" ] && [ -f CHANGELOG.md ] && git cat-file -e HEAD:CHANGELOG.md 2>/dev/null; then
+  unreleased() { awk '/^## / { seen = ($0 ~ /^## \[Unreleased\]/); next } seen && NF'; }
+  if head_ur=$(git show HEAD:CHANGELOG.md | unreleased) && work_ur=$(unreleased <CHANGELOG.md); then
+    added=$(comm -13 <(printf '%s\n' "$head_ur" | LC_ALL=C sort -u) <(printf '%s\n' "$work_ur" | LC_ALL=C sort -u))
+    [ -n "$added" ] && say "CHANGELOG.md gained lines under [Unreleased] — write changelog.d/<section>/<name>.md instead; tools/changelog-collate folds it in at release:
+$(printf '%s\n' "$added" | head -5 | sed 's/^/  /')"
+  else
+    say "CHANGELOG.md could not be compared against HEAD — the [Unreleased] rule could not run"
   fi
 fi
 

--- a/tools/guard
+++ b/tools/guard
@@ -80,28 +80,19 @@ $long"
   else
     say "$f is unreadable — the entry-length check could not run"
   fi
-done < <({ echo CHANGELOG.md; printf '%s\n' "$files" | grep -E '^changelog\.d/[^/]+/[^/]+\.md$'; })
+done < <({ echo CHANGELOG.md; printf '%s\n' "$files" | grep -E '^changelog\.d/' | grep -vx 'changelog.d/README.md'; })
 
-# An entry is a file: changelog.d/<section>/<name>.md holding the Markdown
-# list item it becomes. The collator looks nowhere else, so a fragment filed
-# anywhere else is an entry that ships nothing.
-while IFS= read -r f; do
-  [ -n "$f" ] || continue
-  [ -f "$f" ] || continue
-  [ "$f" = changelog.d/README.md ] && continue
-  if [[ ! "$f" =~ ^changelog\.d/(added|changed|deprecated|removed|fixed|security)/[^/]+\.md$ ]]; then
-    say "$f is not a changelog fragment — name it changelog.d/<section>/<name>.md, section one of: added changed deprecated removed fixed security"
-    continue
+# The fragment format has one judge, and it is the tool that has to read the
+# fragments: tools/changelog-collate --check names every path and body it
+# would refuse, and writes nothing.
+if [ -x tools/changelog-collate ]; then
+  if ! collate_out=$(tools/changelog-collate --check 2>&1); then
+    say "changelog.d holds a fragment the collator refuses:
+$(printf '%s\n' "$collate_out" | head -5 | sed 's/^/  /')"
   fi
-  first=$(sed -n '/[^[:space:]]/{p;q;}' "$f" 2>/dev/null) || {
-    say "$f is unreadable — the fragment shape check could not run"
-    continue
-  }
-  case "$first" in
-    [-*+]\ *) : ;;
-    *) say "$f is not the list item it becomes — a fragment opens with '- ', continuation lines indented" ;;
-  esac
-done < <(printf '%s\n' "$files" | grep -E '^changelog\.d/')
+else
+  say "tools/changelog-collate is missing or not executable — the fragment format check could not run"
+fi
 
 # Two branches that both write CHANGELOG.md's [Unreleased] list insert at the
 # same line, and the merge queue ejects the trailing one. Entries go to
@@ -109,8 +100,11 @@ done < <(printf '%s\n' "$files" | grep -E '^changelog\.d/')
 # new lines are the collator's, the way RATCHET_RAISE=1 declares a baseline.
 if [ "${CHANGELOG_COLLATE:-}" != "1" ] && [ -f CHANGELOG.md ] && git cat-file -e HEAD:CHANGELOG.md 2>/dev/null; then
   unreleased() { awk '/^## / { seen = ($0 ~ /^## \[Unreleased\]/); next } seen && NF'; }
-  if head_ur=$(git show HEAD:CHANGELOG.md | unreleased) && work_ur=$(unreleased <CHANGELOG.md); then
-    added=$(comm -13 <(printf '%s\n' "$head_ur" | LC_ALL=C sort -u) <(printf '%s\n' "$work_ur" | LC_ALL=C sort -u))
+  # One collation for the sort and for comm, or comm calls a byte-ordered
+  # file unsorted and prints lines neither side gained. No -u either: a
+  # second copy of a line HEAD carries once is a line this tree gained.
+  if head_ur=$(git show HEAD:CHANGELOG.md | unreleased) && work_ur=$(unreleased <CHANGELOG.md) &&
+    added=$(LC_ALL=C comm -13 <(printf '%s\n' "$head_ur" | LC_ALL=C sort) <(printf '%s\n' "$work_ur" | LC_ALL=C sort)); then
     [ -n "$added" ] && say "CHANGELOG.md gained lines under [Unreleased] — write changelog.d/<section>/<name>.md instead; tools/changelog-collate folds it in at release:
 $(printf '%s\n' "$added" | head -5 | sed 's/^/  /')"
   else

--- a/tools/tests/changelog-collate.test.sh
+++ b/tools/tests/changelog-collate.test.sh
@@ -1,0 +1,244 @@
+#!/usr/bin/env bash
+# Pins tools/changelog-collate: fragments land under their own section in
+# Keep a Changelog order and filename order, a section the file does not
+# carry is opened in that order, the fragments are deleted, and a run with
+# nothing to fold changes nothing. The refusing direction runs first in every
+# pair, and each refusal is checked to have left CHANGELOG.md untouched —
+# a collator that half-writes the file is the failure this replaces.
+set -euo pipefail
+
+TEST_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+COLLATE="$(cd "$TEST_DIR/.." && pwd)/changelog-collate"
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+
+PASS=0
+FAIL=0
+ok() { PASS=$((PASS + 1)); printf '  ok    %s\n' "$1"; }
+bad() { FAIL=$((FAIL + 1)); printf '  FAIL  %s\n        %s\n' "$1" "${2:-}"; }
+
+R="$TMP/repo"
+mkdir -p "$R"
+git -C "$R" init -q
+git -C "$R" symbolic-ref HEAD refs/heads/main
+
+changelog() { # writes the fixture CHANGELOG.md
+  cat >"$R/CHANGELOG.md" <<'EOF'
+# Changelog
+
+Preamble.
+
+## [Unreleased]
+
+### Added
+
+- An entry the file already carries.
+
+### Fixed
+
+- A two-line entry
+  with a continuation.
+
+## [1.0.0] - 2026-01-01
+
+### Added
+
+- A released entry.
+EOF
+}
+
+fragment() { # SECTION NAME CONTENT
+  mkdir -p "$R/changelog.d/$1"
+  printf '%s' "$3" >"$R/changelog.d/$1/$2"
+}
+
+run_collate() { # sets OUT and RC
+  OUT=""
+  RC=0
+  OUT="$(cd "$R" && "$COLLATE" 2>&1)" || RC=$?
+}
+
+reset() {
+  rm -rf "${R:?}/changelog.d"
+  changelog
+  cp "$R/CHANGELOG.md" "$TMP/before"
+}
+
+untouched() { cmp -s "$R/CHANGELOG.md" "$TMP/before"; }
+
+echo "=== a file the collator cannot place stops the run, changing nothing ==="
+reset
+fragment fixed ken-1.md '- A placeable fragment.
+'
+printf -- '- Stray.\n' >"$R/changelog.d/loose.md"
+run_collate
+[ "$RC" -eq 2 ] && case "$OUT" in *"changelog.d/loose.md is not a changelog fragment"*) true ;; *) false ;; esac \
+  && ok "a file outside a section directory exits 2, naming it" \
+  || bad "a file outside a section directory exits 2, naming it" "rc=$RC out=$OUT"
+untouched && ok "CHANGELOG.md is untouched by the refusal" \
+  || bad "CHANGELOG.md is untouched by the refusal" "$(diff "$TMP/before" "$R/CHANGELOG.md" || true)"
+[ -f "$R/changelog.d/fixed/ken-1.md" ] && ok "the placeable fragment is not deleted by the refusal" \
+  || bad "the placeable fragment is not deleted by the refusal" "it is gone"
+
+reset
+fragment bogus ken-1.md '- Wrong section.
+'
+run_collate
+[ "$RC" -eq 2 ] && case "$OUT" in *"changelog.d/bogus/ken-1.md names no known section"*) true ;; *) false ;; esac \
+  && ok "an unknown section directory exits 2, naming it" \
+  || bad "an unknown section directory exits 2, naming it" "rc=$RC out=$OUT"
+
+reset
+fragment fixed ken-1.md '- Deep.
+'
+mkdir -p "$R/changelog.d/fixed/deeper"
+printf -- '- Deeper.\n' >"$R/changelog.d/fixed/deeper/ken-2.md"
+run_collate
+[ "$RC" -eq 2 ] && case "$OUT" in *"changelog.d/fixed/deeper/ken-2.md sits below a section directory"*) true ;; *) false ;; esac \
+  && ok "a fragment below a section directory exits 2, naming it" \
+  || bad "a fragment below a section directory exits 2, naming it" "rc=$RC out=$OUT"
+
+echo "=== a changelog the collator cannot read stops the run ==="
+reset
+fragment fixed ken-1.md '- A fragment.
+'
+printf '# Changelog\n\n## [1.0.0] - 2026-01-01\n\n- Released.\n' >"$R/CHANGELOG.md"
+cp "$R/CHANGELOG.md" "$TMP/before"
+run_collate
+[ "$RC" -eq 2 ] && case "$OUT" in *"no '## [Unreleased]' heading"*) true ;; *) false ;; esac \
+  && ok "a CHANGELOG with no [Unreleased] exits 2" \
+  || bad "a CHANGELOG with no [Unreleased] exits 2" "rc=$RC out=$OUT"
+untouched && ok "CHANGELOG.md is untouched by that refusal" \
+  || bad "CHANGELOG.md is untouched by that refusal" "it changed"
+case "$(ls "$R")" in *CHANGELOG.md.*) bad "no replacement file is left behind" "$(ls "$R")" ;;
+  *) ok "no replacement file is left behind" ;; esac
+
+reset
+fragment fixed ken-1.md '- A fragment.
+'
+printf '# Changelog\n\n## [Unreleased]\n\n### Notes\n\n- Not a section.\n' >"$R/CHANGELOG.md"
+cp "$R/CHANGELOG.md" "$TMP/before"
+run_collate
+[ "$RC" -eq 2 ] && case "$OUT" in *"names 'Notes' under [Unreleased]"*) true ;; *) false ;; esac \
+  && ok "a heading that is no Keep a Changelog section exits 2, naming it" \
+  || bad "a heading that is no Keep a Changelog section exits 2, naming it" "rc=$RC out=$OUT"
+untouched && ok "CHANGELOG.md is untouched by that refusal too" \
+  || bad "CHANGELOG.md is untouched by that refusal too" "it changed"
+
+echo "=== fragments fold into their sections and are deleted ==="
+reset
+fragment fixed ken-2.md '- Second by filename.
+'
+fragment fixed ken-1.md '- First by filename
+  with a continuation.
+'
+fragment added ken-3.md '- An added fragment.
+'
+fragment security ken-4.md '- A security fragment.' # no trailing newline
+printf '# changelog.d\n' >"$R/changelog.d/README.md"
+run_collate
+[ "$RC" -eq 0 ] && case "$OUT" in *"folded 4 fragments"*) true ;; *) false ;; esac \
+  && ok "the run reports the count it folded" \
+  || bad "the run reports the count it folded" "rc=$RC out=$OUT"
+cat >"$TMP/expected" <<'EOF'
+# Changelog
+
+Preamble.
+
+## [Unreleased]
+
+### Added
+
+- An entry the file already carries.
+- An added fragment.
+
+### Fixed
+
+- A two-line entry
+  with a continuation.
+- First by filename
+  with a continuation.
+- Second by filename.
+
+### Security
+
+- A security fragment.
+
+## [1.0.0] - 2026-01-01
+
+### Added
+
+- A released entry.
+EOF
+if diff -u "$TMP/expected" "$R/CHANGELOG.md" >"$TMP/diff" 2>&1; then
+  ok "the collated changelog is exactly the expected file"
+else
+  bad "the collated changelog is exactly the expected file" "$(cat "$TMP/diff")"
+fi
+[ -d "$R/changelog.d/fixed" ] && bad "the emptied section directories are removed" "changelog.d/fixed remains" \
+  || ok "the emptied section directories are removed"
+[ -f "$R/changelog.d/README.md" ] && ok "the README survives the collation" \
+  || bad "the README survives the collation" "it is gone"
+
+echo "=== a section the file spells twice merges into the first ==="
+reset
+cat >"$R/CHANGELOG.md" <<'EOF'
+# Changelog
+
+## [Unreleased]
+
+### Fixed
+
+- First block.
+
+### Added
+
+- An added entry.
+
+### Fixed
+
+- Second block.
+EOF
+fragment fixed ken-1.md '- A fragment.
+'
+run_collate
+cat >"$TMP/expected" <<'EOF'
+# Changelog
+
+## [Unreleased]
+
+### Added
+
+- An added entry.
+
+### Fixed
+
+- First block.
+- Second block.
+- A fragment.
+EOF
+if diff -u "$TMP/expected" "$R/CHANGELOG.md" >"$TMP/diff" 2>&1; then
+  ok "both blocks and the fragment land under one heading, in section order"
+else
+  bad "both blocks and the fragment land under one heading, in section order" "$(cat "$TMP/diff")"
+fi
+
+echo "=== nothing to fold is a no-op ==="
+reset
+run_collate
+[ "$RC" -eq 0 ] && case "$OUT" in *"no changelog.d directory"*) true ;; *) false ;; esac \
+  && ok "no changelog.d directory is a clean no-op" \
+  || bad "no changelog.d directory is a clean no-op" "rc=$RC out=$OUT"
+untouched && ok "CHANGELOG.md is untouched by the no-op" \
+  || bad "CHANGELOG.md is untouched by the no-op" "it changed"
+mkdir -p "$R/changelog.d"
+printf '# changelog.d\n' >"$R/changelog.d/README.md"
+run_collate
+[ "$RC" -eq 0 ] && case "$OUT" in *"no fragments"*) true ;; *) false ;; esac \
+  && ok "a changelog.d holding only the README is a clean no-op" \
+  || bad "a changelog.d holding only the README is a clean no-op" "rc=$RC out=$OUT"
+untouched && ok "CHANGELOG.md is untouched by that no-op" \
+  || bad "CHANGELOG.md is untouched by that no-op" "it changed"
+
+printf '\n%s passed, %s failed\n' "$PASS" "$FAIL"
+[ "$FAIL" -eq 0 ]

--- a/tools/tests/changelog-collate.test.sh
+++ b/tools/tests/changelog-collate.test.sh
@@ -150,6 +150,17 @@ run_collate
   || bad "the whitespace-only fragment survives the refusal" "it is gone"
 
 reset
+fragment fixed marker.md $'- \n' # a marker and nothing after it
+run_collate
+[ "$RC" -eq 1 ] && case "$OUT" in *"changelog.d/fixed/marker.md has no entry in it"*) true ;; *) false ;; esac \
+  && ok "a marker with nothing after it exits 1, naming it" \
+  || bad "a marker with nothing after it exits 1, naming it" "rc=$RC out=$OUT"
+untouched && ok "no empty list item is folded in" \
+  || bad "no empty list item is folded in" "$(diff "$TMP/before" "$R/CHANGELOG.md" || true)"
+[ -f "$R/changelog.d/fixed/marker.md" ] && ok "the marker-only fragment survives the refusal" \
+  || bad "the marker-only fragment survives the refusal" "it is gone"
+
+reset
 fragment fixed two.md '- First entry.
 - Second entry.
 '
@@ -235,6 +246,33 @@ case "$(cat "$R/CHANGELOG.md")" in *"An untracked entry"*) bad "the untracked fr
 [ -f "$R/changelog.d/fixed/untracked.md" ] && ok "the untracked fragment is not deleted" \
   || bad "the untracked fragment is not deleted" "it is gone"
 rm -f "$R/changelog.d/.DS_Store" "$R/changelog.d/fixed/untracked.md"
+
+echo "=== the write refuses a changelog.d git and the disk disagree about ==="
+# The run folds in the file on disk and then deletes it. An unstaged edit
+# would be published and erased with nothing left carrying it.
+reset
+fragment fixed ken-1.md '- The wording git carries.
+'
+printf -- '- The unstaged rewrite.\n' >"$R/changelog.d/fixed/ken-1.md"
+run_collate
+[ "$RC" -eq 2 ] && case "$OUT" in *"differs between git and the working tree"*"changelog.d/fixed/ken-1.md"*) true ;; *) false ;; esac \
+  && ok "an unstaged fragment edit exits 2, naming the path" \
+  || bad "an unstaged fragment edit exits 2, naming the path" "rc=$RC out=$OUT"
+untouched && ok "CHANGELOG.md is untouched by the dirty refusal" \
+  || bad "CHANGELOG.md is untouched by the dirty refusal" "$(diff "$TMP/before" "$R/CHANGELOG.md" || true)"
+[ -f "$R/changelog.d/fixed/ken-1.md" ] && ok "the unstaged fragment is not deleted" \
+  || bad "the unstaged fragment is not deleted" "it is gone"
+case "$(cat "$R/changelog.d/fixed/ken-1.md")" in *"unstaged rewrite"*) ok "the unstaged edit is still in the file" ;;
+  *) bad "the unstaged edit is still in the file" "$(cat "$R/changelog.d/fixed/ken-1.md")" ;; esac
+run_collate --check
+[ "$RC" -eq 0 ] && ok "--check takes the same tree: it writes and deletes nothing" \
+  || bad "--check takes the same tree: it writes and deletes nothing" "rc=$RC out=$OUT"
+git -C "$R" add -A
+run_collate
+[ "$RC" -eq 0 ] && ok "staging the edit lets the write proceed" \
+  || bad "staging the edit lets the write proceed" "rc=$RC out=$OUT"
+case "$(cat "$R/CHANGELOG.md")" in *"unstaged rewrite"*) ok "the staged wording is the one folded in" ;;
+  *) bad "the staged wording is the one folded in" "$(cat "$R/CHANGELOG.md")" ;; esac
 
 echo "=== a changelog the collator cannot read stops the run ==="
 reset

--- a/tools/tests/changelog-collate.test.sh
+++ b/tools/tests/changelog-collate.test.sh
@@ -67,6 +67,34 @@ run_collate() { # [ARG...] — sets OUT and RC
 
 untouched() { cmp -s "$R/CHANGELOG.md" "$TMP/before"; }
 
+filemode() { # FILE — its permission bits, GNU stat or BSD stat
+  stat -c '%a' "$1" 2>/dev/null || stat -f '%Lp' "$1"
+}
+
+no_leftover() { # no replacement file survives at the repo root
+  local f
+  for f in "$R"/CHANGELOG.md.*; do
+    [ -e "$f" ] && return 1
+  done
+  return 0
+}
+
+# A stub ahead of PATH is how a failure is reached in the window where the
+# replacement file already exists: nothing else in the collator runs mv or cp.
+STUB="$TMP/stub"
+mkdir -p "$STUB"
+stub_failing() { # COMMAND
+  printf '#!/bin/sh\necho "%s: refused by the test stub" >&2\nexit 1\n' "$1" >"$STUB/$1"
+  chmod +x "$STUB/$1"
+}
+unstub() { rm -f "$STUB"/*; }
+
+run_collate_stubbed() { # sets OUT and RC, with STUB ahead of PATH
+  OUT=""
+  RC=0
+  OUT="$(cd "$R" && PATH="$STUB:$PATH" "$COLLATE" 2>&1)" || RC=$?
+}
+
 echo "=== a fragment the format refuses stops the run before any write ==="
 reset
 fragment fixed ken-1.md '- A placeable fragment.
@@ -220,8 +248,8 @@ run_collate
   || bad "a CHANGELOG with no [Unreleased] exits 2" "rc=$RC out=$OUT"
 untouched && ok "CHANGELOG.md is untouched by that refusal" \
   || bad "CHANGELOG.md is untouched by that refusal" "it changed"
-case "$(ls "$R")" in *CHANGELOG.md.*) bad "no replacement file is left behind" "$(ls "$R")" ;;
-  *) ok "no replacement file is left behind" ;; esac
+no_leftover && ok "no replacement file is left behind" \
+  || bad "no replacement file is left behind" "$(ls "$R")"
 
 reset
 fragment fixed ken-1.md '- A fragment.
@@ -234,6 +262,50 @@ run_collate
   || bad "a heading that is no Keep a Changelog section exits 2, naming it" "rc=$RC out=$OUT"
 untouched && ok "CHANGELOG.md is untouched by that refusal too" \
   || bad "CHANGELOG.md is untouched by that refusal too" "it changed"
+
+reset
+fragment fixed ken-1.md '- A fragment.
+'
+rm -f "$R/CHANGELOG.md"
+run_collate
+[ "$RC" -eq 2 ] && case "$OUT" in *"CHANGELOG.md is missing"*) true ;; *) false ;; esac \
+  && ok "a missing CHANGELOG names the file, not an unreadable one" \
+  || bad "a missing CHANGELOG names the file, not an unreadable one" "rc=$RC out=$OUT"
+[ -f "$R/changelog.d/fixed/ken-1.md" ] && ok "the fragment survives a missing CHANGELOG" \
+  || bad "the fragment survives a missing CHANGELOG" "it is gone"
+
+echo "=== a failure past the replacement file leaves nothing half-written ==="
+reset
+fragment fixed ken-1.md '- A fragment.
+'
+stub_failing mv
+run_collate_stubbed
+unstub
+[ "$RC" -eq 2 ] && case "$OUT" in *"could not replace CHANGELOG.md"*) true ;; *) false ;; esac \
+  && ok "a failing rename exits 2, naming the step" \
+  || bad "a failing rename exits 2, naming the step" "rc=$RC out=$OUT"
+untouched && ok "CHANGELOG.md is byte-identical after the failing rename" \
+  || bad "CHANGELOG.md is byte-identical after the failing rename" "$(diff "$TMP/before" "$R/CHANGELOG.md" || true)"
+no_leftover && ok "the replacement file is cleaned up after the failing rename" \
+  || bad "the replacement file is cleaned up after the failing rename" "$(ls "$R")"
+[ -f "$R/changelog.d/fixed/ken-1.md" ] && ok "the fragment survives the failing rename" \
+  || bad "the fragment survives the failing rename" "it is gone"
+
+reset
+fragment fixed ken-1.md '- A fragment.
+'
+stub_failing cp
+run_collate_stubbed
+unstub
+[ "$RC" -eq 2 ] && case "$OUT" in *"could not take CHANGELOG.md's mode"*) true ;; *) false ;; esac \
+  && ok "a failing mode copy exits 2, naming the step" \
+  || bad "a failing mode copy exits 2, naming the step" "rc=$RC out=$OUT"
+untouched && ok "CHANGELOG.md is byte-identical after the failing mode copy" \
+  || bad "CHANGELOG.md is byte-identical after the failing mode copy" "it changed"
+no_leftover && ok "the replacement file is cleaned up after the failing mode copy" \
+  || bad "the replacement file is cleaned up after the failing mode copy" "$(ls "$R")"
+[ -f "$R/changelog.d/fixed/ken-1.md" ] && ok "the fragment survives the failing mode copy" \
+  || bad "the fragment survives the failing mode copy" "it is gone"
 
 echo "=== a fragment that cannot be deleted is named, and none is left unvisited ==="
 if [ "$(id -u)" -ne 0 ]; then
@@ -254,6 +326,9 @@ if [ "$(id -u)" -ne 0 ]; then
 fi
 
 echo "=== fragments fold into their sections and are deleted ==="
+# Keep a Changelog's six sections and their headings are spelled out here
+# rather than read from the collator's own map: a list derived from the
+# subject cannot catch that map being narrowed or a heading being mistyped.
 reset
 fragment fixed ken-2.md '- Second by filename.
 '
@@ -262,11 +337,18 @@ fragment fixed ken-1.md '- First by filename
 '
 fragment added ken-3.md '- An added fragment.
 '
-fragment security ken-4.md '- A security fragment.' # no trailing newline
+fragment changed ken-4.md '- A changed fragment.
+'
+fragment deprecated ken-5.md '- A deprecated fragment.
+'
+fragment removed ken-6.md '- A removed fragment.
+'
+fragment security ken-7.md '- A security fragment.' # no trailing newline
 printf '# changelog.d\n' >"$R/changelog.d/README.md"
 git -C "$R" add -A
+chmod 640 "$R/CHANGELOG.md"
 run_collate
-[ "$RC" -eq 0 ] && case "$OUT" in *"folded 4 entries"*) true ;; *) false ;; esac \
+[ "$RC" -eq 0 ] && case "$OUT" in *"folded 7 entries"*) true ;; *) false ;; esac \
   && ok "the run reports the count it folded" \
   || bad "the run reports the count it folded" "rc=$RC out=$OUT"
 cat >"$TMP/expected" <<'EOF'
@@ -280,6 +362,18 @@ Preamble.
 
 - An entry the file already carries.
 - An added fragment.
+
+### Changed
+
+- A changed fragment.
+
+### Deprecated
+
+- A deprecated fragment.
+
+### Removed
+
+- A removed fragment.
 
 ### Fixed
 
@@ -300,16 +394,23 @@ Preamble.
 - A released entry.
 EOF
 if diff -u "$TMP/expected" "$R/CHANGELOG.md" >"$TMP/diff" 2>&1; then
-  ok "the collated changelog is exactly the expected file"
+  ok "every section folds under its own heading, in Keep a Changelog order"
 else
-  bad "the collated changelog is exactly the expected file" "$(cat "$TMP/diff")"
+  bad "every section folds under its own heading, in Keep a Changelog order" "$(cat "$TMP/diff")"
 fi
-[ -d "$R/changelog.d/fixed" ] && bad "the emptied section directories are removed" "changelog.d/fixed remains" \
-  || ok "the emptied section directories are removed"
+[ "$(filemode "$R/CHANGELOG.md")" = 640 ] && ok "the collated file keeps the mode it replaced" \
+  || bad "the collated file keeps the mode it replaced" "mode is $(filemode "$R/CHANGELOG.md"), not 640"
+chmod 644 "$R/CHANGELOG.md"
+leftover=""
+for s in added changed deprecated removed fixed security; do
+  if [ -d "$R/changelog.d/$s" ]; then leftover="$leftover $s"; fi
+done
+[ -z "$leftover" ] && ok "the emptied section directories are removed" \
+  || bad "the emptied section directories are removed" "still on disk:$leftover"
 [ -f "$R/changelog.d/README.md" ] && ok "the README survives the collation" \
   || bad "the README survives the collation" "it is gone"
 
-echo "=== a section the file spells twice merges into the first ==="
+echo "=== two headings for one section collapse into one, in section order ==="
 reset
 cat >"$R/CHANGELOG.md" <<'EOF'
 # Changelog

--- a/tools/tests/changelog-collate.test.sh
+++ b/tools/tests/changelog-collate.test.sh
@@ -1,16 +1,17 @@
 #!/usr/bin/env bash
-# Pins tools/changelog-collate: fragments land under their own section in
-# Keep a Changelog order and filename order, a section the file does not
-# carry is opened in that order, the fragments are deleted, and a run with
-# nothing to fold changes nothing. The refusing direction runs first in every
-# pair, and each refusal is checked to have left CHANGELOG.md untouched —
-# a collator that half-writes the file is the failure this replaces.
+# Pins tools/changelog-collate: it judges the fragments git carries before it
+# writes anything, folds them under their own section in Keep a Changelog
+# order and filename order, deletes every one of them, and leaves CHANGELOG.md
+# whole when it refuses. The refusing direction runs first in every pair, and
+# each refusal is checked to have left CHANGELOG.md and the fragments as they
+# were — a collator that half-writes or half-deletes is the failure this
+# replaces. --check runs the same judgment and writes nothing.
 set -euo pipefail
 
 TEST_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 COLLATE="$(cd "$TEST_DIR/.." && pwd)/changelog-collate"
 TMP="$(mktemp -d)"
-trap 'rm -rf "$TMP"' EXIT
+trap 'chmod -R u+w "$TMP" 2>/dev/null; rm -rf "$TMP"' EXIT
 
 PASS=0
 FAIL=0
@@ -21,8 +22,11 @@ R="$TMP/repo"
 mkdir -p "$R"
 git -C "$R" init -q
 git -C "$R" symbolic-ref HEAD refs/heads/main
+git -C "$R" config user.email test@example.com
+git -C "$R" config user.name test
 
-changelog() { # writes the fixture CHANGELOG.md
+reset() { # a fixture CHANGELOG and an empty changelog.d, both in the index
+  rm -rf "${R:?}/changelog.d"
   cat >"$R/CHANGELOG.md" <<'EOF'
 # Changelog
 
@@ -45,36 +49,34 @@ Preamble.
 
 - A released entry.
 EOF
+  git -C "$R" add -A
+  cp "$R/CHANGELOG.md" "$TMP/before"
 }
 
-fragment() { # SECTION NAME CONTENT
+fragment() { # SECTION NAME CONTENT — written and staged, the way a commit carries it
   mkdir -p "$R/changelog.d/$1"
   printf '%s' "$3" >"$R/changelog.d/$1/$2"
+  git -C "$R" add -A
 }
 
-run_collate() { # sets OUT and RC
+run_collate() { # [ARG...] — sets OUT and RC
   OUT=""
   RC=0
-  OUT="$(cd "$R" && "$COLLATE" 2>&1)" || RC=$?
-}
-
-reset() {
-  rm -rf "${R:?}/changelog.d"
-  changelog
-  cp "$R/CHANGELOG.md" "$TMP/before"
+  OUT="$(cd "$R" && "$COLLATE" "$@" 2>&1)" || RC=$?
 }
 
 untouched() { cmp -s "$R/CHANGELOG.md" "$TMP/before"; }
 
-echo "=== a file the collator cannot place stops the run, changing nothing ==="
+echo "=== a fragment the format refuses stops the run before any write ==="
 reset
 fragment fixed ken-1.md '- A placeable fragment.
 '
 printf -- '- Stray.\n' >"$R/changelog.d/loose.md"
+git -C "$R" add -A
 run_collate
-[ "$RC" -eq 2 ] && case "$OUT" in *"changelog.d/loose.md is not a changelog fragment"*) true ;; *) false ;; esac \
-  && ok "a file outside a section directory exits 2, naming it" \
-  || bad "a file outside a section directory exits 2, naming it" "rc=$RC out=$OUT"
+[ "$RC" -eq 1 ] && case "$OUT" in *"changelog.d/loose.md is not a changelog fragment"*) true ;; *) false ;; esac \
+  && ok "a file outside a section directory exits 1, naming it" \
+  || bad "a file outside a section directory exits 1, naming it" "rc=$RC out=$OUT"
 untouched && ok "CHANGELOG.md is untouched by the refusal" \
   || bad "CHANGELOG.md is untouched by the refusal" "$(diff "$TMP/before" "$R/CHANGELOG.md" || true)"
 [ -f "$R/changelog.d/fixed/ken-1.md" ] && ok "the placeable fragment is not deleted by the refusal" \
@@ -84,19 +86,127 @@ reset
 fragment bogus ken-1.md '- Wrong section.
 '
 run_collate
-[ "$RC" -eq 2 ] && case "$OUT" in *"changelog.d/bogus/ken-1.md names no known section"*) true ;; *) false ;; esac \
-  && ok "an unknown section directory exits 2, naming it" \
-  || bad "an unknown section directory exits 2, naming it" "rc=$RC out=$OUT"
+[ "$RC" -eq 1 ] && case "$OUT" in *"changelog.d/bogus/ken-1.md names no known section"*) true ;; *) false ;; esac \
+  && ok "an unknown section directory exits 1, naming it" \
+  || bad "an unknown section directory exits 1, naming it" "rc=$RC out=$OUT"
 
 reset
-fragment fixed ken-1.md '- Deep.
+fragment fixed/deeper ken-2.md '- Deeper.
 '
-mkdir -p "$R/changelog.d/fixed/deeper"
-printf -- '- Deeper.\n' >"$R/changelog.d/fixed/deeper/ken-2.md"
 run_collate
-[ "$RC" -eq 2 ] && case "$OUT" in *"changelog.d/fixed/deeper/ken-2.md sits below a section directory"*) true ;; *) false ;; esac \
-  && ok "a fragment below a section directory exits 2, naming it" \
-  || bad "a fragment below a section directory exits 2, naming it" "rc=$RC out=$OUT"
+[ "$RC" -eq 1 ] && case "$OUT" in *"changelog.d/fixed/deeper/ken-2.md sits below a section directory"*) true ;; *) false ;; esac \
+  && ok "a fragment below a section directory exits 1, naming it" \
+  || bad "a fragment below a section directory exits 1, naming it" "rc=$RC out=$OUT"
+
+echo "=== a fragment is exactly one list item, or it is refused ==="
+reset
+fragment fixed empty.md ''
+run_collate
+[ "$RC" -eq 1 ] && case "$OUT" in *"changelog.d/fixed/empty.md has no entry in it"*) true ;; *) false ;; esac \
+  && ok "a zero-byte fragment exits 1, naming it" \
+  || bad "a zero-byte fragment exits 1, naming it" "rc=$RC out=$OUT"
+untouched && ok "CHANGELOG.md is untouched by the empty fragment" \
+  || bad "CHANGELOG.md is untouched by the empty fragment" "it changed"
+[ -f "$R/changelog.d/fixed/empty.md" ] && ok "the empty fragment is still on disk, not silently consumed" \
+  || bad "the empty fragment is still on disk, not silently consumed" "it is gone"
+
+reset
+fragment fixed blank.md '
+
+'
+run_collate
+[ "$RC" -eq 1 ] && case "$OUT" in *"changelog.d/fixed/blank.md has no entry in it"*) true ;; *) false ;; esac \
+  && ok "a whitespace-only fragment exits 1, naming it" \
+  || bad "a whitespace-only fragment exits 1, naming it" "rc=$RC out=$OUT"
+[ -f "$R/changelog.d/fixed/blank.md" ] && ok "the whitespace-only fragment survives the refusal" \
+  || bad "the whitespace-only fragment survives the refusal" "it is gone"
+
+reset
+fragment fixed two.md '- First entry.
+- Second entry.
+'
+run_collate
+[ "$RC" -eq 1 ] && case "$OUT" in *"changelog.d/fixed/two.md holds more than the one entry"*) true ;; *) false ;; esac \
+  && ok "two list items in one fragment exit 1, naming it" \
+  || bad "two list items in one fragment exit 1, naming it" "rc=$RC out=$OUT"
+
+reset
+fragment fixed heading.md '- An entry.
+
+## [9.9.9] - 2026-01-01
+'
+run_collate
+[ "$RC" -eq 1 ] && case "$OUT" in *"changelog.d/fixed/heading.md holds more than the one entry"*) true ;; *) false ;; esac \
+  && ok "a heading inside a fragment exits 1 rather than ending the section it folds into" \
+  || bad "a heading inside a fragment exits 1 rather than ending the section it folds into" "rc=$RC out=$OUT"
+
+reset
+fragment fixed prose.md 'Not a list item.
+'
+run_collate
+[ "$RC" -eq 1 ] && case "$OUT" in *"changelog.d/fixed/prose.md does not open with a list marker"*) true ;; *) false ;; esac \
+  && ok "a fragment opening with prose exits 1, naming it" \
+  || bad "a fragment opening with prose exits 1, naming it" "rc=$RC out=$OUT"
+
+reset
+mkdir -p "$R/changelog.d/fixed"
+ln -s ../../CHANGELOG.md "$R/changelog.d/fixed/link.md"
+git -C "$R" add -A
+run_collate
+[ "$RC" -eq 1 ] && case "$OUT" in *"changelog.d/fixed/link.md is a symlink"*) true ;; *) false ;; esac \
+  && ok "a symlinked fragment exits 1 rather than being followed or skipped" \
+  || bad "a symlinked fragment exits 1 rather than being followed or skipped" "rc=$RC out=$OUT"
+untouched && ok "the symlink target is untouched" \
+  || bad "the symlink target is untouched" "it changed"
+rm -f "$R/changelog.d/fixed/link.md"
+
+reset
+fragment fixed ok.md '- An entry
+  continued over
+  three lines.
+'
+run_collate
+[ "$RC" -eq 0 ] && ok "an entry with indented continuation lines is taken" \
+  || bad "an entry with indented continuation lines is taken" "rc=$RC out=$OUT"
+
+echo "=== --check judges the same fragments and writes nothing ==="
+reset
+fragment fixed two.md '- First entry.
+- Second entry.
+'
+run_collate --check
+[ "$RC" -eq 1 ] && case "$OUT" in *"changelog.d/fixed/two.md holds more than the one entry"*) true ;; *) false ;; esac \
+  && ok "--check exits 1 on a fragment the format refuses" \
+  || bad "--check exits 1 on a fragment the format refuses" "rc=$RC out=$OUT"
+reset
+fragment fixed ken-1.md '- A good entry.
+'
+run_collate --check
+[ "$RC" -eq 0 ] && [ -z "$OUT" ] && ok "--check is silent and exits 0 on a good fragment" \
+  || bad "--check is silent and exits 0 on a good fragment" "rc=$RC out=$OUT"
+untouched && ok "--check writes no CHANGELOG.md" \
+  || bad "--check writes no CHANGELOG.md" "it changed"
+[ -f "$R/changelog.d/fixed/ken-1.md" ] && ok "--check deletes no fragment" \
+  || bad "--check deletes no fragment" "it is gone"
+run_collate --bogus
+[ "$RC" -eq 2 ] && case "$OUT" in *usage*) true ;; *) false ;; esac \
+  && ok "an unknown flag exits 2" \
+  || bad "an unknown flag exits 2" "rc=$RC out=$OUT"
+
+echo "=== the fragments are the ones git carries ==="
+reset
+fragment fixed ken-1.md '- A tracked entry.
+'
+printf 'binary junk\n' >"$R/changelog.d/.DS_Store"
+printf -- '- An untracked entry.\n' >"$R/changelog.d/fixed/untracked.md"
+run_collate
+[ "$RC" -eq 0 ] && ok "an untracked stray under changelog.d does not stop the run" \
+  || bad "an untracked stray under changelog.d does not stop the run" "rc=$RC out=$OUT"
+case "$(cat "$R/CHANGELOG.md")" in *"An untracked entry"*) bad "the untracked fragment is not folded in" "it was" ;;
+  *) ok "the untracked fragment is not folded in" ;; esac
+[ -f "$R/changelog.d/fixed/untracked.md" ] && ok "the untracked fragment is not deleted" \
+  || bad "the untracked fragment is not deleted" "it is gone"
+rm -f "$R/changelog.d/.DS_Store" "$R/changelog.d/fixed/untracked.md"
 
 echo "=== a changelog the collator cannot read stops the run ==="
 reset
@@ -125,6 +235,24 @@ run_collate
 untouched && ok "CHANGELOG.md is untouched by that refusal too" \
   || bad "CHANGELOG.md is untouched by that refusal too" "it changed"
 
+echo "=== a fragment that cannot be deleted is named, and none is left unvisited ==="
+if [ "$(id -u)" -ne 0 ]; then
+  reset
+  fragment fixed a.md '- Undeletable one.
+'
+  fragment fixed b.md '- Undeletable two.
+'
+  chmod a-w "$R/changelog.d/fixed"
+  run_collate
+  chmod u+w "$R/changelog.d/fixed"
+  [ "$RC" -eq 2 ] && case "$OUT" in *"changelog.d/fixed/a.md"*"changelog.d/fixed/b.md"*) true ;; *) false ;; esac \
+    && ok "the refusal names every fragment that survived, not the first" \
+    || bad "the refusal names every fragment that survived, not the first" "rc=$RC out=$OUT"
+  case "$(grep -c 'Undeletable one' "$R/CHANGELOG.md")" in 1) ok "the collation itself completed once" ;;
+    *) bad "the collation itself completed once" "$(grep -n Undeletable "$R/CHANGELOG.md")" ;; esac
+  rm -f "$R/changelog.d/fixed/a.md" "$R/changelog.d/fixed/b.md"
+fi
+
 echo "=== fragments fold into their sections and are deleted ==="
 reset
 fragment fixed ken-2.md '- Second by filename.
@@ -136,8 +264,9 @@ fragment added ken-3.md '- An added fragment.
 '
 fragment security ken-4.md '- A security fragment.' # no trailing newline
 printf '# changelog.d\n' >"$R/changelog.d/README.md"
+git -C "$R" add -A
 run_collate
-[ "$RC" -eq 0 ] && case "$OUT" in *"folded 4 fragments"*) true ;; *) false ;; esac \
+[ "$RC" -eq 0 ] && case "$OUT" in *"folded 4 entries"*) true ;; *) false ;; esac \
   && ok "the run reports the count it folded" \
   || bad "the run reports the count it folded" "rc=$RC out=$OUT"
 cat >"$TMP/expected" <<'EOF'
@@ -226,13 +355,14 @@ fi
 echo "=== nothing to fold is a no-op ==="
 reset
 run_collate
-[ "$RC" -eq 0 ] && case "$OUT" in *"no changelog.d directory"*) true ;; *) false ;; esac \
+[ "$RC" -eq 0 ] && case "$OUT" in *"no fragments"*) true ;; *) false ;; esac \
   && ok "no changelog.d directory is a clean no-op" \
   || bad "no changelog.d directory is a clean no-op" "rc=$RC out=$OUT"
 untouched && ok "CHANGELOG.md is untouched by the no-op" \
   || bad "CHANGELOG.md is untouched by the no-op" "it changed"
 mkdir -p "$R/changelog.d"
 printf '# changelog.d\n' >"$R/changelog.d/README.md"
+git -C "$R" add -A
 run_collate
 [ "$RC" -eq 0 ] && case "$OUT" in *"no fragments"*) true ;; *) false ;; esac \
   && ok "a changelog.d holding only the README is a clean no-op" \

--- a/tools/tests/changelog-collate.test.sh
+++ b/tools/tests/changelog-collate.test.sh
@@ -247,6 +247,29 @@ case "$(cat "$R/CHANGELOG.md")" in *"An untracked entry"*) bad "the untracked fr
   || bad "the untracked fragment is not deleted" "it is gone"
 rm -f "$R/changelog.d/.DS_Store" "$R/changelog.d/fixed/untracked.md"
 
+echo "=== a fragment the index carries and the disk does not is a deletion ==="
+# The release runs the collation, then tools/guard, then stages: between the
+# first two the fragments are gone from the disk and still in the index, and
+# guard's --check has to pass over exactly that state.
+reset
+fragment fixed ken-1.md '- An entry the release folds in.
+'
+git -C "$R" commit -q -m "chore: carry a fragment"
+run_collate
+[ "$RC" -eq 0 ] && ok "the collation folds the committed fragment in" \
+  || bad "the collation folds the committed fragment in" "rc=$RC out=$OUT"
+run_collate --check
+[ "$RC" -eq 0 ] && [ -z "$OUT" ] && ok "--check passes over the deletion the collation just made" \
+  || bad "--check passes over the deletion the collation just made" "rc=$RC out=$OUT"
+run_collate
+[ "$RC" -eq 2 ] && case "$OUT" in *"changelog.d/fixed/ken-1.md is in the index but not a file on disk"*) true ;; *) false ;; esac \
+  && ok "the writing mode still refuses that same missing path" \
+  || bad "the writing mode still refuses that same missing path" "rc=$RC out=$OUT"
+git -C "$R" add -A
+run_collate --check
+[ "$RC" -eq 0 ] && ok "--check is still clean once the deletion is staged" \
+  || bad "--check is still clean once the deletion is staged" "rc=$RC out=$OUT"
+
 echo "=== the write refuses a changelog.d git and the disk disagree about ==="
 # The run folds in the file on disk and then deletes it. An unstaged edit
 # would be published and erased with nothing left carrying it.

--- a/tools/tests/guard.test.sh
+++ b/tools/tests/guard.test.sh
@@ -1,8 +1,10 @@
 #!/usr/bin/env bash
 # Pins what tools/guard still judges once the shipped packages judge the
 # rest: the size-ratchet baseline may only tighten unless RATCHET_RAISE=1
-# says otherwise, and a CHANGELOG entry runs at most three lines. It also
-# pins the absence — a line cap, a work marker, a blanket allow and an
+# says otherwise, a CHANGELOG entry runs at most three lines wherever it is
+# written, a changelog.d fragment is named and shaped so the collator finds
+# it, and the [Unreleased] list gains lines only under CHANGELOG_COLLATE=1.
+# It also pins the absence — a line cap, a work marker, a blanket allow and an
 # oversized file all pass here, because size-ratchet, todo-ban,
 # suppression-ban and byte-ceiling are the judges of those. The failing
 # direction runs first so a green pass is evidence, not a check that cannot
@@ -132,6 +134,81 @@ if [ "$(id -u)" -ne 0 ]; then
   [ "$RC" -ne 0 ] && case "$OUT" in *"CHANGELOG.md is unreadable"*) true ;; *) false ;; esac \
     && ok "an unreadable CHANGELOG fails closed, naming the check that could not run" \
     || bad "an unreadable CHANGELOG fails closed, naming the check that could not run" "rc=$RC out=$OUT"
+fi
+
+echo "=== a changelog fragment is judged as the entry it becomes ==="
+mkdir -p "$R/changelog.d/fixed"
+printf -- '- A four-line fragment\n  second line\n  third line\n  fourth line.\n' >"$R/changelog.d/fixed/ken-1.md"
+git -C "$R" add -A
+run_guard RATCHET_RAISE=
+[ "$RC" -ne 0 ] && case "$OUT" in *"changelog.d/fixed/ken-1.md entries run past three lines"*"line 1: 4 lines"*) true ;; *) false ;; esac \
+  && ok "an over-long fragment fails, naming the fragment and its count" \
+  || bad "an over-long fragment fails, naming the fragment and its count" "rc=$RC out=$OUT"
+printf -- '- A three-line fragment\n  second line\n  third line.\n' >"$R/changelog.d/fixed/ken-1.md"
+git -C "$R" add -A
+run_guard RATCHET_RAISE=
+[ "$RC" -eq 0 ] && ok "a three-line fragment passes" \
+  || bad "a three-line fragment passes" "rc=$RC out=$OUT"
+
+echo "=== a fragment is filed where the collator looks for it ==="
+printf -- '- Stray.\n' >"$R/changelog.d/loose.md"
+mkdir -p "$R/changelog.d/bogus"
+printf -- '- Wrong section.\n' >"$R/changelog.d/bogus/ken-2.md"
+git -C "$R" add -A
+run_guard RATCHET_RAISE=
+[ "$RC" -ne 0 ] && case "$OUT" in *"changelog.d/loose.md is not a changelog fragment"*) true ;; *) false ;; esac \
+  && ok "a fragment outside a section directory fails, naming it" \
+  || bad "a fragment outside a section directory fails, naming it" "rc=$RC out=$OUT"
+case "$OUT" in *"changelog.d/bogus/ken-2.md is not a changelog fragment"*) ok "an unknown section directory fails, naming it" ;;
+  *) bad "an unknown section directory fails, naming it" "$OUT" ;; esac
+rm -f "$R/changelog.d/loose.md"
+rm -rf "${R:?}/changelog.d/bogus"
+printf 'Not a list item.\n' >"$R/changelog.d/fixed/ken-3.md"
+git -C "$R" add -A
+run_guard RATCHET_RAISE=
+[ "$RC" -ne 0 ] && case "$OUT" in *"changelog.d/fixed/ken-3.md is not the list item it becomes"*) true ;; *) false ;; esac \
+  && ok "a fragment that opens with prose fails, naming it" \
+  || bad "a fragment that opens with prose fails, naming it" "rc=$RC out=$OUT"
+rm -f "$R/changelog.d/fixed/ken-3.md"
+if [ "$(id -u)" -ne 0 ]; then
+  chmod 000 "$R/changelog.d/fixed/ken-1.md"
+  run_guard RATCHET_RAISE=
+  chmod 644 "$R/changelog.d/fixed/ken-1.md"
+  [ "$RC" -ne 0 ] && case "$OUT" in *"changelog.d/fixed/ken-1.md is unreadable — the fragment shape check could not run"*) true ;; *) false ;; esac \
+    && ok "an unreadable fragment fails closed, naming the check that could not run" \
+    || bad "an unreadable fragment fails closed, naming the check that could not run" "rc=$RC out=$OUT"
+  case "$OUT" in *"changelog.d/fixed/ken-1.md is unreadable — the entry-length check could not run"*) ok "the entry-length check reports it too" ;;
+    *) bad "the entry-length check reports it too" "$OUT" ;; esac
+fi
+printf '# changelog.d\n\nNot a list item either.\n' >"$R/changelog.d/README.md"
+git -C "$R" add -A
+run_guard RATCHET_RAISE=
+[ "$RC" -eq 0 ] && ok "the README is not judged as a fragment" \
+  || bad "the README is not judged as a fragment" "rc=$RC out=$OUT"
+
+echo "=== the [Unreleased] list is the collator's to write ==="
+git -C "$R" commit -q -m "chore: land the changelog"
+printf '# Changelog\n\n## [Unreleased]\n\n### Fixed\n\n- A three-line entry\n  second line\n  third line.\n- One line.\n- A hand-written line.\n' >"$R/CHANGELOG.md"
+git -C "$R" add -A
+run_guard RATCHET_RAISE=
+[ "$RC" -ne 0 ] && case "$OUT" in *"gained lines under [Unreleased]"*"- A hand-written line."*) true ;; *) false ;; esac \
+  && ok "a hand-written [Unreleased] line fails, quoting the line" \
+  || bad "a hand-written [Unreleased] line fails, quoting the line" "rc=$RC out=$OUT"
+run_guard RATCHET_RAISE= CHANGELOG_COLLATE=1
+[ "$RC" -eq 0 ] && ok "CHANGELOG_COLLATE=1 declares the collator's write" \
+  || bad "CHANGELOG_COLLATE=1 declares the collator's write" "rc=$RC out=$OUT"
+printf '# Changelog\n\n## [Unreleased]\n\n## [1.0.0] - 2026-01-01\n\n### Fixed\n\n- A three-line entry\n  second line\n  third line.\n- One line.\n' >"$R/CHANGELOG.md"
+git -C "$R" add -A
+run_guard RATCHET_RAISE=
+[ "$RC" -eq 0 ] && ok "rotating [Unreleased] into a released version adds no line" \
+  || bad "rotating [Unreleased] into a released version adds no line" "rc=$RC out=$OUT"
+if [ "$(id -u)" -ne 0 ]; then
+  chmod 000 "$R/CHANGELOG.md"
+  run_guard RATCHET_RAISE=
+  chmod 644 "$R/CHANGELOG.md"
+  [ "$RC" -ne 0 ] && case "$OUT" in *"could not be compared against HEAD"*) true ;; *) false ;; esac \
+    && ok "an unreadable CHANGELOG fails the [Unreleased] rule closed too" \
+    || bad "an unreadable CHANGELOG fails the [Unreleased] rule closed too" "rc=$RC out=$OUT"
 fi
 
 echo "=== a test row RATCHET_RAISE declares is still refused by the ratchet ==="

--- a/tools/tests/guard.test.sh
+++ b/tools/tests/guard.test.sh
@@ -153,6 +153,25 @@ git -C "$R" add -A
 run_guard RATCHET_RAISE=
 [ "$RC" -eq 0 ] && ok "a three-line fragment passes" \
   || bad "a three-line fragment passes" "rc=$RC out=$OUT"
+# Keep a Changelog's six sections, written out rather than read from the
+# accepted set: a list derived from the subject cannot catch that set being
+# narrowed, which is the way this rule fails silently.
+SECTION_DIRS="added changed deprecated removed fixed security"
+for s in $SECTION_DIRS; do
+  mkdir -p "$R/changelog.d/$s"
+  printf -- '- An entry filed under %s.\n' "$s" >"$R/changelog.d/$s/ken-2.md"
+done
+git -C "$R" add -A
+run_guard RATCHET_RAISE=
+[ "$RC" -eq 0 ] && ok "a fragment under each of the six sections passes" \
+  || bad "a fragment under each of the six sections passes" "rc=$RC out=$OUT"
+for s in $SECTION_DIRS; do
+  rm -f "$R/changelog.d/$s/ken-2.md"
+  rmdir "$R/changelog.d/$s" 2>/dev/null || true
+done
+mkdir -p "$R/changelog.d/fixed"
+printf -- '- A three-line fragment\n  second line\n  third line.\n' >"$R/changelog.d/fixed/ken-1.md"
+git -C "$R" add -A
 
 echo "=== the fragment format is the collator's verdict, carried by guard ==="
 # Guard owns the entry-length rule, which judges CHANGELOG.md too; the format
@@ -208,6 +227,22 @@ if [ "$(id -u)" -ne 0 ]; then
     && ok "an unreadable CHANGELOG fails the [Unreleased] rule closed too" \
     || bad "an unreadable CHANGELOG fails the [Unreleased] rule closed too" "rc=$RC out=$OUT"
 fi
+# Blank lines are not content. Padding alone cannot refuse — a blank-only
+# result strips to the empty string before the test that quotes it — so what
+# keeping blanks out of the compared sets holds is the diagnostic: the lines
+# it quotes are the lines an author has to act on.
+printf '# Changelog\n\n## [Unreleased]\n\n### Fixed\n\n- One line.\n\n- Another line.\n\n## [1.0.0] - 2026-01-01\n' >"$R/CHANGELOG.md"
+git -C "$R" add -A
+git -C "$R" commit -q -m "chore: rotate the changelog"
+printf '# Changelog\n\n## [Unreleased]\n\n### Fixed\n\n- One line.\n\n\n\n- Another line.\n\n- A real new line.\n\n## [1.0.0] - 2026-01-01\n' >"$R/CHANGELOG.md"
+git -C "$R" add -A
+run_guard RATCHET_RAISE=
+[ "$RC" -ne 0 ] && case "$OUT" in *"gained lines under [Unreleased]"*"- A real new line."*) true ;; *) false ;; esac \
+  && ok "an entry added beside blank padding is refused, quoting the entry" \
+  || bad "an entry added beside blank padding is refused, quoting the entry" "rc=$RC out=$OUT"
+[ "$(printf '%s\n' "$OUT" | grep -c '^  $')" -eq 0 ] \
+  && ok "the padding itself is not quoted back as a gained line" \
+  || bad "the padding itself is not quoted back as a gained line" "$OUT"
 
 echo "=== the [Unreleased] verdict does not turn on the caller's collation ==="
 # comm and its inputs must agree on one order. These lines sort one way by

--- a/tools/tests/guard.test.sh
+++ b/tools/tests/guard.test.sh
@@ -2,8 +2,9 @@
 # Pins what tools/guard still judges once the shipped packages judge the
 # rest: the size-ratchet baseline may only tighten unless RATCHET_RAISE=1
 # says otherwise, a CHANGELOG entry runs at most three lines wherever it is
-# written, a changelog.d fragment is named and shaped so the collator finds
-# it, and the [Unreleased] list gains lines only under CHANGELOG_COLLATE=1.
+# written, the fragment format the collator refuses is refused at commit too,
+# and the [Unreleased] list gains lines only under CHANGELOG_COLLATE=1 — a
+# verdict that must not turn on the caller's collation.
 # It also pins the absence — a line cap, a work marker, a blanket allow and an
 # oversized file all pass here, because size-ratchet, todo-ban,
 # suppression-ban and byte-ceiling are the judges of those. The failing
@@ -37,6 +38,9 @@ git -C "$R" config core.hooksPath "$TMP/nohooks"
 echo '# fixture' >"$R/AGENTS.md"
 ln -s ../AGENTS.md "$R/.claude/CLAUDE.md"
 : >"$R/tools/size-ratchet-baseline.tsv"
+# The fragment format is changelog-collate's verdict and guard runs it, so
+# the fixture carries the collator the way a clone does.
+cp "$(cd "$TEST_DIR/.." && pwd)/changelog-collate" "$R/tools/changelog-collate"
 git -C "$R" add -A
 git -C "$R" commit -q -m fixture
 
@@ -150,36 +154,30 @@ run_guard RATCHET_RAISE=
 [ "$RC" -eq 0 ] && ok "a three-line fragment passes" \
   || bad "a three-line fragment passes" "rc=$RC out=$OUT"
 
-echo "=== a fragment is filed where the collator looks for it ==="
+echo "=== the fragment format is the collator's verdict, carried by guard ==="
+# Guard owns the entry-length rule, which judges CHANGELOG.md too; the format
+# is changelog-collate --check, so one tool answers what a fragment is.
 printf -- '- Stray.\n' >"$R/changelog.d/loose.md"
-mkdir -p "$R/changelog.d/bogus"
-printf -- '- Wrong section.\n' >"$R/changelog.d/bogus/ken-2.md"
 git -C "$R" add -A
 run_guard RATCHET_RAISE=
-[ "$RC" -ne 0 ] && case "$OUT" in *"changelog.d/loose.md is not a changelog fragment"*) true ;; *) false ;; esac \
-  && ok "a fragment outside a section directory fails, naming it" \
-  || bad "a fragment outside a section directory fails, naming it" "rc=$RC out=$OUT"
-case "$OUT" in *"changelog.d/bogus/ken-2.md is not a changelog fragment"*) ok "an unknown section directory fails, naming it" ;;
-  *) bad "an unknown section directory fails, naming it" "$OUT" ;; esac
+[ "$RC" -ne 0 ] && case "$OUT" in *"the collator refuses"*"changelog.d/loose.md is not a changelog fragment"*) true ;; *) false ;; esac \
+  && ok "guard carries the collator's refusal, naming the file" \
+  || bad "guard carries the collator's refusal, naming the file" "rc=$RC out=$OUT"
 rm -f "$R/changelog.d/loose.md"
-rm -rf "${R:?}/changelog.d/bogus"
-printf 'Not a list item.\n' >"$R/changelog.d/fixed/ken-3.md"
+printf -- '- One entry.\n- A second entry.\n' >"$R/changelog.d/fixed/ken-3.md"
 git -C "$R" add -A
 run_guard RATCHET_RAISE=
-[ "$RC" -ne 0 ] && case "$OUT" in *"changelog.d/fixed/ken-3.md is not the list item it becomes"*) true ;; *) false ;; esac \
-  && ok "a fragment that opens with prose fails, naming it" \
-  || bad "a fragment that opens with prose fails, naming it" "rc=$RC out=$OUT"
+[ "$RC" -ne 0 ] && case "$OUT" in *"changelog.d/fixed/ken-3.md holds more than the one entry"*) true ;; *) false ;; esac \
+  && ok "a two-entry fragment is refused at commit, not at release" \
+  || bad "a two-entry fragment is refused at commit, not at release" "rc=$RC out=$OUT"
 rm -f "$R/changelog.d/fixed/ken-3.md"
-if [ "$(id -u)" -ne 0 ]; then
-  chmod 000 "$R/changelog.d/fixed/ken-1.md"
-  run_guard RATCHET_RAISE=
-  chmod 644 "$R/changelog.d/fixed/ken-1.md"
-  [ "$RC" -ne 0 ] && case "$OUT" in *"changelog.d/fixed/ken-1.md is unreadable — the fragment shape check could not run"*) true ;; *) false ;; esac \
-    && ok "an unreadable fragment fails closed, naming the check that could not run" \
-    || bad "an unreadable fragment fails closed, naming the check that could not run" "rc=$RC out=$OUT"
-  case "$OUT" in *"changelog.d/fixed/ken-1.md is unreadable — the entry-length check could not run"*) ok "the entry-length check reports it too" ;;
-    *) bad "the entry-length check reports it too" "$OUT" ;; esac
-fi
+git -C "$R" add -A
+mv "$R/tools/changelog-collate" "$R/tools/changelog-collate.away"
+run_guard RATCHET_RAISE=
+mv "$R/tools/changelog-collate.away" "$R/tools/changelog-collate"
+[ "$RC" -ne 0 ] && case "$OUT" in *"tools/changelog-collate is missing or not executable"*) true ;; *) false ;; esac \
+  && ok "a missing collator fails closed, naming the check that could not run" \
+  || bad "a missing collator fails closed, naming the check that could not run" "rc=$RC out=$OUT"
 printf '# changelog.d\n\nNot a list item either.\n' >"$R/changelog.d/README.md"
 git -C "$R" add -A
 run_guard RATCHET_RAISE=
@@ -210,6 +208,55 @@ if [ "$(id -u)" -ne 0 ]; then
     && ok "an unreadable CHANGELOG fails the [Unreleased] rule closed too" \
     || bad "an unreadable CHANGELOG fails the [Unreleased] rule closed too" "rc=$RC out=$OUT"
 fi
+
+echo "=== the [Unreleased] verdict does not turn on the caller's collation ==="
+# comm and its inputs must agree on one order. These lines sort one way by
+# byte and another under a locale that folds punctuation, so a mismatch makes
+# comm call a sorted file unsorted and name lines nobody wrote.
+UR='# Changelog\n\n## [Unreleased]\n\n### Fixed\n\n- **Breaking:** alpha.\n- plain beta.\n- `code` gamma.\n- Zeta delta.\n'
+printf "$UR" >"$R/CHANGELOG.md"
+git -C "$R" add -A
+git -C "$R" commit -q -m "chore: a changelog that sorts two ways"
+# The locale is discovered from the file under test: any installed one whose
+# order over these very lines differs from byte order will do.
+COLLATE_LOCALE=""
+for cand in $(locale -a 2>/dev/null); do
+  case "$cand" in C | C.* | POSIX) continue ;; esac
+  LC_ALL="$cand" sort "$R/CHANGELOG.md" >"$TMP/loc" 2>/dev/null || continue
+  LC_ALL=C sort "$R/CHANGELOG.md" >"$TMP/byte"
+  cmp -s "$TMP/loc" "$TMP/byte" && continue
+  COLLATE_LOCALE="$cand"
+  break
+done
+if [ -z "$COLLATE_LOCALE" ]; then
+  echo "  note  no installed locale orders these lines differently from C — the collation pair cannot run here"
+else
+  printf '# Changelog\n\n## [Unreleased]\n\n### Fixed\n\n- **Breaking:** alpha.\n- plain beta.\n- `code` gamma.\n' >"$R/CHANGELOG.md"
+  git -C "$R" add -A
+  run_guard RATCHET_RAISE= LC_ALL="$COLLATE_LOCALE"
+  [ "$RC" -eq 0 ] && ok "a deletion-only edit passes under $COLLATE_LOCALE" \
+    || bad "a deletion-only edit passes under $COLLATE_LOCALE" "rc=$RC out=$OUT"
+  printf "$UR"'- A hand-written line.\n' >"$R/CHANGELOG.md"
+  git -C "$R" add -A
+  run_guard RATCHET_RAISE= LC_ALL="$COLLATE_LOCALE"
+  [ "$RC" -ne 0 ] && case "$OUT" in *"gained lines under [Unreleased]"*"- A hand-written line."*) true ;; *) false ;; esac \
+    && ok "under $COLLATE_LOCALE the one added line is the only one named" \
+    || bad "under $COLLATE_LOCALE the one added line is the only one named" "rc=$RC out=$OUT"
+  case "$OUT" in *Breaking*) bad "no untouched line is named as gained" "$OUT" ;; *) ok "no untouched line is named as gained" ;; esac
+fi
+
+echo "=== a second copy of an entry is a line the tree gained ==="
+printf "$UR"'- Zeta delta.\n' >"$R/CHANGELOG.md"
+git -C "$R" add -A
+run_guard RATCHET_RAISE=
+[ "$RC" -ne 0 ] && case "$OUT" in *"gained lines under [Unreleased]"*"- Zeta delta."*) true ;; *) false ;; esac \
+  && ok "a duplicated [Unreleased] line fails, quoting it" \
+  || bad "a duplicated [Unreleased] line fails, quoting it" "rc=$RC out=$OUT"
+printf "$UR" >"$R/CHANGELOG.md"
+git -C "$R" add -A
+run_guard RATCHET_RAISE=
+[ "$RC" -eq 0 ] && ok "control: the same file with no duplicate passes" \
+  || bad "control: the same file with no duplicate passes" "rc=$RC out=$OUT"
 
 echo "=== a test row RATCHET_RAISE declares is still refused by the ratchet ==="
 # Guard judges the declaration; the ratchet judges the row. A test is never

--- a/tools/tests/setup.test.sh
+++ b/tools/tests/setup.test.sh
@@ -90,9 +90,26 @@ printf 'fn main() {}\n' >"$R/crates/a.rs"
 git -C "$R" add -A
 RC=0
 OUT="$(git -C "$R" commit -m "feat: a crate change" 2>&1)" || RC=$?
-[ "$RC" -ne 0 ] && case "$OUT" in *"without a CHANGELOG.md entry"*) true ;; *) false ;; esac \
+[ "$RC" -ne 0 ] && case "$OUT" in *"without a changelog entry"*) true ;; *) false ;; esac \
   && ok "a crates/ change with no changelog entry is refused by the repo lane" \
   || bad "a crates/ change with no changelog entry is refused by the repo lane" "rc=$RC out=$OUT"
+mkdir -p "$R/changelog.d"
+printf '# changelog.d\n' >"$R/changelog.d/README.md"
+git -C "$R" add -A
+RC=0
+OUT="$(git -C "$R" commit -m "feat: a crate change" 2>&1)" || RC=$?
+[ "$RC" -ne 0 ] && case "$OUT" in *"without a changelog entry"*) true ;; *) false ;; esac \
+  && ok "changelog.d's own README does not stand in for a fragment" \
+  || bad "changelog.d's own README does not stand in for a fragment" "rc=$RC out=$OUT"
+mkdir -p "$R/changelog.d/fixed"
+printf -- '- A crate fix consumers see.\n' >"$R/changelog.d/fixed/ken-1.md"
+git -C "$R" add -A
+RC=0
+OUT="$(git -C "$R" commit -m "feat: a crate change" 2>&1)" || RC=$?
+[ "$RC" -eq 0 ] && ok "a changelog.d fragment satisfies the rule" \
+  || bad "a changelog.d fragment satisfies the rule" "rc=$RC out=$OUT"
+printf 'fn other() {}\n' >"$R/crates/b.rs"
+git -C "$R" add -A
 RC=0
 OUT="$(git -C "$R" commit -m "feat: a crate change [no-changelog]" 2>&1)" || RC=$?
 [ "$RC" -eq 0 ] && ok "[no-changelog] in the subject releases it" \
@@ -160,7 +177,7 @@ printf 'fn main() {}\n' >"$R/crates/a.rs"
 git -C "$R" add -A
 RC=0
 OUT="$(git -C "$R" commit -m "feat: a crate change" 2>&1)" || RC=$?
-[ "$RC" -ne 0 ] && case "$OUT" in *"without a CHANGELOG.md entry"*) true ;; *) false ;; esac \
+[ "$RC" -ne 0 ] && case "$OUT" in *"without a changelog entry"*) true ;; *) false ;; esac \
   && ok "the changelog rule still runs, though the hook body exits before the end" \
   || bad "the changelog rule still runs, though the hook body exits before the end" "rc=$RC out=$OUT"
 RC=0

--- a/tools/tests/setup.test.sh
+++ b/tools/tests/setup.test.sh
@@ -114,6 +114,20 @@ RC=0
 OUT="$(git -C "$R" commit -m "feat: a crate change [no-changelog]" 2>&1)" || RC=$?
 [ "$RC" -eq 0 ] && ok "[no-changelog] in the subject releases it" \
   || bad "[no-changelog] in the subject releases it" "rc=$RC out=$OUT"
+printf 'fn third() {}\n' >"$R/crates/c.rs"
+rm -f "$R/changelog.d/fixed/ken-1.md"
+git -C "$R" add -A
+RC=0
+OUT="$(git -C "$R" commit -m "feat: a crate change" 2>&1)" || RC=$?
+[ "$RC" -ne 0 ] && case "$OUT" in *"without a changelog entry"*) true ;; *) false ;; esac \
+  && ok "deleting a fragment is not writing one" \
+  || bad "deleting a fragment is not writing one" "rc=$RC out=$OUT"
+printf '# Changelog\n\n## [Unreleased]\n' >"$R/CHANGELOG.md"
+git -C "$R" add -A
+RC=0
+OUT="$(git -C "$R" commit -m "chore(release): the collated changelog" 2>&1)" || RC=$?
+[ "$RC" -eq 0 ] && ok "CHANGELOG.md still counts, the way the release commit needs" \
+  || bad "CHANGELOG.md still counts, the way the release commit needs" "rc=$RC out=$OUT"
 
 echo "=== this repo caps the subject; git's own subjects are exempt ==="
 LONG="docs: $(printf 'x%.0s' $(seq 1 70))" # 76 characters


### PR DESCRIPTION
## Summary

- A CHANGELOG entry is now a file: `changelog.d/<section>/<name>.md` holding the Markdown list item it becomes. Two branches never write the same `CHANGELOG.md` line, so the merge queue stops ejecting the trailing one.
- `tools/changelog-collate` folds every fragment git carries into `## [Unreleased]` under its section heading, in Keep a Changelog order and filename order, then deletes the fragments. `--check` judges the fragments and writes nothing; `tools/guard` runs that mode, so the format has one judge.
- `tools/guard` refuses a line under `## [Unreleased]` that HEAD does not already carry, `CHANGELOG_COLLATE=1` declares a deliberate write, and `tools/commit-msg` takes a staged fragment as the entry a `crates/` or `ui/` change needs.

The 174 entries already under `## [Unreleased]` stay where they are; the next release consumes them and nothing migrates.

## Completed Issues

- Closes KEN-624 - Top-of-section CHANGELOG entries make concurrent PRs unmergeable in the queue

## Test Plan

- `tools/tests/changelog-collate.test.sh` — 51 cases: the six sections fold in one run against a pinned expected file, a fragment that is not exactly one list item is refused before any write, an undeletable fragment names every survivor, a failing `cp` or `mv` leaves `CHANGELOG.md` byte-identical with no replacement file behind, the collated file keeps its mode, and an untracked stray under `changelog.d` neither stops the run nor is folded.
- `tools/tests/guard.test.sh` — 34 cases: a fragment per section passes, the collator's verdict carries through guard, a hand-written `[Unreleased]` line and a duplicated one both fail, a deletion-only edit passes under a locale whose order differs from byte order, and blank padding is not a gained line.
- `tools/tests/setup.test.sh` — 32 cases: a staged fragment satisfies the `crates/`-or-`ui/` rule, deleting one does not, and `CHANGELOG.md` still counts on the release commit.
- `tools/guard` clean on the branch; `preflight --base origin/main` clean.
