### PR TITLE
fix(KEN-853): a run from the recorded path says what replaced its bytes

### DIFF
--- a/changelog.d/fixed/KEN-853.md
+++ b/changelog.d/fixed/KEN-853.md
@@ -1,0 +1,3 @@
+- After an elevated `kendex update`, the next run of that command tells the
+  app which bytes are installed, so the sidebar keeps offering to update it
+  instead of falling silent.

--- a/crates/cli/tests/command_record.rs
+++ b/crates/cli/tests/command_record.rs
@@ -12,21 +12,55 @@ mod test_util;
 use test_util::rooted;
 
 use std::fs;
-use std::path::Path;
+use std::path::{Path, PathBuf};
 use std::process::{Command, Output};
 
-#[allow(clippy::expect_used)]
 fn kendex(home: &Path, args: &[&str]) -> Output {
-    Command::new(env!("CARGO_BIN_EXE_kendex"))
-        .args(args)
+    kendex_with(home, &[], args)
+}
+
+#[allow(clippy::expect_used)]
+fn kendex_with(home: &Path, vars: &[(&str, &Path)], args: &[&str]) -> Output {
+    let mut run = Command::new(env!("CARGO_BIN_EXE_kendex"));
+    run.args(args)
         .current_dir(home)
         .env_clear()
         .env("HOME", home)
         .env("KENDEX_REAL_HOME", "1")
         .env("KENDEX_BACKGROUND_REFRESH", "off")
-        .env("PATH", std::env::var("PATH").unwrap_or_default())
-        .output()
-        .expect("kendex binary runs")
+        .env("PATH", std::env::var("PATH").unwrap_or_default());
+    for (key, value) in vars {
+        run.env(key, value);
+    }
+    run.output().expect("kendex binary runs")
+}
+
+/// The file this test binary runs the command from, under the one spelling
+/// a run of it reports back: `current_exe` is resolved before it is
+/// recorded, so a fixture naming the unresolved path would compare unequal
+/// on any host whose temporary or target tree runs through a link.
+#[allow(clippy::expect_used)]
+fn the_command_that_runs() -> PathBuf {
+    fs::canonicalize(env!("CARGO_BIN_EXE_kendex")).expect("the built binary canonicalizes")
+}
+
+/// A record written when the command was installed, with the bytes it names
+/// replaced afterwards — the ordering a real install has and a fixture does
+/// not, since it writes both within one millisecond.
+///
+/// A run reads that ordering to decide the bytes may have moved at all, so
+/// a fixture that left the record newer would be answered by the timestamps
+/// and never reach the case it is about.
+#[allow(clippy::expect_used)]
+fn installed_before_the_bytes_were_replaced(record: &Path, bytes: &Path) {
+    let written = fs::metadata(bytes)
+        .and_then(|bytes| bytes.modified())
+        .expect("the fixture command carries a timestamp");
+    fs::File::options()
+        .write(true)
+        .open(record)
+        .and_then(|file| file.set_modified(written - std::time::Duration::from_secs(60)))
+        .expect("the fixture record takes a timestamp");
 }
 
 /// An install made before the record existed has none, and its owner has
@@ -123,11 +157,12 @@ fn a_record_already_there_is_not_written_over_by_a_first_run() {
         "a first run wrote over a record that was already there"
     );
 
