### PR TITLE
fix(KEN-480): keep second-opinion CLI in caller group

### DIFF
--- a/.agents/skills/second-opinion/scripts/second-opinion
+++ b/.agents/skills/second-opinion/scripts/second-opinion
@@ -276,9 +276,13 @@ TIMEOUT_CMD="$(command -v timeout || command -v gtimeout || true)"
 [[ -n "$TIMEOUT_CMD" ]] || echo "Warning: no timeout or gtimeout on PATH — external CLI calls will run without a time limit" >&2
 
 run_with_timeout() {
-  local duration="$1"; shift
-  if [[ -z "$TIMEOUT_CMD" ]]; then "$@"; return; fi
-  "$TIMEOUT_CMD" --foreground -k 30 "$duration" "$@"
+  local duration="$1" stderr_file="$2"; shift 2
+  if [[ -z "$TIMEOUT_CMD" ]]; then
+    echo "→ cmd: direct $*" >&2
+    "$@" 2>"$stderr_file"; return
+  fi
+  echo "→ cmd: $TIMEOUT_CMD --foreground -k 30 ${duration}s $*" >&2
+  "$TIMEOUT_CMD" --foreground -k 30 "$duration" "$@" 2>"$stderr_file"
 }
 
 # --- Defaults -----------------------------------------------------------------
@@ -2157,12 +2161,8 @@ run_target_cli() {
     echo "{\"error\": \"Unknown target: $TARGET_CLI — set $(target_cmd_var "$TARGET_CLI")\"}" >&2
     return 2
   fi
-  case "$TIMEOUT_CMD" in
-    "") echo "→ cmd: direct $cmd" >&2 ;;
-    *) echo "→ cmd: $TIMEOUT_CMD --foreground -k 30 ${TIMEOUT}s $cmd" >&2 ;;
-  esac
   # shellcheck disable=SC2086
-  (cd -- "$CWD" && run_with_timeout "$TIMEOUT" $cmd < "$prompt_file" 2>"$STDERR_TMP") || rc=$?
+  (cd -- "$CWD" && run_with_timeout "$TIMEOUT" "$STDERR_TMP" $cmd < "$prompt_file") || rc=$?
   return "$rc"
 }
 

--- a/.agents/skills/second-opinion/scripts/second-opinion
+++ b/.agents/skills/second-opinion/scripts/second-opinion
@@ -272,17 +272,17 @@ kendex_load_project_env "$PROJECT_ROOT" || {
   exit 1
 }
 
-# Portability: macOS lacks timeout, try gtimeout fallback
-if ! command -v timeout >/dev/null 2>&1; then
-  if command -v gtimeout >/dev/null 2>&1; then
-    timeout() { gtimeout "$@"; }
-  else
-    # No timeout available — warn once and run without a limit. The shim
-    # drops this script's fixed `--foreground -k 30 SECS` arguments.
-    echo "Warning: no timeout or gtimeout on PATH — external CLI calls will run without a time limit" >&2
-    timeout() { shift 4; "$@"; }
-  fi
+# Portability: macOS lacks timeout, try gtimeout fallback.
+TIMEOUT_CMD="$(command -v timeout || command -v gtimeout || true)"
+if [[ -z "$TIMEOUT_CMD" ]]; then
+  echo "Warning: no timeout or gtimeout on PATH — external CLI calls will run without a time limit" >&2
 fi
+
+run_with_timeout() {
+  local duration="$1"; shift
+  if [[ -z "$TIMEOUT_CMD" ]]; then "$@"; return; fi
+  "$TIMEOUT_CMD" --foreground -k 30 "$duration" "$@"
+}
 
 # --- Defaults -----------------------------------------------------------------
 
@@ -2162,7 +2162,7 @@ run_target_cli() {
   fi
   echo "→ cmd: timeout --foreground -k 30 ${TIMEOUT}s $cmd" >&2
   # shellcheck disable=SC2086
-  (cd -- "$CWD" && timeout --foreground -k 30 "$TIMEOUT" $cmd < "$prompt_file" 2>"$STDERR_TMP") || rc=$?
+  (cd -- "$CWD" && run_with_timeout "$TIMEOUT" $cmd < "$prompt_file" 2>"$STDERR_TMP") || rc=$?
   return "$rc"
 }
 

--- a/.agents/skills/second-opinion/scripts/second-opinion
+++ b/.agents/skills/second-opinion/scripts/second-opinion
@@ -278,9 +278,9 @@ if ! command -v timeout >/dev/null 2>&1; then
     timeout() { gtimeout "$@"; }
   else
     # No timeout available — warn once and run without a limit. The shim
-    # drops this script's fixed `-k 30 SECS` arguments.
+    # drops this script's fixed `--foreground -k 30 SECS` arguments.
     echo "Warning: no timeout or gtimeout on PATH — external CLI calls will run without a time limit" >&2
