### PR TITLE
feat(KEN-438): a release candidate updates to the next one

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -148,11 +148,42 @@ jobs:
   publish:
     needs: build
     runs-on: ubuntu-24.04
+    # The pre-release channel below is one mutable pointer, so two tag runs
+    # must not interleave their reads and writes of it: the run that read
+    # first and uploaded last would leave the older manifests in place.
+    # Queued rather than cancelled — a cancelled publish is a tag with no
+    # release at all.
+    concurrency:
+      group: release-publish
+      cancel-in-progress: false
     steps:
       - uses: actions/download-artifact@v4
         with:
           path: dist
           merge-multiple: true
+      # What kind of tag this is, decided once for every step below. SemVer
+      # puts build metadata after a `+` and it is not part of the version,
+      # so the `-` that marks a pre-release is only a `-` in what is left:
+      # v1.0.0+build-1 is a full release. Asking whether the tag contains a
+      # `-` calls that one a candidate while the build it produces reads
+      # itself as a release and follows release URLs, which is the two
+      # halves disagreeing about one tag.
+      - name: Classify the tag
+        id: tag
+        shell: bash
+        run: |
+          version="${GITHUB_REF_NAME#v}"
+          core="${version%%+*}"
+          if [[ ! "$core" =~ ^[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.-]+)?$ ]]; then
+            echo "::error::Tag ${GITHUB_REF_NAME} is not a SemVer version. The release version is the tag without its leading v, and the app parses it as SemVer or refuses to update."
+            exit 1
+          fi
+          case "$core" in
+            *-*) prerelease=true ;;
+            *) prerelease=false ;;
+          esac
+          echo "prerelease=$prerelease" >> "$GITHUB_OUTPUT"
+          echo "version=$version" >> "$GITHUB_OUTPUT"
       - name: Write the update feed
         run: |
           version="${GITHUB_REF_NAME#v}"
