### PR TITLE
test(KEN-814): every Pi suite runs in CI, and CI proves it

### DIFF
--- a/.github/workflows/skill-tests.yml
+++ b/.github/workflows/skill-tests.yml
@@ -207,19 +207,19 @@ jobs:
         working-directory: pi-extensions/pi-qol
         run: |
           npm install --no-save --no-package-lock --ignore-scripts --no-audit --no-fund @earendil-works/pi-agent-core@0.80.5 @earendil-works/pi-ai@0.80.5 @earendil-works/pi-coding-agent@0.80.5 @earendil-works/pi-tui@0.80.5
-          bun test ./tests
+          npm test
 
       - name: pi-output-policy suite
         if: matrix.shard == 'node'
         working-directory: pi-extensions/pi-output-policy
-        run: bun test ./tests
+        run: npm test
 
       # pi-hooks imports only types from pi-coding-agent, which bun erases,
       # so its suite runs with no install.
       - name: pi-hooks suite
         if: matrix.shard == 'node'
         working-directory: pi-extensions/pi-hooks
-        run: bun test ./tests
+        run: npm test
 
       # Pi 0.84.x is the release the extensions are audited against, so the
       # suites that assert 0.84 wire-format parity install that line rather
@@ -234,7 +234,7 @@ jobs:
         working-directory: pi-extensions/pi-agents-tmux
         run: |
           npm install --no-save --no-package-lock --ignore-scripts --no-audit --no-fund @earendil-works/pi-agent-core@0.84.1 @earendil-works/pi-ai@0.84.1 @earendil-works/pi-coding-agent@0.84.1 @earendil-works/pi-tui@0.84.1 typebox
-          bun test ./tests ./extensions/subagent/__tests__
+          npm test
 
       # undici is pinned to the package's own declared range: installing it
       # unversioned resolves the registry's latest major, so the proxy
@@ -253,7 +253,7 @@ jobs:
       - name: pi-questions suite
         if: matrix.shard == 'node'
         working-directory: pi-extensions/pi-questions
-        run: bun test ./extensions/__tests__
+        run: npm test
 
       # The renderer imports pi-tui and pi-coding-agent, so unlike
       # pi-questions its suite needs the 0.84.1 install to resolve at all.
@@ -265,7 +265,7 @@ jobs:
         working-directory: pi-extensions/pi-tool-renderer
         run: |
           npm install --no-save --no-package-lock --ignore-scripts --no-audit --no-fund @earendil-works/pi-agent-core@0.84.1 @earendil-works/pi-ai@0.84.1 @earendil-works/pi-coding-agent@0.84.1 @earendil-works/pi-tui@0.84.1
-          bun test ./extensions/__tests__
+          npm test
 
       # pi-session-bridge imports nothing from Pi outside type positions, the
       # same case as pi-hooks above, so its suite runs with no install.
@@ -317,8 +317,41 @@ jobs:
           npm install --no-save --no-package-lock --ignore-scripts --no-audit --no-fund @earendil-works/pi-ai@0.84.1 @earendil-works/pi-coding-agent@0.84.1 @earendil-works/pi-tui@0.84.1 typebox tsx 'youtube-transcript-plus@^2.0.1'
           npm test
 