-    timeout() { shift 3; "$@"; }
+    timeout() { shift 4; "$@"; }
   fi
 fi
 
@@ -2160,9 +2160,9 @@ run_target_cli() {
     echo "{\"error\": \"Unknown target: $TARGET_CLI — set $(target_cmd_var "$TARGET_CLI")\"}" >&2
     return 2
   fi
-  echo "→ cmd: timeout -k 30 ${TIMEOUT}s $cmd" >&2
+  echo "→ cmd: timeout --foreground -k 30 ${TIMEOUT}s $cmd" >&2
   # shellcheck disable=SC2086
-  (cd -- "$CWD" && timeout -k 30 "$TIMEOUT" $cmd < "$prompt_file" 2>"$STDERR_TMP") || rc=$?
+  (cd -- "$CWD" && timeout --foreground -k 30 "$TIMEOUT" $cmd < "$prompt_file" 2>"$STDERR_TMP") || rc=$?
   return "$rc"
 }
 

--- a/.agents/skills/second-opinion/scripts/second-opinion
+++ b/.agents/skills/second-opinion/scripts/second-opinion
@@ -272,11 +272,8 @@ kendex_load_project_env "$PROJECT_ROOT" || {
   exit 1
 }
 
-# Portability: macOS lacks timeout, try gtimeout fallback.
 TIMEOUT_CMD="$(command -v timeout || command -v gtimeout || true)"
-if [[ -z "$TIMEOUT_CMD" ]]; then
-  echo "Warning: no timeout or gtimeout on PATH — external CLI calls will run without a time limit" >&2
-fi
+[[ -n "$TIMEOUT_CMD" ]] || echo "Warning: no timeout or gtimeout on PATH — external CLI calls will run without a time limit" >&2
 
 run_with_timeout() {
   local duration="$1"; shift
@@ -2160,7 +2157,10 @@ run_target_cli() {
     echo "{\"error\": \"Unknown target: $TARGET_CLI — set $(target_cmd_var "$TARGET_CLI")\"}" >&2
     return 2
   fi
-  echo "→ cmd: timeout --foreground -k 30 ${TIMEOUT}s $cmd" >&2
+  case "$TIMEOUT_CMD" in
+    "") echo "→ cmd: direct $cmd" >&2 ;;
+    *) echo "→ cmd: $TIMEOUT_CMD --foreground -k 30 ${TIMEOUT}s $cmd" >&2 ;;
+  esac
   # shellcheck disable=SC2086
   (cd -- "$CWD" && run_with_timeout "$TIMEOUT" $cmd < "$prompt_file" 2>"$STDERR_TMP") || rc=$?
   return "$rc"

--- a/.agents/skills/second-opinion/tests/timeout-defaults.test.sh
+++ b/.agents/skills/second-opinion/tests/timeout-defaults.test.sh
@@ -12,7 +12,14 @@ export SECOND_OPINION_CURRENT_MODEL=none
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(cd "$SCRIPT_DIR/../../.." && pwd)"
 TMP_ROOT="$(mktemp -d)"
-trap 'rm -rf "$TMP_ROOT"' EXIT
+ABANDON_SESSION=""
+cleanup_abandon_session() {
+  if [[ -n "$ABANDON_SESSION" ]]; then
+    pkill -TERM -s "$ABANDON_SESSION" 2>/dev/null || true
+    wait "$ABANDON_SESSION" 2>/dev/null || true
+  fi
+}
+trap 'cleanup_abandon_session; rm -rf "$TMP_ROOT"' EXIT
 
 # --- Deterministic harness-free session -------------------------------------
 # A positively detected single-model harness now beats any contradicting
@@ -138,49 +145,54 @@ assert_contains "$notimeout_stderr" "Response received" "review still runs witho
 
 # The caller owns the lane's lifetime. GNU timeout must not isolate the CLI
 # from a signal sent to second-opinion's process group.
+if [[ "$(uname -s)" != "Linux" ]] || ! command -v setsid >/dev/null 2>&1 || ! command -v pkill >/dev/null 2>&1; then
+  printf 'SKIP: process-group lifecycle control requires Linux, setsid, and pkill\n'
+  exit 0
+fi
+
 cat > "$TMP_ROOT/bin/sleeping-codex" <<'SH'
 #!/usr/bin/env bash
-printf '%s\n' "$$" > "$FAKE_CLI_PID_FILE"
-exec sleep 300
+on_term() {
+  printf 'terminated\n' > "$FAKE_CLI_TERM_FILE"
+  exit 0
+}
+trap on_term TERM
+printf 'ready\n' > "$FAKE_CLI_READY_FILE"
+while :; do sleep 1; done
 SH
 chmod +x "$TMP_ROOT/bin/sleeping-codex"
 
