### PR TITLE
fix(KEN-761): a project's record cannot claim another checkout's paths

### DIFF
--- a/changelog.d/fixed/KEN-761.md
+++ b/changelog.d/fixed/KEN-761.md
@@ -1,0 +1,3 @@
+- A project's install record can no longer name paths in another checkout, so a
+  refresh in a copied project stops deleting the original's files. Such a
+  record is refused, naming the path.

--- a/changelog.d/fixed/KEN-761.md
+++ b/changelog.d/fixed/KEN-761.md
@@ -1,3 +1,3 @@
-- A project's install record can no longer name paths in another checkout, so a
-  refresh in a copied project stops deleting the original's files. Such a
-  record is refused, naming the path.
+- A refresh in a copied project no longer deletes the original's files.
+  **Breaking:** a record naming another checkout is refused; run `kendex apply
+  --replace-unmanaged --yes` or delete the lock.

--- a/changelog.d/fixed/KEN-761.md
+++ b/changelog.d/fixed/KEN-761.md
@@ -1,3 +1,3 @@
-- A refresh no longer deletes another project's files. **Breaking:** a record
-  naming a path outside its project is refused; run `kendex apply
-  --replace-unmanaged --yes` or delete the lock.
+- A refresh no longer deletes another project's files. **Breaking:** a
+  record naming a path outside its project is refused; delete the lock, then
+  apply to reinstall.

