### PR TITLE
fix(KEN-1146): a NUL in a tracked text file is refused, not skipped

### DIFF
--- a/.agents/skills/size-ratchet/DEVELOPMENT.md
+++ b/.agents/skills/size-ratchet/DEVELOPMENT.md
@@ -47,19 +47,33 @@ gate could not measure is never skipped. A blob that materializes but cannot
 then be counted refuses under its own wording, naming the count of the
 materialized blob rather than the read, because the object store is not the
 fault there. A tracked path containing a tab or newline is refused loudly
-(exit 2; exclude it to skip the gate) — it cannot be represented in the
-line-oriented records.
+(exit 2) — it cannot be represented in the line-oriented records, and the
+content sniff below reaches every tracked path, so the refusal covers the
+whole tracked set rather than the measured part of it.
 
-Every blob the gate measures is sniffed for a NUL in its leading 8000 bytes,
-git's own text/binary rule, which growth-guards states as `gg_blob_is_binary`
-and preflight as `content_is_binary`. The unit does not narrow the coverage:
-a line class, a byte class, and no class at all are all sniffed, because the
+Every tracked blob is sniffed for a NUL in its leading 8000 bytes, git's own
+text/binary rule, which growth-guards states as `gg_blob_is_binary` and
+preflight as `content_is_binary`. The unit does not narrow the coverage: a
+line class, a byte class, and no class at all are all sniffed, because the
 property held is that the blob stays reviewable text, and its content decides
-that where the unit says nothing. `is_excluded` runs before the sniff, so the
-exclusion list is the escape hatch for a real binary asset and an excluded
-path pays nothing for the coverage. Under `--staged` and for any path absent
-from the worktree the blob is materialized once, and the count and the sniff
-read that one copy.
+that where the unit says nothing.
+
+The sniff's one exemption is git's own record. `git check-attr diff` answers
+`unset` for a path given `-diff` and `binary` for one given a binary diff
+driver; either way git keeps the path out of every textual diff, so its bytes
+were never reviewable text and the sniff has nothing to ask. That is the
+escape hatch for a real binary asset. The size exclusion list answers a
+different question — which paths carry no size bound — and its entries carry
+size reasons, so it decides nothing here: a size-excluded text file is sniffed
+like every other tracked path, and the two exemptions are independent. The
+attribute is resolved for the whole tracked set in ONE
+`git ls-files -z | git check-attr -z --stdin diff` before the walk; a fork per
+path is the cost shape that measured 5x when the sniff itself was tried
+per-file. Only a path that is both size-excluded and diff-exempt is read for
+nothing, so only that one is skipped outright.
+
+Under `--staged` and for any path absent from the worktree the blob is
+materialized once, and the count and the sniff read that one copy.
 
 A hit is a collection error (exit 2) naming the path and the byte's offset,
 never the byte itself. Git records such a blob as binary, so it carries no

--- a/.agents/skills/size-ratchet/DEVELOPMENT.md
+++ b/.agents/skills/size-ratchet/DEVELOPMENT.md
@@ -44,59 +44,47 @@ can neither smuggle a new offender past the gate nor loosen a baselined row.
 An index blob that cannot be read (corrupt object, promisor blob
 unavailable) is a collection error (exit 2, naming the file) — a file the
 gate could not measure is never skipped. A blob that materializes but cannot
-then be counted refuses under its own wording, naming the count of the
-materialized blob rather than the read, because the object store is not the
+then be counted refuses under its own wording — the object store is not the
 fault there. A tracked path containing a tab or newline is refused loudly
-(exit 2) — it cannot be represented in the line-oriented records, and the
-content sniff below reaches every tracked path, so the refusal covers the
-whole tracked set rather than the measured part of it.
+(exit 2) before any skip, so the refusal covers the whole tracked set, which
+is what the `check-attr` parse below relies on.
 
 Every tracked blob is sniffed for a NUL in its leading 8000 bytes, git's own
 text/binary rule, which growth-guards states as `gg_blob_is_binary` and
-preflight as `content_is_binary`. The unit does not narrow the coverage: a
-line class, a byte class, and no class at all are all sniffed, because the
-property held is that the blob stays reviewable text, and its content decides
-that where the unit says nothing.
+preflight as `content_is_binary`. The unit does not narrow the coverage: line
+class, byte class, and no class at all are all sniffed, because what is held
+is that the blob stays reviewable text, and its content decides that where
+the unit says nothing. Such a blob has no textual diff and `git grep -I`
+drops it, while `wc` still returns a number and the walk-based sibling lanes
+name it skipped and exit 0. A hit here is a collection error (exit 2) naming
+the path and the byte's offset, never the byte itself — reprinting it would
+put a NUL into the log carrying the diagnostic on. The refusal runs after the
+walk and before any mode branch, so `--seed` and `--update` refuse through
+that one place rather than writing a meaningless count into the baseline.
 
 The sniff's one exemption is git's own record. `git check-attr diff` answers
 `unset` for a path given `-diff` and `binary` for one given a binary diff
 driver; either way git keeps the path out of every textual diff, so its bytes
-were never reviewable text and the sniff has nothing to ask. That is the
-escape hatch for a real binary asset. The size exclusion list answers a
-different question — which paths carry no size bound — and its entries carry
-size reasons, so it decides nothing here: a size-excluded text file is sniffed
-like every other tracked path, and the two exemptions are independent. The
-attribute is resolved for the whole tracked set in ONE
+were never reviewable text. That is the escape hatch for a real binary asset.
+The size exclusion list answers a different question — which paths carry no
+size bound — so it grants no content exemption: a size-excluded text file is
+sniffed like every other tracked path, and only a path that is both
+size-excluded and diff-exempt is skipped outright. The attribute is resolved
+for the whole tracked set in ONE
 `git ls-files -z | git check-attr -z --stdin diff` before the walk; a fork per
 path is the cost shape that measured 5x when the sniff itself was tried
-per-file. Only a path that is both size-excluded and diff-exempt is read for
-nothing, so only that one is skipped outright.
-
-Under `--staged` and for any path absent from the worktree the blob is
-materialized once, and the count and the sniff read that one copy.
-
-A hit is a collection error (exit 2) naming the path and the byte's offset,
-never the byte itself. Git records such a blob as binary, so it carries no
-textual diff; a plain `git grep` for a line inside it answers `Binary file
-<path> matches`, and a `git grep -I` drops the path outright. No line in it
-reaches diff or grep review, while `wc` still returns a number. One raw
-control byte typed in place of its escape puts a source file in that state:
-the byte is invisible or near-invisible in the usual renderings, and the
-walk-based lanes that do see it name the path as not measured, count it in
-`GG_WALK_SKIPPED`, and still exit 0. The refusal runs before any mode
-branch, so `--seed` and `--update` refuse too rather than writing a
-meaningless line count into the baseline.
+per-file. Under `--staged`, and for any path absent from the worktree, the
+blob is materialized once and the count and the sniff read that one copy.
 
 The sniff runs in two stages, so it costs no subprocess on the files that
-pass. A bounded `read -d ''` under `LC_ALL=C` stops at a NUL, bounds itself
-in bytes, and forks nothing — which makes that stage git's rule outright: a
-status of 0 over a chunk short of the window is a NUL inside the window and
-nothing else. An `od` scan of the leading 8000 bytes then locates the byte.
-Because the prefilter is byte-exact, a scan that runs, succeeds, and finds
-nothing means one of two things: the sniff is wrong, or, on the worktree path
-where the two stages read the file separately, a write landed between them.
-Either way it refuses rather than reporting clean; the refusal itself names
-the path and says the scan located none, and leaves the mechanism here.
+pass. A bounded `read -d ''` under `LC_ALL=C` stops at a NUL and bounds
+itself in BYTES, which is the unit git's rule is stated in; that makes the
+stage git's rule outright — a status of 0 over a chunk short of the window
+means a NUL inside it and nothing else. An `od` scan then locates the byte.
+Because the prefilter is byte-exact, a scan that runs, succeeds and finds
+nothing means the sniff is wrong, or — on the worktree path, where the two
+stages read the file separately — a write landed between them. Either way it
+refuses rather than reporting clean.
 
 The baseline is policy input and never enters the measured set. A self row is
 therefore stale. This makes seed, update, and staged tightening converge

--- a/.agents/skills/size-ratchet/DEVELOPMENT.md
+++ b/.agents/skills/size-ratchet/DEVELOPMENT.md
@@ -76,7 +76,9 @@ in bytes, and forks nothing — which makes that stage git's rule outright: a
 status of 0 over a chunk short of the window is a NUL inside the window and
 nothing else. An `od` scan of the leading 8000 bytes then locates the byte.
 Because the prefilter is byte-exact, a scan that runs, succeeds, and finds
-nothing is a contradiction, and refuses rather than reporting clean.
+nothing means one of two things: the sniff is wrong, or, on the worktree path
+where the two stages read the file separately, a write landed between them.
+Either way it refuses rather than reporting clean, and says both causes.
 
 The baseline is policy input and never enters the measured set. A self row is
 therefore stale. This makes seed, update, and staged tightening converge

--- a/.agents/skills/size-ratchet/DEVELOPMENT.md
+++ b/.agents/skills/size-ratchet/DEVELOPMENT.md
@@ -50,19 +50,22 @@ fault there. A tracked path containing a tab or newline is refused loudly
 (exit 2; exclude it to skip the gate) — it cannot be represented in the
 line-oriented records.
 
-Every blob the gate measures in LINES is sniffed for a NUL in its leading
-8000 bytes, git's own text/binary rule, which growth-guards states as
-`gg_blob_is_binary` and preflight as `content_is_binary`. That is every path
-in a line class, and every path in no class at all, which falls to
-`SIZE_RATCHET_THRESHOLD` and is counted in lines. A byte class is never
-asked: it measures the whole blob, and a real asset belongs there or in the
-exclusion list.
+Every blob the gate measures is sniffed for a NUL in its leading 8000 bytes,
+git's own text/binary rule, which growth-guards states as `gg_blob_is_binary`
+and preflight as `content_is_binary`. The unit does not narrow the coverage:
+a line class, a byte class, and no class at all are all sniffed, because the
+property held is that the blob stays reviewable text, and its content decides
+that where the unit says nothing. `is_excluded` runs before the sniff, so the
+exclusion list is the escape hatch for a real binary asset and an excluded
+path pays nothing for the coverage. Under `--staged` and for any path absent
+from the worktree the blob is materialized once, and the count and the sniff
+read that one copy.
 
 A hit is a collection error (exit 2) naming the path and the byte's offset,
 never the byte itself. Git records such a blob as binary, so it carries no
 textual diff; a plain `git grep` for a line inside it answers `Binary file
 <path> matches`, and a `git grep -I` drops the path outright. No line in it
-reaches diff or grep review, while `wc -l` still returns a number. One raw
+reaches diff or grep review, while `wc` still returns a number. One raw
 control byte typed in place of its escape puts a source file in that state:
 the byte is invisible or near-invisible in the usual renderings, and the
 walk-based lanes that do see it name the path as not measured, count it in

--- a/.agents/skills/size-ratchet/DEVELOPMENT.md
+++ b/.agents/skills/size-ratchet/DEVELOPMENT.md
@@ -43,12 +43,12 @@ blob, so "every tracked file" holds on partial trees too — a sparse checkout
 can neither smuggle a new offender past the gate nor loosen a baselined row.
 An index blob that cannot be read (corrupt object, promisor blob
 unavailable) is a collection error (exit 2, naming the file) — a file the
-gate could not measure is never skipped. A blob that reads but cannot then be
-counted refuses under its own wording, naming the count of the materialized
-blob rather than the read, because the object store is not the fault there.
-A tracked path containing a tab or
-newline is refused loudly (exit 2; exclude it to skip the gate) — it cannot
-be represented in the line-oriented records.
+gate could not measure is never skipped. A blob that materializes but cannot
+then be counted refuses under its own wording, naming the count of the
+materialized blob rather than the read, because the object store is not the
+fault there. A tracked path containing a tab or newline is refused loudly
+(exit 2; exclude it to skip the gate) — it cannot be represented in the
+line-oriented records.
 
 Every blob the gate measures in LINES is sniffed for a NUL in its leading
 8000 bytes, git's own text/binary rule, which growth-guards states as