-sleeping_pid_file="$TMP_ROOT/sleeping-cli.pid"
+sleeping_ready_file="$TMP_ROOT/sleeping-cli.ready"
+sleeping_term_file="$TMP_ROOT/sleeping-cli.terminated"
 abandon_stderr="$TMP_ROOT/abandon.stderr"
 PATH="$TMP_ROOT/bin:$PATH" \
   SECOND_OPINION_TARGET=codex \
   SECOND_OPINION_CODEX_CMD=sleeping-codex \
-  FAKE_CLI_PID_FILE="$sleeping_pid_file" \
+  FAKE_CLI_READY_FILE="$sleeping_ready_file" \
+  FAKE_CLI_TERM_FILE="$sleeping_term_file" \
   setsid "$SECOND_OPINION" review --range HEAD --cwd "$WORK" >/dev/null 2>"$abandon_stderr" &
-abandon_pid=$!
+ABANDON_SESSION=$!
 
 for _attempt in {1..100}; do
-  [[ -s "$sleeping_pid_file" ]] && break
+  [[ -s "$sleeping_ready_file" ]] && break
   sleep 0.05
 done
-if [[ ! -s "$sleeping_pid_file" ]]; then
-  kill -TERM -- "-$abandon_pid" 2>/dev/null || true
-  wait "$abandon_pid" 2>/dev/null || true
+if [[ ! -s "$sleeping_ready_file" ]]; then
   printf 'FAIL: sleeping CLI did not start\n' >&2
   sed -n '1,80p' "$abandon_stderr" >&2 || true
   exit 1
 fi
 
-sleeping_cli_pid=$(<"$sleeping_pid_file")
-kill -TERM -- "-$abandon_pid"
-wait "$abandon_pid" 2>/dev/null || true
+kill -TERM -- "-$ABANDON_SESSION" 2>/dev/null || true
+wait "$ABANDON_SESSION" 2>/dev/null || true
 
-sleeping_cli_stopped=0
 for _attempt in {1..100}; do
-  if ! kill -0 "$sleeping_cli_pid" 2>/dev/null; then
-    sleeping_cli_stopped=1
-    break
-  fi
+  [[ -s "$sleeping_term_file" ]] && break
   sleep 0.05
 done
-if [[ $sleeping_cli_stopped -ne 1 ]]; then
-  kill -TERM "$sleeping_cli_pid" 2>/dev/null || true
+if [[ ! -s "$sleeping_term_file" ]]; then
   printf 'FAIL: killing second-opinion process group left the CLI running\n' >&2
   exit 1
 fi
+ABANDON_SESSION=""
 printf 'PASS: killing second-opinion process group stops the CLI\n'

--- a/.agents/skills/second-opinion/tests/timeout-defaults.test.sh
+++ b/.agents/skills/second-opinion/tests/timeout-defaults.test.sh
@@ -88,13 +88,18 @@ assert_contains() {
 }
 
 default_stderr="$TMP_ROOT/default.stderr"
+resolved_timeout="$(command -v timeout || command -v gtimeout || true)"
 PATH="$TMP_ROOT/bin:$PATH" \
   SECOND_OPINION_TARGET=codex \
   SECOND_OPINION_CODEX_CMD=codex \
   "$SECOND_OPINION" review --range HEAD --cwd "$WORK" >/dev/null 2>"$default_stderr"
 
 assert_contains "$default_stderr" "timeout=1080s" "default timeout resolves to documented 1080s"
-assert_contains "$default_stderr" "cmd: timeout --foreground -k 30 1080s codex" "launch log includes explicit default timeout"
+if [[ -n "$resolved_timeout" ]]; then
+  assert_contains "$default_stderr" "cmd: $resolved_timeout --foreground -k 30 1080s codex" "launch log includes resolved default timeout"
+else
+  assert_contains "$default_stderr" "cmd: direct codex" "launch log names direct default execution"
+fi
 
 override_stderr="$TMP_ROOT/override.stderr"
 PATH="$TMP_ROOT/bin:$PATH" \
@@ -104,7 +109,11 @@ PATH="$TMP_ROOT/bin:$PATH" \
   "$SECOND_OPINION" review --range HEAD --cwd "$WORK" >/dev/null 2>"$override_stderr"
 
 assert_contains "$override_stderr" "timeout=7s" "caller timeout override wins"
-assert_contains "$override_stderr" "cmd: timeout --foreground -k 30 7s codex" "launch log includes explicit override timeout"
+if [[ -n "$resolved_timeout" ]]; then
+  assert_contains "$override_stderr" "cmd: $resolved_timeout --foreground -k 30 7s codex" "launch log includes resolved override timeout"
+else
+  assert_contains "$override_stderr" "cmd: direct codex" "launch log names direct override execution"
+fi
 
 # GNU timeout reads 0 as "no limit at all", so --timeout 0 must be refused
 # rather than silently disabling the deadline.
@@ -141,6 +150,7 @@ PATH="$TMP_ROOT/bin:$NOTIMEOUT" \
   "$SECOND_OPINION" review --range HEAD --cwd "$WORK" >/dev/null 2>"$notimeout_stderr"
 
 assert_contains "$notimeout_stderr" "run without a time limit" "missing timeout binary warns instead of refusing"
