### PR TITLE
feat(KEN-444): Update now carries the kendex command across

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2314,6 +2314,7 @@ dependencies = [
  "thiserror 2.0.20",
  "toml 1.1.4+spec-1.1.0",
  "unicode-normalization",
+ "url",
  "yaml-rust2",
 ]
 

--- a/changelog.d/changed/KEN-444.md
+++ b/changelog.d/changed/KEN-444.md
@@ -1,0 +1,3 @@
+- The app's **Update now** brings the `kendex` command across with it, so no
+  terminal is left on the old release. Neither half moves unless both can, and
+  a package-managed command is left alone.

--- a/changelog.d/changed/KEN-444.md
+++ b/changelog.d/changed/KEN-444.md
@@ -1,3 +1,3 @@
 - The app's **Update now** updates a `kendex` command an installer recorded,
-  alongside the app. Otherwise the card says the app moves alone and names the
-  owner; one `kendex update` records it.
+  wherever it sits. Where another owns it or it needs permissions the app
+  lacks, the card names what moves it instead.

--- a/changelog.d/changed/KEN-444.md
+++ b/changelog.d/changed/KEN-444.md
@@ -1,3 +1,3 @@
-- The app's **Update now** brings the `kendex` command across with it, so no
-  terminal stays on the old release. If one half lands without the other the
-  card says so, and updating again moves both.
+- The app's **Update now** moves the `kendex` command with the app where that
+  command is kendex's to replace, and names what owns it where it is not. A
+  half left behind is reported on the card.

--- a/changelog.d/changed/KEN-444.md
+++ b/changelog.d/changed/KEN-444.md
@@ -1,3 +1,3 @@
-- The app's **Update now** moves the `kendex` command with the app where that
-  command is kendex's to replace, and names what owns it where it is not. A
-  half left behind is reported on the card.
+- The app's **Update now** updates the `kendex` command alongside the app.
+  Where another installer owns the command, the card names it and how to
+  update it, and Update now moves the app alone.

--- a/changelog.d/changed/KEN-444.md
+++ b/changelog.d/changed/KEN-444.md
@@ -1,3 +1,3 @@
-- The app's **Update now** updates the `kendex` command alongside the app.
-  Where another installer owns the command, the card names it and how to
-  update it, and Update now moves the app alone.
+- The app's **Update now** updates a `kendex` command an installer recorded,
+  alongside the app. Otherwise the card says the app moves alone and names the
+  owner; one `kendex update` records it.

--- a/changelog.d/changed/KEN-444.md
+++ b/changelog.d/changed/KEN-444.md
@@ -1,3 +1,3 @@
 - The app's **Update now** brings the `kendex` command across with it, so no
-  terminal is left on the old release. Neither half moves unless both can, and
-  a package-managed command is left alone.
+  terminal stays on the old release. If one half lands without the other the
+  card says so, and updating again moves both.

--- a/changelog.d/fixed/KEN-444-command-changed.md
+++ b/changelog.d/fixed/KEN-444-command-changed.md
@@ -1,0 +1,3 @@
+- **Update now** stops instead of going ahead when the `kendex` command
+  beside the app changed since the notice was drawn; the notice reads again
+  and says what is there.

