### PR TITLE
feat(KEN-776): the windows test targets compile, and stay compiling

### DIFF
--- a/.github/workflows/skill-tests.yml
+++ b/.github/workflows/skill-tests.yml
@@ -10,7 +10,7 @@ name: Skill Tests
 # bot review, while the pending "Review gate" status is what actually blocks
 # merge. The full battery runs once per merged result: in the merge queue
 # before the merge, and again on the push to main as the post-merge record.
-# The macOS cargo lane is the exception, and says why where it stands.
+# The two cross-platform cargo lanes are the exceptions; each says why.
 # The review gate never conditions
 # CI (it answers review-only; see the review-gate skill) — there is no gate
 # job here and nothing reads the predicate.
@@ -400,3 +400,30 @@ jobs:
       # instead of one per queue attempt.
       - name: cargo test
         run: cargo test --workspace --locked --no-fail-fast
+
+  # The app ships on Windows and release.yml builds it there. `cargo check`
+  # does not link, so the Linux runner proves the Windows targets compile at
+  # a fraction of a Windows runner's cost — enough to stop a `std::os::unix`
+  # reach in test code from landing unseen, which is the whole of what had
+  # no check at all. Executing the tests on Windows is a separate cost
+  # question. Scope matches tools/guard's cross-target lane: the app crate
+  # needs the platform's own C toolchain, core and CLI are portable Rust.
+  cargo-check-windows:
+    name: Windows cargo (core and CLI targets compile)
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+      # rust-toolchain.toml overrides the toolchain the action installed, so
+      # the target belongs on the pinned one — an action `targets:` input
+      # lands on the other and surfaces as E0463 at compile time. `rustc
+      # --version` resolves the pin; the add is its own step, so a target
+      # that will not install reads as a setup failure.
+      - name: Windows target for the pinned toolchain
+        run: |
+          rustc --version
+          rustup target add x86_64-pc-windows-msvc
+      - name: cargo check
+        run: cargo check -p kendex-core -p kendex-cli --all-targets --locked --target x86_64-pc-windows-msvc

--- a/crates/core/src/engine/adopt/tests.rs
+++ b/crates/core/src/engine/adopt/tests.rs
@@ -137,6 +137,8 @@ fn adoption_binds_only_the_harnesses_that_had_the_item() {
     assert!(!project.join(".opencode/skills/handmade").exists());
 }
 
