### PR TITLE
fix(KEN-861): three adopt refusals name a position the way kendex spells a path

### DIFF
--- a/changelog.d/fixed/KEN-861.md
+++ b/changelog.d/fixed/KEN-861.md
@@ -1,0 +1,2 @@
+- On Windows, the three adopt refusals that name where an item was expected
+  spell that path with `/` instead of `\`.

--- a/crates/core/src/engine/adopt.rs
+++ b/crates/core/src/engine/adopt.rs
@@ -83,10 +83,7 @@ pub fn adopt(
         shared, content, ..
     } = &seen;
     if shared.is_none() && content.is_empty() && !local_item.exists() {
-        return Err(CoreError::ItemNotInSource {
-            name: name.to_owned(),
-            source_name: format!("nothing at {} to adopt", first_position.display()),
-        });
+        return Err(nothing_at(name, first_position));
     }
 
     let in_place = inplace::home(scope, kind, name).is_some();
@@ -149,10 +146,6 @@ fn move_ops(
             },
         })
         .collect();
-    let nothing_here = || CoreError::ItemNotInSource {
-        name: name.to_owned(),
-        source_name: format!("nothing at {} to adopt", first_position.display()),
-    };
     match (shared, in_place) {
         (Some((_, shared)), true) => ops.extend(inplace::relocate_ops(
             name,
@@ -163,7 +156,7 @@ fn move_ops(
         (None, true) => {
             let held: Vec<PathBuf> = content.iter().map(|(_, path)| path.clone()).collect();
             if held.is_empty() {
-                return Err(nothing_here());
+                return Err(nothing_at(name, first_position));
             }
             ops.extend(inplace::relocate_ops(name, &held, &[], local_item)?);
         }
@@ -242,6 +235,19 @@ fn local_item_path(env: &Env, scope: &Scope, kind: ItemKind, name: &str) -> Resu
             name: name.to_owned(),
             source_name: format!("adopt does not support {} yet", other.name()),
         }),
+    }
+}
+
+/// The positions the tools named hold nothing the capture could take.
+/// Said once for both callers: the sentence is the same fact whether the
+/// whole read came back empty or only the in-place arm found no content,
+/// and one string is one place for the spelling to be right. The position
+/// is text the reader is shown rather than a path going back to the
+/// operating system, so `paths::slashed` spells it.
+fn nothing_at(name: &str, position: &Path) -> CoreError {
+    CoreError::ItemNotInSource {
+        name: name.to_owned(),
+        source_name: format!("nothing at {} to adopt", crate::paths::slashed(position)),
     }
 }
 

--- a/crates/core/src/engine/adopt/inplace.rs
+++ b/crates/core/src/engine/adopt/inplace.rs
@@ -85,7 +85,12 @@ pub(super) fn relocate_ops(
     if let Some(wrong) = held.iter().find(|path| !path.join(MARKER).is_file()) {
         return Err(CoreError::ItemNotInSource {
             name: name.to_owned(),
-            source_name: format!("{} is not a folder holding a {MARKER}", wrong.display()),
+            // Text the reader is shown, not a path going back to the
+            // operating system, so `paths::slashed` spells it.
+            source_name: format!(
+                "{} is not a folder holding a {MARKER}",
+                crate::paths::slashed(wrong)
+            ),
         });
     }
     let mut ops = Vec::new();

--- a/crates/core/src/engine/adopt/tests.rs
+++ b/crates/core/src/engine/adopt/tests.rs
@@ -458,3 +458,56 @@ fn the_nesting_refusal_holds_under_a_symlinked_ancestor() {
         HarnessId::Claude
     ));
 }
+
+/// Every adopt refusal that names a position spells it with `/`, whatever
+/// the platform builds the path with. The three below are the ones that
+/// print a position rather than an item name: the read that found nothing
+/// anywhere, the in-place arm that found the home but no content to move
+/// into it, and the folder wearing a skill's name without its marker.
+///
+/// The assertion is a tail spelled `/` in this source and never through
+/// `paths::slashed`, so the two sides only agree where the value really
+/// goes through that rule. On a host where `/` already separates, nothing
+/// here can fail; the lane this holds is Windows, where the unfixed sites
+/// read `app\.claude\skills\ghost`.
+#[test]
+fn an_adopt_refusal_spells_the_position_it_names_with_slashes() {
+    let tail = "app/.claude/skills/ghost";
+
+    let tmp = tempfile::tempdir().unwrap();
+    let env = Env::fake(tmp.path(), FakeOs::Linux);
+    let project = tmp.path().join("app");
+    fs::create_dir_all(&project).unwrap();
+    let scope = Scope::Project {
+        root: project.clone(),
+    };
+    let nowhere = adopt(&env, &scope, ItemKind::Skill, "ghost", &[HarnessId::Claude]).unwrap_err();
+    assert!(nowhere.to_string().contains(tail), "{nowhere}");
+
+    // The shared tree already holds the name, so the read gets past the
+    // first refusal and the in-place arm makes the same complaint.
+    let tmp = tempfile::tempdir().unwrap();
+    let env = Env::fake(tmp.path(), FakeOs::Linux);
+    let project = tmp.path().join("app");
+    fs::create_dir_all(project.join(".agents/skills/ghost")).unwrap();
+    fs::write(project.join(".agents/skills/ghost/SKILL.md"), "mine").unwrap();
+    let scope = Scope::Project {
+        root: project.clone(),
+    };
+    let no_content =
+        adopt(&env, &scope, ItemKind::Skill, "ghost", &[HarnessId::Claude]).unwrap_err();
+    assert!(no_content.to_string().contains(tail), "{no_content}");
+
+    // A directory under the name with no marker in it: content to move,
+    // and nothing that reads back as a skill.
+    let tmp = tempfile::tempdir().unwrap();
+    let env = Env::fake(tmp.path(), FakeOs::Linux);
+    let project = tmp.path().join("app");
+    fs::create_dir_all(project.join(".claude/skills/ghost")).unwrap();
+    fs::write(project.join(".claude/skills/ghost/notes.md"), "mine").unwrap();
+    let scope = Scope::Project {
+        root: project.clone(),
+    };
+    let unmarked = adopt(&env, &scope, ItemKind::Skill, "ghost", &[HarnessId::Claude]).unwrap_err();
+    assert!(unmarked.to_string().contains(tail), "{unmarked}");
+}


### PR DESCRIPTION
Closes KEN-861.

Three adopt refusals formatted a path into their message with `Path::display()`, so on Windows they printed `\` where the rule at `paths::slashed` says a path a person reads or runs is spelled with `/`. Same defect KEN-859 fixed at `source/layout.rs:145`, at the sites that PR deliberately left alone — it was unblocking a red required context on `main` and stayed one line of behaviour.

## All three are output, confirmed rather than assumed

Every one lands in `CoreError::ItemNotInSource`, whose `#[error("'{name}' not found in source '{source_name}'")]` interpolates the field straight into the sentence a reader sees. The crate's one documented `display`-over-`slashed` choice, `legacy_registration` in `engine/pi_hooks_move/migrated.rs`, justifies itself as a search key matched by exact equality and never output — so who consumes these was the question, and it was checked:

