### PR TITLE
fix(KEN-817): a pre-image is synced by the handle that wrote it

### DIFF
--- a/.github/workflows/skill-tests.yml
+++ b/.github/workflows/skill-tests.yml
@@ -402,12 +402,12 @@ jobs:
         run: cargo test --workspace --locked --no-fail-fast
 
   # The app ships on Windows and release.yml builds it there. `cargo check`
-  # does not link, so the Linux runner proves the Windows targets compile at
-  # a fraction of a Windows runner's cost — enough to stop a `std::os::unix`
-  # reach in test code from landing unseen, which is the whole of what had
-  # no check at all. Executing the tests on Windows is a separate cost
-  # question. Scope matches tools/guard's cross-target lane: the app crate
-  # needs the platform's own C toolchain, core and CLI are portable Rust.
+  # does not link, so the Linux runner proves the Windows targets compile
+  # without one — enough to stop a `std::os::unix` reach in test code from
+  # landing unseen. A windows-latest runner is free on this public repo;
+  # what keeps an executing lane out is KEN-817, KEN-818 and KEN-819, and
+  # the lane returns with them. Scope matches tools/guard's cross-target
+  # lane: app needs the platform's C toolchain, core and CLI are portable.
   cargo-check-windows:
     name: Windows cargo (core and CLI targets compile)
     runs-on: ubuntu-latest

--- a/changelog.d/fixed/KEN-817.md
+++ b/changelog.d/fixed/KEN-817.md
@@ -1,0 +1,2 @@
+- Windows: `kendex add`, `refresh` and `apply` no longer fail with "Access is
+  denied" before changing anything, so packages can be installed there at all.

--- a/crates/core/src/apply/journal.rs
+++ b/crates/core/src/apply/journal.rs
@@ -5,7 +5,7 @@ use serde::{Deserialize, Serialize};
 
 use crate::error::{CoreError, Result};
 use crate::fs::{
-    copy_tree, make_symlink, remove_any, sync_dir, sync_dir_durable, sync_file, sync_tree,
+    copy_file_durable, copy_tree_durable, make_symlink, remove_any, sync_dir, sync_dir_durable,
 };
 
 /// Pre-images of everything an apply is about to touch. Restore is
