### PR TITLE
fix(KEN-742): a rejected sign-in is cleared, not kept

### DIFF
--- a/changelog.d/fixed/KEN-742.md
+++ b/changelog.d/fixed/KEN-742.md
@@ -1,3 +1,3 @@
 - A sign-in the server rejects is removed from the credential store, so
   `kendex login` signs you in again instead of telling you to log out first.
-  If the removal fails, the error says what to run.
+  If the removal fails, the CLI says what to run.

--- a/changelog.d/fixed/KEN-742.md
+++ b/changelog.d/fixed/KEN-742.md
@@ -1,0 +1,3 @@
+- A sign-in the server rejects is removed from the credential store, so
+  `kendex login` signs you in again instead of telling you to log out first.
+  If the removal fails, the error says what to run.

--- a/crates/core/src/error.rs
+++ b/crates/core/src/error.rs
@@ -419,9 +419,9 @@ pub enum CoreError {
     #[error("not signed in — run `kendex login` first")]
     NotSignedIn,
 
-    /// The stored sign-in is dead for good: the server refused its refresh
-    /// grant or keeps rejecting freshly rotated access tokens.
-    #[error("{why} — run `kendex login` again")]
+    /// The server refuses this sign-in; the local copy is gone unless `why`
+    /// says it could not be removed, and `why` carries the fitting remedy.
+    #[error("{why}")]
     SignInExpired { why: String },
 }
 

