### PR TITLE
fix(KEN-552): the macOS fixture root is the one the run prints

### DIFF
--- a/crates/cli/tests/presentation/main.rs
+++ b/crates/cli/tests/presentation/main.rs
@@ -29,6 +29,20 @@ pub fn escaped_the_frame(printed: &str) -> Vec<String> {
     loose
 }
 
+/// The fixture root as the binary will see it. A macOS temporary
+/// directory resolves under `/private`, so a fixture that keeps the path
+/// it was handed builds project and catalog paths the run never prints:
+/// what it prints is the resolved form, which merely ends with the one
+/// the fixture holds. Redaction keyed to the unresolved path then leaves
+/// `/private` standing in front of the placeholder, and a fixture that
+/// compares its own paths against printed ones never matches.
+#[allow(clippy::unwrap_used)]
+pub fn rooted(tmp: &tempfile::TempDir) -> PathBuf {
+    tmp.path()
+        .canonicalize()
+        .unwrap_or_else(|_| tmp.path().to_owned())
+}
+
 #[allow(clippy::expect_used)]
 fn kendex(home: &Path, cwd: &Path, ui: &str, args: &[&str]) -> Output {
     Command::new(env!("CARGO_BIN_EXE_kendex"))
@@ -165,7 +179,7 @@ fn blocked_project_at(home: &Path, project: &Path) {
 #[allow(clippy::unwrap_used)]
 pub fn nothing_declared(args: &[&str]) -> Output {
     let tmp = tempfile::tempdir().unwrap();
-    let home = tmp.path();
+    let home = &rooted(&tmp);
     let project = home.join("dev/app");
     fs::create_dir_all(project.join(".claude")).unwrap();
     fs::write(project.join("kendex.toml"), "schema = 6\n").unwrap();
@@ -179,7 +193,7 @@ pub fn nothing_declared(args: &[&str]) -> Output {
 #[allow(clippy::unwrap_used)]
 pub fn both(args: &[&str]) -> (String, String) {
     let tmp = tempfile::tempdir().unwrap();
-    let home = tmp.path();
+    let home = &rooted(&tmp);
     let catalog = home.join("catalog").display().to_string();
     let filled: Vec<String> = args
         .iter()
@@ -205,7 +219,7 @@ pub fn both(args: &[&str]) -> (String, String) {
 #[allow(clippy::unwrap_used)]
 pub fn one(ui: &str, args: &[&str]) -> Ran {
     let tmp = tempfile::tempdir().unwrap();
-    let home = tmp.path().to_owned();
+    let home = rooted(&tmp);
     let catalog = home.join("catalog").display().to_string();
     let filled: Vec<String> = args
         .iter()

--- a/crates/cli/tests/presentation/main.rs
+++ b/crates/cli/tests/presentation/main.rs
@@ -8,6 +8,8 @@ use std::fs;
 use std::path::{Path, PathBuf};
 use std::process::{Command, Output};
 
+use kendex_core::env::Env;
+
 /// The frame a terminal gets, and nothing a verb ever writes itself.
 const FRAMING: [char; 12] = ['┌', '│', '└', '├', '╮', '╯', '─', '◇', '◆', '▲', '■', '●'];
 

--- a/crates/cli/tests/presentation/plain.rs
+++ b/crates/cli/tests/presentation/plain.rs
@@ -11,7 +11,7 @@ use super::*;
 #[allow(clippy::unwrap_used)]
 fn the_blocked_refresh_prints_the_lines_scripts_parse() {
     let tmp = tempfile::tempdir().unwrap();
-    let home = tmp.path();
+    let home = &rooted(&tmp);
     let project = blocked_project(home);
     let printed = said(&kendex(
         home,
@@ -63,7 +63,7 @@ fn the_blocked_refresh_prints_the_lines_scripts_parse() {
 #[allow(clippy::unwrap_used)]
 fn the_blocked_refresh_reads_under_twenty_lines() {
     let tmp = tempfile::tempdir().unwrap();
-    let home = tmp.path();
+    let home = &rooted(&tmp);
     let project = blocked_project(home);
     let printed = said(&kendex(
         home,
@@ -81,7 +81,7 @@ fn the_blocked_refresh_reads_under_twenty_lines() {
 #[allow(clippy::unwrap_used)]
 fn nothing_is_said_twice() {
     let tmp = tempfile::tempdir().unwrap();
-    let home = tmp.path();
+    let home = &rooted(&tmp);
     let project = blocked_project(home);
     let printed = said(&kendex(
         home,
@@ -110,7 +110,7 @@ fn nothing_is_said_twice() {
 #[allow(clippy::unwrap_used)]
 fn no_framing_reaches_a_pipe() {
     let tmp = tempfile::tempdir().unwrap();
-    let home = tmp.path();
+    let home = &rooted(&tmp);
     let project = blocked_project(home);
     for args in [
         vec!["refresh", "-y", "--scope", "project"],
@@ -137,7 +137,7 @@ fn no_framing_reaches_a_pipe() {
 #[allow(clippy::unwrap_used)]
 fn a_run_with_no_terminal_is_plain_without_being_told() {
     let tmp = tempfile::tempdir().unwrap();
-    let home = tmp.path();
+    let home = &rooted(&tmp);
     let project = blocked_project(home);
     let printed = said(&kendex(
         home,
@@ -164,7 +164,7 @@ fn a_run_with_no_terminal_is_plain_without_being_told() {
 #[allow(clippy::unwrap_used)]
 fn show_file_prints_the_files_own_lines() {
     let tmp = tempfile::tempdir().unwrap();
-    let home = tmp.path();
+    let home = &rooted(&tmp);
     let project = home.join("dev/app");
     blocked_project_at(home, &project);
     fs::write(
@@ -208,7 +208,7 @@ fn show_file_prints_the_files_own_lines() {
 #[allow(clippy::unwrap_used)]
 fn a_failure_after_the_write_still_records_and_reports_it() {
     let tmp = tempfile::tempdir().unwrap();
-    let home = tmp.path();
+    let home = &rooted(&tmp);
     let project = home.join("dev/app");
     let catalog = home.join("catalog");
     let armed = catalog.join("skills/armed");

--- a/crates/cli/tests/presentation/plain.rs
+++ b/crates/cli/tests/presentation/plain.rs
@@ -249,7 +249,7 @@ fn a_failure_after_the_write_still_records_and_reports_it() {
         printed.contains("applied 2 changes"),
         "the run said nothing about what it wrote: {printed}"
     );
-    let drift = home.join(".local/share/kendex/drift");
+    let drift = Env::host_rooted(home.clone()).drift_dir();
     let recorded = fs::read_dir(&drift).map(|d| d.count()).unwrap_or(0);
     assert_eq!(
         recorded, 1,

--- a/crates/cli/tests/presentation/pretty.rs
+++ b/crates/cli/tests/presentation/pretty.rs
@@ -182,7 +182,7 @@ const FRAME_LINES: usize = 2;
 #[allow(clippy::unwrap_used)]
 fn one_line_verdicts_are_drawn_as_one_group() {
     let tmp = tempfile::tempdir().unwrap();
-    let home = tmp.path();
+    let home = &rooted(&tmp);
     let project = blocked_project(home);
     // A row to verify has to be installed first; the blocked item stays
     // blocked and the two that install are the clean rows.
@@ -237,7 +237,7 @@ fn a_run_ending_outside_its_ledger_still_closes_the_frame() {
 fn a_warning_after_the_writes_lands_above_the_closing_ledger() {
     for ui in ["plain", "pretty"] {
         let tmp = tempfile::tempdir().unwrap();
-        let home = tmp.path();
+        let home = &rooted(&tmp);
         let project = home.join("dev/app");
         blocked_project_at(home, &project);
         // A file where the snapshot's directory belongs, so deriving it

--- a/crates/cli/tests/presentation/pretty.rs
+++ b/crates/cli/tests/presentation/pretty.rs
@@ -242,9 +242,9 @@ fn a_warning_after_the_writes_lands_above_the_closing_ledger() {
         blocked_project_at(home, &project);
         // A file where the snapshot's directory belongs, so deriving it
         // fails and the pass after the writes has a warning to print.
-        let data = home.join(".local/share/kendex");
-        fs::create_dir_all(&data).unwrap();
-        fs::write(data.join("drift"), "not a directory\n").unwrap();
+        let drift = Env::host_rooted(home.clone()).drift_dir();
+        fs::create_dir_all(drift.parent().unwrap()).unwrap();
+        fs::write(&drift, "not a directory\n").unwrap();
 
         let printed = said(&kendex(
             home,

--- a/crates/cli/tests/presentation/snapshots.rs
+++ b/crates/cli/tests/presentation/snapshots.rs
@@ -14,7 +14,7 @@ use super::*;
 #[allow(clippy::unwrap_used)]
 fn shape(setup: &[&str], args: &[&str]) -> Vec<String> {
     let tmp = tempfile::tempdir().unwrap();
-    let home = tmp.path();
+    let home = &rooted(&tmp);
     let project = blocked_project(home);
     let catalog = home.join("catalog").display().to_string();
     let fill = |args: &[&str]| -> Vec<String> {
@@ -167,7 +167,7 @@ fn remove() {
 fn a_name_off_a_foreign_tree_cannot_forge_a_line() {
     for ui in ["plain", "pretty"] {
         let tmp = tempfile::tempdir().unwrap();
-        let home = tmp.path();
+        let home = &rooted(&tmp);
         let project = home.join("dev/app");
         blocked_project_at(home, &project);
         // Content nothing manages, named with the two characters that
@@ -221,7 +221,7 @@ fn a_name_off_a_foreign_tree_cannot_forge_a_line() {
 fn the_scope_a_line_names_is_escaped_with_the_rest() {
     for ui in ["plain", "pretty"] {
         let tmp = tempfile::tempdir().unwrap();
-        let home = tmp.path();
+        let home = &rooted(&tmp);
         let project = home.join("we\u{1b}[31mird");
         blocked_project_at(home, &project);
         let printed = said(&kendex(
@@ -248,7 +248,7 @@ fn the_scope_a_line_names_is_escaped_with_the_rest() {
 #[allow(clippy::unwrap_used)]
 fn the_verdict_counts_the_lines_the_report_actually_printed() {
     let tmp = tempfile::tempdir().unwrap();
-    let home = tmp.path();
+    let home = &rooted(&tmp);
     let project = crowded_project(home, 14);
     let output = kendex(home, &project, "plain", &["check", "--scope", "project"]);
     let report = String::from_utf8_lossy(&output.stdout).into_owned();
@@ -303,7 +303,7 @@ fn crowded_project(home: &Path, count: usize) -> PathBuf {
 fn a_late_warning_lands_above_the_closing_ledger() {
     for ui in ["plain", "pretty"] {
         let tmp = tempfile::tempdir().unwrap();
-        let home = tmp.path();
+        let home = &rooted(&tmp);
         let project = blocked_project(home);
         kendex(
             home,

--- a/crates/cli/tests/presentation/snapshots.rs
+++ b/crates/cli/tests/presentation/snapshots.rs
@@ -313,7 +313,7 @@ fn a_late_warning_lands_above_the_closing_ledger() {
         );
         // The snapshot's own directory, made unwritable so deriving it
         // fails after the plan has already been written.
-        let drift = home.join(".local/share/kendex/drift");
+        let drift = Env::host_rooted(home.clone()).drift_dir();
         assert!(drift.is_dir(), "the fixture never derived a snapshot");
         let mut mode = fs::metadata(&drift).unwrap().permissions();
         mode.set_readonly(true);

--- a/crates/core/src/env.rs
+++ b/crates/core/src/env.rs
@@ -93,6 +93,15 @@ impl Env {
         Self::rooted(home.into(), os)
     }
 
+    /// This machine's own layout under a home of your choosing. A test
+    /// that runs the binary against a temporary home asks here for the
+    /// paths that run will write, instead of spelling them a second
+    /// time: a spelling agrees with the code until a platform makes the
+    /// two disagree, and the data dir is one that does.
+    pub fn host_rooted(home: impl Into<PathBuf>) -> Self {
+        Self::rooted(home.into(), HOST_OS)
+    }
+
     /// Every root under one home, laid out the way `os` lays them out.
     fn rooted(home: PathBuf, os: FakeOs) -> Self {
         let (config, cache, data) = match os {


### PR DESCRIPTION
`main` is red on the macOS cargo lane. Seven tests in the KEN-552 presentation suite fail on `a96fb5780`, run [33190108320](https://github.com/vanillagreencom/kendex/actions/runs/33190108320):

```
plain::a_failure_after_the_write_still_records_and_reports_it
plain::the_blocked_refresh_prints_the_lines_scripts_parse
pretty::a_warning_after_the_writes_lands_above_the_closing_ledger
snapshots::a_late_warning_lands_above_the_closing_ledger
snapshots::add
snapshots::apply_plan
snapshots::remove
```

This commit was written for #1770 and pushed to its branch, but the merge queue had already captured the pre-push head, so #1770 merged without it. Only the changelog cap trim landed. Same fix, off current main, on its own so it is not coupled to a feature branch's review cycle.

## The mechanism

The rendering is right and the fixtures are wrong. A macOS temporary directory resolves under `/private`, so a fixture that keeps the path it was handed builds project and catalog paths the run never prints: what the binary prints is the resolved form, which merely *ends* with the one the fixture holds. Redaction keyed to the unresolved path therefore strips the tail and leaves `/private` standing in front of the placeholder.

```
expected: conflict: skill growth-guards ... <project>/.claude/skills/growth-guards ...
actual:   conflict: skill growth-guards ... /private<project>/.claude/skills/growth-guards ...
```

## The fix

One `rooted` helper canonicalises the fixture root once at creation, across all 17 fixture sites, so project, catalog and the snapshot directory settle canonical with it.

Doing this at the redaction site instead would leave two of the seven failures standing: `plain::a_failure_after_the_write_still_records_and_reports_it` and `pretty::a_warning_after_the_writes_lands_above_the_closing_ledger` do no redaction at all — they compare fixture-built paths against printed ones.

Test-only. Linux: 31/31 in the presentation suite. macOS is the lane that proves it.