@@ -61,14 +61,14 @@ exclusion list.
 A hit is a collection error (exit 2) naming the path and the byte's offset,
 never the byte itself. Git records such a blob as binary, so it carries no
 textual diff; a plain `git grep` for a line inside it answers `Binary file
-<path> matches`, and the `git grep -I` the growth-guards lanes run drops the
-path outright. No line in it reaches diff or grep review, while `wc -l` still
-returns a number. One raw control byte typed in place of its escape puts a
-source file in that state: the byte is invisible or near-invisible in the
-usual renderings, and the walk-based lanes that do see it name the path as
-not measured, count it in `GG_WALK_SKIPPED`, and still exit 0. The refusal
-runs before any mode branch, so `--seed` and `--update` refuse too rather
-than writing a meaningless line count into the baseline.
+<path> matches`, and a `git grep -I` drops the path outright. No line in it
+reaches diff or grep review, while `wc -l` still returns a number. One raw
+control byte typed in place of its escape puts a source file in that state:
+the byte is invisible or near-invisible in the usual renderings, and the
+walk-based lanes that do see it name the path as not measured, count it in
+`GG_WALK_SKIPPED`, and still exit 0. The refusal runs before any mode
+branch, so `--seed` and `--update` refuse too rather than writing a
+meaningless line count into the baseline.
 
 The sniff runs in two stages, so it costs no subprocess on the files that
 pass. A bounded `read -d ''` under `LC_ALL=C` stops at a NUL, bounds itself

--- a/.agents/skills/size-ratchet/DEVELOPMENT.md
+++ b/.agents/skills/size-ratchet/DEVELOPMENT.md
@@ -71,7 +71,7 @@ size bound — so it grants no content exemption: a size-excluded text file is
 sniffed like every other tracked path, and only a path that is both
 size-excluded and diff-exempt is skipped outright. The attribute is resolved
 for the whole tracked set in ONE
-`git ls-files -z | git check-attr -z --stdin diff` before the walk; a fork per
+`git ls-files -z | git check-attr -z --stdin diff`, `--cached` under `--staged`; a fork per
 path is the cost shape that measured 5x when the sniff itself was tried
 per-file. Under `--staged`, and for any path absent from the worktree, the
 blob is materialized once and the count and the sniff read that one copy.

--- a/.agents/skills/size-ratchet/DEVELOPMENT.md
+++ b/.agents/skills/size-ratchet/DEVELOPMENT.md
@@ -43,25 +43,40 @@ blob, so "every tracked file" holds on partial trees too — a sparse checkout
 can neither smuggle a new offender past the gate nor loosen a baselined row.
 An index blob that cannot be read (corrupt object, promisor blob
 unavailable) is a collection error (exit 2, naming the file) — a file the
-gate could not measure is never skipped. A tracked path containing a tab or
+gate could not measure is never skipped. A blob that reads but cannot then be
+counted refuses under its own wording, naming the count of the materialized
+blob rather than the read, because the object store is not the fault there.
+A tracked path containing a tab or
 newline is refused loudly (exit 2; exclude it to skip the gate) — it cannot
 be represented in the line-oriented records.
 
-Every blob bound for a LINE class is sniffed for a NUL in its leading 8000
-bytes, git's own text/binary rule, which growth-guards states as
-`gg_blob_is_binary`. A hit is a collection error (exit 2) naming the path and
-the byte's offset, never the byte itself: git records such a blob as binary,
-so it has no diff, no `git grep` hit and no line count anyone can check,
-while `wc -l` still returns a number. One raw control byte typed in place of
-its escape puts a source file in that state and nothing else in a commit
-chain notices. Byte classes skip the sniff. They measure the whole blob, and
-a real asset belongs there or in the exclusion list.
+Every blob the gate measures in LINES is sniffed for a NUL in its leading
+8000 bytes, git's own text/binary rule, which growth-guards states as
+`gg_blob_is_binary` and preflight as `content_is_binary`. That is every path
+in a line class, and every path in no class at all, which falls to
+`SIZE_RATCHET_THRESHOLD` and is counted in lines. A byte class is never
+asked: it measures the whole blob, and a real asset belongs there or in the
+exclusion list.
+
+A hit is a collection error (exit 2) naming the path and the byte's offset,
+never the byte itself. Git records such a blob as binary, so it carries no
+textual diff; a plain `git grep` for a line inside it answers `Binary file
+<path> matches`, and the `git grep -I` the growth-guards lanes run drops the
+path outright. No line in it reaches diff or grep review, while `wc -l` still
+returns a number. One raw control byte typed in place of its escape puts a
+source file in that state: the byte is invisible or near-invisible in the
+usual renderings, and the walk-based lanes that do see it name the path as
+not measured, count it in `GG_WALK_SKIPPED`, and still exit 0. The refusal
+runs before any mode branch, so `--seed` and `--update` refuse too rather
+than writing a meaningless line count into the baseline.
 
 The sniff runs in two stages, so it costs no subprocess on the files that
-pass. A bounded `read -d ''` stops at a NUL and forks nothing. In a multibyte
-locale that bound counts characters, so a stop can sit past the window while
-a miss never can, because every character read consumed at least one byte. An
-exact `od` scan of the leading 8000 bytes then confirms a stop and locates it.
+pass. A bounded `read -d ''` under `LC_ALL=C` stops at a NUL, bounds itself
+in bytes, and forks nothing — which makes that stage git's rule outright: a
+status of 0 over a chunk short of the window is a NUL inside the window and
+nothing else. An `od` scan of the leading 8000 bytes then locates the byte.
+Because the prefilter is byte-exact, a scan that runs, succeeds, and finds
+nothing is a contradiction, and refuses rather than reporting clean.
 
 The baseline is policy input and never enters the measured set. A self row is
 therefore stale. This makes seed, update, and staged tightening converge

--- a/.agents/skills/size-ratchet/DEVELOPMENT.md
+++ b/.agents/skills/size-ratchet/DEVELOPMENT.md
@@ -66,15 +66,18 @@ The sniff's one exemption is git's own record. `git check-attr diff` answers
 `unset` for a path given `-diff` and `binary` for one given a binary diff
 driver; either way git keeps the path out of every textual diff, so its bytes
 were never reviewable text. That is the escape hatch for a real binary asset.
-The size exclusion list answers a different question — which paths carry no
-size bound — so it grants no content exemption: a size-excluded text file is
-sniffed like every other tracked path, and only a path that is both
-size-excluded and diff-exempt is skipped outright. The attribute is resolved
-for the whole tracked set in ONE
-`git ls-files -z | git check-attr -z --stdin diff`, `--cached` under `--staged`; a fork per
-path is the cost shape that measured 5x when the sniff itself was tried
-per-file. Under `--staged`, and for any path absent from the worktree, the
-blob is materialized once and the count and the sniff read that one copy.
+The read pins `core.attributesFile` to `/dev/null`, so no user-global file
+grants it; a repo-local `.git/info/attributes` still does — per-clone, never
+committed, never reviewed, and git offers no switch to skip it. The size
+exclusion list answers a different question — which paths carry no size bound
+— so it grants no content exemption: a size-excluded text file is sniffed like
+every other tracked path, and only a path that is both size-excluded and
+diff-exempt is skipped outright. The attribute is resolved for the whole
+tracked set in ONE `git ls-files -z | git check-attr -z --stdin diff`,
+`--cached` under `--staged`; a fork per path is the cost shape that measured
+5x when the sniff itself was tried per-file. Under `--staged`, and for any
+path absent from the worktree, the blob is materialized once and the count and
+the sniff read that one copy.
 
 The sniff runs in two stages, so it costs no subprocess on the files that
 pass. A bounded `read -d ''` under `LC_ALL=C` stops at a NUL and bounds

--- a/.agents/skills/size-ratchet/DEVELOPMENT.md
+++ b/.agents/skills/size-ratchet/DEVELOPMENT.md
@@ -78,7 +78,8 @@ nothing else. An `od` scan of the leading 8000 bytes then locates the byte.
 Because the prefilter is byte-exact, a scan that runs, succeeds, and finds
 nothing means one of two things: the sniff is wrong, or, on the worktree path
 where the two stages read the file separately, a write landed between them.
-Either way it refuses rather than reporting clean, and says both causes.
+Either way it refuses rather than reporting clean; the refusal itself names
+the path and says the scan located none, and leaves the mechanism here.
 
 The baseline is policy input and never enters the measured set. A self row is
 therefore stale. This makes seed, update, and staged tightening converge

--- a/.agents/skills/size-ratchet/DEVELOPMENT.md
+++ b/.agents/skills/size-ratchet/DEVELOPMENT.md
@@ -47,6 +47,22 @@ gate could not measure is never skipped. A tracked path containing a tab or
 newline is refused loudly (exit 2; exclude it to skip the gate) — it cannot
 be represented in the line-oriented records.
 
+Every blob bound for a LINE class is sniffed for a NUL in its leading 8000
+bytes, git's own text/binary rule, which growth-guards states as
+`gg_blob_is_binary`. A hit is a collection error (exit 2) naming the path and
+the byte's offset, never the byte itself: git records such a blob as binary,
+so it has no diff, no `git grep` hit and no line count anyone can check,
+while `wc -l` still returns a number. One raw control byte typed in place of
+its escape puts a source file in that state and nothing else in a commit
+chain notices. Byte classes skip the sniff. They measure the whole blob, and
+a real asset belongs there or in the exclusion list.
+
+The sniff runs in two stages, so it costs no subprocess on the files that
+pass. A bounded `read -d ''` stops at a NUL and forks nothing. In a multibyte
+locale that bound counts characters, so a stop can sit past the window while
+a miss never can, because every character read consumed at least one byte. An
+exact `od` scan of the leading 8000 bytes then confirms a stop and locates it.
+
 The baseline is policy input and never enters the measured set. A self row is
 therefore stale. This makes seed, update, and staged tightening converge
 without re-measuring output that contains its own measurement.

--- a/.agents/skills/size-ratchet/README.md
+++ b/.agents/skills/size-ratchet/README.md
@@ -68,7 +68,8 @@ that. Markdown is measured in bytes and code in lines. Flags and exit codes:
   out of every textual diff, the remedy for a tracked `.png`, `.ico` or
   `.ttf`. The [exclusion list](#exclusion-list) answers a different question,
   which paths carry no size bound, and grants no content exemption. `--seed`
-  and `--update` refuse the same way. Mechanism: `DEVELOPMENT.md`.
+  and `--update` refuse the same way. Under `--staged` that record is the index's,
+  and no global `core.attributesFile` is read. Mechanism: `DEVELOPMENT.md`.
 - Exit codes: `0` clean, `1` violations, `2` usage/config/collection error.
 
 ## Trusted HEAD baseline

--- a/.agents/skills/size-ratchet/README.md
+++ b/.agents/skills/size-ratchet/README.md
@@ -58,18 +58,18 @@ that. Markdown is measured in bytes and code in lines. Flags and exit codes:
   rows whose unit no longer matches their class, and removes rows for files
   now at/under their own threshold or no longer counted. It never adds a row
   or raises a number whose unit stayed the same, then re-checks.
-- **Refused as unmeasurable** (exit 2): a blob measured in lines carrying a
-  NUL inside its leading 8000 bytes — git's own text/binary rule. That covers
-  every path in a line class and every path in no class at all, which falls to
-  `SIZE_RATCHET_THRESHOLD` and is counted in lines. Git records such a blob as
-  binary, so it has no textual diff and no line count that means anything. The
-  diagnostic names the path and the byte's offset, never the byte; the fix is
-  the escape the language spells it with. A real binary asset belongs in a byte
-  class or the [exclusion list](#exclusion-list), neither of which counts
-  lines — that is the remedy for an unclassified `.png`, `.ico` or `.ttf`,
-  which matches no shipped class and is therefore counted in lines. `--seed`
-  and `--update` refuse the same way, so an adopting repo meets this at its
-  first seed rather than at its first check. Mechanism: `DEVELOPMENT.md`.
+- **Refused as unmeasurable** (exit 2): any counted blob carrying a NUL inside
+  its leading 8000 bytes — git's own text/binary rule. The unit does not
+  narrow it: a line class, a byte class, and no class at all are all covered,
+  because what is held is that the blob stays reviewable text and its content
+  decides that, not the number it is counted in. Git records such a blob as
+  binary, so it has no textual diff and no line of it reaches a `git grep`
+  review. The diagnostic names the path and the byte's offset, never the byte;
+  the fix is the escape the language spells it with. A real binary asset
+  belongs in the [exclusion list](#exclusion-list), which is checked before the
+  content is — that is the remedy for a tracked `.png`, `.ico` or `.ttf`.
+  `--seed` and `--update` refuse the same way, so an adopting repo meets this
+  at its first seed rather than at its first check. Mechanism: `DEVELOPMENT.md`.
 - Exit codes: `0` clean, `1` violations, `2` usage/config/collection error.
 
 ## Trusted HEAD baseline

--- a/.agents/skills/size-ratchet/README.md
+++ b/.agents/skills/size-ratchet/README.md
@@ -58,18 +58,19 @@ that. Markdown is measured in bytes and code in lines. Flags and exit codes:
   rows whose unit no longer matches their class, and removes rows for files
   now at/under their own threshold or no longer counted. It never adds a row
   or raises a number whose unit stayed the same, then re-checks.
-- **Refused as unmeasurable** (exit 2): any tracked blob carrying a NUL inside
-  its leading 8000 bytes — git's own text/binary rule, so the blob has no
-  textual diff and no line of it reaches a `git grep` review. Every class is
-  covered, and no class at all: the content decides, not the unit counted. The
-  diagnostic names the path and the byte's offset, never the byte; the fix is
-  the escape the language spells it with. The one exemption is git's own
-  record — a path `.gitattributes` gives `binary` or `-diff` is one git keeps
-  out of every textual diff, the remedy for a tracked `.png`, `.ico` or
-  `.ttf`. The [exclusion list](#exclusion-list) answers a different question,
-  which paths carry no size bound, and grants no content exemption. `--seed`
-  and `--update` refuse the same way. Under `--staged` that record is the index's,
-  and no global `core.attributesFile` is read. Mechanism: `DEVELOPMENT.md`.
+- **Refused as unmeasurable** (exit 2): any tracked blob carrying a NUL
+  inside its leading 8000 bytes — git's own text/binary rule, so the blob has
+  no textual diff and no line of it reaches a `git grep` review. Every class
+  is covered, and no class at all: the content decides, not the unit counted.
+  The diagnostic names the path and the byte's offset, never the byte; the
+  fix is the escape the language spells it with. The one exemption is git's
+  own record — a path `.gitattributes` gives `binary` or `-diff` is one git
+  keeps out of every textual diff. The [exclusion list](#exclusion-list)
+  answers a different question, which paths carry no size bound, and grants
+  no content exemption. `--seed` and `--update` refuse the same way. Under
+  `--staged` that record is the index's, and no global `core.attributesFile`
+  is read; a repo-local `.git/info/attributes` still applies and is neither
+  committed nor reviewed. Mechanism: `DEVELOPMENT.md`.
 - Exit codes: `0` clean, `1` violations, `2` usage/config/collection error.
 
 ## Trusted HEAD baseline

--- a/.agents/skills/size-ratchet/README.md
+++ b/.agents/skills/size-ratchet/README.md
@@ -58,18 +58,22 @@ that. Markdown is measured in bytes and code in lines. Flags and exit codes:
   rows whose unit no longer matches their class, and removes rows for files
   now at/under their own threshold or no longer counted. It never adds a row
   or raises a number whose unit stayed the same, then re-checks.
-- **Refused as unmeasurable** (exit 2): any counted blob carrying a NUL inside
+- **Refused as unmeasurable** (exit 2): any tracked blob carrying a NUL inside
   its leading 8000 bytes — git's own text/binary rule. The unit does not
   narrow it: a line class, a byte class, and no class at all are all covered,
   because what is held is that the blob stays reviewable text and its content
   decides that, not the number it is counted in. Git records such a blob as
   binary, so it has no textual diff and no line of it reaches a `git grep`
   review. The diagnostic names the path and the byte's offset, never the byte;
-  the fix is the escape the language spells it with. A real binary asset
-  belongs in the [exclusion list](#exclusion-list), which is checked before the
-  content is — that is the remedy for a tracked `.png`, `.ico` or `.ttf`.
-  `--seed` and `--update` refuse the same way, so an adopting repo meets this
-  at its first seed rather than at its first check. Mechanism: `DEVELOPMENT.md`.
+  the fix is the escape the language spells it with. The one exemption is
+  git's own record: a path `.gitattributes` gives `binary` or `-diff` is one
+  git keeps out of every textual diff, so it was never reviewable text — that
+  is the remedy for a tracked `.png`, `.ico` or `.ttf`. The
+  [exclusion list](#exclusion-list) answers a different question, which paths
+  carry no size bound, and grants no content exemption: a size-excluded text
+  file is sniffed like every other tracked path. `--seed` and `--update`
+  refuse the same way, so an adopting repo meets this at its first seed rather
+  than at its first check. Mechanism: `DEVELOPMENT.md`.
 - Exit codes: `0` clean, `1` violations, `2` usage/config/collection error.
 
 ## Trusted HEAD baseline

--- a/.agents/skills/size-ratchet/README.md
+++ b/.agents/skills/size-ratchet/README.md
@@ -58,6 +58,13 @@ that. Markdown is measured in bytes and code in lines. Flags and exit codes:
   rows whose unit no longer matches their class, and removes rows for files
   now at/under their own threshold or no longer counted. It never adds a row
   or raises a number whose unit stayed the same, then re-checks.
+- **Refused as unmeasurable** (exit 2): a blob in a LINE class carrying a NUL
+  inside its leading 8000 bytes — git's own text/binary rule. Git records such
+  a blob as binary, so it has no diff, no `git grep` hit and no line count that
+  means anything, while `wc -l` still returns one. The diagnostic names the
+  path and the byte's offset and never the byte itself; the fix is the escape
+  the language spells it with. A real binary asset belongs in a byte class or
+  the [exclusion list](#exclusion-list), neither of which counts lines.
 - Exit codes: `0` clean, `1` violations, `2` usage/config/collection error.
 
 ## Trusted HEAD baseline

--- a/.agents/skills/size-ratchet/README.md
+++ b/.agents/skills/size-ratchet/README.md
@@ -58,13 +58,18 @@ that. Markdown is measured in bytes and code in lines. Flags and exit codes:
   rows whose unit no longer matches their class, and removes rows for files
   now at/under their own threshold or no longer counted. It never adds a row
   or raises a number whose unit stayed the same, then re-checks.
-- **Refused as unmeasurable** (exit 2): a blob in a LINE class carrying a NUL
-  inside its leading 8000 bytes — git's own text/binary rule. Git records such
-  a blob as binary, so it has no diff, no `git grep` hit and no line count that
-  means anything, while `wc -l` still returns one. The diagnostic names the
-  path and the byte's offset and never the byte itself; the fix is the escape
-  the language spells it with. A real binary asset belongs in a byte class or
-  the [exclusion list](#exclusion-list), neither of which counts lines.
+- **Refused as unmeasurable** (exit 2): a blob measured in lines carrying a
+  NUL inside its leading 8000 bytes — git's own text/binary rule. That covers
+  every path in a line class and every path in no class at all, which falls to
+  `SIZE_RATCHET_THRESHOLD` and is counted in lines. Git records such a blob as
+  binary, so it has no textual diff and no line count that means anything. The
+  diagnostic names the path and the byte's offset, never the byte; the fix is
+  the escape the language spells it with. A real binary asset belongs in a byte
+  class or the [exclusion list](#exclusion-list), neither of which counts
+  lines — that is the remedy for an unclassified `.png`, `.ico` or `.ttf`,
+  which matches no shipped class and is therefore counted in lines. `--seed`
+  and `--update` refuse the same way, so an adopting repo meets this at its
+  first seed rather than at its first check. Mechanism: `DEVELOPMENT.md`.
 - Exit codes: `0` clean, `1` violations, `2` usage/config/collection error.
 
 ## Trusted HEAD baseline

--- a/.agents/skills/size-ratchet/README.md
+++ b/.agents/skills/size-ratchet/README.md
@@ -59,21 +59,16 @@ that. Markdown is measured in bytes and code in lines. Flags and exit codes:
   now at/under their own threshold or no longer counted. It never adds a row
   or raises a number whose unit stayed the same, then re-checks.
 - **Refused as unmeasurable** (exit 2): any tracked blob carrying a NUL inside
-  its leading 8000 bytes — git's own text/binary rule. The unit does not
-  narrow it: a line class, a byte class, and no class at all are all covered,
-  because what is held is that the blob stays reviewable text and its content
-  decides that, not the number it is counted in. Git records such a blob as
-  binary, so it has no textual diff and no line of it reaches a `git grep`
-  review. The diagnostic names the path and the byte's offset, never the byte;
-  the fix is the escape the language spells it with. The one exemption is
-  git's own record: a path `.gitattributes` gives `binary` or `-diff` is one
-  git keeps out of every textual diff, so it was never reviewable text — that
-  is the remedy for a tracked `.png`, `.ico` or `.ttf`. The
-  [exclusion list](#exclusion-list) answers a different question, which paths
-  carry no size bound, and grants no content exemption: a size-excluded text
-  file is sniffed like every other tracked path. `--seed` and `--update`
-  refuse the same way, so an adopting repo meets this at its first seed rather
-  than at its first check. Mechanism: `DEVELOPMENT.md`.
+  its leading 8000 bytes — git's own text/binary rule, so the blob has no
+  textual diff and no line of it reaches a `git grep` review. Every class is
+  covered, and no class at all: the content decides, not the unit counted. The
+  diagnostic names the path and the byte's offset, never the byte; the fix is
+  the escape the language spells it with. The one exemption is git's own
+  record — a path `.gitattributes` gives `binary` or `-diff` is one git keeps
+  out of every textual diff, the remedy for a tracked `.png`, `.ico` or
+  `.ttf`. The [exclusion list](#exclusion-list) answers a different question,
+  which paths carry no size bound, and grants no content exemption. `--seed`
+  and `--update` refuse the same way. Mechanism: `DEVELOPMENT.md`.
 - Exit codes: `0` clean, `1` violations, `2` usage/config/collection error.
 
 ## Trusted HEAD baseline

--- a/.agents/skills/size-ratchet/SKILL.md
+++ b/.agents/skills/size-ratchet/SKILL.md
@@ -53,12 +53,11 @@ Reference, repoint, raise, and unit-change behavior is one rule:
 A shrunk row under `--staged` is already lowered and staged by the run itself.
 
 **A NUL is refused, not measured.** Any tracked blob carrying a NUL in its
-leading 8000 bytes is what git calls binary, whatever unit its class counts
-in and whether or not the size exclusion list covers it. The gate exits 2
-naming the path and the byte's offset, in every mode, `--seed` and `--update`
+leading 8000 bytes is what git calls binary, whatever unit its class counts in
+and whether or not the size exclusion list covers it. The gate exits 2 naming
+the path and the byte's offset, in every mode, `--seed` and `--update`
 included. Write the escape the language spells the byte with; a real binary
-asset is declared `binary` or `-diff` in `.gitattributes`, git's own record of
-what it keeps out of a textual diff, which is the only exemption.
+asset is declared `binary` or `-diff` in `.gitattributes`, the only exemption.
 
 **Check composition before the seam.** A file over its cap whose bulk is
 inline tests needs those tests moved to the language's separate-test

--- a/.agents/skills/size-ratchet/SKILL.md
+++ b/.agents/skills/size-ratchet/SKILL.md
@@ -52,12 +52,11 @@ Reference, repoint, raise, and unit-change behavior is one rule:
 [README.md § Trusted HEAD baseline](README.md#trusted-head-baseline).
 A shrunk row under `--staged` is already lowered and staged by the run itself.
 
-**A NUL is refused, not measured.** A blob the gate counts in lines — a line
-class, or no class at all — carrying a NUL in its leading 8000 bytes is what
-git calls binary. The gate exits 2 naming the path and the byte's offset, in
-every mode, `--seed` and `--update` included. Write the escape the language
-spells the byte with; a real binary asset belongs in a byte class or the
-exclusion list.
+**A NUL is refused, not measured.** Any counted blob carrying a NUL in its
+leading 8000 bytes is what git calls binary, whatever unit its class counts
+in. The gate exits 2 naming the path and the byte's offset, in every mode,
+`--seed` and `--update` included. Write the escape the language spells the
+byte with; a real binary asset belongs in the exclusion list.
 
 **Check composition before the seam.** A file over its cap whose bulk is
 inline tests needs those tests moved to the language's separate-test

--- a/.agents/skills/size-ratchet/SKILL.md
+++ b/.agents/skills/size-ratchet/SKILL.md
@@ -52,6 +52,12 @@ Reference, repoint, raise, and unit-change behavior is one rule:
 [README.md § Trusted HEAD baseline](README.md#trusted-head-baseline).
 A shrunk row under `--staged` is already lowered and staged by the run itself.
 
+**A NUL is refused, not measured.** A blob in a line class carrying a NUL in
+its leading 8000 bytes is what git calls binary: no diff, no `git grep` hit,
+no line count worth printing. The gate exits 2 naming the path and the byte's
+offset. Write the escape the language spells the byte with; a real binary
+asset belongs in a byte class or the exclusion list.
+
 **Check composition before the seam.** A file over its cap whose bulk is
 inline tests needs those tests moved to the language's separate-test
 convention, not its concepts split; that move has no seam in it. In Rust

--- a/.agents/skills/size-ratchet/SKILL.md
+++ b/.agents/skills/size-ratchet/SKILL.md
@@ -52,11 +52,13 @@ Reference, repoint, raise, and unit-change behavior is one rule:
 [README.md § Trusted HEAD baseline](README.md#trusted-head-baseline).
 A shrunk row under `--staged` is already lowered and staged by the run itself.
 
-**A NUL is refused, not measured.** Any counted blob carrying a NUL in its
+**A NUL is refused, not measured.** Any tracked blob carrying a NUL in its
 leading 8000 bytes is what git calls binary, whatever unit its class counts
-in. The gate exits 2 naming the path and the byte's offset, in every mode,
-`--seed` and `--update` included. Write the escape the language spells the
-byte with; a real binary asset belongs in the exclusion list.
+in and whether or not the size exclusion list covers it. The gate exits 2
+naming the path and the byte's offset, in every mode, `--seed` and `--update`
+included. Write the escape the language spells the byte with; a real binary
+asset is declared `binary` or `-diff` in `.gitattributes`, git's own record of
+what it keeps out of a textual diff, which is the only exemption.
 
 **Check composition before the seam.** A file over its cap whose bulk is
 inline tests needs those tests moved to the language's separate-test

--- a/.agents/skills/size-ratchet/SKILL.md
+++ b/.agents/skills/size-ratchet/SKILL.md
@@ -52,11 +52,12 @@ Reference, repoint, raise, and unit-change behavior is one rule:
 [README.md § Trusted HEAD baseline](README.md#trusted-head-baseline).
 A shrunk row under `--staged` is already lowered and staged by the run itself.
 
-**A NUL is refused, not measured.** A blob in a line class carrying a NUL in
-its leading 8000 bytes is what git calls binary: no diff, no `git grep` hit,
-no line count worth printing. The gate exits 2 naming the path and the byte's
-offset. Write the escape the language spells the byte with; a real binary
-asset belongs in a byte class or the exclusion list.
+**A NUL is refused, not measured.** A blob the gate counts in lines — a line
+class, or no class at all — carrying a NUL in its leading 8000 bytes is what
+git calls binary. The gate exits 2 naming the path and the byte's offset, in
+every mode, `--seed` and `--update` included. Write the escape the language
+spells the byte with; a real binary asset belongs in a byte class or the
+exclusion list.
 
 **Check composition before the seam.** A file over its cap whose bulk is
 inline tests needs those tests moved to the language's separate-test

--- a/.agents/skills/size-ratchet/scripts/size-ratchet
+++ b/.agents/skills/size-ratchet/scripts/size-ratchet
@@ -578,10 +578,10 @@ note_if_binary() { # PATH BLOBFILE — records a line-class blob git reads as bi
     { seen += NF }
     END { if (found) print off }
   ')" || collection_error "could not scan '$1' for the offset of its NUL byte — refusing to report a verdict"
-  # A scan that ran, succeeded and found nothing contradicts the byte-exact
-  # prefilter that sent it here. Reporting clean on it would be the fail-open
-  # this whole sniff exists to close.
-  [ -n "$off" ] || collection_error "the content prefilter for '$1' stopped at a NUL inside its leading $NUL_SNIFF_BYTES bytes and the scan then located none — refusing to report a verdict over the contradiction"
+  # A scan that ran, succeeded and found nothing means a broken sniff, or a
+  # write between the two reads of a worktree path (staged reads one copy).
+  # Reporting clean either way is the fail-open this sniff exists to close.
+  [ -n "$off" ] || collection_error "the content prefilter for '$1' stopped at a NUL inside its leading $NUL_SNIFF_BYTES bytes and the scan then located none — the two stages read the path separately, so either the file was written between them or the sniff is wrong; refusing to report a verdict either way"
   printf '%s\t%s\n' "$1" "$off" >>"$TMP/binary.paths" \
     || collection_error "could not record the binary-content finding for '$1' — refusing to report a verdict"
 }

--- a/.agents/skills/size-ratchet/scripts/size-ratchet
+++ b/.agents/skills/size-ratchet/scripts/size-ratchet
@@ -543,14 +543,38 @@ flush_batch() { # UNIT — appends one "<path><TAB><count>" row per pending file
   cat "$TMP/batch.tsv" >>"$TMP/counts.raw" || collection_error "could not append the re-measured counts — the measurement is incomplete, refusing to report a verdict"
   clear_batch "$unit"
 }
+# Content exemption is GIT'S OWN record and nothing else. `git check-attr diff`
+# answers `unset` for a path given `-diff` and `binary` for one given a binary
+# diff driver: either way git keeps the path out of every textual diff, so its
+# bytes were never reviewable text and the sniff has nothing to ask. The size
+# exclusion list answers a different question, which paths carry no SIZE bound,
+# so it decides nothing here — a size-excluded text file is sniffed like every
+# other tracked path. ONE `check-attr` process for the whole set: a fork per
+# path is the cost shape that measured 5x when the sniff was tried per-file.
+# The `-z` stream is `path NUL attr NUL value NUL`, folded to one exempt path
+# per line; a newline in a path would misalign that, and the walk refuses every
+# such path before it reads this set.
+ATTR_EXEMPT=""
+if ! { git ls-files -z | git check-attr -z --stdin diff >"$TMP/attr.z"; }; then
+  config_error "could not resolve the 'diff' attribute over the tracked set (git ls-files | git check-attr failed) — refusing to guess what git keeps out of its textual diffs"
+fi
+attr_exempt="$(LC_ALL=C tr '\000' '\n' <"$TMP/attr.z" | awk '
+  NR % 3 == 1 { p = $0; next }
+  NR % 3 == 0 && ($0 == "unset" || $0 == "binary") { print p }
+')" || collection_error "could not read the resolved 'diff' attributes — refusing to guess what git keeps out of its textual diffs"
+ATTR_EXEMPT="$NL$attr_exempt$NL"
+is_diff_exempt() { # PATH — 0 when .gitattributes takes the path out of textual diffs
+  case "$ATTR_EXEMPT" in
+    *"$NL$1$NL"*) return 0 ;;
+  esac
+  return 1
+}
 # A blob git reads as binary is not reviewable content: git's rule is a NUL
 # inside the leading bytes, and it takes the blob out of every textual diff
-# while `wc` still returns a number. Every tracked blob this gate measures is
+# while `wc` still returns a number. Every tracked blob this gate walks is
 # asked the question, in whatever unit its class counts — the property being
 # held is that the blob is text a reviewer and a `git grep` can read, which
-# the CONTENT decides and the unit says nothing about. A real binary asset
-# belongs in the exclusion list, which `is_excluded` applies ahead of the
-# sniff, so an excluded path pays nothing for the coverage.
+# the CONTENT decides and the unit says nothing about.
 # What git and the sibling gates do with such a blob: DEVELOPMENT.md.
 #
 # LINEAGE. growth-guards' `gg_blob_is_binary` (GG_BINARY_SAMPLE) owns this
@@ -591,34 +615,46 @@ note_if_binary() { # PATH BLOBFILE — records a tracked blob git reads as binar
 while IFS= read -r -d '' rec; do
   mode="${rec%% *}"
   f="${rec#*"$TAB"}"
-  is_excluded "$f" && continue
-  case "$f" in
-    *"$NL"*) config_error "tracked path contains a newline, unrepresentable in line-oriented records (exclude it to skip the gate): '$f'" ;;
-    *"$TAB"*) config_error "tracked path contains a tab, unrepresentable in the baseline TSV (exclude it to skip the gate): '$f'" ;;
-  esac
   case "$mode" in
-    120000) continue ;; # tracked symlink — no meaningful size
+    120000) continue ;; # tracked symlink — no meaningful size, and no content
     160000) continue ;; # submodule gitlink — never countable; a baseline
   esac
-  path_threshold "$f"
-  if [ "$PU" = "b" ]; then wcflag="-c"; else wcflag="-l"; fi
+  # Both records this walk writes are line-oriented and tab-separated, and the
+  # sniff below reaches size-excluded paths too, so the refusal covers the
+  # whole tracked set rather than the measured part of it.
+  case "$f" in
+    *"$NL"*) config_error "tracked path contains a newline, unrepresentable in line-oriented records: '$f'" ;;
+    *"$TAB"*) config_error "tracked path contains a tab, unrepresentable in the baseline TSV: '$f'" ;;
+  esac
+  sniff=1
+  if is_diff_exempt "$f"; then sniff=0; fi
+  excluded=0
+  if is_excluded "$f"; then excluded=1; fi
+  # The two exemptions are independent, so only a path carrying both is skipped.
+  if [ "$excluded" -eq 1 ] && [ "$sniff" -eq 0 ]; then continue; fi
+  if [ "$excluded" -eq 0 ]; then
+    path_threshold "$f"
+    if [ "$PU" = "b" ]; then wcflag="-c"; else wcflag="-l"; fi
+  fi
   if [ "$STAGED" -eq 1 ] || [ ! -f "$f" ] || [ -h "$f" ]; then
     # Materialized once: the count and the content sniff read the same bytes,
     # and a second `git show` per path would double the walk under --staged.
     if ! git show ":$f" >"$TMP/blob"; then
-      collection_error "cannot read index blob for tracked file '$f' — its size is unmeasurable, refusing to skip it"
+      collection_error "cannot read index blob for tracked file '$f' — it can be neither measured nor classified, refusing to skip it"
     fi
+    if [ "$sniff" -eq 1 ]; then note_if_binary "$f" "$TMP/blob"; fi
+    if [ "$excluded" -eq 1 ]; then continue; fi
     if ! n="$(wc "$wcflag" <"$TMP/blob")"; then
       collection_error "cannot count the materialized index blob for tracked file '$f' — its size is unmeasurable, refusing to skip it"
     fi
-    note_if_binary "$f" "$TMP/blob"
     n="${n#"${n%%[![:space:]]*}"}" # strip wc's leading whitespace (BSD wc pads)
     case "$n" in
       "" | *[!0-9]*) collection_error "$(unit_noun "$PU") count for index blob of '$f' came back as '$n', not a number — its size is unmeasurable, refusing to skip it" ;;
     esac
     printf '%s\t%s\n' "$f" "$n" >>"$TMP/counts.raw" || collection_error "could not record the count for '$f' — the measurement is incomplete, refusing to report a verdict"
   else
-    note_if_binary "$f" "$f"
+    if [ "$sniff" -eq 1 ]; then note_if_binary "$f" "$f"; fi
+    if [ "$excluded" -eq 1 ]; then continue; fi
     if [ "$PU" = "b" ]; then
       WT_BATCH_B+=("$f")
       WT_BATCH_B_CHARS=$((WT_BATCH_B_CHARS + ${#f} + 1))
@@ -643,7 +679,7 @@ if [ -s "$TMP/binary.paths" ]; then
   while IFS="$TAB" read -r bin_path bin_off; do
     echo "$bin_path: a NUL byte at offset $bin_off" >&2
   done <"$TMP/binary.paths"
-  collection_error "the path(s) above are tracked as reviewable text but carry a NUL inside their leading $NUL_SNIFF_BYTES bytes, so git records them as binary: no textual diff, a plain \`git grep\` reduced to \"Binary file <path> matches\" and a \`git grep -I\` that drops the path outright. Write the escape your language spells the byte with (\\0, \\u0000, \\x00) instead of the raw character; a real binary asset belongs in the exclusion list."
+  collection_error "the path(s) above are tracked as reviewable text but carry a NUL inside their leading $NUL_SNIFF_BYTES bytes, so git records them as binary: no textual diff, a plain \`git grep\` reduced to \"Binary file <path> matches\" and a \`git grep -I\` that drops the path outright. Write the escape your language spells the byte with (\\0, \\u0000, \\x00) instead of the raw character; a real binary asset is declared \`binary\` or \`-diff\` in .gitattributes, which is what takes it out of git's textual diffs and out of this check."
 fi
 counted="$(count_nonempty_lines "$TMP/counts.raw")"
 [ "$counted" -eq "$checked" ] || collection_error "counted $counted of the $checked tracked file(s) selected for measurement — the collection is incomplete, refusing to report a verdict"

--- a/.agents/skills/size-ratchet/scripts/size-ratchet
+++ b/.agents/skills/size-ratchet/scripts/size-ratchet
@@ -543,6 +543,39 @@ flush_batch() { # UNIT — appends one "<path><TAB><count>" row per pending file
   cat "$TMP/batch.tsv" >>"$TMP/counts.raw" || collection_error "could not append the re-measured counts — the measurement is incomplete, refusing to report a verdict"
   clear_batch "$unit"
 }
+# A blob git reads as binary has no line count anyone can check. Git's own
+# heuristic is a NUL inside the leading bytes, the rule growth-guards states
+# as gg_blob_is_binary, and it drops the blob from every diff, `git grep` and
+# review, while `wc -l` still returns a number with nothing readable behind
+# it. One raw control byte typed into a source file instead of its escape
+# puts the file in that state and nothing else notices: the byte renders as a
+# space in every editor and tool, and every other gate passes the file. Only
+# LINE classes ask the question. A real asset carries the byte legitimately
+# and belongs in a byte class or the exclusion list, where nothing counts its
+# lines.
+NUL_SNIFF_BYTES=8000
+note_if_binary() { # PATH BLOBFILE — records a line-class blob git reads as binary
+  local chunk status=0 off
+  # `read -d ''` stops at a NUL and -n bounds the read, at no subprocess cost.
+  # In a multibyte locale that bound counts CHARACTERS, so a stop here can sit
+  # past the sniff window while a miss never can: every character read consumed
+  # at least one byte. So this decides the misses — every text file, every run
+  # — and the exact byte scan below decides and locates the rest.
+  { IFS= read -r -d '' -n "$NUL_SNIFF_BYTES" chunk || status=$?; } <"$2" \
+    || collection_error "cannot read tracked file '$1' — its content cannot be classified, refusing to skip it"
+  { [ "$status" -eq 0 ] && [ "${#chunk}" -lt "$NUL_SNIFF_BYTES" ]; } || return 0
+  # No early exit anywhere in this pipeline: an awk that stopped reading would
+  # SIGPIPE od and, under pipefail, fail the scan on the files that need it.
+  off="$(LC_ALL=C od -An -v -tx1 -N "$NUL_SNIFF_BYTES" <"$2" | awk '
+    found == 0 { for (i = 1; i <= NF; i++) if ($i == "00") { off = seen + i - 1; found = 1; break } }
+    { seen += NF }
+    END { if (found) print off }
+  ')" || collection_error "could not scan '$1' for the offset of its NUL byte — refusing to report a verdict"
+  [ -n "$off" ] || return 0
+  printf '%s\t%s\n' "$1" "$off" >>"$TMP/binary.paths" \
+    || collection_error "could not record the binary-content finding for '$1' — refusing to report a verdict"
+}
+: >"$TMP/binary.paths" || collection_error "could not initialize the binary-content scratch file"
 while IFS= read -r -d '' rec; do
   mode="${rec%% *}"
   f="${rec#*"$TAB"}"
@@ -558,9 +591,15 @@ while IFS= read -r -d '' rec; do
   path_threshold "$f"
   if [ "$PU" = "b" ]; then wcflag="-c"; else wcflag="-l"; fi
   if [ "$STAGED" -eq 1 ] || [ ! -f "$f" ] || [ -h "$f" ]; then
-    if ! n="$(git show ":$f" | wc "$wcflag")"; then
+    # Materialized once: the count and the content sniff read the same bytes,
+    # and a second `git show` per path would double the walk under --staged.
+    if ! git show ":$f" >"$TMP/blob"; then
       collection_error "cannot read index blob for tracked file '$f' — its size is unmeasurable, refusing to skip it"
     fi
+    if ! n="$(wc "$wcflag" <"$TMP/blob")"; then
+      collection_error "cannot read index blob for tracked file '$f' — its size is unmeasurable, refusing to skip it"
+    fi
+    [ "$PU" = "b" ] || note_if_binary "$f" "$TMP/blob"
     n="${n#"${n%%[![:space:]]*}"}" # strip wc's leading whitespace (BSD wc pads)
     case "$n" in
       "" | *[!0-9]*) collection_error "$(unit_noun "$PU") count for index blob of '$f' came back as '$n', not a number — its size is unmeasurable, refusing to skip it" ;;
@@ -573,6 +612,7 @@ while IFS= read -r -d '' rec; do
       flush_batch b
     fi
   else
+    note_if_binary "$f" "$f"
     WT_BATCH_L+=("$f")
     WT_BATCH_L_CHARS=$((WT_BATCH_L_CHARS + ${#f} + 1))
     if [ "${#WT_BATCH_L[@]}" -ge "$BATCH_MAX_FILES" ] || [ "$WT_BATCH_L_CHARS" -ge "$BATCH_MAX_CHARS" ]; then
@@ -583,6 +623,14 @@ while IFS= read -r -d '' rec; do
 done <"$TMP/files.z"
 flush_batch l
 flush_batch b
+if [ -s "$TMP/binary.paths" ]; then
+  # The offset alone, never the byte: echoing it back would put a NUL into the
+  # diagnostic, and the log, terminal or CI annotation carrying it next.
+  while IFS="$TAB" read -r bin_path bin_off; do
+    echo "$bin_path: a NUL byte at offset $bin_off" >&2
+  done <"$TMP/binary.paths"
+  collection_error "the path(s) above are measured in lines but carry a NUL inside their leading $NUL_SNIFF_BYTES bytes, so git records them as binary: no diff, no grep hit, no line count that means anything. Write the escape your language spells the byte with (\\0, \\u0000, \\x00) instead of the raw character; a real binary asset belongs in a byte class or the exclusion list."
+fi
 counted="$(count_nonempty_lines "$TMP/counts.raw")"
 [ "$counted" -eq "$checked" ] || collection_error "counted $counted of the $checked tracked file(s) selected for measurement — the collection is incomplete, refusing to report a verdict"
 : >"$TMP/counts.classed" || collection_error "could not initialize the classified-counts scratch file"

--- a/.agents/skills/size-ratchet/scripts/size-ratchet
+++ b/.agents/skills/size-ratchet/scripts/size-ratchet
@@ -581,7 +581,7 @@ note_if_binary() { # PATH BLOBFILE — records a line-class blob git reads as bi
   # A scan that ran, succeeded and found nothing means a broken sniff, or a
   # write between the two reads of a worktree path (staged reads one copy).
   # Reporting clean either way is the fail-open this sniff exists to close.
-  [ -n "$off" ] || collection_error "the content prefilter for '$1' stopped at a NUL inside its leading $NUL_SNIFF_BYTES bytes and the scan then located none — the two stages read the path separately, so either the file was written between them or the sniff is wrong; refusing to report a verdict either way"
+  [ -n "$off" ] || collection_error "the content prefilter for '$1' stopped at a NUL inside its leading $NUL_SNIFF_BYTES bytes and the scan then located none — refusing to report a verdict"
   printf '%s\t%s\n' "$1" "$off" >>"$TMP/binary.paths" \
     || collection_error "could not record the binary-content finding for '$1' — refusing to report a verdict"
 }

--- a/.agents/skills/size-ratchet/scripts/size-ratchet
+++ b/.agents/skills/size-ratchet/scripts/size-ratchet
@@ -543,24 +543,31 @@ flush_batch() { # UNIT — appends one "<path><TAB><count>" row per pending file
   cat "$TMP/batch.tsv" >>"$TMP/counts.raw" || collection_error "could not append the re-measured counts — the measurement is incomplete, refusing to report a verdict"
   clear_batch "$unit"
 }
-# A blob git reads as binary has no line count anyone can check. Git's own
-# heuristic is a NUL inside the leading bytes, the rule growth-guards states
-# as gg_blob_is_binary, and it drops the blob from every diff, `git grep` and
-# review, while `wc -l` still returns a number with nothing readable behind
-# it. One raw control byte typed into a source file instead of its escape
-# puts the file in that state and nothing else notices: the byte renders as a
-# space in every editor and tool, and every other gate passes the file. Only
-# LINE classes ask the question. A real asset carries the byte legitimately
-# and belongs in a byte class or the exclusion list, where nothing counts its
-# lines.
+# A blob git reads as binary has no line count anyone can check: git's rule
+# is a NUL inside the leading bytes, and it takes the blob out of every
+# textual diff while `wc -l` still returns a number. Every blob this gate
+# measures in LINES is asked the question — a path matching no class at all
+# resolves to SIZE_RATCHET_THRESHOLD in lines and is asked too. A byte class
+# is not asked, and a real asset belongs there or in the exclusion list.
+# What git and the sibling gates do with such a blob: DEVELOPMENT.md.
+#
+# LINEAGE. growth-guards' `gg_blob_is_binary` (GG_BINARY_SAMPLE) owns this
+# rule and preflight's `content_is_binary` (BINARY_SAMPLE) is its other copy.
+# This third one answers the same question by a different mechanism: the gate
+# sniffs every tracked file rather than a matched subset, and it needs the
+# byte offset a boolean does not return. The window and the verdict move
+# together across all three.
 NUL_SNIFF_BYTES=8000
 note_if_binary() { # PATH BLOBFILE — records a line-class blob git reads as binary
-  local chunk status=0 off
-  # `read -d ''` stops at a NUL and -n bounds the read, at no subprocess cost.
-  # In a multibyte locale that bound counts CHARACTERS, so a stop here can sit
-  # past the sniff window while a miss never can: every character read consumed
-  # at least one byte. So this decides the misses — every text file, every run
-  # — and the exact byte scan below decides and locates the rest.
+  # LC_ALL=C for the whole function: it makes the `read` bound and `${#chunk}`
+  # below count BYTES, which is what git's rule is stated in. Without it a
+  # multibyte locale counts characters and the prefilter reads past the window.
+  local LC_ALL=C chunk status=0 off
+  # `read -d ''` stops at a NUL and -n bounds the read, at no subprocess cost,
+  # so this stage decides every miss — every text file, every run — without
+  # forking. Byte-exact, it is git's rule outright: a status of 0 over a chunk
+  # short of the window means a NUL inside the window and nothing else. The
+  # scan below confirms that and locates the byte.
   { IFS= read -r -d '' -n "$NUL_SNIFF_BYTES" chunk || status=$?; } <"$2" \
     || collection_error "cannot read tracked file '$1' — its content cannot be classified, refusing to skip it"
   { [ "$status" -eq 0 ] && [ "${#chunk}" -lt "$NUL_SNIFF_BYTES" ]; } || return 0
@@ -571,7 +578,10 @@ note_if_binary() { # PATH BLOBFILE — records a line-class blob git reads as bi
     { seen += NF }
     END { if (found) print off }
   ')" || collection_error "could not scan '$1' for the offset of its NUL byte — refusing to report a verdict"
-  [ -n "$off" ] || return 0
+  # A scan that ran, succeeded and found nothing contradicts the byte-exact
+  # prefilter that sent it here. Reporting clean on it would be the fail-open
+  # this whole sniff exists to close.
+  [ -n "$off" ] || collection_error "the content prefilter for '$1' stopped at a NUL inside its leading $NUL_SNIFF_BYTES bytes and the scan then located none — refusing to report a verdict over the contradiction"
   printf '%s\t%s\n' "$1" "$off" >>"$TMP/binary.paths" \
     || collection_error "could not record the binary-content finding for '$1' — refusing to report a verdict"
 }
@@ -591,15 +601,23 @@ while IFS= read -r -d '' rec; do
   path_threshold "$f"
   if [ "$PU" = "b" ]; then wcflag="-c"; else wcflag="-l"; fi
   if [ "$STAGED" -eq 1 ] || [ ! -f "$f" ] || [ -h "$f" ]; then
-    # Materialized once: the count and the content sniff read the same bytes,
-    # and a second `git show` per path would double the walk under --staged.
-    if ! git show ":$f" >"$TMP/blob"; then
-      collection_error "cannot read index blob for tracked file '$f' — its size is unmeasurable, refusing to skip it"
+    if [ "$PU" = "b" ]; then
+      # Nothing sniffs a byte class, so the count streams and no copy of the
+      # blob lands on the scratch filesystem.
+      if ! n="$(git show ":$f" | wc "$wcflag")"; then
+        collection_error "cannot read index blob for tracked file '$f' — its size is unmeasurable, refusing to skip it"
+      fi
+    else
+      # Materialized once: the count and the content sniff read the same bytes,
+      # and a second `git show` per path would double the walk under --staged.
+      if ! git show ":$f" >"$TMP/blob"; then
+        collection_error "cannot read index blob for tracked file '$f' — its size is unmeasurable, refusing to skip it"
+      fi
+      if ! n="$(wc "$wcflag" <"$TMP/blob")"; then
+        collection_error "cannot count the materialized index blob for tracked file '$f' — its size is unmeasurable, refusing to skip it"
+      fi
+      note_if_binary "$f" "$TMP/blob"
     fi
-    if ! n="$(wc "$wcflag" <"$TMP/blob")"; then
-      collection_error "cannot read index blob for tracked file '$f' — its size is unmeasurable, refusing to skip it"
-    fi
-    [ "$PU" = "b" ] || note_if_binary "$f" "$TMP/blob"
     n="${n#"${n%%[![:space:]]*}"}" # strip wc's leading whitespace (BSD wc pads)
     case "$n" in
       "" | *[!0-9]*) collection_error "$(unit_noun "$PU") count for index blob of '$f' came back as '$n', not a number — its size is unmeasurable, refusing to skip it" ;;
@@ -629,7 +647,7 @@ if [ -s "$TMP/binary.paths" ]; then
   while IFS="$TAB" read -r bin_path bin_off; do
     echo "$bin_path: a NUL byte at offset $bin_off" >&2
   done <"$TMP/binary.paths"
-  collection_error "the path(s) above are measured in lines but carry a NUL inside their leading $NUL_SNIFF_BYTES bytes, so git records them as binary: no diff, no grep hit, no line count that means anything. Write the escape your language spells the byte with (\\0, \\u0000, \\x00) instead of the raw character; a real binary asset belongs in a byte class or the exclusion list."
+  collection_error "the path(s) above are measured in lines but carry a NUL inside their leading $NUL_SNIFF_BYTES bytes, so git records them as binary: no textual diff, a plain \`git grep\` reduced to \"Binary file <path> matches\" and a \`git grep -I\` that drops the path outright, and no line count that means anything. Write the escape your language spells the byte with (\\0, \\u0000, \\x00) instead of the raw character; a real binary asset belongs in a byte class or the exclusion list."
 fi
 counted="$(count_nonempty_lines "$TMP/counts.raw")"
 [ "$counted" -eq "$checked" ] || collection_error "counted $counted of the $checked tracked file(s) selected for measurement — the collection is incomplete, refusing to report a verdict"

--- a/.agents/skills/size-ratchet/scripts/size-ratchet
+++ b/.agents/skills/size-ratchet/scripts/size-ratchet
@@ -555,7 +555,7 @@ flush_batch() { # UNIT — appends one "<path><TAB><count>" row per pending file
 # per line; a newline in a path would misalign it, and the walk refuses every
 # such path before any verdict — a shift exempts nothing regardless.
 ATTR_EXEMPT=""
-if ! { git ls-files -z | git -c core.attributesFile=/dev/null check-attr -z ${ATTR_SCOPE} --stdin diff >"$TMP/attr.z"; }; then
+if ! { git ls-files -z | GIT_ATTR_NOSYSTEM=1 git -c core.attributesFile=/dev/null check-attr -z ${ATTR_SCOPE} --stdin diff >"$TMP/attr.z"; }; then
   config_error "could not resolve the 'diff' attribute over the tracked set (git ls-files | git check-attr failed) — refusing to guess what git keeps out of its textual diffs"
 fi
 attr_exempt="$(LC_ALL=C tr '\000' '\n' <"$TMP/attr.z" | awk '

--- a/.agents/skills/size-ratchet/scripts/size-ratchet
+++ b/.agents/skills/size-ratchet/scripts/size-ratchet
@@ -552,8 +552,8 @@ flush_batch() { # UNIT — appends one "<path><TAB><count>" row per pending file
 # other tracked path. ONE `check-attr` process for the whole set: a fork per
 # path is the cost shape that measured 5x when the sniff was tried per-file.
 # The `-z` stream is `path NUL attr NUL value NUL`, folded to one exempt path
-# per line; a newline in a path would misalign that, and the walk refuses every
-# such path before it reads this set.
+# per line; a newline in a path would misalign it, and the walk refuses every
+# such path before any verdict — a shift exempts nothing regardless.
 ATTR_EXEMPT=""
 if ! { git ls-files -z | git check-attr -z --stdin diff >"$TMP/attr.z"; }; then
   config_error "could not resolve the 'diff' attribute over the tracked set (git ls-files | git check-attr failed) — refusing to guess what git keeps out of its textual diffs"
@@ -615,16 +615,16 @@ note_if_binary() { # PATH BLOBFILE — records a tracked blob git reads as binar
 while IFS= read -r -d '' rec; do
   mode="${rec%% *}"
   f="${rec#*"$TAB"}"
-  case "$mode" in
-    120000) continue ;; # tracked symlink — no meaningful size, and no content
-    160000) continue ;; # submodule gitlink — never countable; a baseline
-  esac
-  # Both records this walk writes are line-oriented and tab-separated, and the
-  # sniff below reaches size-excluded paths too, so the refusal covers the
-  # whole tracked set rather than the measured part of it.
+  # Above every skip: both records this walk writes are line-oriented and
+  # tab-separated, and the check-attr parse below relies on the refusal
+  # covering the whole tracked set, symlinks and gitlinks included.
   case "$f" in
     *"$NL"*) config_error "tracked path contains a newline, unrepresentable in line-oriented records: '$f'" ;;
     *"$TAB"*) config_error "tracked path contains a tab, unrepresentable in the baseline TSV: '$f'" ;;
+  esac
+  case "$mode" in
+    120000) continue ;; # tracked symlink — no meaningful size, and no content
+    160000) continue ;; # submodule gitlink — never countable; a baseline
   esac
   sniff=1
   if is_diff_exempt "$f"; then sniff=0; fi

--- a/.agents/skills/size-ratchet/scripts/size-ratchet
+++ b/.agents/skills/size-ratchet/scripts/size-ratchet
@@ -543,12 +543,14 @@ flush_batch() { # UNIT — appends one "<path><TAB><count>" row per pending file
   cat "$TMP/batch.tsv" >>"$TMP/counts.raw" || collection_error "could not append the re-measured counts — the measurement is incomplete, refusing to report a verdict"
   clear_batch "$unit"
 }
-# A blob git reads as binary has no line count anyone can check: git's rule
-# is a NUL inside the leading bytes, and it takes the blob out of every
-# textual diff while `wc -l` still returns a number. Every blob this gate
-# measures in LINES is asked the question — a path matching no class at all
-# resolves to SIZE_RATCHET_THRESHOLD in lines and is asked too. A byte class
-# is not asked, and a real asset belongs there or in the exclusion list.
+# A blob git reads as binary is not reviewable content: git's rule is a NUL
+# inside the leading bytes, and it takes the blob out of every textual diff
+# while `wc` still returns a number. Every tracked blob this gate measures is
+# asked the question, in whatever unit its class counts — the property being
+# held is that the blob is text a reviewer and a `git grep` can read, which
+# the CONTENT decides and the unit says nothing about. A real binary asset
+# belongs in the exclusion list, which `is_excluded` applies ahead of the
+# sniff, so an excluded path pays nothing for the coverage.
 # What git and the sibling gates do with such a blob: DEVELOPMENT.md.
 #
 # LINEAGE. growth-guards' `gg_blob_is_binary` (GG_BINARY_SAMPLE) owns this
