### PR TITLE
fix(KEN-1166): a cwd outside a repo refuses with a diagnostic

### DIFF
--- a/.agents/skills/orch/tests/worktree_push.sh
+++ b/.agents/skills/orch/tests/worktree_push.sh
@@ -147,8 +147,8 @@ assert_contains "$(cat "$args_log")" "push $wt --force" "the rejected flag reach
 # lives in one place. This case runs the REAL worktree script, so the two
 # scripts' wiring is held: the argument order the wrapper sends, and push's
 # own diagnostic reaching the caller. It runs FROM the worktree because the
-# worktree script resolves its project at startup and exits 128 before
-# parsing anything when its working directory is not a repository.
+# worktree script resolves its project at startup and refuses before parsing
+# anything when its working directory is not a repository.
 work="$TMP_ROOT/work-owned-typo"
 reset_state "$work"
 typo_before="$(state_json "$work")"

--- a/.agents/skills/worktree/scripts/worktree
+++ b/.agents/skills/worktree/scripts/worktree
@@ -223,11 +223,7 @@ Usage: worktree remove [ID|/path]
 
 Remove a worktree and delete its local branch when it is safely merged.
 Accepts an issue ID (resolved under the configured worktree base dir, falling
-back to the worktree registered for the issue branch) or a direct path. The
-current directory names the repository, so run remove from any checkout of it,
-the worktree being removed included: cwd relocates to the main checkout first.
-The one place it cannot run is the directory the worktrees sit in, which is in
-no repository at all.
+back to the worktree registered for the issue branch) or a direct path.
 
 Failure semantics:
   remove deletes the worktree before deleting the local branch. Configured
@@ -542,31 +538,22 @@ same_canonical_dir() {
 }
 
 # Resolve PROJECT_ROOT via git (works at any depth, inside worktrees too).
-# The assignment sits in the condition on purpose (KEN-1166): rev-parse exits
-# 128 with nothing on stdout when there is no repository, and as a bare
-# assignment under `set -e` that status escapes before the test below ever
-# runs, so every subcommand past the help dispatch died at a bare 128 with no
-# output. Any nonzero status refuses, git's own 128 and a missing git alike,
-# and so does an empty toplevel. Those causes differ, and the first call threw
-# git's account of them away, so the failure branch asks again for stderr
-# alone: without it the message names one cause for every failure and sends an
-# operator whose git is broken to a second checkout to watch it break again.
-# The lookup refuses here or not at all: nothing below resolves a repository
-# from a path argument.
+# The assignment sits in the condition on purpose (KEN-1166): under `set -e` a
+# bare assignment's nonzero status escapes before the test below can run, so
+# the refusal never printed. The failure branch re-runs the lookup for the
+# stderr the first call discarded, so the message carries git's cause.
 if ! PROJECT_ROOT="$(git rev-parse --show-toplevel 2>/dev/null)" || [[ -z "$PROJECT_ROOT" ]]; then
   GIT_LOOKUP_DIAG=""
   if ! GIT_LOOKUP_DIAG="$(git rev-parse --show-toplevel 2>&1 >/dev/null)"; then
-    # One line: git's no-repository message wraps onto two, and "fatal: " is
-    # noise under a line that already says the lookup failed.
+    # Normalize a multi-line fatal to one line; "fatal: " is noise under a line
+    # that already says the lookup failed.
     GIT_LOOKUP_DIAG="${GIT_LOOKUP_DIAG//$'\n'/ }"
     GIT_LOOKUP_DIAG="${GIT_LOOKUP_DIAG#fatal: }"
   fi
   {
     echo "Error: could not resolve a git repository from: $PWD"
     if [[ -n "$GIT_LOOKUP_DIAG" ]]; then echo "  git said: $GIT_LOOKUP_DIAG"; fi
-    echo "  The repository comes from the current directory and never from a path"
-    echo "  argument, so no command runs from here. The directory the worktrees sit"
-    echo "  in is the usual way to land here. Run it from a checkout instead:"
+    echo "  Run it from a checkout of the repository you mean:"
     echo "    cd <main checkout> && .agents/skills/worktree/scripts/worktree remove <ID|PATH>"
   } >&2
   exit 1

