### PR TITLE
fix(KEN-770): a fork or a keep refuses a slot it cannot read back

### DIFF
--- a/changelog.d/fixed/KEN-770.md
+++ b/changelog.d/fixed/KEN-770.md
@@ -1,0 +1,3 @@
+- Forking in place, and keeping a marketplace's packages when you unsubscribe,
+  now refuse a symlink inside `.kendex-local` that would have put the copy
+  outside the project rather than in it.

--- a/crates/core/src/engine/detach.rs
+++ b/crates/core/src/engine/detach.rs
@@ -295,10 +295,13 @@ fn effective_commit(lock: &crate::lock::Lock, item: &ClosureItem) -> Result<Opti
 }
 
 /// The path in the local source one detached item's source-form bytes are
-/// written to. A `plugin/item` name nests one directory level, the shape the
-/// local reader lists back.
-fn local_target(local_root: &std::path::Path, kind: ItemKind, name: &str) -> Result<PathBuf> {
-    Ok(match kind {
+/// written to, or why they may not be. A `plugin/item` name nests one
+/// directory level, the shape the local reader lists back. A symlink among
+/// the components below the local source's root puts the write outside the
+/// scope, where no later read of this source finds the kept package.
+fn local_target(env: &Env, scope: &Scope, kind: ItemKind, name: &str) -> Result<PathBuf> {
+    let local_root = local_source_root(env, scope);
+    let target = match kind {
         ItemKind::Skill => local_root.join("skills").join(name),
         ItemKind::Agent => local_root.join("agents").join(format!("{name}.md")),
         ItemKind::Hook => local_root.join("hooks").join(format!("{name}.sh")),
@@ -310,7 +313,11 @@ fn local_target(local_root: &std::path::Path, kind: ItemKind, name: &str) -> Res
                 source_name: format!("detach does not support {} yet", other.name()),
             });
         }
-    })
+    };
+    if let Some(escape) = crate::source::slot_escapes(env, scope, &target)? {
+        return Err(escape);
+    }
+    Ok(target)
 }
 
 /// Unsubscribe but keep the packages: convert each installation to a local one
@@ -340,7 +347,6 @@ pub fn source(env: &Env, scope: &Scope, source_name: &str) -> Result<Plan> {
         });
     }
 
