### PR TITLE
test(KEN-786): a render a harness rejects reds the check

### DIFF
--- a/.github/workflows/own-catalog.yml
+++ b/.github/workflows/own-catalog.yml
@@ -27,12 +27,13 @@ jobs:
       ref: ${{ github.sha }}
 
   # The one job that lets somebody other than kendex read kendex's output.
-  # Freely installable without an account or an API key: OpenCode, Gemini
-  # CLI, Codex and Claude Code all ship on npm and all answer a local
-  # list/version command offline. Cursor's agent CLI and the GitHub Copilot
-  # CLI are not installed here — both want an authenticated session — so
-  # the suite skips them and says so. A run where every harness was absent
-  # fails; see crates/cli/tests/cli_smoke.rs.
+  # Installed here are the four CLIs that answer offline with what they
+  # loaded from the rendered tree: Codex, OpenCode, Gemini CLI and the
+  # GitHub Copilot CLI. Claude Code, Pi and Cursor's agent CLI are not
+  # installed, because none of them ships a command that reads that tree
+  # without a session — the suite names each of them uncovered and says
+  # why. A run where nothing was read fails; see
+  # crates/cli/tests/cli_smoke.rs.
   #
   # It lives here rather than in the reusable workflow because it exercises
   # kendex's own renderers: a caller's checkout is their catalog, and
@@ -66,11 +67,11 @@ jobs:
             opencode-ai \
             @google/gemini-cli \
             @openai/codex \
-            @anthropic-ai/claude-code
+            @github/copilot
           # Only CLIs whose version flag is confirmed; adding one means
           # confirming it first, because a wrong probe here reds the build
           # for a reason that has nothing to do with kendex.
-          for cli in opencode codex claude; do "$cli" --version; done
+          for cli in opencode codex gemini copilot; do "$cli" --version; done
       - name: Round-trip the emitted trees
         env:
           KENDEX_CLI_SMOKE: "1"

--- a/crates/cli/tests/cli_smoke.rs
+++ b/crates/cli/tests/cli_smoke.rs
@@ -2,10 +2,17 @@
 //! then let each harness's own CLI read them.
 //!
 //! Unit tests assert what our renderers produce. They cannot tell us that
-//! the far end accepts it — the three bugs wshobson recorded in
-//! `docs/round-trip-results.md` were all of that shape, and all of them
-//! passed unit tests. This is the only check in the suite where something
-//! other than kendex reads kendex's output.
+//! the far end accepts it, and every consumer-side bug found so far has
+//! been of that shape: green unit tests over a render the harness threw
+//! away. This is the only check in the suite where something other than
+//! kendex reads kendex's output.
+//!
+//! A probe is a command that *loads* the rendered tree and answers with
+//! what it loaded or what it rejected. `--version` is not one: sixteen
+//! unreadable `.codex/agents/*.toml` files shipped behind a green
+//! `codex --version` (KEN-786), because starting a binary says nothing
+//! about files it never opens. A harness that ships no such command is
+//! named as uncovered, with the reason — never counted as checked.
 //!
 //! Opt-in: set `KENDEX_CLI_SMOKE=1`. Without it the test does nothing and
 //! says so, because installing seven CLIs is not a precondition for
@@ -18,65 +25,281 @@ use std::io::Write;
 use std::path::{Path, PathBuf};
 use std::process::{Command, Output};
 