@@ -558,7 +560,7 @@ flush_batch() { # UNIT — appends one "<path><TAB><count>" row per pending file
 # byte offset a boolean does not return. The window and the verdict move
 # together across all three.
 NUL_SNIFF_BYTES=8000
-note_if_binary() { # PATH BLOBFILE — records a line-class blob git reads as binary
+note_if_binary() { # PATH BLOBFILE — records a tracked blob git reads as binary
   # LC_ALL=C for the whole function: it makes the `read` bound and `${#chunk}`
   # below count BYTES, which is what git's rule is stated in. Without it a
   # multibyte locale counts characters and the prefilter reads past the window.
@@ -601,40 +603,34 @@ while IFS= read -r -d '' rec; do
   path_threshold "$f"
   if [ "$PU" = "b" ]; then wcflag="-c"; else wcflag="-l"; fi
   if [ "$STAGED" -eq 1 ] || [ ! -f "$f" ] || [ -h "$f" ]; then
-    if [ "$PU" = "b" ]; then
-      # Nothing sniffs a byte class, so the count streams and no copy of the
-      # blob lands on the scratch filesystem.
-      if ! n="$(git show ":$f" | wc "$wcflag")"; then
-        collection_error "cannot read index blob for tracked file '$f' — its size is unmeasurable, refusing to skip it"
-      fi
-    else
-      # Materialized once: the count and the content sniff read the same bytes,
-      # and a second `git show` per path would double the walk under --staged.
-      if ! git show ":$f" >"$TMP/blob"; then
-        collection_error "cannot read index blob for tracked file '$f' — its size is unmeasurable, refusing to skip it"
-      fi
-      if ! n="$(wc "$wcflag" <"$TMP/blob")"; then
-        collection_error "cannot count the materialized index blob for tracked file '$f' — its size is unmeasurable, refusing to skip it"
-      fi
-      note_if_binary "$f" "$TMP/blob"
+    # Materialized once: the count and the content sniff read the same bytes,
+    # and a second `git show` per path would double the walk under --staged.
+    if ! git show ":$f" >"$TMP/blob"; then
+      collection_error "cannot read index blob for tracked file '$f' — its size is unmeasurable, refusing to skip it"
     fi
+    if ! n="$(wc "$wcflag" <"$TMP/blob")"; then
+      collection_error "cannot count the materialized index blob for tracked file '$f' — its size is unmeasurable, refusing to skip it"
+    fi
+    note_if_binary "$f" "$TMP/blob"
     n="${n#"${n%%[![:space:]]*}"}" # strip wc's leading whitespace (BSD wc pads)
     case "$n" in
       "" | *[!0-9]*) collection_error "$(unit_noun "$PU") count for index blob of '$f' came back as '$n', not a number — its size is unmeasurable, refusing to skip it" ;;
     esac
     printf '%s\t%s\n' "$f" "$n" >>"$TMP/counts.raw" || collection_error "could not record the count for '$f' — the measurement is incomplete, refusing to report a verdict"
-  elif [ "$PU" = "b" ]; then
-    WT_BATCH_B+=("$f")
-    WT_BATCH_B_CHARS=$((WT_BATCH_B_CHARS + ${#f} + 1))
-    if [ "${#WT_BATCH_B[@]}" -ge "$BATCH_MAX_FILES" ] || [ "$WT_BATCH_B_CHARS" -ge "$BATCH_MAX_CHARS" ]; then
-      flush_batch b
-    fi
   else
     note_if_binary "$f" "$f"
-    WT_BATCH_L+=("$f")
-    WT_BATCH_L_CHARS=$((WT_BATCH_L_CHARS + ${#f} + 1))
-    if [ "${#WT_BATCH_L[@]}" -ge "$BATCH_MAX_FILES" ] || [ "$WT_BATCH_L_CHARS" -ge "$BATCH_MAX_CHARS" ]; then
-      flush_batch l
+    if [ "$PU" = "b" ]; then
+      WT_BATCH_B+=("$f")
+      WT_BATCH_B_CHARS=$((WT_BATCH_B_CHARS + ${#f} + 1))
+      if [ "${#WT_BATCH_B[@]}" -ge "$BATCH_MAX_FILES" ] || [ "$WT_BATCH_B_CHARS" -ge "$BATCH_MAX_CHARS" ]; then
+        flush_batch b
+      fi
+    else
+      WT_BATCH_L+=("$f")
+      WT_BATCH_L_CHARS=$((WT_BATCH_L_CHARS + ${#f} + 1))
+      if [ "${#WT_BATCH_L[@]}" -ge "$BATCH_MAX_FILES" ] || [ "$WT_BATCH_L_CHARS" -ge "$BATCH_MAX_CHARS" ]; then
+        flush_batch l
+      fi
     fi
   fi
   checked=$((checked + 1))
@@ -647,7 +643,7 @@ if [ -s "$TMP/binary.paths" ]; then
   while IFS="$TAB" read -r bin_path bin_off; do
     echo "$bin_path: a NUL byte at offset $bin_off" >&2
   done <"$TMP/binary.paths"
-  collection_error "the path(s) above are measured in lines but carry a NUL inside their leading $NUL_SNIFF_BYTES bytes, so git records them as binary: no textual diff, a plain \`git grep\` reduced to \"Binary file <path> matches\" and a \`git grep -I\` that drops the path outright, and no line count that means anything. Write the escape your language spells the byte with (\\0, \\u0000, \\x00) instead of the raw character; a real binary asset belongs in a byte class or the exclusion list."
+  collection_error "the path(s) above are tracked as reviewable text but carry a NUL inside their leading $NUL_SNIFF_BYTES bytes, so git records them as binary: no textual diff, a plain \`git grep\` reduced to \"Binary file <path> matches\" and a \`git grep -I\` that drops the path outright. Write the escape your language spells the byte with (\\0, \\u0000, \\x00) instead of the raw character; a real binary asset belongs in the exclusion list."
 fi
 counted="$(count_nonempty_lines "$TMP/counts.raw")"
 [ "$counted" -eq "$checked" ] || collection_error "counted $counted of the $checked tracked file(s) selected for measurement — the collection is incomplete, refusing to report a verdict"

--- a/.agents/skills/size-ratchet/scripts/size-ratchet
+++ b/.agents/skills/size-ratchet/scripts/size-ratchet
@@ -9,7 +9,7 @@ NL='
 SHIPPED_CLASSES="AGENTS.md=24k;CLAUDE.md=24k;*/AGENTS.md=24k;*/CLAUDE.md=24k;*/SKILL.md=24k;*/workflows/*.md=40k;*.md=64k;tests/*=800;*/tests/*=800;test/*=800;*/test/*=800;__tests__/*=800;*/__tests__/*=800;tests.rs=800;*/tests.rs=800;*test_util.rs=800;*.test.*=800;*.spec.*=800"
 SHIPPED_FROZEN_CLASSES="*.md;tests/*;*/tests/*;test/*;*/test/*;__tests__/*;*/__tests__/*;tests.rs;*/tests.rs;*test_util.rs;*.test.*;*.spec.*"
 DEFAULT_EXCLUDES="CHANGELOG*.md${TAB}one long file is the documented norm; entries carry the rule"
-STAGED=0
+STAGED=0 ATTR_SCOPE=""
 usage() {
   cat <<'EOF'
 usage: size-ratchet [--staged] [--update | --seed] [--baseline FILE] [--excludes FILE]
@@ -91,7 +91,7 @@ while [ $# -gt 0 ]; do
       usage
       exit 0
       ;;
-    --staged) STAGED=1 ;;
+    --staged) STAGED=1 ATTR_SCOPE=--cached ;; # attributes from the index too
     *) config_error "unknown argument '$1' (see --help)" ;;
   esac
   shift
@@ -555,7 +555,7 @@ flush_batch() { # UNIT — appends one "<path><TAB><count>" row per pending file
 # per line; a newline in a path would misalign it, and the walk refuses every
 # such path before any verdict — a shift exempts nothing regardless.
 ATTR_EXEMPT=""
-if ! { git ls-files -z | git check-attr -z --stdin diff >"$TMP/attr.z"; }; then
+if ! { git ls-files -z | git -c core.attributesFile=/dev/null check-attr -z ${ATTR_SCOPE} --stdin diff >"$TMP/attr.z"; }; then
   config_error "could not resolve the 'diff' attribute over the tracked set (git ls-files | git check-attr failed) — refusing to guess what git keeps out of its textual diffs"
 fi
 attr_exempt="$(LC_ALL=C tr '\000' '\n' <"$TMP/attr.z" | awk '

--- a/.agents/skills/size-ratchet/tests/binary-content.test.sh
+++ b/.agents/skills/size-ratchet/tests/binary-content.test.sh
@@ -189,6 +189,62 @@ for probe in "7999 2 inside" "8000 0 outside"; do
   fi
 done
 
+echo "=== the 8000 bound is bytes even when the locale is multibyte ==="
+# The prefilter's `read -n` bound counts CHARACTERS unless the locale is C, so
+# a NUL past byte 8000 but inside 8000 characters would stop a character-wise
+# read while `od -N 8000` correctly finds nothing — and the contradiction
+# refusal above would then red a file git reads as text. 5000 x U+00E9 is 5000
+# characters and 10000 bytes: the byte at offset 10000 is outside the window by
+# git's rule and inside it by the character count.
+plant_wide_nul() { # 5000 two-byte characters in $R/src/installed.ts, then the byte
+  mkdir -p "$R/src"
+  { awk 'BEGIN { for (i = 0; i < 5000; i++) printf "\303\251" }'; printf '\000'; printf '\n'; } >"$R/src/installed.ts"
+  git -C "$R" add -A
+}
+# No locale is assumed present: the case needs a multibyte one to say anything.
+utf8_locale="$({ locale -a 2>/dev/null || true; } | awk 'tolower($0) ~ /\.utf-?8$/ && !f { v = $0; f = 1 } END { if (f) print v }')"
+if [ -z "$utf8_locale" ]; then
+  printf '  skip  the byte-bound case needs a UTF-8 locale; `locale -a` lists none here\n'
+else
+  new_repo bytebound
+  plant_wide_nul
+  run_in "LC_ALL=$utf8_locale" "LANG=$utf8_locale" SIZE_RATCHET_THRESHOLD=400 -- --staged
+  if [ "$RC" -eq 0 ] && ! has 'located none'; then
+    ok "under $utf8_locale a NUL past byte 8000 leaves the blob text (exit 0)"
+  else
+    bad "the sniff bound counts bytes under a multibyte locale" "rc=$RC out=$OUT"
+  fi
+
+  echo "=== must-fail control: without LC_ALL=C the same fixture is refused ==="
+  # Exit 0 is also what a sniff that never ran returns, so the case above is
+  # evidence only beside a control that reds. The control removes the two words
+  # that make the bound bytes and nothing else.
+  BOUND="$TMP/bound-scripts"
+  mkdir -p "$BOUND"
+  cp -R "$SKILL_DIR/scripts/." "$BOUND/"
+  BOUND_ANCHOR='  local LC_ALL=C chunk status=0 off'
+  if awk -v anchor="$BOUND_ANCHOR" '
+      $0 == anchor { print "  local chunk status=0 off"; n++; next }
+      { print }
+      END { exit (n == 1 ? 0 : 3) }
+    ' "$BOUND/size-ratchet" >"$BOUND/size-ratchet.mut"; then
+    mv "$BOUND/size-ratchet.mut" "$BOUND/size-ratchet"
+    chmod +x "$BOUND/size-ratchet"
+    new_repo boundctrl
+    plant_wide_nul
+    GATE="$BOUND/size-ratchet"
+    run_in "LC_ALL=$utf8_locale" "LANG=$utf8_locale" SIZE_RATCHET_THRESHOLD=400 -- --staged
+    GATE="$SR"
+    if [ "$RC" -eq 2 ] && has 'located none'; then
+      ok "a character-counting bound refuses the same fixture — the case above is evidence"
+    else
+      bad "the control removes the byte bound it should" "rc=$RC out=$OUT"
+    fi
+  else
+    bad "the byte-bound control's substitution matched exactly one site" "no single '$BOUND_ANCHOR' line in $BOUND/size-ratchet"
+  fi
+fi
+
 echo "=== a locating scan that comes back empty refuses, it does not pass ==="
 # The prefilter is byte-exact, so a stop it reports and a scan that then finds
 # nothing are a contradiction. Treating that as clean would be the fail-open

--- a/.agents/skills/size-ratchet/tests/binary-content.test.sh
+++ b/.agents/skills/size-ratchet/tests/binary-content.test.sh
@@ -1,16 +1,19 @@
 #!/usr/bin/env bash
 # Pins the refusal on a line-class blob git reads as binary. A raw NUL typed
-# into a source file instead of its escape makes git call the file binary:
-# no diff, no `git grep` hit, no blame — and `wc -l` still returns a number,
-# so the gate used to report a clean measurement over content nobody could
-# read. The gate now refuses that blob by name and byte offset.
+# into a source file instead of its escape makes git call the file binary: no
+# textual diff, a plain `git grep` reduced to `Binary file <path> matches` and
+# a `git grep -I` that drops the path — and `wc -l` still returns a number, so
+# the gate used to report a clean measurement over content nobody could read.
+# The gate now refuses that blob by name and byte offset.
 #
-# Pinned here: the refusal fires in both scopes (index and worktree), the
-# offset is counted in BYTES and located inside the sniff window, the same
-# bytes in a BYTE class pass because nothing counts their lines, an excluded
-# path stays excluded, and the diagnostic never carries the byte itself.
-# The must-fail control at the end reverts the refusal and shows the NUL
-# fixture going green, so the green cases above are evidence.
+# Pinned here: the refusal fires in both scopes (index and worktree) and in
+# --seed and --update, where a miss would write a meaningless count into the
+# baseline; every offender is named, not just the first; the offset is counted
+# in BYTES and located inside the sniff window; the same bytes in a BYTE class
+# pass because nothing counts their lines; an excluded path stays excluded; a
+# scan that comes back empty is a refusal, not a pass; and the diagnostic never
+# carries the byte itself. The must-fail control at the end reverts the refusal
+# and shows the NUL fixture going green, so the green cases above are evidence.
 set -euo pipefail
 
 TEST_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
@@ -185,6 +188,75 @@ for probe in "7999 2 inside" "8000 0 outside"; do
     bad "the window boundary matches git's rule at offset $pad" "rc=$RC want=$want_rc out=$OUT"
   fi
 done
+
+echo "=== a locating scan that comes back empty refuses, it does not pass ==="
+# The prefilter is byte-exact, so a stop it reports and a scan that then finds
+# nothing are a contradiction. Treating that as clean would be the fail-open
+# the sniff exists to close: an `od` that exits 0 saying nothing must not buy
+# a passing verdict over a NUL-carrying blob. An `od` that exits NONZERO is
+# already caught by pipefail; this is the quiet-success half.
+OD_SHIM="$TMP/od-shim"
+mkdir -p "$OD_SHIM"
+printf '#!/usr/bin/env bash\nexit 0\n' >"$OD_SHIM/od"
+chmod +x "$OD_SHIM/od"
+new_repo scanempty
+plant_nul src/installed.ts 'const a = "x'
+git -C "$R" add -A
+run_in "PATH=$OD_SHIM:$PATH" SIZE_RATCHET_THRESHOLD=400 -- --staged
+if [ "$RC" -eq 2 ] && has "src/installed.ts" && has "located none"; then
+  ok "an od that succeeds and prints nothing is a refusal (exit 2), naming the path"
+else
+  bad "an empty locating scan refuses rather than reporting clean" "rc=$RC out=$OUT"
+fi
+case "$OUT" in *"size-ratchet: OK"*) bad "no OK verdict may accompany the empty scan" "$OUT" ;; *) ok "no OK verdict accompanies the empty scan" ;; esac
+
+echo "=== every offender is named, not just the first ==="
+# The refusal is an aggregation: one row per offender, read back by the
+# reporting loop. That is the shape a repo meets when it adopts the gate —
+# several binary assets in a line class red together, as this repo's own
+# tauri icons did — so a regression to first-offender-only must red here.
+new_repo many
+plant_nul src/a.ts 'const a = "x'
+plant_nul src/b.ts 'const b = "xy'
+plant_nul src/c.ts 'const c = "xyz'
+git -C "$R" add -A
+run_in SIZE_RATCHET_THRESHOLD=400 -- --staged
+named="$(grep -c 'a NUL byte at offset' "$OUTFILE")" || named=0
+if [ "$RC" -eq 2 ] && [ "$named" -eq 3 ] \
+  && has 'src/a.ts: a NUL byte at offset 12' \
+  && has 'src/b.ts: a NUL byte at offset 13' \
+  && has 'src/c.ts: a NUL byte at offset 14'; then
+  ok "all three offenders are named, each at its own offset"
+else
+  bad "the diagnostic names every offender" "rc=$RC named=$named out=$OUT"
+fi
+
+echo "=== --seed refuses and writes no baseline ==="
+# A miss in a writing mode does not merely print a clean verdict: it records a
+# meaningless line count for a binary blob and locks it in.
+new_repo seedmode
+plant_nul src/installed.ts 'const a = "x'
+git -C "$R" add -A
+run_in SIZE_RATCHET_THRESHOLD=400 -- --seed
+if [ "$RC" -eq 2 ] && has 'src/installed.ts: a NUL byte at offset 12' && [ ! -e "$R/tools/size-ratchet-baseline.tsv" ]; then
+  ok "--seed refuses (exit 2) and writes no baseline at all"
+else
+  bad "--seed refuses before it seeds a row" "rc=$RC baseline=$(cat "$R/tools/size-ratchet-baseline.tsv" 2>/dev/null || echo absent) out=$OUT"
+fi
+
+echo "=== --update refuses and leaves the baseline row verbatim ==="
+new_repo updatemode
+plant_nul src/installed.ts 'const a = "x'
+mkdir -p "$R/tools"
+printf 'src/installed.ts\t9999\n' >"$R/tools/size-ratchet-baseline.tsv"
+git -C "$R" add -A
+run_in SIZE_RATCHET_THRESHOLD=400 -- --update
+row="$(cat "$R/tools/size-ratchet-baseline.tsv")"
+if [ "$RC" -eq 2 ] && has 'src/installed.ts: a NUL byte at offset 12' && [ "$row" = "$(printf 'src/installed.ts\t9999')" ]; then
+  ok "--update refuses (exit 2) and the baseline row survives verbatim"
+else
+  bad "--update refuses before it tightens a row" "rc=$RC row=$row out=$OUT"
+fi
 
 echo "=== must-fail control: with the refusal reverted, the NUL fixture goes green ==="
 # The control keeps every call site and the whole detection text and removes

--- a/.agents/skills/size-ratchet/tests/binary-content.test.sh
+++ b/.agents/skills/size-ratchet/tests/binary-content.test.sh
@@ -1,21 +1,18 @@
 #!/usr/bin/env bash
-# Pins the refusal on a tracked blob git reads as binary. A raw NUL typed
-# into a source file instead of its escape makes git call the file binary: no
-# textual diff, a plain `git grep` reduced to `Binary file <path> matches` and
-# a `git grep -I` that drops the path — and `wc -l` still returns a number, so
-# the gate used to report a clean measurement over content nobody could read.
-# The gate now refuses that blob by name and byte offset.
+# Pins the refusal on a tracked blob git reads as binary. A raw NUL typed in
+# place of its escape makes git call the file binary — no textual diff, a
+# `git grep -I` that drops the path — while `wc -l` still returns a number, so
+# the gate used to measure content nobody could read. It now refuses by name
+# and byte offset.
 #
-# Pinned here: the refusal fires in both scopes (index and worktree) and in
-# --seed and --update, where a miss would write a meaningless count into the
-# baseline; every offender is named, not just the first; the offset is counted
-# in BYTES and located inside the sniff window; a byte class is refused too,
-# because the property is the content and not the unit; a SIZE-excluded text
-# path is sniffed like every other path, git's own diff attribute being the
-# only exemption; a scan that comes back empty is a refusal, not a pass; and
-# the diagnostic never carries the byte itself. The must-fail control at the
-# end reverts the refusal and shows the NUL fixture going green, so the green
-# cases above are evidence.
+# Pinned here: the refusal fires in both scopes (index and worktree), and in
+# every mode, since it runs before the --seed and --update branches; a byte
+# class is refused too, the content deciding and not the unit; a SIZE-excluded
+# text path is sniffed like every other, git's own diff attribute the only
+# exemption; the sniff window is bounded in bytes under any locale; and a scan
+# that comes back empty refuses rather than passing. Each must-fail control
+# reverts one behavior and shows the fixture going green, so the green cases
+# are evidence.
 set -euo pipefail
 
 TEST_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
@@ -47,9 +44,8 @@ new_repo() { # NAME
   git -C "$R" config user.name test
 }
 
-# The fixture bytes: a one-line TypeScript source whose string literal carries
-# a raw U+0000 where the author meant to type the escape. `printf` writes the
-# byte; nothing in this file ever holds one, so this suite is itself readable.
+# A one-line TypeScript source whose string literal carries a raw U+0000 where
+# the escape was meant. `printf` writes it, so this suite holds no NUL itself.
 plant_nul() { # PATH LEADING-BYTES
   mkdir -p "$R/$(dirname "$1")"
   { printf '%s' "$2"; printf '\000'; printf 'y";\n'; } >"$R/$1"
@@ -109,8 +105,8 @@ else
 fi
 
 echo "=== the diagnostic never reprints the byte ==="
-# Reprinting it would put a NUL into the log, terminal or CI annotation that
-# carries the diagnostic onward — the same invisibility, one layer out.
+# Reprinting it puts the byte into whatever log or CI annotation carries the
+# diagnostic onward — the same invisibility, one layer out.
 total="$(wc -c <"$OUTFILE")"
 stripped="$(LC_ALL=C tr -d '\000' <"$OUTFILE" | wc -c)"
 if [ "$((total))" -eq "$((stripped))" ] && [ "$((total))" -gt 0 ]; then
@@ -120,9 +116,8 @@ else
 fi
 
 echo "=== a BYTE class is refused too — the content decides, not the unit ==="
-# The whole markdown surface a repo reviews sits in byte classes, so a rule
-# keyed on the measurement unit would leave every SKILL.md, AGENTS.md and
-# workflow doc free to carry the byte and still read `OK`.
+# A repo's whole markdown surface sits in byte classes, so a rule keyed on the
+# unit would leave every SKILL.md and AGENTS.md free to carry the byte.
 new_repo byteclass
 plant_nul skills/demo/SKILL.md 'const a = "x'
 git -C "$R" add -A
@@ -132,8 +127,7 @@ if [ "$RC" -eq 2 ] && has 'skills/demo/SKILL.md: a NUL byte at offset 12'; then
 else
   bad "a byte class is asked about its content too" "rc=$RC out=$OUT"
 fi
-# CI runs the gate without --staged, and a repo's whole markdown surface sits
-# in byte classes, so the arm that reads the worktree copy is the half a NUL
+# CI runs the gate without --staged, so the worktree arm is the half a NUL
 # reaching main would meet. Pinned here, not inferred from the index arm.
 run_in SIZE_RATCHET_THRESHOLD=400 SIZE_RATCHET_CLASSES='*/SKILL.md=24k'
 if [ "$RC" -eq 2 ] && has 'skills/demo/SKILL.md: a NUL byte at offset 12'; then
@@ -144,8 +138,7 @@ fi
 
 echo "=== must-fail control: keyed on the unit again, the same fixture goes green ==="
 # The control restores the one thing that changed — the sniff answering only
-# where the resolved unit is lines — and leaves every call site and the whole
-# diagnostic standing, so a green run here is what the case above rules out.
+# where the resolved unit is lines — and leaves every call site standing.
 UNIT="$TMP/unit-scripts"
 mkdir -p "$UNIT"
 cp -R "$SKILL_DIR/scripts/." "$UNIT/"
@@ -173,10 +166,9 @@ else
 fi
 
 echo "=== a SIZE-excluded text path is sniffed like any other ==="
-# The size exclusion list answers which paths carry no SIZE bound, and its
-# entries carry size reasons — a lockfile, a generated bundle, an append-only
-# log. Reading it as a content exemption too let every one of those carry the
-# byte unseen, the shipped CHANGELOG*.md default worst of all.
+# The exclusion list answers which paths carry no SIZE bound. Reading it as a
+# content exemption let every entry carry the byte unseen — a lockfile, a
+# generated bundle, the shipped CHANGELOG*.md default worst of all.
 new_repo excluded
 plant_nul assets/icon.png 'const a = "x'
 mkdir -p "$R/tools"
@@ -190,10 +182,9 @@ else
 fi
 
 echo "=== and git's own diff attribute is what exempts it ==="
-# The exemption authority is the record git already keeps: a path declared
-# binary (or -diff) is one git keeps out of every textual diff, so its bytes
-# were never reviewable text. Same fixture, same exclusion list, one line of
-# .gitattributes added.
+# The authority is the record git already keeps: a path declared binary (or
+# -diff) is out of every textual diff, so its bytes were never reviewable
+# text. Same fixture, same exclusion list, one .gitattributes line added.
 printf 'assets/* binary\n' >"$R/.gitattributes"
 git -C "$R" add -A
 run_in SIZE_RATCHET_THRESHOLD=400 -- --staged
@@ -205,8 +196,7 @@ fi
 
 echo "=== must-fail control: with the size list back in charge, the same fixture goes green ==="
 # The control restores the one thing that changed — the size exclusion
-# short-circuiting the walk before the sniff — and leaves the attribute
-# lookup, every call site and the whole diagnostic standing.
+# short-circuiting the walk before the sniff — and leaves the rest standing.
 EXC="$TMP/excl-scripts"
 mkdir -p "$EXC"
 cp -R "$SKILL_DIR/scripts/." "$EXC/"
@@ -236,8 +226,7 @@ else
 fi
 
 echo "=== the worktree scan CI runs refuses the same blob ==="
-# CI runs the gate without --staged, over a clean checkout: a NUL that reached
-# main must red there too, not only at the commit that introduced it.
+# A NUL that reached main must red in CI too, not only at its commit.
 new_repo worktree
 plant_nul src/installed.ts 'const a = "x'
 git -C "$R" add -A
@@ -248,48 +237,12 @@ else
   bad "the no---staged scan refuses it too" "rc=$RC out=$OUT"
 fi
 
-echo "=== the offset counts bytes, not characters ==="
-# 100 x U+00E9 is 100 characters and 200 bytes. A count that came from the
-# shell's character-wise read would report 100 here.
-new_repo multibyte
-mkdir -p "$R/src"
-{ awk 'BEGIN { for (i = 0; i < 100; i++) printf "\303\251" }'; printf '\000'; printf '";\n'; } >"$R/src/installed.ts"
-git -C "$R" add -A
-run_in SIZE_RATCHET_THRESHOLD=400 -- --staged
-if [ "$RC" -eq 2 ] && has 'src/installed.ts: a NUL byte at offset 200'; then
-  ok "a NUL behind 100 two-byte characters is reported at byte offset 200"
-else
-  bad "the offset is a byte offset" "rc=$RC out=$OUT"
-fi
-
-echo "=== the sniff window is the leading 8000 bytes, git's own rule ==="
-# git reads a blob as text when no NUL falls in the leading 8000 bytes, so
-# the gate must agree at the boundary in both directions — a byte at offset
-# 7999 is inside the window, one at 8000 is not.
-for probe in "7999 2 inside" "8000 0 outside"; do
-  set -- $probe
-  pad="$1"
-  want_rc="$2"
-  where="$3"
-  new_repo "window-$pad"
-  mkdir -p "$R/src"
-  { awk -v n="$pad" 'BEGIN { for (i = 0; i < n; i++) printf "x" }'; printf '\000'; printf '\n'; } >"$R/src/installed.ts"
-  git -C "$R" add -A
-  run_in SIZE_RATCHET_THRESHOLD=400 -- --staged
-  if [ "$RC" -eq "$want_rc" ]; then
-    ok "a NUL at offset $pad is $where the window (exit $RC)"
-  else
-    bad "the window boundary matches git's rule at offset $pad" "rc=$RC want=$want_rc out=$OUT"
-  fi
-done
-
 echo "=== the 8000 bound is bytes even when the locale is multibyte ==="
-# The prefilter's `read -n` bound counts CHARACTERS unless the locale is C, so
-# a NUL past byte 8000 but inside 8000 characters would stop a character-wise
-# read while `od -N 8000` correctly finds nothing — and the contradiction
-# refusal above would then red a file git reads as text. 5000 x U+00E9 is 5000
-# characters and 10000 bytes: the byte at offset 10000 is outside the window by
-# git's rule and inside it by the character count.
+# The prefilter's read bound counts CHARACTERS unless the locale is C, so a
+# NUL past byte 8000 would stop a character-wise read while `od -N 8000` finds
+# nothing, and the contradiction refusal above would red a file git reads as
+# text. 5000 x U+00E9 is 5000 characters and 10000 bytes: the byte at 10000 is
+# outside the window by git's rule, inside it by the character count.
 plant_wide_nul() { # 5000 two-byte characters in $R/src/installed.ts, then the byte
   mkdir -p "$R/src"
   { awk 'BEGIN { for (i = 0; i < 5000; i++) printf "\303\251" }'; printf '\000'; printf '\n'; } >"$R/src/installed.ts"
@@ -311,8 +264,7 @@ else
 
   echo "=== must-fail control: without LC_ALL=C the same fixture is refused ==="
   # Exit 0 is also what a sniff that never ran returns, so the case above is
-  # evidence only beside a control that reds. The control removes the
-  # `LC_ALL=C` assignment that makes the bound bytes, and nothing else.
+  # evidence only beside this: the `LC_ALL=C` bound removed, nothing else.
   BOUND="$TMP/bound-scripts"
   mkdir -p "$BOUND"
   cp -R "$SKILL_DIR/scripts/." "$BOUND/"
@@ -341,10 +293,9 @@ fi
 
 echo "=== a locating scan that comes back empty refuses, it does not pass ==="
 # The prefilter is byte-exact, so a stop it reports and a scan that then finds
-# nothing are a contradiction. Treating that as clean would be the fail-open
-# the sniff exists to close: an `od` that exits 0 saying nothing must not buy
-# a passing verdict over a NUL-carrying blob. An `od` that exits NONZERO is
-# already caught by pipefail; this is the quiet-success half.
+# nothing contradict each other; calling that clean is the fail-open the sniff
+# exists to close. A NONZERO `od` is already caught by pipefail — this is the
+# quiet-success half.
 OD_SHIM="$TMP/od-shim"
 mkdir -p "$OD_SHIM"
 printf '#!/usr/bin/env bash\nexit 0\n' >"$OD_SHIM/od"
@@ -360,58 +311,10 @@ else
 fi
 case "$OUT" in *"size-ratchet: OK"*) bad "no OK verdict may accompany the empty scan" "$OUT" ;; *) ok "no OK verdict accompanies the empty scan" ;; esac
 
-echo "=== every offender is named, not just the first ==="
-# The refusal is an aggregation: one row per offender, read back by the
-# reporting loop. That is the shape a repo meets when it adopts the gate —
-# several binary assets in a line class red together, as this repo's own
-# tauri icons did — so a regression to first-offender-only must red here.
-new_repo many
-plant_nul src/a.ts 'const a = "x'
-plant_nul src/b.ts 'const b = "xy'
-plant_nul src/c.ts 'const c = "xyz'
-git -C "$R" add -A
-run_in SIZE_RATCHET_THRESHOLD=400 -- --staged
-named="$(grep -c 'a NUL byte at offset' "$OUTFILE")" || named=0
-if [ "$RC" -eq 2 ] && [ "$named" -eq 3 ] \
-  && has 'src/a.ts: a NUL byte at offset 12' \
-  && has 'src/b.ts: a NUL byte at offset 13' \
-  && has 'src/c.ts: a NUL byte at offset 14'; then
-  ok "all three offenders are named, each at its own offset"
-else
-  bad "the diagnostic names every offender" "rc=$RC named=$named out=$OUT"
-fi
-
-echo "=== --seed refuses and writes no baseline ==="
-# A miss in a writing mode does not merely print a clean verdict: it records a
-# meaningless line count for a binary blob and locks it in.
-new_repo seedmode
-plant_nul src/installed.ts 'const a = "x'
-git -C "$R" add -A
-run_in SIZE_RATCHET_THRESHOLD=400 -- --seed
-if [ "$RC" -eq 2 ] && has 'src/installed.ts: a NUL byte at offset 12' && [ ! -e "$R/tools/size-ratchet-baseline.tsv" ]; then
-  ok "--seed refuses (exit 2) and writes no baseline at all"
-else
-  bad "--seed refuses before it seeds a row" "rc=$RC baseline=$(cat "$R/tools/size-ratchet-baseline.tsv" 2>/dev/null || echo absent) out=$OUT"
-fi
-
-echo "=== --update refuses and leaves the baseline row verbatim ==="
-new_repo updatemode
-plant_nul src/installed.ts 'const a = "x'
-mkdir -p "$R/tools"
-printf 'src/installed.ts\t9999\n' >"$R/tools/size-ratchet-baseline.tsv"
-git -C "$R" add -A
-run_in SIZE_RATCHET_THRESHOLD=400 -- --update
-row="$(cat "$R/tools/size-ratchet-baseline.tsv")"
-if [ "$RC" -eq 2 ] && has 'src/installed.ts: a NUL byte at offset 12' && [ "$row" = "$(printf 'src/installed.ts\t9999')" ]; then
-  ok "--update refuses (exit 2) and the baseline row survives verbatim"
-else
-  bad "--update refuses before it tightens a row" "rc=$RC row=$row out=$OUT"
-fi
 
 echo "=== must-fail control: with the refusal reverted, the NUL fixture goes green ==="
 # The control keeps every call site and the whole detection text and removes
-# only the behavior, so a green run below proves the cases above are the
-# refusal's doing rather than an assertion that cannot fail.
+# only the behavior, so a green run below rules out a vacuous assertion.
 CTRL="$TMP/control-scripts"
 mkdir -p "$CTRL"
 cp -R "$SKILL_DIR/scripts/." "$CTRL/"

--- a/.agents/skills/size-ratchet/tests/binary-content.test.sh
+++ b/.agents/skills/size-ratchet/tests/binary-content.test.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Pins the refusal on a line-class blob git reads as binary. A raw NUL typed
+# Pins the refusal on a tracked blob git reads as binary. A raw NUL typed
 # into a source file instead of its escape makes git call the file binary: no
 # textual diff, a plain `git grep` reduced to `Binary file <path> matches` and
 # a `git grep -I` that drops the path — and `wc -l` still returns a number, so
@@ -9,8 +9,9 @@
 # Pinned here: the refusal fires in both scopes (index and worktree) and in
 # --seed and --update, where a miss would write a meaningless count into the
 # baseline; every offender is named, not just the first; the offset is counted
-# in BYTES and located inside the sniff window; the same bytes in a BYTE class
-# pass because nothing counts their lines; an excluded path stays excluded; a
+# in BYTES and located inside the sniff window; a byte class is refused too,
+# because the property is the content and not the unit; an excluded path stays
+# excluded; a
 # scan that comes back empty is a refusal, not a pass; and the diagnostic never
 # carries the byte itself. The must-fail control at the end reverts the refusal
 # and shows the NUL fixture going green, so the green cases above are evidence.
@@ -100,7 +101,7 @@ if [ "$RC" -eq 2 ] && has 'src/installed.ts: a NUL byte at offset 12'; then
 else
   bad "a staged .ts with a NUL is refused naming the offset" "rc=$RC out=$OUT"
 fi
-if has 'measured in lines' && has 'Write the escape'; then
+if has 'tracked as reviewable text' && has 'Write the escape'; then
   ok "the refusal states why it refuses and tells the author to write the escape"
 else
   bad "the refusal carries its cause and remedy" "out=$OUT"
@@ -117,22 +118,55 @@ else
   bad "the refusal never reprints the byte" "total=$total stripped=$stripped"
 fi
 
-echo "=== the same bytes in a BYTE class pass — nothing counts their lines ==="
+echo "=== a BYTE class is refused too — the content decides, not the unit ==="
+# The whole markdown surface a repo reviews sits in byte classes, so a rule
+# keyed on the measurement unit would leave every SKILL.md, AGENTS.md and
+# workflow doc free to carry the byte and still read `OK`.
 new_repo byteclass
-plant_nul src/asset.png 'const a = "x'
+plant_nul skills/demo/SKILL.md 'const a = "x'
 git -C "$R" add -A
-run_in SIZE_RATCHET_THRESHOLD=400 SIZE_RATCHET_CLASSES='*.png=64k' -- --staged
-if [ "$RC" -eq 0 ]; then
-  ok "a .png in a byte class carrying the identical bytes passes (exit 0)"
+run_in SIZE_RATCHET_THRESHOLD=400 SIZE_RATCHET_CLASSES='*/SKILL.md=24k' -- --staged
+if [ "$RC" -eq 2 ] && has 'skills/demo/SKILL.md: a NUL byte at offset 12'; then
+  ok "a SKILL.md in a byte class is refused (exit 2), naming the path and offset"
 else
-  bad "a byte class is never asked about content" "rc=$RC out=$OUT"
+  bad "a byte class is asked about its content too" "rc=$RC out=$OUT"
+fi
+
+echo "=== must-fail control: keyed on the unit again, the same fixture goes green ==="
+# The control restores the one thing that changed — the sniff answering only
+# where the resolved unit is lines — and leaves every call site and the whole
+# diagnostic standing, so a green run here is what the case above rules out.
+UNIT="$TMP/unit-scripts"
+mkdir -p "$UNIT"
+cp -R "$SKILL_DIR/scripts/." "$UNIT/"
+UNIT_ANCHOR='note_if_binary() {'
+if awk -v anchor="$UNIT_ANCHOR" '
+    { print }
+    index($0, anchor) == 1 { print "  if [ \"${PU:-l}\" = \"b\" ]; then return 0; fi # must-fail control: coverage back to line classes"; n++ }
+    END { exit (n == 1 ? 0 : 3) }
+  ' "$UNIT/size-ratchet" >"$UNIT/size-ratchet.mut"; then
+  mv "$UNIT/size-ratchet.mut" "$UNIT/size-ratchet"
+  chmod +x "$UNIT/size-ratchet"
+  new_repo unitctrl
+  plant_nul skills/demo/SKILL.md 'const a = "x'
+  git -C "$R" add -A
+  GATE="$UNIT/size-ratchet"
+  run_in SIZE_RATCHET_THRESHOLD=400 SIZE_RATCHET_CLASSES='*/SKILL.md=24k' -- --staged
+  GATE="$SR"
+  if [ "$RC" -eq 0 ] && ! has 'NUL byte at offset'; then
+    ok "narrowing the sniff back to line classes lets the SKILL.md pass"
+  else
+    bad "the control narrows the coverage it should" "rc=$RC out=$OUT"
+  fi
+else
+  bad "the unit control's substitution matched exactly one site" "no single '$UNIT_ANCHOR' line at the start of a line in $UNIT/size-ratchet"
 fi
 
 echo "=== an excluded path stays excluded ==="
 new_repo excluded
 plant_nul assets/icon.png 'const a = "x'
 mkdir -p "$R/tools"
-printf 'assets/*\tbinary media — no lines to count\n' >"$R/tools/size-ratchet-excludes"
+printf 'assets/*\tbinary media — not reviewable text\n' >"$R/tools/size-ratchet-excludes"
 git -C "$R" add -A
 run_in SIZE_RATCHET_THRESHOLD=400 -- --staged
 if [ "$RC" -eq 0 ]; then

--- a/.agents/skills/size-ratchet/tests/binary-content.test.sh
+++ b/.agents/skills/size-ratchet/tests/binary-content.test.sh
@@ -10,11 +10,12 @@
 # --seed and --update, where a miss would write a meaningless count into the
 # baseline; every offender is named, not just the first; the offset is counted
 # in BYTES and located inside the sniff window; a byte class is refused too,
-# because the property is the content and not the unit; an excluded path stays
-# excluded; a
-# scan that comes back empty is a refusal, not a pass; and the diagnostic never
-# carries the byte itself. The must-fail control at the end reverts the refusal
-# and shows the NUL fixture going green, so the green cases above are evidence.
+# because the property is the content and not the unit; a SIZE-excluded text
+# path is sniffed like every other path, git's own diff attribute being the
+# only exemption; a scan that comes back empty is a refusal, not a pass; and
+# the diagnostic never carries the byte itself. The must-fail control at the
+# end reverts the refusal and shows the NUL fixture going green, so the green
+# cases above are evidence.
 set -euo pipefail
 
 TEST_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
@@ -131,6 +132,15 @@ if [ "$RC" -eq 2 ] && has 'skills/demo/SKILL.md: a NUL byte at offset 12'; then
 else
   bad "a byte class is asked about its content too" "rc=$RC out=$OUT"
 fi
+# CI runs the gate without --staged, and a repo's whole markdown surface sits
+# in byte classes, so the arm that reads the worktree copy is the half a NUL
+# reaching main would meet. Pinned here, not inferred from the index arm.
+run_in SIZE_RATCHET_THRESHOLD=400 SIZE_RATCHET_CLASSES='*/SKILL.md=24k'
+if [ "$RC" -eq 2 ] && has 'skills/demo/SKILL.md: a NUL byte at offset 12'; then
+  ok "the worktree scan CI runs refuses the byte-class blob too (exit 2, same offset)"
+else
+  bad "the byte-class refusal fires in the scope CI runs" "rc=$RC out=$OUT"
+fi
 
 echo "=== must-fail control: keyed on the unit again, the same fixture goes green ==="
 # The control restores the one thing that changed — the sniff answering only
@@ -162,17 +172,67 @@ else
   bad "the unit control's substitution matched exactly one site" "no single '$UNIT_ANCHOR' line at the start of a line in $UNIT/size-ratchet"
 fi
 
-echo "=== an excluded path stays excluded ==="
+echo "=== a SIZE-excluded text path is sniffed like any other ==="
+# The size exclusion list answers which paths carry no SIZE bound, and its
+# entries carry size reasons — a lockfile, a generated bundle, an append-only
+# log. Reading it as a content exemption too let every one of those carry the
+# byte unseen, the shipped CHANGELOG*.md default worst of all.
 new_repo excluded
 plant_nul assets/icon.png 'const a = "x'
 mkdir -p "$R/tools"
 printf 'assets/*\tbinary media — not reviewable text\n' >"$R/tools/size-ratchet-excludes"
 git -C "$R" add -A
 run_in SIZE_RATCHET_THRESHOLD=400 -- --staged
-if [ "$RC" -eq 0 ]; then
-  ok "an excluded path is never sniffed (exit 0)"
+if [ "$RC" -eq 2 ] && has 'assets/icon.png: a NUL byte at offset 12'; then
+  ok "the size exclusion buys no content exemption — the path is refused by name and offset"
 else
-  bad "the exclusion list precedes the sniff" "rc=$RC out=$OUT"
+  bad "a size-excluded text path is sniffed like every other path" "rc=$RC out=$OUT"
+fi
+
+echo "=== and git's own diff attribute is what exempts it ==="
+# The exemption authority is the record git already keeps: a path declared
+# binary (or -diff) is one git keeps out of every textual diff, so its bytes
+# were never reviewable text. Same fixture, same exclusion list, one line of
+# .gitattributes added.
+printf 'assets/* binary\n' >"$R/.gitattributes"
+git -C "$R" add -A
+run_in SIZE_RATCHET_THRESHOLD=400 -- --staged
+if [ "$RC" -eq 0 ] && ! has 'NUL byte at offset'; then
+  ok "a path .gitattributes declares binary is exempt from the sniff (exit 0)"
+else
+  bad "git's own attribute exempts the path" "rc=$RC out=$OUT"
+fi
+
+echo "=== must-fail control: with the size list back in charge, the same fixture goes green ==="
+# The control restores the one thing that changed — the size exclusion
+# short-circuiting the walk before the sniff — and leaves the attribute
+# lookup, every call site and the whole diagnostic standing.
+EXC="$TMP/excl-scripts"
+mkdir -p "$EXC"
+cp -R "$SKILL_DIR/scripts/." "$EXC/"
+EXC_ANCHOR='  if is_excluded "$f"; then excluded=1; fi'
+if awk -v anchor="$EXC_ANCHOR" '
+    { print }
+    $0 == anchor { print "  if [ \"$excluded\" -eq 1 ]; then continue; fi # must-fail control: the size list back in charge of content"; n++ }
+    END { exit (n == 1 ? 0 : 3) }
+  ' "$EXC/size-ratchet" >"$EXC/size-ratchet.mut"; then
+  mv "$EXC/size-ratchet.mut" "$EXC/size-ratchet"
+  chmod +x "$EXC/size-ratchet"
+  new_repo exclctrl
+  plant_nul assets/icon.png 'const a = "x'
+  mkdir -p "$R/tools"
+  printf 'assets/*\tbinary media — not reviewable text\n' >"$R/tools/size-ratchet-excludes"
+  git -C "$R" add -A
+  GATE="$EXC/size-ratchet"
+  run_in SIZE_RATCHET_THRESHOLD=400 -- --staged
+  GATE="$SR"
+  if [ "$RC" -eq 0 ] && ! has 'NUL byte at offset'; then
+    ok "size exclusion short-circuiting the walk lets the NUL fixture pass — the case above reds without it"
+  else
+    bad "the control restores the short-circuit it should" "rc=$RC out=$OUT"
+  fi
+else
+  bad "the exclusion control's substitution matched exactly one site" "no single '$EXC_ANCHOR' line in $EXC/size-ratchet"
 fi
 
 echo "=== the worktree scan CI runs refuses the same blob ==="

--- a/.agents/skills/size-ratchet/tests/binary-content.test.sh
+++ b/.agents/skills/size-ratchet/tests/binary-content.test.sh
@@ -186,12 +186,25 @@ echo "=== and git's own diff attribute is what exempts it ==="
 # -diff) is out of every textual diff, so its bytes were never reviewable
 # text. Same fixture, same exclusion list, one .gitattributes line added.
 printf 'assets/* binary\n' >"$R/.gitattributes"
+run_in SIZE_RATCHET_THRESHOLD=400 -- --staged
+if [ "$RC" -eq 2 ] && has 'assets/icon.png: a NUL byte at offset 12'; then
+  ok "an unstaged .gitattributes exempts nothing under --staged (exit 2)"
+else
+  bad "the staged scope reads the attribute from the index" "rc=$RC out=$OUT"
+fi
 git -C "$R" add -A
 run_in SIZE_RATCHET_THRESHOLD=400 -- --staged
 if [ "$RC" -eq 0 ] && ! has 'NUL byte at offset'; then
   ok "a path .gitattributes declares binary is exempt from the sniff (exit 0)"
 else
   bad "git's own attribute exempts the path" "rc=$RC out=$OUT"
+fi
+awk 'BEGIN { for (i = 0; i < 900; i++) print "x" }' >>"$R/assets/icon.png" # still measured
+run_in SIZE_RATCHET_THRESHOLD=400 SIZE_RATCHET_EXCLUDES=tools/no-list
+if [ "$RC" -eq 1 ] && has 'new offender: assets/icon.png'; then
+  ok "a diff-exempt path is still measured — 900 lines over the threshold reds it"
+else
+  bad "the attribute exempts the sniff, not the measurement" "rc=$RC out=$OUT"
 fi
 
 echo "=== must-fail control: with the size list back in charge, the same fixture goes green ==="

--- a/.agents/skills/size-ratchet/tests/binary-content.test.sh
+++ b/.agents/skills/size-ratchet/tests/binary-content.test.sh
@@ -1,0 +1,220 @@
+#!/usr/bin/env bash
+# Pins the refusal on a line-class blob git reads as binary. A raw NUL typed
+# into a source file instead of its escape makes git call the file binary:
+# no diff, no `git grep` hit, no blame — and `wc -l` still returns a number,
+# so the gate used to report a clean measurement over content nobody could
+# read. The gate now refuses that blob by name and byte offset.
+#
+# Pinned here: the refusal fires in both scopes (index and worktree), the
+# offset is counted in BYTES and located inside the sniff window, the same
+# bytes in a BYTE class pass because nothing counts their lines, an excluded
+# path stays excluded, and the diagnostic never carries the byte itself.
+# The must-fail control at the end reverts the refusal and shows the NUL
+# fixture going green, so the green cases above are evidence.
+set -euo pipefail
+
+TEST_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SKILL_DIR="$(cd "$TEST_DIR/.." && pwd)"
+SR="$SKILL_DIR/scripts/size-ratchet"
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+
+# Hermetic: a leaked setting would mask every case below.
+unset SIZE_RATCHET_THRESHOLD SIZE_RATCHET_CLASSES SIZE_RATCHET_DEFAULT_CLASSES SIZE_RATCHET_FROZEN_CLASSES SIZE_RATCHET_BASELINE SIZE_RATCHET_EXCLUDES SIZE_RATCHET_SETTINGS_FILE RATCHET_RAISE 2>/dev/null || true
+# The shipped class list and frozen list are policy, pinned by
+# shipped-defaults.test.sh. Every fixture here declares its own thresholds,
+# so both start empty and a case that needs one sets it.
+export SIZE_RATCHET_DEFAULT_CLASSES="" SIZE_RATCHET_FROZEN_CLASSES=""
+# A fixture repo is its own repo: an inherited git environment would make
+# `git add` write into the index of whatever repo invoked this suite.
+unset GIT_DIR GIT_COMMON_DIR GIT_WORK_TREE GIT_INDEX_FILE 2>/dev/null || true
+
+PASS=0
+FAIL=0
+ok() { PASS=$((PASS + 1)); printf '  ok    %s\n' "$1"; }
+bad() { FAIL=$((FAIL + 1)); printf '  FAIL  %s\n        %s\n' "$1" "${2:-}"; }
+
+new_repo() { # NAME
+  R="$TMP/$1"
+  mkdir -p "$R"
+  git -C "$R" -c init.defaultBranch=main init -q
+  git -C "$R" config user.email test@example.com
+  git -C "$R" config user.name test
+}
+
+# The fixture bytes: a one-line TypeScript source whose string literal carries
+# a raw U+0000 where the author meant to type the escape. `printf` writes the
+# byte; nothing in this file ever holds one, so this suite is itself readable.
+plant_nul() { # PATH LEADING-BYTES
+  mkdir -p "$R/$(dirname "$1")"
+  { printf '%s' "$2"; printf '\000'; printf 'y";\n'; } >"$R/$1"
+}
+
+# OUT via a file, never a command substitution: bash drops NUL bytes from
+# `$(...)`, so a diagnostic that leaked the byte would read as clean here.
+run_in() { # [VAR=val ...] [-- script-args...] — run $SR in $R; sets OUTFILE, OUT, RC
+  local envs=() args=()
+  while [ $# -gt 0 ]; do
+    case "$1" in
+      --)
+        shift
+        args=("$@")
+        break
+        ;;
+      *) envs+=("$1") ;;
+    esac
+    shift
+  done
+  OUTFILE="$TMP/out.$$"
+  RC=0
+  (cd "$R" && env ${envs[@]+"${envs[@]}"} "$GATE" ${args[@]+"${args[@]}"}) >"$OUTFILE" 2>&1 || RC=$?
+  OUT="$(cat "$OUTFILE")"
+}
+GATE="$SR"
+
+has() { case "$OUT" in *"$1"*) return 0 ;; *) return 1 ;; esac; }
+
+echo "=== control: the same fixture without the byte is measured and clean ==="
+new_repo control
+mkdir -p "$R/src"
+printf 'const a = "xy";\n' >"$R/src/installed.ts"
+git -C "$R" add -A
+run_in SIZE_RATCHET_THRESHOLD=400 -- --staged
+if [ "$RC" -eq 0 ]; then
+  ok "control: a NUL-free .ts under the line threshold passes (exit 0)"
+else
+  bad "control: the fixture is clean but for the byte" "rc=$RC out=$OUT"
+fi
+
+echo "=== a staged line-class blob carrying a NUL is refused by path and offset ==="
+new_repo staged
+plant_nul src/installed.ts 'const a = "x'
+git -C "$R" add -A
+run_in SIZE_RATCHET_THRESHOLD=400 -- --staged
+# 'const a = "x' is 12 bytes, so the byte sits at offset 12.
+if [ "$RC" -eq 2 ] && has 'src/installed.ts: a NUL byte at offset 12'; then
+  ok "the index blob is refused (exit 2), naming the path and the byte offset"
+else
+  bad "a staged .ts with a NUL is refused naming the offset" "rc=$RC out=$OUT"
+fi
+if has 'measured in lines' && has 'Write the escape'; then
+  ok "the refusal states why it refuses and tells the author to write the escape"
+else
+  bad "the refusal carries its cause and remedy" "out=$OUT"
+fi
+
+echo "=== the diagnostic never reprints the byte ==="
+# Reprinting it would put a NUL into the log, terminal or CI annotation that
+# carries the diagnostic onward — the same invisibility, one layer out.
+total="$(wc -c <"$OUTFILE")"
+stripped="$(LC_ALL=C tr -d '\000' <"$OUTFILE" | wc -c)"
+if [ "$((total))" -eq "$((stripped))" ] && [ "$((total))" -gt 0 ]; then
+  ok "the whole diagnostic ($((total)) bytes) carries no NUL of its own"
+else
+  bad "the refusal never reprints the byte" "total=$total stripped=$stripped"
+fi
+
+echo "=== the same bytes in a BYTE class pass — nothing counts their lines ==="
+new_repo byteclass
+plant_nul src/asset.png 'const a = "x'
+git -C "$R" add -A
+run_in SIZE_RATCHET_THRESHOLD=400 SIZE_RATCHET_CLASSES='*.png=64k' -- --staged
+if [ "$RC" -eq 0 ]; then
+  ok "a .png in a byte class carrying the identical bytes passes (exit 0)"
+else
+  bad "a byte class is never asked about content" "rc=$RC out=$OUT"
+fi
+
+echo "=== an excluded path stays excluded ==="
+new_repo excluded
+plant_nul assets/icon.png 'const a = "x'
+mkdir -p "$R/tools"
+printf 'assets/*\tbinary media — no lines to count\n' >"$R/tools/size-ratchet-excludes"
+git -C "$R" add -A
+run_in SIZE_RATCHET_THRESHOLD=400 -- --staged
+if [ "$RC" -eq 0 ]; then
+  ok "an excluded path is never sniffed (exit 0)"
+else
+  bad "the exclusion list precedes the sniff" "rc=$RC out=$OUT"
+fi
+
+echo "=== the worktree scan CI runs refuses the same blob ==="
+# CI runs the gate without --staged, over a clean checkout: a NUL that reached
+# main must red there too, not only at the commit that introduced it.
+new_repo worktree
+plant_nul src/installed.ts 'const a = "x'
+git -C "$R" add -A
+run_in SIZE_RATCHET_THRESHOLD=400
+if [ "$RC" -eq 2 ] && has 'src/installed.ts: a NUL byte at offset 12'; then
+  ok "the worktree copy is refused the same way (exit 2, same offset)"
+else
+  bad "the no---staged scan refuses it too" "rc=$RC out=$OUT"
+fi
+
+echo "=== the offset counts bytes, not characters ==="
+# 100 x U+00E9 is 100 characters and 200 bytes. A count that came from the
+# shell's character-wise read would report 100 here.
+new_repo multibyte
+mkdir -p "$R/src"
+{ awk 'BEGIN { for (i = 0; i < 100; i++) printf "\303\251" }'; printf '\000'; printf '";\n'; } >"$R/src/installed.ts"
+git -C "$R" add -A
+run_in SIZE_RATCHET_THRESHOLD=400 -- --staged
+if [ "$RC" -eq 2 ] && has 'src/installed.ts: a NUL byte at offset 200'; then
+  ok "a NUL behind 100 two-byte characters is reported at byte offset 200"
+else
+  bad "the offset is a byte offset" "rc=$RC out=$OUT"
+fi
+
+echo "=== the sniff window is the leading 8000 bytes, git's own rule ==="
+# git reads a blob as text when no NUL falls in the leading 8000 bytes, so
+# the gate must agree at the boundary in both directions — a byte at offset
+# 7999 is inside the window, one at 8000 is not.
+for probe in "7999 2 inside" "8000 0 outside"; do
+  set -- $probe
+  pad="$1"
+  want_rc="$2"
+  where="$3"
+  new_repo "window-$pad"
+  mkdir -p "$R/src"
+  { awk -v n="$pad" 'BEGIN { for (i = 0; i < n; i++) printf "x" }'; printf '\000'; printf '\n'; } >"$R/src/installed.ts"
+  git -C "$R" add -A
+  run_in SIZE_RATCHET_THRESHOLD=400 -- --staged
+  if [ "$RC" -eq "$want_rc" ]; then
+    ok "a NUL at offset $pad is $where the window (exit $RC)"
+  else
+    bad "the window boundary matches git's rule at offset $pad" "rc=$RC want=$want_rc out=$OUT"
+  fi
+done
+
+echo "=== must-fail control: with the refusal reverted, the NUL fixture goes green ==="
+# The control keeps every call site and the whole detection text and removes
+# only the behavior, so a green run below proves the cases above are the
+# refusal's doing rather than an assertion that cannot fail.
+CTRL="$TMP/control-scripts"
+mkdir -p "$CTRL"
+cp -R "$SKILL_DIR/scripts/." "$CTRL/"
+ANCHOR='note_if_binary() {'
+if awk -v anchor="$ANCHOR" '
+    { print }
+    index($0, anchor) == 1 { print "  return 0 # must-fail control: the refusal, reverted"; n++ }
+    END { exit (n == 1 ? 0 : 3) }
+  ' "$CTRL/size-ratchet" >"$CTRL/size-ratchet.mut"; then
+  mv "$CTRL/size-ratchet.mut" "$CTRL/size-ratchet"
+  chmod +x "$CTRL/size-ratchet"
+  new_repo mustfail
+  plant_nul src/installed.ts 'const a = "x'
+  git -C "$R" add -A
+  GATE="$CTRL/size-ratchet"
+  run_in SIZE_RATCHET_THRESHOLD=400 -- --staged
+  GATE="$SR"
+  if [ "$RC" -eq 0 ] && ! has 'NUL byte at offset'; then
+    ok "reverting the refusal lets the NUL fixture pass — the cases above red without it"
+  else
+    bad "the control removes the behavior it should" "rc=$RC out=$OUT"
+  fi
+else
+  bad "the control's substitution matched exactly one site" "no single '$ANCHOR' line at the start of a line in $CTRL/size-ratchet"
+fi
+
+printf '\n%s passed, %s failed\n' "$PASS" "$FAIL"
+[ "$FAIL" -eq 0 ]

--- a/.agents/skills/size-ratchet/tests/binary-content.test.sh
+++ b/.agents/skills/size-ratchet/tests/binary-content.test.sh
@@ -217,8 +217,8 @@ else
 
   echo "=== must-fail control: without LC_ALL=C the same fixture is refused ==="
   # Exit 0 is also what a sniff that never ran returns, so the case above is
-  # evidence only beside a control that reds. The control removes the two words
-  # that make the bound bytes and nothing else.
+  # evidence only beside a control that reds. The control removes the
+  # `LC_ALL=C` assignment that makes the bound bytes, and nothing else.
   BOUND="$TMP/bound-scripts"
   mkdir -p "$BOUND"
   cp -R "$SKILL_DIR/scripts/." "$BOUND/"

--- a/.agents/skills/size-ratchet/tests/collection-fail-closed.test.sh
+++ b/.agents/skills/size-ratchet/tests/collection-fail-closed.test.sh
@@ -232,9 +232,9 @@ case "$OUT" in *"simulated object read failure"*) ok "git's own stderr is surfac
 case "$OUT" in *"size-ratchet: OK"*) bad "no OK verdict may accompany a collection failure" "$OUT" ;; *) ok "no OK verdict accompanies the collection failure" ;; esac
 
 echo "=== fail-closed: an unreadable index blob in a BYTE class terminates too ==="
-# A byte class never materializes the blob: it streams `git show | wc -c`, so
-# the read's failure reaches the gate through pipefail rather than through the
-# line class's own status check above. Both branches must refuse.
+# A byte class resolves a different threshold and `wc` flag than the line case
+# above, and its rows travel a batch of their own, so the refusal is pinned on
+# both units rather than inferred from one.
 run_bin() { # [SHIMDIR] — run in $R under the byte class; no SHIMDIR is the real git
   OUT=""
   RC=0

--- a/.agents/skills/size-ratchet/tests/collection-fail-closed.test.sh
+++ b/.agents/skills/size-ratchet/tests/collection-fail-closed.test.sh
@@ -73,14 +73,13 @@ run_sr_shimmed() { # SHIMDIR [args...] — run_sr with SHIMDIR first on PATH
   OUT="$(cd "$R" && PATH="$shimdir:$PATH" SIZE_RATCHET_THRESHOLD=10 "$SR" "$@" 2>&1)" || RC=$?
 }
 
-# git shim: fail the index-blob read for `big.txt` (a line class, read through
-# a materialized blob) and for `assets/big.bin` (a byte class, streamed through
-# a pipeline), pass everything else through to the real git.
+# git shim: fail the index-blob read for `big.txt`, pass everything else
+# through to the real git.
 GIT_SHIM="$TMP/git-shim"
 mkdir -p "$GIT_SHIM"
 cat >"$GIT_SHIM/git" <<EOF
 #!/usr/bin/env bash
-if [ "\${1:-}" = "show" ] && { [ "\${2:-}" = ":big.txt" ] || [ "\${2:-}" = ":assets/big.bin" ]; }; then
+if [ "\${1:-}" = "show" ] && [ "\${2:-}" = ":big.txt" ]; then
   echo "fatal: simulated object read failure for \${2#:}" >&2
   exit 128
 fi
@@ -230,29 +229,6 @@ run_sr_shimmed "$GIT_SHIM"
   || bad "an unreadable blob is a collection error naming the file" "rc=$RC out=$OUT"
 case "$OUT" in *"simulated object read failure"*) ok "git's own stderr is surfaced, pinning the cause to the failed read" ;; *) bad "git's own stderr is surfaced" "$OUT" ;; esac
 case "$OUT" in *"size-ratchet: OK"*) bad "no OK verdict may accompany a collection failure" "$OUT" ;; *) ok "no OK verdict accompanies the collection failure" ;; esac
-
-echo "=== fail-closed: an unreadable index blob in a BYTE class terminates too ==="
-# A byte class resolves a different threshold and `wc` flag than the line case
-# above, and its rows travel a batch of their own, so the refusal is pinned on
-# both units rather than inferred from one.
-run_bin() { # [SHIMDIR] — run in $R under the byte class; no SHIMDIR is the real git
-  OUT=""
-  RC=0
-  OUT="$(cd "$R" && PATH="${1:+$1:}$PATH" SIZE_RATCHET_THRESHOLD=10 SIZE_RATCHET_CLASSES='*.bin=64k' "$SR" 2>&1)" || RC=$?
-}
-new_repo blobfailbin
-mkfile assets/big.bin 3
-git -C "$R" add -A
-rm "$R/assets/big.bin" # unstaged: the index still lists it, blob readable
-run_bin
-[ "$RC" -eq 0 ] && case "$OUT" in *"size-ratchet: OK"*) true ;; *) false ;; esac \
-  && ok "shim-free control: the absent byte-class file is counted from its readable blob" \
-  || bad "shim-free control: the absent byte-class file is counted" "rc=$RC out=$OUT"
-run_bin "$GIT_SHIM"
-[ "$RC" -eq 2 ] && case "$OUT" in *"cannot read index blob for tracked file 'assets/big.bin'"*) true ;; *) false ;; esac \
-  && ok "the streamed byte-class read is a collection error: exit 2, naming assets/big.bin" \
-  || bad "an unreadable byte-class blob is a collection error naming the file" "rc=$RC out=$OUT"
-case "$OUT" in *"size-ratchet: OK"*) bad "no OK verdict may accompany the byte-class collection failure" "$OUT" ;; *) ok "no OK verdict accompanies the byte-class collection failure" ;; esac
 
 echo "=== fail-closed: a blob that materializes but cannot be counted terminates ==="
 # The line class materializes the index blob and then counts it, so the read

