### PR TITLE
fix(KEN-820): an update installs only what the release published

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,7 +1,8 @@
 # Release: build the CLI and the desktop app on a native runner per
 # target, then publish a GitHub Release carrying every artifact, the
-# feed.json that `kendex update` consumes, and the signed latest.json the
-# app's Update button installs from.
+# feed.json that `kendex update` consumes, the latest.json the app's Update
+# button installs from, and the signed digests document each lane publishes
+# about what it built.
 #
 # Tag push only: a release bundle is the most expensive job in the repo,
 # and pull requests are covered by the per-crate checks. No build cache:
@@ -139,24 +140,20 @@ jobs:
           done
           ls -l dist
         shell: bash
-      # `kendex update` refuses a command the signature beside it does not
-      # cover, so the command is signed under the same key as the app
-      # bundles. Tauri's signer writes `<file>.sig`; a lane that produced
-      # none published a download no client can verify, so it fails here.
-      - name: Sign the kendex command
+      # A signature proves the bytes it covers and not which release they
+      # are, so this lane also publishes the document that says what it
+      # built: the version, the target, and the hash of each download.
+      # `kendex update` and the app's Update button hold every download to
+      # it. The script signs the document and the command under the same
+      # key the app bundles with, and fails the lane rather than publishing
+      # a download no client can verify.
+      - name: Sign this lane's downloads
         shell: bash
         env:
           TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
           TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}
         run: |
-          ext=""
-          [ "${{ runner.os }}" = "Windows" ] && ext=".exe"
-          binary="dist/kendex-${{ matrix.target }}${ext}"
-          ui/node_modules/.bin/tauri signer sign "$binary"
-          if [ ! -s "${binary}.sig" ]; then
-            echo "::error::No signature for ${binary}. kendex update refuses a command it cannot verify; check this lane's signer step and TAURI_SIGNING_PRIVATE_KEY, then re-run the tag."
-            exit 1
-          fi
+          tools/release-digests "${{ matrix.target }}" "${GITHUB_REF_NAME#v}" dist
       - uses: actions/upload-artifact@v4
         with:
           name: assets-${{ matrix.target }}
@@ -298,11 +295,11 @@ jobs:
           draft: ${{ steps.tag.outputs.prerelease == 'false' }}
           prerelease: ${{ steps.tag.outputs.prerelease == 'true' }}
       # And because "latest" skips them, a candidate has no way to reach the
-      # next one. This release is that way: one fixed tag whose two manifests
-      # are overwritten by each new candidate, which is the URL
-      # `update_channel::feed_url_for` sends a candidate to. The manifests
-      # name their downloads by the tag that built them, so what they point
-      # at is this tag's own release, published by the step above.
+      # next one. This release is that way: one fixed tag whose manifests
+      # and digests documents are overwritten by each new candidate, which
+      # is the URL `update_channel::feed_url_for` sends a candidate to.
+      # They name their downloads by the tag that built them, so what they
+      # point at is this tag's own release, published by the step above.
       - name: Point the pre-release channel at this tag
         if: steps.tag.outputs.prerelease == 'true'
         shell: bash
@@ -352,12 +349,13 @@ jobs:
             # An absent manifest is a channel nothing has published to yet,
             # which is the one case that leaves `current` empty on purpose.
             if grep -qxF latest.json <<< "$assets"; then
-              # Both manifests come down, not only the one the comparison
-              # reads: `gh release upload --clobber` deletes an asset
-              # before uploading its replacement, so these are the only
-              # copies of what the channel had if that upload then fails.
-              if ! gh release download "$CHANNEL" --repo "$GITHUB_REPOSITORY" \
-                   --dir saved --pattern latest.json --pattern feed.json --clobber; then
+              # Everything the channel serves comes down, not only the
+              # one the comparison reads: `gh release upload --clobber`
+              # deletes an asset before uploading its replacement, so
+              # these are the only copies of what the channel had if that
+              # upload then fails.
+              if ! gh release download "$CHANNEL" --repo "$GITHUB_REPOSITORY" --dir saved \
+                   --pattern latest.json --pattern feed.json --pattern 'digests-*' --clobber; then
                 echo "::error::The ${CHANNEL} channel carries a manifest that could not be downloaded. Nothing was written; re-run the tag."
                 exit 1
               fi
@@ -382,7 +380,7 @@ jobs:
             echo "::notice::The pre-release channel carries ${current}, ahead of ${NEW_VERSION}; leaving it as it is."
             exit 0
           fi
-          if ! gh release upload "$CHANNEL" dist/latest.json dist/feed.json \
+          if ! gh release upload "$CHANNEL" dist/latest.json dist/feed.json dist/digests-* \
                --repo "$GITHUB_REPOSITORY" --clobber; then
             # An upload that failed after the delete leaves the channel
             # short a manifest, and a candidate reading a channel with no
@@ -390,7 +388,7 @@ jobs:
             # This is not an atomic swap and does not pretend to be: the
             # job fails either way, and the second message is there because
             # a channel nobody repaired needs saying out loud.
