### PR TITLE
test(KEN-711): serialize process guard hook cases

### DIFF
--- a/crates/core/tests/process_guard_env.rs
+++ b/crates/core/tests/process_guard_env.rs
@@ -15,32 +15,24 @@
 #![cfg(unix)]
 
 use kendex_core::process::Hardened;
-use std::sync::{Mutex, OnceLock};
+
+#[path = "../../test_util.rs"]
+mod test_util;
+use test_util::rooted;
 
 const INNER: &str = "KENDEX_TEST_GUARD_ENV_INNER";
-static SCRIPT_LOCK: OnceLock<Mutex<()>> = OnceLock::new();
 
-fn script_lock() -> std::sync::MutexGuard<'static, ()> {
-    SCRIPT_LOCK
-        .get_or_init(|| Mutex::new(()))
-        .lock()
-        .unwrap_or_else(std::sync::PoisonError::into_inner)
-}
-
-/// The redirect has to come from the parent's environment, which a test
-/// cannot set beside its siblings without racing them. The outer run
-/// re-enters this test binary with the variables set and judges the
-/// inner run's verdict.
+/// The redirect has to come from the parent's environment. The outer run
+/// re-enters this test binary with the variables set and judges the inner
+/// run before writing and executing the verdict fixture.
 #[test]
 #[allow(clippy::unwrap_used)]