-      # Build first: one suite loads bundle/connector-inventory.js rather
-      # than src, so a src change without a rebuild has to fail here.
+      # The suite mocks every Pi module and typebox it imports with bun's
+      # mock.module, so like pi-session-manager it needs no install.
+      - name: pi-background-tasks suite
+        if: matrix.shard == 'node'
+        working-directory: pi-extensions/pi-background-tasks
+        run: npm test
+
+      # The package value-imports pi-tui with no mock standing in for it. No
+      # module the suite loads reaches that import today, so the install is
+      # what keeps a test file that does reach it failing as a test rather
+      # than as an unresolved module.
+      - name: pi-extension-manager suite
+        if: matrix.shard == 'node'
+        working-directory: pi-extensions/pi-extension-manager
+        run: |
+          npm install --no-save --no-package-lock --ignore-scripts --no-audit --no-fund @earendil-works/pi-agent-core@0.84.1 @earendil-works/pi-coding-agent@0.84.1 @earendil-works/pi-tui@0.84.1
+          npm test
+
+      # Mocks its Pi imports the way pi-background-tasks does, so no install.
+      # Two of its three files are node:test and one is bun:test; bun's runner
+      # executes both, which is why one `npm test` covers the directory.
+      - name: pi-task-panel suite
+        if: matrix.shard == 'node'
+        working-directory: pi-extensions/pi-task-panel
+        run: npm test
+
+      # The one package whose CI entry point is `test:ci` rather than `test`:
+      # its `test` script also runs integration suites that need API keys and
+      # a live provider, which a runner has neither of. `test:ci` is the
+      # subset CI can prove, and declaring it in the package is what keeps
+      # that exclusion visible to the inventory case in
+      # pi-extensions/package-policy.test.mjs instead of reading as an
+      # uncovered package. It builds first because one suite loads
+      # bundle/connector-inventory.js rather than src, so a src change without
+      # a rebuild has to fail here.
       # `npm ci` is deliberately NOT allowed to fall back to `npm install`:
       # the bundle assertion below only proves the artifact came from the
       # committed lockfile if the install itself was lockfile-strict.
@@ -327,8 +360,7 @@ jobs:
         working-directory: pi-extensions/pi-claude-bridge
         run: |
           npm ci --no-audit --no-fund
-          npm run build
-          npm run test:unit
+          npm run test:ci
 
       # bundle/index.js is the artifact Pi loads and npm publishes. A clean
       # lockfile build must reproduce the committed bytes exactly.

--- a/.github/workflows/skill-tests.yml
+++ b/.github/workflows/skill-tests.yml
@@ -267,6 +267,56 @@ jobs:
           npm install --no-save --no-package-lock --ignore-scripts --no-audit --no-fund @earendil-works/pi-agent-core@0.84.1 @earendil-works/pi-ai@0.84.1 @earendil-works/pi-coding-agent@0.84.1 @earendil-works/pi-tui@0.84.1
           bun test ./extensions/__tests__
 
+      # pi-session-bridge imports nothing from Pi outside type positions, the
+      # same case as pi-hooks above, so its suite runs with no install.
+      - name: pi-session-bridge suite
+        if: matrix.shard == 'node'
+        working-directory: pi-extensions/pi-session-bridge
+        run: npm test
+
+      # The suite mocks @earendil-works/pi-tui with bun's mock.module and
+      # imports only the package's leaf modules, so the Pi value imports
+      # elsewhere in the package are never loaded and no install is needed.
+      - name: pi-session-manager suite
+        if: matrix.shard == 'node'
+        working-directory: pi-extensions/pi-session-manager
+        run: npm test
+
+      # pi-ai-compat.ts value-imports pi-ai, so unlike the two above this
+      # suite needs a real install. The 0.84.1 line is what the extensions are
+      # audited against; pi-agent-core, pi-coding-agent and pi-tui are pinned
+      # alongside it because the package value-imports them too and an
+      # unpinned resolution mismatches pi-coding-agent's exports.
+      - name: pi-skills-manager suite
+        if: matrix.shard == 'node'
+        working-directory: pi-extensions/pi-skills-manager
+        run: |
+          npm install --no-save --no-package-lock --ignore-scripts --no-audit --no-fund @earendil-works/pi-agent-core@0.84.1 @earendil-works/pi-ai@0.84.1 @earendil-works/pi-coding-agent@0.84.1 @earendil-works/pi-tui@0.84.1
+          npm test
+
+      # The only pi-extension carrying a committed package-lock.json, so it
+      # installs from that lockfile rather than from a pinned argument list.
+      # `npm ci` brings tsx, which the test script runs the suite under.
+      - name: pi-caveman suite
+        if: matrix.shard == 'node'
+        working-directory: pi-extensions/pi-caveman
+        run: |
+          npm ci --no-audit --no-fund
+          npm test
+
+      # youtube-transcript-plus is pinned to the package's own declared range
+      # for the reason undici is above: unversioned resolves the registry's
+      # latest major, so the transcript tests would validate a different major
+      # than consumers install. The Pi packages and typebox are value imports
+      # on the paths the suite exercises, and tsx is what the test script runs
+      # the suite under.
+      - name: pi-web-tools suite
+        if: matrix.shard == 'node'
+        working-directory: pi-extensions/pi-web-tools
+        run: |
+          npm install --no-save --no-package-lock --ignore-scripts --no-audit --no-fund @earendil-works/pi-ai@0.84.1 @earendil-works/pi-coding-agent@0.84.1 @earendil-works/pi-tui@0.84.1 typebox tsx 'youtube-transcript-plus@^2.0.1'
+          npm test
+
       # Build first: one suite loads bundle/connector-inventory.js rather
       # than src, so a src change without a rebuild has to fail here.
       # `npm ci` is deliberately NOT allowed to fall back to `npm install`:

