### PR TITLE
fix(KEN-847): a slot's occupancy is asked of every level under it

### DIFF
--- a/changelog.d/fixed/KEN-847.md
+++ b/changelog.d/fixed/KEN-847.md
@@ -1,0 +1,2 @@
+- Adopting a plain skill no longer deletes an item a declared catalog stores
+  deeper under that name: the adoption is refused and names what is stored.

--- a/crates/core/src/engine/adopt/tests/slots.rs
+++ b/crates/core/src/engine/adopt/tests/slots.rs
@@ -299,6 +299,131 @@ fn a_plain_skill_over_a_slot_holding_a_differently_named_item_refuses() {
     assert!(trash_is_empty(&env));
 }
 
+/// The same catalog with the slot holding a plain skill of its own, which
+/// makes the slot replaceable rather than empty. Its one immediate child,
+/// `foo`, is no item — the item is `foo/eda`, a level further down, which
+/// is where a declared catalog directory legitimately keeps it. A search
+/// that stops at the children reports the slot free and the capture takes
+/// the stored item with the directory.
+#[test]
+fn a_plain_skill_over_an_item_stored_deeper_in_its_slot_refuses() {
+    let tmp = tempfile::tempdir().unwrap();
+    let home = rooted(&tmp);
+    let env = Env::fake(&home, FakeOs::Linux);
+    let stored = store_local_skill(&env, "data-science/foo/eda", "the stored one");
+    store_local_skill(&env, "data-science", "the earlier plain one");
+    let root = crate::source::local_source_root(&env, &Scope::Global);
+    fs::write(
+        root.join("kendex.toml"),
+        "[catalog]\nskills = [\"skills/data-science\"]\n",
+    )
+    .unwrap();
+
+    let refused = refuse_plain_skill(&env, &home, "data-science");
+
+    assert!(refused.contains("data-science/foo/eda"), "{refused:?}");
+    assert_eq!(
+        fs::read_to_string(stored.join("SKILL.md")).unwrap(),
+        "the stored one"
+    );
+    // The source still offers the stored item under its own name, so a
+    // declaration naming it still resolves to content that is there.
+    let sealed = crate::source_read::SealedSource::open(&root).unwrap();
+    let config = crate::source::source_config_for(&sealed, LOCAL_SOURCE_NAME).unwrap();
+    assert_eq!(
+        crate::source::list_items(&sealed, &config, ItemKind::Skill),
+        ["foo/eda"]
+    );
+    assert_eq!(
+        crate::source::find_item(&sealed, &config, ItemKind::Skill, "foo/eda"),
+        Some(stored)
+    );
+    assert!(trash_is_empty(&env));
+}
+
+/// The must-fail half: what the descendant search must NOT call an
+/// occupant. A slot that is an empty directory holds nothing, and the
+/// earlier copy of the name being kept holds only its own supporting tree,
+/// which the capture is written over — the search descends through every
+/// level of that tree and finds no item there, so both adoptions land. A
+/// guard that refuses these refuses every re-adopt.
+#[test]
+fn a_plain_skill_over_a_slot_holding_nothing_of_its_own_lands() {
+    let tmp = tempfile::tempdir().unwrap();
+    let home = rooted(&tmp);
+    let env = Env::fake(&home, FakeOs::Linux);
+    let stored = store_local_skill(&env, "handmade", "the earlier one");
+    fs::create_dir_all(stored.join("references/deep/deeper")).unwrap();
+    fs::write(stored.join("references/deep/deeper/notes.md"), "supporting").unwrap();
+    fs::create_dir_all(stored.join("scripts")).unwrap();
+    fs::write(stored.join("scripts/run.sh"), "#!/bin/sh\n").unwrap();
+    let vacant = crate::source::local_source_root(&env, &Scope::Global).join("skills/vacant");
+    fs::create_dir_all(&vacant).unwrap();
+
+    for (name, body) in [("handmade", "the newer one"), ("vacant", "a first copy")] {
+        let held = home.join(".claude/skills").join(name);
+        fs::create_dir_all(&held).unwrap();
+        fs::write(held.join("SKILL.md"), body).unwrap();
+        let plan = adopt(
+            &env,
+            &Scope::Global,
+            ItemKind::Skill,
+            name,
+            &[HarnessId::Claude],
+        )
+        .unwrap();
+        crate::apply::execute(&env, &plan, None).unwrap();
+    }
+
+    assert_eq!(
+        fs::read_to_string(stored.join("SKILL.md")).unwrap(),
+        "the newer one"
+    );
+    assert_eq!(
+        fs::read_to_string(vacant.join("SKILL.md")).unwrap(),
+        "a first copy"
+    );
+}
+
+/// The descendant search looks at a bounded number of entries, and a slot
+/// wider than that bound is one it has not finished looking at. Not
+/// finished is not empty, so adoption refuses. Nothing is stored under this
+/// slot but the earlier copy's own filler: the bound is the only reason to
+/// refuse, so the refusal is the bound's or it is nobody's.
+#[test]
+fn a_plain_skill_over_a_slot_too_wide_to_search_refuses() {
+    let tmp = tempfile::tempdir().unwrap();
+    let home = rooted(&tmp);
+    let env = Env::fake(&home, FakeOs::Linux);
+    let stored = store_local_skill(&env, "data-science", "the earlier plain one");
+    // One entry past the budget, counting the earlier copy's own SKILL.md.
+    for n in 0..crate::source_read::TREE_BOUND.files {
+        fs::create_dir(stored.join(format!("filler-{n:04}"))).unwrap();
+    }
+
+    let held = home.join(".claude/skills/data-science");
+    fs::create_dir_all(&held).unwrap();
+    fs::write(held.join("SKILL.md"), "the plain one").unwrap();
+    let refused = adopt(
+        &env,
+        &Scope::Global,
+        ItemKind::Skill,
+        "data-science",
+        &[HarnessId::Claude],
+    )
+    .unwrap_err();
+
+    assert!(
+        matches!(refused, CoreError::SourceEscape { .. }),
+        "{refused:?}"
+    );
+    assert_eq!(
+        fs::read_to_string(stored.join("SKILL.md")).unwrap(),
+        "the earlier plain one"
+    );
+    assert!(trash_is_empty(&env));
+}
+
 /// A listing skips a `tests` directory wherever it finds one — the support
 /// vocabulary a browse row is drawn through, since files there are about the
 /// items rather than items. A legal `tests/foo` is therefore a skill no

