### PR TITLE
fix(KEN-786): codex loads the agents kendex renders for it

### DIFF
--- a/.codex/agents/generalist.toml
+++ b/.codex/agents/generalist.toml
@@ -1,8 +1,7 @@
 name = "generalist"
 nickname_candidates = ["Generalist-Atlas", "Generalist-Delta", "Generalist-Echo", "Generalist-Nova", "Generalist-Orion", "Generalist-Vector"]
 description = "General-purpose agent for documentation, cleanup, stale references, code organization, and miscellaneous maintenance tasks."
-tags = ["docs", "refactoring"]
-model = "gpt-5.5"
+model = "gpt-5.6-sol"
 model_reasoning_effort = "high"
 sandbox_mode = "danger-full-access"
 developer_instructions = '''

--- a/.codex/agents/iced.toml
+++ b/.codex/agents/iced.toml
@@ -1,8 +1,7 @@
 name = "iced"
 nickname_candidates = ["Iced-Atlas", "Iced-Delta", "Iced-Echo", "Iced-Nova", "Iced-Orion", "Iced-Vector"]
 description = "Iced UI specialist. Use for Iced widgets, Canvas/Shader rendering, pane_grid layout, Theme system, Subscription-based data flow, or Elm Architecture patterns."
-tags = ["ui"]
-model = "gpt-5.5"
+model = "gpt-5.6-sol"
 model_reasoning_effort = "high"
 sandbox_mode = "danger-full-access"
 developer_instructions = '''

--- a/.codex/agents/planner.toml
+++ b/.codex/agents/planner.toml
@@ -1,8 +1,7 @@
 name = "planner"
 nickname_candidates = ["Planner-Atlas", "Planner-Delta", "Planner-Echo", "Planner-Nova", "Planner-Orion", "Planner-Vector"]
 description = "Planning specialist that explores requirements and code context, weighs architecture trade-offs, and produces ordered implementation plans or plan files. May write planning artifacts; does not edit production code."
-tags = ["planning", "research"]
-model = "gpt-5.5"
+model = "gpt-5.6-sol"
 model_reasoning_effort = "high"
 sandbox_mode = "workspace-write"
 developer_instructions = '''

--- a/.codex/agents/researcher.toml
+++ b/.codex/agents/researcher.toml
@@ -1,8 +1,7 @@
 name = "researcher"
 nickname_candidates = ["Researcher-Atlas", "Researcher-Delta", "Researcher-Echo", "Researcher-Nova", "Researcher-Orion", "Researcher-Vector"]
 description = "Exa-powered research specialist for producing evidence-backed findings reports from project research prompts. Use for research issues, technology investigations, vendor/library comparisons, architectural option analysis, and current-state web research."
-tags = ["research"]
-model = "gpt-5.5"
+model = "gpt-5.6-sol"
 model_reasoning_effort = "high"
 sandbox_mode = "workspace-write"
 developer_instructions = '''

--- a/.codex/agents/reviewer-arch.toml
+++ b/.codex/agents/reviewer-arch.toml
@@ -1,8 +1,7 @@
 name = "reviewer-arch"
 nickname_candidates = ["Reviewer-Arch-Atlas", "Reviewer-Arch-Delta", "Reviewer-Arch-Echo", "Reviewer-Arch-Nova", "Reviewer-Arch-Orion", "Reviewer-Arch-Vector"]
 description = "Architecture reviewer for design reviews, module boundary validation, spec/proposal review, and technical debt assessment."
-tags = ["review"]
-model = "gpt-5.5"
+model = "gpt-5.6-sol"
 model_reasoning_effort = "high"
 sandbox_mode = "workspace-write"
 developer_instructions = '''

--- a/.codex/agents/reviewer-correctness.toml
+++ b/.codex/agents/reviewer-correctness.toml
@@ -1,8 +1,7 @@
 name = "reviewer-correctness"
 nickname_candidates = ["Reviewer-Correctness-Atlas", "Reviewer-Correctness-Delta", "Reviewer-Correctness-Echo", "Reviewer-Correctness-Nova", "Reviewer-Correctness-Orion", "Reviewer-Correctness-Vector"]
 description = "Broad correctness and regression reviewer for behavior breakage, boundary/edge-case predicates, API/CLI/devex regressions, feature-gate leaks, migrations, state semantics, and cross-module side effects."
-tags = ["review"]
-model = "gpt-5.5"
+model = "gpt-5.6-sol"
 model_reasoning_effort = "high"
 sandbox_mode = "workspace-write"
 developer_instructions = '''