--- a/.agents/skills/size-ratchet/tests/collection-fail-closed.test.sh
+++ b/.agents/skills/size-ratchet/tests/collection-fail-closed.test.sh
@@ -30,6 +30,9 @@ unset SIZE_RATCHET_THRESHOLD SIZE_RATCHET_CLASSES SIZE_RATCHET_DEFAULT_CLASSES S
 # shipped-defaults.test.sh. Every fixture here declares its own thresholds,
 # so both start empty and a case that needs one sets it.
 export SIZE_RATCHET_DEFAULT_CLASSES="" SIZE_RATCHET_FROZEN_CLASSES=""
+# A fixture repo is its own repo: an inherited git environment would make the
+# fixture `git add` write into the index of whatever repo invoked this suite.
+unset GIT_DIR GIT_COMMON_DIR GIT_WORK_TREE GIT_INDEX_FILE 2>/dev/null || true
 
 PASS=0
 FAIL=0
@@ -250,6 +253,25 @@ run_bin "$GIT_SHIM"
   && ok "the streamed byte-class read is a collection error: exit 2, naming assets/big.bin" \
   || bad "an unreadable byte-class blob is a collection error naming the file" "rc=$RC out=$OUT"
 case "$OUT" in *"size-ratchet: OK"*) bad "no OK verdict may accompany the byte-class collection failure" "$OUT" ;; *) ok "no OK verdict accompanies the byte-class collection failure" ;; esac
+
+echo "=== fail-closed: a blob that materializes but cannot be counted terminates ==="
+# The line class materializes the index blob and then counts it, so the read
+# succeeding says nothing about the count. Under --staged with one line-class
+# file that count is the run's only wc invocation, so the blanket wc shim
+# reaches it and the asserted wording pins which guard fired.
+new_repo blobcount
+mkfile small.txt 5
+git -C "$R" add -A
+run_sr --staged
+[ "$RC" -eq 0 ] && case "$OUT" in *"size-ratchet: OK"*) true ;; *) false ;; esac \
+  && ok "shim-free control: the materialized index blob is counted and passes" \
+  || bad "shim-free control: the materialized index blob is counted" "rc=$RC out=$OUT"
+run_sr_shimmed "$WC_SHIM" --staged
+[ "$RC" -eq 2 ] && case "$OUT" in *"cannot count the materialized index blob for tracked file 'small.txt'"*) true ;; *) false ;; esac \
+  && ok "an uncountable materialized blob is a collection error: exit 2, naming small.txt" \
+  || bad "an uncountable materialized blob is a collection error naming the file" "rc=$RC out=$OUT"
+case "$OUT" in *"simulated read failure"*) ok "wc's own stderr is surfaced, pinning the cause to the failed count" ;; *) bad "wc's own stderr is surfaced" "$OUT" ;; esac
+case "$OUT" in *"size-ratchet: OK"*) bad "no OK verdict may accompany an uncountable materialized blob" "$OUT" ;; *) ok "no OK verdict accompanies the uncountable materialized blob" ;; esac
 
 echo "=== fail-closed: a baselined unreadable blob refuses --update, baseline untouched ==="
 new_repo updfail

--- a/.agents/skills/size-ratchet/tests/collection-fail-closed.test.sh
+++ b/.agents/skills/size-ratchet/tests/collection-fail-closed.test.sh
@@ -70,14 +70,15 @@ run_sr_shimmed() { # SHIMDIR [args...] — run_sr with SHIMDIR first on PATH
   OUT="$(cd "$R" && PATH="$shimdir:$PATH" SIZE_RATCHET_THRESHOLD=10 "$SR" "$@" 2>&1)" || RC=$?
 }
 
-# git shim: fail `git show :big.txt` (the index-blob read), pass everything
-# else through to the real git.
+# git shim: fail the index-blob read for `big.txt` (a line class, read through
+# a materialized blob) and for `assets/big.bin` (a byte class, streamed through
+# a pipeline), pass everything else through to the real git.
 GIT_SHIM="$TMP/git-shim"
 mkdir -p "$GIT_SHIM"
 cat >"$GIT_SHIM/git" <<EOF
 #!/usr/bin/env bash
-if [ "\${1:-}" = "show" ] && [ "\${2:-}" = ":big.txt" ]; then
-  echo "fatal: simulated object read failure for big.txt" >&2
+if [ "\${1:-}" = "show" ] && { [ "\${2:-}" = ":big.txt" ] || [ "\${2:-}" = ":assets/big.bin" ]; }; then
+  echo "fatal: simulated object read failure for \${2#:}" >&2
   exit 128
 fi
 exec "$REAL_GIT" "\$@"
@@ -226,6 +227,29 @@ run_sr_shimmed "$GIT_SHIM"
   || bad "an unreadable blob is a collection error naming the file" "rc=$RC out=$OUT"
 case "$OUT" in *"simulated object read failure"*) ok "git's own stderr is surfaced, pinning the cause to the failed read" ;; *) bad "git's own stderr is surfaced" "$OUT" ;; esac
 case "$OUT" in *"size-ratchet: OK"*) bad "no OK verdict may accompany a collection failure" "$OUT" ;; *) ok "no OK verdict accompanies the collection failure" ;; esac
+
+echo "=== fail-closed: an unreadable index blob in a BYTE class terminates too ==="
+# A byte class never materializes the blob: it streams `git show | wc -c`, so
+# the read's failure reaches the gate through pipefail rather than through the
+# line class's own status check above. Both branches must refuse.
+run_bin() { # [SHIMDIR] — run in $R under the byte class; no SHIMDIR is the real git
+  OUT=""
+  RC=0
+  OUT="$(cd "$R" && PATH="${1:+$1:}$PATH" SIZE_RATCHET_THRESHOLD=10 SIZE_RATCHET_CLASSES='*.bin=64k' "$SR" 2>&1)" || RC=$?
+}
+new_repo blobfailbin
+mkfile assets/big.bin 3
+git -C "$R" add -A
+rm "$R/assets/big.bin" # unstaged: the index still lists it, blob readable
+run_bin
+[ "$RC" -eq 0 ] && case "$OUT" in *"size-ratchet: OK"*) true ;; *) false ;; esac \
+  && ok "shim-free control: the absent byte-class file is counted from its readable blob" \
+  || bad "shim-free control: the absent byte-class file is counted" "rc=$RC out=$OUT"
+run_bin "$GIT_SHIM"
+[ "$RC" -eq 2 ] && case "$OUT" in *"cannot read index blob for tracked file 'assets/big.bin'"*) true ;; *) false ;; esac \
+  && ok "the streamed byte-class read is a collection error: exit 2, naming assets/big.bin" \
+  || bad "an unreadable byte-class blob is a collection error naming the file" "rc=$RC out=$OUT"
+case "$OUT" in *"size-ratchet: OK"*) bad "no OK verdict may accompany the byte-class collection failure" "$OUT" ;; *) ok "no OK verdict accompanies the byte-class collection failure" ;; esac
 
 echo "=== fail-closed: a baselined unreadable blob refuses --update, baseline untouched ==="
 new_repo updfail

--- a/.gitattributes
+++ b/.gitattributes
@@ -4,3 +4,17 @@
 # in with `include_str!` and asserted to hold no carriage return, and the
 # authoring golden digest is over those same bytes.
 * -text
+
+# Binary assets, declared so git keeps them out of its textual diffs. That
+# declaration is also the size-ratchet content sniff's only exemption: a blob
+# carrying a NUL in its leading 8000 bytes is unreviewable, and a path git
+# never diffs was never reviewable text in the first place. Declared by type
+# rather than by directory — the type is the property, and a directory rule
+# would also claim the README sitting beside the assets.
+*.png binary
+*.jpg binary
+*.gif binary
+*.ico binary
+*.icns binary
+*.ttf binary
+*.mp4 binary

--- a/changelog.d/added/KEN-1146.md
+++ b/changelog.d/added/KEN-1146.md
@@ -1,3 +1,3 @@
-- size-ratchet refuses a file it counts in lines carrying a NUL in its first
-  8000 bytes, naming the path and offset; git shows no diff for it. Write the
-  escape, exclude the path, or use a byte class.
+- size-ratchet refuses any counted file carrying a NUL in its first 8000
+  bytes, naming the path and offset; git shows no diff for it. Write the
+  escape, or exclude the path.

--- a/changelog.d/added/KEN-1146.md
+++ b/changelog.d/added/KEN-1146.md
@@ -1,3 +1,0 @@
-- size-ratchet refuses any tracked file carrying a NUL in its first 8000
-  bytes, naming the path and offset; git shows no diff for it. Write the
-  escape, or declare the path binary in .gitattributes.

--- a/changelog.d/added/KEN-1146.md
+++ b/changelog.d/added/KEN-1146.md
@@ -1,0 +1,3 @@
+- size-ratchet refuses a file it counts in lines when a NUL sits in its first
+  8000 bytes, naming the path and the byte's offset. Git calls such a file
+  binary and shows no diff for it.

--- a/changelog.d/added/KEN-1146.md
+++ b/changelog.d/added/KEN-1146.md
@@ -1,3 +1,3 @@
-- size-ratchet refuses any counted file carrying a NUL in its first 8000
+- size-ratchet refuses any tracked file carrying a NUL in its first 8000
   bytes, naming the path and offset; git shows no diff for it. Write the
-  escape, or exclude the path.
+  escape, or declare the path binary in .gitattributes.

--- a/changelog.d/added/KEN-1146.md
+++ b/changelog.d/added/KEN-1146.md
@@ -1,3 +1,3 @@
-- size-ratchet refuses a file it counts in lines when a NUL sits in its first
-  8000 bytes, naming the path and the byte's offset. Git calls such a file
-  binary and shows no diff for it.
+- size-ratchet refuses a file it counts in lines carrying a NUL in its first
+  8000 bytes, naming the path and offset; git shows no diff for it. Write the
+  escape, exclude the path, or use a byte class.

--- a/changelog.d/changed/KEN-1146.md
+++ b/changelog.d/changed/KEN-1146.md
@@ -1,0 +1,3 @@
+- **Breaking:** `size-ratchet` refuses any tracked file with a NUL in its
+  first 8000 bytes, size excludes included, naming path and offset. Declare
+  binary assets `binary` in `.gitattributes`.

--- a/skills/size-ratchet/DEVELOPMENT.md
+++ b/skills/size-ratchet/DEVELOPMENT.md
@@ -47,19 +47,33 @@ gate could not measure is never skipped. A blob that materializes but cannot
 then be counted refuses under its own wording, naming the count of the
 materialized blob rather than the read, because the object store is not the
 fault there. A tracked path containing a tab or newline is refused loudly
-(exit 2; exclude it to skip the gate) — it cannot be represented in the
-line-oriented records.
+(exit 2) — it cannot be represented in the line-oriented records, and the
+content sniff below reaches every tracked path, so the refusal covers the
+whole tracked set rather than the measured part of it.
 
-Every blob the gate measures is sniffed for a NUL in its leading 8000 bytes,
-git's own text/binary rule, which growth-guards states as `gg_blob_is_binary`
-and preflight as `content_is_binary`. The unit does not narrow the coverage:
-a line class, a byte class, and no class at all are all sniffed, because the
+Every tracked blob is sniffed for a NUL in its leading 8000 bytes, git's own
+text/binary rule, which growth-guards states as `gg_blob_is_binary` and
+preflight as `content_is_binary`. The unit does not narrow the coverage: a
+line class, a byte class, and no class at all are all sniffed, because the
 property held is that the blob stays reviewable text, and its content decides