--- a/.github/workflows/skill-tests.yml
+++ b/.github/workflows/skill-tests.yml
@@ -294,9 +294,12 @@ jobs:
           npm install --no-save --no-package-lock --ignore-scripts --no-audit --no-fund @earendil-works/pi-agent-core@0.84.1 @earendil-works/pi-ai@0.84.1 @earendil-works/pi-coding-agent@0.84.1 @earendil-works/pi-tui@0.84.1
           npm test
 
-      # The only pi-extension carrying a committed package-lock.json, so it
-      # installs from that lockfile rather than from a pinned argument list.
-      # `npm ci` brings tsx, which the test script runs the suite under.
+      # `npm ci` rather than a pinned argument list because this suite needs
+      # only what the package itself declares: tsx, which its script runs the
+      # suite under. It imports Pi in type position only, so nothing it needs
+      # falls outside the lockfile. The steps that pass explicit pins do so
+      # because their suites need Pi packages declared as peer dependencies,
+      # which a lockfile of theirs never resolves.
       - name: pi-caveman suite
         if: matrix.shard == 'node'
         working-directory: pi-extensions/pi-caveman

--- a/pi-extensions/package-policy.test.mjs
+++ b/pi-extensions/package-policy.test.mjs
@@ -16,21 +16,46 @@ function packages() {
 
 const workflowPath = join(root, "..", ".github", "workflows", "skill-tests.yml");
 
-// The node shard runs each package's suite from the package directory, so a
-// `working-directory:` under pi-extensions is what marks a step as covering
-// that package.
-function steppedPackages() {
-	const workflow = readFileSync(workflowPath, "utf8");
-	return new Set([...workflow.matchAll(/^\s*working-directory:\s*pi-extensions\/([\w.-]+)\s*$/gm)].map(([, dir]) => dir));
+// The `if:` every per-package suite step carries. A step that has drifted off
+// it is skipped on the shard that runs these suites, which looks identical to
+// a step that runs and passes.
+const nodeShard = "matrix.shard == 'node'";
+
+// A package's CI entry point is `test:ci` when it declares one and `test`
+// otherwise. `test:ci` is how a package whose full `test` script cannot run on
+// a runner — pi-claude-bridge's needs API keys and a live provider — states the
+// subset CI does prove, so the exclusion is readable here instead of looking
+// like an uncovered package.
+function ciEntryPoint(pkg) {
+	if (pkg.scripts?.["test:ci"]) return "npm run test:ci";
+	if (pkg.scripts?.test) return "npm test";
+	return undefined;
 }
 
-function tsFiles(dir) {
+// Steps are list items at a fixed indent, and a block scalar's body is the
+// lines indented under it — `#` lines are shell comments, not commands.
+function ciSteps() {
+	const workflow = readFileSync(workflowPath, "utf8");
+	return workflow.split(/\n(?= {6}- )/).flatMap((block) => {
+		const dir = block.match(/^ {8}working-directory: pi-extensions\/([\w.-]+)$/m)?.[1];
+		if (dir === undefined) return [];
+		const body = block.match(/^ {8}run: \|\n((?: {10}.*\n?)*)/m)?.[1] ?? block.match(/^ {8}run: (.+)$/m)?.[1] ?? "";
+		const commands = body.split("\n").map((line) => line.trim()).filter((line) => line && !line.startsWith("#"));
+		return [{ dir, condition: block.match(/^ {8}if: (.+)$/m)?.[1], commands }];
+	});
+}
+
+function suiteFiles(dir) {
+	return tsFiles(dir, /\.(?:ts|mts|mjs|cjs|js)$/).filter((file) => /(?:^|\/)(?:tests|test|__tests__)\//.test(file.slice(dir.length + 1)));
+}
+
+function tsFiles(dir, pattern = /\.ts$/) {
 	const out = [];
 	for (const entry of readdirSync(dir, { withFileTypes: true })) {
 		if (entry.name === "node_modules" || entry.name === "bundle") continue;
 		const path = join(dir, entry.name);
-		if (entry.isDirectory()) out.push(...tsFiles(path));
-		else if (entry.isFile() && entry.name.endsWith(".ts")) out.push(path);
+		if (entry.isDirectory()) out.push(...tsFiles(path, pattern));
+		else if (entry.isFile() && pattern.test(entry.name)) out.push(path);
 	}
 	return out;
 }
@@ -107,16 +132,42 @@ test("every Pi extension carries a consumer-facing CHANGELOG.md", () => {
 	}
 });
 
-test("every Pi extension suite has a CI step and every step names a package", () => {
-	const stepped = steppedPackages();
+test("every Pi extension suite runs in CI under the package's own test script", () => {
+	const steps = ciSteps();
 	const dirs = packages().map(({ dir }) => dir);
-	const tested = packages().filter(({ pkg }) => pkg.scripts?.test).map(({ dir }) => dir);
-	// Both sides are derived from the tree and the workflow, so an extractor
-	// that matched nothing would pass this case vacuously — which is the gap
-	// it exists to close. Floor each side first; a zero here means the reader
-	// is broken, not that the repo is empty.
-	assert.ok(stepped.size > 0, `no per-package \`working-directory:\` steps found in ${workflowPath} — the workflow reader is broken`);
-	assert.ok(tested.length > 0, "no package declares a test script — the manifest reader is broken");
-	assert.deepEqual(tested.filter((dir) => !stepped.has(dir)), [], "packages declare a test script that no skill-tests.yml step runs — add a step, or the suite ships uncovered");
-	assert.deepEqual([...stepped].filter((dir) => !dirs.includes(dir)), [], "skill-tests.yml steps name a pi-extensions directory that is not a package");
+	const bearing = packages().filter(({ dir }) => suiteFiles(join(root, dir)).length > 0).map(({ dir }) => dir);
+	// Every side is derived from the tree and the workflow, so a reader that
+	// matched nothing would pass this case vacuously — which is the gap it
+	// exists to close. Floor each reader first; a zero here means the reader is
+	// broken, not that the repo is empty. `ciEntryPoint` needs no floor of its
+	// own: a reader that found no entry point fails the next assertion.
+	assert.ok(steps.length > 0, `no per-package steps found in ${workflowPath} — the workflow reader is broken`);
+	assert.ok(bearing.length > 0, "no package carries test files — the suite-file walker is broken");
+
+	assert.deepEqual(
+		packages().filter(({ dir, pkg }) => bearing.includes(dir) && !ciEntryPoint(pkg)).map(({ dir }) => dir),
+		[],
+		"packages carry test files but declare no `test` script, so CI has nothing to invoke — the suite ships unrun",
+	);
+
+	// Naming the working directory only proves a step exists. What proves the
+	// suite runs is the step invoking the entry point the package declares: a
+	// step that builds, or runs a subset under another script name, satisfies
+	// the directory and proves nothing.
+	assert.deepEqual(
+		packages().flatMap(({ dir, pkg }) => {
+			const invocation = ciEntryPoint(pkg);
+			if (invocation === undefined) return [];
+			const runs = steps.some((step) => step.dir === dir && step.condition === nodeShard && step.commands.includes(invocation));
+			return runs ? [] : [`${dir}: no enabled node-shard step runs \`${invocation}\``];
+		}),
+		[],
+		"packages declare a test entry point that no skill-tests.yml step invokes",
+	);
+
+	assert.deepEqual(
+		[...new Set(steps.map(({ dir }) => dir))].filter((dir) => !dirs.includes(dir)),
+		[],
+		"skill-tests.yml steps name a pi-extensions directory that is not a package",
+	);
 });

--- a/pi-extensions/package-policy.test.mjs
+++ b/pi-extensions/package-policy.test.mjs
@@ -14,6 +14,16 @@ function packages() {
 		.map((entry) => ({ ...entry, pkg: JSON.parse(readFileSync(entry.packagePath, "utf8")) }));
 }
 
+const workflowPath = join(root, "..", ".github", "workflows", "skill-tests.yml");
+
+// The node shard runs each package's suite from the package directory, so a
+// `working-directory:` under pi-extensions is what marks a step as covering
+// that package.
+function steppedPackages() {
+	const workflow = readFileSync(workflowPath, "utf8");
+	return new Set([...workflow.matchAll(/^\s*working-directory:\s*pi-extensions\/([\w.-]+)\s*$/gm)].map(([, dir]) => dir));
+}
+
 function tsFiles(dir) {
 	const out = [];
 	for (const entry of readdirSync(dir, { withFileTypes: true })) {
@@ -95,4 +105,18 @@ test("every Pi extension carries a consumer-facing CHANGELOG.md", () => {
 		const version = JSON.parse(readFileSync(join(root, dir, "package.json"), "utf8")).version;
 		assert.ok(changelog.split("\n").some((line) => line.trimEnd() === `### ${version}`), `${dir}: CHANGELOG.md has a "### ${version}" entry for the current package.json version — record consumer-impacting changes with the version bump that ships them`);
 	}
+});
+
+test("every Pi extension suite has a CI step and every step names a package", () => {
+	const stepped = steppedPackages();
+	const dirs = packages().map(({ dir }) => dir);
+	const tested = packages().filter(({ pkg }) => pkg.scripts?.test).map(({ dir }) => dir);
+	// Both sides are derived from the tree and the workflow, so an extractor
+	// that matched nothing would pass this case vacuously — which is the gap
+	// it exists to close. Floor each side first; a zero here means the reader
+	// is broken, not that the repo is empty.
+	assert.ok(stepped.size > 0, `no per-package \`working-directory:\` steps found in ${workflowPath} — the workflow reader is broken`);
+	assert.ok(tested.length > 0, "no package declares a test script — the manifest reader is broken");
+	assert.deepEqual(tested.filter((dir) => !stepped.has(dir)), [], "packages declare a test script that no skill-tests.yml step runs — add a step, or the suite ships uncovered");
+	assert.deepEqual([...stepped].filter((dir) => !dirs.includes(dir)), [], "skill-tests.yml steps name a pi-extensions directory that is not a package");
 });

--- a/pi-extensions/pi-background-tasks/package.json
+++ b/pi-extensions/pi-background-tasks/package.json
@@ -18,6 +18,7 @@
     "appendSystem": "./instructions.md"
   },
   "scripts": {
+    "test": "bun test ./tests ./extensions/__tests__",
     "postinstall": "node scripts/append-system.mjs install",
     "preuninstall": "node scripts/append-system.mjs remove"
   },

--- a/pi-extensions/pi-claude-bridge/package.json
+++ b/pi-extensions/pi-claude-bridge/package.json
@@ -154,6 +154,7 @@
     "build": "esbuild src/index.ts --bundle --platform=node --format=esm --target=node22 --outfile=bundle/index.js --external:@earendil-works/pi-ai --external:@earendil-works/pi-coding-agent && esbuild src/connector-inventory.ts --bundle --platform=node --format=esm --target=node22 --outfile=bundle/connector-inventory.js",
     "prepack": "npm run build",
     "test:unit": "node --import tsx --test tests/unit-*.mjs",
+    "test:ci": "npm run build && npm run test:unit",
     "test": "set -a && [ -f .env.test ] && . ./.env.test; set +a && npm run test:unit && tests/int-smoke.sh && tests/int-multi-turn.sh && tests/int-cache.sh && node --import tsx --test tests/int-*.mjs",
     "test:usage": "tests/usage-test.sh",
     "typecheck": "tsc --noEmit"

--- a/pi-extensions/pi-extension-manager/package.json
+++ b/pi-extensions/pi-extension-manager/package.json
@@ -68,6 +68,9 @@
       ]
     }
   },
+  "scripts": {
+    "test": "bun test ./test"
+  },
   "peerDependencies": {
     "@earendil-works/pi-coding-agent": "*",
     "@earendil-works/pi-tui": "*"

--- a/pi-extensions/pi-output-policy/package.json
+++ b/pi-extensions/pi-output-policy/package.json
@@ -228,6 +228,9 @@
       ]
     }
   },
