### PR TITLE
fix(KEN-803): a lock says which project wrote it, and the read holds it to that

### DIFF
--- a/changelog.d/security/KEN-803.md
+++ b/changelog.d/security/KEN-803.md
@@ -1,0 +1,1 @@
+- **Breaking:** A lock records which project wrote it, so a refresh no longer trashes a checkout nested inside the project. Existing locks are refused: delete `.kendex-lock.json` and apply again.

--- a/crates/app/tests/apply_migration.rs
+++ b/crates/app/tests/apply_migration.rs
@@ -86,7 +86,10 @@ fn fixture(manifest: impl FnOnce(&std::path::Path) -> String) -> Fixture {
     fs::write(&manifest_path, manifest(&source)).unwrap();
     fs::write(
         project.join(".kendex-lock.json"),
-        "{\n  \"version\": 1,\n  \"entries\": {}\n}\n",
+        format!(
+            "{{\n  \"version\": 1,\n  \"root\": {},\n  \"entries\": {{}}\n}}\n",
+            serde_json::to_string(&project.display().to_string()).unwrap()
+        ),
     )
     .unwrap();
 

--- a/crates/cli/tests/compat.rs
+++ b/crates/cli/tests/compat.rs
@@ -12,6 +12,16 @@ use std::os::unix::fs::PermissionsExt;
 use std::path::Path;
 use std::process::{Command, Output};
 
+/// A lock naming the project it sits in — the record every project lock
+/// carries, without which a read refuses it as nobody's.
+#[allow(clippy::unwrap_used)]
+fn lock_of(proj: &Path, entries: &str) -> String {
+    format!(
+        r#"{{"version":1,"root":{},"entries":{{{entries}}}}}"#,
+        serde_json::to_string(&proj.display().to_string()).unwrap()
+    )
+}
+
 #[allow(clippy::expect_used)]
 fn kendex_in(home: &Path, cwd: &Path, args: &[&str], envs: &[(&str, String)]) -> Output {
     let mut command = Command::new(env!("CARGO_BIN_EXE_kendex"));
@@ -130,7 +140,10 @@ fn report_dry_run_routes_by_ownership_and_rejects_scope_all() {
     // symlinked, as every installed skill is; delivery is not ownership.
     fs::write(
         proj.join(".kendex-lock.json"),
-        r#"{"version":1,"entries":{"agent:orch:claude":{"name":"orch","kind":"agent","harness":"claude","source":"kendex","sourceRepo":"vanillagreencom/kendex","method":"copy","installedAt":"2026-01-01T00:00:00Z","sourceHash":"x","enabled":true},"skill:size-ratchet:claude":{"name":"size-ratchet","kind":"skill","harness":"claude","source":"kendex","sourceRepo":"vanillagreencom/kendex","method":"symlink","installedAt":"2026-01-01T00:00:00Z","sourceHash":"x","enabled":true}}}"#,
+        lock_of(
+            &proj,
+            r#""agent:orch:claude":{"name":"orch","kind":"agent","harness":"claude","source":"kendex","sourceRepo":"vanillagreencom/kendex","method":"copy","installedAt":"2026-01-01T00:00:00Z","sourceHash":"x","enabled":true},"skill:size-ratchet:claude":{"name":"size-ratchet","kind":"skill","harness":"claude","source":"kendex","sourceRepo":"vanillagreencom/kendex","method":"symlink","installedAt":"2026-01-01T00:00:00Z","sourceHash":"x","enabled":true}"#,
+        ),
     )
     .unwrap();
 
@@ -284,7 +297,10 @@ fn report_files_through_a_stubbed_gh() {
     let proj = home.join("proj");
     fs::write(
         proj.join(".kendex-lock.json"),
-        r#"{"version":1,"entries":{"hook:guard:claude":{"name":"guard","kind":"hook","harness":"claude","source":"kendex","sourceRepo":"vanillagreencom/kendex","method":"copy","installedAt":"2026-01-01T00:00:00Z","sourceHash":"x","enabled":true}}}"#,
+        lock_of(
+            &proj,
+            r#""hook:guard:claude":{"name":"guard","kind":"hook","harness":"claude","source":"kendex","sourceRepo":"vanillagreencom/kendex","method":"copy","installedAt":"2026-01-01T00:00:00Z","sourceHash":"x","enabled":true}"#,
+        ),
     )
     .unwrap();
 

--- a/crates/core/src/engine/mod.rs
+++ b/crates/core/src/engine/mod.rs
@@ -299,6 +299,7 @@ fn desired_pass<'a>(
 fn fresh_lock(manifest: &Manifest, lock: &Lock, state: &desired::DesiredState) -> Lock {
     Lock {
         version: crate::lock::LOCK_VERSION,
+        root: lock.root.clone(),
         entries: BTreeMap::new(),
         sources: source_revisions(manifest, lock, state),
         bundles: bundle_revisions(manifest, lock, state),

--- a/crates/core/src/error.rs
+++ b/crates/core/src/error.rs
@@ -59,6 +59,20 @@ pub enum CoreError {
     },
 
     #[error(
+        "{path} was written by the project at {recorded}, not the one at {root} — this lock belongs to another checkout; delete it and apply again"
+    )]
+    LockFromAnotherProject {
+        path: PathBuf,
+        recorded: PathBuf,
+        root: PathBuf,
+    },
+
+    #[error(
+        "{path} does not say which project wrote it — refusing to read it as this project's; delete it and apply again"
+    )]
+    LockWithoutProject { path: PathBuf },
+
+    #[error(
         "{path} was written by a newer kendex (format {found}) — update this app before touching it"
     )]
     SchemaTooNew { path: PathBuf, found: i64 },

