### PR TITLE
fix(KEN-828): an absence assertion is measured as one, not called vacuous

### DIFF
--- a/.agents/skills/dep-radar/tests/generic-engine-lint.test.sh
+++ b/.agents/skills/dep-radar/tests/generic-engine-lint.test.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+# vacuous-suite-scan: absence-subject
 # Architecture-invariant lint: the dep-radar skill is the GENERIC engine.
 # Concrete package, binary, fork, and project names belong in each repo's
 # generated docs/dep-radar/inventory.md, never in the skill docs. This lint is a

--- a/.agents/skills/dep-radar/tests/generic-engine-lint.test.sh
+++ b/.agents/skills/dep-radar/tests/generic-engine-lint.test.sh
@@ -33,10 +33,22 @@ DENYLIST=(
 )
 
 # scan <file> — prints "file: name" for every denylisted name found.
+#
+# grep's status is part of the answer: 0 found, 1 none, anything else is a scan
+# that did not run — a missing file included — and a scan that did not run is
+# not a clean document. It exits rather than returning, so the caller's command
+# substitution carries the refusal: an empty result there reads as "no offender"
+# and is exactly the fail-open this guards.
 scan() {
-  local f="$1" name
+  local f="$1" name status
   for name in "${DENYLIST[@]}"; do
-    if grep -qiw -- "$name" "$f"; then
+    status=0
+    grep -qiw -- "$name" "$f" || status=$?
+    if [[ "$status" -gt 1 ]]; then
+      printf 'the scan of %s could not run (grep exited %s)\n' "$f" "$status" >&2
+      exit 1
+    fi
+    if [[ "$status" -eq 0 ]]; then
       printf '%s: %s\n' "$f" "$name"
     fi
   done

--- a/.agents/skills/dev/tests/handoff-body-file-lint.test.sh
+++ b/.agents/skills/dev/tests/handoff-body-file-lint.test.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+# vacuous-suite-scan: absence-subject
 # Regression lint: reject multiline inline --body in dev workflow docs.
 #
 # A `linear.sh comments create ... --body "` whose opening quote does NOT close

--- a/.agents/skills/dev/tests/handoff-body-file-lint.test.sh
+++ b/.agents/skills/dev/tests/handoff-body-file-lint.test.sh
@@ -20,8 +20,10 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 WORKFLOWS_DIR="$(cd "$SCRIPT_DIR/../workflows" && pwd)"
 
 offenders=0
+scanned=0
 
 while IFS= read -r -d '' file; do
+  scanned=$((scanned + 1))
   lineno=0
   while IFS= read -r line; do
     lineno=$((lineno + 1))
@@ -43,6 +45,13 @@ done < <(find "$WORKFLOWS_DIR" -type f -name '*.md' -print0)
 
 if (( offenders > 0 )); then
   echo "FAIL: $offenders multiline inline --body occurrence(s) found"
+  exit 1
+fi
+
+# An absent offender means nothing when there was nothing to read: a
+# workflows/ holding no markdown reports every line clean.
+if (( scanned == 0 )); then
+  echo "FAIL: no markdown found under $WORKFLOWS_DIR, so this lint read nothing" >&2
   exit 1
 fi
 

--- a/.agents/skills/growth-guards/tests/cleanup-scope.test.sh
+++ b/.agents/skills/growth-guards/tests/cleanup-scope.test.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+# vacuous-suite-scan: absence-subject
 # Pins for the family's EXIT cleanup: it removes only what THIS process
 # created. An inherited GG_TMP or ownership flag must never decide what a
 # guard deletes, and a check a hook lane runs must not remove the settings

--- a/.agents/skills/growth-guards/tests/harness-adoption.test.sh
+++ b/.agents/skills/growth-guards/tests/harness-adoption.test.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+# vacuous-suite-scan: harness-subject
 # Pins what a tenth suite must not be able to forget: no suite may run git
 # against a fixture while inheriting the caller's configuration, and the
 # shared harness must stay outside the tests/*.sh glob that runners execute.

--- a/.agents/skills/growth-guards/tests/path-captures.test.sh
+++ b/.agents/skills/growth-guards/tests/path-captures.test.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+# vacuous-suite-scan: absence-subject
 # Every command substitution that produces a PATH uses the sentinel idiom.
 #
 # Three rounds of review found this one site at a time: `$(...)` strips

--- a/.agents/skills/orch/tests/issue-citation-lint.test.sh
+++ b/.agents/skills/orch/tests/issue-citation-lint.test.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+# vacuous-suite-scan: absence-subject
 # Regression lint for VST-34. .github/instructions/skills-and-agents.instructions.md
 # bans issue-number citations (`kendex#NNN`, bare `(#NNN)`) in instruction-flow
 # skill/agent markdown — the always-loaded SKILL.md and agent-definition files

--- a/.agents/skills/orch/tests/workflow-state-single-command-lint.test.sh
+++ b/.agents/skills/orch/tests/workflow-state-single-command-lint.test.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+# vacuous-suite-scan: absence-subject
 # Regression lint for kendex#526 (a recurrence of the #369/#510 command-shape
 # class). Under Codex `approval=never`, a batch of several newline-separated (or
 # `;`-separated) commands in ONE tool call is rejected purely for its

--- a/.agents/skills/preflight/tests/bash32-portability.test.sh
+++ b/.agents/skills/preflight/tests/bash32-portability.test.sh
@@ -13,7 +13,15 @@ PATTERN='mapfile|readarray|declare -A|declare -gA|local -A'
 PATTERN="$PATTERN"'|(^|[^$])\{[A-Za-z_][A-Za-z0-9_]*\}[<>]'
 PATTERN="$PATTERN"'|\$\{[A-Za-z_][A-Za-z0-9_]*(\[[^]]*\])?(,,|\^\^)'
 
-violations="$(grep -rnE "$PATTERN" "$SCRIPTS_DIR" || true)"
+# grep's status is part of the answer: 0 found, 1 none, anything else is a
+# scan that did not run — and a scan that did not run is not a clean tree.
+violations=""
+scan_status=0
+violations="$(grep -rnE "$PATTERN" "$SCRIPTS_DIR")" || scan_status=$?
+if [ "$scan_status" -gt 1 ]; then
+  echo "the portability scan over $SCRIPTS_DIR could not run (grep exited $scan_status)" >&2
+  exit 1
+fi
 if [ -n "$violations" ]; then
   echo "Bash 4+ constructs found in preflight scripts (must run under Bash 3.2):" >&2
   printf '%s\n' "$violations" >&2
@@ -21,12 +29,21 @@ if [ -n "$violations" ]; then
 fi
 
 fail=0
+checked=0
 for f in "$SCRIPTS_DIR"/*; do
+  [ -f "$f" ] || continue
+  checked=$((checked + 1))
   if ! bash -n "$f"; then
     echo "FAIL: bash -n $f"
     fail=1
   fi
 done
+# An absent forbidden construct means nothing when there was nothing to look
+# in: an empty scripts/ scans clean and syntax-checks clean.
+if [ "$checked" -eq 0 ]; then
+  echo "FAIL: no shipped script found under $SCRIPTS_DIR, so this lint read nothing" >&2
+  exit 1
+fi
 [ "$fail" -eq 0 ] || exit 1
 
 echo "pass: bash32-portability"

--- a/.agents/skills/preflight/tests/bash32-portability.test.sh
+++ b/.agents/skills/preflight/tests/bash32-portability.test.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+# vacuous-suite-scan: absence-subject
 # preflight runs in consumer pre-commit hooks and on macOS system Bash 3.2,
 # so the shipped script may not use Bash 4+ builtins or syntax (mapfile /
 # readarray, associative arrays, automatic FD-allocation redirections,

--- a/.agents/skills/project-management/tests/bash32-portability.test.sh
+++ b/.agents/skills/project-management/tests/bash32-portability.test.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+# vacuous-suite-scan: absence-subject
 # These scripts run under macOS system bash, which is 3.2. Bash 4+ constructs
 # fail there at runtime rather than at review time, so they are linted out.
 set -euo pipefail

--- a/.agents/skills/project-management/tests/bash32-portability.test.sh
+++ b/.agents/skills/project-management/tests/bash32-portability.test.sh
@@ -10,11 +10,31 @@ SKILL_DIR="$(cd "$TEST_DIR/.." && pwd)"
 PASS=0
 FAIL=0
 
+# An absent forbidden construct means nothing when there was nothing to look
+# in: an empty scripts/ scans clean under every pattern below.
+if [ -z "$(find "$SKILL_DIR/scripts" -type f)" ]; then
+  echo "FAIL: no shipped script found under $SKILL_DIR/scripts, so this lint read nothing" >&2
+  exit 1
+fi
+
 check_absent() {
-  local pattern="$1" label="$2"
-  if grep -rnE "$pattern" "$SKILL_DIR/scripts" 2>/dev/null | grep -v '^Binary'; then
+  local pattern="$1" label="$2" hits="" status=0
+  # grep's status is part of the answer: 0 found, 1 none, anything else is a
+  # scan that did not run — and a scan that did not run is not a clean tree.
+  # `2>/dev/null` used to hide that third case, and the pipeline's status came
+  # from the `grep -v` at its end, so an unreadable tree printed PASS.
+  hits="$(grep -rnE "$pattern" "$SKILL_DIR/scripts")" || status=$?
+  if [ "$status" -gt 1 ]; then
+    FAIL=$((FAIL + 1))
+    printf 'FAIL: %s — the scan over %s could not run (grep exited %s)\n' \
+      "$label" "$SKILL_DIR/scripts" "$status" >&2
+    return 0
+  fi
+  hits="$(printf '%s' "$hits" | grep -v '^Binary' || true)"
+  if [ -n "$hits" ]; then
     FAIL=$((FAIL + 1))
     printf 'FAIL: %s\n' "$label" >&2
+    printf '%s\n' "$hits" >&2
   else
     PASS=$((PASS + 1))
     printf 'PASS: %s\n' "$label"

--- a/.agents/skills/project-management/tests/linear-loops-contract.test.sh
+++ b/.agents/skills/project-management/tests/linear-loops-contract.test.sh
@@ -7,6 +7,11 @@
 # present, never that a behavioral claim written in prose is true. It passes
 # vacuously where the template is not shipped.
 #
+# tools/vacuous-suite-scan reports it vacuous for that reason, and the report
+# is correct: the scan stages this skill alone, the template is not in it, and
+# every pin above is then skipped. There is no subject to declare — what would
+# clear the flag is the template travelling with the skill.
+#
 # The bundle rules themselves are prose and have no lint. Nothing here checks
 # that a bundle parent is born in Backlog rather than Triage, carries its
 # project's complete label set, takes its children's highest priority, takes

--- a/.agents/skills/review-gate/tests/bash32-portability.test.sh
+++ b/.agents/skills/review-gate/tests/bash32-portability.test.sh
@@ -39,6 +39,19 @@ if [ "${#sh_files[@]}" -eq 0 ]; then
   echo "FAIL: no shell files found under $SCRIPTS_DIR or $TEST_DIR" >&2
   exit 1
 fi
+# And the two directories are counted apart. tests/ always holds this file, so
+# the check above is satisfied by an empty scripts/ — and an absent forbidden
+# construct means nothing when there was nothing shipped to look in.
+script_files=0
+for f in ${sh_files[@]+"${sh_files[@]}"}; do
+  case "$f" in
+  "$SCRIPTS_DIR"/*) script_files=$((script_files + 1)) ;;
+  esac
+done
+if [ "$script_files" -eq 0 ]; then
+  echo "FAIL: no shell file found under $SCRIPTS_DIR, so this lint read no shipped script" >&2
+  exit 1
+fi
 
 nl='
 '
@@ -51,7 +64,15 @@ for f in ${sh_files[@]+"${sh_files[@]}"}; do
   # `--` before the operands: a path beginning with `-` is parsed as options
   # otherwise. It goes to grep and `bash -n`, which accept it, and NOT to
   # dirname/basename, which reject it on BSD (see the pattern above).
-  hits="$(grep -nE -- "$PATTERN" "$f" || true)"
+  # grep's status is part of the answer: 0 found, 1 none, anything else is a
+  # scan that did not run — and a scan that did not run is not a clean file.
+  hits=""
+  scan_status=0
+  hits="$(grep -nE -- "$PATTERN" "$f")" || scan_status=$?
+  if [ "$scan_status" -gt 1 ]; then
+    echo "FAIL: the portability scan over $f could not run (grep exited $scan_status)" >&2
+    exit 1
+  fi
   if [ -n "$hits" ]; then
     violations="$violations$(printf '%s\n' "$hits" | sed "s|^|$f:|")$nl"
   fi

--- a/.agents/skills/review-gate/tests/bash32-portability.test.sh
+++ b/.agents/skills/review-gate/tests/bash32-portability.test.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+# vacuous-suite-scan: absence-subject
 # The review-gate scripts run on consumer CI images and on macOS system Bash
 # 3.2, so shipped scripts may not use Bash 4+ builtins or syntax
 # (mapfile/readarray, associative arrays, automatic FD-allocation

--- a/.agents/skills/review-gate/tests/review-predicate-selftest-teardown.test.sh
+++ b/.agents/skills/review-gate/tests/review-predicate-selftest-teardown.test.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+# vacuous-suite-scan: harness-subject
 # The wrapper launches its full-decision-table replays from inside the
 # fixture blocks, so an early exit from a later block leaves replays running.
 # This proves the wrapper's teardown owns the whole replay TREE — the

--- a/.agents/skills/reviewer/tests/harness-safe-shell-lint.test.sh
+++ b/.agents/skills/reviewer/tests/harness-safe-shell-lint.test.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+# vacuous-suite-scan: absence-subject
 # Regression test for the reviewer skill's "Harness-Safe Shell" rule (kendex#510,
 # a recurrence of #369). Under Codex `approval=never`, a required read-only
 # validation such as `jq -e <filter> <file> >/dev/null` is rejected because the

--- a/.agents/skills/size-ratchet/tests/bash32-portability.test.sh
+++ b/.agents/skills/size-ratchet/tests/bash32-portability.test.sh
@@ -13,7 +13,15 @@ PATTERN='mapfile|readarray|declare -A|declare -gA|local -A'
 PATTERN="$PATTERN"'|(^|[^$])\{[A-Za-z_][A-Za-z0-9_]*\}[<>]'
 PATTERN="$PATTERN"'|\$\{[A-Za-z_][A-Za-z0-9_]*(\[[^]]*\])?(,,|\^\^)'
 
-violations="$(grep -rnE "$PATTERN" "$SCRIPTS_DIR" || true)"
+# grep's status is part of the answer: 0 found, 1 none, anything else is a
+# scan that did not run — and a scan that did not run is not a clean tree.
+violations=""
+scan_status=0
+violations="$(grep -rnE "$PATTERN" "$SCRIPTS_DIR")" || scan_status=$?
+if [[ "$scan_status" -gt 1 ]]; then
+  echo "the portability scan over $SCRIPTS_DIR could not run (grep exited $scan_status)" >&2
+  exit 1
+fi
 if [[ -n "$violations" ]]; then
   echo "Bash 4+ constructs found in size-ratchet scripts (must run under Bash 3.2):" >&2
   printf '%s\n' "$violations" >&2
@@ -22,12 +30,22 @@ fi
 
 # Syntax-check every shipped script while we are here.
 fail=0
+checked=0
 for f in "$SCRIPTS_DIR"/size-ratchet "$SCRIPTS_DIR"/lib/*.sh; do
+  if [ -f "$f" ]; then
+    checked=$((checked + 1))
+  fi
   if ! bash -n "$f"; then
     echo "FAIL: bash -n $f"
     fail=1
   fi
 done
+# An absent forbidden construct means nothing when there was nothing to look
+# in: an empty scripts/ scans clean.
+if [ "$checked" -eq 0 ]; then
+  echo "FAIL: no shipped script found under $SCRIPTS_DIR, so this lint read nothing" >&2
+  exit 1
+fi
 [ "$fail" -eq 0 ] || exit 1
 
 echo "pass: bash32-portability"

--- a/.agents/skills/size-ratchet/tests/bash32-portability.test.sh
+++ b/.agents/skills/size-ratchet/tests/bash32-portability.test.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+# vacuous-suite-scan: absence-subject
 # size-ratchet runs on consumer CI images and on macOS system Bash 3.2, so
 # shipped scripts may not use Bash 4+ builtins or syntax (mapfile/readarray,
 # associative arrays, automatic FD-allocation redirections, case-conversion

--- a/.agents/skills/worktree/tests/bash32-portability.test.sh
+++ b/.agents/skills/worktree/tests/bash32-portability.test.sh
@@ -13,7 +13,22 @@ PATTERN='mapfile|readarray|declare -A|declare -gA|local -A'
 PATTERN="$PATTERN"'|(^|[^$])\{[A-Za-z_][A-Za-z0-9_]*\}[<>]'
 PATTERN="$PATTERN"'|\$\{[A-Za-z_][A-Za-z0-9_]*(\[[^]]*\])?(,,|\^\^)'
 
-violations="$(grep -rnE "$PATTERN" "$SCRIPTS_DIR" || true)"
+# An absent forbidden construct means nothing when there was nothing to look
+# in: an empty scripts/ scans clean.
+if [ -z "$(find "$SCRIPTS_DIR" -type f)" ]; then
+  echo "FAIL: no shipped script found under $SCRIPTS_DIR, so this lint read nothing" >&2
+  exit 1
+fi
+
+# grep's status is part of the answer: 0 found, 1 none, anything else is a
+# scan that did not run — and a scan that did not run is not a clean tree.
+violations=""
+scan_status=0
+violations="$(grep -rnE "$PATTERN" "$SCRIPTS_DIR")" || scan_status=$?
+if [[ "$scan_status" -gt 1 ]]; then
+  echo "the portability scan over $SCRIPTS_DIR could not run (grep exited $scan_status)" >&2
+  exit 1
+fi
 if [[ -n "$violations" ]]; then
   echo "Bash 4+ constructs found in worktree scripts (must run under Bash 3.2):" >&2
   printf '%s\n' "$violations" >&2

--- a/.agents/skills/worktree/tests/bash32-portability.test.sh
+++ b/.agents/skills/worktree/tests/bash32-portability.test.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+# vacuous-suite-scan: absence-subject
 # Regression test for #575: the worktree skill must stay runnable under macOS
 # system Bash 3.2, so shipped scripts may not use Bash 4+ builtins or syntax
 # (mapfile/readarray, associative arrays, automatic FD-allocation

--- a/skills/dep-radar/tests/generic-engine-lint.test.sh
+++ b/skills/dep-radar/tests/generic-engine-lint.test.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+# vacuous-suite-scan: absence-subject
 # Architecture-invariant lint: the dep-radar skill is the GENERIC engine.
 # Concrete package, binary, fork, and project names belong in each repo's
 # generated docs/dep-radar/inventory.md, never in the skill docs. This lint is a

--- a/skills/dep-radar/tests/generic-engine-lint.test.sh
+++ b/skills/dep-radar/tests/generic-engine-lint.test.sh
@@ -33,10 +33,22 @@ DENYLIST=(
 )
 
 # scan <file> — prints "file: name" for every denylisted name found.
+#
+# grep's status is part of the answer: 0 found, 1 none, anything else is a scan
+# that did not run — a missing file included — and a scan that did not run is
+# not a clean document. It exits rather than returning, so the caller's command
+# substitution carries the refusal: an empty result there reads as "no offender"
+# and is exactly the fail-open this guards.
 scan() {
-  local f="$1" name
+  local f="$1" name status
   for name in "${DENYLIST[@]}"; do
-    if grep -qiw -- "$name" "$f"; then
+    status=0
+    grep -qiw -- "$name" "$f" || status=$?
+    if [[ "$status" -gt 1 ]]; then
+      printf 'the scan of %s could not run (grep exited %s)\n' "$f" "$status" >&2
+      exit 1
+    fi
+    if [[ "$status" -eq 0 ]]; then
       printf '%s: %s\n' "$f" "$name"
     fi
   done

--- a/skills/dev/tests/handoff-body-file-lint.test.sh
+++ b/skills/dev/tests/handoff-body-file-lint.test.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+# vacuous-suite-scan: absence-subject
 # Regression lint: reject multiline inline --body in dev workflow docs.
 #
 # A `linear.sh comments create ... --body "` whose opening quote does NOT close

--- a/skills/dev/tests/handoff-body-file-lint.test.sh
+++ b/skills/dev/tests/handoff-body-file-lint.test.sh
@@ -20,8 +20,10 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 WORKFLOWS_DIR="$(cd "$SCRIPT_DIR/../workflows" && pwd)"
 
 offenders=0
+scanned=0
 
 while IFS= read -r -d '' file; do
+  scanned=$((scanned + 1))
   lineno=0
   while IFS= read -r line; do
     lineno=$((lineno + 1))
@@ -43,6 +45,13 @@ done < <(find "$WORKFLOWS_DIR" -type f -name '*.md' -print0)
 
 if (( offenders > 0 )); then
   echo "FAIL: $offenders multiline inline --body occurrence(s) found"
+  exit 1
+fi
+
+# An absent offender means nothing when there was nothing to read: a
+# workflows/ holding no markdown reports every line clean.
+if (( scanned == 0 )); then
+  echo "FAIL: no markdown found under $WORKFLOWS_DIR, so this lint read nothing" >&2
   exit 1
 fi
 

--- a/skills/growth-guards/tests/cleanup-scope.test.sh
+++ b/skills/growth-guards/tests/cleanup-scope.test.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+# vacuous-suite-scan: absence-subject
 # Pins for the family's EXIT cleanup: it removes only what THIS process
 # created. An inherited GG_TMP or ownership flag must never decide what a
 # guard deletes, and a check a hook lane runs must not remove the settings

--- a/skills/growth-guards/tests/harness-adoption.test.sh
+++ b/skills/growth-guards/tests/harness-adoption.test.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+# vacuous-suite-scan: harness-subject
 # Pins what a tenth suite must not be able to forget: no suite may run git
 # against a fixture while inheriting the caller's configuration, and the
 # shared harness must stay outside the tests/*.sh glob that runners execute.

--- a/skills/growth-guards/tests/path-captures.test.sh
+++ b/skills/growth-guards/tests/path-captures.test.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+# vacuous-suite-scan: absence-subject
 # Every command substitution that produces a PATH uses the sentinel idiom.
 #
 # Three rounds of review found this one site at a time: `$(...)` strips

--- a/skills/harness-ci/tests/bash32-portability.test.sh
+++ b/skills/harness-ci/tests/bash32-portability.test.sh
@@ -13,7 +13,15 @@ PATTERN='mapfile|readarray|declare -A|declare -gA|local -A'
 PATTERN="$PATTERN"'|(^|[^$])\{[A-Za-z_][A-Za-z0-9_]*\}[<>]'
 PATTERN="$PATTERN"'|\$\{[A-Za-z_][A-Za-z0-9_]*(\[[^]]*\])?(,,|\^\^)'
 
-violations="$(grep -rnE "$PATTERN" "$SCRIPTS_DIR" || true)"
+# grep's status is part of the answer: 0 found, 1 none, anything else is a
+# scan that did not run — and a scan that did not run is not a clean tree.
+violations=""
+scan_status=0
+violations="$(grep -rnE "$PATTERN" "$SCRIPTS_DIR")" || scan_status=$?
+if [ "$scan_status" -gt 1 ]; then
+  echo "the portability scan over $SCRIPTS_DIR could not run (grep exited $scan_status)" >&2
+  exit 1
+fi
 if [ -n "$violations" ]; then
   echo "Bash 4+ constructs found in harness-ci scripts (must run under Bash 3.2):" >&2
   printf '%s\n' "$violations" >&2
@@ -21,13 +29,21 @@ if [ -n "$violations" ]; then
 fi
 
 fail=0
+checked=0
 for f in "$SCRIPTS_DIR"/*; do
   [ -f "$f" ] || continue
+  checked=$((checked + 1))
   if ! bash -n "$f"; then
     echo "FAIL: syntax check on $f"
     fail=1
   fi
 done
+# An absent forbidden construct means nothing when there was nothing to look
+# in: an empty scripts/ scans clean and syntax-checks clean.
+if [ "$checked" -eq 0 ]; then
+  echo "FAIL: no shipped script found under $SCRIPTS_DIR, so this lint read nothing" >&2
+  exit 1
+fi
 [ "$fail" -eq 0 ] || exit 1
 
 echo "pass: bash32-portability"

--- a/skills/harness-ci/tests/bash32-portability.test.sh
+++ b/skills/harness-ci/tests/bash32-portability.test.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+# vacuous-suite-scan: absence-subject
 # The classifier runs on whatever image a consumer's CI uses, macOS system
 # Bash 3.2 included, so shipped scripts may not use Bash 4+ builtins or syntax
 # (mapfile/readarray, associative arrays, automatic FD-allocation

--- a/skills/orch/tests/issue-citation-lint.test.sh
+++ b/skills/orch/tests/issue-citation-lint.test.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+# vacuous-suite-scan: absence-subject
 # Regression lint for VST-34. .github/instructions/skills-and-agents.instructions.md
 # bans issue-number citations (`kendex#NNN`, bare `(#NNN)`) in instruction-flow
 # skill/agent markdown — the always-loaded SKILL.md and agent-definition files

--- a/skills/orch/tests/workflow-state-single-command-lint.test.sh
+++ b/skills/orch/tests/workflow-state-single-command-lint.test.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+# vacuous-suite-scan: absence-subject
 # Regression lint for kendex#526 (a recurrence of the #369/#510 command-shape
 # class). Under Codex `approval=never`, a batch of several newline-separated (or
 # `;`-separated) commands in ONE tool call is rejected purely for its

--- a/skills/preflight/tests/bash32-portability.test.sh
+++ b/skills/preflight/tests/bash32-portability.test.sh
@@ -13,7 +13,15 @@ PATTERN='mapfile|readarray|declare -A|declare -gA|local -A'
 PATTERN="$PATTERN"'|(^|[^$])\{[A-Za-z_][A-Za-z0-9_]*\}[<>]'
 PATTERN="$PATTERN"'|\$\{[A-Za-z_][A-Za-z0-9_]*(\[[^]]*\])?(,,|\^\^)'
 
-violations="$(grep -rnE "$PATTERN" "$SCRIPTS_DIR" || true)"
+# grep's status is part of the answer: 0 found, 1 none, anything else is a
+# scan that did not run — and a scan that did not run is not a clean tree.
+violations=""
+scan_status=0
+violations="$(grep -rnE "$PATTERN" "$SCRIPTS_DIR")" || scan_status=$?
+if [ "$scan_status" -gt 1 ]; then
+  echo "the portability scan over $SCRIPTS_DIR could not run (grep exited $scan_status)" >&2
+  exit 1
+fi
 if [ -n "$violations" ]; then
   echo "Bash 4+ constructs found in preflight scripts (must run under Bash 3.2):" >&2
   printf '%s\n' "$violations" >&2
@@ -21,12 +29,21 @@ if [ -n "$violations" ]; then
 fi
 
 fail=0
+checked=0
 for f in "$SCRIPTS_DIR"/*; do
+  [ -f "$f" ] || continue
+  checked=$((checked + 1))
   if ! bash -n "$f"; then
     echo "FAIL: bash -n $f"
     fail=1
   fi
 done
+# An absent forbidden construct means nothing when there was nothing to look
+# in: an empty scripts/ scans clean and syntax-checks clean.
+if [ "$checked" -eq 0 ]; then
+  echo "FAIL: no shipped script found under $SCRIPTS_DIR, so this lint read nothing" >&2
+  exit 1
+fi
 [ "$fail" -eq 0 ] || exit 1
 
 echo "pass: bash32-portability"

--- a/skills/preflight/tests/bash32-portability.test.sh
+++ b/skills/preflight/tests/bash32-portability.test.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+# vacuous-suite-scan: absence-subject
 # preflight runs in consumer pre-commit hooks and on macOS system Bash 3.2,
 # so the shipped script may not use Bash 4+ builtins or syntax (mapfile /
 # readarray, associative arrays, automatic FD-allocation redirections,

--- a/skills/project-management/tests/bash32-portability.test.sh
+++ b/skills/project-management/tests/bash32-portability.test.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+# vacuous-suite-scan: absence-subject
 # These scripts run under macOS system bash, which is 3.2. Bash 4+ constructs
 # fail there at runtime rather than at review time, so they are linted out.
 set -euo pipefail

--- a/skills/project-management/tests/bash32-portability.test.sh
+++ b/skills/project-management/tests/bash32-portability.test.sh
@@ -10,11 +10,31 @@ SKILL_DIR="$(cd "$TEST_DIR/.." && pwd)"
 PASS=0
 FAIL=0
 
+# An absent forbidden construct means nothing when there was nothing to look
+# in: an empty scripts/ scans clean under every pattern below.
+if [ -z "$(find "$SKILL_DIR/scripts" -type f)" ]; then
+  echo "FAIL: no shipped script found under $SKILL_DIR/scripts, so this lint read nothing" >&2
+  exit 1
+fi
+
 check_absent() {
-  local pattern="$1" label="$2"
-  if grep -rnE "$pattern" "$SKILL_DIR/scripts" 2>/dev/null | grep -v '^Binary'; then
+  local pattern="$1" label="$2" hits="" status=0
+  # grep's status is part of the answer: 0 found, 1 none, anything else is a
+  # scan that did not run — and a scan that did not run is not a clean tree.
+  # `2>/dev/null` used to hide that third case, and the pipeline's status came
+  # from the `grep -v` at its end, so an unreadable tree printed PASS.
+  hits="$(grep -rnE "$pattern" "$SKILL_DIR/scripts")" || status=$?
+  if [ "$status" -gt 1 ]; then
+    FAIL=$((FAIL + 1))
+    printf 'FAIL: %s — the scan over %s could not run (grep exited %s)\n' \
+      "$label" "$SKILL_DIR/scripts" "$status" >&2
+    return 0
+  fi
+  hits="$(printf '%s' "$hits" | grep -v '^Binary' || true)"
+  if [ -n "$hits" ]; then
     FAIL=$((FAIL + 1))
     printf 'FAIL: %s\n' "$label" >&2
+    printf '%s\n' "$hits" >&2
   else
     PASS=$((PASS + 1))
     printf 'PASS: %s\n' "$label"

--- a/skills/project-management/tests/linear-loops-contract.test.sh
+++ b/skills/project-management/tests/linear-loops-contract.test.sh
@@ -7,6 +7,11 @@
 # present, never that a behavioral claim written in prose is true. It passes
 # vacuously where the template is not shipped.
 #
+# tools/vacuous-suite-scan reports it vacuous for that reason, and the report
+# is correct: the scan stages this skill alone, the template is not in it, and
+# every pin above is then skipped. There is no subject to declare — what would
+# clear the flag is the template travelling with the skill.
+#
 # The bundle rules themselves are prose and have no lint. Nothing here checks
 # that a bundle parent is born in Backlog rather than Triage, carries its
 # project's complete label set, takes its children's highest priority, takes

--- a/skills/review-gate/tests/bash32-portability.test.sh
+++ b/skills/review-gate/tests/bash32-portability.test.sh
@@ -39,6 +39,19 @@ if [ "${#sh_files[@]}" -eq 0 ]; then
   echo "FAIL: no shell files found under $SCRIPTS_DIR or $TEST_DIR" >&2
   exit 1
 fi
+# And the two directories are counted apart. tests/ always holds this file, so
+# the check above is satisfied by an empty scripts/ — and an absent forbidden
+# construct means nothing when there was nothing shipped to look in.
+script_files=0
+for f in ${sh_files[@]+"${sh_files[@]}"}; do
+  case "$f" in
+  "$SCRIPTS_DIR"/*) script_files=$((script_files + 1)) ;;
+  esac
+done
+if [ "$script_files" -eq 0 ]; then
+  echo "FAIL: no shell file found under $SCRIPTS_DIR, so this lint read no shipped script" >&2
+  exit 1
+fi
 
 nl='
 '
@@ -51,7 +64,15 @@ for f in ${sh_files[@]+"${sh_files[@]}"}; do
   # `--` before the operands: a path beginning with `-` is parsed as options
   # otherwise. It goes to grep and `bash -n`, which accept it, and NOT to
   # dirname/basename, which reject it on BSD (see the pattern above).
-  hits="$(grep -nE -- "$PATTERN" "$f" || true)"
+  # grep's status is part of the answer: 0 found, 1 none, anything else is a
+  # scan that did not run — and a scan that did not run is not a clean file.
+  hits=""
+  scan_status=0
+  hits="$(grep -nE -- "$PATTERN" "$f")" || scan_status=$?
+  if [ "$scan_status" -gt 1 ]; then
+    echo "FAIL: the portability scan over $f could not run (grep exited $scan_status)" >&2
+    exit 1
+  fi
   if [ -n "$hits" ]; then
     violations="$violations$(printf '%s\n' "$hits" | sed "s|^|$f:|")$nl"
   fi

--- a/skills/review-gate/tests/bash32-portability.test.sh
+++ b/skills/review-gate/tests/bash32-portability.test.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+# vacuous-suite-scan: absence-subject
 # The review-gate scripts run on consumer CI images and on macOS system Bash
 # 3.2, so shipped scripts may not use Bash 4+ builtins or syntax
 # (mapfile/readarray, associative arrays, automatic FD-allocation

--- a/skills/review-gate/tests/review-predicate-selftest-teardown.test.sh
+++ b/skills/review-gate/tests/review-predicate-selftest-teardown.test.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+# vacuous-suite-scan: harness-subject
 # The wrapper launches its full-decision-table replays from inside the
 # fixture blocks, so an early exit from a later block leaves replays running.
 # This proves the wrapper's teardown owns the whole replay TREE — the

--- a/skills/reviewer/tests/harness-safe-shell-lint.test.sh
+++ b/skills/reviewer/tests/harness-safe-shell-lint.test.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+# vacuous-suite-scan: absence-subject
 # Regression test for the reviewer skill's "Harness-Safe Shell" rule (kendex#510,
 # a recurrence of #369). Under Codex `approval=never`, a required read-only
 # validation such as `jq -e <filter> <file> >/dev/null` is rejected because the

--- a/skills/size-ratchet/tests/bash32-portability.test.sh
+++ b/skills/size-ratchet/tests/bash32-portability.test.sh
@@ -13,7 +13,15 @@ PATTERN='mapfile|readarray|declare -A|declare -gA|local -A'
 PATTERN="$PATTERN"'|(^|[^$])\{[A-Za-z_][A-Za-z0-9_]*\}[<>]'
 PATTERN="$PATTERN"'|\$\{[A-Za-z_][A-Za-z0-9_]*(\[[^]]*\])?(,,|\^\^)'
 
-violations="$(grep -rnE "$PATTERN" "$SCRIPTS_DIR" || true)"
+# grep's status is part of the answer: 0 found, 1 none, anything else is a
+# scan that did not run — and a scan that did not run is not a clean tree.
+violations=""
+scan_status=0
+violations="$(grep -rnE "$PATTERN" "$SCRIPTS_DIR")" || scan_status=$?
+if [[ "$scan_status" -gt 1 ]]; then
+  echo "the portability scan over $SCRIPTS_DIR could not run (grep exited $scan_status)" >&2
+  exit 1
+fi
 if [[ -n "$violations" ]]; then
   echo "Bash 4+ constructs found in size-ratchet scripts (must run under Bash 3.2):" >&2
   printf '%s\n' "$violations" >&2
@@ -22,12 +30,22 @@ fi
 
 # Syntax-check every shipped script while we are here.
 fail=0
+checked=0
 for f in "$SCRIPTS_DIR"/size-ratchet "$SCRIPTS_DIR"/lib/*.sh; do
+  if [ -f "$f" ]; then
+    checked=$((checked + 1))
+  fi
   if ! bash -n "$f"; then
     echo "FAIL: bash -n $f"
     fail=1
   fi
 done
+# An absent forbidden construct means nothing when there was nothing to look
+# in: an empty scripts/ scans clean.
+if [ "$checked" -eq 0 ]; then
+  echo "FAIL: no shipped script found under $SCRIPTS_DIR, so this lint read nothing" >&2
+  exit 1
+fi
 [ "$fail" -eq 0 ] || exit 1
 
 echo "pass: bash32-portability"

--- a/skills/size-ratchet/tests/bash32-portability.test.sh
+++ b/skills/size-ratchet/tests/bash32-portability.test.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+# vacuous-suite-scan: absence-subject
 # size-ratchet runs on consumer CI images and on macOS system Bash 3.2, so
 # shipped scripts may not use Bash 4+ builtins or syntax (mapfile/readarray,
 # associative arrays, automatic FD-allocation redirections, case-conversion

--- a/skills/worktree/tests/bash32-portability.test.sh
+++ b/skills/worktree/tests/bash32-portability.test.sh
@@ -13,7 +13,22 @@ PATTERN='mapfile|readarray|declare -A|declare -gA|local -A'
 PATTERN="$PATTERN"'|(^|[^$])\{[A-Za-z_][A-Za-z0-9_]*\}[<>]'
 PATTERN="$PATTERN"'|\$\{[A-Za-z_][A-Za-z0-9_]*(\[[^]]*\])?(,,|\^\^)'
 
-violations="$(grep -rnE "$PATTERN" "$SCRIPTS_DIR" || true)"
+# An absent forbidden construct means nothing when there was nothing to look
+# in: an empty scripts/ scans clean.
+if [ -z "$(find "$SCRIPTS_DIR" -type f)" ]; then
+  echo "FAIL: no shipped script found under $SCRIPTS_DIR, so this lint read nothing" >&2
+  exit 1
+fi
+
+# grep's status is part of the answer: 0 found, 1 none, anything else is a
+# scan that did not run — and a scan that did not run is not a clean tree.
+violations=""
+scan_status=0
+violations="$(grep -rnE "$PATTERN" "$SCRIPTS_DIR")" || scan_status=$?
+if [[ "$scan_status" -gt 1 ]]; then
+  echo "the portability scan over $SCRIPTS_DIR could not run (grep exited $scan_status)" >&2
+  exit 1
+fi
 if [[ -n "$violations" ]]; then
   echo "Bash 4+ constructs found in worktree scripts (must run under Bash 3.2):" >&2
   printf '%s\n' "$violations" >&2

--- a/skills/worktree/tests/bash32-portability.test.sh
+++ b/skills/worktree/tests/bash32-portability.test.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+# vacuous-suite-scan: absence-subject
 # Regression test for #575: the worktree skill must stay runnable under macOS
 # system Bash 3.2, so shipped scripts may not use Bash 4+ builtins or syntax
 # (mapfile/readarray, associative arrays, automatic FD-allocation

--- a/tools/tests/vacuous-suite-scan.test.sh
+++ b/tools/tests/vacuous-suite-scan.test.sh
@@ -131,7 +131,39 @@ else
 fi
 has "the contradicting suite is named" "CONTRADICTION liar.test.sh"
 has "the reason is the absence one, not the harness one" \
-  "failed against a blanked product, which holds nothing for it to find"
+  "declares absence-subject but failed against a blanked product"
+has "and it names the found-it reading" \
+  "it found what it forbids in a product holding nothing"
+
+echo "=== the absence reason names the refusal reading as well ==="
+# The other way a declared absence lint fails blanked: it did not find the
+# forbidden thing, it REFUSED TO RUN, because a fail-closed anchor saw the
+# emptied product. From outside the suite the two are one exit status, so the
+# reason names both rather than asserting the one it cannot check.
+S="$(new_skill refusedscan)"
+add_detecting "$S"
+cat >"$S/tests/refused.test.sh" <<'SUITE'
+#!/usr/bin/env bash
+# vacuous-suite-scan: absence-subject
+set -euo pipefail
+p="$(dirname "${BASH_SOURCE[0]}")/../scripts/thing.sh"
+if ! grep -q SHIPPED-MARKER "$p"; then
+  echo "the product is empty; this lint read nothing" >&2
+  exit 1
+fi
+if grep -q FORBIDDEN "$p"; then
+  echo "forbidden token in a shipped script" >&2
+  exit 1
+fi
+SUITE
+scan "$S"
+if [ "$RC" -ne 0 ]; then
+  ok "a declared absence suite that refuses the blanked run is reported"
+else
+  bad "a declared absence suite that refuses the blanked run is reported" "rc=0 out=$OUT"
+fi
+has "and the reason names the refusal reading" \
+  "a fail-closed check refused to run over the emptied product"
 
 echo "=== harness-subject keeps its own reason ==="
 S="$(new_skill harnesslie)"
@@ -164,7 +196,11 @@ else
   bad "a skill of only absence assertions is not a passing scan" "rc=0 out=$OUT"
 fi
 has "and it says nothing was measured" "no suite was measured"
-has "naming absence-subject among the reasons" "absence-subject"
+# The needle is text only the refusal carries. `absence-subject` on its own
+# proves nothing: the tally line above the refusal prints it as a column
+# label, so that needle matched whatever the refusal happened to say.
+has "naming absence-subject among the reasons" \
+  "all harness-subject or absence-subject"
 
 echo "=== a malformed declaration ends the run ==="
 S="$(new_skill twosubjects)"
@@ -198,6 +234,63 @@ else
 fi
 has "and the refusal lists the ones that exist" \
   "known: harness-subject, absence-subject"
+
+echo "=== a malformed declaration is read even on a suite that cannot run ==="
+# A header defect is settled by reading the header, so it must not depend on
+# the suite surviving the pristine run. The cases above all put the bad header
+# on a suite that runs; this one puts it on a suite that fails in the copy and
+# is set aside as unrunnable before any comparison.
+S="$(new_skill unrunnabletypo)"
+add_detecting "$S"
+cat >"$S/tests/brokentypo.test.sh" <<'SUITE'
+#!/usr/bin/env bash
+# vacuous-suite-scan: absense-subject
+set -euo pipefail
+echo "this suite cannot run from a copy" >&2
+exit 1
+SUITE
+scan "$S"
+if [ "$RC" -ne 0 ]; then
+  ok "the typo is refused though its suite never reached the comparison"
+else
+  bad "the typo is refused though its suite never reached the comparison" "rc=0 out=$OUT"
+fi
+has "and the refusal names the unknown subject" \
+  "declares an unknown vacuous-suite-scan subject: absense-subject"
+# The refusal comes before staging, so no tally line was printed for the skill.
+lacks "and nothing was classified first" "unrunnable-in-copy"
+
+echo "=== a declaration below the header window is not read ==="
+# suite_subject reads the first 20 lines. A declaration written past that is
+# not a category the scan honours, and the suite falls back to vacuous.
+S="$(new_skill deepdecl)"
+add_detecting "$S"
+{
+  printf '#!/usr/bin/env bash\n'
+  # Lines 2 through 20, putting the declaration on line 21 — one past the
+  # window, which is the edge the bound is worth pinning at.
+  i=0
+  while [ "$i" -lt 19 ]; do
+    printf '# padding\n'
+    i=$((i + 1))
+  done
+  printf '# vacuous-suite-scan: absence-subject\n'
+  cat <<'SUITE'
+set -euo pipefail
+if grep -q FORBIDDEN "$(dirname "${BASH_SOURCE[0]}")/../scripts/thing.sh"; then
+  echo "forbidden token in a shipped script" >&2
+  exit 1
+fi
+SUITE
+} >"$S/tests/deep.test.sh"
+if [ "$(sed -n '21p' "$S/tests/deep.test.sh")" != "# vacuous-suite-scan: absence-subject" ]; then
+  bad "the fixture puts its declaration on line 21" "$(sed -n '18,23p' "$S/tests/deep.test.sh")"
+else
+  ok "the fixture puts its declaration on line 21"
+fi
+scan "$S" --list
+has "a declaration past line 20 is not read" "vacuous          deep.test.sh"
+lacks "and it is not credited to absence-subject" "absence-subject  deep.test.sh"
 
 printf '\n%s passed, %s failed\n' "$PASS" "$FAIL"
 [ "$FAIL" -eq 0 ]

--- a/tools/tests/vacuous-suite-scan.test.sh
+++ b/tools/tests/vacuous-suite-scan.test.sh
@@ -1,0 +1,203 @@
+#!/usr/bin/env bash
+# Pins how tools/vacuous-suite-scan classifies a suite, over fixture skills
+# small enough to scan in a second.
+#
+# The scan's whole method is to blank a skill's product files and re-run each
+# suite, so what it can conclude from a blanked PASS depends on which direction
+# the suite asserts in. A presence assertion that still passes is asserting
+# nothing. An absence assertion that still passes is passing because the method
+# removed what it looks for. Those are opposite facts and the tool must not
+# report them as one, so every case below is paired: the same suite body with
+# and without its declaration, and each declaration checked against a run that
+# disproves it.
+set -euo pipefail
+
+TEST_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SCAN="$(cd "$TEST_DIR/.." && pwd)/vacuous-suite-scan"
+TMP="$(mktemp -d)"
+trap 'rm -rf -- "${TMP:?}"' EXIT
+
+PASS=0
+FAIL=0
+ok() {
+  PASS=$((PASS + 1))
+  printf '  ok    %s\n' "$1"
+}
+bad() {
+  FAIL=$((FAIL + 1))
+  printf '  FAIL  %s\n        %s\n' "$1" "${2:-}"
+}
+
+OUT=""
+RC=0
+# Errexit is on, so a refusal is captured through an `if` rather than ending
+# the suite that asked for it.
+scan() { # scan SKILL_DIR [FLAG...]
+  if OUT="$("$SCAN" "$@" 2>&1)"; then RC=0; else RC=$?; fi
+}
+
+has() { # has DESCRIPTION NEEDLE
+  case "$OUT" in
+  *"$2"*) ok "$1" ;;
+  *) bad "$1" "not in output: $2"$'\n        '"$OUT" ;;
+  esac
+}
+
+lacks() { # lacks DESCRIPTION NEEDLE
+  case "$OUT" in
+  *"$2"*) bad "$1" "found in output: $2"$'\n        '"$OUT" ;;
+  *) ok "$1" ;;
+  esac
+}
+
+# A fixture skill: one product script holding a marker, plus whichever suites
+# the case names. The product is CLEAN of the forbidden token, which is what
+# lets an absence assertion pass its pristine run.
+new_skill() { # new_skill NAME -> path on stdout
+  local d="$TMP/$1/probe"
+  mkdir -p "$d/scripts" "$d/tests"
+  printf '#!/usr/bin/env bash\necho SHIPPED-MARKER\n' >"$d/scripts/thing.sh"
+  printf '%s' "$d"
+}
+
+# Passes pristine, fails blanked: the marker is gone once the product is
+# emptied. This is what "detecting" means, and every fixture skill carries one
+# so the scan has a measurement to report.
+add_detecting() { # add_detecting SKILL_DIR
+  cat >"$1/tests/detecting.test.sh" <<'SUITE'
+#!/usr/bin/env bash
+set -euo pipefail
+grep -q SHIPPED-MARKER "$(dirname "${BASH_SOURCE[0]}")/../scripts/thing.sh"
+SUITE
+}
+
+# Passes pristine AND blanked: it fails only when a forbidden token appears,
+# and an emptied product has none. DECL is written above the body, so the same
+# assertion can be run declared and undeclared.
+add_absence() { # add_absence SKILL_DIR NAME [DECL_LINE]
+  {
+    printf '#!/usr/bin/env bash\n'
+    [ "$#" -ge 3 ] && printf '%s\n' "$3"
+    cat <<'SUITE'
+set -euo pipefail
+if grep -q FORBIDDEN "$(dirname "${BASH_SOURCE[0]}")/../scripts/thing.sh"; then
+  echo "forbidden token in a shipped script" >&2
+  exit 1
+fi
+SUITE
+  } >"$1/tests/$2.test.sh"
+}
+
+echo "=== a declared absence assertion is its own category, not vacuous ==="
+S="$(new_skill declared)"
+add_detecting "$S"
+add_absence "$S" absence '# vacuous-suite-scan: absence-subject'
+scan "$S" --list
+if [ "$RC" -eq 0 ]; then
+  ok "the scan passes over a declared absence assertion"
+else
+  bad "the scan passes over a declared absence assertion" "rc=$RC out=$OUT"
+fi
+has "it is listed under absence-subject" "absence-subject  absence.test.sh"
+lacks "it is not listed as vacuous" "vacuous          absence.test.sh"
+has "the count line carries an absence-subject column" "1 absence-subject"
+has "nothing was counted vacuous" "0 vacuous"
+
+echo "=== the control: the same assertion undeclared is still called vacuous ==="
+S="$(new_skill undeclared)"
+add_detecting "$S"
+add_absence "$S" absence
+scan "$S" --list
+has "an undeclared absence assertion is reported vacuous" "vacuous          absence.test.sh"
+has "the vacuous count sees it" "1 vacuous"
+lacks "and it is not credited to the new category" "absence-subject  absence.test.sh"
+
+echo "=== a declaration the blanked run disproves is a contradiction ==="
+# Declares absence-subject, but asserts the product is NON-empty: blanking it
+# makes the suite fail, which an absence assertion cannot do.
+S="$(new_skill contradiction)"
+add_detecting "$S"
+cat >"$S/tests/liar.test.sh" <<'SUITE'
+#!/usr/bin/env bash
+# vacuous-suite-scan: absence-subject
+set -euo pipefail
+grep -q SHIPPED-MARKER "$(dirname "${BASH_SOURCE[0]}")/../scripts/thing.sh"
+SUITE
+scan "$S"
+if [ "$RC" -ne 0 ]; then
+  ok "the scan refuses a run holding a contradiction"
+else
+  bad "the scan refuses a run holding a contradiction" "rc=0 out=$OUT"
+fi
+has "the contradicting suite is named" "CONTRADICTION liar.test.sh"
+has "the reason is the absence one, not the harness one" \
+  "failed against a blanked product, which holds nothing for it to find"
+
+echo "=== harness-subject keeps its own reason ==="
+S="$(new_skill harnesslie)"
+add_detecting "$S"
+cat >"$S/tests/harnesslie.test.sh" <<'SUITE'
+#!/usr/bin/env bash
+# vacuous-suite-scan: harness-subject
+set -euo pipefail
+grep -q SHIPPED-MARKER "$(dirname "${BASH_SOURCE[0]}")/../scripts/thing.sh"
+SUITE
+scan "$S"
+if [ "$RC" -ne 0 ]; then
+  ok "a disproved harness-subject claim still fails the run"
+else
+  bad "a disproved harness-subject claim still fails the run" "rc=0 out=$OUT"
+fi
+has "with the reason that fits harness-subject" \
+  "declares harness-subject but breaking product code reached it"
+
+echo "=== a skill of nothing but absence assertions measured nothing ==="
+# The side of the count the new category falls on, asserted rather than
+# described: were absence counted as a measurement, this run would exit 0
+# having settled no suite's vacuity at all.
+S="$(new_skill absenceonly)"
+add_absence "$S" absence '# vacuous-suite-scan: absence-subject'
+scan "$S"
+if [ "$RC" -ne 0 ]; then
+  ok "a skill of only absence assertions is not a passing scan"
+else
+  bad "a skill of only absence assertions is not a passing scan" "rc=0 out=$OUT"
+fi
+has "and it says nothing was measured" "no suite was measured"
+has "naming absence-subject among the reasons" "absence-subject"
+
+echo "=== a malformed declaration ends the run ==="
+S="$(new_skill twosubjects)"
+add_detecting "$S"
+cat >"$S/tests/two.test.sh" <<'SUITE'
+#!/usr/bin/env bash
+# vacuous-suite-scan: harness-subject
+# vacuous-suite-scan: absence-subject
+set -euo pipefail
+SUITE
+scan "$S"
+if [ "$RC" -ne 0 ]; then
+  ok "two declared subjects are refused"
+else
+  bad "two declared subjects are refused" "rc=0 out=$OUT"
+fi
+has "and the refusal names both" "declares 2 vacuous-suite-scan subjects"
+
+S="$(new_skill unknownsubject)"
+add_detecting "$S"
+cat >"$S/tests/typo.test.sh" <<'SUITE'
+#!/usr/bin/env bash
+# vacuous-suite-scan: absense-subject
+set -euo pipefail
+SUITE
+scan "$S"
+if [ "$RC" -ne 0 ]; then
+  ok "a misspelled subject is refused rather than ignored"
+else
+  bad "a misspelled subject is refused rather than ignored" "rc=0 out=$OUT"
+fi
+has "and the refusal lists the ones that exist" \
+  "known: harness-subject, absence-subject"
+
+printf '\n%s passed, %s failed\n' "$PASS" "$FAIL"
+[ "$FAIL" -eq 0 ]

--- a/tools/tests/vacuous-suite-scan.test.sh
+++ b/tools/tests/vacuous-suite-scan.test.sh
@@ -232,8 +232,54 @@ if [ "$RC" -ne 0 ]; then
 else
   bad "a misspelled subject is refused rather than ignored" "rc=0 out=$OUT"
 fi
-has "and the refusal lists the ones that exist" \
-  "known: harness-subject, absence-subject"
+has "and the refusal shows the canonical declarations" \
+  "a declaration is exactly '# vacuous-suite-scan: harness-subject'"
+
+echo "=== a declaration is read by its prefix, so a malformed payload is refused ==="
+# Each line below is one a reader would call a declaration, carrying a payload
+# outside the accepted shape. The failure being pinned is what used to happen
+# to them: the payload was matched as part of the detection, so a line that
+# missed the shape read as no declaration at all and its suite fell through to
+# vacuous with no refusal — the reverse of what the refusal is for.
+refuses_payload() { # refuses_payload NAME DECL_LINE PAYLOAD
+  local S
+  S="$(new_skill "malformed-$1")"
+  add_detecting "$S"
+  add_absence "$S" bad "$2"
+  scan "$S"
+  if [ "$RC" -ne 0 ]; then
+    ok "the $1 payload is refused"
+  else
+    bad "the $1 payload is refused" "rc=0 out=$OUT"
+  fi
+  has "and the refusal prints the $1 payload" \
+    "declares an unknown vacuous-suite-scan subject: '$3'"
+}
+
+refuses_payload underscored '# vacuous-suite-scan: absence_subject' ' absence_subject'
+refuses_payload capitalized '# vacuous-suite-scan: Absence-subject' ' Absence-subject'
+refuses_payload trailing-space '# vacuous-suite-scan: absence-subject ' ' absence-subject '
+refuses_payload empty '# vacuous-suite-scan:' ''
+
+echo "=== a well-formed declaration does not shield a malformed one ==="
+# The doubled-declaration refusal counts declarations, so it has to count the
+# malformed line too: a header whose second line is unreadable is still a
+# header claiming two subjects, not a header claiming the first one.
+S="$(new_skill goodplusbad)"
+add_detecting "$S"
+cat >"$S/tests/pair.test.sh" <<'SUITE'
+#!/usr/bin/env bash
+# vacuous-suite-scan: harness-subject
+# vacuous-suite-scan: absence_subject
+set -euo pipefail
+SUITE
+scan "$S"
+if [ "$RC" -ne 0 ]; then
+  ok "one good and one malformed declaration are refused together"
+else
+  bad "one good and one malformed declaration are refused together" "rc=0 out=$OUT"
+fi
+has "and the count sees both lines" "declares 2 vacuous-suite-scan subjects"
 
 echo "=== a malformed declaration is read even on a suite that cannot run ==="
 # A header defect is settled by reading the header, so it must not depend on
@@ -256,7 +302,7 @@ else
   bad "the typo is refused though its suite never reached the comparison" "rc=0 out=$OUT"
 fi
 has "and the refusal names the unknown subject" \
-  "declares an unknown vacuous-suite-scan subject: absense-subject"
+  "declares an unknown vacuous-suite-scan subject: ' absense-subject'"
 # The refusal comes before staging, so no tally line was printed for the skill.
 lacks "and nothing was classified first" "unrunnable-in-copy"
 

--- a/tools/vacuous-suite-scan
+++ b/tools/vacuous-suite-scan
@@ -39,6 +39,8 @@
 #
 # A suite declares at most one subject. Two declarations are a malformed
 # header rather than a category to resolve by precedence, and they end the run.
+# Every header is read before any suite is staged, so an unknown or doubled
+# declaration ends the run whether or not its suite can run from a copy.
 #
 # What is left under vacuous after those two categories is not always a suite
 # to fix. A suite whose subject does not travel with the skill — a document
@@ -198,17 +200,32 @@ suite_subject() {
 
 # Why a declared subject is contradicted by a failing blanked run. The two
 # subjects are unmeasurable for opposite reasons, so the disproof differs.
+#
+# The absence reason names BOTH readings rather than picking one, because from
+# outside the suite they are indistinguishable: a blanked run that exits
+# nonzero either found what the suite forbids in a product holding nothing, or
+# refused to run at all because a fail-closed check saw the emptied product.
+# Telling them apart would mean re-running the suite against a copy carrying
+# the forbidden thing, and the scan does not know what that thing is for an
+# arbitrary suite — it blanks product files, it does not author violations. A
+# reason that names one cause it cannot verify is the wrong-cause diagnostic
+# this tool exists to refuse; naming both is what it can actually say.
+#
+# A subject with no arm ends the run: an operator reading CONTRADICTION with a
+# blank cause learns nothing, and a subject added to suite_subject's allowlist
+# and forgotten here is exactly how that happens.
 contradiction_reason() {
     case "$1" in
     harness-subject) printf 'declares harness-subject but breaking product code reached it' ;;
-    absence-subject) printf 'declares absence-subject but failed against a blanked product, which holds nothing for it to find' ;;
+    absence-subject) printf 'declares absence-subject but failed against a blanked product: either it found what it forbids in a product holding nothing, or a fail-closed check refused to run over the emptied product' ;;
+    *) die "no contradiction reason for the subject '$1'; a subject suite_subject accepts must have an arm here" ;;
     esac
 }
 
 scan_skill() {
     local skill_dir="$1"
-    local name tmp pristine blanked suite subject measured=0
-    local -a suites=() vacuous=() unrunnable=() red=() harness=() absence=() contradicting=()
+    local name tmp pristine blanked suite subject reason measured=0 i=0
+    local -a suites=() subjects=() vacuous=() unrunnable=() red=() harness=() absence=() contradicting=()
 
     name="$(basename "$skill_dir")"
     [[ -d "$skill_dir/tests" ]] || die "$skill_dir has no tests directory"
@@ -221,6 +238,16 @@ scan_skill() {
         die "$skill_dir/tests holds no shell suites"
     fi
 
+    # Every declaration is read and judged BEFORE anything is staged or run. A
+    # header defect is a defect in text, settled by reading it, so it must not
+    # depend on the suite reaching the comparison: a suite that fails its
+    # pristine run is set aside as unrunnable, and validating inside that loop
+    # left every such suite's declaration unread. It also means a typo fails in
+    # the first second rather than after minutes of staging and running.
+    for suite in "${suites[@]}"; do
+        subjects+=("$(suite_subject "$skill_dir/tests/$suite")")
+    done
+
     tmp="$(mktemp -d)"
     SCAN_TMP="$tmp"
     trap 'rm -rf -- "${SCAN_TMP:?}"' EXIT
@@ -232,11 +259,12 @@ scan_skill() {
     git -C "$tmp/blanked" init -q -b main
 
     for suite in "${suites[@]}"; do
+        subject="${subjects[$i]}"
+        i=$((i + 1))
         if ! run_suite "$pristine/tests/$suite"; then
             unrunnable+=("$suite")
             continue
         fi
-        subject="$(suite_subject "$skill_dir/tests/$suite")"
         if run_suite "$blanked/tests/$suite"; then
             case "$subject" in
             harness-subject) harness+=("$suite") ;;
@@ -281,8 +309,13 @@ scan_skill() {
     printf '%-20s %3d suites  %3d vacuous  %3d harness-subject  %3d absence-subject  %3d detecting  %3d unrunnable-in-copy\n' \
         "$name" "${#suites[@]}" "${#vacuous[@]}" "${#harness[@]}" "${#absence[@]}" "${#red[@]}" "${#unrunnable[@]}"
 
+    # The reason is resolved into a variable first, not inlined into printf's
+    # arguments: a die inside a command substitution there ends only the
+    # subshell, printf still succeeds, and the run would carry on past a
+    # refusal. As an assignment it is errexit's to act on.
     for suite in ${contradicting[@]+"${contradicting[@]}"}; do
-        printf '    CONTRADICTION %s %s\n' "${suite#* }" "$(contradiction_reason "${suite%% *}")"
+        reason="$(contradiction_reason "${suite%% *}")"
+        printf '    CONTRADICTION %s %s\n' "${suite#* }" "$reason"
     done
 
     if [[ "$LIST_NAMES" -eq 1 ]]; then

--- a/tools/vacuous-suite-scan
+++ b/tools/vacuous-suite-scan
@@ -21,6 +21,33 @@
 # product code did reach it after all. What covers a harness suite is its own
 # must-fail control, which mutates the harness directly.
 #
+# A suite whose subject is an ABSENCE — no Bash 4 construct in a shipped
+# script, no banned citation in shipped markdown, no scratch directory left
+# behind — is unmeasurable from the other direction, and the method inverts on
+# it rather than merely missing it: blanking the product removes the very thing
+# the suite looks for, so it passes by construction and gets read as asserting
+# nothing. Such a suite declares
+#
+#     # vacuous-suite-scan: absence-subject
+#
+# in its first 20 lines and is counted under absence-subject instead. This
+# claim is checked the same way, and the check means the opposite thing: a
+# suite that declares it and then FAILS the blanked run found something in a
+# product that holds nothing, so what it asserts is not the absence it
+# declared. What covers an absence assertion is its own must-fail control,
+# which injects the forbidden thing.
+#
+# A suite declares at most one subject. Two declarations are a malformed
+# header rather than a category to resolve by precedence, and they end the run.
+#
+# What is left under vacuous after those two categories is not always a suite
+# to fix. A suite whose subject does not travel with the skill — a document
+# shipped only in the catalog repo, a live driver that opts itself out when its
+# environment is absent — reaches no assertion in either run and is correctly
+# reported vacuous here. There is nothing to declare in that case: what settles
+# such a suite is the subject arriving, not a category. Each one carries its
+# reason in its own header.
+#
 # A skill the caller NAMES must be scannable: a path that does not exist, has
 # no tests directory, or holds no shell suites is an error, because a
 # measurement was asked for and cannot be made. --all enumerates candidates
@@ -39,6 +66,16 @@
 # the copy was not measured, so a run where every suite was unrunnable is a
 # total measurement failure and says so, rather than reporting zeroes at
 # status 0 for automation to read as clean.
+#
+# unrunnable-in-copy is a property of the staging, not a verdict on the suite.
+# One skill is staged alone, so a suite that reads a sibling skill — a
+# cross-skill contract lint reaching for ../reviewer/ — finds nothing there and
+# fails the PRISTINE run, which is where a suite is disqualified before any
+# comparison. The same goes for a suite that reads the repository around the
+# skill, or installs into it. Such a suite is neither confirmed nor denied
+# here; what would settle it is staging its dependencies alongside it, which
+# this scan does not do. Read the count as "out of this method's reach", never
+# as a suite that failed.
 
 set -euo pipefail
 
@@ -138,17 +175,40 @@ run_suite() {
     "$SUITE_TIMEOUT_BIN" "$SUITE_TIMEOUT" bash "$suite_path" >/dev/null 2>&1
 }
 
-# A suite that declares the harness as its subject: this metric breaks product
-# files, and a harness suite has none, so it can neither pass nor fail on their
-# account.
-declares_harness_subject() {
-    head -n 20 "$1" | grep -q '^# vacuous-suite-scan: harness-subject$'
+# The subject a suite declares, empty when it declares none. Both known
+# subjects name something this metric cannot settle, for opposite reasons; the
+# header states which. An unknown word is a typo in a declaration nothing would
+# otherwise read, and two declarations are a header claiming two subjects —
+# both end the run rather than being silently ignored or resolved by order.
+suite_subject() {
+    local declared count
+    declared="$(head -n 20 "$1" | sed -n 's/^# vacuous-suite-scan: \([a-z][a-z-]*\)$/\1/p')"
+    if [[ -z "$declared" ]]; then
+        return 0
+    fi
+    count="$(printf '%s\n' "$declared" | grep -c .)"
+    if [[ "$count" -ne 1 ]]; then
+        die "$1 declares $count vacuous-suite-scan subjects, and a suite has one: $(printf '%s' "$declared" | tr '\n' ' ')"
+    fi
+    case "$declared" in
+    harness-subject | absence-subject) printf '%s' "$declared" ;;
+    *) die "$1 declares an unknown vacuous-suite-scan subject: $declared (known: harness-subject, absence-subject)" ;;
+    esac
+}
+
+# Why a declared subject is contradicted by a failing blanked run. The two
+# subjects are unmeasurable for opposite reasons, so the disproof differs.
+contradiction_reason() {
+    case "$1" in
+    harness-subject) printf 'declares harness-subject but breaking product code reached it' ;;
+    absence-subject) printf 'declares absence-subject but failed against a blanked product, which holds nothing for it to find' ;;
+    esac
 }
 
 scan_skill() {
     local skill_dir="$1"
-    local name tmp pristine blanked suite measured=0
-    local -a suites=() vacuous=() unrunnable=() red=() harness=() contradicting=()
+    local name tmp pristine blanked suite subject measured=0
+    local -a suites=() vacuous=() unrunnable=() red=() harness=() absence=() contradicting=()
 
     name="$(basename "$skill_dir")"
     [[ -d "$skill_dir/tests" ]] || die "$skill_dir has no tests directory"
@@ -176,14 +236,17 @@ scan_skill() {
             unrunnable+=("$suite")
             continue
         fi
+        subject="$(suite_subject "$skill_dir/tests/$suite")"
         if run_suite "$blanked/tests/$suite"; then
-            if declares_harness_subject "$skill_dir/tests/$suite"; then
-                harness+=("$suite")
-            else
-                vacuous+=("$suite")
-            fi
-        elif declares_harness_subject "$skill_dir/tests/$suite"; then
-            contradicting+=("$suite")
+            case "$subject" in
+            harness-subject) harness+=("$suite") ;;
+            absence-subject) absence+=("$suite") ;;
+            *) vacuous+=("$suite") ;;
+            esac
+        elif [[ -n "$subject" ]]; then
+            # "SUBJECT SUITE": the reason to report differs by subject, and a
+            # suite name is a basename from tests/*.sh, so the space splits.
+            contradicting+=("$subject $suite")
         else
             red+=("$suite")
         fi
@@ -201,6 +264,12 @@ scan_skill() {
     #                  reason the category exists — counting it would let a
     #                  target holding only harness suites exit 0 having
     #                  measured no vacuity at all
+    #   absence        NOT settled, for the mirror reason: breaking product
+    #                  files is what removes the thing an absence assertion
+    #                  looks for, so the blanked pass is the method's own
+    #                  doing and says nothing about the suite. Counting it
+    #                  would let a target of nothing but absence assertions
+    #                  exit 0 on measurements none of which were taken.
     #   unrunnable     NOT settled: it never reached the comparison
     #
     # Every category the loop above can assign appears in this list. Adding
@@ -209,16 +278,17 @@ scan_skill() {
     SCAN_MEASURED=$((SCAN_MEASURED + measured))
     [[ "$measured" -gt 0 ]] || SCAN_UNMEASURED="$SCAN_UNMEASURED $name"
 
-    printf '%-20s %3d suites  %3d vacuous  %3d harness-subject  %3d detecting  %3d unrunnable-in-copy\n' \
-        "$name" "${#suites[@]}" "${#vacuous[@]}" "${#harness[@]}" "${#red[@]}" "${#unrunnable[@]}"
+    printf '%-20s %3d suites  %3d vacuous  %3d harness-subject  %3d absence-subject  %3d detecting  %3d unrunnable-in-copy\n' \
+        "$name" "${#suites[@]}" "${#vacuous[@]}" "${#harness[@]}" "${#absence[@]}" "${#red[@]}" "${#unrunnable[@]}"
 
     for suite in ${contradicting[@]+"${contradicting[@]}"}; do
-        printf '    CONTRADICTION %s declares harness-subject but breaking product code reached it\n' "$suite"
+        printf '    CONTRADICTION %s %s\n' "${suite#* }" "$(contradiction_reason "${suite%% *}")"
     done
 
     if [[ "$LIST_NAMES" -eq 1 ]]; then
         for suite in ${vacuous[@]+"${vacuous[@]}"}; do printf '    vacuous          %s\n' "$suite"; done
         for suite in ${harness[@]+"${harness[@]}"}; do printf '    harness-subject  %s\n' "$suite"; done
+        for suite in ${absence[@]+"${absence[@]}"}; do printf '    absence-subject  %s\n' "$suite"; done
         for suite in ${unrunnable[@]+"${unrunnable[@]}"}; do printf '    unrunnable       %s\n' "$suite"; done
     fi
 
@@ -283,13 +353,13 @@ main() {
     # and measuring nothing are the same failure here, at the whole-run level
     # and per skill, so neither needs its own check.
     if [[ "$SCAN_MEASURED" -eq 0 || -n "$SCAN_UNMEASURED" ]]; then
-        die "no suite was measured${SCAN_UNMEASURED:+ in:$SCAN_UNMEASURED} — a scan that measured nothing is not a scan that passed. Name a skill directory or pass --all; a named one measures nothing when its suites cannot run from a copy, or are all harness-subject, which this metric cannot settle"
+        die "no suite was measured${SCAN_UNMEASURED:+ in:$SCAN_UNMEASURED} — a scan that measured nothing is not a scan that passed. Name a skill directory or pass --all; a named one measures nothing when its suites cannot run from a copy, or are all harness-subject or absence-subject, which this metric cannot settle"
     fi
 
     # A separate invariant, not a second statement of the one above: this is a
     # declaration the measurement disproved, not a measurement that failed.
     [[ "$SCAN_CONTRADICTIONS" -eq 0 ]] ||
-        die "a suite declared harness-subject that this metric did reach"
+        die "a suite's declared subject was disproved by the blanked run"
 }
 
 main "$@"

--- a/tools/vacuous-suite-scan
+++ b/tools/vacuous-suite-scan
@@ -39,8 +39,8 @@
 #
 # A suite declares at most one subject. Two declarations are a malformed
 # header rather than a category to resolve by precedence, and they end the run.
-# Every header is read before any suite is staged, so an unknown or doubled
-# declaration ends the run whether or not its suite can run from a copy.
+# An unknown or doubled declaration ends the run whether or not its suite can
+# run from a copy: a skill's headers are read before its suites are staged.
 #
 # What is left under vacuous after those two categories is not always a suite
 # to fix. A suite whose subject does not travel with the skill — a document
@@ -238,12 +238,11 @@ scan_skill() {
         die "$skill_dir/tests holds no shell suites"
     fi
 
-    # Every declaration is read and judged BEFORE anything is staged or run. A
-    # header defect is a defect in text, settled by reading it, so it must not
-    # depend on the suite reaching the comparison: a suite that fails its
-    # pristine run is set aside as unrunnable, and validating inside that loop
-    # left every such suite's declaration unread. It also means a typo fails in
-    # the first second rather than after minutes of staging and running.
+    # This skill's declarations are all read and judged BEFORE any of its
+    # suites is staged or run. A header defect is a defect in text, settled by
+    # reading it, so it must not depend on the suite reaching the comparison: a
+    # suite that fails its pristine run is set aside as unrunnable, and
+    # validating inside that loop left every such suite's declaration unread.
     for suite in "${suites[@]}"; do
         subjects+=("$(suite_subject "$skill_dir/tests/$suite")")
     done

--- a/tools/vacuous-suite-scan
+++ b/tools/vacuous-suite-scan
@@ -179,22 +179,23 @@ run_suite() {
 
 # The subject a suite declares, empty when it declares none. Both known
 # subjects name something this metric cannot settle, for opposite reasons; the
-# header states which. An unknown word is a typo in a declaration nothing would
-# otherwise read, and two declarations are a header claiming two subjects —
-# both end the run rather than being silently ignored or resolved by order.
+# header states which. A line is a declaration by its PREFIX, and its payload
+# judged after: folding the payload into the detection lets a typo outside the
+# accepted shape — an underscore, a capital, a trailing space — read as no
+# declaration at all and fall silently through to vacuous. An unknown payload
+# is refused by name, an empty one included; a malformed second declaration is
+# counted like any other and refused as a header claiming two subjects.
 suite_subject() {
     local declared count
-    declared="$(head -n 20 "$1" | sed -n 's/^# vacuous-suite-scan: \([a-z][a-z-]*\)$/\1/p')"
-    if [[ -z "$declared" ]]; then
-        return 0
-    fi
+    declared="$(head -n 20 "$1" | grep '^# vacuous-suite-scan:')" || true
+    [[ -n "$declared" ]] || return 0
     count="$(printf '%s\n' "$declared" | grep -c .)"
     if [[ "$count" -ne 1 ]]; then
         die "$1 declares $count vacuous-suite-scan subjects, and a suite has one: $(printf '%s' "$declared" | tr '\n' ' ')"
     fi
     case "$declared" in
-    harness-subject | absence-subject) printf '%s' "$declared" ;;
-    *) die "$1 declares an unknown vacuous-suite-scan subject: $declared (known: harness-subject, absence-subject)" ;;
+    "# vacuous-suite-scan: harness-subject" | "# vacuous-suite-scan: absence-subject") printf '%s' "${declared#\# vacuous-suite-scan: }" ;;
+    *) die "$1 declares an unknown vacuous-suite-scan subject: '${declared#\# vacuous-suite-scan:}' (a declaration is exactly '# vacuous-suite-scan: harness-subject' or '# vacuous-suite-scan: absence-subject')" ;;
     esac
 }
 


### PR DESCRIPTION
Closes KEN-828

`tools/vacuous-suite-scan` blanks a skill's product files and re-runs each suite; one that still passes is called vacuous. That reasoning inverts for a suite asserting something is *absent*. Blank the product and the forbidden pattern is gone, so the suite passes by construction, and the scan read that as proof it asserts nothing. It reported 17 suites across 11 skills as vacuous. Sixteen of them were absence assertions.

The proof, on one of the flagged suites: `skills/size-ratchet/tests/bash32-portability.test.sh` passes, and appending `mapfile -t arr < /dev/null` to `scripts/size-ratchet` makes it fail. It detects the regression it exists for.

## What changed

`absence-subject` joins `harness-subject` as a declared category, both read by one `suite_subject` that refuses an unknown word or a doubled declaration. It sits on the not-settled side of the measured count, so a skill of nothing but absence assertions now fails with "no suite was measured" rather than exiting 0 having settled nothing.

Thirteen suites declare `absence-subject` and two `harness-subject`. Classification was verified per suite rather than taken from the issue, and three differ from what the issue said: `growth-guards/harness-adoption` and `review-gate/review-predicate-selftest-teardown` take their subject from `tests/`, which the scan never blanks, so both are `harness-subject`; `review-gate/e2e-sandbox.sh` exits at its own `E2E_REPO` skip on both runs and is correctly reported vacuous.

Eight absence lints reported success over a product they never read. Six `bash32-portability` copies folded grep's status above 1, a scan that did not run, into status 1, nothing matched. `project-management` ran its grep under `2>/dev/null` as an `if` condition. `dev/handoff-body-file-lint` printed `all pass` over a `workflows/` with no markdown. `dep-radar/generic-engine-lint` reported a deleted `README.md` as clean. All eight now capture the scan status, refuse above 1 naming the path, and refuse when the file set they discovered is empty, in the shape `growth-guards/tests/path-captures.test.sh` already uses.

The `unrunnable-in-copy` count is recorded in the tool as a property of staging one skill alone. Those suites are cross-skill contract lints reading `../reviewer/`, which is not there when the scanner stages a skill in isolation; the scan can neither confirm nor deny them.

## Numbers

Before: 17 vacuous across 11 skills. After: 2 vacuous, 13 absence-subject, 6 harness-subject, 0 contradictions. The two remaining are `project-management/linear-loops-contract`, whose subject is a template shipped only in the catalog repo and whose own header has always said so, and `review-gate/e2e-sandbox.sh`.

A full `--all` pass takes 6m14s measured at this head, exit 0.

## Tests

`tools/tests/vacuous-suite-scan.test.sh` is new: 29 assertions over fixture skills, each declared case paired with its undeclared control. It is wired by `.github/workflows/skill-tests.yml`'s `tools/tests/*.test.sh` glob.

Three reviewers ran two cycles. Both blockers they raised were defects in this change, and both were reproduced before being fixed:

- The declaration check sat below the pristine-run guard, so a suite that failed in the copy had its header never read. A misspelled or doubled declaration on such a suite passed the whole scan at status 0, and that blind spot covered 32 suites in this repo.
- One assertion in the new suite could not fail. Its needle matched the tally line's own column label, so reverting the refusal message to its pre-diff wording left the suite green. It now asserts text only the refusal carries, and every other assertion in the file was audited against a 14-mutation battery.

Declined, with reasons: pairing the line-21 header-window fixture with a line-20 one (every real declaration in the repo sits on line 2), and adding an inject-the-forbidden-thing control to the seven declared absence suites that lack one (two reviewers independently planted the forbidden construct in all seven and every detector fired).