--- a/.codex/agents/reviewer-doc.toml
+++ b/.codex/agents/reviewer-doc.toml
@@ -1,8 +1,7 @@
 name = "reviewer-doc"
 nickname_candidates = ["Reviewer-Doc-Atlas", "Reviewer-Doc-Delta", "Reviewer-Doc-Echo", "Reviewer-Doc-Nova", "Reviewer-Doc-Orion", "Reviewer-Doc-Vector"]
 description = "Documentation accuracy reviewer. Verifies changed doc claims against implementation, re-derives transcribed values, checks citations resolve, audits drift."
-tags = ["review", "docs"]
-model = "gpt-5.5"
+model = "gpt-5.6-sol"
 model_reasoning_effort = "high"
 sandbox_mode = "workspace-write"
 developer_instructions = '''

--- a/.codex/agents/reviewer-error.toml
+++ b/.codex/agents/reviewer-error.toml
@@ -1,8 +1,7 @@
 name = "reviewer-error"
 nickname_candidates = ["Reviewer-Error-Atlas", "Reviewer-Error-Delta", "Reviewer-Error-Echo", "Reviewer-Error-Nova", "Reviewer-Error-Orion", "Reviewer-Error-Vector"]
 description = "Silent failure and error handling reviewer. Detects fail-open paths, swallowed errors, wrong-cause diagnostics, and inadequate error propagation."
-tags = ["review", "debugging"]
-model = "gpt-5.5"
+model = "gpt-5.6-sol"
 model_reasoning_effort = "high"
 sandbox_mode = "workspace-write"
 developer_instructions = '''

--- a/.codex/agents/reviewer-perf.toml
+++ b/.codex/agents/reviewer-perf.toml
@@ -1,8 +1,7 @@
 name = "reviewer-perf"
 nickname_candidates = ["Reviewer-Perf-Atlas", "Reviewer-Perf-Delta", "Reviewer-Perf-Echo", "Reviewer-Perf-Nova", "Reviewer-Perf-Orion", "Reviewer-Perf-Vector"]
 description = "Performance validation specialist. Latency validation, benchmark execution, percentile analysis, hot-path cost review, regression detection."
-tags = ["review", "performance"]
-model = "gpt-5.5"
+model = "gpt-5.6-sol"
 model_reasoning_effort = "high"
 sandbox_mode = "workspace-write"
 developer_instructions = '''

--- a/.codex/agents/reviewer-quality.toml
+++ b/.codex/agents/reviewer-quality.toml
@@ -1,8 +1,7 @@
 name = "reviewer-quality"
 nickname_candidates = ["Reviewer-Quality-Atlas", "Reviewer-Quality-Delta", "Reviewer-Quality-Echo", "Reviewer-Quality-Nova", "Reviewer-Quality-Orion", "Reviewer-Quality-Vector"]
 description = "Code quality reviewer for maintainability, simplification, abstraction value, type boundaries, helper reuse, decomposition, and god objects."
-tags = ["review"]
-model = "gpt-5.5"
+model = "gpt-5.6-sol"
 model_reasoning_effort = "high"
 sandbox_mode = "workspace-write"
 developer_instructions = '''

--- a/.codex/agents/reviewer-safety.toml
+++ b/.codex/agents/reviewer-safety.toml
@@ -1,8 +1,7 @@
 name = "reviewer-safety"
 nickname_candidates = ["Reviewer-Safety-Atlas", "Reviewer-Safety-Delta", "Reviewer-Safety-Echo", "Reviewer-Safety-Nova", "Reviewer-Safety-Orion", "Reviewer-Safety-Vector"]
 description = "Memory, thread, and process safety auditor. Unsafe code, data races, lock-free correctness, and file/process races (TOCTOU, PID reuse, shared mutable state)."
