### PR TITLE
fix(KEN-754): the command kendex installs is checked like the app is

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -139,6 +139,26 @@ jobs:
           done
           ls -l dist
         shell: bash
+      # `kendex update` replaces the running command with the bytes the feed
+      # names, and refuses any the signature beside them does not cover, so
+      # the command is signed under the same key as the app bundles rather
+      # than being the one download nothing checks. Tauri's signer writes
+      # `<file>.sig`; a lane that produced none has published a download no
+      # client can verify, so it fails here instead.
+      - name: Sign the kendex command
+        shell: bash
+        env:
+          TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
+          TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}
+        run: |
+          ext=""
+          [ "${{ runner.os }}" = "Windows" ] && ext=".exe"
+          binary="dist/kendex-${{ matrix.target }}${ext}"
+          ui/node_modules/.bin/tauri signer sign "$binary"
+          if [ ! -s "${binary}.sig" ]; then
+            echo "::error::No signature for ${binary}. kendex update refuses a command it cannot verify; check this lane's signer step and TAURI_SIGNING_PRIVATE_KEY, then re-run the tag."
+            exit 1
+          fi
       - uses: actions/upload-artifact@v4
         with:
           name: assets-${{ matrix.target }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -139,12 +139,10 @@ jobs:
           done
           ls -l dist
         shell: bash
-      # `kendex update` replaces the running command with the bytes the feed
-      # names, and refuses any the signature beside them does not cover, so
-      # the command is signed under the same key as the app bundles rather
-      # than being the one download nothing checks. Tauri's signer writes
-      # `<file>.sig`; a lane that produced none has published a download no
-      # client can verify, so it fails here instead.
+      # `kendex update` refuses a command the signature beside it does not
+      # cover, so the command is signed under the same key as the app
+      # bundles. Tauri's signer writes `<file>.sig`; a lane that produced
+      # none published a download no client can verify, so it fails here.
       - name: Sign the kendex command
         shell: bash
         env:

--- a/changelog.d/security/KEN-754.md
+++ b/changelog.d/security/KEN-754.md
@@ -1,0 +1,3 @@
+- `kendex update` verifies the kendex command it downloads, not only the app:
+  an altered binary is refused and the installed command left alone.
+  `KENDEX_UPDATE_FEED` is honored in debug builds only.

--- a/crates/cli/src/commands/update.rs
+++ b/crates/cli/src/commands/update.rs
@@ -8,18 +8,36 @@ use kendex_core::process::Hardened;
 use kendex_core::update_channel::feed_url_for;
 use kendex_core::update_feed::{
     ReleaseFeed, UPDATER_PUBLIC_KEY, VersionRelation, app_image_signature_url, app_image_url,
-    release_notes_url, verify_signature,
+    release_notes_url, signature_url, verify_signature,
 };
 
 use super::{CliResult, out, say};
 
 /// The release feed is parsed by core so the CLI and app accept one schema,
 /// and core picks which feed off the running version so both shells follow
-/// one channel. `KENDEX_UPDATE_FEED` overrides the URL so compat tests run
-/// against a local fixture instead of the network.
+/// one channel.
 fn feed_url() -> String {
-    std::env::var("KENDEX_UPDATE_FEED")
-        .unwrap_or_else(|_| feed_url_for(env!("CARGO_PKG_VERSION")).to_owned())
+    #[cfg(debug_assertions)]
+    {
+        selected_feed(std::env::var("KENDEX_UPDATE_FEED").ok(), true)
+    }
+    #[cfg(not(debug_assertions))]
+    {
+        selected_feed(None, false)
+    }
+}
+
+/// The feed a run reads, given the override it was handed. A debug build
+/// honors it so the compat suite can point a run at a local fixture; a
+/// release build takes the channel's own URL and nothing else, because the
+/// feed names the bytes that replace the running command and an override
+/// would let anything that can set a variable name them instead. The app
+/// gates the same variable the same way (`crates/app/src/app_update.rs`).
+fn selected_feed(override_url: Option<String>, debug_build: bool) -> String {
+    match (debug_build, override_url) {
+        (true, Some(url)) => url,
+        (true, None) | (false, _) => feed_url_for(env!("CARGO_PKG_VERSION")).to_owned(),
+    }
 }
 
 /// The feed keys its assets by the build target, one per lane in
@@ -65,20 +83,30 @@ pub fn run(env: &Env, force: bool) -> CliResult {
     // through a link is judged by its target and replaced at the link.
     let current_exe = Host.resolve(&std::env::current_exe()?);
     let channel = for_cli(&current_exe, &Host);
-    run_on(env, force, &feed_url(), &current_exe, &channel)
+    run_on(
+        env,
+        force,
+        &feed_url(),
+        &current_exe,
+        &channel,
+        UPDATER_PUBLIC_KEY,
+    )
 }
 
 /// The update with everything it reads off this process handed to it: the
-/// feed to ask, the command's own path, and who owns that path. Which arm a
-/// person lands on is the channel, and a package-managed one is the arm no
-/// test can reach by running: `for_cli` judges the real `current_exe`, which
-/// nothing here can place under `/usr` or a brew prefix.
+/// feed to ask, the command's own path, who owns that path, and the key
+/// every download is held to. Which arm a person lands on is the channel,
+/// and a package-managed one is the arm no test can reach by running:
+/// `for_cli` judges the real `current_exe`, which nothing here can place
+/// under `/usr` or a brew prefix. The key is an argument for the same
+/// reason core's is — a test holds a signature it made itself.
 fn run_on(
     env: &Env,
     force: bool,
     feed_url: &str,
     current_exe: &Path,
     channel: &InstallChannel,
+    public_key: &str,
 ) -> CliResult {
     if let InstallChannel::Managed { command } = channel {
         out("a package manager owns this install; update it with:");
@@ -120,13 +148,21 @@ fn run_on(
     // as newer, and both halves are tried again instead of stopping at
     // already-up-to-date. Its bytes are fetched first so a lost download
     // costs nothing that is already on disk.
+    //
+    // The feed is the one input here nothing signs, so the asset URL is a
+    // host anyone who can alter the feed chooses. The signature published
+    // beside those bytes is what makes that harmless: it is fetched from
+    // wherever they came from and still has to check out under a key baked
+    // into this build, so a redirected download is refused rather than
+    // written over the running command.
     let binary = fetch(asset)?;
+    let signature = fetch(&signature_url(asset))?;
     let app_replaced = match channel {
-        InstallChannel::Direct => update_app(env, latest)?,
+        InstallChannel::Direct => update_app(env, latest, public_key)?,
         // Nothing here is ours to replace beyond the command itself.
         InstallChannel::Managed { .. } | InstallChannel::Unknown => false,
     };
-    if let Err(error) = replace_executable(current_exe, &binary) {
+    if let Err(error) = install_verified(current_exe, &binary, &signature, public_key) {
         return Err(command_failure(latest, app_replaced, &error).into());
     }
     out(&format!("updated to {latest}"));
@@ -137,7 +173,7 @@ fn run_on(
 /// already on the new release does leave the machine split, but the
 /// command still reads older than the feed, so running it again repeats
 /// both halves rather than stopping at already-up-to-date.
-fn command_failure(latest: &str, app_replaced: bool, error: &std::io::Error) -> String {
+fn command_failure(latest: &str, app_replaced: bool, error: &str) -> String {
     match app_replaced {
         true => format!(
             "the desktop app is on {latest} and the kendex command is not: {error}; run kendex update again to bring the command across"
@@ -151,12 +187,16 @@ fn command_failure(latest: &str, app_replaced: bool, error: &std::io::Error) -> 
 /// validated at, never from feed text. A machine with no app of ours is
 /// the whole install already; a machine whose app cannot be replaced stops
 /// the run before the command moves, so neither half has.
-fn update_app(env: &Env, latest: &str) -> Result<bool, Box<dyn std::error::Error>> {
+fn update_app(
+    env: &Env,
+    latest: &str,
+    public_key: &str,
+) -> Result<bool, Box<dyn std::error::Error>> {
     // Only the Linux AppImage is an install this command made. Every other
     // platform's app arrives and updates by its own route, and the CLI says
     // nothing about one it did not put there.
     let target = target_triple();
-    let (Some(url), Some(signature_url)) = (
+    let (Some(url), Some(signature_source)) = (
         app_image_url(latest, target)?,
         app_image_signature_url(latest, target)?,
     ) else {
@@ -182,23 +222,25 @@ fn update_app(env: &Env, latest: &str) -> Result<bool, Box<dyn std::error::Error
     // The release job publishes each AppImage beside a minisign signature
     // over exactly those bytes. One that arrives without a signature, or
     // with one that does not check out, is refused rather than installed.
-    let signature = fetch(&signature_url).map_err(|why| app_refused(latest, &why))?;
-    install_app_image(&path, &image, &signature, UPDATER_PUBLIC_KEY)
+    let signature = fetch(&signature_source).map_err(|why| app_refused(latest, &why))?;
+    install_verified(&path, &image, &signature, public_key)
         .map_err(|why| app_refused(latest, &why))?;
     out(&format!("updated the desktop app to {latest}"));
     Ok(true)
 }
 
-/// Write the app only once `signature` checks out under `public_key`, so a
-/// download that fails verification never reaches the installed path.
-fn install_app_image(
+/// Write `bytes` over `path` only once `signature` checks out under
+/// `public_key`, so a download that fails verification never reaches an
+/// installed path. Both halves of an update land through here — the desktop
+/// app and the command itself — so neither is the half nothing checks.
+fn install_verified(
     path: &Path,
-    image: &[u8],
+    bytes: &[u8],
     signature: &[u8],
     public_key: &str,
 ) -> Result<(), String> {
-    verify_signature(public_key, image, signature).map_err(|error| error.to_string())?;
-    replace_executable(path, image).map_err(|error| error.to_string())
+    verify_signature(public_key, bytes, signature).map_err(|error| error.to_string())?;
+    replace_executable(path, bytes).map_err(|error| error.to_string())
 }
 
 /// The one sentence both app-half refusals say: the reason, then what the

--- a/crates/cli/src/commands/update/tests.rs
+++ b/crates/cli/src/commands/update/tests.rs
@@ -26,12 +26,12 @@ fn fetched_urls_are_always_positional_arguments() {
 /// leave a bare io error to be read as total failure.
 #[test]
 fn a_command_that_would_not_move_says_whether_the_app_went_without_it() {
-    let error = || std::io::Error::from(std::io::ErrorKind::PermissionDenied);
-    let split = command_failure("5.1.0", true, &error());
+    let error = "permission denied";
+    let split = command_failure("5.1.0", true, error);
     assert!(split.contains("the desktop app is on 5.1.0"), "{split}");
     assert!(split.contains("run kendex update again"), "{split}");
 
-    let neither = command_failure("5.1.0", false, &error());
+    let neither = command_failure("5.1.0", false, error);
     assert!(!neither.contains("desktop app"), "{neither}");
 }
 
@@ -43,6 +43,7 @@ fn a_release_is_out(dir: &tempfile::TempDir) -> (Env, String, PathBuf) {
     let installed = home.join("kendex");
     std::fs::write(&installed, INSTALLED).unwrap();
     std::fs::write(home.join("new-command"), OFFERED).unwrap();
+    std::fs::write(home.join("new-command.sig"), TEST_SIGNATURE).unwrap();
     std::fs::write(
         home.join("feed.json"),
         format!(
@@ -60,7 +61,9 @@ fn a_release_is_out(dir: &tempfile::TempDir) -> (Env, String, PathBuf) {
 }
 
 const INSTALLED: &[u8] = b"the command already here";
-const OFFERED: &[u8] = b"#!/bin/sh\necho 9.9.9\n";
+/// What the feed offers is the signed blob below, because a release only
+/// offers a command `TEST_SIGNATURE` covers; nothing else gets written.
+const OFFERED: &[u8] = SIGNED_BYTES;
 
 /// The arm no process in this repo can reach, and the one whose absence
 /// costs the most: a package manager owns these bytes, so the run says
@@ -75,7 +78,7 @@ fn a_package_managed_command_is_left_for_its_package_manager() {
         command: "brew upgrade kendex-cli".to_owned(),
     };
 
-    run_on(&env, false, &feed_url, &installed, &brew).unwrap();
+    run_on(&env, false, &feed_url, &installed, &brew, TEST_KEY).unwrap();
 
     assert_eq!(std::fs::read(&installed).unwrap(), INSTALLED);
     assert!(!staged_path(&installed).exists());
@@ -90,17 +93,77 @@ fn a_direct_command_is_replaced_from_the_feed() {
     let dir = tempfile::tempdir().unwrap();
     let (env, feed_url, installed) = a_release_is_out(&dir);
 
-    run_on(&env, false, &feed_url, &installed, &InstallChannel::Direct).unwrap();
+    run_on(
+        &env,
+        false,
+        &feed_url,
+        &installed,
+        &InstallChannel::Direct,
+        TEST_KEY,
+    )
+    .unwrap();
 
     assert_eq!(std::fs::read(&installed).unwrap(), OFFERED);
     assert!(!staged_path(&installed).exists());
 }
 
-/// A throwaway minisign keypair signing `SIGNED_IMAGE`, so the admitted
-/// arm runs the real check rather than a stub standing in for it.
+/// The whole point of signing the command half: the feed names a host, so
+/// a run has to be able to be handed bytes and refuse them. Driven by both
+/// shapes a bad download takes — bytes the signature does not cover, and a
+/// body that is no signature at all — and either way the command that was
+/// already installed is exactly as it was.
+#[test]
+fn a_command_binary_that_fails_verification_is_never_written() {
+    for (file, corrupt) in [
+        (
+            "new-command",
+            b"kendex AppImage bytes, and a little more".as_slice(),
+        ),
+        ("new-command.sig", b"not a signature".as_slice()),
+    ] {
+        let dir = tempfile::tempdir().unwrap();
+        let (env, feed_url, installed) = a_release_is_out(&dir);
+        std::fs::write(dir.path().join(file), corrupt).unwrap();
+
+        let refused = run_on(
+            &env,
+            false,
+            &feed_url,
+            &installed,
+            &InstallChannel::Direct,
+            TEST_KEY,
+        )
+        .unwrap_err()
+        .to_string();
+
+        assert!(
+            refused.contains("could not be replaced"),
+            "{file}: {refused}"
+        );
+        assert_eq!(std::fs::read(&installed).unwrap(), INSTALLED, "{file}");
+        assert!(!staged_path(&installed).exists(), "{file}");
+    }
+}
+
+/// A release build takes the channel's own feed and nothing else: an
+/// override there names the bytes that replace the running command, and
+/// the app holds the same variable to the same rule.
+#[test]
+fn only_debug_builds_accept_a_feed_override() {
+    let fixture = "file:///fixtures/feed.json".to_owned();
+    assert_eq!(selected_feed(Some(fixture.clone()), true), fixture);
+    assert_eq!(
+        selected_feed(Some(fixture), false),
+        feed_url_for(env!("CARGO_PKG_VERSION"))
+    );
+}
+
+/// A throwaway minisign keypair signing `SIGNED_BYTES`, so the admitted
+/// arm runs the real check rather than a stub standing in for it. One pair
+/// serves both halves: the app and the command are held to one key.
 const TEST_KEY: &str = "dW50cnVzdGVkIGNvbW1lbnQ6IG1pbmlzaWduIHB1YmxpYyBrZXk6IDk0QUI0NzI3RTVDMTVCODEKUldTQlc4SGxKMGVybEhxeFovbTJ3U1phMng4aE9VTXByV09pUVRFVFNKbFZ5aWxtUTAvVGgyWEwK";
 const TEST_SIGNATURE: &str = "dW50cnVzdGVkIGNvbW1lbnQ6IHNpZ25hdHVyZSBmcm9tIHJzaWduIHNlY3JldCBrZXkKUlVTQlc4SGxKMGVybElTMUxrbkMyQ0tBWGlnejY1S0xLekovK0tBYllNdkdJTVU0bitTSjRBSCt1RlpwWnZkRHNKcWFTSHVoeStIQkpyVDlOaVRIMmROWVVSb21mMVBVRmd3PQp0cnVzdGVkIGNvbW1lbnQ6IGtlbmRleCB0ZXN0CnpKSnpYYnBtODZYRW40eHgxSTVkeG5YdktxT0k5ZXdmSkEyMkdtZXpreGgwbUNJZysybkJ2cGowUXZ6N2c3RHA4TEZBVXVBQUVMRExuUzFuaVpsaUF3PT0K";
-const SIGNED_IMAGE: &[u8] = b"kendex AppImage bytes";
+const SIGNED_BYTES: &[u8] = b"kendex AppImage bytes";
 
 /// A path with something already installed at it, so every arm can say
 /// whether the bytes there moved.
@@ -117,15 +180,15 @@ fn an_app_image_whose_signature_checks_out_is_written() {
     let dir = tempfile::tempdir().unwrap();
     let installed = installed_app(&dir);
 
-    install_app_image(
+    install_verified(
         &installed,
-        SIGNED_IMAGE,
+        SIGNED_BYTES,
         TEST_SIGNATURE.as_bytes(),
         TEST_KEY,
     )
     .unwrap();
 
-    assert_eq!(std::fs::read(&installed).unwrap(), SIGNED_IMAGE);
+    assert_eq!(std::fs::read(&installed).unwrap(), SIGNED_BYTES);
     assert!(!staged_path(&installed).exists());
 }
 
@@ -137,15 +200,15 @@ fn an_app_image_that_fails_verification_is_never_written() {
     let dir = tempfile::tempdir().unwrap();
     let installed = installed_app(&dir);
 
-    let tampered = install_app_image(&installed, b"tampered", TEST_SIGNATURE.as_bytes(), TEST_KEY)
-        .unwrap_err();
+    let tampered =
+        install_verified(&installed, b"tampered", TEST_SIGNATURE.as_bytes(), TEST_KEY).unwrap_err();
     assert!(
         tampered.contains("signature verification failed"),
         "{tampered}"
     );
 
     let malformed =
-        install_app_image(&installed, SIGNED_IMAGE, b"not a signature", TEST_KEY).unwrap_err();
+        install_verified(&installed, SIGNED_BYTES, b"not a signature", TEST_KEY).unwrap_err();
     assert!(malformed.contains("not base64"), "{malformed}");
 
     assert_eq!(std::fs::read(&installed).unwrap(), b"the app already here");

--- a/crates/cli/tests/compat.rs
+++ b/crates/cli/tests/compat.rs
@@ -324,9 +324,16 @@ fn report_files_through_a_stubbed_gh() {
     assert!(args.contains("kendex-report:v1 asset=guard kind=hook"));
 }
 
+/// The feed is unsigned text naming a host, so what it offers has to be
+/// held to the release key before it lands on the running command. Nothing
+/// here can produce a signature under that key, which is the point: this
+/// drives the real binary end to end and it refuses, leaving the command
+/// exactly as it was. The admitted arm — a signature that checks out, and
+/// the write that follows it — is covered in `commands::update::tests`,
+/// which holds a keypair of its own.
 #[test]
 #[allow(clippy::unwrap_used)]
-fn update_replaces_the_binary_from_a_local_feed() {
+fn update_over_a_local_feed_refuses_a_command_it_cannot_verify() {
     let tmp = sandbox_with_catalog();
     let home = tmp.path();
     let bin = home.join("bin");
@@ -335,7 +342,11 @@ fn update_replaces_the_binary_from_a_local_feed() {
     fs::copy(env!("CARGO_BIN_EXE_kendex"), &me).unwrap();
     fs::set_permissions(&me, fs::Permissions::from_mode(0o755)).unwrap();
 
+    let installed = fs::read(&me).unwrap();
     fs::write(home.join("new-binary"), "#!/bin/sh\necho v9\n").unwrap();
+    // A release publishes a signature beside every download, so the fixture
+    // does too; this one is not the release's, which is what gets refused.
+    fs::write(home.join("new-binary.sig"), "not the release signature").unwrap();
     let target = env!("KENDEX_TARGET");
     fs::write(
         home.join("feed.json"),
@@ -355,12 +366,17 @@ fn update_replaces_the_binary_from_a_local_feed() {
             format!("file://{}/feed.json", home.display()),
         )],
     );
+    let refused = stderr(&output);
+    assert!(!output.status.success(), "{refused}");
     assert!(
-        output.status.success(),
-        "{}",
-        String::from_utf8_lossy(&output.stderr)
+        refused.contains("does not verify under the pinned release key"),
+        "{refused}"
     );
-    assert_eq!(fs::read_to_string(&me).unwrap(), "#!/bin/sh\necho v9\n");
+    assert_eq!(
+        fs::read(&me).unwrap(),
+        installed,
+        "the command moved anyway"
+    );
     let said = String::from_utf8_lossy(&output.stdout);
     match publishes_an_app_image() {
         true => assert!(said.contains("no kendex desktop app here"), "{said}"),
@@ -467,9 +483,9 @@ fn update_replaces_the_binary_from_a_local_feed() {
 /// with no --force and nothing said about one.
 ///
 /// Only a target whose release publishes an AppImage has an app half to
-/// order against. Where none is published the command is the whole
-/// install and the opposite has to hold: it updates itself, and it leaves
-/// alone and says nothing about an app it never installed.
+/// order against. Where none is published the command is the whole install
+/// and what has to hold instead is that it leaves alone, and says nothing
+/// about, an app it never installed.
 #[test]
 #[allow(clippy::unwrap_used)]
 fn a_desktop_app_that_cannot_be_replaced_leaves_the_command_alone() {
@@ -486,6 +502,7 @@ fn a_desktop_app_that_cannot_be_replaced_leaves_the_command_alone() {
     fs::write(app_dir.join("kendex.AppImage"), "old app").unwrap();
 
     fs::write(home.join("new-binary"), "#!/bin/sh\necho v9\n").unwrap();
+    fs::write(home.join("new-binary.sig"), "not the release signature").unwrap();
     let target = env!("KENDEX_TARGET");
     fs::write(
         home.join("feed.json"),
@@ -515,8 +532,14 @@ fn a_desktop_app_that_cannot_be_replaced_leaves_the_command_alone() {
     if !publishes_an_app_image() {
         let only = update();
         let said = format!("{}{}", stderr(&only), stdout(&only));
-        assert!(only.status.success(), "{said}");
-        assert!(command_moved(), "the command did not update itself: {said}");
+        // The command is the whole install here, and it is still held to
+        // the release key: this fixture cannot sign under it, so the run
+        // refuses and the command stays where it was.
+        assert!(!only.status.success(), "{said}");
+        assert!(
+            !command_moved(),
+            "an unverified command was written: {said}"
+        );
         // An AppImage sitting here is not this platform's install, so the
         // command neither touches it nor mentions one.
         assert_eq!(still_old_app(), "old app", "{said}");

--- a/crates/cli/tests/release_workflow/main.rs
+++ b/crates/cli/tests/release_workflow/main.rs
@@ -614,3 +614,4 @@ fn no_lane_triple_is_hardcoded_into_build_or_staging() {
 }
 
 mod channel;
+mod signing;

--- a/crates/cli/tests/release_workflow/signing.rs
+++ b/crates/cli/tests/release_workflow/signing.rs
@@ -1,0 +1,160 @@
+//! Signing the command binary. `kendex update` refuses a download the
+//! release key does not cover, so a lane that stages `kendex-<target>` and
+//! no signature beside it publishes an update every client turns away. That
+//! is a tag-run failure otherwise, because release.yml never runs on a pull
+//! request; here the real step runs against a signer this test controls.
+
+#[cfg(unix)]
+use std::fs;
+#[cfg(unix)]
+use std::os::unix::fs::PermissionsExt;
+
+#[cfg(unix)]
+use crate::test_util::rooted;
+#[cfg(unix)]
+use crate::{LANES, expand, run_script};
+use crate::{step, workflow};
+
+/// The signing step run over one lane in a tree holding that lane's staged
+/// binary and a `tauri` the test wrote: `body` is the shell the shim runs,
+/// which decides whether a signature appears. Returns the exit code, what
+/// the step said, and the signature files left in `dist/`.
+#[cfg(unix)]
+#[allow(clippy::unwrap_used)]
+fn sign(lane: &crate::Lane, body: &str) -> (i32, String, Vec<String>) {
+    let dir = tempfile::tempdir().unwrap();
+    let root = rooted(&dir);
+    let binary = match lane.runner_os {
+        "Windows" => format!("kendex-{}.exe", lane.target),
+        _ => format!("kendex-{}", lane.target),
+    };
+    fs::create_dir_all(root.join("dist")).unwrap();
+    fs::write(root.join("dist").join(&binary), "the built command").unwrap();
+
+    let shim = root.join("ui/node_modules/.bin");
+    fs::create_dir_all(&shim).unwrap();
+    let shim = shim.join("tauri");
+    fs::write(&shim, format!("#!/bin/sh\n{body}\n")).unwrap();
+    fs::set_permissions(&shim, fs::Permissions::from_mode(0o755)).unwrap();
+
+    let workflow = workflow();
+    let script = expand(
+        &run_script(&step(&workflow, "name: Sign the kendex command")),
+        lane,
+    );
+    let run = std::process::Command::new("bash")
+        // The flags a `shell: bash` step gets on a runner.
+        .args(["-eo", "pipefail", "-c", &script])
+        .current_dir(&root)
+        .env_clear()
+        .env("PATH", std::env::var_os("PATH").unwrap_or_default())
+        .output()
+        .unwrap();
+    let mut left: Vec<String> = fs::read_dir(root.join("dist"))
+        .unwrap()
+        .map(|entry| entry.unwrap().file_name().to_string_lossy().into_owned())
+        .filter(|name| name.ends_with(".sig"))
+        .collect();
+    left.sort();
+    let said = format!(
+        "{}{}",
+        String::from_utf8_lossy(&run.stdout),
+        String::from_utf8_lossy(&run.stderr)
+    );
+    (run.status.code().unwrap_or(-1), said, left)
+}
+
+/// Every lane signs the command the staging step left, and the expected
+/// name comes from that step rather than being spelled a second time here:
+/// two spellings agree until one is edited, and the Windows lane's `.exe`
+/// is exactly where they would part.
+#[cfg(unix)]
+#[test]
+fn each_lane_signs_the_command_it_staged() {
+    for lane in &LANES {
+        let staged = crate::stage_assets(lane);
+        let (code, said, sigs) = sign(lane, r#"printf 'sig' > "$3.sig""#);
+        assert_eq!(code, 0, "{}: {said}", lane.target);
+        assert_eq!(sigs.len(), 1, "{}: {sigs:?}", lane.target);
+        let signed = sigs[0].trim_end_matches(".sig");
+        assert!(
+            staged.contains_key(signed),
+            "{} signed {signed}, which staging never left: {:?}",
+            lane.target,
+            staged.keys().collect::<Vec<_>>()
+        );
+    }
+}
+
+/// The lane that matters: a signer that leaves nothing behind has published
+/// a command no client can verify, and every other lane still being green
+/// would let the tag through. It fails here, naming the binary.
+#[cfg(unix)]
+#[test]
+fn a_lane_that_produced_no_signature_fails_the_job_by_name() {
+    for empty in ["exit 0", r#": > "$3.sig""#] {
+        for lane in &LANES {
+            let (code, said, _) = sign(lane, empty);
+            assert_ne!(code, 0, "{}: {said}", lane.target);
+            assert!(
+                said.contains(&format!("kendex-{}", lane.target)),
+                "{} unnamed in: {said}",
+                lane.target
+            );
+        }
+    }
+}
+
+/// A signer that fails stops the lane rather than being stepped over.
+#[cfg(unix)]
+#[test]
+fn a_signer_that_fails_stops_the_lane() {
+    for lane in &LANES {
+        let (code, said, _) = sign(lane, "exit 3");
+        assert_ne!(code, 0, "{}: {said}", lane.target);
+    }
+}
+
+/// The step signs under the release keypair and no other, so the command
+/// and the app bundles are held to one key.
+#[test]
+fn the_step_signs_under_the_release_key() {
+    let workflow = workflow();
+    let lines = step(&workflow, "name: Sign the kendex command").join("\n");
+    assert!(
+        lines.contains("TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}"),
+        "{lines}"
+    );
+    assert!(lines.contains("signer sign"), "{lines}");
+}
+
+/// The publish job now downloads two signatures per lane, and its `add`
+/// globs have to pick the updater bundle's. A glob that also matched the
+/// command's would name a download the app cannot install, and only a tag
+/// run puts the two steps together: here a `dist/` carrying nothing but
+/// command signatures has to leave every platform unanswered.
+#[cfg(unix)]
+#[test]
+fn no_platform_is_answered_by_a_command_signature() {
+    let mut dist = std::collections::BTreeMap::new();
+    for lane in &LANES {
+        let ext = match lane.runner_os {
+            "Windows" => ".exe",
+            _ => "",
+        };
+        dist.insert(
+            format!("kendex-{}{ext}.sig", lane.target),
+            "the command signature".to_owned(),
+        );
+    }
+    let (code, manifest, said) = crate::run_manifest(&dist);
+    assert_ne!(code, 0, "{said}");
+    assert!(manifest.is_empty(), "{manifest}");
+    for lane in &LANES {
+        assert!(
+            said.contains(lane.platform),
+            "{} was answered by a command signature: {said}",
+            lane.platform
+        );
+    }
+}

--- a/crates/core/src/update_feed.rs
+++ b/crates/core/src/update_feed.rs
@@ -145,10 +145,8 @@ pub fn app_image_url(version: &str, target: &str) -> Result<Option<String>> {
 }
 
 /// The minisign signature published beside a release artifact. The release
-/// job publishes every `<artifact>.sig` into the same release, so the name
-/// is the artifact's own with the suffix appended. Both halves of an update
-/// find their signature this way: the AppImage below, and the command
-/// binary the feed names.
+/// job publishes each `<artifact>.sig`, so the name is the artifact's own
+/// with the suffix appended; both halves of an update find theirs this way.
 pub fn signature_url(artifact_url: &str) -> String {
     format!("{artifact_url}.sig")
 }
@@ -348,12 +346,8 @@ mod tests {
             app_image_signature_url("5.1.0", "aarch64-apple-darwin").unwrap(),
             None
         );
-        // The feed names the command binary, and its signature is found by
-        // the same rule rather than by a second spelling.
-        assert_eq!(
-            signature_url("https://example.test/kendex-x86_64-unknown-linux-gnu"),
-            "https://example.test/kendex-x86_64-unknown-linux-gnu.sig"
-        );
+        // The command binary the feed names finds its own by the same rule.
+        assert_eq!(signature_url("https://x/kendex"), "https://x/kendex.sig");
     }
 
     #[test]

--- a/crates/core/src/update_feed.rs
+++ b/crates/core/src/update_feed.rs
@@ -144,11 +144,18 @@ pub fn app_image_url(version: &str, target: &str) -> Result<Option<String>> {
     )))
 }
 
-/// The minisign signature published beside that AppImage. The release job
-/// stages every `<artifact>.sig` tauri produces into the same release, so
-/// the name is the artifact's own with the suffix appended.
+/// The minisign signature published beside a release artifact. The release
+/// job publishes every `<artifact>.sig` into the same release, so the name
+/// is the artifact's own with the suffix appended. Both halves of an update
+/// find their signature this way: the AppImage below, and the command
+/// binary the feed names.
+pub fn signature_url(artifact_url: &str) -> String {
+    format!("{artifact_url}.sig")
+}
+
+/// The signature published beside that AppImage.
 pub fn app_image_signature_url(version: &str, target: &str) -> Result<Option<String>> {
-    Ok(app_image_url(version, target)?.map(|url| format!("{url}.sig")))
+    Ok(app_image_url(version, target)?.map(|url| signature_url(&url)))
 }
 
 /// Refuse a download that `signature` does not cover under
@@ -340,6 +347,12 @@ mod tests {
         assert_eq!(
             app_image_signature_url("5.1.0", "aarch64-apple-darwin").unwrap(),
             None
+        );
+        // The feed names the command binary, and its signature is found by
+        // the same rule rather than by a second spelling.
+        assert_eq!(
+            signature_url("https://example.test/kendex-x86_64-unknown-linux-gnu"),
+            "https://example.test/kendex-x86_64-unknown-linux-gnu.sig"
         );
     }
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -291,13 +291,13 @@ lives in one capability table read by core and UI.
   mid-read; a failed read shows its error with a retry, kept figures headed
   as the last kendex could check, never a definite count — least of all
   zero. Every read the app starts with runs beside the others.
-- **Discovery is the unsigned feed; the app download checks a signature.**
-  Off the launch path, one cross-process transaction reads the fixed feed at
-  most once per six hours, keeps the last result beside any error, and never
-  follows the final link; the preference gates automatic contact, debug builds
-  alone honor `KENDEX_UPDATE_FEED`. Replacing needs the path behind the running
-  one writable and outside a system prefix; a package prefix names its command
-  instead, anything else neither. One sidebar card offers whichever it is.
+- **Discovery is the unsigned feed; both halves verify under one pinned key.**
+  Off the launch path, one cross-process transaction reads the feed at most
+  every six hours, keeps the last result beside any error, and never follows
+  the final link; the preference gates automatic contact; in both shells debug
+  builds alone honor `KENDEX_UPDATE_FEED`. Replacing needs the path behind the
+  running one writable, outside a system prefix; a package prefix names its
+  command instead, anything else neither. One sidebar card offers whichever.
 - Commands that touch disk, git, or a subprocess are
   `#[tauri::command(async)]`. Only window operations stay synchronous.
 - No database: manifests, locks, and native dirs are the state; scans are

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -84,9 +84,9 @@ revisit Intel support then.
   `plugins > updater > pubkey` in `crates/app/tauri.conf.json` and
   `UPDATER_PUBLIC_KEY` in `crates/core/src/update_feed.rs`, held equal by
   `crates/app/tests/tauri_config.rs`. A private key that does not match
-  builds a release the app refuses to install and that `kendex update`
-  refuses to install the desktop app from; the CLI binary half of
-  `kendex update` is unaffected.
+  signs every artifact of that release under a key nothing trusts, so the
+  app refuses to install it and `kendex update` refuses both halves, the
+  desktop app and the kendex command.
 - **macOS signing + notarization** (the seven `APPLE_*` repo secrets:
   certificate p12 + password, signing identity, team id, and the App
   Store Connect API issuer/key-id/key): all seven set, the two mac lanes

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -35,9 +35,11 @@ Release with:
 Review the draft, then publish it. That is the release.
 
 `install.sh` is the exception and says so in its own comments: a machine
-with nothing installed has neither the release key nor minisign, so a first
-install rests on TLS to kendex.ai and github.com. Every update after it is
-held to the key.
+with nothing installed has neither the release key nor minisign, so the
+script rests on TLS to kendex.ai and github.com. That is every run of it,
+not only the first, because the script is the upgrade path too and a re-run
+overwrites what is installed with another unchecked download. `kendex
+update` is the path held to the key.
 
 ## Pre-releases
 

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -11,8 +11,12 @@ per target (Linux x86_64 and aarch64, macOS aarch64 and x86_64, Windows
 x86_64; all free for a public repository) and publishes a **draft** GitHub
 Release with:
 
-- `kendex-<target>[.exe]` — the CLI binary, one per target. These are what
-  `kendex update` downloads.
+- `kendex-<target>[.exe]` — the CLI binary, one per target, and the
+  `<binary>.sig` a lane signs it into. These are what `kendex update`
+  downloads, and it installs neither without the other: a signature the
+  release key does not carry over those exact bytes is refused, so a lane
+  that produced none fails the tag instead of publishing a command no
+  client can verify.
 - The desktop app bundles Tauri produces per platform (deb/rpm/AppImage,
   dmg, NSIS installer), and the `.sig` Tauri writes beside each updater
   bundle. `kendex update` fetches `<AppImage>.sig` straight from the
@@ -29,6 +33,11 @@ Release with:
   unknown value. Keep these fields when adding data.
 
 Review the draft, then publish it. That is the release.
+
+`install.sh` is the exception and says so in its own comments: a machine
+with nothing installed has neither the release key nor minisign, so a first
+install rests on TLS to kendex.ai and github.com. Every update after it is
+held to the key.
 
 ## Pre-releases
 

--- a/install.sh
+++ b/install.sh
@@ -70,15 +70,17 @@ done
 # What this script trusts, stated rather than left to be inferred: TLS to
 # kendex.ai for the script and to github.com for what it downloads. It does
 # not check the minisign signature the release publishes beside each asset,
-# because minisign is not on a machine that has yet to install anything and
-# a check that runs only where the tool happens to be present is one an
-# attacker's target simply does not have. So a first install is trust on
-# first use, and a swapped release asset reaches it.
+# because minisign is not on a machine that has installed nothing and a
+# check that runs only where the tool happens to be present is one an
+# attacker's target simply does not have.
 #
-# That window is the first install and nothing after it. The command this
-# installs carries the release public key, and `kendex update` refuses both
-# halves — the command and the desktop app — unless a signature under that
-# key covers the bytes it downloaded.
+# That holds for every run of this script, not only the first. It is the
+# upgrade path as well as the install, and a re-run overwrites the command
+# and the AppImage with another download nothing checked, so a swapped
+# release asset reaches a machine however many times it has installed here.
+# `kendex update` is the path held to the key: it refuses either half unless
+# a signature under the release key covers the bytes it fetched. A machine
+# kept current by re-running this script never gets that check.
 install_cli() {
   echo "Downloading the kendex command ($target)…"
   # curl exits 22 on an HTTP error — here a 404 for an asset the release

--- a/install.sh
+++ b/install.sh
@@ -67,6 +67,18 @@ for candidate in "$HOME/.local/bin" "/usr/local/bin"; do
 done
 [ -n "$bindir" ] || bindir="$HOME/.local/bin"
 
+# What this script trusts, stated rather than left to be inferred: TLS to
+# kendex.ai for the script and to github.com for what it downloads. It does
+# not check the minisign signature the release publishes beside each asset,
+# because minisign is not on a machine that has yet to install anything and
+# a check that runs only where the tool happens to be present is one an
+# attacker's target simply does not have. So a first install is trust on
+# first use, and a swapped release asset reaches it.
+#
+# That window is the first install and nothing after it. The command this
+# installs carries the release public key, and `kendex update` refuses both
+# halves — the command and the desktop app — unless a signature under that
+# key covers the bytes it downloaded.
 install_cli() {
   echo "Downloading the kendex command ($target)…"
   # curl exits 22 on an HTTP error — here a 404 for an asset the release


### PR DESCRIPTION
`kendex update` verified the desktop AppImage before writing it and did not
verify the command binary. `install_app_image` checks a minisign signature
under `UPDATER_PUBLIC_KEY`; the CLI half fetched its asset and called
`replace_executable` on those bytes with nothing checked. CWE-494.

The feed naming that asset was overridable in a release build: the CLI read
`KENDEX_UPDATE_FEED` unconditionally where the app gates the same override to
debug builds. Taking the unverified half was cheaper than defeating the
verified one, which is what made the split the problem.

## What ships

The release job signs each staged `dist/kendex-<target>` and publishes its
`.sig`, failing the tag when a lane produced none — the fail-closed shape the
signed-manifest step already had. Until that existed there was nothing for the
command half to check against.

`run` fetches `{asset}.sig` and verifies before `replace_executable`, so a
refusal leaves the installed command untouched, as the app half already did.

The CLI's feed override is now `#[cfg(debug_assertions)]`, matching the app.

A test covers a binary that fails verification never being written, mirroring
`an_app_image_that_fails_verification_is_never_written`.

## install.sh

Recorded rather than fixed, deliberately, and written where a reader meets it.
minisign is not on a machine that has yet to install anything, and a check that
runs only where the tool happens to be present is one an attacker's target does
not have. So an `install.sh` run is trust on first use over TLS, and the script
says so.

That applies to every run of the script, not only the first: `install.sh` is the
upgrade path as well as the install, so a re-run overwrites the command with
another unverified download. What is verified is `kendex update`, which refuses
both halves without a signature under the release public key the installed
command carries.

Closes KEN-754
