### PR TITLE
fix(KEN-718): kendex update verifies the AppImage before writing it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,9 +29,9 @@ an outside contributor.
 - The app says when a release is out and offers the one action that fits how
   it was installed: Update now on a direct install, the package manager's own
   command on a managed one, and release notes when neither applies.
-- `kendex update` brings the desktop app along on a direct install, refusing a
-  download the release signature does not match; on a package-manager install
-  it prints that manager's update command instead of replacing what it does not own.
+- `kendex update` brings the desktop app along on a direct install, and on a
+  package-manager install prints that manager's update command instead of
+  replacing files it does not own.
 - Problems now lists a declared package whose place already holds files
   kendex did not write, with the ways out core reports for it: keep those
   files, or install what kendex.toml asks for and send them to the trash.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,9 +29,9 @@ an outside contributor.
 - The app says when a release is out and offers the one action that fits how
   it was installed: Update now on a direct install, the package manager's own
   command on a managed one, and release notes when neither applies.
-- `kendex update` brings the desktop app along on a direct install, and on a
-  package-manager install prints that manager's update command instead of
-  replacing files it does not own.
+- `kendex update` brings the desktop app along on a direct install, refusing a
+  download the release signature does not match; on a package-manager install
+  it prints that manager's update command instead of replacing what it does not own.
 - Problems now lists a declared package whose place already holds files
   kendex did not write, with the ways out core reports for it: keep those
   files, or install what kendex.toml asks for and send them to the trash.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2250,9 +2250,11 @@ dependencies = [
 name = "kendex-core"
 version = "5.0.1"
 dependencies = [
+ "base64 0.22.1",
  "dirs",
  "fd-lock",
  "keyring",
+ "minisign-verify",
  "rustix",
  "semver",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,6 +33,11 @@ fd-lock = "4"
 rustix = { version = "1", features = ["fs"] }
 unicode-normalization = "0.1"
 semver = "1"
+# The app already verifies its own downloads with these, through
+# tauri-plugin-updater; `kendex update` reaches for them directly so the
+# two delivery paths for one AppImage hold the same bar.
+minisign-verify = "0.2"
+base64 = "0.22"
 
 [workspace.lints.rust]
 unsafe_code = "forbid"

--- a/changelog.d/security/KEN-718.md
+++ b/changelog.d/security/KEN-718.md
@@ -1,0 +1,3 @@
+- `kendex update` verifies the desktop app download against the signature the
+  release publishes for it, and refuses one that does not match rather than
+  installing it. The installed app and the kendex command are left as they were.

--- a/crates/app/tests/tauri_config.rs
+++ b/crates/app/tests/tauri_config.rs
@@ -22,3 +22,15 @@ fn the_window_opens_hidden_so_the_saved_zoom_lands_first() {
     // window would simply never be shown if that default ever changed.
     assert_eq!(window["label"].as_str(), Some("main"));
 }
+
+/// The app's updater reads its key from this file at build time, so the
+/// copy core holds for `kendex update` can only be kept honest by an
+/// assertion. Two keys means one delivery path trusting what the other
+/// would turn away.
+#[test]
+fn the_app_and_the_cli_pin_one_updater_key() {
+    assert_eq!(
+        config()["plugins"]["updater"]["pubkey"].as_str(),
+        Some(kendex_core::update_feed::UPDATER_PUBLIC_KEY)
+    );
+}

--- a/crates/cli/src/commands/update.rs
+++ b/crates/cli/src/commands/update.rs
@@ -6,6 +6,7 @@ use kendex_core::install_channel::{Host, HostProbe, InstallChannel, for_cli};
 use kendex_core::process::Hardened;
 use kendex_core::update_feed::{
     RELEASE_FEED_URL, ReleaseFeed, VersionRelation, app_image_url, release_notes_url,
+    verify_app_image,
 };
 
 use super::{CliResult, out, say};
@@ -152,9 +153,29 @@ fn update_app(env: &Env, latest: &str) -> Result<bool, Box<dyn std::error::Error
     }
     say(&format!("updating the desktop app at {}", path.display()));
     let image = fetch(&url)?;
-    replace_executable(&path, &image)?;
+    // The release job publishes each AppImage beside a minisign signature
+    // over exactly those bytes. One that arrives without a signature, or
+    // with one that does not check out, is refused rather than installed.
+    let signature = fetch(&format!("{url}.sig")).map_err(|why| app_refused(latest, &why))?;
+    install_app_image(&path, &image, &signature).map_err(|why| app_refused(latest, &why))?;
     out(&format!("updated the desktop app to {latest}"));
     Ok(true)
+}
+
+/// Write the app only once its signature checks out, so a download that
+/// fails verification never reaches the installed path.
+fn install_app_image(path: &Path, image: &[u8], signature: &[u8]) -> Result<(), String> {
+    verify_app_image(image, signature).map_err(|error| error.to_string())?;
+    replace_executable(path, image).map_err(|error| error.to_string())
+}
+
+/// What to say when the app half refused before it wrote anything. Same
+/// shape as the unwritable-directory branch: the reason, then what the next
+/// run does with it.
+fn app_refused(latest: &str, why: &str) -> String {
+    format!(
+        "the desktop app was not brought to {latest}: {why}; nothing was updated, so kendex update will try both halves again"
+    )
 }
 
 /// Write `bytes` over an executable that may be running: the replacement