- `package/updates/eval.rs:105` is the only code that reads the variant, and it matches `{ .. }`, ignoring the fields.
- The two `contains("not found in source")` filters, `cli/src/commands/engine_common.rs:280` and `cli/src/commands/verify.rs:115`, test the variant's fixed prefix and never the path inside it.

Nothing anywhere matches on `source_name`.

`paths::slashed` alone, not `names::shown(&paths::slashed(..))`. The neighbours wrap in `names::shown`, but that also escapes control characters, which is a second behaviour change nothing here asked for.

## The duplication is folded, as a decision

The two `adopt.rs` sites were one sentence about one fact — every named position holds nothing to take — reached by two routes: the read came back empty, or the in-place arm found the home but no content to move into it. They are now `nothing_at(name, position)`, sitting beside `already_managed` and `copies_differ`, which are already refusal constructors of that shape in that module. The `nothing_here` closure was single-use, so it was a third spelling of the same four lines rather than an abstraction.

One string is now one place for the spelling to be right, which is exactly what these two failed to be while they were apart.

## What holds the fix in place

**No test asserted on any of these three messages.** That is worth stating plainly, because it differs from KEN-859: that PR inherited six existing Windows assertions, and here there were zero, so nothing held the fix on any platform — which is also why the lane did not catch these when it caught the others.

`an_adopt_refusal_spells_the_position_it_names_with_slashes` reaches all three refusals with three fixtures. Its expectation is the tail `app/.claude/skills/ghost`, spelled `/` in the test source and never through `paths::slashed`, so the two sides agree only where the value really goes through the rule. It cannot fail on a `/` host; the lane it holds is Windows.

The control is KEN-859's technique, since no Linux test can otherwise separate the two spellings: driving `spelled` with `!` in place of the produced `/` turns all three assertions red and nothing else in the suite.

```
SITE1 pass=false :: 'ghost' not found in source 'nothing at !tmp!.tmpOUK3dx!app!.claude!skills!ghost to adopt'
SITE2 pass=false :: 'ghost' not found in source 'nothing at !tmp!.tmpzzSEpG!app!.claude!skills!ghost to adopt'
SITE3 pass=false :: '!tmp!.tmp0DXOww!app!.claude!skills!ghost is not a folder holding a SKILL.md'
```

Both mutated files were restored from copies before the commit; `crates/core/src/paths.rs` is untouched in this diff.

## Not touched

`engine/posture.rs:69` also uses `display()`, and #1830 settled the expectation at `posture.rs:262` to match it — so that call and this rule genuinely disagree, and whether the rule wants an exception for a file the person is being told to open is a product decision rather than a defect. It sits with the owner.
