### PR TITLE
fix(KEN-857): a checkout records the rules that made it, and an older one is rebuilt

### DIFF
--- a/changelog.d/fixed/ken-857.md
+++ b/changelog.d/fixed/ken-857.md
@@ -1,0 +1,3 @@
+- A catalog checked out before the line-ending fix is rebuilt after you
+  upgrade, so the fix reaches what your cache already holds and not only what
+  you download next.

--- a/crates/core/src/remote/store.rs
+++ b/crates/core/src/remote/store.rs
@@ -69,7 +69,7 @@ pub fn checkout_dir(env: &Env, key: &str, commit: &str) -> PathBuf {
     env.source_cache_dir().join(COMMITS).join(key).join(commit)
 }
 
-fn receipt_path(env: &Env, key: &str, commit: &str) -> PathBuf {
+pub(super) fn receipt_path(env: &Env, key: &str, commit: &str) -> PathBuf {
     env.source_cache_dir()
         .join(COMMITS)
         .join(key)
@@ -241,15 +241,24 @@ pub fn has_commit(mirror: &Path, commit: &str) -> bool {
         .is_ok_and(|output| output.status.success())
 }
 
-/// A published checkout, if the cache holds this commit unmodified. A
-/// mismatch is not an error: the caller re-materializes from the mirror.
+/// The materialization rules a receipt vouches for, beside the signature.
+/// A signature alone says the bytes are the ones that were written, never
+/// that they are the ones `check_out` writes now. The number rises
+/// whenever `check_out` changes what it writes for a commit.
+const RECEIPT_RULES: &str = "kendex-checkout 1";
+
+/// A published checkout, if the cache holds this commit unmodified under
+/// today's materialization rules. A mismatch is not an error, an
+/// unreadable or unrecognized receipt included: the caller re-materializes
+/// from the mirror.
 pub fn published(env: &Env, key: &str, commit: &str) -> Option<PathBuf> {
     let dir = checkout_dir(env, key, commit);
     if !dir.is_dir() {
         return None;
     }
     let recorded = fs::read_to_string(receipt_path(env, key, commit)).ok()?;
-    (recorded.trim() == tree_signature(&dir).ok()?).then_some(dir)
+    let (rules, signature) = recorded.split_once('\n')?;
+    (rules == RECEIPT_RULES && signature.trim() == tree_signature(&dir).ok()?).then_some(dir)
 }
 
 /// Materialize a commit and publish it atomically. The checkout is built in
@@ -267,7 +276,10 @@ pub fn publish(env: &Env, key: &str, mirror: &Path, commit: &str) -> Result<Path
         // The receipt lands first: a reader that sees the directory always
         // finds the receipt that vouches for it. A receipt with no
         // directory is inert — nothing reads one without the other.
-        atomic_write(&receipt_path(env, key, commit), &tree_signature(&staging)?)
+        atomic_write(
+            &receipt_path(env, key, commit),
+            &format!("{RECEIPT_RULES}\n{}\n", tree_signature(&staging)?),
+        )
     });
     if let Err(error) = result {
         let _ = fs::remove_dir_all(&staging);

--- a/crates/core/src/remote/store.rs
+++ b/crates/core/src/remote/store.rs
@@ -265,7 +265,17 @@ pub fn published(env: &Env, key: &str, commit: &str) -> Option<PathBuf> {
 /// a staging sibling and renamed into place, so an interrupted or failed
 /// publish leaves no directory anyone could read: not a partial one, and
 /// not the one it was replacing.
+///
+/// Every caller holds this repository's cache lock across the call, and
+/// this takes none of its own: an OS lock belongs to the open file
+/// description, so taking one here would report the caller's own as busy.
 pub fn publish(env: &Env, key: &str, mirror: &Path, commit: &str) -> Result<PathBuf> {
+    // Callers test `published` before taking the lock, so the commit can
+    // arrive while this one waits. Publishing over it would move a
+    // directory out from under whoever the first publisher handed it to.
+    if let Some(dir) = published(env, key, commit) {
+        return Ok(dir);
+    }
     let dir = checkout_dir(env, key, commit);
     let parent = dir.parent().unwrap_or(&dir).to_path_buf();
     fs::create_dir_all(&parent).map_err(|e| CoreError::io(&parent, e))?;

--- a/crates/core/src/remote/store.rs
+++ b/crates/core/src/remote/store.rs
@@ -263,7 +263,8 @@ pub fn published(env: &Env, key: &str, commit: &str) -> Option<PathBuf> {
 
 /// Materialize a commit and publish it atomically. The checkout is built in
 /// a staging sibling and renamed into place, so an interrupted or failed
-/// checkout leaves no partial directory anyone could read.
+/// publish leaves no directory anyone could read: not a partial one, and
+/// not the one it was replacing.
 pub fn publish(env: &Env, key: &str, mirror: &Path, commit: &str) -> Result<PathBuf> {
     let dir = checkout_dir(env, key, commit);
     let parent = dir.parent().unwrap_or(&dir).to_path_buf();
@@ -272,23 +273,30 @@ pub fn publish(env: &Env, key: &str, mirror: &Path, commit: &str) -> Result<Path
     if staging.exists() {
         fs::remove_dir_all(&staging).map_err(|e| CoreError::io(&staging, e))?;
     }
-    let result = check_out(&staging, mirror, commit).and_then(|()| {
-        // The receipt lands first: a reader that sees the directory always
-        // finds the receipt that vouches for it. A receipt with no
-        // directory is inert — nothing reads one without the other.
-        atomic_write(
-            &receipt_path(env, key, commit),
-            &format!("{RECEIPT_RULES}\n{}\n", tree_signature(&staging)?),
-        )
-    });
-    if let Err(error) = result {
-        let _ = fs::remove_dir_all(&staging);
-        return Err(error);
-    }
     let replaced = parent.join(format!(".replaced-{}", std::process::id()));
     let _ = fs::remove_dir_all(&replaced);
-    if dir.exists() {
-        fs::rename(&dir, &replaced).map_err(|e| CoreError::io(&dir, e))?;
+    // Two trees of one commit can share a signature, so the order is what
+    // keeps a receipt from vouching for the directory it replaces: the old
+    // directory leaves view, the receipt lands, the new directory lands. A
+    // reader that sees a directory always finds the receipt for it, and in
+    // between sees none, which reads as a miss.
+    let result = check_out(&staging, mirror, commit)
+        .and_then(|()| tree_signature(&staging))
+        .and_then(|signature| {
+            if dir.exists() {
+                fs::rename(&dir, &replaced).map_err(|e| CoreError::io(&dir, e))?;
+            }
+            atomic_write(
+                &receipt_path(env, key, commit),
+                &format!("{RECEIPT_RULES}\n{signature}\n"),
+            )
+        });
+    if let Err(error) = result {
+        let _ = fs::remove_dir_all(&staging);
+        // What was here is out of view under a receipt that may name the
+        // tree that never landed, so it goes too: the mirror rebuilds it.
+        let _ = fs::remove_dir_all(&replaced);
+        return Err(error);
     }
     fs::rename(&staging, &dir).map_err(|e| CoreError::io(&dir, e))?;
     let _ = fs::remove_dir_all(&replaced);

--- a/crates/core/src/remote/tests.rs
+++ b/crates/core/src/remote/tests.rs
@@ -259,6 +259,26 @@ fn a_checkout_published_before_the_rules_were_recorded_is_rebuilt() {
     assert!(store::published(&f.env, &key, &published.commit).is_some());
 }
 
+/// Callers test `published` before taking the lock, so two of them can
+/// miss the same receipt and both go on to publish. The one that wakes
+/// second finds the commit already there and hands back what is in place,
+/// rather than materializing over a directory the first caller is reading.
+/// Removing the mirror is what makes the answer observable: materializing
+/// again is then the one thing that cannot quietly succeed.
+#[test]
+fn a_publisher_that_wakes_to_a_published_commit_leaves_it_alone() {
+    let f = fixture();
+    let first = sync(&f.env, REPO, None).unwrap();
+    let key = key_for(&f.env);
+    let mirror = store::mirror_dir(&f.env, &key);
+    fs::remove_dir_all(&mirror).unwrap();
+
+    let again = store::publish(&f.env, &key, &mirror, &first.commit).unwrap();
+
+    assert_eq!(again, first.root);
+    assert!(body(&again).contains("v1"));
+}
+
 /// Two trees of one commit can share a signature, so a receipt visible
 /// while the old directory is still in place would vouch for the directory
 /// about to be moved out from under a reader. The order is observable at

--- a/crates/core/src/remote/tests.rs
+++ b/crates/core/src/remote/tests.rs
@@ -236,6 +236,29 @@ fn a_tampered_checkout_is_detected_and_rebuilt() {
     assert!(body(&repaired.root).contains("v1"));
 }
 
+/// A checkout an older kendex published is self-consistent with whatever it
+/// wrote, so matching its own signature proves nothing about the rules that
+/// wrote it. Its receipt is the bare signature, the form before those rules
+/// were recorded, and it is rebuilt rather than served.
+#[test]
+fn a_checkout_published_before_the_rules_were_recorded_is_rebuilt() {
+    let f = fixture();
+    let published = sync(&f.env, REPO, None).unwrap();
+    let key = key_for(&f.env);
+    fs::write(
+        store::receipt_path(&f.env, &key, &published.commit),
+        store::tree_signature(&published.root).unwrap(),
+    )
+    .unwrap();
+
+    assert!(store::published(&f.env, &key, &published.commit).is_none());
+
+    let repaired = cached(&f.env, REPO, None).unwrap().unwrap();
+    assert_eq!(repaired.root, published.root);
+    assert!(body(&repaired.root).contains("v1"));
+    assert!(store::published(&f.env, &key, &published.commit).is_some());
+}
+
 /// A checkout that fails half way leaves nothing readable behind: the
 /// directory only ever appears complete, by rename.
 #[test]

--- a/crates/core/src/remote/tests.rs
+++ b/crates/core/src/remote/tests.rs
@@ -259,6 +259,28 @@ fn a_checkout_published_before_the_rules_were_recorded_is_rebuilt() {
     assert!(store::published(&f.env, &key, &published.commit).is_some());
 }
 
+/// Two trees of one commit can share a signature, so a receipt visible
+/// while the old directory is still in place would vouch for the directory
+/// about to be moved out from under a reader. The order is observable at
+/// the step between: a receipt write that cannot land finds the old
+/// checkout already gone rather than still being served.
+#[test]
+fn the_old_checkout_leaves_view_before_the_receipt_names_the_new_one() {
+    let f = fixture();
+    let first = sync(&f.env, REPO, None).unwrap();
+    let key = key_for(&f.env);
+    let mirror = store::mirror_dir(&f.env, &key);
+
+    // Nothing renames a file onto a directory, so the receipt write fails
+    // at exactly the step after the old checkout is moved aside.
+    let receipt = store::receipt_path(&f.env, &key, &first.commit);
+    fs::remove_file(&receipt).unwrap();
+    fs::create_dir(&receipt).unwrap();
+
+    assert!(store::publish(&f.env, &key, &mirror, &first.commit).is_err());
+    assert!(!first.root.exists(), "the old checkout was still in view");
+}
+
 /// A checkout that fails half way leaves nothing readable behind: the
 /// directory only ever appears complete, by rename.
 #[test]

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -521,9 +521,11 @@ lives in one capability table read by core and UI.
   the package page. Commit ids stay behind the table's `…` menu. Muting a
   package's update notifications is a machine-local settings entry. Reuse
   is verified against a publish receipt outside the checkout: a full
-  content hash of the tree. Pre-2.0 clones are read where the new layout
-  has nothing yet, never deleted. The store keeps one tree per resolved
-  commit; nothing prunes it; deleting the cache is the only cleanup.
+  content hash of the tree and the rules that materialized it, so a
+  checkout an older kendex wrote is rebuilt rather than reused. Pre-2.0
+  clones are read where the new layout has nothing yet, never deleted.
+  The store keeps one tree per resolved commit; nothing prunes it;
+  deleting the cache is the only cleanup.
 - **A subscription reference is parsed, never guessed; one repository
   subscribes once per scope.** Two validators in `core/source_ref.rs`: the
   typed one (Subscribe dialog, `marketplace subscribe`, `source add`,

--- a/tools/size-ratchet-baseline.tsv
+++ b/tools/size-ratchet-baseline.tsv
@@ -6,7 +6,7 @@ crates/core/src/engine/pi_hooks_move/migrated.rs	539
 crates/core/src/engine/pi_hooks_move/mod.rs	503
 crates/core/src/engine/pi_hooks_move/preflight.rs	765
 crates/core/src/error.rs	509
-crates/core/src/remote/store.rs	425
+crates/core/src/remote/store.rs	435
 crates/core/src/settings_file.rs	408
 hooks/block-repo-copy.sh	511
 pi-extensions/pi-agents-tmux/extensions/subagent/browser.ts	650

--- a/tools/size-ratchet-baseline.tsv
+++ b/tools/size-ratchet-baseline.tsv
@@ -6,7 +6,7 @@ crates/core/src/engine/pi_hooks_move/migrated.rs	539
 crates/core/src/engine/pi_hooks_move/mod.rs	503
 crates/core/src/engine/pi_hooks_move/preflight.rs	765
 crates/core/src/error.rs	509
-crates/core/src/remote/store.rs	417
+crates/core/src/remote/store.rs	425
 crates/core/src/settings_file.rs	408
 hooks/block-repo-copy.sh	511
 pi-extensions/pi-agents-tmux/extensions/subagent/browser.ts	650

--- a/tools/size-ratchet-baseline.tsv
+++ b/tools/size-ratchet-baseline.tsv
@@ -6,7 +6,7 @@ crates/core/src/engine/pi_hooks_move/migrated.rs	539
 crates/core/src/engine/pi_hooks_move/mod.rs	503
 crates/core/src/engine/pi_hooks_move/preflight.rs	765
 crates/core/src/error.rs	509
-crates/core/src/remote/store.rs	405
+crates/core/src/remote/store.rs	417
 crates/core/src/settings_file.rs	408
 hooks/block-repo-copy.sh	511
 pi-extensions/pi-agents-tmux/extensions/subagent/browser.ts	650


### PR DESCRIPTION
Closes KEN-857.

`remote::store::published` handed back a cached checkout whenever its receipt matched the directory's current `tree_signature`. The receipt was written from the bytes that were materialised, so a checkout made before KEN-810 (#1830) is self-consistent with whatever line endings it was written with, matches itself, and is reused forever. Every caller of `published` then bypasses `git_into` and never reaches the `MATERIALISING` settings that PR added — and a pinned catalog may never resolve a new commit that would force a fresh materialisation.

A receipt that records only a tree signature cannot tell "these are the right bytes" from "these are the bytes we happened to write". That distinction is the whole fix.

## What changes

The receipt now opens with `RECEIPT_RULES` (`kendex-checkout 1`), and `published` requires that line before it computes a signature at all. An old bare-signature receipt is a cache miss, so the next resolution re-materialises through `git_into` and picks up the settings.

Directory keying was the alternative and was rejected: it buys the same property but strands a whole tree per rules change under the old key — nothing prunes the store — and makes `safety_cache_dir` and `adopt_cache` carry a second spelling. The receipt is one file `publish` already overwrites.

## This is cache invalidation, not data migration

Worth saying plainly, because the standing no-migration rule is the natural thing to reach for here. Nothing is converted and no old format is parsed: a cache is rebuilt from the mirror it was always derived from, which is the same thing that happens when a checkout is missing or has been edited.

The rule's own premise also does not reach this case. The no-migration answers on #1820 and #1833 rest on KEN-817 — no journaled apply ever completed on Windows, so no lock exists there. KEN-817 (#1816) changed `fs.rs` only; `store.rs` was untouched, `check_out` writes through git's own `checkout-index`, and `publish` uses `atomic_write` and `fs::rename`. None of that went through the read-only `sync_all` that killed apply, so a Windows user who ran `kendex add` before #1816 can hold a populated cache from a run that then failed at the journal.

## What is deliberately unchanged

The receipt still lands before the directory rename, so a reader that sees the directory always finds the receipt that vouches for it. An unreadable, truncated or unrecognised receipt still falls to re-materialising rather than to an error — a cache miss is not a failure. `tree_signature` and the mismatch path are untouched, and `a_tampered_checkout_is_detected_and_rebuilt` still passes: catching a hand-edited cache is a different protection and stays exactly as strong.

## Validation

`a_checkout_published_before_the_rules_were_recorded_is_rebuilt` writes a pre-versioning receipt over a just-published checkout. Before the change it fails on the first assertion with the stale directory handed back; after, `published` refuses it and the next resolution rebuilds it.

`RATCHET_RAISE=1`, `crates/core/src/remote/store.rs` 405 -> 417, measured.