@@ -239,6 +260,23 @@ mod tests {
 
         let neither = command_failure("5.1.0", false, &error());
         assert!(!neither.contains("desktop app"), "{neither}");
+    }
+
+    /// Verification decides whether the download is ever written: an app
+    /// image whose signature does not check out leaves the installed one
+    /// exactly as it was, with no staged file beside it either.
+    #[test]
+    fn an_app_image_that_fails_verification_is_never_written() {
+        let dir = tempfile::tempdir().unwrap();
+        let installed = dir.path().join("kendex.AppImage");
+        std::fs::write(&installed, b"the app already here").unwrap();
+
+        let error =
+            install_app_image(&installed, b"a replacement", b"not a signature").unwrap_err();
+
+        assert!(error.contains("does not verify"), "{error}");
+        assert_eq!(std::fs::read(&installed).unwrap(), b"the app already here");
+        assert!(!staged_path(&installed).exists());
     }
 
     #[test]

--- a/crates/cli/src/commands/update.rs
+++ b/crates/cli/src/commands/update.rs
@@ -5,8 +5,8 @@ use kendex_core::env::Env;
 use kendex_core::install_channel::{Host, HostProbe, InstallChannel, for_cli};
 use kendex_core::process::Hardened;
 use kendex_core::update_feed::{
-    RELEASE_FEED_URL, ReleaseFeed, VersionRelation, app_image_url, release_notes_url,
-    verify_app_image,
+    RELEASE_FEED_URL, ReleaseFeed, UPDATER_PUBLIC_KEY, VersionRelation, app_image_signature_url,
+    app_image_url, release_notes_url, verify_signature,
 };
 
 use super::{CliResult, out, say};
@@ -136,7 +136,11 @@ fn update_app(env: &Env, latest: &str) -> Result<bool, Box<dyn std::error::Error
     // Only the Linux AppImage is an install this command made. Every other
     // platform's app arrives and updates by its own route, and the CLI says
     // nothing about one it did not put there.