-            if [ -n "$saved" ] && ! gh release upload "$CHANNEL" saved/*.json \
+            if [ -n "$saved" ] && ! gh release upload "$CHANNEL" saved/* \
                  --repo "$GITHUB_REPOSITORY" --clobber; then
               echo "::error::Uploading to the ${CHANNEL} channel failed and the manifests it had could not be put back. Candidates see no updates until a tag re-run repairs the channel."
               exit 1

--- a/changelog.d/security/KEN-820.md
+++ b/changelog.d/security/KEN-820.md
@@ -1,0 +1,3 @@
+- `kendex update` and the app's Update button hold each download to the release's
+  signed record of what it published for this target, so a real signature over
+  another release's binary is refused.

--- a/crates/app/src/app_update.rs
+++ b/crates/app/src/app_update.rs
@@ -116,6 +116,36 @@ fn aim_at_install<T: ReplacementTarget>(target: T, install: &AppInstall) -> T {
     }
 }
 
+/// Whatever will write the downloaded bytes over this install. The plugin
+/// does that behind a method of its own, so this is the only side of the
+/// handoff a test can watch — and the one thing every install has to pass
+/// through on its way there is below.
+trait Installer {
+    fn place(&self, bytes: Vec<u8>) -> Result<(), String>;
+}
+
+impl Installer for tauri_plugin_updater::Update {
+    fn place(&self, bytes: Vec<u8>) -> Result<(), String> {
+        self.install(bytes).map_err(|error| error.to_string())
+    }
+}
+
+/// Write `bytes` only once this release's own document names them as the
+/// download it published for this target. The plugin has already checked
+/// the signature the manifest carried over them, which says they are a
+/// kendex release's and not which one; this is what says they are the
+/// release being installed. Bytes that fail it never reach `installer`.
+fn install_published(
+    digests: &ReleaseDigests,
+    bytes: Vec<u8>,
+    installer: &impl Installer,
+) -> Result<(), String> {
+    digests
+        .verify_app(&bytes)
+        .map_err(|error| error.to_string())?;
+    installer.place(bytes)
+}
+
 /// Where this build installs from, as the plugin wants it. `tauri.conf.json`
 /// names the release channel so the plugin has a configured default, and a
 /// test holds that entry to the same constant; handing the choice over on
@@ -205,10 +235,7 @@ pub async fn app_update_install(app: tauri::AppHandle) -> Result<(), String> {
     let digests = tauri::async_runtime::spawn_blocking(move || published_for_this_target(&offered))
         .await
         .map_err(|error| format!("kendex could not read what this release published: {error}"))??;
-    digests
-        .verify_app(&bytes)
-        .map_err(|error| error.to_string())?;
-    update.install(bytes).map_err(|error| error.to_string())?;
+    install_published(&digests, bytes, &update)?;
     app.restart()
 }
 

--- a/crates/app/src/app_update.rs
+++ b/crates/app/src/app_update.rs
@@ -1,7 +1,10 @@
 use kendex_core::app_update::AppUpdateView;
 use kendex_core::env::Env;
 use kendex_core::install_channel::{AppInstall, Host, InstallChannel};
-use kendex_core::registry::ReleaseFeedFetch;
+use kendex_core::registry::{Fetch, ReleaseFeedFetch};
+use kendex_core::release_digests::{ReleaseDigests, release_digests_url};
+use kendex_core::update_channel::manifest_url_for;
+use kendex_core::update_feed::{UPDATER_PUBLIC_KEY, signature_url};
 use tauri_plugin_updater::UpdaterExt;
 
 fn feed_url() -> String {
@@ -120,15 +123,57 @@ fn aim_at_install<T: ReplacementTarget>(target: T, install: &AppInstall) -> T {
 /// already put its notice card on, instead of two files that agree only
 /// while nobody edits one.
 fn manifest_endpoint() -> Result<tauri::Url, String> {
-    let url = kendex_core::update_channel::manifest_url_for(env!("CARGO_PKG_VERSION"));
+    let url = manifest_url_for(env!("CARGO_PKG_VERSION"));
     tauri::Url::parse(url)
         .map_err(|error| format!("the update manifest URL {url} is unusable: {error}"))
 }
 
+/// The release's own statement about what it published for this target,
+/// read from beside the manifest this build installs from and held to the
+/// release the manifest offered.
+///
+/// The plugin verifies the signature the manifest carries over the bytes
+/// it downloads, which proves they are a kendex release's and not which
+/// one: nothing signs the manifest, so one that can be served or altered
+/// can name a genuine older download, or another platform's, and that
+/// signature checks out. The document names the release, the target and
+/// the hash of each download, and is signed under the key this build
+/// pins, so a download this release did not publish is refused.
+fn published_for_this_target(version: &str) -> Result<ReleaseDigests, String> {
+    read_published(UPDATER_PUBLIC_KEY, env!("KENDEX_TARGET"), version, |url| {
+        let response = ReleaseFeedFetch
+            .get(url, None)
+            .map_err(|error| error.to_string())?;
+        match response.status {
+            200 => Ok(response.body),
+            status => Err(format!("reading {url} answered {status}")),
+        }
+    })
+}
+
+/// The read itself. The key, the target and the transport are arguments
+/// for the reason core's key is: a test holds a release it signed itself,
+/// for a target it names, without reaching the network.
+fn read_published(
+    public_key: &str,
+    target: &str,
+    version: &str,
+    read: impl Fn(&str) -> Result<Vec<u8>, String>,
+) -> Result<ReleaseDigests, String> {
+    let manifest = manifest_url_for(env!("CARGO_PKG_VERSION"));
+    let url = release_digests_url(manifest, target).map_err(|error| error.to_string())?;
+    let document = read(&url)?;
+    let signature = read(&signature_url(&url))?;
+    ReleaseDigests::for_release(public_key, &document, &signature, version, target)
+        .map_err(|error| error.to_string())
+}
+
 /// Replace this install with the latest release and relaunch into it. The
-/// separately signed updater manifest is the delivery path and verifies
-/// itself; the discovery feed never supplies an install URL. A failure
-/// leaves the running app untouched and usable.
+/// manifest names a download and the signature over it; the release's own
+/// digests document names which download this release published for this
+/// target, and the bytes are held to both before anything is installed.
+/// The discovery feed never supplies an install URL. A failure leaves the
+/// running app untouched and usable.
 #[tauri::command]
 #[specta::specta]
 pub async fn app_update_install(app: tauri::AppHandle) -> Result<(), String> {
@@ -148,10 +193,22 @@ pub async fn app_update_install(app: tauri::AppHandle) -> Result<(), String> {
         .await
         .map_err(|error| error.to_string())?
         .ok_or_else(|| "this build is already the latest release".to_owned())?;
-    update
-        .download_and_install(|_chunk, _total| {}, || {})
+    // Downloaded, then judged, then installed: the plugin's own check runs
+    // on the way down, and what this release published for this target is
+    // what says those bytes are the ones the version being installed
+    // names. The read is blocking, so it runs off the async runtime.
+    let bytes = update
+        .download(|_chunk, _total| {}, || {})
         .await
         .map_err(|error| error.to_string())?;
+    let offered = update.version.clone();
+    let digests = tauri::async_runtime::spawn_blocking(move || published_for_this_target(&offered))
+        .await
+        .map_err(|error| format!("kendex could not read what this release published: {error}"))??;
+    digests
+        .verify_app(&bytes)
+        .map_err(|error| error.to_string())?;
+    update.install(bytes).map_err(|error| error.to_string())?;
     app.restart()
 }
 
@@ -167,138 +224,4 @@ pub fn schedule_startup_check() {
 }
 
 #[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn only_debug_builds_accept_a_feed_override() {
-        let fixture = "file:///fixtures/feed.json".to_owned();
-        assert_eq!(selected_feed(Some(fixture.clone()), true), fixture);
-        assert_eq!(
-            selected_feed(Some(fixture), false),
-            kendex_core::update_channel::feed_url_for(env!("CARGO_PKG_VERSION"))
-        );
-    }
-
-    /// The card's check and the install have to be looking at one release,
-    /// or a candidate is offered an update the installer then cannot find.
-    /// Both read the running version, so this asserts they land on the same
-    /// channel and that the endpoint is a URL the plugin will take.
-    #[test]
-    fn the_notice_and_the_install_read_one_channel() {
-        let version = env!("CARGO_PKG_VERSION");
-        let endpoint = manifest_endpoint().expect("the manifest URL parses");
-        assert_eq!(
-            endpoint.as_str(),
-            kendex_core::update_channel::manifest_url_for(version)
-        );
-        use kendex_core::update_channel::{PRERELEASE_FEED_URL, PRERELEASE_MANIFEST_URL};
-        assert_eq!(
-            selected_feed(None, false) == PRERELEASE_FEED_URL,
-            endpoint.as_str() == PRERELEASE_MANIFEST_URL,
-            "the feed and the manifest are on different channels for {version}"
-        );
-    }
-
-    /// Stands in for the updater builder, which keeps what it was handed
-    /// private. What reaches it is what the plugin would have been given.
-    #[derive(Default)]
-    struct Recorder(Option<std::path::PathBuf>);
-
-    impl ReplacementTarget for Recorder {
-        fn replace_at(self, path: &std::path::Path) -> Self {
-            Self(Some(path.to_owned()))
-        }
-    }
-
-    /// The handoff itself. Everything else about this change can be right
-    /// while the approved path never leaves `app_update_install`, and the
-    /// plugin then falls back to rebuilding its own from the launch
-    /// environment, which is the whole defect.
-    #[test]
-    fn the_approved_path_reaches_whatever_will_replace_it() {
-        for install in [
-            AppInstall::AppImage(Some("/home/pat/Apps/kendex.AppImage".into())),
-            AppInstall::MacBundle("/Applications/kendex.app/Contents/MacOS/kendex".into()),
-        ] {
-            assert_eq!(
-                aim_at_install(Recorder::default(), &install).0.as_deref(),
-                install.judged_path(),
-                "{install:?}"
-            );
-        }
-
-        // Nothing to hand over, so the target keeps its own fallback.
-        for install in [AppInstall::WindowsInstaller, AppInstall::AppImage(None)] {
-            assert_eq!(
-                aim_at_install(Recorder::default(), &install).0,
-                None,
-                "{install:?}"
-            );
-        }
-    }
-
-    /// Only the bundle is writable, so `for_app` can approve nothing else.
-    struct OnlyWritable(&'static str);
-
-    impl kendex_core::install_channel::HostProbe for OnlyWritable {
-        fn replaceable(&self, path: &std::path::Path) -> bool {
-            path == std::path::Path::new(self.0)
-        }
-
-        fn exists(&self, _: &std::path::Path) -> bool {
-            false
-        }
-
-        fn resolve(&self, path: &std::path::Path) -> std::path::PathBuf {
-            path.to_owned()
-        }
-
-        fn on_path(&self, _: &str) -> bool {
-            false
-        }
-
-        fn os_release(&self) -> Option<String> {
-            None
-        }
-    }
-
-    /// The plugin decides for itself what to replace, deriving it from the
-    /// path it is handed, so nothing kendex asserts about that path proves
-    /// the two agree. This asks the plugin.
-    ///
-    /// Getting it wrong is not a failed update. The derived path is what the
-    /// macOS installer removes before moving the new bundle in, escalating a
-    /// permission error to a shell `rm -rf` under `with administrator
-    /// privileges`. Hand over the bundle instead of the executable inside it
-    /// and the plugin climbs one level further, to the directory holding
-    /// every other app on the machine. The dependency is a caret range, so a
-    /// minor bump can move this derivation under an unchanged kendex.
-    #[test]
-    fn the_plugin_derives_the_unit_for_app_approved() {
-        let exe = "/Applications/kendex.app/Contents/MacOS/kendex";
-        let bundle = "/Applications/kendex.app";
-        let probe = OnlyWritable(bundle);
-        let install = AppInstall::mac_bundle(&probe, std::path::Path::new(exe));
-        assert_eq!(
-            kendex_core::install_channel::for_app(&install, &probe),
-            InstallChannel::Direct
-        );
-
-        let handed = install.judged_path().expect("a mac bundle carries a path");
-        let derived = tauri_plugin_updater::extract_path_from_executable(handed)
-            .expect("the plugin derives a path from an executable inside a bundle");
-        // True on every platform the function compiles for, and the property
-        // that matters: what the plugin acts on never escapes what kendex
-        // approved.
-        assert!(
-            derived.starts_with(bundle),
-            "plugin derived {} from {handed}, outside the approved {bundle}",
-            derived.display(),
-            handed = handed.display()
-        );
-        // Where the derivation runs for real it lands on the bundle exactly.
-        #[cfg(target_os = "macos")]
-        assert_eq!(derived, std::path::Path::new(bundle));
-    }
-}
+mod tests;

--- a/crates/app/src/app_update/tests.rs
+++ b/crates/app/src/app_update/tests.rs
@@ -1,0 +1,199 @@
+use super::*;
+
+#[test]
+fn only_debug_builds_accept_a_feed_override() {
+    let fixture = "file:///fixtures/feed.json".to_owned();
+    assert_eq!(selected_feed(Some(fixture.clone()), true), fixture);
+    assert_eq!(
+        selected_feed(Some(fixture), false),
+        kendex_core::update_channel::feed_url_for(env!("CARGO_PKG_VERSION"))
+    );
+}
+
+/// The card's check and the install have to be looking at one release,
+/// or a candidate is offered an update the installer then cannot find.
+/// Both read the running version, so this asserts they land on the same
+/// channel and that the endpoint is a URL the plugin will take.
+#[test]
+fn the_notice_and_the_install_read_one_channel() {
+    let version = env!("CARGO_PKG_VERSION");
+    let endpoint = manifest_endpoint().expect("the manifest URL parses");
+    assert_eq!(
+        endpoint.as_str(),
+        kendex_core::update_channel::manifest_url_for(version)
+    );
+    use kendex_core::update_channel::{PRERELEASE_FEED_URL, PRERELEASE_MANIFEST_URL};
+    assert_eq!(
+        selected_feed(None, false) == PRERELEASE_FEED_URL,
+        endpoint.as_str() == PRERELEASE_MANIFEST_URL,
+        "the feed and the manifest are on different channels for {version}"
+    );
+}
+
+/// The document naming what this release published is read from beside
+/// the manifest the install reads, so both come off the channel this
+/// build follows. It is also the one place this build's own target has
+/// to be a name the read will accept: a triple the rule refuses would
+/// leave this platform unable to install anything.
+#[test]
+fn the_digests_document_sits_beside_the_manifest_the_install_reads() {
+    let endpoint = manifest_endpoint().expect("the manifest URL parses");
+    let target = env!("KENDEX_TARGET");
+    let (directory, _) = endpoint
+        .as_str()
+        .rsplit_once('/')
+        .expect("the manifest is served from a directory");
+    assert_eq!(
+        release_digests_url(manifest_url_for(env!("CARGO_PKG_VERSION")), target)
+            .expect("this build's target names a document"),
+        format!("{directory}/digests-{target}.json")
+    );
+}
+
+/// A throwaway minisign keypair and the document it signed for a 9.9.9
+/// Linux lane, so the install's own read runs the real check rather than a
+/// stub standing in for it.
+const TEST_KEY: &str = "dW50cnVzdGVkIGNvbW1lbnQ6IG1pbmlzaWduIHB1YmxpYyBrZXk6IDc1RTYwNzZERUJFMDVFNTcKUldSWFh1RHJiUWZtZFdVSnJYQmd0QnhLVUdUQnN2MWNTR2N6SW9jZ1Z1Q0FoZmlzWDVIeFZJaUkK";
+const TEST_TARGET: &str = "x86_64-unknown-linux-gnu";
+const PUBLISHED: &str = r#"{
+  "schema": 1,
+  "version": "9.9.9",
+  "target": "x86_64-unknown-linux-gnu",
+  "command": "aae05017e20c96dd3cd26b1fd324365c2ab53512db82b53362e75f8f553ffaea",
+  "app": "d489b792c3c3d6e9633ff28507f2c7da40a24eec743521842ebc283c2c3226ff"
+}
+"#;
+const PUBLISHED_SIGNATURE: &str = "dW50cnVzdGVkIGNvbW1lbnQ6IHNpZ25hdHVyZSBmcm9tIHRhdXJpIHNlY3JldCBrZXkKUlVSWFh1RHJiUWZtZFpxNkg5WFpISHVZL2xIMWR6eWxZN3djZUU2NXpERjVNMjRUMUJlcXlnS1V5dUpDNGsySlpHZkRBUEhiOFN3dFRhVElPaWltajA3RTNpNVk3NndJcXdZPQp0cnVzdGVkIGNvbW1lbnQ6IHRpbWVzdGFtcDoxNzg4MDQyMjM0CWZpbGU6ZGlnZXN0cy14ODZfNjQtdW5rbm93bi1saW51eC1nbnUuanNvbgpzSkg3dGJuMXVNSHIyRkE5enlISnVSRWRNS0xXcWxFVEJ1TkRaSXFsR0ZzZm5LbCtqNThBckYzb1JQVE9UeEk5WExEMXpKYTlSZnl0S2xQUXZxTk9Bdz09Cg==";
+/// The app download that document names, and one it does not.
+const PUBLISHED_APP: &[u8] = b"the linux appimage";
+const ANOTHER_RELEASE_APP: &[u8] = b"an older kendex, signed when it shipped";
+
+/// What the install does before it hands the plugin's download back to be
+/// written: read the release's own document off the channel and hold the
+/// bytes to it. The transport answers only at the two URLs this read is
+/// supposed to ask for, so a read that looked anywhere else finds nothing.
+#[test]
+fn the_install_holds_its_download_to_what_this_release_published() {
+    let document = release_digests_url(manifest_url_for(env!("CARGO_PKG_VERSION")), TEST_TARGET)
+        .expect("the channel names a document");
+    let signature = signature_url(&document);
+    let serve = |asked: &str| match asked {
+        _ if asked == document => Ok(PUBLISHED.as_bytes().to_vec()),
+        _ if asked == signature => Ok(PUBLISHED_SIGNATURE.as_bytes().to_vec()),
+        _ => Err(format!("this release published nothing at {asked}")),
+    };
+
+    let published =
+        read_published(TEST_KEY, TEST_TARGET, "9.9.9", serve).expect("the release signed this");
+    published
+        .verify_app(PUBLISHED_APP)
+        .expect("the download this release published");
+    assert!(published.verify_app(ANOTHER_RELEASE_APP).is_err());
+
+    // The manifest is unsigned, so the version it offers is whoever wrote
+    // it to choose; the document is what that claim is held to.
+    let claimed = read_published(TEST_KEY, TEST_TARGET, "9.9.8", serve).unwrap_err();
+    assert!(claimed.contains("the feed offers 9.9.8"), "{claimed}");
+}
+
+/// Stands in for the updater builder, which keeps what it was handed
+/// private. What reaches it is what the plugin would have been given.
+#[derive(Default)]
+struct Recorder(Option<std::path::PathBuf>);
+
+impl ReplacementTarget for Recorder {
+    fn replace_at(self, path: &std::path::Path) -> Self {
+        Self(Some(path.to_owned()))
+    }
+}
+
+/// The handoff itself. Everything else about this change can be right
+/// while the approved path never leaves `app_update_install`, and the
+/// plugin then falls back to rebuilding its own from the launch
+/// environment, which is the whole defect.
+#[test]
+fn the_approved_path_reaches_whatever_will_replace_it() {
+    for install in [
+        AppInstall::AppImage(Some("/home/pat/Apps/kendex.AppImage".into())),
+        AppInstall::MacBundle("/Applications/kendex.app/Contents/MacOS/kendex".into()),
+    ] {
+        assert_eq!(
+            aim_at_install(Recorder::default(), &install).0.as_deref(),
+            install.judged_path(),
+            "{install:?}"
+        );
+    }
+
+    // Nothing to hand over, so the target keeps its own fallback.
+    for install in [AppInstall::WindowsInstaller, AppInstall::AppImage(None)] {
+        assert_eq!(
+            aim_at_install(Recorder::default(), &install).0,
+            None,
+            "{install:?}"
+        );
+    }
+}
+
+/// Only the bundle is writable, so `for_app` can approve nothing else.
+struct OnlyWritable(&'static str);
+
+impl kendex_core::install_channel::HostProbe for OnlyWritable {
+    fn replaceable(&self, path: &std::path::Path) -> bool {
+        path == std::path::Path::new(self.0)
+    }
+
+    fn exists(&self, _: &std::path::Path) -> bool {
+        false
+    }
+
+    fn resolve(&self, path: &std::path::Path) -> std::path::PathBuf {
+        path.to_owned()
+    }
+
+    fn on_path(&self, _: &str) -> bool {
+        false
+    }
+
+    fn os_release(&self) -> Option<String> {
+        None
+    }
+}
+
+/// The plugin decides for itself what to replace, deriving it from the
+/// path it is handed, so nothing kendex asserts about that path proves
+/// the two agree. This asks the plugin.
+///
+/// Getting it wrong is not a failed update. The derived path is what the
+/// macOS installer removes before moving the new bundle in, escalating a
+/// permission error to a shell `rm -rf` under `with administrator
+/// privileges`. Hand over the bundle instead of the executable inside it
+/// and the plugin climbs one level further, to the directory holding
+/// every other app on the machine. The dependency is a caret range, so a
+/// minor bump can move this derivation under an unchanged kendex.
+#[test]
+fn the_plugin_derives_the_unit_for_app_approved() {
+    let exe = "/Applications/kendex.app/Contents/MacOS/kendex";
+    let bundle = "/Applications/kendex.app";
+    let probe = OnlyWritable(bundle);
+    let install = AppInstall::mac_bundle(&probe, std::path::Path::new(exe));
+    assert_eq!(
+        kendex_core::install_channel::for_app(&install, &probe),
+        InstallChannel::Direct
+    );
+
+    let handed = install.judged_path().expect("a mac bundle carries a path");
+    let derived = tauri_plugin_updater::extract_path_from_executable(handed)
+        .expect("the plugin derives a path from an executable inside a bundle");
+    // True on every platform the function compiles for, and the property
+    // that matters: what the plugin acts on never escapes what kendex
+    // approved.
+    assert!(
+        derived.starts_with(bundle),
+        "plugin derived {} from {handed}, outside the approved {bundle}",
+        derived.display(),
+        handed = handed.display()
+    );
+    // Where the derivation runs for real it lands on the bundle exactly.
+    #[cfg(target_os = "macos")]
+    assert_eq!(derived, std::path::Path::new(bundle));
+}

--- a/crates/app/src/app_update/tests.rs
+++ b/crates/app/src/app_update/tests.rs
@@ -74,17 +74,7 @@ const ANOTHER_RELEASE_APP: &[u8] = b"an older kendex, signed when it shipped";
 /// supposed to ask for, so a read that looked anywhere else finds nothing.
 #[test]
 fn the_install_holds_its_download_to_what_this_release_published() {
-    let document = release_digests_url(manifest_url_for(env!("CARGO_PKG_VERSION")), TEST_TARGET)
-        .expect("the channel names a document");
-    let signature = signature_url(&document);
-    let serve = |asked: &str| match asked {
-        _ if asked == document => Ok(PUBLISHED.as_bytes().to_vec()),
-        _ if asked == signature => Ok(PUBLISHED_SIGNATURE.as_bytes().to_vec()),
-        _ => Err(format!("this release published nothing at {asked}")),
-    };
-
-    let published =
-        read_published(TEST_KEY, TEST_TARGET, "9.9.9", serve).expect("the release signed this");
+    let published = published();
     published
         .verify_app(PUBLISHED_APP)
         .expect("the download this release published");
@@ -94,6 +84,65 @@ fn the_install_holds_its_download_to_what_this_release_published() {
     // it to choose; the document is what that claim is held to.
     let claimed = read_published(TEST_KEY, TEST_TARGET, "9.9.8", serve).unwrap_err();
     assert!(claimed.contains("the feed offers 9.9.8"), "{claimed}");
+}
+
+/// A channel serving what this release published, and answering at exactly
+/// the two URLs the install's read is supposed to ask for: a read that
+/// looked anywhere else finds nothing.
+fn serve(asked: &str) -> Result<Vec<u8>, String> {
+    let document = release_digests_url(manifest_url_for(env!("CARGO_PKG_VERSION")), TEST_TARGET)
+        .expect("the channel names a document");
+    if asked == document {
+        return Ok(PUBLISHED.as_bytes().to_vec());
+    }
+    if asked == signature_url(&document) {
+        return Ok(PUBLISHED_SIGNATURE.as_bytes().to_vec());
+    }
+    Err(format!("this release published nothing at {asked}"))
+}
+
+/// The release's own document, read the way the install reads it.
+fn published() -> ReleaseDigests {
+    read_published(TEST_KEY, TEST_TARGET, "9.9.9", serve).expect("the release signed this")
+}
+
+/// Stands in for the plugin's installer. What reaches it is what would
+/// have been written over this install.
+#[derive(Default)]
+struct Placed(std::cell::RefCell<Option<Vec<u8>>>);
+
+impl Installer for Placed {
+    fn place(&self, bytes: Vec<u8>) -> Result<(), String> {
+        *self.0.borrow_mut() = Some(bytes);
+        Ok(())
+    }
+}
+
+/// The boundary itself, driven through the step the install takes rather
+/// than through its halves. Everything else about this change can be right
+/// while the check never runs on the way to the installer, which is the
+/// whole defect: the plugin's signature check admits any kendex release's
+/// bytes, so what this release published for this target is the only thing
+/// between an older signed download and the disk.
+#[test]
+fn only_the_download_this_release_published_reaches_the_installer() {
+    let digests = published();
+
+    let landed = Placed::default();
+    install_published(&digests, PUBLISHED_APP.to_vec(), &landed).expect("the published download");
+    assert_eq!(landed.0.borrow().as_deref(), Some(PUBLISHED_APP));
+
+    let refused = Placed::default();
+    let error = install_published(&digests, ANOTHER_RELEASE_APP.to_vec(), &refused)
+        .expect_err("a download this release never published");
+    assert!(
+        error.contains("the desktop app download hashes to"),
+        "{error}"
+    );
+    assert!(
+        refused.0.borrow().is_none(),
+        "a download this release never published reached the installer"
+    );
 }
 
 /// Stands in for the updater builder, which keeps what it was handed

--- a/crates/cli/src/commands/update.rs
+++ b/crates/cli/src/commands/update.rs
@@ -5,6 +5,7 @@ use kendex_core::env::Env;
 use kendex_core::install_channel::{Host, HostProbe, InstallChannel, for_cli};
 use kendex_core::names::shown;
 use kendex_core::process::Hardened;
+use kendex_core::release_digests::{ReleaseDigests, release_digests_url};
 use kendex_core::update_channel::feed_url_for;
 use kendex_core::update_feed::{
     ReleaseFeed, UPDATER_PUBLIC_KEY, VersionRelation, app_image_signature_url, app_image_url,
@@ -90,16 +91,18 @@ pub fn run(env: &Env, force: bool) -> CliResult {
         &current_exe,
         &channel,
         UPDATER_PUBLIC_KEY,
+        target_triple(),
     )
 }
 
 /// The update with everything it reads off this process handed to it: the
-/// feed to ask, the command's own path, who owns that path, and the key
-/// every download is held to. Which arm a person lands on is the channel,
-/// and a package-managed one is the arm no test can reach by running:
-/// `for_cli` judges the real `current_exe`, which nothing here can place
-/// under `/usr` or a brew prefix. The key is an argument for the same
-/// reason core's is — a test holds a signature it made itself.
+/// feed to ask, the command's own path, who owns that path, the key every
+/// download is held to, and the target this build was made for. Which arm
+/// a person lands on is the channel, and a package-managed one is the arm
+/// no test can reach by running: `for_cli` judges the real `current_exe`,
+/// which nothing here can place under `/usr` or a brew prefix. The key and
+/// the target are arguments for the same reason core's key is — a test
+/// holds a release it signed itself, for a target it names.
 fn run_on(
     env: &Env,
     force: bool,
@@ -107,6 +110,7 @@ fn run_on(
     current_exe: &Path,
     channel: &InstallChannel,
     public_key: &str,
+    target: &str,
 ) -> CliResult {
     if let InstallChannel::Managed { command } = channel {
         out("a package manager owns this install; update it with:");
@@ -135,7 +139,6 @@ fn run_on(
         }
         VersionRelation::Older | VersionRelation::Current | VersionRelation::Newer => {}
     }
-    let target = target_triple();
     let Some(asset) = feed.asset_for(target) else {
         out(&missing_asset_message(relation, latest, current, target)?);
         return Ok(());
@@ -146,27 +149,56 @@ fn run_on(
     // install, so it is the last thing written. Any failure before it
     // leaves the old command in place, the next run still reads the feed
     // as newer, and both halves are tried again instead of stopping at
-    // already-up-to-date. Its bytes are fetched first so a lost download
-    // costs nothing that is already on disk.
+    // already-up-to-date.
     //
-    // The feed is the one input here nothing signs, so the asset URL is a
-    // host anyone who can alter the feed chooses. The signature published
-    // beside those bytes is what makes that harmless: it is fetched from
-    // wherever they came from and still has to check out under a key baked
-    // into this build, so a redirected download is refused rather than
-    // written over the running command.
+    // What is settled before any download: where the app half stands, so a
+    // machine that cannot take it stops here rather than after paying for
+    // the bytes, and what this release published, so both halves are held
+    // to it. The feed is the one input nothing signs — the version, the
+    // target's asset URL and the host serving it are all whoever wrote it
+    // to choose. The digests document is what makes that harmless: it is
+    // the release's own statement, signed under a key baked into this
+    // build, and it names the release, the target and the hash of each
+    // download. A signature that is genuine over some other release's
+    // artifact is refused here rather than written over the running
+    // command.
+    let app_half = app_half(env, latest, target, channel)?;
+    let digests = release_digests(feed_url, target, latest, public_key)?;
     let binary = fetch(asset)?;
     let signature = fetch(&signature_url(asset))?;
-    let app_replaced = match channel {
-        InstallChannel::Direct => update_app(env, latest, public_key)?,
-        // Nothing here is ours to replace beyond the command itself.
-        InstallChannel::Managed { .. } | InstallChannel::Unknown => false,
+    let app_replaced = match &app_half {
+        Some(half) => {
+            replace_app(half, latest, &digests, public_key)?;
+            true
+        }
+        None => false,
     };
-    if let Err(error) = install_verified(current_exe, &binary, &signature, public_key) {
+    let installed = install_verified(current_exe, &binary, &signature, public_key, |bytes| {
+        digests.verify_command(bytes)
+    });
+    if let Err(error) = installed {
         return Err(command_failure(latest, app_replaced, &error).into());
     }
     out(&format!("updated to {latest}"));
     Ok(())
+}
+
+/// The release's own statement about what it published for this target,
+/// read from beside the manifest the channel served and held to the
+/// release the feed offered. Nothing names this document but the channel
+/// and the running build, so a feed cannot point the check that judges it
+/// somewhere else.
+fn release_digests(
+    feed_url: &str,
+    target: &str,
+    latest: &str,
+    public_key: &str,
+) -> Result<ReleaseDigests, String> {
+    let url = release_digests_url(feed_url, target).map_err(|error| error.to_string())?;
+    let document = fetch(&url)?;
+    let signature = fetch(&signature_url(&url))?;
+    ReleaseDigests::for_release(public_key, &document, &signature, latest, target)
+        .map_err(|error| error.to_string())
 }
 
 /// What to say when the command itself could not be replaced. An app
@@ -182,64 +214,99 @@ fn command_failure(latest: &str, app_replaced: bool, error: &str) -> String {
     }
 }
 
-/// Bring the desktop app on this machine to the same release, answering
-/// whether it replaced one. The URL is built from the version the feed was
-/// validated at, never from feed text. A machine with no app of ours is
-/// the whole install already; a machine whose app cannot be replaced stops
-/// the run before the command moves, so neither half has.
-fn update_app(
+/// The desktop app half of this update: where it sits and where its
+/// download is published. Both URLs are built from the version the feed
+/// was validated at, never from feed text.
+struct AppHalf {
+    path: PathBuf,
+    url: String,
+    signature_url: String,
+}
+
+/// Whether this machine has an app of ours to bring across, decided before
+/// anything is downloaded. A machine with no app of ours is the whole
+/// install already; a machine whose app cannot be replaced stops the run
+/// here, with the old command still on disk, so neither half has moved.
+fn app_half(
     env: &Env,
     latest: &str,
-    public_key: &str,
-) -> Result<bool, Box<dyn std::error::Error>> {
-    // Only the Linux AppImage is an install this command made. Every other
-    // platform's app arrives and updates by its own route, and the CLI says
-    // nothing about one it did not put there.
-    let target = target_triple();
-    let (Some(url), Some(signature_source)) = (
-        app_image_url(latest, target)?,
-        app_image_signature_url(latest, target)?,
+    target: &str,
+    channel: &InstallChannel,
+) -> Result<Option<AppHalf>, String> {
+    // Nothing outside a direct install is ours to replace beyond the
+    // command itself. Only the Linux AppImage is an install this command
+    // made; every other platform's app arrives and updates by its own
+    // route, and the CLI says nothing about one it did not put there.
+    let InstallChannel::Direct = channel else {
+        return Ok(None);
+    };
+    let to_url = |result: kendex_core::error::Result<Option<String>>| {
+        result.map_err(|error| error.to_string())
+    };
+    let (Some(url), Some(signature_url)) = (
+        to_url(app_image_url(latest, target))?,
+        to_url(app_image_signature_url(latest, target))?,
     ) else {
-        return Ok(false);
+        return Ok(None);
     };
     let path = env.app_image_file();
     if !Host.exists(&path) {
         out("no kendex desktop app here; the kendex command is the whole install");
-        return Ok(false);
+        return Ok(None);
     }
     if !Host.replaceable(&path) {
         return Err(app_refused(
             latest,
             &format!("the directory holding {} refuses writes", path.display()),
-        )
-        .into());
+        ));
     }
+    Ok(Some(AppHalf {
+        path,
+        url,
+        signature_url,
+    }))
+}
+
+/// Bring the desktop app on this machine to the same release.
+fn replace_app(
+    half: &AppHalf,
+    latest: &str,
+    digests: &ReleaseDigests,
+    public_key: &str,
+) -> Result<(), String> {
     say(&format!(
         "updating the desktop app at {}",
-        shown(&path.display().to_string())
+        shown(&half.path.display().to_string())
     ));
-    let image = fetch(&url)?;
+    let image = fetch(&half.url)?;
     // The release job publishes each AppImage beside a minisign signature
     // over exactly those bytes. One that arrives without a signature, or
-    // with one that does not check out, is refused rather than installed.
-    let signature = fetch(&signature_source).map_err(|why| app_refused(latest, &why))?;
-    install_verified(&path, &image, &signature, public_key)
-        .map_err(|why| app_refused(latest, &why))?;
+    // with one that does not check out, or that is not the download this
+    // release published for this target, is refused rather than installed.
+    let signature = fetch(&half.signature_url).map_err(|why| app_refused(latest, &why))?;
+    install_verified(&half.path, &image, &signature, public_key, |bytes| {
+        digests.verify_app(bytes)
+    })
+    .map_err(|why| app_refused(latest, &why))?;
     out(&format!("updated the desktop app to {latest}"));
-    Ok(true)
+    Ok(())
 }
 
 /// Write `bytes` over `path` only once `signature` checks out under
-/// `public_key`, so a download that fails verification never reaches an
-/// installed path. Both halves of an update land through here — the desktop
-/// app and the command itself — so neither is the half nothing checks.
+/// `public_key` and `published` recognizes them as the artifact this
+/// release named — the signature makes them the release key's, and
+/// `published` makes them this release's, for this target and this half.
+/// Both halves of an update land through here — the desktop app and the
+/// command itself — so neither is the half nothing checks.
 fn install_verified(
     path: &Path,
     bytes: &[u8],
     signature: &[u8],
     public_key: &str,
+    published: impl Fn(&[u8]) -> kendex_core::error::Result<()>,
 ) -> Result<(), String> {
     verify_signature(public_key, bytes, signature).map_err(|error| error.to_string())?;
+    published(bytes).map_err(|error| error.to_string())?;
     replace_executable(path, bytes).map_err(|error| error.to_string())
 }
 

--- a/crates/cli/src/commands/update/tests.rs
+++ b/crates/cli/src/commands/update/tests.rs
@@ -52,11 +52,14 @@ fn a_release_is_out_under(home: &Path) -> (Env, String, PathBuf) {
     std::fs::write(&installed, INSTALLED).unwrap();
     std::fs::write(home.join("new-command"), OFFERED).unwrap();
     std::fs::write(home.join("new-command.sig"), TEST_SIGNATURE).unwrap();
+    // Every release publishes what it built for this target beside its
+    // feed, so the fixture does too; the tests that alter this document
+    // are the ones that say what happens when it is not this release's.
+    publishes(home, PUBLISHED_DIGESTS, PUBLISHED_DIGESTS_SIGNATURE);
     std::fs::write(
         home.join("feed.json"),
         format!(
-            r#"{{"schema": 1, "version": "9.9.9", "assets": {{"{}": {}}}}}"#,
-            target_triple(),
+            r#"{{"schema": 1, "version": "9.9.9", "assets": {{"{TEST_TARGET}": {}}}}}"#,
             serde_json::to_string(&file_url(&home.join("new-command"))).unwrap()
         ),
     )
@@ -68,9 +71,18 @@ fn a_release_is_out_under(home: &Path) -> (Env, String, PathBuf) {
     )
 }
 
+/// Put a digests document and its signature where this target's update
+/// looks for them, which is beside the feed and under this target's name.
+fn publishes(home: &Path, document: &str, signature: &str) {
+    let name = format!("digests-{TEST_TARGET}.json");
+    std::fs::write(home.join(&name), document).unwrap();
+    std::fs::write(home.join(format!("{name}.sig")), signature).unwrap();
+}
+
 const INSTALLED: &[u8] = b"the command already here";
 /// What the feed offers is the signed blob below, because a release only
-/// offers a command `TEST_SIGNATURE` covers; nothing else gets written.
+/// offers a command `TEST_SIGNATURE` covers and `PUBLISHED_DIGESTS` names;
+/// nothing else gets written.
 const OFFERED: &[u8] = SIGNED_BYTES;
 
 /// The arm no process in this repo can reach, and the one whose absence
@@ -86,7 +98,16 @@ fn a_package_managed_command_is_left_for_its_package_manager() {
         command: "brew upgrade kendex-cli".to_owned(),
     };
 
-    run_on(&env, false, &feed_url, &installed, &brew, TEST_KEY).unwrap();
+    run_on(
+        &env,
+        false,
+        &feed_url,
+        &installed,
+        &brew,
+        TEST_KEY,
+        TEST_TARGET,
+    )
+    .unwrap();
 
     assert_eq!(std::fs::read(&installed).unwrap(), INSTALLED);
     assert!(!staged_path(&installed).exists());
@@ -101,40 +122,40 @@ fn a_direct_command_is_replaced_from_the_feed() {
     let dir = tempfile::tempdir().unwrap();
     let (env, feed_url, installed) = a_release_is_out(&dir);
 
-    run_on(
-        &env,
-        false,
-        &feed_url,
-        &installed,
-        &InstallChannel::Direct,
-        TEST_KEY,
-    )
-    .unwrap();
+    direct(&env, &feed_url, &installed).unwrap();
 
     assert_eq!(std::fs::read(&installed).unwrap(), OFFERED);
     assert!(!staged_path(&installed).exists());
+}
+
+/// The one arm every refusal below is read against, so that a green
+/// refusal is the check turning the release away rather than a fixture
+/// that could never have installed anything.
+fn direct(env: &Env, feed_url: &str, installed: &Path) -> CliResult {
+    run_on(
+        env,
+        false,
+        feed_url,
+        installed,
+        &InstallChannel::Direct,
+        TEST_KEY,
+        TEST_TARGET,
+    )
 }
 
 /// The same arm again with the release sitting under a directory whose
 /// name holds characters a URL reserves. A space and a `#` are ordinary in
 /// a Windows profile directory, and spelled into a URL rather than encoded
 /// they address a different file, or none — the fetch either brings back
-/// the wrong bytes or fails outright.
+/// the wrong bytes or fails outright. The digests document is found by the
+/// feed's own URL, so it is fetched through the same spelling.
 #[test]
 fn a_release_under_a_name_a_url_reserves_is_still_fetched() {
     let dir = tempfile::tempdir().unwrap();
     let home = dir.path().join("my release #1");
     let (env, feed_url, installed) = a_release_is_out_under(&home);
 
-    run_on(
-        &env,
-        false,
-        &feed_url,
-        &installed,
-        &InstallChannel::Direct,
-        TEST_KEY,
-    )
-    .unwrap();
+    direct(&env, &feed_url, &installed).unwrap();
 
     assert_eq!(std::fs::read(&installed).unwrap(), OFFERED);
 }
@@ -157,16 +178,7 @@ fn a_command_binary_that_fails_verification_is_never_written() {
         let (env, feed_url, installed) = a_release_is_out(&dir);
         std::fs::write(dir.path().join(file), corrupt).unwrap();
 
-        let refused = run_on(
-            &env,
-            false,
-            &feed_url,
-            &installed,
-            &InstallChannel::Direct,
-            TEST_KEY,
-        )
-        .unwrap_err()
-        .to_string();
+        let refused = direct(&env, &feed_url, &installed).unwrap_err().to_string();
 
         assert!(
             refused.contains("could not be replaced"),
@@ -174,6 +186,80 @@ fn a_command_binary_that_fails_verification_is_never_written() {
         );
         assert_eq!(std::fs::read(&installed).unwrap(), INSTALLED, "{file}");
         assert!(!staged_path(&installed).exists(), "{file}");
+    }
+}
+
+/// The defect this binding exists for: a binary the release key really
+/// signed, offered by a feed for a release it does not belong to. The
+/// signature checks out — it is a genuine one over exactly these bytes —
+/// and the download is still refused, because this release published a
+/// different hash for its command.
+#[test]
+fn a_signed_binary_from_another_release_is_refused() {
+    let dir = tempfile::tempdir().unwrap();
+    let (env, feed_url, installed) = a_release_is_out(&dir);
+    std::fs::write(dir.path().join("new-command"), ANOTHER_RELEASE).unwrap();
+    std::fs::write(
+        dir.path().join("new-command.sig"),
+        ANOTHER_RELEASE_SIGNATURE,
+    )
+    .unwrap();
+
+    let refused = direct(&env, &feed_url, &installed).unwrap_err().to_string();
+
+    assert!(
+        refused.contains("the kendex command hashes to"),
+        "{refused}"
+    );
+    assert_eq!(std::fs::read(&installed).unwrap(), INSTALLED);
+    assert!(!staged_path(&installed).exists());
+}
+
+/// The two ways a feed can point this target at a release that is not the
+/// one it claims: serve another platform's digests, or an earlier
+/// release's. Both documents are genuinely signed — nothing here can forge
+/// one — so what refuses them is the release and target they name.
+#[test]
+fn digests_for_another_target_or_another_release_are_refused() {
+    for (document, signature, why) in [
+        (
+            OTHER_TARGET_DIGESTS,
+            OTHER_TARGET_DIGESTS_SIGNATURE,
+            "aarch64-apple-darwin",
+        ),
+        (OLDER_DIGESTS, OLDER_DIGESTS_SIGNATURE, "5.0.0"),
+    ] {
+        let dir = tempfile::tempdir().unwrap();
+        let (env, feed_url, installed) = a_release_is_out(&dir);
+        publishes(dir.path(), document, signature);
+
+        let refused = direct(&env, &feed_url, &installed).unwrap_err().to_string();
+
+        assert!(refused.contains(why), "{refused}");
+        assert_eq!(std::fs::read(&installed).unwrap(), INSTALLED, "{why}");
+        assert!(!staged_path(&installed).exists(), "{why}");
+    }
+}
+
+/// An update finds the release's statement or installs nothing: a channel
+/// serving no document, or one nothing signed, leaves the command alone
+/// rather than falling back on the signature by itself.
+#[test]
+fn a_release_that_publishes_no_verifiable_digests_installs_nothing() {
+    for missing in [true, false] {
+        let dir = tempfile::tempdir().unwrap();
+        let (env, feed_url, installed) = a_release_is_out(&dir);
+        let name = format!("digests-{TEST_TARGET}.json");
+        match missing {
+            true => std::fs::remove_file(dir.path().join(&name)).unwrap(),
+            false => {
+                std::fs::write(dir.path().join(format!("{name}.sig")), "not a signature").unwrap()
+            }
+        }
+
+        assert!(direct(&env, &feed_url, &installed).is_err(), "{missing}");
+        assert_eq!(std::fs::read(&installed).unwrap(), INSTALLED, "{missing}");
+        assert!(!staged_path(&installed).exists(), "{missing}");
     }
 }
 
@@ -190,12 +276,67 @@ fn only_debug_builds_accept_a_feed_override() {
     );
 }
 
-/// A throwaway minisign keypair signing `SIGNED_BYTES`, so the admitted
-/// arm runs the real check rather than a stub standing in for it. One pair
-/// serves both halves: the app and the command are held to one key.
-const TEST_KEY: &str = "dW50cnVzdGVkIGNvbW1lbnQ6IG1pbmlzaWduIHB1YmxpYyBrZXk6IDk0QUI0NzI3RTVDMTVCODEKUldTQlc4SGxKMGVybEhxeFovbTJ3U1phMng4aE9VTXByV09pUVRFVFNKbFZ5aWxtUTAvVGgyWEwK";
-const TEST_SIGNATURE: &str = "dW50cnVzdGVkIGNvbW1lbnQ6IHNpZ25hdHVyZSBmcm9tIHJzaWduIHNlY3JldCBrZXkKUlVTQlc4SGxKMGVybElTMUxrbkMyQ0tBWGlnejY1S0xLekovK0tBYllNdkdJTVU0bitTSjRBSCt1RlpwWnZkRHNKcWFTSHVoeStIQkpyVDlOaVRIMmROWVVSb21mMVBVRmd3PQp0cnVzdGVkIGNvbW1lbnQ6IGtlbmRleCB0ZXN0CnpKSnpYYnBtODZYRW40eHgxSTVkeG5YdktxT0k5ZXdmSkEyMkdtZXpreGgwbUNJZysybkJ2cGowUXZ6N2c3RHA4TEZBVXVBQUVMRExuUzFuaVpsaUF3PT0K";
+/// A throwaway minisign keypair signing every blob and document below, so
+/// the admitted arm runs the real check rather than a stub standing in for
+/// it. One pair serves both halves: the app and the command are held to
+/// one key. The target is named rather than read off this build, so the
+/// documents are the same on every machine this test runs on.
+const TEST_KEY: &str = "dW50cnVzdGVkIGNvbW1lbnQ6IG1pbmlzaWduIHB1YmxpYyBrZXk6IDc1RTYwNzZERUJFMDVFNTcKUldSWFh1RHJiUWZtZFdVSnJYQmd0QnhLVUdUQnN2MWNTR2N6SW9jZ1Z1Q0FoZmlzWDVIeFZJaUkK";
+const TEST_TARGET: &str = "x86_64-unknown-linux-gnu";
+const TEST_SIGNATURE: &str = "dW50cnVzdGVkIGNvbW1lbnQ6IHNpZ25hdHVyZSBmcm9tIHRhdXJpIHNlY3JldCBrZXkKUlVSWFh1RHJiUWZtZFFaYlYyV1NhdUcwUWR6d1cxRWZGRXo4RzNuUjgrTStHOEhXMDlVSUpvM1p4eTEvdzBtZ2FqZnpxTFZYUGVZU2cyMEVRL29iV3RTZ1ZjQ09pVUFEM3dBPQp0cnVzdGVkIGNvbW1lbnQ6IHRpbWVzdGFtcDoxNzg4MDQyMjM0CWZpbGU6a2VuZGV4LXg4Nl82NC11bmtub3duLWxpbnV4LWdudQpROGN6cHBoVVd4RUNDWlZxTUpXSnhDd0JJUGNUalBsczhjMDJ5L0JOUzQ4d2g3OTNXemU1UHVXRTRmS3RLTS9HZ2pvbzR3eEVpM2ZUVTA4WXd4dGlCZz09Cg==";
 const SIGNED_BYTES: &[u8] = b"kendex AppImage bytes";
+
+/// The app download this release published, and the signature over it.
+const SIGNED_IMAGE: &[u8] = b"the linux appimage";
+const SIGNED_IMAGE_SIGNATURE: &str = "dW50cnVzdGVkIGNvbW1lbnQ6IHNpZ25hdHVyZSBmcm9tIHRhdXJpIHNlY3JldCBrZXkKUlVSWFh1RHJiUWZtZFQ5UklsNVQ1ZjMvV25YVTBnSVJDcDBFVFF4R1RHZlFjbTZabTA4WFhuQklYN0VpSDhnTXJObFBkQnVEdlpQczVVc3J4bVhaZEVWZGg2d2ZFUTlkQlFrPQp0cnVzdGVkIGNvbW1lbnQ6IHRpbWVzdGFtcDoxNzg4MDQyNjUzCWZpbGU6a2VuZGV4XzkuOS45X2FtZDY0LkFwcEltYWdlCnA0RW9QUFFrYTR1WFNwQlJmRUY2VldxTFBDV2tOb0NHeDN6TGI2R0J1K2pacm1Qa3JnbndpeW9kMjBWTDFSZ2M0cHFqM2R2QlNkRmpZRGkwdmZOOEFBPT0K";
+
+/// A binary the release key really signed, published by a release this
+/// one is not.
+const ANOTHER_RELEASE: &[u8] = b"an older kendex, signed when it shipped";
+const ANOTHER_RELEASE_SIGNATURE: &str = "dW50cnVzdGVkIGNvbW1lbnQ6IHNpZ25hdHVyZSBmcm9tIHRhdXJpIHNlY3JldCBrZXkKUlVSWFh1RHJiUWZtZGVPc2R4SXlPL1pMT0xsb3VZbWxVUitUeEJ0RVdFeFlYNklSK25UWXp6eW1xc1orMXhhZlp1VEpFNXl6ZTAxNFdSVUhHSEdZRy92UkRuYUowQ3pqREE4PQp0cnVzdGVkIGNvbW1lbnQ6IHRpbWVzdGFtcDoxNzg4MDQyMjM0CWZpbGU6b3RoZXItcmVsZWFzZS1iaW5hcnkKRGo3KzA1eXdMWVN4TzN5OFhQQU9mbFQrUzFoNzA4NkdJU3RNTzZqaGZLNXhqQmp4aHNzRDZGT2ZBc05ZdlhqbHZOVFdoZTYvWHJXRFo5ZTVyVzRYQWc9PQo=";
+
+/// What `tools/release-digests` wrote for this release's Linux lane,
+/// byte for byte, and the two documents a feed can serve in its place
+/// that are equally genuine and are not this release's.
+const PUBLISHED_DIGESTS: &str = r#"{
+  "schema": 1,
+  "version": "9.9.9",
+  "target": "x86_64-unknown-linux-gnu",
+  "command": "aae05017e20c96dd3cd26b1fd324365c2ab53512db82b53362e75f8f553ffaea",
+  "app": "d489b792c3c3d6e9633ff28507f2c7da40a24eec743521842ebc283c2c3226ff"
+}
+"#;
+const PUBLISHED_DIGESTS_SIGNATURE: &str = "dW50cnVzdGVkIGNvbW1lbnQ6IHNpZ25hdHVyZSBmcm9tIHRhdXJpIHNlY3JldCBrZXkKUlVSWFh1RHJiUWZtZFpxNkg5WFpISHVZL2xIMWR6eWxZN3djZUU2NXpERjVNMjRUMUJlcXlnS1V5dUpDNGsySlpHZkRBUEhiOFN3dFRhVElPaWltajA3RTNpNVk3NndJcXdZPQp0cnVzdGVkIGNvbW1lbnQ6IHRpbWVzdGFtcDoxNzg4MDQyMjM0CWZpbGU6ZGlnZXN0cy14ODZfNjQtdW5rbm93bi1saW51eC1nbnUuanNvbgpzSkg3dGJuMXVNSHIyRkE5enlISnVSRWRNS0xXcWxFVEJ1TkRaSXFsR0ZzZm5LbCtqNThBckYzb1JQVE9UeEk5WExEMXpKYTlSZnl0S2xQUXZxTk9Bdz09Cg==";
+const OTHER_TARGET_DIGESTS: &str = r#"{
+  "schema": 1,
+  "version": "9.9.9",
+  "target": "aarch64-apple-darwin",
+  "command": "ea1eb85cbb8a7c5b0ee438f4924e7825fece13173e9764c8308b1d95bbd7226a",
+  "app": "a9c46ccd0a1b1a38b8e7bceb39644bd068f49fd58aeb185491be24326939d567"
+}
+"#;
+const OTHER_TARGET_DIGESTS_SIGNATURE: &str = "dW50cnVzdGVkIGNvbW1lbnQ6IHNpZ25hdHVyZSBmcm9tIHRhdXJpIHNlY3JldCBrZXkKUlVSWFh1RHJiUWZtZFF5S1FzZklvb203YVRMdVlqa2NNYm15alFnZVBPcFNvQmdRd3FWOFRFQUxxZENMRk1kOUJlQlcyTUJ4bDdPaWJ2UFZHbHYxcE5ubkRsRUNKR3RpL1FRPQp0cnVzdGVkIGNvbW1lbnQ6IHRpbWVzdGFtcDoxNzg4MDQyMjM0CWZpbGU6ZGlnZXN0cy1hYXJjaDY0LWFwcGxlLWRhcndpbi5qc29uCml0RG1oZWpkZW5iZHBmcERNMHZVNHh3eGFmVTNObHBOZVI5clJwOXFXd2pBQWZGMW9WU0ZkQ3Fici9ib2NhRnFVdzFjcW80NWVPWWJNOWdnNlF0NENBPT0K";
+const OLDER_DIGESTS: &str = r#"{
+  "schema": 1,
+  "version": "5.0.0",
+  "target": "x86_64-unknown-linux-gnu",
+  "command": "aae05017e20c96dd3cd26b1fd324365c2ab53512db82b53362e75f8f553ffaea",
+  "app": "42c30601103ba7015436bd2feed7b3867ab36ec71e3bece765400efe82a33a08"
+}
+"#;
+const OLDER_DIGESTS_SIGNATURE: &str = "dW50cnVzdGVkIGNvbW1lbnQ6IHNpZ25hdHVyZSBmcm9tIHRhdXJpIHNlY3JldCBrZXkKUlVSWFh1RHJiUWZtZFJQSzRNQ0I5Rnk3enVxSkhFb3htZXA0L295SS8ycUhHZnRyWVdjcy9uNTJHczE4M1Q4KzZLL0Vja2tTTFB4SVk4RXRneFRpYWszSTRDbTkyd0RrUEFrPQp0cnVzdGVkIGNvbW1lbnQ6IHRpbWVzdGFtcDoxNzg4MDQyMjM0CWZpbGU6ZGlnZXN0cy14ODZfNjQtdW5rbm93bi1saW51eC1nbnUuanNvbgpVbDlnc2FSQUdFMVY2VWI1Z3NpL3BmMVZ4bDBpTm4wZ05aUUkyaG9ldFByMGhtdGVZTVhpUnVFN0ZuQ01ob0lGR08rMlMrazA1L1luUXQwTjNzMUxDdz09Cg==";
+
+/// The release's statement, read the way an update reads it.
+fn published() -> ReleaseDigests {
+    ReleaseDigests::for_release(
+        TEST_KEY,
+        PUBLISHED_DIGESTS.as_bytes(),
+        PUBLISHED_DIGESTS_SIGNATURE.as_bytes(),
+        "9.9.9",
+        TEST_TARGET,
+    )
+    .unwrap()
+}
 
 /// A path with something already installed at it, so every arm can say
 /// whether the bytes there moved.
@@ -205,43 +346,59 @@ fn installed_app(dir: &tempfile::TempDir) -> PathBuf {
     path
 }
 
-/// The admitted arm: a signature that checks out puts the download in
-/// place and leaves no staged file behind.
+/// The admitted arm: a signature that checks out over the download this
+/// release published puts it in place and leaves no staged file behind.
 #[test]
 fn an_app_image_whose_signature_checks_out_is_written() {
     let dir = tempfile::tempdir().unwrap();
     let installed = installed_app(&dir);
+    let digests = published();
 
     install_verified(
         &installed,
-        SIGNED_BYTES,
-        TEST_SIGNATURE.as_bytes(),
+        SIGNED_IMAGE,
+        SIGNED_IMAGE_SIGNATURE.as_bytes(),
         TEST_KEY,
+        |bytes| digests.verify_app(bytes),
     )
     .unwrap();
 
-    assert_eq!(std::fs::read(&installed).unwrap(), SIGNED_BYTES);
+    assert_eq!(std::fs::read(&installed).unwrap(), SIGNED_IMAGE);
     assert!(!staged_path(&installed).exists());
 }
 
-/// The refused arm, driven by both shapes a bad download takes: bytes
-/// the signature does not cover, and a body that is no signature at
-/// all. Either way the installed app is exactly as it was.
+/// The refused arm, driven by all three shapes a bad download takes:
+/// bytes the signature does not cover, a body that is no signature at
+/// all, and bytes carrying a real signature that this release did not
+/// publish for this half. Either way the installed app is exactly as it
+/// was.
 #[test]
 fn an_app_image_that_fails_verification_is_never_written() {
     let dir = tempfile::tempdir().unwrap();
     let installed = installed_app(&dir);
+    let digests = published();
+    let install = |bytes: &[u8], signature: &[u8]| {
+        install_verified(&installed, bytes, signature, TEST_KEY, |bytes| {
+            digests.verify_app(bytes)
+        })
+    };
 
-    let tampered =
-        install_verified(&installed, b"tampered", TEST_SIGNATURE.as_bytes(), TEST_KEY).unwrap_err();
+    let tampered = install(b"tampered", SIGNED_IMAGE_SIGNATURE.as_bytes()).unwrap_err();
     assert!(
         tampered.contains("signature verification failed"),
         "{tampered}"
     );
 
-    let malformed =
-        install_verified(&installed, SIGNED_BYTES, b"not a signature", TEST_KEY).unwrap_err();
+    let malformed = install(SIGNED_IMAGE, b"not a signature").unwrap_err();
     assert!(malformed.contains("not base64"), "{malformed}");
+
+    // Genuinely signed under the same key, and not what this release
+    // published for the app half.
+    let elsewhere = install(SIGNED_BYTES, TEST_SIGNATURE.as_bytes()).unwrap_err();
+    assert!(
+        elsewhere.contains("the desktop app download hashes to"),
+        "{elsewhere}"
+    );
 
     assert_eq!(std::fs::read(&installed).unwrap(), b"the app already here");
     assert!(!staged_path(&installed).exists());

--- a/crates/cli/tests/compat.rs
+++ b/crates/cli/tests/compat.rs
@@ -328,13 +328,33 @@ fn report_files_through_a_stubbed_gh() {
     assert!(args.contains("kendex-report:v1 asset=guard kind=hook"));
 }
 
+/// A release publishes what it built for this target beside its feed, and
+/// signs it; a fixture feed publishes the document and cannot sign it.
+/// That is the point: nothing here can produce a signature under the
+/// release key, so the real binary driven end to end refuses and leaves
+/// the command exactly as it was. The admitted arm — signatures that check
+/// out, and the write that follows them — is covered in
+/// `commands::update::tests`, which holds a keypair of its own.
+#[allow(clippy::unwrap_used)]
+fn a_release_that_cannot_be_verified(home: &Path, target: &str) {
+    let name = format!("digests-{target}.json");
+    fs::write(
+        home.join(&name),
+        format!(
+            r#"{{"schema":1,"version":"9.9.9","target":"{target}","command":"{zero}","app":"{zero}"}}"#,
+            zero = "0".repeat(64)
+        ),
+    )
+    .unwrap();
+    fs::write(
+        home.join(format!("{name}.sig")),
+        "not the release signature",
+    )
+    .unwrap();
+}
+
 /// The feed is unsigned text naming a host, so what it offers has to be
-/// held to the release key before it lands on the running command. Nothing
-/// here can produce a signature under that key, which is the point: this
-/// drives the real binary end to end and it refuses, leaving the command
-/// exactly as it was. The admitted arm — a signature that checks out, and
-/// the write that follows it — is covered in `commands::update::tests`,
-/// which holds a keypair of its own.
+/// held to the release key before it lands on the running command.
 #[test]
 #[allow(clippy::unwrap_used)]
 fn update_over_a_local_feed_refuses_a_command_it_cannot_verify() {
@@ -360,6 +380,7 @@ fn update_over_a_local_feed_refuses_a_command_it_cannot_verify() {
         ),
     )
     .unwrap();
+    a_release_that_cannot_be_verified(home, target);
 
     let output = kendex_copy(
         &me,
@@ -498,6 +519,7 @@ fn a_desktop_app_that_cannot_be_replaced_leaves_the_command_alone() {
         ),
     )
     .unwrap();
+    a_release_that_cannot_be_verified(home, target);
     let update = || {
         kendex_copy(
             &me,

--- a/crates/cli/tests/release_workflow/signing.rs
+++ b/crates/cli/tests/release_workflow/signing.rs
@@ -1,35 +1,67 @@
-//! Signing the command binary. `kendex update` refuses a download the
-//! release key does not cover, so a lane that stages `kendex-<target>` and
-//! no signature beside it publishes an update every client turns away. That
-//! is a tag-run failure otherwise, because release.yml never runs on a pull
-//! request; here the real step runs against a signer this test controls.
+//! Signing what a lane publishes. `kendex update` refuses a download the
+//! release key does not cover and one the release's digests document does
+//! not name, so a lane that stages `kendex-<target>` without both publishes
+//! an update every client turns away. That is a tag-run failure otherwise,
+//! because release.yml never runs on a pull request; here the real step
+//! runs the real script against a signer this test controls.
 
+#[cfg(unix)]
+use std::collections::BTreeMap;
 #[cfg(unix)]
 use std::fs;
 #[cfg(unix)]
 use std::os::unix::fs::PermissionsExt;
+#[cfg(unix)]
+use std::path::Path;
 
 #[cfg(unix)]
 use crate::test_util::rooted;
 #[cfg(unix)]
-use crate::{LANES, expand, run_script};
+use crate::{LANES, expand, run_script, signed_artifacts};
 use crate::{step, workflow};
 
-/// The signing step run over one lane in a tree holding that lane's staged
-/// binary and a `tauri` the test wrote: `body` is the shell the shim runs,
-/// which decides whether a signature appears. Returns the exit code, what
-/// the step said, and the signature files left in `dist/`.
+/// What one lane's signing step did: its exit code, what it said, the
+/// signature files left in `dist/`, and the digests document it wrote.
 #[cfg(unix)]
-#[allow(clippy::unwrap_used)]
-fn sign(lane: &crate::Lane, body: &str) -> (i32, String, Vec<String>) {
-    let dir = tempfile::tempdir().unwrap();
-    let root = rooted(&dir);
-    let binary = match lane.runner_os {
+struct Signed {
+    code: i32,
+    said: String,
+    sigs: Vec<String>,
+    document: String,
+}
+
+#[cfg(unix)]
+fn command_name(lane: &crate::Lane) -> String {
+    match lane.runner_os {
         "Windows" => format!("kendex-{}.exe", lane.target),
         _ => format!("kendex-{}", lane.target),
-    };
+    }
+}
+
+/// The signing step run over one lane in a tree holding the `dist/` that
+/// lane staged, the real `tools/release-digests`, and a `tauri` the test
+/// wrote: `body` is the shell the shim runs, which decides which
+/// signatures appear.
+#[cfg(unix)]
+#[allow(clippy::unwrap_used)]
+fn sign(lane: &crate::Lane, dist: &BTreeMap<String, String>, body: &str) -> Signed {
+    let dir = tempfile::tempdir().unwrap();
+    let root = rooted(&dir);
     fs::create_dir_all(root.join("dist")).unwrap();
-    fs::write(root.join("dist").join(&binary), "the built command").unwrap();
+    for (name, contents) in dist {
+        fs::write(root.join("dist").join(name), contents).unwrap();
+    }
+
+    // The step calls the script out of the checkout, so the tree it runs in
+    // carries the real one rather than a restatement of what it does.
+    fs::create_dir_all(root.join("tools")).unwrap();
+    let script = root.join("tools/release-digests");
+    fs::copy(
+        Path::new(env!("CARGO_MANIFEST_DIR")).join("../../tools/release-digests"),
+        &script,
+    )
+    .unwrap();
+    fs::set_permissions(&script, fs::Permissions::from_mode(0o755)).unwrap();
 
     let shim = root.join("ui/node_modules/.bin");
     fs::create_dir_all(&shim).unwrap();
@@ -38,68 +70,161 @@ fn sign(lane: &crate::Lane, body: &str) -> (i32, String, Vec<String>) {
     fs::set_permissions(&shim, fs::Permissions::from_mode(0o755)).unwrap();
 
     let workflow = workflow();
-    let script = expand(
-        &run_script(&step(&workflow, "name: Sign the kendex command")),
+    let step_script = expand(
+        &run_script(&step(&workflow, "name: Sign this lane's downloads")),
         lane,
     );
     let run = std::process::Command::new("bash")
         // The flags a `shell: bash` step gets on a runner.
-        .args(["-eo", "pipefail", "-c", &script])
+        .args(["-eo", "pipefail", "-c", &step_script])
         .current_dir(&root)
         .env_clear()
         .env("PATH", std::env::var_os("PATH").unwrap_or_default())
+        .env("GITHUB_REF_NAME", "v5.1.0")
         .output()
         .unwrap();
-    let mut left: Vec<String> = fs::read_dir(root.join("dist"))
+    // The bundler already signed its own artifacts, and staging carried
+    // those into `dist/`; what this step did is what was not there before.
+    let mut sigs: Vec<String> = fs::read_dir(root.join("dist"))
         .unwrap()
         .map(|entry| entry.unwrap().file_name().to_string_lossy().into_owned())
-        .filter(|name| name.ends_with(".sig"))
+        .filter(|name| name.ends_with(".sig") && !dist.contains_key(name))
         .collect();
-    left.sort();
-    let said = format!(
-        "{}{}",
-        String::from_utf8_lossy(&run.stdout),
-        String::from_utf8_lossy(&run.stderr)
-    );
-    (run.status.code().unwrap_or(-1), said, left)
+    sigs.sort();
+    Signed {
+        code: run.status.code().unwrap_or(-1),
+        said: format!(
+            "{}{}",
+            String::from_utf8_lossy(&run.stdout),
+            String::from_utf8_lossy(&run.stderr)
+        ),
+        sigs,
+        document: fs::read_to_string(
+            root.join("dist")
+                .join(format!("digests-{}.json", lane.target)),
+        )
+        .unwrap_or_default(),
+    }
 }
 
-/// Every lane signs the command the staging step left, and the expected
-/// name comes from that step rather than being spelled a second time here:
-/// two spellings agree until one is edited, and the Windows lane's `.exe`
-/// is exactly where they would part.
+/// A signer that answers for every file it is handed.
+#[cfg(unix)]
+const SIGNS: &str = r#"printf 'sig' > "$3.sig""#;
+
+/// Every lane signs the command the staging step left and the document it
+/// wrote about that lane, and the names come from staging rather than
+/// being spelled a second time here: two spellings agree until one is
+/// edited, and the Windows lane's `.exe` is exactly where they would part.
 #[cfg(unix)]
 #[test]
-fn each_lane_signs_the_command_it_staged() {
+#[allow(clippy::unwrap_used)]
+fn each_lane_signs_the_command_and_the_document_it_published() {
     for lane in &LANES {
         let staged = crate::stage_assets(lane);
-        let (code, said, sigs) = sign(lane, r#"printf 'sig' > "$3.sig""#);
-        assert_eq!(code, 0, "{}: {said}", lane.target);
-        assert_eq!(sigs.len(), 1, "{}: {sigs:?}", lane.target);
-        let signed = sigs[0].trim_end_matches(".sig");
+        let signed = sign(lane, &staged, SIGNS);
+        assert_eq!(signed.code, 0, "{}: {}", lane.target, signed.said);
+
+        let command = command_name(lane);
         assert!(
-            staged.contains_key(signed),
-            "{} signed {signed}, which staging never left: {:?}",
+            staged.contains_key(&command),
+            "{} signed {command}, which staging never left: {:?}",
             lane.target,
             staged.keys().collect::<Vec<_>>()
+        );
+        assert_eq!(
+            signed.sigs,
+            vec![
+                format!("digests-{}.json.sig", lane.target),
+                format!("{command}.sig"),
+            ],
+            "{}",
+            lane.target
+        );
+
+        let document: serde_json::Value = serde_json::from_str(&signed.document).unwrap();
+        assert_eq!(document["schema"].as_u64(), Some(1), "{}", lane.target);
+        assert_eq!(
+            document["version"].as_str(),
+            Some("5.1.0"),
+            "{}",
+            lane.target
+        );
+        assert_eq!(
+            document["target"].as_str(),
+            Some(lane.target),
+            "{}",
+            lane.target
         );
     }
 }
 
-/// The lane that matters: a signer that leaves nothing behind has published
-/// a command no client can verify, and every other lane still being green
-/// would let the tag through. It fails here, naming the binary.
+/// The two halves this document is read against: the command the feed
+/// names for a target, and the download the manifest step names for that
+/// platform. Take either away and the lane refuses rather than publishing
+/// a statement missing a download; change its bytes and the digest moves
+/// with them, so the field is measured rather than restated.
 #[cfg(unix)]
 #[test]
-fn a_lane_that_produced_no_signature_fails_the_job_by_name() {
-    for empty in ["exit 0", r#": > "$3.sig""#] {
-        for lane in &LANES {
-            let (code, said, _) = sign(lane, empty);
-            assert_ne!(code, 0, "{}: {said}", lane.target);
-            assert!(
-                said.contains(&format!("kendex-{}", lane.target)),
-                "{} unnamed in: {said}",
+#[allow(clippy::unwrap_used)]
+fn the_document_measures_the_two_downloads_a_lane_publishes() {
+    for lane in &LANES {
+        let staged = crate::stage_assets(lane);
+        let app = signed_artifacts()
+            .iter()
+            .find(|(platform, _)| *platform == lane.platform)
+            .map(|(_, file)| file.clone())
+            .unwrap();
+        let published = sign(lane, &staged, SIGNS);
+        let document: serde_json::Value = serde_json::from_str(&published.document).unwrap();
+
+        for (field, file) in [("command", command_name(lane)), ("app", app)] {
+            let mut moved = staged.clone();
+            moved.insert(file.clone(), "bytes from somewhere else".to_owned());
+            let other: serde_json::Value =
+                serde_json::from_str(&sign(lane, &moved, SIGNS).document).unwrap();
+            assert_ne!(
+                document[field], other[field],
+                "{}: the {field} digest ignores {file}",
                 lane.target
+            );
+
+            let mut gone = staged.clone();
+            gone.remove(&file);
+            let refused = sign(lane, &gone, SIGNS);
+            assert_ne!(
+                refused.code, 0,
+                "{}: a lane with no {file} published a document anyway: {}",
+                lane.target, refused.document
+            );
+        }
+    }
+}
+
+/// The lane that matters: a signer that leaves nothing behind has
+/// published a download no client can verify, and every other lane still
+/// being green would let the tag through. It fails here, naming the file
+/// that went unsigned — whichever of the two it was.
+#[cfg(unix)]
+#[test]
+fn a_download_that_went_unsigned_fails_the_job_by_name() {
+    for (shim, unsigned) in [
+        ("exit 0", "kendex-"),
+        (r#": > "$3.sig""#, "kendex-"),
+        // A signer that answers for the command and not the document.
+        (
+            r#"case "$3" in *digests-*) exit 0 ;; *) printf 'sig' > "$3.sig" ;; esac"#,
+            "digests-",
+        ),
+    ] {
+        for lane in &LANES {
+            let staged = crate::stage_assets(lane);
+            let signed = sign(lane, &staged, shim);
+            assert_ne!(signed.code, 0, "{}: {}", lane.target, signed.said);
+            assert!(
+                signed.said.contains(&format!("{unsigned}{}", lane.target)),
+                "{} unnamed in: {}",
+                lane.target,
+                signed.said
             );
         }
     }
@@ -110,26 +235,27 @@ fn a_lane_that_produced_no_signature_fails_the_job_by_name() {
 #[test]
 fn a_signer_that_fails_stops_the_lane() {
     for lane in &LANES {
-        let (code, said, _) = sign(lane, "exit 3");
-        assert_ne!(code, 0, "{}: {said}", lane.target);
+        let staged = crate::stage_assets(lane);
+        let signed = sign(lane, &staged, "exit 3");
+        assert_ne!(signed.code, 0, "{}: {}", lane.target, signed.said);
     }
 }
 
-/// The step signs under the release keypair and no other, so the command
-/// and the app bundles are held to one key.
+/// The step signs under the release keypair and no other, so the command,
+/// the document and the app bundles are held to one key.
 #[test]
 fn the_step_signs_under_the_release_key() {
     let workflow = workflow();
-    let lines = step(&workflow, "name: Sign the kendex command").join("\n");
+    let lines = step(&workflow, "name: Sign this lane's downloads").join("\n");
     assert!(
         lines.contains("TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}"),
         "{lines}"
     );
-    assert!(lines.contains("signer sign"), "{lines}");
+    assert!(lines.contains("tools/release-digests"), "{lines}");
 }
 
-/// The publish job now downloads two signatures per lane, and its `add`
-/// globs have to pick the updater bundle's. A glob that also matched the
+/// The publish job downloads two signatures per lane, and its `add` globs
+/// have to pick the updater bundle's. A glob that also matched the
 /// command's would name a download the app cannot install, and only a tag
 /// run puts the two steps together: here a `dist/` carrying nothing but
 /// command signatures has to leave every platform unanswered.
@@ -138,12 +264,8 @@ fn the_step_signs_under_the_release_key() {
 fn no_platform_is_answered_by_a_command_signature() {
     let mut dist = std::collections::BTreeMap::new();
     for lane in &LANES {
-        let ext = match lane.runner_os {
-            "Windows" => ".exe",
-            _ => "",
-        };
         dist.insert(
-            format!("kendex-{}{ext}.sig", lane.target),
+            format!("{}.sig", command_name(lane)),
             "the command signature".to_owned(),
         );
     }

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -30,6 +30,7 @@ pub mod pi_ext;
 pub mod process;
 pub mod quality;
 pub mod registry;
+pub mod release_digests;
 pub mod remote;
 pub mod render;
 pub mod repo_effects;

--- a/crates/core/src/release_digests.rs
+++ b/crates/core/src/release_digests.rs
@@ -1,0 +1,179 @@
+//! What a release published for one target, as a statement the release key
+//! covers.
+//!
+//! A signature over a download proves the bytes and nothing else: not the
+//! version they are, not the target they were built for, not the asset they
+//! were named as. Nothing signs the feed that names them, so a feed that
+//! can be served or altered can advertise the current release while
+//! pointing this target at an older, legitimately signed kendex binary, or
+//! at another platform's. Both verify, because both signatures are real.
+//!
+//! Each release lane therefore publishes `digests-<target>.json` beside its
+//! manifests and signs it under the same key: the version, the target, and
+//! the SHA-256 of each download built for it, in one document
+//! (`tools/release-digests`). An update reads it from the channel it read
+//! the feed from, holds it to the release and target it asked for, and
+//! installs nothing whose hash is not the one named there. A genuine
+//! signature over the wrong artifact no longer passes.
+
+use sha2::{Digest, Sha256};
+
+use crate::error::{CoreError, Result};
+use crate::hash::hex;
+use crate::update_feed::verify_signature;
+
+pub const DIGESTS_SCHEMA: u32 = 1;
+/// Five fixed fields; anything near this is not a document a lane wrote.
+pub const MAX_DIGESTS_BYTES: usize = 4 * 1024;
+/// SHA-256 in lowercase hex, the shape `sha256sum` prints.
+const DIGEST_CHARS: usize = 64;
+/// A target triple is the widest name a lane carries; nothing longer is one.
+const MAX_TARGET_BYTES: usize = 128;
+
+/// One release lane's signed statement. Unknown fields stay readable within
+/// a schema version, the way the feed's do, so a lane can add data without
+/// breaking clients already in the field.
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+pub struct ReleaseDigests {
+    /// An absent value is the pre-versioned schema 1 shape.
+    #[serde(default = "default_schema")]
+    pub schema: u32,
+    pub version: String,
+    pub target: String,
+    /// The kendex command binary this lane staged.
+    pub command: String,
+    /// The app download this lane bundled: the AppImage on Linux, the app
+    /// archive on macOS, the installer on Windows.
+    pub app: String,
+}
+
+fn default_schema() -> u32 {
+    DIGESTS_SCHEMA
+}
+
+impl ReleaseDigests {
+    /// The statement `version` published for `target`, read only once
+    /// `signature` covers `bytes` under `public_key_base64` and the
+    /// document says it is that release and that target.
+    ///
+    /// Both halves matter. The signature makes the document the release's
+    /// own; the two comparisons make it *this* release's, so replaying an
+    /// older release's genuinely signed statement — or another target's —
+    /// is refused rather than silently answering for the one asked for.
+    /// The key is an argument for the same reason `verify_signature`'s is:
+    /// a test holds a signature it made itself.
+    pub fn for_release(
+        public_key_base64: &str,
+        bytes: &[u8],
+        signature: &[u8],
+        version: &str,
+        target: &str,
+    ) -> Result<Self> {
+        if bytes.len() > MAX_DIGESTS_BYTES {
+            return malformed(format!(
+                "the release digests are {} bytes; the limit is {MAX_DIGESTS_BYTES}",
+                bytes.len()
+            ));
+        }
+        verify_signature(public_key_base64, bytes, signature)?;
+        let digests: Self =
+            serde_json::from_slice(bytes).map_err(|error| CoreError::UpdateFeedMalformed {
+                why: format!("the release digests are not readable: {error}"),
+            })?;
+        digests.validate()?;
+        if digests.version != version {
+            return malformed(format!(
+                "the feed offers {version} and the digests served for it are {}'s",
+                digests.version
+            ));
+        }
+        if digests.target != target {
+            return malformed(format!(
+                "the release digests for {target} were served the ones for {}",
+                digests.target
+            ));
+        }
+        Ok(digests)
+    }
+
+    /// Refuse a command binary the release did not publish for this target.
+    pub fn verify_command(&self, bytes: &[u8]) -> Result<()> {
+        verify_digest("the kendex command", &self.command, bytes)
+    }
+
+    /// Refuse an app download the release did not publish for this target.
+    pub fn verify_app(&self, bytes: &[u8]) -> Result<()> {
+        verify_digest("the desktop app download", &self.app, bytes)
+    }
+
+    fn validate(&self) -> Result<()> {
+        if self.schema != DIGESTS_SCHEMA {
+            return malformed(format!(
+                "release digests schema {} is not supported; this build reads schema {DIGESTS_SCHEMA}",
+                self.schema
+            ));
+        }
+        if self.target.is_empty() || self.target.len() > MAX_TARGET_BYTES {
+            return malformed(format!(
+                "the release digests name a target of {} bytes; the range is 1..={MAX_TARGET_BYTES}",
+                self.target.len()
+            ));
+        }
+        // A field that is not a digest could never equal one, so it would
+        // refuse every download rather than admit a wrong one. It is still
+        // a malformed document and says so here, instead of arriving later
+        // as a mismatch against bytes that were fine.
+        for (what, digest) in [("command", &self.command), ("app", &self.app)] {
+            if digest.len() != DIGEST_CHARS || !digest.bytes().all(|b| b.is_ascii_hexdigit()) {
+                return malformed(format!(
+                    "the release digest for the {what} is not {DIGEST_CHARS} hex characters"
+                ));
+            }
+        }
+        Ok(())
+    }
+}
+
+/// Where a channel publishes the digests for `target`: beside the manifest
+/// that channel serves, under the name only that target's lane writes.
+/// Derived from the manifest URL rather than taken from the manifest, so
+/// the document that judges what a feed offers is never named by it.
+pub fn release_digests_url(manifest_url: &str, target: &str) -> Result<String> {
+    if target.is_empty()
+        || target.len() > MAX_TARGET_BYTES
+        || !target
+            .bytes()
+            .all(|b| b.is_ascii_alphanumeric() || b == b'-' || b == b'_')
+    {
+        return malformed(format!(
+            "'{target}' is not a build target this release names"
+        ));
+    }
+    let Some((directory, _)) = manifest_url.rsplit_once('/') else {
+        return malformed(format!(
+            "the URL '{manifest_url}' names no directory to read the release digests from"
+        ));
+    };
+    Ok(format!("{directory}/digests-{target}.json"))
+}
+
+/// Refuse `bytes` that are not the artifact `expected` names. `what` opens
+/// the sentence, so a refusal says which half of an update was turned away.
+fn verify_digest(what: &str, expected: &str, bytes: &[u8]) -> Result<()> {
+    let mut hasher = Sha256::new();
+    hasher.update(bytes);
+    let found = hex(&hasher.finalize());
+    match found.eq_ignore_ascii_case(expected) {
+        true => Ok(()),
+        false => Err(CoreError::UpdateSignatureRefused {
+            why: format!("{what} hashes to {found}, and this release published {expected} for it"),
+        }),
+    }
+}
+
+fn malformed<T>(why: String) -> Result<T> {
+    Err(CoreError::UpdateFeedMalformed { why })
+}
+
+#[cfg(test)]
+mod tests;

--- a/crates/core/src/release_digests/tests.rs
+++ b/crates/core/src/release_digests/tests.rs
@@ -1,0 +1,214 @@
+use super::*;
+
+/// A throwaway minisign keypair signing every document below, generated
+/// once so the admitted arm runs the real check rather than a stub standing
+/// in for it. The documents carry no path and no URL, so one signature
+/// covers each of them on every machine this test runs on.
+const TEST_KEY: &str = "dW50cnVzdGVkIGNvbW1lbnQ6IG1pbmlzaWduIHB1YmxpYyBrZXk6IDc1RTYwNzZERUJFMDVFNTcKUldSWFh1RHJiUWZtZFdVSnJYQmd0QnhLVUdUQnN2MWNTR2N6SW9jZ1Z1Q0FoZmlzWDVIeFZJaUkK";
+
+/// What `tools/release-digests` wrote for the 9.9.9 Linux lane, byte for
+/// byte, so the shape this parses is the shape a release publishes.
+const PUBLISHED: &str = r#"{
+  "schema": 1,
+  "version": "9.9.9",
+  "target": "x86_64-unknown-linux-gnu",
+  "command": "aae05017e20c96dd3cd26b1fd324365c2ab53512db82b53362e75f8f553ffaea",
+  "app": "d489b792c3c3d6e9633ff28507f2c7da40a24eec743521842ebc283c2c3226ff"
+}
+"#;
+const PUBLISHED_SIGNATURE: &str = "dW50cnVzdGVkIGNvbW1lbnQ6IHNpZ25hdHVyZSBmcm9tIHRhdXJpIHNlY3JldCBrZXkKUlVSWFh1RHJiUWZtZFpxNkg5WFpISHVZL2xIMWR6eWxZN3djZUU2NXpERjVNMjRUMUJlcXlnS1V5dUpDNGsySlpHZkRBUEhiOFN3dFRhVElPaWltajA3RTNpNVk3NndJcXdZPQp0cnVzdGVkIGNvbW1lbnQ6IHRpbWVzdGFtcDoxNzg4MDQyMjM0CWZpbGU6ZGlnZXN0cy14ODZfNjQtdW5rbm93bi1saW51eC1nbnUuanNvbgpzSkg3dGJuMXVNSHIyRkE5enlISnVSRWRNS0xXcWxFVEJ1TkRaSXFsR0ZzZm5LbCtqNThBckYzb1JQVE9UeEk5WExEMXpKYTlSZnl0S2xQUXZxTk9Bdz09Cg==";
+/// The bytes `PUBLISHED` names as this release's command and app download.
+const COMMAND: &[u8] = b"kendex AppImage bytes";
+const APP: &[u8] = b"the linux appimage";
+
+const TARGET: &str = "x86_64-unknown-linux-gnu";
+const VERSION: &str = "9.9.9";
+
+/// The same lane's document from an earlier release, signed when it
+/// shipped: what a feed claiming 9.9.9 can serve to answer for a release
+/// it is not.
+const OLDER: &str = r#"{
+  "schema": 1,
+  "version": "5.0.0",
+  "target": "x86_64-unknown-linux-gnu",
+  "command": "aae05017e20c96dd3cd26b1fd324365c2ab53512db82b53362e75f8f553ffaea",
+  "app": "42c30601103ba7015436bd2feed7b3867ab36ec71e3bece765400efe82a33a08"
+}
+"#;
+const OLDER_SIGNATURE: &str = "dW50cnVzdGVkIGNvbW1lbnQ6IHNpZ25hdHVyZSBmcm9tIHRhdXJpIHNlY3JldCBrZXkKUlVSWFh1RHJiUWZtZFJQSzRNQ0I5Rnk3enVxSkhFb3htZXA0L295SS8ycUhHZnRyWVdjcy9uNTJHczE4M1Q4KzZLL0Vja2tTTFB4SVk4RXRneFRpYWszSTRDbTkyd0RrUEFrPQp0cnVzdGVkIGNvbW1lbnQ6IHRpbWVzdGFtcDoxNzg4MDQyMjM0CWZpbGU6ZGlnZXN0cy14ODZfNjQtdW5rbm93bi1saW51eC1nbnUuanNvbgpVbDlnc2FSQUdFMVY2VWI1Z3NpL3BmMVZ4bDBpTm4wZ05aUUkyaG9ldFByMGhtdGVZTVhpUnVFN0ZuQ01ob0lGR08rMlMrazA1L1luUXQwTjNzMUxDdz09Cg==";
+
+/// Another platform's document for the same release, equally genuine.
+const OTHER_TARGET: &str = r#"{
+  "schema": 1,
+  "version": "9.9.9",
+  "target": "aarch64-apple-darwin",
+  "command": "ea1eb85cbb8a7c5b0ee438f4924e7825fece13173e9764c8308b1d95bbd7226a",
+  "app": "a9c46ccd0a1b1a38b8e7bceb39644bd068f49fd58aeb185491be24326939d567"
+}
+"#;
+const OTHER_TARGET_SIGNATURE: &str = "dW50cnVzdGVkIGNvbW1lbnQ6IHNpZ25hdHVyZSBmcm9tIHRhdXJpIHNlY3JldCBrZXkKUlVSWFh1RHJiUWZtZFF5S1FzZklvb203YVRMdVlqa2NNYm15alFnZVBPcFNvQmdRd3FWOFRFQUxxZENMRk1kOUJlQlcyTUJ4bDdPaWJ2UFZHbHYxcE5ubkRsRUNKR3RpL1FRPQp0cnVzdGVkIGNvbW1lbnQ6IHRpbWVzdGFtcDoxNzg4MDQyMjM0CWZpbGU6ZGlnZXN0cy1hYXJjaDY0LWFwcGxlLWRhcndpbi5qc29uCml0RG1oZWpkZW5iZHBmcERNMHZVNHh3eGFmVTNObHBOZVI5clJwOXFXd2pBQWZGMW9WU0ZkQ3Fici9ib2NhRnFVdzFjcW80NWVPWWJNOWdnNlF0NENBPT0K";
+
+/// Documents this key really signed whose contents are not a statement
+/// this build can act on. Each is signed, so each reaches the reading that
+/// refuses it rather than stopping at the signature.
+const UNREADABLE: &[(&str, &str, &str)] = &[
+    (
+        r#"{"schema":2,"version":"9.9.9","target":"x86_64-unknown-linux-gnu","command":"aae05017e20c96dd3cd26b1fd324365c2ab53512db82b53362e75f8f553ffaea","app":"aae05017e20c96dd3cd26b1fd324365c2ab53512db82b53362e75f8f553ffaea"}"#,
+        "dW50cnVzdGVkIGNvbW1lbnQ6IHNpZ25hdHVyZSBmcm9tIHRhdXJpIHNlY3JldCBrZXkKUlVSWFh1RHJiUWZtZFJrRXhhM2h0WWZia2VoYUh3SXgwcEs0NUxGMURaWjBaaWlLS0N5bmVQNEJ1VElKc0JNZHZPQW8xaFZZREpkS3p2TUVpbVJQVU5iSTVqaWRRUmhtTkFjPQp0cnVzdGVkIGNvbW1lbnQ6IHRpbWVzdGFtcDoxNzg4MDQyMzM0CWZpbGU6c2NoZW1hLmpzb24KRVJpQWxCaGpxeTdGNHlYL2I5eGdoaGdHWk94NDBlZ1huNS9NN1V5Vnk2L0NTd2VTUEpmc1hTaXN4SkxDdkVKcUtkVFU1QVFMa200elJ6T1pjdlVVQnc9PQo=",
+        "schema 2 is not supported",
+    ),
+    (
+        r#"{"schema":1,"version":"9.9.9","target":"","command":"aae05017e20c96dd3cd26b1fd324365c2ab53512db82b53362e75f8f553ffaea","app":"aae05017e20c96dd3cd26b1fd324365c2ab53512db82b53362e75f8f553ffaea"}"#,
+        "dW50cnVzdGVkIGNvbW1lbnQ6IHNpZ25hdHVyZSBmcm9tIHRhdXJpIHNlY3JldCBrZXkKUlVSWFh1RHJiUWZtZFdsZ2x3SjdKQ0lFTVpPMkVZNUdXSWlzNENaQ050QnRRYXlGeTBMWEpDZlFmRWQ3TTV4dGhIZUhhQ0tSYk5ac1FVQ1d6WDNRaUkxSm5odGVCdjI2dmdZPQp0cnVzdGVkIGNvbW1lbnQ6IHRpbWVzdGFtcDoxNzg4MDQyMzM0CWZpbGU6dGFyZ2V0Lmpzb24KZDhUbmxYNWllQTFEOEVPaU5rK3lUbmVmRFp2bmtGYklQaHhIL3hYR0JhWGhTRTJRVlhZNjlkbnd0bVN2Umgva2tURVpndzczWkxJd0FwVW5kK1RLRGc9PQo=",
+        "name a target of 0 bytes",
+    ),
+    (
+        r#"{"schema":1,"version":"9.9.9","target":"x86_64-unknown-linux-gnu","command":"not a digest","app":"aae05017e20c96dd3cd26b1fd324365c2ab53512db82b53362e75f8f553ffaea"}"#,
+        "dW50cnVzdGVkIGNvbW1lbnQ6IHNpZ25hdHVyZSBmcm9tIHRhdXJpIHNlY3JldCBrZXkKUlVSWFh1RHJiUWZtZGNjMVhlcHpnOUlRNEFsUDNDMG5LdmFmMm4rMGFPbm03bGR2R1BRbHpDTjV0bEN6OEc4dlBlRUp0YjRRTTM3dk5zWVhCZ3dTUm8wWitBVWg5WTNXM0FrPQp0cnVzdGVkIGNvbW1lbnQ6IHRpbWVzdGFtcDoxNzg4MDQyMzM0CWZpbGU6ZGlnZXN0Lmpzb24KekVPZGxDWmh1NXFJN1RwUTRrUElxT0JvQlgxVzNZaXJ1UlFHMlRwRzNKdjhQNnlta01qSjN3YjNHamxISUExaERZVS96dVJydE5WZDNBK3cyclVlQ1E9PQo=",
+        "digest for the command is not 64 hex characters",
+    ),
+    (
+        "a release published a page, not a document",
+        "dW50cnVzdGVkIGNvbW1lbnQ6IHNpZ25hdHVyZSBmcm9tIHRhdXJpIHNlY3JldCBrZXkKUlVSWFh1RHJiUWZtZFR1UUdwOGhobmlyaldFWGJNcGJRZ01jVGE0dUxOLzRkZGtsUnkrQ0d1K2JSVXB6MlRkMkg0REEwUTB4VWlzaUJmVnA1a1ZQQ01mczFyUWRkcW83UndBPQp0cnVzdGVkIGNvbW1lbnQ6IHRpbWVzdGFtcDoxNzg4MDQyMzM0CWZpbGU6cHJvc2UuanNvbgozT3RDVVZGeXNaMEI5MUhndStVQzZmTGJFeEM0azRFUEhPT3RpNnZJWDFLd01KRFlYdk9RQlFsZ0pIc3UxVVp6azJHVEo1U29QaFZ2RXdjVTlOdCtBdz09Cg==",
+        "not readable",
+    ),
+];
+
+fn read(document: &str, signature: &str) -> Result<ReleaseDigests> {
+    ReleaseDigests::for_release(
+        TEST_KEY,
+        document.as_bytes(),
+        signature.as_bytes(),
+        VERSION,
+        TARGET,
+    )
+}
+
+/// The admitted arm, and the one every refusal below is read against: the
+/// release's own document for the release and target being asked about.
+#[test]
+fn the_release_own_document_for_this_target_is_read() {
+    let digests = read(PUBLISHED, PUBLISHED_SIGNATURE).expect("the release signed this document");
+    assert_eq!(digests.schema, DIGESTS_SCHEMA);
+    assert_eq!(digests.version, VERSION);
+    assert_eq!(digests.target, TARGET);
+    digests
+        .verify_command(COMMAND)
+        .expect("the published command");
+    digests.verify_app(APP).expect("the published app download");
+}
+
+/// The whole defect in one assertion: a genuine signature over another
+/// release's document, or another platform's, does not answer for the one
+/// asked for. Both are real signatures under the pinned key, so what
+/// refuses them is the binding and nothing else.
+#[test]
+fn a_genuinely_signed_document_for_another_release_or_target_is_refused() {
+    let older = read(OLDER, OLDER_SIGNATURE).unwrap_err().to_string();
+    assert!(older.contains("the feed offers 9.9.9"), "{older}");
+    assert!(older.contains("5.0.0"), "{older}");
+
+    let elsewhere = read(OTHER_TARGET, OTHER_TARGET_SIGNATURE)
+        .unwrap_err()
+        .to_string();
+    assert!(elsewhere.contains("aarch64-apple-darwin"), "{elsewhere}");
+}
+
+/// A document nothing signed is not the release's, whatever it says, and
+/// neither is one whose bytes moved after it was signed.
+#[test]
+fn a_document_the_release_key_does_not_cover_is_refused() {
+    let tampered = PUBLISHED.replace("9.9.9", "9.9.8");
+    for (document, signature) in [
+        (PUBLISHED, ""),
+        (PUBLISHED, "not a signature"),
+        (tampered.as_str(), PUBLISHED_SIGNATURE),
+    ] {
+        let refused = ReleaseDigests::for_release(
+            TEST_KEY,
+            document.as_bytes(),
+            signature.as_bytes(),
+            "9.9.8",
+            TARGET,
+        );
+        assert!(refused.is_err(), "{document} under '{signature}'");
+    }
+}
+
+/// Signed and still unreadable: each of these reaches the reading of the
+/// document, so a green pass here is the reading refusing, not the
+/// signature check standing in for it.
+#[test]
+fn a_signed_document_this_build_cannot_act_on_is_refused() {
+    for (document, signature, why) in UNREADABLE {
+        let refused = read(document, signature).unwrap_err().to_string();
+        assert!(refused.contains(why), "{refused}");
+    }
+}
+
+/// The size cap is read before anything else, so a body too large to be a
+/// lane's document never reaches the signature check.
+#[test]
+fn a_body_larger_than_a_document_is_refused_unread() {
+    let huge = vec![b' '; MAX_DIGESTS_BYTES + 1];
+    let refused = ReleaseDigests::for_release(TEST_KEY, &huge, b"", VERSION, TARGET)
+        .unwrap_err()
+        .to_string();
+    assert!(refused.contains("the limit is"), "{refused}");
+}
+
+/// Bytes the release did not publish for this half are refused even when
+/// the document is the release's own — which is the case where a signature
+/// is genuine over an artifact this release never named.
+#[test]
+fn bytes_this_release_did_not_publish_are_refused() {
+    let digests = read(PUBLISHED, PUBLISHED_SIGNATURE).expect("the release signed this document");
+    for bytes in [APP, b"an older kendex, signed when it shipped".as_slice()] {
+        let refused = digests.verify_command(bytes).unwrap_err().to_string();
+        assert!(
+            refused.contains("the kendex command hashes to"),
+            "{refused}"
+        );
+        assert!(refused.contains(&digests.command), "{refused}");
+    }
+    let refused = digests.verify_app(COMMAND).unwrap_err().to_string();
+    assert!(refused.contains("the desktop app download"), "{refused}");
+}
+
+/// The document is found beside the manifest the channel served, never at
+/// a name the feed supplied.
+#[test]
+fn the_document_is_a_sibling_of_the_manifest_it_judges() {
+    use crate::update_channel::{PRERELEASE_FEED_URL, RELEASE_FEED_URL, RELEASE_MANIFEST_URL};
+    assert_eq!(
+        release_digests_url(RELEASE_FEED_URL, TARGET).unwrap(),
+        "https://github.com/vanillagreencom/kendex/releases/latest/download/digests-x86_64-unknown-linux-gnu.json"
+    );
+    assert_eq!(
+        release_digests_url(RELEASE_MANIFEST_URL, TARGET).unwrap(),
+        release_digests_url(RELEASE_FEED_URL, TARGET).unwrap()
+    );
+    assert_eq!(
+        release_digests_url(PRERELEASE_FEED_URL, TARGET).unwrap(),
+        "https://github.com/vanillagreencom/kendex/releases/download/prerelease/digests-x86_64-unknown-linux-gnu.json"
+    );
+    assert_eq!(
+        release_digests_url("file:///tmp/fixture/feed.json", TARGET).unwrap(),
+        "file:///tmp/fixture/digests-x86_64-unknown-linux-gnu.json"
+    );
+}
+
+/// A target is a build name, so nothing that could steer the read
+/// elsewhere is one.
+#[test]
+fn a_target_that_is_not_a_build_name_names_no_document() {
+    for target in ["", "../../../etc/passwd", "x86_64/../..", &"t".repeat(129)] {
+        assert!(
+            release_digests_url(RELEASE_FEED_URL_FIXTURE, target).is_err(),
+            "{target}"
+        );
+    }
+    assert!(release_digests_url("digests", TARGET).is_err());
+}
+
+const RELEASE_FEED_URL_FIXTURE: &str = "https://example.test/download/feed.json";

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -291,13 +291,13 @@ lives in one capability table read by core and UI.
   mid-read; a failed read shows its error with a retry, kept figures headed
   as the last kendex could check, never a definite count — least of all
   zero. Every read the app starts with runs beside the others.
-- **Discovery is the unsigned feed; both halves verify under one pinned key.**
-  Off the launch path, one cross-process transaction reads the feed at most
-  every six hours, keeps the last result beside any error, and never follows
-  the final link; the preference gates automatic contact; in both shells debug
-  builds alone honor `KENDEX_UPDATE_FEED`. Replacing needs the path behind the
+- **Discovery is unsigned; one pinned key covers a document binding each
+  download to its release and target.** Off the launch path, one transaction
+  reads the feed six-hourly at most, keeps the last result beside any error
+  and never follows the final link; a preference gates automatic contact; only
+  debug builds honor `KENDEX_UPDATE_FEED`. Replacing needs the path behind the
   running one writable, outside a system prefix; a package prefix names its
-  command instead, anything else neither. One sidebar card offers whichever.
+  command instead, anything else neither. A sidebar card offers whichever.
 - Commands that touch disk, git, or a subprocess are
   `#[tauri::command(async)]`. Only window operations stay synchronous.
 - No database: manifests, locks, and native dirs are the state; scans are

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -21,10 +21,20 @@ Release with:
   dmg, NSIS installer), and the `.sig` Tauri writes beside each updater
   bundle. `kendex update` fetches `<AppImage>.sig` straight from the
   release, so it is a published asset and not only an input to `latest.json`.
-- `latest.json` — the signed manifest the app's Update button installs
-  from, one `{signature, url}` per platform. The publish job writes it from
-  the `.sig` files the lanes staged, and names any platform whose signature
-  never arrived and fails rather than publishing a release without it.
+- `latest.json` — the manifest the app's Update button installs from, one
+  `{signature, url}` per platform. The publish job writes it from the `.sig`
+  files the lanes staged, and names any platform whose signature never
+  arrived and fails rather than publishing a release without it. Nothing
+  signs the manifest itself, which is what the digests below are for.
+- `digests-<target>.json` and its `.sig` — what one lane published, signed
+  under the release key: the version, the target, and the SHA-256 of that
+  lane's command and app download (`tools/release-digests`). Both shells
+  read the document for their own target from the channel they read their
+  manifest from, hold it to the release and target they asked for, and
+  install nothing whose hash it does not name. A signature proves the bytes
+  it covers and not which release they are, so without this a feed or
+  manifest that can be served or altered can offer a genuine older
+  download, or another platform's, and it verifies.
 - `feed.json` — the update feed `kendex update` reads from
   `releases/latest/download/feed.json`. Publishing the draft makes the
   version "latest". New feeds carry `schema: 1`, a SemVer `version`, and an

--- a/tools/release-digests
+++ b/tools/release-digests
@@ -1,0 +1,124 @@
+#!/usr/bin/env bash
+# release-digests — what one release lane publishes about what it built:
+# the version, the target, and the SHA-256 of each download that lane
+# staged, in one document signed under the release key.
+#
+# A signature over a download proves the bytes and nothing else — not the
+# version they are, not the target they were built for. Nothing signs the
+# feed that names them, so a feed that can be served or altered can point
+# this target at an older, legitimately signed kendex binary, or at
+# another platform's, and both verify. An update reads this document from
+# the channel it read the feed from, holds it to the release and target it
+# asked for, and installs nothing whose hash it does not name.
+#
+# usage: tools/release-digests [--document-only] TARGET VERSION DIST
+#
+#   TARGET   the Rust target triple this lane built
+#   VERSION  the version this release was built as, without a leading v
+#   DIST     the directory `Stage release assets` filled
+#
+# Writes DIST/digests-TARGET.json, then signs it and the kendex command
+# beside it with the tauri signer under TAURI_SIGNING_PRIVATE_KEY. A lane
+# that produced no signature published a download no client can verify, so
+# it fails here rather than in the release.
+#
+# --document-only writes the document and signs nothing: signing needs the
+# release secret, which no test has, and the document is what a test can
+# hold to the shape the client reads.
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+die() {
+  echo "::error::$*" >&2
+  exit 1
+}
+
+document_only=0
+if [ "${1:-}" = "--document-only" ]; then
+  document_only=1
+  shift
+fi
+[ "$#" -eq 3 ] || die "usage: tools/release-digests [--document-only] TARGET VERSION DIST"
+target=$1
+version=$2
+dist=$3
+
+[ -d "$dist" ] || die "$dist is not a directory, so this lane staged nothing to publish."
+# The version reaches a JSON document and a URL, so it is held to the
+# characters a SemVer version is made of before either.
+case "$version" in
+  "" | *[!0-9A-Za-z.+-]*) die "'$version' is not a version this release could have been built as." ;;
+esac
+
+# What this lane's two downloads are named. The command is staged under its
+# triple; the app download is the artifact this platform's updater installs,
+# which is the one the release's latest.json names for it.
+ext=""
+case "$target" in
+  x86_64-unknown-linux-gnu) app_glob="kendex_*_amd64.AppImage" ;;
+  aarch64-unknown-linux-gnu) app_glob="kendex_*_aarch64.AppImage" ;;
+  aarch64-apple-darwin | x86_64-apple-darwin) app_glob="kendex-${target}.app.tar.gz" ;;
+  x86_64-pc-windows-msvc)
+    app_glob="kendex_*_x64-setup.exe"
+    ext=".exe"
+    ;;
+  *) die "'$target' is not a target this release builds; add it here and to the release matrix together." ;;
+esac
+
+# Exactly one match or none: two AppImages in dist/ is a lane that staged
+# another release's artifact beside its own, and picking either would sign
+# a document naming bytes nobody can account for.
+only_match() {
+  local what=$1 pattern=$2 candidate found=""
+  for candidate in "$dist"/$pattern; do
+    [ -f "$candidate" ] || continue
+    [ -z "$found" ] || die "$dist holds more than one $what ($found and $candidate); this lane cannot say which one it published."
+    found=$candidate
+  done
+  [ -n "$found" ] || die "$dist holds no $what matching $pattern; check this lane's staging step, then re-run the tag."
+  printf '%s' "$found"
+}
+
+# Plain SHA-256 in lowercase hex, the shape sha256sum prints and the
+# client recomputes. macOS ships shasum and no sha256sum.
+digest() {
+  local file=$1 line
+  if command -v sha256sum >/dev/null 2>&1; then
+    line=$(sha256sum "$file") || die "sha256sum could not read $file."
+  else
+    line=$(shasum -a 256 "$file") || die "shasum could not read $file."
+  fi
+  line=${line%% *}
+  [ "${#line}" -eq 64 ] || die "the digest of $file came back as '$line', which is not SHA-256."
+  printf '%s' "$line"
+}
+
+command_binary=$(only_match "kendex command" "kendex-${target}${ext}")
+app_download=$(only_match "app download" "$app_glob")
+# Both digests are taken before the document is opened. A command
+# substitution that failed inside the heredoc would leave its field empty
+# and the document written anyway, which is a lane publishing a statement
+# it never measured.
+command_digest=$(digest "$command_binary")
+app_digest=$(digest "$app_download")
+document="$dist/digests-${target}.json"
+
+cat >"$document" <<JSON
+{
+  "schema": 1,
+  "version": "${version}",
+  "target": "${target}",
+  "command": "${command_digest}",
+  "app": "${app_digest}"
+}
+JSON
+
+[ "$document_only" -eq 0 ] || exit 0
+
+for file in "$command_binary" "$document"; do
+  "$ROOT/ui/node_modules/.bin/tauri" signer sign "$file" ||
+    die "The signer failed on ${file}. kendex update refuses what it cannot verify; check TAURI_SIGNING_PRIVATE_KEY, then re-run the tag."
+  [ -s "${file}.sig" ] ||
+    die "No signature for ${file}. kendex update refuses what it cannot verify; check this lane's signer step and TAURI_SIGNING_PRIVATE_KEY, then re-run the tag."
+done

--- a/tools/tests/release-digests.test.sh
+++ b/tools/tests/release-digests.test.sh
@@ -1,0 +1,159 @@
+#!/usr/bin/env bash
+# Pins tools/release-digests: it names this lane's two downloads by the
+# rules the release publishes them under, measures each with SHA-256, and
+# writes one document naming the version and the target. The refusing
+# direction runs first in every pair, and each refusal is checked to have
+# left no document behind — a lane that half-wrote one would publish a
+# statement it never measured, which every client then holds its downloads
+# to. Signing is not driven here: it needs the release secret, so
+# --document-only is the mode a test can run.
+set -euo pipefail
+
+TEST_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+DIGESTS="$(cd "$TEST_DIR/.." && pwd)/release-digests"
+TMP="$(mktemp -d)"
+trap 'rm -rf -- "${TMP:?}"' EXIT
+
+PASS=0
+FAIL=0
+ok() {
+  PASS=$((PASS + 1))
+  printf '  ok    %s\n' "$1"
+}
+bad() {
+  FAIL=$((FAIL + 1))
+  printf '  FAIL  %s\n        %s\n' "$1" "${2:-}"
+}
+
+DIST="$TMP/dist"
+OUT=""
+RC=0
+
+# A lane that built the Linux x86_64 release: the command it staged and the
+# AppImage its bundler produced, beside the sibling files a lane also
+# stages and no document names.
+linux_lane() {
+  rm -rf "$DIST"
+  mkdir -p "$DIST"
+  printf 'the kendex command' >"$DIST/kendex-x86_64-unknown-linux-gnu"
+  printf 'the app download' >"$DIST/kendex_9.9.9_amd64.AppImage"
+  printf 'a signature' >"$DIST/kendex_9.9.9_amd64.AppImage.sig"
+  printf 'a package' >"$DIST/kendex_9.9.9_amd64.deb"
+}
+
+# Errexit is on, so a refusal is captured through an `if` rather than
+# ending the suite that is asking for it.
+run() { # run TARGET VERSION [DIST]
+  if OUT=$("$DIGESTS" --document-only "$1" "$2" "${3-$DIST}" 2>&1); then
+    RC=0
+  else
+    RC=$?
+  fi
+}
+
+document() { printf '%s/digests-%s.json' "$DIST" "$1"; }
+
+field() { # field NAME FILE
+  sed -n "s/.*\"$1\": \"\\([^\"]*\\)\".*/\\1/p" "$2"
+}
+
+# --- refusals ---------------------------------------------------------
+
+linux_lane
+run aarch64-unknown-linux-musl 9.9.9
+[ "$RC" -ne 0 ] && case "$OUT" in *"not a target this release builds"*) true ;; *) false ;; esac &&
+  ok "a target the release does not build is refused" ||
+  bad "a target the release does not build is refused" "rc=$RC out=$OUT"
+
+run x86_64-unknown-linux-gnu '9.9.9", "target": "elsewhere'
+[ "$RC" -ne 0 ] && case "$OUT" in *"not a version"*) true ;; *) false ;; esac &&
+  ok "a version carrying JSON of its own is refused" ||
+  bad "a version carrying JSON of its own is refused" "rc=$RC out=$OUT"
+
+run x86_64-unknown-linux-gnu 9.9.9 "$TMP/never-staged"
+[ "$RC" -ne 0 ] && case "$OUT" in *"is not a directory"*) true ;; *) false ;; esac &&
+  ok "a lane that staged nothing is refused" ||
+  bad "a lane that staged nothing is refused" "rc=$RC out=$OUT"
+
+linux_lane
+rm "$DIST/kendex-x86_64-unknown-linux-gnu"
+run x86_64-unknown-linux-gnu 9.9.9
+[ "$RC" -ne 0 ] && case "$OUT" in *"holds no kendex command"*) true ;; *) false ;; esac &&
+  ok "a lane missing its command is refused" ||
+  bad "a lane missing its command is refused" "rc=$RC out=$OUT"
+[ ! -f "$(document x86_64-unknown-linux-gnu)" ] &&
+  ok "a refused lane leaves no document behind" ||
+  bad "a refused lane leaves no document behind" "$(cat "$(document x86_64-unknown-linux-gnu)")"
+
+linux_lane
+rm "$DIST/kendex_9.9.9_amd64.AppImage"
+run x86_64-unknown-linux-gnu 9.9.9
+[ "$RC" -ne 0 ] && case "$OUT" in *"holds no app download"*) true ;; *) false ;; esac &&
+  ok "a lane missing its app download is refused" ||
+  bad "a lane missing its app download is refused" "rc=$RC out=$OUT"
+
+linux_lane
+printf 'another release' >"$DIST/kendex_5.0.0_amd64.AppImage"
+run x86_64-unknown-linux-gnu 9.9.9
+[ "$RC" -ne 0 ] && case "$OUT" in *"more than one app download"*) true ;; *) false ;; esac &&
+  ok "two app downloads in one lane are refused rather than picked between" ||
+  bad "two app downloads in one lane are refused rather than picked between" "rc=$RC out=$OUT"
+
+# --- the document ------------------------------------------------------
+
+linux_lane
+run x86_64-unknown-linux-gnu 9.9.9
+DOC=$(document x86_64-unknown-linux-gnu)
+[ "$RC" -eq 0 ] && [ -f "$DOC" ] &&
+  ok "the lane above, with nothing missing, writes its document" ||
+  bad "the lane above, with nothing missing, writes its document" "rc=$RC out=$OUT"
+
+[ "$(field version "$DOC")" = "9.9.9" ] && [ "$(field target "$DOC")" = "x86_64-unknown-linux-gnu" ] &&
+  ok "the document names the release and the target it was written for" ||
+  bad "the document names the release and the target it was written for" "$(cat "$DOC")"
+
+expect_command=$(sha256sum "$DIST/kendex-x86_64-unknown-linux-gnu" | cut -d' ' -f1)
+expect_app=$(sha256sum "$DIST/kendex_9.9.9_amd64.AppImage" | cut -d' ' -f1)
+[ "$(field command "$DOC")" = "$expect_command" ] && [ "$(field app "$DOC")" = "$expect_app" ] &&
+  ok "each digest is plain SHA-256 over the download it names" ||
+  bad "each digest is plain SHA-256 over the download it names" "$(cat "$DOC")"
+
+# The document is what a client parses, so a lane that wrote something
+# only sed can read would pass every check above and fail in the field.
+if command -v jq >/dev/null 2>&1; then
+  jq -e '.schema == 1 and (.command | test("^[0-9a-f]{64}$")) and (.app | test("^[0-9a-f]{64}$"))' \
+    "$DOC" >/dev/null 2>&1 &&
+    ok "the document is JSON carrying the schema this build reads" ||
+    bad "the document is JSON carrying the schema this build reads" "$(cat "$DOC")"
+fi
+
+# --- the lanes this host cannot build ----------------------------------
+
+rm -rf "$DIST"
+mkdir -p "$DIST"
+printf 'the windows command' >"$DIST/kendex-x86_64-pc-windows-msvc.exe"
+printf 'the windows installer' >"$DIST/kendex_9.9.9_x64-setup.exe"
+printf 'a signature' >"$DIST/kendex_9.9.9_x64-setup.exe.sig"
+run x86_64-pc-windows-msvc 9.9.9
+DOC=$(document x86_64-pc-windows-msvc)
+[ "$RC" -eq 0 ] &&
+  [ "$(field command "$DOC")" = "$(sha256sum "$DIST/kendex-x86_64-pc-windows-msvc.exe" | cut -d' ' -f1)" ] &&
+  [ "$(field app "$DOC")" = "$(sha256sum "$DIST/kendex_9.9.9_x64-setup.exe" | cut -d' ' -f1)" ] &&
+  ok "the Windows lane measures the .exe command and the installer" ||
+  bad "the Windows lane measures the .exe command and the installer" "rc=$RC out=$OUT"
+
+rm -rf "$DIST"
+mkdir -p "$DIST"
+printf 'the mac command' >"$DIST/kendex-aarch64-apple-darwin"
+printf 'the mac archive' >"$DIST/kendex-aarch64-apple-darwin.app.tar.gz"
+printf 'a signature' >"$DIST/kendex-aarch64-apple-darwin.app.tar.gz.sig"
+printf 'a disk image' >"$DIST/kendex_9.9.9_aarch64.dmg"
+run aarch64-apple-darwin 9.9.9
+DOC=$(document aarch64-apple-darwin)
+[ "$RC" -eq 0 ] &&
+  [ "$(field app "$DOC")" = "$(sha256sum "$DIST/kendex-aarch64-apple-darwin.app.tar.gz" | cut -d' ' -f1)" ] &&
+  ok "the macOS lane measures the archive its updater installs, not the dmg" ||
+  bad "the macOS lane measures the archive its updater installs, not the dmg" "rc=$RC out=$OUT"
+
+printf '\n%s passed, %s failed\n' "$PASS" "$FAIL"
+[ "$FAIL" -eq 0 ]

