### PR TITLE
fix(KEN-474): a write lands where its directories point, or is refused

### DIFF
--- a/changelog.d/fixed/KEN-474.md
+++ b/changelog.d/fixed/KEN-474.md
@@ -1,3 +1,3 @@
 - A project's plan names where each write lands, following a symlinked
-  harness directory to the folder it points at. A write that would land
-  outside the project is refused, naming that place.
+  harness directory to the folder it points at. A write that then moves, or
+  lands outside the project, is refused and says where.

--- a/changelog.d/fixed/KEN-474.md
+++ b/changelog.d/fixed/KEN-474.md
@@ -1,3 +1,3 @@
-- The plan kendex shows names each item and where its write lands, following
-  a symlinked harness directory to the folder it points at. A write that then
-  moves, or leaves the project, is refused.
+- The plan names each item and where its write lands, following a symlinked
+  harness directory. A write that leaves the project is refused, and a
+  rollback reaches through the link.

--- a/changelog.d/fixed/KEN-474.md
+++ b/changelog.d/fixed/KEN-474.md
@@ -1,3 +1,3 @@
-- A plan names where each write lands, following a symlinked harness
-  directory to the folder it points at. A write that then moves, or lands
-  outside the project it belongs to, is refused by name.
+- The plan kendex shows names where each write lands, following a symlinked
+  harness directory to the folder it points at. A write that then moves, or
+  lands outside the project, is refused by name.

--- a/changelog.d/fixed/KEN-474.md
+++ b/changelog.d/fixed/KEN-474.md
@@ -1,3 +1,3 @@
-- A project's plan names where each write lands, following a symlinked
-  harness directory to the folder it points at. A write that then moves, or
-  lands outside the project, is refused and says where.
+- A plan names where each write lands, following a symlinked harness
+  directory to the folder it points at. A write that then moves, or lands
+  outside the project it belongs to, is refused by name.

--- a/changelog.d/fixed/KEN-474.md
+++ b/changelog.d/fixed/KEN-474.md
@@ -1,0 +1,3 @@
+- A project's plan names where each write lands, following a symlinked
+  harness directory to the folder it points at. A write that would land
+  outside the project is refused, naming that place.

--- a/changelog.d/fixed/KEN-474.md
+++ b/changelog.d/fixed/KEN-474.md
@@ -1,3 +1,3 @@
-- The plan kendex shows names where each write lands, following a symlinked
-  harness directory to the folder it points at. A write that then moves, or
-  lands outside the project, is refused by name.
+- The plan kendex shows names each item and where its write lands, following
+  a symlinked harness directory to the folder it points at. A write that then
+  moves, or leaves the project, is refused.

--- a/changelog.d/fixed/KEN-474.md
+++ b/changelog.d/fixed/KEN-474.md
@@ -1,3 +1,3 @@
 - The plan names each item and where its write lands, following a symlinked
-  harness directory. A write that leaves the project is refused, and a
-  rollback reaches through the link.
+  harness directory. A write leaving the project is refused, and a
+  rollback puts bytes back only in the file they came from.

