### PR TITLE
feat(KEN-717): a package's safety check gets its own tab

### DIFF
--- a/changelog.d/changed/KEN-717.md
+++ b/changelog.d/changed/KEN-717.md
@@ -1,0 +1,3 @@
+- A package's safety check has its own Safety score tab, with the score on the
+  tab beside the words. Overview opens on the package itself rather than on the
+  check's findings.

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -249,22 +249,22 @@ lives in one capability table read by core and UI.
   plugin registry a plugin names; an unknown registry is the user's.
   Vendor-owned content is scored by nothing and asked about nowhere: listed
   in the Library, labelled with who ships it, left alone.
-- A package's page tabs `Overview · Projects · Customize`; Customize is last, the
-  only tab a kind can lack. Projects lists each place installed in, with its update
-  and removal; the header's `Delete` takes every copy. Customize edits instructions,
-  the skills an agent gets, per-tool settings, and a skill's own declared settings;
-  the Customize page keeps what is not about one package (the `all` row, custom
-  hooks, a project's skills folder) plus an index of what is customized there. Both
-  edit one manifest draft per scope; the package page adds a settings draft, and one
-  Save bar writes both as one transaction (`stores/editor.ts`; reloads only when
-  nothing is unsaved). `lib/customization.ts` slices it, `lib/settings-rows.ts` the rows.
-- A place is customized by settings, a settings value off its package default,
-  a hand edit, or a fork, and `lib/customized-places.ts::placeStandings` is the
-  one answer, over a `PlacesSource` only `placesSource` builds. Its readers are
-  what `grep -rn placeStandings ui/src` finds, the Customize index
-  (`lib/customized-here.ts`) among them: it reads the drafts open for its place
-  and calls nothing customized until every read lands (`lib/updates-read-state.ts`:
-  pending is checking, failed is packages missing).
+- A package's page tabs `Overview · Projects · Safety score · Customize`; Customize
+  is last, the only tab a kind can lack. Projects lists each place installed in,
+  with its update and removal; the header's `Delete` takes every copy. Safety score
+  carries the automated check's finding. Customize edits instructions, the skills an
+  agent gets, per-tool settings, and a skill's own declared settings; the Customize
+  page keeps what is not about one package (the `all` row, custom hooks, a project's
+  skills folder) plus an index of what is customized there. Both edit one manifest
+  draft per scope; the package page adds a settings draft, and one Save bar writes
+  both as one transaction (`stores/editor.ts`; reloads only when nothing is unsaved).
+  `lib/customization.ts` slices it, `lib/settings-rows.ts` the rows.
+- A place is customized by settings, a settings value off its package default, a
+  hand edit, or a fork, and `lib/customized-places.ts::placeStandings` is the one
+  answer, over a `PlacesSource` only `placesSource` builds. Its readers are what
+  `grep -rn placeStandings ui/src` finds, the Customize index
+  (`lib/customized-here.ts`) among them: it reads the drafts open for its place and calls
+  nothing customized until every read lands (`lib/updates-read-state.ts`: pending is checking, failed is packages missing).
 - Hook events have one vocabulary — Claude Code's names, in
   `core/hook.rs::EVENTS`; every other harness's map is keyed by it. The
   picker offers that list, the validator rejects anything outside it, the renderers read it.

--- a/ui/src/components/package/package-body.tsx
+++ b/ui/src/components/package/package-body.tsx
@@ -9,7 +9,6 @@ import { DiffView } from "@/components/diff/diff-view";
 import { DotSpinner } from "@/components/loading";
 import { FilePreview } from "@/components/package/file-preview";
 import { EditedNotice } from "@/components/package/fork-notice";
-import { PackageSafety } from "@/components/package/package-safety";
 import { PackageSidebar } from "@/components/package/package-sidebar";
 import type { PackageView } from "@/components/package/use-package-data";
 import type { ItemGroup } from "@/lib/derive";
@@ -17,9 +16,10 @@ import { harnessName } from "@/lib/labels";
 import { versionRowLabel } from "@/lib/versions";
 import type { PackageRef } from "@/stores/nav";
 
-/** What a package is, as installed: its safety reading over the whole
- *  thing, then its provenance and switches on the left with the file it is
- *  made of — or a comparison — on the right. */
+/** What a package is, as installed: its provenance and switches on the
+ *  left, with the file it is made of — or a comparison — on the right. The
+ *  safety reading answers for the whole package rather than for what this
+ *  view happens to show, so it has a tab of its own. */
 export function PackageBody({
   reference,
   group,
@@ -78,11 +78,6 @@ export function PackageBody({
         onResolved={onReload}
       />
       <div className="flex flex-col gap-8">
-        {/* The score answers for the whole package, so it stands above what
-            the page happens to be showing — a file, or a comparison of two
-            versions. Closing a diff is not what makes a package's reading
-            true, and a Preview opens this page straight into one. */}
-        <PackageSafety reference={reference} />
         {view.mode === "diff" ? (
           diff ? (
             <DiffView

--- a/ui/src/components/package/package-safety.dom.test.tsx
+++ b/ui/src/components/package/package-safety.dom.test.tsx
@@ -6,15 +6,22 @@ import { commands } from "@/bindings";
 import { ADOPTABLE } from "@/lib/adoptable";
 import {
   SAFETY_CHECK_FAILED,
+  SAFETY_NOT_READ,
+  SAFETY_NOT_READ_BODY,
   SAFETY_RETRY_LABEL,
   staleSafetyNote,
 } from "@/lib/copy-safety";
 import { SEVERITY_LABELS } from "@/lib/labels";
 import { useAuditStore } from "@/stores/audit";
 import { refreshDownstream } from "@/stores/marketplaces-shared";
+import type { PackageRef } from "@/stores/nav";
 import { useScanStore } from "@/stores/scan";
 import { mount, settle } from "@/test/dom";
-import { PackageSafety } from "./package-safety";
+import {
+  PackageSafety,
+  SafetyScoreLabel,
+  usePackageSafety,
+} from "./package-safety";
 
 vi.mock("@/bindings", () => ({
   commands: { auditAll: vi.fn(), scanMachine: vi.fn() },
@@ -22,6 +29,22 @@ vi.mock("@/bindings", () => ({
 vi.mock("sonner", () => ({ toast: { error: vi.fn(), success: vi.fn() } }));
 
 const GLOBAL: Scope = { scope: "global" };
+
+/** The tab exactly as the page wires it: one reading behind the label and
+ *  the panel, so a test can never see the two disagree. */
+function SafetyTab({ reference }: { reference: PackageRef }) {
+  const reading = usePackageSafety(
+    reference.kind,
+    reference.name,
+    reference.scope,
+  );
+  return (
+    <>
+      <SafetyScoreLabel reading={reading} />
+      <PackageSafety reading={reading} />
+    </>
+  );
+}
 
 const gh: ItemSafety = {
   kind: "skill",
@@ -96,9 +119,7 @@ describe("a package installed just now", () => {
     });
 
     const host = mount(
-      <PackageSafety
-        reference={{ kind: "skill", name: "gh", scope: GLOBAL }}
-      />,
+      <SafetyTab reference={{ kind: "skill", name: "gh", scope: GLOBAL }} />,
     );
     await settle();
     expect(host.textContent).not.toContain("58/100");
@@ -133,9 +154,7 @@ describe("when the check could not run", () => {
       .mockResolvedValue({ status: "ok", data: [view([gh])] });
 
     const host = mount(
-      <PackageSafety
-        reference={{ kind: "skill", name: "gh", scope: GLOBAL }}
-      />,
+      <SafetyTab reference={{ kind: "skill", name: "gh", scope: GLOBAL }} />,
     );
     await settle();
 
@@ -174,9 +193,7 @@ describe("when the check could not run", () => {
     });
 
     const host = mount(
-      <PackageSafety
-        reference={{ kind: "skill", name: "gh", scope: GLOBAL }}
-      />,
+      <SafetyTab reference={{ kind: "skill", name: "gh", scope: GLOBAL }} />,
     );
     await settle();
 
@@ -208,9 +225,7 @@ describe("when only this package's place could not be read", () => {
     });
 
     const host = mount(
-      <PackageSafety
-        reference={{ kind: "skill", name: "gh", scope: GLOBAL }}
-      />,
+      <SafetyTab reference={{ kind: "skill", name: "gh", scope: GLOBAL }} />,
     );
     await settle();
 
@@ -231,13 +246,44 @@ describe("when only this package's place could not be read", () => {
     });
 
     const host = mount(
-      <PackageSafety
-        reference={{ kind: "skill", name: "gh", scope: GLOBAL }}
-      />,
+      <SafetyTab reference={{ kind: "skill", name: "gh", scope: GLOBAL }} />,
     );
     await settle();
 
     expect(host.textContent).toContain("58/100");
     expect(host.textContent).not.toContain("couldn't run");
+  });
+});
+
+// The audit came back and had no row for this package. Nothing found and
+// nothing read are different claims, and a blank tab would make the first
+// one on the strength of the second.
+describe("when the audit answered with no reading for this package", () => {
+  it("says it has not been scored, and the retry gets a reading", async () => {
+    vi.mocked(commands.auditAll)
+      .mockResolvedValueOnce({ status: "ok", data: [view([])] })
+      .mockResolvedValue({ status: "ok", data: [view([gh])] });
+
+    const host = mount(
+      <SafetyTab reference={{ kind: "skill", name: "gh", scope: GLOBAL }} />,
+    );
+    await settle();
+
+    expect(host.textContent).toContain(SAFETY_NOT_READ);
+    expect(host.textContent).toContain(SAFETY_NOT_READ_BODY);
+    expect(host.textContent).not.toContain(SAFETY_CHECK_FAILED);
+    // The label has nothing to show either, and a dash is not a score.
+    expect(host.textContent).toContain("—");
+
+    const retry = [...host.querySelectorAll("button")].find(
+      (button) => button.textContent === SAFETY_RETRY_LABEL,
+    );
+    if (!retry) throw new Error("expected a retry button");
+    await act(async () => {
+      retry.click();
+    });
+    await settle();
+
+    expect(host.textContent).toContain("58/100");
   });
 });

--- a/ui/src/components/package/package-safety.dom.test.tsx
+++ b/ui/src/components/package/package-safety.dom.test.tsx
@@ -32,7 +32,13 @@ const GLOBAL: Scope = { scope: "global" };
 
 /** The tab exactly as the page wires it: one reading behind the label and
  *  the panel, so a test can never see the two disagree. */
-function SafetyTab({ reference }: { reference: PackageRef }) {
+function SafetyTab({
+  reference,
+  vendor = null,
+}: {
+  reference: PackageRef;
+  vendor?: string | null;
+}) {
   const reading = usePackageSafety(
     reference.kind,
     reference.name,
@@ -40,8 +46,8 @@ function SafetyTab({ reference }: { reference: PackageRef }) {
   );
   return (
     <>
-      <SafetyScoreLabel reading={reading} />
-      <PackageSafety reading={reading} />
+      <SafetyScoreLabel reading={reading} vendor={vendor} />
+      <PackageSafety reading={reading} vendor={vendor} />
     </>
   );
 }

--- a/ui/src/components/package/package-safety.tsx
+++ b/ui/src/components/package/package-safety.tsx
@@ -1,4 +1,4 @@
-import { CircleHelp, TriangleAlert } from "lucide-react";
+import { CircleHelp, Package, TriangleAlert } from "lucide-react";
 import type { ItemKind, Scope } from "@/bindings";
 import { EmptyState } from "@/components/empty-state";
 import {
@@ -9,6 +9,7 @@ import { DotSpinner } from "@/components/loading";
 import { SafetyPanel } from "@/components/safety-panel";
 import { ScoreCircle } from "@/components/score-circle";
 import { Button } from "@/components/ui/button";
+import { vendorHelp } from "@/lib/copy";
 import {
   SAFETY_CHECK_FAILED,
   SAFETY_CHECKING,
@@ -17,6 +18,7 @@ import {
   SAFETY_RETRY_LABEL,
   SAFETY_TAB,
   SAFETY_TAB_STALE,
+  SAFETY_VENDOR,
   severityTone,
 } from "@/lib/copy-safety";
 import { useAuditOnMount } from "@/stores/audit";
@@ -45,8 +47,17 @@ export function usePackageSafety(
  *  figure is not read as a count the check just took. Somebody looking at
  *  Overview sees only this label, and a kept number that looks current
  *  there is a claim nothing on the machine supports. */
-export function SafetyScoreLabel({ reading }: { reading: InstalledReading }) {
+export function SafetyScoreLabel({
+  reading,
+  vendor,
+}: {
+  reading: InstalledReading;
+  vendor: string | null;
+}) {
   const { result, failure } = reading;
+  // A tool's own content carries no disc at all. The dash reads as a figure
+  // still on its way, and for this one nothing is on its way.
+  if (vendor) return <>{SAFETY_TAB}</>;
   const current = result !== null && failure === null;
   return (
     <>
@@ -69,17 +80,37 @@ export function SafetyScoreLabel({ reading }: { reading: InstalledReading }) {
 
 /** What the check made of this package, in full.
  *
- *  Four answers that must never blur: a reading, a check that failed with
- *  nothing kept from a better one, a first check still on its way, and an
- *  audit that answered with no reading for this package at all. A blank
- *  panel for any of the last three would read as a package the check found
- *  nothing in, which is the one claim it has not made. */
-export function PackageSafety({ reading }: { reading: InstalledReading }) {
+ *  Five answers that must never blur: content the audit does not read at
+ *  all, a reading, a check that failed with nothing kept from a better one,
+ *  a first check still on its way, and an audit that answered with no
+ *  reading for this package. A blank panel for any of them would read as a
+ *  package the check found nothing in, which is the one claim it has not
+ *  made.
+ *
+ *  The vendor answer comes first and carries no retry. `observed_rows`
+ *  skips content a tool ships itself, so no audit will ever score it, and
+ *  the unscored state's button would ask for a check that is not coming. */
+export function PackageSafety({
+  reading,
+  vendor,
+}: {
+  reading: InstalledReading;
+  vendor: string | null;
+}) {
   const retry = (
     <Button variant="outline" onClick={reading.retry}>
       {SAFETY_RETRY_LABEL}
     </Button>
   );
+  if (vendor) {
+    return (
+      <div className="flex justify-center">
+        <EmptyState icon={Package} title={SAFETY_VENDOR}>
+          {vendorHelp(vendor)}
+        </EmptyState>
+      </div>
+    );
+  }
   if (reading.result) {
     return (
       <SafetyPanel

--- a/ui/src/components/package/package-safety.tsx
+++ b/ui/src/components/package/package-safety.tsx
@@ -17,6 +17,7 @@ import {
   SAFETY_NOT_READ_BODY,
   SAFETY_RETRY_LABEL,
   SAFETY_TAB,
+  SAFETY_TAB_FAILED,
   SAFETY_TAB_STALE,
   SAFETY_VENDOR,
   severityTone,
@@ -59,6 +60,15 @@ export function SafetyScoreLabel({
   // still on its way, and for this one nothing is on its way.
   if (vendor) return <>{SAFETY_TAB}</>;
   const current = result !== null && failure === null;
+  // A check that failed is marked whether or not it left a reading behind.
+  // A dash alone is what a pending check and an unscored answer both show,
+  // so a failure drawn that way is a failure nobody is told about.
+  const mark =
+    failure === null
+      ? null
+      : result !== null
+        ? SAFETY_TAB_STALE
+        : SAFETY_TAB_FAILED;
   return (
     <>
       {SAFETY_TAB}
@@ -67,11 +77,11 @@ export function SafetyScoreLabel({
         score={result?.safety.score ?? null}
         tone={current ? severityTone(result.findings) : "muted"}
       />
-      {result !== null && failure !== null ? (
+      {mark ? (
         <>
           <TriangleAlert className="size-3.5 text-warning" />
           {/* Colour is never the only carrier of the fact. */}
-          <span className="sr-only">{SAFETY_TAB_STALE}</span>
+          <span className="sr-only">{mark}</span>
         </>
       ) : null}
     </>

--- a/ui/src/components/package/package-safety.tsx
+++ b/ui/src/components/package/package-safety.tsx
@@ -16,6 +16,7 @@ import {
   SAFETY_NOT_READ_BODY,
   SAFETY_RETRY_LABEL,
   SAFETY_TAB,
+  SAFETY_TAB_STALE,
   severityTone,
 } from "@/lib/copy-safety";
 import { useAuditOnMount } from "@/stores/audit";
@@ -36,17 +37,32 @@ export function usePackageSafety(
 /** The tab's name with the score after it. The words come first: the disc
  *  is decorative, so a tab labelled with the figure alone would name a
  *  number and nothing it is a number of. Until a reading arrives the disc
- *  shows a dash rather than a zero, which is a score a package can earn. */
+ *  shows a dash rather than a zero, which is a score a package can earn.
+ *
+ *  A reading kept from before a failed check is on the tab too, because it
+ *  is the last thing anything knows. It stops being drawn as a current
+ *  severity: the disc goes muted and the tab carries the mark, so the
+ *  figure is not read as a count the check just took. Somebody looking at
+ *  Overview sees only this label, and a kept number that looks current
+ *  there is a claim nothing on the machine supports. */
 export function SafetyScoreLabel({ reading }: { reading: InstalledReading }) {
-  const { result } = reading;
+  const { result, failure } = reading;
+  const current = result !== null && failure === null;
   return (
     <>
       {SAFETY_TAB}
       <ScoreCircle
         size="sm"
         score={result?.safety.score ?? null}
-        tone={result ? severityTone(result.findings) : "muted"}
+        tone={current ? severityTone(result.findings) : "muted"}
       />
+      {result !== null && failure !== null ? (
+        <>
+          <TriangleAlert className="size-3.5 text-warning" />
+          {/* Colour is never the only carrier of the fact. */}
+          <span className="sr-only">{SAFETY_TAB_STALE}</span>
+        </>
+      ) : null}
     </>
   );
 }

--- a/ui/src/components/package/package-safety.tsx
+++ b/ui/src/components/package/package-safety.tsx
@@ -1,24 +1,69 @@
-import { useInstalledReading } from "@/components/installed-score";
+import { CircleHelp, TriangleAlert } from "lucide-react";
+import type { ItemKind, Scope } from "@/bindings";
+import { EmptyState } from "@/components/empty-state";
+import {
+  type InstalledReading,
+  useInstalledReading,
+} from "@/components/installed-score";
 import { DotSpinner } from "@/components/loading";
-import { SafetyPanel, SafetyUnavailable } from "@/components/safety-panel";
+import { SafetyPanel } from "@/components/safety-panel";
+import { ScoreCircle } from "@/components/score-circle";
+import { Button } from "@/components/ui/button";
+import {
+  SAFETY_CHECK_FAILED,
+  SAFETY_CHECKING,
+  SAFETY_NOT_READ,
+  SAFETY_NOT_READ_BODY,
+  SAFETY_RETRY_LABEL,
+  SAFETY_TAB,
+  severityTone,
+} from "@/lib/copy-safety";
 import { useAuditOnMount } from "@/stores/audit";
-import type { PackageRef } from "@/stores/nav";
 
-/** The installed package's safety reading, scored where the files sit.
- *
- *  The audit is the slowest thing the app does, so the page can open before
- *  it has answered. Until it does the block says it is still reading rather
- *  than showing a score it does not have — an absent block would read as
- *  "nothing found", which is the one claim the check has not made yet, and
- *  a check that failed says so with the way to ask again rather than
- *  spinning for the session. */
-export function PackageSafety({ reference }: { reference: PackageRef }) {
+/** The safety reading for the copy installed at the one place this page is
+ *  about — not the same name somewhere else on the machine. Asks for a
+ *  fresh audit as the page comes up; the store's freshness window decides
+ *  whether that costs anything. */
+export function usePackageSafety(
+  kind: ItemKind,
+  name: string,
+  scope: Scope,
+): InstalledReading {
   useAuditOnMount();
-  // This place's copy, not the same name somewhere else on the machine.
-  const reading = useInstalledReading(reference.kind, reference.name, [
-    reference.scope,
-  ]);
+  return useInstalledReading(kind, name, [scope]);
+}
 
+/** The tab's name with the score after it. The words come first: the disc
+ *  is decorative, so a tab labelled with the figure alone would name a
+ *  number and nothing it is a number of. Until a reading arrives the disc
+ *  shows a dash rather than a zero, which is a score a package can earn. */
+export function SafetyScoreLabel({ reading }: { reading: InstalledReading }) {
+  const { result } = reading;
+  return (
+    <>
+      {SAFETY_TAB}
+      <ScoreCircle
+        size="sm"
+        score={result?.safety.score ?? null}
+        tone={result ? severityTone(result.findings) : "muted"}
+      />
+    </>
+  );
+}
+
+/** What the check made of this package, in full.
+ *
+ *  Four answers that must never blur: a reading, a check that failed with
+ *  nothing kept from a better one, a first check still on its way, and an
+ *  audit that answered with no reading for this package at all. A blank
+ *  panel for any of the last three would read as a package the check found
+ *  nothing in, which is the one claim it has not made. */
+export function PackageSafety({ reading }: { reading: InstalledReading }) {
+  const retry = (
+    <Button variant="outline" onClick={reading.retry}>
+      {SAFETY_RETRY_LABEL}
+    </Button>
+  );
   if (reading.result) {
     return (
       <SafetyPanel
@@ -31,16 +76,30 @@ export function PackageSafety({ reference }: { reference: PackageRef }) {
   }
   if (reading.failure !== null) {
     return (
-      <SafetyUnavailable message={reading.failure} onRetry={reading.retry} />
+      <div className="flex justify-center">
+        <EmptyState
+          icon={TriangleAlert}
+          title={SAFETY_CHECK_FAILED}
+          action={retry}
+        >
+          {reading.failure}
+        </EmptyState>
+      </div>
     );
   }
-  // Answered with no row for this package is an answer: nothing here is
-  // installed where the check could read it.
-  if (!reading.waiting) return null;
+  if (reading.waiting) {
+    return (
+      <p className="flex items-center justify-center gap-2 py-20 text-sm text-muted-foreground">
+        <DotSpinner />
+        {SAFETY_CHECKING}
+      </p>
+    );
+  }
   return (
-    <p className="flex items-center gap-2 text-sm text-muted-foreground">
-      <DotSpinner />
-      Checking this package…
-    </p>
+    <div className="flex justify-center">
+      <EmptyState icon={CircleHelp} title={SAFETY_NOT_READ} action={retry}>
+        {SAFETY_NOT_READ_BODY}
+      </EmptyState>
+    </div>
   );
 }

--- a/ui/src/components/package/package-tabs.dom.test.tsx
+++ b/ui/src/components/package/package-tabs.dom.test.tsx
@@ -5,7 +5,7 @@ import type { AuditView, ItemSafety, Scope } from "@/bindings";
 import { commands } from "@/bindings";
 import { ADOPTABLE } from "@/lib/adoptable";
 import { PROJECTS_TAB } from "@/lib/copy-projects";
-import { SAFETY_TAB } from "@/lib/copy-safety";
+import { SAFETY_TAB, SAFETY_TAB_STALE } from "@/lib/copy-safety";
 import { useAuditStore } from "@/stores/audit";
 import { mount, settle } from "@/test/dom";
 import { PackageTabs } from "./package-tabs";
@@ -135,5 +135,62 @@ describe("a package's tab strip", () => {
       (trigger) => trigger.textContent,
     );
     expect(labels).toEqual(["Overview", PROJECTS_TAB, `${SAFETY_TAB}58`]);
+  });
+});
+
+// A reading that outlived the check meant to replace it is the last thing
+// anything knows, not what the files say now. The panel already heads it
+// that way; the tab is what somebody standing on Overview or Projects sees,
+// and a kept figure drawn as a current one there is a claim nothing on the
+// machine supports.
+describe("the tab's figure when the check could not run again", () => {
+  const disc = (host: HTMLElement) => {
+    const found = tab(host, SAFETY_TAB).querySelector("span[aria-hidden]");
+    if (!found) throw new Error("no score disc on the tab");
+    return found;
+  };
+
+  it("marks a kept reading and drops its severity tone", async () => {
+    // Three hours is well past the freshness window, so the mount asks for
+    // a new audit — and it is that ask which fails, leaving the earlier
+    // reading on the tab.
+    vi.mocked(commands.auditAll).mockResolvedValue({
+      status: "error",
+      error: "audit crashed",
+    });
+    useAuditStore.setState({
+      views: [view([deploy])],
+      auditedAt: Date.now() - 3 * 60 * 60 * 1000,
+      backgroundFailureAnnounced: true,
+    });
+
+    const host = strip();
+    await settle();
+
+    // The number stays, because it is the last reading there is.
+    expect(tab(host, SAFETY_TAB).textContent).toBe(
+      `${SAFETY_TAB}58${SAFETY_TAB_STALE}`,
+    );
+    // The words carry it, so the mark is never colour alone.
+    expect(tab(host, SAFETY_TAB).querySelector(".sr-only")?.textContent).toBe(
+      SAFETY_TAB_STALE,
+    );
+    // 58 with one high finding is the warning tone when it is current.
+    expect(disc(host).className).toContain("text-muted-foreground");
+    expect(disc(host).className).not.toContain("text-warning");
+  });
+
+  it("leaves a current reading unmarked, in the tone it earned", async () => {
+    vi.mocked(commands.auditAll).mockResolvedValue({
+      status: "ok",
+      data: [view([deploy])],
+    });
+
+    const host = strip();
+    await settle();
+
+    expect(tab(host, SAFETY_TAB).textContent).toBe(`${SAFETY_TAB}58`);
+    expect(tab(host, SAFETY_TAB).querySelector(".sr-only")).toBeNull();
+    expect(disc(host).className).toContain("text-warning");
   });
 });

--- a/ui/src/components/package/package-tabs.dom.test.tsx
+++ b/ui/src/components/package/package-tabs.dom.test.tsx
@@ -10,6 +10,7 @@ import {
   SAFETY_NOT_READ,
   SAFETY_RETRY_LABEL,
   SAFETY_TAB,
+  SAFETY_TAB_FAILED,
   SAFETY_TAB_STALE,
   SAFETY_VENDOR,
 } from "@/lib/copy-safety";
@@ -248,5 +249,44 @@ describe("a package the harness ships itself", () => {
     expect(host.textContent).toContain(SAFETY_NOT_READ);
     expect(host.textContent).not.toContain(SAFETY_VENDOR);
     expect(retryButton(host)).toBeDefined();
+  });
+});
+
+// Overview is the tab a page opens on, so the label is the only thing most
+// readers see. Before the check moved off Overview a failed audit said so
+// there; the label has to carry that now, and a dash cannot, because a dash
+// is also what a pending check and an unscored answer show.
+describe("the tab's label when no reading arrived at all", () => {
+  const label = async () => {
+    const host = strip();
+    await settle();
+    return tab(host, SAFETY_TAB);
+  };
+
+  it("marks a first check that failed", async () => {
+    vi.mocked(commands.auditAll).mockResolvedValue({
+      status: "error",
+      error: "audit crashed",
+    });
+
+    expect((await label()).textContent).toBe(
+      `${SAFETY_TAB}—${SAFETY_TAB_FAILED}`,
+    );
+  });
+
+  it("leaves a check still running unmarked", async () => {
+    // Never resolves, so nothing has answered and nothing has failed.
+    vi.mocked(commands.auditAll).mockReturnValue(new Promise(() => {}));
+
+    expect((await label()).textContent).toBe(`${SAFETY_TAB}—`);
+  });
+
+  it("leaves an answer with no row for this package unmarked", async () => {
+    vi.mocked(commands.auditAll).mockResolvedValue({
+      status: "ok",
+      data: [view([])],
+    });
+
+    expect((await label()).textContent).toBe(`${SAFETY_TAB}—`);
   });
 });

--- a/ui/src/components/package/package-tabs.dom.test.tsx
+++ b/ui/src/components/package/package-tabs.dom.test.tsx
@@ -1,0 +1,139 @@
+// @vitest-environment jsdom
+import { act } from "react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { AuditView, ItemSafety, Scope } from "@/bindings";
+import { commands } from "@/bindings";
+import { ADOPTABLE } from "@/lib/adoptable";
+import { PROJECTS_TAB } from "@/lib/copy-projects";
+import { SAFETY_TAB } from "@/lib/copy-safety";
+import { useAuditStore } from "@/stores/audit";
+import { mount, settle } from "@/test/dom";
+import { PackageTabs } from "./package-tabs";
+
+vi.mock("@/bindings", () => ({
+  commands: { auditAll: vi.fn(), scanMachine: vi.fn() },
+}));
+vi.mock("sonner", () => ({ toast: { error: vi.fn(), success: vi.fn() } }));
+
+const GLOBAL: Scope = { scope: "global" };
+
+const deploy: ItemSafety = {
+  kind: "command",
+  name: "deploy",
+  harness: "claude",
+  scope: GLOBAL,
+  location: "",
+  findings: [
+    {
+      rule: "dangerous-commands",
+      severity: "high",
+      location: "deploy.md",
+      line: 20,
+      message: "runs a shell command that deletes files without asking",
+      remediation: "scope the command to a specific path, or drop it",
+    },
+  ],
+  skipped: [],
+  safety: { score: 58, deductions: [] },
+  quality: null,
+  ruleset: 3,
+};
+
+const view = (safety: ItemSafety[]): AuditView => ({
+  scope: GLOBAL,
+  drift: [],
+  plan: [],
+  notes: [],
+  warnings: [],
+  safety,
+  adoptable: ADOPTABLE,
+  exits: [],
+});
+
+const OVERVIEW_MARKER = "what this package is";
+
+const strip = () =>
+  mount(
+    <PackageTabs
+      kind="command"
+      name="deploy"
+      scope={GLOBAL}
+      scopes={[GLOBAL]}
+      harnesses={["claude"]}
+      busy={false}
+      onDelete={() => {}}
+      body={<p>{OVERVIEW_MARKER}</p>}
+    />,
+  );
+
+const tab = (host: HTMLElement, label: string) => {
+  const found = [...host.querySelectorAll('[data-slot="tabs-trigger"]')].find(
+    (trigger) => trigger.textContent?.startsWith(label),
+  );
+  if (!found) throw new Error(`no ${label} tab`);
+  return found as HTMLElement;
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  useAuditStore.setState({
+    views: [],
+    auditing: false,
+    auditedAt: null,
+    scopeCheckedAt: {},
+    error: null,
+    checkError: null,
+    backgroundFailureAnnounced: false,
+  });
+});
+
+// The safety block used to open the Overview page, above the file the page
+// is actually about. It is a tab of its own now, so Overview starts at what
+// a person came to read and the score is one click away rather than in the
+// way of it.
+describe("a package's tab strip", () => {
+  it("names the score after the words, and keeps it out of Overview", async () => {
+    vi.mocked(commands.auditAll).mockResolvedValue({
+      status: "ok",
+      data: [view([deploy])],
+    });
+
+    const host = strip();
+    await settle();
+
+    // The circle follows the text, so the tab reads as a score of
+    // something rather than as a bare number.
+    expect(tab(host, SAFETY_TAB).textContent).toBe(`${SAFETY_TAB}58`);
+
+    const overview = [
+      ...host.querySelectorAll('[data-slot="tabs-content"]'),
+    ].find((panel) => panel.textContent?.includes(OVERVIEW_MARKER));
+    if (!overview) throw new Error("no overview panel");
+    expect(overview.textContent).not.toContain("58/100");
+
+    await act(async () => {
+      tab(host, SAFETY_TAB).click();
+    });
+    await settle();
+
+    expect(host.textContent).toContain("58/100");
+    expect(host.textContent).toContain("deploy.md:20");
+  });
+
+  // Customize is the only tab a kind can lack. A kind without it still has
+  // bytes the check reads, so the score keeps its place on the strip.
+  it("carries the score for a kind with nothing to customize", async () => {
+    vi.mocked(commands.auditAll).mockResolvedValue({
+      status: "ok",
+      data: [view([deploy])],
+    });
+
+    const host = strip();
+    await settle();
+
+    const labels = [...host.querySelectorAll('[data-slot="tabs-trigger"]')].map(
+      (trigger) => trigger.textContent,
+    );
+    expect(labels).toEqual(["Overview", PROJECTS_TAB, `${SAFETY_TAB}58`]);
+  });
+});

--- a/ui/src/components/package/package-tabs.dom.test.tsx
+++ b/ui/src/components/package/package-tabs.dom.test.tsx
@@ -4,8 +4,15 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { AuditView, ItemSafety, Scope } from "@/bindings";
 import { commands } from "@/bindings";
 import { ADOPTABLE } from "@/lib/adoptable";
+import { vendorHelp } from "@/lib/copy";
 import { PROJECTS_TAB } from "@/lib/copy-projects";
-import { SAFETY_TAB, SAFETY_TAB_STALE } from "@/lib/copy-safety";
+import {
+  SAFETY_NOT_READ,
+  SAFETY_RETRY_LABEL,
+  SAFETY_TAB,
+  SAFETY_TAB_STALE,
+  SAFETY_VENDOR,
+} from "@/lib/copy-safety";
 import { useAuditStore } from "@/stores/audit";
 import { mount, settle } from "@/test/dom";
 import { PackageTabs } from "./package-tabs";
@@ -52,7 +59,7 @@ const view = (safety: ItemSafety[]): AuditView => ({
 
 const OVERVIEW_MARKER = "what this package is";
 
-const strip = () =>
+const strip = ({ vendor = null }: { vendor?: string | null } = {}) =>
   mount(
     <PackageTabs
       kind="command"
@@ -60,6 +67,7 @@ const strip = () =>
       scope={GLOBAL}
       scopes={[GLOBAL]}
       harnesses={["claude"]}
+      vendor={vendor}
       busy={false}
       onDelete={() => {}}
       body={<p>{OVERVIEW_MARKER}</p>}
@@ -192,5 +200,53 @@ describe("the tab's figure when the check could not run again", () => {
     expect(tab(host, SAFETY_TAB).textContent).toBe(`${SAFETY_TAB}58`);
     expect(tab(host, SAFETY_TAB).querySelector(".sr-only")).toBeNull();
     expect(disc(host).className).toContain("text-warning");
+  });
+});
+
+// Content a tool ships itself is skipped by observed_rows, so no audit will
+// ever score it. Left to the unscored state it would sit on a permanent
+// dash behind a Try again that asks for a check that is not coming.
+describe("a package the harness ships itself", () => {
+  const VENDOR = "OpenAI";
+
+  const openSafety = async (vendor: string | null) => {
+    vi.mocked(commands.auditAll).mockResolvedValue({
+      status: "ok",
+      data: [view([])],
+    });
+    const host = strip({ vendor });
+    await settle();
+    await act(async () => {
+      tab(host, SAFETY_TAB).click();
+    });
+    await settle();
+    return host;
+  };
+
+  const retryButton = (host: HTMLElement) =>
+    [...host.querySelectorAll("button")].find(
+      (button) => button.textContent === SAFETY_RETRY_LABEL,
+    );
+
+  it("says who ships it, and offers no check it cannot run", async () => {
+    const host = await openSafety(VENDOR);
+
+    // No disc: a dash reads as a figure still on its way.
+    expect(tab(host, SAFETY_TAB).textContent).toBe(SAFETY_TAB);
+    expect(host.textContent).toContain(SAFETY_VENDOR);
+    expect(host.textContent).toContain(vendorHelp(VENDOR));
+    expect(host.textContent).not.toContain(SAFETY_NOT_READ);
+    expect(retryButton(host)).toBeUndefined();
+  });
+
+  // The contrast that makes the case above mean anything: a package kendex
+  // does read, which the audit simply has no row for yet, still asks again.
+  it("leaves a genuinely unscored package its retry", async () => {
+    const host = await openSafety(null);
+
+    expect(tab(host, SAFETY_TAB).textContent).toBe(`${SAFETY_TAB}—`);
+    expect(host.textContent).toContain(SAFETY_NOT_READ);
+    expect(host.textContent).not.toContain(SAFETY_VENDOR);
+    expect(retryButton(host)).toBeDefined();
   });
 });

--- a/ui/src/components/package/package-tabs.tsx
+++ b/ui/src/components/package/package-tabs.tsx
@@ -2,6 +2,11 @@ import type { ReactNode } from "react";
 import type { HarnessId, ItemKind, Scope } from "@/bindings";
 import { ItemCustomize } from "@/components/customize/item-customize";
 import { PackageProjects } from "@/components/package/package-projects";
+import {
+  PackageSafety,
+  SafetyScoreLabel,
+  usePackageSafety,
+} from "@/components/package/package-safety";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { CUSTOMIZE_TAB, OVERVIEW_TAB } from "@/lib/copy-customize";
 import { PROJECTS_TAB } from "@/lib/copy-projects";
@@ -9,15 +14,16 @@ import { canCustomize } from "@/lib/customization";
 import { PAGE_GUTTER, WIDE_CONTENT_WIDTH } from "@/lib/layout";
 import { cn } from "@/lib/utils";
 
-/** The package page's scrolling content: what the package is, the places
- *  it is installed in, and — for a kind whose rendering the person can
- *  shape — what they have changed about it.
+/** The package page's scrolling content: what the package is, the places it
+ *  is installed in, what the safety check made of it, and — for a kind whose
+ *  rendering the person can shape — what they have changed about it.
  *
  *  Customize is last because it is the only tab a package kind can lack,
  *  so every other tab keeps its position whatever the package is. */
 export function PackageTabs({
   kind,
   name,
+  scope,
   scopes,
   harnesses,
   busy,
@@ -26,6 +32,9 @@ export function PackageTabs({
 }: {
   kind: ItemKind;
   name: string;
+  /** The one place this page is about. The score answers for the copy
+   *  installed there, which is the copy the rest of the page describes. */
+  scope: Scope;
   scopes: Scope[];
   harnesses: HarnessId[];
   busy: boolean;
@@ -35,6 +44,9 @@ export function PackageTabs({
   onDelete: () => void;
   body: ReactNode;
 }) {
+  // Read once here rather than in each of the two places it shows: the tab
+  // and its panel are one claim, and two readings could disagree.
+  const safety = usePackageSafety(kind, name, scope);
   const customizable = canCustomize(kind);
   return (
     <div className={cn("min-h-0 flex-1 overflow-y-auto", PAGE_GUTTER)}>
@@ -43,6 +55,9 @@ export function PackageTabs({
           <TabsList>
             <TabsTrigger value="overview">{OVERVIEW_TAB}</TabsTrigger>
             <TabsTrigger value="projects">{PROJECTS_TAB}</TabsTrigger>
+            <TabsTrigger value="safety">
+              <SafetyScoreLabel reading={safety} />
+            </TabsTrigger>
             {customizable ? (
               <TabsTrigger value="customize">{CUSTOMIZE_TAB}</TabsTrigger>
             ) : null}
@@ -58,6 +73,9 @@ export function PackageTabs({
               busy={busy}
               onDelete={onDelete}
             />
+          </TabsContent>
+          <TabsContent value="safety" className="pt-6">
+            <PackageSafety reading={safety} />
           </TabsContent>
           {customizable ? (
             <TabsContent value="customize" className="pt-6">

--- a/ui/src/components/package/package-tabs.tsx
+++ b/ui/src/components/package/package-tabs.tsx
@@ -26,6 +26,7 @@ export function PackageTabs({
   scope,
   scopes,
   harnesses,
+  vendor,
   busy,
   onDelete,
   body,
@@ -37,6 +38,11 @@ export function PackageTabs({
   scope: Scope;
   scopes: Scope[];
   harnesses: HarnessId[];
+  /** Who ships the copy at `scope`, when a tool ships it itself. The audit
+   *  never reads such a package, so its tab says so instead of offering a
+   *  check that will not come. Read off the one installation this page is
+   *  about, the same copy the score would have answered for. */
+  vendor: string | null;
   busy: boolean;
   /** Opens the dialog that deletes every copy — the Projects tab offers
    *  the whole-package deletion beside its per-place removals, and one
@@ -56,7 +62,7 @@ export function PackageTabs({
             <TabsTrigger value="overview">{OVERVIEW_TAB}</TabsTrigger>
             <TabsTrigger value="projects">{PROJECTS_TAB}</TabsTrigger>
             <TabsTrigger value="safety">
-              <SafetyScoreLabel reading={safety} />
+              <SafetyScoreLabel reading={safety} vendor={vendor} />
             </TabsTrigger>
             {customizable ? (
               <TabsTrigger value="customize">{CUSTOMIZE_TAB}</TabsTrigger>
@@ -75,7 +81,7 @@ export function PackageTabs({
             />
           </TabsContent>
           <TabsContent value="safety" className="pt-6">
-            <PackageSafety reading={safety} />
+            <PackageSafety reading={safety} vendor={vendor} />
           </TabsContent>
           {customizable ? (
             <TabsContent value="customize" className="pt-6">

--- a/ui/src/lib/copy-safety.ts
+++ b/ui/src/lib/copy-safety.ts
@@ -27,6 +27,11 @@ export const SAFETY_TAB_STALE = "the last reading kendex could check";
 // The audit is the slowest thing the app does, so the tab opens before it
 // has answered. A wait is not an outcome, and this says which it is.
 export const SAFETY_CHECKING = "Checking this package…";
+// Content a tool ships itself is never scored: the audit skips it, because
+// the reader did not choose it and cannot change it. That is a settled
+// answer rather than a reading still to come, so the tab says which — the
+// unscored state's retry would ask for a check that is not coming.
+export const SAFETY_VENDOR = "Shipped with the harness";
 // The audit answered and had no reading for this package. Nothing found and
 // nothing read are different claims, and only the second one is true here.
 export const SAFETY_NOT_READ = "This package hasn't been scored";

--- a/ui/src/lib/copy-safety.ts
+++ b/ui/src/lib/copy-safety.ts
@@ -24,6 +24,10 @@ export const SAFETY_TAB = "Safety score";
 // for the mark beside it: a colour and an icon alone would leave a kept
 // number reading as a current one.
 export const SAFETY_TAB_STALE = "the last reading kendex could check";
+// The same job where the failure left nothing behind it. Overview is the
+// tab a page opens on, so without this the only sign of a check that never
+// ran is a dash — which is also what pending and unscored show.
+export const SAFETY_TAB_FAILED = "the check couldn't run";
 // The audit is the slowest thing the app does, so the tab opens before it
 // has answered. A wait is not an outcome, and this says which it is.
 export const SAFETY_CHECKING = "Checking this package…";

--- a/ui/src/lib/copy-safety.ts
+++ b/ui/src/lib/copy-safety.ts
@@ -19,6 +19,11 @@ export const SAFETY_CAVEAT =
 // The package page's own tab for the reading. The score follows these
 // words on the tab itself, so the tab never says the number twice.
 export const SAFETY_TAB = "Safety score";
+// What the tab's figure is when a reading outlives the check meant to
+// replace it. Short enough to sit on a tab, and it is the accessible name
+// for the mark beside it: a colour and an icon alone would leave a kept
+// number reading as a current one.
+export const SAFETY_TAB_STALE = "the last reading kendex could check";
 // The audit is the slowest thing the app does, so the tab opens before it
 // has answered. A wait is not an outcome, and this says which it is.
 export const SAFETY_CHECKING = "Checking this package…";

--- a/ui/src/lib/copy-safety.ts
+++ b/ui/src/lib/copy-safety.ts
@@ -15,6 +15,18 @@ import { relativeTime } from "@/lib/relative-time";
 // reads whole — so the partial read is named as a skill's.
 export const SAFETY_CAVEAT =
   "An automated check for risky patterns, not a review. It can miss things, and a package too large to read is not checked at all.";
+
+// The package page's own tab for the reading. The score follows these
+// words on the tab itself, so the tab never says the number twice.
+export const SAFETY_TAB = "Safety score";
+// The audit is the slowest thing the app does, so the tab opens before it
+// has answered. A wait is not an outcome, and this says which it is.
+export const SAFETY_CHECKING = "Checking this package…";
+// The audit answered and had no reading for this package. Nothing found and
+// nothing read are different claims, and only the second one is true here.
+export const SAFETY_NOT_READ = "This package hasn't been scored";
+export const SAFETY_NOT_READ_BODY =
+  "The last check answered without a reading for it. Ask for a new check to get one.";
 const SEVERITY_ORDER: Severity[] = ["critical", "high", "medium", "low"];
 
 /** How bad the worst finding is, as a number that only ever gets compared:

--- a/ui/src/lib/package-places.test.ts
+++ b/ui/src/lib/package-places.test.ts
@@ -14,6 +14,7 @@ import {
   removablePlaces,
   type UpdatesStanding,
   updatableRows,
+  vendorAt,
 } from "@/lib/package-places";
 import { scopeKey } from "@/lib/scope";
 
@@ -75,6 +76,7 @@ const UNMANAGED: Origin = { origin: "unmanaged" };
 const install = (
   scope: Scope,
   harness: HarnessId = "claude",
+  vendor: string | null = null,
 ): ObservedItem => ({
   kind: "skill",
   name: "gh",
@@ -87,7 +89,7 @@ const install = (
   description: null,
   tags: [],
   modifiedAt: null,
-  vendor: null,
+  vendor,
 });
 
 /** One provenance row, which the join keys per harness the same way. */
@@ -321,5 +323,56 @@ describe("which places kendex can remove", () => {
     const built = places([VG, HYPR], [], {}, "skill", SETTLED, owned([VG]));
 
     expect(removablePlaces(built).map((one) => one.scope)).toEqual([VG]);
+  });
+});
+
+// A place holds one installation per harness, and the safety reading merges
+// every one of them. Reading the vendor off the first row alone answered for
+// a set it does not speak for: a tool's bundled copy beside a copy the
+// reader owns would have suppressed the second one's real score.
+describe("vendorAt", () => {
+  it("names the vendor when every copy in the place is theirs", () => {
+    expect(
+      vendorAt(
+        [install(VG, "claude", "Anthropic"), install(VG, "codex", "Anthropic")],
+        VG,
+      ),
+    ).toBe("Anthropic");
+  });
+
+  it("names nobody when one copy in the place is the reader's own", () => {
+    expect(
+      vendorAt([install(VG, "claude", "Anthropic"), install(VG, "codex")], VG),
+    ).toBeNull();
+  });
+
+  // The reader's own copy is first here, so a check that stopped at row one
+  // would get this right by luck and the case above wrong.
+  it("names nobody whichever copy the scan happened to list first", () => {
+    expect(
+      vendorAt([install(VG, "codex"), install(VG, "claude", "Anthropic")], VG),
+    ).toBeNull();
+  });
+
+  it("names nobody when the copies disagree about who ships them", () => {
+    expect(
+      vendorAt(
+        [install(VG, "claude", "Anthropic"), install(VG, "codex", "OpenAI")],
+        VG,
+      ),
+    ).toBeNull();
+  });
+
+  it("asks only the place it was given", () => {
+    const installs = [
+      install(VG, "claude"),
+      install(HYPR, "claude", "Anthropic"),
+    ];
+    expect(vendorAt(installs, HYPR)).toBe("Anthropic");
+    expect(vendorAt(installs, VG)).toBeNull();
+  });
+
+  it("names nobody where the package is not installed at all", () => {
+    expect(vendorAt([install(VG, "claude", "Anthropic")], MINE)).toBeNull();
   });
 });

--- a/ui/src/lib/package-places.ts
+++ b/ui/src/lib/package-places.ts
@@ -153,3 +153,20 @@ export const updatableRows = (places: PackagePlace[]): UpdateRow[] =>
   places.flatMap((place) =>
     place.updatable && place.row !== null ? [place.row] : [],
   );
+
+/** Who ships this package at one place, when a tool ships it itself.
+ *
+ *  A place holds one installation per harness and the safety reading merges
+ *  every one of them, so the vendor question is asked of the same set. One
+ *  vendor copy beside a copy the reader owns is a package with a real score,
+ *  and naming a vendor there would hide it. Null the moment any copy there
+ *  is the reader's own, or the vendors disagree. */
+export function vendorAt(
+  installs: ObservedItem[],
+  scope: Scope,
+): string | null {
+  const here = installs.filter((install) => sameScope(install.scope, scope));
+  const vendor = here[0]?.vendor ?? null;
+  if (!vendor) return null;
+  return here.every((install) => install.vendor === vendor) ? vendor : null;
+}

--- a/ui/src/pages/package.test.tsx
+++ b/ui/src/pages/package.test.tsx
@@ -17,7 +17,7 @@ import {
   OPEN_IN_FILE_BROWSER_LABEL,
   OPEN_IN_LABEL,
 } from "@/lib/copy";
-import { SAFETY_TAB } from "@/lib/copy-safety";
+import { SAFETY_TAB, SAFETY_VENDOR } from "@/lib/copy-safety";
 import { editorOpenPath } from "@/lib/editor-path";
 import { SEVERITY_LABELS } from "@/lib/labels";
 import { scopeKey } from "@/lib/scope";
@@ -160,8 +160,11 @@ beforeEach(() => {
   vi.clearAllMocks();
   // clearAllMocks leaves implementations standing, and a test that
   // answers the audit would otherwise answer it for every test after
-  // it in this file.
+  // it in this file. The default is an audit that ran and found nothing
+  // to say about this package: a check that never answers is a state the
+  // safety tab reports, so a test must ask for it rather than inherit it.
   vi.mocked(commands.auditAll).mockReset();
+  vi.mocked(commands.auditAll).mockResolvedValue({ status: "ok", data: [] });
   vi.mocked(commands.packageMeta).mockResolvedValue(nothing);
   vi.mocked(commands.packageFiles).mockResolvedValue(nothing);
   vi.mocked(commands.packageVersions).mockResolvedValue(nothing);
@@ -348,6 +351,47 @@ describe("the package page's safety tab", () => {
     // Nothing scored the place this page is about, so the tab shows the
     // dash rather than the other place's 12.
     expect(scoreTab(host).textContent).toBe(`${SAFETY_TAB}—`);
+  });
+
+  // One place holds one copy per harness, and the reading merges them all.
+  // A vendor read off whichever copy the scan listed first would answer for
+  // a set it does not speak for, and would hide the score the reader's own
+  // copy earned behind "kendex doesn't check this".
+  it("shows the score where one copy is the harness's and one is not", async () => {
+    vi.mocked(commands.auditAll).mockResolvedValue({
+      status: "ok",
+      data: [scoredView],
+    });
+    useAuditStore.setState({ auditedAt: 1, views: [scoredView] });
+    // The bundled copy is listed first, exactly the order that hid the score.
+    useScanStore.setState({
+      result: {
+        harnesses: [],
+        items: [
+          { ...installedAt(VG), harness: "claude", vendor: "Anthropic" },
+          { ...installedAt(VG), harness: "codex" },
+        ],
+        missingProjects: [],
+        warnings: [],
+      },
+    });
+    useNavStore.setState({
+      page: "package",
+      packageRef: { kind: "skill", name: "gh", scope: VG },
+      packageView: null,
+    });
+    const host = mount(<PackagePage />);
+    await settle();
+
+    expect(scoreTab(host).textContent).toBe(`${SAFETY_TAB}58`);
+
+    await act(async () => {
+      scoreTab(host).click();
+    });
+    await settle();
+
+    expect(host.textContent).toContain("58/100");
+    expect(host.textContent).not.toContain(SAFETY_VENDOR);
   });
 });
 

--- a/ui/src/pages/package.test.tsx
+++ b/ui/src/pages/package.test.tsx
@@ -17,6 +17,7 @@ import {
   OPEN_IN_FILE_BROWSER_LABEL,
   OPEN_IN_LABEL,
 } from "@/lib/copy";
+import { SAFETY_TAB } from "@/lib/copy-safety";
 import { editorOpenPath } from "@/lib/editor-path";
 import { SEVERITY_LABELS } from "@/lib/labels";
 import { scopeKey } from "@/lib/scope";
@@ -46,7 +47,7 @@ vi.mock("@/bindings", async (importOriginal) => ({
     openInEditor: vi.fn(),
     libraryProvenance: vi.fn(),
     packageDiff: vi.fn(),
-    // The page's safety block asks for a fresh audit as it mounts.
+    // The page's safety tab asks for a fresh audit as it mounts.
     auditAll: vi.fn(),
   },
 }));
@@ -232,10 +233,19 @@ const scoredView: AuditView = {
   ],
 };
 
+/** The Safety score tab's own label, which carries the figure. */
+const scoreTab = (host: HTMLElement) => {
+  const found = [...host.querySelectorAll('[data-slot="tabs-trigger"]')].find(
+    (trigger) => trigger.textContent?.startsWith(SAFETY_TAB),
+  );
+  if (!found) throw new Error("no Safety score tab");
+  return found as HTMLElement;
+};
+
 // The score the audit gave this package's bytes, and what produced it.
 // Nothing else in the app renders a scope's `safety` rows, so a page that
-// dropped this block would leave every installed reading unread.
-describe("the package page's safety block", () => {
+// dropped this tab would leave every installed reading unread.
+describe("the package page's safety tab", () => {
   it("shows the score for this place, with the findings behind it", async () => {
     useAuditStore.setState({
       auditedAt: 1,
@@ -244,6 +254,13 @@ describe("the package page's safety block", () => {
 
     const host = await openPage(VG, [VG], { [scopeKey(VG)]: PLAIN });
 
+    expect(scoreTab(host).textContent).toBe(`${SAFETY_TAB}58`);
+
+    await act(async () => {
+      scoreTab(host).click();
+    });
+    await settle();
+
     expect(host.textContent).toContain("58/100");
     expect(host.textContent).toContain(SEVERITY_LABELS.high);
     expect(host.textContent).toContain("SKILL.md:20");
@@ -251,8 +268,9 @@ describe("the package page's safety block", () => {
 
   // A Preview from an Updates row opens this page straight into a diff. The
   // score answers for the whole package, not for whichever two versions are
-  // side by side, so closing the comparison cannot be what makes it appear.
-  it("stands above a comparison, not only beside the files", async () => {
+  // side by side, so a comparison on the Overview tab cannot be what keeps
+  // the figure off the strip.
+  it("carries the score while a comparison is open", async () => {
     useAuditStore.setState({
       auditedAt: 1,
       views: [scoredView],
@@ -268,6 +286,13 @@ describe("the package page's safety block", () => {
         to: "2222222222",
       },
     );
+
+    expect(scoreTab(host).textContent).toBe(`${SAFETY_TAB}58`);
+
+    await act(async () => {
+      scoreTab(host).click();
+    });
+    await settle();
 
     expect(host.textContent).toContain("58/100");
     expect(host.textContent).toContain("SKILL.md:20");
@@ -305,7 +330,9 @@ describe("the package page's safety block", () => {
 
     const host = await openPage(VG, [VG, HYPR], { [scopeKey(VG)]: PLAIN });
 
-    expect(host.textContent).not.toContain("12/100");
+    // Nothing scored the place this page is about, so the tab shows the
+    // dash rather than the other place's 12.
+    expect(scoreTab(host).textContent).toBe(`${SAFETY_TAB}—`);
   });
 });
 
@@ -418,7 +445,7 @@ describe("the package page's file actions", () => {
   });
 });
 
-// Three tabs in one order, and only one of them can be missing: Customize
+// Four tabs in one order, and only one of them can be missing: Customize
 // is the tab a kind can lack, so it goes last and the others keep their
 // place whatever the package is.
 describe("the package page's tabs", () => {
@@ -427,13 +454,20 @@ describe("the package page's tabs", () => {
       (tab) => tab.textContent,
     );
 
-  it("puts Projects between Overview and Customize", async () => {
+  it("puts Projects and the score between Overview and Customize", async () => {
     const host = await openPage(VG, [VG], { [scopeKey(VG)]: PLAIN });
 
-    expect(tabs(host)).toEqual(["Overview", "Projects", "Customize"]);
+    // Nothing has scored this package in these tests, so the tab carries
+    // the dash it shows before a reading arrives.
+    expect(tabs(host)).toEqual([
+      "Overview",
+      "Projects",
+      `${SAFETY_TAB}—`,
+      "Customize",
+    ]);
   });
 
-  it("keeps Projects for a kind with nothing to customize", async () => {
+  it("keeps them both for a kind with nothing to customize", async () => {
     const host = await openPage(
       VG,
       [VG],
@@ -442,7 +476,7 @@ describe("the package page's tabs", () => {
       "mcp-server",
     );
 
-    expect(tabs(host)).toEqual(["Overview", "Projects"]);
+    expect(tabs(host)).toEqual(["Overview", "Projects", `${SAFETY_TAB}—`]);
   });
 });
 

--- a/ui/src/pages/package.test.tsx
+++ b/ui/src/pages/package.test.tsx
@@ -158,6 +158,10 @@ const updateRow = (scope: Project): UpdateRow => ({
 
 beforeEach(() => {
   vi.clearAllMocks();
+  // clearAllMocks leaves implementations standing, and a test that
+  // answers the audit would otherwise answer it for every test after
+  // it in this file.
+  vi.mocked(commands.auditAll).mockReset();
   vi.mocked(commands.packageMeta).mockResolvedValue(nothing);
   vi.mocked(commands.packageFiles).mockResolvedValue(nothing);
   vi.mocked(commands.packageVersions).mockResolvedValue(nothing);
@@ -247,6 +251,13 @@ const scoreTab = (host: HTMLElement) => {
 // dropped this tab would leave every installed reading unread.
 describe("the package page's safety tab", () => {
   it("shows the score for this place, with the findings behind it", async () => {
+    // The mount asks for a fresh audit and gets one, so the tab's figure is
+    // a reading the check just took rather than one kept from before a
+    // failure — which is a different label and a different claim.
+    vi.mocked(commands.auditAll).mockResolvedValue({
+      status: "ok",
+      data: [scoredView],
+    });
     useAuditStore.setState({
       auditedAt: 1,
       views: [scoredView],
@@ -271,6 +282,10 @@ describe("the package page's safety tab", () => {
   // side by side, so a comparison on the Overview tab cannot be what keeps
   // the figure off the strip.
   it("carries the score while a comparison is open", async () => {
+    vi.mocked(commands.auditAll).mockResolvedValue({
+      status: "ok",
+      data: [scoredView],
+    });
     useAuditStore.setState({
       auditedAt: 1,
       views: [scoredView],

--- a/ui/src/pages/package.tsx
+++ b/ui/src/pages/package.tsx
@@ -18,6 +18,7 @@ import { NO_PER_PACKAGE_UPDATE_NOTE } from "@/lib/copy-updates";
 import { groupItems, groupScopes, installationAt } from "@/lib/derive";
 import { packageDisplayName } from "@/lib/labels";
 import { usePackageMark } from "@/lib/package-mark";
+import { vendorAt } from "@/lib/package-places";
 import { sameScope } from "@/lib/scope";
 import {
   canUpdatePackage,
@@ -219,7 +220,7 @@ export function PackagePage() {
         name={group.name}
         scope={ref.scope}
         scopes={groupScopes(group)}
-        vendor={primary.vendor}
+        vendor={vendorAt(group.installations, ref.scope)}
         harnesses={group.harnesses as HarnessId[]}
         busy={mutating}
         onDelete={() => setConfirmDelete(true)}

--- a/ui/src/pages/package.tsx
+++ b/ui/src/pages/package.tsx
@@ -219,6 +219,7 @@ export function PackagePage() {
         name={group.name}
         scope={ref.scope}
         scopes={groupScopes(group)}
+        vendor={primary.vendor}
         harnesses={group.harnesses as HarnessId[]}
         busy={mutating}
         onDelete={() => setConfirmDelete(true)}

--- a/ui/src/pages/package.tsx
+++ b/ui/src/pages/package.tsx
@@ -217,6 +217,7 @@ export function PackagePage() {
       <PackageTabs
         kind={group.kind}
         name={group.name}
+        scope={ref.scope}
         scopes={groupScopes(group)}
         harnesses={group.harnesses as HarnessId[]}
         busy={mutating}


### PR DESCRIPTION
The safety check was crammed at the top of the package Overview. It gets its own
tab.

## What changed

The package page's tab strip is now `Overview · Projects · Safety score ·
Customize`. The `Safety score` label is the words followed by the existing score
circle, circle after the text. Every safety detail moved out of Overview, which
now opens at Details with no safety block above it. The panel carries the score,
the headline, the disclaimer and the per-finding rows with their `file:line`
chips.

The reading is taken once in the tab strip rather than in each of the two places
it appears: the tab label and its panel are one claim, and two reads could
disagree.

The tab's accessible name is `Safety score` alone, with the circle
`aria-hidden`, so the figure is not announced twice.

## Tab order

Customize stays last because it is the only tab a package kind can lack, so the
tabs before it hold their position on every package. The strip itself is no
longer wrapped in `canCustomize` — it always renders, and only the Customize
trigger and panel are conditional.

## Verification

`tools/guard` green by exit code. 1052 tests across the UI suite.

Confirmed on screen, driving the real pages in Chromium against the mock bridge:

- The strip and the circle-after-text label.
- A hook, which has no Customize, showing the tab in its place.
- Overview opening at Details with no safety block.
- The panel's score, headline, disclaimer and finding rows.
- The not-scored state as a designed empty state with a working `Try again`.

Not seen on screen, covered by tests only: the "check couldn't run" state and the
loading spinner. The audit was not forced to fail in the mock.

This branch was rebased onto KEN-782 (#1799) after it merged. Both tabs live in
one strip; the conflicting cases in `package.test.tsx` were updated to the real
order rather than removed.

Closes KEN-717
