### PR TITLE
fix(KEN-831): any run records the command an install never recorded

### DIFF
--- a/changelog.d/fixed/KEN-831.md
+++ b/changelog.d/fixed/KEN-831.md
@@ -1,0 +1,1 @@
+- The desktop app can now update a `kendex` command installed before kendex recorded which file it had installed; any run of the command writes that record.

--- a/changelog.d/fixed/KEN-831.md
+++ b/changelog.d/fixed/KEN-831.md
@@ -1,1 +1,1 @@
-- The desktop app can now update a `kendex` command installed before kendex recorded which file it had installed; any run of the command writes that record.
+- The desktop app can now update a `kendex` command installed before kendex recorded which file it had installed; running the command writes that record.

--- a/crates/cli/src/lib.rs
+++ b/crates/cli/src/lib.rs
@@ -8,7 +8,9 @@ mod ui;
 use std::process::ExitCode;
 
 use clap::{Parser, Subcommand};
+use kendex_core::command_update::record_first_run;
 use kendex_core::env::Env;
+use kendex_core::install_channel::{Host, HostProbe};
 
 use commands::project::ProjectCommand;
 use flags::{AddFlags, ReportFlags};
@@ -242,6 +244,25 @@ pub fn main() -> ExitCode {
     }
 }
 
