### PR TITLE
fix(KEN-736): an expired sign-in reads as expired, not signed out

### DIFF
--- a/changelog.d/fixed/KEN-736.md
+++ b/changelog.d/fixed/KEN-736.md
@@ -1,0 +1,3 @@
+- An expired sign-in now reads as expired everywhere instead of quietly signing
+  you out: a submit that meets one stops offering the submit, and the
+  submissions poll no longer hides it.

--- a/crates/app/src/account.rs
+++ b/crates/app/src/account.rs
@@ -7,6 +7,7 @@ use std::path::PathBuf;
 
 use kendex_core::author::{self, SubmitPreflight};
 use kendex_core::env::Env;
+use kendex_core::error::CoreError;
 use kendex_core::registry::credentials::{Credential, KeyringStore};
 use kendex_core::registry::login::{self, Poll};
 use kendex_core::registry::me::{self, AccountState};
@@ -104,10 +105,46 @@ pub struct SubmittedView {
     pub status: String,
 }
 
+/// Why a call made under the stored sign-in did not answer.
+///
+/// Expiry is the account ending, not one action failing: the credential
+/// is gone, and every surface built on the account has to say so. As a
+/// message it reaches only the surface that asked, which is how a person
+/// gets told their sign-in expired by a dialog while the sidebar goes on
+/// naming them. So it is a shape the caller can act on rather than a
+/// sentence it would have to recognise by its words.
+#[derive(Debug, Serialize, Type)]
+#[serde(tag = "kind", rename_all = "kebab-case")]
+pub enum AccountCallRefused {
+    /// The sign-in is dead and the credential has been cleared. The
+    /// message is the whole sentence, the remedy included, because the
+    /// surface that shows it has nothing else to say.
+    Expired {
+        message: String,
+    },
+    Failed {
+        message: String,
+    },
+}
+
+/// What a failed authenticated call means to the surfaces the account
+/// feeds. Expiry is the one failure that is news about the account
+/// itself; every other is this action's alone.
+fn refused(error: CoreError) -> AccountCallRefused {
+    match error {
+        expired @ CoreError::SignInExpired { .. } => AccountCallRefused::Expired {
+            message: expired.to_string(),
+        },
+        other => AccountCallRefused::Failed {
+            message: other.to_string(),
+        },
+    }
+}
+
 #[tauri::command(async)]
 #[specta::specta]