-    let Some(url) = app_image_url(latest, target_triple())? else {
+    let target = target_triple();
+    let (Some(url), Some(signature_url)) = (
+        app_image_url(latest, target)?,
+        app_image_signature_url(latest, target)?,
+    ) else {
         return Ok(false);
     };
     let path = env.app_image_file();
@@ -145,9 +149,9 @@ fn update_app(env: &Env, latest: &str) -> Result<bool, Box<dyn std::error::Error
         return Ok(false);
     }
     if !Host.replaceable(&path) {
-        return Err(format!(
-            "the desktop app at {} cannot be replaced, because that directory refuses writes; nothing was updated, so kendex update will try both halves again",
-            path.display()
+        return Err(app_refused(
+            latest,
+            &format!("the directory holding {} refuses writes", path.display()),
         )
         .into());
     }
@@ -156,22 +160,27 @@ fn update_app(env: &Env, latest: &str) -> Result<bool, Box<dyn std::error::Error
     // The release job publishes each AppImage beside a minisign signature
     // over exactly those bytes. One that arrives without a signature, or
     // with one that does not check out, is refused rather than installed.
-    let signature = fetch(&format!("{url}.sig")).map_err(|why| app_refused(latest, &why))?;
-    install_app_image(&path, &image, &signature).map_err(|why| app_refused(latest, &why))?;
+    let signature = fetch(&signature_url).map_err(|why| app_refused(latest, &why))?;
+    install_app_image(&path, &image, &signature, UPDATER_PUBLIC_KEY)
+        .map_err(|why| app_refused(latest, &why))?;
     out(&format!("updated the desktop app to {latest}"));
     Ok(true)
 }
 
-/// Write the app only once its signature checks out, so a download that
-/// fails verification never reaches the installed path.
-fn install_app_image(path: &Path, image: &[u8], signature: &[u8]) -> Result<(), String> {
-    verify_app_image(image, signature).map_err(|error| error.to_string())?;
+/// Write the app only once `signature` checks out under `public_key`, so a
+/// download that fails verification never reaches the installed path.
+fn install_app_image(
+    path: &Path,
+    image: &[u8],
+    signature: &[u8],
+    public_key: &str,
+) -> Result<(), String> {
+    verify_signature(public_key, image, signature).map_err(|error| error.to_string())?;
     replace_executable(path, image).map_err(|error| error.to_string())
 }
 
-/// What to say when the app half refused before it wrote anything. Same
-/// shape as the unwritable-directory branch: the reason, then what the next
-/// run does with it.
+/// The one sentence both app-half refusals say: the reason, then what the
+/// next run does with it.
 fn app_refused(latest: &str, why: &str) -> String {
     format!(
         "the desktop app was not brought to {latest}: {why}; nothing was updated, so kendex update will try both halves again"
@@ -183,13 +192,26 @@ fn app_refused(latest: &str, why: &str) -> String {
 /// OS allows on a running file.
 fn replace_executable(path: &Path, bytes: &[u8]) -> std::io::Result<()> {
     let staged = staged_path(path);
-    std::fs::write(&staged, bytes)?;
+    match stage(&staged, bytes).and_then(|()| std::fs::rename(&staged, path)) {
+        Ok(()) => Ok(()),
+        Err(error) => {
+            // Nobody else writes a file named for this process, so a run
+            // that failed takes its own away instead of leaving one behind
+            // per process id.
+            let _ = std::fs::remove_file(&staged);
+            Err(error)
+        }
+    }
+}
+
+fn stage(staged: &Path, bytes: &[u8]) -> std::io::Result<()> {
+    std::fs::write(staged, bytes)?;
     #[cfg(unix)]
     {
         use std::os::unix::fs::PermissionsExt;
-        std::fs::set_permissions(&staged, std::fs::Permissions::from_mode(0o755))?;
+        std::fs::set_permissions(staged, std::fs::Permissions::from_mode(0o755))?;
     }
-    std::fs::rename(&staged, path)
+    Ok(())
 }
 
 fn missing_asset_message(
@@ -214,12 +236,15 @@ fn missing_asset_message(
     })
 }
 
+/// The process id keeps two concurrent runs off one staged file. Without
+/// it they share a name, and what the rename installs is whatever the other
+/// run last wrote there rather than the bytes this one verified.
 fn staged_path(current: &std::path::Path) -> PathBuf {
     let mut name = current
         .file_name()
         .map(|n| n.to_string_lossy().into_owned())
         .unwrap_or_else(|| "kendex".to_owned());
-    name.push_str(".update");
+    name.push_str(&format!(".update.{}", std::process::id()));
     current.with_file_name(name)
 }
 
@@ -262,21 +287,99 @@ mod tests {
         assert!(!neither.contains("desktop app"), "{neither}");
     }
 
-    /// Verification decides whether the download is ever written: an app
-    /// image whose signature does not check out leaves the installed one
-    /// exactly as it was, with no staged file beside it either.
+    /// A throwaway minisign keypair signing `SIGNED_IMAGE`, so the admitted
+    /// arm runs the real check rather than a stub standing in for it.
+    const TEST_KEY: &str = "dW50cnVzdGVkIGNvbW1lbnQ6IG1pbmlzaWduIHB1YmxpYyBrZXk6IDk0QUI0NzI3RTVDMTVCODEKUldTQlc4SGxKMGVybEhxeFovbTJ3U1phMng4aE9VTXByV09pUVRFVFNKbFZ5aWxtUTAvVGgyWEwK";
+    const TEST_SIGNATURE: &str = "dW50cnVzdGVkIGNvbW1lbnQ6IHNpZ25hdHVyZSBmcm9tIHJzaWduIHNlY3JldCBrZXkKUlVTQlc4SGxKMGVybElTMUxrbkMyQ0tBWGlnejY1S0xLekovK0tBYllNdkdJTVU0bitTSjRBSCt1RlpwWnZkRHNKcWFTSHVoeStIQkpyVDlOaVRIMmROWVVSb21mMVBVRmd3PQp0cnVzdGVkIGNvbW1lbnQ6IGtlbmRleCB0ZXN0CnpKSnpYYnBtODZYRW40eHgxSTVkeG5YdktxT0k5ZXdmSkEyMkdtZXpreGgwbUNJZysybkJ2cGowUXZ6N2c3RHA4TEZBVXVBQUVMRExuUzFuaVpsaUF3PT0K";
+    const SIGNED_IMAGE: &[u8] = b"kendex AppImage bytes";
+
+    /// A path with something already installed at it, so every arm can say
+    /// whether the bytes there moved.
+    fn installed_app(dir: &tempfile::TempDir) -> PathBuf {
+        let path = dir.path().join("kendex.AppImage");
+        std::fs::write(&path, b"the app already here").unwrap();
+        path
+    }
+
+    /// The admitted arm: a signature that checks out puts the download in
+    /// place and leaves no staged file behind.
+    #[test]
+    fn an_app_image_whose_signature_checks_out_is_written() {
+        let dir = tempfile::tempdir().unwrap();
+        let installed = installed_app(&dir);
+
+        install_app_image(
+            &installed,
+            SIGNED_IMAGE,
+            TEST_SIGNATURE.as_bytes(),
+            TEST_KEY,
+        )
+        .unwrap();
+
+        assert_eq!(std::fs::read(&installed).unwrap(), SIGNED_IMAGE);
+        assert!(!staged_path(&installed).exists());
+    }
+
+    /// The refused arm, driven by both shapes a bad download takes: bytes
+    /// the signature does not cover, and a body that is no signature at
+    /// all. Either way the installed app is exactly as it was.
     #[test]
     fn an_app_image_that_fails_verification_is_never_written() {
         let dir = tempfile::tempdir().unwrap();
-        let installed = dir.path().join("kendex.AppImage");
-        std::fs::write(&installed, b"the app already here").unwrap();
+        let installed = installed_app(&dir);
 
-        let error =
-            install_app_image(&installed, b"a replacement", b"not a signature").unwrap_err();
+        let tampered =
+            install_app_image(&installed, b"tampered", TEST_SIGNATURE.as_bytes(), TEST_KEY)
+                .unwrap_err();
+        assert!(
+            tampered.contains("signature verification failed"),
+            "{tampered}"
+        );
 
-        assert!(error.contains("does not verify"), "{error}");
+        let malformed =
+            install_app_image(&installed, SIGNED_IMAGE, b"not a signature", TEST_KEY).unwrap_err();
+        assert!(malformed.contains("not base64"), "{malformed}");
+
         assert_eq!(std::fs::read(&installed).unwrap(), b"the app already here");
         assert!(!staged_path(&installed).exists());
+    }
+
+    /// Two runs sharing one staged path would each rename the other's bytes
+    /// into place, so the name carries the process id. It stays a sibling
+    /// of the target, since a rename cannot cross filesystems.
+    #[test]
+    fn the_staged_file_is_a_sibling_named_for_this_process() {
+        let target = Path::new("/opt/kendex/kendex.AppImage");
+        let staged = staged_path(target);
+        assert_eq!(staged.parent(), target.parent());
+        let suffix = format!(".update.{}", std::process::id());
+        assert!(
+            staged.to_string_lossy().ends_with(&suffix),
+            "{}",
+            staged.display()
+        );
+    }
+
+    /// A run whose rename cannot land takes its own staged file away, or
+    /// the directory collects one per process id that ever tried.
+    #[test]
+    fn a_replacement_that_cannot_land_leaves_no_staged_file() {
+        let dir = tempfile::tempdir().unwrap();
+        let target = dir.path().join("kendex.AppImage");
+        std::fs::create_dir(&target).unwrap();
+
+        assert!(replace_executable(&target, b"bytes").is_err());
+        assert!(!staged_path(&target).exists());
+    }
+
+    /// Both app-half refusals promise the same thing, so the sentence is
+    /// asserted where it is written rather than at each caller.
+    #[test]
+    fn a_refused_app_half_names_the_release_the_reason_and_the_retry() {
+        let said = app_refused("5.1.0", "the directory holding /opt/kendex refuses writes");
+        assert!(said.contains("5.1.0"), "{said}");
+        assert!(said.contains("refuses writes"), "{said}");
+        assert!(said.contains("nothing was updated"), "{said}");
     }
 
     #[test]

--- a/crates/cli/tests/release_workflow.rs
+++ b/crates/cli/tests/release_workflow.rs
@@ -192,6 +192,30 @@ fn the_manifest_pairs_every_signature_with_the_artifact_it_signs() {
     }
 }
 
+/// `kendex update` fetches the AppImage's signature by appending `.sig` to
+/// the download URL core builds, so that URL has to name the artifact a tag
+/// run actually signs. A rename on either side leaves the app half of the
+/// command fetching a file no release carries.
+#[test]
+fn the_appimage_url_core_builds_is_the_artifact_the_release_signs() {
+    let base = "https://github.com/vanillagreencom/kendex/releases/download/v5.1.0";
+    for (platform, target) in [
+        ("linux-x86_64", "x86_64-unknown-linux-gnu"),
+        ("linux-aarch64", "aarch64-unknown-linux-gnu"),
+    ] {
+        let artifact = SIGNED_ARTIFACTS
+            .iter()
+            .find(|(key, _)| *key == platform)
+            .map(|(_, file)| *file)
+            .unwrap_or_default();
+        assert_eq!(
+            kendex_core::update_feed::app_image_url("5.1.0", target).unwrap_or_default(),
+            Some(format!("{base}/{artifact}")),
+            "{platform}"
+        );
+    }
+}
+
 /// Tauri v2 signs the AppImage itself. The `.AppImage.tar.gz` shape belongs
 /// to the deprecated v1-compatible updater, and looking for it leaves Linux
 /// out of the manifest with the job still green.

--- a/crates/cli/tests/release_workflow.rs
+++ b/crates/cli/tests/release_workflow.rs
@@ -192,12 +192,13 @@ fn the_manifest_pairs_every_signature_with_the_artifact_it_signs() {
     }
 }
 
-/// `kendex update` fetches the AppImage's signature by appending `.sig` to
-/// the download URL core builds, so that URL has to name the artifact a tag
-/// run actually signs. A rename on either side leaves the app half of the
-/// command fetching a file no release carries.
+/// `kendex update` fetches both of these by name, so both have to be files
+/// a tag run actually publishes: the AppImage the manifest step names, and
+/// the `.sig` beside it that its `kendex_*_amd64.AppImage.sig` glob matches.
+/// A rename on either side is first seen by a user whose update fails after
+/// the release shipped, because release.yml runs on tags only.
 #[test]
-fn the_appimage_url_core_builds_is_the_artifact_the_release_signs() {
+fn the_urls_core_builds_are_the_artifact_the_release_signs_and_its_signature() {
     let base = "https://github.com/vanillagreencom/kendex/releases/download/v5.1.0";
     for (platform, target) in [
         ("linux-x86_64", "x86_64-unknown-linux-gnu"),
@@ -211,6 +212,11 @@ fn the_appimage_url_core_builds_is_the_artifact_the_release_signs() {
         assert_eq!(
             kendex_core::update_feed::app_image_url("5.1.0", target).unwrap_or_default(),
             Some(format!("{base}/{artifact}")),
+            "{platform}"
+        );
+        assert_eq!(
+            kendex_core::update_feed::app_image_signature_url("5.1.0", target).unwrap_or_default(),
+            Some(format!("{base}/{artifact}.sig")),
             "{platform}"
         );
     }

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -19,6 +19,8 @@ unicode-normalization.workspace = true
 tempfile.workspace = true
 keyring.workspace = true
 semver.workspace = true
+minisign-verify.workspace = true
+base64.workspace = true
 
 [target.'cfg(unix)'.dependencies]
 rustix.workspace = true

--- a/crates/core/src/error.rs
+++ b/crates/core/src/error.rs
@@ -400,6 +400,11 @@ pub enum CoreError {
     #[error("the release feed is not valid for this build: {why}")]
     UpdateFeedMalformed { why: String },
 
+    /// A download that does not carry the release's own signature is never
+    /// installed, whatever served it.
+    #[error("the download does not verify under the pinned release key: {why}")]
+    UpdateSignatureRefused { why: String },
+
     /// A guard's configuration is wrong or a measurement could not be
     /// taken — the loud exit-2 state, never a silent pass.
     #[error("{check}: {message}")]

--- a/crates/core/src/update_feed.rs
+++ b/crates/core/src/update_feed.rs
@@ -1,4 +1,5 @@
-//! Strict parsing and version comparison for the public release feed.
+//! Strict parsing and version comparison for the public release feed, and
+//! the pinned key the desktop app download is verified under.
 
 use std::cmp::Ordering;
 use std::collections::BTreeMap;

--- a/crates/core/src/update_feed.rs
+++ b/crates/core/src/update_feed.rs
@@ -145,26 +145,30 @@ pub fn app_image_url(version: &str, target: &str) -> Result<Option<String>> {
     )))
 }
 
-/// Refuse an AppImage that is not the one this release signed. `signature`
-/// is the body of the `<artifact>.AppImage.sig` the release job publishes
-/// beside every AppImage — base64 over a minisign signature file, the same
-/// bytes the app's updater manifest carries inline.
-pub fn verify_app_image(image: &[u8], signature: &[u8]) -> Result<()> {
-    verify_minisign(UPDATER_PUBLIC_KEY, image, signature)
+/// The minisign signature published beside that AppImage. The release job
+/// stages every `<artifact>.sig` tauri produces into the same release, so
+/// the name is the artifact's own with the suffix appended.
+pub fn app_image_signature_url(version: &str, target: &str) -> Result<Option<String>> {
+    Ok(app_image_url(version, target)?.map(|url| format!("{url}.sig")))
 }
 
-/// The key is a parameter so a test can hold a signature it made itself;
-/// every caller passes the pinned key.
-fn verify_minisign(public_key_base64: &str, data: &[u8], signature: &[u8]) -> Result<()> {
-    let key_text = decode_base64("the pinned public key", public_key_base64.as_bytes())?;
+/// Refuse a download that `signature` does not cover under
+/// `public_key_base64`. Both are base64 over a minisign file, the shape
+/// `tauri.conf.json` pins its key in and the release job publishes each
+/// `<artifact>.sig` in. Callers installing a release pass
+/// `UPDATER_PUBLIC_KEY`; the key is an argument so a test can hold a
+/// signature it made itself.
+pub fn verify_signature(public_key_base64: &str, data: &[u8], signature: &[u8]) -> Result<()> {
+    let key_text = decode_base64("the public key", public_key_base64.as_bytes())?;
     let key = PublicKey::decode(&key_text)
-        .map_err(|error| refused(format!("the pinned public key is not minisign: {error}")))?;
+        .map_err(|error| refused(format!("the public key is not minisign: {error}")))?;
     let signature_text = decode_base64("the signature", signature)?;
     let signature = Signature::decode(&signature_text)
         .map_err(|error| refused(format!("the signature is not minisign: {error}")))?;
     // Legacy signatures are accepted because the app's updater accepts them
-    // under this same key; a narrower rule here would put one artifact
-    // behind two bars again, which is what this shares a key to avoid.
+    // under this same key: tauri-plugin-updater 2.10.1 src/updater.rs:1461
+    // passes true here. A narrower rule would put one artifact behind two
+    // bars again, which is what sharing the key avoids.
     key.verify(data, &signature, true)
         .map_err(|error| refused(error.to_string()))
 }
@@ -221,9 +225,9 @@ mod tests {
 
     #[test]
     fn a_signature_over_these_bytes_verifies_and_one_over_any_other_does_not() {
-        assert!(verify_minisign(TEST_KEY, SIGNED_IMAGE, TEST_SIGNATURE.as_bytes()).is_ok());
+        assert!(verify_signature(TEST_KEY, SIGNED_IMAGE, TEST_SIGNATURE.as_bytes()).is_ok());
         assert!(
-            verify_minisign(TEST_KEY, b"tampered AppImage", TEST_SIGNATURE.as_bytes()).is_err()
+            verify_signature(TEST_KEY, b"tampered AppImage", TEST_SIGNATURE.as_bytes()).is_err()
         );
     }
 
@@ -232,7 +236,7 @@ mod tests {
     #[test]
     fn a_signature_that_is_absent_or_malformed_is_refused() {
         for body in [b"".as_slice(), b"not base64 !!", TEST_KEY.as_bytes()] {
-            assert!(verify_minisign(TEST_KEY, SIGNED_IMAGE, body).is_err());
+            assert!(verify_signature(TEST_KEY, SIGNED_IMAGE, body).is_err());
         }
     }
 
@@ -241,7 +245,7 @@ mod tests {
     /// this build could not read in the first place.
     #[test]
     fn the_pinned_key_is_the_one_a_download_is_held_to() {
-        let error = verify_app_image(SIGNED_IMAGE, TEST_SIGNATURE.as_bytes())
+        let error = verify_signature(UPDATER_PUBLIC_KEY, SIGNED_IMAGE, TEST_SIGNATURE.as_bytes())
             .unwrap_err()
             .to_string();
         assert!(error.contains("created with a different key"), "{error}");
@@ -292,6 +296,21 @@ mod tests {
                 .relation_to("5.0.1")
                 .unwrap(),
             VersionRelation::Older
+        );
+    }
+
+    #[test]
+    fn the_signature_url_is_the_app_image_url_with_the_published_suffix() {
+        assert_eq!(
+            app_image_signature_url("5.1.0", "x86_64-unknown-linux-gnu").unwrap(),
+            Some(
+                "https://github.com/vanillagreencom/kendex/releases/download/v5.1.0/kendex_5.1.0_amd64.AppImage.sig"
+                    .to_owned()
+            )
+        );
+        assert_eq!(
+            app_image_signature_url("5.1.0", "aarch64-apple-darwin").unwrap(),
+            None
         );
     }
 

--- a/crates/core/src/update_feed.rs
+++ b/crates/core/src/update_feed.rs
@@ -3,6 +3,8 @@
 use std::cmp::Ordering;
 use std::collections::BTreeMap;
 
+use base64::Engine;
+use minisign_verify::{PublicKey, Signature};
 use semver::Version;
 use serde::{Deserialize, Serialize};
 
@@ -12,6 +14,11 @@ pub const FEED_SCHEMA: u32 = 1;
 pub const MAX_FEED_BYTES: usize = 64 * 1024;
 pub const RELEASE_FEED_URL: &str =
     "https://github.com/vanillagreencom/kendex/releases/latest/download/feed.json";
+/// The minisign public key every kendex release is signed under, in the
+/// base64 shape `crates/app/tauri.conf.json` pins for the app's own
+/// updater. `crates/app/tests/tauri_config.rs` holds the two to one string,
+/// so the CLI and the app cannot end up trusting different keys.
+pub const UPDATER_PUBLIC_KEY: &str = "dW50cnVzdGVkIGNvbW1lbnQ6IG1pbmlzaWduIHB1YmxpYyBrZXk6IEJENUIwQjkxMUFGNTJFOTIKUldTU0x2VWFrUXRidmJFQnhKSi9iU3pwTVVJVlhrY3JHbVoyV1BjVmJSdDYzZ2VjVnZzSjlEMDkK";
 const MAX_VERSION_BYTES: usize = 128;
 const MAX_ASSETS: usize = 32;
 const MAX_TARGET_BYTES: usize = 128;
@@ -138,6 +145,41 @@ pub fn app_image_url(version: &str, target: &str) -> Result<Option<String>> {
     )))
 }
 
+/// Refuse an AppImage that is not the one this release signed. `signature`
+/// is the body of the `<artifact>.AppImage.sig` the release job publishes
+/// beside every AppImage — base64 over a minisign signature file, the same
+/// bytes the app's updater manifest carries inline.
+pub fn verify_app_image(image: &[u8], signature: &[u8]) -> Result<()> {
+    verify_minisign(UPDATER_PUBLIC_KEY, image, signature)
+}
+
+/// The key is a parameter so a test can hold a signature it made itself;
+/// every caller passes the pinned key.
+fn verify_minisign(public_key_base64: &str, data: &[u8], signature: &[u8]) -> Result<()> {
+    let key_text = decode_base64("the pinned public key", public_key_base64.as_bytes())?;
+    let key = PublicKey::decode(&key_text)
+        .map_err(|error| refused(format!("the pinned public key is not minisign: {error}")))?;
+    let signature_text = decode_base64("the signature", signature)?;
+    let signature = Signature::decode(&signature_text)
+        .map_err(|error| refused(format!("the signature is not minisign: {error}")))?;
+    // Legacy signatures are accepted because the app's updater accepts them
+    // under this same key; a narrower rule here would put one artifact
+    // behind two bars again, which is what this shares a key to avoid.
+    key.verify(data, &signature, true)
+        .map_err(|error| refused(error.to_string()))
+}
+
+fn decode_base64(what: &str, value: &[u8]) -> Result<String> {
+    let bytes = base64::engine::general_purpose::STANDARD
+        .decode(value)
+        .map_err(|error| refused(format!("{what} is not base64: {error}")))?;
+    String::from_utf8(bytes).map_err(|error| refused(format!("{what} is not text: {error}")))
+}
+
+fn refused(why: String) -> CoreError {
+    CoreError::UpdateSignatureRefused { why }
+}
+
 fn parse_version(source: &str, value: &str) -> Result<Version> {
     Version::parse(value).map_err(|error| CoreError::UpdateFeedMalformed {
         why: format!("{source} version '{value}' is not SemVer: {error}"),
@@ -167,6 +209,42 @@ mod tests {
         })
         .unwrap();
         ReleaseFeed::parse(&body)
+    }
+
+    /// A throwaway minisign keypair signing `SIGNED_IMAGE`, generated once
+    /// so the good case is a real signature rather than a stub. Both values
+    /// are base64 over the key and signature files, the shape
+    /// `tauri.conf.json` and a published `.sig` carry.
+    const TEST_KEY: &str = "dW50cnVzdGVkIGNvbW1lbnQ6IG1pbmlzaWduIHB1YmxpYyBrZXk6IDk0QUI0NzI3RTVDMTVCODEKUldTQlc4SGxKMGVybEhxeFovbTJ3U1phMng4aE9VTXByV09pUVRFVFNKbFZ5aWxtUTAvVGgyWEwK";
+    const TEST_SIGNATURE: &str = "dW50cnVzdGVkIGNvbW1lbnQ6IHNpZ25hdHVyZSBmcm9tIHJzaWduIHNlY3JldCBrZXkKUlVTQlc4SGxKMGVybElTMUxrbkMyQ0tBWGlnejY1S0xLekovK0tBYllNdkdJTVU0bitTSjRBSCt1RlpwWnZkRHNKcWFTSHVoeStIQkpyVDlOaVRIMmROWVVSb21mMVBVRmd3PQp0cnVzdGVkIGNvbW1lbnQ6IGtlbmRleCB0ZXN0CnpKSnpYYnBtODZYRW40eHgxSTVkeG5YdktxT0k5ZXdmSkEyMkdtZXpreGgwbUNJZysybkJ2cGowUXZ6N2c3RHA4TEZBVXVBQUVMRExuUzFuaVpsaUF3PT0K";
+    const SIGNED_IMAGE: &[u8] = b"kendex AppImage bytes";
+
+    #[test]
+    fn a_signature_over_these_bytes_verifies_and_one_over_any_other_does_not() {
+        assert!(verify_minisign(TEST_KEY, SIGNED_IMAGE, TEST_SIGNATURE.as_bytes()).is_ok());
+        assert!(
+            verify_minisign(TEST_KEY, b"tampered AppImage", TEST_SIGNATURE.as_bytes()).is_err()
+        );
+    }
+
+    /// Everything that is not a signature file is refused too, the empty
+    /// body a served error page or a missing `.sig` leaves included.
+    #[test]
+    fn a_signature_that_is_absent_or_malformed_is_refused() {
+        for body in [b"".as_slice(), b"not base64 !!", TEST_KEY.as_bytes()] {
+            assert!(verify_minisign(TEST_KEY, SIGNED_IMAGE, body).is_err());
+        }
+    }
+
+    /// A download is held to the pinned key and no other: a signature made
+    /// under a different one is turned away for that, and not for a key
+    /// this build could not read in the first place.
+    #[test]
+    fn the_pinned_key_is_the_one_a_download_is_held_to() {
+        let error = verify_app_image(SIGNED_IMAGE, TEST_SIGNATURE.as_bytes())
+            .unwrap_err()
+            .to_string();
+        assert!(error.contains("created with a different key"), "{error}");
     }
 
     #[test]

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -291,7 +291,7 @@ lives in one capability table read by core and UI.
   mid-read; a failed read shows its error with a retry, kept figures headed
   as the last kendex could check, never a definite count — least of all
   zero. Every read the app starts with runs beside the others.
-- **Discovery is the unsigned feed; delivery is a signed manifest.** Off the
+- **Discovery is the unsigned feed; delivery checks a signature.** Off the
   launch path, one cross-process transaction reads the fixed feed at most once
   per six hours, keeps the last result beside any error, and never follows the
   final link; the preference gates automatic contact, debug builds alone honor

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -291,12 +291,12 @@ lives in one capability table read by core and UI.
   mid-read; a failed read shows its error with a retry, kept figures headed
   as the last kendex could check, never a definite count — least of all
   zero. Every read the app starts with runs beside the others.
-- **Discovery is the unsigned feed; delivery checks a signature.** Off the
-  launch path, one cross-process transaction reads the fixed feed at most once
-  per six hours, keeps the last result beside any error, and never follows the
-  final link; the preference gates automatic contact, debug builds alone honor
-  `KENDEX_UPDATE_FEED`. Replacing needs the path behind the running one
-  writable and outside a system prefix; a package prefix names its command
+- **Discovery is the unsigned feed; the app download checks a signature.**
+  Off the launch path, one cross-process transaction reads the fixed feed at
+  most once per six hours, keeps the last result beside any error, and never
+  follows the final link; the preference gates automatic contact, debug builds
+  alone honor `KENDEX_UPDATE_FEED`. Replacing needs the path behind the running
+  one writable and outside a system prefix; a package prefix names its command
   instead, anything else neither. One sidebar card offers whichever it is.
 - Commands that touch disk, git, or a subprocess are
   `#[tauri::command(async)]`. Only window operations stay synchronous.

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -14,7 +14,9 @@ Release with:
 - `kendex-<target>[.exe]` — the CLI binary, one per target. These are what
   `kendex update` downloads.
 - The desktop app bundles Tauri produces per platform (deb/rpm/AppImage,
-  dmg, NSIS installer).
+  dmg, NSIS installer), and the `.sig` Tauri writes beside each updater
+  bundle. `kendex update` fetches `<AppImage>.sig` straight from the
+  release, so it is a published asset and not only an input to `latest.json`.
 - `latest.json` — the signed manifest the app's Update button installs
   from, one `{signature, url}` per platform. The publish job writes it from
   the `.sig` files the lanes staged, and names any platform whose signature
@@ -39,9 +41,13 @@ revisit Intel support then.
   `TAURI_SIGNING_PRIVATE_KEY_PASSWORD` repo secrets): required. Every lane
   bundles an updater-enabled target, so an unset key fails bundling with
   "A public key has been found, but no private key" and the tag produces no
-  release. The public half is `plugins > updater > pubkey` in
-  `crates/app/tauri.conf.json`; a private key that does not match it builds
-  a release the app refuses to install. CLI self-update is unaffected.
+  release. The public half lives in two files that rotate together:
+  `plugins > updater > pubkey` in `crates/app/tauri.conf.json` and
+  `UPDATER_PUBLIC_KEY` in `crates/core/src/update_feed.rs`, held equal by
+  `crates/app/tests/tauri_config.rs`. A private key that does not match
+  builds a release the app refuses to install and that `kendex update`
+  refuses to install the desktop app from; the CLI binary half of
+  `kendex update` is unaffected.
 - **macOS signing + notarization** (the seven `APPLE_*` repo secrets:
   certificate p12 + password, signing identity, team id, and the App
   Store Connect API issuer/key-id/key): all seven set, the two mac lanes

--- a/tools/size-ratchet-baseline.tsv
+++ b/tools/size-ratchet-baseline.tsv
@@ -5,7 +5,7 @@ crates/core/src/engine/detach.rs	603
 crates/core/src/engine/pi_hooks_move/migrated.rs	540
 crates/core/src/engine/pi_hooks_move/mod.rs	503
 crates/core/src/engine/pi_hooks_move/preflight.rs	765
-crates/core/src/error.rs	432
+crates/core/src/error.rs	437
 crates/core/src/remote/store.rs	405
 docs/ARCHITECTURE.md	801
 hooks/block-repo-copy.sh	511


### PR DESCRIPTION
The app's Update button replaced the AppImage only after a minisign check. `kendex update` wrote that same file on TLS trust alone. One artifact, two bars.

`update_app` now fetches the release's `.sig` beside the AppImage and verifies it under the key core pins before anything is written. A refusal leaves the app untouched and returns before the command replaces itself, so the installed version still reads older than the feed and the next run tries both halves again.

## One key, held equal

Tauri reads `plugins > updater > pubkey` from `tauri.conf.json` at build time and cannot read a Rust constant, so that copy cannot be deleted. Core owns `UPDATER_PUBLIC_KEY` and `crates/app/tests/tauri_config.rs` holds the two strings equal — a rotation that edits only one file fails `cargo test --workspace`. `docs/RELEASING.md` now says both files rotate together.

`allow_legacy` matches tauri-plugin-updater 2.10.1 `src/updater.rs:1461`, cited in the comment: being stricter than the app would put one artifact back behind two bars.

## Controls

Both arms are covered, and each was proved red once before being trusted. A signature under a key the test owns admits and the image is written; a tampered one and a malformed one each refuse with their own distinguishing cause, leaving the installed file byte-identical and no staged file behind. The signature URL is built in core beside `app_image_url` and asserted against the artifact list the release manifest step is driven with, so renaming the suffix fails a test rather than a tag run.

`staged_path` now carries the process id. Two concurrent runs previously shared one `.update` sibling, so what the rename installed was whatever the other run last wrote there — not the bytes this one verified. A run whose rename cannot land removes its own staged file.

## Deliberately not here

The CLI binary is still fetched on TLS trust alone, and `feed.json` publishes no signature for it. KEN-718 names this as the open question it does not answer: signing one half and not the other is the inconsistency it replaces, so the answer has to cover both, and it needs a release-job change. Filed as KEN-754, with `install.sh` in the same issue. KEN-755 covers the verification rule drifting from the plugin's under a caret range.

`docs/ARCHITECTURE.md` is scoped to match: the invariant now reads "the app download checks a signature" rather than claiming it of delivery generally.

Closes KEN-718