+assert_contains "$notimeout_stderr" "cmd: direct codex" "missing timeout binary logs direct execution"
 assert_contains "$notimeout_stderr" "Response received" "review still runs without a timeout binary"
 
 # The caller owns the lane's lifetime. GNU timeout must not isolate the CLI

--- a/.agents/skills/second-opinion/tests/timeout-defaults.test.sh
+++ b/.agents/skills/second-opinion/tests/timeout-defaults.test.sh
@@ -87,7 +87,7 @@ PATH="$TMP_ROOT/bin:$PATH" \
   "$SECOND_OPINION" review --range HEAD --cwd "$WORK" >/dev/null 2>"$default_stderr"
 
 assert_contains "$default_stderr" "timeout=1080s" "default timeout resolves to documented 1080s"
-assert_contains "$default_stderr" "cmd: timeout -k 30 1080s codex" "launch log includes explicit default timeout"
+assert_contains "$default_stderr" "cmd: timeout --foreground -k 30 1080s codex" "launch log includes explicit default timeout"
 
 override_stderr="$TMP_ROOT/override.stderr"
 PATH="$TMP_ROOT/bin:$PATH" \
@@ -97,7 +97,7 @@ PATH="$TMP_ROOT/bin:$PATH" \
   "$SECOND_OPINION" review --range HEAD --cwd "$WORK" >/dev/null 2>"$override_stderr"
 
 assert_contains "$override_stderr" "timeout=7s" "caller timeout override wins"
-assert_contains "$override_stderr" "cmd: timeout -k 30 7s codex" "launch log includes explicit override timeout"
+assert_contains "$override_stderr" "cmd: timeout --foreground -k 30 7s codex" "launch log includes explicit override timeout"
 
 # GNU timeout reads 0 as "no limit at all", so --timeout 0 must be refused
 # rather than silently disabling the deadline.
@@ -135,3 +135,52 @@ PATH="$TMP_ROOT/bin:$NOTIMEOUT" \
 
 assert_contains "$notimeout_stderr" "run without a time limit" "missing timeout binary warns instead of refusing"
 assert_contains "$notimeout_stderr" "Response received" "review still runs without a timeout binary"
+
+# The caller owns the lane's lifetime. GNU timeout must not isolate the CLI
+# from a signal sent to second-opinion's process group.
+cat > "$TMP_ROOT/bin/sleeping-codex" <<'SH'
+#!/usr/bin/env bash
+printf '%s\n' "$$" > "$FAKE_CLI_PID_FILE"
+exec sleep 300
+SH
+chmod +x "$TMP_ROOT/bin/sleeping-codex"
+
+sleeping_pid_file="$TMP_ROOT/sleeping-cli.pid"
+abandon_stderr="$TMP_ROOT/abandon.stderr"
+PATH="$TMP_ROOT/bin:$PATH" \
+  SECOND_OPINION_TARGET=codex \
+  SECOND_OPINION_CODEX_CMD=sleeping-codex \
+  FAKE_CLI_PID_FILE="$sleeping_pid_file" \
+  setsid "$SECOND_OPINION" review --range HEAD --cwd "$WORK" >/dev/null 2>"$abandon_stderr" &
+abandon_pid=$!
+
+for _attempt in {1..100}; do
+  [[ -s "$sleeping_pid_file" ]] && break
+  sleep 0.05
+done
+if [[ ! -s "$sleeping_pid_file" ]]; then
+  kill -TERM -- "-$abandon_pid" 2>/dev/null || true
+  wait "$abandon_pid" 2>/dev/null || true
+  printf 'FAIL: sleeping CLI did not start\n' >&2
+  sed -n '1,80p' "$abandon_stderr" >&2 || true
+  exit 1
+fi
+
+sleeping_cli_pid=$(<"$sleeping_pid_file")
+kill -TERM -- "-$abandon_pid"
+wait "$abandon_pid" 2>/dev/null || true
+
+sleeping_cli_stopped=0
+for _attempt in {1..100}; do
+  if ! kill -0 "$sleeping_cli_pid" 2>/dev/null; then
+    sleeping_cli_stopped=1
+    break
+  fi
+  sleep 0.05
+done
+if [[ $sleeping_cli_stopped -ne 1 ]]; then
+  kill -TERM "$sleeping_cli_pid" 2>/dev/null || true
+  printf 'FAIL: killing second-opinion process group left the CLI running\n' >&2
+  exit 1
+fi
+printf 'PASS: killing second-opinion process group stops the CLI\n'

--- a/changelog.d/fixed/KEN-480.md
+++ b/changelog.d/fixed/KEN-480.md
@@ -1,0 +1,1 @@
+- second-opinion now stops external model CLIs when callers terminate their process group.

