### PR TITLE
fix(KEN-725): a submissions read that failed reads as unknown, not none

### DIFF
--- a/changelog.d/fixed/KEN-725.md
+++ b/changelog.d/fixed/KEN-725.md
@@ -1,0 +1,3 @@
+- Mine now says when it could not check your submissions, instead of
+  reporting every marketplace as never submitted and offering to submit
+  work already in review.

--- a/crates/app/src/account.rs
+++ b/crates/app/src/account.rs
@@ -3,6 +3,7 @@
 //! uses. The app never sees a GitHub password — a code, a browser tab,
 //! done.
 
+use std::collections::BTreeMap;
 use std::path::PathBuf;
 
 use kendex_core::author::{self, SubmitPreflight};
@@ -11,7 +12,9 @@ use kendex_core::error::CoreError;
 use kendex_core::registry::credentials::{Credential, KeyringStore};
 use kendex_core::registry::login::{self, Poll};
 use kendex_core::registry::me::{self, AccountState};
-use kendex_core::registry::submit::{self, SubmissionRow};
+use kendex_core::registry::submit::{
+    self, SubmissionAsk, SubmissionRow, SubmissionState, SubmissionsRead,
+};
 use kendex_core::registry::{CurlFetch, base_url};
 use serde::{Deserialize, Serialize};
 use specta::Type;