-tags = ["review", "security"]
-model = "gpt-5.5"
+model = "gpt-5.6-sol"
 model_reasoning_effort = "high"
 sandbox_mode = "workspace-write"
 developer_instructions = '''

--- a/.codex/agents/reviewer-security.toml
+++ b/.codex/agents/reviewer-security.toml
@@ -1,8 +1,7 @@
 name = "reviewer-security"
 nickname_candidates = ["Reviewer-Security-Atlas", "Reviewer-Security-Delta", "Reviewer-Security-Echo", "Reviewer-Security-Nova", "Reviewer-Security-Orion", "Reviewer-Security-Vector"]
 description = "Application security reviewer. Auth logic, input handling, trust/ownership gating, path containment, and secret exposure."
-tags = ["review", "security"]
-model = "gpt-5.5"
+model = "gpt-5.6-sol"
 model_reasoning_effort = "high"
 sandbox_mode = "workspace-write"
 developer_instructions = '''

--- a/.codex/agents/reviewer-test.toml
+++ b/.codex/agents/reviewer-test.toml
@@ -1,8 +1,7 @@
 name = "reviewer-test"
 nickname_candidates = ["Reviewer-Test-Atlas", "Reviewer-Test-Delta", "Reviewer-Test-Echo", "Reviewer-Test-Nova", "Reviewer-Test-Orion", "Reviewer-Test-Vector"]
 description = "Test coverage and quality reviewer. Verifies coverage, detects vacuous tests and missing must-fail controls, audits assertion tightness and test wiring."
-tags = ["review", "testing"]
-model = "gpt-5.5"
+model = "gpt-5.6-sol"
 model_reasoning_effort = "high"
 sandbox_mode = "workspace-write"
 developer_instructions = '''

--- a/.codex/agents/rust.toml
+++ b/.codex/agents/rust.toml
@@ -1,8 +1,7 @@
 name = "rust"
 nickname_candidates = ["Rust-Atlas", "Rust-Delta", "Rust-Echo", "Rust-Nova", "Rust-Orion", "Rust-Vector"]
 description = "Rust engineer for performance-critical systems. Use for zero-allocation hot paths, lock-free algorithms, SIMD optimization, and systems programming."
-tags = ["performance"]
-model = "gpt-5.5"
+model = "gpt-5.6-sol"
 model_reasoning_effort = "high"
 sandbox_mode = "danger-full-access"
 developer_instructions = '''

--- a/.codex/agents/scout.toml
+++ b/.codex/agents/scout.toml
@@ -1,8 +1,7 @@
 name = "scout"
 nickname_candidates = ["Scout-Atlas", "Scout-Delta", "Scout-Echo", "Scout-Nova", "Scout-Orion", "Scout-Vector"]
 description = "Fast reconnaissance agent for exploring codebases, finding files by pattern, searching keywords, answering architecture questions, and returning compressed cited context or report artifacts. Specify thoroughness: quick, medium, or very thorough."
-tags = ["research"]
-model = "gpt-5.5"
+model = "gpt-5.6-sol"
 model_reasoning_effort = "medium"
 sandbox_mode = "workspace-write"
 developer_instructions = '''

--- a/.codex/agents/tpm.toml
+++ b/.codex/agents/tpm.toml
@@ -1,8 +1,7 @@
 name = "tpm"
 nickname_candidates = ["TPM-Atlas", "TPM-Delta", "TPM-Echo", "TPM-Nova", "TPM-Orion", "TPM-Vector"]
 description = "Technical Program Manager for analyzing roadmaps, project lifecycle, and progress. Returns recommendations only — does not modify project management tools."
-tags = ["planning"]
-model = "gpt-5.5"
+model = "gpt-5.6-sol"
 model_reasoning_effort = "high"
 sandbox_mode = "workspace-write"
 developer_instructions = '''

--- a/changelog.d/fixed/KEN-786.md
+++ b/changelog.d/fixed/KEN-786.md
@@ -1,0 +1,3 @@
+- Codex now loads the agents kendex renders for it. Every one carried a `tags`
+  key Codex rejects, so it ignored all of them and warned at launch. Rendered
+  Codex agents also move to gpt-5.6-sol.