-/// One harness's own CLI, and the command that makes it read what we wrote.
+/// What a harness's CLI said, kept apart because the two streams answer
+/// different questions: `codex doctor` prints its report on stdout and
+/// exits non-zero for the unrelated reason that a staged home has no
+/// credentials, so its verdict reads stdout and ignores the status.
+struct Said {
+    out: String,
+    err: String,
+    ok: bool,
+}
+
+impl Said {
+    fn all(&self) -> String {
+        format!("{}{}", self.out, self.err)
+    }
+}
+
+/// The command that makes one harness read what kendex wrote, and how to
+/// tell from its answer that it did.
+struct Reader {
+    args: &'static [&'static str],
+    /// Rendered files this command loads, relative to the staged home.
+    /// Asserted present before the probe runs: a staging that stopped
+    /// emitting one of them would otherwise pass the probe vacuously.
+    loads: &'static [&'static str],
+    /// `Ok` when the CLI says it loaded what we wrote.
+    verdict: fn(&Said) -> Result<(), String>,
+    /// The rejected renders the must-fail control writes — one per way
+    /// this verdict can go red, so no branch of it is only asserted in
+    /// the direction that passes.
+    rejects: &'static [Reject],
+}
+
+/// A render this harness is known to refuse, so the control can watch the
+/// probe go red on one.
+struct Reject {
+    /// Relative to the staged home; one of the reader's `loads`.
+    file: &'static str,
+    /// Rewrites that file into one the harness rejects.
+    spoil: fn(&str) -> String,
+    /// What `spoil` leaves behind. The control asserts this is really in
+    /// the file before it asserts the CLI rejected it, so a spoiler that
+    /// quietly stopped applying cannot read as a rejection.
+    marker: &'static str,
+}
+
+enum Reads {
+    /// This harness's own CLI loads the rendered tree and reports on it.
+    Cli(Reader),
+    /// Nothing this CLI ships reads the rendered tree without an
+    /// authenticated session. Recorded so the gap is reported by name.
+    NothingOffline(&'static str),
+}
+
+/// One harness, and whether anything it ships can read kendex's output.
 struct Probe {
     /// The binary as it is installed.
     bin: &'static str,
     /// kendex's id for the same tool.
     harness: &'static str,
-    args: &'static [&'static str],
-    /// A string the output must contain — set where the CLI actually lists
-    /// what it loaded, so the check proves the tree was read and not merely
-    /// that the binary starts.
-    expects: Option<&'static str>,
+    reads: Reads,
 }
 
-/// Which of these CI installs is documented in
-/// `.github/workflows/catalog-check.yml`; the rest are skipped when absent.
+/// Which of these CI installs is decided in `.github/workflows/own-catalog.yml`;
+/// the rest are reported uncovered when absent.
 const PROBES: &[Probe] = &[
+    Probe {
+        bin: "codex",
+        harness: "codex",
+        reads: Reads::Cli(Reader {
+            args: &["doctor", "--json"],
+            loads: &[".codex/agents/reviewer.toml"],
+            verdict: codex_loaded_every_agent,
+            rejects: &[Reject {
+                file: ".codex/agents/reviewer.toml",
+                spoil: append_tags_table,
+                marker: "tags = [\"review\"]",
+            }],
+        }),
+    },
     Probe {
         bin: "opencode",
         harness: "opencode",
-        args: &["agent", "list"],
-        expects: Some("reviewer"),
+        reads: Reads::Cli(Reader {
+            args: &["agent", "list"],
+            loads: &[".config/opencode/agents/reviewer.md"],
+            verdict: opencode_listed_the_agent,
+            rejects: &[
+                // opencode accepts an unknown key and rejects an unknown
+                // value, so one control breaks the value...
+                Reject {
+                    file: ".config/opencode/agents/reviewer.md",
+                    spoil: |body| body.replace("mode: subagent", "mode: not-a-mode"),
+                    marker: "mode: not-a-mode",
+                },
+                // ...and the other breaks the frontmatter, which opencode
+                // answers by listing the agent under its default mode
+                // rather than by failing.
+                Reject {
+                    file: ".config/opencode/agents/reviewer.md",
+                    spoil: open_a_yaml_sequence,
+                    marker: "tags: [unclosed",
+                },
+            ],
+        }),
     },
     Probe {
         bin: "gemini",
         harness: "gemini",
-        args: &["extensions", "list"],
-        expects: None,
-    },
-    Probe {
-        bin: "codex",
-        harness: "codex",
-        args: &["--version"],
-        expects: None,
-    },
-    Probe {
-        bin: "claude",
-        harness: "claude",
-        args: &["--version"],
-        expects: None,
-    },
-    Probe {
-        bin: "cursor-agent",
-        harness: "cursor",
-        args: &["--version"],
-        expects: None,
-    },
-    Probe {
-        bin: "pi",
-        harness: "pi",
-        args: &["--version"],
-        expects: None,
+        reads: Reads::Cli(Reader {
+            args: &["skills", "list"],
+            // One command, two trees: listing skills also builds the user
+            // agent registry, which reports every role file it could not
+            // parse.
+            loads: &[
+                ".gemini/skills/release-notes/SKILL.md",
+                ".gemini/agents/reviewer.md",
+            ],
+            verdict: gemini_read_both_trees,
+            rejects: &[
+                Reject {
+                    file: ".gemini/agents/reviewer.md",
+                    spoil: open_a_yaml_sequence,
+                    marker: "tags: [unclosed",
+                },
+                // gemini reads a broken skill frontmatter leniently and
+                // drops a skill that has none, so the skill half of the
+                // verdict is controlled by taking the frontmatter away.
+                Reject {
+                    file: ".gemini/skills/release-notes/SKILL.md",
+                    spoil: |_| "# release-notes\n\nno frontmatter, so no skill\n".to_string(),
+                    marker: "no frontmatter, so no skill",
+                },
+            ],
+        }),
     },
     Probe {
         bin: "copilot",
         harness: "copilot",
-        args: &["--version"],
-        expects: None,
+        reads: Reads::Cli(Reader {
+            args: &["skill", "list"],
+            loads: &[".copilot/skills/release-notes/SKILL.md"],
+            verdict: copilot_listed_the_skill,
+            rejects: &[Reject {
+                file: ".copilot/skills/release-notes/SKILL.md",
+                spoil: open_a_yaml_sequence,
+                marker: "tags: [unclosed",
+            }],
+        }),
+    },
+    Probe {
+        bin: "claude",
+        harness: "claude",
+        reads: Reads::NothingOffline(
+            "`claude doctor` reads install state and settings, never the agent or \
+             skill tree; `claude plugin list` sees nothing kendex writes; `-p` needs \
+             a live session",
+        ),
+    },
+    Probe {
+        bin: "pi",
+        harness: "pi",
+        reads: Reads::NothingOffline(
+            "`pi list` reads installed extension packages, not the rendered agents \
+             or skills; `pi config` is a TUI and every other read wants a provider key",
+        ),
+    },
+    Probe {
+        bin: "cursor-agent",
+        harness: "cursor",
+        reads: Reads::NothingOffline(
+            "cursor-agent ships no list or doctor command — every read starts an \
+             authenticated session; kendex also renders for Cursor at project scope \
+             only, which this global staging does not reach",
+        ),
     },
 ];