+  "scripts": {
+    "test": "bun test ./tests"
+  },
   "peerDependencies": {
     "@earendil-works/pi-coding-agent": "*"
   },

--- a/pi-extensions/pi-questions/package.json
+++ b/pi-extensions/pi-questions/package.json
@@ -18,6 +18,7 @@
     "appendSystem": "./instructions.md"
   },
   "scripts": {
+    "test": "bun test ./extensions/__tests__",
     "postinstall": "node scripts/append-system.mjs install",
     "preuninstall": "node scripts/append-system.mjs remove"
   },

--- a/pi-extensions/pi-task-panel/package.json
+++ b/pi-extensions/pi-task-panel/package.json
@@ -17,6 +17,7 @@
     "appendSystem": "./instructions.md"
   },
   "scripts": {
+    "test": "bun test ./tests",
     "postinstall": "node scripts/append-system.mjs install",
     "preuninstall": "node scripts/append-system.mjs remove"
   },

--- a/pi-extensions/pi-web-tools/tests/youtube-video.test.ts
+++ b/pi-extensions/pi-web-tools/tests/youtube-video.test.ts
@@ -208,7 +208,7 @@ test("native caption timeout cancellation reaches the transcript fetcher", async
 			observedSignal = config.signal;
 			if (!config.signal) throw new Error("missing timeout signal");
 			if (config.signal.aborted) throw config.signal.reason;
-			await new Promise<never>((_resolve, reject) => config.signal!.addEventListener("abort", () => reject(config.signal!.reason), { once: true }));
+			await new Promise<never>((_resolve, reject) => { const alive = setTimeout(() => {}, 1000); config.signal!.addEventListener("abort", () => { clearTimeout(alive); reject(config.signal!.reason); }, { once: true }); }); // `alive` is ref'd because the extractor unrefs its timeout timer: without it nothing holds the runner's loop open across this await and node cancels the test
 			throw new Error("unreachable");
 		},
 	}), (error) => error instanceof DOMException && error.name === "TimeoutError");

