### PR TITLE
fix(KEN-859): a refusal names a stored item the way kendex spells a path

### DIFF
--- a/changelog.d/fixed/KEN-859.md
+++ b/changelog.d/fixed/KEN-859.md
@@ -1,0 +1,2 @@
+- On Windows, a refusal that names the item already stored in a name's slot
+  spells its path with `/`, the way every other path kendex prints is spelled.

--- a/changelog.d/fixed/KEN-859.md
+++ b/changelog.d/fixed/KEN-859.md
@@ -1,2 +1,2 @@
 - On Windows, a refusal that names the item already stored in a name's slot
-  spells its path with `/`, the way every other path kendex prints is spelled.
+  spells its path with `/` instead of `\`.

--- a/crates/core/src/source/layout.rs
+++ b/crates/core/src/source/layout.rs
@@ -141,8 +141,10 @@ pub(super) fn stored_in_slot(
     let Some(occupant) = occupant else {
         return Ok(None);
     };
+    // Text, so `paths::slashed` spells it — the rule every other path the
+    // adopt refusals name goes through.
     let occupant = sealed.relative(&occupant).unwrap_or(&occupant);
-    Ok(Some(crate::names::shown(&occupant.display().to_string())))
+    Ok(Some(crate::names::shown(&crate::paths::slashed(occupant))))
 }
 
 pub(super) fn agent_stems(sealed: &SealedSource, dir: &str) -> Vec<String> {

--- a/crates/core/src/source/layout.rs
+++ b/crates/core/src/source/layout.rs
@@ -141,8 +141,8 @@ pub(super) fn stored_in_slot(
     let Some(occupant) = occupant else {
         return Ok(None);
     };
-    // Text, so `paths::slashed` spells it — the rule every other path the
-    // adopt refusals name goes through.
+    // Text, not a path handed back to the operating system, so
+    // `paths::slashed` spells it rather than the platform's separator.
     let occupant = sealed.relative(&occupant).unwrap_or(&occupant);
     Ok(Some(crate::names::shown(&crate::paths::slashed(occupant))))
 }


### PR DESCRIPTION
Closes KEN-859. **`main` is red on the required `Windows cargo (workspace tests)` context, so this unblocks every open PR in the fleet.**

Six `engine::adopt::tests::slots` refusals fail on Windows, all added by KEN-631 (#1831, merged `2af608d82`). Each asserts the refusal names the stored item, and on Windows the message reads `skills\data-science\eda is stored here` where the test looks for `data-science/eda`.

## The producer was the wrong side, not the tests

Worth stating, because the cheap reading is that six tests hardcode a `/` and should be relaxed.

All six go through one producer: `source::slot_unreachable`'s plain-name arm, formatting `layout::stored_in_slot`'s answer. That answer is `sealed.relative(&occupant)` — the source-root-relative position of the stored item — so it is a path, and the `skills` segment is that root-relative prefix rather than part of a name. But `paths.rs` writes the rule for a path inside text with no carve-out for one a person only reads: *a path a person reads or runs is spelled with `/`*.

Three things put the obligation on the producer:

- **The refusals either side of it already do this.** `already_managed` (`engine/adopt.rs:251`) and the `TogglesDiffer` detail (`engine/adopt/held.rs:210`) are both `names::shown(&paths::slashed(..))`, and `check_item` (`check_catalog.rs:287`) strips to the source root and slashes — this exact construction. The broken line was that pattern with the `slashed` dropped.
- **The one documented exception is the opposite category.** `legacy_registration` in `engine/pi_hooks_move/migrated.rs` chooses `display` deliberately and says why: the string is a search key `registered` matches by exact equality, *"a search key, never output"*. This is output.
- **Nothing matches on this sentence.** Both callers, `adopt::plan_item` and `fork::vacant`, wrap it into a `CoreError` for display; no Rust or TypeScript consumer greps it.

No split among the six — one producer, one answer. One line in `source/layout.rs:145`, and no assertion changed, so each still fails if the refusal names the wrong item.

## Why nothing caught it

`2af608d82` has no Windows job at all — the lane landed one commit later, in `3312a3684` (KEN-810, #1830). Every main run since has been red. The required context closes that window for everything after it.

## The control

No Linux test can separate the two producers: where `/` already separates, `slashed` replaces `/` with `/`. So the wiring was proven instead — `paths::slashed` temporarily driven with `'e'` in place of `MAIN_SEPARATOR`, a letter the fixtures contain. Exactly the six named in the issue turned red, the other five in the file stayed green, and the experiment was reverted (`paths.rs` is untouched in this diff). The standing control is those six on the Windows lane.

## Deliberately not touched

`engine/posture.rs:69` builds its ignore-note with `exclude.display()`, and #1830's test at `posture.rs:262` now builds the expectation the same way. That call and this one disagree about the same rule. It is not red, it is outside this issue, and whether the rule wants an exception for "a file the person opens" is a product decision rather than a defect — so it is raised with the owner rather than filed or fixed here.