--- a/ui/src/bindings.ts
+++ b/ui/src/bindings.ts
@@ -18,9 +18,11 @@ export const commands = {
 	appUpdateChannel: () => typedError<InstallChannel, string>(__TAURI_INVOKE("app_update_channel")),
 	/**
 	 *  Replace this install with the latest release and relaunch into it. The
-	 *  separately signed updater manifest is the delivery path and verifies
-	 *  itself; the discovery feed never supplies an install URL. A failure
-	 *  leaves the running app untouched and usable.
+	 *  manifest names a download and the signature over it; the release's own
+	 *  digests document names which download this release published for this
+	 *  target, and the bytes are held to both before anything is installed.
+	 *  The discovery feed never supplies an install URL. A failure leaves the
+	 *  running app untouched and usable.
 	 */
 	appUpdateInstall: () => typedError<null, string>(__TAURI_INVOKE("app_update_install")),
 	scanMachine: () => typedError<ScanResult, string>(__TAURI_INVOKE("scan_machine")),


### PR DESCRIPTION
An update signature proved the bytes and not which release they are. Four
reviewers raised this across three PRs today, and it is the last gap in the
update path before the 1.0 release gate treats `kendex update` as verified.

The feed naming the asset is unsigned, so a feed that can be served or altered
could advertise the current release while pointing this target at any older,
legitimately signed kendex binary — a previous release, or another platform's —
with that binary's genuine `.sig`. Verification succeeded, because the signature
was real for those bytes, and the command was downgraded or replaced with an
executable that cannot run here. Comparing the feed's version to the manifest
did not close it: that version is the attacker's to write.

## The premise the issue got wrong

Both the issue and my delegation said the app's `latest.json` is a signed
manifest the plugin verifies, so the binding question there was narrower. It is
not. In `tauri-plugin-updater` 2.10.1, `updater.rs` verifies the signature over
the downloaded artifact and nothing else, and the signature it verifies against
is the one the manifest supplied. The app had the same gap as the CLI, so both
shells are fixed here rather than one.

## What ships

Each release lane publishes `digests-<target>.json` beside its manifests and
signs it under the release key: the version, the target, and the SHA-256 of that
lane's command binary and app download.

Both shells read the document for their own target, from the channel they read
their manifest from, hold it to the release and target they asked for, and
install nothing whose hash it does not name. The document is named by the
running build and the channel, never by the feed, so a feed cannot redirect the
check that judges it.

Requirement 2 was already implemented — `--force` in the CLI, `release.version >
current` in the plugin — but rested on a version the attacker wrote. It now
rests on one the release states.

## Hashes rather than signing the feed

Signing the feed authenticates the asset URL, not the bytes served at it. An
attacker who can write release assets — the threat model in this issue's triage
— still passes that check. Hashing what was published closes it.

## Verification

`tools/guard` exit 0. The release-digests suite is 13/13 and the release
workflow suite 30/30. Ten must-fail controls were run and read: five on
`tools/release-digests` (unknown target, unchecked version, missing artifact,
duplicate artifact, missing dist, and a dropped empty-signature check) and five
on the Rust side (version binding, target binding, signature check, document
validation, digest check). Each turned its intended test red and green again on
restore.

One line no test covers: `digests.verify_app(&bytes)` inside the async
`app_update_install` command; its two halves are covered separately.

Two structural moves: the CLI's app-half guard moved ahead of every download, so
a run refuses before paying for bytes; and the app crate's inline test module
moved to `crates/app/src/app_update/tests.rs`, without which the new tests would
have pushed `app_update.rs` past its 400-line ratchet.

Closes KEN-820