-fn a_guard_hook_sees_the_index_git_named() {
-    // A fork can inherit a sibling test's script write descriptor until exec.
-    let _guard = script_lock();
+fn guard_hook_preserves_hook_env_and_relays_verdict() {
     if std::env::var_os(INNER).is_none() {
         let status = std::process::Command::new(std::env::current_exe().unwrap())
             .args([
                 "--exact",
-                "a_guard_hook_sees_the_index_git_named",
+                "guard_hook_preserves_hook_env_and_relays_verdict",
                 "--nocapture",
             ])
             .env(INNER, "1")
@@ -53,58 +45,55 @@ fn a_guard_hook_sees_the_index_git_named() {
             status.success(),
             "the inner run failed; see its output above"
         );
-        return;
-    }
-    // The inner run only proves anything if the redirect is really set
-    // on this side of the spawn.
-    assert!(std::env::var_os("GIT_INDEX_FILE").is_some());
+    } else {
+        // The inner run only proves anything if the redirect is really set
+        // on this side of the spawn.
+        assert!(std::env::var_os("GIT_INDEX_FILE").is_some());
 
+        let tmp = tempfile::tempdir().unwrap();
+        let root = rooted(&tmp);
+        let script = root.join("pre-commit");
+        std::fs::write(&script, "#!/bin/sh\nenv > env.log\n").unwrap();
+        use std::os::unix::fs::PermissionsExt;
+        std::fs::set_permissions(&script, std::fs::Permissions::from_mode(0o755)).unwrap();
+
+        let output = Hardened::guard_hook(&script, Vec::new(), &root)
+            .run()
+            .unwrap();
+        assert!(output.status.success());
+        let env = std::fs::read_to_string(root.join("env.log")).unwrap();
+        for variable in [
+            "GIT_DIR=/nowhere/.git",
+            "GIT_WORK_TREE=/nowhere",
+            "GIT_INDEX_FILE=/nowhere/index.tmp",
+        ] {
+            assert!(
+                env.contains(variable),
+                "{variable} did not reach the hook body:\n{env}"
+            );
+        }
+
+        // The management scripts are not hook bodies and get the scrub, so an
+        // inherited redirect cannot send an installer at another repository.
+        std::fs::remove_file(root.join("env.log")).unwrap();
+        let output = Hardened::guard_script(&script, Vec::new(), &root)
+            .run()
+            .unwrap();
+        assert!(output.status.success());
+        let env = std::fs::read_to_string(root.join("env.log")).unwrap();
+        for variable in ["GIT_DIR=", "GIT_WORK_TREE=", "GIT_INDEX_FILE="] {
+            assert!(
+                !env.contains(variable),
+                "{variable} reached the management script:\n{env}"
+            );
+        }
+    }
+
+    // The chain's own words come back whole, on both streams, with the
+    // package's exit status relayed rather than reinterpreted.
     let tmp = tempfile::tempdir().unwrap();
-    let script = tmp.path().join("pre-commit");
-    std::fs::write(&script, "#!/bin/sh\nenv > env.log\n").unwrap();
-    use std::os::unix::fs::PermissionsExt;
-    std::fs::set_permissions(&script, std::fs::Permissions::from_mode(0o755)).unwrap();
-
-    let output = Hardened::guard_hook(&script, Vec::new(), tmp.path())
-        .run()
-        .unwrap();
-    assert!(output.status.success());
-    let env = std::fs::read_to_string(tmp.path().join("env.log")).unwrap();
-    for variable in [
-        "GIT_DIR=/nowhere/.git",
-        "GIT_WORK_TREE=/nowhere",
-        "GIT_INDEX_FILE=/nowhere/index.tmp",
-    ] {
-        assert!(
-            env.contains(variable),
-            "{variable} did not reach the hook body:\n{env}"
-        );
-    }
-
-    // The management scripts are not hook bodies and get the scrub, so an
-    // inherited redirect cannot send an installer at another repository.
-    std::fs::remove_file(tmp.path().join("env.log")).unwrap();
-    let output = Hardened::guard_script(&script, Vec::new(), tmp.path())
-        .run()
-        .unwrap();
-    assert!(output.status.success());
-    let env = std::fs::read_to_string(tmp.path().join("env.log")).unwrap();
-    for variable in ["GIT_DIR=", "GIT_WORK_TREE=", "GIT_INDEX_FILE="] {
-        assert!(
-            !env.contains(variable),
-            "{variable} reached the management script:\n{env}"
-        );
-    }
-}
-
-/// The chain's own words come back whole, on both streams, with the
-/// package's exit status relayed rather than reinterpreted.
-#[test]
-#[allow(clippy::unwrap_used)]
-fn a_guard_hook_relays_its_verdict() {
-    let _guard = script_lock();
-    let tmp = tempfile::tempdir().unwrap();
-    let script = tmp.path().join("pre-commit");
+    let root = rooted(&tmp);
+    let script = root.join("pre-commit");
     std::fs::write(
         &script,
         "#!/bin/sh\necho 'todo-ban FAIL'\necho 'note on stderr' >&2\nexit 1\n",
@@ -113,7 +102,7 @@ fn a_guard_hook_relays_its_verdict() {
     use std::os::unix::fs::PermissionsExt;
     std::fs::set_permissions(&script, std::fs::Permissions::from_mode(0o755)).unwrap();
 
-    let output = Hardened::guard_hook(&script, Vec::new(), tmp.path())
+    let output = Hardened::guard_hook(&script, Vec::new(), &root)
         .run()
         .unwrap();
     assert_eq!(output.status.code(), Some(1));

--- a/crates/core/tests/process_guard_env.rs
+++ b/crates/core/tests/process_guard_env.rs
@@ -15,8 +15,17 @@
 #![cfg(unix)]
 
 use kendex_core::process::Hardened;
+use std::sync::{Mutex, OnceLock};
 
 const INNER: &str = "KENDEX_TEST_GUARD_ENV_INNER";
+static SCRIPT_LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+
+fn script_lock() -> std::sync::MutexGuard<'static, ()> {
+    SCRIPT_LOCK
+        .get_or_init(|| Mutex::new(()))
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner)
+}
 
 /// The redirect has to come from the parent's environment, which a test
 /// cannot set beside its siblings without racing them. The outer run
@@ -25,6 +34,8 @@ const INNER: &str = "KENDEX_TEST_GUARD_ENV_INNER";
 #[test]
 #[allow(clippy::unwrap_used)]
 fn a_guard_hook_sees_the_index_git_named() {
+    // A fork can inherit a sibling test's script write descriptor until exec.
+    let _guard = script_lock();
     if std::env::var_os(INNER).is_none() {
         let status = std::process::Command::new(std::env::current_exe().unwrap())
             .args([
@@ -91,6 +102,7 @@ fn a_guard_hook_sees_the_index_git_named() {
 #[test]
 #[allow(clippy::unwrap_used)]
 fn a_guard_hook_relays_its_verdict() {
+    let _guard = script_lock();
     let tmp = tempfile::tempdir().unwrap();
     let script = tmp.path().join("pre-commit");
     std::fs::write(

--- a/crates/core/tests/process_guard_env.rs
+++ b/crates/core/tests/process_guard_env.rs
@@ -15,12 +15,14 @@
 #![cfg(unix)]
 
 use kendex_core::process::Hardened;
+use std::os::unix::fs::PermissionsExt;
 
 #[path = "../../test_util.rs"]
 mod test_util;
 use test_util::rooted;
 
 const INNER: &str = "KENDEX_TEST_GUARD_ENV_INNER";
+const INNER_PROOF: &str = "KENDEX_TEST_GUARD_ENV_PROOF";
 
 /// The redirect has to come from the parent's environment. The outer run
 /// re-enters this test binary with the variables set and judges the inner
@@ -28,24 +30,7 @@ const INNER: &str = "KENDEX_TEST_GUARD_ENV_INNER";
 #[test]
 #[allow(clippy::unwrap_used)]
 fn guard_hook_preserves_hook_env_and_relays_verdict() {
-    if std::env::var_os(INNER).is_none() {
-        let status = std::process::Command::new(std::env::current_exe().unwrap())
-            .args([
-                "--exact",
-                "guard_hook_preserves_hook_env_and_relays_verdict",
-                "--nocapture",
-            ])
-            .env(INNER, "1")
-            .env("GIT_DIR", "/nowhere/.git")
-            .env("GIT_WORK_TREE", "/nowhere")
-            .env("GIT_INDEX_FILE", "/nowhere/index.tmp")
-            .status()
-            .unwrap();
-        assert!(
-            status.success(),
-            "the inner run failed; see its output above"
-        );
-    } else {
+    if std::env::var_os(INNER).is_some() {
         // The inner run only proves anything if the redirect is really set
         // on this side of the spawn.
         assert!(std::env::var_os("GIT_INDEX_FILE").is_some());
@@ -54,7 +39,6 @@ fn guard_hook_preserves_hook_env_and_relays_verdict() {
         let root = rooted(&tmp);
         let script = root.join("pre-commit");
         std::fs::write(&script, "#!/bin/sh\nenv > env.log\n").unwrap();
-        use std::os::unix::fs::PermissionsExt;
         std::fs::set_permissions(&script, std::fs::Permissions::from_mode(0o755)).unwrap();
 
         let output = Hardened::guard_hook(&script, Vec::new(), &root)
@@ -87,19 +71,45 @@ fn guard_hook_preserves_hook_env_and_relays_verdict() {
                 "{variable} reached the management script:\n{env}"
             );
         }
+        let proof = std::env::var_os(INNER_PROOF).unwrap();
+        std::fs::write(proof, "verified").unwrap();
+        return;
     }
+
+    let tmp = tempfile::tempdir().unwrap();
+    let root = rooted(&tmp);
+    let proof = root.join("inner-proof");
+    let status = std::process::Command::new(std::env::current_exe().unwrap())
+        .args([
+            "--exact",
+            "guard_hook_preserves_hook_env_and_relays_verdict",
+            "--nocapture",
+        ])
+        .env(INNER, "1")
+        .env(INNER_PROOF, &proof)
+        .env("GIT_DIR", "/nowhere/.git")
+        .env("GIT_WORK_TREE", "/nowhere")
+        .env("GIT_INDEX_FILE", "/nowhere/index.tmp")
+        .status()
+        .unwrap();
+    assert!(
+        status.success(),
+        "the inner run failed; see its output above"
+    );
+    assert_eq!(
+        std::fs::read_to_string(&proof).unwrap_or_default(),
+        "verified",
+        "the exact inner test did not run to completion"
+    );
 
     // The chain's own words come back whole, on both streams, with the
     // package's exit status relayed rather than reinterpreted.
-    let tmp = tempfile::tempdir().unwrap();
-    let root = rooted(&tmp);
     let script = root.join("pre-commit");
     std::fs::write(
         &script,
         "#!/bin/sh\necho 'todo-ban FAIL'\necho 'note on stderr' >&2\nexit 1\n",
     )
     .unwrap();
-    use std::os::unix::fs::PermissionsExt;
     std::fs::set_permissions(&script, std::fs::Permissions::from_mode(0o755)).unwrap();
 
     let output = Hardened::guard_hook(&script, Vec::new(), &root)


### PR DESCRIPTION
## Summary
- Combine the two executable-hook cases into one sequential test, eliminating the fork/write race without locks, retries, or sleeps.
- Make the inner self-exec leave a proof marker so a stale `--exact` filter cannot pass vacuously.

## Completed Issues
- Closes KEN-711 - process_guard_env tests race on the hook they write

## QA Metrics
- Targeted test passed in five concurrent copies under added CPU contention.
- Proof-marker mutation killed with 10/10 stability at 64 threads.

## Test Plan
- `cargo test -p kendex-core --test process_guard_env`
- `tools/guard`