+
+/// The `tags` key Codex refused, written back exactly as the renderer used
+/// to emit it (KEN-786).
+fn append_tags_table(body: &str) -> String {
+    format!("{body}\ntags = [\"review\"]\n")
+}
+
+/// A flow sequence with no closing bracket: the frontmatter parses as YAML
+/// nowhere.
+fn open_a_yaml_sequence(body: &str) -> String {
+    body.replacen("description:", "tags: [unclosed\ndescription:", 1)
+}
+
+fn codex_loaded_every_agent(said: &Said) -> Result<(), String> {
+    // `codex doctor` exits non-zero in a staged home for the unrelated
+    // reason that there are no credentials there, so the exit status is
+    // not the signal — the report on stdout is.
+    let report: serde_json::Value = serde_json::from_str(&said.out).map_err(|err| {
+        format!(
+            "codex doctor --json printed no report ({err}): {}",
+            said.err
+        )
+    })?;
+    let details = report
+        .pointer("/checks/config.load/details")
+        .ok_or_else(|| format!("codex doctor --json has no config.load check: {}", said.out))?;
+    // Both keys are absent from a clean load, so a missing count is zero
+    // warnings rather than a read that failed.
+    let count = details
+        .get("startup warnings")
+        .and_then(serde_json::Value::as_str)
+        .unwrap_or("0");
+    if count == "0" {
+        return Ok(());
+    }
+    let warnings = details
+        .get("startup warning")
+        .map_or_else(String::new, ToString::to_string);
+    Err(format!(
+        "codex raised {count} startup warning(s): {warnings}"
+    ))
+}
+
+fn opencode_listed_the_agent(said: &Said) -> Result<(), String> {
+    if !said.ok {
+        return Err(format!("opencode agent list failed: {}", said.all()));
+    }
+    // The mode is half the assertion: frontmatter opencode cannot parse
+    // falls back to the default mode instead of erroring, so matching the
+    // name alone would pass a render it had already degraded.
+    if said.all().contains("reviewer (subagent)") {
+        return Ok(());
+    }
+    Err(format!(
+        "opencode did not list `reviewer (subagent)`: {}",
+        said.all()
+    ))
+}
+
+fn gemini_read_both_trees(said: &Said) -> Result<(), String> {
+    let all = said.all();
+    if let Some(line) = all
+        .lines()
+        .find(|line| line.contains("Failed to load agent from"))
+    {
+        return Err(format!("gemini rejected a rendered agent: {}", line.trim()));
+    }
+    if !said.ok {
+        return Err(format!("gemini skills list failed: {all}"));
+    }
+    // gemini prints the path it loaded each skill from, so the assertion
+    // is on the rendered file rather than on the wording around it.
+    if all.contains(".gemini/skills/release-notes/SKILL.md") {
+        return Ok(());
+    }
+    Err(format!("gemini did not list the rendered skill: {all}"))
+}
+
+fn copilot_listed_the_skill(said: &Said) -> Result<(), String> {
+    let all = said.all();
+    // copilot names the file it could not read; matching the path keeps
+    // the check off its own builtin skills.
+    if let Some(line) = all
+        .lines()
+        .find(|line| line.contains("skills/release-notes/SKILL.md"))
+    {
+        return Err(format!(
+            "copilot rejected the rendered skill: {}",
+            line.trim()
+        ));
+    }
+    if !said.ok {
+        return Err(format!("copilot skill list failed: {all}"));
+    }
+    if all.contains("release-notes - Use this when writing release notes") {
+        return Ok(());
+    }
+    Err(format!("copilot did not list the rendered skill: {all}"))
+}
 
 fn note(line: &str) {
     let _ = writeln!(std::io::stderr(), "smoke: {line}");
@@ -96,11 +319,24 @@ fn run(bin: &str, home: &Path, cwd: &Path, args: &[&str]) -> Output {
         .expect("the command runs")
 }
 
+fn ask(bin: &str, home: &Path, args: &[&str]) -> Said {
+    let out = run(bin, home, home, args);
+    Said {
+        out: String::from_utf8_lossy(&out.stdout).into_owned(),
+        err: String::from_utf8_lossy(&out.stderr).into_owned(),
+        ok: out.status.success(),
+    }
+}
+
 fn installed(bin: &str) -> bool {
     Command::new("sh")
         .args(["-c", &format!("command -v {bin}")])
         .output()
         .is_ok_and(|out| out.status.success())
+}
+
+fn enabled() -> bool {
+    std::env::var("KENDEX_CLI_SMOKE").as_deref() == Ok("1")
 }
 
 /// A catalog with one item of every kind kendex renders, then a global
@@ -113,6 +349,14 @@ fn stage(home: &Path) -> PathBuf {
         std::fs::create_dir_all(path.parent().unwrap()).unwrap();
         std::fs::write(path, body).unwrap();
     };
+    // Without a control file the source is read through the skills search
+    // table, which yields agents and skills and silently leaves the hook,
+    // the command and the MCP server on the floor — three kinds staged to
+    // disk and installed nowhere.
+    write(
+        "kendex.toml",
+        "[marketplace]\nname = \"smoke\"\ndescription = \"The round-trip fixtures.\"\n",
+    );
     write(
         "agents/reviewer.md",
         "---\nname: reviewer\ndescription: Use this when reviewing a change for risk.\nmodel: sonnet\nrole: engineer\n---\n\n# reviewer\n\nRead the diff and name what could break.\n",
@@ -161,59 +405,153 @@ fn stage(home: &Path) -> PathBuf {
     catalog
 }
 
+/// Every rendered file the reader claims to load is really there, so a
+/// probe can never pass over a tree kendex stopped writing.
+fn staged(home: &Path, reader: &Reader, harness: &str) -> Result<(), String> {
+    for relative in reader.loads {
+        if !home.join(relative).is_file() {
+            return Err(format!(
+                "{harness}: kendex rendered no {relative}, so `{}` would read nothing",
+                reader.args.join(" ")
+            ));
+        }
+    }
+    Ok(())
+}
+
 #[test]
 #[allow(clippy::unwrap_used)]
 fn every_harness_cli_reads_what_kendex_wrote() {
-    if std::env::var("KENDEX_CLI_SMOKE").as_deref() != Ok("1") {
+    if !enabled() {
         note("not run — set KENDEX_CLI_SMOKE=1 with the harness CLIs installed");
         return;
     }
     let tmp = tempfile::tempdir().unwrap();
     let home = tmp.path();
-    std::fs::create_dir_all(home).unwrap();
     stage(home);
 
-    let mut checked = Vec::new();
-    let mut skipped = Vec::new();
+    let mut validated = 0_usize;
+    let mut uncovered = Vec::new();
     let mut failed = Vec::new();
     for probe in PROBES {
+        let reader = match &probe.reads {
+            Reads::Cli(reader) => reader,
+            Reads::NothingOffline(why) => {
+                uncovered.push(probe.harness);
+                note(&format!("{}: UNCOVERED — {why}", probe.harness));
+                continue;
+            }
+        };
         if !installed(probe.bin) {
-            skipped.push(probe.harness);
+            uncovered.push(probe.harness);
             note(&format!(
-                "{}: skipped, {} is not installed",
-                probe.harness, probe.bin
+                "{}: UNCOVERED — {} is not installed, so `{}` never ran",
+                probe.harness,
+                probe.bin,
+                reader.args.join(" ")
             ));
             continue;
         }
-        let out = run(probe.bin, home, home, probe.args);
-        let said = format!(
-            "{}{}",
-            String::from_utf8_lossy(&out.stdout),
-            String::from_utf8_lossy(&out.stderr)
-        );
-        let listed = probe.expects.is_none_or(|needle| said.contains(needle));
-        match out.status.success() && listed {
-            true => checked.push(probe.harness),
-            false => failed.push(format!("{} ({}): {said}", probe.harness, probe.bin)),
+        if let Err(missing) = staged(home, reader, probe.harness) {
+            failed.push(missing);
+            continue;
+        }
+        match (reader.verdict)(&ask(probe.bin, home, reader.args)) {
+            Ok(()) => {
+                validated += 1;
+                note(&format!(
+                    "{}: validated by `{} {}`",
+                    probe.harness,
+                    probe.bin,
+                    reader.args.join(" ")
+                ));
+            }
+            Err(why) => failed.push(format!("{} ({}): {why}", probe.harness, probe.bin)),
         }
     }
 
     note(&format!(
-        "{} checked, {} skipped, {} failed",
-        checked.len(),
-        skipped.len(),
+        "coverage: {validated} validated, {} uncovered ({}), {} failed",
+        uncovered.len(),
+        uncovered.join(", "),
         failed.len()
     ));
     assert!(failed.is_empty(), "{}", failed.join("\n"));
     // The whole point of the gate: a run that reached nothing proves
     // nothing, and must never be reported as a pass.
     assert!(
-        !checked.is_empty(),
-        "every harness CLI was absent, so nothing was checked — install at least one of: {}",
+        validated > 0,
+        "no harness CLI read anything, so nothing was checked — install at least one of: {}",
         PROBES
             .iter()
+            .filter(|probe| matches!(probe.reads, Reads::Cli(_)))
             .map(|probe| probe.bin)
             .collect::<Vec<_>>()
             .join(", ")
+    );
+}
+
+/// The control the probes exist for: put back a render the harness refuses
+/// and watch its own probe go red. A probe that cannot fail is not a check,
+/// and every `--version` probe this file used to carry was one.
+#[test]
+#[allow(clippy::unwrap_used)]
+fn a_render_the_harness_refuses_reds_its_probe() {
+    if !enabled() {
+        note("not run — set KENDEX_CLI_SMOKE=1 with the harness CLIs installed");
+        return;
+    }
+    let tmp = tempfile::tempdir().unwrap();
+    let home = tmp.path();
+    stage(home);
+
+    let mut controlled = 0_usize;
+    for probe in PROBES {
+        let Reads::Cli(reader) = &probe.reads else {
+            continue;
+        };
+        if !installed(probe.bin) {
+            note(&format!(
+                "{}: control not run, {} is not installed",
+                probe.harness, probe.bin
+            ));
+            continue;
+        }
+        for reject in reader.rejects {
+            let path = home.join(reject.file);
+            let good = std::fs::read_to_string(&path).unwrap();
+            std::fs::write(&path, (reject.spoil)(&good)).unwrap();
+            let spoiled = std::fs::read_to_string(&path).unwrap();
+            // Before asking whether the CLI rejected the file, prove the
+            // file really holds what the harness rejects: a spoiler that
+            // stopped applying would otherwise leave this test passing on
+            // a clean render the probe correctly accepted.
+            assert!(
+                spoiled.contains(reject.marker),
+                "{}: the control wrote no `{}` into {}",
+                probe.harness,
+                reject.marker,
+                reject.file
+            );
+            let verdict = (reader.verdict)(&ask(probe.bin, home, reader.args));
+            std::fs::write(&path, &good).unwrap();
+            assert!(
+                verdict.is_err(),
+                "{} ({}) accepted {} carrying `{}` — its probe cannot fail",
+                probe.harness,
+                probe.bin,
+                reject.file,
+                reject.marker
+            );
+            controlled += 1;
+            note(&format!(
+                "{}: control red on `{}` in {}",
+                probe.harness, reject.marker, reject.file
+            ));
+        }
+    }
+    assert!(
+        controlled > 0,
+        "no probe was put under control, so none is known to be able to fail"
     );
 }


### PR DESCRIPTION
The second deliverable of KEN-786: a render a harness rejects now fails before
merge, with per-harness coverage reported by name.

## The check already existed and this bug walked through it

`crates/cli/tests/cli_smoke.rs`, run by the "real-CLI round trip" job, exists to
notice when a harness stops reading what kendex wrote. It stages a catalog,
installs globally for every harness, and invokes each CLI. It did not notice,
because five of its seven probes were `--version`. Starting a binary says nothing
about files it never opens, so sixteen unreadable `.codex/agents/*.toml` passed it
green.

So this is not a new checker beside the old one — the old one is the check, and
its probes did not read. Each probe now runs a command that loads the rendered
tree and answers with what it loaded or what it rejected, and asserts on that
answer.

## Coverage

| harness | probe | |
|---|---|---|
| codex | `doctor --json` | zero startup warnings |
| opencode | `agent list` | the agent and its mode |
| gemini | `skills list` | the rendered SKILL.md path, and any role file refused |
| copilot | `skill list` | the skill by name |
| claude | — | uncovered: `doctor` reads install state and settings, never the agent or skill tree; `plugin list` sees nothing kendex writes; `-p` needs a live session |
| pi | — | uncovered: `pi list` reads installed extension packages, not rendered agents or skills; `pi config` is a TUI, and every other read wants a provider key |
| cursor | — | uncovered: no list or doctor command, every read starts an authenticated session |

The run prints `coverage: 4 validated, 3 uncovered (claude, pi, cursor), 0 failed`.
Uncovered is reported by name with its reason, never counted as checked and never
skipped silently.

Two notes on that table. `copilot skill list` was verified to work with no
credentials at all — `env -i` with an empty `HOME`, exit 0 — so the previous
comment claiming Copilot needs an authenticated session was wrong, and the probe
holds in CI. Cursor is uncovered for a second reason as well: kendex renders for
it at project scope only, which this global staging does not reach.

## Must-fail control

A second test writes a rejected render back into each probe's own file and asserts
the probe goes red: `tags` into the Codex TOML, `mode: not-a-mode` and unclosed
YAML into the OpenCode and Gemini agents, frontmatter stripped from a SKILL.md.
Each control asserts its marker is really in the file before asserting the CLI
rejected it, so a spoiler that quietly stopped applying cannot read as a
rejection. Each probe also asserts the files it loads are present before running,
so a staging that stopped emitting one cannot pass vacuously.

`codex doctor` exits non-zero in a staged home for the unrelated reason that there
are no credentials there, so its verdict reads stdout and ignores the status.

## CI

The job installs the four CLIs that are probed. It no longer installs Claude
Code, which nothing reads.

`tools/guard` green. `KENDEX_CLI_SMOKE=1 cargo test -p kendex-cli --test cli_smoke`
passes both tests.

Refs KEN-786