@@ -60,8 +60,7 @@ pub fn write(dir: &Path, paths: &[PathBuf]) -> Result<()> {
             let slot = store.join(&slot_name);
             let resolved_file = path.exists() && path.is_file();
             if resolved_file {
-                fs::copy(path, &slot).map_err(|e| CoreError::io(path, e))?;
-                sync_file(&slot)?;
+                copy_file_durable(path, &slot)?;
             }
             PreState::Symlink {
                 target: fs::read_link(path).map_err(|e| CoreError::io(path, e))?,
@@ -69,15 +68,13 @@ pub fn write(dir: &Path, paths: &[PathBuf]) -> Result<()> {
             }
         } else if path.is_dir() {
             let slot = store.join(index.to_string());
-            copy_tree(path, &slot)?;
-            sync_tree(&slot)?;
+            copy_tree_durable(path, &slot)?;
             PreState::Dir {
                 store: index.to_string(),
             }
         } else if path.is_file() {
             let slot = store.join(index.to_string());
-            fs::copy(path, &slot).map_err(|e| CoreError::io(path, e))?;
-            sync_file(&slot)?;
+            copy_file_durable(path, &slot)?;
             PreState::File {
                 store: index.to_string(),
             }
@@ -218,9 +215,7 @@ fn rollback_where(dir: &Path, restore: impl Fn(&Path) -> bool) -> Result<()> {
                 if let Some(parent) = entry.path.parent() {
                     fs::create_dir_all(parent).map_err(|e| CoreError::io(parent, e))?;
                 }
-                fs::copy(store.join(slot), &entry.path)
-                    .map_err(|e| CoreError::io(&entry.path, e))?;
-                sync_file(&entry.path)?;
+                copy_file_durable(&store.join(slot), &entry.path)?;
             }
             PreState::Symlink {
                 target,
@@ -233,14 +228,11 @@ fn rollback_where(dir: &Path, restore: impl Fn(&Path) -> bool) -> Result<()> {
                 // A write may have gone through the link: restore the
                 // linked-to file's bytes too.
                 if let Some(slot) = slot {
-                    fs::copy(store.join(slot), &entry.path)
-                        .map_err(|e| CoreError::io(&entry.path, e))?;
-                    sync_file(&entry.path)?;
+                    copy_file_durable(&store.join(slot), &entry.path)?;
                 }
             }
             PreState::Dir { store: slot } => {
-                copy_tree(&store.join(slot), &entry.path)?;
-                sync_tree(&entry.path)?;
+                copy_tree_durable(&store.join(slot), &entry.path)?;
             }
         }
     }

--- a/crates/core/src/fs.rs
+++ b/crates/core/src/fs.rs
@@ -126,17 +126,27 @@ pub(crate) fn copy_file_durable(from: &Path, to: &Path) -> Result<()> {
     sync_written_file(to)
 }
 
-/// Flush a file this process has just written, through a handle the
-/// platform will accept.
+/// Flush a file this process has just written, leaving its mode on disk
+/// alongside its bytes.
 ///
 /// A read-only handle is enough on Unix and refused on Windows, whose
 /// `FlushFileBuffers` documents `GENERIC_WRITE` as a requirement, so the
 /// write handle is what this asks for. A file that came from a read-only
 /// source refuses one — `fs::copy` carries `FILE_ATTRIBUTE_READONLY`
 /// across on Windows and the mode on Unix — so a refusal relaxes the
-/// mode for the length of the flush and restores it afterwards, flush
-/// failed or not. The file is one this process created moments ago and
-/// is the only writer of, so the window it opens is over its own work.
+/// mode, flushes, puts the mode back through that same handle and
+/// flushes again. The second flush is what makes the restored mode
+/// durable; a chmod by path after the last flush would leave the file
+/// read-only to a reader and writable on disk.
+///
+/// On Ok, what is on disk is the bytes and the mode the copy carried
+/// over. The window this cannot close is between relaxing the mode and
+/// that second flush: a crash inside it leaves the copy owner-writable
+/// on disk, and the only way to avoid opening it would be a flush the
+/// platform refuses. Nothing reads a pre-image through that window — a
+/// journal whose `meta.json` was never written is swept rather than
+/// replayed, and a rollback a crash interrupts is re-run, laying the
+/// pre-image down again.
 fn sync_written_file(path: &Path) -> Result<()> {
     let write_handle = || fs::OpenOptions::new().write(true).open(path);
     let refused = match write_handle() {
@@ -148,9 +158,15 @@ fn sync_written_file(path: &Path) -> Result<()> {
         return Err(CoreError::io(path, refused));
     };
     fs::set_permissions(path, writable(&mode)).map_err(|e| CoreError::io(path, e))?;
-    let flushed = write_handle().and_then(|file| file.sync_all());
-    // Restored before the outcome is reported: a flush that failed must
-    // not also leave the file writable.
+    let flushed = write_handle().and_then(|file| {
+        file.sync_all()?;
+        file.set_permissions(mode.clone())?;
+        file.sync_all()
+    });
+    // The mode goes back whether any of that worked or not, and by path,
+    // because what failed may have been the handle itself. Where the
+    // block above reached its own restore this repeats a mode already on
+    // disk, so a crash losing this chmod cannot leave the file writable.
     fs::set_permissions(path, mode).map_err(|e| CoreError::io(path, e))?;
     flushed.map_err(|e| CoreError::io(path, e))
 }
@@ -220,9 +236,13 @@ pub(crate) fn remove_any(path: &Path) -> Result<()> {
 
 /// Reproduce a whole tree at `to`, with every file on disk before this
 /// returns: each file copied and flushed by `copy_file_durable`, each
-/// directory synced once its entries are in it. Nothing outside the tree
-/// is opened — a link is reproduced as a link and never read through — so
-/// the sync reaches exactly what this copy created and nothing else.
+/// directory synced through `sync_dir_durable` once its entries are in
+/// it. A directory sync that fails stops the copy — the best-effort
+/// `sync_dir` would let this return Ok over a name that never reached
+/// disk, and the journal writes its meta on the strength of that Ok.
+/// Nothing outside the tree is opened — a link is reproduced as a link
+/// and never read through — so the sync reaches exactly what this copy
+/// created and nothing else.
 pub(crate) fn copy_tree_durable(from: &Path, to: &Path) -> Result<()> {
     copy_tree_inner(from, to, true)
 }
@@ -242,7 +262,7 @@ fn copy_tree_inner(from: &Path, to: &Path, durable: bool) -> Result<()> {
         copy_any_inner(&source, &to.join(name), durable)?;
     }
     if durable {
-        sync_dir(to);
+        sync_dir_durable(to)?;
     }
     Ok(())
 }

--- a/crates/core/src/fs.rs
+++ b/crates/core/src/fs.rs
@@ -84,9 +84,8 @@ fn write_then_rename(
     }
     drop(temp_file);
     fs::rename(&tmp, &path).map_err(|e| discard(e, &path))?;
-    #[cfg(unix)]
-    if durable && let Ok(dir) = fs::File::open(parent) {
-        let _ = dir.sync_all();
+    if durable {
+        sync_dir(parent);
     }
     Ok(())
 }
@@ -110,14 +109,42 @@ pub fn read_if_exists(path: &Path) -> Result<Option<String>> {
     }
 }
 
-pub(crate) fn sync_file(path: &Path) -> Result<()> {
-    fs::File::open(path)
-        .and_then(|f| f.sync_all())
-        .map_err(|e| CoreError::io(path, e))
+/// Reproduce a file's bytes at `to` and have them on disk before this
+/// returns, synced through the very handle that wrote them.
+///
+/// The sync cannot be a step of its own against the finished file.
+/// Flushing needs a handle opened for writing — on Windows literally so,
+/// `FlushFileBuffers` is refused without `GENERIC_WRITE` — and the copy
+/// carries the source's permissions, so a read-only source leaves behind
+/// a file this process may not reopen for writing on either platform.
+/// The handle that did the writing is the one handle guaranteed to be
+/// flushable, which is why `atomic_write_durable` syncs its temp file
+/// before the rename rather than the named file after it.
+pub(crate) fn copy_file_durable(from: &Path, to: &Path) -> Result<()> {
+    let mut source = fs::File::open(from).map_err(|e| CoreError::io(from, e))?;
+    let mut copy = fs::File::create(to).map_err(|e| CoreError::io(to, e))?;
+    std::io::copy(&mut source, &mut copy).map_err(|e| CoreError::io(to, e))?;
+    // The mode is part of what a pre-image holds: a hook restored without
+    // its execute bit is a hook that stops running. Set through the open
+    // handle and before the sync, so the write access this handle already
+    // holds is what applies it and one sync persists bytes and mode
+    // together.
+    let mode = source
+        .metadata()
+        .map_err(|e| CoreError::io(from, e))?
+        .permissions();
+    copy.set_permissions(mode)
+        .map_err(|e| CoreError::io(to, e))?;
+    copy.sync_all().map_err(|e| CoreError::io(to, e))
 }
 
-/// Directory fsync is a no-op on platforms where directories cannot be
-/// opened (Windows); rename durability there rides on the volume flush.
+/// Persist a directory's own entries — the names in it, not the bytes of
+/// what they name. Unix only: Windows has no handle to a directory to
+/// flush, so there a new or renamed *name* rides on the volume flush
+/// while the *bytes* under it are already durable, through
+/// `copy_file_durable` or `atomic_write_durable`. That asymmetry is the
+/// whole of the platform gap — file contents are guaranteed on both,
+/// directory entries only on Unix.
 pub(crate) fn sync_dir(path: &Path) {
     #[cfg(unix)]
     if let Ok(dir) = fs::File::open(path) {
@@ -144,30 +171,6 @@ pub(crate) fn sync_dir_durable(path: &Path) -> Result<()> {
     }
 }
 
-/// Sync a tree's files and directories, a link treated as a leaf: the
-/// parent's sync persists the entry itself, and what it points at is not
-/// this tree's — following it would sync files outside the tree, or the
-/// same tree again through a link back into it until the kernel refuses
-/// the path. The same reading of a link as `hash_tree_as_is`.
-pub(crate) fn sync_tree(root: &Path) -> Result<()> {
-    let Ok(kind) = fs::symlink_metadata(root).map(|meta| meta.file_type()) else {
-        return Ok(());
-    };
-    if kind.is_symlink() {
-        return Ok(());
-    }
-    if kind.is_file() {
-        return sync_file(root);
-    }
-    if let Ok(entries) = fs::read_dir(root) {
-        for entry in entries.flatten() {
-            sync_tree(&entry.path())?;
-        }
-        sync_dir(root);
-    }
-    Ok(())
-}
-
 /// Remove whatever is at `path`, if anything is. A remove-if-present: the
 /// journal's restore of an absent pre-image asks for it on paths nothing
 /// ever wrote to, and failing there would strand the journal and take
@@ -181,7 +184,16 @@ pub(crate) fn remove_any(path: &Path) -> Result<()> {
     Ok(())
 }
 
-pub(crate) fn copy_tree(from: &Path, to: &Path) -> Result<()> {
+/// Reproduce a whole tree at `to`, with every file on disk before this
+/// returns: each file synced through the handle that wrote it, each
+/// directory once its entries are in it. Nothing outside the tree is
+/// opened — a link is reproduced as a link and never read through — so
+/// the sync reaches exactly what this copy created and nothing else.
+pub(crate) fn copy_tree_durable(from: &Path, to: &Path) -> Result<()> {
+    copy_tree_inner(from, to, true)
+}
+
+fn copy_tree_inner(from: &Path, to: &Path, durable: bool) -> Result<()> {
     fs::create_dir_all(to).map_err(|e| CoreError::io(to, e))?;
     // An entry the listing could not produce is an entry nothing was
     // proven about, so it stops the copy rather than dropping out of it —
@@ -193,7 +205,10 @@ pub(crate) fn copy_tree(from: &Path, to: &Path) -> Result<()> {
         let Some(name) = source.file_name() else {
             continue;
         };
-        copy_any(&source, &to.join(name))?;
+        copy_any_inner(&source, &to.join(name), durable)?;
+    }
+    if durable {
+        sync_dir(to);
     }
     Ok(())
 }
@@ -207,11 +222,17 @@ pub(crate) fn copy_tree(from: &Path, to: &Path) -> Result<()> {
 /// link whose target is gone fails with the target's ENOENT under the
 /// link's name.
 pub(crate) fn copy_any(from: &Path, to: &Path) -> Result<()> {
+    copy_any_inner(from, to, false)
+}
+
+fn copy_any_inner(from: &Path, to: &Path, durable: bool) -> Result<()> {
     if from.is_symlink() {
         let target = fs::read_link(from).map_err(|e| CoreError::io(from, e))?;
         make_symlink(&target, to)
     } else if from.is_dir() {
-        copy_tree(from, to)
+        copy_tree_inner(from, to, durable)
+    } else if durable {
+        copy_file_durable(from, to)
     } else {
         fs::copy(from, to)
             .map(|_| ())

--- a/crates/core/src/fs.rs
+++ b/crates/core/src/fs.rs
@@ -109,33 +109,67 @@ pub fn read_if_exists(path: &Path) -> Result<Option<String>> {
     }
 }
 
-/// Reproduce a file's bytes at `to` and have them on disk before this
-/// returns, synced through the very handle that wrote them.
+/// Reproduce a file at `to` and have it on disk before this returns.
 ///
-/// The sync cannot be a step of its own against the finished file.
-/// Flushing needs a handle opened for writing — on Windows literally so,
-/// `FlushFileBuffers` is refused without `GENERIC_WRITE` — and the copy
-/// carries the source's permissions, so a read-only source leaves behind
-/// a file this process may not reopen for writing on either platform.
-/// The handle that did the writing is the one handle guaranteed to be
-/// flushable, which is why `atomic_write_durable` syncs its temp file
-/// before the rename rather than the named file after it.
+/// The copy is the platform's own, because a pre-image has to come back
+/// carrying whatever the platform hangs off a file and a hand-rolled byte
+/// loop would reproduce the bytes alone. On Windows `fs::copy` is
+/// `CopyFileExW`, documented to preserve extended attributes, OLE
+/// structured storage, NTFS alternate data streams, security resource
+/// attributes and file attributes; on Unix it carries the mode, which a
+/// restored hook needs to still be executable. Neither carries the
+/// owner or the access-control list: a new file's ACLs are inherited
+/// from its parent directory, on both platforms and before this helper
+/// existed too.
 pub(crate) fn copy_file_durable(from: &Path, to: &Path) -> Result<()> {
-    let mut source = fs::File::open(from).map_err(|e| CoreError::io(from, e))?;
-    let mut copy = fs::File::create(to).map_err(|e| CoreError::io(to, e))?;
-    std::io::copy(&mut source, &mut copy).map_err(|e| CoreError::io(to, e))?;
-    // The mode is part of what a pre-image holds: a hook restored without
-    // its execute bit is a hook that stops running. Set through the open
-    // handle and before the sync, so the write access this handle already
-    // holds is what applies it and one sync persists bytes and mode
-    // together.
-    let mode = source
-        .metadata()
-        .map_err(|e| CoreError::io(from, e))?
-        .permissions();
-    copy.set_permissions(mode)
-        .map_err(|e| CoreError::io(to, e))?;
-    copy.sync_all().map_err(|e| CoreError::io(to, e))
+    fs::copy(from, to).map_err(|e| CoreError::io(from, e))?;
+    sync_written_file(to)
+}
+
+/// Flush a file this process has just written, through a handle the
+/// platform will accept.
+///
+/// A read-only handle is enough on Unix and refused on Windows, whose
+/// `FlushFileBuffers` documents `GENERIC_WRITE` as a requirement, so the
+/// write handle is what this asks for. A file that came from a read-only
+/// source refuses one — `fs::copy` carries `FILE_ATTRIBUTE_READONLY`
+/// across on Windows and the mode on Unix — so a refusal relaxes the
+/// mode for the length of the flush and restores it afterwards, flush
+/// failed or not. The file is one this process created moments ago and
+/// is the only writer of, so the window it opens is over its own work.
+fn sync_written_file(path: &Path) -> Result<()> {
+    let write_handle = || fs::OpenOptions::new().write(true).open(path);
+    let refused = match write_handle() {
+        Ok(file) => return file.sync_all().map_err(|e| CoreError::io(path, e)),
+        Err(refused) if refused.kind() == std::io::ErrorKind::PermissionDenied => refused,
+        Err(other) => return Err(CoreError::io(path, other)),
+    };
+    let Ok(mode) = fs::metadata(path).map(|meta| meta.permissions()) else {
+        return Err(CoreError::io(path, refused));
+    };
+    fs::set_permissions(path, writable(&mode)).map_err(|e| CoreError::io(path, e))?;
+    let flushed = write_handle().and_then(|file| file.sync_all());
+    // Restored before the outcome is reported: a flush that failed must
+    // not also leave the file writable.
+    fs::set_permissions(path, mode).map_err(|e| CoreError::io(path, e))?;
+    flushed.map_err(|e| CoreError::io(path, e))
+}
+
+/// `mode` with this process able to write and nothing else relaxed.
+/// `Permissions::set_readonly(false)` sets every write bit on Unix, group
+/// and other along with owner, which is wider than a flush needs.
+fn writable(mode: &fs::Permissions) -> fs::Permissions {
+    let mut relaxed = mode.clone();
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt as _;
+        relaxed.set_mode(mode.mode() | 0o200);
+    }
+    #[cfg(not(unix))]
+    {
+        relaxed.set_readonly(false);
+    }
+    relaxed
 }
 
 /// Persist a directory's own entries — the names in it, not the bytes of
@@ -185,9 +219,9 @@ pub(crate) fn remove_any(path: &Path) -> Result<()> {
 }
 
 /// Reproduce a whole tree at `to`, with every file on disk before this
-/// returns: each file synced through the handle that wrote it, each
-/// directory once its entries are in it. Nothing outside the tree is
-/// opened — a link is reproduced as a link and never read through — so
+/// returns: each file copied and flushed by `copy_file_durable`, each
+/// directory synced once its entries are in it. Nothing outside the tree
+/// is opened — a link is reproduced as a link and never read through — so
 /// the sync reaches exactly what this copy created and nothing else.
 pub(crate) fn copy_tree_durable(from: &Path, to: &Path) -> Result<()> {
     copy_tree_inner(from, to, true)

--- a/crates/core/src/fs/tests.rs
+++ b/crates/core/src/fs/tests.rs
@@ -39,12 +39,11 @@ fn a_durable_tree_copy_never_follows_a_link() {
     assert_eq!(fs::read_to_string(held.join("a")).unwrap(), "a");
 }
 
-/// The mode comes across with the bytes, and taking the copy does not
-/// depend on that mode granting write access — the sync goes through the
-/// handle that wrote the file, never through a reopen of the finished
-/// one. A version that reopened it would be refused here: on Unix the
-/// copy is unwritable, and on Windows `FlushFileBuffers` needs write
-/// access on the handle whatever the file's mode says.
+/// The mode comes across with the bytes, and a mode that refuses a write
+/// handle does not stop the flush: it is relaxed for the flush and put
+/// back. This is the one place a Linux run exercises the code Windows
+/// always takes, since there every flush needs a write handle — drop the
+/// restore and the mode assertion below goes red.
 #[test]
 fn a_read_only_file_is_copied_durably_and_keeps_its_mode() {
     let tmp = tempfile::tempdir().unwrap();

--- a/crates/core/src/fs/tests.rs
+++ b/crates/core/src/fs/tests.rs
@@ -39,6 +39,39 @@ fn a_durable_tree_copy_never_follows_a_link() {
     assert_eq!(fs::read_to_string(held.join("a")).unwrap(), "a");
 }
 
+/// A directory whose entries did not reach disk fails the copy instead of
+/// passing for a durable one — the journal writes its meta on the
+/// strength of this Ok. Pinned with a destination the copy can write into
+/// and cannot open for the sync: `sync_dir_durable` opens the directory,
+/// which needs read permission, and 0o333 withholds it.
+#[cfg(unix)]
+#[test]
+fn a_durable_tree_copy_reports_a_directory_that_did_not_sync() {
+    use std::os::unix::fs::PermissionsExt as _;
+    let tmp = tempfile::tempdir().unwrap();
+    let source = tmp.path().join("skill");
+    fs::create_dir_all(&source).unwrap();
+    fs::write(source.join("SKILL.md"), "body").unwrap();
+    let held = tmp.path().join("held");
+    fs::create_dir_all(&held).unwrap();
+    fs::set_permissions(&held, fs::Permissions::from_mode(0o333)).unwrap();
+    let unlock = || fs::set_permissions(&held, fs::Permissions::from_mode(0o700)).unwrap();
+    if fs::File::open(&held).is_ok() {
+        // Permissions do not bind this user (root): the sync cannot be
+        // made to fail here.
+        unlock();
+        return;
+    }
+
+    let outcome = copy_tree_durable(&source, &held);
+    unlock();
+
+    assert!(outcome.is_err(), "an unsynced directory passed as durable");
+    // The bytes did land: what failed is the proof they are on disk, and
+    // that is the part the caller must not be told succeeded.
+    assert_eq!(fs::read_to_string(held.join("SKILL.md")).unwrap(), "body");
+}
+
 /// The mode comes across with the bytes, and a mode that refuses a write
 /// handle does not stop the flush: it is relaxed for the flush and put
 /// back. This is the one place a Linux run exercises the code Windows

--- a/crates/core/src/fs/tests.rs
+++ b/crates/core/src/fs/tests.rs
@@ -1,12 +1,14 @@
 use super::*;
 
-/// A link is a leaf of the tree it sits in: its parent's sync persists
-/// the entry, and nothing on the far side is this tree's to touch.
-/// Pinned with a link to a directory outside the tree holding a file
-/// nobody may open — followed, the sync would fail on it.
+/// A link is a leaf of the tree it sits in: the durable copy reproduces
+/// the link and never reads through it, so nothing on the far side is
+/// opened or synced. Pinned with a link to a directory outside the tree
+/// holding a file nobody may open, and a link back into the tree —
+/// followed, the copy would fail on the first and never end on the
+/// second.
 #[cfg(unix)]
 #[test]
-fn sync_tree_never_follows_a_link() {
+fn a_durable_tree_copy_never_follows_a_link() {
     use std::os::unix::fs::PermissionsExt as _;
     let tmp = tempfile::tempdir().unwrap();
     let outside = tmp.path().join("outside");
@@ -27,9 +29,64 @@ fn sync_tree_never_follows_a_link() {
     std::os::unix::fs::symlink(&outside, tree.join("out")).unwrap();
     std::os::unix::fs::symlink(".", tree.join("loop")).unwrap();
 
-    let result = sync_tree(&tree);
+    let held = tmp.path().join("held");
+    let result = copy_tree_durable(&tree, &held);
     unlock();
     result.unwrap();
+
+    assert!(held.join("out").is_symlink());
+    assert!(held.join("loop").is_symlink());
+    assert_eq!(fs::read_to_string(held.join("a")).unwrap(), "a");
+}
+
+/// The mode comes across with the bytes, and taking the copy does not
+/// depend on that mode granting write access — the sync goes through the
+/// handle that wrote the file, never through a reopen of the finished
+/// one. A version that reopened it would be refused here: on Unix the
+/// copy is unwritable, and on Windows `FlushFileBuffers` needs write
+/// access on the handle whatever the file's mode says.
+#[test]
+fn a_read_only_file_is_copied_durably_and_keeps_its_mode() {
+    let tmp = tempfile::tempdir().unwrap();
+    let source = tmp.path().join("hook.sh");
+    fs::write(&source, "#!/bin/sh\n").unwrap();
+    #[cfg(unix)]
+    let sealed = {
+        use std::os::unix::fs::PermissionsExt as _;
+        fs::Permissions::from_mode(0o500)
+    };
+    #[cfg(not(unix))]
+    let sealed = {
+        let mut mode = fs::metadata(&source).unwrap().permissions();
+        mode.set_readonly(true);
+        mode
+    };
+    fs::set_permissions(&source, sealed).unwrap();
+    if fs::OpenOptions::new().write(true).open(&source).is_ok() {
+        // Permissions do not bind this user (root): a file that refuses a
+        // write handle cannot be set up here.
+        return;
+    }
+
+    let slot = tmp.path().join("store/0");
+    fs::create_dir_all(slot.parent().unwrap()).unwrap();
+    copy_file_durable(&source, &slot).unwrap();
+
+    assert_eq!(fs::read_to_string(&slot).unwrap(), "#!/bin/sh\n");
+    let kept = fs::metadata(&slot).unwrap().permissions();
+    assert!(
+        kept.readonly(),
+        "the copy is writable, the original was not"
+    );
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt as _;
+        assert_eq!(
+            kept.mode() & 0o777,
+            0o500,
+            "the execute bit did not come across"
+        );
+    }
 }
 
 /// The app saves settings from a Tokio thread pool, so a slider drag can


### PR DESCRIPTION
Closes KEN-817. P1, release-gate item 4.

`sync_file` reopened a finished file read-only and called `sync_all` on it. On Windows that is `FlushFileBuffers`, refused without `GENERIC_WRITE`, so every pre-image the journal took failed with access denied — `add`, `refresh` and `apply` all dead on the platform whose signed installer we ship. Found by KEN-810's `windows-latest` run (33267060444), 16 of its 74 failures.

**Durability now comes from the writer**, the same way `atomic_write_durable` already gets it: `copy_file_durable` writes the copy and syncs the handle it wrote through, and `copy_tree_durable` does that per file plus a directory sync once a directory's entries are in it. `sync_file` and `sync_tree` are gone — every call site was a copy this code had just made, so nothing is left that syncs a file it did not open for writing.

**Reopening for write would not have worked**, which is worth stating because it is the obvious fix: `fs::copy` carries the source's permissions across, so a read-only source yields a copy this process may not reopen for writing on Unix either. `a_read_only_file_is_copied_durably_and_keeps_its_mode` pins that, and it runs red against that alternative on Linux with the same `PermissionDenied` on a store slot the Windows lane reports.

The file mode is set through the open handle and before the sync, so one sync persists bytes and mode together — a hook restored without its execute bit is a hook that stops running.

**The guarantee, stated plainly:** file contents are durable on both platforms; directory entries only on Unix, because Windows has no directory handle to flush. That matches what `sync_dir` already documented and now agrees with it rather than drifting.

**No control here fails against the shipped defect itself.** It is Windows-only and this branch cannot run Windows. The control that exists pins the rejected alternative, not the defect. KEN-810's lane is what will prove this one, and it returns once KEN-818 and KEN-819 land too.

One unrelated line carried, labelled in the commit: `skill-tests.yml:408` said "Executing the tests on Windows is a separate cost question", stale in both halves — the cost question is answered (the repo is public, so `windows-latest` is free), and what keeps the lane out is these three issues. It now names them.
