### PR TITLE
fix(KEN-552): main goes green — the cap, and the macOS fixture root

### DIFF
--- a/changelog.d/added/KEN-552.md
+++ b/changelog.d/added/KEN-552.md
@@ -1,3 +1,3 @@
-- `add`, `apply`, `check`, `refresh`, `remove` and `verify` frame their output on
-  a terminal and close on what they did; other verbs keep plain lines.
+- `add`, `apply`, `check`, `refresh`, `remove` and `verify` frame and group their
+  output on a terminal and close on what they did; others keep plain lines.
   `KENDEX_UI=plain|pretty` forces either.

--- a/changelog.d/added/KEN-552.md
+++ b/changelog.d/added/KEN-552.md
@@ -1,3 +1,3 @@
-- `add`, `apply`, `check`, `refresh`, `remove` and `verify` frame and group
-  their output on a terminal and close on what they did; every other verb
-  keeps its plain lines. `KENDEX_UI=plain|pretty` forces either rendering.
+- `add`, `apply`, `check`, `refresh`, `remove` and `verify` frame their output on
+  a terminal and close on what they did; other verbs keep plain lines.
+  `KENDEX_UI=plain|pretty` forces either.

--- a/changelog.d/changed/KEN-552.md
+++ b/changelog.d/changed/KEN-552.md
@@ -1,3 +1,3 @@
-- CLI stdout is byte-identical for every verb. On stderr `apply` and `add`
-  close on the outcome ledger, `remove` heads its ops `changes:`, `check`
-  ends on a needs-attention line, and `verify` prints its verdict last.
+- CLI stdout is byte-identical for all verbs. On stderr `apply` and `add` close
+  on the outcome ledger, `remove` heads its ops `changes:`, `check` on a
+  needs-attention line and `verify` on its verdict.

--- a/crates/cli/tests/presentation/main.rs
+++ b/crates/cli/tests/presentation/main.rs
@@ -29,6 +29,20 @@ pub fn escaped_the_frame(printed: &str) -> Vec<String> {
     loose
 }
 
