### PR TITLE
fix(docs-writing): correct three claims the bot round found wrong

### DIFF
--- a/.agents/skills/docs-writing/SKILL.md
+++ b/.agents/skills/docs-writing/SKILL.md
@@ -101,8 +101,9 @@ Read on demand for one subsystem. The `doc-drift-check` hook names it when cover
 Read by an agent or maintainer looking up one value. Any lookup document: `references/`, `schemas/`, `patterns/`, a named file such as `CHECKS.md`, or one under `docs/`.
 
 - Tables and lists. One row per item.
-- The value, its meaning, and its default.
-- Excluded: narrative, worked examples, and rationale.
+- The value or the shape the contract fixes, its meaning, and its default.
+- The semantics a reader needs to produce or consume that shape, and no more.
+- Excluded: rationale, and narrative that defines nothing.
 - A file under `references/` exists only where a named workflow loads it on demand.
 
 ### `SKILL.md`, `workflows/*.md`, `agents/*.md`

--- a/.agents/skills/github/SKILL.md
+++ b/.agents/skills/github/SKILL.md
@@ -62,7 +62,7 @@ Contracts: `label-add --help`, `git-https-auth --help`, `git-diff-summary --help
 
 ### PR Merge Outcomes
 
-Full contract: `pr-merge --help`. Exit `75` is volatile: the caller arms one exact head and waits on that head with the orch skill's `queue-wait`, whose `--help` § Verdicts maps each verdict to a route; an unrecognized verdict is never re-armed. With the review-gate skill installed, its `pr-watch.sh` reads every open PR in one pass and prints a `disarmed` line for each one whose gate is open with no arming; a healthy PR emits nothing. If `can_merge` is false with no `issues`, read `state`. The thread gate is **Policy, not mechanism.** `--force` and the explicit-user-only `--admin` are its overrides.
+Full contract: `pr-merge --help`. Exit `75` is volatile: the caller arms one exact head and waits on that head with the orch skill's `queue-wait`, whose `--help` § Verdicts maps each verdict to a route; an unrecognized verdict is never re-armed. With the review-gate skill installed, its `pr-watch.sh` reads every open PR in one pass and prints a `disarmed` line for each un-queued, non-draft PR whose gate is open with no arming; an armed or queued PR is healthy and emits nothing. If `can_merge` is false with no `issues`, read `state`. The thread gate is **Policy, not mechanism.** `--force` and the explicit-user-only `--admin` are its overrides.
 
 ### PR blocked with no visible conversations
 

--- a/.agents/skills/second-opinion/README.md
+++ b/.agents/skills/second-opinion/README.md
@@ -34,7 +34,7 @@ Needs `jq` and at least one external CLI, `claude` or `codex`, logged in.
 ./scripts/second-opinion review --target claude --range HEAD~3..HEAD --cwd .
 ```
 
-Every mode picks the first roster entry that is available and runs a different model from the session. The review prompt reviews through fixed lenses (correctness, security and fail-open, adversarial inputs, portability, repo-rule adherence, docs-versus-code drift, test adequacy) and appends the repository's own instruction files, the same inputs the GitHub review bots read. The orch skill runs `review` as a local pre-PR review during `submit-pr` and can offer one during `review-pr`.
+Every mode picks roster entries that are available and run a different model from the session: one, or up to `SECOND_OPINION_COUNT` of them in `review`. The review prompt reviews through fixed lenses (correctness, security and fail-open, adversarial inputs, portability, repo-rule adherence, docs-versus-code drift, test adequacy) and appends the repository's own instruction files, the same inputs the GitHub review bots read. The orch skill runs `review` as a local pre-PR review during `submit-pr` and can offer one during `review-pr`.
 
 Flags, exit codes and the artifact contract: `second-opinion --help`.
 

--- a/skills/docs-writing/SKILL.md
+++ b/skills/docs-writing/SKILL.md
@@ -93,8 +93,9 @@ Read on demand for one subsystem. The `doc-drift-check` hook names it when cover
 Read by an agent or maintainer looking up one value. Any lookup document: `references/`, `schemas/`, `patterns/`, a named file such as `CHECKS.md`, or one under `docs/`.
 
 - Tables and lists. One row per item.
