### PR TITLE
docs(KEN-781): each workflow step is numbered, each rule has one owner

### DIFF
--- a/.agents/skills/project-management/README.md
+++ b/.agents/skills/project-management/README.md
@@ -1,6 +1,6 @@
 # Project Management Skill
 
-Turns planning conversations into tracked work: cycle plans, backlog audits, roadmaps, and research-driven decomposition. It exists to keep the backlog small and true — every audit is expected to close more issues than it opens, and an observation only becomes an issue when it changes what someone experiences and someone could finish it as-is.
+Turns planning conversations into tracked work: cycle plans, backlog audits, roadmaps, and research-driven decomposition. It exists to keep the backlog small and true; what qualifies as an issue and what gets closed is the creation bar in [`SKILL.md`](SKILL.md) § Disposition.
 
 ## How it works
 

--- a/.agents/skills/project-management/SKILL.md
+++ b/.agents/skills/project-management/SKILL.md
@@ -42,7 +42,7 @@ Wrappers run in the primary session: they own the user dialog and every tracker 
 | `research-complete` | `[ISSUE_ID]` | [research-complete](workflows/research-complete.md) |
 | `research-issue` | — | [research-issue](workflows/research-issue.md) — internal, invoked by `research-spike` |
 
-`audit-issues` is **primary-session only**: § 6 needs the session's interactive question tool, and § 7 mutates only against approvals collected there — the roadmap-plan § 5 answer that roadmap-create carries in is validated and admitted at § 6, never around it. Delegate the `tpm-audit.md` analysis it spawns, never the wrapper.
+`audit-issues` is **primary-session only** ([audit-issues](workflows/audit-issues.md) preamble): the roadmap-plan § 5 answer that roadmap-create carries in is validated and admitted at § 6, never around it.
 
 The `@[path]` given to `roadmap plan` may be research findings or a **finished plan** (a design the user has reviewed). A finished plan is the spec: derive issues from it instead of re-planning, and every issue cites it.
 