+/// The fixture root as the binary will see it. A macOS temporary
+/// directory resolves under `/private`, so a fixture that keeps the path
+/// it was handed builds project and catalog paths the run never prints:
+/// what it prints is the resolved form, which merely ends with the one
+/// the fixture holds. Redaction keyed to the unresolved path then leaves
+/// `/private` standing in front of the placeholder, and a fixture that
+/// compares its own paths against printed ones never matches.
+#[allow(clippy::unwrap_used)]
+pub fn rooted(tmp: &tempfile::TempDir) -> PathBuf {
+    tmp.path()
+        .canonicalize()
+        .unwrap_or_else(|_| tmp.path().to_owned())
+}
+
 #[allow(clippy::expect_used)]
 fn kendex(home: &Path, cwd: &Path, ui: &str, args: &[&str]) -> Output {
     Command::new(env!("CARGO_BIN_EXE_kendex"))
@@ -165,7 +179,7 @@ fn blocked_project_at(home: &Path, project: &Path) {
 #[allow(clippy::unwrap_used)]
 pub fn nothing_declared(args: &[&str]) -> Output {
     let tmp = tempfile::tempdir().unwrap();
-    let home = tmp.path();
+    let home = &rooted(&tmp);
     let project = home.join("dev/app");
     fs::create_dir_all(project.join(".claude")).unwrap();
     fs::write(project.join("kendex.toml"), "schema = 6\n").unwrap();
@@ -179,7 +193,7 @@ pub fn nothing_declared(args: &[&str]) -> Output {
 #[allow(clippy::unwrap_used)]
 pub fn both(args: &[&str]) -> (String, String) {
     let tmp = tempfile::tempdir().unwrap();
-    let home = tmp.path();
+    let home = &rooted(&tmp);
     let catalog = home.join("catalog").display().to_string();
     let filled: Vec<String> = args
         .iter()
@@ -205,7 +219,7 @@ pub fn both(args: &[&str]) -> (String, String) {
 #[allow(clippy::unwrap_used)]
 pub fn one(ui: &str, args: &[&str]) -> Ran {
     let tmp = tempfile::tempdir().unwrap();
-    let home = tmp.path().to_owned();
+    let home = rooted(&tmp);
     let catalog = home.join("catalog").display().to_string();
     let filled: Vec<String> = args
         .iter()

--- a/crates/cli/tests/presentation/plain.rs
+++ b/crates/cli/tests/presentation/plain.rs
@@ -11,7 +11,7 @@ use super::*;
 #[allow(clippy::unwrap_used)]
 fn the_blocked_refresh_prints_the_lines_scripts_parse() {
     let tmp = tempfile::tempdir().unwrap();
-    let home = tmp.path();
+    let home = &rooted(&tmp);
     let project = blocked_project(home);
     let printed = said(&kendex(
         home,
@@ -63,7 +63,7 @@ fn the_blocked_refresh_prints_the_lines_scripts_parse() {
 #[allow(clippy::unwrap_used)]
 fn the_blocked_refresh_reads_under_twenty_lines() {
     let tmp = tempfile::tempdir().unwrap();
-    let home = tmp.path();
+    let home = &rooted(&tmp);
     let project = blocked_project(home);
     let printed = said(&kendex(
         home,
@@ -81,7 +81,7 @@ fn the_blocked_refresh_reads_under_twenty_lines() {
 #[allow(clippy::unwrap_used)]
 fn nothing_is_said_twice() {
     let tmp = tempfile::tempdir().unwrap();
-    let home = tmp.path();
+    let home = &rooted(&tmp);
     let project = blocked_project(home);
     let printed = said(&kendex(
         home,
@@ -110,7 +110,7 @@ fn nothing_is_said_twice() {
 #[allow(clippy::unwrap_used)]
 fn no_framing_reaches_a_pipe() {
     let tmp = tempfile::tempdir().unwrap();
-    let home = tmp.path();
+    let home = &rooted(&tmp);
     let project = blocked_project(home);
     for args in [
         vec!["refresh", "-y", "--scope", "project"],
@@ -137,7 +137,7 @@ fn no_framing_reaches_a_pipe() {
 #[allow(clippy::unwrap_used)]
 fn a_run_with_no_terminal_is_plain_without_being_told() {
     let tmp = tempfile::tempdir().unwrap();
-    let home = tmp.path();
+    let home = &rooted(&tmp);
     let project = blocked_project(home);
     let printed = said(&kendex(
         home,
@@ -164,7 +164,7 @@ fn a_run_with_no_terminal_is_plain_without_being_told() {
 #[allow(clippy::unwrap_used)]
 fn show_file_prints_the_files_own_lines() {
     let tmp = tempfile::tempdir().unwrap();
-    let home = tmp.path();
+    let home = &rooted(&tmp);
     let project = home.join("dev/app");
     blocked_project_at(home, &project);
     fs::write(
@@ -208,7 +208,7 @@ fn show_file_prints_the_files_own_lines() {
 #[allow(clippy::unwrap_used)]
 fn a_failure_after_the_write_still_records_and_reports_it() {
     let tmp = tempfile::tempdir().unwrap();
-    let home = tmp.path();
+    let home = &rooted(&tmp);
     let project = home.join("dev/app");
     let catalog = home.join("catalog");
     let armed = catalog.join("skills/armed");

--- a/crates/cli/tests/presentation/pretty.rs
+++ b/crates/cli/tests/presentation/pretty.rs
@@ -182,7 +182,7 @@ const FRAME_LINES: usize = 2;
 #[allow(clippy::unwrap_used)]
 fn one_line_verdicts_are_drawn_as_one_group() {
     let tmp = tempfile::tempdir().unwrap();
-    let home = tmp.path();
+    let home = &rooted(&tmp);
     let project = blocked_project(home);
     // A row to verify has to be installed first; the blocked item stays
     // blocked and the two that install are the clean rows.
@@ -237,7 +237,7 @@ fn a_run_ending_outside_its_ledger_still_closes_the_frame() {
 fn a_warning_after_the_writes_lands_above_the_closing_ledger() {
     for ui in ["plain", "pretty"] {
         let tmp = tempfile::tempdir().unwrap();
-        let home = tmp.path();
+        let home = &rooted(&tmp);
         let project = home.join("dev/app");
         blocked_project_at(home, &project);
         // A file where the snapshot's directory belongs, so deriving it

--- a/crates/cli/tests/presentation/snapshots.rs
+++ b/crates/cli/tests/presentation/snapshots.rs
@@ -14,7 +14,7 @@ use super::*;
 #[allow(clippy::unwrap_used)]
 fn shape(setup: &[&str], args: &[&str]) -> Vec<String> {
     let tmp = tempfile::tempdir().unwrap();
-    let home = tmp.path();
+    let home = &rooted(&tmp);
     let project = blocked_project(home);
     let catalog = home.join("catalog").display().to_string();
     let fill = |args: &[&str]| -> Vec<String> {
@@ -167,7 +167,7 @@ fn remove() {
 fn a_name_off_a_foreign_tree_cannot_forge_a_line() {
     for ui in ["plain", "pretty"] {
         let tmp = tempfile::tempdir().unwrap();
-        let home = tmp.path();
+        let home = &rooted(&tmp);
         let project = home.join("dev/app");
         blocked_project_at(home, &project);
         // Content nothing manages, named with the two characters that
@@ -221,7 +221,7 @@ fn a_name_off_a_foreign_tree_cannot_forge_a_line() {
 fn the_scope_a_line_names_is_escaped_with_the_rest() {
     for ui in ["plain", "pretty"] {
         let tmp = tempfile::tempdir().unwrap();
-        let home = tmp.path();
+        let home = &rooted(&tmp);
         let project = home.join("we\u{1b}[31mird");
         blocked_project_at(home, &project);
         let printed = said(&kendex(
@@ -248,7 +248,7 @@ fn the_scope_a_line_names_is_escaped_with_the_rest() {
 #[allow(clippy::unwrap_used)]
 fn the_verdict_counts_the_lines_the_report_actually_printed() {
     let tmp = tempfile::tempdir().unwrap();
-    let home = tmp.path();
+    let home = &rooted(&tmp);
     let project = crowded_project(home, 14);
     let output = kendex(home, &project, "plain", &["check", "--scope", "project"]);
     let report = String::from_utf8_lossy(&output.stdout).into_owned();
@@ -303,7 +303,7 @@ fn crowded_project(home: &Path, count: usize) -> PathBuf {
 fn a_late_warning_lands_above_the_closing_ledger() {
     for ui in ["plain", "pretty"] {
         let tmp = tempfile::tempdir().unwrap();
-        let home = tmp.path();
+        let home = &rooted(&tmp);
         let project = blocked_project(home);
         kendex(
             home,


### PR DESCRIPTION
`origin/main` is red on two counts, and this PR clears both in one step. They cannot be split: the cap trim alone fails the macOS lane, and the canonicalisation alone leaves the guard failure standing.

## 1. The changelog fragments exceed the cap

```
$ .agents/skills/growth-guards/scripts/changelog-entries
changelog-entries FAIL long entry: changelog.d/added/KEN-552.md:1 — 220 characters (cap 200)
changelog-entries FAIL long entry: changelog.d/changed/KEN-552.md:1 — 216 characters (cap 200)
```

KEN-601 landed the cap at `666ac8886`. KEN-552 landed one commit later at `34d41b1f2`, carrying fragments written before the cap existed. Nothing re-judged an already-queued PR's fragments against a rule that arrived while it sat in the queue, and merge-group-only checks do not run at PR time, so neither gate caught it. `tools/guard` runs `changelog-entries` against the index unconditionally, so the failure is not confined to branches that are behind — main itself is red, which blocks every commit in every worktree.

Length only, both entries.

- `added`: dropped "and group" and the trailing "rendering".
- `changed`: "every verb" to "all verbs", and the second "ends" elided across the list.

No outcome is stated differently, nothing is added, nothing is dropped. **If either trim loses a distinction its author wanted, reword it freely** — this exists to unblock the tree, not to settle KEN-552's copy.

## 2. The presentation fixtures fail on macOS

Seven tests fail on the macOS cargo lane, all in the KEN-552 presentation suite: `plain::a_failure_after_the_write_still_records_and_reports_it`, `plain::the_blocked_refresh_prints_the_lines_scripts_parse`, `pretty::a_warning_after_the_writes_lands_above_the_closing_ledger`, `snapshots::a_late_warning_lands_above_the_closing_ledger`, and `snapshots::add`, `apply_plan`, `remove`.

The rendering is right and the fixtures are wrong. A macOS temporary directory resolves under `/private`, so a fixture that keeps the path it was handed builds project and catalog paths the run never prints: what the binary prints is the resolved form, which merely *ends* with the one the fixture holds. Redaction keyed to the unresolved path therefore strips the tail and leaves `/private` standing in front of the placeholder:

```
expected: conflict: skill growth-guards ... <project>/.claude/skills/growth-guards ...
actual:   conflict: skill growth-guards ... /private<project>/.claude/skills/growth-guards ...
```

The fix canonicalises the fixture root once at creation, in one `rooted` helper across all 17 fixture sites, so project, catalog and the snapshot directory settle canonical with it. Doing it at the redaction site instead would leave two of the seven failures standing: `plain::a_failure_after_the_write_still_records_and_reports_it` and `pretty::a_warning_after_the_writes_lands_above_the_closing_ledger` do no redaction at all — they compare fixture-built paths against printed ones.

Linux: 31/31 in the presentation suite. macOS is the lane that proves it.

## Why one PR

The cap trim alone cannot merge: it fails the macOS lane this canonicalisation fixes. The canonicalisation alone cannot merge either: it leaves the guard failure standing. Split into two, each PR blocks on the other and neither lands. This exists to take main from red to green in one step.

Opened by the account lane, which had two branches stuck at the commit step behind this.
