### PR TITLE
fix(KEN-783): one mark answers for a package, wherever it is drawn

### DIFF
--- a/changelog.d/fixed/KEN-783.md
+++ b/changelog.d/fixed/KEN-783.md
@@ -1,0 +1,3 @@
+- A package page's mark now answers for the package everywhere, as its Library
+  row does. The Customize tab marks which places and settings hold your
+  changes, and names the skills an agent gets.

--- a/crates/app/src/editor.rs
+++ b/crates/app/src/editor.rs
@@ -30,11 +30,38 @@ pub struct EditorInventory {
     /// with an assignment no apply has written. An agent absent here has
     /// no recorded assignment — which is not the same as having none.
     pub automatic_skills: std::collections::BTreeMap<String, Vec<String>>,
+    /// The `[agent-skills]` entry each installed agent reads, by agent
+    /// name, resolved by the engine — a reviewer agent with no entry of
+    /// its own reads its base agent's. Sent resolved so the UI never has
+    /// to know which agents inherit from which; an agent absent here has
+    /// no entry reaching it at all.
+    pub declared_skill_rows: std::collections::BTreeMap<String, DeclaredSkillRow>,
     pub harnesses: Vec<HarnessId>,
     /// The events a hook can be written against, and when each fires. Sent
     /// rather than spelled out in the UI so the picker cannot offer an
     /// event the validator would then reject.
     pub hook_events: Vec<HookEvent>,
+}
+
+/// What one scope's lock and manifest say about its agents' skills: the
+/// assignment each got from the catalog, and the `[agent-skills]` entry
+/// each reads. Both keyed by agent name, both off the same pass, so the
+/// two cannot end up keyed by different sets of agents.
+#[derive(Default)]
+struct AgentSkillFacts {
+    automatic: std::collections::BTreeMap<String, Vec<String>>,
+    declared: std::collections::BTreeMap<String, DeclaredSkillRow>,
+}
+
+/// One agent's skill declaration and the agent it is written under. The
+/// two names are the same for an entry an agent owns, and differ for one
+/// it inherits — which is the difference between a list this page edits
+/// and a list it only reports.
+#[derive(Serialize, Type)]
+#[serde(rename_all = "camelCase")]
+pub struct DeclaredSkillRow {
+    pub skills: Vec<String>,
+    pub under: String,
 }
 
 #[derive(Serialize, Type)]
