### PR TITLE
fix(KEN-842): one spelling from a harness's skills dir to the verb that looks in it

### DIFF
--- a/changelog.d/fixed/KEN-842.md
+++ b/changelog.d/fixed/KEN-842.md
@@ -1,0 +1,3 @@
+- On Windows, a package a harness installs is now one kendex verbs can find,
+  a project skill's link reaches the tree it names, and a package's history
+  and its origin read the same as everywhere else.

--- a/crates/app/tests/repo_effects.rs
+++ b/crates/app/tests/repo_effects.rs
@@ -189,7 +189,7 @@ fn the_effect_comes_back_unrun_and_a_separate_yes_arms_it() {
     let hooks = f.project.join(".git/hooks");
     let written: Vec<&str> = offer.writes.iter().map(|w| w.path.as_str()).collect();
     assert!(
-        written.contains(&hooks.join("pre-commit").to_str().unwrap()),
+        written.contains(&kendex_core::paths::slashed(&hooks.join("pre-commit")).as_str()),
         "{written:?}"
     );
     assert!(offer.writes.iter().all(|w| w.shared), "{:?}", offer.writes);

--- a/crates/cli/tests/presentation/plain.rs
+++ b/crates/cli/tests/presentation/plain.rs
@@ -21,7 +21,7 @@ fn the_blocked_refresh_prints_the_lines_scripts_parse() {
         "plain",
         &["refresh", "-y", "--scope", "project"],
     ));
-    let scope = project.display().to_string();
+    let scope = kendex_core::paths::slashed(&project);
 
     let shape: Vec<String> = printed
         .lines()

--- a/crates/cli/tests/presentation/snapshots.rs
+++ b/crates/cli/tests/presentation/snapshots.rs
@@ -32,7 +32,7 @@ fn shape(setup: &[&str], args: &[&str]) -> Vec<String> {
     let ready = fill(args);
     let borrowed: Vec<&str> = ready.iter().map(String::as_str).collect();
     let printed = said(&kendex(home, &project, "plain", &borrowed));
-    let scope = project.display().to_string();
+    let scope = kendex_core::paths::slashed(&project);
     printed
         .lines()
         .map(|line| match line.split_whitespace().next() {

--- a/crates/cli/tests/refresh_ledger/main.rs
+++ b/crates/cli/tests/refresh_ledger/main.rs
@@ -154,7 +154,7 @@ fn a_blocked_refresh_ends_on_a_ledger_naming_every_outcome_and_its_next_step() {
     assert!(
         printed.contains(&format!(
             "  also at {}",
-            project.join(".agents/skills/growth-guards").display()
+            kendex_core::paths::slashed(&project.join(".agents/skills/growth-guards"))
         )),
         "every position is named, so the reader can act on each: {printed}"
     );
@@ -167,7 +167,7 @@ fn a_blocked_refresh_ends_on_a_ledger_naming_every_outcome_and_its_next_step() {
         ledger(&printed),
         format!(
             "{}: refreshed 3 changes · skipped 1 item on conflict · flagged 2 items on safety",
-            project.display()
+            kendex_core::paths::slashed(&project)
         ),
         "{printed}"
     );
@@ -224,7 +224,10 @@ fn a_clean_refresh_ends_on_the_count_alone() {
     ));
     assert_eq!(
         ledger(&printed),
-        format!("{}: refreshed 2 changes", project.display()),
+        format!(
+            "{}: refreshed 2 changes",
+            kendex_core::paths::slashed(&project)
+        ),
         "a clean run reports its writes and carries no outcome it does not have: {printed}"
     );
 }
@@ -264,7 +267,7 @@ fn a_current_scope_with_findings_still_reads_up_to_date() {
         ledger(&printed),
         format!(
             "{}: up to date · flagged 1 item on safety",
-            project.display()
+            kendex_core::paths::slashed(&project)
         ),
         "{printed}"
     );

--- a/crates/cli/tests/remote_e2e.rs
+++ b/crates/cli/tests/remote_e2e.rs
@@ -223,7 +223,7 @@ fn updates_lines_lead_with_their_place() {
         .unwrap_or_else(|| panic!("no gh line in {said}"));
     let root = proj.canonicalize().unwrap();
     assert!(
-        line.starts_with(&format!("{}  skill gh", root.display())),
+        line.starts_with(&format!("{}  skill gh", kendex_core::paths::slashed(&root))),
         "{line}"
     );
 

--- a/crates/core/src/author/import/apply.rs
+++ b/crates/core/src/author/import/apply.rs
@@ -375,9 +375,10 @@ fn executable_if_script(path: &Path, bytes: &[u8]) -> Result<()> {
     Ok(())
 }
 
+/// What the outcome calls one written file: its path under the import
+/// target, in the one spelling kendex publishes a path in. Callers read
+/// these back against catalog paths, which are `/`-spelled wherever they
+/// are written down.
 fn rel_name(target: &Path, dest: &Path) -> String {
-    dest.strip_prefix(target)
-        .unwrap_or(dest)
-        .display()
-        .to_string()
+    crate::paths::slashed(dest.strip_prefix(target).unwrap_or(dest))
 }

--- a/crates/core/src/author/import/origins.rs
+++ b/crates/core/src/author/import/origins.rs
@@ -42,6 +42,9 @@ pub(super) fn unmanaged_paths(
 /// installed copy of a marketplace package differs from the marketplace's
 /// own bytes. Empty for rows import cannot carry (config-entry kinds have
 /// no file of their own to copy).
+/// The `String` is where the bytes were read from, said the way kendex
+/// says a path: [`crate::paths::slashed`], because callers match on it
+/// (`.agents/skills/…`) and a `\` there matches nothing.
 type OriginRead = (CandidateGroup, Option<Bytes>, String, Option<PathBuf>);
 
 pub(super) fn origins_of(
@@ -92,7 +95,7 @@ pub(super) fn origins_of(
             vec![(
                 CandidateGroup::Unmanaged,
                 Some(bytes),
-                path.display().to_string(),
+                crate::paths::slashed(path),
                 Some(path.clone()),
             )]
         }
@@ -173,7 +176,7 @@ pub(super) fn marketplace_origins(
                 license,
             },
             Some(edited),
-            installed.display().to_string(),
+            crate::paths::slashed(installed),
             Some(installed.clone()),
         ));
     }
@@ -189,7 +192,7 @@ pub(super) fn catalog_bytes(
     let config = crate::source::source_config_for(&sealed, provenance).ok()?;
     let path = crate::source::find_item(&sealed, &config, row.kind, &row.name)?;
     let bytes = read_bytes(&sealed, row.kind, &path)?;
-    let location = root.join(rel(&sealed, &path)).display().to_string();
+    let location = crate::paths::slashed(&root.join(rel_path(&sealed, &path)));
     Some((Some(bytes), location, path))
 }
 
@@ -208,11 +211,18 @@ pub(super) fn read_bytes(sealed: &SealedSource, kind: ItemKind, path: &Path) -> 
     }
 }
 
