### PR TITLE
fix(KEN-739): an identity read settles only under its own credential

### DIFF
--- a/changelog.d/fixed/KEN-739.md
+++ b/changelog.d/fixed/KEN-739.md
@@ -1,3 +1,3 @@
-- Signing out and back in as a different account while the account panel is
-  loading no longer shows the previous account's name. The outdated read is
-  refused, and reloading shows the new account.
+- The account panel no longer shows the previous account's name after
+  signing in as somebody else. A cached identity belongs to one sign-in and
+  is never served under another.

--- a/changelog.d/fixed/KEN-739.md
+++ b/changelog.d/fixed/KEN-739.md
@@ -1,3 +1,2 @@
-- The account panel no longer shows the previous account's name after
-  signing in as somebody else. A cached identity belongs to one sign-in and
-  is never served under another.
+- Signing in as another account no longer shows the previous account's name,
+  or reports its sign-in as expired. An identity read belongs to one sign-in.

--- a/changelog.d/fixed/KEN-739.md
+++ b/changelog.d/fixed/KEN-739.md
@@ -1,0 +1,3 @@
+- Signing out and back in as a different account while the account panel is
+  loading no longer shows the previous account's name — the outdated read is
+  refused, and reloading shows the new account.

--- a/changelog.d/fixed/KEN-739.md
+++ b/changelog.d/fixed/KEN-739.md
@@ -1,3 +1,3 @@
 - Signing out and back in as a different account while the account panel is
-  loading no longer shows the previous account's name — the outdated read is
+  loading no longer shows the previous account's name. The outdated read is
   refused, and reloading shows the new account.

--- a/crates/app/src/account.rs
+++ b/crates/app/src/account.rs
@@ -72,6 +72,8 @@ pub fn account_login_poll(device_code: String) -> Result<String, String> {
                     access_token: pair.access_token,
                     refresh_token: pair.refresh_token,
                     capabilities: pair.capabilities,
+                    // `commit_login` names the sign-in.
+                    sign_in: String::new(),
                 },
             )
             .map_err(|e| e.to_string())?;

--- a/crates/cli/src/commands/login.rs
+++ b/crates/cli/src/commands/login.rs
@@ -49,6 +49,8 @@ pub fn login() -> Result<()> {
                         access_token: pair.access_token,
                         refresh_token: pair.refresh_token,
                         capabilities: pair.capabilities,
+                        // `commit_login` names the sign-in.
+                        sign_in: String::new(),
                     },
                 )?;
                 say("Signed in. The credential is in your system keychain.");

--- a/crates/core/src/registry/client.rs
+++ b/crates/core/src/registry/client.rs
@@ -7,17 +7,29 @@ use crate::registry::credentials::{Credential, CredentialStore};
 use crate::registry::login::TokenPair;
 use crate::registry::{Fetch, FetchResponse, base_url};
 
+/// One answer and the credential it finally went out under. A rotation
+/// mid-call replaces what the caller started with, so the answer belongs
+/// to the replacement; a caller binding the answer to a sign-in must
+/// bind it to this one.
+pub struct Authenticated {
+    pub response: FetchResponse,
+    pub credential: Credential,
+}
+
 /// Run one authenticated call, refreshing a rejected access token once.
 /// Refresh rotation is locked across processes and saved before retry.
 pub fn with_access(
     fetch: &dyn Fetch,
     store: &dyn CredentialStore,
     call: impl Fn(&str) -> Result<FetchResponse>,
-) -> Result<FetchResponse> {
+) -> Result<Authenticated> {
     let credential = required(store.load()?)?;
     let first = call(&credential.access_token)?;
     if first.status != 401 {
-        return Ok(first);
+        return Ok(Authenticated {
+            response: first,
+            credential,
+        });
     }
     rotate_after_rejection(fetch, store, &call, credential)
 }