--- a/crates/core/src/render/agent/codex.rs
+++ b/crates/core/src/render/agent/codex.rs
@@ -8,6 +8,7 @@ const NICKNAME_SUFFIXES: [&str; 6] = ["Atlas", "Delta", "Echo", "Nova", "Orion",
 
 /// Codex agent: TOML whose `developer_instructions` carries the whole prompt.
 /// No native skills field and no hook wiring, so both render as prose.
+/// Tags are left out: Codex denies unknown fields, and one costs the whole file.
 pub fn generate(agent: &EffectiveAgent) -> RenderedAgent {
     let source = agent.source;
     let o = &agent.overrides;
@@ -26,14 +27,6 @@ pub fn generate(agent: &EffectiveAgent) -> RenderedAgent {
         "description = \"{}\"\n",
         escape(&source.description)
     ));
-    if !source.tags.is_empty() {
-        let words: Vec<String> = source
-            .tags
-            .iter()
-            .map(|tag| format!("\"{}\"", escape(tag)))
-            .collect();
-        out.push_str(&format!("tags = [{}]\n", words.join(", ")));
-    }
     let model = o.model.as_deref().unwrap_or(&source.model);
     let resolved = resolve_model(HarnessId::Codex, model);
     warnings.extend(resolved.warning.map(crate::render::RenderWarning::new));
@@ -228,7 +221,7 @@ mod tests {
 
     fn source(name: &str, role: &str) -> SourceAgent {
         parse_source_agent(&format!(
-            "---\nname: {name}\ndescription: Codex agent\nmodel: sonnet\nrole: {role}\n---\nBody text.\n"
+            "---\nname: {name}\ndescription: Codex agent\nmodel: sonnet\nrole: {role}\ntags: performance\n---\nBody text.\n"
         ))
         .unwrap()
     }
@@ -261,6 +254,16 @@ mod tests {
         assert!(engineer.contains("model = \"gpt-5.6-sol\""));
         assert!(!engineer.contains("model_reasoning_effort"));
         assert!(engineer.contains("- dev: .agents/skills/dev/SKILL.md"));
+    }
+
+    /// One unknown field costs Codex the whole agent file.
+    #[test]
+    fn a_tagged_source_renders_no_tags_key() {
+        let source = source("rust", "engineer");
+        assert_eq!(source.tags, vec!["performance"]);
+        let text = generate(&effective(&source, &Scope::Global)).text;
+        let (keys, _) = text.split_once("developer_instructions").unwrap();
+        assert!(!keys.contains("tags"), "{keys}");
     }
 
     #[test]

--- a/kendex-local.toml
+++ b/kendex-local.toml
@@ -577,7 +577,6 @@ background = true
 effort = "high"
 
 [agent-frontmatter.codex.generalist]
-model = "gpt-5.5"
 sandbox-mode = "danger-full-access"
 model-reasoning-effort = "high"
 nickname-candidates = [
@@ -590,7 +589,6 @@ nickname-candidates = [
 ]
 
 [agent-frontmatter.codex.iced]
-model = "gpt-5.5"
 sandbox-mode = "danger-full-access"
 model-reasoning-effort = "high"
 nickname-candidates = [
@@ -603,7 +601,6 @@ nickname-candidates = [
 ]
 
 [agent-frontmatter.codex.planner]
-model = "gpt-5.5"
 sandbox-mode = "workspace-write"
 model-reasoning-effort = "high"
 nickname-candidates = [
@@ -616,7 +613,6 @@ nickname-candidates = [
 ]
 
 [agent-frontmatter.codex.researcher]
-model = "gpt-5.5"
 sandbox-mode = "workspace-write"
 model-reasoning-effort = "high"
 nickname-candidates = [
@@ -629,7 +625,6 @@ nickname-candidates = [
 ]
 
 [agent-frontmatter.codex.reviewer-arch]
-model = "gpt-5.5"
 sandbox-mode = "workspace-write"
 model-reasoning-effort = "high"
 nickname-candidates = [
@@ -642,7 +637,6 @@ nickname-candidates = [
 ]
 
 [agent-frontmatter.codex.reviewer-correctness]
-model = "gpt-5.5"
 sandbox-mode = "workspace-write"
 model-reasoning-effort = "high"
 nickname-candidates = [
@@ -655,7 +649,6 @@ nickname-candidates = [
 ]
 
 [agent-frontmatter.codex.reviewer-doc]
-model = "gpt-5.5"
 sandbox-mode = "workspace-write"
 model-reasoning-effort = "high"
 nickname-candidates = [
@@ -668,7 +661,6 @@ nickname-candidates = [
 ]
 
 [agent-frontmatter.codex.reviewer-error]
-model = "gpt-5.5"
 sandbox-mode = "workspace-write"
 model-reasoning-effort = "high"
 nickname-candidates = [
@@ -681,7 +673,6 @@ nickname-candidates = [
 ]
 
 [agent-frontmatter.codex.reviewer-perf]
-model = "gpt-5.5"
 sandbox-mode = "workspace-write"
 model-reasoning-effort = "high"
 nickname-candidates = [
@@ -694,7 +685,6 @@ nickname-candidates = [
 ]
 
 [agent-frontmatter.codex.reviewer-quality]
-model = "gpt-5.5"
 sandbox-mode = "workspace-write"
 model-reasoning-effort = "high"
 nickname-candidates = [
@@ -707,7 +697,6 @@ nickname-candidates = [
 ]
 
 [agent-frontmatter.codex.reviewer-safety]
-model = "gpt-5.5"
 sandbox-mode = "workspace-write"
 model-reasoning-effort = "high"
 nickname-candidates = [
@@ -720,7 +709,6 @@ nickname-candidates = [
 ]
 
 [agent-frontmatter.codex.reviewer-security]
-model = "gpt-5.5"
 sandbox-mode = "workspace-write"
 model-reasoning-effort = "high"
 nickname-candidates = [
@@ -733,7 +721,6 @@ nickname-candidates = [
 ]
 
 [agent-frontmatter.codex.reviewer-test]
-model = "gpt-5.5"
 sandbox-mode = "workspace-write"
 model-reasoning-effort = "high"
 nickname-candidates = [
@@ -746,7 +733,6 @@ nickname-candidates = [
 ]
 
 [agent-frontmatter.codex.rust]
-model = "gpt-5.5"
 sandbox-mode = "danger-full-access"
 model-reasoning-effort = "high"
 nickname-candidates = [
@@ -759,7 +745,6 @@ nickname-candidates = [
 ]
 
 [agent-frontmatter.codex.scout]
-model = "gpt-5.5"
 sandbox-mode = "workspace-write"
 model-reasoning-effort = "medium"
 nickname-candidates = [
@@ -772,7 +757,6 @@ nickname-candidates = [
 ]
 
 [agent-frontmatter.codex.tpm]
-model = "gpt-5.5"
 sandbox-mode = "workspace-write"
 model-reasoning-effort = "high"
 nickname-candidates = [


### PR DESCRIPTION
Codex refuses an agent role file on the first unknown key, so the `tags = [...]`
line the emitter wrote made it drop all sixteen rendered agents and warn once per
file at launch. A Codex user in this repo got no kendex-managed agents at all.

I probed the schema before changing anything: one candidate key per probe file,
read back through `codex doctor --json`. `tags`, `keywords`, `categories`,
`labels`, `topics`, `aliases`, `capabilities`, `color`, `role`, `effort`,
`prompt`, `system_prompt`, `when_to_use` and `allowed_tools` are all rejected as
unknown. There is nowhere for the tag content to go, so the render leaves it out.
Every other key the emitter writes is accepted.

The renders also read `model = "gpt-5.5"`, which was not staleness: `kendex-local.toml`
pinned it per agent, below the model table that already resolves Codex to
`gpt-5.6-sol`. Dropping those overrides lets the table govern.

## Verification

`codex doctor --json` surfaces this class at `.checks["config.load"].details`.
Project `.codex/agents/` is only read when the project is trusted, so the run
uses a scratch `CODEX_HOME` whose `config.toml` trusts the worktree path — read
only, nothing written to either checkout. Note that doctor exits non-zero under a
scratch home because there is no auth there; the JSON is the signal, not the exit
code.

- On this branch: `startup warnings` absent, zero malformed-agent warnings.
- Must-fail control: dropping one extra render carrying a `tags` line into
  `.codex/agents/` brings the count back to 1, naming that file. Removed after.
- `a_tagged_source_renders_no_tags_key` asserts the source's tags are non-empty
  before asserting the render omits the key, so it cannot pass vacuously.
- `tools/guard` green.

## Scope

KEN-786 carries four deliverables and this is the first. The render-validation
check and its per-harness coverage report follow in their own PR. The missing
harness CLIs are installed on the machine already — `gemini-cli 0.50.0` and
`github-copilot-cli 1.0.81` from the CachyOS repos, and `cursor-agent 2026.08.25`
via `aur/cursor-cli`, which is the package that ships it; there is no
`cursor-agent` package under that name.

Refs KEN-786