--- a/crates/core/src/lock.rs
+++ b/crates/core/src/lock.rs
@@ -8,7 +8,7 @@ use crate::env::Env;
 use crate::manifest::Method;
 use crate::model::{HarnessId, ItemKind, Scope};
 
-/// Current lock version. Versions 1 (v0.1) through 6 still load — the
+/// Current lock version. Versions 1 (v0.1) through 7 still load — the
 /// shapes are compatible and the next lock write records the current
 /// version. A lock newer than this build refuses to load. Version 3 added
 /// `source_commit` and `rendered_hash`; version 4 added `settings-seeds`;
@@ -16,18 +16,22 @@ use crate::model::{HarnessId, ItemKind, Scope};
 /// a recorded registration for hooks with a script of their own; version
 /// 6 added `bundles`; version 7 dropped the scope an install reason
 /// recorded, which was always the scope holding the lock and spelled a
-/// project's root as an absolute path.
+/// project's root as an absolute path; version 8 added `root`, the
+/// project a record was written under.
 /// Each bump is what stops an older build from reading the lock, dropping
 /// the newer record on its next write, and erasing evidence — of which
 /// bytes are whose, of which comment blocks seeding wrote, of a move out
-/// of the directory pi reserved being over, or of where an installed set
-/// sits. Two of those are why a bump is not optional: a build that
-/// dropped the pi record would read a finished move as unfinished and
-/// reclaim what the person has since put under the reserved name, and one
-/// that dropped a set's commit would leave a set whose members have come
-/// apart placeable at nothing, so the next update of anything else takes
-/// its other members current.
-pub const LOCK_VERSION: u32 = 7;
+/// of the directory pi reserved being over, of where an installed set
+/// sits, or of which project wrote the record. Three of those are why a
+/// bump is not optional: a build that dropped the pi record would read a
+/// finished move as unfinished and reclaim what the person has since put
+/// under the reserved name; one that dropped a set's commit would leave a
+/// set whose members have come apart placeable at nothing, so the next
+/// update of anything else takes its other members current; and one that
+/// dropped `root` would refresh a project holding a nested checkout's
+/// lock without the ownership check, taking that checkout's files, then
+/// write the record back with nothing left to catch it.
+pub const LOCK_VERSION: u32 = 8;
 
 /// The lock file a project scope carries. The global lock is `lock.json`
 /// under the app's own directory ([`Env::global_lock_file`]).

--- a/crates/core/src/lock.rs
+++ b/crates/core/src/lock.rs
@@ -36,6 +36,20 @@ pub const LOCK_FILE: &str = ".kendex-lock.json";
 #[derive(Debug, Clone, PartialEq, Eq, Default, Serialize, Deserialize, Type)]
 pub struct Lock {
     pub version: u32,
+    /// The project root this record was written under.
+    ///
+    /// Containment answers whether a claimed path is under the root
+    /// reading the lock; it cannot answer whose record this is, because a
+    /// second checkout nested below that root sits inside it and so does
+    /// every path a lock carried out of it names. This says which root
+    /// wrote the record, and the read holds it against the root reading.
+    ///
+    /// `None` on the global lock, which has no single root — each harness
+    /// owns a directory of its own. `None` on a project lock is a record
+    /// from a build that did not write it down: it parses so the read can
+    /// refuse it by name, never so a project can adopt it.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub root: Option<PathBuf>,
     #[serde(default)]
     pub entries: BTreeMap<String, LockEntry>,
     /// The commit each declared source resolved to, by source name.

--- a/crates/core/src/lock/file.rs
+++ b/crates/core/src/lock/file.rs
@@ -5,6 +5,7 @@ use std::path::{Component, Path, PathBuf};
 
 use crate::error::{CoreError, Result};
 use crate::fs::{atomic_write, read_if_exists};
+use crate::paths::canonical;
 
 use super::{LOCK_FILE, LOCK_VERSION, Lock, Reason};
 
@@ -84,6 +85,80 @@ fn refuse_foreign_paths(path: &Path, lock: &Lock) -> Result<()> {
     }
 }
 