@@ -57,7 +57,7 @@ TPM analysis workflows, each returning JSON per its schema: [tpm-cycle-plan](wor
 - Every path's scope status is enumerated in § Scope by Path; a mode added later states its own row rather than inheriting silence.
 - Sync the Linear cache before a workflow's first cache read: `sync --reconcile` in a run that mutates the tracker, `sync --if-stale 15` in a read-only lookup. A cache read that comes back missing or stale after that halts the workflow and reports the sync failure — never a partial result, a live-only substitute, or a retry against the stale cache.
 - Resolve tracker context once per run (audit-issues § 1.2) and route every preflight, fetch, and mutation through it. A GitHub-tracked run must not require Linear installation, sync, or authentication; where GitHub lacks a Linear concept, degrade in a documented note, never silently.
-- Before any issue create or label update, run the label preflight in [references/labels.md](references/labels.md) against the live inventory and project taxonomy. Unknown labels, parent/group labels, missing required categories, and exclusivity violations halt before mutation.
+- Before any issue create or label update, run the label preflight in [references/labels.md](references/labels.md) against the live inventory and project taxonomy; any § Validation failure there halts before mutation.
 - In multi-issue analysis, keep verification context per issue. One issue's PR, branch, or resolved path set never scopes another's checks.
 
 ## Scope by Path
@@ -72,8 +72,8 @@ The Linear cache is workspace-wide, so each path states whether it resolves the 
 | tpm-audit `project-order` | yes | § 11 initiatives, projects, and per-project issues |
 | tpm-roadmap-plan | yes, § 1.1 | § 1.4 projects, § 1.5 comparison set |
 | tpm-cycle-plan | **no** | **no** — `session-status` picks the active project workspace-wide, and every later read is scoped to that pick |
-| audit-issues §§ 7.2-7.5 | inherits | reads rooted at an in-scope project or an issue this run mutated |
-| audit-issues § 1.2.2, § 3 | **no** | **no** — `session-status` selects projects workspace-wide |
+| audit-issues §§ 7.2-7.5 | n/a — executes an artifact tpm-audit produced under its scope | reads rooted at an in-scope project or an issue this run mutated |
+| audit-issues § 1.2.1, § 3 | **no** | **no** — `session-status` selects projects workspace-wide |
 | cycle-plan, roadmap-plan, roadmap-create, research-spike | **no** | **no** — project, initiative, and label reads span the workspace |
 | research-complete | n/a | reads are rooted at the caller's issue identifier |
 | research-issue | n/a | reads rooted at the caller's identifiers; the project it creates into is the caller's pick |

--- a/.agents/skills/project-management/schemas/audit-issues-input.md
+++ b/.agents/skills/project-management/schemas/audit-issues-input.md
@@ -97,8 +97,10 @@ Without the block, audit-issues infers the tracker from `parent_issue`: an `issu
 In `decompose-under-parent` mode, `parent_issue` is the blocked implementation issue (also listed in `blocked_issues`), converted into the coordination-only parent of the new domain children. For every item in `child_indexes`:
 
 - MUST be created as a sub-issue of `hierarchy_contract.parent_issue`, in the parent's project: `action: "create"` with `hierarchy: {"action": "make_child", "parent": [hierarchy_contract.parent_issue]}`.
-- MUST NOT be resolved to `skip`, `update`, `expand`, or `combine` by duplicate or overlap analysis. When an existing issue — including `parent_issue` — already carries scope belonging to a covered item, that scope moves into the new domain child via the child's `supersedes[]` (full coverage) or a `related` relation (partial overlap), never by updating the existing issue in place of the child create.
-- `parent_issue` is coordination-only. It is never one domain's implementation leaf, and never an `update`/`expand` target for covered scope.
+- MUST NOT be resolved to `skip`, `update`, `expand`, or `combine` by duplicate or overlap analysis.
+- `parent_issue` is coordination-only.
+
+What the analysis must do to satisfy these: [tpm-audit.md](../workflows/tpm-audit.md) § 7.0.
 
 ## Building from Review Findings
 

--- a/.agents/skills/project-management/schemas/audit-output.md
+++ b/.agents/skills/project-management/schemas/audit-output.md
@@ -59,7 +59,7 @@ Mode `team` uses this same shape with `project: null` — its input set is the w
 | `declined[]` | `title`, `reason` — one line naming the creation-bar test it failed |
 | `project_dependency_issues[]` | `from_project`, `to_project`, `current_relation`, `should_be`, `reason` |
 
-**`ready_to_schedule[]`** is a scheduling signal only — an active issue whose blockers are all Done or Cancelled. Completed-blocker relations are satisfied history, never stale metadata (the owning rule: linear SKILL.md § Blocked Label vs Issue Relations): they never appear in `remove_relations[]` or under any stale-metadata framing.
+**`ready_to_schedule[]`** is a scheduling signal only — an active issue whose blockers are all Done or Cancelled. A completed-blocker relation is satisfied history, never stale metadata (the owning rule: linear SKILL.md § Blocked Label vs Issue Relations).
 
 **`analysis[]`** holds non-actionable observations only; anything actionable must use a structured field.
 

--- a/.agents/skills/project-management/tests/partial-cache-answer.test.sh
+++ b/.agents/skills/project-management/tests/partial-cache-answer.test.sh
@@ -104,7 +104,7 @@ require "$skill" 'Silence is not inheritance: a new mode adds its row' \
 for path in 'tpm-audit .project., .team.' 'tpm-audit .issues., Linear' \
             'tpm-audit .issues., GitHub' 'tpm-audit .project-order.' \
             'tpm-roadmap-plan' 'tpm-cycle-plan' 'audit-issues §§ 7\.2-7\.5' \
-            'audit-issues § 1\.2\.2, § 3' 'research-complete' 'research-issue'; do
+            'audit-issues § 1\.2\.1, § 3' 'research-complete' 'research-issue'; do
   grep -Eq -- "\| $path \|" "$skill" \
     || fail "the scope enumeration does not carry a row for: $path"
 done

--- a/.agents/skills/project-management/tests/tracker-routing-contract.test.sh
+++ b/.agents/skills/project-management/tests/tracker-routing-contract.test.sh
@@ -69,12 +69,12 @@ require "$audit_issues" 'Linear installation/authentication is not a prerequisit
 
 # --- Preflight branches are tracker-conditional and disjoint ----------------
 
-require "$audit_issues" '1\.2\.2 Preflight — Linear \(TRACKER=linear\)' 'Linear preflight branch'
-require "$audit_issues" '1\.2\.3 Preflight — GitHub \(TRACKER=github\)' 'GitHub preflight branch'
+require "$audit_issues" '1\.2\.1 Preflight — Linear \(TRACKER=linear\)' 'Linear preflight branch'
+require "$audit_issues" '1\.2\.2 Preflight — GitHub \(TRACKER=github\)' 'GitHub preflight branch'
 require_fixed "$audit_issues" '.agents/skills/linear/scripts/linear.sh sync --reconcile' 'Linear sync in the Linear branch'
 require_fixed "$audit_issues" 'gh label list --repo [OWNER/REPO] --limit 200 --json name,description' 'GitHub live label inventory'
 require_fixed "$audit_issues" 'gh issue list --repo [OWNER/REPO] --state open --limit 200 --json number,title,labels' 'GitHub open-issue inventory'
-assert_linear_free "$(extract "$audit_issues" '^#### 1\.2\.3 ' '^### 1\.3 ' github-preflight)" 'GitHub preflight branch'
+assert_linear_free "$(extract "$audit_issues" '^#### 1\.2\.2 ' '^### 1\.3 ' github-preflight)" 'GitHub preflight branch'
 
 # --- Every approved action has a GitHub execution route --------------------
 

--- a/.agents/skills/project-management/workflows/audit-issues.md
+++ b/.agents/skills/project-management/workflows/audit-issues.md
@@ -231,7 +231,7 @@ Before any mutation that creates an issue or changes labels:
 
 1. Build the intended operation per finding: `create` and gap issues take the full `create_fields.labels[]`; `agent_mismatch` is `replace_category` on `agent`; `label_cooccurrence` is `add`; a `label_updates[]` entry carries its own mode and category.
 2. For an existing issue, fetch current labels and compute the full final set, preserving unrelated labels — Linear `cache issues get [ISSUE_ID]`, GitHub `gh issue view [N] --repo [OWNER/REPO] --json labels`.
-3. Validate against the § 1.2 inventory and taxonomy per [labels.md](../references/labels.md) § Validation. Any failure there halts before mutation and reports the failing set. A required label missing from the tracker needs explicit user authorization before creation — never auto-create.
+3. Validate against the § 1.2 inventory and taxonomy per [labels.md](../references/labels.md) § Validation. Any failure there halts before mutation and reports the failing set; a label the tracker lacks follows § Creating Labels in the same file.
 4. Pass only the validated final set: Linear `--labels`, GitHub `gh issue create --label` and the github skill's `label-add`/`label-remove`.
 
 ### 7.1 Apply Corrections

--- a/.agents/skills/project-management/workflows/audit-issues.md
+++ b/.agents/skills/project-management/workflows/audit-issues.md
@@ -19,7 +19,7 @@ Audit tracked issues and projects, apply the mechanical corrections, and take cr
 
 The input file's `tracker` block fixes the tracker for the whole audit. A caller that already resolved one (orch `TRACKER`) must set it.
 
-**Hierarchy contract.** When the input file carries `hierarchy_contract`, every `child_indexes` item comes back as `action: create` with `hierarchy.action: make_child` under the contract parent, in the parent's project. § 4.2 enforces this before anything is presented or executed. A research issue never appears in `parent_issue`.
+**Hierarchy contract.** A `hierarchy_contract` in the input file is binding per [audit-issues-input.md](../schemas/audit-issues-input.md) § Hierarchy Contract; § 4.2 enforces it before anything is presented or executed.
 
 ---
 
@@ -47,7 +47,7 @@ Store as `TRACKER`, plus `[OWNER/REPO]` when `TRACKER=github`.
 
 **GitHub mode runs no Linear commands** — no `sync`, `session-status`, cache read, or Linear mutation anywhere in this workflow. Linear installation/authentication is not a prerequisite for a GitHub-tracked audit.
 
-#### 1.2.2 Preflight — Linear (TRACKER=linear)
+#### 1.2.1 Preflight — Linear (TRACKER=linear)
 
 ```bash
 .agents/skills/linear/scripts/linear.sh sync --reconcile
@@ -60,7 +60,7 @@ Run `reconcile-work-items` only where the orch skill is installed (skip the line
 
 Keep `project` for fallback target resolution and the issue-label inventory for every create/update preflight.
 
-#### 1.2.3 Preflight — GitHub (TRACKER=github)
+#### 1.2.2 Preflight — GitHub (TRACKER=github)
 
 ```bash
 gh label list --repo [OWNER/REPO] --limit 200 --json name,description
@@ -231,7 +231,7 @@ Before any mutation that creates an issue or changes labels:
 
 1. Build the intended operation per finding: `create` and gap issues take the full `create_fields.labels[]`; `agent_mismatch` is `replace_category` on `agent`; `label_cooccurrence` is `add`; a `label_updates[]` entry carries its own mode and category.
 2. For an existing issue, fetch current labels and compute the full final set, preserving unrelated labels — Linear `cache issues get [ISSUE_ID]`, GitHub `gh issue view [N] --repo [OWNER/REPO] --json labels`.
-3. Validate against the § 1.2 inventory and taxonomy per [labels.md](../references/labels.md). Unknown labels, parent/group labels, missing required categories, or exclusivity violations halt before mutation and report the failing set. A required label missing from the tracker needs explicit user authorization before creation — never auto-create.
+3. Validate against the § 1.2 inventory and taxonomy per [labels.md](../references/labels.md) § Validation. Any failure there halts before mutation and reports the failing set. A required label missing from the tracker needs explicit user authorization before creation — never auto-create.
 4. Pass only the validated final set: Linear `--labels`, GitHub `gh issue create --label` and the github skill's `label-add`/`label-remove`.
 
 ### 7.1 Apply Corrections
@@ -305,11 +305,11 @@ For each issue cancelled in § 7.1 or § 7.2:
 
 **Linear**: `issues list-relations [CANCELED_ID]`, then `issues remove-relation [CANCELED_ID] --blocks [TARGET_ID]` for each `blocks` relation to a non-cancelled issue. `related` relations stay as historical record.
 
-**GitHub**: there are no relation objects. Scan the § 1.2.3 inventory and the issues touched here for body lines referencing the closed number, and update those bodies through the § 7.2 route or note the stale reference in a comment.
+**GitHub**: there are no relation objects. Scan the § 1.2.2 inventory and the issues touched here for body lines referencing the closed number, and update those bodies through the § 7.2 route or note the stale reference in a comment.
 
 If a target is left with no remaining blocker and this audit created an issue covering the same domain, ask: "[ISSUE_ID] unblocked by cancellation of [ISSUE_ID]. Add blocker?" Execute approved additions.
 
-For decision-eliminated or superseded cancellations, take the old pattern from `obsolete[].evidence.eliminated_pattern` or `supersedes[].reason`, check the parent and siblings (GitHub: the § 1.2.3 inventory) for non-cancelled issues whose title or description still names it, and ask "Update stale references?" before rewriting title or description and commenting `"Updated: [OLD] → [NEW] per [DECISION_ID]"`.
+For decision-eliminated or superseded cancellations, take the old pattern from `obsolete[].evidence.eliminated_pattern` or `supersedes[].reason`, check the parent and siblings (GitHub: the § 1.2.2 inventory) for non-cancelled issues whose title or description still names it, and ask "Update stale references?" before rewriting title or description and commenting `"Updated: [OLD] → [NEW] per [DECISION_ID]"`.
 
 ### 7.5 Post-Mutation Verification
 

--- a/.agents/skills/project-management/workflows/cycle-plan.md
+++ b/.agents/skills/project-management/workflows/cycle-plan.md
@@ -91,7 +91,7 @@ Ask: `Approve plan` | `Modify` | `Cancel`. `Modify` takes free-text changes, adj
 .agents/skills/linear/scripts/linear.sh cache labels list --format=safe
 ```
 
-Preserve unrelated labels and replace only the action's target category unless it says `replace_all_labels: true`. Unknown labels, parent/group labels, missing required categories, or exclusivity violations halt before mutation.
+Preserve unrelated labels and replace only the action's target category unless it says `replace_all_labels: true`. Any § Validation failure there halts before mutation.
 
 ### 4.2 Create the Cycle
 

--- a/.agents/skills/project-management/workflows/research-complete.md
+++ b/.agents/skills/project-management/workflows/research-complete.md
@@ -29,7 +29,7 @@ Capture the researcher metadata from `raw-exa.json` (`.metadata`: `researchMode`
 .agents/skills/linear/scripts/linear.sh cache labels list --format=safe
 ```
 
-Issue labels only, validated per [labels.md](../references/labels.md) — unknown labels, parent/group labels, missing required categories, or exclusivity violations halt before mutation.
+Issue labels only, validated per [labels.md](../references/labels.md) § Validation; any failure there halts before mutation.
 
 **Skip if** the issue already carries domain labels. Otherwise infer them from `findings.md` by matching component paths, compute `FINAL_LABELS = EXISTING + INFERRED` preserving unrelated labels, preflight, then `issues update [ISSUE_ID] --labels "[FINAL_LABELS]"`. When the domain is unclear or spans several, add every likely one.
 

--- a/.agents/skills/project-management/workflows/research-issue.md
+++ b/.agents/skills/project-management/workflows/research-issue.md
@@ -30,7 +30,7 @@ Type follows domain count when the caller did not supply one: 1 domain is Target
 
 Resolve `RESEARCH_WORKFLOW_LABEL` from the project taxonomy and this inventory per [labels.md](../references/labels.md); do not assume the literal name `research` exists.
 
-Build `VALIDATED_LABELS = [agent:researcher, RESEARCH_WORKFLOW_LABEL, DOMAINS...]` from issue labels only, and confirm each exists in the live inventory, is assignable (not a parent/group label), and satisfies the taxonomy's category and exclusivity rules. Unknown labels, parent/group labels, missing required categories, or exclusivity violations halt before mutation. A required label missing from the tracker needs explicit user authorization before creation — never create one automatically.
+Build `VALIDATED_LABELS = [agent:researcher, RESEARCH_WORKFLOW_LABEL, DOMAINS...]` from issue labels only and validate it per [labels.md](../references/labels.md) § Validation; any failure there halts before mutation. A label the tracker lacks follows § Creating Labels in the same file.
 
 ### 1.2 Create
 

--- a/.agents/skills/project-management/workflows/roadmap-create.md
+++ b/.agents/skills/project-management/workflows/roadmap-create.md
@@ -93,7 +93,7 @@ Position within the backlog is not set here; `audit-issues project-order` owns p
 .agents/skills/linear/scripts/linear.sh cache labels list --format=safe
 ```
 
-Load the project taxonomy and validate every issue's `labels[]` per [labels.md](../references/labels.md) before writing the audit file. Complete a set from the taxonomy when only `agent`/`agent_label` is present. Unknown labels, parent/group labels, missing required categories, or exclusivity violations halt before mutation.
+Load the project taxonomy and validate every issue's `labels[]` per [labels.md](../references/labels.md) § Validation before writing the audit file. Complete a set from the taxonomy when only `agent`/`agent_label` is present. Any failure there halts before mutation.
 
 ### 4.2 Convert to Audit Input
 
@@ -105,13 +105,17 @@ Deterministic mapping only — do NOT re-analyze, and do NOT re-type: generate t
 | `identifier` | null — all proposed |
 | `title`, `action`, `target`, `reason` | Same fields on `organized_issues[i]` |
 | `project.recommended` | `project_placement.project_name`; `recommended_id` = `PROJECT_ID` from § 3.2 |
-| `add_relations` | `depends_on_proposed` titles → `blocked_by: ["#N"]` by index; `depends_on_existing` → `blocked_by: ["[ISSUE_ID]"]`. A reference to any entry § 2 omitted — a relation or a `hierarchy.parent` — retargets to that entry's existing `target` issue id when the action executed; when the action was skipped, the reference is removed and the dependent re-enters § 5 marked `"reapprove": true` — never a dangling `#N`. Relations are already lifted to parent level — preserve them |
-| `hierarchy` | Bundle children are always `make_child` of `#[parent_index]` — or, when that parent was omitted at § 2, of its existing `target` id per the retargeting rule above. Parents and standalone issues follow `hierarchy_recommendation`: `children_of_origin` → `make_child` of the origin ID, anything else → `none`, `mixed` → per the TPM grouping |
+| `add_relations` | `depends_on_proposed` titles → `blocked_by: ["#N"]` by index; `depends_on_existing` → `blocked_by: ["[ISSUE_ID]"]`. Relations are already lifted to parent level — preserve them. A reference to an entry § 2 omitted follows step 1 below |
+| `hierarchy` | Bundle children are `make_child` of their bundle parent per step 1 below. Parents and standalone issues follow `hierarchy_recommendation`: `children_of_origin` → `make_child` of the origin ID, anything else → `none`, `mixed` → per the TPM grouping |
 | `supersedes` | Supersession entries in `cross_project_findings` — only those § 2 neither executed nor skipped |
 | `cross_project_findings.conflicts[]` | Each resolution is applied before conversion: a wait/sequence resolution becomes `blocked_by: ["[ISSUE_ID]"]` on the affected entry; a `Modify approach` text lands in that entry's `create_fields` and marks it `"reapprove": true`; `Skip this issue` omits it. A resolution with no representable effect halts naming the conflict |
-| existing-work actions decided at § 2 | An action § 2 executed (cancel/expand/descope) is OMITTED from `issues[]` (never `skip`); a `supersede` whose cancellation § 2 executed enters as a plain `create` with `supersedes` cleared; an action § 2 skipped — globally or per action — is omitted as well, a skipped supersession dropping its replacement too; the § 5 report lists every omission with its § 2 outcome. Nothing § 6 or § 7 sees can override a § 2 answer |
 | `obsolete` | `organized_issues[i].obsolete` |
 | `priority_misalignment`, `agent_mismatch` | null — already correct |
+
+The two rules the rows above defer to:
+
+1. **Retargeting.** A reference to any entry § 2 omitted — a relation or a `hierarchy.parent` — retargets to that entry's existing `target` issue id when the action executed; when the action was skipped, the reference is removed and the dependent re-enters § 5 marked `"reapprove": true` — never a dangling `#N`. A bundle child is `make_child` of `#[parent_index]` or, when that parent was omitted at § 2, of its existing `target` id.
+2. **Omission.** An action § 2 executed (cancel/expand/descope) is OMITTED from `issues[]` (never `skip`); a `supersede` whose cancellation § 2 executed enters as a plain `create` with `supersedes` cleared; an action § 2 skipped — globally or per action — is omitted as well, a skipped supersession dropping its replacement too; the § 5 report lists every omission with its § 2 outcome. Nothing § 6 or § 7 sees can override a § 2 answer.
 
 Each entry's `create_fields` carries `description` (synthesized from title, feature context, and breaking changes), `recommendation` (requirement bullets, plus doc updates and migration steps), `location`, `estimate`, `priority`, `labels[]` (authoritative, validated in § 4.1), `agent_label`, `is_bundle_parent`, and `source_path` = the plan markdown path. A bundle parent sets `is_bundle_parent: true` with no description or recommendation; generate [parent-issue-template.md](../templates/parent-issue-template.md) content after the children exist, via workflow-actions § Descriptions (parent rebuild).
 

--- a/.agents/skills/project-management/workflows/roadmap-plan.md
+++ b/.agents/skills/project-management/workflows/roadmap-plan.md
@@ -11,19 +11,25 @@ Plan a roadmap: research gate, specialist consultation, TPM analysis, architectu
 | `... --origin-issue [ISSUE_ID]` | Supply origin-issue context for the hierarchy decision |
 | `... --planner-handoff @[plan-file]` | Consume a plan from a scout → planner chain |
 
-Extract `FEATURE`, `RESEARCH_PATH`, `ORIGIN_ISSUE`, and `PLANNER_HANDOFF` (each null when absent). Read the `@[path]` file and classify it: research findings inform planning; a **finished plan** — a design document the user has reviewed that already settles approach and workstreams — is the SPEC. With a SPEC: § 1 is satisfied, § 2 runs in slicing mode, the § 5 report presents the derived issues against it, and the spec's path travels as `RESEARCH_PATH` → `research_ref`, which the issue template writes as the `**Research**` line on every created issue (unconditionally; the § 6 research question offers the reference to pre-existing issues only). The spec skips no approval and no creation gate. Refresh a stale cache before the first read here and in §§ 1-2. Planning itself only reads; the § 1 research-spike branch delegates to research-issue, which reconciles again before it creates anything:
+1. Extract `FEATURE`, `RESEARCH_PATH`, `ORIGIN_ISSUE`, and `PLANNER_HANDOFF` (each null when absent).
 
-```bash
-.agents/skills/linear/scripts/linear.sh sync --if-stale 15
-```
+2. Read the `@[path]` file and classify it: research findings inform planning; a **finished plan** — a design document the user has reviewed that already settles approach and workstreams — is the SPEC.
 
-With `--origin-issue`, fetch it and keep `id`, `title`, `project`, `description`, `children`:
+3. With a SPEC: § 1 is satisfied, § 2 runs in slicing mode, the § 5 report presents the derived issues against it, and the spec's path travels as `RESEARCH_PATH` → `research_ref`, which the issue template writes as the `**Research**` line on every created issue (unconditionally; the § 6 research question offers the reference to pre-existing issues only). The spec skips no approval and no creation gate.
 
-```bash
-.agents/skills/linear/scripts/linear.sh cache issues get [ORIGIN_ISSUE_ID]
-```
+4. Refresh a stale cache before the first read here and in §§ 1-2. Planning itself only reads; the § 1 research-spike branch delegates to research-issue, which reconciles again before it creates anything:
 
-With `--planner-handoff`, read the file and keep its plan path, recommended approach, proposed phases or issue candidates, any TPM handoff recommendation, and referenced issue or project names. Never run `planner` from here. A handoff skips no gate, no TPM step, no approval, and no creation confirmation.
+   ```bash
+   .agents/skills/linear/scripts/linear.sh sync --if-stale 15
+   ```
+
+5. With `--origin-issue`, fetch it and keep `id`, `title`, `project`, `description`, `children`:
+
+   ```bash
+   .agents/skills/linear/scripts/linear.sh cache issues get [ORIGIN_ISSUE_ID]
+   ```
+
+6. With `--planner-handoff`, read the file and keep its plan path, recommended approach, proposed phases or issue candidates, any TPM handoff recommendation, and referenced issue or project names. Never run `planner` from here. A handoff skips no gate, no TPM step, no approval, and no creation confirmation.
 
 ---
 
@@ -31,13 +37,15 @@ With `--planner-handoff`, read the file and keep its plan path, recommended appr
 
 **Skip if** `RESEARCH_PATH` was provided.
 
-Search existing artifacts on disk first — the project's research and plan directories (`docs/research/`, `docs/plans/`, or the project's equivalents) by `FEATURE` keywords; classify a match with the Inputs rule (research vs SPEC) exactly as an `@[path]` argument, and when several match, ask the user which applies; a selected artifact ends this gate → § 2. Only when the disk search finds nothing, query the tracker: resolve `RESEARCH_WORKFLOW_LABEL` from the project taxonomy and the live inventory (`cache labels list --format=safe`), then query it. If no unambiguous assignable label exists, skip the lookup and continue to § 2; do not query a hard-coded fallback label.
+1. Search existing artifacts on disk first — the project's research and plan directories (`docs/research/`, `docs/plans/`, or the project's equivalents) by `FEATURE` keywords.
 
-```bash
-.agents/skills/linear/scripts/linear.sh cache issues list --label "[RESEARCH_WORKFLOW_LABEL]" --state "Done" --max
-```
+2. Then classify a match with the Inputs rule (research vs SPEC) exactly as an `@[path]` argument, and when several match, ask the user which applies; a selected artifact ends this gate → § 2. Only when the disk search finds nothing, query the tracker: resolve `RESEARCH_WORKFLOW_LABEL` from the project taxonomy and the live inventory (`cache labels list --format=safe`), then query it. If no unambiguous assignable label exists, skip the lookup and continue to § 2; do not query a hard-coded fallback label.
 
-Filter for `FEATURE` keywords. A match supplies `RESEARCH_PATH` from the issue → § 2.
+   ```bash
+   .agents/skills/linear/scripts/linear.sh cache issues list --label "[RESEARCH_WORKFLOW_LABEL]" --state "Done" --max
+   ```
+
+3. Filter for `FEATURE` keywords. A match supplies `RESEARCH_PATH` from the issue → § 2.
 
 With no match, ask the user:
 
@@ -117,9 +125,13 @@ Report as JSON:
 6. Out-of-spec work (spec mode only): anything needed beyond the spec's phases — each entry names the work and whether the spec's own deliverables need it
 </delegation_format>
 
-Keep the result as `ARCH_FINDINGS` (`validated_findings[]`, `deprecated_code[]`, `breaking_changes[]`, `required_refactors[]`, `risk_assessment`, `out_of_spec[]`). Fold verified findings into the TPM JSON before presenting: scope additions go into the issues they belong to, ordering fixes into relations, and any standalone addition — a `required_refactors[]` prerequisite, a second-opinion finding, or a needed `out_of_spec[]` entry — re-enters § 2's delegation table for its domain and § 3; the fold never invents issue fields. In spec mode the fold stops at the spec's boundary, with the same exception the TPM applies: an `out_of_spec[]` entry the spec's own deliverables need re-enters planning like any standalone addition; every other entry becomes an `architecture_gaps[]` row with `recommendation: out_of_scope` — never `defer` — naming the spec in `reason`, rendered under ARCHITECTURE GAPS in § 5.
+1. Keep the result as `ARCH_FINDINGS` (`validated_findings[]`, `deprecated_code[]`, `breaking_changes[]`, `required_refactors[]`, `risk_assessment`, `out_of_spec[]`).
 
-For a major feature — any of: ten or more creation entries, entries spanning two or more `agent:*` domains, a listed breaking change, or `risk_assessment.level: high` — planned without an already-reviewed spec, also run the `second-opinion` skill (challenge mode) on the plan here and fold verified findings in the same way. When the skill is not installed, or is installed but cannot complete (no eligible target, missing external CLI, timeout, nonzero exit), the § 5 report's `Cross-model review` field reads `unavailable — <reason>` and the workflow continues. A SPEC that already passed external review skips this (`skipped — reviewed spec`); a non-major plan records `skipped — not required`.
+2. Fold verified findings into the TPM JSON before presenting: scope additions go into the issues they belong to, ordering fixes into relations, and any standalone addition — a `required_refactors[]` prerequisite, a second-opinion finding, or a needed `out_of_spec[]` entry — re-enters § 2's delegation table for its domain and § 3; the fold never invents issue fields.
+
+3. In spec mode the fold stops at the spec's boundary, with the same exception the TPM applies: an `out_of_spec[]` entry the spec's own deliverables need re-enters planning like any standalone addition; every other entry becomes an `architecture_gaps[]` row with `recommendation: out_of_scope` — never `defer` — naming the spec in `reason`, rendered under ARCHITECTURE GAPS in § 5.
+
+4. For a major feature — any of: ten or more creation entries, entries spanning two or more `agent:*` domains, a listed breaking change, or `risk_assessment.level: high` — planned without an already-reviewed spec, also run the `second-opinion` skill (challenge mode) on the plan here and fold verified findings in the same way. When the skill is not installed, or is installed but cannot complete (no eligible target, missing external CLI, timeout, nonzero exit), the § 5 report's `Cross-model review` field reads `unavailable — <reason>` and the workflow continues. A SPEC that already passed external review skips this (`skipped — reviewed spec`); a non-major plan records `skipped — not required`.
 
 ---
 

--- a/.agents/skills/project-management/workflows/tpm-audit.md
+++ b/.agents/skills/project-management/workflows/tpm-audit.md
@@ -4,7 +4,7 @@ Analyze issues and projects for relations, labels, hierarchy, placement, duplica
 
 **Do NOT modify the tracker.** Return recommendations only.
 
-**Hold the creation bar** ([SKILL.md](../SKILL.md) § Disposition). An observation becomes a `create` only when it changes what a user or operator experiences (or blocks work that does), nothing open already covers it, and someone could finish it without a new investigation. Everything else is `skip` with a one-line reason. Every run that reads an issue backlog also completes the § 6 cancellation sweep.
+**Hold the creation bar** ([SKILL.md](../SKILL.md) § Disposition). An observation that clears it is a `create`; everything else is `skip` with a one-line reason. Every run that reads an issue backlog also completes the § 6 cancellation sweep.
 
 ## Inputs
 
@@ -227,7 +227,13 @@ Never add to `obsolete[]` without code verification.
 
 With `DECISION_REF` present, also detect issues the decision made unnecessary by changing the approach (not the scope): read the decision (`.agents/skills/decider/scripts/decisions get [DECISION_REF]`), extract the patterns it explicitly replaced, search the comparison set for issues implementing them, exclude anything already in `supersedes[]`, and record confidence 100 with evidence `{decision_eliminated: true, decision_ref, eliminated_pattern}`.
 
-**Below the bar.** Every active issue in the comparison set as § 1.5 fetched it is re-read against the creation bar's first and third tests as they stand today (the second, coverage by other work, is not reapplied: an issue always covers itself). One that fails (the bar's own list, not restated here) is a cancellation with confidence 100 and evidence `{below_bar: true, test, who_hits_it}`: `test` names the failed test, `who_hits_it` is the one-line user story and how often a user meets it, written after reading the issue's body (on GitHub, `gh issue view <n>`; the § 1.5 list carries no body). In project mode it is an `obsolete[]` entry; in issue mode it is the issue's own `issues[]` entry with `action: "cancel"` and that evidence in its `obsolete` field. The bar's two exceptions (a shipped-path security or data-loss defect; a critical-harm or financial-loss edge case) never go here on likelihood; the third test still applies to them. The code-verification rule above is for implementation-obsolete entries; a `below_bar` entry is verified by reading the body and, where it names a path, producer, or regression, checking that claim in the repository before the entry is written.
+**Below the bar.**
+
+1. Re-read every active issue in the comparison set as § 1.5 fetched it against the creation bar's first and third tests as they stand today (the second, coverage by other work, is not reapplied: an issue always covers itself).
+2. One that fails (the bar's own list, not restated here) is a cancellation with confidence 100 and evidence `{below_bar: true, test, who_hits_it}`: `test` names the failed test, `who_hits_it` is the one-line user story and how often a user meets it, written after reading the issue's body (on GitHub, `gh issue view <n>`; the § 1.5 list carries no body).
+3. In project mode it is an `obsolete[]` entry; in issue mode it is the issue's own `issues[]` entry with `action: "cancel"` and that evidence in its `obsolete` field.
+4. The bar's two exceptions (a shipped-path security or data-loss defect; a critical-harm or financial-loss edge case) never go here on likelihood; the third test still applies to them.
+5. The code-verification rule above is for implementation-obsolete entries; a `below_bar` entry is verified by reading the body and, where it names a path, producer, or regression, checking that claim in the repository before the entry is written.
 
 ### 6.3 Project Fit
 

--- a/skills/project-management/README.md
+++ b/skills/project-management/README.md
@@ -1,6 +1,6 @@
 # Project Management Skill
 
-Turns planning conversations into tracked work: cycle plans, backlog audits, roadmaps, and research-driven decomposition. It exists to keep the backlog small and true — every audit is expected to close more issues than it opens, and an observation only becomes an issue when it changes what someone experiences and someone could finish it as-is.
+Turns planning conversations into tracked work: cycle plans, backlog audits, roadmaps, and research-driven decomposition. It exists to keep the backlog small and true; what qualifies as an issue and what gets closed is the creation bar in [`SKILL.md`](SKILL.md) § Disposition.
 
 ## How it works
 

--- a/skills/project-management/SKILL.md
+++ b/skills/project-management/SKILL.md
@@ -42,7 +42,7 @@ Wrappers run in the primary session: they own the user dialog and every tracker 
 | `research-complete` | `[ISSUE_ID]` | [research-complete](workflows/research-complete.md) |
 | `research-issue` | — | [research-issue](workflows/research-issue.md) — internal, invoked by `research-spike` |
 
-`audit-issues` is **primary-session only**: § 6 needs the session's interactive question tool, and § 7 mutates only against approvals collected there — the roadmap-plan § 5 answer that roadmap-create carries in is validated and admitted at § 6, never around it. Delegate the `tpm-audit.md` analysis it spawns, never the wrapper.
+`audit-issues` is **primary-session only** ([audit-issues](workflows/audit-issues.md) preamble): the roadmap-plan § 5 answer that roadmap-create carries in is validated and admitted at § 6, never around it.
 
 The `@[path]` given to `roadmap plan` may be research findings or a **finished plan** (a design the user has reviewed). A finished plan is the spec: derive issues from it instead of re-planning, and every issue cites it.
 
@@ -57,7 +57,7 @@ TPM analysis workflows, each returning JSON per its schema: [tpm-cycle-plan](wor
 - Every path's scope status is enumerated in § Scope by Path; a mode added later states its own row rather than inheriting silence.
 - Sync the Linear cache before a workflow's first cache read: `sync --reconcile` in a run that mutates the tracker, `sync --if-stale 15` in a read-only lookup. A cache read that comes back missing or stale after that halts the workflow and reports the sync failure — never a partial result, a live-only substitute, or a retry against the stale cache.
 - Resolve tracker context once per run (audit-issues § 1.2) and route every preflight, fetch, and mutation through it. A GitHub-tracked run must not require Linear installation, sync, or authentication; where GitHub lacks a Linear concept, degrade in a documented note, never silently.
-- Before any issue create or label update, run the label preflight in [references/labels.md](references/labels.md) against the live inventory and project taxonomy. Unknown labels, parent/group labels, missing required categories, and exclusivity violations halt before mutation.
+- Before any issue create or label update, run the label preflight in [references/labels.md](references/labels.md) against the live inventory and project taxonomy; any § Validation failure there halts before mutation.
 - In multi-issue analysis, keep verification context per issue. One issue's PR, branch, or resolved path set never scopes another's checks.
 
 ## Scope by Path
@@ -72,8 +72,8 @@ The Linear cache is workspace-wide, so each path states whether it resolves the 
 | tpm-audit `project-order` | yes | § 11 initiatives, projects, and per-project issues |
 | tpm-roadmap-plan | yes, § 1.1 | § 1.4 projects, § 1.5 comparison set |
 | tpm-cycle-plan | **no** | **no** — `session-status` picks the active project workspace-wide, and every later read is scoped to that pick |
-| audit-issues §§ 7.2-7.5 | inherits | reads rooted at an in-scope project or an issue this run mutated |
-| audit-issues § 1.2.2, § 3 | **no** | **no** — `session-status` selects projects workspace-wide |
+| audit-issues §§ 7.2-7.5 | n/a — executes an artifact tpm-audit produced under its scope | reads rooted at an in-scope project or an issue this run mutated |
+| audit-issues § 1.2.1, § 3 | **no** | **no** — `session-status` selects projects workspace-wide |
 | cycle-plan, roadmap-plan, roadmap-create, research-spike | **no** | **no** — project, initiative, and label reads span the workspace |
 | research-complete | n/a | reads are rooted at the caller's issue identifier |
 | research-issue | n/a | reads rooted at the caller's identifiers; the project it creates into is the caller's pick |

--- a/skills/project-management/schemas/audit-issues-input.md
+++ b/skills/project-management/schemas/audit-issues-input.md
@@ -97,8 +97,10 @@ Without the block, audit-issues infers the tracker from `parent_issue`: an `issu
 In `decompose-under-parent` mode, `parent_issue` is the blocked implementation issue (also listed in `blocked_issues`), converted into the coordination-only parent of the new domain children. For every item in `child_indexes`:
 
 - MUST be created as a sub-issue of `hierarchy_contract.parent_issue`, in the parent's project: `action: "create"` with `hierarchy: {"action": "make_child", "parent": [hierarchy_contract.parent_issue]}`.
-- MUST NOT be resolved to `skip`, `update`, `expand`, or `combine` by duplicate or overlap analysis. When an existing issue — including `parent_issue` — already carries scope belonging to a covered item, that scope moves into the new domain child via the child's `supersedes[]` (full coverage) or a `related` relation (partial overlap), never by updating the existing issue in place of the child create.
-- `parent_issue` is coordination-only. It is never one domain's implementation leaf, and never an `update`/`expand` target for covered scope.
+- MUST NOT be resolved to `skip`, `update`, `expand`, or `combine` by duplicate or overlap analysis.
+- `parent_issue` is coordination-only.
+
+What the analysis must do to satisfy these: [tpm-audit.md](../workflows/tpm-audit.md) § 7.0.
 
 ## Building from Review Findings
 

--- a/skills/project-management/schemas/audit-output.md
+++ b/skills/project-management/schemas/audit-output.md
@@ -59,7 +59,7 @@ Mode `team` uses this same shape with `project: null` — its input set is the w
 | `declined[]` | `title`, `reason` — one line naming the creation-bar test it failed |
 | `project_dependency_issues[]` | `from_project`, `to_project`, `current_relation`, `should_be`, `reason` |
 
-**`ready_to_schedule[]`** is a scheduling signal only — an active issue whose blockers are all Done or Cancelled. Completed-blocker relations are satisfied history, never stale metadata (the owning rule: linear SKILL.md § Blocked Label vs Issue Relations): they never appear in `remove_relations[]` or under any stale-metadata framing.
+**`ready_to_schedule[]`** is a scheduling signal only — an active issue whose blockers are all Done or Cancelled. A completed-blocker relation is satisfied history, never stale metadata (the owning rule: linear SKILL.md § Blocked Label vs Issue Relations).
 
 **`analysis[]`** holds non-actionable observations only; anything actionable must use a structured field.
 

--- a/skills/project-management/tests/partial-cache-answer.test.sh
+++ b/skills/project-management/tests/partial-cache-answer.test.sh
@@ -104,7 +104,7 @@ require "$skill" 'Silence is not inheritance: a new mode adds its row' \
 for path in 'tpm-audit .project., .team.' 'tpm-audit .issues., Linear' \
             'tpm-audit .issues., GitHub' 'tpm-audit .project-order.' \
             'tpm-roadmap-plan' 'tpm-cycle-plan' 'audit-issues §§ 7\.2-7\.5' \
-            'audit-issues § 1\.2\.2, § 3' 'research-complete' 'research-issue'; do
+            'audit-issues § 1\.2\.1, § 3' 'research-complete' 'research-issue'; do
   grep -Eq -- "\| $path \|" "$skill" \
     || fail "the scope enumeration does not carry a row for: $path"
 done

--- a/skills/project-management/tests/tracker-routing-contract.test.sh
+++ b/skills/project-management/tests/tracker-routing-contract.test.sh
@@ -69,12 +69,12 @@ require "$audit_issues" 'Linear installation/authentication is not a prerequisit
 
 # --- Preflight branches are tracker-conditional and disjoint ----------------
 
-require "$audit_issues" '1\.2\.2 Preflight — Linear \(TRACKER=linear\)' 'Linear preflight branch'
-require "$audit_issues" '1\.2\.3 Preflight — GitHub \(TRACKER=github\)' 'GitHub preflight branch'
+require "$audit_issues" '1\.2\.1 Preflight — Linear \(TRACKER=linear\)' 'Linear preflight branch'
+require "$audit_issues" '1\.2\.2 Preflight — GitHub \(TRACKER=github\)' 'GitHub preflight branch'
 require_fixed "$audit_issues" '.agents/skills/linear/scripts/linear.sh sync --reconcile' 'Linear sync in the Linear branch'
 require_fixed "$audit_issues" 'gh label list --repo [OWNER/REPO] --limit 200 --json name,description' 'GitHub live label inventory'
 require_fixed "$audit_issues" 'gh issue list --repo [OWNER/REPO] --state open --limit 200 --json number,title,labels' 'GitHub open-issue inventory'
-assert_linear_free "$(extract "$audit_issues" '^#### 1\.2\.3 ' '^### 1\.3 ' github-preflight)" 'GitHub preflight branch'
+assert_linear_free "$(extract "$audit_issues" '^#### 1\.2\.2 ' '^### 1\.3 ' github-preflight)" 'GitHub preflight branch'
 
 # --- Every approved action has a GitHub execution route --------------------
 

--- a/skills/project-management/workflows/audit-issues.md
+++ b/skills/project-management/workflows/audit-issues.md
@@ -231,7 +231,7 @@ Before any mutation that creates an issue or changes labels:
 
 1. Build the intended operation per finding: `create` and gap issues take the full `create_fields.labels[]`; `agent_mismatch` is `replace_category` on `agent`; `label_cooccurrence` is `add`; a `label_updates[]` entry carries its own mode and category.
 2. For an existing issue, fetch current labels and compute the full final set, preserving unrelated labels — Linear `cache issues get [ISSUE_ID]`, GitHub `gh issue view [N] --repo [OWNER/REPO] --json labels`.
-3. Validate against the § 1.2 inventory and taxonomy per [labels.md](../references/labels.md) § Validation. Any failure there halts before mutation and reports the failing set. A required label missing from the tracker needs explicit user authorization before creation — never auto-create.
+3. Validate against the § 1.2 inventory and taxonomy per [labels.md](../references/labels.md) § Validation. Any failure there halts before mutation and reports the failing set; a label the tracker lacks follows § Creating Labels in the same file.
 4. Pass only the validated final set: Linear `--labels`, GitHub `gh issue create --label` and the github skill's `label-add`/`label-remove`.
 
 ### 7.1 Apply Corrections

--- a/skills/project-management/workflows/audit-issues.md
+++ b/skills/project-management/workflows/audit-issues.md
@@ -19,7 +19,7 @@ Audit tracked issues and projects, apply the mechanical corrections, and take cr
 
 The input file's `tracker` block fixes the tracker for the whole audit. A caller that already resolved one (orch `TRACKER`) must set it.
 
-**Hierarchy contract.** When the input file carries `hierarchy_contract`, every `child_indexes` item comes back as `action: create` with `hierarchy.action: make_child` under the contract parent, in the parent's project. § 4.2 enforces this before anything is presented or executed. A research issue never appears in `parent_issue`.
+**Hierarchy contract.** A `hierarchy_contract` in the input file is binding per [audit-issues-input.md](../schemas/audit-issues-input.md) § Hierarchy Contract; § 4.2 enforces it before anything is presented or executed.
 
 ---
 
@@ -47,7 +47,7 @@ Store as `TRACKER`, plus `[OWNER/REPO]` when `TRACKER=github`.
 
 **GitHub mode runs no Linear commands** — no `sync`, `session-status`, cache read, or Linear mutation anywhere in this workflow. Linear installation/authentication is not a prerequisite for a GitHub-tracked audit.
 
-#### 1.2.2 Preflight — Linear (TRACKER=linear)
+#### 1.2.1 Preflight — Linear (TRACKER=linear)
 
 ```bash
 .agents/skills/linear/scripts/linear.sh sync --reconcile
@@ -60,7 +60,7 @@ Run `reconcile-work-items` only where the orch skill is installed (skip the line
 
 Keep `project` for fallback target resolution and the issue-label inventory for every create/update preflight.
 
-#### 1.2.3 Preflight — GitHub (TRACKER=github)
+#### 1.2.2 Preflight — GitHub (TRACKER=github)
 
 ```bash
 gh label list --repo [OWNER/REPO] --limit 200 --json name,description
@@ -231,7 +231,7 @@ Before any mutation that creates an issue or changes labels:
 
 1. Build the intended operation per finding: `create` and gap issues take the full `create_fields.labels[]`; `agent_mismatch` is `replace_category` on `agent`; `label_cooccurrence` is `add`; a `label_updates[]` entry carries its own mode and category.
 2. For an existing issue, fetch current labels and compute the full final set, preserving unrelated labels — Linear `cache issues get [ISSUE_ID]`, GitHub `gh issue view [N] --repo [OWNER/REPO] --json labels`.
-3. Validate against the § 1.2 inventory and taxonomy per [labels.md](../references/labels.md). Unknown labels, parent/group labels, missing required categories, or exclusivity violations halt before mutation and report the failing set. A required label missing from the tracker needs explicit user authorization before creation — never auto-create.
+3. Validate against the § 1.2 inventory and taxonomy per [labels.md](../references/labels.md) § Validation. Any failure there halts before mutation and reports the failing set. A required label missing from the tracker needs explicit user authorization before creation — never auto-create.
 4. Pass only the validated final set: Linear `--labels`, GitHub `gh issue create --label` and the github skill's `label-add`/`label-remove`.
 
 ### 7.1 Apply Corrections
@@ -305,11 +305,11 @@ For each issue cancelled in § 7.1 or § 7.2:
 
 **Linear**: `issues list-relations [CANCELED_ID]`, then `issues remove-relation [CANCELED_ID] --blocks [TARGET_ID]` for each `blocks` relation to a non-cancelled issue. `related` relations stay as historical record.
 
-**GitHub**: there are no relation objects. Scan the § 1.2.3 inventory and the issues touched here for body lines referencing the closed number, and update those bodies through the § 7.2 route or note the stale reference in a comment.
+**GitHub**: there are no relation objects. Scan the § 1.2.2 inventory and the issues touched here for body lines referencing the closed number, and update those bodies through the § 7.2 route or note the stale reference in a comment.
 
 If a target is left with no remaining blocker and this audit created an issue covering the same domain, ask: "[ISSUE_ID] unblocked by cancellation of [ISSUE_ID]. Add blocker?" Execute approved additions.
 
-For decision-eliminated or superseded cancellations, take the old pattern from `obsolete[].evidence.eliminated_pattern` or `supersedes[].reason`, check the parent and siblings (GitHub: the § 1.2.3 inventory) for non-cancelled issues whose title or description still names it, and ask "Update stale references?" before rewriting title or description and commenting `"Updated: [OLD] → [NEW] per [DECISION_ID]"`.
+For decision-eliminated or superseded cancellations, take the old pattern from `obsolete[].evidence.eliminated_pattern` or `supersedes[].reason`, check the parent and siblings (GitHub: the § 1.2.2 inventory) for non-cancelled issues whose title or description still names it, and ask "Update stale references?" before rewriting title or description and commenting `"Updated: [OLD] → [NEW] per [DECISION_ID]"`.
 
 ### 7.5 Post-Mutation Verification
 

--- a/skills/project-management/workflows/cycle-plan.md
+++ b/skills/project-management/workflows/cycle-plan.md
@@ -91,7 +91,7 @@ Ask: `Approve plan` | `Modify` | `Cancel`. `Modify` takes free-text changes, adj
 .agents/skills/linear/scripts/linear.sh cache labels list --format=safe
 ```
 
-Preserve unrelated labels and replace only the action's target category unless it says `replace_all_labels: true`. Unknown labels, parent/group labels, missing required categories, or exclusivity violations halt before mutation.
+Preserve unrelated labels and replace only the action's target category unless it says `replace_all_labels: true`. Any § Validation failure there halts before mutation.
 
 ### 4.2 Create the Cycle
 

--- a/skills/project-management/workflows/research-complete.md
+++ b/skills/project-management/workflows/research-complete.md
@@ -29,7 +29,7 @@ Capture the researcher metadata from `raw-exa.json` (`.metadata`: `researchMode`
 .agents/skills/linear/scripts/linear.sh cache labels list --format=safe
 ```
 
-Issue labels only, validated per [labels.md](../references/labels.md) — unknown labels, parent/group labels, missing required categories, or exclusivity violations halt before mutation.
+Issue labels only, validated per [labels.md](../references/labels.md) § Validation; any failure there halts before mutation.
 
 **Skip if** the issue already carries domain labels. Otherwise infer them from `findings.md` by matching component paths, compute `FINAL_LABELS = EXISTING + INFERRED` preserving unrelated labels, preflight, then `issues update [ISSUE_ID] --labels "[FINAL_LABELS]"`. When the domain is unclear or spans several, add every likely one.
 

--- a/skills/project-management/workflows/research-issue.md
+++ b/skills/project-management/workflows/research-issue.md
@@ -30,7 +30,7 @@ Type follows domain count when the caller did not supply one: 1 domain is Target
 
 Resolve `RESEARCH_WORKFLOW_LABEL` from the project taxonomy and this inventory per [labels.md](../references/labels.md); do not assume the literal name `research` exists.
 
-Build `VALIDATED_LABELS = [agent:researcher, RESEARCH_WORKFLOW_LABEL, DOMAINS...]` from issue labels only, and confirm each exists in the live inventory, is assignable (not a parent/group label), and satisfies the taxonomy's category and exclusivity rules. Unknown labels, parent/group labels, missing required categories, or exclusivity violations halt before mutation. A required label missing from the tracker needs explicit user authorization before creation — never create one automatically.
+Build `VALIDATED_LABELS = [agent:researcher, RESEARCH_WORKFLOW_LABEL, DOMAINS...]` from issue labels only and validate it per [labels.md](../references/labels.md) § Validation; any failure there halts before mutation. A label the tracker lacks follows § Creating Labels in the same file.
 
 ### 1.2 Create
 

--- a/skills/project-management/workflows/roadmap-create.md
+++ b/skills/project-management/workflows/roadmap-create.md
@@ -93,7 +93,7 @@ Position within the backlog is not set here; `audit-issues project-order` owns p
 .agents/skills/linear/scripts/linear.sh cache labels list --format=safe
 ```
 
-Load the project taxonomy and validate every issue's `labels[]` per [labels.md](../references/labels.md) before writing the audit file. Complete a set from the taxonomy when only `agent`/`agent_label` is present. Unknown labels, parent/group labels, missing required categories, or exclusivity violations halt before mutation.
+Load the project taxonomy and validate every issue's `labels[]` per [labels.md](../references/labels.md) § Validation before writing the audit file. Complete a set from the taxonomy when only `agent`/`agent_label` is present. Any failure there halts before mutation.
 
 ### 4.2 Convert to Audit Input
 
@@ -105,13 +105,17 @@ Deterministic mapping only — do NOT re-analyze, and do NOT re-type: generate t
 | `identifier` | null — all proposed |
 | `title`, `action`, `target`, `reason` | Same fields on `organized_issues[i]` |
 | `project.recommended` | `project_placement.project_name`; `recommended_id` = `PROJECT_ID` from § 3.2 |
-| `add_relations` | `depends_on_proposed` titles → `blocked_by: ["#N"]` by index; `depends_on_existing` → `blocked_by: ["[ISSUE_ID]"]`. A reference to any entry § 2 omitted — a relation or a `hierarchy.parent` — retargets to that entry's existing `target` issue id when the action executed; when the action was skipped, the reference is removed and the dependent re-enters § 5 marked `"reapprove": true` — never a dangling `#N`. Relations are already lifted to parent level — preserve them |
-| `hierarchy` | Bundle children are always `make_child` of `#[parent_index]` — or, when that parent was omitted at § 2, of its existing `target` id per the retargeting rule above. Parents and standalone issues follow `hierarchy_recommendation`: `children_of_origin` → `make_child` of the origin ID, anything else → `none`, `mixed` → per the TPM grouping |
+| `add_relations` | `depends_on_proposed` titles → `blocked_by: ["#N"]` by index; `depends_on_existing` → `blocked_by: ["[ISSUE_ID]"]`. Relations are already lifted to parent level — preserve them. A reference to an entry § 2 omitted follows step 1 below |
+| `hierarchy` | Bundle children are `make_child` of their bundle parent per step 1 below. Parents and standalone issues follow `hierarchy_recommendation`: `children_of_origin` → `make_child` of the origin ID, anything else → `none`, `mixed` → per the TPM grouping |
 | `supersedes` | Supersession entries in `cross_project_findings` — only those § 2 neither executed nor skipped |
 | `cross_project_findings.conflicts[]` | Each resolution is applied before conversion: a wait/sequence resolution becomes `blocked_by: ["[ISSUE_ID]"]` on the affected entry; a `Modify approach` text lands in that entry's `create_fields` and marks it `"reapprove": true`; `Skip this issue` omits it. A resolution with no representable effect halts naming the conflict |
-| existing-work actions decided at § 2 | An action § 2 executed (cancel/expand/descope) is OMITTED from `issues[]` (never `skip`); a `supersede` whose cancellation § 2 executed enters as a plain `create` with `supersedes` cleared; an action § 2 skipped — globally or per action — is omitted as well, a skipped supersession dropping its replacement too; the § 5 report lists every omission with its § 2 outcome. Nothing § 6 or § 7 sees can override a § 2 answer |
 | `obsolete` | `organized_issues[i].obsolete` |
 | `priority_misalignment`, `agent_mismatch` | null — already correct |
+
+The two rules the rows above defer to:
+
+1. **Retargeting.** A reference to any entry § 2 omitted — a relation or a `hierarchy.parent` — retargets to that entry's existing `target` issue id when the action executed; when the action was skipped, the reference is removed and the dependent re-enters § 5 marked `"reapprove": true` — never a dangling `#N`. A bundle child is `make_child` of `#[parent_index]` or, when that parent was omitted at § 2, of its existing `target` id.
+2. **Omission.** An action § 2 executed (cancel/expand/descope) is OMITTED from `issues[]` (never `skip`); a `supersede` whose cancellation § 2 executed enters as a plain `create` with `supersedes` cleared; an action § 2 skipped — globally or per action — is omitted as well, a skipped supersession dropping its replacement too; the § 5 report lists every omission with its § 2 outcome. Nothing § 6 or § 7 sees can override a § 2 answer.
 
 Each entry's `create_fields` carries `description` (synthesized from title, feature context, and breaking changes), `recommendation` (requirement bullets, plus doc updates and migration steps), `location`, `estimate`, `priority`, `labels[]` (authoritative, validated in § 4.1), `agent_label`, `is_bundle_parent`, and `source_path` = the plan markdown path. A bundle parent sets `is_bundle_parent: true` with no description or recommendation; generate [parent-issue-template.md](../templates/parent-issue-template.md) content after the children exist, via workflow-actions § Descriptions (parent rebuild).
 

--- a/skills/project-management/workflows/roadmap-plan.md
+++ b/skills/project-management/workflows/roadmap-plan.md
@@ -11,19 +11,25 @@ Plan a roadmap: research gate, specialist consultation, TPM analysis, architectu
 | `... --origin-issue [ISSUE_ID]` | Supply origin-issue context for the hierarchy decision |
 | `... --planner-handoff @[plan-file]` | Consume a plan from a scout → planner chain |
 
-Extract `FEATURE`, `RESEARCH_PATH`, `ORIGIN_ISSUE`, and `PLANNER_HANDOFF` (each null when absent). Read the `@[path]` file and classify it: research findings inform planning; a **finished plan** — a design document the user has reviewed that already settles approach and workstreams — is the SPEC. With a SPEC: § 1 is satisfied, § 2 runs in slicing mode, the § 5 report presents the derived issues against it, and the spec's path travels as `RESEARCH_PATH` → `research_ref`, which the issue template writes as the `**Research**` line on every created issue (unconditionally; the § 6 research question offers the reference to pre-existing issues only). The spec skips no approval and no creation gate. Refresh a stale cache before the first read here and in §§ 1-2. Planning itself only reads; the § 1 research-spike branch delegates to research-issue, which reconciles again before it creates anything:
+1. Extract `FEATURE`, `RESEARCH_PATH`, `ORIGIN_ISSUE`, and `PLANNER_HANDOFF` (each null when absent).
 
-```bash
-.agents/skills/linear/scripts/linear.sh sync --if-stale 15
-```
+2. Read the `@[path]` file and classify it: research findings inform planning; a **finished plan** — a design document the user has reviewed that already settles approach and workstreams — is the SPEC.
 
-With `--origin-issue`, fetch it and keep `id`, `title`, `project`, `description`, `children`:
+3. With a SPEC: § 1 is satisfied, § 2 runs in slicing mode, the § 5 report presents the derived issues against it, and the spec's path travels as `RESEARCH_PATH` → `research_ref`, which the issue template writes as the `**Research**` line on every created issue (unconditionally; the § 6 research question offers the reference to pre-existing issues only). The spec skips no approval and no creation gate.
 
-```bash
-.agents/skills/linear/scripts/linear.sh cache issues get [ORIGIN_ISSUE_ID]
-```
+4. Refresh a stale cache before the first read here and in §§ 1-2. Planning itself only reads; the § 1 research-spike branch delegates to research-issue, which reconciles again before it creates anything:
 
-With `--planner-handoff`, read the file and keep its plan path, recommended approach, proposed phases or issue candidates, any TPM handoff recommendation, and referenced issue or project names. Never run `planner` from here. A handoff skips no gate, no TPM step, no approval, and no creation confirmation.
+   ```bash
+   .agents/skills/linear/scripts/linear.sh sync --if-stale 15
+   ```
+
+5. With `--origin-issue`, fetch it and keep `id`, `title`, `project`, `description`, `children`:
+
+   ```bash
+   .agents/skills/linear/scripts/linear.sh cache issues get [ORIGIN_ISSUE_ID]
+   ```
+
+6. With `--planner-handoff`, read the file and keep its plan path, recommended approach, proposed phases or issue candidates, any TPM handoff recommendation, and referenced issue or project names. Never run `planner` from here. A handoff skips no gate, no TPM step, no approval, and no creation confirmation.
 
 ---
 
@@ -31,13 +37,15 @@ With `--planner-handoff`, read the file and keep its plan path, recommended appr
 
 **Skip if** `RESEARCH_PATH` was provided.
 
-Search existing artifacts on disk first — the project's research and plan directories (`docs/research/`, `docs/plans/`, or the project's equivalents) by `FEATURE` keywords; classify a match with the Inputs rule (research vs SPEC) exactly as an `@[path]` argument, and when several match, ask the user which applies; a selected artifact ends this gate → § 2. Only when the disk search finds nothing, query the tracker: resolve `RESEARCH_WORKFLOW_LABEL` from the project taxonomy and the live inventory (`cache labels list --format=safe`), then query it. If no unambiguous assignable label exists, skip the lookup and continue to § 2; do not query a hard-coded fallback label.
+1. Search existing artifacts on disk first — the project's research and plan directories (`docs/research/`, `docs/plans/`, or the project's equivalents) by `FEATURE` keywords.
 
-```bash
-.agents/skills/linear/scripts/linear.sh cache issues list --label "[RESEARCH_WORKFLOW_LABEL]" --state "Done" --max
-```
+2. Then classify a match with the Inputs rule (research vs SPEC) exactly as an `@[path]` argument, and when several match, ask the user which applies; a selected artifact ends this gate → § 2. Only when the disk search finds nothing, query the tracker: resolve `RESEARCH_WORKFLOW_LABEL` from the project taxonomy and the live inventory (`cache labels list --format=safe`), then query it. If no unambiguous assignable label exists, skip the lookup and continue to § 2; do not query a hard-coded fallback label.
 
-Filter for `FEATURE` keywords. A match supplies `RESEARCH_PATH` from the issue → § 2.
+   ```bash
+   .agents/skills/linear/scripts/linear.sh cache issues list --label "[RESEARCH_WORKFLOW_LABEL]" --state "Done" --max
+   ```
+
+3. Filter for `FEATURE` keywords. A match supplies `RESEARCH_PATH` from the issue → § 2.
 
 With no match, ask the user:
 
@@ -117,9 +125,13 @@ Report as JSON:
 6. Out-of-spec work (spec mode only): anything needed beyond the spec's phases — each entry names the work and whether the spec's own deliverables need it
 </delegation_format>
 
-Keep the result as `ARCH_FINDINGS` (`validated_findings[]`, `deprecated_code[]`, `breaking_changes[]`, `required_refactors[]`, `risk_assessment`, `out_of_spec[]`). Fold verified findings into the TPM JSON before presenting: scope additions go into the issues they belong to, ordering fixes into relations, and any standalone addition — a `required_refactors[]` prerequisite, a second-opinion finding, or a needed `out_of_spec[]` entry — re-enters § 2's delegation table for its domain and § 3; the fold never invents issue fields. In spec mode the fold stops at the spec's boundary, with the same exception the TPM applies: an `out_of_spec[]` entry the spec's own deliverables need re-enters planning like any standalone addition; every other entry becomes an `architecture_gaps[]` row with `recommendation: out_of_scope` — never `defer` — naming the spec in `reason`, rendered under ARCHITECTURE GAPS in § 5.
+1. Keep the result as `ARCH_FINDINGS` (`validated_findings[]`, `deprecated_code[]`, `breaking_changes[]`, `required_refactors[]`, `risk_assessment`, `out_of_spec[]`).
 
-For a major feature — any of: ten or more creation entries, entries spanning two or more `agent:*` domains, a listed breaking change, or `risk_assessment.level: high` — planned without an already-reviewed spec, also run the `second-opinion` skill (challenge mode) on the plan here and fold verified findings in the same way. When the skill is not installed, or is installed but cannot complete (no eligible target, missing external CLI, timeout, nonzero exit), the § 5 report's `Cross-model review` field reads `unavailable — <reason>` and the workflow continues. A SPEC that already passed external review skips this (`skipped — reviewed spec`); a non-major plan records `skipped — not required`.
+2. Fold verified findings into the TPM JSON before presenting: scope additions go into the issues they belong to, ordering fixes into relations, and any standalone addition — a `required_refactors[]` prerequisite, a second-opinion finding, or a needed `out_of_spec[]` entry — re-enters § 2's delegation table for its domain and § 3; the fold never invents issue fields.
+
+3. In spec mode the fold stops at the spec's boundary, with the same exception the TPM applies: an `out_of_spec[]` entry the spec's own deliverables need re-enters planning like any standalone addition; every other entry becomes an `architecture_gaps[]` row with `recommendation: out_of_scope` — never `defer` — naming the spec in `reason`, rendered under ARCHITECTURE GAPS in § 5.
+
+4. For a major feature — any of: ten or more creation entries, entries spanning two or more `agent:*` domains, a listed breaking change, or `risk_assessment.level: high` — planned without an already-reviewed spec, also run the `second-opinion` skill (challenge mode) on the plan here and fold verified findings in the same way. When the skill is not installed, or is installed but cannot complete (no eligible target, missing external CLI, timeout, nonzero exit), the § 5 report's `Cross-model review` field reads `unavailable — <reason>` and the workflow continues. A SPEC that already passed external review skips this (`skipped — reviewed spec`); a non-major plan records `skipped — not required`.
 
 ---
 

--- a/skills/project-management/workflows/tpm-audit.md
+++ b/skills/project-management/workflows/tpm-audit.md
@@ -4,7 +4,7 @@ Analyze issues and projects for relations, labels, hierarchy, placement, duplica
 
 **Do NOT modify the tracker.** Return recommendations only.
 
-**Hold the creation bar** ([SKILL.md](../SKILL.md) § Disposition). An observation becomes a `create` only when it changes what a user or operator experiences (or blocks work that does), nothing open already covers it, and someone could finish it without a new investigation. Everything else is `skip` with a one-line reason. Every run that reads an issue backlog also completes the § 6 cancellation sweep.
+**Hold the creation bar** ([SKILL.md](../SKILL.md) § Disposition). An observation that clears it is a `create`; everything else is `skip` with a one-line reason. Every run that reads an issue backlog also completes the § 6 cancellation sweep.
 
 ## Inputs
 
@@ -227,7 +227,13 @@ Never add to `obsolete[]` without code verification.
 
 With `DECISION_REF` present, also detect issues the decision made unnecessary by changing the approach (not the scope): read the decision (`.agents/skills/decider/scripts/decisions get [DECISION_REF]`), extract the patterns it explicitly replaced, search the comparison set for issues implementing them, exclude anything already in `supersedes[]`, and record confidence 100 with evidence `{decision_eliminated: true, decision_ref, eliminated_pattern}`.
 
-**Below the bar.** Every active issue in the comparison set as § 1.5 fetched it is re-read against the creation bar's first and third tests as they stand today (the second, coverage by other work, is not reapplied: an issue always covers itself). One that fails (the bar's own list, not restated here) is a cancellation with confidence 100 and evidence `{below_bar: true, test, who_hits_it}`: `test` names the failed test, `who_hits_it` is the one-line user story and how often a user meets it, written after reading the issue's body (on GitHub, `gh issue view <n>`; the § 1.5 list carries no body). In project mode it is an `obsolete[]` entry; in issue mode it is the issue's own `issues[]` entry with `action: "cancel"` and that evidence in its `obsolete` field. The bar's two exceptions (a shipped-path security or data-loss defect; a critical-harm or financial-loss edge case) never go here on likelihood; the third test still applies to them. The code-verification rule above is for implementation-obsolete entries; a `below_bar` entry is verified by reading the body and, where it names a path, producer, or regression, checking that claim in the repository before the entry is written.
+**Below the bar.**
+
+1. Re-read every active issue in the comparison set as § 1.5 fetched it against the creation bar's first and third tests as they stand today (the second, coverage by other work, is not reapplied: an issue always covers itself).
+2. One that fails (the bar's own list, not restated here) is a cancellation with confidence 100 and evidence `{below_bar: true, test, who_hits_it}`: `test` names the failed test, `who_hits_it` is the one-line user story and how often a user meets it, written after reading the issue's body (on GitHub, `gh issue view <n>`; the § 1.5 list carries no body).
+3. In project mode it is an `obsolete[]` entry; in issue mode it is the issue's own `issues[]` entry with `action: "cancel"` and that evidence in its `obsolete` field.
+4. The bar's two exceptions (a shipped-path security or data-loss defect; a critical-harm or financial-loss edge case) never go here on likelihood; the third test still applies to them.
+5. The code-verification rule above is for implementation-obsolete entries; a `below_bar` entry is verified by reading the body and, where it names a path, producer, or regression, checking that claim in the repository before the entry is written.
 
 ### 6.3 Project Fit
 


### PR DESCRIPTION
Prose and structure only, split from KEN-779 (#1788) so that behavior diff stayed reviewable. No rule changes.

## Numbering and step structure

- `audit-issues.md` — § 1.2.2/§ 1.2.3 existed with no § 1.2.1; renumbered.
- `tpm-roadmap-plan.md` — § 1 subsections started at 1.2; renumbered.
- `roadmap-plan.md` — the ~200-word Inputs paragraph held four sequential directives (extract vars, classify the `@path`, SPEC semantics, origin fetch); they are numbered steps now. Same for the § 1 three-actions sentence and the § 4 fold paragraph.
- `tpm-audit.md` § 6.2 "Below the bar" — one 200-word paragraph holding a procedure, now numbered steps, content unchanged.
- `roadmap-create.md` § 4.2 — the retargeting and omission rules were multi-sentence table cells; each is its own numbered step below the table.

## Dedup — one owner plus pointers

The verbatim halt-list enumeration appeared five times outside its owner (`labels.md` § Validation); each is a pointer now, keeping the test-pinned `halts before mutation` phrase. Same treatment for the `audit-issues.md` preamble hierarchy paragraph, `tpm-audit.md`'s opening sentences, `SKILL.md`'s primary-session duplicate, `audit-output.md`'s completed-blocker rationale, `audit-issues-input.md`'s hierarchy MUST list, `research-issue.md`'s label-authorization duplicate, and `README.md`'s intro restatement.

## One carried item from #1788's review

`SKILL.md` § Scope by Path — the `audit-issues §§ 7.2-7.5` row read `inherits` in the **Resolves** column. Every other cell names a section, a command, or a mechanism, so it is checkable by reading the named thing; `inherits` is a characterisation a reader cannot verify without already knowing what it inherits from. It now reads `n/a — executes an artifact tpm-audit produced under its scope`.

Raised by that PR's implementer against their own work and deliberately not fixed there, since #1788 was under a hard freeze and the row was not wrong.

## Verification

26 files, +134/−86 — the diff removes more prose than it adds. No ratchet row moved. 12 skill suites green from both trees, `diff -r` clean, `tools/guard` exit 0. Five of those suites grep exact phrases, so they were run after each cut rather than at the end.

Closes KEN-781
