### PR TITLE
fix(KEN-598): a renamed fork answers to its new name

### DIFF
--- a/changelog.d/fixed/KEN-598.md
+++ b/changelog.d/fixed/KEN-598.md
@@ -1,0 +1,3 @@
+- Renaming a fork now writes the new name into the package's own file, so
+  the renamed skill or agent installs instead of being refused at the next
+  apply for calling itself by its old name.

--- a/crates/core/src/engine/fork.rs
+++ b/crates/core/src/engine/fork.rs
@@ -208,6 +208,37 @@ fn capture(kind: ItemKind, edited: &std::path::Path) -> Result<Capture> {
     })
 }
 
+/// The files of a skill's tree that carry the name the item answers to:
+/// SKILL.md under either spelling, because a switched-off installation
+/// keeps its content under the `.disabled` name and that is the same
+/// claim on the same name. An agent's source is one file, so the file
+/// itself is the one — no list to consult.
+const SKILL_NAME_FILES: [&str; 2] = ["SKILL.md", "SKILL.md.disabled"];
+
+fn carries_name(rel: &std::path::Path) -> bool {
+    rel.to_str()
+        .is_some_and(|rel| SKILL_NAME_FILES.contains(&rel))
+}
+
+/// The bytes answering to `name`. A tool knows a skill or an agent by the
+/// name its frontmatter gives, and the loader validators refuse a
+/// rendering whose file calls it something other than the name it
+/// installs under — so a copy landing under a new name says that name.
+/// A frontmatter without a name gets one, exactly as rendering would give
+/// it one; bytes whose name no single scalar can carry refuse the whole
+/// operation rather than land a copy that still answers to the old name.
+fn named_bytes(bytes: Vec<u8>, name: &str) -> Result<Vec<u8>> {
+    let refused = |problem: String| CoreError::ForkNameUnusable {
+        name: crate::names::shown(name),
+        problem,
+    };
+    let text =
+        std::str::from_utf8(&bytes).map_err(|_| refused("the file is not text".to_owned()))?;
+    crate::render::skill::with_name(text, name)
+        .map(String::into_bytes)
+        .map_err(|problem| refused(problem.to_string()))
+}
+
 /// The local source's path for an item of this kind under `name`.
 fn local_item(env: &Env, scope: &Scope, kind: ItemKind, name: &str) -> PathBuf {
     let local_root = local_source_root(env, scope);

--- a/crates/core/src/engine/fork/beside.rs
+++ b/crates/core/src/engine/fork/beside.rs
@@ -4,7 +4,10 @@
 //! source's content under the name it always had, the edits under the name
 //! the user chose.
 
-use super::{Capture, capture, capture_ops, edited_rendering, provenance, vacant_name};
+use super::{
+    Capture, capture, capture_ops, carries_name, edited_rendering, named_bytes, provenance,
+    vacant_name,
+};
 use crate::apply::{Op, Plan, PlannedOp, Pre};
 use crate::engine::ops::manifest_for_mutation;
 use crate::env::Env;
@@ -89,35 +92,21 @@ pub fn fork_beside(
     })
 }
 