+/// Whether `recorded` and `root` name the same directory.
+///
+/// Canonically at both ends ([`canonical`]), because neither side arrives
+/// holding the one spelling (invariant 17): macOS fronts its temp
+/// directories through `/var -> /private/var`, so a root compared as text
+/// does not equal itself.
+///
+/// A spelling that resolves to nothing is not this project's root. The
+/// root reading a lock is the directory that lock was just read out of, so
+/// it resolves; one that cannot be reached is not the one that can.
+fn same_directory(recorded: &Path, root: &Path) -> bool {
+    matches!(
+        (canonical(recorded), canonical(root)),
+        (Ok(recorded), Ok(root)) if recorded == root
+    )
+}
+
+/// Which project wrote this record, held against the project reading it.
+///
+/// [`refuse_foreign_paths`] establishes containment, and containment is not
+/// ownership: a second checkout nested below this root sits inside it, so
+/// every path a lock carried out of that checkout names is inside too.
+/// Refresh reads those as positions this project owns and takes back the
+/// ones a new render no longer produces — out of the nested tree. Only the
+/// root that wrote the record settles it, so the record says which.
+///
+/// A record naming no project is refused rather than adopted: nothing here
+/// knows who wrote it, and reading it as this project's is exactly the
+/// guess the refusal exists to stop.
+///
+/// The global lock has no single root, so it records none and there is
+/// nothing to hold it to.
+fn refuse_another_project(path: &Path, lock: &Lock) -> Result<()> {
+    let Some(root) = project_root_at(path) else {
+        return Ok(());
+    };
+    let Some(recorded) = lock.root.as_deref() else {
+        return Err(CoreError::LockWithoutProject {
+            path: path.to_path_buf(),
+        });
+    };
+    match same_directory(recorded, root) {
+        true => Ok(()),
+        false => Err(CoreError::LockFromAnotherProject {
+            path: path.to_path_buf(),
+            recorded: recorded.to_path_buf(),
+            root: root.to_path_buf(),
+        }),
+    }
+}
+
+/// Name the project this record is written under, refusing one that
+/// already names another.
+///
+/// Stamped at the write rather than where each record is built: this is the
+/// one call that knows the path being written, which is the same knowledge
+/// the read checks against — two answers to one question is how the two
+/// ends come apart. What a project lock cannot hand out it cannot be made
+/// to hold, so a record naming another root is refused here too.
+///
+/// The root goes down canonical where it resolves and as spelled where it
+/// does not — a first write reaches here before the directory it names
+/// exists. Nothing turns on which: [`same_directory`] resolves both sides.
+fn stamp_project(path: &Path, lock: &mut Lock) -> Result<()> {
+    let Some(root) = project_root_at(path) else {
+        return Ok(());
+    };
+    if lock.root.is_some() {
+        return refuse_another_project(path, lock);
+    }
+    lock.root = Some(canonical(root).unwrap_or_else(|_| root.to_path_buf()));
+    Ok(())
+}
+
 /// What sits at a lock path. A v1 lock keys entries by bare name and carries
 /// a `harnesses` array; v2 keys carry `kind:name:harness` with one `harness`
 /// field. The shapes are incompatible — deserializing v1 text straight into
@@ -157,6 +232,7 @@ pub fn parse_text(path: &Path, text: &str) -> Result<LockFile> {
     })?;
     backfill_requested_reason(&mut lock);
     refuse_foreign_paths(path, &lock)?;
+    refuse_another_project(path, &lock)?;
     Ok(LockFile::Current(lock))
 }
 