-that where the unit says nothing. `is_excluded` runs before the sniff, so the
-exclusion list is the escape hatch for a real binary asset and an excluded
-path pays nothing for the coverage. Under `--staged` and for any path absent
-from the worktree the blob is materialized once, and the count and the sniff
-read that one copy.
+that where the unit says nothing.
+
+The sniff's one exemption is git's own record. `git check-attr diff` answers
+`unset` for a path given `-diff` and `binary` for one given a binary diff
+driver; either way git keeps the path out of every textual diff, so its bytes
+were never reviewable text and the sniff has nothing to ask. That is the
+escape hatch for a real binary asset. The size exclusion list answers a
+different question — which paths carry no size bound — and its entries carry
+size reasons, so it decides nothing here: a size-excluded text file is sniffed
+like every other tracked path, and the two exemptions are independent. The
+attribute is resolved for the whole tracked set in ONE
+`git ls-files -z | git check-attr -z --stdin diff` before the walk; a fork per
+path is the cost shape that measured 5x when the sniff itself was tried
+per-file. Only a path that is both size-excluded and diff-exempt is read for
+nothing, so only that one is skipped outright.
+
+Under `--staged` and for any path absent from the worktree the blob is
+materialized once, and the count and the sniff read that one copy.
 
 A hit is a collection error (exit 2) naming the path and the byte's offset,
 never the byte itself. Git records such a blob as binary, so it carries no

--- a/skills/size-ratchet/DEVELOPMENT.md
+++ b/skills/size-ratchet/DEVELOPMENT.md
@@ -44,59 +44,47 @@ can neither smuggle a new offender past the gate nor loosen a baselined row.
 An index blob that cannot be read (corrupt object, promisor blob
 unavailable) is a collection error (exit 2, naming the file) — a file the
 gate could not measure is never skipped. A blob that materializes but cannot
-then be counted refuses under its own wording, naming the count of the
-materialized blob rather than the read, because the object store is not the
+then be counted refuses under its own wording — the object store is not the
 fault there. A tracked path containing a tab or newline is refused loudly
-(exit 2) — it cannot be represented in the line-oriented records, and the
-content sniff below reaches every tracked path, so the refusal covers the
-whole tracked set rather than the measured part of it.
+(exit 2) before any skip, so the refusal covers the whole tracked set, which
+is what the `check-attr` parse below relies on.
 
 Every tracked blob is sniffed for a NUL in its leading 8000 bytes, git's own
 text/binary rule, which growth-guards states as `gg_blob_is_binary` and
-preflight as `content_is_binary`. The unit does not narrow the coverage: a
-line class, a byte class, and no class at all are all sniffed, because the
-property held is that the blob stays reviewable text, and its content decides
-that where the unit says nothing.
+preflight as `content_is_binary`. The unit does not narrow the coverage: line
+class, byte class, and no class at all are all sniffed, because what is held
+is that the blob stays reviewable text, and its content decides that where
+the unit says nothing. Such a blob has no textual diff and `git grep -I`
+drops it, while `wc` still returns a number and the walk-based sibling lanes
+name it skipped and exit 0. A hit here is a collection error (exit 2) naming
+the path and the byte's offset, never the byte itself — reprinting it would
+put a NUL into the log carrying the diagnostic on. The refusal runs after the
+walk and before any mode branch, so `--seed` and `--update` refuse through
+that one place rather than writing a meaningless count into the baseline.
 
 The sniff's one exemption is git's own record. `git check-attr diff` answers
 `unset` for a path given `-diff` and `binary` for one given a binary diff
 driver; either way git keeps the path out of every textual diff, so its bytes
-were never reviewable text and the sniff has nothing to ask. That is the
-escape hatch for a real binary asset. The size exclusion list answers a
-different question — which paths carry no size bound — and its entries carry
-size reasons, so it decides nothing here: a size-excluded text file is sniffed
-like every other tracked path, and the two exemptions are independent. The
-attribute is resolved for the whole tracked set in ONE
+were never reviewable text. That is the escape hatch for a real binary asset.
+The size exclusion list answers a different question — which paths carry no
+size bound — so it grants no content exemption: a size-excluded text file is
+sniffed like every other tracked path, and only a path that is both
+size-excluded and diff-exempt is skipped outright. The attribute is resolved
+for the whole tracked set in ONE
 `git ls-files -z | git check-attr -z --stdin diff` before the walk; a fork per
 path is the cost shape that measured 5x when the sniff itself was tried
-per-file. Only a path that is both size-excluded and diff-exempt is read for
-nothing, so only that one is skipped outright.
-
-Under `--staged` and for any path absent from the worktree the blob is
-materialized once, and the count and the sniff read that one copy.
-
-A hit is a collection error (exit 2) naming the path and the byte's offset,
-never the byte itself. Git records such a blob as binary, so it carries no
-textual diff; a plain `git grep` for a line inside it answers `Binary file
-<path> matches`, and a `git grep -I` drops the path outright. No line in it
-reaches diff or grep review, while `wc` still returns a number. One raw
-control byte typed in place of its escape puts a source file in that state:
-the byte is invisible or near-invisible in the usual renderings, and the
-walk-based lanes that do see it name the path as not measured, count it in
-`GG_WALK_SKIPPED`, and still exit 0. The refusal runs before any mode
-branch, so `--seed` and `--update` refuse too rather than writing a
-meaningless line count into the baseline.
+per-file. Under `--staged`, and for any path absent from the worktree, the
+blob is materialized once and the count and the sniff read that one copy.
 
 The sniff runs in two stages, so it costs no subprocess on the files that
-pass. A bounded `read -d ''` under `LC_ALL=C` stops at a NUL, bounds itself
-in bytes, and forks nothing — which makes that stage git's rule outright: a
-status of 0 over a chunk short of the window is a NUL inside the window and
-nothing else. An `od` scan of the leading 8000 bytes then locates the byte.
-Because the prefilter is byte-exact, a scan that runs, succeeds, and finds
-nothing means one of two things: the sniff is wrong, or, on the worktree path
-where the two stages read the file separately, a write landed between them.
-Either way it refuses rather than reporting clean; the refusal itself names
-the path and says the scan located none, and leaves the mechanism here.
+pass. A bounded `read -d ''` under `LC_ALL=C` stops at a NUL and bounds
+itself in BYTES, which is the unit git's rule is stated in; that makes the
+stage git's rule outright — a status of 0 over a chunk short of the window
+means a NUL inside it and nothing else. An `od` scan then locates the byte.
+Because the prefilter is byte-exact, a scan that runs, succeeds and finds
+nothing means the sniff is wrong, or — on the worktree path, where the two
+stages read the file separately — a write landed between them. Either way it
+refuses rather than reporting clean.
 
 The baseline is policy input and never enters the measured set. A self row is
 therefore stale. This makes seed, update, and staged tightening converge

--- a/skills/size-ratchet/DEVELOPMENT.md
+++ b/skills/size-ratchet/DEVELOPMENT.md
@@ -76,7 +76,9 @@ in bytes, and forks nothing — which makes that stage git's rule outright: a
 status of 0 over a chunk short of the window is a NUL inside the window and
 nothing else. An `od` scan of the leading 8000 bytes then locates the byte.
 Because the prefilter is byte-exact, a scan that runs, succeeds, and finds
-nothing is a contradiction, and refuses rather than reporting clean.
+nothing means one of two things: the sniff is wrong, or, on the worktree path
+where the two stages read the file separately, a write landed between them.
+Either way it refuses rather than reporting clean, and says both causes.
 
 The baseline is policy input and never enters the measured set. A self row is
 therefore stale. This makes seed, update, and staged tightening converge

--- a/skills/size-ratchet/DEVELOPMENT.md
+++ b/skills/size-ratchet/DEVELOPMENT.md
@@ -50,19 +50,22 @@ fault there. A tracked path containing a tab or newline is refused loudly
 (exit 2; exclude it to skip the gate) — it cannot be represented in the
 line-oriented records.
 
-Every blob the gate measures in LINES is sniffed for a NUL in its leading
-8000 bytes, git's own text/binary rule, which growth-guards states as
-`gg_blob_is_binary` and preflight as `content_is_binary`. That is every path
-in a line class, and every path in no class at all, which falls to
-`SIZE_RATCHET_THRESHOLD` and is counted in lines. A byte class is never
-asked: it measures the whole blob, and a real asset belongs there or in the
-exclusion list.
+Every blob the gate measures is sniffed for a NUL in its leading 8000 bytes,
+git's own text/binary rule, which growth-guards states as `gg_blob_is_binary`
+and preflight as `content_is_binary`. The unit does not narrow the coverage:
+a line class, a byte class, and no class at all are all sniffed, because the
+property held is that the blob stays reviewable text, and its content decides
+that where the unit says nothing. `is_excluded` runs before the sniff, so the
+exclusion list is the escape hatch for a real binary asset and an excluded
+path pays nothing for the coverage. Under `--staged` and for any path absent
+from the worktree the blob is materialized once, and the count and the sniff
+read that one copy.
 
 A hit is a collection error (exit 2) naming the path and the byte's offset,
 never the byte itself. Git records such a blob as binary, so it carries no
 textual diff; a plain `git grep` for a line inside it answers `Binary file
 <path> matches`, and a `git grep -I` drops the path outright. No line in it
-reaches diff or grep review, while `wc -l` still returns a number. One raw
+reaches diff or grep review, while `wc` still returns a number. One raw
 control byte typed in place of its escape puts a source file in that state:
 the byte is invisible or near-invisible in the usual renderings, and the
 walk-based lanes that do see it name the path as not measured, count it in

--- a/skills/size-ratchet/DEVELOPMENT.md
+++ b/skills/size-ratchet/DEVELOPMENT.md
@@ -43,12 +43,12 @@ blob, so "every tracked file" holds on partial trees too — a sparse checkout
 can neither smuggle a new offender past the gate nor loosen a baselined row.
 An index blob that cannot be read (corrupt object, promisor blob
 unavailable) is a collection error (exit 2, naming the file) — a file the
-gate could not measure is never skipped. A blob that reads but cannot then be
-counted refuses under its own wording, naming the count of the materialized
-blob rather than the read, because the object store is not the fault there.
-A tracked path containing a tab or
-newline is refused loudly (exit 2; exclude it to skip the gate) — it cannot
-be represented in the line-oriented records.
+gate could not measure is never skipped. A blob that materializes but cannot
+then be counted refuses under its own wording, naming the count of the
+materialized blob rather than the read, because the object store is not the
+fault there. A tracked path containing a tab or newline is refused loudly
+(exit 2; exclude it to skip the gate) — it cannot be represented in the
+line-oriented records.
 
 Every blob the gate measures in LINES is sniffed for a NUL in its leading
 8000 bytes, git's own text/binary rule, which growth-guards states as
@@ -61,14 +61,14 @@ exclusion list.
 A hit is a collection error (exit 2) naming the path and the byte's offset,
 never the byte itself. Git records such a blob as binary, so it carries no
 textual diff; a plain `git grep` for a line inside it answers `Binary file
-<path> matches`, and the `git grep -I` the growth-guards lanes run drops the
-path outright. No line in it reaches diff or grep review, while `wc -l` still
-returns a number. One raw control byte typed in place of its escape puts a
-source file in that state: the byte is invisible or near-invisible in the
-usual renderings, and the walk-based lanes that do see it name the path as
-not measured, count it in `GG_WALK_SKIPPED`, and still exit 0. The refusal
-runs before any mode branch, so `--seed` and `--update` refuse too rather
-than writing a meaningless line count into the baseline.
+<path> matches`, and a `git grep -I` drops the path outright. No line in it
+reaches diff or grep review, while `wc -l` still returns a number. One raw
+control byte typed in place of its escape puts a source file in that state:
+the byte is invisible or near-invisible in the usual renderings, and the
+walk-based lanes that do see it name the path as not measured, count it in
+`GG_WALK_SKIPPED`, and still exit 0. The refusal runs before any mode
+branch, so `--seed` and `--update` refuse too rather than writing a
+meaningless line count into the baseline.
 
 The sniff runs in two stages, so it costs no subprocess on the files that
 pass. A bounded `read -d ''` under `LC_ALL=C` stops at a NUL, bounds itself

--- a/skills/size-ratchet/DEVELOPMENT.md
+++ b/skills/size-ratchet/DEVELOPMENT.md
@@ -71,7 +71,7 @@ size bound — so it grants no content exemption: a size-excluded text file is
 sniffed like every other tracked path, and only a path that is both
 size-excluded and diff-exempt is skipped outright. The attribute is resolved
 for the whole tracked set in ONE
-`git ls-files -z | git check-attr -z --stdin diff` before the walk; a fork per
+`git ls-files -z | git check-attr -z --stdin diff`, `--cached` under `--staged`; a fork per
 path is the cost shape that measured 5x when the sniff itself was tried
 per-file. Under `--staged`, and for any path absent from the worktree, the
 blob is materialized once and the count and the sniff read that one copy.

--- a/skills/size-ratchet/DEVELOPMENT.md
+++ b/skills/size-ratchet/DEVELOPMENT.md
@@ -43,25 +43,40 @@ blob, so "every tracked file" holds on partial trees too — a sparse checkout
 can neither smuggle a new offender past the gate nor loosen a baselined row.
 An index blob that cannot be read (corrupt object, promisor blob
 unavailable) is a collection error (exit 2, naming the file) — a file the
-gate could not measure is never skipped. A tracked path containing a tab or
+gate could not measure is never skipped. A blob that reads but cannot then be
+counted refuses under its own wording, naming the count of the materialized
+blob rather than the read, because the object store is not the fault there.
+A tracked path containing a tab or
 newline is refused loudly (exit 2; exclude it to skip the gate) — it cannot
 be represented in the line-oriented records.
 
-Every blob bound for a LINE class is sniffed for a NUL in its leading 8000
-bytes, git's own text/binary rule, which growth-guards states as
-`gg_blob_is_binary`. A hit is a collection error (exit 2) naming the path and
-the byte's offset, never the byte itself: git records such a blob as binary,
-so it has no diff, no `git grep` hit and no line count anyone can check,
-while `wc -l` still returns a number. One raw control byte typed in place of
-its escape puts a source file in that state and nothing else in a commit
-chain notices. Byte classes skip the sniff. They measure the whole blob, and
-a real asset belongs there or in the exclusion list.
+Every blob the gate measures in LINES is sniffed for a NUL in its leading
+8000 bytes, git's own text/binary rule, which growth-guards states as
+`gg_blob_is_binary` and preflight as `content_is_binary`. That is every path
+in a line class, and every path in no class at all, which falls to
+`SIZE_RATCHET_THRESHOLD` and is counted in lines. A byte class is never
+asked: it measures the whole blob, and a real asset belongs there or in the
+exclusion list.
+
+A hit is a collection error (exit 2) naming the path and the byte's offset,
+never the byte itself. Git records such a blob as binary, so it carries no
+textual diff; a plain `git grep` for a line inside it answers `Binary file
+<path> matches`, and the `git grep -I` the growth-guards lanes run drops the
+path outright. No line in it reaches diff or grep review, while `wc -l` still
+returns a number. One raw control byte typed in place of its escape puts a
+source file in that state: the byte is invisible or near-invisible in the
+usual renderings, and the walk-based lanes that do see it name the path as
+not measured, count it in `GG_WALK_SKIPPED`, and still exit 0. The refusal
+runs before any mode branch, so `--seed` and `--update` refuse too rather
+than writing a meaningless line count into the baseline.
 
 The sniff runs in two stages, so it costs no subprocess on the files that
-pass. A bounded `read -d ''` stops at a NUL and forks nothing. In a multibyte
-locale that bound counts characters, so a stop can sit past the window while
-a miss never can, because every character read consumed at least one byte. An
-exact `od` scan of the leading 8000 bytes then confirms a stop and locates it.
+pass. A bounded `read -d ''` under `LC_ALL=C` stops at a NUL, bounds itself
+in bytes, and forks nothing — which makes that stage git's rule outright: a
+status of 0 over a chunk short of the window is a NUL inside the window and
+nothing else. An `od` scan of the leading 8000 bytes then locates the byte.
+Because the prefilter is byte-exact, a scan that runs, succeeds, and finds
+nothing is a contradiction, and refuses rather than reporting clean.
 
 The baseline is policy input and never enters the measured set. A self row is
 therefore stale. This makes seed, update, and staged tightening converge

--- a/skills/size-ratchet/DEVELOPMENT.md
+++ b/skills/size-ratchet/DEVELOPMENT.md
@@ -66,15 +66,18 @@ The sniff's one exemption is git's own record. `git check-attr diff` answers
 `unset` for a path given `-diff` and `binary` for one given a binary diff
 driver; either way git keeps the path out of every textual diff, so its bytes
 were never reviewable text. That is the escape hatch for a real binary asset.
-The size exclusion list answers a different question — which paths carry no
-size bound — so it grants no content exemption: a size-excluded text file is
-sniffed like every other tracked path, and only a path that is both
-size-excluded and diff-exempt is skipped outright. The attribute is resolved
-for the whole tracked set in ONE
-`git ls-files -z | git check-attr -z --stdin diff`, `--cached` under `--staged`; a fork per
-path is the cost shape that measured 5x when the sniff itself was tried
-per-file. Under `--staged`, and for any path absent from the worktree, the
-blob is materialized once and the count and the sniff read that one copy.
+The read pins `core.attributesFile` to `/dev/null`, so no user-global file
+grants it; a repo-local `.git/info/attributes` still does — per-clone, never
+committed, never reviewed, and git offers no switch to skip it. The size
+exclusion list answers a different question — which paths carry no size bound
+— so it grants no content exemption: a size-excluded text file is sniffed like
+every other tracked path, and only a path that is both size-excluded and
+diff-exempt is skipped outright. The attribute is resolved for the whole
+tracked set in ONE `git ls-files -z | git check-attr -z --stdin diff`,
+`--cached` under `--staged`; a fork per path is the cost shape that measured
+5x when the sniff itself was tried per-file. Under `--staged`, and for any
+path absent from the worktree, the blob is materialized once and the count and
+the sniff read that one copy.
 
 The sniff runs in two stages, so it costs no subprocess on the files that
 pass. A bounded `read -d ''` under `LC_ALL=C` stops at a NUL and bounds

--- a/skills/size-ratchet/DEVELOPMENT.md
+++ b/skills/size-ratchet/DEVELOPMENT.md
@@ -78,7 +78,8 @@ nothing else. An `od` scan of the leading 8000 bytes then locates the byte.
 Because the prefilter is byte-exact, a scan that runs, succeeds, and finds
 nothing means one of two things: the sniff is wrong, or, on the worktree path
 where the two stages read the file separately, a write landed between them.
-Either way it refuses rather than reporting clean, and says both causes.
+Either way it refuses rather than reporting clean; the refusal itself names
+the path and says the scan located none, and leaves the mechanism here.
 
 The baseline is policy input and never enters the measured set. A self row is
 therefore stale. This makes seed, update, and staged tightening converge

--- a/skills/size-ratchet/DEVELOPMENT.md
+++ b/skills/size-ratchet/DEVELOPMENT.md
@@ -47,6 +47,22 @@ gate could not measure is never skipped. A tracked path containing a tab or
 newline is refused loudly (exit 2; exclude it to skip the gate) — it cannot
 be represented in the line-oriented records.
 
+Every blob bound for a LINE class is sniffed for a NUL in its leading 8000
+bytes, git's own text/binary rule, which growth-guards states as
+`gg_blob_is_binary`. A hit is a collection error (exit 2) naming the path and
+the byte's offset, never the byte itself: git records such a blob as binary,
+so it has no diff, no `git grep` hit and no line count anyone can check,
+while `wc -l` still returns a number. One raw control byte typed in place of
+its escape puts a source file in that state and nothing else in a commit
+chain notices. Byte classes skip the sniff. They measure the whole blob, and
+a real asset belongs there or in the exclusion list.
+
+The sniff runs in two stages, so it costs no subprocess on the files that
+pass. A bounded `read -d ''` stops at a NUL and forks nothing. In a multibyte
+locale that bound counts characters, so a stop can sit past the window while
+a miss never can, because every character read consumed at least one byte. An
+exact `od` scan of the leading 8000 bytes then confirms a stop and locates it.
+
 The baseline is policy input and never enters the measured set. A self row is
 therefore stale. This makes seed, update, and staged tightening converge
 without re-measuring output that contains its own measurement.

--- a/skills/size-ratchet/README.md
+++ b/skills/size-ratchet/README.md
@@ -68,7 +68,8 @@ that. Markdown is measured in bytes and code in lines. Flags and exit codes:
   out of every textual diff, the remedy for a tracked `.png`, `.ico` or
   `.ttf`. The [exclusion list](#exclusion-list) answers a different question,
   which paths carry no size bound, and grants no content exemption. `--seed`
-  and `--update` refuse the same way. Mechanism: `DEVELOPMENT.md`.
+  and `--update` refuse the same way. Under `--staged` that record is the index's,
+  and no global `core.attributesFile` is read. Mechanism: `DEVELOPMENT.md`.
 - Exit codes: `0` clean, `1` violations, `2` usage/config/collection error.
 
 ## Trusted HEAD baseline

--- a/skills/size-ratchet/README.md
+++ b/skills/size-ratchet/README.md
@@ -58,18 +58,18 @@ that. Markdown is measured in bytes and code in lines. Flags and exit codes:
   rows whose unit no longer matches their class, and removes rows for files
   now at/under their own threshold or no longer counted. It never adds a row
   or raises a number whose unit stayed the same, then re-checks.
-- **Refused as unmeasurable** (exit 2): a blob measured in lines carrying a
-  NUL inside its leading 8000 bytes — git's own text/binary rule. That covers
-  every path in a line class and every path in no class at all, which falls to
-  `SIZE_RATCHET_THRESHOLD` and is counted in lines. Git records such a blob as
-  binary, so it has no textual diff and no line count that means anything. The
-  diagnostic names the path and the byte's offset, never the byte; the fix is
-  the escape the language spells it with. A real binary asset belongs in a byte
-  class or the [exclusion list](#exclusion-list), neither of which counts
-  lines — that is the remedy for an unclassified `.png`, `.ico` or `.ttf`,
-  which matches no shipped class and is therefore counted in lines. `--seed`
-  and `--update` refuse the same way, so an adopting repo meets this at its
-  first seed rather than at its first check. Mechanism: `DEVELOPMENT.md`.
+- **Refused as unmeasurable** (exit 2): any counted blob carrying a NUL inside
+  its leading 8000 bytes — git's own text/binary rule. The unit does not
+  narrow it: a line class, a byte class, and no class at all are all covered,
+  because what is held is that the blob stays reviewable text and its content
+  decides that, not the number it is counted in. Git records such a blob as
+  binary, so it has no textual diff and no line of it reaches a `git grep`
+  review. The diagnostic names the path and the byte's offset, never the byte;
+  the fix is the escape the language spells it with. A real binary asset
+  belongs in the [exclusion list](#exclusion-list), which is checked before the
+  content is — that is the remedy for a tracked `.png`, `.ico` or `.ttf`.
+  `--seed` and `--update` refuse the same way, so an adopting repo meets this
+  at its first seed rather than at its first check. Mechanism: `DEVELOPMENT.md`.
 - Exit codes: `0` clean, `1` violations, `2` usage/config/collection error.
 
 ## Trusted HEAD baseline

--- a/skills/size-ratchet/README.md
+++ b/skills/size-ratchet/README.md
@@ -58,18 +58,19 @@ that. Markdown is measured in bytes and code in lines. Flags and exit codes:
   rows whose unit no longer matches their class, and removes rows for files
   now at/under their own threshold or no longer counted. It never adds a row
   or raises a number whose unit stayed the same, then re-checks.
-- **Refused as unmeasurable** (exit 2): any tracked blob carrying a NUL inside
-  its leading 8000 bytes — git's own text/binary rule, so the blob has no
-  textual diff and no line of it reaches a `git grep` review. Every class is
-  covered, and no class at all: the content decides, not the unit counted. The
-  diagnostic names the path and the byte's offset, never the byte; the fix is
-  the escape the language spells it with. The one exemption is git's own
-  record — a path `.gitattributes` gives `binary` or `-diff` is one git keeps
-  out of every textual diff, the remedy for a tracked `.png`, `.ico` or
-  `.ttf`. The [exclusion list](#exclusion-list) answers a different question,
-  which paths carry no size bound, and grants no content exemption. `--seed`
-  and `--update` refuse the same way. Under `--staged` that record is the index's,
-  and no global `core.attributesFile` is read. Mechanism: `DEVELOPMENT.md`.
+- **Refused as unmeasurable** (exit 2): any tracked blob carrying a NUL
+  inside its leading 8000 bytes — git's own text/binary rule, so the blob has
+  no textual diff and no line of it reaches a `git grep` review. Every class
+  is covered, and no class at all: the content decides, not the unit counted.
+  The diagnostic names the path and the byte's offset, never the byte; the
+  fix is the escape the language spells it with. The one exemption is git's
+  own record — a path `.gitattributes` gives `binary` or `-diff` is one git
+  keeps out of every textual diff. The [exclusion list](#exclusion-list)
+  answers a different question, which paths carry no size bound, and grants
+  no content exemption. `--seed` and `--update` refuse the same way. Under
+  `--staged` that record is the index's, and no global `core.attributesFile`
+  is read; a repo-local `.git/info/attributes` still applies and is neither
+  committed nor reviewed. Mechanism: `DEVELOPMENT.md`.
 - Exit codes: `0` clean, `1` violations, `2` usage/config/collection error.
 
 ## Trusted HEAD baseline

--- a/skills/size-ratchet/README.md
+++ b/skills/size-ratchet/README.md
@@ -58,18 +58,22 @@ that. Markdown is measured in bytes and code in lines. Flags and exit codes:
   rows whose unit no longer matches their class, and removes rows for files
   now at/under their own threshold or no longer counted. It never adds a row
   or raises a number whose unit stayed the same, then re-checks.
-- **Refused as unmeasurable** (exit 2): any counted blob carrying a NUL inside
+- **Refused as unmeasurable** (exit 2): any tracked blob carrying a NUL inside
   its leading 8000 bytes — git's own text/binary rule. The unit does not
   narrow it: a line class, a byte class, and no class at all are all covered,
   because what is held is that the blob stays reviewable text and its content
   decides that, not the number it is counted in. Git records such a blob as
   binary, so it has no textual diff and no line of it reaches a `git grep`
   review. The diagnostic names the path and the byte's offset, never the byte;
-  the fix is the escape the language spells it with. A real binary asset
-  belongs in the [exclusion list](#exclusion-list), which is checked before the
-  content is — that is the remedy for a tracked `.png`, `.ico` or `.ttf`.
-  `--seed` and `--update` refuse the same way, so an adopting repo meets this
-  at its first seed rather than at its first check. Mechanism: `DEVELOPMENT.md`.
+  the fix is the escape the language spells it with. The one exemption is
+  git's own record: a path `.gitattributes` gives `binary` or `-diff` is one
+  git keeps out of every textual diff, so it was never reviewable text — that
+  is the remedy for a tracked `.png`, `.ico` or `.ttf`. The
+  [exclusion list](#exclusion-list) answers a different question, which paths
+  carry no size bound, and grants no content exemption: a size-excluded text
+  file is sniffed like every other tracked path. `--seed` and `--update`
+  refuse the same way, so an adopting repo meets this at its first seed rather
+  than at its first check. Mechanism: `DEVELOPMENT.md`.
 - Exit codes: `0` clean, `1` violations, `2` usage/config/collection error.
 
 ## Trusted HEAD baseline

--- a/skills/size-ratchet/README.md
+++ b/skills/size-ratchet/README.md
@@ -58,6 +58,13 @@ that. Markdown is measured in bytes and code in lines. Flags and exit codes:
   rows whose unit no longer matches their class, and removes rows for files
   now at/under their own threshold or no longer counted. It never adds a row
   or raises a number whose unit stayed the same, then re-checks.
+- **Refused as unmeasurable** (exit 2): a blob in a LINE class carrying a NUL
+  inside its leading 8000 bytes — git's own text/binary rule. Git records such
+  a blob as binary, so it has no diff, no `git grep` hit and no line count that
+  means anything, while `wc -l` still returns one. The diagnostic names the
+  path and the byte's offset and never the byte itself; the fix is the escape
+  the language spells it with. A real binary asset belongs in a byte class or
+  the [exclusion list](#exclusion-list), neither of which counts lines.
 - Exit codes: `0` clean, `1` violations, `2` usage/config/collection error.
 
 ## Trusted HEAD baseline

--- a/skills/size-ratchet/README.md
+++ b/skills/size-ratchet/README.md
@@ -58,13 +58,18 @@ that. Markdown is measured in bytes and code in lines. Flags and exit codes:
   rows whose unit no longer matches their class, and removes rows for files
   now at/under their own threshold or no longer counted. It never adds a row
   or raises a number whose unit stayed the same, then re-checks.
-- **Refused as unmeasurable** (exit 2): a blob in a LINE class carrying a NUL
-  inside its leading 8000 bytes — git's own text/binary rule. Git records such
-  a blob as binary, so it has no diff, no `git grep` hit and no line count that
-  means anything, while `wc -l` still returns one. The diagnostic names the
-  path and the byte's offset and never the byte itself; the fix is the escape
-  the language spells it with. A real binary asset belongs in a byte class or
-  the [exclusion list](#exclusion-list), neither of which counts lines.
+- **Refused as unmeasurable** (exit 2): a blob measured in lines carrying a
+  NUL inside its leading 8000 bytes — git's own text/binary rule. That covers
+  every path in a line class and every path in no class at all, which falls to
+  `SIZE_RATCHET_THRESHOLD` and is counted in lines. Git records such a blob as
+  binary, so it has no textual diff and no line count that means anything. The
+  diagnostic names the path and the byte's offset, never the byte; the fix is
+  the escape the language spells it with. A real binary asset belongs in a byte
+  class or the [exclusion list](#exclusion-list), neither of which counts
+  lines — that is the remedy for an unclassified `.png`, `.ico` or `.ttf`,
+  which matches no shipped class and is therefore counted in lines. `--seed`
+  and `--update` refuse the same way, so an adopting repo meets this at its
+  first seed rather than at its first check. Mechanism: `DEVELOPMENT.md`.
 - Exit codes: `0` clean, `1` violations, `2` usage/config/collection error.
 
 ## Trusted HEAD baseline

--- a/skills/size-ratchet/README.md
+++ b/skills/size-ratchet/README.md
@@ -59,21 +59,16 @@ that. Markdown is measured in bytes and code in lines. Flags and exit codes:
   now at/under their own threshold or no longer counted. It never adds a row
   or raises a number whose unit stayed the same, then re-checks.
 - **Refused as unmeasurable** (exit 2): any tracked blob carrying a NUL inside
-  its leading 8000 bytes — git's own text/binary rule. The unit does not
-  narrow it: a line class, a byte class, and no class at all are all covered,
-  because what is held is that the blob stays reviewable text and its content
-  decides that, not the number it is counted in. Git records such a blob as
-  binary, so it has no textual diff and no line of it reaches a `git grep`
-  review. The diagnostic names the path and the byte's offset, never the byte;
-  the fix is the escape the language spells it with. The one exemption is
-  git's own record: a path `.gitattributes` gives `binary` or `-diff` is one
-  git keeps out of every textual diff, so it was never reviewable text — that
-  is the remedy for a tracked `.png`, `.ico` or `.ttf`. The
-  [exclusion list](#exclusion-list) answers a different question, which paths
-  carry no size bound, and grants no content exemption: a size-excluded text
-  file is sniffed like every other tracked path. `--seed` and `--update`
-  refuse the same way, so an adopting repo meets this at its first seed rather
-  than at its first check. Mechanism: `DEVELOPMENT.md`.
+  its leading 8000 bytes — git's own text/binary rule, so the blob has no
+  textual diff and no line of it reaches a `git grep` review. Every class is
+  covered, and no class at all: the content decides, not the unit counted. The
+  diagnostic names the path and the byte's offset, never the byte; the fix is
+  the escape the language spells it with. The one exemption is git's own
+  record — a path `.gitattributes` gives `binary` or `-diff` is one git keeps
+  out of every textual diff, the remedy for a tracked `.png`, `.ico` or
+  `.ttf`. The [exclusion list](#exclusion-list) answers a different question,
+  which paths carry no size bound, and grants no content exemption. `--seed`
+  and `--update` refuse the same way. Mechanism: `DEVELOPMENT.md`.
 - Exit codes: `0` clean, `1` violations, `2` usage/config/collection error.
 
 ## Trusted HEAD baseline

--- a/skills/size-ratchet/SKILL.md
+++ b/skills/size-ratchet/SKILL.md
@@ -44,11 +44,12 @@ Reference, repoint, raise, and unit-change behavior is one rule:
 [README.md § Trusted HEAD baseline](README.md#trusted-head-baseline).
 A shrunk row under `--staged` is already lowered and staged by the run itself.
 
-**A NUL is refused, not measured.** A blob in a line class carrying a NUL in
-its leading 8000 bytes is what git calls binary: no diff, no `git grep` hit,
-no line count worth printing. The gate exits 2 naming the path and the byte's
-offset. Write the escape the language spells the byte with; a real binary
-asset belongs in a byte class or the exclusion list.
+**A NUL is refused, not measured.** A blob the gate counts in lines — a line
+class, or no class at all — carrying a NUL in its leading 8000 bytes is what
+git calls binary. The gate exits 2 naming the path and the byte's offset, in
+every mode, `--seed` and `--update` included. Write the escape the language
+spells the byte with; a real binary asset belongs in a byte class or the
+exclusion list.
 
 **Check composition before the seam.** A file over its cap whose bulk is
 inline tests needs those tests moved to the language's separate-test

--- a/skills/size-ratchet/SKILL.md
+++ b/skills/size-ratchet/SKILL.md
@@ -44,6 +44,12 @@ Reference, repoint, raise, and unit-change behavior is one rule:
 [README.md § Trusted HEAD baseline](README.md#trusted-head-baseline).
 A shrunk row under `--staged` is already lowered and staged by the run itself.
 
+**A NUL is refused, not measured.** A blob in a line class carrying a NUL in
+its leading 8000 bytes is what git calls binary: no diff, no `git grep` hit,
+no line count worth printing. The gate exits 2 naming the path and the byte's
+offset. Write the escape the language spells the byte with; a real binary
+asset belongs in a byte class or the exclusion list.
+
 **Check composition before the seam.** A file over its cap whose bulk is
 inline tests needs those tests moved to the language's separate-test
 convention, not its concepts split; that move has no seam in it. In Rust

--- a/skills/size-ratchet/SKILL.md
+++ b/skills/size-ratchet/SKILL.md
@@ -45,12 +45,11 @@ Reference, repoint, raise, and unit-change behavior is one rule:
 A shrunk row under `--staged` is already lowered and staged by the run itself.
 
 **A NUL is refused, not measured.** Any tracked blob carrying a NUL in its
-leading 8000 bytes is what git calls binary, whatever unit its class counts
-in and whether or not the size exclusion list covers it. The gate exits 2
-naming the path and the byte's offset, in every mode, `--seed` and `--update`
+leading 8000 bytes is what git calls binary, whatever unit its class counts in
+and whether or not the size exclusion list covers it. The gate exits 2 naming
+the path and the byte's offset, in every mode, `--seed` and `--update`
 included. Write the escape the language spells the byte with; a real binary
-asset is declared `binary` or `-diff` in `.gitattributes`, git's own record of
-what it keeps out of a textual diff, which is the only exemption.
+asset is declared `binary` or `-diff` in `.gitattributes`, the only exemption.
 
 **Check composition before the seam.** A file over its cap whose bulk is
 inline tests needs those tests moved to the language's separate-test

--- a/skills/size-ratchet/SKILL.md
+++ b/skills/size-ratchet/SKILL.md
@@ -44,12 +44,11 @@ Reference, repoint, raise, and unit-change behavior is one rule:
 [README.md § Trusted HEAD baseline](README.md#trusted-head-baseline).
 A shrunk row under `--staged` is already lowered and staged by the run itself.
 
-**A NUL is refused, not measured.** A blob the gate counts in lines — a line
-class, or no class at all — carrying a NUL in its leading 8000 bytes is what
-git calls binary. The gate exits 2 naming the path and the byte's offset, in
-every mode, `--seed` and `--update` included. Write the escape the language
-spells the byte with; a real binary asset belongs in a byte class or the
-exclusion list.
+**A NUL is refused, not measured.** Any counted blob carrying a NUL in its
+leading 8000 bytes is what git calls binary, whatever unit its class counts
+in. The gate exits 2 naming the path and the byte's offset, in every mode,
+`--seed` and `--update` included. Write the escape the language spells the
+byte with; a real binary asset belongs in the exclusion list.
 
 **Check composition before the seam.** A file over its cap whose bulk is
 inline tests needs those tests moved to the language's separate-test

--- a/skills/size-ratchet/SKILL.md
+++ b/skills/size-ratchet/SKILL.md
@@ -44,11 +44,13 @@ Reference, repoint, raise, and unit-change behavior is one rule:
 [README.md § Trusted HEAD baseline](README.md#trusted-head-baseline).
 A shrunk row under `--staged` is already lowered and staged by the run itself.
 
-**A NUL is refused, not measured.** Any counted blob carrying a NUL in its
+**A NUL is refused, not measured.** Any tracked blob carrying a NUL in its
 leading 8000 bytes is what git calls binary, whatever unit its class counts
-in. The gate exits 2 naming the path and the byte's offset, in every mode,
-`--seed` and `--update` included. Write the escape the language spells the
-byte with; a real binary asset belongs in the exclusion list.
+in and whether or not the size exclusion list covers it. The gate exits 2
+naming the path and the byte's offset, in every mode, `--seed` and `--update`
+included. Write the escape the language spells the byte with; a real binary
+asset is declared `binary` or `-diff` in `.gitattributes`, git's own record of
+what it keeps out of a textual diff, which is the only exemption.
 
 **Check composition before the seam.** A file over its cap whose bulk is
 inline tests needs those tests moved to the language's separate-test

--- a/skills/size-ratchet/scripts/size-ratchet
+++ b/skills/size-ratchet/scripts/size-ratchet
@@ -578,10 +578,10 @@ note_if_binary() { # PATH BLOBFILE — records a line-class blob git reads as bi
     { seen += NF }
     END { if (found) print off }
   ')" || collection_error "could not scan '$1' for the offset of its NUL byte — refusing to report a verdict"
-  # A scan that ran, succeeded and found nothing contradicts the byte-exact
-  # prefilter that sent it here. Reporting clean on it would be the fail-open
-  # this whole sniff exists to close.
-  [ -n "$off" ] || collection_error "the content prefilter for '$1' stopped at a NUL inside its leading $NUL_SNIFF_BYTES bytes and the scan then located none — refusing to report a verdict over the contradiction"
+  # A scan that ran, succeeded and found nothing means a broken sniff, or a
+  # write between the two reads of a worktree path (staged reads one copy).
+  # Reporting clean either way is the fail-open this sniff exists to close.
+  [ -n "$off" ] || collection_error "the content prefilter for '$1' stopped at a NUL inside its leading $NUL_SNIFF_BYTES bytes and the scan then located none — the two stages read the path separately, so either the file was written between them or the sniff is wrong; refusing to report a verdict either way"
   printf '%s\t%s\n' "$1" "$off" >>"$TMP/binary.paths" \
     || collection_error "could not record the binary-content finding for '$1' — refusing to report a verdict"
 }

--- a/skills/size-ratchet/scripts/size-ratchet
+++ b/skills/size-ratchet/scripts/size-ratchet
@@ -543,14 +543,38 @@ flush_batch() { # UNIT — appends one "<path><TAB><count>" row per pending file
   cat "$TMP/batch.tsv" >>"$TMP/counts.raw" || collection_error "could not append the re-measured counts — the measurement is incomplete, refusing to report a verdict"
   clear_batch "$unit"
 }
+# Content exemption is GIT'S OWN record and nothing else. `git check-attr diff`
+# answers `unset` for a path given `-diff` and `binary` for one given a binary
+# diff driver: either way git keeps the path out of every textual diff, so its
+# bytes were never reviewable text and the sniff has nothing to ask. The size
+# exclusion list answers a different question, which paths carry no SIZE bound,
+# so it decides nothing here — a size-excluded text file is sniffed like every
+# other tracked path. ONE `check-attr` process for the whole set: a fork per
+# path is the cost shape that measured 5x when the sniff was tried per-file.
+# The `-z` stream is `path NUL attr NUL value NUL`, folded to one exempt path
+# per line; a newline in a path would misalign that, and the walk refuses every
+# such path before it reads this set.
+ATTR_EXEMPT=""
+if ! { git ls-files -z | git check-attr -z --stdin diff >"$TMP/attr.z"; }; then
+  config_error "could not resolve the 'diff' attribute over the tracked set (git ls-files | git check-attr failed) — refusing to guess what git keeps out of its textual diffs"
+fi
+attr_exempt="$(LC_ALL=C tr '\000' '\n' <"$TMP/attr.z" | awk '
+  NR % 3 == 1 { p = $0; next }
+  NR % 3 == 0 && ($0 == "unset" || $0 == "binary") { print p }
+')" || collection_error "could not read the resolved 'diff' attributes — refusing to guess what git keeps out of its textual diffs"
+ATTR_EXEMPT="$NL$attr_exempt$NL"
+is_diff_exempt() { # PATH — 0 when .gitattributes takes the path out of textual diffs
+  case "$ATTR_EXEMPT" in
+    *"$NL$1$NL"*) return 0 ;;
+  esac
+  return 1
+}
 # A blob git reads as binary is not reviewable content: git's rule is a NUL
 # inside the leading bytes, and it takes the blob out of every textual diff
-# while `wc` still returns a number. Every tracked blob this gate measures is
+# while `wc` still returns a number. Every tracked blob this gate walks is
 # asked the question, in whatever unit its class counts — the property being
 # held is that the blob is text a reviewer and a `git grep` can read, which
-# the CONTENT decides and the unit says nothing about. A real binary asset
-# belongs in the exclusion list, which `is_excluded` applies ahead of the
-# sniff, so an excluded path pays nothing for the coverage.
+# the CONTENT decides and the unit says nothing about.
 # What git and the sibling gates do with such a blob: DEVELOPMENT.md.
 #
 # LINEAGE. growth-guards' `gg_blob_is_binary` (GG_BINARY_SAMPLE) owns this
@@ -591,34 +615,46 @@ note_if_binary() { # PATH BLOBFILE — records a tracked blob git reads as binar
 while IFS= read -r -d '' rec; do
   mode="${rec%% *}"
   f="${rec#*"$TAB"}"
-  is_excluded "$f" && continue
-  case "$f" in
-    *"$NL"*) config_error "tracked path contains a newline, unrepresentable in line-oriented records (exclude it to skip the gate): '$f'" ;;
-    *"$TAB"*) config_error "tracked path contains a tab, unrepresentable in the baseline TSV (exclude it to skip the gate): '$f'" ;;
-  esac
   case "$mode" in
-    120000) continue ;; # tracked symlink — no meaningful size
+    120000) continue ;; # tracked symlink — no meaningful size, and no content
     160000) continue ;; # submodule gitlink — never countable; a baseline
   esac
-  path_threshold "$f"
-  if [ "$PU" = "b" ]; then wcflag="-c"; else wcflag="-l"; fi
+  # Both records this walk writes are line-oriented and tab-separated, and the
+  # sniff below reaches size-excluded paths too, so the refusal covers the
+  # whole tracked set rather than the measured part of it.
+  case "$f" in
+    *"$NL"*) config_error "tracked path contains a newline, unrepresentable in line-oriented records: '$f'" ;;
+    *"$TAB"*) config_error "tracked path contains a tab, unrepresentable in the baseline TSV: '$f'" ;;
+  esac
+  sniff=1
+  if is_diff_exempt "$f"; then sniff=0; fi
+  excluded=0
+  if is_excluded "$f"; then excluded=1; fi
+  # The two exemptions are independent, so only a path carrying both is skipped.
+  if [ "$excluded" -eq 1 ] && [ "$sniff" -eq 0 ]; then continue; fi
+  if [ "$excluded" -eq 0 ]; then
+    path_threshold "$f"
+    if [ "$PU" = "b" ]; then wcflag="-c"; else wcflag="-l"; fi
+  fi
   if [ "$STAGED" -eq 1 ] || [ ! -f "$f" ] || [ -h "$f" ]; then
     # Materialized once: the count and the content sniff read the same bytes,
     # and a second `git show` per path would double the walk under --staged.
     if ! git show ":$f" >"$TMP/blob"; then
-      collection_error "cannot read index blob for tracked file '$f' — its size is unmeasurable, refusing to skip it"
+      collection_error "cannot read index blob for tracked file '$f' — it can be neither measured nor classified, refusing to skip it"
     fi
+    if [ "$sniff" -eq 1 ]; then note_if_binary "$f" "$TMP/blob"; fi
+    if [ "$excluded" -eq 1 ]; then continue; fi
     if ! n="$(wc "$wcflag" <"$TMP/blob")"; then
       collection_error "cannot count the materialized index blob for tracked file '$f' — its size is unmeasurable, refusing to skip it"
     fi
-    note_if_binary "$f" "$TMP/blob"
     n="${n#"${n%%[![:space:]]*}"}" # strip wc's leading whitespace (BSD wc pads)
     case "$n" in
       "" | *[!0-9]*) collection_error "$(unit_noun "$PU") count for index blob of '$f' came back as '$n', not a number — its size is unmeasurable, refusing to skip it" ;;
     esac
     printf '%s\t%s\n' "$f" "$n" >>"$TMP/counts.raw" || collection_error "could not record the count for '$f' — the measurement is incomplete, refusing to report a verdict"
   else
-    note_if_binary "$f" "$f"
+    if [ "$sniff" -eq 1 ]; then note_if_binary "$f" "$f"; fi
+    if [ "$excluded" -eq 1 ]; then continue; fi
     if [ "$PU" = "b" ]; then
       WT_BATCH_B+=("$f")
       WT_BATCH_B_CHARS=$((WT_BATCH_B_CHARS + ${#f} + 1))
@@ -643,7 +679,7 @@ if [ -s "$TMP/binary.paths" ]; then
   while IFS="$TAB" read -r bin_path bin_off; do
     echo "$bin_path: a NUL byte at offset $bin_off" >&2
   done <"$TMP/binary.paths"
-  collection_error "the path(s) above are tracked as reviewable text but carry a NUL inside their leading $NUL_SNIFF_BYTES bytes, so git records them as binary: no textual diff, a plain \`git grep\` reduced to \"Binary file <path> matches\" and a \`git grep -I\` that drops the path outright. Write the escape your language spells the byte with (\\0, \\u0000, \\x00) instead of the raw character; a real binary asset belongs in the exclusion list."
+  collection_error "the path(s) above are tracked as reviewable text but carry a NUL inside their leading $NUL_SNIFF_BYTES bytes, so git records them as binary: no textual diff, a plain \`git grep\` reduced to \"Binary file <path> matches\" and a \`git grep -I\` that drops the path outright. Write the escape your language spells the byte with (\\0, \\u0000, \\x00) instead of the raw character; a real binary asset is declared \`binary\` or \`-diff\` in .gitattributes, which is what takes it out of git's textual diffs and out of this check."
 fi
 counted="$(count_nonempty_lines "$TMP/counts.raw")"
 [ "$counted" -eq "$checked" ] || collection_error "counted $counted of the $checked tracked file(s) selected for measurement — the collection is incomplete, refusing to report a verdict"

--- a/skills/size-ratchet/scripts/size-ratchet
+++ b/skills/size-ratchet/scripts/size-ratchet
@@ -543,6 +543,39 @@ flush_batch() { # UNIT — appends one "<path><TAB><count>" row per pending file
   cat "$TMP/batch.tsv" >>"$TMP/counts.raw" || collection_error "could not append the re-measured counts — the measurement is incomplete, refusing to report a verdict"
   clear_batch "$unit"
 }
+# A blob git reads as binary has no line count anyone can check. Git's own
+# heuristic is a NUL inside the leading bytes, the rule growth-guards states
+# as gg_blob_is_binary, and it drops the blob from every diff, `git grep` and
+# review, while `wc -l` still returns a number with nothing readable behind
+# it. One raw control byte typed into a source file instead of its escape
+# puts the file in that state and nothing else notices: the byte renders as a
+# space in every editor and tool, and every other gate passes the file. Only
+# LINE classes ask the question. A real asset carries the byte legitimately
+# and belongs in a byte class or the exclusion list, where nothing counts its
+# lines.
+NUL_SNIFF_BYTES=8000
+note_if_binary() { # PATH BLOBFILE — records a line-class blob git reads as binary
+  local chunk status=0 off
+  # `read -d ''` stops at a NUL and -n bounds the read, at no subprocess cost.
+  # In a multibyte locale that bound counts CHARACTERS, so a stop here can sit
+  # past the sniff window while a miss never can: every character read consumed
+  # at least one byte. So this decides the misses — every text file, every run
+  # — and the exact byte scan below decides and locates the rest.
+  { IFS= read -r -d '' -n "$NUL_SNIFF_BYTES" chunk || status=$?; } <"$2" \
+    || collection_error "cannot read tracked file '$1' — its content cannot be classified, refusing to skip it"
+  { [ "$status" -eq 0 ] && [ "${#chunk}" -lt "$NUL_SNIFF_BYTES" ]; } || return 0
+  # No early exit anywhere in this pipeline: an awk that stopped reading would
+  # SIGPIPE od and, under pipefail, fail the scan on the files that need it.
+  off="$(LC_ALL=C od -An -v -tx1 -N "$NUL_SNIFF_BYTES" <"$2" | awk '
+    found == 0 { for (i = 1; i <= NF; i++) if ($i == "00") { off = seen + i - 1; found = 1; break } }
+    { seen += NF }
+    END { if (found) print off }
+  ')" || collection_error "could not scan '$1' for the offset of its NUL byte — refusing to report a verdict"
+  [ -n "$off" ] || return 0
+  printf '%s\t%s\n' "$1" "$off" >>"$TMP/binary.paths" \
+    || collection_error "could not record the binary-content finding for '$1' — refusing to report a verdict"
+}
+: >"$TMP/binary.paths" || collection_error "could not initialize the binary-content scratch file"
 while IFS= read -r -d '' rec; do
   mode="${rec%% *}"
   f="${rec#*"$TAB"}"
@@ -558,9 +591,15 @@ while IFS= read -r -d '' rec; do
   path_threshold "$f"
   if [ "$PU" = "b" ]; then wcflag="-c"; else wcflag="-l"; fi
   if [ "$STAGED" -eq 1 ] || [ ! -f "$f" ] || [ -h "$f" ]; then
-    if ! n="$(git show ":$f" | wc "$wcflag")"; then
+    # Materialized once: the count and the content sniff read the same bytes,
+    # and a second `git show` per path would double the walk under --staged.
+    if ! git show ":$f" >"$TMP/blob"; then
       collection_error "cannot read index blob for tracked file '$f' — its size is unmeasurable, refusing to skip it"
     fi
+    if ! n="$(wc "$wcflag" <"$TMP/blob")"; then
+      collection_error "cannot read index blob for tracked file '$f' — its size is unmeasurable, refusing to skip it"
+    fi
+    [ "$PU" = "b" ] || note_if_binary "$f" "$TMP/blob"
     n="${n#"${n%%[![:space:]]*}"}" # strip wc's leading whitespace (BSD wc pads)
     case "$n" in
       "" | *[!0-9]*) collection_error "$(unit_noun "$PU") count for index blob of '$f' came back as '$n', not a number — its size is unmeasurable, refusing to skip it" ;;
@@ -573,6 +612,7 @@ while IFS= read -r -d '' rec; do
       flush_batch b
     fi
   else
+    note_if_binary "$f" "$f"
     WT_BATCH_L+=("$f")
     WT_BATCH_L_CHARS=$((WT_BATCH_L_CHARS + ${#f} + 1))
     if [ "${#WT_BATCH_L[@]}" -ge "$BATCH_MAX_FILES" ] || [ "$WT_BATCH_L_CHARS" -ge "$BATCH_MAX_CHARS" ]; then
@@ -583,6 +623,14 @@ while IFS= read -r -d '' rec; do
 done <"$TMP/files.z"
 flush_batch l
 flush_batch b
+if [ -s "$TMP/binary.paths" ]; then
+  # The offset alone, never the byte: echoing it back would put a NUL into the
+  # diagnostic, and the log, terminal or CI annotation carrying it next.
+  while IFS="$TAB" read -r bin_path bin_off; do
+    echo "$bin_path: a NUL byte at offset $bin_off" >&2
+  done <"$TMP/binary.paths"
+  collection_error "the path(s) above are measured in lines but carry a NUL inside their leading $NUL_SNIFF_BYTES bytes, so git records them as binary: no diff, no grep hit, no line count that means anything. Write the escape your language spells the byte with (\\0, \\u0000, \\x00) instead of the raw character; a real binary asset belongs in a byte class or the exclusion list."
+fi
 counted="$(count_nonempty_lines "$TMP/counts.raw")"
 [ "$counted" -eq "$checked" ] || collection_error "counted $counted of the $checked tracked file(s) selected for measurement — the collection is incomplete, refusing to report a verdict"
 : >"$TMP/counts.classed" || collection_error "could not initialize the classified-counts scratch file"

--- a/skills/size-ratchet/scripts/size-ratchet
+++ b/skills/size-ratchet/scripts/size-ratchet
@@ -581,7 +581,7 @@ note_if_binary() { # PATH BLOBFILE — records a line-class blob git reads as bi
   # A scan that ran, succeeded and found nothing means a broken sniff, or a
   # write between the two reads of a worktree path (staged reads one copy).
   # Reporting clean either way is the fail-open this sniff exists to close.
-  [ -n "$off" ] || collection_error "the content prefilter for '$1' stopped at a NUL inside its leading $NUL_SNIFF_BYTES bytes and the scan then located none — the two stages read the path separately, so either the file was written between them or the sniff is wrong; refusing to report a verdict either way"
+  [ -n "$off" ] || collection_error "the content prefilter for '$1' stopped at a NUL inside its leading $NUL_SNIFF_BYTES bytes and the scan then located none — refusing to report a verdict"
   printf '%s\t%s\n' "$1" "$off" >>"$TMP/binary.paths" \
     || collection_error "could not record the binary-content finding for '$1' — refusing to report a verdict"
 }

--- a/skills/size-ratchet/scripts/size-ratchet
+++ b/skills/size-ratchet/scripts/size-ratchet
@@ -543,24 +543,31 @@ flush_batch() { # UNIT — appends one "<path><TAB><count>" row per pending file
   cat "$TMP/batch.tsv" >>"$TMP/counts.raw" || collection_error "could not append the re-measured counts — the measurement is incomplete, refusing to report a verdict"
   clear_batch "$unit"
 }
-# A blob git reads as binary has no line count anyone can check. Git's own
-# heuristic is a NUL inside the leading bytes, the rule growth-guards states
-# as gg_blob_is_binary, and it drops the blob from every diff, `git grep` and
-# review, while `wc -l` still returns a number with nothing readable behind
-# it. One raw control byte typed into a source file instead of its escape
-# puts the file in that state and nothing else notices: the byte renders as a
-# space in every editor and tool, and every other gate passes the file. Only
-# LINE classes ask the question. A real asset carries the byte legitimately
-# and belongs in a byte class or the exclusion list, where nothing counts its
-# lines.
+# A blob git reads as binary has no line count anyone can check: git's rule
+# is a NUL inside the leading bytes, and it takes the blob out of every
+# textual diff while `wc -l` still returns a number. Every blob this gate
+# measures in LINES is asked the question — a path matching no class at all
+# resolves to SIZE_RATCHET_THRESHOLD in lines and is asked too. A byte class
+# is not asked, and a real asset belongs there or in the exclusion list.
+# What git and the sibling gates do with such a blob: DEVELOPMENT.md.
+#
+# LINEAGE. growth-guards' `gg_blob_is_binary` (GG_BINARY_SAMPLE) owns this
+# rule and preflight's `content_is_binary` (BINARY_SAMPLE) is its other copy.
+# This third one answers the same question by a different mechanism: the gate
+# sniffs every tracked file rather than a matched subset, and it needs the
+# byte offset a boolean does not return. The window and the verdict move
+# together across all three.
 NUL_SNIFF_BYTES=8000
 note_if_binary() { # PATH BLOBFILE — records a line-class blob git reads as binary
-  local chunk status=0 off
-  # `read -d ''` stops at a NUL and -n bounds the read, at no subprocess cost.
-  # In a multibyte locale that bound counts CHARACTERS, so a stop here can sit
-  # past the sniff window while a miss never can: every character read consumed
-  # at least one byte. So this decides the misses — every text file, every run
-  # — and the exact byte scan below decides and locates the rest.
+  # LC_ALL=C for the whole function: it makes the `read` bound and `${#chunk}`
+  # below count BYTES, which is what git's rule is stated in. Without it a
+  # multibyte locale counts characters and the prefilter reads past the window.
+  local LC_ALL=C chunk status=0 off
+  # `read -d ''` stops at a NUL and -n bounds the read, at no subprocess cost,
+  # so this stage decides every miss — every text file, every run — without
+  # forking. Byte-exact, it is git's rule outright: a status of 0 over a chunk
+  # short of the window means a NUL inside the window and nothing else. The
+  # scan below confirms that and locates the byte.
   { IFS= read -r -d '' -n "$NUL_SNIFF_BYTES" chunk || status=$?; } <"$2" \
     || collection_error "cannot read tracked file '$1' — its content cannot be classified, refusing to skip it"
   { [ "$status" -eq 0 ] && [ "${#chunk}" -lt "$NUL_SNIFF_BYTES" ]; } || return 0
@@ -571,7 +578,10 @@ note_if_binary() { # PATH BLOBFILE — records a line-class blob git reads as bi
     { seen += NF }
     END { if (found) print off }
   ')" || collection_error "could not scan '$1' for the offset of its NUL byte — refusing to report a verdict"
-  [ -n "$off" ] || return 0
+  # A scan that ran, succeeded and found nothing contradicts the byte-exact
+  # prefilter that sent it here. Reporting clean on it would be the fail-open
+  # this whole sniff exists to close.
+  [ -n "$off" ] || collection_error "the content prefilter for '$1' stopped at a NUL inside its leading $NUL_SNIFF_BYTES bytes and the scan then located none — refusing to report a verdict over the contradiction"
   printf '%s\t%s\n' "$1" "$off" >>"$TMP/binary.paths" \
     || collection_error "could not record the binary-content finding for '$1' — refusing to report a verdict"
 }
@@ -591,15 +601,23 @@ while IFS= read -r -d '' rec; do
   path_threshold "$f"
   if [ "$PU" = "b" ]; then wcflag="-c"; else wcflag="-l"; fi
   if [ "$STAGED" -eq 1 ] || [ ! -f "$f" ] || [ -h "$f" ]; then
-    # Materialized once: the count and the content sniff read the same bytes,
-    # and a second `git show` per path would double the walk under --staged.
-    if ! git show ":$f" >"$TMP/blob"; then
-      collection_error "cannot read index blob for tracked file '$f' — its size is unmeasurable, refusing to skip it"
+    if [ "$PU" = "b" ]; then
+      # Nothing sniffs a byte class, so the count streams and no copy of the
+      # blob lands on the scratch filesystem.
+      if ! n="$(git show ":$f" | wc "$wcflag")"; then
+        collection_error "cannot read index blob for tracked file '$f' — its size is unmeasurable, refusing to skip it"
+      fi
+    else
+      # Materialized once: the count and the content sniff read the same bytes,
+      # and a second `git show` per path would double the walk under --staged.
+      if ! git show ":$f" >"$TMP/blob"; then
+        collection_error "cannot read index blob for tracked file '$f' — its size is unmeasurable, refusing to skip it"
+      fi
+      if ! n="$(wc "$wcflag" <"$TMP/blob")"; then
+        collection_error "cannot count the materialized index blob for tracked file '$f' — its size is unmeasurable, refusing to skip it"
+      fi
+      note_if_binary "$f" "$TMP/blob"
     fi
-    if ! n="$(wc "$wcflag" <"$TMP/blob")"; then
-      collection_error "cannot read index blob for tracked file '$f' — its size is unmeasurable, refusing to skip it"
-    fi
-    [ "$PU" = "b" ] || note_if_binary "$f" "$TMP/blob"
     n="${n#"${n%%[![:space:]]*}"}" # strip wc's leading whitespace (BSD wc pads)
     case "$n" in
       "" | *[!0-9]*) collection_error "$(unit_noun "$PU") count for index blob of '$f' came back as '$n', not a number — its size is unmeasurable, refusing to skip it" ;;
