### PR TITLE
fix(KEN-753): a cask install's Update button runs and relaunches

### DIFF
--- a/changelog.d/fixed/KEN-753.md
+++ b/changelog.d/fixed/KEN-753.md
@@ -1,0 +1,3 @@
+- macOS: Update now works on a Homebrew cask install, and the app relaunches
+  into the new version instead of exiting. It refused the symlinked
+  `/Applications/kendex.app` launch path before.

--- a/crates/app/Cargo.toml
+++ b/crates/app/Cargo.toml
@@ -13,7 +13,23 @@ serde.workspace = true
 # `tauri::generate_context!` expands the updater plugin's config through it.
 serde_json.workspace = true
 toml.workspace = true
-tauri.workspace = true
+# `process-relaunch-dangerous-allow-symlink-macos` opts out of tauri's refusal
+# to name its own binary when the launch path has a symlinked ancestor. Every
+# Homebrew cask install has one: the `app` stanza puts a symlink at
+# `/Applications/kendex.app` pointing into the Caskroom. That refusal sits
+# behind both `UpdaterBuilder::build` and `AppHandle::restart`, so without
+# this the Update button downloads nothing and a fixed download would exit
+# without relaunching.
+#
+# The launch path is still checked; kendex checks it rather than delegating.
+# `install_channel::for_app` canonicalizes the path through the link and
+# approves only a `.app` bundle it can replace, `app_update_install` refuses
+# any install that resolver did not call `Direct`, and the approved path is
+# what reaches the updater. `crates/app/tests/cask_symlink_launch.rs` holds
+# both halves against a real symlinked layout.
+tauri = { workspace = true, features = [
+    "process-relaunch-dangerous-allow-symlink-macos",
+] }
 tauri-specta.workspace = true
 specta.workspace = true
 specta-typescript.workspace = true