--- a/changelog.d/fixed/KEN-761.md
+++ b/changelog.d/fixed/KEN-761.md
@@ -1,3 +1,3 @@
-- A refresh in a copied project no longer deletes the original's files.
-  **Breaking:** a record naming another checkout is refused; run `kendex apply
+- A refresh no longer deletes another project's files. **Breaking:** a record
+  naming a path outside its project is refused; run `kendex apply
   --replace-unmanaged --yes` or delete the lock.

--- a/crates/core/src/engine/bundles.rs
+++ b/crates/core/src/engine/bundles.rs
@@ -62,7 +62,6 @@ pub(super) fn expand(
                     bundle: BundleRef {
                         source: decl.source.clone(),
                         name: name.clone(),
-                        scope: scope.clone(),
                     },
                 },
                 harnesses,

--- a/crates/core/src/engine/deps.rs
+++ b/crates/core/src/engine/deps.rs
@@ -18,7 +18,7 @@ use std::collections::{BTreeMap, BTreeSet, VecDeque};
 use crate::error::Result;
 use crate::lock::{InstallRef, Reason};
 use crate::manifest::{ItemDecl, Manifest};
-use crate::model::{HarnessId, ItemKind, Scope};
+use crate::model::{HarnessId, ItemKind};
 use crate::source::{SourceConfig, find_item, list_items};
 use crate::source_read::SealedSource;
 
@@ -67,7 +67,6 @@ pub(crate) fn declared_dependencies(
 /// bundle members are walked like any other: what a skill needs does not
 /// depend on how it was chosen.
 pub(super) fn expand(
-    scope: &Scope,
     manifest: &Manifest,
     expansion: &mut Expansion,
     catalogs: &mut Catalogs,
@@ -131,7 +130,6 @@ pub(super) fn expand(
                     kind: ItemKind::Skill,
                     name: parent.clone(),
                     harness,
-                    scope: scope.clone(),
                 };
                 grew |= expansion.add(
                     ItemKind::Skill,

--- a/crates/core/src/engine/desired/hold/tests.rs
+++ b/crates/core/src/engine/desired/hold/tests.rs
@@ -1,7 +1,7 @@
 use super::*;
 use crate::lock::{BundleRef, InstallRef, LockEntry};
 use crate::manifest::{ItemDecl, SourceDecl};
-use crate::model::{HarnessId, Scope};
+use crate::model::HarnessId;
 
 fn manifest_with(items: &[(&str, Option<&str>)], bundles: &[&str]) -> Manifest {
     let mut manifest = Manifest::default();
@@ -112,7 +112,6 @@ fn a_derived_targets_bundle_is_exempt_and_a_stranger_bundle_holds() {
         bundle: BundleRef {
             source: "cat".to_owned(),
             name: bundle.to_owned(),
-            scope: Scope::Global,
         },
     };
     let lock = lock_with(&[
@@ -370,14 +369,12 @@ fn an_edge_recorded_against_another_source_exempts_nothing() {
             kind: ItemKind::Skill,
             name: "parent".to_owned(),
             harness: HarnessId::Claude,
-            scope: Scope::Global,
         },
     };
     let of_old_kit = Reason::MemberOf {
         bundle: BundleRef {
             source: "old".to_owned(),
             name: "kit".to_owned(),
-            scope: Scope::Global,
         },
     };
     let lock = lock_with(&[
@@ -394,7 +391,6 @@ fn an_edge_recorded_against_another_source_exempts_nothing() {
                     bundle: BundleRef {
                         source: "cat".to_owned(),
                         name: "kit".to_owned(),
-                        scope: Scope::Global,
                     },
                 }],
             ),
@@ -459,7 +455,6 @@ fn a_left_behind_installation_of_the_target_exempts_nothing() {
             kind: ItemKind::Skill,
             name: "parent".to_owned(),
             harness: HarnessId::Claude,
-            scope: Scope::Global,
         },
     };
     let lock = lock_with(&[

--- a/crates/core/src/engine/expansion.rs
+++ b/crates/core/src/engine/expansion.rs
@@ -346,7 +346,7 @@ pub(super) fn expand(
         open: BTreeMap::new(),
     };
     super::bundles::expand(scope, manifest, held, &mut expansion, &mut catalogs, state);
-    super::deps::expand(scope, manifest, &mut expansion, &mut catalogs, state);
+    super::deps::expand(manifest, &mut expansion, &mut catalogs, state);
     expansion.report_rev_disagreements(state);
     expansion
 }

--- a/crates/core/src/engine/mod.rs
+++ b/crates/core/src/engine/mod.rs
@@ -224,8 +224,8 @@ fn plan_scope_once(
     pi_hooks_move::record_finished(&mut new_lock, &moved_out);
     stale::stale_instruction_rows(env, scope, lock, &new_lock, &mut config_edits)?;
     plan_config_edits(env, scope, config_edits, &mut ops)?;
-    let set_changes = set_changes(scope, lock, &new_lock);
-    let kept = kept_members(scope, lock, &new_lock, &options.uninstalled_bundles);
+    let set_changes = set_changes(lock, &new_lock);
+    let kept = kept_members(lock, &new_lock, &options.uninstalled_bundles);
     let repo_effects_leaving = repo_effects::leaving(env, scope, lock, &new_lock)?;
     plan_lock_write(env, scope, disk_lock, new_lock, &mut ops)?;
     scope_notes.extend(scope_wide(scope, &mut ops)?);

--- a/crates/core/src/engine/removal.rs
+++ b/crates/core/src/engine/removal.rs
@@ -234,7 +234,7 @@ pub(super) fn orphans(
         });
         if !removable {
             if unneeded {
-                sweepable.push(super::SetChange::dropped(scope, entry));
+                sweepable.push(super::SetChange::dropped(entry));
             }
             new_lock.entries.insert(key.clone(), entry.clone());
             continue;

--- a/crates/core/src/engine/set_change.rs
+++ b/crates/core/src/engine/set_change.rs
@@ -9,7 +9,7 @@ use serde::{Deserialize, Serialize};
 use specta::Type;
 
 use crate::lock::{Lock, LockEntry, Reason};
-use crate::model::{HarnessId, ItemKind, Scope};
+use crate::model::{HarnessId, ItemKind};
 
 /// Whether a plan brings an installation into being or takes one away.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Type)]
@@ -35,9 +35,9 @@ pub struct SetChange {
 }
 
 impl SetChange {
-    pub(super) fn added(scope: &Scope, entry: &LockEntry) -> SetChange {
+    pub(super) fn added(entry: &LockEntry) -> SetChange {
         SetChange {
-            reason: why_wanted(scope, &entry.reasons),
+            reason: why_wanted(&entry.reasons),
             direction: SetDirection::Add,
             kind: entry.kind,
             name: entry.name.clone(),
@@ -45,12 +45,12 @@ impl SetChange {
         }
     }
 
-    pub(super) fn dropped(scope: &Scope, entry: &LockEntry) -> SetChange {
+    pub(super) fn dropped(entry: &LockEntry) -> SetChange {
         let reason = match entry.reasons.contains(&Reason::Requested) {
             true => "no longer declared here".to_owned(),
             false => format!(
                 "nothing needs it anymore — it was {}",
-                why_wanted(scope, &entry.reasons)
+                why_wanted(&entry.reasons)
             ),
         };
         SetChange {
@@ -77,30 +77,17 @@ pub struct KeptInstall {
 }
 
 /// The reasons an installation exists, said once, in the words a preview
-/// uses. Reasons from another scope name it — a global bundle pulling a
-/// project item in has to read as what it is.
-fn why_wanted(scope: &Scope, reasons: &BTreeSet<Reason>) -> String {
+/// uses. Every reason in a lock was recorded by a pass over the scope that
+/// lock belongs to, so there is no other scope for one of them to name.
+fn why_wanted(reasons: &BTreeSet<Reason>) -> String {
     let mut said: Vec<String> = Vec::new();
     for reason in reasons {
-        let elsewhere = |other: &Scope| match other == scope {
-            true => String::new(),
-            false => format!(" in {}", other.label()),
-        };
         said.push(match reason {
             Reason::Requested => "asked for".to_owned(),
-            Reason::RequiredBy { by } => format!(
-                "required by the {} {}{}",
-                by.kind.name(),
-                by.name,
-                elsewhere(&by.scope)
-            ),
-            Reason::MemberOf { bundle } => {
-                format!(
-                    "part of the {} bundle{}",
-                    bundle.name,
-                    elsewhere(&bundle.scope)
-                )
+            Reason::RequiredBy { by } => {
+                format!("required by the {} {}", by.kind.name(), by.name)
             }
+            Reason::MemberOf { bundle } => format!("part of the {} bundle", bundle.name),
         });
     }
     said.join(", and ")
@@ -109,19 +96,19 @@ fn why_wanted(scope: &Scope, reasons: &BTreeSet<Reason>) -> String {
 /// The installed set before against the installed set after — every
 /// installation this plan brings into being or takes away, whatever the
 /// reason. Regeneration of an installation that stays is not in here.
-pub(super) fn set_changes(scope: &Scope, before: &Lock, after: &Lock) -> Vec<SetChange> {
+pub(super) fn set_changes(before: &Lock, after: &Lock) -> Vec<SetChange> {
     let mut changes: Vec<SetChange> = after
         .entries
         .iter()
         .filter(|(key, _)| !before.entries.contains_key(*key))
-        .map(|(_, entry)| SetChange::added(scope, entry))
+        .map(|(_, entry)| SetChange::added(entry))
         .collect();
     changes.extend(
         before
             .entries
             .iter()
             .filter(|(key, _)| !after.entries.contains_key(*key))
-            .map(|(_, entry)| SetChange::dropped(scope, entry)),
+            .map(|(_, entry)| SetChange::dropped(entry)),
     );
     changes
 }
@@ -130,12 +117,7 @@ pub(super) fn set_changes(scope: &Scope, before: &Lock, after: &Lock) -> Vec<Set
 /// members that survive are here — the ones that went are already in the set
 /// changes — and each reads back with the reasons it has left, which is
 /// exactly what the user needs to see to believe the split.
-pub(super) fn kept_members(
-    scope: &Scope,
-    before: &Lock,
-    after: &Lock,
-    bundles: &[String],
-) -> Vec<KeptInstall> {
+pub(super) fn kept_members(before: &Lock, after: &Lock, bundles: &[String]) -> Vec<KeptInstall> {
     if bundles.is_empty() {
         return Vec::new();
     }
@@ -153,7 +135,7 @@ pub(super) fn kept_members(
             kind: entry.kind,
             name: entry.name.clone(),
             harness: entry.harness,
-            reason: why_wanted(scope, &entry.reasons),
+            reason: why_wanted(&entry.reasons),
         })
         .collect()
 }

--- a/crates/core/src/error.rs
+++ b/crates/core/src/error.rs
@@ -49,6 +49,16 @@ pub enum CoreError {
     LockCorrupt { path: PathBuf, message: String },
 
     #[error(
+        "{path} records {key} at {recorded}, outside the project at {root} — this lock belongs to another checkout; delete it and apply again"
+    )]
+    LockOutsideProject {
+        path: PathBuf,
+        key: String,
+        recorded: PathBuf,
+        root: PathBuf,
+    },
+
+    #[error(
         "{path} was written by a newer kendex (format {found}) — update this app before touching it"
     )]
     SchemaTooNew { path: PathBuf, found: i64 },

--- a/crates/core/src/lock.rs
+++ b/crates/core/src/lock.rs
@@ -1,22 +1,22 @@
 use std::collections::{BTreeMap, BTreeSet};
-use std::path::{Path, PathBuf};
+use std::path::PathBuf;
 
 use serde::{Deserialize, Serialize};
 use specta::Type;
 
 use crate::env::Env;
-use crate::error::{CoreError, Result};
-use crate::fs::{atomic_write, read_if_exists};
 use crate::manifest::Method;
 use crate::model::{HarnessId, ItemKind, Scope};
 
-/// Current lock version. Versions 1 (v0.1) through 5 still load — the
+/// Current lock version. Versions 1 (v0.1) through 6 still load — the
 /// shapes are compatible and the next lock write records the current
 /// version. A lock newer than this build refuses to load. Version 3 added
 /// `source_commit` and `rendered_hash`; version 4 added `settings-seeds`;
 /// version 5 added `left_pi_reserved_name`, a registration's matcher, and
 /// a recorded registration for hooks with a script of their own; version
-/// 6 added `bundles`.
+/// 6 added `bundles`; version 7 dropped the scope an install reason
+/// recorded, which was always the scope holding the lock and spelled a
+/// project's root as an absolute path.
 /// Each bump is what stops an older build from reading the lock, dropping
 /// the newer record on its next write, and erasing evidence — of which
 /// bytes are whose, of which comment blocks seeding wrote, of a move out
@@ -27,7 +27,7 @@ use crate::model::{HarnessId, ItemKind, Scope};
 /// that dropped a set's commit would leave a set whose members have come
 /// apart placeable at nothing, so the next update of anything else takes
 /// its other members current.
-pub const LOCK_VERSION: u32 = 6;
+pub const LOCK_VERSION: u32 = 7;
 
 /// The lock file a project scope carries. The global lock is `lock.json`
 /// under the app's own directory ([`Env::global_lock_file`]).
@@ -107,7 +107,9 @@ pub struct BundleRev {
 }
 
 /// One installation an edge points at: the counterpart named the way the
-/// manifest and the lock name an installation.
+/// manifest and the lock name an installation. Both ends sit in the scope
+/// whose lock holds the record, so the scope is the file's, not the
+/// reference's.
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize, Type)]
 #[serde(rename_all = "camelCase")]
 pub struct InstallRef {
@@ -117,7 +119,6 @@ pub struct InstallRef {
     pub kind: ItemKind,
     pub name: String,
     pub harness: HarnessId,
-    pub scope: Scope,
 }
 
 /// The bundle an installation came in with.
@@ -126,7 +127,6 @@ pub struct InstallRef {
 pub struct BundleRef {
     pub source: String,
     pub name: String,
-    pub scope: Scope,
 }
 
 /// Why one installation exists. An installation holds a *set* of these — the
@@ -272,6 +272,9 @@ pub fn skill_names(lock: &Lock) -> std::collections::BTreeSet<String> {
         .collect()
 }
 
+mod file;
+pub use file::{LockFile, is_v1_text, load, load_file, parse_text, save};
+
 /// Where this scope's lock lives. Off the canonical root, like every
 /// scope-path derivation (`manifest::manifest_path`): the path must
 /// compare equal to the ones the engine's plan speaks, whatever spelling
@@ -281,119 +284,6 @@ pub fn lock_path(env: &Env, scope: &Scope) -> PathBuf {
         Scope::Global => env.global_lock_file(),
         Scope::Project { root } => Env::project_lock_file(root),
     }
-}
-
-/// What sits at a lock path. A v1 lock keys entries by bare name and carries
-/// a `harnesses` array; v2 keys carry `kind:name:harness` with one `harness`
-/// field. The shapes are incompatible — deserializing v1 text straight into
-/// [`Lock`] surfaces a raw "missing field" error instead of naming what the
-/// file actually is.
-#[derive(Debug, Clone, PartialEq)]
-pub enum LockFile {
-    Absent,
-    Legacy { raw: String },
-    Current(Lock),
-}
-
-/// `"version": 1` alone cannot identify the old product generation: this
-/// product's own v0.1 locks also say 1 and load compatibly (see
-/// [`LOCK_VERSION`]). The key shape is the discriminator — bare-name keys
-/// against v2's always-present `kind:name:harness` separator — and it only
-/// applies to files not declaring a version above 1, so a current file with
-/// odd keys is diagnosed as corrupt, never mislabeled v1. An empty map
-/// matches both shapes and reads as current, the only reading a lost lock
-/// or a fresh scope can mean.
-fn is_v1(value: &serde_json::Value) -> bool {
-    let version = value.get("version").and_then(serde_json::Value::as_i64);
-    if version.is_some_and(|v| v > 1) {
-        return false;
-    }
-    value
-        .get("entries")
-        .and_then(serde_json::Value::as_object)
-        .is_some_and(|entries| !entries.is_empty() && entries.keys().all(|k| !k.contains(':')))
-}
-
-/// Text-taking wrapper for callers (the CLI's one-shot v1 importer) that
-/// have not already parsed the JSON. Unparseable text is not v1 — it is
-/// corrupt, and `load_file` names that distinctly.
-pub fn is_v1_text(text: &str) -> bool {
-    serde_json::from_str(text).is_ok_and(|value| is_v1(&value))
-}
-
-pub fn load_file(path: &Path) -> Result<LockFile> {
-    let Some(text) = read_if_exists(path)? else {
-        return Ok(LockFile::Absent);
-    };
-    parse_text(path, &text)
-}
-
-/// [`load_file`] for text the caller already read — the importer binds its
-/// preconditions to the exact bytes it classified, so it must classify the
-/// bytes it read rather than a later re-read.
-pub fn parse_text(path: &Path, text: &str) -> Result<LockFile> {
-    let value: serde_json::Value =
-        serde_json::from_str(text).map_err(|e| CoreError::LockCorrupt {
-            path: path.to_path_buf(),
-            message: e.to_string(),
-        })?;
-    if let Some(version) = value.get("version").and_then(serde_json::Value::as_i64)
-        && version > i64::from(LOCK_VERSION)
-    {
-        return Err(CoreError::SchemaTooNew {
-            path: path.to_path_buf(),
-            found: version,
-        });
-    }
-    if is_v1(&value) {
-        return Ok(LockFile::Legacy {
-            raw: text.to_owned(),
-        });
-    }
-    let mut lock: Lock = serde_json::from_value(value).map_err(|e| CoreError::LockCorrupt {
-        path: path.to_path_buf(),
-        message: e.to_string(),
-    })?;
-    backfill_requested_reason(&mut lock);
-    Ok(LockFile::Current(lock))
-}
-
-// A record written before installations carried their reasons: everything
-// installed then was installed because it was asked for, which is the only
-// reading that cannot invent a dependency nobody declared. The next write
-// records it.
-fn backfill_requested_reason(lock: &mut Lock) {
-    for entry in lock.entries.values_mut() {
-        if entry.reasons.is_empty() {
-            entry.reasons.insert(Reason::Requested);
-        }
-    }
-}
-
-/// Load for mutation: a v1 lock is a hard error, never a write target — same
-/// posture as [`crate::manifest::load_for_mutation`]. Callers that only
-/// observe (the audit view) use [`load_file`] instead so a v1 lock degrades
-/// to a note rather than blocking the read.
-pub fn load(path: &Path) -> Result<Lock> {
-    match load_file(path)? {
-        LockFile::Absent => Ok(Lock {
-            version: LOCK_VERSION,
-            ..Lock::default()
-        }),
-        LockFile::Legacy { .. } => Err(CoreError::LegacyLock {
-            path: path.to_path_buf(),
-        }),
-        LockFile::Current(lock) => Ok(lock),
-    }
-}
-
-pub fn save(path: &Path, lock: &Lock) -> Result<()> {
-    let mut text = serde_json::to_string_pretty(lock).map_err(|e| CoreError::JsonParse {
-        path: path.to_path_buf(),
-        message: e.to_string(),
-    })?;
-    text.push('\n');
-    atomic_write(path, &text)
 }
 
 #[cfg(test)]

--- a/crates/core/src/lock/file.rs
+++ b/crates/core/src/lock/file.rs
@@ -1,7 +1,7 @@
 //! Reading and writing a lock file: what sits at a path, the boundary a
 //! project's record may claim, and the version shapes that still load.
 
-use std::path::{Path, PathBuf};
+use std::path::{Component, Path, PathBuf};
 
 use crate::error::{CoreError, Result};
 use crate::fs::{atomic_write, read_if_exists};
@@ -25,12 +25,28 @@ fn project_root_at(path: &Path) -> Option<&Path> {
     }
 }
 
+/// Whether `path` reaches out of `root`.
+///
+/// Two ways it can. It can name somewhere else outright, which
+/// `Path::starts_with` catches. Or it can start under `root` and walk back
+/// out: `starts_with` matches component against component and resolves
+/// nothing, so `<root>/../elsewhere` reads as inside while every operation
+/// on it lands outside.
+///
+/// A `..` is refused rather than resolved. Nothing kendex writes carries
+/// one — an emitted path is names joined onto a root [`super::lock_path`]
+/// already resolved (invariant 17) — so there is no reading of one to
+/// recover, and refusing does not turn on getting normalization right.
+fn reaches_outside(root: &Path, path: &Path) -> bool {
+    !path.starts_with(root) || path.components().any(|part| part == Component::ParentDir)
+}
+
 /// The first position a lock claims outside `root`, with the entry claiming
 /// it.
 ///
-/// One spelling meets one spelling (invariant 17): `emitted.paths` are
-/// written off the canonical root, and the root here is the parent of a lock
-/// path [`super::lock_path`] already canonicalized. Nothing re-canonicalizes.
+/// Held to [`reaches_outside`] rather than to the spellings kendex's own
+/// writes keep: what this judges is a record kendex may not have written,
+/// which is the whole reason it is here.
 fn outside_the_project(root: &Path, lock: &Lock) -> Option<(String, PathBuf)> {
     lock.entries.iter().find_map(|(key, entry)| {
         let outside = entry
@@ -38,7 +54,7 @@ fn outside_the_project(root: &Path, lock: &Lock) -> Option<(String, PathBuf)> {
             .as_ref()?
             .paths
             .iter()
-            .find(|path| !path.starts_with(root))?;
+            .find(|path| reaches_outside(root, path))?;
         Some((key.clone(), outside.clone()))
     })
 }

--- a/crates/core/src/lock/file.rs
+++ b/crates/core/src/lock/file.rs
@@ -1,0 +1,184 @@
+//! Reading and writing a lock file: what sits at a path, the boundary a
+//! project's record may claim, and the version shapes that still load.
+
+use std::path::{Path, PathBuf};
+
+use crate::error::{CoreError, Result};
+use crate::fs::{atomic_write, read_if_exists};
+
+use super::{LOCK_FILE, LOCK_VERSION, Lock, Reason};
+
+/// The project root whose lock sits at `path`, or `None` where the path is
+/// the global lock. The inverse of [`super::lock_path`]: a project scope's lock is
+/// written at its root under [`LOCK_FILE`], and the global lock lives under
+/// the app's own directory with a name of its own.
+fn project_root_at(path: &Path) -> Option<&Path> {
+    if path.file_name()? != LOCK_FILE {
+        return None;
+    }
+    // A relatively named lock sits in the current directory, which is what
+    // it has to answer as: the empty prefix `parent` gives back is one
+    // every path starts with, and containment would wave anything through.
+    match path.parent() {
+        Some(root) if !root.as_os_str().is_empty() => Some(root),
+        _ => Some(Path::new(".")),
+    }
+}
+
+/// The first position a lock claims outside `root`, with the entry claiming
+/// it.
+///
+/// One spelling meets one spelling (invariant 17): `emitted.paths` are
+/// written off the canonical root, and the root here is the parent of a lock
+/// path [`super::lock_path`] already canonicalized. Nothing re-canonicalizes.
+fn outside_the_project(root: &Path, lock: &Lock) -> Option<(String, PathBuf)> {
+    lock.entries.iter().find_map(|(key, entry)| {
+        let outside = entry
+            .emitted
+            .as_ref()?
+            .paths
+            .iter()
+            .find(|path| !path.starts_with(root))?;
+        Some((key.clone(), outside.clone()))
+    })
+}
+
+/// A project scope installs only inside its own root, so `emitted.paths`
+/// reaching past it is not a record this project ever wrote — a lock carried
+/// along with a copied checkout is one that does. Refresh and removal read
+/// those paths as the positions this scope owns and take back the ones a new
+/// render no longer produces, which in another tree is somebody else's
+/// files. So the record is refused, naming the path, at both ends: no read
+/// hands one out and no write puts one down.
+///
+/// The global lock has no single root — each harness owns a directory of its
+/// own — so it has no boundary to check.
+fn refuse_foreign_paths(path: &Path, lock: &Lock) -> Result<()> {
+    let Some(root) = project_root_at(path) else {
+        return Ok(());
+    };
+    match outside_the_project(root, lock) {
+        None => Ok(()),
+        Some((key, recorded)) => Err(CoreError::LockOutsideProject {
+            path: path.to_path_buf(),
+            key,
+            recorded,
+            root: root.to_path_buf(),
+        }),
+    }
+}
+
+/// What sits at a lock path. A v1 lock keys entries by bare name and carries
+/// a `harnesses` array; v2 keys carry `kind:name:harness` with one `harness`
+/// field. The shapes are incompatible — deserializing v1 text straight into
+/// [`Lock`] surfaces a raw "missing field" error instead of naming what the
+/// file actually is.
+#[derive(Debug, Clone, PartialEq)]
+pub enum LockFile {
+    Absent,
+    Legacy { raw: String },
+    Current(Lock),
+}
+
+/// `"version": 1` alone cannot identify the old product generation: this
+/// product's own v0.1 locks also say 1 and load compatibly (see
+/// [`LOCK_VERSION`]). The key shape is the discriminator — bare-name keys
+/// against v2's always-present `kind:name:harness` separator — and it only
+/// applies to files not declaring a version above 1, so a current file with
+/// odd keys is diagnosed as corrupt, never mislabeled v1. An empty map
+/// matches both shapes and reads as current, the only reading a lost lock
+/// or a fresh scope can mean.
+fn is_v1(value: &serde_json::Value) -> bool {
+    let version = value.get("version").and_then(serde_json::Value::as_i64);
+    if version.is_some_and(|v| v > 1) {
+        return false;
+    }
+    value
+        .get("entries")
+        .and_then(serde_json::Value::as_object)
+        .is_some_and(|entries| !entries.is_empty() && entries.keys().all(|k| !k.contains(':')))
+}
+
+/// Text-taking wrapper for callers (the CLI's one-shot v1 importer) that
+/// have not already parsed the JSON. Unparseable text is not v1 — it is
+/// corrupt, and `load_file` names that distinctly.
+pub fn is_v1_text(text: &str) -> bool {
+    serde_json::from_str(text).is_ok_and(|value| is_v1(&value))
+}
+
+pub fn load_file(path: &Path) -> Result<LockFile> {
+    let Some(text) = read_if_exists(path)? else {
+        return Ok(LockFile::Absent);
+    };
+    parse_text(path, &text)
+}
+
+/// [`load_file`] for text the caller already read — the importer binds its
+/// preconditions to the exact bytes it classified, so it must classify the
+/// bytes it read rather than a later re-read.
+pub fn parse_text(path: &Path, text: &str) -> Result<LockFile> {
+    let value: serde_json::Value =
+        serde_json::from_str(text).map_err(|e| CoreError::LockCorrupt {
+            path: path.to_path_buf(),
+            message: e.to_string(),
+        })?;
+    if let Some(version) = value.get("version").and_then(serde_json::Value::as_i64)
+        && version > i64::from(LOCK_VERSION)
+    {
+        return Err(CoreError::SchemaTooNew {
+            path: path.to_path_buf(),
+            found: version,
+        });
+    }
+    if is_v1(&value) {
+        return Ok(LockFile::Legacy {
+            raw: text.to_owned(),
+        });
+    }
+    let mut lock: Lock = serde_json::from_value(value).map_err(|e| CoreError::LockCorrupt {
+        path: path.to_path_buf(),
+        message: e.to_string(),
+    })?;
+    backfill_requested_reason(&mut lock);
+    refuse_foreign_paths(path, &lock)?;
+    Ok(LockFile::Current(lock))
+}
+
+// A record written before installations carried their reasons: everything
+// installed then was installed because it was asked for, which is the only
+// reading that cannot invent a dependency nobody declared. The next write
+// records it.
+fn backfill_requested_reason(lock: &mut Lock) {
+    for entry in lock.entries.values_mut() {
+        if entry.reasons.is_empty() {
+            entry.reasons.insert(Reason::Requested);
+        }
+    }
+}
+
+/// Load for mutation: a v1 lock is a hard error, never a write target — same
+/// posture as [`crate::manifest::load_for_mutation`]. Callers that only
+/// observe (the audit view) use [`load_file`] instead so a v1 lock degrades
+/// to a note rather than blocking the read.
+pub fn load(path: &Path) -> Result<Lock> {
+    match load_file(path)? {
+        LockFile::Absent => Ok(Lock {
+            version: LOCK_VERSION,
+            ..Lock::default()
+        }),
+        LockFile::Legacy { .. } => Err(CoreError::LegacyLock {
+            path: path.to_path_buf(),
+        }),
+        LockFile::Current(lock) => Ok(lock),
+    }
+}
+
+pub fn save(path: &Path, lock: &Lock) -> Result<()> {
+    refuse_foreign_paths(path, lock)?;
+    let mut text = serde_json::to_string_pretty(lock).map_err(|e| CoreError::JsonParse {
+        path: path.to_path_buf(),
+        message: e.to_string(),
+    })?;
+    text.push('\n');
+    atomic_write(path, &text)
+}

--- a/crates/core/src/lock/tests.rs
+++ b/crates/core/src/lock/tests.rs
@@ -1,4 +1,7 @@
+use std::path::Path;
+
 use super::*;
+use crate::error::CoreError;
 
 #[test]
 fn lock_round_trips_and_missing_file_is_empty() {
@@ -36,14 +39,12 @@ fn lock_round_trips_and_missing_file_is_empty() {
                         kind: ItemKind::Skill,
                         name: "dev".into(),
                         harness: HarnessId::Claude,
-                        scope: Scope::Global,
                     },
                 },
                 Reason::MemberOf {
                     bundle: BundleRef {
                         source: "kendex".into(),
                         name: "starter".into(),
-                        scope: Scope::Global,
                     },
                 },
             ]),
@@ -133,4 +134,122 @@ fn an_empty_lock_reads_as_current() {
     let path = tmp.path().join(".kendex-lock.json");
     std::fs::write(&path, r#"{"version":1,"entries":{}}"#).unwrap();
     assert!(matches!(load_file(&path).unwrap(), LockFile::Current(_)));
+}
+
+/// A record whose `emitted.paths` reach outside the project holding it, as
+/// written by hand under `key` — the shape a lock copied from another
+/// checkout has.
+fn recording(path: &Path, key: &str, emitted: &Path) {
+    std::fs::write(
+        path,
+        format!(
+            r#"{{"version":7,"entries":{{"{key}":{{"name":"gh","kind":"skill","harness":"claude","source":"kendex","sourceRepo":"vanillagreencom/kendex","method":"symlink","installedAt":"2026-01-01T00:00:00Z","sourceHash":"abc","enabled":true,"emitted":{{"kind":"skill","name":"gh","paths":["{}"]}}}}}}}}"#,
+            emitted.display()
+        ),
+    )
+    .unwrap();
+}
+
+/// A project lock may claim only what sits under its own root: the paths a
+/// refresh reads back are the ones it takes off disk, and past the root
+/// those belong to another project.
+#[test]
+fn a_project_lock_claiming_another_tree_is_refused() {
+    let tmp = tempfile::tempdir().unwrap();
+    let root = tmp.path().join("here");
+    std::fs::create_dir(&root).unwrap();
+    let path = root.join(LOCK_FILE);
+    let elsewhere = tmp.path().join("there/.agents/skills/gh");
+    recording(&path, "skill:gh:claude", &elsewhere);
+
+    let refused = load(&path).unwrap_err();
+    assert!(
+        matches!(
+            &refused,
+            CoreError::LockOutsideProject { key, recorded, .. }
+                if key == "skill:gh:claude" && recorded == &elsewhere
+        ),
+        "{refused:?}"
+    );
+
+    recording(&path, "skill:gh:claude", &root.join(".agents/skills/gh"));
+    assert_eq!(load(&path).unwrap().entries.len(), 1, "its own root loads");
+}
+
+/// The record is refused at the writing end too: what a project lock cannot
+/// hand out it cannot be made to hold.
+#[test]
+fn a_project_lock_is_never_written_claiming_another_tree() {
+    let tmp = tempfile::tempdir().unwrap();
+    let root = tmp.path().join("here");
+    std::fs::create_dir(&root).unwrap();
+    let path = root.join(LOCK_FILE);
+    let elsewhere = tmp.path().join("there/.agents/skills/gh");
+
+    let mut lock = Lock {
+        version: LOCK_VERSION,
+        ..Lock::default()
+    };
+    lock.entries.insert(
+        entry_key(ItemKind::Skill, "gh", HarnessId::Claude),
+        LockEntry {
+            registration: None,
+            left_pi_reserved_name: false,
+            name: "gh".into(),
+            kind: ItemKind::Skill,
+            harness: HarnessId::Claude,
+            source: "kendex".into(),
+            source_repo: "vanillagreencom/kendex".into(),
+            method: Method::Symlink,
+            installed_at: crate::clock::timestamp(),
+            source_hash: "abc".into(),
+            source_commit: None,
+            rendered_hash: None,
+            enabled: true,
+            upstream_skills: None,
+            emitted: Some(EmittedArtifact {
+                kind: ItemKind::Skill,
+                name: "gh".into(),
+                paths: vec![elsewhere.clone()],
+            }),
+            reasons: BTreeSet::from([Reason::Requested]),
+        },
+    );
+
+    assert!(matches!(
+        save(&path, &lock),
+        Err(CoreError::LockOutsideProject { .. })
+    ));
+    assert!(!path.exists(), "and nothing is left at the path");
+}
+
+/// A lock named relatively is the current directory's, and nothing absolute
+/// is under that. Read as the empty prefix `Path::parent` gives back, every
+/// path would pass.
+#[test]
+fn a_relatively_named_project_lock_still_has_a_boundary() {
+    let tmp = tempfile::tempdir().unwrap();
+    let path = tmp.path().join(LOCK_FILE);
+    let elsewhere = tmp.path().join("there/.agents/skills/gh");
+    recording(&path, "skill:gh:claude", &elsewhere);
+    let text = std::fs::read_to_string(&path).unwrap();
+
+    assert!(matches!(
+        parse_text(Path::new(LOCK_FILE), &text),
+        Err(CoreError::LockOutsideProject { .. })
+    ));
+}
+
+/// The global lock has no single root — each harness owns a directory of
+/// its own, and none of them is under the app directory the lock sits in.
+#[test]
+fn the_global_lock_records_paths_outside_its_own_directory() {
+    let tmp = tempfile::tempdir().unwrap();
+    let app = tmp.path().join("config/kendex");
+    std::fs::create_dir_all(&app).unwrap();
+    let path = app.join("lock.json");
+    // A harness directory, which is nowhere near the app's own.
+    let elsewhere = tmp.path().join("home/.claude/skills/gh");
+    recording(&path, "skill:gh:claude", &elsewhere);
+    assert_eq!(load(&path).unwrap().entries.len(), 1);
 }

--- a/crates/core/tests/bundles/main.rs
+++ b/crates/core/tests/bundles/main.rs
@@ -138,24 +138,22 @@ pub fn installed(f: &Fixture, kind: ItemKind, name: &str) -> bool {
     path.exists() || path.is_symlink()
 }
 
-pub fn member_of(source: &str, bundle: &str, scope: &Scope) -> Reason {
+pub fn member_of(source: &str, bundle: &str) -> Reason {
     Reason::MemberOf {
         bundle: BundleRef {
             source: source.to_owned(),
             name: bundle.to_owned(),
-            scope: scope.clone(),
         },
     }
 }
 
-pub fn required_by(source: &str, name: &str, scope: &Scope) -> Reason {
+pub fn required_by(source: &str, name: &str) -> Reason {
     Reason::RequiredBy {
         by: InstallRef {
             source: source.to_owned(),
             kind: ItemKind::Skill,
             name: name.to_owned(),
             harness: HarnessId::Claude,
-            scope: scope.clone(),
         },
     }
 }
@@ -178,19 +176,18 @@ fn a_bundle_installs_its_members_and_the_manifest_holds_only_the_bundle() {
     assert!(manifest.skills.is_empty() && manifest.agents.is_empty());
     assert_eq!(manifest.bundles["starter"].source, "cat");
 
-    let scope = f.scope.canonical();
     let lock = lock_of(&f);
     for key in ["skill:dev:claude", "agent:writer:claude"] {
         assert_eq!(
             lock.entries[key].reasons,
-            BTreeSet::from([member_of("cat", "starter", &scope)]),
+            BTreeSet::from([member_of("cat", "starter")]),
             "{key}"
         );
     }
     // What a member needs comes in behind it, as its own kind of edge.
     assert_eq!(
         lock.entries["skill:github:claude"].reasons,
-        BTreeSet::from([required_by("cat", "dev", &scope)])
+        BTreeSet::from([required_by("cat", "dev")])
     );
 }
 
@@ -246,13 +243,12 @@ fn a_multi_edge_member_behaves_through_every_removal_order() {
     let f = fixture(declarations);
     catalog_bundles(&f.source, STARTER_WITH_GITHUB);
     apply_now(&f);
-    let scope = f.scope.canonical();
     assert_eq!(
         lock_of(&f).entries["skill:github:claude"].reasons,
         BTreeSet::from([
             Reason::Requested,
-            member_of("cat", "starter", &scope),
-            required_by("cat", "dev", &scope),
+            member_of("cat", "starter"),
+            required_by("cat", "dev"),
         ])
     );
     remove(&f, "starter", false);

--- a/crates/core/tests/bundles/more.rs
+++ b/crates/core/tests/bundles/more.rs
@@ -123,11 +123,7 @@ fn a_plugin_registry_plugin_installs_as_a_bundle() {
         .expect("the plugin's skill installed");
     assert_eq!(
         entry.reasons,
-        std::collections::BTreeSet::from([super::member_of(
-            "market",
-            "data-science",
-            &f.scope.canonical()
-        )])
+        std::collections::BTreeSet::from([super::member_of("market", "data-science")])
     );
     assert!(
         lock.entries

--- a/crates/core/tests/dependencies/main.rs
+++ b/crates/core/tests/dependencies/main.rs
@@ -87,14 +87,13 @@ fn manifest_of(f: &Fixture) -> kendex_core::manifest::Manifest {
     }
 }
 
-fn required_by(source: &str, name: &str, scope: &Scope) -> Reason {
+fn required_by(source: &str, name: &str) -> Reason {
     Reason::RequiredBy {
         by: kendex_core::lock::InstallRef {
             source: source.to_owned(),
             kind: ItemKind::Skill,
             name: name.to_owned(),
             harness: HarnessId::Claude,
-            scope: scope.clone(),
         },
     }
 }
@@ -119,14 +118,13 @@ fn an_installation_records_every_reason_it_exists() {
     apply_now(&f);
 
     let lock = lock_of(&f);
-    let scope = f.scope.canonical();
     assert_eq!(
         lock.entries["skill:dev:claude"].reasons,
         BTreeSet::from([Reason::Requested])
     );
     assert_eq!(
         lock.entries["skill:github:claude"].reasons,
-        BTreeSet::from([Reason::Requested, required_by("cat", "dev", &scope)])
+        BTreeSet::from([Reason::Requested, required_by("cat", "dev")])
     );
 }
 
@@ -141,10 +139,9 @@ fn a_dependency_installs_without_being_declared() {
 
     assert!(installed(&f, "dev") && installed(&f, "github"));
     assert!(!manifest_of(&f).skills.contains_key("github"));
-    let scope = f.scope.canonical();
     assert_eq!(
         lock_of(&f).entries["skill:github:claude"].reasons,
-        BTreeSet::from([required_by("cat", "dev", &scope)])
+        BTreeSet::from([required_by("cat", "dev")])
     );
 }
 

--- a/crates/core/tests/install_seam/bundles.rs
+++ b/crates/core/tests/install_seam/bundles.rs
@@ -141,13 +141,11 @@ fn installing_the_whole_bundle_subsumes_equal_members_and_keeps_shaped_ones() {
     );
     assert!(manifest.bundles.contains_key("starter"));
 
-    let scope = f.scope.canonical();
     let lock = load_lock(&lock_path(&f.env, &f.scope)).unwrap();
     let member = Reason::MemberOf {
         bundle: BundleRef {
             source: "cat".to_owned(),
             name: "starter".to_owned(),
-            scope: scope.clone(),
         },
     };
     assert_eq!(

--- a/crates/core/tests/lock_from_another_project.rs
+++ b/crates/core/tests/lock_from_another_project.rs
@@ -1,0 +1,192 @@
+//! A lock that travelled with a copied checkout names the paths of the
+//! checkout it came from.
+//!
+//! Refresh reads `emitted.paths` as the positions this scope owns and takes
+//! back the ones it no longer renders. Pointed at another tree those are
+//! somebody else's files, and a project scope writes only inside its own
+//! root — so the record is refused, naming the path, and the other tree is
+//! not read as this one's to take.
+#![cfg(unix)]
+
+use std::collections::BTreeMap;
+use std::fs;
+use std::path::{Path, PathBuf};
+
+use kendex_core::engine::{PlanOptions, audit, plan_apply};
+use kendex_core::env::{Env, FakeOs};
+use kendex_core::error::CoreError;
+use kendex_core::model::Scope;
+
+/// One path as it sits on disk, in whatever detail tells two states apart:
+/// a file by its bytes, a link by its target, a directory by being one.
+#[derive(Debug, PartialEq, Eq)]
+enum Entry {
+    Dir,
+    /// Read as text: every file this fixture puts on disk is one, and a
+    /// failed comparison has to be readable.
+    File(String),
+    Link(PathBuf),
+}
+
+#[allow(clippy::unwrap_used)]
+fn put(path: &Path, text: &str) {
+    fs::create_dir_all(path.parent().unwrap()).unwrap();
+    fs::write(path, text).unwrap();
+}
+
+/// Every path under `root`, keyed by its place in the tree. Comparing two of
+/// these compares the file list and the contents at once, so a file gone, a
+/// file added and a byte changed all read as a difference.
+#[allow(clippy::unwrap_used)]
+fn snapshot(root: &Path) -> BTreeMap<PathBuf, Entry> {
+    let mut found = BTreeMap::new();
+    let mut queue = vec![root.to_path_buf()];
+    while let Some(dir) = queue.pop() {
+        for entry in fs::read_dir(&dir).unwrap() {
+            let path = entry.unwrap().path();
+            let key = path.strip_prefix(root).unwrap().to_path_buf();
+            let meta = fs::symlink_metadata(&path).unwrap();
+            if meta.file_type().is_symlink() {
+                found.insert(key, Entry::Link(fs::read_link(&path).unwrap()));
+            } else if meta.is_dir() {
+                found.insert(key, Entry::Dir);
+                queue.push(path);
+            } else {
+                let bytes = fs::read(&path).unwrap();
+                found.insert(
+                    key,
+                    Entry::File(String::from_utf8_lossy(&bytes).into_owned()),
+                );
+            }
+        }
+    }
+    found
+}
+
+#[allow(clippy::unwrap_used)]
+fn declare(root: &Path, catalog: &Path) {
+    put(
+        &root.join("kendex.toml"),
+        &format!(
+            "schema = 6\n\n[sources.cat]\npath = \"{}\"\n\n[install]\nharnesses = [\"claude\"]\nmethod = \"symlink\"\n\n[skills.ship]\nsource = \"cat\"\n",
+            catalog.display()
+        ),
+    );
+}
+
+fn project(root: &Path) -> Scope {
+    Scope::Project {
+        root: root.to_path_buf(),
+    }
+}
+
+/// What `kendex refresh` plans with: it sweeps what nothing accounts for.
+fn refresh() -> PlanOptions {
+    PlanOptions {
+        sweep_unneeded: true,
+        ..PlanOptions::default()
+    }
+}
+
+/// The must-fail control for the containment refusal. Without it the copied
+/// record is read as this project's own: every path it names is a position
+/// the new render does not produce, so refresh takes them to the trash —
+/// out of the other checkout.
+#[test]
+#[allow(clippy::unwrap_used)]
+fn a_lock_carried_from_another_checkout_is_refused_and_that_checkout_stands() {
+    let tmp = tempfile::tempdir().unwrap();
+    // Resolved: the engine resolves a scope root before writing any of the
+    // paths it records, and on macOS the temp directory is reached through
+    // `/var -> private/var`.
+    let home = tmp.path().canonicalize().unwrap();
+    let catalog = home.join("catalog");
+    put(
+        &catalog.join("skills/ship/SKILL.md"),
+        "---\nname: ship\ndescription: ship\n---\n\nShip the branch.\n",
+    );
+    let env = Env::fake(&home, FakeOs::Linux);
+
+    let installed = home.join("dev/app");
+    declare(&installed, &catalog);
+    let report = audit(&env, &project(&installed)).unwrap();
+    kendex_core::apply::execute(&env, &report.plan, None).unwrap();
+
+    // A second checkout of the same project, seeded with the first one's
+    // lock — which is how a linked worktree gets one.
+    let elsewhere = home.join("dev/worktree");
+    declare(&elsewhere, &catalog);
+    fs::copy(
+        installed.join(".kendex-lock.json"),
+        elsewhere.join(".kendex-lock.json"),
+    )
+    .unwrap();
+
+    let before = snapshot(&installed);
+    assert_eq!(
+        before.get(Path::new(".agents/skills/ship/SKILL.md")),
+        Some(&Entry::File(
+            fs::read_to_string(catalog.join("skills/ship/SKILL.md")).unwrap()
+        )),
+        "the install this refusal protects is on disk to begin with"
+    );
+    assert_eq!(
+        before.get(Path::new(".claude/skills/ship")),
+        Some(&Entry::Link(PathBuf::from("../../.agents/skills/ship"))),
+        "and so is the link the tool reads it through"
+    );
+
+    // The whole operation, the way refresh runs it: plan the scope, and
+    // carry out whatever it planned.
+    let refused = match plan_apply(&env, &project(&elsewhere), &refresh()) {
+        Ok(report) => {
+            kendex_core::apply::execute(&env, &report.plan, None).unwrap();
+            None
+        }
+        Err(error) => Some(error),
+    };
+
+    assert_eq!(
+        snapshot(&installed),
+        before,
+        "the checkout the lock came from is exactly as it was"
+    );
+    let refused = refused.expect("a record naming another project is refused");
+    assert!(
+        matches!(
+            &refused,
+            CoreError::LockOutsideProject { key, recorded, root, .. }
+                if key == "skill:ship:claude"
+                    && recorded == &installed.join(".agents/skills/ship")
+                    && root == &elsewhere
+        ),
+        "the refusal names the entry, the path it claims and the project that cannot hold it: {refused:?}"
+    );
+}
+
+/// The refusal is about reaching past the root, not about recording paths:
+/// a project whose lock names its own positions refreshes as it always did.
+#[test]
+#[allow(clippy::unwrap_used)]
+fn a_lock_naming_its_own_project_refreshes() {
+    let tmp = tempfile::tempdir().unwrap();
+    let home = tmp.path().canonicalize().unwrap();
+    let catalog = home.join("catalog");
+    put(
+        &catalog.join("skills/ship/SKILL.md"),
+        "---\nname: ship\ndescription: ship\n---\n\nShip the branch.\n",
+    );
+    let env = Env::fake(&home, FakeOs::Linux);
+
+    let root = home.join("dev/app");
+    declare(&root, &catalog);
+    let report = audit(&env, &project(&root)).unwrap();
+    kendex_core::apply::execute(&env, &report.plan, None).unwrap();
+
+    let again = plan_apply(&env, &project(&root), &refresh()).unwrap();
+    assert!(
+        again.plan.ops.is_empty(),
+        "an install that is where its record says settles: {:?}",
+        again.plan.ops
+    );
+}

--- a/crates/core/tests/lock_from_another_project.rs
+++ b/crates/core/tests/lock_from_another_project.rs
@@ -190,3 +190,90 @@ fn a_lock_naming_its_own_project_refreshes() {
         again.plan.ops
     );
 }
+
+/// The paths one entry claims, rewritten as they sit in the file.
+#[allow(clippy::unwrap_used)]
+fn claim(lock: &Path, key: &str, paths: &[PathBuf]) {
+    let mut record: serde_json::Value =
+        serde_json::from_str(&fs::read_to_string(lock).unwrap()).unwrap();
+    record["entries"][key]["emitted"]["paths"] = paths
+        .iter()
+        .map(|path| serde_json::Value::String(path.display().to_string()))
+        .collect();
+    fs::write(lock, serde_json::to_string_pretty(&record).unwrap()).unwrap();
+}
+
+/// The must-fail control for the escape a prefix comparison alone lets
+/// through: `<project>/../elsewhere` starts with `<project>` component for
+/// component, and every operation on it lands in `elsewhere`.
+#[test]
+#[allow(clippy::unwrap_used)]
+fn a_lock_walking_back_out_of_its_project_is_refused_and_the_tree_it_points_at_stands() {
+    let tmp = tempfile::tempdir().unwrap();
+    let home = tmp.path().canonicalize().unwrap();
+    let catalog = home.join("catalog");
+    put(
+        &catalog.join("skills/ship/SKILL.md"),
+        "---\nname: ship\ndescription: ship\n---\n\nShip the branch.\n",
+    );
+    let env = Env::fake(&home, FakeOs::Linux);
+
+    let installed = home.join("dev/app");
+    declare(&installed, &catalog);
+    let report = audit(&env, &project(&installed)).unwrap();
+    kendex_core::apply::execute(&env, &report.plan, None).unwrap();
+
+    // A project of its own, whose record claims the other one's positions
+    // by walking out of this one.
+    let elsewhere = home.join("dev/other");
+    declare(&elsewhere, &catalog);
+    let out = |rest: &str| elsewhere.join("..").join("app").join(rest);
+    fs::copy(
+        installed.join(".kendex-lock.json"),
+        elsewhere.join(".kendex-lock.json"),
+    )
+    .unwrap();
+    claim(
+        &elsewhere.join(".kendex-lock.json"),
+        "skill:ship:claude",
+        &[out(".agents/skills/ship"), out(".claude/skills/ship")],
+    );
+    assert!(
+        out(".agents/skills/ship").starts_with(&elsewhere),
+        "the escape is one a prefix comparison reads as inside"
+    );
+
+    let before = snapshot(&installed);
+    assert_eq!(
+        before.get(Path::new(".agents/skills/ship/SKILL.md")),
+        Some(&Entry::File(
+            fs::read_to_string(catalog.join("skills/ship/SKILL.md")).unwrap()
+        )),
+        "the install this refusal protects is on disk to begin with"
+    );
+
+    let refused = match plan_apply(&env, &project(&elsewhere), &refresh()) {
+        Ok(report) => {
+            kendex_core::apply::execute(&env, &report.plan, None).unwrap();
+            None
+        }
+        Err(error) => Some(error),
+    };
+
+    assert_eq!(
+        snapshot(&installed),
+        before,
+        "the tree the record walked out to is exactly as it was"
+    );
+    let refused = refused.expect("a record walking out of its project is refused");
+    assert!(
+        matches!(
+            &refused,
+            CoreError::LockOutsideProject { key, recorded, root, .. }
+                if key == "skill:ship:claude"
+                    && recorded == &out(".agents/skills/ship")
+                    && root == &elsewhere
+        ),
+        "the refusal names the entry, the path it claims and the project that cannot hold it: {refused:?}"
+    );
+}

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -117,8 +117,8 @@ lives in one capability table read by core and UI.
    tool reading it. A link at anything else stays a conflict.
    Ownership is what kendex wrote, read from the positions lock entries
    wrote (recorded for skills and codex commands, derived elsewhere) —
-   never from the lock key alone, and never from an entry merely being on
-   the books. A link the user put at a shared config file or a manifest
+   never from the lock key alone, from an entry merely on the books, or
+   from a project record naming a position outside its own root. A link the user put at a shared config file or a manifest
    (dotfiles) is not foreign: the edit goes through it, link kept, and the
    precondition binds to the bytes reachable there; whether a link may sit
    at a position is decided at plan time, never by the write.

--- a/tools/size-ratchet-baseline.tsv
+++ b/tools/size-ratchet-baseline.tsv
@@ -4,7 +4,7 @@ crates/core/src/engine/detach.rs	547
 crates/core/src/engine/pi_hooks_move/migrated.rs	540
 crates/core/src/engine/pi_hooks_move/mod.rs	503
 crates/core/src/engine/pi_hooks_move/preflight.rs	765
-crates/core/src/error.rs	448
+crates/core/src/error.rs	458
 crates/core/src/remote/store.rs	405
 crates/core/src/settings_file.rs	408
 docs/ARCHITECTURE.md	801


### PR DESCRIPTION
A project scope installs only inside its own root, so an `emitted.paths` entry reaching past that root is not a record this project ever wrote. A lock copied along with a checkout is exactly such a record — and refresh reads those paths as the positions this scope owns, then takes back the ones it no longer renders. The files it removes are in another repository.

This is reproduced, not inferred. A refresh run from a worktree deleted four tracked paths from the shared checkout: `.agents/skills/app-deploy/SKILL.md`, `.agents/skills/kendex-issues/SKILL.md` and their two `.claude/skills` symlinks. Only `source: in-place`, `method: symlink` items reach it; catalog-sourced items were spared by hitting a `Conflict:` refusal first, which is what made the incident look narrower than it was.

## Scale

In one worktree before the fix: 80 emitted paths outside the worktree across 60 lock entries — 20 skills fanned across three harness namespaces — all naming the shared checkout. The two that were deleted were not special; they were the two that got past the earlier refusal.

## The fix

Refusal on containment, at the read and the write of a lock (`crates/core/src/lock/file.rs`), not at each consumer. Every reader — `engine/owned.rs`, `engine/stale.rs`, `repo_effects::recorded_roots`, the app, the CLI — reaches a lock through `load`/`load_file`, so one judge covers all of them and a new consumer cannot bypass it. `save` refuses the same record, so no such path is written or removed at either end. The refusal names the entry, the path and the project that cannot hold it.

Scope-relative storage was the other candidate and was rejected: the global lock has no single root, so the stored shape would be mixed; and an old absolute path joined onto a root still yields the absolute path, so it would need this same containment check to be safe anyway.

## The issue's open question, settled

`reasons[].by.scope.root` does **not** resolve into a write target. It was written in `engine/deps.rs` and `engine/bundles.rs` with the plan's own scope — always the scope holding the lock — and its only reader was `set_change.rs::why_wanted`, comparing it against the current scope to decide whether to append " in `<scope>`" to a preview string, a comparison production could never make differ. No removal, sweep or write ever read it. `reasons[].by.scope` and `reasons[].bundle.scope` are therefore removed rather than corrected: there is no non-absolute spelling of a project scope, and the field carried no information.

## Existing locks

`emitted.paths` keep their shape. A lock whose paths sit inside its own project root loads and refreshes exactly as before — that is every lock a project wrote for itself. One whose paths point outside is refused and the operation writes nothing, so a stale absolute path never becomes a removal target. Locks seeded into a linked worktree from another checkout are the refused case, by design.

`LOCK_VERSION` 6 → 7 for the dropped reason scope: reading a v6 lock ignores the extra field and the next write drops it, and an older build reading a v7 lock reports that it was written by a newer kendex rather than failing on a missing key.

## Control

`crates/core/tests/lock_from_another_project.rs` installs a skill into one project, seeds a second with the first's lock (how a linked worktree acquires one), runs the whole refresh against the second, and compares the first project's file list and contents against a snapshot taken before. Without the fix it is red, and the plan carries the incident verbatim — `Trash { path: ".../.agents/skills/ship" }` plus the `.claude/skills` symlink. `a_lock_naming_its_own_project_refreshes` is the control that keeps the refusal from being satisfied by refusing everything.

Four unit controls in `lock/tests.rs`, each proven red by mutating the guard it covers: the read refusal, the write refusal, the empty-prefix case a relatively named lock would otherwise pass on, and the global lock's exemption.

## Note for review

`lock.rs` goes 464 → 291 by splitting reading and writing into `lock/file.rs`, the seam `manifest/mod.rs` + `manifest/file.rs` already uses. `error.rs` takes `RATCHET_RAISE` 448 → 458 for one more variant — one enum, no seam to split at. `docs/ARCHITECTURE.md` invariant 6 is reworded in place to name the boundary; 801 lines before and after.

`sourceRepo` naming this repo is expected and is unchanged.

Closes KEN-761