--- a/crates/app/src/app_update.rs
+++ b/crates/app/src/app_update.rs
@@ -328,23 +328,14 @@ fn app_half_failed(release: &str, half: CommandHalf, error: &str) -> String {
 
 /// Replace this install with the latest release and relaunch into it,
 /// carrying across a `kendex` command that is kendex's to replace. One
-/// another installer owns stays where it is, named on the card by
-<<<<<<< HEAD
-/// `app_update_command_channel` before this ever runs. The manifest names a
-/// download and the signature over it; the release's own digests document
-/// names which download this release published for this target, and the
-/// app's bytes are held to both before anything is installed. The discovery
-/// feed never supplies an install URL, and the command's own bytes are held
-/// to the same key the CLI holds them to. A failure leaves the running app
-/// untouched and usable.
-=======
-/// `app_update_command_channel` before this ever runs — and `shown` is
-/// what that card said, so a command that changed since is refused rather
-/// than acted on in silence. The separately signed
-/// updater manifest is the delivery path for the app and verifies itself;
-/// the command's own bytes are held to the same key the CLI holds them to.
-/// A failure leaves the running app untouched and usable.
->>>>>>> af37782ce (fix(KEN-444): a command that changed under the card is not acted on)
+/// another installer owns stays where it is, named on the card before this
+/// runs; `shown` is what that card said, so a command that changed since is
+/// refused rather than acted on in silence. The manifest names a download
+/// and the signature over it, the release's own digests document names what
+/// this release published for this target, and the app's bytes are held to
+/// both. The discovery feed never supplies an install URL, and the command's
+/// bytes are held to the key the CLI holds them to. A failure leaves the
+/// running app untouched and usable.
 ///
 /// The command moves first. What this flow's notice card reads is the
 /// app's own baked version, so the app is the state marker here and is
@@ -375,23 +366,15 @@ pub async fn app_update_install(
         .await
         .map_err(|error| error.to_string())?
         .ok_or_else(|| "this build is already the latest release".to_owned())?;
-<<<<<<< HEAD
-    let half = move_the_command(install, update.version.clone()).await?;
+    let half = move_the_command(install, update.version.clone(), shown).await?;
     // Downloaded, then judged, then installed: the plugin's own check runs
-    // on the way down, and what this release published for this target is
-    // what says those bytes are the ones the version being installed
-    // names. The read is blocking, so it runs off the async runtime.
-    //
-    // Every failure from here reports the command half too. It has already
-    // moved by now, so a bare app error would leave a person reading that
-    // the app did not update while their terminal answers the new version.
+    // on the way down, and what this release published for this target says
+    // those bytes are the version being installed. The read is blocking, so
+    // it runs off the async runtime. Every failure from here names the
+    // command half too — it has moved by now, and a bare app error would
+    // report no update while the terminal answers the new version.
     let bytes = update
         .download(|_chunk, _total| {}, || {})
-=======
-    let half = move_the_command(install, update.version.clone(), shown).await?;
-    update
-        .download_and_install(|_chunk, _total| {}, || {})
->>>>>>> af37782ce (fix(KEN-444): a command that changed under the card is not acted on)
         .await
         .map_err(|error| app_half_failed(&update.version, half, &error.to_string()))?;
     let offered = update.version.clone();

--- a/crates/app/src/app_update.rs
+++ b/crates/app/src/app_update.rs
@@ -2,8 +2,8 @@ use std::path::{Path, PathBuf};
 
 use kendex_core::app_update::AppUpdateView;
 use kendex_core::command_update::{
-    CommandBeside, CommandHalf, bring_command_across, command_beside_app, command_candidates,
-    recorded_command,
+    CommandBeside, CommandHalf, CommandNotice, bring_command_across, command_beside_app,
+    command_candidates, recorded_command,
 };
 use kendex_core::env::Env;
 use kendex_core::install_channel::{AppInstall, Host, InstallChannel};
@@ -100,8 +100,10 @@ pub fn app_update_channel() -> Result<InstallChannel, String> {
 }
 
 /// What the card has to say about the `kendex` command beside this app:
-/// the channel that owns it where kendex must not replace it, and nothing
-/// where there is none or where Update now will carry it across.
+/// the channel that owns it where another installer does, the one command
+/// that moves it where it is kendex's own but sits where this app cannot
+/// write, and nothing where there is none or where Update now carries it
+/// across itself.
 ///
 /// Without this the app replaces itself, restarts, and clears its card
 /// while the terminal command stays on the old release with nothing on
@@ -109,13 +111,10 @@ pub fn app_update_channel() -> Result<InstallChannel, String> {
 /// about, arrived at from the other side.
 #[tauri::command(async)]
 #[specta::specta]
-pub fn app_update_command_channel() -> Result<Option<InstallChannel>, String> {
+pub fn app_update_command_channel() -> Result<Option<CommandNotice>, String> {
     let env = Env::detect().map_err(|error| error.to_string())?;
     let beside = command_beside(&env, &app_install()?, std::env::var_os("PATH").as_deref());
-    Ok(match beside {
-        CommandBeside::NotOurs(channel) => Some(channel),
-        CommandBeside::Ours(_) | CommandBeside::Absent => None,
-    })
+    Ok(CommandNotice::for_card(&beside))
 }
 
 /// Somewhere to put the path kendex approved, on whatever will perform the
@@ -237,7 +236,7 @@ fn command_beside(
         &Host,
         &command_candidates(&env.home, path_var),
         &not_the_command(install, std::env::current_exe().ok()),
-        recorded_command(env).as_deref(),
+        recorded_command(env).as_ref(),
     )
 }
 
@@ -262,6 +261,7 @@ async fn move_the_command(install: AppInstall, release: String) -> Result<Comman
     tauri::async_runtime::spawn_blocking(move || {
         let env = Env::detect().map_err(|error| error.to_string())?;
         bring_command_across(
+            &env,
             &command_beside(&env, &install, std::env::var_os("PATH").as_deref()),
             &feed,
             &release,

--- a/crates/app/src/app_update.rs
+++ b/crates/app/src/app_update.rs
@@ -1,4 +1,7 @@
 use kendex_core::app_update::AppUpdateView;
+use kendex_core::command_update::{
+    CommandBeside, CommandHalf, bring_command_across, command_beside_app, command_candidates,
+};
 use kendex_core::env::Env;
 use kendex_core::install_channel::{AppInstall, Host, InstallChannel};
 use kendex_core::registry::{Fetch, ReleaseFeedFetch};
@@ -198,12 +201,70 @@ fn read_published(
         .map_err(|error| error.to_string())
 }
 
-/// Replace this install with the latest release and relaunch into it. The
-/// manifest names a download and the signature over it; the release's own
-/// digests document names which download this release published for this
-/// target, and the bytes are held to both before anything is installed.
-/// The discovery feed never supplies an install URL. A failure leaves the
-/// running app untouched and usable.
+/// The `kendex` command this app would carry across with it, if there is
+/// one. `install.sh` puts the two side by side, so an app that moved alone
+/// would leave every terminal on the old release; a dmg or msi that
+/// installed no command has nothing to carry, which is an answer rather
+/// than a failure.
+fn command_beside(
+    env: &Env,
+    install: &AppInstall,
+    path_var: Option<&std::ffi::OsStr>,
+) -> CommandBeside {
+    command_beside_app(
+        &Host,
+        &command_candidates(&env.home, path_var),
+        install.judged_path(),
+    )
+}
+
+/// Run the command half off the async runtime: it downloads a release
+/// binary over the network, which is not work to hold a runtime worker on.
+async fn move_the_command(install: AppInstall, release: String) -> Result<CommandHalf, String> {
+    let feed = feed_url();
+    tauri::async_runtime::spawn_blocking(move || {
+        let env = Env::detect().map_err(|error| error.to_string())?;
+        bring_command_across(
+            &command_beside(&env, &install, std::env::var_os("PATH").as_deref()),
+            &feed,
+            &release,
+            env!("KENDEX_TARGET"),
+            UPDATER_PUBLIC_KEY,
+        )
+    })
+    .await
+    .map_err(|error| format!("the kendex command half did not run: {error}"))?
+}
+
+/// What to say when the app half would not land. A command already across
+/// leaves the machine split, but the app's own version is unchanged, so
+/// the card still offers the release and pressing it again repeats both
+/// halves rather than stopping at already-current.
+fn app_half_failed(release: &str, half: CommandHalf, error: &str) -> String {
+    match half {
+        CommandHalf::Moved => format!(
+            "the kendex command is on {release} and the desktop app is not: {error}; press Update now again to bring the app across"
+        ),
+        CommandHalf::Untouched => format!("the desktop app could not be replaced: {error}"),
+    }
+}
+
+/// Replace this install with the latest release and relaunch into it,
+/// carrying the `kendex` command across with it. The manifest names a
+/// download and the signature over it; the release's own digests document
+/// names which download this release published for this target, and the
+/// app's bytes are held to both before anything is installed. The
+/// discovery feed never supplies an install URL, and the command's own
+/// bytes are held to the same key the CLI holds them to. A failure leaves
+/// the running app untouched and usable.
+///
+/// The command moves first. What this flow's notice card reads is the
+/// app's own baked version, so the app is the state marker here and is
+/// written last — the mirror of `kendex update`, where the command's baked
+/// version is the marker and the command is written last. A command that
+/// will not move therefore leaves both halves where they were and the card
+/// still offering the release, where an app already replaced and relaunched
+/// would report itself current and never come back for the command.
 #[tauri::command]
 #[specta::specta]
 pub async fn app_update_install(app: tauri::AppHandle) -> Result<(), String> {
@@ -223,19 +284,27 @@ pub async fn app_update_install(app: tauri::AppHandle) -> Result<(), String> {
         .await
         .map_err(|error| error.to_string())?
         .ok_or_else(|| "this build is already the latest release".to_owned())?;
+    let half = move_the_command(install, update.version.clone()).await?;
     // Downloaded, then judged, then installed: the plugin's own check runs
     // on the way down, and what this release published for this target is
     // what says those bytes are the ones the version being installed
     // names. The read is blocking, so it runs off the async runtime.
+    //
+    // Every failure from here reports the command half too. It has already
+    // moved by now, so a bare app error would leave a person reading that
+    // the app did not update while their terminal answers the new version.
     let bytes = update
         .download(|_chunk, _total| {}, || {})
         .await
-        .map_err(|error| error.to_string())?;
+        .map_err(|error| app_half_failed(&update.version, half, &error.to_string()))?;
     let offered = update.version.clone();
-    let digests = tauri::async_runtime::spawn_blocking(move || published_for_this_target(&offered))
+    let read = tauri::async_runtime::spawn_blocking(move || published_for_this_target(&offered))
         .await
-        .map_err(|error| format!("kendex could not read what this release published: {error}"))??;
-    install_published(&digests, bytes, &update)?;
+        .map_err(|error| format!("kendex could not read what this release published: {error}"))
+        .and_then(|published| published);
+    let digests = read.map_err(|error| app_half_failed(&update.version, half, &error))?;
+    install_published(&digests, bytes, &update)
+        .map_err(|error| app_half_failed(&update.version, half, &error))?;
     app.restart()
 }
 

--- a/crates/app/src/app_update.rs
+++ b/crates/app/src/app_update.rs
@@ -256,13 +256,25 @@ fn not_the_command(install: &AppInstall, running: Option<PathBuf>) -> Vec<PathBu
 
 /// Run the command half off the async runtime: it downloads a release
 /// binary over the network, which is not work to hold a runtime worker on.
-async fn move_the_command(install: AppInstall, release: String) -> Result<CommandHalf, String> {
+///
+/// `shown` is what the card said about this command when it was drawn, and
+/// the lookup runs again here, so the two can disagree: a card is on screen
+/// for as long as a person leaves it there, and what is at a path in that
+/// time is not this app's to control. Disagreeing, nothing is written —
+/// see [`still_as_shown`].
+async fn move_the_command(
+    install: AppInstall,
+    release: String,
+    shown: Option<CommandNotice>,
+) -> Result<CommandHalf, String> {
     let feed = feed_url();
     tauri::async_runtime::spawn_blocking(move || {
         let env = Env::detect().map_err(|error| error.to_string())?;
+        let beside = command_beside(&env, &install, std::env::var_os("PATH").as_deref());
+        still_as_shown(&beside, shown.as_ref())?;
         bring_command_across(
             &env,
-            &command_beside(&env, &install, std::env::var_os("PATH").as_deref()),
+            &beside,
             &feed,
             &release,
             env!("KENDEX_TARGET"),
@@ -271,6 +283,34 @@ async fn move_the_command(install: AppInstall, release: String) -> Result<Comman
     })
     .await
     .map_err(|error| format!("the kendex command half did not run: {error}"))?
+}
+
+/// Whether the command beside the app is still the one the card described.
+///
+/// The card is the whole of what a person is told about that command,
+/// because Update now restarts the app and takes the card with it. A
+/// disposition that changed while the card sat on screen is therefore a
+/// sentence that was never said: an app that went ahead anyway would
+/// replace itself, restart, and leave behind a command nothing had warned
+/// about — the silent split this flow exists to prevent, reached by
+/// another road.
+///
+/// Compared as what was *said*, not as what was found. Two `Ours` at
+/// different paths say the same nothing to a person and are the same
+/// answer here; `Ours` become `NotOurs` says something new, and so does
+/// the reverse, which would touch a file the card promised to leave alone.
+///
+/// Refused before the app half runs, so nothing is written and the card is
+/// still on screen to carry the refusal.
+fn still_as_shown(beside: &CommandBeside, shown: Option<&CommandNotice>) -> Result<(), String> {
+    if CommandNotice::for_card(beside).as_ref() == shown {
+        return Ok(());
+    }
+    Err(
+        "the kendex command beside this app is no longer the one the notice \
+         described, so nothing was updated; the notice now says what is there"
+            .to_owned(),
+    )
 }
 
 /// What to say when the app half would not land. A command already across
@@ -289,6 +329,7 @@ fn app_half_failed(release: &str, half: CommandHalf, error: &str) -> String {
 /// Replace this install with the latest release and relaunch into it,
 /// carrying across a `kendex` command that is kendex's to replace. One
 /// another installer owns stays where it is, named on the card by
+<<<<<<< HEAD
 /// `app_update_command_channel` before this ever runs. The manifest names a
 /// download and the signature over it; the release's own digests document
 /// names which download this release published for this target, and the
@@ -296,6 +337,14 @@ fn app_half_failed(release: &str, half: CommandHalf, error: &str) -> String {
 /// feed never supplies an install URL, and the command's own bytes are held
 /// to the same key the CLI holds them to. A failure leaves the running app
 /// untouched and usable.
+=======
+/// `app_update_command_channel` before this ever runs — and `shown` is
+/// what that card said, so a command that changed since is refused rather
+/// than acted on in silence. The separately signed
+/// updater manifest is the delivery path for the app and verifies itself;
+/// the command's own bytes are held to the same key the CLI holds them to.
+/// A failure leaves the running app untouched and usable.
+>>>>>>> af37782ce (fix(KEN-444): a command that changed under the card is not acted on)
 ///
 /// The command moves first. What this flow's notice card reads is the
 /// app's own baked version, so the app is the state marker here and is
@@ -306,7 +355,10 @@ fn app_half_failed(release: &str, half: CommandHalf, error: &str) -> String {
 /// would report itself current and never come back for the command.
 #[tauri::command]
 #[specta::specta]
-pub async fn app_update_install(app: tauri::AppHandle) -> Result<(), String> {
+pub async fn app_update_install(
+    app: tauri::AppHandle,
+    shown: Option<CommandNotice>,
+) -> Result<(), String> {
     // The notice offers this on no other channel; the command asks anyway,
     // so nothing a caller gets wrong can overwrite a package manager's files.
     let install = app_install()?;
@@ -323,6 +375,7 @@ pub async fn app_update_install(app: tauri::AppHandle) -> Result<(), String> {
         .await
         .map_err(|error| error.to_string())?
         .ok_or_else(|| "this build is already the latest release".to_owned())?;
+<<<<<<< HEAD
     let half = move_the_command(install, update.version.clone()).await?;
     // Downloaded, then judged, then installed: the plugin's own check runs
     // on the way down, and what this release published for this target is
@@ -334,6 +387,11 @@ pub async fn app_update_install(app: tauri::AppHandle) -> Result<(), String> {
     // the app did not update while their terminal answers the new version.
     let bytes = update
         .download(|_chunk, _total| {}, || {})
+=======
+    let half = move_the_command(install, update.version.clone(), shown).await?;
+    update
+        .download_and_install(|_chunk, _total| {}, || {})
+>>>>>>> af37782ce (fix(KEN-444): a command that changed under the card is not acted on)
         .await
         .map_err(|error| app_half_failed(&update.version, half, &error.to_string()))?;
     let offered = update.version.clone();

--- a/crates/app/src/app_update.rs
+++ b/crates/app/src/app_update.rs
@@ -3,6 +3,7 @@ use std::path::{Path, PathBuf};
 use kendex_core::app_update::AppUpdateView;
 use kendex_core::command_update::{
     CommandBeside, CommandHalf, bring_command_across, command_beside_app, command_candidates,
+    recorded_command,
 };
 use kendex_core::env::Env;
 use kendex_core::install_channel::{AppInstall, Host, InstallChannel};
@@ -236,6 +237,7 @@ fn command_beside(
         &Host,
         &command_candidates(&env.home, path_var),
         &not_the_command(install, std::env::current_exe().ok()),
+        recorded_command(env).as_deref(),
     )
 }
 

--- a/crates/app/src/app_update.rs
+++ b/crates/app/src/app_update.rs
@@ -1,3 +1,5 @@
+use std::path::{Path, PathBuf};
+
 use kendex_core::app_update::AppUpdateView;
 use kendex_core::command_update::{
     CommandBeside, CommandHalf, bring_command_across, command_beside_app, command_candidates,
@@ -214,8 +216,22 @@ fn command_beside(
     command_beside_app(
         &Host,
         &command_candidates(&env.home, path_var),
-        install.judged_path(),
+        &not_the_command(install, std::env::current_exe().ok()),
     )
+}
+
+/// What this process is, and what it is about to replace. Neither is ever
+/// the command it carries across, and neither stands in for the other: an
+/// AppImage's executable lives inside a mount that is not the image the
+/// updater judged, and the Windows installer judges no path at all while
+/// the desktop executable is `kendex.exe`, the name the command carries
+/// too. Excluded only by the updater's path, a Windows install whose
+/// directory is on `PATH` would take its own executable for the command.
+fn not_the_command(install: &AppInstall, running: Option<PathBuf>) -> Vec<PathBuf> {
+    running
+        .into_iter()
+        .chain(install.judged_path().map(Path::to_owned))
+        .collect()
 }
 
 /// Run the command half off the async runtime: it downloads a release

--- a/crates/app/src/app_update.rs
+++ b/crates/app/src/app_update.rs
@@ -98,6 +98,25 @@ pub fn app_update_channel() -> Result<InstallChannel, String> {
     ))
 }
 
+/// What the card has to say about the `kendex` command beside this app:
+/// the channel that owns it where kendex must not replace it, and nothing
+/// where there is none or where Update now will carry it across.
+///
+/// Without this the app replaces itself, restarts, and clears its card
+/// while the terminal command stays on the old release with nothing on
+/// screen having said so — the silent divergence this issue was written
+/// about, arrived at from the other side.
+#[tauri::command(async)]
+#[specta::specta]
+pub fn app_update_command_channel() -> Result<Option<InstallChannel>, String> {
+    let env = Env::detect().map_err(|error| error.to_string())?;
+    let beside = command_beside(&env, &app_install()?, std::env::var_os("PATH").as_deref());
+    Ok(match beside {
+        CommandBeside::NotOurs(channel) => Some(channel),
+        CommandBeside::Ours(_) | CommandBeside::Absent => None,
+    })
+}
+
 /// Somewhere to put the path kendex approved, on whatever will perform the
 /// replacement. The plugin keeps what it was handed private, so this side
 /// of the handoff is the only side a test can watch.
@@ -266,13 +285,15 @@ fn app_half_failed(release: &str, half: CommandHalf, error: &str) -> String {
 }
 
 /// Replace this install with the latest release and relaunch into it,
-/// carrying the `kendex` command across with it. The manifest names a
+/// carrying across a `kendex` command that is kendex's to replace. One
+/// another installer owns stays where it is, named on the card by
+/// `app_update_command_channel` before this ever runs. The manifest names a
 /// download and the signature over it; the release's own digests document
 /// names which download this release published for this target, and the
-/// app's bytes are held to both before anything is installed. The
-/// discovery feed never supplies an install URL, and the command's own
-/// bytes are held to the same key the CLI holds them to. A failure leaves
-/// the running app untouched and usable.
+/// app's bytes are held to both before anything is installed. The discovery
+/// feed never supplies an install URL, and the command's own bytes are held
+/// to the same key the CLI holds them to. A failure leaves the running app
+/// untouched and usable.
 ///
 /// The command moves first. What this flow's notice card reads is the
 /// app's own baked version, so the app is the state marker here and is

--- a/crates/app/src/app_update/tests.rs
+++ b/crates/app/src/app_update/tests.rs
@@ -189,6 +189,12 @@ fn the_approved_path_reaches_whatever_will_replace_it() {
 struct OnlyWritable(&'static str);
 
 impl kendex_core::install_channel::HostProbe for OnlyWritable {
+    /// Nothing routed through this fake asks; `for_app` and `for_cli`
+    /// judge a path they were handed rather than looking one up.
+    fn is_command(&self, path: &Path) -> bool {
+        self.exists(path)
+    }
+
     fn replaceable(&self, path: &std::path::Path) -> bool {
         path == std::path::Path::new(self.0)
     }
@@ -266,10 +272,9 @@ fn a_failed_app_half_says_whether_the_command_went_ahead_of_it() {
 }
 
 /// The command this app would carry across is looked for beside the app,
-/// never inside it: an image the app is about to replace is not a command,
-/// however it is reached. Read as a difference rather than an absolute,
-/// because the candidate list ends with a system path this machine may
-/// well have a kendex in.
+/// never inside it. Read as a difference rather than an absolute, because
+/// the candidate list ends with a system path this machine may well have a
+/// kendex in.
 #[test]
 fn the_app_s_own_image_is_never_the_command_it_carries() {
     let dir = tempfile::tempdir().unwrap();
@@ -277,6 +282,11 @@ fn the_app_s_own_image_is_never_the_command_it_carries() {
     std::fs::create_dir_all(&bin).unwrap();
     let image = bin.join("kendex");
     std::fs::write(&image, b"the running AppImage").unwrap();
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        std::fs::set_permissions(&image, std::fs::Permissions::from_mode(0o755)).unwrap();
+    }
     let env = Env::host_rooted(dir.path());
     let path_var = std::ffi::OsString::from(&bin);
     let ours = CommandBeside::Ours(Host.resolve(&image));
@@ -290,10 +300,40 @@ fn the_app_s_own_image_is_never_the_command_it_carries() {
         ours
     );
 
-    // The same file, with nothing claiming it as the app: the exclusion
-    // above is what answered, and not a search that never reached it.
+    // The same file with nothing claiming it: the exclusion above is what
+    // answered, and not a search that never reached it. `AppImage(None)`
+    // rather than `WindowsInstaller`, because on Windows this process's own
+    // executable is excluded too and a test binary is not the app.
     assert_eq!(
-        command_beside(&env, &AppInstall::WindowsInstaller, Some(&path_var)),
+        command_beside(&env, &AppInstall::AppImage(None), Some(&path_var)),
         ours
+    );
+}
+
+/// The two paths a family update must never write over, and why naming one
+/// is not enough. An AppImage's executable lives inside a mount that is not
+/// the image the updater judged, so the judged path is needed; the Windows
+/// installer judges no path at all while the desktop executable carries the
+/// command's own name, so the running executable is needed. Excluded by the
+/// judged path alone, a Windows install on `PATH` would replace itself with
+/// the CLI binary.
+#[test]
+fn the_running_executable_is_excluded_where_the_updater_names_no_path() {
+    let exe = PathBuf::from("C:/Program Files/kendex/kendex.exe");
+    assert_eq!(
+        not_the_command(&AppInstall::WindowsInstaller, Some(exe.clone())),
+        vec![exe.clone()],
+        "the updater judges no path on Windows, so nothing else excludes the app"
+    );
+
+    let image = PathBuf::from("/home/pat/Apps/kendex.AppImage");
+    let inside = PathBuf::from("/tmp/.mount_kendex/usr/bin/kendex-app");
+    assert_eq!(
+        not_the_command(
+            &AppInstall::AppImage(Some(image.clone())),
+            Some(inside.clone())
+        ),
+        vec![inside, image],
+        "neither the mounted executable nor the image it came from is the command"
     );
 }

--- a/crates/app/src/app_update/tests.rs
+++ b/crates/app/src/app_update/tests.rs
@@ -1,3 +1,5 @@
+use kendex_core::install_channel::HostProbe as _;
+
 use super::*;
 
 #[test]
@@ -245,4 +247,53 @@ fn the_plugin_derives_the_unit_for_app_approved() {
     // Where the derivation runs for real it lands on the bundle exactly.
     #[cfg(target_os = "macos")]
     assert_eq!(derived, std::path::Path::new(bundle));
+}
+
+/// The two sentences a failed app half gets, and the difference between
+/// them. A command already across has to be named — the machine is split,
+/// and the card is the only place that can say so — while a command that
+/// never moved leaves nothing to report but the app's own failure.
+#[test]
+fn a_failed_app_half_says_whether_the_command_went_ahead_of_it() {
+    let split = app_half_failed("5.1.0", CommandHalf::Moved, "permission denied");
+    assert!(split.contains("the kendex command is on 5.1.0"), "{split}");
+    assert!(split.contains("permission denied"), "{split}");
+    assert!(split.contains("press Update now again"), "{split}");
+
+    let neither = app_half_failed("5.1.0", CommandHalf::Untouched, "permission denied");
+    assert!(!neither.contains("kendex command"), "{neither}");
+    assert!(neither.contains("permission denied"), "{neither}");
+}
+
+/// The command this app would carry across is looked for beside the app,
+/// never inside it: an image the app is about to replace is not a command,
+/// however it is reached. Read as a difference rather than an absolute,
+/// because the candidate list ends with a system path this machine may
+/// well have a kendex in.
+#[test]
+fn the_app_s_own_image_is_never_the_command_it_carries() {
+    let dir = tempfile::tempdir().unwrap();
+    let bin = dir.path().join("bin");
+    std::fs::create_dir_all(&bin).unwrap();
+    let image = bin.join("kendex");
+    std::fs::write(&image, b"the running AppImage").unwrap();
+    let env = Env::host_rooted(dir.path());
+    let path_var = std::ffi::OsString::from(&bin);
+    let ours = CommandBeside::Ours(Host.resolve(&image));
+
+    assert_ne!(
+        command_beside(
+            &env,
+            &AppInstall::AppImage(Some(image.clone())),
+            Some(&path_var)
+        ),
+        ours
+    );
+
+    // The same file, with nothing claiming it as the app: the exclusion
+    // above is what answered, and not a search that never reached it.
+    assert_eq!(
+        command_beside(&env, &AppInstall::WindowsInstaller, Some(&path_var)),
+        ours
+    );
 }

--- a/crates/app/src/app_update/tests.rs
+++ b/crates/app/src/app_update/tests.rs
@@ -207,6 +207,12 @@ impl kendex_core::install_channel::HostProbe for OnlyWritable {
         path.to_owned()
     }
 
+    /// Nothing routed through this fake asks either: `for_app` judges a
+    /// path, never the bytes at it.
+    fn digest(&self, _: &std::path::Path) -> Option<String> {
+        None
+    }
+
     fn on_path(&self, _: &str) -> bool {
         false
     }
@@ -306,7 +312,7 @@ fn the_app_s_own_image_is_never_the_command_it_carries() {
     // `AppImage(None)` rather than `WindowsInstaller`, because on Windows
     // this process's own executable is excluded too and a test binary is
     // not the app.
-    kendex_core::command_update::record_command(&env, &image).unwrap();
+    kendex_core::command_update::record_installed(&env, &image).unwrap();
     assert_eq!(
         command_beside(&env, &AppInstall::AppImage(None), Some(&path_var)),
         ours

--- a/crates/app/src/app_update/tests.rs
+++ b/crates/app/src/app_update/tests.rs
@@ -300,10 +300,13 @@ fn the_app_s_own_image_is_never_the_command_it_carries() {
         ours
     );
 
-    // The same file with nothing claiming it: the exclusion above is what
-    // answered, and not a search that never reached it. `AppImage(None)`
-    // rather than `WindowsInstaller`, because on Windows this process's own
-    // executable is excluded too and a test binary is not the app.
+    // The same file with nothing claiming it as the app, and an installer's
+    // record behind it: the exclusion above is what answered, and not a
+    // search that never reached it or a command nothing vouched for.
+    // `AppImage(None)` rather than `WindowsInstaller`, because on Windows
+    // this process's own executable is excluded too and a test binary is
+    // not the app.
+    kendex_core::command_update::record_command(&env, &image).unwrap();
     assert_eq!(
         command_beside(&env, &AppInstall::AppImage(None), Some(&path_var)),
         ours

--- a/crates/app/src/app_update/tests.rs
+++ b/crates/app/src/app_update/tests.rs
@@ -346,3 +346,86 @@ fn the_running_executable_is_excluded_where_the_updater_names_no_path() {
         "neither the mounted executable nor the image it came from is the command"
     );
 }
+
+/// One machine with a `kendex` command an installer recorded, and the
+/// notice the card would have drawn for it.
+#[allow(clippy::unwrap_used)]
+fn a_recorded_command(dir: &tempfile::TempDir) -> (Env, std::ffi::OsString, PathBuf) {
+    let bin = dir.path().join("bin");
+    std::fs::create_dir_all(&bin).unwrap();
+    let command = bin.join("kendex");
+    std::fs::write(&command, b"the kendex command an installer put here").unwrap();
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        std::fs::set_permissions(&command, std::fs::Permissions::from_mode(0o755)).unwrap();
+    }
+    let env = Env::host_rooted(dir.path());
+    kendex_core::command_update::record_installed(&env, &command).unwrap();
+    (env, std::ffi::OsString::from(&bin), command)
+}
+
+/// A card is on screen for as long as a person leaves it there, and what
+/// is at a path in that time is not this app's to control. The lookup runs
+/// again when Update now is pressed, so it can answer differently from the
+/// card — and going ahead on the new answer replaces the app, restarts it,
+/// and takes away the only surface that could have said the command was
+/// left behind. So the install is refused instead, before anything is
+/// written.
+///
+/// Driven through the real lookup rather than a described state: the file
+/// at the recorded path is replaced between the two reads, which is the
+/// finding's own scenario.
+#[test]
+#[allow(clippy::unwrap_used)]
+fn a_command_that_changed_under_the_card_refuses_the_install() {
+    let dir = tempfile::tempdir().unwrap();
+    let (env, path_var, command) = a_recorded_command(&dir);
+    let install = AppInstall::AppImage(None);
+    let drawn = command_beside(&env, &install, Some(&path_var));
+    let card = CommandNotice::for_card(&drawn);
+
+    // The control: unchanged, the install goes ahead exactly as before.
+    assert_eq!(card, None, "a recorded command is the app's to carry");
+    still_as_shown(&drawn, card.as_ref()).unwrap();
+
+    // Someone replaces the recorded binary with a wrapper of their own.
+    std::fs::write(&command, b"#!/bin/sh\nexec /opt/kendex/kendex \"$@\"\n").unwrap();
+    let now = command_beside(&env, &install, Some(&path_var));
+    assert_eq!(
+        CommandNotice::for_card(&now),
+        Some(CommandNotice::Unknown),
+        "the fixture only means something if the answer actually changed"
+    );
+
+    let refused = still_as_shown(&now, card.as_ref()).unwrap_err();
+    assert!(
+        refused.contains("no longer the one the notice"),
+        "{refused}"
+    );
+    assert!(refused.contains("nothing was updated"), "{refused}");
+}
+
+/// The other direction, and why it is refused too: the card said the app
+/// moves alone, and the command has since become one this app would
+/// replace. Going ahead would write over a file the person was told would
+/// be left where it is.
+#[test]
+#[allow(clippy::unwrap_used)]
+fn a_command_that_became_ours_under_the_card_refuses_too() {
+    let dir = tempfile::tempdir().unwrap();
+    let (env, path_var, command) = a_recorded_command(&dir);
+    let install = AppInstall::AppImage(None);
+    // Nothing recorded yet, as far as this card knows.
+    let card = Some(CommandNotice::Unknown);
+
+    let now = command_beside(&env, &install, Some(&path_var));
+
+    assert_eq!(
+        now,
+        CommandBeside::Ours(Host.resolve(&command)),
+        "the fixture only means something if the answer actually changed"
+    );
+    let refused = still_as_shown(&now, card.as_ref()).unwrap_err();
+    assert!(refused.contains("nothing was updated"), "{refused}");
+}

--- a/crates/app/src/lib.rs
+++ b/crates/app/src/lib.rs
@@ -45,6 +45,7 @@ pub fn specta_builder() -> Builder<tauri::Wry> {
         commands::app_version,
         app_update::app_update_check,
         app_update::app_update_channel,
+        app_update::app_update_command_channel,
         app_update::app_update_install,
         commands::scan_machine,
         app_settings::get_settings,

--- a/crates/app/src/native.rs
+++ b/crates/app/src/native.rs
@@ -6,6 +6,7 @@
 use std::path::{Path, PathBuf};
 use std::process::{Command, Stdio};
 
+use kendex_core::fs::is_executable;
 use tauri_plugin_dialog::DialogExt;
 
 /// Native folder picker. Blocking, so this must not run on the main thread
@@ -92,20 +93,6 @@ fn editor_candidates(editor_override: Option<&str>) -> Vec<&str> {
         .into_iter()
         .chain(EDITOR_CANDIDATES)
         .collect()
-}
-
-fn is_executable(path: &Path) -> bool {
-    #[cfg(unix)]
-    {
-        use std::os::unix::fs::PermissionsExt;
-        std::fs::metadata(path)
-            .map(|m| m.is_file() && m.permissions().mode() & 0o111 != 0)
-            .unwrap_or(false)
-    }
-    #[cfg(not(unix))]
-    {
-        path.is_file()
-    }
 }
 
 /// The file names a bare command may resolve to: the name itself, and on

--- a/crates/cli/src/commands/update.rs
+++ b/crates/cli/src/commands/update.rs
@@ -1,6 +1,6 @@
 use std::path::{Path, PathBuf};
 
-use kendex_core::command_update::{fetch, replace_executable};
+use kendex_core::command_update::{fetch, record_command, replace_executable};
 use kendex_core::env::Env;
 use kendex_core::install_channel::{Host, HostProbe, InstallChannel, for_cli};
 use kendex_core::names::shown;
@@ -91,6 +91,16 @@ fn run_on(
     // code of zero. What is left here is Direct, which passes, or Unknown,
     // whose refusal core words for both shells.
     channel.allow_replacement()?;
+    // The running command is at this path and is one of ours, which is the
+    // one thing no lookup by name can establish. Recorded before anything
+    // is fetched, so a machine that installed before this record existed
+    // gains it from any run — including one that finds nothing to do — and
+    // the desktop app can carry the command across from then on.
+    if let Err(why) = record_command(env, current_exe) {
+        say(&format!(
+            "the desktop app will not update this command until it can be recorded: {why}"
+        ));
+    }
     let feed_bytes = fetch(feed_url)?;
     let feed = ReleaseFeed::parse(&feed_bytes)?;
     let latest = feed.version.as_str();

--- a/crates/cli/src/commands/update.rs
+++ b/crates/cli/src/commands/update.rs
@@ -1,6 +1,10 @@
 use std::path::{Path, PathBuf};
 
+<<<<<<< HEAD
 use kendex_core::command_update::{fetch, record_command, replace_executable};
+=======
+use kendex_core::command_update::{download, record_command, record_installed};
+>>>>>>> c8d81d730 (fix(KEN-444): the record says which file, and where it can be written)
 use kendex_core::env::Env;
 use kendex_core::install_channel::{Host, HostProbe, InstallChannel, for_cli};
 use kendex_core::names::shown;
@@ -96,7 +100,7 @@ fn run_on(
     // is fetched, so a machine that installed before this record existed
     // gains it from any run — including one that finds nothing to do — and
     // the desktop app can carry the command across from then on.
-    if let Err(why) = record_command(env, current_exe) {
+    if let Err(why) = record_installed(env, current_exe) {
         say(&format!(
             "the desktop app will not update this command until it can be recorded: {why}"
         ));
@@ -158,6 +162,15 @@ fn run_on(
     });
     if let Err(error) = installed {
         return Err(command_failure(latest, app_replaced, &error).into());
+    }
+    // The record above named the bytes that were here; these are the bytes
+    // that replaced them. Left stale it stops matching, and the app then
+    // refuses a command it does own — the safe direction, and one the next
+    // run of this command undoes either way.
+    if let Err(why) = record_command(env, current_exe, &command.bytes) {
+        say(&format!(
+            "the desktop app will not update this command until it can be recorded: {why}"
+        ));
     }
     out(&format!("updated to {latest}"));
     Ok(())

--- a/crates/cli/src/commands/update.rs
+++ b/crates/cli/src/commands/update.rs
@@ -1,10 +1,9 @@
 use std::path::{Path, PathBuf};
-use std::time::Duration;
 
+use kendex_core::command_update::{fetch, replace_executable};
 use kendex_core::env::Env;
 use kendex_core::install_channel::{Host, HostProbe, InstallChannel, for_cli};
 use kendex_core::names::shown;
-use kendex_core::process::Hardened;
 use kendex_core::release_digests::{ReleaseDigests, release_digests_url};
 use kendex_core::update_channel::feed_url_for;
 use kendex_core::update_feed::{
@@ -45,37 +44,6 @@ fn selected_feed(override_url: Option<String>, debug_build: bool) -> String {
 /// `.github/workflows/release.yml`; `build.rs` bakes it in from Cargo.
 fn target_triple() -> &'static str {
     env!("KENDEX_TARGET")
-}
-
-fn fetch(url: &str) -> Result<Vec<u8>, String> {
-    // This fetches release binaries as well as the small feed, so it needs
-    // room for a slow download.
-    let output = Hardened::curl(&curl_args(url))
-        .timeout(Duration::from_secs(600))
-        .run()
-        .map_err(|e| format!("curl unavailable: {e}"))?;
-    if !output.status.success() {
-        return Err(format!(
-            "fetching {url} failed: {}",
-            String::from_utf8_lossy(&output.stderr).trim()
-        ));
-    }
-    Ok(output.stdout)
-}
-
-fn curl_args(url: &str) -> [&str; 10] {
-    [
-        "-fsS",
-        "--location",
-        "--max-redirs",
-        "3",
-        "--proto",
-        "=https,file",
-        "--proto-redir",
-        "=https",
-        "--",
-        url,
-    ]
 }
 
 pub fn run(env: &Env, force: bool) -> CliResult {
@@ -318,33 +286,6 @@ fn app_refused(latest: &str, why: &str) -> String {
     )
 }
 
-/// Write `bytes` over an executable that may be running: the replacement
-/// lands beside it whole and takes its place by rename, which every target
-/// OS allows on a running file.
-fn replace_executable(path: &Path, bytes: &[u8]) -> std::io::Result<()> {
-    let staged = staged_path(path);
-    match stage(&staged, bytes).and_then(|()| std::fs::rename(&staged, path)) {
-        Ok(()) => Ok(()),
-        Err(error) => {
-            // Nobody else writes a file named for this process, so a run
-            // that failed takes its own away instead of leaving one behind
-            // per process id.
-            let _ = std::fs::remove_file(&staged);
-            Err(error)
-        }
-    }
-}
-
-fn stage(staged: &Path, bytes: &[u8]) -> std::io::Result<()> {
-    std::fs::write(staged, bytes)?;
-    #[cfg(unix)]
-    {
-        use std::os::unix::fs::PermissionsExt;
-        std::fs::set_permissions(staged, std::fs::Permissions::from_mode(0o755))?;
-    }
-    Ok(())
-}
-
 fn missing_asset_message(
     relation: VersionRelation,
     latest: &str,
@@ -365,18 +306,6 @@ fn missing_asset_message(
             "release {latest} has no asset for {target}; installed {current} is newer; release notes: {notes}"
         ),
     })
-}
-
-/// The process id keeps two concurrent runs off one staged file. Without
-/// it they share a name, and what the rename installs is whatever the other
-/// run last wrote there rather than the bytes this one verified.
-fn staged_path(current: &std::path::Path) -> PathBuf {
-    let mut name = current
-        .file_name()
-        .map(|n| n.to_string_lossy().into_owned())
-        .unwrap_or_else(|| "kendex".to_owned());
-    name.push_str(&format!(".update.{}", std::process::id()));
-    current.with_file_name(name)
 }
 
 #[cfg(test)]

--- a/crates/cli/src/commands/update.rs
+++ b/crates/cli/src/commands/update.rs
@@ -80,8 +80,10 @@ fn run_on(
     public_key: &str,
     target: &str,
 ) -> CliResult {
-    if let InstallChannel::Managed { command } = channel {
-        out("a package manager owns this install; update it with:");
+    if let InstallChannel::Managed { manager, command } = channel {
+        out(&format!(
+            "this install came from {manager}; update it with:"
+        ));
         out(&format!("  {command}"));
         return Ok(());
     }

--- a/crates/cli/src/commands/update.rs
+++ b/crates/cli/src/commands/update.rs
@@ -1,10 +1,6 @@
 use std::path::{Path, PathBuf};
 
-<<<<<<< HEAD
-use kendex_core::command_update::{fetch, record_command, replace_executable};
-=======
-use kendex_core::command_update::{download, record_command, record_installed};
->>>>>>> c8d81d730 (fix(KEN-444): the record says which file, and where it can be written)
+use kendex_core::command_update::{fetch, record_command, record_installed, replace_executable};
 use kendex_core::env::Env;
 use kendex_core::install_channel::{Host, HostProbe, InstallChannel, for_cli};
 use kendex_core::names::shown;
@@ -167,7 +163,7 @@ fn run_on(
     // that replaced them. Left stale it stops matching, and the app then
     // refuses a command it does own — the safe direction, and one the next
     // run of this command undoes either way.
-    if let Err(why) = record_command(env, current_exe, &command.bytes) {
+    if let Err(why) = record_command(env, current_exe, &binary) {
         say(&format!(
             "the desktop app will not update this command until it can be recorded: {why}"
         ));

--- a/crates/cli/src/commands/update/tests.rs
+++ b/crates/cli/src/commands/update/tests.rs
@@ -4,28 +4,9 @@ use kendex_core::command_update::staged_path;
 
 use super::*;
 
-#[path = "../../../fixture_url.rs"]
+#[path = "../../../../fixture_url.rs"]
 mod fixture_url;
 use fixture_url::file_url;
-
-#[test]
-fn fetched_urls_are_always_positional_arguments() {
-    assert_eq!(
-        curl_args("--output=/tmp/owned"),
-        [
-            "-fsS",
-            "--location",
-            "--max-redirs",
-            "3",
-            "--proto",
-            "=https,file",
-            "--proto-redir",
-            "=https",
-            "--",
-            "--output=/tmp/owned",
-        ]
-    );
-}
 
 /// The one skew this order can still leave is an app already across
 /// and a command that would not move. It is not a dead end — the

--- a/crates/cli/src/commands/update/tests.rs
+++ b/crates/cli/src/commands/update/tests.rs
@@ -437,3 +437,49 @@ fn missing_asset_message_never_calls_current_or_older_available() {
     assert!(older.contains("is newer") && !older.contains("is available"));
     assert!(newer.contains("is available"));
 }
+
+/// The running command is at a path nothing else can vouch for: a lookup
+/// by name cannot tell this binary from a wrapper someone wrote, and this
+/// run is the one place that knows. So it records the path, on a run that
+/// updated and on one that found nothing to do, which is how an install
+/// made before the record existed gains one.
+#[test]
+fn an_update_records_the_command_it_is_running_as() {
+    for force in [true, false] {
+        let dir = tempfile::tempdir().unwrap();
+        let (env, feed_url, installed) = a_release_is_out(&dir);
+
+        run_on(
+            &env,
+            force,
+            &feed_url,
+            &installed,
+            &InstallChannel::Direct,
+            TEST_KEY,
+        )
+        .unwrap();
+
+        assert_eq!(
+            kendex_core::command_update::recorded_command(&env),
+            Some(installed.clone()),
+            "force: {force}"
+        );
+    }
+}
+
+/// A package manager's copy is not ours to record. The run says whose it
+/// is and stops before anything is written, and a record left here would
+/// tell the app to replace bytes the CLI just refused to touch.
+#[test]
+fn a_package_managed_run_records_nothing() {
+    let dir = tempfile::tempdir().unwrap();
+    let (env, feed_url, installed) = a_release_is_out(&dir);
+    let brew = InstallChannel::Managed {
+        manager: "Homebrew".to_owned(),
+        command: "brew upgrade kendex-cli".to_owned(),
+    };
+
+    run_on(&env, false, &feed_url, &installed, &brew, TEST_KEY).unwrap();
+
+    assert_eq!(kendex_core::command_update::recorded_command(&env), None);
+}

--- a/crates/cli/src/commands/update/tests.rs
+++ b/crates/cli/src/commands/update/tests.rs
@@ -1,3 +1,7 @@
+use std::path::PathBuf;
+
+use kendex_core::command_update::staged_path;
+
 use super::*;
 
 #[path = "../../../fixture_url.rs"]

--- a/crates/cli/src/commands/update/tests.rs
+++ b/crates/cli/src/commands/update/tests.rs
@@ -443,6 +443,12 @@ fn missing_asset_message_never_calls_current_or_older_available() {
 /// run is the one place that knows. So it records the path, on a run that
 /// updated and on one that found nothing to do, which is how an install
 /// made before the record existed gains one.
+///
+/// And it records what is at that path, not only the path: a name outlives
+/// whatever answered to it, so the digest is what tells this binary from
+/// the next file to arrive under its name. Which means the record has to
+/// follow the write — left naming the bytes this run replaced, it would
+/// refuse the app the command it just brought current.
 #[test]
 fn an_update_records_the_command_it_is_running_as() {
     for force in [true, false] {
@@ -460,11 +466,63 @@ fn an_update_records_the_command_it_is_running_as() {
         .unwrap();
 
         assert_eq!(
-            kendex_core::command_update::recorded_command(&env),
-            Some(installed.clone()),
+            std::fs::read(&installed).unwrap(),
+            OFFERED,
             "force: {force}"
         );
+        assert_eq!(
+            kendex_core::command_update::recorded_command(&env),
+            Some(kendex_core::command_update::InstalledCommand {
+                path: installed.clone(),
+                digest: kendex_core::hash::sha256_hex(OFFERED),
+            }),
+            "force: {force}"
+        );
+        assert_ne!(
+            kendex_core::hash::sha256_hex(OFFERED),
+            kendex_core::hash::sha256_hex(INSTALLED),
+            "the two digests have to differ or the assertion above proves nothing"
+        );
     }
+}
+
+/// A run that finds nothing to do still records, and records the bytes
+/// that are there — the path is what an install made before this record
+/// existed is missing, and the digest is what makes it usable.
+#[test]
+fn a_run_with_nothing_to_do_records_the_bytes_already_installed() {
+    let dir = tempfile::tempdir().unwrap();
+    let (env, _, installed) = a_release_is_out(&dir);
+    // A feed offering exactly what is running: nothing to fetch, nothing
+    // to write.
+    let feed = dir.path().join("current.json");
+    std::fs::write(
+        &feed,
+        format!(
+            r#"{{"schema": 1, "version": "{}", "assets": {{}}}}"#,
+            env!("CARGO_PKG_VERSION")
+        ),
+    )
+    .unwrap();
+
+    run_on(
+        &env,
+        false,
+        &file_url(&feed),
+        &installed,
+        &InstallChannel::Direct,
+        TEST_KEY,
+    )
+    .unwrap();
+
+    assert_eq!(std::fs::read(&installed).unwrap(), INSTALLED);
+    assert_eq!(
+        kendex_core::command_update::recorded_command(&env),
+        Some(kendex_core::command_update::InstalledCommand {
+            path: installed,
+            digest: kendex_core::hash::sha256_hex(INSTALLED),
+        })
+    );
 }
 
 /// A package manager's copy is not ours to record. The run says whose it

--- a/crates/cli/src/commands/update/tests.rs
+++ b/crates/cli/src/commands/update/tests.rs
@@ -462,6 +462,7 @@ fn an_update_records_the_command_it_is_running_as() {
             &installed,
             &InstallChannel::Direct,
             TEST_KEY,
+            TEST_TARGET,
         )
         .unwrap();
 
@@ -512,6 +513,7 @@ fn a_run_with_nothing_to_do_records_the_bytes_already_installed() {
         &installed,
         &InstallChannel::Direct,
         TEST_KEY,
+        TEST_TARGET,
     )
     .unwrap();
 
@@ -537,7 +539,16 @@ fn a_package_managed_run_records_nothing() {
         command: "brew upgrade kendex-cli".to_owned(),
     };
 
-    run_on(&env, false, &feed_url, &installed, &brew, TEST_KEY).unwrap();
+    run_on(
+        &env,
+        false,
+        &feed_url,
+        &installed,
+        &brew,
+        TEST_KEY,
+        TEST_TARGET,
+    )
+    .unwrap();
 
     assert_eq!(kendex_core::command_update::recorded_command(&env), None);
 }

--- a/crates/cli/src/commands/update/tests.rs
+++ b/crates/cli/src/commands/update/tests.rs
@@ -80,6 +80,7 @@ fn a_package_managed_command_is_left_for_its_package_manager() {
     let dir = tempfile::tempdir().unwrap();
     let (env, feed_url, installed) = a_release_is_out(&dir);
     let brew = InstallChannel::Managed {
+        manager: "Homebrew".to_owned(),
         command: "brew upgrade kendex-cli".to_owned(),
     };
 

--- a/crates/cli/tests/compat.rs
+++ b/crates/cli/tests/compat.rs
@@ -3,7 +3,7 @@
 //! init scaffolding.
 #![cfg(unix)]
 
-#[path = "../fixture_url.rs"]
+#[path = "../../fixture_url.rs"]
 mod fixture_url;
 use fixture_url::file_url;
 

--- a/crates/cli/tests/install_script.rs
+++ b/crates/cli/tests/install_script.rs
@@ -9,6 +9,10 @@ use std::os::unix::fs::PermissionsExt;
 use std::path::{Path, PathBuf};
 use std::process::Command;
 
+#[path = "../../test_util.rs"]
+mod test_util;
+use test_util::rooted;
+
 #[allow(clippy::unwrap_used)]
 fn write_exe(path: &Path, body: &str) {
     fs::write(path, body).unwrap();
@@ -31,7 +35,23 @@ fn requested_urls(os: &str, arch: &str) -> String {
 #[allow(clippy::unwrap_used)]
 fn run_install(os: &str, arch: &str, fail: Option<(&str, i32)>) -> (std::process::Output, String) {
     let tmp = tempfile::tempdir().unwrap();
-    let home = tmp.path();
+    run_install_in(os, arch, fail, tmp.path())
+}
+
+/// The same run against a home the caller keeps, for a test that reads what
+/// the script left behind rather than only what it fetched.
+#[allow(clippy::unwrap_used)]
+fn run_install_at(os: &str, arch: &str, home: &Path) -> (std::process::Output, String) {
+    run_install_in(os, arch, None, home)
+}
+
+#[allow(clippy::unwrap_used)]
+fn run_install_in(
+    os: &str,
+    arch: &str,
+    fail: Option<(&str, i32)>,
+    home: &Path,
+) -> (std::process::Output, String) {
     let fake = home.join("fake-bin");
     let bindir = home.join(".local/bin");
     fs::create_dir_all(&fake).unwrap();
@@ -267,5 +287,42 @@ fn where_a_real_install_puts_the_command_is_a_candidate() {
             .contains(&PathBuf::from(installed)),
         "install.sh installed {installed}, which no candidate under {} covers",
         home.display()
+    );
+}
+
+/// The desktop app carries the command across only when an installer said
+/// which file it is, so `install.sh` has to leave that record where the
+/// app's own resolver looks — and at the path it actually installed. A
+/// script that installs and records nothing leaves every app-driven update
+/// refusing a command it really does own.
+#[test]
+#[allow(clippy::unwrap_used)]
+fn install_sh_records_the_command_it_installed() {
+    let tmp = tempfile::tempdir().unwrap();
+    // The canonical root, and the same one handed to the script: install.sh
+    // writes under the HOME it was given, and a resolver asked about a
+    // different spelling of that directory reads an empty one.
+    let home = rooted(&tmp);
+    let (output, _) = run_install_at("Linux", "x86_64", &home);
+    assert!(
+        output.status.success(),
+        "install.sh failed:\n{}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let said = String::from_utf8_lossy(&output.stdout);
+    let installed = said
+        .lines()
+        .find_map(|line| line.strip_prefix("Installed the kendex command to "))
+        .unwrap_or_else(|| panic!("install.sh did not say where it installed:\n{said}"));
+
+    // Asked of the resolver rather than spelled a second time: the data
+    // directory differs by platform and a second spelling agrees until it
+    // does not.
+    let record = kendex_core::env::Env::host_rooted(&home).installed_command_file();
+    assert_eq!(
+        fs::read_to_string(&record).unwrap_or_default().trim(),
+        installed,
+        "install.sh recorded nothing usable at {}",
+        record.display()
     );
 }

--- a/crates/cli/tests/install_script.rs
+++ b/crates/cli/tests/install_script.rs
@@ -45,6 +45,20 @@ fn run_install_at(os: &str, arch: &str, home: &Path) -> (std::process::Output, S
     run_install_in(os, arch, None, home)
 }
 
+/// What `uname -s` answers on the machine running these tests.
+///
+/// A test that reads back what the script wrote has to drive the script as
+/// this host: `install.sh` picks its data directory from `uname`, `Env`
+/// picks the same one from the target it was built for, and told `Linux` on
+/// a mac the script writes under `.local/share` while the resolver reads
+/// `Library/Application Support`. One finds nothing there and reads it as a
+/// script that recorded nothing; the other finds nothing there and reads it
+/// as the record correctly withheld.
+const HOST_UNAME: &str = match cfg!(target_os = "macos") {
+    true => "Darwin",
+    false => "Linux",
+};
+
 #[allow(clippy::unwrap_used)]
 fn run_install_in(
     os: &str,
@@ -309,7 +323,7 @@ fn install_sh_records_the_command_it_installed() {
     // writes under the HOME it was given, and a resolver asked about a
     // different spelling of that directory reads an empty one.
     let home = rooted(&tmp);
-    let (output, _) = run_install_at("Linux", "x86_64", &home);
+    let (output, _) = run_install_at(HOST_UNAME, "x86_64", &home);
     assert!(
         output.status.success(),
         "install.sh failed:\n{}",
@@ -357,7 +371,7 @@ fn install_sh_records_nothing_it_cannot_take_a_digest_for() {
         write_exe(&fake.join(tool), "#!/bin/sh\nexit 1\n");
     }
 
-    let (output, _) = run_install_at("Linux", "x86_64", &home);
+    let (output, _) = run_install_at(HOST_UNAME, "x86_64", &home);
 
     assert!(
         output.status.success(),

--- a/crates/cli/tests/install_script.rs
+++ b/crates/cli/tests/install_script.rs
@@ -6,7 +6,7 @@
 
 use std::fs;
 use std::os::unix::fs::PermissionsExt;
-use std::path::Path;
+use std::path::{Path, PathBuf};
 use std::process::Command;
 
 #[allow(clippy::unwrap_used)]
@@ -175,4 +175,97 @@ fn a_network_failure_does_not_blame_the_release() {
     );
     assert!(!stderr.contains("may have no build"), "{stderr}");
     assert!(!stderr.contains("chmod"), "{stderr}");
+}
+
+/// Every directory `install.sh` can install the command into, read out of
+/// the script's own selection rather than restated here. A shape this
+/// cannot parse fails the same way a changed destination does, because a
+/// silent no-match would be the drift it exists to catch.
+#[allow(clippy::unwrap_used)]
+fn installer_bin_dirs(script: &str) -> Vec<String> {
+    let chosen_from = script
+        .lines()
+        .find_map(|line| {
+            line.trim()
+                .strip_prefix("for candidate in ")?
+                .strip_suffix("; do")
+        })
+        .expect("install.sh picks its bindir from a `for candidate in ...; do` list");
+    // The fallback when none of them is on PATH. Written as its own
+    // assignment, so it is read as its own line.
+    let fallback = script
+        .lines()
+        .find_map(|line| {
+            line.trim()
+                .strip_prefix(r#"[ -n "$bindir" ] || bindir=""#)?
+                .strip_suffix('"')
+        })
+        .expect("install.sh falls back to a bindir when none is on PATH");
+    let mut dirs: Vec<String> = chosen_from
+        .split_whitespace()
+        .chain(std::iter::once(fallback))
+        .map(|dir| dir.trim_matches('"').to_owned())
+        .collect();
+    dirs.dedup();
+    assert!(!dirs.is_empty(), "install.sh named no bindir");
+    dirs
+}
+
+/// The one fact `install.sh` and `kendex_core::command_update` both hold:
+/// where the command is installed. The app looks the command up to carry
+/// it across, and a launcher's `PATH` need not carry the installer's
+/// directory, so the fallback roots are what finds it there. If the
+/// installer moves its destination and this list does not follow, an
+/// app-driven update stops finding the command and moves the app alone.
+///
+/// Read against the script itself, so the divergence fails here rather
+/// than on a machine.
+#[test]
+#[allow(clippy::unwrap_used)]
+fn every_directory_the_installer_can_choose_is_a_candidate() {
+    let script = Path::new(env!("CARGO_MANIFEST_DIR")).join("../../install.sh");
+    let home = Path::new("/home/pat");
+    // No PATH, so what comes back is the fallback list and nothing else —
+    // the case this contract is about.
+    let candidates = kendex_core::command_update::command_candidates(home, None);
+
+    for dir in installer_bin_dirs(&fs::read_to_string(&script).unwrap()) {
+        let expanded = PathBuf::from(dir.replace("$HOME", &home.display().to_string()));
+        assert!(
+            candidates
+                .iter()
+                .any(|found| found.parent() == Some(&expanded)),
+            "install.sh can install into {}, which no candidate covers: {candidates:?}",
+            expanded.display()
+        );
+    }
+}
+
+/// The same contract from the other end, run rather than read: install.sh
+/// performs a real install and says where it put the command, and that
+/// directory is one the lookup would reach.
+#[test]
+#[allow(clippy::unwrap_used)]
+fn where_a_real_install_puts_the_command_is_a_candidate() {
+    let (output, _) = run_install("Linux", "x86_64", None);
+    let said = String::from_utf8_lossy(&output.stdout);
+    let installed = said
+        .lines()
+        .find_map(|line| line.strip_prefix("Installed the kendex command to "))
+        .unwrap_or_else(|| panic!("install.sh did not say where it installed:\n{said}"));
+    let home = PathBuf::from(installed)
+        .parent()
+        .unwrap()
+        .parent()
+        .unwrap()
+        .parent()
+        .unwrap()
+        .to_owned();
+
+    assert!(
+        kendex_core::command_update::command_candidates(&home, None)
+            .contains(&PathBuf::from(installed)),
+        "install.sh installed {installed}, which no candidate under {} covers",
+        home.display()
+    );
 }

--- a/crates/cli/tests/install_script.rs
+++ b/crates/cli/tests/install_script.rs
@@ -292,9 +292,15 @@ fn where_a_real_install_puts_the_command_is_a_candidate() {
 
 /// The desktop app carries the command across only when an installer said
 /// which file it is, so `install.sh` has to leave that record where the
-/// app's own resolver looks — and at the path it actually installed. A
-/// script that installs and records nothing leaves every app-driven update
-/// refusing a command it really does own.
+/// app's own resolver looks — at the path it actually installed, and with
+/// the digest of the bytes it put there. A script that installs and
+/// records nothing leaves every app-driven update refusing a command it
+/// really does own; one that records a path alone leaves the app judging
+/// by a name, which the next file to arrive under that name inherits.
+///
+/// Read back through the resolver rather than by hand: what shape the
+/// record takes is core's to say, and a second spelling here agrees until
+/// it does not.
 #[test]
 #[allow(clippy::unwrap_used)]
 fn install_sh_records_the_command_it_installed() {
@@ -318,11 +324,60 @@ fn install_sh_records_the_command_it_installed() {
     // Asked of the resolver rather than spelled a second time: the data
     // directory differs by platform and a second spelling agrees until it
     // does not.
-    let record = kendex_core::env::Env::host_rooted(&home).installed_command_file();
+    let env = kendex_core::env::Env::host_rooted(&home);
+    let recorded = kendex_core::command_update::recorded_command(&env).unwrap_or_else(|| {
+        panic!(
+            "install.sh recorded nothing this build can read at {}",
+            env.installed_command_file().display()
+        )
+    });
+    assert_eq!(recorded.path, PathBuf::from(installed));
     assert_eq!(
-        fs::read_to_string(&record).unwrap_or_default().trim(),
-        installed,
-        "install.sh recorded nothing usable at {}",
-        record.display()
+        recorded.digest,
+        kendex_core::hash::sha256_hex(&fs::read(installed).unwrap()),
+        "the record names bytes other than the ones install.sh left at {installed}"
+    );
+}
+
+/// No way to compute a digest is a record this build could not check, so
+/// the script writes none and says so. A path on its own is exactly the
+/// record this change exists to stop being enough: written anyway, it
+/// would put the app back to judging a command by its name.
+#[test]
+#[allow(clippy::unwrap_used)]
+fn install_sh_records_nothing_it_cannot_take_a_digest_for() {
+    let tmp = tempfile::tempdir().unwrap();
+    let home = rooted(&tmp);
+    // Every spelling of the digest, ahead of the real ones on `PATH` and
+    // failing. `command -v` finds each, so the script reaches one and gets
+    // nothing back rather than falling through to a tool that works.
+    let fake = home.join("fake-bin");
+    fs::create_dir_all(&fake).unwrap();
+    for tool in ["sha256sum", "shasum", "openssl"] {
+        write_exe(&fake.join(tool), "#!/bin/sh\nexit 1\n");
+    }
+
+    let (output, _) = run_install_at("Linux", "x86_64", &home);
+
+    assert!(
+        output.status.success(),
+        "a missing digest tool costs the record, never the install:\n{}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert!(
+        String::from_utf8_lossy(&output.stderr).contains("could not record the command's identity"),
+        "the run said nothing about the record it did not write:\n{}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let env = kendex_core::env::Env::host_rooted(&home);
+    assert_eq!(
+        kendex_core::command_update::recorded_command(&env),
+        None,
+        "a record with no digest is one the app would judge by name alone"
+    );
+    assert!(
+        !env.installed_command_file().exists(),
+        "nothing half-written at {}",
+        env.installed_command_file().display()
     );
 }

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -28,6 +28,9 @@ rustix.workspace = true
 [dev-dependencies]
 tempfile.workspace = true
 fd-lock.workspace = true
+# Fixtures serve the release feed off disk, and a `file://` URL for a host
+# path is a grammar, not a substitution. Already in the tree under tauri.
+url = "2"
 
 [lints]
 workspace = true

--- a/crates/core/src/command_update.rs
+++ b/crates/core/src/command_update.rs
@@ -32,9 +32,15 @@ use std::time::Duration;
 use semver::Version;
 
 use crate::env::Env;
-use crate::install_channel::{HostProbe, InstallChannel, for_cli};
+use crate::install_channel::{HostProbe, InstallChannel, package_owner};
 use crate::process::Hardened;
 use crate::update_feed::{ReleaseFeed, signature_url, verify_signature};
+
+mod notice;
+mod record;
+
+pub use notice::CommandNotice;
+pub use record::{InstalledCommand, record_command, record_installed, recorded_command};
 
 /// What `install.sh` installs the command as. Windows has no command
 /// beside the app — the installer carries the app alone — so the name
@@ -55,6 +61,14 @@ pub enum CommandBeside {
     /// moves while the command stays put is the divergence this whole
     /// path exists to prevent.
     NotOurs(InstallChannel),
+    /// A `kendex` command an installer recorded, in a directory this
+    /// process cannot write. `install.sh` reaches `/usr/local/bin` with
+    /// `sudo` whenever that is the first of its two directories on `PATH`,
+    /// and the desktop app runs unprivileged, so this is an ordinary
+    /// install rather than an exotic one. It is ours; what is missing is
+    /// the privilege, and saying "not ours" here would name no owner and
+    /// offer no way out of a state a single command fixes.
+    NeedsPrivilege(PathBuf),
     /// No `kendex` command beside the app — a dmg or msi install, where
     /// the app is the whole install. An answer, not a failure.
     Absent,
@@ -128,23 +142,34 @@ pub fn command_candidates(home: &Path, path_var: Option<&OsStr>) -> Vec<PathBuf>
 /// command carries. Written over, the command binary lands on the app and
 /// the app is then written back over it, leaving no command at all.
 ///
-/// `installed` is the command an installer recorded, and it is what makes
-/// a candidate ours. Everything else here is about the file's shape, and
+/// `installed` is what an installer recorded, and it is what makes a
+/// candidate ours. Everything else here is about the file's shape, and
 /// shape is not identity: a wrapper someone wrote that runs the real
 /// `kendex` is executable, is named `kendex`, and sits in a directory that
 /// takes a rename, so every other question answers yes and a release
 /// binary lands on their script. `kendex update` needs no record, because
 /// the path it judges is the one it is running from; this function found
 /// its path by name, and a name is a guess until something confirms it.
+///
+/// The record is read from both ends. It is searched as well as checked,
+/// so a command installed where neither `PATH` nor `install.sh` would put
+/// it — `~/.cargo/bin/kendex`, under an app a Finder launch hands the four
+/// system directories — is reachable at all; and it is a path *and* a
+/// digest, because a path is a name and names outlive the files that held
+/// them. Remove the recorded binary, drop a wrapper or a retargeted
+/// symlink at that path, and the path still compares equal.
 pub fn command_beside_app(
     probe: &dyn HostProbe,
     candidates: &[PathBuf],
     running: &[PathBuf],
-    installed: Option<&Path>,
+    installed: Option<&InstalledCommand>,
 ) -> CommandBeside {
     let running: Vec<PathBuf> = running.iter().map(|path| probe.resolve(path)).collect();
-    let installed = installed.map(|path| probe.resolve(path));
-    for candidate in candidates {
+    let record = installed.map(|record| (probe.resolve(&record.path), record.digest.as_str()));
+    // Last in the search, because everything ahead of it is what a shell
+    // resolves first, and that is the copy a person actually runs.
+    let searched = candidates.iter().chain(installed.map(|r| &r.path));
+    for candidate in searched {
         if !probe.is_command(candidate) {
             continue;
         }
@@ -152,44 +177,26 @@ pub fn command_beside_app(
         if running.contains(&resolved) {
             continue;
         }
-        return match for_cli(&resolved, probe) {
-            // Asked before the record, because a package manager's copy
-            // has an owner worth naming and the card can name it. Only
-            // the arm that would replace the file needs proof.
-            InstallChannel::Direct if installed.as_deref() == Some(resolved.as_path()) => {
-                CommandBeside::Ours(resolved)
-            }
-            // Replaceable, and nothing says it is ours. Refusing costs a
-            // person one command; being wrong costs them their file.
-            InstallChannel::Direct => CommandBeside::NotOurs(InstallChannel::Unknown),
-            owned => CommandBeside::NotOurs(owned),
+        // Asked before the record, because a package manager's copy has an
+        // owner worth naming and no record of ours changes whose bytes
+        // those are.
+        if let Some(owner) = package_owner(&resolved, probe) {
+            return CommandBeside::NotOurs(owner);
+        }
+        let ours = record.as_ref().is_some_and(|(path, digest)| {
+            *path == resolved && probe.digest(&resolved).as_deref() == Some(*digest)
+        });
+        if !ours {
+            // Nothing proves it ours. Refusing costs a person one command;
+            // being wrong costs them their file.
+            return CommandBeside::NotOurs(InstallChannel::Unknown);
+        }
+        return match probe.replaceable(&resolved) {
+            true => CommandBeside::Ours(resolved),
+            false => CommandBeside::NeedsPrivilege(resolved),
         };
     }
     CommandBeside::Absent
-}
-
-/// The `kendex` command an installer recorded, resolved as written.
-///
-/// Absent where nothing has been recorded — an install older than this
-/// record, or one made some other way — and absent for anything that is
-/// not one absolute path, because a record this build cannot read is not
-/// a record it should act on.
-pub fn recorded_command(env: &Env) -> Option<PathBuf> {
-    let recorded = std::fs::read_to_string(env.installed_command_file()).ok()?;
-    let path = PathBuf::from(recorded.trim());
-    path.is_absolute().then_some(path)
-}
-
-/// Record `path` as the `kendex` command this install owns, so the desktop
-/// app can carry it across. Written by whatever put the command there.
-pub fn record_command(env: &Env, path: &Path) -> Result<(), String> {
-    let file = env.installed_command_file();
-    if let Some(parent) = file.parent() {
-        std::fs::create_dir_all(parent)
-            .map_err(|error| format!("{} could not be created: {error}", parent.display()))?;
-    }
-    std::fs::write(&file, format!("{}\n", path.display()))
-        .map_err(|error| format!("{} could not be written: {error}", file.display()))
 }
 
 /// Bring the `kendex` command beside a desktop app to `release`, before
@@ -204,7 +211,12 @@ pub fn record_command(env: &Env, path: &Path) -> Result<(), String> {
 /// A release with no command for this target stops the run for the same
 /// reason. There is a command installed here — that is what `Ours` means —
 /// and a release that cannot move it can only leave it behind.
+///
+/// Every other `beside` leaves the command where it is, `NeedsPrivilege`
+/// included: the app cannot write that directory, and the card named it
+/// before Update now was pressed.
 pub fn bring_command_across(
+    env: &Env,
     beside: &CommandBeside,
     feed_url: &str,
     release: &str,
@@ -229,12 +241,23 @@ pub fn bring_command_across(
     // Named as the command half. Read off a card that has just been
     // pressed, a bare fetch or signature error says nothing about which of
     // the two halves it came from.
-    download(asset)
-        .and_then(|command| command.install_at(path, public_key))
-        .map_err(|why| {
-            format!("the kendex command could not be updated: {why}; nothing was updated")
-        })?;
+    let command = download(asset).map_err(command_half_failed)?;
+    command
+        .install_at(path, public_key)
+        .map_err(command_half_failed)?;
+    // The record now names bytes that are gone, so it is rewritten for the
+    // bytes that replaced them. A rewrite that fails costs the next
+    // app-driven update, never this one: the record stops matching, the
+    // app then refuses a command it does own rather than replacing one it
+    // does not, and any `kendex update` run restores it. That is why this
+    // is not an error — the command is across, and saying otherwise would
+    // send a person to press a button that has already done its work.
+    let _ = record_command(env, path, &command.bytes);
     Ok(CommandHalf::Moved)
+}
+
+fn command_half_failed(why: String) -> String {
+    format!("the kendex command could not be updated: {why}; nothing was updated")
 }
 
 /// One release under SemVer precedence, so build metadata cannot split a

--- a/crates/core/src/command_update.rs
+++ b/crates/core/src/command_update.rs
@@ -5,9 +5,18 @@
 //! command, and both write the half that is their own state marker last.
 //! For `kendex update` that is the command, whose baked version the next
 //! run reads to decide whether it is done; for the app it is the app,
-//! whose baked version the sidebar card reads. Either way a failure before
-//! the marker leaves both halves where they were, so the next attempt
-//! repeats them rather than stopping at already-current.
+//! whose baked version the sidebar card reads.
+//!
+//! Neither shell moves the two halves atomically, and neither claims to.
+//! A failure before the marker leaves both where they were. A failure
+//! while writing the marker leaves the pair split, one half across and
+//! one not, and every caller here reports that rather than hiding it —
+//! `app_half_failed` in the app, `command_failure` in the CLI.
+//!
+//! What the ordering buys is which half is left behind. The marker is the
+//! one still reading old, so the next attempt reads a release newer than
+//! itself and moves both halves again, instead of stopping at
+//! already-current with the other half stranded on the old version.
 
 use std::cmp::Ordering;
 use std::ffi::OsStr;
@@ -74,31 +83,41 @@ pub fn command_candidates(home: &Path, path_var: Option<&OsStr>) -> Vec<PathBuf>
 }
 
 /// The command a desktop app's family update would replace: the first
-/// candidate present on this machine, resolved to the file behind any
-/// link, judged by the rule `kendex update` judges its own bytes by.
+/// candidate this machine would actually run, resolved to the file behind
+/// any link, judged by the rule `kendex update` judges its own bytes by.
 ///
-/// The search stops at the first one that exists rather than hunting for
-/// a replaceable one further down, because the command a person runs is
-/// the one their `PATH` resolves first: passing over a package-owned
+/// A candidate has to be a command, not merely a path that is there. A
+/// directory or a data file named `kendex` sitting in a writable directory
+/// answers every other question the same way a command does — it exists,
+/// and its parent takes a rename — so accepting presence alone would stop
+/// the search on something a shell would have passed over, and write a
+/// release binary onto whatever it was.
+///
+/// Past that, the search stops at the first one, rather than hunting for a
+/// replaceable one further down: the command a person runs is the one
+/// their `PATH` resolves first, and passing over a package-owned
 /// `/usr/bin/kendex` to replace a second copy would move the half nobody
 /// runs and leave the half they do.
 ///
-/// `app_bytes` is what the app itself is about to replace, and is never a
-/// candidate. On a machine where that path is also reachable as `kendex`,
-/// the command binary would otherwise be written over the app and the app
-/// written back over it, leaving no command at all.
+/// `running` is this process and whatever it is about to replace, and
+/// neither is ever the command. Both have to be named, because neither
+/// covers the other: on Linux the AppImage the updater judged is not the
+/// executable inside it, and on Windows the updater judges no path at all
+/// while the desktop executable is `kendex.exe` — the same name the
+/// command carries. Written over, the command binary lands on the app and
+/// the app is then written back over it, leaving no command at all.
 pub fn command_beside_app(
     probe: &dyn HostProbe,
     candidates: &[PathBuf],
-    app_bytes: Option<&Path>,
+    running: &[PathBuf],
 ) -> CommandBeside {
-    let app_bytes = app_bytes.map(|path| probe.resolve(path));
+    let running: Vec<PathBuf> = running.iter().map(|path| probe.resolve(path)).collect();
     for candidate in candidates {
-        if !probe.exists(candidate) {
+        if !probe.is_command(candidate) {
             continue;
         }
         let resolved = probe.resolve(candidate);
-        if app_bytes.as_deref() == Some(resolved.as_path()) {
+        if running.contains(&resolved) {
             continue;
         }
         return match for_cli(&resolved, probe) {

--- a/crates/core/src/command_update.rs
+++ b/crates/core/src/command_update.rs
@@ -1,0 +1,272 @@
+//! Bringing an installed kendex binary to a release: the download, the
+//! signature check, the write, and the command half of a family update.
+//!
+//! Both shells drive one release across the desktop app and the `kendex`
+//! command, and both write the half that is their own state marker last.
+//! For `kendex update` that is the command, whose baked version the next
+//! run reads to decide whether it is done; for the app it is the app,
+//! whose baked version the sidebar card reads. Either way a failure before
+//! the marker leaves both halves where they were, so the next attempt
+//! repeats them rather than stopping at already-current.
+
+use std::cmp::Ordering;
+use std::ffi::OsStr;
+use std::path::{Path, PathBuf};
+use std::time::Duration;
+
+use semver::Version;
+
+use crate::install_channel::{HostProbe, InstallChannel, for_cli};
+use crate::process::Hardened;
+use crate::update_feed::{ReleaseFeed, signature_url, verify_signature};
+
+/// What `install.sh` installs the command as. Windows has no command
+/// beside the app — the installer carries the app alone — so the name
+/// there only ever fails to exist.
+#[cfg(windows)]
+const COMMAND_NAME: &str = "kendex.exe";
+#[cfg(not(windows))]
+const COMMAND_NAME: &str = "kendex";
+
+/// The command binary a running desktop app would bring across with it.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum CommandBeside {
+    /// A `kendex` command whose bytes this install may replace.
+    Ours(PathBuf),
+    /// A `kendex` command another installer owns. Those bytes are that
+    /// installer's to move, so the app updates itself alone.
+    NotOurs,
+    /// No `kendex` command beside the app — a dmg or msi install, where
+    /// the app is the whole install. An answer, not a failure.
+    Absent,
+}
+
+/// Whether the command half of a family update moved, which is the whole
+/// difference between the two sentences a failed app half gets.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum CommandHalf {
+    Moved,
+    Untouched,
+}
+
+/// Where the `kendex` command may be, in the order a shell resolves it:
+/// everything on `PATH` first, then the two directories `install.sh`
+/// chooses between. Reading `PATH` first is what makes the command a
+/// family update replaces the one `kendex --version` answers from; the
+/// two additions cover a desktop launcher whose `PATH` never picked up
+/// `~/.local/bin`.
+pub fn command_candidates(home: &Path, path_var: Option<&OsStr>) -> Vec<PathBuf> {
+    let on_path = path_var
+        .into_iter()
+        .flat_map(std::env::split_paths)
+        .map(|dir| dir.join(COMMAND_NAME));
+    let install_sh = [
+        home.join(".local").join("bin").join(COMMAND_NAME),
+        Path::new("/usr/local/bin").join(COMMAND_NAME),
+    ];
+    let mut candidates: Vec<PathBuf> = Vec::new();
+    for candidate in on_path.chain(install_sh) {
+        if !candidates.contains(&candidate) {
+            candidates.push(candidate);
+        }
+    }
+    candidates
+}
+
+/// The command a desktop app's family update would replace: the first
+/// candidate present on this machine, resolved to the file behind any
+/// link, judged by the rule `kendex update` judges its own bytes by.
+///
+/// The search stops at the first one that exists rather than hunting for
+/// a replaceable one further down, because the command a person runs is
+/// the one their `PATH` resolves first: passing over a package-owned
+/// `/usr/bin/kendex` to replace a second copy would move the half nobody
+/// runs and leave the half they do.
+///
+/// `app_bytes` is what the app itself is about to replace, and is never a
+/// candidate. On a machine where that path is also reachable as `kendex`,
+/// the command binary would otherwise be written over the app and the app
+/// written back over it, leaving no command at all.
+pub fn command_beside_app(
+    probe: &dyn HostProbe,
+    candidates: &[PathBuf],
+    app_bytes: Option<&Path>,
+) -> CommandBeside {
+    let app_bytes = app_bytes.map(|path| probe.resolve(path));
+    for candidate in candidates {
+        if !probe.exists(candidate) {
+            continue;
+        }
+        let resolved = probe.resolve(candidate);
+        if app_bytes.as_deref() == Some(resolved.as_path()) {
+            continue;
+        }
+        return match for_cli(&resolved, probe) {
+            InstallChannel::Direct => CommandBeside::Ours(resolved),
+            InstallChannel::Managed { .. } | InstallChannel::Unknown => CommandBeside::NotOurs,
+        };
+    }
+    CommandBeside::Absent
+}
+
+/// Bring the `kendex` command beside a desktop app to `release`, before
+/// the app itself moves.
+///
+/// The two halves have to name one release, or the pair ends up split by
+/// version rather than by failure: a feed offering anything but the
+/// release the app is installing stops the run with nothing written, and
+/// the app's own version is then still behind, so the card still offers
+/// the release and pressing it again repeats both halves.
+///
+/// A release with no command for this target stops the run for the same
+/// reason. There is a command installed here — that is what `Ours` means —
+/// and a release that cannot move it can only leave it behind.
+pub fn bring_command_across(
+    beside: &CommandBeside,
+    feed_url: &str,
+    release: &str,
+    target: &str,
+    public_key: &str,
+) -> Result<CommandHalf, String> {
+    let CommandBeside::Ours(path) = beside else {
+        return Ok(CommandHalf::Untouched);
+    };
+    let feed = ReleaseFeed::parse(&fetch(feed_url)?).map_err(|error| error.to_string())?;
+    if !one_release(&feed.version, release) {
+        return Err(format!(
+            "the desktop app installs {release} and the release feed offers the kendex command at {}; nothing was updated",
+            feed.version
+        ));
+    }
+    let Some(asset) = feed.asset_for(target) else {
+        return Err(format!(
+            "release {release} publishes no kendex command for {target}, so the command installed here would be left behind; nothing was updated"
+        ));
+    };
+    // Named as the command half. Read off a card that has just been
+    // pressed, a bare fetch or signature error says nothing about which of
+    // the two halves it came from.
+    download(asset)
+        .and_then(|command| command.install_at(path, public_key))
+        .map_err(|why| {
+            format!("the kendex command could not be updated: {why}; nothing was updated")
+        })?;
+    Ok(CommandHalf::Moved)
+}
+
+/// One release under SemVer precedence, so build metadata cannot split a
+/// pair the release job published together. Versions this build cannot
+/// parse have to match exactly, which is the answer that can only refuse.
+fn one_release(feed: &str, offered: &str) -> bool {
+    match (Version::parse(feed), Version::parse(offered)) {
+        (Ok(feed), Ok(offered)) => feed.cmp_precedence(&offered) == Ordering::Equal,
+        _ => feed == offered,
+    }
+}
+
+/// A release artifact and the minisign signature published beside it,
+/// both in hand before either lands. Holding them is what lets a caller
+/// order its writes: a download that was never going to arrive costs
+/// nothing that is already on disk.
+pub struct SignedArtifact {
+    pub bytes: Vec<u8>,
+    pub signature: Vec<u8>,
+}
+
+/// Fetch what `url` serves together with the `.sig` published beside it.
+///
+/// The feed is the one input nothing signs, so the URL here is a host
+/// whoever can alter the feed chooses. The signature is what makes that
+/// harmless: it comes from wherever the bytes came from and still has to
+/// check out under a key baked into this build.
+pub fn download(url: &str) -> Result<SignedArtifact, String> {
+    Ok(SignedArtifact {
+        bytes: fetch(url)?,
+        signature: fetch(&signature_url(url))?,
+    })
+}
+
+impl SignedArtifact {
+    /// Write these bytes over `path`, and only once the signature checks
+    /// out under `public_key`, so a download that fails verification never
+    /// reaches an installed path. Every half of every update lands through
+    /// here, so none of them is the half nothing checks.
+    pub fn install_at(&self, path: &Path, public_key: &str) -> Result<(), String> {
+        verify_signature(public_key, &self.bytes, &self.signature)
+            .map_err(|error| error.to_string())?;
+        replace_executable(path, &self.bytes).map_err(|error| error.to_string())
+    }
+}
+
+pub fn fetch(url: &str) -> Result<Vec<u8>, String> {
+    // This fetches release binaries as well as the small feed, so it needs
+    // room for a slow download.
+    let output = Hardened::curl(&curl_args(url))
+        .timeout(Duration::from_secs(600))
+        .run()
+        .map_err(|e| format!("curl unavailable: {e}"))?;
+    if !output.status.success() {
+        return Err(format!(
+            "fetching {url} failed: {}",
+            String::from_utf8_lossy(&output.stderr).trim()
+        ));
+    }
+    Ok(output.stdout)
+}
+
+fn curl_args(url: &str) -> [&str; 10] {
+    [
+        "-fsS",
+        "--location",
+        "--max-redirs",
+        "3",
+        "--proto",
+        "=https,file",
+        "--proto-redir",
+        "=https",
+        "--",
+        url,
+    ]
+}
+
+/// Write `bytes` over an executable that may be running: the replacement
+/// lands beside it whole and takes its place by rename, which every target
+/// OS allows on a running file.
+pub fn replace_executable(path: &Path, bytes: &[u8]) -> std::io::Result<()> {
+    let staged = staged_path(path);
+    match stage(&staged, bytes).and_then(|()| std::fs::rename(&staged, path)) {
+        Ok(()) => Ok(()),
+        Err(error) => {
+            // Nobody else writes a file named for this process, so a run
+            // that failed takes its own away instead of leaving one behind
+            // per process id.
+            let _ = std::fs::remove_file(&staged);
+            Err(error)
+        }
+    }
+}
+
+fn stage(staged: &Path, bytes: &[u8]) -> std::io::Result<()> {
+    std::fs::write(staged, bytes)?;
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        std::fs::set_permissions(staged, std::fs::Permissions::from_mode(0o755))?;
+    }
+    Ok(())
+}
+
+/// The process id keeps two concurrent runs off one staged file. Without
+/// it they share a name, and what the rename installs is whatever the other
+/// run last wrote there rather than the bytes this one verified.
+pub fn staged_path(current: &Path) -> PathBuf {
+    let mut name = current
+        .file_name()
+        .map(|n| n.to_string_lossy().into_owned())
+        .unwrap_or_else(|| "kendex".to_owned());
+    name.push_str(&format!(".update.{}", std::process::id()));
+    current.with_file_name(name)
+}
+
+#[cfg(test)]
+mod tests;

--- a/crates/core/src/command_update.rs
+++ b/crates/core/src/command_update.rs
@@ -31,6 +31,7 @@ use std::time::Duration;
 
 use semver::Version;
 
+use crate::env::Env;
 use crate::install_channel::{HostProbe, InstallChannel, for_cli};
 use crate::process::Hardened;
 use crate::update_feed::{ReleaseFeed, signature_url, verify_signature};
@@ -126,12 +127,23 @@ pub fn command_candidates(home: &Path, path_var: Option<&OsStr>) -> Vec<PathBuf>
 /// while the desktop executable is `kendex.exe` — the same name the
 /// command carries. Written over, the command binary lands on the app and
 /// the app is then written back over it, leaving no command at all.
+///
+/// `installed` is the command an installer recorded, and it is what makes
+/// a candidate ours. Everything else here is about the file's shape, and
+/// shape is not identity: a wrapper someone wrote that runs the real
+/// `kendex` is executable, is named `kendex`, and sits in a directory that
+/// takes a rename, so every other question answers yes and a release
+/// binary lands on their script. `kendex update` needs no record, because
+/// the path it judges is the one it is running from; this function found
+/// its path by name, and a name is a guess until something confirms it.
 pub fn command_beside_app(
     probe: &dyn HostProbe,
     candidates: &[PathBuf],
     running: &[PathBuf],
+    installed: Option<&Path>,
 ) -> CommandBeside {
     let running: Vec<PathBuf> = running.iter().map(|path| probe.resolve(path)).collect();
+    let installed = installed.map(|path| probe.resolve(path));
     for candidate in candidates {
         if !probe.is_command(candidate) {
             continue;
@@ -141,11 +153,43 @@ pub fn command_beside_app(
             continue;
         }
         return match for_cli(&resolved, probe) {
-            InstallChannel::Direct => CommandBeside::Ours(resolved),
+            // Asked before the record, because a package manager's copy
+            // has an owner worth naming and the card can name it. Only
+            // the arm that would replace the file needs proof.
+            InstallChannel::Direct if installed.as_deref() == Some(resolved.as_path()) => {
+                CommandBeside::Ours(resolved)
+            }
+            // Replaceable, and nothing says it is ours. Refusing costs a
+            // person one command; being wrong costs them their file.
+            InstallChannel::Direct => CommandBeside::NotOurs(InstallChannel::Unknown),
             owned => CommandBeside::NotOurs(owned),
         };
     }
     CommandBeside::Absent
+}
+
+/// The `kendex` command an installer recorded, resolved as written.
+///
+/// Absent where nothing has been recorded — an install older than this
+/// record, or one made some other way — and absent for anything that is
+/// not one absolute path, because a record this build cannot read is not
+/// a record it should act on.
+pub fn recorded_command(env: &Env) -> Option<PathBuf> {
+    let recorded = std::fs::read_to_string(env.installed_command_file()).ok()?;
+    let path = PathBuf::from(recorded.trim());
+    path.is_absolute().then_some(path)
+}
+
+/// Record `path` as the `kendex` command this install owns, so the desktop
+/// app can carry it across. Written by whatever put the command there.
+pub fn record_command(env: &Env, path: &Path) -> Result<(), String> {
+    let file = env.installed_command_file();
+    if let Some(parent) = file.parent() {
+        std::fs::create_dir_all(parent)
+            .map_err(|error| format!("{} could not be created: {error}", parent.display()))?;
+    }
+    std::fs::write(&file, format!("{}\n", path.display()))
+        .map_err(|error| format!("{} could not be written: {error}", file.display()))
 }
 
 /// Bring the `kendex` command beside a desktop app to `release`, before

--- a/crates/core/src/command_update.rs
+++ b/crates/core/src/command_update.rs
@@ -1,11 +1,17 @@
 //! Bringing an installed kendex binary to a release: the download, the
 //! signature check, the write, and the command half of a family update.
 //!
-//! Both shells drive one release across the desktop app and the `kendex`
-//! command, and both write the half that is their own state marker last.
-//! For `kendex update` that is the command, whose baked version the next
-//! run reads to decide whether it is done; for the app it is the app,
-//! whose baked version the sidebar card reads.
+//! Both shells drive one release across the desktop app and a `kendex`
+//! command that is kendex's to replace, and both write the half that is
+//! their own state marker last. For `kendex update` that is the command,
+//! whose baked version the next run reads to decide whether it is done;
+//! for the app it is the app, whose baked version the sidebar card reads.
+//!
+//! A command another installer owns is not carried, and that is not a
+//! failure — those bytes are that installer's to move. It is never left
+//! in silence either: `kendex update` names the owning command and stops,
+//! and the app's card names it before Update now is pressed, because
+//! afterwards the app has restarted and there is no card to say it on.
 //!
 //! Neither shell moves the two halves atomically, and neither claims to.
 //! A failure before the marker leaves both where they were. A failure
@@ -42,9 +48,12 @@ const COMMAND_NAME: &str = "kendex";
 pub enum CommandBeside {
     /// A `kendex` command whose bytes this install may replace.
     Ours(PathBuf),
-    /// A `kendex` command another installer owns. Those bytes are that
-    /// installer's to move, so the app updates itself alone.
-    NotOurs,
+    /// A `kendex` command another installer owns, carrying the channel
+    /// that names who. Those bytes are that installer's to move, so the
+    /// app updates itself alone — and has to say so, because an app that
+    /// moves while the command stays put is the divergence this whole
+    /// path exists to prevent.
+    NotOurs(InstallChannel),
     /// No `kendex` command beside the app — a dmg or msi install, where
     /// the app is the whole install. An answer, not a failure.
     Absent,
@@ -58,6 +67,17 @@ pub enum CommandHalf {
     Untouched,
 }
 
+/// The two directories `install.sh` chooses its `bindir` between: the
+/// first already on `PATH`, or the first of the pair when neither is.
+///
+/// The script is the source of that choice and this is its only spelling
+/// in Rust. `crates/cli/tests/install_script.rs` reads the list out of the
+/// script itself and fails when the two drift, so a change of destination
+/// there cannot quietly leave app-driven updates unable to find the
+/// command on a machine whose launcher `PATH` omits it.
+const INSTALLER_HOME_BIN: &str = ".local/bin";
+const INSTALLER_SYSTEM_BIN: &str = "/usr/local/bin";
+
 /// Where the `kendex` command may be, in the order a shell resolves it:
 /// everything on `PATH` first, then the two directories `install.sh`
 /// chooses between. Reading `PATH` first is what makes the command a
@@ -70,8 +90,8 @@ pub fn command_candidates(home: &Path, path_var: Option<&OsStr>) -> Vec<PathBuf>
         .flat_map(std::env::split_paths)
         .map(|dir| dir.join(COMMAND_NAME));
     let install_sh = [
-        home.join(".local").join("bin").join(COMMAND_NAME),
-        Path::new("/usr/local/bin").join(COMMAND_NAME),
+        home.join(INSTALLER_HOME_BIN).join(COMMAND_NAME),
+        Path::new(INSTALLER_SYSTEM_BIN).join(COMMAND_NAME),
     ];
     let mut candidates: Vec<PathBuf> = Vec::new();
     for candidate in on_path.chain(install_sh) {
@@ -122,7 +142,7 @@ pub fn command_beside_app(
         }
         return match for_cli(&resolved, probe) {
             InstallChannel::Direct => CommandBeside::Ours(resolved),
-            InstallChannel::Managed { .. } | InstallChannel::Unknown => CommandBeside::NotOurs,
+            owned => CommandBeside::NotOurs(owned),
         };
     }
     CommandBeside::Absent

--- a/crates/core/src/command_update/notice.rs
+++ b/crates/core/src/command_update/notice.rs
@@ -3,7 +3,7 @@
 //! so the rule that no value read off the machine reaches a command string
 //! is kept in one file.
 
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 use specta::Type;
 
 use super::CommandBeside;
@@ -18,7 +18,7 @@ use crate::names::shown;
 /// Every string is fixed text decided by which arm ran, save the path,
 /// which names one file to a person who may have several — the rule the
 /// [`InstallChannel`] command strings already live under.
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Type)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Type)]
 #[serde(
     tag = "kind",
     rename_all = "camelCase",

--- a/crates/core/src/command_update/notice.rs
+++ b/crates/core/src/command_update/notice.rs
@@ -1,0 +1,69 @@
+//! What the sidebar card is told about the `kendex` command beside the
+//! app. The one place a [`CommandBeside`] becomes text bound for the UI,
+//! so the rule that no value read off the machine reaches a command string
+//! is kept in one file.
+
+use serde::Serialize;
+use specta::Type;
+
+use super::CommandBeside;
+use crate::install_channel::InstallChannel;
+use crate::names::shown;
+
+/// What the sidebar card says about the `kendex` command beside the app,
+/// before Update now is pressed — afterwards the app has restarted and
+/// there is no card left to say it on. `None` where there is nothing to
+/// say: no command here, or one Update now carries across itself.
+///
+/// Every string is fixed text decided by which arm ran, save the path,
+/// which names one file to a person who may have several — the rule the
+/// [`InstallChannel`] command strings already live under.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Type)]
+#[serde(
+    tag = "kind",
+    rename_all = "camelCase",
+    rename_all_fields = "camelCase"
+)]
+pub enum CommandNotice {
+    /// Another installer owns the command; `manager` names it and
+    /// `command` brings it current.
+    Managed { manager: String, command: String },
+    /// Nothing names an owner and no record proves the file is kendex's,
+    /// so there is no name to print and no command to offer.
+    Unknown,
+    /// Kendex's own command, where this app cannot write. `command` is
+    /// what carries it across with the privilege the app lacks.
+    NeedsPrivilege { path: String, command: String },
+}
+
+/// What `kendex update` is spelled as when it has to run as root.
+const ELEVATED_UPDATE: &str = "sudo kendex update";
+
+impl CommandNotice {
+    /// What the card owes a person about this command, or `None` where it
+    /// owes them nothing.
+    pub fn for_card(beside: &CommandBeside) -> Option<Self> {
+        match beside {
+            CommandBeside::Ours(_) | CommandBeside::Absent => None,
+            CommandBeside::NeedsPrivilege(path) => Some(Self::NeedsPrivilege {
+                path: shown(&path.display().to_string()),
+                command: ELEVATED_UPDATE.to_owned(),
+            }),
+            CommandBeside::NotOurs(InstallChannel::Managed { manager, command }) => {
+                Some(Self::Managed {
+                    manager: manager.clone(),
+                    command: command.clone(),
+                })
+            }
+            // `Direct` never reaches here — a command judged replaceable
+            // is `Ours` or `NeedsPrivilege` — and `Unknown` is the arm
+            // that names nobody. Both say the same thing to a person.
+            CommandBeside::NotOurs(InstallChannel::Direct | InstallChannel::Unknown) => {
+                Some(Self::Unknown)
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests;

--- a/crates/core/src/command_update/notice/tests.rs
+++ b/crates/core/src/command_update/notice/tests.rs
@@ -1,0 +1,38 @@
+use super::*;
+
+/// What the card is owed, per state. Every arm that is not the app's own
+/// to carry says something, and no arm invents a name or a command: the
+/// managed one repeats the installer's, the privileged one the single
+/// fixed command that supplies what is missing, and the unknown one
+/// neither.
+#[test]
+fn the_card_is_told_what_each_state_owes_a_person() {
+    assert_eq!(
+        CommandNotice::for_card(&CommandBeside::Ours("/x/kendex".into())),
+        None
+    );
+    assert_eq!(CommandNotice::for_card(&CommandBeside::Absent), None);
+    assert_eq!(
+        CommandNotice::for_card(&CommandBeside::NotOurs(InstallChannel::Unknown)),
+        Some(CommandNotice::Unknown)
+    );
+    assert_eq!(
+        CommandNotice::for_card(&CommandBeside::NotOurs(InstallChannel::Managed {
+            manager: "Homebrew".to_owned(),
+            command: "brew upgrade kendex-cli".to_owned(),
+        })),
+        Some(CommandNotice::Managed {
+            manager: "Homebrew".to_owned(),
+            command: "brew upgrade kendex-cli".to_owned(),
+        })
+    );
+    assert_eq!(
+        CommandNotice::for_card(&CommandBeside::NeedsPrivilege(
+            "/usr/local/bin/kendex".into()
+        )),
+        Some(CommandNotice::NeedsPrivilege {
+            path: "/usr/local/bin/kendex".to_owned(),
+            command: ELEVATED_UPDATE.to_owned(),
+        })
+    );
+}

--- a/crates/core/src/command_update/record.rs
+++ b/crates/core/src/command_update/record.rs
@@ -1,0 +1,70 @@
+//! What an installer left behind so the desktop app can tell the `kendex`
+//! command it installed from any other executable carrying that name.
+//!
+//! `install.sh` writes it, `kendex update` refreshes it for the binary it
+//! is running as, and every replacement rewrites it for the bytes that
+//! landed. Read by `command_update::command_beside_app`, which will not
+//! replace a file no record vouches for.
+
+use std::path::{Path, PathBuf};
+
+use crate::env::Env;
+
+/// What an installer recorded about the `kendex` command it installed:
+/// where it put it, and what it put there.
+///
+/// Both halves have to match before those bytes are replaced. The path
+/// alone was the whole record once, and a path is only a name: the file
+/// behind it can be removed and another put in its place, and the wrapper
+/// this record exists to protect is exactly the kind of thing that turns
+/// up at a name kendex used to answer to.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct InstalledCommand {
+    /// Absolute, as the installer wrote it; resolved where it is used.
+    pub path: PathBuf,
+    /// Plain SHA-256 of the recorded bytes, hex — what `sha256sum` prints,
+    /// so `install.sh` and this build compute the same value.
+    pub digest: String,
+}
+
+/// The `kendex` command an installer recorded.
+///
+/// Absent where nothing has been recorded — an install older than this
+/// record, or one made some other way — and absent for anything that is
+/// not one absolute path and one SHA-256, because a record this build
+/// cannot read is not a record it should act on.
+pub fn recorded_command(env: &Env) -> Option<InstalledCommand> {
+    let recorded = std::fs::read_to_string(env.installed_command_file()).ok()?;
+    let mut lines = recorded.lines();
+    let path = PathBuf::from(lines.next()?.trim());
+    let digest = lines.next()?.trim().to_owned();
+    let sha256 = digest.len() == 64 && digest.bytes().all(|b| b.is_ascii_hexdigit());
+    (path.is_absolute() && sha256).then_some(InstalledCommand { path, digest })
+}
+
+/// Record `path`, holding `bytes`, as the `kendex` command this install
+/// owns, so the desktop app can carry it across. Written by whatever put
+/// the command there, and rewritten by whatever replaces it: a record left
+/// naming bytes that are gone is a record that stops matching, which
+/// refuses a command kendex does own rather than replacing one it does not.
+pub fn record_command(env: &Env, path: &Path, bytes: &[u8]) -> Result<(), String> {
+    let file = env.installed_command_file();
+    if let Some(parent) = file.parent() {
+        std::fs::create_dir_all(parent)
+            .map_err(|error| format!("{} could not be created: {error}", parent.display()))?;
+    }
+    let digest = crate::hash::sha256_hex(bytes);
+    std::fs::write(&file, format!("{}\n{digest}\n", path.display()))
+        .map_err(|error| format!("{} could not be written: {error}", file.display()))
+}
+
+/// The same record, taken from a file already on disk — the running
+/// command identifying itself, where the bytes are not in hand.
+pub fn record_installed(env: &Env, path: &Path) -> Result<(), String> {
+    let bytes = std::fs::read(path)
+        .map_err(|error| format!("{} could not be read: {error}", path.display()))?;
+    record_command(env, path, &bytes)
+}
+
+#[cfg(test)]
+mod tests;

--- a/crates/core/src/command_update/record/tests.rs
+++ b/crates/core/src/command_update/record/tests.rs
@@ -1,0 +1,50 @@
+//! What the record proves about a file, and what it refuses to prove.
+//! The lookup itself lives in the parent; these are the arms that turn on
+//! the record alone, against real files rather than a described machine.
+
+use super::*;
+
+/// Bytes to take an identity from — a wrapper someone wrote, which is the
+/// kind of file a record has to be able to disown.
+const WRAPPER: &[u8] = b"#!/bin/sh\nexec /opt/kendex/kendex \"$@\"\n";
+
+/// A record this build cannot read is not a record it acts on. The file
+/// carries two lines and both have to be what they claim: one absolute
+/// path, and one SHA-256. A half-written record, a relative path, or a
+/// digest that is not one reads as no record rather than as a record with
+/// a field to work around.
+#[test]
+fn a_record_that_is_not_a_path_and_a_digest_is_no_record() {
+    let dir = tempfile::tempdir().unwrap();
+    let env = Env::host_rooted(dir.path());
+    let file = env.installed_command_file();
+    std::fs::create_dir_all(file.parent().unwrap()).unwrap();
+    assert_eq!(recorded_command(&env), None, "nothing written at all");
+
+    let digest = crate::hash::sha256_hex(WRAPPER);
+    for written in [
+        String::new(),
+        "  \n".to_owned(),
+        // The path alone: the whole of the record before the digest
+        // existed, and a build that acted on it would replace by name.
+        "/usr/local/bin/kendex\n".to_owned(),
+        format!("bin/kendex\n{digest}\n"),
+        format!("/usr/local/bin/kendex\n{}\n", &digest[..63]),
+        format!("/usr/local/bin/kendex\n{}z\n", &digest[..63]),
+        format!("/usr/local/bin/kendex\n{digest}{digest}\n"),
+    ] {
+        std::fs::write(&file, &written).unwrap();
+        assert_eq!(recorded_command(&env), None, "{written:?}");
+    }
+
+    // The control: the same file, well formed, is read. Without it every
+    // assertion above passes for a reader that returns `None` always.
+    record_command(&env, Path::new("/usr/local/bin/kendex"), WRAPPER).unwrap();
+    assert_eq!(
+        recorded_command(&env),
+        Some(InstalledCommand {
+            path: PathBuf::from("/usr/local/bin/kendex"),
+            digest,
+        })
+    );
+}

--- a/crates/core/src/command_update/tests.rs
+++ b/crates/core/src/command_update/tests.rs
@@ -144,7 +144,10 @@ fn no_command_or_one_another_installer_owns_lets_the_app_go_alone() {
     let dir = tempfile::tempdir().unwrap();
     let (feed_url, installed) = a_release_is_out(&dir);
 
-    for beside in [CommandBeside::Absent, CommandBeside::NotOurs] {
+    for beside in [
+        CommandBeside::Absent,
+        CommandBeside::NotOurs(InstallChannel::Unknown),
+    ] {
         assert_eq!(
             across(&beside, &feed_url, RELEASE).unwrap(),
             CommandHalf::Untouched,
@@ -267,35 +270,44 @@ fn the_command_a_shell_resolves_first_is_the_one_replaced() {
     );
 }
 
-/// A copy another installer owns is never replaced, whether this build
-/// can name the command that owns it or not — and it is judged by the
+/// A copy another installer owns is never replaced, and the answer names
+/// who owns it, so the card can tell the person which command moves it
+/// rather than leaving the app to update alone in silence. Judged by the
 /// file behind the name, because a link on `PATH` is how a package's copy
 /// is reached without ever naming its prefix.
+///
+/// Both arms of "not ours" run: a distro whose helper this build can name,
+/// and one it cannot, where the honest answer carries no command at all.
 #[test]
-fn a_command_another_installer_owns_is_never_ours() {
+fn a_command_another_installer_owns_is_never_ours_and_names_its_owner() {
     let named = candidates(&["/usr/bin/kendex"]);
     let linked = candidates(&["/home/pat/.local/bin/kendex"]);
-    for (machine, probed) in [
+    let cases = [
         (
             Machine {
                 present: named.clone(),
+                arch: true,
                 ..Machine::default()
             },
             &named,
+            InstallChannel::Managed {
+                command: "update kendex with your AUR helper".to_owned(),
+            },
         ),
         (
             Machine {
                 present: linked.clone(),
                 links: vec![(linked[0].clone(), named[0].clone())],
-                arch: true,
                 ..Machine::default()
             },
             &linked,
+            InstallChannel::Unknown,
         ),
-    ] {
+    ];
+    for (machine, probed, owner) in cases {
         assert_eq!(
             command_beside_app(&machine, probed, &[]),
-            CommandBeside::NotOurs,
+            CommandBeside::NotOurs(owner),
             "{probed:?}"
         );
     }
@@ -386,27 +398,30 @@ fn a_directory_or_a_data_file_named_kendex_is_not_a_command() {
 /// `PATH` first, then the two directories `install.sh` chooses between,
 /// each named once — a launcher whose `PATH` already carries `.local/bin`
 /// must not have it probed twice.
+///
+/// Written against the constants rather than against their values: what
+/// those values have to be is `install.sh`'s to say, and the contract test
+/// in `crates/cli/tests/install_script.rs` reads them out of the script.
 #[test]
 fn candidates_are_path_then_the_installer_s_own_dirs_without_repeats() {
     let home = Path::new("/home/pat");
-    let path = std::ffi::OsString::from("/home/pat/.local/bin:/usr/bin");
-    let found = command_candidates(home, Some(&path));
+    let home_bin = home.join(INSTALLER_HOME_BIN);
+    let system = Path::new(INSTALLER_SYSTEM_BIN).join(COMMAND_NAME);
+    let path = std::ffi::OsString::from(format!("{}:/usr/bin", home_bin.display()));
+
     assert_eq!(
-        found,
-        candidates(&[
-            &format!("/home/pat/.local/bin/{COMMAND_NAME}"),
-            &format!("/usr/bin/{COMMAND_NAME}"),
-            &format!("/usr/local/bin/{COMMAND_NAME}"),
-        ])
+        command_candidates(home, Some(&path)),
+        vec![
+            home_bin.join(COMMAND_NAME),
+            PathBuf::from(format!("/usr/bin/{COMMAND_NAME}")),
+            system.clone(),
+        ]
     );
 
-    // No PATH at all still leaves the installer's own two.
+    // No PATH at all still leaves the installer's own two, in its order.
     assert_eq!(
         command_candidates(home, None),
-        candidates(&[
-            &format!("/home/pat/.local/bin/{COMMAND_NAME}"),
-            &format!("/usr/local/bin/{COMMAND_NAME}"),
-        ])
+        vec![home_bin.join(COMMAND_NAME), system]
     );
 }
 

--- a/crates/core/src/command_update/tests.rs
+++ b/crates/core/src/command_update/tests.rs
@@ -48,8 +48,20 @@ fn a_release_is_out_under(home: &Path) -> (String, PathBuf) {
     (file_url(&home.join("feed.json")), installed)
 }
 
+/// The command half, against a record store this test owns. Most arms
+/// never read it; the one that does is the refresh after a write.
 fn across(beside: &CommandBeside, feed: &str, release: &str) -> Result<CommandHalf, String> {
-    bring_command_across(beside, feed, release, TARGET, TEST_KEY)
+    let store = tempfile::tempdir().unwrap();
+    across_in(&Env::host_rooted(store.path()), beside, feed, release)
+}
+
+fn across_in(
+    env: &Env,
+    beside: &CommandBeside,
+    feed: &str,
+    release: &str,
+) -> Result<CommandHalf, String> {
+    bring_command_across(env, beside, feed, release, TARGET, TEST_KEY)
 }
 
 /// The whole point of the family update: the command a person runs ends
@@ -123,7 +135,9 @@ fn a_release_with_no_command_for_this_target_stops_the_family() {
     let dir = tempfile::tempdir().unwrap();
     let (feed_url, installed) = a_release_is_out(&dir);
 
+    let store = tempfile::tempdir().unwrap();
     let refused = bring_command_across(
+        &Env::host_rooted(store.path()),
         &CommandBeside::Ours(installed.clone()),
         &feed_url,
         RELEASE,
@@ -211,13 +225,16 @@ struct Machine {
     /// Paths that are there and are not commands: a directory, or a data
     /// file, carrying a command's name.
     not_commands: Vec<PathBuf>,
+    /// Paths whose directory refuses this process's writes — what an
+    /// unprivileged app meets at a `sudo`-installed `/usr/local/bin`.
+    unwritable: Vec<PathBuf>,
     links: Vec<(PathBuf, PathBuf)>,
     arch: bool,
 }
 
 impl HostProbe for Machine {
-    fn replaceable(&self, _: &Path) -> bool {
-        true
+    fn replaceable(&self, path: &Path) -> bool {
+        !self.unwritable.iter().any(|p| p == path)
     }
 
     fn exists(&self, path: &Path) -> bool {
@@ -233,6 +250,13 @@ impl HostProbe for Machine {
             .iter()
             .find(|(from, _)| from == path)
             .map_or_else(|| path.to_owned(), |(_, to)| to.clone())
+    }
+
+    /// One file, one digest: what a path holds stands in for the bytes at
+    /// it, so two different files never carry one identity.
+    fn digest(&self, path: &Path) -> Option<String> {
+        self.is_command(path)
+            .then(|| crate::hash::sha256_hex(path.display().to_string().as_bytes()))
     }
 
     fn on_path(&self, _: &str) -> bool {
@@ -253,7 +277,21 @@ fn candidates(paths: &[&str]) -> Vec<PathBuf> {
 /// and the found path is a different file, which reads `NotOurs` and fails
 /// the assertion just as loudly.
 fn located(machine: &Machine, probed: &[PathBuf], installed: &str) -> CommandBeside {
-    command_beside_app(machine, probed, &[], Some(Path::new(installed)))
+    command_beside_app(machine, probed, &[], Some(&recorded(machine, installed)))
+}
+
+/// The record an installer would have left for a file on this machine:
+/// where it installed, and the digest of what is there now.
+fn recorded(machine: &Machine, path: &str) -> InstalledCommand {
+    let path = PathBuf::from(path);
+    InstalledCommand {
+        digest: machine
+            .digest(&machine.resolve(&path))
+            // Nothing at that path to take an identity from — a record of
+            // a file this machine does not have.
+            .unwrap_or_else(|| "0".repeat(64)),
+        path,
+    }
 }
 
 /// `PATH` order decides which `kendex` a person runs, so it decides which
@@ -344,7 +382,12 @@ fn nothing_installed_and_the_running_app_both_read_absent() {
         ..Machine::default()
     };
     assert_eq!(
-        command_beside_app(&only_the_app, &probed, &[image.clone()], Some(&image)),
+        command_beside_app(
+            &only_the_app,
+            &probed,
+            &[image.clone()],
+            Some(&recorded(&only_the_app, &image.display().to_string()))
+        ),
         CommandBeside::Absent
     );
 }
@@ -367,12 +410,22 @@ fn a_windows_app_on_path_is_never_taken_for_the_command() {
     // What the updater offers on Windows: no path at all. Recorded, so
     // the fixture reaches the app and the exclusion is what stops it.
     assert_eq!(
-        command_beside_app(&machine, &probed, &[], Some(&exe)),
+        command_beside_app(
+            &machine,
+            &probed,
+            &[],
+            Some(&recorded(&machine, &exe.display().to_string()))
+        ),
         CommandBeside::Ours(exe.clone()),
         "the fixture has to reach the app before the exclusion can be what stops it"
     );
     assert_eq!(
-        command_beside_app(&machine, &probed, &[exe.clone()], Some(&exe)),
+        command_beside_app(
+            &machine,
+            &probed,
+            &[exe.clone()],
+            Some(&recorded(&machine, &exe.display().to_string()))
+        ),
         CommandBeside::Absent
     );
 }
@@ -554,7 +607,7 @@ fn a_command_no_installer_recorded_is_never_replaced() {
     let (env, wrapper) = a_kendex_on_this_machine(&dir);
     let probed = vec![wrapper.clone()];
 
-    let beside = command_beside_app(&Host, &probed, &[], recorded_command(&env).as_deref());
+    let beside = command_beside_app(&Host, &probed, &[], recorded_command(&env).as_ref());
     assert_eq!(beside, CommandBeside::NotOurs(InstallChannel::Unknown));
 
     let (feed_url, _) = a_release_is_out(&dir);
@@ -569,23 +622,73 @@ fn a_command_no_installer_recorded_is_never_replaced() {
 /// record behind it. Read against the arm above, this is what says the
 /// record is what refused the wrapper, and not a fixture that could never
 /// have been carried in the first place.
+///
+/// The record is rewritten for what landed, too: leave it naming the bytes
+/// that were replaced and the next release finds a command it owns and
+/// cannot prove, which refuses an update nobody had to be refused.
 #[test]
 fn the_command_an_installer_recorded_is_carried_across() {
     let dir = tempfile::tempdir().unwrap();
     let (env, command) = a_kendex_on_this_machine(&dir);
-    record_command(&env, &command).unwrap();
+    record_installed(&env, &command).unwrap();
     let probed = vec![command.clone()];
 
-    let beside = command_beside_app(&Host, &probed, &[], recorded_command(&env).as_deref());
+    let beside = command_beside_app(&Host, &probed, &[], recorded_command(&env).as_ref());
     assert_eq!(beside, CommandBeside::Ours(Host.resolve(&command)));
 
     let (feed_url, _) = a_release_is_out(&dir);
     assert_eq!(
-        across(&beside, &feed_url, RELEASE).unwrap(),
+        across_in(&env, &beside, &feed_url, RELEASE).unwrap(),
         CommandHalf::Moved
     );
     assert_eq!(std::fs::read(&command).unwrap(), OFFERED);
+    assert_eq!(
+        recorded_command(&env).unwrap().digest,
+        crate::hash::sha256_hex(OFFERED),
+        "the record still names the bytes that were replaced"
+    );
+    assert_eq!(
+        command_beside_app(&Host, &probed, &[], recorded_command(&env).as_ref()),
+        CommandBeside::Ours(Host.resolve(&command)),
+        "a release the app just installed is not one it has to refuse next time"
+    );
 }
+
+/// The harm the record exists to stop, arrived at through the record
+/// itself: a path is a name, and the file behind a name can be replaced.
+/// Remove what kendex installed, put a wrapper of your own at that path,
+/// and every question about the path answers yes — so the digest is what
+/// has to answer no, and the wrapper is left as its author wrote it.
+#[test]
+fn a_different_file_at_the_recorded_path_is_not_the_recorded_command() {
+    let dir = tempfile::tempdir().unwrap();
+    let (env, command) = a_kendex_on_this_machine(&dir);
+    record_installed(&env, &command).unwrap();
+    let probed = vec![command.clone()];
+
+    // The control: what the same lookup says while the recorded bytes are
+    // still there. Without it, an assertion below passes for a fixture
+    // that was never carried in the first place.
+    assert_eq!(
+        command_beside_app(&Host, &probed, &[], recorded_command(&env).as_ref()),
+        CommandBeside::Ours(Host.resolve(&command))
+    );
+
+    std::fs::write(&command, SOMEONE_ELSES).unwrap();
+    let beside = command_beside_app(&Host, &probed, &[], recorded_command(&env).as_ref());
+
+    assert_eq!(beside, CommandBeside::NotOurs(InstallChannel::Unknown));
+    let (feed_url, _) = a_release_is_out(&dir);
+    assert_eq!(
+        across(&beside, &feed_url, RELEASE).unwrap(),
+        CommandHalf::Untouched
+    );
+    assert_eq!(std::fs::read(&command).unwrap(), SOMEONE_ELSES);
+}
+
+/// A second wrapper, written where the first one was: the bytes differ,
+/// so the digest differs, and the path they share proves nothing.
+const SOMEONE_ELSES: &[u8] = b"#!/bin/sh\nexec /opt/other/kendex \"$@\"\n";
 
 /// A record naming one command says nothing about another. Someone with
 /// an install.sh kendex and a wrapper of their own on `PATH` ahead of it
@@ -594,30 +697,101 @@ fn the_command_an_installer_recorded_is_carried_across() {
 fn a_record_of_one_command_does_not_vouch_for_another() {
     let dir = tempfile::tempdir().unwrap();
     let (env, wrapper) = a_kendex_on_this_machine(&dir);
-    record_command(&env, Path::new("/home/pat/.local/bin/kendex")).unwrap();
+    record_command(&env, Path::new("/home/pat/.local/bin/kendex"), WRAPPER).unwrap();
 
     assert_eq!(
-        command_beside_app(&Host, &[wrapper], &[], recorded_command(&env).as_deref()),
+        command_beside_app(&Host, &[wrapper], &[], recorded_command(&env).as_ref()),
+        CommandBeside::NotOurs(InstallChannel::Unknown),
+        "the digest matches the bytes and the path does not"
+    );
+}
+
+/// A recorded command outside `PATH` and outside both directories
+/// `install.sh` chooses between — `~/.cargo/bin/kendex` under an app a
+/// Finder launch hands the four system directories. Nothing else in the
+/// search names it, so the record has to be searched and not only
+/// checked, or the app updates alone and every terminal stays behind.
+#[test]
+fn a_recorded_command_no_other_route_reaches_is_still_found() {
+    let cargo_bin = "/home/pat/.cargo/bin/kendex";
+    let machine = Machine {
+        present: candidates(&[cargo_bin]),
+        ..Machine::default()
+    };
+    // What a Finder launch leaves: no kendex on `PATH`, and none in
+    // either installer directory.
+    let probed = command_candidates(
+        Path::new("/home/pat"),
+        Some(&std::ffi::OsString::from("/usr/bin:/bin")),
+    );
+    assert!(
+        !probed.iter().any(|p| p == Path::new(cargo_bin)),
+        "the fixture only means something while no other candidate names it: {probed:?}"
+    );
+
+    assert_eq!(
+        located(&machine, &probed, cargo_bin),
+        CommandBeside::Ours(cargo_bin.into())
+    );
+}
+
+/// `install.sh` writes `/usr/local/bin` with `sudo` whenever that is the
+/// first of its two directories on `PATH`, and the desktop app runs
+/// unprivileged. The command there is kendex's — an installer recorded
+/// it, digest and all — and what is missing is the privilege to replace
+/// it. Called not ours, that reads as a command kendex has no claim on and
+/// names nothing a person can do; called what it is, the card can name the
+/// one command that moves it.
+#[test]
+fn a_recorded_command_this_app_cannot_write_is_ours_without_the_privilege() {
+    let sudo_installed = "/usr/local/bin/kendex";
+    let probed = candidates(&[sudo_installed]);
+    let unprivileged = Machine {
+        present: probed.clone(),
+        unwritable: probed.clone(),
+        ..Machine::default()
+    };
+
+    assert_eq!(
+        located(&unprivileged, &probed, sudo_installed),
+        CommandBeside::NeedsPrivilege(sudo_installed.into())
+    );
+
+    // The control the arm above needs: the same path, writable, is where
+    // the answer differs. A fixture nothing could carry would read
+    // `NeedsPrivilege` for the wrong reason.
+    let privileged = Machine {
+        present: probed.clone(),
+        ..Machine::default()
+    };
+    assert_eq!(
+        located(&privileged, &probed, sudo_installed),
+        CommandBeside::Ours(sudo_installed.into())
+    );
+
+    // And the privilege is not a way around the record: an unrecorded
+    // command in a directory this process cannot write is still not ours.
+    assert_eq!(
+        located(&unprivileged, &probed, "/home/pat/.local/bin/kendex"),
         CommandBeside::NotOurs(InstallChannel::Unknown)
     );
 }
 
-/// A record this build cannot read is not a record it acts on: a relative
-/// path, an empty file, or nothing written at all all mean the same thing.
+/// The command half writes nothing where the app has no privilege to
+/// write it. The card said so before Update now was pressed; what must
+/// not happen is a write attempt reported as a moved half.
 #[test]
-fn a_record_that_is_not_one_absolute_path_is_no_record() {
+fn the_command_half_leaves_a_path_it_cannot_write_alone() {
     let dir = tempfile::tempdir().unwrap();
-    let env = Env::host_rooted(dir.path());
-    assert_eq!(recorded_command(&env), None);
+    let (feed_url, installed) = a_release_is_out(&dir);
 
-    for written in ["", "  ", "bin/kendex", "\n"] {
-        record_command(&env, Path::new(written)).unwrap();
-        assert_eq!(recorded_command(&env), None, "{written:?}");
-    }
+    let half = across(
+        &CommandBeside::NeedsPrivilege(installed.clone()),
+        &feed_url,
+        RELEASE,
+    )
+    .unwrap();
 
-    record_command(&env, Path::new("/usr/local/bin/kendex")).unwrap();
-    assert_eq!(
-        recorded_command(&env),
-        Some(PathBuf::from("/usr/local/bin/kendex"))
-    );
+    assert_eq!(half, CommandHalf::Untouched);
+    assert_eq!(std::fs::read(&installed).unwrap(), INSTALLED);
 }

--- a/crates/core/src/command_update/tests.rs
+++ b/crates/core/src/command_update/tests.rs
@@ -1,4 +1,5 @@
 use super::*;
+use crate::install_channel::Host;
 
 #[path = "../../../fixture_url.rs"]
 mod fixture_url;
@@ -247,6 +248,14 @@ fn candidates(paths: &[&str]) -> Vec<PathBuf> {
     paths.iter().map(PathBuf::from).collect()
 }
 
+/// The lookup with an installer's record behind it. Tests about *which*
+/// candidate wins record the one they expect to win: get the order wrong
+/// and the found path is a different file, which reads `NotOurs` and fails
+/// the assertion just as loudly.
+fn located(machine: &Machine, probed: &[PathBuf], installed: &str) -> CommandBeside {
+    command_beside_app(machine, probed, &[], Some(Path::new(installed)))
+}
+
 /// `PATH` order decides which `kendex` a person runs, so it decides which
 /// one a family update replaces: the search reads `PATH` before the
 /// installer's own directories and stops at the first candidate that
@@ -265,7 +274,7 @@ fn the_command_a_shell_resolves_first_is_the_one_replaced() {
     );
 
     assert_eq!(
-        command_beside_app(&machine, &probed, &[]),
+        located(&machine, &probed, on_path),
         CommandBeside::Ours(on_path.into())
     );
 }
@@ -306,8 +315,10 @@ fn a_command_another_installer_owns_is_never_ours_and_names_its_owner() {
         ),
     ];
     for (machine, probed, owner) in cases {
+        // Recorded, so the refusal is the installer's ownership and not
+        // a missing record.
         assert_eq!(
-            command_beside_app(&machine, probed, &[]),
+            located(&machine, probed, &probed[0].display().to_string()),
             CommandBeside::NotOurs(owner),
             "{probed:?}"
         );
@@ -324,7 +335,7 @@ fn nothing_installed_and_the_running_app_both_read_absent() {
     let image = PathBuf::from("/home/pat/.local/bin/kendex");
     let probed = vec![image.clone()];
     assert_eq!(
-        command_beside_app(&Machine::default(), &probed, &[]),
+        located(&Machine::default(), &probed, &image.display().to_string()),
         CommandBeside::Absent
     );
 
@@ -333,7 +344,7 @@ fn nothing_installed_and_the_running_app_both_read_absent() {
         ..Machine::default()
     };
     assert_eq!(
-        command_beside_app(&only_the_app, &probed, &[image]),
+        command_beside_app(&only_the_app, &probed, &[image.clone()], Some(&image)),
         CommandBeside::Absent
     );
 }
@@ -353,14 +364,15 @@ fn a_windows_app_on_path_is_never_taken_for_the_command() {
     };
     let probed = vec![exe.clone()];
 
-    // What the updater offers on Windows: no path at all.
+    // What the updater offers on Windows: no path at all. Recorded, so
+    // the fixture reaches the app and the exclusion is what stops it.
     assert_eq!(
-        command_beside_app(&machine, &probed, &[]),
+        command_beside_app(&machine, &probed, &[], Some(&exe)),
         CommandBeside::Ours(exe.clone()),
         "the fixture has to reach the app before the exclusion can be what stops it"
     );
     assert_eq!(
-        command_beside_app(&machine, &probed, &[exe]),
+        command_beside_app(&machine, &probed, &[exe.clone()], Some(&exe)),
         CommandBeside::Absent
     );
 }
@@ -380,7 +392,7 @@ fn a_directory_or_a_data_file_named_kendex_is_not_a_command() {
     let probed = candidates(&["/opt/a/kendex", "/opt/b/kendex", "/usr/local/bin/kendex"]);
 
     assert_eq!(
-        command_beside_app(&machine, &probed, &[]),
+        located(&machine, &probed, "/usr/local/bin/kendex"),
         CommandBeside::Ours(real)
     );
 
@@ -391,7 +403,7 @@ fn a_directory_or_a_data_file_named_kendex_is_not_a_command() {
         ..Machine::default()
     };
     assert_eq!(
-        command_beside_app(&neither, &probed[..2], &[]),
+        located(&neither, &probed[..2], "/usr/local/bin/kendex"),
         CommandBeside::Absent
     );
 }
@@ -510,4 +522,102 @@ fn a_replacement_that_cannot_land_leaves_no_staged_file() {
 
     assert!(replace_executable(&target, b"bytes").is_err());
     assert!(!staged_path(&target).exists());
+}
+
+/// One machine, one executable named `kendex` in a directory that takes a
+/// rename. Whether it is ours is the only thing the two arms below differ
+/// on, and it is the only thing that decides.
+fn a_kendex_on_this_machine(dir: &tempfile::TempDir) -> (Env, PathBuf) {
+    let bin = dir.path().join("bin");
+    std::fs::create_dir_all(&bin).unwrap();
+    let command = bin.join("kendex");
+    std::fs::write(&command, WRAPPER).unwrap();
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        std::fs::set_permissions(&command, std::fs::Permissions::from_mode(0o755)).unwrap();
+    }
+    (Env::host_rooted(dir.path()), command)
+}
+
+/// What someone wrote themselves: a shell script named `kendex` that runs
+/// the real one. Executable, correctly named, and in a writable directory.
+const WRAPPER: &[u8] = b"#!/bin/sh\nexec /opt/kendex/kendex \"$@\"\n";
+
+/// A wrapper someone wrote is not kendex, however much it looks like it
+/// from outside. Nothing recorded it, so it is refused and the card is
+/// told there is no owner to name — and the file is left exactly as its
+/// author wrote it.
+#[test]
+fn a_command_no_installer_recorded_is_never_replaced() {
+    let dir = tempfile::tempdir().unwrap();
+    let (env, wrapper) = a_kendex_on_this_machine(&dir);
+    let probed = vec![wrapper.clone()];
+
+    let beside = command_beside_app(&Host, &probed, &[], recorded_command(&env).as_deref());
+    assert_eq!(beside, CommandBeside::NotOurs(InstallChannel::Unknown));
+
+    let (feed_url, _) = a_release_is_out(&dir);
+    assert_eq!(
+        across(&beside, &feed_url, RELEASE).unwrap(),
+        CommandHalf::Untouched
+    );
+    assert_eq!(std::fs::read(&wrapper).unwrap(), WRAPPER);
+}
+
+/// The same file, the same directory, the same shape — with an installer's
+/// record behind it. Read against the arm above, this is what says the
+/// record is what refused the wrapper, and not a fixture that could never
+/// have been carried in the first place.
+#[test]
+fn the_command_an_installer_recorded_is_carried_across() {
+    let dir = tempfile::tempdir().unwrap();
+    let (env, command) = a_kendex_on_this_machine(&dir);
+    record_command(&env, &command).unwrap();
+    let probed = vec![command.clone()];
+
+    let beside = command_beside_app(&Host, &probed, &[], recorded_command(&env).as_deref());
+    assert_eq!(beside, CommandBeside::Ours(Host.resolve(&command)));
+
+    let (feed_url, _) = a_release_is_out(&dir);
+    assert_eq!(
+        across(&beside, &feed_url, RELEASE).unwrap(),
+        CommandHalf::Moved
+    );
+    assert_eq!(std::fs::read(&command).unwrap(), OFFERED);
+}
+
+/// A record naming one command says nothing about another. Someone with
+/// an install.sh kendex and a wrapper of their own on `PATH` ahead of it
+/// keeps the wrapper.
+#[test]
+fn a_record_of_one_command_does_not_vouch_for_another() {
+    let dir = tempfile::tempdir().unwrap();
+    let (env, wrapper) = a_kendex_on_this_machine(&dir);
+    record_command(&env, Path::new("/home/pat/.local/bin/kendex")).unwrap();
+
+    assert_eq!(
+        command_beside_app(&Host, &[wrapper], &[], recorded_command(&env).as_deref()),
+        CommandBeside::NotOurs(InstallChannel::Unknown)
+    );
+}
+
+/// A record this build cannot read is not a record it acts on: a relative
+/// path, an empty file, or nothing written at all all mean the same thing.
+#[test]
+fn a_record_that_is_not_one_absolute_path_is_no_record() {
+    let dir = tempfile::tempdir().unwrap();
+    let env = Env::host_rooted(dir.path());
+    assert_eq!(recorded_command(&env), None);
+
+    for written in ["", "  ", "bin/kendex", "\n"] {
+        record_command(&env, Path::new(written)).unwrap();
+        assert_eq!(recorded_command(&env), None, "{written:?}");
+    }
+
+    record_command(&env, Path::new("/usr/local/bin/kendex")).unwrap();
+    assert_eq!(
+        recorded_command(&env),
+        Some(PathBuf::from("/usr/local/bin/kendex"))
+    );
 }

--- a/crates/core/src/command_update/tests.rs
+++ b/crates/core/src/command_update/tests.rs
@@ -1,0 +1,406 @@
+use super::*;
+
+/// A throwaway minisign keypair signing `OFFERED`, so the admitted arm
+/// runs the real check rather than a stub standing in for it. One pair
+/// serves both halves: the app and the command are held to one key.
+const TEST_KEY: &str = "dW50cnVzdGVkIGNvbW1lbnQ6IG1pbmlzaWduIHB1YmxpYyBrZXk6IDk0QUI0NzI3RTVDMTVCODEKUldTQlc4SGxKMGVybEhxeFovbTJ3U1phMng4aE9VTXByV09pUVRFVFNKbFZ5aWxtUTAvVGgyWEwK";
+const TEST_SIGNATURE: &str = "dW50cnVzdGVkIGNvbW1lbnQ6IHNpZ25hdHVyZSBmcm9tIHJzaWduIHNlY3JldCBrZXkKUlVTQlc4SGxKMGVybElTMUxrbkMyQ0tBWGlnejY1S0xLekovK0tBYllNdkdJTVU0bitTSjRBSCt1RlpwWnZkRHNKcWFTSHVoeStIQkpyVDlOaVRIMmROWVVSb21mMVBVRmd3PQp0cnVzdGVkIGNvbW1lbnQ6IGtlbmRleCB0ZXN0CnpKSnpYYnBtODZYRW40eHgxSTVkeG5YdktxT0k5ZXdmSkEyMkdtZXpreGgwbUNJZysybkJ2cGowUXZ6N2c3RHA4TEZBVXVBQUVMRExuUzFuaVpsaUF3PT0K";
+
+/// What the feed offers is the signed blob, because a release only ever
+/// offers a command `TEST_SIGNATURE` covers; nothing else gets written.
+const OFFERED: &[u8] = b"kendex AppImage bytes";
+const INSTALLED: &[u8] = b"the command already here";
+/// The release the fixture feed publishes, and the target it publishes
+/// for — fixed here so a test says the same thing on every build host.
+const RELEASE: &str = "9.9.9";
+const TARGET: &str = "x86_64-unknown-linux-gnu";
+
+/// One machine mid-update: a `kendex` command already installed, and a
+/// release the feed offers at [`RELEASE`] with a signed command binary
+/// behind it. What each arm does to that command is the whole difference
+/// between them.
+fn a_release_is_out(dir: &tempfile::TempDir) -> (String, PathBuf) {
+    let home = dir.path();
+    let installed = home.join("kendex");
+    std::fs::write(&installed, INSTALLED).unwrap();
+    std::fs::write(home.join("new-command"), OFFERED).unwrap();
+    std::fs::write(home.join("new-command.sig"), TEST_SIGNATURE).unwrap();
+    std::fs::write(
+        home.join("feed.json"),
+        format!(
+            r#"{{"schema": 1, "version": "{RELEASE}", "assets": {{"{TARGET}": "file://{}/new-command"}}}}"#,
+            home.display()
+        ),
+    )
+    .unwrap();
+    (format!("file://{}/feed.json", home.display()), installed)
+}
+
+fn across(beside: &CommandBeside, feed: &str, release: &str) -> Result<CommandHalf, String> {
+    bring_command_across(beside, feed, release, TARGET, TEST_KEY)
+}
+
+/// The whole point of the family update: the command a person runs ends
+/// up on the release the app is installing, and it got there from that
+/// release's own published asset.
+#[test]
+fn the_command_lands_on_the_release_the_app_is_installing() {
+    let dir = tempfile::tempdir().unwrap();
+    let (feed_url, installed) = a_release_is_out(&dir);
+
+    let half = across(&CommandBeside::Ours(installed.clone()), &feed_url, RELEASE).unwrap();
+
+    assert_eq!(half, CommandHalf::Moved);
+    assert_eq!(std::fs::read(&installed).unwrap(), OFFERED);
+    assert!(!staged_path(&installed).exists());
+}
+
+/// Skew, driven from both sides: the app installing a release the feed is
+/// behind, and one the feed is ahead of. Either way the pair would come out
+/// split by version rather than by failure, so nothing is written and the
+/// app's own version stays behind, which is what brings the card back to
+/// try both halves again. Build metadata is not skew — SemVer keeps it out
+/// of precedence, and the release job stamps one version into both.
+#[test]
+fn a_feed_on_another_release_moves_neither_half() {
+    for offered in ["9.9.8", "10.0.0"] {
+        let dir = tempfile::tempdir().unwrap();
+        let (feed_url, installed) = a_release_is_out(&dir);
+
+        let refused =
+            across(&CommandBeside::Ours(installed.clone()), &feed_url, offered).unwrap_err();
+
+        assert!(refused.contains(offered), "{offered}: {refused}");
+        assert!(refused.contains(RELEASE), "{offered}: {refused}");
+        assert!(
+            refused.contains("nothing was updated"),
+            "{offered}: {refused}"
+        );
+        assert_eq!(std::fs::read(&installed).unwrap(), INSTALLED, "{offered}");
+    }
+
+    let dir = tempfile::tempdir().unwrap();
+    let (feed_url, installed) = a_release_is_out(&dir);
+    let build_metadata = format!("{RELEASE}+ci");
+    assert_eq!(
+        across(&CommandBeside::Ours(installed), &feed_url, &build_metadata).unwrap(),
+        CommandHalf::Moved
+    );
+}
+
+/// A release that publishes no command for this machine cannot move the
+/// command that is installed on it, so it moves neither half rather than
+/// leaving one behind. The refusal names the target, because that is the
+/// only part a person can act on.
+#[test]
+fn a_release_with_no_command_for_this_target_stops_the_family() {
+    let dir = tempfile::tempdir().unwrap();
+    let (feed_url, installed) = a_release_is_out(&dir);
+
+    let refused = bring_command_across(
+        &CommandBeside::Ours(installed.clone()),
+        &feed_url,
+        RELEASE,
+        "sparc-unknown-none-elf",
+        TEST_KEY,
+    )
+    .unwrap_err();
+
+    assert!(refused.contains("sparc-unknown-none-elf"), "{refused}");
+    assert!(refused.contains("nothing was updated"), "{refused}");
+    assert_eq!(std::fs::read(&installed).unwrap(), INSTALLED);
+}
+
+/// Absence is not failure. A dmg or msi with no command beside it is the
+/// whole install already, and a command another installer owns is that
+/// installer's to move — neither stops the app from updating itself.
+#[test]
+fn no_command_or_one_another_installer_owns_lets_the_app_go_alone() {
+    let dir = tempfile::tempdir().unwrap();
+    let (feed_url, installed) = a_release_is_out(&dir);
+
+    for beside in [CommandBeside::Absent, CommandBeside::NotOurs] {
+        assert_eq!(
+            across(&beside, &feed_url, RELEASE).unwrap(),
+            CommandHalf::Untouched,
+            "{beside:?}"
+        );
+        assert_eq!(std::fs::read(&installed).unwrap(), INSTALLED, "{beside:?}");
+    }
+}
+
+/// The command half is signed for the same reason the app half is: the feed
+/// names a host, so a run has to be able to be handed bytes and refuse them.
+/// Driven by both shapes a bad download takes, and either way the command
+/// already installed is exactly as it was.
+#[test]
+fn a_command_binary_that_fails_verification_is_never_written() {
+    for (file, corrupt) in [
+        ("new-command", b"kendex AppImage bytes, and more".as_slice()),
+        ("new-command.sig", b"not a signature".as_slice()),
+    ] {
+        let dir = tempfile::tempdir().unwrap();
+        let (feed_url, installed) = a_release_is_out(&dir);
+        std::fs::write(dir.path().join(file), corrupt).unwrap();
+
+        let refused =
+            across(&CommandBeside::Ours(installed.clone()), &feed_url, RELEASE).unwrap_err();
+
+        assert!(
+            refused.contains("the kendex command could not be updated"),
+            "{file}: {refused}"
+        );
+        assert_eq!(std::fs::read(&installed).unwrap(), INSTALLED, "{file}");
+        assert!(!staged_path(&installed).exists(), "{file}");
+    }
+}
+
+/// The recovery the ordering exists for. A machine left split — a command
+/// already across, an app that would not follow — presses again, and the
+/// command half runs over bytes already at the release rather than refusing
+/// them, so the retry that fixes the app does not stall on the half that
+/// already worked.
+#[test]
+fn a_retry_over_a_command_already_across_is_not_refused() {
+    let dir = tempfile::tempdir().unwrap();
+    let (feed_url, installed) = a_release_is_out(&dir);
+    let beside = CommandBeside::Ours(installed.clone());
+
+    across(&beside, &feed_url, RELEASE).unwrap();
+    let again = across(&beside, &feed_url, RELEASE).unwrap();
+
+    assert_eq!(again, CommandHalf::Moved);
+    assert_eq!(std::fs::read(&installed).unwrap(), OFFERED);
+}
+
+/// A machine described by what is on it, so arms `for_cli` can only reach
+/// through a real filesystem are reachable here.
+#[derive(Default)]
+struct Machine {
+    present: Vec<PathBuf>,
+    links: Vec<(PathBuf, PathBuf)>,
+    arch: bool,
+}
+
+impl HostProbe for Machine {
+    fn replaceable(&self, _: &Path) -> bool {
+        true
+    }
+
+    fn exists(&self, path: &Path) -> bool {
+        self.present.iter().any(|p| p == path)
+    }
+
+    fn resolve(&self, path: &Path) -> PathBuf {
+        self.links
+            .iter()
+            .find(|(from, _)| from == path)
+            .map_or_else(|| path.to_owned(), |(_, to)| to.clone())
+    }
+
+    fn on_path(&self, _: &str) -> bool {
+        false
+    }
+
+    fn os_release(&self) -> Option<String> {
+        self.arch.then(|| "ID=arch\n".to_owned())
+    }
+}
+
+fn candidates(paths: &[&str]) -> Vec<PathBuf> {
+    paths.iter().map(PathBuf::from).collect()
+}
+
+/// `PATH` order decides which `kendex` a person runs, so it decides which
+/// one a family update replaces: the search reads `PATH` before the
+/// installer's own directories and stops at the first candidate that
+/// exists. Replacing a second copy further down would move the half nobody
+/// runs and leave the half they do.
+#[test]
+fn the_command_a_shell_resolves_first_is_the_one_replaced() {
+    let on_path = "/opt/bin/kendex";
+    let machine = Machine {
+        present: candidates(&[on_path, "/home/pat/.local/bin/kendex"]),
+        ..Machine::default()
+    };
+    let probed = command_candidates(
+        Path::new("/home/pat"),
+        Some(&std::ffi::OsString::from("/opt/bin")),
+    );
+
+    assert_eq!(
+        command_beside_app(&machine, &probed, None),
+        CommandBeside::Ours(on_path.into())
+    );
+}
+
+/// A copy another installer owns is never replaced, whether this build
+/// can name the command that owns it or not — and it is judged by the
+/// file behind the name, because a link on `PATH` is how a package's copy
+/// is reached without ever naming its prefix.
+#[test]
+fn a_command_another_installer_owns_is_never_ours() {
+    let named = candidates(&["/usr/bin/kendex"]);
+    let linked = candidates(&["/home/pat/.local/bin/kendex"]);
+    for (machine, probed) in [
+        (
+            Machine {
+                present: named.clone(),
+                ..Machine::default()
+            },
+            &named,
+        ),
+        (
+            Machine {
+                present: linked.clone(),
+                links: vec![(linked[0].clone(), named[0].clone())],
+                arch: true,
+            },
+            &linked,
+        ),
+    ] {
+        assert_eq!(
+            command_beside_app(&machine, probed, None),
+            CommandBeside::NotOurs,
+            "{probed:?}"
+        );
+    }
+}
+
+/// Two ways to have no command to move. Nothing installed under any
+/// candidate is a dmg or msi install; the app's own bytes reachable as
+/// `kendex` are not a command at all — written over, they would take the
+/// command binary and then be written back by the app half, leaving the
+/// machine with neither.
+#[test]
+fn nothing_installed_and_the_app_s_own_bytes_both_read_absent() {
+    let image = Path::new("/home/pat/.local/bin/kendex");
+    let probed = vec![image.to_owned()];
+    let empty = Machine::default();
+    assert_eq!(
+        command_beside_app(&empty, &probed, None),
+        CommandBeside::Absent
+    );
+
+    let only_the_app = Machine {
+        present: probed.clone(),
+        ..Machine::default()
+    };
+    assert_eq!(
+        command_beside_app(&only_the_app, &probed, Some(image)),
+        CommandBeside::Absent
+    );
+}
+
+/// `PATH` first, then the two directories `install.sh` chooses between,
+/// each named once — a launcher whose `PATH` already carries `.local/bin`
+/// must not have it probed twice.
+#[test]
+fn candidates_are_path_then_the_installer_s_own_dirs_without_repeats() {
+    let home = Path::new("/home/pat");
+    let path = std::ffi::OsString::from("/home/pat/.local/bin:/usr/bin");
+    let found = command_candidates(home, Some(&path));
+    assert_eq!(
+        found,
+        candidates(&[
+            &format!("/home/pat/.local/bin/{COMMAND_NAME}"),
+            &format!("/usr/bin/{COMMAND_NAME}"),
+            &format!("/usr/local/bin/{COMMAND_NAME}"),
+        ])
+    );
+
+    // No PATH at all still leaves the installer's own two.
+    assert_eq!(
+        command_candidates(home, None),
+        candidates(&[
+            &format!("/home/pat/.local/bin/{COMMAND_NAME}"),
+            &format!("/usr/local/bin/{COMMAND_NAME}"),
+        ])
+    );
+}
+
+#[test]
+fn fetched_urls_are_always_positional_arguments() {
+    assert_eq!(
+        curl_args("--output=/tmp/owned"),
+        [
+            "-fsS",
+            "--location",
+            "--max-redirs",
+            "3",
+            "--proto",
+            "=https,file",
+            "--proto-redir",
+            "=https",
+            "--",
+            "--output=/tmp/owned",
+        ]
+    );
+}
+
+fn artifact(bytes: &[u8], signature: &[u8]) -> SignedArtifact {
+    SignedArtifact {
+        bytes: bytes.to_vec(),
+        signature: signature.to_vec(),
+    }
+}
+
+/// The write both halves of both shells land through, read from both
+/// sides. A signature that checks out puts the download in place; the two
+/// shapes a bad download takes — bytes the signature does not cover, and a
+/// body that is no signature at all — are turned away by name, and leave
+/// what was installed exactly as it was. Neither arm leaves a staged file.
+#[test]
+fn an_artifact_is_written_only_when_its_signature_checks_out() {
+    let dir = tempfile::tempdir().unwrap();
+    let installed = dir.path().join("kendex.AppImage");
+    let already = b"the app already here";
+    std::fs::write(&installed, already).unwrap();
+
+    let tampered = artifact(b"tampered", TEST_SIGNATURE.as_bytes())
+        .install_at(&installed, TEST_KEY)
+        .unwrap_err();
+    assert!(
+        tampered.contains("signature verification failed"),
+        "{tampered}"
+    );
+    let malformed = artifact(OFFERED, b"not a signature")
+        .install_at(&installed, TEST_KEY)
+        .unwrap_err();
+    assert!(malformed.contains("not base64"), "{malformed}");
+    assert_eq!(std::fs::read(&installed).unwrap(), already);
+
+    artifact(OFFERED, TEST_SIGNATURE.as_bytes())
+        .install_at(&installed, TEST_KEY)
+        .unwrap();
+    assert_eq!(std::fs::read(&installed).unwrap(), OFFERED);
+    assert!(!staged_path(&installed).exists());
+}
+
+/// Two runs sharing one staged path would each rename the other's bytes into
+/// place, so the name carries the process id, and it stays a sibling of the
+/// target since a rename cannot cross filesystems.
+#[test]
+fn the_staged_file_is_a_sibling_named_for_this_process() {
+    let target = Path::new("/opt/kendex/kendex.AppImage");
+    let staged = staged_path(target);
+    assert_eq!(staged.parent(), target.parent());
+    let suffix = format!(".update.{}", std::process::id());
+    assert!(
+        staged.to_string_lossy().ends_with(&suffix),
+        "{}",
+        staged.display()
+    );
+}
+
+/// A run whose rename cannot land takes its own staged file away, or the
+/// directory collects one per process id that ever tried.
+#[test]
+fn a_replacement_that_cannot_land_leaves_no_staged_file() {
+    let dir = tempfile::tempdir().unwrap();
+    let target = dir.path().join("kendex.AppImage");
+    std::fs::create_dir(&target).unwrap();
+
+    assert!(replace_executable(&target, b"bytes").is_err());
+    assert!(!staged_path(&target).exists());
+}

--- a/crates/core/src/command_update/tests.rs
+++ b/crates/core/src/command_update/tests.rs
@@ -202,7 +202,11 @@ fn a_retry_over_a_command_already_across_is_not_refused() {
 /// through a real filesystem are reachable here.
 #[derive(Default)]
 struct Machine {
+    /// Paths this machine would run.
     present: Vec<PathBuf>,
+    /// Paths that are there and are not commands: a directory, or a data
+    /// file, carrying a command's name.
+    not_commands: Vec<PathBuf>,
     links: Vec<(PathBuf, PathBuf)>,
     arch: bool,
 }
@@ -213,6 +217,10 @@ impl HostProbe for Machine {
     }
 
     fn exists(&self, path: &Path) -> bool {
+        self.is_command(path) || self.not_commands.iter().any(|p| p == path)
+    }
+
+    fn is_command(&self, path: &Path) -> bool {
         self.present.iter().any(|p| p == path)
     }
 
@@ -254,7 +262,7 @@ fn the_command_a_shell_resolves_first_is_the_one_replaced() {
     );
 
     assert_eq!(
-        command_beside_app(&machine, &probed, None),
+        command_beside_app(&machine, &probed, &[]),
         CommandBeside::Ours(on_path.into())
     );
 }
@@ -280,12 +288,13 @@ fn a_command_another_installer_owns_is_never_ours() {
                 present: linked.clone(),
                 links: vec![(linked[0].clone(), named[0].clone())],
                 arch: true,
+                ..Machine::default()
             },
             &linked,
         ),
     ] {
         assert_eq!(
-            command_beside_app(&machine, probed, None),
+            command_beside_app(&machine, probed, &[]),
             CommandBeside::NotOurs,
             "{probed:?}"
         );
@@ -293,17 +302,16 @@ fn a_command_another_installer_owns_is_never_ours() {
 }
 
 /// Two ways to have no command to move. Nothing installed under any
-/// candidate is a dmg or msi install; the app's own bytes reachable as
-/// `kendex` are not a command at all — written over, they would take the
+/// candidate is a dmg or msi install; the running app reachable as
+/// `kendex` is not a command to carry — written over, it would take the
 /// command binary and then be written back by the app half, leaving the
 /// machine with neither.
 #[test]
-fn nothing_installed_and_the_app_s_own_bytes_both_read_absent() {
-    let image = Path::new("/home/pat/.local/bin/kendex");
-    let probed = vec![image.to_owned()];
-    let empty = Machine::default();
+fn nothing_installed_and_the_running_app_both_read_absent() {
+    let image = PathBuf::from("/home/pat/.local/bin/kendex");
+    let probed = vec![image.clone()];
     assert_eq!(
-        command_beside_app(&empty, &probed, None),
+        command_beside_app(&Machine::default(), &probed, &[]),
         CommandBeside::Absent
     );
 
@@ -312,7 +320,65 @@ fn nothing_installed_and_the_app_s_own_bytes_both_read_absent() {
         ..Machine::default()
     };
     assert_eq!(
-        command_beside_app(&only_the_app, &probed, Some(image)),
+        command_beside_app(&only_the_app, &probed, &[image]),
+        CommandBeside::Absent
+    );
+}
+
+/// Windows is the case the updater's own path cannot cover. It judges no
+/// path there, so nothing but the running executable itself keeps the app
+/// out of the search — and the desktop executable is `kendex.exe`, the
+/// name the command carries, so an install directory on `PATH` puts the
+/// app first in line. Taken for the command, it would be overwritten with
+/// the CLI binary before the updater ever ran.
+#[test]
+fn a_windows_app_on_path_is_never_taken_for_the_command() {
+    let exe = PathBuf::from("C:/Program Files/kendex/kendex.exe");
+    let machine = Machine {
+        present: vec![exe.clone()],
+        ..Machine::default()
+    };
+    let probed = vec![exe.clone()];
+
+    // What the updater offers on Windows: no path at all.
+    assert_eq!(
+        command_beside_app(&machine, &probed, &[]),
+        CommandBeside::Ours(exe.clone()),
+        "the fixture has to reach the app before the exclusion can be what stops it"
+    );
+    assert_eq!(
+        command_beside_app(&machine, &probed, &[exe]),
+        CommandBeside::Absent
+    );
+}
+
+/// A candidate has to be a command. A directory and a data file each carry
+/// the name in a writable place, which answers every other question the
+/// way a real command does, and each would take a release binary written
+/// over it. The search passes both and lands on the command behind them.
+#[test]
+fn a_directory_or_a_data_file_named_kendex_is_not_a_command() {
+    let real = PathBuf::from("/usr/local/bin/kendex");
+    let machine = Machine {
+        present: vec![real.clone()],
+        not_commands: candidates(&["/opt/a/kendex", "/opt/b/kendex"]),
+        ..Machine::default()
+    };
+    let probed = candidates(&["/opt/a/kendex", "/opt/b/kendex", "/usr/local/bin/kendex"]);
+
+    assert_eq!(
+        command_beside_app(&machine, &probed, &[]),
+        CommandBeside::Ours(real)
+    );
+
+    // With nothing runnable behind them they stop nothing: the answer is
+    // that there is no command here, not that one of them is it.
+    let neither = Machine {
+        not_commands: candidates(&["/opt/a/kendex", "/opt/b/kendex"]),
+        ..Machine::default()
+    };
+    assert_eq!(
+        command_beside_app(&neither, &probed[..2], &[]),
         CommandBeside::Absent
     );
 }

--- a/crates/core/src/command_update/tests.rs
+++ b/crates/core/src/command_update/tests.rs
@@ -1,5 +1,9 @@
 use super::*;
 
+#[path = "../../../fixture_url.rs"]
+mod fixture_url;
+use fixture_url::file_url;
+
 /// A throwaway minisign keypair signing `OFFERED`, so the admitted arm
 /// runs the real check rather than a stub standing in for it. One pair
 /// serves both halves: the app and the command are held to one key.
@@ -20,20 +24,27 @@ const TARGET: &str = "x86_64-unknown-linux-gnu";
 /// behind it. What each arm does to that command is the whole difference
 /// between them.
 fn a_release_is_out(dir: &tempfile::TempDir) -> (String, PathBuf) {
-    let home = dir.path();
+    a_release_is_out_under(dir.path())
+}
+
+fn a_release_is_out_under(home: &Path) -> (String, PathBuf) {
+    std::fs::create_dir_all(home).unwrap();
     let installed = home.join("kendex");
     std::fs::write(&installed, INSTALLED).unwrap();
     std::fs::write(home.join("new-command"), OFFERED).unwrap();
     std::fs::write(home.join("new-command.sig"), TEST_SIGNATURE).unwrap();
+    // A path spliced into a URL is not a URL: a home directory holding a
+    // space or a `#` addresses a different file, or none. The feed is JSON,
+    // which has no literal string, so the URL goes through serde too.
     std::fs::write(
         home.join("feed.json"),
         format!(
-            r#"{{"schema": 1, "version": "{RELEASE}", "assets": {{"{TARGET}": "file://{}/new-command"}}}}"#,
-            home.display()
+            r#"{{"schema": 1, "version": "{RELEASE}", "assets": {{"{TARGET}": {}}}}}"#,
+            serde_json::to_string(&file_url(&home.join("new-command"))).unwrap()
         ),
     )
     .unwrap();
-    (format!("file://{}/feed.json", home.display()), installed)
+    (file_url(&home.join("feed.json")), installed)
 }
 
 fn across(beside: &CommandBeside, feed: &str, release: &str) -> Result<CommandHalf, String> {
@@ -53,6 +64,20 @@ fn the_command_lands_on_the_release_the_app_is_installing() {
     assert_eq!(half, CommandHalf::Moved);
     assert_eq!(std::fs::read(&installed).unwrap(), OFFERED);
     assert!(!staged_path(&installed).exists());
+}
+
+/// The same arm with the release sitting under a directory whose name holds
+/// characters a URL reserves. A space and a `#` are ordinary in a Windows
+/// profile directory, and spelled into a URL rather than encoded they
+/// address a different file, or none.
+#[test]
+fn a_release_under_a_name_a_url_reserves_is_still_fetched() {
+    let dir = tempfile::tempdir().unwrap();
+    let (feed_url, installed) = a_release_is_out_under(&dir.path().join("my release #1"));
+
+    across(&CommandBeside::Ours(installed.clone()), &feed_url, RELEASE).unwrap();
+
+    assert_eq!(std::fs::read(&installed).unwrap(), OFFERED);
 }
 
 /// Skew, driven from both sides: the app installing a release the feed is

--- a/crates/core/src/command_update/tests.rs
+++ b/crates/core/src/command_update/tests.rs
@@ -291,6 +291,7 @@ fn a_command_another_installer_owns_is_never_ours_and_names_its_owner() {
             },
             &named,
             InstallChannel::Managed {
+                manager: "an AUR helper".to_owned(),
                 command: "update kendex with your AUR helper".to_owned(),
             },
         ),

--- a/crates/core/src/env.rs
+++ b/crates/core/src/env.rs
@@ -183,13 +183,15 @@ impl Env {
         self.cache_dir.join(APP_DIR).join("app-update.lock")
     }
 
-    /// Where an installer records the `kendex` command it installed, one
-    /// absolute path on one line.
+    /// Where an installer records the `kendex` command it installed: one
+    /// absolute path, then the SHA-256 of the bytes it put there, a line
+    /// each.
     ///
     /// Being executable and being named `kendex` is not being kendex, so
-    /// the desktop app carries a command across only when it is the one
-    /// written here. `install.sh` writes it and `kendex update` refreshes
-    /// it for the binary it is running as.
+    /// the desktop app carries a command across only when it is the file
+    /// written here — the path says where and the digest says which, since
+    /// a name outlives whatever answered to it. `install.sh` writes both,
+    /// and every replacement rewrites them for the bytes that landed.
     pub fn installed_command_file(&self) -> PathBuf {
         self.data_dir.join(APP_DIR).join("installed-command")
     }

--- a/crates/core/src/env.rs
+++ b/crates/core/src/env.rs
@@ -183,6 +183,17 @@ impl Env {
         self.cache_dir.join(APP_DIR).join("app-update.lock")
     }
 
+    /// Where an installer records the `kendex` command it installed, one
+    /// absolute path on one line.
+    ///
+    /// Being executable and being named `kendex` is not being kendex, so
+    /// the desktop app carries a command across only when it is the one
+    /// written here. `install.sh` writes it and `kendex update` refreshes
+    /// it for the binary it is running as.
+    pub fn installed_command_file(&self) -> PathBuf {
+        self.data_dir.join(APP_DIR).join("installed-command")
+    }
+
     /// The Linux desktop AppImage `install.sh` writes — the one copy of the
     /// app the CLI is allowed to replace.
     pub fn app_image_file(&self) -> PathBuf {

--- a/crates/core/src/fs.rs
+++ b/crates/core/src/fs.rs
@@ -10,6 +10,22 @@ mod lock;
 pub(crate) use links::{points_at, resolved, spelling};
 pub(crate) use lock::{LockedFile, open_read_no_follow};
 
+/// Whether a path is something a shell would run: a regular file with an
+/// execute bit. Being present is a different question — a directory, or a
+/// data file, can carry the name of a command and answer yes to it.
+pub fn is_executable(path: &Path) -> bool {
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        fs::metadata(path)
+            .is_ok_and(|meta| meta.is_file() && meta.permissions().mode() & 0o111 != 0)
+    }
+    #[cfg(not(unix))]
+    {
+        path.is_file()
+    }
+}
+
 /// Write via a sibling temp file + rename so readers never see a torn file.
 /// A symlink at the path is followed: the file it points at is replaced and
 /// the link stays — renaming over the link itself would swap a user's

--- a/crates/core/src/guard/mod.rs
+++ b/crates/core/src/guard/mod.rs
@@ -29,12 +29,13 @@ use crate::process::Hardened;
 
 mod repo;
 mod resolve;
+use crate::fs::is_executable;
 pub use repo::Repo;
 pub use resolve::Installed;
 /// The tool directories the verbs search, in order — the installer's own
 /// list, pinned against it by `guard_hooks::the_search_roots_match…`.
 pub use resolve::SKILL_ROOTS as SEARCH_ROOTS;
-use resolve::{bind, is_executable};
+use resolve::bind;
 
 /// The package that owns the checks and the git shims.
 pub const SKILL: &str = "growth-guards";

--- a/crates/core/src/guard/resolve.rs
+++ b/crates/core/src/guard/resolve.rs
@@ -9,6 +9,7 @@
 use std::path::{Path, PathBuf};
 
 use crate::error::Result;
+use crate::fs::is_executable;
 
 use super::{SKILL, guard_err};
 
@@ -249,19 +250,6 @@ fn project_root(repo: &super::Repo) -> Option<PathBuf> {
             return None;
         }
         dir = dir.parent()?;
-    }
-}
-
-pub(super) fn is_executable(path: &Path) -> bool {
-    #[cfg(unix)]
-    {
-        use std::os::unix::fs::PermissionsExt;
-        std::fs::metadata(path)
-            .is_ok_and(|meta| meta.is_file() && meta.permissions().mode() & 0o111 != 0)
-    }
-    #[cfg(not(unix))]
-    {
-        path.is_file()
     }
 }
 

--- a/crates/core/src/hash.rs
+++ b/crates/core/src/hash.rs
@@ -131,6 +131,18 @@ pub fn hash_bytes(bytes: &[u8]) -> String {
     hex(&hasher.finalize())
 }
 
+/// Plain SHA-256 over these bytes, hex, with nothing framed in — the
+/// digest `sha256sum` and `shasum -a 256` print for a file holding them.
+///
+/// [`hash_bytes`] is kendex's own encoding and only kendex can produce it.
+/// This one is what a shell script and this build can both compute over one
+/// file and get the same answer for, which is what the installed-command
+/// record needs: `install.sh` writes the digest of the binary it installed
+/// and the app checks the file it found against it.
+pub fn sha256_hex(bytes: &[u8]) -> String {
+    hex(&Sha256::digest(bytes))
+}
+
 /// The hash an in-memory rendered tree will have once written — mirrors
 /// `hash_tree` so plans can compare desired vs. disk without materializing.
 pub fn hash_files(files: &[(std::path::PathBuf, Vec<u8>)]) -> String {

--- a/crates/core/src/install_channel.rs
+++ b/crates/core/src/install_channel.rs
@@ -19,6 +19,15 @@ const BREW_PREFIXES: [&str; 3] = [
 /// Where the AUR `kendex-bin` package puts the desktop app.
 const PACKAGED_APP_IMAGE: &str = "/usr/lib/kendex/kendex.AppImage";
 
+/// What to call the installer that owns a path. Fixed text, decided by
+/// which branch of the detection ran, so no value read off the machine
+/// ever reaches it — the rule the command string already lives under.
+const HOMEBREW: &str = "Homebrew";
+/// Every Arch arm gets the class, never the tool. `paru` sitting on `PATH`
+/// today says nothing about what fetched the package, so naming it would
+/// be inventing the one fact this build does not have.
+const AUR_HELPER: &str = "an AUR helper";
+
 /// How the running install may be brought up to date.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Type)]
 #[serde(
@@ -29,9 +38,16 @@ const PACKAGED_APP_IMAGE: &str = "/usr/lib/kendex/kendex.AppImage";
 pub enum InstallChannel {
     /// The running install is ours to replace.
     Direct,
-    /// A system package manager owns these bytes; `command` brings them
-    /// current and is the only thing to offer.
-    Managed { command: String },
+    /// A system package manager owns these bytes. `manager` names it and
+    /// `command` brings them current; both are decided where the manager
+    /// is detected, so nothing downstream has to read a name back out of
+    /// the command string and guess.
+    ///
+    /// `manager` is not optional. Every branch that reaches here knows
+    /// which installer it found, and a detection that could not say who
+    /// owns a path is [`InstallChannel::Unknown`] — which names nobody and
+    /// offers nothing, and is where the honest degradation already lives.
+    Managed { manager: String, command: String },
     /// Not recognised: say a release is out, never replace anything, never
     /// invent a command.
     Unknown,
@@ -43,8 +59,8 @@ impl InstallChannel {
     pub fn allow_replacement(&self) -> Result<(), String> {
         match self {
             Self::Direct => Ok(()),
-            Self::Managed { command } => Err(format!(
-                "a package manager owns this install; update it with: {command}"
+            Self::Managed { manager, command } => Err(format!(
+                "this install came from {manager}; update it with: {command}"
             )),
             Self::Unknown => Err(
                 "kendex cannot tell how this copy was installed, so it will not replace it"
@@ -248,6 +264,7 @@ pub fn for_app(install: &AppInstall, probe: &dyn HostProbe) -> InstallChannel {
 pub fn for_cli(exe: &Path, probe: &dyn HostProbe) -> InstallChannel {
     if starts_with_any(exe, &BREW_PREFIXES) {
         return InstallChannel::Managed {
+            manager: HOMEBREW.to_owned(),
             command: "brew upgrade kendex-cli".to_owned(),
         };
     }
@@ -294,7 +311,10 @@ fn arch_channel(package: ArchPackage, probe: &dyn HostProbe) -> InstallChannel {
     } else {
         format!("update {name} with your AUR helper")
     };
-    InstallChannel::Managed { command }
+    InstallChannel::Managed {
+        manager: AUR_HELPER.to_owned(),
+        command,
+    }
 }
 
 fn replaceable_or_unknown(path: &Path, probe: &dyn HostProbe) -> InstallChannel {

--- a/crates/core/src/install_channel.rs
+++ b/crates/core/src/install_channel.rs
@@ -151,6 +151,13 @@ pub trait HostProbe {
     /// Whether a path is present on this machine.
     fn exists(&self, path: &Path) -> bool;
 
+    /// Whether a path is a command this machine would run: a regular file
+    /// with an execute bit. Presence is a weaker question — a directory, or
+    /// a data file, can carry a command's name and still never run — and
+    /// answering the weaker one is how a search settles on a path a shell
+    /// would have passed over.
+    fn is_command(&self, path: &Path) -> bool;
+
     /// The path with every symlink followed, or the path itself where it
     /// cannot be resolved. Which install owns a file is a fact about the
     /// file, never about the name it was reached by: a Homebrew formula
@@ -189,6 +196,10 @@ impl HostProbe for Host {
 
     fn exists(&self, path: &Path) -> bool {
         path.exists()
+    }
+
+    fn is_command(&self, path: &Path) -> bool {
+        crate::fs::is_executable(path)
     }
 
     fn resolve(&self, path: &Path) -> PathBuf {

--- a/crates/core/src/install_channel.rs
+++ b/crates/core/src/install_channel.rs
@@ -181,6 +181,10 @@ pub trait HostProbe {
     /// the path it was exec'd with, symlinks intact.
     fn resolve(&self, path: &Path) -> PathBuf;
 
+    /// The plain SHA-256 of a file's bytes, absent where it cannot be read.
+    /// A name kendex once answered to says nothing about what answers now.
+    fn digest(&self, path: &Path) -> Option<String>;
+
     /// Whether a command is on `PATH`.
     fn on_path(&self, command: &str) -> bool;
 
@@ -220,6 +224,12 @@ impl HostProbe for Host {
 
     fn resolve(&self, path: &Path) -> PathBuf {
         std::fs::canonicalize(path).unwrap_or_else(|_| path.to_owned())
+    }
+
+    fn digest(&self, path: &Path) -> Option<String> {
+        std::fs::read(path)
+            .ok()
+            .map(|b| crate::hash::sha256_hex(&b))
     }
 
     fn on_path(&self, command: &str) -> bool {
@@ -262,20 +272,29 @@ pub fn for_app(install: &AppInstall, probe: &dyn HostProbe) -> InstallChannel {
 /// call, once, on the path it will also write to. Resolving here instead
 /// would decide about the file while the caller still held the link.
 pub fn for_cli(exe: &Path, probe: &dyn HostProbe) -> InstallChannel {
+    package_owner(exe, probe).unwrap_or_else(|| replaceable_or_unknown(exe, probe))
+}
+
+/// The package manager whose prefix `exe` sits under, where one does.
+///
+/// Split from [`for_cli`], whose `Unknown` is both "a manager this build
+/// cannot name owns it" and "nobody owns it and we cannot write it" —
+/// opposites, to a caller holding proof the file is kendex's.
+pub fn package_owner(exe: &Path, probe: &dyn HostProbe) -> Option<InstallChannel> {
     if starts_with_any(exe, &BREW_PREFIXES) {
-        return InstallChannel::Managed {
+        return Some(InstallChannel::Managed {
             manager: HOMEBREW.to_owned(),
             command: "brew upgrade kendex-cli".to_owned(),
-        };
+        });
     }
     if system_owned(exe) {
         let package = match probe.exists(Path::new(PACKAGED_APP_IMAGE)) {
             true => ArchPackage::Bin,
             false => ArchPackage::Cli,
         };
-        return arch_channel(package, probe);
+        return Some(arch_channel(package, probe));
     }
-    replaceable_or_unknown(exe, probe)
+    None
 }
 
 /// The two AUR packages that carry kendex. The name comes from where the

--- a/crates/core/src/install_channel/tests.rs
+++ b/crates/core/src/install_channel/tests.rs
@@ -72,10 +72,17 @@ impl HostProbe for Fake {
     }
 }
 
-fn managed(command: &str) -> InstallChannel {
+fn managed(manager: &str, command: &str) -> InstallChannel {
     InstallChannel::Managed {
+        manager: manager.to_owned(),
         command: command.to_owned(),
     }
+}
+
+/// Every Arch arm names the class rather than the helper it found, so the
+/// expectation is written once here and read at each site.
+fn aur(command: &str) -> InstallChannel {
+    managed(AUR_HELPER, command)
 }
 
 fn app_image(path: &str) -> AppInstall {
@@ -115,7 +122,7 @@ fn a_packaged_appimage_names_its_package_even_where_the_file_is_writable() {
         .on_path("paru");
     assert_eq!(
         for_app(&app_image(PACKAGED_APP_IMAGE), &probe),
-        managed("paru -S kendex-bin")
+        aur("paru -S kendex-bin")
     );
 }
 
@@ -131,7 +138,7 @@ fn an_arch_derivative_naming_arch_in_id_like_is_recognised() {
     let probe = Fake::default().os_release(CACHYOS).on_path("yay");
     assert_eq!(
         for_app(&app_image(PACKAGED_APP_IMAGE), &probe),
-        managed("yay -S kendex-bin")
+        aur("yay -S kendex-bin")
     );
 }
 
@@ -154,7 +161,7 @@ fn with_no_aur_helper_the_command_is_helper_neutral_prose() {
     let probe = Fake::default().os_release(ARCH);
     assert_eq!(
         for_app(&app_image(PACKAGED_APP_IMAGE), &probe),
-        managed("update kendex-bin with your AUR helper")
+        aur("update kendex-bin with your AUR helper")
     );
 }
 
@@ -166,7 +173,7 @@ fn paru_wins_over_yay_when_both_are_installed() {
         .on_path("paru");
     assert_eq!(
         for_app(&app_image(PACKAGED_APP_IMAGE), &probe),
-        managed("paru -S kendex-bin")
+        aur("paru -S kendex-bin")
     );
 }
 
@@ -242,7 +249,7 @@ fn a_brew_linked_cli_is_brews_to_upgrade_however_it_was_reached() {
         for reached in [linked, cellar] {
             assert_eq!(
                 for_cli(&probe.resolve(Path::new(reached)), &probe),
-                managed("brew upgrade kendex-cli"),
+                managed(HOMEBREW, "brew upgrade kendex-cli"),
                 "{reached}"
             );
         }
@@ -279,7 +286,7 @@ fn an_appimage_reached_through_a_link_belongs_to_whatever_it_points_at() {
         install,
         AppInstall::AppImage(Some(PathBuf::from(PACKAGED_APP_IMAGE)))
     );
-    assert_eq!(for_app(&install, &probe), managed("paru -S kendex-bin"));
+    assert_eq!(for_app(&install, &probe), aur("paru -S kendex-bin"));
 }
 
 #[test]
@@ -302,22 +309,25 @@ fn the_packaged_cli_names_whichever_package_put_it_there() {
         .os_release(ARCH)
         .on_path("paru")
         .present(PACKAGED_APP_IMAGE);
-    assert_eq!(for_cli(exe, &both), managed("paru -S kendex-bin"));
+    assert_eq!(for_cli(exe, &both), aur("paru -S kendex-bin"));
     let cli_only = Fake::default().os_release(ARCH).on_path("paru");
-    assert_eq!(for_cli(exe, &cli_only), managed("paru -S kendex"));
+    assert_eq!(for_cli(exe, &cli_only), aur("paru -S kendex"));
 }
 
 /// Anything a resolver read off the machine — a distro name, an os-release
-/// line, the path itself — stays out of the string a person is told to run.
+/// line, the path itself — stays out of the string a person is told to run,
+/// and out of the manager named beside it. Both are fixed text picked by
+/// which branch of the detection ran.
 #[test]
 fn nothing_read_from_the_machine_reaches_a_command_string() {
     let hostile = "ID=arch\nPRETTY_NAME=\"; rm -rf /\"\nID_LIKE=\"arch $(whoami)\"\n";
     let exe = Path::new("/usr/bin/kendex; rm -rf /");
     let probe = Fake::default().os_release(hostile).on_path("paru");
-    let InstallChannel::Managed { command } = for_cli(exe, &probe) else {
+    let InstallChannel::Managed { manager, command } = for_cli(exe, &probe) else {
         panic!("a package-owned path on Arch is Managed");
     };
     assert_eq!(command, "paru -S kendex");
+    assert_eq!(manager, AUR_HELPER);
 }
 
 #[test]
@@ -338,8 +348,10 @@ fn an_os_release_value_is_read_unquoted_and_whole() {
 fn in_place_replacement_is_refused_off_a_direct_install() {
     assert_eq!(InstallChannel::Direct.allow_replacement(), Ok(()));
     assert_eq!(
-        managed("paru -S kendex-bin").allow_replacement(),
-        Err("a package manager owns this install; update it with: paru -S kendex-bin".to_owned())
+        aur("paru -S kendex-bin").allow_replacement(),
+        Err(format!(
+            "this install came from {AUR_HELPER}; update it with: paru -S kendex-bin"
+        ))
     );
     assert!(InstallChannel::Unknown.allow_replacement().is_err());
 }
@@ -544,4 +556,25 @@ fn judged_path_hands_over_the_file_for_app_approved() {
 
     assert_eq!(AppInstall::WindowsInstaller.judged_path(), None);
     assert_eq!(AppInstall::AppImage(None).judged_path(), None);
+}
+
+/// The manager names are what a person reads on the card, so they are
+/// pinned by value here rather than through the constants every per-branch
+/// test compares against. Two managers sharing one name pass all of those
+/// and still send a Homebrew user to an AUR helper.
+#[test]
+fn each_installer_is_named_as_itself() {
+    let named = |channel| match channel {
+        InstallChannel::Managed { manager, .. } => manager,
+        other => panic!("expected a managed channel, got {other:?}"),
+    };
+    let brew = Path::new("/opt/homebrew/Cellar/kendex-cli/5.0.1/bin/kendex");
+    let arch = Fake::default().os_release(ARCH).on_path("paru");
+
+    assert_eq!(named(for_cli(brew, &Fake::default())), "Homebrew");
+    assert_eq!(
+        named(for_cli(Path::new("/usr/bin/kendex"), &arch)),
+        "an AUR helper"
+    );
+    assert_ne!(HOMEBREW, AUR_HELPER);
 }

--- a/crates/core/src/install_channel/tests.rs
+++ b/crates/core/src/install_channel/tests.rs
@@ -56,6 +56,12 @@ impl HostProbe for Fake {
         self.present.iter().any(|p| Path::new(p) == path)
     }
 
+    /// Nothing routed through this fake asks either: which installer owns
+    /// a path is a question about the path, not about the bytes at it.
+    fn digest(&self, _: &Path) -> Option<String> {
+        None
+    }
+
     fn on_path(&self, command: &str) -> bool {
         self.on_path.iter().any(|c| c == command)
     }

--- a/crates/core/src/install_channel/tests.rs
+++ b/crates/core/src/install_channel/tests.rs
@@ -42,6 +42,12 @@ impl Fake {
 }
 
 impl HostProbe for Fake {
+    /// Nothing routed through this fake asks; `for_app` and `for_cli`
+    /// judge a path they were handed rather than looking one up.
+    fn is_command(&self, path: &Path) -> bool {
+        self.exists(path)
+    }
+
     fn replaceable(&self, path: &Path) -> bool {
         self.replaceable.iter().any(|p| Path::new(p) == path)
     }

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -14,6 +14,7 @@ pub mod base;
 pub(crate) mod capture;
 pub mod check_catalog;
 pub mod clock;
+pub mod command_update;
 pub mod configedit;
 pub mod discover;
 pub mod drift;

--- a/crates/fixture_url.rs
+++ b/crates/fixture_url.rs
@@ -1,8 +1,8 @@
-//! The one `file://` URL builder the CLI's fixtures share. Kept beside
-//! `src/` so cargo does not build it as a test target of its own, and
-//! separate from `crates/test_util.rs` because it needs the `url`
-//! dev-dependency that only this crate carries — and named for what it
-//! holds, so neither include can resolve to the other file by accident.
+//! The one `file://` URL builder the fixtures share. Kept beside
+//! `test_util.rs` so cargo does not build it as a test target of its own,
+//! and separate from it because it needs a `url` dev-dependency that only
+//! the crates including this file carry — and named for what it holds, so
+//! neither include can resolve to the other file by accident.
 
 use std::path::Path;
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -293,11 +293,11 @@ lives in one capability table read by core and UI.
   zero. Every read the app starts with runs beside the others.
 - **Discovery is unsigned; one pinned key covers a document binding each
   download to its release and target.** Off the launch path, one transaction
-  reads the feed six-hourly at most, keeps the last result beside any error
-  and never follows the final link; a preference gates contact; only debug
-  builds honor `KENDEX_UPDATE_FEED`. Replacing needs the running path
-  writable, outside a system prefix; a package prefix names its command,
-  anything else neither. Either shell carries both halves, version marker last.
+  reads the feed six-hourly, keeps the last result and error, following no
+  final link; a preference gates it; debug builds alone honor
+  `KENDEX_UPDATE_FEED`. Replacing needs the running path writable, outside a
+  system prefix; a package prefix names its command and the card says which,
+  anything else neither. Either shell carries a command it owns, marker last.
 - Commands that touch disk, git, or a subprocess are
   `#[tauri::command(async)]`. Only window operations stay synchronous.
 - No database: manifests, locks, and native dirs are the state; scans are

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -294,10 +294,10 @@ lives in one capability table read by core and UI.
 - **Discovery is unsigned; one pinned key covers a document binding each
   download to its release and target.** Off the launch path, one transaction
   reads the feed six-hourly at most, keeps the last result beside any error
-  and never follows the final link; a preference gates automatic contact; only
-  debug builds honor `KENDEX_UPDATE_FEED`. Replacing needs the path behind the
-  running one writable, outside a system prefix; a package prefix names its
-  command instead, anything else neither. A sidebar card offers whichever.
+  and never follows the final link; a preference gates contact; only debug
+  builds honor `KENDEX_UPDATE_FEED`. Replacing needs the running path
+  writable, outside a system prefix; a package prefix names its command,
+  anything else neither. Either shell carries both halves, version marker last.
 - Commands that touch disk, git, or a subprocess are
   `#[tauri::command(async)]`. Only window operations stay synchronous.
 - No database: manifests, locks, and native dirs are the state; scans are

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -293,8 +293,8 @@ lives in one capability table read by core and UI.
   zero. Every read the app starts with runs beside the others.
 - **Discovery is unsigned; one pinned key covers a document binding each
   download to its release and target.** Off the launch path, one transaction
-  reads the feed six-hourly, keeps the last result and error, following no
-  final link; a preference gates it; debug builds alone honor
+  reads the feed six-hourly at most, keeps the last result and error,
+  following no final link; a preference gates it; debug builds alone honor
   `KENDEX_UPDATE_FEED`. Replacing needs the running path writable, outside a
   system prefix; a package prefix names its command and the card says which,
   anything else neither. Either shell carries a command it owns, marker last.

--- a/install.sh
+++ b/install.sh
@@ -60,6 +60,17 @@ base="https://github.com/$repo/releases/download/$version"
 work="$(mktemp -d)" || { echo "install.sh: nowhere to download to" >&2; exit 1; }
 trap 'rm -rf "$work"' EXIT
 
+# Where kendex keeps its own state, spelled the way the app's resolver
+# spells it — `dirs::data_dir()`, which is XDG on Linux and Application
+# Support on macOS. Both ends have to agree or the app reads an empty
+# directory and decides the command is nobody's.
+kendex_data() {
+  case "$kind" in
+    macos) printf '%s' "$HOME/Library/Application Support/kendex" ;;
+    *) printf '%s' "${XDG_DATA_HOME:-$HOME/.local/share}/kendex" ;;
+  esac
+}
+
 # Pick a bin dir already on PATH; prefer a writable user dir over sudo.
 bindir=""
 for candidate in "$HOME/.local/bin" "/usr/local/bin"; do
@@ -106,6 +117,18 @@ install_cli() {
     sudo install -D -m 0755 "$work/kendex" "$bindir/kendex"
   fi
   echo "Installed the kendex command to $bindir/kendex"
+  # What this script installed, so the desktop app can tell this file from
+  # any other executable someone has named `kendex` — a wrapper script in a
+  # writable directory answers every other test the same way, and the app
+  # would otherwise write a release binary over it. Failing to record it
+  # costs the app-side update, never the install, so it is reported and the
+  # run continues.
+  state="$(kendex_data)"
+  if mkdir -p "$state" 2>/dev/null && printf '%s\n' "$bindir/kendex" > "$state/installed-command"; then
+    :
+  else
+    echo "install.sh: could not record the command's path in $state; the desktop app will not update it." >&2
+  fi
 }
 
 # One icon size into the theme directory it belongs to.
@@ -172,7 +195,7 @@ desktop_arg() {
 install_app_linux() {
   local data libdir
   data="${XDG_DATA_HOME:-$HOME/.local/share}"
-  libdir="$data/kendex"
+  libdir="$(kendex_data)"
   echo "Downloading the desktop app…"
   if ! curl -fSL --proto '=https' -o "$work/kendex.AppImage" \
       "$base/kendex_${plain}_${appimage_arch}.AppImage"; then

--- a/install.sh
+++ b/install.sh
@@ -123,11 +123,36 @@ install_cli() {
   # would otherwise write a release binary over it. Failing to record it
   # costs the app-side update, never the install, so it is reported and the
   # run continues.
+  #
+  # The path and the digest of the bytes at it, one per line. A path is a
+  # name, and the file behind a name can be replaced: without the digest a
+  # wrapper written where this command used to be reads as this command.
   state="$(kendex_data)"
-  if mkdir -p "$state" 2>/dev/null && printf '%s\n' "$bindir/kendex" > "$state/installed-command"; then
+  digest="$(sha256_of "$bindir/kendex")" || digest=""
+  if [ -n "$digest" ] && mkdir -p "$state" 2>/dev/null \
+     && printf '%s\n%s\n' "$bindir/kendex" "$digest" > "$state/installed-command"; then
     :
   else
-    echo "install.sh: could not record the command's path in $state; the desktop app will not update it." >&2
+    echo "install.sh: could not record the command's identity in $state; the desktop app will not update it." >&2
+  fi
+}
+
+# The SHA-256 of a file, hex and nothing else, however this machine spells
+# it. Linux ships `sha256sum` with coreutils — which this script already
+# needs for `install` — and macOS ships `shasum`; `openssl` covers a machine
+# with neither. Every one of them prints the digest first and the filename
+# after, so one `cut` reads all three. No tool means no digest, which the
+# caller reports rather than recording a line the app cannot check.
+sha256_of() {
+  if command -v sha256sum >/dev/null 2>&1; then
+    sha256sum "$1" | cut -d' ' -f1
+  elif command -v shasum >/dev/null 2>&1; then
+    shasum -a 256 "$1" | cut -d' ' -f1
+  elif command -v openssl >/dev/null 2>&1; then
+    # `-r` for the same "digest filename" shape the other two print.
+    openssl dgst -sha256 -r "$1" | cut -d' ' -f1
+  else
+    return 1
   fi
 }
 

--- a/tools/size-ratchet-baseline.tsv
+++ b/tools/size-ratchet-baseline.tsv
@@ -1,5 +1,6 @@
 .github/workflows/review-gate-writer.yml	662
 .github/workflows/skill-tests.yml	514
+crates/app/src/app_update.rs	403
 crates/core/src/engine/detach.rs	441
 crates/core/src/engine/pi_hooks_move/migrated.rs	539
 crates/core/src/engine/pi_hooks_move/mod.rs	503

--- a/ui/src/bindings.ts
+++ b/ui/src/bindings.ts
@@ -17,12 +17,22 @@ export const commands = {
 	 */
 	appUpdateChannel: () => typedError<InstallChannel, string>(__TAURI_INVOKE("app_update_channel")),
 	/**
-	 *  Replace this install with the latest release and relaunch into it. The
-	 *  manifest names a download and the signature over it; the release's own
-	 *  digests document names which download this release published for this
-	 *  target, and the bytes are held to both before anything is installed.
-	 *  The discovery feed never supplies an install URL. A failure leaves the
-	 *  running app untouched and usable.
+	 *  Replace this install with the latest release and relaunch into it,
+	 *  carrying the `kendex` command across with it. The manifest names a
+	 *  download and the signature over it; the release's own digests document
+	 *  names which download this release published for this target, and the
+	 *  app's bytes are held to both before anything is installed. The
+	 *  discovery feed never supplies an install URL, and the command's own
+	 *  bytes are held to the same key the CLI holds them to. A failure leaves
+	 *  the running app untouched and usable.
+	 * 
+	 *  The command moves first. What this flow's notice card reads is the
+	 *  app's own baked version, so the app is the state marker here and is
+	 *  written last — the mirror of `kendex update`, where the command's baked
+	 *  version is the marker and the command is written last. A command that
+	 *  will not move therefore leaves both halves where they were and the card
+	 *  still offering the release, where an app already replaced and relaunched
+	 *  would report itself current and never come back for the command.
 	 */
 	appUpdateInstall: () => typedError<null, string>(__TAURI_INVOKE("app_update_install")),
 	scanMachine: () => typedError<ScanResult, string>(__TAURI_INVOKE("scan_machine")),

--- a/ui/src/bindings.ts
+++ b/ui/src/bindings.ts
@@ -30,10 +30,17 @@ export const commands = {
 /**  The running install is ours to replace. */
 { kind: "direct" } | 
 /**
- *  A system package manager owns these bytes; `command` brings them
- *  current and is the only thing to offer.
+ *  A system package manager owns these bytes. `manager` names it and
+ *  `command` brings them current; both are decided where the manager
+ *  is detected, so nothing downstream has to read a name back out of
+ *  the command string and guess.
+ * 
+ *  `manager` is not optional. Every branch that reaches here knows
+ *  which installer it found, and a detection that could not say who
+ *  owns a path is [`InstallChannel::Unknown`] — which names nobody and
+ *  offers nothing, and is where the honest degradation already lives.
  */
-{ kind: "managed"; command: string } | 
+{ kind: "managed"; manager: string; command: string } | 
 /**
  *  Not recognised: say a release is out, never replace anything, never
  *  invent a command.
@@ -1495,10 +1502,17 @@ export type InstallChannel =
 /**  The running install is ours to replace. */
 { kind: "direct" } | 
 /**
- *  A system package manager owns these bytes; `command` brings them
- *  current and is the only thing to offer.
+ *  A system package manager owns these bytes. `manager` names it and
+ *  `command` brings them current; both are decided where the manager
+ *  is detected, so nothing downstream has to read a name back out of
+ *  the command string and guess.
+ * 
+ *  `manager` is not optional. Every branch that reaches here knows
+ *  which installer it found, and a detection that could not say who
+ *  owns a path is [`InstallChannel::Unknown`] — which names nobody and
+ *  offers nothing, and is where the honest degradation already lives.
  */
-{ kind: "managed"; command: string } | 
+{ kind: "managed"; manager: string; command: string } | 
 /**
  *  Not recognised: say a release is out, never replace anything, never
  *  invent a command.

--- a/ui/src/bindings.ts
+++ b/ui/src/bindings.ts
@@ -17,14 +17,39 @@ export const commands = {
 	 */
 	appUpdateChannel: () => typedError<InstallChannel, string>(__TAURI_INVOKE("app_update_channel")),
 	/**
+	 *  What the card has to say about the `kendex` command beside this app:
+	 *  the channel that owns it where kendex must not replace it, and nothing
+	 *  where there is none or where Update now will carry it across.
+	 * 
+	 *  Without this the app replaces itself, restarts, and clears its card
+	 *  while the terminal command stays on the old release with nothing on
+	 *  screen having said so — the silent divergence this issue was written
+	 *  about, arrived at from the other side.
+	 */
+	appUpdateCommandChannel: () => typedError<
+/**  The running install is ours to replace. */
+{ kind: "direct" } | 
+/**
+ *  A system package manager owns these bytes; `command` brings them
+ *  current and is the only thing to offer.
+ */
+{ kind: "managed"; command: string } | 
+/**
+ *  Not recognised: say a release is out, never replace anything, never
+ *  invent a command.
+ */
+{ kind: "unknown" } | null, string>(__TAURI_INVOKE("app_update_command_channel")),
+	/**
 	 *  Replace this install with the latest release and relaunch into it,
-	 *  carrying the `kendex` command across with it. The manifest names a
+	 *  carrying across a `kendex` command that is kendex's to replace. One
+	 *  another installer owns stays where it is, named on the card by
+	 *  `app_update_command_channel` before this ever runs. The manifest names a
 	 *  download and the signature over it; the release's own digests document
 	 *  names which download this release published for this target, and the
-	 *  app's bytes are held to both before anything is installed. The
-	 *  discovery feed never supplies an install URL, and the command's own
-	 *  bytes are held to the same key the CLI holds them to. A failure leaves
-	 *  the running app untouched and usable.
+	 *  app's bytes are held to both before anything is installed. The discovery
+	 *  feed never supplies an install URL, and the command's own bytes are held
+	 *  to the same key the CLI holds them to. A failure leaves the running app
+	 *  untouched and usable.
 	 * 
 	 *  The command moves first. What this flow's notice card reads is the
 	 *  app's own baked version, so the app is the state marker here and is

--- a/ui/src/bindings.ts
+++ b/ui/src/bindings.ts
@@ -48,13 +48,12 @@ export const commands = {
 	 *  Replace this install with the latest release and relaunch into it,
 	 *  carrying across a `kendex` command that is kendex's to replace. One
 	 *  another installer owns stays where it is, named on the card by
-	 *  `app_update_command_channel` before this ever runs. The manifest names a
-	 *  download and the signature over it; the release's own digests document
-	 *  names which download this release published for this target, and the
-	 *  app's bytes are held to both before anything is installed. The discovery
-	 *  feed never supplies an install URL, and the command's own bytes are held
-	 *  to the same key the CLI holds them to. A failure leaves the running app
-	 *  untouched and usable.
+	 *  `app_update_command_channel` before this ever runs — and `shown` is
+	 *  what that card said, so a command that changed since is refused rather
+	 *  than acted on in silence. The separately signed
+	 *  updater manifest is the delivery path for the app and verifies itself;
+	 *  the command's own bytes are held to the same key the CLI holds them to.
+	 *  A failure leaves the running app untouched and usable.
 	 * 
 	 *  The command moves first. What this flow's notice card reads is the
 	 *  app's own baked version, so the app is the state marker here and is
@@ -64,7 +63,22 @@ export const commands = {
 	 *  still offering the release, where an app already replaced and relaunched
 	 *  would report itself current and never come back for the command.
 	 */
-	appUpdateInstall: () => typedError<null, string>(__TAURI_INVOKE("app_update_install")),
+	appUpdateInstall: (shown: 
+/**
+ *  Another installer owns the command; `manager` names it and
+ *  `command` brings it current.
+ */
+{ kind: "managed"; manager: string; command: string } | 
+/**
+ *  Nothing names an owner and no record proves the file is kendex's,
+ *  so there is no name to print and no command to offer.
+ */
+{ kind: "unknown" } | 
+/**
+ *  Kendex's own command, where this app cannot write. `command` is
+ *  what carries it across with the privilege the app lacks.
+ */
+{ kind: "needsPrivilege"; path: string; command: string } | null) => typedError<null, string>(__TAURI_INVOKE("app_update_install", { shown })),
 	scanMachine: () => typedError<ScanResult, string>(__TAURI_INVOKE("scan_machine")),
 	getSettings: () => typedError<SettingsRead, string>(__TAURI_INVOKE("get_settings")),
 	/**

--- a/ui/src/bindings.ts
+++ b/ui/src/bindings.ts
@@ -18,8 +18,10 @@ export const commands = {
 	appUpdateChannel: () => typedError<InstallChannel, string>(__TAURI_INVOKE("app_update_channel")),
 	/**
 	 *  What the card has to say about the `kendex` command beside this app:
-	 *  the channel that owns it where kendex must not replace it, and nothing
-	 *  where there is none or where Update now will carry it across.
+	 *  the channel that owns it where another installer does, the one command
+	 *  that moves it where it is kendex's own but sits where this app cannot
+	 *  write, and nothing where there is none or where Update now carries it
+	 *  across itself.
 	 * 
 	 *  Without this the app replaces itself, restarts, and clears its card
 	 *  while the terminal command stays on the old release with nothing on
@@ -27,25 +29,21 @@ export const commands = {
 	 *  about, arrived at from the other side.
 	 */
 	appUpdateCommandChannel: () => typedError<
-/**  The running install is ours to replace. */
-{ kind: "direct" } | 
 /**
- *  A system package manager owns these bytes. `manager` names it and
- *  `command` brings them current; both are decided where the manager
- *  is detected, so nothing downstream has to read a name back out of
- *  the command string and guess.
- * 
- *  `manager` is not optional. Every branch that reaches here knows
- *  which installer it found, and a detection that could not say who
- *  owns a path is [`InstallChannel::Unknown`] — which names nobody and
- *  offers nothing, and is where the honest degradation already lives.
+ *  Another installer owns the command; `manager` names it and
+ *  `command` brings it current.
  */
 { kind: "managed"; manager: string; command: string } | 
 /**
- *  Not recognised: say a release is out, never replace anything, never
- *  invent a command.
+ *  Nothing names an owner and no record proves the file is kendex's,
+ *  so there is no name to print and no command to offer.
  */
-{ kind: "unknown" } | null, string>(__TAURI_INVOKE("app_update_command_channel")),
+{ kind: "unknown" } | 
+/**
+ *  Kendex's own command, where this app cannot write. `command` is
+ *  what carries it across with the privilege the app lacks.
+ */
+{ kind: "needsPrivilege"; path: string; command: string } | null, string>(__TAURI_INVOKE("app_update_command_channel")),
 	/**
 	 *  Replace this install with the latest release and relaunch into it,
 	 *  carrying across a `kendex` command that is kendex's to replace. One
@@ -840,6 +838,33 @@ export type CatalogSummary = {
 	 */
 	subscription: SubscriptionRef | null,
 };
+
+/**
+ *  What the sidebar card says about the `kendex` command beside the app,
+ *  before Update now is pressed — afterwards the app has restarted and
+ *  there is no card left to say it on. `None` where there is nothing to
+ *  say: no command here, or one Update now carries across itself.
+ * 
+ *  Every string is fixed text decided by which arm ran, save the path,
+ *  which names one file to a person who may have several — the rule the
+ *  [`InstallChannel`] command strings already live under.
+ */
+export type CommandNotice = 
+/**
+ *  Another installer owns the command; `manager` names it and
+ *  `command` brings it current.
+ */
+{ kind: "managed"; manager: string; command: string } | 
+/**
+ *  Nothing names an owner and no record proves the file is kendex's,
+ *  so there is no name to print and no command to offer.
+ */
+{ kind: "unknown" } | 
+/**
+ *  Kendex's own command, where this app cannot write. `command` is
+ *  what carries it across with the privilege the app lacks.
+ */
+{ kind: "needsPrivilege"; path: string; command: string };
 
 /**
  *  A package whose presence changes what this one does, and whether it is

--- a/ui/src/bindings.ts
+++ b/ui/src/bindings.ts
@@ -47,13 +47,14 @@ export const commands = {
 	/**
 	 *  Replace this install with the latest release and relaunch into it,
 	 *  carrying across a `kendex` command that is kendex's to replace. One
-	 *  another installer owns stays where it is, named on the card by
-	 *  `app_update_command_channel` before this ever runs — and `shown` is
-	 *  what that card said, so a command that changed since is refused rather
-	 *  than acted on in silence. The separately signed
-	 *  updater manifest is the delivery path for the app and verifies itself;
-	 *  the command's own bytes are held to the same key the CLI holds them to.
-	 *  A failure leaves the running app untouched and usable.
+	 *  another installer owns stays where it is, named on the card before this
+	 *  runs; `shown` is what that card said, so a command that changed since is
+	 *  refused rather than acted on in silence. The manifest names a download
+	 *  and the signature over it, the release's own digests document names what
+	 *  this release published for this target, and the app's bytes are held to
+	 *  both. The discovery feed never supplies an install URL, and the command's
+	 *  bytes are held to the key the CLI holds them to. A failure leaves the
+	 *  running app untouched and usable.
 	 * 
 	 *  The command moves first. What this flow's notice card reads is the
 	 *  app's own baked version, so the app is the state marker here and is

--- a/ui/src/components/sidebar-notice.dom.test.tsx
+++ b/ui/src/components/sidebar-notice.dom.test.tsx
@@ -9,6 +9,8 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { AppUpdateView, InstallChannel } from "@/bindings";
 import { commands } from "@/bindings";
 import {
+  APP_UPDATE_COMMAND_LEFT_NOTE,
+  APP_UPDATE_COMMAND_MANAGED_NOTE,
   APP_UPDATE_DISMISS_LABEL,
   APP_UPDATE_INSTALL_LABEL,
   APP_UPDATE_INSTALLING_LABEL,
@@ -26,6 +28,7 @@ vi.mock("@/bindings", async (importOriginal) => ({
     appVersion: vi.fn(),
     appUpdateCheck: vi.fn(),
     appUpdateChannel: vi.fn(),
+    appUpdateCommandChannel: vi.fn(),
     appUpdateInstall: vi.fn(),
     getSettings: vi.fn(),
     updateSettings: vi.fn(),
@@ -63,10 +66,17 @@ const available = (muted = false): { status: "ok"; data: AppUpdateView } =>
   });
 
 /** Load the store as the startup fan-out does, then put the card on screen. */
-async function show(channel: InstallChannel = { kind: "direct" }) {
+async function show(
+  channel: InstallChannel = { kind: "direct" },
+  commandChannel: InstallChannel | null = null,
+) {
   vi.mocked(commands.appUpdateChannel).mockResolvedValue({
     status: "ok",
     data: channel,
+  });
+  vi.mocked(commands.appUpdateCommandChannel).mockResolvedValue({
+    status: "ok",
+    data: commandChannel,
   });
   await useNoticeStore.getState().load();
   const container = mount(<SidebarNotice />);
@@ -192,12 +202,48 @@ describe("the action each channel allows", () => {
     expect(container.textContent).not.toContain(APP_UPDATE_INSTALL_LABEL);
   });
 
+  // Update now replaces the app and restarts into it, so anything the
+  // person needs to know about the command it leaves behind has to be on
+  // the card before the button is pressed. Afterwards there is no card.
+  it("says the command is left behind, and who updates it", async () => {
+    const container = await show(
+      { kind: "direct" },
+      { kind: "managed", command: "brew upgrade kendex-cli" },
+    );
+    expect(container.textContent).toContain(APP_UPDATE_INSTALL_LABEL);
+    expect(container.textContent).toContain(APP_UPDATE_COMMAND_LEFT_NOTE);
+    expect(container.textContent).toContain(APP_UPDATE_COMMAND_MANAGED_NOTE);
+    expect(container.textContent).toContain("brew upgrade kendex-cli");
+  });
+
+  // Nothing kendex could name owns it, so the card says the command is
+  // left behind and stops there rather than inventing a way to move it.
+  it("names no command where nothing could tell who owns it", async () => {
+    const container = await show({ kind: "direct" }, { kind: "unknown" });
+    expect(container.textContent).toContain(APP_UPDATE_COMMAND_LEFT_NOTE);
+    expect(container.textContent).not.toContain(
+      APP_UPDATE_COMMAND_MANAGED_NOTE,
+    );
+  });
+
+  // The two cases with nothing to say: no command beside the app, and one
+  // Update now will carry across itself.
+  it("says nothing about the command where it is not left behind", async () => {
+    const container = await show({ kind: "direct" }, null);
+    expect(container.textContent).toContain(APP_UPDATE_INSTALL_LABEL);
+    expect(container.textContent).not.toContain(APP_UPDATE_COMMAND_LEFT_NOTE);
+  });
+
   // A channel read that failed is the same offer as one nothing
   // recognised: never a replacement built on a guess.
   it("falls back to no action when the channel could not be read", async () => {
     vi.mocked(commands.appUpdateChannel).mockResolvedValue({
       status: "error",
       error: "the running app's own path is unreadable",
+    });
+    vi.mocked(commands.appUpdateCommandChannel).mockResolvedValue({
+      status: "ok",
+      data: null,
     });
     await useNoticeStore.getState().load();
     const container = mount(<SidebarNotice />);

--- a/ui/src/components/sidebar-notice.dom.test.tsx
+++ b/ui/src/components/sidebar-notice.dom.test.tsx
@@ -6,7 +6,7 @@
 import userEvent from "@testing-library/user-event";
 import { act } from "react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import type { AppUpdateView, InstallChannel } from "@/bindings";
+import type { AppUpdateView, CommandNotice, InstallChannel } from "@/bindings";
 import { commands } from "@/bindings";
 import {
   APP_UPDATE_COMMAND_UNKNOWN_NOTE,
@@ -17,6 +17,7 @@ import {
   APP_UPDATE_TITLE,
   APP_UPDATE_UNKNOWN_NOTE,
   appUpdateCommandManagedNote,
+  appUpdateCommandPrivilegeNote,
 } from "@/lib/copy";
 import { useNoticeStore } from "@/stores/notice";
 import { mount, settle } from "@/test/dom";
@@ -68,7 +69,7 @@ const available = (muted = false): { status: "ok"; data: AppUpdateView } =>
 /** Load the store as the startup fan-out does, then put the card on screen. */
 async function show(
   channel: InstallChannel = { kind: "direct" },
-  commandChannel: InstallChannel | null = null,
+  commandChannel: CommandNotice | null = null,
 ) {
   vi.mocked(commands.appUpdateChannel).mockResolvedValue({
     status: "ok",
@@ -237,6 +238,30 @@ describe("the action each channel allows", () => {
       appUpdateCommandManagedNote("an AUR helper"),
     );
     expect(container.textContent).not.toContain("Homebrew");
+  });
+
+  // The command is kendex's own and the app cannot write where it sits,
+  // which is neither of the two answers above: there is an owner, and one
+  // command moves it. Said with the path, because a person may have more
+  // than one kendex and only one of them is the file this is about.
+  it("names the command that moves one only privilege withholds", async () => {
+    const container = await show(
+      { kind: "direct" },
+      {
+        kind: "needsPrivilege",
+        path: "/usr/local/bin/kendex",
+        command: "sudo kendex update",
+      },
+    );
+    expect(container.textContent).toContain(
+      appUpdateCommandPrivilegeNote("/usr/local/bin/kendex"),
+    );
+    expect(container.textContent).toContain("sudo kendex update");
+    // Not the answer for a command nothing could place: that one names
+    // nothing to run, and this one does.
+    expect(container.textContent).not.toContain(
+      APP_UPDATE_COMMAND_UNKNOWN_NOTE,
+    );
   });
 
   // Nothing kendex could name owns it, so the card says the command is

--- a/ui/src/components/sidebar-notice.dom.test.tsx
+++ b/ui/src/components/sidebar-notice.dom.test.tsx
@@ -302,6 +302,49 @@ describe("the action each channel allows", () => {
 });
 
 describe("a replacement that did not happen", () => {
+  // The engine refuses an install whose command changed since the card was
+  // drawn, and it can only tell that if it is handed what the card said.
+  // Handing it nothing would leave every such install going ahead on an
+  // answer the person never saw.
+  it("hands the engine the note the card is showing", async () => {
+    vi.mocked(commands.appUpdateInstall).mockResolvedValue({
+      status: "ok",
+      data: null,
+    });
+    const showing: CommandNotice = {
+      kind: "managed",
+      manager: "Homebrew",
+      command: "brew upgrade kendex-cli",
+    };
+    const container = await show({ kind: "direct" }, showing);
+    await press(container, APP_UPDATE_INSTALL_LABEL);
+    expect(commands.appUpdateInstall).toHaveBeenCalledWith(showing);
+  });
+
+  // The refusal tells the person the notice now says what is there, so the
+  // card has to read again — otherwise the sentence is false and pressing
+  // Update now again meets the same refusal forever.
+  it("reads the command again after a refusal, so the note is true", async () => {
+    vi.mocked(commands.appUpdateInstall).mockResolvedValue({
+      status: "error",
+      error:
+        "the kendex command beside this app is no longer the one the notice described",
+    });
+    const changed: CommandNotice = { kind: "unknown" };
+    const container = await show({ kind: "direct" }, null);
+    vi.mocked(commands.appUpdateCommandChannel).mockResolvedValue({
+      status: "ok",
+      data: changed,
+    });
+
+    await press(container, APP_UPDATE_INSTALL_LABEL);
+    await settle();
+
+    expect(useNoticeStore.getState().commandChannel).toEqual(changed);
+    expect(container.textContent).toContain(APP_UPDATE_COMMAND_UNKNOWN_NOTE);
+    expect(container.textContent).toContain("no longer the one the notice");
+  });
+
   it("says why on the card and leaves the action to try again", async () => {
     vi.mocked(commands.appUpdateInstall).mockResolvedValue({
       status: "error",

--- a/ui/src/components/sidebar-notice.dom.test.tsx
+++ b/ui/src/components/sidebar-notice.dom.test.tsx
@@ -9,14 +9,14 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { AppUpdateView, InstallChannel } from "@/bindings";
 import { commands } from "@/bindings";
 import {
-  APP_UPDATE_COMMAND_LEFT_NOTE,
-  APP_UPDATE_COMMAND_MANAGED_NOTE,
+  APP_UPDATE_COMMAND_UNKNOWN_NOTE,
   APP_UPDATE_DISMISS_LABEL,
   APP_UPDATE_INSTALL_LABEL,
   APP_UPDATE_INSTALLING_LABEL,
   APP_UPDATE_NOTES_LABEL,
   APP_UPDATE_TITLE,
   APP_UPDATE_UNKNOWN_NOTE,
+  appUpdateCommandManagedNote,
 } from "@/lib/copy";
 import { useNoticeStore } from "@/stores/notice";
 import { mount, settle } from "@/test/dom";
@@ -190,6 +190,7 @@ describe("the action each channel allows", () => {
   it("shows a package manager's command and offers no replacement", async () => {
     const container = await show({
       kind: "managed",
+      manager: "an AUR helper",
       command: "paru -S kendex-bin",
     });
     expect(container.textContent).toContain("paru -S kendex-bin");
@@ -205,25 +206,47 @@ describe("the action each channel allows", () => {
   // Update now replaces the app and restarts into it, so anything the
   // person needs to know about the command it leaves behind has to be on
   // the card before the button is pressed. Afterwards there is no card.
-  it("says the command is left behind, and who updates it", async () => {
+  it("names the installer that owns the command, and how to move it", async () => {
     const container = await show(
       { kind: "direct" },
-      { kind: "managed", command: "brew upgrade kendex-cli" },
+      {
+        kind: "managed",
+        manager: "Homebrew",
+        command: "brew upgrade kendex-cli",
+      },
     );
     expect(container.textContent).toContain(APP_UPDATE_INSTALL_LABEL);
-    expect(container.textContent).toContain(APP_UPDATE_COMMAND_LEFT_NOTE);
-    expect(container.textContent).toContain(APP_UPDATE_COMMAND_MANAGED_NOTE);
+    expect(container.textContent).toContain(
+      appUpdateCommandManagedNote("Homebrew"),
+    );
     expect(container.textContent).toContain("brew upgrade kendex-cli");
+  });
+
+  // The name comes from the channel, so a different installer reads as
+  // itself rather than as whatever the first case happened to be.
+  it("names whichever installer the channel carries", async () => {
+    const container = await show(
+      { kind: "direct" },
+      {
+        kind: "managed",
+        manager: "an AUR helper",
+        command: "paru -S kendex",
+      },
+    );
+    expect(container.textContent).toContain(
+      appUpdateCommandManagedNote("an AUR helper"),
+    );
+    expect(container.textContent).not.toContain("Homebrew");
   });
 
   // Nothing kendex could name owns it, so the card says the command is
   // left behind and stops there rather than inventing a way to move it.
-  it("names no command where nothing could tell who owns it", async () => {
+  it("names no installer where nothing could tell who owns it", async () => {
     const container = await show({ kind: "direct" }, { kind: "unknown" });
-    expect(container.textContent).toContain(APP_UPDATE_COMMAND_LEFT_NOTE);
-    expect(container.textContent).not.toContain(
-      APP_UPDATE_COMMAND_MANAGED_NOTE,
-    );
+    expect(container.textContent).toContain(APP_UPDATE_COMMAND_UNKNOWN_NOTE);
+    // No half-written sentence, and no invented owner.
+    expect(container.textContent).not.toContain("installed by");
+    expect(container.textContent).not.toContain("update it with:");
   });
 
   // The two cases with nothing to say: no command beside the app, and one
@@ -231,7 +254,7 @@ describe("the action each channel allows", () => {
   it("says nothing about the command where it is not left behind", async () => {
     const container = await show({ kind: "direct" }, null);
     expect(container.textContent).toContain(APP_UPDATE_INSTALL_LABEL);
-    expect(container.textContent).not.toContain(APP_UPDATE_COMMAND_LEFT_NOTE);
+    expect(container.textContent).not.toContain("updates the app only");
   });
 
   // A channel read that failed is the same offer as one nothing

--- a/ui/src/components/sidebar-notice.tsx
+++ b/ui/src/components/sidebar-notice.tsx
@@ -1,6 +1,8 @@
 import { Loader2, X } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import {
+  APP_UPDATE_COMMAND_LEFT_NOTE,
+  APP_UPDATE_COMMAND_MANAGED_NOTE,
   APP_UPDATE_DISMISS_LABEL,
   APP_UPDATE_INSTALL_LABEL,
   APP_UPDATE_INSTALLING_LABEL,
@@ -22,6 +24,7 @@ import { useNoticeStore } from "@/stores/notice";
 export function SidebarNotice() {
   const notice = useNoticeStore((s) => s.notice);
   const channel = useNoticeStore((s) => s.channel);
+  const commandChannel = useNoticeStore((s) => s.commandChannel);
   const installing = useNoticeStore((s) => s.installing);
   const error = useNoticeStore((s) => s.error);
   const install = useNoticeStore((s) => s.install);
@@ -61,21 +64,44 @@ export function SidebarNotice() {
       </p>
 
       {channel.kind === "direct" ? (
-        <Button
-          size="sm"
-          className="mt-2.5 w-full"
-          disabled={installing}
-          onClick={() => void install()}
-        >
-          {installing ? (
+        <>
+          <Button
+            size="sm"
+            className="mt-2.5 w-full"
+            disabled={installing}
+            onClick={() => void install()}
+          >
+            {installing ? (
+              <>
+                <Loader2 className="animate-spin" />
+                {APP_UPDATE_INSTALLING_LABEL}
+              </>
+            ) : (
+              APP_UPDATE_INSTALL_LABEL
+            )}
+          </Button>
+          {/* The app is kendex's to replace and the command beside it is
+              not, so Update now moves one and leaves the other. Said
+              before the button is pressed, because afterwards the app has
+              restarted and the card is gone. */}
+          {commandChannel === null ? null : (
             <>
-              <Loader2 className="animate-spin" />
-              {APP_UPDATE_INSTALLING_LABEL}
+              <p className="mt-2 text-xs text-muted-foreground">
+                {APP_UPDATE_COMMAND_LEFT_NOTE}
+              </p>
+              {commandChannel.kind === "managed" ? (
+                <>
+                  <p className="mt-1 text-xs text-muted-foreground">
+                    {APP_UPDATE_COMMAND_MANAGED_NOTE}
+                  </p>
+                  <pre className="mt-1 overflow-x-auto whitespace-pre-wrap break-words rounded bg-foreground/[0.05] px-2 py-1.5 font-mono text-[11px] leading-5">
+                    {commandChannel.command}
+                  </pre>
+                </>
+              ) : null}
             </>
-          ) : (
-            APP_UPDATE_INSTALL_LABEL
           )}
-        </Button>
+        </>
       ) : channel.kind === "managed" ? (
         <>
           <p className="mt-2.5 text-xs text-muted-foreground">

--- a/ui/src/components/sidebar-notice.tsx
+++ b/ui/src/components/sidebar-notice.tsx
@@ -1,8 +1,7 @@
 import { Loader2, X } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import {
-  APP_UPDATE_COMMAND_LEFT_NOTE,
-  APP_UPDATE_COMMAND_MANAGED_NOTE,
+  APP_UPDATE_COMMAND_UNKNOWN_NOTE,
   APP_UPDATE_DISMISS_LABEL,
   APP_UPDATE_INSTALL_LABEL,
   APP_UPDATE_INSTALLING_LABEL,
@@ -10,6 +9,7 @@ import {
   APP_UPDATE_NOTES_LABEL,
   APP_UPDATE_TITLE,
   APP_UPDATE_UNKNOWN_NOTE,
+  appUpdateCommandManagedNote,
   appUpdateVersionsLabel,
 } from "@/lib/copy";
 import { useNoticeStore } from "@/stores/notice";
@@ -84,22 +84,23 @@ export function SidebarNotice() {
               not, so Update now moves one and leaves the other. Said
               before the button is pressed, because afterwards the app has
               restarted and the card is gone. */}
-          {commandChannel === null ? null : (
+          {commandChannel === null ? null : commandChannel.kind ===
+            "managed" ? (
             <>
               <p className="mt-2 text-xs text-muted-foreground">
-                {APP_UPDATE_COMMAND_LEFT_NOTE}
+                {appUpdateCommandManagedNote(commandChannel.manager)}
               </p>
-              {commandChannel.kind === "managed" ? (
-                <>
-                  <p className="mt-1 text-xs text-muted-foreground">
-                    {APP_UPDATE_COMMAND_MANAGED_NOTE}
-                  </p>
-                  <pre className="mt-1 overflow-x-auto whitespace-pre-wrap break-words rounded bg-foreground/[0.05] px-2 py-1.5 font-mono text-[11px] leading-5">
-                    {commandChannel.command}
-                  </pre>
-                </>
-              ) : null}
+              <pre className="mt-1 overflow-x-auto whitespace-pre-wrap break-words rounded bg-foreground/[0.05] px-2 py-1.5 font-mono text-[11px] leading-5">
+                {commandChannel.command}
+              </pre>
             </>
+          ) : (
+            // Nothing named the installer, so there is no name to print
+            // and no command to run: the card says the app moves alone and
+            // stops, rather than leaving a gap where a name would go.
+            <p className="mt-2 text-xs text-muted-foreground">
+              {APP_UPDATE_COMMAND_UNKNOWN_NOTE}
+            </p>
           )}
         </>
       ) : channel.kind === "managed" ? (

--- a/ui/src/components/sidebar-notice.tsx
+++ b/ui/src/components/sidebar-notice.tsx
@@ -10,6 +10,7 @@ import {
   APP_UPDATE_TITLE,
   APP_UPDATE_UNKNOWN_NOTE,
   appUpdateCommandManagedNote,
+  appUpdateCommandPrivilegeNote,
   appUpdateVersionsLabel,
 } from "@/lib/copy";
 import { useNoticeStore } from "@/stores/notice";
@@ -85,22 +86,24 @@ export function SidebarNotice() {
               before the button is pressed, because afterwards the app has
               restarted and the card is gone. */}
           {commandChannel === null ? null : commandChannel.kind ===
-            "managed" ? (
-            <>
-              <p className="mt-2 text-xs text-muted-foreground">
-                {appUpdateCommandManagedNote(commandChannel.manager)}
-              </p>
-              <pre className="mt-1 overflow-x-auto whitespace-pre-wrap break-words rounded bg-foreground/[0.05] px-2 py-1.5 font-mono text-[11px] leading-5">
-                {commandChannel.command}
-              </pre>
-            </>
-          ) : (
+            "unknown" ? (
             // Nothing named the installer, so there is no name to print
             // and no command to run: the card says the app moves alone and
             // stops, rather than leaving a gap where a name would go.
             <p className="mt-2 text-xs text-muted-foreground">
               {APP_UPDATE_COMMAND_UNKNOWN_NOTE}
             </p>
+          ) : (
+            <>
+              <p className="mt-2 text-xs text-muted-foreground">
+                {commandChannel.kind === "managed"
+                  ? appUpdateCommandManagedNote(commandChannel.manager)
+                  : appUpdateCommandPrivilegeNote(commandChannel.path)}
+              </p>
+              <pre className="mt-1 overflow-x-auto whitespace-pre-wrap break-words rounded bg-foreground/[0.05] px-2 py-1.5 font-mono text-[11px] leading-5">
+                {commandChannel.command}
+              </pre>
+            </>
           )}
         </>
       ) : channel.kind === "managed" ? (

--- a/ui/src/dev/mock-core.ts
+++ b/ui/src/dev/mock-core.ts
@@ -57,7 +57,11 @@ export const coreHandlers: Record<string, Handler> = {
   app_update_channel: () => {
     switch (wanted("update")) {
       case "managed":
-        return { kind: "managed", command: "paru -S kendex-bin" };
+        return {
+          kind: "managed",
+          manager: "an AUR helper",
+          command: "paru -S kendex-bin",
+        };
       case "unknown":
         return { kind: "unknown" };
       default:
@@ -69,7 +73,11 @@ export const coreHandlers: Record<string, Handler> = {
   // carries across itself.
   app_update_command_channel: () =>
     wanted("update") === "commandManaged"
-      ? { kind: "managed", command: "brew upgrade kendex-cli" }
+      ? {
+          kind: "managed",
+          manager: "Homebrew",
+          command: "brew upgrade kendex-cli",
+        }
       : null,
   // The mock browser harness has no install to replace, so the successful
   // path is the one thing it cannot show: the real command relaunches the

--- a/ui/src/dev/mock-core.ts
+++ b/ui/src/dev/mock-core.ts
@@ -64,6 +64,13 @@ export const coreHandlers: Record<string, Handler> = {
         return { kind: "direct" };
     }
   },
+  // Who owns the `kendex` command beside the app, when that is not kendex.
+  // Null is the ordinary machine: no command here, or one Update now
+  // carries across itself.
+  app_update_command_channel: () =>
+    wanted("update") === "commandManaged"
+      ? { kind: "managed", command: "brew upgrade kendex-cli" }
+      : null,
   // The mock browser harness has no install to replace, so the successful
   // path is the one thing it cannot show: the real command relaunches the
   // app and never returns. A refusal is a plain string, which is what the

--- a/ui/src/dev/mock-core.ts
+++ b/ui/src/dev/mock-core.ts
@@ -68,17 +68,27 @@ export const coreHandlers: Record<string, Handler> = {
         return { kind: "direct" };
     }
   },
-  // Who owns the `kendex` command beside the app, when that is not kendex.
+  // What the card owes a person about the `kendex` command beside the app.
   // Null is the ordinary machine: no command here, or one Update now
   // carries across itself.
-  app_update_command_channel: () =>
-    wanted("update") === "commandManaged"
-      ? {
+  app_update_command_channel: () => {
+    switch (wanted("update")) {
+      case "commandManaged":
+        return {
           kind: "managed",
           manager: "Homebrew",
           command: "brew upgrade kendex-cli",
-        }
-      : null,
+        };
+      case "commandPrivilege":
+        return {
+          kind: "needsPrivilege",
+          path: "/usr/local/bin/kendex",
+          command: "sudo kendex update",
+        };
+      default:
+        return null;
+    }
+  },
   // The mock browser harness has no install to replace, so the successful
   // path is the one thing it cannot show: the real command relaunches the
   // app and never returns. A refusal is a plain string, which is what the

--- a/ui/src/lib/copy.ts
+++ b/ui/src/lib/copy.ts
@@ -221,6 +221,13 @@ export const APP_UPDATE_DISMISS_LABEL = "Hide until the next version";
 export const APP_UPDATE_MANAGED_NOTE = "Update it with:";
 export const APP_UPDATE_UNKNOWN_NOTE =
   "Update kendex the way you installed it.";
+// Said under Update now when the app is kendex's to replace and the
+// `kendex` command beside it is not. The app moves and the command does
+// not, so the card names that before the button is pressed rather than
+// leaving a terminal on the old version with nothing having said so.
+export const APP_UPDATE_COMMAND_LEFT_NOTE =
+  "Update now moves the app. The kendex command here is not kendex's to replace.";
+export const APP_UPDATE_COMMAND_MANAGED_NOTE = "Update the command with:";
 // A whole-settings write the engine refused because the file moved under
 // it. Said wherever a change is one field and the retry is to press again.
 export const SETTINGS_MOVED_MESSAGE =

--- a/ui/src/lib/copy.ts
+++ b/ui/src/lib/copy.ts
@@ -237,6 +237,12 @@ export const appUpdateCommandManagedNote = (manager: string): string =>
 // for the app, about the command instead.
 export const APP_UPDATE_COMMAND_UNKNOWN_NOTE =
   "Update now updates the app only. Update the kendex command the way you installed it.";
+// The command is kendex's own — an installer recorded it — but it sits in
+// a directory this app cannot write, which is where install.sh puts it
+// whenever /usr/local/bin is the first of its two directories on PATH.
+// Not the unknown note: there is an owner, and one command moves it.
+export const appUpdateCommandPrivilegeNote = (path: string): string =>
+  `Update now updates the app only. The kendex command at ${path} needs permissions this app does not have; update it with:`;
 // A whole-settings write the engine refused because the file moved under
 // it. Said wherever a change is one field and the retry is to press again.
 export const SETTINGS_MOVED_MESSAGE =

--- a/ui/src/lib/copy.ts
+++ b/ui/src/lib/copy.ts
@@ -223,11 +223,20 @@ export const APP_UPDATE_UNKNOWN_NOTE =
   "Update kendex the way you installed it.";
 // Said under Update now when the app is kendex's to replace and the
 // `kendex` command beside it is not. The app moves and the command does
-// not, so the card names that before the button is pressed rather than
+// not, so the card says that before the button is pressed rather than
 // leaving a terminal on the old version with nothing having said so.
-export const APP_UPDATE_COMMAND_LEFT_NOTE =
-  "Update now moves the app. The kendex command here is not kendex's to replace.";
-export const APP_UPDATE_COMMAND_MANAGED_NOTE = "Update the command with:";
+//
+// It names the installer that owns the command, never a generic "your
+// package manager": the detection knows which one it found, and the
+// channel carries the name so nothing here has to read it back out of the
+// command string.
+export const appUpdateCommandManagedNote = (manager: string): string =>
+  `Update now updates the app only. The kendex command was installed by ${manager}; update it with:`;
+// Nothing could say who owns the command, so there is no installer to name
+// and no command to offer. The same answer APP_UPDATE_UNKNOWN_NOTE gives
+// for the app, about the command instead.
+export const APP_UPDATE_COMMAND_UNKNOWN_NOTE =
+  "Update now updates the app only. Update the kendex command the way you installed it.";
 // A whole-settings write the engine refused because the file moved under
 // it. Said wherever a change is one field and the retry is to press again.
 export const SETTINGS_MOVED_MESSAGE =

--- a/ui/src/stores/account-startup.dom.test.tsx
+++ b/ui/src/stores/account-startup.dom.test.tsx
@@ -23,6 +23,7 @@ vi.mock("@/bindings", () => ({
     mineSubmissionStates: vi.fn(async () => ({})),
     appUpdateCheck: vi.fn(),
     appUpdateChannel: vi.fn(),
+    appUpdateCommandChannel: vi.fn(),
     appVersion: vi.fn(),
   },
   ZOOM: { min: 50, max: 200, step: 10, default: 100 },
@@ -83,6 +84,10 @@ describe("who reads the account", () => {
       status: "error",
       error: "no channel in a test",
     } as Awaited<ReturnType<typeof commands.appUpdateChannel>>);
+    vi.mocked(commands.appUpdateCommandChannel).mockResolvedValue({
+      status: "error",
+      error: "no command channel in a test",
+    } as Awaited<ReturnType<typeof commands.appUpdateCommandChannel>>);
     vi.mocked(commands.appVersion).mockResolvedValue(
       "0.0.0-test" as Awaited<ReturnType<typeof commands.appVersion>>,
     );

--- a/ui/src/stores/notice.ts
+++ b/ui/src/stores/notice.ts
@@ -1,5 +1,5 @@
 import { create } from "zustand";
-import { commands, type InstallChannel } from "@/bindings";
+import { type CommandNotice, commands, type InstallChannel } from "@/bindings";
 import { SETTINGS_MOVED_MESSAGE } from "@/lib/copy";
 import { settled } from "@/lib/settled";
 
@@ -21,10 +21,11 @@ interface NoticeState {
   notice: AppUpdateNotice | null;
   /** Which action the card may offer. Read once beside the check. */
   channel: InstallChannel;
-  /** Who owns the `kendex` command beside this app, when that is not
-   *  kendex. Null when there is no command here or when Update now will
-   *  carry it across, which are the two cases with nothing to say. */
-  commandChannel: InstallChannel | null;
+  /** What the card owes a person about the `kendex` command beside this
+   *  app: who owns it where kendex does not, or the one command that moves
+   *  a command kendex owns but cannot write. Null when there is no command
+   *  here or when Update now will carry it across. */
+  commandChannel: CommandNotice | null;
   /** A replacement is running. There are no progress events, so this is
    *  the whole of what the card can say about it. */
   installing: boolean;

--- a/ui/src/stores/notice.ts
+++ b/ui/src/stores/notice.ts
@@ -21,6 +21,10 @@ interface NoticeState {
   notice: AppUpdateNotice | null;
   /** Which action the card may offer. Read once beside the check. */
   channel: InstallChannel;
+  /** Who owns the `kendex` command beside this app, when that is not
+   *  kendex. Null when there is no command here or when Update now will
+   *  carry it across, which are the two cases with nothing to say. */
+  commandChannel: InstallChannel | null;
   /** A replacement is running. There are no progress events, so this is
    *  the whole of what the card can say about it. */
   installing: boolean;
@@ -66,13 +70,15 @@ async function mute(version: string): Promise<string | null> {
 export const useNoticeStore = create<NoticeState>((set, get) => ({
   notice: null,
   channel: UNRESOLVED,
+  commandChannel: null,
   installing: false,
   error: null,
 
   load: async () => {
-    const [view, channel, current] = await Promise.all([
+    const [view, channel, commandChannel, current] = await Promise.all([
       settled(commands.appUpdateCheck(false)),
       settled(commands.appUpdateChannel()),
+      settled(commands.appUpdateCommandChannel()),
       // The running version is the half of the sentence the release feed
       // cannot supply; without it there is no notice to write.
       commands.appVersion().catch(() => null),
@@ -87,6 +93,11 @@ export const useNoticeStore = create<NoticeState>((set, get) => ({
         releaseNotesUrl: status.releaseNotesUrl,
       },
       channel: channel.status === "ok" ? channel.data : UNRESOLVED,
+      // A read that failed says nothing rather than guessing: the note is
+      // about a command this app will not touch, and inventing one would
+      // send a person to a package manager that does not own it.
+      commandChannel:
+        commandChannel.status === "ok" ? commandChannel.data : null,
     });
   },
 

--- a/ui/src/stores/notice.ts
+++ b/ui/src/stores/notice.ts
@@ -105,12 +105,25 @@ export const useNoticeStore = create<NoticeState>((set, get) => ({
   install: async () => {
     if (get().installing) return;
     set({ installing: true, error: null });
-    const response = await settled(commands.appUpdateInstall());
+    // What the card is showing about the command beside the app, handed
+    // over so the engine can refuse an install whose command changed since
+    // the card was drawn. The card is the only place that warning could
+    // have been read, and Update now takes the card away with the restart.
+    const response = await settled(
+      commands.appUpdateInstall(get().commandChannel),
+    );
     // A replacement that worked does not come back: the app restarts into
     // the new version. So only a failure ends the in-flight state, and it
     // leaves the action on the card to try again.
-    if (response.status === "error")
+    if (response.status === "error") {
       set({ installing: false, error: response.error });
+      // One of those failures is that the command is no longer what this
+      // card says, and the refusal tells the person the card now shows
+      // what is there. Read again so that is true, and so pressing Update
+      // now again acts on the answer rather than meeting the same refusal.
+      const fresh = await settled(commands.appUpdateCommandChannel());
+      if (fresh.status === "ok") set({ commandChannel: fresh.data });
+    }
   },
 
   openNotes: async () => {


### PR DESCRIPTION
The app's Update now replaced the AppImage and relaunched, and never touched the
kendex command beside it. On an install.sh machine the two halves are two files,
so a person who updated from the app was left running terminal automation on the
old command while the app moved on.

`kendex update` already moved both halves on a direct install. The app did not.

## One path, two callers

The command-replacement logic moved out of `crates/cli` into
`crates/core/src/command_update.rs`, and both ends call it. A second
implementation of "replace the kendex command" is how the two ends drift, which
is the defect this issue exists to prevent — so there is one.

It carries KEN-754's guarantee with it: the command binary is verified under the
pinned key before it replaces anything, on the app-driven path as much as the
CLI one.

## What the issue asked for

- The plugin swaps the app and the same flow carries the command across; a
  partial failure is reported rather than silent.
- Package-managed installs still self-update neither half — `allow_replacement`
  already refused anything but a direct install and still does. An install with
  no command beside the app stays app-only; absence is not failure.
- Tests pin the two versions equal after a family update, and cover skew in both
  directions.

## Note on the title

The issue is titled "install.sh family updates". It is not built there:
`docs/plans/update-notice-and-account.md` records that app-and-CLI-together
lives in `kendex update`, and this change makes the app reuse that path rather
than adding a third place where an update can happen.

## Rebase

Rebased onto main after #1813 landed. That PR added a `curl_args` test to the
CLI's update tests; this change moved `curl_args` into core, so the test moved
with it and still asserts what it did — worth more there, since the function now
serves both update paths.

`tools/guard` green by exit code.

Closes KEN-444