@@ -223,24 +254,61 @@ jobs:
       - uses: softprops/action-gh-release@v2
         with:
           files: dist/*
-          draft: ${{ !contains(github.ref_name, '-') }}
-          prerelease: ${{ contains(github.ref_name, '-') }}
+          draft: ${{ steps.tag.outputs.prerelease == 'false' }}
+          prerelease: ${{ steps.tag.outputs.prerelease == 'true' }}
       # And because "latest" skips them, a candidate has no way to reach the
       # next one. This release is that way: one fixed tag whose two manifests
       # are overwritten by each new candidate, which is the URL
-      # `update_feed::feed_url_for` sends a candidate to. The manifests name
-      # their downloads by the tag that built them, so what they point at is
-      # this tag's own release, published by the step above.
+      # `update_channel::feed_url_for` sends a candidate to. The manifests
+      # name their downloads by the tag that built them, so what they point
+      # at is this tag's own release, published by the step above.
       - name: Point the pre-release channel at this tag
-        if: contains(github.ref_name, '-')
+        if: steps.tag.outputs.prerelease == 'true'
         shell: bash
         env:
           GH_TOKEN: ${{ github.token }}
           CHANNEL: prerelease
+          NEW_VERSION: ${{ steps.tag.outputs.version }}
         run: |
-          gh release view "$CHANNEL" --repo "$GITHUB_REPOSITORY" > /dev/null 2>&1 ||
+          # Whether $1 is ahead of $2 under SemVer precedence, which is
+          # jq's own ordering once each version is turned into the key
+          # SemVer compares by: the numeric core, then a release ranking
+          # above the pre-releases leading to it, then the pre-release
+          # identifiers, where an all-digit one ranks below an alphanumeric
+          # one and alphanumerics compare as text. That last rule is why
+          # `sort -V` cannot stand in here: it reads rc10 as past rc2,
+          # where SemVer puts rc10 first. Build metadata is not part of the
+          # version and comes off before any of it.
+          ahead_of() {
+            [ "$(jq -rn --arg a "$1" --arg b "$2" '
+              def ident: if test("^[0-9]+$") then [0, tonumber] else [1, .] end;
+              def key: split("+")[0]
+                | (split("-")[0] | split(".") | map(tonumber)) as $core
+                | (index("-") as $i | if $i == null then null else .[$i + 1:] end) as $pre
+                | [$core,
+                   (if $pre == null then 1 else 0 end),
+                   (if $pre == null then [] else ($pre | split(".") | map(ident)) end)];
+              if ($a | key) > ($b | key) then "yes" else "no" end')" = yes ]
+          }
+          current=""
+          if gh release view "$CHANNEL" --repo "$GITHUB_REPOSITORY" > /dev/null 2>&1; then
+            if gh release download "$CHANNEL" --repo "$GITHUB_REPOSITORY" \
+                 --pattern latest.json --output channel.json --clobber > /dev/null 2>&1; then
+              current=$(jq -r '.version // empty' channel.json)
+            fi
+          else
             gh release create "$CHANNEL" --repo "$GITHUB_REPOSITORY" --prerelease \
               --title "Pre-release channel" \
               --notes "The update manifests of the newest kendex pre-release. Nothing here is a download; each manifest names assets on the release it came from."
+          fi
+          # A tag re-run after a later one would otherwise roll every
+          # candidate back to it, and on this channel a rollback looks
+          # exactly like the update path being broken. Only a strictly
+          # newer current refuses the write, so re-running the tag the
+          # channel already carries still refreshes it.
+          if [ -n "$current" ] && ahead_of "$current" "$NEW_VERSION"; then
+            echo "::notice::The pre-release channel carries ${current}, ahead of ${NEW_VERSION}; leaving it as it is."
+            exit 0
+          fi
           gh release upload "$CHANNEL" dist/latest.json dist/feed.json \
             --repo "$GITHUB_REPOSITORY" --clobber

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -325,6 +325,7 @@ jobs:
             exit 1
           fi
           current=""
+          saved=""
           if grep -qxF "$CHANNEL" <<< "$tags"; then
             if ! assets=$(gh api "repos/${GITHUB_REPOSITORY}/releases/tags/${CHANNEL}" --jq '.assets[].name'); then
               echo "::error::The ${CHANNEL} channel is published but its assets could not be read. Nothing was written; re-run the tag."
@@ -333,12 +334,17 @@ jobs:
             # An absent manifest is a channel nothing has published to yet,
             # which is the one case that leaves `current` empty on purpose.
             if grep -qxF latest.json <<< "$assets"; then
+              # Both manifests come down, not only the one the comparison
+              # reads: `gh release upload --clobber` deletes an asset
+              # before uploading its replacement, so these are the only
+              # copies of what the channel had if that upload then fails.
               if ! gh release download "$CHANNEL" --repo "$GITHUB_REPOSITORY" \
-                   --pattern latest.json --output channel.json --clobber; then
+                   --dir saved --pattern latest.json --pattern feed.json --clobber; then
                 echo "::error::The ${CHANNEL} channel carries a manifest that could not be downloaded. Nothing was written; re-run the tag."
                 exit 1
               fi
-              current=$(jq -r '.version // empty' channel.json)
+              saved=1
+              current=$(jq -r '.version // empty' saved/latest.json)
               if [ -z "$current" ]; then
                 echo "::error::The ${CHANNEL} channel's manifest names no version, so nothing here can say whether ${NEW_VERSION} is ahead of it. Repair the channel, then re-run the tag."
                 exit 1
@@ -358,5 +364,19 @@ jobs:
             echo "::notice::The pre-release channel carries ${current}, ahead of ${NEW_VERSION}; leaving it as it is."
             exit 0
           fi
-          gh release upload "$CHANNEL" dist/latest.json dist/feed.json \
-            --repo "$GITHUB_REPOSITORY" --clobber
+          if ! gh release upload "$CHANNEL" dist/latest.json dist/feed.json \
+               --repo "$GITHUB_REPOSITORY" --clobber; then
+            # An upload that failed after the delete leaves the channel
+            # short a manifest, and a candidate reading a channel with no
+            # latest.json sees no update at all. Put back what came down.
+            # This is not an atomic swap and does not pretend to be: the
+            # job fails either way, and the second message is there because
+            # a channel nobody repaired needs saying out loud.
+            if [ -n "$saved" ] && ! gh release upload "$CHANNEL" saved/*.json \
+                 --repo "$GITHUB_REPOSITORY" --clobber; then
+              echo "::error::Uploading to the ${CHANNEL} channel failed and the manifests it had could not be put back. Candidates see no updates until a tag re-run repairs the channel."
+              exit 1
+            fi
+            echo "::error::Uploading to the ${CHANNEL} channel failed; what it carried is back in place. Re-run the tag."
+            exit 1
+          fi

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -161,24 +161,47 @@ jobs:
         with:
           path: dist
           merge-multiple: true
-      # What kind of tag this is, decided once for every step below. SemVer
-      # puts build metadata after a `+` and it is not part of the version,
-      # so the `-` that marks a pre-release is only a `-` in what is left:
-      # v1.0.0+build-1 is a full release. Asking whether the tag contains a
-      # `-` calls that one a candidate while the build it produces reads
-      # itself as a release and follows release URLs, which is the two
-      # halves disagreeing about one tag.
+      # What kind of tag this is, decided once for every step below, and
+      # taken from the version this release was built as rather than from
+      # the tag's punctuation. Nothing here can run kendex's own parser, and
+      # a regex written to stand in for it is not SemVer: it admits
+      # v01.0.0, v1.0.0-01 and v1.0.0-alpha..1, which the parser refuses, so
+      # the release would publish a manifest version every candidate then
+      # fails to read. Cargo will not build a package whose version is not
+      # SemVer, so the string read back here has already been through that
+      # parser, and holding the tag to it is a real verdict rather than a
+      # second opinion about one.
+      #
+      # It is also the check docs/RELEASING.md asks for and nothing
+      # enforced. A tag naming a version no artifact carries publishes a
+      # feed pointing at downloads that are not there, which every install
+      # reads as a release it cannot fetch.
       - name: Classify the tag
         id: tag
         shell: bash
         run: |
-          version="${GITHUB_REF_NAME#v}"
-          core="${version%%+*}"
-          if [[ ! "$core" =~ ^[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.-]+)?$ ]]; then
-            echo "::error::Tag ${GITHUB_REF_NAME} is not a SemVer version. The release version is the tag without its leading v, and the app parses it as SemVer or refuses to update."
+          # The artifact upload does not carry the executable bit across.
+          built_cli=dist/kendex-x86_64-unknown-linux-gnu
+          chmod +x "$built_cli"
+          if ! built=$("./$built_cli" --version); then
+            echo "::error::Could not read the version back from ${built_cli}, so nothing here can say what this release was built as."
             exit 1
           fi
-          case "$core" in
+          built=${built##* }
+          version="${GITHUB_REF_NAME#v}"
+          if [ "$version" != "$built" ]; then
+            echo "::error::Tag ${GITHUB_REF_NAME} names version ${version}, and this release was built as ${built}. The tag is the version without its leading v; bump the version to match, or re-tag the commit that carries it."
+            exit 1
+          fi
+          # SemVer keeps build metadata after a `+` and out of the version,
+          # so the `-` opening a pre-release is only a `-` in what is left:
+          # 1.0.0+build-1 is a full release. On a string a parser has
+          # already accepted, that is the grammar rather than a guess about
+          # it. Asking only whether the tag contains a `-` calls
+          # v1.0.0+build-1 a candidate while the build it produces reads
+          # itself as a release and follows release URLs, which is the two
+          # halves disagreeing about one tag.
+          case "${version%%+*}" in
             *-*) prerelease=true ;;
             *) prerelease=false ;;
           esac
@@ -290,11 +313,36 @@ jobs:
                    (if $pre == null then [] else ($pre | split(".") | map(ident)) end)];
               if ($a | key) > ($b | key) then "yes" else "no" end')" = yes ]
           }
+          # Every read below either answers or stops the job. A guard on a
+          # destructive write that cannot tell "nothing published there
+          # yet" from "the read failed" is not a guard: one lost
+          # connection reads as an empty channel and the upload rolls it
+          # back to this tag, which is the case the guard exists for. So
+          # whether the channel is there is settled by a listing that
+          # succeeded, never by a call that failed.
+          if ! tags=$(gh api "repos/${GITHUB_REPOSITORY}/releases" --paginate --jq '.[].tag_name'); then
+            echo "::error::Could not list this repository's releases, so nothing here can say what the ${CHANNEL} channel carries. Nothing was written; re-run the tag."
+            exit 1
+          fi
           current=""
-          if gh release view "$CHANNEL" --repo "$GITHUB_REPOSITORY" > /dev/null 2>&1; then
-            if gh release download "$CHANNEL" --repo "$GITHUB_REPOSITORY" \
-                 --pattern latest.json --output channel.json --clobber > /dev/null 2>&1; then
+          if grep -qxF "$CHANNEL" <<< "$tags"; then
+            if ! assets=$(gh api "repos/${GITHUB_REPOSITORY}/releases/tags/${CHANNEL}" --jq '.assets[].name'); then
+              echo "::error::The ${CHANNEL} channel is published but its assets could not be read. Nothing was written; re-run the tag."
+              exit 1
+            fi
+            # An absent manifest is a channel nothing has published to yet,
+            # which is the one case that leaves `current` empty on purpose.
+            if grep -qxF latest.json <<< "$assets"; then
+              if ! gh release download "$CHANNEL" --repo "$GITHUB_REPOSITORY" \
+                   --pattern latest.json --output channel.json --clobber; then
+                echo "::error::The ${CHANNEL} channel carries a manifest that could not be downloaded. Nothing was written; re-run the tag."
+                exit 1
+              fi
               current=$(jq -r '.version // empty' channel.json)
+              if [ -z "$current" ]; then
+                echo "::error::The ${CHANNEL} channel's manifest names no version, so nothing here can say whether ${NEW_VERSION} is ahead of it. Repair the channel, then re-run the tag."
+                exit 1
+              fi
             fi
           else
             gh release create "$CHANNEL" --repo "$GITHUB_REPOSITORY" --prerelease \

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -214,7 +214,33 @@ jobs:
             --argjson platforms "$platforms" \
             '{version: $version, pub_date: $pub_date, platforms: $platforms}' > dist/latest.json
           cat dist/latest.json
+      # A full release lands as a draft to review before publishing makes it
+      # "latest" (docs/RELEASING.md). A pre-release cannot: its assets are
+      # unreachable while it is a draft, so nothing could install it, and
+      # testing the update path end to end is the whole reason a tag like
+      # v1.0.0-rc2 is cut. Publishing it reaches nobody who is not already
+      # on a candidate — GitHub resolves "latest" past every pre-release.
       - uses: softprops/action-gh-release@v2
         with:
           files: dist/*
-          draft: true
+          draft: ${{ !contains(github.ref_name, '-') }}
+          prerelease: ${{ contains(github.ref_name, '-') }}
+      # And because "latest" skips them, a candidate has no way to reach the
+      # next one. This release is that way: one fixed tag whose two manifests
+      # are overwritten by each new candidate, which is the URL
+      # `update_feed::feed_url_for` sends a candidate to. The manifests name
+      # their downloads by the tag that built them, so what they point at is
+      # this tag's own release, published by the step above.
+      - name: Point the pre-release channel at this tag
+        if: contains(github.ref_name, '-')
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+          CHANNEL: prerelease
+        run: |
+          gh release view "$CHANNEL" --repo "$GITHUB_REPOSITORY" > /dev/null 2>&1 ||
+            gh release create "$CHANNEL" --repo "$GITHUB_REPOSITORY" --prerelease \
+              --title "Pre-release channel" \
+              --notes "The update manifests of the newest kendex pre-release. Nothing here is a download; each manifest names assets on the release it came from."
+          gh release upload "$CHANNEL" dist/latest.json dist/feed.json \
+            --repo "$GITHUB_REPOSITORY" --clobber

--- a/.pi/prompts/gh-release.md
+++ b/.pi/prompts/gh-release.md
@@ -42,5 +42,7 @@ Added entry; major only when asked).
    bundles, and `feed.json`. Missing asset → fix the workflow, re-tag only
    after deleting the failed draft and tag.
 7. Publish the draft: `gh release edit vX.Y.Z --draft=false`. Confirm
-   `releases/latest/download/feed.json` serves the new version.
+   `releases/latest/download/feed.json` serves the new version. A
+   pre-release tag (`v1.0.0-rc1`) skips this — the workflow publishes it
+   and repoints the `prerelease` channel itself (docs/RELEASING.md).
 8. Report: tag, assets, anything skipped.

--- a/changelog.d/added/KEN-438.md
+++ b/changelog.d/added/KEN-438.md
@@ -1,0 +1,1 @@
+- A tagged release candidate publishes as a pre-release, and a build that is itself a candidate takes its updates from the candidate channel in both the app and `kendex update`.

--- a/crates/app/src/app_update.rs
+++ b/crates/app/src/app_update.rs
@@ -18,7 +18,9 @@ fn feed_url() -> String {
 fn selected_feed(override_url: Option<String>, debug_build: bool) -> String {
     match (debug_build, override_url) {
         (true, Some(url)) => url,
-        (true, None) | (false, _) => kendex_core::update_feed::RELEASE_FEED_URL.to_owned(),
+        (true, None) | (false, _) => {
+            kendex_core::update_channel::feed_url_for(env!("CARGO_PKG_VERSION")).to_owned()
+        }
     }
 }
 
@@ -111,6 +113,18 @@ fn aim_at_install<T: ReplacementTarget>(target: T, install: &AppInstall) -> T {
     }
 }
 
+/// Where this build installs from, as the plugin wants it. `tauri.conf.json`
+/// names the release channel so the plugin has a configured default, and a
+/// test holds that entry to the same constant; handing the choice over on
+/// every install is what keeps a release candidate on the channel core
+/// already put its notice card on, instead of two files that agree only
+/// while nobody edits one.
+fn manifest_endpoint() -> Result<tauri::Url, String> {
+    let url = kendex_core::update_channel::manifest_url_for(env!("CARGO_PKG_VERSION"));
+    tauri::Url::parse(url)
+        .map_err(|error| format!("the update manifest URL {url} is unusable: {error}"))
+}
+
 /// Replace this install with the latest release and relaunch into it. The
 /// separately signed updater manifest is the delivery path and verifies
 /// itself; the discovery feed never supplies an install URL. A failure
@@ -123,6 +137,8 @@ pub async fn app_update_install(app: tauri::AppHandle) -> Result<(), String> {
     let install = app_install()?;
     kendex_core::install_channel::for_app(&install, &Host).allow_replacement()?;
     let update = aim_at_install(app.updater_builder(), &install)
+        .endpoints(vec![manifest_endpoint()?])
+        .map_err(|error| error.to_string())?
         .build()
         .map_err(|error| error.to_string())?
         .check()
@@ -157,7 +173,27 @@ mod tests {
         assert_eq!(selected_feed(Some(fixture.clone()), true), fixture);
         assert_eq!(
             selected_feed(Some(fixture), false),
-            kendex_core::update_feed::RELEASE_FEED_URL
+            kendex_core::update_channel::feed_url_for(env!("CARGO_PKG_VERSION"))
+        );
+    }
+
+    /// The card's check and the install have to be looking at one release,
+    /// or a candidate is offered an update the installer then cannot find.
+    /// Both read the running version, so this asserts they land on the same
+    /// channel and that the endpoint is a URL the plugin will take.
+    #[test]
+    fn the_notice_and_the_install_read_one_channel() {
+        let version = env!("CARGO_PKG_VERSION");
+        let endpoint = manifest_endpoint().expect("the manifest URL parses");
+        assert_eq!(
+            endpoint.as_str(),
+            kendex_core::update_channel::manifest_url_for(version)
+        );
+        use kendex_core::update_channel::{PRERELEASE_FEED_URL, PRERELEASE_MANIFEST_URL};
+        assert_eq!(
+            selected_feed(None, false) == PRERELEASE_FEED_URL,
+            endpoint.as_str() == PRERELEASE_MANIFEST_URL,
+            "the feed and the manifest are on different channels for {version}"
         );
     }
 

--- a/crates/app/tests/tauri_config.rs
+++ b/crates/app/tests/tauri_config.rs
@@ -34,3 +34,23 @@ fn the_app_and_the_cli_pin_one_updater_key() {
         Some(kendex_core::update_feed::UPDATER_PUBLIC_KEY)
     );
 }
+
+/// The plugin needs a configured endpoint, and the install hands it core's
+/// choice on top. The configured one is the release channel, so an install
+/// that ever stopped overriding it falls back to full releases rather than
+/// to whatever a stale edit left here — and a build that is not a release
+/// candidate finds the two already equal.
+#[test]
+fn the_configured_endpoint_is_the_release_channel() {
+    assert_eq!(
+        config()["plugins"]["updater"]["endpoints"][0].as_str(),
+        Some(kendex_core::update_channel::RELEASE_MANIFEST_URL)
+    );
+    assert_eq!(
+        config()["plugins"]["updater"]["endpoints"]
+            .as_array()
+            .map(Vec::len),
+        Some(1),
+        "a second endpoint the install does not choose is one nothing holds to a channel"
+    );
+}

--- a/crates/app/tests/tauri_config.rs
+++ b/crates/app/tests/tauri_config.rs
@@ -35,6 +35,20 @@ fn the_app_and_the_cli_pin_one_updater_key() {
     );
 }
 
+/// The app bundle and the CLI carry their versions in different files, and
+/// the release is held to one of them: the publish job reads the version
+/// back out of the built CLI and refuses a tag that names another. Left to
+/// drift, a tag matching the CLI would ship an app bundle of some other
+/// version, which the updater then reads as already current or as older
+/// than a release it cannot find.
+#[test]
+fn the_app_and_the_cli_ship_one_version() {
+    assert_eq!(
+        config()["version"].as_str(),
+        Some(env!("CARGO_PKG_VERSION"))
+    );
+}
+
 /// The plugin needs a configured endpoint, and the install hands it core's
 /// choice on top. The configured one is the release channel, so an install
 /// that ever stopped overriding it falls back to full releases rather than

--- a/crates/cli/src/commands/update.rs
+++ b/crates/cli/src/commands/update.rs
@@ -5,18 +5,21 @@ use kendex_core::env::Env;
 use kendex_core::install_channel::{Host, HostProbe, InstallChannel, for_cli};
 use kendex_core::names::shown;
 use kendex_core::process::Hardened;
+use kendex_core::update_channel::feed_url_for;
 use kendex_core::update_feed::{
-    RELEASE_FEED_URL, ReleaseFeed, UPDATER_PUBLIC_KEY, VersionRelation, app_image_signature_url,
-    app_image_url, release_notes_url, verify_signature,
+    ReleaseFeed, UPDATER_PUBLIC_KEY, VersionRelation, app_image_signature_url, app_image_url,
+    release_notes_url, verify_signature,
 };
 
 use super::{CliResult, out, say};
 
-/// The release feed is parsed by core so the CLI and app accept one schema.
-/// `KENDEX_UPDATE_FEED` overrides the URL so compat tests run against a
-/// local fixture instead of the network.
+/// The release feed is parsed by core so the CLI and app accept one schema,
+/// and core picks which feed off the running version so both shells follow
+/// one channel. `KENDEX_UPDATE_FEED` overrides the URL so compat tests run
+/// against a local fixture instead of the network.
 fn feed_url() -> String {
-    std::env::var("KENDEX_UPDATE_FEED").unwrap_or_else(|_| RELEASE_FEED_URL.to_owned())
+    std::env::var("KENDEX_UPDATE_FEED")
+        .unwrap_or_else(|_| feed_url_for(env!("CARGO_PKG_VERSION")).to_owned())
 }
 
 /// The feed keys its assets by the build target, one per lane in

--- a/crates/cli/tests/release_workflow/channel.rs
+++ b/crates/cli/tests/release_workflow/channel.rs
@@ -1,24 +1,58 @@
 //! The pre-release channel: how a tag whose version is a release candidate
 //! is published, and the one fixed release whose manifests every candidate
-//! reads its updates from. None of it runs on a pull request, and the two
-//! halves — the workflow's channel tag and the URLs core sends a candidate
-//! to — are one name in two files that only a tag run would otherwise put
-//! together.
+//! reads its updates from. None of it runs on a pull request, and the parts
+//! that have to agree — the workflow's idea of what a tag is against core's,
+//! and the workflow's channel tag against the URLs core sends a candidate
+//! to — are two files that only a tag run would otherwise put together.
 
 #[cfg(unix)]
 use std::fs;
 
-#[cfg(unix)]
-use crate::{run_script, test_util::rooted};
-use crate::{step, workflow};
+use crate::test_util::rooted;
+use crate::{run_script, step, workflow};
 
-/// The one GitHub expression this workflow's correctness rests on, in the
-/// only two shapes a tag takes here. Everything below evaluates it the way
-/// a runner would rather than transcribing what the file says, so an
-/// inverted `!` or a swapped pair fails here and not on a tag. An `if:` is
-/// already an expression and carries no delimiters; a `with:` input needs
-/// them, and without them would reach the action as its own literal text.
-fn contains_dash(expression: &str, ref_name: &str) -> bool {
+/// Whether core sends a build of this version to the pre-release channel.
+/// Every claim below about what the workflow should do is written against
+/// this rather than against a list, so the two cannot drift.
+fn core_calls_it_a_candidate(version: &str) -> bool {
+    kendex_core::update_channel::feed_url_for(version)
+        == kendex_core::update_channel::PRERELEASE_FEED_URL
+}
+
+/// Runs the classifier step for one tag and returns its exit code and the
+/// `prerelease` output it wrote, empty when it wrote none.
+#[allow(clippy::unwrap_used)]
+fn classify(ref_name: &str) -> (i32, String) {
+    let dir = tempfile::tempdir().unwrap();
+    let root = rooted(&dir);
+    let output = root.join("github.output");
+    std::fs::write(&output, "").unwrap();
+    let workflow = workflow();
+    let script = run_script(&step(&workflow, "name: Classify the tag"));
+    let run = std::process::Command::new("bash")
+        .arg("-e")
+        .arg("-c")
+        .arg(&script)
+        .env_clear()
+        .env("PATH", std::env::var("PATH").unwrap_or_default())
+        .env("GITHUB_REF_NAME", ref_name)
+        .env("GITHUB_OUTPUT", &output)
+        .output()
+        .unwrap();
+    let written = std::fs::read_to_string(&output).unwrap_or_default();
+    let value = written
+        .lines()
+        .find_map(|line| line.strip_prefix("prerelease="))
+        .unwrap_or_default()
+        .to_owned();
+    (run.status.code().unwrap_or(-1), value)
+}
+
+/// Evaluates one of the workflow's `steps.tag.outputs.prerelease == '…'`
+/// expressions against the value the classifier wrote, the way a runner
+/// would, rather than transcribing what the file says. An `if:` is already
+/// an expression and carries no delimiters; a `with:` input needs them.
+fn eval_flag(expression: &str, prerelease: &str) -> bool {
     let trimmed = expression.trim();
     let body = match trimmed.strip_prefix("${{") {
         Some(rest) => rest
@@ -27,20 +61,23 @@ fn contains_dash(expression: &str, ref_name: &str) -> bool {
             .trim(),
         None => trimmed,
     };
-    let (negated, call) = match body.strip_prefix('!') {
-        Some(rest) => (true, rest.trim()),
-        None => (false, body),
-    };
+    let (read, want) = body
+        .split_once("==")
+        .unwrap_or_else(|| panic!("not a comparison: {expression}"));
     assert_eq!(
-        call, "contains(github.ref_name, '-')",
-        "this test only evaluates the pre-release test; rewrite it for: {call}"
+        read.trim(),
+        "steps.tag.outputs.prerelease",
+        "this test only evaluates the classifier's output; rewrite it for: {expression}"
     );
-    ref_name.contains('-') != negated
+    prerelease == want.trim().trim_matches('\'')
 }
 
-/// The `with:` inputs of the release step, evaluated for one tag.
+/// The `draft` and `prerelease` inputs of the release step, evaluated for
+/// one tag through the classifier that feeds them.
 #[allow(clippy::unwrap_used)]
 fn publish_inputs(ref_name: &str) -> (bool, bool) {
+    let (code, prerelease) = classify(ref_name);
+    assert_eq!(code, 0, "{ref_name} did not classify");
     let workflow = workflow();
     let publish = step(&workflow, "uses: softprops/action-gh-release@v2");
     let input = |name: &str| {
@@ -54,9 +91,50 @@ fn publish_inputs(ref_name: &str) -> (bool, bool) {
             line.trim().starts_with("${{"),
             "{name} is a literal, not an expression: {line}"
         );
-        contains_dash(line, ref_name)
+        eval_flag(line, &prerelease)
     };
     (input("draft"), input("prerelease"))
+}
+
+/// The workflow and the build it produces have to mean the same thing by
+/// "candidate". SemVer keeps build metadata after a `+` and out of the
+/// version, so v1.0.0+build-1 is a full release that merely contains a
+/// dash — the tag shape that made the two halves disagree, and the reason
+/// this is asked of core rather than of a hand-written list.
+#[test]
+fn the_workflow_and_the_build_agree_on_what_a_candidate_is() {
+    for version in [
+        "1.0.0",
+        "5.0.1",
+        "10.2.3",
+        "1.0.0+build-1",
+        "1.0.0+1-2-3",
+        "1.0.0-rc1",
+        "1.0.0-rc2",
+        "5.1.0-beta.1",
+        "1.0.0-rc1+build-1",
+    ] {
+        let (code, prerelease) = classify(&format!("v{version}"));
+        assert_eq!(code, 0, "v{version} did not classify");
+        assert_eq!(
+            prerelease,
+            core_calls_it_a_candidate(version).to_string(),
+            "the workflow and core disagree about {version}"
+        );
+    }
+}
+
+/// A tag core cannot parse would reach the release channel while the
+/// workflow guessed from its punctuation, so the tag stops here instead.
+/// The version has to be the tag without its leading v, and a build whose
+/// version is not SemVer cannot compare itself to a feed at all.
+#[test]
+fn a_tag_that_is_not_semver_fails_the_job() {
+    for tag in ["v1.0", "vnightly-1", "v1.0.0.1", "release-1.0.0", "v1.0.0-"] {
+        let (code, prerelease) = classify(tag);
+        assert_ne!(code, 0, "{tag} was accepted as {prerelease}");
+        assert!(prerelease.is_empty(), "{tag} wrote {prerelease}");
+    }
 }
 
 /// A full release is still the draft `docs/RELEASING.md` describes, and a
@@ -66,11 +144,34 @@ fn publish_inputs(ref_name: &str) -> (bool, bool) {
 /// since GitHub resolves `latest` past pre-releases.
 #[test]
 fn a_candidate_publishes_and_a_full_release_stays_a_draft() {
-    for tag in ["v1.0.0", "v5.0.1", "v10.2.3"] {
+    for tag in ["v1.0.0", "v5.0.1", "v1.0.0+build-1"] {
         assert_eq!(publish_inputs(tag), (true, false), "{tag}");
     }
     for tag in ["v1.0.0-rc1", "v1.0.0-rc2", "v5.1.0-beta.1"] {
         assert_eq!(publish_inputs(tag), (false, true), "{tag}");
+    }
+}
+
+/// The step runs for a candidate and for nothing else. Running it on a full
+/// release would leave the candidates' channel pointing at a draft whose
+/// assets do not resolve, so a candidate would be offered an update that
+/// 404s until somebody published the draft by hand.
+#[test]
+fn the_channel_is_repointed_for_a_candidate_and_no_other_tag() {
+    let workflow = workflow();
+    let guard = step(&workflow, "name: Point the pre-release channel at this tag")
+        .iter()
+        .find_map(|l| l.trim().strip_prefix("if: "))
+        .expect("the channel step runs unconditionally")
+        .to_owned();
+    for tag in ["v1.0.0-rc1", "v1.0.0-rc2", "v1.0.0", "v1.0.0+build-1"] {
+        let (code, prerelease) = classify(tag);
+        assert_eq!(code, 0, "{tag} did not classify");
+        assert_eq!(
+            eval_flag(&guard, &prerelease),
+            core_calls_it_a_candidate(tag.trim_start_matches('v')),
+            "{tag}"
+        );
     }
 }
 
@@ -85,11 +186,26 @@ fn channel_step_env(name: &str) -> String {
         .to_owned()
 }
 
-/// Runs the pre-release channel step with `gh` stubbed, and returns every
-/// command line it ran. `channel_exists` is what `gh release view` answers.
+/// What one run of the channel step did.
+#[cfg(unix)]
+struct Pointed {
+    code: i32,
+    calls: Vec<String>,
+}
+
+#[cfg(unix)]
+impl Pointed {
+    fn ran(&self, verb: &str) -> Option<&String> {
+        self.calls.iter().find(|c| c.starts_with(verb))
+    }
+}
+
+/// Runs the pre-release channel step with `gh` stubbed. `carries` is the
+/// version the channel's own `latest.json` already names — `None` for a
+/// channel release that does not exist yet.
 #[cfg(unix)]
 #[allow(clippy::unwrap_used)]
-fn point_channel(channel_exists: bool) -> (i32, Vec<String>) {
+fn point_channel(carries: Option<&str>, new_version: &str) -> Pointed {
     use std::os::unix::fs::PermissionsExt;
     let dir = tempfile::tempdir().unwrap();
     let root = rooted(&dir);
@@ -101,12 +217,28 @@ fn point_channel(channel_exists: bool) -> (i32, Vec<String>) {
     let bin = root.join("bin");
     fs::create_dir_all(&bin).unwrap();
     let log = root.join("gh.log");
-    // `release view` is the only call whose answer changes the run; the
-    // stub records every call either way so the assertions can read them.
+    // Records every call, and answers the two the run reads: whether the
+    // channel release is there, and what its manifest says it carries.
+    // `--output` is honoured rather than assumed so a step that downloaded
+    // to some other name would read an empty version and be caught.
     fs::write(
         bin.join("gh"),
-        "#!/bin/sh\nprintf '%s\\n' \"$*\" >> \"$GH_LOG\"\n\
-         [ \"$1 $2\" = \"release view\" ] && exit \"$GH_VIEW_EXIT\"\nexit 0\n",
+        "#!/bin/sh\n\
+         printf '%s\\n' \"$*\" >> \"$GH_LOG\"\n\
+         if [ \"$1 $2\" = \"release view\" ]; then\n\
+           [ -n \"$GH_CARRIES\" ] || exit 1\n\
+           exit 0\n\
+         fi\n\
+         if [ \"$1 $2\" = \"release download\" ]; then\n\
+           [ -n \"$GH_CARRIES\" ] || exit 1\n\
+           while [ $# -gt 0 ]; do\n\
+             [ \"$1\" = \"--output\" ] && out=$2\n\
+             shift\n\
+           done\n\
+           [ -n \"$out\" ] || exit 1\n\
+           printf '{\"version\":\"%s\"}\\n' \"$GH_CARRIES\" > \"$out\"\n\
+         fi\n\
+         exit 0\n",
     )
     .unwrap();
     fs::set_permissions(bin.join("gh"), fs::Permissions::from_mode(0o755)).unwrap();
@@ -134,9 +266,10 @@ fn point_channel(channel_exists: bool) -> (i32, Vec<String>) {
             ),
         )
         .env("GH_LOG", &log)
-        .env("GH_VIEW_EXIT", if channel_exists { "0" } else { "1" })
+        .env("GH_CARRIES", carries.unwrap_or_default())
         .env("GITHUB_REPOSITORY", "vanillagreencom/kendex")
         .env("CHANNEL", channel_step_env("CHANNEL"))
+        .env("NEW_VERSION", new_version)
         .env("GH_TOKEN", "token")
         .output()
         .unwrap();
@@ -145,26 +278,9 @@ fn point_channel(channel_exists: bool) -> (i32, Vec<String>) {
         .lines()
         .map(str::to_owned)
         .collect();
-    (run.status.code().unwrap_or(-1), calls)
-}
-
-/// The step runs for a candidate and for nothing else. Running it on a full
-/// release would leave the candidates' channel pointing at a draft whose
-/// assets do not resolve, so a candidate would be offered an update that
-/// 404s until somebody published the draft by hand.
-#[test]
-fn the_channel_is_repointed_for_a_candidate_and_no_other_tag() {
-    let workflow = workflow();
-    let guard = step(&workflow, "name: Point the pre-release channel at this tag")
-        .iter()
-        .find_map(|l| l.trim().strip_prefix("if: "))
-        .expect("the channel step runs unconditionally")
-        .to_owned();
-    for tag in ["v1.0.0-rc1", "v1.0.0-rc2"] {
-        assert!(contains_dash(&guard, tag), "{tag}");
-    }
-    for tag in ["v1.0.0", "v5.0.1"] {
-        assert!(!contains_dash(&guard, tag), "{tag}");
+    Pointed {
+        code: run.status.code().unwrap_or(-1),
+        calls,
     }
 }
 
@@ -175,15 +291,18 @@ fn the_channel_is_repointed_for_a_candidate_and_no_other_tag() {
 #[cfg(unix)]
 #[test]
 fn every_candidate_replaces_both_manifests_on_the_channel() {
-    for exists in [true, false] {
-        let (code, calls) = point_channel(exists);
-        assert_eq!(code, 0, "exists={exists}: {calls:?}");
-        let created = calls.iter().any(|c| c.starts_with("release create"));
-        assert_eq!(created, !exists, "exists={exists}: {calls:?}");
-        let upload = calls
-            .iter()
-            .find(|c| c.starts_with("release upload"))
-            .unwrap_or_else(|| panic!("exists={exists} uploaded nothing: {calls:?}"));
+    for carries in [None, Some("1.0.0-rc1")] {
+        let run = point_channel(carries, "1.0.0-rc2");
+        assert_eq!(run.code, 0, "carries={carries:?}: {:?}", run.calls);
+        assert_eq!(
+            run.ran("release create").is_some(),
+            carries.is_none(),
+            "carries={carries:?}: {:?}",
+            run.calls
+        );
+        let upload = run
+            .ran("release upload")
+            .unwrap_or_else(|| panic!("carries={carries:?} uploaded nothing: {:?}", run.calls));
         // Named from the URLs rather than by hand: a manifest renamed on
         // one side and not the other publishes to a name nothing reads.
         for url in [
@@ -198,6 +317,82 @@ fn every_candidate_replaces_both_manifests_on_the_channel() {
         }
         assert!(upload.contains("--clobber"), "{upload}");
     }
+}
+
+/// Whether core reads `latest` as ahead of `running` — the same comparison
+/// the running build makes of the channel it is pointed at, and what the
+/// step in the workflow has to arrive at from bash.
+#[allow(clippy::unwrap_used)]
+fn core_reads_as_newer(latest: &str, running: &str) -> bool {
+    let feed =
+        format!(r#"{{"schema":1,"version":"{latest}","assets":{{"t":"https://example.test/k"}}}}"#);
+    kendex_core::update_feed::ReleaseFeed::parse(feed.as_bytes())
+        .unwrap()
+        .relation_to(running)
+        .unwrap()
+        == kendex_core::update_feed::VersionRelation::Newer
+}
+
+/// The channel only moves forward. A tag re-run after a later one would
+/// otherwise put its own older manifests back, and every candidate machine
+/// would quietly drop to that release and stop being offered anything —
+/// which on this channel is indistinguishable from the update path being
+/// broken, the very thing the channel exists to test.
+///
+/// The step's bash and core have to reach one answer, so the expectation
+/// is asked of core rather than written out: whatever a build would call
+/// newer is what the channel is allowed to move to.
+#[cfg(unix)]
+#[test]
+fn a_tag_behind_the_channel_leaves_it_alone() {
+    let versions = [
+        "1.0.0-rc1",
+        "1.0.0-rc2",
+        "1.0.0-rc9",
+        "1.0.0-rc10",
+        "1.0.0-beta.1",
+        "1.1.0-rc1",
+        "2.0.0-rc1",
+        "1.0.0-rc2+build",
+    ];
+    for carried in versions {
+        for tagged in versions {
+            let run = point_channel(Some(carried), tagged);
+            assert_eq!(run.code, 0, "{carried} -> {tagged}: {:?}", run.calls);
+            // Equal versions re-run the same tag, which refreshes rather
+            // than rolls back, so only a strictly newer carried version
+            // holds the channel.
+            let refused = core_reads_as_newer(carried, tagged);
+            assert_eq!(
+                run.ran("release upload").is_none(),
+                refused,
+                "channel carries {carried}, tag is {tagged}: {:?}",
+                run.calls
+            );
+        }
+    }
+}
+
+/// Two tag runs that interleave a read and a write would leave the older
+/// manifests on the channel however carefully each one compares, so the
+/// job that owns the channel takes a concurrency group and the runs queue.
+/// Cancelling instead would answer a tag with no release at all.
+#[test]
+fn two_publishes_cannot_interleave_their_writes_to_the_channel() {
+    let workflow = workflow();
+    let publish: Vec<&str> = workflow
+        .lines()
+        .skip_while(|l| l.trim() != "publish:")
+        .take_while(|l| l.trim() != "steps:")
+        .collect();
+    let value = |key: &str| {
+        publish
+            .iter()
+            .find_map(|l| l.trim().strip_prefix(&format!("{key}: ")))
+            .unwrap_or_else(|| panic!("the publish job declares no {key}:\n{publish:#?}"))
+    };
+    assert!(!value("group").is_empty());
+    assert_eq!(value("cancel-in-progress"), "false");
 }
 
 /// The channel tag in the workflow and the URLs core sends a candidate to

--- a/crates/cli/tests/release_workflow/channel.rs
+++ b/crates/cli/tests/release_workflow/channel.rs
@@ -364,9 +364,10 @@ fn point_channel(channel: Channel, new_version: &str, fail: Option<&str>) -> Poi
     let log = root.join("gh.log");
     // Records every call and answers the three the run reads: whether the
     // channel is among the repository's releases, whether it carries a
-    // manifest, and what that manifest says. `--output` is honoured rather
-    // than assumed, so a step downloading to some other name would read no
-    // version and be caught.
+    // manifest, and what those manifests say. `--dir` and `--pattern` are
+    // honoured rather than assumed, so a step that downloaded somewhere
+    // else, or stopped asking for one of the two manifests, has nothing on
+    // disk to read back or to put back.
     fs::write(
         bin.join("gh"),
         "#!/bin/sh\n\
@@ -386,11 +387,18 @@ fn point_channel(channel: Channel, new_version: &str, fail: Option<&str>) -> Poi
          esac\n\
          if [ \"$1 $2\" = \"release download\" ]; then\n\
            while [ $# -gt 0 ]; do\n\
-             [ \"$1\" = \"--output\" ] && out=$2\n\
+             [ \"$1\" = \"--dir\" ] && dir=$2\n\
+             [ \"$1\" = \"--pattern\" ] && want=\"$want $2\"\n\
              shift\n\
            done\n\
-           [ -n \"$out\" ] || exit 1\n\
-           printf '%s\\n' \"$GH_MANIFEST\" > \"$out\"\n\
+           [ -n \"$dir\" ] || exit 1\n\
+           mkdir -p \"$dir\"\n\
+           for name in $want; do\n\
+             case \"$name\" in\n\
+               latest.json) printf '%s\\n' \"$GH_MANIFEST\" > \"$dir/latest.json\" ;;\n\
+               feed.json) printf '%s\\n' \"$GH_FEED\" > \"$dir/feed.json\" ;;\n\
+             esac\n\
+           done\n\
          fi\n\
          exit 0\n",
     )
@@ -430,6 +438,10 @@ fn point_channel(channel: Channel, new_version: &str, fail: Option<&str>) -> Poi
         .env("GH_EXISTS", exists)
         .env("GH_HAS_MANIFEST", has_manifest)
         .env("GH_MANIFEST", &manifest)
+        .env(
+            "GH_FEED",
+            r#"{"schema":1,"version":"published","assets":{}}"#,
+        )
         .env("GH_FAIL", fail.unwrap_or_default())
         .env("GITHUB_REPOSITORY", "vanillagreencom/kendex")
         .env("CHANNEL", channel_step_env("CHANNEL"))
@@ -514,6 +526,41 @@ fn every_candidate_replaces_both_manifests_on_the_channel() {
         }
         assert!(upload.contains("--clobber"), "{upload}");
     }
+}
+
+/// `gh release upload --clobber` deletes an asset before uploading its
+/// replacement, and says in its own help that a failed upload loses the
+/// original. A candidate reading a channel with no `latest.json` sees no
+/// update at all, so an upload that fell over halfway would break every
+/// candidate machine until somebody re-ran a tag. What came down goes back
+/// up. Not an atomic swap — there is no such thing here — but a failure
+/// that leaves the channel as it found it.
+#[cfg(unix)]
+#[test]
+fn a_failed_upload_puts_back_what_the_channel_had() {
+    let run = point_channel(
+        Channel::Carrying("1.0.0-rc1"),
+        "1.0.0-rc2",
+        Some("dist/latest.json"),
+    );
+    assert_ne!(
+        run.code, 0,
+        "a failed upload was survivable: {:?}",
+        run.calls
+    );
+    let restored = run
+        .calls
+        .iter()
+        .filter(|c| c.starts_with("release upload"))
+        .nth(1)
+        .unwrap_or_else(|| panic!("nothing was put back: {:?}", run.calls));
+    // Both names, and from the copies on disk: the shell expanded the glob
+    // against what the download actually wrote, so a manifest that never
+    // came down could not appear here.
+    for name in ["saved/latest.json", "saved/feed.json"] {
+        assert!(restored.contains(name), "{name} not restored: {restored}");
+    }
+    assert!(restored.contains("--clobber"), "{restored}");
 }
 
 /// Whether core reads `latest` as ahead of `running` — the same comparison

--- a/crates/cli/tests/release_workflow/channel.rs
+++ b/crates/cli/tests/release_workflow/channel.rs
@@ -1,0 +1,219 @@
+//! The pre-release channel: how a tag whose version is a release candidate
+//! is published, and the one fixed release whose manifests every candidate
+//! reads its updates from. None of it runs on a pull request, and the two
+//! halves — the workflow's channel tag and the URLs core sends a candidate
+//! to — are one name in two files that only a tag run would otherwise put
+//! together.
+
+#[cfg(unix)]
+use std::fs;
+
+#[cfg(unix)]
+use crate::{run_script, test_util::rooted};
+use crate::{step, workflow};
+
+/// The one GitHub expression this workflow's correctness rests on, in the
+/// only two shapes a tag takes here. Everything below evaluates it the way
+/// a runner would rather than transcribing what the file says, so an
+/// inverted `!` or a swapped pair fails here and not on a tag. An `if:` is
+/// already an expression and carries no delimiters; a `with:` input needs
+/// them, and without them would reach the action as its own literal text.
+fn contains_dash(expression: &str, ref_name: &str) -> bool {
+    let trimmed = expression.trim();
+    let body = match trimmed.strip_prefix("${{") {
+        Some(rest) => rest
+            .strip_suffix("}}")
+            .unwrap_or_else(|| panic!("unclosed GitHub expression: {expression}"))
+            .trim(),
+        None => trimmed,
+    };
+    let (negated, call) = match body.strip_prefix('!') {
+        Some(rest) => (true, rest.trim()),
+        None => (false, body),
+    };
+    assert_eq!(
+        call, "contains(github.ref_name, '-')",
+        "this test only evaluates the pre-release test; rewrite it for: {call}"
+    );
+    ref_name.contains('-') != negated
+}
+
+/// The `with:` inputs of the release step, evaluated for one tag.
+#[allow(clippy::unwrap_used)]
+fn publish_inputs(ref_name: &str) -> (bool, bool) {
+    let workflow = workflow();
+    let publish = step(&workflow, "uses: softprops/action-gh-release@v2");
+    let input = |name: &str| {
+        let line = publish
+            .iter()
+            .find_map(|l| l.trim().strip_prefix(&format!("{name}: ")))
+            .unwrap_or_else(|| panic!("the release step declares no {name}"));
+        // A `with:` input outside `${{ }}` reaches the action as that text,
+        // and every non-empty string reads as true there.
+        assert!(
+            line.trim().starts_with("${{"),
+            "{name} is a literal, not an expression: {line}"
+        );
+        contains_dash(line, ref_name)
+    };
+    (input("draft"), input("prerelease"))
+}
+
+/// A full release is still the draft `docs/RELEASING.md` describes, and a
+/// candidate is published outright. Published is the whole point: a draft's
+/// assets are unreachable, so a candidate nobody can download tests
+/// nothing. Marked pre-release is what keeps it away from everyone else,
+/// since GitHub resolves `latest` past pre-releases.
+#[test]
+fn a_candidate_publishes_and_a_full_release_stays_a_draft() {
+    for tag in ["v1.0.0", "v5.0.1", "v10.2.3"] {
+        assert_eq!(publish_inputs(tag), (true, false), "{tag}");
+    }
+    for tag in ["v1.0.0-rc1", "v1.0.0-rc2", "v5.1.0-beta.1"] {
+        assert_eq!(publish_inputs(tag), (false, true), "{tag}");
+    }
+}
+
+/// One value of the pre-release channel step's `env:` block.
+#[allow(clippy::unwrap_used)]
+fn channel_step_env(name: &str) -> String {
+    let workflow = workflow();
+    step(&workflow, "name: Point the pre-release channel at this tag")
+        .iter()
+        .find_map(|l| l.trim().strip_prefix(&format!("{name}: ")))
+        .unwrap_or_else(|| panic!("the channel step sets no {name}"))
+        .to_owned()
+}
+
+/// Runs the pre-release channel step with `gh` stubbed, and returns every
+/// command line it ran. `channel_exists` is what `gh release view` answers.
+#[cfg(unix)]
+#[allow(clippy::unwrap_used)]
+fn point_channel(channel_exists: bool) -> (i32, Vec<String>) {
+    use std::os::unix::fs::PermissionsExt;
+    let dir = tempfile::tempdir().unwrap();
+    let root = rooted(&dir);
+    let dist = root.join("dist");
+    fs::create_dir_all(&dist).unwrap();
+    for name in ["latest.json", "feed.json"] {
+        fs::write(dist.join(name), "{}").unwrap();
+    }
+    let bin = root.join("bin");
+    fs::create_dir_all(&bin).unwrap();
+    let log = root.join("gh.log");
+    // `release view` is the only call whose answer changes the run; the
+    // stub records every call either way so the assertions can read them.
+    fs::write(
+        bin.join("gh"),
+        "#!/bin/sh\nprintf '%s\\n' \"$*\" >> \"$GH_LOG\"\n\
+         [ \"$1 $2\" = \"release view\" ] && exit \"$GH_VIEW_EXIT\"\nexit 0\n",
+    )
+    .unwrap();
+    fs::set_permissions(bin.join("gh"), fs::Permissions::from_mode(0o755)).unwrap();
+
+    let workflow = workflow();
+    let script = run_script(&step(
+        &workflow,
+        "name: Point the pre-release channel at this tag",
+    ));
+    // `shell: bash` on a runner is `bash -e`, so a failed `gh` fails the
+    // step. Without it the exit code below is the last command's alone and
+    // an upload that never landed would read as a run that worked.
+    let run = std::process::Command::new("bash")
+        .arg("-e")
+        .arg("-c")
+        .arg(&script)
+        .current_dir(&root)
+        .env_clear()
+        .env(
+            "PATH",
+            format!(
+                "{}:{}",
+                bin.display(),
+                std::env::var("PATH").unwrap_or_default()
+            ),
+        )
+        .env("GH_LOG", &log)
+        .env("GH_VIEW_EXIT", if channel_exists { "0" } else { "1" })
+        .env("GITHUB_REPOSITORY", "vanillagreencom/kendex")
+        .env("CHANNEL", channel_step_env("CHANNEL"))
+        .env("GH_TOKEN", "token")
+        .output()
+        .unwrap();
+    let calls = fs::read_to_string(&log)
+        .unwrap_or_default()
+        .lines()
+        .map(str::to_owned)
+        .collect();
+    (run.status.code().unwrap_or(-1), calls)
+}
+
+/// The step runs for a candidate and for nothing else. Running it on a full
+/// release would leave the candidates' channel pointing at a draft whose
+/// assets do not resolve, so a candidate would be offered an update that
+/// 404s until somebody published the draft by hand.
+#[test]
+fn the_channel_is_repointed_for_a_candidate_and_no_other_tag() {
+    let workflow = workflow();
+    let guard = step(&workflow, "name: Point the pre-release channel at this tag")
+        .iter()
+        .find_map(|l| l.trim().strip_prefix("if: "))
+        .expect("the channel step runs unconditionally")
+        .to_owned();
+    for tag in ["v1.0.0-rc1", "v1.0.0-rc2"] {
+        assert!(contains_dash(&guard, tag), "{tag}");
+    }
+    for tag in ["v1.0.0", "v5.0.1"] {
+        assert!(!contains_dash(&guard, tag), "{tag}");
+    }
+}
+
+/// Both manifests reach the channel whether or not the release behind it
+/// exists yet, and the upload replaces what is there. Without `--clobber`
+/// the first candidate's manifests stay and every later one is refused, so
+/// the channel would freeze on rc1 while reporting success.
+#[cfg(unix)]
+#[test]
+fn every_candidate_replaces_both_manifests_on_the_channel() {
+    for exists in [true, false] {
+        let (code, calls) = point_channel(exists);
+        assert_eq!(code, 0, "exists={exists}: {calls:?}");
+        let created = calls.iter().any(|c| c.starts_with("release create"));
+        assert_eq!(created, !exists, "exists={exists}: {calls:?}");
+        let upload = calls
+            .iter()
+            .find(|c| c.starts_with("release upload"))
+            .unwrap_or_else(|| panic!("exists={exists} uploaded nothing: {calls:?}"));
+        // Named from the URLs rather than by hand: a manifest renamed on
+        // one side and not the other publishes to a name nothing reads.
+        for url in [
+            kendex_core::update_channel::PRERELEASE_FEED_URL,
+            kendex_core::update_channel::PRERELEASE_MANIFEST_URL,
+        ] {
+            let file = url.rsplit('/').next().unwrap_or_default();
+            assert!(
+                upload.contains(&format!("dist/{file}")),
+                "dist/{file} missing from {upload}"
+            );
+        }
+        assert!(upload.contains("--clobber"), "{upload}");
+    }
+}
+
+/// The channel tag in the workflow and the URLs core sends a candidate to
+/// are one name in two files, and a tag run is the only thing that would
+/// otherwise put them together. A rename on either side leaves candidates
+/// reading a URL nothing publishes to, which reads to them as up to date.
+#[test]
+fn the_channel_tag_is_the_one_core_sends_a_candidate_to() {
+    let channel = channel_step_env("CHANNEL");
+    for url in [
+        kendex_core::update_channel::PRERELEASE_FEED_URL,
+        kendex_core::update_channel::PRERELEASE_MANIFEST_URL,
+    ] {
+        assert!(
+            url.contains(&format!("/releases/download/{channel}/")),
+            "{url} is not served from the {channel} release"
+        );
+    }
+}

--- a/crates/cli/tests/release_workflow/channel.rs
+++ b/crates/cli/tests/release_workflow/channel.rs
@@ -19,33 +19,69 @@ fn core_calls_it_a_candidate(version: &str) -> bool {
         == kendex_core::update_channel::PRERELEASE_FEED_URL
 }
 
-/// Runs the classifier step for one tag and returns its exit code and the
-/// `prerelease` output it wrote, empty when it wrote none.
+/// The CLI the classifier reads the built version back from, named the way
+/// the staging step leaves it in `dist/`. A release job runs on Linux
+/// x86_64, so this is the one lane's binary it can execute.
+const BUILT_CLI: &str = "kendex-x86_64-unknown-linux-gnu";
+
+/// Runs the classifier step for one tag against a `dist/` holding `cli` as
+/// the release binary. Returns the exit code and the `prerelease` output,
+/// empty when it wrote none.
+#[cfg(unix)]
 #[allow(clippy::unwrap_used)]
-fn classify(ref_name: &str) -> (i32, String) {
+fn classify_with_cli(ref_name: &str, cli: &str) -> (i32, String) {
+    use std::os::unix::fs::PermissionsExt;
     let dir = tempfile::tempdir().unwrap();
     let root = rooted(&dir);
     let output = root.join("github.output");
-    std::fs::write(&output, "").unwrap();
+    fs::write(&output, "").unwrap();
+    let dist = root.join("dist");
+    fs::create_dir_all(&dist).unwrap();
+    // Written without the executable bit, because the artifact upload does
+    // not carry one across either — the step has to restore it.
+    fs::write(dist.join(BUILT_CLI), cli).unwrap();
+    fs::set_permissions(dist.join(BUILT_CLI), fs::Permissions::from_mode(0o644)).unwrap();
+
     let workflow = workflow();
     let script = run_script(&step(&workflow, "name: Classify the tag"));
     let run = std::process::Command::new("bash")
         .arg("-e")
         .arg("-c")
         .arg(&script)
+        .current_dir(&root)
         .env_clear()
         .env("PATH", std::env::var("PATH").unwrap_or_default())
         .env("GITHUB_REF_NAME", ref_name)
         .env("GITHUB_OUTPUT", &output)
         .output()
         .unwrap();
-    let written = std::fs::read_to_string(&output).unwrap_or_default();
+    let written = fs::read_to_string(&output).unwrap_or_default();
     let value = written
         .lines()
         .find_map(|line| line.strip_prefix("prerelease="))
         .unwrap_or_default()
         .to_owned();
     (run.status.code().unwrap_or(-1), value)
+}
+
+/// A release binary that answers `--version` out of the version Cargo
+/// built it with, the way the real one does.
+#[cfg(unix)]
+fn cli_built_as(version: &str) -> String {
+    format!("#!/bin/sh\nprintf 'kendex %s\\n' '{version}'\n")
+}
+
+/// A run against a release built as `built`.
+#[cfg(unix)]
+fn classify_built_as(ref_name: &str, built: &str) -> (i32, String) {
+    classify_with_cli(ref_name, &cli_built_as(built))
+}
+
+/// The ordinary case: the tag and the build agree, which is what every
+/// claim about classification is about.
+#[cfg(unix)]
+fn classify(ref_name: &str) -> (i32, String) {
+    classify_built_as(ref_name, ref_name.trim_start_matches('v'))
 }
 
 /// Evaluates one of the workflow's `steps.tag.outputs.prerelease == '…'`
@@ -74,6 +110,7 @@ fn eval_flag(expression: &str, prerelease: &str) -> bool {
 
 /// The `draft` and `prerelease` inputs of the release step, evaluated for
 /// one tag through the classifier that feeds them.
+#[cfg(unix)]
 #[allow(clippy::unwrap_used)]
 fn publish_inputs(ref_name: &str) -> (bool, bool) {
     let (code, prerelease) = classify(ref_name);
@@ -101,6 +138,7 @@ fn publish_inputs(ref_name: &str) -> (bool, bool) {
 /// version, so v1.0.0+build-1 is a full release that merely contains a
 /// dash — the tag shape that made the two halves disagree, and the reason
 /// this is asked of core rather than of a hand-written list.
+#[cfg(unix)]
 #[test]
 fn the_workflow_and_the_build_agree_on_what_a_candidate_is() {
     for version in [
@@ -124,17 +162,107 @@ fn the_workflow_and_the_build_agree_on_what_a_candidate_is() {
     }
 }
 
-/// A tag core cannot parse would reach the release channel while the
-/// workflow guessed from its punctuation, so the tag stops here instead.
-/// The version has to be the tag without its leading v, and a build whose
-/// version is not SemVer cannot compare itself to a feed at all.
+/// Versions no release can be built as, because Cargo runs the same parser
+/// core does and refuses them. Each is a shape a regex written to stand in
+/// for that parser waves through: a leading zero in the core, a numeric
+/// pre-release identifier with a leading zero, an empty identifier, and an
+/// empty build. Published, each would name a manifest version every
+/// candidate then fails to read.
+const REFUSED_VERSIONS: [&str; 6] = [
+    "01.0.0",
+    "1.0.0-01",
+    "1.0.0-alpha..1",
+    "1.0.0+",
+    "1.0",
+    "1.0.0.1",
+];
+
+/// Why those four must never reach a manifest, asked of core rather than
+/// asserted from the shapes. The valid versions beside them are the ones
+/// they shadow — a pre-release identifier may be a bare zero, and may be
+/// alphanumeric with dots — so this cannot pass by refusing everything.
 #[test]
-fn a_tag_that_is_not_semver_fails_the_job() {
-    for tag in ["v1.0", "vnightly-1", "v1.0.0.1", "release-1.0.0", "v1.0.0-"] {
-        let (code, prerelease) = classify(tag);
-        assert_ne!(code, 0, "{tag} was accepted as {prerelease}");
+fn core_refuses_the_versions_a_regex_would_wave_through() {
+    for version in REFUSED_VERSIONS {
+        assert!(
+            !core_can_read(version),
+            "{version} reads, so it is not an example of anything"
+        );
+    }
+    for version in ["1.0.0-0", "1.0.0-alpha.1", "1.0.0+build.1", "1.0.0-rc1+b"] {
+        assert!(core_can_read(version), "{version}");
+    }
+}
+
+/// What a candidate reading the channel's manifest makes of a version:
+/// `ReleaseFeed::parse` is what runs on it on every machine, and a version
+/// it refuses stops that install from seeing any update at all.
+fn core_can_read(version: &str) -> bool {
+    let feed = format!(r#"{{"schema":1,"version":"{version}","assets":{{}}}}"#);
+    kendex_core::update_feed::ReleaseFeed::parse(feed.as_bytes()).is_ok()
+}
+
+/// The tag has to be the version the release was built as. That is what
+/// keeps the refused versions above out: none of them can be a Cargo
+/// version, so no build reports one, and a tag naming one cannot match.
+/// It also catches a tag that is perfectly good SemVer and still wrong —
+/// v1.0.1 over a 1.0.0 build publishes a feed naming downloads that were
+/// never uploaded, which a regex could never have seen.
+#[cfg(unix)]
+#[test]
+fn a_tag_that_is_not_the_version_built_fails_the_job() {
+    for tag in REFUSED_VERSIONS {
+        let (code, prerelease) = classify_built_as(&format!("v{tag}"), "1.0.0");
+        assert_ne!(code, 0, "v{tag} was accepted as {prerelease}");
+        assert!(prerelease.is_empty(), "v{tag} wrote {prerelease}");
+    }
+    // Both directions of a plain mismatch, and the leading v is not part
+    // of the version on either side of the comparison.
+    for (tag, built) in [
+        ("v1.0.1", "1.0.0"),
+        ("v1.0.0", "1.0.1"),
+        ("v1.0.0", "1.0.0-rc1"),
+        ("v1.0.0-rc1", "1.0.0"),
+    ] {
+        let (code, prerelease) = classify_built_as(tag, built);
+        assert_ne!(code, 0, "{tag} over a {built} build was accepted");
         assert!(prerelease.is_empty(), "{tag} wrote {prerelease}");
     }
+}
+
+/// A release whose CLI cannot be run, or that answers nothing, says
+/// nothing about what it was built as. Either way the tag stops rather
+/// than being classified on a guess about its own text — which is the
+/// whole of what a run has to go on once the parser is out of reach.
+#[cfg(unix)]
+#[test]
+fn a_release_that_cannot_report_its_version_fails_the_job() {
+    for cli in [
+        "#!/bin/sh\nexit 1\n",
+        "#!/bin/sh\necho 'kendex 1.0.0'\nexit 1\n",
+        "#!/bin/sh\n",
+        "not a program at all\n",
+    ] {
+        let (code, prerelease) = classify_with_cli("v1.0.0", cli);
+        assert_ne!(code, 0, "{cli:?} was accepted as {prerelease}");
+        assert!(prerelease.is_empty(), "{cli:?} wrote {prerelease}");
+    }
+}
+
+/// The name the classifier reaches for is the one a tag run actually
+/// leaves in `dist/`. Renamed on either side, the step reads nothing and
+/// every tag stops at a version it cannot find.
+#[cfg(unix)]
+#[test]
+fn the_classifier_reads_a_binary_the_release_stages() {
+    assert!(
+        crate::release().dist.contains_key(BUILT_CLI),
+        "no lane stages {BUILT_CLI}"
+    );
+    assert!(
+        run_script(&step(&workflow(), "name: Classify the tag")).contains(BUILT_CLI),
+        "the classifier does not read {BUILT_CLI}"
+    );
 }
 
 /// A full release is still the draft `docs/RELEASING.md` describes, and a
@@ -142,6 +270,7 @@ fn a_tag_that_is_not_semver_fails_the_job() {
 /// assets are unreachable, so a candidate nobody can download tests
 /// nothing. Marked pre-release is what keeps it away from everyone else,
 /// since GitHub resolves `latest` past pre-releases.
+#[cfg(unix)]
 #[test]
 fn a_candidate_publishes_and_a_full_release_stays_a_draft() {
     for tag in ["v1.0.0", "v5.0.1", "v1.0.0+build-1"] {
@@ -156,6 +285,7 @@ fn a_candidate_publishes_and_a_full_release_stays_a_draft() {
 /// release would leave the candidates' channel pointing at a draft whose
 /// assets do not resolve, so a candidate would be offered an update that
 /// 404s until somebody published the draft by hand.
+#[cfg(unix)]
 #[test]
 fn the_channel_is_repointed_for_a_candidate_and_no_other_tag() {
     let workflow = workflow();
@@ -200,12 +330,27 @@ impl Pointed {
     }
 }
 
-/// Runs the pre-release channel step with `gh` stubbed. `carries` is the
-/// version the channel's own `latest.json` already names — `None` for a
-/// channel release that does not exist yet.
+/// The state of the pre-release channel a run finds.
+#[cfg(unix)]
+#[derive(Clone, Copy, Debug)]
+enum Channel<'a> {
+    /// No channel release published yet.
+    Absent,
+    /// Published, with nothing uploaded to it — the one state that leaves
+    /// the guard with no version to compare and lets the write through.
+    Empty,
+    /// Published, its manifest naming this version.
+    Carrying(&'a str),
+    /// Published, with a manifest that names no version at all.
+    Unreadable,
+}
+
+/// Runs the pre-release channel step with `gh` stubbed. `fail` is a
+/// fragment of the one `gh` call that should fail, standing in for the
+/// transient errors every read here has to tell apart from an answer.
 #[cfg(unix)]
 #[allow(clippy::unwrap_used)]
-fn point_channel(carries: Option<&str>, new_version: &str) -> Pointed {
+fn point_channel(channel: Channel, new_version: &str, fail: Option<&str>) -> Pointed {
     use std::os::unix::fs::PermissionsExt;
     let dir = tempfile::tempdir().unwrap();
     let root = rooted(&dir);
@@ -217,31 +362,47 @@ fn point_channel(carries: Option<&str>, new_version: &str) -> Pointed {
     let bin = root.join("bin");
     fs::create_dir_all(&bin).unwrap();
     let log = root.join("gh.log");
-    // Records every call, and answers the two the run reads: whether the
-    // channel release is there, and what its manifest says it carries.
-    // `--output` is honoured rather than assumed so a step that downloaded
-    // to some other name would read an empty version and be caught.
+    // Records every call and answers the three the run reads: whether the
+    // channel is among the repository's releases, whether it carries a
+    // manifest, and what that manifest says. `--output` is honoured rather
+    // than assumed, so a step downloading to some other name would read no
+    // version and be caught.
     fs::write(
         bin.join("gh"),
         "#!/bin/sh\n\
          printf '%s\\n' \"$*\" >> \"$GH_LOG\"\n\
-         if [ \"$1 $2\" = \"release view\" ]; then\n\
-           [ -n \"$GH_CARRIES\" ] || exit 1\n\
-           exit 0\n\
+         if [ -n \"$GH_FAIL\" ]; then\n\
+           case \"$*\" in *\"$GH_FAIL\"*) exit 1 ;; esac\n\
          fi\n\
+         case \"$2\" in\n\
+           */releases)\n\
+             [ -n \"$GH_EXISTS\" ] && printf '%s\\n' \"$CHANNEL\"\n\
+             exit 0\n\
+             ;;\n\
+           */releases/tags/*)\n\
+             [ -n \"$GH_HAS_MANIFEST\" ] && printf 'latest.json\\n'\n\
+             exit 0\n\
+             ;;\n\
+         esac\n\
          if [ \"$1 $2\" = \"release download\" ]; then\n\
-           [ -n \"$GH_CARRIES\" ] || exit 1\n\
            while [ $# -gt 0 ]; do\n\
              [ \"$1\" = \"--output\" ] && out=$2\n\
              shift\n\
            done\n\
            [ -n \"$out\" ] || exit 1\n\
-           printf '{\"version\":\"%s\"}\\n' \"$GH_CARRIES\" > \"$out\"\n\
+           printf '%s\\n' \"$GH_MANIFEST\" > \"$out\"\n\
          fi\n\
          exit 0\n",
     )
     .unwrap();
     fs::set_permissions(bin.join("gh"), fs::Permissions::from_mode(0o755)).unwrap();
