### PR TITLE
fix(KEN-800): the scan exits nonzero unless something was measured

### DIFF
--- a/tools/vacuous-suite-scan
+++ b/tools/vacuous-suite-scan
@@ -118,9 +118,16 @@ require_setup() {
     # That is a wrong-cause diagnostic, which is the class this whole change
     # exists to remove. The value is judged once, by the same tool that will
     # use it, and its own message is what the operator sees.
+    # 125 is the only status that means the duration was rejected: timeout
+    # documents it as the tool itself failing. 124 means the opposite — the
+    # duration was accepted and applied, and the command hit it — so treating
+    # any nonzero status as a rejection refuses valid configurations. Which
+    # ones is not even fixed: whether `true` finishes inside the operator's
+    # own bound is a race that moves with the machine and its load, so the
+    # same duration is refused on one run and accepted on the next.
     local probe_err="" probe_rc=0
     probe_err="$("$SUITE_TIMEOUT_BIN" "$SUITE_TIMEOUT" true 2>&1)" || probe_rc=$?
-    if [[ "$probe_rc" -ne 0 ]]; then
+    if [[ "$probe_rc" -eq 125 ]]; then
         probe_err="${probe_err%%$'\n'*}"
         die "VACUOUS_SCAN_TIMEOUT of '$SUITE_TIMEOUT' is not a duration $SUITE_TIMEOUT_BIN accepts${probe_err:+ — $probe_err}"
     fi

--- a/tools/vacuous-suite-scan
+++ b/tools/vacuous-suite-scan
@@ -96,14 +96,19 @@ list_suites() {
 require_setup() {
     command -v "$SUITE_TIMEOUT_BIN" >/dev/null 2>&1 ||
         die "$SUITE_TIMEOUT_BIN is not installed: every suite is run under it, so without it nothing can be measured (GNU coreutils provides it, as gtimeout on macOS — set VACUOUS_SCAN_TIMEOUT_BIN)"
-    [[ "$SUITE_TIMEOUT" =~ ^[0-9]+[smhd]?$ ]] ||
-        die "VACUOUS_SCAN_TIMEOUT is not a whole-number duration: $SUITE_TIMEOUT"
-    # Matched, not evaluated. Bash arithmetic reads a zero-padded number as
-    # octal, so `-gt 0` on 08 fails with "value too great for base" and the
-    # refusal below then reports a valid duration as a disabled bound — wrong
-    # about the value and wrong about the reason. GNU timeout accepts 08.
-    if [[ "${SUITE_TIMEOUT%[smhd]}" =~ ^0+$ ]]; then
-        die "VACUOUS_SCAN_TIMEOUT of $SUITE_TIMEOUT disables the bound rather than setting it, which is never what a caller means by zero"
+    # One thing is refused here, and timeout judges the rest. Its DURATION is
+    # a floating point number with an optional suffix, so 0.5 and 1.5s are
+    # valid and a whole-number rule here would reject values the tool accepts
+    # — a second copy of someone else's grammar, wrong the moment it drifts.
+    # The scan needs exactly one refusal of its own: a duration with nothing
+    # non-zero in it, because zero disables the bound instead of setting it.
+    #
+    # Matched, never evaluated. Bash arithmetic reads a zero-padded number as
+    # octal, so a comparison against 08 fails with "value too great for base"
+    # and the refusal then reports a valid duration as a disabled bound —
+    # wrong about the value and wrong about the reason.
+    if [[ "${SUITE_TIMEOUT%[smhd]}" =~ ^0*\.?0*$ ]]; then
+        die "VACUOUS_SCAN_TIMEOUT of '$SUITE_TIMEOUT' carries no non-zero duration; zero disables the bound rather than setting it"
     fi
 }
 

--- a/tools/vacuous-suite-scan
+++ b/tools/vacuous-suite-scan
@@ -98,8 +98,13 @@ require_setup() {
         die "$SUITE_TIMEOUT_BIN is not installed: every suite is run under it, so without it nothing can be measured (GNU coreutils provides it, as gtimeout on macOS — set VACUOUS_SCAN_TIMEOUT_BIN)"
     [[ "$SUITE_TIMEOUT" =~ ^[0-9]+[smhd]?$ ]] ||
         die "VACUOUS_SCAN_TIMEOUT is not a whole-number duration: $SUITE_TIMEOUT"
-    [[ "${SUITE_TIMEOUT%[smhd]}" -gt 0 ]] ||
+    # Matched, not evaluated. Bash arithmetic reads a zero-padded number as
+    # octal, so `-gt 0` on 08 fails with "value too great for base" and the
+    # refusal below then reports a valid duration as a disabled bound — wrong
+    # about the value and wrong about the reason. GNU timeout accepts 08.
+    if [[ "${SUITE_TIMEOUT%[smhd]}" =~ ^0+$ ]]; then
         die "VACUOUS_SCAN_TIMEOUT of $SUITE_TIMEOUT disables the bound rather than setting it, which is never what a caller means by zero"
+    fi
 }
 
 run_suite() {
@@ -158,9 +163,23 @@ scan_skill() {
         fi
     done
 
-    # A measurement is a suite that produced a verdict. An unrunnable one did
-    # not: it never reached the comparison this scan is made of.
-    measured=$((${#vacuous[@]} + ${#harness[@]} + ${#red[@]} + ${#contradicting[@]}))
+    # A measurement is a suite whose vacuity this metric actually settled.
+    #
+    #   vacuous        settled: it passed with the product blanked
+    #   detecting      settled: it failed with the product blanked
+    #   contradicting  settled the same way as detecting; what is wrong there
+    #                  is the suite's own declaration, which the check at the
+    #                  end of main reports separately
+    #   harness        NOT settled: this metric works by breaking product
+    #                  files and a harness suite has none, which is the whole
+    #                  reason the category exists — counting it would let a
+    #                  target holding only harness suites exit 0 having
+    #                  measured no vacuity at all
+    #   unrunnable     NOT settled: it never reached the comparison
+    #
+    # Every category the loop above can assign appears in this list. Adding
+    # another means deciding which side of it the new one sits on, here.
+    measured=$((${#vacuous[@]} + ${#red[@]} + ${#contradicting[@]}))
     SCAN_MEASURED=$((SCAN_MEASURED + measured))
     [[ "$measured" -gt 0 ]] || SCAN_UNMEASURED="$SCAN_UNMEASURED $name"
 
@@ -238,7 +257,7 @@ main() {
     # and measuring nothing are the same failure here, at the whole-run level
     # and per skill, so neither needs its own check.
     if [[ "$SCAN_MEASURED" -eq 0 || -n "$SCAN_UNMEASURED" ]]; then
-        die "no suite was measured${SCAN_UNMEASURED:+ in:$SCAN_UNMEASURED} — a scan that measured nothing is not a scan that passed; name a skill directory or pass --all, and check that its suites run from a copy"
+        die "no suite was measured${SCAN_UNMEASURED:+ in:$SCAN_UNMEASURED} — a scan that measured nothing is not a scan that passed. Name a skill directory or pass --all; a named one measures nothing when its suites cannot run from a copy, or are all harness-subject, which this metric cannot settle"
     fi
 
     # A separate invariant, not a second statement of the one above: this is a

--- a/tools/vacuous-suite-scan
+++ b/tools/vacuous-suite-scan
@@ -31,14 +31,28 @@
 #   tools/vacuous-suite-scan --all                    # every skill with suites
 #   tools/vacuous-suite-scan skills/linear            # one named skill
 #   tools/vacuous-suite-scan --list --all             # names, not just counts
+#
+# The invariant, stated once and enforced once, where the exit status is
+# computed: the scan exits nonzero unless suites were actually MEASURED, and
+# the number gating that is the count of measurements taken — not of targets
+# named, directories resolved, or suites found. A suite that could not run in
+# the copy was not measured, so a run where every suite was unrunnable is a
+# total measurement failure and says so, rather than reporting zeroes at
+# status 0 for automation to read as clean.
 
 set -euo pipefail
 
 REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 LIST_NAMES=0
 SUITE_TIMEOUT="${VACUOUS_SCAN_TIMEOUT:-120}"
+# macOS ships coreutils' timeout as gtimeout when it ships it at all, so the
+# name is overridable — and its absence is a setup error, reported once here
+# rather than as every suite failing to run.
+SUITE_TIMEOUT_BIN="${VACUOUS_SCAN_TIMEOUT_BIN:-timeout}"
 SCAN_TMP=""
 SCAN_CONTRADICTIONS=0
+SCAN_MEASURED=0
+SCAN_UNMEASURED=""
 
 die() {
     echo "vacuous-suite-scan: $*" >&2
@@ -79,9 +93,18 @@ list_suites() {
     done
 }
 
+require_setup() {
+    command -v "$SUITE_TIMEOUT_BIN" >/dev/null 2>&1 ||
+        die "$SUITE_TIMEOUT_BIN is not installed: every suite is run under it, so without it nothing can be measured (GNU coreutils provides it, as gtimeout on macOS — set VACUOUS_SCAN_TIMEOUT_BIN)"
+    [[ "$SUITE_TIMEOUT" =~ ^[0-9]+[smhd]?$ ]] ||
+        die "VACUOUS_SCAN_TIMEOUT is not a whole-number duration: $SUITE_TIMEOUT"
+    [[ "${SUITE_TIMEOUT%[smhd]}" -gt 0 ]] ||
+        die "VACUOUS_SCAN_TIMEOUT of $SUITE_TIMEOUT disables the bound rather than setting it, which is never what a caller means by zero"
+}
+
 run_suite() {
     local suite_path="$1"
-    timeout "$SUITE_TIMEOUT" bash "$suite_path" >/dev/null 2>&1
+    "$SUITE_TIMEOUT_BIN" "$SUITE_TIMEOUT" bash "$suite_path" >/dev/null 2>&1
 }
 
 # A suite that declares the harness as its subject: this metric breaks product
@@ -93,7 +116,7 @@ declares_harness_subject() {
 
 scan_skill() {
     local skill_dir="$1"
-    local name tmp pristine blanked suite
+    local name tmp pristine blanked suite measured=0
     local -a suites=() vacuous=() unrunnable=() red=() harness=() contradicting=()
 
     name="$(basename "$skill_dir")"
@@ -135,6 +158,12 @@ scan_skill() {
         fi
     done
 
+    # A measurement is a suite that produced a verdict. An unrunnable one did
+    # not: it never reached the comparison this scan is made of.
+    measured=$((${#vacuous[@]} + ${#harness[@]} + ${#red[@]} + ${#contradicting[@]}))
+    SCAN_MEASURED=$((SCAN_MEASURED + measured))
+    [[ "$measured" -gt 0 ]] || SCAN_UNMEASURED="$SCAN_UNMEASURED $name"
+
     printf '%-20s %3d suites  %3d vacuous  %3d harness-subject  %3d detecting  %3d unrunnable-in-copy\n' \
         "$name" "${#suites[@]}" "${#vacuous[@]}" "${#harness[@]}" "${#red[@]}" "${#unrunnable[@]}"
 
@@ -161,6 +190,8 @@ scannable() {
 main() {
     local -a targets=() resolved=()
     local arg all=0
+
+    require_setup
     for arg in "$@"; do
         case "$arg" in
         --list) LIST_NAMES=1 ;;
@@ -197,15 +228,21 @@ main() {
         done
     fi
 
-    # The requirement that stands whichever mode ran: never report success
-    # having measured nothing.
-    [[ ${#resolved[@]} -gt 0 ]] ||
-        die "nothing to scan: name a skill directory, or pass --all"
-
-    for arg in "${resolved[@]}"; do
+    for arg in ${resolved[@]+"${resolved[@]}"}; do
         scan_skill "$arg"
     done
 
+    # The one place the exit status is decided, and it is gated on the count of
+    # measurements TAKEN — never on the count of directories resolved, which is
+    # what let a run whose every suite was unrunnable exit 0. Selecting nothing
+    # and measuring nothing are the same failure here, at the whole-run level
+    # and per skill, so neither needs its own check.
+    if [[ "$SCAN_MEASURED" -eq 0 || -n "$SCAN_UNMEASURED" ]]; then
+        die "no suite was measured${SCAN_UNMEASURED:+ in:$SCAN_UNMEASURED} — a scan that measured nothing is not a scan that passed; name a skill directory or pass --all, and check that its suites run from a copy"
+    fi
+
+    # A separate invariant, not a second statement of the one above: this is a
+    # declaration the measurement disproved, not a measurement that failed.
     [[ "$SCAN_CONTRADICTIONS" -eq 0 ]] ||
         die "a suite declared harness-subject that this metric did reach"
 }

--- a/tools/vacuous-suite-scan
+++ b/tools/vacuous-suite-scan
@@ -110,6 +110,20 @@ require_setup() {
     if [[ "${SUITE_TIMEOUT%[smhd]}" =~ ^0*\.?0*$ ]]; then
         die "VACUOUS_SCAN_TIMEOUT of '$SUITE_TIMEOUT' carries no non-zero duration; zero disables the bound rather than setting it"
     fi
+
+    # Everything else is timeout's to judge, and it judges here rather than per
+    # suite: run_suite sends its complaint to /dev/null, so a bad duration
+    # would make every suite look unrunnable and the scan would report "no
+    # suite was measured" — blaming the suites for a fault in the duration.
+    # That is a wrong-cause diagnostic, which is the class this whole change
+    # exists to remove. The value is judged once, by the same tool that will
+    # use it, and its own message is what the operator sees.
+    local probe_err="" probe_rc=0
+    probe_err="$("$SUITE_TIMEOUT_BIN" "$SUITE_TIMEOUT" true 2>&1)" || probe_rc=$?
+    if [[ "$probe_rc" -ne 0 ]]; then
+        probe_err="${probe_err%%$'\n'*}"
+        die "VACUOUS_SCAN_TIMEOUT of '$SUITE_TIMEOUT' is not a duration $SUITE_TIMEOUT_BIN accepts${probe_err:+ — $probe_err}"
+    fi
 }
 
 run_suite() {


### PR DESCRIPTION
`tools/vacuous-suite-scan` can report success having measured nothing. This shipped in #1807 — its review thread was still open when the PR merged — so it is a defect on `main` rather than one caught in review.

## The defect

When every pristine suite is unrunnable — GNU `timeout` absent on stock macOS, or every suite exceeding the configured bound — the scan prints `0 vacuous`, `0 detecting`, `1 unrunnable-in-copy` and **exits 0**. Automation cannot distinguish total measurement failure from a clean result.

The cause is one substitution: the exit gated on `resolved`, which counts **directories**, not suites successfully executed.

## Stated once, not guarded per mode

This is the **third** variant of the same invariant on this work:

1. an unknown skill silently skipped, exit 0;
2. the advertised `skills/*/` glob aborting before scanning anything — a fix for (1) overshooting;
3. this one, which shipped.

Each was fixed at one level and violated at the next, which is the argument against a fourth per-mode guard. The invariant now lives **once, where the exit status is computed**: the scan exits nonzero unless at least one suite was actually *measured*, and the number gating that is the count of measurements taken rather than directories resolved. The earlier modes fall out of that single condition rather than each carrying its own check.

## A missing `timeout` is a setup error

Every suite runs under `timeout`, so its absence means nothing can be measured — that is a property of the environment, not of 46 individual suites. It now says so once and stops:

```
$ PATH=<no timeout> tools/vacuous-suite-scan skills/linear
vacuous-suite-scan: timeout is not installed: every suite is run under it, so
without it nothing can be measured (GNU coreutils provides it, as gtimeout on
macOS — set VACUOUS_SCAN_TIMEOUT_BIN)
rc=1
```

`VACUOUS_SCAN_TIMEOUT=0` is also rejected up front rather than measured and reported empty, because a zero *disables* the bound in `timeout` rather than setting it — which is never what a caller means by zero:

```
$ VACUOUS_SCAN_TIMEOUT=0 tools/vacuous-suite-scan skills/linear
vacuous-suite-scan: VACUOUS_SCAN_TIMEOUT of 0 disables the bound rather than
setting it, which is never what a caller means by zero
rc=1
```

## Verification

Both probes above run against this branch. A normal scan is unaffected: `linear 50 suites 0 vacuous 4 harness-subject 46 detecting 0 unrunnable-in-copy`, exit 0. `tools/guard` clean.

One file, +45/−8.

---

## Review round: a fourth variant, inside this fix

Two findings on the diff above, both fixed in `340d9f152`.

**The fourth variant, and the first one this invariant's own fix introduced.** `harness-subject` was counted as a measurement. The script defines that category as *not measurable by this method* — it settles vacuity by blanking product files, and a harness suite has none — so a target holding only harness suites exited 0 having measured no vacuity at all. Confirmed on the parent commit: an all-harness fixture printed a well-formed table and exited **0**; it now exits 1 naming the cause.

Variants 1–3 were levels the rule had not reached yet. This one is different in kind: a **new category admitted without asking which side of the rule it sat on**, in the same change that fixed the rule. That is the argument for where the fix landed — the count expression now carries the full category list with each side and states that adding one means deciding there, so the next category is asked the question at the line someone would otherwise edit without asking.

| Category | Counts? | Why |
|---|---|---|
| `vacuous` | yes | settled: passed with the product blanked |
| `detecting` | yes | settled: failed with the product blanked |
| `contradicting` | yes | settled the same way; what is wrong is the suite's *declaration*, reported by its own check |
| `harness` | no | not settled: no product files to break — the reason the category exists |
| `unrunnable` | no | not settled: never reached the comparison |

This refuses no result. The table still prints and still names every harness suite; what it refuses is to assert that the result answers the question asked.

**A zero-padded duration was read as octal.** `VACUOUS_SCAN_TIMEOUT=08` passed the format check, then bash arithmetic read the `-gt` operand as octal, emitted `value too great for base`, and fired the zero-refusal — reporting a valid duration as a disabled bound. Wrong about the value *and* wrong about the reason, so a caller would have gone looking at their own setting. The all-zero test is now a pattern match (`=~ ^0+$`), which never evaluates the string. Accepted: `8`, `08`, `08s`, `3600`, `5m`. Refused: `0`, `00`, `0s`, `0h`.

Worth recording, since it is why refusing zero is a decision rather than documentation: GNU `timeout 0` does not fire immediately — its own `--help` says *a duration of 0 disables the associated timeout*. So zero would never have reproduced the reported case; it silently removes the bound.

Reproducing the shipped defect took a purpose-built fixture. A 1-second bound over `linear` was tried first and left 39 suites still measuring, so a tight timeout was not enough to force the shape; a throwaway skill whose only suite exits 1 was.

Refs KEN-800