@@ -191,7 +267,9 @@ pub fn load(path: &Path) -> Result<Lock> {
 
 pub fn save(path: &Path, lock: &Lock) -> Result<()> {
     refuse_foreign_paths(path, lock)?;
-    let mut text = serde_json::to_string_pretty(lock).map_err(|e| CoreError::JsonParse {
+    let mut lock = lock.clone();
+    stamp_project(path, &mut lock)?;
+    let mut text = serde_json::to_string_pretty(&lock).map_err(|e| CoreError::JsonParse {
         path: path.to_path_buf(),
         message: e.to_string(),
     })?;

--- a/crates/core/src/lock/tests.rs
+++ b/crates/core/src/lock/tests.rs
@@ -54,7 +54,7 @@ fn lock_round_trips_and_missing_file_is_empty() {
     let loaded = load(&path).unwrap();
     assert_eq!(
         loaded.root,
-        Some(tmp.path().canonicalize().unwrap()),
+        Some(crate::paths::canonical(tmp.path()).unwrap()),
         "the write names the project it went down under"
     );
     assert_eq!(
@@ -272,7 +272,7 @@ fn a_project_lock_read_through_a_linked_spelling_of_its_root_is_still_its_own() 
 
     assert_eq!(
         load(&via.join(LOCK_FILE)).unwrap().root,
-        Some(real.clone()),
+        Some(crate::paths::canonical(&real).unwrap()),
         "the write records the directory, not the way in"
     );
     load(&real.join(LOCK_FILE)).expect("its own root, spelled directly");

--- a/crates/core/src/lock/tests.rs
+++ b/crates/core/src/lock/tests.rs
@@ -51,7 +51,19 @@ fn lock_round_trips_and_missing_file_is_empty() {
         },
     );
     save(&path, &lock).unwrap();
-    assert_eq!(load(&path).unwrap(), lock);
+    let loaded = load(&path).unwrap();
+    assert_eq!(
+        loaded.root,
+        Some(tmp.path().canonicalize().unwrap()),
+        "the write names the project it went down under"
+    );
+    assert_eq!(
+        Lock {
+            root: None,
+            ..loaded
+        },
+        lock
+    );
     assert!(std::fs::read_to_string(&path).unwrap().ends_with('\n'));
 }
 
@@ -63,7 +75,10 @@ fn entries_without_reasons_read_as_requested() {
     let path = tmp.path().join(".kendex-lock.json");
     std::fs::write(
         &path,
-        r#"{"version":2,"entries":{"skill:gh:claude":{"name":"gh","kind":"skill","harness":"claude","source":"kendex","sourceRepo":"vanillagreencom/kendex","method":"symlink","installedAt":"2026-01-01T00:00:00Z","sourceHash":"abc","enabled":true}}}"#,
+        format!(
+            r#"{{"version":2,"root":{},"entries":{{"skill:gh:claude":{{"name":"gh","kind":"skill","harness":"claude","source":"kendex","sourceRepo":"vanillagreencom/kendex","method":"symlink","installedAt":"2026-01-01T00:00:00Z","sourceHash":"abc","enabled":true}}}}}}"#,
+            json(tmp.path())
+        ),
     )
     .unwrap();
     let lock = load(&path).unwrap();
@@ -132,24 +147,145 @@ fn a_newer_lock_refuses_to_load() {
 fn an_empty_lock_reads_as_current() {
     let tmp = tempfile::tempdir().unwrap();
     let path = tmp.path().join(".kendex-lock.json");
-    std::fs::write(&path, r#"{"version":1,"entries":{}}"#).unwrap();
+    std::fs::write(
+        &path,
+        format!(
+            r#"{{"version":1,"root":{},"entries":{{}}}}"#,
+            json(tmp.path())
+        ),
+    )
+    .unwrap();
     assert!(matches!(load_file(&path).unwrap(), LockFile::Current(_)));
+}
+
+/// A path as JSON data rather than text spliced into a literal: a
+/// backslash in one is an escape JSON has to be told about.
+fn json(path: &Path) -> String {
+    serde_json::to_string(&path.display().to_string()).unwrap()
 }
 
 /// A record whose `emitted.paths` reach outside the project holding it, as
 /// written by hand under `key` — the shape a lock copied from another
-/// checkout has.
-fn recording(path: &Path, key: &str, emitted: &Path) {
+/// checkout has. `wrote_it` is the project the record names as its own;
+/// `None` writes the field out, which is what the global lock holds.
+fn recording(path: &Path, key: &str, emitted: &Path, wrote_it: Option<&Path>) {
     std::fs::write(
         path,
         format!(
-            r#"{{"version":7,"entries":{{"{key}":{{"name":"gh","kind":"skill","harness":"claude","source":"kendex","sourceRepo":"vanillagreencom/kendex","method":"symlink","installedAt":"2026-01-01T00:00:00Z","sourceHash":"abc","enabled":true,"emitted":{{"kind":"skill","name":"gh","paths":[{}]}}}}}}}}"#,
+            r#"{{"version":7,{}"entries":{{"{key}":{{"name":"gh","kind":"skill","harness":"claude","source":"kendex","sourceRepo":"vanillagreencom/kendex","method":"symlink","installedAt":"2026-01-01T00:00:00Z","sourceHash":"abc","enabled":true,"emitted":{{"kind":"skill","name":"gh","paths":[{}]}}}}}}}}"#,
+            wrote_it.map_or(String::new(), |root| format!(
+                r#""root":{},"#,
+                json(root)
+            )),
             // A path is data here, not text spliced into the literal: a
             // backslash in it is an escape JSON has to be told about.
-            serde_json::to_string(&emitted.display().to_string()).unwrap()
+            json(emitted)
         ),
     )
     .unwrap();
+}
+
+/// Containment cannot answer whose record this is: a checkout nested below
+/// this root sits inside it, so every path a lock carried out of that
+/// checkout names passes the boundary. The record says which root wrote it,
+/// and the refusal names both so the reader can see which is which.
+#[test]
+fn a_project_lock_another_project_wrote_is_refused_naming_both() {
+    let tmp = tempfile::tempdir().unwrap();
+    let root = tmp.path().join("here");
+    let nested = root.join("vendor/thing");
+    std::fs::create_dir_all(&nested).unwrap();
+    let path = root.join(LOCK_FILE);
+    recording(
+        &path,
+        "skill:gh:claude",
+        &nested.join(".agents/skills/gh"),
+        Some(&nested),
+    );
+
+    let refused = load(&path).unwrap_err();
+    assert!(
+        matches!(
+            &refused,
+            CoreError::LockFromAnotherProject { recorded, root: reading, .. }
+                if recorded == &nested && reading == &root
+        ),
+        "{refused:?}"
+    );
+}
+
+/// A record naming no project is refused rather than adopted: nothing knows
+/// who wrote it, and reading it as this project's is the guess the refusal
+/// exists to stop.
+#[test]
+fn a_project_lock_naming_no_project_is_refused() {
+    let tmp = tempfile::tempdir().unwrap();
+    let root = tmp.path().join("here");
+    std::fs::create_dir(&root).unwrap();
+    let path = root.join(LOCK_FILE);
+    recording(
+        &path,
+        "skill:gh:claude",
+        &root.join(".agents/skills/gh"),
+        None,
+    );
+
+    assert!(matches!(
+        load(&path),
+        Err(CoreError::LockWithoutProject { .. })
+    ));
+}
+
+/// A root has one spelling (invariant 17), and neither end holds it: the
+/// record goes down canonical while a caller may name the same directory
+/// through a link — which is the spelling macOS hands every temp path,
+/// `/var` fronting `/private/var`. Compared as text a root does not equal
+/// itself, and every project reached that way loses its own lock.
+#[test]
+#[cfg(unix)]
+fn a_project_lock_read_through_a_linked_spelling_of_its_root_is_still_its_own() {
+    let tmp = tempfile::tempdir().unwrap();
+    let real = tmp.path().join("real");
+    std::fs::create_dir(&real).unwrap();
+    let via = tmp.path().join("via");
+    std::os::unix::fs::symlink(&real, &via).unwrap();
+
+    let lock = Lock {
+        version: LOCK_VERSION,
+        ..Lock::default()
+    };
+    save(&via.join(LOCK_FILE), &lock).unwrap();
+
+    assert_eq!(
+        load(&via.join(LOCK_FILE)).unwrap().root,
+        Some(real.clone()),
+        "the write records the directory, not the way in"
+    );
+    load(&real.join(LOCK_FILE)).expect("its own root, spelled directly");
+    load(&via.join(LOCK_FILE)).expect("its own root, spelled through the link");
+}
+
+/// The write end of the ownership rule: what a project lock cannot hand out
+/// it cannot be made to hold.
+#[test]
+fn a_project_lock_is_never_written_naming_another_project() {
+    let tmp = tempfile::tempdir().unwrap();
+    let root = tmp.path().join("here");
+    let nested = root.join("vendor/thing");
+    std::fs::create_dir_all(&nested).unwrap();
+    let path = root.join(LOCK_FILE);
+
+    let lock = Lock {
+        version: LOCK_VERSION,
+        root: Some(nested),
+        ..Lock::default()
+    };
+
+    assert!(matches!(
+        save(&path, &lock),
+        Err(CoreError::LockFromAnotherProject { .. })
+    ));
+    assert!(!path.exists(), "and nothing is left at the path");
 }
 
 /// A project lock may claim only what sits under its own root: the paths a
@@ -162,7 +298,7 @@ fn a_project_lock_claiming_another_tree_is_refused() {
     std::fs::create_dir(&root).unwrap();
     let path = root.join(LOCK_FILE);
     let elsewhere = tmp.path().join("there/.agents/skills/gh");
-    recording(&path, "skill:gh:claude", &elsewhere);
+    recording(&path, "skill:gh:claude", &elsewhere, Some(&root));
 
     let refused = load(&path).unwrap_err();
     assert!(
@@ -174,7 +310,12 @@ fn a_project_lock_claiming_another_tree_is_refused() {
         "{refused:?}"
     );
 
-    recording(&path, "skill:gh:claude", &root.join(".agents/skills/gh"));
+    recording(
+        &path,
+        "skill:gh:claude",
+        &root.join(".agents/skills/gh"),
+        Some(&root),
+    );
     assert_eq!(load(&path).unwrap().entries.len(), 1, "its own root loads");
 }
 
@@ -233,7 +374,7 @@ fn a_relatively_named_project_lock_still_has_a_boundary() {
     let tmp = tempfile::tempdir().unwrap();
     let path = tmp.path().join(LOCK_FILE);
     let elsewhere = tmp.path().join("there/.agents/skills/gh");
-    recording(&path, "skill:gh:claude", &elsewhere);
+    recording(&path, "skill:gh:claude", &elsewhere, Some(tmp.path()));
     let text = std::fs::read_to_string(&path).unwrap();
 
     assert!(matches!(
@@ -252,6 +393,6 @@ fn the_global_lock_records_paths_outside_its_own_directory() {
     let path = app.join("lock.json");
     // A harness directory, which is nowhere near the app's own.
     let elsewhere = tmp.path().join("home/.claude/skills/gh");
-    recording(&path, "skill:gh:claude", &elsewhere);
+    recording(&path, "skill:gh:claude", &elsewhere, None);
     assert_eq!(load(&path).unwrap().entries.len(), 1);
 }

--- a/crates/core/src/lock/tests.rs
+++ b/crates/core/src/lock/tests.rs
@@ -125,20 +125,34 @@ fn unparseable_json_is_reported_as_corrupt() {
 }
 
 /// A lock a future kendex wrote refuses to load rather than being
-/// silently misread or corrupted by an older build.
+/// silently misread or corrupted by an older build. That refusal is what
+/// every bump buys, so it is held at exactly one version above this
+/// build's — the version the next bump hands to the build before it — and
+/// against a record this project could otherwise adopt, leaving the
+/// version as the only thing refusing it.
 #[test]
 fn a_newer_lock_refuses_to_load() {
     let tmp = tempfile::tempdir().unwrap();
     let path = tmp.path().join(".kendex-lock.json");
-    std::fs::write(&path, r#"{"version":99,"entries":{}}"#).unwrap();
-    assert!(matches!(
-        load_file(&path),
-        Err(CoreError::SchemaTooNew { found: 99, .. })
-    ));
-    assert!(matches!(
-        load(&path),
-        Err(CoreError::SchemaTooNew { found: 99, .. })
-    ));
+    let ahead = i64::from(LOCK_VERSION) + 1;
+    std::fs::write(
+        &path,
+        format!(
+            r#"{{"version":{ahead},"root":{},"entries":{{}}}}"#,
+            json(tmp.path())
+        ),
+    )
+    .unwrap();
+    let refused = load_file(&path).unwrap_err();
+    assert!(
+        matches!(refused, CoreError::SchemaTooNew { found, .. } if found == ahead),
+        "{refused}"
+    );
+    let refused = load(&path).unwrap_err();
+    assert!(
+        matches!(refused, CoreError::SchemaTooNew { found, .. } if found == ahead),
+        "{refused}"
+    );
 }
 
 /// An empty `entries` map is indistinguishable between v1 and v2 — it
@@ -172,7 +186,7 @@ fn recording(path: &Path, key: &str, emitted: &Path, wrote_it: Option<&Path>) {
     std::fs::write(
         path,
         format!(
-            r#"{{"version":7,{}"entries":{{"{key}":{{"name":"gh","kind":"skill","harness":"claude","source":"kendex","sourceRepo":"vanillagreencom/kendex","method":"symlink","installedAt":"2026-01-01T00:00:00Z","sourceHash":"abc","enabled":true,"emitted":{{"kind":"skill","name":"gh","paths":[{}]}}}}}}}}"#,
+            r#"{{"version":{LOCK_VERSION},{}"entries":{{"{key}":{{"name":"gh","kind":"skill","harness":"claude","source":"kendex","sourceRepo":"vanillagreencom/kendex","method":"symlink","installedAt":"2026-01-01T00:00:00Z","sourceHash":"abc","enabled":true,"emitted":{{"kind":"skill","name":"gh","paths":[{}]}}}}}}}}"#,
             wrote_it.map_or(String::new(), |root| format!(
                 r#""root":{},"#,
                 json(root)

--- a/crates/core/tests/lock_from_another_project.rs
+++ b/crates/core/tests/lock_from_another_project.rs
@@ -10,7 +10,7 @@
 
 #[path = "../../test_util.rs"]
 mod test_util;
-use test_util::source_path;
+use test_util::{rooted, source_path};
 
 use std::collections::BTreeMap;
 use std::fs;
@@ -279,5 +279,79 @@ fn a_lock_walking_back_out_of_its_project_is_refused_and_the_tree_it_points_at_s
                     && root == &elsewhere
         ),
         "the refusal names the entry, the path it claims and the project that cannot hold it: {refused:?}"
+    );
+}
+
+/// Containment is not ownership. A second checkout nested below this root
+/// sits inside it, so every path a lock carried out of that checkout names
+/// passes the boundary check — and the parent's refresh then reads them as
+/// positions it owns and takes back the ones its own render does not
+/// produce, out of the nested tree. The record says which root wrote it, so
+/// the read can tell.
+#[test]
+#[allow(clippy::unwrap_used)]
+fn a_lock_from_a_checkout_nested_inside_the_project_is_refused_and_that_checkout_stands() {
+    let tmp = tempfile::tempdir().unwrap();
+    let home = rooted(&tmp);
+    let catalog = home.join("catalog");
+    put(
+        &catalog.join("skills/ship/SKILL.md"),
+        "---\nname: ship\ndescription: ship\n---\n\nShip the branch.\n",
+    );
+    let env = Env::fake(&home, FakeOs::Linux);
+
+    let outer = home.join("dev/app");
+    declare(&outer, &catalog);
+    let report = audit(&env, &project(&outer)).unwrap();
+    kendex_core::apply::execute(&env, &report.plan, None).unwrap();
+
+    // A checkout of its own, living under the first one — a vendored
+    // repository, or a worktree somebody put inside the tree it came from.
+    let nested = outer.join("vendor/thing");
+    declare(&nested, &catalog);
+    let report = audit(&env, &project(&nested)).unwrap();
+    kendex_core::apply::execute(&env, &report.plan, None).unwrap();
+
+    // Its lock, carried up to the project holding it. Every path it names
+    // starts with the outer root, so containment waves all of them through.
+    fs::copy(
+        nested.join(".kendex-lock.json"),
+        outer.join(".kendex-lock.json"),
+    )
+    .unwrap();
+    let before = snapshot(&nested);
+    assert_eq!(
+        before.get(Path::new(".agents/skills/ship/SKILL.md")),
+        Some(&Entry::File(
+            fs::read_to_string(catalog.join("skills/ship/SKILL.md")).unwrap()
+        )),
+        "the install this refusal protects is on disk to begin with"
+    );
+    assert!(
+        nested.join(".agents/skills/ship").starts_with(&outer),
+        "the claim is one containment reads as inside"
+    );
+
+    let refused = match plan_apply(&env, &project(&outer), &refresh()) {
+        Ok(report) => {
+            kendex_core::apply::execute(&env, &report.plan, None).unwrap();
+            None
+        }
+        Err(error) => Some(error),
+    };
+
+    assert_eq!(
+        snapshot(&nested),
+        before,
+        "the checkout the lock came from is exactly as it was"
+    );
+    let refused = refused.expect("a record another checkout wrote is refused");
+    assert!(
+        matches!(
+            &refused,
+            CoreError::LockFromAnotherProject { recorded, root, .. }
+                if recorded == &nested && root == &outer
+        ),
+        "the refusal names the project that wrote the record and the one reading it: {refused:?}"
     );
 }

--- a/crates/core/tests/migration.rs
+++ b/crates/core/tests/migration.rs
@@ -49,7 +49,10 @@ fn fixture() -> Fixture {
     fs::write(&manifest_path, &original).unwrap();
     fs::write(
         project.join(".kendex-lock.json"),
-        "{\n  \"version\": 1,\n  \"entries\": {}\n}\n",
+        format!(
+            "{{\n  \"version\": 1,\n  \"root\": {},\n  \"entries\": {{}}\n}}\n",
+            serde_json::to_string(&project.display().to_string()).unwrap()
+        ),
     )
     .unwrap();
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -118,7 +118,7 @@ lives in one capability table read by core and UI.
    Ownership is what kendex wrote, read from the positions lock entries
    wrote (recorded for skills and codex commands, derived elsewhere) —
    never from the lock key alone, from an entry merely on the books, or
-   from a project record naming a position outside its own root. A link the user put at a shared config file or a manifest
+   from a project record another root wrote or naming a position outside its own root. A link the user put at a shared config file or a manifest
    (dotfiles) is not foreign: the edit goes through it, link kept, and the
    precondition binds to the bytes reachable there; whether a link may sit
    at a position is decided at plan time, never by the write.

--- a/tools/size-ratchet-baseline.tsv
+++ b/tools/size-ratchet-baseline.tsv
@@ -5,7 +5,7 @@ crates/core/src/engine/detach.rs	441
 crates/core/src/engine/pi_hooks_move/migrated.rs	539
 crates/core/src/engine/pi_hooks_move/mod.rs	503
 crates/core/src/engine/pi_hooks_move/preflight.rs	765
-crates/core/src/error.rs	495
+crates/core/src/error.rs	509
 crates/core/src/remote/store.rs	405
 crates/core/src/settings_file.rs	408
 docs/ARCHITECTURE.md	801


### PR DESCRIPTION
Closes KEN-803.

`lock/file.rs` refused an `emitted.paths` entry reaching outside the project root, which establishes containment. Containment is not ownership: a checkout nested BELOW the project root sits inside it, so every path in a lock copied out of that nested checkout passed. The parent's refresh then read those paths as positions it owns, `stale_emitted` treated them as obsolete once the parent rendered its own, and the nested checkout's files were deleted.

`Lock.root` records the project root a record was written under. `save` stamps it and `parse_text` checks it, both keyed off `project_root_at(path)` — the same derivation containment already uses. Containment runs first and ownership second, so existing `LockOutsideProject` refusals keep their exact cause.

**One spelling on both sides.** `same_directory` runs `paths::canonical` on both roots. Comparing spellings would reintroduce the class #1820 closed and the one that ejected #1800 on the macOS lane: `/var` → `/private/var` means a root never equals its own spelling. `a_project_lock_read_through_a_linked_spelling_of_its_root_is_still_its_own` writes through a symlinked spelling and reads back through both; reducing `same_directory` to `recorded == root` turns that one test red and nothing else.

**Two refusals, because they have two remedies.** `LockFromAnotherProject { path, recorded, root }` names both roots; `LockWithoutProject { path }` is a record that names none. Both are distinct from `LockOutsideProject`, so a reader knows which rule they met. Nothing outside the tests matches on `LockOutsideProject`, and `audit.rs` maps unnamed variants to `ScopeErrorKind::Other` carrying the message, so the siblings break no caller.

**No `LOCK_VERSION` bump.** A bump refuses only *newer* locks — 1..6 still load and `SchemaTooNew` fires only above the current version — so it would refuse nothing here, and the ownership check would stay bypassable by deleting one line of JSON from a copied lock. `#[serde(default)]` plus a named refusal is the smaller change and it is KEN-474's pattern: `Pre.landed` parses so the restore can refuse it by name.

**Breaking.** Every lock that exists predates the field, so the first run after this lands refuses with `LockWithoutProject` and needs `.kendex-lock.json` deleted and a fresh apply. Deleting a lock loses `renderedHash`, so edit detection reports conflicts until the next apply re-anchors. The changelog fragment carries the migration inline.

**Controls, and one of them changed what shipped.** Removing only the load check still turns the nested test red — but through the write end's rollback, so the nested tree was never touched and the load check proved nothing. Removing both is what produces the reported damage: the parent's refresh deletes `vendor/thing/.agents/skills/ship` and its `.claude/skills/ship` link, caught by the snapshot. A control that stopped at one end would have looked green for the wrong reason. `a_lock_naming_its_own_project_refreshes` is the control that the refusal does not fire on a lock this project legitimately wrote.