-/// The captured bytes answering to `new_name`. A tool knows a skill or an
-/// agent by the name its frontmatter gives, and discovery treats a
-/// directory and its frontmatter disagreeing as a finding — so a copy under
-/// a new name says that name, or it would shadow the original it sits
-/// beside. A frontmatter without a name gets one, exactly as rendering
-/// would give it one; bytes whose name no single scalar can carry refuse
-/// the fork rather than land a copy that still answers to the old one.
+/// The captured bytes answering to `new_name` — [`named_bytes`] over the
+/// files that carry the name. A copy under a new name says that name, or
+/// it would shadow the original it sits beside: discovery treats a
+/// directory and its frontmatter disagreeing as a finding.
 fn named(captured: Capture, new_name: &str) -> Result<Capture> {
-    let rename = |bytes: Vec<u8>| -> Result<Vec<u8>> {
-        let refused = |problem: String| CoreError::ForkNameUnusable {
-            name: crate::names::shown(new_name),
-            problem,
-        };
-        let text =
-            std::str::from_utf8(&bytes).map_err(|_| refused("the file is not text".to_owned()))?;
-        crate::render::skill::with_name(text, new_name)
-            .map(String::into_bytes)
-            .map_err(|problem| refused(problem.to_string()))
-    };
     Ok(match captured {
         Capture::Tree(files) => Capture::Tree(
             files
                 .into_iter()
-                .map(|(rel, bytes)| match rel.to_str() {
-                    Some("SKILL.md") => rename(bytes).map(|bytes| (rel, bytes)),
-                    _ => Ok((rel, bytes)),
+                .map(|(rel, bytes)| match carries_name(&rel) {
+                    true => named_bytes(bytes, new_name).map(|bytes| (rel, bytes)),
+                    false => Ok((rel, bytes)),
                 })
                 .collect::<Result<Vec<_>>>()?,
         ),
-        Capture::File(bytes) => Capture::File(rename(bytes)?),
+        Capture::File(bytes) => Capture::File(named_bytes(bytes, new_name)?),
     })
 }

--- a/crates/core/src/engine/fork/rename.rs
+++ b/crates/core/src/engine/fork/rename.rs
@@ -1,7 +1,9 @@
 //! Renaming a fork: the declaration, its provenance record, and its files in
 //! the local source move to the new name together.
 
-use super::{local_item, vacant_name};
+use std::path::{Path, PathBuf};
+
+use super::{SKILL_NAME_FILES, local_item, named_bytes, vacant_name};
 use crate::apply::{Op, Plan, PlannedOp, Pre};
 use crate::engine::ops::manifest_for_mutation;
 use crate::env::Env;
@@ -54,6 +56,7 @@ pub fn rename_fork(env: &Env, scope: &Scope, kind: ItemKind, old: &str, new: &st
     );
     let mut ops = Vec::new();
     if from.exists() {
+        let stamped = stamp_name(kind, &from, &to, new)?;
         ops.push(PlannedOp {
             description: format!("rename the fork's files to {new}"),
             op: Op::Rename {
@@ -66,6 +69,7 @@ pub fn rename_fork(env: &Env, scope: &Scope, kind: ItemKind, old: &str, new: &st
                 to_pre: Pre::Absent,
             },
         });
+        ops.extend(stamped);
     }
     let Some(decl) = manifest.declared_mut(kind).remove(old) else {
         return Err(CoreError::NotDeclared {
@@ -92,4 +96,56 @@ pub fn rename_fork(env: &Env, scope: &Scope, kind: ItemKind, old: &str, new: &st
         scope: scope.clone(),
         ops,
     })
+}
+
+/// The writes that leave the renamed fork answering to `new`. Moving the
+/// directory and the declaration is not the whole rename: every tool knows
+/// a skill or an agent by the name its frontmatter gives, and the loader
+/// validators refuse a rendering whose file calls it something other than
+/// the name it installs under — so a rename that left the name behind
+/// would hand the person a package refused at the next apply.
+///
+/// Each write binds to the bytes the rename just carried, at the path it
+/// carried them to. Ops run in order and each proves its own precondition
+/// immediately before it writes, so what stands at the new path when the
+/// write runs is exactly the file hashed here at the old one; binding to
+/// the old path would prove nothing, the rename having emptied it. The
+/// binding is the plain-file one because kendex does not write a skill's
+/// or an agent's document through a link — a link arriving in the moved
+/// tree's place refuses the write rather than landing these bytes at the
+/// other end of it.
+///
+/// A name no single scalar can carry refuses the rename here, before
+/// anything is written: renaming around it is how the fork ends up
+/// declared under one name and answering to another.
+fn stamp_name(kind: ItemKind, from: &Path, to: &Path, new: &str) -> Result<Vec<PlannedOp>> {
+    let moved: Vec<(PathBuf, PathBuf)> = match kind {
+        ItemKind::Skill => SKILL_NAME_FILES
+            .iter()
+            .map(|rel| (from.join(rel), to.join(rel)))
+            .collect(),
+        // Every other kind the local source keeps is one file, and the
+        // file is what moved.
+        _ => vec![(from.to_path_buf(), to.to_path_buf())],
+    };
+    let mut ops = Vec::new();
+    for (old, new_path) in moved {
+        // Absent here is also "there, but not a plain file": a link or a
+        // directory wearing the name carries nothing this can stamp, and
+        // a rendering reading it is refused for that on its own.
+        let pre = Pre::plain_observed(&old)?;
+        if matches!(pre, Pre::Absent) {
+            continue;
+        }
+        let bytes = std::fs::read(&old).map_err(|e| CoreError::io(&old, e))?;
+        ops.push(PlannedOp {
+            description: format!("give the renamed {} its new name, {new}", kind.name()),
+            op: Op::WriteFile {
+                pre,
+                bytes: named_bytes(bytes, new)?,
+                path: new_path,
+            },
+        });
+    }
+    Ok(ops)
 }

--- a/crates/core/src/engine/fork/rename.rs
+++ b/crates/core/src/engine/fork/rename.rs
@@ -54,6 +54,17 @@ pub fn rename_fork(env: &Env, scope: &Scope, kind: ItemKind, old: &str, new: &st
         local_item(env, scope, kind, old),
         local_item(env, scope, kind, new),
     );
+    // `vacant_name` proved the destination reachable; the slot being left
+    // has to be too. A link anywhere below the local source's root and the
+    // fork's files makes the move dishonest: the rename carries the link
+    // rather than the tree, and every op bound to what stands past it —
+    // the name-stamping write below first of all — then acts on the far
+    // end, outside what this scope manages. Refused here, before a single
+    // op is planned, in the sealed reader's own words: it names the
+    // component it stopped at, which is the thing to go and look at.
+    if let Some(escape) = crate::source::slot_escapes(env, scope, &from)? {
+        return Err(escape);
+    }
     let mut ops = Vec::new();
     if from.exists() {
         let stamped = stamp_name(kind, &from, &to, new)?;

--- a/crates/core/src/source.rs
+++ b/crates/core/src/source.rs
@@ -37,6 +37,30 @@ pub fn repo_leaf(provenance: &str) -> &str {
         .unwrap_or(provenance)
 }
 
+/// Why nothing at `slot` can be read back through this scope's local
+/// source: it sits outside the source's root, or a component below that
+/// root is a symlink, which the sealed reader will not look through. The
+/// path half of [`slot_unreachable`], asked on its own by a caller whose
+/// slot already holds an item and whose name is therefore not in
+/// question — a rename's. The answer is the reader's own refusal, naming
+/// the component it stopped at: a second vocabulary for the same
+/// condition would be a second rule to keep true. Reachability is about
+/// the components below the root, so a person's link at the root itself
+/// is followed, once, by the reader every other read of this source
+/// goes through.
+pub(crate) fn slot_escapes(
+    env: &Env,
+    scope: &Scope,
+    slot: &std::path::Path,
+) -> Result<Option<CoreError>> {
+    let root = local_source_root(env, scope);
+    if !root.is_dir() {
+        return Ok(None);
+    }
+    let sealed = crate::source_read::SealedSource::open(&root)?;
+    Ok(sealed.contained(slot).err())
+}
+
 /// Why the local source cannot hold an item's bytes at `slot`, in words
 /// for the person who typed the name. A fork's capture and adoption's
 /// both land here, and both ask this before planning a byte.
@@ -60,16 +84,16 @@ pub(crate) fn slot_unreachable(
     name: &str,
     slot: &std::path::Path,
 ) -> Result<Option<String>> {
+    if let Some(escape) = slot_escapes(env, scope, slot)? {
+        return Ok(Some(format!(
+            "the local source cannot be written there — {escape}"
+        )));
+    }
     let root = local_source_root(env, scope);
     if !root.is_dir() {
         return Ok(None);
     }
     let sealed = crate::source_read::SealedSource::open(&root)?;
-    if let Err(escape) = sealed.contained(slot) {
-        return Ok(Some(format!(
-            "the local source cannot be written there — {escape}"
-        )));
-    }
     let config = source_config_for(&sealed, LOCAL_SOURCE_NAME)?;
     let Some((plugin, _)) = crate::names::split(name) else {
         return Ok(None);

--- a/crates/core/tests/edits_and_forks/forks.rs
+++ b/crates/core/tests/edits_and_forks/forks.rs
@@ -224,6 +224,68 @@ fn a_fork_whose_file_cannot_carry_the_name_refuses_the_rename() {
     assert!(text.contains("[skills.gh]"), "{text}");
 }
 
+/// A fork whose slot is reached through a link is not a fork the rename
+/// can move: `fs::rename` carries the link rather than the tree, and every
+/// op the plan binds past it — the name-stamping write first of all —
+/// then acts on the far end, outside the scope. Refused before a single
+/// op is planned, and the tree at the far end is untouched.
+/// Built on the world whose home is itself reached through a link, the
+/// spelling macOS hands every test: the refusal names the component the
+/// sealed reader stopped at, which it probes from the canonicalized root,
+/// so an assertion written in the caller's spelling would pass on Linux
+/// and fail on the macOS lane alone.
+#[cfg(unix)]
+#[test]
+#[allow(clippy::unwrap_used)]
+fn a_fork_reached_through_a_link_refuses_the_rename() {
+    let w = world_via_link();
+    write_skill(&w.upstream, "gh", "Upstream.");
+    commit(&w.upstream, "one");
+    declare(&w, "[skills.gh]\nsource = \"cat\"\n");
+    sync_and_apply(&w);
+    fs::write(
+        skill_file(&w),
+        "---\nname: gh\ndescription: mine\n---\nMine.\n",
+    )
+    .unwrap();
+    let plan = fork::fork(&w.env, &w.scope, ItemKind::Skill, "gh", HarnessId::Claude).unwrap();
+    apply::execute(&w.env, &plan, None).unwrap();
+
+    // The fork's slot becomes a link to a tree outside the scope.
+    let outside = w.home.join("outside/gh");
+    fs::create_dir_all(&outside).unwrap();
+    let theirs = "---\nname: gh\ndescription: theirs\n---\nTheirs.\n";
+    fs::write(outside.join("SKILL.md"), theirs).unwrap();
+    let slot = w.home.join("app/.kendex-local/skills/gh");
+    fs::remove_dir_all(&slot).unwrap();
+    std::os::unix::fs::symlink(&outside, &slot).unwrap();
+    let before = manifest_text(&w);
+
+    let refused = fork::rename_fork(&w.env, &w.scope, ItemKind::Skill, "gh", "my-gh").unwrap_err();
+    // The reader probes from the canonicalized local-source root, so that
+    // is the spelling the refusal names. The root is a real directory; the
+    // slot below it is the link, and canonicalizing that would follow it.
+    let named = w
+        .home
+        .join("app/.kendex-local")
+        .canonicalize()
+        .unwrap()
+        .join("skills/gh");
+    assert!(
+        matches!(&refused, CoreError::SourceEscape { path, reason }
+            if path == &named && reason.contains("symlink")),
+        "the refusal must name the link it stopped at: {refused:?}"
+    );
+    assert_eq!(
+        fs::read_to_string(outside.join("SKILL.md")).unwrap(),
+        theirs,
+        "the rename wrote through the link, at the far end of it"
+    );
+    assert!(slot.is_symlink(), "the link itself was moved");
+    assert!(!w.home.join("app/.kendex-local/skills/my-gh").exists());
+    assert_eq!(manifest_text(&w), before);
+}
+
 /// The rename plan binds to the fork's files as they were when it was
 /// made. An edit landing on them after planning refuses the move — run
 /// anyway, the rename would carry the edit to the new name, where a later

--- a/crates/core/tests/edits_and_forks/forks.rs
+++ b/crates/core/tests/edits_and_forks/forks.rs
@@ -118,11 +118,110 @@ fn rename_fork_moves_the_declaration_and_refuses_depended_on_names() {
     assert!(text.contains("[skills.my-gh]"), "{text}");
     assert!(text.contains("[forks.skill.my-gh]"));
     assert!(!text.contains("[skills.gh]"));
+    let source = w.home.join("app/.kendex-local/skills/my-gh/SKILL.md");
+    assert!(source.is_file());
+
+    // The rename is not done when the files have moved: every tool knows
+    // a skill by the name its SKILL.md gives, so a fork still calling
+    // itself `gh` installs as a name nobody declared and the loader
+    // validators refuse the rendering outright.
+    let moved = fs::read_to_string(&source).unwrap();
+    assert!(moved.contains("name: my-gh"), "{moved}");
     assert!(
-        w.home
-            .join("app/.kendex-local/skills/my-gh/SKILL.md")
-            .is_file()
+        moved.contains("Mine."),
+        "the rename took the fork's own text"
     );
+
+    let report = audit(&w.env, &w.scope).unwrap();
+    assert!(
+        !report
+            .drift
+            .iter()
+            .any(|row| row.name == "my-gh" && row.state == DriftState::Conflict),
+        "the renamed fork is refused at the next apply: {:?}",
+        report.drift
+    );
+    apply::execute(&w.env, &report.plan, None).unwrap();
+    let installed = fs::read_to_string(w.home.join("app/.agents/skills/my-gh/SKILL.md")).unwrap();
+    assert!(installed.contains("name: my-gh"), "{installed}");
+}
+
+/// The same for an agent, whose source is one file rather than a tree:
+/// Claude and Gemini register an agent under its frontmatter name and
+/// their validators refuse a file calling itself something other than the
+/// name it installs under, exactly as a skill's does.
+#[test]
+#[allow(clippy::unwrap_used)]
+fn renaming_an_agent_fork_leaves_it_answering_to_its_new_name() {
+    let w = world();
+    write_agent(&w.upstream, "rev", "Review.");
+    commit(&w.upstream, "one");
+    declare(&w, "[agents.rev]\nsource = \"cat\"\n");
+    sync_and_apply(&w);
+
+    let rendered = w.home.join("app/.claude/agents/rev.md");
+    fs::write(
+        &rendered,
+        "---\nname: rev\ndescription: mine\n---\nMy review.\n",
+    )
+    .unwrap();
+    let plan = fork::fork(&w.env, &w.scope, ItemKind::Agent, "rev", HarnessId::Claude).unwrap();
+    apply::execute(&w.env, &plan, None).unwrap();
+    let report = audit(&w.env, &w.scope).unwrap();
+    apply::execute(&w.env, &report.plan, None).unwrap();
+
+    let plan = fork::rename_fork(&w.env, &w.scope, ItemKind::Agent, "rev", "my-rev").unwrap();
+    apply::execute(&w.env, &plan, None).unwrap();
+    let source = fs::read_to_string(w.home.join("app/.kendex-local/agents/my-rev.md")).unwrap();
+    assert!(source.contains("name: my-rev"), "{source}");
+    assert!(source.contains("My review."), "{source}");
+
+    let report = audit(&w.env, &w.scope).unwrap();
+    assert!(
+        !report
+            .drift
+            .iter()
+            .any(|row| row.name == "my-rev" && row.state == DriftState::Conflict),
+        "the renamed agent fork is refused at the next apply: {:?}",
+        report.drift
+    );
+    apply::execute(&w.env, &report.plan, None).unwrap();
+    let installed = fs::read_to_string(w.home.join("app/.claude/agents/my-rev.md")).unwrap();
+    assert!(installed.contains("name: my-rev"), "{installed}");
+}
+
+/// A fork whose own file cannot carry a name refuses the rename instead of
+/// half-doing it: renaming around the problem is exactly how a fork ends
+/// up declared under one name and answering to another.
+#[test]
+#[allow(clippy::unwrap_used)]
+fn a_fork_whose_file_cannot_carry_the_name_refuses_the_rename() {
+    let w = world();
+    write_skill(&w.upstream, "gh", "Upstream.");
+    commit(&w.upstream, "one");
+    declare(&w, "[skills.gh]\nsource = \"cat\"\n");
+    sync_and_apply(&w);
+    fs::write(
+        skill_file(&w),
+        "---\nname: gh\ndescription: mine\n---\nMine.\n",
+    )
+    .unwrap();
+    let plan = fork::fork(&w.env, &w.scope, ItemKind::Skill, "gh", HarnessId::Claude).unwrap();
+    apply::execute(&w.env, &plan, None).unwrap();
+
+    let source = w.home.join("app/.kendex-local/skills/gh/SKILL.md");
+    fs::write(&source, "---\nname: gh\nname: gh\n---\nMine.\n").unwrap();
+    let refused = fork::rename_fork(&w.env, &w.scope, ItemKind::Skill, "gh", "my-gh").unwrap_err();
+    assert!(
+        matches!(refused, CoreError::ForkNameUnusable { .. }),
+        "{refused:?}"
+    );
+    assert!(
+        !w.home.join("app/.kendex-local/skills/my-gh").exists(),
+        "a refused rename must write nothing"
+    );
+    let text = fs::read_to_string(manifest::manifest_path(&w.env, &w.scope)).unwrap();
+    assert!(text.contains("[skills.gh]"), "{text}");
 }
 
 /// The rename plan binds to the fork's files as they were when it was


### PR DESCRIPTION
Renaming a fork left it refused at the next apply.

`rename_fork` moved the fork's directory, its declaration, its provenance and its decisions, and left the name in the file itself. Every tool knows a skill or an agent by the name its frontmatter gives, so the next plan found a package installing as one name and calling itself another — `validate_skill_tree` raises "SKILL.md calls the skill `gh` but it installs as `my-gh`", the Claude and Gemini agent validators raise "installs as `x` but calls itself `y`", and `refusal_reason` refuses the rendering. Anyone renaming a fork of a package that carries a name, which is nearly all of them, hit it. Reachable from `kendex fork --rename` and from the app.

## What changed

The rename plans a write of the name-carrying file with the new name stamped in, after the move.

The rewrite itself is not new: `fork_beside` already did this, and it is lifted to the parent module so both callers share one copy rather than growing a second.

## Two things checked rather than assumed

**The binding.** The write is bound to the bytes the move just carried to the new path. Ops run in order and each proves its own precondition immediately before writing, so the hash taken at the old path is what stands at the new one when the write runs. The binding is the plain-file one deliberately: a link arriving in the moved tree's place must refuse the write rather than land these bytes at the other end of it.

**A name no single scalar can carry** now refuses the rename outright, before anything is written. Renaming around such a file is how a fork ends up declared under one name and answering to another, which is the defect this fixes.

## Tests

`rename_fork_moves_the_declaration_and_refuses_depended_on_names` extended past the rename to audit and apply, asserting the renamed package renders with no refusal, and the agent kind added beside the skill. The suite is 53 green.

Closes KEN-598
