### PR TITLE
fix(pi-web-tools): keep web_fetch available without an Exa key

### DIFF
--- a/changelog.d/fixed/1808.md
+++ b/changelog.d/fixed/1808.md
@@ -1,0 +1,2 @@
+- Pi web tools keep `web_fetch` on installs with no Exa key: its direct HTTP,
+  GitHub, PDF and YouTube paths never needed one. — thanks @Aelbannan

--- a/pi-extensions/pi-web-tools/src/active-tools.ts
+++ b/pi-extensions/pi-web-tools/src/active-tools.ts
@@ -16,7 +16,10 @@ export function desiredWebTools(model: ModelLike | undefined, settings: WebTools
 	if (settings.exaAdvancedEnabled) desired.push("web_answer", "web_find_similar", "code_search");
 	if (settings.compatibilityTools) desired.push("fetch_content", "get_search_content", "web_search_exa", "web_fetch_exa", "web_research_exa", "web_answer_exa", "web_find_similar_exa");
 	if (!settings.apiKeys.exa) {
-		for (const exaOnly of ["web_fetch", "web_research", "web_answer", "web_find_similar", "code_search", "fetch_content", "web_fetch_exa", "web_research_exa", "web_answer_exa", "web_find_similar_exa"] as PackageToolName[]) {
+		// web_fetch is not in this list: its primary paths (direct HTTP, GitHub
+		// clone, PDF, YouTube transcripts) need no key, and the Exa /contents
+		// fallback in tools/web-fetch.ts is skipped when the key is unset.
+		for (const exaOnly of ["web_research", "web_answer", "web_find_similar", "code_search", "fetch_content", "web_fetch_exa", "web_research_exa", "web_answer_exa", "web_find_similar_exa"] as PackageToolName[]) {
 			const index = desired.indexOf(exaOnly);
 			if (index >= 0) desired.splice(index, 1);
 		}

--- a/pi-extensions/pi-web-tools/tests/provider-selection.test.ts
+++ b/pi-extensions/pi-web-tools/tests/provider-selection.test.ts
@@ -1,6 +1,6 @@
 import assert from "node:assert/strict";
 import test from "node:test";
-import { computeNextActiveTools } from "../src/active-tools.js";
+import { computeNextActiveTools, desiredWebTools } from "../src/active-tools.js";
 import { resolveWebProvider, resolveWebProviderCandidates } from "../src/provider-selection.js";
 import { DEFAULT_SETTINGS, type WebToolsSettings } from "../src/settings.js";
 
@@ -28,4 +28,18 @@ test("active tool sync preserves native tools and keeps web_search available for
 	assert.ok(next.includes("bash"));
 	assert.ok(next.includes("image_generation"));
 	assert.ok(next.includes("web_search"));
+});
+
+test("web_fetch stays available without an Exa key while Exa-only tools remain gated", () => {
+	const model = { provider: "openai-codex", id: "gpt-5.6-sol" };
+	const noKey = desiredWebTools(model, settings());
+	assert.ok(noKey.includes("web_fetch"), "web_fetch works via direct HTTP/GitHub/PDF/YouTube without a key");
+	assert.ok(noKey.includes("get_web_content"));
+	assert.ok(!noKey.includes("web_research"));
+	assert.ok(!noKey.includes("web_answer"));
+	assert.ok(!noKey.includes("code_search"));
+	const withKey = desiredWebTools(model, settings({ apiKeys: { exa: "exa-key" }, exaAdvancedEnabled: true }));
+	assert.ok(withKey.includes("web_fetch"));
+	assert.ok(withKey.includes("web_research"));
+	assert.ok(withKey.includes("code_search"));
 });


### PR DESCRIPTION
web_fetch is a base tool whose primary paths (direct HTTP, GitHub clone, PDF, YouTube transcripts) need no API key; the Exa /contents fallback in tools/web-fetch.ts is already skipped when the key is unset. Removing web_fetch from the exa-key gate in desiredWebTools stops the tool from being dropped from the active tool set on keyless installs, matching BASE_TOOL_NAMES. Exa-only tools (web_research, web_answer, code_search, and the compatibility aliases) remain gated.

Adds a regression test in tests/provider-selection.test.ts.