-    // And nothing was read to reach that answer. Every run comes through
-    // here, `--version` and `--help` among them, so the steady state has
-    // to cost a look at one name — not a read and a hash of the whole
-    // executable. A running path that is not there at all says so: the
-    // read that would have failed never happens.
+    // And the running file was not read to reach that answer. Every run
+    // comes through here, `--version` and `--help` among them, so a record
+    // this build cannot read costs a look at one name and nothing else —
+    // never a read and a hash of the whole executable. A running path that
+    // is not there at all says so: the read that would have failed never
+    // happens.
     kendex_core::command_update::record_first_run(&env, &home.join("no/such/kendex")).unwrap();
     assert!(
         !home.join("no/such/kendex").exists(),
@@ -207,5 +242,149 @@ fn a_run_does_not_take_the_record_off_another_install() {
         kendex_core::command_update::recorded_command(&env).map(|record| record.path),
         Some(theirs),
         "a run repointed a record it did not write"
+    );
+}
+
+/// The bytes a record names after the run that replaced them wrote its own
+/// record somewhere else. What an elevated `kendex update` leaves behind:
+/// the path is still the person's command, the digest is a file that is
+/// gone, and `command_beside_app` stops matching the one command the card
+/// was offering.
+const REPLACED: &[u8] = b"the bytes an elevated update replaced";
+
+/// A replacement made with privilege the app lacks writes its record into
+/// the privileged account's data directory, so this one keeps naming bytes
+/// that are gone. The next run from the recorded path is running those new
+/// bytes, which is the same proof a first run offers, and it says what is
+/// there now.
+///
+/// Read back through the resolver rather than off the file: what has to
+/// hold is the answer the app gets, and a test that parses the file itself
+/// would pass for a record the app reads as none.
+#[test]
+#[allow(clippy::unwrap_used)]
+fn a_run_from_the_recorded_path_says_what_replaced_its_bytes() {
+    let tmp = tempfile::tempdir().unwrap();
+    let home = rooted(&tmp);
+    let env = kendex_core::env::Env::host_rooted(&home);
+    let installed = the_command_that_runs();
+    kendex_core::command_update::record_command(&env, &installed, REPLACED).unwrap();
+    installed_before_the_bytes_were_replaced(&env.installed_command_file(), &installed);
+
+    kendex(&home, &["verify"]);
+
+    let recorded = kendex_core::command_update::recorded_command(&env)
+        .unwrap_or_else(|| panic!("no record at {}", env.installed_command_file().display()));
+    assert_eq!(
+        recorded.path, installed,
+        "the run moved the record off the path it was installed at"
+    );
+    assert_eq!(
+        recorded.digest,
+        kendex_core::hash::sha256_hex(&fs::read(&installed).unwrap()),
+        "the record still names the bytes the elevated run replaced"
+    );
+}
+
+/// The same, where the data directory is the one `XDG_DATA_HOME` names
+/// rather than the one under `HOME`. The withdrawn fix carried `HOME` onto
+/// a `sudo` line and so was correct only for people who do not set this;
+/// a record written by the person's own run reads their own variable.
+///
+/// Linux alone: `XDG_DATA_HOME` is the layout `dirs` reads there, and the
+/// macOS layout has no such variable to honour.
+#[test]
+#[cfg(target_os = "linux")]
+#[allow(clippy::unwrap_used)]
+fn the_record_a_run_moves_is_the_one_xdg_data_home_names() {
+    let tmp = tempfile::tempdir().unwrap();
+    let home = rooted(&tmp);
+    // A second home whose Linux data directory is the one the run is told
+    // to use, so the fixture asks `Env` for that path instead of spelling
+    // the layout a second time.
+    let elsewhere = home.join("elsewhere");
+    let env = kendex_core::env::Env::host_rooted(&elsewhere);
+    let data_home = elsewhere.join(".local/share");
+    let installed = the_command_that_runs();
+    kendex_core::command_update::record_command(&env, &installed, REPLACED).unwrap();
+    installed_before_the_bytes_were_replaced(&env.installed_command_file(), &installed);
+
+    kendex_with(&home, &[("XDG_DATA_HOME", &data_home)], &["verify"]);
+
+    let recorded = kendex_core::command_update::recorded_command(&env)
+        .unwrap_or_else(|| panic!("no record at {}", env.installed_command_file().display()));
+    assert_eq!(
+        recorded.digest,
+        kendex_core::hash::sha256_hex(&fs::read(&installed).unwrap()),
+        "the run read a data directory other than the one it was given"
+    );
+    assert!(
+        !kendex_core::env::Env::host_rooted(&home)
+            .installed_command_file()
+            .exists(),
+        "the run wrote a second record under HOME, so the assertion above proves nothing"
+    );
+}
+
+/// Only the digest moves, and only for the file the run is executing. A
+/// record naming another install whose bytes have also been replaced is
+/// left exactly as it is: repointing a record by path is what
+/// `record_first_run` refuses, and a version that acted on the mismatch
+/// alone would take a person's record off the copy they run.
+#[test]
+#[allow(clippy::unwrap_used)]
+fn a_run_does_not_say_what_replaced_another_installs_bytes() {
+    let tmp = tempfile::tempdir().unwrap();
+    let home = rooted(&tmp);
+    let env = kendex_core::env::Env::host_rooted(&home);
+    let theirs = home.join("bin/kendex");
+    fs::create_dir_all(theirs.parent().unwrap()).unwrap();
+    fs::write(&theirs, b"the kendex install.sh put here").unwrap();
+    kendex_core::command_update::record_command(&env, &theirs, REPLACED).unwrap();
+    // Older than the bytes at both paths, so the timestamps let the run
+    // reach the case and the path is the only thing that can refuse it.
+    installed_before_the_bytes_were_replaced(&env.installed_command_file(), &theirs);
+    let before = fs::read_to_string(env.installed_command_file()).unwrap();
+
+    kendex(&home, &["verify"]);
+
+    assert_eq!(
+        fs::read_to_string(env.installed_command_file()).unwrap(),
+        before,
+        "a run rewrote a record naming a file it was not running from"
+    );
+}
+
+/// A record whose path and digest both still describe the file is not
+/// written at all — not rewritten with the same content, which the file
+/// alone cannot tell apart from being left alone, so the timestamp is what
+/// is read.
+#[test]
+#[allow(clippy::unwrap_used)]
+fn a_record_that_still_matches_is_not_written() {
+    let tmp = tempfile::tempdir().unwrap();
+    let home = rooted(&tmp);
+    let env = kendex_core::env::Env::host_rooted(&home);
+    let installed = the_command_that_runs();
+    let bytes = fs::read(&installed).unwrap();
+    kendex_core::command_update::record_command(&env, &installed, &bytes).unwrap();
+    // Backdated for the same reason the replacement cases are: without it
+    // the timestamps refuse the case and this passes without the digest
+    // ever being compared.
+    installed_before_the_bytes_were_replaced(&env.installed_command_file(), &installed);
+    let untouched = fs::metadata(env.installed_command_file())
+        .unwrap()
+        .modified()
+        .unwrap();
+
+    kendex(&home, &["verify"]);
+
+    assert_eq!(
+        fs::metadata(env.installed_command_file())
+            .unwrap()
+            .modified()
+            .unwrap(),
+        untouched,
+        "a record naming the bytes that are there was written over"
     );
 }