--- a/.agents/skills/worktree/scripts/worktree
+++ b/.agents/skills/worktree/scripts/worktree
@@ -554,7 +554,7 @@ if ! PROJECT_ROOT="$(git rev-parse --show-toplevel 2>/dev/null)" || [[ -z "$PROJ
     echo "Error: could not resolve a git repository from: $PWD"
     if [[ -n "$GIT_LOOKUP_DIAG" ]]; then echo "  git said: $GIT_LOOKUP_DIAG"; fi
     echo "  Run it from a checkout of the repository you mean:"
-    echo "    cd <main checkout> && .agents/skills/worktree/scripts/worktree remove <ID|PATH>"
+    echo "    cd <main checkout> && .agents/skills/worktree/scripts/worktree <command>"
   } >&2
   exit 1
 fi

--- a/.agents/skills/worktree/scripts/worktree
+++ b/.agents/skills/worktree/scripts/worktree
@@ -224,8 +224,10 @@ Usage: worktree remove [ID|/path]
 Remove a worktree and delete its local branch when it is safely merged.
 Accepts an issue ID (resolved under the configured worktree base dir, falling
 back to the worktree registered for the issue branch) or a direct path. The
-current directory names the repository, so removing the worktree you are
-standing in means cd-ing to the main checkout first, not to its parent.
+current directory names the repository, so run remove from any checkout of it,
+the worktree being removed included: cwd relocates to the main checkout first.
+The one place it cannot run is the directory the worktrees sit in, which is in
+no repository at all.
 
 Failure semantics:
   remove deletes the worktree before deleting the local branch. Configured
@@ -541,18 +543,30 @@ same_canonical_dir() {
 
 # Resolve PROJECT_ROOT via git (works at any depth, inside worktrees too).
 # The assignment sits in the condition on purpose (KEN-1166): rev-parse exits
-# 128 outside a repository, and as a bare assignment under `set -e` that
-# status escapes before the test below ever runs, so every subcommand died at
-# a bare 128 with no output. Any nonzero status refuses, git's own 128 and a
-# missing git alike, and so does an empty toplevel. The lookup refuses here or
-# not at all: nothing below searches upward or resolves a repository from an
-# argument.
+# 128 with nothing on stdout when there is no repository, and as a bare
+# assignment under `set -e` that status escapes before the test below ever
+# runs, so every subcommand past the help dispatch died at a bare 128 with no
+# output. Any nonzero status refuses, git's own 128 and a missing git alike,
+# and so does an empty toplevel. Those causes differ, and the first call threw
+# git's account of them away, so the failure branch asks again for stderr
+# alone: without it the message names one cause for every failure and sends an
+# operator whose git is broken to a second checkout to watch it break again.
+# The lookup refuses here or not at all: nothing below resolves a repository
+# from a path argument.
 if ! PROJECT_ROOT="$(git rev-parse --show-toplevel 2>/dev/null)" || [[ -z "$PROJECT_ROOT" ]]; then
+  GIT_LOOKUP_DIAG=""
+  if ! GIT_LOOKUP_DIAG="$(git rev-parse --show-toplevel 2>&1 >/dev/null)"; then
+    # One line: git's no-repository message wraps onto two, and "fatal: " is
+    # noise under a line that already says the lookup failed.
+    GIT_LOOKUP_DIAG="${GIT_LOOKUP_DIAG//$'\n'/ }"
+    GIT_LOOKUP_DIAG="${GIT_LOOKUP_DIAG#fatal: }"
+  fi
   {
-    echo "Error: not inside a git repository: $PWD"
-    echo "  Every worktree command reads the repository from the current directory and"
-    echo "  never searches for one. Run it from the checkout, including when removing"
-    echo "  the worktree you are standing in:"
+    echo "Error: could not resolve a git repository from: $PWD"
+    if [[ -n "$GIT_LOOKUP_DIAG" ]]; then echo "  git said: $GIT_LOOKUP_DIAG"; fi
+    echo "  The repository comes from the current directory and never from a path"
+    echo "  argument, so no command runs from here. The directory the worktrees sit"
+    echo "  in is the usual way to land here. Run it from a checkout instead:"
     echo "    cd <main checkout> && .agents/skills/worktree/scripts/worktree remove <ID|PATH>"
   } >&2
   exit 1

--- a/.agents/skills/worktree/scripts/worktree
+++ b/.agents/skills/worktree/scripts/worktree
@@ -223,7 +223,9 @@ Usage: worktree remove [ID|/path]
 
 Remove a worktree and delete its local branch when it is safely merged.
 Accepts an issue ID (resolved under the configured worktree base dir, falling
-back to the worktree registered for the issue branch) or a direct path.
+back to the worktree registered for the issue branch) or a direct path. The
+current directory names the repository, so removing the worktree you are
+standing in means cd-ing to the main checkout first, not to its parent.
 
 Failure semantics:
   remove deletes the worktree before deleting the local branch. Configured
@@ -537,10 +539,22 @@ same_canonical_dir() {
   [[ "$a" == "$b" ]]
 }
 
-# Resolve PROJECT_ROOT via git (works at any depth, inside worktrees too)
-PROJECT_ROOT="$(git rev-parse --show-toplevel 2>/dev/null)"
-if [[ -z "$PROJECT_ROOT" ]]; then
-  echo "Error: Not inside a git repository" >&2
+# Resolve PROJECT_ROOT via git (works at any depth, inside worktrees too).
+# The assignment sits in the condition on purpose (KEN-1166): rev-parse exits
+# 128 outside a repository, and as a bare assignment under `set -e` that
+# status escapes before the test below ever runs, so every subcommand died at
+# a bare 128 with no output. Any nonzero status refuses, git's own 128 and a
+# missing git alike, and so does an empty toplevel. The lookup refuses here or
+# not at all: nothing below searches upward or resolves a repository from an
+# argument.
+if ! PROJECT_ROOT="$(git rev-parse --show-toplevel 2>/dev/null)" || [[ -z "$PROJECT_ROOT" ]]; then
+  {
+    echo "Error: not inside a git repository: $PWD"
+    echo "  Every worktree command reads the repository from the current directory and"
+    echo "  never searches for one. Run it from the checkout, including when removing"
+    echo "  the worktree you are standing in:"
+    echo "    cd <main checkout> && .agents/skills/worktree/scripts/worktree remove <ID|PATH>"
+  } >&2
   exit 1
 fi
 

--- a/.agents/skills/worktree/tests/worktree_help_dispatch.sh
+++ b/.agents/skills/worktree/tests/worktree_help_dispatch.sh
@@ -139,6 +139,11 @@ elif [[ "$norepo_status" -eq 128 && "$norepo_probe" == *"not a git repository"* 
       "worktree $cmd names the cwd it could not resolve a repository from"
     assert_contains "$err" "Run it from a checkout of the repository you mean" \
       "worktree $cmd names what to do instead"
+    # One refusal serves every non-help command, so its example names none: a
+    # subcommand baked in here is the wrong next step for the other callers,
+    # and `remove` deletes a worktree and a branch.
+    assert_contains "$err" "scripts/worktree <command>" \
+      "worktree $cmd offers a recovery example with no subcommand of its own"
     assert_eq "$out" "" "worktree $cmd prints nothing on stdout outside a git repository"
   done
 

--- a/.agents/skills/worktree/tests/worktree_help_dispatch.sh
+++ b/.agents/skills/worktree/tests/worktree_help_dispatch.sh
@@ -137,7 +137,7 @@ elif [[ "$norepo_status" -eq 128 && "$norepo_probe" == *"not a git repository"* 
     assert_eq "$status" 1 "worktree $cmd exits 1 outside a git repository"
     assert_contains "$err" "could not resolve a git repository from: $NOREPO" \
       "worktree $cmd names the cwd it could not resolve a repository from"
-    assert_contains "$err" "Run it from a checkout instead" \
+    assert_contains "$err" "Run it from a checkout of the repository you mean" \
       "worktree $cmd names what to do instead"
     assert_eq "$out" "" "worktree $cmd prints nothing on stdout outside a git repository"
   done
@@ -145,12 +145,18 @@ elif [[ "$norepo_status" -eq 128 && "$norepo_probe" == *"not a git repository"* 
   # The cause is git's, not the script's guess at it. A repository with no git
   # to read it is the case that separates the two: the cwd IS a checkout, and
   # a message asserting otherwise sends the operator to a second one.
+  # LC_ALL=C like the probe above: the message under test is translated, so an
+  # unpinned locale reddens this on a workstation and nowhere else.
   mkdir -p "$TMP_ROOT/empty-bin"
   status=0
-  out=$(cd "$TEST_DIR" && PATH="$TMP_ROOT/empty-bin" "$WORKTREE_SCRIPT" list 2>"$TMP_ROOT/nogit.err") || status=$?
-  err=$(cat "$TMP_ROOT/nogit.err")
+  out=$(cd "$TEST_DIR" && LC_ALL=C PATH="$TMP_ROOT/empty-bin" "$WORKTREE_SCRIPT" list 2>"$TMP_ROOT/nogit.err") || status=$?
+  # Read the quoted line, not the whole stream: without the anchor the needle
+  # also matches the shell's own unredirected message, which is what stderr
+  # carries when the refusal quotes nothing at all.
+  said=""
+  if ! said=$(grep -F '  git said: ' "$TMP_ROOT/nogit.err"); then said=""; fi
   assert_eq "$status" 1 "worktree list exits 1 when git is not on PATH"
-  assert_contains "$err" "git: command not found" \
+  assert_contains "$said" "git: command not found" \
     "the refusal quotes git's own account rather than asserting a cause"
   assert_eq "$out" "" "worktree list prints nothing on stdout when git is not on PATH"
 else

--- a/.agents/skills/worktree/tests/worktree_help_dispatch.sh
+++ b/.agents/skills/worktree/tests/worktree_help_dispatch.sh
@@ -14,6 +14,11 @@
 # diagnostic naming the cwd rather than dying at git's bare 128 (KEN-1166).
 set -euo pipefail
 
+# A pre-commit hook exports GIT_DIR and GIT_INDEX_FILE, which point every git
+# call in this file back at the real repository: the fixtures below would be
+# built in it, and the no-repository fixture would look like a repository.
+unset GIT_DIR GIT_COMMON_DIR GIT_WORK_TREE GIT_INDEX_FILE
+
 TEST_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 WORKTREE_SCRIPT="${WORKTREE_SCRIPT:-$(cd "$TEST_DIR/.." && pwd)/scripts/worktree}"
 TMP_ROOT="$(cd "$(mktemp -d)" && pwd -P)"
@@ -130,12 +135,24 @@ elif [[ "$norepo_status" -eq 128 && "$norepo_probe" == *"not a git repository"* 
     out=$(cd "$NOREPO" && "$WORKTREE_SCRIPT" $cmd 2>"$TMP_ROOT/norepo.err") || status=$?
     err=$(cat "$TMP_ROOT/norepo.err")
     assert_eq "$status" 1 "worktree $cmd exits 1 outside a git repository"
-    assert_contains "$err" "not inside a git repository: $NOREPO" \
+    assert_contains "$err" "could not resolve a git repository from: $NOREPO" \
       "worktree $cmd names the cwd it could not resolve a repository from"
-    assert_contains "$err" "Run it from the checkout" \
+    assert_contains "$err" "Run it from a checkout instead" \
       "worktree $cmd names what to do instead"
     assert_eq "$out" "" "worktree $cmd prints nothing on stdout outside a git repository"
   done
+
+  # The cause is git's, not the script's guess at it. A repository with no git
+  # to read it is the case that separates the two: the cwd IS a checkout, and
+  # a message asserting otherwise sends the operator to a second one.
+  mkdir -p "$TMP_ROOT/empty-bin"
+  status=0
+  out=$(cd "$TEST_DIR" && PATH="$TMP_ROOT/empty-bin" "$WORKTREE_SCRIPT" list 2>"$TMP_ROOT/nogit.err") || status=$?
+  err=$(cat "$TMP_ROOT/nogit.err")
+  assert_eq "$status" 1 "worktree list exits 1 when git is not on PATH"
+  assert_contains "$err" "git: command not found" \
+    "the refusal quotes git's own account rather than asserting a cause"
+  assert_eq "$out" "" "worktree list prints nothing on stdout when git is not on PATH"
 else
   FAIL=$((FAIL + 1))
   printf '  FAIL  %s\n        status:   %s\n        diagnostic: %s\n' \

--- a/.agents/skills/worktree/tests/worktree_help_dispatch.sh
+++ b/.agents/skills/worktree/tests/worktree_help_dispatch.sh
@@ -8,6 +8,10 @@
 # the dispatcher routes. tools/tests/help-inert.test.sh holds the same
 # contract for the top-level forms, alongside the other CLIs that each
 # carried their own copy of it.
+#
+# The same boundary from the other side: a command that is not help does
+# reach the repository lookup, and outside a repository it refuses with a
+# diagnostic naming the cwd rather than dying at git's bare 128 (KEN-1166).
 set -euo pipefail
 
 TEST_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
@@ -115,6 +119,22 @@ elif [[ "$norepo_status" -eq 128 && "$norepo_probe" == *"not a git repository"* 
     status=0
     out=$(cd "$NOREPO" && "$WORKTREE_SCRIPT" "$cmd" --help) || status=$?
     assert_eq "$status" 0 "worktree $cmd --help exits 0 outside a git repository"
+  done
+
+  # Past help, the repository lookup runs and has nothing to find. It refuses
+  # once, naming the cwd and the checkout to run from; `remove` is the form
+  # that gets run from the worktrees' parent, so it is held here too.
+  for cmd in "list" "remove ISSUE-GONE"; do
+    status=0
+    # shellcheck disable=SC2086
+    out=$(cd "$NOREPO" && "$WORKTREE_SCRIPT" $cmd 2>"$TMP_ROOT/norepo.err") || status=$?
+    err=$(cat "$TMP_ROOT/norepo.err")
+    assert_eq "$status" 1 "worktree $cmd exits 1 outside a git repository"
+    assert_contains "$err" "not inside a git repository: $NOREPO" \
+      "worktree $cmd names the cwd it could not resolve a repository from"
+    assert_contains "$err" "Run it from the checkout" \
+      "worktree $cmd names what to do instead"
+    assert_eq "$out" "" "worktree $cmd prints nothing on stdout outside a git repository"
   done
 else
   FAIL=$((FAIL + 1))

--- a/changelog.d/fixed/KEN-1166.md
+++ b/changelog.d/fixed/KEN-1166.md
@@ -1,0 +1,1 @@
+- `worktree` run from outside a git repository now names that directory and the checkout to run from, instead of exiting 128 with no output.

--- a/skills/orch/tests/worktree_push.sh
+++ b/skills/orch/tests/worktree_push.sh
@@ -147,8 +147,8 @@ assert_contains "$(cat "$args_log")" "push $wt --force" "the rejected flag reach
 # lives in one place. This case runs the REAL worktree script, so the two
 # scripts' wiring is held: the argument order the wrapper sends, and push's
 # own diagnostic reaching the caller. It runs FROM the worktree because the
-# worktree script resolves its project at startup and exits 128 before
-# parsing anything when its working directory is not a repository.
+# worktree script resolves its project at startup and refuses before parsing
+# anything when its working directory is not a repository.
 work="$TMP_ROOT/work-owned-typo"
 reset_state "$work"
 typo_before="$(state_json "$work")"

--- a/skills/worktree/scripts/worktree
+++ b/skills/worktree/scripts/worktree
@@ -223,11 +223,7 @@ Usage: worktree remove [ID|/path]
 
 Remove a worktree and delete its local branch when it is safely merged.
 Accepts an issue ID (resolved under the configured worktree base dir, falling
-back to the worktree registered for the issue branch) or a direct path. The
-current directory names the repository, so run remove from any checkout of it,
-the worktree being removed included: cwd relocates to the main checkout first.
-The one place it cannot run is the directory the worktrees sit in, which is in
-no repository at all.
+back to the worktree registered for the issue branch) or a direct path.
 
 Failure semantics:
   remove deletes the worktree before deleting the local branch. Configured
@@ -542,31 +538,22 @@ same_canonical_dir() {
 }
 
 # Resolve PROJECT_ROOT via git (works at any depth, inside worktrees too).
-# The assignment sits in the condition on purpose (KEN-1166): rev-parse exits
-# 128 with nothing on stdout when there is no repository, and as a bare
-# assignment under `set -e` that status escapes before the test below ever
-# runs, so every subcommand past the help dispatch died at a bare 128 with no
-# output. Any nonzero status refuses, git's own 128 and a missing git alike,
-# and so does an empty toplevel. Those causes differ, and the first call threw
-# git's account of them away, so the failure branch asks again for stderr
-# alone: without it the message names one cause for every failure and sends an
-# operator whose git is broken to a second checkout to watch it break again.
-# The lookup refuses here or not at all: nothing below resolves a repository
-# from a path argument.
+# The assignment sits in the condition on purpose (KEN-1166): under `set -e` a
+# bare assignment's nonzero status escapes before the test below can run, so
+# the refusal never printed. The failure branch re-runs the lookup for the
+# stderr the first call discarded, so the message carries git's cause.
 if ! PROJECT_ROOT="$(git rev-parse --show-toplevel 2>/dev/null)" || [[ -z "$PROJECT_ROOT" ]]; then
   GIT_LOOKUP_DIAG=""
   if ! GIT_LOOKUP_DIAG="$(git rev-parse --show-toplevel 2>&1 >/dev/null)"; then
-    # One line: git's no-repository message wraps onto two, and "fatal: " is
-    # noise under a line that already says the lookup failed.
+    # Normalize a multi-line fatal to one line; "fatal: " is noise under a line
+    # that already says the lookup failed.
     GIT_LOOKUP_DIAG="${GIT_LOOKUP_DIAG//$'\n'/ }"
     GIT_LOOKUP_DIAG="${GIT_LOOKUP_DIAG#fatal: }"
   fi
   {
     echo "Error: could not resolve a git repository from: $PWD"
     if [[ -n "$GIT_LOOKUP_DIAG" ]]; then echo "  git said: $GIT_LOOKUP_DIAG"; fi
-    echo "  The repository comes from the current directory and never from a path"
-    echo "  argument, so no command runs from here. The directory the worktrees sit"
-    echo "  in is the usual way to land here. Run it from a checkout instead:"
+    echo "  Run it from a checkout of the repository you mean:"
     echo "    cd <main checkout> && .agents/skills/worktree/scripts/worktree remove <ID|PATH>"
   } >&2
   exit 1

--- a/skills/worktree/scripts/worktree
+++ b/skills/worktree/scripts/worktree
@@ -554,7 +554,7 @@ if ! PROJECT_ROOT="$(git rev-parse --show-toplevel 2>/dev/null)" || [[ -z "$PROJ
     echo "Error: could not resolve a git repository from: $PWD"
     if [[ -n "$GIT_LOOKUP_DIAG" ]]; then echo "  git said: $GIT_LOOKUP_DIAG"; fi
     echo "  Run it from a checkout of the repository you mean:"
-    echo "    cd <main checkout> && .agents/skills/worktree/scripts/worktree remove <ID|PATH>"
+    echo "    cd <main checkout> && .agents/skills/worktree/scripts/worktree <command>"
   } >&2
   exit 1
 fi

--- a/skills/worktree/scripts/worktree
+++ b/skills/worktree/scripts/worktree
@@ -224,8 +224,10 @@ Usage: worktree remove [ID|/path]
 Remove a worktree and delete its local branch when it is safely merged.
 Accepts an issue ID (resolved under the configured worktree base dir, falling
 back to the worktree registered for the issue branch) or a direct path. The
-current directory names the repository, so removing the worktree you are
-standing in means cd-ing to the main checkout first, not to its parent.
+current directory names the repository, so run remove from any checkout of it,
+the worktree being removed included: cwd relocates to the main checkout first.
+The one place it cannot run is the directory the worktrees sit in, which is in
+no repository at all.
 
 Failure semantics:
   remove deletes the worktree before deleting the local branch. Configured
@@ -541,18 +543,30 @@ same_canonical_dir() {
 
 # Resolve PROJECT_ROOT via git (works at any depth, inside worktrees too).
 # The assignment sits in the condition on purpose (KEN-1166): rev-parse exits
-# 128 outside a repository, and as a bare assignment under `set -e` that
-# status escapes before the test below ever runs, so every subcommand died at
-# a bare 128 with no output. Any nonzero status refuses, git's own 128 and a
-# missing git alike, and so does an empty toplevel. The lookup refuses here or
-# not at all: nothing below searches upward or resolves a repository from an
-# argument.
+# 128 with nothing on stdout when there is no repository, and as a bare
+# assignment under `set -e` that status escapes before the test below ever
+# runs, so every subcommand past the help dispatch died at a bare 128 with no
+# output. Any nonzero status refuses, git's own 128 and a missing git alike,
+# and so does an empty toplevel. Those causes differ, and the first call threw
+# git's account of them away, so the failure branch asks again for stderr
+# alone: without it the message names one cause for every failure and sends an
+# operator whose git is broken to a second checkout to watch it break again.
+# The lookup refuses here or not at all: nothing below resolves a repository
+# from a path argument.
 if ! PROJECT_ROOT="$(git rev-parse --show-toplevel 2>/dev/null)" || [[ -z "$PROJECT_ROOT" ]]; then
+  GIT_LOOKUP_DIAG=""
+  if ! GIT_LOOKUP_DIAG="$(git rev-parse --show-toplevel 2>&1 >/dev/null)"; then
+    # One line: git's no-repository message wraps onto two, and "fatal: " is
+    # noise under a line that already says the lookup failed.
+    GIT_LOOKUP_DIAG="${GIT_LOOKUP_DIAG//$'\n'/ }"
+    GIT_LOOKUP_DIAG="${GIT_LOOKUP_DIAG#fatal: }"
+  fi
   {
-    echo "Error: not inside a git repository: $PWD"
-    echo "  Every worktree command reads the repository from the current directory and"
-    echo "  never searches for one. Run it from the checkout, including when removing"
-    echo "  the worktree you are standing in:"
+    echo "Error: could not resolve a git repository from: $PWD"
+    if [[ -n "$GIT_LOOKUP_DIAG" ]]; then echo "  git said: $GIT_LOOKUP_DIAG"; fi
+    echo "  The repository comes from the current directory and never from a path"
+    echo "  argument, so no command runs from here. The directory the worktrees sit"
+    echo "  in is the usual way to land here. Run it from a checkout instead:"
     echo "    cd <main checkout> && .agents/skills/worktree/scripts/worktree remove <ID|PATH>"
   } >&2
   exit 1

--- a/skills/worktree/scripts/worktree
+++ b/skills/worktree/scripts/worktree
@@ -223,7 +223,9 @@ Usage: worktree remove [ID|/path]
 
 Remove a worktree and delete its local branch when it is safely merged.
 Accepts an issue ID (resolved under the configured worktree base dir, falling
-back to the worktree registered for the issue branch) or a direct path.
+back to the worktree registered for the issue branch) or a direct path. The
+current directory names the repository, so removing the worktree you are
+standing in means cd-ing to the main checkout first, not to its parent.
 
 Failure semantics:
   remove deletes the worktree before deleting the local branch. Configured
@@ -537,10 +539,22 @@ same_canonical_dir() {
   [[ "$a" == "$b" ]]
 }
 
-# Resolve PROJECT_ROOT via git (works at any depth, inside worktrees too)
-PROJECT_ROOT="$(git rev-parse --show-toplevel 2>/dev/null)"
-if [[ -z "$PROJECT_ROOT" ]]; then
-  echo "Error: Not inside a git repository" >&2
+# Resolve PROJECT_ROOT via git (works at any depth, inside worktrees too).
+# The assignment sits in the condition on purpose (KEN-1166): rev-parse exits
+# 128 outside a repository, and as a bare assignment under `set -e` that
+# status escapes before the test below ever runs, so every subcommand died at
+# a bare 128 with no output. Any nonzero status refuses, git's own 128 and a
+# missing git alike, and so does an empty toplevel. The lookup refuses here or
+# not at all: nothing below searches upward or resolves a repository from an
+# argument.
+if ! PROJECT_ROOT="$(git rev-parse --show-toplevel 2>/dev/null)" || [[ -z "$PROJECT_ROOT" ]]; then
+  {
+    echo "Error: not inside a git repository: $PWD"
+    echo "  Every worktree command reads the repository from the current directory and"
+    echo "  never searches for one. Run it from the checkout, including when removing"
+    echo "  the worktree you are standing in:"
+    echo "    cd <main checkout> && .agents/skills/worktree/scripts/worktree remove <ID|PATH>"
+  } >&2
   exit 1
 fi
 

--- a/skills/worktree/tests/worktree_help_dispatch.sh
+++ b/skills/worktree/tests/worktree_help_dispatch.sh
@@ -139,6 +139,11 @@ elif [[ "$norepo_status" -eq 128 && "$norepo_probe" == *"not a git repository"* 
       "worktree $cmd names the cwd it could not resolve a repository from"
     assert_contains "$err" "Run it from a checkout of the repository you mean" \
       "worktree $cmd names what to do instead"
+    # One refusal serves every non-help command, so its example names none: a
+    # subcommand baked in here is the wrong next step for the other callers,
+    # and `remove` deletes a worktree and a branch.
+    assert_contains "$err" "scripts/worktree <command>" \
+      "worktree $cmd offers a recovery example with no subcommand of its own"
     assert_eq "$out" "" "worktree $cmd prints nothing on stdout outside a git repository"
   done
 

--- a/skills/worktree/tests/worktree_help_dispatch.sh
+++ b/skills/worktree/tests/worktree_help_dispatch.sh
@@ -137,7 +137,7 @@ elif [[ "$norepo_status" -eq 128 && "$norepo_probe" == *"not a git repository"* 
     assert_eq "$status" 1 "worktree $cmd exits 1 outside a git repository"
     assert_contains "$err" "could not resolve a git repository from: $NOREPO" \
       "worktree $cmd names the cwd it could not resolve a repository from"
-    assert_contains "$err" "Run it from a checkout instead" \
+    assert_contains "$err" "Run it from a checkout of the repository you mean" \
       "worktree $cmd names what to do instead"
     assert_eq "$out" "" "worktree $cmd prints nothing on stdout outside a git repository"
   done
@@ -145,12 +145,18 @@ elif [[ "$norepo_status" -eq 128 && "$norepo_probe" == *"not a git repository"* 
   # The cause is git's, not the script's guess at it. A repository with no git
   # to read it is the case that separates the two: the cwd IS a checkout, and
   # a message asserting otherwise sends the operator to a second one.
+  # LC_ALL=C like the probe above: the message under test is translated, so an
+  # unpinned locale reddens this on a workstation and nowhere else.
   mkdir -p "$TMP_ROOT/empty-bin"
   status=0
-  out=$(cd "$TEST_DIR" && PATH="$TMP_ROOT/empty-bin" "$WORKTREE_SCRIPT" list 2>"$TMP_ROOT/nogit.err") || status=$?
-  err=$(cat "$TMP_ROOT/nogit.err")
+  out=$(cd "$TEST_DIR" && LC_ALL=C PATH="$TMP_ROOT/empty-bin" "$WORKTREE_SCRIPT" list 2>"$TMP_ROOT/nogit.err") || status=$?
+  # Read the quoted line, not the whole stream: without the anchor the needle
+  # also matches the shell's own unredirected message, which is what stderr
+  # carries when the refusal quotes nothing at all.
+  said=""
+  if ! said=$(grep -F '  git said: ' "$TMP_ROOT/nogit.err"); then said=""; fi
   assert_eq "$status" 1 "worktree list exits 1 when git is not on PATH"
-  assert_contains "$err" "git: command not found" \
+  assert_contains "$said" "git: command not found" \
     "the refusal quotes git's own account rather than asserting a cause"
   assert_eq "$out" "" "worktree list prints nothing on stdout when git is not on PATH"
 else

--- a/skills/worktree/tests/worktree_help_dispatch.sh
+++ b/skills/worktree/tests/worktree_help_dispatch.sh
@@ -14,6 +14,11 @@
 # diagnostic naming the cwd rather than dying at git's bare 128 (KEN-1166).
 set -euo pipefail
 
+# A pre-commit hook exports GIT_DIR and GIT_INDEX_FILE, which point every git
+# call in this file back at the real repository: the fixtures below would be
+# built in it, and the no-repository fixture would look like a repository.
+unset GIT_DIR GIT_COMMON_DIR GIT_WORK_TREE GIT_INDEX_FILE
+
 TEST_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 WORKTREE_SCRIPT="${WORKTREE_SCRIPT:-$(cd "$TEST_DIR/.." && pwd)/scripts/worktree}"
 TMP_ROOT="$(cd "$(mktemp -d)" && pwd -P)"
@@ -130,12 +135,24 @@ elif [[ "$norepo_status" -eq 128 && "$norepo_probe" == *"not a git repository"* 
     out=$(cd "$NOREPO" && "$WORKTREE_SCRIPT" $cmd 2>"$TMP_ROOT/norepo.err") || status=$?
     err=$(cat "$TMP_ROOT/norepo.err")
     assert_eq "$status" 1 "worktree $cmd exits 1 outside a git repository"
-    assert_contains "$err" "not inside a git repository: $NOREPO" \
+    assert_contains "$err" "could not resolve a git repository from: $NOREPO" \
       "worktree $cmd names the cwd it could not resolve a repository from"
-    assert_contains "$err" "Run it from the checkout" \
+    assert_contains "$err" "Run it from a checkout instead" \
       "worktree $cmd names what to do instead"
     assert_eq "$out" "" "worktree $cmd prints nothing on stdout outside a git repository"
   done
+
+  # The cause is git's, not the script's guess at it. A repository with no git
+  # to read it is the case that separates the two: the cwd IS a checkout, and
+  # a message asserting otherwise sends the operator to a second one.
+  mkdir -p "$TMP_ROOT/empty-bin"
+  status=0
+  out=$(cd "$TEST_DIR" && PATH="$TMP_ROOT/empty-bin" "$WORKTREE_SCRIPT" list 2>"$TMP_ROOT/nogit.err") || status=$?
+  err=$(cat "$TMP_ROOT/nogit.err")
+  assert_eq "$status" 1 "worktree list exits 1 when git is not on PATH"
+  assert_contains "$err" "git: command not found" \
+    "the refusal quotes git's own account rather than asserting a cause"
+  assert_eq "$out" "" "worktree list prints nothing on stdout when git is not on PATH"
 else
   FAIL=$((FAIL + 1))
   printf '  FAIL  %s\n        status:   %s\n        diagnostic: %s\n' \

--- a/skills/worktree/tests/worktree_help_dispatch.sh
+++ b/skills/worktree/tests/worktree_help_dispatch.sh
@@ -8,6 +8,10 @@
 # the dispatcher routes. tools/tests/help-inert.test.sh holds the same
 # contract for the top-level forms, alongside the other CLIs that each
 # carried their own copy of it.
+#
+# The same boundary from the other side: a command that is not help does
+# reach the repository lookup, and outside a repository it refuses with a
+# diagnostic naming the cwd rather than dying at git's bare 128 (KEN-1166).
 set -euo pipefail
 
 TEST_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
@@ -115,6 +119,22 @@ elif [[ "$norepo_status" -eq 128 && "$norepo_probe" == *"not a git repository"* 
     status=0
     out=$(cd "$NOREPO" && "$WORKTREE_SCRIPT" "$cmd" --help) || status=$?
     assert_eq "$status" 0 "worktree $cmd --help exits 0 outside a git repository"
+  done
+
+  # Past help, the repository lookup runs and has nothing to find. It refuses
+  # once, naming the cwd and the checkout to run from; `remove` is the form
+  # that gets run from the worktrees' parent, so it is held here too.
+  for cmd in "list" "remove ISSUE-GONE"; do
+    status=0
+    # shellcheck disable=SC2086
+    out=$(cd "$NOREPO" && "$WORKTREE_SCRIPT" $cmd 2>"$TMP_ROOT/norepo.err") || status=$?
+    err=$(cat "$TMP_ROOT/norepo.err")
+    assert_eq "$status" 1 "worktree $cmd exits 1 outside a git repository"
+    assert_contains "$err" "not inside a git repository: $NOREPO" \
+      "worktree $cmd names the cwd it could not resolve a repository from"
+    assert_contains "$err" "Run it from the checkout" \
+      "worktree $cmd names what to do instead"
+    assert_eq "$out" "" "worktree $cmd prints nothing on stdout outside a git repository"
   done
 else
   FAIL=$((FAIL + 1))

--- a/tools/size-ratchet-baseline.tsv
+++ b/tools/size-ratchet-baseline.tsv
@@ -119,5 +119,5 @@ skills/second-opinion/tests/lane-scratch-durability.test.sh	999
 skills/second-opinion/tests/review-dual-model.test.sh	1516
 skills/size-ratchet/scripts/lib/settings.sh	546
 skills/size-ratchet/scripts/size-ratchet	996
-skills/worktree/scripts/worktree	4544
+skills/worktree/scripts/worktree	4558
 skills/worktree/scripts/worktree-session-guard	442

--- a/tools/size-ratchet-baseline.tsv
+++ b/tools/size-ratchet-baseline.tsv
@@ -119,5 +119,5 @@ skills/second-opinion/tests/lane-scratch-durability.test.sh	999
 skills/second-opinion/tests/review-dual-model.test.sh	1516
 skills/size-ratchet/scripts/lib/settings.sh	546
 skills/size-ratchet/scripts/size-ratchet	996
-skills/worktree/scripts/worktree	4530
+skills/worktree/scripts/worktree	4544
 skills/worktree/scripts/worktree-session-guard	442

--- a/tools/size-ratchet-baseline.tsv
+++ b/tools/size-ratchet-baseline.tsv
@@ -119,5 +119,5 @@ skills/second-opinion/tests/lane-scratch-durability.test.sh	999
 skills/second-opinion/tests/review-dual-model.test.sh	1516
 skills/size-ratchet/scripts/lib/settings.sh	546
 skills/size-ratchet/scripts/size-ratchet	996
-skills/worktree/scripts/worktree	4558
+skills/worktree/scripts/worktree	4545
 skills/worktree/scripts/worktree-session-guard	442


### PR DESCRIPTION
## Summary

- `git rev-parse --show-toplevel` exits 128 outside a repository, and the result was assigned with a bare `PROJECT_ROOT="$(...)"`. Under `set -e` that status escapes from the assignment itself, so the script's own "not inside a git repository" check on the next line never ran — every subcommand past the help dispatch died at a bare 128 with empty stdout and stderr. The assignment moves into the `if` condition, where `set -e` leaves it alone.
- The refusal names the cwd and quotes git's own reason, so a missing git, a bare repository, and a dubious-ownership refusal each report their real cause instead of all reading as "no repository". Nothing below searches upward or resolves a repository from a path argument: the lookup refuses at the one point it cannot judge.
- `remove` is where this bit — you cannot remove the worktree you stand in from inside a directory that is about to vanish, and the obvious place to stand is the worktrees' parent, which is in no repository.

## Completed Issues

- Closes KEN-1166 - worktree script exits 128 with no output when cwd is outside a repo

## Created Issues

- KEN-1193 - Preflight lane for the bare git assignment under set -e, and the five surviving sites — Project: Skills & Agents Library

## Test Plan

`skills/worktree/tests/worktree_help_dispatch.sh` gains coverage for the boundary from the failing side, alongside the existing assertions that `--help` is answered without a repository:

- A non-help command outside any repository exits 1, names the cwd on stderr, and prints nothing on stdout.
- The refusal quotes git's own account rather than asserting a cause, anchored on the `git said: ` line the fix emits rather than on git's text wherever it appears.
- The fixture clears `GIT_DIR`, `GIT_COMMON_DIR`, `GIT_WORK_TREE` and `GIT_INDEX_FILE`, so the suite runs from a git hook and from any shell that inherits them.

Verification run on the branch:

- `skills/worktree/tests/worktree_help_dispatch.sh` — 54 pass, 0 fail; holds under an exported `GIT_DIR`/`GIT_COMMON_DIR`/`GIT_WORK_TREE`/`GIT_INDEX_FILE`, and under `LANGUAGE=de`.
- `skills/orch/tests/worktree_push.sh` — 79 pass, 0 fail. All 20 worktree suites and `tools/tests/help-inert.test.sh` green.
- Must-fail controls: reverting the guard to the bare assignment reddens the new assertions; stubbing out the diagnostic block reddens the `git said:` assertion; removing the env-var unset leaves the new coverage unrun.
- `tools/guard` exit 0, preflight clean. Size-ratchet row for `skills/worktree/scripts/worktree` moves 4530 → 4545.

https://claude.ai/code/session_012t4c7BczibebvmE9JPsTRG