--- a/crates/core/src/source/layout.rs
+++ b/crates/core/src/source/layout.rs
@@ -121,23 +121,20 @@ pub(super) fn stored_in_slot(
     if !sealed.dir_at(&held)? {
         return Ok(None);
     }
-    // Being the plain item makes the slot replaceable, not empty. Its own
-    // `SKILL.md` and supporting files belong to the item the capture is
-    // written over, so they are not occupants — but a namespaced item
-    // stored under the same directory is a second item, and the write
-    // takes it too. Which children are items is `stored_item`'s to say,
-    // the same judge `flat_skills` lists them by.
-    let replaceable = stored_item(sealed, kind, &held)?;
     // A read that could not be made is not an empty directory, and a probe
     // that could not be made is not a child that is no item: reading either
     // one as the other is how a guard deletes what it exists to protect.
-    let mut occupant = None;
-    for entry in sealed.all_entries(&held)? {
-        if !replaceable || stored_item(sealed, kind, &entry)? {
-            occupant = Some(entry);
-            break;
-        }
-    }
+    let occupant = match stored_item(sealed, kind, &held)? {
+        // Being the plain item makes the slot replaceable, not empty. Its
+        // own `SKILL.md` and supporting files belong to the item the
+        // capture is written over, so they are not occupants — but an item
+        // stored under the same directory is a second item, and the write
+        // takes it too.
+        true => descendant_item(sealed, kind, &held)?,
+        // A slot that is not the item holds nothing the capture may take,
+        // so any entry at all is an occupant.
+        false => sealed.all_entries(&held)?.into_iter().next(),
+    };
     let Some(occupant) = occupant else {
         return Ok(None);
     };
@@ -145,6 +142,66 @@ pub(super) fn stored_in_slot(
     // `paths::slashed` spells it rather than the platform's separator.
     let occupant = sealed.relative(&occupant).unwrap_or(&occupant);
     Ok(Some(crate::names::shown(&crate::paths::slashed(occupant))))
+}
+
+/// The shallowest item stored anywhere under a replaceable slot, or
+/// nothing when the slot holds only the plain item's own files. Which
+/// directory is an item is [`stored_item`]'s to say, the same judge
+/// `flat_skills` lists them by.
+///
+/// Immediate children are not the whole slot. A catalog that declares its
+/// own directories stores its items under one of them, and that directory
+/// can itself be a plain name's slot: with `skills/data-science` declared,
+/// `foo/eda` is stored at `skills/data-science/foo/eda`, where the only
+/// child of the slot is `foo`, which is no item. How deep the items sit is
+/// the catalog's to choose, so the search descends instead of reading the
+/// tables that chose it — a table says what a source OFFERS, and both the
+/// display exclusions it is drawn through and an unusable one offering
+/// nothing read as an empty slot over a directory holding content.
+///
+/// The search is bounded by the entries it looks at rather than by depth,
+/// which leaves a directory's whole width free to multiply at every level.
+/// The budget is the tree bound: a slot holding more entries than kendex
+/// will read out of one tree holds more than it can render back. Past it
+/// the search has not finished looking, which is not the same answer as
+/// having found nothing, and this is a guard — so it refuses.
+fn descendant_item(
+    sealed: &SealedSource,
+    kind: ItemKind,
+    slot: &std::path::Path,
+) -> Result<Option<PathBuf>> {
+    let budget = crate::source_read::TREE_BOUND.files;
+    let mut left = budget;
+    // Breadth first: the occupant named is a path a person is sent to look
+    // at, and the shallowest one is the nearest to the name they typed.
+    let mut pending = std::collections::VecDeque::from([slot.to_path_buf()]);
+    while let Some(dir) = pending.pop_front() {
+        for entry in sealed.all_entries(&dir)? {
+            let Some(remaining) = left.checked_sub(1) else {
+                return Err(crate::error::CoreError::SourceEscape {
+                    path: slot.to_path_buf(),
+                    reason: format!(
+                        "more than {budget} entries under one slot — \
+                         cannot tell what is stored there"
+                    ),
+                });
+            };
+            left = remaining;
+            // Only a directory is a skill and only a directory holds one,
+            // so an entry that is neither is no item and no place to keep
+            // looking. The probe is fallible all the same: an entry the
+            // filesystem will not describe is not an entry that is no
+            // directory.
+            if !sealed.dir_at(&entry)? {
+                continue;
+            }
+            if stored_item(sealed, kind, &entry)? {
+                return Ok(Some(entry));
+            }
+            pending.push_back(entry);
+        }
+    }
+    Ok(None)
 }
 
 pub(super) fn agent_stems(sealed: &SealedSource, dir: &str) -> Vec<String> {


### PR DESCRIPTION
Closes KEN-847.

KEN-631's guard decides a plain name's slot is free when nothing is stored under it. Where the slot is itself the plain item it is *replaceable rather than empty*, and that arm asked `stored_item` of each immediate child only. A declared catalog can legitimately store an item deeper: with `[catalog] skills = ["skills/data-science"]`, the name `foo/eda` lives at `skills/data-science/foo/eda`, so the only immediate child `foo` is not itself an item, the slot reported free, and `capture_ops` trashed the whole directory and left the declaration dangling.

`descendant_item` now searches every level under the slot for something `stored_item` calls an item. The `!replaceable` arm is unchanged in behaviour — any entry at all is an occupant there.

**No configuration is read.** Reading the configured roots was the other candidate and it was rejected on the record: occupancy is a safety question, and the catalog configuration has already defeated this guard twice — `CatalogMode::Unusable` read as a successful empty listing, and the browse listing's reserved-prefix exclusions hid a legal `tests/foo`. `stored_item` remains the one judge of what makes a directory an item, the same judge `flat_skills` lists by, and no second test for it was added.

**Every probe stays fallible.** A descendant walk multiplies the places a read can fail, and this guard's history is a read that could not be made being answered as "nothing there". `all_entries` per directory, `dir_at` per entry and `stored_item` per directory all propagate, and a symlinked entry errors inside `contained`, so the walk cannot loop and cannot silently skip.

**The bound is total entries examined, capped at `TREE_BOUND.files` (2048), refusing with `SourceEscape` on exhaustion.** Depth alone bounds nothing: the reader caps one directory at 4096 entries, so a depth-16 limit still admits 4096^16. Counting entries bounds the work directly and bounds depth as a consequence, since each level costs at least one entry. 2048 is reused rather than invented — it is the number of files kendex will read out of any one tree, so a slot wider than that already holds more than the rest of the engine will render back. Not having finished looking is not an answer of "nothing there", so the adoption refuses without planning a byte.

The walk is breadth-first, so the named occupant is the shallowest path rather than an arbitrary deep one.

**Deliberate over-refusal:** a `tests` or `fixtures` directory under the slot is descended like any other, so a skill shipping a `SKILL.md` as a fixture is refused. That is the listing's exclusions being correct for drawing rows and wrong for this question — already on the record in `a_plain_skill_over_a_slot_no_listing_names_refuses` — and the issue prices over-refusal at one rename against a lost package.

**Tests.** Three controls, both directions proven red. `a_plain_skill_over_an_item_stored_deeper_in_its_slot_refuses` is the reviewer's fixture and asserts the refusal names `data-science/foo/eda`, the stored `SKILL.md` is unchanged, the source still lists `foo/eda`, `find_item` still resolves it, and the trash is empty. `a_plain_skill_over_a_slot_holding_nothing_of_its_own_lands` is the must-fail half — an earlier copy with a three-level supporting tree, and a genuinely empty slot, both still land. `a_plain_skill_over_a_slot_too_wide_to_search_refuses` sits exactly one entry past the bound with nothing stored under the slot, so the refusal is the bound's or nobody's. Reverting the search to child-only reddens the first and third; making it count any descendant directory reddens the second and misnames the first.

All thirteen existing controls in `slots.rs` are green and unedited.