--- a/skills/second-opinion/scripts/second-opinion
+++ b/skills/second-opinion/scripts/second-opinion
@@ -276,9 +276,13 @@ TIMEOUT_CMD="$(command -v timeout || command -v gtimeout || true)"
 [[ -n "$TIMEOUT_CMD" ]] || echo "Warning: no timeout or gtimeout on PATH — external CLI calls will run without a time limit" >&2
 
 run_with_timeout() {
-  local duration="$1"; shift
-  if [[ -z "$TIMEOUT_CMD" ]]; then "$@"; return; fi
-  "$TIMEOUT_CMD" --foreground -k 30 "$duration" "$@"
+  local duration="$1" stderr_file="$2"; shift 2
+  if [[ -z "$TIMEOUT_CMD" ]]; then
+    echo "→ cmd: direct $*" >&2
+    "$@" 2>"$stderr_file"; return
+  fi
+  echo "→ cmd: $TIMEOUT_CMD --foreground -k 30 ${duration}s $*" >&2
+  "$TIMEOUT_CMD" --foreground -k 30 "$duration" "$@" 2>"$stderr_file"
 }
 
 # --- Defaults -----------------------------------------------------------------
@@ -2157,12 +2161,8 @@ run_target_cli() {
     echo "{\"error\": \"Unknown target: $TARGET_CLI — set $(target_cmd_var "$TARGET_CLI")\"}" >&2
     return 2
   fi
-  case "$TIMEOUT_CMD" in
-    "") echo "→ cmd: direct $cmd" >&2 ;;
-    *) echo "→ cmd: $TIMEOUT_CMD --foreground -k 30 ${TIMEOUT}s $cmd" >&2 ;;
-  esac
   # shellcheck disable=SC2086
-  (cd -- "$CWD" && run_with_timeout "$TIMEOUT" $cmd < "$prompt_file" 2>"$STDERR_TMP") || rc=$?
+  (cd -- "$CWD" && run_with_timeout "$TIMEOUT" "$STDERR_TMP" $cmd < "$prompt_file") || rc=$?
   return "$rc"
 }
 

--- a/skills/second-opinion/scripts/second-opinion
+++ b/skills/second-opinion/scripts/second-opinion
@@ -272,17 +272,17 @@ kendex_load_project_env "$PROJECT_ROOT" || {
   exit 1
 }
 
-# Portability: macOS lacks timeout, try gtimeout fallback
-if ! command -v timeout >/dev/null 2>&1; then
-  if command -v gtimeout >/dev/null 2>&1; then
-    timeout() { gtimeout "$@"; }
-  else
-    # No timeout available — warn once and run without a limit. The shim
-    # drops this script's fixed `--foreground -k 30 SECS` arguments.
-    echo "Warning: no timeout or gtimeout on PATH — external CLI calls will run without a time limit" >&2
-    timeout() { shift 4; "$@"; }
-  fi
+# Portability: macOS lacks timeout, try gtimeout fallback.
+TIMEOUT_CMD="$(command -v timeout || command -v gtimeout || true)"
+if [[ -z "$TIMEOUT_CMD" ]]; then
+  echo "Warning: no timeout or gtimeout on PATH — external CLI calls will run without a time limit" >&2
 fi
+
+run_with_timeout() {
+  local duration="$1"; shift
+  if [[ -z "$TIMEOUT_CMD" ]]; then "$@"; return; fi
+  "$TIMEOUT_CMD" --foreground -k 30 "$duration" "$@"
+}
 
 # --- Defaults -----------------------------------------------------------------
 
@@ -2162,7 +2162,7 @@ run_target_cli() {
   fi
   echo "→ cmd: timeout --foreground -k 30 ${TIMEOUT}s $cmd" >&2
   # shellcheck disable=SC2086
-  (cd -- "$CWD" && timeout --foreground -k 30 "$TIMEOUT" $cmd < "$prompt_file" 2>"$STDERR_TMP") || rc=$?
+  (cd -- "$CWD" && run_with_timeout "$TIMEOUT" $cmd < "$prompt_file" 2>"$STDERR_TMP") || rc=$?
   return "$rc"
 }
 

--- a/skills/second-opinion/scripts/second-opinion
+++ b/skills/second-opinion/scripts/second-opinion
@@ -278,9 +278,9 @@ if ! command -v timeout >/dev/null 2>&1; then
     timeout() { gtimeout "$@"; }
   else
     # No timeout available — warn once and run without a limit. The shim
-    # drops this script's fixed `-k 30 SECS` arguments.
+    # drops this script's fixed `--foreground -k 30 SECS` arguments.
     echo "Warning: no timeout or gtimeout on PATH — external CLI calls will run without a time limit" >&2
-    timeout() { shift 3; "$@"; }
+    timeout() { shift 4; "$@"; }
   fi
 fi
 