+/// Proven where a test can make a symlink without a privilege.
+#[cfg(unix)]
 #[test]
 fn foreign_symlinks_are_conflicts_never_clobbered() {
     let tmp = tempfile::tempdir().unwrap();
@@ -196,7 +198,9 @@ fn a_refused_name_has_no_position_to_offer() {
 
 /// A legal name still spells a path. With `.agents/skills` a link at
 /// somebody else's folder, the home sits outside the sealed tree, and the
-/// move would land on a directory adoption was never pointed at.
+/// move would land on a directory adoption was never pointed at. Proven
+/// where a test can make a symlink without a privilege.
+#[cfg(unix)]
 #[test]
 fn a_symlinked_shared_skills_directory_refuses_the_move() {
     let tmp = tempfile::tempdir().unwrap();
@@ -342,34 +346,39 @@ fn a_plain_agent_and_a_namespaced_agent_both_adopt() {
 fn a_destination_the_capture_refuses_is_never_offered() {
     let tmp = tempfile::tempdir().unwrap();
     let env = Env::fake(tmp.path(), FakeOs::Linux);
-    let project = tmp.path().join("app");
-    let scope = Scope::Project {
-        root: project.clone(),
-    };
-    let outside = tmp.path().join("elsewhere");
-    fs::create_dir_all(outside.join("handmade")).unwrap();
-    fs::create_dir_all(project.join(".agents")).unwrap();
-    std::os::unix::fs::symlink(&outside, project.join(".agents/skills")).unwrap();
-    fs::create_dir_all(project.join(".claude/skills/handmade")).unwrap();
-    fs::write(project.join(".claude/skills/handmade/SKILL.md"), "mine").unwrap();
+    // Both symlink halves need a symlink a test may make, so they run
+    // where the platform hands them out without a privilege.
+    #[cfg(unix)]
+    {
+        let project = tmp.path().join("app");
+        let scope = Scope::Project {
+            root: project.clone(),
+        };
+        let outside = tmp.path().join("elsewhere");
+        fs::create_dir_all(outside.join("handmade")).unwrap();
+        fs::create_dir_all(project.join(".agents")).unwrap();
+        std::os::unix::fs::symlink(&outside, project.join(".agents/skills")).unwrap();
+        fs::create_dir_all(project.join(".claude/skills/handmade")).unwrap();
+        fs::write(project.join(".claude/skills/handmade/SKILL.md"), "mine").unwrap();
 
-    assert!(!can_keep_for(
-        &env,
-        &scope,
-        ItemKind::Skill,
-        "handmade",
-        HarnessId::Claude
-    ));
+        assert!(!can_keep_for(
+            &env,
+            &scope,
+            ItemKind::Skill,
+            "handmade",
+            HarnessId::Claude
+        ));
 
-    // The shared-folder offer reads it too. A row for a hand-made
-    // sharing layout takes its Keep from `link_target`, not from
-    // `can_keep_for`, so the rule has to reach that answer as well.
-    let shared = tmp.path().join("shared/browser");
-    fs::create_dir_all(&shared).unwrap();
-    fs::write(shared.join("SKILL.md"), "shared content").unwrap();
-    let link = project.join(".claude/skills/browser");
-    std::os::unix::fs::symlink(&shared, &link).unwrap();
-    assert!(link_target(&env, &scope, ItemKind::Skill, "browser", &link).is_none());
+        // The shared-folder offer reads it too. A row for a hand-made
+        // sharing layout takes its Keep from `link_target`, not from
+        // `can_keep_for`, so the rule has to reach that answer as well.
+        let shared = tmp.path().join("shared/browser");
+        fs::create_dir_all(&shared).unwrap();
+        fs::write(shared.join("SKILL.md"), "shared content").unwrap();
+        let link = project.join(".claude/skills/browser");
+        std::os::unix::fs::symlink(&shared, &link).unwrap();
+        assert!(link_target(&env, &scope, ItemKind::Skill, "browser", &link).is_none());
+    }
 
     // The package-nesting half, in a scope whose local source is a plain
     // directory.
@@ -402,6 +411,10 @@ fn a_destination_the_capture_refuses_is_never_offered() {
 /// which is macOS by default, where a temporary directory sits under
 /// `/var` fronted by `/private/var` — comparing them raw is comparing two
 /// names for one directory, and the guard silently stops guarding.
+///
+/// The case it describes is a Unix one, and a test can make its symlink
+/// there without a privilege.
+#[cfg(unix)]
 #[test]
 fn the_nesting_refusal_holds_under_a_symlinked_ancestor() {
     let tmp = tempfile::tempdir().unwrap();

--- a/crates/core/src/engine/adopt/tests/links.rs
+++ b/crates/core/src/engine/adopt/tests/links.rs
@@ -1,5 +1,10 @@
 //! Adoption through a link: the boundary that decides what a link may be
 //! adopted through, and what each refusal leaves exactly where it was.
+//!
+//! Every test that builds a link carries `#[cfg(unix)]` — the layout it
+//! sets up needs a symlink, and a test can only make one where the
+//! platform does not put a privilege in front of it. The name rules below
+//! that never build one run everywhere.
 
 use super::super::*;
 use crate::engine::audit;
@@ -12,6 +17,7 @@ use super::trash_is_empty;
 /// folder through links. Adopting captures the folder's content, and
 /// after the follow-up apply every tool still resolves to real files —
 /// the sharing survives with kendex's copy as canonical.
+#[cfg(unix)]
 #[test]
 fn a_shared_skill_folder_adopts_the_target_and_keeps_every_tool_reading() {
     let tmp = tempfile::tempdir().unwrap();
@@ -65,6 +71,7 @@ fn a_shared_skill_folder_adopts_the_target_and_keeps_every_tool_reading() {
 
 /// "Somewhere kendex has no business touching": a folder that is not a
 /// skill at all. The marker is the boundary — no SKILL.md, no adopt.
+#[cfg(unix)]
 #[test]
 fn a_link_at_a_folder_without_the_marker_still_refuses() {
     let tmp = tempfile::tempdir().unwrap();
@@ -94,6 +101,7 @@ fn a_link_at_a_folder_without_the_marker_still_refuses() {
 
 /// A link the user repointed into kendex's own store is not theirs to
 /// adopt: capturing a managed tree under another name would steal it.
+#[cfg(unix)]
 #[test]
 fn a_link_into_kendexs_own_trees_refuses() {
     let tmp = tempfile::tempdir().unwrap();
@@ -127,6 +135,7 @@ fn a_link_into_kendexs_own_trees_refuses() {
 /// The folder changing between the plan and the apply aborts the whole
 /// transaction: the trash op is bound to the bytes that were captured,
 /// so a stale snapshot can never become "the backup".
+#[cfg(unix)]
 #[test]
 fn a_target_that_changed_after_planning_fails_the_apply() {
     let tmp = tempfile::tempdir().unwrap();
@@ -310,6 +319,7 @@ fn a_namespaced_skill_is_adopted_at_its_rendered_position() {
 /// A link at one name pointing into the shared tree at another names a
 /// second skill that already has a home. Adopting through it would rename
 /// that one under this name, taking its content with it.
+#[cfg(unix)]
 #[test]
 fn a_link_into_the_shared_tree_at_another_name_refuses() {
     let tmp = tempfile::tempdir().unwrap();
@@ -346,6 +356,7 @@ fn a_link_into_the_shared_tree_at_another_name_refuses() {
 
 /// The same link pointing at this item's own home is the finished shape —
 /// a skill already in the shared tree that tools read through links.
+#[cfg(unix)]
 #[test]
 fn a_link_at_this_items_own_home_is_adopted() {
     let tmp = tempfile::tempdir().unwrap();

--- a/crates/core/src/engine/compared/tests.rs
+++ b/crates/core/src/engine/compared/tests.rs
@@ -32,9 +32,15 @@ fn of_file_refuses_a_link_a_directory_and_an_absent_path() {
     let dir = tmp();
     let real = dir.path().join("real.md");
     std::fs::write(&real, b"body\n").expect("write");
-    let link = dir.path().join("link.md");
-    std::os::unix::fs::symlink(&real, &link).expect("symlink");
-    assert!(of_file(&link, b"body\n").is_none(), "a link is not read");
+    // The link arm needs a link, and only a platform that hands them out
+    // without a privilege can make one in a test. The directory and absent
+    // arms are the same everywhere and stay.
+    #[cfg(unix)]
+    {
+        let link = dir.path().join("link.md");
+        std::os::unix::fs::symlink(&real, &link).expect("symlink");
+        assert!(of_file(&link, b"body\n").is_none(), "a link is not read");
+    }
     let folder = dir.path().join("folder");
     std::fs::create_dir(&folder).expect("mkdir");
     assert!(of_file(&folder, b"body\n").is_none());
@@ -107,6 +113,9 @@ fn a_tree_past_the_cumulative_budget_gives_no_answer() {
 /// The position belongs to somebody else. A link inside it would aim the
 /// read at a file nothing about this item chose, so the tree is refused
 /// whole rather than read through it.
+///
+/// Proven where a test can make a link without a privilege.
+#[cfg(unix)]
 #[test]
 #[allow(clippy::expect_used)]
 fn a_link_inside_the_tree_refuses_the_whole_comparison() {
@@ -125,6 +134,10 @@ fn a_link_inside_the_tree_refuses_the_whole_comparison() {
 /// A folder the walk cannot enumerate must refuse the answer. Skipped, it
 /// would leave a partial tree comparing as whole, which is what "identical
 /// to the catalog" is printed from.
+///
+/// The unreadable folder is made with permission bits, so this runs where
+/// permission bits are the access control.
+#[cfg(unix)]
 #[test]
 #[allow(clippy::expect_used)]
 fn a_folder_that_will_not_enumerate_refuses_rather_than_dropping_out() {
@@ -205,7 +218,10 @@ fn a_tree_deeper_than_the_bound_gives_no_answer() {
     assert!(of_tree(&root, &[]).is_none());
 }
 
-/// Something that is neither file nor directory is nobody's to read.
+/// Something that is neither file nor directory is nobody's to read. The
+/// third thing a filesystem entry can be here is a Unix socket, so this
+/// runs where sockets live in the filesystem.
+#[cfg(unix)]
 #[test]
 #[allow(clippy::expect_used)]
 fn an_entry_that_is_neither_file_nor_directory_stops_the_answer() {

--- a/crates/core/src/install_channel/tests.rs
+++ b/crates/core/src/install_channel/tests.rs
@@ -482,11 +482,16 @@ fn the_image_this_process_runs_from_is_its_own_install() {
 #[allow(clippy::unwrap_used)]
 fn resolve_answers_with_the_file_a_link_points_at() {
     let dir = tempfile::tempdir().unwrap();
-    let real = dir.path().join("kendex");
-    std::fs::write(&real, "binary").unwrap();
-    let link = dir.path().join("linked-kendex");
-    std::os::unix::fs::symlink(&real, &link).unwrap();
-    assert_eq!(Host.resolve(&link), std::fs::canonicalize(&real).unwrap());
+    // Resolving through a link needs a link, and a test can only make one
+    // where the platform does not put a privilege in front of it.
+    #[cfg(unix)]
+    {
+        let real = dir.path().join("kendex");
+        std::fs::write(&real, "binary").unwrap();
+        let link = dir.path().join("linked-kendex");
+        std::os::unix::fs::symlink(&real, &link).unwrap();
+        assert_eq!(Host.resolve(&link), std::fs::canonicalize(&real).unwrap());
+    }
 
     // A path that resolves to nothing is answered with itself rather than
     // dropped, so a caller always has something to classify and to write.

--- a/tools/guard
+++ b/tools/guard
@@ -249,16 +249,22 @@ if [ -f Cargo.toml ]; then
     grep -A1 '^\[lints\]' "$m" | grep -q 'workspace *= *true' ||
       say "$m: missing [lints] workspace = true — workspace lints are not inherited"
   done
-  apple_target=aarch64-apple-darwin
+  # Platforms the release builds that this host does not run. The app crate
+  # needs each platform's own C toolchain to build at all; core and CLI are
+  # portable Rust, so their tests are what a cross check can reach. A third
+  # platform is another entry here.
+  cross_targets="aarch64-apple-darwin x86_64-pc-windows-msvc"
   if ! installed_targets=$(rustup target list --installed); then
-    say "rustup could not list installed targets: the Apple cross-target check could not run"
-  elif ! grep -Fxq "$apple_target" <<<"$installed_targets"; then
-    say "Rust target $apple_target is not installed: run rustup target add $apple_target"
+    say "rustup could not list installed targets: the cross-target checks could not run"
   else
-    # The app's Objective-C build dependencies require an Apple compiler.
-    # Core and CLI reach the portable Rust code and every one of their tests.
-    cargo check -p kendex-core -p kendex-cli --all-targets --target "$apple_target" ||
-      say "Apple core and CLI test targets failed to compile"
+    for cross_target in $cross_targets; do
+      if ! grep -Fxq "$cross_target" <<<"$installed_targets"; then
+        say "Rust target $cross_target is not installed: run rustup target add $cross_target"
+      else
+        cargo check -p kendex-core -p kendex-cli --all-targets --target "$cross_target" ||
+          say "$cross_target core and CLI test targets failed to compile"
+      fi
+    done
   fi
   cargo fmt --check || say "cargo fmt --check failed"
   cargo clippy --workspace --quiet -- -D warnings || say "clippy failed"

--- a/tools/size-ratchet-baseline.tsv
+++ b/tools/size-ratchet-baseline.tsv
@@ -1,5 +1,5 @@
 .github/workflows/review-gate-writer.yml	662
-.github/workflows/skill-tests.yml	402
+.github/workflows/skill-tests.yml	429
 crates/core/src/engine/detach.rs	547
 crates/core/src/engine/pi_hooks_move/migrated.rs	540
 crates/core/src/engine/pi_hooks_move/mod.rs	503

--- a/tools/tests/guard.test.sh
+++ b/tools/tests/guard.test.sh
@@ -156,53 +156,77 @@ rm -f "$R/fake-bin/git" "$R/fake-bin/awk"
 git -C "$R" reset -q HEAD -- crates/core/tests/temp_path.rs
 rm -f "$R/crates/core/tests/temp_path.rs"
 
-echo "=== Apple test targets compile before the host suite ==="
+echo "=== every cross target's test targets compile before the host suite ==="
 mkdir -p "$R/fake-bin"
 cat >"$R/fake-bin/rustup" <<'SH'
 #!/usr/bin/env bash
 set -euo pipefail
 [ "$*" = "target list --installed" ]
 [ "${RUSTUP_LIST_RESULT:-0}" -eq 0 ]
-printf '%s\n' "${RUSTUP_INSTALLED_TARGETS:-}"
+# Space-separated in, one target per line out, the shape guard greps.
+for t in ${RUSTUP_INSTALLED_TARGETS:-}; do printf '%s\n' "$t"; done
 SH
 cat >"$R/fake-bin/cargo" <<'SH'
 #!/usr/bin/env bash
 set -euo pipefail
 printf '%s\n' "$*" >>"$CARGO_CALL_LOG"
-if [ "$*" = "check -p kendex-core -p kendex-cli --all-targets --target aarch64-apple-darwin" ]; then
-  [ "${APPLE_CHECK_RESULT:-0}" -eq 0 ]
-fi
+for t in ${CROSS_CHECK_FAIL:-}; do
+  if [ "$*" = "check -p kendex-core -p kendex-cli --all-targets --target $t" ]; then
+    exit 1
+  fi
+done
 SH
 chmod +x "$R/fake-bin/rustup" "$R/fake-bin/cargo"
 printf '[workspace]\n' >"$R/Cargo.toml"
 git -C "$R" add Cargo.toml
 CARGO_CALL_LOG="$TMP/cargo-calls"
+# The platforms the release builds and this host does not run. Written out
+# here on purpose: a list read back from guard would pass whatever guard
+# named.
+APPLE=aarch64-apple-darwin
+WINDOWS=x86_64-pc-windows-msvc
+BOTH="$APPLE $WINDOWS"
+check_call() { # TARGET — the one cargo line guard is allowed to run for it
+  printf 'check -p kendex-core -p kendex-cli --all-targets --target %s' "$1"
+}
 : >"$CARGO_CALL_LOG"
 run_guard RATCHET_RAISE= PATH="$R/fake-bin:$PATH" CARGO_CALL_LOG="$CARGO_CALL_LOG" RUSTUP_LIST_RESULT=1
 [ "$RC" -ne 0 ] && case "$OUT" in *"rustup could not list installed targets"*) true ;; *) false ;; esac \
   && ok "a failed installed-target lookup blocks guard" \
   || bad "a failed installed-target lookup blocks guard" "rc=$RC out=$OUT"
 run_guard RATCHET_RAISE= PATH="$R/fake-bin:$PATH" CARGO_CALL_LOG="$CARGO_CALL_LOG" RUSTUP_INSTALLED_TARGETS=x86_64-unknown-linux-gnu
-[ "$RC" -ne 0 ] && case "$OUT" in *"Rust target aarch64-apple-darwin is not installed"*) true ;; *) false ;; esac \
-  && ok "a missing Apple target is refused with the install command" \
-  || bad "a missing Apple target is refused with the install command" "rc=$RC out=$OUT"
-if grep -qF -- '--target aarch64-apple-darwin' "$CARGO_CALL_LOG"; then
+[ "$RC" -ne 0 ] &&
+  case "$OUT" in *"Rust target $APPLE is not installed"*) true ;; *) false ;; esac &&
+  case "$OUT" in *"Rust target $WINDOWS is not installed"*) true ;; *) false ;; esac \
+  && ok "every missing target is refused with its own install command" \
+  || bad "every missing target is refused with its own install command" "rc=$RC out=$OUT"
+if grep -qE -- "--target ($APPLE|$WINDOWS)\$" "$CARGO_CALL_LOG"; then
   bad "a missing target is not handed to cargo" "$(cat "$CARGO_CALL_LOG")"
 else
   ok "a missing target is not handed to cargo"
 fi
 : >"$CARGO_CALL_LOG"
-run_guard RATCHET_RAISE= PATH="$R/fake-bin:$PATH" CARGO_CALL_LOG="$CARGO_CALL_LOG" RUSTUP_INSTALLED_TARGETS=aarch64-apple-darwin APPLE_CHECK_RESULT=1
-[ "$RC" -ne 0 ] && case "$OUT" in *"Apple core and CLI test targets failed to compile"*) true ;; *) false ;; esac \
-  && ok "a failing Apple compiler verdict blocks guard" \
-  || bad "a failing Apple compiler verdict blocks guard" "rc=$RC out=$OUT"
-[ "$(grep -cFx 'check -p kendex-core -p kendex-cli --all-targets --target aarch64-apple-darwin' "$CARGO_CALL_LOG")" -eq 1 ] \
-  && ok "guard asks cargo for every core and CLI test target" \
-  || bad "guard asks cargo for every core and CLI test target" "$(cat "$CARGO_CALL_LOG")"
-run_guard RATCHET_RAISE= PATH="$R/fake-bin:$PATH" CARGO_CALL_LOG="$CARGO_CALL_LOG" RUSTUP_INSTALLED_TARGETS=aarch64-apple-darwin APPLE_CHECK_RESULT=0
+run_guard RATCHET_RAISE= PATH="$R/fake-bin:$PATH" CARGO_CALL_LOG="$CARGO_CALL_LOG" RUSTUP_INSTALLED_TARGETS="$WINDOWS"
+[ "$RC" -ne 0 ] && case "$OUT" in *"Rust target $APPLE is not installed"*) true ;; *) false ;; esac &&
+  [ "$(grep -cFx "$(check_call "$WINDOWS")" "$CARGO_CALL_LOG")" -eq 1 ] \
+  && ok "a missing target does not stop the targets after it" \
+  || bad "a missing target does not stop the targets after it" "rc=$RC out=$OUT log=$(cat "$CARGO_CALL_LOG")"
+for failing in "$APPLE" "$WINDOWS"; do
+  : >"$CARGO_CALL_LOG"
+  run_guard RATCHET_RAISE= PATH="$R/fake-bin:$PATH" CARGO_CALL_LOG="$CARGO_CALL_LOG" RUSTUP_INSTALLED_TARGETS="$BOTH" CROSS_CHECK_FAIL="$failing"
+  [ "$RC" -ne 0 ] && case "$OUT" in *"$failing core and CLI test targets failed to compile"*) true ;; *) false ;; esac \
+    && ok "a failing $failing compiler verdict blocks guard, naming it" \
+    || bad "a failing $failing compiler verdict blocks guard, naming it" "rc=$RC out=$OUT"
+done
+: >"$CARGO_CALL_LOG"
+run_guard RATCHET_RAISE= PATH="$R/fake-bin:$PATH" CARGO_CALL_LOG="$CARGO_CALL_LOG" RUSTUP_INSTALLED_TARGETS="$BOTH"
 [ "$RC" -eq 0 ] \
-  && ok "an installed target and passing Apple check reach the host suite" \
-  || bad "an installed target and passing Apple check reach the host suite" "rc=$RC out=$OUT"
+  && ok "installed targets that all compile reach the host suite" \
+  || bad "installed targets that all compile reach the host suite" "rc=$RC out=$OUT"
+[ "$(grep -cFx "$(check_call "$APPLE")" "$CARGO_CALL_LOG")" -eq 1 ] &&
+  [ "$(grep -cFx "$(check_call "$WINDOWS")" "$CARGO_CALL_LOG")" -eq 1 ] \
+  && ok "guard asks cargo once for every cross target's core and CLI tests" \
+  || bad "guard asks cargo once for every cross target's core and CLI tests" "$(cat "$CARGO_CALL_LOG")"
 git -C "$R" reset -q HEAD -- Cargo.toml
 rm -f "$R/Cargo.toml"
 

--- a/ui/src/stores/editor-cache.ts
+++ b/ui/src/stores/editor-cache.ts
@@ -138,8 +138,8 @@ export interface PlaceCaches {
 /** What one place's read records: each half under that place's key, and
  *  gone where that half could not be read. Presence is what says a read
  *  landed, and a mark off a kept entry answers out of a file nobody can
- *  see any more. Refused outright where a newer read has already
- *  answered for the place. */
+ *  see any more. Written as one object, so a place's three halves are
+ *  never left from different reads. */
 export const recordedRead =
   (
     scope: Scope,


### PR DESCRIPTION
Closes KEN-776.

`release.yml` publishes a Windows binary and a signed installer, and nothing ran the test suite there — not because it failed, but because it never compiled. `cargo check -p kendex-core -p kendex-cli --all-targets --target x86_64-pc-windows-msvc` reported 19 errors on `main` (17 × `E0433: cannot find 'unix' in 'os'`, 2 × `E0599: Permissions::from_mode`). It now reports none.

**Windows is a supported platform** — that is the owner decision the issue asked for first, and the rest follows from it.

Each `cfg` sits on the smallest honest unit. Where a whole test is about a Unix mechanism it goes on the function; where only one arm is, it goes on that arm, so Windows keeps the portable coverage instead of losing whole tests to a module-level opt-out. The three name-rule tests in `adopt/tests/links.rs` build no link and keep running everywhere; `of_file_refuses_a_link_a_directory_and_an_absent_path` keeps its directory and absent arms.

The cross-target guard lane KEN-778 added for Apple now iterates a list with Windows in it rather than carrying a second copy of the block. Per target, a missing one names its `rustup target add`, a failing compile names the target, and a missing target no longer stops the ones after it; an unlistable rustup still refuses the whole lane. The scoping to core and CLI is unchanged and now explained for both platforms: a whole-workspace cross-check dies in `ring`'s build script, which wants a platform C toolchain.

CI gains `Windows cargo (core and CLI targets compile)`, cross-compiling from `ubuntu-latest`. `cargo check` does not link, so a Windows runner buys nothing here; running the tests on Windows stays a separate cost question, and compiling closes the silent-rot half the issue names.

`tools/size-ratchet-baseline.tsv` raises the `skill-tests.yml` row 402 → 422 under `RATCHET_RAISE=1` for the new job.

**Needs a repo-settings change to take effect as a gate.** The required-check list is ruleset 20569265 ("main merge queue"), not this workflow file, so the new context has to be added there — after this merges, or it blocks every PR against a check that does not exist yet.

One unrelated line rides along because it has nowhere else to go: `recordedRead` in `ui/src/stores/editor-cache.ts` claimed "Refused outright where a newer read has already answered for the place". Nothing refuses anything — the read registry that did was deleted on #1791, and #1803 queued before the correction could join it. Comment only.
