### PR TITLE
fix(KEN-791): a value spanning lines is seeded whole, or named

### DIFF
--- a/changelog.d/fixed/KEN-791.md
+++ b/changelog.d/fixed/KEN-791.md
@@ -1,0 +1,3 @@
+- A settings-template value spanning several lines now seeds whole, instead
+  of an unterminated line that stopped `kendex.settings.toml` parsing. A
+  value nothing closes is named, not written.

--- a/crates/core/src/engine/desired.rs
+++ b/crates/core/src/engine/desired.rs
@@ -147,8 +147,10 @@ pub struct DesiredState {
     pub manifest_update: Option<Manifest>,
     /// `[env]` defaults shipped by enabled skills
     /// (kendex.settings.toml.example), every declaration in order — each
-    /// with the skill that ships it. Seeding writes the first declaration
-    /// of a key; a refresh listens to the key's recorded owner.
+    /// with the skill that ships it, incomplete values included, because a
+    /// key nothing can supply is reported by name. Seeding writes the
+    /// first declaration whose template completes the value; a refresh
+    /// listens to the key's recorded owner.
     pub settings_env: Vec<crate::settings_seed::SeededEnv>,
     /// Where each planned skill's settings template stands: read, absent,
     /// or out of reach. `settings_env` is this same text run through the

--- a/crates/core/src/engine/scope_writes.rs
+++ b/crates/core/src/engine/scope_writes.rs
@@ -278,7 +278,7 @@ pub(super) fn plan_settings_seed(
     if state.settings_env.is_empty() && edits.is_empty() {
         return Ok(Vec::new());
     }
-    let notes = crate::settings_seed::conflict_notes(&state.settings_env);
+    let notes = crate::settings_seed::seed_notes(&state.settings_env);
     let path = crate::settings_seed::settings_file_path(root);
     let file = path
         .file_name()

--- a/crates/core/src/settings_file.rs
+++ b/crates/core/src/settings_file.rs
@@ -347,7 +347,7 @@ fn resolve(edit: &SettingsEdit, templates: &[SeededEnv]) -> Refused<String> {
     let value = match &edit.value {
         SettingsEditValue::Set { value } => value.clone(),
         SettingsEditValue::Reset => {
-            let line = declared.entry.assignment.first().map_or("", String::as_str);
+            let line = declared.entry.opening();
             decoded_value(line).ok_or_else(|| SettingsRefusal::Value {
                 key: edit.key.clone(),
                 problem: format!(

--- a/crates/core/src/settings_file.rs
+++ b/crates/core/src/settings_file.rs
@@ -347,7 +347,7 @@ fn resolve(edit: &SettingsEdit, templates: &[SeededEnv]) -> Refused<String> {
     let value = match &edit.value {
         SettingsEditValue::Set { value } => value.clone(),
         SettingsEditValue::Reset => {
-            let line = declared.entry.lines.last().map_or("", String::as_str);
+            let line = declared.entry.assignment.first().map_or("", String::as_str);
             decoded_value(line).ok_or_else(|| SettingsRefusal::Value {
                 key: edit.key.clone(),
                 problem: format!(

--- a/crates/core/src/settings_file/tests.rs
+++ b/crates/core/src/settings_file/tests.rs
@@ -8,7 +8,8 @@ fn seeded(owner: &str, key: &str, line: &str) -> SeededEnv {
     SeededEnv {
         entry: EnvEntry {
             key: key.to_owned(),
-            lines: vec![format!("# what {key} does"), line.to_owned()],
+            comment: vec![format!("# what {key} does")],
+            assignment: vec![line.to_owned()],
         },
         owner: owner.to_owned(),
     }

--- a/crates/core/src/settings_file/tests.rs
+++ b/crates/core/src/settings_file/tests.rs
@@ -9,7 +9,7 @@ fn seeded(owner: &str, key: &str, line: &str) -> SeededEnv {
         entry: EnvEntry {
             key: key.to_owned(),
             comment: vec![format!("# what {key} does")],
-            assignment: vec![line.to_owned()],
+            assignment: line.to_owned(),
         },
         owner: owner.to_owned(),
     }

--- a/crates/core/src/settings_seed.rs
+++ b/crates/core/src/settings_seed.rs
@@ -47,12 +47,11 @@ pub struct EnvEntry {
     pub comment: Vec<String>,
     /// Every physical line of the assignment, from the one carrying the
     /// `=` through the one that closes the value — a value TOML lets span
-    /// lines is seeded whole or not at all. Empty where nothing closes it.
-    ///
-    /// Held apart from the comment rather than counted off one end of a
-    /// list of both: which lines are the value is the walk's answer, and a
-    /// reader that took all-but-the-last would call a multiline value's
-    /// opening line part of the comment above it.
+    /// lines is seeded whole or not at all. Empty where the template's
+    /// value is not complete text seeding could copy.
+    /// Held apart from the comment because which lines are the value is
+    /// the walk's answer: a reader taking all-but-the-last off one list
+    /// calls a multiline value's opening line part of the comment.
     pub assignment: Vec<String>,
 }
 
@@ -62,11 +61,12 @@ impl EnvEntry {
         self.comment.iter().chain(&self.assignment)
     }
 
-    /// Whether the template's value closes, which is whether there is
-    /// anything here to write. An assignment nothing closes has no
-    /// complete text to seed, so the key is refused by name
-    /// ([`unterminated_notes`]) rather than written half-finished.
-    pub fn closes(&self) -> bool {
+    /// Whether the template spells this value out in full, which is
+    /// whether there is anything here to write. Not the same as ending: a
+    /// value can close, carry on, or break off mid-string, and only the
+    /// first is text seeding may copy. A key with nothing complete behind
+    /// it is refused by name rather than written half-finished.
+    pub fn complete(&self) -> bool {
         !self.assignment.is_empty()
     }
 }
@@ -85,30 +85,6 @@ impl SeededEnv {
     /// ledger hashes it.
     fn comment(&self) -> &[String] {
         trim_blank_edges(&self.entry.comment)
-    }
-
-    /// The default this entry ships, spelled the way a note shows it: the
-    /// decoded value in quotes, or the assignment's right-hand side
-    /// verbatim where the strict reader cannot decode it. Every entry
-    /// `merge` seeds has one, so a note can never drop an owner and then
-    /// name the wrong package as the one whose value lands.
-    ///
-    /// A value spanning lines is shown on the note's one line, its lines
-    /// joined by a space. Shown from the `=` line alone every multiline
-    /// value would read as its bare opening delimiter, and two packages
-    /// shipping different ones would be grouped as agreeing — the note
-    /// exists to say they disagree.
-    fn default_shown(&self) -> String {
-        let line = self.entry.assignment.first().map_or("", String::as_str);
-        if let Some(value) = crate::settings_template::decoded_value(line) {
-            return format!("\"{value}\"");
-        }
-        let opening = line.split_once('=').map_or(line, |(_, value)| value);
-        std::iter::once(opening)
-            .chain(self.entry.assignment.iter().skip(1).map(String::as_str))
-            .map(str::trim)
-            .collect::<Vec<&str>>()
-            .join(" ")
     }
 
     /// The ledger record seeding this entry writes.
@@ -224,14 +200,18 @@ pub fn extract_env_entries(template: &str) -> Vec<EnvEntry> {
                 // `InValue`, so the run is exactly this entry's.
                 let mut assignment = vec![row.text.to_owned()];
                 let mut open = row.carries;
+                let mut broken = row.unterminated;
                 while open && index < rows.len() {
                     assignment.push(rows[index].text.to_owned());
                     open = rows[index].carries;
+                    broken |= rows[index].unterminated;
                     index += 1;
                 }
-                // The file ended inside the value. There is no complete
-                // text to seed, so this entry carries none.
-                if open {
+                // Complete means BOTH: the value closed, and no line of it
+                // left a string nothing closes. Neither implies the other
+                // — `TOKEN = "` carries nothing and is still unfinished —
+                // and either alone would seed text that does not parse.
+                if open || broken {
                     assignment.clear();
                 }
                 entries.push(EnvEntry {
@@ -298,6 +278,24 @@ fn render_entries(entries: &[&SeededEnv], eol: &str) -> String {
     out
 }
 
+/// The declaration that speaks for a key: the first one seeding can write
+/// whole, in declaration order. `None` where no installed template spells
+/// the key's value out in full.
+///
+/// The one answer to "whose value lands", because four things must agree
+/// on it: the bytes `merge` writes, the owner [`record_seeds`] records,
+/// the template a later comment refresh is gated on, and the skill
+/// [`conflict_notes`] names. Derived four times it was changed in one, and
+/// a broken template declaring a key before a valid one had the valid
+/// skill's bytes written under the broken skill's name — which stops the
+/// real owner's comments refreshing and lets the broken one overwrite
+/// them.
+pub fn writable_for<'a>(entries: &'a [SeededEnv], key: &str) -> Option<&'a SeededEnv> {
+    entries
+        .iter()
+        .find(|seeded| seeded.entry.key == key && seeded.entry.complete())
+}
+
 /// Merge missing entries into the settings text, byte-faithfully: the
 /// inserted block is the only change, spelled in the file's own line
 /// terminator. `None` = nothing to add. Returns the new text plus the keys
@@ -307,19 +305,21 @@ pub fn merge(original: Option<&str>, entries: &[SeededEnv]) -> Option<(String, V
     if original.is_some_and(|text| env_blocked(text).is_some()) {
         return None;
     }
-    let mut existing: BTreeSet<String> = original
+    let existing: BTreeSet<String> = original
         .map(assigned_keys)
         .unwrap_or_default()
         .into_iter()
         .collect();
-    // First declaration wins a key that several skills ship — the first
-    // that can be written whole, so one skill's unterminated template does
-    // not claim a key another ships properly. A key nothing can supply is
-    // refused by name in [`unterminated_notes`], never written in part.
+    // Each distinct key once, in declaration order, taken from the one
+    // declaration that speaks for it. The winner comes from `writable_for`
+    // rather than being re-derived here, so the bytes written, the ledger
+    // and the notes cannot name three different skills.
+    let mut seen: BTreeSet<&str> = BTreeSet::new();
     let missing: Vec<&SeededEnv> = entries
         .iter()
-        .filter(|seeded| seeded.entry.closes())
-        .filter(|seeded| existing.insert(seeded.entry.key.clone()))
+        .filter(|seeded| seen.insert(seeded.entry.key.as_str()))
+        .filter(|seeded| !existing.contains(&seeded.entry.key))
+        .filter_map(|seeded| writable_for(entries, &seeded.entry.key))
         .collect();
     if missing.is_empty() {
         return None;
@@ -377,14 +377,16 @@ pub fn merge(original: Option<&str>, entries: &[SeededEnv]) -> Option<(String, V
 }
 
 /// The ledger records the added entries were seeded, each under the owner
-/// whose lines were written — the first declaration, as `merge` chose.
+/// whose lines were written — asked of [`writable_for`], the same question
+/// `merge` asked, so the record names the skill that actually supplied the
+/// bytes.
 pub fn record_seeds(
     seeds: &mut BTreeMap<String, SettingsSeed>,
     entries: &[SeededEnv],
     added: &[String],
 ) {
     for key in added {
-        if let Some(seeded) = entries.iter().find(|seeded| &seeded.entry.key == key) {
+        if let Some(seeded) = writable_for(entries, key) {
             seeds.insert(key.clone(), seeded.seed_record());
         }
     }

--- a/crates/core/src/settings_seed.rs
+++ b/crates/core/src/settings_seed.rs
@@ -6,6 +6,12 @@
 //! must never add a key that some assignment outside `[env]` already
 //! names.
 //!
+//! An entry is written whole or not at all. A value TOML lets span lines
+//! carries every one of them; a value nothing closes has no complete text
+//! to copy and is refused by name ([`unterminated_notes`]), because its
+//! opening delimiter alone would leave the consumer's file unparseable
+//! from that line down. Neither case is ever silent.
+//!
 //! Seeded comments stay current ([`refresh`]): the lock keeps, per key, the
 //! FNV-1a hash of the comment block last written by seeding, and a key's
 //! comment is rewritten to the template's revision only while its on-disk
@@ -21,8 +27,10 @@ use crate::lock::SettingsSeed;
 use crate::settings_toml::{Line, Row};
 
 mod env;
+mod notes;
 mod refresh;
 pub use env::{EnvBlocked, env_blocked};
+pub use notes::{conflict_notes, seed_notes, unterminated_notes};
 pub use refresh::refresh_comments;
 
 pub const SETTINGS_FILE: &str = "kendex.settings.toml";
@@ -35,7 +43,32 @@ pub fn settings_file_path(project_root: &std::path::Path) -> std::path::PathBuf 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct EnvEntry {
     pub key: String,
-    pub lines: Vec<String>,
+    /// The comment block above the assignment, in file order.
+    pub comment: Vec<String>,
+    /// Every physical line of the assignment, from the one carrying the
+    /// `=` through the one that closes the value — a value TOML lets span
+    /// lines is seeded whole or not at all. Empty where nothing closes it.
+    ///
+    /// Held apart from the comment rather than counted off one end of a
+    /// list of both: which lines are the value is the walk's answer, and a
+    /// reader that took all-but-the-last would call a multiline value's
+    /// opening line part of the comment above it.
+    pub assignment: Vec<String>,
+}
+
+impl EnvEntry {
+    /// The lines seeding writes for this entry, comment first.
+    fn lines(&self) -> impl Iterator<Item = &String> {
+        self.comment.iter().chain(&self.assignment)
+    }
+
+    /// Whether the template's value closes, which is whether there is
+    /// anything here to write. An assignment nothing closes has no
+    /// complete text to seed, so the key is refused by name
+    /// ([`unterminated_notes`]) rather than written half-finished.
+    pub fn closes(&self) -> bool {
+        !self.assignment.is_empty()
+    }
 }
 
 /// One entry as a scope plans it: the template's lines plus the skill that
@@ -51,10 +84,7 @@ impl SeededEnv {
     /// The comment block this entry would write, trimmed the way the
     /// ledger hashes it.
     fn comment(&self) -> &[String] {
-        let Some((_, comment)) = self.entry.lines.split_last() else {
-            return &[];
-        };
-        trim_blank_edges(comment)
+        trim_blank_edges(&self.entry.comment)
     }
 
     /// The default this entry ships, spelled the way a note shows it: the
@@ -62,16 +92,23 @@ impl SeededEnv {
     /// verbatim where the strict reader cannot decode it. Every entry
     /// `merge` seeds has one, so a note can never drop an owner and then
     /// name the wrong package as the one whose value lands.
+    ///
+    /// A value spanning lines is shown on the note's one line, its lines
+    /// joined by a space. Shown from the `=` line alone every multiline
+    /// value would read as its bare opening delimiter, and two packages
+    /// shipping different ones would be grouped as agreeing — the note
+    /// exists to say they disagree.
     fn default_shown(&self) -> String {
-        let line = self.entry.lines.last().map_or("", String::as_str);
-        match crate::settings_template::decoded_value(line) {
-            Some(value) => format!("\"{value}\""),
-            None => line
-                .split_once('=')
-                .map_or(line, |(_, value)| value)
-                .trim()
-                .to_owned(),
+        let line = self.entry.assignment.first().map_or("", String::as_str);
+        if let Some(value) = crate::settings_template::decoded_value(line) {
+            return format!("\"{value}\"");
         }
+        let opening = line.split_once('=').map_or(line, |(_, value)| value);
+        std::iter::once(opening)
+            .chain(self.entry.assignment.iter().skip(1).map(String::as_str))
+            .map(str::trim)
+            .collect::<Vec<&str>>()
+            .join(" ")
     }
 
     /// The ledger record seeding this entry writes.
@@ -140,18 +177,29 @@ pub(crate) fn table_row(row: &Row) -> bool {
     row.kind == Line::Table
 }
 
+/// Every `[env]` entry the template declares, each holding all of its own
+/// lines: the walk says where a value ends, so one spanning lines is taken
+/// whole. An entry whose value nothing closes comes back with no
+/// assignment lines — still an entry, because [`unterminated_notes`] has
+/// to name it.
 pub fn extract_env_entries(template: &str) -> Vec<EnvEntry> {
+    let rows = crate::settings_toml::rows(template);
     let mut entries = Vec::new();
     let mut in_env = false;
     let mut pending: Vec<String> = Vec::new();
-    for row in crate::settings_toml::rows(template) {
-        // A value's own lines are the value: read as structure they seed
-        // keys the template never declared.
+    let mut index = 0;
+    while index < rows.len() {
+        let row = &rows[index];
+        index += 1;
+        // A value's own lines go with the assignment that opened them,
+        // taken below. Reaching here they belong to a value opened
+        // outside `[env]`: read as structure they seed keys the template
+        // never declared.
         if row.kind == Line::InValue {
             continue;
         }
-        if table_row(&row) {
-            if opens_env(&row) {
+        if table_row(row) {
+            if opens_env(row) {
                 in_env = true;
                 pending.clear();
                 continue;
@@ -167,11 +215,30 @@ pub fn extract_env_entries(template: &str) -> Vec<EnvEntry> {
             Line::Blank => pending.clear(),
             Line::Comment => pending.push(row.text.to_owned()),
             _ => {
-                if let Some(key) = assignment_key(&row) {
-                    let mut lines = std::mem::take(&mut pending);
-                    lines.push(row.text.to_owned());
-                    entries.push(EnvEntry { key, lines });
+                let Some(key) = assignment_key(row) else {
+                    continue;
+                };
+                let comment = std::mem::take(&mut pending);
+                // The assignment runs to wherever its value closes. Every
+                // line under an open value is one the walk called
+                // `InValue`, so the run is exactly this entry's.
+                let mut assignment = vec![row.text.to_owned()];
+                let mut open = row.carries;
+                while open && index < rows.len() {
+                    assignment.push(rows[index].text.to_owned());
+                    open = rows[index].carries;
+                    index += 1;
                 }
+                // The file ended inside the value. There is no complete
+                // text to seed, so this entry carries none.
+                if open {
+                    assignment.clear();
+                }
+                entries.push(EnvEntry {
+                    key,
+                    comment,
+                    assignment,
+                });
             }
         }
     }
@@ -221,7 +288,9 @@ fn render_entries(entries: &[&SeededEnv], eol: &str) -> String {
         if !out.is_empty() {
             out.push_str(eol);
         }
-        for line in &seeded.entry.lines {
+        // Every line of the entry, the value's continuation lines
+        // included: a value is written whole or the entry never got here.
+        for line in seeded.entry.lines() {
             out.push_str(line);
             out.push_str(eol);
         }
@@ -243,9 +312,13 @@ pub fn merge(original: Option<&str>, entries: &[SeededEnv]) -> Option<(String, V
         .unwrap_or_default()
         .into_iter()
         .collect();
-    // First declaration wins a key that several skills ship.
+    // First declaration wins a key that several skills ship — the first
+    // that can be written whole, so one skill's unterminated template does
+    // not claim a key another ships properly. A key nothing can supply is
+    // refused by name in [`unterminated_notes`], never written in part.
     let missing: Vec<&SeededEnv> = entries
         .iter()
+        .filter(|seeded| seeded.entry.closes())
         .filter(|seeded| existing.insert(seeded.entry.key.clone()))
         .collect();
     if missing.is_empty() {
@@ -301,56 +374,6 @@ pub fn merge(original: Option<&str>, entries: &[SeededEnv]) -> Option<(String, V
         out.push_str(row.raw);
     }
     Some((out, added))
-}
-
-/// What the plan says about keys several packages ship with different
-/// defaults: one line per key, naming every default and everyone who ships
-/// it. `merge` takes the first declaration and writes nothing about the
-/// others, so a disagreement about what a key should be is invisible
-/// anywhere else — and packages agreeing on a shared key, which is the
-/// ordinary case, say nothing at all.
-///
-/// Every entry counts, whatever shape its value is in. `merge` reads the
-/// same lenient list, so an entry this dropped would be one the note left
-/// out of a key it does seed — and with it the owner named as the one
-/// whose value lands.
-///
-/// The note is raised before the settings file is even read, because the
-/// disagreement is worth saying either way. So it says which default
-/// seeding WOULD write, under the condition seeding writes at all: a key
-/// the file already assigns is left alone, and a note claiming a value
-/// landed would be false exactly there.
-///
-/// Key, owners and defaults are all catalog text a download supplied, so
-/// the finished line goes through [`crate::names::shown`]: a note is read
-/// on a terminal, and nothing in it is a sequence to act on.
-pub fn conflict_notes(entries: &[SeededEnv]) -> Vec<String> {
-    // Distinct defaults per key, each with its owners, both in declaration
-    // order; the key order is the file's, so the notes read stably.
-    let mut by_key: BTreeMap<&str, Vec<(String, Vec<&str>)>> = BTreeMap::new();
-    for seeded in entries {
-        let default = seeded.default_shown();
-        let defaults = by_key.entry(&seeded.entry.key).or_default();
-        match defaults.iter_mut().find(|(seen, _)| seen == &default) {
-            Some((_, owners)) => owners.push(&seeded.owner),
-            None => defaults.push((default, vec![&seeded.owner])),
-        }
-    }
-    by_key
-        .into_iter()
-        .filter(|(_, defaults)| defaults.len() > 1)
-        .map(|(key, defaults)| {
-            let lands = defaults[0].1[0];
-            let shown: Vec<String> = defaults
-                .iter()
-                .map(|(value, owners)| format!("{value} ({})", owners.join(", ")))
-                .collect();
-            crate::names::shown(&format!(
-                "{SETTINGS_FILE} {key}: packages ship different defaults — {} — where this file does not already assign it, {lands}'s is the one seeded, so set the value yourself if that is not the one you want",
-                shown.join(", ")
-            ))
-        })
-        .collect()
 }
 
 /// The ledger records the added entries were seeded, each under the owner

--- a/crates/core/src/settings_seed.rs
+++ b/crates/core/src/settings_seed.rs
@@ -200,11 +200,11 @@ pub fn extract_env_entries(template: &str) -> Vec<EnvEntry> {
                 // `InValue`, so the run is exactly this entry's.
                 let mut assignment = vec![row.text.to_owned()];
                 let mut open = row.carries;
-                let mut broken = row.unterminated;
+                let mut broken = row.broken;
                 while open && index < rows.len() {
                     assignment.push(rows[index].text.to_owned());
                     open = rows[index].carries;
-                    broken |= rows[index].unterminated;
+                    broken |= rows[index].broken;
                     index += 1;
                 }
                 // Complete means BOTH: the value closed, and no line of it

--- a/crates/core/src/settings_seed.rs
+++ b/crates/core/src/settings_seed.rs
@@ -12,6 +12,13 @@
 //! opening delimiter alone would leave the consumer's file unparseable
 //! from that line down. Neither case is ever silent.
 //!
+//! Two kinds of newline meet in a seeded block and only one is the file's.
+//! The terminators between entries and around the block belong to the
+//! destination and take its spelling; the ones INSIDE a value are the
+//! value's own content and go out exactly as the template wrote them. Both
+//! spelled the destination's way, an LF template seeded into a CRLF file
+//! hands the consumer a different string from the one it declared.
+//!
 //! Seeded comments stay current ([`refresh`]): the lock keeps, per key, the
 //! FNV-1a hash of the comment block last written by seeding, and a key's
 //! comment is rewritten to the template's revision only while its on-disk
@@ -21,17 +28,17 @@
 //! merge) are the only bytes that change, so CRLF files and
 //! missing-terminator state survive untouched.
 
-use std::collections::{BTreeMap, BTreeSet};
-
 use crate::lock::SettingsSeed;
 use crate::settings_toml::{Line, Row};
 
 mod env;
 mod notes;
 mod refresh;
+mod write;
 pub use env::{EnvBlocked, env_blocked};
 pub use notes::{conflict_notes, seed_notes, unterminated_notes};
 pub use refresh::refresh_comments;
+pub use write::{merge, record_seeds};
 
 pub const SETTINGS_FILE: &str = "kendex.settings.toml";
 pub const SETTINGS_TEMPLATE: &str = "kendex.settings.toml.example";
@@ -45,22 +52,20 @@ pub struct EnvEntry {
     pub key: String,
     /// The comment block above the assignment, in file order.
     pub comment: Vec<String>,
-    /// Every physical line of the assignment, from the one carrying the
-    /// `=` through the one that closes the value — a value TOML lets span
-    /// lines is seeded whole or not at all. Empty where the template's
-    /// value is not complete text seeding could copy.
-    /// Held apart from the comment because which lines are the value is
-    /// the walk's answer: a reader taking all-but-the-last off one list
-    /// calls a multiline value's opening line part of the comment.
-    pub assignment: Vec<String>,
+    /// The whole assignment as the template spells it, from the `=` line
+    /// through the line closing the value, with the newlines BETWEEN its
+    /// lines exactly as written and none after the last. Empty where the
+    /// template's value is not complete text seeding could copy.
+    ///
+    /// One string rather than a list of lines because a multiline value's
+    /// newlines are its own content: re-joined in the destination file's
+    /// terminator they would change the string the consumer reads. Held
+    /// apart from the comment because which lines are the value is the
+    /// walk's answer, not a count off one end of a list of both.
+    pub assignment: String,
 }
 
 impl EnvEntry {
-    /// The lines seeding writes for this entry, comment first.
-    fn lines(&self) -> impl Iterator<Item = &String> {
-        self.comment.iter().chain(&self.assignment)
-    }
-
     /// Whether the template spells this value out in full, which is
     /// whether there is anything here to write. Not the same as ending: a
     /// value can close, carry on, or break off mid-string, and only the
@@ -68,6 +73,12 @@ impl EnvEntry {
     /// it is refused by name rather than written half-finished.
     pub fn complete(&self) -> bool {
         !self.assignment.is_empty()
+    }
+
+    /// The line carrying the `=`, without its terminator. Empty for an
+    /// entry with no complete value.
+    pub fn opening(&self) -> &str {
+        self.assignment.lines().next().unwrap_or("")
     }
 }
 
@@ -198,19 +209,29 @@ pub fn extract_env_entries(template: &str) -> Vec<EnvEntry> {
                 // The assignment runs to wherever its value closes. Every
                 // line under an open value is one the walk called
                 // `InValue`, so the run is exactly this entry's.
-                let mut assignment = vec![row.text.to_owned()];
+                // Taken as raw bytes, terminators included: the newlines
+                // between a value's lines are INSIDE the value, and a
+                // reader that kept only the text would hand the writer
+                // lines to re-join in the destination file's terminator,
+                // rewriting the string's own content.
+                let mut assignment = String::from(row.raw);
                 let mut open = row.carries;
                 let mut broken = row.broken;
                 while open && index < rows.len() {
-                    assignment.push(rows[index].text.to_owned());
+                    assignment.push_str(rows[index].raw);
                     open = rows[index].carries;
                     broken |= rows[index].broken;
                     index += 1;
                 }
+                // The terminator after the LAST line is not part of the
+                // value — it separates this entry from the next, and the
+                // destination file supplies it.
+                assignment.truncate(crate::settings_toml::content_of(&assignment).len());
                 // Complete means BOTH: the value closed, and no line of it
-                // left a string nothing closes. Neither implies the other
-                // — `TOKEN = "` carries nothing and is still unfinished —
-                // and either alone would seed text that does not parse.
+                // left a container the grammar cannot continue. Neither
+                // implies the other — `TOKEN = "` carries nothing and is
+                // still unfinished — and either alone would seed text that
+                // does not parse.
                 if open || broken {
                     assignment.clear();
                 }
@@ -234,162 +255,33 @@ pub fn assigned_keys(text: &str) -> Vec<String> {
         .collect()
 }
 
-/// The terminator new lines are written with: whatever the file's first
-/// terminated line uses, `\n` where it has nothing to say.
-fn file_eol(rows: &[Row]) -> &'static str {
-    match rows
+/// Every declaration seeding could write for this key, in declaration
+/// order. The one gate on `complete()` for the purpose of choosing: no
+/// consumer filters entries itself, so none can be left behind when the
+/// rule changes.
+///
+/// Four consumers must agree on which declarations count — the bytes
+/// `merge` writes, the owner [`record_seeds`] records, the template a
+/// later comment refresh is gated on, and the defaults
+/// [`conflict_notes`] compares. Derived separately, the rule was changed
+/// in one and missed in the rest: a broken template declaring a key
+/// before a valid one had the valid skill's bytes written under the
+/// broken skill's name, and the notes reported a conflict between a
+/// skill's real default and a broken one's empty one.
+pub fn writable_all<'a>(
+    entries: &'a [SeededEnv],
+    key: &str,
+) -> impl Iterator<Item = &'a SeededEnv> {
+    entries
         .iter()
-        .find(|row| row.raw.ends_with('\n'))
-        .is_some_and(|row| row.raw.ends_with("\r\n"))
-    {
-        true => "\r\n",
-        false => "\n",
-    }
-}
-
-/// The `[env]` section's line span: the header's index and the index of
-/// the first line after the section (the next table header, or the end
-/// of the file). `None` = no `[env]` header. Seeding and refresh both
-/// splice inside this span, so they cannot disagree about where it ends.
-fn env_section(rows: &[Row]) -> Option<(usize, usize)> {
-    let start = rows.iter().position(opens_env)?;
-    let end = rows
-        .iter()
-        .enumerate()
-        .skip(start + 1)
-        .find_map(|(index, row)| table_row(row).then_some(index))
-        .unwrap_or(rows.len());
-    Some((start, end))
-}
-
-fn render_entries(entries: &[&SeededEnv], eol: &str) -> String {
-    let mut out = String::new();
-    for seeded in entries {
-        if !out.is_empty() {
-            out.push_str(eol);
-        }
-        // Every line of the entry, the value's continuation lines
-        // included: a value is written whole or the entry never got here.
-        for line in seeded.entry.lines() {
-            out.push_str(line);
-            out.push_str(eol);
-        }
-    }
-    out
+        .filter(move |seeded| seeded.entry.key == key && seeded.entry.complete())
 }
 
 /// The declaration that speaks for a key: the first one seeding can write
-/// whole, in declaration order. `None` where no installed template spells
-/// the key's value out in full.
-///
-/// The one answer to "whose value lands", because four things must agree
-/// on it: the bytes `merge` writes, the owner [`record_seeds`] records,
-/// the template a later comment refresh is gated on, and the skill
-/// [`conflict_notes`] names. Derived four times it was changed in one, and
-/// a broken template declaring a key before a valid one had the valid
-/// skill's bytes written under the broken skill's name — which stops the
-/// real owner's comments refreshing and lets the broken one overwrite
-/// them.
+/// whole. `None` where no installed template spells the key's value out in
+/// full, which is the case [`unterminated_notes`] owns.
 pub fn writable_for<'a>(entries: &'a [SeededEnv], key: &str) -> Option<&'a SeededEnv> {
-    entries
-        .iter()
-        .find(|seeded| seeded.entry.key == key && seeded.entry.complete())
-}
-
-/// Merge missing entries into the settings text, byte-faithfully: the
-/// inserted block is the only change, spelled in the file's own line
-/// terminator. `None` = nothing to add. Returns the new text plus the keys
-/// that were added.
-pub fn merge(original: Option<&str>, entries: &[SeededEnv]) -> Option<(String, Vec<String>)> {
-    // Nowhere to write: the plan reports the shape, and no byte moves.
-    if original.is_some_and(|text| env_blocked(text).is_some()) {
-        return None;
-    }
-    let existing: BTreeSet<String> = original
-        .map(assigned_keys)
-        .unwrap_or_default()
-        .into_iter()
-        .collect();
-    // Each distinct key once, in declaration order, taken from the one
-    // declaration that speaks for it. The winner comes from `writable_for`
-    // rather than being re-derived here, so the bytes written, the ledger
-    // and the notes cannot name three different skills.
-    let mut seen: BTreeSet<&str> = BTreeSet::new();
-    let missing: Vec<&SeededEnv> = entries
-        .iter()
-        .filter(|seeded| seen.insert(seeded.entry.key.as_str()))
-        .filter(|seeded| !existing.contains(&seeded.entry.key))
-        .filter_map(|seeded| writable_for(entries, &seeded.entry.key))
-        .collect();
-    if missing.is_empty() {
-        return None;
-    }
-    let added: Vec<String> = missing.iter().map(|s| s.entry.key.clone()).collect();
-
-    let Some(original) = original else {
-        let mut out = String::from(
-            "# Public kendex settings seeded from installed skill defaults.\n# Skill scripts read this [env] table; process env and .env.local override it.\n# Keep secrets, tokens, and personal overrides in .env.local.\n\n[env]\n",
-        );
-        out.push_str(&render_entries(&missing, "\n"));
-        return Some((out, added));
-    };
-
-    let rows = crate::settings_toml::rows(original);
-    let eol = file_eol(&rows);
-    let env = env_section(&rows);
-    // Where the new block lands: the end of the `[env]` section, or the end
-    // of the file (with a header) when there is none.
-    let insert_at = env.map_or(rows.len(), |(_, end)| end);
-
-    let mut block = String::new();
-    // A final line with no terminator gets one — the once-only repair that
-    // makes inserting after it possible at all.
-    if insert_at == rows.len()
-        && rows
-            .last()
-            .is_some_and(|row| row.text.len() == row.raw.len() && !row.raw.is_empty())
-    {
-        block.push_str(eol);
-    }
-    if env.is_none() {
-        if !rows.is_empty() && insert_at > 0 && !rows[insert_at - 1].text.trim().is_empty() {
-            block.push_str(eol);
-        }
-        block.push_str("[env]");
-        block.push_str(eol);
-    } else if insert_at > 0 && !rows[insert_at - 1].text.trim().is_empty() {
-        block.push_str(eol);
-    }
-    block.push_str(&render_entries(&missing, eol));
-    if insert_at < rows.len() && !rows[insert_at].text.trim().is_empty() {
-        block.push_str(eol);
-    }
-
-    let mut out = String::with_capacity(original.len() + block.len());
-    for row in &rows[..insert_at] {
-        out.push_str(row.raw);
-    }
-    out.push_str(&block);
-    for row in &rows[insert_at..] {
-        out.push_str(row.raw);
-    }
-    Some((out, added))
-}
-
-/// The ledger records the added entries were seeded, each under the owner
-/// whose lines were written — asked of [`writable_for`], the same question
-/// `merge` asked, so the record names the skill that actually supplied the
-/// bytes.
-pub fn record_seeds(
-    seeds: &mut BTreeMap<String, SettingsSeed>,
-    entries: &[SeededEnv],
-    added: &[String],
-) {
-    for key in added {
-        if let Some(seeded) = writable_for(entries, key) {
-            seeds.insert(key.clone(), seeded.seed_record());
-        }
-    }
+    writable_all(entries, key).next()
 }
 
 #[cfg(test)]

--- a/crates/core/src/settings_seed/notes.rs
+++ b/crates/core/src/settings_seed/notes.rs
@@ -16,10 +16,11 @@ use super::{SETTINGS_FILE, SeededEnv};
 /// else — and packages agreeing on a shared key, which is the ordinary
 /// case, say nothing at all.
 ///
-/// Every entry counts, whatever shape its value is in. `merge` reads the
-/// same lenient list, so an entry this dropped would be one the note left
-/// out of a key it does seed — and with it the owner named as the one
-/// whose value lands.
+/// The groups are built from the writable declarations, the same
+/// selection `merge` seeds from, so the defaults compared here are the
+/// ones that could actually land. A declaration whose value its template
+/// never completes ships no default to disagree with and is reported by
+/// [`unterminated_notes`] instead.
 ///
 /// The note is raised before the settings file is even read, because the
 /// disagreement is worth saying either way. So it says which default

--- a/crates/core/src/settings_seed/notes.rs
+++ b/crates/core/src/settings_seed/notes.rs
@@ -1,0 +1,107 @@
+//! What the plan says about a set of entries before a byte is written.
+//!
+//! Split from the seeding beside it because the two answer different
+//! questions. Nothing here decides what to write or where — it only says
+//! what a person has to know about what seeding is about to do, or
+//! decline to do, and every note is read on a terminal.
+
+use std::collections::BTreeMap;
+
+use super::{SETTINGS_FILE, SeededEnv};
+
+/// What the plan says about keys several packages ship with different
+/// defaults: one line per key, naming every default and everyone who ships
+/// it. `merge` takes the first declaration and writes nothing about the
+/// others, so a disagreement about what a key should be is invisible
+/// anywhere else — and packages agreeing on a shared key, which is the
+/// ordinary case, say nothing at all.
+///
+/// Every entry counts, whatever shape its value is in. `merge` reads the
+/// same lenient list, so an entry this dropped would be one the note left
+/// out of a key it does seed — and with it the owner named as the one
+/// whose value lands.
+///
+/// The note is raised before the settings file is even read, because the
+/// disagreement is worth saying either way. So it says which default
+/// seeding WOULD write, under the condition seeding writes at all: a key
+/// the file already assigns is left alone, and a note claiming a value
+/// landed would be false exactly there.
+///
+/// Key, owners and defaults are all catalog text a download supplied, so
+/// the finished line goes through [`crate::names::shown`]: a note is read
+/// on a terminal, and nothing in it is a sequence to act on.
+pub fn conflict_notes(entries: &[SeededEnv]) -> Vec<String> {
+    // Distinct defaults per key, each with its owners, both in declaration
+    // order; the key order is the file's, so the notes read stably.
+    let mut by_key: BTreeMap<&str, Vec<(String, Vec<&str>)>> = BTreeMap::new();
+    for seeded in entries {
+        let default = seeded.default_shown();
+        let defaults = by_key.entry(&seeded.entry.key).or_default();
+        match defaults.iter_mut().find(|(seen, _)| seen == &default) {
+            Some((_, owners)) => owners.push(&seeded.owner),
+            None => defaults.push((default, vec![&seeded.owner])),
+        }
+    }
+    by_key
+        .into_iter()
+        .filter(|(_, defaults)| defaults.len() > 1)
+        .map(|(key, defaults)| {
+            let lands = defaults[0].1[0];
+            let shown: Vec<String> = defaults
+                .iter()
+                .map(|(value, owners)| format!("{value} ({})", owners.join(", ")))
+                .collect();
+            crate::names::shown(&format!(
+                "{SETTINGS_FILE} {key}: packages ship different defaults — {} — where this file does not already assign it, {lands}'s is the one seeded, so set the value yourself if that is not the one you want",
+                shown.join(", ")
+            ))
+        })
+        .collect()
+}
+
+/// What the plan says about a key seeding will not write at all: a
+/// template whose value opens something nothing closes. That is an
+/// unterminated template, not a multiline one — a value that closes is
+/// seeded whole, however many lines it takes. There is no complete text to
+/// copy here, and the opening line alone would leave the consumer's file
+/// unparseable from there down, so the key is refused and named rather
+/// than dropped in silence.
+///
+/// Only a key NO installed template can supply is named: where one skill
+/// ships it broken and another ships it whole, [`super::merge`] seeds the whole
+/// one and there is nothing for a person to do.
+///
+/// Key and owners are catalog text a download supplied, so the finished
+/// line goes through [`crate::names::shown`] like every other note.
+pub fn unterminated_notes(entries: &[SeededEnv]) -> Vec<String> {
+    // Per key: whether any declaration closes, and who ships the ones
+    // that do not. Key order is the file's, so the notes read stably.
+    let mut by_key: BTreeMap<&str, (bool, Vec<&str>)> = BTreeMap::new();
+    for seeded in entries {
+        let (closes, owners) = by_key.entry(&seeded.entry.key).or_default();
+        match seeded.entry.closes() {
+            true => *closes = true,
+            false => owners.push(&seeded.owner),
+        }
+    }
+    by_key
+        .into_iter()
+        .filter(|(_, (closes, _))| !closes)
+        .map(|(key, (_, owners))| {
+            crate::names::shown(&format!(
+                "{SETTINGS_FILE} {key}: {}'s template opens a value nothing closes, so there is no complete default to seed and nothing was written for this key — fix the template, or set the key yourself",
+                owners.join(", ")
+            ))
+        })
+        .collect()
+}
+
+/// Everything the plan says about these entries before a byte is written:
+/// keys several packages ship with different defaults, and keys no
+/// template can supply whole. One call so a caller cannot take half the
+/// answer — a note nobody asked for is a key silently left out.
+pub fn seed_notes(entries: &[SeededEnv]) -> Vec<String> {
+    let mut notes = conflict_notes(entries);
+    notes.extend(unterminated_notes(entries));
+    notes
+}

--- a/crates/core/src/settings_seed/notes.rs
+++ b/crates/core/src/settings_seed/notes.rs
@@ -33,17 +33,28 @@ use super::{SETTINGS_FILE, SeededEnv};
 pub fn conflict_notes(entries: &[SeededEnv]) -> Vec<String> {
     // Distinct defaults per key, each with its owners, both in declaration
     // order; the key order is the file's, so the notes read stably.
+    //
+    // The declarations come from `writable_all`, the same selection every
+    // other consumer takes, rather than from a filter of this loop's own.
+    // An incomplete declaration ships no default to disagree with — it
+    // grouped as an empty one and reported two skills as conflicting when
+    // only one of them had said anything.
     let mut by_key: BTreeMap<&str, Vec<Shipped>> = BTreeMap::new();
-    for seeded in entries {
-        let identity = seeded.default_key();
-        let defaults = by_key.entry(&seeded.entry.key).or_default();
-        match defaults.iter_mut().find(|had| had.identity == identity) {
-            Some(had) => had.owners.push(&seeded.owner),
-            None => defaults.push(Shipped {
-                identity,
-                shown: seeded.default_shown(),
-                owners: vec![&seeded.owner],
-            }),
+    for key in entries.iter().map(|seeded| seeded.entry.key.as_str()) {
+        let defaults = by_key.entry(key).or_default();
+        if !defaults.is_empty() {
+            continue;
+        }
+        for seeded in super::writable_all(entries, key) {
+            let identity = seeded.default_key();
+            match defaults.iter_mut().find(|had| had.identity == identity) {
+                Some(had) => had.owners.push(&seeded.owner),
+                None => defaults.push(Shipped {
+                    identity,
+                    shown: seeded.default_shown(),
+                    owners: vec![&seeded.owner],
+                }),
+            }
         }
     }
     by_key
@@ -81,11 +92,16 @@ struct Shipped<'a> {
 /// What the plan says about a key seeding will not write at all: a
 /// template that never finishes the value. That is an unterminated
 /// template, not a multiline one — a value that closes is seeded whole,
-/// however many lines it takes — and it covers a string broken off on its
-/// own line as much as one that runs to the end of the file. There is no
-/// complete text to copy either way, and writing what there is would leave
-/// the consumer's file unparseable from that line down, so the key is
-/// refused and named rather than dropped in silence.
+/// however many lines it takes.
+///
+/// Which delimiter was left open is deliberately not named. Completeness
+/// comes off the enumerated grammar in [`crate::settings_toml`], so a form
+/// added there would leave a list here stale, and the message would send
+/// somebody to the wrong part of their template. The key name is what
+/// tells them where to look. There is no complete text to copy whatever
+/// the shape, and writing what there is would leave the consumer's file
+/// unparseable from that line down, so the key is refused and named
+/// rather than dropped in silence.
 ///
 /// Only a key NO installed template can supply is named: where one skill
 /// ships it broken and another ships it whole, [`super::merge`] seeds the whole
@@ -109,7 +125,7 @@ pub fn unterminated_notes(entries: &[SeededEnv]) -> Vec<String> {
         .filter(|(_, (complete, _))| !complete)
         .map(|(key, (_, owners))| {
             crate::names::shown(&format!(
-                "{SETTINGS_FILE} {key}: {}'s template leaves this value unfinished — a string or array nothing closes — so there is no complete default to seed and nothing was written for this key; fix the template, or set the key yourself",
+                "{SETTINGS_FILE} {key}: {}'s template never finishes this value — it opens something that is never closed — so there is no complete default to seed and nothing was written for this key; fix the template, or set the key yourself",
                 owners.join(", ")
             ))
         })
@@ -173,17 +189,16 @@ impl SeededEnv {
     /// The default where the strict reader can read one: a plain one-line
     /// double-quoted string.
     fn decoded(&self) -> Option<String> {
-        let line = self.entry.assignment.first().map_or("", String::as_str);
-        crate::settings_template::decoded_value(line)
+        crate::settings_template::decoded_value(self.entry.opening())
     }
 
     /// The assignment's right-hand side, line by line, as written. The
     /// opening line's is trimmed of the space after its `=`; every line
     /// after it is the value's own text and is left alone.
     fn raw_default(&self) -> impl Iterator<Item = &str> {
-        let line = self.entry.assignment.first().map_or("", String::as_str);
-        let opening = line.split_once('=').map_or(line, |(_, value)| value);
-        std::iter::once(opening.trim())
-            .chain(self.entry.assignment.iter().skip(1).map(String::as_str))
+        let mut lines = self.entry.assignment.lines();
+        let opening = lines.next().unwrap_or("");
+        let right = opening.split_once('=').map_or(opening, |(_, value)| value);
+        std::iter::once(right.trim()).chain(lines)
     }
 }

--- a/crates/core/src/settings_seed/notes.rs
+++ b/crates/core/src/settings_seed/notes.rs
@@ -11,10 +11,10 @@ use super::{SETTINGS_FILE, SeededEnv};
 
 /// What the plan says about keys several packages ship with different
 /// defaults: one line per key, naming every default and everyone who ships
-/// it. `merge` takes the first declaration and writes nothing about the
-/// others, so a disagreement about what a key should be is invisible
-/// anywhere else — and packages agreeing on a shared key, which is the
-/// ordinary case, say nothing at all.
+/// it. `merge` writes one declaration and says nothing about the others,
+/// so a disagreement about what a key should be is invisible anywhere
+/// else — and packages agreeing on a shared key, which is the ordinary
+/// case, say nothing at all.
 ///
 /// Every entry counts, whatever shape its value is in. `merge` reads the
 /// same lenient list, so an entry this dropped would be one the note left
@@ -33,39 +33,59 @@ use super::{SETTINGS_FILE, SeededEnv};
 pub fn conflict_notes(entries: &[SeededEnv]) -> Vec<String> {
     // Distinct defaults per key, each with its owners, both in declaration
     // order; the key order is the file's, so the notes read stably.
-    let mut by_key: BTreeMap<&str, Vec<(String, Vec<&str>)>> = BTreeMap::new();
+    let mut by_key: BTreeMap<&str, Vec<Shipped>> = BTreeMap::new();
     for seeded in entries {
-        let default = seeded.default_shown();
+        let identity = seeded.default_key();
         let defaults = by_key.entry(&seeded.entry.key).or_default();
-        match defaults.iter_mut().find(|(seen, _)| seen == &default) {
-            Some((_, owners)) => owners.push(&seeded.owner),
-            None => defaults.push((default, vec![&seeded.owner])),
+        match defaults.iter_mut().find(|had| had.identity == identity) {
+            Some(had) => had.owners.push(&seeded.owner),
+            None => defaults.push(Shipped {
+                identity,
+                shown: seeded.default_shown(),
+                owners: vec![&seeded.owner],
+            }),
         }
     }
     by_key
         .into_iter()
         .filter(|(_, defaults)| defaults.len() > 1)
-        .map(|(key, defaults)| {
-            let lands = defaults[0].1[0];
+        .filter_map(|(key, defaults)| {
+            // Whose value lands is `writable_for`'s answer, never the
+            // first declaration: naming a skill whose template seeding
+            // could not write would point at bytes that never arrived.
+            // With no writable declaration nothing is seeded at all, and
+            // `unterminated_notes` is the note that belongs to that key.
+            let lands = &super::writable_for(entries, key)?.owner;
             let shown: Vec<String> = defaults
                 .iter()
-                .map(|(value, owners)| format!("{value} ({})", owners.join(", ")))
+                .map(|had| format!("{} ({})", had.shown, had.owners.join(", ")))
                 .collect();
-            crate::names::shown(&format!(
+            Some(crate::names::shown(&format!(
                 "{SETTINGS_FILE} {key}: packages ship different defaults — {} — where this file does not already assign it, {lands}'s is the one seeded, so set the value yourself if that is not the one you want",
                 shown.join(", ")
-            ))
+            )))
         })
         .collect()
 }
 
+/// One distinct default under a key: what tells it apart, what a person
+/// reads, and everyone who ships it. Identity and display are held apart
+/// because they answer different questions — see
+/// [`SeededEnv::default_key`].
+struct Shipped<'a> {
+    identity: String,
+    shown: String,
+    owners: Vec<&'a str>,
+}
+
 /// What the plan says about a key seeding will not write at all: a
-/// template whose value opens something nothing closes. That is an
-/// unterminated template, not a multiline one — a value that closes is
-/// seeded whole, however many lines it takes. There is no complete text to
-/// copy here, and the opening line alone would leave the consumer's file
-/// unparseable from there down, so the key is refused and named rather
-/// than dropped in silence.
+/// template that never finishes the value. That is an unterminated
+/// template, not a multiline one — a value that closes is seeded whole,
+/// however many lines it takes — and it covers a string broken off on its
+/// own line as much as one that runs to the end of the file. There is no
+/// complete text to copy either way, and writing what there is would leave
+/// the consumer's file unparseable from that line down, so the key is
+/// refused and named rather than dropped in silence.
 ///
 /// Only a key NO installed template can supply is named: where one skill
 /// ships it broken and another ships it whole, [`super::merge`] seeds the whole
@@ -74,22 +94,22 @@ pub fn conflict_notes(entries: &[SeededEnv]) -> Vec<String> {
 /// Key and owners are catalog text a download supplied, so the finished
 /// line goes through [`crate::names::shown`] like every other note.
 pub fn unterminated_notes(entries: &[SeededEnv]) -> Vec<String> {
-    // Per key: whether any declaration closes, and who ships the ones
-    // that do not. Key order is the file's, so the notes read stably.
+    // Per key: whether any declaration is complete, and who ships the
+    // ones that are not. Key order is the file's, so notes read stably.
     let mut by_key: BTreeMap<&str, (bool, Vec<&str>)> = BTreeMap::new();
     for seeded in entries {
-        let (closes, owners) = by_key.entry(&seeded.entry.key).or_default();
-        match seeded.entry.closes() {
-            true => *closes = true,
+        let (complete, owners) = by_key.entry(&seeded.entry.key).or_default();
+        match seeded.entry.complete() {
+            true => *complete = true,
             false => owners.push(&seeded.owner),
         }
     }
     by_key
         .into_iter()
-        .filter(|(_, (closes, _))| !closes)
+        .filter(|(_, (complete, _))| !complete)
         .map(|(key, (_, owners))| {
             crate::names::shown(&format!(
-                "{SETTINGS_FILE} {key}: {}'s template opens a value nothing closes, so there is no complete default to seed and nothing was written for this key — fix the template, or set the key yourself",
+                "{SETTINGS_FILE} {key}: {}'s template leaves this value unfinished — a string or array nothing closes — so there is no complete default to seed and nothing was written for this key; fix the template, or set the key yourself",
                 owners.join(", ")
             ))
         })
@@ -104,4 +124,66 @@ pub fn seed_notes(entries: &[SeededEnv]) -> Vec<String> {
     let mut notes = conflict_notes(entries);
     notes.extend(unterminated_notes(entries));
     notes
+}
+
+/// How a default reads and how two are told apart. Here rather than
+/// beside the entry itself because a note is the only thing that asks:
+/// seeding writes the template's own lines and never a rendering of
+/// them.
+impl SeededEnv {
+    /// The default this entry ships, spelled the way a note shows it: the
+    /// decoded value in quotes, or the assignment's right-hand side
+    /// verbatim where the strict reader cannot decode it. Every entry
+    /// `merge` seeds has one, so a note can never drop an owner and then
+    /// name the wrong package as the one whose value lands.
+    ///
+    /// A value spanning lines is shown on the note's one line, its lines
+    /// joined by a space. Shown from the `=` line alone every multiline
+    /// value would read as its bare opening delimiter, and two packages
+    /// shipping different ones would be grouped as agreeing — the note
+    /// exists to say they disagree.
+    pub(super) fn default_shown(&self) -> String {
+        match self.decoded() {
+            Some(value) => format!("\"{value}\""),
+            None => self
+                .raw_default()
+                .map(str::trim)
+                .collect::<Vec<&str>>()
+                .join(" "),
+        }
+    }
+
+    /// What tells two defaults apart. [`SeededEnv::default_shown`] is for
+    /// reading and collapses a value's lines onto one, which two different
+    /// values can share: a multiline holding `a\nb` and one holding `a b`
+    /// display alike. Grouped on that text, two skills shipping genuinely
+    /// different values are reported as agreeing — the one disagreement
+    /// [`conflict_notes`] exists to catch. So comparison keeps the value
+    /// as the template spells it, and only the display collapses.
+    ///
+    /// A decodable value still compares decoded, so `X = "a"` and
+    /// `X = "a" # note` stay one default rather than two.
+    pub(super) fn default_key(&self) -> String {
+        match self.decoded() {
+            Some(value) => format!("\"{value}\""),
+            None => self.raw_default().collect::<Vec<&str>>().join("\n"),
+        }
+    }
+
+    /// The default where the strict reader can read one: a plain one-line
+    /// double-quoted string.
+    fn decoded(&self) -> Option<String> {
+        let line = self.entry.assignment.first().map_or("", String::as_str);
+        crate::settings_template::decoded_value(line)
+    }
+
+    /// The assignment's right-hand side, line by line, as written. The
+    /// opening line's is trimmed of the space after its `=`; every line
+    /// after it is the value's own text and is left alone.
+    fn raw_default(&self) -> impl Iterator<Item = &str> {
+        let line = self.entry.assignment.first().map_or("", String::as_str);
+        let opening = line.split_once('=').map_or(line, |(_, value)| value);
+        std::iter::once(opening.trim())
+            .chain(self.entry.assignment.iter().skip(1).map(String::as_str))
+    }
 }

--- a/crates/core/src/settings_seed/refresh.rs
+++ b/crates/core/src/settings_seed/refresh.rs
@@ -10,9 +10,8 @@ use std::collections::{BTreeMap, BTreeSet};
 
 use crate::lock::SettingsSeed;
 
-use super::{
-    SeededEnv, assignment_key, comment_hash, env_section, file_eol, table_row, trim_blank_edges,
-};
+use super::write::{env_section, file_eol};
+use super::{SeededEnv, assignment_key, comment_hash, table_row, trim_blank_edges};
 use crate::settings_toml::Line;
 
 /// Rewrite `[env]` comment blocks whose upstream template text changed,
@@ -146,9 +145,8 @@ fn template_for<'a>(
     if first.owner == owner {
         return Some(first);
     }
-    entries
-        .iter()
-        .find(|seeded| seeded.entry.key == key && seeded.entry.complete() && seeded.owner == owner)
+    super::writable_all(entries, key)
+        .find(|seeded| seeded.owner == owner)
         .or(Some(first))
 }
 

--- a/crates/core/src/settings_seed/refresh.rs
+++ b/crates/core/src/settings_seed/refresh.rs
@@ -128,23 +128,28 @@ pub fn refresh_comments(
 
 /// The template that speaks for a key: the recorded owner's when several
 /// skills ship the key — declaration order must not shadow the ledger —
-/// else the first declaration.
+/// else the one [`super::writable_for`] chose.
+///
+/// Only a template that supplies a complete value is a candidate, on
+/// either path. A template seeding could not write is not the one whose
+/// comment belongs beside the key, and taking it here would let a broken
+/// skill rewrite the prose above bytes another skill supplied.
 fn template_for<'a>(
     key: &str,
     entries: &'a [SeededEnv],
     record: Option<&SettingsSeed>,
 ) -> Option<&'a SeededEnv> {
-    let mut candidates = entries.iter().filter(|seeded| seeded.entry.key == key);
-    let first = candidates.next()?;
+    let first = super::writable_for(entries, key)?;
     let Some(owner) = record.and_then(|record| record.owner.as_deref()) else {
         return Some(first);
     };
-    match first.owner == owner {
-        true => Some(first),
-        false => candidates
-            .find(|seeded| seeded.owner == owner)
-            .or(Some(first)),
+    if first.owner == owner {
+        return Some(first);
     }
+    entries
+        .iter()
+        .find(|seeded| seeded.entry.key == key && seeded.entry.complete() && seeded.owner == owner)
+        .or(Some(first))
 }
 
 /// Adoption, not takeover: a block already matching the template enters

--- a/crates/core/src/settings_seed/tests.rs
+++ b/crates/core/src/settings_seed/tests.rs
@@ -2,6 +2,8 @@ use std::collections::BTreeMap;
 
 use super::*;
 
+mod notes;
+
 const TEMPLATE: &str = "# ignored preamble\n[env]\n# Which reviewer set to run.\n# Comma separated.\nREVIEWERS = \"arch,security\"\n\nDEPTH = \"2\"\n\n[other]\nX = \"1\"\n";
 
 fn seeded(template: &str, owner: &str) -> Vec<SeededEnv> {
@@ -339,111 +341,6 @@ fn comment_hash_matches_v1s_algorithm() {
     });
 }
 
-/// Every `[env]` entry each named owner's template ships, in the order the
-/// owners are given — the order seeding resolves a shared key in.
-fn shipped(owners: &[(&str, &str)]) -> Vec<SeededEnv> {
-    owners
-        .iter()
-        .flat_map(|(owner, template)| seeded(template, owner))
-        .collect()
-}
-
-#[test]
-fn one_note_groups_every_owner_and_every_distinct_default() {
-    let notes = conflict_notes(&shipped(&[
-        ("alpha", "[env]\n# Wait.\nWAIT = \"900\"\n"),
-        ("beta", "[env]\n# Wait.\nWAIT = \"900\"\n"),
-        ("gamma", "[env]\n# Wait.\nWAIT = \"600\"\n"),
-    ]));
-    assert_eq!(
-        notes,
-        [
-            "kendex.settings.toml WAIT: packages ship different defaults — \"900\" (alpha, beta), \"600\" (gamma) — where this file does not already assign it, alpha's is the one seeded, so set the value yourself if that is not the one you want"
-        ]
-    );
-}
-
-#[test]
-fn packages_agreeing_on_a_shared_key_say_nothing() {
-    let notes = conflict_notes(&shipped(&[
-        (
-            "alpha",
-            "[env]\n# Mode.\nMODE = \"enforce\"\n# Wait.\nWAIT = \"900\"\n",
-        ),
-        (
-            "beta",
-            "[env]\n# Mode.\nMODE = \"enforce\"\n# Wait.\nWAIT = \"900\"\n",
-        ),
-    ]));
-    assert!(notes.is_empty(), "{notes:?}");
-}
-
-#[test]
-fn a_key_only_one_package_ships_says_nothing() {
-    let notes = conflict_notes(&shipped(&[
-        ("alpha", "[env]\n# Depth.\nDEPTH = \"2\"\n"),
-        ("beta", "[env]\n# Width.\nWIDTH = \"3\"\n"),
-    ]));
-    assert!(notes.is_empty(), "{notes:?}");
-}
-
-#[test]
-fn the_note_names_the_owner_whose_value_merge_actually_seeds() {
-    // alpha's default carries a trailing comment, which the loaders read
-    // and a stricter decoder once threw away — dropping alpha from the note
-    // and naming beta as the package whose value lands.
-    let entries = shipped(&[
-        ("alpha", "[env]\n# Wait.\nWAIT = \"900\" # seconds\n"),
-        ("beta", "[env]\n# Wait.\nWAIT = \"600\"\n"),
-        ("gamma", "[env]\n# Wait.\nWAIT = \"300\"\n"),
-    ]);
-    let notes = conflict_notes(&entries);
-    assert_eq!(
-        notes,
-        [
-            "kendex.settings.toml WAIT: packages ship different defaults — \"900\" (alpha), \"600\" (beta), \"300\" (gamma) — where this file does not already assign it, alpha's is the one seeded, so set the value yourself if that is not the one you want"
-        ]
-    );
-    // And alpha is what merge writes, which is what the note claims.
-    let (merged, added) = merge(None, &entries).unwrap();
-    assert_eq!(added, ["WAIT"]);
-    assert!(merged.contains("WAIT = \"900\" # seconds"), "{merged}");
-}
-
-#[test]
-fn a_default_no_decoder_reads_still_names_its_owner() {
-    let notes = conflict_notes(&shipped(&[
-        ("alpha", "[env]\n# Wait.\nWAIT = 900\n"),
-        ("beta", "[env]\n# Wait.\nWAIT = \"600\"\n"),
-    ]));
-    assert_eq!(
-        notes,
-        [
-            "kendex.settings.toml WAIT: packages ship different defaults — 900 (alpha), \"600\" (beta) — where this file does not already assign it, alpha's is the one seeded, so set the value yourself if that is not the one you want"
-        ]
-    );
-}
-
-#[test]
-fn a_trailing_comment_is_not_a_different_default() {
-    let notes = conflict_notes(&shipped(&[
-        ("alpha", "[env]\n# Wait.\nWAIT = \"900\"\n"),
-        ("beta", "[env]\n# Wait.\nWAIT = \"900\" # seconds\n"),
-    ]));
-    assert!(notes.is_empty(), "{notes:?}");
-}
-
-#[test]
-fn catalog_text_reaches_a_note_escaped() {
-    let notes = conflict_notes(&shipped(&[
-        ("alpha", "[env]\n# Wait.\nWAIT = \"90\u{1b}[31m0\"\n"),
-        ("be\u{1b}[31mta", "[env]\n# Wait.\nWAIT = \"600\"\n"),
-    ]));
-    assert_eq!(notes.len(), 1, "{notes:?}");
-    assert!(!notes[0].contains('\u{1b}'), "{notes:?}");
-    assert!(notes[0].contains("\\u{1b}[31m"), "{notes:?}");
-}
-
 /// A container the reader does not track ends the `[env]` section where
 /// no table starts, and the seed lands inside somebody's value. Both
 /// shapes: a nested `[` taken for a header, and a header the boundary
@@ -655,7 +552,7 @@ fn a_value_spanning_lines_is_seeded_whole() {
             value.lines().count(),
             "{value}"
         );
-        assert!(entries[0].closes(), "{value}");
+        assert!(entries[0].complete(), "{value}");
 
         let (text, added) = merge(None, &seeded(&template, "review")).expect("both are missing");
         assert_eq!(added, ["BLOB", "DEPTH"], "{value}");
@@ -683,7 +580,7 @@ fn a_value_nothing_closes_is_refused_by_name() {
     let template = "[env]\n# How deep.\nDEPTH = \"2\"\n\n# A blob.\nBLOB = \"\"\"\nsome text\n";
     let entries = extract_env_entries(template);
     assert_eq!(entry_keys(&entries), ["DEPTH", "BLOB"]);
-    assert!(!entries[1].closes(), "{entries:?}");
+    assert!(!entries[1].complete(), "{entries:?}");
     assert!(entries[1].assignment.is_empty(), "{entries:?}");
 
     let shipped = seeded(template, "review");
@@ -710,23 +607,84 @@ fn a_value_nothing_closes_is_refused_by_name() {
     assert!(text.contains("BLOB = \"ok\""), "{text}");
 }
 
-/// Two packages shipping one key with different multiline values do
-/// disagree, and the note has to say so. Shown from the `=` line alone
-/// both read as a bare `"""` and the note would group them as agreeing.
+/// Closing and being finished are different questions, and the shape that
+/// proves it is the one closest to what this all exists to prevent: a
+/// single-line string ends with its line by definition, so `TOKEN = "`
+/// carries nothing onto the next line and is still unfinished. Read
+/// completeness off the absence of a carry and it seeds, putting an
+/// unterminated line in the consumer's file — the exact outcome refused
+/// everywhere else here.
 #[test]
-fn two_different_multiline_defaults_are_not_one_default() {
-    let template = |body: &str| format!("[env]\n# A blob.\nBLOB = \"\"\"\n{body}\n\"\"\"\n");
-    let mut shipped = seeded(&template("from a"), "a");
-    shipped.extend(seeded(&template("from b"), "b"));
-    let notes = conflict_notes(&shipped);
-    assert_eq!(notes.len(), 1, "{notes:?}");
-    // Each value shown whole on the one line, so the two read as the
-    // different defaults they are.
-    assert!(notes[0].contains("\"\"\" from a \"\"\" (a)"), "{notes:?}");
-    assert!(notes[0].contains("\"\"\" from b \"\"\" (b)"), "{notes:?}");
+fn a_one_line_value_left_unterminated_is_refused_by_name() {
+    for template in [
+        "[env]\n# A token.\nTOKEN = \"\n",
+        // With the file continuing under it, and with no terminator.
+        "[env]\n# A token.\nTOKEN = \"\n\n# How deep.\nDEPTH = \"2\"\n",
+        "[env]\n# A token.\nTOKEN = \"",
+    ] {
+        let entries = extract_env_entries(template);
+        assert!(!entries[0].complete(), "{template:?}: {entries:?}");
+        assert!(entries[0].assignment.is_empty(), "{template:?}");
 
-    // And two shipping the SAME multiline value still say nothing.
-    let mut agreeing = seeded(&template("same"), "a");
-    agreeing.extend(seeded(&template("same"), "b"));
-    assert!(conflict_notes(&agreeing).is_empty());
+        let shipped = seeded(template, "review");
+        let written = merge(None, &shipped);
+        assert!(
+            !written
+                .as_ref()
+                .is_some_and(|(text, _)| text.contains("TOKEN")),
+            "{template:?}: nothing may be written for it: {written:?}"
+        );
+        if let Some((text, _)) = &written {
+            text.parse::<toml::Table>()
+                .unwrap_or_else(|e| panic!("{template:?}: seeded file must parse: {e}\n{text}"));
+        }
+        let notes = unterminated_notes(&shipped);
+        assert_eq!(notes.len(), 1, "{template:?}: {notes:?}");
+        assert!(notes[0].contains("TOKEN"), "{template:?}: {notes:?}");
+    }
+}
+
+/// One key, one winner, and everyone has to name it. A broken template
+/// declaring a key before a valid one had `merge` write the valid skill's
+/// bytes while the ledger and the notes named the broken one — a record
+/// pointing at a template that supplied nothing, which stops the real
+/// owner's comments refreshing and lets the broken owner's overwrite them.
+#[test]
+fn a_broken_declaration_before_a_valid_one_never_becomes_the_owner() {
+    let mut shipped = seeded("[env]\n# Theirs.\nMODE = \"\n", "broken");
+    shipped.extend(seeded("[env]\n# Ours.\nMODE = \"real\"\n", "good"));
+    assert_eq!(shipped.len(), 2, "both declarations are entries");
+
+    // The bytes written.
+    let (text, added) = merge(None, &shipped).expect("MODE is missing");
+    assert_eq!(added, ["MODE"]);
+    assert!(text.contains("MODE = \"real\""), "{text}");
+    assert!(text.contains("# Ours."), "the winner's comment too: {text}");
+
+    // The ledger.
+    let mut ledger = BTreeMap::new();
+    record_seeds(&mut ledger, &shipped, &added);
+    assert_eq!(ledger["MODE"].owner.as_deref(), Some("good"));
+
+    // The selection everyone asks.
+    assert_eq!(
+        writable_for(&shipped, "MODE").map(|s| s.owner.as_str()),
+        Some("good")
+    );
+
+    // And the notes: a broken declaration is not a competing default that
+    // lands, so nothing claims the broken skill's value was seeded.
+    for note in seed_notes(&shipped) {
+        assert!(!note.contains("broken's is the one seeded"), "{note}");
+    }
+
+    // The refresh gate follows the same winner: with the ledger naming
+    // `good`, `good`'s template is the one whose comment may rewrite.
+    let file = "[env]\n# Ours.\nMODE = \"mine\"\n";
+    let mut revised = seeded("[env]\n# Theirs, revised.\nMODE = \"\n", "broken");
+    revised.extend(seeded("[env]\n# Ours, revised.\nMODE = \"real\"\n", "good"));
+    let (out, updated) = refresh_comments(file, &revised, &mut ledger);
+    assert_eq!(updated, ["MODE"]);
+    assert!(out.contains("# Ours, revised."), "{out}");
+    assert!(!out.contains("Theirs"), "{out}");
 }

--- a/crates/core/src/settings_seed/tests.rs
+++ b/crates/core/src/settings_seed/tests.rs
@@ -688,3 +688,66 @@ fn a_broken_declaration_before_a_valid_one_never_becomes_the_owner() {
     assert!(out.contains("# Ours, revised."), "{out}");
     assert!(!out.contains("Theirs"), "{out}");
 }
+
+/// The third form completeness had not been asked about. TOML 1.0 forbids
+/// a newline inside an inline table, so `MAP = {` is broken where it
+/// stands: nothing carries, and asking only what carries called it
+/// finished and wrote it into the consumer's file. Completeness now comes
+/// off the grammar's own split — a form either may cross a newline or may
+/// not — so every delimited form answers, not the two remembered.
+#[test]
+fn an_inline_table_left_open_is_refused_by_name() {
+    for template in [
+        "[env]\n# A map.\nMAP = {\n",
+        "[env]\n# A map.\nMAP = { a = 1,\n\n# How deep.\nDEPTH = \"2\"\n",
+        "[env]\n# A map.\nMAP = { a = { b = 1 }\n",
+        "[env]\n# A map.\nMAP = {",
+    ] {
+        let entries = extract_env_entries(template);
+        assert!(!entries[0].complete(), "{template:?}: {entries:?}");
+
+        let shipped = seeded(template, "review");
+        let written = merge(None, &shipped);
+        assert!(
+            !written
+                .as_ref()
+                .is_some_and(|(text, _)| text.contains("MAP")),
+            "{template:?}: nothing may be written for it: {written:?}"
+        );
+        if let Some((text, _)) = &written {
+            text.parse::<toml::Table>()
+                .unwrap_or_else(|e| panic!("{template:?}: must parse: {e}\n{text}"));
+        }
+        let notes = unterminated_notes(&shipped);
+        assert_eq!(notes.len(), 1, "{template:?}: {notes:?}");
+        assert!(notes[0].contains("MAP"), "{template:?}: {notes:?}");
+    }
+}
+
+/// The other half: an inline table that closes on its line is an ordinary
+/// complete value and seeds like any other. A completeness rule that
+/// refused every brace would be as wrong as one that accepted every brace.
+#[test]
+fn an_inline_table_that_closes_seeds_like_any_other_value() {
+    for value in [
+        "{ a = 1 }",
+        "{ a = { b = 1 } }",
+        "{ a = \"}\" }",
+        "{ a = [1, 2] }",
+    ] {
+        let template = format!("[env]\n# A map.\nMAP = {value}\n");
+        let entries = extract_env_entries(&template);
+        assert!(entries[0].complete(), "{value}: {entries:?}");
+        assert_eq!(entries[0].assignment, [format!("MAP = {value}")], "{value}");
+
+        let shipped = seeded(&template, "review");
+        assert!(unterminated_notes(&shipped).is_empty(), "{value}");
+        let (text, added) = merge(None, &shipped).expect("MAP is missing");
+        assert_eq!(added, ["MAP"], "{value}");
+        let want: toml::Table = template.parse().expect("the template parses");
+        let got: toml::Table = text
+            .parse()
+            .unwrap_or_else(|e| panic!("{value}: seeded file must parse: {e}\n{text}"));
+        assert_eq!(got["env"]["MAP"], want["env"]["MAP"], "{value}");
+    }
+}

--- a/crates/core/src/settings_seed/tests.rs
+++ b/crates/core/src/settings_seed/tests.rs
@@ -419,12 +419,10 @@ fn a_broken_declaration_before_a_valid_one_never_becomes_the_owner() {
     assert!(!out.contains("Theirs"), "{out}");
 }
 
-/// The third form completeness had not been asked about. TOML 1.0 forbids
-/// a newline inside an inline table, so `MAP = {` is broken where it
-/// stands: nothing carries, and asking only what carries called it
-/// finished and wrote it into the consumer's file. Completeness now comes
-/// off the grammar's own split — a form either may cross a newline or may
-/// not — so every delimited form answers, not the two remembered.
+/// An inline table the file never closes is refused like any other
+/// container the file never closes: the carry runs to the end and nothing
+/// completes it. Completeness comes off the grammar's own split rather
+/// than a rule per form, so this needs no case of its own.
 #[test]
 fn an_inline_table_left_open_is_refused_by_name() {
     for template in [
@@ -454,9 +452,9 @@ fn an_inline_table_left_open_is_refused_by_name() {
     }
 }
 
-/// The other half: an inline table that closes on its line is an ordinary
-/// complete value and seeds like any other. A completeness rule that
-/// refused every brace would be as wrong as one that accepted every brace.
+/// The other half: an inline table that closes is an ordinary complete
+/// value and seeds like any other. A completeness rule that refused every
+/// brace would be as wrong as one that accepted every brace.
 #[test]
 fn an_inline_table_that_closes_seeds_like_any_other_value() {
     for value in [
@@ -582,4 +580,53 @@ fn the_refusal_names_the_key_and_no_particular_delimiter() {
             );
         }
     }
+}
+
+/// An inline table spanning lines is a value like any other under the spec
+/// this workspace parses with. Treated as line-local it was refused, and
+/// worse: the lines holding it read as structure, so `a = 1` beneath
+/// `MAP = {` seeded as a key of its own that the template never declared.
+#[test]
+fn an_inline_table_spanning_lines_is_seeded_whole() {
+    for value in [
+        "{\na = 1\n}",
+        "{ items = [\n  1,\n] }",
+        "{\n  a = { b = 1 },\n}",
+        "{\n  a = \"\"\"\n  text\n  \"\"\",\n}",
+    ] {
+        let template = format!("[env]\n# A map.\nMAP = {value}\n");
+        let entries = extract_env_entries(&template);
+        // One entry, not one per line the value happens to hold.
+        assert_eq!(entry_keys(&entries), ["MAP"], "{value}");
+        assert!(entries[0].complete(), "{value}: {entries:?}");
+        assert_eq!(entries[0].assignment, format!("MAP = {value}"), "{value}");
+
+        let shipped = seeded(&template, "review");
+        assert!(seed_notes(&shipped).is_empty(), "{value}");
+        let (text, added) = merge(None, &shipped).expect("MAP is missing");
+        assert_eq!(added, ["MAP"], "{value}");
+        let want: toml::Table = template.parse().expect("the template parses");
+        let got: toml::Table = text
+            .parse()
+            .unwrap_or_else(|e| panic!("{value}: seeded file must parse: {e}\n{text}"));
+        assert_eq!(got["env"]["MAP"], want["env"]["MAP"], "{value}");
+    }
+}
+
+/// A key beneath a multiline value belongs to the value, and one beneath a
+/// closed one belongs to the file. Both directions, because reading the
+/// first as structure is what invented a declaration.
+#[test]
+fn a_key_under_an_inline_table_belongs_to_whichever_owns_its_line() {
+    let inside = "[env]\n# A map.\nMAP = {\na = 1\n}\n\n# How deep.\nDEPTH = \"2\"\n";
+    assert_eq!(entry_keys(&extract_env_entries(inside)), ["MAP", "DEPTH"]);
+
+    let (text, added) = merge(None, &seeded(inside, "review")).expect("both are missing");
+    assert_eq!(added, ["MAP", "DEPTH"]);
+    let got: toml::Table = text.parse().expect("the seeded file parses");
+    assert!(got["env"]["MAP"].get("a").is_some(), "{text}");
+    assert!(
+        got["env"].get("a").is_none(),
+        "a is MAP's, not the table's: {text}"
+    );
 }

--- a/crates/core/src/settings_seed/tests.rs
+++ b/crates/core/src/settings_seed/tests.rs
@@ -3,6 +3,7 @@ use std::collections::BTreeMap;
 use super::*;
 
 mod notes;
+mod refresh;
 
 const TEMPLATE: &str = "# ignored preamble\n[env]\n# Which reviewer set to run.\n# Comma separated.\nREVIEWERS = \"arch,security\"\n\nDEPTH = \"2\"\n\n[other]\nX = \"1\"\n";
 
@@ -16,21 +17,13 @@ fn seeded(template: &str, owner: &str) -> Vec<SeededEnv> {
         .collect()
 }
 
-/// The ledger as seeding would have left it for these entries.
-fn ledger_for(entries: &[SeededEnv]) -> BTreeMap<String, SettingsSeed> {
-    entries
-        .iter()
-        .map(|seeded| (seeded.entry.key.clone(), seeded.seed_record()))
-        .collect()
-}
-
 #[test]
 fn entries_carry_their_comment_blocks() {
     let entries = extract_env_entries(TEMPLATE);
     assert_eq!(entries.len(), 2);
     assert_eq!(entries[0].key, "REVIEWERS");
     assert_eq!(entries[0].comment.len(), 2);
-    assert_eq!(entries[0].assignment, ["REVIEWERS = \"arch,security\""]);
+    assert_eq!(entries[0].assignment, "REVIEWERS = \"arch,security\"");
     assert_eq!(entries[1].key, "DEPTH");
 }
 
@@ -83,264 +76,6 @@ fn merge_at_file_end_repairs_a_missing_terminator_once() {
     assert!(merged.ends_with("DEPTH = \"2\"\n"));
 }
 
-#[test]
-fn unedited_seeded_comment_refreshes_when_the_template_revises_it() {
-    let v1 = seeded("[env]\n# Old words.\nDEPTH = \"2\"\n", "review");
-    let mut ledger = ledger_for(&v1);
-    let file = "[env]\n# Old words.\nDEPTH = \"9\"\n";
-
-    let v2 = seeded(
-        "[env]\n# New words.\n# Two lines now.\nDEPTH = \"2\"\n",
-        "review",
-    );
-    let (out, updated) = refresh_comments(file, &v2, &mut ledger);
-    assert_eq!(updated, ["DEPTH"]);
-    assert_eq!(
-        out,
-        "[env]\n# New words.\n# Two lines now.\nDEPTH = \"9\"\n"
-    );
-    assert_eq!(
-        ledger.get("DEPTH").unwrap().hash,
-        comment_hash(&["# New words.".to_owned(), "# Two lines now.".to_owned()]),
-        "the ledger follows the rewrite"
-    );
-
-    // Idempotent: running again changes nothing.
-    let (again, updated) = refresh_comments(&out, &v2, &mut ledger);
-    assert_eq!(again, out);
-    assert!(updated.is_empty());
-}
-
-#[test]
-fn a_hand_edited_comment_is_preserved_forever() {
-    let v1 = seeded("[env]\n# Old words.\nDEPTH = \"2\"\n", "review");
-    let mut ledger = ledger_for(&v1);
-    let file = "[env]\n# My own explanation.\nDEPTH = \"9\"\n";
-
-    let v2 = seeded("[env]\n# New words.\nDEPTH = \"2\"\n", "review");
-    let (out, updated) = refresh_comments(file, &v2, &mut ledger);
-    assert_eq!(out, file, "a hand-edited comment never rewrites");
-    assert!(updated.is_empty());
-}
-
-#[test]
-fn value_lines_are_untouched_byte_for_byte() {
-    let v1 = seeded("[env]\n# Old.\nDEPTH = \"2\"\n", "review");
-    let mut ledger = ledger_for(&v1);
-    // Odd spacing and a trailing comment on the value line must survive.
-    let file = "[env]\n# Old.\nDEPTH   =\t\"9\"   # keep me\n";
-    let v2 = seeded("[env]\n# New.\nDEPTH = \"2\"\n", "review");
-    let (out, _) = refresh_comments(file, &v2, &mut ledger);
-    assert_eq!(out, "[env]\n# New.\nDEPTH   =\t\"9\"   # keep me\n");
-}
-
-#[test]
-fn crlf_and_missing_terminator_survive_outside_the_comment_block() {
-    let v1 = seeded("[env]\n# Old.\nDEPTH = \"2\"\n", "review");
-    let mut ledger = ledger_for(&v1);
-    let file = "# head\r\n[env]\r\n# Old.\r\nDEPTH = \"9\"\r\n\r\n[custom]\r\nX = \"1\"";
-    let v2 = seeded("[env]\n# New.\nDEPTH = \"2\"\n", "review");
-    let (out, updated) = refresh_comments(file, &v2, &mut ledger);
-    assert_eq!(updated, ["DEPTH"]);
-    assert_eq!(
-        out, "# head\r\n[env]\r\n# New.\r\nDEPTH = \"9\"\r\n\r\n[custom]\r\nX = \"1\"",
-        "comment bytes are the only bytes that changed"
-    );
-}
-
-#[test]
-fn another_owners_template_never_rewrites_a_seeded_comment() {
-    let original_owner = seeded("[env]\n# Old.\nDEPTH = \"2\"\n", "review");
-    let mut ledger = ledger_for(&original_owner);
-    let file = "[env]\n# Old.\nDEPTH = \"9\"\n";
-    // A different skill now ships the same key with new words.
-    let intruder = seeded("[env]\n# Their words.\nDEPTH = \"3\"\n", "other-skill");
-    let (out, updated) = refresh_comments(file, &intruder, &mut ledger);
-    assert_eq!(out, file);
-    assert!(updated.is_empty());
-    assert_eq!(
-        ledger.get("DEPTH").unwrap().owner.as_deref(),
-        Some("review"),
-        "the record stays with its owner"
-    );
-}
-
-#[test]
-fn a_v1_imported_record_verifies_but_never_rewrites() {
-    let mut ledger = BTreeMap::new();
-    ledger.insert(
-        "DEPTH".to_owned(),
-        SettingsSeed {
-            owner: None,
-            hash: comment_hash(&["# Old.".to_owned()]),
-        },
-    );
-    let file = "[env]\n# Old.\nDEPTH = \"9\"\n";
-    let v2 = seeded("[env]\n# New.\nDEPTH = \"2\"\n", "review");
-    let (out, updated) = refresh_comments(file, &v2, &mut ledger);
-    assert_eq!(out, file, "legacy-owned: preserved, never rewritten");
-    assert!(updated.is_empty());
-    assert_eq!(ledger.get("DEPTH").unwrap().owner, None);
-}
-
-#[test]
-fn bootstrap_adopts_a_template_matching_comment_and_freezes_an_edited_one() {
-    // Pre-ledger install: the file matches the current template exactly.
-    let mut ledger = BTreeMap::new();
-    let file = "[env]\n# Current words.\nDEPTH = \"9\"\n";
-    let current = seeded("[env]\n# Current words.\nDEPTH = \"2\"\n", "review");
-    let (out, updated) = refresh_comments(file, &current, &mut ledger);
-    assert_eq!(out, file);
-    assert!(updated.is_empty());
-    assert_eq!(
-        ledger.get("DEPTH").unwrap().owner.as_deref(),
-        Some("review"),
-        "a matching comment is adopted into the ledger"
-    );
-    // The next template revision now refreshes it.
-    let revised = seeded("[env]\n# Revised words.\nDEPTH = \"2\"\n", "review");
-    let (out, updated) = refresh_comments(&out, &revised, &mut ledger);
-    assert_eq!(updated, ["DEPTH"]);
-    assert!(out.contains("# Revised words."));
-
-    // Pre-ledger install whose comment differs: hand-edited, never adopted.
-    let mut ledger = BTreeMap::new();
-    let edited = "[env]\n# Somebody's own words.\nDEPTH = \"9\"\n";
-    let (out, updated) = refresh_comments(edited, &revised, &mut ledger);
-    assert_eq!(out, edited);
-    assert!(updated.is_empty());
-    assert!(!ledger.contains_key("DEPTH"));
-}
-
-/// A bare key says nothing about who wrote it: an empty on-disk block
-/// matching an empty template block is not adoption evidence, or a later
-/// template revision would write prose above a line the user typed.
-#[test]
-fn a_bare_key_is_never_adopted() {
-    let mut ledger = BTreeMap::new();
-    let file = "[env]\nDEPTH = \"9\"\n";
-    let bare = seeded("[env]\nDEPTH = \"2\"\n", "review");
-    let (out, updated) = refresh_comments(file, &bare, &mut ledger);
-    assert_eq!(out, file);
-    assert!(updated.is_empty());
-    assert!(!ledger.contains_key("DEPTH"), "nothing to adopt");
-
-    let with_words = seeded("[env]\n# Now with words.\nDEPTH = \"2\"\n", "review");
-    let (out, updated) = refresh_comments(file, &with_words, &mut ledger);
-    assert_eq!(out, file, "the user's bare key stays bare");
-    assert!(updated.is_empty());
-}
-
-/// A v1 import names no owner. A template earns the record when the
-/// comment on disk is provably what v1 seeded and matches the template
-/// word for word; a comment that drifted stays legacy-owned.
-#[test]
-fn a_v1_record_is_adopted_only_by_a_matching_template_over_unedited_text() {
-    let mut ledger = BTreeMap::new();
-    ledger.insert(
-        "DEPTH".to_owned(),
-        SettingsSeed {
-            owner: None,
-            hash: comment_hash(&["# Old.".to_owned()]),
-        },
-    );
-    let file = "[env]\n# Old.\nDEPTH = \"9\"\n";
-    let same_words = seeded("[env]\n# Old.\nDEPTH = \"2\"\n", "review");
-    let (out, updated) = refresh_comments(file, &same_words, &mut ledger);
-    assert_eq!(out, file);
-    assert!(updated.is_empty());
-    assert_eq!(
-        ledger.get("DEPTH").unwrap().owner.as_deref(),
-        Some("review"),
-        "provably unedited and word-for-word the template: adopted"
-    );
-    let revised = seeded("[env]\n# Newer.\nDEPTH = \"2\"\n", "review");
-    let (out, updated) = refresh_comments(&out, &revised, &mut ledger);
-    assert_eq!(updated, ["DEPTH"]);
-    assert!(out.contains("# Newer."));
-
-    // Hand-edited since v1 seeded it (hash no longer matches), even if the
-    // words now happen to equal a template: legacy-owned, frozen.
-    let mut ledger = BTreeMap::new();
-    ledger.insert(
-        "DEPTH".to_owned(),
-        SettingsSeed {
-            owner: None,
-            hash: comment_hash(&["# What v1 wrote.".to_owned()]),
-        },
-    );
-    let edited = "[env]\n# Old.\nDEPTH = \"9\"\n";
-    refresh_comments(edited, &same_words, &mut ledger);
-    assert_eq!(ledger.get("DEPTH").unwrap().owner, None);
-}
-
-/// Two skills ship one key. Seeding wrote the first declaration; a later
-/// pass where the other skill enumerates first must still refresh from
-/// the recorded owner's template — declaration order never shadows the
-/// ledger.
-#[test]
-fn the_recorded_owner_speaks_for_a_key_several_skills_ship() {
-    let review = seeded("[env]\n# Review's words.\nDEPTH = \"2\"\n", "review");
-    let mut ledger = ledger_for(&review);
-    let file = "[env]\n# Review's words.\nDEPTH = \"9\"\n";
-    let mut entries = seeded("[env]\n# Lint's words.\nDEPTH = \"1\"\n", "aaa-lint");
-    entries.extend(seeded(
-        "[env]\n# Review's better words.\nDEPTH = \"2\"\n",
-        "review",
-    ));
-    let (out, updated) = refresh_comments(file, &entries, &mut ledger);
-    assert_eq!(updated, ["DEPTH"]);
-    assert!(out.contains("# Review's better words."), "{out}");
-    assert!(!out.contains("# Lint's words."));
-    assert_eq!(
-        ledger.get("DEPTH").unwrap().owner.as_deref(),
-        Some("review")
-    );
-}
-
-/// Seeding writes the first declaration of a key and the ledger records
-/// that skill — the same choice, so the owner can refresh what it wrote.
-#[test]
-fn merge_seeds_the_first_declaration_and_records_it_as_owner() {
-    let mut entries = seeded("[env]\n# First.\nDEPTH = \"1\"\n", "first");
-    entries.extend(seeded("[env]\n# Second.\nDEPTH = \"2\"\n", "second"));
-    let (out, added) = merge(Some("[env]\n"), &entries).unwrap();
-    assert_eq!(added, ["DEPTH"]);
-    assert!(out.contains("# First.\nDEPTH = \"1\""), "{out}");
-    assert!(!out.contains("# Second."));
-    let mut ledger = BTreeMap::new();
-    record_seeds(&mut ledger, &entries, &added);
-    assert_eq!(ledger.get("DEPTH").unwrap().owner.as_deref(), Some("first"));
-}
-
-/// A hand-made duplicate inside `[env]` is judged once, at its first
-/// site — never two rewrites and never a key listed twice in the plan.
-#[test]
-fn a_duplicated_key_is_refreshed_once() {
-    let v1 = seeded("[env]\n# Old.\nDEPTH = \"2\"\n", "review");
-    let mut ledger = ledger_for(&v1);
-    let file = "[env]\n# Old.\nDEPTH = \"9\"\n# Old.\nDEPTH = \"8\"\n";
-    let v2 = seeded("[env]\n# New.\nDEPTH = \"2\"\n", "review");
-    let (out, updated) = refresh_comments(file, &v2, &mut ledger);
-    assert_eq!(updated, ["DEPTH"]);
-    assert_eq!(out, "[env]\n# New.\nDEPTH = \"9\"\n# Old.\nDEPTH = \"8\"\n");
-}
-
-#[test]
-fn comment_hash_matches_v1s_algorithm() {
-    // Locked against v1's `format!("{:016x}", fnv1a(join("\n")))` so
-    // imported ledgers verify without re-guessing.
-    assert_eq!(comment_hash(&[]), "cbf29ce484222325");
-    assert_eq!(comment_hash(&["# a".to_owned()]), {
-        let mut h: u64 = 0xcbf2_9ce4_8422_2325;
-        for b in b"# a" {
-            h ^= u64::from(*b);
-            h = h.wrapping_mul(0x0000_0100_0000_01b3);
-        }
-        format!("{h:016x}")
-    });
-}
-
 /// A container the reader does not track ends the `[env]` section where
 /// no table starts, and the seed lands inside somebody's value. Both
 /// shapes: a nested `[` taken for a header, and a header the boundary
@@ -351,7 +86,7 @@ fn a_seed_lands_after_the_env_table_and_never_inside_a_value() {
         entry: EnvEntry {
             key: "DEPTH".to_owned(),
             comment: vec!["# How deep.".to_owned()],
-            assignment: vec!["DEPTH = \"2\"".to_owned()],
+            assignment: "DEPTH = \"2\"".to_owned(),
         },
         owner: "review".to_owned(),
     }];
@@ -388,7 +123,7 @@ fn a_header_the_loaders_refuse_is_still_the_table_a_seed_lands_in() {
         entry: EnvEntry {
             key: "DEPTH".to_owned(),
             comment: vec!["# How deep.".to_owned()],
-            assignment: vec!["DEPTH = \"2\"".to_owned()],
+            assignment: "DEPTH = \"2\"".to_owned(),
         },
         owner: "review".to_owned(),
     }];
@@ -437,7 +172,7 @@ fn any_spelling_of_the_env_header_is_the_table_a_seed_lands_in() {
         entry: EnvEntry {
             key: "DEPTH".to_owned(),
             comment: vec!["# How deep.".to_owned()],
-            assignment: vec!["DEPTH = \"2\"".to_owned()],
+            assignment: "DEPTH = \"2\"".to_owned(),
         },
         owner: "review".to_owned(),
     }];
@@ -469,7 +204,7 @@ fn an_env_declared_as_an_array_of_tables_is_refused_rather_than_seeded() {
         entry: EnvEntry {
             key: "DEPTH".to_owned(),
             comment: vec!["# How deep.".to_owned()],
-            assignment: vec!["DEPTH = \"2\"".to_owned()],
+            assignment: "DEPTH = \"2\"".to_owned(),
         },
         owner: "review".to_owned(),
     }];
@@ -493,7 +228,7 @@ fn a_top_level_env_assignment_is_refused_rather_than_seeded() {
         entry: EnvEntry {
             key: "DEPTH".to_owned(),
             comment: vec!["# How deep.".to_owned()],
-            assignment: vec!["DEPTH = \"2\"".to_owned()],
+            assignment: "DEPTH = \"2\"".to_owned(),
         },
         owner: "review".to_owned(),
     }];
@@ -545,13 +280,8 @@ fn a_value_spanning_lines_is_seeded_whole() {
         // The value's continuation lines are the assignment's, and the
         // comment above it is still only the comment.
         assert_eq!(entries[0].comment, ["# A blob."], "{value}");
-        // One assignment line per line of the value: the first carries
-        // the `=`, the last closes it.
-        assert_eq!(
-            entries[0].assignment.len(),
-            value.lines().count(),
-            "{value}"
-        );
+        // The whole assignment, spelled as the template spells it.
+        assert_eq!(entries[0].assignment, format!("BLOB = {value}"), "{value}");
         assert!(entries[0].complete(), "{value}");
 
         let (text, added) = merge(None, &seeded(&template, "review")).expect("both are missing");
@@ -738,7 +468,7 @@ fn an_inline_table_that_closes_seeds_like_any_other_value() {
         let template = format!("[env]\n# A map.\nMAP = {value}\n");
         let entries = extract_env_entries(&template);
         assert!(entries[0].complete(), "{value}: {entries:?}");
-        assert_eq!(entries[0].assignment, [format!("MAP = {value}")], "{value}");
+        assert_eq!(entries[0].assignment, format!("MAP = {value}"), "{value}");
 
         let shipped = seeded(&template, "review");
         assert!(unterminated_notes(&shipped).is_empty(), "{value}");
@@ -749,5 +479,107 @@ fn an_inline_table_that_closes_seeds_like_any_other_value() {
             .parse()
             .unwrap_or_else(|e| panic!("{value}: seeded file must parse: {e}\n{text}"));
         assert_eq!(got["env"]["MAP"], want["env"]["MAP"], "{value}");
+    }
+}
+
+/// Two kinds of newline meet in a seeded block and only one of them is the
+/// file's. The terminators between entries and around the block are the
+/// destination's; the ones INSIDE a multiline value are the value's own
+/// content, and rewriting them hands the consumer a different string from
+/// the one the template declared.
+#[test]
+fn a_values_own_newlines_survive_a_file_that_spells_them_differently() {
+    let template = "[env]\n# A blob.\nBLOB = \"\"\"\nline one\nline two\n\"\"\"\n";
+    let file = "[env]\r\nMODE = \"a\"\r\n";
+    let (out, added) = merge(Some(file), &seeded(template, "review")).expect("BLOB is missing");
+    assert_eq!(added, ["BLOB"]);
+
+    // The value arrives exactly as the template spelled it.
+    assert!(
+        out.contains("BLOB = \"\"\"\nline one\nline two\n\"\"\""),
+        "{out:?}"
+    );
+    // And the lines around it are the file's own.
+    assert!(out.contains("# A blob.\r\n"), "{out:?}");
+    assert!(out.ends_with("\"\"\"\r\n"), "{out:?}");
+    assert!(
+        out.starts_with(file),
+        "the original bytes are untouched: {out:?}"
+    );
+
+    // What the consumer reads back is the template's value, unchanged.
+    let want: toml::Table = template.parse().expect("the template parses");
+    let got: toml::Table = out.parse().expect("the seeded file parses");
+    assert_eq!(got["env"]["BLOB"], want["env"]["BLOB"], "{out:?}");
+
+    // The other direction too: a CRLF template into an LF file.
+    let crlf = "[env]\r\n# A blob.\r\nBLOB = \"\"\"\r\nline one\r\n\"\"\"\r\n";
+    let (out, _) = merge(Some("[env]\nMODE = \"a\"\n"), &seeded(crlf, "review")).expect("missing");
+    assert!(
+        out.contains("BLOB = \"\"\"\r\nline one\r\n\"\"\""),
+        "{out:?}"
+    );
+    assert!(out.contains("# A blob.\n"), "{out:?}");
+}
+
+/// An incomplete declaration ships no default, so it cannot disagree with
+/// one. Grouped as if it did, a broken declaration beside a valid one
+/// produced a conflict note between two skills where only one had said
+/// anything — and the seed itself was already correct, so the note sent a
+/// person to arbitrate a disagreement that did not exist.
+#[test]
+fn an_incomplete_declaration_is_not_a_default_to_disagree_with() {
+    let mut shipped = seeded("[env]\n# Theirs.\nBLOB = \"\"\"\n", "broken");
+    shipped.extend(seeded("[env]\n# Ours.\nBLOB = \"ok\"\n", "good"));
+
+    assert!(
+        conflict_notes(&shipped).is_empty(),
+        "one default is not a disagreement: {:?}",
+        conflict_notes(&shipped)
+    );
+    // The key is supplied, so nothing is refused either: no note at all.
+    assert!(unterminated_notes(&shipped).is_empty());
+    assert!(
+        seed_notes(&shipped).is_empty(),
+        "{:?}",
+        seed_notes(&shipped)
+    );
+
+    let (text, added) = merge(None, &shipped).expect("BLOB is missing");
+    assert_eq!(added, ["BLOB"]);
+    assert!(text.contains("BLOB = \"ok\""), "{text}");
+
+    // Two complete declarations that really do differ still say so.
+    let mut real = seeded("[env]\n# Theirs.\nBLOB = \"theirs\"\n", "one");
+    real.extend(seeded("[env]\n# Ours.\nBLOB = \"ours\"\n", "two"));
+    assert_eq!(
+        conflict_notes(&real).len(),
+        1,
+        "{:?}",
+        conflict_notes(&real)
+    );
+}
+
+/// The refusal fires for every form the grammar can leave open, so it may
+/// not name a subset of them. Naming "a string or an array" sent somebody
+/// whose inline table was unclosed to the wrong part of their template,
+/// and any list goes stale the moment the enumerated grammar grows.
+#[test]
+fn the_refusal_names_the_key_and_no_particular_delimiter() {
+    for (template, key) in [
+        ("[env]\n# A.\nTOKEN = \"\n", "TOKEN"),
+        ("[env]\n# A.\nMAP = {\n", "MAP"),
+        ("[env]\n# A.\nLIST = [\n", "LIST"),
+        ("[env]\n# A.\nBLOB = \"\"\"\n", "BLOB"),
+    ] {
+        let notes = unterminated_notes(&seeded(template, "review"));
+        assert_eq!(notes.len(), 1, "{template:?}: {notes:?}");
+        assert!(notes[0].contains(key), "the key is named: {notes:?}");
+        for named in ["string", "array", "inline table", "quote", "bracket"] {
+            assert!(
+                !notes[0].contains(named),
+                "{template:?}: names {named}, which is only true of some: {notes:?}"
+            );
+        }
     }
 }

--- a/crates/core/src/settings_seed/tests.rs
+++ b/crates/core/src/settings_seed/tests.rs
@@ -27,7 +27,8 @@ fn entries_carry_their_comment_blocks() {
     let entries = extract_env_entries(TEMPLATE);
     assert_eq!(entries.len(), 2);
     assert_eq!(entries[0].key, "REVIEWERS");
-    assert_eq!(entries[0].lines.len(), 3);
+    assert_eq!(entries[0].comment.len(), 2);
+    assert_eq!(entries[0].assignment, ["REVIEWERS = \"arch,security\""]);
     assert_eq!(entries[1].key, "DEPTH");
 }
 
@@ -452,7 +453,8 @@ fn a_seed_lands_after_the_env_table_and_never_inside_a_value() {
     let seeded = [SeededEnv {
         entry: EnvEntry {
             key: "DEPTH".to_owned(),
-            lines: vec!["# How deep.".to_owned(), "DEPTH = \"2\"".to_owned()],
+            comment: vec!["# How deep.".to_owned()],
+            assignment: vec!["DEPTH = \"2\"".to_owned()],
         },
         owner: "review".to_owned(),
     }];
@@ -488,7 +490,8 @@ fn a_header_the_loaders_refuse_is_still_the_table_a_seed_lands_in() {
     let seeded = [SeededEnv {
         entry: EnvEntry {
             key: "DEPTH".to_owned(),
-            lines: vec!["# How deep.".to_owned(), "DEPTH = \"2\"".to_owned()],
+            comment: vec!["# How deep.".to_owned()],
+            assignment: vec!["DEPTH = \"2\"".to_owned()],
         },
         owner: "review".to_owned(),
     }];
@@ -536,7 +539,8 @@ fn any_spelling_of_the_env_header_is_the_table_a_seed_lands_in() {
     let seeded = [SeededEnv {
         entry: EnvEntry {
             key: "DEPTH".to_owned(),
-            lines: vec!["# How deep.".to_owned(), "DEPTH = \"2\"".to_owned()],
+            comment: vec!["# How deep.".to_owned()],
+            assignment: vec!["DEPTH = \"2\"".to_owned()],
         },
         owner: "review".to_owned(),
     }];
@@ -567,7 +571,8 @@ fn an_env_declared_as_an_array_of_tables_is_refused_rather_than_seeded() {
     let seeded = [SeededEnv {
         entry: EnvEntry {
             key: "DEPTH".to_owned(),
-            lines: vec!["# How deep.".to_owned(), "DEPTH = \"2\"".to_owned()],
+            comment: vec!["# How deep.".to_owned()],
+            assignment: vec!["DEPTH = \"2\"".to_owned()],
         },
         owner: "review".to_owned(),
     }];
@@ -590,7 +595,8 @@ fn a_top_level_env_assignment_is_refused_rather_than_seeded() {
     let seeded = [SeededEnv {
         entry: EnvEntry {
             key: "DEPTH".to_owned(),
-            lines: vec!["# How deep.".to_owned(), "DEPTH = \"2\"".to_owned()],
+            comment: vec!["# How deep.".to_owned()],
+            assignment: vec!["DEPTH = \"2\"".to_owned()],
         },
         owner: "review".to_owned(),
     }];
@@ -618,4 +624,109 @@ fn a_top_level_env_assignment_is_refused_rather_than_seeded() {
         merge(Some(nested), &seeded).is_some(),
         "another table's env is not this file's env"
     );
+}
+
+/// Every entry key in declaration order.
+fn entry_keys(entries: &[EnvEntry]) -> Vec<&str> {
+    entries.iter().map(|entry| entry.key.as_str()).collect()
+}
+
+/// A value TOML lets span lines is seeded whole. Stopping at the line
+/// carrying the `=` would write `BLOB = """` with nothing under it: the
+/// string never closes, every key seeded after it falls inside it, and the
+/// consumer's file stops parsing from there down.
+#[test]
+fn a_value_spanning_lines_is_seeded_whole() {
+    for value in [
+        "\"\"\"\nsome text\n\"\"\"",
+        "'''\nsome text\n'''",
+        "[\n  \"a\",\n  \"b\",\n]",
+    ] {
+        let template = format!("[env]\n# A blob.\nBLOB = {value}\n\n# How deep.\nDEPTH = \"2\"\n");
+        let entries = extract_env_entries(&template);
+        assert_eq!(entry_keys(&entries), ["BLOB", "DEPTH"], "{value}");
+        // The value's continuation lines are the assignment's, and the
+        // comment above it is still only the comment.
+        assert_eq!(entries[0].comment, ["# A blob."], "{value}");
+        // One assignment line per line of the value: the first carries
+        // the `=`, the last closes it.
+        assert_eq!(
+            entries[0].assignment.len(),
+            value.lines().count(),
+            "{value}"
+        );
+        assert!(entries[0].closes(), "{value}");
+
+        let (text, added) = merge(None, &seeded(&template, "review")).expect("both are missing");
+        assert_eq!(added, ["BLOB", "DEPTH"], "{value}");
+        // Spelled as the template spells it, and closed: the seeded file
+        // parses, and BLOB reads back as the value the template declares.
+        assert!(
+            text.contains(&format!("BLOB = {value}\n")),
+            "{value}: {text}"
+        );
+        let want: toml::Table = template.parse().expect("the template parses");
+        let got: toml::Table = text
+            .parse()
+            .unwrap_or_else(|error| panic!("{value}: seeded file must parse: {error}\n{text}"));
+        assert_eq!(got["env"]["BLOB"], want["env"]["BLOB"], "{value}");
+        assert_eq!(got["env"]["DEPTH"], want["env"]["DEPTH"], "{value}");
+    }
+}
+
+/// A value nothing closes is not a multiline value: there is no complete
+/// text to copy, and writing the opening line alone is the corruption
+/// itself. Seeding writes nothing for that key — and says so, naming it.
+/// A silent drop would leave a key nobody finds until a script reads it.
+#[test]
+fn a_value_nothing_closes_is_refused_by_name() {
+    let template = "[env]\n# How deep.\nDEPTH = \"2\"\n\n# A blob.\nBLOB = \"\"\"\nsome text\n";
+    let entries = extract_env_entries(template);
+    assert_eq!(entry_keys(&entries), ["DEPTH", "BLOB"]);
+    assert!(!entries[1].closes(), "{entries:?}");
+    assert!(entries[1].assignment.is_empty(), "{entries:?}");
+
+    let shipped = seeded(template, "review");
+    let (text, added) = merge(None, &shipped).expect("DEPTH is missing");
+    assert_eq!(added, ["DEPTH"]);
+    assert!(
+        !text.contains("BLOB"),
+        "no part of it may be written:\n{text}"
+    );
+    text.parse::<toml::Table>().expect("the seeded file parses");
+
+    let notes = unterminated_notes(&shipped);
+    assert_eq!(notes.len(), 1, "{notes:?}");
+    assert!(notes[0].contains("BLOB"), "the key is named: {notes:?}");
+    assert!(notes[0].contains("review"), "and who ships it: {notes:?}");
+
+    // Where another skill ships the same key whole, that one is seeded
+    // and nothing is reported: there is nothing for a person to do.
+    let whole = seeded("[env]\n# A blob.\nBLOB = \"ok\"\n", "other");
+    let both: Vec<SeededEnv> = shipped.iter().cloned().chain(whole).collect();
+    assert!(unterminated_notes(&both).is_empty(), "{both:?}");
+    let (text, added) = merge(None, &both).expect("both are missing");
+    assert_eq!(added, ["DEPTH", "BLOB"]);
+    assert!(text.contains("BLOB = \"ok\""), "{text}");
+}
+
+/// Two packages shipping one key with different multiline values do
+/// disagree, and the note has to say so. Shown from the `=` line alone
+/// both read as a bare `"""` and the note would group them as agreeing.
+#[test]
+fn two_different_multiline_defaults_are_not_one_default() {
+    let template = |body: &str| format!("[env]\n# A blob.\nBLOB = \"\"\"\n{body}\n\"\"\"\n");
+    let mut shipped = seeded(&template("from a"), "a");
+    shipped.extend(seeded(&template("from b"), "b"));
+    let notes = conflict_notes(&shipped);
+    assert_eq!(notes.len(), 1, "{notes:?}");
+    // Each value shown whole on the one line, so the two read as the
+    // different defaults they are.
+    assert!(notes[0].contains("\"\"\" from a \"\"\" (a)"), "{notes:?}");
+    assert!(notes[0].contains("\"\"\" from b \"\"\" (b)"), "{notes:?}");
+
+    // And two shipping the SAME multiline value still say nothing.
+    let mut agreeing = seeded(&template("same"), "a");
+    agreeing.extend(seeded(&template("same"), "b"));
+    assert!(conflict_notes(&agreeing).is_empty());
 }

--- a/crates/core/src/settings_seed/tests/notes.rs
+++ b/crates/core/src/settings_seed/tests/notes.rs
@@ -1,0 +1,154 @@
+//! What the plan says before a byte is written: shared keys with
+//! different defaults, and keys no template can supply.
+
+use super::*;
+
+/// Every `[env]` entry each named owner's template ships, in the order the
+/// owners are given — the order seeding resolves a shared key in.
+fn shipped(owners: &[(&str, &str)]) -> Vec<SeededEnv> {
+    owners
+        .iter()
+        .flat_map(|(owner, template)| seeded(template, owner))
+        .collect()
+}
+
+#[test]
+fn one_note_groups_every_owner_and_every_distinct_default() {
+    let notes = conflict_notes(&shipped(&[
+        ("alpha", "[env]\n# Wait.\nWAIT = \"900\"\n"),
+        ("beta", "[env]\n# Wait.\nWAIT = \"900\"\n"),
+        ("gamma", "[env]\n# Wait.\nWAIT = \"600\"\n"),
+    ]));
+    assert_eq!(
+        notes,
+        [
+            "kendex.settings.toml WAIT: packages ship different defaults — \"900\" (alpha, beta), \"600\" (gamma) — where this file does not already assign it, alpha's is the one seeded, so set the value yourself if that is not the one you want"
+        ]
+    );
+}
+
+#[test]
+fn packages_agreeing_on_a_shared_key_say_nothing() {
+    let notes = conflict_notes(&shipped(&[
+        (
+            "alpha",
+            "[env]\n# Mode.\nMODE = \"enforce\"\n# Wait.\nWAIT = \"900\"\n",
+        ),
+        (
+            "beta",
+            "[env]\n# Mode.\nMODE = \"enforce\"\n# Wait.\nWAIT = \"900\"\n",
+        ),
+    ]));
+    assert!(notes.is_empty(), "{notes:?}");
+}
+
+#[test]
+fn a_key_only_one_package_ships_says_nothing() {
+    let notes = conflict_notes(&shipped(&[
+        ("alpha", "[env]\n# Depth.\nDEPTH = \"2\"\n"),
+        ("beta", "[env]\n# Width.\nWIDTH = \"3\"\n"),
+    ]));
+    assert!(notes.is_empty(), "{notes:?}");
+}
+
+#[test]
+fn the_note_names_the_owner_whose_value_merge_actually_seeds() {
+    // alpha's default carries a trailing comment, which the loaders read
+    // and a stricter decoder once threw away — dropping alpha from the note
+    // and naming beta as the package whose value lands.
+    let entries = shipped(&[
+        ("alpha", "[env]\n# Wait.\nWAIT = \"900\" # seconds\n"),
+        ("beta", "[env]\n# Wait.\nWAIT = \"600\"\n"),
+        ("gamma", "[env]\n# Wait.\nWAIT = \"300\"\n"),
+    ]);
+    let notes = conflict_notes(&entries);
+    assert_eq!(
+        notes,
+        [
+            "kendex.settings.toml WAIT: packages ship different defaults — \"900\" (alpha), \"600\" (beta), \"300\" (gamma) — where this file does not already assign it, alpha's is the one seeded, so set the value yourself if that is not the one you want"
+        ]
+    );
+    // And alpha is what merge writes, which is what the note claims.
+    let (merged, added) = merge(None, &entries).unwrap();
+    assert_eq!(added, ["WAIT"]);
+    assert!(merged.contains("WAIT = \"900\" # seconds"), "{merged}");
+}
+
+#[test]
+fn a_default_no_decoder_reads_still_names_its_owner() {
+    let notes = conflict_notes(&shipped(&[
+        ("alpha", "[env]\n# Wait.\nWAIT = 900\n"),
+        ("beta", "[env]\n# Wait.\nWAIT = \"600\"\n"),
+    ]));
+    assert_eq!(
+        notes,
+        [
+            "kendex.settings.toml WAIT: packages ship different defaults — 900 (alpha), \"600\" (beta) — where this file does not already assign it, alpha's is the one seeded, so set the value yourself if that is not the one you want"
+        ]
+    );
+}
+
+#[test]
+fn a_trailing_comment_is_not_a_different_default() {
+    let notes = conflict_notes(&shipped(&[
+        ("alpha", "[env]\n# Wait.\nWAIT = \"900\"\n"),
+        ("beta", "[env]\n# Wait.\nWAIT = \"900\" # seconds\n"),
+    ]));
+    assert!(notes.is_empty(), "{notes:?}");
+}
+
+#[test]
+fn catalog_text_reaches_a_note_escaped() {
+    let notes = conflict_notes(&shipped(&[
+        ("alpha", "[env]\n# Wait.\nWAIT = \"90\u{1b}[31m0\"\n"),
+        ("be\u{1b}[31mta", "[env]\n# Wait.\nWAIT = \"600\"\n"),
+    ]));
+    assert_eq!(notes.len(), 1, "{notes:?}");
+    assert!(!notes[0].contains('\u{1b}'), "{notes:?}");
+    assert!(notes[0].contains("\\u{1b}[31m"), "{notes:?}");
+}
+
+/// Two packages shipping one key with different multiline values do
+/// disagree, and the note has to say so. Shown from the `=` line alone
+/// both read as a bare `"""` and the note would group them as agreeing.
+#[test]
+fn two_different_multiline_defaults_are_not_one_default() {
+    let template = |body: &str| format!("[env]\n# A blob.\nBLOB = \"\"\"\n{body}\n\"\"\"\n");
+    let mut shipped = seeded(&template("from a"), "a");
+    shipped.extend(seeded(&template("from b"), "b"));
+    let notes = conflict_notes(&shipped);
+    assert_eq!(notes.len(), 1, "{notes:?}");
+    // Each value shown whole on the one line, so the two read as the
+    // different defaults they are.
+    assert!(notes[0].contains("\"\"\" from a \"\"\" (a)"), "{notes:?}");
+    assert!(notes[0].contains("\"\"\" from b \"\"\" (b)"), "{notes:?}");
+
+    // And two shipping the SAME multiline value still say nothing.
+    let mut agreeing = seeded(&template("same"), "a");
+    agreeing.extend(seeded(&template("same"), "b"));
+    assert!(conflict_notes(&agreeing).is_empty());
+}
+/// Two defaults that differ only in what the display collapses are still
+/// two defaults. `default_shown` joins a value's lines with a space for
+/// reading, so a multiline holding `a\nb` and one holding `a b` render
+/// alike; grouped on that text the disagreement disappears, which is the
+/// one thing this note exists to catch.
+#[test]
+fn defaults_the_display_collapses_alike_are_still_a_disagreement() {
+    let template = |body: &str| format!("[env]\n# A blob.\nBLOB = \"\"\"\n{body}\n\"\"\"\n");
+    let mut shipped = seeded(&template("a\nb"), "split");
+    shipped.extend(seeded(&template("a b"), "joined"));
+    // The display cannot tell them apart; the note still must.
+    assert_eq!(shipped[0].default_shown(), shipped[1].default_shown());
+    assert_ne!(shipped[0].default_key(), shipped[1].default_key());
+
+    let notes = conflict_notes(&shipped);
+    assert_eq!(notes.len(), 1, "{notes:?}");
+    assert!(notes[0].contains("(split)"), "{notes:?}");
+    assert!(notes[0].contains("(joined)"), "{notes:?}");
+
+    // Two that really are the same value still say nothing.
+    let mut agreeing = seeded(&template("a\nb"), "one");
+    agreeing.extend(seeded(&template("a\nb"), "two"));
+    assert!(conflict_notes(&agreeing).is_empty());
+}

--- a/crates/core/src/settings_seed/tests/refresh.rs
+++ b/crates/core/src/settings_seed/tests/refresh.rs
@@ -1,0 +1,272 @@
+//! Seeded comments staying current: what a refresh may rewrite, and
+//! everything it must preserve forever.
+
+use std::collections::BTreeMap;
+
+use super::*;
+
+/// The ledger as seeding would have left it for these entries.
+fn ledger_for(entries: &[SeededEnv]) -> BTreeMap<String, SettingsSeed> {
+    entries
+        .iter()
+        .map(|seeded| (seeded.entry.key.clone(), seeded.seed_record()))
+        .collect()
+}
+
+#[test]
+fn unedited_seeded_comment_refreshes_when_the_template_revises_it() {
+    let v1 = seeded("[env]\n# Old words.\nDEPTH = \"2\"\n", "review");
+    let mut ledger = ledger_for(&v1);
+    let file = "[env]\n# Old words.\nDEPTH = \"9\"\n";
+
+    let v2 = seeded(
+        "[env]\n# New words.\n# Two lines now.\nDEPTH = \"2\"\n",
+        "review",
+    );
+    let (out, updated) = refresh_comments(file, &v2, &mut ledger);
+    assert_eq!(updated, ["DEPTH"]);
+    assert_eq!(
+        out,
+        "[env]\n# New words.\n# Two lines now.\nDEPTH = \"9\"\n"
+    );
+    assert_eq!(
+        ledger.get("DEPTH").unwrap().hash,
+        comment_hash(&["# New words.".to_owned(), "# Two lines now.".to_owned()]),
+        "the ledger follows the rewrite"
+    );
+
+    // Idempotent: running again changes nothing.
+    let (again, updated) = refresh_comments(&out, &v2, &mut ledger);
+    assert_eq!(again, out);
+    assert!(updated.is_empty());
+}
+
+#[test]
+fn a_hand_edited_comment_is_preserved_forever() {
+    let v1 = seeded("[env]\n# Old words.\nDEPTH = \"2\"\n", "review");
+    let mut ledger = ledger_for(&v1);
+    let file = "[env]\n# My own explanation.\nDEPTH = \"9\"\n";
+
+    let v2 = seeded("[env]\n# New words.\nDEPTH = \"2\"\n", "review");
+    let (out, updated) = refresh_comments(file, &v2, &mut ledger);
+    assert_eq!(out, file, "a hand-edited comment never rewrites");
+    assert!(updated.is_empty());
+}
+
+#[test]
+fn value_lines_are_untouched_byte_for_byte() {
+    let v1 = seeded("[env]\n# Old.\nDEPTH = \"2\"\n", "review");
+    let mut ledger = ledger_for(&v1);
+    // Odd spacing and a trailing comment on the value line must survive.
+    let file = "[env]\n# Old.\nDEPTH   =\t\"9\"   # keep me\n";
+    let v2 = seeded("[env]\n# New.\nDEPTH = \"2\"\n", "review");
+    let (out, _) = refresh_comments(file, &v2, &mut ledger);
+    assert_eq!(out, "[env]\n# New.\nDEPTH   =\t\"9\"   # keep me\n");
+}
+
+#[test]
+fn crlf_and_missing_terminator_survive_outside_the_comment_block() {
+    let v1 = seeded("[env]\n# Old.\nDEPTH = \"2\"\n", "review");
+    let mut ledger = ledger_for(&v1);
+    let file = "# head\r\n[env]\r\n# Old.\r\nDEPTH = \"9\"\r\n\r\n[custom]\r\nX = \"1\"";
+    let v2 = seeded("[env]\n# New.\nDEPTH = \"2\"\n", "review");
+    let (out, updated) = refresh_comments(file, &v2, &mut ledger);
+    assert_eq!(updated, ["DEPTH"]);
+    assert_eq!(
+        out, "# head\r\n[env]\r\n# New.\r\nDEPTH = \"9\"\r\n\r\n[custom]\r\nX = \"1\"",
+        "comment bytes are the only bytes that changed"
+    );
+}
+
+#[test]
+fn another_owners_template_never_rewrites_a_seeded_comment() {
+    let original_owner = seeded("[env]\n# Old.\nDEPTH = \"2\"\n", "review");
+    let mut ledger = ledger_for(&original_owner);
+    let file = "[env]\n# Old.\nDEPTH = \"9\"\n";
+    // A different skill now ships the same key with new words.
+    let intruder = seeded("[env]\n# Their words.\nDEPTH = \"3\"\n", "other-skill");
+    let (out, updated) = refresh_comments(file, &intruder, &mut ledger);
+    assert_eq!(out, file);
+    assert!(updated.is_empty());
+    assert_eq!(
+        ledger.get("DEPTH").unwrap().owner.as_deref(),
+        Some("review"),
+        "the record stays with its owner"
+    );
+}
+
+#[test]
+fn a_v1_imported_record_verifies_but_never_rewrites() {
+    let mut ledger = BTreeMap::new();
+    ledger.insert(
+        "DEPTH".to_owned(),
+        SettingsSeed {
+            owner: None,
+            hash: comment_hash(&["# Old.".to_owned()]),
+        },
+    );
+    let file = "[env]\n# Old.\nDEPTH = \"9\"\n";
+    let v2 = seeded("[env]\n# New.\nDEPTH = \"2\"\n", "review");
+    let (out, updated) = refresh_comments(file, &v2, &mut ledger);
+    assert_eq!(out, file, "legacy-owned: preserved, never rewritten");
+    assert!(updated.is_empty());
+    assert_eq!(ledger.get("DEPTH").unwrap().owner, None);
+}
+
+#[test]
+fn bootstrap_adopts_a_template_matching_comment_and_freezes_an_edited_one() {
+    // Pre-ledger install: the file matches the current template exactly.
+    let mut ledger = BTreeMap::new();
+    let file = "[env]\n# Current words.\nDEPTH = \"9\"\n";
+    let current = seeded("[env]\n# Current words.\nDEPTH = \"2\"\n", "review");
+    let (out, updated) = refresh_comments(file, &current, &mut ledger);
+    assert_eq!(out, file);
+    assert!(updated.is_empty());
+    assert_eq!(
+        ledger.get("DEPTH").unwrap().owner.as_deref(),
+        Some("review"),
+        "a matching comment is adopted into the ledger"
+    );
+    // The next template revision now refreshes it.
+    let revised = seeded("[env]\n# Revised words.\nDEPTH = \"2\"\n", "review");
+    let (out, updated) = refresh_comments(&out, &revised, &mut ledger);
+    assert_eq!(updated, ["DEPTH"]);
+    assert!(out.contains("# Revised words."));
+
+    // Pre-ledger install whose comment differs: hand-edited, never adopted.
+    let mut ledger = BTreeMap::new();
+    let edited = "[env]\n# Somebody's own words.\nDEPTH = \"9\"\n";
+    let (out, updated) = refresh_comments(edited, &revised, &mut ledger);
+    assert_eq!(out, edited);
+    assert!(updated.is_empty());
+    assert!(!ledger.contains_key("DEPTH"));
+}
+
+/// A bare key says nothing about who wrote it: an empty on-disk block
+/// matching an empty template block is not adoption evidence, or a later
+/// template revision would write prose above a line the user typed.
+#[test]
+fn a_bare_key_is_never_adopted() {
+    let mut ledger = BTreeMap::new();
+    let file = "[env]\nDEPTH = \"9\"\n";
+    let bare = seeded("[env]\nDEPTH = \"2\"\n", "review");
+    let (out, updated) = refresh_comments(file, &bare, &mut ledger);
+    assert_eq!(out, file);
+    assert!(updated.is_empty());
+    assert!(!ledger.contains_key("DEPTH"), "nothing to adopt");
+
+    let with_words = seeded("[env]\n# Now with words.\nDEPTH = \"2\"\n", "review");
+    let (out, updated) = refresh_comments(file, &with_words, &mut ledger);
+    assert_eq!(out, file, "the user's bare key stays bare");
+    assert!(updated.is_empty());
+}
+
+/// A v1 import names no owner. A template earns the record when the
+/// comment on disk is provably what v1 seeded and matches the template
+/// word for word; a comment that drifted stays legacy-owned.
+#[test]
+fn a_v1_record_is_adopted_only_by_a_matching_template_over_unedited_text() {
+    let mut ledger = BTreeMap::new();
+    ledger.insert(
+        "DEPTH".to_owned(),
+        SettingsSeed {
+            owner: None,
+            hash: comment_hash(&["# Old.".to_owned()]),
+        },
+    );
+    let file = "[env]\n# Old.\nDEPTH = \"9\"\n";
+    let same_words = seeded("[env]\n# Old.\nDEPTH = \"2\"\n", "review");
+    let (out, updated) = refresh_comments(file, &same_words, &mut ledger);
+    assert_eq!(out, file);
+    assert!(updated.is_empty());
+    assert_eq!(
+        ledger.get("DEPTH").unwrap().owner.as_deref(),
+        Some("review"),
+        "provably unedited and word-for-word the template: adopted"
+    );
+    let revised = seeded("[env]\n# Newer.\nDEPTH = \"2\"\n", "review");
+    let (out, updated) = refresh_comments(&out, &revised, &mut ledger);
+    assert_eq!(updated, ["DEPTH"]);
+    assert!(out.contains("# Newer."));
+
+    // Hand-edited since v1 seeded it (hash no longer matches), even if the
+    // words now happen to equal a template: legacy-owned, frozen.
+    let mut ledger = BTreeMap::new();
+    ledger.insert(
+        "DEPTH".to_owned(),
+        SettingsSeed {
+            owner: None,
+            hash: comment_hash(&["# What v1 wrote.".to_owned()]),
+        },
+    );
+    let edited = "[env]\n# Old.\nDEPTH = \"9\"\n";
+    refresh_comments(edited, &same_words, &mut ledger);
+    assert_eq!(ledger.get("DEPTH").unwrap().owner, None);
+}
+
+/// Two skills ship one key. Seeding wrote the first declaration; a later
+/// pass where the other skill enumerates first must still refresh from
+/// the recorded owner's template — declaration order never shadows the
+/// ledger.
+#[test]
+fn the_recorded_owner_speaks_for_a_key_several_skills_ship() {
+    let review = seeded("[env]\n# Review's words.\nDEPTH = \"2\"\n", "review");
+    let mut ledger = ledger_for(&review);
+    let file = "[env]\n# Review's words.\nDEPTH = \"9\"\n";
+    let mut entries = seeded("[env]\n# Lint's words.\nDEPTH = \"1\"\n", "aaa-lint");
+    entries.extend(seeded(
+        "[env]\n# Review's better words.\nDEPTH = \"2\"\n",
+        "review",
+    ));
+    let (out, updated) = refresh_comments(file, &entries, &mut ledger);
+    assert_eq!(updated, ["DEPTH"]);
+    assert!(out.contains("# Review's better words."), "{out}");
+    assert!(!out.contains("# Lint's words."));
+    assert_eq!(
+        ledger.get("DEPTH").unwrap().owner.as_deref(),
+        Some("review")
+    );
+}
+
+/// Seeding writes the first declaration of a key and the ledger records
+/// that skill — the same choice, so the owner can refresh what it wrote.
+#[test]
+fn merge_seeds_the_first_declaration_and_records_it_as_owner() {
+    let mut entries = seeded("[env]\n# First.\nDEPTH = \"1\"\n", "first");
+    entries.extend(seeded("[env]\n# Second.\nDEPTH = \"2\"\n", "second"));
+    let (out, added) = merge(Some("[env]\n"), &entries).unwrap();
+    assert_eq!(added, ["DEPTH"]);
+    assert!(out.contains("# First.\nDEPTH = \"1\""), "{out}");
+    assert!(!out.contains("# Second."));
+    let mut ledger = BTreeMap::new();
+    record_seeds(&mut ledger, &entries, &added);
+    assert_eq!(ledger.get("DEPTH").unwrap().owner.as_deref(), Some("first"));
+}
+
+/// A hand-made duplicate inside `[env]` is judged once, at its first
+/// site — never two rewrites and never a key listed twice in the plan.
+#[test]
+fn a_duplicated_key_is_refreshed_once() {
+    let v1 = seeded("[env]\n# Old.\nDEPTH = \"2\"\n", "review");
+    let mut ledger = ledger_for(&v1);
+    let file = "[env]\n# Old.\nDEPTH = \"9\"\n# Old.\nDEPTH = \"8\"\n";
+    let v2 = seeded("[env]\n# New.\nDEPTH = \"2\"\n", "review");
+    let (out, updated) = refresh_comments(file, &v2, &mut ledger);
+    assert_eq!(updated, ["DEPTH"]);
+    assert_eq!(out, "[env]\n# New.\nDEPTH = \"9\"\n# Old.\nDEPTH = \"8\"\n");
+}
+
+#[test]
+fn comment_hash_matches_v1s_algorithm() {
+    // Locked against v1's `format!("{:016x}", fnv1a(join("\n")))` so
+    // imported ledgers verify without re-guessing.
+    assert_eq!(comment_hash(&[]), "cbf29ce484222325");
+    assert_eq!(comment_hash(&["# a".to_owned()]), {
+        let mut h: u64 = 0xcbf2_9ce4_8422_2325;
+        for b in b"# a" {
+            h ^= u64::from(*b);
+            h = h.wrapping_mul(0x0000_0100_0000_01b3);
+        }
+        format!("{h:016x}")
+    });
+}

--- a/crates/core/src/settings_seed/tests/refresh.rs
+++ b/crates/core/src/settings_seed/tests/refresh.rs
@@ -204,10 +204,9 @@ fn a_v1_record_is_adopted_only_by_a_matching_template_over_unedited_text() {
     assert_eq!(ledger.get("DEPTH").unwrap().owner, None);
 }
 
-/// Two skills ship one key. Seeding wrote the first declaration; a later
-/// pass where the other skill enumerates first must still refresh from
-/// the recorded owner's template — declaration order never shadows the
-/// ledger.
+/// Two skills ship one key. Seeding wrote one of them; a later pass where
+/// the other skill enumerates first must still refresh from the recorded
+/// owner's template — declaration order never shadows the ledger.
 #[test]
 fn the_recorded_owner_speaks_for_a_key_several_skills_ship() {
     let review = seeded("[env]\n# Review's words.\nDEPTH = \"2\"\n", "review");
@@ -228,10 +227,11 @@ fn the_recorded_owner_speaks_for_a_key_several_skills_ship() {
     );
 }
 
-/// Seeding writes the first declaration of a key and the ledger records
-/// that skill — the same choice, so the owner can refresh what it wrote.
+/// Seeding writes the first declaration that can be written whole and the
+/// ledger records that skill — one selection, so the owner can refresh
+/// what it wrote.
 #[test]
-fn merge_seeds_the_first_declaration_and_records_it_as_owner() {
+fn merge_seeds_the_first_writable_declaration_and_records_it_as_owner() {
     let mut entries = seeded("[env]\n# First.\nDEPTH = \"1\"\n", "first");
     entries.extend(seeded("[env]\n# Second.\nDEPTH = \"2\"\n", "second"));
     let (out, added) = merge(Some("[env]\n"), &entries).unwrap();

--- a/crates/core/src/settings_seed/write.rs
+++ b/crates/core/src/settings_seed/write.rs
@@ -1,0 +1,158 @@
+//! Writing entries into the consumer's settings file.
+//!
+//! Split from the reading beside it because the two answer different
+//! questions. Everything here is byte-faithful: the inserted block is the
+//! only change, and inside it the comment lines take the destination
+//! file's terminator while a value's own newlines are copied as the
+//! template wrote them.
+
+use std::collections::{BTreeMap, BTreeSet};
+
+use crate::lock::SettingsSeed;
+use crate::settings_toml::Row;
+
+use super::{SeededEnv, assigned_keys, env_blocked, opens_env, table_row, writable_for};
+
+/// The terminator new lines are written with: whatever the file's first
+/// terminated line uses, `\n` where it has nothing to say.
+pub(super) fn file_eol(rows: &[Row]) -> &'static str {
+    match rows
+        .iter()
+        .find(|row| row.raw.ends_with('\n'))
+        .is_some_and(|row| row.raw.ends_with("\r\n"))
+    {
+        true => "\r\n",
+        false => "\n",
+    }
+}
+
+/// The `[env]` section's line span: the header's index and the index of
+/// the first line after the section (the next table header, or the end
+/// of the file). `None` = no `[env]` header. Seeding and refresh both
+/// splice inside this span, so they cannot disagree about where it ends.
+pub(super) fn env_section(rows: &[Row]) -> Option<(usize, usize)> {
+    let start = rows.iter().position(opens_env)?;
+    let end = rows
+        .iter()
+        .enumerate()
+        .skip(start + 1)
+        .find_map(|(index, row)| table_row(row).then_some(index))
+        .unwrap_or(rows.len());
+    Some((start, end))
+}
+
+fn render_entries(entries: &[&SeededEnv], eol: &str) -> String {
+    let mut out = String::new();
+    for seeded in entries {
+        if !out.is_empty() {
+            out.push_str(eol);
+        }
+        // Two kinds of newline, and only one of them is the file's. The
+        // comment lines are the file's own structure and take its
+        // terminator; the value goes out byte for byte, because the
+        // newlines inside it are content the template chose.
+        for line in &seeded.entry.comment {
+            out.push_str(line);
+            out.push_str(eol);
+        }
+        out.push_str(&seeded.entry.assignment);
+        out.push_str(eol);
+    }
+    out
+}
+
+/// Merge missing entries into the settings text, byte-faithfully: the
+/// inserted block is the only change, spelled in the file's own line
+/// terminator. `None` = nothing to add. Returns the new text plus the keys
+/// that were added.
+pub fn merge(original: Option<&str>, entries: &[SeededEnv]) -> Option<(String, Vec<String>)> {
+    // Nowhere to write: the plan reports the shape, and no byte moves.
+    if original.is_some_and(|text| env_blocked(text).is_some()) {
+        return None;
+    }
+    let existing: BTreeSet<String> = original
+        .map(assigned_keys)
+        .unwrap_or_default()
+        .into_iter()
+        .collect();
+    // Each distinct key once, in declaration order, taken from the one
+    // declaration that speaks for it. The winner comes from `writable_for`
+    // rather than being re-derived here, so the bytes written, the ledger
+    // and the notes cannot name three different skills.
+    let mut seen: BTreeSet<&str> = BTreeSet::new();
+    let missing: Vec<&SeededEnv> = entries
+        .iter()
+        .filter(|seeded| seen.insert(seeded.entry.key.as_str()))
+        .filter(|seeded| !existing.contains(&seeded.entry.key))
+        .filter_map(|seeded| writable_for(entries, &seeded.entry.key))
+        .collect();
+    if missing.is_empty() {
+        return None;
+    }
+    let added: Vec<String> = missing.iter().map(|s| s.entry.key.clone()).collect();
+
+    let Some(original) = original else {
+        let mut out = String::from(
+            "# Public kendex settings seeded from installed skill defaults.\n# Skill scripts read this [env] table; process env and .env.local override it.\n# Keep secrets, tokens, and personal overrides in .env.local.\n\n[env]\n",
+        );
+        out.push_str(&render_entries(&missing, "\n"));
+        return Some((out, added));
+    };
+
+    let rows = crate::settings_toml::rows(original);
+    let eol = file_eol(&rows);
+    let env = env_section(&rows);
+    // Where the new block lands: the end of the `[env]` section, or the end
+    // of the file (with a header) when there is none.
+    let insert_at = env.map_or(rows.len(), |(_, end)| end);
+
+    let mut block = String::new();
+    // A final line with no terminator gets one — the once-only repair that
+    // makes inserting after it possible at all.
+    if insert_at == rows.len()
+        && rows
+            .last()
+            .is_some_and(|row| row.text.len() == row.raw.len() && !row.raw.is_empty())
+    {
+        block.push_str(eol);
+    }
+    if env.is_none() {
+        if !rows.is_empty() && insert_at > 0 && !rows[insert_at - 1].text.trim().is_empty() {
+            block.push_str(eol);
+        }
+        block.push_str("[env]");
+        block.push_str(eol);
+    } else if insert_at > 0 && !rows[insert_at - 1].text.trim().is_empty() {
+        block.push_str(eol);
+    }
+    block.push_str(&render_entries(&missing, eol));
+    if insert_at < rows.len() && !rows[insert_at].text.trim().is_empty() {
+        block.push_str(eol);
+    }
+
+    let mut out = String::with_capacity(original.len() + block.len());
+    for row in &rows[..insert_at] {
+        out.push_str(row.raw);
+    }
+    out.push_str(&block);
+    for row in &rows[insert_at..] {
+        out.push_str(row.raw);
+    }
+    Some((out, added))
+}
+
+/// The ledger records the added entries were seeded, each under the owner
+/// whose lines were written — asked of [`writable_for`], the same question
+/// `merge` asked, so the record names the skill that actually supplied the
+/// bytes.
+pub fn record_seeds(
+    seeds: &mut BTreeMap<String, SettingsSeed>,
+    entries: &[SeededEnv],
+    added: &[String],
+) {
+    for key in added {
+        if let Some(seeded) = writable_for(entries, key) {
+            seeds.insert(key.clone(), seeded.seed_record());
+        }
+    }
+}

--- a/crates/core/src/settings_toml.rs
+++ b/crates/core/src/settings_toml.rs
@@ -21,11 +21,14 @@
 //! inside `BLOB` to write over. That last one damages a file somebody
 //! owns, which is why the memory lives here now instead of three times.
 //!
-//! What this settles is exactly one thing: **which lines are structure and
-//! which are inside a value**, and where a structure line's top-level `=`
-//! falls. What a table means, what a finding is, and which values the
-//! shell loaders will read stay with the three callers, because they
-//! differ on purpose — the check is strict where seeding is lenient.
+//! What this settles is **which lines are structure and which are inside a
+//! value**, where a structure line's top-level `=` falls, and which lines
+//! left a value unfinished. The last is its own fact, not the absence of
+//! the first: a single-line string ends with its line, so one left open
+//! carries nothing and finishes nothing at the same time. What a table
+//! means, what a finding is, and which values the shell loaders will read
+//! stay with the three callers, because they differ on purpose — the
+//! check is strict where seeding is lenient.
 //!
 //! ## What the grammar can carry across a line
 //!
@@ -39,7 +42,9 @@
 //! - **Arrays** carry over line ends and nest. Tracked by depth, because a
 //!   flag cannot say how deep and a nested `[` is not a table header.
 //! - **Single-line strings**, basic and literal, end with their line by
-//!   definition. The walk steps over them inside a line and never past it.
+//!   definition. The walk steps over them inside a line and never past it,
+//!   and reports one left unterminated as its own fact — nothing carries,
+//!   so no later line could report it.
 //! - **Inline tables** may not hold a newline in TOML 1.0, so they carry
 //!   nothing across one. What they hold on their own line — `=` and `[` —
 //!   reaches no decision: only a line whose first non-blank character is
@@ -114,6 +119,12 @@ pub struct Row<'a> {
     /// assignment cannot ask the line under it whether the value closed
     /// when the file ends there.
     pub carries: bool,
+    /// Whether this line ends inside a string nothing closes. Never the
+    /// same question as [`Row::carries`], and not its opposite: a
+    /// single-line string ends with its line by definition, so one left
+    /// unterminated carries nothing and no later line completes it.
+    /// `TOKEN = "` carries nothing and is not finished either.
+    pub unterminated: bool,
 }
 
 impl Row<'_> {
@@ -146,7 +157,8 @@ pub fn rows(text: &str) -> Vec<Row<'_>> {
             true => Line::InValue,
             false => kind_of(content),
         };
-        carry = advance(content, carry);
+        let ends = advance(content, carry);
+        carry = ends.carry;
         out.push(Row {
             line: line_number(index),
             raw,
@@ -154,6 +166,7 @@ pub fn rows(text: &str) -> Vec<Row<'_>> {
             at,
             kind,
             carries: carry.inside(),
+            unterminated: ends.unterminated,
         });
         at += raw.len();
     }

--- a/crates/core/src/settings_toml.rs
+++ b/crates/core/src/settings_toml.rs
@@ -108,6 +108,12 @@ pub struct Row<'a> {
     /// Byte offset of `text` in the source.
     pub at: usize,
     pub kind: Line<'a>,
+    /// Whether this line leaves a value open — the same fact
+    /// [`Line::InValue`] tells about the lines below it, told from the
+    /// line that opened it. Both tellings are needed: a caller holding an
+    /// assignment cannot ask the line under it whether the value closed
+    /// when the file ends there.
+    pub carries: bool,
 }
 
 impl Row<'_> {
@@ -147,6 +153,7 @@ pub fn rows(text: &str) -> Vec<Row<'_>> {
             text: content,
             at,
             kind,
+            carries: carry.inside(),
         });
         at += raw.len();
     }

--- a/crates/core/src/settings_toml.rs
+++ b/crates/core/src/settings_toml.rs
@@ -30,35 +30,43 @@
 //!
 //! ## Where every value form can end
 //!
-//! Enumerated from TOML's value grammar rather than added one at a time as
-//! each face of the same defect surfaced: twice now a form nobody had
-//! considered read as finished and was copied into somebody's file. A
-//! value is exactly one of string, integer, float, boolean, one of the
-//! five date-time forms, array, or inline table. Each either has
-//! delimiters or does not, and each delimited one may cross a newline or
-//! may not:
+//! Enumerated from the value grammar of the spec the workspace's `toml`
+//! dependency implements — the root `Cargo.toml` is where that is chosen,
+//! and this table has to be re-read against it whenever it moves. Written
+//! out rather than added a form at a time as each face of the same defect
+//! surfaced: twice a form nobody had considered read as finished and was
+//! copied into somebody's file, and once a form was refused that the
+//! parser accepts. A value is exactly one of string, integer, float,
+//! boolean, one of the five date-time forms, array, or inline table. Each
+//! either has delimiters or does not, and each delimited one may cross a
+//! newline or may not:
 //!
 //! | Form                      | Delimiter | Crosses a newline |
 //! |---------------------------|-----------|-------------------|
 //! | Multi-line basic string   | `"""`     | yes, carried      |
 //! | Multi-line literal string | `'''`     | yes, carried      |
 //! | Array                     | `[` `]`   | yes, carried      |
+//! | Inline table              | `{` `}`   | yes, carried      |
 //! | Single-line string        | `"` `'`   | no, breaks        |
-//! | Inline table              | `{` `}`   | no, breaks        |
 //! | Integer, float, boolean   | none      | cannot be open    |
 //! | The five date-time forms  | none      | cannot be open    |
 //!
-//! Arrays are carried by depth rather than by a flag, because a flag
-//! cannot say how deep and a nested `[` is not a table header. A scalar is
-//! one token holding none of `[`, `]`, `{`, `}`, `"`, `'`, `#` or `=`, so
-//! none can be mistaken for structure, conceal it, or be left open.
+//! Arrays and inline tables are carried by depth rather than by a flag,
+//! because a flag cannot say how deep and a nested `[` is not a table
+//! header. Depth is also why nothing here is a rule per form: an array
+//! inside an inline table, or a table inside an array, closes when its own
+//! delimiter does, like any other. A scalar is one token holding none of
+//! `[`, `]`, `{`, `}`, `"`, `'`, `#` or `=`, so none can be mistaken for
+//! structure, conceal it, or be left open.
 //!
-//! That is the whole of the value grammar, so both sets are closed: three
-//! forms carry, two break where their line ends, and the scalars cannot be
+//! That is the whole of the value grammar, so both sets are closed: four
+//! forms carry, one breaks where its line ends, and the scalars cannot be
 //! open at all. A value is COMPLETE only where the line it ended on left
 //! neither kind open — which is why a row carries the two as separate
-//! facts and neither is the other's negation. A form this table cannot
-//! answer for is a gap to name here, never a silent default of complete.
+//! facts and neither is the other's negation. A container the file never
+//! closes carries to the end and is incomplete there. A form this table
+//! cannot answer for is a gap to name here, never a silent default of
+//! complete.
 //!
 //! Every claim in this table has a control in `tests.rs`; the last three
 //! times this file was wrong, it was wrong in a comment first.

--- a/crates/core/src/settings_toml.rs
+++ b/crates/core/src/settings_toml.rs
@@ -33,13 +33,12 @@
 //! Enumerated from the value grammar of the spec the workspace's `toml`
 //! dependency implements — the root `Cargo.toml` is where that is chosen,
 //! and this table has to be re-read against it whenever it moves. Written
-//! out rather than added a form at a time as each face of the same defect
-//! surfaced: twice a form nobody had considered read as finished and was
-//! copied into somebody's file, and once a form was refused that the
-//! parser accepts. A value is exactly one of string, integer, float,
-//! boolean, one of the five date-time forms, array, or inline table. Each
-//! either has delimiters or does not, and each delimited one may cross a
-//! newline or may not:
+//! out whole rather than a form at a time: a form left off it reads as
+//! finished and is copied into somebody's file, and one filed in the wrong
+//! column is refused though the parser accepts it. A value is exactly one
+//! of string, integer, float, boolean, one of the five date-time forms,
+//! array, or inline table. Each either has delimiters or does not, and each
+//! delimited one may cross a newline or may not:
 //!
 //! | Form                      | Delimiter | Crosses a newline |
 //! |---------------------------|-----------|-------------------|
@@ -68,8 +67,9 @@
 //! cannot answer for is a gap to name here, never a silent default of
 //! complete.
 //!
-//! Every claim in this table has a control in `tests.rs`; the last three
-//! times this file was wrong, it was wrong in a comment first.
+//! Every claim in this table has a control in `tests.rs`. This file goes
+//! wrong in a comment before it goes wrong in code, so the table is the
+//! thing to re-read against the spec first.
 //!
 //! What a line leaves open is read off it once, apart from the decision
 //! about what the line is, because the two are independent — a line can
@@ -132,14 +132,16 @@ pub struct Row<'a> {
     /// assignment cannot ask the line under it whether the value closed
     /// when the file ends there.
     pub carries: bool,
-    /// Whether this line ends with a container open that the grammar does
-    /// not let a later line close — a single-line string, or an inline
-    /// table. The complement of [`Row::carries`], never its negation: both
-    /// are false for a value that simply ended, and `TOKEN = "` and
-    /// `MAP = {` carry nothing and are not finished either.
+    /// Whether this line ends inside a delimiter no later line may close.
+    /// Only a single-line string can be one: the grammar ends it with its
+    /// line, so nothing below it can finish it. Every other container
+    /// carries instead, and one the file never closes carries to the end
+    /// of the file — [`Row::carries`] is what answers for those.
     ///
-    /// A value is complete only where neither is true of it. Asking
-    /// `carries` alone has now twice called a broken line finished.
+    /// The complement of [`Row::carries`], never its negation: both are
+    /// false for a value that simply ended, and `TOKEN = "` carries
+    /// nothing and is not finished either. A value is complete only where
+    /// neither is true of it.
     pub broken: bool,
 }
 

--- a/crates/core/src/settings_toml.rs
+++ b/crates/core/src/settings_toml.rs
@@ -22,41 +22,46 @@
 //! owns, which is why the memory lives here now instead of three times.
 //!
 //! What this settles is **which lines are structure and which are inside a
-//! value**, where a structure line's top-level `=` falls, and which lines
-//! left a value unfinished. The last is its own fact, not the absence of
-//! the first: a single-line string ends with its line, so one left open
-//! carries nothing and finishes nothing at the same time. What a table
-//! means, what a finding is, and which values the shell loaders will read
-//! stay with the three callers, because they differ on purpose — the
-//! check is strict where seeding is lenient.
+//! value**, where a structure line's top-level `=` falls, and **whether a
+//! line left a value unfinished**. What a table means, what a finding is,
+//! and which values the shell loaders will read stay with the three
+//! callers, because they differ on purpose — the check is strict where
+//! seeding is lenient.
 //!
-//! ## What the grammar can carry across a line
+//! ## Where every value form can end
 //!
 //! Enumerated from TOML's value grammar rather than added one at a time as
-//! each face of the same defect surfaced. A value is exactly one of:
-//! string, integer, float, boolean, one of the five date-time forms,
-//! array, inline table. Taking them in turn:
+//! each face of the same defect surfaced: twice now a form nobody had
+//! considered read as finished and was copied into somebody's file. A
+//! value is exactly one of string, integer, float, boolean, one of the
+//! five date-time forms, array, or inline table. Each either has
+//! delimiters or does not, and each delimited one may cross a newline or
+//! may not:
 //!
-//! - **Multi-line basic** and **multi-line literal** strings carry
-//!   arbitrary text over line ends. Tracked.
-//! - **Arrays** carry over line ends and nest. Tracked by depth, because a
-//!   flag cannot say how deep and a nested `[` is not a table header.
-//! - **Single-line strings**, basic and literal, end with their line by
-//!   definition. The walk steps over them inside a line and never past it,
-//!   and reports one left unterminated as its own fact — nothing carries,
-//!   so no later line could report it.
-//! - **Inline tables** may not hold a newline in TOML 1.0, so they carry
-//!   nothing across one. What they hold on their own line — `=` and `[` —
-//!   reaches no decision: only a line whose first non-blank character is
-//!   `[` reads as a table, and the assignment's `=` is the first one no
-//!   string encloses.
-//! - **Every scalar** is a single token holding none of `[`, `]`, `"`,
-//!   `'`, `#` or `=`, so none can be mistaken for structure or conceal it.
+//! | Form                      | Delimiter | Crosses a newline |
+//! |---------------------------|-----------|-------------------|
+//! | Multi-line basic string   | `"""`     | yes, carried      |
+//! | Multi-line literal string | `'''`     | yes, carried      |
+//! | Array                     | `[` `]`   | yes, carried      |
+//! | Single-line string        | `"` `'`   | no, breaks        |
+//! | Inline table              | `{` `}`   | no, breaks        |
+//! | Integer, float, boolean   | none      | cannot be open    |
+//! | The five date-time forms  | none      | cannot be open    |
 //!
-//! That is the whole of the value grammar, so the set that can carry
-//! across a line is closed at three, and all three are tracked. Every
-//! claim in this list has a control in `tests.rs`; the last three times
-//! this file was wrong, it was wrong in a comment first.
+//! Arrays are carried by depth rather than by a flag, because a flag
+//! cannot say how deep and a nested `[` is not a table header. A scalar is
+//! one token holding none of `[`, `]`, `{`, `}`, `"`, `'`, `#` or `=`, so
+//! none can be mistaken for structure, conceal it, or be left open.
+//!
+//! That is the whole of the value grammar, so both sets are closed: three
+//! forms carry, two break where their line ends, and the scalars cannot be
+//! open at all. A value is COMPLETE only where the line it ended on left
+//! neither kind open — which is why a row carries the two as separate
+//! facts and neither is the other's negation. A form this table cannot
+//! answer for is a gap to name here, never a silent default of complete.
+//!
+//! Every claim in this table has a control in `tests.rs`; the last three
+//! times this file was wrong, it was wrong in a comment first.
 //!
 //! What a line leaves open is read off it once, apart from the decision
 //! about what the line is, because the two are independent — a line can
@@ -119,12 +124,15 @@ pub struct Row<'a> {
     /// assignment cannot ask the line under it whether the value closed
     /// when the file ends there.
     pub carries: bool,
-    /// Whether this line ends inside a string nothing closes. Never the
-    /// same question as [`Row::carries`], and not its opposite: a
-    /// single-line string ends with its line by definition, so one left
-    /// unterminated carries nothing and no later line completes it.
-    /// `TOKEN = "` carries nothing and is not finished either.
-    pub unterminated: bool,
+    /// Whether this line ends with a container open that the grammar does
+    /// not let a later line close — a single-line string, or an inline
+    /// table. The complement of [`Row::carries`], never its negation: both
+    /// are false for a value that simply ended, and `TOKEN = "` and
+    /// `MAP = {` carry nothing and are not finished either.
+    ///
+    /// A value is complete only where neither is true of it. Asking
+    /// `carries` alone has now twice called a broken line finished.
+    pub broken: bool,
 }
 
 impl Row<'_> {
@@ -166,7 +174,7 @@ pub fn rows(text: &str) -> Vec<Row<'_>> {
             at,
             kind,
             carries: carry.inside(),
-            unterminated: ends.unterminated,
+            broken: ends.broken,
         });
         at += raw.len();
     }

--- a/crates/core/src/settings_toml/tests.rs
+++ b/crates/core/src/settings_toml/tests.rs
@@ -431,3 +431,31 @@ fn a_header_carries_its_key_and_whether_the_loaders_read_it() {
         assert_eq!(header_of(refused), None, "{refused}");
     }
 }
+
+/// `carries` is [`Line::InValue`] told from the line that opened the
+/// value, and the two are not interchangeable: a caller holding an
+/// assignment reads the fact off that line, which is the only place it is
+/// there to read when the file ends with the value still open.
+#[test]
+fn a_line_says_for_itself_whether_it_left_a_value_open() {
+    let carries = |text: &str| -> Vec<bool> { rows(text).iter().map(|row| row.carries).collect() };
+    for open in ["\"\"\"", "'''", "["] {
+        // Opened, carried, closed: only the last line is clear again.
+        let closed = format!("A = {open}\ntext\n{}\n", close_of(open));
+        assert_eq!(carries(&closed), [true, true, false], "{open}");
+        // Left open at the end of the file, where no line below it exists
+        // to be InValue.
+        let unclosed = format!("A = {open}\n");
+        assert_eq!(carries(&unclosed), [true], "{open}");
+    }
+    // A value that closes on its own line carries nothing.
+    assert_eq!(carries("A = \"one\"\nB = \"two\"\n"), [false, false]);
+}
+
+/// The delimiter that closes what this one opens.
+fn close_of(open: &str) -> &str {
+    match open {
+        "[" => "]",
+        other => other,
+    }
+}

--- a/crates/core/src/settings_toml/tests.rs
+++ b/crates/core/src/settings_toml/tests.rs
@@ -322,11 +322,12 @@ fn a_table_header_leaves_nothing_open() {
     }
 }
 
-/// An inline table holds no newline in TOML 1.0, so it carries nothing;
-/// its `=` and `[` reach no decision, because the assignment's `=` is the
-/// first one outside a string and only a line-leading `[` is a table.
+/// An inline table that closes on its own line leaves nothing open, so the
+/// line below it is structure again. What it held reaches no decision: the
+/// assignment's `=` is the first one outside a string, and only a
+/// line-leading `[` is a table.
 #[test]
-fn an_inline_table_carries_nothing_across_a_line() {
+fn a_closed_inline_table_does_not_reach_the_line_below_it() {
     let text = "[env]\nA = { b = [1], c = \"x\" }\nMODE = \"real\"\n";
     assert_eq!(keys(text), vec!["A".to_owned(), "MODE".to_owned()]);
     assert_eq!(
@@ -479,15 +480,8 @@ fn a_form_the_grammar_cannot_continue_says_so_without_carrying() {
             "{quote}: broken, and the line under it is structure again"
         );
     }
-    // An inline table may not hold a newline either, so one still open
-    // where the line ends is broken exactly as the string is.
-    assert_eq!(
-        ends("MAP = {\nMODE = \"real\"\n"),
-        [(false, true), (false, false)],
-        "an inline table cannot be continued by the line under it"
-    );
-    assert_eq!(ends("MAP = { a = { b = 1 }\n"), [(false, true)], "nested");
-
+    // Nothing else can be broken: every other container carries, so a
+    // later line closes it or the carry runs off the end of the file.
     // A value that closes says neither, whatever its form.
     for closed in [
         "TOKEN = \"ok\"\n",
@@ -515,14 +509,37 @@ fn a_form_the_grammar_cannot_continue_says_so_without_carrying() {
         ends("LIST = [\n  1,\n]\n"),
         [(true, false), (true, false), (false, false)]
     );
-    // A brace inside a carried array still has to close on its own line.
+    // An inline table carries by depth like an array, so what is legal
+    // inside one is whatever is legal in any other container.
     assert_eq!(
-        ends("LIST = [\n  { a = 1 },\n]\n"),
-        [(true, false), (true, false), (false, false)]
+        ends("MAP = {\na = 1\n}\n"),
+        [(true, false), (true, false), (false, false)],
+        "the lines under it are the value's, not structure"
     );
     assert_eq!(
-        ends("LIST = [\n  { a = 1,\n]\n"),
-        [(true, false), (true, true), (false, false)],
-        "the array carries; the inline table on that line does not"
+        ends("MAP = { items = [\n  1,\n] }\n"),
+        [(true, false), (true, false), (false, false)],
+        "a multiline array nested in an inline table"
+    );
+    assert_eq!(
+        ends("MAP = { a = { b = 1 }\n"),
+        [(true, false)],
+        "the outer table is still open"
+    );
+    assert_eq!(
+        ends("LIST = [\n  { a = 1 },\n]\n"),
+        [(true, false), (true, false), (false, false)],
+        "and an inline table nested in an array"
+    );
+    // Depth is what answers, so the two nest through each other.
+    assert_eq!(
+        ends("LIST = [\n  { a = [\n    1,\n  ] },\n]\n"),
+        [
+            (true, false),
+            (true, false),
+            (true, false),
+            (true, false),
+            (false, false)
+        ]
     );
 }

--- a/crates/core/src/settings_toml/tests.rs
+++ b/crates/core/src/settings_toml/tests.rs
@@ -459,3 +459,31 @@ fn close_of(open: &str) -> &str {
         other => other,
     }
 }
+
+/// The other half of what a line leaves behind, and not the negation of
+/// `carries`: a single-line string ends with its line, so one left
+/// unterminated carries nothing and is still not finished. A caller
+/// reading completeness off `carries` alone calls `TOKEN = "` closed.
+#[test]
+fn an_unterminated_single_line_string_says_so_without_carrying() {
+    let ends = |text: &str| -> Vec<(bool, bool)> {
+        rows(text)
+            .iter()
+            .map(|row| (row.carries, row.unterminated))
+            .collect()
+    };
+    for quote in ['"', '\''] {
+        assert_eq!(
+            ends(&format!("TOKEN = {quote}\nMODE = \"real\"\n")),
+            [(false, true), (false, false)],
+            "{quote}: broken, and the line under it is structure again"
+        );
+    }
+    // A value that closes says neither, and one that carries says only
+    // that it carries.
+    assert_eq!(ends("TOKEN = \"ok\"\n"), [(false, false)]);
+    assert_eq!(
+        ends("BLOB = \"\"\"\ntext\n\"\"\"\n"),
+        [(true, false), (true, false), (false, false)]
+    );
+}

--- a/crates/core/src/settings_toml/tests.rs
+++ b/crates/core/src/settings_toml/tests.rs
@@ -465,11 +465,11 @@ fn close_of(open: &str) -> &str {
 /// unterminated carries nothing and is still not finished. A caller
 /// reading completeness off `carries` alone calls `TOKEN = "` closed.
 #[test]
-fn an_unterminated_single_line_string_says_so_without_carrying() {
+fn a_form_the_grammar_cannot_continue_says_so_without_carrying() {
     let ends = |text: &str| -> Vec<(bool, bool)> {
         rows(text)
             .iter()
-            .map(|row| (row.carries, row.unterminated))
+            .map(|row| (row.carries, row.broken))
             .collect()
     };
     for quote in ['"', '\''] {
@@ -479,11 +479,50 @@ fn an_unterminated_single_line_string_says_so_without_carrying() {
             "{quote}: broken, and the line under it is structure again"
         );
     }
-    // A value that closes says neither, and one that carries says only
-    // that it carries.
-    assert_eq!(ends("TOKEN = \"ok\"\n"), [(false, false)]);
+    // An inline table may not hold a newline either, so one still open
+    // where the line ends is broken exactly as the string is.
+    assert_eq!(
+        ends("MAP = {\nMODE = \"real\"\n"),
+        [(false, true), (false, false)],
+        "an inline table cannot be continued by the line under it"
+    );
+    assert_eq!(ends("MAP = { a = { b = 1 }\n"), [(false, true)], "nested");
+
+    // A value that closes says neither, whatever its form.
+    for closed in [
+        "TOKEN = \"ok\"\n",
+        "MAP = { a = 1 }\n",
+        "MAP = { a = { b = 1 } }\n",
+        "MAP = { a = \"}\" }\n",
+        "LIST = [1, 2]\n",
+        // The scalars, which have no delimiters to leave open at all.
+        "N = 12\n",
+        "F = 1.5\n",
+        "B = true\n",
+        "D = 1979-05-27T07:32:00Z\n",
+        "D = 1979-05-27\n",
+        "D = 07:32:00\n",
+    ] {
+        assert_eq!(ends(closed), [(false, false)], "{closed:?}");
+    }
+    // And one that carries says only that it carries — the string and
+    // array answers are unchanged.
     assert_eq!(
         ends("BLOB = \"\"\"\ntext\n\"\"\"\n"),
         [(true, false), (true, false), (false, false)]
+    );
+    assert_eq!(
+        ends("LIST = [\n  1,\n]\n"),
+        [(true, false), (true, false), (false, false)]
+    );
+    // A brace inside a carried array still has to close on its own line.
+    assert_eq!(
+        ends("LIST = [\n  { a = 1 },\n]\n"),
+        [(true, false), (true, false), (false, false)]
+    );
+    assert_eq!(
+        ends("LIST = [\n  { a = 1,\n]\n"),
+        [(true, false), (true, true), (false, false)],
+        "the array carries; the inline table on that line does not"
     );
 }

--- a/crates/core/src/settings_toml/walk.rs
+++ b/crates/core/src/settings_toml/walk.rs
@@ -3,9 +3,9 @@
 //!
 //! Split from the row model above it because the two answer different
 //! questions. This one never decides what a line IS — it only says what a
-//! line leaves open and where its pieces are, which is the state every
-//! classification depends on and none of them is allowed to compute for
-//! itself.
+//! line leaves open, what it left unfinished, and where its pieces are,
+//! which is the state every classification depends on and none of them is
+//! allowed to compute for itself.
 
 use std::ops::Range;
 
@@ -49,6 +49,20 @@ impl Carry {
     }
 }
 
+/// What one line leaves behind. Two facts, because they are not the same
+/// one: what continues onto the next line, and what this line broke.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub(super) struct Ends {
+    /// What a line below this one starts inside.
+    pub(super) carry: Carry,
+    /// A single-line string opened on this line and never closed. It does
+    /// NOT carry — the grammar ends such a string with its line — so no
+    /// later line completes it and nothing about the value is pending.
+    /// Read closure from the absence of a carry alone and `TOKEN = "`
+    /// answers the same as a value that simply ended: closed.
+    pub(super) unterminated: bool,
+}
+
 /// The byte offset of the first `=` no string encloses. `None` where the
 /// line holds no such `=` — including a string opened where a key belongs,
 /// which is not an assignment this reader will hand out a span for.
@@ -68,7 +82,8 @@ pub(super) fn top_level_equals(content: &str) -> Option<usize> {
     None
 }
 
-/// Walk one line and return what it leaves open.
+/// Walk one line and return what it leaves behind: what carries onto the
+/// next line, and whether it broke off inside a single-line string.
 ///
 /// The one place a line's containers are read, so no classification arm
 /// can drop them: an open string first, then the brackets and strings the
@@ -76,7 +91,7 @@ pub(super) fn top_level_equals(content: &str) -> Option<usize> {
 /// line, and a stray `]` cannot take the depth below zero — an unbalanced
 /// file is not TOML, and underflowing here would read the whole rest of
 /// it as one value.
-pub(super) fn advance(content: &str, carry: Carry) -> Carry {
+pub(super) fn advance(content: &str, carry: Carry) -> Ends {
     let mut carry = carry;
     let mut index = 0;
     if let Some(kind) = carry.string {
@@ -85,9 +100,15 @@ pub(super) fn advance(content: &str, carry: Carry) -> Carry {
                 carry.string = None;
                 index = end;
             }
-            None => return carry,
+            None => {
+                return Ends {
+                    carry,
+                    unterminated: false,
+                };
+            }
         }
     }
+    let mut unterminated = false;
     let bytes = content.as_bytes();
     while index < bytes.len() {
         match bytes[index] {
@@ -103,14 +124,21 @@ pub(super) fn advance(content: &str, carry: Carry) -> Carry {
             b'"' | b'\'' => match string_at(content, index) {
                 Some(end) => index = end,
                 None => {
+                    // Opens a multiline, which carries — or opens a
+                    // single-line string that never closes, which is the
+                    // one break that leaves nothing pending behind it.
                     carry.string = opened_at(content, index);
+                    unterminated = carry.string.is_none();
                     break;
                 }
             },
             _ => index += 1,
         }
     }
-    carry
+    Ends {
+        carry,
+        unterminated,
+    }
 }
 
 /// The byte just past the string starting at `index`, or `None` where it

--- a/crates/core/src/settings_toml/walk.rs
+++ b/crates/core/src/settings_toml/walk.rs
@@ -31,8 +31,8 @@ impl Open {
 }
 
 /// What a value has left open across a line boundary — every container
-/// the grammar can carry over one, in one value, so a walk cannot answer
-/// for one and forget the other.
+/// the grammar can carry over one, held together in one value, so a walk
+/// cannot answer for one of them and forget another.
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
 pub(super) struct Carry {
     /// The multiline string still open, if any.

--- a/crates/core/src/settings_toml/walk.rs
+++ b/crates/core/src/settings_toml/walk.rs
@@ -1,5 +1,5 @@
 //! Reading one line's characters: which of them are inside a string, how
-//! deep the arrays are, and where a value's quotes sit.
+//! deep the arrays and inline tables are, and where a value's quotes sit.
 //!
 //! Split from the row model above it because the two answer different
 //! questions. This one never decides what a line IS — it only says what a
@@ -49,18 +49,22 @@ impl Carry {
     }
 }
 
-/// What one line leaves behind. Two facts, because they are not the same
-/// one: what continues onto the next line, and what this line broke.
+/// What one line leaves behind. Two facts, because the grammar splits its
+/// containers in two: those a later line may close, and those it may not.
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
 pub(super) struct Ends {
-    /// What a line below this one starts inside.
+    /// What a line below this one starts inside — the containers a later
+    /// line is allowed to close.
     pub(super) carry: Carry,
-    /// A single-line string opened on this line and never closed. It does
-    /// NOT carry — the grammar ends such a string with its line — so no
-    /// later line completes it and nothing about the value is pending.
-    /// Read closure from the absence of a carry alone and `TOKEN = "`
-    /// answers the same as a value that simply ended: closed.
-    pub(super) unterminated: bool,
+    /// Whether a container the grammar does NOT let cross a newline was
+    /// still open at the end of this line: a single-line string, or an
+    /// inline table. No later line may close either, so the value is
+    /// broken where it stands and nothing about it is pending.
+    ///
+    /// The complement of [`Carry`], not its negation. Read closure from
+    /// the absence of a carry alone and `TOKEN = "` and `MAP = {` both
+    /// answer the same as a value that simply ended: closed.
+    pub(super) broken: bool,
 }
 
 /// The byte offset of the first `=` no string encloses. `None` where the
@@ -82,15 +86,19 @@ pub(super) fn top_level_equals(content: &str) -> Option<usize> {
     None
 }
 
-/// Walk one line and return what it leaves behind: what carries onto the
-/// next line, and whether it broke off inside a single-line string.
+/// Walk one line and return what it leaves behind: the containers a later
+/// line may close, and whether one it may not was left open.
 ///
 /// The one place a line's containers are read, so no classification arm
-/// can drop them: an open string first, then the brackets and strings the
-/// rest of the line opens and closes. A `#` outside a string ends the
-/// line, and a stray `]` cannot take the depth below zero — an unbalanced
-/// file is not TOML, and underflowing here would read the whole rest of
-/// it as one value.
+/// can drop them: an open string first, then the brackets, braces and
+/// strings the rest of the line opens and closes. A `#` outside a string
+/// ends the line, and a stray `]` or `}` cannot take a depth below zero —
+/// an unbalanced file is not TOML, and underflowing here would read the
+/// whole rest of it as one value.
+///
+/// Every delimited form in the grammar is opened here and closed here, so
+/// "was anything left open" is answered for all of them at once rather
+/// than for the ones somebody remembered. See the module doc's table.
 pub(super) fn advance(content: &str, carry: Carry) -> Ends {
     let mut carry = carry;
     let mut index = 0;
@@ -103,12 +111,16 @@ pub(super) fn advance(content: &str, carry: Carry) -> Ends {
             None => {
                 return Ends {
                     carry,
-                    unterminated: false,
+                    broken: false,
                 };
             }
         }
     }
-    let mut unterminated = false;
+    // Inline tables may not hold a newline, so their depth is counted for
+    // this line alone and never joins the carry: one still open where the
+    // line ends can never be closed.
+    let mut tables = 0usize;
+    let mut string_broken = false;
     let bytes = content.as_bytes();
     while index < bytes.len() {
         match bytes[index] {
@@ -121,14 +133,21 @@ pub(super) fn advance(content: &str, carry: Carry) -> Ends {
                 carry.arrays = carry.arrays.saturating_sub(1);
                 index += 1;
             }
+            b'{' => {
+                tables += 1;
+                index += 1;
+            }
+            b'}' => {
+                tables = tables.saturating_sub(1);
+                index += 1;
+            }
             b'"' | b'\'' => match string_at(content, index) {
                 Some(end) => index = end,
                 None => {
-                    // Opens a multiline, which carries — or opens a
-                    // single-line string that never closes, which is the
-                    // one break that leaves nothing pending behind it.
+                    // Opens a multiline, which carries — or a single-line
+                    // string that never closes, which cannot.
                     carry.string = opened_at(content, index);
-                    unterminated = carry.string.is_none();
+                    string_broken = carry.string.is_none();
                     break;
                 }
             },
@@ -137,7 +156,7 @@ pub(super) fn advance(content: &str, carry: Carry) -> Ends {
     }
     Ends {
         carry,
-        unterminated,
+        broken: string_broken || tables > 0,
     }
 }
 

--- a/crates/core/src/settings_toml/walk.rs
+++ b/crates/core/src/settings_toml/walk.rs
@@ -39,13 +39,17 @@ pub(super) struct Carry {
     string: Option<Open>,
     /// How many arrays are open. Counted rather than flagged: arrays nest.
     arrays: usize,
+    /// How many inline tables are open. Counted for the same reason, and
+    /// carried for the same reason: under the spec this workspace parses
+    /// with, an inline table may hold newlines like any other container.
+    tables: usize,
 }
 
 impl Carry {
     /// Whether a line starting here is inside a value rather than being
     /// structure of its own.
     pub(super) fn inside(self) -> bool {
-        self.string.is_some() || self.arrays > 0
+        self.string.is_some() || self.arrays > 0 || self.tables > 0
     }
 }
 
@@ -57,13 +61,14 @@ pub(super) struct Ends {
     /// line is allowed to close.
     pub(super) carry: Carry,
     /// Whether a container the grammar does NOT let cross a newline was
-    /// still open at the end of this line: a single-line string, or an
-    /// inline table. No later line may close either, so the value is
-    /// broken where it stands and nothing about it is pending.
+    /// still open at the end of this line. Only a single-line string can
+    /// be one: every other container carries, so a later line closes it or
+    /// the carry runs to the end of the file, and both are answered by
+    /// [`Carry`].
     ///
     /// The complement of [`Carry`], not its negation. Read closure from
-    /// the absence of a carry alone and `TOKEN = "` and `MAP = {` both
-    /// answer the same as a value that simply ended: closed.
+    /// the absence of a carry alone and `TOKEN = "` answers the same as a
+    /// value that simply ended: closed.
     pub(super) broken: bool,
 }
 
@@ -94,7 +99,8 @@ pub(super) fn top_level_equals(content: &str) -> Option<usize> {
 /// strings the rest of the line opens and closes. A `#` outside a string
 /// ends the line, and a stray `]` or `}` cannot take a depth below zero —
 /// an unbalanced file is not TOML, and underflowing here would read the
-/// whole rest of it as one value.
+/// whole rest of it as one value. A container left open at the end of the
+/// file simply never closes, which is what an unparseable file is.
 ///
 /// Every delimited form in the grammar is opened here and closed here, so
 /// "was anything left open" is answered for all of them at once rather
@@ -116,10 +122,6 @@ pub(super) fn advance(content: &str, carry: Carry) -> Ends {
             }
         }
     }
-    // Inline tables may not hold a newline, so their depth is counted for
-    // this line alone and never joins the carry: one still open where the
-    // line ends can never be closed.
-    let mut tables = 0usize;
     let mut string_broken = false;
     let bytes = content.as_bytes();
     while index < bytes.len() {
@@ -134,11 +136,11 @@ pub(super) fn advance(content: &str, carry: Carry) -> Ends {
                 index += 1;
             }
             b'{' => {
-                tables += 1;
+                carry.tables += 1;
                 index += 1;
             }
             b'}' => {
-                tables = tables.saturating_sub(1);
+                carry.tables = carry.tables.saturating_sub(1);
                 index += 1;
             }
             b'"' | b'\'' => match string_at(content, index) {
@@ -156,7 +158,7 @@ pub(super) fn advance(content: &str, carry: Carry) -> Ends {
     }
     Ends {
         carry,
-        broken: string_broken || tables > 0,
+        broken: string_broken,
     }
 }
 

--- a/crates/core/tests/settings_seed_apply.rs
+++ b/crates/core/tests/settings_seed_apply.rs
@@ -382,7 +382,7 @@ fn a_key_shipped_with_differing_defaults_gets_one_grouped_note() {
     assert!(about[0].contains("\"900\" (alpha, beta)"), "{about:?}");
     assert!(about[0].contains("\"600\" (gamma)"), "{about:?}");
 
-    // The note changes nothing: the first declaration is still what lands.
+    // The note changes nothing: the declaration seeding picked still lands.
     apply_now(&f);
     let seeded = fs::read_to_string(f.project.join("kendex.settings.toml")).unwrap();
     assert!(seeded.contains("WAIT = \"900\""), "{seeded}");

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -454,15 +454,15 @@ lives in one capability table read by core and UI.
   repeats it.
 - **A seeded settings comment refreshes only while provably unedited.**
   Skills seed `[env]` defaults into `kendex.settings.toml` write-if-absent;
-  the lock keeps, per key, the seeding skill and the FNV-1a hash of the
-  comment block last written. A revision rewrites a key's comment only
-  while its on-disk text hashes to that record and the template belongs to
-  the recorded owner. A v1 record imports with no owner; a template earns
-  it only where the comment is provably what v1 seeded, word for word.
-  Where several skills ship one key, the first declaration is seeded,
-  refresh follows the recorded owner, a bare key is never adopted, and a
-  plan note names every owner and default where they differ. Seeding never
-  touches a value; an edit rides that same write, moving its span alone.
+  the lock keeps, per key, the seeding skill and the FNV-1a hash of its
+  comment. A revision rewrites that comment only while its text still hashes
+  to the record and the template is the recorded owner's. A v1 record
+  imports with no owner, earned only where the comment is word for word
+  v1's. Where several skills ship one key, the first whose template
+  completes the value is seeded, refresh follows that owner, a bare key is
+  never adopted, and a note names every owner and differing default. A value
+  no template completes is seeded from none, under a note naming the key.
+  Seeding never touches a value; an edit rides that write, its span alone.
 - **Schemas are versioned and migrations are applies.** Manifest and lock
   carry a format version; older files load, and the upgrade rides the
   normal journaled, previewed plan as a surgical edit (the version line

--- a/docs/authoring/settings.md
+++ b/docs/authoring/settings.md
@@ -73,8 +73,14 @@ runs.
 
 Seeding stays lenient, and that is the point of checking: in the consumer's
 `kendex.settings.toml` a duplicate assignment inside `[env]` fails the load,
-while a template with one seeds its first declaration and drops the rest
-without a word. Write each key once.
+while a template with one seeds the first declaration it can write whole and
+drops the rest without a word. Write each key once.
+
+A value the template never closes is the one thing seeding will not pass
+over in silence. It writes nothing for that key — a partial value would stop
+the consumer's file parsing from that line down — and the plan names the key
+instead. A value that does close is seeded whole however many lines it
+takes, spelled exactly as the template spells it.
 
 ## Naming
 


### PR DESCRIPTION
Closes KEN-791.

Seeding gave each `[env]` entry the assignment's opening physical line only, so a template whose value spans lines seeded `BLOB = """` alone. Nothing closed the string, every key seeded after it fell inside it, and the consumer's `kendex.settings.toml` stopped parsing from there down — each later read and each later seed against that file then failed. This is on `main` today and ships in released kendex; #1779's walk rewrite did not create it.

An entry now carries every physical line of its value, so the seeded file gets the complete value closed and byte-faithful to the template. A value the template never closes cannot be carried whole, and that one refuses the seed naming the key. Neither case drops a declared key silently.

The walk already knew where a value ends — that is what `settings_toml` was built for — so `Row` carries the fact from the line that opened the value rather than seeding growing a second notion of it.

Controls cover `"""`, `'''`, a multiline array and an unterminated value, each red before the fix.

No shipped template carries a multiline value today; all 29 `kendex.settings.toml.example` files across this repo, hyprtrade and vg are single-line. TOML allows the shape and the seed is deterministic, so one consumer template is enough to reach it.

One unrelated line rides along because it has nowhere else to go: `recordedRead` in `ui/src/stores/editor-cache.ts` still claimed "Refused outright where a newer read has already answered for the place". Nothing refuses anything — the read registry that did was deleted on #1791, which merged frozen and could not take the correction, so the false sentence is on `main`. Comment only.