-    let local_root = local_source_root(env, &scope);
     let mut ops = Vec::new();
     let mut carried: Vec<(String, AgentCarry)> = Vec::new();
     for item in &closure.items {
@@ -350,7 +356,7 @@ pub fn source(env: &Env, scope: &Scope, source_name: &str) -> Result<Plan> {
         let commit = effective_commit(&lock, item)?;
         let (files, carry) = source_form(env, &scope, &manifest, item, commit.as_deref())?;
         carried.extend(carry.map(|carry| (item.name.clone(), carry)));
-        let target = local_target(&local_root, item.kind, &item.name)?;
+        let target = local_target(env, &scope, item.kind, &item.name)?;
         ops.extend(capture_to_local(item.kind, &item.name, &target, files)?);
     }
     // The catalog's own mapping tables shaped every rendering — skills the

--- a/crates/core/src/engine/fork.rs
+++ b/crates/core/src/engine/fork.rs
@@ -326,6 +326,12 @@ fn local_item(env: &Env, scope: &Scope, kind: ItemKind, name: &str) -> PathBuf {
 /// are captured under the same name, and the edited artifact itself goes
 /// to the trash — bound to the exact bytes just captured (invariant 7) —
 /// so the follow-up apply renders the fork in its place.
+///
+/// The slot has to be one this scope's local source can read back, asked
+/// here rather than at each caller: a fork in place has no new name to ask
+/// it of. `Pre::Absent` refuses a link wearing the item's own name, but a
+/// link one component above leaves the slot absent past it, and the
+/// capture lands at the far end, outside anything kendex manages.
 fn capture_ops(
     env: &Env,
     scope: &Scope,
@@ -335,6 +341,9 @@ fn capture_ops(
     captured: Capture,
 ) -> Result<Vec<PlannedOp>> {
     let local_item = local_item(env, scope, kind, name);
+    if let Some(escape) = crate::source::slot_escapes(env, scope, &local_item)? {
+        return Err(escape);
+    }
     let mut ops = Vec::new();
     if local_item.exists() {
         ops.push(PlannedOp {

--- a/crates/core/tests/edits_and_forks/forks.rs
+++ b/crates/core/tests/edits_and_forks/forks.rs
@@ -499,3 +499,68 @@ fn forking_the_users_own_content_is_refused() {
     assert_eq!(manifest_text(&w), before);
     assert!(!w.home.join("app/.kendex-local/skills/here").exists());
 }
+
+/// A fork in place captures under the name the item already has, so it
+/// never passes the vacancy check that asks a new name whether its slot is
+/// reachable. `Pre::Absent` refuses a link wearing the item's own name, but
+/// a link one component above — the `skills` directory of the local source
+/// — leaves the slot absent past it, and the captured tree would land at
+/// the far end, outside anything kendex manages. Refused before an op is
+/// planned, with nothing written through the link.
+/// Built on the world whose home is itself reached through a link, the
+/// spelling macOS hands every test: the sealed reader probes from the
+/// canonicalized root, so an assertion in the caller's spelling would pass
+/// on Linux and fail on the macOS lane alone.
+#[cfg(unix)]
+#[test]
+#[allow(clippy::unwrap_used)]
+fn a_local_source_reached_through_a_link_refuses_the_fork() {
+    let w = world_via_link();
+    write_skill(&w.upstream, "gh", "Upstream.");
+    commit(&w.upstream, "one");
+    declare(&w, "[skills.gh]\nsource = \"cat\"\n");
+    sync_and_apply(&w);
+    fs::write(
+        skill_file(&w),
+        "---\nname: gh\ndescription: mine\n---\nMine.\n",
+    )
+    .unwrap();
+
+    // The component above the slot — not the slot itself — is the link.
+    let outside = w.home.join("outside");
+    fs::create_dir_all(&outside).unwrap();
+    fs::create_dir_all(w.home.join("app/.kendex-local")).unwrap();
+    let skills = w.home.join("app/.kendex-local/skills");
+    std::os::unix::fs::symlink(&outside, &skills).unwrap();
+    let before = manifest_text(&w);
+
+    let refused =
+        fork::fork(&w.env, &w.scope, ItemKind::Skill, "gh", HarnessId::Claude).unwrap_err();
+    // The reader probes from the canonicalized local-source root, so that
+    // is the spelling the refusal names. The root is a real directory; the
+    // component below it is the link, and canonicalizing that would follow
+    // it.
+    let named = w
+        .home
+        .join("app/.kendex-local")
+        .canonicalize()
+        .unwrap()
+        .join("skills");
+    assert!(
+        matches!(&refused, CoreError::SourceEscape { path, reason }
+            if path == &named && reason.contains("symlink")),
+        "the refusal must name the link it stopped at: {refused:?}"
+    );
+    assert!(
+        !outside.join("gh").exists(),
+        "the capture wrote through the link, at the far end of it"
+    );
+    assert!(skills.is_symlink(), "the link itself was replaced");
+    assert_eq!(manifest_text(&w), before);
+    assert!(
+        fs::read_to_string(skill_file(&w))
+            .unwrap()
+            .contains("Mine."),
+        "a refused fork must leave the edited install alone"
+    );
+}

--- a/crates/core/tests/unsubscribe_keep.rs
+++ b/crates/core/tests/unsubscribe_keep.rs
@@ -7,6 +7,7 @@ use std::path::Path;
 
 use kendex_core::apply;
 use kendex_core::env::{Env, FakeOs};
+use kendex_core::error::CoreError;
 use kendex_core::manifest::{self, ManifestFile};
 use kendex_core::model::Scope;
 
@@ -27,8 +28,37 @@ fn world(
     extra_sources: &str,
 ) -> (tempfile::TempDir, Env, Scope, std::path::PathBuf) {
     let tmp = tempfile::tempdir().unwrap();
-    let home = tmp.path();
-    let env = Env::fake(home, FakeOs::Linux);
+    let home = tmp.path().to_path_buf();
+    world_at(tmp, home, declarations, extra_sources)
+}
+
+/// [`world`], with every path reaching the home through a symlink — the
+/// spelling macOS hands every test anyway (`/var` → `/private/var` fronts
+/// its temp directories), reproduced here so the canonical spelling the
+/// engine speaks and the one the caller holds differ on every platform.
+#[allow(clippy::unwrap_used)]
+fn world_via_link(
+    declarations: &str,
+    extra_sources: &str,
+) -> (tempfile::TempDir, Env, Scope, std::path::PathBuf) {
+    let tmp = tempfile::tempdir().unwrap();
+    let real = tmp.path().join("real");
+    fs::create_dir_all(&real).unwrap();
+    let home = tmp.path().join("via");
+    std::os::unix::fs::symlink(&real, &home).unwrap();
+    world_at(tmp, home, declarations, extra_sources)
+}
+
+/// The fixture body both worlds share; `home` is the spelling every path
+/// handed back speaks.
+#[allow(clippy::unwrap_used)]
+fn world_at(
+    tmp: tempfile::TempDir,
+    home: std::path::PathBuf,
+    declarations: &str,
+    extra_sources: &str,
+) -> (tempfile::TempDir, Env, Scope, std::path::PathBuf) {
+    let env = Env::fake(&home, FakeOs::Linux);
     let project = home.join("dev/app");
     fs::create_dir_all(project.join(".claude")).unwrap();
     let catalog = home.join("catalog");
@@ -108,5 +138,57 @@ fn keeping_an_agent_carries_the_catalogs_mapping_tables() {
         settled.plan.is_empty(),
         "a kept scope must audit clean: {:?}",
         settled.plan.ops
+    );
+}
+
+/// Keeping a marketplace's packages writes source-form bytes into the
+/// local source, and the slot it writes to has to be one that source can
+/// read back. A symlink among the components below the local source's
+/// root — its `skills` directory here — sends the write to the far end of
+/// the link, outside anything kendex manages, where no later read of the
+/// source finds the package the keep was for. Refused before an op is
+/// planned, with nothing written through the link.
+///
+/// Built on the world whose home is reached through a symlink: detach
+/// canonicalizes the scope and the sealed reader probes from the
+/// canonicalized root, so an assertion written in the caller's spelling
+/// would pass on Linux and fail on the macOS lane alone.
+#[test]
+#[allow(clippy::unwrap_used)]
+fn keeping_a_package_refuses_a_local_source_reached_through_a_link() {
+    let (_tmp, env, scope, catalog) = world_via_link("[skills.gh]\nsource = \"cat\"\n", "");
+    skill(&catalog, "gh", "Upstream.");
+    apply_now(&env, &scope);
+
+    // The component above the slot — not the slot itself — is the link.
+    let home = catalog.parent().unwrap();
+    let outside = home.join("outside");
+    fs::create_dir_all(&outside).unwrap();
+    let local = home.join("dev/app/.kendex-local");
+    fs::create_dir_all(&local).unwrap();
+    let skills = local.join("skills");
+    std::os::unix::fs::symlink(&outside, &skills).unwrap();
+    let before = fs::read_to_string(manifest::manifest_path(&env, &scope)).unwrap();
+
+    let refused = kendex_core::engine::detach::source(&env, &scope, "cat").unwrap_err();
+    // The reader probes from the canonicalized local-source root, so that
+    // is the spelling the refusal names. The root is a real directory; the
+    // component below it is the link, and canonicalizing that would follow
+    // it.
+    let named = local.canonicalize().unwrap().join("skills");
+    assert!(
+        matches!(&refused, CoreError::SourceEscape { path, reason }
+            if path == &named && reason.contains("symlink")),
+        "the refusal must name the link it stopped at: {refused:?}"
+    );
+    assert!(
+        !outside.join("gh").exists(),
+        "the keep wrote through the link, at the far end of it"
+    );
+    assert!(skills.is_symlink(), "the link itself was replaced");
+    assert_eq!(
+        fs::read_to_string(manifest::manifest_path(&env, &scope)).unwrap(),
+        before,
+        "a refused keep leaves the subscription declared"
     );
 }

--- a/tools/size-ratchet-baseline.tsv
+++ b/tools/size-ratchet-baseline.tsv
@@ -1,6 +1,6 @@
 .github/workflows/review-gate-writer.yml	662
 .github/workflows/skill-tests.yml	408
-crates/core/src/engine/detach.rs	541
+crates/core/src/engine/detach.rs	547
 crates/core/src/engine/pi_hooks_move/migrated.rs	540
 crates/core/src/engine/pi_hooks_move/mod.rs	503
 crates/core/src/engine/pi_hooks_move/preflight.rs	765


### PR DESCRIPTION
Two planners derived a write target inside the scope's local source without asking whether that slot is one the source can read back. A symlink among the components below the local source root leaves the slot itself absent past the link, so `Pre::Absent` passes and the bytes land at the far end — outside anything kendex manages, where no later read of the source finds them. The rename case was demonstrated on #1780.

Both now ask `source::slot_escapes`, at the function that derives the target rather than at each caller:

- `fork::capture_ops` — the one a fork in place reaches, under the unchanged name and so never through `vacant_name`.
- `detach::local_target` — asked no containment question at all; now takes `(env, scope, kind, name)` and derives the local root itself, mirroring `adopt::destination`.

`fork_beside`, `adopt` and `rename_fork` were already covered and are untouched.

## Enumeration

Every planner in `crates/core/src/engine` that computes a local-source write target was read off where the target is derived, not off the names in the issue. Reproduce with a sweep of the write-op variants (`WriteTree`, `WriteFile`, `Symlink`, `EditFile`, `WriteExecutable`, `Rename`) for those whose destination is under `local_source_root`. Result: the two fixed here, three already covered, and the rest write elsewhere or plan nothing. No third uncovered site.

## Tests

One per site, both on a linked world:

- `forks::a_local_source_reached_through_a_link_refuses_the_fork`
- `keeping_a_package_refuses_a_local_source_reached_through_a_link`

`unsubscribe_keep.rs` had no linked world, so its `world` is split into `world_at` with a `world_via_link` beside it. That is load-bearing rather than cosmetic: detach canonicalizes the scope, so a refusal asserted in the caller's path spelling passes under a plain `world()` and fails only on the linked world — the shape that passes on Linux and fails on the macOS lane.

Each asserts the refusal is `CoreError::SourceEscape` naming the canonicalized component with a `symlink` reason, that nothing exists at the far end of the link, that the link is intact, and that the manifest is byte-identical. Each was run red with only its own guard removed; the fork case planned `WriteTree` rooted at the far end.

## Note for review

`crates/core/src/engine/detach.rs` raises its size-ratchet row 541 → 547, carried as `RATCHET_RAISE=1` on the commit. The added lines are the guard call and the comment naming what it holds; the file has no concept seam to split at.

A pre-existing limit is unchanged and deliberately not narrowed: `SealedSource::open` canonicalizes the local source root, so a link at `.kendex-local` itself is followed once. Everything below it is refused.

Closes KEN-770