-- The value, its meaning, and its default.
-- Excluded: narrative, worked examples, and rationale.
+- The value or the shape the contract fixes, its meaning, and its default.
+- The semantics a reader needs to produce or consume that shape, and no more.
+- Excluded: rationale, and narrative that defines nothing.
 - A file under `references/` exists only where a named workflow loads it on demand.
 
 ### `SKILL.md`, `workflows/*.md`, `agents/*.md`

--- a/skills/github/SKILL.md
+++ b/skills/github/SKILL.md
@@ -54,7 +54,7 @@ Contracts: `label-add --help`, `git-https-auth --help`, `git-diff-summary --help
 
 ### PR Merge Outcomes
 
-Full contract: `pr-merge --help`. Exit `75` is volatile: the caller arms one exact head and waits on that head with the orch skill's `queue-wait`, whose `--help` § Verdicts maps each verdict to a route; an unrecognized verdict is never re-armed. With the review-gate skill installed, its `pr-watch.sh` reads every open PR in one pass and prints a `disarmed` line for each one whose gate is open with no arming; a healthy PR emits nothing. If `can_merge` is false with no `issues`, read `state`. The thread gate is **Policy, not mechanism.** `--force` and the explicit-user-only `--admin` are its overrides.
+Full contract: `pr-merge --help`. Exit `75` is volatile: the caller arms one exact head and waits on that head with the orch skill's `queue-wait`, whose `--help` § Verdicts maps each verdict to a route; an unrecognized verdict is never re-armed. With the review-gate skill installed, its `pr-watch.sh` reads every open PR in one pass and prints a `disarmed` line for each un-queued, non-draft PR whose gate is open with no arming; an armed or queued PR is healthy and emits nothing. If `can_merge` is false with no `issues`, read `state`. The thread gate is **Policy, not mechanism.** `--force` and the explicit-user-only `--admin` are its overrides.
 
 ### PR blocked with no visible conversations
 

--- a/skills/second-opinion/README.md
+++ b/skills/second-opinion/README.md
@@ -34,7 +34,7 @@ Needs `jq` and at least one external CLI, `claude` or `codex`, logged in.
 ./scripts/second-opinion review --target claude --range HEAD~3..HEAD --cwd .
 ```
 
-Every mode picks the first roster entry that is available and runs a different model from the session. The review prompt reviews through fixed lenses (correctness, security and fail-open, adversarial inputs, portability, repo-rule adherence, docs-versus-code drift, test adequacy) and appends the repository's own instruction files, the same inputs the GitHub review bots read. The orch skill runs `review` as a local pre-PR review during `submit-pr` and can offer one during `review-pr`.
+Every mode picks roster entries that are available and run a different model from the session: one, or up to `SECOND_OPINION_COUNT` of them in `review`. The review prompt reviews through fixed lenses (correctness, security and fail-open, adversarial inputs, portability, repo-rule adherence, docs-versus-code drift, test adequacy) and appends the repository's own instruction files, the same inputs the GitHub review bots read. The orch skill runs `review` as a local pre-PR review during `submit-pr` and can offer one during `review-pr`.
 
 Flags, exit codes and the artifact contract: `second-opinion --help`.
 


### PR DESCRIPTION
Three wrong claims the bot round on #2110 found, all introduced by #2109 or #2110. Prose only.

- `skills/second-opinion/README.md`: the reworded sentence said every mode picks one roster entry. `review` takes up to `SECOND_OPINION_COUNT` of them, which the feature list two sections above already states and `scripts/second-opinion:920` implements.
- `skills/docs-writing/SKILL.md` § Reference docs: widening the class to `schemas/` and `patterns/` put files such as `skills/reviewer/schemas/review-finding.md` under a list admitting only single values and excluding narrative, so the rewrite workflow would delete a shape and the semantics needed to produce it. The list admits the shape a contract fixes and the semantics a reader needs for it, and excludes rationale and narrative that defines nothing.
- `skills/github/SKILL.md`: the `pr-watch.sh` claim dropped the qualification its `--help` carries. The `disarmed` line covers an un-queued, non-draft PR; an armed or queued one is a healthy state that emits nothing (`skills/review-gate/scripts/pr-watch.sh:652`, `--help` lines 70-72 and 86-89).

## Checks

Full commit chain clean. md-format 871 files, md-refs 519 references, prose 194 files. Renders synced.

Last PR of the writing-rules block. Both bot rounds on #2109 and #2110 are triaged and their threads answered and resolved.

KEN-1203

https://claude.ai/code/session_01H8suUs4dddkHvFpzP1iJVY
