### PR TITLE
fix(KEN-1203): prose scans architecture docs once the repo says all

### DIFF
--- a/.agents/skills/growth-guards/CHECKS.md
+++ b/.agents/skills/growth-guards/CHECKS.md
@@ -82,7 +82,7 @@ Lines joined with CR stripped, whitespace runs collapsed to one space, trimmed, 
 
 A history reference in a scanned markdown file fails: a calendar date (`20YY-MM-DD`), a three- or four-digit issue number after `#`, or one of `previously`, `used to`, `no longer`, `reverted`, `an earlier`, `earlier round`, `incident`, `historically`, `originally`, `at the time`. Matching is case-insensitive and whole-word (`incidental`, `unreverted` do not fire). The issue-number shape takes no leading boundary (`<file>.md#1204` fires), and the character after the digits must be neither a digit nor a hex letter (`#12345`, `#1234ab`, `#0088cc` pass). A decision ID (`D042`) carries no `#` and never fires.
 
-Scope is `GROWTH_GUARDS_PROSE_PATHS`; there is no excludes list. The default, each name spelled twice because `*` crosses `/` but never stands in for the separator:
+Scope is `GROWTH_GUARDS_PROSE_PATHS`; there is no excludes list. `docs/architecture/*.md` joins the default only under `GROWTH_GUARDS_MD_SCOPE=all`, the switch a repository flips once its markdown is rewritten; an explicit path list is used as given. The default, each name spelled twice because `*` crosses `/` but never stands in for the separator:
 
 ```
 SKILL.md */SKILL.md AGENTS.md */AGENTS.md CLAUDE.md */CLAUDE.md workflows/*.md */workflows/*.md agents/*.md */agents/*.md docs/architecture/*.md

--- a/.agents/skills/growth-guards/scripts/prose
+++ b/.agents/skills/growth-guards/scripts/prose
@@ -40,8 +40,13 @@ source "$SCRIPT_DIR/lib/settings.sh"
 # because `*` crosses `/` but never stands in for the separator itself, and
 # the second spelling is also what reaches a rendered copy under `.claude/`
 # or `.agents/`. The architecture docs those files point at are loaded the
-# same way, so they hold the same rule.
-PATHS_DEFAULT="SKILL.md */SKILL.md AGENTS.md */AGENTS.md CLAUDE.md */CLAUDE.md workflows/*.md */workflows/*.md agents/*.md */agents/*.md docs/architecture/*.md"
+# same way, so they hold the same rule — once the repository says its
+# markdown is rewritten (GROWTH_GUARDS_MD_SCOPE=all, the switch the markdown
+# lanes read); before that a repository's architecture docs are what the
+# rewrite is for, and this lane has no staged scope to spare them.
+PATHS_CORE="SKILL.md */SKILL.md AGENTS.md */AGENTS.md CLAUDE.md */CLAUDE.md workflows/*.md */workflows/*.md agents/*.md */agents/*.md"
+PATHS_ARCH="docs/architecture/*.md"
+PATHS_DEFAULT="$PATHS_CORE $PATHS_ARCH"
 
 usage() {
   cat <<EOF
@@ -77,6 +82,12 @@ fi
 
 gg_repo_root_cd
 
+MD_SCOPE="$(gg_setting GROWTH_GUARDS_MD_SCOPE touched)" || exit 2
+case "$MD_SCOPE" in
+  all) ;;
+  touched) PATHS_DEFAULT="$PATHS_CORE" ;;
+  *) gg_config_error "GROWTH_GUARDS_MD_SCOPE must be 'touched' or 'all', got '$(gg_scrubbed "$MD_SCOPE")'" ;;
+esac
 PATHS_RAW="$(gg_setting GROWTH_GUARDS_PROSE_PATHS "$PATHS_DEFAULT")" || exit 2
 
 # The path list, its validation and its matcher are the family's, shared with

--- a/.agents/skills/growth-guards/tests/prose.test.sh
+++ b/.agents/skills/growth-guards/tests/prose.test.sh
@@ -120,11 +120,19 @@ new_repo scope
 put SKILL.md 'clean'
 for f in SKILL.md AGENTS.md CLAUDE.md skills/dev/SKILL.md skills/dev/AGENTS.md skills/dev/CLAUDE.md workflows/ship.md skills/dev/workflows/ship.md agents/rust.md .claude/agents/rust.md docs/architecture/overview.md docs/architecture/topic.md; do
   put "$f" 'Seeded 2026-08-12.'
-  run_prose
+  GROWTH_GUARDS_MD_SCOPE=all run_prose
   [ "$RC" -eq 1 ] && case "$OUT" in *"history reference: $f:1:"*) true ;; *) false ;; esac \
     && ok "$f is in the default scope" || bad "$f is in the default scope" "rc=$RC out=$OUT"
   put "$f" 'clean'
 done
+put docs/architecture/overview.md 'Seeded 2026-08-12.'
+run_prose
+[ "$RC" -eq 0 ] && ok "under GROWTH_GUARDS_MD_SCOPE=touched the architecture docs are not yet in scope" \
+  || bad "architecture docs wait for scope all" "rc=$RC out=$OUT"
+GROWTH_GUARDS_MD_SCOPE=all run_prose
+[ "$RC" -eq 1 ] && case "$OUT" in *"history reference: docs/architecture/overview.md:1:"*) true ;; *) false ;; esac \
+  && ok "control: under scope all the same file fails" || bad "control: scope all scans architecture docs" "rc=$RC out=$OUT"
+put docs/architecture/overview.md 'clean'
 run_prose
 [ "$RC" -eq 0 ] && ok "control: with every scoped file clean, the scan passes" \
   || bad "control: scoped files clean" "rc=$RC out=$OUT"
@@ -134,8 +142,8 @@ done
 run_prose
 # The count is asserted with the status: a scan that matched NOTHING also
 # exits 0, and would satisfy a bare rc check while proving nothing.
-[ "$RC" -eq 0 ] && case "$OUT" in *"prose: OK — no history references in 12 scanned file(s)"*) true ;; *) false ;; esac \
-  && ok "README, CHECKS, docs, CHANGELOG, references and a workflows-named file keep their history, with the twelve scoped files still read" \
+[ "$RC" -eq 0 ] && case "$OUT" in *"prose: OK — no history references in 10 scanned file(s)"*) true ;; *) false ;; esac \
+  && ok "README, CHECKS, docs, CHANGELOG, references and a workflows-named file keep their history, with the ten scoped files still read" \
   || bad "out-of-scope files keep their history" "rc=$RC out=$OUT"
 
 echo "=== GROWTH_GUARDS_PROSE_PATHS REPLACES the list (and that is provable) ==="

--- a/changelog.d/changed/KEN-1203-prose-arch-scope.md
+++ b/changelog.d/changed/KEN-1203-prose-arch-scope.md
@@ -1,0 +1,1 @@
+- The prose lane scans `docs/architecture/*.md` by default only once a repo sets `GROWTH_GUARDS_MD_SCOPE = "all"`, so a consumer's commits are not blocked before its docs rewrite.

--- a/skills/growth-guards/CHECKS.md
+++ b/skills/growth-guards/CHECKS.md
@@ -82,7 +82,7 @@ Lines joined with CR stripped, whitespace runs collapsed to one space, trimmed, 
 
 A history reference in a scanned markdown file fails: a calendar date (`20YY-MM-DD`), a three- or four-digit issue number after `#`, or one of `previously`, `used to`, `no longer`, `reverted`, `an earlier`, `earlier round`, `incident`, `historically`, `originally`, `at the time`. Matching is case-insensitive and whole-word (`incidental`, `unreverted` do not fire). The issue-number shape takes no leading boundary (`<file>.md#1204` fires), and the character after the digits must be neither a digit nor a hex letter (`#12345`, `#1234ab`, `#0088cc` pass). A decision ID (`D042`) carries no `#` and never fires.
 
-Scope is `GROWTH_GUARDS_PROSE_PATHS`; there is no excludes list. The default, each name spelled twice because `*` crosses `/` but never stands in for the separator:
+Scope is `GROWTH_GUARDS_PROSE_PATHS`; there is no excludes list. `docs/architecture/*.md` joins the default only under `GROWTH_GUARDS_MD_SCOPE=all`, the switch a repository flips once its markdown is rewritten; an explicit path list is used as given. The default, each name spelled twice because `*` crosses `/` but never stands in for the separator:
 
 ```
 SKILL.md */SKILL.md AGENTS.md */AGENTS.md CLAUDE.md */CLAUDE.md workflows/*.md */workflows/*.md agents/*.md */agents/*.md docs/architecture/*.md

--- a/skills/growth-guards/scripts/prose
+++ b/skills/growth-guards/scripts/prose
@@ -40,8 +40,13 @@ source "$SCRIPT_DIR/lib/settings.sh"
 # because `*` crosses `/` but never stands in for the separator itself, and
 # the second spelling is also what reaches a rendered copy under `.claude/`
 # or `.agents/`. The architecture docs those files point at are loaded the
-# same way, so they hold the same rule.
-PATHS_DEFAULT="SKILL.md */SKILL.md AGENTS.md */AGENTS.md CLAUDE.md */CLAUDE.md workflows/*.md */workflows/*.md agents/*.md */agents/*.md docs/architecture/*.md"
+# same way, so they hold the same rule — once the repository says its
+# markdown is rewritten (GROWTH_GUARDS_MD_SCOPE=all, the switch the markdown
+# lanes read); before that a repository's architecture docs are what the
+# rewrite is for, and this lane has no staged scope to spare them.
+PATHS_CORE="SKILL.md */SKILL.md AGENTS.md */AGENTS.md CLAUDE.md */CLAUDE.md workflows/*.md */workflows/*.md agents/*.md */agents/*.md"
+PATHS_ARCH="docs/architecture/*.md"
+PATHS_DEFAULT="$PATHS_CORE $PATHS_ARCH"
 
 usage() {
   cat <<EOF
@@ -77,6 +82,12 @@ fi
 
 gg_repo_root_cd
 
+MD_SCOPE="$(gg_setting GROWTH_GUARDS_MD_SCOPE touched)" || exit 2
+case "$MD_SCOPE" in
+  all) ;;
+  touched) PATHS_DEFAULT="$PATHS_CORE" ;;
+  *) gg_config_error "GROWTH_GUARDS_MD_SCOPE must be 'touched' or 'all', got '$(gg_scrubbed "$MD_SCOPE")'" ;;
+esac
 PATHS_RAW="$(gg_setting GROWTH_GUARDS_PROSE_PATHS "$PATHS_DEFAULT")" || exit 2
 
 # The path list, its validation and its matcher are the family's, shared with

--- a/skills/growth-guards/tests/prose.test.sh
+++ b/skills/growth-guards/tests/prose.test.sh
@@ -120,11 +120,19 @@ new_repo scope
 put SKILL.md 'clean'
 for f in SKILL.md AGENTS.md CLAUDE.md skills/dev/SKILL.md skills/dev/AGENTS.md skills/dev/CLAUDE.md workflows/ship.md skills/dev/workflows/ship.md agents/rust.md .claude/agents/rust.md docs/architecture/overview.md docs/architecture/topic.md; do
   put "$f" 'Seeded 2026-08-12.'
-  run_prose
+  GROWTH_GUARDS_MD_SCOPE=all run_prose
   [ "$RC" -eq 1 ] && case "$OUT" in *"history reference: $f:1:"*) true ;; *) false ;; esac \
     && ok "$f is in the default scope" || bad "$f is in the default scope" "rc=$RC out=$OUT"
   put "$f" 'clean'
 done
+put docs/architecture/overview.md 'Seeded 2026-08-12.'
+run_prose
+[ "$RC" -eq 0 ] && ok "under GROWTH_GUARDS_MD_SCOPE=touched the architecture docs are not yet in scope" \
+  || bad "architecture docs wait for scope all" "rc=$RC out=$OUT"
+GROWTH_GUARDS_MD_SCOPE=all run_prose
+[ "$RC" -eq 1 ] && case "$OUT" in *"history reference: docs/architecture/overview.md:1:"*) true ;; *) false ;; esac \
+  && ok "control: under scope all the same file fails" || bad "control: scope all scans architecture docs" "rc=$RC out=$OUT"
+put docs/architecture/overview.md 'clean'
 run_prose
 [ "$RC" -eq 0 ] && ok "control: with every scoped file clean, the scan passes" \
   || bad "control: scoped files clean" "rc=$RC out=$OUT"
@@ -134,8 +142,8 @@ done
 run_prose
 # The count is asserted with the status: a scan that matched NOTHING also
 # exits 0, and would satisfy a bare rc check while proving nothing.
-[ "$RC" -eq 0 ] && case "$OUT" in *"prose: OK — no history references in 12 scanned file(s)"*) true ;; *) false ;; esac \
-  && ok "README, CHECKS, docs, CHANGELOG, references and a workflows-named file keep their history, with the twelve scoped files still read" \
+[ "$RC" -eq 0 ] && case "$OUT" in *"prose: OK — no history references in 10 scanned file(s)"*) true ;; *) false ;; esac \
+  && ok "README, CHECKS, docs, CHANGELOG, references and a workflows-named file keep their history, with the ten scoped files still read" \
   || bad "out-of-scope files keep their history" "rc=$RC out=$OUT"
 
 echo "=== GROWTH_GUARDS_PROSE_PATHS REPLACES the list (and that is provable) ==="


### PR DESCRIPTION
The prose lane has no staged scope, so its widened default (docs/architecture) blocked every consumer commit before the consumer's docs rewrite. docs/architecture joins the default only under GROWTH_GUARDS_MD_SCOPE=all, the switch the markdown lanes already read. Tracking: KEN-1203.

https://claude.ai/code/session_01LbVeBZNo3nBLtjiNcRG2JA