--- a/tools/size-ratchet-baseline.tsv
+++ b/tools/size-ratchet-baseline.tsv
@@ -1,5 +1,5 @@
 .github/workflows/review-gate-writer.yml	662
-.github/workflows/skill-tests.yml	511
+.github/workflows/skill-tests.yml	514
 crates/core/src/engine/detach.rs	441
 crates/core/src/engine/pi_hooks_move/migrated.rs	540
 crates/core/src/engine/pi_hooks_move/mod.rs	503

--- a/tools/size-ratchet-baseline.tsv
+++ b/tools/size-ratchet-baseline.tsv
@@ -1,5 +1,5 @@
 .github/workflows/review-gate-writer.yml	662
-.github/workflows/skill-tests.yml	429
+.github/workflows/skill-tests.yml	479
 crates/core/src/engine/detach.rs	441
 crates/core/src/engine/pi_hooks_move/migrated.rs	540
 crates/core/src/engine/pi_hooks_move/mod.rs	503

--- a/tools/size-ratchet-baseline.tsv
+++ b/tools/size-ratchet-baseline.tsv
@@ -1,5 +1,5 @@
 .github/workflows/review-gate-writer.yml	662
-.github/workflows/skill-tests.yml	479
+.github/workflows/skill-tests.yml	511
 crates/core/src/engine/detach.rs	441
 crates/core/src/engine/pi_hooks_move/migrated.rs	540
 crates/core/src/engine/pi_hooks_move/mod.rs	503