+/// Where `path` sits inside the catalog, as text a caller can match: an
+/// origin's location is read back against catalog paths, and those are
+/// `/`-spelled wherever they are written down.
 pub(super) fn rel(sealed: &SealedSource, path: &Path) -> String {
-    path.strip_prefix(sealed.root())
-        .unwrap_or(path)
-        .display()
-        .to_string()
+    crate::paths::slashed(rel_path(sealed, path))
+}
+
+/// The same as a path, for a caller that has more to join on before the
+/// spelling is settled — spelling a path in two halves leaves the seam in
+/// whichever spelling the platform joined with.
+fn rel_path<'a>(sealed: &SealedSource, path: &'a Path) -> &'a Path {
+    path.strip_prefix(sealed.root()).unwrap_or(path)
 }
 
 pub(super) fn scope_manifest(env: &Env, scope: &Scope) -> Manifest {

--- a/crates/core/src/author/status.rs
+++ b/crates/core/src/author/status.rs
@@ -102,7 +102,7 @@ pub fn status(path: &Path) -> Result<MineRow> {
     let tally = report.tally();
     let meta = config.marketplace.clone().unwrap_or_default();
     Ok(MineRow {
-        path: path.display().to_string(),
+        path: crate::paths::slashed(path),
         name: meta.name.unwrap_or(leaf),
         description: meta.description,
         license: meta.license,

--- a/crates/core/src/check_catalog.rs
+++ b/crates/core/src/check_catalog.rs
@@ -284,11 +284,7 @@ pub fn check_item(
     path: &Path,
 ) -> Result<CheckedItem> {
     let content = content(sealed, kind, path)?;
-    let file = path
-        .strip_prefix(sealed.root())
-        .unwrap_or(path)
-        .display()
-        .to_string();
+    let file = crate::paths::slashed(path.strip_prefix(sealed.root()).unwrap_or(path));
     let mut structural = structural(kind, name, &file, &content);
     structural.extend(settings::findings(sealed, kind, name, &file, path)?);
     // The safety half of the authoring check: the same rules an install

--- a/crates/core/src/check_catalog/settings.rs
+++ b/crates/core/src/check_catalog/settings.rs
@@ -36,10 +36,7 @@ pub(super) fn findings(
     // A one-skill catalog IS the catalog root, so the item's own path is
     // empty and joining with a separator would spell an absolute
     // `/kendex.settings.toml.example`. Path::join knows the difference.
-    let at = Path::new(file)
-        .join(template)
-        .to_string_lossy()
-        .into_owned();
+    let at = crate::paths::slashed(&Path::new(file).join(template));
     Ok(crate::settings_template::read(&text)
         .findings
         .into_iter()

--- a/crates/core/src/engine/adopt.rs
+++ b/crates/core/src/engine/adopt.rs
@@ -248,7 +248,7 @@ fn local_item_path(env: &Env, scope: &Scope, kind: ItemKind, name: &str) -> Resu
 pub(super) fn already_managed(name: &str, path: &Path) -> CoreError {
     CoreError::AlreadyManaged {
         name: name.to_owned(),
-        path: crate::names::shown(&path.display().to_string()),
+        path: crate::names::shown(&crate::paths::slashed(path)),
     }
 }
 

--- a/crates/core/src/engine/adopt/held.rs
+++ b/crates/core/src/engine/adopt/held.rs
@@ -207,7 +207,7 @@ pub(super) fn read_positions(
     if let Some((_, at)) = positions.iter().find(|(_, at)| both_spellings(kind, at)) {
         return Err(CoreError::TogglesDiffer {
             name: name.to_owned(),
-            detail: crate::names::shown(&at.display().to_string()),
+            detail: crate::names::shown(&crate::paths::slashed(at)),
         });
     }
 

--- a/crates/core/src/engine/adopt/hooks.rs
+++ b/crates/core/src/engine/adopt/hooks.rs
@@ -218,7 +218,7 @@ fn script_move(scope: &Scope, command: &str, ops: &mut Vec<PlannedOp>) -> Result
     if home.exists() {
         return Err(CoreError::AlreadyManaged {
             name: file.to_string_lossy().into_owned(),
-            path: crate::names::shown(&home.display().to_string()),
+            path: crate::names::shown(&crate::paths::slashed(&home)),
         });
     }
     ops.push(PlannedOp {

--- a/crates/core/src/engine/item_plan.rs
+++ b/crates/core/src/engine/item_plan.rs
@@ -216,7 +216,7 @@ pub(super) enum Planned {
 pub(super) fn unmanaged(cause: DriftCause, path: &std::path::Path) -> Planned {
     Planned::Unmanaged {
         cause,
-        detail: path.display().to_string(),
+        detail: crate::paths::slashed(path),
         compared: None,
         also: Vec::new(),
     }
@@ -234,7 +234,7 @@ pub(super) fn unmanaged_compared(
 ) -> Planned {
     Planned::Unmanaged {
         cause,
-        detail: path.display().to_string(),
+        detail: crate::paths::slashed(path),
         compared,
         also: Vec::new(),
     }

--- a/crates/core/src/engine/item_source.rs
+++ b/crates/core/src/engine/item_source.rs
@@ -62,7 +62,7 @@ pub(crate) fn read_capped(path: &Path) -> Result<ItemSource> {
     let bytes = std::fs::read(path).map_err(|e| CoreError::io(path, e))?;
     let taken = char_boundary(&bytes, bytes.len().min(MAX_SOURCE_BYTES));
     Ok(ItemSource {
-        path: path.display().to_string(),
+        path: crate::paths::slashed(path),
         content: String::from_utf8_lossy(&bytes[..taken]).into_owned(),
         truncated: bytes.len() > taken,
     })

--- a/crates/core/src/engine/observed.rs
+++ b/crates/core/src/engine/observed.rs
@@ -33,7 +33,7 @@ pub fn observed_rows(env: &Env, scope: &Scope) -> Result<Vec<ItemSafety>> {
             name: item.name.clone(),
             harness: item.harness,
             scope: item.scope.clone(),
-            location: item.path.display().to_string(),
+            location: crate::paths::slashed(&item.path),
             advisory: result,
         })
         .collect())

--- a/crates/core/src/engine/scoring/input.rs
+++ b/crates/core/src/engine/scoring/input.rs
@@ -10,7 +10,7 @@ use super::super::desired::{Artifact, Desired};
 pub(super) fn input_for(item: &Desired) -> AuditInput {
     let (location, content) = match &item.artifact {
         Artifact::File { path, bytes } => (
-            path.display().to_string(),
+            crate::paths::slashed(path),
             Content::Document {
                 text: String::from_utf8_lossy(bytes).into_owned(),
             },
@@ -20,7 +20,7 @@ pub(super) fn input_for(item: &Desired) -> AuditInput {
         Artifact::Tree {
             canonical, files, ..
         } => (
-            canonical.display().to_string(),
+            crate::paths::slashed(canonical),
             crate::quality::observe::tree_content_from_bytes(files),
         ),
         Artifact::Registration { script, edits } => registration(item, script.as_ref(), edits),
@@ -42,8 +42,8 @@ fn registration(
     edits: &[(std::path::PathBuf, ConfigEdit)],
 ) -> (String, Content) {
     let location = script
-        .map(|(path, _)| path.display().to_string())
-        .or_else(|| edits.first().map(|(path, _)| path.display().to_string()))
+        .map(|(path, _)| crate::paths::slashed(path))
+        .or_else(|| edits.first().map(|(path, _)| crate::paths::slashed(path)))
         .unwrap_or_else(|| item.name.clone());
     let content = match item.kind {
         ItemKind::McpServer => match mcp_entry(edits) {

--- a/crates/core/src/engine/tree_plan.rs
+++ b/crates/core/src/engine/tree_plan.rs
@@ -140,7 +140,7 @@ pub(super) fn plan_tree(
 fn unowned_link(link: Option<&Path>, owned: &BTreeSet<PathBuf>) -> Option<String> {
     let link = link?;
     (!link.is_symlink() && link.exists() && !owned.contains(link))
-        .then(|| link.display().to_string())
+        .then(|| crate::paths::slashed(link))
 }
 
 /// Carry another in-the-way position on a refusal that already names one.

--- a/crates/core/src/engine/unmanaged.rs
+++ b/crates/core/src/engine/unmanaged.rs
@@ -81,7 +81,7 @@ pub(super) fn unmanaged_rows(
             harness: item.harness,
             scope: scope.clone(),
             state: DriftState::Unmanaged,
-            detail: item.path.display().to_string(),
+            detail: crate::paths::slashed(&item.path),
             cause: None,
             compared: None,
             also_in_the_way: Vec::new(),

--- a/crates/core/src/fs.rs
+++ b/crates/core/src/fs.rs
@@ -332,10 +332,11 @@ pub(crate) fn make_symlink(target: &Path, link: &Path) -> Result<()> {
 
 #[cfg(windows)]
 pub(crate) fn make_symlink(target: &Path, link: &Path) -> Result<()> {
-    if target.is_dir() {
-        std::os::windows::fs::symlink_dir(target, link).map_err(|e| CoreError::io(link, e))
-    } else {
-        std::os::windows::fs::symlink_file(target, link).map_err(|e| CoreError::io(link, e))
+    match links::leads_to_dir(link, target) {
+        true => std::os::windows::fs::symlink_dir(target, link).map_err(|e| CoreError::io(link, e)),
+        false => {
+            std::os::windows::fs::symlink_file(target, link).map_err(|e| CoreError::io(link, e))
+        }
     }
 }
 

--- a/crates/core/src/fs/links.rs
+++ b/crates/core/src/fs/links.rs
@@ -6,6 +6,10 @@
 //! to the link's own parent; anywhere else (a project link into the app's
 //! own folder, a global install) there is nothing shared to be relative to
 //! and the absolute path is the only spelling that reaches.
+//!
+//! Whichever text it holds, that text is read against the link's own
+//! parent and never against a working directory — for where it leads, and
+//! on Windows for which kind of link to make at all.
 
 use std::path::{Component, Path, PathBuf};
 
@@ -50,6 +54,23 @@ pub(crate) fn resolved(link: &Path, points_to: &Path) -> Option<PathBuf> {
         return Some(points_to.to_path_buf());
     }
     normalize(&link.parent()?.join(points_to))
+}
+
+/// Whether the text `link` is about to hold leads to a directory.
+///
+/// Windows records which kind a link is when it is made, and a file link
+/// pointing at a directory does not resolve at all — `exists()` on it is
+/// false and every read through it fails. The text is relative to the
+/// link's own parent, never to this process's working directory, so the
+/// question has to be asked of the resolved path: asking `target.is_dir()`
+/// asks about `<cwd>/../../.agents/skills/x`, which is somebody else's
+/// tree or nothing.
+///
+/// Unix links carry no kind, so only Windows asks — and the test suite,
+/// which is how the rule is proven on a host that never calls it.
+#[cfg(any(windows, test))]
+pub(crate) fn leads_to_dir(link: &Path, target: &Path) -> bool {
+    resolved(link, target).is_some_and(|at| at.is_dir())
 }
 
 fn has_parent_ref(path: &Path) -> bool {
@@ -163,5 +184,31 @@ mod tests {
             Some(p("/w/proj/.agents/skills/deploy")),
         );
         assert_eq!(resolved(&link, &p("/abs/x")), Some(p("/abs/x")));
+    }
+
+    /// The kind a Windows link is made with, asked of the link's own
+    /// parent. Against the `target.is_dir()` this replaced, the first of
+    /// these is red: that call reads the same text against the working
+    /// directory, where it names nothing, so every relative link to a
+    /// shared tree was made as a file link and did not resolve.
+    #[test]
+    fn a_relative_link_is_judged_from_its_own_parent() -> std::io::Result<()> {
+        let tmp = tempfile::tempdir()?;
+        let project = tmp.path().join("app");
+        std::fs::create_dir_all(project.join(".agents/skills/deploy"))?;
+        std::fs::create_dir_all(project.join(".claude/skills"))?;
+        std::fs::write(project.join(".agents/skills/deploy/SKILL.md"), "x")?;
+        let link = project.join(".claude/skills/deploy");
+
+        assert!(leads_to_dir(&link, &p("../../.agents/skills/deploy")));
+        assert!(leads_to_dir(&link, &project.join(".agents/skills/deploy")));
+        // A file, and a target that leads nowhere at all: neither is a
+        // directory link, and the second must not guess that it is.
+        assert!(!leads_to_dir(
+            &link,
+            &p("../../.agents/skills/deploy/SKILL.md")
+        ));
+        assert!(!leads_to_dir(&link, &p("../../.agents/skills/absent")));
+        Ok(())
     }
 }

--- a/crates/core/src/model.rs
+++ b/crates/core/src/model.rs
@@ -118,7 +118,7 @@ impl Scope {
     pub fn label(&self) -> String {
         match self {
             Scope::Global => "global".to_owned(),
-            Scope::Project { root } => root.display().to_string(),
+            Scope::Project { root } => crate::paths::slashed(root),
         }
     }
 

--- a/crates/core/src/package/detail.rs
+++ b/crates/core/src/package/detail.rs
@@ -370,7 +370,7 @@ pub(crate) fn capped(path: &Path, bytes: Vec<u8>) -> ItemSource {
         at
     };
     ItemSource {
-        path: path.display().to_string(),
+        path: crate::paths::slashed(path),
         content: String::from_utf8_lossy(&bytes[..taken]).into_owned(),
         truncated: bytes.len() > taken,
     }

--- a/crates/core/src/package/updates.rs
+++ b/crates/core/src/package/updates.rs
@@ -135,7 +135,7 @@ use eval::Eval;
 pub(crate) fn scope_key(scope: &Scope) -> String {
     match scope.canonical() {
         Scope::Global => "global".to_owned(),
-        Scope::Project { root } => root.display().to_string(),
+        Scope::Project { root } => crate::paths::slashed(&root),
     }
 }
 

--- a/crates/core/src/paths.rs
+++ b/crates/core/src/paths.rs
@@ -54,6 +54,12 @@ const LEGACY_MAX_PATH: usize = 248;
 /// gets a path that shell cannot read, which is the honest answer where
 /// the alternative names a different file or none. A root reaches here
 /// that way only from a harness root somebody set to the verbatim form.
+///
+/// **Routing a producer here routes its readers too.** A test that builds
+/// both sides of a comparison carries one spelling whichever it is, and
+/// that is why fixture paths are left raw — but the moment one side is a
+/// value from here, the expectation has to be spelled here as well, or the
+/// two agree only on the host where the separator already matches.
 pub fn slashed(path: &Path) -> String {
     let text = path.to_string_lossy();
     let reduced = plain(&text);

--- a/crates/core/src/quality/dimensions.rs
+++ b/crates/core/src/quality/dimensions.rs
@@ -281,7 +281,7 @@ fn coherence(body: &str, files: &[TreeFile], anti: &mut Vec<AntiPattern>) -> u32
         .filter(|target| {
             !files
                 .iter()
-                .any(|file| file.path.to_string_lossy().as_ref() == target.as_str())
+                .any(|file| crate::paths::slashed(&file.path) == target.as_str())
         })
         .collect();
     if broken.is_empty() {

--- a/crates/core/src/quality/mod.rs
+++ b/crates/core/src/quality/mod.rs
@@ -115,6 +115,8 @@ impl Severity {
 /// invisible to every rule, which is a pass nobody earned.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct TreeFile {
+    /// Relative to the tree's root, and `/`-spelled wherever it becomes
+    /// text: the links it is compared against are written that way.
     pub path: PathBuf,
     pub bytes: usize,
     pub text: Option<String>,
@@ -255,7 +257,8 @@ pub struct AuditInput {
     pub kind: ItemKind,
     pub name: String,
     pub harness: Option<HarnessId>,
-    /// The artifact's path, or the config file holding the entry.
+    /// The artifact's path, or the config file holding the entry, `/`-spelled
+    /// so a finding from the plan and one from disk name the same place.
     pub location: String,
     pub content: Content,
 }

--- a/crates/core/src/quality/observe.rs
+++ b/crates/core/src/quality/observe.rs
@@ -51,7 +51,7 @@ pub fn tree_content_from_bytes(files: &[(PathBuf, Vec<u8>)]) -> Content {
 
 /// What this observation carries, read as an audit input.
 pub fn input_for(item: &ObservedItem) -> AuditInput {
-    let location = item.path.display().to_string();
+    let location = crate::paths::slashed(&item.path);
     let content = match item.kind {
         ItemKind::Skill => read_tree(&item.path),
         ItemKind::Agent | ItemKind::Command | ItemKind::PiExtension => read_document(&item.path),
@@ -272,7 +272,7 @@ fn read_plugin(path: &Path) -> Content {
         git_origin: root
             .join(".git")
             .exists()
-            .then(|| root.display().to_string()),
+            .then(|| crate::paths::slashed(root)),
         scripts: files
             .into_iter()
             .filter(|file| is_source(&file.path))

--- a/crates/core/src/quality/observe/hook.rs
+++ b/crates/core/src/quality/observe/hook.rs
@@ -38,7 +38,7 @@ pub(super) fn read_hook(item: &ObservedItem) -> Content {
         return Content::Hook {
             event: String::new(),
             matcher: None,
-            command: item.path.display().to_string(),
+            command: crate::paths::slashed(&item.path),
             values: None,
             script: Some(text),
         };

--- a/crates/core/src/quality/observe/tests.rs
+++ b/crates/core/src/quality/observe/tests.rs
@@ -296,7 +296,7 @@ fn a_hook_command_that_carries_the_danger_still_scores() {
     assert_eq!(dangerous[0].severity, crate::quality::Severity::High);
     assert_eq!(
         dangerous[0].location,
-        format!("{} (command)", path.display()),
+        format!("{} (command)", crate::paths::slashed(&path)),
         "{:?}",
         found.findings
     );
@@ -453,7 +453,7 @@ fn every_executable_variant_of_a_copilot_entry_scores() {
     assert_eq!(dangerous[0].severity, crate::quality::Severity::High);
     assert_eq!(
         dangerous[0].location,
-        format!("{} (command)", path.display()),
+        format!("{} (command)", crate::paths::slashed(&path)),
         "{:?}",
         found.findings
     );

--- a/crates/core/src/quality/text.rs
+++ b/crates/core/src/quality/text.rs
@@ -205,7 +205,7 @@ fn tree_docs(
             let Some(text) = file.text else {
                 return TreeFile { text: None, ..file };
             };
-            let location = format!("{root}/{}", file.path.display());
+            let location = format!("{root}/{}", crate::paths::slashed(&file.path));
             let supporting = is_supporting(&file.path);
             let text = clean(location.clone(), &text);
             docs.push(Doc {

--- a/crates/core/src/remote/history.rs
+++ b/crates/core/src/remote/history.rs
@@ -51,7 +51,10 @@ fn stdout_capped(git: Hardened) -> Result<String> {
 
 /// A subtree path as a pathspec git will not interpret.
 fn literal(rel: &Path) -> String {
-    format!(":(literal){}", rel.display())
+    // Slashed: git matches a pathspec against index paths, and those are
+    // `/`-spelled on every platform. A `\` here matches no path at all,
+    // and an empty log reads as "nothing changed".
+    format!(":(literal){}", crate::paths::slashed(rel))
 }
 
 /// A commit subject as something safe to show: control characters become

--- a/crates/core/src/repo_effects/disclosure.rs
+++ b/crates/core/src/repo_effects/disclosure.rs
@@ -165,7 +165,7 @@ pub fn offers(scope: &Scope, effects: &[DeclaredEffects], installed: &BTreeSet<S
                     // `<root>/.git`, and this flag is a claim about who
                     // else sees the file.
                     shared: git_dir.is_some_and(|dir| target.starts_with(dir)),
-                    path: shown(&target.display().to_string()),
+                    path: shown(&crate::paths::slashed(&target)),
                 }
             })
             .collect();

--- a/crates/core/src/repo_effects/disclosure/tests.rs
+++ b/crates/core/src/repo_effects/disclosure/tests.rs
@@ -81,13 +81,13 @@ fn git_paths_land_in_the_common_dir_and_read_as_shared() {
     };
     assert_eq!(
         hook.path,
-        main.join(".git/hooks/pre-commit").display().to_string()
+        crate::paths::slashed(&main.join(".git/hooks/pre-commit"))
     );
     assert!(hook.shared, "{hook:?}");
     // `.github` shares a prefix with `.git` as text and nothing else.
     assert_eq!(
         workflow.path,
-        linked.join(".github/x").display().to_string()
+        crate::paths::slashed(&linked.join(".github/x"))
     );
     assert!(!workflow.shared, "{workflow:?}");
 }
@@ -123,7 +123,7 @@ fn a_git_path_is_read_by_components_not_by_prefix() {
         };
         assert_eq!(
             written.path,
-            common.join("hooks/pre-commit").display().to_string(),
+            crate::paths::slashed(&common.join("hooks/pre-commit")),
             "{spelling}"
         );
         assert!(written.shared, "{spelling}: {written:?}");
@@ -138,7 +138,7 @@ fn a_git_path_is_read_by_components_not_by_prefix() {
     let [written] = offers.shown[0].writes.as_slice() else {
         panic!("one path: {offers:?}");
     };
-    assert_eq!(written.path, common.display().to_string());
+    assert_eq!(written.path, crate::paths::slashed(&common));
     assert!(written.shared, "{written:?}");
 }
 

--- a/crates/core/src/source.rs
+++ b/crates/core/src/source.rs
@@ -243,7 +243,7 @@ pub fn resolve(env: &Env, scope: &Scope, name: &str, manifest: &Manifest) -> Res
         return match crate::paths::canonical(&joined) {
             Ok(root) if root.is_dir() => Ok(SourceState::Ready(ResolvedSource {
                 name: name.to_owned(),
-                provenance: root.display().to_string(),
+                provenance: crate::paths::slashed(&root),
                 root,
                 commit: None,
             })),

--- a/crates/core/src/source/browse/preview.rs
+++ b/crates/core/src/source/browse/preview.rs
@@ -125,11 +125,7 @@ fn shown_text(text: &str) -> String {
 }
 
 fn file_row(rel: &Path, len: usize) -> PackageFile {
-    let path = rel
-        .components()
-        .map(|c| c.as_os_str().to_string_lossy())
-        .collect::<Vec<_>>()
-        .join("/");
+    let path = crate::paths::slashed(rel);
     PackageFile {
         is_readme: !path.contains('/') && path.eq_ignore_ascii_case("README.md"),
         size: len.min(u32::MAX as usize) as u32,

--- a/crates/core/src/source/browse/safety/input.rs
+++ b/crates/core/src/source/browse/safety/input.rs
@@ -31,11 +31,7 @@ pub(super) fn input_for(
     item: &Item,
 ) -> Result<AuditInput> {
     let path = &item.path;
-    let location = path
-        .strip_prefix(browsed.sealed.root())
-        .unwrap_or(path)
-        .display()
-        .to_string();
+    let location = crate::paths::slashed(path.strip_prefix(browsed.sealed.root()).unwrap_or(path));
     let content = match kind {
         // Through the same constructor the plan reads a tree with, over
         // the tree this project would install — the rendering every tool

--- a/crates/core/src/source/browse/tests/summary.rs
+++ b/crates/core/src/source/browse/tests/summary.rs
@@ -25,7 +25,7 @@ fn a_subscription_summary_answers_with_itself_and_counts_its_offer() {
             source: "cat".to_owned(),
         })
     );
-    assert_eq!(report.provenance, catalog.display().to_string());
+    assert_eq!(report.provenance, crate::paths::slashed(&catalog));
     assert_eq!(report.repo_key, None, "a path is no GitHub repository");
     assert_eq!(report.commit, None);
     assert_eq!(report.warning, None);

--- a/crates/core/src/source/catalog.rs
+++ b/crates/core/src/source/catalog.rs
@@ -180,7 +180,7 @@ fn group(
     entry: &PluginEntry,
     findings: &mut Vec<CatalogFinding>,
 ) -> Result<CatalogGroup> {
-    let at = entry.dir.display().to_string();
+    let at = crate::paths::slashed(&entry.dir);
     check_manifest(sealed, entry, &at, findings)?;
     let mut members = Vec::new();
     for kind in [ItemKind::Agent, ItemKind::Command, ItemKind::Skill] {

--- a/crates/core/src/source/discover.rs
+++ b/crates/core/src/source/discover.rs
@@ -145,7 +145,7 @@ impl Walk<'_> {
             };
             let Some(name) = name.to_str() else {
                 self.discovery.findings.push(CatalogFinding::new(
-                    rel.display().to_string(),
+                    crate::paths::slashed(rel),
                     format!(
                         "`{}` is not a UTF-8 name, which no harness can load",
                         names::shown(&name.to_string_lossy())
@@ -178,7 +178,7 @@ impl Walk<'_> {
                 .all(|c| matches!(c, std::path::Component::Normal(_)))
         {
             self.discovery.findings.push(CatalogFinding::new(
-                names::shown(&rel.display().to_string()),
+                names::shown(&crate::paths::slashed(rel)),
                 "this path leads out of the repository".to_owned(),
                 "keep every skill in a plain directory under a recognized root",
             ));
@@ -200,7 +200,7 @@ impl Walk<'_> {
         if !self.taken_rels.insert(rel.to_path_buf()) {
             return Ok(());
         }
-        let location = rel.display().to_string();
+        let location = crate::paths::slashed(rel);
         if let Some(problem) = names::segment_problem(name) {
             self.discovery.findings.push(CatalogFinding::new(
                 location,
@@ -385,7 +385,7 @@ mod tests {
                 let Surface::SubdirPerItem { dir, .. } = surface else {
                     continue;
                 };
-                let dir = dir.to_string_lossy().into_owned();
+                let dir = crate::paths::slashed(&dir);
                 assert!(
                     SKILL_ROOTS.contains(&dir.as_str()),
                     "{} reads project skills from {dir}, which the search table misses",

--- a/crates/core/src/source/plugin_registry.rs
+++ b/crates/core/src/source/plugin_registry.rs
@@ -32,6 +32,9 @@ pub const PLUGIN_MANIFEST: &str = ".claude-plugin/plugin.json";
 /// Something wrong with a catalog, said in the catalog author's terms.
 #[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, specta::Type)]
 pub struct CatalogFinding {
+    /// Where in the catalog, repository-relative and `/`-spelled — the
+    /// catalog author reads it beside the `/`-spelled roots the search
+    /// table names, and it is one string on every host.
     pub location: String,
     pub problem: String,
     pub fix: String,
@@ -199,7 +202,7 @@ fn read_entry(sealed: &SealedSource, index: usize, entry: &Value, registry: &mut
             at,
             format!(
                 "`{}` is not a directory in this catalog",
-                names::shown(&dir.display().to_string())
+                names::shown(&crate::paths::slashed(&dir))
             ),
             "point the entry at a directory that exists, or drop the entry",
         ));

--- a/crates/core/tests/guard_skill_roots.rs
+++ b/crates/core/tests/guard_skill_roots.rs
@@ -33,7 +33,7 @@ fn adapter_skill_roots(project: &Path, env: &Env) -> BTreeSet<String> {
             let relative = dir
                 .strip_prefix(project)
                 .expect("a project surface is under the project root");
-            roots.insert(relative.to_string_lossy().into_owned());
+            roots.insert(kendex_core::paths::slashed(relative));
         }
     }
     roots

--- a/crates/core/tests/pi_hooks_move/observed.rs
+++ b/crates/core/tests/pi_hooks_move/observed.rs
@@ -57,7 +57,7 @@ fn a_held_hook_is_listed_where_it_runs_from() {
     assert!(
         scored.iter().any(|row| row.kind == ItemKind::Hook
             && row.harness == HarnessId::Pi
-            && row.location == w.dot().join("hooks.json").display().to_string()),
+            && row.location == kendex_core::paths::slashed(&w.dot().join("hooks.json"))),
         "the safety scan counts it too: {:?}",
         scored
             .iter()
@@ -131,7 +131,7 @@ fn a_link_at_the_new_registry_does_not_bring_the_old_one_back() {
         observed_rows(&w.env, &w.scope())
             .unwrap()
             .iter()
-            .all(|row| row.location != w.dot().join("hooks.json").display().to_string()),
+            .all(|row| row.location != kendex_core::paths::slashed(&w.dot().join("hooks.json"))),
         "and the safety scan says the same"
     );
 

--- a/crates/core/tests/unmanaged_shapes.rs
+++ b/crates/core/tests/unmanaged_shapes.rs
@@ -213,7 +213,7 @@ fn a_file_where_a_folder_goes_is_never_offered_the_keep() {
     let row = row.drift.iter().find(|row| row.name == "deploy").unwrap();
     assert_eq!(row.state, DriftState::Conflict);
     assert_eq!(row.cause, Some(DriftCause::UnmanagedWrongShape), "{row:?}");
-    assert_eq!(row.detail, position.display().to_string());
+    assert_eq!(row.detail, kendex_core::paths::slashed(&position));
     assert!(!row.cause.unwrap().can_keep());
     assert!(row.cause.unwrap().can_replace());
     assert!(
@@ -243,7 +243,7 @@ fn a_folder_where_a_file_goes_is_never_offered_the_keep() {
     let row = row.drift.iter().find(|row| row.name == "scout").unwrap();
     assert_eq!(row.state, DriftState::Conflict);
     assert_eq!(row.cause, Some(DriftCause::UnmanagedWrongShape), "{row:?}");
-    assert_eq!(row.detail, position.display().to_string());
+    assert_eq!(row.detail, kendex_core::paths::slashed(&position));
     assert!(!row.cause.unwrap().can_keep());
     assert!(
         adopt(
@@ -333,7 +333,7 @@ fn a_position_reaches_the_row_as_the_path_it_is() {
     assert_eq!(row.cause, Some(DriftCause::UnmanagedContent), "{row:?}");
     assert_eq!(
         row.detail,
-        position.display().to_string(),
+        kendex_core::paths::slashed(&position),
         "the row carries a rendering of the place instead of the place"
     );
     assert!(

--- a/crates/core/tests/unmanaged_takeover/main.rs
+++ b/crates/core/tests/unmanaged_takeover/main.rs
@@ -124,7 +124,7 @@ fn the_refusal_says_which_files_are_in_the_way() {
     );
     assert_eq!(
         row.detail,
-        dir.display().to_string(),
+        kendex_core::paths::slashed(&dir),
         "the row says where they are, and the surface says what that means"
     );
 
@@ -401,10 +401,14 @@ fn the_refusal_names_every_position_a_take_over_empties() {
 
     let audited = audit(&w.env, &w.scope).unwrap();
     let row = deploy_row(&audited.drift);
-    assert_eq!(row.detail, canonical.display().to_string(), "{row:?}");
+    assert_eq!(
+        row.detail,
+        kendex_core::paths::slashed(&canonical),
+        "{row:?}"
+    );
     assert_eq!(
         row.also_in_the_way,
-        vec![link.display().to_string()],
+        vec![kendex_core::paths::slashed(&link)],
         "{row:?}"
     );
 
@@ -437,7 +441,11 @@ fn an_empty_harness_position_is_not_named_as_in_the_way() {
 
     let audited = audit(&w.env, &w.scope).unwrap();
     let row = deploy_row(&audited.drift);
-    assert_eq!(row.detail, canonical.display().to_string(), "{row:?}");
+    assert_eq!(
+        row.detail,
+        kendex_core::paths::slashed(&canonical),
+        "{row:?}"
+    );
     assert!(row.also_in_the_way.is_empty(), "{row:?}");
 }
 

--- a/ui/src/bindings.ts
+++ b/ui/src/bindings.ts
@@ -748,6 +748,11 @@ export type Catalog = { by: "subscription"; scope: Scope; source: string } |
 
 /**  Something wrong with a catalog, said in the catalog author's terms. */
 export type CatalogFinding = {
+	/**
+	 *  Where in the catalog, repository-relative and `/`-spelled — the
+	 *  catalog author reads it beside the `/`-spelled roots the search
+	 *  table names, and it is one string on every host.
+	 */
 	location: string,
 	problem: string,
 	fix: string,


### PR DESCRIPTION
Closes KEN-842.

A harness installs a project skill into `.claude\skills` on Windows, and every root, table and record kendex holds that against is spelled `/`. The comparison that should match does not, so a package that is really there is one the guard verbs cannot find — across five harnesses. Found by running the Windows suite the KEN-810 lane adds (#1830), not by reading it: `cargo check` passes on every site here.

`paths::slashed` (KEN-819, #1820) is the spelling rule and these sites predate it. They are routed to it rather than fixed one string at a time.

## The rule the routing follows

A path becomes text through `slashed` when the text is **data**: matched against a `/`-spelled value, published in a record field a caller reads back, or handed to a program that spells `/`. It stays raw when it goes back to the operating system or to another program in that program's own spelling, when it is hashed or keyed with both sides built the same way, when it is one component and so holds no separator, or when it is a path named inside a sentence for the person at this machine.

That rule is in the commit so a later site has an answer without a second review.

## What changes for a user

`outcome.written` lists `skills/gh` again rather than `skills\gh`. A provenance `location` comes back matchable, so an in-place skill reads as its own candidate. A `:(literal)` pathspec matches index paths, which are `/`-spelled on every host — a `\` matched nothing and an empty log read as "nothing changed". A skill's relative links are held against the tree's own file list, so a link into a subdirectory stopped reporting as broken. `CheckFinding.file` and the settings template beside it read as one path. `AuditInput.location` is one string whether the audit came from a plan or from disk.

## A seventh failure that was not spelling

`a_namespaced_skill_is_adopted_at_its_rendered_position` loses the rendered file for a different reason. Windows records which kind a link is when it is made, and `make_symlink` asked `target.is_dir()` of the link's own text — text relative to the link's parent, not to this process's working directory, so it read `<cwd>/../../.agents/skills/<name>`: somebody else's tree, or nothing. Every relative link to a shared tree was therefore made as a file link, and a file link to a directory does not resolve — `exists()` is false and reads through it fail. `is_symlink()` is true either way, which is why one test caught it and the others did not.

`links::leads_to_dir` resolves the text against the link's parent first, and its control runs red against the call it replaces.

## Enumeration

Every path-to-text conversion in `crates/core`, single-component ones dropped (a `file_name`, `file_stem` or `extension` holds no separator and cannot be spelled two ways):

```
grep -rn -E 'display\(\)|to_string_lossy|to_str\(\)' crates/core --include=*.rs \
  | grep -vE ':[0-9]+: *(//|///|//!)' \
  | grep -vE 'file_name\(\)|file_stem\(\)|extension\(\)'
```

278 hits on the base commit, every one with a verdict in the commit body, grouped as routed / raw because the platform's spelling is what reaches / raw because both sides are built the same way / raw because there is nothing to spell / raw because it is a sentence rather than a field / test fixtures. 237 still match after the change, because a routed site now reads `paths::slashed` and drops out of the grep.

This is #1820's precedent, and it is the mechanism rather than the instance: that PR's narrowed pass missed three sites its exhaustive list then found.

## Validation

`tools/guard` passes. The routing itself cannot be red on Linux, where `slashed` is the identity — that is the point of it. The spelling rule is proven where it was written, by the `spelled` and `plain` controls in `paths.rs` that drive it with Windows-shaped input on any host. The link-kind fix has its own control, red against the call it replaces.

The Windows lane is not on `main` yet, so this cannot be proven on Windows here — the same position KEN-817, KEN-818 and KEN-819 landed from. #1830 restacks on this and is where all seven are proven.

## Not touched

`posture.rs:259` and `repo_effects/disclosure/tests.rs:14` leak the extended-length prefix into operator text and into a `git worktree add` argument. That is KEN-830, declined on #1820. Line-ending and reserved-name fixture failures on the same Windows run are test-side and land with the lane in #1830.

## Why there is no migration for the persisted path identities

Two reviewers have independently asked for one, so it belongs here rather than only in the commit body.

`Scope::label` and `ResolvedSource::provenance` are written into `LockEntry.source_repo` and into the ignored-update records, and this change spells them with `/`. Nothing needs migrating because **no Windows install has ever written a lock.** KEN-817 (#1816) found `sync_file` calling `sync_all` on a read-only handle, which Windows refuses without `GENERIC_WRITE`; every pre-image the journal took failed with access denied, so `add`, `refresh` and `apply` were all dead on the platform — and those verbs are the only writers of both stores.

On Unix `Path::display()` already produces `/`, so `slashed` is the identity function there and every stored value round-trips byte for byte.

The mechanism both reviewers describe is real: `item_plan.rs:67` compares exactly and would report a source rebind, and `Eval::is_ignored` would stop matching. It is moot only because nothing is in the old state. kendex's no-migration rule (KEN-787) is what keeps compatibility code out for states no machine is in — the same call the owner made on #1820 for `HookCommand`.