@@ -175,6 +178,21 @@ pub fn mine_submit(repo: String) -> Result<SubmittedView, AccountCallRefused> {
 #[specta::specta]
 pub fn mine_submissions() -> Result<Vec<SubmissionRow>, AccountCallRefused> {
     submit::submissions(&CurlFetch, &KeyringStore).map_err(refused)
+}
+
+/// What each authored marketplace's submission reads as, given the rows a
+/// read left in hand and how that read went. A ruling over what the
+/// caller already holds: it asks the server nothing, so the tab re-asks
+/// whenever its rows, its marketplaces, or the read's outcome change
+/// rather than once per row it draws.
+#[tauri::command]
+#[specta::specta]
+pub fn mine_submission_states(
+    read: SubmissionsRead,
+    rows: Vec<SubmissionRow>,
+    asks: Vec<SubmissionAsk>,
+) -> BTreeMap<String, SubmissionState> {
+    submit::states(read, &rows, &asks)
 }
 
 #[cfg(test)]

--- a/crates/app/src/lib.rs
+++ b/crates/app/src/lib.rs
@@ -115,6 +115,7 @@ pub fn specta_builder() -> Builder<tauri::Wry> {
         account::mine_submit_preflight,
         account::mine_submit,
         account::mine_submissions,
+        account::mine_submission_states,
         packages::package_versions,
         packages::update::package_update,
         packages::update::package_update_many,

--- a/crates/core/src/registry/submit.rs
+++ b/crates/core/src/registry/submit.rs
@@ -47,13 +47,15 @@ pub enum SubmissionState {
 ///
 /// `landed` means the rows in hand are the whole of what the server
 /// lists, so a repository missing from them is not submitted. `failed`
-/// means they are only what it last said, so a repository missing from
-/// them is unknown rather than unsubmitted.
+/// means they are only what it last said, and `unread` that no read has
+/// been made at all: before the first one, and after a credential ends
+/// and takes its rows with it. Under neither is absence an answer.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Deserialize, specta::Type)]
 #[serde(rename_all = "kebab-case")]
 pub enum SubmissionsRead {
     Landed,
     Failed,
+    Unread,
 }
 
 /// One marketplace to answer about: where it is, and the GitHub
@@ -69,10 +71,9 @@ pub struct SubmissionAsk {
 ///
 /// A submission is keyed by the GitHub repository, so a marketplace with
 /// no remote has nothing the server could have listed and is not
-/// submitted whatever the read did. One the rows name is submitted, under
-/// the row the server gave, and that stands under a failed read too: it
-/// is what the server last said. Absence is an answer only while reads
-/// are landing.
+/// submitted whatever the read did. One the rows name is submitted under
+/// the row the server gave, and stays so under a read that did not land:
+/// it is what the server last said. Absence answers only where one did.
 pub fn states(
     read: SubmissionsRead,
     rows: &[SubmissionRow],
@@ -91,7 +92,7 @@ fn state_for(read: SubmissionsRead, rows: &[SubmissionRow], repo: Option<&str>) 
         Some(row) => SubmissionState::Submitted { row: row.clone() },
         None => match read {
             SubmissionsRead::Landed => SubmissionState::NotSubmitted,
-            SubmissionsRead::Failed => SubmissionState::Unknown,
+            SubmissionsRead::Failed | SubmissionsRead::Unread => SubmissionState::Unknown,
         },
     }
 }
@@ -162,6 +163,12 @@ mod tests {
         }
     }
 
+    const READS: [SubmissionsRead; 3] = [
+        SubmissionsRead::Landed,
+        SubmissionsRead::Failed,
+        SubmissionsRead::Unread,
+    ];
+
     fn asked(read: SubmissionsRead, rows: &[SubmissionRow], ask: SubmissionAsk) -> SubmissionState {
         let path = ask.path.clone();
         states(read, rows, &[ask])
@@ -174,7 +181,7 @@ mod tests {
     /// makes it less certain — the offer stays a first submit.
     #[test]
     fn a_marketplace_with_no_remote_is_not_submitted_however_the_read_went() {
-        for read in [SubmissionsRead::Landed, SubmissionsRead::Failed] {
+        for read in READS {
             assert_eq!(
                 asked(read, &[row("ada/team-skills")], ask("/mine", None)),
                 SubmissionState::NotSubmitted
@@ -187,7 +194,7 @@ mod tests {
     #[test]
     fn a_row_in_hand_answers_for_itself_under_a_failed_read() {
         let rows = [row("ada/team-skills")];
-        for read in [SubmissionsRead::Landed, SubmissionsRead::Failed] {
+        for read in READS {
             assert_eq!(
                 asked(read, &rows, ask("/mine", Some("ada/team-skills"))),
                 SubmissionState::Submitted {
@@ -197,20 +204,19 @@ mod tests {
         }
     }
 
-    /// The whole point of the two read outcomes: absence means not
-    /// submitted only while reads are landing. Reporting it as unsubmitted
-    /// under a failed read offers a first submit over work in review.
+    /// The whole point of the read outcomes: absence means not submitted
+    /// only where a read landed to say so. Under a read that failed or
+    /// one never made it offers a first submit over work in review.
     #[test]
-    fn absence_stops_being_an_answer_once_a_read_fails() {
+    fn absence_is_an_answer_only_where_a_read_landed() {
         let asking = || ask("/mine", Some("ada/team-skills"));
         assert_eq!(
             asked(SubmissionsRead::Landed, &[], asking()),
             SubmissionState::NotSubmitted
         );
-        assert_eq!(
-            asked(SubmissionsRead::Failed, &[], asking()),
-            SubmissionState::Unknown
-        );
+        for read in [SubmissionsRead::Failed, SubmissionsRead::Unread] {
+            assert_eq!(asked(read, &[], asking()), SubmissionState::Unknown);
+        }
     }
 
     /// Every marketplace asked about gets an answer, under the path it

--- a/crates/core/src/registry/submit.rs
+++ b/crates/core/src/registry/submit.rs
@@ -2,7 +2,9 @@
 //! and read back the caller's rows. Authentication, refresh rotation, and
 //! the dead-grant sign-out rules belong to [`crate::registry::client`].
 
-use serde::Deserialize;
+use std::collections::BTreeMap;
+
+use serde::{Deserialize, Serialize};
 
 use crate::error::{CoreError, Result};
 use crate::registry::client::{server_message, with_access};
@@ -25,6 +27,73 @@ pub struct SubmissionRow {
     pub status_reason: Option<String>,
     pub head_commit: Option<String>,
     pub indexed_at: Option<String>,
+}
+
+/// What is known about one marketplace's submission.
+///
+/// `not-submitted` is a positive answer: nothing of this marketplace is
+/// listed, and the read saying so landed. `unknown` is the absence of an
+/// answer: the last read failed, and what is in hand does not name this
+/// repository. `submitted` carries the row the server listed it under.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, specta::Type)]
+#[serde(tag = "kind", rename_all = "kebab-case")]
+pub enum SubmissionState {
+    NotSubmitted,
+    Unknown,
+    Submitted { row: SubmissionRow },
+}
+
+/// How the last read of the caller's submissions went.
+///
+/// `landed` means the rows in hand are the whole of what the server
+/// lists, so a repository missing from them is not submitted. `failed`
+/// means they are only what it last said, so a repository missing from
+/// them is unknown rather than unsubmitted.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Deserialize, specta::Type)]
+#[serde(rename_all = "kebab-case")]
+pub enum SubmissionsRead {
+    Landed,
+    Failed,
+}
+
+/// One marketplace to answer about: where it is, and the GitHub
+/// repository a submission of it would be keyed by. `repo` is absent for
+/// a marketplace with no GitHub remote.
+#[derive(Debug, Clone, Deserialize, specta::Type)]
+pub struct SubmissionAsk {
+    pub path: String,
+    pub repo: Option<String>,
+}
+
+/// What each marketplace asked about reads as, keyed by its path.
+///
+/// A submission is keyed by the GitHub repository, so a marketplace with
+/// no remote has nothing the server could have listed and is not
+/// submitted whatever the read did. One the rows name is submitted, under
+/// the row the server gave, and that stands under a failed read too: it
+/// is what the server last said. Absence is an answer only while reads
+/// are landing.
+pub fn states(
+    read: SubmissionsRead,
+    rows: &[SubmissionRow],
+    asks: &[SubmissionAsk],
+) -> BTreeMap<String, SubmissionState> {
+    asks.iter()
+        .map(|ask| (ask.path.clone(), state_for(read, rows, ask.repo.as_deref())))
+        .collect()
+}
+
+fn state_for(read: SubmissionsRead, rows: &[SubmissionRow], repo: Option<&str>) -> SubmissionState {
+    let Some(repo) = repo else {
+        return SubmissionState::NotSubmitted;
+    };
+    match rows.iter().find(|row| row.repo == repo) {
+        Some(row) => SubmissionState::Submitted { row: row.clone() },
+        None => match read {
+            SubmissionsRead::Landed => SubmissionState::NotSubmitted,
+            SubmissionsRead::Failed => SubmissionState::Unknown,
+        },
+    }
 }
 
 #[derive(Deserialize)]
@@ -69,5 +138,103 @@ pub fn submissions(fetch: &dyn Fetch, store: &dyn CredentialStore) -> Result<Vec
 fn server_said(response: &FetchResponse) -> CoreError {
     CoreError::Authoring {
         message: server_message(response),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn row(repo: &str) -> SubmissionRow {
+        SubmissionRow {
+            repo: repo.to_owned(),
+            status: "pending".to_owned(),
+            status_reason: None,
+            head_commit: None,
+            indexed_at: None,
+        }
+    }
+
+    fn ask(path: &str, repo: Option<&str>) -> SubmissionAsk {
+        SubmissionAsk {
+            path: path.to_owned(),
+            repo: repo.map(str::to_owned),
+        }
+    }
+
+    fn asked(read: SubmissionsRead, rows: &[SubmissionRow], ask: SubmissionAsk) -> SubmissionState {
+        let path = ask.path.clone();
+        states(read, rows, &[ask])
+            .remove(&path)
+            .expect("a state for every marketplace asked about")
+    }
+
+    /// A submission is keyed by the GitHub repository. A marketplace
+    /// without one has nothing the server could have listed, so no read
+    /// makes it less certain — the offer stays a first submit.
+    #[test]
+    fn a_marketplace_with_no_remote_is_not_submitted_however_the_read_went() {
+        for read in [SubmissionsRead::Landed, SubmissionsRead::Failed] {
+            assert_eq!(
+                asked(read, &[row("ada/team-skills")], ask("/mine", None)),
+                SubmissionState::NotSubmitted
+            );
+        }
+    }
+
+    /// A row already read is what the server last said about that
+    /// repository, and a later read that failed does not unsay it.
+    #[test]
+    fn a_row_in_hand_answers_for_itself_under_a_failed_read() {
+        let rows = [row("ada/team-skills")];
+        for read in [SubmissionsRead::Landed, SubmissionsRead::Failed] {
+            assert_eq!(
+                asked(read, &rows, ask("/mine", Some("ada/team-skills"))),
+                SubmissionState::Submitted {
+                    row: row("ada/team-skills")
+                }
+            );
+        }
+    }
+
+    /// The whole point of the two read outcomes: absence means not
+    /// submitted only while reads are landing. Reporting it as unsubmitted
+    /// under a failed read offers a first submit over work in review.
+    #[test]
+    fn absence_stops_being_an_answer_once_a_read_fails() {
+        let asking = || ask("/mine", Some("ada/team-skills"));
+        assert_eq!(
+            asked(SubmissionsRead::Landed, &[], asking()),
+            SubmissionState::NotSubmitted
+        );
+        assert_eq!(
+            asked(SubmissionsRead::Failed, &[], asking()),
+            SubmissionState::Unknown
+        );
+    }
+
+    /// Every marketplace asked about gets an answer, under the path it
+    /// was asked about: the caller looks each row up by its own path.
+    #[test]
+    fn every_marketplace_asked_about_is_answered_under_its_own_path() {
+        let answered = states(
+            SubmissionsRead::Failed,
+            &[row("ada/team-skills")],
+            &[
+                ask("/mine/team", Some("ada/team-skills")),
+                ask("/mine/scratch", None),
+                ask("/mine/other", Some("ada/other")),
+            ],
+        );
+        assert_eq!(
+            answered.keys().collect::<Vec<_>>(),
+            ["/mine/other", "/mine/scratch", "/mine/team"]
+        );
+        assert_eq!(answered["/mine/other"], SubmissionState::Unknown);
+        assert_eq!(answered["/mine/scratch"], SubmissionState::NotSubmitted);
+        assert!(matches!(
+            answered["/mine/team"],
+            SubmissionState::Submitted { .. }
+        ));
     }
 }

--- a/crates/core/src/registry/submit.rs
+++ b/crates/core/src/registry/submit.rs
@@ -48,8 +48,7 @@ pub enum SubmissionState {
 /// `landed` means the rows in hand are the whole of what the server
 /// lists, so a repository missing from them is not submitted. `failed`
 /// means they are only what it last said, and `unread` that no read has
-/// been made at all: before the first one, and after a credential ends
-/// and takes its rows with it. Under neither is absence an answer.
+/// been made. Under neither is absence an answer.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Deserialize, specta::Type)]
 #[serde(rename_all = "kebab-case")]
 pub enum SubmissionsRead {
@@ -204,9 +203,8 @@ mod tests {
         }
     }
 
-    /// The whole point of the read outcomes: absence means not submitted
-    /// only where a read landed to say so. Under a read that failed or
-    /// one never made it offers a first submit over work in review.
+    /// Absence means not submitted only where a read landed to say so,
+    /// or it offers a first submit over work already in review.
     #[test]
     fn absence_is_an_answer_only_where_a_read_landed() {
         let asking = || ask("/mine", Some("ada/team-skills"));

--- a/ui/src/bindings.ts
+++ b/ui/src/bindings.ts
@@ -2451,10 +2451,11 @@ export type SubmissionState = { kind: "not-submitted" } | { kind: "unknown" } | 
  * 
  *  `landed` means the rows in hand are the whole of what the server
  *  lists, so a repository missing from them is not submitted. `failed`
- *  means they are only what it last said, so a repository missing from
- *  them is unknown rather than unsubmitted.
+ *  means they are only what it last said, and `unread` that no read has
+ *  been made at all: before the first one, and after a credential ends
+ *  and takes its rows with it. Under neither is absence an answer.
  */
-export type SubmissionsRead = "landed" | "failed";
+export type SubmissionsRead = "landed" | "failed" | "unread";
 
 export type SubmitPreflight = {
 	row: MineRow,

--- a/ui/src/bindings.ts
+++ b/ui/src/bindings.ts
@@ -2452,8 +2452,7 @@ export type SubmissionState = { kind: "not-submitted" } | { kind: "unknown" } | 
  *  `landed` means the rows in hand are the whole of what the server
  *  lists, so a repository missing from them is not submitted. `failed`
  *  means they are only what it last said, and `unread` that no read has
- *  been made at all: before the first one, and after a credential ends
- *  and takes its rows with it. Under neither is absence an answer.
+ *  been made. Under neither is absence an answer.
  */
 export type SubmissionsRead = "landed" | "failed" | "unread";
 

--- a/ui/src/bindings.ts
+++ b/ui/src/bindings.ts
@@ -255,6 +255,14 @@ export const commands = {
 	mineSubmitPreflight: (path: string) => typedError<SubmitPreflight, string>(__TAURI_INVOKE("mine_submit_preflight", { path })),
 	mineSubmit: (repo: string) => typedError<SubmittedView, AccountCallRefused>(__TAURI_INVOKE("mine_submit", { repo })),
 	mineSubmissions: () => typedError<SubmissionRow[], AccountCallRefused>(__TAURI_INVOKE("mine_submissions")),
+	/**
+	 *  What each authored marketplace's submission reads as, given the rows a
+	 *  read left in hand and how that read went. A ruling over what the
+	 *  caller already holds: it asks the server nothing, so the tab re-asks
+	 *  whenever its rows, its marketplaces, or the read's outcome change
+	 *  rather than once per row it draws.
+	 */
+	mineSubmissionStates: (read: SubmissionsRead, rows: SubmissionRow[], asks: SubmissionAsk[]) => __TAURI_INVOKE<{ [key in string]: SubmissionState }>("mine_submission_states", { read, rows, asks }),
 	packageVersions: (scope: Scope, kind: ItemKind, name: string) => typedError<VersionRow[], string>(__TAURI_INVOKE("package_versions", { scope, kind, name })),
 	/**
 	 *  Bring one package current and apply — the Updates page's per-package
@@ -2409,6 +2417,16 @@ export type StatusFinding = {
 	fix: string,
 };
 
+/**
+ *  One marketplace to answer about: where it is, and the GitHub
+ *  repository a submission of it would be keyed by. `repo` is absent for
+ *  a marketplace with no GitHub remote.
+ */
+export type SubmissionAsk = {
+	path: string,
+	repo: string | null,
+};
+
 /**  One row of GET /api/v1/submissions — what a Mine row polls. */
 export type SubmissionRow = {
 	repo: string,
@@ -2417,6 +2435,26 @@ export type SubmissionRow = {
 	head_commit: string | null,
 	indexed_at: string | null,
 };
+
+/**
+ *  What is known about one marketplace's submission.
+ * 
+ *  `not-submitted` is a positive answer: nothing of this marketplace is
+ *  listed, and the read saying so landed. `unknown` is the absence of an
+ *  answer: the last read failed, and what is in hand does not name this
+ *  repository. `submitted` carries the row the server listed it under.
+ */
+export type SubmissionState = { kind: "not-submitted" } | { kind: "unknown" } | { kind: "submitted"; row: SubmissionRow };
+
+/**
+ *  How the last read of the caller's submissions went.
+ * 
+ *  `landed` means the rows in hand are the whole of what the server
+ *  lists, so a repository missing from them is not submitted. `failed`
+ *  means they are only what it last said, so a repository missing from
+ *  them is unknown rather than unsubmitted.
+ */
+export type SubmissionsRead = "landed" | "failed";
 
 export type SubmitPreflight = {
 	row: MineRow,

--- a/ui/src/components/marketplaces/mine-row.test.tsx
+++ b/ui/src/components/marketplaces/mine-row.test.tsx
@@ -44,7 +44,7 @@ const row = (findings: StatusFinding[]): MineRow => ({
 const card = (findings: StatusFinding[]) => (
   <MineRowCard
     row={row(findings)}
-    submission={null}
+    submission={{ kind: "none" }}
     onImport={() => {}}
     onSubmit={() => {}}
   />

--- a/ui/src/components/marketplaces/mine-row.test.tsx
+++ b/ui/src/components/marketplaces/mine-row.test.tsx
@@ -44,7 +44,7 @@ const row = (findings: StatusFinding[]): MineRow => ({
 const card = (findings: StatusFinding[]) => (
   <MineRowCard
     row={row(findings)}
-    submission={{ kind: "none" }}
+    submission={null}
     onImport={() => {}}
     onSubmit={() => {}}
   />

--- a/ui/src/components/marketplaces/mine-row.tsx
+++ b/ui/src/components/marketplaces/mine-row.tsx
@@ -4,7 +4,6 @@ import {
   commands,
   type MineRow as MineRowData,
   type StatusFinding,
-  type SubmissionRow,
 } from "@/bindings";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
@@ -18,6 +17,11 @@ import {
 import { worstSeverityLabel } from "@/lib/copy-safety";
 import { SEVERITY_LABELS } from "@/lib/labels";
 import { useMineStore } from "@/stores/mine";
+import {
+  type SubmissionState,
+  submissionLine,
+  submitLabel,
+} from "./mine-submission";
 
 /** A finding's severity in words beside its message, never by
  * implication: the app's own word for a safety severity, the check's own
@@ -63,24 +67,6 @@ function gitLine(row: MineRowData): string {
   return parts.join(" · ");
 }
 
-/** What a submission status reads as on the row. */
-function submissionLine(submission: SubmissionRow): string {
-  switch (submission.status) {
-    case "pending":
-      return "Submitted · in review";
-    case "listed":
-      return "Listed in the community directory";
-    case "needs-changes":
-      return submission.status_reason
-        ? `Needs changes — ${submission.status_reason}`
-        : "Needs changes";
-    case "delisted":
-      return "Delisted";
-    default:
-      return `Submitted · ${submission.status}`;
-  }
-}
-
 /** One authored marketplace: what kendex found in the folder, what the
  * check says, what git says — and the actions that grow it. */
 export function MineRowCard({
@@ -90,7 +76,7 @@ export function MineRowCard({
   onSubmit,
 }: {
   row: MineRowData;
-  submission: SubmissionRow | null;
+  submission: SubmissionState;
   onImport: (path: string) => void;
   onSubmit: (path: string) => void;
 }) {
@@ -99,6 +85,7 @@ export function MineRowCard({
   const acceptManifest = useMineStore((s) => s.acceptManifest);
   const [showFindings, setShowFindings] = useState(false);
   const problems = row.breakage;
+  const status = submissionLine(submission);
 
   return (
     <div className="rounded-lg border border-border p-4">
@@ -122,15 +109,16 @@ export function MineRowCard({
           <p className="mt-1 text-sm text-muted-foreground">
             {countsLine(row)} · {gitLine(row)}
           </p>
-          {submission ? (
+          {status ? (
             <p
               className={
-                submission.status === "needs-changes"
+                submission.kind === "submitted" &&
+                submission.row.status === "needs-changes"
                   ? "mt-1 text-sm text-warning"
                   : "mt-1 text-sm text-muted-foreground"
               }
             >
-              {submissionLine(submission)}
+              {status}
             </p>
           ) : null}
         </div>
@@ -143,7 +131,7 @@ export function MineRowCard({
             Import packages…
           </Button>
           <Button size="sm" onClick={() => onSubmit(row.path)}>
-            {submission ? "Re-submit…" : "Submit to community…"}
+            {submitLabel(submission)}
           </Button>
           <DropdownMenu>
             <DropdownMenuTrigger

--- a/ui/src/components/marketplaces/mine-row.tsx
+++ b/ui/src/components/marketplaces/mine-row.tsx
@@ -4,6 +4,7 @@ import {
   commands,
   type MineRow as MineRowData,
   type StatusFinding,
+  type SubmissionState,
 } from "@/bindings";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
@@ -17,11 +18,7 @@ import {
 import { worstSeverityLabel } from "@/lib/copy-safety";
 import { SEVERITY_LABELS } from "@/lib/labels";
 import { useMineStore } from "@/stores/mine";
-import {
-  type SubmissionState,
-  submissionLine,
-  submitLabel,
-} from "./mine-submission";
+import { submissionLine, submitLabel } from "./mine-submission";
 
 /** A finding's severity in words beside its message, never by
  * implication: the app's own word for a safety severity, the check's own
@@ -76,7 +73,7 @@ export function MineRowCard({
   onSubmit,
 }: {
   row: MineRowData;
-  submission: SubmissionState;
+  submission: SubmissionState | null;
   onImport: (path: string) => void;
   onSubmit: (path: string) => void;
 }) {
@@ -112,7 +109,7 @@ export function MineRowCard({
           {status ? (
             <p
               className={
-                submission.kind === "submitted" &&
+                submission?.kind === "submitted" &&
                 submission.row.status === "needs-changes"
                   ? "mt-1 text-sm text-warning"
                   : "mt-1 text-sm text-muted-foreground"

--- a/ui/src/components/marketplaces/mine-submission.ts
+++ b/ui/src/components/marketplaces/mine-submission.ts
@@ -1,40 +1,17 @@
-// What a Mine row knows about its own submission, and what that reads as.
-// Three answers, not two: a marketplace the server never listed and one
-// the app could not ask about must not read alike, or work already in
-// review is offered a first submit.
-import type { SubmissionRow } from "@/bindings";
+// What a Mine row's submission state reads as. The state itself and the
+// rule that decides which one a read leaves are core's: `SubmissionState`
+// is generated from it and `mineSubmissionStates` answers with it.
+import type { SubmissionState } from "@/bindings";
 
-/** What is known about one marketplace's submission. `unknown` is the
- *  absence of an answer, which is what a submissions read that failed
- *  leaves behind. */
-export type SubmissionState =
-  | { kind: "none" }
-  | { kind: "unknown" }
-  | { kind: "submitted"; row: SubmissionRow };
-
-/** What the rows in hand say about one marketplace. A row already read
- *  answers for itself even under a standing failure: it is what the
- *  server last said, and the tab labels it stale rather than hiding it.
- *  Absence is only an answer while the reads land, so a failure turns it
- *  into no answer at all. */
-export const submissionFor = (
-  rows: SubmissionRow[] | null,
-  failed: boolean,
-  repo: string | null,
-): SubmissionState => {
-  // A submission is keyed by the GitHub repository, so a marketplace with
-  // no remote has nothing the server could have listed: not submitted is
-  // the whole answer, and no failure makes it less certain.
-  if (repo === null) return { kind: "none" };
-  const found = rows?.find((candidate) => candidate.repo === repo);
-  if (found) return { kind: "submitted", row: found };
-  return failed ? { kind: "unknown" } : { kind: "none" };
-};
+/** The answer a row has not been given yet, which is the screen before
+ *  the first read lands. It shows what a marketplace nobody has submitted
+ *  shows, and neither reads as a claim about the server. */
+type Unanswered = SubmissionState | null;
 
 /** What a submission state reads as on the row, or null where the row has
  *  nothing to say about one. */
-export const submissionLine = (state: SubmissionState): string | null => {
-  if (state.kind === "none") return null;
+export const submissionLine = (state: Unanswered): string | null => {
+  if (state === null || state.kind === "not-submitted") return null;
   if (state.kind === "unknown") return "Submission status unknown";
   switch (state.row.status) {
     case "pending":
@@ -55,7 +32,7 @@ export const submissionLine = (state: SubmissionState): string | null => {
 /** What the submit button offers. Without an answer neither of the other
  *  two is honest: one says the marketplace was never submitted, the other
  *  that it was. */
-export const submitLabel = (state: SubmissionState): string => {
-  if (state.kind === "submitted") return "Re-submit…";
-  return state.kind === "unknown" ? "Submit…" : "Submit to community…";
+export const submitLabel = (state: Unanswered): string => {
+  if (state?.kind === "submitted") return "Re-submit…";
+  return state?.kind === "unknown" ? "Submit…" : "Submit to community…";
 };

--- a/ui/src/components/marketplaces/mine-submission.ts
+++ b/ui/src/components/marketplaces/mine-submission.ts
@@ -1,0 +1,61 @@
+// What a Mine row knows about its own submission, and what that reads as.
+// Three answers, not two: a marketplace the server never listed and one
+// the app could not ask about must not read alike, or work already in
+// review is offered a first submit.
+import type { SubmissionRow } from "@/bindings";
+
+/** What is known about one marketplace's submission. `unknown` is the
+ *  absence of an answer, which is what a submissions read that failed
+ *  leaves behind. */
+export type SubmissionState =
+  | { kind: "none" }
+  | { kind: "unknown" }
+  | { kind: "submitted"; row: SubmissionRow };
+
+/** What the rows in hand say about one marketplace. A row already read
+ *  answers for itself even under a standing failure: it is what the
+ *  server last said, and the tab labels it stale rather than hiding it.
+ *  Absence is only an answer while the reads land, so a failure turns it
+ *  into no answer at all. */
+export const submissionFor = (
+  rows: SubmissionRow[] | null,
+  failed: boolean,
+  repo: string | null,
+): SubmissionState => {
+  // A submission is keyed by the GitHub repository, so a marketplace with
+  // no remote has nothing the server could have listed: not submitted is
+  // the whole answer, and no failure makes it less certain.
+  if (repo === null) return { kind: "none" };
+  const found = rows?.find((candidate) => candidate.repo === repo);
+  if (found) return { kind: "submitted", row: found };
+  return failed ? { kind: "unknown" } : { kind: "none" };
+};
+
+/** What a submission state reads as on the row, or null where the row has
+ *  nothing to say about one. */
+export const submissionLine = (state: SubmissionState): string | null => {
+  if (state.kind === "none") return null;
+  if (state.kind === "unknown") return "Submission status unknown";
+  switch (state.row.status) {
+    case "pending":
+      return "Submitted · in review";
+    case "listed":
+      return "Listed in the community directory";
+    case "needs-changes":
+      return state.row.status_reason
+        ? `Needs changes — ${state.row.status_reason}`
+        : "Needs changes";
+    case "delisted":
+      return "Delisted";
+    default:
+      return `Submitted · ${state.row.status}`;
+  }
+};
+
+/** What the submit button offers. Without an answer neither of the other
+ *  two is honest: one says the marketplace was never submitted, the other
+ *  that it was. */
+export const submitLabel = (state: SubmissionState): string => {
+  if (state.kind === "submitted") return "Re-submit…";
+  return state.kind === "unknown" ? "Submit…" : "Submit to community…";
+};

--- a/ui/src/components/marketplaces/mine-submission.ts
+++ b/ui/src/components/marketplaces/mine-submission.ts
@@ -3,9 +3,9 @@
 // is generated from it and `mineSubmissionStates` answers with it.
 import type { SubmissionState } from "@/bindings";
 
-/** The answer a row has not been given yet, which is the screen before
- *  the first read lands. It shows what a marketplace nobody has submitted
- *  shows, and neither reads as a claim about the server. */
+/** The answer a row has not been given yet: core has been asked and has
+ *  not come back. It says nothing on the row, the way not-submitted does,
+ *  and claims nothing in the offer, the way unknown does. */
 type Unanswered = SubmissionState | null;
 
 /** What a submission state reads as on the row, or null where the row has
@@ -33,6 +33,6 @@ export const submissionLine = (state: Unanswered): string | null => {
  *  two is honest: one says the marketplace was never submitted, the other
  *  that it was. */
 export const submitLabel = (state: Unanswered): string => {
-  if (state?.kind === "submitted") return "Re-submit…";
-  return state?.kind === "unknown" ? "Submit…" : "Submit to community…";
+  if (state === null || state.kind === "unknown") return "Submit…";
+  return state.kind === "submitted" ? "Re-submit…" : "Submit to community…";
 };

--- a/ui/src/components/marketplaces/mine-submission.ts
+++ b/ui/src/components/marketplaces/mine-submission.ts
@@ -3,9 +3,8 @@
 // is generated from it and `mineSubmissionStates` answers with it.
 import type { SubmissionState } from "@/bindings";
 
-/** The answer a row has not been given yet: core has been asked and has
- *  not come back. It says nothing on the row, the way not-submitted does,
- *  and claims nothing in the offer, the way unknown does. */
+/** The answer a row has not been given yet: nothing on the row, the way
+ *  not-submitted reads, and no claim in the offer, the way unknown does. */
 type Unanswered = SubmissionState | null;
 
 /** What a submission state reads as on the row, or null where the row has
@@ -30,8 +29,7 @@ export const submissionLine = (state: Unanswered): string | null => {
 };
 
 /** What the submit button offers. Without an answer neither of the other
- *  two is honest: one says the marketplace was never submitted, the other
- *  that it was. */
+ *  two is honest: one claims it was never submitted, the other that it was. */
 export const submitLabel = (state: Unanswered): string => {
   if (state === null || state.kind === "unknown") return "Submit…";
   return state.kind === "submitted" ? "Re-submit…" : "Submit to community…";

--- a/ui/src/components/marketplaces/mine-tab.dom.test.tsx
+++ b/ui/src/components/marketplaces/mine-tab.dom.test.tsx
@@ -230,6 +230,31 @@ describe("a submissions read the app could not make", () => {
     ]);
   });
 
+  // No rows and no failure is not a read that landed: it is the moment
+  // before the first read, and it is where a credential's end leaves the
+  // tab. Calling it landed puts the first-submit offer back on work that
+  // may be in review.
+  it("tells core no read has been made until one does", async () => {
+    useMineStore.setState({ rows: [MINE] });
+    vi.mocked(commands.mineSubmissions).mockResolvedValue(answered([ROW]));
+
+    await showing();
+
+    const first = vi.mocked(commands.mineSubmissionStates).mock.calls[0];
+    expect(first?.slice(0, 2)).toEqual(["unread", []]);
+  });
+
+  it("offers no first submit for a row core has not answered for", async () => {
+    useMineStore.setState({ rows: [MINE] });
+    vi.mocked(commands.mineSubmissions).mockResolvedValue(answered([ROW]));
+
+    const text = await showing({});
+
+    expect(text).toContain("Submit…");
+    expect(text).not.toContain("Submit to community…");
+    expect(text).not.toContain("Submission status unknown");
+  });
+
   it("draws an unknown state as unknown, claiming neither offer", async () => {
     useMineStore.setState({ rows: [MINE] });
     vi.mocked(commands.mineSubmissions).mockResolvedValue(

--- a/ui/src/components/marketplaces/mine-tab.dom.test.tsx
+++ b/ui/src/components/marketplaces/mine-tab.dom.test.tsx
@@ -4,8 +4,8 @@
 // found the sign-in dead used to be discarded, so a session could die
 // under an open window and every surface go on saying signed in.
 import { act } from "react";
-import { afterEach, beforeEach, expect, it, vi } from "vitest";
-import { commands } from "@/bindings";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { commands, type MineListRow } from "@/bindings";
 import { useAccountStore } from "@/stores/account";
 import { useMineStore } from "@/stores/mine";
 import { mount, settle } from "@/test/dom";
@@ -30,15 +30,46 @@ const ADA = { name: "Ada Lovelace", githubLogin: "ada" };
 const ROW = {
   repo: "ada/team-skills",
   status: "pending",
-  statusReason: null,
-  headCommit: null,
-  indexedAt: null,
+  status_reason: null,
+  head_commit: null,
+  indexed_at: null,
 };
 
 const EXPIRED =
   "your sign-in has expired (invalid_grant) — run `kendex login` again";
 
 const answered = <T,>(data: T) => ({ status: "ok", data }) as never;
+
+const FAILED = "kendex.ai could not be reached";
+
+const refused = (kind: "expired" | "failed", message: string) =>
+  ({ status: "error", error: { kind, message } }) as never;
+
+/** One authored marketplace whose GitHub remote is the repo `ROW` is
+ *  about, so the row and the submission can be joined or fail to be. */
+const MINE: MineListRow = {
+  state: "ready",
+  row: {
+    path: "/home/ada/dev/team-skills",
+    name: "team-skills",
+    description: null,
+    license: "MIT",
+    counts: { skill: 1 },
+    bundles: 0,
+    declared: true,
+    breakage: 0,
+    advisory: 0,
+    safetyFindings: 0,
+    findings: [],
+    git: {
+      repository: true,
+      clean: true,
+      remote: "git@github.com:ada/team-skills.git",
+      candidate: "ada/team-skills",
+      ahead: 0,
+    },
+  },
+};
 
 // The tab's own rows are not what is under test: `load` is stubbed so the
 // mount reaches no command, and the tab renders its empty state while the
@@ -52,6 +83,7 @@ beforeEach(() => {
     error: null,
     readError: null,
     submissions: null,
+    submissionsError: null,
     signingIn: false,
     userCode: null,
   });
@@ -70,10 +102,9 @@ it("moves the account to expired on a poll tick that meets a dead sign-in", asyn
   expect(useAccountStore.getState().submissions).toEqual([ROW]);
 
   // The session dies between ticks, with nothing on this tab asking.
-  vi.mocked(commands.mineSubmissions).mockResolvedValue({
-    status: "error",
-    error: { kind: "expired", message: EXPIRED },
-  } as never);
+  vi.mocked(commands.mineSubmissions).mockResolvedValue(
+    refused("expired", EXPIRED),
+  );
   await act(async () => {
     vi.advanceTimersByTime(POLL_MS);
   });
@@ -91,10 +122,9 @@ it("moves the account to expired on a poll tick that meets a dead sign-in", asyn
 // again: the effect is keyed to holding a credential, and expired holds
 // none.
 it("stops polling once a tick has found the sign-in expired", async () => {
-  vi.mocked(commands.mineSubmissions).mockResolvedValue({
-    status: "error",
-    error: { kind: "expired", message: EXPIRED },
-  } as never);
+  vi.mocked(commands.mineSubmissions).mockResolvedValue(
+    refused("expired", EXPIRED),
+  );
   mount(<MineTab />);
   await settle();
   expect(useAccountStore.getState().account).toEqual({
@@ -122,10 +152,9 @@ it("leaves the account alone when a tick fails for any other reason", async () =
   mount(<MineTab />);
   await settle();
 
-  vi.mocked(commands.mineSubmissions).mockResolvedValue({
-    status: "error",
-    error: { kind: "failed", message: "kendex.ai could not be reached" },
-  } as never);
+  vi.mocked(commands.mineSubmissions).mockResolvedValue(
+    refused("failed", FAILED),
+  );
   await act(async () => {
     vi.advanceTimersByTime(POLL_MS);
   });
@@ -137,4 +166,112 @@ it("leaves the account alone when a tick fails for any other reason", async () =
     signIn: SIGN_IN,
   });
   expect(useAccountStore.getState().submissions).toEqual([ROW]);
+});
+
+// The defect this tab had: a read that never landed is not the same fact
+// as a server that answered with nothing, and offering a first submit
+// over work already in review is what telling them apart prevents.
+describe("a submissions read the app could not make", () => {
+  const showing = async () => {
+    const host = mount(<MineTab />);
+    await settle();
+    return host.textContent ?? "";
+  };
+
+  it("says the status is unknown where an empty list says nothing", async () => {
+    useMineStore.setState({ rows: [MINE] });
+    vi.mocked(commands.mineSubmissions).mockResolvedValue(
+      refused("failed", FAILED),
+    );
+
+    const text = await showing();
+
+    expect(text).toContain("Could not check your submissions");
+    expect(text).toContain(FAILED);
+    expect(text).toContain("Submission status unknown");
+    // The offer claims nothing either: "Submit to community…" would say
+    // this marketplace was never submitted, which is the unread fact.
+    expect(text).toContain("Submit…");
+    expect(text).not.toContain("Submit to community…");
+  });
+
+  // The control for the assertions above: the same tab, the same row, a
+  // read that landed. Every string above has to go the other way, or they
+  // are matching the page rather than the failure.
+  it("says none of that when the read lands with nothing submitted", async () => {
+    useMineStore.setState({ rows: [MINE] });
+    vi.mocked(commands.mineSubmissions).mockResolvedValue(answered([]));
+
+    const text = await showing();
+
+    expect(text).not.toContain("Could not check your submissions");
+    expect(text).not.toContain("Submission status unknown");
+    expect(text).toContain("Submit to community…");
+  });
+
+  // Nothing is unknown about a folder the server could not have listed:
+  // a submission is keyed by the GitHub repository, and this one has none.
+  it("leaves a marketplace with no GitHub remote saying nothing", async () => {
+    useMineStore.setState({
+      rows: [
+        {
+          ...MINE,
+          row: { ...MINE.row, git: { ...MINE.row.git, candidate: null } },
+        },
+      ],
+    });
+    vi.mocked(commands.mineSubmissions).mockResolvedValue(
+      refused("failed", FAILED),
+    );
+
+    const text = await showing();
+
+    expect(text).toContain("Could not check your submissions");
+    expect(text).not.toContain("Submission status unknown");
+    expect(text).toContain("Submit to community…");
+  });
+
+  // Stale and labelled beats empty: the rows are what the server last
+  // said, and clearing them would take away the one thing still known.
+  it("keeps the rows a tick already read when a later tick fails", async () => {
+    useMineStore.setState({ rows: [MINE] });
+    vi.mocked(commands.mineSubmissions).mockResolvedValue(answered([ROW]));
+    const host = mount(<MineTab />);
+    await settle();
+    expect(host.textContent).toContain("Submitted · in review");
+
+    vi.mocked(commands.mineSubmissions).mockResolvedValue(
+      refused("failed", FAILED),
+    );
+    await act(async () => {
+      vi.advanceTimersByTime(POLL_MS);
+    });
+    await settle();
+
+    expect(useAccountStore.getState().submissions).toEqual([ROW]);
+    expect(host.textContent).toContain("Submitted · in review");
+    expect(host.textContent).toContain("Could not check your submissions");
+    expect(host.textContent).toContain("Re-submit…");
+  });
+
+  // A read that lands takes the notice away on its own, so a server that
+  // came back does not leave a warning standing over current rows.
+  it("clears the notice on the next tick that lands", async () => {
+    useMineStore.setState({ rows: [MINE] });
+    vi.mocked(commands.mineSubmissions).mockResolvedValue(
+      refused("failed", FAILED),
+    );
+    const host = mount(<MineTab />);
+    await settle();
+    expect(host.textContent).toContain("Could not check your submissions");
+
+    vi.mocked(commands.mineSubmissions).mockResolvedValue(answered([ROW]));
+    await act(async () => {
+      vi.advanceTimersByTime(POLL_MS);
+    });
+    await settle();
+
+    expect(host.textContent).not.toContain("Could not check your submissions");
+    expect(host.textContent).toContain("Submitted · in review");
+  });
 });

--- a/ui/src/components/marketplaces/mine-tab.dom.test.tsx
+++ b/ui/src/components/marketplaces/mine-tab.dom.test.tsx
@@ -71,8 +71,7 @@ const READY = {
 
 const MINE: MineListRow = { state: "ready", row: READY };
 
-/** The same marketplace with no GitHub remote: nothing a submission could
- *  be keyed by. */
+/** The same marketplace with no remote: nothing to key a submission by. */
 const NO_REMOTE: MineListRow = {
   state: "ready",
   row: {
@@ -181,11 +180,9 @@ it("leaves the account alone when a tick fails for any other reason", async () =
 });
 
 // The defect this tab had: a read that never landed is not the same fact
-// as a server that answered with nothing, and offering a first submit
-// over work already in review is what telling them apart prevents. Which
-// of the three a marketplace is in is core's ruling, tested in
-// crates/core/src/registry/submit.rs. What is asserted here is the two
-// halves this tab owns: what it hands core, and what it draws back.
+// as a server that answered with nothing. Which of the three a
+// marketplace is in is core's ruling, tested in its own crate; the halves
+// asserted here are the tab's own: what it hands core, what it draws.
 describe("a submissions read the app could not make", () => {
   const showing = async (states: Record<string, unknown> = {}) => {
     vi.mocked(commands.mineSubmissionStates).mockResolvedValue(states as never);
@@ -217,23 +214,8 @@ describe("a submissions read the app could not make", () => {
     ]);
   });
 
-  it("hands core the landed outcome when the read comes back", async () => {
-    useMineStore.setState({ rows: [MINE] });
-    vi.mocked(commands.mineSubmissions).mockResolvedValue(answered([ROW]));
-
-    await showing();
-
-    expect(asked()).toEqual([
-      "landed",
-      [ROW],
-      [{ path: READY.path, repo: "ada/team-skills" }],
-    ]);
-  });
-
   // No rows and no failure is not a read that landed: it is the moment
-  // before the first read, and it is where a credential's end leaves the
-  // tab. Calling it landed puts the first-submit offer back on work that
-  // may be in review.
+  // before the first, and where a credential's end leaves the tab.
   it("tells core no read has been made until one does", async () => {
     useMineStore.setState({ rows: [MINE] });
     vi.mocked(commands.mineSubmissions).mockResolvedValue(answered([ROW]));
@@ -270,9 +252,7 @@ describe("a submissions read the app could not make", () => {
     expect(text).not.toContain("Submit to community…");
   });
 
-  // The control for the assertions above: the other answer core gives
-  // about a marketplace nothing is listed for. Every string above has to
-  // go the other way, or they are matching the page rather than the state.
+  // The control: every string has to go the other way.
   it("draws a not-submitted state as nothing said at all", async () => {
     useMineStore.setState({ rows: [MINE] });
     vi.mocked(commands.mineSubmissions).mockResolvedValue(answered([]));
@@ -285,13 +265,23 @@ describe("a submissions read the app could not make", () => {
   });
 
   // Stale and labelled beats empty: the rows are what the server last
-  // said, and clearing them would take away the one thing still known.
-  it("keeps the rows a tick already read when a later tick fails", async () => {
+  // said. The answer ruled from them is another matter, its outcome now
+  // passed — a banner beside a first-submit offer is the same wrong claim.
+  it("keeps the rows a tick read, and drops the answer ruled under it", async () => {
     useMineStore.setState({ rows: [MINE] });
     vi.mocked(commands.mineSubmissions).mockResolvedValue(answered([ROW]));
+    vi.mocked(commands.mineSubmissionStates).mockResolvedValue({
+      [READY.path]: { kind: "not-submitted" },
+    } as never);
     const host = mount(<MineTab />);
     await settle();
     expect(asked()?.[0]).toBe("landed");
+    expect(host.textContent).toContain("Submit to community…");
+
+    // The replacement ask is still out when the render below happens.
+    vi.mocked(commands.mineSubmissionStates).mockReturnValue(
+      new Promise(() => {}) as never,
+    );
 
     vi.mocked(commands.mineSubmissions).mockResolvedValue(
       refused("failed", FAILED),
@@ -310,11 +300,10 @@ describe("a submissions read the app could not make", () => {
       [{ path: READY.path, repo: "ada/team-skills" }],
     ]);
     expect(host.textContent).toContain("Could not check your submissions");
+    expect(host.textContent).not.toContain("Submit to community…");
   });
 
-  // The ask goes out again whenever what it rules on changes, so two are
-  // out at once whenever a tick lands while one is in flight. The older
-  // answer describes inputs the tab has already moved past.
+  // Two asks overlap whenever a tick lands while one is in flight.
   it("draws the newer answer when an older ask lands after it", async () => {
     useMineStore.setState({ rows: [MINE] });
     vi.mocked(commands.mineSubmissions).mockResolvedValue(answered([]));
@@ -348,24 +337,28 @@ describe("a submissions read the app could not make", () => {
     expect(host.textContent).toContain("Submission status unknown");
   });
 
-  // A read that lands takes the notice away on its own, so a server that
-  // came back does not leave a warning standing over current rows.
-  it("clears the notice on the next tick that lands", async () => {
+  // Nothing retries the ask, so a refusal leaves the rows unanswered.
+  it("drops the answer in hand when the ask is refused", async () => {
     useMineStore.setState({ rows: [MINE] });
-    vi.mocked(commands.mineSubmissions).mockResolvedValue(
-      refused("failed", FAILED),
-    );
+    vi.mocked(commands.mineSubmissions).mockResolvedValue(answered([ROW]));
+    vi.mocked(commands.mineSubmissionStates).mockResolvedValue({
+      [READY.path]: { kind: "submitted", row: ROW },
+    } as never);
     const host = mount(<MineTab />);
     await settle();
-    expect(host.textContent).toContain("Could not check your submissions");
+    expect(host.textContent).toContain("Submitted · in review");
+    expect(host.textContent).toContain("Re-submit…");
 
-    vi.mocked(commands.mineSubmissions).mockResolvedValue(answered([ROW]));
+    // A second marketplace sends the ask out again under the same
+    // outcome, so only the catch can drop the answer already in hand.
+    vi.mocked(commands.mineSubmissionStates).mockRejectedValue(new Error("no"));
     await act(async () => {
-      vi.advanceTimersByTime(POLL_MS);
+      useMineStore.setState({ rows: [MINE, NO_REMOTE] });
     });
     await settle();
 
-    expect(host.textContent).not.toContain("Could not check your submissions");
-    expect(asked()?.[0]).toBe("landed");
+    expect(host.textContent).not.toContain("Submitted · in review");
+    expect(host.textContent).not.toContain("Re-submit…");
+    expect(host.textContent).toContain("Submit…");
   });
 });

--- a/ui/src/components/marketplaces/mine-tab.dom.test.tsx
+++ b/ui/src/components/marketplaces/mine-tab.dom.test.tsx
@@ -18,6 +18,7 @@ const SIGN_IN = "sign-in-ada";
 vi.mock("@/bindings", () => ({
   commands: {
     mineSubmissions: vi.fn(),
+    mineSubmissionStates: vi.fn(),
     mineSubmitPreflight: vi.fn(),
     mineAuthoringDoc: vi.fn(),
     pickFolder: vi.fn(),
@@ -47,27 +48,37 @@ const refused = (kind: "expired" | "failed", message: string) =>
 
 /** One authored marketplace whose GitHub remote is the repo `ROW` is
  *  about, so the row and the submission can be joined or fail to be. */
-const MINE: MineListRow = {
+const READY = {
+  path: "/home/ada/dev/team-skills",
+  name: "team-skills",
+  description: null,
+  license: "MIT",
+  counts: { skill: 1 },
+  bundles: 0,
+  declared: true,
+  breakage: 0,
+  advisory: 0,
+  safetyFindings: 0,
+  findings: [],
+  git: {
+    repository: true,
+    clean: true,
+    remote: "git@github.com:ada/team-skills.git",
+    candidate: "ada/team-skills",
+    ahead: 0,
+  },
+};
+
+const MINE: MineListRow = { state: "ready", row: READY };
+
+/** The same marketplace with no GitHub remote: nothing a submission could
+ *  be keyed by. */
+const NO_REMOTE: MineListRow = {
   state: "ready",
   row: {
-    path: "/home/ada/dev/team-skills",
-    name: "team-skills",
-    description: null,
-    license: "MIT",
-    counts: { skill: 1 },
-    bundles: 0,
-    declared: true,
-    breakage: 0,
-    advisory: 0,
-    safetyFindings: 0,
-    findings: [],
-    git: {
-      repository: true,
-      clean: true,
-      remote: "git@github.com:ada/team-skills.git",
-      candidate: "ada/team-skills",
-      ahead: 0,
-    },
+    ...READY,
+    path: "/home/ada/dev/scratch-skills",
+    git: { ...READY.git, remote: null, candidate: null },
   },
 };
 
@@ -77,6 +88,7 @@ const MINE: MineListRow = {
 beforeEach(() => {
   vi.useFakeTimers();
   vi.clearAllMocks();
+  vi.mocked(commands.mineSubmissionStates).mockResolvedValue({});
   useMineStore.setState({ rows: [], load: async () => {} });
   useAccountStore.setState({
     account: { kind: "signed-in", identity: ADA, signIn: SIGN_IN },
@@ -170,63 +182,79 @@ it("leaves the account alone when a tick fails for any other reason", async () =
 
 // The defect this tab had: a read that never landed is not the same fact
 // as a server that answered with nothing, and offering a first submit
-// over work already in review is what telling them apart prevents.
+// over work already in review is what telling them apart prevents. Which
+// of the three a marketplace is in is core's ruling, tested in
+// crates/core/src/registry/submit.rs. What is asserted here is the two
+// halves this tab owns: what it hands core, and what it draws back.
 describe("a submissions read the app could not make", () => {
-  const showing = async () => {
+  const showing = async (states: Record<string, unknown> = {}) => {
+    vi.mocked(commands.mineSubmissionStates).mockResolvedValue(states as never);
     const host = mount(<MineTab />);
     await settle();
     return host.textContent ?? "";
   };
 
-  it("says the status is unknown where an empty list says nothing", async () => {
+  const asked = () => vi.mocked(commands.mineSubmissionStates).mock.lastCall;
+
+  it("hands core the failed outcome, the rows in hand, and every marketplace", async () => {
+    useMineStore.setState({ rows: [MINE, NO_REMOTE] });
+    useAccountStore.setState({ submissions: [ROW] });
+    vi.mocked(commands.mineSubmissions).mockResolvedValue(
+      refused("failed", FAILED),
+    );
+
+    await showing();
+
+    // The remote-less marketplace goes out with a null repo rather than
+    // being left out: core answers about every marketplace this tab draws.
+    expect(asked()).toEqual([
+      "failed",
+      [ROW],
+      [
+        { path: READY.path, repo: "ada/team-skills" },
+        { path: "/home/ada/dev/scratch-skills", repo: null },
+      ],
+    ]);
+  });
+
+  it("hands core the landed outcome when the read comes back", async () => {
+    useMineStore.setState({ rows: [MINE] });
+    vi.mocked(commands.mineSubmissions).mockResolvedValue(answered([ROW]));
+
+    await showing();
+
+    expect(asked()).toEqual([
+      "landed",
+      [ROW],
+      [{ path: READY.path, repo: "ada/team-skills" }],
+    ]);
+  });
+
+  it("draws an unknown state as unknown, claiming neither offer", async () => {
     useMineStore.setState({ rows: [MINE] });
     vi.mocked(commands.mineSubmissions).mockResolvedValue(
       refused("failed", FAILED),
     );
 
-    const text = await showing();
+    const text = await showing({ [READY.path]: { kind: "unknown" } });
 
     expect(text).toContain("Could not check your submissions");
     expect(text).toContain(FAILED);
     expect(text).toContain("Submission status unknown");
-    // The offer claims nothing either: "Submit to community…" would say
-    // this marketplace was never submitted, which is the unread fact.
     expect(text).toContain("Submit…");
     expect(text).not.toContain("Submit to community…");
   });
 
-  // The control for the assertions above: the same tab, the same row, a
-  // read that landed. Every string above has to go the other way, or they
-  // are matching the page rather than the failure.
-  it("says none of that when the read lands with nothing submitted", async () => {
+  // The control for the assertions above: the other answer core gives
+  // about a marketplace nothing is listed for. Every string above has to
+  // go the other way, or they are matching the page rather than the state.
+  it("draws a not-submitted state as nothing said at all", async () => {
     useMineStore.setState({ rows: [MINE] });
     vi.mocked(commands.mineSubmissions).mockResolvedValue(answered([]));
 
-    const text = await showing();
+    const text = await showing({ [READY.path]: { kind: "not-submitted" } });
 
     expect(text).not.toContain("Could not check your submissions");
-    expect(text).not.toContain("Submission status unknown");
-    expect(text).toContain("Submit to community…");
-  });
-
-  // Nothing is unknown about a folder the server could not have listed:
-  // a submission is keyed by the GitHub repository, and this one has none.
-  it("leaves a marketplace with no GitHub remote saying nothing", async () => {
-    useMineStore.setState({
-      rows: [
-        {
-          ...MINE,
-          row: { ...MINE.row, git: { ...MINE.row.git, candidate: null } },
-        },
-      ],
-    });
-    vi.mocked(commands.mineSubmissions).mockResolvedValue(
-      refused("failed", FAILED),
-    );
-
-    const text = await showing();
-
-    expect(text).toContain("Could not check your submissions");
     expect(text).not.toContain("Submission status unknown");
     expect(text).toContain("Submit to community…");
   });
@@ -238,7 +266,7 @@ describe("a submissions read the app could not make", () => {
     vi.mocked(commands.mineSubmissions).mockResolvedValue(answered([ROW]));
     const host = mount(<MineTab />);
     await settle();
-    expect(host.textContent).toContain("Submitted · in review");
+    expect(asked()?.[0]).toBe("landed");
 
     vi.mocked(commands.mineSubmissions).mockResolvedValue(
       refused("failed", FAILED),
@@ -249,9 +277,50 @@ describe("a submissions read the app could not make", () => {
     await settle();
 
     expect(useAccountStore.getState().submissions).toEqual([ROW]);
-    expect(host.textContent).toContain("Submitted · in review");
+    // The rows that tick already read reach core under the failed
+    // outcome, which is all stale-but-labelled needs from this tab.
+    expect(asked()).toEqual([
+      "failed",
+      [ROW],
+      [{ path: READY.path, repo: "ada/team-skills" }],
+    ]);
     expect(host.textContent).toContain("Could not check your submissions");
-    expect(host.textContent).toContain("Re-submit…");
+  });
+
+  // The ask goes out again whenever what it rules on changes, so two are
+  // out at once whenever a tick lands while one is in flight. The older
+  // answer describes inputs the tab has already moved past.
+  it("draws the newer answer when an older ask lands after it", async () => {
+    useMineStore.setState({ rows: [MINE] });
+    vi.mocked(commands.mineSubmissions).mockResolvedValue(answered([]));
+    const land: ((states: unknown) => void)[] = [];
+    vi.mocked(commands.mineSubmissionStates).mockImplementation(
+      () => new Promise((resolve) => land.push(resolve)) as never,
+    );
+    const host = mount(<MineTab />);
+    await settle();
+
+    // A tick that fails changes the outcome, so a second ask goes out.
+    vi.mocked(commands.mineSubmissions).mockResolvedValue(
+      refused("failed", FAILED),
+    );
+    await act(async () => {
+      vi.advanceTimersByTime(POLL_MS);
+    });
+    await settle();
+    expect(land.length).toBeGreaterThan(1);
+
+    // The newest ask answers first, then every older one after it.
+    const newest = land.length - 1;
+    await act(async () => {
+      land[newest]({ [READY.path]: { kind: "unknown" } });
+      for (let older = 0; older < newest; older += 1) {
+        land[older]({ [READY.path]: { kind: "not-submitted" } });
+      }
+    });
+    await settle();
+
+    expect(host.textContent).toContain("Submission status unknown");
   });
 
   // A read that lands takes the notice away on its own, so a server that
@@ -272,6 +341,6 @@ describe("a submissions read the app could not make", () => {
     await settle();
 
     expect(host.textContent).not.toContain("Could not check your submissions");
-    expect(host.textContent).toContain("Submitted · in review");
+    expect(asked()?.[0]).toBe("landed");
   });
 });

--- a/ui/src/components/marketplaces/mine-tab.tsx
+++ b/ui/src/components/marketplaces/mine-tab.tsx
@@ -1,6 +1,6 @@
 import { BookOpen, FolderOpen, Hammer, Plus } from "lucide-react";
 import { useEffect, useState } from "react";
-import { commands } from "@/bindings";
+import { commands, type SubmissionState } from "@/bindings";
 import { EmptyState } from "@/components/empty-state";
 import { TextBar } from "@/components/loading";
 import { MarkdownView } from "@/components/markdown-view";
@@ -17,7 +17,6 @@ import { useMineStore } from "@/stores/mine";
 import { MineCreateDialog } from "./mine-create-dialog";
 import { MineImportDialog } from "./mine-import-dialog";
 import { MineRowCard } from "./mine-row";
-import { submissionFor } from "./mine-submission";
 import { MineSubmitDialog } from "./mine-submit-dialog";
 
 /** The marketplaces the user authors. Rows are computed fresh from each
@@ -36,6 +35,9 @@ export function MineTab() {
   const signedIn = useAccountStore((s) => hasCredential(s.account));
   const submissions = useAccountStore((s) => s.submissions);
   const submissionsError = useAccountStore((s) => s.submissionsError);
+  const [states, setStates] = useState<Record<string, SubmissionState> | null>(
+    null,
+  );
 
   useEffect(() => {
     void load();
@@ -54,6 +56,31 @@ export function MineTab() {
     const timer = setInterval(() => void loadSubmissions(), 60_000);
     return () => clearInterval(timer);
   }, [signedIn, loadSubmissions]);
+
+  // What each row's submission reads as is core's ruling, not this
+  // tab's, and it is asked for once per change of what it rules on rather
+  // than once per row drawn. The cleanup drops an answer a newer ask has
+  // already superseded.
+  useEffect(() => {
+    if (rows === null) return;
+    let current = true;
+    void commands
+      .mineSubmissionStates(
+        submissionsError === null ? "landed" : "failed",
+        submissions ?? [],
+        rows.flatMap((entry) =>
+          entry.state === "ready"
+            ? [{ path: entry.row.path, repo: entry.row.git.candidate }]
+            : [],
+        ),
+      )
+      .then((answered) => {
+        if (current) setStates(answered);
+      });
+    return () => {
+      current = false;
+    };
+  }, [rows, submissions, submissionsError]);
 
   const pickExisting = () => {
     void commands.pickFolder().then((picked) => {
@@ -113,11 +140,7 @@ export function MineTab() {
               <MineRowCard
                 key={entry.row.path}
                 row={entry.row}
-                submission={submissionFor(
-                  submissions,
-                  submissionsError !== null,
-                  entry.row.git.candidate,
-                )}
+                submission={states?.[entry.row.path] ?? null}
                 onImport={(path) => setImportTarget(path)}
                 onSubmit={(path) => setSubmitTarget(path)}
               />

--- a/ui/src/components/marketplaces/mine-tab.tsx
+++ b/ui/src/components/marketplaces/mine-tab.tsx
@@ -66,7 +66,11 @@ export function MineTab() {
     let current = true;
     void commands
       .mineSubmissionStates(
-        submissionsError === null ? "landed" : "failed",
+        submissionsError !== null
+          ? "failed"
+          : submissions === null
+            ? "unread"
+            : "landed",
         submissions ?? [],
         rows.flatMap((entry) =>
           entry.state === "ready"

--- a/ui/src/components/marketplaces/mine-tab.tsx
+++ b/ui/src/components/marketplaces/mine-tab.tsx
@@ -1,6 +1,10 @@
 import { BookOpen, FolderOpen, Hammer, Plus } from "lucide-react";
 import { useEffect, useState } from "react";
-import { commands, type SubmissionState } from "@/bindings";
+import {
+  commands,
+  type SubmissionState,
+  type SubmissionsRead,
+} from "@/bindings";
 import { EmptyState } from "@/components/empty-state";
 import { TextBar } from "@/components/loading";
 import { MarkdownView } from "@/components/markdown-view";
@@ -35,9 +39,18 @@ export function MineTab() {
   const signedIn = useAccountStore((s) => hasCredential(s.account));
   const submissions = useAccountStore((s) => s.submissions);
   const submissionsError = useAccountStore((s) => s.submissionsError);
-  const [states, setStates] = useState<Record<string, SubmissionState> | null>(
-    null,
-  );
+  const [states, setStates] = useState<{
+    read: SubmissionsRead;
+    answered: Record<string, SubmissionState>;
+  } | null>(null);
+  // What happened to the last read: what core rules on, and the only
+  // outcome its answer is good for.
+  const read: SubmissionsRead =
+    submissionsError !== null
+      ? "failed"
+      : submissions === null
+        ? "unread"
+        : "landed";
 
   useEffect(() => {
     void load();
@@ -50,27 +63,22 @@ export function MineTab() {
     // "in review" forever after the server listed it would be a lie. A
     // failing read keeps that interval: the poll runs only while this tab
     // is open, the tab says a read is failing instead of hiding it, and
-    // backing off would only delay the tick that takes the notice away
-    // for the person watching for it. An expired sign-in ends the poll
-    // outright, so nothing here retries a credential known to be dead.
+    // backing off would only delay the tick that clears the notice for
+    // whoever is watching. An expired sign-in ends the poll outright.
     const timer = setInterval(() => void loadSubmissions(), 60_000);
     return () => clearInterval(timer);
   }, [signedIn, loadSubmissions]);
 
-  // What each row's submission reads as is core's ruling, not this
-  // tab's, and it is asked for once per change of what it rules on rather
-  // than once per row drawn. The cleanup drops an answer a newer ask has
-  // already superseded.
+  // What each row's submission reads as is core's ruling, asked for once
+  // per change of what it rules on rather than once per row drawn. The
+  // cleanup drops an answer a newer ask superseded, and a refusal drops
+  // the one in hand: nothing retries, and unanswered is the honest read.
   useEffect(() => {
     if (rows === null) return;
     let current = true;
     void commands
       .mineSubmissionStates(
-        submissionsError !== null
-          ? "failed"
-          : submissions === null
-            ? "unread"
-            : "landed",
+        read,
         submissions ?? [],
         rows.flatMap((entry) =>
           entry.state === "ready"
@@ -79,12 +87,15 @@ export function MineTab() {
         ),
       )
       .then((answered) => {
-        if (current) setStates(answered);
+        if (current) setStates({ read, answered });
+      })
+      .catch(() => {
+        if (current) setStates(null);
       });
     return () => {
       current = false;
     };
-  }, [rows, submissions, submissionsError]);
+  }, [rows, submissions, read]);
 
   const pickExisting = () => {
     void commands.pickFolder().then((picked) => {
@@ -144,7 +155,11 @@ export function MineTab() {
               <MineRowCard
                 key={entry.row.path}
                 row={entry.row}
-                submission={states?.[entry.row.path] ?? null}
+                submission={
+                  states?.read === read
+                    ? (states.answered[entry.row.path] ?? null)
+                    : null
+                }
                 onImport={(path) => setImportTarget(path)}
                 onSubmit={(path) => setSubmitTarget(path)}
               />

--- a/ui/src/components/marketplaces/mine-tab.tsx
+++ b/ui/src/components/marketplaces/mine-tab.tsx
@@ -4,6 +4,7 @@ import { commands } from "@/bindings";
 import { EmptyState } from "@/components/empty-state";
 import { TextBar } from "@/components/loading";
 import { MarkdownView } from "@/components/markdown-view";
+import { StatusNote } from "@/components/status-note";
 import { Button } from "@/components/ui/button";
 import {
   Dialog,
@@ -16,6 +17,7 @@ import { useMineStore } from "@/stores/mine";
 import { MineCreateDialog } from "./mine-create-dialog";
 import { MineImportDialog } from "./mine-import-dialog";
 import { MineRowCard } from "./mine-row";
+import { submissionFor } from "./mine-submission";
 import { MineSubmitDialog } from "./mine-submit-dialog";
 
 /** The marketplaces the user authors. Rows are computed fresh from each
@@ -33,6 +35,7 @@ export function MineTab() {
   const loadSubmissions = useAccountStore((s) => s.loadSubmissions);
   const signedIn = useAccountStore((s) => hasCredential(s.account));
   const submissions = useAccountStore((s) => s.submissions);
+  const submissionsError = useAccountStore((s) => s.submissionsError);
 
   useEffect(() => {
     void load();
@@ -42,7 +45,12 @@ export function MineTab() {
     if (!signedIn) return;
     void loadSubmissions();
     // The submissions API names a 60-second poll interval; a row saying
-    // "in review" forever after the server listed it would be a lie.
+    // "in review" forever after the server listed it would be a lie. A
+    // failing read keeps that interval: the poll runs only while this tab
+    // is open, the tab says a read is failing instead of hiding it, and
+    // backing off would only delay the tick that takes the notice away
+    // for the person watching for it. An expired sign-in ends the poll
+    // outright, so nothing here retries a credential known to be dead.
     const timer = setInterval(() => void loadSubmissions(), 60_000);
     return () => clearInterval(timer);
   }, [signedIn, loadSubmissions]);
@@ -95,16 +103,21 @@ export function MineTab() {
       ) : (
         <>
           <div className="flex justify-end">{actions}</div>
+          {submissionsError ? (
+            <StatusNote tone="warning" title="Could not check your submissions">
+              {submissionsError}
+            </StatusNote>
+          ) : null}
           {rows.map((entry) =>
             entry.state === "ready" ? (
               <MineRowCard
                 key={entry.row.path}
                 row={entry.row}
-                submission={
-                  submissions?.find(
-                    (candidate) => candidate.repo === entry.row.git.candidate,
-                  ) ?? null
-                }
+                submission={submissionFor(
+                  submissions,
+                  submissionsError !== null,
+                  entry.row.git.candidate,
+                )}
                 onImport={(path) => setImportTarget(path)}
                 onSubmit={(path) => setSubmitTarget(path)}
               />

--- a/ui/src/dev/mock-account.test.ts
+++ b/ui/src/dev/mock-account.test.ts
@@ -9,6 +9,7 @@ import {
 import { mockInvoke } from "./mock";
 import {
   accountFromUrl,
+  callRefusal,
   EXPIRING_CALLS,
   expiringCallFromUrl,
   isSignedIn,
@@ -16,7 +17,9 @@ import {
   MOCK_ACCOUNTS,
   setExpiringCall,
   setMockAccount,
+  setUnreachable,
   UNREADABLE,
+  unreachableFromUrl,
 } from "./mock-account";
 
 /** What the store settles on when it reads through the harness. */
@@ -236,5 +239,41 @@ describe("what ?account= picks", () => {
       UNREADABLE,
     ]);
     warn.mockRestore();
+  });
+});
+
+// The Mine tab tells a submissions read it could not make from a server
+// that answered with nothing, and no `?account=` state produces the
+// first: the credential is fine, the server is not.
+describe("the outage the dev URL arms", () => {
+  it("reads the flag off the URL, present or absent", () => {
+    expect(unreachableFromUrl("?unreachable")).toBe(true);
+    expect(unreachableFromUrl("?unreachable=1")).toBe(true);
+    expect(unreachableFromUrl("?account=signed-in")).toBe(false);
+  });
+
+  it("refuses every call under the sign-in, and keeps refusing", () => {
+    setMockAccount({ ok: MOCK_ACCOUNTS["signed-in"] });
+    setUnreachable(true);
+    try {
+      for (const call of EXPIRING_CALLS) {
+        expect(callRefusal(call)).toEqual({
+          kind: "failed",
+          message: expect.stringContaining("kendex.ai could not be reached"),
+        });
+      }
+      // The account is the one thing an outage must not touch: signing
+      // the person out over it is the failure this whole state exists to
+      // keep the app from confusing with an expiry.
+      expect(isSignedIn()).toBe(true);
+    } finally {
+      setUnreachable(false);
+    }
+  });
+
+  it("lets the calls through once it is off", () => {
+    setMockAccount({ ok: MOCK_ACCOUNTS["signed-in"] });
+    setUnreachable(false);
+    expect(callRefusal("mine_submissions")).toBeNull();
   });
 });

--- a/ui/src/dev/mock-account.ts
+++ b/ui/src/dev/mock-account.ts
@@ -118,6 +118,26 @@ export function expiringCallFromUrl(search: string): ExpiringCall | null {
   return null;
 }
 
+/** What an outage answers with: the sentence kendex.ai's client writes
+ *  when it could not reach the server at all. */
+const UNREACHABLE = "kendex.ai could not be reached — check your connection";
+
+/** Whether `?unreachable` is on the dev URL, which makes every call under
+ *  the sign-in fail the way an outage does. It is the state the Mine tab
+ *  labels its rows unknown for, and no `?account=` state produces it: the
+ *  credential is fine, the server is not. */
+export function unreachableFromUrl(search: string): boolean {
+  return new URLSearchParams(search).has("unreachable");
+}
+
+let unreachable =
+  typeof window !== "undefined" && unreachableFromUrl(window.location.search);
+
+/** Arms the outage, for tests and for the dev URL. */
+export function setUnreachable(on: boolean): void {
+  unreachable = on;
+}
+
 let expiring: ExpiringCall | null =
   typeof window === "undefined"
     ? null
@@ -138,6 +158,9 @@ export function setExpiringCall(call: ExpiringCall | null): void {
  *  back to a working call rather than expiring for the rest of the
  *  session. */
 export function callRefusal(call: ExpiringCall): AccountCallRefused | null {
+  // An outage is not the credential's doing, so it outlives no scenario
+  // and ends no sign-in: every call keeps failing until it is turned off.
+  if (unreachable) return { kind: "failed", message: UNREACHABLE };
   if (expiring === call) {
     expiring = null;
     served = { ok: SIGNED_OUT };

--- a/ui/src/dev/mock-mine.ts
+++ b/ui/src/dev/mock-mine.ts
@@ -1,4 +1,5 @@
-// The Mine tab against canned data: rows, import inventory, submit.
+// The Mine tab against canned data: rows, import inventory, the offers.
+// Submissions are their own file — the sign-in gates them.
 import type {
   ImportCandidate,
   ImportSelection,
@@ -6,8 +7,8 @@ import type {
   MineRow,
   SubmitPreflight,
 } from "@/bindings";
-import { callRefusal, type ExpiringCall } from "./mock-account";
 import type { Handler } from "./mock-state";
+import { submissionHandlers } from "./mock-submissions";
 
 function row(overrides: Partial<MineRow>): MineRow {
   return {
@@ -156,24 +157,9 @@ function preflightFor(path: string): SubmitPreflight {
   };
 }
 
-const SUBMISSION = {
-  repo: "jane/team-skills",
-  status: "pending",
-  status_reason: null,
-  head_commit: null,
-  indexed_at: null,
-};
-
-const underSignIn = <T>(call: ExpiringCall, answer: T) => {
-  const refused = callRefusal(call);
-  return refused ? Promise.reject(refused) : answer;
-};
-
 export const mineHandlers: Record<string, Handler> = {
+  ...submissionHandlers,
   mine_submit_preflight: (args: { path: string }) => preflightFor(args.path),
-  mine_submit: (args: { repo: string }) =>
-    underSignIn("mine_submit", { repo: args.repo, status: "pending" }),
-  mine_submissions: () => underSignIn("mine_submissions", [SUBMISSION]),
   mine_authoring_doc: () =>
     "# How a marketplace repo works\n\nA kendex marketplace is a git repository.\n",
   mine_list: () => rows,

--- a/ui/src/dev/mock-submissions.ts
+++ b/ui/src/dev/mock-submissions.ts
@@ -1,0 +1,59 @@
+// The submissions side of the Mine tab against canned data: the one row
+// the server lists, the refusal every call under the sign-in meets, and
+// the browser stand-in for core's ruling over them.
+import type {
+  SubmissionAsk,
+  SubmissionRow,
+  SubmissionState,
+  SubmissionsRead,
+} from "@/bindings";
+import { callRefusal, type ExpiringCall } from "./mock-account";
+import type { Handler } from "./mock-state";
+
+/** The one row the mock server lists, for the marketplace whose remote
+ *  the Mine fixtures give. */
+const SUBMISSION = {
+  repo: "jane/team-skills",
+  status: "pending",
+  status_reason: null,
+  head_commit: null,
+  indexed_at: null,
+};
+
+/** The browser stand-in for core's ruling. Core owns it and is tested on
+ *  it; this exists only because the mock bridge has no Rust behind it. */
+const states = (
+  read: SubmissionsRead,
+  rows: SubmissionRow[],
+  asks: SubmissionAsk[],
+): Record<string, SubmissionState> =>
+  Object.fromEntries(
+    asks.map((ask): [string, SubmissionState] => {
+      const listed = ask.repo
+        ? rows.find((row) => row.repo === ask.repo)
+        : undefined;
+      if (listed) return [ask.path, { kind: "submitted", row: listed }];
+      return [
+        ask.path,
+        ask.repo && read === "failed"
+          ? { kind: "unknown" }
+          : { kind: "not-submitted" },
+      ];
+    }),
+  );
+
+const underSignIn = <T>(call: ExpiringCall, answer: T) => {
+  const refused = callRefusal(call);
+  return refused ? Promise.reject(refused) : answer;
+};
+
+export const submissionHandlers: Record<string, Handler> = {
+  mine_submit: (args: { repo: string }) =>
+    underSignIn("mine_submit", { repo: args.repo, status: "pending" }),
+  mine_submissions: () => underSignIn("mine_submissions", [SUBMISSION]),
+  mine_submission_states: (args: {
+    read: SubmissionsRead;
+    rows: SubmissionRow[];
+    asks: SubmissionAsk[];
+  }) => states(args.read, args.rows, args.asks),
+};

--- a/ui/src/dev/mock-submissions.ts
+++ b/ui/src/dev/mock-submissions.ts
@@ -20,8 +20,8 @@ const SUBMISSION = {
   indexed_at: null,
 };
 
-/** The browser stand-in for core's ruling. Core owns it and is tested on
- *  it; this exists only because the mock bridge has no Rust behind it. */
+/** The browser stand-in for `kendex_core::registry::submit::states`,
+ *  which owns this ruling: the mock bridge has no Rust behind it. */
 const states = (
   read: SubmissionsRead,
   rows: SubmissionRow[],
@@ -35,7 +35,7 @@ const states = (
       if (listed) return [ask.path, { kind: "submitted", row: listed }];
       return [
         ask.path,
-        ask.repo && read === "failed"
+        ask.repo && read !== "landed"
           ? { kind: "unknown" }
           : { kind: "not-submitted" },
       ];

--- a/ui/src/stores/account-refused.test.ts
+++ b/ui/src/stores/account-refused.test.ts
@@ -307,3 +307,110 @@ describe("a call refused because the sign-in expired", () => {
     expect(useAccountStore.getState().submissions).toBeNull();
   });
 });
+
+// The other refusal. It says nothing about the credential, so the account
+// stays where it is — but it does say the rows on screen are no longer
+// confirmed, and dropping that left the tab reporting work already in
+// review as never submitted.
+describe("a submissions read the server could not answer", () => {
+  const ROW = {
+    repo: "ada/team-skills",
+    status: "pending",
+    status_reason: null,
+    head_commit: null,
+    indexed_at: null,
+  };
+  const WHY = "kendex.ai could not be reached";
+
+  const signedIn = {
+    kind: "signed-in" as const,
+    identity: ADA,
+    signIn: SIGN_IN,
+  };
+
+  const fails = () =>
+    vi.mocked(commands.mineSubmissions).mockResolvedValue({
+      status: "error",
+      error: { kind: "failed", message: WHY },
+    } as Awaited<ReturnType<typeof commands.mineSubmissions>>);
+
+  it("records why, and leaves the rows it could not refresh", async () => {
+    useAccountStore.setState({ account: signedIn, submissions: [ROW] });
+    fails();
+
+    await useAccountStore.getState().loadSubmissions();
+
+    expect(useAccountStore.getState().submissionsError).toBe(WHY);
+    expect(useAccountStore.getState().submissions).toEqual([ROW]);
+    expect(account()).toEqual(signedIn);
+  });
+
+  // Expiry is the credential ending, and the rows go with it. A failure
+  // about a read of them would sit on the Mine tab over an account the
+  // sidebar and Settings already say is expired.
+  it("leaves nothing behind when the same read meets a dead sign-in", async () => {
+    useAccountStore.setState({
+      account: signedIn,
+      submissions: [ROW],
+      submissionsError: WHY,
+    });
+    vi.mocked(commands.mineSubmissions).mockResolvedValue({
+      status: "error",
+      error: { kind: "expired", message: "run login again" },
+    } as Awaited<ReturnType<typeof commands.mineSubmissions>>);
+
+    await useAccountStore.getState().loadSubmissions();
+
+    expect(account()).toEqual({ kind: "expired", signIn: SIGN_IN });
+    expect(useAccountStore.getState().submissions).toBeNull();
+    expect(useAccountStore.getState().submissionsError).toBeNull();
+  });
+
+  it("goes with the credential when the person signs out", async () => {
+    useAccountStore.setState({ account: signedIn, submissionsError: WHY });
+    vi.mocked(commands.accountLogout).mockResolvedValue({
+      status: "ok",
+      data: null,
+    } as Awaited<ReturnType<typeof commands.accountLogout>>);
+
+    await useAccountStore.getState().signOut();
+
+    expect(useAccountStore.getState().submissionsError).toBeNull();
+  });
+
+  it("takes the failure back when a later read lands", async () => {
+    useAccountStore.setState({ account: signedIn, submissionsError: WHY });
+
+    await useAccountStore.getState().loadSubmissions();
+
+    expect(useAccountStore.getState().submissionsError).toBeNull();
+    expect(useAccountStore.getState().submissions).toEqual([]);
+  });
+
+  // A failure about a credential nobody holds any more explains rows
+  // nobody is looking at, and would sit over the account that replaced it.
+  // The read has to still be out when the account moves, so its answer is
+  // held back until the sign-out has landed.
+  it("says nothing about an account that changed hands under it", async () => {
+    useAccountStore.setState({ account: signedIn });
+    vi.mocked(commands.accountLogout).mockResolvedValue({
+      status: "ok",
+      data: null,
+    } as Awaited<ReturnType<typeof commands.accountLogout>>);
+    type Answer = Awaited<ReturnType<typeof commands.mineSubmissions>>;
+    let land: (answer: Answer) => void = () => {};
+    vi.mocked(commands.mineSubmissions).mockReturnValue(
+      new Promise<Answer>((resolve) => {
+        land = resolve;
+      }),
+    );
+
+    const polling = useAccountStore.getState().loadSubmissions();
+    await useAccountStore.getState().signOut();
+    land({ status: "error", error: { kind: "failed", message: WHY } });
+    await polling;
+
+    expect(useAccountStore.getState().submissionsError).toBeNull();
+    expect(account()).toEqual({ kind: "signed-out" });
+  });
+});

--- a/ui/src/stores/account-refused.test.ts
+++ b/ui/src/stores/account-refused.test.ts
@@ -387,6 +387,55 @@ describe("a submissions read the server could not answer", () => {
     expect(useAccountStore.getState().submissions).toEqual([]);
   });
 
+  // The tab's timer and a submit that just landed both ask, so two reads
+  // are routinely out at once. Whichever was asked for last is the later
+  // word on the same credential, and it is the one that has to stand
+  // however the responses come back.
+  describe("two reads out at once", () => {
+    type Answer = Awaited<ReturnType<typeof commands.mineSubmissions>>;
+
+    /** Hands back the two reads' resolvers in the order they were asked
+     *  for, both still out. */
+    const bothOut = () => {
+      const land: ((answer: Answer) => void)[] = [];
+      vi.mocked(commands.mineSubmissions).mockImplementation(
+        () => new Promise<Answer>((resolve) => land.push(resolve)),
+      );
+      useAccountStore.setState({ account: signedIn });
+      const first = useAccountStore.getState().loadSubmissions();
+      const second = useAccountStore.getState().loadSubmissions();
+      return { land, first, second };
+    };
+
+    const landed = { status: "ok", data: [ROW] } as Answer;
+    const failed = {
+      status: "error",
+      error: { kind: "failed", message: WHY },
+    } as Answer;
+
+    it("keeps the newer success when the older read fails last", async () => {
+      const { land, first, second } = bothOut();
+      land[1](landed);
+      await second;
+      land[0](failed);
+      await first;
+
+      expect(useAccountStore.getState().submissions).toEqual([ROW]);
+      expect(useAccountStore.getState().submissionsError).toBeNull();
+    });
+
+    it("keeps the newer failure when the older read lands last", async () => {
+      const { land, first, second } = bothOut();
+      land[1](failed);
+      await second;
+      land[0](landed);
+      await first;
+
+      expect(useAccountStore.getState().submissionsError).toBe(WHY);
+      expect(useAccountStore.getState().submissions).toBeNull();
+    });
+  });
+
   // A failure about a credential nobody holds any more explains rows
   // nobody is looking at, and would sit over the account that replaced it.
   // The read has to still be out when the account moves, so its answer is

--- a/ui/src/stores/account-refused.test.ts
+++ b/ui/src/stores/account-refused.test.ts
@@ -436,6 +436,40 @@ describe("a submissions read the server could not answer", () => {
     });
   });
 
+  // The guards and the write have to be one continuation. Handing the
+  // answer back across an await puts a microtask between them, and a
+  // sign-out resolving its own await lands in that gap: the guards let
+  // the rows through, the account ends, and the rows are written over it.
+  // Reachable only by interleaving, never by a click.
+  it("writes no rows over an account that ended after the guards", async () => {
+    useAccountStore.setState({ account: signedIn });
+    type Answer = Awaited<ReturnType<typeof commands.mineSubmissions>>;
+    type Out = Awaited<ReturnType<typeof commands.accountLogout>>;
+    let landRows: (answer: Answer) => void = () => {};
+    let landOut: (answer: Out) => void = () => {};
+    vi.mocked(commands.mineSubmissions).mockReturnValue(
+      new Promise<Answer>((resolve) => {
+        landRows = resolve;
+      }),
+    );
+    vi.mocked(commands.accountLogout).mockReturnValue(
+      new Promise<Out>((resolve) => {
+        landOut = resolve;
+      }),
+    );
+
+    const polling = useAccountStore.getState().loadSubmissions();
+    const out = useAccountStore.getState().signOut();
+    // The read answers first, so its guards run while the account is
+    // still held; the sign-out lands in the microtask straight after.
+    landRows({ status: "ok", data: [ROW] });
+    landOut({ status: "ok", data: null });
+    await Promise.all([polling, out]);
+
+    expect(account()).toEqual({ kind: "signed-out" });
+    expect(useAccountStore.getState().submissions).toBeNull();
+  });
+
   // A failure about a credential nobody holds any more explains rows
   // nobody is looking at, and would sit over the account that replaced it.
   // The read has to still be out when the account moves, so its answer is

--- a/ui/src/stores/account-startup.dom.test.tsx
+++ b/ui/src/stores/account-startup.dom.test.tsx
@@ -20,6 +20,7 @@ vi.mock("@/bindings", () => ({
     updatesOverview: vi.fn(),
     mineList: vi.fn(),
     mineSubmitPreflight: vi.fn(),
+    mineSubmissionStates: vi.fn(async () => ({})),
     appUpdateCheck: vi.fn(),
     appUpdateChannel: vi.fn(),
     appVersion: vi.fn(),

--- a/ui/src/stores/account-submissions.ts
+++ b/ui/src/stores/account-submissions.ts
@@ -35,20 +35,27 @@ let reads = 0;
  *  Neither does one whose credential changed hands while it was coming,
  *  which is about nobody on screen. `handovers` is read before the call
  *  and again after it, and `refused` decides what a refusal says about
- *  the account itself. */
+ *  the account itself.
+ *
+ *  `write` is taken rather than returned so that it runs in the same
+ *  continuation as the guards. Handing an answer back across an await
+ *  puts a microtask between the check and the write, and a sign-out
+ *  landing in it ends the account after the guards have already let the
+ *  rows through. */
 export const readSubmissions = async (
   handovers: () => number,
   refused: (refusal: AccountCallRefused, since: number) => void,
-): Promise<Partial<Submissions> | null> => {
+  write: (fields: Partial<Submissions>) => void,
+): Promise<void> => {
   reads += 1;
   const mine = reads;
   const before = handovers();
   const answer = await commands.mineSubmissions();
-  if (mine !== reads || before !== handovers()) return null;
+  if (mine !== reads || before !== handovers()) return;
   // The poll shows nothing of its own, so a session that died between
   // ticks would otherwise go on being polled invisibly.
   if (answer.status === "error") refused(answer.error, before);
-  return fromSubmissionsRead(answer);
+  write(fromSubmissionsRead(answer));
 };
 
 /** What a read's answer writes.

--- a/ui/src/stores/account-submissions.ts
+++ b/ui/src/stores/account-submissions.ts
@@ -1,7 +1,11 @@
 // The marketplaces this credential has submitted, and what a read of them
 // writes. They hang off the account store because a credential's end takes
 // them with it; the store owns the guards, and this owns the answer.
-import type { AccountCallRefused, SubmissionRow } from "@/bindings";
+import {
+  type AccountCallRefused,
+  commands,
+  type SubmissionRow,
+} from "@/bindings";
 
 /** The submissions half of the account store. */
 export interface Submissions {
@@ -17,6 +21,36 @@ export const noSubmissions: Submissions = {
   submissionsError: null,
 };
 
+/** Submissions reads in the order they were asked for. Only the newest
+ *  may land: the tab polls on a timer and a submit that just landed asks
+ *  again, so two are routinely out at once and the slower is not the
+ *  truer one. */
+let reads = 0;
+
+/** Makes the read and answers what to write, or null where its answer may
+ *  not be written at all.
+ *
+ *  A read a newer one overtook says nothing, refusal included: both are
+ *  about the same credential and the newer one is the later word on it.
+ *  Neither does one whose credential changed hands while it was coming,
+ *  which is about nobody on screen. `handovers` is read before the call
+ *  and again after it, and `refused` decides what a refusal says about
+ *  the account itself. */
+export const readSubmissions = async (
+  handovers: () => number,
+  refused: (refusal: AccountCallRefused, since: number) => void,
+): Promise<Partial<Submissions> | null> => {
+  reads += 1;
+  const mine = reads;
+  const before = handovers();
+  const answer = await commands.mineSubmissions();
+  if (mine !== reads || before !== handovers()) return null;
+  // The poll shows nothing of its own, so a session that died between
+  // ticks would otherwise go on being polled invisibly.
+  if (answer.status === "error") refused(answer.error, before);
+  return fromSubmissionsRead(answer);
+};
+
 /** What a read's answer writes.
  *
  *  An expiry is news about the credential rather than about the rows, and
@@ -25,7 +59,7 @@ export const noSubmissions: Submissions = {
  *  why they are not current: stale and labelled beats an empty tab, which
  *  reads as a marketplace nobody ever submitted and offers a first submit
  *  over work already in review. */
-export const fromSubmissionsRead = (
+const fromSubmissionsRead = (
   answer:
     | { status: "ok"; data: SubmissionRow[] }
     | { status: "error"; error: AccountCallRefused },

--- a/ui/src/stores/account-submissions.ts
+++ b/ui/src/stores/account-submissions.ts
@@ -1,0 +1,39 @@
+// The marketplaces this credential has submitted, and what a read of them
+// writes. They hang off the account store because a credential's end takes
+// them with it; the store owns the guards, and this owns the answer.
+import type { AccountCallRefused, SubmissionRow } from "@/bindings";
+
+/** The submissions half of the account store. */
+export interface Submissions {
+  submissions: SubmissionRow[] | null;
+  /** Why the last submissions read failed, or null when one landed. */
+  submissionsError: string | null;
+}
+
+/** What a credential's end leaves in them: the rows were its, and the
+ *  failure explained an account nobody holds any more. */
+export const noSubmissions: Submissions = {
+  submissions: null,
+  submissionsError: null,
+};
+
+/** What a read's answer writes.
+ *
+ *  An expiry is news about the credential rather than about the rows, and
+ *  the store's own handling of it clears them, so it writes nothing here.
+ *  Any other failure leaves the rows already read where they are and says
+ *  why they are not current: stale and labelled beats an empty tab, which
+ *  reads as a marketplace nobody ever submitted and offers a first submit
+ *  over work already in review. */
+export const fromSubmissionsRead = (
+  answer:
+    | { status: "ok"; data: SubmissionRow[] }
+    | { status: "error"; error: AccountCallRefused },
+): Partial<Submissions> => {
+  if (answer.status === "ok") {
+    return { submissions: answer.data, submissionsError: null };
+  }
+  return answer.error.kind === "failed"
+    ? { submissionsError: answer.error.message }
+    : {};
+};

--- a/ui/src/stores/account.ts
+++ b/ui/src/stores/account.ts
@@ -15,8 +15,8 @@ import {
   sameCredential,
 } from "./account-state";
 import {
-  fromSubmissionsRead,
   noSubmissions,
+  readSubmissions,
   type Submissions,
 } from "./account-submissions";
 
@@ -211,16 +211,8 @@ export const useAccountStore = create<AccountStore>((set, get) => ({
 
   loadSubmissions: async () => {
     if (!hasCredential(get().account)) return;
-    const before = handover;
-    const rows = await commands.mineSubmissions();
-    // Rows and refusals belong to the account they were asked for: ones
-    // that changed hands in flight belong to nobody on screen, and
-    // `refused` turns an obsolete expiry away on the same count.
-    if (before !== handover) return;
-    // The poll shows nothing of its own, so a session that died between
-    // ticks would otherwise go on being polled invisibly.
-    if (rows.status === "error") get().refused(rows.error, before);
-    set(fromSubmissionsRead(rows));
+    const written = await readSubmissions(get().handovers, get().refused);
+    if (written) set(written);
   },
 
   handovers: () => handover,

--- a/ui/src/stores/account.ts
+++ b/ui/src/stores/account.ts
@@ -4,11 +4,7 @@
 // Startup makes the one account read; every surface reads `account` from
 // here rather than asking again.
 import { create } from "zustand";
-import {
-  type AccountCallRefused,
-  commands,
-  type SubmissionRow,
-} from "@/bindings";
+import { type AccountCallRefused, commands } from "@/bindings";
 import { readAccount } from "./account-read";
 import {
   type AccountState,
@@ -18,6 +14,11 @@ import {
   keepsExpiry,
   sameCredential,
 } from "./account-state";
+import {
+  fromSubmissionsRead,
+  noSubmissions,
+  type Submissions,
+} from "./account-submissions";
 
 // The one door every surface already comes to for these.
 export {
@@ -27,7 +28,7 @@ export {
   type SettledAccount,
 } from "./account-state";
 
-interface AccountStore {
+interface AccountStore extends Submissions {
   account: AccountState;
   /** The in-flight device flow, when one is showing. */
   userCode: string | null;
@@ -43,7 +44,6 @@ interface AccountStore {
    *  tell a read still on its way from one that was never made: the first
    *  has nothing to ask for again, and the second has never asked. */
   reading: boolean;
-  submissions: SubmissionRow[] | null;
 
   /** The account read. Startup makes it, a return to the window repeats
    *  it, and a failure surface retries with it. No surface reads on
@@ -86,11 +86,9 @@ let reads = 0;
  *  holds any more. The `handover` bump is the change of hands itself, so
  *  a read still out for the old credential is abandoned. Callers keep
  *  their own guards; only the write is shared. */
-const credentialEnded = (
-  account: AccountState,
-): Pick<AccountStore, "account" | "submissions" | "readError"> => {
+const credentialEnded = (account: AccountState) => {
   handover += 1;
-  return { account, submissions: null, readError: null };
+  return { account, readError: null, ...noSubmissions };
 };
 
 const wait = (seconds: number) =>
@@ -104,7 +102,7 @@ export const useAccountStore = create<AccountStore>((set, get) => ({
   error: null,
   readError: null,
   reading: false,
-  submissions: null,
+  ...noSubmissions,
 
   load: async () => {
     reads += 1;
@@ -215,16 +213,14 @@ export const useAccountStore = create<AccountStore>((set, get) => ({
     if (!hasCredential(get().account)) return;
     const before = handover;
     const rows = await commands.mineSubmissions();
+    // Rows and refusals belong to the account they were asked for: ones
+    // that changed hands in flight belong to nobody on screen, and
+    // `refused` turns an obsolete expiry away on the same count.
+    if (before !== handover) return;
     // The poll shows nothing of its own, so a session that died between
     // ticks would otherwise go on being polled invisibly.
-    if (rows.status === "error") {
-      get().refused(rows.error, before);
-      return;
-    }
-    // Rows belong to the account they were asked for: ones that changed
-    // hands while they were coming belong to nobody on screen.
-    if (before !== handover) return;
-    set({ submissions: rows.data });
+    if (rows.status === "error") get().refused(rows.error, before);
+    set(fromSubmissionsRead(rows));
   },
 
   handovers: () => handover,

--- a/ui/src/stores/account.ts
+++ b/ui/src/stores/account.ts
@@ -211,8 +211,7 @@ export const useAccountStore = create<AccountStore>((set, get) => ({
 
   loadSubmissions: async () => {
     if (!hasCredential(get().account)) return;
-    const written = await readSubmissions(get().handovers, get().refused);
-    if (written) set(written);
+    await readSubmissions(get().handovers, get().refused, set);
   },
 
   handovers: () => handover,

--- a/ui/src/test/account-store.ts
+++ b/ui/src/test/account-store.ts
@@ -42,6 +42,7 @@ export const fresh = () =>
     error: null,
     readError: null,
     submissions: null,
+    submissionsError: null,
     signingIn: false,
     userCode: null,
     reading: false,


### PR DESCRIPTION
The Mine tab joined its rows against a submissions list that stayed null whenever the read failed. So an outage, a server error or a dead credential made every authored marketplace read as never submitted, and offered a first submit over work already in review. Nothing on the page said a read had failed, and the 60-second poll repeated it in silence.

## Unknown is not none

The store keeps why the last read failed, and keeps the rows it could not refresh — stale and labelled beats an empty tab. A row the stale list does not name says its status is unknown and offers a neutral Submit, which claims neither that it was submitted nor that it was not. That is the distinction the issue asks for: "we could not check" must not look like "you have not submitted this".

A failed tick never clears rows already loaded.

## The poll keeps its interval

The issue asks for a decision on backing off after repeated failures, so: no back-off. Three reasons. The poll runs only while the tab is open, so it is bounded by attention rather than by time. The failure is now visible, so a repeating one is legible instead of silent. And an expiry already ends the poll outright, which is the case where repeating was genuinely harmful. A back-off would trade a visible retry for a hidden one, and hide a recovered server behind a growing delay.

## Built on what KEN-736 landed

`AccountCallRefused`'s `failed` arm was the thing being dropped, so this gives it an owner rather than inventing a state. The dev-mock bridge gained the failing-read scenario too, so the flow can be driven in the harness rather than only asserted.

Closes KEN-725
