### PR TITLE
fix(KEN-788): the generated wrapper comes off by section, not string

### DIFF
--- a/changelog.d/fixed/KEN-788.md
+++ b/changelog.d/fixed/KEN-788.md
@@ -1,1 +1,1 @@
-- Forking an agent keeps the person's and the publisher's own prose: only what the next render writes again comes off, however much their own words resemble it.
+- Forking an agent takes off exactly what the next render writes again — nothing of the person's or the publisher's own prose, and nothing left behind to stand twice.

--- a/changelog.d/fixed/KEN-788.md
+++ b/changelog.d/fixed/KEN-788.md
@@ -1,0 +1,1 @@
+- Forking an agent no longer takes the person's own words for generated ones — a deleted banner, prose that borrows a wrapper line, an edited section — and refuses a rendering it cannot read.

--- a/changelog.d/fixed/KEN-788.md
+++ b/changelog.d/fixed/KEN-788.md
@@ -1,1 +1,1 @@
-- Forking an agent no longer takes prose for generated content — a deleted banner, a borrowed wrapper line, an edited section, a published section standing where a generated one did.
+- Forking an agent no longer takes prose for generated content — a deleted banner, a borrowed wrapper line, an edited section, or a published section that reads like a generated one on any harness.

--- a/changelog.d/fixed/KEN-788.md
+++ b/changelog.d/fixed/KEN-788.md
@@ -1,1 +1,1 @@
-- Forking an agent no longer takes prose for generated content — a deleted banner, a borrowed wrapper line, an edited section, or a published section that reads like a generated one on any harness.
+- Forking an agent keeps the person's and the publisher's own prose: only what the next render writes again comes off, however much their own words resemble it.

--- a/changelog.d/fixed/KEN-788.md
+++ b/changelog.d/fixed/KEN-788.md
@@ -1,1 +1,1 @@
-- Forking an agent no longer takes the person's own words for generated ones — a deleted banner, prose that borrows a wrapper line, an edited section — and refuses a rendering it cannot read.
+- Forking an agent no longer takes prose for generated content — a deleted banner, a borrowed wrapper line, an edited section, a published section standing where a generated one did.

--- a/crates/core/src/engine/fork/agent.rs
+++ b/crates/core/src/engine/fork/agent.rs
@@ -239,15 +239,11 @@ fn source_form(
     };
     let published = std::str::from_utf8(published)
         .map_err(|_| refused("the catalog's file for it is not text".to_owned()))?;
-    let (frontmatter, publisher) = crate::frontmatter::split(published).map_err(refused)?;
+    let (frontmatter, _) = crate::frontmatter::split(published).map_err(refused)?;
     let body = crate::frontmatter::split(edited)
         .map(|(_, body)| body)
         .unwrap_or(edited);
-    Ok(format!(
-        "---\n{frontmatter}---\n\n{}",
-        prose(body, publisher, wrapper)
-    )
-    .into_bytes())
+    Ok(format!("---\n{frontmatter}---\n\n{}", prose(body, wrapper)).into_bytes())
 }
 
 /// What the project and the catalog put around one agent's prose.

--- a/crates/core/src/engine/fork/agent.rs
+++ b/crates/core/src/engine/fork/agent.rs
@@ -19,13 +19,18 @@ use crate::manifest::FrontmatterOverrides;
 use crate::model::{HarnessId, ItemKind, Scope};
 
 use crate::render::agent::{
-    EffectiveAgent, GENERATED_BANNER, SourceAgent, hooks_for_agent, merge_overrides,
-    merged_instructions, parse_source_agent,
+    EffectiveAgent, SourceAgent, hooks_for_agent, merge_overrides, merged_instructions,
+    parse_source_agent,
 };
+
+mod prose;
+mod wrapper;
 
 use super::ForkOf;
 use super::stated::{carried_edits, dropped, stated, uncleared};
 use crate::engine::agent_carry::{AgentCarry, agent_carry};
+use prose::prose;
+use wrapper::{Wrapper, wrapper};
 
 /// One captured agent: the source-form bytes for the local source, and the
 /// catalog values that have to reach the manifest with them.
@@ -81,12 +86,17 @@ pub(super) fn capture_agent(of: &ForkOf, edited: &Path) -> Result<CapturedAgent>
     };
 
     let edited_text = std::fs::read_to_string(edited).map_err(|e| CoreError::io(edited, e))?;
-    let bytes = source_form(
-        &published,
-        &edited_text,
-        name,
-        wrapper(scope, &publisher, harness, &around).as_ref(),
-    )?;
+    // A rendering this reader cannot account for is a refusal, never a
+    // capture taken anyway: the wrapper says which words are the person's,
+    // and one read wrongly cuts their own out of their prose.
+    let read = wrapper(scope, &publisher, harness, &around).map_err(|problem| {
+        CoreError::ForkWrapperUnreadable {
+            name: crate::names::shown(name),
+            harness: harness.display_name().to_owned(),
+            problem,
+        }
+    })?;
+    let bytes = source_form(&published, &edited_text, name, read.as_ref())?;
     let captured = parse_source_agent(&String::from_utf8_lossy(&bytes))
         .map_err(|problem| unreadable(name, &decl.source, problem))?;
     let refused = |problem: String| CoreError::ForkWidensAccess {
@@ -221,7 +231,7 @@ fn source_form(
     published: &[u8],
     edited: &str,
     name: &str,
-    wrapper: Option<&(String, String)>,
+    wrapper: Option<&Wrapper>,
 ) -> Result<Vec<u8>> {
     let refused = |problem: String| CoreError::ForkNameUnusable {
         name: crate::names::shown(name),
@@ -236,31 +246,6 @@ fn source_form(
     Ok(format!("---\n{frontmatter}---\n\n{}", prose(body, wrapper)).into_bytes())
 }
 
-/// The person's own prose: the edited body with the generated wrapper
-/// taken off. Everything in that wrapper is written again by the next
-/// render, out of the manifest entries this fork carries, so prose keeping
-/// a copy of it would render twice — the banner duplication one layer out.
-///
-/// The banner comes off separately as well, because a person who deleted
-/// that one line leaves a body the wrapper no longer matches, and that is
-/// no reason to keep the rest of it.
-fn prose(body: &str, wrapper: Option<&(String, String)>) -> String {
-    let mut kept = body;
-    if let Some((before, after)) = wrapper {
-        kept = kept.strip_prefix(before.as_str()).unwrap_or(kept);
-        kept = kept.strip_suffix(after.as_str()).unwrap_or(kept);
-    }
-    let mut out = String::new();
-    for line in kept.lines().filter(|line| line.trim() != GENERATED_BANNER) {
-        out.push_str(line);
-        out.push('\n');
-    }
-    // Only the blank separators go. A first line indented into a code
-    // block is the person's own content, and trimming it would render
-    // their block as ordinary prose.
-    format!("{}\n", out.trim_start_matches('\n').trim_end())
-}
-
 /// What the project and the catalog put around one agent's prose.
 struct Around<'a> {
     skills: Vec<String>,
@@ -268,27 +253,6 @@ struct Around<'a> {
     launch: Option<String>,
     additional: Option<String>,
     hooks: Vec<&'a crate::manifest::CustomHook>,
-}
-
-/// The generated wrapper this harness writes around an agent's own prose:
-/// everything before it, and everything after. Asked of the renderer with
-/// a stand-in body rather than assembled from a list of headings here, so
-/// a renderer that grows a section cannot leave this reader behind.
-fn wrapper(
-    scope: &Scope,
-    publisher: &SourceAgent,
-    harness: HarnessId,
-    around: &Around,
-) -> Option<(String, String)> {
-    const STAND_IN: &str = "kendexstandsinfortheagentsownprose";
-    let source = SourceAgent {
-        body: STAND_IN.to_owned(),
-        ..publisher.clone()
-    };
-    let text = render(scope, &source, harness, around)?;
-    let (_, body) = crate::frontmatter::split(&text).ok()?;
-    let (before, after) = body.split_once(STAND_IN)?;
-    Some((before.to_owned(), after.to_owned()))
 }
 
 /// One rendering of this agent for this harness, or `None` where the

--- a/crates/core/src/engine/fork/agent.rs
+++ b/crates/core/src/engine/fork/agent.rs
@@ -239,11 +239,15 @@ fn source_form(
     };
     let published = std::str::from_utf8(published)
         .map_err(|_| refused("the catalog's file for it is not text".to_owned()))?;
-    let (frontmatter, _) = crate::frontmatter::split(published).map_err(refused)?;
+    let (frontmatter, publisher) = crate::frontmatter::split(published).map_err(refused)?;
     let body = crate::frontmatter::split(edited)
         .map(|(_, body)| body)
         .unwrap_or(edited);
-    Ok(format!("---\n{frontmatter}---\n\n{}", prose(body, wrapper)).into_bytes())
+    Ok(format!(
+        "---\n{frontmatter}---\n\n{}",
+        prose(body, publisher, wrapper)
+    )
+    .into_bytes())
 }
 
 /// What the project and the catalog put around one agent's prose.

--- a/crates/core/src/engine/fork/agent/prose.rs
+++ b/crates/core/src/engine/fork/agent/prose.rs
@@ -1,0 +1,110 @@
+//! Taking the generated wrapper off an edited body. A rendering on disk is
+//! the person's prose inside everything the renderer wrote around it, and
+//! a fork keeps the prose alone: whatever the next render writes again out
+//! of the manifest this fork carries would otherwise stand twice.
+
+use crate::render::agent::GENERATED_BANNER;
+
+use super::wrapper::Wrapper;
+
+/// The person's own prose: the edited body with the generated wrapper
+/// taken off. Everything in that wrapper is written again by the next
+/// render, out of the manifest entries this fork carries, so prose keeping
+/// a copy of it would render twice — the banner duplication one layer out.
+///
+/// The wrapper comes off section by section, each tried where the one
+/// before it stopped. A section the body does not hold whole is one the
+/// person deleted — the banner is the one they reach for — and it is
+/// passed over without taking anything, so the sections after it still
+/// come off and a line of the person's own is never taken for a line of
+/// the wrapper.
+pub(super) fn prose(body: &str, wrapper: Option<&Wrapper>) -> String {
+    let lines: Vec<&str> = body.lines().collect();
+    let mut kept = lines.as_slice();
+    if let Some(wrapper) = wrapper {
+        kept = &kept[taken(kept, &said(&wrapper.before, false))..];
+        let back: Vec<&str> = kept.iter().rev().copied().collect();
+        kept = &kept[..kept.len() - taken(&back, &said(&wrapper.after, true))];
+    }
+    let mut out = String::new();
+    // The banner is a section like any other and comes off with them.
+    // Filtered again here for the body no wrapper could be read for,
+    // where nothing was taken off at all.
+    for line in kept.iter().filter(|line| line.trim() != GENERATED_BANNER) {
+        out.push_str(line);
+        out.push('\n');
+    }
+    // Only the blank separators go. A first line indented into a code
+    // block is the person's own content, and trimming it would render
+    // their block as ordinary prose.
+    format!("{}\n", out.trim_start_matches('\n').trim_end())
+}
+
+/// The lines that identify each section, in the order a walk from this
+/// end meets them. Blank lines are left out: they separate sections
+/// rather than say which one this is, and a person who closed a gap up
+/// has not deleted a section.
+fn said<'a>(sections: &'a [String], from_the_end: bool) -> Vec<Vec<&'a str>> {
+    let lines = |section: &'a String| -> Vec<&'a str> {
+        let said = section.lines().filter(|line| !line.trim().is_empty());
+        match from_the_end {
+            true => said.rev().collect(),
+            false => said.collect(),
+        }
+    };
+    match from_the_end {
+        true => sections.iter().rev().map(lines).collect(),
+        false => sections.iter().map(lines).collect(),
+    }
+}
+
+/// How many lines at the front of `body` the wrapper wrote. Each section
+/// is tried where the one before it stopped and nothing is searched for,
+/// so the count is the run of lines the wrapper accounts for and stops
+/// where the person's own prose starts.
+fn taken(body: &[&str], sections: &[Vec<&str>]) -> usize {
+    let mut at = 0;
+    for section in sections {
+        if let Some(more) = held(&body[at..], section) {
+            at += more;
+        }
+    }
+    at
+}
+
+/// How many lines at the front of `body` hold this whole section, or
+/// `None` where they do not. Whole means every line the section is
+/// identified by, in its order, with nothing but blank lines among them.
+/// A body holding some of a section holds none of it: half a section is
+/// as likely to be the person writing what the renderer would have
+/// written as it is the remains of what it wrote.
+fn held(body: &[&str], section: &[&str]) -> Option<usize> {
+    if section.is_empty() {
+        return None;
+    }
+    let mut matched = 0;
+    let mut through = 0;
+    for (at, line) in body.iter().enumerate() {
+        if line.trim().is_empty() {
+            continue;
+        }
+        if line != section.get(matched)? {
+            return None;
+        }
+        matched += 1;
+        through = at + 1;
+        if matched == section.len() {
+            break;
+        }
+    }
+    if matched < section.len() {
+        return None;
+    }
+    // The blank lines behind it separated it from what came next, and
+    // are the wrapper's too.
+    let trailing = body[through..]
+        .iter()
+        .take_while(|line| line.trim().is_empty())
+        .count();
+    Some(through + trailing)
+}