@@ -629,7 +647,7 @@ if [ -s "$TMP/binary.paths" ]; then
   while IFS="$TAB" read -r bin_path bin_off; do
     echo "$bin_path: a NUL byte at offset $bin_off" >&2
   done <"$TMP/binary.paths"
-  collection_error "the path(s) above are measured in lines but carry a NUL inside their leading $NUL_SNIFF_BYTES bytes, so git records them as binary: no diff, no grep hit, no line count that means anything. Write the escape your language spells the byte with (\\0, \\u0000, \\x00) instead of the raw character; a real binary asset belongs in a byte class or the exclusion list."
+  collection_error "the path(s) above are measured in lines but carry a NUL inside their leading $NUL_SNIFF_BYTES bytes, so git records them as binary: no textual diff, a plain \`git grep\` reduced to \"Binary file <path> matches\" and a \`git grep -I\` that drops the path outright, and no line count that means anything. Write the escape your language spells the byte with (\\0, \\u0000, \\x00) instead of the raw character; a real binary asset belongs in a byte class or the exclusion list."
 fi
 counted="$(count_nonempty_lines "$TMP/counts.raw")"
 [ "$counted" -eq "$checked" ] || collection_error "counted $counted of the $checked tracked file(s) selected for measurement — the collection is incomplete, refusing to report a verdict"

--- a/skills/size-ratchet/scripts/size-ratchet
+++ b/skills/size-ratchet/scripts/size-ratchet
@@ -555,7 +555,7 @@ flush_batch() { # UNIT — appends one "<path><TAB><count>" row per pending file
 # per line; a newline in a path would misalign it, and the walk refuses every
 # such path before any verdict — a shift exempts nothing regardless.
 ATTR_EXEMPT=""
-if ! { git ls-files -z | git -c core.attributesFile=/dev/null check-attr -z ${ATTR_SCOPE} --stdin diff >"$TMP/attr.z"; }; then
+if ! { git ls-files -z | GIT_ATTR_NOSYSTEM=1 git -c core.attributesFile=/dev/null check-attr -z ${ATTR_SCOPE} --stdin diff >"$TMP/attr.z"; }; then
   config_error "could not resolve the 'diff' attribute over the tracked set (git ls-files | git check-attr failed) — refusing to guess what git keeps out of its textual diffs"
 fi
 attr_exempt="$(LC_ALL=C tr '\000' '\n' <"$TMP/attr.z" | awk '

--- a/skills/size-ratchet/scripts/size-ratchet
+++ b/skills/size-ratchet/scripts/size-ratchet
@@ -552,8 +552,8 @@ flush_batch() { # UNIT — appends one "<path><TAB><count>" row per pending file
 # other tracked path. ONE `check-attr` process for the whole set: a fork per
 # path is the cost shape that measured 5x when the sniff was tried per-file.
 # The `-z` stream is `path NUL attr NUL value NUL`, folded to one exempt path
-# per line; a newline in a path would misalign that, and the walk refuses every
-# such path before it reads this set.
+# per line; a newline in a path would misalign it, and the walk refuses every
+# such path before any verdict — a shift exempts nothing regardless.
 ATTR_EXEMPT=""
 if ! { git ls-files -z | git check-attr -z --stdin diff >"$TMP/attr.z"; }; then
   config_error "could not resolve the 'diff' attribute over the tracked set (git ls-files | git check-attr failed) — refusing to guess what git keeps out of its textual diffs"
@@ -615,16 +615,16 @@ note_if_binary() { # PATH BLOBFILE — records a tracked blob git reads as binar
 while IFS= read -r -d '' rec; do
   mode="${rec%% *}"
   f="${rec#*"$TAB"}"
-  case "$mode" in
-    120000) continue ;; # tracked symlink — no meaningful size, and no content
-    160000) continue ;; # submodule gitlink — never countable; a baseline
-  esac
-  # Both records this walk writes are line-oriented and tab-separated, and the
-  # sniff below reaches size-excluded paths too, so the refusal covers the
-  # whole tracked set rather than the measured part of it.
+  # Above every skip: both records this walk writes are line-oriented and
+  # tab-separated, and the check-attr parse below relies on the refusal
+  # covering the whole tracked set, symlinks and gitlinks included.
   case "$f" in
     *"$NL"*) config_error "tracked path contains a newline, unrepresentable in line-oriented records: '$f'" ;;
     *"$TAB"*) config_error "tracked path contains a tab, unrepresentable in the baseline TSV: '$f'" ;;
+  esac
+  case "$mode" in
+    120000) continue ;; # tracked symlink — no meaningful size, and no content
+    160000) continue ;; # submodule gitlink — never countable; a baseline
   esac
   sniff=1
   if is_diff_exempt "$f"; then sniff=0; fi

--- a/skills/size-ratchet/scripts/size-ratchet
+++ b/skills/size-ratchet/scripts/size-ratchet
@@ -543,12 +543,14 @@ flush_batch() { # UNIT — appends one "<path><TAB><count>" row per pending file
   cat "$TMP/batch.tsv" >>"$TMP/counts.raw" || collection_error "could not append the re-measured counts — the measurement is incomplete, refusing to report a verdict"
   clear_batch "$unit"
 }
-# A blob git reads as binary has no line count anyone can check: git's rule
-# is a NUL inside the leading bytes, and it takes the blob out of every
-# textual diff while `wc -l` still returns a number. Every blob this gate
-# measures in LINES is asked the question — a path matching no class at all
-# resolves to SIZE_RATCHET_THRESHOLD in lines and is asked too. A byte class
-# is not asked, and a real asset belongs there or in the exclusion list.
+# A blob git reads as binary is not reviewable content: git's rule is a NUL
+# inside the leading bytes, and it takes the blob out of every textual diff
+# while `wc` still returns a number. Every tracked blob this gate measures is
+# asked the question, in whatever unit its class counts — the property being
+# held is that the blob is text a reviewer and a `git grep` can read, which
+# the CONTENT decides and the unit says nothing about. A real binary asset
+# belongs in the exclusion list, which `is_excluded` applies ahead of the
+# sniff, so an excluded path pays nothing for the coverage.
 # What git and the sibling gates do with such a blob: DEVELOPMENT.md.
 #
 # LINEAGE. growth-guards' `gg_blob_is_binary` (GG_BINARY_SAMPLE) owns this