@@ -2160,9 +2160,9 @@ run_target_cli() {
     echo "{\"error\": \"Unknown target: $TARGET_CLI — set $(target_cmd_var "$TARGET_CLI")\"}" >&2
     return 2
   fi
-  echo "→ cmd: timeout -k 30 ${TIMEOUT}s $cmd" >&2
+  echo "→ cmd: timeout --foreground -k 30 ${TIMEOUT}s $cmd" >&2
   # shellcheck disable=SC2086
-  (cd -- "$CWD" && timeout -k 30 "$TIMEOUT" $cmd < "$prompt_file" 2>"$STDERR_TMP") || rc=$?
+  (cd -- "$CWD" && timeout --foreground -k 30 "$TIMEOUT" $cmd < "$prompt_file" 2>"$STDERR_TMP") || rc=$?
   return "$rc"
 }
 

--- a/skills/second-opinion/scripts/second-opinion
+++ b/skills/second-opinion/scripts/second-opinion
@@ -272,11 +272,8 @@ kendex_load_project_env "$PROJECT_ROOT" || {
   exit 1
 }
 
-# Portability: macOS lacks timeout, try gtimeout fallback.
 TIMEOUT_CMD="$(command -v timeout || command -v gtimeout || true)"
-if [[ -z "$TIMEOUT_CMD" ]]; then
-  echo "Warning: no timeout or gtimeout on PATH — external CLI calls will run without a time limit" >&2
-fi
+[[ -n "$TIMEOUT_CMD" ]] || echo "Warning: no timeout or gtimeout on PATH — external CLI calls will run without a time limit" >&2
 
 run_with_timeout() {
   local duration="$1"; shift
@@ -2160,7 +2157,10 @@ run_target_cli() {
     echo "{\"error\": \"Unknown target: $TARGET_CLI — set $(target_cmd_var "$TARGET_CLI")\"}" >&2
     return 2
   fi
-  echo "→ cmd: timeout --foreground -k 30 ${TIMEOUT}s $cmd" >&2
+  case "$TIMEOUT_CMD" in
+    "") echo "→ cmd: direct $cmd" >&2 ;;
+    *) echo "→ cmd: $TIMEOUT_CMD --foreground -k 30 ${TIMEOUT}s $cmd" >&2 ;;
+  esac
   # shellcheck disable=SC2086
   (cd -- "$CWD" && run_with_timeout "$TIMEOUT" $cmd < "$prompt_file" 2>"$STDERR_TMP") || rc=$?
   return "$rc"

--- a/skills/second-opinion/tests/timeout-defaults.test.sh
+++ b/skills/second-opinion/tests/timeout-defaults.test.sh
@@ -12,7 +12,14 @@ export SECOND_OPINION_CURRENT_MODEL=none
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(cd "$SCRIPT_DIR/../../.." && pwd)"
 TMP_ROOT="$(mktemp -d)"
-trap 'rm -rf "$TMP_ROOT"' EXIT
+ABANDON_SESSION=""
+cleanup_abandon_session() {
+  if [[ -n "$ABANDON_SESSION" ]]; then
+    pkill -TERM -s "$ABANDON_SESSION" 2>/dev/null || true
+    wait "$ABANDON_SESSION" 2>/dev/null || true
+  fi
+}
+trap 'cleanup_abandon_session; rm -rf "$TMP_ROOT"' EXIT
 
 # --- Deterministic harness-free session -------------------------------------
 # A positively detected single-model harness now beats any contradicting
@@ -138,49 +145,54 @@ assert_contains "$notimeout_stderr" "Response received" "review still runs witho
 
 # The caller owns the lane's lifetime. GNU timeout must not isolate the CLI
 # from a signal sent to second-opinion's process group.
+if [[ "$(uname -s)" != "Linux" ]] || ! command -v setsid >/dev/null 2>&1 || ! command -v pkill >/dev/null 2>&1; then
+  printf 'SKIP: process-group lifecycle control requires Linux, setsid, and pkill\n'
+  exit 0
+fi
+
 cat > "$TMP_ROOT/bin/sleeping-codex" <<'SH'
 #!/usr/bin/env bash
-printf '%s\n' "$$" > "$FAKE_CLI_PID_FILE"
-exec sleep 300
+on_term() {
+  printf 'terminated\n' > "$FAKE_CLI_TERM_FILE"
+  exit 0
+}
+trap on_term TERM
+printf 'ready\n' > "$FAKE_CLI_READY_FILE"
+while :; do sleep 1; done
 SH
 chmod +x "$TMP_ROOT/bin/sleeping-codex"
 
-sleeping_pid_file="$TMP_ROOT/sleeping-cli.pid"
+sleeping_ready_file="$TMP_ROOT/sleeping-cli.ready"
+sleeping_term_file="$TMP_ROOT/sleeping-cli.terminated"
 abandon_stderr="$TMP_ROOT/abandon.stderr"
 PATH="$TMP_ROOT/bin:$PATH" \
   SECOND_OPINION_TARGET=codex \
   SECOND_OPINION_CODEX_CMD=sleeping-codex \