@@ -123,26 +150,43 @@ pub fn custom_hook_deliveries(
 /// Every agent's recorded upstream assignment in one scope. A read-only
 /// lookup, so a v1 lock degrades to "nothing recorded" like the rest of the
 /// read surface instead of taking the editor's inventory down with it.
-fn automatic_skills(
+///
+/// Both answers come off one pass over the lock's agent entries, so the
+/// two maps cannot end up keyed by different sets of agents.
+fn agent_skill_facts(
     env: &Env,
     scope: &Scope,
-) -> Result<std::collections::BTreeMap<String, Vec<String>>, String> {
+    manifest: Option<&manifest::Manifest>,
+) -> Result<AgentSkillFacts, String> {
     let lock = match kendex_core::lock::load_file(&kendex_core::lock::lock_path(env, scope))
         .map_err(|e| e.to_string())?
     {
         kendex_core::lock::LockFile::Current(lock) => lock,
         kendex_core::lock::LockFile::Absent | kendex_core::lock::LockFile::Legacy { .. } => {
-            return Ok(std::collections::BTreeMap::new());
+            return Ok(AgentSkillFacts::default());
         }
     };
-    Ok(lock
-        .entries
-        .into_values()
-        .filter(|entry| entry.kind == ItemKind::Agent)
+    let mut facts = AgentSkillFacts::default();
+    for entry in lock.entries.into_values() {
+        if entry.kind != ItemKind::Agent {
+            continue;
+        }
         // One row per harness, all carrying the same assignment: the name
         // is the key the editor asks by, and the rows agree on it.
-        .filter_map(|entry| Some((entry.name, entry.upstream_skills?)))
-        .collect())
+        if let Some(skills) = entry.upstream_skills {
+            facts.automatic.insert(entry.name.clone(), skills);
+        }
+        let row = manifest
+            .and_then(|m| kendex_core::mapping::declared_skills(m, &entry.name))
+            .map(|(skills, under)| DeclaredSkillRow {
+                skills: skills.clone(),
+                under: under.to_owned(),
+            });
+        if let Some(row) = row {
+            facts.declared.insert(entry.name, row);
+        }
+    }
+    Ok(facts)
 }
 
 #[tauri::command(async)]
@@ -151,11 +195,13 @@ pub fn editor_inventory(scope: Scope) -> Result<EditorInventory, String> {
     let env = env()?;
     let loaded = manifest::load_for_mutation(&manifest::manifest_path(&env, &scope))
         .map_err(|e| e.to_string())?;
+    let facts = agent_skill_facts(&env, &scope, loaded.as_ref())?;
     let mut inventory = EditorInventory {
         declared_agents: Vec::new(),
         declared_skills: Vec::new(),
         available_skills: Vec::new(),
-        automatic_skills: automatic_skills(&env, &scope)?,
+        automatic_skills: facts.automatic,
+        declared_skill_rows: facts.declared,
         // Per-harness settings are only offered for harnesses kendex
         // writes to.
         harnesses: HarnessId::ALL
@@ -221,6 +267,7 @@ mod tests {
     use super::*;
     use kendex_core::env::FakeOs;
     use kendex_core::lock::{Lock, LockEntry, entry_key, lock_path, save};
+    use kendex_core::manifest::Manifest;
 
     fn entry(kind: ItemKind, name: &str, upstream_skills: Option<&[&str]>) -> LockEntry {
         LockEntry {
@@ -260,6 +307,17 @@ mod tests {
         (tmp, env, scope)
     }
 
+    fn manifest_with(rows: &[(&str, &[&str])]) -> Manifest {
+        let mut manifest = Manifest::default();
+        for (agent, skills) in rows {
+            manifest.agent_skills.insert(
+                (*agent).to_owned(),
+                skills.iter().map(|s| (*s).to_owned()).collect(),
+            );
+        }
+        manifest
+    }
+
     #[test]
     #[allow(clippy::unwrap_used)]
     fn reads_each_agents_recorded_assignment() {
@@ -269,12 +327,12 @@ mod tests {
             // other kind is not an assignment and is not reported as one.
             entry(ItemKind::Skill, "dev", Some(&["worktree"])),
         ]);
-        let map = automatic_skills(&env, &scope).unwrap();
+        let automatic = agent_skill_facts(&env, &scope, None).unwrap().automatic;
         assert_eq!(
-            map.get("orch").map(Vec::as_slice),
+            automatic.get("orch").map(Vec::as_slice),
             Some(&["dev".to_owned(), "github".to_owned()][..])
         );
-        assert!(!map.contains_key("dev"));
+        assert!(!automatic.contains_key("dev"));
     }
 
     // An agent with nothing recorded is absent, not empty: the editor
@@ -284,11 +342,8 @@ mod tests {
     #[allow(clippy::unwrap_used)]
     fn leaves_an_unrecorded_agent_out_rather_than_calling_it_empty() {
         let (_tmp, env, scope) = scope_with(vec![entry(ItemKind::Agent, "scout", None)]);
-        assert!(
-            !automatic_skills(&env, &scope)
-                .unwrap()
-                .contains_key("scout")
-        );
+        let automatic = agent_skill_facts(&env, &scope, None).unwrap().automatic;
+        assert!(!automatic.contains_key("scout"));
     }
 
     #[test]
@@ -299,6 +354,33 @@ mod tests {
         let root = tmp.path().join("dev/app");
         std::fs::create_dir_all(&root).unwrap();
         let scope = Scope::Project { root };
-        assert!(automatic_skills(&env, &scope).unwrap().is_empty());
+        let facts = agent_skill_facts(&env, &scope, None).unwrap();
+        assert!(facts.automatic.is_empty() && facts.declared.is_empty());
+    }
+
+    // The UI is told which entry each agent reads and where it lives, so
+    // it never has to know that a reviewer agent inherits.
+    #[test]
+    #[allow(clippy::unwrap_used)]
+    fn resolves_the_entry_each_agent_reads() {
+        let (_tmp, env, scope) = scope_with(vec![
+            entry(ItemKind::Agent, "reviewer-rust", None),
+            entry(ItemKind::Agent, "orch", None),
+            entry(ItemKind::Agent, "scout", None),
+        ]);
+        let manifest = manifest_with(&[("rust", &["worktree"]), ("orch", &["dev"])]);
+        let declared = agent_skill_facts(&env, &scope, Some(&manifest))
+            .unwrap()
+            .declared;
+
+        let inherited = declared.get("reviewer-rust").unwrap();
+        assert_eq!(inherited.skills, vec!["worktree".to_owned()]);
+        assert_eq!(inherited.under, "rust");
+
+        let own = declared.get("orch").unwrap();
+        assert_eq!(own.under, "orch");
+
+        // No entry reaches this one at all.
+        assert!(!declared.contains_key("scout"));
     }
 }

--- a/crates/app/src/editor.rs
+++ b/crates/app/src/editor.rs
@@ -24,6 +24,12 @@ pub struct EditorInventory {
     pub declared_agents: Vec<String>,
     pub declared_skills: Vec<String>,
     pub available_skills: Vec<String>,
+    /// What each agent gets while nothing is chosen for it, by agent name.
+    /// Read from the lock rather than recomputed: the question the editor
+    /// asks is what this agent has, and a fresh computation would answer
+    /// with an assignment no apply has written. An agent absent here has
+    /// no recorded assignment — which is not the same as having none.
+    pub automatic_skills: std::collections::BTreeMap<String, Vec<String>>,
     pub harnesses: Vec<HarnessId>,
     /// The events a hook can be written against, and when each fires. Sent
     /// rather than spelled out in the UI so the picker cannot offer an
@@ -114,6 +120,31 @@ pub fn custom_hook_deliveries(
         .collect())
 }
 
+/// Every agent's recorded upstream assignment in one scope. A read-only
+/// lookup, so a v1 lock degrades to "nothing recorded" like the rest of the
+/// read surface instead of taking the editor's inventory down with it.
+fn automatic_skills(
+    env: &Env,
+    scope: &Scope,
+) -> Result<std::collections::BTreeMap<String, Vec<String>>, String> {
+    let lock = match kendex_core::lock::load_file(&kendex_core::lock::lock_path(env, scope))
+        .map_err(|e| e.to_string())?
+    {
+        kendex_core::lock::LockFile::Current(lock) => lock,
+        kendex_core::lock::LockFile::Absent | kendex_core::lock::LockFile::Legacy { .. } => {
+            return Ok(std::collections::BTreeMap::new());
+        }
+    };
+    Ok(lock
+        .entries
+        .into_values()
+        .filter(|entry| entry.kind == ItemKind::Agent)
+        // One row per harness, all carrying the same assignment: the name
+        // is the key the editor asks by, and the rows agree on it.
+        .filter_map(|entry| Some((entry.name, entry.upstream_skills?)))
+        .collect())
+}
+
 #[tauri::command(async)]
 #[specta::specta]
 pub fn editor_inventory(scope: Scope) -> Result<EditorInventory, String> {
@@ -124,6 +155,7 @@ pub fn editor_inventory(scope: Scope) -> Result<EditorInventory, String> {
         declared_agents: Vec::new(),
         declared_skills: Vec::new(),
         available_skills: Vec::new(),
+        automatic_skills: automatic_skills(&env, &scope)?,
         // Per-harness settings are only offered for harnesses kendex
         // writes to.
         harnesses: HarnessId::ALL
@@ -182,4 +214,91 @@ pub fn item_source(
     harness: HarnessId,
 ) -> Result<ItemSource, String> {
     engine::item_source(&env()?, &scope, kind, &name, harness).map_err(|e| e.to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use kendex_core::env::FakeOs;
+    use kendex_core::lock::{Lock, LockEntry, entry_key, lock_path, save};
+
+    fn entry(kind: ItemKind, name: &str, upstream_skills: Option<&[&str]>) -> LockEntry {
+        LockEntry {
+            name: name.to_owned(),
+            kind,
+            harness: HarnessId::Claude,
+            source: "kendex".to_owned(),
+            source_repo: "o/r".to_owned(),
+            method: kendex_core::manifest::Method::Copy,
+            installed_at: "2026-01-01T00:00:00Z".to_owned(),
+            source_hash: "x".to_owned(),
+            source_commit: None,
+            rendered_hash: None,
+            enabled: true,
+            upstream_skills: upstream_skills
+                .map(|list| list.iter().map(|s| (*s).to_owned()).collect()),
+            emitted: None,
+            registration: None,
+            left_pi_reserved_name: false,
+            reasons: std::collections::BTreeSet::from([kendex_core::lock::Reason::Requested]),
+        }
+    }
+
+    #[allow(clippy::unwrap_used)]
+    fn scope_with(entries: Vec<LockEntry>) -> (tempfile::TempDir, Env, Scope) {
+        let tmp = tempfile::tempdir().unwrap();
+        let env = Env::fake(tmp.path(), FakeOs::Linux);
+        let root = tmp.path().join("dev/app");
+        std::fs::create_dir_all(&root).unwrap();
+        let scope = Scope::Project { root };
+        let mut lock = Lock::default();
+        for entry in entries {
+            lock.entries
+                .insert(entry_key(entry.kind, &entry.name, entry.harness), entry);
+        }
+        save(&lock_path(&env, &scope), &lock).unwrap();
+        (tmp, env, scope)
+    }
+
+    #[test]
+    #[allow(clippy::unwrap_used)]
+    fn reads_each_agents_recorded_assignment() {
+        let (_tmp, env, scope) = scope_with(vec![
+            entry(ItemKind::Agent, "orch", Some(&["dev", "github"])),
+            // Only an agent is assigned skills. A list recorded under any
+            // other kind is not an assignment and is not reported as one.
+            entry(ItemKind::Skill, "dev", Some(&["worktree"])),
+        ]);
+        let map = automatic_skills(&env, &scope).unwrap();
+        assert_eq!(
+            map.get("orch").map(Vec::as_slice),
+            Some(&["dev".to_owned(), "github".to_owned()][..])
+        );
+        assert!(!map.contains_key("dev"));
+    }
+
+    // An agent with nothing recorded is absent, not empty: the editor
+    // prints "the catalog gives this agent no skills" for an empty list,
+    // and an unrecorded assignment is a different fact from that one.
+    #[test]
+    #[allow(clippy::unwrap_used)]
+    fn leaves_an_unrecorded_agent_out_rather_than_calling_it_empty() {
+        let (_tmp, env, scope) = scope_with(vec![entry(ItemKind::Agent, "scout", None)]);
+        assert!(
+            !automatic_skills(&env, &scope)
+                .unwrap()
+                .contains_key("scout")
+        );
+    }
+
+    #[test]
+    #[allow(clippy::unwrap_used)]
+    fn answers_with_nothing_where_the_scope_has_no_lock() {
+        let tmp = tempfile::tempdir().unwrap();
+        let env = Env::fake(tmp.path(), FakeOs::Linux);
+        let root = tmp.path().join("dev/app");
+        std::fs::create_dir_all(&root).unwrap();
+        let scope = Scope::Project { root };
+        assert!(automatic_skills(&env, &scope).unwrap().is_empty());
+    }
 }

--- a/crates/app/src/editor.rs
+++ b/crates/app/src/editor.rs
@@ -45,8 +45,9 @@ pub struct EditorInventory {
 
 /// What one scope's lock and manifest say about its agents' skills: the
 /// assignment each got from the catalog, and the `[agent-skills]` entry
-/// each reads. Both keyed by agent name, both off the same pass, so the
-/// two cannot end up keyed by different sets of agents.
+/// each reads. Both are keyed by agent name and filled in one pass, and
+/// an agent is in either only when that question has an answer for it —
+/// so an agent in one may be absent from the other.
 #[derive(Default)]
 struct AgentSkillFacts {
     automatic: std::collections::BTreeMap<String, Vec<String>>,
@@ -151,8 +152,10 @@ pub fn custom_hook_deliveries(
 /// lookup, so a v1 lock degrades to "nothing recorded" like the rest of the
 /// read surface instead of taking the editor's inventory down with it.
 ///
-/// Both answers come off one pass over the lock's agent entries, so the
-/// two maps cannot end up keyed by different sets of agents.
+/// Both answers come off one pass over the lock's agent entries. Presence
+/// in each is its own question: an agent lands in `automatic` only with a
+/// recorded assignment, and in `declared` only where an entry resolves, so
+/// neither map's keys are the other's.
 fn agent_skill_facts(
     env: &Env,
     scope: &Scope,

--- a/crates/core/src/engine/agent_carry.rs
+++ b/crates/core/src/engine/agent_carry.rs
@@ -190,7 +190,7 @@ fn carry_skills(manifest: &mut Manifest, from: &str, to: &str, gone: bool) {
         carry(&mut manifest.agent_skills, from, to, gone);
         return;
     }
-    let inherited = crate::engine::agent_skills::declared_skills(manifest, from).cloned();
+    let inherited = crate::mapping::declared_skills(manifest, from).map(|(list, _)| list.clone());
     if let Some(skills) = inherited {
         manifest.agent_skills.insert(to.to_owned(), skills);
     }
@@ -265,8 +265,8 @@ pub(crate) fn configured_as(manifest: &Manifest, from: &str, to: &str) -> Option
     // moves what it moves: a name with no row of its own reads the base
     // agent's, and a row written here would shadow the person's — the
     // exact-key question would call that name vacant.
-    let reached = crate::engine::agent_skills::skills_key(manifest, to);
-    if reached.is_some() && reached != crate::engine::agent_skills::skills_key(manifest, from) {
+    let reached = crate::mapping::skills_key(manifest, to);
+    if reached.is_some() && reached != crate::mapping::skills_key(manifest, from) {
         return Some(match manifest.agent_skills.contains_key(to) {
             true => "[agent-skills]",
             false => "[agent-skills], under the base name this one reads",

--- a/crates/core/src/engine/agent_skills.rs
+++ b/crates/core/src/engine/agent_skills.rs
@@ -3,7 +3,7 @@
 
 use crate::lock::entry_key;
 use crate::manifest::Manifest;
-use crate::mapping::{EffectiveSkills, effective_skills};
+use crate::mapping::{EffectiveSkills, effective_skills, skills_key};
 use crate::model::ItemKind;
 use crate::render::agent::Role;
 use crate::source::list_items;
@@ -45,10 +45,13 @@ pub(super) fn assigned_skills(
     if skills.manifest_additions.is_empty() {
         return skills;
     }
-    let entry = updated_manifest
-        .agent_skills
-        .entry(merge_key(ctx.manifest, ctx.name))
-        .or_default();
+    // The key the effective list was read from. Writing additions anywhere
+    // else creates an entry that shadows the one being read, and the
+    // shadowed skills silently vanish from the next rendering.
+    let key = skills_key(ctx.manifest, ctx.name)
+        .unwrap_or(ctx.name)
+        .to_owned();
+    let entry = updated_manifest.agent_skills.entry(key).or_default();
     for skill in &skills.manifest_additions {
         if !entry.contains(skill) {
             entry.push(skill.clone());
@@ -56,41 +59,4 @@ pub(super) fn assigned_skills(
     }
     *manifest_changed = true;
     skills
-}
-
-/// The `agent_skills` key the effective list was read from. Writing
-/// additions anywhere else creates an entry that shadows the one being read,
-/// and the shadowed skills silently vanish from the next rendering.
-fn merge_key(manifest: &Manifest, name: &str) -> String {
-    if manifest.agent_skills.contains_key(name) {
-        return name.to_owned();
-    }
-    let stripped = crate::mapping::skill_match_prefix(name);
-    match manifest.agent_skills.contains_key(stripped) {
-        true => stripped.to_owned(),
-        false => name.to_owned(),
-    }
-}
-
-/// Which `[agent-skills]` key this agent's assignment is written under —
-/// its own name, or the base name a reviewer agent falls back to — and
-/// `None` where neither holds a row. Asked for the key rather than the
-/// value, a caller can tell a row the agent owns from one it only reaches,
-/// which is the difference between shadowing someone's assignment and
-/// moving the agent's own.
-pub(super) fn skills_key<'a>(manifest: &'a Manifest, name: &str) -> Option<&'a str> {
-    let base = crate::mapping::skill_match_prefix(name);
-    manifest
-        .agent_skills
-        .get_key_value(name)
-        .or_else(|| manifest.agent_skills.get_key_value(base))
-        .map(|(key, _)| key.as_str())
-}
-
-/// The `[agent-skills]` entry this agent reads, at the key above. Asking
-/// for the exact name alone would call a real assignment absent and render
-/// the upstream list over the top of it, which is the removal the person
-/// made coming back.
-pub(super) fn declared_skills<'a>(manifest: &'a Manifest, name: &str) -> Option<&'a Vec<String>> {
-    skills_key(manifest, name).and_then(|key| manifest.agent_skills.get(key))
 }

--- a/crates/core/src/engine/desired_agent.rs
+++ b/crates/core/src/engine/desired_agent.rs
@@ -11,7 +11,6 @@ use crate::render::agent::{
 use crate::render::permission::PermissionIntent;
 use crate::render::validate::validate_agent;
 
-use super::agent_skills::declared_skills;
 use super::desired::{Artifact, Desired, DesiredState, ItemCtx, native_dir};
 
 /// The agent as this tool will know it, or `None` where that is the agent

--- a/crates/core/src/engine/desired_agent.rs
+++ b/crates/core/src/engine/desired_agent.rs
@@ -307,7 +307,7 @@ fn from_manifest<'a>(manifest: &'a Manifest, harness: HarnessId, name: &str) -> 
             .agent_frontmatter
             .get(harness.name())
             .and_then(|by_agent| by_agent.get(name)),
-        skills: declared_skills(manifest, name).cloned(),
+        skills: crate::mapping::declared_skills(manifest, name).map(|(list, _)| list.clone()),
         custom_hooks: manifest
             .custom_hooks
             .iter()
@@ -351,7 +351,7 @@ fn gathered<'a>(
         // Still the project's contribution or nothing: with no declaration
         // to read, the source's own assignment is the publisher's and is
         // not folded in here.
-        skills: declared_skills(ctx.manifest, ctx.name).map(|_| effective.to_vec()),
+        skills: crate::mapping::declared_skills(ctx.manifest, ctx.name).map(|_| effective.to_vec()),
         ..from_manifest(ctx.manifest, harness, ctx.name)
     }
 }

--- a/crates/core/src/mapping.rs
+++ b/crates/core/src/mapping.rs
@@ -21,6 +21,24 @@ pub(crate) fn skill_match_prefix(agent_name: &str) -> &str {
     agent_name.strip_prefix("reviewer-").unwrap_or(agent_name)
 }
 
+/// The `[agent-skills]` entry this agent reads and the name it is written
+/// under. A reviewer agent with no entry of its own reads its base
+/// agent's, so the two names differ exactly when the entry is inherited.
+///
+/// The one place the lookup lives. Asking for the exact name alone calls a
+/// real assignment absent and renders the upstream list over the top of
+/// it, which is the removal the person made coming back.
+pub fn declared_skills<'a>(
+    manifest: &'a Manifest,
+    agent_name: &'a str,
+) -> Option<(&'a Vec<String>, &'a str)> {
+    if let Some(own) = manifest.agent_skills.get(agent_name) {
+        return Some((own, agent_name));
+    }
+    let base = skill_match_prefix(agent_name);
+    manifest.agent_skills.get(base).map(|list| (list, base))
+}
+
 fn prefixed_matches(agent_name: &str, available: &[String]) -> Vec<String> {
     let name = agent_name.to_lowercase();
     let prefix = skill_match_prefix(&name);
@@ -101,12 +119,7 @@ pub fn effective_skills(
     recorded_upstream: Option<&[String]>,
 ) -> EffectiveSkills {
     let upstream_now = upstream_skills(agent_name, role, source, available);
-    let stripped = skill_match_prefix(agent_name);
-    let declared = manifest
-        .agent_skills
-        .get(agent_name)
-        .or_else(|| manifest.agent_skills.get(stripped));
-    let Some(declared) = declared else {
+    let Some((declared, _)) = declared_skills(manifest, agent_name) else {
         return EffectiveSkills {
             effective: upstream_now.clone(),
             upstream_now,

--- a/crates/core/src/mapping.rs
+++ b/crates/core/src/mapping.rs
@@ -21,22 +21,33 @@ pub(crate) fn skill_match_prefix(agent_name: &str) -> &str {
     agent_name.strip_prefix("reviewer-").unwrap_or(agent_name)
 }
 
-/// The `[agent-skills]` entry this agent reads and the name it is written
+/// The `[agent-skills]` entry this agent reads, and the key it is written
 /// under. A reviewer agent with no entry of its own reads its base
-/// agent's, so the two names differ exactly when the entry is inherited.
+/// agent's, so the key differs from the name exactly when the entry is
+/// inherited.
 ///
-/// The one place the lookup lives. Asking for the exact name alone calls a
-/// real assignment absent and renders the upstream list over the top of
-/// it, which is the removal the person made coming back.
+/// Both halves from one answer, and the only place the rule is spelled.
+/// Asking for the exact name alone calls a real assignment absent and
+/// renders the upstream list over the top of it, which is the removal the
+/// person made coming back. Asking for the key alone loses the difference
+/// between a row an agent owns and one it only reaches — which is the
+/// difference between moving the agent's own assignment and shadowing
+/// somebody else's.
 pub fn declared_skills<'a>(
     manifest: &'a Manifest,
-    agent_name: &'a str,
+    agent_name: &str,
 ) -> Option<(&'a Vec<String>, &'a str)> {
-    if let Some(own) = manifest.agent_skills.get(agent_name) {
-        return Some((own, agent_name));
-    }
     let base = skill_match_prefix(agent_name);
-    manifest.agent_skills.get(base).map(|list| (list, base))
+    manifest
+        .agent_skills
+        .get_key_value(agent_name)
+        .or_else(|| manifest.agent_skills.get_key_value(base))
+        .map(|(key, list)| (list, key.as_str()))
+}
+
+/// The key alone, for a caller that only has to place a write.
+pub fn skills_key<'a>(manifest: &'a Manifest, agent_name: &str) -> Option<&'a str> {
+    declared_skills(manifest, agent_name).map(|(_, key)| key)
 }
 
 fn prefixed_matches(agent_name: &str, available: &[String]) -> Vec<String> {
@@ -178,6 +189,71 @@ mod tests {
         source.role_skills.insert("engineer".into(), vec![]);
         let skills = upstream_skills("rust", Some(Role::Engineer), &source, &available());
         assert_eq!(skills, ["github"]);
+    }
+
+    fn declaring(rows: &[(&str, &[&str])]) -> Manifest {
+        let mut manifest = Manifest {
+            schema: MANIFEST_SCHEMA,
+            ..Manifest::default()
+        };
+        for (agent, skills) in rows {
+            manifest.agent_skills.insert(
+                (*agent).to_owned(),
+                skills.iter().map(|s| (*s).to_owned()).collect(),
+            );
+        }
+        manifest
+    }
+
+    // One answer carries both halves. A caller that had only the list
+    // could not tell a row an agent owns from one it reaches, and a
+    // caller that had only the key would look the list up again — which
+    // is how the same rule came to be spelled in three places.
+    #[test]
+    fn one_lookup_answers_with_the_entry_and_the_key_it_is_under() {
+        let manifest = declaring(&[("rust", &["dev"]), ("orch", &["github"])]);
+
+        let (skills, key) = declared_skills(&manifest, "reviewer-rust").unwrap();
+        assert_eq!(skills, &["dev".to_owned()]);
+        assert_eq!(key, "rust");
+
+        let (_, own) = declared_skills(&manifest, "orch").unwrap();
+        assert_eq!(own, "orch");
+
+        // Only `reviewer-` reaches a base agent, and a name nothing
+        // declares for reaches nothing.
+        assert!(declared_skills(&manifest, "planner-rust").is_none());
+        assert!(declared_skills(&manifest, "scout").is_none());
+    }
+
+    // The key alone drops a half off the same answer rather than asking
+    // the question a second way.
+    #[test]
+    fn the_key_is_the_same_answer_without_its_list() {
+        let manifest = declaring(&[("rust", &["dev"])]);
+        for name in ["rust", "reviewer-rust", "scout"] {
+            assert_eq!(
+                skills_key(&manifest, name),
+                declared_skills(&manifest, name).map(|(_, key)| key),
+            );
+        }
+    }
+
+    // An agent that reaches its base agent's row renders from that row:
+    // the exact-name question would call it undeclared and put the
+    // upstream list back over the person's removals.
+    #[test]
+    fn a_reviewer_agent_renders_from_the_row_it_reaches() {
+        let manifest = declaring(&[("rust", &["dev"])]);
+        let result = effective_skills(
+            "reviewer-rust",
+            Some(Role::Reviewer),
+            &manifest,
+            &SourceConfig::default(),
+            &available(),
+            None,
+        );
+        assert_eq!(result.effective, ["dev"]);
     }
 
     #[test]

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -211,8 +211,8 @@ lives in one capability table read by core and UI.
   (`HarnessId` in core, "Harnesses" in the sidebar). Never "tool" on screen.
 - Hue carries exactly one meaning: **which harness** (`--tool-*`, one per
   harness). Status keeps the semantic tokens; item kinds are told apart by
-  icon. One exception: a Library row's kind icon takes `--customized` when
-  the package is changed, and the table prints the key above itself.
+  icon. One exception: a kind icon takes `--customized` where the package
+  is changed, on a Library row and on its own page; the table prints the key.
 - In a table, a harness is its mark (logo + hue), name on hover and for
   screen readers. Where a tool is stated once — a package's own details —
   the name is written out.
@@ -259,12 +259,12 @@ lives in one capability table read by core and UI.
   `lib/customization.ts` slices that draft per package.
 - A place is customized by settings, a hand edit, or a fork, and
   `lib/customized-places.ts::placeStandings` is the one answer, over a
-  `PlacesSource` that only `placesSource` builds. Its three readers: the
-  Library row's mark (`lib/library-standings.ts`), the package header's
-  (`lib/package-mark.ts`), and the Customize index (`lib/customized-here.ts`),
-  which reads the open draft for its place and says nothing is customized
-  only once the update read has landed (`lib/updates-read-state.ts`:
-  pending says it is checking, failed that packages may be missing).
+  `PlacesSource` that only `placesSource` builds. Its readers are what
+  `grep -rn placeStandings ui/src` finds, the Customize index
+  (`lib/customized-here.ts`) among them: it reads the open draft for its
+  place and says nothing is customized only once the update read has
+  landed (`lib/updates-read-state.ts`: pending says it is checking, failed
+  that packages may be missing).
 - Hook events have one vocabulary — Claude Code's names, in
   `core/hook.rs::EVENTS`; every other harness's map is keyed by it. The
   picker offers that list, the validator rejects anything outside it, the renderers read it.

--- a/ui/src/bindings.ts
+++ b/ui/src/bindings.ts
@@ -913,6 +913,17 @@ export type DeclaredEffects = {
 	root: string,
 } & RepoEffects;
 
+/**
+ *  One agent's skill declaration and the agent it is written under. The
+ *  two names are the same for an entry an agent owns, and differ for one
+ *  it inherits — which is the difference between a list this page edits
+ *  and a list it only reports.
+ */
+export type DeclaredSkillRow = {
+	skills: string[],
+	under: string,
+};
+
 /**  One rule firing once, and what it cost. */
 export type Deduction = {
 	rule: string,
@@ -1119,6 +1130,14 @@ export type EditorInventory = {
 	 *  no recorded assignment — which is not the same as having none.
 	 */
 	automaticSkills: { [key in string]: string[] },
+	/**
+	 *  The `[agent-skills]` entry each installed agent reads, by agent
+	 *  name, resolved by the engine — a reviewer agent with no entry of
+	 *  its own reads its base agent's. Sent resolved so the UI never has
+	 *  to know which agents inherit from which; an agent absent here has
+	 *  no entry reaching it at all.
+	 */
+	declaredSkillRows: { [key in string]: DeclaredSkillRow },
 	harnesses: HarnessId[],
 	/**
 	 *  The events a hook can be written against, and when each fires. Sent

--- a/ui/src/bindings.ts
+++ b/ui/src/bindings.ts
@@ -1111,6 +1111,14 @@ export type EditorInventory = {
 	declaredAgents: string[],
 	declaredSkills: string[],
 	availableSkills: string[],
+	/**
+	 *  What each agent gets while nothing is chosen for it, by agent name.
+	 *  Read from the lock rather than recomputed: the question the editor
+	 *  asks is what this agent has, and a fresh computation would answer
+	 *  with an assignment no apply has written. An agent absent here has
+	 *  no recorded assignment — which is not the same as having none.
+	 */
+	automaticSkills: { [key in string]: string[] },
 	harnesses: HarnessId[],
 	/**
 	 *  The events a hook can be written against, and when each fires. Sent

--- a/ui/src/components/customize/controls.tsx
+++ b/ui/src/components/customize/controls.tsx
@@ -1,4 +1,5 @@
 import { type ReactNode, useEffect, useState } from "react";
+import { StatusDot } from "@/components/status-dot";
 import { Input } from "@/components/ui/input";
 import {
   Select,
@@ -7,17 +8,39 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@/components/ui/select";
+import { CUSTOMIZED_MARK } from "@/lib/copy-customize";
+import { cn } from "@/lib/utils";
 
 export function Field({
   label,
+  set = false,
   children,
 }: {
   label: string;
+  /** This field holds a value of the reader's. Marked on the label, not
+   *  in the box: every box carries a placeholder example, so a place
+   *  customized only through Settings otherwise reads as untouched until
+   *  someone compares the grid field by field against the examples. */
+  set?: boolean;
   children: ReactNode;
 }) {
   return (
     <div className="space-y-1">
-      <p className="text-xs text-muted-foreground">{label}</p>
+      <p
+        className={cn(
+          "flex items-center gap-1.5 text-xs",
+          set ? "text-customized" : "text-muted-foreground",
+        )}
+      >
+        {label}
+        {set ? (
+          <>
+            <StatusDot tone="customized" className="size-1.5" />
+            {/* Colour is never the only carrier of the fact. */}
+            <span className="sr-only">{CUSTOMIZED_MARK}</span>
+          </>
+        ) : null}
+      </p>
       {children}
     </div>
   );

--- a/ui/src/components/customize/frontmatter-fields.test.tsx
+++ b/ui/src/components/customize/frontmatter-fields.test.tsx
@@ -1,0 +1,44 @@
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, it } from "vitest";
+import { FrontmatterFields } from "@/components/customize/frontmatter-fields";
+import { CUSTOMIZED_MARK } from "@/lib/copy-customize";
+import type { DraftFrontmatter } from "@/lib/editor-draft";
+
+const render = (overrides: Partial<DraftFrontmatter>) =>
+  renderToStaticMarkup(
+    <FrontmatterFields
+      overrides={overrides as DraftFrontmatter}
+      onSet={() => {}}
+    />,
+  );
+
+// Every box in this grid carries a placeholder example. Read as values,
+// they make a place customized only through Settings look untouched —
+// which is how a real customization got reported as the app failing to
+// load the manifest holding it.
+describe("a field holding a value of the reader's", () => {
+  it("says so on its label, in words as well as in colour", () => {
+    const shown = render({ effort: "xhigh" });
+    expect(shown).toContain("text-customized");
+    expect(shown).toContain(CUSTOMIZED_MARK);
+  });
+
+  it("marks nothing where the grid is all examples", () => {
+    const shown = render({});
+    expect(shown).not.toContain("text-customized");
+    expect(shown).not.toContain(CUSTOMIZED_MARK);
+  });
+
+  // A placeholder is still on screen for an unset field; the mark is what
+  // tells the two apart, so it must not follow the placeholder.
+  it("leaves a field showing only its example unmarked", () => {
+    const shown = render({ effort: "xhigh" });
+    expect(shown).toContain('placeholder="opus"');
+    expect(shown.match(/text-customized/g)).toHaveLength(1);
+  });
+
+  it("marks a list and a flag the same way it marks text", () => {
+    expect(render({ "allow-tools": ["Read"] })).toContain(CUSTOMIZED_MARK);
+    expect(render({ pane: true })).toContain(CUSTOMIZED_MARK);
+  });
+});

--- a/ui/src/components/customize/frontmatter-fields.tsx
+++ b/ui/src/components/customize/frontmatter-fields.tsx
@@ -12,7 +12,8 @@ import {
 
 // The manifest key is what a hand-written kendex.toml uses; the label is
 // what a reader sees. A list field says what a list looks like in its
-// placeholder rather than in a parenthesis after its name.
+// placeholder rather than in a parenthesis after its name — an example,
+// never a value, which is why a field holding one says so on its label.
 const TEXT_FIELDS = [
   ["model", "Model", "opus"],
   ["effort", "Effort", "high"],
@@ -52,7 +53,7 @@ export function FrontmatterFields({
   return (
     <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-3">
       {TEXT_FIELDS.map(([field, label, placeholder]) => (
-        <Field key={field} label={label}>
+        <Field key={field} label={label} set={overrides[field] != null}>
           <Input
             aria-label={label}
             placeholder={placeholder}
@@ -67,7 +68,7 @@ export function FrontmatterFields({
         </Field>
       ))}
       {LIST_FIELDS.map(([field, label, placeholder]) => (
-        <Field key={field} label={label}>
+        <Field key={field} label={label} set={overrides[field] != null}>
           <CommitInput
             label={label}
             placeholder={placeholder}
@@ -77,7 +78,7 @@ export function FrontmatterFields({
         </Field>
       ))}
       {FLAG_FIELDS.map(([field, label]) => (
-        <Field key={field} label={label}>
+        <Field key={field} label={label} set={overrides[field] != null}>
           <TriStateSelect
             label={label}
             value={overrides[field]}

--- a/ui/src/components/customize/item-customize.dom.test.tsx
+++ b/ui/src/components/customize/item-customize.dom.test.tsx
@@ -12,6 +12,8 @@ const HYPR: Scope = { scope: "project", root: "/work/hyprtrade" };
 
 const empty = { schema: 1, install: {} };
 const withSetting = { ...empty, "skill-instructions": { gh: "mine" } };
+// The row is set on `rust`; `reviewer-rust` only reaches it.
+const baseRow = { ...empty, "agent-skills": { rust: ["worktree"] } };
 
 const rows = [VG, HYPR].map((scope) => ({
   scope,
@@ -137,5 +139,50 @@ describe("the skills a place declares", () => {
       }),
     });
     expect(host.textContent).not.toContain(skillsInherited("rust"));
+  });
+});
+
+// The two questions on this tab, and the rule that keeps them apart: the
+// chip says whether you changed this agent here, the Skills section says
+// what it gets and from where. A row set on another agent is named by the
+// second and not counted by the first.
+describe("an agent whose only row is set on another agent", () => {
+  const agentRows = [VG, HYPR].map((scope) => ({
+    ...(rows[0] as Record<string, unknown>),
+    scope,
+    kind: "agent",
+    name: "reviewer-rust",
+  }));
+
+  it("names the row without marking the place", () => {
+    useUpdatesStore.setState({ rows: agentRows as never, loaded: true });
+    useEditorStore.setState({
+      scope: VG,
+      draft: baseRow as never,
+      saved: {
+        "/work/vg": baseRow as never,
+        "/work/hyprtrade": empty as never,
+      },
+      inventories: {
+        "/work/vg": {
+          availableSkills: [],
+          automaticSkills: {},
+          declaredSkillRows: {
+            "reviewer-rust": { skills: ["worktree"], under: "rust" },
+          },
+          harnesses: ["claude"],
+        } as unknown as EditorInventory,
+      },
+    });
+    const host = mount(
+      <ItemCustomize
+        kind="agent"
+        name="reviewer-rust"
+        scopes={[VG, HYPR]}
+        harnesses={["claude"]}
+      />,
+    );
+    expect(host.textContent).toContain(skillsInherited("rust"));
+    expect(markedPlaces(host)).toEqual([]);
   });
 });

--- a/ui/src/components/customize/item-customize.dom.test.tsx
+++ b/ui/src/components/customize/item-customize.dom.test.tsx
@@ -1,0 +1,81 @@
+// @vitest-environment jsdom
+import { beforeEach, describe, expect, it } from "vitest";
+import type { Scope } from "@/bindings";
+import { ItemCustomize } from "@/components/customize/item-customize";
+import { CUSTOMIZED_MARK } from "@/lib/copy-customize";
+import { useEditorStore } from "@/stores/editor";
+import { useUpdatesStore } from "@/stores/updates";
+import { mount } from "@/test/dom";
+
+const VG: Scope = { scope: "project", root: "/work/vg" };
+const HYPR: Scope = { scope: "project", root: "/work/hyprtrade" };
+
+const empty = { schema: 1, install: {} };
+const withSetting = { ...empty, "skill-instructions": { gh: "mine" } };
+
+const rows = [VG, HYPR].map((scope) => ({
+  scope,
+  kind: "skill",
+  name: "gh",
+  source: "cat",
+  repo: "o/r",
+  repoIdentity: "o/r",
+  current: null,
+  latest: null,
+  updateAvailable: false,
+  pinned: false,
+  holdOwner: null,
+  ignored: false,
+  blockedByLocalEdit: false,
+  editedHarnesses: [],
+  forkableHarness: null,
+  canDiscard: false,
+  forked: false,
+}));
+
+const seed = (saved: Record<string, unknown>) => {
+  useUpdatesStore.setState({ rows: rows as never, loaded: true });
+  useEditorStore.setState({
+    scope: VG,
+    draft: saved["/work/vg"] as never,
+    saved: saved as never,
+  });
+};
+
+const tab = () =>
+  mount(
+    <ItemCustomize
+      kind="skill"
+      name="gh"
+      scopes={[VG, HYPR]}
+      harnesses={["claude"]}
+    />,
+  );
+
+/** The place each chip names, and only the chips carrying the mark. */
+const markedPlaces = (host: HTMLElement) =>
+  [...host.querySelectorAll("button[aria-pressed]")]
+    .map((pill) => pill.textContent ?? "")
+    .filter((text) => text.includes(CUSTOMIZED_MARK))
+    .map((text) => text.replace(CUSTOMIZED_MARK, ""));
+
+// Chips that look alike whatever a place holds make "which of these three
+// is mine" a question you answer by opening each one and reading four
+// sections — and let this tab and the Library row say different things
+// about the same package.
+describe("the place chips", () => {
+  beforeEach(() => {
+    useEditorStore.setState({ saved: {}, draft: null });
+    useUpdatesStore.setState({ rows: [], loaded: false });
+  });
+
+  it("marks the place that holds something and leaves the other plain", () => {
+    seed({ "/work/vg": withSetting, "/work/hyprtrade": empty });
+    expect(markedPlaces(tab())).toEqual(["vg"]);
+  });
+
+  it("marks nothing where no place holds anything", () => {
+    seed({ "/work/vg": empty, "/work/hyprtrade": empty });
+    expect(markedPlaces(tab())).toEqual([]);
+  });
+});

--- a/ui/src/components/customize/item-customize.dom.test.tsx
+++ b/ui/src/components/customize/item-customize.dom.test.tsx
@@ -1,8 +1,8 @@
 // @vitest-environment jsdom
 import { beforeEach, describe, expect, it } from "vitest";
-import type { Scope } from "@/bindings";
+import type { EditorInventory, Scope } from "@/bindings";
 import { ItemCustomize } from "@/components/customize/item-customize";
-import { CUSTOMIZED_MARK } from "@/lib/copy-customize";
+import { CUSTOMIZED_MARK, skillsInherited } from "@/lib/copy-customize";
 import { useEditorStore } from "@/stores/editor";
 import { useUpdatesStore } from "@/stores/updates";
 import { mount } from "@/test/dom";
@@ -77,5 +77,65 @@ describe("the place chips", () => {
   it("marks nothing where no place holds anything", () => {
     seed({ "/work/vg": empty, "/work/hyprtrade": empty });
     expect(markedPlaces(tab())).toEqual([]);
+  });
+});
+
+// Which agents inherit an [agent-skills] row from which is the engine's
+// rule. The tab reads the answer it is handed, keyed to the place it is
+// open at, and knows nothing about how it was reached.
+describe("the skills a place declares", () => {
+  const inventory = (
+    declaredSkillRows: EditorInventory["declaredSkillRows"],
+  ): EditorInventory =>
+    ({
+      declaredAgents: [],
+      declaredSkills: [],
+      availableSkills: ["dev", "worktree"],
+      automaticSkills: { "reviewer-rust": ["dev"] },
+      declaredSkillRows,
+      harnesses: ["claude"],
+      hookEvents: [],
+    }) as unknown as EditorInventory;
+
+  const openAt = (
+    scope: Scope,
+    inventories: Record<string, EditorInventory>,
+  ) => {
+    useUpdatesStore.setState({ rows: [], loaded: true });
+    useEditorStore.setState({
+      scope,
+      draft: empty as never,
+      saved: { "/work/vg": empty as never },
+      inventories,
+    });
+    return mount(
+      <ItemCustomize
+        kind="agent"
+        name="reviewer-rust"
+        scopes={[VG]}
+        harnesses={["claude"]}
+      />,
+    );
+  };
+
+  it("names the row the engine says this agent reads", () => {
+    const host = openAt(VG, {
+      "/work/vg": inventory({
+        "reviewer-rust": { skills: ["worktree"], under: "rust" },
+      }),
+    });
+    expect(host.textContent).toContain(skillsInherited("rust"));
+    expect(host.textContent).toContain("worktree");
+  });
+
+  // The inventory belongs to a place. Read loose, another place's answer
+  // would offer this agent an assignment nobody set here.
+  it("reads no other place's answer", () => {
+    const host = openAt(HYPR, {
+      "/work/vg": inventory({
+        "reviewer-rust": { skills: ["worktree"], under: "rust" },
+      }),
+    });
+    expect(host.textContent).not.toContain(skillsInherited("rust"));
   });
 });

--- a/ui/src/components/customize/item-customize.tsx
+++ b/ui/src/components/customize/item-customize.tsx
@@ -20,11 +20,7 @@ import {
   SKILLS_SECTION,
   WRITTEN_INTO,
 } from "@/lib/copy-customize";
-import {
-  declaredSkillsRow,
-  itemCustomization,
-  sharedCustomization,
-} from "@/lib/customization";
+import { itemCustomization, sharedCustomization } from "@/lib/customization";
 import {
   manifestsForEditing,
   placeStandings,
@@ -33,7 +29,7 @@ import {
 import { setInstruction } from "@/lib/editor-draft";
 import { scopeName } from "@/lib/labels";
 import { scopeKey } from "@/lib/scope";
-import { useEditorStore } from "@/stores/editor";
+import { openInventory, useEditorStore } from "@/stores/editor";
 import { useUpdatesStore } from "@/stores/updates";
 
 /** Everything kendex lets a person change about one installed package,
@@ -51,27 +47,18 @@ export function ItemCustomize({
   scopes: Scope[];
   harnesses: HarnessId[];
 }) {
-  const {
-    scope,
-    draft,
-    saved,
-    inventory,
-    dirty,
-    error,
-    stale,
-    setScope,
-    load,
-    edit,
-  } = useEditorStore();
+  const { scope, draft, saved, dirty, error, stale, setScope, load, edit } =
+    useEditorStore();
+  const inventory = useEditorStore(openInventory);
   const rows = useUpdatesStore((s) => s.rows);
   const updatesLoaded = useUpdatesStore((s) => s.loaded);
 
   const mine = itemCustomization(draft, kind, name);
-  // The row this agent renders with when it has none of its own. The
-  // engine resolves a reviewer agent to its base agent's row, so a screen
-  // that only asked for the exact name named the catalog's list over one
-  // the person wrote.
-  const declared = declaredSkillsRow(draft, name);
+  // The row this agent renders with when it has none of its own, resolved
+  // by the engine and read here already answered: which agents inherit
+  // from which is the engine's rule, and a copy of it here is a copy that
+  // drifts. `under` naming another agent is what makes it inherited.
+  const declared = inventory?.declaredSkillRows[name];
   const inheritedSkills = declared && declared.under !== name ? declared : null;
   const shared = sharedCustomization(draft);
   const tools = (inventory?.harnesses ?? []).filter((id) =>

--- a/ui/src/components/customize/item-customize.tsx
+++ b/ui/src/components/customize/item-customize.tsx
@@ -5,10 +5,12 @@ import { ItemSkills } from "@/components/customize/item-skills";
 import { StaleNote } from "@/components/customize/stale-note";
 import { Pill } from "@/components/pill";
 import { Section } from "@/components/section";
+import { StatusDot } from "@/components/status-dot";
 import { StatusNote } from "@/components/status-note";
 import {
   ADDITIONAL_HELP,
   ADDITIONAL_LABEL,
+  CUSTOMIZED_MARK,
   LAUNCH_HELP,
   LAUNCH_LABEL,
   SAVE_FIRST,
@@ -19,10 +21,16 @@ import {
   WRITTEN_INTO,
 } from "@/lib/copy-customize";
 import { itemCustomization, sharedCustomization } from "@/lib/customization";
+import {
+  manifestsForEditing,
+  placeStandings,
+  placesSource,
+} from "@/lib/customized-places";
 import { setInstruction } from "@/lib/editor-draft";
 import { scopeName } from "@/lib/labels";
 import { scopeKey } from "@/lib/scope";
 import { useEditorStore } from "@/stores/editor";
+import { useUpdatesStore } from "@/stores/updates";
 
 /** Everything kendex lets a person change about one installed package,
  *  on that package's own page. The same manifest the Customize page edits,
@@ -39,13 +47,44 @@ export function ItemCustomize({
   scopes: Scope[];
   harnesses: HarnessId[];
 }) {
-  const { scope, draft, inventory, dirty, error, stale, setScope, load, edit } =
-    useEditorStore();
+  const {
+    scope,
+    draft,
+    saved,
+    inventory,
+    dirty,
+    error,
+    stale,
+    setScope,
+    load,
+    edit,
+  } = useEditorStore();
+  const rows = useUpdatesStore((s) => s.rows);
+  const updatesLoaded = useUpdatesStore((s) => s.loaded);
 
   const mine = itemCustomization(draft, kind, name);
   const shared = sharedCustomization(draft);
   const tools = (inventory?.harnesses ?? []).filter((id) =>
     harnesses.includes(id),
+  );
+  // The chips answer the same question the Library row does, by the same
+  // rule: a tab whose places all look alike makes "which of these three is
+  // mine" a matter of opening each one and reading four sections. The open
+  // draft stands in for its saved manifest, so a change made here marks
+  // its chip before it is saved.
+  const customizedIn = new Set(
+    placeStandings(
+      placesSource(
+        manifestsForEditing(saved, draft, scope),
+        rows,
+        updatesLoaded,
+      ),
+      kind,
+      name,
+      scopes,
+    )
+      .filter((standing) => standing.standing === "customized")
+      .map((standing) => scopeKey(standing.scope)),
   );
 
   return (
@@ -67,6 +106,13 @@ export function ItemCustomize({
               onClick={() => void setScope(where)}
             >
               {scopeName(where)}
+              {customizedIn.has(scopeKey(where)) ? (
+                <>
+                  <StatusDot tone="customized" className="size-1.5" />
+                  {/* Colour is never the only carrier of the fact. */}
+                  <span className="sr-only">{CUSTOMIZED_MARK}</span>
+                </>
+              ) : null}
             </Pill>
           ))}
         </div>

--- a/ui/src/components/customize/item-customize.tsx
+++ b/ui/src/components/customize/item-customize.tsx
@@ -60,6 +60,12 @@ export function ItemCustomize({
   // drifts. `under` naming another agent is what makes it inherited.
   const declared = inventory?.declaredSkillRows[name];
   const inheritedSkills = declared && declared.under !== name ? declared : null;
+  // An inherited row is named here and is not marked above. The chip and
+  // the Library row answer "did you change this agent here?", and nobody
+  // changed this one — the row is set on another agent, and the Remove on
+  // this page writes this agent's name, so a mark here would point at a
+  // change the reader cannot find or undo. This section answers the other
+  // question: what the agent gets, and which agent it is set on.
   const shared = sharedCustomization(draft);
   const tools = (inventory?.harnesses ?? []).filter((id) =>
     harnesses.includes(id),

--- a/ui/src/components/customize/item-customize.tsx
+++ b/ui/src/components/customize/item-customize.tsx
@@ -20,7 +20,11 @@ import {
   SKILLS_SECTION,
   WRITTEN_INTO,
 } from "@/lib/copy-customize";
-import { itemCustomization, sharedCustomization } from "@/lib/customization";
+import {
+  declaredSkillsRow,
+  itemCustomization,
+  sharedCustomization,
+} from "@/lib/customization";
 import {
   manifestsForEditing,
   placeStandings,
@@ -63,6 +67,12 @@ export function ItemCustomize({
   const updatesLoaded = useUpdatesStore((s) => s.loaded);
 
   const mine = itemCustomization(draft, kind, name);
+  // The row this agent renders with when it has none of its own. The
+  // engine resolves a reviewer agent to its base agent's row, so a screen
+  // that only asked for the exact name named the catalog's list over one
+  // the person wrote.
+  const declared = declaredSkillsRow(draft, name);
+  const inheritedSkills = declared && declared.under !== name ? declared : null;
   const shared = sharedCustomization(draft);
   const tools = (inventory?.harnesses ?? []).filter((id) =>
     harnesses.includes(id),
@@ -175,6 +185,7 @@ export function ItemCustomize({
             <ItemSkills
               agent={name}
               chosen={mine.skills}
+              inherited={inheritedSkills}
               inventory={inventory}
               onChange={edit}
             />

--- a/ui/src/components/customize/item-skills.test.tsx
+++ b/ui/src/components/customize/item-skills.test.tsx
@@ -17,6 +17,7 @@ const inventory = (
     declaredSkills: [],
     availableSkills: ["dev", "github", "worktree"],
     automaticSkills,
+    declaredSkillRows: {},
     harnesses: ["claude"],
     hookEvents: [],
   }) as unknown as EditorInventory;

--- a/ui/src/components/customize/item-skills.test.tsx
+++ b/ui/src/components/customize/item-skills.test.tsx
@@ -27,13 +27,20 @@ const render = (
   automaticSkills: Record<string, string[]>,
   inherited: { skills: string[]; under: string } | null = null,
   agent = "orch",
+) => withInventory(inventory(automaticSkills), chosen, inherited, agent);
+
+const withInventory = (
+  held: EditorInventory | null,
+  chosen: string[] | null,
+  inherited: { skills: string[]; under: string } | null = null,
+  agent = "orch",
 ) =>
   renderToStaticMarkup(
     <ItemSkills
       agent={agent}
       chosen={chosen}
       inherited={inherited}
-      inventory={inventory(automaticSkills)}
+      inventory={held}
       onChange={() => {}}
     />,
   );
@@ -97,5 +104,23 @@ describe("a row this agent inherits", () => {
     const shown = render(["dev"], {}, inherited, "reviewer-rust");
     expect(shown).toContain("Remove dev");
     expect(shown).not.toContain(skillsInherited("rust"));
+  });
+});
+
+// The editor drops a place's inventory when its read fails, so "no entry
+// for this agent" and "no inventory at all" both arrive as undefined.
+// Only the first is a fact about the agent.
+describe("a place whose inventory was not read", () => {
+  it("makes no claim about what the agent gets", () => {
+    const shown = withInventory(null, null);
+    expect(shown).not.toContain(SKILLS_AUTOMATIC_UNRECORDED);
+    expect(shown).not.toContain(SKILLS_AUTOMATIC_NONE);
+    expect(shown).not.toContain(SKILLS_AUTOMATIC);
+  });
+
+  // The claim is still made where an inventory was read and holds nothing
+  // for this agent — that is a fact, and dropping it would lose it.
+  it("still says so where the inventory was read and has no entry", () => {
+    expect(render(null, {})).toContain(SKILLS_AUTOMATIC_UNRECORDED);
   });
 });

--- a/ui/src/components/customize/item-skills.test.tsx
+++ b/ui/src/components/customize/item-skills.test.tsx
@@ -1,0 +1,63 @@
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, it } from "vitest";
+import type { EditorInventory } from "@/bindings";
+import { ItemSkills } from "@/components/customize/item-skills";
+import {
+  SKILLS_AUTOMATIC,
+  SKILLS_AUTOMATIC_NONE,
+  SKILLS_AUTOMATIC_UNRECORDED,
+} from "@/lib/copy-customize";
+
+const inventory = (
+  automaticSkills: Record<string, string[]>,
+): EditorInventory =>
+  ({
+    declaredAgents: [],
+    declaredSkills: [],
+    availableSkills: ["dev", "github", "worktree"],
+    automaticSkills,
+    harnesses: ["claude"],
+    hookEvents: [],
+  }) as unknown as EditorInventory;
+
+const render = (
+  chosen: string[] | null,
+  automaticSkills: Record<string, string[]>,
+) =>
+  renderToStaticMarkup(
+    <ItemSkills
+      agent="orch"
+      chosen={chosen}
+      inventory={inventory(automaticSkills)}
+      onChange={() => {}}
+    />,
+  );
+
+// An automatic list drawn as an empty box reads as "this agent has no
+// skills", which is a different claim from the one the section is making.
+describe("the automatic state", () => {
+  it("names the skills the catalog gives the agent", () => {
+    const shown = render(null, { orch: ["dev", "github"] });
+    expect(shown).toContain(SKILLS_AUTOMATIC);
+    expect(shown).toContain("dev");
+    expect(shown).toContain("github");
+  });
+
+  it("offers no Remove on a list that is not the reader's", () => {
+    expect(render(null, { orch: ["dev"] })).not.toContain("Remove dev");
+    expect(render(["dev"], {})).toContain("Remove dev");
+  });
+
+  it("says so plainly where the catalog assigns nothing", () => {
+    const shown = render(null, { orch: [] });
+    expect(shown).toContain(SKILLS_AUTOMATIC_NONE);
+  });
+
+  // Nothing recorded is not the same fact as nothing assigned, and the
+  // section may not print the second over the first.
+  it("keeps an unrecorded assignment apart from an empty one", () => {
+    const shown = render(null, {});
+    expect(shown).toContain(SKILLS_AUTOMATIC_UNRECORDED);
+    expect(shown).not.toContain(SKILLS_AUTOMATIC_NONE);
+  });
+});

--- a/ui/src/components/customize/item-skills.test.tsx
+++ b/ui/src/components/customize/item-skills.test.tsx
@@ -6,6 +6,7 @@ import {
   SKILLS_AUTOMATIC,
   SKILLS_AUTOMATIC_NONE,
   SKILLS_AUTOMATIC_UNRECORDED,
+  skillsInherited,
 } from "@/lib/copy-customize";
 
 const inventory = (
@@ -23,11 +24,14 @@ const inventory = (
 const render = (
   chosen: string[] | null,
   automaticSkills: Record<string, string[]>,
+  inherited: { skills: string[]; under: string } | null = null,
+  agent = "orch",
 ) =>
   renderToStaticMarkup(
     <ItemSkills
-      agent="orch"
+      agent={agent}
       chosen={chosen}
+      inherited={inherited}
       inventory={inventory(automaticSkills)}
       onChange={() => {}}
     />,
@@ -59,5 +63,38 @@ describe("the automatic state", () => {
     const shown = render(null, {});
     expect(shown).toContain(SKILLS_AUTOMATIC_UNRECORDED);
     expect(shown).not.toContain(SKILLS_AUTOMATIC_NONE);
+  });
+});
+
+// A reviewer agent with no row of its own renders the row set on its base
+// agent. Naming the catalog's list there says the agent gets skills it
+// does not get, over a list the person wrote by hand.
+describe("a row this agent inherits", () => {
+  const inherited = { skills: ["worktree"], under: "rust" };
+
+  it("names the inherited list, not the catalog's", () => {
+    const shown = render(
+      null,
+      { "reviewer-rust": ["dev"] },
+      inherited,
+      "reviewer-rust",
+    );
+    expect(shown).toContain("worktree");
+    expect(shown).not.toContain(">dev<");
+    expect(shown).toContain(skillsInherited("rust"));
+    expect(shown).not.toContain(SKILLS_AUTOMATIC);
+  });
+
+  // The row lives under another agent, and the controls here write this
+  // agent's own. An X that silently changed nothing is worse than none.
+  it("offers no Remove on a row that is not this agent's", () => {
+    const shown = render(null, {}, inherited, "reviewer-rust");
+    expect(shown).not.toContain("Remove worktree");
+  });
+
+  it("prefers this agent's own row when it has one", () => {
+    const shown = render(["dev"], {}, inherited, "reviewer-rust");
+    expect(shown).toContain("Remove dev");
+    expect(shown).not.toContain(skillsInherited("rust"));
   });
 });

--- a/ui/src/components/customize/item-skills.tsx
+++ b/ui/src/components/customize/item-skills.tsx
@@ -44,7 +44,8 @@ export function ItemSkills({
 }) {
   // What the catalog gave this agent, so the automatic state names the
   // skills instead of leaving an empty box that reads as "none".
-  // Undefined is "nothing recorded here", which is not "none".
+  // Undefined is "nothing recorded here", which is not "none" — and only
+  // an inventory that was read can say even that.
   const automatic = inventory?.automaticSkills[agent];
   const shown = chosen ?? inherited?.skills ?? automatic ?? [];
   const known = [
@@ -59,11 +60,15 @@ export function ItemSkills({
   // picking one the catalog already assigns is how a declaration that
   // keeps it starts.
   const unchosen = known.filter((skill) => !(chosen ?? []).includes(skill));
-  const note = chosen ? SKILLS_CHOSEN : notChosen(inherited, automatic);
+  const note = chosen
+    ? SKILLS_CHOSEN
+    : notChosen(inventory, inherited, automatic);
 
   return (
     <div className="flex flex-col gap-3">
-      <p className="text-[13px] text-muted-foreground">{note}</p>
+      {note ? (
+        <p className="text-[13px] text-muted-foreground">{note}</p>
+      ) : null}
       {shown.length > 0 ? (
         <div className="flex flex-wrap gap-1.5">
           {shown.map((skill) => (
@@ -121,11 +126,19 @@ export function ItemSkills({
 
 /** What the section says when this agent has no row of its own: the list
  *  it inherits, the catalog's, or that nothing is recorded here — three
- *  answers, and none of them may be printed over another. */
+ *  answers, and none of them may be printed over another.
+ *
+ *  Null is a fourth: with no inventory read for this place there is
+ *  nothing to say, and "nothing is recorded" would be saying it. The
+ *  editor drops a place's inventory when its read fails, so the two
+ *  arrive here looking alike — an absent entry and an absent inventory —
+ *  and only the second means nobody knows. */
 function notChosen(
+  inventory: EditorInventory | null,
   inherited: { under: string } | null,
   automatic: string[] | undefined,
-): string {
+): string | null {
+  if (!inventory) return null;
   if (inherited) return skillsInherited(inherited.under);
   if (automatic === undefined) return SKILLS_AUTOMATIC_UNRECORDED;
   return automatic.length > 0 ? SKILLS_AUTOMATIC : SKILLS_AUTOMATIC_NONE;

--- a/ui/src/components/customize/item-skills.tsx
+++ b/ui/src/components/customize/item-skills.tsx
@@ -1,9 +1,12 @@
 import { X } from "lucide-react";
+import type { ReactNode } from "react";
 import type { EditorInventory } from "@/bindings";
 import { AddEntry } from "@/components/customize/controls";
 import { Button } from "@/components/ui/button";
 import {
   SKILLS_AUTOMATIC,
+  SKILLS_AUTOMATIC_NONE,
+  SKILLS_AUTOMATIC_UNRECORDED,
   SKILLS_BACK_TO_AUTOMATIC,
   SKILLS_CHOSEN,
   SKILLS_NONE_AVAILABLE,
@@ -13,6 +16,7 @@ import {
   type Draft,
   setAgentSkill,
 } from "@/lib/editor-draft";
+import { cn } from "@/lib/utils";
 
 /**
  * Which skills one agent gets. Chosen skills are chips and the rest live
@@ -26,44 +30,63 @@ export function ItemSkills({
   onChange,
 }: {
   agent: string;
-  /** null while kendex picks skills from the agent's tags. */
+  /** null while the catalog's own assignment stands. */
   chosen: string[] | null;
   inventory: EditorInventory | null;
   onChange: (change: (draft: Draft) => Draft) => void;
 }) {
+  // What the catalog gave this agent, so the automatic state names the
+  // skills instead of leaving an empty box that reads as "none".
+  // Undefined is "nothing recorded here", which is not "none".
+  const automatic = inventory?.automaticSkills[agent];
+  const shown = chosen ?? automatic ?? [];
   const known = [
     ...new Set([
       ...(inventory?.declaredSkills ?? []),
       ...(inventory?.availableSkills ?? []),
-      ...(chosen ?? []),
+      ...shown,
     ]),
   ].sort();
+  // Against the reader's own list, not against what the catalog gave: in
+  // the automatic state every known skill is still a choice to make, and
+  // picking one the catalog already assigns is how a declaration that
+  // keeps it starts.
   const unchosen = known.filter((skill) => !(chosen ?? []).includes(skill));
+  const note = chosen
+    ? SKILLS_CHOSEN
+    : automatic === undefined
+      ? SKILLS_AUTOMATIC_UNRECORDED
+      : automatic.length > 0
+        ? SKILLS_AUTOMATIC
+        : SKILLS_AUTOMATIC_NONE;
 
   return (
     <div className="flex flex-col gap-3">
-      <p className="text-[13px] text-muted-foreground">
-        {chosen ? SKILLS_CHOSEN : SKILLS_AUTOMATIC}
-      </p>
-      {chosen && chosen.length > 0 ? (
+      <p className="text-[13px] text-muted-foreground">{note}</p>
+      {shown.length > 0 ? (
         <div className="flex flex-wrap gap-1.5">
-          {chosen.map((skill) => (
-            <span
-              key={skill}
-              className="inline-flex h-7 items-center gap-1 rounded-full bg-secondary pr-1.5 pl-3 text-xs font-medium"
-            >
+          {shown.map((skill) => (
+            <Chip key={skill} removable={chosen !== null}>
               {skill}
-              <button
-                type="button"
-                aria-label={`Remove ${skill}`}
-                className="rounded-full p-0.5 text-muted-foreground hover:text-foreground"
-                onClick={() =>
-                  onChange((draft) => setAgentSkill(draft, agent, skill, false))
-                }
-              >
-                <X className="size-3.5" />
-              </button>
-            </span>
+              {/* Removable only where the list is the reader's own. Taking
+                  one off the catalog's list is choosing a list, which the
+                  picker below is the way into — an X here would look like
+                  an edit and quietly become a declaration. */}
+              {chosen ? (
+                <button
+                  type="button"
+                  aria-label={`Remove ${skill}`}
+                  className="rounded-full p-0.5 text-muted-foreground hover:text-foreground"
+                  onClick={() =>
+                    onChange((draft) =>
+                      setAgentSkill(draft, agent, skill, false),
+                    )
+                  }
+                >
+                  <X className="size-3.5" />
+                </button>
+              ) : null}
+            </Chip>
           ))}
         </div>
       ) : null}
@@ -92,5 +115,24 @@ export function ItemSkills({
         ) : null}
       </div>
     </div>
+  );
+}
+
+function Chip({
+  removable,
+  children,
+}: {
+  removable: boolean;
+  children: ReactNode;
+}) {
+  return (
+    <span
+      className={cn(
+        "inline-flex h-7 items-center gap-1 rounded-full bg-secondary text-xs font-medium",
+        removable ? "pr-1.5 pl-3" : "px-3",
+      )}
+    >
+      {children}
+    </span>
   );
 }

--- a/ui/src/components/customize/item-skills.tsx
+++ b/ui/src/components/customize/item-skills.tsx
@@ -10,6 +10,7 @@ import {
   SKILLS_BACK_TO_AUTOMATIC,
   SKILLS_CHOSEN,
   SKILLS_NONE_AVAILABLE,
+  skillsInherited,
 } from "@/lib/copy-customize";
 import {
   clearAgentSkills,
@@ -26,12 +27,18 @@ import { cn } from "@/lib/utils";
 export function ItemSkills({
   agent,
   chosen,
+  inherited,
   inventory,
   onChange,
 }: {
   agent: string;
-  /** null while the catalog's own assignment stands. */
+  /** This agent's own `[agent-skills]` row; null where it has none. */
   chosen: string[] | null;
+  /** The row this agent inherits and the agent it is set on — a reviewer
+   *  agent with no row of its own renders its base agent's list, and that
+   *  list, not the catalog's, is what it gets. Null when nothing is
+   *  inherited, and never set alongside `chosen`. */
+  inherited: { skills: string[]; under: string } | null;
   inventory: EditorInventory | null;
   onChange: (change: (draft: Draft) => Draft) => void;
 }) {
@@ -39,7 +46,7 @@ export function ItemSkills({
   // skills instead of leaving an empty box that reads as "none".
   // Undefined is "nothing recorded here", which is not "none".
   const automatic = inventory?.automaticSkills[agent];
-  const shown = chosen ?? automatic ?? [];
+  const shown = chosen ?? inherited?.skills ?? automatic ?? [];
   const known = [
     ...new Set([
       ...(inventory?.declaredSkills ?? []),
@@ -52,13 +59,7 @@ export function ItemSkills({
   // picking one the catalog already assigns is how a declaration that
   // keeps it starts.
   const unchosen = known.filter((skill) => !(chosen ?? []).includes(skill));
-  const note = chosen
-    ? SKILLS_CHOSEN
-    : automatic === undefined
-      ? SKILLS_AUTOMATIC_UNRECORDED
-      : automatic.length > 0
-        ? SKILLS_AUTOMATIC
-        : SKILLS_AUTOMATIC_NONE;
+  const note = chosen ? SKILLS_CHOSEN : notChosen(inherited, automatic);
 
   return (
     <div className="flex flex-col gap-3">
@@ -116,6 +117,18 @@ export function ItemSkills({
       </div>
     </div>
   );
+}
+
+/** What the section says when this agent has no row of its own: the list
+ *  it inherits, the catalog's, or that nothing is recorded here — three
+ *  answers, and none of them may be printed over another. */
+function notChosen(
+  inherited: { under: string } | null,
+  automatic: string[] | undefined,
+): string {
+  if (inherited) return skillsInherited(inherited.under);
+  if (automatic === undefined) return SKILLS_AUTOMATIC_UNRECORDED;
+  return automatic.length > 0 ? SKILLS_AUTOMATIC : SKILLS_AUTOMATIC_NONE;
 }
 
 function Chip({

--- a/ui/src/components/library/installed-view.dom.test.tsx
+++ b/ui/src/components/library/installed-view.dom.test.tsx
@@ -1,0 +1,89 @@
+// @vitest-environment jsdom
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { ObservedItem, Scope } from "@/bindings";
+import { InstalledView } from "@/components/library/installed-view";
+import { useEditorStore } from "@/stores/editor";
+import { useLibraryViewStore } from "@/stores/library-view";
+import { useNavStore } from "@/stores/nav";
+import { useProvenanceStore } from "@/stores/provenance";
+import { useScanStore } from "@/stores/scan";
+import { useUpdatesStore } from "@/stores/updates";
+import { mount } from "@/test/dom";
+
+const VG: Scope = { scope: "project", root: "/work/vg" };
+const HYPR: Scope = { scope: "project", root: "/work/hyprtrade" };
+
+const installed = (scope: Scope): ObservedItem =>
+  ({
+    kind: "skill",
+    name: "gh",
+    scope,
+    harness: "claude",
+    path: `${scope.scope === "project" ? scope.root : ""}/.claude/skills/gh`,
+    fileState: { state: "file" },
+    enabled: true,
+    origin: null,
+    description: "about gh",
+    tags: [],
+    modifiedAt: null,
+    vendor: null,
+  }) as unknown as ObservedItem;
+
+// Customized in both places.
+const mine = { schema: 1, install: {}, "skill-instructions": { gh: "mine" } };
+
+const markOf = (host: HTMLElement) =>
+  [...host.querySelectorAll("tbody tr")]
+    .map((row) => row.textContent ?? "")
+    .find((text) => text.includes("Customized"));
+
+// A row's mark answers for the package, so the Where filter may decide
+// which rows are on screen and never what one of them says. Read from the
+// filtered groups, this row said "Customized in vg" while the package's
+// own page named both places — the contradiction the issue is about,
+// arriving through the filter instead of through the header.
+describe("the Library's mark under a Where filter", () => {
+  beforeEach(() => {
+    vi.spyOn(useProvenanceStore.getState(), "load").mockResolvedValue();
+    vi.spyOn(useEditorStore.getState(), "loadAll").mockResolvedValue();
+    useEditorStore.setState({
+      saved: { "/work/vg": mine as never, "/work/hyprtrade": mine as never },
+    });
+    useUpdatesStore.setState({ rows: [], loaded: true });
+    useScanStore.setState({
+      result: {
+        harnesses: [],
+        items: [installed(VG), installed(HYPR)],
+        missingProjects: [],
+        warnings: [],
+      } as never,
+    });
+    useLibraryViewStore.setState({
+      kind: "any",
+      harness: "any",
+      tag: "any",
+      from: "any",
+    });
+  });
+
+  const shown = (scope: "all" | { project: string }) => {
+    useNavStore.setState({ libraryScope: scope, search: "" });
+    return markOf(mount(<InstalledView />));
+  };
+
+  it("says the same thing narrowed to one project as it does unnarrowed", () => {
+    const everywhere = shown("all");
+    expect(everywhere).toContain("2 of 2 projects");
+
+    const narrowed = shown({ project: "/work/vg" });
+    expect(narrowed).toContain("2 of 2 projects");
+    expect(narrowed).toContain("Customized in vg and hyprtrade");
+  });
+
+  // The filter still decides which rows are on screen.
+  it("still narrows the table to the place asked for", () => {
+    useNavStore.setState({ libraryScope: { project: "/work/vg" }, search: "" });
+    const host = mount(<InstalledView />);
+    expect(host.querySelectorAll("tbody tr")).toHaveLength(1);
+  });
+});

--- a/ui/src/components/library/installed-view.tsx
+++ b/ui/src/components/library/installed-view.tsx
@@ -115,14 +115,21 @@ export function InstalledView() {
     );
   }, [result, scope, kind, harness, tag, from, search, provenance]);
 
+  // Every group the scan holds, before any narrowing.
+  const everywhere = useMemo(
+    () => (result ? groupItems(result.items) : []),
+    [result],
+  );
+  // Read from those, never from the filtered set: a mark answers for the
+  // package, so narrowing the table to one project must not change what it
+  // says. Read from `groups`, a package customized in two projects said
+  // "Customized in vg" here and named both on its own page — the same
+  // contradiction, arriving through the Where filter.
+  const standingsFor = useLibraryStandings(everywhere);
   // The count the filtered total is measured against: every row the table
   // could show, not the ones left after the current narrowing. Shared with
   // Home's Installed tile so the two can never disagree.
-  const standingsFor = useLibraryStandings(groups);
-  const total = useMemo(
-    () => (result ? installedCount(groupItems(result.items)) : 0),
-    [result],
-  );
+  const total = useMemo(() => installedCount(everywhere), [everywhere]);
   // The filter's vocabulary is what the join actually says, so a value
   // is never offered that no row carries.
   const fromOptions = useMemo(

--- a/ui/src/components/library/installed-view.tsx
+++ b/ui/src/components/library/installed-view.tsx
@@ -27,7 +27,7 @@ import {
 import { PAGE_GUTTER, WIDE_CONTENT_WIDTH } from "@/lib/layout";
 import { isNarrowed, UNFILTERED } from "@/lib/library-handoff";
 import { useLibraryStandings } from "@/lib/library-standings";
-import { libraryMark } from "@/lib/place-marks";
+import { packageMark } from "@/lib/place-marks";
 import { cn } from "@/lib/utils";
 import { useEditorStore } from "@/stores/editor";
 import {
@@ -166,7 +166,7 @@ export function InstalledView() {
             ref={scroller}
             className="min-w-0 flex-1 overflow-y-auto pr-2 [scrollbar-gutter:stable]"
           >
-            {groups.some((g) => libraryMark(standingsFor(g))) ? (
+            {groups.some((g) => packageMark(standingsFor(g))) ? (
               <LibraryLegend />
             ) : null}
             <Table>
@@ -195,7 +195,7 @@ export function InstalledView() {
                         group.name,
                         groupScopes(group),
                       )}
-                      mark={libraryMark(standingsFor(group))}
+                      mark={packageMark(standingsFor(group))}
                       forkedIn={standingsFor(group)
                         .filter((s) => s.why === "forked")
                         .map((s) => s.scope)}

--- a/ui/src/components/package/package-header.test.tsx
+++ b/ui/src/components/package/package-header.test.tsx
@@ -18,16 +18,34 @@ describe("PackageHeader", () => {
       />,
     );
 
-  it("prints the place the mark names", () => {
-    const shown = render({
-      label: "Customized in vg",
-      goTo: { scope: "project", root: "/work/vg" },
-      why: "settings",
-    });
-    expect(shown).toContain("Customized in vg");
+  const mark: PlaceMark = {
+    label: "Customized in vg · 1 of 3 places",
+    goTo: null,
+    why: "settings",
+  };
+
+  it("prints what the mark says about the package", () => {
+    expect(render(mark)).toContain("Customized in vg · 1 of 3 places");
   });
 
-  it("says nothing where this place holds nothing", () => {
+  it("says nothing where no place holds anything", () => {
     expect(render(null)).not.toContain("Customized");
+  });
+
+  // The Library row marks a customized package by colouring its kind icon
+  // and putting the mark under the name in that colour. The header says
+  // the same thing the same way rather than in a pill of its own.
+  it("marks it the way the Library row does, not with a badge", () => {
+    const shown = render(mark);
+    // The kind icon takes the customized colour, as it does on the row.
+    expect(shown).toContain("translate-y-[0.1875rem] text-customized");
+    // And the words are plain text, not the pill this header used to draw.
+    expect(shown).not.toContain("badge");
+  });
+
+  it("leaves the icon muted where nothing is customized", () => {
+    const shown = render(null);
+    expect(shown).toContain("translate-y-[0.1875rem] text-muted-foreground");
+    expect(shown).not.toContain("text-customized");
   });
 });

--- a/ui/src/components/package/package-header.tsx
+++ b/ui/src/components/package/package-header.tsx
@@ -6,6 +6,7 @@ import { Badge } from "@/components/ui/badge";
 import { FORKED_BADGE_LABEL } from "@/lib/copy";
 import { kindIcon } from "@/lib/kind-icon";
 import type { PlaceMark } from "@/lib/place-marks";
+import { cn } from "@/lib/utils";
 
 /** The package page's title block: what this is, what it says about itself,
  *  and the things you can do to it. */
@@ -33,21 +34,31 @@ export function PackageHeader({
         // a badge alongside makes the row taller than the words, and
         // centring against that visibly floats the icon off the title.
         <span className="flex items-baseline gap-2.5">
-          <Icon className="size-5 shrink-0 translate-y-[0.1875rem] text-muted-foreground" />
+          <Icon
+            className={cn(
+              "size-5 shrink-0 translate-y-[0.1875rem]",
+              // The same colour the Library row gives a customized
+              // package's icon, so one package is marked one way.
+              mark ? "text-customized" : "text-muted-foreground",
+            )}
+          />
           <span className="min-w-0 truncate">{displayName}</span>
           {forked ? (
             <Badge variant="outline">{FORKED_BADGE_LABEL}</Badge>
           ) : null}
-          {mark ? (
-            // The place it names is the page being read, so there is
-            // nowhere for it to lead: it states where, and the way there
-            // is already underfoot.
-            <Badge variant="customized">{mark.label}</Badge>
-          ) : null}
         </span>
       }
       subtitle={
-        description ? <InlineMarkdown source={description} /> : undefined
+        mark || description ? (
+          <>
+            {/* Under the title and above the description, in words, the
+                way the Library row carries it — not a pill beside the
+                name. A badge there read as a property of the title; this
+                is a sentence about the package. */}
+            {mark ? <p className="mb-1 text-customized">{mark.label}</p> : null}
+            {description ? <InlineMarkdown source={description} /> : null}
+          </>
+        ) : undefined
       }
       action={action}
     />

--- a/ui/src/dev/fixture-scopes.ts
+++ b/ui/src/dev/fixture-scopes.ts
@@ -12,5 +12,12 @@ export const AVAILABLE_SKILLS = [
   "tests",
 ];
 
+/** What the catalog gives each agent while nothing is chosen for it —
+ *  the lock's record, which the dev shell has no engine to write. */
+export const AUTOMATIC_SKILLS: Record<string, string[]> = {
+  orch: ["deploy", "github", "release-notes"],
+  reviewer: ["code-review", "tests"],
+};
+
 export const GLOBAL: Scope = { scope: "global" };
 export const proj = (root: string): Scope => ({ scope: "project", root });

--- a/ui/src/dev/fixtures.ts
+++ b/ui/src/dev/fixtures.ts
@@ -22,7 +22,12 @@ import { harnesses, items } from "./fixture-observed";
 import { provenance } from "./fixture-provenance";
 import { ACME, API } from "./fixture-scopes";
 
-export { ACME, API, AVAILABLE_SKILLS } from "./fixture-scopes";
+export {
+  ACME,
+  API,
+  AUTOMATIC_SKILLS,
+  AVAILABLE_SKILLS,
+} from "./fixture-scopes";
 
 export interface MockState {
   settings: AppSettings;

--- a/ui/src/dev/mock-agent-skills.ts
+++ b/ui/src/dev/mock-agent-skills.ts
@@ -1,0 +1,25 @@
+import type { DeclaredSkillRow, Manifest_Serialize } from "@/bindings";
+
+/** The engine's `[agent-skills]` lookup, stood in for by the dev shell:
+ *  an agent reads its own row, and a `reviewer-` agent with none reads its
+ *  base agent's. The real answer comes from
+ *  `crates/core/src/mapping.rs::declared_skills`; nothing outside this
+ *  file may reimplement it, which is why the shell keeps its stand-in
+ *  here beside its other canned answers rather than in the app. */
+export function declaredSkillRows(
+  manifest: Manifest_Serialize | undefined,
+): Record<string, DeclaredSkillRow> {
+  const rows = manifest?.["agent-skills"] ?? {};
+  const out: Record<string, DeclaredSkillRow> = {};
+  for (const agent of Object.keys(manifest?.agents ?? {})) {
+    const own = rows[agent];
+    if (own) {
+      out[agent] = { skills: own, under: agent };
+      continue;
+    }
+    const base = agent.replace(/^reviewer-/, "");
+    const inherited = base === agent ? undefined : rows[base];
+    if (inherited) out[agent] = { skills: inherited, under: base };
+  }
+  return out;
+}

--- a/ui/src/dev/mock-audit.ts
+++ b/ui/src/dev/mock-audit.ts
@@ -5,6 +5,7 @@ import type {
   Scope,
 } from "@/bindings";
 import { AUTOMATIC_SKILLS, AVAILABLE_SKILLS } from "./fixtures";
+import { declaredSkillRows } from "./mock-agent-skills";
 import {
   DECL_KEYS,
   declTable,
@@ -163,6 +164,7 @@ export const auditHandlers: Record<string, Handler> = {
       declaredSkills: Object.keys(m?.skills ?? {}),
       availableSkills: AVAILABLE_SKILLS,
       automaticSkills: AUTOMATIC_SKILLS,
+      declaredSkillRows: declaredSkillRows(m),
       harnesses: m?.install.harnesses ?? ["claude"],
       hookEvents: HOOK_EVENTS,
     };

--- a/ui/src/dev/mock-audit.ts
+++ b/ui/src/dev/mock-audit.ts
@@ -4,7 +4,7 @@ import type {
   Manifest_Serialize,
   Scope,
 } from "@/bindings";
-import { AVAILABLE_SKILLS } from "./fixtures";
+import { AUTOMATIC_SKILLS, AVAILABLE_SKILLS } from "./fixtures";
 import {
   DECL_KEYS,
   declTable,
@@ -162,6 +162,7 @@ export const auditHandlers: Record<string, Handler> = {
       declaredAgents: Object.keys(m?.agents ?? {}),
       declaredSkills: Object.keys(m?.skills ?? {}),
       availableSkills: AVAILABLE_SKILLS,
+      automaticSkills: AUTOMATIC_SKILLS,
       harnesses: m?.install.harnesses ?? ["claude"],
       hookEvents: HOOK_EVENTS,
     };

--- a/ui/src/lib/copy-customize.ts
+++ b/ui/src/lib/copy-customize.ts
@@ -41,6 +41,11 @@ export const SKILLS_AUTOMATIC =
   "The catalog gives this agent these. Add one and this agent keeps exactly what you choose.";
 export const SKILLS_AUTOMATIC_NONE =
   "The catalog gives this agent no skills. Add one and this agent keeps exactly what you choose.";
+/** A reviewer agent with no row of its own renders its base agent's list.
+ *  The chips are that row, so the line names where it lives — this page
+ *  edits this agent's row, and picking here starts one. */
+export const skillsInherited = (base: string): string =>
+  `Set on ${base}, which this agent reads its skills from. Add one and this agent keeps exactly what you choose instead.`;
 export const SKILLS_AUTOMATIC_UNRECORDED =
   "The catalog picks these, and kendex records which ones the next time it installs here. Add one and this agent keeps exactly what you choose.";
 export const SKILLS_CHOSEN =

--- a/ui/src/lib/copy-customize.ts
+++ b/ui/src/lib/copy-customize.ts
@@ -33,8 +33,16 @@ export const SHARED_ALSO_APPLIES =
   "Your instructions for everything apply here too.";
 export const SHARED_VIEW = "See them";
 export const SKILLS_SECTION = "Skills";
+// The automatic state has three answers, not two. A catalog that assigns
+// nothing and a scope whose lock has not recorded an assignment yet are
+// different facts, and printing the first over the second reads an agent
+// nobody has asked about as an agent with no skills.
 export const SKILLS_AUTOMATIC =
-  "kendex picks these from the agent's tags. Add one and this agent keeps exactly what you choose.";
+  "The catalog gives this agent these. Add one and this agent keeps exactly what you choose.";
+export const SKILLS_AUTOMATIC_NONE =
+  "The catalog gives this agent no skills. Add one and this agent keeps exactly what you choose.";
+export const SKILLS_AUTOMATIC_UNRECORDED =
+  "The catalog picks these, and kendex records which ones the next time it installs here. Add one and this agent keeps exactly what you choose.";
 export const SKILLS_CHOSEN =
   "This agent gets exactly these. Remove them all to give it none.";
 export const SKILLS_NONE_AVAILABLE =

--- a/ui/src/lib/customization.test.ts
+++ b/ui/src/lib/customization.test.ts
@@ -3,10 +3,12 @@ import {
   canCustomize,
   clearItemCustomization,
   customizedItems,
+  declaredSkillsRow,
   frontmatterFor,
   isCustomized,
   itemCustomization,
   sharedCustomization,
+  skillsBaseAgent,
 } from "./customization";
 import { type Draft, EMPTY_FRONTMATTER, emptyDraft } from "./editor-draft";
 
@@ -92,5 +94,60 @@ describe("clearItemCustomization", () => {
     const after = clearItemCustomization(draft(), "skill", "github");
     expect(after["skill-instructions"]).toEqual({ all: "be brief" });
     expect(after["agent-skills"]).toEqual({ orch: ["github", "docs"] });
+  });
+});
+
+// The engine renders a `reviewer-` agent with no row of its own from its
+// base agent's row (`crates/core/src/engine/desired_agent.rs`,
+// `declared_skills`). A reader here that asked for the exact name alone
+// called a real assignment absent.
+describe("declaredSkillsRow", () => {
+  const rows = (agentSkills: Record<string, string[]>): Draft => ({
+    ...emptyDraft(),
+    "agent-skills": agentSkills,
+  });
+
+  it("returns the agent's own row under its own name", () => {
+    expect(declaredSkillsRow(rows({ rust: ["worktree"] }), "rust")).toEqual({
+      skills: ["worktree"],
+      under: "rust",
+    });
+  });
+
+  it("falls back to the base agent's row for a reviewer agent", () => {
+    expect(
+      declaredSkillsRow(rows({ rust: ["worktree"] }), "reviewer-rust"),
+    ).toEqual({ skills: ["worktree"], under: "rust" });
+  });
+
+  it("prefers the agent's own row over the one it would inherit", () => {
+    const both = rows({ rust: ["worktree"], "reviewer-rust": ["dev"] });
+    expect(declaredSkillsRow(both, "reviewer-rust")).toEqual({
+      skills: ["dev"],
+      under: "reviewer-rust",
+    });
+  });
+
+  // An empty row is a declaration saying "none", not an absent one.
+  it("keeps an empty row as a declaration", () => {
+    expect(declaredSkillsRow(rows({ rust: [] }), "rust")).toEqual({
+      skills: [],
+      under: "rust",
+    });
+  });
+
+  it("says nothing where no row reaches this agent", () => {
+    expect(
+      declaredSkillsRow(rows({ orch: ["dev"] }), "reviewer-rust"),
+    ).toBeNull();
+    expect(declaredSkillsRow(emptyDraft(), "rust")).toBeNull();
+    expect(declaredSkillsRow(null, "rust")).toBeNull();
+  });
+
+  // Only `reviewer-` is stripped; nothing else inherits.
+  it("gives no other prefix a base agent", () => {
+    expect(skillsBaseAgent("reviewer-rust")).toBe("rust");
+    expect(skillsBaseAgent("planner-rust")).toBe("planner-rust");
+    expect(skillsBaseAgent("reviewer")).toBe("reviewer");
   });
 });

--- a/ui/src/lib/customization.test.ts
+++ b/ui/src/lib/customization.test.ts
@@ -3,12 +3,10 @@ import {
   canCustomize,
   clearItemCustomization,
   customizedItems,
-  declaredSkillsRow,
   frontmatterFor,
   isCustomized,
   itemCustomization,
   sharedCustomization,
-  skillsBaseAgent,
 } from "./customization";
 import { type Draft, EMPTY_FRONTMATTER, emptyDraft } from "./editor-draft";
 
@@ -94,60 +92,5 @@ describe("clearItemCustomization", () => {
     const after = clearItemCustomization(draft(), "skill", "github");
     expect(after["skill-instructions"]).toEqual({ all: "be brief" });
     expect(after["agent-skills"]).toEqual({ orch: ["github", "docs"] });
-  });
-});
-
-// The engine renders a `reviewer-` agent with no row of its own from its
-// base agent's row (`crates/core/src/engine/desired_agent.rs`,
-// `declared_skills`). A reader here that asked for the exact name alone
-// called a real assignment absent.
-describe("declaredSkillsRow", () => {
-  const rows = (agentSkills: Record<string, string[]>): Draft => ({
-    ...emptyDraft(),
-    "agent-skills": agentSkills,
-  });
-
-  it("returns the agent's own row under its own name", () => {
-    expect(declaredSkillsRow(rows({ rust: ["worktree"] }), "rust")).toEqual({
-      skills: ["worktree"],
-      under: "rust",
-    });
-  });
-
-  it("falls back to the base agent's row for a reviewer agent", () => {
-    expect(
-      declaredSkillsRow(rows({ rust: ["worktree"] }), "reviewer-rust"),
-    ).toEqual({ skills: ["worktree"], under: "rust" });
-  });
-
-  it("prefers the agent's own row over the one it would inherit", () => {
-    const both = rows({ rust: ["worktree"], "reviewer-rust": ["dev"] });
-    expect(declaredSkillsRow(both, "reviewer-rust")).toEqual({
-      skills: ["dev"],
-      under: "reviewer-rust",
-    });
-  });
-
-  // An empty row is a declaration saying "none", not an absent one.
-  it("keeps an empty row as a declaration", () => {
-    expect(declaredSkillsRow(rows({ rust: [] }), "rust")).toEqual({
-      skills: [],
-      under: "rust",
-    });
-  });
-
-  it("says nothing where no row reaches this agent", () => {
-    expect(
-      declaredSkillsRow(rows({ orch: ["dev"] }), "reviewer-rust"),
-    ).toBeNull();
-    expect(declaredSkillsRow(emptyDraft(), "rust")).toBeNull();
-    expect(declaredSkillsRow(null, "rust")).toBeNull();
-  });
-
-  // Only `reviewer-` is stripped; nothing else inherits.
-  it("gives no other prefix a base agent", () => {
-    expect(skillsBaseAgent("reviewer-rust")).toBe("rust");
-    expect(skillsBaseAgent("planner-rust")).toBe("planner-rust");
-    expect(skillsBaseAgent("reviewer")).toBe("reviewer");
   });
 });

--- a/ui/src/lib/customization.ts
+++ b/ui/src/lib/customization.ts
@@ -67,6 +67,39 @@ export function itemCustomization(
   };
 }
 
+/** The base agent a `reviewer-` agent reads its skills from — its own name
+ *  for every other agent. The engine's own lookup, spelled
+ *  `crates/core/src/mapping.rs::skill_match_prefix`. */
+export const skillsBaseAgent = (name: string): string =>
+  name.startsWith(REVIEWER_PREFIX) ? name.slice(REVIEWER_PREFIX.length) : name;
+
+const REVIEWER_PREFIX = "reviewer-";
+
+/** One agent's `[agent-skills]` row and the name it lives under, or null
+ *  where nothing is declared for it.
+ *
+ *  The lookup the engine renders by
+ *  (`crates/core/src/engine/desired_agent.rs::declared_skills`): a
+ *  `reviewer-` agent with no row of its own reads its base agent's. Asking
+ *  for the exact name alone calls a real assignment absent, and the screen
+ *  then names the catalog's list over a list the person wrote.
+ *
+ *  `under` is the agent's own name for a row it owns and the base agent's
+ *  for one it inherits — the two cases the screen has to tell apart, since
+ *  only the first is the reader's to edit here. */
+export function declaredSkillsRow(
+  draft: Draft | null,
+  name: string,
+): { skills: string[]; under: string } | null {
+  const rows = draft?.["agent-skills"];
+  if (!rows) return null;
+  const own = rows[name];
+  if (own) return { skills: own, under: name };
+  const base = skillsBaseAgent(name);
+  const inherited = base === name ? undefined : rows[base];
+  return inherited ? { skills: inherited, under: base } : null;
+}
+
 /** Whether a person has set anything at all on this package. */
 export const isCustomized = (one: ItemCustomization): boolean =>
   one.launch != null ||

--- a/ui/src/lib/customization.ts
+++ b/ui/src/lib/customization.ts
@@ -67,39 +67,6 @@ export function itemCustomization(
   };
 }
 
-/** The base agent a `reviewer-` agent reads its skills from — its own name
- *  for every other agent. The engine's own lookup, spelled
- *  `crates/core/src/mapping.rs::skill_match_prefix`. */
-export const skillsBaseAgent = (name: string): string =>
-  name.startsWith(REVIEWER_PREFIX) ? name.slice(REVIEWER_PREFIX.length) : name;
-
-const REVIEWER_PREFIX = "reviewer-";
-
-/** One agent's `[agent-skills]` row and the name it lives under, or null
- *  where nothing is declared for it.
- *
- *  The lookup the engine renders by
- *  (`crates/core/src/engine/desired_agent.rs::declared_skills`): a
- *  `reviewer-` agent with no row of its own reads its base agent's. Asking
- *  for the exact name alone calls a real assignment absent, and the screen
- *  then names the catalog's list over a list the person wrote.
- *
- *  `under` is the agent's own name for a row it owns and the base agent's
- *  for one it inherits — the two cases the screen has to tell apart, since
- *  only the first is the reader's to edit here. */
-export function declaredSkillsRow(
-  draft: Draft | null,
-  name: string,
-): { skills: string[]; under: string } | null {
-  const rows = draft?.["agent-skills"];
-  if (!rows) return null;
-  const own = rows[name];
-  if (own) return { skills: own, under: name };
-  const base = skillsBaseAgent(name);
-  const inherited = base === name ? undefined : rows[base];
-  return inherited ? { skills: inherited, under: base } : null;
-}
-
 /** Whether a person has set anything at all on this package. */
 export const isCustomized = (one: ItemCustomization): boolean =>
   one.launch != null ||

--- a/ui/src/lib/customized-places.test.ts
+++ b/ui/src/lib/customized-places.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it } from "vitest";
 import type { Scope, UpdateRow } from "@/bindings";
 import { customizedLine } from "@/lib/copy-customize";
 import type { Draft } from "@/lib/editor-draft";
-import { libraryMark } from "@/lib/place-marks";
+import { packageMark } from "@/lib/place-marks";
 import {
   customizedHere,
   manifestsForEditing,
@@ -156,7 +156,7 @@ describe("customizedHere", () => {
       manifests: { "/work/vg": empty() },
       rows: [row(VG, { blockedByLocalEdit: true })],
     });
-    const mark = libraryMark(placeStandings(s, "skill", "gh", [VG]));
+    const mark = packageMark(placeStandings(s, "skill", "gh", [VG]));
     expect(mark?.label).toBe("Customized in vg");
     expect(mark?.why).toBe("edited");
     expect(customizedHere(s, VG)).toMatchObject([

--- a/ui/src/lib/customized-places.ts
+++ b/ui/src/lib/customized-places.ts
@@ -141,14 +141,6 @@ export function placeStandings(
   );
 }
 
-export function standingIn(
-  standings: PlaceStanding[],
-  scope: Scope,
-): PlaceStanding | undefined {
-  const key = scopeKey(scope);
-  return standings.find((s) => scopeKey(s.scope) === key);
-}
-
 /** One row of the Customize page's index: a package this place holds
  *  something for, every fact that makes it so, and what its overlay sets. */
 export interface CustomizedHere {

--- a/ui/src/lib/package-mark.test.ts
+++ b/ui/src/lib/package-mark.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import type { Scope } from "@/bindings";
+import type { Scope, UpdateRow } from "@/bindings";
 import { groupItems } from "@/lib/derive";
 import { markFor } from "./package-mark";
 
@@ -21,6 +21,31 @@ const item = (scope: Scope) => ({
 
 const group = groupItems([item(VG), item(HYPR)] as never)[0];
 
+// Both places have been read for hand edits and forks, so a count over
+// them is a count over places somebody looked at.
+const rows = [VG, HYPR].map(
+  (scope) =>
+    ({
+      scope,
+      kind: "skill",
+      name: "gh",
+      source: "cat",
+      repo: "o/r",
+      repoIdentity: "o/r",
+      current: null,
+      latest: null,
+      updateAvailable: false,
+      pinned: false,
+      holdOwner: null,
+      ignored: false,
+      blockedByLocalEdit: false,
+      editedHarnesses: [],
+      forkableHarness: null,
+      canDiscard: false,
+      forked: false,
+    }) as unknown as UpdateRow,
+);
+
 // Customized in vg and nowhere else.
 const saved = {
   "/work/vg": { schema: 1, install: {}, "skill-instructions": { gh: "mine" } },
@@ -28,13 +53,20 @@ const saved = {
 };
 
 describe("markFor", () => {
-  // The page reads this with the place it is about. Handed the editor's
-  // open place instead, the same package answers differently — which is
-  // what makes the argument worth pinning.
-  it("answers for the place it is given", () => {
-    expect(markFor(saved as never, [], true, group, VG)?.label).toBe(
-      "Customized in vg",
+  // The page names a place; the mark is about the package. Answering for
+  // the place the page happened to open at is what let the Library row and
+  // the package's header state two different facts under the same words.
+  it("answers for the package, not for the place the page opened at", () => {
+    expect(markFor(saved as never, rows, true, group)?.label).toBe(
+      "Customized in vg · 1 of 2 projects",
     );
-    expect(markFor(saved as never, [], true, group, HYPR)).toBeNull();
+  });
+
+  it("says nothing where no place holds anything", () => {
+    const untouched = {
+      "/work/vg": { schema: 1, install: {} },
+      "/work/hyprtrade": { schema: 1, install: {} },
+    };
+    expect(markFor(untouched as never, rows, true, group)).toBeNull();
   });
 });

--- a/ui/src/lib/package-mark.ts
+++ b/ui/src/lib/package-mark.ts
@@ -1,45 +1,58 @@
-import type { Scope, UpdateRow } from "@/bindings";
+import { useEffect, useMemo } from "react";
+import type { UpdateRow } from "@/bindings";
 import { placeStandings, placesSource } from "@/lib/customized-places";
 import type { ItemGroup } from "@/lib/derive";
 import { groupScopes } from "@/lib/derive";
 import type { Draft } from "@/lib/editor-draft";
-import { headerMark, type PlaceMark } from "@/lib/place-marks";
+import { type PlaceMark, packageMark } from "@/lib/place-marks";
+import { scopeKey } from "@/lib/scope";
 import { useEditorStore } from "@/stores/editor";
 import { useUpdatesStore } from "@/stores/updates";
 
-/** The mark for one package at one place.
+/** The mark for one package, over every place it is installed.
  *
- *  Takes the place rather than reading the editor's: the editor is pointed
- *  wherever the Customize tab was last used, and a page that names a place
- *  has to answer for the place it names. */
+ *  No place is passed in on purpose: the page names a place, but the mark
+ *  is about the package. Answering for the one place the page happened to
+ *  open at is what let the Library and this page state two different
+ *  facts under the same words. */
 export function markFor(
   saved: Record<string, Draft>,
   rows: UpdateRow[],
   updatesLoaded: boolean,
   group: ItemGroup,
-  scope: Scope,
 ): PlaceMark | null {
-  return headerMark(
+  return packageMark(
     placeStandings(
       placesSource(saved, rows, updatesLoaded),
       group.kind,
       group.name,
       groupScopes(group),
     ),
-    scope,
   );
 }
 
-/** Takes the group and place as they are, absent included: the page reads
- *  this before it knows whether the scan has the package, and a hook that
- *  can only be called once that is settled is a hook called conditionally. */
-export function usePackageMark(
-  group: ItemGroup | null,
-  scope: Scope | null,
-): PlaceMark | null {
+/** Takes the group as it is, absent included: the page reads this before
+ *  it knows whether the scan has the package, and a hook that can only be
+ *  called once that is settled is a hook called conditionally.
+ *
+ *  Reads the manifests it counts rather than trusting whatever a page
+ *  happened to open. The editor holds one place at a time, and a mark
+ *  drawn over the places nobody read is the answer the header used to
+ *  give — right about one place and silent about the rest. */
+export function usePackageMark(group: ItemGroup | null): PlaceMark | null {
   const saved = useEditorStore((s) => s.saved);
+  const loadPlaces = useEditorStore((s) => s.loadPlaces);
   const rows = useUpdatesStore((s) => s.rows);
   const updatesLoaded = useUpdatesStore((s) => s.loaded);
-  if (!group || !scope) return null;
-  return markFor(saved, rows, updatesLoaded, group, scope);
+  // The scan rebuilds the group on every read, so what is held onto is
+  // which places those are, not the array they arrived in.
+  const scopes = group ? groupScopes(group) : [];
+  const key = scopes.map(scopeKey).join("|");
+  // biome-ignore lint/correctness/useExhaustiveDependencies: which places, not which array
+  const places = useMemo(() => scopes, [key]);
+  useEffect(() => {
+    if (places.length > 0) void loadPlaces(places);
+  }, [places, loadPlaces]);
+  if (!group) return null;
+  return markFor(saved, rows, updatesLoaded, group);
 }

--- a/ui/src/lib/place-marks.test.ts
+++ b/ui/src/lib/place-marks.test.ts
@@ -59,7 +59,7 @@ describe("packageMark", () => {
 describe("one rule wherever the mark is drawn", () => {
   it("answers the same for a package however the page was opened at it", () => {
     const standings = [mine(HYPR), mine(KENDEX), mine(VG)];
-    const label = "Customized in hyprtrade and kendex and vg · 3 of 3 projects";
+    const label = "Customized in hyprtrade, kendex and vg · 3 of 3 projects";
     expect(packageMark(standings)?.label).toBe(label);
     // The same standings read in any order are the same fact about the
     // package; nothing here takes a place to answer about.
@@ -85,6 +85,38 @@ describe("the word a count is in", () => {
     expect(packageMark([mine(GLOBAL), stock(VG)])?.label).toBe(
       `Customized in ${USER_LEVEL_PLACE} · 1 of 2 places`,
     );
+  });
+});
+
+// A list a person would write: commas up to the last name, one "and"
+// before it, no serial comma. Two names take the "and" alone.
+describe("how the names are joined", () => {
+  const DOCS: Scope = { scope: "project", root: "/work/docs" };
+
+  it("joins two with and", () => {
+    expect(packageMark([mine(VG), mine(HYPR)])?.label).toBe(
+      "Customized in vg and hyprtrade · 2 of 2 projects",
+    );
+  });
+
+  it("joins three as a comma list ending in and", () => {
+    expect(packageMark([mine(VG), mine(HYPR), mine(KENDEX)])?.label).toBe(
+      "Customized in vg, hyprtrade and kendex · 3 of 3 projects",
+    );
+  });
+
+  it("keeps to one and however many places there are", () => {
+    const label =
+      packageMark([mine(VG), mine(HYPR), mine(KENDEX), mine(DOCS)])?.label ??
+      "";
+    expect(label).toBe(
+      "Customized in vg, hyprtrade, kendex and docs · 4 of 4 projects",
+    );
+    expect(label.match(/ and /g)).toHaveLength(1);
+  });
+
+  it("names one place on its own", () => {
+    expect(packageMark([mine(VG)])?.label).toBe("Customized in vg");
   });
 });
 

--- a/ui/src/lib/place-marks.test.ts
+++ b/ui/src/lib/place-marks.test.ts
@@ -1,11 +1,13 @@
 import { describe, expect, it } from "vitest";
 import type { Scope } from "@/bindings";
+import { USER_LEVEL_PLACE } from "@/lib/copy-updates";
 import type { PlaceStanding } from "./customized-places";
-import { headerMark, libraryMark } from "./place-marks";
+import { packageMark } from "./place-marks";
 
 const GLOBAL: Scope = { scope: "global" };
 const VG: Scope = { scope: "project", root: "/work/vg" };
 const HYPR: Scope = { scope: "project", root: "/work/hyprtrade" };
+const KENDEX: Scope = { scope: "project", root: "/work/kendex" };
 
 const mine = (scope: Scope): PlaceStanding => ({
   scope,
@@ -23,52 +25,66 @@ const unknown = (scope: Scope): PlaceStanding => ({
   why: null,
 });
 
-describe("libraryMark", () => {
+describe("packageMark", () => {
   it("names the place and counts the rest", () => {
-    const got = libraryMark([stock(GLOBAL), mine(VG), stock(HYPR)]);
+    const got = packageMark([stock(GLOBAL), mine(VG), stock(HYPR)]);
     expect(got?.label).toBe("Customized in vg · 1 of 3 places");
     expect(got?.goTo).toEqual(VG);
   });
 
   it("names the place without a count when there is only one", () => {
-    expect(libraryMark([mine(VG)])?.label).toBe("Customized in vg");
+    expect(packageMark([mine(VG)])?.label).toBe("Customized in vg");
   });
 
   it("says nothing where nothing is customized", () => {
-    expect(libraryMark([stock(GLOBAL), stock(VG)])).toBeNull();
+    expect(packageMark([stock(GLOBAL), stock(VG)])).toBeNull();
   });
 
   // A count over places nobody read is a number with no meaning behind it.
   it("drops the count while a place is unread", () => {
-    const got = libraryMark([mine(VG), unknown(HYPR)]);
+    const got = packageMark([mine(VG), unknown(HYPR)]);
     expect(got?.label).toBe("Customized in vg");
   });
 
   it("names both places and leads nowhere in particular", () => {
-    const got = libraryMark([mine(VG), mine(HYPR), stock(GLOBAL)]);
+    const got = packageMark([mine(VG), mine(HYPR), stock(GLOBAL)]);
     expect(got?.label).toBe("Customized in vg and hyprtrade · 2 of 3 places");
     expect(got?.goTo).toBeNull();
   });
 });
 
-describe("headerMark", () => {
-  // The header names a place, so its badge answers for that place — not
-  // for whichever place the package happens to be customized in.
-  it("answers for the place the page is showing", () => {
-    const standings = [mine(VG), stock(HYPR)];
-    expect(headerMark(standings, VG)?.label).toBe("Customized in vg");
-    expect(headerMark(standings, HYPR)).toBeNull();
+// The bug this rule was written for: a Library row said "3 of 3 places"
+// while the package's own header said "Customized in hyprtrade", and
+// nothing on either told the reader they answered different questions.
+describe("one rule wherever the mark is drawn", () => {
+  it("answers the same for a package however the page was opened at it", () => {
+    const standings = [mine(HYPR), mine(KENDEX), mine(VG)];
+    const label = "Customized in hyprtrade and kendex and vg · 3 of 3 projects";
+    expect(packageMark(standings)?.label).toBe(label);
+    // The same standings read in any order are the same fact about the
+    // package; nothing here takes a place to answer about.
+    expect(packageMark([...standings].reverse())?.label).toContain(
+      "3 of 3 projects",
+    );
+  });
+});
+
+describe("the word a count is in", () => {
+  it("calls a set of projects projects", () => {
+    expect(packageMark([mine(VG), stock(HYPR)])?.label).toBe(
+      "Customized in vg · 1 of 2 projects",
+    );
   });
 
-  // The place it names is the page the reader is on, so a control here
-  // would look like a way somewhere and do nothing.
-  it("offers no destination: the place it names is the page itself", () => {
-    expect(headerMark([mine(VG)], VG)?.goTo).toBeNull();
-  });
-
-  it("finds the place by value, not by identity", () => {
-    const got = headerMark([mine(VG)], { scope: "project", root: "/work/vg" });
-    expect(got?.label).toBe("Customized in vg");
+  // The personal scope is not a project, so the set it is in is mixed and
+  // takes the word the rest of the app uses for a mixed set.
+  it("calls a set holding the personal scope places", () => {
+    expect(packageMark([mine(VG), stock(GLOBAL)])?.label).toBe(
+      "Customized in vg · 1 of 2 places",
+    );
+    expect(packageMark([mine(GLOBAL), stock(VG)])?.label).toBe(
+      `Customized in ${USER_LEVEL_PLACE} · 1 of 2 places`,
+    );
   });
 });
 
@@ -78,16 +94,9 @@ const CLIENT_A: Scope = { scope: "project", root: "/work/client" };
 const CLIENT_B: Scope = { scope: "project", root: "/personal/client" };
 
 describe("places that share a folder name", () => {
-  it("names enough of the path to tell them apart on a row", () => {
-    const got = libraryMark([mine(CLIENT_A), stock(CLIENT_B)]);
+  it("names enough of the path to tell them apart", () => {
+    const got = packageMark([mine(CLIENT_A), stock(CLIENT_B)]);
     expect(got?.label).toContain("work/client");
     expect(got?.label).not.toContain("personal/client");
-  });
-
-  it("tells them apart in the header too", () => {
-    const standings = [mine(CLIENT_A), stock(CLIENT_B)];
-    expect(headerMark(standings, CLIENT_A)?.label).toBe(
-      "Customized in work/client",
-    );
   });
 });

--- a/ui/src/lib/place-marks.ts
+++ b/ui/src/lib/place-marks.ts
@@ -1,9 +1,5 @@
 import type { Scope } from "@/bindings";
-import {
-  type PlaceStanding,
-  standingIn,
-  type Why,
-} from "@/lib/customized-places";
+import type { PlaceStanding, Why } from "@/lib/customized-places";
 import { placeName } from "@/lib/update-groups";
 
 /** What a mark says, and where it leads if anywhere. */
@@ -11,65 +7,47 @@ export interface PlaceMark {
   label: string;
   /** The place a click opens, where opening one is worth offering.
    *
-   *  Null in two cases, and the label tells them apart: the mark names
-   *  several places, so no one of them is the destination; or it names
-   *  the place already on screen, where a control would lead back to
-   *  where the reader stands. A single-place mark is therefore not always
-   *  a followable one. */
+   *  Null when the mark names several places, so no one of them is the
+   *  destination. A caller already standing in the place a single-place
+   *  mark names ignores this rather than offering a way back to where the
+   *  reader stands. */
   goTo: Scope | null;
   why: Why | null;
 }
 
 const customized = (s: PlaceStanding) => s.standing === "customized";
 
-/** The Library row's mark: which places hold changes, out of how many.
+/** What a counted set of places is called. Projects among themselves are
+ *  projects; the personal scope makes the set a mixed one, and "places" is
+ *  the word the rest of the app already uses for that. */
+const placeWord = (scopes: Scope[]): string =>
+  scopes.every((s) => s.scope === "project") ? "projects" : "places";
+
+/** The mark for one package: which places hold changes, out of how many.
+ *
+ *  One rule wherever it is drawn. A Library row and the package's own
+ *  header ask the same question about the same package, so a header that
+ *  answered only for the place its page was opened at had the app
+ *  contradicting itself — "3 of 3 places" on the row, "Customized in
+ *  hyprtrade" on the page, both true by their own rule and neither saying
+ *  which question it answered.
  *
  *  Names the place while there is one to name — "Customized in vg" says
  *  more than "1 of 3 places" and is the answer to the question actually
  *  being asked. The count follows only when it adds something, and the
  *  bare word never appears alone. */
-export function libraryMark(standings: PlaceStanding[]): PlaceMark | null {
+export function packageMark(standings: PlaceStanding[]): PlaceMark | null {
   const all = standings.map((s) => s.scope);
   const mine = standings.filter(customized);
   if (mine.length === 0) return null;
   const unknown = standings.some((s) => s.standing === "unknown");
-  if (mine.length === 1) {
-    const only = mine[0];
-    const where = placeName(only.scope, all);
-    // With a place unread, "1 of 3" would be counting places nobody has
-    // looked at — so the count is left off rather than guessed at.
-    const label =
-      standings.length === 1 || unknown
-        ? `Customized in ${where}`
-        : `Customized in ${where} · 1 of ${standings.length} places`;
-    return { label, goTo: only.scope, why: only.why };
-  }
   const named = mine.map((s) => placeName(s.scope, all)).join(" and ");
-  const label = unknown
-    ? `Customized in ${named}`
-    : `Customized in ${named} · ${mine.length} of ${standings.length} places`;
-  return { label, goTo: null, why: null };
-}
-
-/** The package header's mark: about the place the page is showing, and
- *  only that one. The header names a place, so its badge answers for the
- *  place it names rather than for the package everywhere.
- *
- *  It leads nowhere on purpose. The place it names is the page the reader
- *  is on, so there is no elsewhere to open — a control here would look
- *  like a way somewhere and do nothing. */
-export function headerMark(
-  standings: PlaceStanding[],
-  scope: Scope,
-): PlaceMark | null {
-  const here = standingIn(standings, scope) ?? null;
-  if (!here || !customized(here)) return null;
-  return {
-    label: `Customized in ${placeName(
-      here.scope,
-      standings.map((s) => s.scope),
-    )}`,
-    goTo: null,
-    why: here.why,
-  };
+  // With a place unread, "1 of 3" would be counting places nobody has
+  // looked at — so the count is left off rather than guessed at.
+  const label =
+    standings.length === 1 || unknown
+      ? `Customized in ${named}`
+      : `Customized in ${named} · ${mine.length} of ${standings.length} ${placeWord(all)}`;
+  const only = mine.length === 1 ? mine[0] : null;
+  return { label, goTo: only?.scope ?? null, why: only?.why ?? null };
 }

--- a/ui/src/lib/place-marks.ts
+++ b/ui/src/lib/place-marks.ts
@@ -17,6 +17,14 @@ export interface PlaceMark {
 
 const customized = (s: PlaceStanding) => s.standing === "customized";
 
+/** Names in a line, the way a person writes them: no serial comma, and
+ *  the `and` only in front of the last one. Three places joined with two
+ *  `and`s read as a chant rather than a list. */
+const listed = (names: string[]): string =>
+  names.length < 3
+    ? names.join(" and ")
+    : `${names.slice(0, -1).join(", ")} and ${names[names.length - 1]}`;
+
 /** What a counted set of places is called. Projects among themselves are
  *  projects; the personal scope makes the set a mixed one, and "places" is
  *  the word the rest of the app already uses for that. */
@@ -41,7 +49,7 @@ export function packageMark(standings: PlaceStanding[]): PlaceMark | null {
   const mine = standings.filter(customized);
   if (mine.length === 0) return null;
   const unknown = standings.some((s) => s.standing === "unknown");
-  const named = mine.map((s) => placeName(s.scope, all)).join(" and ");
+  const named = listed(mine.map((s) => placeName(s.scope, all)));
   // With a place unread, "1 of 3" would be counting places nobody has
   // looked at — so the count is left off rather than guessed at.
   const label =

--- a/ui/src/pages/customize.tsx
+++ b/ui/src/pages/customize.tsx
@@ -32,7 +32,7 @@ import { useCustomizedHere } from "@/lib/customized-here";
 import { CONTENT_WIDTH, PAGE_BODY } from "@/lib/layout";
 import { updatesReadState } from "@/lib/updates-read-state";
 import { cn } from "@/lib/utils";
-import { useEditorStore } from "@/stores/editor";
+import { openInventory, useEditorStore } from "@/stores/editor";
 import { useSettingsStore } from "@/stores/settings";
 import { useUpdatesStore } from "@/stores/updates";
 
@@ -43,7 +43,6 @@ export function CustomizePage() {
   const {
     scope,
     draft,
-    inventory,
     dirty,
     loading,
     saving,
@@ -54,6 +53,7 @@ export function CustomizePage() {
     edit,
     save,
   } = useEditorStore();
+  const inventory = useEditorStore(openInventory);
   const projects = useSettingsStore((s) => s.settings?.projects ?? []);
   const customized = useCustomizedHere(draft, scope);
   const updates = useUpdatesStore(updatesReadState);

--- a/ui/src/pages/package.test.tsx
+++ b/ui/src/pages/package.test.tsx
@@ -7,6 +7,7 @@ import type {
   Manifest_Serialize,
   ObservedItem,
   Scope,
+  UpdateRow,
 } from "@/bindings";
 import { commands } from "@/bindings";
 import { ADOPTABLE } from "@/lib/adoptable";
@@ -117,7 +118,34 @@ const openPage = async (
 const editElsewhere = (scope: Project) =>
   act(() => useEditorStore.getState().setScope(scope));
 
-const title = (host: HTMLElement) => host.querySelector("h1")?.textContent;
+const header = (host: HTMLElement) => host.querySelector("header")?.textContent;
+
+/** What the Updates read says about gh in one place: nothing hand-edited
+ *  and nothing forked. Without a row a place's hand-edit state is unread,
+ *  and the mark counts only places somebody has looked at. */
+const updateRow = (scope: Project): UpdateRow => ({
+  scope,
+  kind: "skill",
+  name: "gh",
+  source: "cat",
+  repo: "o/r",
+  repoIdentity: "o/r",
+  current: null,
+  latest: null,
+  updateAvailable: false,
+  pinned: false,
+  holdOwner: null,
+  ignored: false,
+  blockedByLocalEdit: false,
+  editedHarnesses: [],
+  forkableHarness: null,
+  canDiscard: false,
+  canTakeLatest: false,
+  derived: false,
+  forked: false,
+  mixed: false,
+  removedUpstream: false,
+});
 
 beforeEach(() => {
   vi.clearAllMocks();
@@ -263,33 +291,59 @@ describe("the package page's safety block", () => {
   });
 });
 
-// The header names a place, and the editor is pointed wherever the
-// Customize tab was last used. Those are different places the moment the
-// tab's project chip is clicked, and the mark has to keep answering for
-// the one the page is about.
-describe("the package page's header mark", () => {
-  it("still names this place after the editor moves to another", async () => {
-    const host = await openPage(VG, [VG, HYPR], {
-      [scopeKey(VG)]: CUSTOMIZED,
-      [scopeKey(HYPR)]: PLAIN,
+// The page names a place; the mark is about the package. It has to say
+// the same thing the package's Library row says, wherever the page was
+// opened from and wherever the editor is pointed — those are the two ways
+// the same package used to get two different answers.
+describe("the package page's mark", () => {
+  beforeEach(() => {
+    useUpdatesStore.setState({
+      rows: [updateRow(VG), updateRow(HYPR)],
+      loaded: true,
     });
-    expect(title(host)).toContain("Customized in vg");
-
-    await editElsewhere(HYPR);
-    expect(useEditorStore.getState().scope).toEqual(HYPR);
-    expect(title(host)).toContain("Customized in vg");
   });
 
-  it("does not borrow the mark of the place the editor moved to", async () => {
+  it("counts every place, not the one the page was opened at", async () => {
+    const host = await openPage(VG, [VG, HYPR], {
+      [scopeKey(VG)]: CUSTOMIZED,
+      [scopeKey(HYPR)]: CUSTOMIZED,
+    });
+    await settle();
+    expect(header(host)).toContain(
+      "Customized in vg and hyprtrade · 2 of 2 projects",
+    );
+  });
+
+  it("says so about a place the page was not opened at", async () => {
     const host = await openPage(VG, [VG, HYPR], {
       [scopeKey(VG)]: PLAIN,
       [scopeKey(HYPR)]: CUSTOMIZED,
     });
-    expect(title(host)).not.toContain("Customized");
+    await settle();
+    expect(header(host)).toContain("Customized in hyprtrade · 1 of 2 projects");
+  });
+
+  it("stands still while the editor moves to another place", async () => {
+    const host = await openPage(VG, [VG, HYPR], {
+      [scopeKey(VG)]: CUSTOMIZED,
+      [scopeKey(HYPR)]: PLAIN,
+    });
+    await settle();
+    const said = "Customized in vg · 1 of 2 projects";
+    expect(header(host)).toContain(said);
 
     await editElsewhere(HYPR);
-    expect(useEditorStore.getState().draft).toEqual(CUSTOMIZED);
-    expect(title(host)).not.toContain("Customized");
+    expect(useEditorStore.getState().scope).toEqual(HYPR);
+    expect(header(host)).toContain(said);
+  });
+
+  it("says nothing where no place holds anything", async () => {
+    const host = await openPage(VG, [VG, HYPR], {
+      [scopeKey(VG)]: PLAIN,
+      [scopeKey(HYPR)]: PLAIN,
+    });
+    await settle();
+    expect(header(host)?.includes("Customized")).toBe(false);
   });
 });
 

--- a/ui/src/pages/package.tsx
+++ b/ui/src/pages/package.tsx
@@ -98,7 +98,7 @@ export function PackagePage() {
     ),
   );
 
-  const mark = usePackageMark(group, ref?.scope ?? null);
+  const mark = usePackageMark(group);
   // The package can still be installed elsewhere while this place has no
   // copy of it — a page about a place that does not have it has nothing
   // to show and no actions that would land anywhere.

--- a/ui/src/stores/editor-cache.ts
+++ b/ui/src/stores/editor-cache.ts
@@ -1,0 +1,57 @@
+import { commands, type EditorInventory, type Scope } from "@/bindings";
+import { type Draft, emptyDraft, toDraft } from "@/lib/editor-draft";
+import { scopeKey } from "@/lib/scope";
+
+// The editor's scope-keyed caches: what is read per place, how it is
+// written, and how the open place's answer is found. Split out from the
+// store so there is one module to look at when asking whether a value can
+// belong to the wrong place: the store only calls these.
+
+/** The inventory of the place the editor is open at, and no other. A
+ *  lookup rather than a field, so the answer is either this place's or
+ *  absent — there is no third state where another place's read is still
+ *  on screen. */
+export const openInventory = (state: {
+  scope: Scope;
+  inventories: Record<string, EditorInventory>;
+}): EditorInventory | null => state.inventories[scopeKey(state.scope)] ?? null;
+
+/** What one scope's read produced, written into that scope's key — or its
+ *  absence, when the read produced nothing.
+ *
+ *  Every scope-keyed cache is written through here and nowhere else. A
+ *  cache that is only written on success keeps its last good answer for a
+ *  place that has stopped reading, and the place then goes on being marked
+ *  from a manifest nobody can see any more. Passing the failure through as
+ *  `null` is what makes an unread place unread rather than stale, and
+ *  having one writer is what stops the next cache from needing its own
+ *  invalidation point. */
+export const recorded = <T>(
+  cache: Record<string, T>,
+  scope: Scope,
+  value: T | null,
+): Record<string, T> => {
+  const next = { ...cache };
+  if (value === null) delete next[scopeKey(scope)];
+  else next[scopeKey(scope)] = value;
+  return next;
+};
+
+/** Each named scope's saved manifest, keyed by scope. A read that fails is
+ *  left out rather than recorded as an empty manifest: a place nobody could
+ *  read is not a place holding nothing, and the marks tell them apart. */
+export const manifestsOf = async (
+  scopes: Scope[],
+): Promise<Record<string, Draft>> => {
+  const loaded = await Promise.all(
+    scopes.map((scope) => commands.getManifest(scope)),
+  );
+  const saved: Record<string, Draft> = {};
+  for (const [index, response] of loaded.entries()) {
+    if (response.status !== "ok") continue;
+    saved[scopeKey(scopes[index])] = response.data.manifest
+      ? toDraft(response.data.manifest)
+      : emptyDraft();
+  }
+  return saved;
+};

--- a/ui/src/stores/editor.test.ts
+++ b/ui/src/stores/editor.test.ts
@@ -1,7 +1,9 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import type { AuditView_Serialize, EditorInventory } from "@/bindings";
+import type { AuditView_Serialize, EditorInventory, Scope } from "@/bindings";
 import { commands } from "@/bindings";
+import { groupItems } from "@/lib/derive";
 import { emptyDraft } from "@/lib/editor-draft";
+import { markFor } from "@/lib/package-mark";
 import { useEditorStore } from "./editor";
 
 vi.mock("@/bindings", () => ({
@@ -112,5 +114,72 @@ describe("editor store", () => {
     expect(state.base).toBe("b2");
     expect(state.draft).toEqual(emptyDraft());
     expect(state.dirty).toBe(false);
+  });
+});
+
+// A place whose manifest cannot be read is unread, not whatever it last
+// said. Left standing, the cached answer keeps the mark claiming a
+// customization nobody can see any more — the one thing the third state
+// ("unknown", never "stock") exists to prevent.
+describe("loadPlaces after a read stops working", () => {
+  const VG: Scope = { scope: "project", root: "/work/vg" };
+  const HYPR: Scope = { scope: "project", root: "/work/hyprtrade" };
+  const CUSTOMIZED = {
+    schema: 1,
+    install: {},
+    "skill-instructions": { gh: "mine" },
+  };
+
+  const item = (scope: Scope) => ({
+    kind: "skill",
+    name: "gh",
+    scope,
+    harness: "claude",
+    path: "/x/.claude/skills/gh",
+    fileState: "file",
+    enabled: true,
+    origin: null,
+    description: "about gh",
+    tags: [],
+  });
+  const group = groupItems([item(VG), item(HYPR)] as never)[0];
+
+  const answer = (ok: boolean) =>
+    vi.mocked(commands.getManifest).mockImplementation((scope) =>
+      Promise.resolve(
+        ok || scope.scope !== "project" || scope.root !== VG.root
+          ? {
+              status: "ok" as const,
+              data: {
+                manifest: (scope.scope === "project" && scope.root === VG.root
+                  ? CUSTOMIZED
+                  : { schema: 1, install: {} }) as never,
+                base: null,
+              },
+            }
+          : { status: "error" as const, error: "permission denied" },
+      ),
+    );
+
+  it("drops the place it can no longer read instead of keeping its last answer", async () => {
+    answer(true);
+    await useEditorStore.getState().loadPlaces([VG, HYPR]);
+    expect(
+      markFor(useEditorStore.getState().saved, [], true, group)?.label,
+    ).toBe("Customized in vg");
+
+    answer(false);
+    await useEditorStore.getState().loadPlaces([VG, HYPR]);
+    expect(useEditorStore.getState().saved["/work/vg"]).toBeUndefined();
+    expect(
+      markFor(useEditorStore.getState().saved, [], true, group),
+    ).toBeNull();
+  });
+
+  it("leaves the places it was not asked about alone", async () => {
+    useEditorStore.setState({ saved: { elsewhere: emptyDraft() } });
+    answer(true);
+    await useEditorStore.getState().loadPlaces([VG]);
+    expect(useEditorStore.getState().saved.elsewhere).toEqual(emptyDraft());
   });
 });

--- a/ui/src/stores/editor.test.ts
+++ b/ui/src/stores/editor.test.ts
@@ -4,7 +4,7 @@ import { commands } from "@/bindings";
 import { groupItems } from "@/lib/derive";
 import { emptyDraft } from "@/lib/editor-draft";
 import { markFor } from "@/lib/package-mark";
-import { useEditorStore } from "./editor";
+import { openInventory, useEditorStore } from "./editor";
 
 vi.mock("@/bindings", () => ({
   commands: {
@@ -35,8 +35,8 @@ describe("editor store", () => {
       scope: { scope: "global" },
       draft: null,
       base: null,
-      inventory: null,
       saved: {},
+      inventories: {},
       dirty: false,
       loading: false,
       saving: false,
@@ -181,5 +181,78 @@ describe("loadPlaces after a read stops working", () => {
     answer(true);
     await useEditorStore.getState().loadPlaces([VG]);
     expect(useEditorStore.getState().saved.elsewhere).toEqual(emptyDraft());
+  });
+});
+
+// Switching a place chip goes through setScope/load, not loadPlaces. A
+// cache that is only written on success keeps the last place's answer,
+// and the mark and the Skills section then read it as this place's.
+describe("a place the editor switches to and cannot read", () => {
+  const VG: Scope = { scope: "project", root: "/work/vg" };
+  const HYPR: Scope = { scope: "project", root: "/work/hyprtrade" };
+  const CUSTOMIZED = {
+    schema: 1,
+    install: {},
+    "skill-instructions": { gh: "mine" },
+  };
+  const forVG = { declaredAgents: ["orch"] } as unknown as EditorInventory;
+  const forHYPR = { declaredAgents: ["scout"] } as unknown as EditorInventory;
+
+  const manifestReads = (ok: boolean) =>
+    vi.mocked(commands.getManifest).mockResolvedValue(
+      ok
+        ? {
+            status: "ok",
+            data: { manifest: CUSTOMIZED as never, base: null },
+          }
+        : { status: "error", error: "permission denied" },
+    );
+  const inventoryReads = (data: EditorInventory | null) =>
+    vi
+      .mocked(commands.editorInventory)
+      .mockResolvedValue(
+        data
+          ? { status: "ok", data }
+          : { status: "error", error: "no sources" },
+      );
+
+  // Read once, so there is a cached answer to go stale, then read again
+  // and fail. Without the first read this proves nothing.
+  it("drops the manifest it read before rather than keeping it", async () => {
+    manifestReads(true);
+    inventoryReads(forHYPR);
+    await useEditorStore.getState().setScope(HYPR);
+    expect(useEditorStore.getState().saved["/work/hyprtrade"]).toBeDefined();
+
+    manifestReads(false);
+    await useEditorStore.getState().setScope(VG);
+    await useEditorStore.getState().setScope(HYPR);
+    expect(useEditorStore.getState().saved["/work/hyprtrade"]).toBeUndefined();
+  });
+
+  it("drops the inventory it read before rather than keeping it", async () => {
+    manifestReads(true);
+    inventoryReads(forHYPR);
+    await useEditorStore.getState().setScope(HYPR);
+    expect(openInventory(useEditorStore.getState())).toBe(forHYPR);
+
+    inventoryReads(null);
+    await useEditorStore.getState().setScope(VG);
+    await useEditorStore.getState().setScope(HYPR);
+    expect(openInventory(useEditorStore.getState())).toBeNull();
+    expect(useEditorStore.getState().error).toBe("no sources");
+  });
+
+  // The point of keying these by scope: another place's answer is not
+  // reachable from here, whatever the reads did.
+  it("never serves one place's inventory as another's", () => {
+    useEditorStore.setState({
+      scope: HYPR,
+      inventories: { "/work/vg": forVG },
+    });
+    expect(openInventory(useEditorStore.getState())).toBeNull();
+
+    useEditorStore.setState({ scope: VG });
+    expect(openInventory(useEditorStore.getState())).toBe(forVG);
   });
 });

--- a/ui/src/stores/editor.ts
+++ b/ui/src/stores/editor.ts
@@ -182,7 +182,17 @@ export const useEditorStore = create<EditorState>((set, get) => {
 
     loadPlaces: async (scopes) => {
       const read = await manifestsOf(scopes);
-      set((state) => ({ saved: { ...state.saved, ...read } }));
+      set((state) => {
+        const saved = { ...state.saved };
+        // Every scope asked for leaves first. A read that failed has to
+        // land as unread, and merging over what is already there would
+        // leave the last answer standing instead — a place that read
+        // fine once and cannot be read now would go on being counted
+        // customized, which is the one thing the third state exists to
+        // prevent.
+        for (const scope of scopes) delete saved[scopeKey(scope)];
+        return { saved: { ...saved, ...read } };
+      });
     },
 
     edit: (change) => {

--- a/ui/src/stores/editor.ts
+++ b/ui/src/stores/editor.ts
@@ -32,9 +32,31 @@ interface EditorState {
   load: () => Promise<void>;
   /** Read every scope's manifest, for the marks drawn outside the editor. */
   loadAll: () => Promise<void>;
+  /** Read the manifests of named places only, merged into what is already
+   *  read. A page about one package needs the places that package sits in
+   *  and nothing else — asking for every scope would put the machine's
+   *  whole project list behind one package's mark. */
+  loadPlaces: (scopes: Scope[]) => Promise<void>;
   edit: (change: (draft: Draft) => Draft) => void;
   save: () => Promise<void>;
 }
+
+/** Each named scope's saved manifest, keyed by scope. A read that fails is
+ *  left out rather than recorded as an empty manifest: a place nobody could
+ *  read is not a place holding nothing, and the marks tell them apart. */
+const manifestsOf = async (scopes: Scope[]): Promise<Record<string, Draft>> => {
+  const loaded = await Promise.all(
+    scopes.map((scope) => commands.getManifest(scope)),
+  );
+  const saved: Record<string, Draft> = {};
+  for (const [index, response] of loaded.entries()) {
+    if (response.status !== "ok") continue;
+    saved[scopeKey(scopes[index])] = response.data.manifest
+      ? toDraft(response.data.manifest)
+      : emptyDraft();
+  }
+  return saved;
+};
 
 export const useEditorStore = create<EditorState>((set, get) => {
   const load = async () => {
@@ -153,17 +175,14 @@ export const useEditorStore = create<EditorState>((set, get) => {
         { scope: "global" },
         ...projects.map((root) => ({ scope: "project" as const, root })),
       ];
-      const loaded = await Promise.all(
-        scopes.map((scope) => commands.getManifest(scope)),
-      );
-      const saved: Record<string, Draft> = {};
-      for (const [index, response] of loaded.entries()) {
-        if (response.status !== "ok") continue;
-        saved[scopeKey(scopes[index])] = response.data.manifest
-          ? toDraft(response.data.manifest)
-          : emptyDraft();
-      }
-      set({ saved });
+      // Replaced, not merged: this is the whole list, so a scope that has
+      // gone leaves with it.
+      set({ saved: await manifestsOf(scopes) });
+    },
+
+    loadPlaces: async (scopes) => {
+      const read = await manifestsOf(scopes);
+      set((state) => ({ saved: { ...state.saved, ...read } }));
     },
 
     edit: (change) => {

--- a/ui/src/stores/editor.ts
+++ b/ui/src/stores/editor.ts
@@ -3,8 +3,11 @@ import { commands, type EditorInventory, type Scope } from "@/bindings";
 import { type Draft, emptyDraft, toDraft } from "@/lib/editor-draft";
 import { sameScope, scopeKey } from "@/lib/scope";
 import { useAuditStore } from "./audit";
+import { manifestsOf, openInventory, recorded } from "./editor-cache";
 import { useScanStore } from "./scan";
 import { useSettingsStore } from "./settings";
+
+export { openInventory } from "./editor-cache";
 
 interface EditorState {
   /** The single scope being edited — deliberately not the sidebar filter. */
@@ -14,11 +17,16 @@ interface EditorState {
    *  with every save, so a copy of a file something else has since written
    *  is refused instead of putting the older file back. */
   base: string | null;
-  inventory: EditorInventory | null;
   /** Every scope's saved manifest, keyed by scope. What the Library and the
    *  Customize index read to mark what has been customized; `draft` above is
    *  the one copy being edited. */
   saved: Record<string, Draft>;
+  /** Every scope's editor inventory, keyed by scope. Keyed rather than
+   *  held loose beside `scope`, so a read belonging to one place cannot be
+   *  served as another's answer: read it through {@link openInventory},
+   *  which finds nothing for a place that was never read or whose read
+   *  failed. */
+  inventories: Record<string, EditorInventory>;
   dirty: boolean;
   loading: boolean;
   saving: boolean;
@@ -41,23 +49,6 @@ interface EditorState {
   save: () => Promise<void>;
 }
 
-/** Each named scope's saved manifest, keyed by scope. A read that fails is
- *  left out rather than recorded as an empty manifest: a place nobody could
- *  read is not a place holding nothing, and the marks tell them apart. */
-const manifestsOf = async (scopes: Scope[]): Promise<Record<string, Draft>> => {
-  const loaded = await Promise.all(
-    scopes.map((scope) => commands.getManifest(scope)),
-  );
-  const saved: Record<string, Draft> = {};
-  for (const [index, response] of loaded.entries()) {
-    if (response.status !== "ok") continue;
-    saved[scopeKey(scopes[index])] = response.data.manifest
-      ? toDraft(response.data.manifest)
-      : emptyDraft();
-  }
-  return saved;
-};
-
 export const useEditorStore = create<EditorState>((set, get) => {
   const load = async () => {
     const { scope } = get();
@@ -73,13 +64,18 @@ export const useEditorStore = create<EditorState>((set, get) => {
       set({ loading: false });
     }
     if (manifest.status === "error") {
-      set({
+      set((state) => ({
         draft: null,
         base: null,
+        // This place has stopped reading, so what it last said goes with
+        // it. Left in place, the mark would keep answering for this
+        // package here out of a manifest that can no longer be read.
+        saved: recorded(state.saved, scope, null),
+        inventories: recorded(state.inventories, scope, null),
         dirty: false,
         stale: false,
         error: manifest.error,
-      });
+      }));
       return;
     }
     // With no manifest here yet the editor still opens, on an empty one:
@@ -91,8 +87,16 @@ export const useEditorStore = create<EditorState>((set, get) => {
     set((state) => ({
       draft,
       base: manifest.data.base,
-      inventory: inventory.status === "ok" ? inventory.data : state.inventory,
-      saved: { ...state.saved, [scopeKey(scope)]: draft },
+      saved: recorded(state.saved, scope, draft),
+      // An inventory that failed to read leaves this place without one,
+      // rather than leaving the last place's on screen: the Skills section
+      // would otherwise offer another place's assignment as this one's,
+      // and a pick made from it writes a declaration nobody meant.
+      inventories: recorded(
+        state.inventories,
+        scope,
+        inventory.status === "ok" ? inventory.data : null,
+      ),
       dirty: false,
       stale: false,
       error: inventory.status === "ok" ? null : inventory.error,
@@ -137,8 +141,8 @@ export const useEditorStore = create<EditorState>((set, get) => {
     scope: { scope: "global" },
     draft: null,
     base: null,
-    inventory: null,
     saved: {},
+    inventories: {},
     dirty: false,
     loading: false,
     saving: false,
@@ -182,17 +186,12 @@ export const useEditorStore = create<EditorState>((set, get) => {
 
     loadPlaces: async (scopes) => {
       const read = await manifestsOf(scopes);
-      set((state) => {
-        const saved = { ...state.saved };
-        // Every scope asked for leaves first. A read that failed has to
-        // land as unread, and merging over what is already there would
-        // leave the last answer standing instead — a place that read
-        // fine once and cannot be read now would go on being counted
-        // customized, which is the one thing the third state exists to
-        // prevent.
-        for (const scope of scopes) delete saved[scopeKey(scope)];
-        return { saved: { ...saved, ...read } };
-      });
+      set((state) => ({
+        saved: scopes.reduce(
+          (saved, scope) => recorded(saved, scope, read[scopeKey(scope)]),
+          state.saved,
+        ),
+      }));
     },
 
     edit: (change) => {

--- a/ui/src/stores/editor.ts
+++ b/ui/src/stores/editor.ts
@@ -3,7 +3,7 @@ import { commands, type EditorInventory, type Scope } from "@/bindings";
 import { type Draft, emptyDraft, toDraft } from "@/lib/editor-draft";
 import { sameScope, scopeKey } from "@/lib/scope";
 import { useAuditStore } from "./audit";
-import { manifestsOf, openInventory, recorded } from "./editor-cache";
+import { manifestsOf, recorded } from "./editor-cache";
 import { useScanStore } from "./scan";
 import { useSettingsStore } from "./settings";
 


### PR DESCRIPTION
The Library row said `Customized in hyprtrade and kendex and vg · 3 of 3 places`
and the same package's header said `Customized in hyprtrade`. Both were true by
their own rule, and nothing told the reader they answered different questions.
The header only ever spoke for the place its page was opened at.

There is no engine bug here. `customizedItems` and `placeFacts` read the manifest
correctly and `3 of 3` was the true count. The owner read the `kendex` place as
untouched and concluded the app could not load `kendex-local.toml`; what actually
happened is that its one customization is frontmatter, drawn in the same grid as
twelve hardcoded placeholder examples.

## What changed

One mark rule, drawn the same way in the Library row and the package header. The
header reads every place the package sits in rather than the one it was opened
at, so the words and the count match wherever they appear. A count over projects
says `projects` and becomes `places` once the personal scope is among them.

The header's pill is gone. The mark is plain text in the customized colour under
the title, with the kind icon in that colour, matching how the Library row
already marks a customized package.

The Customize tab could not settle the argument either, so its place chips now
carry the mark. A settings field holding a value says so on its label, so a place
customized only through Settings no longer reads as untouched beside the
placeholder examples. The Skills section names the skills the catalog gives an
agent instead of showing an empty box that reads as "none" — and the old copy
claiming kendex picks skills from the agent's tags is gone, because it never did.

## The one backend change

`EditorInventory` gains `automatic_skills`, read from the lock's existing
`upstream_skills` field. The UI had no list of what an untouched agent gets. It
reads the recorded assignment rather than recomputing one, because a fresh
computation would name skills no apply has written. Read-only, no schema change,
and a v1 lock degrades to "nothing recorded" like the rest of the read surface.

## Scope

`installed-row.tsx` carries a comment arguing the mark must never be hover-only.
KEN-782 moves the Library mark to hover and lands after this, so that comment is
untouched here — the issue says whichever change lands second amends it.

The Projects tab, the Delete dialog and the hover behaviour are KEN-782. Tab
order is left alone; KEN-717 and KEN-782 both negotiate it.

## Verification

`tools/guard` green. 909 UI tests pass across 111 files, 14 of them new, covering
the mark rule, the header, the place chips, the settings labels and the skills
naming.

The visual requirements are confirmed by DOM tests rather than by eye. This is
owner-reported UX, so the running app is the real check.

Closes KEN-783