--- a/crates/app/src/audit.rs
+++ b/crates/app/src/audit.rs
@@ -117,12 +117,7 @@ pub fn view(env: &Env, scope: &Scope) -> AuditView {
         scope: scope.clone(),
         exits: engine::exits::for_rows(env, scope, &report.drift),
         drift: report.drift,
-        plan: report
-            .plan
-            .ops
-            .iter()
-            .map(|op| op.description.clone())
-            .collect(),
+        plan: report.plan.ops.iter().map(apply::PlannedOp::line).collect(),
         notes: report.notes,
         warnings: report.warnings,
         safety,

--- a/crates/app/src/editor/save.rs
+++ b/crates/app/src/editor/save.rs
@@ -210,17 +210,22 @@ fn write_customize(
         // Leading the plan: every later op was planned against the manifest
         // this write makes durable, and the base still holds — the file is
         // the one the copy on screen was read from.
-        report.plan.ops.insert(
-            0,
-            PlannedOp {
-                description: "Save kendex.toml".into(),
-                op: Op::WriteManifest {
-                    pre: Pre::from(&claimed),
-                    path: path.clone(),
-                    manifest: Box::new(manifest),
+        report
+            .plan
+            .insert(
+                0,
+                PlannedOp {
+                    description: "Save kendex.toml".into(),
+                    op: Op::WriteManifest {
+                        pre: Pre::from(&claimed),
+                        path: path.clone(),
+                        manifest: Box::new(manifest),
+                    },
                 },
-            },
-        );
+            )
+            .map_err(|error| WriteRefused::Failed {
+                message: error.to_string(),
+            })?;
     }
     // The bound preconditions refuse a file that moved between the checks
     // above and the write itself, and that refusal is the same answer the

--- a/crates/app/src/editor/save/tests.rs
+++ b/crates/app/src/editor/save/tests.rs
@@ -61,7 +61,7 @@ fn a_writer_landing_after_the_editor_read_is_refused_mid_apply() {
             .plan
             .ops
             .iter()
-            .any(|op| op.description.contains("Upgrade")),
+            .any(|op| op.line().contains("Upgrade")),
         "the schema upgrade is the plan's manifest write: {:?}",
         report.plan.ops
     );

--- a/crates/cli/src/commands/adopt.rs
+++ b/crates/cli/src/commands/adopt.rs
@@ -39,7 +39,7 @@ pub fn run(
 
     let move_plan = adopt::adopt(env, &scope, kind, &name, &harnesses)?;
     for op in &move_plan.ops {
-        say(&format!("  - {}", shown(&op.description)));
+        say(&format!("  - {}", shown(&op.line())));
     }
     kendex_core::apply::execute(env, &move_plan, None)?;
 

--- a/crates/cli/src/commands/drift_hook.rs
+++ b/crates/cli/src/commands/drift_hook.rs
@@ -28,7 +28,7 @@ pub fn install(env: &Env, scope: &Scope, yes: bool) -> CliResult {
     } else {
         say(&format!("{}: declaring the drift hook", scope_label(scope)));
         for op in &plan.ops {
-            say(&format!("  - {}", shown(&op.description)));
+            say(&format!("  - {}", shown(&op.line())));
         }
         let report = kendex_core::engine::EngineReport {
             repo_effects: Vec::new(),
@@ -50,7 +50,7 @@ pub fn install(env: &Env, scope: &Scope, yes: bool) -> CliResult {
         kendex_core::engine::plan_apply(env, scope, &kendex_core::engine::PlanOptions::default())?;
     if !report.plan.is_empty() {
         for op in &report.plan.ops {
-            say(&format!("  - {}", shown(&op.description)));
+            say(&format!("  - {}", shown(&op.line())));
         }
         print_safety(&report);
         confirm_and_execute(env, &report, yes)?;

--- a/crates/cli/src/commands/engine_common.rs
+++ b/crates/cli/src/commands/engine_common.rs
@@ -62,7 +62,7 @@ pub fn print_report(env: &Env, report: &EngineReport) -> Vec<super::offers::Bloc
     // asked to approve a count was never shown what it covers.
     say(&format!("plan: {} change{}", ops, plural(ops)));
     for op in &report.plan.ops {
-        say(&format!("  - {}", shown(&op.description)));
+        say(&format!("  - {}", shown(&op.line())));
     }
     blocked
 }

--- a/crates/cli/src/commands/fork_cmd.rs
+++ b/crates/cli/src/commands/fork_cmd.rs
@@ -44,7 +44,7 @@ pub fn run(env: &Env, args: ForkArgs) -> CliResult {
         None => kendex_core::engine::fork::fork(env, &scope, kind, &args.name, harness)?,
     };
     for op in &plan.ops {
-        say(&format!("  - {}", shown(&op.description)));
+        say(&format!("  - {}", shown(&op.line())));
     }
     kendex_core::apply::execute(env, &plan, None)?;
 

--- a/crates/cli/src/commands/remove.rs
+++ b/crates/cli/src/commands/remove.rs
@@ -74,7 +74,7 @@ pub fn run(env: &Env, names: Vec<String>, filter: ScopeFilter, mode: Removal) ->
         // list of writes under the word "removed" says the wrong thing.
         say("changes:");
         for op in &report.plan.ops {
-            say(&format!("  - {}", shown(&op.description)));
+            say(&format!("  - {}", shown(&op.line())));
         }
         if matches!(mode, Removal::KeepDeclaration) {
             say(&format!(

--- a/crates/core/src/apply/journal.rs
+++ b/crates/core/src/apply/journal.rs
@@ -18,6 +18,21 @@ pub struct Journal {
 #[derive(Debug, Serialize, Deserialize)]
 pub struct Entry {
     pub path: PathBuf,
+    /// Where `path` reached when this pre-image was taken.
+    ///
+    /// A restore puts bytes back where they came from, and where they came
+    /// from is not a spelling: a directory on the way to them can be
+    /// somebody's link, and can become one afterwards. The journal's paths
+    /// are its caller's own and need not be landings — under a temp root
+    /// reached through a link none of them is — so the place is written
+    /// down rather than inferred from how the path reads.
+    ///
+    /// `None` is a journal from a build that did not write it down. It
+    /// parses so that the restore can refuse it by name; nothing here
+    /// supplies a landing for it, because supplying one would be guessing
+    /// where somebody's bytes came from.
+    #[serde(default)]
+    pub landed: Option<PathBuf>,
     pub state: PreState,
 }
 
@@ -82,6 +97,7 @@ pub fn write(dir: &Path, paths: &[PathBuf]) -> Result<()> {
             PreState::Absent
         };
         entries.push(Entry {
+            landed: Some(super::landing::landing(path)),
             path: path.clone(),
             state,
         });
@@ -198,9 +214,11 @@ fn rollback_where(dir: &Path, restore: impl Fn(&Path) -> bool) -> Result<()> {
     };
     let journal: Journal = match serde_json::from_str(&text) {
         Ok(journal) => journal,
-        // A torn meta can only mean the crash hit before the durable meta
-        // write completed — and mutations only start after it completes, so
-        // the world is untouched and the journal is safe to discard.
+        // A meta that will not parse is a torn one. It is written whole
+        // and durably before any mutation starts, so a partial one proves
+        // the world untouched and the journal safe to discard. A journal
+        // that parses but cannot be acted on is a different thing, whose
+        // mutations did start: that one is refused below, never cleared.
         Err(_) => return clear(dir),
     };
     let store = dir.join("store");
@@ -208,13 +226,20 @@ fn rollback_where(dir: &Path, restore: impl Fn(&Path) -> bool) -> Result<()> {
         if !restore(&entry.path) {
             continue;
         }
-        // A pre-image goes back where it was taken from. The journal holds
-        // the landing an apply recorded, so a path that no longer lands on
-        // itself is reached through a directory somebody has changed since,
-        // and restoring there would put these bytes somewhere they never
-        // came from. Refused, leaving the journal pending for inspection,
-        // the way a restore set that will not parse is.
-        super::landing::unmoved(&entry.path)?;
+        // A pre-image goes back where it came from, and the journal says
+        // where that was. A path reaching somewhere else now is reached
+        // through a directory somebody has changed since, and restoring
+        // there would put these bytes where they never came from. So is a
+        // journal that never wrote the place down: the apply it belongs to
+        // did mutate, and nothing here can say whether these bytes still
+        // have a way back. Both refuse, leaving the journal pending for
+        // inspection, the way a restore set that will not parse does.
+        let Some(landed) = &entry.landed else {
+            return Err(CoreError::UnrecordedLanding {
+                path: entry.path.clone(),
+            });
+        };
+        super::landing::still_reaches(landed, &entry.path)?;
         remove_any(&entry.path)?;
         match &entry.state {
             PreState::Absent => {}

--- a/crates/core/src/apply/journal.rs
+++ b/crates/core/src/apply/journal.rs
@@ -208,6 +208,13 @@ fn rollback_where(dir: &Path, restore: impl Fn(&Path) -> bool) -> Result<()> {
         if !restore(&entry.path) {
             continue;
         }
+        // A pre-image goes back where it was taken from. The journal holds
+        // the landing an apply recorded, so a path that no longer lands on
+        // itself is reached through a directory somebody has changed since,
+        // and restoring there would put these bytes somewhere they never
+        // came from. Refused, leaving the journal pending for inspection,
+        // the way a restore set that will not parse is.
+        super::landing::unmoved(&entry.path)?;
         remove_any(&entry.path)?;
         match &entry.state {
             PreState::Absent => {}

--- a/crates/core/src/apply/journal.rs
+++ b/crates/core/src/apply/journal.rs
@@ -49,6 +49,19 @@ pub enum PreState {
     Symlink {
         target: PathBuf,
         store: Option<String>,
+        /// The file those bytes were copied from: this link followed the
+        /// whole way, leaf included.
+        ///
+        /// Not the entry's own landing, which stops at the leaf because
+        /// the write path has its own answers for a link sitting at a
+        /// position. These bytes came from the far end of it, and
+        /// redirecting a directory on the way to that end leaves the same
+        /// link reaching a different file — one the pre-image would then
+        /// be written into. `None` where nothing was copied, and where a
+        /// journal was written before the far end was recorded, which the
+        /// restore refuses rather than guesses at.
+        #[serde(default)]
+        reached: Option<PathBuf>,
     },
     /// Tree copied under `store/<index>/` in the journal dir.
     Dir {
@@ -74,12 +87,17 @@ pub fn write(dir: &Path, paths: &[PathBuf]) -> Result<()> {
             let slot_name = index.to_string();
             let slot = store.join(&slot_name);
             let resolved_file = path.exists() && path.is_file();
+            let mut reached = None;
             if resolved_file {
                 copy_file_durable(path, &slot)?;
+                // Read after the copy, so what is recorded is the file the
+                // bytes in the slot actually came from.
+                reached = Some(path.canonicalize().map_err(|e| CoreError::io(path, e))?);
             }
             PreState::Symlink {
                 target: fs::read_link(path).map_err(|e| CoreError::io(path, e))?,
                 store: resolved_file.then_some(slot_name),
+                reached,
             }
         } else if path.is_dir() {
             let slot = store.join(index.to_string());
@@ -252,14 +270,33 @@ fn rollback_where(dir: &Path, restore: impl Fn(&Path) -> bool) -> Result<()> {
             PreState::Symlink {
                 target,
                 store: slot,
+                reached,
             } => {
                 if let Some(parent) = entry.path.parent() {
                     fs::create_dir_all(parent).map_err(|e| CoreError::io(parent, e))?;
                 }
                 make_symlink(target, &entry.path)?;
                 // A write may have gone through the link: restore the
-                // linked-to file's bytes too.
+                // linked-to file's bytes too, and only into the file they
+                // came from. The link is back where it was, so the far end
+                // is knowable again — and it is a different question from
+                // the entry's own landing, which stops at this link.
                 if let Some(slot) = slot {
+                    let Some(reached) = reached else {
+                        return Err(CoreError::UnrecordedLanding {
+                            path: entry.path.clone(),
+                        });
+                    };
+                    let now = entry
+                        .path
+                        .canonicalize()
+                        .map_err(|e| CoreError::io(&entry.path, e))?;
+                    if now != *reached {
+                        return Err(CoreError::TargetMoved {
+                            path: entry.path.clone(),
+                            now,
+                        });
+                    }
                     copy_file_durable(&store.join(slot), &entry.path)?;
                 }
             }

--- a/crates/core/src/apply/landing.rs
+++ b/crates/core/src/apply/landing.rs
@@ -35,25 +35,42 @@
 use std::path::{Component, Path, PathBuf};
 
 use crate::error::{CoreError, Result};
-use crate::model::Scope;
 
 use super::{Op, PlannedOp};
 
-/// Land every write target this plan carries, refusing one that lands
-/// outside the scope. The paths are rewritten, so what the plan shows and
-/// what apply writes is the one place the bytes reach.
-pub(super) fn land(scope: &Scope, ops: &mut [PlannedOp]) -> Result<()> {
-    // Landing and judging are two things, and only one of them is a
-    // project's. Every target lands, whatever scope it belongs to: what
-    // the plan shows and what apply writes has to be the place the bytes
-    // reach, and everything downstream is held to that landing. What the
-    // global scope has no answer for is the judgement — nothing encloses
-    // it, so its targets have no root to leave, and somebody keeping
-    // `~/.claude` in a dotfiles repo is describing their layout.
-    let root = match scope.canonical() {
-        Scope::Project { root } => Some(root),
-        Scope::Global => None,
-    };
+/// What a target that reads as outside the root is taken to be.
+#[derive(Clone, Copy)]
+enum Outside {
+    /// Its builder's business. A plan arrives whole from something that
+    /// knows why a target of its own sits outside the scope: an adoption
+    /// captures the folder a link of the person's own points at, and that
+    /// boundary is adoption's to draw.
+    Theirs,
+    /// Refused. An op joining a plan already made carries no such account,
+    /// and what joins one is this scope's own record.
+    Refused,
+}
+
+/// Land every write target this plan carries, refusing one that reads as
+/// inside the root and lands outside it. The paths are rewritten, so what
+/// the plan shows and what apply writes is the one place the bytes reach.
+///
+/// `root` is the canonical scope root, fixed by the caller and never read
+/// again here. `None` is the global scope, which nothing encloses: its
+/// targets still land — everything downstream is held to a landing — but
+/// they have no root to leave, and somebody keeping `~/.claude` in a
+/// dotfiles repo is describing their layout.
+pub(super) fn land(root: Option<&Path>, ops: &mut [PlannedOp]) -> Result<()> {
+    land_with(root, Outside::Theirs, ops)
+}
+
+/// The same for an op joining a plan already made, which must land inside
+/// the root that plan fixed.
+pub(super) fn land_inside(root: Option<&Path>, ops: &mut [PlannedOp]) -> Result<()> {
+    land_with(root, Outside::Refused, ops)
+}
+
+fn land_with(root: Option<&Path>, outside: Outside, ops: &mut [PlannedOp]) -> Result<()> {
     for planned in ops {
         // Read before the landing moves the link, because a link's text
         // is spelled from the parent it was to sit in.
@@ -64,10 +81,10 @@ pub(super) fn land(scope: &Scope, ops: &mut [PlannedOp]) -> Result<()> {
             _ => None,
         };
         for path in planned.op.touched_mut() {
-            *path = landed_within(root.as_deref(), path)?;
+            *path = landed_within(root, outside, path)?;
         }
         if let Some((was, Some(destination))) = intended {
-            respell(root.as_deref(), &was, &destination, &mut planned.op);
+            respell(root, &was, &destination, &mut planned.op);
         }
     }
     Ok(())
@@ -112,23 +129,23 @@ pub(super) fn op_unmoved(op: &Op) -> Result<()> {
 
 /// Where `path` lands, provided a target inside `root` stays inside it.
 ///
-/// Landing is unconditional; only the judgement needs a root, and two
-/// paths are landed without one. A global target has no scope to leave.
-/// So does a path that was never under the project root, which is
-/// somewhere its own caller had to decide about: an adoption captures the
-/// folder a link of the person's own points at, and the boundary for that
-/// is adoption's. Landing both anyway is what lets [`unmoved`] hold them
-/// to the same promise as the rest.
+/// Landing is unconditional; only the judgement needs a root. A global
+/// target has none, and a path that reads as outside a project root may
+/// have none either — see [`Outside`]. Landing them anyway is what lets
+/// [`unmoved`] hold them to the same promise as the rest.
 ///
 /// A `..` still standing in the landing is one no existing directory
 /// resolved away, so where it reaches is not known and containment cannot
 /// be established: refused rather than normalized, since nothing kendex
 /// derives from a scope root carries one.
-fn landed_within(root: Option<&Path>, path: &Path) -> Result<PathBuf> {
+fn landed_within(root: Option<&Path>, outside: Outside, path: &Path) -> Result<PathBuf> {
     let landed = landing(path);
-    let Some(root) = root.filter(|root| path.starts_with(root)) else {
+    let Some(root) = root else {
         return Ok(landed);
     };
+    if !path.starts_with(root) && matches!(outside, Outside::Theirs) {
+        return Ok(landed);
+    }
     if !landed.starts_with(root) || landed.components().any(|part| part == Component::ParentDir) {
         return Err(CoreError::ScopeEscape {
             path: path.to_path_buf(),
@@ -181,7 +198,7 @@ mod tests {
         let target = root.join("absent/../../elsewhere/x");
         assert!(target.starts_with(&root), "it reads as inside the root");
         assert!(matches!(
-            landed_within(Some(&root), &target),
+            landed_within(Some(&root), Outside::Theirs, &target),
             Err(CoreError::ScopeEscape { .. })
         ));
     }

--- a/crates/core/src/apply/landing.rs
+++ b/crates/core/src/apply/landing.rs
@@ -104,22 +104,33 @@ fn respell(root: Option<&Path>, was: &Path, destination: &Path, op: &mut Op) {
     *target = crate::fs::spelling(root, destination, link);
 }
 
-/// Whether this path is still the place the plan landed it on.
+/// Whether this path still reaches the place a record says it reached.
 ///
-/// A landed path's directories are all real, so landing it again returns
-/// it unchanged. Anything else means a directory on the way to it has
-/// become a link since, and the write would reach a place the plan never
-/// named. The window between this answer and the syscall after it is
-/// KEN-813.
-pub(super) fn unmoved(path: &Path) -> Result<()> {
+/// The comparison is against the record, never against a property of the
+/// spelling: whether a path is its own landing says something about how
+/// it was written down, not about whether it has moved. A caller's own
+/// path need not be a landing, and under a temp root reached through a
+/// link — every one on macOS, where `/var` fronts `/private/var` — none
+/// of them is.
+///
+/// The window between this answer and the syscall after it is KEN-813.
+pub(super) fn still_reaches(recorded: &Path, path: &Path) -> Result<()> {
     let now = landing(path);
-    if now != path {
+    if now != recorded {
         return Err(CoreError::TargetMoved {
             path: path.to_path_buf(),
             now,
         });
     }
     Ok(())
+}
+
+/// The same for a path whose record is itself: a plan's targets, which
+/// [`land`] fixed at their landings. A landed path's directories are all
+/// real, so landing it again returns it unchanged, and anything else
+/// means one of them has become a link since.
+pub(super) fn unmoved(path: &Path) -> Result<()> {
+    still_reaches(path, path)
 }
 
 /// [`unmoved`] for every path one op mutates.
@@ -156,14 +167,14 @@ fn landed_within(root: Option<&Path>, outside: Outside, path: &Path) -> Result<P
     Ok(landed)
 }
 
-/// Where a target lands once the directories on the way to it are
+/// Where a path reaches once the directories on the way to it are
 /// followed.
 ///
 /// The target's own name is left as it was. Whether that position is
 /// itself a link is a separate question with answers of its own — a
 /// foreign link is a conflict, a shared tree's link is one kendex wrote —
 /// and resolving it here would take those answers away.
-fn landing(path: &Path) -> PathBuf {
+pub(super) fn landing(path: &Path) -> PathBuf {
     match (path.parent(), path.file_name()) {
         (Some(parent), Some(name)) => resolved_dir(parent).join(name),
         _ => path.to_path_buf(),

--- a/crates/core/src/apply/landing.rs
+++ b/crates/core/src/apply/landing.rs
@@ -43,11 +43,16 @@ use super::{Op, PlannedOp};
 /// outside the scope. The paths are rewritten, so what the plan shows and
 /// what apply writes is the one place the bytes reach.
 pub(super) fn land(scope: &Scope, ops: &mut [PlannedOp]) -> Result<()> {
-    let Scope::Project { root } = scope.canonical() else {
-        // Nothing encloses the global scope: its roots are the machine's
-        // own harness directories, which a person is free to keep
-        // wherever they keep their dotfiles.
-        return Ok(());
+    // Landing and judging are two things, and only one of them is a
+    // project's. Every target lands, whatever scope it belongs to: what
+    // the plan shows and what apply writes has to be the place the bytes
+    // reach, and everything downstream is held to that landing. What the
+    // global scope has no answer for is the judgement — nothing encloses
+    // it, so its targets have no root to leave, and somebody keeping
+    // `~/.claude` in a dotfiles repo is describing their layout.
+    let root = match scope.canonical() {
+        Scope::Project { root } => Some(root),
+        Scope::Global => None,
     };
     for planned in ops {
         // Read before the landing moves the link, because a link's text
@@ -59,10 +64,10 @@ pub(super) fn land(scope: &Scope, ops: &mut [PlannedOp]) -> Result<()> {
             _ => None,
         };
         for path in planned.op.touched_mut() {
-            *path = landed_within(&root, path)?;
+            *path = landed_within(root.as_deref(), path)?;
         }
         if let Some((was, Some(destination))) = intended {
-            respell(&root, &was, &destination, &mut planned.op);
+            respell(root.as_deref(), &was, &destination, &mut planned.op);
         }
     }
     Ok(())
@@ -72,14 +77,14 @@ pub(super) fn land(scope: &Scope, ops: &mut [PlannedOp]) -> Result<()> {
 /// its text steps out of the parent it was written for. Respelled from
 /// the parent it landed in, by the same rule that spelled it, so it
 /// reaches the destination it was made to reach.
-fn respell(root: &Path, was: &Path, destination: &Path, op: &mut Op) {
+fn respell(root: Option<&Path>, was: &Path, destination: &Path, op: &mut Op) {
     let Op::Symlink { link, target, .. } = op else {
         return;
     };
     if was.parent() == link.parent() {
         return;
     }
-    *target = crate::fs::spelling(Some(root), destination, link);
+    *target = crate::fs::spelling(root, destination, link);
 }
 
 /// Whether this path is still the place the plan landed it on.
@@ -87,7 +92,8 @@ fn respell(root: &Path, was: &Path, destination: &Path, op: &mut Op) {
 /// A landed path's directories are all real, so landing it again returns
 /// it unchanged. Anything else means a directory on the way to it has
 /// become a link since, and the write would reach a place the plan never
-/// named.
+/// named. The window between this answer and the syscall after it is
+/// KEN-813.
 pub(super) fn unmoved(path: &Path) -> Result<()> {
     let now = landing(path);
     if now != path {
@@ -106,22 +112,23 @@ pub(super) fn op_unmoved(op: &Op) -> Result<()> {
 
 /// Where `path` lands, provided a target inside `root` stays inside it.
 ///
-/// A path that was never under the root is landed but not judged. This
-/// rule is about a target that reads as in-scope and is not. A path that
-/// says outside is somewhere its own caller had to decide about: an
-/// adoption captures the folder a link of the person's own points at, and
-/// the boundary for that is adoption's. Landing it anyway is what lets
-/// [`unmoved`] hold it to the same promise as the rest.
+/// Landing is unconditional; only the judgement needs a root, and two
+/// paths are landed without one. A global target has no scope to leave.
+/// So does a path that was never under the project root, which is
+/// somewhere its own caller had to decide about: an adoption captures the
+/// folder a link of the person's own points at, and the boundary for that
+/// is adoption's. Landing both anyway is what lets [`unmoved`] hold them
+/// to the same promise as the rest.
 ///
 /// A `..` still standing in the landing is one no existing directory
 /// resolved away, so where it reaches is not known and containment cannot
 /// be established: refused rather than normalized, since nothing kendex
 /// derives from a scope root carries one.
-fn landed_within(root: &Path, path: &Path) -> Result<PathBuf> {
+fn landed_within(root: Option<&Path>, path: &Path) -> Result<PathBuf> {
     let landed = landing(path);
-    if !path.starts_with(root) {
+    let Some(root) = root.filter(|root| path.starts_with(root)) else {
         return Ok(landed);
-    }
+    };
     if !landed.starts_with(root) || landed.components().any(|part| part == Component::ParentDir) {
         return Err(CoreError::ScopeEscape {
             path: path.to_path_buf(),
@@ -174,7 +181,7 @@ mod tests {
         let target = root.join("absent/../../elsewhere/x");
         assert!(target.starts_with(&root), "it reads as inside the root");
         assert!(matches!(
-            landed_within(&root, &target),
+            landed_within(Some(&root), &target),
             Err(CoreError::ScopeEscape { .. })
         ));
     }

--- a/crates/core/src/apply/landing.rs
+++ b/crates/core/src/apply/landing.rs
@@ -1,0 +1,131 @@
+//! Where a plan's write targets land, and the scope they may not leave.
+//!
+//! A derived target is a name joined onto a scope root, and the
+//! directories in between are somebody else's to arrange: point
+//! `.claude/hooks` at another folder and every write through it lands
+//! there. So a plan that speaks the joined spelling describes writes that
+//! happen somewhere else — and a containment check on that spelling passes
+//! for a target that is not inside the scope at all.
+//!
+//! Both answers come from landing the target once: follow the directories
+//! on the way to it, then judge the place it reaches.
+
+use std::path::{Component, Path, PathBuf};
+
+use crate::error::{CoreError, Result};
+use crate::model::Scope;
+
+use super::PlannedOp;
+
+/// Land every write target this plan carries, refusing one that lands
+/// outside the scope. The paths are rewritten, so what the plan shows,
+/// records and writes is the one place the bytes reach.
+pub(super) fn land(scope: &Scope, ops: &mut [PlannedOp]) -> Result<()> {
+    let Scope::Project { root } = scope.canonical() else {
+        // Nothing encloses the global scope: its roots are the machine's
+        // own harness directories, which a person is free to keep
+        // wherever they keep their dotfiles.
+        return Ok(());
+    };
+    for planned in ops {
+        for path in planned.op.touched_mut() {
+            *path = landed_within(&root, path)?;
+        }
+    }
+    Ok(())
+}
+
+/// The same judgement over a plan already built, taking nothing back.
+///
+/// This is the one every apply passes through, whoever built the plan and
+/// whatever was appended to it afterwards, so a write site that never
+/// landed its own targets still cannot reach out of the scope. It is also
+/// the second look: a directory swapped for a link after the plan was
+/// shown moves the target, and the write must not follow it.
+pub(super) fn check(scope: &Scope, ops: &[PlannedOp]) -> Result<()> {
+    let Scope::Project { root } = scope.canonical() else {
+        return Ok(());
+    };
+    for planned in ops {
+        for path in planned.op.touched() {
+            landed_within(&root, &path)?;
+        }
+    }
+    Ok(())
+}
+
+/// Where `path` lands, provided a target inside `root` stays inside it.
+///
+/// A path that was never under the root is left alone. This rule is about
+/// a target that reads as in-scope and is not — the spelling says inside
+/// while the write lands elsewhere. A path that says outside is somewhere
+/// its own caller had to decide about: an adoption captures the folder a
+/// link of the person's own points at, and the boundary for that is
+/// adoption's.
+///
+/// A `..` still standing in the landing is one no existing directory
+/// resolved away, so where it reaches is not known and containment cannot
+/// be established: refused rather than normalized, since nothing kendex
+/// derives from a scope root carries one.
+fn landed_within(root: &Path, path: &Path) -> Result<PathBuf> {
+    if !path.starts_with(root) {
+        return Ok(path.to_path_buf());
+    }
+    let landed = landing(path);
+    if !landed.starts_with(root) || landed.components().any(|part| part == Component::ParentDir) {
+        return Err(CoreError::ScopeEscape {
+            path: path.to_path_buf(),
+            landed,
+            root: root.to_path_buf(),
+        });
+    }
+    Ok(landed)
+}
+
+/// Where a target lands once the directories on the way to it are
+/// followed.
+///
+/// The target's own name is left as it was. Whether that position is
+/// itself a link is a separate question with answers of its own — a
+/// foreign link is a conflict, a shared tree's link is one kendex wrote —
+/// and resolving it here would take those answers away.
+fn landing(path: &Path) -> PathBuf {
+    match (path.parent(), path.file_name()) {
+        (Some(parent), Some(name)) => resolved_dir(parent).join(name),
+        _ => path.to_path_buf(),
+    }
+}
+
+/// The longest existing prefix of `dir` followed, with the rest joined
+/// back on. A target's directories need not exist yet, and the ones that
+/// do are the only ones that can point anywhere.
+fn resolved_dir(dir: &Path) -> PathBuf {
+    if let Ok(resolved) = dir.canonicalize() {
+        return resolved;
+    }
+    match (dir.parent(), dir.file_name()) {
+        (Some(parent), Some(name)) => resolved_dir(parent).join(name),
+        _ => dir.to_path_buf(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// A `..` under a directory that does not exist is resolved by
+    /// nothing, so the landing still holds it. Read lexically it is inside
+    /// the root; followed it is not, and the refusal is what says so.
+    #[test]
+    #[allow(clippy::unwrap_used)]
+    fn a_landing_that_still_walks_back_is_refused() {
+        let tmp = tempfile::tempdir().unwrap();
+        let root = tmp.path().canonicalize().unwrap();
+        let target = root.join("absent/../../elsewhere/x");
+        assert!(target.starts_with(&root), "it reads as inside the root");
+        assert!(matches!(
+            landed_within(&root, &target),
+            Err(CoreError::ScopeEscape { .. })
+        ));
+    }
+}

--- a/crates/core/src/apply/landing.rs
+++ b/crates/core/src/apply/landing.rs
@@ -1,25 +1,47 @@
-//! Where a plan's write targets land, and the scope they may not leave.
+//! Where a plan's write targets land, the scope they may not leave, and
+//! the promise a landing is afterwards.
 //!
 //! A derived target is a name joined onto a scope root, and the
 //! directories in between are somebody else's to arrange: point
 //! `.claude/hooks` at another folder and every write through it lands
 //! there. So a plan that speaks the joined spelling describes writes that
-//! happen somewhere else — and a containment check on that spelling passes
+//! happen somewhere else, and a containment check on that spelling passes
 //! for a target that is not inside the scope at all.
 //!
-//! Both answers come from landing the target once: follow the directories
-//! on the way to it, then judge the place it reaches.
+//! [`land`] settles both at plan time. Every target becomes the place it
+//! reaches, and one that reaches out of the scope is refused by that
+//! place's name. What that buys afterwards is an identity: a landed path
+//! is one whose every directory is already real, so it lands on itself.
+//! [`unmoved`] asks exactly that, of one path, immediately before it is
+//! used.
+//!
+//! Asking it beats asking the containment question again, and the
+//! difference is not a detail:
+//!
+//! - Containment needs a root, and a root re-read from disk is a root
+//!   somebody can move. Rename the project directory and leave a link in
+//!   its place and the re-derived root is the link's target, against which
+//!   every planned path reads as deliberately outside the scope.
+//! - Containment stays true when an ancestor is swapped for a link to
+//!   another place in the same project. The write then lands somewhere the
+//!   plan never showed anybody, and no containment test can see it.
+//! - A landing is per path and per moment, so it holds for an op appended
+//!   after the plan was shown, and for the op after the one that just
+//!   created a link.
+//!
+//! The landing is what the person was shown, so the landing is what the
+//! write is held to. Nothing here re-derives the root; the plan fixed it.
 
 use std::path::{Component, Path, PathBuf};
 
 use crate::error::{CoreError, Result};
 use crate::model::Scope;
 
-use super::PlannedOp;
+use super::{Op, PlannedOp};
 
 /// Land every write target this plan carries, refusing one that lands
-/// outside the scope. The paths are rewritten, so what the plan shows,
-/// records and writes is the one place the bytes reach.
+/// outside the scope. The paths are rewritten, so what the plan shows and
+/// what apply writes is the one place the bytes reach.
 pub(super) fn land(scope: &Scope, ops: &mut [PlannedOp]) -> Result<()> {
     let Scope::Project { root } = scope.canonical() else {
         // Nothing encloses the global scope: its roots are the machine's
@@ -28,50 +50,78 @@ pub(super) fn land(scope: &Scope, ops: &mut [PlannedOp]) -> Result<()> {
         return Ok(());
     };
     for planned in ops {
+        // Read before the landing moves the link, because a link's text
+        // is spelled from the parent it was to sit in.
+        let intended = match &planned.op {
+            Op::Symlink { link, target, .. } => {
+                Some((link.clone(), crate::fs::resolved(link, target)))
+            }
+            _ => None,
+        };
         for path in planned.op.touched_mut() {
             *path = landed_within(&root, path)?;
+        }
+        if let Some((was, Some(destination))) = intended {
+            respell(&root, &was, &destination, &mut planned.op);
         }
     }
     Ok(())
 }
 
-/// The same judgement over a plan already built, taking nothing back.
-///
-/// This is the one every apply passes through, whoever built the plan and
-/// whatever was appended to it afterwards, so a write site that never
-/// landed its own targets still cannot reach out of the scope. It is also
-/// the second look: a directory swapped for a link after the plan was
-/// shown moves the target, and the write must not follow it.
-pub(super) fn check(scope: &Scope, ops: &[PlannedOp]) -> Result<()> {
-    let Scope::Project { root } = scope.canonical() else {
-        return Ok(());
+/// A link the landing moved says something else from where it now sits:
+/// its text steps out of the parent it was written for. Respelled from
+/// the parent it landed in, by the same rule that spelled it, so it
+/// reaches the destination it was made to reach.
+fn respell(root: &Path, was: &Path, destination: &Path, op: &mut Op) {
+    let Op::Symlink { link, target, .. } = op else {
+        return;
     };
-    for planned in ops {
-        for path in planned.op.touched() {
-            landed_within(&root, &path)?;
-        }
+    if was.parent() == link.parent() {
+        return;
+    }
+    *target = crate::fs::spelling(Some(root), destination, link);
+}
+
+/// Whether this path is still the place the plan landed it on.
+///
+/// A landed path's directories are all real, so landing it again returns
+/// it unchanged. Anything else means a directory on the way to it has
+/// become a link since, and the write would reach a place the plan never
+/// named.
+pub(super) fn unmoved(path: &Path) -> Result<()> {
+    let now = landing(path);
+    if now != path {
+        return Err(CoreError::TargetMoved {
+            path: path.to_path_buf(),
+            now,
+        });
     }
     Ok(())
+}
+
+/// [`unmoved`] for every path one op mutates.
+pub(super) fn op_unmoved(op: &Op) -> Result<()> {
+    op.touched().iter().try_for_each(|path| unmoved(path))
 }
 
 /// Where `path` lands, provided a target inside `root` stays inside it.
 ///
-/// A path that was never under the root is left alone. This rule is about
-/// a target that reads as in-scope and is not — the spelling says inside
-/// while the write lands elsewhere. A path that says outside is somewhere
-/// its own caller had to decide about: an adoption captures the folder a
-/// link of the person's own points at, and the boundary for that is
-/// adoption's.
+/// A path that was never under the root is landed but not judged. This
+/// rule is about a target that reads as in-scope and is not. A path that
+/// says outside is somewhere its own caller had to decide about: an
+/// adoption captures the folder a link of the person's own points at, and
+/// the boundary for that is adoption's. Landing it anyway is what lets
+/// [`unmoved`] hold it to the same promise as the rest.
 ///
 /// A `..` still standing in the landing is one no existing directory
 /// resolved away, so where it reaches is not known and containment cannot
 /// be established: refused rather than normalized, since nothing kendex
 /// derives from a scope root carries one.
 fn landed_within(root: &Path, path: &Path) -> Result<PathBuf> {
-    if !path.starts_with(root) {
-        return Ok(path.to_path_buf());
-    }
     let landed = landing(path);
+    if !path.starts_with(root) {
+        return Ok(landed);
+    }
     if !landed.starts_with(root) || landed.components().any(|part| part == Component::ParentDir) {
         return Err(CoreError::ScopeEscape {
             path: path.to_path_buf(),

--- a/crates/core/src/apply/mod.rs
+++ b/crates/core/src/apply/mod.rs
@@ -15,7 +15,7 @@ mod transaction;
 
 pub use common::{common_key, execute_common, recover_common_journals};
 pub use op::{Op, Pre, read_git_config};
-pub use plan::{Plan, PlannedOp};
+pub use plan::{Description, Plan, PlannedOp};
 use transaction::run_journaled;
 
 /// Filesystem-safe key naming a scope's journal dir and lock file. Keys off

--- a/crates/core/src/apply/mod.rs
+++ b/crates/core/src/apply/mod.rs
@@ -96,9 +96,6 @@ pub struct ApplyOutcome {
 pub fn execute(env: &Env, plan: &Plan, fail_after: Option<usize>) -> Result<ApplyOutcome> {
     let _guard = lock_scope(env, &plan.scope)?;
     let recovered_first = recover(env, &plan.scope)?;
-    // Under the lock and after recovery, because both can move what the
-    // directories on the way to a target point at.
-    landing::check(&plan.scope, &plan.ops)?;
     let applied = run_journaled(env, &plan.ops, &scope_key(&plan.scope), fail_after)?;
     // The scope just changed; a drift snapshot describing the old state
     // would send the next session chasing drift that no longer exists.

--- a/crates/core/src/apply/mod.rs
+++ b/crates/core/src/apply/mod.rs
@@ -6,13 +6,16 @@ use crate::model::Scope;
 
 mod common;
 pub mod journal;
+mod landing;
 mod op;
 mod plain;
+mod plan;
 mod pre;
 mod transaction;
 
 pub use common::{common_key, execute_common, recover_common_journals};
-pub use op::{Op, Plan, PlannedOp, Pre, read_git_config};
+pub use op::{Op, Pre, read_git_config};
+pub use plan::{Plan, PlannedOp};
 use transaction::run_journaled;
 
 /// Filesystem-safe key naming a scope's journal dir and lock file. Keys off
@@ -93,6 +96,9 @@ pub struct ApplyOutcome {
 pub fn execute(env: &Env, plan: &Plan, fail_after: Option<usize>) -> Result<ApplyOutcome> {
     let _guard = lock_scope(env, &plan.scope)?;
     let recovered_first = recover(env, &plan.scope)?;
+    // Under the lock and after recovery, because both can move what the
+    // directories on the way to a target point at.
+    landing::check(&plan.scope, &plan.ops)?;
     let applied = run_journaled(env, &plan.ops, &scope_key(&plan.scope), fail_after)?;
     // The scope just changed; a drift snapshot describing the old state
     // would send the next session chasing drift that no longer exists.

--- a/crates/core/src/apply/op.rs
+++ b/crates/core/src/apply/op.rs
@@ -6,7 +6,6 @@ use crate::env::Env;
 use crate::error::{CoreError, Result};
 use crate::lock::Lock;
 use crate::manifest::Manifest;
-use crate::model::Scope;
 
 #[derive(Debug, Clone, PartialEq)]
 pub enum Op {
@@ -111,6 +110,25 @@ impl Op {
             Op::WriteManifest { path, .. } => vec![path.clone()],
             Op::WriteExecutable { path, .. } => vec![path.clone()],
             Op::GitConfigSwap { file, .. } => vec![file.clone()],
+        }
+    }
+
+    /// The same paths, borrowed so they can be replaced by where they
+    /// land ([`super::landing`]). Exhaustive like [`Op::touched`], so an
+    /// op added to this enum can no more skip the landing than the
+    /// journal.
+    pub(super) fn touched_mut(&mut self) -> Vec<&mut PathBuf> {
+        match self {
+            Op::WriteFile { path, .. } => vec![path],
+            Op::WriteTree { root, .. } => vec![root],
+            Op::Symlink { link, .. } => vec![link],
+            Op::Rename { from, to, .. } => vec![from, to],
+            Op::Trash { path, .. } => vec![path],
+            Op::EditFile { path, .. } => vec![path],
+            Op::WriteLock { path, .. } => vec![path],
+            Op::WriteManifest { path, .. } => vec![path],
+            Op::WriteExecutable { path, .. } => vec![path],
+            Op::GitConfigSwap { file, .. } => vec![file],
         }
     }
 
@@ -371,22 +389,4 @@ fn unique_in(dir: &Path, base: &str) -> PathBuf {
         counter += 1;
     }
     candidate
-}
-
-#[derive(Debug, Clone, PartialEq)]
-pub struct PlannedOp {
-    pub description: String,
-    pub op: Op,
-}
-
-#[derive(Debug, Clone, PartialEq)]
-pub struct Plan {
-    pub scope: Scope,
-    pub ops: Vec<PlannedOp>,
-}
-
-impl Plan {
-    pub fn is_empty(&self) -> bool {
-        self.ops.is_empty()
-    }
 }

--- a/crates/core/src/apply/plan.rs
+++ b/crates/core/src/apply/plan.rs
@@ -8,33 +8,73 @@ use crate::model::Scope;
 
 use super::{Op, landing};
 
+/// What one op does, said for a preview.
+///
+/// A description that names the position its op acts on is kept as the two
+/// halves that position sits between, never as a sentence with the
+/// position written into it. [`PlannedOp::line`] takes the position from
+/// the op, which is the landed one, so a preview and the write it
+/// describes can only ever name one place.
+///
+/// Two halves rather than a marker inside the sentence: a marker is text,
+/// and text a search looks for is text some name is allowed to be. A skill
+/// called `{}` is a legal name ([`crate::names::segment_problem`]), and
+/// the sentence that carries it must survive being drawn.
+#[derive(Debug, Clone, PartialEq)]
+pub struct Description {
+    opening: String,
+    /// What follows the position. `None` where this description names no
+    /// position at all, which is most of them.
+    closing: Option<String>,
+}
+
+impl Description {
+    /// A description naming the position its op acts on, between these two
+    /// halves. Either may be empty; neither holds the position.
+    pub fn around(opening: impl Into<String>, closing: impl Into<String>) -> Description {
+        Description {
+            opening: opening.into(),
+            closing: Some(closing.into()),
+        }
+    }
+}
+
+impl From<String> for Description {
+    fn from(said: String) -> Description {
+        Description {
+            opening: said,
+            closing: None,
+        }
+    }
+}
+
+impl From<&str> for Description {
+    fn from(said: &str) -> Description {
+        said.to_owned().into()
+    }
+}
+
 #[derive(Debug, Clone, PartialEq)]
 pub struct PlannedOp {
-    /// What this op does, said for a preview.
-    ///
-    /// A description that names a position writes `{}` where the position
-    /// goes and never the position itself; [`PlannedOp::line`] fills it in
-    /// from the op. Written in, it would say where the plan first joined
-    /// the path rather than where the bytes go, and the two are not the
-    /// same once the landing has followed a directory somebody pointed
-    /// elsewhere.
-    pub description: String,
+    pub description: Description,
     pub op: Op,
 }
 
 impl PlannedOp {
     /// The line a preview draws for this op, with the position it acts on
-    /// filled in. That position comes from the op, which is the landed
-    /// one, so a confirmation and the write it asks about can only ever
-    /// name one place.
+    /// filled in.
     pub fn line(&self) -> String {
-        let Some(path) = self.op.touched().into_iter().next() else {
-            // Every op names at least one path. Without one there is no
-            // position to fill in and the prose stands as written.
-            return self.description.clone();
+        let Description { opening, closing } = &self.description;
+        let Some(closing) = closing else {
+            return opening.clone();
         };
-        let shown = crate::names::shown(&path.display().to_string());
-        self.description.replacen("{}", &shown, 1)
+        let Some(at) = self.op.touched().into_iter().next() else {
+            // Every op names at least one path. Without one there is no
+            // position to draw and the halves close over nothing.
+            return format!("{opening}{closing}");
+        };
+        let at = crate::names::shown(&at.display().to_string());
+        format!("{opening}{at}{closing}")
     }
 }
 

--- a/crates/core/src/apply/plan.rs
+++ b/crates/core/src/apply/plan.rs
@@ -1,5 +1,7 @@
-//! The plan an apply runs: the ops in order, and the scope they belong
-//! to.
+//! The plan an apply runs: the ops in order, the scope they belong to,
+//! and the line a preview draws for each.
+
+use std::path::PathBuf;
 
 use crate::error::Result;
 use crate::model::Scope;
@@ -8,13 +10,47 @@ use super::{Op, landing};
 
 #[derive(Debug, Clone, PartialEq)]
 pub struct PlannedOp {
+    /// What this op does, said for a preview.
+    ///
+    /// A description that names a position writes `{}` where the position
+    /// goes and never the position itself; [`PlannedOp::line`] fills it in
+    /// from the op. Written in, it would say where the plan first joined
+    /// the path rather than where the bytes go, and the two are not the
+    /// same once the landing has followed a directory somebody pointed
+    /// elsewhere.
     pub description: String,
     pub op: Op,
+}
+
+impl PlannedOp {
+    /// The line a preview draws for this op, with the position it acts on
+    /// filled in. That position comes from the op, which is the landed
+    /// one, so a confirmation and the write it asks about can only ever
+    /// name one place.
+    pub fn line(&self) -> String {
+        let Some(path) = self.op.touched().into_iter().next() else {
+            // Every op names at least one path. Without one there is no
+            // position to fill in and the prose stands as written.
+            return self.description.clone();
+        };
+        let shown = crate::names::shown(&path.display().to_string());
+        self.description.replacen("{}", &shown, 1)
+    }
 }
 
 #[derive(Debug, Clone, PartialEq)]
 pub struct Plan {
     pub scope: Scope,
+    /// The canonical scope root this plan's targets were landed against,
+    /// read once when the plan was made. `None` at global scope, which
+    /// nothing encloses.
+    ///
+    /// Kept rather than derived again, because deriving it again is
+    /// reading it after somebody could have moved it: a project directory
+    /// renamed with a link left in its place answers `canonicalize` with
+    /// the link's target, and an op landed against that would be landed
+    /// against wherever the link went.
+    root: Option<PathBuf>,
     pub ops: Vec<PlannedOp>,
 }
 
@@ -25,8 +61,28 @@ impl Plan {
     /// makes its plan here, so a preview names the position the bytes
     /// reach rather than the spelling the derivation joined.
     pub fn landed(scope: Scope, mut ops: Vec<PlannedOp>) -> Result<Plan> {
-        landing::land(&scope, &mut ops)?;
-        Ok(Plan { scope, ops })
+        let root = match scope.canonical() {
+            Scope::Project { root } => Some(root),
+            Scope::Global => None,
+        };
+        landing::land(root.as_deref(), &mut ops)?;
+        Ok(Plan { scope, root, ops })
+    }
+
+    /// Take on one more op at `index`, landed against the root this plan
+    /// fixed.
+    ///
+    /// The way to add to a plan: an op appended straight to `ops` carries
+    /// whatever path its caller derived, and a caller deriving one now is
+    /// deriving it from a scope it reads now. Held to this plan's root
+    /// instead, and to it strictly — a target outside it is refused,
+    /// where one arriving with the plan itself would not be.
+    pub fn insert(&mut self, index: usize, planned: PlannedOp) -> Result<()> {
+        let mut joining = [planned];
+        landing::land_inside(self.root.as_deref(), &mut joining)?;
+        let [planned] = joining;
+        self.ops.insert(index, planned);
+        Ok(())
     }
 
     pub fn is_empty(&self) -> bool {

--- a/crates/core/src/apply/plan.rs
+++ b/crates/core/src/apply/plan.rs
@@ -1,0 +1,35 @@
+//! The plan an apply runs: the ops in order, and the scope they belong
+//! to.
+
+use crate::error::Result;
+use crate::model::Scope;
+
+use super::{Op, landing};
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct PlannedOp {
+    pub description: String,
+    pub op: Op,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct Plan {
+    pub scope: Scope,
+    pub ops: Vec<PlannedOp>,
+}
+
+impl Plan {
+    /// A plan whose write targets are the places they land: the
+    /// directories between the scope root and each target followed, and a
+    /// target landing outside the scope refused by name. Every builder
+    /// makes its plan here, so a preview names the position the bytes
+    /// reach rather than the spelling the derivation joined.
+    pub fn landed(scope: Scope, mut ops: Vec<PlannedOp>) -> Result<Plan> {
+        landing::land(&scope, &mut ops)?;
+        Ok(Plan { scope, ops })
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.ops.is_empty()
+    }
+}

--- a/crates/core/src/apply/tests.rs
+++ b/crates/core/src/apply/tests.rs
@@ -10,7 +10,7 @@ fn write_plan(scope: Scope, path: PathBuf, content: &str, pre: Pre) -> Plan {
     plan(
         scope,
         vec![PlannedOp {
-            description: format!("write {}", path.display()),
+            description: format!("write {}", path.display()).into(),
             op: Op::WriteFile {
                 path,
                 bytes: content.as_bytes().to_vec(),

--- a/crates/core/src/apply/tests.rs
+++ b/crates/core/src/apply/tests.rs
@@ -7,9 +7,9 @@ fn env_in(dir: &Path) -> Env {
 }
 
 fn write_plan(scope: Scope, path: PathBuf, content: &str, pre: Pre) -> Plan {
-    Plan {
+    plan(
         scope,
-        ops: vec![PlannedOp {
+        vec![PlannedOp {
             description: format!("write {}", path.display()),
             op: Op::WriteFile {
                 path,
@@ -17,7 +17,14 @@ fn write_plan(scope: Scope, path: PathBuf, content: &str, pre: Pre) -> Plan {
                 pre,
             },
         }],
-    }
+    )
+}
+
+/// Through the constructor the product builds every plan with: it is what
+/// fixes each path at the place it lands, which the transaction then holds
+/// it to.
+fn plan(scope: Scope, ops: Vec<PlannedOp>) -> Plan {
+    Plan::landed(scope, ops).expect("a plan whose targets stay in their scope")
 }
 
 #[test]
@@ -28,9 +35,9 @@ fn fault_at_every_boundary_leaves_disk_untouched() {
     fs::create_dir_all(target.parent().unwrap()).unwrap();
     fs::write(&target, "before").unwrap();
 
-    let plan = Plan {
-        scope: Scope::Global,
-        ops: vec![
+    let plan = plan(
+        Scope::Global,
+        vec![
             PlannedOp {
                 description: "first".into(),
                 op: Op::WriteFile {
@@ -48,7 +55,7 @@ fn fault_at_every_boundary_leaves_disk_untouched() {
                 },
             },
         ],
-    };
+    );
 
     for boundary in 0..=1 {
         let error = execute(&env, &plan, Some(boundary)).unwrap_err();
@@ -152,9 +159,9 @@ fn trash_receives_removals() {
     fs::create_dir_all(&victim).unwrap();
     fs::write(victim.join("SKILL.md"), "content").unwrap();
 
-    let plan = Plan {
-        scope: Scope::Global,
-        ops: vec![PlannedOp {
+    let plan = plan(
+        Scope::Global,
+        vec![PlannedOp {
             description: "remove skill".into(),
             op: Op::Trash {
                 absent_is_done: true,
@@ -162,7 +169,7 @@ fn trash_receives_removals() {
                 pre: Pre::Any,
             },
         }],
-    };
+    );
     execute(&env, &plan, None).unwrap();
     assert!(!victim.exists());
     let trashed: Vec<_> = fs::read_dir(env.trash_dir()).unwrap().flatten().collect();
@@ -183,9 +190,9 @@ fn a_copy_already_gone_does_not_take_the_removal_with_it() {
     fs::create_dir_all(present.parent().unwrap()).unwrap();
     fs::write(&present, "content").unwrap();
 
-    let plan = Plan {
-        scope: Scope::Global,
-        ops: vec![
+    let plan = plan(
+        Scope::Global,
+        vec![
             PlannedOp {
                 description: "remove the copy that is gone".into(),
                 op: Op::Trash {
@@ -205,7 +212,7 @@ fn a_copy_already_gone_does_not_take_the_removal_with_it() {
                 },
             },
         ],
-    };
+    );
 
     assert_eq!(execute(&env, &plan, None).unwrap().applied, 2);
     assert!(!present.exists());
@@ -224,9 +231,9 @@ fn a_link_whose_target_is_gone_still_goes_to_the_trash() {
     fs::create_dir_all(link.parent().unwrap()).unwrap();
     std::os::unix::fs::symlink(&gone, &link).unwrap();
 
-    let plan = Plan {
-        scope: Scope::Global,
-        ops: vec![PlannedOp {
+    let plan = plan(
+        Scope::Global,
+        vec![PlannedOp {
             description: "remove the link".into(),
             op: Op::Trash {
                 absent_is_done: true,
@@ -236,7 +243,7 @@ fn a_link_whose_target_is_gone_still_goes_to_the_trash() {
                 },
             },
         }],
-    };
+    );
 
     execute(&env, &plan, None).unwrap();
     assert!(!link.is_symlink());
@@ -270,9 +277,9 @@ fn a_link_crosses_a_filesystem_boundary_into_the_trash() {
     let gone = elsewhere.path().join("shared/decider");
     std::os::unix::fs::symlink(&gone, &link).unwrap();
 
-    let plan = Plan {
-        scope: Scope::Global,
-        ops: vec![PlannedOp {
+    let plan = plan(
+        Scope::Global,
+        vec![PlannedOp {
             description: "remove the link".into(),
             op: Op::Trash {
                 absent_is_done: true,
@@ -282,7 +289,7 @@ fn a_link_crosses_a_filesystem_boundary_into_the_trash() {
                 },
             },
         }],
-    };
+    );
 
     execute(&env, &plan, None).unwrap();
     assert!(!link.is_symlink());
@@ -312,9 +319,9 @@ fn a_copy_that_cannot_be_read_stops_the_removal() {
         return;
     }
 
-    let plan = Plan {
-        scope: Scope::Global,
-        ops: vec![PlannedOp {
+    let plan = plan(
+        Scope::Global,
+        vec![PlannedOp {
             description: "remove the copy nothing can read".into(),
             op: Op::Trash {
                 absent_is_done: true,
@@ -322,7 +329,7 @@ fn a_copy_that_cannot_be_read_stops_the_removal() {
                 pre: Pre::Any,
             },
         }],
-    };
+    );
 
     // Unlocked before anything can panic: a sealed directory outlives the
     // TempDir that cannot remove it.
@@ -341,9 +348,9 @@ fn a_copy_that_changed_still_stops_the_removal() {
     let edited = tmp.path().join("edited.md");
     fs::write(&edited, "not what the plan read").unwrap();
 
-    let plan = Plan {
-        scope: Scope::Global,
-        ops: vec![PlannedOp {
+    let plan = plan(
+        Scope::Global,
+        vec![PlannedOp {
             description: "remove the edited copy".into(),
             op: Op::Trash {
                 absent_is_done: true,
@@ -353,7 +360,7 @@ fn a_copy_that_changed_still_stops_the_removal() {
                 },
             },
         }],
-    };
+    );
 
     let error = execute(&env, &plan, None).unwrap_err();
     assert!(matches!(error, CoreError::RolledBack { .. }));

--- a/crates/core/src/apply/transaction.rs
+++ b/crates/core/src/apply/transaction.rs
@@ -5,7 +5,7 @@
 
 use std::path::PathBuf;
 
-use super::{PlannedOp, journal};
+use super::{PlannedOp, journal, landing};
 use crate::env::Env;
 use crate::error::{CoreError, Result};
 
@@ -26,6 +26,10 @@ pub(super) fn run_journaled(
     }
     let journal_dir = journal::journal_dir_for(&env.journal_dir(), key);
     let mut touched: Vec<PathBuf> = ops.iter().flat_map(|p| p.op.touched()).collect();
+    // Before the pre-images, so a path already moved never has somebody
+    // else's bytes copied into this journal on its behalf. It settles
+    // nothing for the ops themselves: each is asked again in the loop.
+    touched.iter().try_for_each(|path| landing::unmoved(path))?;
     touched.extend(created_dir_roots(&touched));
     journal::write(&journal_dir, &touched)?;
 
@@ -40,7 +44,11 @@ pub(super) fn run_journaled(
                 cause: Box::new(error),
             });
         }
-        if let Err(error) = planned.op.run(env) {
+        // Asked here rather than once before the loop: an op ahead of
+        // this one can create the link this one's path would then be
+        // reached through, and a check that ran before either of them saw
+        // a parent that did not exist yet.
+        if let Err(error) = landing::op_unmoved(&planned.op).and_then(|()| planned.op.run(env)) {
             journal::rollback_mutated(&journal_dir, &mutated_before_failure(ops, index, &error))?;
             return Err(CoreError::RolledBack {
                 reason: format!("'{}' failed: {error}", planned.description),
@@ -63,7 +71,12 @@ pub(super) fn run_journaled(
 /// paths are restored too.
 fn mutated_before_failure(ops: &[PlannedOp], index: usize, error: &CoreError) -> Vec<PathBuf> {
     let ran = match error {
-        CoreError::PlanStale { .. } | CoreError::Injected => &ops[..index],
+        // A target that moved is refused before the op is handed the
+        // path, so op `index` mutated nothing, the same as a stale
+        // precondition.
+        CoreError::PlanStale { .. } | CoreError::TargetMoved { .. } | CoreError::Injected => {
+            &ops[..index]
+        }
         _ => &ops[..=index],
     };
     ran.iter().flat_map(|p| p.op.touched()).collect()

--- a/crates/core/src/apply/transaction.rs
+++ b/crates/core/src/apply/transaction.rs
@@ -40,7 +40,7 @@ pub(super) fn run_journaled(
             let error = CoreError::Injected;
             journal::rollback_mutated(&journal_dir, &mutated_before_failure(ops, index, &error))?;
             return Err(CoreError::RolledBack {
-                reason: format!("injected fault before '{}'", planned.description),
+                reason: format!("injected fault before '{}'", planned.line()),
                 cause: Box::new(error),
             });
         }
@@ -51,7 +51,7 @@ pub(super) fn run_journaled(
         if let Err(error) = landing::op_unmoved(&planned.op).and_then(|()| planned.op.run(env)) {
             journal::rollback_mutated(&journal_dir, &mutated_before_failure(ops, index, &error))?;
             return Err(CoreError::RolledBack {
-                reason: format!("'{}' failed: {error}", planned.description),
+                reason: format!("'{}' failed: {error}", planned.line()),
                 cause: Box::new(error),
             });
         }

--- a/crates/core/src/drift/hook.rs
+++ b/crates/core/src/drift/hook.rs
@@ -159,5 +159,5 @@ pub fn install_plan(env: &Env, scope: &Scope) -> Result<Plan> {
         });
     }
 
-    Ok(Plan { scope, ops })
+    Plan::landed(scope, ops)
 }

--- a/crates/core/src/engine/adopt.rs
+++ b/crates/core/src/engine/adopt.rs
@@ -118,10 +118,7 @@ pub fn adopt(
             manifest: Box::new(manifest),
         },
     });
-    Ok(Plan {
-        scope: scope.clone(),
-        ops,
-    })
+    Plan::landed(scope.clone(), ops)
 }
 
 /// Everything the move itself takes: the broken links cleared, and then

--- a/crates/core/src/engine/adopt.rs
+++ b/crates/core/src/engine/adopt.rs
@@ -1,7 +1,7 @@
 use std::path::{Path, PathBuf};
 
 use super::ops::manifest_for_mutation;
-use crate::apply::{Op, Plan, PlannedOp, Pre};
+use crate::apply::{Description, Op, Plan, PlannedOp, Pre};
 use crate::env::Env;
 use crate::error::{CoreError, Result};
 use crate::manifest::{self, INPLACE_SOURCE_NAME, ItemDecl, LOCAL_SOURCE_NAME};
@@ -141,7 +141,7 @@ fn move_ops(
     let mut ops: Vec<PlannedOp> = broken
         .iter()
         .map(|(path, pre)| PlannedOp {
-            description: "clear the broken link at {}".to_owned(),
+            description: Description::around("clear the broken link at ", ""),
             op: Op::Trash {
                 absent_is_done: false,
                 path: path.clone(),

--- a/crates/core/src/engine/adopt.rs
+++ b/crates/core/src/engine/adopt.rs
@@ -141,7 +141,7 @@ fn move_ops(
     let mut ops: Vec<PlannedOp> = broken
         .iter()
         .map(|(path, pre)| PlannedOp {
-            description: format!("clear the broken link at {}", path.display()),
+            description: "clear the broken link at {}".to_owned(),
             op: Op::Trash {
                 absent_is_done: false,
                 path: path.clone(),

--- a/crates/core/src/engine/adopt/capture.rs
+++ b/crates/core/src/engine/adopt/capture.rs
@@ -136,7 +136,7 @@ pub(super) fn capture_ops(
     });
     for (_, original) in content {
         ops.push(PlannedOp {
-            description: format!("trash the unmanaged original at {}", original.display()),
+            description: "trash the unmanaged original at {}".to_owned(),
             op: Op::Trash {
                 absent_is_done: false,
                 path: original.clone(),

--- a/crates/core/src/engine/adopt/capture.rs
+++ b/crates/core/src/engine/adopt/capture.rs
@@ -10,7 +10,7 @@
 use std::fs;
 use std::path::{Path, PathBuf};
 
-use crate::apply::{Op, PlannedOp, Pre};
+use crate::apply::{Description, Op, PlannedOp, Pre};
 use crate::env::Env;
 use crate::error::{CoreError, Result};
 use crate::model::{HarnessId, ItemKind, Scope};
@@ -108,7 +108,7 @@ pub(super) fn capture_ops(
     // it goes to the trash first, where it can be got back.
     if local_item.exists() {
         ops.push(PlannedOp {
-            description: format!("trash the local source's earlier copy of {name}"),
+            description: format!("trash the local source's earlier copy of {name}").into(),
             op: Op::Trash {
                 absent_is_done: false,
                 path: local_item.to_path_buf(),
@@ -131,12 +131,12 @@ pub(super) fn capture_ops(
         },
     };
     ops.push(PlannedOp {
-        description: format!("move {name} into the local source"),
+        description: format!("move {name} into the local source").into(),
         op: capture,
     });
     for (_, original) in content {
         ops.push(PlannedOp {
-            description: "trash the unmanaged original at {}".to_owned(),
+            description: Description::around("trash the unmanaged original at ", ""),
             op: Op::Trash {
                 absent_is_done: false,
                 path: original.clone(),

--- a/crates/core/src/engine/adopt/hooks.rs
+++ b/crates/core/src/engine/adopt/hooks.rs
@@ -89,10 +89,7 @@ pub(super) fn adopt_hook(
             manifest: Box::new(manifest),
         },
     });
-    Ok(Plan {
-        scope: scope.clone(),
-        ops,
-    })
+    Plan::landed(scope.clone(), ops)
 }
 
 /// Every named tool's copy of the registration this name identifies, read

--- a/crates/core/src/engine/adopt/hooks.rs
+++ b/crates/core/src/engine/adopt/hooks.rs
@@ -336,7 +336,7 @@ fn drop_old_entries(found: &[Found]) -> Result<Vec<PlannedOp>> {
         .into_iter()
         .map(|(path, edits)| {
             Ok(PlannedOp {
-                description: format!("drop the old registration in {}", path.display()),
+                description: "drop the old registration in {}".to_owned(),
                 op: Op::EditFile {
                     pre: Pre::observed(&path)?,
                     path,

--- a/crates/core/src/engine/adopt/hooks.rs
+++ b/crates/core/src/engine/adopt/hooks.rs
@@ -22,7 +22,7 @@
 use std::collections::BTreeMap;
 use std::path::{Path, PathBuf};
 
-use crate::apply::{Op, Plan, PlannedOp, Pre};
+use crate::apply::{Description, Op, Plan, PlannedOp, Pre};
 use crate::configedit::ConfigEdit;
 use crate::engine::targets::HookFormat;
 use crate::env::Env;
@@ -222,7 +222,7 @@ fn script_move(scope: &Scope, command: &str, ops: &mut Vec<PlannedOp>) -> Result
         });
     }
     ops.push(PlannedOp {
-        description: format!("move {token} into {HOME}"),
+        description: format!("move {token} into {HOME}").into(),
         // The entries as they sit: `hash_tree` follows links, so a script
         // swapped for a link to the same bytes between plan and apply would
         // move the wrong object.
@@ -336,7 +336,7 @@ fn drop_old_entries(found: &[Found]) -> Result<Vec<PlannedOp>> {
         .into_iter()
         .map(|(path, edits)| {
             Ok(PlannedOp {
-                description: "drop the old registration in {}".to_owned(),
+                description: Description::around("drop the old registration in ", ""),
                 op: Op::EditFile {
                     pre: Pre::observed(&path)?,
                     path,

--- a/crates/core/src/engine/adopt/inplace.rs
+++ b/crates/core/src/engine/adopt/inplace.rs
@@ -15,7 +15,7 @@
 
 use std::path::{Path, PathBuf};
 
-use crate::apply::{Op, PlannedOp, Pre};
+use crate::apply::{Description, Op, PlannedOp, Pre};
 use crate::error::{CoreError, Result};
 use crate::model::{ItemKind, Scope};
 
@@ -91,7 +91,7 @@ pub(super) fn relocate_ops(
     let mut ops = Vec::new();
     for (link, raw) in links {
         ops.push(PlannedOp {
-            description: "clear the link at {}".to_owned(),
+            description: Description::around("clear the link at ", ""),
             op: Op::Trash {
                 absent_is_done: false,
                 path: link.clone(),
@@ -113,7 +113,7 @@ pub(super) fn relocate_ops(
     if let Some(from) = from {
         if !cleared && (home.exists() || home.is_symlink()) {
             ops.push(PlannedOp {
-                description: "trash what is already at {}".to_owned(),
+                description: Description::around("trash what is already at ", ""),
                 op: Op::Trash {
                     absent_is_done: false,
                     path: home.to_path_buf(),
@@ -128,7 +128,7 @@ pub(super) fn relocate_ops(
         // directory swapped for a link to the same bytes between plan and
         // apply would move the wrong object.
         ops.push(PlannedOp {
-            description: format!("move {name} into the shared .agents tree"),
+            description: format!("move {name} into the shared .agents tree").into(),
             op: Op::Rename {
                 from_pre: Pre::tree_as_is(from)?,
                 to_pre: Pre::Absent,
@@ -145,7 +145,7 @@ pub(super) fn relocate_ops(
         // would trash whatever arrived at that position after the plan was
         // read — including content nobody compared with anything.
         ops.push(PlannedOp {
-            description: "trash the second copy at {}".to_owned(),
+            description: Description::around("trash the second copy at ", ""),
             op: Op::Trash {
                 absent_is_done: false,
                 path: path.clone(),

--- a/crates/core/src/engine/adopt/inplace.rs
+++ b/crates/core/src/engine/adopt/inplace.rs
@@ -91,7 +91,7 @@ pub(super) fn relocate_ops(
     let mut ops = Vec::new();
     for (link, raw) in links {
         ops.push(PlannedOp {
-            description: format!("clear the link at {}", link.display()),
+            description: "clear the link at {}".to_owned(),
             op: Op::Trash {
                 absent_is_done: false,
                 path: link.clone(),
@@ -113,7 +113,7 @@ pub(super) fn relocate_ops(
     if let Some(from) = from {
         if !cleared && (home.exists() || home.is_symlink()) {
             ops.push(PlannedOp {
-                description: format!("trash what is already at {}", home.display()),
+                description: "trash what is already at {}".to_owned(),
                 op: Op::Trash {
                     absent_is_done: false,
                     path: home.to_path_buf(),
@@ -145,7 +145,7 @@ pub(super) fn relocate_ops(
         // would trash whatever arrived at that position after the plan was
         // read — including content nobody compared with anything.
         ops.push(PlannedOp {
-            description: format!("trash the second copy at {}", path.display()),
+            description: "trash the second copy at {}".to_owned(),
             op: Op::Trash {
                 absent_is_done: false,
                 path: path.clone(),

--- a/crates/core/src/engine/adopt/shared.rs
+++ b/crates/core/src/engine/adopt/shared.rs
@@ -5,7 +5,7 @@
 use std::fs;
 use std::path::{Path, PathBuf};
 
-use crate::apply::{Op, PlannedOp, Pre};
+use crate::apply::{Description, Op, PlannedOp, Pre};
 use crate::env::Env;
 use crate::error::{CoreError, Result};
 use crate::model::{HarnessId, ItemKind, Scope};
@@ -193,7 +193,7 @@ pub(super) fn shared_capture_ops(
     let mut ops = Vec::new();
     if local_item.exists() {
         ops.push(PlannedOp {
-            description: format!("trash the local source's earlier copy of {name}"),
+            description: format!("trash the local source's earlier copy of {name}").into(),
             op: Op::Trash {
                 absent_is_done: false,
                 path: local_item.to_path_buf(),
@@ -204,7 +204,8 @@ pub(super) fn shared_capture_ops(
         });
     }
     ops.push(PlannedOp {
-        description: format!("move the shared folder's content of {name} into the local source"),
+        description: format!("move the shared folder's content of {name} into the local source")
+            .into(),
         op: Op::WriteTree {
             root: local_item.to_path_buf(),
             files: crate::capture::read_tree(&shared.target)?,
@@ -212,7 +213,7 @@ pub(super) fn shared_capture_ops(
         },
     });
     ops.push(PlannedOp {
-        description: "trash the shared folder at {} (recoverable)".to_owned(),
+        description: Description::around("trash the shared folder at ", " (recoverable)"),
         op: Op::Trash {
             absent_is_done: false,
             path: shared.target.clone(),
@@ -223,7 +224,7 @@ pub(super) fn shared_capture_ops(
     });
     for (link, raw) in &shared.links {
         ops.push(PlannedOp {
-            description: "clear the link at {}".to_owned(),
+            description: Description::around("clear the link at ", ""),
             op: Op::Trash {
                 absent_is_done: false,
                 path: link.clone(),

--- a/crates/core/src/engine/adopt/shared.rs
+++ b/crates/core/src/engine/adopt/shared.rs
@@ -212,10 +212,7 @@ pub(super) fn shared_capture_ops(
         },
     });
     ops.push(PlannedOp {
-        description: format!(
-            "trash the shared folder at {} (recoverable)",
-            shared.target.display()
-        ),
+        description: "trash the shared folder at {} (recoverable)".to_owned(),
         op: Op::Trash {
             absent_is_done: false,
             path: shared.target.clone(),
@@ -226,7 +223,7 @@ pub(super) fn shared_capture_ops(
     });
     for (link, raw) in &shared.links {
         ops.push(PlannedOp {
-            description: format!("clear the link at {}", link.display()),
+            description: "clear the link at {}".to_owned(),
             op: Op::Trash {
                 absent_is_done: false,
                 path: link.clone(),

--- a/crates/core/src/engine/detach.rs
+++ b/crates/core/src/engine/detach.rs
@@ -393,10 +393,7 @@ pub fn source(env: &Env, scope: &Scope, source_name: &str) -> Result<Plan> {
             manifest: Box::new(converted),
         },
     });
-    Ok(Plan {
-        scope: scope.clone(),
-        ops,
-    })
+    Plan::landed(scope.clone(), ops)
 }
 
 /// The manifest this conversion writes: every kept package reading `local`

--- a/crates/core/src/engine/detach.rs
+++ b/crates/core/src/engine/detach.rs
@@ -386,7 +386,7 @@ pub fn source(env: &Env, scope: &Scope, source_name: &str) -> Result<Plan> {
 
     let manifest_path = crate::manifest::manifest_path(env, &scope);
     ops.push(PlannedOp {
-        description: format!("keep {source_name}'s packages as your own in kendex.toml"),
+        description: format!("keep {source_name}'s packages as your own in kendex.toml").into(),
         op: Op::WriteManifest {
             pre: Pre::observed(&manifest_path)?,
             path: manifest_path,

--- a/crates/core/src/engine/detach/capture.rs
+++ b/crates/core/src/engine/detach/capture.rs
@@ -141,7 +141,7 @@ pub(super) fn capture_to_local(
         },
     };
     Ok(vec![PlannedOp {
-        description: format!("keep {} {name} in your local source", kind.name()),
+        description: format!("keep {} {name} in your local source", kind.name()).into(),
         op,
     }])
 }

--- a/crates/core/src/engine/file_plan.rs
+++ b/crates/core/src/engine/file_plan.rs
@@ -194,10 +194,7 @@ fn plan_absent_file(
 /// reach a terminal as its own characters.
 pub(super) fn set_aside(path: &std::path::Path, pre: Pre) -> PlannedOp {
     PlannedOp {
-        description: format!(
-            "Move the files already at {} to the trash",
-            crate::names::shown(&path.display().to_string())
-        ),
+        description: "Move the files already at {} to the trash".to_owned(),
         op: Op::Trash {
             absent_is_done: false,
             path: path.to_path_buf(),

--- a/crates/core/src/engine/file_plan.rs
+++ b/crates/core/src/engine/file_plan.rs
@@ -10,7 +10,7 @@ use super::compared::of_file;
 use super::desired::{Artifact, Desired};
 use super::item_plan::{Planned, unmanaged, unmanaged_compared};
 use super::{DriftCause, DriftState};
-use crate::apply::{Op, PlannedOp, Pre};
+use crate::apply::{Description, Op, PlannedOp, Pre};
 use crate::env::Env;
 use crate::error::Result;
 use crate::hash::hash_tree;
@@ -98,7 +98,8 @@ pub(super) fn plan_written_file(
                     item.name,
                     item.harness.display_name(),
                     advisory(env, scope, item)
-                ),
+                )
+                .into(),
                 op: Op::WriteFile {
                     path: path.to_path_buf(),
                     bytes: bytes.to_vec(),
@@ -171,7 +172,7 @@ fn plan_absent_file(
         };
         let flip = if item.enabled { "on" } else { "off" };
         ops.push(PlannedOp {
-            description: format!("Turn {} {flip}", item.name),
+            description: format!("Turn {} {flip}", item.name).into(),
             op: Op::Rename {
                 from_pre,
                 from: alternate,
@@ -194,7 +195,7 @@ fn plan_absent_file(
 /// reach a terminal as its own characters.
 pub(super) fn set_aside(path: &std::path::Path, pre: Pre) -> PlannedOp {
     PlannedOp {
-        description: "Move the files already at {} to the trash".to_owned(),
+        description: Description::around("Move the files already at ", " to the trash"),
         op: Op::Trash {
             absent_is_done: false,
             path: path.to_path_buf(),
@@ -218,7 +219,8 @@ fn install(
             item.name,
             item.harness.display_name(),
             advisory(env, scope, item)
-        ),
+        )
+        .into(),
         op: Op::WriteFile {
             path: path.to_path_buf(),
             bytes: bytes.to_vec(),

--- a/crates/core/src/engine/fork.rs
+++ b/crates/core/src/engine/fork.rs
@@ -99,7 +99,7 @@ pub fn fork(
 
     let manifest_path = manifest::manifest_path(env, scope);
     ops.push(PlannedOp {
-        description: format!("record the fork of {name} in kendex.toml"),
+        description: format!("record the fork of {name} in kendex.toml").into(),
         op: Op::WriteManifest {
             pre: Pre::observed(&manifest_path)?,
             path: manifest_path,
@@ -302,7 +302,7 @@ fn capture_ops(
     let mut ops = Vec::new();
     if local_item.exists() {
         ops.push(PlannedOp {
-            description: format!("trash the local source's earlier copy of {name}"),
+            description: format!("trash the local source's earlier copy of {name}").into(),
             op: Op::Trash {
                 absent_is_done: false,
                 path: local_item.clone(),
@@ -325,11 +325,11 @@ fn capture_ops(
         },
     };
     ops.push(PlannedOp {
-        description: format!("keep the edited {} {name} as a local fork", kind.name()),
+        description: format!("keep the edited {} {name} as a local fork", kind.name()).into(),
         op: capture,
     });
     ops.push(PlannedOp {
-        description: format!("clear the edited install of {name} for re-render"),
+        description: format!("clear the edited install of {name} for re-render").into(),
         op: Op::Trash {
             absent_is_done: false,
             pre: Pre::HashIs {

--- a/crates/core/src/engine/fork.rs
+++ b/crates/core/src/engine/fork.rs
@@ -106,10 +106,7 @@ pub fn fork(
             manifest: Box::new(manifest),
         },
     });
-    Ok(Plan {
-        scope: scope.clone(),
-        ops,
-    })
+    Plan::landed(scope.clone(), ops)
 }
 
 /// The file or tree holding this rendering's edited bytes. Skills capture

--- a/crates/core/src/engine/fork/beside.rs
+++ b/crates/core/src/engine/fork/beside.rs
@@ -146,7 +146,7 @@ pub fn fork_beside(
 
     let manifest_path = manifest::manifest_path(env, scope);
     ops.push(PlannedOp {
-        description: format!("record the fork of {name} as {new_name} in kendex.toml"),
+        description: format!("record the fork of {name} as {new_name} in kendex.toml").into(),
         op: Op::WriteManifest {
             pre: Pre::observed(&manifest_path)?,
             path: manifest_path,

--- a/crates/core/src/engine/fork/beside.rs
+++ b/crates/core/src/engine/fork/beside.rs
@@ -153,10 +153,7 @@ pub fn fork_beside(
             manifest: Box::new(manifest),
         },
     });
-    Ok(Plan {
-        scope: scope.clone(),
-        ops,
-    })
+    Plan::landed(scope.clone(), ops)
 }
 
 /// The captured bytes answering to `new_name` — [`named_bytes`] over the

--- a/crates/core/src/engine/fork/rename.rs
+++ b/crates/core/src/engine/fork/rename.rs
@@ -120,10 +120,7 @@ pub fn rename_fork(env: &Env, scope: &Scope, kind: ItemKind, old: &str, new: &st
             manifest: Box::new(manifest),
         },
     });
-    Ok(Plan {
-        scope: scope.clone(),
-        ops,
-    })
+    Plan::landed(scope.clone(), ops)
 }
 
 /// Refuse a rename that widens the agent's access. A harness's own deny

--- a/crates/core/src/engine/fork/rename.rs
+++ b/crates/core/src/engine/fork/rename.rs
@@ -76,7 +76,7 @@ pub fn rename_fork(env: &Env, scope: &Scope, kind: ItemKind, old: &str, new: &st
     if from.exists() {
         let stamped = stamp_name(kind, &from, &to, new)?;
         ops.push(PlannedOp {
-            description: format!("rename the fork's files to {new}"),
+            description: format!("rename the fork's files to {new}").into(),
             op: Op::Rename {
                 // The fork moves whole, whatever sits in it: a dangling
                 // link the person left there is carried along, not a
@@ -113,7 +113,7 @@ pub fn rename_fork(env: &Env, scope: &Scope, kind: ItemKind, old: &str, new: &st
     }
     let manifest_path = manifest::manifest_path(env, scope);
     ops.push(PlannedOp {
-        description: format!("record the rename to {new} in kendex.toml"),
+        description: format!("record the rename to {new} in kendex.toml").into(),
         op: Op::WriteManifest {
             pre: Pre::observed(&manifest_path)?,
             path: manifest_path,
@@ -222,7 +222,7 @@ fn stamp_name(kind: ItemKind, from: &Path, to: &Path, new: &str) -> Result<Vec<P
         }
         let bytes = std::fs::read(&old).map_err(|e| CoreError::io(&old, e))?;
         ops.push(PlannedOp {
-            description: format!("give the renamed {} its new name, {new}", kind.name()),
+            description: format!("give the renamed {} its new name, {new}", kind.name()).into(),
             op: Op::WriteFile {
                 pre,
                 bytes: named_bytes(bytes, new)?,

--- a/crates/core/src/engine/mod.rs
+++ b/crates/core/src/engine/mod.rs
@@ -237,10 +237,7 @@ fn plan_scope_once(
         repo_effects: repo_effects::run(&state, &drift, &set_changes, lock),
         repo_effects_leaving,
         drift,
-        plan: Plan {
-            scope: scope.clone(),
-            ops,
-        },
+        plan: Plan::landed(scope.clone(), ops)?,
         notes: state.notes,
         warnings: state.warnings,
         set_changes,
@@ -358,10 +355,7 @@ pub fn plan_apply(env: &Env, scope: &Scope, options: &PlanOptions) -> Result<Eng
     // that would touch a file this build won't write to.
     let mut report = EngineReport {
         drift: Vec::new(),
-        plan: Plan {
-            scope: scope.clone(),
-            ops: Vec::new(),
-        },
+        plan: Plan::landed(scope.clone(), Vec::new())?,
         notes: Vec::new(),
         warnings: Vec::new(),
         set_changes: Vec::new(),

--- a/crates/core/src/engine/ops.rs
+++ b/crates/core/src/engine/ops.rs
@@ -379,7 +379,7 @@ pub(crate) fn insert_manifest_save(
     plan.insert(
         0,
         PlannedOp {
-            description: format!("Save {file}"),
+            description: format!("Save {file}").into(),
             op: Op::WriteManifest {
                 pre: Pre::observed(&path)?,
                 path,

--- a/crates/core/src/engine/ops.rs
+++ b/crates/core/src/engine/ops.rs
@@ -376,7 +376,7 @@ pub(crate) fn insert_manifest_save(
         .file_name()
         .map(|name| name.to_string_lossy().into_owned())
         .unwrap_or_else(|| path.display().to_string());
-    plan.ops.insert(
+    plan.insert(
         0,
         PlannedOp {
             description: format!("Save {file}"),
@@ -386,6 +386,5 @@ pub(crate) fn insert_manifest_save(
                 manifest: Box::new(manifest),
             },
         },
-    );
-    Ok(())
+    )
 }

--- a/crates/core/src/engine/pi_hooks_move/disposal.rs
+++ b/crates/core/src/engine/pi_hooks_move/disposal.rs
@@ -42,12 +42,7 @@ pub(super) fn plan_directory(
     };
     let each = |sink: &mut Sink| {
         for (path, proven) in take {
-            trash(
-                format!("Move pi hooks out of {}", dir.display()),
-                path,
-                proven,
-                sink,
-            );
+            trash("Move pi hooks out of {}".to_owned(), path, proven, sink);
         }
     };
     if !strangers.is_empty() {
@@ -70,12 +65,7 @@ pub(super) fn plan_directory(
     // Nothing here is anybody else's, so the whole directory goes when
     // this pass takes everything the lock names in it.
     if !take.is_empty() && take.len() == ours.len() {
-        return whole(
-            format!("Move pi hooks out of {}", dir.display()),
-            dir,
-            ours,
-            sink,
-        );
+        return whole("Move pi hooks out of {}".to_owned(), dir, ours, sink);
     }
     // And when it names nothing and the directory is empty — the shell a
     // finished move leaves behind, which pi still warns about and which
@@ -84,7 +74,7 @@ pub(super) fn plan_directory(
     // an empty directory here is one the person made, and theirs.
     if claimed && ours.is_empty() {
         let taken = whole(
-            format!("Remove the empty {} pi warns about", dir.display()),
+            "Remove the empty {} pi warns about".to_owned(),
             dir,
             ours,
             sink,
@@ -271,7 +261,7 @@ pub(super) fn plan_registry(
     };
     if after.as_object().is_some_and(|object| object.is_empty()) {
         trash(
-            format!("Move the pi hook registry out of {}", registry.display()),
+            "Move the pi hook registry out of {}".to_owned(),
             registry,
             &crate::hash::hash_bytes(current.as_bytes()),
             sink,

--- a/crates/core/src/engine/pi_hooks_move/disposal.rs
+++ b/crates/core/src/engine/pi_hooks_move/disposal.rs
@@ -5,6 +5,7 @@ use std::collections::BTreeSet;
 use std::ffi::OsString;
 use std::path::{Path, PathBuf};
 
+use crate::apply::Description;
 use crate::configedit::ConfigEdit;
 use crate::error::Result;
 
@@ -42,7 +43,12 @@ pub(super) fn plan_directory(
     };
     let each = |sink: &mut Sink| {
         for (path, proven) in take {
-            trash("Move pi hooks out of {}".to_owned(), path, proven, sink);
+            trash(
+                Description::around("Move pi hooks out of ", ""),
+                path,
+                proven,
+                sink,
+            );
         }
     };
     if !strangers.is_empty() {
@@ -65,7 +71,12 @@ pub(super) fn plan_directory(
     // Nothing here is anybody else's, so the whole directory goes when
     // this pass takes everything the lock names in it.
     if !take.is_empty() && take.len() == ours.len() {
-        return whole("Move pi hooks out of {}".to_owned(), dir, ours, sink);
+        return whole(
+            Description::around("Move pi hooks out of ", ""),
+            dir,
+            ours,
+            sink,
+        );
     }
     // And when it names nothing and the directory is empty — the shell a
     // finished move leaves behind, which pi still warns about and which
@@ -74,7 +85,7 @@ pub(super) fn plan_directory(
     // an empty directory here is one the person made, and theirs.
     if claimed && ours.is_empty() {
         let taken = whole(
-            "Remove the empty {} pi warns about".to_owned(),
+            Description::around("Remove the empty ", " pi warns about"),
             dir,
             ours,
             sink,
@@ -103,7 +114,7 @@ pub(super) fn plan_directory(
 /// unchanged: that, not the order of two reads, is what makes the proof
 /// and the binding describe one state. A file arriving at any point
 /// either shows up in a listing or changes the hash the apply checks.
-fn whole(description: String, dir: &Path, ours: &BTreeSet<OsString>, sink: &mut Sink) -> bool {
+fn whole(description: Description, dir: &Path, ours: &BTreeSet<OsString>, sink: &mut Sink) -> bool {
     // Checked here rather than inferred from the caller: `hash_tree`
     // resolves links, so one child link would walk a tree kendex does not
     // own. The caller only asks about a directory whose every child it
@@ -261,7 +272,7 @@ pub(super) fn plan_registry(
     };
     if after.as_object().is_some_and(|object| object.is_empty()) {
         trash(
-            "Move the pi hook registry out of {}".to_owned(),
+            Description::around("Move the pi hook registry out of ", ""),
             registry,
             &crate::hash::hash_bytes(current.as_bytes()),
             sink,

--- a/crates/core/src/engine/pi_hooks_move/mod.rs
+++ b/crates/core/src/engine/pi_hooks_move/mod.rs
@@ -26,7 +26,7 @@ use std::collections::BTreeSet;
 use std::ffi::OsString;
 use std::path::{Path, PathBuf};
 
-use crate::apply::{Op, PlannedOp};
+use crate::apply::{Description, Op, PlannedOp};
 use crate::env::Env;
 use crate::error::Result;
 use crate::harness::pi;
@@ -316,7 +316,7 @@ fn move_out(
 /// Nothing else in the plan derives a legacy path, so the guard has no
 /// overlap to catch today — it is the boundary every Trash op in a plan
 /// passes, kept so a future pass that does overlap cannot slip past it.
-fn trash(description: String, path: &Path, proven: &str, sink: &mut Sink) {
+fn trash(description: Description, path: &Path, proven: &str, sink: &mut Sink) {
     sink.guard.extend(
         sink.ops,
         [PlannedOp {

--- a/crates/core/src/engine/posture.rs
+++ b/crates/core/src/engine/posture.rs
@@ -78,7 +78,9 @@ pub(super) fn plan_posture(
         return Ok(());
     };
     ops.push(PlannedOp {
-        description: "Keep this machine's install ledger out of the repository".to_owned(),
+        description: "Keep this machine's install ledger out of the repository"
+            .to_owned()
+            .into(),
         op: Op::WriteFile {
             pre: Pre::observed(&path)?,
             path,

--- a/crates/core/src/engine/removal.rs
+++ b/crates/core/src/engine/removal.rs
@@ -5,7 +5,7 @@ use super::desired;
 use super::owned::{Owned, installed};
 use super::targets::disabled_name;
 use super::{DriftRow, DriftState, PlanOptions};
-use crate::apply::{Op, PlannedOp, Pre};
+use crate::apply::{Description, Op, PlannedOp, Pre};
 use crate::env::Env;
 use crate::error::Result;
 use crate::lock::{Lock, LockEntry};
@@ -59,7 +59,7 @@ pub fn edit_holds(env: &Env, scope: &Scope, entry: &LockEntry) -> bool {
 /// link we manage. Anything edited between preview and apply fails the
 /// precondition and the whole apply rolls back, instead of moving work
 /// nobody looked at into the trash.
-pub(super) fn trash(description: String, path: PathBuf) -> Result<PlannedOp> {
+pub(super) fn trash(description: Description, path: PathBuf) -> Result<PlannedOp> {
     let pre = match path.is_symlink() {
         true => Pre::SymlinkTo {
             target: std::fs::read_link(&path).map_err(|e| crate::error::CoreError::io(&path, e))?,
@@ -102,7 +102,8 @@ pub(super) fn removal_ops(
                         "Move {} {}'s files to the trash",
                         entry.kind.name(),
                         entry.name
-                    ),
+                    )
+                    .into(),
                     candidate,
                 )?);
             }

--- a/crates/core/src/engine/scope_writes.rs
+++ b/crates/core/src/engine/scope_writes.rs
@@ -104,7 +104,7 @@ pub(super) fn plan_config_edits(
             .map(|name| name.to_string_lossy().into_owned())
             .unwrap_or_else(|| path.display().to_string());
         ops.push(PlannedOp {
-            description: format!("Update {file} ({})", labels.join(", ")),
+            description: format!("Update {file} ({})", labels.join(", ")).into(),
             op: Op::EditFile { pre, path, edits },
         });
     }
@@ -362,7 +362,7 @@ pub(super) fn plan_settings_seed(
         said.push(format!("set {}", edited.join(", ")));
     }
     ops.push(PlannedOp {
-        description: format!("Update {file} ({})", said.join("; ")),
+        description: format!("Update {file} ({})", said.join("; ")).into(),
         op: Op::WriteFile {
             // Bound to the bytes AND to their being a plain file. This
             // path refuses a symlinked settings file above, and a check

--- a/crates/core/src/engine/scope_writes/manifest_text.rs
+++ b/crates/core/src/engine/scope_writes/manifest_text.rs
@@ -173,7 +173,10 @@ fn surgical_manifest_write(
             manifest: Box::new(expected),
         },
     };
-    ops.push(PlannedOp { description, op });
+    ops.push(PlannedOp {
+        description: description.into(),
+        op,
+    });
     Ok(())
 }
 

--- a/crates/core/src/engine/stale.rs
+++ b/crates/core/src/engine/stale.rs
@@ -61,7 +61,8 @@ pub(super) fn stale_emitted(
                     "Move {} {}'s old files to the trash",
                     recorded.kind.name(),
                     recorded.name
-                ),
+                )
+                .into(),
                 path.clone(),
             )?;
             guard.extend(ops, [planned]);

--- a/crates/core/src/engine/tree_plan.rs
+++ b/crates/core/src/engine/tree_plan.rs
@@ -235,7 +235,8 @@ fn write_ops(
                 item.harness.display_name(),
                 item.kind.name(),
                 item.name
-            ),
+            )
+            .into(),
             op: Op::Trash {
                 absent_is_done: false,
                 path: canonical.to_path_buf(),
@@ -258,7 +259,8 @@ fn write_ops(
                 true => ", in the folder its tools share",
                 false => "",
             }
-        ),
+        )
+        .into(),
         op: Op::WriteTree {
             root: canonical.to_path_buf(),
             files: files.to_vec(),

--- a/crates/core/src/engine/tree_plan/link.rs
+++ b/crates/core/src/engine/tree_plan/link.rs
@@ -57,7 +57,8 @@ pub(super) fn plan_link(
                     item.harness.display_name(),
                     item.kind.name(),
                     item.name
-                ),
+                )
+                .into(),
                 op: Op::Trash {
                     absent_is_done: false,
                     path: link.to_path_buf(),
@@ -73,7 +74,8 @@ pub(super) fn plan_link(
                 item.harness.display_name(),
                 item.kind.name(),
                 item.name
-            ),
+            )
+            .into(),
             op: Op::Symlink {
                 link: link.to_path_buf(),
                 target: spelled,
@@ -156,7 +158,7 @@ fn respell(
     ops: &mut Vec<PlannedOp>,
 ) {
     ops.push(PlannedOp {
-        description: why,
+        description: why.into(),
         op: Op::Trash {
             absent_is_done: false,
             path: link.to_path_buf(),
@@ -169,7 +171,8 @@ fn respell(
             item.harness.display_name(),
             item.kind.name(),
             item.name
-        ),
+        )
+        .into(),
         op: Op::Symlink {
             link: link.to_path_buf(),
             target: spelled,

--- a/crates/core/src/error.rs
+++ b/crates/core/src/error.rs
@@ -76,6 +76,9 @@ pub enum CoreError {
     #[error("{path} now lands at {now} — refusing to write where the plan did not")]
     TargetMoved { path: PathBuf, now: PathBuf },
 
+    #[error("{path}: this journal does not say where it reached — refusing to put anything back")]
+    UnrecordedLanding { path: PathBuf },
+
     #[error("'{name}' already installed from {existing} — refusing to rebind to {requested}")]
     SourceCollision {
         name: String,

--- a/crates/core/src/error.rs
+++ b/crates/core/src/error.rs
@@ -73,6 +73,9 @@ pub enum CoreError {
         root: PathBuf,
     },
 
+    #[error("{path} now lands at {now} — refusing to write where the plan did not")]
+    TargetMoved { path: PathBuf, now: PathBuf },
+
     #[error("'{name}' already installed from {existing} — refusing to rebind to {requested}")]
     SourceCollision {
         name: String,

--- a/crates/core/src/error.rs
+++ b/crates/core/src/error.rs
@@ -66,6 +66,13 @@ pub enum CoreError {
     #[error("{path}: refused catalog read — {reason}")]
     SourceEscape { path: PathBuf, reason: String },
 
+    #[error("{path} lands at {landed}, outside {root} — refusing to write there")]
+    ScopeEscape {
+        path: PathBuf,
+        landed: PathBuf,
+        root: PathBuf,
+    },
+
     #[error("'{name}' already installed from {existing} — refusing to rebind to {requested}")]
     SourceCollision {
         name: String,

--- a/crates/core/src/fs.rs
+++ b/crates/core/src/fs.rs
@@ -7,7 +7,7 @@ use crate::error::{CoreError, Result};
 
 mod links;
 mod lock;
-pub(crate) use links::{points_at, spelling};
+pub(crate) use links::{points_at, resolved, spelling};
 pub(crate) use lock::{LockedFile, open_read_no_follow};
 
 /// Write via a sibling temp file + rename so readers never see a torn file.

--- a/crates/core/src/source_ops/subscribe.rs
+++ b/crates/core/src/source_ops/subscribe.rs
@@ -335,15 +335,21 @@ fn announce_subscription(
         (Some(repo), None) => repo.clone(),
         (None, _) => decl.path.clone().unwrap_or_default(),
     };
-    let line = format!(
-        "Subscribes {} to '{name}' ({what}) — {}",
-        scope.label(),
-        manifest::manifest_path(env, scope).display()
-    );
+    let said = format!("Subscribes {} to '{name}' ({what}) — ", scope.label());
+    // The file is the op's to name, not this line's: the write goes where
+    // the plan landed it, and a spelling derived again here would name
+    // somewhere else the moment a directory on the way is a link.
+    let mut written = None;
     for op in &mut report.plan.ops {
         if let crate::apply::Op::WriteManifest { .. } = &op.op {
-            op.description = line.clone().into();
+            op.description = crate::apply::Description::around(said.clone(), "");
+            written = Some(op.line());
         }
     }
-    report.notes.push(line);
+    // No write, no landed place to name — the file the subscription would
+    // go in is all there is to say, and nothing disagrees with it.
+    report.notes.push(
+        written
+            .unwrap_or_else(|| format!("{said}{}", manifest::manifest_path(env, scope).display())),
+    );
 }

--- a/crates/core/src/source_ops/subscribe.rs
+++ b/crates/core/src/source_ops/subscribe.rs
@@ -342,7 +342,7 @@ fn announce_subscription(
     );
     for op in &mut report.plan.ops {
         if let crate::apply::Op::WriteManifest { .. } = &op.op {
-            op.description = line.clone();
+            op.description = line.clone().into();
         }
     }
     report.notes.push(line);

--- a/crates/core/tests/byte_faithful.rs
+++ b/crates/core/tests/byte_faithful.rs
@@ -177,10 +177,11 @@ fn a_written_tree_keeps_shebang_files_executable() {
             pre: kendex_core::apply::Pre::Absent,
         },
     };
-    let plan = kendex_core::apply::Plan {
-        scope: kendex_core::model::Scope::Global,
-        ops: vec![op],
-    };
+    // Through the constructor the product builds every plan with: it is
+    // what fixes each path at the place it lands, which the transaction
+    // then holds it to.
+    let plan =
+        kendex_core::apply::Plan::landed(kendex_core::model::Scope::Global, vec![op]).unwrap();
     kendex_core::apply::execute(&env, &plan, None).unwrap();
     let script = std::fs::metadata(root.join("scripts/run")).unwrap();
     assert!(

--- a/crates/core/tests/edits_and_forks/disabled.rs
+++ b/crates/core/tests/edits_and_forks/disabled.rs
@@ -106,7 +106,7 @@ fn an_edit_landing_after_the_enable_was_planned_refuses_the_toggle() {
             .plan
             .ops
             .iter()
-            .any(|op| op.description.contains("Turn rev on")),
+            .any(|op| op.line().contains("Turn rev on")),
         "{:?}",
         report.plan.ops
     );

--- a/crates/core/tests/edits_and_forks/forks.rs
+++ b/crates/core/tests/edits_and_forks/forks.rs
@@ -445,7 +445,7 @@ fn forking_a_skill_whose_native_link_was_repointed_reads_the_managed_tree() {
             .unwrap();
     // The captured content is the canonical tree, and nothing trashes the
     // foreign directory.
-    let descriptions: Vec<&str> = plan.ops.iter().map(|op| op.description.as_str()).collect();
+    let descriptions: Vec<String> = plan.ops.iter().map(|op| op.line()).collect();
     let debug = format!("{:?}", plan.ops);
     assert!(
         !debug.contains("foreign"),

--- a/crates/core/tests/hook_promises.rs
+++ b/crates/core/tests/hook_promises.rs
@@ -100,13 +100,7 @@ fn a_hook_says_which_tools_run_it_and_which_only_read_it() {
         );
     }
 
-    let described = |text: &str| {
-        report
-            .plan
-            .ops
-            .iter()
-            .any(|op| op.description.contains(text))
-    };
+    let described = |text: &str| report.plan.ops.iter().any(|op| op.line().contains(text));
     assert!(described("Install hook guard for Cursor (advisory)"));
     assert!(described("Install hook guard for OpenCode (advisory)"));
     for tool in ["Claude Code", "Codex", "Gemini CLI", "GitHub Copilot"] {

--- a/crates/core/tests/kinds/config_files.rs
+++ b/crates/core/tests/kinds/config_files.rs
@@ -149,19 +149,9 @@ fn an_unreadable_settings_file_is_one_conflict_not_a_scope_error() {
         "{}",
         conflict.detail
     );
+    assert!(report.plan.ops.iter().any(|op| op.line().contains("ship")));
     assert!(
-        report
-            .plan
-            .ops
-            .iter()
-            .any(|op| op.description.contains("ship"))
-    );
-    assert!(
-        !report
-            .plan
-            .ops
-            .iter()
-            .any(|op| op.description.contains("guard")),
+        !report.plan.ops.iter().any(|op| op.line().contains("guard")),
         "a hook that cannot register does not half-install"
     );
 }

--- a/crates/core/tests/marketplace_subscribe.rs
+++ b/crates/core/tests/marketplace_subscribe.rs
@@ -244,7 +244,7 @@ fn subscribing_a_project_from_a_personal_subscription_mutates_only_the_project()
         .plan
         .ops
         .iter()
-        .map(|op| op.description.as_str())
+        .map(|op| op.line())
         .find(|description| description.starts_with("Subscribes"))
         .unwrap()
         .to_owned();

--- a/crates/core/tests/migration.rs
+++ b/crates/core/tests/migration.rs
@@ -74,7 +74,7 @@ fn a_v01_scope_upgrades_in_place_changing_only_the_schema_line() {
             .plan
             .ops
             .iter()
-            .any(|op| op.description.contains("Upgrade kendex.toml"))
+            .any(|op| op.line().contains("Upgrade kendex.toml"))
     );
     apply::execute(&f.env, &report.plan, None).unwrap();
 
@@ -95,7 +95,7 @@ fn a_v01_scope_upgrades_in_place_changing_only_the_schema_line() {
             .plan
             .ops
             .iter()
-            .any(|op| op.description.contains("Upgrade"))
+            .any(|op| op.line().contains("Upgrade"))
     );
     assert!(again.drift.is_empty());
 }

--- a/crates/core/tests/package_pins/main.rs
+++ b/crates/core/tests/package_pins/main.rs
@@ -371,7 +371,7 @@ fn two_parents_pinning_different_revs_of_one_dependency_change_nothing() {
     );
     assert!(
         !report.plan.ops.iter().any(|op| {
-            format!("{:?}", op.op).contains("helper") && op.description.contains("helper")
+            format!("{:?}", op.op).contains("helper") && op.line().contains("helper")
         }),
         "nothing is written for a conflicted item: {:?}",
         report.plan.ops

--- a/crates/core/tests/pi_hooks_move/strangers.rs
+++ b/crates/core/tests/pi_hooks_move/strangers.rs
@@ -280,12 +280,7 @@ fn the_empty_directory_op_says_what_it_does() {
     fs::create_dir_all(w.dot().join("hooks")).unwrap();
 
     let report = audit(&w.env, &w.scope()).unwrap();
-    let said: Vec<&str> = report
-        .plan
-        .ops
-        .iter()
-        .map(|op| op.description.as_str())
-        .collect();
+    let said: Vec<String> = report.plan.ops.iter().map(|op| op.line()).collect();
     assert!(
         said.iter().any(|line| line.starts_with("Remove the empty")),
         "{said:?}"

--- a/crates/core/tests/sealed_source.rs
+++ b/crates/core/tests/sealed_source.rs
@@ -69,11 +69,5 @@ fn a_symlinked_catalog_cannot_leak_host_files_into_artifacts() {
         }
     }
     // The clean skill still installs.
-    assert!(
-        report
-            .plan
-            .ops
-            .iter()
-            .any(|op| op.description.contains("good"))
-    );
+    assert!(report.plan.ops.iter().any(|op| op.line().contains("good")));
 }

--- a/crates/core/tests/settings_edits.rs
+++ b/crates/core/tests/settings_edits.rs
@@ -235,12 +235,12 @@ fn a_save_that_seeds_a_missing_key_and_sets_it_is_one_write() {
         ..PlanOptions::default()
     };
     let report = plan_scope(&f.env, &f.scope, &manifest, &lock, &options).unwrap();
-    let writes: Vec<&str> = report
+    let writes: Vec<String> = report
         .plan
         .ops
         .iter()
-        .filter(|op| op.description.contains("kendex.settings.toml"))
-        .map(|op| op.description.as_str())
+        .filter(|op| op.line().contains("kendex.settings.toml"))
+        .map(|op| op.line())
         .collect();
     assert_eq!(writes.len(), 1, "{writes:?}");
     assert!(writes[0].contains("seed REVIEWERS, DEPTH"), "{writes:?}");
@@ -613,7 +613,7 @@ fn an_env_declared_as_an_array_of_tables_stops_the_write_and_says_why() {
             .plan
             .ops
             .iter()
-            .any(|op| op.description.contains("kendex.settings.toml")),
+            .any(|op| op.line().contains("kendex.settings.toml")),
         "nothing may be written into a file with nowhere to write"
     );
     apply::execute(&f.env, &report.plan, None).unwrap();

--- a/crates/core/tests/settings_seed_apply.rs
+++ b/crates/core/tests/settings_seed_apply.rs
@@ -95,7 +95,7 @@ fn seeds_env_defaults_and_never_overwrites_user_values() {
             .plan
             .ops
             .iter()
-            .any(|op| op.description.contains("kendex.settings.toml")),
+            .any(|op| op.line().contains("kendex.settings.toml")),
         "clean settings file must not be re-planned"
     );
 
@@ -132,7 +132,7 @@ fn occupied_settings_path_is_a_conflict_not_a_clobber() {
             .plan
             .ops
             .iter()
-            .any(|op| op.description.contains("kendex.settings.toml"))
+            .any(|op| op.line().contains("kendex.settings.toml"))
     );
 }
 
@@ -273,7 +273,7 @@ fn a_skill_installed_on_no_harness_seeds_nothing() {
             .plan
             .ops
             .iter()
-            .any(|op| op.description.contains("kendex.settings.toml")),
+            .any(|op| op.line().contains("kendex.settings.toml")),
         "{:?}",
         report
             .plan
@@ -307,7 +307,7 @@ fn an_adoption_only_ledger_change_is_written_to_the_lock() {
             .plan
             .ops
             .iter()
-            .any(|op| op.description.contains("kendex.settings.toml")),
+            .any(|op| op.line().contains("kendex.settings.toml")),
         "adoption changes no file: {:?}",
         report
             .plan
@@ -435,7 +435,7 @@ fn the_note_claims_no_write_for_a_key_the_file_already_assigns() {
             .plan
             .ops
             .iter()
-            .any(|op| op.description.contains("kendex.settings.toml")),
+            .any(|op| op.line().contains("kendex.settings.toml")),
         "an assigned key must not be re-seeded"
     );
     apply_now(&f);

--- a/crates/core/tests/symlinked_harness_dir.rs
+++ b/crates/core/tests/symlinked_harness_dir.rs
@@ -92,6 +92,17 @@ fn planned_tree(plan: &apply::Plan) -> Vec<PathBuf> {
         .collect()
 }
 
+/// Where the plan says its file writes go.
+fn planned_writes(plan: &apply::Plan) -> Vec<PathBuf> {
+    plan.ops
+        .iter()
+        .filter_map(|planned| match &planned.op {
+            Op::WriteFile { path, .. } => Some(path.clone()),
+            _ => None,
+        })
+        .collect()
+}
+
 /// Where the plan puts this skill's harness link.
 fn planned_links(plan: &apply::Plan) -> Vec<PathBuf> {
     plan.ops
@@ -390,4 +401,138 @@ fn a_global_harness_directory_kept_in_a_dotfiles_repo_is_written_through() {
         "---\nname: ship\ndescription: ship\n---\n\nShip the branch.\n",
         "the bytes are readable through the person's link"
     );
+}
+
+/// The line a confirmation draws names the place the write goes. A person
+/// approving a preview is approving what it says, so the position in the
+/// sentence and the position in the op cannot be two different places.
+#[test]
+#[allow(clippy::unwrap_used)]
+fn the_line_a_confirmation_draws_names_the_landed_position() {
+    let f = fixture();
+    let elsewhere = f.project.join("shared");
+    link_agents_dir(&f, &elsewhere);
+    // Somebody else's files, sitting where the declaration installs.
+    put(&elsewhere.join("skills/ship/SKILL.md"), "Not kendex's.\n");
+
+    let report = kendex_core::engine::plan_apply(
+        &f.env,
+        &f.scope,
+        &kendex_core::engine::PlanOptions {
+            replace_unmanaged: true,
+            ..kendex_core::engine::PlanOptions::default()
+        },
+    )
+    .unwrap();
+    let lines: Vec<String> = report.plan.ops.iter().map(apply::PlannedOp::line).collect();
+    assert!(
+        lines.contains(&format!(
+            "Move the files already at {} to the trash",
+            elsewhere.join("skills/ship").display()
+        )),
+        "the line names where the trashing happens: {lines:?}"
+    );
+}
+
+/// An op joining a plan after it was made is landed like every op that
+/// arrived with it.
+#[test]
+#[allow(clippy::unwrap_used)]
+fn an_op_joining_a_plan_is_landed_against_the_root_the_plan_fixed() {
+    let f = fixture();
+    let elsewhere = f.project.join("shared");
+    link_agents_dir(&f, &elsewhere);
+
+    let mut plan = apply::Plan::landed(f.scope.clone(), Vec::new()).unwrap();
+    plan.insert(
+        0,
+        apply::PlannedOp {
+            description: "write at {}".into(),
+            op: Op::WriteFile {
+                path: f.project.join(".agents/late"),
+                bytes: b"late".to_vec(),
+                pre: apply::Pre::Absent,
+            },
+        },
+    )
+    .unwrap();
+
+    assert_eq!(
+        planned_writes(&plan),
+        vec![elsewhere.join("late")],
+        "the op that joined late lands like the rest"
+    );
+    assert_eq!(
+        plan.ops[0].line(),
+        format!("write at {}", elsewhere.join("late").display()),
+    );
+}
+
+/// The root a plan was made with is the root an op joining it is held to.
+/// Re-deriving one now would read it after the swap, and the write would
+/// go wherever the replacement points.
+#[test]
+#[allow(clippy::unwrap_used)]
+fn an_op_joining_a_plan_after_the_project_was_swapped_is_refused() {
+    let f = fixture();
+    let mut plan = apply::Plan::landed(f.scope.clone(), Vec::new()).unwrap();
+
+    let moved = f.home.join("moved");
+    let victim = f.home.join("victim");
+    fs::create_dir_all(&victim).unwrap();
+    fs::rename(&f.project, &moved).unwrap();
+    std::os::unix::fs::symlink(&victim, &f.project).unwrap();
+
+    // Derived now, the way a caller inserting a record write derives it:
+    // through the scope, which reads the replacement.
+    let path = kendex_core::manifest::manifest_path(&f.env, &f.scope);
+    assert!(path.starts_with(&victim), "the caller derived {path:?}");
+
+    let refused = plan
+        .insert(
+            0,
+            apply::PlannedOp {
+                description: "save the record at {}".into(),
+                op: Op::WriteFile {
+                    path,
+                    bytes: b"schema = 6\n".to_vec(),
+                    pre: apply::Pre::Absent,
+                },
+            },
+        )
+        .unwrap_err();
+    assert!(
+        matches!(refused, CoreError::ScopeEscape { .. }),
+        "an op joining this plan must land inside the root it fixed: {refused}"
+    );
+    assert!(plan.ops.is_empty(), "nothing joined the plan");
+    assert!(!victim.join("kendex.toml").exists());
+}
+
+/// A raw `..` that no existing directory resolves away is refused on the
+/// way in, so an op cannot walk out of the plan's root by spelling.
+#[test]
+#[allow(clippy::unwrap_used)]
+fn an_op_joining_a_plan_cannot_walk_out_of_its_root() {
+    let f = fixture();
+    let mut plan = apply::Plan::landed(f.scope.clone(), Vec::new()).unwrap();
+
+    let refused = plan
+        .insert(
+            0,
+            apply::PlannedOp {
+                description: "write at {}".into(),
+                op: Op::WriteFile {
+                    path: f.project.join("absent/../../victim"),
+                    bytes: b"taken".to_vec(),
+                    pre: apply::Pre::Absent,
+                },
+            },
+        )
+        .unwrap_err();
+    assert!(
+        matches!(refused, CoreError::ScopeEscape { .. }),
+        "{refused}"
+    );
+    assert!(plan.ops.is_empty(), "nothing joined the plan");
 }

--- a/crates/core/tests/symlinked_harness_dir.rs
+++ b/crates/core/tests/symlinked_harness_dir.rs
@@ -447,7 +447,7 @@ fn an_op_joining_a_plan_is_landed_against_the_root_the_plan_fixed() {
     plan.insert(
         0,
         apply::PlannedOp {
-            description: "write at {}".into(),
+            description: apply::Description::around("write at ", ""),
             op: Op::WriteFile {
                 path: f.project.join(".agents/late"),
                 bytes: b"late".to_vec(),
@@ -535,4 +535,34 @@ fn an_op_joining_a_plan_cannot_walk_out_of_its_root() {
         "{refused}"
     );
     assert!(plan.ops.is_empty(), "nothing joined the plan");
+}
+
+/// A name is content, and a preview draws it whole. The position an op
+/// acts on is not something to go looking for in the sentence — any token
+/// worth searching for is a token some name is allowed to be, and `{}` is
+/// a name kendex accepts.
+#[test]
+#[allow(clippy::unwrap_used)]
+fn a_name_that_reads_like_a_slot_is_drawn_as_itself() {
+    let f = fixture();
+    put(
+        &f.home.join("catalog/skills/{}/SKILL.md"),
+        "---\nname: \"{}\"\ndescription: braces\n---\n\nBraces.\n",
+    );
+    put(
+        &f.project.join("kendex.toml"),
+        &format!(
+            "schema = 6\n\n[sources.cat]\npath = \"{}\"\n\n[install]\nharnesses = [\"claude\"]\n\n[skills.\"{{}}\"]\nsource = \"cat\"\n",
+            f.home.join("catalog").display()
+        ),
+    );
+
+    let report = audit(&f.env, &f.scope).unwrap();
+    let lines: Vec<String> = report.plan.ops.iter().map(apply::PlannedOp::line).collect();
+    assert!(
+        lines.contains(
+            &"Write skill {}'s files for Claude Code, in the folder its tools share".to_owned()
+        ),
+        "the name is drawn as itself: {lines:?}"
+    );
 }

--- a/crates/core/tests/symlinked_harness_dir.rs
+++ b/crates/core/tests/symlinked_harness_dir.rs
@@ -637,3 +637,88 @@ fn a_journal_that_never_said_where_its_paths_reached_is_refused() {
         "the journal stands, for a person to look at"
     );
 }
+
+/// A pre-image copied through a link goes back into the file it came from.
+///
+/// The entry's own landing stops at the link, deliberately, so it says
+/// nothing about the far end. Redirect a directory on the way to that end
+/// and the same link reaches another file — one these bytes never came out
+/// of, and must not be written into.
+#[test]
+#[allow(clippy::unwrap_used)]
+fn a_pre_image_taken_through_a_link_is_not_put_into_another_file() {
+    let f = fixture();
+    let held = f.project.join("store/kept.md");
+    let decoy = f.project.join("decoy/kept.md");
+    put(&held, "the bytes an apply would put back\n");
+    put(&decoy, "somebody else's file\n");
+    let link = f.project.join("reads");
+    std::os::unix::fs::symlink(&held, &link).unwrap();
+
+    let dir = apply::journal::journal_dir_for(&f.env.journal_dir(), &apply::scope_key(&f.scope));
+    apply::journal::write(&dir, &[link.clone()]).unwrap();
+
+    // The link is untouched and still reads the same text. The directory
+    // on the way to what it names is what changed.
+    fs::rename(f.project.join("store"), f.project.join("kept-store")).unwrap();
+    std::os::unix::fs::symlink(f.project.join("decoy"), f.project.join("store")).unwrap();
+    assert_eq!(fs::canonicalize(&link).unwrap(), decoy, "the far end moved");
+
+    let refused = apply::recover(&f.env, &f.scope).unwrap_err();
+    assert!(
+        matches!(&refused, CoreError::TargetMoved { now, .. } if *now == decoy),
+        "{refused}"
+    );
+    assert_eq!(
+        fs::read_to_string(&decoy).unwrap(),
+        "somebody else's file\n",
+        "the pre-image did not land in a file it never came from"
+    );
+    assert!(apply::journal::pending(&dir), "the journal stands");
+}
+
+/// A subscription's preview and its note name the file the write goes to.
+///
+/// Both are drawn from the op, so a config directory the person keeps
+/// somewhere else cannot leave the two disagreeing — which is what a
+/// spelling derived a second time, after the plan was landed, would do.
+#[test]
+#[allow(clippy::unwrap_used)]
+fn a_subscription_says_the_file_its_write_lands_in() {
+    let f = fixture();
+    let dotfiles = f.home.join("dotfiles/config");
+    fs::create_dir_all(dotfiles.join("kendex")).unwrap();
+    std::os::unix::fs::symlink(&dotfiles, f.home.join(".config")).unwrap();
+
+    let subscribed = kendex_core::source_ops::subscribe(
+        &f.env,
+        &Scope::Global,
+        &f.home.join("catalog").display().to_string(),
+        Some("cat"),
+    )
+    .unwrap();
+    let derived = f.env.global_manifest_file();
+    let landed = dotfiles.join("kendex").join(derived.file_name().unwrap());
+    assert_ne!(
+        derived, landed,
+        "the config directory is reached through a link"
+    );
+    let said = subscribed
+        .report
+        .plan
+        .ops
+        .iter()
+        .map(apply::PlannedOp::line)
+        .find(|line| line.starts_with("Subscribes"))
+        .expect("the subscription writes the manifest");
+
+    assert!(
+        said.ends_with(&landed.display().to_string()),
+        "the preview names the file the write lands in: {said}"
+    );
+    assert!(
+        subscribed.report.notes.contains(&said),
+        "and the note says the same thing: {:?}",
+        subscribed.report.notes
+    );
+}

--- a/crates/core/tests/symlinked_harness_dir.rs
+++ b/crates/core/tests/symlinked_harness_dir.rs
@@ -566,3 +566,74 @@ fn a_name_that_reads_like_a_slot_is_drawn_as_itself() {
         "the name is drawn as itself: {lines:?}"
     );
 }
+
+/// A restore puts bytes back through a link that was there all along.
+///
+/// The journal's paths are its caller's own and need not be landings —
+/// under a temp root reached through a link, which is every temp root on
+/// macOS, none of them is. Judging one by whether it reads as its own
+/// landing refuses every restore there while nothing has moved at all.
+#[test]
+#[allow(clippy::unwrap_used)]
+fn a_restore_reaches_through_a_link_that_never_moved() {
+    let f = fixture();
+    let elsewhere = f.project.join("shared");
+    link_agents_dir(&f, &elsewhere);
+    let held = f.project.join(".agents/skills/ship/SKILL.md");
+    put(&held, "the bytes an apply would put back\n");
+
+    // What an apply that died mid-write leaves behind, recorded at the
+    // spelling its caller had.
+    let dir = apply::journal::journal_dir_for(&f.env.journal_dir(), &apply::scope_key(&f.scope));
+    apply::journal::write(&dir, &[held.clone()]).unwrap();
+    fs::write(&held, "half-written\n").unwrap();
+
+    assert!(apply::recover(&f.env, &f.scope).unwrap(), "recovery ran");
+    assert_eq!(
+        fs::read_to_string(elsewhere.join("skills/ship/SKILL.md")).unwrap(),
+        "the bytes an apply would put back\n",
+        "the pre-image is back at the place the link points at"
+    );
+    assert!(!apply::journal::pending(&dir), "the journal is spent");
+}
+
+/// A journal from a build that did not write down where its paths reached.
+///
+/// Its apply mutated — a journal exists because one did — so the world is
+/// not untouched and the record cannot be discarded as a torn write. Where
+/// those bytes came from is the one thing it does not say, and a restore
+/// that supplied an answer would be guessing. It stands, for a person.
+#[test]
+#[allow(clippy::unwrap_used)]
+fn a_journal_that_never_said_where_its_paths_reached_is_refused() {
+    let f = fixture();
+    let held = f.project.join(".agents/skills/ship/SKILL.md");
+    put(&held, "the bytes an apply would put back\n");
+    let dir = apply::journal::journal_dir_for(&f.env.journal_dir(), &apply::scope_key(&f.scope));
+    apply::journal::write(&dir, &[held.clone()]).unwrap();
+
+    // The shape an older build wrote: every entry, no landing.
+    let meta = dir.join("meta.json");
+    let mut record: serde_json::Value =
+        serde_json::from_str(&fs::read_to_string(&meta).unwrap()).unwrap();
+    for entry in record["entries"].as_array_mut().unwrap() {
+        entry.as_object_mut().unwrap().remove("landed");
+    }
+    fs::write(&meta, serde_json::to_string_pretty(&record).unwrap()).unwrap();
+    fs::write(&held, "half-written\n").unwrap();
+
+    let refused = apply::recover(&f.env, &f.scope).unwrap_err();
+    assert!(
+        matches!(&refused, CoreError::UnrecordedLanding { path } if *path == held),
+        "{refused}"
+    );
+    assert_eq!(
+        fs::read_to_string(&held).unwrap(),
+        "half-written\n",
+        "nothing was put back over the half-written bytes"
+    );
+    assert!(
+        apply::journal::pending(&dir),
+        "the journal stands, for a person to look at"
+    );
+}

--- a/crates/core/tests/symlinked_harness_dir.rs
+++ b/crates/core/tests/symlinked_harness_dir.rs
@@ -69,6 +69,18 @@ fn link_agents_dir(f: &Fixture, target: &Path) {
     std::os::unix::fs::symlink(target, f.project.join(".agents")).unwrap();
 }
 
+/// The place a refused op's path now reaches, when that is why it was
+/// refused.
+fn moved_target(error: &CoreError) -> Option<PathBuf> {
+    match error {
+        // Refused as its op's turn came, so the transaction rolled back
+        // what ran before it.
+        CoreError::RolledBack { cause, .. } => moved_target(cause),
+        CoreError::TargetMoved { now, .. } => Some(now.clone()),
+        _ => None,
+    }
+}
+
 /// Where the plan says this skill's tree goes.
 fn planned_tree(plan: &apply::Plan) -> Vec<PathBuf> {
     plan.ops
@@ -166,5 +178,171 @@ fn a_recorded_path_that_now_lands_outside_takes_nothing_with_it() {
     assert_eq!(
         fs::read_to_string(victim.join("skills/ship/SKILL.md")).unwrap(),
         "Not kendex's.\n"
+    );
+}
+
+/// Between the plan and the apply the project directory is renamed and a
+/// link left in its place. Every planned path still spells the old
+/// project, so nothing about it reads as outside a scope root; what says
+/// so is that the paths no longer land where the plan put them.
+#[test]
+#[allow(clippy::unwrap_used)]
+fn a_project_directory_swapped_for_a_link_stops_the_apply() {
+    let f = fixture();
+    let report = audit(&f.env, &f.scope).unwrap();
+
+    let moved = f.home.join("moved");
+    let victim = f.home.join("victim");
+    fs::create_dir_all(&victim).unwrap();
+    fs::rename(&f.project, &moved).unwrap();
+    std::os::unix::fs::symlink(&victim, &f.project).unwrap();
+
+    let refused = apply::execute(&f.env, &report.plan, None).unwrap_err();
+    assert!(
+        matches!(moved_target(&refused), Some(now) if now.starts_with(&victim)),
+        "the refusal names where the write would have gone: {refused}"
+    );
+    assert!(
+        !victim.join(".agents").exists(),
+        "nothing was written through the replacement link"
+    );
+}
+
+/// The same swap, to a folder still inside the project. Containment holds
+/// the whole way through, so only comparing against the landing the plan
+/// showed catches it.
+#[test]
+#[allow(clippy::unwrap_used)]
+fn an_ancestor_swapped_for_a_link_inside_the_project_stops_the_apply() {
+    let f = fixture();
+    let report = audit(&f.env, &f.scope).unwrap();
+
+    let elsewhere = f.project.join("elsewhere");
+    fs::create_dir_all(&elsewhere).unwrap();
+    std::os::unix::fs::symlink(&elsewhere, f.project.join(".agents")).unwrap();
+
+    let refused = apply::execute(&f.env, &report.plan, None).unwrap_err();
+    assert_eq!(
+        moved_target(&refused),
+        Some(elsewhere.join("skills/ship")),
+        "the refusal names the position inside the project the write moved to: {refused}"
+    );
+    assert!(
+        !elsewhere.join("skills").exists(),
+        "the write did not follow the link"
+    );
+}
+
+/// One op in the plan makes the link the next op's path would be reached
+/// through. Nothing is wrong when the plan is made, which is why the
+/// question is asked again as each op's turn comes.
+#[test]
+#[allow(clippy::unwrap_used)]
+fn a_link_an_earlier_op_creates_stops_the_op_behind_it() {
+    let f = fixture();
+    let victim = f.home.join("victim");
+    fs::create_dir_all(&victim).unwrap();
+    let link = f.project.join("link");
+
+    let plan = apply::Plan::landed(
+        f.scope.clone(),
+        vec![
+            apply::PlannedOp {
+                description: "make the link".into(),
+                op: Op::Symlink {
+                    link: link.clone(),
+                    target: victim.clone(),
+                    pre: apply::Pre::Absent,
+                },
+            },
+            apply::PlannedOp {
+                description: "write behind it".into(),
+                op: Op::WriteFile {
+                    path: link.join("taken"),
+                    bytes: b"kendex's".to_vec(),
+                    pre: apply::Pre::Absent,
+                },
+            },
+        ],
+    )
+    .unwrap();
+
+    let refused = apply::execute(&f.env, &plan, None).unwrap_err();
+    assert_eq!(
+        moved_target(&refused),
+        Some(victim.join("taken")),
+        "the second op is refused by where its path now reaches: {refused}"
+    );
+    assert!(!victim.join("taken").exists(), "nothing was written there");
+    assert!(
+        !link.exists() && !link.is_symlink(),
+        "the first op rolled back"
+    );
+}
+
+/// A link the landing moved has to keep meaning what it meant. Its text is
+/// read from the parent it sits in, and landing gave it another one.
+#[test]
+#[allow(clippy::unwrap_used)]
+fn a_link_the_landing_moved_still_reaches_the_tree_it_named() {
+    let f = fixture();
+    let shared = f.project.join("shared");
+    fs::create_dir_all(&shared).unwrap();
+    fs::create_dir_all(f.project.join(".claude")).unwrap();
+    std::os::unix::fs::symlink(&shared, f.project.join(".claude/skills")).unwrap();
+
+    let report = audit(&f.env, &f.scope).unwrap();
+    apply::execute(&f.env, &report.plan, None).unwrap();
+
+    let landed = shared.join("ship");
+    assert!(
+        landed.is_symlink(),
+        "the link landed through .claude/skills"
+    );
+    let destination = fs::canonicalize(&landed).unwrap();
+    assert_eq!(
+        destination,
+        fs::canonicalize(f.project.join(".agents/skills/ship")).unwrap(),
+        "it reaches the tree it was made to reach"
+    );
+    assert_eq!(
+        fs::read_to_string(landed.join("SKILL.md")).unwrap(),
+        "---\nname: ship\ndescription: ship\n---\n\nShip the branch.\n",
+    );
+}
+
+/// An apply that never finished leaves pre-images to put back. They go
+/// back where they were taken from, so a directory swapped for a link in
+/// the meantime stops the restore rather than sending somebody's bytes
+/// through it.
+#[test]
+#[allow(clippy::unwrap_used)]
+fn a_restore_whose_path_moved_is_refused_and_leaves_the_journal() {
+    let f = fixture();
+    let held = f.project.join(".agents/skills/ship/SKILL.md");
+    put(&held, "the bytes an apply would put back\n");
+
+    // What an apply that died mid-write leaves behind.
+    let dir = apply::journal::journal_dir_for(&f.env.journal_dir(), &apply::scope_key(&f.scope));
+    apply::journal::write(&dir, &[held.clone()]).unwrap();
+
+    let victim = f.home.join("victim");
+    fs::create_dir_all(&victim).unwrap();
+    fs::remove_dir_all(f.project.join(".agents")).unwrap();
+    std::os::unix::fs::symlink(&victim, f.project.join(".agents")).unwrap();
+
+    let refused = apply::recover(&f.env, &f.scope).unwrap_err();
+    assert_eq!(
+        moved_target(&refused),
+        Some(victim.join("skills/ship/SKILL.md")),
+        "the restore is refused by where the path now reaches: {refused}"
+    );
+    assert!(
+        !victim.join("skills").exists(),
+        "nothing was restored through the link"
+    );
+    assert!(
+        apply::journal::pending(&dir),
+        "the journal stands, for a person to look at"
     );
 }

--- a/crates/core/tests/symlinked_harness_dir.rs
+++ b/crates/core/tests/symlinked_harness_dir.rs
@@ -92,6 +92,17 @@ fn planned_tree(plan: &apply::Plan) -> Vec<PathBuf> {
         .collect()
 }
 
+/// Where the plan puts this skill's harness link.
+fn planned_links(plan: &apply::Plan) -> Vec<PathBuf> {
+    plan.ops
+        .iter()
+        .filter_map(|planned| match &planned.op {
+            Op::Symlink { link, .. } => Some(link.clone()),
+            _ => None,
+        })
+        .collect()
+}
+
 /// A link inside the scope is followed: the bytes land at its target, and
 /// the plan names that position rather than the spelling it was joined
 /// from. A plan naming the joined spelling would describe a write that
@@ -344,5 +355,39 @@ fn a_restore_whose_path_moved_is_refused_and_leaves_the_journal() {
     assert!(
         apply::journal::pending(&dir),
         "the journal stands, for a person to look at"
+    );
+}
+
+/// The dotfiles shape at global scope: the harness directory is a link
+/// into a repository the person keeps their config in. Nothing encloses
+/// the global scope, so there is no root for the write to leave — it goes
+/// where the link points, and the plan says so.
+#[test]
+#[allow(clippy::unwrap_used)]
+fn a_global_harness_directory_kept_in_a_dotfiles_repo_is_written_through() {
+    let f = fixture();
+    let dotfiles = f.home.join("dotfiles/.claude");
+    fs::create_dir_all(dotfiles.join("skills")).unwrap();
+    std::os::unix::fs::symlink(&dotfiles, f.home.join(".claude")).unwrap();
+    put(
+        &f.env.global_manifest_file(),
+        &format!(
+            "schema = 6\n\n[sources.cat]\npath = \"{}\"\n\n[install]\nharnesses = [\"claude\"]\n\n[skills.ship]\nsource = \"cat\"\n",
+            f.home.join("catalog").display()
+        ),
+    );
+
+    let report = audit(&f.env, &Scope::Global).unwrap();
+    assert_eq!(
+        planned_links(&report.plan),
+        vec![dotfiles.join("skills/ship")],
+        "the plan names the place the link points at"
+    );
+
+    apply::execute(&f.env, &report.plan, None).unwrap();
+    assert_eq!(
+        fs::read_to_string(dotfiles.join("skills/ship/SKILL.md")).unwrap(),
+        "---\nname: ship\ndescription: ship\n---\n\nShip the branch.\n",
+        "the bytes are readable through the person's link"
     );
 }

--- a/crates/core/tests/symlinked_harness_dir.rs
+++ b/crates/core/tests/symlinked_harness_dir.rs
@@ -1,0 +1,170 @@
+//! A harness directory somebody pointed somewhere else.
+//!
+//! The two answers pull against each other. A link inside the scope is a
+//! layout, not an attack: the write goes where the link points and the plan
+//! says so. A link that leaves the scope root is refused, and the refusal
+//! names the place it would have written.
+#![cfg(unix)]
+
+use std::fs;
+use std::path::{Path, PathBuf};
+
+use kendex_core::apply::{self, Op};
+use kendex_core::engine::audit;
+use kendex_core::env::{Env, FakeOs};
+use kendex_core::error::CoreError;
+use kendex_core::model::Scope;
+
+struct Fixture {
+    _tmp: tempfile::TempDir,
+    env: Env,
+    scope: Scope,
+    home: PathBuf,
+    project: PathBuf,
+}
+
+#[allow(clippy::unwrap_used)]
+fn put(path: &Path, text: &str) {
+    fs::create_dir_all(path.parent().unwrap()).unwrap();
+    fs::write(path, text).unwrap();
+}
+
+/// A project declaring one skill from a path source beside it. The temp
+/// root is resolved: on macOS it is reached through `/var -> private/var`,
+/// and a fixture spelling the unresolved form would compare against
+/// nothing the engine produces.
+#[allow(clippy::unwrap_used)]
+fn fixture() -> Fixture {
+    let tmp = tempfile::tempdir().unwrap();
+    let home = tmp.path().canonicalize().unwrap();
+    let project = home.join("dev/app");
+    let source = home.join("catalog");
+    put(
+        &source.join("skills/ship/SKILL.md"),
+        "---\nname: ship\ndescription: ship\n---\n\nShip the branch.\n",
+    );
+    put(
+        &project.join("kendex.toml"),
+        &format!(
+            "schema = 6\n\n[sources.cat]\npath = \"{}\"\n\n[install]\nharnesses = [\"claude\"]\n\n[skills.ship]\nsource = \"cat\"\n",
+            source.display()
+        ),
+    );
+    Fixture {
+        env: Env::fake(&home, FakeOs::Linux),
+        scope: Scope::Project {
+            root: project.clone(),
+        },
+        home,
+        project,
+        _tmp: tmp,
+    }
+}
+
+/// Point the shared tree's directory at `target`, the way a person who
+/// keeps that folder somewhere else would.
+#[allow(clippy::unwrap_used)]
+fn link_agents_dir(f: &Fixture, target: &Path) {
+    fs::create_dir_all(target).unwrap();
+    std::os::unix::fs::symlink(target, f.project.join(".agents")).unwrap();
+}
+
+/// Where the plan says this skill's tree goes.
+fn planned_tree(plan: &apply::Plan) -> Vec<PathBuf> {
+    plan.ops
+        .iter()
+        .filter_map(|planned| match &planned.op {
+            Op::WriteTree { root, .. } => Some(root.clone()),
+            _ => None,
+        })
+        .collect()
+}
+
+/// A link inside the scope is followed: the bytes land at its target, and
+/// the plan names that position rather than the spelling it was joined
+/// from. A plan naming the joined spelling would describe a write that
+/// happens elsewhere.
+#[test]
+#[allow(clippy::unwrap_used)]
+fn a_link_inside_the_scope_is_written_through_and_planned_by_where_it_lands() {
+    let f = fixture();
+    let elsewhere = f.project.join("shared");
+    link_agents_dir(&f, &elsewhere);
+
+    let report = audit(&f.env, &f.scope).unwrap();
+    assert_eq!(
+        planned_tree(&report.plan),
+        vec![elsewhere.join("skills/ship")],
+        "the plan names the place the link points at"
+    );
+
+    apply::execute(&f.env, &report.plan, None).unwrap();
+    assert_eq!(
+        fs::read_to_string(elsewhere.join("skills/ship/SKILL.md")).unwrap(),
+        "---\nname: ship\ndescription: ship\n---\n\nShip the branch.\n",
+        "the bytes are through the link, at its target"
+    );
+}
+
+/// A link that leaves the scope root is refused, naming where the write
+/// would have gone, and nothing is written there.
+#[test]
+#[allow(clippy::unwrap_used)]
+fn a_link_out_of_the_scope_is_refused_by_the_place_it_lands() {
+    let f = fixture();
+    let outside = f.home.join("victim");
+    link_agents_dir(&f, &outside);
+
+    let refused = audit(&f.env, &f.scope).unwrap_err();
+    let CoreError::ScopeEscape { landed, root, .. } = refused else {
+        panic!("a write out of the scope must be refused: {refused}");
+    };
+    assert_eq!(landed, outside.join("skills/ship"));
+    assert_eq!(root, f.project);
+    assert!(
+        !outside.join("skills").exists(),
+        "the refusal wrote nothing at the far end"
+    );
+}
+
+/// The record's own paths are held to the same rule. A lock names a
+/// position under the project, and the write it licenses is a removal —
+/// so a directory on the way to it that points out of the project takes a
+/// tree at the far end unless the landing is judged.
+#[test]
+#[allow(clippy::unwrap_used)]
+fn a_recorded_path_that_now_lands_outside_takes_nothing_with_it() {
+    let f = fixture();
+    let report = audit(&f.env, &f.scope).unwrap();
+    apply::execute(&f.env, &report.plan, None).unwrap();
+
+    // The same position the lock recorded, reached through a link out of
+    // the project, with somebody else's tree at the end of it.
+    let victim = f.home.join("victim");
+    put(&victim.join("skills/ship/SKILL.md"), "Not kendex's.\n");
+    fs::remove_dir_all(f.project.join(".agents")).unwrap();
+    std::os::unix::fs::symlink(&victim, f.project.join(".agents")).unwrap();
+
+    put(
+        &f.project.join("kendex.toml"),
+        "schema = 6\n\n[install]\nharnesses = [\"claude\"]\n",
+    );
+    let refused = kendex_core::engine::plan_apply(
+        &f.env,
+        &f.scope,
+        &kendex_core::engine::PlanOptions {
+            remove_orphans: true,
+            removal_filter: Some(vec!["ship".into()]),
+            ..kendex_core::engine::PlanOptions::default()
+        },
+    )
+    .unwrap_err();
+    let CoreError::ScopeEscape { landed, .. } = refused else {
+        panic!("a removal landing out of the scope must be refused: {refused}");
+    };
+    assert_eq!(landed, victim.join("skills/ship"));
+    assert_eq!(
+        fs::read_to_string(victim.join("skills/ship/SKILL.md")).unwrap(),
+        "Not kendex's.\n"
+    );
+}

--- a/crates/core/tests/unmanaged_check/main.rs
+++ b/crates/core/tests/unmanaged_check/main.rs
@@ -209,10 +209,7 @@ fn bytes_that_already_match_are_never_prescribed_a_replacement() {
         re.drift
     );
     assert!(
-        !re.plan
-            .ops
-            .iter()
-            .any(|op| op.description.contains("trash")),
+        !re.plan.ops.iter().any(|op| op.line().contains("trash")),
         "and nothing needed replacing: {:?}",
         re.plan.ops
     );

--- a/crates/core/tests/unmanaged_ownership.rs
+++ b/crates/core/tests/unmanaged_ownership.rs
@@ -340,11 +340,11 @@ fn the_take_over_shows_the_path_it_moves() {
         ..PlanOptions::default()
     };
     let report = plan_apply(&env, &scope, &taking_over).unwrap();
-    let moves: Vec<&str> = report
+    let moves: Vec<String> = report
         .plan
         .ops
         .iter()
-        .map(|op| op.description.as_str())
+        .map(|op| op.line())
         .filter(|line| line.starts_with("Move the files already at"))
         .collect();
     assert!(!moves.is_empty(), "nothing was moved out of the way");

--- a/crates/core/tests/unmanaged_shapes.rs
+++ b/crates/core/tests/unmanaged_shapes.rs
@@ -179,7 +179,7 @@ fn one_tree_shared_by_two_tools_is_moved_aside_once() {
         .plan
         .ops
         .iter()
-        .filter(|op| op.description.starts_with("Move the files already at"))
+        .filter(|op| op.line().starts_with("Move the files already at"))
         .count();
     assert_eq!(moves, 1, "{:?}", report.plan.ops);
     apply::execute(&w.env, &report.plan, None).unwrap();
@@ -271,11 +271,11 @@ fn a_tree_write_says_which_tool_it_is_for() {
     fs::write(blocked.join("SKILL.md"), BEFORE).unwrap();
 
     let report = plan_apply(&w.env, &w.scope, &PlanOptions::default()).unwrap();
-    let written: Vec<&String> = report
+    let written: Vec<String> = report
         .plan
         .ops
         .iter()
-        .map(|op| &op.description)
+        .map(|op| op.line())
         .filter(|line| line.contains("deploy's files"))
         .collect();
     assert_eq!(

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -195,10 +195,10 @@ lives in one capability table read by core and UI.
 17. One spelling per path, fixed once where the root enters: a scope root at
     each derivation helper (`Scope::canonical` in `manifest_path`,
     `lock_path`), a source root at `SealedSource::open`, a declared path at
-    `source::resolve`, a plan's targets at `Plan::landed`, which refuses a
-    landing outside the scope root and which every later use is held to. No
-    comparison meets two spellings of one file (macOS fronts `/var` with
-    `/private/var`), and git is handed the repository's own.
+    `source::resolve`, a plan's targets at `Plan::landed`, which refuses an
+    inside spelling that lands outside the root and which every later use is
+    held to. No comparison meets two spellings of one file (macOS fronts
+    `/var` with `/private/var`), and git is handed the repository's own.
 
 ## Decisions
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -194,11 +194,11 @@ lives in one capability table read by core and UI.
     package sees the real home.
 17. One spelling per path, fixed once where the root enters: a scope root at
     each derivation helper (`Scope::canonical` in `manifest_path`,
-    `lock_path`, plan entries), a source root at `SealedSource::open`, a
-    declared path at `source::resolve`, a plan's targets at `Plan::landed` —
-    one landing outside the scope root is refused. No comparison may meet
-    two spellings of one file (macOS fronts `/var` with `/private/var`), and
-    a path handed to git speaks the repository's own.
+    `lock_path`), a source root at `SealedSource::open`, a declared path at
+    `source::resolve`, a plan's targets at `Plan::landed`, which refuses a
+    landing outside the scope root and which every later use is held to. No
+    comparison meets two spellings of one file (macOS fronts `/var` with
+    `/private/var`), and git is handed the repository's own.
 
 ## Decisions
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -192,13 +192,13 @@ lives in one capability table read by core and UI.
     absolute path is used as written; a child process inherits this
     process's environment (`process/mod.rs`), so `npm` run for a Pi
     package sees the real home.
-17. One spelling per path, fixed once where the root enters: a scope root
-    at each derivation helper (`Scope::canonical` in `manifest_path`,
-    `lock_path`, and the engine's plan entries),
-    a source root at `SealedSource::open`, a declared path at
-    `source::resolve`. Nothing re-canonicalizes downstream, no comparison
-    may meet two spellings of one file (macOS fronts `/var` with
-    `/private/var`), and a path handed to git speaks the repository's own.
+17. One spelling per path, fixed once where the root enters: a scope root at
+    each derivation helper (`Scope::canonical` in `manifest_path`,
+    `lock_path`, plan entries), a source root at `SealedSource::open`, a
+    declared path at `source::resolve`, a plan's targets at `Plan::landed` —
+    one landing outside the scope root is refused. No comparison may meet
+    two spellings of one file (macOS fronts `/var` with `/private/var`), and
+    a path handed to git speaks the repository's own.
 
 ## Decisions
 

--- a/tools/size-ratchet-baseline.tsv
+++ b/tools/size-ratchet-baseline.tsv
@@ -1,6 +1,6 @@
 .github/workflows/review-gate-writer.yml	662
 .github/workflows/skill-tests.yml	429
-crates/core/src/engine/detach.rs	444
+crates/core/src/engine/detach.rs	441
 crates/core/src/engine/pi_hooks_move/migrated.rs	540
 crates/core/src/engine/pi_hooks_move/mod.rs	503
 crates/core/src/engine/pi_hooks_move/preflight.rs	765

--- a/tools/size-ratchet-baseline.tsv
+++ b/tools/size-ratchet-baseline.tsv
@@ -4,7 +4,7 @@ crates/core/src/engine/detach.rs	444
 crates/core/src/engine/pi_hooks_move/migrated.rs	540
 crates/core/src/engine/pi_hooks_move/mod.rs	503
 crates/core/src/engine/pi_hooks_move/preflight.rs	765
-crates/core/src/error.rs	481
+crates/core/src/error.rs	484
 crates/core/src/remote/store.rs	405
 crates/core/src/settings_file.rs	408
 docs/ARCHITECTURE.md	801

--- a/tools/size-ratchet-baseline.tsv
+++ b/tools/size-ratchet-baseline.tsv
@@ -4,7 +4,7 @@ crates/core/src/engine/detach.rs	444
 crates/core/src/engine/pi_hooks_move/migrated.rs	540
 crates/core/src/engine/pi_hooks_move/mod.rs	503
 crates/core/src/engine/pi_hooks_move/preflight.rs	765
-crates/core/src/error.rs	478
+crates/core/src/error.rs	481
 crates/core/src/remote/store.rs	405
 crates/core/src/settings_file.rs	408
 docs/ARCHITECTURE.md	801

--- a/tools/size-ratchet-baseline.tsv
+++ b/tools/size-ratchet-baseline.tsv
@@ -4,7 +4,7 @@ crates/core/src/engine/detach.rs	444
 crates/core/src/engine/pi_hooks_move/migrated.rs	540
 crates/core/src/engine/pi_hooks_move/mod.rs	503
 crates/core/src/engine/pi_hooks_move/preflight.rs	765
-crates/core/src/error.rs	471
+crates/core/src/error.rs	478
 crates/core/src/remote/store.rs	405
 crates/core/src/settings_file.rs	408
 docs/ARCHITECTURE.md	801


### PR DESCRIPTION
Containment was judged on the spelling a target was joined from, and only the target's own name was ever asked whether it was a link. A `.claude/hooks` or `.agents` somebody pointed elsewhere therefore read as inside the scope while every write through it landed at the far end — and a lock recording such a position had its removal trashed there too.

## The rule

Every op's targets are landed once, at `Plan::landed`: the directories between the canonical scope root and the target are followed, and the target's own name is left as it is, so a foreign link at the leaf stays the conflict it already was. A landing inside the root is what the plan shows and what apply writes. A landing outside it is refused by that position's name.

`apply::execute` asks the same question again under the scope lock, so a plan built elsewhere, appended to after it was shown, or whose directory was swapped for a link between preview and write, still cannot reach out of the scope.

**Both halves of the Done-when are load-bearing and pull against each other.** A user who symlinked their own dotfile directory gets their write where the link points — that is their layout, not an attack — and only a parent link resolving outside the scope root is refused. A fix that refuses all symlinked harness dirs satisfies neither, and running exactly that control turns the first test red while the second stays green.

## Why a new write site cannot bypass it

The enumeration comes off `Op::touched()`, which already had to list every mutated path for the journal. `Op::touched_mut()` sits beside it borrowing the same exhaustive match, so a new `Op` variant can no more skip the landing than it can skip the journal — the compiler forces both arms.

Every project-scope write in this tree is a `PlannedOp`. Reproduce the sweep by checking the three ways one could avoid being: direct record writes (`lock::save`, `manifest::save` — both callers are inside `Op::run`), direct filesystem writes outside `apply/` (all inside `#[cfg(test)]`), and a second executor (`run_journaled` has two callers; the other is `execute_common`, deliberately unjudged because repository-common state lives in the git common dir, outside the scope root by design).

## Scope

Derivations are unchanged: `desired/places.rs` and `engine/targets.rs` keep producing the joined spelling, as do the artifact fields, `emitted.paths`, the `owned` set and `TrashGuard::keep` — all compared only against each other, so they stay consistent. Only what the plan shows, what apply writes, and what a removal takes move to the landing. That is why the recorded-path case closes with no patch at its own site: `removal_ops` builds its Trash op from the recorded path and `Plan::landed` lands it before anything runs.

`source::slot_escapes` is untouched and both call sites are intact. It guards a different boundary — the local source root, via the sealed reader, so that bytes written can be read back — which is tighter than "inside the scope" and is not this rule's question.

Adoption is deliberately outside the rule: it legitimately mutates the folder a user's own link points at, outside the project. This rule only judges a path that reads as inside the root; a path that says outside is its own caller's boundary.

## Tests

`crates/core/tests/symlinked_harness_dir.rs`, each asserting the op's path, the bytes on disk, and the error's fields — never a message `contains`:

- `a_link_inside_the_scope_is_written_through_and_planned_by_where_it_lands`
- `a_link_out_of_the_scope_is_refused_by_the_place_it_lands`
- `a_recorded_path_that_now_lands_outside_takes_nothing_with_it`

Each is red under the pre-fix shape. A unit control in `landing.rs` covers a `..` that survives because no directory resolves it.

## Note for review

`error.rs` takes `RATCHET_RAISE` 448 → 455 — a refusal is one variant in an error enum, which has no seam to split at. To avoid a second raise, `Plan` and `PlannedOp` moved out of `op.rs` into `apply/plan.rs`, which is where `Plan::landed` belongs; `detach.rs` tightened 547 → 544. `docs/ARCHITECTURE.md` invariant 17 said "Nothing re-canonicalizes downstream", which the landing does, so it is reworded within the same seven lines; the file is still exactly 801.

`Op::WriteExecutable`, `Op::GitConfigSwap` and `apply::execute_common` have no producers or callers in this tree. They are left alone, and `touched_mut` covers both op variants so the landing does not depend on what they turn out to be.

Closes KEN-474
