### PR TITLE
chore(KEN-824): an unrouted issue create is refused

### DIFF
--- a/kendex.settings.toml
+++ b/kendex.settings.toml
@@ -15,7 +15,7 @@ LINEAR_TEAM_PREFIX = "KEN"
 # Declared agent-routing label set (e.g. "agent:generalist, agent:rust").
 # Non-empty makes `issues create` refuse a create carrying none of them —
 # such an issue is invisible to agent routing. Empty = guard off.
-LINEAR_AGENT_LABELS = ""
+LINEAR_AGENT_LABELS = "agent:generalist, agent:rust, agent:iced, agent:researcher, agent:multi, agent:human"
 
 # Reviewer merge gate: "approval" needs a GitHub approval; "review" needs a
 # non-author review of the current head plus zero unresolved threads; "off"


### PR DESCRIPTION
Turns on the agent-label guard in \`linear.sh issues create\` for this repo: \`LINEAR_AGENT_LABELS\` names the six routing labels, so a create carrying none of them is refused before any API call. Six of the last thirty filings arrived with no labels and no project (KEN-796 to 799, 807, 812); those are labelled by hand.

KEN-824.

https://claude.ai/code/session_016h3mVqr8MNPw3KiJeKJiVB