--- a/crates/core/src/engine/fork/agent/prose.rs
+++ b/crates/core/src/engine/fork/agent/prose.rs
@@ -4,7 +4,7 @@
 //! of the manifest this fork carries would otherwise stand twice.
 
 use crate::render::agent::GENERATED_BANNER;
-use crate::render::fence_marker;
+use crate::render::inside_a_block;
 
 use super::wrapper::Wrapper;
 
@@ -59,42 +59,31 @@ pub(super) fn prose(body: &str, wrapper: Option<&Wrapper>) -> String {
     format!("{}\n", out.trim_start_matches('\n').trim_end())
 }
 
-/// One line a section is identified by. `fenced` is a line standing
-/// inside a fenced code block, where whitespace is content the person can
-/// edit rather than separation between sections.
+/// One line a section is identified by. `inside` is a line standing
+/// inside a code block, where whitespace is content the person can edit
+/// rather than separation between sections.
 struct Line<'a> {
     text: &'a str,
-    fenced: bool,
+    inside: bool,
 }
 
 /// The lines that identify each section, in the order a walk from this
-/// end meets them. A blank line outside a fenced block is left out: it
+/// end meets them. A blank line outside a code block is left out: it
 /// separates sections rather than says which one this is, and a person
 /// who closed a gap up has not deleted a section. Inside one it is kept,
 /// because there it is a line of the block's own text.
 fn said<'a>(sections: &'a [String], from_the_end: bool) -> Vec<Vec<Line<'a>>> {
     let lines = |section: &'a String| -> Vec<Line<'a>> {
-        let mut fence: Option<(char, usize)> = None;
-        let mut said = Vec::new();
-        for text in section.lines() {
-            let fenced = fence.is_some();
-            match (fence_marker(text), fence) {
-                (Some((marker, run, bare)), Some((open, len)))
-                    if marker == open && run >= len && bare =>
-                {
-                    fence = None;
-                }
-                (Some((marker, run, _)), None) => fence = Some((marker, run)),
-                _ => {}
-            }
-            if fenced || !text.trim().is_empty() {
-                said.push(Line { text, fenced });
-            }
+        let mut said: Vec<Line<'a>> = section
+            .lines()
+            .zip(inside_a_block(section))
+            .filter(|(text, inside)| *inside || !text.trim().is_empty())
+            .map(|(text, inside)| Line { text, inside })
+            .collect();
+        if from_the_end {
+            said.reverse();
         }
-        match from_the_end {
-            true => said.into_iter().rev().collect(),
-            false => said,
-        }
+        said
     };
     match from_the_end {
         true => sections.iter().rev().map(lines).collect(),
@@ -148,10 +137,10 @@ fn held(body: &[&str], section: &[Line]) -> Option<usize> {
         let want = section.get(matched)?;
         // A blank line the section is not standing on is separation, and
         // a person may open or close a gap without touching the section.
-        // One the section does stand on is a line of a fenced block, where
+        // One the section does stand on is a line of a code block, where
         // their whitespace is content: it has to match byte for byte, and
         // one they added stands against the block's next line and refuses.
-        if line.trim().is_empty() && !want.fenced {
+        if line.trim().is_empty() && !want.inside {
             continue;
         }
         if *line != want.text {

--- a/crates/core/src/engine/fork/agent/prose.rs
+++ b/crates/core/src/engine/fork/agent/prose.rs
@@ -4,6 +4,7 @@
 //! of the manifest this fork carries would otherwise stand twice.
 
 use crate::render::agent::GENERATED_BANNER;
+use crate::render::fence_marker;
 
 use super::wrapper::Wrapper;
 
@@ -27,20 +28,28 @@ use super::wrapper::Wrapper;
 /// holds more copies of it than the publisher brought.
 pub(super) fn prose(body: &str, wrapper: Option<&Wrapper>) -> String {
     let lines: Vec<&str> = body.lines().collect();
-    let mut kept = lines.as_slice();
-    if let Some(wrapper) = wrapper {
-        let publisher: Vec<&str> = wrapper.published.lines().collect();
-        kept = &kept[taken(kept, &publisher, &said(&wrapper.before, false))..];
-        let body_back: Vec<&str> = kept.iter().rev().copied().collect();
-        let publisher_back: Vec<&str> = publisher.iter().rev().copied().collect();
-        kept =
-            &kept[..kept.len() - taken(&body_back, &publisher_back, &said(&wrapper.after, true))];
-    }
+    let kept: Vec<&str> = match wrapper {
+        Some(wrapper) => {
+            let publisher: Vec<&str> = wrapper.published.lines().collect();
+            let front = &lines[taken(&lines, &publisher, &said(&wrapper.before, false))..];
+            let body_back: Vec<&str> = front.iter().rev().copied().collect();
+            let publisher_back: Vec<&str> = publisher.iter().rev().copied().collect();
+            let back = taken(&body_back, &publisher_back, &said(&wrapper.after, true));
+            front[..front.len() - back].to_vec()
+        }
+        // Nothing was subtracted, so the banner the renderer wrote is
+        // still standing in the body — the one line the next render is
+        // certain to write again. Where a wrapper was read the banner is
+        // a section like any other and the walk has already had it, so
+        // filtering here would take a line the walk deliberately kept.
+        None => lines
+            .iter()
+            .filter(|line| line.trim() != GENERATED_BANNER)
+            .copied()
+            .collect(),
+    };
     let mut out = String::new();
-    // The banner is a section like any other and comes off with them.
-    // Filtered again here for the body no wrapper could be read for,
-    // where nothing was taken off at all.
-    for line in kept.iter().filter(|line| line.trim() != GENERATED_BANNER) {
+    for line in kept {
         out.push_str(line);
         out.push('\n');
     }
@@ -50,16 +59,41 @@ pub(super) fn prose(body: &str, wrapper: Option<&Wrapper>) -> String {
     format!("{}\n", out.trim_start_matches('\n').trim_end())
 }
 
+/// One line a section is identified by. `fenced` is a line standing
+/// inside a fenced code block, where whitespace is content the person can
+/// edit rather than separation between sections.
+struct Line<'a> {
+    text: &'a str,
+    fenced: bool,
+}
+
 /// The lines that identify each section, in the order a walk from this
-/// end meets them. Blank lines are left out: they separate sections
-/// rather than say which one this is, and a person who closed a gap up
-/// has not deleted a section.
-fn said<'a>(sections: &'a [String], from_the_end: bool) -> Vec<Vec<&'a str>> {
-    let lines = |section: &'a String| -> Vec<&'a str> {
-        let said = section.lines().filter(|line| !line.trim().is_empty());
+/// end meets them. A blank line outside a fenced block is left out: it
+/// separates sections rather than says which one this is, and a person
+/// who closed a gap up has not deleted a section. Inside one it is kept,
+/// because there it is a line of the block's own text.
+fn said<'a>(sections: &'a [String], from_the_end: bool) -> Vec<Vec<Line<'a>>> {
+    let lines = |section: &'a String| -> Vec<Line<'a>> {
+        let mut fence: Option<(char, usize)> = None;
+        let mut said = Vec::new();
+        for text in section.lines() {
+            let fenced = fence.is_some();
+            match (fence_marker(text), fence) {
+                (Some((marker, run, bare)), Some((open, len)))
+                    if marker == open && run >= len && bare =>
+                {
+                    fence = None;
+                }
+                (Some((marker, run, _)), None) => fence = Some((marker, run)),
+                _ => {}
+            }
+            if fenced || !text.trim().is_empty() {
+                said.push(Line { text, fenced });
+            }
+        }
         match from_the_end {
-            true => said.rev().collect(),
-            false => said.collect(),
+            true => said.into_iter().rev().collect(),
+            false => said,
         }
     };
     match from_the_end {
@@ -74,7 +108,7 @@ fn said<'a>(sections: &'a [String], from_the_end: bool) -> Vec<Vec<&'a str>> {
 /// where the person's own prose starts. A section the published prose
 /// brought its own copies of is taken only where the body holds one more
 /// than those, which is the copy the wrapper added.
-fn taken(body: &[&str], published: &[&str], sections: &[Vec<&str>]) -> usize {
+fn taken(body: &[&str], published: &[&str], sections: &[Vec<Line>]) -> usize {
     let mut at = 0;
     for section in sections {
         if copies(&body[at..], section) > copies(published, section)
@@ -88,7 +122,7 @@ fn taken(body: &[&str], published: &[&str], sections: &[Vec<&str>]) -> usize {
 
 /// How many copies of this section stand one after another at the front of
 /// `body`.
-fn copies(body: &[&str], section: &[&str]) -> usize {
+fn copies(body: &[&str], section: &[Line]) -> usize {
     let mut at = 0;
     let mut seen = 0;
     while let Some(more) = held(&body[at..], section) {
@@ -100,21 +134,27 @@ fn copies(body: &[&str], section: &[&str]) -> usize {
 
 /// How many lines at the front of `body` hold this whole section, or
 /// `None` where they do not. Whole means every line the section is
-/// identified by, in its order, with nothing but blank lines among them.
-/// A body holding some of a section holds none of it: half a section is
-/// as likely to be the person writing what the renderer would have
-/// written as it is the remains of what it wrote.
-fn held(body: &[&str], section: &[&str]) -> Option<usize> {
+/// identified by, in its order, with nothing but separating blank lines
+/// among them. A body holding some of a section holds none of it: half a
+/// section is as likely to be the person writing what the renderer would
+/// have written as it is the remains of what it wrote.
+fn held(body: &[&str], section: &[Line]) -> Option<usize> {
     if section.is_empty() {
         return None;
     }
     let mut matched = 0;
     let mut through = 0;
     for (at, line) in body.iter().enumerate() {
-        if line.trim().is_empty() {
+        let want = section.get(matched)?;
+        // A blank line the section is not standing on is separation, and
+        // a person may open or close a gap without touching the section.
+        // One the section does stand on is a line of a fenced block, where
+        // their whitespace is content: it has to match byte for byte, and
+        // one they added stands against the block's next line and refuses.
+        if line.trim().is_empty() && !want.fenced {
             continue;
         }
-        if line != section.get(matched)? {
+        if *line != want.text {
             return None;
         }
         matched += 1;

--- a/crates/core/src/engine/fork/agent/prose.rs
+++ b/crates/core/src/engine/fork/agent/prose.rs
@@ -19,17 +19,17 @@ use super::wrapper::Wrapper;
 /// come off and a line of the person's own is never taken for a line of
 /// the wrapper.
 ///
-/// `published` is the prose as the catalog wrote it, and it is the floor.
-/// A generated section may read exactly like one the published prose
-/// opens or closes with, and where the person deleted the generated copy
-/// the publisher's is what stands in its place. Nothing in the text tells
-/// the two apart, so the count does: the wrapper may take a section only
-/// where the body holds more copies of it than the published prose brought.
-pub(super) fn prose(body: &str, published: &str, wrapper: Option<&Wrapper>) -> String {
+/// The publisher's prose, as this harness renders it, is the floor. A
+/// generated section may read exactly like one that prose opens or closes
+/// with, and where the person deleted the generated copy the publisher's
+/// is what stands in its place. Nothing in the text tells the two apart,
+/// so the count does: the wrapper may take a section only where the body
+/// holds more copies of it than the publisher brought.
+pub(super) fn prose(body: &str, wrapper: Option<&Wrapper>) -> String {
     let lines: Vec<&str> = body.lines().collect();
     let mut kept = lines.as_slice();
     if let Some(wrapper) = wrapper {
-        let publisher: Vec<&str> = published.lines().collect();
+        let publisher: Vec<&str> = wrapper.published.lines().collect();
         kept = &kept[taken(kept, &publisher, &said(&wrapper.before, false))..];
         let body_back: Vec<&str> = kept.iter().rev().copied().collect();
         let publisher_back: Vec<&str> = publisher.iter().rev().copied().collect();

--- a/crates/core/src/engine/fork/agent/prose.rs
+++ b/crates/core/src/engine/fork/agent/prose.rs
@@ -18,13 +18,23 @@ use super::wrapper::Wrapper;
 /// passed over without taking anything, so the sections after it still
 /// come off and a line of the person's own is never taken for a line of
 /// the wrapper.
-pub(super) fn prose(body: &str, wrapper: Option<&Wrapper>) -> String {
+///
+/// `published` is the prose as the catalog wrote it, and it is the floor.
+/// A generated section may read exactly like one the published prose
+/// opens or closes with, and where the person deleted the generated copy
+/// the publisher's is what stands in its place. Nothing in the text tells
+/// the two apart, so the count does: the wrapper may take a section only
+/// where the body holds more copies of it than the published prose brought.
+pub(super) fn prose(body: &str, published: &str, wrapper: Option<&Wrapper>) -> String {
     let lines: Vec<&str> = body.lines().collect();
     let mut kept = lines.as_slice();
     if let Some(wrapper) = wrapper {
-        kept = &kept[taken(kept, &said(&wrapper.before, false))..];
-        let back: Vec<&str> = kept.iter().rev().copied().collect();
-        kept = &kept[..kept.len() - taken(&back, &said(&wrapper.after, true))];
+        let publisher: Vec<&str> = published.lines().collect();
+        kept = &kept[taken(kept, &publisher, &said(&wrapper.before, false))..];
+        let body_back: Vec<&str> = kept.iter().rev().copied().collect();
+        let publisher_back: Vec<&str> = publisher.iter().rev().copied().collect();
+        kept =
+            &kept[..kept.len() - taken(&body_back, &publisher_back, &said(&wrapper.after, true))];
     }
     let mut out = String::new();
     // The banner is a section like any other and comes off with them.
@@ -61,15 +71,31 @@ fn said<'a>(sections: &'a [String], from_the_end: bool) -> Vec<Vec<&'a str>> {
 /// How many lines at the front of `body` the wrapper wrote. Each section
 /// is tried where the one before it stopped and nothing is searched for,
 /// so the count is the run of lines the wrapper accounts for and stops
-/// where the person's own prose starts.
-fn taken(body: &[&str], sections: &[Vec<&str>]) -> usize {
+/// where the person's own prose starts. A section the published prose
+/// brought its own copies of is taken only where the body holds one more
+/// than those, which is the copy the wrapper added.
+fn taken(body: &[&str], published: &[&str], sections: &[Vec<&str>]) -> usize {
     let mut at = 0;
     for section in sections {
-        if let Some(more) = held(&body[at..], section) {
+        if copies(&body[at..], section) > copies(published, section)
+            && let Some(more) = held(&body[at..], section)
+        {
             at += more;
         }
     }
     at
+}
+
+/// How many copies of this section stand one after another at the front of
+/// `body`.
+fn copies(body: &[&str], section: &[&str]) -> usize {
+    let mut at = 0;
+    let mut seen = 0;
+    while let Some(more) = held(&body[at..], section) {
+        at += more;
+        seen += 1;
+    }
+    seen
 }
 
 /// How many lines at the front of `body` hold this whole section, or

--- a/crates/core/src/engine/fork/agent/wrapper.rs
+++ b/crates/core/src/engine/fork/agent/wrapper.rs
@@ -24,6 +24,13 @@ enum Wrote {
 pub(super) struct Wrapper {
     pub before: Vec<String>,
     pub after: Vec<String>,
+    /// The publisher's own prose as this harness renders it, which is the
+    /// text a section's copies are counted against. Every harness but
+    /// Claude rewrites a body's tool references, so the catalog's bytes
+    /// and what those bytes stand as in the rendering are different text —
+    /// and a count taken from the source would read a rewritten line as a
+    /// section the publisher never brought.
+    pub published: String,
 }
 
 /// Every input that can produce a section, in the order the renderer is
@@ -56,15 +63,26 @@ pub(super) fn wrapper(
     harness: HarnessId,
     around: &Around,
 ) -> Result<Option<Wrapper>, String> {
-    let (Some((bare_before, bare_after)), Some((before, after))) = (
+    let (Some((bare_before, bare_after)), Some((before, after)), Some(bare_body)) = (
         ends(scope, publisher, harness, &bare(around)),
         ends(scope, publisher, harness, around),
+        document(scope, publisher, harness, &bare(around)),
     ) else {
         return Ok(None);
+    };
+    // The bare rendering is the banner and the separators with this prose
+    // between them, so what stands between the ends of that same rendering
+    // is the prose alone, in the words this harness renders it in.
+    let Some(published) = bare_body
+        .strip_prefix(bare_before.as_str())
+        .and_then(|rest| rest.strip_suffix(bare_after.as_str()))
+    else {
+        return Err("the prose it publishes does not stand whole inside it".to_owned());
     };
     let mut read = Wrapper {
         before: vec![bare_before.clone()],
         after: Vec::new(),
+        published: published.to_owned(),
     };
     for wrote in FROM {
         let Some((one_before, one_after)) = ends(scope, publisher, harness, &only(around, wrote))
@@ -110,10 +128,22 @@ fn ends(
         body: STAND_IN.to_owned(),
         ..publisher.clone()
     };
-    let text = render(scope, &source, harness, around)?;
-    let (_, body) = crate::frontmatter::split(&text).ok()?;
+    let body = document(scope, &source, harness, around)?;
     let (before, after) = body.split_once(STAND_IN)?;
     Some((before.to_owned(), after.to_owned()))
+}
+
+/// One rendering with its frontmatter taken off, which is the document the
+/// wrapper is read out of.
+fn document(
+    scope: &Scope,
+    source: &SourceAgent,
+    harness: HarnessId,
+    around: &Around,
+) -> Option<String> {
+    let text = render(scope, source, harness, around)?;
+    let (_, body) = crate::frontmatter::split(&text).ok()?;
+    Some(body.to_owned())
 }
 
 /// The same configuration with every section-producing input emptied.

--- a/crates/core/src/engine/fork/agent/wrapper.rs
+++ b/crates/core/src/engine/fork/agent/wrapper.rs
@@ -1,0 +1,142 @@
+//! The generated document around one agent's prose, read back as the
+//! sections the renderer wrote. Where each one starts and ends is asked of
+//! the renderer rather than read off its output: any boundary recovered
+//! from text can be forged by content that legitimately holds that text,
+//! and an agent's instructions may say anything, headings included.
+
+use crate::model::{HarnessId, Scope};
+use crate::render::agent::SourceAgent;
+
+use super::{Around, render};
+
+/// One input a section can come from. The banner comes from no input —
+/// it is what the bare rendering holds — so it is not one of these.
+#[derive(Clone, Copy)]
+enum Wrote {
+    LaunchInstructions,
+    Skills,
+    Hooks,
+    AdditionalInstructions,
+}
+
+/// The generated wrapper, as the sections the renderer wrote, each the
+/// bytes one input added, in the order it wrote them.
+pub(super) struct Wrapper {
+    pub before: Vec<String>,
+    pub after: Vec<String>,
+}
+
+/// Every input that can produce a section, in the order the renderer is
+/// taken to write them. Taken, not trusted: [`wrapper`] rebuilds the
+/// rendering out of the sections it read and refuses where the rebuild is
+/// not the rendering byte for byte, so a renderer that reorders, grows, or
+/// splits a section is a refusal rather than a body cut in the wrong
+/// place.
+const FROM: [Wrote; 4] = [
+    Wrote::LaunchInstructions,
+    Wrote::Skills,
+    Wrote::Hooks,
+    Wrote::AdditionalInstructions,
+];
+
+/// The wrapper this harness writes around this agent's prose, or `None`
+/// where the harness refuses the agent's permission intent and installs
+/// no file at all. `Err` is a rendering this reader cannot account for,
+/// which is a refusal: a wrapper read wrongly cuts the person's own words
+/// out of their prose.
+///
+/// Each section's extent is asked of the renderer, by rendering the same
+/// agent with that one input and no other and taking what the rendering
+/// gains over the one that asked for no sections at all. Nothing is
+/// searched for in the rendered text, so a heading standing inside an
+/// instruction's own words is part of that instruction and opens nothing.
+pub(super) fn wrapper(
+    scope: &Scope,
+    publisher: &SourceAgent,
+    harness: HarnessId,
+    around: &Around,
+) -> Result<Option<Wrapper>, String> {
+    let (Some((bare_before, bare_after)), Some((before, after))) = (
+        ends(scope, publisher, harness, &bare(around)),
+        ends(scope, publisher, harness, around),
+    ) else {
+        return Ok(None);
+    };
+    let mut read = Wrapper {
+        before: vec![bare_before.clone()],
+        after: Vec::new(),
+    };
+    for wrote in FROM {
+        let Some((one_before, one_after)) = ends(scope, publisher, harness, &only(around, wrote))
+        else {
+            return Ok(None);
+        };
+        let above = one_before.strip_prefix(bare_before.as_str());
+        let below = one_after.strip_prefix(bare_after.as_str());
+        match (above, below) {
+            (Some(""), Some("")) => continue,
+            (Some(text), Some("")) => read.before.push(text.to_owned()),
+            (Some(""), Some(text)) => read.after.push(text.to_owned()),
+            (Some(_), Some(_)) => {
+                return Err("a section of it stands both above and below the prose".to_owned());
+            }
+            (None, _) | (_, None) => {
+                return Err(
+                    "a section of it rewrites the document around it, rather than adding to it"
+                        .to_owned(),
+                );
+            }
+        }
+    }
+    match read.before.concat() == before && format!("{bare_after}{}", read.after.concat()) == after
+    {
+        true => Ok(Some(read)),
+        false => Err("its sections do not add up to the document it writes".to_owned()),
+    }
+}
+
+/// What the renderer writes above and below one agent's own prose, asked
+/// of the renderer with a stand-in body rather than assembled from a list
+/// of headings here, so a renderer that grows a section cannot leave this
+/// reader behind.
+fn ends(
+    scope: &Scope,
+    publisher: &SourceAgent,
+    harness: HarnessId,
+    around: &Around,
+) -> Option<(String, String)> {
+    const STAND_IN: &str = "kendexstandsinfortheagentsownprose";
+    let source = SourceAgent {
+        body: STAND_IN.to_owned(),
+        ..publisher.clone()
+    };
+    let text = render(scope, &source, harness, around)?;
+    let (_, body) = crate::frontmatter::split(&text).ok()?;
+    let (before, after) = body.split_once(STAND_IN)?;
+    Some((before.to_owned(), after.to_owned()))
+}
+
+/// The same configuration with every section-producing input emptied.
+/// What the renderer writes for it is the banner and the separators — the
+/// floor every section stands on.
+fn bare<'a>(around: &Around<'a>) -> Around<'a> {
+    Around {
+        skills: Vec::new(),
+        launch: None,
+        additional: None,
+        hooks: Vec::new(),
+        overrides: around.overrides.clone(),
+    }
+}
+
+/// The same configuration with one input kept and every other emptied.
+fn only<'a>(around: &Around<'a>, wrote: Wrote) -> Around<'a> {
+    let mut one = bare(around);
+    match wrote {
+        Wrote::LaunchInstructions => one.launch = around.launch.clone(),
+        Wrote::Skills => one.skills = around.skills.clone(),
+        Wrote::Hooks => one.hooks = around.hooks.clone(),
+        Wrote::AdditionalInstructions => one.additional = around.additional.clone(),
+    }
+    one
+}

--- a/crates/core/src/engine/fork/agent/wrapper.rs
+++ b/crates/core/src/engine/fork/agent/wrapper.rs
@@ -10,12 +10,15 @@ use crate::render::agent::SourceAgent;
 use super::{Around, render};
 
 /// One input a section can come from. The banner comes from no input —
-/// it is what the bare rendering holds — so it is not one of these.
+/// it is what the bare rendering holds — so it is not one of these. A
+/// hook is one input each: the renderer writes a section per hook, and an
+/// input standing for all of them accounts for a body only where every
+/// one of them is still in it.
 #[derive(Clone, Copy)]
 enum Wrote {
     LaunchInstructions,
     Skills,
-    Hooks,
+    Hook(usize),
     AdditionalInstructions,
 }
 
@@ -39,12 +42,12 @@ pub(super) struct Wrapper {
 /// not the rendering byte for byte, so a renderer that reorders, grows, or
 /// splits a section is a refusal rather than a body cut in the wrong
 /// place.
-const FROM: [Wrote; 4] = [
-    Wrote::LaunchInstructions,
-    Wrote::Skills,
-    Wrote::Hooks,
-    Wrote::AdditionalInstructions,
-];
+fn from(around: &Around) -> Vec<Wrote> {
+    let mut from = vec![Wrote::LaunchInstructions, Wrote::Skills];
+    from.extend((0..around.hooks.len()).map(Wrote::Hook));
+    from.push(Wrote::AdditionalInstructions);
+    from
+}
 
 /// The wrapper this harness writes around this agent's prose, or `None`
 /// where the harness refuses the agent's permission intent and installs
@@ -84,7 +87,7 @@ pub(super) fn wrapper(
         after: Vec::new(),
         published: published.to_owned(),
     };
-    for wrote in FROM {
+    for wrote in from(around) {
         let Some((one_before, one_after)) = ends(scope, publisher, harness, &only(around, wrote))
         else {
             return Ok(None);
@@ -165,7 +168,7 @@ fn only<'a>(around: &Around<'a>, wrote: Wrote) -> Around<'a> {
     match wrote {
         Wrote::LaunchInstructions => one.launch = around.launch.clone(),
         Wrote::Skills => one.skills = around.skills.clone(),
-        Wrote::Hooks => one.hooks = around.hooks.clone(),
+        Wrote::Hook(at) => one.hooks = around.hooks.get(at).copied().into_iter().collect(),
         Wrote::AdditionalInstructions => one.additional = around.additional.clone(),
     }
     one

--- a/crates/core/src/error.rs
+++ b/crates/core/src/error.rs
@@ -254,6 +254,17 @@ pub enum CoreError {
     #[error("keeping '{name}' as your own cannot carry {problem} — nothing was written")]
     ForkWidensAccess { name: String, problem: String },
 
+    /// A fork refused before writing anything: the generated document
+    /// around this agent's prose does not read back as the sections the
+    /// renderer wrote, so there is no telling the person's own words from
+    /// the generated ones, and a capture would cut theirs out.
+    #[error("keeping '{name}' as your own cannot read its {harness} rendering: {problem}")]
+    ForkWrapperUnreadable {
+        name: String,
+        harness: String,
+        problem: String,
+    },
+
     /// Adoption refused before writing anything: a name kendex would not
     /// install, or a hook entry doing something a declaration has no field
     /// for, is refused rather than followed or quietly reshaped.

--- a/crates/core/src/render/fences.rs
+++ b/crates/core/src/render/fences.rs
@@ -1,5 +1,7 @@
-//! Where the fenced code blocks are, so the prose rewrite leaves them
-//! alone.
+//! Where a document's code blocks are, so the prose rewrite leaves them
+//! alone and the fork walk reads their whitespace as content. Fenced and
+//! indented blocks are both blocks; this module is the one place that says
+//! which lines stand inside one.
 
 /// A fence line: any leading whitespace, then three or more backticks or
 /// tildes. `bare` — nothing but whitespace after the run — is what makes a
@@ -14,4 +16,53 @@ pub fn fence_marker(line: &str) -> Option<(char, usize, bool)> {
     let marker = rest.chars().next().filter(|c| matches!(c, '`' | '~'))?;
     let run = rest.chars().take_while(|c| *c == marker).count();
     (run >= 3).then(|| (marker, run, rest[run..].trim().is_empty()))
+}
+
+/// Which lines of `text` stand inside a code block: between a fence's
+/// markers, or under the first line of a run indented four spaces or a
+/// tab. A block's own first line is not inside it — what stands above
+/// that line is prose, and the blank between them separates the two.
+///
+/// Inside a block a blank line is a line of the block's own text; outside
+/// one it separates paragraphs and carries nothing a reader would miss.
+pub fn inside_a_block(text: &str) -> Vec<bool> {
+    let lines: Vec<&str> = text.lines().collect();
+    let mut inside = vec![false; lines.len()];
+    let mut fence: Option<(char, usize)> = None;
+    for (at, line) in lines.iter().enumerate() {
+        inside[at] = fence.is_some();
+        match (fence_marker(line), fence) {
+            (Some((marker, run, bare)), Some((open, len)))
+                if marker == open && run >= len && bare =>
+            {
+                fence = None;
+            }
+            (Some((marker, run, _)), None) => fence = Some((marker, run)),
+            _ => {}
+        }
+    }
+    // A run of indented lines is a block of its own. Every line from the
+    // one that opened it to the last it holds is inside it, blank lines
+    // among them included — they are the block's, not separation between
+    // blocks — and a blank run trailing it belongs to whatever follows.
+    let mut opened: Option<usize> = None;
+    for (at, line) in lines.iter().enumerate() {
+        if inside[at] {
+            opened = None;
+            continue;
+        }
+        if line.trim().is_empty() {
+            continue;
+        }
+        match line.starts_with("    ") || line.starts_with('\t') {
+            true => {
+                if let Some(from) = opened {
+                    inside[from + 1..=at].fill(true);
+                }
+                opened = Some(at);
+            }
+            false => opened = None,
+        }
+    }
+    inside
 }

--- a/crates/core/src/render/mod.rs
+++ b/crates/core/src/render/mod.rs
@@ -6,6 +6,10 @@ pub mod skill;
 pub mod validate;
 pub mod vocab;
 
+/// Where a fenced code block stands, which is what tells whitespace that
+/// is a block's own content from whitespace that separates prose.
+pub(crate) use fences::fence_marker;
+
 /// One thing the user should hear about a rendering, with the fix when
 /// there is one — every render lint travels through this shape.
 #[derive(Debug, Clone, PartialEq)]

--- a/crates/core/src/render/mod.rs
+++ b/crates/core/src/render/mod.rs
@@ -6,9 +6,9 @@ pub mod skill;
 pub mod validate;
 pub mod vocab;
 
-/// Where a fenced code block stands, which is what tells whitespace that
-/// is a block's own content from whitespace that separates prose.
-pub(crate) use fences::fence_marker;
+/// Which lines stand inside a code block, which is what tells whitespace
+/// that is a block's own content from whitespace that separates prose.
+pub(crate) use fences::inside_a_block;
 
 /// One thing the user should hear about a rendering, with the fix when
 /// there is one — every render lint travels through this shape.

--- a/crates/core/tests/edits_and_forks/agent_wrapper.rs
+++ b/crates/core/tests/edits_and_forks/agent_wrapper.rs
@@ -338,3 +338,71 @@ fn an_edited_generated_section_is_kept_and_the_canonical_one_written_beside_it()
     );
     assert_eq!(banners(&text), 1, "{text}");
 }
+
+/// The published prose may open and close with sections of its own that
+/// read exactly like the generated ones. Delete the generated copies and
+/// the publisher's are what stands at each boundary — so a walk that knows
+/// only what the renderer writes takes them, and a whole section of
+/// somebody's catalog prose is gone.
+#[test]
+#[allow(clippy::unwrap_used)]
+fn a_published_section_standing_where_a_generated_one_did_is_not_taken() {
+    let w = agent_world(
+        "\"claude\"",
+        "---\nname: rev\ndescription: agent rev\n---\n## Launch Instructions\n\nRead the brief first.\n\nUpstream body.\n\n## Additional Instructions\n\nSay what you changed.\n",
+        "",
+        "[agent-launch-instructions]\nrev = \"Read the brief first.\"\n\n[agent-additional-instructions]\nrev = \"Say what you changed.\"\n",
+    );
+    let file = rendered(&w, HarnessId::Claude, "rev");
+    let text = fs::read_to_string(&file).unwrap();
+    // Each section stands twice: the catalog's own copy, and the generated
+    // one that is a duplicate of it.
+    for section in ["## Launch Instructions", "## Additional Instructions"] {
+        assert_eq!(times(&text, section), 2, "{text}");
+    }
+
+    // The person deletes the generated copy of each, keeping the
+    // publisher's. Only theirs is left standing at either boundary.
+    let head = "## Launch Instructions\n\nRead the brief first.\n\n";
+    let tail = "\n## Additional Instructions\n\nSay what you changed.\n";
+    let edited = text.replacen(head, "", 1);
+    let cut = edited.rfind(tail).unwrap();
+    let edited = format!("{}{}", &edited[..cut], &edited[cut + tail.len()..])
+        .replace("Upstream body.", "My body.");
+    for section in ["## Launch Instructions", "## Additional Instructions"] {
+        assert_eq!(times(&edited, section), 1, "{edited}");
+    }
+    assert_eq!(banners(&edited), 1, "{edited}");
+    fs::write(&file, &edited).unwrap();
+
+    let plan = fork::fork(&w.env, &w.scope, ItemKind::Agent, "rev", HarnessId::Claude).unwrap();
+    apply::execute(&w.env, &plan, None).unwrap();
+    resettle(&w);
+
+    let source = fs::read_to_string(captured(&w, "rev")).unwrap();
+    for line in [
+        "## Launch Instructions",
+        "Read the brief first.",
+        "## Additional Instructions",
+        "Say what you changed.",
+        "My body.",
+    ] {
+        assert_eq!(
+            times(&source, line),
+            1,
+            "{line} is the publisher's own prose and the capture took it for the wrapper's: {source}"
+        );
+    }
+
+    let text = fs::read_to_string(&file).unwrap();
+    for line in [
+        "## Launch Instructions",
+        "Read the brief first.",
+        "## Additional Instructions",
+        "Say what you changed.",
+    ] {
+        assert_eq!(times(&text, line), 2, "{line} count wrong: {text}");
+    }
+    assert_eq!(times(&text, "My body."), 1, "{text}");
+    assert_eq!(banners(&text), 1, "{text}");
+}

--- a/crates/core/tests/edits_and_forks/agent_wrapper.rs
+++ b/crates/core/tests/edits_and_forks/agent_wrapper.rs
@@ -484,3 +484,104 @@ fn a_published_section_the_rewrite_makes_identical_is_not_taken() {
     assert_eq!(times(&text, "My body."), 1, "{text}");
     assert_eq!(banners(&text), 1, "{text}");
 }
+
+/// A body may spell the banner as an example of it — indented into a code
+/// block, where it is the person's own content. The walk had the banner
+/// already, as the section the renderer wrote at the top; a filter run
+/// over what the walk kept takes their line as well, wherever it stands.
+#[test]
+#[allow(clippy::unwrap_used)]
+fn a_banner_line_the_body_spells_as_an_example_is_kept() {
+    let example = format!("    {BANNER}");
+    let w = agent_world(
+        "\"claude\"",
+        &format!(
+            "---\nname: rev\ndescription: agent rev\n---\nUpstream body. Every rendering opens with:\n\n{example}\n"
+        ),
+        "",
+        "",
+    );
+    let file = rendered(&w, HarnessId::Claude, "rev");
+    let text = fs::read_to_string(&file).unwrap();
+    // The generated banner, and the person's example of one.
+    assert_eq!(banners(&text), 2, "{text}");
+    edit_body(&file);
+
+    let plan = fork::fork(&w.env, &w.scope, ItemKind::Agent, "rev", HarnessId::Claude).unwrap();
+    apply::execute(&w.env, &plan, None).unwrap();
+    resettle(&w);
+
+    let source = fs::read_to_string(captured(&w, "rev")).unwrap();
+    assert_eq!(
+        banners(&source),
+        1,
+        "the example is the person's own line and the capture took it for the renderer's: {source}"
+    );
+    assert!(
+        source.contains(&example),
+        "the example keeps the indent that makes it a code block: {source}"
+    );
+
+    let text = fs::read_to_string(&file).unwrap();
+    assert_eq!(banners(&text), 2, "{text}");
+    assert_eq!(
+        times(&text, "My body. Every rendering opens with:"),
+        1,
+        "{text}"
+    );
+}
+
+/// A generated section may carry a fenced code block, and inside one a
+/// blank line is a line of the block rather than separation between
+/// sections. A person who edits that whitespace has edited the section,
+/// so it is theirs now and the canonical one is written beside it — a
+/// walk that reads their blank lines as separators subtracts the block
+/// they edited and their edit is gone with it.
+#[test]
+#[allow(clippy::unwrap_used)]
+fn whitespace_a_person_edits_inside_a_generated_code_block_is_their_edit() {
+    let w = agent_world(
+        "\"claude\"",
+        "---\nname: rev\ndescription: agent rev\n---\nUpstream body.\n",
+        "",
+        "[agent-additional-instructions]\nrev = \"\"\"\nRun each in turn:\n\n```sh\nfirst\n\nsecond\n```\"\"\"\n",
+    );
+    let file = rendered(&w, HarnessId::Claude, "rev");
+    let text = fs::read_to_string(&file).unwrap();
+    assert!(text.contains("```sh\nfirst\n\nsecond\n```"), "{text}");
+
+    // The person closes the gap inside the block and leaves every other
+    // line of the section standing.
+    let edited = text
+        .replace("first\n\nsecond", "first\nsecond")
+        .replace("Upstream body.", "My body.");
+    assert_eq!(times(&edited, "## Additional Instructions"), 1, "{edited}");
+    fs::write(&file, &edited).unwrap();
+
+    let plan = fork::fork(&w.env, &w.scope, ItemKind::Agent, "rev", HarnessId::Claude).unwrap();
+    apply::execute(&w.env, &plan, None).unwrap();
+    resettle(&w);
+
+    let source = fs::read_to_string(captured(&w, "rev")).unwrap();
+    assert!(
+        source.contains("```sh\nfirst\nsecond\n```"),
+        "the block they edited is their words now, gap and all: {source}"
+    );
+    for line in [
+        "## Additional Instructions",
+        "Run each in turn:",
+        "My body.",
+    ] {
+        assert_eq!(times(&source, line), 1, "{line} count wrong: {source}");
+    }
+
+    let text = fs::read_to_string(&file).unwrap();
+    assert_eq!(
+        times(&text, "## Additional Instructions"),
+        2,
+        "the section the person edited, and the canonical one beside it: {text}"
+    );
+    assert!(text.contains("```sh\nfirst\nsecond\n```"), "{text}");
+    assert!(text.contains("```sh\nfirst\n\nsecond\n```"), "{text}");
+    assert_eq!(banners(&text), 1, "{text}");
+}

--- a/crates/core/tests/edits_and_forks/agent_wrapper.rs
+++ b/crates/core/tests/edits_and_forks/agent_wrapper.rs
@@ -585,3 +585,132 @@ fn whitespace_a_person_edits_inside_a_generated_code_block_is_their_edit() {
     assert!(text.contains("```sh\nfirst\n\nsecond\n```"), "{text}");
     assert_eq!(banners(&text), 1, "{text}");
 }
+
+/// The renderer writes a section per hook, so the wrapper has to hold one
+/// entry per hook. Held together, a body one hook was deleted from
+/// matches none of them, and the walk stops where they stand — every
+/// generated section written before them stays in the capture and the
+/// next render writes it a second time.
+#[test]
+#[allow(clippy::unwrap_used)]
+fn deleting_one_of_several_hooks_still_takes_the_sections_before_them_off() {
+    let w = world();
+    write_skill(&w.upstream, "recon", "Recon.");
+    write_agent(&w.upstream, "rev", "Upstream body.");
+    fs::write(
+        w.upstream.join("kendex.toml"),
+        "[agent-skills]\nrev = [\"recon\"]\n",
+    )
+    .unwrap();
+    commit(&w.upstream, "one");
+    let path = manifest::manifest_path(&w.env, &w.scope);
+    fs::create_dir_all(path.parent().unwrap()).unwrap();
+    fs::write(
+        &path,
+        format!(
+            "schema = 6\n\n[sources.cat]\nrepo = \"{REPO}\"\n\n[install]\nharnesses = [\"gemini\"]\nmethod = \"symlink\"\n\n[agents.rev]\nsource = \"cat\"\n\n[skills.recon]\nsource = \"cat\"\n\n[[custom-hooks]]\nname = \"first\"\nevent = \"PreToolUse\"\ncommand = \"./scripts/first.sh\"\nagents = [\"rev\"]\n\n[[custom-hooks]]\nname = \"second\"\nevent = \"PostToolUse\"\ncommand = \"./scripts/second.sh\"\nagents = [\"rev\"]\n"
+        ),
+    )
+    .unwrap();
+    sync_and_apply(&w);
+    let file = rendered(&w, HarnessId::Gemini, "rev");
+    let text = fs::read_to_string(&file).unwrap();
+    let first = "## Safety: PreToolUse on every match";
+    let second = "## Safety: PostToolUse on every match";
+    for line in ["## Required Skills", first, second] {
+        assert_eq!(times(&text, line), 1, "{line} count wrong: {text}");
+    }
+
+    // The person deletes the last hook's section and leaves the other
+    // hook and the skills section standing.
+    let tail = format!("\n{second}\n\nRun: `./scripts/second.sh`\n");
+    let cut = text.rfind(&tail).unwrap();
+    let edited = format!("{}{}", &text[..cut], &text[cut + tail.len()..])
+        .replace("Upstream body.", "My body.");
+    assert_eq!(times(&edited, second), 0, "{edited}");
+    assert_eq!(times(&edited, first), 1, "{edited}");
+    fs::write(&file, &edited).unwrap();
+
+    let plan = fork::fork(&w.env, &w.scope, ItemKind::Agent, "rev", HarnessId::Gemini).unwrap();
+    apply::execute(&w.env, &plan, None).unwrap();
+    resettle(&w);
+
+    let source = fs::read_to_string(captured(&w, "rev")).unwrap();
+    for line in [
+        "## Required Skills",
+        "- recon: .agents/skills/recon/SKILL.md",
+        first,
+    ] {
+        assert_eq!(
+            times(&source, line),
+            0,
+            "the fork writes {line} again, so the capture must not hold it: {source}"
+        );
+    }
+    assert!(source.contains("My body."), "{source}");
+
+    let text = fs::read_to_string(&file).unwrap();
+    for line in [
+        "## Required Skills",
+        "- recon: .agents/skills/recon/SKILL.md",
+        first,
+        second,
+        "My body.",
+    ] {
+        assert_eq!(times(&text, line), 1, "{line} count wrong: {text}");
+    }
+    assert_eq!(banners(&text), 1, "{text}");
+}
+
+/// A code block indented into the prose is a block like a fenced one, and
+/// a blank line inside it is the block's own. A walk that reads a block
+/// only where its markers are takes the section the person edited, and
+/// their edit goes with it.
+#[test]
+#[allow(clippy::unwrap_used)]
+fn whitespace_a_person_edits_inside_an_indented_block_is_their_edit() {
+    let w = agent_world(
+        "\"claude\"",
+        "---\nname: rev\ndescription: agent rev\n---\nUpstream body.\n",
+        "",
+        "[agent-additional-instructions]\nrev = \"\"\"\nRun each in turn:\n\n    first\n\n    second\"\"\"\n",
+    );
+    let file = rendered(&w, HarnessId::Claude, "rev");
+    let text = fs::read_to_string(&file).unwrap();
+    assert!(text.contains("    first\n\n    second"), "{text}");
+
+    // The person closes the gap inside the block and leaves every other
+    // line of the section standing.
+    let edited = text
+        .replace("    first\n\n    second", "    first\n    second")
+        .replace("Upstream body.", "My body.");
+    assert_eq!(times(&edited, "## Additional Instructions"), 1, "{edited}");
+    fs::write(&file, &edited).unwrap();
+
+    let plan = fork::fork(&w.env, &w.scope, ItemKind::Agent, "rev", HarnessId::Claude).unwrap();
+    apply::execute(&w.env, &plan, None).unwrap();
+    resettle(&w);
+
+    let source = fs::read_to_string(captured(&w, "rev")).unwrap();
+    assert!(
+        source.contains("    first\n    second"),
+        "the block they edited is their words now, gap and all: {source}"
+    );
+    for line in [
+        "## Additional Instructions",
+        "Run each in turn:",
+        "My body.",
+    ] {
+        assert_eq!(times(&source, line), 1, "{line} count wrong: {source}");
+    }
+
+    let text = fs::read_to_string(&file).unwrap();
+    assert_eq!(
+        times(&text, "## Additional Instructions"),
+        2,
+        "the section the person edited, and the canonical one beside it: {text}"
+    );
+    assert!(text.contains("    first\n    second"), "{text}");
+    assert!(text.contains("    first\n\n    second"), "{text}");
+    assert_eq!(banners(&text), 1, "{text}");
+}

--- a/crates/core/tests/edits_and_forks/agent_wrapper.rs
+++ b/crates/core/tests/edits_and_forks/agent_wrapper.rs
@@ -1,0 +1,340 @@
+//! Taking the generated wrapper off an agent's prose. The rendering a fork
+//! is captured from is the person's own words inside everything the
+//! renderer wrote around them, and a person may have edited or deleted any
+//! of it: what comes off has to be what the renderer wrote and nothing of
+//! theirs, however much theirs reads like it.
+
+use std::fs;
+
+use super::*;
+
+/// The generated banner is the one line a person reaches for when they
+/// want it out of their way, and deleting it leaves a body the wrapper no
+/// longer starts with. Every section that wrapper introduced is still
+/// generated, so a capture that keeps them renders each of them twice.
+#[test]
+#[allow(clippy::unwrap_used)]
+fn deleting_the_banner_alone_still_takes_the_generated_sections_off() {
+    let w = agent_world(
+        "\"claude\"",
+        "---\nname: rev\ndescription: agent rev\n---\nUpstream body.\n",
+        "",
+        "[agent-launch-instructions]\nrev = \"Read the brief first.\"\n\n[agent-additional-instructions]\nrev = \"Say what you changed.\"\n",
+    );
+    let file = rendered(&w, HarnessId::Claude, "rev");
+    edit_body(&file);
+    let edited = fs::read_to_string(&file)
+        .unwrap()
+        .replace(&format!("{BANNER}\n"), "");
+    assert_eq!(banners(&edited), 0, "{edited}");
+    fs::write(&file, &edited).unwrap();
+
+    let plan = fork::fork(&w.env, &w.scope, ItemKind::Agent, "rev", HarnessId::Claude).unwrap();
+    apply::execute(&w.env, &plan, None).unwrap();
+    resettle(&w);
+
+    // Each section is counted by its heading and by a line only that
+    // section holds: a heading the capture kept and the render wrote again
+    // stands twice, and so does the text under it.
+    let generated = [
+        "## Launch Instructions",
+        "Read the brief first.",
+        "## Additional Instructions",
+        "Say what you changed.",
+    ];
+    let source = fs::read_to_string(captured(&w, "rev")).unwrap();
+    for line in generated {
+        assert_eq!(
+            times(&source, line),
+            0,
+            "the capture kept {line}, which the render writes again: {source}"
+        );
+    }
+    assert!(source.contains("My body."), "{source}");
+
+    let text = fs::read_to_string(&file).unwrap();
+    for line in generated {
+        assert_eq!(times(&text, line), 1, "{line} stands twice: {text}");
+    }
+    assert_eq!(banners(&text), 1, "{text}");
+    assert_eq!(times(&text, "My body."), 1, "{text}");
+}
+
+/// A generated section comes off the prose whole, rows and all. Keeping
+/// any part of one leaves a headerless fragment in the body, standing
+/// beside the freshly generated section it was cut from.
+#[test]
+#[allow(clippy::unwrap_used)]
+fn a_section_the_fork_writes_again_comes_off_whole() {
+    let w = world();
+    write_skill(&w.upstream, "mine", "Mine.");
+    write_skill(&w.upstream, "theirs", "Theirs.");
+    write_agent(&w.upstream, "rev", "Upstream body.");
+    fs::write(
+        w.upstream.join("kendex.toml"),
+        "[agent-skills]\nrev = [\"mine\", \"theirs\"]\n",
+    )
+    .unwrap();
+    commit(&w.upstream, "one");
+    let path = manifest::manifest_path(&w.env, &w.scope);
+    fs::create_dir_all(path.parent().unwrap()).unwrap();
+    fs::write(
+        &path,
+        format!(
+            "schema = 6\n\n[sources.cat]\nrepo = \"{REPO}\"\n\n[install]\nharnesses = [\"gemini\"]\nmethod = \"symlink\"\n\n[agents.rev]\nsource = \"cat\"\n\n[skills.mine]\nsource = \"cat\"\n\n[skills.theirs]\nsource = \"cat\"\n"
+        ),
+    )
+    .unwrap();
+    sync_and_apply(&w);
+    let file = rendered(&w, HarnessId::Gemini, "rev");
+    edit_body(&file);
+
+    let plan = fork::fork(&w.env, &w.scope, ItemKind::Agent, "rev", HarnessId::Gemini).unwrap();
+    apply::execute(&w.env, &plan, None).unwrap();
+    resettle(&w);
+
+    let source = fs::read_to_string(captured(&w, "rev")).unwrap();
+    assert_eq!(
+        times(&source, "## Required Skills"),
+        0,
+        "the fork writes the section again, so the capture must not hold it: {source}"
+    );
+    for row in [
+        "- mine: .agents/skills/mine/SKILL.md",
+        "- theirs: .agents/skills/theirs/SKILL.md",
+    ] {
+        assert_eq!(
+            times(&source, row),
+            0,
+            "a row of the section the fork writes again is a headerless fragment: {source}"
+        );
+    }
+    assert!(source.contains("My body."), "{source}");
+
+    let text = fs::read_to_string(&file).unwrap();
+    assert_eq!(times(&text, "## Required Skills"), 1, "{text}");
+    for row in [
+        "- mine: .agents/skills/mine/SKILL.md",
+        "- theirs: .agents/skills/theirs/SKILL.md",
+    ] {
+        assert_eq!(
+            times(&text, row),
+            1,
+            "the fork keeps the skills it was rendered with, each once: {text}"
+        );
+    }
+    assert_eq!(banners(&text), 1, "{text}");
+    assert_eq!(times(&text, "My body."), 1, "{text}");
+}
+
+/// A section is what wrote it, not what it reads like. An agent whose own
+/// instructions spell `## Required Skills` has not made that heading a
+/// section: the instructions are one section, inner heading and all, so
+/// deleting the real skills section leaves the walk to pass over it and
+/// still take the instructions off whole.
+#[test]
+#[allow(clippy::unwrap_used)]
+fn a_heading_inside_instruction_text_is_not_a_generated_section() {
+    let w = world();
+    write_skill(&w.upstream, "recon", "Recon.");
+    write_agent(&w.upstream, "rev", "Upstream body.");
+    fs::write(
+        w.upstream.join("kendex.toml"),
+        "[agent-skills]\nrev = [\"recon\"]\n",
+    )
+    .unwrap();
+    commit(&w.upstream, "one");
+    let path = manifest::manifest_path(&w.env, &w.scope);
+    fs::create_dir_all(path.parent().unwrap()).unwrap();
+    fs::write(
+        &path,
+        format!(
+            "schema = 6\n\n[sources.cat]\nrepo = \"{REPO}\"\n\n[install]\nharnesses = [\"gemini\"]\nmethod = \"symlink\"\n\n[agents.rev]\nsource = \"cat\"\n\n[skills.recon]\nsource = \"cat\"\n\n[agent-additional-instructions]\nrev = \"\"\"\nBefore the heading.\n\n## Required Skills\n\nAfter the heading.\"\"\"\n"
+        ),
+    )
+    .unwrap();
+    sync_and_apply(&w);
+    let file = rendered(&w, HarnessId::Gemini, "rev");
+
+    // The person deletes the generated skills section and leaves the
+    // instructions standing. What follows their prose is now one section
+    // whose own words spell the heading of the one they deleted.
+    let edited = fs::read_to_string(&file)
+        .unwrap()
+        .replace(
+            "\n## Required Skills\n\nRead each before acting:\n- recon: .agents/skills/recon/SKILL.md\n",
+            "",
+        )
+        .replace("Upstream body.", "My body.");
+    assert_eq!(times(&edited, "## Required Skills"), 1, "{edited}");
+    assert_eq!(times(&edited, "Read each before acting:"), 0, "{edited}");
+    fs::write(&file, &edited).unwrap();
+
+    let plan = fork::fork(&w.env, &w.scope, ItemKind::Agent, "rev", HarnessId::Gemini).unwrap();
+    apply::execute(&w.env, &plan, None).unwrap();
+    resettle(&w);
+
+    let source = fs::read_to_string(captured(&w, "rev")).unwrap();
+    for line in [
+        "## Required Skills",
+        "## Additional Instructions",
+        "Before the heading.",
+        "After the heading.",
+    ] {
+        assert_eq!(
+            times(&source, line),
+            0,
+            "the render writes {line} again, so the capture must not hold it: {source}"
+        );
+    }
+    assert!(source.contains("My body."), "{source}");
+
+    let text = fs::read_to_string(&file).unwrap();
+    for line in [
+        "Read each before acting:",
+        "- recon: .agents/skills/recon/SKILL.md",
+        "## Additional Instructions",
+        "Before the heading.",
+        "After the heading.",
+        "My body.",
+    ] {
+        assert_eq!(times(&text, line), 1, "{line} count wrong: {text}");
+    }
+    assert_eq!(
+        times(&text, "## Required Skills"),
+        2,
+        "the generated section and the instructions' own heading, one each: {text}"
+    );
+    assert_eq!(banners(&text), 1, "{text}");
+}
+
+/// A generated instruction saying what the person's own prose already says
+/// is the ordinary reason to delete the generated one. Their line is then
+/// their own, standing where the wrapper's used to, and a subtraction that
+/// goes looking for a line rather than for a whole section takes it.
+#[test]
+#[allow(clippy::unwrap_used)]
+fn prose_borrowing_the_wrappers_words_at_either_end_is_kept() {
+    let w = agent_world(
+        "\"claude\"",
+        "---\nname: rev\ndescription: agent rev\n---\nUpstream body.\n",
+        "",
+        "[agent-launch-instructions]\nrev = \"Read the brief first.\"\n\n[agent-additional-instructions]\nrev = \"Say what you changed.\"\n",
+    );
+    let file = rendered(&w, HarnessId::Claude, "rev");
+    let edited = fs::read_to_string(&file)
+        .unwrap()
+        .replace("## Launch Instructions\n\nRead the brief first.\n\n", "")
+        .replace(
+            "\n## Additional Instructions\n\nSay what you changed.\n",
+            "",
+        )
+        .replace(
+            "Upstream body.",
+            "Read the brief first.\n\nMiddle of my body.\n\nSay what you changed.",
+        );
+    // Both generated sections deleted, and each of their lines now stands
+    // once — as the person's own first and last line.
+    for line in ["## Launch Instructions", "## Additional Instructions"] {
+        assert_eq!(times(&edited, line), 0, "{edited}");
+    }
+    for line in ["Read the brief first.", "Say what you changed."] {
+        assert_eq!(times(&edited, line), 1, "{edited}");
+    }
+    fs::write(&file, &edited).unwrap();
+
+    let plan = fork::fork(&w.env, &w.scope, ItemKind::Agent, "rev", HarnessId::Claude).unwrap();
+    apply::execute(&w.env, &plan, None).unwrap();
+    resettle(&w);
+
+    let source = fs::read_to_string(captured(&w, "rev")).unwrap();
+    for line in [
+        "Read the brief first.",
+        "Middle of my body.",
+        "Say what you changed.",
+    ] {
+        assert_eq!(
+            times(&source, line),
+            1,
+            "the capture took {line} for the wrapper's, and it was the person's: {source}"
+        );
+    }
+    for line in ["## Launch Instructions", "## Additional Instructions"] {
+        assert_eq!(times(&source, line), 0, "{source}");
+    }
+
+    // Their line stands beside the generated one it duplicates, which is
+    // what deleting the generated one and writing their own asked for.
+    let text = fs::read_to_string(&file).unwrap();
+    for line in ["Read the brief first.", "Say what you changed."] {
+        assert_eq!(times(&text, line), 2, "{line} count wrong: {text}");
+    }
+    for line in [
+        "## Launch Instructions",
+        "## Additional Instructions",
+        "Middle of my body.",
+    ] {
+        assert_eq!(times(&text, line), 1, "{line} count wrong: {text}");
+    }
+    assert_eq!(banners(&text), 1, "{text}");
+}
+
+/// Nothing here can tell a generated section the person edited from prose
+/// of their own that resembles one — that is the forgery this reading
+/// exists to refuse — so a section the body does not hold whole is kept as
+/// their words, and the canonical one is written beside it. Two copies are
+/// visible and a person can settle them; words taken for the wrapper's are
+/// gone.
+#[test]
+#[allow(clippy::unwrap_used)]
+fn an_edited_generated_section_is_kept_and_the_canonical_one_written_beside_it() {
+    let w = agent_world(
+        "\"claude\"",
+        "---\nname: rev\ndescription: agent rev\n---\nUpstream body.\n",
+        "",
+        "[agent-launch-instructions]\nrev = \"Read the brief first.\"\n",
+    );
+    let file = rendered(&w, HarnessId::Claude, "rev");
+    let edited = fs::read_to_string(&file)
+        .unwrap()
+        .replace(
+            "Read the brief first.",
+            "Read the brief first, then the tests.",
+        )
+        .replace("Upstream body.", "My body.");
+    // The heading still stands; only the line under it was rewritten.
+    assert_eq!(times(&edited, "## Launch Instructions"), 1, "{edited}");
+    assert_eq!(times(&edited, "Read the brief first."), 0, "{edited}");
+    fs::write(&file, &edited).unwrap();
+
+    let plan = fork::fork(&w.env, &w.scope, ItemKind::Agent, "rev", HarnessId::Claude).unwrap();
+    apply::execute(&w.env, &plan, None).unwrap();
+    resettle(&w);
+
+    let source = fs::read_to_string(captured(&w, "rev")).unwrap();
+    for line in [
+        "## Launch Instructions",
+        "Read the brief first, then the tests.",
+        "My body.",
+    ] {
+        assert_eq!(
+            times(&source, line),
+            1,
+            "the edited section is the person's words now, and {line} is one of them: {source}"
+        );
+    }
+
+    let text = fs::read_to_string(&file).unwrap();
+    assert_eq!(
+        times(&text, "## Launch Instructions"),
+        2,
+        "the section the person edited, and the canonical one beside it: {text}"
+    );
+    assert_eq!(times(&text, "Read the brief first."), 1, "{text}");
+    assert_eq!(
+        times(&text, "Read the brief first, then the tests."),
+        1,
+        "{text}"
+    );
+    assert_eq!(banners(&text), 1, "{text}");
+}

--- a/crates/core/tests/edits_and_forks/agent_wrapper.rs
+++ b/crates/core/tests/edits_and_forks/agent_wrapper.rs
@@ -406,3 +406,81 @@ fn a_published_section_standing_where_a_generated_one_did_is_not_taken() {
     assert_eq!(times(&text, "My body."), 1, "{text}");
     assert_eq!(banners(&text), 1, "{text}");
 }
+
+/// Every harness but Claude says an agent's tool references in its own
+/// words, so the catalog's bytes and what those bytes stand as in the
+/// rendering are different text. A published section the rewrite turns
+/// into an exact copy of a generated one is invisible to a count taken
+/// from the source: the count has to be taken from the rendering, or the
+/// publisher's own section goes when the person deletes the generated one.
+#[test]
+#[allow(clippy::unwrap_used)]
+fn a_published_section_the_rewrite_makes_identical_is_not_taken() {
+    let w = agent_world(
+        "\"gemini\"",
+        "---\nname: rev\ndescription: agent rev\n---\n## Launch Instructions\n\nUse the Read tool.\n\nUpstream body.\n\n## Additional Instructions\n\nUse the Bash tool.\n",
+        "",
+        "[agent-launch-instructions]\nrev = \"Use the read_file tool.\"\n\n[agent-additional-instructions]\nrev = \"Use the run_shell_command tool.\"\n",
+    );
+    let file = rendered(&w, HarnessId::Gemini, "rev");
+    let text = fs::read_to_string(&file).unwrap();
+    // The catalog wrote Claude's names, and Gemini's rendering says them
+    // in Gemini's — which is what makes each published section read
+    // exactly like the generated one standing beside it.
+    for line in ["Use the Read tool.", "Use the Bash tool."] {
+        assert_eq!(times(&text, line), 0, "{text}");
+    }
+    for line in [
+        "## Launch Instructions",
+        "Use the read_file tool.",
+        "## Additional Instructions",
+        "Use the run_shell_command tool.",
+    ] {
+        assert_eq!(times(&text, line), 2, "{line} count wrong: {text}");
+    }
+
+    // The person deletes the generated copy at each boundary, keeping the
+    // publisher's.
+    let head = "## Launch Instructions\n\nUse the read_file tool.\n\n";
+    let tail = "\n## Additional Instructions\n\nUse the run_shell_command tool.\n";
+    let edited = text.replacen(head, "", 1);
+    let cut = edited.rfind(tail).unwrap();
+    let edited = format!("{}{}", &edited[..cut], &edited[cut + tail.len()..])
+        .replace("Upstream body.", "My body.");
+    for section in ["## Launch Instructions", "## Additional Instructions"] {
+        assert_eq!(times(&edited, section), 1, "{edited}");
+    }
+    assert_eq!(banners(&edited), 1, "{edited}");
+    fs::write(&file, &edited).unwrap();
+
+    let plan = fork::fork(&w.env, &w.scope, ItemKind::Agent, "rev", HarnessId::Gemini).unwrap();
+    apply::execute(&w.env, &plan, None).unwrap();
+    resettle(&w);
+
+    let source = fs::read_to_string(captured(&w, "rev")).unwrap();
+    for line in [
+        "## Launch Instructions",
+        "Use the read_file tool.",
+        "## Additional Instructions",
+        "Use the run_shell_command tool.",
+        "My body.",
+    ] {
+        assert_eq!(
+            times(&source, line),
+            1,
+            "{line} is the publisher's own prose and the capture took it for the wrapper's: {source}"
+        );
+    }
+
+    let text = fs::read_to_string(&file).unwrap();
+    for line in [
+        "## Launch Instructions",
+        "Use the read_file tool.",
+        "## Additional Instructions",
+        "Use the run_shell_command tool.",
+    ] {
+        assert_eq!(times(&text, line), 2, "{line} count wrong: {text}");
+    }
+    assert_eq!(times(&text, "My body."), 1, "{text}");
+    assert_eq!(banners(&text), 1, "{text}");
+}

--- a/crates/core/tests/edits_and_forks/main.rs
+++ b/crates/core/tests/edits_and_forks/main.rs
@@ -7,6 +7,7 @@ mod access;
 mod agent_capture;
 mod agent_settings;
 mod agent_tables;
+mod agent_wrapper;
 mod beside;
 mod disabled;
 mod edited_harness;

--- a/tools/size-ratchet-baseline.tsv
+++ b/tools/size-ratchet-baseline.tsv
@@ -4,7 +4,7 @@ crates/core/src/engine/detach.rs	441
 crates/core/src/engine/pi_hooks_move/migrated.rs	540
 crates/core/src/engine/pi_hooks_move/mod.rs	503
 crates/core/src/engine/pi_hooks_move/preflight.rs	765
-crates/core/src/error.rs	484
+crates/core/src/error.rs	495
 crates/core/src/remote/store.rs	405
 crates/core/src/settings_file.rs	408
 docs/ARCHITECTURE.md	801


### PR DESCRIPTION
`prose()` took the generated wrapper off the edited body by exact match at both ends — `strip_prefix(before)`, `strip_suffix(after)`, each falling back to keeping the whole body. Two ways past it, and they are the same subtraction failing:

- **Banner deleted.** `before` includes the generated banner, so a person who removed only that one line leaves a body the prefix no longer matches. The line filter below removes the banner but not the section it introduced, so the wrapper survived into the fork's own source and the next render wrote it again. The function's own comment already promised this case worked.
- **Partial section.** Where the fork writes a shorter copy of a section, the common prefix/suffix subtraction kept a middle fragment with no heading — a bare bullet landing in the agent body, outside the instruction it belonged under and ahead of a freshly generated section it was cut from.

One string at each end can say neither "this wrapper, minus a line the person removed" nor "this section, partially".

## The fix

The wrapper stops being one string at each end and becomes the sequence of generated sections it is made of.

`generated(body, wrapper)` counts how many lines at the front of a body the wrapper wrote, walking the wrapper's lines in order and skipping one the body no longer holds, stopping at the first body line the unmatched remainder does not hold. Run once forward for `before` and once on reversed slices for `after`.

`not_coming_back(was, will_be)` keeps back only the sections no `will_be` section opens under the same heading, and keeps them whole. `sections()` splits on the document's own headings rather than a list of names kept here — the same reason `wrapper()` asks the renderer instead of assembling one.

Both sites fall out of it. The banner's absence now skips one wrapper line and the section it introduced still comes off, so there is nothing left for the line filter to run after. A section the fork writes again is subtracted whole and can leave no fragment; `dropped_section`, which produced the headerless bullet, is deleted.

Preservation is not extended to the `before` half: `Around` differs between `was` and `will_be` only in `skills`, and skills render after the prose on every harness that has them, so only `after` can lose a section.

## Tests

Both count exact lines with the file's own `times()` helper — no `contains`, because a `contains` assertion is what let a section duplication through on a sibling PR.

- `deleting_the_banner_alone_still_takes_the_generated_sections_off` — a Claude agent with launch and additional instructions, body edited, banner line alone removed. Counts both headings and the distinctive text under each: 0 in the captured source, 1 in the settled rendering. Red on base with `## Launch Instructions` at 1 in the captured source.
- `a_section_the_fork_writes_again_comes_off_whole` — a Gemini agent assigned catalog skills `mine` and `theirs`, with `mine` in the local source so the fork's own rendering carries half the section. Red on base with the `theirs` bullet at 1 in the captured source, dumped as a bare bullet under the body with no heading.

## Note for review

The subtraction moved to `crates/core/src/engine/fork/agent/prose.rs`. `agent.rs` hit 432 lines against the 400 threshold with no baseline row, so that move is a split at a concept seam rather than a raise. It also answers a question of its own.

`crates/core/src/error.rs` does take a raise, 484 to 495, for the `ForkWrapperUnreadable` variant — an enum of error variants has no seam to split at, and the added lines are the refusal itself. It was declared with `RATCHET_RAISE=1` on the commit that made it, whose body carries the reason; the row equals the file's actual line count, so the merge-group tighten check reads it as exact rather than loose. An earlier revision of this note said the PR carried no baseline edit, which was true of the `agent.rs` split it described and wrong about the PR.

`local_skills` and the preservation branch stay: on this base the branch is still reached and is what keeps the existing written-once test green. It is KEN-777 that makes it dead, not this change. This area is being restructured on that branch too, so whichever lands second will want a look at `not_coming_back`, which is what `dropped_section` used to feed.

Closes KEN-788