+
+    let (exists, has_manifest, manifest) = match channel {
+        Channel::Absent => ("", "", String::new()),
+        Channel::Empty => ("1", "", String::new()),
+        Channel::Carrying(version) => ("1", "1", format!(r#"{{"version":"{version}"}}"#)),
+        Channel::Unreadable => ("1", "1", "{}".to_owned()),
+    };
 
     let workflow = workflow();
     let script = run_script(&step(
@@ -266,7 +427,10 @@ fn point_channel(carries: Option<&str>, new_version: &str) -> Pointed {
             ),
         )
         .env("GH_LOG", &log)
-        .env("GH_CARRIES", carries.unwrap_or_default())
+        .env("GH_EXISTS", exists)
+        .env("GH_HAS_MANIFEST", has_manifest)
+        .env("GH_MANIFEST", &manifest)
+        .env("GH_FAIL", fail.unwrap_or_default())
         .env("GITHUB_REPOSITORY", "vanillagreencom/kendex")
         .env("CHANNEL", channel_step_env("CHANNEL"))
         .env("NEW_VERSION", new_version)
@@ -284,6 +448,35 @@ fn point_channel(carries: Option<&str>, new_version: &str) -> Pointed {
     }
 }
 
+/// A read that failed is not an empty channel. Every one of these leaves
+/// the guard unable to say what the channel carries, and a run that
+/// treated that as "nothing there" would upload over whatever is — which
+/// is the rollback the guard exists to prevent, reached through a lost
+/// connection instead of a stale tag.
+#[cfg(unix)]
+#[test]
+fn a_read_it_could_not_make_stops_the_write() {
+    for (state, failing) in [
+        (Channel::Carrying("2.0.0-rc1"), "/releases --paginate"),
+        (Channel::Carrying("2.0.0-rc1"), "/releases/tags/"),
+        (Channel::Carrying("2.0.0-rc1"), "release download"),
+    ] {
+        let run = point_channel(state, "1.0.0-rc1", Some(failing));
+        assert_ne!(run.code, 0, "{failing} was survivable: {:?}", run.calls);
+        assert!(
+            run.ran("release upload").is_none(),
+            "{failing} still uploaded: {:?}",
+            run.calls
+        );
+    }
+
+    // A manifest that names no version is the same answer: nothing here
+    // can tell whether this tag is ahead of what is published.
+    let run = point_channel(Channel::Unreadable, "1.0.0-rc1", None);
+    assert_ne!(run.code, 0, "an unreadable manifest was survivable");
+    assert!(run.ran("release upload").is_none(), "{:?}", run.calls);
+}
+
 /// Both manifests reach the channel whether or not the release behind it
 /// exists yet, and the upload replaces what is there. Without `--clobber`
 /// the first candidate's manifests stay and every later one is refused, so
@@ -291,18 +484,22 @@ fn point_channel(carries: Option<&str>, new_version: &str) -> Pointed {
 #[cfg(unix)]
 #[test]
 fn every_candidate_replaces_both_manifests_on_the_channel() {
-    for carries in [None, Some("1.0.0-rc1")] {
-        let run = point_channel(carries, "1.0.0-rc2");
-        assert_eq!(run.code, 0, "carries={carries:?}: {:?}", run.calls);
+    for state in [
+        Channel::Absent,
+        Channel::Empty,
+        Channel::Carrying("1.0.0-rc1"),
+    ] {
+        let run = point_channel(state, "1.0.0-rc2", None);
+        assert_eq!(run.code, 0, "{state:?}: {:?}", run.calls);
         assert_eq!(
             run.ran("release create").is_some(),
-            carries.is_none(),
-            "carries={carries:?}: {:?}",
+            matches!(state, Channel::Absent),
+            "{state:?}: {:?}",
             run.calls
         );
         let upload = run
             .ran("release upload")
-            .unwrap_or_else(|| panic!("carries={carries:?} uploaded nothing: {:?}", run.calls));
+            .unwrap_or_else(|| panic!("{state:?} uploaded nothing: {:?}", run.calls));
         // Named from the URLs rather than by hand: a manifest renamed on
         // one side and not the other publishes to a name nothing reads.
         for url in [
@@ -357,7 +554,7 @@ fn a_tag_behind_the_channel_leaves_it_alone() {
     ];
     for carried in versions {
         for tagged in versions {
-            let run = point_channel(Some(carried), tagged);
+            let run = point_channel(Channel::Carrying(carried), tagged, None);
             assert_eq!(run.code, 0, "{carried} -> {tagged}: {:?}", run.calls);
             // Equal versions re-run the same tag, which refreshes rather
             // than rolls back, so only a strictly newer carried version

--- a/crates/cli/tests/release_workflow/main.rs
+++ b/crates/cli/tests/release_workflow/main.rs
@@ -13,6 +13,9 @@ use std::fs;
 use std::path::Path;
 use std::sync::OnceLock;
 
+#[path = "../../../test_util.rs"]
+mod test_util;
+
 const TARGET_EXPR: &str = "${{ matrix.target }}";
 
 #[allow(clippy::unwrap_used)]
@@ -609,3 +612,5 @@ fn no_lane_triple_is_hardcoded_into_build_or_staging() {
         }
     }
 }
+
+mod channel;

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -46,5 +46,6 @@ pub mod source_ops;
 pub mod source_read;
 pub mod source_ref;
 pub mod tags;
+pub mod update_channel;
 pub mod update_feed;
 pub mod vendor;

--- a/crates/core/src/update_channel.rs
+++ b/crates/core/src/update_channel.rs
@@ -1,0 +1,95 @@
+//! Which release channel a build follows, and where that channel's two
+//! manifests are served from. Reading the feed is `update_feed`'s job;
+//! this module only decides which one to read.
+
+use semver::Version;
+
+pub const RELEASE_FEED_URL: &str =
+    "https://github.com/vanillagreencom/kendex/releases/latest/download/feed.json";
+/// The manifest the app's updater installs a full release from. `latest`
+/// is GitHub's own word for the newest release that is neither a draft nor
+/// a pre-release, so both release-channel URLs move on their own when a tag
+/// is published and neither can ever resolve to a release candidate.
+pub const RELEASE_MANIFEST_URL: &str =
+    "https://github.com/vanillagreencom/kendex/releases/latest/download/latest.json";
+/// The pre-release channel is one fixed release whose two manifests the
+/// tag job overwrites every time a pre-release is published. A release
+/// candidate has no other way to reach the next one: GitHub resolves
+/// `latest` past every pre-release, so the URL above would tell rc1 it is
+/// current while rc2 sits published beside it.
+pub const PRERELEASE_FEED_URL: &str =
+    "https://github.com/vanillagreencom/kendex/releases/download/prerelease/feed.json";
+pub const PRERELEASE_MANIFEST_URL: &str =
+    "https://github.com/vanillagreencom/kendex/releases/download/prerelease/latest.json";
+/// Whether a build takes its updates from the pre-release channel. The
+/// running version is the whole answer: a version carrying a SemVer
+/// pre-release identifier is itself a release candidate and follows the
+/// candidates, and every other version follows full releases. A version
+/// this build cannot parse follows full releases too, which is the answer
+/// that can only ever offer someone less than they asked for.
+///
+/// So a shipped 1.0.0 is never offered 1.1.0-rc1, and nothing has to be
+/// set on the machine for a candidate to find its successor — which is
+/// what makes the release-build test of the update path possible at all.
+fn on_prerelease_channel(current_version: &str) -> bool {
+    Version::parse(current_version).is_ok_and(|version| !version.pre.is_empty())
+}
+
+/// The discovery feed `current_version` reads. Both shells call this with
+/// their own baked version rather than deciding for themselves, so the app
+/// and `kendex update` cannot end up on different channels.
+pub fn feed_url_for(current_version: &str) -> &'static str {
+    match on_prerelease_channel(current_version) {
+        true => PRERELEASE_FEED_URL,
+        false => RELEASE_FEED_URL,
+    }
+}
+
+/// The signed manifest `current_version` installs the desktop app from,
+/// chosen by the same rule as the feed above.
+pub fn manifest_url_for(current_version: &str) -> &'static str {
+    match on_prerelease_channel(current_version) {
+        true => PRERELEASE_MANIFEST_URL,
+        false => RELEASE_MANIFEST_URL,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The rule the whole pre-release test path rests on, read from both
+    /// ends: a candidate follows candidates, and a shipped release never
+    /// does. Getting the second half wrong ships 1.0.0 taking 1.1.0-rc1,
+    /// which is the one outcome this channel must not have.
+    #[test]
+    fn a_candidate_follows_candidates_and_a_full_release_never_does() {
+        for candidate in ["1.0.0-rc1", "1.0.0-rc2", "5.1.0-beta.1", "1.0.0-rc1+build"] {
+            assert_eq!(feed_url_for(candidate), PRERELEASE_FEED_URL, "{candidate}");
+            assert_eq!(
+                manifest_url_for(candidate),
+                PRERELEASE_MANIFEST_URL,
+                "{candidate}"
+            );
+        }
+        // The last two are versions no build carries; a value that is not
+        // SemVer resolves to the release channel rather than to nothing.
+        for full in ["1.0.0", "5.0.1", "5.0.1+feed", "", "not a version"] {
+            assert_eq!(feed_url_for(full), RELEASE_FEED_URL, "{full}");
+            assert_eq!(manifest_url_for(full), RELEASE_MANIFEST_URL, "{full}");
+        }
+    }
+
+    /// A candidate reaches its successor only because the two channels are
+    /// served from different places: the release channel's `latest` is
+    /// resolved by GitHub past every pre-release, so a candidate pointed at
+    /// it would read the last full release and call itself current.
+    #[test]
+    fn the_two_channels_are_not_the_same_url() {
+        assert_ne!(RELEASE_FEED_URL, PRERELEASE_FEED_URL);
+        assert_ne!(RELEASE_MANIFEST_URL, PRERELEASE_MANIFEST_URL);
+        for url in [PRERELEASE_FEED_URL, PRERELEASE_MANIFEST_URL] {
+            assert!(!url.contains("/releases/latest/"), "{url}");
+        }
+    }
+}

--- a/crates/core/src/update_feed.rs
+++ b/crates/core/src/update_feed.rs
@@ -297,8 +297,11 @@ mod tests {
             VersionRelation::Older
         );
         // A release candidate is behind the next candidate and behind the
-        // release it leads to. Text order puts rc10 behind rc2 and 1.0.0
-        // behind 1.0.0-rc1, which offers a downgrade as an update.
+        // release it leads to. Plain text order puts 1.0.0 behind
+        // 1.0.0-rc1, which offers a downgrade as an update. Within the
+        // identifiers, though, text order is the rule: rc10 is behind rc2,
+        // because SemVer compares an identifier numerically only when it
+        // is all digits.
         for latest in ["1.0.0-rc2", "1.0.0-rc10", "1.0.0"] {
             assert_eq!(
                 ReleaseFeed::parse(&feed(latest))
@@ -313,6 +316,13 @@ mod tests {
             ReleaseFeed::parse(&feed("1.0.0-rc1"))
                 .unwrap()
                 .relation_to("1.0.0")
+                .unwrap(),
+            VersionRelation::Older
+        );
+        assert_eq!(
+            ReleaseFeed::parse(&feed("1.0.0-rc10"))
+                .unwrap()
+                .relation_to("1.0.0-rc2")
                 .unwrap(),
             VersionRelation::Older
         );

--- a/crates/core/src/update_feed.rs
+++ b/crates/core/src/update_feed.rs
@@ -13,8 +13,6 @@ use crate::error::{CoreError, Result};
 
 pub const FEED_SCHEMA: u32 = 1;
 pub const MAX_FEED_BYTES: usize = 64 * 1024;
-pub const RELEASE_FEED_URL: &str =
-    "https://github.com/vanillagreencom/kendex/releases/latest/download/feed.json";
 /// The minisign public key every kendex release is signed under, in the
 /// base64 shape `crates/app/tauri.conf.json` pins for the app's own
 /// updater. `crates/app/tests/tauri_config.rs` holds the two to one string,
@@ -295,6 +293,26 @@ mod tests {
             ReleaseFeed::parse(&feed("5.0.0"))
                 .unwrap()
                 .relation_to("5.0.1")
+                .unwrap(),
+            VersionRelation::Older
+        );
+        // A release candidate is behind the next candidate and behind the
+        // release it leads to. Text order puts rc10 behind rc2 and 1.0.0
+        // behind 1.0.0-rc1, which offers a downgrade as an update.
+        for latest in ["1.0.0-rc2", "1.0.0-rc10", "1.0.0"] {
+            assert_eq!(
+                ReleaseFeed::parse(&feed(latest))
+                    .unwrap()
+                    .relation_to("1.0.0-rc1")
+                    .unwrap(),
+                VersionRelation::Newer,
+                "{latest}"
+            );
+        }
+        assert_eq!(
+            ReleaseFeed::parse(&feed("1.0.0-rc1"))
+                .unwrap()
+                .relation_to("1.0.0")
                 .unwrap(),
             VersionRelation::Older
         );

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -119,4 +119,9 @@ entries are still under that heading.
 ## Version bumps
 
 The workspace version in `Cargo.toml` and `crates/app/tauri.conf.json`
-must match the tag (minus the `v`).
+must match the tag (minus the `v`). The publish job enforces it: it reads
+the version back out of the CLI it just built and stops the tag when the
+two differ, so a tag naming a version no artifact carries never publishes
+a feed. `crates/app/tests/tauri_config.rs` holds the two config files to
+one version, and Cargo refuses a version that is not SemVer, which is what
+makes the version the tag is held to one the app can parse.

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -43,9 +43,15 @@ That same resolution is why a candidate cannot reach the next one through
 `releases/latest`. The publish job therefore also overwrites `latest.json`
 and `feed.json` on a fixed `prerelease` release, and a build whose own
 version is a candidate reads its updates from there
-(`update_feed::feed_url_for`, which the app and `kendex update` both call
-with their baked version). A shipped `1.0.0` is on the release channel and
-is never offered a candidate; nothing on the machine selects this.
+(`update_channel::feed_url_for`, which the app and `kendex update` both
+call with their baked version). A shipped `1.0.0` is on the release channel
+and is never offered a candidate; nothing on the machine selects this.
+
+The channel only ever moves forward: the publish job reads the version it
+already carries and leaves it alone when that is ahead of the tag being
+published, so re-running an older tag cannot roll every candidate back to
+it. Two tag runs are queued rather than interleaved by the `publish` job's
+concurrency group, which is what keeps that read and its write together.
 
 The channel keeps whatever the last candidate left on it, so a machine on
 a candidate stays on candidates until it is moved to a full release by

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -30,6 +30,28 @@ Release with:
 
 Review the draft, then publish it. That is the release.
 
+## Pre-releases
+
+A tag whose version carries a SemVer pre-release identifier — `v1.0.0-rc1`
+— runs the same workflow and takes two different turns at the end. It is
+published outright, marked pre-release rather than left as a draft: a
+draft's assets are unreachable, and a candidate nobody can download tests
+nothing. Being marked pre-release is what keeps it to candidates, since
+GitHub resolves `releases/latest` past every one of them.
+
+That same resolution is why a candidate cannot reach the next one through
+`releases/latest`. The publish job therefore also overwrites `latest.json`
+and `feed.json` on a fixed `prerelease` release, and a build whose own
+version is a candidate reads its updates from there
+(`update_feed::feed_url_for`, which the app and `kendex update` both call
+with their baked version). A shipped `1.0.0` is on the release channel and
+is never offered a candidate; nothing on the machine selects this.
+
+The channel keeps whatever the last candidate left on it, so a machine on
+a candidate stays on candidates until it is moved to a full release by
+hand. Cutting candidates for a release means cutting one more when the
+final ships, or reinstalling those machines.
+
 The workflow runs on tag push only, never on pull requests. Every lane
 builds the CLI and the desktop app together; there is no build cache.
 The Intel macOS lane uses `macos-15-intel`, supported until August 2027 —


### PR DESCRIPTION
Most of KEN-438 shipped in #1721 while the issue stayed Todo: the updater
plugin, `createUpdaterArtifacts`, the pubkey, the signed `latest.json` in the
release workflow, the Windows passive install mode, the cask's `auto_updates`,
and `app_update_install` wired to the sidebar card. This is the remainder, cut
to what the owner's release gate needs.

## The rc1 to rc2 test could not run

The gate on KEN-787 requires the update path tested for real on both platforms,
rc1 to rc2, through the app's Update now and through `kendex update`. That was
impossible, for a reason unrelated to signing.

Both update paths resolved through GitHub's `releases/latest/` URL — the
updater endpoint in `tauri.conf.json` and `RELEASE_FEED_URL` in
`update_feed.rs`. `latest` is GitHub's word for the newest release that is
neither a draft nor a pre-release, so it resolves *past* every candidate.
Tagging `v1.0.0-rc2` would publish a correctly signed `latest.json` that neither
shell would ever fetch, and rc1 would be told it is current.

Second half: the tag job published with `draft: true` and no `prerelease`, and a
draft's assets are not served by the download URLs at all.

## What this ships

A pre-release channel. `crates/core/src/update_channel.rs` decides which of two
manifest pairs a build reads, from the running version alone: a version carrying
a SemVer pre-release identifier follows candidates, everything else follows full
releases, and a version that will not parse follows full releases — the answer
that can only ever offer someone less than they asked for. Nothing has to be set
on the machine, which is what makes a release-build test possible. A shipped
1.0.0 is never offered 1.1.0-rc1.

Both shells call `feed_url_for` with their own baked version rather than deciding
separately, so the app and `kendex update` cannot land on different channels.

The pre-release channel is one fixed `prerelease` release whose two manifests
each new candidate overwrites. The manifests name their downloads by the tag that
built them, so they point at that tag's own release. A full-release tag still
lands as a draft to review before publishing; a pre-release tag publishes,
because its assets are unreachable while it is a draft and installing it is the
entire point.

`crates/cli/tests/release_workflow/channel.rs` covers the channel rules and the
workflow's tag conditions. `crates/app/tests/tauri_config.rs` gains assertions
tying the config's endpoints to the constants.

## Not in this change

The signing keypair. The public half is unchanged and this builds against it;
`TAURI_SIGNING_PRIVATE_KEY` remains the owner gate `docs/RELEASING.md` names.

The rc1 to rc2 test itself, which needs signed release builds and both machines.
This makes it runnable.

Closes KEN-438