--- a/crates/cli/tests/command_record.rs
+++ b/crates/cli/tests/command_record.rs
@@ -21,9 +21,15 @@ fn kendex(home: &Path, args: &[&str]) -> Output {
 
 #[allow(clippy::expect_used)]
 fn kendex_with(home: &Path, vars: &[(&str, &Path)], args: &[&str]) -> Output {
+    command(home, vars)
+        .args(args)
+        .output()
+        .expect("kendex binary runs")
+}
+
+fn command(home: &Path, vars: &[(&str, &Path)]) -> Command {
     let mut run = Command::new(env!("CARGO_BIN_EXE_kendex"));
-    run.args(args)
-        .current_dir(home)
+    run.current_dir(home)
         .env_clear()
         .env("HOME", home)
         .env("KENDEX_REAL_HOME", "1")
@@ -32,7 +38,40 @@ fn kendex_with(home: &Path, vars: &[(&str, &Path)], args: &[&str]) -> Output {
     for (key, value) in vars {
         run.env(key, value);
     }
-    run.output().expect("kendex binary runs")
+    run
+}
+
+/// Whether a run ended at all, inside `limit`. For the cases whose failure
+/// is a command that never returns, where `output` would hang the suite
+/// rather than fail it.
+#[allow(clippy::expect_used)]
+fn ran_within(home: &Path, args: &[&str], limit: std::time::Duration) -> bool {
+    let mut run = command(home, &[])
+        .args(args)
+        .stdout(std::process::Stdio::null())
+        .stderr(std::process::Stdio::null())
+        .spawn()
+        .expect("kendex binary runs");
+    let deadline = std::time::Instant::now() + limit;
+    loop {
+        if run.try_wait().expect("the run reports its state").is_some() {
+            return true;
+        }
+        if std::time::Instant::now() >= deadline {
+            let _ = run.kill();
+            let _ = run.wait();
+            return false;
+        }
+        std::thread::sleep(std::time::Duration::from_millis(50));
+    }
+}
+
+/// The time a file was last written.
+#[allow(clippy::expect_used)]
+fn modified(path: &Path) -> std::time::SystemTime {
+    fs::metadata(path)
+        .and_then(|found| found.modified())
+        .unwrap_or_else(|error| panic!("no timestamp on {}: {error}", path.display()))
 }
 
 /// The file this test binary runs the command from, under the one spelling
@@ -61,6 +100,27 @@ fn installed_before_the_bytes_were_replaced(record: &Path, bytes: &Path) {
         .open(record)
         .and_then(|file| file.set_modified(written - std::time::Duration::from_secs(60)))
         .expect("the fixture record takes a timestamp");
+}
+
+/// The same ordering for a link, whose own timestamps the standard library
+/// cannot reach: opening one follows it, so `set_modified` would stamp the
+/// file at the other end. `touch -h` reaches them, and the GNU and BSD
+/// builds both carry it.
+#[allow(clippy::expect_used)]
+fn older_than_the_command(link: &Path, command: &Path) {
+    let reference = link
+        .parent()
+        .expect("the fixture link sits in a directory")
+        .join("fixture-timestamp");
+    fs::write(&reference, "").expect("the fixture reference is written");
+    installed_before_the_bytes_were_replaced(&reference, command);
+    let stamped = Command::new("touch")
+        .args(["-h", "-r"])
+        .args([&reference, &link.to_path_buf()])
+        .status()
+        .expect("touch runs");
+    assert!(stamped.success(), "the fixture link took no timestamp");
+    fs::remove_file(&reference).expect("the fixture reference is removed");
 }
 
 /// An install made before the record existed has none, and its owner has
@@ -355,13 +415,21 @@ fn a_run_does_not_say_what_replaced_another_installs_bytes() {
     );
 }
 
-/// A record whose path and digest both still describe the file is not
-/// written at all — not rewritten with the same content, which the file
-/// alone cannot tell apart from being left alone, so the timestamp is what
-/// is read.
+/// A record whose path and digest both still describe the file keeps its
+/// content, and comes out of the run saying which version of the command
+/// it describes.
+///
+/// The content is half the answer. The other half is the timestamp: an
+/// elevated `update --force` installs the same bytes again and leaves the
+/// command newer than a record that already names it, so a run that read,
+/// hashed and then left the timestamp alone would leave that true forever
+/// and every later run would read and hash the whole command for nothing.
+/// Carrying the command's own time onto the record is what closes it, and
+/// the assertion below is that closure rather than a proxy for it: the run
+/// reads on only where the command is strictly newer.
 #[test]
 #[allow(clippy::unwrap_used)]
-fn a_record_that_still_matches_is_not_written() {
+fn a_record_that_still_matches_keeps_its_content_and_stops_being_reread() {
     let tmp = tempfile::tempdir().unwrap();
     let home = rooted(&tmp);
     let env = kendex_core::env::Env::host_rooted(&home);
@@ -372,19 +440,122 @@ fn a_record_that_still_matches_is_not_written() {
     // the timestamps refuse the case and this passes without the digest
     // ever being compared.
     installed_before_the_bytes_were_replaced(&env.installed_command_file(), &installed);
-    let untouched = fs::metadata(env.installed_command_file())
-        .unwrap()
-        .modified()
-        .unwrap();
+    let written = fs::read_to_string(env.installed_command_file()).unwrap();
 
     kendex(&home, &["verify"]);
 
     assert_eq!(
-        fs::metadata(env.installed_command_file())
-            .unwrap()
-            .modified()
-            .unwrap(),
-        untouched,
-        "a record naming the bytes that are there was written over"
+        fs::read_to_string(env.installed_command_file()).unwrap(),
+        written,
+        "a record naming the bytes that are there was rewritten"
+    );
+    assert_eq!(
+        modified(&env.installed_command_file()),
+        modified(&installed),
+        "the record still reads older than the command, so every later run rereads it"
+    );
+}
+
+/// What a repair leaves behind is the command's own time, not the moment
+/// the record was written.
+///
+/// The difference is a replacement landing between the read and the write.
+/// Stamped with the clock, that record would name the bytes this run read
+/// while claiming to be newer than the ones that replaced them, and no
+/// later run would ever look again: the state this whole change exists to
+/// repair, made permanent. Stamped with the time of the file that was
+/// read, the newer bytes are still newer and the next run repairs them.
+///
+/// The interleaving itself is not driven here. Landing a replacement
+/// inside that window needs a seam in the code under test, and this
+/// asserts the property that makes the window harmless instead.
+#[test]
+#[allow(clippy::unwrap_used)]
+fn a_repair_leaves_the_record_naming_the_bytes_it_read() {
+    let tmp = tempfile::tempdir().unwrap();
+    let home = rooted(&tmp);
+    let env = kendex_core::env::Env::host_rooted(&home);
+    let installed = the_command_that_runs();
+    kendex_core::command_update::record_command(&env, &installed, REPLACED).unwrap();
+    installed_before_the_bytes_were_replaced(&env.installed_command_file(), &installed);
+
+    kendex(&home, &["verify"]);
+
+    assert_eq!(
+        modified(&env.installed_command_file()),
+        modified(&installed),
+        "the repaired record was stamped with the clock rather than the command it read"
+    );
+}
+
+/// A pipe at the record path is not a record and is never read. Reading one
+/// with nothing writing it blocks forever, and this read happens before the
+/// arguments are parsed, so `--version` and `--help` would hang with it.
+///
+/// Driven against the built command under a deadline, since the failure is
+/// a run that does not end.
+#[test]
+#[allow(clippy::unwrap_used)]
+fn a_pipe_at_the_record_path_does_not_hold_the_command() {
+    let tmp = tempfile::tempdir().unwrap();
+    let home = rooted(&tmp);
+    let env = kendex_core::env::Env::host_rooted(&home);
+    let file = env.installed_command_file();
+    fs::create_dir_all(file.parent().unwrap()).unwrap();
+    let made = Command::new("mkfifo").arg(&file).status().unwrap();
+    assert!(
+        made.success(),
+        "the fixture pipe was not made at {}",
+        file.display()
+    );
+
+    let ended = ran_within(&home, &["--version"], std::time::Duration::from_secs(30));
+
+    assert!(ended, "the command hung on a pipe at {}", file.display());
+}
+
+/// A link at the record path is a name somebody else chose, and a write
+/// through it lands on the file at the other end. The record path is only
+/// ever a plain file this install wrote, so a link there is refused and the
+/// file it points at is left alone.
+///
+/// The link is backdated rather than the file it names: the run reads the
+/// link's own timestamp to decide the command may have moved, so a link
+/// made just now would be refused by the timestamps and this would pass
+/// without the link ever being the reason.
+#[test]
+#[allow(clippy::unwrap_used)]
+fn a_link_at_the_record_path_is_not_written_through() {
+    let tmp = tempfile::tempdir().unwrap();
+    let home = rooted(&tmp);
+    let env = kendex_core::env::Env::host_rooted(&home);
+    let file = env.installed_command_file();
+    fs::create_dir_all(file.parent().unwrap()).unwrap();
+    let installed = the_command_that_runs();
+    // A whole, valid record naming the running command with bytes that are
+    // gone: follow the link and there is every reason to rewrite it.
+    let aimed_at = home.join("someone-elses-file");
+    fs::write(
+        &aimed_at,
+        format!(
+            "{}
+{}
+",
+            installed.display(),
+            kendex_core::hash::sha256_hex(REPLACED)
+        ),
+    )
+    .unwrap();
+    let theirs = fs::read_to_string(&aimed_at).unwrap();
+    std::os::unix::fs::symlink(&aimed_at, &file).unwrap();
+    older_than_the_command(&file, &installed);
+
+    kendex(&home, &["verify"]);
+
+    assert_eq!(
+        fs::read_to_string(&aimed_at).unwrap(),
+        theirs,
+        "the run wrote through a link at {}",
+        file.display()
     );
 }

--- a/crates/core/src/command_update/record.rs
+++ b/crates/core/src/command_update/record.rs
@@ -3,12 +3,15 @@
 //!
 //! `install.sh` writes it, `kendex update` refreshes it for the binary it
 //! is running as, and every replacement rewrites it for the bytes that
-//! landed. Read by `command_update::command_beside_app`, which will not
-//! replace a file no record vouches for.
+//! landed. A replacement made under another account writes that account's
+//! record instead, so the next run from the recorded path moves this one to
+//! the bytes it finds there. Read by `command_update::command_beside_app`,
+//! which will not replace a file no record vouches for.
 
 use std::path::{Path, PathBuf};
 
 use crate::env::Env;
+use crate::install_channel::{Host, HostProbe};
 
 /// What an installer recorded about the `kendex` command it installed:
 /// where it put it, and what it put there.
@@ -119,6 +122,9 @@ fn stage(
 /// being run once, and the app would then carry the copy nobody uses and
 /// leave the one they do.
 ///
+/// A record already here goes to [`refresh_the_replaced_bytes`], which
+/// holds that rule and moves the digest alone.
+///
 /// A record already present but unreadable stays as it is. `recorded_command`
 /// reads it as no record and the app refuses the command, which is the safe
 /// direction; `kendex update` rewrites it, because that is the run replacing
@@ -131,15 +137,16 @@ pub fn record_first_run(env: &Env, running: &Path) -> Result<(), String> {
     // Asked before anything is read. Every run reaches here, `--version`
     // and `--help` included, and the answer after the first is always the
     // same one — so the steady state costs a look at one name rather than
-    // a read and a hash of the whole executable and a staging file made
-    // and unmade beside it. `symlink_metadata`, so a link occupying the
-    // name counts as occupying it.
+    // a staging file made and unmade beside it, and the arm below buys the
+    // read and the hash of the whole executable out of it too.
+    // `symlink_metadata`, so a link occupying the name counts as occupying
+    // it.
     //
     // Not the arbiter, only the cheap answer. Two runs can both see
     // nothing here; the link below is what decides which of them was
     // first.
-    if std::fs::symlink_metadata(&file).is_ok() {
-        return Ok(());
+    if let Ok(here) = std::fs::symlink_metadata(&file) {
+        return refresh_the_replaced_bytes(env, running, &here);
     }
     std::fs::create_dir_all(parent)
         .map_err(|error| format!("{} could not be created: {error}", parent.display()))?;
@@ -175,6 +182,67 @@ pub fn record_first_run(env: &Env, running: &Path) -> Result<(), String> {
         Err(error) if error.kind() == std::io::ErrorKind::AlreadyExists => Ok(()),
         Err(error) => Err(format!("{} could not be written: {error}", file.display())),
     }
+}
+
+/// Move the digest of a record that names the file this process is running
+/// from, where the bytes at that file are no longer the ones it names.
+///
+/// An update run with the privilege the desktop app lacks writes its record
+/// into the privileged account's data directory, so the record here keeps
+/// naming the bytes that run replaced. `command_beside_app` then stops
+/// matching a command kendex does own, and the card that offered the one
+/// command out of that state falls to the arm that names nobody. The person
+/// is left with a current command the app will never offer to move again.
+///
+/// What licenses the write is what licenses a first run, and it is the same
+/// file: a process running from the recorded path is the recorded command,
+/// whatever bytes it now holds, and executing them is the proof no lookup
+/// by name can offer. So the digest moves and the path does not. A record
+/// naming any other file is left alone — repointing a record by path is
+/// what `record_first_run` refuses, and it still refuses it.
+///
+/// Nothing here is privileged and nothing crosses an account. The process
+/// is the person's own, the file is the one their own [`Env`] names, and
+/// the bytes hashed are the ones this process was loaded from.
+fn refresh_the_replaced_bytes(
+    env: &Env,
+    running: &Path,
+    record_file: &std::fs::Metadata,
+) -> Result<(), String> {
+    let Some(record) = recorded_command(env) else {
+        return Ok(());
+    };
+    if Host.resolve(&record.path) != Host.resolve(running) {
+        return Ok(());
+    }
+    // The record is written after the bytes it describes — by `install.sh`,
+    // by every replacement, and by the arm above — so bytes no newer than
+    // the record are bytes it already names. Every run of every verb
+    // reaches here, and that ordering is what keeps the steady state off a
+    // read and a hash of the whole executable. Where either timestamp
+    // cannot be read the record stays as it is, which is this function's
+    // answer to everything it cannot establish; a replacement that carried
+    // an older timestamp across is missed the same way, and the record then
+    // stays exactly where it was before this arm existed.
+    let replaced = match (
+        record_file.modified(),
+        std::fs::metadata(running).and_then(|bytes| bytes.modified()),
+    ) {
+        (Ok(recorded_at), Ok(written_at)) => written_at > recorded_at,
+        _ => false,
+    };
+    if !replaced {
+        return Ok(());
+    }
+    let bytes = std::fs::read(running)
+        .map_err(|error| format!("{} could not be read: {error}", running.display()))?;
+    if crate::hash::sha256_hex(&bytes) == record.digest {
+        return Ok(());
+    }
+    // Written back under the path the record already spells, not the
+    // resolved one: the two name the same file, and a record rewritten as
+    // a link's target stops describing the name a later release replaces.
+    record_command(env, &record.path, &bytes)
 }
 
 /// The same record, taken from a file already on disk — the running

--- a/crates/core/src/command_update/record.rs
+++ b/crates/core/src/command_update/record.rs
@@ -142,11 +142,22 @@ pub fn record_first_run(env: &Env, running: &Path) -> Result<(), String> {
     // `symlink_metadata`, so a link occupying the name counts as occupying
     // it.
     //
+    // Only a plain file is read on. Anything else at that name is where
+    // this function has always stopped, and it has to stay that way: a
+    // pipe there blocks the read below and holds every run of every verb
+    // before its arguments are parsed, and a link there is a name someone
+    // else chose for a write kendex would then aim at whatever it points
+    // at. Neither is a record, and the app reads no record until the run
+    // that replaces the command writes one.
+    //
     // Not the arbiter, only the cheap answer. Two runs can both see
     // nothing here; the link below is what decides which of them was
     // first.
     if let Ok(here) = std::fs::symlink_metadata(&file) {
-        return refresh_the_replaced_bytes(env, running, &here);
+        return match here.is_file() {
+            true => refresh_the_replaced_bytes(env, running, &here),
+            false => Ok(()),
+        };
     }
     std::fs::create_dir_all(parent)
         .map_err(|error| format!("{} could not be created: {error}", parent.display()))?;
@@ -204,45 +215,80 @@ pub fn record_first_run(env: &Env, running: &Path) -> Result<(), String> {
 /// Nothing here is privileged and nothing crosses an account. The process
 /// is the person's own, the file is the one their own [`Env`] names, and
 /// the bytes hashed are the ones this process was loaded from.
+///
+/// The record's modified time is read here as which version of the command
+/// it describes, and left saying that on the way out. `record_file` is the
+/// caller's `symlink_metadata`, which has already established this is a
+/// plain file rather than a link or a pipe.
 fn refresh_the_replaced_bytes(
     env: &Env,
     running: &Path,
     record_file: &std::fs::Metadata,
 ) -> Result<(), String> {
+    let file = env.installed_command_file();
     let Some(record) = recorded_command(env) else {
         return Ok(());
     };
     if Host.resolve(&record.path) != Host.resolve(running) {
         return Ok(());
     }
-    // The record is written after the bytes it describes — by `install.sh`,
-    // by every replacement, and by the arm above — so bytes no newer than
-    // the record are bytes it already names. Every run of every verb
-    // reaches here, and that ordering is what keeps the steady state off a
-    // read and a hash of the whole executable. Where either timestamp
-    // cannot be read the record stays as it is, which is this function's
-    // answer to everything it cannot establish; a replacement that carried
-    // an older timestamp across is missed the same way, and the record then
-    // stays exactly where it was before this arm existed.
-    let replaced = match (
+    // The record's own timestamp says which version of the file it
+    // describes, so bytes no newer than that are bytes it already names.
+    // Every run of every verb reaches here, and that comparison is what
+    // keeps the steady state off a read and a hash of the whole
+    // executable. Where either timestamp cannot be read the record stays
+    // as it is, which is this function's answer to everything it cannot
+    // establish; a replacement landing on the same timestamp or an older
+    // one is missed the same way, and the record then stays exactly where
+    // it was before this arm existed.
+    let (Ok(recorded_at), Ok(written_at)) = (
         record_file.modified(),
         std::fs::metadata(running).and_then(|bytes| bytes.modified()),
-    ) {
-        (Ok(recorded_at), Ok(written_at)) => written_at > recorded_at,
-        _ => false,
+    ) else {
+        return Ok(());
     };
-    if !replaced {
+    if written_at <= recorded_at {
         return Ok(());
     }
     let bytes = std::fs::read(running)
         .map_err(|error| format!("{} could not be read: {error}", running.display()))?;
-    if crate::hash::sha256_hex(&bytes) == record.digest {
-        return Ok(());
+    // A record already naming these bytes is left as it is rather than
+    // rewritten with what it already holds. No reader can tell the two
+    // apart afterwards, and that is the point: `record_command` truncates
+    // before it writes, so rewriting would open a window where a reader
+    // sees half a record where there was a whole one.
+    if crate::hash::sha256_hex(&bytes) != record.digest {
+        // Written back under the path the record already spells, not the
+        // resolved one: the two name the same file, and a record rewritten
+        // as a link's target stops describing the name a later release
+        // replaces.
+        record_command(env, &record.path, &bytes)?;
     }
-    // Written back under the path the record already spells, not the
-    // resolved one: the two name the same file, and a record rewritten as
-    // a link's target stops describing the name a later release replaces.
-    record_command(env, &record.path, &bytes)
+    // Read before the bytes were, and stamped whether or not the digest
+    // moved. Both halves matter.
+    //
+    // Stamped even where nothing was written, or a replacement installing
+    // the same bytes again leaves the file newer than a record that
+    // already names it and every later run pays the read and the hash for
+    // nothing.
+    //
+    // Stamped with the file's own time rather than this moment, so the
+    // record never claims to describe bytes this run did not read. A
+    // replacement landing between that read and this write is then still
+    // newer than the record, and the next run repairs it. Taking the clock
+    // instead would leave the record naming bytes that are gone with a
+    // timestamp that says otherwise, which is this defect made permanent.
+    stamp(&file, written_at)
+}
+
+/// Say which version of a file a record describes, by giving the record
+/// that file's own modified time.
+fn stamp(file: &Path, written_at: std::time::SystemTime) -> Result<(), String> {
+    std::fs::File::options()
+        .write(true)
+        .open(file)
+        .and_then(|handle| handle.set_modified(written_at))
+        .map_err(|error| format!("{} could not be stamped: {error}", file.display()))
 }
 
 /// The same record, taken from a file already on disk — the running


### PR DESCRIPTION
Closes KEN-853.

The `NeedsPrivilege` card offers an elevated `kendex update`. The elevated run replaces the command and then writes its record into the privileged account's data directory, because sudo resets the environment. The person's own record still names the bytes that were replaced, `command_beside_app` stops matching, and the card falls from `NeedsPrivilege` to the arm that names nobody — so the one command the card offers works once and then stops being offered.

## The shape, and why this one

The unprivileged side refreshes the record. A process running from the recorded path *is* the recorded command, whatever bytes it now holds, and executing them is the proof no lookup by name can give — so a run from that path may move the digest of a record whose path still matches and whose digest no longer does.

That is not a new trust rule. `record_first_run` already holds it from the other side: "a record already here is repointed by the run that replaces the bytes it names and by nothing else." So the arm sits where the early return used to, moves the digest, and leaves the path exactly as the record spelled it. A record naming any other file is still refused — the second-kendex guard that function already existed for.

Rejected: *the elevated run writes nothing and says what is left to do* turns a silent failure into an instruction nobody has to follow, and still needs this mechanism to exist for the instruction to be actionable. *Privileges dropped for the record write alone* puts `setresuid`/`setgroups` — the highest-consequence code in the repo — inside a file manager, and leans on `SUDO_UID`, which is absent under `su`, `doas` or a plain root shell and is environment an attacker sometimes supplies.

## Why this cannot become the withdrawn fix

The elevated run is untouched. It still writes the privileged account's record in that account's data directory; that record is simply irrelevant to the app now. The only new write is the person's own unprivileged process writing the file its own `Env` names, holding the hash of the bytes that process was loaded from. No environment is carried across a sudo line, no path is opened with privilege, and nothing is chowned. `XDG_DATA_HOME` is read the way every other unprivileged run reads it, which is why that requirement holds without a special case.

## The steady state

A committed test asserts in prose that the steady state must cost "a look at one name, not a read and a hash of the whole executable" — reading and hashing an 11 MB command is about 6 ms on every run of every verb, `--version` included. The arm is gated on the executable's mtime being newer than the record's, which is the exact statement of "the bytes changed after the record was written" rather than a speed hack: the record is always written after the bytes it describes, by `install.sh`, by every replacement and by the first run. Steady state is two stats plus a 100-byte read. A replacement carrying an older timestamp across is missed and the record then stays where it stands today, so the failure direction is the status quo.

## The gap this leaves

The card stays `Unknown` from the moment the elevated update finishes until the person's next run of that command — any verb. Nothing else closes it: the app only reads the record, and writes one only for a command it replaced itself, which by definition it cannot do here. For someone who pastes the sudo line and then lives in the GUI, that window is unbounded. What it costs is bounded: their command is current, and what they lose is the card's offer of the *next* release, not the update they just ran.

## Tests

All four drive the built binary and read the record back through `recorded_command` rather than parsing the file: a run from the recorded path says what replaced its bytes; the record it moves is the one `XDG_DATA_HOME` names (Linux only, since `dirs` reads XDG only there, and it also asserts no record appeared under `HOME`, so the first assertion cannot pass by accident); a run does not say what replaced another install's bytes; and a record that still matches is not written, judged on mtime, since content equality cannot tell "left alone" from "rewritten identically".

Mutation-checked rather than merely green: stubbing the new arm reddens both positive tests, and deleting the path check or the digest check reddens the two must-fail controls. Both must-fail fixtures are backdated so the timestamps let the run reach the case and the check under test is the only thing that can refuse it.

`ELEVATED_UPDATE` is untouched — what the card offers is KEN-855.