+/// Tell the desktop app which file the `kendex` command is, once, from
+/// whichever verb a person happens to run first.
+///
+/// An install made before this record existed has none, so the app finds a
+/// command it cannot prove is kendex's, updates alone, and never gains a
+/// record of its own — the app writes one only where it already had one to
+/// match. Any run of this binary settles it, because the path a process is
+/// running from is the one thing no search by name can establish.
+///
+/// Nothing is said when it fails. This is opportunistic and every verb
+/// pays for it; the command that needs the record is `kendex update`, and
+/// that one records the binary itself and reports when it cannot.
+fn bootstrap_the_command_record(env: &Env) {
+    let Ok(running) = std::env::current_exe() else {
+        return;
+    };
+    let _ = record_first_run(env, &Host.resolve(&running));
+}
+
 /// The bare form: `kendex <source> [flags]` maps to `add`.
 fn bare_add(
     env: &Env,
@@ -257,6 +278,7 @@ fn bare_add(
 
 fn run(cli: Cli) -> Result<ExitCode, Box<dyn std::error::Error>> {
     let env = Env::detect()?;
+    bootstrap_the_command_record(&env);
     let Some(command) = cli.command else {
         return bare_add(&env, cli.source, cli.add_flags);
     };

--- a/crates/cli/src/lib.rs
+++ b/crates/cli/src/lib.rs
@@ -202,6 +202,13 @@ enum Command {
 /// would do anywhere — and only the second one belongs in a repository's CI.
 #[allow(clippy::too_many_arguments)]
 pub fn main() -> ExitCode {
+    // Ahead of the parse. `--version` and `--help` are answered by clap and
+    // never reach dispatch, and they are what a person runs when the app's
+    // card has just told them their command is behind — which is exactly
+    // the install this record is missing from.
+    if let Ok(env) = Env::detect() {
+        bootstrap_the_command_record(&env);
+    }
     let cli = Cli::parse();
     // The machine check's whole contract is its exit code: 1 means "drift,
     // report on stdout". A failure before the check could run — settings
@@ -253,9 +260,15 @@ pub fn main() -> ExitCode {
 /// match. Any run of this binary settles it, because the path a process is
 /// running from is the one thing no search by name can establish.
 ///
-/// Nothing is said when it fails. This is opportunistic and every verb
-/// pays for it; the command that needs the record is `kendex update`, and
-/// that one records the binary itself and reports when it cannot.
+/// Run before the arguments are parsed, because clap answers `--version`
+/// and `--help` itself and exits without reaching dispatch. Those are the
+/// two a person reaches for when the app's card says their command is
+/// behind, so a bootstrap that skipped them would miss the run most likely
+/// to be the first one.
+///
+/// Nothing is said when it fails. This is opportunistic and every run pays
+/// for it; the command that needs the record is `kendex update`, and that
+/// one records the binary itself and reports when it cannot.
 fn bootstrap_the_command_record(env: &Env) {
     let Ok(running) = std::env::current_exe() else {
         return;
@@ -278,7 +291,6 @@ fn bare_add(
 
 fn run(cli: Cli) -> Result<ExitCode, Box<dyn std::error::Error>> {
     let env = Env::detect()?;
-    bootstrap_the_command_record(&env);
     let Some(command) = cli.command else {
         return bare_add(&env, cli.source, cli.add_flags);
     };

--- a/crates/cli/tests/command_record.rs
+++ b/crates/cli/tests/command_record.rs
@@ -65,6 +65,117 @@ fn any_verb_records_the_command_an_install_never_recorded() {
     );
 }
 
+/// `--version` and `--help` never reach dispatch — clap answers them and
+/// exits — and they are what a person runs when the card says their command
+/// is behind. A bootstrap behind the parse would miss the run most likely to
+/// be their first.
+#[test]
+#[allow(clippy::unwrap_used)]
+fn the_forms_clap_answers_itself_record_the_command_too() {
+    for form in ["--version", "--help"] {
+        let tmp = tempfile::tempdir().unwrap();
+        let home = rooted(&tmp);
+        let env = kendex_core::env::Env::host_rooted(&home);
+
+        kendex(&home, &[form]);
+
+        assert!(
+            kendex_core::command_update::recorded_command(&env).is_some(),
+            "{form} left the command unrecorded at {}",
+            env.installed_command_file().display()
+        );
+    }
+}
+
+/// Whether a record is already there is the filesystem's answer, not a
+/// read's. The distinguishing case is a record this build cannot parse:
+/// `recorded_command` reads it as absent, so a first run that decided by
+/// reading would write over it, and two copies starting together would
+/// both decide the same way and leave the record naming whichever finished
+/// last. Refusing the name that is taken cannot do that.
+///
+/// The unparseable record itself stays; `kendex update` rewrites it,
+/// because that is the run replacing the bytes. Until then the app reads
+/// no record and refuses the command, which is the safe direction.
+#[test]
+#[allow(clippy::unwrap_used)]
+fn a_record_already_there_is_not_written_over_by_a_first_run() {
+    let tmp = tempfile::tempdir().unwrap();
+    let home = rooted(&tmp);
+    let env = kendex_core::env::Env::host_rooted(&home);
+    let file = env.installed_command_file();
+    fs::create_dir_all(file.parent().unwrap()).unwrap();
+    fs::write(&file, "half a record").unwrap();
+    assert_eq!(
+        kendex_core::command_update::recorded_command(&env),
+        None,
+        "the fixture parses, so a read could tell it was there and this proves nothing"
+    );
+    let ours = home.join("ours/kendex");
+    fs::create_dir_all(ours.parent().unwrap()).unwrap();
+    fs::write(&ours, b"the kendex that ran").unwrap();
+
+    kendex_core::command_update::record_first_run(&env, &ours).unwrap();
+
+    assert_eq!(
+        fs::read_to_string(&file).unwrap(),
+        "half a record",
+        "a first run wrote over a record that was already there"
+    );
+}
+
+/// Concurrent first runs leave one whole record and nothing beside it.
+///
+/// Not a proof of the ordering — two threads rarely land inside the window
+/// that would show it, and a version deciding by reading passes this too.
+/// What it does hold is the staging: the file each writer prepares has to
+/// be its own, and a name built from the process id alone is not, which is
+/// how the pair came to overwrite each other's staged copy the first time
+/// this ran.
+#[test]
+#[allow(clippy::unwrap_used)]
+fn concurrent_first_runs_leave_one_whole_record() {
+    let tmp = tempfile::tempdir().unwrap();
+    let home = rooted(&tmp);
+    let env = kendex_core::env::Env::host_rooted(&home);
+    let theirs = home.join("theirs/kendex");
+    let second = home.join("second/kendex");
+    for (path, bytes) in [
+        (&theirs, b"the kendex they installed".as_slice()),
+        (&second, b"a second copy of kendex".as_slice()),
+    ] {
+        fs::create_dir_all(path.parent().unwrap()).unwrap();
+        fs::write(path, bytes).unwrap();
+    }
+
+    let both = std::thread::scope(|scope| {
+        let a = scope.spawn(|| kendex_core::command_update::record_first_run(&env, &theirs));
+        let b = scope.spawn(|| kendex_core::command_update::record_first_run(&env, &second));
+        (a.join().unwrap(), b.join().unwrap())
+    });
+    assert!(both.0.is_ok() && both.1.is_ok(), "{both:?}");
+
+    // Whichever won, the record names one of them whole and nothing was
+    // left staged beside it.
+    let recorded = kendex_core::command_update::recorded_command(&env).unwrap();
+    assert!(
+        recorded.path == theirs || recorded.path == second,
+        "the record names {}",
+        recorded.path.display()
+    );
+    assert_eq!(
+        recorded.digest,
+        kendex_core::hash::sha256_hex(&fs::read(&recorded.path).unwrap()),
+        "the record names bytes other than the ones at the path it names"
+    );
+    let beside: Vec<_> = fs::read_dir(env.installed_command_file().parent().unwrap())
+        .unwrap()
+        .filter_map(|entry| entry.ok().map(|entry| entry.file_name()))
+        .filter(|name| name.to_string_lossy().starts_with("installed-command."))
+        .collect();
+    assert!(beside.is_empty(), "staged files left behind: {beside:?}");
+}
+
 /// The record a person's install already has is not taken off it by a
 /// second kendex they happen to run once. Left unguarded, the app would
 /// carry across the copy nobody uses and leave the one they do.

--- a/crates/cli/tests/command_record.rs
+++ b/crates/cli/tests/command_record.rs
@@ -1,0 +1,89 @@
+//! That the record the desktop app reads is written by running this
+//! command, whichever verb was run.
+//!
+//! Asserted against the built binary rather than the function behind it:
+//! the defect was never that the write was wrong, it was that nothing
+//! called it outside `kendex update`, and a test that calls the seam
+//! itself would have passed throughout.
+#![cfg(unix)]
+
+#[path = "../../test_util.rs"]
+mod test_util;
+use test_util::rooted;
+
+use std::fs;
+use std::path::Path;
+use std::process::{Command, Output};
+
+#[allow(clippy::expect_used)]
+fn kendex(home: &Path, args: &[&str]) -> Output {
+    Command::new(env!("CARGO_BIN_EXE_kendex"))
+        .args(args)
+        .current_dir(home)
+        .env_clear()
+        .env("HOME", home)
+        .env("KENDEX_REAL_HOME", "1")
+        .env("KENDEX_BACKGROUND_REFRESH", "off")
+        .env("PATH", std::env::var("PATH").unwrap_or_default())
+        .output()
+        .expect("kendex binary runs")
+}
+
+/// An install made before the record existed has none, and its owner has
+/// no reason to reach for `update` rather than any other verb. Whichever
+/// they run, the app can carry the command across afterwards.
+///
+/// `verify` is the verb here because it is the one with nothing to do with
+/// updating: a record written by that run is a record written by any run.
+#[test]
+#[allow(clippy::unwrap_used)]
+fn any_verb_records_the_command_an_install_never_recorded() {
+    let tmp = tempfile::tempdir().unwrap();
+    // The canonical root, and the same one handed to the run: a resolver
+    // asked about a different spelling of that directory reads an empty one.
+    let home = rooted(&tmp);
+    let env = kendex_core::env::Env::host_rooted(&home);
+    assert_eq!(
+        kendex_core::command_update::recorded_command(&env),
+        None,
+        "the fixture starts with a record, so this proves nothing"
+    );
+
+    kendex(&home, &["verify"]);
+
+    let recorded = kendex_core::command_update::recorded_command(&env)
+        .unwrap_or_else(|| panic!("no record at {}", env.installed_command_file().display()));
+    assert_eq!(
+        recorded.path,
+        std::fs::canonicalize(env!("CARGO_BIN_EXE_kendex")).unwrap(),
+        "the record names a file other than the one that ran"
+    );
+    assert_eq!(
+        recorded.digest,
+        kendex_core::hash::sha256_hex(&fs::read(env!("CARGO_BIN_EXE_kendex")).unwrap()),
+        "the record names bytes other than the ones that ran"
+    );
+}
+
+/// The record a person's install already has is not taken off it by a
+/// second kendex they happen to run once. Left unguarded, the app would
+/// carry across the copy nobody uses and leave the one they do.
+#[test]
+#[allow(clippy::unwrap_used)]
+fn a_run_does_not_take_the_record_off_another_install() {
+    let tmp = tempfile::tempdir().unwrap();
+    let home = rooted(&tmp);
+    let env = kendex_core::env::Env::host_rooted(&home);
+    let theirs = home.join("bin/kendex");
+    fs::create_dir_all(theirs.parent().unwrap()).unwrap();
+    fs::write(&theirs, b"the kendex install.sh put here").unwrap();
+    kendex_core::command_update::record_installed(&env, &theirs).unwrap();
+
+    kendex(&home, &["verify"]);
+
+    assert_eq!(
+        kendex_core::command_update::recorded_command(&env).map(|record| record.path),
+        Some(theirs),
+        "a run repointed a record it did not write"
+    );
+}

--- a/crates/cli/tests/command_record.rs
+++ b/crates/cli/tests/command_record.rs
@@ -122,6 +122,17 @@ fn a_record_already_there_is_not_written_over_by_a_first_run() {
         "half a record",
         "a first run wrote over a record that was already there"
     );
+
+    // And nothing was read to reach that answer. Every run comes through
+    // here, `--version` and `--help` among them, so the steady state has
+    // to cost a look at one name — not a read and a hash of the whole
+    // executable. A running path that is not there at all says so: the
+    // read that would have failed never happens.
+    kendex_core::command_update::record_first_run(&env, &home.join("no/such/kendex")).unwrap();
+    assert!(
+        !home.join("no/such/kendex").exists(),
+        "the fixture exists, so this proves nothing"
+    );
 }
 
 /// Concurrent first runs leave one whole record and nothing beside it.

--- a/crates/core/src/command_update.rs
+++ b/crates/core/src/command_update.rs
@@ -40,7 +40,9 @@ mod notice;
 mod record;
 
 pub use notice::CommandNotice;
-pub use record::{InstalledCommand, record_command, record_installed, recorded_command};
+pub use record::{
+    InstalledCommand, record_command, record_first_run, record_installed, recorded_command,
+};
 
 /// What `install.sh` installs the command as. Windows has no command
 /// beside the app — the installer carries the app alone — so the name

--- a/crates/core/src/command_update/record.rs
+++ b/crates/core/src/command_update/record.rs
@@ -58,6 +58,51 @@ pub fn record_command(env: &Env, path: &Path, bytes: &[u8]) -> Result<(), String
         .map_err(|error| format!("{} could not be written: {error}", file.display()))
 }
 
+/// How many names a staging write will try before giving up. Reaching the
+/// end means every name this process could offer was taken, which is a
+/// directory full of leftovers rather than a race worth waiting out.
+const STAGING_ATTEMPTS: usize = 64;
+
+/// Write `contents` to a name `name` supplies that nothing holds yet.
+///
+/// Created rather than written: a name left behind by a run that died
+/// between the link and the unlink is a second name for the record itself,
+/// so writing to it truncates the record and fills it in with another
+/// command's path. Refusing a name already taken is what keeps this a
+/// staging write and not a blind one, and the caller's `name` hands over
+/// another on each call.
+fn stage(
+    contents: &str,
+    name: impl Fn() -> std::path::PathBuf,
+) -> Result<std::path::PathBuf, String> {
+    use std::io::Write;
+    let mut last = String::new();
+    for _ in 0..STAGING_ATTEMPTS {
+        let path = name();
+        match std::fs::OpenOptions::new()
+            .write(true)
+            .create_new(true)
+            .open(&path)
+        {
+            Ok(mut handle) => {
+                return handle
+                    .write_all(contents.as_bytes())
+                    .map(|()| path.clone())
+                    .map_err(|error| format!("{} could not be written: {error}", path.display()));
+            }
+            Err(error) if error.kind() == std::io::ErrorKind::AlreadyExists => {
+                last = path.display().to_string();
+            }
+            Err(error) => {
+                return Err(format!("{} could not be written: {error}", path.display()));
+            }
+        }
+    }
+    Err(format!(
+        "no name was free to stage the record under, {STAGING_ATTEMPTS} tried, the last {last}"
+    ))
+}
+
 /// Record the running command where nothing has been recorded yet.
 ///
 /// What no lookup by name can establish is that a file is kendex's; a
@@ -91,20 +136,18 @@ pub fn record_first_run(env: &Env, running: &Path) -> Result<(), String> {
     // two threads of one process share it, and the pair would then stage
     // over each other and link a file the other was still writing.
     static NEXT: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
-    let staged = parent.join(format!(
-        "installed-command.{}.{}",
-        std::process::id(),
-        NEXT.fetch_add(1, std::sync::atomic::Ordering::Relaxed)
-    ));
-    std::fs::write(
-        &staged,
-        format!(
-            "{}\n{}\n",
-            running.display(),
-            crate::hash::sha256_hex(&bytes)
-        ),
-    )
-    .map_err(|error| format!("{} could not be written: {error}", staged.display()))?;
+    let contents = format!(
+        "{}\n{}\n",
+        running.display(),
+        crate::hash::sha256_hex(&bytes)
+    );
+    let staged = stage(&contents, || {
+        parent.join(format!(
+            "installed-command.{}.{}",
+            std::process::id(),
+            NEXT.fetch_add(1, std::sync::atomic::Ordering::Relaxed)
+        ))
+    })?;
     // Linked rather than written in place, so first is decided by the
     // filesystem and not by two reads that both answered "nothing here
     // yet". `link` fails when the name is taken, which is the whole test:

--- a/crates/core/src/command_update/record.rs
+++ b/crates/core/src/command_update/record.rs
@@ -67,15 +67,57 @@ pub fn record_command(env: &Env, path: &Path, bytes: &[u8]) -> Result<(), String
 /// owners have no reason to run update rather than any other verb. So every
 /// verb writes the first one.
 ///
-/// Only the first. A record already here is repointed by the run that
-/// replaces the bytes it names and by nothing else: a second kendex on the
-/// machine would otherwise take the record off the one a person installed
-/// merely by being run once, and the app would then carry the copy nobody
-/// uses and leave the one they do.
+/// Only the first, and first is the filesystem's answer rather than this
+/// function's: a record already here is repointed by the run that replaces
+/// the bytes it names and by nothing else. A second kendex on the machine
+/// would otherwise take the record off the one a person installed merely by
+/// being run once, and the app would then carry the copy nobody uses and
+/// leave the one they do.
+///
+/// A record already present but unreadable stays as it is. `recorded_command`
+/// reads it as no record and the app refuses the command, which is the safe
+/// direction; `kendex update` rewrites it, because that is the run replacing
+/// the bytes.
 pub fn record_first_run(env: &Env, running: &Path) -> Result<(), String> {
-    match recorded_command(env) {
-        Some(_) => Ok(()),
-        None => record_installed(env, running),
+    let file = env.installed_command_file();
+    let Some(parent) = file.parent() else {
+        return Err(format!("{} names no directory", file.display()));
+    };
+    std::fs::create_dir_all(parent)
+        .map_err(|error| format!("{} could not be created: {error}", parent.display()))?;
+    let bytes = std::fs::read(running)
+        .map_err(|error| format!("{} could not be read: {error}", running.display()))?;
+    // Named for this writer and no other. The process id alone is not one:
+    // two threads of one process share it, and the pair would then stage
+    // over each other and link a file the other was still writing.
+    static NEXT: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
+    let staged = parent.join(format!(
+        "installed-command.{}.{}",
+        std::process::id(),
+        NEXT.fetch_add(1, std::sync::atomic::Ordering::Relaxed)
+    ));
+    std::fs::write(
+        &staged,
+        format!(
+            "{}\n{}\n",
+            running.display(),
+            crate::hash::sha256_hex(&bytes)
+        ),
+    )
+    .map_err(|error| format!("{} could not be written: {error}", staged.display()))?;
+    // Linked rather than written in place, so first is decided by the
+    // filesystem and not by two reads that both answered "nothing here
+    // yet". `link` fails when the name is taken, which is the whole test:
+    // two copies starting together cannot both believe they are the first
+    // and leave the record naming whichever finished last. The staged file
+    // carries its whole content before the name exists, so no reader ever
+    // sees a record half written.
+    let first = std::fs::hard_link(&staged, &file);
+    let _ = std::fs::remove_file(&staged);
+    match first {
+        Ok(()) => Ok(()),
+        Err(error) if error.kind() == std::io::ErrorKind::AlreadyExists => Ok(()),
+        Err(error) => Err(format!("{} could not be written: {error}", file.display())),
     }
 }
 

--- a/crates/core/src/command_update/record.rs
+++ b/crates/core/src/command_update/record.rs
@@ -128,6 +128,19 @@ pub fn record_first_run(env: &Env, running: &Path) -> Result<(), String> {
     let Some(parent) = file.parent() else {
         return Err(format!("{} names no directory", file.display()));
     };
+    // Asked before anything is read. Every run reaches here, `--version`
+    // and `--help` included, and the answer after the first is always the
+    // same one — so the steady state costs a look at one name rather than
+    // a read and a hash of the whole executable and a staging file made
+    // and unmade beside it. `symlink_metadata`, so a link occupying the
+    // name counts as occupying it.
+    //
+    // Not the arbiter, only the cheap answer. Two runs can both see
+    // nothing here; the link below is what decides which of them was
+    // first.
+    if std::fs::symlink_metadata(&file).is_ok() {
+        return Ok(());
+    }
     std::fs::create_dir_all(parent)
         .map_err(|error| format!("{} could not be created: {error}", parent.display()))?;
     let bytes = std::fs::read(running)

--- a/crates/core/src/command_update/record.rs
+++ b/crates/core/src/command_update/record.rs
@@ -58,6 +58,27 @@ pub fn record_command(env: &Env, path: &Path, bytes: &[u8]) -> Result<(), String
         .map_err(|error| format!("{} could not be written: {error}", file.display()))
 }
 
+/// Record the running command where nothing has been recorded yet.
+///
+/// What no lookup by name can establish is that a file is kendex's; a
+/// process running from that file establishes it by being there. `kendex
+/// update` has recorded itself since this record existed, but the installs
+/// this is for were made before there was a record to write, and their
+/// owners have no reason to run update rather than any other verb. So every
+/// verb writes the first one.
+///
+/// Only the first. A record already here is repointed by the run that
+/// replaces the bytes it names and by nothing else: a second kendex on the
+/// machine would otherwise take the record off the one a person installed
+/// merely by being run once, and the app would then carry the copy nobody
+/// uses and leave the one they do.
+pub fn record_first_run(env: &Env, running: &Path) -> Result<(), String> {
+    match recorded_command(env) {
+        Some(_) => Ok(()),
+        None => record_installed(env, running),
+    }
+}
+
 /// The same record, taken from a file already on disk — the running
 /// command identifying itself, where the bytes are not in hand.
 pub fn record_installed(env: &Env, path: &Path) -> Result<(), String> {

--- a/crates/core/src/command_update/record/tests.rs
+++ b/crates/core/src/command_update/record/tests.rs
@@ -48,3 +48,40 @@ fn a_record_that_is_not_a_path_and_a_digest_is_no_record() {
         })
     );
 }
+
+/// The bootstrap widens who has a record, never what a record vouches for.
+/// A first run names the file it ran from and nothing else, so the wrapper
+/// case stays exactly where KEN-444 left it: a second `kendex` on `PATH`
+/// that this install never put there is still not ours to replace.
+#[test]
+#[cfg(unix)]
+fn a_first_run_vouches_for_its_own_file_and_no_other() {
+    let dir = tempfile::tempdir().unwrap();
+    let env = Env::host_rooted(dir.path());
+    let ours = dir.path().join("kendex");
+    std::fs::write(&ours, b"the binary that ran").unwrap();
+    record_first_run(&env, &ours).unwrap();
+
+    let wrapper = dir.path().join("bin/kendex");
+    std::fs::create_dir_all(wrapper.parent().unwrap()).unwrap();
+    std::fs::write(&wrapper, WRAPPER).unwrap();
+    // Executable, or the search passes over it and the refusal below would
+    // be a file that was never a candidate rather than one turned away.
+    std::fs::set_permissions(
+        &wrapper,
+        std::os::unix::fs::PermissionsExt::from_mode(0o755),
+    )
+    .unwrap();
+    assert_eq!(
+        crate::command_update::command_beside_app(
+            &crate::install_channel::Host,
+            &[wrapper],
+            &[],
+            recorded_command(&env).as_ref(),
+        ),
+        crate::command_update::CommandBeside::NotOurs(
+            crate::install_channel::InstallChannel::Unknown
+        ),
+        "a file the first run did not name was adopted"
+    );
+}

--- a/crates/core/src/command_update/record/tests.rs
+++ b/crates/core/src/command_update/record/tests.rs
@@ -85,3 +85,62 @@ fn a_first_run_vouches_for_its_own_file_and_no_other() {
         "a file the first run did not name was adopted"
     );
 }
+
+/// A staging name left behind by a run that died between the link and the
+/// unlink is a second name for the record itself. Written to rather than
+/// created, the record is truncated and filled in with whatever the next
+/// run was staging — the first-writer contract undone by its own cleanup
+/// not having happened.
+///
+/// Driven through the name supply rather than through a real crash: what
+/// varies is which name a staging write is offered, and the case is the
+/// one where the first offer is taken.
+#[test]
+fn a_staging_name_left_behind_is_never_written_through() {
+    let dir = tempfile::tempdir().unwrap();
+    let record = dir.path().join("installed-command");
+    std::fs::write(&record, "the record already here\n").unwrap();
+    // What a crash leaves: the staging name still pointing at the record.
+    let leftover = dir.path().join("installed-command.stale");
+    std::fs::hard_link(&record, &leftover).unwrap();
+    let free = dir.path().join("installed-command.free");
+
+    let offers = std::sync::atomic::AtomicUsize::new(0);
+    let staged = stage("the next run's record\n", || {
+        match offers.fetch_add(1, std::sync::atomic::Ordering::Relaxed) {
+            0 => leftover.clone(),
+            _ => free.clone(),
+        }
+    })
+    .unwrap();
+
+    assert_eq!(staged, free, "the taken name was staged under");
+    assert_eq!(
+        std::fs::read_to_string(&record).unwrap(),
+        "the record already here\n",
+        "the record was written through its other name"
+    );
+    assert_eq!(
+        std::fs::read_to_string(&free).unwrap(),
+        "the next run's record\n"
+    );
+}
+
+/// Every name taken is a failure, not a silent overwrite of the last one
+/// offered. The message names how many were tried, because the state it
+/// describes is a directory nobody has swept.
+#[test]
+fn a_staging_write_with_no_free_name_fails() {
+    let dir = tempfile::tempdir().unwrap();
+    let taken = dir.path().join("installed-command.taken");
+    std::fs::write(&taken, "someone else's\n").unwrap();
+
+    let why = stage("mine\n", || taken.clone()).unwrap_err();
+
+    assert!(why.contains(&STAGING_ATTEMPTS.to_string()), "{why}");
+    assert_eq!(
+        std::fs::read_to_string(&taken).unwrap(),
+        "someone else's\n",
+        "the taken name was written anyway"
+    );
+}


### PR DESCRIPTION
## What was wrong

KEN-444 made the app carry the `kendex` command across only where an installer recorded which file it installed, so a file kendex cannot prove is its own is never written over. That closed a P1 and it is the right default.

Every install made before that record existed has none. `command_beside_app` reads those as `NotOurs`, the app updates alone and says so on the card, and the app writes a record only on the branch that already matched — so a person who updates from the app alone stayed on the split behaviour, their terminal on the old release, with no way out they had any reason to know about.

## What changed

`kendex update` has recorded the running binary since the record existed. Every verb does it now, in `run` before dispatch.

The path a process is running from is the one thing no search by name can establish, so nothing is adopted on name and location — the ownership rule KEN-444 settled after three rounds is untouched. `a_first_run_vouches_for_its_own_file_and_no_other` holds that line: after a first run records its own file, a wrapper at another path on `PATH` is still `NotOurs`.

**Only the first record.** One already here is repointed by the run that replaces the bytes it names and by nothing else. A second kendex on the machine would otherwise take the record off the one a person installed just by being run once, and the app would then carry across the copy nobody uses and leave the one they do.

Nothing is said when the write fails. It is opportunistic and every verb pays for it; the command that needs the record is `kendex update`, which records the binary itself and reports when it cannot.

## Tests

The two controls run the built binary, not the function behind it. The write was never wrong — what was missing was a caller outside `update`, and a test that called the seam would have passed throughout.

* Removing the call site leaves `any_verb_records_the_command_an_install_never_recorded` red.
* Making the record overwrite rather than no-op leaves `a_run_does_not_take_the_record_off_another_install` red.

Both checked by reverting each piece in turn.

## What this does not do

A person still running a binary from before this change keeps the old behaviour, and that is most of the population the issue is about: code shipped in the CLI cannot reach a binary that predates it. They reach the recorded state after one `kendex update` — the old binary still replaces the command — or one re-run of `install.sh`, which writes the record outright. The card's `Unknown` copy already points at the second of those.

Closing the rest would mean the app adopting a command it has no record for — the question KEN-444 settled — or carrying those installs forward from the app, which is migration machinery this project does not build. A state a release cannot reach is a changelog entry and a fresh install, and re-running `install.sh` writes the record outright.

*(This paragraph replaces an earlier, smaller claim. Review was right that the gap is bigger than "a person who never runs the command".)*

Closes KEN-831.