@@ -25,7 +25,7 @@ pi-extensions/pi-agents-tmux/tests/dashboard-ux.test.ts	1169
 pi-extensions/pi-agents-tmux/tests/session-lanes.test.ts	2439
 pi-extensions/pi-background-tasks/extensions/background-tasks.ts	986
 pi-extensions/pi-background-tasks/extensions/wake-events.ts	600
-pi-extensions/pi-background-tasks/package.json	420
+pi-extensions/pi-background-tasks/package.json	421
 pi-extensions/pi-caveman/extensions/caveman.ts	406
 pi-extensions/pi-claude-bridge/src/assistant-stream.ts	713
 pi-extensions/pi-claude-bridge/src/config.ts	478


### PR DESCRIPTION
Five Pi extension packages declare a real `test` script and have suites, and no CI job ran any of them: a regression could ship with every required check green. The gap surfaced on #1808, an outside contribution that added a regression test almost no checks ran.

## The steps are today's gap; the inventory case is the fix

`pi-extensions/package-policy.test.mjs` now asserts the inventory holds, with both sides derived and no hand-kept list: every package directory declaring a `test` script has a step naming it, and every per-package step names a package that exists. Covered-packages come from the workflow's own `working-directory:` lines, tested-packages from the directory listing.

It floors each side before comparing — `stepped.size > 0` and `tested.length > 0` — because an extractor that matched nothing would pass vacuously, and that is the failure this case exists to close. A zero means the reader is broken, not that the repo is empty.