-  FAKE_CLI_PID_FILE="$sleeping_pid_file" \
+  FAKE_CLI_READY_FILE="$sleeping_ready_file" \
+  FAKE_CLI_TERM_FILE="$sleeping_term_file" \
   setsid "$SECOND_OPINION" review --range HEAD --cwd "$WORK" >/dev/null 2>"$abandon_stderr" &
-abandon_pid=$!
+ABANDON_SESSION=$!
 
 for _attempt in {1..100}; do
-  [[ -s "$sleeping_pid_file" ]] && break
+  [[ -s "$sleeping_ready_file" ]] && break
   sleep 0.05
 done
-if [[ ! -s "$sleeping_pid_file" ]]; then
-  kill -TERM -- "-$abandon_pid" 2>/dev/null || true
-  wait "$abandon_pid" 2>/dev/null || true
+if [[ ! -s "$sleeping_ready_file" ]]; then
   printf 'FAIL: sleeping CLI did not start\n' >&2
   sed -n '1,80p' "$abandon_stderr" >&2 || true
   exit 1
 fi
 
-sleeping_cli_pid=$(<"$sleeping_pid_file")
-kill -TERM -- "-$abandon_pid"
-wait "$abandon_pid" 2>/dev/null || true
+kill -TERM -- "-$ABANDON_SESSION" 2>/dev/null || true
+wait "$ABANDON_SESSION" 2>/dev/null || true
 
-sleeping_cli_stopped=0
 for _attempt in {1..100}; do
-  if ! kill -0 "$sleeping_cli_pid" 2>/dev/null; then
-    sleeping_cli_stopped=1
-    break
-  fi
+  [[ -s "$sleeping_term_file" ]] && break
   sleep 0.05
 done
-if [[ $sleeping_cli_stopped -ne 1 ]]; then
-  kill -TERM "$sleeping_cli_pid" 2>/dev/null || true
+if [[ ! -s "$sleeping_term_file" ]]; then
   printf 'FAIL: killing second-opinion process group left the CLI running\n' >&2
   exit 1
 fi
+ABANDON_SESSION=""
 printf 'PASS: killing second-opinion process group stops the CLI\n'

--- a/skills/second-opinion/tests/timeout-defaults.test.sh
+++ b/skills/second-opinion/tests/timeout-defaults.test.sh
@@ -88,13 +88,18 @@ assert_contains() {
 }
 
 default_stderr="$TMP_ROOT/default.stderr"
+resolved_timeout="$(command -v timeout || command -v gtimeout || true)"
 PATH="$TMP_ROOT/bin:$PATH" \
   SECOND_OPINION_TARGET=codex \
   SECOND_OPINION_CODEX_CMD=codex \
   "$SECOND_OPINION" review --range HEAD --cwd "$WORK" >/dev/null 2>"$default_stderr"
 
 assert_contains "$default_stderr" "timeout=1080s" "default timeout resolves to documented 1080s"
-assert_contains "$default_stderr" "cmd: timeout --foreground -k 30 1080s codex" "launch log includes explicit default timeout"
+if [[ -n "$resolved_timeout" ]]; then
+  assert_contains "$default_stderr" "cmd: $resolved_timeout --foreground -k 30 1080s codex" "launch log includes resolved default timeout"
+else
+  assert_contains "$default_stderr" "cmd: direct codex" "launch log names direct default execution"
+fi
 
 override_stderr="$TMP_ROOT/override.stderr"
 PATH="$TMP_ROOT/bin:$PATH" \
@@ -104,7 +109,11 @@ PATH="$TMP_ROOT/bin:$PATH" \
   "$SECOND_OPINION" review --range HEAD --cwd "$WORK" >/dev/null 2>"$override_stderr"
 
 assert_contains "$override_stderr" "timeout=7s" "caller timeout override wins"
-assert_contains "$override_stderr" "cmd: timeout --foreground -k 30 7s codex" "launch log includes explicit override timeout"
+if [[ -n "$resolved_timeout" ]]; then
+  assert_contains "$override_stderr" "cmd: $resolved_timeout --foreground -k 30 7s codex" "launch log includes resolved override timeout"
+else
+  assert_contains "$override_stderr" "cmd: direct codex" "launch log names direct override execution"
+fi
 
 # GNU timeout reads 0 as "no limit at all", so --timeout 0 must be refused
 # rather than silently disabling the deadline.
@@ -141,6 +150,7 @@ PATH="$TMP_ROOT/bin:$NOTIMEOUT" \
   "$SECOND_OPINION" review --range HEAD --cwd "$WORK" >/dev/null 2>"$notimeout_stderr"
 
 assert_contains "$notimeout_stderr" "run without a time limit" "missing timeout binary warns instead of refusing"
+assert_contains "$notimeout_stderr" "cmd: direct codex" "missing timeout binary logs direct execution"
 assert_contains "$notimeout_stderr" "Response received" "review still runs without a timeout binary"
 
 # The caller owns the lane's lifetime. GNU timeout must not isolate the CLI

