### PR TITLE
fix(KEN-606): a declaration outranks the pin a set was held with

### DIFF
--- a/changelog.d/changed/KEN-606.md
+++ b/changelog.d/changed/KEN-606.md
@@ -1,0 +1,3 @@
+- **Breaking:** the install record is version 6 and records where each bundle
+  sits. Upgrading rewrites it on the next apply; an older kendex refuses it
+  rather than reading it, so do not go back.

--- a/changelog.d/fixed/KEN-606.md
+++ b/changelog.d/fixed/KEN-606.md
@@ -1,0 +1,3 @@
+- Updating a package a bundle also carries now moves that package alone —
+  the bundle and its other members stay on the version they were installed
+  from.

--- a/crates/core/src/engine/bundles.rs
+++ b/crates/core/src/engine/bundles.rs
@@ -28,6 +28,7 @@ use crate::model::{HarnessId, ItemKind, Scope};
 use crate::source::find_item;
 
 use super::ItemWarning;
+use super::desired::hold::HeldPins;
 use super::desired::{DesiredState, target_harnesses};
 use super::expansion::{Catalogs, Expansion};
 
@@ -46,6 +47,7 @@ struct Carried {
 pub(super) fn expand(
     scope: &Scope,
     manifest: &Manifest,
+    held: Option<&HeldPins>,
     expansion: &mut Expansion,
     catalogs: &mut Catalogs,
     state: &mut DesiredState,
@@ -53,7 +55,7 @@ pub(super) fn expand(
     let mut carried: BTreeMap<(ItemKind, String), Carried> = BTreeMap::new();
     for (name, decl) in &manifest.bundles {
         for (kind, member, member_decl, harnesses) in
-            installable(name, decl, scope, manifest, catalogs, state)
+            installable(name, decl, scope, manifest, held, catalogs, state)
         {
             let edge = (
                 Reason::MemberOf {
@@ -137,6 +139,44 @@ pub(crate) fn member_decl(bundle: &ItemDecl) -> ItemDecl {
     }
 }
 
+/// The revision one member reads, where the set is not the only thing that
+/// says.
+///
+/// A set carries one revision to everything in it, and that is the answer
+/// wherever the member has nothing else to read. A member the manifest
+/// declares does: a single-package update pins the declarations it holds
+/// still, so reading the set's pin onto a declared member wants one
+/// package at two revisions this pass invented, and a plan that refuses
+/// both writes nothing for a package nobody pinned. The declaration is
+/// what the person acted on, so it decides.
+///
+/// Only a revision this pass invented gives way. Where the person wrote
+/// one — on the set, on the member, or on both — the two stand as written
+/// and whatever they disagree about is theirs to reconcile, reported the
+/// way a whole-scope pass reports it.
+fn carried_rev(
+    manifest: &Manifest,
+    held: Option<&HeldPins>,
+    bundle: &str,
+    bundle_rev: Option<String>,
+    kind: ItemKind,
+    member: &str,
+) -> Option<String> {
+    let Some(decl) = manifest.declared(kind).get(member) else {
+        return bundle_rev;
+    };
+    let set_pin_invented = held.is_some_and(|pins| pins.invented_bundle(bundle));
+    let member_pin_invented = held.is_some_and(|pins| pins.invented_item(kind, member));
+    let set_holds_a_chosen_rev = bundle_rev.is_some() && !set_pin_invented;
+    let member_holds_a_chosen_rev = decl.rev.is_some() && !member_pin_invented;
+    if set_holds_a_chosen_rev || member_holds_a_chosen_rev {
+        // A revision the person wrote is in play, so both sides stand as
+        // they wrote them — the set's without the pin this pass put on it.
+        return if set_pin_invented { None } else { bundle_rev };
+    }
+    decl.rev.clone()
+}
+
 /// The members of one set this plan can actually install, each with the
 /// declaration it installs under and the tools it lands on. Every member left
 /// out is accounted for: held back by a removal, not offered by the catalog,
@@ -146,6 +186,7 @@ fn installable(
     decl: &ItemDecl,
     scope: &Scope,
     manifest: &Manifest,
+    held: Option<&HeldPins>,
     catalogs: &mut Catalogs,
     state: &mut DesiredState,
 ) -> Vec<(ItemKind, String, ItemDecl, Vec<HarnessId>)> {
@@ -189,7 +230,15 @@ fn installable(
             });
             continue;
         }
-        let member_decl = member_decl(decl);
+        let mut member_decl = member_decl(decl);
+        member_decl.rev = carried_rev(
+            manifest,
+            held,
+            name,
+            member_decl.rev,
+            member.kind,
+            &member.name,
+        );
         let harnesses = target_harnesses(&member_decl, manifest, member.kind, scope);
         if harnesses.is_empty() {
             state.notes.push(format!(

--- a/crates/core/src/engine/bundles.rs
+++ b/crates/core/src/engine/bundles.rs
@@ -144,16 +144,17 @@ pub(crate) fn member_decl(bundle: &ItemDecl) -> ItemDecl {
 ///
 /// A set carries one revision to everything in it, and that is the answer
 /// wherever the member has nothing else to read. A member the manifest
-/// declares does: a single-package update pins the declarations it holds
-/// still, so reading the set's pin onto a declared member wants one
-/// package at two revisions this pass invented, and a plan that refuses
-/// both writes nothing for a package nobody pinned. The declaration is
-/// what the person acted on, so it decides.
+/// declares reads its own declaration instead, and what the set brings to
+/// that reading is the revision the person wrote on the set — never the
+/// pin a single-package update invented to hold the set still. Weighed
+/// against the pin, one package is wanted at two revisions nobody chose,
+/// and a plan that refuses both writes nothing for a package nobody
+/// pinned.
 ///
-/// Only a revision this pass invented gives way. Where the person wrote
-/// one — on the set, on the member, or on both — the two stand as written
-/// and whatever they disagree about is theirs to reconcile, reported the
-/// way a whole-scope pass reports it.
+/// What the declaration brings is the revision the person wrote on it, and
+/// [`super::expansion::Planned`] keeps that where the pass pinned the
+/// declaration too. Where the two differ the disagreement is real, and it
+/// is stated in the revisions they wrote.
 fn carried_rev(
     manifest: &Manifest,
     held: Option<&HeldPins>,
@@ -162,19 +163,13 @@ fn carried_rev(
     kind: ItemKind,
     member: &str,
 ) -> Option<String> {
-    let Some(decl) = manifest.declared(kind).get(member) else {
+    if !manifest.declared(kind).contains_key(member) {
         return bundle_rev;
-    };
-    let set_pin_invented = held.is_some_and(|pins| pins.invented_bundle(bundle));
-    let member_pin_invented = held.is_some_and(|pins| pins.invented_item(kind, member));
-    let set_holds_a_chosen_rev = bundle_rev.is_some() && !set_pin_invented;
-    let member_holds_a_chosen_rev = decl.rev.is_some() && !member_pin_invented;
-    if set_holds_a_chosen_rev || member_holds_a_chosen_rev {
-        // A revision the person wrote is in play, so both sides stand as
-        // they wrote them — the set's without the pin this pass put on it.
-        return if set_pin_invented { None } else { bundle_rev };
     }
-    decl.rev.clone()
+    match held.is_some_and(|pins| pins.invented_bundle(bundle)) {
+        true => None,
+        false => bundle_rev,
+    }
 }
 
 /// The members of one set this plan can actually install, each with the

--- a/crates/core/src/engine/desired.rs
+++ b/crates/core/src/engine/desired.rs
@@ -202,18 +202,22 @@ pub(super) mod hold;
 /// and hashes and renderings must reflect that rewrite — otherwise the very
 /// next audit reads the merged manifest and calls a clean install stale. The
 /// merge is idempotent, so recomputing against it converges in one repeat.
-pub fn desired_state(
+///
+/// `held` names the declarations a single-package update pinned itself, so
+/// the closure can tell them from the holds the person chose.
+pub(super) fn desired_state(
     env: &Env,
     scope: &Scope,
     manifest: &Manifest,
     lock: &Lock,
     hold_upstream_skills: bool,
+    held: Option<&hold::HeldPins>,
 ) -> Result<DesiredState> {
-    let first = compute(env, scope, manifest, lock, hold_upstream_skills)?;
+    let first = compute(env, scope, manifest, lock, hold_upstream_skills, held)?;
     let Some(merged) = first.manifest_update else {
         return Ok(first);
     };
-    let mut second = compute(env, scope, &merged, lock, hold_upstream_skills)?;
+    let mut second = compute(env, scope, &merged, lock, hold_upstream_skills, held)?;
     second.manifest_update = Some(merged);
     Ok(second)
 }
@@ -224,6 +228,7 @@ fn compute(
     manifest: &Manifest,
     lock: &Lock,
     hold_upstream_skills: bool,
+    held: Option<&hold::HeldPins>,
 ) -> Result<DesiredState> {
     let mut state = DesiredState::default();
     let mut updated_manifest = manifest.clone();
@@ -231,7 +236,7 @@ fn compute(
     // Everything is planned from the closure — what was declared, what the
     // installed bundles carry, and what those skills require — while the
     // manifest keeps holding only what was chosen.
-    let expansion = super::expansion::expand(env, scope, manifest, &mut state);
+    let expansion = super::expansion::expand(env, scope, manifest, held, &mut state);
     let collisions = super::catalog::Collisions::find(&expansion, &mut state);
 
     for kind in super::expansion::PLANNED_KINDS {

--- a/crates/core/src/engine/desired/hold.rs
+++ b/crates/core/src/engine/desired/hold.rs
@@ -60,10 +60,19 @@ enum Owner {
 /// Every reference is followed by the source it records, never by name
 /// alone: the edge names which parent, and which bundle, this dependency
 /// belongs to.
+///
+/// `carriers` says whether the sets that carry this installation own it.
+/// They do not where it has a declaration of its own to read: held still,
+/// such a set keeps its other members where they are, and the target moves
+/// on its own declaration. A parent walked to from here is another matter
+/// and always names its sets — it carries their revision onto what it
+/// requires, so a set that owns a parent has to read fresh whatever the
+/// target's own declaration says.
 fn owners_of(
     lock: &Lock,
     entry: &LockEntry,
     seen: &mut BTreeSet<(ItemKind, String, String)>,
+    carriers: bool,
 ) -> BTreeSet<Owner> {
     if !seen.insert((entry.kind, entry.name.clone(), entry.source.clone())) {
         return BTreeSet::new();
@@ -78,12 +87,13 @@ fn owners_of(
                     source: entry.source.clone(),
                 });
             }
-            Reason::MemberOf { bundle } => {
+            Reason::MemberOf { bundle } if carriers => {
                 owners.insert(Owner::Bundle {
                     name: bundle.name.clone(),
                     source: bundle.source.clone(),
                 });
             }
+            Reason::MemberOf { .. } => {}
             Reason::RequiredBy { by } => {
                 // A copy of the guard per parent, not one shared between
                 // them. One item is one entry per tool and those entries
@@ -95,7 +105,7 @@ fn owners_of(
                 for parent in lock.entries.values().filter(|parent| {
                     parent.kind == by.kind && parent.name == by.name && parent.source == by.source
                 }) {
-                    owners.extend(owners_of(lock, parent, &mut seen.clone()));
+                    owners.extend(owners_of(lock, parent, &mut seen.clone(), true));
                 }
             }
         }
@@ -162,14 +172,16 @@ pub(crate) fn planning_manifest<'a>(
 
 /// The manifest a single-package update plans from: the target reads
 /// fresh, and so does whatever carries its revision — the parent of a
-/// dependency always, and the sets that hold it only where the target has
-/// no declaration of its own to read. Every other unpinned remote
-/// declaration and bundle is pinned at the commit its lock entries agree
-/// on. A declaration the lock cannot place — nothing installed,
-/// installations disagreeing on their commit, or any one of them recorded
-/// against a source this declaration no longer reads from — is left to
-/// resolve fresh: a wrong pin would move it somewhere nobody asked for,
-/// and fresh is what a whole-scope apply gives it anyway.
+/// dependency always, and the sets that carry the target itself only
+/// where it has no declaration of its own to read. Every other unpinned
+/// declaration is pinned at the commit its lock entries agree on, and
+/// every unpinned set at the commit the record says it came out as.
+///
+/// A declaration the lock cannot place — nothing installed, installations
+/// disagreeing on their commit, or any one of them recorded against a
+/// source this declaration no longer reads from — is left to resolve
+/// fresh: a wrong pin would move it somewhere nobody asked for, and fresh
+/// is what a whole-scope apply gives it anyway.
 fn held_manifest(
     manifest: &Manifest,
     lock: &Lock,
@@ -196,44 +208,19 @@ fn held_manifest(
     // in under. An entry a rebind left behind is an installation of a
     // package this declaration no longer is, and its edges lead to
     // declarations this update has no business unpinning.
-    let installations: Vec<&LockEntry> = lock
-        .entries
-        .values()
-        .filter(|entry| {
-            entry.kind == target.0
-                && entry.name == target.1
-                && reads_from
-                    .as_ref()
-                    .is_none_or(|source| &entry.source == source)
-        })
-        .collect();
-    for entry in &installations {
-        exempt.extend(owners_of(lock, entry, &mut BTreeSet::new()));
-    }
-    // A target with a declaration of its own reads that declaration, so the
-    // sets that carry the target itself are held still along with everything
-    // else — `bundles::carried_rev` lets the declaration decide what the
-    // member installs, and a set left free takes its other members current
-    // as a side effect of an update nobody asked it for. A target with no
-    // declaration has only the set's revision to read, which has to resolve
-    // fresh for it to move at all.
-    //
-    // Only the sets that carry it: one reached through a dependency parent
-    // owns that parent's revision, not this target's. Pinning it pins the
-    // parent, which then carries its commit onto the target while the
-    // target's own declaration reads fresh — and the update the person
-    // asked for reports a conflict instead of happening.
-    if reads_from.is_some() {
-        for entry in &installations {
-            for reason in &entry.reasons {
-                if let Reason::MemberOf { bundle } = reason {
-                    exempt.remove(&Owner::Bundle {
-                        name: bundle.name.clone(),
-                        source: bundle.source.clone(),
-                    });
-                }
-            }
-        }
+    for entry in lock.entries.values().filter(|entry| {
+        entry.kind == target.0
+            && entry.name == target.1
+            && reads_from
+                .as_ref()
+                .is_none_or(|source| &entry.source == source)
+    }) {
+        exempt.extend(owners_of(
+            lock,
+            entry,
+            &mut BTreeSet::new(),
+            reads_from.is_none(),
+        ));
     }
     let mut held = manifest.clone();
     let mut pins = HeldPins {
@@ -278,16 +265,7 @@ fn held_manifest(
         let Some(repo) = source_repo(manifest, &decl.source) else {
             continue;
         };
-        // Where anything is here only as a member, that is what says where
-        // the set is; the members the person also declared are asked only
-        // when nothing else can answer.
-        let carried_alone = lock
-            .entries
-            .values()
-            .any(|entry| member_of(entry, name, &decl.source) && !also_declared(entry));
-        let Some(commit) = held_at(lock, &decl.source, repo, |entry| {
-            member_of(entry, name, &decl.source) && !(carried_alone && also_declared(entry))
-        }) else {
+        let Some(commit) = held_commit(lock, name, &decl.source, repo) else {
             continue;
         };
         decl.rev = Some(commit);
@@ -344,32 +322,27 @@ fn held_at(
     agreed
 }
 
-/// Whether this installation is here as a member of the named bundle — the
-/// entries whose recorded commits say where the bundle is held. Matched by
-/// source as well as name: a membership recorded against another catalog's
-/// set of the same name is not this declaration's evidence.
-fn member_of(entry: &LockEntry, bundle: &str, source: &str) -> bool {
-    entry.reasons.iter().any(
-        |reason| matches!(reason, Reason::MemberOf { bundle: of } if of.name == bundle && of.source == source),
-    )
-}
-
-/// Whether the person declared this installation as well as receiving it
-/// through a set.
+/// Where a set is held: the commit the record says it came out as.
 ///
-/// Such an installation is the weaker evidence of where its set is held:
-/// its commit is the one its own declaration reads, and a single-package
-/// update moves that commit off the set's. Counted alongside the members
-/// that have only the set to read, the two say the set is in two places,
-/// it can then be held at no commit at all, and its other members come
-/// current as the side effect this hold exists to remove.
+/// A set has no installation of its own, so this is the only account of
+/// where it sits that survives its members moving. Read back only where
+/// the declaration still reads from what the record names — a rebind
+/// leaves it describing a set this scope no longer installs.
 ///
-/// It is still evidence where the set has no other kind. A set whose every
-/// member is also declared has nothing else recorded, and held at no
-/// commit it reads its source's tip — where an unrelated update installs
-/// whatever the catalog has since added to the set.
-fn also_declared(entry: &LockEntry) -> bool {
-    entry.reasons.contains(&Reason::Requested)
+/// A lock written before that commit was recorded has none, and the
+/// members are all there is to go on: they were installed together and
+/// nothing has moved one of them off the set on its own yet, so where they
+/// agree is where the set is. The next write records it.
+fn held_commit(lock: &Lock, bundle: &str, source: &str, repo: &str) -> Option<String> {
+    if let Some(recorded) = lock.bundles.get(bundle) {
+        return (recorded.source == source && recorded.source_repo == repo)
+            .then(|| recorded.commit.clone());
+    }
+    held_at(lock, source, repo, |entry| {
+        entry.reasons.iter().any(
+            |reason| matches!(reason, Reason::MemberOf { bundle: of } if of.name == bundle && of.source == source),
+        )
+    })
 }
 
 #[cfg(test)]

--- a/crates/core/src/engine/desired/hold.rs
+++ b/crates/core/src/engine/desired/hold.rs
@@ -111,6 +111,21 @@ pub(crate) struct HeldPins {
 }
 
 impl HeldPins {
+    /// Whether the revision this declaration now reads is one this pass
+    /// invented. A member of a set consults it to tell a hold the person
+    /// chose from a hold that only exists to keep the rest of the scope
+    /// still — the first is theirs to reconcile, the second is not.
+    pub(crate) fn invented_item(&self, kind: ItemKind, name: &str) -> bool {
+        self.items
+            .iter()
+            .any(|(of_kind, of_name)| *of_kind == kind && of_name == name)
+    }
+
+    /// [`HeldPins::invented_item`] for a set's own declaration.
+    pub(crate) fn invented_bundle(&self, name: &str) -> bool {
+        self.bundles.iter().any(|of_name| of_name == name)
+    }
+
     /// Remove the synthetic pins from a manifest the plan is about to
     /// write. Every pinned declaration had no `rev` before the hold, so
     /// clearing it restores the declaration exactly.
@@ -145,11 +160,12 @@ pub(crate) fn planning_manifest<'a>(
     }
 }
 
-/// The manifest a single-package update plans from: the target — and every
-/// declaration that accounts for it, because the owner is what carries a
-/// derived package's revision — reads fresh, while every other unpinned
-/// remote declaration and bundle is pinned at the commit its lock entries
-/// agree on. A declaration the lock cannot place — nothing installed,
+/// The manifest a single-package update plans from: the target reads
+/// fresh, and so does whatever carries its revision — the parent of a
+/// dependency always, and the sets that hold it only where the target has
+/// no declaration of its own to read. Every other unpinned remote
+/// declaration and bundle is pinned at the commit its lock entries agree
+/// on. A declaration the lock cannot place — nothing installed,
 /// installations disagreeing on their commit, or any one of them recorded
 /// against a source this declaration no longer reads from — is left to
 /// resolve fresh: a wrong pin would move it somewhere nobody asked for,
@@ -188,6 +204,16 @@ fn held_manifest(
                 .is_none_or(|source| &entry.source == source)
     }) {
         exempt.extend(owners_of(lock, entry, &mut BTreeSet::new()));
+    }
+    // A target with a declaration of its own reads that declaration, so the
+    // sets that also carry it are held still along with everything else —
+    // `bundles::carried_rev` lets the declaration decide what the member
+    // installs. A set left free instead takes its other
+    // members current as a side effect of an update nobody asked it for. A
+    // target with no declaration has only the set's revision to read, which
+    // has to resolve fresh for it to move at all.
+    if reads_from.is_some() {
+        exempt.retain(|owner| !matches!(owner, Owner::Bundle { .. }));
     }
     let mut held = manifest.clone();
     let mut pins = HeldPins {

--- a/crates/core/src/engine/desired/hold.rs
+++ b/crates/core/src/engine/desired/hold.rs
@@ -196,24 +196,44 @@ fn held_manifest(
     // in under. An entry a rebind left behind is an installation of a
     // package this declaration no longer is, and its edges lead to
     // declarations this update has no business unpinning.
-    for entry in lock.entries.values().filter(|entry| {
-        entry.kind == target.0
-            && entry.name == target.1
-            && reads_from
-                .as_ref()
-                .is_none_or(|source| &entry.source == source)
-    }) {
+    let installations: Vec<&LockEntry> = lock
+        .entries
+        .values()
+        .filter(|entry| {
+            entry.kind == target.0
+                && entry.name == target.1
+                && reads_from
+                    .as_ref()
+                    .is_none_or(|source| &entry.source == source)
+        })
+        .collect();
+    for entry in &installations {
         exempt.extend(owners_of(lock, entry, &mut BTreeSet::new()));
     }
     // A target with a declaration of its own reads that declaration, so the
-    // sets that also carry it are held still along with everything else —
-    // `bundles::carried_rev` lets the declaration decide what the member
-    // installs. A set left free instead takes its other
-    // members current as a side effect of an update nobody asked it for. A
-    // target with no declaration has only the set's revision to read, which
-    // has to resolve fresh for it to move at all.
+    // sets that carry the target itself are held still along with everything
+    // else — `bundles::carried_rev` lets the declaration decide what the
+    // member installs, and a set left free takes its other members current
+    // as a side effect of an update nobody asked it for. A target with no
+    // declaration has only the set's revision to read, which has to resolve
+    // fresh for it to move at all.
+    //
+    // Only the sets that carry it: one reached through a dependency parent
+    // owns that parent's revision, not this target's. Pinning it pins the
+    // parent, which then carries its commit onto the target while the
+    // target's own declaration reads fresh — and the update the person
+    // asked for reports a conflict instead of happening.
     if reads_from.is_some() {
-        exempt.retain(|owner| !matches!(owner, Owner::Bundle { .. }));
+        for entry in &installations {
+            for reason in &entry.reasons {
+                if let Reason::MemberOf { bundle } = reason {
+                    exempt.remove(&Owner::Bundle {
+                        name: bundle.name.clone(),
+                        source: bundle.source.clone(),
+                    });
+                }
+            }
+        }
     }
     let mut held = manifest.clone();
     let mut pins = HeldPins {
@@ -317,12 +337,21 @@ fn held_at(
     agreed
 }
 
-/// Whether this installation is here as a member of the named bundle — the
-/// entries whose recorded commits say where the bundle is held. Matched by
-/// source as well as name: a membership recorded against another catalog's
-/// set of the same name is not this declaration's evidence.
+/// Whether this installation is here as a member of the named bundle and
+/// nothing else — the entries whose recorded commits say where the bundle
+/// is held. Matched by source as well as name: a membership recorded
+/// against another catalog's set of the same name is not this
+/// declaration's evidence.
+///
+/// An installation the person also declared is not evidence either: its
+/// commit is the one its own declaration reads, and a single-package
+/// update moves that commit off the set's. Counted as the set's, the two
+/// read as members disagreeing, the set can be held at no commit at all,
+/// and its undeclared members come current as the side effect this hold
+/// exists to remove.
 fn member_of(entry: &LockEntry, bundle: &str, source: &str) -> bool {
-    entry.reasons.iter().any(
+    !entry.reasons.contains(&Reason::Requested)
+        && entry.reasons.iter().any(
         |reason| matches!(reason, Reason::MemberOf { bundle: of } if of.name == bundle && of.source == source),
     )
 }

--- a/crates/core/src/engine/desired/hold.rs
+++ b/crates/core/src/engine/desired/hold.rs
@@ -278,8 +278,15 @@ fn held_manifest(
         let Some(repo) = source_repo(manifest, &decl.source) else {
             continue;
         };
+        // Where anything is here only as a member, that is what says where
+        // the set is; the members the person also declared are asked only
+        // when nothing else can answer.
+        let carried_alone = lock
+            .entries
+            .values()
+            .any(|entry| member_of(entry, name, &decl.source) && !also_declared(entry));
         let Some(commit) = held_at(lock, &decl.source, repo, |entry| {
-            member_of(entry, name, &decl.source)
+            member_of(entry, name, &decl.source) && !(carried_alone && also_declared(entry))
         }) else {
             continue;
         };
@@ -337,23 +344,32 @@ fn held_at(
     agreed
 }
 
-/// Whether this installation is here as a member of the named bundle and
-/// nothing else — the entries whose recorded commits say where the bundle
-/// is held. Matched by source as well as name: a membership recorded
-/// against another catalog's set of the same name is not this
-/// declaration's evidence.
-///
-/// An installation the person also declared is not evidence either: its
-/// commit is the one its own declaration reads, and a single-package
-/// update moves that commit off the set's. Counted as the set's, the two
-/// read as members disagreeing, the set can be held at no commit at all,
-/// and its undeclared members come current as the side effect this hold
-/// exists to remove.
+/// Whether this installation is here as a member of the named bundle — the
+/// entries whose recorded commits say where the bundle is held. Matched by
+/// source as well as name: a membership recorded against another catalog's
+/// set of the same name is not this declaration's evidence.
 fn member_of(entry: &LockEntry, bundle: &str, source: &str) -> bool {
-    !entry.reasons.contains(&Reason::Requested)
-        && entry.reasons.iter().any(
+    entry.reasons.iter().any(
         |reason| matches!(reason, Reason::MemberOf { bundle: of } if of.name == bundle && of.source == source),
     )
+}
+
+/// Whether the person declared this installation as well as receiving it
+/// through a set.
+///
+/// Such an installation is the weaker evidence of where its set is held:
+/// its commit is the one its own declaration reads, and a single-package
+/// update moves that commit off the set's. Counted alongside the members
+/// that have only the set to read, the two say the set is in two places,
+/// it can then be held at no commit at all, and its other members come
+/// current as the side effect this hold exists to remove.
+///
+/// It is still evidence where the set has no other kind. A set whose every
+/// member is also declared has nothing else recorded, and held at no
+/// commit it reads its source's tip — where an unrelated update installs
+/// whatever the catalog has since added to the set.
+fn also_declared(entry: &LockEntry) -> bool {
+    entry.reasons.contains(&Reason::Requested)
 }
 
 #[cfg(test)]

--- a/crates/core/src/engine/expansion.rs
+++ b/crates/core/src/engine/expansion.rs
@@ -58,6 +58,12 @@ pub const NO_PER_PACKAGE_UPDATE: &str = "has no per-package update — Pi extens
 pub(super) struct Planned {
     pub(super) decl: ItemDecl,
     pub(super) harnesses: Vec<HarnessId>,
+    /// The revision the person chose for this item, where `decl` reads a
+    /// pin this pass invented to hold the scope still. What a set carries
+    /// is weighed against this and never against the pin: two revisions
+    /// nobody wrote read as agreement, and a warning that names one names
+    /// a commit kendex made up.
+    chosen_rev: Option<String>,
 }
 
 #[derive(Default)]
@@ -115,7 +121,14 @@ impl Expansion {
     /// A declaration the user wrote: it installs as written, and it is here
     /// even when no tool can hold it — the plan says so rather than going
     /// quiet about a declaration that produced nothing.
-    fn declared(&mut self, kind: ItemKind, name: &str, decl: &ItemDecl, harnesses: Vec<HarnessId>) {
+    fn declared(
+        &mut self,
+        kind: ItemKind,
+        name: &str,
+        decl: &ItemDecl,
+        harnesses: Vec<HarnessId>,
+        chosen_rev: Option<String>,
+    ) {
         for harness in &harnesses {
             self.reasons
                 .entry((kind, name.to_owned(), *harness))
@@ -127,6 +140,7 @@ impl Expansion {
             Planned {
                 decl: decl.clone(),
                 harnesses,
+                chosen_rev,
             },
         );
     }
@@ -141,6 +155,12 @@ impl Expansion {
         harness: HarnessId,
         reason: Reason,
     ) -> bool {
+        // A set weighs its revision against the one the person chose for
+        // the item; every other derivation weighs it against the revision
+        // the item actually reads. What a dependency reads is its parent's
+        // own commit, invented pin included — KEN-765 is where that edge
+        // learns the difference.
+        let carried_by_a_set = matches!(reason, Reason::MemberOf { .. });
         let fresh = self
             .reasons
             .entry((kind, name.to_owned(), harness))
@@ -152,16 +172,21 @@ impl Expansion {
             .or_insert_with(|| Planned {
                 decl: decl.clone(),
                 harnesses: Vec::new(),
+                chosen_rev: decl.rev.clone(),
             });
+        let wanted_at = match carried_by_a_set {
+            true => &planned.chosen_rev,
+            false => &planned.decl.rev,
+        };
         // Two derivations pinning one item at different revisions cannot
         // both be honored — one filesystem identity exists. The kept one is
         // whichever got here first (deterministic: parents walk in map
         // order); the refused one is recorded so the plan can say so.
-        if planned.decl.source == decl.source && planned.decl.rev != decl.rev {
+        if planned.decl.source == decl.source && *wanted_at != decl.rev {
             self.rev_disagreements.push((
                 kind,
                 name.to_owned(),
-                planned.decl.rev.clone(),
+                wanted_at.clone(),
                 decl.rev.clone(),
             ));
         }
@@ -297,7 +322,11 @@ pub(super) fn expand(
     for kind in PLANNED_KINDS {
         for (name, decl) in manifest.declared(kind) {
             let harnesses = target_harnesses(decl, manifest, kind, scope);
-            expansion.declared(kind, name, decl, harnesses);
+            let chosen_rev = match held {
+                Some(pins) if pins.invented_item(kind, name) => None,
+                _ => decl.rev.clone(),
+            };
+            expansion.declared(kind, name, decl, harnesses, chosen_rev);
             // A removal is recorded so that nothing derives the item back on
             // its own. Declaring it by name is the plainest statement that it
             // is wanted, so it installs and the record sits there doing

--- a/crates/core/src/engine/expansion.rs
+++ b/crates/core/src/engine/expansion.rs
@@ -281,10 +281,16 @@ impl Catalogs<'_> {
 
 /// The whole installed set this manifest asks for: what it declares, what the
 /// bundles it installs carry, and what those skills require.
+///
+/// `held` names the declarations this pass pinned itself, where the
+/// manifest is a single-package update's pinned copy: a set's members read
+/// it to tell a hold the person chose from one invented to keep the rest
+/// of the scope still.
 pub(super) fn expand(
     env: &Env,
     scope: &Scope,
     manifest: &Manifest,
+    held: Option<&super::desired::hold::HeldPins>,
     state: &mut DesiredState,
 ) -> Expansion {
     let mut expansion = Expansion::default();
@@ -310,7 +316,7 @@ pub(super) fn expand(
         manifest,
         open: BTreeMap::new(),
     };
-    super::bundles::expand(scope, manifest, &mut expansion, &mut catalogs, state);
+    super::bundles::expand(scope, manifest, held, &mut expansion, &mut catalogs, state);
     super::deps::expand(scope, manifest, &mut expansion, &mut catalogs, state);
     expansion.report_rev_disagreements(state);
     expansion

--- a/crates/core/src/engine/mod.rs
+++ b/crates/core/src/engine/mod.rs
@@ -76,7 +76,8 @@ pub fn installed_paths(
 use desired::desired_state;
 pub use scope_writes::persists_manifest;
 use scope_writes::{
-    plan_config_edits, plan_lock_write, plan_manifest_write, plan_settings_seed, source_revisions,
+    bundle_revisions, plan_config_edits, plan_lock_write, plan_manifest_write, plan_settings_seed,
+    source_revisions,
 };
 pub use set_change::{KeptInstall, SetChange, SetDirection};
 use set_change::{kept_members, set_changes};
@@ -288,13 +289,14 @@ fn desired_pass<'a>(
 }
 
 /// The record this pass will write, before any of it is filled in: the
-/// per-source resolutions it just made, and the seeding evidence carried
-/// forward — only seeding and refresh may move that.
+/// per-source and per-set resolutions it just made, and the seeding
+/// evidence carried forward — only seeding and refresh may move that.
 fn fresh_lock(manifest: &Manifest, lock: &Lock, state: &desired::DesiredState) -> Lock {
     Lock {
         version: crate::lock::LOCK_VERSION,
         entries: BTreeMap::new(),
         sources: source_revisions(manifest, lock, state),
+        bundles: bundle_revisions(manifest, lock, state),
         settings_seeds: lock.settings_seeds.clone(),
     }
 }

--- a/crates/core/src/engine/mod.rs
+++ b/crates/core/src/engine/mod.rs
@@ -279,6 +279,7 @@ fn desired_pass<'a>(
         planning.as_ref(),
         lock,
         options.hold_upstream_skills,
+        held_pins.as_ref(),
     )?;
     if let (Some(pins), Some(update)) = (&held_pins, state.manifest_update.as_mut()) {
         pins.unpin(update);

--- a/crates/core/src/engine/ops.rs
+++ b/crates/core/src/engine/ops.rs
@@ -260,7 +260,7 @@ fn still_derived(
     names: &[String],
 ) -> BTreeSet<(ItemKind, String)> {
     let mut state = crate::engine::desired::DesiredState::default();
-    let expansion = super::expansion::expand(env, scope, manifest, &mut state);
+    let expansion = super::expansion::expand(env, scope, manifest, None, &mut state);
     let mut derived = BTreeSet::new();
     for name in names {
         for kind in super::expansion::PLANNED_KINDS {

--- a/crates/core/src/engine/planned.rs
+++ b/crates/core/src/engine/planned.rs
@@ -33,7 +33,7 @@ pub fn planned_declarations(
 ) -> Vec<PlannedDeclaration> {
     let scope = scope.canonical();
     let mut state = desired::DesiredState::default();
-    let expanded = expansion::expand(env, &scope, manifest, &mut state);
+    let expanded = expansion::expand(env, &scope, manifest, None, &mut state);
     let mut out = Vec::new();
     for kind in expansion::PLANNED_KINDS {
         for (name, planned) in expanded.of(kind) {

--- a/crates/core/src/engine/scope_writes.rs
+++ b/crates/core/src/engine/scope_writes.rs
@@ -9,7 +9,7 @@ use crate::apply::{Op, PlannedOp, Pre};
 use crate::base::Base;
 use crate::env::Env;
 use crate::error::Result;
-use crate::lock::{Lock, SourceRev, lock_path};
+use crate::lock::{BundleRev, Lock, SourceRev, lock_path};
 use crate::manifest::Manifest;
 use crate::model::{HarnessId, ItemKind, Scope};
 use crate::source::SourceState;
@@ -111,6 +111,44 @@ pub(super) fn plan_config_edits(
     Ok(())
 }
 
+/// Which commit each installed set was read at, for the lock to record.
+/// Carried forward and dropped on the same terms as [`source_revisions`],
+/// and read from the same resolutions: a set is read at its declaration's
+/// revision, so what it came out as is what that resolution resolved to.
+pub(super) fn bundle_revisions(
+    manifest: &Manifest,
+    lock: &Lock,
+    state: &DesiredState,
+) -> BTreeMap<String, BundleRev> {
+    let mut revisions: BTreeMap<String, BundleRev> = lock
+        .bundles
+        .iter()
+        .filter(|(name, _)| manifest.bundles.contains_key(*name))
+        .map(|(name, revision)| (name.clone(), revision.clone()))
+        .collect();
+    for (name, decl) in &manifest.bundles {
+        let resolution = match &decl.rev {
+            Some(rev) => state.pinned.get(&(decl.source.clone(), rev.clone())),
+            None => state.sources.get(&decl.source),
+        };
+        let Some(SourceState::Ready(ready)) = resolution else {
+            continue;
+        };
+        let Some(commit) = ready.commit.clone() else {
+            continue;
+        };
+        revisions.insert(
+            name.clone(),
+            BundleRev {
+                source: decl.source.clone(),
+                source_repo: ready.provenance.clone(),
+                commit,
+            },
+        );
+    }
+    revisions
+}
+
 /// Which commit each source resolved to, for the lock to record. What
 /// earlier passes resolved is carried forward — a source that is offline
 /// today should not lose the commit it was reading yesterday — and a source
@@ -159,6 +197,7 @@ pub(super) fn plan_lock_write(
 ) -> Result<()> {
     if new_lock.entries == lock.entries
         && (new_lock.sources == lock.sources || new_lock.entries.is_empty())
+        && (new_lock.bundles == lock.bundles || new_lock.entries.is_empty())
         && new_lock.settings_seeds == lock.settings_seeds
         && (lock.version == crate::lock::LOCK_VERSION || lock.entries.is_empty())
     {

--- a/crates/core/src/lock.rs
+++ b/crates/core/src/lock.rs
@@ -40,6 +40,14 @@ pub struct Lock {
     /// lock costs the record, not the pin.
     #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
     pub sources: BTreeMap<String, SourceRev>,
+    /// The commit each installed set was read at, by the name the manifest
+    /// installs it under. The same cache as `sources` and never intent: a
+    /// set has no installation of its own, so without this the only
+    /// account of where it sits is whatever its members happen to record —
+    /// and a member the person declared moves off that commit on its own.
+    /// A lock written before this was recorded simply has none.
+    #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
+    pub bundles: BTreeMap<String, BundleRev>,
     /// Per `kendex.settings.toml` key: which skill seeded it and the hash
     /// of the comment block seeding last wrote — the proof a later refresh
     /// needs before it may rewrite the comment to a newer template.
@@ -75,6 +83,22 @@ pub struct SourceRev {
     /// The selector that produced it, when the manifest names one.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub rev: Option<String>,
+    pub commit: String,
+}
+
+/// One installed set's resolution at the last write.
+///
+/// Where it was read from is part of the record, because a rebind leaves
+/// it naming a set this scope no longer reads: matched by name alone, one
+/// catalog's set would say where another catalog's is held.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Type)]
+#[serde(rename_all = "camelCase")]
+pub struct BundleRev {
+    /// The declared source it was read from.
+    pub source: String,
+    /// `owner/repo`, a canonical path, or `local` — the repository that
+    /// source pointed at when it was read.
+    pub source_repo: String,
     pub commit: String,
 }
 

--- a/crates/core/src/lock.rs
+++ b/crates/core/src/lock.rs
@@ -10,20 +10,24 @@ use crate::fs::{atomic_write, read_if_exists};
 use crate::manifest::Method;
 use crate::model::{HarnessId, ItemKind, Scope};
 
-/// Current lock version. Versions 1 (v0.1) through 4 still load — the
+/// Current lock version. Versions 1 (v0.1) through 5 still load — the
 /// shapes are compatible and the next lock write records the current
 /// version. A lock newer than this build refuses to load. Version 3 added
 /// `source_commit` and `rendered_hash`; version 4 added `settings-seeds`;
 /// version 5 added `left_pi_reserved_name`, a registration's matcher, and
-/// a recorded registration for hooks with a script of their own.
+/// a recorded registration for hooks with a script of their own; version
+/// 6 added `bundles`.
 /// Each bump is what stops an older build from reading the lock, dropping
 /// the newer record on its next write, and erasing evidence — of which
-/// bytes are whose, of which comment blocks seeding wrote, or of a move
-/// out of the directory pi reserved being over. That last one is why
-/// this bump is not optional: a build that dropped the record would read
-/// a finished move as unfinished, and reclaim what the person has since
-/// put under the reserved name.
-pub const LOCK_VERSION: u32 = 5;
+/// bytes are whose, of which comment blocks seeding wrote, of a move out
+/// of the directory pi reserved being over, or of where an installed set
+/// sits. Two of those are why a bump is not optional: a build that
+/// dropped the pi record would read a finished move as unfinished and
+/// reclaim what the person has since put under the reserved name, and one
+/// that dropped a set's commit would leave a set whose members have come
+/// apart placeable at nothing, so the next update of anything else takes
+/// its other members current.
+pub const LOCK_VERSION: u32 = 6;
 
 /// The lock file a project scope carries. The global lock is `lock.json`
 /// under the app's own directory ([`Env::global_lock_file`]).

--- a/crates/core/tests/package_pins/main.rs
+++ b/crates/core/tests/package_pins/main.rs
@@ -389,6 +389,35 @@ fn two_parents_pinning_different_revs_of_one_dependency_change_nothing() {
     assert!(installed_body(&w, "helper").contains("Helper one."));
 }
 
+#[allow(clippy::unwrap_used)]
+fn fetch_mirrors(w: &World) {
+    let loaded = manifest::load_for_mutation(&manifest::manifest_path(&w.env, &w.scope))
+        .unwrap()
+        .unwrap();
+    remote::sync_sources(&w.env, &loaded).unwrap();
+}
+
+#[allow(clippy::unwrap_used)]
+fn locked_commit(w: &World, name: &str) -> String {
+    let lock = load_lock(&lock_path(&w.env, &w.scope)).unwrap();
+    lock.entries[&entry_key(ItemKind::Skill, name, HarnessId::Claude)]
+        .source_commit
+        .clone()
+        .unwrap()
+}
+
+/// The manifest text as it sits on disk, and the revision a package is
+/// declared with there. A synthetic hold that reaches the file is a hold
+/// nobody chose: that package stops updating, forever and silently.
+#[allow(clippy::unwrap_used)]
+fn declared_rev(w: &World, name: &str) -> Option<String> {
+    let loaded = manifest::load_for_mutation(&manifest::manifest_path(&w.env, &w.scope))
+        .unwrap()
+        .unwrap();
+    loaded.declared(ItemKind::Skill)[name].rev.clone()
+}
+
+mod sets;
 mod single_update;
 mod validate;
 

--- a/crates/core/tests/package_pins/sets.rs
+++ b/crates/core/tests/package_pins/sets.rs
@@ -9,6 +9,7 @@ use std::fs;
 
 use kendex_core::apply;
 use kendex_core::engine::DriftState;
+use kendex_core::lock::{load as load_lock, lock_path, save as save_lock};
 use kendex_core::manifest;
 use kendex_core::model::ItemKind;
 use kendex_core::package;
@@ -447,5 +448,231 @@ fn a_set_whose_members_are_all_declared_stays_where_it_is() {
     assert_eq!(
         loaded.bundles["kit"].rev, None,
         "and the hold that held it still for this pass is not one the person chose"
+    );
+}
+
+/// The same set, with the update aimed at one of its own members rather
+/// than at an unrelated declaration. The target reads fresh and the set
+/// has to be held — and the only installations that can say where it is
+/// held are its declared members, the target's among them, whose commit is
+/// the one about to move.
+#[test]
+#[allow(clippy::unwrap_used)]
+fn updating_a_member_of_an_all_declared_set_leaves_the_set_where_it_is() {
+    let w = world();
+    write_skill(&w.upstream, "a", "", "a version one.");
+    write_skill(&w.upstream, "b", "", "b version one.");
+    fs::write(
+        w.upstream.join("kendex.toml"),
+        "[bundles.kit]\ndescription = \"a set\"\nskills = [\"a\", \"b\"]\n",
+    )
+    .unwrap();
+    let first = commit(&w.upstream, "one");
+    declare(
+        &w,
+        "[skills.a]\nsource = \"cat\"\n\n[skills.b]\nsource = \"cat\"\n\n[bundles.kit]\nsource = \"cat\"\n",
+    );
+    sync_and_apply(&w);
+
+    write_skill(&w.upstream, "a", "", "a version two.");
+    write_skill(&w.upstream, "b", "", "b version two.");
+    write_skill(&w.upstream, "c", "", "c version one.");
+    fs::write(
+        w.upstream.join("kendex.toml"),
+        "[bundles.kit]\ndescription = \"a set\"\nskills = [\"a\", \"b\", \"c\"]\n",
+    )
+    .unwrap();
+    let second = commit(&w.upstream, "two");
+    fetch_mirrors(&w);
+
+    let report = package::update_one(&w.env, &w.scope, ItemKind::Skill, "a").unwrap();
+    apply::execute(&w.env, &report.plan, None).unwrap();
+
+    assert!(
+        installed_body(&w, "a").contains("a version two."),
+        "the package the person named has to actually move"
+    );
+    assert_eq!(locked_commit(&w, "a"), second);
+    assert!(
+        !w.home.join("app/.agents/skills/c").exists(),
+        "the set was read where it is installed, not at its source's tip: {:?}",
+        report.plan.ops
+    );
+    assert!(installed_body(&w, "b").contains("b version one."));
+    assert_eq!(locked_commit(&w, "b"), first);
+
+    let loaded = manifest::load_for_mutation(&manifest::manifest_path(&w.env, &w.scope))
+        .unwrap()
+        .unwrap();
+    assert_eq!(loaded.bundles["kit"].rev, None);
+}
+
+/// The scope a member moving alone leaves behind: the set's members sit at
+/// two commits, so nothing they record agrees and no reading of them can
+/// place the set. What the record says the set came out as still can, and
+/// the next update of anything else holds it there rather than opening it
+/// at its source's tip.
+#[test]
+#[allow(clippy::unwrap_used)]
+fn a_set_whose_members_split_across_commits_still_holds() {
+    let w = world();
+    write_skill(&w.upstream, "a", "", "a version one.");
+    write_skill(&w.upstream, "b", "", "b version one.");
+    fs::write(
+        w.upstream.join("kendex.toml"),
+        "[bundles.kit]\ndescription = \"a set\"\nskills = [\"a\", \"b\"]\n",
+    )
+    .unwrap();
+    let first = commit(&w.upstream, "one");
+    declare(
+        &w,
+        "[skills.a]\nsource = \"cat\"\n\n[skills.b]\nsource = \"cat\"\n\n[bundles.kit]\nsource = \"cat\"\n",
+    );
+    sync_and_apply(&w);
+
+    write_skill(&w.upstream, "a", "", "a version two.");
+    let second = commit(&w.upstream, "two");
+    fetch_mirrors(&w);
+    let report = package::update_one(&w.env, &w.scope, ItemKind::Skill, "a").unwrap();
+    apply::execute(&w.env, &report.plan, None).unwrap();
+    assert_eq!(
+        locked_commit(&w, "a"),
+        second,
+        "the split this test is about"
+    );
+    assert_eq!(locked_commit(&w, "b"), first);
+
+    // Upstream grows the set while the members are apart.
+    write_skill(&w.upstream, "c", "", "c version one.");
+    write_skill(&w.upstream, "b", "", "b version three.");
+    fs::write(
+        w.upstream.join("kendex.toml"),
+        "[bundles.kit]\ndescription = \"a set\"\nskills = [\"a\", \"b\", \"c\"]\n",
+    )
+    .unwrap();
+    let third = commit(&w.upstream, "three");
+    fetch_mirrors(&w);
+
+    let report = package::update_one(&w.env, &w.scope, ItemKind::Skill, "b").unwrap();
+    apply::execute(&w.env, &report.plan, None).unwrap();
+
+    assert!(
+        !w.home.join("app/.agents/skills/c").exists(),
+        "the set is held where the record says it came out, not at its tip: {:?}",
+        report.plan.ops
+    );
+    assert_eq!(locked_commit(&w, "b"), third, "the target still moves");
+    assert_eq!(
+        locked_commit(&w, "a"),
+        second,
+        "and the member that moved before stays where it moved to"
+    );
+}
+
+/// One set carrying both a declared package and something that requires
+/// it. The set owns the package two ways at once — it carries it, and it
+/// owns the parent whose revision reaches it — and the second is the one
+/// that decides: a set that owns a parent has to read fresh, or the parent
+/// carries its commit onto a target whose own declaration reads fresh and
+/// the update ends in a conflict without updating anything.
+#[test]
+#[allow(clippy::unwrap_used)]
+fn updating_a_package_its_set_also_owns_through_a_parent_still_moves_it() {
+    let w = world();
+    write_skill(&w.upstream, "a", "", "a version one.");
+    write_skill(
+        &w.upstream,
+        "parent",
+        "dependencies:\n  required: [a]\n",
+        "parent version one.",
+    );
+    fs::write(
+        w.upstream.join("kendex.toml"),
+        "[bundles.kit]\ndescription = \"a set\"\nskills = [\"a\", \"parent\"]\n",
+    )
+    .unwrap();
+    commit(&w.upstream, "one");
+    declare(
+        &w,
+        "[skills.a]\nsource = \"cat\"\n\n[bundles.kit]\nsource = \"cat\"\n",
+    );
+    sync_and_apply(&w);
+
+    write_skill(&w.upstream, "a", "", "a version two.");
+    let second = commit(&w.upstream, "two");
+    fetch_mirrors(&w);
+
+    let report = package::update_one(&w.env, &w.scope, ItemKind::Skill, "a").unwrap();
+    assert!(
+        !reports_a_rev_conflict(&report, "a"),
+        "the set owns what requires the package as well as carrying it: {:?}",
+        report.warnings
+    );
+    apply::execute(&w.env, &report.plan, None).unwrap();
+
+    assert!(
+        installed_body(&w, "a").contains("a version two."),
+        "the package the person named has to actually move"
+    );
+    assert_eq!(locked_commit(&w, "a"), second);
+}
+
+/// A lock written before a set's commit was recorded has none. The members
+/// were installed together and none of them has moved off the set on its
+/// own yet, so where they agree is where the set is — and that reading
+/// stands in until the next write records it.
+#[test]
+#[allow(clippy::unwrap_used)]
+fn a_lock_that_records_no_set_commit_reads_the_members_instead() {
+    let w = world();
+    write_skill(&w.upstream, "a", "", "a version one.");
+    write_skill(&w.upstream, "b", "", "b version one.");
+    fs::write(
+        w.upstream.join("kendex.toml"),
+        "[bundles.kit]\ndescription = \"a set\"\nskills = [\"a\", \"b\"]\n",
+    )
+    .unwrap();
+    let first = commit(&w.upstream, "one");
+    declare(
+        &w,
+        "[skills.a]\nsource = \"cat\"\n\n[bundles.kit]\nsource = \"cat\"\n",
+    );
+    sync_and_apply(&w);
+
+    // The record an older kendex would have left: everything else the same,
+    // the set's commit simply absent.
+    let path = lock_path(&w.env, &w.scope);
+    let mut lock = load_lock(&path).unwrap();
+    assert!(
+        !lock.bundles.is_empty(),
+        "this pass records it, which is what the test removes"
+    );
+    lock.bundles.clear();
+    save_lock(&path, &lock).unwrap();
+
+    write_skill(&w.upstream, "a", "", "a version two.");
+    write_skill(&w.upstream, "c", "", "c version one.");
+    fs::write(
+        w.upstream.join("kendex.toml"),
+        "[bundles.kit]\ndescription = \"a set\"\nskills = [\"a\", \"b\", \"c\"]\n",
+    )
+    .unwrap();
+    let second = commit(&w.upstream, "two");
+    fetch_mirrors(&w);
+
+    let report = package::update_one(&w.env, &w.scope, ItemKind::Skill, "a").unwrap();
+    apply::execute(&w.env, &report.plan, None).unwrap();
+
+    assert!(installed_body(&w, "a").contains("a version two."));
+    assert_eq!(locked_commit(&w, "a"), second);
+    assert!(
+        !w.home.join("app/.agents/skills/c").exists(),
+        "the members placed the set: {:?}",
+        report.plan.ops
+    );
+    assert_eq!(locked_commit(&w, "b"), first);
+    assert!(
+        !load_lock(&path).unwrap().bundles.is_empty(),
+        "and the write that followed recorded it"
     );
 }

--- a/crates/core/tests/package_pins/sets.rs
+++ b/crates/core/tests/package_pins/sets.rs
@@ -388,3 +388,64 @@ fn a_conflict_with_a_hand_pinned_set_names_no_invented_commit() {
         "the set's own pin is: {message}"
     );
 }
+
+/// A set every one of whose members is also declared outright. Nothing is
+/// installed here only as a member, so the set's own members are the only
+/// installations that can say where it is held. Left saying nothing it
+/// reads its source's tip, and an unrelated single-package update takes
+/// whatever the catalog has added to the set since — a package nobody
+/// asked for, installed by an update about something else.
+#[test]
+#[allow(clippy::unwrap_used)]
+fn a_set_whose_members_are_all_declared_stays_where_it_is() {
+    let w = world();
+    write_skill(&w.upstream, "a", "", "a version one.");
+    write_skill(&w.upstream, "b", "", "b version one.");
+    write_skill(&w.upstream, "solo", "", "solo version one.");
+    fs::write(
+        w.upstream.join("kendex.toml"),
+        "[bundles.kit]\ndescription = \"a set\"\nskills = [\"a\", \"b\"]\n",
+    )
+    .unwrap();
+    let first = commit(&w.upstream, "one");
+    declare(
+        &w,
+        "[skills.a]\nsource = \"cat\"\n\n[skills.b]\nsource = \"cat\"\n\n[skills.solo]\nsource = \"cat\"\n\n[bundles.kit]\nsource = \"cat\"\n",
+    );
+    sync_and_apply(&w);
+
+    // Upstream grows the set and moves the unrelated package.
+    write_skill(&w.upstream, "c", "", "c version one.");
+    write_skill(&w.upstream, "solo", "", "solo version two.");
+    fs::write(
+        w.upstream.join("kendex.toml"),
+        "[bundles.kit]\ndescription = \"a set\"\nskills = [\"a\", \"b\", \"c\"]\n",
+    )
+    .unwrap();
+    let second = commit(&w.upstream, "two");
+    fetch_mirrors(&w);
+
+    let report = package::update_one(&w.env, &w.scope, ItemKind::Skill, "solo").unwrap();
+    apply::execute(&w.env, &report.plan, None).unwrap();
+
+    assert!(installed_body(&w, "solo").contains("solo version two."));
+    assert_eq!(locked_commit(&w, "solo"), second);
+
+    assert!(
+        !w.home.join("app/.agents/skills/c").exists(),
+        "the set was read where it is installed, not at its source's tip: {:?}",
+        report.plan.ops
+    );
+    assert!(installed_body(&w, "a").contains("a version one."));
+    assert!(installed_body(&w, "b").contains("b version one."));
+    assert_eq!(locked_commit(&w, "a"), first);
+    assert_eq!(locked_commit(&w, "b"), first);
+
+    let loaded = manifest::load_for_mutation(&manifest::manifest_path(&w.env, &w.scope))
+        .unwrap()
+        .unwrap();
+    assert_eq!(
+        loaded.bundles["kit"].rev, None,
+        "and the hold that held it still for this pass is not one the person chose"
+    );
+}

--- a/crates/core/tests/package_pins/sets.rs
+++ b/crates/core/tests/package_pins/sets.rs
@@ -8,8 +8,9 @@
 use std::fs;
 
 use kendex_core::apply;
-use kendex_core::engine::DriftState;
-use kendex_core::lock::{load as load_lock, lock_path, save as save_lock};
+use kendex_core::engine::{DriftState, audit};
+use kendex_core::error::CoreError;
+use kendex_core::lock::{LOCK_VERSION, load as load_lock, lock_path, save as save_lock};
 use kendex_core::manifest;
 use kendex_core::model::ItemKind;
 use kendex_core::package;
@@ -674,5 +675,68 @@ fn a_lock_that_records_no_set_commit_reads_the_members_instead() {
     assert!(
         !load_lock(&path).unwrap().bundles.is_empty(),
         "and the write that followed recorded it"
+    );
+}
+
+/// A lock behind the current version is rewritten on the next apply, and
+/// that is the whole migration a bump needs here: a scope holding an older
+/// record gains the new one by being applied, not by machinery that goes
+/// looking for it. The version alone has to be enough — this lock is
+/// otherwise exactly what this build writes.
+#[test]
+#[allow(clippy::unwrap_used)]
+fn a_lock_behind_the_current_version_is_rewritten() {
+    let w = world();
+    write_skill(&w.upstream, "a", "", "a version one.");
+    write_skill(&w.upstream, "b", "", "b version one.");
+    fs::write(
+        w.upstream.join("kendex.toml"),
+        "[bundles.kit]\ndescription = \"a set\"\nskills = [\"a\", \"b\"]\n",
+    )
+    .unwrap();
+    commit(&w.upstream, "one");
+    declare(&w, "[bundles.kit]\nsource = \"cat\"\n");
+    sync_and_apply(&w);
+
+    let path = lock_path(&w.env, &w.scope);
+    let mut lock = load_lock(&path).unwrap();
+    assert_eq!(
+        lock.version, LOCK_VERSION,
+        "this build writes the current version"
+    );
+    lock.version = LOCK_VERSION - 1;
+    save_lock(&path, &lock).unwrap();
+
+    let report = audit(&w.env, &w.scope).unwrap();
+    apply::execute(&w.env, &report.plan, None).unwrap();
+
+    assert_eq!(
+        load_lock(&path).unwrap().version,
+        LOCK_VERSION,
+        "nothing else about this lock differs, so the version is what asked for the write"
+    );
+}
+
+/// The refusal that makes the bump worth anything: a build whose format is
+/// older than the lock in front of it stops rather than reading it, so it
+/// never writes back a record with the newer evidence stripped out.
+#[test]
+#[allow(clippy::unwrap_used)]
+fn a_lock_from_a_newer_format_is_refused_rather_than_read() {
+    let w = world();
+    write_skill(&w.upstream, "a", "", "a version one.");
+    commit(&w.upstream, "one");
+    declare(&w, "[skills.a]\nsource = \"cat\"\n");
+    sync_and_apply(&w);
+
+    let path = lock_path(&w.env, &w.scope);
+    let mut lock = load_lock(&path).unwrap();
+    lock.version = LOCK_VERSION + 1;
+    save_lock(&path, &lock).unwrap();
+
+    let error = load_lock(&path).unwrap_err();
+    assert!(
+        matches!(error, CoreError::SchemaTooNew { found, .. } if found == i64::from(LOCK_VERSION) + 1),
+        "{error}"
     );
 }

--- a/crates/core/tests/package_pins/sets.rs
+++ b/crates/core/tests/package_pins/sets.rs
@@ -1,0 +1,390 @@
+//! A package a set carries, and what decides the revision it reads.
+//!
+//! A set carries one revision to everything in it. Declare one of those
+//! packages outright and there are two readings of its revision to
+//! reconcile — and a single-package update, which pins the rest of the
+//! scope still to hold it there, adds a third that nobody wrote.
+
+use std::fs;
+
+use kendex_core::apply;
+use kendex_core::engine::DriftState;
+use kendex_core::manifest;
+use kendex_core::model::ItemKind;
+use kendex_core::package;
+
+use super::{
+    World, commit, declare, declared_rev, fetch_mirrors, installed_body, locked_commit,
+    sync_and_apply, world, write_skill,
+};
+
+/// What the plan says this package is wanted at, as the person reads it.
+fn rev_conflict_message(report: &kendex_core::engine::EngineReport, name: &str) -> String {
+    report
+        .warnings
+        .iter()
+        .find(|w| w.name == name && w.message.contains("wanted at"))
+        .map(|w| w.message.clone())
+        .unwrap_or_default()
+}
+
+#[test]
+#[allow(clippy::unwrap_used)]
+fn updating_a_bundle_member_moves_its_bundle_and_no_one_else() {
+    let w = world();
+    write_skill(&w.upstream, "m1", "", "m1 version one.");
+    write_skill(&w.upstream, "m2", "", "m2 version one.");
+    write_skill(&w.upstream, "solo", "", "solo version one.");
+    fs::write(
+        w.upstream.join("kendex.toml"),
+        "[bundles.kit]\ndescription = \"a set\"\nskills = [\"m1\", \"m2\"]\n",
+    )
+    .unwrap();
+    let first = commit(&w.upstream, "one");
+    declare(
+        &w,
+        "[skills.solo]\nsource = \"cat\"\n\n[bundles.kit]\nsource = \"cat\"\n",
+    );
+    sync_and_apply(&w);
+
+    write_skill(&w.upstream, "m1", "", "m1 version two.");
+    write_skill(&w.upstream, "m2", "", "m2 version two.");
+    write_skill(&w.upstream, "solo", "", "solo version two.");
+    let second = commit(&w.upstream, "two");
+    fetch_mirrors(&w);
+
+    // The member has no declaration of its own — the bundle is what
+    // carries its revision, so updating the member moves the bundle.
+    let report = package::update_one(&w.env, &w.scope, ItemKind::Skill, "m1").unwrap();
+    apply::execute(&w.env, &report.plan, None).unwrap();
+
+    assert!(installed_body(&w, "m1").contains("m1 version two."));
+    assert!(
+        installed_body(&w, "m2").contains("m2 version two."),
+        "a fellow member shares the bundle's one revision"
+    );
+    assert!(
+        installed_body(&w, "solo").contains("solo version one."),
+        "a follower outside the bundle stays put"
+    );
+    assert_eq!(locked_commit(&w, "m1"), second);
+    assert_eq!(locked_commit(&w, "solo"), first);
+}
+
+/// A world whose catalog carries a set of `a` and `b`, with `a` declared
+/// outright as well: the scope that has two readings of one package's
+/// revision to reconcile. Returns the commit everything is installed from
+/// and the one upstream moved to.
+#[allow(clippy::unwrap_used)]
+fn a_declared_member_of_a_set(w: &World, also_declared: &str) -> (String, String) {
+    write_skill(&w.upstream, "a", "", "a version one.");
+    write_skill(&w.upstream, "b", "", "b version one.");
+    write_skill(&w.upstream, "solo", "", "solo version one.");
+    fs::write(
+        w.upstream.join("kendex.toml"),
+        "[bundles.kit]\ndescription = \"a set\"\nskills = [\"a\", \"b\"]\n",
+    )
+    .unwrap();
+    let first = commit(&w.upstream, "one");
+    declare(w, also_declared);
+    sync_and_apply(w);
+
+    write_skill(&w.upstream, "a", "", "a version two.");
+    write_skill(&w.upstream, "b", "", "b version two.");
+    write_skill(&w.upstream, "solo", "", "solo version two.");
+    let second = commit(&w.upstream, "two");
+    fetch_mirrors(w);
+    (first, second)
+}
+
+/// Whether the plan reports this package as wanted at two revisions at
+/// once — the conflict that writes nothing and asks the person to
+/// reconcile pins.
+fn reports_a_rev_conflict(report: &kendex_core::engine::EngineReport, name: &str) -> bool {
+    report
+        .drift
+        .iter()
+        .any(|row| row.name == name && row.state == DriftState::Conflict)
+        || report
+            .warnings
+            .iter()
+            .any(|w| w.name == name && w.message.contains("wanted at"))
+}
+
+/// A package the person declared and a set also carries has two readings
+/// of its revision. Their own declaration is the one they acted on, so it
+/// decides: the package moves, and the set stays where its record says it
+/// is with every other member still on it.
+#[test]
+#[allow(clippy::unwrap_used)]
+fn updating_a_declared_package_a_set_also_carries_moves_it_alone() {
+    let w = world();
+    let (first, second) = a_declared_member_of_a_set(
+        &w,
+        "[skills.a]\nsource = \"cat\"\n\n[bundles.kit]\nsource = \"cat\"\n",
+    );
+
+    let report = package::update_one(&w.env, &w.scope, ItemKind::Skill, "a").unwrap();
+    assert!(
+        !reports_a_rev_conflict(&report, "a"),
+        "the declaration and the set's hold are both this pass's reading, not a conflict the person made: {:?}",
+        report.warnings
+    );
+    apply::execute(&w.env, &report.plan, None).unwrap();
+
+    assert!(installed_body(&w, "a").contains("a version two."));
+    assert!(
+        installed_body(&w, "b").contains("b version one."),
+        "a fellow member of the set must not come current as a side effect"
+    );
+    assert_eq!(locked_commit(&w, "a"), second);
+    assert_eq!(
+        locked_commit(&w, "b"),
+        first,
+        "the set stays at the commit its record says it is on"
+    );
+    assert_eq!(
+        declared_rev(&w, "a"),
+        None,
+        "the target was never held, and nothing invented a hold for it"
+    );
+    let loaded = manifest::load_for_mutation(&manifest::manifest_path(&w.env, &w.scope))
+        .unwrap()
+        .unwrap();
+    assert_eq!(
+        loaded.bundles["kit"].rev, None,
+        "the hold that held the set still for this pass is not a hold the person chose"
+    );
+}
+
+/// The scope the update above leaves behind: the set's members sit on two
+/// commits, and the declared one is the record for where it is. Moving the
+/// other member reads it that way instead of pinning it through the set
+/// again and refusing to write either revision.
+#[test]
+#[allow(clippy::unwrap_used)]
+fn moving_the_rest_of_the_set_afterwards_leaves_the_declared_member_put() {
+    let w = world();
+    let (_, second) = a_declared_member_of_a_set(
+        &w,
+        "[skills.a]\nsource = \"cat\"\n\n[bundles.kit]\nsource = \"cat\"\n",
+    );
+
+    let report = package::update_one(&w.env, &w.scope, ItemKind::Skill, "a").unwrap();
+    apply::execute(&w.env, &report.plan, None).unwrap();
+
+    // `b` has no declaration of its own, so the set is what carries its
+    // revision and moving it moves the set.
+    let report = package::update_one(&w.env, &w.scope, ItemKind::Skill, "b").unwrap();
+    assert!(
+        !reports_a_rev_conflict(&report, "a"),
+        "the declared member is read off its own declaration, not pinned through the set twice: {:?}",
+        report.warnings
+    );
+    apply::execute(&w.env, &report.plan, None).unwrap();
+
+    assert!(installed_body(&w, "b").contains("b version two."));
+    assert!(installed_body(&w, "a").contains("a version two."));
+    assert_eq!(locked_commit(&w, "a"), second);
+    assert_eq!(locked_commit(&w, "b"), second);
+}
+
+/// The must-fail control: a set and a member pinned at different commits
+/// is a disagreement the person wrote, and a single-package update
+/// elsewhere in the scope still reports it and writes nothing for the
+/// package it is about.
+#[test]
+#[allow(clippy::unwrap_used)]
+fn a_hold_the_person_wrote_against_their_set_still_conflicts() {
+    let w = world();
+    let (first, second) = a_declared_member_of_a_set(
+        &w,
+        "[skills.solo]\nsource = \"cat\"\n\n[skills.a]\nsource = \"cat\"\n\n[bundles.kit]\nsource = \"cat\"\n",
+    );
+
+    // The person pins the package one way and the set that carries it
+    // another. Nothing invented either revision.
+    declare(
+        &w,
+        &format!(
+            "[skills.solo]\nsource = \"cat\"\n\n[skills.a]\nsource = \"cat\"\nrev = \"{second}\"\n\n[bundles.kit]\nsource = \"cat\"\nrev = \"{first}\"\n"
+        ),
+    );
+
+    let report = package::update_one(&w.env, &w.scope, ItemKind::Skill, "solo").unwrap();
+    assert!(
+        reports_a_rev_conflict(&report, "a"),
+        "two revisions the person pinned must still conflict: {:?}",
+        report.drift
+    );
+    apply::execute(&w.env, &report.plan, None).unwrap();
+
+    assert!(
+        installed_body(&w, "a").contains("a version one."),
+        "nothing is written for a conflicted package"
+    );
+    assert_eq!(
+        locked_commit(&w, "a"),
+        first,
+        "and its record is left exactly as it was"
+    );
+}
+/// A set can reach a declared package through what requires it rather than
+/// by carrying it. That set holds the parent's revision, not this
+/// package's: held still, it carries its commit onto a package whose own
+/// declaration reads fresh, and the update the person asked for reports a
+/// conflict instead of happening.
+#[test]
+#[allow(clippy::unwrap_used)]
+fn updating_a_package_a_set_reaches_through_a_parent_still_moves_it() {
+    let w = world();
+    write_skill(&w.upstream, "a", "", "a version one.");
+    write_skill(
+        &w.upstream,
+        "parent",
+        "dependencies:\n  required: [a]\n",
+        "parent version one.",
+    );
+    fs::write(
+        w.upstream.join("kendex.toml"),
+        "[bundles.kit]\ndescription = \"a set\"\nskills = [\"parent\"]\n",
+    )
+    .unwrap();
+    commit(&w.upstream, "one");
+    declare(
+        &w,
+        "[skills.a]\nsource = \"cat\"\n\n[bundles.kit]\nsource = \"cat\"\n",
+    );
+    sync_and_apply(&w);
+
+    write_skill(&w.upstream, "a", "", "a version two.");
+    let second = commit(&w.upstream, "two");
+    fetch_mirrors(&w);
+
+    let report = package::update_one(&w.env, &w.scope, ItemKind::Skill, "a").unwrap();
+    assert!(
+        !reports_a_rev_conflict(&report, "a"),
+        "the set owns what requires the package, not the package: {:?}",
+        report.warnings
+    );
+    apply::execute(&w.env, &report.plan, None).unwrap();
+
+    assert!(
+        installed_body(&w, "a").contains("a version two."),
+        "the package the person named has to actually move"
+    );
+    assert_eq!(locked_commit(&w, "a"), second);
+}
+
+/// Once a declared member has moved on its own, the set's members sit on
+/// two commits and the moved one is no longer evidence of where the set
+/// is. Read as evidence it leaves the set placeable at no commit at all,
+/// and the next update of anything else takes the set's undeclared members
+/// current.
+#[test]
+#[allow(clippy::unwrap_used)]
+fn a_member_that_moved_alone_no_longer_says_where_its_set_is() {
+    let w = world();
+    let (first, _) = a_declared_member_of_a_set(
+        &w,
+        "[skills.a]\nsource = \"cat\"\n\n[skills.solo]\nsource = \"cat\"\n\n[bundles.kit]\nsource = \"cat\"\n",
+    );
+
+    let report = package::update_one(&w.env, &w.scope, ItemKind::Skill, "a").unwrap();
+    apply::execute(&w.env, &report.plan, None).unwrap();
+
+    write_skill(&w.upstream, "b", "", "b version three.");
+    write_skill(&w.upstream, "solo", "", "solo version three.");
+    let third = commit(&w.upstream, "three");
+    fetch_mirrors(&w);
+
+    let report = package::update_one(&w.env, &w.scope, ItemKind::Skill, "solo").unwrap();
+    apply::execute(&w.env, &report.plan, None).unwrap();
+
+    assert!(installed_body(&w, "solo").contains("solo version three."));
+    assert!(
+        installed_body(&w, "b").contains("b version one."),
+        "the set is still held where its own members say it is"
+    );
+    assert_eq!(locked_commit(&w, "b"), first);
+    assert_eq!(locked_commit(&w, "solo"), third);
+}
+
+/// A set the person pinned by hand, carrying a member they declared with
+/// no revision of its own, is a disagreement a whole-scope pass reports. A
+/// single-package update elsewhere holds that member at the commit it is
+/// installed from — and weighed against that invented pin, the person's
+/// own pin reads as agreement and the conflict disappears.
+#[test]
+#[allow(clippy::unwrap_used)]
+fn a_hand_pinned_set_conflicts_with_a_member_this_pass_pinned() {
+    let w = world();
+    let (first, _) = a_declared_member_of_a_set(
+        &w,
+        "[skills.a]\nsource = \"cat\"\n\n[skills.solo]\nsource = \"cat\"\n\n[bundles.kit]\nsource = \"cat\"\n",
+    );
+    // Pinned at the very commit the member is installed from, which is the
+    // pin this pass would otherwise invent for it.
+    declare(
+        &w,
+        &format!(
+            "[skills.a]\nsource = \"cat\"\n\n[skills.solo]\nsource = \"cat\"\n\n[bundles.kit]\nsource = \"cat\"\nrev = \"{first}\"\n"
+        ),
+    );
+
+    let report = package::update_one(&w.env, &w.scope, ItemKind::Skill, "solo").unwrap();
+    assert!(
+        reports_a_rev_conflict(&report, "a"),
+        "the set's pin is the person's and the member's declaration follows the source: {:?}",
+        report.warnings
+    );
+    assert!(
+        rev_conflict_message(&report, "a").contains("the source's own revision"),
+        "the declaration follows the source, which is what it has to say: {}",
+        rev_conflict_message(&report, "a")
+    );
+    apply::execute(&w.env, &report.plan, None).unwrap();
+
+    assert!(
+        installed_body(&w, "solo").contains("solo version two."),
+        "the package the person named still updates"
+    );
+    assert!(
+        installed_body(&w, "a").contains("a version one."),
+        "and nothing is written for the conflicted one"
+    );
+}
+
+/// The same disagreement with the set pinned somewhere else again: the
+/// warning has to name the revisions the person wrote, never the commit
+/// this pass pinned the member at to hold the rest of the scope still.
+#[test]
+#[allow(clippy::unwrap_used)]
+fn a_conflict_with_a_hand_pinned_set_names_no_invented_commit() {
+    let w = world();
+    let (first, second) = a_declared_member_of_a_set(
+        &w,
+        "[skills.a]\nsource = \"cat\"\n\n[skills.solo]\nsource = \"cat\"\n\n[bundles.kit]\nsource = \"cat\"\n",
+    );
+    declare(
+        &w,
+        &format!(
+            "[skills.a]\nsource = \"cat\"\n\n[skills.solo]\nsource = \"cat\"\n\n[bundles.kit]\nsource = \"cat\"\nrev = \"{second}\"\n"
+        ),
+    );
+
+    let report = package::update_one(&w.env, &w.scope, ItemKind::Skill, "solo").unwrap();
+    let message = rev_conflict_message(&report, "a");
+    assert!(
+        message.contains("the source's own revision"),
+        "the member's declaration follows the source: {message}"
+    );
+    assert!(
+        !message.contains(&first[..7]),
+        "the commit this pass pinned the member at is not one the person can act on: {message}"
+    );
+    assert!(
+        message.contains(&second[..7]),
+        "the set's own pin is: {message}"
+    );
+}

--- a/crates/core/tests/package_pins/single_update.rs
+++ b/crates/core/tests/package_pins/single_update.rs
@@ -6,7 +6,7 @@
 use std::fs;
 
 use kendex_core::apply;
-use kendex_core::engine::{PlanOptions, plan_refresh};
+use kendex_core::engine::{DriftState, PlanOptions, plan_refresh};
 use kendex_core::error::CoreError;
 use kendex_core::lock::{entry_key, load as load_lock, lock_path};
 use kendex_core::manifest;
@@ -117,6 +117,164 @@ fn updating_a_bundle_member_moves_its_bundle_and_no_one_else() {
     );
     assert_eq!(locked_commit(&w, "m1"), second);
     assert_eq!(locked_commit(&w, "solo"), first);
+}
+
+/// A world whose catalog carries a set of `a` and `b`, with `a` declared
+/// outright as well: the scope that has two readings of one package's
+/// revision to reconcile. Returns the commit everything is installed from
+/// and the one upstream moved to.
+#[allow(clippy::unwrap_used)]
+fn a_declared_member_of_a_set(w: &World, also_declared: &str) -> (String, String) {
+    write_skill(&w.upstream, "a", "", "a version one.");
+    write_skill(&w.upstream, "b", "", "b version one.");
+    fs::write(
+        w.upstream.join("kendex.toml"),
+        "[bundles.kit]\ndescription = \"a set\"\nskills = [\"a\", \"b\"]\n",
+    )
+    .unwrap();
+    let first = commit(&w.upstream, "one");
+    declare(w, also_declared);
+    sync_and_apply(w);
+
+    write_skill(&w.upstream, "a", "", "a version two.");
+    write_skill(&w.upstream, "b", "", "b version two.");
+    let second = commit(&w.upstream, "two");
+    fetch_mirrors(w);
+    (first, second)
+}
+
+/// Whether the plan reports this package as wanted at two revisions at
+/// once — the conflict that writes nothing and asks the person to
+/// reconcile pins.
+fn reports_a_rev_conflict(report: &kendex_core::engine::EngineReport, name: &str) -> bool {
+    report
+        .drift
+        .iter()
+        .any(|row| row.name == name && row.state == DriftState::Conflict)
+        || report
+            .warnings
+            .iter()
+            .any(|w| w.name == name && w.message.contains("wanted at"))
+}
+
+/// A package the person declared and a set also carries has two readings
+/// of its revision. Their own declaration is the one they acted on, so it
+/// decides: the package moves, and the set stays where its record says it
+/// is with every other member still on it.
+#[test]
+#[allow(clippy::unwrap_used)]
+fn updating_a_declared_package_a_set_also_carries_moves_it_alone() {
+    let w = world();
+    let (first, second) = a_declared_member_of_a_set(
+        &w,
+        "[skills.a]\nsource = \"cat\"\n\n[bundles.kit]\nsource = \"cat\"\n",
+    );
+
+    let report = package::update_one(&w.env, &w.scope, ItemKind::Skill, "a").unwrap();
+    assert!(
+        !reports_a_rev_conflict(&report, "a"),
+        "the declaration and the set's hold are both this pass's reading, not a conflict the person made: {:?}",
+        report.warnings
+    );
+    apply::execute(&w.env, &report.plan, None).unwrap();
+
+    assert!(installed_body(&w, "a").contains("a version two."));
+    assert!(
+        installed_body(&w, "b").contains("b version one."),
+        "a fellow member of the set must not come current as a side effect"
+    );
+    assert_eq!(locked_commit(&w, "a"), second);
+    assert_eq!(
+        locked_commit(&w, "b"),
+        first,
+        "the set stays at the commit its record says it is on"
+    );
+    assert_eq!(
+        declared_rev(&w, "a"),
+        None,
+        "the target was never held, and nothing invented a hold for it"
+    );
+    let loaded = manifest::load_for_mutation(&manifest::manifest_path(&w.env, &w.scope))
+        .unwrap()
+        .unwrap();
+    assert_eq!(
+        loaded.bundles["kit"].rev, None,
+        "the hold that held the set still for this pass is not a hold the person chose"
+    );
+}
+
+/// The scope the update above leaves behind: the set's members sit on two
+/// commits, and the declared one is the record for where it is. Moving the
+/// other member reads it that way instead of pinning it through the set
+/// again and refusing to write either revision.
+#[test]
+#[allow(clippy::unwrap_used)]
+fn moving_the_rest_of_the_set_afterwards_leaves_the_declared_member_put() {
+    let w = world();
+    let (_, second) = a_declared_member_of_a_set(
+        &w,
+        "[skills.a]\nsource = \"cat\"\n\n[bundles.kit]\nsource = \"cat\"\n",
+    );
+
+    let report = package::update_one(&w.env, &w.scope, ItemKind::Skill, "a").unwrap();
+    apply::execute(&w.env, &report.plan, None).unwrap();
+
+    // `b` has no declaration of its own, so the set is what carries its
+    // revision and moving it moves the set.
+    let report = package::update_one(&w.env, &w.scope, ItemKind::Skill, "b").unwrap();
+    assert!(
+        !reports_a_rev_conflict(&report, "a"),
+        "the declared member is read off its own declaration, not pinned through the set twice: {:?}",
+        report.warnings
+    );
+    apply::execute(&w.env, &report.plan, None).unwrap();
+
+    assert!(installed_body(&w, "b").contains("b version two."));
+    assert!(installed_body(&w, "a").contains("a version two."));
+    assert_eq!(locked_commit(&w, "a"), second);
+    assert_eq!(locked_commit(&w, "b"), second);
+}
+
+/// The must-fail control: a set and a member pinned at different commits
+/// is a disagreement the person wrote, and a single-package update
+/// elsewhere in the scope still reports it and writes nothing for the
+/// package it is about.
+#[test]
+#[allow(clippy::unwrap_used)]
+fn a_hold_the_person_wrote_against_their_set_still_conflicts() {
+    let w = world();
+    write_skill(&w.upstream, "solo", "", "solo version one.");
+    let (first, second) = a_declared_member_of_a_set(
+        &w,
+        "[skills.solo]\nsource = \"cat\"\n\n[skills.a]\nsource = \"cat\"\n\n[bundles.kit]\nsource = \"cat\"\n",
+    );
+
+    // The person pins the package one way and the set that carries it
+    // another. Nothing invented either revision.
+    declare(
+        &w,
+        &format!(
+            "[skills.solo]\nsource = \"cat\"\n\n[skills.a]\nsource = \"cat\"\nrev = \"{second}\"\n\n[bundles.kit]\nsource = \"cat\"\nrev = \"{first}\"\n"
+        ),
+    );
+
+    let report = package::update_one(&w.env, &w.scope, ItemKind::Skill, "solo").unwrap();
+    assert!(
+        reports_a_rev_conflict(&report, "a"),
+        "two revisions the person pinned must still conflict: {:?}",
+        report.drift
+    );
+    apply::execute(&w.env, &report.plan, None).unwrap();
+
+    assert!(
+        installed_body(&w, "a").contains("a version one."),
+        "nothing is written for a conflicted package"
+    );
+    assert_eq!(
+        locked_commit(&w, "a"),
+        first,
+        "and its record is left exactly as it was"
+    );
 }
 
 #[test]

--- a/crates/core/tests/package_pins/single_update.rs
+++ b/crates/core/tests/package_pins/single_update.rs
@@ -6,34 +6,17 @@
 use std::fs;
 
 use kendex_core::apply;
-use kendex_core::engine::{DriftState, PlanOptions, plan_refresh};
+use kendex_core::engine::{PlanOptions, plan_refresh};
 use kendex_core::error::CoreError;
-use kendex_core::lock::{entry_key, load as load_lock, lock_path};
+use kendex_core::lock::{load as load_lock, lock_path};
 use kendex_core::manifest;
-use kendex_core::model::{HarnessId, ItemKind};
-use kendex_core::{package, remote};
+use kendex_core::model::ItemKind;
+use kendex_core::package;
 
 use super::{
-    REPO, World, commit, declare, installed_body, sync_and_apply, world, write_agent,
-    write_manifest, write_skill,
+    REPO, World, commit, declare, declared_rev, fetch_mirrors, installed_body, locked_commit,
+    sync_and_apply, world, write_agent, write_manifest, write_skill,
 };
-
-#[allow(clippy::unwrap_used)]
-fn fetch_mirrors(w: &World) {
-    let loaded = manifest::load_for_mutation(&manifest::manifest_path(&w.env, &w.scope))
-        .unwrap()
-        .unwrap();
-    remote::sync_sources(&w.env, &loaded).unwrap();
-}
-
-#[allow(clippy::unwrap_used)]
-fn locked_commit(w: &World, name: &str) -> String {
-    let lock = load_lock(&lock_path(&w.env, &w.scope)).unwrap();
-    lock.entries[&entry_key(ItemKind::Skill, name, HarnessId::Claude)]
-        .source_commit
-        .clone()
-        .unwrap()
-}
 
 #[test]
 #[allow(clippy::unwrap_used)]
@@ -74,207 +57,6 @@ fn updating_one_follower_leaves_its_siblings_at_their_commits() {
     apply::execute(&w.env, &report.plan, None).unwrap();
     assert!(installed_body(&w, "b").contains("b version two."));
     assert_eq!(locked_commit(&w, "b"), second);
-}
-
-#[test]
-#[allow(clippy::unwrap_used)]
-fn updating_a_bundle_member_moves_its_bundle_and_no_one_else() {
-    let w = world();
-    write_skill(&w.upstream, "m1", "", "m1 version one.");
-    write_skill(&w.upstream, "m2", "", "m2 version one.");
-    write_skill(&w.upstream, "solo", "", "solo version one.");
-    fs::write(
-        w.upstream.join("kendex.toml"),
-        "[bundles.kit]\ndescription = \"a set\"\nskills = [\"m1\", \"m2\"]\n",
-    )
-    .unwrap();
-    let first = commit(&w.upstream, "one");
-    declare(
-        &w,
-        "[skills.solo]\nsource = \"cat\"\n\n[bundles.kit]\nsource = \"cat\"\n",
-    );
-    sync_and_apply(&w);
-
-    write_skill(&w.upstream, "m1", "", "m1 version two.");
-    write_skill(&w.upstream, "m2", "", "m2 version two.");
-    write_skill(&w.upstream, "solo", "", "solo version two.");
-    let second = commit(&w.upstream, "two");
-    fetch_mirrors(&w);
-
-    // The member has no declaration of its own — the bundle is what
-    // carries its revision, so updating the member moves the bundle.
-    let report = package::update_one(&w.env, &w.scope, ItemKind::Skill, "m1").unwrap();
-    apply::execute(&w.env, &report.plan, None).unwrap();
-
-    assert!(installed_body(&w, "m1").contains("m1 version two."));
-    assert!(
-        installed_body(&w, "m2").contains("m2 version two."),
-        "a fellow member shares the bundle's one revision"
-    );
-    assert!(
-        installed_body(&w, "solo").contains("solo version one."),
-        "a follower outside the bundle stays put"
-    );
-    assert_eq!(locked_commit(&w, "m1"), second);
-    assert_eq!(locked_commit(&w, "solo"), first);
-}
-
-/// A world whose catalog carries a set of `a` and `b`, with `a` declared
-/// outright as well: the scope that has two readings of one package's
-/// revision to reconcile. Returns the commit everything is installed from
-/// and the one upstream moved to.
-#[allow(clippy::unwrap_used)]
-fn a_declared_member_of_a_set(w: &World, also_declared: &str) -> (String, String) {
-    write_skill(&w.upstream, "a", "", "a version one.");
-    write_skill(&w.upstream, "b", "", "b version one.");
-    fs::write(
-        w.upstream.join("kendex.toml"),
-        "[bundles.kit]\ndescription = \"a set\"\nskills = [\"a\", \"b\"]\n",
-    )
-    .unwrap();
-    let first = commit(&w.upstream, "one");
-    declare(w, also_declared);
-    sync_and_apply(w);
-
-    write_skill(&w.upstream, "a", "", "a version two.");
-    write_skill(&w.upstream, "b", "", "b version two.");
-    let second = commit(&w.upstream, "two");
-    fetch_mirrors(w);
-    (first, second)
-}
-
-/// Whether the plan reports this package as wanted at two revisions at
-/// once — the conflict that writes nothing and asks the person to
-/// reconcile pins.
-fn reports_a_rev_conflict(report: &kendex_core::engine::EngineReport, name: &str) -> bool {
-    report
-        .drift
-        .iter()
-        .any(|row| row.name == name && row.state == DriftState::Conflict)
-        || report
-            .warnings
-            .iter()
-            .any(|w| w.name == name && w.message.contains("wanted at"))
-}
-
-/// A package the person declared and a set also carries has two readings
-/// of its revision. Their own declaration is the one they acted on, so it
-/// decides: the package moves, and the set stays where its record says it
-/// is with every other member still on it.
-#[test]
-#[allow(clippy::unwrap_used)]
-fn updating_a_declared_package_a_set_also_carries_moves_it_alone() {
-    let w = world();
-    let (first, second) = a_declared_member_of_a_set(
-        &w,
-        "[skills.a]\nsource = \"cat\"\n\n[bundles.kit]\nsource = \"cat\"\n",
-    );
-
-    let report = package::update_one(&w.env, &w.scope, ItemKind::Skill, "a").unwrap();
-    assert!(
-        !reports_a_rev_conflict(&report, "a"),
-        "the declaration and the set's hold are both this pass's reading, not a conflict the person made: {:?}",
-        report.warnings
-    );
-    apply::execute(&w.env, &report.plan, None).unwrap();
-
-    assert!(installed_body(&w, "a").contains("a version two."));
-    assert!(
-        installed_body(&w, "b").contains("b version one."),
-        "a fellow member of the set must not come current as a side effect"
-    );
-    assert_eq!(locked_commit(&w, "a"), second);
-    assert_eq!(
-        locked_commit(&w, "b"),
-        first,
-        "the set stays at the commit its record says it is on"
-    );
-    assert_eq!(
-        declared_rev(&w, "a"),
-        None,
-        "the target was never held, and nothing invented a hold for it"
-    );
-    let loaded = manifest::load_for_mutation(&manifest::manifest_path(&w.env, &w.scope))
-        .unwrap()
-        .unwrap();
-    assert_eq!(
-        loaded.bundles["kit"].rev, None,
-        "the hold that held the set still for this pass is not a hold the person chose"
-    );
-}
-
-/// The scope the update above leaves behind: the set's members sit on two
-/// commits, and the declared one is the record for where it is. Moving the
-/// other member reads it that way instead of pinning it through the set
-/// again and refusing to write either revision.
-#[test]
-#[allow(clippy::unwrap_used)]
-fn moving_the_rest_of_the_set_afterwards_leaves_the_declared_member_put() {
-    let w = world();
-    let (_, second) = a_declared_member_of_a_set(
-        &w,
-        "[skills.a]\nsource = \"cat\"\n\n[bundles.kit]\nsource = \"cat\"\n",
-    );
-
-    let report = package::update_one(&w.env, &w.scope, ItemKind::Skill, "a").unwrap();
-    apply::execute(&w.env, &report.plan, None).unwrap();
-
-    // `b` has no declaration of its own, so the set is what carries its
-    // revision and moving it moves the set.
-    let report = package::update_one(&w.env, &w.scope, ItemKind::Skill, "b").unwrap();
-    assert!(
-        !reports_a_rev_conflict(&report, "a"),
-        "the declared member is read off its own declaration, not pinned through the set twice: {:?}",
-        report.warnings
-    );
-    apply::execute(&w.env, &report.plan, None).unwrap();
-
-    assert!(installed_body(&w, "b").contains("b version two."));
-    assert!(installed_body(&w, "a").contains("a version two."));
-    assert_eq!(locked_commit(&w, "a"), second);
-    assert_eq!(locked_commit(&w, "b"), second);
-}
-
-/// The must-fail control: a set and a member pinned at different commits
-/// is a disagreement the person wrote, and a single-package update
-/// elsewhere in the scope still reports it and writes nothing for the
-/// package it is about.
-#[test]
-#[allow(clippy::unwrap_used)]
-fn a_hold_the_person_wrote_against_their_set_still_conflicts() {
-    let w = world();
-    write_skill(&w.upstream, "solo", "", "solo version one.");
-    let (first, second) = a_declared_member_of_a_set(
-        &w,
-        "[skills.solo]\nsource = \"cat\"\n\n[skills.a]\nsource = \"cat\"\n\n[bundles.kit]\nsource = \"cat\"\n",
-    );
-
-    // The person pins the package one way and the set that carries it
-    // another. Nothing invented either revision.
-    declare(
-        &w,
-        &format!(
-            "[skills.solo]\nsource = \"cat\"\n\n[skills.a]\nsource = \"cat\"\nrev = \"{second}\"\n\n[bundles.kit]\nsource = \"cat\"\nrev = \"{first}\"\n"
-        ),
-    );
-
-    let report = package::update_one(&w.env, &w.scope, ItemKind::Skill, "solo").unwrap();
-    assert!(
-        reports_a_rev_conflict(&report, "a"),
-        "two revisions the person pinned must still conflict: {:?}",
-        report.drift
-    );
-    apply::execute(&w.env, &report.plan, None).unwrap();
-
-    assert!(
-        installed_body(&w, "a").contains("a version one."),
-        "nothing is written for a conflicted package"
-    );
-    assert_eq!(
-        locked_commit(&w, "a"),
-        first,
-        "and its record is left exactly as it was"
-    );
 }
 
 #[test]
@@ -330,17 +112,6 @@ fn updating_a_name_nothing_declares_or_records_is_refused() {
 
     let error = package::update_one(&w.env, &w.scope, ItemKind::Skill, "stranger").unwrap_err();
     assert!(matches!(error, CoreError::NotDeclared { .. }), "{error}");
-}
-
-/// The manifest text as it sits on disk, and the revision a package is
-/// declared with there. A synthetic hold that reaches the file is a hold
-/// nobody chose: that package stops updating, forever and silently.
-#[allow(clippy::unwrap_used)]
-fn declared_rev(w: &World, name: &str) -> Option<String> {
-    let loaded = manifest::load_for_mutation(&manifest::manifest_path(&w.env, &w.scope))
-        .unwrap()
-        .unwrap();
-    loaded.declared(ItemKind::Skill)[name].rev.clone()
 }
 
 #[allow(clippy::unwrap_used)]


### PR DESCRIPTION
A package can be declared outright and also be carried by a bundle. Updating that package alone moved the bundle's other members too, while the app and the CLI reported only the package you named.

The single-package update pins every unrelated declaration at its locked commit and leaves the target fresh. The exemption was computed from the lock entry's reasons, so an entry carrying both `Requested` and `MemberOf` named the bundle as an owner: the bundle was exempt too, resolved at its tip, and its other members rode along.

## What changed

The exemption now stops at the target's own declaration where it has one. That declaration is what the target reads, so the bundle is held still like every other follower.

Then the two revisions have to meet. `member_decl` copies a bundle's revision onto every member, so a held bundle would hand the target a revision while its own declaration reads fresh — one package wanted at two revisions, both invented by this pass, which `Expansion::add` reports as a conflict the user never created, with a remedy naming a pin kendex strips again before writing the manifest. `bundles::carried_rev` breaks that tie: where the member has its own declaration, the declaration decides.

**Only a revision this pass invented gives way.** Where the person wrote one — on the bundle, on the member, or on both — the two stand as written and the disagreement reports exactly as a whole-scope pass reports it. `HeldPins` gained two queries so the tie-break can tell the two apart; that is the only thing in `hold.rs` besides the narrowed exemption, and the precedence itself lives in `bundles.rs` as the issue requires.

A target with no declaration of its own is unchanged: the bundle's revision is the only one it has, so the bundle reads fresh and its members move with it. That is `updating_a_bundle_member_moves_its_bundle_and_no_one_else`, accepted behaviour, still passing.

## Why move it alone rather than refuse

The issue allowed either. This is the over-reach defect, so the fix is to move exactly what was asked and nothing else — the direct negation of the bug. Refusing would change the product instead of fixing it, and would make a legitimate action fail with an explanation the user then has to work around. The user declared that package themselves, so their own declaration is what they are acting on. The toast stays plain: `Updated gh to v2.1`.

## Tests

- `updating_a_declared_package_a_set_also_carries_moves_it_alone` — the target moves alone.
- `moving_the_rest_of_the_set_afterwards_leaves_the_declared_member_put` — the bundle and its other members stay at their locked commits.
- `a_hold_the_person_wrote_against_their_set_still_conflicts` — a user-made revision conflict still reports, as the must-fail control.
- `updating_a_bundle_member_moves_its_bundle_and_no_one_else` — unchanged accepted behaviour.

25 pass in `package_pins`.

## Note for KEN-604

That issue makes `update_only` carry a set of targets, turning the exemption into a union. The precedence here is decided per member against that member's own declaration, so it holds for a set without change: each target reads its own declaration, and a bundle is held still unless it is itself a target.

## The dependency edge is not fixed here

`owners_of` exempts a dependency parent whether or not the target has its own declaration, so updating a declared package that a declared parent requires still brings that parent current. It is the same defect family, one relation over, and it needs the same two halves: `deps.rs` copies a parent's revision onto what it requires exactly as `member_decl` copies a bundle's, so unexempting alone would produce the invented-conflict trap described above. No reported symptom, so it is filed as KEN-765 rather than widened into this PR.

Closes KEN-606