--- a/crates/app/src/app_update.rs
+++ b/crates/app/src/app_update.rs
@@ -139,8 +139,11 @@ pub async fn app_update_install(app: tauri::AppHandle) -> Result<(), String> {
     let update = aim_at_install(app.updater_builder(), &install)
         .endpoints(vec![manifest_endpoint()?])
         .map_err(|error| error.to_string())?
+        // What is left here after the cask fix is the app failing to place
+        // itself. The plugin's own text for that is a bare io error, which
+        // names no doer and no stage.
         .build()
-        .map_err(|error| error.to_string())?
+        .map_err(|error| format!("kendex could not start an update for this install: {error}"))?
         .check()
         .await
         .map_err(|error| error.to_string())?

--- a/crates/app/tests/cask_symlink_launch.rs
+++ b/crates/app/tests/cask_symlink_launch.rs
@@ -1,0 +1,157 @@
+//! The Homebrew cask is the default macOS install, and its `app` stanza puts
+//! a symlink at `/Applications/kendex.app` pointing into the Caskroom, so
+//! every launch from there carries a symlinked ancestor. Two halves have to
+//! hold on that layout: kendex judges the bundle behind the link, and tauri
+//! stops refusing to name a binary reached through one.
+#![cfg(unix)]
+
+#[path = "../../test_util.rs"]
+mod test_util;
+use test_util::rooted;
+
+use std::path::{Path, PathBuf};
+
+use kendex_core::install_channel::{AppInstall, Host, InstallChannel, for_app};
+
+/// Tells the child process which half of the probe it is. The parent sets
+/// it; the child answers rather than launching another child.
+const PROBE_VAR: &str = "KENDEX_CASK_SYMLINK_PROBE";
+
+/// What a child prints once it has named its own binary. The parent needs
+/// this in the output, so a filter that matches no test fails rather than
+/// passing on an empty run.
+const PROBE_OK: &str = "cask-symlink probe named ";
+
+/// The probe's own name, as the harness filter spells it.
+const PROBE_TEST: &str = "a_symlinked_launch_path_names_its_own_binary";
+
+/// The tauri feature that turns the refusal off.
+const SYMLINK_FEATURE: &str = "process-relaunch-dangerous-allow-symlink-macos";
+
+/// A cask's shape under `root`: the versioned bundle in the Caskroom, and
+/// `Applications/kendex.app` linked at it. Returns the path a launch from
+/// `/Applications` is handed, then the bundle really holding those bytes.
+#[allow(clippy::unwrap_used)]
+fn cask_layout(root: &Path) -> (PathBuf, PathBuf) {
+    let bundle = root.join("Caskroom/kendex/5.0.1/kendex.app");
+    std::fs::create_dir_all(bundle.join("Contents/MacOS")).unwrap();
+    std::fs::write(bundle.join("Contents/MacOS/kendex"), b"").unwrap();
+    let applications = root.join("Applications");
+    std::fs::create_dir_all(&applications).unwrap();
+    std::os::unix::fs::symlink(&bundle, applications.join("kendex.app")).unwrap();
+    (
+        applications.join("kendex.app/Contents/MacOS/kendex"),
+        bundle,
+    )
+}
+
+/// The path the process is handed is the link. What `for_app` approves, and
+/// what `app_update_install` then hands the updater, is the Caskroom copy
+/// that the replacement actually overwrites — never the `/Applications`
+/// name it was reached by.
+#[test]
+#[allow(clippy::unwrap_used)]
+fn a_cask_launch_path_is_judged_at_the_bundle_behind_the_link() {
+    let tmp = tempfile::tempdir().unwrap();
+    let root = rooted(&tmp);
+    let (launch, bundle) = cask_layout(&root);
+
+    let install = AppInstall::mac_bundle(&Host, &launch);
+    let judged = install.judged_path().expect("a mac bundle carries a path");
+    assert_eq!(
+        judged,
+        bundle.join("Contents/MacOS/kendex"),
+        "the link was judged instead of the bundle behind it"
+    );
+    assert_eq!(
+        for_app(&install, &Host),
+        InstallChannel::Direct,
+        "a writable cask bundle is ours to replace"
+    );
+
+    // The updater climbs from the path it is handed to the unit it removes
+    // and replaces. Nothing it lands on may escape the approved bundle.
+    let derived = tauri_plugin_updater::extract_path_from_executable(judged).unwrap();
+    assert!(
+        derived.starts_with(&bundle),
+        "the updater derived {} from {}, outside the approved {}",
+        derived.display(),
+        judged.display(),
+        bundle.display()
+    );
+    assert!(
+        !derived.starts_with(root.join("Applications")),
+        "the updater would replace the link at {}",
+        derived.display()
+    );
+}
+
+/// tauri's own refusal, run from a real symlinked launch path.
+///
+/// It is computed before `main` from the path the process was exec'd with,
+/// so nothing inside one process can stand in for it: this launches the test
+/// binary again through a symlinked directory and asks the child. Both
+/// refusal sites are named — the updater resolves its target with
+/// `tauri::utils::platform::current_exe`, and the relaunch after a
+/// successful replace goes through `tauri::process::current_binary`. On
+/// Linux the check does not apply and the child answers trivially; on macOS
+/// it is the difference between an Update button that works and one that
+/// reports a symlink policy.
+#[test]
+#[allow(clippy::unwrap_used)]
+fn a_symlinked_launch_path_names_its_own_binary() {
+    if std::env::var_os(PROBE_VAR).is_some() {
+        let updater = tauri::utils::platform::current_exe()
+            .expect("the updater's path resolution refused a symlinked launch path");
+        let relaunch = tauri::process::current_binary(&tauri::Env::default())
+            .expect("the relaunch after an update refused a symlinked launch path");
+        assert_eq!(updater, relaunch);
+        println!("{PROBE_OK}{}", updater.display());
+        return;
+    }
+
+    let tmp = tempfile::tempdir().unwrap();
+    let root = rooted(&tmp);
+    let exe = std::env::current_exe().unwrap();
+    // The cask's shape without copying the binary: a symlinked directory in
+    // the middle of the launch path, real bytes behind it.
+    let bundle = root.join("kendex.app");
+    std::fs::create_dir_all(bundle.join("Contents")).unwrap();
+    std::os::unix::fs::symlink(exe.parent().unwrap(), bundle.join("Contents/MacOS")).unwrap();
+    let launch = bundle.join("Contents/MacOS").join(exe.file_name().unwrap());
+
+    let child = std::process::Command::new(&launch)
+        .args(["--exact", PROBE_TEST, "--nocapture", "--test-threads=1"])
+        .env(PROBE_VAR, "1")
+        .output()
+        .unwrap();
+    let stdout = String::from_utf8_lossy(&child.stdout);
+    assert!(
+        child.status.success() && stdout.contains(PROBE_OK),
+        "launched through {}: {}\n{stdout}{}",
+        launch.display(),
+        child.status,
+        String::from_utf8_lossy(&child.stderr)
+    );
+}
+
+/// The refusal is macOS-only and no CI lane runs this crate's tests there,
+/// so the probe above would stay green on every machine that could notice
+/// the feature going missing. This notices.
+#[test]
+#[allow(clippy::unwrap_used)]
+fn the_manifest_still_turns_the_refusal_off() {
+    let manifest =
+        std::fs::read_to_string(Path::new(env!("CARGO_MANIFEST_DIR")).join("Cargo.toml")).unwrap();
+    let features = manifest.parse::<toml::Table>().unwrap()["dependencies"]["tauri"]["features"]
+        .as_array()
+        .expect("the tauri dependency names the features it turns on")
+        .clone();
+    assert!(
+        features
+            .iter()
+            .any(|name| name.as_str() == Some(SYMLINK_FEATURE)),
+        "crates/app/Cargo.toml no longer enables {SYMLINK_FEATURE}, so a cask \
+         install's Update button refuses its own launch path again"
+    );
+}


### PR DESCRIPTION
The Homebrew cask is the default macOS install, and its `app` stanza puts a
symlink at `/Applications/kendex.app` pointing into the Caskroom. Tauri refuses
to name its own binary when the launch path has a symlinked ancestor, and that
refusal sits behind both `UpdaterBuilder::build` and `AppHandle::restart`. So the
notice offered Update now, the click produced tauri's raw sentence about a
symlink policy, and a fixed download would have exited without relaunching.

Supplying `executable_path` does not avoid it: `build` resolves
`self.executable_path.clone().unwrap_or(current_exe()?)`, and `unwrap_or` takes
its argument by value, so `current_exe()?` is evaluated eagerly and returns
before the override is read.

## The decision

Three cures were on the table and the owner chose the one that makes the button
work: enable tauri's `process-relaunch-dangerous-allow-symlink-macos`. A cask
install is the default on macOS and it is the install the release gate tests, so
the alternatives — classifying it as package-managed, or explaining the failure
better — both end with the default macOS install unable to update itself.

kendex does not stop checking the path; it stops delegating the check.
`install_channel::for_app` canonicalizes through the link and approves only a
`.app` bundle it can replace, `app_update_install` refuses any install that
resolver did not call `Direct`, and the approved path is what reaches the
updater. That reasoning is written at the feature declaration in
`crates/app/Cargo.toml`, where the next person to read the flag will meet it.

## Both refusals

`build` and `restart` fail through the same `current_exe`, so fixing only the
first would have shipped a worse outcome than the bug: the app would update and
then vanish, leaving no window to say what happened. Both are covered.

## Test

`crates/app/tests/cask_symlink_launch.rs` builds a real symlinked layout and
holds both halves against it, rather than asserting kendex-side values a struct
would satisfy without a symlink in sight.

Linux is unaffected — `current_binary` returns `env.appimage` there.

`tools/guard` green by exit code. macOS behaviour is established by reading the
locked tauri sources and by the symlinked-layout test; the owner's Mac is
offline, so it is not confirmed on that machine.

Closes KEN-753
