### PR TITLE
fix(KEN-1203): the md-refs paths key carries its own comment block

### DIFF
--- a/.agents/skills/growth-guards/kendex.settings.toml.example
+++ b/.agents/skills/growth-guards/kendex.settings.toml.example
@@ -47,6 +47,10 @@ GROWTH_GUARDS_MD_SCOPE = "touched"
 # path. GROWTH_GUARDS_MD_EXCLUDES (default tools/md-excludes, pattern<TAB>reason
 # rows) drops vendored or generated markdown from both.
 GROWTH_GUARDS_MD_PATHS = "*.md"
+
+# The markdown md-refs judges under --all: the agent-loaded files and the
+# architecture docs, space-separated shell globs against the full
+# repo-relative path.
 GROWTH_GUARDS_MD_REFS_PATHS = "AGENTS.md */AGENTS.md CLAUDE.md */CLAUDE.md SKILL.md */SKILL.md workflows/*.md */workflows/*.md agents/*.md */agents/*.md docs/architecture/*.md"
 
 # The source files the comments lane reads, a space-separated list of shell

--- a/skills/growth-guards/kendex.settings.toml.example
+++ b/skills/growth-guards/kendex.settings.toml.example
@@ -47,6 +47,10 @@ GROWTH_GUARDS_MD_SCOPE = "touched"
 # path. GROWTH_GUARDS_MD_EXCLUDES (default tools/md-excludes, pattern<TAB>reason
 # rows) drops vendored or generated markdown from both.
 GROWTH_GUARDS_MD_PATHS = "*.md"
+
+# The markdown md-refs judges under --all: the agent-loaded files and the
+# architecture docs, space-separated shell globs against the full
+# repo-relative path.
 GROWTH_GUARDS_MD_REFS_PATHS = "AGENTS.md */AGENTS.md CLAUDE.md */CLAUDE.md SKILL.md */SKILL.md workflows/*.md */workflows/*.md agents/*.md */agents/*.md docs/architecture/*.md"
 
 # The source files the comments lane reads, a space-separated list of shell


### PR DESCRIPTION
The strict catalog check on main refused the growth-guards settings example: the md-refs paths key had no comment block above it after the lane merge. One comment block; the check passes with 0 advisory. Tracking: KEN-1203.

https://claude.ai/code/session_01LbVeBZNo3nBLtjiNcRG2JA