### PR TITLE
fix(KEN-1160): a local failure is a read that failed, not offline

### DIFF
--- a/changelog.d/fixed/KEN-1160-cache-write.md
+++ b/changelog.d/fixed/KEN-1160-cache-write.md
@@ -1,0 +1,3 @@
+- A directory or account read no longer fails because kendex could not write
+  its cache. A full or read-only home now costs a re-fetch next time instead
+  of an error.

--- a/changelog.d/fixed/KEN-1160-cache-write.md
+++ b/changelog.d/fixed/KEN-1160-cache-write.md
@@ -1,3 +1,3 @@
-- A directory or account read no longer fails because kendex could not write
-  its cache. A full or read-only home now costs a re-fetch next time instead
-  of an error.
+- A read no longer fails because kendex could not write or delete its cache.
+  A full or read-only home costs a re-fetch next time instead of an error, and
+  an expired sign-in still says so.

--- a/changelog.d/fixed/KEN-1160.md
+++ b/changelog.d/fixed/KEN-1160.md
@@ -1,0 +1,3 @@
+- The account now says so when the failure is on your machine — a refused
+  credential lock, a full disk, a second kendex holding it. It used to read
+  as "Offline", blaming a directory nothing had asked.

--- a/crates/app/src/account.rs
+++ b/crates/app/src/account.rs
@@ -27,10 +27,11 @@ pub struct AccountStatus {
 ///
 /// The two are one question the surface has to answer: may the name from
 /// the last read stand as the last one kendex.ai confirmed? Only a read
-/// whose request reached the directory and came back with nothing leaves
-/// it standing; one this machine stopped learned nothing about the
-/// directory, and showing the name as offline would name the wrong cause
-/// and send the person to check a working network.
+/// whose request went out and came back with nothing leaves it standing —
+/// a network with no route to kendex.ai included, since the machine did
+/// ask. One this machine stopped never asked, so it learned nothing, and
+/// showing the name as offline would name the wrong cause and send the
+/// person to check a working network.
 ///
 /// Each carries the whole sentence, because the surface that shows it has
 /// nothing else to say. It is named here rather than on the variants

--- a/crates/app/src/account.rs
+++ b/crates/app/src/account.rs
@@ -10,7 +10,7 @@ use kendex_core::env::Env;
 use kendex_core::error::CoreError;
 use kendex_core::registry::credentials::{Credential, KeyringStore};
 use kendex_core::registry::login::{self, Poll};
-use kendex_core::registry::me::{self, AccountState};
+use kendex_core::registry::me::{self, AccountState, AccountUnread};
 use kendex_core::registry::submit::{self, SubmissionRow};
 use kendex_core::registry::{CurlFetch, base_url};
 use serde::{Deserialize, Serialize};
@@ -23,11 +23,44 @@ pub struct AccountStatus {
     pub endpoint: String,
 }
 
+/// Why the account could not be read.
+///
+/// The two are one question the surface has to answer: may the name from
+/// the last read stand as the last one kendex.ai confirmed? Only a read
+/// that reached the directory and came back with nothing leaves it
+/// standing; one this machine refused says nothing about the directory,
+/// and showing the name as offline would name the wrong cause and send
+/// the person to check a working network.
+///
+/// Each carries the whole sentence, because the surface that shows it has
+/// nothing else to say. It is named here rather than on the variants
+/// because specta hoists a variant's doc above the whole union.
+#[derive(Debug, Serialize, Type)]
+#[serde(tag = "kind", rename_all = "kebab-case")]
+pub enum AccountReadFailed {
+    Local { message: String },
+    Unreachable { message: String },
+}
+
+impl From<AccountUnread> for AccountReadFailed {
+    fn from(unread: AccountUnread) -> AccountReadFailed {
+        let message = unread.error().to_string();
+        match unread {
+            AccountUnread::Local(_) => AccountReadFailed::Local { message },
+            AccountUnread::Unreachable(_) => AccountReadFailed::Unreachable { message },
+        }
+    }
+}
+
 #[tauri::command(async)]
 #[specta::specta]
-pub fn account_status() -> Result<AccountStatus, String> {
-    let env = Env::detect().map_err(|e| e.to_string())?;
-    let state = me::load(&env, &CurlFetch, &KeyringStore).map_err(|e| e.to_string())?;
+pub fn account_status() -> Result<AccountStatus, AccountReadFailed> {
+    // A machine with no home directory to read from has asked kendex.ai
+    // nothing, so this is local like any other refusal ahead of the call.
+    let env = Env::detect().map_err(|error| AccountReadFailed::Local {
+        message: error.to_string(),
+    })?;
+    let state = me::load(&env, &CurlFetch, &KeyringStore)?;
     Ok(AccountStatus {
         state,
         endpoint: base_url(),

--- a/crates/app/src/account.rs
+++ b/crates/app/src/account.rs
@@ -27,10 +27,10 @@ pub struct AccountStatus {
 ///
 /// The two are one question the surface has to answer: may the name from
 /// the last read stand as the last one kendex.ai confirmed? Only a read
-/// that reached the directory and came back with nothing leaves it
-/// standing; one this machine refused says nothing about the directory,
-/// and showing the name as offline would name the wrong cause and send
-/// the person to check a working network.
+/// whose request reached the directory and came back with nothing leaves
+/// it standing; one this machine stopped learned nothing about the
+/// directory, and showing the name as offline would name the wrong cause
+/// and send the person to check a working network.
 ///
 /// Each carries the whole sentence, because the surface that shows it has
 /// nothing else to say. It is named here rather than on the variants
@@ -230,6 +230,35 @@ mod tests {
             refused(CoreError::NotSignedIn),
             AccountCallRefused::Failed { .. }
         ));
+    }
+
+    /// The seam the account fix crosses: which half of the read failed is
+    /// decided in core, and this carries that across unchanged. Swapping
+    /// the arms would put "Offline — signed in when kendex.ai was last
+    /// reached" back in front of someone whose keychain is locked, and the
+    /// sentence is the producer's, so a rewrite here would lose the cause
+    /// the surface shows beside the retry.
+    #[test]
+    fn the_read_failure_reaches_the_surface_as_the_half_that_failed() {
+        let locked = "the credential store on this machine could not be used";
+        let refusal = AccountReadFailed::from(AccountUnread::Local(
+            CoreError::CredentialStoreUnavailable {
+                why: "the keyring is locked".to_owned(),
+            },
+        ));
+        let AccountReadFailed::Local { message } = refusal else {
+            panic!("a store this machine refused is local");
+        };
+        assert!(message.starts_with(locked), "{message}");
+
+        let away =
+            AccountReadFailed::from(AccountUnread::Unreachable(CoreError::RegistryUnavailable {
+                why: "no route".to_owned(),
+            }));
+        let AccountReadFailed::Unreachable { message } = away else {
+            panic!("a directory that did not answer is unreachable");
+        };
+        assert!(message.contains("no route"), "{message}");
     }
 
     /// The expired refusal is all the surface has to show, and the whole

--- a/crates/core/src/error.rs
+++ b/crates/core/src/error.rs
@@ -17,10 +17,10 @@ pub enum CoreError {
     },
 
     /// A command that never ran: it could not be spawned, or what it needed
-    /// to run could not be written. Told apart from every failure of a
-    /// command that did run — a timeout, a non-zero exit — because only
-    /// this one means the work was never attempted, which is what a caller
-    /// deciding whether a cached answer may stand in has to know.
+    /// to run could not be written. Nothing a command that did start can
+    /// fail with belongs here — not a timeout, not a non-zero exit —
+    /// because callers read this as proof the work was never attempted,
+    /// which is what decides whether a cached answer may stand in.
     #[error("{label} could not be started: {why}")]
     CommandNotStarted { label: String, why: String },
 

--- a/crates/core/src/error.rs
+++ b/crates/core/src/error.rs
@@ -16,6 +16,14 @@ pub enum CoreError {
         source: std::io::Error,
     },
 
+    /// A command that never ran: it could not be spawned, or what it needed
+    /// to run could not be written. Told apart from every failure of a
+    /// command that did run — a timeout, a non-zero exit — because only
+    /// this one means the work was never attempted, which is what a caller
+    /// deciding whether a cached answer may stand in has to know.
+    #[error("{label} could not be started: {why}")]
+    CommandNotStarted { label: String, why: String },
+
     #[error("{}: invalid TOML: {message}", crate::names::shown(&path.display().to_string()))]
     TomlParse { path: PathBuf, message: String },
 
@@ -494,6 +502,14 @@ impl CoreError {
         CoreError::Io {
             path: path.into(),
             source,
+        }
+    }
+
+    /// A command that never ran; `why` says what stopped it.
+    pub fn not_started(label: &str, why: impl std::fmt::Display) -> Self {
+        CoreError::CommandNotStarted {
+            label: label.to_owned(),
+            why: why.to_string(),
         }
     }
 }

--- a/crates/core/src/process/mod.rs
+++ b/crates/core/src/process/mod.rs
@@ -166,15 +166,16 @@ impl Hardened {
     }
 
     pub fn run(mut self) -> Result<Output> {
+        // The two ways it never runs at all; every failure below did run.
         let mut child = match self.command.spawn() {
             Ok(child) => child,
-            Err(error) => return Err(CoreError::io(&self.label, error)),
+            Err(error) => return Err(CoreError::not_started(&self.label, error)),
         };
         let (Some(mut stdout), Some(mut stderr)) = (child.stdout.take(), child.stderr.take())
         else {
-            return Err(CoreError::io(
+            return Err(CoreError::not_started(
                 &self.label,
-                io::Error::other("child was spawned without pipes"),
+                "it was spawned without pipes",
             ));
         };
         // Drained on threads: a child that fills a pipe buffer would block

--- a/crates/core/src/process/mod.rs
+++ b/crates/core/src/process/mod.rs
@@ -166,16 +166,16 @@ impl Hardened {
     }
 
     pub fn run(mut self) -> Result<Output> {
-        // The two ways it never runs at all; every failure below did run.
+        // Only a failed spawn never ran; missing pipes are a broken invariant.
         let mut child = match self.command.spawn() {
             Ok(child) => child,
             Err(error) => return Err(CoreError::not_started(&self.label, error)),
         };
         let (Some(mut stdout), Some(mut stderr)) = (child.stdout.take(), child.stderr.take())
         else {
-            return Err(CoreError::not_started(
+            return Err(CoreError::io(
                 &self.label,
-                "it was spawned without pipes",
+                io::Error::other("spawned without pipes"),
             ));
         };
         // Drained on threads: a child that fills a pipe buffer would block

--- a/crates/core/src/process/tests.rs
+++ b/crates/core/src/process/tests.rs
@@ -559,3 +559,21 @@ fn a_descendant_holding_the_pipes_does_not_outlive_the_timeout() {
     };
     assert_eq!(source.kind(), io::ErrorKind::TimedOut);
 }
+
+/// The producer `registry/client.rs` reads to tell a request that never
+/// went out from one the directory did not answer. A real spawn failure
+/// rather than a hand-built error: the classification is only worth
+/// anything if the shipped path raises the name the seam matches on, and
+/// the error it raised one commit before this was an ordinary `Io`.
+#[test]
+fn a_program_that_cannot_be_spawned_says_it_never_started() {
+    let error = Hardened::program("/nonexistent/kendex-not-a-program", &[])
+        .timeout(Duration::from_secs(5))
+        .run()
+        .unwrap_err();
+    let CoreError::CommandNotStarted { label, why } = error else {
+        panic!("a command that never ran must say so, not report as a run that failed");
+    };
+    assert!(label.contains("kendex-not-a-program"), "{label}");
+    assert!(!why.is_empty(), "the reason it could not start is empty");
+}

--- a/crates/core/src/process/tests.rs
+++ b/crates/core/src/process/tests.rs
@@ -563,8 +563,7 @@ fn a_descendant_holding_the_pipes_does_not_outlive_the_timeout() {
 /// The producer `registry/client.rs` reads to tell a request that never
 /// went out from one the directory did not answer. A real spawn failure
 /// rather than a hand-built error: the classification is only worth
-/// anything if the shipped path raises the name the seam matches on, and
-/// the error it raised one commit before this was an ordinary `Io`.
+/// anything if the shipped path raises the name the seam matches on.
 #[test]
 fn a_program_that_cannot_be_spawned_says_it_never_started() {
     let error = Hardened::program("/nonexistent/kendex-not-a-program", &[])

--- a/crates/core/src/registry.rs
+++ b/crates/core/src/registry.rs
@@ -244,7 +244,11 @@ fn run_with_config(url: &str, config: &str) -> Result<FetchResponse> {
     } else {
         "=https"
     };
-    let file = tempfile_0600(config)?;
+    // The config file carries the request, so a machine that cannot write
+    // it never sends one. That is the same fact the runner reports when it
+    // cannot spawn curl, and it is said the same way: a caller weighing a
+    // cached answer must not read either as the directory going quiet.
+    let file = tempfile_0600(config).map_err(|error| CoreError::not_started("curl", error))?;
     let path = file.path().to_string_lossy().into_owned();
     let args = [
         "-sS",

--- a/crates/core/src/registry/client.rs
+++ b/crates/core/src/registry/client.rs
@@ -11,13 +11,13 @@ use crate::registry::{Fetch, FetchResponse, base_url};
 /// to do about it rather than in the error's name.
 ///
 /// A caller holding a cache reads this to decide whether a cached
-/// generation may stand in for the answer. Only `Unreachable` is the
-/// directory failing to answer; every other failure happened on this
-/// machine or is news about the sign-in itself, and serving a cache for
-/// one of those would tell the user the directory was last reached when
-/// nothing ever asked it. Each variant is chosen at the site that raises
-/// the failure, so a local failure added later cannot fall into the
-/// remote half by nobody naming it.
+/// generation may stand in for the answer. Only `Unreachable` is a request
+/// that reached the directory; every other failure is this machine's or is
+/// news about the sign-in itself, and serving a cache for one of those
+/// would tell the user the directory was last reached on some date when
+/// what stopped this read was never out on the network. Each variant is
+/// chosen at the site that raises the failure, so a local failure added
+/// later cannot fall into the remote half by nobody naming it.
 #[derive(Debug)]
 pub enum CallFailed {
     /// This machine holds no credential for the endpoint.
@@ -25,10 +25,14 @@ pub enum CallFailed {
     /// The sign-in is dead server-side. The error carries the whole
     /// sentence, remedy included.
     Expired(CoreError),
-    /// The call was never made: the credential store refused a read or a
-    /// write, or the refresh lock could not be taken.
+    /// This machine stopped the request the call needed: the credential
+    /// store refused a read or a write, the refresh lock could not be
+    /// taken, the request could not be sent. An earlier request in the
+    /// same call may well have gone out and come back; what did not is
+    /// the one this call needed, so nothing was learned about the
+    /// directory.
     Local(CoreError),
-    /// The call went out and no usable answer came back.
+    /// The request reached the directory and no usable answer came back.
     Unreachable(CoreError),
 }
 
@@ -46,6 +50,21 @@ impl From<CallFailed> for CoreError {
 /// One authenticated call's answer, or why there is none.
 pub type Called = std::result::Result<FetchResponse, CallFailed>;
 
+/// One attempt to send the request, read for whether it was ever sent.
+///
+/// The transport names that itself: a config file it could not write and a
+/// curl it could not spawn both raise `CommandNotStarted`, and nothing a
+/// sent request can fail with does. Reading that name here is reading the
+/// classification the raising site made, not making a second one — which
+/// is why this is a single name and never a list of them.
+fn sent(attempt: Result<FetchResponse>) -> Called {
+    match attempt {
+        Ok(response) => Ok(response),
+        Err(never_sent @ CoreError::CommandNotStarted { .. }) => Err(CallFailed::Local(never_sent)),
+        Err(error) => Err(CallFailed::Unreachable(error)),
+    }
+}
+
 /// Run one authenticated call, refreshing a rejected access token once.
 /// Refresh rotation is locked across processes and saved before retry.
 /// Every path that answers `Expired` removes the credential current
@@ -57,7 +76,7 @@ pub fn with_access(
     call: impl Fn(&str) -> Result<FetchResponse>,
 ) -> Called {
     let opened_under = current(store)?;
-    let first = call(&opened_under.access_token).map_err(CallFailed::Unreachable)?;
+    let first = sent(call(&opened_under.access_token))?;
     if first.status != 401 {
         return Ok(first);
     }
@@ -86,7 +105,7 @@ fn rotate_after_rejection(
         let locked = current(store)?;
         if locked.access_token != rejected.access_token {
             drop(refresh_guard);
-            let retried = call(&locked.access_token).map_err(CallFailed::Unreachable)?;
+            let retried = sent(call(&locked.access_token))?;
             if retried.status != 401 {
                 return Ok(retried);
             }
@@ -135,7 +154,7 @@ fn rotate_locked(
     store.save(&rotated).map_err(CallFailed::Local)?;
     drop(refresh_guard);
 
-    let second = call(&rotated.access_token).map_err(CallFailed::Unreachable)?;
+    let second = sent(call(&rotated.access_token))?;
     if second.status == 401 {
         return Err(rejected_access(store));
     }

--- a/crates/core/src/registry/client.rs
+++ b/crates/core/src/registry/client.rs
@@ -7,22 +7,71 @@ use crate::registry::credentials::{Credential, CredentialStore};
 use crate::registry::login::TokenPair;
 use crate::registry::{Fetch, FetchResponse, base_url};
 
+/// Why an authenticated call did not answer, said in what its caller has
+/// to do about it rather than in the error's name.
+///
+/// A caller holding a cache reads this to decide whether a cached
+/// generation may stand in for the answer. Only `Unreachable` is the
+/// directory failing to answer; every other failure happened on this
+/// machine or is news about the sign-in itself, and serving a cache for
+/// one of those would tell the user the directory was last reached when
+/// nothing ever asked it. Each variant is chosen at the site that raises
+/// the failure, so a local failure added later cannot fall into the
+/// remote half by nobody naming it.
+#[derive(Debug)]
+pub enum CallFailed {
+    /// This machine holds no credential for the endpoint.
+    NotSignedIn,
+    /// The sign-in is dead server-side. The error carries the whole
+    /// sentence, remedy included.
+    Expired(CoreError),
+    /// The call was never made: the credential store refused a read or a
+    /// write, or the refresh lock could not be taken.
+    Local(CoreError),
+    /// The call went out and no usable answer came back.
+    Unreachable(CoreError),
+}
+
+impl From<CallFailed> for CoreError {
+    fn from(failed: CallFailed) -> CoreError {
+        match failed {
+            CallFailed::NotSignedIn => CoreError::NotSignedIn,
+            CallFailed::Expired(error)
+            | CallFailed::Local(error)
+            | CallFailed::Unreachable(error) => error,
+        }
+    }
+}
+
+/// One authenticated call's answer, or why there is none.
+pub type Called = std::result::Result<FetchResponse, CallFailed>;
+
 /// Run one authenticated call, refreshing a rejected access token once.
 /// Refresh rotation is locked across processes and saved before retry.
-/// Every path that answers `SignInExpired` removes the credential current
+/// Every path that answers `Expired` removes the credential current
 /// when its removal lock is acquired, and says in `why` when the store
 /// would not give it up.
 pub fn with_access(
     fetch: &dyn Fetch,
     store: &dyn CredentialStore,
     call: impl Fn(&str) -> Result<FetchResponse>,
-) -> Result<FetchResponse> {
-    let opened_under = required(store.load()?)?;
-    let first = call(&opened_under.access_token)?;
+) -> Called {
+    let opened_under = current(store)?;
+    let first = call(&opened_under.access_token).map_err(CallFailed::Unreachable)?;
     if first.status != 401 {
         return Ok(first);
     }
     rotate_after_rejection(fetch, store, &call, opened_under)
+}
+
+/// The credential this call goes out under. A store that refuses the read
+/// is not a machine with no credential, and the two answer differently.
+fn current(store: &dyn CredentialStore) -> std::result::Result<Credential, CallFailed> {
+    match store.load() {
+        Ok(Some(credential)) => Ok(credential),
+        Ok(None) => Err(CallFailed::NotSignedIn),
+        Err(error) => Err(CallFailed::Local(error)),
+    }
 }
 
 fn rotate_after_rejection(
@@ -30,14 +79,14 @@ fn rotate_after_rejection(
     store: &dyn CredentialStore,
     call: &impl Fn(&str) -> Result<FetchResponse>,
     mut rejected: Credential,
-) -> Result<FetchResponse> {
+) -> Called {
     let mut newer_retries = 0;
     loop {
-        let refresh_guard = store.refresh_guard()?;
-        let locked = required(store.load()?)?;
+        let refresh_guard = store.refresh_guard().map_err(CallFailed::Local)?;
+        let locked = current(store)?;
         if locked.access_token != rejected.access_token {
             drop(refresh_guard);
-            let retried = call(&locked.access_token)?;
+            let retried = call(&locked.access_token).map_err(CallFailed::Unreachable)?;
             if retried.status != 401 {
                 return Ok(retried);
             }
@@ -58,7 +107,7 @@ fn rotate_locked(
     call: &impl Fn(&str) -> Result<FetchResponse>,
     credential: Credential,
     refresh_guard: Box<dyn crate::registry::credentials::CredentialRefreshGuard + '_>,
-) -> Result<FetchResponse> {
+) -> Called {
     let pair = match refresh(fetch, &credential.refresh_token) {
         Ok(pair) => pair,
         Err(Refused::Definitive(why)) => {
@@ -73,7 +122,7 @@ fn rotate_locked(
                 format!("your sign-in has expired ({why})"),
             ));
         }
-        Err(Refused::Transient(error)) => return Err(error),
+        Err(Refused::Transient(error)) => return Err(CallFailed::Unreachable(error)),
     };
     let rotated = Credential {
         endpoint: base_url(),
@@ -83,10 +132,10 @@ fn rotate_locked(
         // Rotation replaces the tokens, never the sign-in they belong to.
         sign_in: credential.sign_in.clone(),
     };
-    store.save(&rotated)?;
+    store.save(&rotated).map_err(CallFailed::Local)?;
     drop(refresh_guard);
 
-    let second = call(&rotated.access_token)?;
+    let second = call(&rotated.access_token).map_err(CallFailed::Unreachable)?;
     if second.status == 401 {
         return Err(rejected_access(store));
     }
@@ -129,14 +178,10 @@ pub fn logout(fetch: &dyn Fetch, store: &dyn CredentialStore) -> Result<bool> {
     Ok(true)
 }
 
-fn required(credential: Option<Credential>) -> Result<Credential> {
-    credential.ok_or(CoreError::NotSignedIn)
-}
-
 /// The server rejected the access token used by this call. Re-take the
 /// credential transaction, then clear whichever sign-in is current. A login
 /// completed while the rejected request was in flight is current here too.
-fn rejected_access(store: &dyn CredentialStore) -> CoreError {
+fn rejected_access(store: &dyn CredentialStore) -> CallFailed {
     let removal = match store.refresh_guard() {
         Ok(_guard) => match store.clear() {
             Ok(()) => Removal::Done,
@@ -161,9 +206,11 @@ enum Removal {
 /// the current credential up never replaces the server's refusal; only
 /// `why` grows. The remedy rides in `why` because it depends on what the
 /// removal did: a credential still installed makes `kendex login` refuse,
-/// and the next attempt removes it.
-fn expired(removal: Removal, why: String) -> CoreError {
-    match removal {
+/// and the next attempt removes it. A store that refused the removal does
+/// not make this a local failure: the server has ended the sign-in either
+/// way, and that is what every surface has to say.
+fn expired(removal: Removal, why: String) -> CallFailed {
+    CallFailed::Expired(match removal {
         Removal::Done => CoreError::SignInExpired {
             why: format!("{why} — run `kendex login` again"),
         },
@@ -173,7 +220,7 @@ fn expired(removal: Removal, why: String) -> CoreError {
                  run this again once that clears, then `kendex login`"
             ),
         },
-    }
+    })
 }
 
 enum Refused {

--- a/crates/core/src/registry/client.rs
+++ b/crates/core/src/registry/client.rs
@@ -12,12 +12,14 @@ use crate::registry::{Fetch, FetchResponse, base_url};
 ///
 /// A caller holding a cache reads this to decide whether a cached
 /// generation may stand in for the answer. Only `Unreachable` is a request
-/// that reached the directory; every other failure is this machine's or is
-/// news about the sign-in itself, and serving a cache for one of those
-/// would tell the user the directory was last reached on some date when
-/// what stopped this read was never out on the network. Each variant is
-/// chosen at the site that raises the failure, so a local failure added
-/// later cannot fall into the remote half by nobody naming it.
+/// that went out; every other failure is this machine's or is news about
+/// the sign-in itself, and serving a cache for one of those would tell the
+/// user the directory was last reached on some date when nothing this read
+/// needed was ever put on the network. A request that went out and found
+/// no route is `Unreachable` too — it was sent, and the cache stands in
+/// for the answer it did not get. Each variant is chosen at the site that
+/// raises the failure, so a local failure added later cannot fall into the
+/// remote half by nobody naming it.
 #[derive(Debug)]
 pub enum CallFailed {
     /// This machine holds no credential for the endpoint.
@@ -32,7 +34,8 @@ pub enum CallFailed {
     /// the one this call needed, so nothing was learned about the
     /// directory.
     Local(CoreError),
-    /// The request reached the directory and no usable answer came back.
+    /// The request went out and no usable answer came back, whether the
+    /// directory refused it, answered badly, or was never found.
     Unreachable(CoreError),
 }
 
@@ -142,6 +145,7 @@ fn rotate_locked(
             ));
         }
         Err(Refused::Transient(error)) => return Err(CallFailed::Unreachable(error)),
+        Err(Refused::NeverSent(error)) => return Err(CallFailed::Local(error)),
     };
     let rotated = Credential {
         endpoint: base_url(),
@@ -245,6 +249,10 @@ fn expired(removal: Removal, why: String) -> CallFailed {
 enum Refused {
     Definitive(String),
     Transient(CoreError),
+    /// The rotation request never went out, so nothing about the grant was
+    /// learned. Separate from `Transient` because that one is the answer
+    /// coming back wrong, which a cached generation may stand in for.
+    NeverSent(CoreError),
 }
 
 fn refresh(fetch: &dyn Fetch, refresh_token: &str) -> std::result::Result<TokenPair, Refused> {
@@ -253,9 +261,15 @@ fn refresh(fetch: &dyn Fetch, refresh_token: &str) -> std::result::Result<TokenP
         "refresh_token": refresh_token,
     })
     .to_string();
-    let response = fetch
-        .post_json(&format!("{}/api/v1/device/token", base_url()), &body)
-        .map_err(Refused::Transient)?;
+    // Which half of the send failed is the transport's to say, and `sent`
+    // is the one place that reads it; this hands the same answer on in
+    // `Refused`'s terms rather than judging it a second time.
+    let response =
+        match sent(fetch.post_json(&format!("{}/api/v1/device/token", base_url()), &body)) {
+            Ok(response) => response,
+            Err(CallFailed::Local(error)) => return Err(Refused::NeverSent(error)),
+            Err(failed) => return Err(Refused::Transient(failed.into())),
+        };
     // Only these statuses prove the refresh grant is dead. Timeouts, rate
     // limits, and server failures keep the credential available for retry.
     if matches!(response.status, 400 | 401 | 403) {

--- a/crates/core/src/registry/generation.rs
+++ b/crates/core/src/registry/generation.rs
@@ -113,15 +113,9 @@ impl<'e> GenerationFile<'e> {
     /// a 304 re-dates the cached one, and any failure — transport error,
     /// refused status, unparseable body — serves the cached value as
     /// stale, erring only with nothing to serve. `refused` words the
-    /// error for a status that is neither 200 nor 304.
-    ///
-    /// A generation that could not be written — a full or read-only home,
-    /// a cache path taken by something else — does not fail the read. The
-    /// answer is what the server sent and this parsed; the file is how the
-    /// next read avoids asking again. Failing here would report a machine's
-    /// own refusal as the fetch not landing, which is the one thing every
-    /// error out of this call means. The cost is a read that re-fetches
-    /// next time, which is what an unwritten cache is for.
+    /// error for a status that is neither 200 nor 304. Every error out of
+    /// this call is the fetch not landing, which is what lets a caller
+    /// holding one judgment about the network read them all the same way.
     pub fn settle<T>(
         &self,
         cached: Option<(Generation, T)>,
@@ -137,7 +131,7 @@ impl<'e> GenerationFile<'e> {
         match response.status {
             200 => match parse(&response.body) {
                 Ok(value) => {
-                    let _ = self.write(&Generation {
+                    self.write(&Generation {
                         endpoint: base_url(),
                         credential: self.credential.clone(),
                         etag: response.etag,
@@ -156,7 +150,7 @@ impl<'e> GenerationFile<'e> {
                 let (generation, value) = cached.ok_or_else(|| CoreError::RegistryMalformed {
                     why: "the server said 'unchanged' but nothing is cached".into(),
                 })?;
-                let _ = self.write(&Generation {
+                self.write(&Generation {
                     fetched_at: now,
                     credential: self.credential.clone(),
                     ..generation
@@ -171,14 +165,25 @@ impl<'e> GenerationFile<'e> {
         }
     }
 
-    fn write(&self, generation: &Generation) -> Result<()> {
+    /// Leave this fetch where the next read will find it, or leave nothing.
+    ///
+    /// A generation that could not be written — a full or read-only home, a
+    /// cache path taken by something else — is never the caller's failure.
+    /// The answer is what the server sent and the caller parsed; this file
+    /// is only how the next read avoids asking for it again. Raising here
+    /// would report a refusal by this machine as the fetch not landing,
+    /// which is what every error out of [`GenerationFile::settle`] means.
+    /// The cost of swallowing is one re-fetch, which is what an unwritten
+    /// cache is for.
+    fn write(&self, generation: &Generation) {
         let dir = self.env.registry_cache_dir();
-        std::fs::create_dir_all(&dir).map_err(|error| CoreError::io(&dir, error))?;
-        let json =
-            serde_json::to_string(generation).map_err(|error| CoreError::RegistryMalformed {
-                why: error.to_string(),
-            })?;
-        atomic_write_no_follow(&dir.join(self.file), &json)
+        if std::fs::create_dir_all(&dir).is_err() {
+            return;
+        }
+        let Ok(json) = serde_json::to_string(generation) else {
+            return;
+        };
+        let _ = atomic_write_no_follow(&dir.join(self.file), &json);
     }
 }
 

--- a/crates/core/src/registry/generation.rs
+++ b/crates/core/src/registry/generation.rs
@@ -114,6 +114,14 @@ impl<'e> GenerationFile<'e> {
     /// refused status, unparseable body — serves the cached value as
     /// stale, erring only with nothing to serve. `refused` words the
     /// error for a status that is neither 200 nor 304.
+    ///
+    /// A generation that could not be written — a full or read-only home,
+    /// a cache path taken by something else — does not fail the read. The
+    /// answer is what the server sent and this parsed; the file is how the
+    /// next read avoids asking again. Failing here would report a machine's
+    /// own refusal as the fetch not landing, which is the one thing every
+    /// error out of this call means. The cost is a read that re-fetches
+    /// next time, which is what an unwritten cache is for.
     pub fn settle<T>(
         &self,
         cached: Option<(Generation, T)>,
@@ -129,13 +137,13 @@ impl<'e> GenerationFile<'e> {
         match response.status {
             200 => match parse(&response.body) {
                 Ok(value) => {
-                    self.write(&Generation {
+                    let _ = self.write(&Generation {
                         endpoint: base_url(),
                         credential: self.credential.clone(),
                         etag: response.etag,
                         fetched_at: now,
                         body: String::from_utf8_lossy(&response.body).into_owned(),
-                    })?;
+                    });
                     Ok(Loaded {
                         value,
                         fetched_at: now,
@@ -148,11 +156,11 @@ impl<'e> GenerationFile<'e> {
                 let (generation, value) = cached.ok_or_else(|| CoreError::RegistryMalformed {
                     why: "the server said 'unchanged' but nothing is cached".into(),
                 })?;
-                self.write(&Generation {
+                let _ = self.write(&Generation {
                     fetched_at: now,
                     credential: self.credential.clone(),
                     ..generation
-                })?;
+                });
                 Ok(Loaded {
                     value,
                     fetched_at: now,

--- a/crates/core/src/registry/me.rs
+++ b/crates/core/src/registry/me.rs
@@ -9,7 +9,7 @@ use serde::{Deserialize, Serialize};
 
 use crate::env::Env;
 use crate::error::{CoreError, Result};
-use crate::registry::client::{self, server_message};
+use crate::registry::client::{self, CallFailed, server_message};
 use crate::registry::credentials::{Credential, CredentialStore};
 use crate::registry::generation::GenerationFile;
 use crate::registry::{Fetch, base_url};
@@ -42,6 +42,33 @@ pub enum AccountState {
     Expired,
 }
 
+/// Why an account read could not answer at all.
+///
+/// [`AccountState`] is what a read settles on; this is the absence of an
+/// answer. A surface holding a name from an earlier read has to choose
+/// between showing it as the last one confirmed and saying nothing new
+/// was learned, and only the difference between "the directory did not
+/// answer" and "this machine refused" settles that choice.
+#[derive(Debug)]
+pub enum AccountUnread {
+    /// The directory was never asked: the credential store refused, the
+    /// refresh lock could not be taken, the cached identity could not be
+    /// dropped.
+    Local(CoreError),
+    /// The directory was asked and no identity could be settled from what
+    /// came back, with nothing cached to stand in.
+    Unreachable(CoreError),
+}
+
+impl AccountUnread {
+    /// The failure itself, for a surface that shows its sentence.
+    pub fn error(&self) -> &CoreError {
+        match self {
+            AccountUnread::Local(error) | AccountUnread::Unreachable(error) => error,
+        }
+    }
+}
+
 /// The wire shape of GET /api/v1/me, exactly as the contract fixture says.
 #[derive(Deserialize)]
 struct WireMe {
@@ -52,17 +79,23 @@ struct WireMe {
 /// Ask who is signed in. An absent credential is `SignedOut`; a dead credential is
 /// `Expired` and its cached identity is dropped; an unreachable or
 /// misbehaving server serves the cached identity as `Offline`, and errors
-/// only with nothing cached to serve. A keychain refusal that reaches this
-/// call on its own is none of those: it is local, so it errors with its own
-/// sentence however warm the cache is. One that refused the removal behind
-/// the server's rejection rides in that `SignInExpired`'s `why` and still
+/// only with nothing cached to serve. A failure on this machine is none of
+/// those: [`client::with_access`] hands back which half of the call failed,
+/// so a local one errors with its own sentence however warm the cache is
+/// and never reaches [`GenerationFile::settle`], whose whole domain is a
+/// fetch that did not land. A store that refused the removal behind the
+/// server's rejection rides in that `SignInExpired`'s `why` and still
 /// answers `Expired`. The cache key names the sign-in this read opened with
 /// rather than either token, so a refresh rotation leaves it readable. The
 /// store gets no final read after the authenticated call: a sign-out or
 /// account switch landing in that final request window does not change this
 /// call's answer.
-pub fn load(env: &Env, fetch: &dyn Fetch, store: &dyn CredentialStore) -> Result<AccountState> {
-    let Some(credential) = store.load()? else {
+pub fn load(
+    env: &Env,
+    fetch: &dyn Fetch,
+    store: &dyn CredentialStore,
+) -> std::result::Result<AccountState, AccountUnread> {
+    let Some(credential) = store.load().map_err(AccountUnread::Local)? else {
         return Ok(AccountState::SignedOut);
     };
     // The sign-in's own name, which a rotation carries and only a new
@@ -79,28 +112,33 @@ pub fn load(env: &Env, fetch: &dyn Fetch, store: &dyn CredentialStore) -> Result
     let fetched = match client::with_access(fetch, store, |access| {
         fetch.get_auth(&url, etag.as_deref(), Some(access))
     }) {
+        Ok(response) => Ok(response),
         // Logout won a race with this read: the re-login state without
         // refreshing, exactly as if the credential had been gone up front.
-        Err(CoreError::NotSignedIn) => return Ok(AccountState::SignedOut),
+        Err(CallFailed::NotSignedIn) => return Ok(AccountState::SignedOut),
         // Producing this removed whichever credential was current when the
         // removal lock was acquired, or said in `why` that the store would
         // not give it up. The identity this read opened with is forgotten;
         // another sign-in would discard it by key anyway.
-        Err(CoreError::SignInExpired { .. }) => {
-            cache.forget()?;
+        Err(CallFailed::Expired(_)) => {
+            cache.forget().map_err(AccountUnread::Local)?;
             return Ok(AccountState::Expired);
         }
-        // The keychain refused a read or a write somewhere inside the call.
+        // The machine refused before the directory was asked anything.
         // Serving the cache as `Offline` would tell the user the directory
-        // was last reached, when the machine never asked it anything.
-        Err(refused @ CoreError::CredentialStoreUnavailable { .. }) => return Err(refused),
-        fetched => fetched,
+        // was last reached, when nothing ever asked it.
+        Err(CallFailed::Local(error)) => return Err(AccountUnread::Local(error)),
+        // The directory was asked and did not answer usefully, which is
+        // exactly what a cached generation stands in for.
+        Err(CallFailed::Unreachable(error)) => Err(error),
     };
-    let loaded = cache.settle(cached, fetched, parse, |response| {
-        CoreError::RegistryUnavailable {
-            why: server_message(response),
-        }
-    })?;
+    let loaded = cache
+        .settle(cached, fetched, parse, |response| {
+            CoreError::RegistryUnavailable {
+                why: server_message(response),
+            }
+        })
+        .map_err(AccountUnread::Unreachable)?;
     Ok(match loaded.stale {
         false => AccountState::SignedIn {
             identity: loaded.value,

--- a/crates/core/src/registry/me.rs
+++ b/crates/core/src/registry/me.rs
@@ -51,12 +51,13 @@ pub enum AccountState {
 /// answer" and "this machine refused" settles that choice.
 #[derive(Debug)]
 pub enum AccountUnread {
-    /// The directory was never asked: the credential store refused, the
-    /// refresh lock could not be taken, the cached identity could not be
-    /// dropped.
+    /// This machine stopped the read: the credential store refused, the
+    /// refresh lock could not be taken, the request could not be sent, the
+    /// cached identity could not be dropped. Nothing came back from the
+    /// directory, so nothing is known about it.
     Local(CoreError),
-    /// The directory was asked and no identity could be settled from what
-    /// came back, with nothing cached to stand in.
+    /// A request reached the directory and no identity could be settled
+    /// from what came back, with nothing cached to stand in.
     Unreachable(CoreError),
 }
 
@@ -82,7 +83,7 @@ struct WireMe {
 /// only with nothing cached to serve. A failure on this machine is none of
 /// those: [`client::with_access`] hands back which half of the call failed,
 /// so a local one errors with its own sentence however warm the cache is
-/// and never reaches [`GenerationFile::settle`], whose whole domain is a
+/// and never reaches [`GenerationFile::settle`], whose every error is a
 /// fetch that did not land. A store that refused the removal behind the
 /// server's rejection rides in that `SignInExpired`'s `why` and still
 /// answers `Expired`. The cache key names the sign-in this read opened with
@@ -124,12 +125,12 @@ pub fn load(
             cache.forget().map_err(AccountUnread::Local)?;
             return Ok(AccountState::Expired);
         }
-        // The machine refused before the directory was asked anything.
-        // Serving the cache as `Offline` would tell the user the directory
-        // was last reached, when nothing ever asked it.
+        // This machine stopped the request this read needed. Serving the
+        // cache as `Offline` would tell the user the directory was last
+        // reached on some date, when nothing about it was ever in doubt.
         Err(CallFailed::Local(error)) => return Err(AccountUnread::Local(error)),
-        // The directory was asked and did not answer usefully, which is
-        // exactly what a cached generation stands in for.
+        // The request reached the directory and did not answer usefully,
+        // which is exactly what a cached generation stands in for.
         Err(CallFailed::Unreachable(error)) => Err(error),
     };
     let loaded = cache

--- a/crates/core/src/registry/me.rs
+++ b/crates/core/src/registry/me.rs
@@ -52,12 +52,12 @@ pub enum AccountState {
 #[derive(Debug)]
 pub enum AccountUnread {
     /// This machine stopped the read: the credential store refused, the
-    /// refresh lock could not be taken, the request could not be sent, the
-    /// cached identity could not be dropped. Nothing came back from the
-    /// directory, so nothing is known about it.
+    /// refresh lock could not be taken, the request could not be sent. An
+    /// earlier request may well have gone out and come back; the answer
+    /// this read needed did not, so nothing about the directory is known.
     Local(CoreError),
-    /// A request reached the directory and no identity could be settled
-    /// from what came back, with nothing cached to stand in.
+    /// The request went out and no identity could be settled from what
+    /// came back, with nothing cached to stand in.
     Unreachable(CoreError),
 }
 
@@ -121,16 +121,23 @@ pub fn load(
         // removal lock was acquired, or said in `why` that the store would
         // not give it up. The identity this read opened with is forgotten;
         // another sign-in would discard it by key anyway.
+        //
+        // A generation that will not delete is left where it is, for the
+        // same reason one that will not be written does not fail a read:
+        // the expiry is what this read learned, and reporting a refused
+        // unlink instead would leave the surface naming the person as
+        // signed in under a credential the server has already ended. What
+        // stays behind is keyed to a sign-in nothing will open with again.
         Err(CallFailed::Expired(_)) => {
-            cache.forget().map_err(AccountUnread::Local)?;
+            let _ = cache.forget();
             return Ok(AccountState::Expired);
         }
         // This machine stopped the request this read needed. Serving the
         // cache as `Offline` would tell the user the directory was last
         // reached on some date, when nothing about it was ever in doubt.
         Err(CallFailed::Local(error)) => return Err(AccountUnread::Local(error)),
-        // The request reached the directory and did not answer usefully,
-        // which is exactly what a cached generation stands in for.
+        // The request went out and no usable answer came back, which is
+        // exactly what a cached generation stands in for.
         Err(CallFailed::Unreachable(error)) => Err(error),
     };
     let loaded = cache

--- a/crates/core/tests/me_client/main.rs
+++ b/crates/core/tests/me_client/main.rs
@@ -475,6 +475,29 @@ fn a_cache_that_cannot_be_written_still_answers_the_fresh_name() {
     }
 }
 
+/// The same rule on the other side of the same file: the expiry is what
+/// this read learned, and a machine that will not let the cached identity
+/// go must not turn that into a refused unlink, leaving the surface naming
+/// someone as signed in under a credential the server has ended.
+#[test]
+fn an_expiry_survives_a_cache_that_cannot_be_dropped() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let root = rooted(&dir);
+    let env = env_in(&root);
+    let cache_dir = env.registry_cache_dir();
+    if let Some(parent) = cache_dir.parent() {
+        std::fs::create_dir_all(parent).expect("mkdir");
+    }
+    std::fs::write(&cache_dir, "not a directory").expect("plant");
+
+    let dead = Canned::new(vec![
+        ok(401, None, r#"{"error":"invalid_token"}"#),
+        ok(400, None, r#"{"error":"invalid_grant"}"#),
+    ]);
+    let state = me::load(&env, &dead, &MemoryStore::signed_in()).expect("expiry is the answer");
+    assert_eq!(state, AccountState::Expired);
+}
+
 #[test]
 fn network_away_with_nothing_cached_is_an_error() {
     let dir = tempfile::tempdir().expect("tempdir");

--- a/crates/core/tests/me_client/main.rs
+++ b/crates/core/tests/me_client/main.rs
@@ -418,27 +418,36 @@ fn a_local_failure_in_rotation_is_never_served_as_offline() {
 }
 
 /// A request the machine could not put out is not the directory going
-/// quiet. It lands on the first authenticated request of every read, ahead
-/// of the rotation branch, and the transport names it rather than leaving
-/// the seam to guess from where in the sequence it happened.
+/// quiet, at either of the two places a read sends one: the authenticated
+/// request every read makes, and the rotation POST behind a 401. The
+/// transport names it at the raising site rather than leaving the seam to
+/// guess from where in the sequence it happened.
 #[test]
 fn a_request_that_never_went_out_is_not_served_as_offline() {
-    let dir = tempfile::tempdir().expect("tempdir");
-    let root = rooted(&dir);
-    let env = env_in(&root);
-    let store = MemoryStore::signed_in();
-    let first = Canned::new(vec![ok(200, None, &fixture_body(&["success", "body"]))]);
-    me::load(&env, &first, &store).expect("first load");
+    // `Canned` serves one queue to both verbs, so the second answer is
+    // what the refresh POST gets.
+    let scripts: [fn() -> Vec<Result<FetchResponse>>; 2] = [
+        || vec![never_sent()],
+        || vec![ok(401, None, r#"{"error":"invalid_token"}"#), never_sent()],
+    ];
+    for script in scripts {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let root = rooted(&dir);
+        let env = env_in(&root);
+        let store = MemoryStore::signed_in();
+        let first = Canned::new(vec![ok(200, None, &fixture_body(&["success", "body"]))]);
+        me::load(&env, &first, &store).expect("first load");
 
-    let unsent = Canned::new(vec![never_sent()]);
-    let refused = me::load(&env, &unsent, &store).expect_err("an unsent request errors");
-    assert!(
-        matches!(
-            refused,
-            AccountUnread::Local(CoreError::CommandNotStarted { .. })
-        ),
-        "the cache stood in for a request that never went out: {refused:?}"
-    );
+        let unsent = Canned::new(script());
+        let refused = me::load(&env, &unsent, &store).expect_err("an unsent request errors");
+        assert!(
+            matches!(
+                refused,
+                AccountUnread::Local(CoreError::CommandNotStarted { .. })
+            ),
+            "the cache stood in for a request that never went out: {refused:?}"
+        );
+    }
 }
 
 /// The cache is how the next read avoids asking, never the answer itself.

--- a/crates/core/tests/me_client/main.rs
+++ b/crates/core/tests/me_client/main.rs
@@ -7,7 +7,7 @@
 //! is a `cmp` away.
 
 use std::cell::{Cell, RefCell};
-use std::path::Path;
+use std::path::{Path, PathBuf};
 
 #[path = "../../../test_util.rs"]
 mod test_util;
@@ -16,7 +16,7 @@ use test_util::rooted;
 use kendex_core::env::{Env, FakeOs};
 use kendex_core::error::{CoreError, Result};
 use kendex_core::registry::credentials::{Credential, CredentialRefreshGuard, CredentialStore};
-use kendex_core::registry::me::{self, AccountState};
+use kendex_core::registry::me::{self, AccountState, AccountUnread};
 use kendex_core::registry::{Fetch, FetchResponse};
 
 const FIXTURE: &str = include_str!("../fixtures/api-v1-me.json");
@@ -96,6 +96,9 @@ struct MemoryStore {
     /// after `load` has taken the sign-in and before the authenticated call
     /// takes it again.
     refuses_from: Option<u32>,
+    /// What `refresh_guard` answers instead of a guard, standing in for
+    /// the local failures `KeyringStore::refresh_guard` raises.
+    guard_refusal: Option<fn() -> CoreError>,
     reads: Cell<u32>,
 }
 
@@ -104,6 +107,7 @@ impl MemoryStore {
         MemoryStore {
             credential: RefCell::new(credential),
             refuses_from: None,
+            guard_refusal: None,
             reads: Cell::new(0),
         }
     }
@@ -125,6 +129,13 @@ impl MemoryStore {
     fn refusing_from(read: u32) -> MemoryStore {
         MemoryStore {
             refuses_from: Some(read),
+            ..MemoryStore::signed_in()
+        }
+    }
+
+    fn refusing_the_guard(refusal: fn() -> CoreError) -> MemoryStore {
+        MemoryStore {
+            guard_refusal: Some(refusal),
             ..MemoryStore::signed_in()
         }
     }
@@ -152,7 +163,10 @@ impl CredentialStore for MemoryStore {
         Ok(())
     }
     fn refresh_guard(&self) -> Result<Box<dyn CredentialRefreshGuard + '_>> {
-        Ok(Box::new(MemoryGuard))
+        match self.guard_refusal {
+            Some(refusal) => Err(refusal()),
+            None => Ok(Box::new(MemoryGuard)),
+        }
     }
 }
 
@@ -302,14 +316,54 @@ fn a_refusing_keychain_is_not_served_as_offline() {
     let refused = me::load(&env, &unused, &store).expect_err("a refusing keychain errors");
 
     assert!(
-        matches!(refused, CoreError::CredentialStoreUnavailable { .. }),
+        matches!(
+            refused,
+            AccountUnread::Local(CoreError::CredentialStoreUnavailable { .. })
+        ),
         "the cache stood in for the keychain: {refused:?}"
     );
     assert!(
-        !refused.to_string().contains("community directory"),
-        "the user is sent to check a working network: {refused}"
+        !refused.error().to_string().contains("community directory"),
+        "the user is sent to check a working network: {}",
+        refused.error()
     );
     assert_eq!(*unused.calls.borrow(), 0, "the directory was never asked");
+}
+
+/// The rest of the rotation branch's local failures, which the variant
+/// list this replaced never named: the transaction lock's parent could not
+/// be created or the lock itself could not be taken (`Io` — a read-only or
+/// full home, wrong permissions, a symlink at the path), and a second
+/// kendex process held the lock past the deadline
+/// (`CredentialRefreshBusy`). Both are this machine refusing, and a warm
+/// cache must answer for neither.
+#[test]
+fn a_local_failure_in_rotation_is_never_served_as_offline() {
+    const LOCK: &str = "/kendex/credentials.lock";
+    let refusals: [fn() -> CoreError; 2] = [
+        || CoreError::io(LOCK, std::io::Error::other("read-only file system")),
+        || CoreError::CredentialRefreshBusy {
+            lock: PathBuf::from(LOCK),
+        },
+    ];
+    for refusal in refusals {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let root = rooted(&dir);
+        let env = env_in(&root);
+        let warm = MemoryStore::signed_in();
+        let first = Canned::new(vec![ok(200, None, &fixture_body(&["success", "body"]))]);
+        me::load(&env, &first, &warm).expect("first load");
+
+        // The 401 is what sends the call into the rotation branch, which is
+        // where the refresh lock is taken.
+        let store = MemoryStore::refusing_the_guard(refusal);
+        let rejected = Canned::new(vec![ok(401, None, r#"{"error":"invalid_token"}"#)]);
+        let refused = me::load(&env, &rejected, &store).expect_err("a local refusal errors");
+        assert!(
+            matches!(refused, AccountUnread::Local(_)),
+            "the cache stood in for a failure on this machine: {refused:?}"
+        );
+    }
 }
 
 #[test]
@@ -548,7 +602,9 @@ fn a_304_with_nothing_cached_is_refused() {
     assert!(
         matches!(
             me::load(&env_in(dir.path()), &unchanged, &MemoryStore::signed_in()),
-            Err(CoreError::RegistryMalformed { .. })
+            Err(AccountUnread::Unreachable(
+                CoreError::RegistryMalformed { .. }
+            ))
         ),
         "an identity cannot be fabricated from 'unchanged'"
     );

--- a/crates/core/tests/me_client/main.rs
+++ b/crates/core/tests/me_client/main.rs
@@ -90,6 +90,16 @@ fn away() -> Result<FetchResponse> {
     })
 }
 
+/// The transport refusing to send at all — a curl config file it could not
+/// write, a curl it could not spawn. `registry.rs` raises exactly this
+/// shape, and only for a request that never went out.
+fn never_sent() -> Result<FetchResponse> {
+    Err(CoreError::CommandNotStarted {
+        label: "curl".to_owned(),
+        why: "No space left on device".to_owned(),
+    })
+}
+
 struct MemoryStore {
     credential: RefCell<Option<Credential>>,
     /// Which read starts refusing, counting from one: a keychain that locks
@@ -99,6 +109,10 @@ struct MemoryStore {
     /// What `refresh_guard` answers instead of a guard, standing in for
     /// the local failures `KeyringStore::refresh_guard` raises.
     guard_refusal: Option<fn() -> CoreError>,
+    /// What `save` answers instead of storing the rotated credential,
+    /// standing in for a keychain that takes the read and refuses the
+    /// write.
+    save_refusal: Option<fn() -> CoreError>,
     reads: Cell<u32>,
 }
 
@@ -108,6 +122,7 @@ impl MemoryStore {
             credential: RefCell::new(credential),
             refuses_from: None,
             guard_refusal: None,
+            save_refusal: None,
             reads: Cell::new(0),
         }
     }
@@ -139,10 +154,20 @@ impl MemoryStore {
             ..MemoryStore::signed_in()
         }
     }
+
+    fn refusing_the_save(refusal: fn() -> CoreError) -> MemoryStore {
+        MemoryStore {
+            save_refusal: Some(refusal),
+            ..MemoryStore::signed_in()
+        }
+    }
 }
 
 impl CredentialStore for MemoryStore {
     fn save(&self, credential: &Credential) -> Result<()> {
+        if let Some(refusal) = self.save_refusal {
+            return Err(refusal());
+        }
         *self.credential.borrow_mut() = Some(credential.clone());
         Ok(())
     }
@@ -333,20 +358,48 @@ fn a_refusing_keychain_is_not_served_as_offline() {
 /// The rest of the rotation branch's local failures, which the variant
 /// list this replaced never named: the transaction lock's parent could not
 /// be created or the lock itself could not be taken (`Io` — a read-only or
-/// full home, wrong permissions, a symlink at the path), and a second
-/// kendex process held the lock past the deadline
-/// (`CredentialRefreshBusy`). Both are this machine refusing, and a warm
-/// cache must answer for neither.
+/// full home, wrong permissions, a symlink at the path), a second kendex
+/// process held the lock past the deadline (`CredentialRefreshBusy`), and
+/// the keychain that gave the credential up would not store the rotated
+/// one (`CredentialStoreUnavailable`). Each is this machine refusing, and
+/// a warm cache must answer for none of them.
 #[test]
 fn a_local_failure_in_rotation_is_never_served_as_offline() {
     const LOCK: &str = "/kendex/credentials.lock";
-    let refusals: [fn() -> CoreError; 2] = [
-        || CoreError::io(LOCK, std::io::Error::other("read-only file system")),
-        || CoreError::CredentialRefreshBusy {
-            lock: PathBuf::from(LOCK),
-        },
+    const REJECTED: &str = r#"{"error":"invalid_token"}"#;
+    const ROTATED: &str =
+        r#"{"access_token":"kxa_new","refresh_token":"kxr_new","capabilities":[]}"#;
+    // The store that refuses, paired with the answers the call needs to
+    // reach it: a 401 is what sends it into the rotation branch, and a
+    // refused save is reached only once the refresh has come back.
+    type Case = (fn() -> MemoryStore, fn() -> Vec<Result<FetchResponse>>);
+    let cases: [Case; 3] = [
+        (
+            || {
+                MemoryStore::refusing_the_guard(|| {
+                    CoreError::io(LOCK, std::io::Error::other("read-only file system"))
+                })
+            },
+            || vec![ok(401, None, REJECTED)],
+        ),
+        (
+            || {
+                MemoryStore::refusing_the_guard(|| CoreError::CredentialRefreshBusy {
+                    lock: PathBuf::from(LOCK),
+                })
+            },
+            || vec![ok(401, None, REJECTED)],
+        ),
+        (
+            || {
+                MemoryStore::refusing_the_save(|| CoreError::CredentialStoreUnavailable {
+                    why: "the rotated sign-in could not be stored".to_owned(),
+                })
+            },
+            || vec![ok(401, None, REJECTED), ok(200, None, ROTATED)],
+        ),
     ];
-    for refusal in refusals {
+    for (refusing, answers) in cases {
         let dir = tempfile::tempdir().expect("tempdir");
         let root = rooted(&dir);
         let env = env_in(&root);
@@ -354,15 +407,62 @@ fn a_local_failure_in_rotation_is_never_served_as_offline() {
         let first = Canned::new(vec![ok(200, None, &fixture_body(&["success", "body"]))]);
         me::load(&env, &first, &warm).expect("first load");
 
-        // The 401 is what sends the call into the rotation branch, which is
-        // where the refresh lock is taken.
-        let store = MemoryStore::refusing_the_guard(refusal);
-        let rejected = Canned::new(vec![ok(401, None, r#"{"error":"invalid_token"}"#)]);
+        let store = refusing();
+        let rejected = Canned::new(answers());
         let refused = me::load(&env, &rejected, &store).expect_err("a local refusal errors");
         assert!(
             matches!(refused, AccountUnread::Local(_)),
             "the cache stood in for a failure on this machine: {refused:?}"
         );
+    }
+}
+
+/// A request the machine could not put out is not the directory going
+/// quiet. It lands on the first authenticated request of every read, ahead
+/// of the rotation branch, and the transport names it rather than leaving
+/// the seam to guess from where in the sequence it happened.
+#[test]
+fn a_request_that_never_went_out_is_not_served_as_offline() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let root = rooted(&dir);
+    let env = env_in(&root);
+    let store = MemoryStore::signed_in();
+    let first = Canned::new(vec![ok(200, None, &fixture_body(&["success", "body"]))]);
+    me::load(&env, &first, &store).expect("first load");
+
+    let unsent = Canned::new(vec![never_sent()]);
+    let refused = me::load(&env, &unsent, &store).expect_err("an unsent request errors");
+    assert!(
+        matches!(
+            refused,
+            AccountUnread::Local(CoreError::CommandNotStarted { .. })
+        ),
+        "the cache stood in for a request that never went out: {refused:?}"
+    );
+}
+
+/// The cache is how the next read avoids asking, never the answer itself.
+/// A machine that cannot write it has still been told who is signed in, and
+/// reporting that as a read that did not land would serve the identity it
+/// just parsed back as `Offline` — the same lie, from the far side of the
+/// call. The cache directory's path is taken by a regular file here, which
+/// `create_dir_all` refuses whatever the process's euid.
+#[test]
+fn a_cache_that_cannot_be_written_still_answers_the_fresh_name() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let root = rooted(&dir);
+    let env = env_in(&root);
+    let cache_dir = env.registry_cache_dir();
+    if let Some(parent) = cache_dir.parent() {
+        std::fs::create_dir_all(parent).expect("mkdir");
+    }
+    std::fs::write(&cache_dir, "not a directory").expect("plant");
+
+    let fetch = Canned::new(vec![ok(200, None, &fixture_body(&["success", "body"]))]);
+    let state = me::load(&env, &fetch, &MemoryStore::signed_in()).expect("the read landed");
+    match state {
+        AccountState::SignedIn { identity } => assert_eq!(identity.name, "Ada Lovelace"),
+        other => panic!("an unwritable cache lost the answer the server gave: {other:?}"),
     }
 }
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -727,10 +727,10 @@ lives in one capability table read by core and UI.
   `KENDEX_API`); tests inject transports. Bearer calls route through `registry/client.rs`: one
   named cross-process lock serializes login, logout and refresh rotation, saving rotations
   before retry; a rejected request re-takes it to clear the current credential. A call that
-  did not answer is typed by which half failed (`CallFailed`), so only a call that reached the
-  directory may be stood in for by a stale generation and a refusal on this machine reaches the
-  account surfaces as a read that failed rather than as offline. A generation the machine could
-  not write never fails a read the server answered. `skillssh.rs`
+  did not answer is typed by which half failed (`CallFailed`), so only a request that went out may
+  be stood in for by a stale generation and a refusal on this machine reaches the account surfaces
+  as a read that failed rather than as offline. A generation the machine could not write or delete
+  never fails a read. `skillssh.rs`
   pins its public wire schema and kill switch (`KENDEX_SKILLSSH=off`); a hit
   is a lead, never an identity, and installs through the same subscribe path.
   Collections install through `add`.

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -727,9 +727,10 @@ lives in one capability table read by core and UI.
   `KENDEX_API`); tests inject transports. Bearer calls route through `registry/client.rs`: one
   named cross-process lock serializes login, logout and refresh rotation, saving rotations
   before retry; a rejected request re-takes it to clear the current credential. A call that
-  did not answer is typed by which half failed (`CallFailed`), so only one the server answered
-  may be stood in for by a stale generation and a refusal on this machine reaches the account
-  surfaces as a read that failed rather than as offline. `skillssh.rs`
+  did not answer is typed by which half failed (`CallFailed`), so only a call that reached the
+  directory may be stood in for by a stale generation and a refusal on this machine reaches the
+  account surfaces as a read that failed rather than as offline. A generation the machine could
+  not write never fails a read the server answered. `skillssh.rs`
   pins its public wire schema and kill switch (`KENDEX_SKILLSSH=off`); a hit
   is a lead, never an identity, and installs through the same subscribe path.
   Collections install through `add`.

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -726,7 +726,10 @@ lives in one capability table read by core and UI.
   expiry. All reads go through the `Fetch` trait (curl via `Hardened`, plain http only under
   `KENDEX_API`); tests inject transports. Bearer calls route through `registry/client.rs`: one
   named cross-process lock serializes login, logout and refresh rotation, saving rotations
-  before retry; a rejected request re-takes it to clear the current credential. `skillssh.rs`
+  before retry; a rejected request re-takes it to clear the current credential. A call that
+  did not answer is typed by which half failed (`CallFailed`), so only one the server answered
+  may be stood in for by a stale generation and a refusal on this machine reaches the account
+  surfaces as a read that failed rather than as offline. `skillssh.rs`
   pins its public wire schema and kill switch (`KENDEX_SKILLSSH=off`); a hit
   is a lead, never an identity, and installs through the same subscribe path.
   Collections install through `add`.

--- a/tools/size-ratchet-baseline.tsv
+++ b/tools/size-ratchet-baseline.tsv
@@ -3,7 +3,7 @@
 crates/core/src/engine/deps.rs	455
 crates/core/src/engine/detach.rs	417
 crates/core/src/engine/expansion.rs	414
-crates/core/src/error.rs	501
+crates/core/src/error.rs	517
 crates/core/src/mapping.rs	411
 crates/core/src/settings_file.rs	408
 pi-extensions/pi-agents-tmux/extensions/subagent/browser.ts	650

--- a/ui/src/bindings.ts
+++ b/ui/src/bindings.ts
@@ -509,10 +509,11 @@ export type AccountCallRefused = { kind: "expired"; message: string } | { kind: 
  * 
  *  The two are one question the surface has to answer: may the name from
  *  the last read stand as the last one kendex.ai confirmed? Only a read
- *  whose request reached the directory and came back with nothing leaves
- *  it standing; one this machine stopped learned nothing about the
- *  directory, and showing the name as offline would name the wrong cause
- *  and send the person to check a working network.
+ *  whose request went out and came back with nothing leaves it standing —
+ *  a network with no route to kendex.ai included, since the machine did
+ *  ask. One this machine stopped never asked, so it learned nothing, and
+ *  showing the name as offline would name the wrong cause and send the
+ *  person to check a working network.
  * 
  *  Each carries the whole sentence, because the surface that shows it has
  *  nothing else to say. It is named here rather than on the variants

--- a/ui/src/bindings.ts
+++ b/ui/src/bindings.ts
@@ -332,7 +332,7 @@ export const commands = {
 	 *  text the repository publishes.
 	 */
 	mineAuthoringDoc: () => __TAURI_INVOKE<string>("mine_authoring_doc"),
-	accountStatus: () => typedError<AccountStatus, string>(__TAURI_INVOKE("account_status")),
+	accountStatus: () => typedError<AccountStatus, AccountReadFailed>(__TAURI_INVOKE("account_status")),
 	accountLoginStart: () => typedError<LoginStart, string>(__TAURI_INVOKE("account_login_start")),
 	/**  One poll; the frontend owns the timer so a closed dialog stops asking. */
 	accountLoginPoll: (deviceCode: string) => typedError<LoginPoll, string>(__TAURI_INVOKE("account_login_poll", { deviceCode })),
@@ -503,6 +503,22 @@ export type AboutView = {
  *  describing `Failed` too.
  */
 export type AccountCallRefused = { kind: "expired"; message: string } | { kind: "failed"; message: string };
+
+/**
+ *  Why the account could not be read.
+ * 
+ *  The two are one question the surface has to answer: may the name from
+ *  the last read stand as the last one kendex.ai confirmed? Only a read
+ *  that reached the directory and came back with nothing leaves it
+ *  standing; one this machine refused says nothing about the directory,
+ *  and showing the name as offline would name the wrong cause and send
+ *  the person to check a working network.
+ * 
+ *  Each carries the whole sentence, because the surface that shows it has
+ *  nothing else to say. It is named here rather than on the variants
+ *  because specta hoists a variant's doc above the whole union.
+ */
+export type AccountReadFailed = { kind: "local"; message: string } | { kind: "unreachable"; message: string };
 
 /**
  *  What the account surfaces render, every one of them settled: the UI

--- a/ui/src/bindings.ts
+++ b/ui/src/bindings.ts
@@ -509,10 +509,10 @@ export type AccountCallRefused = { kind: "expired"; message: string } | { kind: 
  * 
  *  The two are one question the surface has to answer: may the name from
  *  the last read stand as the last one kendex.ai confirmed? Only a read
- *  that reached the directory and came back with nothing leaves it
- *  standing; one this machine refused says nothing about the directory,
- *  and showing the name as offline would name the wrong cause and send
- *  the person to check a working network.
+ *  whose request reached the directory and came back with nothing leaves
+ *  it standing; one this machine stopped learned nothing about the
+ *  directory, and showing the name as offline would name the wrong cause
+ *  and send the person to check a working network.
  * 
  *  Each carries the whole sentence, because the surface that shows it has
  *  nothing else to say. It is named here rather than on the variants

--- a/ui/src/stores/account-read.ts
+++ b/ui/src/stores/account-read.ts
@@ -3,12 +3,22 @@
 // The store keeps what the last read settled on; this is the read itself —
 // the command, the rename from its wire shape, and the seam a test takes
 // over to answer as a state no server is behind.
-import { type AccountStatus, commands } from "@/bindings";
+import {
+  type AccountReadFailed,
+  type AccountStatus,
+  commands,
+} from "@/bindings";
 import type { SettledAccount } from "./account";
 
 /** What a read of the account answers: the state it settled on, or why it
- * could not be read. */
-export type AccountRead = { ok: SettledAccount } | { error: string };
+ * could not be read.
+ *
+ * `kind` is whether kendex.ai was asked at all, which is the backend's to
+ * say and not something a reason can be read for. Only a read that reached
+ * it leaves the name it had standing as last-confirmed. */
+export type AccountRead =
+  | { ok: SettledAccount }
+  | { error: string; kind: AccountReadFailed["kind"] };
 
 type ReadAccount = () => Promise<AccountRead>;
 
@@ -32,7 +42,8 @@ const settled = (wire: AccountStatus["state"]): SettledAccount => {
  * and with the rejection when the credential is dead. */
 const fromBridge: ReadAccount = async () => {
   const status = await commands.accountStatus();
-  if (status.status === "error") return { error: status.error };
+  if (status.status === "error")
+    return { error: status.error.message, kind: status.error.kind };
   return { ok: settled(status.data.state) };
 };
 
@@ -59,6 +70,8 @@ export const readAccount: ReadAccount = async () => {
   try {
     return await reader();
   } catch (error: unknown) {
-    return { error: String(error) };
+    // A reader that threw never got an answer out of the backend, so
+    // nothing was asked of kendex.ai on the far side of it either.
+    return { error: String(error), kind: "local" };
   }
 };

--- a/ui/src/stores/account-state.ts
+++ b/ui/src/stores/account-state.ts
@@ -31,10 +31,13 @@ type WithIdentity = Extract<AccountState, { kind: "signed-in" | "offline" }>;
 export const hasCredential = (account: AccountState): account is WithIdentity =>
   account.kind === "signed-in" || account.kind === "offline";
 
-/** The same credential, no longer confirmed: what a read that failed
- *  leaves when it already knew who holds it. Null when there is nothing
- *  to go offline with, which is a credential whose name has not been read
- *  yet, or no credential at all. */
+/** The same credential, no longer confirmed: what a read that reached
+ *  kendex.ai and came back with nothing leaves when it already knew who
+ *  holds it. Reserved for that read. A failure on this machine never gets
+ *  here — the directory was not asked, so "when kendex.ai was last
+ *  reached" would name a cause nothing observed. Null when there is
+ *  nothing to go offline with, which is a credential whose name has not
+ *  been read yet, or no credential at all. */
 export const asOffline = (account: AccountState): SettledAccount | null =>
   hasCredential(account) && account.identity
     ? { kind: "offline", identity: account.identity }

--- a/ui/src/stores/account-state.ts
+++ b/ui/src/stores/account-state.ts
@@ -31,13 +31,14 @@ type WithIdentity = Extract<AccountState, { kind: "signed-in" | "offline" }>;
 export const hasCredential = (account: AccountState): account is WithIdentity =>
   account.kind === "signed-in" || account.kind === "offline";
 
-/** The same credential, no longer confirmed: what a read that reached
- *  kendex.ai and came back with nothing leaves when it already knew who
- *  holds it. Reserved for that read. A failure on this machine never gets
- *  here — the directory was not asked, so "when kendex.ai was last
- *  reached" would name a cause nothing observed. Null when there is
- *  nothing to go offline with, which is a credential whose name has not
- *  been read yet, or no credential at all. */
+/** The same credential, no longer confirmed: what a read whose request
+ *  went out and came back with nothing leaves when it already knew who
+ *  holds it. Reserved for that read, a network with no route to kendex.ai
+ *  included, since the machine did ask. A failure on this machine never
+ *  gets here — the answer this read needed was never asked for, so "when
+ *  kendex.ai was last reached" would name a cause nothing observed. Null
+ *  when there is nothing to go offline with, which is a credential whose
+ *  name has not been read yet, or no credential at all. */
 export const asOffline = (account: AccountState): SettledAccount | null =>
   hasCredential(account) && account.identity
     ? { kind: "offline", identity: account.identity }

--- a/ui/src/stores/account.test.ts
+++ b/ui/src/stores/account.test.ts
@@ -187,6 +187,10 @@ describe("a read that could not be made", () => {
   // their type promises. A reader that throws instead would otherwise leave
   // the read with nothing recorded, nothing to retry from, and a rejection
   // nobody catches: every caller of load says `void load()`.
+  //
+  // A throw is also a read that never reached kendex.ai, whatever failed
+  // behind it, so it must leave a name already in hand where it is rather
+  // than aging the account into offline.
   it("records any reader that threw rather than answered", async () => {
     setAccountReader(async () => {
       throw new Error("the harness reader threw");
@@ -197,6 +201,12 @@ describe("a read that could not be made", () => {
       "the harness reader threw",
     );
     expect(useAccountStore.getState().reading).toBe(false);
+
+    useAccountStore.setState({
+      account: { kind: "signed-in", identity: ADA },
+    });
+    await load();
+    expect(account()).toEqual({ kind: "signed-in", identity: ADA });
   });
 });
 

--- a/ui/src/stores/account.test.ts
+++ b/ui/src/stores/account.test.ts
@@ -113,14 +113,30 @@ describe("the account state a read settles on", () => {
 
 // A read that failed knows nothing new, so it takes nothing away.
 describe("a read that could not be made", () => {
-  it("becomes offline when a name is already in hand", async () => {
+  it("becomes offline when the directory was asked and a name is in hand", async () => {
+    useAccountStore.setState({
+      account: { kind: "signed-in", identity: ADA },
+    });
+    unreadable("no route to kendex.ai", "unreachable");
+    await load();
+    expect(account()).toEqual({
+      kind: "offline",
+      identity: ADA,
+    });
+    expect(useAccountStore.getState().readError).toBe("no route to kendex.ai");
+  });
+
+  // Offline says kendex.ai was reached on some date and not since. A
+  // refusal on this machine never asked it anything, so the state stands
+  // as the last read left it and the reason is all this one adds.
+  it("leaves the name it had alone when the machine refused", async () => {
     useAccountStore.setState({
       account: { kind: "signed-in", identity: ADA },
     });
     unreadable();
     await load();
     expect(account()).toEqual({
-      kind: "offline",
+      kind: "signed-in",
       identity: ADA,
     });
     expect(useAccountStore.getState().readError).toBe("keychain locked");

--- a/ui/src/stores/account.ts
+++ b/ui/src/stores/account.ts
@@ -119,10 +119,14 @@ export const useAccountStore = create<AccountStore>((set, get) => ({
     if (handover.stale(before)) return;
     if ("error" in answer) {
       // A read that failed knows nothing new, so it never takes anything
-      // away. With an identity already in hand the failure is exactly
-      // offline; a credential without a name stays signed in, and a state
-      // never read stays unread with the failure to show for it.
-      const offline = asOffline(get().account);
+      // away. Where it reached kendex.ai and came back with nothing, an
+      // identity already in hand is exactly offline; a credential without
+      // a name stays signed in, and a state never read stays unread with
+      // the failure to show for it. A failure on this machine settles
+      // nothing about the directory, so it leaves every state alone and
+      // the reason is all it adds.
+      const offline =
+        answer.kind === "unreachable" ? asOffline(get().account) : null;
       const readError = answer.error;
       set(offline ? { account: offline, readError } : { readError });
       return;

--- a/ui/src/test/account-store.ts
+++ b/ui/src/test/account-store.ts
@@ -4,7 +4,11 @@
 // Each test file installs its own `vi.mock("@/bindings", ...)`; the
 // helpers here read through whichever mock the importing file set up.
 import { vi } from "vitest";
-import { type AccountStatus, commands } from "@/bindings";
+import {
+  type AccountReadFailed,
+  type AccountStatus,
+  commands,
+} from "@/bindings";
 import { type SettledAccount, useAccountStore } from "@/stores/account";
 import { setAccountReader } from "@/stores/account-read";
 
@@ -18,10 +22,16 @@ export const answers = (state: AccountStatus["state"]) =>
     data: { state, endpoint: "https://kendex.ai" },
   } as Awaited<ReturnType<typeof commands.accountStatus>>);
 
-export const unreadable = (why = "keychain locked") =>
+/** What the command answers when the read did not land. The default is a
+ *  refusal on this machine, which is the failure that says nothing about
+ *  kendex.ai; pass `"unreachable"` for the directory not answering. */
+export const unreadable = (
+  why = "keychain locked",
+  kind: AccountReadFailed["kind"] = "local",
+) =>
   vi.mocked(commands.accountStatus).mockResolvedValue({
     status: "error",
-    error: why,
+    error: { kind, message: why },
   } as Awaited<ReturnType<typeof commands.accountStatus>>);
 
 /** What a backend that has reached the server answers with. */


### PR DESCRIPTION
## Summary

- A local failure inside `me::load` no longer reaches `GenerationFile::settle` by construction rather than by a list of variant names. `client::with_access` answers a typed `CallFailed`, `me::load` answers `AccountUnread`, and `crates/app` carries the split across as `AccountReadFailed` — so only a call the directory actually answered can be stood in for by a stale generation.
- The transport says whether the request went out. `Hardened::run` raises `CoreError::CommandNotStarted` for a command that never ran, the registry transport raises it for a curl config it could not write, and `sent()` reads that one name in one place. A full disk or an unspawnable curl is no longer reported as the directory being away — on the first authenticated request of every read, and on the rotation POST.
- A generation the machine cannot write, or cannot delete, no longer fails the read. `GenerationFile::write` is infallible and swallows internally; the `Expired` arm ignores a refused `forget` and still answers `Expired`. The cache is how the next read avoids asking, not the answer.
- On the UI half, the store gates `asOffline` on the failure kind, so a refusal on this machine leaves the settled state where it was and shows its own sentence beside the retry instead of claiming kendex.ai was last reached on some date.

## Completed Issues

- Closes KEN-1160 - A local failure still reads as a directory outage

## Test Plan

- `tools/guard` exit 0 on the rebased head: fmt, clippy, doc, `cargo test --workspace`, tsc, biome, and 1127 UI tests across 142 files.
- `preflight --base origin/main` clean across 19 changed files; size-ratchet clean, with `crates/core/src/error.rs` declared at 517 (`RATCHET_RAISE` for `CommandNotStarted` and its constructor, composed with the raise main landed independently).
- Controls added, one per surface, each shown to fail when its behaviour is reverted: the app-side `AccountUnread → AccountReadFailed` mapper; a refused credential save in the rotation branch; a request that never went out, on both the first call and the refresh POST; a cache that cannot be written; an expiry whose cache cannot be dropped; a real spawn failure through `Hardened::program`; and a seeded assertion holding the UI's thrown-reader case.
- The expiry control's refusal is euid-independent by construction (a directory planted where the generation file goes, `EISDIR`), so it cannot pass silently under a root CI — verified with the mutant still failing at euid 0 under `unshare -Ur`.

## Review

Nine reviewers over three cycles plus a focused verification pass: 24 findings, 22 unique after dedupe, all 22 fixed. No findings escalated, declined, or filed. Two root causes were closed structurally rather than patched per site — the transport's local/remote split now happens where the failure is raised, and `GenerationFile::write` cannot reintroduce the class it once carried.

Known gap, stated rather than papered over: the `registry.rs` curl-config producer of `CommandNotStarted` is pinned only through the spawn-side control. Driving it for real needs process-global `TMPDIR` mutation, which is racy against the parallel suite and unsafe in edition 2024; it is a single `map_err` on the name the spawn control does pin.

https://claude.ai/code/session_01QjAJpyw2uTvhdMmRJYxRNr
