### PR TITLE
fix(KEN-818): a package path is judged by its shape, not the host

### DIFF
--- a/changelog.d/security/KEN-818.md
+++ b/changelog.d/security/KEN-818.md
@@ -1,0 +1,3 @@
+- A Pi extension's `package.json` can only name files inside its own package.
+  A path reaching outside it is refused identically on every platform, not by
+  whatever the running one calls absolute.

--- a/changelog.d/security/KEN-818.md
+++ b/changelog.d/security/KEN-818.md
@@ -1,3 +1,3 @@
-- A Pi extension's `package.json` can only name files inside its own package.
-  A path reaching outside it is refused identically on every platform, not by
-  whatever the running one calls absolute.
+- The executables a Pi extension declares, and the system text it appends, now
+  have to sit inside the package. A path reaching outside is refused the same
+  way on every platform.

--- a/crates/core/src/pi_ext/files.rs
+++ b/crates/core/src/pi_ext/files.rs
@@ -87,19 +87,44 @@ pub(super) fn package_path(scope_root: &Path, name: &str) -> Result<PathBuf> {
 
 /// Resolve a package-relative path from `package.json`, refusing one that
 /// points outside the package.
+///
+/// The declared string is judged on its own shape, not on what the running
+/// platform makes of it, so one `package.json` is refused identically
+/// wherever it installs. `Path::is_absolute` cannot do that: on Windows
+/// `/etc/passwd` is not absolute, Rust wanting a drive or a UNC prefix
+/// first, and `Path::join` drops the base for it anyway. So a leading `/`
+/// is refused everywhere, and so are the two characters that spell the
+/// Windows escapes: `\`, which is a separator there and hides `..\..` from
+/// `Component::ParentDir` when the string is parsed here, and `:`, which
+/// opens a drive, a device prefix or an alternate data stream. The result
+/// is then built from the segments checked here rather than by joining the
+/// declared string, so nothing unexamined reaches the filesystem.
 pub(super) fn inside(base: &Path, relative: &str, name: &str) -> Result<PathBuf> {
-    let path = Path::new(relative);
-    if path.is_absolute()
-        || path
-            .components()
-            .any(|part| part == std::path::Component::ParentDir)
-    {
-        return Err(CoreError::PiPackage {
-            name: name.to_owned(),
-            message: format!("`{relative}` points outside the package"),
-        });
+    let refuse = || CoreError::PiPackage {
+        name: name.to_owned(),
+        message: format!("`{relative}` does not name a path inside the package"),
+    };
+    if relative.starts_with('/') || relative.contains('\\') || relative.contains(':') {
+        return Err(refuse());
     }
-    Ok(base.join(relative.trim_start_matches("./")))
+    let mut path = base.to_path_buf();
+    let mut named = false;
+    for part in relative.split('/') {
+        if part.is_empty() || part == "." {
+            continue;
+        }
+        if part == ".." {
+            return Err(refuse());
+        }
+        path.push(part);
+        named = true;
+    }
+    // Nothing but separators and `.` names the package directory itself,
+    // which is not a file a package can declare.
+    if !named {
+        return Err(refuse());
+    }
+    Ok(path)
 }
 
 /// Removal never deletes: the replaced or uninstalled copy moves to the
@@ -154,8 +179,65 @@ mod tests {
             inside(base, "dist/index.js", "p").unwrap(),
             PathBuf::from("/pkg/dist/index.js")
         );
+        // `.` and doubled separators are spelling, not an escape: a run of
+        // separators collapses, so both of these name the same file under the
+        // package and resolve there. The second is where the old code judged
+        // one string and joined another — trimming `./` off the front left a
+        // rooted path that `join` then dropped the base for, landing it on
+        // `/dist/sub/index.js` on Unix as much as on Windows.
+        for spelling in ["dist/./sub//index.js", ".//dist/sub/index.js"] {
+            assert_eq!(
+                inside(base, spelling, "p").unwrap(),
+                PathBuf::from("/pkg/dist/sub/index.js"),
+                "{spelling:?} names a file inside the package"
+            );
+        }
         assert!(inside(base, "../outside.js", "p").is_err());
         assert!(inside(base, "/etc/passwd", "p").is_err());
+    }
+
+    /// Every one of these is an escape on some platform, so `inside` refuses
+    /// it on all of them: the rule reads the declared string, and a package
+    /// author's `package.json` cannot mean one thing on Linux and another on
+    /// Windows. Each case is refused on the platform running this test, which
+    /// is what makes the property testable off Windows at all.
+    #[test]
+    fn escape_spellings_are_refused_on_every_platform() {
+        let base = Path::new("/pkg");
+        for spelling in [
+            // Rooted. `is_absolute` says false on Windows, `join` drops the
+            // base anyway.
+            "/etc/passwd",
+            // Drive-absolute and drive-relative. Neither is absolute to Rust
+            // on Unix, and `C:foo` resolves against the drive's own cwd.
+            "C:\\Windows\\System32\\drivers\\etc\\hosts",
+            "C:/Windows/System32",
+            "C:evil",
+            // UNC share and device namespace.
+            "\\\\server\\share\\evil",
+            "\\\\?\\C:\\evil",
+            // Backslash traversal: `Component::ParentDir` never sees it when
+            // the string is parsed on Unix.
+            "..\\..\\evil",
+            "dist\\..\\..\\evil",
+            // Alternate data stream: a second, hidden write target on the
+            // same name.
+            "cli.js:stream",
+            // Forward-slash traversal, in and past the middle of a path.
+            "../outside.js",
+            "dist/../../outside.js",
+            // Names nothing at all — the package directory or the bin
+            // directory itself, which a caller would then unlink.
+            "",
+            ".",
+            "./",
+            "/",
+        ] {
+            assert!(
+                inside(base, spelling, "p").is_err(),
+                "{spelling:?} should be refused"
+            );
+        }
     }
 
     /// A name a dangling link holds is a name that is taken, and `exists`

--- a/crates/core/src/pi_ext/files.rs
+++ b/crates/core/src/pi_ext/files.rs
@@ -93,36 +93,42 @@ pub(super) fn package_path(scope_root: &Path, name: &str) -> Result<PathBuf> {
 /// wherever it installs. `Path::is_absolute` cannot do that: on Windows
 /// `/etc/passwd` is not absolute, Rust wanting a drive or a UNC prefix
 /// first, and `Path::join` drops the base for it anyway. So a leading `/`
-/// is refused everywhere, and so are the two characters that spell the
-/// Windows escapes: `\`, which is a separator there and hides `..\..` from
-/// `Component::ParentDir` when the string is parsed here, and `:`, which
-/// opens a drive, a device prefix or an alternate data stream. The result
-/// is then built from the segments checked here rather than by joining the
-/// declared string, so nothing unexamined reaches the filesystem.
+/// is refused here, on the shape of the string.
+///
+/// Every segment then answers to [`crate::names::segment_problem`], which is
+/// where this repository already keeps what a name may be and what Windows
+/// will quietly make of one. That is the judge on purpose: a segment ending
+/// in a dot or a space is trimmed by Windows, so `.. ` arrives as `..` and
+/// no comparison against the literal `..` will ever see it, and the same
+/// holds for the next spelling nobody has thought of. It also refuses the
+/// `\` that is a separator there and the `:` that opens a drive, a device
+/// prefix or an alternate data stream. The result is built from the
+/// segments checked here rather than by joining the declared string, so
+/// nothing unexamined reaches the filesystem.
 pub(super) fn inside(base: &Path, relative: &str, name: &str) -> Result<PathBuf> {
-    let refuse = || CoreError::PiPackage {
+    let refuse = |detail: &str| CoreError::PiPackage {
         name: name.to_owned(),
-        message: format!("`{relative}` does not name a path inside the package"),
+        message: format!("`{relative}` does not name a path inside the package: {detail}"),
     };
-    if relative.starts_with('/') || relative.contains('\\') || relative.contains(':') {
-        return Err(refuse());
+    if relative.starts_with('/') {
+        return Err(refuse("it starts at the root of the drive"));
     }
     let mut path = base.to_path_buf();
     let mut named = false;
     for part in relative.split('/') {
+        // A run of separators collapses and `.` is the directory it sits in;
+        // neither names anything, and neither is a segment to check.
         if part.is_empty() || part == "." {
             continue;
         }
-        if part == ".." {
-            return Err(refuse());
+        if let Some(problem) = crate::names::segment_problem(part) {
+            return Err(refuse(&problem));
         }
         path.push(part);
         named = true;
     }
-    // Nothing but separators and `.` names the package directory itself,
-    // which is not a file a package can declare.
     if !named {
-        return Err(refuse());
+        return Err(refuse("it names the package directory, not a file in it"));
     }
     Ok(path)
 }
@@ -226,6 +232,21 @@ mod tests {
             // Forward-slash traversal, in and past the middle of a path.
             "../outside.js",
             "dist/../../outside.js",
+            // Traversal wearing a trailing dot or space. Windows drops those
+            // from a component on the way to the filesystem, so `.. ` arrives
+            // as `..` while no segment here ever equals `..`. This is why the
+            // segment rule is `names::segment_problem` and not a list of
+            // spellings to compare against: the list is short by one again at
+            // the next spelling, and the trimming rule is not.
+            ".. /victim",
+            ".. /.. /outside",
+            "dist/.. /.. /outside",
+            "... /outside",
+            // The same trimming on an ordinary name: `victim.` and `victim`
+            // are two names here and one file there, so a package could reach
+            // a file kendex believes it did not name.
+            "dist/victim./x",
+            "dist/victim /x",
             // Names nothing at all — the package directory or the bin
             // directory itself, which a caller would then unlink.
             "",

--- a/crates/core/src/pi_ext/files.rs
+++ b/crates/core/src/pi_ext/files.rs
@@ -106,9 +106,15 @@ pub(super) fn package_path(scope_root: &Path, name: &str) -> Result<PathBuf> {
 /// segments checked here rather than by joining the declared string, so
 /// nothing unexamined reaches the filesystem.
 pub(super) fn inside(base: &Path, relative: &str, name: &str) -> Result<PathBuf> {
+    // The path is the package's own text on its way to a terminal, so it is
+    // quoted through the same escape `segment_problem` uses for the segment
+    // it names — both halves of the message or neither.
     let refuse = |detail: &str| CoreError::PiPackage {
         name: name.to_owned(),
-        message: format!("`{relative}` does not name a path inside the package: {detail}"),
+        message: format!(
+            "`{}` does not name a path inside the package: {detail}",
+            crate::names::shown(relative)
+        ),
     };
     if relative.starts_with('/') {
         return Err(refuse("it starts at the root of the drive"));
@@ -259,6 +265,21 @@ mod tests {
                 "{spelling:?} should be refused"
             );
         }
+    }
+
+    /// The refusal quotes a string the package wrote, so it leaves escaped.
+    /// Raw, an escape sequence would clear the line the diagnostic is on and
+    /// a right-to-left override would reorder what follows it, which is a
+    /// package deciding what the terminal says about it.
+    #[test]
+    fn a_refusal_escapes_the_path_it_names() {
+        let message = inside(Path::new("/pkg"), "dist/\u{1b}[2K\u{202e}sj.live", "p")
+            .unwrap_err()
+            .to_string();
+        assert!(!message.contains('\u{1b}'), "{message}");
+        assert!(!message.contains('\u{202e}'), "{message}");
+        assert!(message.contains("\\u{1b}"), "{message}");
+        assert!(message.contains("\\u{202e}"), "{message}");
     }
 
     /// A name a dangling link holds is a name that is taken, and `exists`


### PR DESCRIPTION
Closes KEN-818. **P1, security**, release-gate item 4.

`inside()` at `pi_ext/files.rs:90` keeps a path declared in a package's `package.json` from pointing outside the package. It refused an escape with `Path::is_absolute` — a question about the running host, asked of a string a package author wrote.

**Wider than the issue says.** KEN-818 describes this as a Windows hole, and it is one: `Path::new("/etc/passwd").is_absolute()` is false there, so the check passed and `Path::join` dropped the base. But the check also read one string and joined a different one — `trim_start_matches("./")` turned `.//etc/passwd` into a rooted path *after* the check had looked at it, so that spelling escaped **on Unix too**. The issue understates the defect; this PR fixes both.

Why it matters rather than being a tidiness point: `pi_ext/mod.rs:327` runs a key from the package's own `bins` map through `inside`, and `link_bins` then unlinks whatever is at the result and creates a symlink there. The escape is a write, not a read.

**The rule now reads the declared string, not the host's opinion of it.** A leading `/`, a `\` or a `:` is refused on every platform; `..` is refused per segment; and the returned path is built from the segments that were actually checked rather than by joining the declared string, so there is no second parse to disagree with the first. The same `package.json` is refused identically wherever it is installed, which is the property a containment check should have.

**The controls fail on Linux against the old code**, case by case — deliberately. A containment rule that reads the string can be tested anywhere, and a test that only failed on Windows would just be the platform check written again.