@@ -27,7 +39,7 @@ fn rotate_after_rejection(
     store: &dyn CredentialStore,
     call: &impl Fn(&str) -> Result<FetchResponse>,
     mut rejected: Credential,
-) -> Result<FetchResponse> {
+) -> Result<Authenticated> {
     let mut newer_retries = 0;
     loop {
         let refresh_guard = store.refresh_guard()?;
@@ -36,7 +48,10 @@ fn rotate_after_rejection(
             drop(refresh_guard);
             let retried = call(&locked.access_token)?;
             if retried.status != 401 {
-                return Ok(retried);
+                return Ok(Authenticated {
+                    response: retried,
+                    credential: locked,
+                });
             }
             if newer_retries == 1 {
                 return Err(rejected_access());
@@ -55,7 +70,7 @@ fn rotate_locked(
     call: &impl Fn(&str) -> Result<FetchResponse>,
     credential: Credential,
     refresh_guard: Box<dyn crate::registry::credentials::CredentialRefreshGuard + '_>,
-) -> Result<FetchResponse> {
+) -> Result<Authenticated> {
     let pair = match refresh(fetch, &credential.refresh_token) {
         Ok(pair) => pair,
         Err(Refused::Definitive(why)) => {
@@ -93,7 +108,10 @@ fn rotate_locked(
     if second.status == 401 {
         return Err(rejected_access());
     }
-    Ok(second)
+    Ok(Authenticated {
+        response: second,
+        credential: rotated,
+    })
 }
 
 /// Commit a completed device login without racing refresh or logout.

--- a/crates/core/src/registry/client.rs
+++ b/crates/core/src/registry/client.rs
@@ -68,7 +68,7 @@ fn rotate_after_rejection(
                 });
             }
             if newer_retries == 1 {
-                return Err(rejected_access());
+                return Err(rejected_access(store, &locked));
             }
             newer_retries += 1;
             rejected = locked;
@@ -120,7 +120,7 @@ fn rotate_locked(
 
     let second = call(&rotated.access_token)?;
     if second.status == 401 {
-        return Err(rejected_access());
+        return Err(rejected_access(store, &rotated));
     }
     // This call made the replacement, so the answer descends from the
     // credential it rotated away from.
@@ -168,10 +168,31 @@ fn required(credential: Option<Credential>) -> Result<Credential> {
     credential.ok_or(CoreError::NotSignedIn)
 }
 
-fn rejected_access() -> CoreError {
-    CoreError::SignInExpired {
-        why: "the server does not accept this sign-in".to_owned(),
+/// The server rejected the access token this call is authenticated as.
+/// That is an expiry only while the sign-in it belongs to is the one
+/// installed: a sign-in landing while the request was in flight makes the
+/// rejection somebody else's, and calling it an expiry pins one account's
+/// answer on another. Only whether the expiry is produced is decided here;
+/// what the expiry means for the stored credential is unchanged.
+fn rejected_access(store: &dyn CredentialStore, authenticated_as: &Credential) -> CoreError {
+    match still_installed(store, authenticated_as) {
+        Ok(true) => CoreError::SignInExpired {
+            why: "the server does not accept this sign-in".to_owned(),
+        },
+        Ok(false) => sign_in_changed("authenticating"),
+        Err(error) => error,
     }
+}
+
+/// Whether the installed sign-in is still this credential's, read under
+/// the credential transaction so the answer is not itself racing a
+/// rotation. A machine signed out in the meantime is not this
+/// credential's either.
+fn still_installed(store: &dyn CredentialStore, credential: &Credential) -> Result<bool> {
+    let _guard = store.refresh_guard()?;
+    Ok(store
+        .load()?
+        .is_some_and(|installed| installed.refresh_token == credential.refresh_token))
 }
 
 pub(super) fn sign_in_changed(action: &str) -> CoreError {

--- a/crates/core/src/registry/client.rs
+++ b/crates/core/src/registry/client.rs
@@ -7,23 +7,17 @@ use crate::registry::credentials::{Credential, CredentialStore};
 use crate::registry::login::TokenPair;
 use crate::registry::{Fetch, FetchResponse, base_url};
 
-/// One answer, the credential it went out under, and the sign-in it
-/// descends from.
+/// One answer and the credential it finally went out under.
 ///
-/// A call reaches its final credential three ways: it answers under what
-/// it opened with, it rotates to a replacement it made itself, or it
-/// adopts one another writer installed while it was in flight. The first
-/// two descend from what the call opened with. The third descends from
-/// the adopted credential, because nothing links it to what the call
-/// began with.
-///
-/// A caller that read state before the call compares that state's sign-in
-/// against `descends_from`: equal means nothing but this call moved the
-/// credential, whatever route it took.
+/// A call reaches that credential three ways: it answers under what it
+/// opened with, it rotates to a replacement it made itself, or it adopts
+/// one another writer installed while it was in flight. A rotation keeps
+/// `sign_in`; the other two carry whatever sign-in they belong to. So a
+/// caller that read state before the call compares that state's sign-in
+/// against this credential's, and the three routes need no telling apart.
 pub struct Authenticated {
     pub response: FetchResponse,
     pub credential: Credential,
-    pub descends_from: Credential,
 }
 
 /// Run one authenticated call, refreshing a rejected access token once.
@@ -38,7 +32,6 @@ pub fn with_access(
     if first.status != 401 {
         return Ok(Authenticated {
             response: first,
-            descends_from: opened_under.clone(),
             credential: opened_under,
         });
     }
@@ -60,10 +53,9 @@ fn rotate_after_rejection(
             let retried = call(&locked.access_token)?;
             if retried.status != 401 {
                 // Somebody else installed this credential mid-call. The
-                // answer is theirs, and it descends from their sign-in.
+                // answer is theirs, and carries their sign-in.
                 return Ok(Authenticated {
                     response: retried,
-                    descends_from: locked.clone(),
                     credential: locked,
                 });
             }
@@ -108,6 +100,8 @@ fn rotate_locked(
         access_token: pair.access_token,
         refresh_token: pair.refresh_token,
         capabilities: pair.capabilities,
+        // Rotation replaces the tokens, never the sign-in they belong to.
+        sign_in: credential.sign_in.clone(),
     };
     // Mixed-version writers do not know this guard. Never replace a family
     // an older client committed during the refresh request.
@@ -122,12 +116,9 @@ fn rotate_locked(
     if second.status == 401 {
         return Err(rejected_access(store, &rotated));
     }
-    // This call made the replacement, so the answer descends from the
-    // credential it rotated away from.
     Ok(Authenticated {
         response: second,
         credential: rotated,
-        descends_from: credential,
     })
 }
 
@@ -136,7 +127,14 @@ fn rotate_locked(
 /// account's cached identity around this.
 pub fn commit_login(store: &dyn CredentialStore, credential: &Credential) -> Result<()> {
     let _guard = store.refresh_guard()?;
-    store.save(credential)
+    // The sign-in is named here and nowhere else. A device flow mints a
+    // refresh token no other sign-in has, so its digest names this one
+    // without inventing a second source of uniqueness, and rotation
+    // carries the name rather than recomputing it.
+    store.save(&Credential {
+        sign_in: crate::hash::hash_bytes(credential.refresh_token.as_bytes()),
+        ..credential.clone()
+    })
 }
 
 /// Revoke and clear the current sign-in under the credential transaction lock.

--- a/crates/core/src/registry/client.rs
+++ b/crates/core/src/registry/client.rs
@@ -7,13 +7,15 @@ use crate::registry::credentials::{Credential, CredentialStore};
 use crate::registry::login::TokenPair;
 use crate::registry::{Fetch, FetchResponse, base_url};
 
-/// One answer and the credential it finally went out under. A rotation
-/// mid-call replaces what the caller started with, so the answer belongs
-/// to the replacement; a caller binding the answer to a sign-in must
-/// bind it to this one.
+/// One answer and the two credentials that bracket the call. A rotation
+/// mid-call replaces what the call opened with, so the answer belongs to
+/// `credential`; state the caller read before the call belongs to
+/// `opened_under`, which a rotation leaves alone and somebody else's
+/// sign-in does not.
 pub struct Authenticated {
     pub response: FetchResponse,
     pub credential: Credential,
+    pub opened_under: Credential,
 }
 
 /// Run one authenticated call, refreshing a rejected access token once.
@@ -23,15 +25,17 @@ pub fn with_access(
     store: &dyn CredentialStore,
     call: impl Fn(&str) -> Result<FetchResponse>,
 ) -> Result<Authenticated> {
-    let credential = required(store.load()?)?;
-    let first = call(&credential.access_token)?;
-    if first.status != 401 {
-        return Ok(Authenticated {
-            response: first,
-            credential,
-        });
-    }
-    rotate_after_rejection(fetch, store, &call, credential)
+    let opened_under = required(store.load()?)?;
+    let first = call(&opened_under.access_token)?;
+    let (response, credential) = match first.status {
+        401 => rotate_after_rejection(fetch, store, &call, opened_under.clone())?,
+        _ => (first, opened_under.clone()),
+    };
+    Ok(Authenticated {
+        response,
+        credential,
+        opened_under,
+    })
 }
 
 fn rotate_after_rejection(
@@ -39,7 +43,7 @@ fn rotate_after_rejection(
     store: &dyn CredentialStore,
     call: &impl Fn(&str) -> Result<FetchResponse>,
     mut rejected: Credential,
-) -> Result<Authenticated> {
+) -> Result<(FetchResponse, Credential)> {
     let mut newer_retries = 0;
     loop {
         let refresh_guard = store.refresh_guard()?;
@@ -48,10 +52,7 @@ fn rotate_after_rejection(
             drop(refresh_guard);
             let retried = call(&locked.access_token)?;
             if retried.status != 401 {
-                return Ok(Authenticated {
-                    response: retried,
-                    credential: locked,
-                });
+                return Ok((retried, locked));
             }
             if newer_retries == 1 {
                 return Err(rejected_access());
@@ -70,7 +71,7 @@ fn rotate_locked(
     call: &impl Fn(&str) -> Result<FetchResponse>,
     credential: Credential,
     refresh_guard: Box<dyn crate::registry::credentials::CredentialRefreshGuard + '_>,
-) -> Result<Authenticated> {
+) -> Result<(FetchResponse, Credential)> {
     let pair = match refresh(fetch, &credential.refresh_token) {
         Ok(pair) => pair,
         Err(Refused::Definitive(why)) => {
@@ -108,10 +109,7 @@ fn rotate_locked(
     if second.status == 401 {
         return Err(rejected_access());
     }
-    Ok(Authenticated {
-        response: second,
-        credential: rotated,
-    })
+    Ok((second, rotated))
 }
 
 /// Commit a completed device login without racing refresh or logout.

--- a/crates/core/src/registry/client.rs
+++ b/crates/core/src/registry/client.rs
@@ -7,15 +7,23 @@ use crate::registry::credentials::{Credential, CredentialStore};
 use crate::registry::login::TokenPair;
 use crate::registry::{Fetch, FetchResponse, base_url};
 
-/// One answer and the two credentials that bracket the call. A rotation
-/// mid-call replaces what the call opened with, so the answer belongs to
-/// `credential`; state the caller read before the call belongs to
-/// `opened_under`, which a rotation leaves alone and somebody else's
-/// sign-in does not.
+/// One answer, the credential it went out under, and the sign-in it
+/// descends from.
+///
+/// A call reaches its final credential three ways: it answers under what
+/// it opened with, it rotates to a replacement it made itself, or it
+/// adopts one another writer installed while it was in flight. The first
+/// two descend from what the call opened with. The third descends from
+/// the adopted credential, because nothing links it to what the call
+/// began with.
+///
+/// A caller that read state before the call compares that state's sign-in
+/// against `descends_from`: equal means nothing but this call moved the
+/// credential, whatever route it took.
 pub struct Authenticated {
     pub response: FetchResponse,
     pub credential: Credential,
-    pub opened_under: Credential,
+    pub descends_from: Credential,
 }
 
 /// Run one authenticated call, refreshing a rejected access token once.
@@ -27,15 +35,14 @@ pub fn with_access(
 ) -> Result<Authenticated> {
     let opened_under = required(store.load()?)?;
     let first = call(&opened_under.access_token)?;
-    let (response, credential) = match first.status {
-        401 => rotate_after_rejection(fetch, store, &call, opened_under.clone())?,
-        _ => (first, opened_under.clone()),
-    };
-    Ok(Authenticated {
-        response,
-        credential,
-        opened_under,
-    })
+    if first.status != 401 {
+        return Ok(Authenticated {
+            response: first,
+            descends_from: opened_under.clone(),
+            credential: opened_under,
+        });
+    }
+    rotate_after_rejection(fetch, store, &call, opened_under)
 }
 
 fn rotate_after_rejection(
@@ -43,7 +50,7 @@ fn rotate_after_rejection(
     store: &dyn CredentialStore,
     call: &impl Fn(&str) -> Result<FetchResponse>,
     mut rejected: Credential,
-) -> Result<(FetchResponse, Credential)> {
+) -> Result<Authenticated> {
     let mut newer_retries = 0;
     loop {
         let refresh_guard = store.refresh_guard()?;
@@ -52,7 +59,13 @@ fn rotate_after_rejection(
             drop(refresh_guard);
             let retried = call(&locked.access_token)?;
             if retried.status != 401 {
-                return Ok((retried, locked));
+                // Somebody else installed this credential mid-call. The
+                // answer is theirs, and it descends from their sign-in.
+                return Ok(Authenticated {
+                    response: retried,
+                    descends_from: locked.clone(),
+                    credential: locked,
+                });
             }
             if newer_retries == 1 {
                 return Err(rejected_access());
@@ -71,7 +84,7 @@ fn rotate_locked(
     call: &impl Fn(&str) -> Result<FetchResponse>,
     credential: Credential,
     refresh_guard: Box<dyn crate::registry::credentials::CredentialRefreshGuard + '_>,
-) -> Result<(FetchResponse, Credential)> {
+) -> Result<Authenticated> {
     let pair = match refresh(fetch, &credential.refresh_token) {
         Ok(pair) => pair,
         Err(Refused::Definitive(why)) => {
@@ -109,7 +122,13 @@ fn rotate_locked(
     if second.status == 401 {
         return Err(rejected_access());
     }
-    Ok((second, rotated))
+    // This call made the replacement, so the answer descends from the
+    // credential it rotated away from.
+    Ok(Authenticated {
+        response: second,
+        credential: rotated,
+        descends_from: credential,
+    })
 }
 
 /// Commit a completed device login without racing refresh or logout.

--- a/crates/core/src/registry/client.rs
+++ b/crates/core/src/registry/client.rs
@@ -139,7 +139,7 @@ fn rejected_access() -> CoreError {
     }
 }
 
-fn sign_in_changed(action: &str) -> CoreError {
+pub(super) fn sign_in_changed(action: &str) -> CoreError {
     CoreError::RegistryUnavailable {
         why: format!("the sign-in changed while {action}; retry the request"),
     }

--- a/crates/core/src/registry/credentials.rs
+++ b/crates/core/src/registry/credentials.rs
@@ -32,6 +32,16 @@ pub struct Credential {
     pub access_token: String,
     pub refresh_token: String,
     pub capabilities: Vec<String>,
+    /// Names the sign-in itself. Minted when one is committed and copied
+    /// through every rotation, so the tokens say who is talking now and
+    /// this says which sign-in they belong to — the thing a cache has to
+    /// be keyed to, since a rotation would otherwise strand it. Defaulted
+    /// because this is read back from the keychain: a credential stored
+    /// before the name existed still parses, and its empty name matches
+    /// no cache written since, which costs one refetch. Only one such
+    /// credential can exist, because every sign-in since mints a name.
+    #[serde(default)]
+    pub sign_in: String,
 }
 
 /// The seam tests replace: the real store is the OS keychain.
@@ -150,6 +160,20 @@ impl CredentialStore for KeyringStore {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// The keychain holds credentials written by earlier builds. A field
+    /// they cannot carry must never decide whether they parse: failing
+    /// here signs the machine out, where an unnamed sign-in only costs a
+    /// refetch.
+    #[test]
+    fn a_credential_stored_before_the_sign_in_had_a_name_still_reads() {
+        let stored = r#"{"endpoint":"https://kendex.ai","access_token":"kxa",
+                         "refresh_token":"kxr","capabilities":[]}"#;
+        let credential: Credential =
+            serde_json::from_str(stored).expect("a stored credential still reads");
+        assert_eq!(credential.refresh_token, "kxr");
+        assert!(credential.sign_in.is_empty());
+    }
 
     #[test]
     fn a_sandboxed_build_never_reaches_the_real_sign_in() {

--- a/crates/core/src/registry/generation.rs
+++ b/crates/core/src/registry/generation.rs
@@ -23,6 +23,10 @@ const MAX_CACHE_BYTES: u64 = MAX_RESPONSE_BYTES as u64 * 2;
 #[derive(Serialize, Deserialize)]
 pub(super) struct Generation {
     pub endpoint: String,
+    /// Which sign-in this generation belongs to, as [`GenerationFile::bound_to`]
+    /// names it. Absent on a generation no credential produced.
+    #[serde(default)]
+    pub credential: Option<String>,
     pub etag: Option<String>,
     pub fetched_at: u64,
     pub body: String,
@@ -39,11 +43,31 @@ pub(super) struct Loaded<T> {
 pub(super) struct GenerationFile<'e> {
     env: &'e Env,
     file: &'static str,
+    credential: Option<String>,
 }
 
 impl<'e> GenerationFile<'e> {
     pub fn new(env: &'e Env, file: &'static str) -> GenerationFile<'e> {
-        GenerationFile { env, file }
+        GenerationFile {
+            env,
+            file,
+            credential: None,
+        }
+    }
+
+    /// Key this file to one sign-in, named by a secret only that sign-in
+    /// has. A generation carrying another key is discarded on read just
+    /// as another endpoint's is, so a cache outliving the sign-in that
+    /// filled it can never be served under the next one. The secret is
+    /// hashed here and the file holds the digest: this is a cache, not
+    /// the keychain. A caller with no credential — the community
+    /// directory — leaves the key unset and reads only unkeyed
+    /// generations.
+    pub fn bound_to(self, sign_in: &str) -> GenerationFile<'e> {
+        GenerationFile {
+            credential: Some(crate::hash::hash_bytes(sign_in.as_bytes())),
+            ..self
+        }
     }
 
     fn path(&self) -> std::path::PathBuf {
@@ -55,7 +79,9 @@ impl<'e> GenerationFile<'e> {
     /// endpoint's, or a body the caller's strict parse refuses. The
     /// cache lives on this machine, but "on this machine" is not
     /// "trusted to be well-formed": the same cap and the same parse the
-    /// network response passed.
+    /// network response passed. Another sign-in's is refused the same
+    /// way, so nothing here has to reason about how the file outlived
+    /// the credential that wrote it.
     pub fn read<T>(&self, parse: impl Fn(&[u8]) -> Result<T>) -> Option<(Generation, T)> {
         let file = open_read_no_follow(&self.path()).ok()?;
         let metadata = file.metadata().ok()?;
@@ -65,7 +91,7 @@ impl<'e> GenerationFile<'e> {
         let mut text = String::new();
         file.take(MAX_CACHE_BYTES).read_to_string(&mut text).ok()?;
         let generation: Generation = serde_json::from_str(&text).ok()?;
-        if generation.endpoint != base_url() {
+        if generation.endpoint != base_url() || generation.credential != self.credential {
             return None;
         }
         let value = parse(generation.body.as_bytes()).ok()?;
@@ -104,6 +130,7 @@ impl<'e> GenerationFile<'e> {
                 Ok(value) => {
                     self.write(&Generation {
                         endpoint: base_url(),
+                        credential: self.credential.clone(),
                         etag: response.etag,
                         fetched_at: now,
                         body: String::from_utf8_lossy(&response.body).into_owned(),
@@ -122,6 +149,7 @@ impl<'e> GenerationFile<'e> {
                 })?;
                 self.write(&Generation {
                     fetched_at: now,
+                    credential: self.credential.clone(),
                     ..generation
                 })?;
                 Ok(Loaded {

--- a/crates/core/src/registry/generation.rs
+++ b/crates/core/src/registry/generation.rs
@@ -55,12 +55,13 @@ impl<'e> GenerationFile<'e> {
         }
     }
 
-    /// Key this file to one sign-in, named by a secret only that sign-in
-    /// has. A generation carrying another key is discarded on read just
-    /// as another endpoint's is, so a cache outliving the sign-in that
-    /// filled it can never be served under the next one. The secret is
-    /// hashed here and the file holds the digest: this is a cache, not
-    /// the keychain. A caller with no credential — the community
+    /// Key this file to one sign-in, named by whatever the caller uses to
+    /// tell one sign-in from the next. A generation carrying another key
+    /// is discarded on read just as another endpoint's is, so a cache
+    /// outliving the sign-in that filled it can never be served under the
+    /// next one. The name is hashed here rather than stored, so a caller
+    /// that hands over a secret still leaves none on disk: this is a
+    /// cache, not the keychain. A caller with no sign-in — the community
     /// directory — leaves the key unset and reads only unkeyed
     /// generations.
     pub fn bound_to(self, sign_in: &str) -> GenerationFile<'e> {

--- a/crates/core/src/registry/me.rs
+++ b/crates/core/src/registry/me.rs
@@ -53,25 +53,28 @@ struct WireMe {
 /// dropped; an unreachable or misbehaving server serves the cached
 /// identity as `Offline`, and errors only with nothing cached to serve. A
 /// credential gone by the time the answer lands is `SignedOut` too, and
-/// nothing is written back over the sign-out. An answer is refused as
-/// retryable, rather than cached, unless the credential it went out under
-/// is the one still installed: a refresh rotation mid-read is that same
-/// credential and settles normally, while a sign-in as somebody else is
-/// not and never gets the previous account's name written under it. With
-/// no answer to bind, the cache stands in only for the credential the
-/// read started with, so a transport failure behind a rotation is
-/// refused too.
+/// nothing is written back over the sign-out. Everything this read
+/// settles belongs to one sign-in: the cache it opens with, the call it
+/// sends, and the answer it caches. A sign-in as somebody else at any
+/// point across that span is refused as retryable rather than served,
+/// because the identity in hand is the previous account's. A refresh
+/// rotation mid-read is the same sign-in throughout and settles as
+/// usual.
 pub fn load(env: &Env, fetch: &dyn Fetch, store: &dyn CredentialStore) -> Result<AccountState> {
-    let Some(issued_under) = store.load()? else {
+    let Some(credential) = store.load()? else {
         return Ok(AccountState::SignedOut);
     };
+    // The token family names the sign-in. The cache read next, the call
+    // sent after it, and the answer settled at the end all have to be
+    // this one.
+    let issued_under = credential.refresh_token;
     let cache = cache(env);
     let cached = cache.read(parse);
     let etag = cached
         .as_ref()
         .and_then(|(generation, _)| generation.etag.clone());
     let url = format!("{}/api/v1/me", base_url());
-    let (fetched, answered_for) = match client::with_access(fetch, store, |access| {
+    let (fetched, opened_under, answered_for) = match client::with_access(fetch, store, |access| {
         fetch.get_auth(&url, etag.as_deref(), Some(access))
     }) {
         // Logout won a race with this read: the re-login state without
@@ -84,10 +87,14 @@ pub fn load(env: &Env, fetch: &dyn Fetch, store: &dyn CredentialStore) -> Result
             cache.forget()?;
             return Ok(AccountState::Expired);
         }
-        Ok(authenticated) => (Ok(authenticated.response), authenticated.credential),
-        // Nothing came back, so the cache is what settles, and the cache
+        Ok(authenticated) => (
+            Ok(authenticated.response),
+            authenticated.opened_under.refresh_token,
+            authenticated.credential.refresh_token,
+        ),
+        // Nothing came back, so the cache is the whole answer, and it
         // belongs to whoever was signed in when the read began.
-        Err(error) => (Err(error), issued_under),
+        Err(error) => (Err(error), issued_under.clone(), issued_under.clone()),
     };
     // A sign-out that landed while this read was in flight already forgot
     // the cache; settling now would write the identity straight back. The
@@ -96,10 +103,13 @@ pub fn load(env: &Env, fetch: &dyn Fetch, store: &dyn CredentialStore) -> Result
         return Ok(AccountState::SignedOut);
     };
     // Existence is not identity: a sign-out followed by a sign-in leaves
-    // a credential here too, and this answer belongs to neither of them.
-    // The token family names the sign-in, and a rotation saves its
-    // replacement before the call goes out, so the two match there.
-    if installed.refresh_token != answered_for.refresh_token {
+    // a credential here too, and nothing here belongs to either of them.
+    // Two spans to close. A sign-in landing before the call leaves the
+    // previous account's identity in `cached`, which a 304 hands back and
+    // any failure serves as offline. One landing after it settles this
+    // answer under a stranger. A rotation is neither: it saves its
+    // replacement before the call goes out, so both comparisons hold.
+    if opened_under != issued_under || answered_for != installed.refresh_token {
         return Err(sign_in_changed("reading your account"));
     }
     let loaded = cache.settle(cached, fetched, parse, |response| {

--- a/crates/core/src/registry/me.rs
+++ b/crates/core/src/registry/me.rs
@@ -61,16 +61,16 @@ struct WireMe {
 /// concurrent rotation of the same account, which the call adopts and
 /// answers under: nothing here can tell that from a different account
 /// signing in, and the retry costs less than the wrong name. A rotation
-/// this read performed is the same sign-in throughout and settles as
-/// usual.
+/// this read performed keeps the sign-in it rotated, so it settles as
+/// usual and its cache stays readable afterwards.
 pub fn load(env: &Env, fetch: &dyn Fetch, store: &dyn CredentialStore) -> Result<AccountState> {
     let Some(credential) = store.load()? else {
         return Ok(AccountState::SignedOut);
     };
-    // The token family names the sign-in. The cache read next, the call
-    // sent after it, and the answer settled at the end all have to be
-    // this one.
-    let issued_under = credential.refresh_token;
+    // The sign-in's own name, which a rotation carries and only a new
+    // sign-in changes. The cache read next, the call sent after it, and
+    // the answer settled at the end all have to be this one.
+    let issued_under = credential.sign_in;
     // Keyed to this sign-in, so a generation the previous one left behind
     // is not a cache at all here.
     let cache = cache(env).bound_to(&issued_under);
@@ -79,7 +79,7 @@ pub fn load(env: &Env, fetch: &dyn Fetch, store: &dyn CredentialStore) -> Result
         .as_ref()
         .and_then(|(generation, _)| generation.etag.clone());
     let url = format!("{}/api/v1/me", base_url());
-    let (fetched, descends_from, answered_for) = match client::with_access(fetch, store, |access| {
+    let (fetched, answered_for) = match client::with_access(fetch, store, |access| {
         fetch.get_auth(&url, etag.as_deref(), Some(access))
     }) {
         // Logout won a race with this read: the re-login state without
@@ -92,14 +92,10 @@ pub fn load(env: &Env, fetch: &dyn Fetch, store: &dyn CredentialStore) -> Result
             cache.forget()?;
             return Ok(AccountState::Expired);
         }
-        Ok(authenticated) => (
-            Ok(authenticated.response),
-            authenticated.descends_from.refresh_token,
-            authenticated.credential.refresh_token,
-        ),
+        Ok(authenticated) => (Ok(authenticated.response), authenticated.credential.sign_in),
         // Nothing came back, so the cache is the whole answer, and it
         // belongs to whoever was signed in when the read began.
-        Err(error) => (Err(error), issued_under.clone(), issued_under.clone()),
+        Err(error) => (Err(error), issued_under.clone()),
     };
     // A sign-out that landed while this read was in flight already forgot
     // the cache; settling now would write the identity straight back. The
@@ -109,26 +105,20 @@ pub fn load(env: &Env, fetch: &dyn Fetch, store: &dyn CredentialStore) -> Result
     };
     // Existence is not identity: a sign-out followed by a sign-in leaves
     // a credential here too, and nothing here belongs to either of them.
-    // One rule over two spans. Up to and through the call, the answer has
-    // to descend from the sign-in `cached` was read under; a credential
-    // installed anywhere in there leaves the previous account's identity
-    // in hand, which a 304 gives back whole and any failure serves as
-    // offline. After the call, the answer has to be the sign-in still
-    // installed. `with_access` reports what its own rotation produced, so
-    // a rotation satisfies both.
-    if descends_from != issued_under || answered_for != installed.refresh_token {
+    // One name over two spans. The answer has to carry the sign-in
+    // `cached` was read under, and that sign-in has to be the one still
+    // installed. A sign-in landing before the call leaves the previous
+    // account's identity in hand, which a 304 gives back whole and any
+    // failure serves as offline; one landing after settles this answer
+    // under a stranger. A rotation is neither, because it keeps the name.
+    if answered_for != issued_under || installed.sign_in != issued_under {
         return Err(sign_in_changed("reading your account"));
     }
-    // The answer belongs to the credential it went out under, which this
-    // read's own rotation may have replaced; key what gets written to
-    // that one so the next read still finds it.
-    let loaded = cache
-        .bound_to(&answered_for)
-        .settle(cached, fetched, parse, |response| {
-            CoreError::RegistryUnavailable {
-                why: server_message(response),
-            }
-        })?;
+    let loaded = cache.settle(cached, fetched, parse, |response| {
+        CoreError::RegistryUnavailable {
+            why: server_message(response),
+        }
+    })?;
     Ok(match loaded.stale {
         false => AccountState::SignedIn {
             identity: loaded.value,

--- a/crates/core/src/registry/me.rs
+++ b/crates/core/src/registry/me.rs
@@ -4,16 +4,37 @@
 //! told apart by asking the server; when the network is away the cached
 //! identity is served as the offline state instead of nothing.
 
+use std::sync::atomic::{AtomicU64, Ordering};
+
 use serde::{Deserialize, Serialize};
 
 use crate::env::Env;
 use crate::error::{CoreError, Result};
-use crate::registry::client::{self, server_message};
+use crate::registry::client::{self, server_message, sign_in_changed};
 use crate::registry::credentials::{Credential, CredentialStore};
 use crate::registry::generation::GenerationFile;
 use crate::registry::{Fetch, base_url};
 
 const CACHE_FILE: &str = "me.cache.json";
+
+/// How many sign-ins and sign-outs this process has committed. Paired
+/// with the credential itself it tells a replaced sign-in from a rotated
+/// one: the tokens change either way, but only a sign-in or a sign-out
+/// moves this count. Nothing is published through the counter — it is
+/// compared for inequality alone, and the credential it stands beside is
+/// read from the store — so coherence on the single location is all the
+/// comparison needs and no ordering here is load-bearing.
+static SIGN_IN_CHANGES: AtomicU64 = AtomicU64::new(0);
+
+fn sign_in_changes() -> u64 {
+    SIGN_IN_CHANGES.load(Ordering::Relaxed)
+}
+
+/// Advanced before a sign-in or sign-out touches the store, so no
+/// credential change slips in under a read that already took the count.
+fn sign_in_changing() {
+    SIGN_IN_CHANGES.fetch_add(1, Ordering::Relaxed);
+}
 
 /// Who the credential belongs to, as the identity endpoint answers it.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, specta::Type)]
@@ -53,11 +74,14 @@ struct WireMe {
 /// dropped; an unreachable or misbehaving server serves the cached
 /// identity as `Offline`, and errors only with nothing cached to serve. A
 /// credential gone by the time the answer lands is `SignedOut` too, and
-/// nothing is written back over the sign-out.
+/// nothing is written back over the sign-out; an answer that outlived the
+/// credential it was issued for is refused as retryable rather than
+/// cached under the replacement.
 pub fn load(env: &Env, fetch: &dyn Fetch, store: &dyn CredentialStore) -> Result<AccountState> {
-    if store.load()?.is_none() {
+    let Some(issued_under) = store.load()? else {
         return Ok(AccountState::SignedOut);
-    }
+    };
+    let changes_before = sign_in_changes();
     let cache = cache(env);
     let cached = cache.read(parse);
     let etag = cached
@@ -82,8 +106,17 @@ pub fn load(env: &Env, fetch: &dyn Fetch, store: &dyn CredentialStore) -> Result
     // A sign-out that landed while this read was in flight already forgot
     // the cache; settling now would write the identity straight back. The
     // module's rule throughout: a missing credential means logout won.
-    if store.load()?.is_none() {
+    let Some(installed) = store.load()? else {
         return Ok(AccountState::SignedOut);
+    };
+    // Existence is not identity: a sign-out followed by a sign-in leaves
+    // a credential here too, and this answer belongs to neither of them.
+    // A different token family under an unmoved count is `with_access`
+    // rotating this same sign-in, which leaves the answer good.
+    let replaced = sign_in_changes() != changes_before
+        && installed.refresh_token != issued_under.refresh_token;
+    if replaced {
+        return Err(sign_in_changed("reading your account"));
     }
     let loaded = cache.settle(cached, fetched, parse, |response| {
         CoreError::RegistryUnavailable {
@@ -101,12 +134,14 @@ pub fn load(env: &Env, fetch: &dyn Fetch, store: &dyn CredentialStore) -> Result
 }
 
 /// Commit a fresh sign-in and drop the previous account's cached
-/// identity, so the new credential never pairs with the old name.
+/// identity, so the new credential never pairs with the old name. A read
+/// still in flight is invalidated here rather than allowed to settle.
 pub fn commit_sign_in(
     env: &Env,
     store: &dyn CredentialStore,
     credential: &Credential,
 ) -> Result<()> {
+    sign_in_changing();
     cache(env).forget()?;
     client::commit_login(store, credential)
 }
@@ -115,6 +150,7 @@ pub fn commit_sign_in(
 /// every surface calls. When revocation fails the credential is kept for
 /// retry, and so is the cache. Returns false when already signed out.
 pub fn sign_out(env: &Env, fetch: &dyn Fetch, store: &dyn CredentialStore) -> Result<bool> {
+    sign_in_changing();
     let was_signed_in = client::logout(fetch, store)?;
     cache(env).forget()?;
     Ok(was_signed_in)

--- a/crates/core/src/registry/me.rs
+++ b/crates/core/src/registry/me.rs
@@ -4,8 +4,6 @@
 //! told apart by asking the server; when the network is away the cached
 //! identity is served as the offline state instead of nothing.
 
-use std::sync::atomic::{AtomicU64, Ordering};
-
 use serde::{Deserialize, Serialize};
 
 use crate::env::Env;
@@ -16,25 +14,6 @@ use crate::registry::generation::GenerationFile;
 use crate::registry::{Fetch, base_url};
 
 const CACHE_FILE: &str = "me.cache.json";
-
-/// How many sign-ins and sign-outs this process has committed. Paired
-/// with the credential itself it tells a replaced sign-in from a rotated
-/// one: the tokens change either way, but only a sign-in or a sign-out
-/// moves this count. Nothing is published through the counter — it is
-/// compared for inequality alone, and the credential it stands beside is
-/// read from the store — so coherence on the single location is all the
-/// comparison needs and no ordering here is load-bearing.
-static SIGN_IN_CHANGES: AtomicU64 = AtomicU64::new(0);
-
-fn sign_in_changes() -> u64 {
-    SIGN_IN_CHANGES.load(Ordering::Relaxed)
-}
-
-/// Advanced before a sign-in or sign-out touches the store, so no
-/// credential change slips in under a read that already took the count.
-fn sign_in_changing() {
-    SIGN_IN_CHANGES.fetch_add(1, Ordering::Relaxed);
-}
 
 /// Who the credential belongs to, as the identity endpoint answers it.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, specta::Type)]
@@ -74,21 +53,25 @@ struct WireMe {
 /// dropped; an unreachable or misbehaving server serves the cached
 /// identity as `Offline`, and errors only with nothing cached to serve. A
 /// credential gone by the time the answer lands is `SignedOut` too, and
-/// nothing is written back over the sign-out; an answer that outlived the
-/// credential it was issued for is refused as retryable rather than
-/// cached under the replacement.
+/// nothing is written back over the sign-out. An answer is refused as
+/// retryable, rather than cached, unless the credential it went out under
+/// is the one still installed: a refresh rotation mid-read is that same
+/// credential and settles normally, while a sign-in as somebody else is
+/// not and never gets the previous account's name written under it. With
+/// no answer to bind, the cache stands in only for the credential the
+/// read started with, so a transport failure behind a rotation is
+/// refused too.
 pub fn load(env: &Env, fetch: &dyn Fetch, store: &dyn CredentialStore) -> Result<AccountState> {
     let Some(issued_under) = store.load()? else {
         return Ok(AccountState::SignedOut);
     };
-    let changes_before = sign_in_changes();
     let cache = cache(env);
     let cached = cache.read(parse);
     let etag = cached
         .as_ref()
         .and_then(|(generation, _)| generation.etag.clone());
     let url = format!("{}/api/v1/me", base_url());
-    let fetched = match client::with_access(fetch, store, |access| {
+    let (fetched, answered_for) = match client::with_access(fetch, store, |access| {
         fetch.get_auth(&url, etag.as_deref(), Some(access))
     }) {
         // Logout won a race with this read: the re-login state without
@@ -101,7 +84,10 @@ pub fn load(env: &Env, fetch: &dyn Fetch, store: &dyn CredentialStore) -> Result
             cache.forget()?;
             return Ok(AccountState::Expired);
         }
-        fetched => fetched,
+        Ok(authenticated) => (Ok(authenticated.response), authenticated.credential),
+        // Nothing came back, so the cache is what settles, and the cache
+        // belongs to whoever was signed in when the read began.
+        Err(error) => (Err(error), issued_under),
     };
     // A sign-out that landed while this read was in flight already forgot
     // the cache; settling now would write the identity straight back. The
@@ -111,11 +97,9 @@ pub fn load(env: &Env, fetch: &dyn Fetch, store: &dyn CredentialStore) -> Result
     };
     // Existence is not identity: a sign-out followed by a sign-in leaves
     // a credential here too, and this answer belongs to neither of them.
-    // A different token family under an unmoved count is `with_access`
-    // rotating this same sign-in, which leaves the answer good.
-    let replaced = sign_in_changes() != changes_before
-        && installed.refresh_token != issued_under.refresh_token;
-    if replaced {
+    // The token family names the sign-in, and a rotation saves its
+    // replacement before the call goes out, so the two match there.
+    if installed.refresh_token != answered_for.refresh_token {
         return Err(sign_in_changed("reading your account"));
     }
     let loaded = cache.settle(cached, fetched, parse, |response| {
@@ -134,23 +118,26 @@ pub fn load(env: &Env, fetch: &dyn Fetch, store: &dyn CredentialStore) -> Result
 }
 
 /// Commit a fresh sign-in and drop the previous account's cached
-/// identity, so the new credential never pairs with the old name. A read
-/// still in flight is invalidated here rather than allowed to settle.
+/// identity, so the new credential never pairs with the old name. The
+/// cache is forgotten twice: once before the save, so a crash between the
+/// two leaves no inherited identity, and once after, because a read
+/// settling in that window was still holding the credential the old
+/// identity belongs to and had every right to cache it.
 pub fn commit_sign_in(
     env: &Env,
     store: &dyn CredentialStore,
     credential: &Credential,
 ) -> Result<()> {
-    sign_in_changing();
-    cache(env).forget()?;
-    client::commit_login(store, credential)
+    let cache = cache(env);
+    cache.forget()?;
+    client::commit_login(store, credential)?;
+    cache.forget()
 }
 
 /// Revoke, clear, and forget the cached identity — the one sign-out
 /// every surface calls. When revocation fails the credential is kept for
 /// retry, and so is the cache. Returns false when already signed out.
 pub fn sign_out(env: &Env, fetch: &dyn Fetch, store: &dyn CredentialStore) -> Result<bool> {
-    sign_in_changing();
     let was_signed_in = client::logout(fetch, store)?;
     cache(env).forget()?;
     Ok(was_signed_in)

--- a/crates/core/src/registry/me.rs
+++ b/crates/core/src/registry/me.rs
@@ -1,8 +1,9 @@
 //! Who is signed in: GET /api/v1/me through the rotation-safe bearer
 //! client. The last good answer is cached through [`super::generation`]
 //! with no TTL, because "signed in", "offline" and "expired" can only be
-//! told apart by asking the server; when the network is away the cached
-//! identity is served as the offline state instead of nothing.
+//! told apart by asking the server; when the network is away this
+//! sign-in's cached identity is served as the offline state instead of
+//! nothing.
 
 use serde::{Deserialize, Serialize};
 
@@ -55,14 +56,12 @@ struct WireMe {
 /// credential gone by the time the answer lands is `SignedOut` too, and
 /// nothing is written back over the sign-out. Everything this read
 /// settles belongs to one sign-in: the cache it opens with, the call it
-/// sends, and the answer it caches. A credential this read did not itself
-/// rotate to is refused as retryable rather than served, because the
-/// identity in hand is the previous account's. That refusal covers a
-/// concurrent rotation of the same account, which the call adopts and
-/// answers under: nothing here can tell that from a different account
-/// signing in, and the retry costs less than the wrong name. A rotation
-/// this read performed keeps the sign-in it rotated, so it settles as
-/// usual and its cache stays readable afterwards.
+/// sends, and the answer it caches. That sign-in is named on the
+/// credential, so what is compared is the name and not the tokens, which
+/// move. A rotation keeps the name whichever call performed it, so it
+/// settles as usual and leaves a cache the next read can still use. Only
+/// a different sign-in is refused as retryable, because then the identity
+/// in hand is the previous account's.
 pub fn load(env: &Env, fetch: &dyn Fetch, store: &dyn CredentialStore) -> Result<AccountState> {
     let Some(credential) = store.load()? else {
         return Ok(AccountState::SignedOut);
@@ -85,9 +84,9 @@ pub fn load(env: &Env, fetch: &dyn Fetch, store: &dyn CredentialStore) -> Result
         // Logout won a race with this read: the re-login state without
         // refreshing, exactly as if the credential had been gone up front.
         Err(CoreError::NotSignedIn) => return Ok(AccountState::SignedOut),
-        // The credential is dead and the client cleared it; a cached
-        // identity kept here could resurface as another account's
-        // "offline" after the next sign-in.
+        // The credential is dead and the client cleared it; the identity
+        // it named has no reason to outlive it on disk, and the next
+        // sign-in would find it keyed to this one and discard it unread.
         Err(CoreError::SignInExpired { .. }) => {
             cache.forget()?;
             return Ok(AccountState::Expired);
@@ -161,6 +160,8 @@ pub fn sign_out(env: &Env, fetch: &dyn Fetch, store: &dyn CredentialStore) -> Re
     Ok(was_signed_in)
 }
 
+/// The identity cache file, named but not yet keyed to a sign-in.
+/// `forget` needs no key; the one caller that reads takes one first.
 fn cache(env: &Env) -> GenerationFile<'_> {
     GenerationFile::new(env, CACHE_FILE)
 }

--- a/crates/core/src/registry/me.rs
+++ b/crates/core/src/registry/me.rs
@@ -71,7 +71,9 @@ pub fn load(env: &Env, fetch: &dyn Fetch, store: &dyn CredentialStore) -> Result
     // sent after it, and the answer settled at the end all have to be
     // this one.
     let issued_under = credential.refresh_token;
-    let cache = cache(env);
+    // Keyed to this sign-in, so a generation the previous one left behind
+    // is not a cache at all here.
+    let cache = cache(env).bound_to(&issued_under);
     let cached = cache.read(parse);
     let etag = cached
         .as_ref()
@@ -117,11 +119,16 @@ pub fn load(env: &Env, fetch: &dyn Fetch, store: &dyn CredentialStore) -> Result
     if descends_from != issued_under || answered_for != installed.refresh_token {
         return Err(sign_in_changed("reading your account"));
     }
-    let loaded = cache.settle(cached, fetched, parse, |response| {
-        CoreError::RegistryUnavailable {
-            why: server_message(response),
-        }
-    })?;
+    // The answer belongs to the credential it went out under, which this
+    // read's own rotation may have replaced; key what gets written to
+    // that one so the next read still finds it.
+    let loaded = cache
+        .bound_to(&answered_for)
+        .settle(cached, fetched, parse, |response| {
+            CoreError::RegistryUnavailable {
+                why: server_message(response),
+            }
+        })?;
     Ok(match loaded.stale {
         false => AccountState::SignedIn {
             identity: loaded.value,
@@ -133,11 +140,16 @@ pub fn load(env: &Env, fetch: &dyn Fetch, store: &dyn CredentialStore) -> Result
 }
 
 /// Commit a fresh sign-in and drop the previous account's cached
-/// identity, so the new credential never pairs with the old name. The
-/// cache is forgotten twice: once before the save, so a crash between the
-/// two leaves no inherited identity, and once after, because a read
-/// settling in that window was still holding the credential the old
-/// identity belongs to and had every right to cache it.
+/// identity, so the new credential never pairs with the old name.
+///
+/// The cache is forgotten twice. The first runs before anything is
+/// installed and fails the call, because failing there leaves nothing
+/// half-done. The second clears what a read settled between the two
+/// writes, holding a credential that was still genuinely installed, and
+/// cannot fail the call: the sign-in is committed by then, and saying it
+/// failed would leave the caller telling the user the opposite of what
+/// the machine holds. A generation surviving that forget is keyed to the
+/// previous sign-in and is discarded on read.
 pub fn commit_sign_in(
     env: &Env,
     store: &dyn CredentialStore,
@@ -146,7 +158,8 @@ pub fn commit_sign_in(
     let cache = cache(env);
     cache.forget()?;
     client::commit_login(store, credential)?;
-    cache.forget()
+    let _ = cache.forget();
+    Ok(())
 }
 
 /// Revoke, clear, and forget the cached identity — the one sign-out

--- a/crates/core/src/registry/me.rs
+++ b/crates/core/src/registry/me.rs
@@ -55,10 +55,13 @@ struct WireMe {
 /// credential gone by the time the answer lands is `SignedOut` too, and
 /// nothing is written back over the sign-out. Everything this read
 /// settles belongs to one sign-in: the cache it opens with, the call it
-/// sends, and the answer it caches. A sign-in as somebody else at any
-/// point across that span is refused as retryable rather than served,
-/// because the identity in hand is the previous account's. A refresh
-/// rotation mid-read is the same sign-in throughout and settles as
+/// sends, and the answer it caches. A credential this read did not itself
+/// rotate to is refused as retryable rather than served, because the
+/// identity in hand is the previous account's. That refusal covers a
+/// concurrent rotation of the same account, which the call adopts and
+/// answers under: nothing here can tell that from a different account
+/// signing in, and the retry costs less than the wrong name. A rotation
+/// this read performed is the same sign-in throughout and settles as
 /// usual.
 pub fn load(env: &Env, fetch: &dyn Fetch, store: &dyn CredentialStore) -> Result<AccountState> {
     let Some(credential) = store.load()? else {
@@ -74,7 +77,7 @@ pub fn load(env: &Env, fetch: &dyn Fetch, store: &dyn CredentialStore) -> Result
         .as_ref()
         .and_then(|(generation, _)| generation.etag.clone());
     let url = format!("{}/api/v1/me", base_url());
-    let (fetched, opened_under, answered_for) = match client::with_access(fetch, store, |access| {
+    let (fetched, descends_from, answered_for) = match client::with_access(fetch, store, |access| {
         fetch.get_auth(&url, etag.as_deref(), Some(access))
     }) {
         // Logout won a race with this read: the re-login state without
@@ -89,7 +92,7 @@ pub fn load(env: &Env, fetch: &dyn Fetch, store: &dyn CredentialStore) -> Result
         }
         Ok(authenticated) => (
             Ok(authenticated.response),
-            authenticated.opened_under.refresh_token,
+            authenticated.descends_from.refresh_token,
             authenticated.credential.refresh_token,
         ),
         // Nothing came back, so the cache is the whole answer, and it
@@ -104,12 +107,14 @@ pub fn load(env: &Env, fetch: &dyn Fetch, store: &dyn CredentialStore) -> Result
     };
     // Existence is not identity: a sign-out followed by a sign-in leaves
     // a credential here too, and nothing here belongs to either of them.
-    // Two spans to close. A sign-in landing before the call leaves the
-    // previous account's identity in `cached`, which a 304 hands back and
-    // any failure serves as offline. One landing after it settles this
-    // answer under a stranger. A rotation is neither: it saves its
-    // replacement before the call goes out, so both comparisons hold.
-    if opened_under != issued_under || answered_for != installed.refresh_token {
+    // One rule over two spans. Up to and through the call, the answer has
+    // to descend from the sign-in `cached` was read under; a credential
+    // installed anywhere in there leaves the previous account's identity
+    // in hand, which a 304 gives back whole and any failure serves as
+    // offline. After the call, the answer has to be the sign-in still
+    // installed. `with_access` reports what its own rotation produced, so
+    // a rotation satisfies both.
+    if descends_from != issued_under || answered_for != installed.refresh_token {
         return Err(sign_in_changed("reading your account"));
     }
     let loaded = cache.settle(cached, fetched, parse, |response| {

--- a/crates/core/src/registry/submit.rs
+++ b/crates/core/src/registry/submit.rs
@@ -37,7 +37,8 @@ pub fn submit(fetch: &dyn Fetch, store: &dyn CredentialStore, repo: &str) -> Res
     let url = format!("{}/api/v1/submissions", base_url());
     let response = with_access(fetch, store, |access| {
         fetch.post_json_auth(&url, &body, Some(access))
-    })?;
+    })?
+    .response;
     if response.status == 201 {
         return serde_json::from_slice(&response.body).map_err(|error| {
             CoreError::RegistryMalformed {
@@ -52,7 +53,8 @@ pub fn submissions(fetch: &dyn Fetch, store: &dyn CredentialStore) -> Result<Vec
     let url = format!("{}/api/v1/submissions", base_url());
     let response = with_access(fetch, store, |access| {
         fetch.get_auth(&url, None, Some(access))
-    })?;
+    })?
+    .response;
     if response.status == 200 {
         let wire: WireSubmissions = serde_json::from_slice(&response.body).map_err(|error| {
             CoreError::RegistryMalformed {

--- a/crates/core/tests/credential_transactions.rs
+++ b/crates/core/tests/credential_transactions.rs
@@ -62,6 +62,7 @@ fn credential(name: &str) -> Credential {
         access_token: format!("kxa_{name}"),
         refresh_token: format!("kxr_{name}"),
         capabilities: vec!["submission:write".to_owned()],
+        sign_in: format!("sign-in-{name}"),
     }
 }
 

--- a/crates/core/tests/me_client.rs
+++ b/crates/core/tests/me_client.rs
@@ -204,6 +204,48 @@ impl Fetch for RacingFetch<'_> {
     }
 }
 
+/// A store that lets an identity read settle inside the window
+/// `commit_sign_in` opens between forgetting the cache and saving the new
+/// credential. The old credential really is still installed there, so
+/// that settle is legitimate and nothing but a second forget clears it.
+struct SettlingStore<'a> {
+    inner: MemoryStore,
+    env: &'a Env,
+    body: String,
+}
+
+impl CredentialStore for SettlingStore<'_> {
+    fn save(&self, credential: &Credential) -> Result<()> {
+        write_cache(self.env, &self.body);
+        self.inner.save(credential)
+    }
+    fn load(&self) -> Result<Option<Credential>> {
+        self.inner.load()
+    }
+    fn clear(&self) -> Result<()> {
+        self.inner.clear()
+    }
+    fn refresh_guard(&self) -> Result<Box<dyn CredentialRefreshGuard + '_>> {
+        self.inner.refresh_guard()
+    }
+}
+
+fn write_cache(env: &Env, body: &str) {
+    let dir = env.registry_cache_dir();
+    std::fs::create_dir_all(&dir).expect("mkdir");
+    let generation = serde_json::json!({
+        "endpoint": "https://kendex.ai",
+        "etag": serde_json::Value::Null,
+        "fetched_at": 1,
+        "body": body,
+    });
+    std::fs::write(
+        dir.join("me.cache.json"),
+        serde_json::to_string(&generation).expect("generation"),
+    )
+    .expect("write");
+}
+
 fn other_account() -> Credential {
     Credential {
         endpoint: "https://kendex.ai".to_owned(),
@@ -634,7 +676,7 @@ fn a_read_settling_under_a_replacement_credential_is_discarded() {
 }
 
 #[test]
-fn a_read_settling_after_a_plain_sign_out_stays_signed_out() {
+fn a_real_sign_out_mid_read_leaves_no_cached_identity() {
     let dir = tempfile::tempdir().expect("tempdir");
     let env = env_in(dir.path());
     let store = MemoryStore::signed_in();
@@ -687,5 +729,21 @@ fn a_rotation_mid_read_still_settles_the_answer() {
     assert!(
         env.registry_cache_dir().join("me.cache.json").exists(),
         "a rotated read caches its identity like any other"
+    );
+}
+
+#[test]
+fn a_sign_in_clears_an_identity_that_settled_while_it_committed() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let env = env_in(dir.path());
+    let store = SettlingStore {
+        inner: MemoryStore::signed_in(),
+        env: &env,
+        body: fixture_body(&["success", "body"]),
+    };
+    me::commit_sign_in(&env, &store, &other_account()).expect("commit");
+    assert!(
+        !env.registry_cache_dir().join("me.cache.json").exists(),
+        "an identity cached before the new credential landed is still the old account's"
     );
 }

--- a/crates/core/tests/me_client.rs
+++ b/crates/core/tests/me_client.rs
@@ -5,7 +5,7 @@
 //! a byte copy of kendex-web's
 //! `contracts/api/v1/me.json` — drift between the repos is a `cmp` away.
 
-use std::cell::RefCell;
+use std::cell::{Cell, RefCell};
 use std::path::Path;
 
 use kendex_core::env::{Env, FakeOs};
@@ -141,6 +141,75 @@ impl CredentialStore for VanishingStore {
     }
     fn refresh_guard(&self) -> Result<Box<dyn CredentialRefreshGuard + '_>> {
         Ok(Box::new(MemoryGuard))
+    }
+}
+
+/// A transport that lets the sign-out — and, when one is given, the
+/// sign-in that follows it — land while the identity request is still
+/// outstanding. That is the only moment the race is reachable inside one
+/// process: the request hangs on the curl cap while the user signs out
+/// and completes a device flow as somebody else.
+struct RacingFetch<'a> {
+    env: &'a Env,
+    store: &'a MemoryStore,
+    signs_in_as: Option<Credential>,
+    answer: RefCell<Option<Result<FetchResponse>>>,
+    raced: Cell<bool>,
+}
+
+impl<'a> RacingFetch<'a> {
+    fn new(
+        env: &'a Env,
+        store: &'a MemoryStore,
+        signs_in_as: Option<Credential>,
+        answer: Result<FetchResponse>,
+    ) -> RacingFetch<'a> {
+        RacingFetch {
+            env,
+            store,
+            signs_in_as,
+            answer: RefCell::new(Some(answer)),
+            raced: Cell::new(false),
+        }
+    }
+}
+
+impl Fetch for RacingFetch<'_> {
+    fn get_auth(
+        &self,
+        _url: &str,
+        _if_none_match: Option<&str>,
+        _bearer: Option<&str>,
+    ) -> Result<FetchResponse> {
+        if !self.raced.replace(true) {
+            let revoke = Canned::new(vec![ok(200, None, "{}")]);
+            me::sign_out(self.env, &revoke, self.store).expect("sign out mid-read");
+            if let Some(next) = &self.signs_in_as {
+                me::commit_sign_in(self.env, self.store, next).expect("sign in mid-read");
+            }
+        }
+        self.answer
+            .borrow_mut()
+            .take()
+            .expect("the read asked twice")
+    }
+
+    fn post_json_auth(
+        &self,
+        _url: &str,
+        _body: &str,
+        _bearer: Option<&str>,
+    ) -> Result<FetchResponse> {
+        panic!("the identity read posts nothing")
+    }
+}
+
+fn other_account() -> Credential {
+    Credential {
+        endpoint: "https://kendex.ai".to_owned(),
+        access_token: "kxa_other".to_owned(),
+        refresh_token: "kxr_other".to_owned(),
+        capabilities: vec![],
     }
 }
 
@@ -527,5 +596,96 @@ fn an_oversized_identity_cache_reads_as_no_cache() {
     assert!(
         me::load(&env, &down, &MemoryStore::signed_in()).is_err(),
         "a cache past the cap is never read, however well-formed"
+    );
+}
+
+#[test]
+fn a_read_settling_under_a_replacement_credential_is_discarded() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let env = env_in(dir.path());
+    let store = MemoryStore::signed_in();
+    // Ada's read is in flight when she signs out and somebody else signs
+    // in. A credential is installed again by the time it settles, so
+    // existence alone would wave this answer through.
+    let racing = RacingFetch::new(
+        &env,
+        &store,
+        Some(other_account()),
+        ok(200, None, &fixture_body(&["success", "body"])),
+    );
+    let refused = me::load(&env, &racing, &store).expect_err("a stale identity must be refused");
+    assert!(
+        matches!(refused, CoreError::RegistryUnavailable { .. }),
+        "a replaced credential is a retryable read, not an account state: got {refused:?}"
+    );
+    assert_eq!(
+        store
+            .load()
+            .expect("load")
+            .expect("credential")
+            .access_token,
+        "kxa_other",
+        "the replacement stays installed; only the answer is dropped"
+    );
+    assert!(
+        !env.registry_cache_dir().join("me.cache.json").exists(),
+        "the previous account's identity must not be cached under its successor"
+    );
+}
+
+#[test]
+fn a_read_settling_after_a_plain_sign_out_stays_signed_out() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let env = env_in(dir.path());
+    let store = MemoryStore::signed_in();
+    let racing = RacingFetch::new(
+        &env,
+        &store,
+        None,
+        ok(200, None, &fixture_body(&["success", "body"])),
+    );
+    assert_eq!(
+        me::load(&env, &racing, &store).expect("load"),
+        AccountState::SignedOut,
+        "a removed credential is signed out, not a refused read"
+    );
+    assert!(
+        !env.registry_cache_dir().join("me.cache.json").exists(),
+        "a read finishing after sign-out must leave no identity on disk"
+    );
+}
+
+#[test]
+fn a_rotation_mid_read_still_settles_the_answer() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let env = env_in(dir.path());
+    let store = MemoryStore::signed_in();
+    // Refreshing replaces both tokens without changing who is signed in,
+    // so the answer this read comes back with is still that account's.
+    let fetch = Canned::new(vec![
+        ok(401, None, r#"{"error":"invalid_token"}"#),
+        ok(
+            200,
+            None,
+            r#"{"access_token":"kxa_new","refresh_token":"kxr_new","capabilities":[]}"#,
+        ),
+        ok(200, None, &fixture_body(&["success", "body"])),
+    ]);
+    match me::load(&env, &fetch, &store).expect("load") {
+        AccountState::SignedIn { identity } => assert_eq!(identity.name, "Ada Lovelace"),
+        other => panic!("a rotated sign-in is the same sign-in, got {other:?}"),
+    }
+    assert_eq!(
+        store
+            .load()
+            .expect("load")
+            .expect("credential")
+            .refresh_token,
+        "kxr_new",
+        "the rotation is what makes this the case it is"
+    );
+    assert!(
+        env.registry_cache_dir().join("me.cache.json").exists(),
+        "a rotated read caches its identity like any other"
     );
 }

--- a/crates/core/tests/me_client/main.rs
+++ b/crates/core/tests/me_client/main.rs
@@ -17,6 +17,11 @@ use kendex_core::registry::{Fetch, FetchResponse};
 
 const FIXTURE: &str = include_str!("../fixtures/api-v1-me.json");
 
+/// The sign-in every fixture credential belongs to. A rotation carries it
+/// and only a new sign-in changes it, so a cache keyed to it survives one
+/// and not the other.
+const ADA: &str = "sign-in-ada";
+
 /// A canned transport: each call pops the next scripted answer and
 /// records what rode along with it.
 struct Canned {
@@ -90,6 +95,7 @@ impl MemoryStore {
             access_token: "kxa_old".to_owned(),
             refresh_token: "kxr_old".to_owned(),
             capabilities: vec!["submission:write".to_owned()],
+            sign_in: ADA.to_owned(),
         })))
     }
 
@@ -125,8 +131,8 @@ impl CredentialRefreshGuard for MemoryGuard {}
 /// The key a generation carries beside its endpoint, exactly as `me.rs`
 /// writes it. A cache planted by hand needs the sign-in it belongs to, or
 /// the read refuses it for the wrong reason and the test proves nothing.
-fn sign_in_key(refresh_token: &str) -> serde_json::Value {
-    kendex_core::hash::hash_bytes(refresh_token.as_bytes()).into()
+fn sign_in_key(sign_in: &str) -> serde_json::Value {
+    kendex_core::hash::hash_bytes(sign_in.as_bytes()).into()
 }
 
 /// Plant a generation where a finished read would have left one.
@@ -361,7 +367,7 @@ fn a_cache_from_another_endpoint_is_never_served() {
     // refuse it.
     let generation = serde_json::json!({
         "endpoint": "https://somewhere.else",
-        "credential": sign_in_key("kxr_old"),
+        "credential": sign_in_key(ADA),
         "etag": serde_json::Value::Null,
         "fetched_at": 1,
         "body": r#"{"name":"Stranger","github_login":null}"#,
@@ -433,6 +439,7 @@ fn a_fresh_sign_in_never_inherits_the_previous_identity() {
             access_token: "kxa_next".to_owned(),
             refresh_token: "kxr_next".to_owned(),
             capabilities: vec![],
+            sign_in: String::new(),
         },
     )
     .expect("commit");
@@ -472,7 +479,7 @@ fn an_oversized_identity_cache_reads_as_no_cache() {
         r#"{{"name":"Ada Lovelace","github_login":null,"pad":"{}"}}"#,
         "x".repeat(41_000_000)
     );
-    write_cache(&env, &body, None, Some("kxr_old"));
+    write_cache(&env, &body, None, Some(ADA));
     let down = Canned::new(vec![away()]);
     assert!(
         me::load(&env, &down, &MemoryStore::signed_in()).is_err(),

--- a/crates/core/tests/me_client/main.rs
+++ b/crates/core/tests/me_client/main.rs
@@ -1,11 +1,12 @@
 //! The identity client: GET /api/v1/me against the contract fixture,
 //! every account state, all of them settled and all of them `load`'s
 //! answers, the offline cache ladder, and the cache's endpoint key. The
-//! UI holds its own "not read yet" and never gets it here. The fixture is
-//! a byte copy of kendex-web's
-//! `contracts/api/v1/me.json` — drift between the repos is a `cmp` away.
+//! UI holds its own "not read yet" and never gets it here. Which sign-in
+//! an answer belongs to is `sign_in_binding`. The fixture is a byte copy
+//! of kendex-web's `contracts/api/v1/me.json` — drift between the repos
+//! is a `cmp` away.
 
-use std::cell::{Cell, RefCell};
+use std::cell::RefCell;
 use std::path::Path;
 
 use kendex_core::env::{Env, FakeOs};
@@ -14,7 +15,7 @@ use kendex_core::registry::credentials::{Credential, CredentialRefreshGuard, Cre
 use kendex_core::registry::me::{self, AccountState};
 use kendex_core::registry::{Fetch, FetchResponse};
 
-const FIXTURE: &str = include_str!("fixtures/api-v1-me.json");
+const FIXTURE: &str = include_str!("../fixtures/api-v1-me.json");
 
 /// A canned transport: each call pops the next scripted answer and
 /// records what rode along with it.
@@ -116,144 +117,6 @@ impl CredentialStore for MemoryStore {
 
 struct MemoryGuard;
 impl CredentialRefreshGuard for MemoryGuard {}
-
-/// A store whose credential disappears after N loads — logout winning a
-/// race against the read.
-struct VanishingStore {
-    loads_before_gone: RefCell<u32>,
-    credential: Credential,
-}
-
-impl CredentialStore for VanishingStore {
-    fn save(&self, _credential: &Credential) -> Result<()> {
-        Ok(())
-    }
-    fn load(&self) -> Result<Option<Credential>> {
-        let mut left = self.loads_before_gone.borrow_mut();
-        if *left == 0 {
-            return Ok(None);
-        }
-        *left -= 1;
-        Ok(Some(self.credential.clone()))
-    }
-    fn clear(&self) -> Result<()> {
-        Ok(())
-    }
-    fn refresh_guard(&self) -> Result<Box<dyn CredentialRefreshGuard + '_>> {
-        Ok(Box::new(MemoryGuard))
-    }
-}
-
-/// A transport that lets the sign-out — and, when one is given, the
-/// sign-in that follows it — land while the identity request is still
-/// outstanding. That is the only moment the race is reachable inside one
-/// process: the request hangs on the curl cap while the user signs out
-/// and completes a device flow as somebody else.
-struct RacingFetch<'a> {
-    env: &'a Env,
-    store: &'a MemoryStore,
-    signs_in_as: Option<Credential>,
-    answer: RefCell<Option<Result<FetchResponse>>>,
-    raced: Cell<bool>,
-}
-
-impl<'a> RacingFetch<'a> {
-    fn new(
-        env: &'a Env,
-        store: &'a MemoryStore,
-        signs_in_as: Option<Credential>,
-        answer: Result<FetchResponse>,
-    ) -> RacingFetch<'a> {
-        RacingFetch {
-            env,
-            store,
-            signs_in_as,
-            answer: RefCell::new(Some(answer)),
-            raced: Cell::new(false),
-        }
-    }
-}
-
-impl Fetch for RacingFetch<'_> {
-    fn get_auth(
-        &self,
-        _url: &str,
-        _if_none_match: Option<&str>,
-        _bearer: Option<&str>,
-    ) -> Result<FetchResponse> {
-        if !self.raced.replace(true) {
-            let revoke = Canned::new(vec![ok(200, None, "{}")]);
-            me::sign_out(self.env, &revoke, self.store).expect("sign out mid-read");
-            if let Some(next) = &self.signs_in_as {
-                me::commit_sign_in(self.env, self.store, next).expect("sign in mid-read");
-            }
-        }
-        self.answer
-            .borrow_mut()
-            .take()
-            .expect("the read asked twice")
-    }
-
-    fn post_json_auth(
-        &self,
-        _url: &str,
-        _body: &str,
-        _bearer: Option<&str>,
-    ) -> Result<FetchResponse> {
-        panic!("the identity read posts nothing")
-    }
-}
-
-/// A store that lets an identity read settle inside the window
-/// `commit_sign_in` opens between forgetting the cache and saving the new
-/// credential. The old credential really is still installed there, so
-/// that settle is legitimate and nothing but a second forget clears it.
-struct SettlingStore<'a> {
-    inner: MemoryStore,
-    env: &'a Env,
-    body: String,
-}
-
-impl CredentialStore for SettlingStore<'_> {
-    fn save(&self, credential: &Credential) -> Result<()> {
-        write_cache(self.env, &self.body);
-        self.inner.save(credential)
-    }
-    fn load(&self) -> Result<Option<Credential>> {
-        self.inner.load()
-    }
-    fn clear(&self) -> Result<()> {
-        self.inner.clear()
-    }
-    fn refresh_guard(&self) -> Result<Box<dyn CredentialRefreshGuard + '_>> {
-        self.inner.refresh_guard()
-    }
-}
-
-fn write_cache(env: &Env, body: &str) {
-    let dir = env.registry_cache_dir();
-    std::fs::create_dir_all(&dir).expect("mkdir");
-    let generation = serde_json::json!({
-        "endpoint": "https://kendex.ai",
-        "etag": serde_json::Value::Null,
-        "fetched_at": 1,
-        "body": body,
-    });
-    std::fs::write(
-        dir.join("me.cache.json"),
-        serde_json::to_string(&generation).expect("generation"),
-    )
-    .expect("write");
-}
-
-fn other_account() -> Credential {
-    Credential {
-        endpoint: "https://kendex.ai".to_owned(),
-        access_token: "kxa_other".to_owned(),
-        refresh_token: "kxr_other".to_owned(),
-        capabilities: vec![],
-    }
-}
 
 fn env_in(dir: &Path) -> Env {
     Env::fake(dir, FakeOs::Linux)
@@ -426,57 +289,6 @@ fn a_rotation_the_server_still_rejects_reads_as_expired() {
     let state = me::load(&env_in(dir.path()), &fetch, &MemoryStore::signed_in()).expect("load");
     assert_eq!(state, AccountState::Expired);
 }
-
-#[test]
-fn logout_winning_the_race_reads_as_signed_out() {
-    let dir = tempfile::tempdir().expect("tempdir");
-    // The guard's read and with_access's first read still see the
-    // credential; the locked re-read after the 401 finds it gone.
-    let store = VanishingStore {
-        loads_before_gone: RefCell::new(2),
-        credential: Credential {
-            endpoint: "https://kendex.ai".to_owned(),
-            access_token: "kxa_old".to_owned(),
-            refresh_token: "kxr_old".to_owned(),
-            capabilities: vec![],
-        },
-    };
-    let fetch = Canned::new(vec![ok(401, None, r#"{"error":"invalid_token"}"#)]);
-    let state = me::load(&env_in(dir.path()), &fetch, &store).expect("load");
-    assert_eq!(state, AccountState::SignedOut);
-    assert_eq!(
-        *fetch.calls.borrow(),
-        1,
-        "no refresh is attempted once logout won"
-    );
-}
-
-#[test]
-fn a_sign_out_landing_mid_read_is_never_written_back() {
-    let dir = tempfile::tempdir().expect("tempdir");
-    let env = env_in(dir.path());
-    // The opening check and with_access both still see the credential; by
-    // the time the answer is settled, sign-out has cleared it.
-    let store = VanishingStore {
-        loads_before_gone: RefCell::new(2),
-        credential: Credential {
-            endpoint: "https://kendex.ai".to_owned(),
-            access_token: "kxa_old".to_owned(),
-            refresh_token: "kxr_old".to_owned(),
-            capabilities: vec![],
-        },
-    };
-    let fetch = Canned::new(vec![ok(200, None, &fixture_body(&["success", "body"]))]);
-    assert_eq!(
-        me::load(&env, &fetch, &store).expect("load"),
-        AccountState::SignedOut
-    );
-    assert!(
-        !env.registry_cache_dir().join("me.cache.json").exists(),
-        "a read finishing after sign-out must leave no identity on disk"
-    );
-}
-
 #[test]
 fn revalidation_sends_the_etag_and_304_keeps_the_identity() {
     let dir = tempfile::tempdir().expect("tempdir");
@@ -641,109 +453,4 @@ fn an_oversized_identity_cache_reads_as_no_cache() {
     );
 }
 
-#[test]
-fn a_read_settling_under_a_replacement_credential_is_discarded() {
-    let dir = tempfile::tempdir().expect("tempdir");
-    let env = env_in(dir.path());
-    let store = MemoryStore::signed_in();
-    // Ada's read is in flight when she signs out and somebody else signs
-    // in. A credential is installed again by the time it settles, so
-    // existence alone would wave this answer through.
-    let racing = RacingFetch::new(
-        &env,
-        &store,
-        Some(other_account()),
-        ok(200, None, &fixture_body(&["success", "body"])),
-    );
-    let refused = me::load(&env, &racing, &store).expect_err("a stale identity must be refused");
-    assert!(
-        matches!(refused, CoreError::RegistryUnavailable { .. }),
-        "a replaced credential is a retryable read, not an account state: got {refused:?}"
-    );
-    assert_eq!(
-        store
-            .load()
-            .expect("load")
-            .expect("credential")
-            .access_token,
-        "kxa_other",
-        "the replacement stays installed; only the answer is dropped"
-    );
-    assert!(
-        !env.registry_cache_dir().join("me.cache.json").exists(),
-        "the previous account's identity must not be cached under its successor"
-    );
-}
-
-#[test]
-fn a_real_sign_out_mid_read_leaves_no_cached_identity() {
-    let dir = tempfile::tempdir().expect("tempdir");
-    let env = env_in(dir.path());
-    let store = MemoryStore::signed_in();
-    let racing = RacingFetch::new(
-        &env,
-        &store,
-        None,
-        ok(200, None, &fixture_body(&["success", "body"])),
-    );
-    assert_eq!(
-        me::load(&env, &racing, &store).expect("load"),
-        AccountState::SignedOut,
-        "a removed credential is signed out, not a refused read"
-    );
-    assert!(
-        !env.registry_cache_dir().join("me.cache.json").exists(),
-        "a read finishing after sign-out must leave no identity on disk"
-    );
-}
-
-#[test]
-fn a_rotation_mid_read_still_settles_the_answer() {
-    let dir = tempfile::tempdir().expect("tempdir");
-    let env = env_in(dir.path());
-    let store = MemoryStore::signed_in();
-    // Refreshing replaces both tokens without changing who is signed in,
-    // so the answer this read comes back with is still that account's.
-    let fetch = Canned::new(vec![
-        ok(401, None, r#"{"error":"invalid_token"}"#),
-        ok(
-            200,
-            None,
-            r#"{"access_token":"kxa_new","refresh_token":"kxr_new","capabilities":[]}"#,
-        ),
-        ok(200, None, &fixture_body(&["success", "body"])),
-    ]);
-    match me::load(&env, &fetch, &store).expect("load") {
-        AccountState::SignedIn { identity } => assert_eq!(identity.name, "Ada Lovelace"),
-        other => panic!("a rotated sign-in is the same sign-in, got {other:?}"),
-    }
-    assert_eq!(
-        store
-            .load()
-            .expect("load")
-            .expect("credential")
-            .refresh_token,
-        "kxr_new",
-        "the rotation is what makes this the case it is"
-    );
-    assert!(
-        env.registry_cache_dir().join("me.cache.json").exists(),
-        "a rotated read caches its identity like any other"
-    );
-}
-
-#[test]
-fn a_sign_in_clears_an_identity_that_settled_while_it_committed() {
-    let dir = tempfile::tempdir().expect("tempdir");
-    let env = env_in(dir.path());
-    let store = SettlingStore {
-        inner: MemoryStore::signed_in(),
-        env: &env,
-        body: fixture_body(&["success", "body"]),
-    };
-    me::commit_sign_in(&env, &store, &other_account()).expect("commit");
-    assert!(
-        !env.registry_cache_dir().join("me.cache.json").exists(),
-        "an identity cached before the new credential landed is still the old account's"
-    );
-}
+mod sign_in_binding;

--- a/crates/core/tests/me_client/main.rs
+++ b/crates/core/tests/me_client/main.rs
@@ -96,6 +96,10 @@ impl MemoryStore {
     fn signed_out() -> MemoryStore {
         MemoryStore(RefCell::new(None))
     }
+
+    fn signed_in_as(credential: Credential) -> MemoryStore {
+        MemoryStore(RefCell::new(Some(credential)))
+    }
 }
 
 impl CredentialStore for MemoryStore {
@@ -117,6 +121,31 @@ impl CredentialStore for MemoryStore {
 
 struct MemoryGuard;
 impl CredentialRefreshGuard for MemoryGuard {}
+
+/// The key a generation carries beside its endpoint, exactly as `me.rs`
+/// writes it. A cache planted by hand needs the sign-in it belongs to, or
+/// the read refuses it for the wrong reason and the test proves nothing.
+fn sign_in_key(refresh_token: &str) -> serde_json::Value {
+    kendex_core::hash::hash_bytes(refresh_token.as_bytes()).into()
+}
+
+/// Plant a generation where a finished read would have left one.
+fn write_cache(env: &Env, body: &str, etag: Option<&str>, sign_in: Option<&str>) {
+    let dir = env.registry_cache_dir();
+    std::fs::create_dir_all(&dir).expect("mkdir");
+    let generation = serde_json::json!({
+        "endpoint": "https://kendex.ai",
+        "credential": sign_in.map(sign_in_key),
+        "etag": etag,
+        "fetched_at": 1,
+        "body": body,
+    });
+    std::fs::write(
+        dir.join("me.cache.json"),
+        serde_json::to_string(&generation).expect("generation"),
+    )
+    .expect("write");
+}
 
 fn env_in(dir: &Path) -> Env {
     Env::fake(dir, FakeOs::Linux)
@@ -328,9 +357,18 @@ fn a_cache_from_another_endpoint_is_never_served() {
     let env = env_in(dir.path());
     let registry_dir = env.registry_cache_dir();
     std::fs::create_dir_all(&registry_dir).expect("mkdir");
+    // This sign-in's own key, so the endpoint is the only thing left to
+    // refuse it.
+    let generation = serde_json::json!({
+        "endpoint": "https://somewhere.else",
+        "credential": sign_in_key("kxr_old"),
+        "etag": serde_json::Value::Null,
+        "fetched_at": 1,
+        "body": r#"{"name":"Stranger","github_login":null}"#,
+    });
     std::fs::write(
         registry_dir.join("me.cache.json"),
-        r#"{"endpoint":"https://somewhere.else","etag":null,"fetched_at":1,"body":"{\"name\":\"Stranger\",\"github_login\":null}"}"#,
+        serde_json::to_string(&generation).expect("generation"),
     )
     .expect("write");
     let down = Canned::new(vec![away()]);
@@ -426,26 +464,15 @@ fn a_304_with_nothing_cached_is_refused() {
 fn an_oversized_identity_cache_reads_as_no_cache() {
     let dir = tempfile::tempdir().expect("tempdir");
     let env = env_in(dir.path());
-    let registry_dir = env.registry_cache_dir();
-    std::fs::create_dir_all(&registry_dir).expect("mkdir");
-    // This endpoint's own generation, holding an identity that parses:
-    // the size is the only thing left to refuse it, so the cap is what
-    // this test measures. A padded body keeps that honest.
+    // This endpoint's and this sign-in's own generation, holding an
+    // identity that parses: the size is the only thing left to refuse it,
+    // so the cap is what this test measures. A padded body keeps that
+    // honest.
     let body = format!(
         r#"{{"name":"Ada Lovelace","github_login":null,"pad":"{}"}}"#,
         "x".repeat(41_000_000)
     );
-    let generation = serde_json::json!({
-        "endpoint": "https://kendex.ai",
-        "etag": serde_json::Value::Null,
-        "fetched_at": 1,
-        "body": body,
-    });
-    std::fs::write(
-        registry_dir.join("me.cache.json"),
-        serde_json::to_string(&generation).expect("generation"),
-    )
-    .expect("write");
+    write_cache(&env, &body, None, Some("kxr_old"));
     let down = Canned::new(vec![away()]);
     assert!(
         me::load(&env, &down, &MemoryStore::signed_in()).is_err(),

--- a/crates/core/tests/me_client/sign_in_binding.rs
+++ b/crates/core/tests/me_client/sign_in_binding.rs
@@ -11,9 +11,10 @@ use kendex_core::env::Env;
 use kendex_core::error::{CoreError, Result};
 use kendex_core::registry::credentials::{Credential, CredentialRefreshGuard, CredentialStore};
 use kendex_core::registry::me::{self, AccountState};
+use kendex_core::registry::submit;
 use kendex_core::registry::{Fetch, FetchResponse};
 
-use super::{Canned, MemoryGuard, MemoryStore, away, env_in, fixture_body, ok, write_cache};
+use super::{ADA, Canned, MemoryGuard, MemoryStore, away, env_in, fixture_body, ok, write_cache};
 
 /// A store whose credential disappears after N loads — logout winning a
 /// race against the read.
@@ -114,7 +115,7 @@ struct SettlingStore<'a> {
 
 impl CredentialStore for SettlingStore<'_> {
     fn save(&self, credential: &Credential) -> Result<()> {
-        write_cache(self.env, &self.body, None, Some("kxr_old"));
+        write_cache(self.env, &self.body, None, Some(ADA));
         self.inner.save(credential)
     }
     fn load(&self) -> Result<Option<Credential>> {
@@ -212,6 +213,7 @@ impl CredentialStore for RestlessStore {
             access_token: format!("kxa_{read}"),
             refresh_token: format!("kxr_{read}"),
             capabilities: vec![],
+            sign_in: format!("sign-in-{read}"),
         }))
     }
     fn clear(&self) -> Result<()> {
@@ -228,6 +230,7 @@ fn other_account() -> Credential {
         access_token: "kxa_other".to_owned(),
         refresh_token: "kxr_other".to_owned(),
         capabilities: vec![],
+        sign_in: "sign-in-other".to_owned(),
     }
 }
 
@@ -243,6 +246,7 @@ fn logout_winning_the_race_reads_as_signed_out() {
             access_token: "kxa_old".to_owned(),
             refresh_token: "kxr_old".to_owned(),
             capabilities: vec![],
+            sign_in: ADA.to_owned(),
         },
     };
     let fetch = Canned::new(vec![ok(401, None, r#"{"error":"invalid_token"}"#)]);
@@ -268,6 +272,7 @@ fn a_sign_out_landing_mid_read_is_never_written_back() {
             access_token: "kxa_old".to_owned(),
             refresh_token: "kxr_old".to_owned(),
             capabilities: vec![],
+            sign_in: ADA.to_owned(),
         },
     };
     let fetch = Canned::new(vec![ok(200, None, &fixture_body(&["success", "body"]))]);
@@ -401,12 +406,7 @@ fn a_read_whose_sign_in_changed_before_the_call(
     etag: Option<&str>,
     answer: Result<FetchResponse>,
 ) -> Result<AccountState> {
-    write_cache(
-        env,
-        &fixture_body(&["success", "body"]),
-        etag,
-        Some("kxr_old"),
-    );
+    write_cache(env, &fixture_body(&["success", "body"]), etag, Some(ADA));
     let store = SwitchingStore::after(1);
     let fetch = Canned::new(vec![answer]);
     me::load(env, &fetch, &store)
@@ -453,12 +453,7 @@ fn a_transport_failure_never_serves_a_cache_from_another_sign_in() {
 fn an_adopted_credential_never_serves_a_cache_from_another_sign_in() {
     let dir = tempfile::tempdir().expect("tempdir");
     let env = env_in(dir.path());
-    write_cache(
-        &env,
-        &fixture_body(&["success", "body"]),
-        None,
-        Some("kxr_old"),
-    );
+    write_cache(&env, &fixture_body(&["success", "body"]), None, Some(ADA));
     // Two reads in, `load` holds its own credential and has read the
     // cache under it. The request then 401s, and the locked re-read finds
     // somebody else's credential, which the call adopts and retries under
@@ -488,12 +483,7 @@ fn a_cache_from_another_sign_in_is_never_served() {
     // that failed, a crash between the two writes, whatever left it
     // there. Somebody else is signed in now and the network is away, so
     // this cache is the only identity on hand.
-    write_cache(
-        &env,
-        &fixture_body(&["success", "body"]),
-        None,
-        Some("kxr_old"),
-    );
+    write_cache(&env, &fixture_body(&["success", "body"]), None, Some(ADA));
     let store = MemoryStore::signed_in_as(other_account());
     let down = Canned::new(vec![away()]);
     assert!(
@@ -532,7 +522,7 @@ fn the_cache_names_the_sign_in_without_holding_its_token() {
         "the cache file is not the keychain"
     );
     assert!(
-        written.contains(&kendex_core::hash::hash_bytes(b"kxr_old")),
+        written.contains(&kendex_core::hash::hash_bytes(ADA.as_bytes())),
         "the generation names the sign-in it belongs to"
     );
 }
@@ -605,4 +595,76 @@ fn a_rejection_under_a_newer_token_is_not_the_next_account_s_expiry() {
         matches!(refused, CoreError::RegistryUnavailable { .. }),
         "the sign-in moved under this call, so the read is retryable: got {refused:?}"
     );
+}
+
+/// A refresh the server answers, rotating both tokens and keeping the
+/// sign-in they belong to.
+fn rotation() -> Result<FetchResponse> {
+    ok(
+        200,
+        None,
+        r#"{"access_token":"kxa_new","refresh_token":"kxr_new","capabilities":[]}"#,
+    )
+}
+
+#[test]
+fn a_rotation_by_another_call_leaves_the_identity_cache_readable() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let env = env_in(dir.path());
+    let store = MemoryStore::signed_in();
+    let first = Canned::new(vec![ok(200, None, &fixture_body(&["success", "body"]))]);
+    me::load(&env, &first, &store).expect("first load");
+
+    // Any authenticated call can rotate, and submissions is one. The
+    // tokens move; the sign-in the cached identity belongs to does not.
+    let rotating = Canned::new(vec![
+        ok(401, None, r#"{"error":"invalid_token"}"#),
+        rotation(),
+        ok(200, None, r#"{"submissions":[]}"#),
+    ]);
+    submit::submissions(&rotating, &store).expect("submissions");
+    assert_eq!(
+        store
+            .load()
+            .expect("load")
+            .expect("credential")
+            .refresh_token,
+        "kxr_new",
+        "the rotation is what makes this the case it is"
+    );
+
+    let down = Canned::new(vec![away()]);
+    match me::load(&env, &down, &store).expect("offline load") {
+        AccountState::Offline { identity } => assert_eq!(identity.name, "Ada Lovelace"),
+        other => panic!("the cached identity outlives a rotation, got {other:?}"),
+    }
+}
+
+#[test]
+fn a_rotation_that_then_fails_leaves_the_identity_cache_readable() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let env = env_in(dir.path());
+    let store = MemoryStore::signed_in();
+    let first = Canned::new(vec![ok(200, None, &fixture_body(&["success", "body"]))]);
+    me::load(&env, &first, &store).expect("first load");
+
+    // This read rotates and then meets a refused status, so it serves the
+    // cache and writes nothing back. What is on disk is still the first
+    // read's generation, and it has to survive the rotation that just
+    // happened under it.
+    let hurt = Canned::new(vec![
+        ok(401, None, r#"{"error":"invalid_token"}"#),
+        rotation(),
+        ok(503, None, r#"{"error":"down"}"#),
+    ]);
+    assert!(matches!(
+        me::load(&env, &hurt, &store).expect("load"),
+        AccountState::Offline { .. }
+    ));
+
+    let down = Canned::new(vec![away()]);
+    match me::load(&env, &down, &store).expect("offline load") {
+        AccountState::Offline { identity } => assert_eq!(identity.name, "Ada Lovelace"),
+        other => panic!("the next read still has that generation, got {other:?}"),
+    }
 }

--- a/crates/core/tests/me_client/sign_in_binding.rs
+++ b/crates/core/tests/me_client/sign_in_binding.rs
@@ -193,6 +193,35 @@ impl CredentialStore for JammingStore<'_> {
     }
 }
 
+/// A store where somebody signs in again between every read: each load
+/// hands back a credential no earlier read saw. It drives the branch that
+/// gives up after two retries under newer tokens.
+struct RestlessStore {
+    reads: Cell<u32>,
+}
+
+impl CredentialStore for RestlessStore {
+    fn save(&self, _credential: &Credential) -> Result<()> {
+        Ok(())
+    }
+    fn load(&self) -> Result<Option<Credential>> {
+        let read = self.reads.get() + 1;
+        self.reads.set(read);
+        Ok(Some(Credential {
+            endpoint: "https://kendex.ai".to_owned(),
+            access_token: format!("kxa_{read}"),
+            refresh_token: format!("kxr_{read}"),
+            capabilities: vec![],
+        }))
+    }
+    fn clear(&self) -> Result<()> {
+        Ok(())
+    }
+    fn refresh_guard(&self) -> Result<Box<dyn CredentialRefreshGuard + '_>> {
+        Ok(Box::new(MemoryGuard))
+    }
+}
+
 fn other_account() -> Credential {
     Credential {
         endpoint: "https://kendex.ai".to_owned(),
@@ -526,5 +555,54 @@ fn a_sign_in_that_cannot_clear_the_cache_still_reports_success() {
             .refresh_token,
         "kxr_other",
         "the sign-in this call reported is the one the machine holds"
+    );
+}
+
+#[test]
+fn a_rejection_after_a_rotation_is_not_the_next_account_s_expiry() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let env = env_in(dir.path());
+    // Four reads carry this sign-in: the read's own, the call's, the
+    // locked re-read, and the check before the rotation is saved. The
+    // fifth is the one that decides whether the rejection is an expiry,
+    // and by then somebody else is signed in.
+    let store = SwitchingStore::after(4);
+    let fetch = Canned::new(vec![
+        ok(401, None, r#"{"error":"invalid_token"}"#),
+        ok(
+            200,
+            None,
+            r#"{"access_token":"kxa_new","refresh_token":"kxr_new","capabilities":[]}"#,
+        ),
+        ok(401, None, r#"{"error":"invalid_token"}"#),
+    ]);
+    let refused = me::load(&env, &fetch, &store)
+        .expect_err("one account's rejection is not another account's expiry");
+    assert!(
+        matches!(refused, CoreError::RegistryUnavailable { .. }),
+        "the sign-in moved under this call, so the read is retryable: got {refused:?}"
+    );
+}
+
+#[test]
+fn a_rejection_under_a_newer_token_is_not_the_next_account_s_expiry() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let env = env_in(dir.path());
+    // Every read finds a newer credential, so the call keeps retrying
+    // under somebody else's token until it gives up. Whoever is signed in
+    // by then never had a request rejected.
+    let store = RestlessStore {
+        reads: Cell::new(0),
+    };
+    let fetch = Canned::new(vec![
+        ok(401, None, r#"{"error":"invalid_token"}"#),
+        ok(401, None, r#"{"error":"invalid_token"}"#),
+        ok(401, None, r#"{"error":"invalid_token"}"#),
+    ]);
+    let refused = me::load(&env, &fetch, &store)
+        .expect_err("a rejection under a token that keeps moving is nobody's expiry");
+    assert!(
+        matches!(refused, CoreError::RegistryUnavailable { .. }),
+        "the sign-in moved under this call, so the read is retryable: got {refused:?}"
     );
 }

--- a/crates/core/tests/me_client/sign_in_binding.rs
+++ b/crates/core/tests/me_client/sign_in_binding.rs
@@ -13,7 +13,7 @@ use kendex_core::registry::credentials::{Credential, CredentialRefreshGuard, Cre
 use kendex_core::registry::me::{self, AccountState};
 use kendex_core::registry::{Fetch, FetchResponse};
 
-use super::{Canned, MemoryGuard, MemoryStore, away, env_in, fixture_body, ok};
+use super::{Canned, MemoryGuard, MemoryStore, away, env_in, fixture_body, ok, write_cache};
 
 /// A store whose credential disappears after N loads — logout winning a
 /// race against the read.
@@ -114,7 +114,7 @@ struct SettlingStore<'a> {
 
 impl CredentialStore for SettlingStore<'_> {
     fn save(&self, credential: &Credential) -> Result<()> {
-        write_cache(self.env, &self.body, None);
+        write_cache(self.env, &self.body, None, Some("kxr_old"));
         self.inner.save(credential)
     }
     fn load(&self) -> Result<Option<Credential>> {
@@ -126,22 +126,6 @@ impl CredentialStore for SettlingStore<'_> {
     fn refresh_guard(&self) -> Result<Box<dyn CredentialRefreshGuard + '_>> {
         self.inner.refresh_guard()
     }
-}
-
-fn write_cache(env: &Env, body: &str, etag: Option<&str>) {
-    let dir = env.registry_cache_dir();
-    std::fs::create_dir_all(&dir).expect("mkdir");
-    let generation = serde_json::json!({
-        "endpoint": "https://kendex.ai",
-        "etag": etag,
-        "fetched_at": 1,
-        "body": body,
-    });
-    std::fs::write(
-        dir.join("me.cache.json"),
-        serde_json::to_string(&generation).expect("generation"),
-    )
-    .expect("write");
 }
 
 /// A store that hands out one credential for the first `loads` reads and
@@ -181,6 +165,31 @@ impl CredentialStore for SwitchingStore {
     }
     fn refresh_guard(&self) -> Result<Box<dyn CredentialRefreshGuard + '_>> {
         Ok(Box::new(MemoryGuard))
+    }
+}
+
+/// A store that jams the cache path shut as the sign-in saves: a
+/// directory where the file goes, which `remove_file` refuses. The first
+/// forget has already run by then, so this hits only the second.
+struct JammingStore<'a> {
+    inner: MemoryStore,
+    env: &'a Env,
+}
+
+impl CredentialStore for JammingStore<'_> {
+    fn save(&self, credential: &Credential) -> Result<()> {
+        let jam = self.env.registry_cache_dir().join("me.cache.json");
+        std::fs::create_dir_all(&jam).expect("jam the cache path");
+        self.inner.save(credential)
+    }
+    fn load(&self) -> Result<Option<Credential>> {
+        self.inner.load()
+    }
+    fn clear(&self) -> Result<()> {
+        self.inner.clear()
+    }
+    fn refresh_guard(&self) -> Result<Box<dyn CredentialRefreshGuard + '_>> {
+        self.inner.refresh_guard()
     }
 }
 
@@ -328,10 +337,13 @@ fn a_rotation_mid_read_still_settles_the_answer() {
         "kxr_new",
         "the rotation is what makes this the case it is"
     );
-    assert!(
-        env.registry_cache_dir().join("me.cache.json").exists(),
-        "a rotated read caches its identity like any other"
-    );
+    // Keyed to the credential the answer went out under, not the one the
+    // read opened with, or the next read would find nothing.
+    let down = Canned::new(vec![away()]);
+    match me::load(&env, &down, &store).expect("offline load") {
+        AccountState::Offline { identity } => assert_eq!(identity.name, "Ada Lovelace"),
+        other => panic!("the rotated read's cache is still this sign-in's, got {other:?}"),
+    }
 }
 
 #[test]
@@ -360,7 +372,12 @@ fn a_read_whose_sign_in_changed_before_the_call(
     etag: Option<&str>,
     answer: Result<FetchResponse>,
 ) -> Result<AccountState> {
-    write_cache(env, &fixture_body(&["success", "body"]), etag);
+    write_cache(
+        env,
+        &fixture_body(&["success", "body"]),
+        etag,
+        Some("kxr_old"),
+    );
     let store = SwitchingStore::after(1);
     let fetch = Canned::new(vec![answer]);
     me::load(env, &fetch, &store)
@@ -407,7 +424,12 @@ fn a_transport_failure_never_serves_a_cache_from_another_sign_in() {
 fn an_adopted_credential_never_serves_a_cache_from_another_sign_in() {
     let dir = tempfile::tempdir().expect("tempdir");
     let env = env_in(dir.path());
-    write_cache(&env, &fixture_body(&["success", "body"]), None);
+    write_cache(
+        &env,
+        &fixture_body(&["success", "body"]),
+        None,
+        Some("kxr_old"),
+    );
     // Two reads in, `load` holds its own credential and has read the
     // cache under it. The request then 401s, and the locked re-read finds
     // somebody else's credential, which the call adopts and retries under
@@ -426,5 +448,83 @@ fn an_adopted_credential_never_serves_a_cache_from_another_sign_in() {
         *fetch.calls.borrow(),
         2,
         "the retry under the adopted credential is what this test is about"
+    );
+}
+
+#[test]
+fn a_cache_from_another_sign_in_is_never_served() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let env = env_in(dir.path());
+    // The previous account's generation outlived its sign-out — a forget
+    // that failed, a crash between the two writes, whatever left it
+    // there. Somebody else is signed in now and the network is away, so
+    // this cache is the only identity on hand.
+    write_cache(
+        &env,
+        &fixture_body(&["success", "body"]),
+        None,
+        Some("kxr_old"),
+    );
+    let store = MemoryStore::signed_in_as(other_account());
+    let down = Canned::new(vec![away()]);
+    assert!(
+        me::load(&env, &down, &store).is_err(),
+        "the previous account's name is not this account's offline identity"
+    );
+}
+
+#[test]
+fn a_generation_carrying_no_sign_in_is_never_served() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let env = env_in(dir.path());
+    // A generation that names no sign-in cannot be shown to belong to
+    // this one, so it is another sign-in's as far as the read is
+    // concerned.
+    write_cache(&env, &fixture_body(&["success", "body"]), None, None);
+    let down = Canned::new(vec![away()]);
+    assert!(
+        me::load(&env, &down, &MemoryStore::signed_in()).is_err(),
+        "an unkeyed generation is not this sign-in's identity"
+    );
+}
+
+#[test]
+fn the_cache_names_the_sign_in_without_holding_its_token() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let env = env_in(dir.path());
+    let store = MemoryStore::signed_in();
+    let fetch = Canned::new(vec![ok(200, None, &fixture_body(&["success", "body"]))]);
+    me::load(&env, &fetch, &store).expect("load");
+
+    let written = std::fs::read_to_string(env.registry_cache_dir().join("me.cache.json"))
+        .expect("the read cached its answer");
+    assert!(
+        !written.contains("kxr_old"),
+        "the cache file is not the keychain"
+    );
+    assert!(
+        written.contains(&kendex_core::hash::hash_bytes(b"kxr_old")),
+        "the generation names the sign-in it belongs to"
+    );
+}
+
+#[test]
+fn a_sign_in_that_cannot_clear_the_cache_still_reports_success() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let env = env_in(dir.path());
+    let store = JammingStore {
+        inner: MemoryStore::signed_in(),
+        env: &env,
+    };
+    me::commit_sign_in(&env, &store, &other_account())
+        .expect("the credential is installed, so the sign-in did not fail");
+    assert_eq!(
+        store
+            .load()
+            .expect("load")
+            .expect("credential")
+            .refresh_token,
+        "kxr_other",
+        "the sign-in this call reported is the one the machine holds"
     );
 }

--- a/crates/core/tests/me_client/sign_in_binding.rs
+++ b/crates/core/tests/me_client/sign_in_binding.rs
@@ -1,0 +1,404 @@
+//! Which sign-in an identity read belongs to. Everything here drives a
+//! credential changing while a read is in flight: logout winning the
+//! race, a sign-out landing mid-read, a sign-in as somebody else before
+//! or after the call, and a refresh rotation, which changes both tokens
+//! and is the one case that must still settle. The transports and stores
+//! here exist to place that change at an exact point in `load`.
+
+use std::cell::{Cell, RefCell};
+
+use kendex_core::env::Env;
+use kendex_core::error::{CoreError, Result};
+use kendex_core::registry::credentials::{Credential, CredentialRefreshGuard, CredentialStore};
+use kendex_core::registry::me::{self, AccountState};
+use kendex_core::registry::{Fetch, FetchResponse};
+
+use super::{Canned, MemoryGuard, MemoryStore, away, env_in, fixture_body, ok};
+
+/// A store whose credential disappears after N loads — logout winning a
+/// race against the read.
+struct VanishingStore {
+    loads_before_gone: RefCell<u32>,
+    credential: Credential,
+}
+
+impl CredentialStore for VanishingStore {
+    fn save(&self, _credential: &Credential) -> Result<()> {
+        Ok(())
+    }
+    fn load(&self) -> Result<Option<Credential>> {
+        let mut left = self.loads_before_gone.borrow_mut();
+        if *left == 0 {
+            return Ok(None);
+        }
+        *left -= 1;
+        Ok(Some(self.credential.clone()))
+    }
+    fn clear(&self) -> Result<()> {
+        Ok(())
+    }
+    fn refresh_guard(&self) -> Result<Box<dyn CredentialRefreshGuard + '_>> {
+        Ok(Box::new(MemoryGuard))
+    }
+}
+
+/// A transport that lets the sign-out — and, when one is given, the
+/// sign-in that follows it — land while the identity request is still
+/// outstanding. That is the only moment the race is reachable inside one
+/// process: the request hangs on the curl cap while the user signs out
+/// and completes a device flow as somebody else.
+struct RacingFetch<'a> {
+    env: &'a Env,
+    store: &'a MemoryStore,
+    signs_in_as: Option<Credential>,
+    answer: RefCell<Option<Result<FetchResponse>>>,
+    raced: Cell<bool>,
+}
+
+impl<'a> RacingFetch<'a> {
+    fn new(
+        env: &'a Env,
+        store: &'a MemoryStore,
+        signs_in_as: Option<Credential>,
+        answer: Result<FetchResponse>,
+    ) -> RacingFetch<'a> {
+        RacingFetch {
+            env,
+            store,
+            signs_in_as,
+            answer: RefCell::new(Some(answer)),
+            raced: Cell::new(false),
+        }
+    }
+}
+
+impl Fetch for RacingFetch<'_> {
+    fn get_auth(
+        &self,
+        _url: &str,
+        _if_none_match: Option<&str>,
+        _bearer: Option<&str>,
+    ) -> Result<FetchResponse> {
+        if !self.raced.replace(true) {
+            let revoke = Canned::new(vec![ok(200, None, "{}")]);
+            me::sign_out(self.env, &revoke, self.store).expect("sign out mid-read");
+            if let Some(next) = &self.signs_in_as {
+                me::commit_sign_in(self.env, self.store, next).expect("sign in mid-read");
+            }
+        }
+        self.answer
+            .borrow_mut()
+            .take()
+            .expect("the read asked twice")
+    }
+
+    fn post_json_auth(
+        &self,
+        _url: &str,
+        _body: &str,
+        _bearer: Option<&str>,
+    ) -> Result<FetchResponse> {
+        panic!("the identity read posts nothing")
+    }
+}
+
+/// A store that lets an identity read settle inside the window
+/// `commit_sign_in` opens between forgetting the cache and saving the new
+/// credential. The old credential really is still installed there, so
+/// that settle is legitimate and nothing but a second forget clears it.
+struct SettlingStore<'a> {
+    inner: MemoryStore,
+    env: &'a Env,
+    body: String,
+}
+
+impl CredentialStore for SettlingStore<'_> {
+    fn save(&self, credential: &Credential) -> Result<()> {
+        write_cache(self.env, &self.body, None);
+        self.inner.save(credential)
+    }
+    fn load(&self) -> Result<Option<Credential>> {
+        self.inner.load()
+    }
+    fn clear(&self) -> Result<()> {
+        self.inner.clear()
+    }
+    fn refresh_guard(&self) -> Result<Box<dyn CredentialRefreshGuard + '_>> {
+        self.inner.refresh_guard()
+    }
+}
+
+fn write_cache(env: &Env, body: &str, etag: Option<&str>) {
+    let dir = env.registry_cache_dir();
+    std::fs::create_dir_all(&dir).expect("mkdir");
+    let generation = serde_json::json!({
+        "endpoint": "https://kendex.ai",
+        "etag": etag,
+        "fetched_at": 1,
+        "body": body,
+    });
+    std::fs::write(
+        dir.join("me.cache.json"),
+        serde_json::to_string(&generation).expect("generation"),
+    )
+    .expect("write");
+}
+
+/// A store that hands out one credential for the first `loads` reads and
+/// somebody else's after that. Two reads in, `load` has taken its own
+/// credential and read the cache under it, and the call is about to read
+/// the store for itself: that is the window a sign-in lands in.
+struct SwitchingStore {
+    loads: RefCell<u32>,
+    before: Credential,
+    after: Credential,
+}
+
+impl SwitchingStore {
+    fn after(loads: u32) -> SwitchingStore {
+        SwitchingStore {
+            loads: RefCell::new(loads),
+            before: MemoryStore::signed_in().0.into_inner().expect("credential"),
+            after: other_account(),
+        }
+    }
+}
+
+impl CredentialStore for SwitchingStore {
+    fn save(&self, _credential: &Credential) -> Result<()> {
+        Ok(())
+    }
+    fn load(&self) -> Result<Option<Credential>> {
+        let mut left = self.loads.borrow_mut();
+        if *left == 0 {
+            return Ok(Some(self.after.clone()));
+        }
+        *left -= 1;
+        Ok(Some(self.before.clone()))
+    }
+    fn clear(&self) -> Result<()> {
+        Ok(())
+    }
+    fn refresh_guard(&self) -> Result<Box<dyn CredentialRefreshGuard + '_>> {
+        Ok(Box::new(MemoryGuard))
+    }
+}
+
+fn other_account() -> Credential {
+    Credential {
+        endpoint: "https://kendex.ai".to_owned(),
+        access_token: "kxa_other".to_owned(),
+        refresh_token: "kxr_other".to_owned(),
+        capabilities: vec![],
+    }
+}
+
+#[test]
+fn logout_winning_the_race_reads_as_signed_out() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    // The guard's read and with_access's first read still see the
+    // credential; the locked re-read after the 401 finds it gone.
+    let store = VanishingStore {
+        loads_before_gone: RefCell::new(2),
+        credential: Credential {
+            endpoint: "https://kendex.ai".to_owned(),
+            access_token: "kxa_old".to_owned(),
+            refresh_token: "kxr_old".to_owned(),
+            capabilities: vec![],
+        },
+    };
+    let fetch = Canned::new(vec![ok(401, None, r#"{"error":"invalid_token"}"#)]);
+    let state = me::load(&env_in(dir.path()), &fetch, &store).expect("load");
+    assert_eq!(state, AccountState::SignedOut);
+    assert_eq!(
+        *fetch.calls.borrow(),
+        1,
+        "no refresh is attempted once logout won"
+    );
+}
+
+#[test]
+fn a_sign_out_landing_mid_read_is_never_written_back() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let env = env_in(dir.path());
+    // The opening check and with_access both still see the credential; by
+    // the time the answer is settled, sign-out has cleared it.
+    let store = VanishingStore {
+        loads_before_gone: RefCell::new(2),
+        credential: Credential {
+            endpoint: "https://kendex.ai".to_owned(),
+            access_token: "kxa_old".to_owned(),
+            refresh_token: "kxr_old".to_owned(),
+            capabilities: vec![],
+        },
+    };
+    let fetch = Canned::new(vec![ok(200, None, &fixture_body(&["success", "body"]))]);
+    assert_eq!(
+        me::load(&env, &fetch, &store).expect("load"),
+        AccountState::SignedOut
+    );
+    assert!(
+        !env.registry_cache_dir().join("me.cache.json").exists(),
+        "a read finishing after sign-out must leave no identity on disk"
+    );
+}
+
+#[test]
+fn a_read_settling_under_a_replacement_credential_is_discarded() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let env = env_in(dir.path());
+    let store = MemoryStore::signed_in();
+    // Ada's read is in flight when she signs out and somebody else signs
+    // in. A credential is installed again by the time it settles, so
+    // existence alone would wave this answer through.
+    let racing = RacingFetch::new(
+        &env,
+        &store,
+        Some(other_account()),
+        ok(200, None, &fixture_body(&["success", "body"])),
+    );
+    let refused = me::load(&env, &racing, &store).expect_err("a stale identity must be refused");
+    assert!(
+        matches!(refused, CoreError::RegistryUnavailable { .. }),
+        "a replaced credential is a retryable read, not an account state: got {refused:?}"
+    );
+    assert_eq!(
+        store
+            .load()
+            .expect("load")
+            .expect("credential")
+            .access_token,
+        "kxa_other",
+        "the replacement stays installed; only the answer is dropped"
+    );
+    assert!(
+        !env.registry_cache_dir().join("me.cache.json").exists(),
+        "the previous account's identity must not be cached under its successor"
+    );
+}
+
+#[test]
+fn a_real_sign_out_mid_read_leaves_no_cached_identity() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let env = env_in(dir.path());
+    let store = MemoryStore::signed_in();
+    let racing = RacingFetch::new(
+        &env,
+        &store,
+        None,
+        ok(200, None, &fixture_body(&["success", "body"])),
+    );
+    assert_eq!(
+        me::load(&env, &racing, &store).expect("load"),
+        AccountState::SignedOut,
+        "a removed credential is signed out, not a refused read"
+    );
+    assert!(
+        !env.registry_cache_dir().join("me.cache.json").exists(),
+        "a read finishing after sign-out must leave no identity on disk"
+    );
+}
+
+#[test]
+fn a_rotation_mid_read_still_settles_the_answer() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let env = env_in(dir.path());
+    let store = MemoryStore::signed_in();
+    // Refreshing replaces both tokens without changing who is signed in,
+    // so the answer this read comes back with is still that account's.
+    let fetch = Canned::new(vec![
+        ok(401, None, r#"{"error":"invalid_token"}"#),
+        ok(
+            200,
+            None,
+            r#"{"access_token":"kxa_new","refresh_token":"kxr_new","capabilities":[]}"#,
+        ),
+        ok(200, None, &fixture_body(&["success", "body"])),
+    ]);
+    match me::load(&env, &fetch, &store).expect("load") {
+        AccountState::SignedIn { identity } => assert_eq!(identity.name, "Ada Lovelace"),
+        other => panic!("a rotated sign-in is the same sign-in, got {other:?}"),
+    }
+    assert_eq!(
+        store
+            .load()
+            .expect("load")
+            .expect("credential")
+            .refresh_token,
+        "kxr_new",
+        "the rotation is what makes this the case it is"
+    );
+    assert!(
+        env.registry_cache_dir().join("me.cache.json").exists(),
+        "a rotated read caches its identity like any other"
+    );
+}
+
+#[test]
+fn a_sign_in_clears_an_identity_that_settled_while_it_committed() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let env = env_in(dir.path());
+    let store = SettlingStore {
+        inner: MemoryStore::signed_in(),
+        env: &env,
+        body: fixture_body(&["success", "body"]),
+    };
+    me::commit_sign_in(&env, &store, &other_account()).expect("commit");
+    assert!(
+        !env.registry_cache_dir().join("me.cache.json").exists(),
+        "an identity cached before the new credential landed is still the old account's"
+    );
+}
+
+/// The identity cached under one account, read into this call, and then
+/// somebody else's credential installed before the request goes out. What
+/// comes back from the server decides which route would serve the cache:
+/// a 304 hands it back whole, a refused status and a transport failure
+/// each serve it as offline. None of them may.
+fn a_read_whose_sign_in_changed_before_the_call(
+    env: &Env,
+    etag: Option<&str>,
+    answer: Result<FetchResponse>,
+) -> Result<AccountState> {
+    write_cache(env, &fixture_body(&["success", "body"]), etag);
+    let store = SwitchingStore::after(1);
+    let fetch = Canned::new(vec![answer]);
+    me::load(env, &fetch, &store)
+}
+
+#[test]
+fn a_refused_status_never_serves_a_cache_from_another_sign_in() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let env = env_in(dir.path());
+    let refused = a_read_whose_sign_in_changed_before_the_call(
+        &env,
+        None,
+        ok(503, None, r#"{"error":"down"}"#),
+    )
+    .expect_err("the cached identity belongs to the previous account");
+    assert!(
+        matches!(refused, CoreError::RegistryUnavailable { .. }),
+        "a changed sign-in is a retryable read: got {refused:?}"
+    );
+}
+
+#[test]
+fn a_304_never_serves_a_cache_from_another_sign_in() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let env = env_in(dir.path());
+    assert!(
+        a_read_whose_sign_in_changed_before_the_call(&env, Some("\"v1\""), ok(304, None, ""))
+            .is_err(),
+        "'unchanged' answers the etag of a cache this credential never saw"
+    );
+}
+
+#[test]
+fn a_transport_failure_never_serves_a_cache_from_another_sign_in() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let env = env_in(dir.path());
+    assert!(
+        a_read_whose_sign_in_changed_before_the_call(&env, None, away()).is_err(),
+        "the offline identity would be the previous account's"
+    );
+}

--- a/crates/core/tests/me_client/sign_in_binding.rs
+++ b/crates/core/tests/me_client/sign_in_binding.rs
@@ -402,3 +402,29 @@ fn a_transport_failure_never_serves_a_cache_from_another_sign_in() {
         "the offline identity would be the previous account's"
     );
 }
+
+#[test]
+fn an_adopted_credential_never_serves_a_cache_from_another_sign_in() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let env = env_in(dir.path());
+    write_cache(&env, &fixture_body(&["success", "body"]), None);
+    // Two reads in, `load` holds its own credential and has read the
+    // cache under it. The request then 401s, and the locked re-read finds
+    // somebody else's credential, which the call adopts and retries under
+    // rather than refreshing. The answer is theirs; the cache is not.
+    let store = SwitchingStore::after(2);
+    let fetch = Canned::new(vec![
+        ok(401, None, r#"{"error":"invalid_token"}"#),
+        ok(503, None, r#"{"error":"down"}"#),
+    ]);
+    let refused = me::load(&env, &fetch, &store).expect_err("an adopted sign-in is not this one");
+    assert!(
+        matches!(refused, CoreError::RegistryUnavailable { .. }),
+        "an adopted sign-in is a retryable read: got {refused:?}"
+    );
+    assert_eq!(
+        *fetch.calls.borrow(),
+        2,
+        "the retry under the adopted credential is what this test is about"
+    );
+}

--- a/crates/core/tests/submit_client.rs
+++ b/crates/core/tests/submit_client.rs
@@ -71,6 +71,7 @@ impl MemoryStore {
             access_token: "kxa_old".to_owned(),
             refresh_token: "kxr_old".to_owned(),
             capabilities: vec!["submission:write".to_owned()],
+            sign_in: "sign-in-old".to_owned(),
         })))
     }
 }
@@ -605,6 +606,7 @@ fn replacement_login() -> Credential {
         access_token: "kxa_login".to_owned(),
         refresh_token: "kxr_login".to_owned(),
         capabilities: vec!["submission:write".to_owned()],
+        sign_in: "sign-in-login".to_owned(),
     }
 }
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -665,16 +665,16 @@ lives in one capability table read by core and UI.
   `source/index.rs` feeds kendex.ai under the site's own caps, refusing
   structural problems whole, dropping only unusable rows. `generation.rs` is
   the one cache mechanism: an endpoint-keyed generation written atomically
-  under `Env::registry_cache_dir`, a failed refresh serving the last fetch
-  labeled stale. `cache.rs` adds the directory's one-hour TTL; the identity
-  (`me.rs`) has none and is forgotten on sign-in, sign-out and expiry. All
-  reads go through the `Fetch` trait (curl via `Hardened`, plain http only
-  under `KENDEX_API`); tests inject transports. Bearer calls route through
-  `registry/client.rs`: one named cross-process lock serializes login,
+  under `Env::registry_cache_dir`, a failed refresh serving the last fetch as
+  stale. `cache.rs` adds the directory's one-hour TTL; the identity (`me.rs`)
+  has none, is keyed to its sign-in, and is forgotten on sign-in, sign-out and
+  expiry. All reads go through the `Fetch` trait (curl via `Hardened`, plain
+  http only under `KENDEX_API`); tests inject transports. Bearer calls route
+  through `registry/client.rs`: one named cross-process lock serializes login,
   logout and refresh rotation, saving rotations before retry. `skillssh.rs`
   pins its public wire schema and kill switch (`KENDEX_SKILLSSH=off`); a hit
-  is a lead, never an identity, and installs through the same subscribe
-  path. Collections and deep links arrive with W3/W4.
+  is a lead, never an identity, and installs through the same subscribe path.
+  Collections and deep links arrive with W3/W4.
 - **Intent in the manifest, closure in the plan, edges in the lock.** The
   manifest records choices, never consequences: items asked for, bundles
   installed, optional dependencies taken, what stays removed. A bundle's


### PR DESCRIPTION
`me::load` rechecked the credential after its fetch with `store.load()?.is_none()`. That asks whether a credential exists, which a sign-out followed by a sign-in as somebody else answers yes — so account A's in-flight answer settled under account B, was returned as B, and was written to a cache with no TTL that later served it as `Offline`.

The recheck is now an identity, not an existence. `client::with_access` returns the credential the call finally went out under, and `load` refuses unless that credential is the one still installed.

## Why the credential and not a counter

A rotation and a replacement both change the token family, so the family alone cannot tell them apart — but the only rotation that can legitimately intervene is the one `with_access` performs inside this very call, and it saves the replacement before the call goes out. Binding to the credential the call used makes rotation compare equal without needing a second signal.

This is the shape `client.rs` already uses: `rotate_locked` and `logout` decide the same question by comparing refresh-token families and refusing with `sign_in_changed`. Two of the three sites this touches are that comparison.

A transport error returns no credential to bind, so the read binds to the one it started with and a failure behind a rotation is refused rather than served from cache — the same conservative answer.

## commit_sign_in forgets twice

Once before the save, so a crash between the two leaves no inherited identity; once after, because a read settling in that window held a credential that was genuinely installed and had every right to cache it. Without the second forget the previous account's name landed in the file the sign-in had just cleared.

## Scope

The in-process race, per the issue. The cross-process variant and the residual window between the recheck and `cache.settle` are the declined class — races between two invocations on one machine, per kendex#1687.

## What the guard compares

The sign-in's own name. `commit_login` mints it once, from the digest of the refresh token the device flow issued; every rotation copies it and only a new sign-in changes it. The cache it opens with, the call it sends and the answer it settles all have to carry that one name.

That makes a rotation performed by any caller settle normally, including one this read adopted from a concurrent `submit` — a rotation preserves the sign-in, so it is still the same account, and the binding is meant to allow it. A different account signing in changes the name and is refused as retryable.

An earlier revision of this PR refused the adopted-rotation case and this description said so. That was a consequence of keying on a token that moved on both rotation and replacement, not something worth keeping: naming the sign-in draws the line by itself, so `Authenticated` no longer carries an origin marker and `load` no longer re-keys before settling.

Closes KEN-739