--- a/skills/second-opinion/tests/timeout-defaults.test.sh
+++ b/skills/second-opinion/tests/timeout-defaults.test.sh
@@ -87,7 +87,7 @@ PATH="$TMP_ROOT/bin:$PATH" \
   "$SECOND_OPINION" review --range HEAD --cwd "$WORK" >/dev/null 2>"$default_stderr"
 
 assert_contains "$default_stderr" "timeout=1080s" "default timeout resolves to documented 1080s"
-assert_contains "$default_stderr" "cmd: timeout -k 30 1080s codex" "launch log includes explicit default timeout"
+assert_contains "$default_stderr" "cmd: timeout --foreground -k 30 1080s codex" "launch log includes explicit default timeout"
 
 override_stderr="$TMP_ROOT/override.stderr"
 PATH="$TMP_ROOT/bin:$PATH" \
@@ -97,7 +97,7 @@ PATH="$TMP_ROOT/bin:$PATH" \
   "$SECOND_OPINION" review --range HEAD --cwd "$WORK" >/dev/null 2>"$override_stderr"
 
 assert_contains "$override_stderr" "timeout=7s" "caller timeout override wins"
-assert_contains "$override_stderr" "cmd: timeout -k 30 7s codex" "launch log includes explicit override timeout"
+assert_contains "$override_stderr" "cmd: timeout --foreground -k 30 7s codex" "launch log includes explicit override timeout"
 
 # GNU timeout reads 0 as "no limit at all", so --timeout 0 must be refused
 # rather than silently disabling the deadline.
@@ -135,3 +135,52 @@ PATH="$TMP_ROOT/bin:$NOTIMEOUT" \
 
 assert_contains "$notimeout_stderr" "run without a time limit" "missing timeout binary warns instead of refusing"
 assert_contains "$notimeout_stderr" "Response received" "review still runs without a timeout binary"
+
+# The caller owns the lane's lifetime. GNU timeout must not isolate the CLI
+# from a signal sent to second-opinion's process group.
+cat > "$TMP_ROOT/bin/sleeping-codex" <<'SH'
+#!/usr/bin/env bash
+printf '%s\n' "$$" > "$FAKE_CLI_PID_FILE"
+exec sleep 300
+SH
+chmod +x "$TMP_ROOT/bin/sleeping-codex"
+
+sleeping_pid_file="$TMP_ROOT/sleeping-cli.pid"
+abandon_stderr="$TMP_ROOT/abandon.stderr"
+PATH="$TMP_ROOT/bin:$PATH" \
+  SECOND_OPINION_TARGET=codex \
+  SECOND_OPINION_CODEX_CMD=sleeping-codex \
+  FAKE_CLI_PID_FILE="$sleeping_pid_file" \
+  setsid "$SECOND_OPINION" review --range HEAD --cwd "$WORK" >/dev/null 2>"$abandon_stderr" &
+abandon_pid=$!
+
+for _attempt in {1..100}; do
+  [[ -s "$sleeping_pid_file" ]] && break
+  sleep 0.05
+done
+if [[ ! -s "$sleeping_pid_file" ]]; then
+  kill -TERM -- "-$abandon_pid" 2>/dev/null || true
+  wait "$abandon_pid" 2>/dev/null || true
+  printf 'FAIL: sleeping CLI did not start\n' >&2
+  sed -n '1,80p' "$abandon_stderr" >&2 || true
+  exit 1
+fi
+
+sleeping_cli_pid=$(<"$sleeping_pid_file")
+kill -TERM -- "-$abandon_pid"
+wait "$abandon_pid" 2>/dev/null || true
+
+sleeping_cli_stopped=0
+for _attempt in {1..100}; do
+  if ! kill -0 "$sleeping_cli_pid" 2>/dev/null; then
+    sleeping_cli_stopped=1
+    break
+  fi
+  sleep 0.05
+done
+if [[ $sleeping_cli_stopped -ne 1 ]]; then
+  kill -TERM "$sleeping_cli_pid" 2>/dev/null || true
+  printf 'FAIL: killing second-opinion process group left the CLI running\n' >&2
+  exit 1
+fi
+printf 'PASS: killing second-opinion process group stops the CLI\n'


### PR DESCRIPTION
## Summary
- Keep second-opinion model CLIs in the caller's process group with GNU `timeout --foreground`.
- Run directly with one warning when no timeout binary exists, with launch diagnostics owned beside the actual invocation.
- Add a Linux must-fail process-group control with portable skips and owned-session cleanup.

## Completed Issues
- Closes KEN-480 - second-opinion: the external CLI dies with the lane (timeout --foreground)

## Test Plan
- `.agents/skills/preflight/scripts/preflight --base origin/main --repo /home/method/dev/.worktrees/kendex/ken-480`
- `tools/guard`
- Full second-opinion test suites in both source and committed render