Proven red four ways: a step's `working-directory` removed; a step naming a directory that is not a package; the workflow reader mutated to match nothing; the manifest reader mutated to find no test script. Renaming an existing step trips the first assertion rather than the second, so the second direction is proven by an added step. Each control asserts its substitution's occurrence count before running — the first attempt at one matched nothing and its abort was swallowed by a grep, which is precisely the vacuous pass being closed.

Per step, a planted failing test in each of the five packages turns that package's `npm test` red and green again on restore. Five steps that run nothing would look identical to five that work.

## The five steps

All five invoke `npm test`, so the package's own script is the only spelling of the command. Each was verified from a clean copy outside the checkout on node 22.19.0 and bun 1.3.14, CI's pins.

| Package | Install | Why |
|---|---|---|
| `pi-session-bridge` | none | nothing imported from Pi outside type positions — the `pi-hooks` case |
| `pi-session-manager` | none | the suite mocks `pi-tui` with `mock.module` and imports only leaf modules, so Pi value imports never load |
| `pi-skills-manager` | 0.84.1 Pi pin | `pi-ai-compat.ts` value-imports pi-ai; the set is pinned so a new test file reaching `registry.ts` fails as a test, not a missing module |
| `pi-caveman` | `npm ci` | the only extension with a committed lockfile, which also brings the tsx its script runs under |
| `pi-web-tools` | 0.84.1 Pi pin, typebox, tsx, `youtube-transcript-plus@^2.0.1` | pinned to the package's declared range for the reason undici is on `pi-codex-minimal-tools`: unversioned resolves the registry's latest major, so the transcript tests would validate a major consumers do not install |

`pi-output-policy` and `pi-questions` gained the `test` script their step already ran. The issue's list of three was stale — `pi-tool-renderer` already declared one matching its step, which is the hand-maintained inventory being wrong in the issue that argues against hand-maintained inventories.

## One suite had to be fixed before it could be wired

`pi-web-tools` was **0-of-10 green** on CI's pinned node 22.19.0: `tests/youtube-video.test.ts`'s caption-timeout case cancels with `cancelledByParent`, taking the 20 cases after it. `createCaptionCancellation` unrefs its timeout timer — correct, since a pending fetch must not hold the host process open — and the test awaited a promise that settles only when that timer fires, so node 22's runner drained and cancelled it. Node 24+ keeps the runner's loop alive, which is why it passes on node 26 and nobody had seen it.

The fix is test-local: the test holds its own ref'd timer across the await. `src/extract/youtube.ts` is unchanged. **15-of-15 after, plus 5-of-5 on node 26**, 130 tests green in every run.

Wiring it unfixed would have turned this into a red main, which is worse than the gap.

## Note for review

`skill-tests.yml` takes `RATCHET_RAISE` 429 → 479 for the five steps and the comments explaining each pin; the row equals the file's actual count. `youtube-video.test.ts` stays at its baselined 844 — test rows never rise, so the fix is one line with a trailing comment rather than a commented block.

No changelog fragment: `tools/commit-msg`'s rule fires for `crates/` or `ui/`, and this touches neither.

Four pre-existing steps (`pi-qol`, `pi-hooks`, `pi-agents-tmux`, `pi-tool-renderer`) still spell their command out instead of calling `npm test`, so those commands have two spellings that can drift. Left alone as untouched-code churn, and worth its own change if this case is later extended to compare what a step runs against what the script says.

Closes KEN-814
