### PR TITLE
fix(KEN-605): a version switch says what the plan held back

### DIFF
--- a/changelog.d/fixed/KEN-605.md
+++ b/changelog.d/fixed/KEN-605.md
@@ -1,0 +1,3 @@
+- Switching a package's version, and turning Follow source back on, now say
+  when the copy on disk was held back instead of reporting an update that
+  never reached the files.

--- a/crates/app/src/packages.rs
+++ b/crates/app/src/packages.rs
@@ -32,7 +32,10 @@ pub fn package_versions(
 /// scope's view afterwards. The plan holds a rendering back rather than
 /// writing over a copy somebody changed, and the view alone cannot say
 /// which of the two happened — a caller reading only the view says
-/// "Updated" over a package that never moved.
+/// "Updated" over a package that never moved. Every command that applies
+/// one package answers with this, the version switch included: a hold
+/// that moves in the manifest is refused on disk for the same reasons an
+/// update is.
 #[derive(serde::Serialize, specta::Type)]
 #[serde(rename_all = "camelCase")]
 pub struct PackageUpdate {
@@ -70,21 +73,35 @@ pub fn package_update(scope: Scope, kind: ItemKind, name: String) -> Result<Pack
     }
     let env = env()?;
     let report = package::update_one(&env, &scope, kind, &name).map_err(|e| e.to_string())?;
-    let held_back = package::held_back(&report, kind, &name)
+    settle_package(&env, &scope, kind, &name, &report)
+}
+
+/// Apply one package-scoped plan and answer with what it did to that
+/// package beside the standing it leaves. Read off the report before the
+/// apply runs, because that is the record naming which renderings the
+/// plan writes and which it refuses.
+fn settle_package(
+    env: &Env,
+    scope: &Scope,
+    kind: ItemKind,
+    name: &str,
+    report: &engine::EngineReport,
+) -> Result<PackageUpdate, String> {
+    let held_back = package::held_back(report, kind, name)
         .into_iter()
         .cloned()
         .collect();
-    let removed = package::removed(&report, kind, &name)
+    let removed = package::removed(report, kind, name)
         .into_iter()
         .cloned()
         .collect();
-    let moved = package::moving(&report, kind, &name)
+    let moved = package::moving(report, kind, name)
         .into_iter()
         .cloned()
         .collect();
-    apply::execute(&env, &report.plan, None).map_err(|e| e.to_string())?;
+    apply::execute(env, &report.plan, None).map_err(|e| e.to_string())?;
     Ok(PackageUpdate {
-        view: view(&env, &scope),
+        view: view(env, scope),
         held_back,
         removed,
         moved,
@@ -97,6 +114,11 @@ pub fn package_update(scope: Scope, kind: ItemKind, name: String) -> Result<Pack
 /// neighbours current. The exception is a follower the lock cannot place
 /// — never installed, or installations disagreeing — which resolves fresh
 /// here as it would under a whole-scope apply.
+///
+/// The answer is the same `PackageUpdate` the update command gives, and
+/// for the same reason: the manifest takes the new hold either way, while
+/// a rendering somebody edited is held back on disk, so a caller reading
+/// the view alone would report a switch that never reached the files.
 #[tauri::command(async)]
 #[specta::specta]
 pub fn package_set_rev(
@@ -104,7 +126,7 @@ pub fn package_set_rev(
     kind: ItemKind,
     name: String,
     rev: Option<String>,
-) -> Result<AuditView, String> {
+) -> Result<PackageUpdate, String> {
     let env = env()?;
     let report = package::set_rev_with(
         &env,
@@ -115,8 +137,7 @@ pub fn package_set_rev(
         &engine::PlanOptions::for_package(kind, &name),
     )
     .map_err(|e| e.to_string())?;
-    apply::execute(&env, &report.plan, None).map_err(|e| e.to_string())?;
-    Ok(view(&env, &scope))
+    settle_package(&env, &scope, kind, &name, &report)
 }
 
 #[tauri::command(async)]

--- a/ui/src/bindings.ts
+++ b/ui/src/bindings.ts
@@ -273,8 +273,13 @@ export const commands = {
 	 *  neighbours current. The exception is a follower the lock cannot place
 	 *  — never installed, or installations disagreeing — which resolves fresh
 	 *  here as it would under a whole-scope apply.
+	 * 
+	 *  The answer is the same `PackageUpdate` the update command gives, and
+	 *  for the same reason: the manifest takes the new hold either way, while
+	 *  a rendering somebody edited is held back on disk, so a caller reading
+	 *  the view alone would report a switch that never reached the files.
 	 */
-	packageSetRev: (scope: Scope, kind: ItemKind, name: string, rev: string | null) => typedError<AuditView_Serialize, string>(__TAURI_INVOKE("package_set_rev", { scope, kind, name, rev })),
+	packageSetRev: (scope: Scope, kind: ItemKind, name: string, rev: string | null) => typedError<PackageUpdate_Serialize, string>(__TAURI_INVOKE("package_set_rev", { scope, kind, name, rev })),
 	packageDiff: (scope: Scope, kind: ItemKind, name: string, from: VersionSel, to: VersionSel, harness: "claude" | "codex" | "opencode" | "cursor" | "pi" | "gemini" | "copilot" | null) => typedError<PackageDiff, string>(__TAURI_INVOKE("package_diff", { scope, kind, name, from, to, harness })),
 	/**  Keep an edited install as a local fork, then render it in place. */
 	packageFork: (scope: Scope, kind: ItemKind, name: string, harness: HarnessId) => typedError<AuditView_Serialize, string>(__TAURI_INVOKE("package_fork", { scope, kind, name, harness })),
@@ -1922,7 +1927,10 @@ export type PackageSafety = {
  *  scope's view afterwards. The plan holds a rendering back rather than
  *  writing over a copy somebody changed, and the view alone cannot say
  *  which of the two happened — a caller reading only the view says
- *  "Updated" over a package that never moved.
+ *  "Updated" over a package that never moved. Every command that applies
+ *  one package answers with this, the version switch included: a hold
+ *  that moves in the manifest is refused on disk for the same reasons an
+ *  update is.
  */
 export type PackageUpdate = PackageUpdate_Serialize | PackageUpdate_Deserialize;
 
@@ -1931,7 +1939,10 @@ export type PackageUpdate = PackageUpdate_Serialize | PackageUpdate_Deserialize;
  *  scope's view afterwards. The plan holds a rendering back rather than
  *  writing over a copy somebody changed, and the view alone cannot say
  *  which of the two happened — a caller reading only the view says
- *  "Updated" over a package that never moved.
+ *  "Updated" over a package that never moved. Every command that applies
+ *  one package answers with this, the version switch included: a hold
+ *  that moves in the manifest is refused on disk for the same reasons an
+ *  update is.
  */
 export type PackageUpdate_Deserialize = {
 	view: AuditView_Deserialize,
@@ -1957,7 +1968,10 @@ export type PackageUpdate_Deserialize = {
  *  scope's view afterwards. The plan holds a rendering back rather than
  *  writing over a copy somebody changed, and the view alone cannot say
  *  which of the two happened — a caller reading only the view says
- *  "Updated" over a package that never moved.
+ *  "Updated" over a package that never moved. Every command that applies
+ *  one package answers with this, the version switch included: a hold
+ *  that moves in the manifest is refused on disk for the same reasons an
+ *  update is.
  */
 export type PackageUpdate_Serialize = {
 	view: AuditView_Serialize,

--- a/ui/src/components/package/use-package-data.test.ts
+++ b/ui/src/components/package/use-package-data.test.ts
@@ -65,31 +65,59 @@ const actions = (held: boolean) =>
     () => {},
   );
 
+const VIEW = {
+  scope: { scope: "global" } as const,
+  drift: [],
+  plan: [],
+  notes: [],
+  warnings: [],
+  safety: [],
+  adoptable: [],
+  exits: [],
+  error: null,
+};
+
+const conflict = (harness: "claude" | "codex") => ({
+  kind: "skill" as const,
+  name: "gh",
+  harness,
+  scope: { scope: "global" } as const,
+  state: "conflict" as const,
+  detail: "you changed this copy",
+  cause: "local-edit" as const,
+});
+
+const stale = (harness: "claude" | "codex") => ({
+  ...conflict(harness),
+  state: "stale" as const,
+  detail: "behind its source",
+  cause: null,
+});
+
+/** What a single-package apply answers with — the update command and the
+ *  version switch alike, so a test names the parts it cares about. */
+const answer = (parts: {
+  heldBack?: ReturnType<typeof conflict>[];
+  removed?: ReturnType<typeof conflict>[];
+  moved?: ReturnType<typeof stale>[];
+}) =>
+  ({
+    status: "ok",
+    data: { view: VIEW, heldBack: [], removed: [], moved: [], ...parts },
+  }) as never;
+
+const HELD_IN_CLAUDE =
+  "the copy in Claude Code needs attention on the package page";
+
 describe("packageVersionActions", () => {
   beforeEach(() => {
     vi.clearAllMocks();
   });
 
   it("brings a following package current through the single-package apply", async () => {
-    vi.mocked(commands.packageUpdate).mockResolvedValue({
-      status: "ok",
-      data: {
-        view: {
-          scope: { scope: "global" },
-          drift: [],
-          plan: [],
-          notes: [],
-          warnings: [],
-          safety: [],
-          adoptable: [],
-          exits: [],
-          error: null,
-        },
-        heldBack: [],
-        removed: [],
-        moved: [],
-      },
-    });
+    vi.mocked(commands.packageUpdate).mockResolvedValue(
+      answer({ moved: [stale("claude")] }),
+    );
     actions(false).updateToLatest(version("b".repeat(40)));
     await vi.waitFor(() => expect(commands.packageUpdate).toHaveBeenCalled());
     expect(vi.mocked(commands.packageUpdate).mock.calls).toEqual([
@@ -100,64 +128,121 @@ describe("packageVersionActions", () => {
   });
 
   it("says what was held back rather than claiming the package moved", async () => {
-    vi.mocked(commands.packageUpdate).mockResolvedValue({
-      status: "ok",
-      data: {
-        view: {
-          scope: { scope: "global" },
-          drift: [],
-          plan: [],
-          notes: [],
-          warnings: [],
-          safety: [],
-          adoptable: [],
-          exits: [],
-          error: null,
-        },
-        removed: [],
-        heldBack: [
-          {
-            kind: "skill",
-            name: "gh",
-            harness: "claude",
-            scope: { scope: "global" },
-            state: "conflict",
-            detail: "you changed this copy",
-            cause: "local-edit",
-          },
-        ],
-        moved: [],
-      },
-    });
+    vi.mocked(commands.packageUpdate).mockResolvedValue(
+      answer({ heldBack: [conflict("claude")] }),
+    );
     actions(false).updateToLatest(version("b".repeat(40)));
     await vi.waitFor(() => expect(toast.info).toHaveBeenCalled());
     expect(toast.success).not.toHaveBeenCalled();
     expect(toast.info).toHaveBeenCalledWith(
-      "gh was not updated — the copy in Claude Code needs attention on the package page",
+      `gh was not updated — ${HELD_IN_CLAUDE}`,
+    );
+  });
+
+  // The control the held cases below are read against: a switch the plan
+  // wrote everywhere still says so, and says which version it landed on.
+  it("says a version switch the plan wrote landed", async () => {
+    const row = version("c".repeat(40));
+    vi.mocked(commands.packageSetRev).mockResolvedValue(
+      answer({ moved: [stale("claude")] }),
+    );
+    actions(false).switchTo(row);
+    await vi.waitFor(() => expect(toast.success).toHaveBeenCalled());
+    expect(vi.mocked(commands.packageSetRev).mock.calls).toEqual([
+      [ref.scope, ref.kind, ref.name, row.id],
+    ]);
+    expect(toast.success).toHaveBeenCalledWith("Updated gh to v2");
+    expect(toast.info).not.toHaveBeenCalled();
+  });
+
+  // The manifest took the new hold and the files did not move with it.
+  // Saying "Updated" here is the bug this whole path answers.
+  it("does not call a version switch updated when the plan held the copy back", async () => {
+    vi.mocked(commands.packageSetRev).mockResolvedValue(
+      answer({ heldBack: [conflict("claude")] }),
+    );
+    actions(false).switchTo(version("c".repeat(40)));
+    await vi.waitFor(() => expect(toast.info).toHaveBeenCalled());
+    expect(toast.success).not.toHaveBeenCalled();
+    expect(toast.info).toHaveBeenCalledWith(
+      `gh is set to v2, but nothing was written — ${HELD_IN_CLAUDE}`,
+    );
+  });
+
+  it("names the tool a switch could not reach when it wrote the others", async () => {
+    vi.mocked(commands.packageSetRev).mockResolvedValue(
+      answer({ heldBack: [conflict("claude")], moved: [stale("codex")] }),
+    );
+    actions(false).switchTo(version("c".repeat(40)));
+    await vi.waitFor(() => expect(toast.success).toHaveBeenCalled());
+    expect(toast.success).toHaveBeenCalledWith(
+      `Updated gh to v2 — ${HELD_IN_CLAUDE}`,
     );
   });
 
   it("moves a held package's hold instead of applying it", async () => {
     const row = version("c".repeat(40));
-    vi.mocked(commands.packageSetRev).mockResolvedValue({
-      status: "ok",
-      data: {
-        scope: { scope: "global" },
-        drift: [],
-        plan: [],
-        notes: [],
-        warnings: [],
-        safety: [],
-        adoptable: [],
-        exits: [],
-        error: null,
-      },
-    });
+    vi.mocked(commands.packageSetRev).mockResolvedValue(
+      answer({ moved: [stale("claude")] }),
+    );
     actions(true).updateToLatest(row);
     await vi.waitFor(() => expect(commands.packageSetRev).toHaveBeenCalled());
     expect(vi.mocked(commands.packageSetRev).mock.calls).toEqual([
       [ref.scope, ref.kind, ref.name, row.id],
     ]);
     expect(commands.packageUpdate).not.toHaveBeenCalled();
+    expect(toast.success).toHaveBeenCalledWith("Updated gh to v2");
+  });
+
+  // Update on a held package is a hold move, and a hold move can be
+  // refused on disk exactly as an update can.
+  it("does not call Update on a held package updated when the copy was held back", async () => {
+    vi.mocked(commands.packageSetRev).mockResolvedValue(
+      answer({ heldBack: [conflict("claude")] }),
+    );
+    actions(true).updateToLatest(version("c".repeat(40)));
+    await vi.waitFor(() => expect(toast.info).toHaveBeenCalled());
+    expect(toast.success).not.toHaveBeenCalled();
+    expect(toast.info).toHaveBeenCalledWith(
+      `gh is set to v2, but nothing was written — ${HELD_IN_CLAUDE}`,
+    );
+  });
+
+  it("says Follow source landed when the plan wrote the package", async () => {
+    vi.mocked(commands.packageSetRev).mockResolvedValue(
+      answer({ moved: [stale("claude")] }),
+    );
+    actions(true).follow();
+    await vi.waitFor(() => expect(toast.success).toHaveBeenCalled());
+    expect(vi.mocked(commands.packageSetRev).mock.calls).toEqual([
+      [ref.scope, ref.kind, ref.name, null],
+    ]);
+    expect(toast.success).toHaveBeenCalledWith("Now following its source");
+  });
+
+  // The manifest follows again either way; the toast may not stay silent
+  // about a copy the apply could not move.
+  it("says Follow source wrote nothing when the copy was held back", async () => {
+    vi.mocked(commands.packageSetRev).mockResolvedValue(
+      answer({ heldBack: [conflict("claude")] }),
+    );
+    actions(true).follow();
+    await vi.waitFor(() => expect(toast.info).toHaveBeenCalled());
+    expect(toast.success).not.toHaveBeenCalled();
+    expect(toast.info).toHaveBeenCalledWith(
+      `Now following its source, but nothing was written — ${HELD_IN_CLAUDE}`,
+    );
+  });
+
+  it("says a copy that went to the trash was not replaced", async () => {
+    vi.mocked(commands.packageSetRev).mockResolvedValue(
+      answer({ removed: [conflict("claude")] }),
+    );
+    actions(false).switchTo(version("c".repeat(40)));
+    await vi.waitFor(() => expect(toast.error).toHaveBeenCalled());
+    expect(toast.success).not.toHaveBeenCalled();
+    expect(toast.error).toHaveBeenCalledWith(
+      "gh could not be installed — the copy in Claude Code went to the trash and nothing replaced it",
+    );
   });
 });

--- a/ui/src/components/package/use-package-data.ts
+++ b/ui/src/components/package/use-package-data.ts
@@ -1,21 +1,27 @@
 import { useCallback, useEffect, useState } from "react";
-import { toast } from "sonner";
 import {
   commands,
   type HarnessId,
   type PackageDiff,
   type PackageFile,
   type PackageMeta_Serialize,
+  type PackageUpdate_Serialize,
   type Scope,
   type VersionRow,
 } from "@/bindings";
 import {
+  FOLLOW_SOURCE_STALLED_TOAST,
   FOLLOW_SOURCE_TOAST,
+  notSwitchedToastLead,
   updatedToastLabel,
   VERSION_ERROR_TITLE,
 } from "@/lib/copy";
 import { sameScope } from "@/lib/scope";
-import { showUpdateOutcome } from "@/lib/update-outcome";
+import {
+  type OutcomeLines,
+  showUpdateOutcome,
+  updateLines,
+} from "@/lib/update-outcome";
 import { versionRowLabel } from "@/lib/versions";
 import { useAuditStore } from "@/stores/audit";
 import { useEditorStore } from "@/stores/editor";
@@ -137,9 +143,18 @@ export function packageVersionActions(
     void useScanStore.getState().refresh();
     void useAuditStore.getState().refresh({ force: true });
   };
+  // Every one of these applies a plan that can refuse a rendering, so
+  // none of them toasts off the click: the command's own report says what
+  // reached the files, and `lines` is only how this surface words it.
+  // This page has no edited-row filter, and a refusal is broader than an
+  // edit anyway — files kendex never put there, a provenance clash — so
+  // the held answer arrives here whatever the page believes about edits.
   const run = (
-    call: Promise<{ status: "ok" } | { status: "error"; error: string }>,
-    toastMessage: string,
+    call: Promise<
+      | { status: "ok"; data: PackageUpdate_Serialize }
+      | { status: "error"; error: string }
+    >,
+    lines: OutcomeLines,
   ) => {
     setBusy(true);
     void call.then((response) => {
@@ -148,45 +163,35 @@ export function packageVersionActions(
         showError(response.error);
         return;
       }
-      toast.success(toastMessage);
+      showUpdateOutcome(displayName, response.data, lines);
       afterChange();
     });
   };
 
-  const switchTo = (row: VersionRow) =>
-    run(
-      commands.packageSetRev(ref.scope, ref.kind, ref.name, row.id),
-      updatedToastLabel(`${displayName} to ${versionRowLabel(row)}`),
-    );
+  const switchTo = (row: VersionRow) => {
+    const version = versionRowLabel(row);
+    return run(commands.packageSetRev(ref.scope, ref.kind, ref.name, row.id), {
+      moved: updatedToastLabel(`${displayName} to ${version}`),
+      stalled: notSwitchedToastLead(displayName, version),
+    });
+  };
 
   // A held package moves its hold to the latest; a follower is brought
   // current by the single-package apply — Update never silently pins a
   // follower, and does not move the scope's other followers along.
-  //
-  // The follower's toast comes from what the apply reports, not from the
-  // click: this page has no edited-row filter of its own, so a hand-edited
-  // copy the plan held back reaches here and must not be called updated.
-  const updateToLatest = (latest: VersionRow) => {
-    if (held) return switchTo(latest);
-    setBusy(true);
-    void commands
-      .packageUpdate(ref.scope, ref.kind, ref.name)
-      .then((response) => {
-        setBusy(false);
-        if (response.status === "error") {
-          showError(response.error);
-          return;
-        }
-        showUpdateOutcome(displayName, response.data);
-        afterChange();
-      });
-  };
+  const updateToLatest = (latest: VersionRow) =>
+    held
+      ? switchTo(latest)
+      : run(
+          commands.packageUpdate(ref.scope, ref.kind, ref.name),
+          updateLines(displayName),
+        );
 
   const follow = () =>
-    run(
-      commands.packageSetRev(ref.scope, ref.kind, ref.name, null),
-      FOLLOW_SOURCE_TOAST,
-    );
+    run(commands.packageSetRev(ref.scope, ref.kind, ref.name, null), {
+      moved: FOLLOW_SOURCE_TOAST,
+      stalled: FOLLOW_SOURCE_STALLED_TOAST,
+    });
 
   return { switchTo, updateToLatest, follow };
 }

--- a/ui/src/dev/mock-packages.ts
+++ b/ui/src/dev/mock-packages.ts
@@ -25,6 +25,15 @@ const standing = () => ({
   lastFetched: Math.floor(Date.now() / 1000),
 });
 
+// What a single-package apply reports: the standing it leaves, and the
+// renderings it wrote, held, or took away — nothing refused here.
+const packageUpdate = (scope: Scope) => ({
+  view: view(scope),
+  heldBack: [],
+  removed: [],
+  moved: [],
+});
+
 export const packageHandlers: Record<string, Handler> = {
   package_versions: ({ name }: { name: string }) => [
     {
@@ -64,16 +73,12 @@ export const packageHandlers: Record<string, Handler> = {
     if (ignored) store.state.ignored.push({ kind, name });
     return standing();
   },
-  package_set_rev: ({ scope }: { scope: Scope }) => view(scope),
-  // The single-package apply answers with what it wrote and what a
-  // conflict held back, not the view alone — a mock that returns the bare
-  // view leaves the toast reading `heldBack` off undefined.
-  package_update: ({ scope }: { scope: Scope }) => ({
-    view: view(scope),
-    heldBack: [],
-    removed: [],
-    moved: [],
-  }),
+  // A single-package apply answers with what it wrote and what a conflict
+  // held back, not the view alone — a mock that returns the bare view
+  // leaves the toast reading `heldBack` off undefined. The version switch
+  // answers the same way, so both read the one builder.
+  package_set_rev: ({ scope }: { scope: Scope }) => packageUpdate(scope),
+  package_update: ({ scope }: { scope: Scope }) => packageUpdate(scope),
   package_diff: ({ from, to }: { from: VersionSel; to: VersionSel }) => ({
     files: [
       {

--- a/ui/src/lib/copy-updates.ts
+++ b/ui/src/lib/copy-updates.ts
@@ -83,18 +83,19 @@ export const updatedSomeToastLabel = (
   `Updated ${updated === 1 ? "1 package" : `${updated} packages`} — ${skipped === 1 ? "1 place needs" : `${skipped} places need`} attention on its own row`;
 export const updatedCountToastLabel = (updated: number): string =>
   `Updated ${updated === 1 ? "1 package" : `${updated} packages`}`;
-// What a single-package Update did when a conflict stopped part of it —
-// a copy changed by hand, files kendex never put there. The tool is named
-// because that is where the person goes to settle it.
+// What a conflict stopped, said after whatever the surface already said
+// about its own action — an update, a version switch, a Follow source
+// flip. The lead is the surface's; this tail is everyone's, and it names
+// the tool because that is where the person goes to settle it.
 const toolList = (tools: string[]): string =>
   tools.length > 1
     ? `${tools.slice(0, -1).join(", ")} and ${tools[tools.length - 1]}`
     : (tools[0] ?? "");
-export const updatedExceptToastLabel = (
-  name: string,
+export const needsAttentionToastLabel = (
+  lead: string,
   tools: string[],
 ): string =>
-  `Updated ${name} — the copy in ${toolList(tools)} needs attention on the package page`;
+  `${lead} — the copy in ${toolList(tools)} needs attention on the package page`;
 // A refusal with nothing of the person's in the files does not leave the
 // old copy alone: it goes to the trash and nothing is written back. Said
 // plainly, because it is the one outcome that took something away.
@@ -107,8 +108,8 @@ export const removedNotReplacedCountToastLabel = (removed: number): string =>
   removed === 1
     ? "1 package could not be installed — its copy went to the trash and nothing replaced it"
     : `${removed} packages could not be installed — their copies went to the trash and nothing replaced them`;
-export const notUpdatedToastLabel = (name: string, tools: string[]): string =>
-  `${name} was not updated — the copy in ${toolList(tools)} needs attention on the package page`;
+export const notUpdatedToastLead = (name: string): string =>
+  `${name} was not updated`;
 // A run where one place failed: the error is already on screen, so this
 // says what the rest of it came to — as a fact, never as a success.
 export const movedDespiteErrorToastLabel = (packages: number): string =>

--- a/ui/src/lib/copy.ts
+++ b/ui/src/lib/copy.ts
@@ -136,6 +136,12 @@ export const BACK_TO_FILES_LABEL = "Back to files";
 export const DIFF_TRUNCATED_NOTE =
   "This comparison is long; only the first part is shown.";
 export const VERSION_ERROR_TITLE = "Couldn't switch versions";
+// A switch the plan would not write anywhere: the manifest took the new
+// hold, the copy on disk is the one it always was. Both halves are said,
+// because either on its own is the wrong story — and what follows this
+// names the tool whose copy stopped it.
+export const notSwitchedToastLead = (name: string, version: string): string =>
+  `${name} is set to ${version}, but nothing was written`;
 
 // Updates page.
 export const UPDATES_EMPTY = "Everything is up to date";
@@ -194,6 +200,10 @@ export const FORKED_ATTENTION_DETAIL =
   "Your changes are safe — nothing will overwrite them. Decide whether to keep each as your own copy.";
 
 export const FOLLOW_SOURCE_TOAST = "Now following its source";
+// The manifest follows again and the copy on disk did not move with it —
+// true of the switch, silent about the files, so both are said.
+export const FOLLOW_SOURCE_STALLED_TOAST =
+  "Now following its source, but nothing was written";
 
 // The app's own out-of-date notice, in the sidebar. It names both versions
 // and offers the one action the install channel allows: a replacement where

--- a/ui/src/lib/update-outcome.test.ts
+++ b/ui/src/lib/update-outcome.test.ts
@@ -47,10 +47,14 @@ describe("outcomeOf", () => {
     });
   });
 
-  // A hold move answers with the view alone, so the command succeeding is
-  // all there is to go on.
-  it("reads a hold move as moved", () => {
-    expect(outcomeOf(null)).toEqual({ removed: [], held: [], moved: true });
+  // A plan that refused nothing wrote the package, whether or not the
+  // report names a rendering it moved.
+  it("reads an apply that refused nothing as moved", () => {
+    expect(outcomeOf(update({}))).toEqual({
+      removed: [],
+      held: [],
+      moved: true,
+    });
   });
 
   it("reads a refusal that kept the copy as held, and nothing moved", () => {

--- a/ui/src/lib/update-outcome.ts
+++ b/ui/src/lib/update-outcome.ts
@@ -11,12 +11,12 @@ import type { HarnessId, PackageUpdate_Serialize, UpdateRow } from "@/bindings";
 import { UPDATED_ALL_TOAST, updatedToastLabel } from "@/lib/copy";
 import {
   movedDespiteErrorToastLabel,
+  needsAttentionToastLabel,
   nothingMovedToastLabel,
-  notUpdatedToastLabel,
+  notUpdatedToastLead,
   removedNotReplacedCountToastLabel,
   removedNotReplacedToastLabel,
   updatedCountToastLabel,
-  updatedExceptToastLabel,
   updatedSomeToastLabel,
 } from "@/lib/copy-updates";
 import { harnessName, packageDisplayName } from "@/lib/labels";
@@ -40,16 +40,11 @@ export type UpdateOutcome = {
   moved: boolean;
 };
 
-/** Read what a single-package apply reported. `null` is a hold move:
- *  `packageSetRev` answers with the view alone, so it moved on the
- *  strength of the command succeeding — the reading that path has always
- *  had. */
-export const outcomeOf = (
-  update: PackageUpdate_Serialize | null,
-): UpdateOutcome => {
-  if (!update) {
-    return { removed: [], held: [], moved: true };
-  }
+/** Read what a single-package apply reported. Every command that applies
+ *  one package answers with this record — the update and the version
+ *  switch alike — so there is no shape here meaning "it succeeded, ask no
+ *  further". */
+export const outcomeOf = (update: PackageUpdate_Serialize): UpdateOutcome => {
   const removed = toolsOf(update.removed);
   const held = toolsOf(update.heldBack);
   return {
@@ -61,10 +56,25 @@ export const outcomeOf = (
   };
 };
 
-/** Toast what the apply did to `name`. */
+/** The two lines one surface writes about its own action: what it says
+ *  when the plan wrote the package, and what it says when the plan wrote
+ *  nothing. A version switch and a Follow source flip did something an
+ *  update did not — the manifest moved — so the wording is theirs, while
+ *  which of the two is said stays here. The partial case is the moved
+ *  line with the held tail after it, so no surface spells that one out. */
+export type OutcomeLines = { moved: string; stalled: string };
+
+/** How an Update says it, and the default for every other surface. */
+export const updateLines = (name: string): OutcomeLines => ({
+  moved: updatedToastLabel(name),
+  stalled: notUpdatedToastLead(name),
+});
+
+/** Toast what the apply did to `name`, in `lines`' wording. */
 export const showUpdateOutcome = (
   name: string,
   update: PackageUpdate_Serialize,
+  lines: OutcomeLines = updateLines(name),
 ): void => {
   const outcome = outcomeOf(update);
   // Said first and said as an error: a refusal with nothing of the
@@ -75,14 +85,14 @@ export const showUpdateOutcome = (
     return;
   }
   if (outcome.held.length === 0) {
-    toast.success(updatedToastLabel(name));
+    toast.success(lines.moved);
     return;
   }
   if (outcome.moved) {
-    toast.success(updatedExceptToastLabel(name, outcome.held));
+    toast.success(needsAttentionToastLabel(lines.moved, outcome.held));
     return;
   }
-  toast.info(notUpdatedToastLabel(name, outcome.held));
+  toast.info(needsAttentionToastLabel(lines.stalled, outcome.held));
 };
 
 /** What a run over several places did: the places it wrote, how many it

--- a/ui/src/stores/updates-apply.ts
+++ b/ui/src/stores/updates-apply.ts
@@ -13,14 +13,13 @@ import { type BulkOutcome, outcomeOf } from "@/lib/update-outcome";
 
 type Report = (error: string) => void;
 
-/** What one place's Update did: whether the command landed at all, and —
- *  for a following package — what the plan wrote and what it held back.
- *  A hold move reports neither: `packageSetRev` answers with the view
- *  alone. */
-export type ApplyOutcome = {
-  ok: boolean;
-  update: PackageUpdate_Serialize | null;
-};
+/** What one place's Update did: whether the command landed at all, and
+ *  what the plan wrote and what it held back. Both commands report it, so
+ *  a landed apply always carries the record and a failed one never
+ *  needs to invent an empty stand-in for it. */
+export type ApplyOutcome =
+  | { ok: false }
+  | { ok: true; update: PackageUpdate_Serialize };
 
 /** Bring one place current. Held packages move by moving the hold;
  *  following ones come current through the single-package apply. Either
@@ -32,23 +31,18 @@ export const applyRow = async (
   row: UpdateRow,
   report: Report,
 ): Promise<ApplyOutcome> => {
-  if (row.pinned && row.latest) {
-    const response = await commands.packageSetRev(
-      row.scope,
-      row.kind,
-      row.name,
-      row.latest.commit,
-    );
-    if (response.status === "error") {
-      report(response.error);
-      return { ok: false, update: null };
-    }
-    return { ok: true, update: null };
-  }
-  const response = await commands.packageUpdate(row.scope, row.kind, row.name);
+  const response =
+    row.pinned && row.latest
+      ? await commands.packageSetRev(
+          row.scope,
+          row.kind,
+          row.name,
+          row.latest.commit,
+        )
+      : await commands.packageUpdate(row.scope, row.kind, row.name);
   if (response.status === "error") {
     report(response.error);
-    return { ok: false, update: null };
+    return { ok: false };
   }
   return { ok: true, update: response.data };
 };

--- a/ui/src/stores/updates-bulk.test.ts
+++ b/ui/src/stores/updates-bulk.test.ts
@@ -98,13 +98,14 @@ describe("updates store: bulk update", () => {
       adoptable: ADOPTABLE,
       exits: [],
     };
+    const clean = { view, heldBack: [], removed: [], moved: [] };
     vi.mocked(commands.packageSetRev).mockResolvedValue({
       status: "ok",
-      data: view,
+      data: clean,
     });
     vi.mocked(commands.packageUpdate).mockResolvedValue({
       status: "ok",
-      data: { view: view, heldBack: [], removed: [], moved: [] },
+      data: clean,
     });
     vi.mocked(commands.updatesOverview).mockResolvedValue({
       status: "ok",

--- a/ui/src/stores/updates-toast.test.ts
+++ b/ui/src/stores/updates-toast.test.ts
@@ -155,6 +155,25 @@ describe("updates store: a package the plan held back", () => {
     );
   });
 
+  // A pinned row moves its hold instead of running the update, and that
+  // write is refused on disk for the same reasons — so the row's toast
+  // reads the hold move's own report rather than the click.
+  it("never claims a pinned package was updated when its copy stayed", async () => {
+    ready([]);
+    vi.mocked(commands.packageSetRev).mockResolvedValue({
+      status: "ok",
+      data: { view, heldBack: [conflict("claude")], removed: [], moved: [] },
+    });
+    await useUpdatesStore
+      .getState()
+      .updateOne(row({ name: "gh", pinned: true }));
+    expect(commands.packageUpdate).not.toHaveBeenCalled();
+    expect(toast.success).not.toHaveBeenCalled();
+    expect(toast.info).toHaveBeenCalledWith(
+      "gh was not updated — the copy in Claude Code needs attention on the package page",
+    );
+  });
+
   it("names the tool still holding it when the other copies moved", async () => {
     held({ heldBack: [conflict("codex")], moved: [stale("claude")] });
     await useUpdatesStore.getState().updateOne(row({ name: "gh" }));

--- a/ui/src/stores/updates.test.ts
+++ b/ui/src/stores/updates.test.ts
@@ -680,14 +680,19 @@ describe("updates store", () => {
     vi.mocked(commands.packageSetRev).mockResolvedValue({
       status: "ok",
       data: {
-        scope: { scope: "global" },
-        drift: [],
-        plan: [],
-        notes: [],
-        warnings: [],
-        safety: [],
-        adoptable: ADOPTABLE,
-        exits: [],
+        view: {
+          scope: { scope: "global" },
+          drift: [],
+          plan: [],
+          notes: [],
+          warnings: [],
+          safety: [],
+          adoptable: ADOPTABLE,
+          exits: [],
+        },
+        heldBack: [],
+        removed: [],
+        moved: [],
       },
     });
     vi.mocked(commands.updatesOverview).mockResolvedValue({

--- a/ui/src/stores/updates.ts
+++ b/ui/src/stores/updates.ts
@@ -1,7 +1,7 @@
 import { toast } from "sonner";
 import { create } from "zustand";
 import { commands, type ItemWarning, type UpdateRow } from "@/bindings";
-import { UPDATE_ERROR_TITLE, updatedToastLabel } from "@/lib/copy";
+import { UPDATE_ERROR_TITLE } from "@/lib/copy";
 import {
   nothingToUpdateToastLabel,
   UPDATE_NEEDS_CHECK_NOTE,
@@ -20,7 +20,7 @@ import { rowUnsettled, unsettled } from "@/lib/updates-read-state";
 import { useAuditStore } from "./audit";
 import { useProblemsStore } from "./problems";
 import { useScanStore } from "./scan";
-import { type ApplyOutcome, applyRow, applyRows } from "./updates-apply";
+import { applyRow, applyRows } from "./updates-apply";
 import { followSwitch, type PendingFollow } from "./updates-follow";
 import { overviewApplier } from "./updates-overview";
 
@@ -159,19 +159,19 @@ export const useUpdatesStore = create<UpdatesState>((set, get) => {
       try {
         // The commit and its follow-up overview ride the side-effect
         // chain, so nothing older can land on top of them.
-        let outcome: ApplyOutcome = { ok: false, update: null };
+        let landed = false;
         const error = await get().mutate(async () => {
-          outcome = await applyRow(row, reportUpdate);
+          const outcome = await applyRow(row, reportUpdate);
+          // Either command can come back held: the plan refuses to write
+          // over a copy somebody changed, and saying "Updated" over that
+          // is the whole point of asking the command what it did.
+          if (outcome.ok) showUpdateOutcome(row.name, outcome.update);
+          landed = outcome.ok;
           return null;
         });
         if (error !== null) {
           showError(UPDATE_ERROR_TITLE, error);
-        } else if (outcome.ok) {
-          // A following package can come back held: the plan refuses to
-          // write over a copy somebody changed, and saying "Updated" over
-          // that is the whole point of asking the command what it did.
-          if (outcome.update) showUpdateOutcome(row.name, outcome.update);
-          else toast.success(updatedToastLabel(row.name));
+        } else if (landed) {
           await useScanStore.getState().refresh();
           await useAuditStore.getState().refresh({ force: true });
         }


### PR DESCRIPTION
Switching a package's version, or turning Follow source back on, reported an update whether or not one reached the files.

`package_set_rev` wrote the manifest revision, applied the plan, and returned a bare `AuditView`. When the planner held a hand-edited rendering back rather than writing over it, that view was indistinguishable from a clean apply. KEN-462 had already fixed the sibling command — `package_update` returns `PackageUpdate { view, held_back, moved }` and `lib/update-outcome.ts` renders the cases honestly — and `package_set_rev` was left on the old shape, so three call sites claimed success unconditionally: `switchTo`, `updateToLatest` on a held package, and `follow`.

## What changed

`package_set_rev` returns `PackageUpdate`. It and `package_update` build that answer through one new `settle_package`, which reads `held_back`, `removed` and `moving` off the `EngineReport` before the apply runs. Bindings regenerated.

All three call sites render the command's report through `showUpdateOutcome`, sharing one `run` helper.

No fourth outcome category was invented. `showUpdateOutcome` gained an `OutcomeLines` parameter carrying the surface's `moved` and `stalled` leads and composes the tail itself, so a switch says `gh is set to v2, but nothing was written — the copy in Claude Code needs attention on the package page`, and Follow source says `Now following its source, but nothing was written — …`. The classification in `outcomeOf` is untouched, except that it no longer accepts `null`: no command answers with the view alone now.

## Why this option

The issue offered two. The other one blocks version switching and Follow source while edits exist. It cannot carry the fix on its own: `held_back` is broader than `edited` — files kendex never put there and provenance clashes reach it too — so the held path is live where `edited` is false or unevaluated, and gating on edits alone would leave the dishonest toast in place for exactly those cases. This does not touch which rows the Updates table offers, or KEN-573's rule that an edited package is not updatable.

## A forced consequence

Once `packageSetRev` reports, `applyRow` either passes the record on or fabricates a `null` to discard it. It passes it on, so `ApplyOutcome` is a union and the per-row toast for a held pinned place stops claiming an update.

## Verification

`cargo fmt`, `cargo clippy --workspace -- -D warnings`, `cargo test --workspace`, 826 UI tests, `tools/guard`, `tools/changelog-collate --check`, the size ratchet and preflight are clean. `updates.ts` was trimmed to 249 lines to stay under the ratchet's 250 for `ui/*.ts`; no baseline row was raised.

Must-fail control: replacing `showUpdateOutcome` with an unconditional `toast.success` turns the six held and removed assertions red and leaves the five clean-apply controls green. One test was replaced — `update-outcome.test.ts`'s "reads a hold move as moved" covered `outcomeOf(null)`, a shape that no longer exists, and its replacement asserts the same reading off a report that refused nothing.

Closes KEN-605