@@ -558,7 +560,7 @@ flush_batch() { # UNIT — appends one "<path><TAB><count>" row per pending file
 # byte offset a boolean does not return. The window and the verdict move
 # together across all three.
 NUL_SNIFF_BYTES=8000
-note_if_binary() { # PATH BLOBFILE — records a line-class blob git reads as binary
+note_if_binary() { # PATH BLOBFILE — records a tracked blob git reads as binary
   # LC_ALL=C for the whole function: it makes the `read` bound and `${#chunk}`
   # below count BYTES, which is what git's rule is stated in. Without it a
   # multibyte locale counts characters and the prefilter reads past the window.
@@ -601,40 +603,34 @@ while IFS= read -r -d '' rec; do
   path_threshold "$f"
   if [ "$PU" = "b" ]; then wcflag="-c"; else wcflag="-l"; fi
   if [ "$STAGED" -eq 1 ] || [ ! -f "$f" ] || [ -h "$f" ]; then
-    if [ "$PU" = "b" ]; then
-      # Nothing sniffs a byte class, so the count streams and no copy of the
-      # blob lands on the scratch filesystem.
-      if ! n="$(git show ":$f" | wc "$wcflag")"; then
-        collection_error "cannot read index blob for tracked file '$f' — its size is unmeasurable, refusing to skip it"
-      fi
-    else
-      # Materialized once: the count and the content sniff read the same bytes,
-      # and a second `git show` per path would double the walk under --staged.
-      if ! git show ":$f" >"$TMP/blob"; then
-        collection_error "cannot read index blob for tracked file '$f' — its size is unmeasurable, refusing to skip it"
-      fi
-      if ! n="$(wc "$wcflag" <"$TMP/blob")"; then
-        collection_error "cannot count the materialized index blob for tracked file '$f' — its size is unmeasurable, refusing to skip it"
-      fi
-      note_if_binary "$f" "$TMP/blob"
+    # Materialized once: the count and the content sniff read the same bytes,
+    # and a second `git show` per path would double the walk under --staged.
+    if ! git show ":$f" >"$TMP/blob"; then
+      collection_error "cannot read index blob for tracked file '$f' — its size is unmeasurable, refusing to skip it"
     fi
+    if ! n="$(wc "$wcflag" <"$TMP/blob")"; then
+      collection_error "cannot count the materialized index blob for tracked file '$f' — its size is unmeasurable, refusing to skip it"
+    fi
+    note_if_binary "$f" "$TMP/blob"
     n="${n#"${n%%[![:space:]]*}"}" # strip wc's leading whitespace (BSD wc pads)
     case "$n" in
       "" | *[!0-9]*) collection_error "$(unit_noun "$PU") count for index blob of '$f' came back as '$n', not a number — its size is unmeasurable, refusing to skip it" ;;
     esac
     printf '%s\t%s\n' "$f" "$n" >>"$TMP/counts.raw" || collection_error "could not record the count for '$f' — the measurement is incomplete, refusing to report a verdict"
-  elif [ "$PU" = "b" ]; then
-    WT_BATCH_B+=("$f")
-    WT_BATCH_B_CHARS=$((WT_BATCH_B_CHARS + ${#f} + 1))
-    if [ "${#WT_BATCH_B[@]}" -ge "$BATCH_MAX_FILES" ] || [ "$WT_BATCH_B_CHARS" -ge "$BATCH_MAX_CHARS" ]; then
-      flush_batch b
-    fi
   else
     note_if_binary "$f" "$f"
-    WT_BATCH_L+=("$f")
-    WT_BATCH_L_CHARS=$((WT_BATCH_L_CHARS + ${#f} + 1))
-    if [ "${#WT_BATCH_L[@]}" -ge "$BATCH_MAX_FILES" ] || [ "$WT_BATCH_L_CHARS" -ge "$BATCH_MAX_CHARS" ]; then
-      flush_batch l
+    if [ "$PU" = "b" ]; then
+      WT_BATCH_B+=("$f")
+      WT_BATCH_B_CHARS=$((WT_BATCH_B_CHARS + ${#f} + 1))
+      if [ "${#WT_BATCH_B[@]}" -ge "$BATCH_MAX_FILES" ] || [ "$WT_BATCH_B_CHARS" -ge "$BATCH_MAX_CHARS" ]; then
+        flush_batch b
+      fi
+    else
+      WT_BATCH_L+=("$f")
+      WT_BATCH_L_CHARS=$((WT_BATCH_L_CHARS + ${#f} + 1))
+      if [ "${#WT_BATCH_L[@]}" -ge "$BATCH_MAX_FILES" ] || [ "$WT_BATCH_L_CHARS" -ge "$BATCH_MAX_CHARS" ]; then
+        flush_batch l
+      fi
     fi
   fi
   checked=$((checked + 1))
@@ -647,7 +643,7 @@ if [ -s "$TMP/binary.paths" ]; then
   while IFS="$TAB" read -r bin_path bin_off; do
     echo "$bin_path: a NUL byte at offset $bin_off" >&2
   done <"$TMP/binary.paths"
-  collection_error "the path(s) above are measured in lines but carry a NUL inside their leading $NUL_SNIFF_BYTES bytes, so git records them as binary: no textual diff, a plain \`git grep\` reduced to \"Binary file <path> matches\" and a \`git grep -I\` that drops the path outright, and no line count that means anything. Write the escape your language spells the byte with (\\0, \\u0000, \\x00) instead of the raw character; a real binary asset belongs in a byte class or the exclusion list."
+  collection_error "the path(s) above are tracked as reviewable text but carry a NUL inside their leading $NUL_SNIFF_BYTES bytes, so git records them as binary: no textual diff, a plain \`git grep\` reduced to \"Binary file <path> matches\" and a \`git grep -I\` that drops the path outright. Write the escape your language spells the byte with (\\0, \\u0000, \\x00) instead of the raw character; a real binary asset belongs in the exclusion list."
 fi
 counted="$(count_nonempty_lines "$TMP/counts.raw")"
 [ "$counted" -eq "$checked" ] || collection_error "counted $counted of the $checked tracked file(s) selected for measurement — the collection is incomplete, refusing to report a verdict"

--- a/skills/size-ratchet/scripts/size-ratchet
+++ b/skills/size-ratchet/scripts/size-ratchet
@@ -9,7 +9,7 @@ NL='
 SHIPPED_CLASSES="AGENTS.md=24k;CLAUDE.md=24k;*/AGENTS.md=24k;*/CLAUDE.md=24k;*/SKILL.md=24k;*/workflows/*.md=40k;*.md=64k;tests/*=800;*/tests/*=800;test/*=800;*/test/*=800;__tests__/*=800;*/__tests__/*=800;tests.rs=800;*/tests.rs=800;*test_util.rs=800;*.test.*=800;*.spec.*=800"
 SHIPPED_FROZEN_CLASSES="*.md;tests/*;*/tests/*;test/*;*/test/*;__tests__/*;*/__tests__/*;tests.rs;*/tests.rs;*test_util.rs;*.test.*;*.spec.*"
 DEFAULT_EXCLUDES="CHANGELOG*.md${TAB}one long file is the documented norm; entries carry the rule"
-STAGED=0
+STAGED=0 ATTR_SCOPE=""
 usage() {
   cat <<'EOF'
 usage: size-ratchet [--staged] [--update | --seed] [--baseline FILE] [--excludes FILE]
@@ -91,7 +91,7 @@ while [ $# -gt 0 ]; do
       usage
       exit 0
       ;;
-    --staged) STAGED=1 ;;
+    --staged) STAGED=1 ATTR_SCOPE=--cached ;; # attributes from the index too
     *) config_error "unknown argument '$1' (see --help)" ;;
   esac
   shift
@@ -555,7 +555,7 @@ flush_batch() { # UNIT — appends one "<path><TAB><count>" row per pending file
 # per line; a newline in a path would misalign it, and the walk refuses every
 # such path before any verdict — a shift exempts nothing regardless.
 ATTR_EXEMPT=""
-if ! { git ls-files -z | git check-attr -z --stdin diff >"$TMP/attr.z"; }; then
+if ! { git ls-files -z | git -c core.attributesFile=/dev/null check-attr -z ${ATTR_SCOPE} --stdin diff >"$TMP/attr.z"; }; then
   config_error "could not resolve the 'diff' attribute over the tracked set (git ls-files | git check-attr failed) — refusing to guess what git keeps out of its textual diffs"
 fi
 attr_exempt="$(LC_ALL=C tr '\000' '\n' <"$TMP/attr.z" | awk '

--- a/skills/size-ratchet/tests/binary-content.test.sh
+++ b/skills/size-ratchet/tests/binary-content.test.sh
@@ -189,6 +189,62 @@ for probe in "7999 2 inside" "8000 0 outside"; do
   fi
 done
 
+echo "=== the 8000 bound is bytes even when the locale is multibyte ==="
+# The prefilter's `read -n` bound counts CHARACTERS unless the locale is C, so
+# a NUL past byte 8000 but inside 8000 characters would stop a character-wise
+# read while `od -N 8000` correctly finds nothing — and the contradiction
+# refusal above would then red a file git reads as text. 5000 x U+00E9 is 5000
+# characters and 10000 bytes: the byte at offset 10000 is outside the window by
+# git's rule and inside it by the character count.
+plant_wide_nul() { # 5000 two-byte characters in $R/src/installed.ts, then the byte
+  mkdir -p "$R/src"
+  { awk 'BEGIN { for (i = 0; i < 5000; i++) printf "\303\251" }'; printf '\000'; printf '\n'; } >"$R/src/installed.ts"
+  git -C "$R" add -A
+}
+# No locale is assumed present: the case needs a multibyte one to say anything.
+utf8_locale="$({ locale -a 2>/dev/null || true; } | awk 'tolower($0) ~ /\.utf-?8$/ && !f { v = $0; f = 1 } END { if (f) print v }')"
+if [ -z "$utf8_locale" ]; then
+  printf '  skip  the byte-bound case needs a UTF-8 locale; `locale -a` lists none here\n'
+else
+  new_repo bytebound
+  plant_wide_nul
+  run_in "LC_ALL=$utf8_locale" "LANG=$utf8_locale" SIZE_RATCHET_THRESHOLD=400 -- --staged
+  if [ "$RC" -eq 0 ] && ! has 'located none'; then
+    ok "under $utf8_locale a NUL past byte 8000 leaves the blob text (exit 0)"
+  else
+    bad "the sniff bound counts bytes under a multibyte locale" "rc=$RC out=$OUT"
+  fi
+
+  echo "=== must-fail control: without LC_ALL=C the same fixture is refused ==="
+  # Exit 0 is also what a sniff that never ran returns, so the case above is
+  # evidence only beside a control that reds. The control removes the two words
+  # that make the bound bytes and nothing else.
+  BOUND="$TMP/bound-scripts"
+  mkdir -p "$BOUND"
+  cp -R "$SKILL_DIR/scripts/." "$BOUND/"
+  BOUND_ANCHOR='  local LC_ALL=C chunk status=0 off'
+  if awk -v anchor="$BOUND_ANCHOR" '
+      $0 == anchor { print "  local chunk status=0 off"; n++; next }
+      { print }
+      END { exit (n == 1 ? 0 : 3) }
+    ' "$BOUND/size-ratchet" >"$BOUND/size-ratchet.mut"; then
+    mv "$BOUND/size-ratchet.mut" "$BOUND/size-ratchet"
+    chmod +x "$BOUND/size-ratchet"
+    new_repo boundctrl
+    plant_wide_nul
+    GATE="$BOUND/size-ratchet"
+    run_in "LC_ALL=$utf8_locale" "LANG=$utf8_locale" SIZE_RATCHET_THRESHOLD=400 -- --staged
+    GATE="$SR"
+    if [ "$RC" -eq 2 ] && has 'located none'; then
+      ok "a character-counting bound refuses the same fixture — the case above is evidence"
+    else
+      bad "the control removes the byte bound it should" "rc=$RC out=$OUT"
+    fi
+  else
+    bad "the byte-bound control's substitution matched exactly one site" "no single '$BOUND_ANCHOR' line in $BOUND/size-ratchet"
+  fi
+fi
+
 echo "=== a locating scan that comes back empty refuses, it does not pass ==="
 # The prefilter is byte-exact, so a stop it reports and a scan that then finds
 # nothing are a contradiction. Treating that as clean would be the fail-open

--- a/skills/size-ratchet/tests/binary-content.test.sh
+++ b/skills/size-ratchet/tests/binary-content.test.sh
@@ -1,16 +1,19 @@
 #!/usr/bin/env bash
 # Pins the refusal on a line-class blob git reads as binary. A raw NUL typed
-# into a source file instead of its escape makes git call the file binary:
-# no diff, no `git grep` hit, no blame — and `wc -l` still returns a number,
-# so the gate used to report a clean measurement over content nobody could
-# read. The gate now refuses that blob by name and byte offset.
+# into a source file instead of its escape makes git call the file binary: no
+# textual diff, a plain `git grep` reduced to `Binary file <path> matches` and
+# a `git grep -I` that drops the path — and `wc -l` still returns a number, so
+# the gate used to report a clean measurement over content nobody could read.
+# The gate now refuses that blob by name and byte offset.
 #
-# Pinned here: the refusal fires in both scopes (index and worktree), the
-# offset is counted in BYTES and located inside the sniff window, the same
-# bytes in a BYTE class pass because nothing counts their lines, an excluded
-# path stays excluded, and the diagnostic never carries the byte itself.
-# The must-fail control at the end reverts the refusal and shows the NUL
-# fixture going green, so the green cases above are evidence.
+# Pinned here: the refusal fires in both scopes (index and worktree) and in
+# --seed and --update, where a miss would write a meaningless count into the
+# baseline; every offender is named, not just the first; the offset is counted
+# in BYTES and located inside the sniff window; the same bytes in a BYTE class
+# pass because nothing counts their lines; an excluded path stays excluded; a
+# scan that comes back empty is a refusal, not a pass; and the diagnostic never
+# carries the byte itself. The must-fail control at the end reverts the refusal
+# and shows the NUL fixture going green, so the green cases above are evidence.
 set -euo pipefail
 
 TEST_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
@@ -185,6 +188,75 @@ for probe in "7999 2 inside" "8000 0 outside"; do
     bad "the window boundary matches git's rule at offset $pad" "rc=$RC want=$want_rc out=$OUT"
   fi
 done
+
+echo "=== a locating scan that comes back empty refuses, it does not pass ==="
+# The prefilter is byte-exact, so a stop it reports and a scan that then finds
+# nothing are a contradiction. Treating that as clean would be the fail-open
+# the sniff exists to close: an `od` that exits 0 saying nothing must not buy
+# a passing verdict over a NUL-carrying blob. An `od` that exits NONZERO is
+# already caught by pipefail; this is the quiet-success half.
+OD_SHIM="$TMP/od-shim"
+mkdir -p "$OD_SHIM"
+printf '#!/usr/bin/env bash\nexit 0\n' >"$OD_SHIM/od"
+chmod +x "$OD_SHIM/od"
+new_repo scanempty
+plant_nul src/installed.ts 'const a = "x'
+git -C "$R" add -A
+run_in "PATH=$OD_SHIM:$PATH" SIZE_RATCHET_THRESHOLD=400 -- --staged
+if [ "$RC" -eq 2 ] && has "src/installed.ts" && has "located none"; then
+  ok "an od that succeeds and prints nothing is a refusal (exit 2), naming the path"
+else
+  bad "an empty locating scan refuses rather than reporting clean" "rc=$RC out=$OUT"
+fi
+case "$OUT" in *"size-ratchet: OK"*) bad "no OK verdict may accompany the empty scan" "$OUT" ;; *) ok "no OK verdict accompanies the empty scan" ;; esac
+
+echo "=== every offender is named, not just the first ==="
+# The refusal is an aggregation: one row per offender, read back by the
+# reporting loop. That is the shape a repo meets when it adopts the gate —
+# several binary assets in a line class red together, as this repo's own
+# tauri icons did — so a regression to first-offender-only must red here.
+new_repo many
+plant_nul src/a.ts 'const a = "x'
+plant_nul src/b.ts 'const b = "xy'
+plant_nul src/c.ts 'const c = "xyz'
+git -C "$R" add -A
+run_in SIZE_RATCHET_THRESHOLD=400 -- --staged
+named="$(grep -c 'a NUL byte at offset' "$OUTFILE")" || named=0
+if [ "$RC" -eq 2 ] && [ "$named" -eq 3 ] \
+  && has 'src/a.ts: a NUL byte at offset 12' \
+  && has 'src/b.ts: a NUL byte at offset 13' \
+  && has 'src/c.ts: a NUL byte at offset 14'; then
+  ok "all three offenders are named, each at its own offset"
+else
+  bad "the diagnostic names every offender" "rc=$RC named=$named out=$OUT"
+fi
+
+echo "=== --seed refuses and writes no baseline ==="
+# A miss in a writing mode does not merely print a clean verdict: it records a
+# meaningless line count for a binary blob and locks it in.
+new_repo seedmode
+plant_nul src/installed.ts 'const a = "x'
+git -C "$R" add -A
+run_in SIZE_RATCHET_THRESHOLD=400 -- --seed
+if [ "$RC" -eq 2 ] && has 'src/installed.ts: a NUL byte at offset 12' && [ ! -e "$R/tools/size-ratchet-baseline.tsv" ]; then
+  ok "--seed refuses (exit 2) and writes no baseline at all"
+else
+  bad "--seed refuses before it seeds a row" "rc=$RC baseline=$(cat "$R/tools/size-ratchet-baseline.tsv" 2>/dev/null || echo absent) out=$OUT"
+fi
+
+echo "=== --update refuses and leaves the baseline row verbatim ==="
+new_repo updatemode
+plant_nul src/installed.ts 'const a = "x'
+mkdir -p "$R/tools"
+printf 'src/installed.ts\t9999\n' >"$R/tools/size-ratchet-baseline.tsv"
+git -C "$R" add -A
+run_in SIZE_RATCHET_THRESHOLD=400 -- --update
+row="$(cat "$R/tools/size-ratchet-baseline.tsv")"
+if [ "$RC" -eq 2 ] && has 'src/installed.ts: a NUL byte at offset 12' && [ "$row" = "$(printf 'src/installed.ts\t9999')" ]; then
+  ok "--update refuses (exit 2) and the baseline row survives verbatim"
+else
+  bad "--update refuses before it tightens a row" "rc=$RC row=$row out=$OUT"
+fi
 
 echo "=== must-fail control: with the refusal reverted, the NUL fixture goes green ==="
 # The control keeps every call site and the whole detection text and removes

--- a/skills/size-ratchet/tests/binary-content.test.sh
+++ b/skills/size-ratchet/tests/binary-content.test.sh
@@ -1,21 +1,18 @@
 #!/usr/bin/env bash
-# Pins the refusal on a tracked blob git reads as binary. A raw NUL typed
-# into a source file instead of its escape makes git call the file binary: no
-# textual diff, a plain `git grep` reduced to `Binary file <path> matches` and
-# a `git grep -I` that drops the path — and `wc -l` still returns a number, so
-# the gate used to report a clean measurement over content nobody could read.
-# The gate now refuses that blob by name and byte offset.
+# Pins the refusal on a tracked blob git reads as binary. A raw NUL typed in
+# place of its escape makes git call the file binary — no textual diff, a
+# `git grep -I` that drops the path — while `wc -l` still returns a number, so
+# the gate used to measure content nobody could read. It now refuses by name
+# and byte offset.
 #
-# Pinned here: the refusal fires in both scopes (index and worktree) and in
-# --seed and --update, where a miss would write a meaningless count into the
-# baseline; every offender is named, not just the first; the offset is counted
-# in BYTES and located inside the sniff window; a byte class is refused too,
-# because the property is the content and not the unit; a SIZE-excluded text
-# path is sniffed like every other path, git's own diff attribute being the
-# only exemption; a scan that comes back empty is a refusal, not a pass; and
-# the diagnostic never carries the byte itself. The must-fail control at the
-# end reverts the refusal and shows the NUL fixture going green, so the green
-# cases above are evidence.
+# Pinned here: the refusal fires in both scopes (index and worktree), and in
+# every mode, since it runs before the --seed and --update branches; a byte
+# class is refused too, the content deciding and not the unit; a SIZE-excluded
+# text path is sniffed like every other, git's own diff attribute the only
+# exemption; the sniff window is bounded in bytes under any locale; and a scan
+# that comes back empty refuses rather than passing. Each must-fail control
+# reverts one behavior and shows the fixture going green, so the green cases
+# are evidence.
 set -euo pipefail
 
 TEST_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
@@ -47,9 +44,8 @@ new_repo() { # NAME
   git -C "$R" config user.name test
 }
 
-# The fixture bytes: a one-line TypeScript source whose string literal carries
-# a raw U+0000 where the author meant to type the escape. `printf` writes the
-# byte; nothing in this file ever holds one, so this suite is itself readable.
+# A one-line TypeScript source whose string literal carries a raw U+0000 where
+# the escape was meant. `printf` writes it, so this suite holds no NUL itself.
 plant_nul() { # PATH LEADING-BYTES
   mkdir -p "$R/$(dirname "$1")"
   { printf '%s' "$2"; printf '\000'; printf 'y";\n'; } >"$R/$1"
@@ -109,8 +105,8 @@ else
 fi
 
 echo "=== the diagnostic never reprints the byte ==="
-# Reprinting it would put a NUL into the log, terminal or CI annotation that
-# carries the diagnostic onward — the same invisibility, one layer out.
+# Reprinting it puts the byte into whatever log or CI annotation carries the
+# diagnostic onward — the same invisibility, one layer out.
 total="$(wc -c <"$OUTFILE")"
 stripped="$(LC_ALL=C tr -d '\000' <"$OUTFILE" | wc -c)"
 if [ "$((total))" -eq "$((stripped))" ] && [ "$((total))" -gt 0 ]; then
@@ -120,9 +116,8 @@ else
 fi
 
 echo "=== a BYTE class is refused too — the content decides, not the unit ==="
-# The whole markdown surface a repo reviews sits in byte classes, so a rule
-# keyed on the measurement unit would leave every SKILL.md, AGENTS.md and
-# workflow doc free to carry the byte and still read `OK`.
+# A repo's whole markdown surface sits in byte classes, so a rule keyed on the
+# unit would leave every SKILL.md and AGENTS.md free to carry the byte.
 new_repo byteclass
 plant_nul skills/demo/SKILL.md 'const a = "x'
 git -C "$R" add -A
@@ -132,8 +127,7 @@ if [ "$RC" -eq 2 ] && has 'skills/demo/SKILL.md: a NUL byte at offset 12'; then
 else
   bad "a byte class is asked about its content too" "rc=$RC out=$OUT"
 fi
-# CI runs the gate without --staged, and a repo's whole markdown surface sits
-# in byte classes, so the arm that reads the worktree copy is the half a NUL
+# CI runs the gate without --staged, so the worktree arm is the half a NUL
 # reaching main would meet. Pinned here, not inferred from the index arm.
 run_in SIZE_RATCHET_THRESHOLD=400 SIZE_RATCHET_CLASSES='*/SKILL.md=24k'
 if [ "$RC" -eq 2 ] && has 'skills/demo/SKILL.md: a NUL byte at offset 12'; then
@@ -144,8 +138,7 @@ fi
 
 echo "=== must-fail control: keyed on the unit again, the same fixture goes green ==="
 # The control restores the one thing that changed — the sniff answering only
-# where the resolved unit is lines — and leaves every call site and the whole
-# diagnostic standing, so a green run here is what the case above rules out.
+# where the resolved unit is lines — and leaves every call site standing.
 UNIT="$TMP/unit-scripts"
 mkdir -p "$UNIT"
 cp -R "$SKILL_DIR/scripts/." "$UNIT/"
@@ -173,10 +166,9 @@ else
 fi
 
 echo "=== a SIZE-excluded text path is sniffed like any other ==="
-# The size exclusion list answers which paths carry no SIZE bound, and its
-# entries carry size reasons — a lockfile, a generated bundle, an append-only
-# log. Reading it as a content exemption too let every one of those carry the
-# byte unseen, the shipped CHANGELOG*.md default worst of all.
+# The exclusion list answers which paths carry no SIZE bound. Reading it as a
+# content exemption let every entry carry the byte unseen — a lockfile, a
+# generated bundle, the shipped CHANGELOG*.md default worst of all.
 new_repo excluded
 plant_nul assets/icon.png 'const a = "x'
 mkdir -p "$R/tools"
@@ -190,10 +182,9 @@ else
 fi
 
 echo "=== and git's own diff attribute is what exempts it ==="
-# The exemption authority is the record git already keeps: a path declared
-# binary (or -diff) is one git keeps out of every textual diff, so its bytes
-# were never reviewable text. Same fixture, same exclusion list, one line of
-# .gitattributes added.
+# The authority is the record git already keeps: a path declared binary (or
+# -diff) is out of every textual diff, so its bytes were never reviewable
+# text. Same fixture, same exclusion list, one .gitattributes line added.
 printf 'assets/* binary\n' >"$R/.gitattributes"
 git -C "$R" add -A
 run_in SIZE_RATCHET_THRESHOLD=400 -- --staged
@@ -205,8 +196,7 @@ fi
 
 echo "=== must-fail control: with the size list back in charge, the same fixture goes green ==="
 # The control restores the one thing that changed — the size exclusion
-# short-circuiting the walk before the sniff — and leaves the attribute
-# lookup, every call site and the whole diagnostic standing.
+# short-circuiting the walk before the sniff — and leaves the rest standing.
 EXC="$TMP/excl-scripts"
 mkdir -p "$EXC"
 cp -R "$SKILL_DIR/scripts/." "$EXC/"
@@ -236,8 +226,7 @@ else
 fi
 
 echo "=== the worktree scan CI runs refuses the same blob ==="
-# CI runs the gate without --staged, over a clean checkout: a NUL that reached
-# main must red there too, not only at the commit that introduced it.
+# A NUL that reached main must red in CI too, not only at its commit.
 new_repo worktree
 plant_nul src/installed.ts 'const a = "x'
 git -C "$R" add -A
@@ -248,48 +237,12 @@ else
   bad "the no---staged scan refuses it too" "rc=$RC out=$OUT"
 fi
 
-echo "=== the offset counts bytes, not characters ==="
-# 100 x U+00E9 is 100 characters and 200 bytes. A count that came from the
-# shell's character-wise read would report 100 here.
-new_repo multibyte
-mkdir -p "$R/src"
-{ awk 'BEGIN { for (i = 0; i < 100; i++) printf "\303\251" }'; printf '\000'; printf '";\n'; } >"$R/src/installed.ts"
-git -C "$R" add -A
-run_in SIZE_RATCHET_THRESHOLD=400 -- --staged
-if [ "$RC" -eq 2 ] && has 'src/installed.ts: a NUL byte at offset 200'; then
-  ok "a NUL behind 100 two-byte characters is reported at byte offset 200"
-else
-  bad "the offset is a byte offset" "rc=$RC out=$OUT"
-fi
-
-echo "=== the sniff window is the leading 8000 bytes, git's own rule ==="
-# git reads a blob as text when no NUL falls in the leading 8000 bytes, so
-# the gate must agree at the boundary in both directions — a byte at offset
-# 7999 is inside the window, one at 8000 is not.
-for probe in "7999 2 inside" "8000 0 outside"; do
-  set -- $probe
-  pad="$1"
-  want_rc="$2"
-  where="$3"
-  new_repo "window-$pad"
-  mkdir -p "$R/src"
-  { awk -v n="$pad" 'BEGIN { for (i = 0; i < n; i++) printf "x" }'; printf '\000'; printf '\n'; } >"$R/src/installed.ts"
-  git -C "$R" add -A
-  run_in SIZE_RATCHET_THRESHOLD=400 -- --staged
-  if [ "$RC" -eq "$want_rc" ]; then
-    ok "a NUL at offset $pad is $where the window (exit $RC)"
-  else
-    bad "the window boundary matches git's rule at offset $pad" "rc=$RC want=$want_rc out=$OUT"
-  fi
-done
-
 echo "=== the 8000 bound is bytes even when the locale is multibyte ==="
-# The prefilter's `read -n` bound counts CHARACTERS unless the locale is C, so
-# a NUL past byte 8000 but inside 8000 characters would stop a character-wise
-# read while `od -N 8000` correctly finds nothing — and the contradiction
-# refusal above would then red a file git reads as text. 5000 x U+00E9 is 5000
-# characters and 10000 bytes: the byte at offset 10000 is outside the window by
-# git's rule and inside it by the character count.
+# The prefilter's read bound counts CHARACTERS unless the locale is C, so a
+# NUL past byte 8000 would stop a character-wise read while `od -N 8000` finds
+# nothing, and the contradiction refusal above would red a file git reads as
+# text. 5000 x U+00E9 is 5000 characters and 10000 bytes: the byte at 10000 is
+# outside the window by git's rule, inside it by the character count.
 plant_wide_nul() { # 5000 two-byte characters in $R/src/installed.ts, then the byte
   mkdir -p "$R/src"
   { awk 'BEGIN { for (i = 0; i < 5000; i++) printf "\303\251" }'; printf '\000'; printf '\n'; } >"$R/src/installed.ts"
@@ -311,8 +264,7 @@ else
 
   echo "=== must-fail control: without LC_ALL=C the same fixture is refused ==="
   # Exit 0 is also what a sniff that never ran returns, so the case above is
-  # evidence only beside a control that reds. The control removes the
-  # `LC_ALL=C` assignment that makes the bound bytes, and nothing else.
+  # evidence only beside this: the `LC_ALL=C` bound removed, nothing else.
   BOUND="$TMP/bound-scripts"
   mkdir -p "$BOUND"
   cp -R "$SKILL_DIR/scripts/." "$BOUND/"
@@ -341,10 +293,9 @@ fi
 
 echo "=== a locating scan that comes back empty refuses, it does not pass ==="
 # The prefilter is byte-exact, so a stop it reports and a scan that then finds
-# nothing are a contradiction. Treating that as clean would be the fail-open
-# the sniff exists to close: an `od` that exits 0 saying nothing must not buy
-# a passing verdict over a NUL-carrying blob. An `od` that exits NONZERO is
-# already caught by pipefail; this is the quiet-success half.
+# nothing contradict each other; calling that clean is the fail-open the sniff
+# exists to close. A NONZERO `od` is already caught by pipefail — this is the
+# quiet-success half.
 OD_SHIM="$TMP/od-shim"
 mkdir -p "$OD_SHIM"
 printf '#!/usr/bin/env bash\nexit 0\n' >"$OD_SHIM/od"
@@ -360,58 +311,10 @@ else
 fi
 case "$OUT" in *"size-ratchet: OK"*) bad "no OK verdict may accompany the empty scan" "$OUT" ;; *) ok "no OK verdict accompanies the empty scan" ;; esac
 
-echo "=== every offender is named, not just the first ==="
-# The refusal is an aggregation: one row per offender, read back by the
-# reporting loop. That is the shape a repo meets when it adopts the gate —
-# several binary assets in a line class red together, as this repo's own
-# tauri icons did — so a regression to first-offender-only must red here.
-new_repo many
-plant_nul src/a.ts 'const a = "x'
-plant_nul src/b.ts 'const b = "xy'
-plant_nul src/c.ts 'const c = "xyz'
-git -C "$R" add -A
-run_in SIZE_RATCHET_THRESHOLD=400 -- --staged
-named="$(grep -c 'a NUL byte at offset' "$OUTFILE")" || named=0
-if [ "$RC" -eq 2 ] && [ "$named" -eq 3 ] \
-  && has 'src/a.ts: a NUL byte at offset 12' \
-  && has 'src/b.ts: a NUL byte at offset 13' \
-  && has 'src/c.ts: a NUL byte at offset 14'; then
-  ok "all three offenders are named, each at its own offset"
-else
-  bad "the diagnostic names every offender" "rc=$RC named=$named out=$OUT"
-fi
-
-echo "=== --seed refuses and writes no baseline ==="
-# A miss in a writing mode does not merely print a clean verdict: it records a
-# meaningless line count for a binary blob and locks it in.
-new_repo seedmode
-plant_nul src/installed.ts 'const a = "x'
-git -C "$R" add -A
-run_in SIZE_RATCHET_THRESHOLD=400 -- --seed
-if [ "$RC" -eq 2 ] && has 'src/installed.ts: a NUL byte at offset 12' && [ ! -e "$R/tools/size-ratchet-baseline.tsv" ]; then
-  ok "--seed refuses (exit 2) and writes no baseline at all"
-else
-  bad "--seed refuses before it seeds a row" "rc=$RC baseline=$(cat "$R/tools/size-ratchet-baseline.tsv" 2>/dev/null || echo absent) out=$OUT"
-fi
-
-echo "=== --update refuses and leaves the baseline row verbatim ==="
-new_repo updatemode
-plant_nul src/installed.ts 'const a = "x'
-mkdir -p "$R/tools"
-printf 'src/installed.ts\t9999\n' >"$R/tools/size-ratchet-baseline.tsv"
-git -C "$R" add -A
-run_in SIZE_RATCHET_THRESHOLD=400 -- --update
-row="$(cat "$R/tools/size-ratchet-baseline.tsv")"
-if [ "$RC" -eq 2 ] && has 'src/installed.ts: a NUL byte at offset 12' && [ "$row" = "$(printf 'src/installed.ts\t9999')" ]; then
-  ok "--update refuses (exit 2) and the baseline row survives verbatim"
-else
-  bad "--update refuses before it tightens a row" "rc=$RC row=$row out=$OUT"
-fi
 
 echo "=== must-fail control: with the refusal reverted, the NUL fixture goes green ==="
 # The control keeps every call site and the whole detection text and removes
-# only the behavior, so a green run below proves the cases above are the
-# refusal's doing rather than an assertion that cannot fail.
+# only the behavior, so a green run below rules out a vacuous assertion.
 CTRL="$TMP/control-scripts"
 mkdir -p "$CTRL"
 cp -R "$SKILL_DIR/scripts/." "$CTRL/"

--- a/skills/size-ratchet/tests/binary-content.test.sh
+++ b/skills/size-ratchet/tests/binary-content.test.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Pins the refusal on a line-class blob git reads as binary. A raw NUL typed
+# Pins the refusal on a tracked blob git reads as binary. A raw NUL typed
 # into a source file instead of its escape makes git call the file binary: no
 # textual diff, a plain `git grep` reduced to `Binary file <path> matches` and
 # a `git grep -I` that drops the path — and `wc -l` still returns a number, so
@@ -9,8 +9,9 @@
 # Pinned here: the refusal fires in both scopes (index and worktree) and in
 # --seed and --update, where a miss would write a meaningless count into the
 # baseline; every offender is named, not just the first; the offset is counted
-# in BYTES and located inside the sniff window; the same bytes in a BYTE class
-# pass because nothing counts their lines; an excluded path stays excluded; a
+# in BYTES and located inside the sniff window; a byte class is refused too,
+# because the property is the content and not the unit; an excluded path stays
+# excluded; a
 # scan that comes back empty is a refusal, not a pass; and the diagnostic never
 # carries the byte itself. The must-fail control at the end reverts the refusal
 # and shows the NUL fixture going green, so the green cases above are evidence.
@@ -100,7 +101,7 @@ if [ "$RC" -eq 2 ] && has 'src/installed.ts: a NUL byte at offset 12'; then
 else
   bad "a staged .ts with a NUL is refused naming the offset" "rc=$RC out=$OUT"
 fi
-if has 'measured in lines' && has 'Write the escape'; then
+if has 'tracked as reviewable text' && has 'Write the escape'; then
   ok "the refusal states why it refuses and tells the author to write the escape"
 else
   bad "the refusal carries its cause and remedy" "out=$OUT"
@@ -117,22 +118,55 @@ else
   bad "the refusal never reprints the byte" "total=$total stripped=$stripped"
 fi
 
-echo "=== the same bytes in a BYTE class pass — nothing counts their lines ==="
+echo "=== a BYTE class is refused too — the content decides, not the unit ==="
+# The whole markdown surface a repo reviews sits in byte classes, so a rule
+# keyed on the measurement unit would leave every SKILL.md, AGENTS.md and
+# workflow doc free to carry the byte and still read `OK`.
 new_repo byteclass
-plant_nul src/asset.png 'const a = "x'
+plant_nul skills/demo/SKILL.md 'const a = "x'
 git -C "$R" add -A
-run_in SIZE_RATCHET_THRESHOLD=400 SIZE_RATCHET_CLASSES='*.png=64k' -- --staged
-if [ "$RC" -eq 0 ]; then
-  ok "a .png in a byte class carrying the identical bytes passes (exit 0)"
+run_in SIZE_RATCHET_THRESHOLD=400 SIZE_RATCHET_CLASSES='*/SKILL.md=24k' -- --staged
+if [ "$RC" -eq 2 ] && has 'skills/demo/SKILL.md: a NUL byte at offset 12'; then
+  ok "a SKILL.md in a byte class is refused (exit 2), naming the path and offset"
 else
-  bad "a byte class is never asked about content" "rc=$RC out=$OUT"
+  bad "a byte class is asked about its content too" "rc=$RC out=$OUT"
+fi
+
+echo "=== must-fail control: keyed on the unit again, the same fixture goes green ==="
+# The control restores the one thing that changed — the sniff answering only
+# where the resolved unit is lines — and leaves every call site and the whole
+# diagnostic standing, so a green run here is what the case above rules out.
+UNIT="$TMP/unit-scripts"
+mkdir -p "$UNIT"
+cp -R "$SKILL_DIR/scripts/." "$UNIT/"
+UNIT_ANCHOR='note_if_binary() {'
+if awk -v anchor="$UNIT_ANCHOR" '
+    { print }
+    index($0, anchor) == 1 { print "  if [ \"${PU:-l}\" = \"b\" ]; then return 0; fi # must-fail control: coverage back to line classes"; n++ }
+    END { exit (n == 1 ? 0 : 3) }
+  ' "$UNIT/size-ratchet" >"$UNIT/size-ratchet.mut"; then
+  mv "$UNIT/size-ratchet.mut" "$UNIT/size-ratchet"
+  chmod +x "$UNIT/size-ratchet"
+  new_repo unitctrl
+  plant_nul skills/demo/SKILL.md 'const a = "x'
+  git -C "$R" add -A
+  GATE="$UNIT/size-ratchet"
+  run_in SIZE_RATCHET_THRESHOLD=400 SIZE_RATCHET_CLASSES='*/SKILL.md=24k' -- --staged
+  GATE="$SR"
+  if [ "$RC" -eq 0 ] && ! has 'NUL byte at offset'; then
+    ok "narrowing the sniff back to line classes lets the SKILL.md pass"
+  else
+    bad "the control narrows the coverage it should" "rc=$RC out=$OUT"
+  fi
+else
+  bad "the unit control's substitution matched exactly one site" "no single '$UNIT_ANCHOR' line at the start of a line in $UNIT/size-ratchet"
 fi
 
 echo "=== an excluded path stays excluded ==="
 new_repo excluded
 plant_nul assets/icon.png 'const a = "x'
 mkdir -p "$R/tools"
-printf 'assets/*\tbinary media — no lines to count\n' >"$R/tools/size-ratchet-excludes"
+printf 'assets/*\tbinary media — not reviewable text\n' >"$R/tools/size-ratchet-excludes"
 git -C "$R" add -A
 run_in SIZE_RATCHET_THRESHOLD=400 -- --staged
 if [ "$RC" -eq 0 ]; then

--- a/skills/size-ratchet/tests/binary-content.test.sh
+++ b/skills/size-ratchet/tests/binary-content.test.sh
@@ -10,11 +10,12 @@
 # --seed and --update, where a miss would write a meaningless count into the
 # baseline; every offender is named, not just the first; the offset is counted
 # in BYTES and located inside the sniff window; a byte class is refused too,
-# because the property is the content and not the unit; an excluded path stays
-# excluded; a
-# scan that comes back empty is a refusal, not a pass; and the diagnostic never
-# carries the byte itself. The must-fail control at the end reverts the refusal
-# and shows the NUL fixture going green, so the green cases above are evidence.
+# because the property is the content and not the unit; a SIZE-excluded text
+# path is sniffed like every other path, git's own diff attribute being the
+# only exemption; a scan that comes back empty is a refusal, not a pass; and
+# the diagnostic never carries the byte itself. The must-fail control at the
+# end reverts the refusal and shows the NUL fixture going green, so the green
+# cases above are evidence.
 set -euo pipefail
 
 TEST_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
@@ -131,6 +132,15 @@ if [ "$RC" -eq 2 ] && has 'skills/demo/SKILL.md: a NUL byte at offset 12'; then
 else
   bad "a byte class is asked about its content too" "rc=$RC out=$OUT"
 fi
+# CI runs the gate without --staged, and a repo's whole markdown surface sits
+# in byte classes, so the arm that reads the worktree copy is the half a NUL
+# reaching main would meet. Pinned here, not inferred from the index arm.
+run_in SIZE_RATCHET_THRESHOLD=400 SIZE_RATCHET_CLASSES='*/SKILL.md=24k'
+if [ "$RC" -eq 2 ] && has 'skills/demo/SKILL.md: a NUL byte at offset 12'; then
+  ok "the worktree scan CI runs refuses the byte-class blob too (exit 2, same offset)"
+else
+  bad "the byte-class refusal fires in the scope CI runs" "rc=$RC out=$OUT"
+fi
 
 echo "=== must-fail control: keyed on the unit again, the same fixture goes green ==="
 # The control restores the one thing that changed — the sniff answering only
@@ -162,17 +172,67 @@ else
   bad "the unit control's substitution matched exactly one site" "no single '$UNIT_ANCHOR' line at the start of a line in $UNIT/size-ratchet"
 fi
 
-echo "=== an excluded path stays excluded ==="
+echo "=== a SIZE-excluded text path is sniffed like any other ==="
+# The size exclusion list answers which paths carry no SIZE bound, and its
+# entries carry size reasons — a lockfile, a generated bundle, an append-only
+# log. Reading it as a content exemption too let every one of those carry the
+# byte unseen, the shipped CHANGELOG*.md default worst of all.
 new_repo excluded
 plant_nul assets/icon.png 'const a = "x'
 mkdir -p "$R/tools"
 printf 'assets/*\tbinary media — not reviewable text\n' >"$R/tools/size-ratchet-excludes"
 git -C "$R" add -A
 run_in SIZE_RATCHET_THRESHOLD=400 -- --staged
-if [ "$RC" -eq 0 ]; then
-  ok "an excluded path is never sniffed (exit 0)"
+if [ "$RC" -eq 2 ] && has 'assets/icon.png: a NUL byte at offset 12'; then
+  ok "the size exclusion buys no content exemption — the path is refused by name and offset"
 else
-  bad "the exclusion list precedes the sniff" "rc=$RC out=$OUT"
+  bad "a size-excluded text path is sniffed like every other path" "rc=$RC out=$OUT"
+fi
+
+echo "=== and git's own diff attribute is what exempts it ==="
+# The exemption authority is the record git already keeps: a path declared
+# binary (or -diff) is one git keeps out of every textual diff, so its bytes
+# were never reviewable text. Same fixture, same exclusion list, one line of
+# .gitattributes added.
+printf 'assets/* binary\n' >"$R/.gitattributes"
+git -C "$R" add -A
+run_in SIZE_RATCHET_THRESHOLD=400 -- --staged
+if [ "$RC" -eq 0 ] && ! has 'NUL byte at offset'; then
+  ok "a path .gitattributes declares binary is exempt from the sniff (exit 0)"
+else
+  bad "git's own attribute exempts the path" "rc=$RC out=$OUT"
+fi
+
+echo "=== must-fail control: with the size list back in charge, the same fixture goes green ==="
+# The control restores the one thing that changed — the size exclusion
+# short-circuiting the walk before the sniff — and leaves the attribute
+# lookup, every call site and the whole diagnostic standing.
+EXC="$TMP/excl-scripts"
+mkdir -p "$EXC"
+cp -R "$SKILL_DIR/scripts/." "$EXC/"
+EXC_ANCHOR='  if is_excluded "$f"; then excluded=1; fi'
+if awk -v anchor="$EXC_ANCHOR" '
+    { print }
+    $0 == anchor { print "  if [ \"$excluded\" -eq 1 ]; then continue; fi # must-fail control: the size list back in charge of content"; n++ }
+    END { exit (n == 1 ? 0 : 3) }
+  ' "$EXC/size-ratchet" >"$EXC/size-ratchet.mut"; then
+  mv "$EXC/size-ratchet.mut" "$EXC/size-ratchet"
+  chmod +x "$EXC/size-ratchet"
+  new_repo exclctrl
+  plant_nul assets/icon.png 'const a = "x'
+  mkdir -p "$R/tools"
+  printf 'assets/*\tbinary media — not reviewable text\n' >"$R/tools/size-ratchet-excludes"
+  git -C "$R" add -A
+  GATE="$EXC/size-ratchet"
+  run_in SIZE_RATCHET_THRESHOLD=400 -- --staged
+  GATE="$SR"
+  if [ "$RC" -eq 0 ] && ! has 'NUL byte at offset'; then
+    ok "size exclusion short-circuiting the walk lets the NUL fixture pass — the case above reds without it"
+  else
+    bad "the control restores the short-circuit it should" "rc=$RC out=$OUT"
+  fi
+else
+  bad "the exclusion control's substitution matched exactly one site" "no single '$EXC_ANCHOR' line in $EXC/size-ratchet"
 fi
 
 echo "=== the worktree scan CI runs refuses the same blob ==="

--- a/skills/size-ratchet/tests/binary-content.test.sh
+++ b/skills/size-ratchet/tests/binary-content.test.sh
@@ -186,12 +186,25 @@ echo "=== and git's own diff attribute is what exempts it ==="
 # -diff) is out of every textual diff, so its bytes were never reviewable
 # text. Same fixture, same exclusion list, one .gitattributes line added.
 printf 'assets/* binary\n' >"$R/.gitattributes"
+run_in SIZE_RATCHET_THRESHOLD=400 -- --staged
+if [ "$RC" -eq 2 ] && has 'assets/icon.png: a NUL byte at offset 12'; then
+  ok "an unstaged .gitattributes exempts nothing under --staged (exit 2)"
+else
+  bad "the staged scope reads the attribute from the index" "rc=$RC out=$OUT"
+fi
 git -C "$R" add -A
 run_in SIZE_RATCHET_THRESHOLD=400 -- --staged
 if [ "$RC" -eq 0 ] && ! has 'NUL byte at offset'; then
   ok "a path .gitattributes declares binary is exempt from the sniff (exit 0)"
 else
   bad "git's own attribute exempts the path" "rc=$RC out=$OUT"
+fi
+awk 'BEGIN { for (i = 0; i < 900; i++) print "x" }' >>"$R/assets/icon.png" # still measured
+run_in SIZE_RATCHET_THRESHOLD=400 SIZE_RATCHET_EXCLUDES=tools/no-list
+if [ "$RC" -eq 1 ] && has 'new offender: assets/icon.png'; then
+  ok "a diff-exempt path is still measured — 900 lines over the threshold reds it"
+else
+  bad "the attribute exempts the sniff, not the measurement" "rc=$RC out=$OUT"
 fi
 
 echo "=== must-fail control: with the size list back in charge, the same fixture goes green ==="

--- a/skills/size-ratchet/tests/binary-content.test.sh
+++ b/skills/size-ratchet/tests/binary-content.test.sh
@@ -1,0 +1,220 @@
+#!/usr/bin/env bash
+# Pins the refusal on a line-class blob git reads as binary. A raw NUL typed
+# into a source file instead of its escape makes git call the file binary:
+# no diff, no `git grep` hit, no blame — and `wc -l` still returns a number,
+# so the gate used to report a clean measurement over content nobody could
+# read. The gate now refuses that blob by name and byte offset.
+#
+# Pinned here: the refusal fires in both scopes (index and worktree), the
+# offset is counted in BYTES and located inside the sniff window, the same
+# bytes in a BYTE class pass because nothing counts their lines, an excluded
+# path stays excluded, and the diagnostic never carries the byte itself.
+# The must-fail control at the end reverts the refusal and shows the NUL
+# fixture going green, so the green cases above are evidence.
+set -euo pipefail
+
+TEST_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SKILL_DIR="$(cd "$TEST_DIR/.." && pwd)"
+SR="$SKILL_DIR/scripts/size-ratchet"
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+
+# Hermetic: a leaked setting would mask every case below.
+unset SIZE_RATCHET_THRESHOLD SIZE_RATCHET_CLASSES SIZE_RATCHET_DEFAULT_CLASSES SIZE_RATCHET_FROZEN_CLASSES SIZE_RATCHET_BASELINE SIZE_RATCHET_EXCLUDES SIZE_RATCHET_SETTINGS_FILE RATCHET_RAISE 2>/dev/null || true
+# The shipped class list and frozen list are policy, pinned by
+# shipped-defaults.test.sh. Every fixture here declares its own thresholds,
+# so both start empty and a case that needs one sets it.
+export SIZE_RATCHET_DEFAULT_CLASSES="" SIZE_RATCHET_FROZEN_CLASSES=""
+# A fixture repo is its own repo: an inherited git environment would make
+# `git add` write into the index of whatever repo invoked this suite.
+unset GIT_DIR GIT_COMMON_DIR GIT_WORK_TREE GIT_INDEX_FILE 2>/dev/null || true
+
+PASS=0
+FAIL=0
+ok() { PASS=$((PASS + 1)); printf '  ok    %s\n' "$1"; }
+bad() { FAIL=$((FAIL + 1)); printf '  FAIL  %s\n        %s\n' "$1" "${2:-}"; }
+
+new_repo() { # NAME
+  R="$TMP/$1"
+  mkdir -p "$R"
+  git -C "$R" -c init.defaultBranch=main init -q
+  git -C "$R" config user.email test@example.com
+  git -C "$R" config user.name test
+}
+
+# The fixture bytes: a one-line TypeScript source whose string literal carries
+# a raw U+0000 where the author meant to type the escape. `printf` writes the
+# byte; nothing in this file ever holds one, so this suite is itself readable.
+plant_nul() { # PATH LEADING-BYTES
+  mkdir -p "$R/$(dirname "$1")"
+  { printf '%s' "$2"; printf '\000'; printf 'y";\n'; } >"$R/$1"
+}
+
+# OUT via a file, never a command substitution: bash drops NUL bytes from
+# `$(...)`, so a diagnostic that leaked the byte would read as clean here.
+run_in() { # [VAR=val ...] [-- script-args...] — run $SR in $R; sets OUTFILE, OUT, RC
+  local envs=() args=()
+  while [ $# -gt 0 ]; do
+    case "$1" in
+      --)
+        shift
+        args=("$@")
+        break
+        ;;
+      *) envs+=("$1") ;;
+    esac
+    shift
+  done
+  OUTFILE="$TMP/out.$$"
+  RC=0
+  (cd "$R" && env ${envs[@]+"${envs[@]}"} "$GATE" ${args[@]+"${args[@]}"}) >"$OUTFILE" 2>&1 || RC=$?
+  OUT="$(cat "$OUTFILE")"
+}
+GATE="$SR"
+
+has() { case "$OUT" in *"$1"*) return 0 ;; *) return 1 ;; esac; }
+
+echo "=== control: the same fixture without the byte is measured and clean ==="
+new_repo control
+mkdir -p "$R/src"
+printf 'const a = "xy";\n' >"$R/src/installed.ts"
+git -C "$R" add -A
+run_in SIZE_RATCHET_THRESHOLD=400 -- --staged
+if [ "$RC" -eq 0 ]; then
+  ok "control: a NUL-free .ts under the line threshold passes (exit 0)"
+else
+  bad "control: the fixture is clean but for the byte" "rc=$RC out=$OUT"
+fi
+
+echo "=== a staged line-class blob carrying a NUL is refused by path and offset ==="
+new_repo staged
+plant_nul src/installed.ts 'const a = "x'
+git -C "$R" add -A
+run_in SIZE_RATCHET_THRESHOLD=400 -- --staged
+# 'const a = "x' is 12 bytes, so the byte sits at offset 12.
+if [ "$RC" -eq 2 ] && has 'src/installed.ts: a NUL byte at offset 12'; then
+  ok "the index blob is refused (exit 2), naming the path and the byte offset"
+else
+  bad "a staged .ts with a NUL is refused naming the offset" "rc=$RC out=$OUT"
+fi
+if has 'measured in lines' && has 'Write the escape'; then
+  ok "the refusal states why it refuses and tells the author to write the escape"
+else
+  bad "the refusal carries its cause and remedy" "out=$OUT"
+fi
+
+echo "=== the diagnostic never reprints the byte ==="
+# Reprinting it would put a NUL into the log, terminal or CI annotation that
+# carries the diagnostic onward — the same invisibility, one layer out.
+total="$(wc -c <"$OUTFILE")"
+stripped="$(LC_ALL=C tr -d '\000' <"$OUTFILE" | wc -c)"
+if [ "$((total))" -eq "$((stripped))" ] && [ "$((total))" -gt 0 ]; then
+  ok "the whole diagnostic ($((total)) bytes) carries no NUL of its own"
+else
+  bad "the refusal never reprints the byte" "total=$total stripped=$stripped"
+fi
+
+echo "=== the same bytes in a BYTE class pass — nothing counts their lines ==="
+new_repo byteclass
+plant_nul src/asset.png 'const a = "x'
+git -C "$R" add -A
+run_in SIZE_RATCHET_THRESHOLD=400 SIZE_RATCHET_CLASSES='*.png=64k' -- --staged
+if [ "$RC" -eq 0 ]; then
+  ok "a .png in a byte class carrying the identical bytes passes (exit 0)"
+else
+  bad "a byte class is never asked about content" "rc=$RC out=$OUT"
+fi
+
+echo "=== an excluded path stays excluded ==="
+new_repo excluded
+plant_nul assets/icon.png 'const a = "x'
+mkdir -p "$R/tools"
+printf 'assets/*\tbinary media — no lines to count\n' >"$R/tools/size-ratchet-excludes"
+git -C "$R" add -A
+run_in SIZE_RATCHET_THRESHOLD=400 -- --staged
+if [ "$RC" -eq 0 ]; then
+  ok "an excluded path is never sniffed (exit 0)"
+else
+  bad "the exclusion list precedes the sniff" "rc=$RC out=$OUT"
+fi
+
+echo "=== the worktree scan CI runs refuses the same blob ==="
+# CI runs the gate without --staged, over a clean checkout: a NUL that reached
+# main must red there too, not only at the commit that introduced it.
+new_repo worktree
+plant_nul src/installed.ts 'const a = "x'
+git -C "$R" add -A
+run_in SIZE_RATCHET_THRESHOLD=400
+if [ "$RC" -eq 2 ] && has 'src/installed.ts: a NUL byte at offset 12'; then
+  ok "the worktree copy is refused the same way (exit 2, same offset)"
+else
+  bad "the no---staged scan refuses it too" "rc=$RC out=$OUT"
+fi
+
+echo "=== the offset counts bytes, not characters ==="
+# 100 x U+00E9 is 100 characters and 200 bytes. A count that came from the
+# shell's character-wise read would report 100 here.
+new_repo multibyte
+mkdir -p "$R/src"
+{ awk 'BEGIN { for (i = 0; i < 100; i++) printf "\303\251" }'; printf '\000'; printf '";\n'; } >"$R/src/installed.ts"
+git -C "$R" add -A
+run_in SIZE_RATCHET_THRESHOLD=400 -- --staged
+if [ "$RC" -eq 2 ] && has 'src/installed.ts: a NUL byte at offset 200'; then
+  ok "a NUL behind 100 two-byte characters is reported at byte offset 200"
+else
+  bad "the offset is a byte offset" "rc=$RC out=$OUT"
+fi
+
+echo "=== the sniff window is the leading 8000 bytes, git's own rule ==="
+# git reads a blob as text when no NUL falls in the leading 8000 bytes, so
+# the gate must agree at the boundary in both directions — a byte at offset
+# 7999 is inside the window, one at 8000 is not.
+for probe in "7999 2 inside" "8000 0 outside"; do
+  set -- $probe
+  pad="$1"
+  want_rc="$2"
+  where="$3"
+  new_repo "window-$pad"
+  mkdir -p "$R/src"
+  { awk -v n="$pad" 'BEGIN { for (i = 0; i < n; i++) printf "x" }'; printf '\000'; printf '\n'; } >"$R/src/installed.ts"
+  git -C "$R" add -A
+  run_in SIZE_RATCHET_THRESHOLD=400 -- --staged
+  if [ "$RC" -eq "$want_rc" ]; then
+    ok "a NUL at offset $pad is $where the window (exit $RC)"
+  else
+    bad "the window boundary matches git's rule at offset $pad" "rc=$RC want=$want_rc out=$OUT"
+  fi
+done
+
+echo "=== must-fail control: with the refusal reverted, the NUL fixture goes green ==="
+# The control keeps every call site and the whole detection text and removes
+# only the behavior, so a green run below proves the cases above are the
+# refusal's doing rather than an assertion that cannot fail.
+CTRL="$TMP/control-scripts"
+mkdir -p "$CTRL"
+cp -R "$SKILL_DIR/scripts/." "$CTRL/"
+ANCHOR='note_if_binary() {'
+if awk -v anchor="$ANCHOR" '
+    { print }
+    index($0, anchor) == 1 { print "  return 0 # must-fail control: the refusal, reverted"; n++ }
+    END { exit (n == 1 ? 0 : 3) }
+  ' "$CTRL/size-ratchet" >"$CTRL/size-ratchet.mut"; then
+  mv "$CTRL/size-ratchet.mut" "$CTRL/size-ratchet"
+  chmod +x "$CTRL/size-ratchet"
+  new_repo mustfail
+  plant_nul src/installed.ts 'const a = "x'
+  git -C "$R" add -A
+  GATE="$CTRL/size-ratchet"
+  run_in SIZE_RATCHET_THRESHOLD=400 -- --staged
+  GATE="$SR"
+  if [ "$RC" -eq 0 ] && ! has 'NUL byte at offset'; then
+    ok "reverting the refusal lets the NUL fixture pass — the cases above red without it"
+  else
+    bad "the control removes the behavior it should" "rc=$RC out=$OUT"
+  fi
+else
+  bad "the control's substitution matched exactly one site" "no single '$ANCHOR' line at the start of a line in $CTRL/size-ratchet"
+fi
+
+printf '\n%s passed, %s failed\n' "$PASS" "$FAIL"
+[ "$FAIL" -eq 0 ]

--- a/skills/size-ratchet/tests/binary-content.test.sh
+++ b/skills/size-ratchet/tests/binary-content.test.sh
@@ -217,8 +217,8 @@ else
 
   echo "=== must-fail control: without LC_ALL=C the same fixture is refused ==="
   # Exit 0 is also what a sniff that never ran returns, so the case above is
-  # evidence only beside a control that reds. The control removes the two words
-  # that make the bound bytes and nothing else.
+  # evidence only beside a control that reds. The control removes the
+  # `LC_ALL=C` assignment that makes the bound bytes, and nothing else.
   BOUND="$TMP/bound-scripts"
   mkdir -p "$BOUND"
   cp -R "$SKILL_DIR/scripts/." "$BOUND/"

--- a/skills/size-ratchet/tests/collection-fail-closed.test.sh
+++ b/skills/size-ratchet/tests/collection-fail-closed.test.sh
@@ -232,9 +232,9 @@ case "$OUT" in *"simulated object read failure"*) ok "git's own stderr is surfac
 case "$OUT" in *"size-ratchet: OK"*) bad "no OK verdict may accompany a collection failure" "$OUT" ;; *) ok "no OK verdict accompanies the collection failure" ;; esac
 
 echo "=== fail-closed: an unreadable index blob in a BYTE class terminates too ==="
-# A byte class never materializes the blob: it streams `git show | wc -c`, so
-# the read's failure reaches the gate through pipefail rather than through the
-# line class's own status check above. Both branches must refuse.
+# A byte class resolves a different threshold and `wc` flag than the line case
+# above, and its rows travel a batch of their own, so the refusal is pinned on
+# both units rather than inferred from one.
 run_bin() { # [SHIMDIR] — run in $R under the byte class; no SHIMDIR is the real git
   OUT=""
   RC=0

--- a/skills/size-ratchet/tests/collection-fail-closed.test.sh
+++ b/skills/size-ratchet/tests/collection-fail-closed.test.sh
@@ -73,14 +73,13 @@ run_sr_shimmed() { # SHIMDIR [args...] — run_sr with SHIMDIR first on PATH
   OUT="$(cd "$R" && PATH="$shimdir:$PATH" SIZE_RATCHET_THRESHOLD=10 "$SR" "$@" 2>&1)" || RC=$?
 }
 
-# git shim: fail the index-blob read for `big.txt` (a line class, read through
-# a materialized blob) and for `assets/big.bin` (a byte class, streamed through
-# a pipeline), pass everything else through to the real git.
+# git shim: fail the index-blob read for `big.txt`, pass everything else
+# through to the real git.
 GIT_SHIM="$TMP/git-shim"
 mkdir -p "$GIT_SHIM"
 cat >"$GIT_SHIM/git" <<EOF
 #!/usr/bin/env bash
-if [ "\${1:-}" = "show" ] && { [ "\${2:-}" = ":big.txt" ] || [ "\${2:-}" = ":assets/big.bin" ]; }; then
+if [ "\${1:-}" = "show" ] && [ "\${2:-}" = ":big.txt" ]; then
   echo "fatal: simulated object read failure for \${2#:}" >&2
   exit 128
 fi
@@ -230,29 +229,6 @@ run_sr_shimmed "$GIT_SHIM"
   || bad "an unreadable blob is a collection error naming the file" "rc=$RC out=$OUT"
 case "$OUT" in *"simulated object read failure"*) ok "git's own stderr is surfaced, pinning the cause to the failed read" ;; *) bad "git's own stderr is surfaced" "$OUT" ;; esac
 case "$OUT" in *"size-ratchet: OK"*) bad "no OK verdict may accompany a collection failure" "$OUT" ;; *) ok "no OK verdict accompanies the collection failure" ;; esac
-
-echo "=== fail-closed: an unreadable index blob in a BYTE class terminates too ==="
-# A byte class resolves a different threshold and `wc` flag than the line case
-# above, and its rows travel a batch of their own, so the refusal is pinned on
-# both units rather than inferred from one.
-run_bin() { # [SHIMDIR] — run in $R under the byte class; no SHIMDIR is the real git
-  OUT=""
-  RC=0
-  OUT="$(cd "$R" && PATH="${1:+$1:}$PATH" SIZE_RATCHET_THRESHOLD=10 SIZE_RATCHET_CLASSES='*.bin=64k' "$SR" 2>&1)" || RC=$?
-}
-new_repo blobfailbin
-mkfile assets/big.bin 3
-git -C "$R" add -A
-rm "$R/assets/big.bin" # unstaged: the index still lists it, blob readable
-run_bin
-[ "$RC" -eq 0 ] && case "$OUT" in *"size-ratchet: OK"*) true ;; *) false ;; esac \
-  && ok "shim-free control: the absent byte-class file is counted from its readable blob" \
-  || bad "shim-free control: the absent byte-class file is counted" "rc=$RC out=$OUT"
-run_bin "$GIT_SHIM"
-[ "$RC" -eq 2 ] && case "$OUT" in *"cannot read index blob for tracked file 'assets/big.bin'"*) true ;; *) false ;; esac \
-  && ok "the streamed byte-class read is a collection error: exit 2, naming assets/big.bin" \
-  || bad "an unreadable byte-class blob is a collection error naming the file" "rc=$RC out=$OUT"
-case "$OUT" in *"size-ratchet: OK"*) bad "no OK verdict may accompany the byte-class collection failure" "$OUT" ;; *) ok "no OK verdict accompanies the byte-class collection failure" ;; esac
 
 echo "=== fail-closed: a blob that materializes but cannot be counted terminates ==="
 # The line class materializes the index blob and then counts it, so the read