--- a/crates/core/src/registry/client.rs
+++ b/crates/core/src/registry/client.rs
@@ -22,6 +22,10 @@ pub struct Authenticated {
 
 /// Run one authenticated call, refreshing a rejected access token once.
 /// Refresh rotation is locked across processes and saved before retry.
+/// Every path that answers `SignInExpired` removes the rejected credential
+/// first, and says in `why` when the store would not give it up. A family
+/// another writer installed by then is answered with `sign_in_changed`
+/// instead, and nothing is removed.
 pub fn with_access(
     fetch: &dyn Fetch,
     store: &dyn CredentialStore,
@@ -82,16 +86,12 @@ fn rotate_locked(
         Err(Refused::Definitive(why)) => {
             // Older installed clients do not take this guard. A network call
             // gives one time to replace the family, so re-read before clearing.
-            match store.load()? {
-                Some(kept) if kept.refresh_token != credential.refresh_token => {
-                    return Err(sign_in_changed("refreshing"));
-                }
-                Some(_) => store.clear()?,
-                None => {}
-            }
-            return Err(CoreError::SignInExpired {
-                why: format!("your sign-in has expired ({why})"),
-            });
+            let removal = remove_rejected(store, &credential);
+            return Err(expired(
+                removal,
+                format!("your sign-in has expired ({why})"),
+                "refreshing",
+            ));
         }
         Err(Refused::Transient(error)) => return Err(error),
     };
@@ -170,27 +170,72 @@ fn required(credential: Option<Credential>) -> Result<Credential> {
 /// That is an expiry only while the sign-in it belongs to is the one
 /// installed: a sign-in landing while the request was in flight makes the
 /// rejection somebody else's, and calling it an expiry pins one account's
-/// answer on another. Only whether the expiry is produced is decided here;
-/// what the expiry means for the stored credential is unchanged.
+/// answer on another. Both callers drop the refresh guard before the call
+/// the server rejects, so it is re-taken here and the one re-read settles
+/// both halves: whether this call may call it an expiry, and whether the
+/// credential behind it goes.
 fn rejected_access(store: &dyn CredentialStore, authenticated_as: &Credential) -> CoreError {
-    match still_installed(store, authenticated_as) {
-        Ok(true) => CoreError::SignInExpired {
-            why: "the server does not accept this sign-in".to_owned(),
+    let removal = match store.refresh_guard() {
+        Ok(_guard) => remove_rejected(store, authenticated_as),
+        Err(error) => Removal::Failed(error),
+    };
+    expired(
+        removal,
+        "the server does not accept this sign-in".to_owned(),
+        "authenticating",
+    )
+}
+
+/// What the re-read did with the family the server rejected.
+enum Removal {
+    /// It is not installed any more.
+    Done,
+    /// Another writer's family is installed; nothing was touched.
+    Moved,
+    /// It may still be installed: the store refused a read or a delete.
+    Failed(CoreError),
+}
+
+/// The one re-read both producers make before they speak for the stored
+/// credential, taken under the credential transaction so the answer is
+/// not itself racing a rotation. A machine signed out in the meantime is
+/// not this credential's either, and leaves nothing to remove. Callers
+/// hold the refresh guard around this.
+fn remove_rejected(store: &dyn CredentialStore, rejected: &Credential) -> Removal {
+    let installed = match store.load() {
+        Ok(installed) => installed,
+        Err(error) => return Removal::Failed(error),
+    };
+    match installed {
+        Some(installed) if installed.refresh_token != rejected.refresh_token => Removal::Moved,
+        Some(_) => match store.clear() {
+            Ok(()) => Removal::Done,
+            Err(error) => Removal::Failed(error),
         },
-        Ok(false) => sign_in_changed("authenticating"),
-        Err(error) => error,
+        None => Removal::Done,
     }
 }
 
-/// Whether the installed sign-in is still this credential's, read under
-/// the credential transaction so the answer is not itself racing a
-/// rotation. A machine signed out in the meantime is not this
-/// credential's either.
-fn still_installed(store: &dyn CredentialStore, credential: &Credential) -> Result<bool> {
-    let _guard = store.refresh_guard()?;
-    Ok(store
-        .load()?
-        .is_some_and(|installed| installed.refresh_token == credential.refresh_token))
+/// The one verdict both producers answer with. A store that would not give
+/// the credential up never replaces the server's refusal, because the
+/// sign-in is dead either way and only `why` grows; a family another writer
+/// installed is the one thing that is not this call's to speak for. The
+/// remedy rides in `why` because it depends on what the removal did: a
+/// credential still installed makes `kendex login` refuse, and the next
+/// attempt is what removes it.
+fn expired(removal: Removal, why: String, moved_while: &str) -> CoreError {
+    match removal {
+        Removal::Done => CoreError::SignInExpired {
+            why: format!("{why} — run `kendex login` again"),
+        },
+        Removal::Moved => sign_in_changed(moved_while),
+        Removal::Failed(error) => CoreError::SignInExpired {
+            why: format!(
+                "{why}, and the local copy could not be removed: {error} — \
+                 run this again once that clears, then `kendex login`"
+            ),
+        },
+    }
 }
 
 pub(super) fn sign_in_changed(action: &str) -> CoreError {

--- a/crates/core/src/registry/me.rs
+++ b/crates/core/src/registry/me.rs
@@ -84,9 +84,10 @@ pub fn load(env: &Env, fetch: &dyn Fetch, store: &dyn CredentialStore) -> Result
         // Logout won a race with this read: the re-login state without
         // refreshing, exactly as if the credential had been gone up front.
         Err(CoreError::NotSignedIn) => return Ok(AccountState::SignedOut),
-        // The credential is dead and the client cleared it; the identity
-        // it named has no reason to outlive it on disk, and the next
-        // sign-in would find it keyed to this one and discard it unread.
+        // Producing this removed the rejected credential, or said in `why`
+        // that the store would not give it up. Either way the identity it
+        // named has no reason to outlive it on disk, and the next sign-in
+        // would find it keyed to this one and discard it unread.
         Err(CoreError::SignInExpired { .. }) => {
             cache.forget()?;
             return Ok(AccountState::Expired);

--- a/crates/core/tests/credential_transactions.rs
+++ b/crates/core/tests/credential_transactions.rs
@@ -1,4 +1,5 @@
-//! Mixed-version logout safety and bounded concurrent-token retries.
+//! Mixed-version logout safety, bounded concurrent-token retries, and the
+//! sign-in a rejection clears — never one another writer installed.
 
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::{Arc, Mutex, MutexGuard, mpsc};
@@ -12,6 +13,13 @@ use kendex_core::registry::{Fetch, FetchResponse};
 struct Store {
     credential: Mutex<Option<Credential>>,
     transaction: Mutex<()>,
+    /// Which take of the refresh guard starts refusing, counting from one —
+    /// a lock another process holds past the deadline.
+    guard_refused_from: Option<usize>,
+    guard_takes: AtomicUsize,
+    /// A keychain that will not give the credential up: the delete fails
+    /// and the credential stays installed.
+    delete_refused: bool,
 }
 
 impl Store {
@@ -19,6 +27,23 @@ impl Store {
         Self {
             credential: Mutex::new(Some(credential("old"))),
             transaction: Mutex::new(()),
+            guard_refused_from: None,
+            guard_takes: AtomicUsize::new(0),
+            delete_refused: false,
+        }
+    }
+
+    fn guard_refused_from(take: usize) -> Self {
+        Self {
+            guard_refused_from: Some(take),
+            ..Self::signed_in()
+        }
+    }
+
+    fn delete_refused() -> Self {
+        Self {
+            delete_refused: true,
+            ..Self::signed_in()
         }
     }
 }
@@ -45,11 +70,25 @@ impl CredentialStore for Store {
     }
 
     fn clear(&self) -> Result<()> {
+        if self.delete_refused {
+            return Err(CoreError::RegistryUnavailable {
+                why: "the credential store refused the removal".to_owned(),
+            });
+        }
         *self.credential.lock().map_err(|_| lock_error())? = None;
         Ok(())
     }
 
     fn refresh_guard(&self) -> Result<Box<dyn CredentialRefreshGuard + '_>> {
+        let take = self.guard_takes.fetch_add(1, Ordering::SeqCst) + 1;
+        if self.guard_refused_from.is_some_and(|first| take >= first) {
+            // Named, never opened: nothing here resolves the path, and a
+            // real spelling would be a second copy of the one the store
+            // derives.
+            return Err(CoreError::CredentialRefreshBusy {
+                lock: std::path::PathBuf::from("held-by-another-process"),
+            });
+        }
         Ok(Box::new(Guard {
             _guard: self.transaction.lock().map_err(|_| lock_error())?,
         }))
@@ -171,10 +210,32 @@ fn an_older_logout_during_revoke_stays_signed_out() {
     assert!(store.load().unwrap().is_none());
 }
 
+/// What another writer does to the store while the rejected call is in
+/// flight, in the window neither producer holds the refresh guard across.
+enum Race {
+    None,
+    /// A login installing this family.
+    Install(&'static str),
+    /// A logout, leaving nothing installed.
+    LogOut,
+}
+
+impl Race {
+    fn run(&self, store: &Store) -> Result<()> {
+        match self {
+            Race::None => Ok(()),
+            Race::Install(name) => store.save(&credential(name)),
+            Race::LogOut => store.clear(),
+        }
+    }
+}
+
 struct RejectingNewerTokens {
     store: Arc<Store>,
     bearers: Mutex<Vec<String>>,
     refresh_calls: AtomicUsize,
+    /// What lands as the last token is rejected.
+    race_on_last: Race,
 }
 
 impl Fetch for RejectingNewerTokens {
@@ -208,7 +269,7 @@ impl Fetch for RejectingNewerTokens {
         match bearer {
             "kxa_old" => self.store.save(&credential("newer-one"))?,
             "kxa_newer-one" => self.store.save(&credential("newer-two"))?,
-            "kxa_newer-two" => {}
+            "kxa_newer-two" => self.race_on_last.run(&self.store)?,
             other => {
                 return Err(CoreError::RegistryUnavailable {
                     why: format!("unexpected bearer {other}"),
@@ -227,6 +288,7 @@ fn two_rejected_concurrent_tokens_end_the_bounded_retry() {
         store: Arc::clone(&store),
         bearers: Mutex::new(Vec::new()),
         refresh_calls: AtomicUsize::new(0),
+        race_on_last: Race::None,
     };
 
     let refused = submit(&fetch, store.as_ref(), "jane/skills")
@@ -242,5 +304,209 @@ fn two_rejected_concurrent_tokens_end_the_bounded_retry() {
         ["kxa_old", "kxa_newer-one", "kxa_newer-two"]
     );
     assert_eq!(fetch.refresh_calls.load(Ordering::SeqCst), 0);
-    assert_eq!(store.load().unwrap().unwrap().access_token, "kxa_newer-two");
+    assert!(
+        store.load().unwrap().is_none(),
+        "the sign-in the server refused is not left installed"
+    );
+}
+
+#[test]
+#[allow(clippy::unwrap_used)]
+fn a_login_landing_during_the_bounded_retry_is_never_cleared() {
+    let store = Arc::new(Store::signed_in());
+    let fetch = RejectingNewerTokens {
+        store: Arc::clone(&store),
+        bearers: Mutex::new(Vec::new()),
+        refresh_calls: AtomicUsize::new(0),
+        race_on_last: Race::Install("newest"),
+    };
+
+    let refused = submit(&fetch, store.as_ref(), "jane/skills")
+        .unwrap_err()
+        .to_string();
+
+    assert!(
+        refused.contains("the sign-in changed while authenticating"),
+        "{refused}"
+    );
+    assert_eq!(store.load().unwrap().unwrap().access_token, "kxa_newest");
+}
+
+/// Rotates once and rejects the fresh token too, optionally letting another
+/// writer reach the store while that rejection is in flight.
+struct RejectingRotation {
+    store: Arc<Store>,
+    /// What lands while the rejection of the rotated token is in flight.
+    race_on_rotated: Race,
+}
+
+impl Fetch for RejectingRotation {
+    fn get_auth(
+        &self,
+        _url: &str,
+        _etag: Option<&str>,
+        _bearer: Option<&str>,
+    ) -> Result<FetchResponse> {
+        Err(CoreError::RegistryUnavailable {
+            why: "unexpected GET".to_owned(),
+        })
+    }
+
+    fn post_json_auth(
+        &self,
+        _url: &str,
+        body: &str,
+        bearer: Option<&str>,
+    ) -> Result<FetchResponse> {
+        let Some(bearer) = bearer else {
+            assert!(body.contains("kxr_old"), "{body}");
+            return response(
+                200,
+                r#"{"access_token":"kxa_rotated","refresh_token":"kxr_rotated","capabilities":["submission:write"]}"#,
+            );
+        };
+        match bearer {
+            "kxa_old" => {}
+            "kxa_rotated" => self.race_on_rotated.run(&self.store)?,
+            other => {
+                return Err(CoreError::RegistryUnavailable {
+                    why: format!("unexpected bearer {other}"),
+                });
+            }
+        }
+        response(401, r#"{"error":"invalid_token"}"#)
+    }
+}
+
+#[test]
+#[allow(clippy::unwrap_used)]
+fn a_rotation_the_server_still_rejects_clears_the_sign_in() {
+    let store = Arc::new(Store::signed_in());
+    let fetch = RejectingRotation {
+        store: Arc::clone(&store),
+        race_on_rotated: Race::None,
+    };
+
+    let refused = submit(&fetch, store.as_ref(), "jane/skills")
+        .unwrap_err()
+        .to_string();
+
+    assert!(
+        refused.contains("server does not accept this sign-in"),
+        "{refused}"
+    );
+    assert!(
+        refused.contains("— run `kendex login` again"),
+        "with the credential gone, signing in again is what works: {refused}"
+    );
+    assert!(
+        store.load().unwrap().is_none(),
+        "the freshly rotated family the server refused is not left installed"
+    );
+}
+
+#[test]
+#[allow(clippy::unwrap_used)]
+fn a_login_landing_after_rotation_is_never_cleared() {
+    let store = Arc::new(Store::signed_in());
+    let fetch = RejectingRotation {
+        store: Arc::clone(&store),
+        race_on_rotated: Race::Install("newest"),
+    };
+
+    let refused = submit(&fetch, store.as_ref(), "jane/skills")
+        .unwrap_err()
+        .to_string();
+
+    assert!(
+        refused.contains("the sign-in changed while authenticating"),
+        "{refused}"
+    );
+    assert_eq!(store.load().unwrap().unwrap().access_token, "kxa_newest");
+}
+
+#[test]
+#[allow(clippy::unwrap_used)]
+fn a_logout_landing_after_rotation_still_answers_expired() {
+    let store = Arc::new(Store::signed_in());
+    let fetch = RejectingRotation {
+        store: Arc::clone(&store),
+        race_on_rotated: Race::LogOut,
+    };
+
+    let refused = submit(&fetch, store.as_ref(), "jane/skills")
+        .unwrap_err()
+        .to_string();
+
+    assert!(
+        refused.contains("server does not accept this sign-in"),
+        "{refused}"
+    );
+    assert!(
+        !refused.contains("could not be removed"),
+        "nothing was left to remove: {refused}"
+    );
+    assert!(store.load().unwrap().is_none());
+}
+
+#[test]
+#[allow(clippy::unwrap_used)]
+fn a_store_that_will_not_open_still_answers_expired() {
+    // Rotation takes the guard once; the take that removes the rejected
+    // family is the second, and that is the one another process holds.
+    let store = Arc::new(Store::guard_refused_from(2));
+    let fetch = RejectingRotation {
+        store: Arc::clone(&store),
+        race_on_rotated: Race::None,
+    };
+
+    let refused = submit(&fetch, store.as_ref(), "jane/skills")
+        .unwrap_err()
+        .to_string();
+
+    assert!(
+        refused.contains("server does not accept this sign-in"),
+        "a store failure must not stand in for the server's refusal: {refused}"
+    );
+    assert!(
+        refused.contains("the local copy could not be removed: credential refresh is busy"),
+        "the user learns the sign-in is dead and still installed: {refused}"
+    );
+    assert_eq!(store.load().unwrap().unwrap().access_token, "kxa_rotated");
+}
+
+#[test]
+#[allow(clippy::unwrap_used)]
+fn a_store_that_will_not_delete_still_answers_expired() {
+    let store = Arc::new(Store::delete_refused());
+    let fetch = RejectingRotation {
+        store: Arc::clone(&store),
+        race_on_rotated: Race::None,
+    };
+
+    let refused = submit(&fetch, store.as_ref(), "jane/skills")
+        .unwrap_err()
+        .to_string();
+
+    assert!(
+        refused.contains("server does not accept this sign-in"),
+        "a delete failure must not stand in for the server's refusal: {refused}"
+    );
+    assert!(
+        refused.contains("the local copy could not be removed"),
+        "the user learns the credential is still installed: {refused}"
+    );
+    assert!(
+        refused.contains("the credential store refused the removal"),
+        "the user learns what refused it: {refused}"
+    );
+    assert!(
+        !refused.contains("— run `kendex login` again"),
+        "signing in again refuses while the credential is still installed: {refused}"
+    );
+    assert_eq!(
+        store.load().unwrap().unwrap().access_token,
+        "kxa_rotated",
+        "the delete failed, so the family the server refused is still installed"
+    );
 }

--- a/crates/core/tests/me_client/main.rs
+++ b/crates/core/tests/me_client/main.rs
@@ -312,6 +312,8 @@ fn an_expired_credential_drops_the_cached_identity() {
 #[test]
 fn a_rotation_the_server_still_rejects_reads_as_expired() {
     let dir = tempfile::tempdir().expect("tempdir");
+    let env = env_in(dir.path());
+    let store = MemoryStore::signed_in();
     let fetch = Canned::new(vec![
         ok(401, None, r#"{"error":"invalid_token"}"#),
         ok(
@@ -321,8 +323,20 @@ fn a_rotation_the_server_still_rejects_reads_as_expired() {
         ),
         ok(401, None, r#"{"error":"invalid_token"}"#),
     ]);
-    let state = me::load(&env_in(dir.path()), &fetch, &MemoryStore::signed_in()).expect("load");
+    let state = me::load(&env, &fetch, &store).expect("load");
     assert_eq!(state, AccountState::Expired);
+    assert!(
+        store.load().expect("load").is_none(),
+        "a rotation the server refuses is not kept for endless retries"
+    );
+
+    let quiet = Canned::new(vec![]);
+    assert_eq!(
+        me::load(&env, &quiet, &store).expect("second load"),
+        AccountState::SignedOut,
+        "the rejected sign-in is gone, so the next read asks nothing"
+    );
+    assert_eq!(*quiet.calls.borrow(), 0);
 }
 #[test]
 fn revalidation_sends_the_etag_and_304_keeps_the_identity() {


### PR DESCRIPTION
`CoreError::SignInExpired` meant two different things. The refresh-rejection path in `rotate_locked` cleared the credential before returning it; `rejected_access()` returned it and cleared nothing, from the second 401 after a successful rotation and from the bounded newer-token retry. `me::load`'s comment stated the cleared half, which was false for both `rejected_access` sites.

## What the variant promises now

The rejected sign-in is not installed any more — or the store would not give it up, and `why` says so.

Both producers keep it. Clearing goes through one `remove_rejected` helper that re-reads under the credential transaction and clears only what was rejected, so a family another writer installed is never touched — it answers `sign_in_changed` instead, the same conservative refusal `client.rs` already makes at its family-mismatch sites.

## The failure that is not a re-diagnosis

A cleanup failure must not replace the server's verdict. `me::load` matches only `SignInExpired`, so any other error falls through to the cache and draws "signed in as ⟨name⟩, offline" for a sign-in the server has refused — no error shown, repeating for as long as the store failure lasts. Only a moved family changes the verdict; a busy guard, a refused delete or an unreadable credential still answer `SignInExpired`, with the removal failure folded into `why` so the user learns both facts.

`Removal::Done | Moved | Failed` carries that decision, because a moved family and a keyring failure are both `RegistryUnavailable` and the verdict cannot be read off the variant.

## The CLI consequence

With the credential retained, `kendex login` refused a fresh sign-in while the app showed the account as expired, and the way out was a `logout` whose revoke could itself fail against the family the server already refuses. Clearing resolves it.

## Controls

Arms proved red once: clearing removed, the family check neutered, the already-gone arm, a guard another process holds, and the fallback that keeps `SignInExpired` when removal fails. Both race tests assert the whole message so they name the site that produced it.

Two arms are untested as this stands. A `store.load()` failure inside `remove_rejected` needs a load-position counter whose magic index would break on any change to the call sequence. A `store.clear()` that refuses is reachable but unreached — the guard-failure test stops earlier — so the fallback is proved through the guard path only; a test for it is in the current round.

Closes KEN-742