-pub fn mine_submit(repo: String) -> Result<SubmittedView, String> {
-    let outcome = submit::submit(&CurlFetch, &KeyringStore, &repo).map_err(|e| e.to_string())?;
+pub fn mine_submit(repo: String) -> Result<SubmittedView, AccountCallRefused> {
+    let outcome = submit::submit(&CurlFetch, &KeyringStore, &repo).map_err(refused)?;
     Ok(SubmittedView {
         repo: outcome.repo,
         status: outcome.status,
@@ -116,6 +153,50 @@ pub fn mine_submit(repo: String) -> Result<SubmittedView, String> {
 
 #[tauri::command(async)]
 #[specta::specta]
-pub fn mine_submissions() -> Result<Vec<SubmissionRow>, String> {
-    submit::submissions(&CurlFetch, &KeyringStore).map_err(|e| e.to_string())
+pub fn mine_submissions() -> Result<Vec<SubmissionRow>, AccountCallRefused> {
+    submit::submissions(&CurlFetch, &KeyringStore).map_err(refused)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The account moves on expiry and on nothing else. A refusal that
+    /// says the server would not take the submission is about the
+    /// submission, and signing the person out over it would be a lie.
+    #[test]
+    fn expiry_is_the_one_refusal_that_is_news_about_the_account() {
+        assert!(matches!(
+            refused(CoreError::SignInExpired {
+                why: "the server does not accept this sign-in".to_owned()
+            }),
+            AccountCallRefused::Expired { .. }
+        ));
+        assert!(matches!(
+            refused(CoreError::Authoring {
+                message: "that repository is already submitted".to_owned()
+            }),
+            AccountCallRefused::Failed { .. }
+        ));
+        assert!(matches!(
+            refused(CoreError::NotSignedIn),
+            AccountCallRefused::Failed { .. }
+        ));
+    }
+
+    /// The expired refusal is all the surface has to show, so it carries
+    /// the remedy and not just the diagnosis.
+    #[test]
+    fn the_expired_refusal_carries_the_remedy_with_the_reason() {
+        let refusal = refused(CoreError::SignInExpired {
+            why: "your sign-in has expired (invalid_grant)".to_owned(),
+        });
+        let AccountCallRefused::Expired { message } = refusal else {
+            panic!("a dead sign-in is an expiry");
+        };
+        assert_eq!(
+            message,
+            "your sign-in has expired (invalid_grant) — run `kendex login` again"
+        );
+    }
 }

--- a/crates/app/src/account.rs
+++ b/crates/app/src/account.rs
@@ -56,16 +56,30 @@ pub fn account_login_start() -> Result<LoginStart, String> {
     })
 }
 
+/// Where one poll of the device flow left the sign-in.
+///
+/// `Signed` carries the name minted for the credential just stored, the
+/// same one a later read of this account answers with. It is here so the
+/// caller holds a named credential from the moment one exists, rather
+/// than an unnamed one until the read that follows names it.
+#[derive(Debug, Serialize, Type)]
+#[serde(tag = "kind", rename_all = "kebab-case")]
+pub enum LoginPoll {
+    Pending,
+    SlowDown,
+    Signed { sign_in: String },
+}
+
 /// One poll; the frontend owns the timer so a closed dialog stops asking.
 #[tauri::command(async)]
 #[specta::specta]
-pub fn account_login_poll(device_code: String) -> Result<String, String> {
+pub fn account_login_poll(device_code: String) -> Result<LoginPoll, String> {
     match login::poll_once(&CurlFetch, &device_code).map_err(|e| e.to_string())? {
-        Poll::Pending => Ok("pending".to_owned()),
-        Poll::SlowDown => Ok("slow-down".to_owned()),
+        Poll::Pending => Ok(LoginPoll::Pending),
+        Poll::SlowDown => Ok(LoginPoll::SlowDown),
         Poll::Signed(pair) => {
             let env = Env::detect().map_err(|e| e.to_string())?;
-            me::commit_sign_in(
+            let sign_in = me::commit_sign_in(
                 &env,
                 &KeyringStore,
                 &Credential {
@@ -78,7 +92,7 @@ pub fn account_login_poll(device_code: String) -> Result<String, String> {
                 },
             )
             .map_err(|e| e.to_string())?;
-            Ok("signed".to_owned())
+            Ok(LoginPoll::Signed { sign_in })
         }
     }
 }

--- a/crates/app/src/account.rs
+++ b/crates/app/src/account.rs
@@ -184,19 +184,19 @@ mod tests {
         ));
     }
 
-    /// The expired refusal is all the surface has to show, so it carries
-    /// the remedy and not just the diagnosis.
+    /// The expired refusal is all the surface has to show, and the whole
+    /// sentence is the producer's: the diagnosis and the remedy that fits
+    /// what the removal did. This layer passes it through and adds
+    /// nothing, so a remedy chosen upstream cannot be overwritten here.
     #[test]
     fn the_expired_refusal_carries_the_remedy_with_the_reason() {
+        let sentence = "your sign-in has expired (invalid_grant) \u{2014} run `kendex login` again";
         let refusal = refused(CoreError::SignInExpired {
-            why: "your sign-in has expired (invalid_grant)".to_owned(),
+            why: sentence.to_owned(),
         });
         let AccountCallRefused::Expired { message } = refusal else {
             panic!("a dead sign-in is an expiry");
         };
-        assert_eq!(
-            message,
-            "your sign-in has expired (invalid_grant) — run `kendex login` again"
-        );
+        assert_eq!(message, sentence);
     }
 }

--- a/crates/app/src/account.rs
+++ b/crates/app/src/account.rs
@@ -107,29 +107,35 @@ pub struct SubmittedView {
 
 /// Why a call made under the stored sign-in did not answer.
 ///
-/// Expiry is the account ending, not one action failing: the credential
-/// is gone, and every surface built on the account has to say so. As a
+/// Expiry is the account ending, not one action failing: the sign-in is
+/// dead, and every surface built on the account has to say so. As a
 /// message it reaches only the surface that asked, which is how a person
 /// gets told their sign-in expired by a dialog while the sidebar goes on
 /// naming them. So it is a shape the caller can act on rather than a
 /// sentence it would have to recognise by its words.
+///
+/// `Expired`'s message is the whole sentence, the remedy included,
+/// because the surface that shows it has nothing else to say. What
+/// became of the local copy is the producer's to state in that sentence,
+/// which says so when the copy could not be removed. It is named here
+/// rather than documented on the variant because specta hoists a
+/// variant's doc above the whole union, where it would read as
+/// describing `Failed` too.
 #[derive(Debug, Serialize, Type)]
 #[serde(tag = "kind", rename_all = "kebab-case")]
 pub enum AccountCallRefused {
-    /// The sign-in is dead and the credential has been cleared. The
-    /// message is the whole sentence, the remedy included, because the
-    /// surface that shows it has nothing else to say.
-    Expired {
-        message: String,
-    },
-    Failed {
-        message: String,
-    },
+    Expired { message: String },
+    Failed { message: String },
 }
 
 /// What a failed authenticated call means to the surfaces the account
 /// feeds. Expiry is the one failure that is news about the account
 /// itself; every other is this action's alone.
+///
+/// `NotSignedIn` is among the others deliberately. It says this machine
+/// holds no credential, which is the question the account read already
+/// answers; moving the account from a call that met it would put a
+/// second judge on what `me::load` owns.
 fn refused(error: CoreError) -> AccountCallRefused {
     match error {
         expired @ CoreError::SignInExpired { .. } => AccountCallRefused::Expired {

--- a/crates/core/src/registry/client.rs
+++ b/crates/core/src/registry/client.rs
@@ -122,19 +122,23 @@ fn rotate_locked(
     })
 }
 
-/// Commit a completed device login without racing refresh or logout.
-/// Surfaces call `me::commit_sign_in`, which drops the previous
-/// account's cached identity around this.
-pub fn commit_login(store: &dyn CredentialStore, credential: &Credential) -> Result<()> {
+/// Commit a completed device login without racing refresh or logout, and
+/// answer the name minted for it. Surfaces call `me::commit_sign_in`,
+/// which drops the previous account's cached identity around this.
+pub fn commit_login(store: &dyn CredentialStore, credential: &Credential) -> Result<String> {
     let _guard = store.refresh_guard()?;
     // The sign-in is named here and nowhere else. A device flow mints a
     // refresh token no other sign-in has, so its digest names this one
     // without inventing a second source of uniqueness, and rotation
-    // carries the name rather than recomputing it.
+    // carries the name rather than recomputing it. It is answered rather
+    // than left to be recomputed, which would be a second place that
+    // decides what a sign-in is called.
+    let sign_in = crate::hash::hash_bytes(credential.refresh_token.as_bytes());
     store.save(&Credential {
-        sign_in: crate::hash::hash_bytes(credential.refresh_token.as_bytes()),
+        sign_in: sign_in.clone(),
         ..credential.clone()
-    })
+    })?;
+    Ok(sign_in)
 }
 
 /// Revoke and clear the current sign-in under the credential transaction lock.

--- a/crates/core/src/registry/me.rs
+++ b/crates/core/src/registry/me.rs
@@ -28,7 +28,7 @@ pub struct Identity {
 /// What the account surfaces render, every one of them settled: the UI
 /// holds its own "not read yet" until the first answer comes back.
 ///
-/// The states that hold a credential carry `sign_in`, the name of the
+/// The states about a credential carry `sign_in`, the name of the
 /// sign-in they were read under. It is [`Credential::sign_in`]: minted
 /// once when a sign-in is committed, carried through every rotation, and
 /// replaced only by another sign-in. A caller holding an earlier answer
@@ -50,7 +50,9 @@ pub enum AccountState {
         sign_in: String,
     },
     /// The credential is dead server-side — signing in again is the fix.
-    Expired,
+    Expired {
+        sign_in: String,
+    },
 }
 
 /// The wire shape of GET /api/v1/me, exactly as the contract fixture says.
@@ -101,7 +103,9 @@ pub fn load(env: &Env, fetch: &dyn Fetch, store: &dyn CredentialStore) -> Result
         // would find it keyed to this one and discard it unread.
         Err(CoreError::SignInExpired { .. }) => {
             cache.forget()?;
-            return Ok(AccountState::Expired);
+            return Ok(AccountState::Expired {
+                sign_in: issued_under,
+            });
         }
         Ok(authenticated) => (Ok(authenticated.response), authenticated.credential.sign_in),
         // Nothing came back, so the cache is the whole answer, and it

--- a/crates/core/src/registry/me.rs
+++ b/crates/core/src/registry/me.rs
@@ -27,16 +27,27 @@ pub struct Identity {
 
 /// What the account surfaces render, every one of them settled: the UI
 /// holds its own "not read yet" until the first answer comes back.
+///
+/// The states that hold a credential carry `sign_in`, the name of the
+/// sign-in they were read under. It is [`Credential::sign_in`]: minted
+/// once when a sign-in is committed, carried through every rotation, and
+/// replaced only by another sign-in. A caller holding an earlier answer
+/// compares it to tell the credential it has from one that replaced it,
+/// which no part of the identity can answer — a rename leaves the same
+/// credential, and signing in again as the same person leaves a
+/// different one under the same name.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, specta::Type)]
 #[serde(tag = "state", rename_all = "kebab-case")]
 pub enum AccountState {
     SignedOut,
     SignedIn {
         identity: Identity,
+        sign_in: String,
     },
     /// The server could not be asked; the identity is the last good fetch.
     Offline {
         identity: Identity,
+        sign_in: String,
     },
     /// The credential is dead server-side — signing in again is the fix.
     Expired,
@@ -119,18 +130,24 @@ pub fn load(env: &Env, fetch: &dyn Fetch, store: &dyn CredentialStore) -> Result
             why: server_message(response),
         }
     })?;
+    // Checked equal to what is installed just above, so the answer names
+    // the sign-in it was actually read under.
     Ok(match loaded.stale {
         false => AccountState::SignedIn {
             identity: loaded.value,
+            sign_in: issued_under,
         },
         true => AccountState::Offline {
             identity: loaded.value,
+            sign_in: issued_under,
         },
     })
 }
 
 /// Commit a fresh sign-in and drop the previous account's cached
 /// identity, so the new credential never pairs with the old name.
+/// Answers the name minted for it, which is what a later read of this
+/// account will carry back and what a caller compares against.
 ///
 /// The cache is forgotten twice. The first runs before anything is
 /// installed and fails the call, because failing there leaves nothing
@@ -144,12 +161,12 @@ pub fn commit_sign_in(
     env: &Env,
     store: &dyn CredentialStore,
     credential: &Credential,
-) -> Result<()> {
+) -> Result<String> {
     let cache = cache(env);
     cache.forget()?;
-    client::commit_login(store, credential)?;
+    let sign_in = client::commit_login(store, credential)?;
     let _ = cache.forget();
-    Ok(())
+    Ok(sign_in)
 }
 
 /// Revoke, clear, and forget the cached identity — the one sign-out

--- a/crates/core/tests/me_client/main.rs
+++ b/crates/core/tests/me_client/main.rs
@@ -227,6 +227,22 @@ fn a_read_answers_with_the_sign_in_it_was_read_under() {
     }
 }
 
+/// The expiry names the sign-in the server refused, so a caller holding it
+/// can tell that verdict from one about a credential installed since.
+#[test]
+fn an_expiry_answers_with_the_sign_in_the_server_refused() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let store = MemoryStore::signed_in();
+    let fetch = Canned::new(vec![
+        ok(401, None, ""),
+        ok(400, None, r#"{"error":"invalid_grant"}"#),
+    ]);
+    match me::load(&env_in(dir.path()), &fetch, &store).expect("load") {
+        AccountState::Expired { sign_in } => assert_eq!(sign_in, ADA),
+        other => panic!("expected expired, got {other:?}"),
+    }
+}
+
 /// A read the server could not answer serves the cached identity, and it
 /// belongs to the sign-in that was installed when the read began.
 #[test]
@@ -320,7 +336,7 @@ fn a_dead_refresh_grant_reads_as_expired() {
         ok(400, None, r#"{"error":"invalid_grant"}"#),
     ]);
     let state = me::load(&env_in(dir.path()), &fetch, &store).expect("load");
-    assert_eq!(state, AccountState::Expired);
+    assert!(matches!(state, AccountState::Expired { .. }));
     assert!(
         store.load().expect("load").is_none(),
         "a dead credential is not kept for endless retries"
@@ -341,10 +357,10 @@ fn an_expired_credential_drops_the_cached_identity() {
         ok(401, None, r#"{"error":"invalid_token"}"#),
         ok(400, None, r#"{"error":"invalid_grant"}"#),
     ]);
-    assert_eq!(
+    assert!(matches!(
         me::load(&env, &dead, &store).expect("load"),
-        AccountState::Expired
-    );
+        AccountState::Expired { .. }
+    ));
     assert!(
         !cache.exists(),
         "the next sign-in must not inherit this account's identity"
@@ -366,7 +382,7 @@ fn a_rotation_the_server_still_rejects_reads_as_expired() {
         ok(401, None, r#"{"error":"invalid_token"}"#),
     ]);
     let state = me::load(&env, &fetch, &store).expect("load");
-    assert_eq!(state, AccountState::Expired);
+    assert!(matches!(state, AccountState::Expired { .. }));
     assert!(
         store.load().expect("load").is_none(),
         "a rotation the server refuses is not kept for endless retries"

--- a/crates/core/tests/me_client/main.rs
+++ b/crates/core/tests/me_client/main.rs
@@ -196,7 +196,7 @@ fn the_fixture_success_body_reads_as_signed_in() {
     let fetch = Canned::new(vec![ok(status, None, &fixture_body(&["success", "body"]))]);
     let state = me::load(&env, &fetch, &MemoryStore::signed_in()).expect("load");
     match state {
-        AccountState::SignedIn { identity } => {
+        AccountState::SignedIn { identity, .. } => {
             assert_eq!(identity.name, "Ada Lovelace");
             assert_eq!(identity.github_login.as_deref(), Some("1234567"));
         }
@@ -206,6 +206,48 @@ fn the_fixture_success_body_reads_as_signed_in() {
         fetch.bearers.borrow().as_slice(),
         [Some("kxa_old".to_owned())]
     );
+}
+
+/// The answer names the sign-in it was read under, which is what a caller
+/// holding an earlier answer compares against. Nothing in the identity can
+/// stand in for it: a rename leaves the same credential, and signing in
+/// again as the same person leaves a different one under the same name.
+#[test]
+fn a_read_answers_with_the_sign_in_it_was_read_under() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let fetch = Canned::new(vec![ok(
+        fixture_status(&["success", "status"]),
+        None,
+        &fixture_body(&["success", "body"]),
+    )]);
+    let state = me::load(&env_in(dir.path()), &fetch, &MemoryStore::signed_in()).expect("load");
+    match state {
+        AccountState::SignedIn { sign_in, .. } => assert_eq!(sign_in, ADA),
+        other => panic!("expected signed-in, got {other:?}"),
+    }
+}
+
+/// A read the server could not answer serves the cached identity, and it
+/// belongs to the sign-in that was installed when the read began.
+#[test]
+fn an_offline_read_answers_with_that_sign_in_too() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let env = env_in(dir.path());
+    let store = MemoryStore::signed_in();
+    let warm = Canned::new(vec![ok(
+        fixture_status(&["success", "status"]),
+        None,
+        &fixture_body(&["success", "body"]),
+    )]);
+    me::load(&env, &warm, &store).expect("warm the cache");
+
+    let offline = Canned::new(vec![Err(CoreError::RegistryUnavailable {
+        why: "the network is away".to_owned(),
+    })]);
+    match me::load(&env, &offline, &store).expect("load") {
+        AccountState::Offline { sign_in, .. } => assert_eq!(sign_in, ADA),
+        other => panic!("expected offline, got {other:?}"),
+    }
 }
 
 #[test]
@@ -218,7 +260,7 @@ fn the_fixture_unlinked_body_reads_as_no_github_login() {
     )]);
     let state = me::load(&env_in(dir.path()), &fetch, &MemoryStore::signed_in()).expect("load");
     match state {
-        AccountState::SignedIn { identity } => assert_eq!(identity.github_login, None),
+        AccountState::SignedIn { identity, .. } => assert_eq!(identity.github_login, None),
         other => panic!("expected signed-in, got {other:?}"),
     }
 }
@@ -234,7 +276,7 @@ fn network_away_serves_the_cached_identity_as_offline() {
     let down = Canned::new(vec![away()]);
     let state = me::load(&env, &down, &store).expect("offline load");
     match state {
-        AccountState::Offline { identity } => assert_eq!(identity.name, "Ada Lovelace"),
+        AccountState::Offline { identity, .. } => assert_eq!(identity.name, "Ada Lovelace"),
         other => panic!("expected offline, got {other:?}"),
     }
 }

--- a/crates/core/tests/me_client/sign_in_binding.rs
+++ b/crates/core/tests/me_client/sign_in_binding.rs
@@ -359,7 +359,7 @@ fn a_rotation_mid_read_still_settles_the_answer() {
         ok(200, None, &fixture_body(&["success", "body"])),
     ]);
     match me::load(&env, &fetch, &store).expect("load") {
-        AccountState::SignedIn { identity } => assert_eq!(identity.name, "Ada Lovelace"),
+        AccountState::SignedIn { identity, .. } => assert_eq!(identity.name, "Ada Lovelace"),
         other => panic!("a rotated sign-in is the same sign-in, got {other:?}"),
     }
     assert_eq!(
@@ -375,7 +375,7 @@ fn a_rotation_mid_read_still_settles_the_answer() {
     // read opened with, or the next read would find nothing.
     let down = Canned::new(vec![away()]);
     match me::load(&env, &down, &store).expect("offline load") {
-        AccountState::Offline { identity } => assert_eq!(identity.name, "Ada Lovelace"),
+        AccountState::Offline { identity, .. } => assert_eq!(identity.name, "Ada Lovelace"),
         other => panic!("the rotated read's cache is still this sign-in's, got {other:?}"),
     }
 }
@@ -635,7 +635,7 @@ fn a_rotation_by_another_call_leaves_the_identity_cache_readable() {
 
     let down = Canned::new(vec![away()]);
     match me::load(&env, &down, &store).expect("offline load") {
-        AccountState::Offline { identity } => assert_eq!(identity.name, "Ada Lovelace"),
+        AccountState::Offline { identity, .. } => assert_eq!(identity.name, "Ada Lovelace"),
         other => panic!("the cached identity outlives a rotation, got {other:?}"),
     }
 }
@@ -664,7 +664,7 @@ fn a_rotation_that_then_fails_leaves_the_identity_cache_readable() {
 
     let down = Canned::new(vec![away()]);
     match me::load(&env, &down, &store).expect("offline load") {
-        AccountState::Offline { identity } => assert_eq!(identity.name, "Ada Lovelace"),
+        AccountState::Offline { identity, .. } => assert_eq!(identity.name, "Ada Lovelace"),
         other => panic!("the next read still has that generation, got {other:?}"),
     }
 }

--- a/ui/src/bindings.ts
+++ b/ui/src/bindings.ts
@@ -253,8 +253,8 @@ export const commands = {
 	accountLoginPoll: (deviceCode: string) => typedError<string, string>(__TAURI_INVOKE("account_login_poll", { deviceCode })),
 	accountLogout: () => typedError<null, string>(__TAURI_INVOKE("account_logout")),
 	mineSubmitPreflight: (path: string) => typedError<SubmitPreflight, string>(__TAURI_INVOKE("mine_submit_preflight", { path })),
-	mineSubmit: (repo: string) => typedError<SubmittedView, string>(__TAURI_INVOKE("mine_submit", { repo })),
-	mineSubmissions: () => typedError<SubmissionRow[], string>(__TAURI_INVOKE("mine_submissions")),
+	mineSubmit: (repo: string) => typedError<SubmittedView, AccountCallRefused>(__TAURI_INVOKE("mine_submit", { repo })),
+	mineSubmissions: () => typedError<SubmissionRow[], AccountCallRefused>(__TAURI_INVOKE("mine_submissions")),
 	packageVersions: (scope: Scope, kind: ItemKind, name: string) => typedError<VersionRow[], string>(__TAURI_INVOKE("package_versions", { scope, kind, name })),
 	/**
 	 *  Bring one package current and apply — the Updates page's per-package
@@ -356,6 +356,24 @@ export type AboutView = {
 	found: AboutFound[],
 	findings: CatalogFinding[],
 };
+
+/**
+ *  Why a call made under the stored sign-in did not answer.
+ * 
+ *  Expiry is the account ending, not one action failing: the credential
+ *  is gone, and every surface built on the account has to say so. As a
+ *  message it reaches only the surface that asked, which is how a person
+ *  gets told their sign-in expired by a dialog while the sidebar goes on
+ *  naming them. So it is a shape the caller can act on rather than a
+ *  sentence it would have to recognise by its words.
+ */
+export type AccountCallRefused = 
+/**
+ *  The sign-in is dead and the credential has been cleared. The
+ *  message is the whole sentence, the remedy included, because the
+ *  surface that shows it has nothing else to say.
+ */
+{ kind: "expired"; message: string } | { kind: "failed"; message: string };
 
 /**
  *  What the account surfaces render, every one of them settled: the UI

--- a/ui/src/bindings.ts
+++ b/ui/src/bindings.ts
@@ -381,7 +381,7 @@ export type AccountCallRefused = { kind: "expired"; message: string } | { kind: 
  *  What the account surfaces render, every one of them settled: the UI
  *  holds its own "not read yet" until the first answer comes back.
  * 
- *  The states that hold a credential carry `sign_in`, the name of the
+ *  The states about a credential carry `sign_in`, the name of the
  *  sign-in they were read under. It is [`Credential::sign_in`]: minted
  *  once when a sign-in is committed, carried through every rotation, and
  *  replaced only by another sign-in. A caller holding an earlier answer
@@ -394,7 +394,7 @@ export type AccountState = { state: "signed-out" } | { state: "signed-in"; ident
 /**  The server could not be asked; the identity is the last good fetch. */
 { state: "offline"; identity: Identity; sign_in: string } | 
 /**  The credential is dead server-side — signing in again is the fix. */
-{ state: "expired" };
+{ state: "expired"; sign_in: string };
 
 export type AccountStatus = {
 	state: AccountState,

--- a/ui/src/bindings.ts
+++ b/ui/src/bindings.ts
@@ -250,7 +250,7 @@ export const commands = {
 	accountStatus: () => typedError<AccountStatus, string>(__TAURI_INVOKE("account_status")),
 	accountLoginStart: () => typedError<LoginStart, string>(__TAURI_INVOKE("account_login_start")),
 	/**  One poll; the frontend owns the timer so a closed dialog stops asking. */
-	accountLoginPoll: (deviceCode: string) => typedError<string, string>(__TAURI_INVOKE("account_login_poll", { deviceCode })),
+	accountLoginPoll: (deviceCode: string) => typedError<LoginPoll, string>(__TAURI_INVOKE("account_login_poll", { deviceCode })),
 	accountLogout: () => typedError<null, string>(__TAURI_INVOKE("account_logout")),
 	mineSubmitPreflight: (path: string) => typedError<SubmitPreflight, string>(__TAURI_INVOKE("mine_submit_preflight", { path })),
 	mineSubmit: (repo: string) => typedError<SubmittedView, AccountCallRefused>(__TAURI_INVOKE("mine_submit", { repo })),
@@ -380,10 +380,19 @@ export type AccountCallRefused = { kind: "expired"; message: string } | { kind: 
 /**
  *  What the account surfaces render, every one of them settled: the UI
  *  holds its own "not read yet" until the first answer comes back.
+ * 
+ *  The states that hold a credential carry `sign_in`, the name of the
+ *  sign-in they were read under. It is [`Credential::sign_in`]: minted
+ *  once when a sign-in is committed, carried through every rotation, and
+ *  replaced only by another sign-in. A caller holding an earlier answer
+ *  compares it to tell the credential it has from one that replaced it,
+ *  which no part of the identity can answer — a rename leaves the same
+ *  credential, and signing in again as the same person leaves a
+ *  different one under the same name.
  */
-export type AccountState = { state: "signed-out" } | { state: "signed-in"; identity: Identity } | 
+export type AccountState = { state: "signed-out" } | { state: "signed-in"; identity: Identity; sign_in: string } | 
 /**  The server could not be asked; the identity is the last good fetch. */
-{ state: "offline"; identity: Identity } | 
+{ state: "offline"; identity: Identity; sign_in: string } | 
 /**  The credential is dead server-side — signing in again is the fix. */
 { state: "expired" };
 
@@ -1549,6 +1558,16 @@ export type Line = {
 };
 
 export type LineKind = "context" | "add" | "remove";
+
+/**
+ *  Where one poll of the device flow left the sign-in.
+ * 
+ *  `Signed` carries the name minted for the credential just stored, the
+ *  same one a later read of this account answers with. It is here so the
+ *  caller holds a named credential from the moment one exists, rather
+ *  than an unnamed one until the read that follows names it.
+ */
+export type LoginPoll = { kind: "pending" } | { kind: "slow-down" } | { kind: "signed"; sign_in: string };
 
 export type LoginStart = {
 	deviceCode: string,

--- a/ui/src/bindings.ts
+++ b/ui/src/bindings.ts
@@ -360,20 +360,22 @@ export type AboutView = {
 /**
  *  Why a call made under the stored sign-in did not answer.
  * 
- *  Expiry is the account ending, not one action failing: the credential
- *  is gone, and every surface built on the account has to say so. As a
+ *  Expiry is the account ending, not one action failing: the sign-in is
+ *  dead, and every surface built on the account has to say so. As a
  *  message it reaches only the surface that asked, which is how a person
  *  gets told their sign-in expired by a dialog while the sidebar goes on
  *  naming them. So it is a shape the caller can act on rather than a
  *  sentence it would have to recognise by its words.
+ * 
+ *  `Expired`'s message is the whole sentence, the remedy included,
+ *  because the surface that shows it has nothing else to say. What
+ *  became of the local copy is the producer's to state in that sentence,
+ *  which says so when the copy could not be removed. It is named here
+ *  rather than documented on the variant because specta hoists a
+ *  variant's doc above the whole union, where it would read as
+ *  describing `Failed` too.
  */
-export type AccountCallRefused = 
-/**
- *  The sign-in is dead and the credential has been cleared. The
- *  message is the whole sentence, the remedy included, because the
- *  surface that shows it has nothing else to say.
- */
-{ kind: "expired"; message: string } | { kind: "failed"; message: string };
+export type AccountCallRefused = { kind: "expired"; message: string } | { kind: "failed"; message: string };
 
 /**
  *  What the account surfaces render, every one of them settled: the UI

--- a/ui/src/components/account-section.dom.test.tsx
+++ b/ui/src/components/account-section.dom.test.tsx
@@ -100,7 +100,7 @@ const press = async (host: HTMLElement, label: string) => {
 const SETTLED: [string, AccountState][] = [
   ["signed-in", { kind: "signed-in", identity: ADA, signIn: SIGN_IN }],
   ["signed-out", { kind: "signed-out" }],
-  ["expired", { kind: "expired" }],
+  ["expired", { kind: "expired", signIn: SIGN_IN }],
   ["offline", { kind: "offline", identity: ADA, signIn: SIGN_IN }],
 ];
 
@@ -183,7 +183,7 @@ describe("the state the section draws", () => {
   // The other half of that bug: `hasCredential` is false for expired, so a
   // rejected credential drew as a plain signed-out account.
   it("says a rejected credential was rejected, not signed out", () => {
-    const host = show({ account: { kind: "expired" } });
+    const host = show({ account: { kind: "expired", signIn: SIGN_IN } });
     expect(host.textContent).toContain(ACCOUNT_EXPIRED_TITLE);
     expect(host.textContent).not.toContain(ACCOUNT_SIGNED_OUT_NOTE);
     expect(offered(host)).toEqual([ACCOUNT_SIGN_IN_AGAIN_LABEL]);
@@ -297,7 +297,7 @@ describe("signing in and out", () => {
   });
 
   it("starts it again from a credential the server rejected", async () => {
-    const host = show({ account: { kind: "expired" } });
+    const host = show({ account: { kind: "expired", signIn: SIGN_IN } });
     await press(host, ACCOUNT_SIGN_IN_AGAIN_LABEL);
     expect(act.signIn).toHaveBeenCalledTimes(1);
   });

--- a/ui/src/components/account-section.dom.test.tsx
+++ b/ui/src/components/account-section.dom.test.tsx
@@ -29,6 +29,10 @@ import { type AccountState, useAccountStore } from "@/stores/account";
 import { mount } from "@/test/dom";
 import { AccountSection } from "./account-section";
 
+/** The name core mints for a sign-in; two answers about one
+ *  credential carry the same one. */
+const SIGN_IN = "sign-in-ada";
+
 vi.mock("@/bindings", () => ({ commands: {} }));
 
 // The provider's account id is an opaque number, not a handle. Every
@@ -94,15 +98,17 @@ const press = async (host: HTMLElement, label: string) => {
 };
 
 const SETTLED: [string, AccountState][] = [
-  ["signed-in", { kind: "signed-in", identity: ADA }],
+  ["signed-in", { kind: "signed-in", identity: ADA, signIn: SIGN_IN }],
   ["signed-out", { kind: "signed-out" }],
   ["expired", { kind: "expired" }],
-  ["offline", { kind: "offline", identity: ADA }],
+  ["offline", { kind: "offline", identity: ADA, signIn: SIGN_IN }],
 ];
 
 describe("the state the section draws", () => {
   it("names the account and offers a sign-out when signed in", () => {
-    const host = show({ account: { kind: "signed-in", identity: ADA } });
+    const host = show({
+      account: { kind: "signed-in", identity: ADA, signIn: SIGN_IN },
+    });
     expect(host.textContent).toContain(ADA.name);
     expect(initial(host)).toBe("A");
     expect(offered(host)).toEqual([ACCOUNT_SIGN_OUT_LABEL]);
@@ -117,7 +123,9 @@ describe("the state the section draws", () => {
   // one part of unbounded length, so it is the part that is cut off.
   it("cuts a long name off rather than widening the row", () => {
     const long = { name: "A".repeat(200), githubLogin: "1234567" };
-    const host = show({ account: { kind: "signed-in", identity: long } });
+    const host = show({
+      account: { kind: "signed-in", identity: long, signIn: SIGN_IN },
+    });
     // jsdom lays nothing out, so the class carrying the rule is what can be
     // checked: the element holding the name is the one that gives.
     const named = [...host.querySelectorAll("span")].find(
@@ -130,7 +138,9 @@ describe("the state the section draws", () => {
   // A credential in the keychain is not a person: the section may say it is
   // signed in, but it must not put a name to an account nobody has named.
   it("names nobody when the credential has no identity yet", () => {
-    const host = show({ account: { kind: "signed-in", identity: null } });
+    const host = show({
+      account: { kind: "signed-in", identity: null, signIn: SIGN_IN },
+    });
     expect(host.textContent).toContain(ACCOUNT_SIGNED_IN_LABEL);
     expect(host.textContent).not.toContain(ADA.name);
     expect(initial(host)).toBe("");
@@ -141,7 +151,9 @@ describe("the state the section draws", () => {
   // stand-in: falling back to it would print an opaque number as a person.
   it("names nobody when the server sent a blank name", () => {
     const blank = { name: "  ", githubLogin: "1234567" };
-    const host = show({ account: { kind: "signed-in", identity: blank } });
+    const host = show({
+      account: { kind: "signed-in", identity: blank, signIn: SIGN_IN },
+    });
     expect(host.textContent).toContain(ACCOUNT_SIGNED_IN_LABEL);
     expect(host.textContent).not.toContain(blank.githubLogin);
     expect(initial(host)).toBe("");
@@ -150,7 +162,9 @@ describe("the state the section draws", () => {
   // The bug this section had: `hasCredential` is true for offline, so an
   // unconfirmed credential drew as a confirmed sign-in.
   it("marks an unconfirmed credential offline, not signed in", () => {
-    const host = show({ account: { kind: "offline", identity: ADA } });
+    const host = show({
+      account: { kind: "offline", identity: ADA, signIn: SIGN_IN },
+    });
     expect(host.textContent).toContain(ADA.name);
     expect(host.textContent).toContain(ACCOUNT_OFFLINE_LABEL);
     expect(host.textContent).toContain(ACCOUNT_OFFLINE_TITLE);
@@ -160,7 +174,9 @@ describe("the state the section draws", () => {
   // The credential is still this machine's to drop, and dropping it is what
   // stops the app asking the server about it.
   it("still offers a sign-out while offline", () => {
-    const host = show({ account: { kind: "offline", identity: ADA } });
+    const host = show({
+      account: { kind: "offline", identity: ADA, signIn: SIGN_IN },
+    });
     expect(offered(host)).toEqual([ACCOUNT_SIGN_OUT_LABEL]);
   });
 
@@ -237,7 +253,7 @@ describe("the retry a failed read gets", () => {
   // state keeps its own row and the failure gets a second one.
   it("sits beside a state that did land", () => {
     const host = show({
-      account: { kind: "offline", identity: ADA },
+      account: { kind: "offline", identity: ADA, signIn: SIGN_IN },
       readError: "keychain locked",
     });
     expect(host.textContent).toContain("keychain locked");
@@ -267,7 +283,9 @@ describe("the retry a failed read gets", () => {
 
 describe("signing in and out", () => {
   it("signs out from the row that names the account", async () => {
-    const host = show({ account: { kind: "signed-in", identity: ADA } });
+    const host = show({
+      account: { kind: "signed-in", identity: ADA, signIn: SIGN_IN },
+    });
     await press(host, ACCOUNT_SIGN_OUT_LABEL);
     expect(act.signOut).toHaveBeenCalledTimes(1);
   });

--- a/ui/src/components/marketplaces/mine-submit-dialog.dom.test.tsx
+++ b/ui/src/components/marketplaces/mine-submit-dialog.dom.test.tsx
@@ -3,6 +3,7 @@
 // the read fails with no identity to fall back on, so the account is
 // still unknown and the dialog offers a sign-in. The reason it is
 // offering one has to be on screen with it.
+import userEvent from "@testing-library/user-event";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { commands, type MineRow, type SubmitPreflight } from "@/bindings";
 import { useAccountStore } from "@/stores/account";
@@ -48,6 +49,43 @@ const preflight: SubmitPreflight = {
 };
 
 const UNREACHABLE = "kendex.ai could not be reached";
+const EXPIRED =
+  "your sign-in has expired (invalid_grant) — run `kendex login` again";
+
+const button = (label: string) =>
+  Array.from(document.body.querySelectorAll("button")).find(
+    (candidate) => candidate.textContent === label,
+  );
+
+const JANE = { name: "Jane", githubLogin: "jane" };
+
+/** Signed in, with the folder ready to go: what the dialog looks like the
+ *  moment before the submit that meets the refusal under test. */
+const readyToSubmit = () => {
+  vi.clearAllMocks();
+  vi.mocked(commands.mineSubmitPreflight).mockResolvedValue({
+    status: "ok",
+    data: preflight,
+  } as never);
+  useAccountStore.setState({
+    account: { kind: "signed-in", identity: JANE },
+    error: null,
+    readError: null,
+    submissions: [],
+    signingIn: false,
+    userCode: null,
+  });
+};
+
+const showDialog = () =>
+  mount(
+    <MineSubmitDialog
+      path={row.path}
+      open={true}
+      onOpenChange={() => {}}
+      onSubmitted={() => {}}
+    />,
+  );
 
 describe("the submit dialog when the account could not be read", () => {
   beforeEach(() => {
@@ -101,5 +139,74 @@ describe("the submit dialog when the account could not be read", () => {
 
     const alert = document.body.querySelector('[role="alert"]');
     expect(alert?.textContent).toBe("the approval was denied");
+  });
+});
+
+// The submit is the one place a person meets an expired sign-in on this
+// tab, and the credential is already gone by the time the refusal lands.
+// Read as a message it would leave the dialog offering a submit that
+// cannot go out, and the sidebar naming an account nobody is signed in
+// to any more.
+describe("a submit that meets an expired sign-in", () => {
+  beforeEach(() => {
+    readyToSubmit();
+    vi.mocked(commands.mineSubmit).mockResolvedValue({
+      status: "error",
+      error: { kind: "expired", message: EXPIRED },
+    } as never);
+  });
+
+  const submit = async () => {
+    showDialog();
+    await settle();
+    const offered = button("Submit");
+    expect(offered).toBeDefined();
+    await userEvent.click(offered as HTMLButtonElement);
+    await settle();
+  };
+
+  it("moves the account to expired and drops the rows with it", async () => {
+    await submit();
+    expect(useAccountStore.getState().account).toEqual({ kind: "expired" });
+    expect(useAccountStore.getState().submissions).toBeNull();
+  });
+
+  it("stops offering the submit and offers the sign-in that fixes it", async () => {
+    await submit();
+    expect(button("Submit")).toBeUndefined();
+    expect(button("Sign in with GitHub")).toBeDefined();
+  });
+
+  it("says what happened, in the sentence the backend sent", async () => {
+    await submit();
+    const alert = document.body.querySelector('[role="alert"]');
+    expect(alert?.textContent).toBe(EXPIRED);
+  });
+});
+
+// Everything else a submit can be refused for is about the submit. The
+// account is not news, and signing the person out over a repository the
+// server would not take is a lie the sidebar would then tell.
+describe("a submit refused for any other reason", () => {
+  it("shows the refusal and leaves the account where it was", async () => {
+    const REFUSED = "you cannot push to jane/team-skills";
+    readyToSubmit();
+    vi.mocked(commands.mineSubmit).mockResolvedValue({
+      status: "error",
+      error: { kind: "failed", message: REFUSED },
+    } as never);
+    showDialog();
+    await settle();
+    await userEvent.click(button("Submit") as HTMLButtonElement);
+    await settle();
+
+    expect(document.body.querySelector('[role="alert"]')?.textContent).toBe(
+      REFUSED,
+    );
+    expect(useAccountStore.getState().account).toEqual({
+      kind: "signed-in",
+      identity: JANE,
+    });
+    expect(useAccountStore.getState().submissions).toEqual([]);
   });
 });

--- a/ui/src/components/marketplaces/mine-submit-dialog.dom.test.tsx
+++ b/ui/src/components/marketplaces/mine-submit-dialog.dom.test.tsx
@@ -10,6 +10,10 @@ import { useAccountStore } from "@/stores/account";
 import { mount, settle } from "@/test/dom";
 import { MineSubmitDialog } from "./mine-submit-dialog";
 
+/** The name core mints for a sign-in; two answers about one
+ *  credential carry the same one. */
+const SIGN_IN = "sign-in-ada";
+
 vi.mock("@/bindings", () => ({
   commands: {
     mineSubmit: vi.fn(),
@@ -69,7 +73,7 @@ const readyToSubmit = () => {
     data: preflight,
   } as never);
   useAccountStore.setState({
-    account: { kind: "signed-in", identity: JANE },
+    account: { kind: "signed-in", identity: JANE, signIn: SIGN_IN },
     error: null,
     readError: null,
     submissions: [],
@@ -255,6 +259,7 @@ describe("a submit refused for any other reason", () => {
     expect(useAccountStore.getState().account).toEqual({
       kind: "signed-in",
       identity: JANE,
+      signIn: SIGN_IN,
     });
     expect(useAccountStore.getState().submissions).toEqual([]);
   });

--- a/ui/src/components/marketplaces/mine-submit-dialog.dom.test.tsx
+++ b/ui/src/components/marketplaces/mine-submit-dialog.dom.test.tsx
@@ -173,7 +173,10 @@ describe("a submit that meets an expired sign-in", () => {
 
   it("moves the account to expired and drops the rows with it", async () => {
     await submit();
-    expect(useAccountStore.getState().account).toEqual({ kind: "expired" });
+    expect(useAccountStore.getState().account).toEqual({
+      kind: "expired",
+      signIn: SIGN_IN,
+    });
     expect(useAccountStore.getState().submissions).toBeNull();
   });
 

--- a/ui/src/components/marketplaces/mine-submit-dialog.dom.test.tsx
+++ b/ui/src/components/marketplaces/mine-submit-dialog.dom.test.tsx
@@ -14,6 +14,7 @@ vi.mock("@/bindings", () => ({
   commands: {
     mineSubmit: vi.fn(),
     mineSubmitPreflight: vi.fn(),
+    accountLoginStart: vi.fn(),
     openUrl: vi.fn(),
   },
 }));
@@ -142,11 +143,12 @@ describe("the submit dialog when the account could not be read", () => {
   });
 });
 
-// The submit is the one place a person meets an expired sign-in on this
-// tab, and the credential is already gone by the time the refusal lands.
-// Read as a message it would leave the dialog offering a submit that
-// cannot go out, and the sidebar naming an account nobody is signed in
-// to any more.
+// Two things on this tab meet an expired sign-in. This is the one a
+// person meets directly, with the refusal's own sentence to show for it;
+// the submissions poll meets it with nothing of its own. Read as a
+// message it would leave the dialog offering a submit that cannot go
+// out, and the sidebar naming an account nobody is signed in to any
+// more.
 describe("a submit that meets an expired sign-in", () => {
   beforeEach(() => {
     readyToSubmit();
@@ -181,6 +183,53 @@ describe("a submit that meets an expired sign-in", () => {
     await submit();
     const alert = document.body.querySelector('[role="alert"]');
     expect(alert?.textContent).toBe(EXPIRED);
+  });
+});
+
+// The refusal offers a sign-in, and the sign-in can fail in its own
+// right. Two sentences then want the one alert, and the expiry is the
+// wrong one: it has been acted on, its remedy is the button just
+// pressed, and what stopped the person now is the device flow.
+describe("the sign-in the expired dialog offers", () => {
+  const UNSTARTABLE = "kendex.ai could not start the sign-in";
+
+  const submitThenSignIn = async () => {
+    readyToSubmit();
+    vi.mocked(commands.mineSubmit).mockResolvedValue({
+      status: "error",
+      error: { kind: "expired", message: EXPIRED },
+    } as never);
+    showDialog();
+    await settle();
+    await userEvent.click(button("Submit") as HTMLButtonElement);
+    await settle();
+    await userEvent.click(button("Sign in with GitHub") as HTMLButtonElement);
+    await settle();
+  };
+
+  it("shows the device flow's failure instead of the expiry it replaced", async () => {
+    vi.mocked(commands.accountLoginStart).mockResolvedValue({
+      status: "error",
+      error: UNSTARTABLE,
+    } as never);
+    await submitThenSignIn();
+
+    expect(document.body.querySelector('[role="alert"]')?.textContent).toBe(
+      UNSTARTABLE,
+    );
+  });
+
+  it("takes the expiry off the screen while the sign-in is out", async () => {
+    // Nothing has failed yet, so there is nothing to say. Left standing,
+    // the expiry would tell someone waiting on an approval to go and run
+    // the command that approval is replacing.
+    vi.mocked(commands.accountLoginStart).mockReturnValue(
+      new Promise(() => {}) as never,
+    );
+    await submitThenSignIn();
+
+    expect(document.body.querySelector('[role="alert"]')).toBeNull();
+    expect(button("Waiting for approval…")).toBeDefined();
   });
 });
 

--- a/ui/src/components/marketplaces/mine-submit-dialog.tsx
+++ b/ui/src/components/marketplaces/mine-submit-dialog.tsx
@@ -37,6 +37,7 @@ export function MineSubmitDialog({
   // this dialog offers a sign-in for. Without it the offer has no reason
   // on screen and points at a server that is already out of reach.
   const readError = useAccountStore((s) => s.readError);
+  const refused = useAccountStore((s) => s.refused);
   const [preflight, setPreflight] = useState<SubmitPreflight | null>(null);
   const [busy, setBusy] = useState(false);
   const [error, setError] = useState<string | null>(null);
@@ -63,7 +64,11 @@ export function MineSubmitDialog({
     void commands.mineSubmit(preflight.candidate).then((answer) => {
       setBusy(false);
       if (answer.status === "error") {
-        setError(answer.error);
+        setError(answer.error.message);
+        // An expired sign-in takes the offer away with it: the footer
+        // reads the account, so this dialog stops offering a submit
+        // nothing can carry and offers the sign-in that fixes it.
+        refused(answer.error);
         return;
       }
       setSubmitted(answer.data.status);

--- a/ui/src/components/marketplaces/mine-submit-dialog.tsx
+++ b/ui/src/components/marketplaces/mine-submit-dialog.tsx
@@ -151,7 +151,17 @@ export function MineSubmitDialog({
               {busy ? "Submitting…" : "Submit"}
             </Button>
           ) : (
-            <Button onClick={() => void signIn()} disabled={signingIn}>
+            <Button
+              onClick={() => {
+                // The refusal that offered this sign-in has been acted
+                // on, and the alert now belongs to the sign-in. Left
+                // standing it would outlive its own remedy and cover
+                // whatever the device flow has to say for itself.
+                setError(null);
+                void signIn();
+              }}
+              disabled={signingIn}
+            >
               {signingIn ? "Waiting for approval…" : "Sign in with GitHub"}
             </Button>
           )}

--- a/ui/src/components/marketplaces/mine-submit-dialog.tsx
+++ b/ui/src/components/marketplaces/mine-submit-dialog.tsx
@@ -38,6 +38,7 @@ export function MineSubmitDialog({
   // on screen and points at a server that is already out of reach.
   const readError = useAccountStore((s) => s.readError);
   const refused = useAccountStore((s) => s.refused);
+  const handovers = useAccountStore((s) => s.handovers);
   const [preflight, setPreflight] = useState<SubmitPreflight | null>(null);
   const [busy, setBusy] = useState(false);
   const [error, setError] = useState<string | null>(null);
@@ -61,14 +62,21 @@ export function MineSubmitDialog({
     if (!preflight?.candidate) return;
     setBusy(true);
     setError(null);
+    // The account this submit goes out under. What comes back is read
+    // against it, so an expiry that lands after the sign-in was replaced
+    // cannot end the account that replaced it.
+    const since = handovers();
     void commands.mineSubmit(preflight.candidate).then((answer) => {
       setBusy(false);
       if (answer.status === "error") {
+        // The refusal answers the submit this person pressed, so it is
+        // shown either way. Whether it is also news about the account is
+        // the store's to decide.
         setError(answer.error.message);
         // An expired sign-in takes the offer away with it: the footer
         // reads the account, so this dialog stops offering a submit
         // nothing can carry and offers the sign-in that fixes it.
-        refused(answer.error);
+        refused(answer.error, since);
         return;
       }
       setSubmitted(answer.data.status);

--- a/ui/src/components/marketplaces/mine-tab.dom.test.tsx
+++ b/ui/src/components/marketplaces/mine-tab.dom.test.tsx
@@ -80,7 +80,10 @@ it("moves the account to expired on a poll tick that meets a dead sign-in", asyn
   await settle();
 
   expect(commands.mineSubmissions).toHaveBeenCalledTimes(2);
-  expect(useAccountStore.getState().account).toEqual({ kind: "expired" });
+  expect(useAccountStore.getState().account).toEqual({
+    kind: "expired",
+    signIn: SIGN_IN,
+  });
   expect(useAccountStore.getState().submissions).toBeNull();
 });
 
@@ -94,7 +97,10 @@ it("stops polling once a tick has found the sign-in expired", async () => {
   } as never);
   mount(<MineTab />);
   await settle();
-  expect(useAccountStore.getState().account).toEqual({ kind: "expired" });
+  expect(useAccountStore.getState().account).toEqual({
+    kind: "expired",
+    signIn: SIGN_IN,
+  });
 
   // The interval itself, not the store guard behind it: without the
   // cleanup, or with the effect no longer keyed to holding a credential,

--- a/ui/src/components/marketplaces/mine-tab.dom.test.tsx
+++ b/ui/src/components/marketplaces/mine-tab.dom.test.tsx
@@ -1,0 +1,124 @@
+// @vitest-environment jsdom
+// The submissions poll is the only thing on this tab that keeps asking
+// after the page settles, and it shows nothing of its own: a tick that
+// found the sign-in dead used to be discarded, so a session could die
+// under an open window and every surface go on saying signed in.
+import { act } from "react";
+import { afterEach, beforeEach, expect, it, vi } from "vitest";
+import { commands } from "@/bindings";
+import { useAccountStore } from "@/stores/account";
+import { useMineStore } from "@/stores/mine";
+import { mount, settle } from "@/test/dom";
+import { MineTab } from "./mine-tab";
+
+vi.mock("@/bindings", () => ({
+  commands: {
+    mineSubmissions: vi.fn(),
+    mineSubmitPreflight: vi.fn(),
+    mineAuthoringDoc: vi.fn(),
+    pickFolder: vi.fn(),
+    openUrl: vi.fn(),
+  },
+}));
+
+const ADA = { name: "Ada Lovelace", githubLogin: "ada" };
+
+const ROW = {
+  repo: "ada/team-skills",
+  status: "pending",
+  statusReason: null,
+  headCommit: null,
+  indexedAt: null,
+};
+
+const EXPIRED =
+  "your sign-in has expired (invalid_grant) — run `kendex login` again";
+
+const answered = <T,>(data: T) => ({ status: "ok", data }) as never;
+
+// The tab's own rows are not what is under test: `load` is stubbed so the
+// mount reaches no command, and the tab renders its empty state while the
+// poll runs behind it.
+beforeEach(() => {
+  vi.useFakeTimers();
+  vi.clearAllMocks();
+  useMineStore.setState({ rows: [], load: async () => {} });
+  useAccountStore.setState({
+    account: { kind: "signed-in", identity: ADA },
+    error: null,
+    readError: null,
+    submissions: null,
+    signingIn: false,
+    userCode: null,
+  });
+});
+
+afterEach(() => vi.useRealTimers());
+
+// The interval the API names, exactly: a poll that meets the expiry is
+// the whole point, and a tick that never fires proves nothing.
+const POLL_MS = 60_000;
+
+it("moves the account to expired on a poll tick that meets a dead sign-in", async () => {
+  vi.mocked(commands.mineSubmissions).mockResolvedValue(answered([ROW]));
+  mount(<MineTab />);
+  await settle();
+  expect(useAccountStore.getState().submissions).toEqual([ROW]);
+
+  // The session dies between ticks, with nothing on this tab asking.
+  vi.mocked(commands.mineSubmissions).mockResolvedValue({
+    status: "error",
+    error: { kind: "expired", message: EXPIRED },
+  } as never);
+  await act(async () => {
+    vi.advanceTimersByTime(POLL_MS);
+  });
+  await settle();
+
+  expect(commands.mineSubmissions).toHaveBeenCalledTimes(2);
+  expect(useAccountStore.getState().account).toEqual({ kind: "expired" });
+  expect(useAccountStore.getState().submissions).toBeNull();
+});
+
+// Expiry is the credential ending, so the poll it stopped must not start
+// again: the effect is keyed to holding a credential, and expired holds
+// none.
+it("stops polling once a tick has found the sign-in expired", async () => {
+  vi.mocked(commands.mineSubmissions).mockResolvedValue({
+    status: "error",
+    error: { kind: "expired", message: EXPIRED },
+  } as never);
+  mount(<MineTab />);
+  await settle();
+  expect(useAccountStore.getState().account).toEqual({ kind: "expired" });
+
+  await act(async () => {
+    vi.advanceTimersByTime(POLL_MS * 3);
+  });
+  await settle();
+  expect(commands.mineSubmissions).toHaveBeenCalledTimes(1);
+});
+
+// A poll the server could not answer for any other reason says nothing
+// about the sign-in. Signing the person out over an outage would take the
+// tab away from them and lose the rows it was still showing.
+it("leaves the account alone when a tick fails for any other reason", async () => {
+  vi.mocked(commands.mineSubmissions).mockResolvedValue(answered([ROW]));
+  mount(<MineTab />);
+  await settle();
+
+  vi.mocked(commands.mineSubmissions).mockResolvedValue({
+    status: "error",
+    error: { kind: "failed", message: "kendex.ai could not be reached" },
+  } as never);
+  await act(async () => {
+    vi.advanceTimersByTime(POLL_MS);
+  });
+  await settle();
+
+  expect(useAccountStore.getState().account).toEqual({
+    kind: "signed-in",
+    identity: ADA,
+  });
+  expect(useAccountStore.getState().submissions).toEqual([ROW]);
+});

--- a/ui/src/components/marketplaces/mine-tab.dom.test.tsx
+++ b/ui/src/components/marketplaces/mine-tab.dom.test.tsx
@@ -11,6 +11,10 @@ import { useMineStore } from "@/stores/mine";
 import { mount, settle } from "@/test/dom";
 import { MineTab } from "./mine-tab";
 
+/** The name core mints for a sign-in; two answers about one
+ *  credential carry the same one. */
+const SIGN_IN = "sign-in-ada";
+
 vi.mock("@/bindings", () => ({
   commands: {
     mineSubmissions: vi.fn(),
@@ -44,7 +48,7 @@ beforeEach(() => {
   vi.clearAllMocks();
   useMineStore.setState({ rows: [], load: async () => {} });
   useAccountStore.setState({
-    account: { kind: "signed-in", identity: ADA },
+    account: { kind: "signed-in", identity: ADA, signIn: SIGN_IN },
     error: null,
     readError: null,
     submissions: null,
@@ -124,6 +128,7 @@ it("leaves the account alone when a tick fails for any other reason", async () =
   expect(useAccountStore.getState().account).toEqual({
     kind: "signed-in",
     identity: ADA,
+    signIn: SIGN_IN,
   });
   expect(useAccountStore.getState().submissions).toEqual([ROW]);
 });

--- a/ui/src/components/marketplaces/mine-tab.dom.test.tsx
+++ b/ui/src/components/marketplaces/mine-tab.dom.test.tsx
@@ -92,6 +92,11 @@ it("stops polling once a tick has found the sign-in expired", async () => {
   await settle();
   expect(useAccountStore.getState().account).toEqual({ kind: "expired" });
 
+  // The interval itself, not the store guard behind it: without the
+  // cleanup, or with the effect no longer keyed to holding a credential,
+  // a timer is still armed here and the advance below finds it.
+  expect(vi.getTimerCount()).toBe(0);
+
   await act(async () => {
     vi.advanceTimersByTime(POLL_MS * 3);
   });

--- a/ui/src/components/sidebar-account.dom.test.tsx
+++ b/ui/src/components/sidebar-account.dom.test.tsx
@@ -19,6 +19,10 @@ import { useNavStore } from "@/stores/nav";
 import { mount } from "@/test/dom";
 import { SidebarAccount } from "./sidebar-account";
 
+/** The name core mints for a sign-in; two answers about one
+ *  credential carry the same one. */
+const SIGN_IN = "sign-in-ada";
+
 vi.mock("@/bindings", () => ({ commands: {} }));
 
 // The provider's account id is an opaque number, not a handle. Every
@@ -53,10 +57,10 @@ const spoken = (host: HTMLElement): string =>
 
 /** The states a read can settle on, each named for the message it fails in. */
 const SETTLED: [string, AccountState][] = [
-  ["signed-in", { kind: "signed-in", identity: ADA }],
+  ["signed-in", { kind: "signed-in", identity: ADA, signIn: SIGN_IN }],
   ["signed-out", { kind: "signed-out" }],
   ["expired", { kind: "expired" }],
-  ["offline", { kind: "offline", identity: ADA }],
+  ["offline", { kind: "offline", identity: ADA, signIn: SIGN_IN }],
 ];
 
 beforeEach(() => {
@@ -93,7 +97,7 @@ describe("what the account row draws", () => {
   });
 
   it("shows the name and its initial when signed in", () => {
-    const host = show({ kind: "signed-in", identity: ADA });
+    const host = show({ kind: "signed-in", identity: ADA, signIn: SIGN_IN });
     expect(seen(host)).toContain(ADA.name);
     expect(seen(host)).toContain("A");
     expect(seen(host)).not.toContain(ACCOUNT_OFFLINE_LABEL);
@@ -112,22 +116,22 @@ describe("what the account row draws", () => {
   // signed in, but it must not put a name or a letter to an account the
   // server has not named.
   it("names nobody when the credential has no identity yet", () => {
-    expect(seen(show({ kind: "signed-in", identity: null }))).toBe(
-      ACCOUNT_SIGNED_IN_LABEL,
-    );
+    expect(
+      seen(show({ kind: "signed-in", identity: null, signIn: SIGN_IN })),
+    ).toBe(ACCOUNT_SIGNED_IN_LABEL);
   });
 
   // The server answers with a String, so a blank one is a name it does not
   // have rather than a field it did not send.
   it("names nobody when the server sent a blank name", () => {
     const blank = { name: "  ", githubLogin: "1234567" };
-    expect(seen(show({ kind: "signed-in", identity: blank }))).toBe(
-      ACCOUNT_SIGNED_IN_LABEL,
-    );
+    expect(
+      seen(show({ kind: "signed-in", identity: blank, signIn: SIGN_IN })),
+    ).toBe(ACCOUNT_SIGNED_IN_LABEL);
   });
 
   it("reads as offline when the credential could not be confirmed", () => {
-    const host = show({ kind: "offline", identity: ADA });
+    const host = show({ kind: "offline", identity: ADA, signIn: SIGN_IN });
     expect(seen(host)).toContain(ADA.name);
     expect(seen(host)).toContain(ACCOUNT_OFFLINE_LABEL);
   });
@@ -185,10 +189,18 @@ describe("how the sentence behind a row reaches a person", () => {
 // mean something the row cannot show, and where the click goes for the rest.
 describe("the sentence behind each row", () => {
   it.each([
-    ["signed-in", { kind: "signed-in", identity: ADA }, ACCOUNT_ROW_TITLE],
+    [
+      "signed-in",
+      { kind: "signed-in", identity: ADA, signIn: SIGN_IN },
+      ACCOUNT_ROW_TITLE,
+    ],
     ["signed-out", { kind: "signed-out" }, ACCOUNT_ROW_TITLE],
     ["expired", { kind: "expired" }, ACCOUNT_EXPIRED_TITLE],
-    ["offline", { kind: "offline", identity: ADA }, ACCOUNT_OFFLINE_TITLE],
+    [
+      "offline",
+      { kind: "offline", identity: ADA, signIn: SIGN_IN },
+      ACCOUNT_OFFLINE_TITLE,
+    ],
   ] as [string, AccountState, string][])(
     "says what the %s row means",
     (_state, account, sentence) => {

--- a/ui/src/components/sidebar-account.dom.test.tsx
+++ b/ui/src/components/sidebar-account.dom.test.tsx
@@ -59,7 +59,7 @@ const spoken = (host: HTMLElement): string =>
 const SETTLED: [string, AccountState][] = [
   ["signed-in", { kind: "signed-in", identity: ADA, signIn: SIGN_IN }],
   ["signed-out", { kind: "signed-out" }],
-  ["expired", { kind: "expired" }],
+  ["expired", { kind: "expired", signIn: SIGN_IN }],
   ["offline", { kind: "offline", identity: ADA, signIn: SIGN_IN }],
 ];
 
@@ -93,7 +93,9 @@ describe("what the account row draws", () => {
   });
 
   it("asks for a fresh sign-in when the credential is expired", () => {
-    expect(seen(show({ kind: "expired" }))).toBe(ACCOUNT_SIGN_IN_AGAIN_LABEL);
+    expect(seen(show({ kind: "expired", signIn: SIGN_IN }))).toBe(
+      ACCOUNT_SIGN_IN_AGAIN_LABEL,
+    );
   });
 
   it("shows the name and its initial when signed in", () => {
@@ -195,7 +197,7 @@ describe("the sentence behind each row", () => {
       ACCOUNT_ROW_TITLE,
     ],
     ["signed-out", { kind: "signed-out" }, ACCOUNT_ROW_TITLE],
-    ["expired", { kind: "expired" }, ACCOUNT_EXPIRED_TITLE],
+    ["expired", { kind: "expired", signIn: SIGN_IN }, ACCOUNT_EXPIRED_TITLE],
     [
       "offline",
       { kind: "offline", identity: ADA, signIn: SIGN_IN },

--- a/ui/src/dev/mock-account.test.ts
+++ b/ui/src/dev/mock-account.test.ts
@@ -67,11 +67,37 @@ describe("the account states the dev bridge can answer as", () => {
 
   it("signs in through the device flow and out again", async () => {
     await mockInvoke("account_login_start");
-    expect(await mockInvoke("account_login_poll")).toBe("pending");
-    expect(await mockInvoke("account_login_poll")).toBe("signed");
-    expect((await read()).account).toEqual(MOCK_ACCOUNTS["signed-in"]);
+    expect(await mockInvoke("account_login_poll")).toEqual({ kind: "pending" });
+    const approved = (await mockInvoke("account_login_poll")) as {
+      kind: string;
+      sign_in: string;
+    };
+    expect(approved.kind).toBe("signed");
+    // The approval names the credential it stored, and the read that
+    // follows has to answer with that same name or the store counts a
+    // second change of hands for one sign-in.
+    const settled = (await read()).account;
+    expect(settled).toEqual({
+      ...MOCK_ACCOUNTS["signed-in"],
+      signIn: approved.sign_in,
+    });
     await mockInvoke("account_logout");
     expect((await read()).account).toEqual(MOCK_ACCOUNTS["signed-out"]);
+  });
+
+  // Signing in again is a different credential, which is what makes the
+  // re-sign-in case reachable in the harness at all.
+  it("mints a new name for every sign-in", async () => {
+    const approve = async () => {
+      await mockInvoke("account_login_start");
+      await mockInvoke("account_login_poll");
+      const signed = (await mockInvoke("account_login_poll")) as {
+        sign_in: string;
+      };
+      return signed.sign_in;
+    };
+    const first = await approve();
+    expect(await approve()).not.toBe(first);
   });
 });
 
@@ -120,8 +146,10 @@ describe("the expiry the dev URL arms", () => {
 
     // The sign-in the dialog offers, and the submit that works after it.
     await mockInvoke("account_login_start");
-    expect(await mockInvoke("account_login_poll")).toBe("pending");
-    expect(await mockInvoke("account_login_poll")).toBe("signed");
+    await mockInvoke("account_login_poll");
+    expect(await mockInvoke("account_login_poll")).toMatchObject({
+      kind: "signed",
+    });
     expect((await answerOf("mine_submit")).answer).toMatchObject({
       status: "pending",
     });

--- a/ui/src/dev/mock-account.test.ts
+++ b/ui/src/dev/mock-account.test.ts
@@ -9,11 +9,12 @@ import {
 import { mockInvoke } from "./mock";
 import {
   accountFromUrl,
-  callsExpiredFromUrl,
+  EXPIRING_CALLS,
+  expiringCallFromUrl,
   isSignedIn,
   MOCK_ACCOUNT_NAMES,
   MOCK_ACCOUNTS,
-  setCallsExpired,
+  setExpiringCall,
   setMockAccount,
   UNREADABLE,
 } from "./mock-account";
@@ -74,57 +75,97 @@ describe("the account states the dev bridge can answer as", () => {
   });
 });
 
-// A refusal the harness sends as a bare string leaves every consumer
-// reading `answer.error.message` with undefined and its surface blank,
-// and the name-matching test above cannot see it.
-describe("how the calls made under the sign-in refuse", () => {
-  const refusalOf = (command: string) =>
-    mockInvoke(command, { repo: "jane/team-skills" }).then(
-      () => null,
-      (refusal: unknown) => refusal,
+// A payload of the right shape proves nothing about whether the flow it
+// belongs to can be walked, and a bare string leaves every consumer
+// reading `answer.error.message` with undefined. What the harness owes is
+// the sequence: reach the submit, meet the expiry there, take the sign-in
+// it offers, and submit again.
+describe("the expiry the dev URL arms", () => {
+  const REPO = "jane/team-skills";
+
+  const answerOf = (
+    command: string,
+  ): Promise<{ answer?: unknown; refusal?: unknown }> =>
+    mockInvoke(command, { repo: REPO }).then(
+      (answer: unknown) => ({ answer }),
+      (refusal: unknown) => ({ refusal }),
     );
 
-  const CALLS = ["mine_submit", "mine_submissions"];
+  const refusalOf = async (command: string) =>
+    (await answerOf(command)).refusal;
 
   beforeEach(() => {
     setMockAccount({ ok: MOCK_ACCOUNTS["signed-in"] });
-    setCallsExpired(false);
+    setExpiringCall(null);
   });
 
-  afterEach(() => setCallsExpired(false));
+  afterEach(() => setExpiringCall(null));
 
-  it("names the sentence and the kind a consumer reads", async () => {
-    setCallsExpired(true);
-    for (const command of CALLS) {
-      const refusal = await refusalOf(command);
-      expect(refusal, command).toMatchObject({ kind: "expired" });
-      expect((refusal as AccountCallRefused).message, command).toContain(
-        "kendex login",
-      );
-    }
+  it("carries a person from a working submit through expiry and back", async () => {
+    setExpiringCall("mine_submit");
+
+    // The tab polls its submissions on mount. That is not the call the
+    // expiry is on, so it answers and leaves the submit reachable.
+    expect((await answerOf("mine_submissions")).answer).toHaveLength(1);
+    expect(isSignedIn()).toBe(true);
+
+    const refusal = await refusalOf("mine_submit");
+    expect(refusal).toMatchObject({ kind: "expired" });
+    expect((refusal as AccountCallRefused).message).toContain("kendex login");
+
+    // The account does not revive underneath it: the credential went with
+    // the sign-in, so the read that follows says signed out.
+    expect(isSignedIn()).toBe(false);
+    expect(await commandState()).toBe("signed-out");
+
+    // The sign-in the dialog offers, and the submit that works after it.
+    await mockInvoke("account_login_start");
+    expect(await mockInvoke("account_login_poll")).toBe("pending");
+    expect(await mockInvoke("account_login_poll")).toBe("signed");
+    expect((await answerOf("mine_submit")).answer).toMatchObject({
+      status: "pending",
+    });
   });
 
-  it("is about the call, not the account, with no credential to use", async () => {
+  // The poll meeting a dead sign-in is the tab's other new path, and it
+  // has to be reachable without a person pressing anything.
+  it("puts it on the poll instead when the poll is the call named", async () => {
+    setExpiringCall("mine_submissions");
+    expect(await refusalOf("mine_submissions")).toMatchObject({
+      kind: "expired",
+    });
+    expect(isSignedIn()).toBe(false);
+  });
+
+  it("spends the expiry on one call rather than every call after it", async () => {
+    setExpiringCall("mine_submit");
+    expect(await refusalOf("mine_submit")).toMatchObject({ kind: "expired" });
+    // Signed in again, the same call goes through: a scenario that never
+    // clears cannot show a recovery.
+    setMockAccount({ ok: MOCK_ACCOUNTS["signed-in"] });
+    expect((await answerOf("mine_submit")).answer).toMatchObject({
+      status: "pending",
+    });
+  });
+
+  it("refuses about the call, not the account, with no credential to use", async () => {
     setMockAccount({ ok: MOCK_ACCOUNTS["signed-out"] });
-    for (const command of CALLS) {
+    for (const command of EXPIRING_CALLS) {
       expect(await refusalOf(command), command).toMatchObject({
         kind: "failed",
       });
     }
   });
 
-  // Submit is gated on the read saying signed in, so the expired refusal
-  // is reachable only while the read still says a credential is held.
-  it("meets the expiry under a read that still says signed in", async () => {
-    setCallsExpired(true);
-    expect(isSignedIn()).toBe(true);
-    expect(await refusalOf("mine_submit")).toMatchObject({ kind: "expired" });
-  });
-
-  it("is off unless the dev URL asks for it", () => {
-    expect(callsExpiredFromUrl("?tab=mine&calls=expired")).toBe(true);
-    expect(callsExpiredFromUrl("?tab=mine")).toBe(false);
-    expect(callsExpiredFromUrl("?calls=failed")).toBe(false);
+  it("arms only a call it has, and says so otherwise", () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    expect(expiringCallFromUrl("?tab=mine&expire=mine_submit")).toBe(
+      "mine_submit",
+    );
+    expect(expiringCallFromUrl("?tab=mine")).toBeNull();
+    expect(expiringCallFromUrl("?expire=mine_forget")).toBeNull();
+    expect(warn).toHaveBeenCalledTimes(1);
+    warn.mockRestore();
   });
 });
 

--- a/ui/src/dev/mock-account.test.ts
+++ b/ui/src/dev/mock-account.test.ts
@@ -1,5 +1,5 @@
-import { beforeEach, describe, expect, it, vi } from "vitest";
-import type { AccountStatus } from "@/bindings";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { AccountCallRefused, AccountStatus } from "@/bindings";
 import {
   hasCredential,
   type SettledAccount,
@@ -9,9 +9,11 @@ import {
 import { mockInvoke } from "./mock";
 import {
   accountFromUrl,
+  callsExpiredFromUrl,
   isSignedIn,
   MOCK_ACCOUNT_NAMES,
   MOCK_ACCOUNTS,
+  setCallsExpired,
   setMockAccount,
   UNREADABLE,
 } from "./mock-account";
@@ -69,6 +71,60 @@ describe("the account states the dev bridge can answer as", () => {
     expect((await read()).account).toEqual(MOCK_ACCOUNTS["signed-in"]);
     await mockInvoke("account_logout");
     expect((await read()).account).toEqual(MOCK_ACCOUNTS["signed-out"]);
+  });
+});
+
+// A refusal the harness sends as a bare string leaves every consumer
+// reading `answer.error.message` with undefined and its surface blank,
+// and the name-matching test above cannot see it.
+describe("how the calls made under the sign-in refuse", () => {
+  const refusalOf = (command: string) =>
+    mockInvoke(command, { repo: "jane/team-skills" }).then(
+      () => null,
+      (refusal: unknown) => refusal,
+    );
+
+  const CALLS = ["mine_submit", "mine_submissions"];
+
+  beforeEach(() => {
+    setMockAccount({ ok: MOCK_ACCOUNTS["signed-in"] });
+    setCallsExpired(false);
+  });
+
+  afterEach(() => setCallsExpired(false));
+
+  it("names the sentence and the kind a consumer reads", async () => {
+    setCallsExpired(true);
+    for (const command of CALLS) {
+      const refusal = await refusalOf(command);
+      expect(refusal, command).toMatchObject({ kind: "expired" });
+      expect((refusal as AccountCallRefused).message, command).toContain(
+        "kendex login",
+      );
+    }
+  });
+
+  it("is about the call, not the account, with no credential to use", async () => {
+    setMockAccount({ ok: MOCK_ACCOUNTS["signed-out"] });
+    for (const command of CALLS) {
+      expect(await refusalOf(command), command).toMatchObject({
+        kind: "failed",
+      });
+    }
+  });
+
+  // Submit is gated on the read saying signed in, so the expired refusal
+  // is reachable only while the read still says a credential is held.
+  it("meets the expiry under a read that still says signed in", async () => {
+    setCallsExpired(true);
+    expect(isSignedIn()).toBe(true);
+    expect(await refusalOf("mine_submit")).toMatchObject({ kind: "expired" });
+  });
+
+  it("is off unless the dev URL asks for it", () => {
+    expect(callsExpiredFromUrl("?tab=mine&calls=expired")).toBe(true);
+    expect(callsExpiredFromUrl("?tab=mine")).toBe(false);
+    expect(callsExpiredFromUrl("?calls=failed")).toBe(false);
   });
 });
 

--- a/ui/src/dev/mock-account.ts
+++ b/ui/src/dev/mock-account.ts
@@ -40,7 +40,7 @@ export const MOCK_ACCOUNTS: Record<SettledAccount["kind"], SettledAccount> = {
   "signed-out": SIGNED_OUT,
   "signed-in": SIGNED_IN,
   offline: { kind: "offline", identity: IDENTITY, signIn: SIGN_IN },
-  expired: { kind: "expired" },
+  expired: { kind: "expired", signIn: SIGN_IN },
 };
 
 /** A read that cannot be made is the fifth thing the store draws, so the
@@ -162,7 +162,7 @@ const wire = (account: SettledAccount): AccountStatus["state"] => {
     case "signed-out":
       return { state: "signed-out" };
     case "expired":
-      return { state: "expired" };
+      return { state: "expired", sign_in: account.signIn };
     case "offline":
       return {
         state: "offline",

--- a/ui/src/dev/mock-account.ts
+++ b/ui/src/dev/mock-account.ts
@@ -77,30 +77,57 @@ export function isSignedIn(): boolean {
 const EXPIRED =
   "your sign-in has expired (invalid_grant) — run `kendex login` again";
 
-/** Whether the calls made under the sign-in meet an expiry. The read and
- *  the calls answer separately because the server can refuse a credential
- *  this machine still holds, which is the only way the expired refusal is
- *  reachable: the Submit that meets it is gated on the read saying signed
- *  in, so `?account=expired` takes the button away instead of the
- *  refusal. */
-export const callsExpiredFromUrl = (search: string): boolean =>
-  new URLSearchParams(search).get("calls") === "expired";
+/** The calls that go out under the stored sign-in, by the name the bridge
+ *  dispatches on. */
+export const EXPIRING_CALLS = ["mine_submit", "mine_submissions"] as const;
 
-let callsExpired =
+export type ExpiringCall = (typeof EXPIRING_CALLS)[number];
+
+/** Which call `?expire=` puts the expiry on, or null for none.
+ *
+ *  It names one call rather than arming them all because the Mine tab
+ *  polls its submissions on mount: an expiry both calls answer to would
+ *  end the account before anyone could press Submit, and the submit
+ *  meeting one is the flow this exists to show. The read and the calls
+ *  answer separately for the same reason. The server can refuse a
+ *  credential this machine still holds, and `?account=expired` takes the
+ *  Submit away instead of letting it meet the refusal. */
+export function expiringCallFromUrl(search: string): ExpiringCall | null {
+  const asked = new URLSearchParams(search).get("expire");
+  if (asked === null) return null;
+  const named = EXPIRING_CALLS.find((call) => call === asked);
+  if (named) return named;
+  console.warn(
+    `mock cannot expire '${asked}' — nothing armed. Pick one of ${EXPIRING_CALLS.join(", ")}`,
+  );
+  return null;
+}
+
+let expiring: ExpiringCall | null =
   typeof window === "undefined"
-    ? false
-    : callsExpiredFromUrl(window.location.search);
+    ? null
+    : expiringCallFromUrl(window.location.search);
 
-/** What the calls refuse with, for tests and for the dev URL. */
-export function setCallsExpired(expired: boolean): void {
-  callsExpired = expired;
+/** Arms the expiry on one call, for tests and for the dev URL. */
+export function setExpiringCall(call: ExpiringCall | null): void {
+  expiring = call;
 }
 
 /** Why a call made under the sign-in refuses, or null when it goes
  *  through. Tagged as the command answers, so a consumer reading
- *  `.message` gets the sentence rather than undefined. */
-export function callRefusal(): AccountCallRefused | null {
-  if (callsExpired) return { kind: "expired", message: EXPIRED };
+ *  `.message` gets the sentence rather than undefined.
+ *
+ *  Meeting the expiry is what ends the sign-in, so the credential goes
+ *  with it and the read that follows says signed out, as it does in the
+ *  app. The scenario is spent in the same moment: signing in again comes
+ *  back to a working call rather than expiring for the rest of the
+ *  session. */
+export function callRefusal(call: ExpiringCall): AccountCallRefused | null {
+  if (expiring === call) {
+    expiring = null;
+    served = { ok: SIGNED_OUT };
+    return { kind: "expired", message: EXPIRED };
+  }
   if (!isSignedIn()) return { kind: "failed", message: "sign in first" };
   return null;
 }

--- a/ui/src/dev/mock-account.ts
+++ b/ui/src/dev/mock-account.ts
@@ -7,7 +7,7 @@
 // that could not be confirmed, one that was rejected, a read that fails —
 // reach the store through its dev reader, which the backend takes over
 // once it can reach the server. `?account=` on the dev URL picks one.
-import type { AccountStatus } from "@/bindings";
+import type { AccountCallRefused, AccountStatus } from "@/bindings";
 import { hasCredential, type SettledAccount } from "@/stores/account";
 import { type AccountRead, setAccountReader } from "@/stores/account-read";
 import type { Handler } from "./mock-state";
@@ -71,6 +71,38 @@ export function setMockAccount(read: AccountRead): void {
 
 export function isSignedIn(): boolean {
   return "ok" in served && hasCredential(served.ok);
+}
+
+/** The whole sentence a real expiry carries, remedy included. */
+const EXPIRED =
+  "your sign-in has expired (invalid_grant) — run `kendex login` again";
+
+/** Whether the calls made under the sign-in meet an expiry. The read and
+ *  the calls answer separately because the server can refuse a credential
+ *  this machine still holds, which is the only way the expired refusal is
+ *  reachable: the Submit that meets it is gated on the read saying signed
+ *  in, so `?account=expired` takes the button away instead of the
+ *  refusal. */
+export const callsExpiredFromUrl = (search: string): boolean =>
+  new URLSearchParams(search).get("calls") === "expired";
+
+let callsExpired =
+  typeof window === "undefined"
+    ? false
+    : callsExpiredFromUrl(window.location.search);
+
+/** What the calls refuse with, for tests and for the dev URL. */
+export function setCallsExpired(expired: boolean): void {
+  callsExpired = expired;
+}
+
+/** Why a call made under the sign-in refuses, or null when it goes
+ *  through. Tagged as the command answers, so a consumer reading
+ *  `.message` gets the sentence rather than undefined. */
+export function callRefusal(): AccountCallRefused | null {
+  if (callsExpired) return { kind: "expired", message: EXPIRED };
+  if (!isSignedIn()) return { kind: "failed", message: "sign in first" };
+  return null;
 }
 
 /** Points the store's account read here, so `?account=` picks a state

--- a/ui/src/dev/mock-account.ts
+++ b/ui/src/dev/mock-account.ts
@@ -17,14 +17,29 @@ import type { Handler } from "./mock-state";
 const IDENTITY = { name: "Ada Lovelace", githubLogin: "1234567" };
 
 const SIGNED_OUT: SettledAccount = { kind: "signed-out" };
-const SIGNED_IN: SettledAccount = { kind: "signed-in", identity: IDENTITY };
+/** The name core mints for a sign-in: one per credential, a new one for
+ *  every sign-in. Minting it here the way core does is what makes signing
+ *  in again a change of hands in the harness, as it is in the app. */
+let signIns = 0;
+const mintSignIn = (): string => {
+  signIns += 1;
+  return `sign-in-${signIns}`;
+};
+
+const SIGN_IN = mintSignIn();
+
+const SIGNED_IN: SettledAccount = {
+  kind: "signed-in",
+  identity: IDENTITY,
+  signIn: SIGN_IN,
+};
 
 /** Every state the store can settle on, and the name `?account=` calls it.
  *  Typed by the state's own tag, so a sixth state has to be added here. */
 export const MOCK_ACCOUNTS: Record<SettledAccount["kind"], SettledAccount> = {
   "signed-out": SIGNED_OUT,
   "signed-in": SIGNED_IN,
-  offline: { kind: "offline", identity: IDENTITY },
+  offline: { kind: "offline", identity: IDENTITY, signIn: SIGN_IN },
   expired: { kind: "expired" },
 };
 
@@ -149,9 +164,17 @@ const wire = (account: SettledAccount): AccountStatus["state"] => {
     case "expired":
       return { state: "expired" };
     case "offline":
-      return { state: "offline", identity: account.identity };
+      return {
+        state: "offline",
+        identity: account.identity,
+        sign_in: account.signIn,
+      };
     case "signed-in":
-      return { state: "signed-in", identity: account.identity ?? IDENTITY };
+      return {
+        state: "signed-in",
+        identity: account.identity ?? IDENTITY,
+        sign_in: account.signIn,
+      };
   }
 };
 
@@ -174,9 +197,12 @@ export const accountHandlers: Record<string, Handler> = {
   },
   account_login_poll: () => {
     polls += 1;
-    if (polls < 2) return "pending";
-    served = { ok: SIGNED_IN };
-    return "signed";
+    if (polls < 2) return { kind: "pending" };
+    // The credential the approval stores, and the name it is stored
+    // under: the read that follows has to answer with this one.
+    const signIn = mintSignIn();
+    served = { ok: { ...SIGNED_IN, signIn } };
+    return { kind: "signed", sign_in: signIn };
   },
   account_logout: () => {
     served = { ok: SIGNED_OUT };

--- a/ui/src/dev/mock-mine.ts
+++ b/ui/src/dev/mock-mine.ts
@@ -6,7 +6,7 @@ import type {
   MineRow,
   SubmitPreflight,
 } from "@/bindings";
-import { callRefusal } from "./mock-account";
+import { callRefusal, type ExpiringCall } from "./mock-account";
 import type { Handler } from "./mock-state";
 
 function row(overrides: Partial<MineRow>): MineRow {
@@ -163,16 +163,16 @@ const SUBMISSION = {
   indexed_at: null,
 };
 
-const underSignIn = <T>(answer: T) => {
-  const refused = callRefusal();
+const underSignIn = <T>(call: ExpiringCall, answer: T) => {
+  const refused = callRefusal(call);
   return refused ? Promise.reject(refused) : answer;
 };
 
 export const mineHandlers: Record<string, Handler> = {
   mine_submit_preflight: (args: { path: string }) => preflightFor(args.path),
   mine_submit: (args: { repo: string }) =>
-    underSignIn({ repo: args.repo, status: "pending" }),
-  mine_submissions: () => underSignIn([SUBMISSION]),
+    underSignIn("mine_submit", { repo: args.repo, status: "pending" }),
+  mine_submissions: () => underSignIn("mine_submissions", [SUBMISSION]),
   mine_authoring_doc: () =>
     "# How a marketplace repo works\n\nA kendex marketplace is a git repository.\n",
   mine_list: () => rows,

--- a/ui/src/dev/mock-mine.ts
+++ b/ui/src/dev/mock-mine.ts
@@ -6,7 +6,7 @@ import type {
   MineRow,
   SubmitPreflight,
 } from "@/bindings";
-import { isSignedIn } from "./mock-account";
+import { callRefusal } from "./mock-account";
 import type { Handler } from "./mock-state";
 
 function row(overrides: Partial<MineRow>): MineRow {
@@ -155,24 +155,24 @@ function preflightFor(path: string): SubmitPreflight {
   };
 }
 
+const SUBMISSION = {
+  repo: "jane/team-skills",
+  status: "pending",
+  status_reason: null,
+  head_commit: null,
+  indexed_at: null,
+};
+
+const underSignIn = <T>(answer: T) => {
+  const refused = callRefusal();
+  return refused ? Promise.reject(refused) : answer;
+};
+
 export const mineHandlers: Record<string, Handler> = {
   mine_submit_preflight: (args: { path: string }) => preflightFor(args.path),
-  mine_submit: (args: { repo: string }) => {
-    if (!isSignedIn()) return Promise.reject("sign in first");
-    return { repo: args.repo, status: "pending" };
-  },
-  mine_submissions: () =>
-    isSignedIn()
-      ? [
-          {
-            repo: "jane/team-skills",
-            status: "pending",
-            status_reason: null,
-            head_commit: null,
-            indexed_at: null,
-          },
-        ]
-      : Promise.reject("sign in first"),
+  mine_submit: (args: { repo: string }) =>
+    underSignIn({ repo: args.repo, status: "pending" }),
+  mine_submissions: () => underSignIn([SUBMISSION]),
   mine_authoring_doc: () =>
     "# How a marketplace repo works\n\nA kendex marketplace is a git repository.\n",
   mine_list: () => rows,

--- a/ui/src/stores/account-read.ts
+++ b/ui/src/stores/account-read.ts
@@ -27,7 +27,7 @@ const settled = (wire: AccountStatus["state"]): SettledAccount => {
     case "offline":
       return { kind: "offline", identity: wire.identity, signIn: wire.sign_in };
     case "expired":
-      return { kind: "expired" };
+      return { kind: "expired", signIn: wire.sign_in };
   }
 };
 

--- a/ui/src/stores/account-read.ts
+++ b/ui/src/stores/account-read.ts
@@ -19,9 +19,13 @@ const settled = (wire: AccountStatus["state"]): SettledAccount => {
     case "signed-out":
       return { kind: "signed-out" };
     case "signed-in":
-      return { kind: "signed-in", identity: wire.identity };
+      return {
+        kind: "signed-in",
+        identity: wire.identity,
+        signIn: wire.sign_in,
+      };
     case "offline":
-      return { kind: "offline", identity: wire.identity };
+      return { kind: "offline", identity: wire.identity, signIn: wire.sign_in };
     case "expired":
       return { kind: "expired" };
   }

--- a/ui/src/stores/account-refused.test.ts
+++ b/ui/src/stores/account-refused.test.ts
@@ -28,6 +28,12 @@ vi.mock("@/bindings", () => ({
 beforeEach(() => {
   fresh();
   vi.clearAllMocks();
+  // A read that finds the credential replaced asks for the new account's
+  // rows, so the harness has an answer for it.
+  vi.mocked(commands.mineSubmissions).mockResolvedValue({
+    status: "ok",
+    data: [],
+  } as Awaited<ReturnType<typeof commands.mineSubmissions>>);
 });
 
 // A command made under the sign-in is the second way the credential is
@@ -264,8 +270,9 @@ describe("a call refused because the sign-in expired", () => {
         signIn: "sign-in-next",
       });
       // The rows went with the account that owned them, at the read that
-      // saw the change of hands, not at the refusal that landed after.
-      expect(useAccountStore.getState().submissions).toBeNull();
+      // saw the change of hands, not at the refusal that landed after,
+      // and that read asked for the new account's in their place.
+      expect(useAccountStore.getState().submissions).toEqual([]);
     });
   });
 

--- a/ui/src/stores/account-refused.test.ts
+++ b/ui/src/stores/account-refused.test.ts
@@ -7,6 +7,7 @@ import {
   BOB,
   fresh,
   load,
+  OTHER_SIGN_IN,
   SIGN_IN,
   serves,
 } from "@/test/account-store";
@@ -48,7 +49,7 @@ describe("a call refused because the sign-in expired", () => {
       submissions: [],
     });
     met();
-    expect(account()).toEqual({ kind: "expired" });
+    expect(account()).toEqual({ kind: "expired", signIn: SIGN_IN });
     expect(useAccountStore.getState().submissions).toBeNull();
   });
 
@@ -61,7 +62,7 @@ describe("a call refused because the sign-in expired", () => {
     // says signed out. What the command learned has to outlive it.
     answers({ state: "signed-out" });
     await load();
-    expect(account()).toEqual({ kind: "expired" });
+    expect(account()).toEqual({ kind: "expired", signIn: SIGN_IN });
   });
 
   // KEN-742 leaves the credential, and its cached identity, where the
@@ -74,14 +75,61 @@ describe("a call refused because the sign-in expired", () => {
       account: { kind: "signed-in", identity: ADA, signIn: SIGN_IN },
     });
     met();
-    expect(account()).toEqual({ kind: "expired" });
+    expect(account()).toEqual({ kind: "expired", signIn: SIGN_IN });
 
     serves({ kind: "offline", identity: ADA, signIn: SIGN_IN });
     await load();
 
-    expect(account()).toEqual({ kind: "expired" });
+    expect(account()).toEqual({ kind: "expired", signIn: SIGN_IN });
     // What the submit dialog gates its Submit button on.
     expect(hasCredential(account())).toBe(false);
+  });
+
+  // The verdict was about the sign-in it named. A credential another
+  // process installed is not that one, and holding the expiry over it
+  // leaves a live sign-in reading as dead with Submit withheld.
+  it("lets go of it for a credential known to be a different one", async () => {
+    useAccountStore.setState({
+      account: { kind: "signed-in", identity: ADA, signIn: SIGN_IN },
+    });
+    met();
+
+    serves({ kind: "offline", identity: BOB, signIn: OTHER_SIGN_IN });
+    await load();
+
+    expect(account()).toEqual({
+      kind: "offline",
+      identity: BOB,
+      signIn: OTHER_SIGN_IN,
+    });
+    expect(hasCredential(account())).toBe(true);
+  });
+
+  // An unnamed credential is not known to be a different one, and an
+  // answer that cannot see the server does not get to overturn one that
+  // could on a difference nobody established.
+  it("keeps it when the offline answer names no sign-in", async () => {
+    useAccountStore.setState({
+      account: { kind: "signed-in", identity: ADA, signIn: SIGN_IN },
+    });
+    met();
+
+    serves({ kind: "offline", identity: ADA, signIn: "" });
+    await load();
+
+    expect(account()).toEqual({ kind: "expired", signIn: SIGN_IN });
+  });
+
+  it("keeps it when neither side names one", async () => {
+    useAccountStore.setState({
+      account: { kind: "signed-in", identity: ADA, signIn: "" },
+    });
+    met();
+
+    serves({ kind: "offline", identity: ADA, signIn: "" });
+    await load();
+
+    expect(account()).toEqual({ kind: "expired", signIn: "" });
   });
 
   it("drops rows already out for the credential it ended", async () => {
@@ -248,7 +296,7 @@ describe("a call refused because the sign-in expired", () => {
       error: expired,
     } as Awaited<ReturnType<typeof commands.mineSubmissions>>);
     await useAccountStore.getState().loadSubmissions();
-    expect(account()).toEqual({ kind: "expired" });
+    expect(account()).toEqual({ kind: "expired", signIn: SIGN_IN });
     expect(useAccountStore.getState().submissions).toBeNull();
   });
 });

--- a/ui/src/stores/account-refused.test.ts
+++ b/ui/src/stores/account-refused.test.ts
@@ -1,0 +1,254 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { commands } from "@/bindings";
+import {
+  ADA,
+  account,
+  answers,
+  BOB,
+  fresh,
+  load,
+  SIGN_IN,
+  serves,
+} from "@/test/account-store";
+import { hasCredential, useAccountStore } from "./account";
+
+// `vi.mock` is hoisted above the imports, so its factory cannot reach one.
+vi.mock("@/bindings", () => ({
+  commands: {
+    accountStatus: vi.fn(),
+    accountLogout: vi.fn(),
+    accountLoginStart: vi.fn(),
+    accountLoginPoll: vi.fn(),
+    mineSubmissions: vi.fn(),
+    openUrl: vi.fn(),
+  },
+}));
+
+beforeEach(() => {
+  fresh();
+  vi.clearAllMocks();
+});
+
+// A command made under the sign-in is the second way the credential is
+// found to have ended; the read is the first. What the two leave behind
+// has to be the same thing, or the sidebar and Settings > Account answer
+// to two rules about one account.
+describe("a call refused because the sign-in expired", () => {
+  const expired = { kind: "expired" as const, message: "run login again" };
+
+  /** The refusal landing under the account it was made for. */
+  const met = () =>
+    useAccountStore
+      .getState()
+      .refused(expired, useAccountStore.getState().handovers());
+
+  it("goes to expired and drops the rows with it", () => {
+    useAccountStore.setState({
+      account: { kind: "signed-in", identity: ADA, signIn: SIGN_IN },
+      submissions: [],
+    });
+    met();
+    expect(account()).toEqual({ kind: "expired" });
+    expect(useAccountStore.getState().submissions).toBeNull();
+  });
+
+  it("keeps the explanation through the read that follows it", async () => {
+    useAccountStore.setState({
+      account: { kind: "signed-in", identity: ADA, signIn: SIGN_IN },
+    });
+    met();
+    // The refusal cleared the credential, so this read finds none and
+    // says signed out. What the command learned has to outlive it.
+    answers({ state: "signed-out" });
+    await load();
+    expect(account()).toEqual({ kind: "expired" });
+  });
+
+  // KEN-742 leaves the credential, and its cached identity, where the
+  // removal fails. An outage then answers `offline` for a sign-in the
+  // server has already refused, and offline holds a credential: without
+  // the same rule the signed-out answer gets, the dead sign-in comes
+  // back usable and the Submit it cannot carry is offered again.
+  it("keeps expired through a read that could not reach the server", async () => {
+    useAccountStore.setState({
+      account: { kind: "signed-in", identity: ADA, signIn: SIGN_IN },
+    });
+    met();
+    expect(account()).toEqual({ kind: "expired" });
+
+    serves({ kind: "offline", identity: ADA, signIn: SIGN_IN });
+    await load();
+
+    expect(account()).toEqual({ kind: "expired" });
+    // What the submit dialog gates its Submit button on.
+    expect(hasCredential(account())).toBe(false);
+  });
+
+  it("drops rows already out for the credential it ended", async () => {
+    useAccountStore.setState({
+      account: { kind: "signed-in", identity: ADA, signIn: SIGN_IN },
+      submissions: null,
+    });
+    vi.mocked(commands.mineSubmissions).mockImplementation(async () => {
+      met();
+      return { status: "ok", data: [] } as Awaited<
+        ReturnType<typeof commands.mineSubmissions>
+      >;
+    });
+    await useAccountStore.getState().loadSubmissions();
+    expect(useAccountStore.getState().submissions).toBeNull();
+  });
+
+  it("changes nothing once the account has already moved on", () => {
+    // A sign-out taken while the call was out is the person's own
+    // answer; the rejection that lands behind it is about a credential
+    // they already gave up.
+    useAccountStore.setState({ account: { kind: "signed-out" } });
+    met();
+    expect(account()).toEqual({ kind: "signed-out" });
+  });
+
+  // The expiry belongs to the credential the call went out under. A
+  // submit is in flight for as long as the server takes, and the sign-in
+  // can be replaced inside that window: a sign-out, a device flow
+  // finishing behind the dialog, or `kendex login` in a terminal, which
+  // the next window focus reads. Ending the account over an expiry that
+  // is not about the credential on screen signs the person out of the
+  // one they just signed into.
+  describe("that lands after the sign-in it was made under is gone", () => {
+    const ROW = {
+      repo: "ada/team-skills",
+      status: "pending",
+      status_reason: null,
+      head_commit: null,
+      indexed_at: null,
+    };
+
+    /** Submits under the account on screen, replaces the sign-in with
+     *  `replace` while it is in flight, and lands the expiry behind it.
+     *  Answers what the store settled on before the refusal, which is
+     *  what a refusal about a credential nobody holds must leave. */
+    const refusedAfter = async (replace: () => Promise<void>) => {
+      useAccountStore.setState({
+        account: { kind: "signed-in", identity: ADA, signIn: SIGN_IN },
+        submissions: [ROW],
+      });
+      const since = useAccountStore.getState().handovers();
+      await replace();
+      const settled = {
+        account: account(),
+        submissions: useAccountStore.getState().submissions,
+      };
+      useAccountStore.getState().refused(expired, since);
+      return settled;
+    };
+
+    /** Nothing the refusal did: the account and its rows as they were. */
+    const unchangedFrom = (settled: {
+      account: ReturnType<typeof account>;
+      submissions: ReturnType<typeof useAccountStore.getState>["submissions"];
+    }) => {
+      expect(account()).toEqual(settled.account);
+      expect(useAccountStore.getState().submissions).toEqual(
+        settled.submissions,
+      );
+    };
+
+    it("leaves a sign-out where it found it", async () => {
+      vi.mocked(commands.accountLogout).mockResolvedValue({
+        status: "ok",
+        data: null,
+      } as Awaited<ReturnType<typeof commands.accountLogout>>);
+      const settled = await refusedAfter(() =>
+        useAccountStore.getState().signOut(),
+      );
+      unchangedFrom(settled);
+      expect(account()).toEqual({ kind: "signed-out" });
+    });
+
+    it("leaves the credential a device flow put there in its place", async () => {
+      vi.mocked(commands.accountLoginStart).mockResolvedValue({
+        status: "ok",
+        data: {
+          deviceCode: "kxd_test",
+          userCode: "ABCD-2345",
+          verificationUrl: "https://kendex.ai/device",
+          intervalSeconds: 1,
+        },
+      } as Awaited<ReturnType<typeof commands.accountLoginStart>>);
+      vi.mocked(commands.accountLoginPoll).mockResolvedValue({
+        status: "ok",
+        data: { kind: "signed", sign_in: SIGN_IN },
+      } as Awaited<ReturnType<typeof commands.accountLoginPoll>>);
+      vi.mocked(commands.openUrl).mockResolvedValue({
+        status: "ok",
+        data: null,
+      } as Awaited<ReturnType<typeof commands.openUrl>>);
+      serves({ kind: "signed-in", identity: BOB, signIn: SIGN_IN });
+
+      const settled = await refusedAfter(async () => {
+        vi.useFakeTimers();
+        const signing = useAccountStore.getState().signIn();
+        await vi.advanceTimersByTimeAsync(1100);
+        await signing;
+        vi.useRealTimers();
+      });
+
+      unchangedFrom(settled);
+      expect(account()).toEqual({
+        kind: "signed-in",
+        identity: BOB,
+        signIn: SIGN_IN,
+      });
+    });
+
+    // The route a terminal `kendex login` takes: nothing in the app signs
+    // in, and the replacement arrives as a read that finds a credential
+    // where there was already one.
+    it("leaves a credential a terminal login put there in its place", async () => {
+      serves({ kind: "signed-in", identity: BOB, signIn: "sign-in-next" });
+      const settled = await refusedAfter(load);
+
+      unchangedFrom(settled);
+      expect(account()).toEqual({
+        kind: "signed-in",
+        identity: BOB,
+        signIn: "sign-in-next",
+      });
+      // The rows went with the account that owned them, at the read that
+      // saw the change of hands, not at the refusal that landed after.
+      expect(useAccountStore.getState().submissions).toBeNull();
+    });
+  });
+
+  it("says nothing about the account when the refusal is anything else", () => {
+    const signedIn = {
+      kind: "signed-in" as const,
+      identity: ADA,
+      signIn: SIGN_IN,
+    };
+    useAccountStore.setState({ account: signedIn, submissions: [] });
+    useAccountStore
+      .getState()
+      .refused(
+        { kind: "failed", message: "kendex.ai could not be reached" },
+        useAccountStore.getState().handovers(),
+      );
+    expect(account()).toEqual(signedIn);
+    expect(useAccountStore.getState().submissions).toEqual([]);
+  });
+
+  it("is what a submissions poll does with the refusal it gets", async () => {
+    useAccountStore.setState({
+      account: { kind: "signed-in", identity: ADA, signIn: SIGN_IN },
+      submissions: [],
+    });
+    vi.mocked(commands.mineSubmissions).mockResolvedValue({
+      status: "error",
+      error: expired,
+    } as Awaited<ReturnType<typeof commands.mineSubmissions>>);
+    await useAccountStore.getState().loadSubmissions();
+    expect(account()).toEqual({ kind: "expired" });
+    expect(useAccountStore.getState().submissions).toBeNull();
+  });
+});

--- a/ui/src/stores/account-state.ts
+++ b/ui/src/stores/account-state.ts
@@ -40,18 +40,26 @@ export const cachedIdentity = (
  *
  *  The question is whether the credential changed hands, not whether its
  *  name has arrived. A credential is stored before anything knows who it
- *  belongs to, and the read that names it is the one landing here, so a
- *  missing name on either side is not evidence of a different account.
+ *  belongs to, so a state with no identity at all is transitional and the
+ *  read landing here is the one that names it. That is the only wildcard.
+ *  Between two identities that have both been read, a null `githubLogin`
+ *  is a settled fact about an account whose GitHub link was removed, and
+ *  it separates them from a linked one the way any other value would.
  *
- *  What a read is told is who the account belongs to, and nothing that
- *  separates one sign-in for that person from the next, so the same
- *  person signing in again reads as the same credential. */
+ *  What this cannot separate: two read identities that agree on
+ *  everything the app is given. A read is told who the account belongs to
+ *  and nothing that tells one sign-in for that person from the next, so
+ *  the same person signing in again, and two unlinked accounts sharing a
+ *  name, both read as the credential already held. Separating those needs
+ *  a stable per-sign-in identifier the app is not handed today. */
 export const sameAccount = (
   held: AccountState,
   read: AccountState,
 ): boolean => {
   if (!hasCredential(held) || !hasCredential(read)) return false;
-  const who = held.identity?.githubLogin ?? null;
-  const now = read.identity?.githubLogin ?? null;
-  return who === null || now === null || who === now;
+  if (held.identity === null || read.identity === null) return true;
+  return (
+    held.identity.githubLogin === read.identity.githubLogin &&
+    held.identity.name === read.identity.name
+  );
 };

--- a/ui/src/stores/account-state.ts
+++ b/ui/src/stores/account-state.ts
@@ -1,0 +1,49 @@
+// What an account is, and what can be told about one by looking at it.
+// The store that holds one, reads it, and moves it is `account.ts`.
+
+/** Who the account belongs to, as the server names them. The linked
+ * GitHub account is null once it has been unlinked. */
+export interface AccountIdentity {
+  name: string;
+  githubLogin: string | null;
+}
+
+/** What is known about the account right now.
+ *
+ * `signed-in` carries the identity once the backend has one; a credential
+ * in the keychain is enough to be signed in before then. `offline` is a
+ * credential we know the owner of but could not confirm; `expired` is one
+ * the server no longer accepts. */
+export type AccountState =
+  | { kind: "loading" }
+  | { kind: "signed-out" }
+  | { kind: "signed-in"; identity: AccountIdentity | null }
+  | { kind: "offline"; identity: AccountIdentity }
+  | { kind: "expired" };
+
+/** Every state but the one that means "not read yet". */
+export type SettledAccount = Exclude<AccountState, { kind: "loading" }>;
+
+/** The states that hold a credential, and so may know a name. */
+type WithIdentity = Extract<AccountState, { kind: "signed-in" | "offline" }>;
+
+/** Signed in far enough to submit: an unconfirmed credential still is. */
+export const hasCredential = (account: AccountState): account is WithIdentity =>
+  account.kind === "signed-in" || account.kind === "offline";
+
+export const cachedIdentity = (
+  account: AccountState,
+): AccountIdentity | null => (hasCredential(account) ? account.identity : null);
+
+/** Whether a read landed on the credential already held, as far as a read
+ *  can tell. It is told who the account belongs to and nothing that
+ *  separates one sign-in for that person from the next, so the same
+ *  person signing in again reads as the same credential here. */
+export const sameAccount = (
+  held: AccountState,
+  read: AccountState,
+): boolean => {
+  if (!hasCredential(held) || !hasCredential(read)) return false;
+  const who = held.identity?.githubLogin ?? null;
+  return who !== null && who === (read.identity?.githubLogin ?? null);
+};

--- a/ui/src/stores/account-state.ts
+++ b/ui/src/stores/account-state.ts
@@ -36,14 +36,22 @@ export const cachedIdentity = (
 ): AccountIdentity | null => (hasCredential(account) ? account.identity : null);
 
 /** Whether a read landed on the credential already held, as far as a read
- *  can tell. It is told who the account belongs to and nothing that
+ *  can tell.
+ *
+ *  The question is whether the credential changed hands, not whether its
+ *  name has arrived. A credential is stored before anything knows who it
+ *  belongs to, and the read that names it is the one landing here, so a
+ *  missing name on either side is not evidence of a different account.
+ *
+ *  What a read is told is who the account belongs to, and nothing that
  *  separates one sign-in for that person from the next, so the same
- *  person signing in again reads as the same credential here. */
+ *  person signing in again reads as the same credential. */
 export const sameAccount = (
   held: AccountState,
   read: AccountState,
 ): boolean => {
   if (!hasCredential(held) || !hasCredential(read)) return false;
   const who = held.identity?.githubLogin ?? null;
-  return who !== null && who === (read.identity?.githubLogin ?? null);
+  const now = read.identity?.githubLogin ?? null;
+  return who === null || now === null || who === now;
 };

--- a/ui/src/stores/account-state.ts
+++ b/ui/src/stores/account-state.ts
@@ -15,16 +15,16 @@ export interface AccountIdentity {
  * credential we know the owner of but could not confirm; `expired` is one
  * the server no longer accepts.
  *
- * The states that hold a credential carry `signIn`, the name core minted
- * for that sign-in. It arrives with the credential and comes back on
- * every read of it, so two answers can be compared for whether they are
- * about the same sign-in. */
+ * The states about a credential carry `signIn`, the name core minted for
+ * that sign-in. It arrives with the credential and comes back on every
+ * read of it, so two answers can be compared for whether they are about
+ * the same one. */
 export type AccountState =
   | { kind: "loading" }
   | { kind: "signed-out" }
   | { kind: "signed-in"; identity: AccountIdentity | null; signIn: string }
   | { kind: "offline"; identity: AccountIdentity; signIn: string }
-  | { kind: "expired" };
+  | { kind: "expired"; signIn: string };
 
 /** Every state but the one that means "not read yet". */
 export type SettledAccount = Exclude<AccountState, { kind: "loading" }>;
@@ -45,18 +45,63 @@ export const asOffline = (account: AccountState): SettledAccount | null =>
     ? { kind: "offline", identity: account.identity, signIn: account.signIn }
     : null;
 
-/** Whether two answers are about the same sign-in.
+/** Which sign-in a state is about, or null when that is not known.
  *
- * Core mints `signIn` when a sign-in is committed, carries it through
- * every token rotation, and replaces it only when another sign-in
- * replaces the credential. So this asks the question the caller actually
- * has, which is whether the credential changed hands, rather than
- * inferring it from the identity: a rename leaves the same credential,
- * and signing in again as the same person leaves a different one under
- * the same name. Neither is visible in what a read says about who the
- * account belongs to. */
+ *  `Credential::sign_in` is `#[serde(default)]` in core so a credential
+ *  stored before the field existed still parses instead of signing that
+ *  person out, and such a credential reads back with an empty name. Empty
+ *  therefore means not-yet-named, never named-empty. It is the absence of
+ *  an answer, so it is never equal to another absence: two credentials
+ *  that both predate the field are not thereby the same sign-in. */
+const signInOf = (account: AccountState): string | null =>
+  "signIn" in account && account.signIn !== "" ? account.signIn : null;
+
+/* The two questions below both follow one rule: only a KNOWN difference is
+ * a difference, and only a KNOWN match is a match. Neither is the negation
+ * of the other, and their unknown branches deliberately disagree, because
+ * each takes the answer that is safe for its own question.
+ *
+ * `sameCredential` asks whether this is the credential already held, and
+ * answering yes wrongly keeps another account's rows and lets an obsolete
+ * refusal end the wrong sign-in. Unknown must not claim sameness.
+ *
+ * `differentCredential` asks whether to overturn an expiry the server
+ * already ruled on, and answering yes wrongly hands back a submit under a
+ * credential known to be dead. Unknown must not overturn it.
+ *
+ * The cost of unknown falls on a credential stored before core named
+ * sign-ins, at most one machine-wide: every read counts as a change of
+ * hands, which refetches its rows, until the next sign-in names it. */
+
+/** Whether two answers are known to be about the same sign-in. */
 export const sameCredential = (
   held: AccountState,
   read: AccountState,
-): boolean =>
-  hasCredential(held) && hasCredential(read) && held.signIn === read.signIn;
+): boolean => {
+  if (!hasCredential(held) || !hasCredential(read)) return false;
+  const before = signInOf(held);
+  return before !== null && before === signInOf(read);
+};
+
+/** Whether two answers are known to be about different sign-ins. */
+export const differentCredential = (
+  held: AccountState,
+  read: AccountState,
+): boolean => {
+  const before = signInOf(held);
+  const now = signInOf(read);
+  return before !== null && now !== null && before !== now;
+};
+
+/** Whether a settled read leaves a standing expiry where it is.
+ *
+ *  A read that finds no credential is the refusal's own doing, and one
+ *  that could not reach the server knows less than the server already
+ *  said: neither takes the verdict back. The exception is an offline
+ *  answer about a credential known to be a different one, which some
+ *  other process installed; the verdict was about the sign-in it named
+ *  and says nothing about this one. */
+export const keepsExpiry = (held: AccountState, read: AccountState): boolean =>
+  held.kind === "expired" &&
+  (read.kind === "signed-out" ||
+    (read.kind === "offline" && !differentCredential(held, read)));

--- a/ui/src/stores/account-state.ts
+++ b/ui/src/stores/account-state.ts
@@ -13,12 +13,17 @@ export interface AccountIdentity {
  * `signed-in` carries the identity once the backend has one; a credential
  * in the keychain is enough to be signed in before then. `offline` is a
  * credential we know the owner of but could not confirm; `expired` is one
- * the server no longer accepts. */
+ * the server no longer accepts.
+ *
+ * The states that hold a credential carry `signIn`, the name core minted
+ * for that sign-in. It arrives with the credential and comes back on
+ * every read of it, so two answers can be compared for whether they are
+ * about the same sign-in. */
 export type AccountState =
   | { kind: "loading" }
   | { kind: "signed-out" }
-  | { kind: "signed-in"; identity: AccountIdentity | null }
-  | { kind: "offline"; identity: AccountIdentity }
+  | { kind: "signed-in"; identity: AccountIdentity | null; signIn: string }
+  | { kind: "offline"; identity: AccountIdentity; signIn: string }
   | { kind: "expired" };
 
 /** Every state but the one that means "not read yet". */
@@ -31,35 +36,27 @@ type WithIdentity = Extract<AccountState, { kind: "signed-in" | "offline" }>;
 export const hasCredential = (account: AccountState): account is WithIdentity =>
   account.kind === "signed-in" || account.kind === "offline";
 
-export const cachedIdentity = (
-  account: AccountState,
-): AccountIdentity | null => (hasCredential(account) ? account.identity : null);
+/** The same credential, no longer confirmed: what a read that failed
+ *  leaves when it already knew who holds it. Null when there is nothing
+ *  to go offline with, which is a credential whose name has not been read
+ *  yet, or no credential at all. */
+export const asOffline = (account: AccountState): SettledAccount | null =>
+  hasCredential(account) && account.identity
+    ? { kind: "offline", identity: account.identity, signIn: account.signIn }
+    : null;
 
-/** Whether a read landed on the credential already held, as far as a read
- *  can tell.
+/** Whether two answers are about the same sign-in.
  *
- *  The question is whether the credential changed hands, not whether its
- *  name has arrived. A credential is stored before anything knows who it
- *  belongs to, so a state with no identity at all is transitional and the
- *  read landing here is the one that names it. That is the only wildcard.
- *  Between two identities that have both been read, a null `githubLogin`
- *  is a settled fact about an account whose GitHub link was removed, and
- *  it separates them from a linked one the way any other value would.
- *
- *  What this cannot separate: two read identities that agree on
- *  everything the app is given. A read is told who the account belongs to
- *  and nothing that tells one sign-in for that person from the next, so
- *  the same person signing in again, and two unlinked accounts sharing a
- *  name, both read as the credential already held. Separating those needs
- *  a stable per-sign-in identifier the app is not handed today. */
-export const sameAccount = (
+ * Core mints `signIn` when a sign-in is committed, carries it through
+ * every token rotation, and replaces it only when another sign-in
+ * replaces the credential. So this asks the question the caller actually
+ * has, which is whether the credential changed hands, rather than
+ * inferring it from the identity: a rename leaves the same credential,
+ * and signing in again as the same person leaves a different one under
+ * the same name. Neither is visible in what a read says about who the
+ * account belongs to. */
+export const sameCredential = (
   held: AccountState,
   read: AccountState,
-): boolean => {
-  if (!hasCredential(held) || !hasCredential(read)) return false;
-  if (held.identity === null || read.identity === null) return true;
-  return (
-    held.identity.githubLogin === read.identity.githubLogin &&
-    held.identity.name === read.identity.name
-  );
-};
+): boolean =>
+  hasCredential(held) && hasCredential(read) && held.signIn === read.signIn;

--- a/ui/src/stores/account-state.ts
+++ b/ui/src/stores/account-state.ts
@@ -56,42 +56,64 @@ export const asOffline = (account: AccountState): SettledAccount | null =>
 const signInOf = (account: AccountState): string | null =>
   "signIn" in account && account.signIn !== "" ? account.signIn : null;
 
-/* The two questions below both follow one rule: only a KNOWN difference is
- * a difference, and only a KNOWN match is a match. Neither is the negation
- * of the other, and their unknown branches deliberately disagree, because
- * each takes the answer that is safe for its own question.
+/** What a read says about the credential it found, set against the one
+ *  already held.
  *
- * `sameCredential` asks whether this is the credential already held, and
- * answering yes wrongly keeps another account's rows and lets an obsolete
- * refusal end the wrong sign-in. Unknown must not claim sameness.
+ *  Three answers, not two. `unknown` is not a shade of `different`: it is
+ *  the absence of an answer, and every caller has to decide for itself
+ *  what to do without one. A caller that treats it as either of the other
+ *  two will be wrong for one of the two questions below. */
+export type CredentialMatch = "same" | "different" | "unknown";
+
+export const credentialMatch = (
+  held: AccountState,
+  read: AccountState,
+): CredentialMatch => {
+  const before = signInOf(held);
+  const now = signInOf(read);
+  if (before === null || now === null) return "unknown";
+  return before === now ? "same" : "different";
+};
+
+/* What the callers make of `unknown`, which is the part worth reading
+ * together. Each takes the answer that is safe for its own question, and
+ * they are not the same answer:
  *
- * `differentCredential` asks whether to overturn an expiry the server
- * already ruled on, and answering yes wrongly hands back a submit under a
- * credential known to be dead. Unknown must not overturn it.
+ * Is this the credential already held? Unknown must not claim sameness,
+ * so the account is treated as having changed hands. Claiming it wrongly
+ * would keep another account's rows and let an obsolete refusal end the
+ * sign-in that replaced it.
  *
- * The cost of unknown falls on a credential stored before core named
- * sign-ins, at most one machine-wide: every read counts as a change of
- * hands, which refetches its rows, until the next sign-in names it. */
+ * May this overturn an expiry the server already ruled on? Unknown must
+ * not overturn it, so the verdict stands. Overturning it wrongly would
+ * hand back a submit under a credential known to be dead.
+ *
+ * Should the rows be asked for again? Unknown must ask. Rows are cleared
+ * whenever sameness cannot be proven, and not asking leaves the tab
+ * showing nothing at all, which is the one answer that is never right.
+ *
+ * The cost falls on a credential stored before core named sign-ins, at
+ * most one machine-wide: it can never be proven the same, so every read
+ * counts as a change of hands and refetches its rows. That is one extra
+ * call per read until the next sign-in names it. */
 
 /** Whether two answers are known to be about the same sign-in. */
 export const sameCredential = (
   held: AccountState,
   read: AccountState,
-): boolean => {
-  if (!hasCredential(held) || !hasCredential(read)) return false;
-  const before = signInOf(held);
-  return before !== null && before === signInOf(read);
-};
+): boolean =>
+  hasCredential(held) &&
+  hasCredential(read) &&
+  credentialMatch(held, read) === "same";
 
-/** Whether two answers are known to be about different sign-ins. */
-export const differentCredential = (
-  held: AccountState,
-  read: AccountState,
-): boolean => {
-  const before = signInOf(held);
-  const now = signInOf(read);
-  return before !== null && now !== null && before !== now;
-};
+/** Whether a read that changed hands should ask for the new account's
+ *  rows. Anything not proven the same asks, `unknown` included: the rows
+ *  were cleared on that same doubt, and leaving them cleared without
+ *  asking shows nothing at all. A credential this store never held is
+ *  not that case, so the first read of a session asks for nothing, and
+ *  one that is simply gone has nothing to ask for. */
+export const asksForRows = (held: AccountState, read: AccountState): boolean =>
+  hasCredential(held) && credentialMatch(held, read) !== "same";
 
 /** Whether a settled read leaves a standing expiry where it is.
  *
@@ -104,4 +126,4 @@ export const differentCredential = (
 export const keepsExpiry = (held: AccountState, read: AccountState): boolean =>
   held.kind === "expired" &&
   (read.kind === "signed-out" ||
-    (read.kind === "offline" && !differentCredential(held, read)));
+    (read.kind === "offline" && credentialMatch(held, read) !== "different"));

--- a/ui/src/stores/account.test.ts
+++ b/ui/src/stores/account.test.ts
@@ -1,5 +1,18 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { type AccountStatus, commands } from "@/bindings";
+import { commands } from "@/bindings";
+import {
+  ADA,
+  account,
+  answers,
+  BOB,
+  fresh,
+  load,
+  OTHER_SIGN_IN,
+  ROW,
+  SIGN_IN,
+  serves,
+  unreadable,
+} from "@/test/account-store";
 import {
   type AccountIdentity,
   hasCredential,
@@ -8,6 +21,7 @@ import {
 } from "./account";
 import { type AccountRead, setAccountReader } from "./account-read";
 
+// `vi.mock` is hoisted above the imports, so its factory cannot reach one.
 vi.mock("@/bindings", () => ({
   commands: {
     accountStatus: vi.fn(),
@@ -18,39 +32,6 @@ vi.mock("@/bindings", () => ({
     openUrl: vi.fn(),
   },
 }));
-
-const ADA = { name: "Ada Lovelace", githubLogin: "ada" };
-
-/** What the real command answers: the state the backend settled on. */
-const answers = (state: AccountStatus["state"]) =>
-  vi.mocked(commands.accountStatus).mockResolvedValue({
-    status: "ok",
-    data: { state, endpoint: "https://kendex.ai" },
-  } as Awaited<ReturnType<typeof commands.accountStatus>>);
-
-const unreadable = (why = "keychain locked") =>
-  vi.mocked(commands.accountStatus).mockResolvedValue({
-    status: "error",
-    error: why,
-  } as Awaited<ReturnType<typeof commands.accountStatus>>);
-
-/** What a backend that has reached the server answers with. */
-const serves = (account: SettledAccount) =>
-  setAccountReader(async () => ({ ok: account }));
-
-const load = () => useAccountStore.getState().load();
-const account = () => useAccountStore.getState().account;
-
-const fresh = () =>
-  useAccountStore.setState({
-    account: { kind: "loading" },
-    error: null,
-    readError: null,
-    submissions: null,
-    signingIn: false,
-    userCode: null,
-    reading: false,
-  });
 
 beforeEach(() => {
   fresh();
@@ -71,13 +52,21 @@ describe("the account state a read settles on", () => {
   });
 
   it("carries every state the command settles on", async () => {
-    answers({ state: "signed-in", identity: ADA });
+    answers({ state: "signed-in", identity: ADA, sign_in: SIGN_IN });
     await load();
-    expect(account()).toEqual({ kind: "signed-in", identity: ADA });
+    expect(account()).toEqual({
+      kind: "signed-in",
+      identity: ADA,
+      signIn: SIGN_IN,
+    });
 
-    answers({ state: "offline", identity: ADA });
+    answers({ state: "offline", identity: ADA, sign_in: SIGN_IN });
     await load();
-    expect(account()).toEqual({ kind: "offline", identity: ADA });
+    expect(account()).toEqual({
+      kind: "offline",
+      identity: ADA,
+      signIn: SIGN_IN,
+    });
 
     answers({ state: "expired" });
     await load();
@@ -94,21 +83,33 @@ describe("the account state a read settles on", () => {
     expect(account()).toEqual({ kind: "expired" });
 
     // Signing in is what takes it off the screen.
-    answers({ state: "signed-in", identity: ADA });
+    answers({ state: "signed-in", identity: ADA, sign_in: SIGN_IN });
     await load();
-    expect(account()).toEqual({ kind: "signed-in", identity: ADA });
+    expect(account()).toEqual({
+      kind: "signed-in",
+      identity: ADA,
+      signIn: SIGN_IN,
+    });
   });
 
   it("carries the identity the backend names", async () => {
-    serves({ kind: "signed-in", identity: ADA });
+    serves({ kind: "signed-in", identity: ADA, signIn: SIGN_IN });
     await load();
-    expect(account()).toEqual({ kind: "signed-in", identity: ADA });
+    expect(account()).toEqual({
+      kind: "signed-in",
+      identity: ADA,
+      signIn: SIGN_IN,
+    });
   });
 
   it("is offline with the cached identity when the server is unreachable", async () => {
-    serves({ kind: "offline", identity: ADA });
+    serves({ kind: "offline", identity: ADA, signIn: SIGN_IN });
     await load();
-    expect(account()).toEqual({ kind: "offline", identity: ADA });
+    expect(account()).toEqual({
+      kind: "offline",
+      identity: ADA,
+      signIn: SIGN_IN,
+    });
   });
 
   it("is expired when the credential is no longer accepted", async () => {
@@ -121,20 +122,30 @@ describe("the account state a read settles on", () => {
 // A read that failed knows nothing new, so it takes nothing away.
 describe("a read that could not be made", () => {
   it("becomes offline when a name is already in hand", async () => {
-    useAccountStore.setState({ account: { kind: "signed-in", identity: ADA } });
+    useAccountStore.setState({
+      account: { kind: "signed-in", identity: ADA, signIn: SIGN_IN },
+    });
     unreadable();
     await load();
-    expect(account()).toEqual({ kind: "offline", identity: ADA });
+    expect(account()).toEqual({
+      kind: "offline",
+      identity: ADA,
+      signIn: SIGN_IN,
+    });
     expect(useAccountStore.getState().readError).toBe("keychain locked");
   });
 
   it("leaves a credential with no name signed in", async () => {
     useAccountStore.setState({
-      account: { kind: "signed-in", identity: null },
+      account: { kind: "signed-in", identity: null, signIn: SIGN_IN },
     });
     unreadable();
     await load();
-    expect(account()).toEqual({ kind: "signed-in", identity: null });
+    expect(account()).toEqual({
+      kind: "signed-in",
+      identity: null,
+      signIn: SIGN_IN,
+    });
     expect(useAccountStore.getState().readError).toBe("keychain locked");
   });
 
@@ -235,7 +246,9 @@ describe("whether a read is out", () => {
   // A read the account outran is dropped, but it was still the last read
   // out: leaving the flag up would disable a retry with nothing to wait for.
   it("is false when the read it dropped was the last one out", async () => {
-    useAccountStore.setState({ account: { kind: "signed-in", identity: ADA } });
+    useAccountStore.setState({
+      account: { kind: "signed-in", identity: ADA, signIn: SIGN_IN },
+    });
     const gates = staged();
     const out = load();
     vi.mocked(commands.accountLogout).mockResolvedValue({
@@ -243,7 +256,7 @@ describe("whether a read is out", () => {
       data: null,
     } as Awaited<ReturnType<typeof commands.accountLogout>>);
     await useAccountStore.getState().signOut();
-    gates[0]?.({ ok: { kind: "signed-in", identity: ADA } });
+    gates[0]?.({ ok: { kind: "signed-in", identity: ADA, signIn: SIGN_IN } });
     await out;
     expect(reading()).toBe(false);
     expect(account()).toEqual({ kind: "signed-out" });
@@ -265,7 +278,7 @@ describe("an approved device flow", () => {
     } as Awaited<ReturnType<typeof commands.accountLoginStart>>);
     vi.mocked(commands.accountLoginPoll).mockResolvedValue({
       status: "ok",
-      data: "signed",
+      data: { kind: "signed", sign_in: SIGN_IN },
     } as Awaited<ReturnType<typeof commands.accountLoginPoll>>);
     vi.mocked(commands.openUrl).mockResolvedValue({
       status: "ok",
@@ -284,9 +297,13 @@ describe("an approved device flow", () => {
   beforeEach(approves);
 
   it("puts the name the read brings back on the account", async () => {
-    serves({ kind: "signed-in", identity: ADA });
+    serves({ kind: "signed-in", identity: ADA, signIn: SIGN_IN });
     await signIn();
-    expect(account()).toEqual({ kind: "signed-in", identity: ADA });
+    expect(account()).toEqual({
+      kind: "signed-in",
+      identity: ADA,
+      signIn: SIGN_IN,
+    });
     expect(useAccountStore.getState().signingIn).toBe(false);
   });
 
@@ -294,14 +311,18 @@ describe("an approved device flow", () => {
     unreadable();
     await signIn();
     expect(hasCredential(account())).toBe(true);
-    expect(account()).toEqual({ kind: "signed-in", identity: null });
+    expect(account()).toEqual({
+      kind: "signed-in",
+      identity: null,
+      signIn: SIGN_IN,
+    });
   });
 
   // One sign-in is one change of hands. The approval stores the
   // credential and the read that follows only names it, so counting that
   // read as a second handover discards work started on the first.
   it("counts one handover for the approval and the read that names it", async () => {
-    serves({ kind: "signed-in", identity: ADA });
+    serves({ kind: "signed-in", identity: ADA, signIn: SIGN_IN });
     const before = useAccountStore.getState().handovers();
     await signIn();
     expect(useAccountStore.getState().handovers()).toBe(before + 1);
@@ -326,7 +347,7 @@ describe("an approved device flow", () => {
     let polling: Promise<void> | null = null;
     setAccountReader(async () => {
       polling = useAccountStore.getState().loadSubmissions();
-      return { ok: { kind: "signed-in", identity: ADA } };
+      return { ok: { kind: "signed-in", identity: ADA, signIn: SIGN_IN } };
     });
 
     await signIn();
@@ -338,47 +359,61 @@ describe("an approved device flow", () => {
 
 // The read repeats on its own now, so it must not be able to write over
 // what the person just did.
-// `github_login` is null for an account whose GitHub link was removed,
-// not only for a credential nothing has read yet. The first is a settled
-// fact about a real account and the second is a state on its way
-// somewhere, and only the second is a wildcard.
-describe("a read finding an account with no GitHub link", () => {
-  const ADA_UNLINKED = { name: "Ada Lovelace", githubLogin: null };
-  const BOB_UNLINKED = { name: "Bob", githubLogin: null };
-  const ROW = {
-    repo: "ada/team-skills",
-    status: "pending",
-    status_reason: null,
-    head_commit: null,
-    indexed_at: null,
-  };
+// The identity says who the account belongs to. It cannot say which
+// sign-in the credential came from, and those come apart in both
+// directions: a person renames themselves or unlinks GitHub under one
+// credential, and signs in again to get a different credential under an
+// identity that has not changed at all.
+describe("what a read compares to decide the credential changed hands", () => {
+  const RENAMED = { name: "Ada L.", githubLogin: "ada" };
+  const UNLINKED = { name: "Ada Lovelace", githubLogin: null };
 
-  const heldThenRead = async (held: AccountIdentity, read: AccountIdentity) => {
-    useAccountStore.setState({
-      account: { kind: "signed-in", identity: held },
-      submissions: [ROW],
-    });
+  /** Reads `read` while `held` is on screen, and answers how many times
+   *  the account changed hands over it. */
+  const heldThenRead = async (held: SettledAccount, read: SettledAccount) => {
+    useAccountStore.setState({ account: held, submissions: [ROW] });
     const before = useAccountStore.getState().handovers();
-    serves({ kind: "signed-in", identity: read });
+    serves(read);
     await load();
     return useAccountStore.getState().handovers() - before;
   };
 
-  // Two unlinked accounts are still two accounts, and the rows the first
-  // one was holding are not the second one's to show.
-  it("counts one unlinked account replacing another as a change of hands", async () => {
-    expect(await heldThenRead(ADA_UNLINKED, BOB_UNLINKED)).toBe(1);
-    expect(useAccountStore.getState().submissions).toBeNull();
-    expect(account()).toEqual({ kind: "signed-in", identity: BOB_UNLINKED });
+  const signedIn = (identity: AccountIdentity, signIn = SIGN_IN) =>
+    ({ kind: "signed-in", identity, signIn }) as const;
+
+  // A profile rename is one account editing itself. Counting it as a
+  // change of hands would clear the rows, and with a submit in flight it
+  // would discard that credential's own expiry.
+  it("does not count a rename under one sign-in", async () => {
+    expect(await heldThenRead(signedIn(ADA), signedIn(RENAMED))).toBe(0);
+    expect(useAccountStore.getState().submissions).toEqual([ROW]);
   });
 
-  it("counts an unlinked account replacing a linked one too", async () => {
-    expect(await heldThenRead(ADA, ADA_UNLINKED)).toBe(1);
+  it("does not count the GitHub link being removed", async () => {
+    expect(await heldThenRead(signedIn(ADA), signedIn(UNLINKED))).toBe(0);
+    expect(useAccountStore.getState().submissions).toEqual([ROW]);
+  });
+
+  // The hole no comparison of identity fields could close: `kendex login`
+  // in a terminal, by the person already signed in. Everything a read is
+  // told about who they are is unchanged, and the credential is not the
+  // one the app was holding.
+  it("counts the same person signing in again", async () => {
+    expect(
+      await heldThenRead(signedIn(ADA), signedIn(ADA, OTHER_SIGN_IN)),
+    ).toBe(1);
     expect(useAccountStore.getState().submissions).toBeNull();
   });
 
-  it("leaves the same unlinked account where it is", async () => {
-    expect(await heldThenRead(ADA_UNLINKED, ADA_UNLINKED)).toBe(0);
+  it("counts a different person signing in", async () => {
+    expect(
+      await heldThenRead(signedIn(ADA), signedIn(BOB, OTHER_SIGN_IN)),
+    ).toBe(1);
+    expect(useAccountStore.getState().submissions).toBeNull();
+  });
+
+  it("counts nothing when the same sign-in is read again", async () => {
+    expect(await heldThenRead(signedIn(ADA), signedIn(ADA))).toBe(0);
     expect(useAccountStore.getState().submissions).toEqual([ROW]);
   });
 });
@@ -425,7 +460,9 @@ describe("a read racing a deliberate change", () => {
     return gates;
   };
 
-  const signedIn: AccountRead = { ok: { kind: "signed-in", identity: ADA } };
+  const signedIn: AccountRead = {
+    ok: { kind: "signed-in", identity: ADA, signIn: SIGN_IN },
+  };
 
   const logsOut = () =>
     vi.mocked(commands.accountLogout).mockResolvedValue({
@@ -445,7 +482,9 @@ describe("a read racing a deliberate change", () => {
   });
 
   it("drops a read that began before a sign-out", async () => {
-    useAccountStore.setState({ account: { kind: "signed-in", identity: ADA } });
+    useAccountStore.setState({
+      account: { kind: "signed-in", identity: ADA, signIn: SIGN_IN },
+    });
     const gates = staged();
     const reading = load();
     logsOut();
@@ -458,7 +497,9 @@ describe("a read racing a deliberate change", () => {
   // The sign-out is not the account changing hands; the reply that says
   // the credential is gone is. A read begun in between knows neither.
   it("drops a read that began while a sign-out was landing", async () => {
-    useAccountStore.setState({ account: { kind: "signed-in", identity: ADA } });
+    useAccountStore.setState({
+      account: { kind: "signed-in", identity: ADA, signIn: SIGN_IN },
+    });
     const answered: { now?: () => void } = {};
     vi.mocked(commands.accountLogout).mockReturnValue(
       new Promise((resolve) => {
@@ -480,7 +521,7 @@ describe("a read racing a deliberate change", () => {
   it("drops rows that arrive after the account changed hands", async () => {
     const arrivingAfter = async (change: () => Promise<void>) => {
       useAccountStore.setState({
-        account: { kind: "signed-in", identity: ADA },
+        account: { kind: "signed-in", identity: ADA, signIn: SIGN_IN },
         submissions: [],
       });
       vi.mocked(commands.mineSubmissions).mockImplementation(async () => {
@@ -508,7 +549,7 @@ describe("a read racing a deliberate change", () => {
   // to leave the same thing behind, or someone else's stay on screen.
   it("drops the submissions when a read finds the credential gone", async () => {
     useAccountStore.setState({
-      account: { kind: "signed-in", identity: ADA },
+      account: { kind: "signed-in", identity: ADA, signIn: SIGN_IN },
       submissions: [],
     });
     answers({ state: "signed-out" });
@@ -520,7 +561,7 @@ describe("a read racing a deliberate change", () => {
 describe("signing out", () => {
   it("goes to signed out and drops the submissions with it", async () => {
     useAccountStore.setState({
-      account: { kind: "signed-in", identity: ADA },
+      account: { kind: "signed-in", identity: ADA, signIn: SIGN_IN },
       submissions: [],
     });
     vi.mocked(commands.accountLogout).mockResolvedValue({
@@ -551,222 +592,17 @@ describe("which states go looking for submissions", () => {
   };
 
   it("asks while a credential is held", async () => {
-    expect(await asks({ kind: "signed-in", identity: ADA })).toBe(true);
+    expect(
+      await asks({ kind: "signed-in", identity: ADA, signIn: SIGN_IN }),
+    ).toBe(true);
     vi.clearAllMocks();
-    expect(await asks({ kind: "offline", identity: ADA })).toBe(true);
+    expect(
+      await asks({ kind: "offline", identity: ADA, signIn: SIGN_IN }),
+    ).toBe(true);
   });
 
   it("does not ask once it is signed out or expired", async () => {
     expect(await asks({ kind: "signed-out" })).toBe(false);
     expect(await asks({ kind: "expired" })).toBe(false);
-  });
-});
-
-// A command made under the sign-in is the second way the credential is
-// found to have ended; the read is the first. What the two leave behind
-// has to be the same thing, or the sidebar and Settings > Account answer
-// to two rules about one account.
-describe("a call refused because the sign-in expired", () => {
-  const expired = { kind: "expired" as const, message: "run login again" };
-
-  /** The refusal landing under the account it was made for. */
-  const met = () =>
-    useAccountStore
-      .getState()
-      .refused(expired, useAccountStore.getState().handovers());
-
-  it("goes to expired and drops the rows with it", () => {
-    useAccountStore.setState({
-      account: { kind: "signed-in", identity: ADA },
-      submissions: [],
-    });
-    met();
-    expect(account()).toEqual({ kind: "expired" });
-    expect(useAccountStore.getState().submissions).toBeNull();
-  });
-
-  it("keeps the explanation through the read that follows it", async () => {
-    useAccountStore.setState({ account: { kind: "signed-in", identity: ADA } });
-    met();
-    // The refusal cleared the credential, so this read finds none and
-    // says signed out. What the command learned has to outlive it.
-    answers({ state: "signed-out" });
-    await load();
-    expect(account()).toEqual({ kind: "expired" });
-  });
-
-  // KEN-742 leaves the credential, and its cached identity, where the
-  // removal fails. An outage then answers `offline` for a sign-in the
-  // server has already refused, and offline holds a credential: without
-  // the same rule the signed-out answer gets, the dead sign-in comes
-  // back usable and the Submit it cannot carry is offered again.
-  it("keeps expired through a read that could not reach the server", async () => {
-    useAccountStore.setState({ account: { kind: "signed-in", identity: ADA } });
-    met();
-    expect(account()).toEqual({ kind: "expired" });
-
-    serves({ kind: "offline", identity: ADA });
-    await load();
-
-    expect(account()).toEqual({ kind: "expired" });
-    // What the submit dialog gates its Submit button on.
-    expect(hasCredential(account())).toBe(false);
-  });
-
-  it("drops rows already out for the credential it ended", async () => {
-    useAccountStore.setState({
-      account: { kind: "signed-in", identity: ADA },
-      submissions: null,
-    });
-    vi.mocked(commands.mineSubmissions).mockImplementation(async () => {
-      met();
-      return { status: "ok", data: [] } as Awaited<
-        ReturnType<typeof commands.mineSubmissions>
-      >;
-    });
-    await useAccountStore.getState().loadSubmissions();
-    expect(useAccountStore.getState().submissions).toBeNull();
-  });
-
-  it("changes nothing once the account has already moved on", () => {
-    // A sign-out taken while the call was out is the person's own
-    // answer; the rejection that lands behind it is about a credential
-    // they already gave up.
-    useAccountStore.setState({ account: { kind: "signed-out" } });
-    met();
-    expect(account()).toEqual({ kind: "signed-out" });
-  });
-
-  // The expiry belongs to the credential the call went out under. A
-  // submit is in flight for as long as the server takes, and the sign-in
-  // can be replaced inside that window: a sign-out, a device flow
-  // finishing behind the dialog, or `kendex login` in a terminal, which
-  // the next window focus reads. Ending the account over an expiry that
-  // is not about the credential on screen signs the person out of the
-  // one they just signed into.
-  describe("that lands after the sign-in it was made under is gone", () => {
-    const BOB = { name: "Bob", githubLogin: "bob" };
-    const ROW = {
-      repo: "ada/team-skills",
-      status: "pending",
-      status_reason: null,
-      head_commit: null,
-      indexed_at: null,
-    };
-
-    /** Submits under the account on screen, replaces the sign-in with
-     *  `replace` while it is in flight, and lands the expiry behind it.
-     *  Answers what the store settled on before the refusal, which is
-     *  what a refusal about a credential nobody holds must leave. */
-    const refusedAfter = async (replace: () => Promise<void>) => {
-      useAccountStore.setState({
-        account: { kind: "signed-in", identity: ADA },
-        submissions: [ROW],
-      });
-      const since = useAccountStore.getState().handovers();
-      await replace();
-      const settled = {
-        account: account(),
-        submissions: useAccountStore.getState().submissions,
-      };
-      useAccountStore.getState().refused(expired, since);
-      return settled;
-    };
-
-    /** Nothing the refusal did: the account and its rows as they were. */
-    const unchangedFrom = (settled: {
-      account: ReturnType<typeof account>;
-      submissions: ReturnType<typeof useAccountStore.getState>["submissions"];
-    }) => {
-      expect(account()).toEqual(settled.account);
-      expect(useAccountStore.getState().submissions).toEqual(
-        settled.submissions,
-      );
-    };
-
-    it("leaves a sign-out where it found it", async () => {
-      vi.mocked(commands.accountLogout).mockResolvedValue({
-        status: "ok",
-        data: null,
-      } as Awaited<ReturnType<typeof commands.accountLogout>>);
-      const settled = await refusedAfter(() =>
-        useAccountStore.getState().signOut(),
-      );
-      unchangedFrom(settled);
-      expect(account()).toEqual({ kind: "signed-out" });
-    });
-
-    it("leaves the credential a device flow put there in its place", async () => {
-      vi.mocked(commands.accountLoginStart).mockResolvedValue({
-        status: "ok",
-        data: {
-          deviceCode: "kxd_test",
-          userCode: "ABCD-2345",
-          verificationUrl: "https://kendex.ai/device",
-          intervalSeconds: 1,
-        },
-      } as Awaited<ReturnType<typeof commands.accountLoginStart>>);
-      vi.mocked(commands.accountLoginPoll).mockResolvedValue({
-        status: "ok",
-        data: "signed",
-      } as Awaited<ReturnType<typeof commands.accountLoginPoll>>);
-      vi.mocked(commands.openUrl).mockResolvedValue({
-        status: "ok",
-        data: null,
-      } as Awaited<ReturnType<typeof commands.openUrl>>);
-      serves({ kind: "signed-in", identity: BOB });
-
-      const settled = await refusedAfter(async () => {
-        vi.useFakeTimers();
-        const signing = useAccountStore.getState().signIn();
-        await vi.advanceTimersByTimeAsync(1100);
-        await signing;
-        vi.useRealTimers();
-      });
-
-      unchangedFrom(settled);
-      expect(account()).toEqual({ kind: "signed-in", identity: BOB });
-    });
-
-    // The route a terminal `kendex login` takes: nothing in the app signs
-    // in, and the replacement arrives as a read that finds a credential
-    // where there was already one.
-    it("leaves a credential a terminal login put there in its place", async () => {
-      serves({ kind: "signed-in", identity: BOB });
-      const settled = await refusedAfter(load);
-
-      unchangedFrom(settled);
-      expect(account()).toEqual({ kind: "signed-in", identity: BOB });
-      // The rows went with the account that owned them, at the read that
-      // saw the change of hands, not at the refusal that landed after.
-      expect(useAccountStore.getState().submissions).toBeNull();
-    });
-  });
-
-  it("says nothing about the account when the refusal is anything else", () => {
-    const signedIn = { kind: "signed-in" as const, identity: ADA };
-    useAccountStore.setState({ account: signedIn, submissions: [] });
-    useAccountStore
-      .getState()
-      .refused(
-        { kind: "failed", message: "kendex.ai could not be reached" },
-        useAccountStore.getState().handovers(),
-      );
-    expect(account()).toEqual(signedIn);
-    expect(useAccountStore.getState().submissions).toEqual([]);
-  });
-
-  it("is what a submissions poll does with the refusal it gets", async () => {
-    useAccountStore.setState({
-      account: { kind: "signed-in", identity: ADA },
-      submissions: [],
-    });
-    vi.mocked(commands.mineSubmissions).mockResolvedValue({
-      status: "error",
-      error: expired,
-    } as Awaited<ReturnType<typeof commands.mineSubmissions>>);
-    await useAccountStore.getState().loadSubmissions();
-    expect(account()).toEqual({ kind: "expired" });
-    expect(useAccountStore.getState().submissions).toBeNull();
   });
 });

--- a/ui/src/stores/account.test.ts
+++ b/ui/src/stores/account.test.ts
@@ -473,3 +473,81 @@ describe("which states go looking for submissions", () => {
     expect(await asks({ kind: "expired" })).toBe(false);
   });
 });
+
+// A command made under the sign-in is the second way the credential is
+// found to have ended; the read is the first. What the two leave behind
+// has to be the same thing, or the sidebar and Settings > Account answer
+// to two rules about one account.
+describe("a call refused because the sign-in expired", () => {
+  const expired = { kind: "expired" as const, message: "run login again" };
+
+  const met = () => useAccountStore.getState().refused(expired);
+
+  it("goes to expired and drops the rows with it", () => {
+    useAccountStore.setState({
+      account: { kind: "signed-in", identity: ADA },
+      submissions: [],
+    });
+    met();
+    expect(account()).toEqual({ kind: "expired" });
+    expect(useAccountStore.getState().submissions).toBeNull();
+  });
+
+  it("keeps the explanation through the read that follows it", async () => {
+    useAccountStore.setState({ account: { kind: "signed-in", identity: ADA } });
+    met();
+    // Meeting expiry is what cleared the credential, so the next read
+    // finds none. What the command learned has to outlive that read.
+    answers({ state: "signed-out" });
+    await load();
+    expect(account()).toEqual({ kind: "expired" });
+  });
+
+  it("drops rows already out for the credential it ended", async () => {
+    useAccountStore.setState({
+      account: { kind: "signed-in", identity: ADA },
+      submissions: null,
+    });
+    vi.mocked(commands.mineSubmissions).mockImplementation(async () => {
+      met();
+      return { status: "ok", data: [] } as Awaited<
+        ReturnType<typeof commands.mineSubmissions>
+      >;
+    });
+    await useAccountStore.getState().loadSubmissions();
+    expect(useAccountStore.getState().submissions).toBeNull();
+  });
+
+  it("changes nothing once the account has already moved on", () => {
+    // A sign-out taken while the call was out is the person's own
+    // answer; the rejection that lands behind it is about a credential
+    // they already gave up.
+    useAccountStore.setState({ account: { kind: "signed-out" } });
+    met();
+    expect(account()).toEqual({ kind: "signed-out" });
+  });
+
+  it("says nothing about the account when the refusal is anything else", () => {
+    const signedIn = { kind: "signed-in" as const, identity: ADA };
+    useAccountStore.setState({ account: signedIn, submissions: [] });
+    useAccountStore
+      .getState()
+      .refused({ kind: "failed", message: "kendex.ai could not be reached" });
+    expect(account()).toEqual(signedIn);
+    expect(useAccountStore.getState().submissions).toEqual([]);
+  });
+
+  it("is what a submissions poll does with the refusal it gets", async () => {
+    useAccountStore.setState({
+      account: { kind: "signed-in", identity: ADA },
+      submissions: [],
+    });
+    vi.mocked(commands.mineSubmissions).mockResolvedValue({
+      status: "error",
+      error: expired,
+    } as Awaited<ReturnType<typeof commands.mineSubmissions>>);
+    await useAccountStore.getState().loadSubmissions();
+    expect(account()).toEqual({ kind: "expired" });
+    expect(useAccountStore.getState().submissions).toBeNull();
+  });
+});

--- a/ui/src/stores/account.test.ts
+++ b/ui/src/stores/account.test.ts
@@ -68,19 +68,19 @@ describe("the account state a read settles on", () => {
       signIn: SIGN_IN,
     });
 
-    answers({ state: "expired" });
+    answers({ state: "expired", sign_in: SIGN_IN });
     await load();
-    expect(account()).toEqual({ kind: "expired" });
+    expect(account()).toEqual({ kind: "expired", signIn: SIGN_IN });
   });
 
   it("keeps the expired explanation on the read that follows it", async () => {
-    answers({ state: "expired" });
+    answers({ state: "expired", sign_in: SIGN_IN });
     await load();
     // Answering expired is what clears the credential, so the next read
     // finds none. The explanation has to outlive that read.
     answers({ state: "signed-out" });
     await load();
-    expect(account()).toEqual({ kind: "expired" });
+    expect(account()).toEqual({ kind: "expired", signIn: SIGN_IN });
 
     // Signing in is what takes it off the screen.
     answers({ state: "signed-in", identity: ADA, sign_in: SIGN_IN });
@@ -113,9 +113,9 @@ describe("the account state a read settles on", () => {
   });
 
   it("is expired when the credential is no longer accepted", async () => {
-    serves({ kind: "expired" });
+    serves({ kind: "expired", signIn: SIGN_IN });
     await load();
-    expect(account()).toEqual({ kind: "expired" });
+    expect(account()).toEqual({ kind: "expired", signIn: SIGN_IN });
   });
 });
 
@@ -412,6 +412,24 @@ describe("what a read compares to decide the credential changed hands", () => {
     expect(useAccountStore.getState().submissions).toBeNull();
   });
 
+  // Core defaults `sign_in` so a credential stored before the field
+  // existed still parses instead of signing that person out, and it reads
+  // back empty. Empty is the absence of an answer: two such credentials
+  // are unrelated, and calling them one sign-in would keep the first
+  // account's rows under the second.
+  it("counts a change of hands between two unnamed credentials", async () => {
+    expect(await heldThenRead(signedIn(ADA, ""), signedIn(BOB, ""))).toBe(1);
+    expect(useAccountStore.getState().submissions).toBeNull();
+  });
+
+  it("counts one even where nothing else about them differs", async () => {
+    expect(await heldThenRead(signedIn(ADA, ""), signedIn(ADA, ""))).toBe(1);
+  });
+
+  it("counts one when a named credential replaces an unnamed one", async () => {
+    expect(await heldThenRead(signedIn(ADA, ""), signedIn(ADA))).toBe(1);
+  });
+
   it("counts nothing when the same sign-in is read again", async () => {
     expect(await heldThenRead(signedIn(ADA), signedIn(ADA))).toBe(0);
     expect(useAccountStore.getState().submissions).toEqual([ROW]);
@@ -603,6 +621,6 @@ describe("which states go looking for submissions", () => {
 
   it("does not ask once it is signed out or expired", async () => {
     expect(await asks({ kind: "signed-out" })).toBe(false);
-    expect(await asks({ kind: "expired" })).toBe(false);
+    expect(await asks({ kind: "expired", signIn: SIGN_IN })).toBe(false);
   });
 });

--- a/ui/src/stores/account.test.ts
+++ b/ui/src/stores/account.test.ts
@@ -427,7 +427,8 @@ describe("what a read compares to decide the credential changed hands", () => {
   // account's rows under the second.
   it("counts a change of hands between two unnamed credentials", async () => {
     expect(await heldThenRead(signedIn(ADA, ""), signedIn(BOB, ""))).toBe(1);
-    expect(useAccountStore.getState().submissions).toBeNull();
+    // Cleared on the doubt, and asked for again on the same doubt.
+    expect(useAccountStore.getState().submissions).toEqual([]);
   });
 
   it("counts one even where nothing else about them differs", async () => {
@@ -463,6 +464,28 @@ describe("what a read compares to decide the credential changed hands", () => {
   // The store's one read at startup settles an account it never held, and
   // that is not a credential being replaced. Submissions stay the Mine
   // tab's to ask for, as the store's "no surface reads on mount" says.
+  // A credential that predates the field can never be proven the same as
+  // the next one, so every read clears its rows. If the refetch waits for
+  // a proven difference the tab is emptied and stays empty, for exactly
+  // the people whose credential cannot answer, until they sign in again.
+  it("asks again for an unnamed credential it cannot prove unchanged", async () => {
+    const THEIRS = { ...ROW, repo: "ada/other-skills" };
+    vi.mocked(commands.mineSubmissions).mockResolvedValue({
+      status: "ok",
+      data: [THEIRS],
+    } as Awaited<ReturnType<typeof commands.mineSubmissions>>);
+    useAccountStore.setState({
+      account: signedIn(ADA, ""),
+      submissions: [ROW],
+    });
+
+    serves(signedIn(ADA, ""));
+    await load();
+
+    expect(useAccountStore.getState().submissions).toEqual([THEIRS]);
+    expect(commands.mineSubmissions).toHaveBeenCalledTimes(1);
+  });
+
   it("asks for nothing on the first read of the session", async () => {
     serves(signedIn(ADA));
     await load();

--- a/ui/src/stores/account.test.ts
+++ b/ui/src/stores/account.test.ts
@@ -496,8 +496,8 @@ describe("a call refused because the sign-in expired", () => {
   it("keeps the explanation through the read that follows it", async () => {
     useAccountStore.setState({ account: { kind: "signed-in", identity: ADA } });
     met();
-    // Meeting expiry is what cleared the credential, so the next read
-    // finds none. What the command learned has to outlive that read.
+    // The refusal cleared the credential, so this read finds none and
+    // says signed out. What the command learned has to outlive it.
     answers({ state: "signed-out" });
     await load();
     expect(account()).toEqual({ kind: "expired" });

--- a/ui/src/stores/account.test.ts
+++ b/ui/src/stores/account.test.ts
@@ -1,6 +1,11 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { type AccountStatus, commands } from "@/bindings";
-import { hasCredential, type SettledAccount, useAccountStore } from "./account";
+import {
+  type AccountIdentity,
+  hasCredential,
+  type SettledAccount,
+  useAccountStore,
+} from "./account";
 import { type AccountRead, setAccountReader } from "./account-read";
 
 vi.mock("@/bindings", () => ({
@@ -333,6 +338,51 @@ describe("an approved device flow", () => {
 
 // The read repeats on its own now, so it must not be able to write over
 // what the person just did.
+// `github_login` is null for an account whose GitHub link was removed,
+// not only for a credential nothing has read yet. The first is a settled
+// fact about a real account and the second is a state on its way
+// somewhere, and only the second is a wildcard.
+describe("a read finding an account with no GitHub link", () => {
+  const ADA_UNLINKED = { name: "Ada Lovelace", githubLogin: null };
+  const BOB_UNLINKED = { name: "Bob", githubLogin: null };
+  const ROW = {
+    repo: "ada/team-skills",
+    status: "pending",
+    status_reason: null,
+    head_commit: null,
+    indexed_at: null,
+  };
+
+  const heldThenRead = async (held: AccountIdentity, read: AccountIdentity) => {
+    useAccountStore.setState({
+      account: { kind: "signed-in", identity: held },
+      submissions: [ROW],
+    });
+    const before = useAccountStore.getState().handovers();
+    serves({ kind: "signed-in", identity: read });
+    await load();
+    return useAccountStore.getState().handovers() - before;
+  };
+
+  // Two unlinked accounts are still two accounts, and the rows the first
+  // one was holding are not the second one's to show.
+  it("counts one unlinked account replacing another as a change of hands", async () => {
+    expect(await heldThenRead(ADA_UNLINKED, BOB_UNLINKED)).toBe(1);
+    expect(useAccountStore.getState().submissions).toBeNull();
+    expect(account()).toEqual({ kind: "signed-in", identity: BOB_UNLINKED });
+  });
+
+  it("counts an unlinked account replacing a linked one too", async () => {
+    expect(await heldThenRead(ADA, ADA_UNLINKED)).toBe(1);
+    expect(useAccountStore.getState().submissions).toBeNull();
+  });
+
+  it("leaves the same unlinked account where it is", async () => {
+    expect(await heldThenRead(ADA_UNLINKED, ADA_UNLINKED)).toBe(0);
+    expect(useAccountStore.getState().submissions).toEqual([ROW]);
+  });
+});
+
 describe("a read racing a deliberate change", () => {
   it("leaves a denied approval its explanation", async () => {
     vi.mocked(commands.accountLoginStart).mockResolvedValue({

--- a/ui/src/stores/account.test.ts
+++ b/ui/src/stores/account.test.ts
@@ -291,6 +291,44 @@ describe("an approved device flow", () => {
     expect(hasCredential(account())).toBe(true);
     expect(account()).toEqual({ kind: "signed-in", identity: null });
   });
+
+  // One sign-in is one change of hands. The approval stores the
+  // credential and the read that follows only names it, so counting that
+  // read as a second handover discards work started on the first.
+  it("counts one handover for the approval and the read that names it", async () => {
+    serves({ kind: "signed-in", identity: ADA });
+    const before = useAccountStore.getState().handovers();
+    await signIn();
+    expect(useAccountStore.getState().handovers()).toBe(before + 1);
+  });
+
+  // The Mine tab asks for submissions the moment a credential exists,
+  // which is before the read that names it lands. A second handover in
+  // between discards the answer, and the rows read as unsubmitted until
+  // the next sixty-second tick.
+  it("keeps rows asked for on approval through the read that names it", async () => {
+    const ROW = {
+      repo: "ada/team-skills",
+      status: "pending",
+      status_reason: null,
+      head_commit: null,
+      indexed_at: null,
+    };
+    vi.mocked(commands.mineSubmissions).mockResolvedValue({
+      status: "ok",
+      data: [ROW],
+    } as Awaited<ReturnType<typeof commands.mineSubmissions>>);
+    let polling: Promise<void> | null = null;
+    setAccountReader(async () => {
+      polling = useAccountStore.getState().loadSubmissions();
+      return { ok: { kind: "signed-in", identity: ADA } };
+    });
+
+    await signIn();
+    await polling;
+
+    expect(useAccountStore.getState().submissions).toEqual([ROW]);
+  });
 });
 
 // The read repeats on its own now, so it must not be able to write over
@@ -505,6 +543,24 @@ describe("a call refused because the sign-in expired", () => {
     answers({ state: "signed-out" });
     await load();
     expect(account()).toEqual({ kind: "expired" });
+  });
+
+  // KEN-742 leaves the credential, and its cached identity, where the
+  // removal fails. An outage then answers `offline` for a sign-in the
+  // server has already refused, and offline holds a credential: without
+  // the same rule the signed-out answer gets, the dead sign-in comes
+  // back usable and the Submit it cannot carry is offered again.
+  it("keeps expired through a read that could not reach the server", async () => {
+    useAccountStore.setState({ account: { kind: "signed-in", identity: ADA } });
+    met();
+    expect(account()).toEqual({ kind: "expired" });
+
+    serves({ kind: "offline", identity: ADA });
+    await load();
+
+    expect(account()).toEqual({ kind: "expired" });
+    // What the submit dialog gates its Submit button on.
+    expect(hasCredential(account())).toBe(false);
   });
 
   it("drops rows already out for the credential it ended", async () => {

--- a/ui/src/stores/account.test.ts
+++ b/ui/src/stores/account.test.ts
@@ -36,6 +36,12 @@ vi.mock("@/bindings", () => ({
 beforeEach(() => {
   fresh();
   vi.clearAllMocks();
+  // A read that finds the credential replaced asks for the new account's
+  // rows, so the harness has an answer for it.
+  vi.mocked(commands.mineSubmissions).mockResolvedValue({
+    status: "ok",
+    data: [],
+  } as Awaited<ReturnType<typeof commands.mineSubmissions>>);
 });
 
 afterEach(() => setAccountReader(null));
@@ -402,14 +408,16 @@ describe("what a read compares to decide the credential changed hands", () => {
     expect(
       await heldThenRead(signedIn(ADA), signedIn(ADA, OTHER_SIGN_IN)),
     ).toBe(1);
-    expect(useAccountStore.getState().submissions).toBeNull();
+    // The last credential's rows are gone and the new one's are asked
+    // for, which is what the harness answers with here.
+    expect(useAccountStore.getState().submissions).toEqual([]);
   });
 
   it("counts a different person signing in", async () => {
     expect(
       await heldThenRead(signedIn(ADA), signedIn(BOB, OTHER_SIGN_IN)),
     ).toBe(1);
-    expect(useAccountStore.getState().submissions).toBeNull();
+    expect(useAccountStore.getState().submissions).toEqual([]);
   });
 
   // Core defaults `sign_in` so a credential stored before the field
@@ -428,6 +436,51 @@ describe("what a read compares to decide the credential changed hands", () => {
 
   it("counts one when a named credential replaces an unnamed one", async () => {
     expect(await heldThenRead(signedIn(ADA, ""), signedIn(ADA))).toBe(1);
+  });
+
+  // The Mine tab's poll is keyed to being signed in, which never stops
+  // being true across a swap, so nothing asks again for up to a minute.
+  // Clearing the last account's rows is the floor; the new account's
+  // rows are what belongs on screen.
+  it("asks for the new sign-in's rows rather than leaving the tab empty", async () => {
+    const THEIRS = { ...ROW, repo: "bob/team-skills" };
+    vi.mocked(commands.mineSubmissions).mockResolvedValue({
+      status: "ok",
+      data: [THEIRS],
+    } as Awaited<ReturnType<typeof commands.mineSubmissions>>);
+    useAccountStore.setState({
+      account: signedIn(ADA),
+      submissions: [ROW],
+    });
+
+    serves(signedIn(BOB, OTHER_SIGN_IN));
+    await load();
+
+    expect(useAccountStore.getState().submissions).toEqual([THEIRS]);
+    expect(commands.mineSubmissions).toHaveBeenCalledTimes(1);
+  });
+
+  // The store's one read at startup settles an account it never held, and
+  // that is not a credential being replaced. Submissions stay the Mine
+  // tab's to ask for, as the store's "no surface reads on mount" says.
+  it("asks for nothing on the first read of the session", async () => {
+    serves(signedIn(ADA));
+    await load();
+
+    expect(commands.mineSubmissions).not.toHaveBeenCalled();
+  });
+
+  it("asks for nothing when the same sign-in is read again", async () => {
+    useAccountStore.setState({
+      account: signedIn(ADA),
+      submissions: [ROW],
+    });
+
+    serves(signedIn(ADA));
+    await load();
+
+    expect(useAccountStore.getState().submissions).toEqual([ROW]);
+    expect(commands.mineSubmissions).not.toHaveBeenCalled();
   });
 
   it("counts nothing when the same sign-in is read again", async () => {

--- a/ui/src/stores/account.test.ts
+++ b/ui/src/stores/account.test.ts
@@ -481,7 +481,11 @@ describe("which states go looking for submissions", () => {
 describe("a call refused because the sign-in expired", () => {
   const expired = { kind: "expired" as const, message: "run login again" };
 
-  const met = () => useAccountStore.getState().refused(expired);
+  /** The refusal landing under the account it was made for. */
+  const met = () =>
+    useAccountStore
+      .getState()
+      .refused(expired, useAccountStore.getState().handovers());
 
   it("goes to expired and drops the rows with it", () => {
     useAccountStore.setState({
@@ -527,12 +531,121 @@ describe("a call refused because the sign-in expired", () => {
     expect(account()).toEqual({ kind: "signed-out" });
   });
 
+  // The expiry belongs to the credential the call went out under. A
+  // submit is in flight for as long as the server takes, and the sign-in
+  // can be replaced inside that window: a sign-out, a device flow
+  // finishing behind the dialog, or `kendex login` in a terminal, which
+  // the next window focus reads. Ending the account over an expiry that
+  // is not about the credential on screen signs the person out of the
+  // one they just signed into.
+  describe("that lands after the sign-in it was made under is gone", () => {
+    const BOB = { name: "Bob", githubLogin: "bob" };
+    const ROW = {
+      repo: "ada/team-skills",
+      status: "pending",
+      status_reason: null,
+      head_commit: null,
+      indexed_at: null,
+    };
+
+    /** Submits under the account on screen, replaces the sign-in with
+     *  `replace` while it is in flight, and lands the expiry behind it.
+     *  Answers what the store settled on before the refusal, which is
+     *  what a refusal about a credential nobody holds must leave. */
+    const refusedAfter = async (replace: () => Promise<void>) => {
+      useAccountStore.setState({
+        account: { kind: "signed-in", identity: ADA },
+        submissions: [ROW],
+      });
+      const since = useAccountStore.getState().handovers();
+      await replace();
+      const settled = {
+        account: account(),
+        submissions: useAccountStore.getState().submissions,
+      };
+      useAccountStore.getState().refused(expired, since);
+      return settled;
+    };
+
+    /** Nothing the refusal did: the account and its rows as they were. */
+    const unchangedFrom = (settled: {
+      account: ReturnType<typeof account>;
+      submissions: ReturnType<typeof useAccountStore.getState>["submissions"];
+    }) => {
+      expect(account()).toEqual(settled.account);
+      expect(useAccountStore.getState().submissions).toEqual(
+        settled.submissions,
+      );
+    };
+
+    it("leaves a sign-out where it found it", async () => {
+      vi.mocked(commands.accountLogout).mockResolvedValue({
+        status: "ok",
+        data: null,
+      } as Awaited<ReturnType<typeof commands.accountLogout>>);
+      const settled = await refusedAfter(() =>
+        useAccountStore.getState().signOut(),
+      );
+      unchangedFrom(settled);
+      expect(account()).toEqual({ kind: "signed-out" });
+    });
+
+    it("leaves the credential a device flow put there in its place", async () => {
+      vi.mocked(commands.accountLoginStart).mockResolvedValue({
+        status: "ok",
+        data: {
+          deviceCode: "kxd_test",
+          userCode: "ABCD-2345",
+          verificationUrl: "https://kendex.ai/device",
+          intervalSeconds: 1,
+        },
+      } as Awaited<ReturnType<typeof commands.accountLoginStart>>);
+      vi.mocked(commands.accountLoginPoll).mockResolvedValue({
+        status: "ok",
+        data: "signed",
+      } as Awaited<ReturnType<typeof commands.accountLoginPoll>>);
+      vi.mocked(commands.openUrl).mockResolvedValue({
+        status: "ok",
+        data: null,
+      } as Awaited<ReturnType<typeof commands.openUrl>>);
+      serves({ kind: "signed-in", identity: BOB });
+
+      const settled = await refusedAfter(async () => {
+        vi.useFakeTimers();
+        const signing = useAccountStore.getState().signIn();
+        await vi.advanceTimersByTimeAsync(1100);
+        await signing;
+        vi.useRealTimers();
+      });
+
+      unchangedFrom(settled);
+      expect(account()).toEqual({ kind: "signed-in", identity: BOB });
+    });
+
+    // The route a terminal `kendex login` takes: nothing in the app signs
+    // in, and the replacement arrives as a read that finds a credential
+    // where there was already one.
+    it("leaves a credential a terminal login put there in its place", async () => {
+      serves({ kind: "signed-in", identity: BOB });
+      const settled = await refusedAfter(load);
+
+      unchangedFrom(settled);
+      expect(account()).toEqual({ kind: "signed-in", identity: BOB });
+      // The rows went with the account that owned them, at the read that
+      // saw the change of hands, not at the refusal that landed after.
+      expect(useAccountStore.getState().submissions).toBeNull();
+    });
+  });
+
   it("says nothing about the account when the refusal is anything else", () => {
     const signedIn = { kind: "signed-in" as const, identity: ADA };
     useAccountStore.setState({ account: signedIn, submissions: [] });
     useAccountStore
       .getState()
-      .refused({ kind: "failed", message: "kendex.ai could not be reached" });
+      .refused(
+        { kind: "failed", message: "kendex.ai could not be reached" },
+        useAccountStore.getState().handovers(),
+      );
     expect(account()).toEqual(signedIn);
     expect(useAccountStore.getState().submissions).toEqual([]);
   });

--- a/ui/src/stores/account.ts
+++ b/ui/src/stores/account.ts
@@ -72,10 +72,11 @@ interface AccountStore {
   signOut: () => Promise<void>;
   loadSubmissions: () => Promise<void>;
   /** A call made under the sign-in, read for what its refusal says about
-   *  the account. Expiry is the credential ending, and the call that met
-   *  it is what took the credential away, so it leaves behind what
-   *  signing out leaves. Every other refusal is news about that one
-   *  action and about nothing else, and stays where it was made. */
+   *  the account. Expiry is the credential ending: the sign-in is dead
+   *  server-side and nothing on this machine can revive it, so it leaves
+   *  behind what signing out leaves. Every other refusal is news about
+   *  that one action and about nothing else, and stays where it was
+   *  made. */
   refused: (refusal: AccountCallRefused) => void;
 }
 
@@ -90,6 +91,18 @@ let handover = 0;
 /** Reads in the order they were asked for. Only the newest may land: two
  *  can be out at once, and the slower one is not the truer one. */
 let reads = 0;
+
+/** What the end of a credential leaves behind, wherever it ends: the rows
+ *  were its, and a read that failed under it explains an account nobody
+ *  holds any more. The `handover` bump is the change of hands itself, so
+ *  a read still out for the old credential is abandoned. Callers keep
+ *  their own guards; only the write is shared. */
+const credentialEnded = (
+  account: AccountState,
+): Pick<AccountStore, "account" | "submissions" | "readError"> => {
+  handover += 1;
+  return { account, submissions: null, readError: null };
+};
 
 const wait = (seconds: number) =>
   new Promise((resolve) => setTimeout(resolve, seconds * 1000));
@@ -135,19 +148,13 @@ export const useAccountStore = create<AccountStore>((set, get) => ({
     // leaves what signing out leaves, so nobody's rows outlive them.
     if (hasCredential(answer.ok)) set({ account: answer.ok, readError: null });
     else {
-      // Losing the credential by observation changes hands as surely as
-      // signing out does, so work already out for the old one is stale.
-      handover += 1;
-      // The server says expired once: answering it clears the credential,
-      // so the next read says signed out. The explanation outlives that
-      // read — only signing in or out takes it off the screen.
+      // A read taken after a call met the expiry finds no credential
+      // where the refusal cleared it, and says signed out. Expired is
+      // the explanation for that, and only signing in or out takes it
+      // off the screen.
       const held = get().account;
       const keep = held.kind === "expired" && answer.ok.kind === "signed-out";
-      set({
-        account: keep ? held : answer.ok,
-        readError: null,
-        submissions: null,
-      });
+      set(credentialEnded(keep ? held : answer.ok));
     }
   },
 
@@ -204,13 +211,7 @@ export const useAccountStore = create<AccountStore>((set, get) => ({
       set({ error: out.error });
       return;
     }
-    handover += 1;
-    set({
-      account: { kind: "signed-out" },
-      submissions: null,
-      error: null,
-      readError: null,
-    });
+    set({ ...credentialEnded({ kind: "signed-out" }), error: null });
   },
 
   loadSubmissions: async () => {
@@ -233,15 +234,9 @@ export const useAccountStore = create<AccountStore>((set, get) => ({
     // while the call was out, a second call meeting the same dead
     // sign-in — is about a credential nobody holds any more.
     if (!hasCredential(get().account)) return;
-    // Losing the credential this way changes hands as surely as signing
-    // out does, so work already out for the old one is stale.
-    handover += 1;
-    // Meeting expiry is what cleared the credential, so the next read
-    // finds none and says signed out; `load` is where this outlives it.
-    set({
-      account: { kind: "expired" },
-      readError: null,
-      submissions: null,
-    });
+    // The next read says signed out where the refusal cleared the
+    // credential, and meets the same dead sign-in and says expired where
+    // it could not. `load` keeps this state through either answer.
+    set(credentialEnded({ kind: "expired" }));
   },
 }));

--- a/ui/src/stores/account.ts
+++ b/ui/src/stores/account.ts
@@ -132,24 +132,27 @@ export const useAccountStore = create<AccountStore>((set, get) => ({
       else set({ readError: answer.error });
       return;
     }
-    // Submissions belong to the credential. A read that finds it gone
-    // leaves what signing out leaves, so nobody's rows outlive them.
-    if (hasCredential(answer.ok)) {
-      // A read that finds someone else's credential has watched the
-      // account change hands, which nothing in the app did: `kendex
-      // login` in a terminal is the way that happens. The rows it was
-      // holding were the last account's.
-      if (sameAccount(get().account, answer.ok))
-        set({ account: answer.ok, readError: null });
-      else set(credentialEnded(answer.ok));
+    const held = get().account;
+    // The server said this sign-in was dead. A read that finds no
+    // credential is that refusal's own doing, and one that could not
+    // reach the server knows less than what the server already said:
+    // neither takes the expiry back. The removal that fails leaves the
+    // credential and its cached identity in place, which is how an
+    // outage answers `offline` for a sign-in already known to be dead.
+    if (
+      held.kind === "expired" &&
+      (answer.ok.kind === "signed-out" || answer.ok.kind === "offline")
+    ) {
+      set(credentialEnded(held));
+    } else if (sameAccount(held, answer.ok)) {
+      // The credential already held, named at last or confirmed again.
+      set({ account: answer.ok, readError: null });
     } else {
-      // A read taken after a call met the expiry finds no credential
-      // where the refusal cleared it, and says signed out. Expired is
-      // the explanation for that, and only signing in or out takes it
-      // off the screen.
-      const held = get().account;
-      const keep = held.kind === "expired" && answer.ok.kind === "signed-out";
-      set(credentialEnded(keep ? held : answer.ok));
+      // Either the credential is gone, or a read has found one the app
+      // did not put there: `kendex login` in a terminal is how that
+      // happens. Both are the account changing hands, and submissions
+      // belong to the credential, so nobody's rows outlive them.
+      set(credentialEnded(answer.ok));
     }
   },
 

--- a/ui/src/stores/account.ts
+++ b/ui/src/stores/account.ts
@@ -12,8 +12,8 @@ import {
 import { readAccount } from "./account-read";
 import {
   type AccountState,
+  asksForRows,
   asOffline,
-  differentCredential,
   hasCredential,
   keepsExpiry,
   sameCredential,
@@ -143,10 +143,9 @@ export const useAccountStore = create<AccountStore>((set, get) => ({
       set(credentialEnded(answer.ok));
       // Clearing is only the floor. The tab asks for rows when it becomes
       // signed in, which never stopped being true across a swap, so
-      // nothing would ask again for a minute and the new sign-in would
-      // sit in front of an empty tab. Only a known replacement asks; a
-      // credential merely gone has nothing to ask for.
-      if (differentCredential(held, answer.ok)) await get().loadSubmissions();
+      // nothing else would ask again for a minute and the new sign-in
+      // would sit in front of an empty tab.
+      if (asksForRows(held, answer.ok)) await get().loadSubmissions();
     }
   },
 

--- a/ui/src/stores/account.ts
+++ b/ui/src/stores/account.ts
@@ -12,9 +12,9 @@ import {
 import { readAccount } from "./account-read";
 import {
   type AccountState,
-  cachedIdentity,
+  asOffline,
   hasCredential,
-  sameAccount,
+  sameCredential,
 } from "./account-state";
 
 // The one door every surface already comes to for these.
@@ -53,9 +53,8 @@ interface AccountStore {
   signOut: () => Promise<void>;
   loadSubmissions: () => Promise<void>;
   /** How many times the account has changed hands. A call going out under
-   *  the sign-in reads this first and gives it back to `refused`, which
-   *  is how an expiry about a credential nobody holds any more is told
-   *  from one about the credential on screen. */
+   *  the sign-in reads it first and gives it back to `refused`, which
+   *  drops an expiry about a credential nobody holds any more. */
   handovers: () => number;
   /** A call made under the sign-in, read for what its refusal says about
    *  the account. Expiry is the credential ending: the sign-in is dead
@@ -123,13 +122,9 @@ export const useAccountStore = create<AccountStore>((set, get) => ({
       // away. With an identity already in hand the failure is exactly
       // offline; a credential without a name stays signed in, and a state
       // never read stays unread with the failure to show for it.
-      const identity = cachedIdentity(get().account);
-      if (identity)
-        set({
-          account: { kind: "offline", identity },
-          readError: answer.error,
-        });
-      else set({ readError: answer.error });
+      const offline = asOffline(get().account);
+      const readError = answer.error;
+      set(offline ? { account: offline, readError } : { readError });
       return;
     }
     const held = get().account;
@@ -144,8 +139,8 @@ export const useAccountStore = create<AccountStore>((set, get) => ({
       (answer.ok.kind === "signed-out" || answer.ok.kind === "offline")
     ) {
       set(credentialEnded(held));
-    } else if (sameAccount(held, answer.ok)) {
-      // The credential already held, named at last or confirmed again.
+    } else if (sameCredential(held, answer.ok)) {
+      // The same sign-in: named at last, or confirmed again.
       set({ account: answer.ok, readError: null });
     } else {
       // Either the credential is gone, or a read has found one the app
@@ -180,21 +175,27 @@ export const useAccountStore = create<AccountStore>((set, get) => ({
         set({ signingIn: false, userCode: null, error: polled.error });
         return;
       }
-      if (polled.data === "signed") {
+      if (polled.data.kind === "signed") {
         // The approval is proof a credential was stored, so it is recorded
         // before anything else is asked: a read that fails after this must
-        // not leave the person looking at a sign-in button. The read that
-        // follows is what puts a name to it.
+        // not leave the person looking at a sign-in button. The poll
+        // answers with the sign-in core minted, so the credential is named
+        // from the moment it exists and the read that follows only puts a
+        // person's name to it.
         handover += 1;
         set({
           signingIn: false,
           userCode: null,
-          account: { kind: "signed-in", identity: null },
+          account: {
+            kind: "signed-in",
+            identity: null,
+            signIn: polled.data.sign_in,
+          },
         });
         await get().load();
         return;
       }
-      if (polled.data === "slow-down") interval += 5;
+      if (polled.data.kind === "slow-down") interval += 5;
     }
   },
 

--- a/ui/src/stores/account.ts
+++ b/ui/src/stores/account.ts
@@ -4,7 +4,11 @@
 // Startup makes the one account read; every surface reads `account` from
 // here rather than asking again.
 import { create } from "zustand";
-import { commands, type SubmissionRow } from "@/bindings";
+import {
+  type AccountCallRefused,
+  commands,
+  type SubmissionRow,
+} from "@/bindings";
 import { readAccount } from "./account-read";
 
 /** Who the account belongs to, as the server names them. The linked
@@ -67,6 +71,12 @@ interface AccountStore {
   cancelSignIn: () => void;
   signOut: () => Promise<void>;
   loadSubmissions: () => Promise<void>;
+  /** A call made under the sign-in, read for what its refusal says about
+   *  the account. Expiry is the credential ending, and the call that met
+   *  it is what took the credential away, so it leaves behind what
+   *  signing out leaves. Every other refusal is news about that one
+   *  action and about nothing else, and stays where it was made. */
+  refused: (refusal: AccountCallRefused) => void;
 }
 
 /** Bumped to abandon a poll loop whose dialog was closed. */
@@ -207,9 +217,31 @@ export const useAccountStore = create<AccountStore>((set, get) => ({
     if (!hasCredential(get().account)) return;
     const before = handover;
     const rows = await commands.mineSubmissions();
-    // Rows belong to the account they were asked for. One that changed
-    // hands while they were coming has none of them.
+    // Rows belong to the account they were asked for, and so does a
+    // refusal: one that changed hands while they were coming has neither.
     if (before !== handover) return;
     if (rows.status === "ok") set({ submissions: rows.data });
+    // The poll shows nothing of its own, so a session that died between
+    // ticks would otherwise go on being polled invisibly.
+    else get().refused(rows.error);
+  },
+
+  refused: (refusal) => {
+    if (refusal.kind !== "expired") return;
+    // Expiry is a credential ending, so there has to be one to end. A
+    // refusal landing after the account moved on — a sign-out taken
+    // while the call was out, a second call meeting the same dead
+    // sign-in — is about a credential nobody holds any more.
+    if (!hasCredential(get().account)) return;
+    // Losing the credential this way changes hands as surely as signing
+    // out does, so work already out for the old one is stale.
+    handover += 1;
+    // Meeting expiry is what cleared the credential, so the next read
+    // finds none and says signed out; `load` is where this outlives it.
+    set({
+      account: { kind: "expired" },
+      readError: null,
+      submissions: null,
+    });
   },
 }));

--- a/ui/src/stores/account.ts
+++ b/ui/src/stores/account.ts
@@ -10,39 +10,20 @@ import {
   type SubmissionRow,
 } from "@/bindings";
 import { readAccount } from "./account-read";
+import {
+  type AccountState,
+  cachedIdentity,
+  hasCredential,
+  sameAccount,
+} from "./account-state";
 
-/** Who the account belongs to, as the server names them. The linked
- * GitHub account is null once it has been unlinked. */
-export interface AccountIdentity {
-  name: string;
-  githubLogin: string | null;
-}
-
-/** What is known about the account right now.
- *
- * `signed-in` carries the identity once the backend has one; a credential
- * in the keychain is enough to be signed in before then. `offline` is a
- * credential we know the owner of but could not confirm; `expired` is one
- * the server no longer accepts. */
-export type AccountState =
-  | { kind: "loading" }
-  | { kind: "signed-out" }
-  | { kind: "signed-in"; identity: AccountIdentity | null }
-  | { kind: "offline"; identity: AccountIdentity }
-  | { kind: "expired" };
-
-/** Every state but the one that means "not read yet". */
-export type SettledAccount = Exclude<AccountState, { kind: "loading" }>;
-
-/** The states that hold a credential, and so may know a name. */
-type WithIdentity = Extract<AccountState, { kind: "signed-in" | "offline" }>;
-
-/** Signed in far enough to submit: an unconfirmed credential still is. */
-export const hasCredential = (account: AccountState): account is WithIdentity =>
-  account.kind === "signed-in" || account.kind === "offline";
-
-const cachedIdentity = (account: AccountState): AccountIdentity | null =>
-  hasCredential(account) ? account.identity : null;
+// The one door every surface already comes to for these.
+export {
+  type AccountIdentity,
+  type AccountState,
+  hasCredential,
+  type SettledAccount,
+} from "./account-state";
 
 interface AccountStore {
   account: AccountState;
@@ -71,13 +52,20 @@ interface AccountStore {
   cancelSignIn: () => void;
   signOut: () => Promise<void>;
   loadSubmissions: () => Promise<void>;
+  /** How many times the account has changed hands. A call going out under
+   *  the sign-in reads this first and gives it back to `refused`, which
+   *  is how an expiry about a credential nobody holds any more is told
+   *  from one about the credential on screen. */
+  handovers: () => number;
   /** A call made under the sign-in, read for what its refusal says about
    *  the account. Expiry is the credential ending: the sign-in is dead
    *  server-side and nothing on this machine can revive it, so it leaves
    *  behind what signing out leaves. Every other refusal is news about
    *  that one action and about nothing else, and stays where it was
-   *  made. */
-  refused: (refusal: AccountCallRefused) => void;
+   *  made.
+   *
+   *  `since` is the count the call went out under. */
+  refused: (refusal: AccountCallRefused, since: number) => void;
 }
 
 /** Bumped to abandon a poll loop whose dialog was closed. */
@@ -146,8 +134,15 @@ export const useAccountStore = create<AccountStore>((set, get) => ({
     }
     // Submissions belong to the credential. A read that finds it gone
     // leaves what signing out leaves, so nobody's rows outlive them.
-    if (hasCredential(answer.ok)) set({ account: answer.ok, readError: null });
-    else {
+    if (hasCredential(answer.ok)) {
+      // A read that finds someone else's credential has watched the
+      // account change hands, which nothing in the app did: `kendex
+      // login` in a terminal is the way that happens. The rows it was
+      // holding were the last account's.
+      if (sameAccount(get().account, answer.ok))
+        set({ account: answer.ok, readError: null });
+      else set(credentialEnded(answer.ok));
+    } else {
       // A read taken after a call met the expiry finds no credential
       // where the refusal cleared it, and says signed out. Expired is
       // the explanation for that, and only signing in or out takes it
@@ -218,21 +213,29 @@ export const useAccountStore = create<AccountStore>((set, get) => ({
     if (!hasCredential(get().account)) return;
     const before = handover;
     const rows = await commands.mineSubmissions();
-    // Rows belong to the account they were asked for, and so does a
-    // refusal: one that changed hands while they were coming has neither.
-    if (before !== handover) return;
-    if (rows.status === "ok") set({ submissions: rows.data });
     // The poll shows nothing of its own, so a session that died between
     // ticks would otherwise go on being polled invisibly.
-    else get().refused(rows.error);
+    if (rows.status === "error") {
+      get().refused(rows.error, before);
+      return;
+    }
+    // Rows belong to the account they were asked for: ones that changed
+    // hands while they were coming belong to nobody on screen.
+    if (before !== handover) return;
+    set({ submissions: rows.data });
   },
 
-  refused: (refusal) => {
+  handovers: () => handover,
+
+  refused: (refusal, since) => {
     if (refusal.kind !== "expired") return;
-    // Expiry is a credential ending, so there has to be one to end. A
-    // refusal landing after the account moved on — a sign-out taken
-    // while the call was out, a second call meeting the same dead
-    // sign-in — is about a credential nobody holds any more.
+    // The expiry belongs to the credential the call went out under. One
+    // that landed after the account changed hands — a sign-out taken
+    // while the call was out, a sign-in finishing behind it — is about a
+    // credential nobody holds any more, and ending the account over it
+    // would end the one that replaced it.
+    if (since !== handover) return;
+    // Expiry is a credential ending, so there has to be one to end.
     if (!hasCredential(get().account)) return;
     // The next read says signed out where the refusal cleared the
     // credential, and meets the same dead sign-in and says expired where

--- a/ui/src/stores/account.ts
+++ b/ui/src/stores/account.ts
@@ -13,6 +13,7 @@ import { readAccount } from "./account-read";
 import {
   type AccountState,
   asOffline,
+  differentCredential,
   hasCredential,
   keepsExpiry,
   sameCredential,
@@ -140,6 +141,12 @@ export const useAccountStore = create<AccountStore>((set, get) => ({
       // happens. Both are the account changing hands, and submissions
       // belong to the credential, so nobody's rows outlive them.
       set(credentialEnded(answer.ok));
+      // Clearing is only the floor. The tab asks for rows when it becomes
+      // signed in, which never stopped being true across a swap, so
+      // nothing would ask again for a minute and the new sign-in would
+      // sit in front of an empty tab. Only a known replacement asks; a
+      // credential merely gone has nothing to ask for.
+      if (differentCredential(held, answer.ok)) await get().loadSubmissions();
     }
   },
 

--- a/ui/src/stores/account.ts
+++ b/ui/src/stores/account.ts
@@ -14,6 +14,7 @@ import {
   type AccountState,
   asOffline,
   hasCredential,
+  keepsExpiry,
   sameCredential,
 } from "./account-state";
 
@@ -128,16 +129,7 @@ export const useAccountStore = create<AccountStore>((set, get) => ({
       return;
     }
     const held = get().account;
-    // The server said this sign-in was dead. A read that finds no
-    // credential is that refusal's own doing, and one that could not
-    // reach the server knows less than what the server already said:
-    // neither takes the expiry back. The removal that fails leaves the
-    // credential and its cached identity in place, which is how an
-    // outage answers `offline` for a sign-in already known to be dead.
-    if (
-      held.kind === "expired" &&
-      (answer.ok.kind === "signed-out" || answer.ok.kind === "offline")
-    ) {
+    if (keepsExpiry(held, answer.ok)) {
       set(credentialEnded(held));
     } else if (sameCredential(held, answer.ok)) {
       // The same sign-in: named at last, or confirmed again.
@@ -240,10 +232,12 @@ export const useAccountStore = create<AccountStore>((set, get) => ({
     // would end the one that replaced it.
     if (since !== handover) return;
     // Expiry is a credential ending, so there has to be one to end.
-    if (!hasCredential(get().account)) return;
+    const held = get().account;
+    if (!hasCredential(held)) return;
     // The next read says signed out where the refusal cleared the
     // credential, and meets the same dead sign-in and says expired where
-    // it could not. `load` keeps this state through either answer.
-    set(credentialEnded({ kind: "expired" }));
+    // it could not. `load` keeps this state through either answer, and
+    // the name says which sign-in the verdict was about.
+    set(credentialEnded({ kind: "expired", signIn: held.signIn }));
   },
 }));

--- a/ui/src/test/account-store.ts
+++ b/ui/src/test/account-store.ts
@@ -1,0 +1,58 @@
+// The account store's test harness: the wire answer, the reader seam, the
+// named fixtures, and the reset, shared by the files that exercise it.
+//
+// Each test file installs its own `vi.mock("@/bindings", ...)`; the
+// helpers here read through whichever mock the importing file set up.
+import { vi } from "vitest";
+import { type AccountStatus, commands } from "@/bindings";
+import { type SettledAccount, useAccountStore } from "@/stores/account";
+import { setAccountReader } from "@/stores/account-read";
+
+/** The name core mints for a sign-in; two answers about one credential
+ *  carry the same one, and a new sign-in carries a different one. */
+export const SIGN_IN = "sign-in-ada";
+export const OTHER_SIGN_IN = "sign-in-next";
+
+export const ADA = { name: "Ada Lovelace", githubLogin: "ada" };
+export const BOB = { name: "Bob", githubLogin: "bob" };
+
+/** What the real command answers: the state the backend settled on. */
+export const answers = (state: AccountStatus["state"]) =>
+  vi.mocked(commands.accountStatus).mockResolvedValue({
+    status: "ok",
+    data: { state, endpoint: "https://kendex.ai" },
+  } as Awaited<ReturnType<typeof commands.accountStatus>>);
+
+export const unreadable = (why = "keychain locked") =>
+  vi.mocked(commands.accountStatus).mockResolvedValue({
+    status: "error",
+    error: why,
+  } as Awaited<ReturnType<typeof commands.accountStatus>>);
+
+/** What a backend that has reached the server answers with. */
+export const serves = (account: SettledAccount) =>
+  setAccountReader(async () => ({ ok: account }));
+
+export const load = () => useAccountStore.getState().load();
+export const account = () => useAccountStore.getState().account;
+
+export const fresh = () =>
+  useAccountStore.setState({
+    account: { kind: "loading" },
+    error: null,
+    readError: null,
+    submissions: null,
+    signingIn: false,
+    userCode: null,
+    reading: false,
+  });
+
+/** One submission row, so a test can watch rows survive or go with the
+ *  credential that owned them. */
+export const ROW = {
+  repo: "ada/team-skills",
+  status: "pending",
+  status_reason: null,
+  head_commit: null,
+  indexed_at: null,
+};


### PR DESCRIPTION
`mine_submit` and `mine_submissions` both ended `map_err(|e| e.to_string())`, so expiry was discovered and then lost at the app boundary. The submit dialog showed the words and went on offering Submit; the submissions poll discarded them and kept asking every 60 seconds with nothing on screen. Meeting expiry is what clears the credential, so the next account read said signed out and `Expired` was unreachable from the paths that produce it.

## The shape

Both commands answer with `AccountCallRefused`, the same tagged shape `WriteRefused` already uses rather than a new one: `Expired` carries the producer's whole sentence, everything else is `Failed`. The store folds an expired refusal into the account the way a read that finds the credential gone does, so the sidebar row, Settings > Account and the rows all move together, and the dialog offers the sign-in instead of the submit.

`NotSignedIn` deliberately stays `Failed`. It says this machine holds no credential, which the account read already answers; moving the account from it would put a second judge on what `me::load` owns. The reason is recorded on `refused` so the mapping does not read as an oversight.

## What review changed

The alert used to survive the sign-in it prompted. Submit meets expiry, the person takes the offered sign-in, the device flow is denied — and the dialog still read "your sign-in has expired", masking the failure they had just hit. The sign-in now clears the local error as it begins, so the expiry sentence stays until the person acts on it and the alert then belongs to the device flow.

The expiry docs claimed the credential is always cleared. KEN-742 landed the branch where it is not while this was in flight, so the claim was true when written. Qualified at the source and carried into the regenerated bindings; the variant sentence is folded into the type doc because specta hoists it above the whole union.

The credential-ended write existed in three verbatim copies; one `credentialEnded` writer now owns it, with the guards left where they differ.

The dev mock refused with bare strings, so no harness path could reach the flow this adds. Both handlers answer the tagged shape, and `calls=expired` drives the expired refusal under a read that still says signed in — the only state where a Submit that meets it is reachable.

## Not here

A non-expiry submissions failure still reaches nothing, so a failed first poll renders every authored row as never-submitted. That is KEN-725, which this issue blocks and which is next.

Closes KEN-736