--- a/skills/size-ratchet/tests/collection-fail-closed.test.sh
+++ b/skills/size-ratchet/tests/collection-fail-closed.test.sh
@@ -30,6 +30,9 @@ unset SIZE_RATCHET_THRESHOLD SIZE_RATCHET_CLASSES SIZE_RATCHET_DEFAULT_CLASSES S
 # shipped-defaults.test.sh. Every fixture here declares its own thresholds,
 # so both start empty and a case that needs one sets it.
 export SIZE_RATCHET_DEFAULT_CLASSES="" SIZE_RATCHET_FROZEN_CLASSES=""
+# A fixture repo is its own repo: an inherited git environment would make the
+# fixture `git add` write into the index of whatever repo invoked this suite.
+unset GIT_DIR GIT_COMMON_DIR GIT_WORK_TREE GIT_INDEX_FILE 2>/dev/null || true
 
 PASS=0
 FAIL=0
@@ -250,6 +253,25 @@ run_bin "$GIT_SHIM"
   && ok "the streamed byte-class read is a collection error: exit 2, naming assets/big.bin" \
   || bad "an unreadable byte-class blob is a collection error naming the file" "rc=$RC out=$OUT"
 case "$OUT" in *"size-ratchet: OK"*) bad "no OK verdict may accompany the byte-class collection failure" "$OUT" ;; *) ok "no OK verdict accompanies the byte-class collection failure" ;; esac
+
+echo "=== fail-closed: a blob that materializes but cannot be counted terminates ==="
+# The line class materializes the index blob and then counts it, so the read
+# succeeding says nothing about the count. Under --staged with one line-class
+# file that count is the run's only wc invocation, so the blanket wc shim
+# reaches it and the asserted wording pins which guard fired.
+new_repo blobcount
+mkfile small.txt 5
+git -C "$R" add -A
+run_sr --staged
+[ "$RC" -eq 0 ] && case "$OUT" in *"size-ratchet: OK"*) true ;; *) false ;; esac \
+  && ok "shim-free control: the materialized index blob is counted and passes" \
+  || bad "shim-free control: the materialized index blob is counted" "rc=$RC out=$OUT"
+run_sr_shimmed "$WC_SHIM" --staged
+[ "$RC" -eq 2 ] && case "$OUT" in *"cannot count the materialized index blob for tracked file 'small.txt'"*) true ;; *) false ;; esac \
+  && ok "an uncountable materialized blob is a collection error: exit 2, naming small.txt" \
+  || bad "an uncountable materialized blob is a collection error naming the file" "rc=$RC out=$OUT"
+case "$OUT" in *"simulated read failure"*) ok "wc's own stderr is surfaced, pinning the cause to the failed count" ;; *) bad "wc's own stderr is surfaced" "$OUT" ;; esac
+case "$OUT" in *"size-ratchet: OK"*) bad "no OK verdict may accompany an uncountable materialized blob" "$OUT" ;; *) ok "no OK verdict accompanies the uncountable materialized blob" ;; esac
 
 echo "=== fail-closed: a baselined unreadable blob refuses --update, baseline untouched ==="
 new_repo updfail

--- a/skills/size-ratchet/tests/collection-fail-closed.test.sh
+++ b/skills/size-ratchet/tests/collection-fail-closed.test.sh
@@ -70,14 +70,15 @@ run_sr_shimmed() { # SHIMDIR [args...] — run_sr with SHIMDIR first on PATH
   OUT="$(cd "$R" && PATH="$shimdir:$PATH" SIZE_RATCHET_THRESHOLD=10 "$SR" "$@" 2>&1)" || RC=$?
 }
 
-# git shim: fail `git show :big.txt` (the index-blob read), pass everything
-# else through to the real git.
+# git shim: fail the index-blob read for `big.txt` (a line class, read through
+# a materialized blob) and for `assets/big.bin` (a byte class, streamed through
+# a pipeline), pass everything else through to the real git.
 GIT_SHIM="$TMP/git-shim"
 mkdir -p "$GIT_SHIM"
 cat >"$GIT_SHIM/git" <<EOF
 #!/usr/bin/env bash
-if [ "\${1:-}" = "show" ] && [ "\${2:-}" = ":big.txt" ]; then
-  echo "fatal: simulated object read failure for big.txt" >&2
+if [ "\${1:-}" = "show" ] && { [ "\${2:-}" = ":big.txt" ] || [ "\${2:-}" = ":assets/big.bin" ]; }; then
+  echo "fatal: simulated object read failure for \${2#:}" >&2
   exit 128
 fi
 exec "$REAL_GIT" "\$@"
@@ -226,6 +227,29 @@ run_sr_shimmed "$GIT_SHIM"
   || bad "an unreadable blob is a collection error naming the file" "rc=$RC out=$OUT"
 case "$OUT" in *"simulated object read failure"*) ok "git's own stderr is surfaced, pinning the cause to the failed read" ;; *) bad "git's own stderr is surfaced" "$OUT" ;; esac
 case "$OUT" in *"size-ratchet: OK"*) bad "no OK verdict may accompany a collection failure" "$OUT" ;; *) ok "no OK verdict accompanies the collection failure" ;; esac
+
+echo "=== fail-closed: an unreadable index blob in a BYTE class terminates too ==="
+# A byte class never materializes the blob: it streams `git show | wc -c`, so
+# the read's failure reaches the gate through pipefail rather than through the
+# line class's own status check above. Both branches must refuse.
+run_bin() { # [SHIMDIR] — run in $R under the byte class; no SHIMDIR is the real git
+  OUT=""
+  RC=0
+  OUT="$(cd "$R" && PATH="${1:+$1:}$PATH" SIZE_RATCHET_THRESHOLD=10 SIZE_RATCHET_CLASSES='*.bin=64k' "$SR" 2>&1)" || RC=$?
+}
+new_repo blobfailbin
+mkfile assets/big.bin 3
+git -C "$R" add -A
+rm "$R/assets/big.bin" # unstaged: the index still lists it, blob readable
+run_bin
+[ "$RC" -eq 0 ] && case "$OUT" in *"size-ratchet: OK"*) true ;; *) false ;; esac \
+  && ok "shim-free control: the absent byte-class file is counted from its readable blob" \
+  || bad "shim-free control: the absent byte-class file is counted" "rc=$RC out=$OUT"
+run_bin "$GIT_SHIM"
+[ "$RC" -eq 2 ] && case "$OUT" in *"cannot read index blob for tracked file 'assets/big.bin'"*) true ;; *) false ;; esac \
+  && ok "the streamed byte-class read is a collection error: exit 2, naming assets/big.bin" \
+  || bad "an unreadable byte-class blob is a collection error naming the file" "rc=$RC out=$OUT"
+case "$OUT" in *"size-ratchet: OK"*) bad "no OK verdict may accompany the byte-class collection failure" "$OUT" ;; *) ok "no OK verdict accompanies the byte-class collection failure" ;; esac
 
 echo "=== fail-closed: a baselined unreadable blob refuses --update, baseline untouched ==="
 new_repo updfail

--- a/tools/size-ratchet-baseline.tsv
+++ b/tools/size-ratchet-baseline.tsv
@@ -118,6 +118,6 @@ skills/second-opinion/tests/cli-failure-gate.test.sh	1204
 skills/second-opinion/tests/lane-scratch-durability.test.sh	999
 skills/second-opinion/tests/review-dual-model.test.sh	1516
 skills/size-ratchet/scripts/lib/settings.sh	546
-skills/size-ratchet/scripts/size-ratchet	1079
+skills/size-ratchet/scripts/size-ratchet	1094
 skills/worktree/scripts/worktree	4545
 skills/worktree/scripts/worktree-session-guard	442

--- a/tools/size-ratchet-baseline.tsv
+++ b/tools/size-ratchet-baseline.tsv
@@ -118,6 +118,6 @@ skills/second-opinion/tests/cli-failure-gate.test.sh	1204
 skills/second-opinion/tests/lane-scratch-durability.test.sh	999
 skills/second-opinion/tests/review-dual-model.test.sh	1516
 skills/size-ratchet/scripts/lib/settings.sh	546
-skills/size-ratchet/scripts/size-ratchet	1047
+skills/size-ratchet/scripts/size-ratchet	1043
 skills/worktree/scripts/worktree	4545
 skills/worktree/scripts/worktree-session-guard	442

--- a/tools/size-ratchet-baseline.tsv
+++ b/tools/size-ratchet-baseline.tsv
@@ -118,6 +118,6 @@ skills/second-opinion/tests/cli-failure-gate.test.sh	1204
 skills/second-opinion/tests/lane-scratch-durability.test.sh	999
 skills/second-opinion/tests/review-dual-model.test.sh	1516
 skills/size-ratchet/scripts/lib/settings.sh	546
-skills/size-ratchet/scripts/size-ratchet	996
+skills/size-ratchet/scripts/size-ratchet	1029
 skills/worktree/scripts/worktree	4545
 skills/worktree/scripts/worktree-session-guard	442

--- a/tools/size-ratchet-baseline.tsv
+++ b/tools/size-ratchet-baseline.tsv
@@ -118,6 +118,6 @@ skills/second-opinion/tests/cli-failure-gate.test.sh	1204
 skills/second-opinion/tests/lane-scratch-durability.test.sh	999
 skills/second-opinion/tests/review-dual-model.test.sh	1516
 skills/size-ratchet/scripts/lib/settings.sh	546
-skills/size-ratchet/scripts/size-ratchet	1043
+skills/size-ratchet/scripts/size-ratchet	1079
 skills/worktree/scripts/worktree	4545
 skills/worktree/scripts/worktree-session-guard	442

--- a/tools/size-ratchet-baseline.tsv
+++ b/tools/size-ratchet-baseline.tsv
@@ -118,6 +118,6 @@ skills/second-opinion/tests/cli-failure-gate.test.sh	1204
 skills/second-opinion/tests/lane-scratch-durability.test.sh	999
 skills/second-opinion/tests/review-dual-model.test.sh	1516
 skills/size-ratchet/scripts/lib/settings.sh	546
-skills/size-ratchet/scripts/size-ratchet	1029
+skills/size-ratchet/scripts/size-ratchet	1047
 skills/worktree/scripts/worktree	4545
 skills/worktree/scripts/worktree-session-guard	442

--- a/tools/size-ratchet-excludes
+++ b/tools/size-ratchet-excludes
@@ -32,4 +32,4 @@ ui/src/components/ui/*	shadcn-generated UI primitives — vendored generated cod
 docs/img/*	README screenshots and the tour gif — binary media
 kendex-local.toml	this repo's own install state — the CLI writes one table per declared item, so it grows with the install and has no seam a person can split
 crates/app/gen/schemas/*.json	tauri-build output — capability schemas regenerated on every build of crates/app, never hand-edited
-crates/app/icons/*	tauri bundle icons (png/ico/icns) — binary media, no lines to count
+crates/app/icons/*	tauri bundle icons (png/ico/icns) — binary media, not reviewable text

--- a/tools/size-ratchet-excludes
+++ b/tools/size-ratchet-excludes
@@ -32,3 +32,4 @@ ui/src/components/ui/*	shadcn-generated UI primitives — vendored generated cod
 docs/img/*	README screenshots and the tour gif — binary media
 kendex-local.toml	this repo's own install state — the CLI writes one table per declared item, so it grows with the install and has no seam a person can split
 crates/app/gen/schemas/*.json	tauri-build output — capability schemas regenerated on every build of crates/app, never hand-edited
+crates/app/icons/*	tauri bundle icons (png/ico/icns) — binary media, no lines to count


### PR DESCRIPTION
A raw NUL in a tracked text file makes git call the blob binary: no textual diff, `git grep` reduced to `Binary file <path> matches`, and `git grep -I` dropping it outright. On KEN-1135 that hid 55 lines of new logic in `ui/src/lib/installed-places.ts` for four review rounds, and nothing in the commit chain refused it — `tools/guard`, preflight, biome, tsc, clippy and the full suites all pass a source file carrying the byte.

`size-ratchet` now refuses it.

## What it does

Every counted blob is sniffed for a NUL in its leading 8000 bytes — git's own text/binary rule — and a hit exits 2 naming the path and the byte's offset, never reprinting the byte. The refusal fires before any mode branch, so `--staged`, `--seed` and `--update` all refuse through one place, and it runs in the worktree scan CI executes as well as under `--staged`.

**The sniff keys on content, not on the unit a path is counted in.** A byte class is not exempt: every markdown class in the shipped list is a byte class, so keying on the unit would have left the whole surface agents load as instructions — `SKILL.md`, `AGENTS.md`, `CLAUDE.md` — carrying the original defect one class over.

**The only exemption is git's own record.** A path `.gitattributes` gives `binary` or `-diff` is one git keeps out of every textual diff, so it was never reviewable text. The exclusion list answers a different question — which paths carry no size bound — and grants no content exemption, so a size-excluded text file like `CHANGELOG.md` is sniffed like any other. Under `--staged` the attribute is read from the index, matching how the baseline and the exclusion list are already read there, so an untracked `.gitattributes` cannot silence the commit gate.

`.gitattributes` declares this repo's seven binary media types, which covers all 84 tracked NUL-carrying files.

## Cost

Measured CPU min-of-N on 2976 tracked files: `check` +19%, `--staged` +15-24% against the fork point. The attribute lookup is one `git check-attr --stdin` process for the whole path set, not a fork per path — a per-path control measured 3.8x. The two-stage sniff costs no subprocess on files that pass: a full 8000-byte read is 10 syscalls and no fork.

## Breaking

A repo with a tracked binary asset that `.gitattributes` does not declare now reds. Declare it `binary` there; the excludes list no longer exempts content.

## Verification

- A staged text file carrying a NUL is refused naming the offset, in a line class and a byte class, in both scopes.
- A file declared `binary` passes, and is still measured for size — the two exemptions are independent.
- Each control was proven to red against a mutant that reverts what it pins.
- The gate is green over this repo's 2976 tracked files in both scopes; all 11 size-ratchet suites pass.

Known and documented: a repo-local `.git/info/attributes` also grants the exemption and git offers no switch to skip it. It is per-clone, never committed, never reviewed — the same write access as `.git/hooks` — and CI's clean checkout refuses regardless. `README.md` and `DEVELOPMENT.md` say so rather than claiming only committed attributes count.

Closes KEN-1146

https://claude.ai/code/session_01RUrngiPYgZu5hBayZitdpx
