### PR TITLE
refactor(growth-guards): share baseline policy reads

### DIFF
--- a/.agents/skills/growth-guards/scripts/suppression-ban
+++ b/.agents/skills/growth-guards/scripts/suppression-ban
@@ -202,52 +202,22 @@ validate_baseline() { # FILE LABEL
 # copy too: an unstaged row bump must not authorize growth the commit does not
 # carry. Only a never-tracked baseline, and --update (which rewrites the
 # worktree copy), read from disk.
-# Both probes reserve one status for their one expected answer; anything else
-# is git failing to answer, and a ratchet that cannot read its own baseline
-# must not fall through to a looser source than the index carries.
-baseline_in_index() { # 0 = the index has it, 1 = it does not
-  local status=0
-  git ls-files --error-unmatch -- ":(literal)$BASELINE_FILE" >/dev/null 2>&1 || status=$?
-  case "$status" in
-    0) return 0 ;;
-    1) return 1 ;;
-    *) gg_collection_error "could not query the index for $BASELINE_FILE (git ls-files exit $status); refusing to treat it as untracked" ;;
-  esac
-}
-
-baseline_in_head() { # 0 = HEAD has it (so an index miss is a staged deletion)
-  local head_status=0 tree_status=0 entry=""
-  # ls-tree, never `cat-file -e`: with rev:path syntax git answers "no such
-  # path in HEAD" with the same 128 an operational failure returns.
-  git rev-parse --verify --quiet HEAD >/dev/null 2>&1 || head_status=$?
-  case "$head_status" in
-    0) ;;
-    1) return 1 ;;
-    *) gg_collection_error "could not resolve HEAD while reading $BASELINE_FILE (git rev-parse exit $head_status); refusing to treat it as untracked" ;;
-  esac
-  entry="$(git ls-tree HEAD -- ":(literal)$BASELINE_FILE" 2>/dev/null)" || tree_status=$?
-  [ "$tree_status" -eq 0 ] \
-    || gg_collection_error "could not probe HEAD for $BASELINE_FILE (git ls-tree exit $tree_status); refusing to treat it as untracked"
-  [ -n "$entry" ]
-}
-
 BASELINE_FROM_INDEX=0
 if [ "$MODE" = "update" ] && [ -f "$BASELINE_FILE" ]; then
   validate_baseline "$BASELINE_FILE" "$BASELINE_FILE"
   cp -- "$BASELINE_FILE" "$GG_TMP/baseline.tsv"
-elif baseline_in_index; then
-  # No worktree copy to rewrite — what --update needs to know.
-  [ -f "$BASELINE_FILE" ] || BASELINE_FROM_INDEX=1
-  git show ":0:$BASELINE_FILE" >"$GG_TMP/baseline.tsv" || gg_config_error "failed to read tracked baseline from the index: $BASELINE_FILE"
-  validate_baseline "$GG_TMP/baseline.tsv" "$BASELINE_FILE (index copy)"
-elif baseline_in_head; then
-  # Staged for deletion: the commit freezes nothing.
-  : >"$GG_TMP/baseline.tsv"
-elif [ -f "$BASELINE_FILE" ]; then
-  validate_baseline "$BASELINE_FILE" "$BASELINE_FILE"
-  cp -- "$BASELINE_FILE" "$GG_TMP/baseline.tsv"
 else
-  : >"$GG_TMP/baseline.tsv"
+  baseline_status=0
+  gg_policy_content "$BASELINE_FILE" >"$GG_TMP/baseline.tsv" || baseline_status=$?
+  case "$baseline_status" in
+    0)
+      # A readable policy with no worktree file came from the index.
+      [ -f "$BASELINE_FILE" ] || BASELINE_FROM_INDEX=1
+      validate_baseline "$GG_TMP/baseline.tsv" "$BASELINE_FILE"
+      ;;
+    1) : >"$GG_TMP/baseline.tsv" ;;
+    *) gg_collection_error "could not read the baseline $BASELINE_FILE (exit $baseline_status, cause above)" ;;
+  esac
 fi
 
 evaluate() { # BASELINE-TSV — violations on stdout, one per line, tab-separated

--- a/skills/growth-guards/scripts/suppression-ban
+++ b/skills/growth-guards/scripts/suppression-ban
@@ -202,52 +202,22 @@ validate_baseline() { # FILE LABEL
 # copy too: an unstaged row bump must not authorize growth the commit does not
 # carry. Only a never-tracked baseline, and --update (which rewrites the
 # worktree copy), read from disk.
-# Both probes reserve one status for their one expected answer; anything else
-# is git failing to answer, and a ratchet that cannot read its own baseline
-# must not fall through to a looser source than the index carries.
-baseline_in_index() { # 0 = the index has it, 1 = it does not
-  local status=0
-  git ls-files --error-unmatch -- ":(literal)$BASELINE_FILE" >/dev/null 2>&1 || status=$?
-  case "$status" in
-    0) return 0 ;;
-    1) return 1 ;;
-    *) gg_collection_error "could not query the index for $BASELINE_FILE (git ls-files exit $status); refusing to treat it as untracked" ;;
-  esac
-}
-
-baseline_in_head() { # 0 = HEAD has it (so an index miss is a staged deletion)
-  local head_status=0 tree_status=0 entry=""
-  # ls-tree, never `cat-file -e`: with rev:path syntax git answers "no such
-  # path in HEAD" with the same 128 an operational failure returns.
-  git rev-parse --verify --quiet HEAD >/dev/null 2>&1 || head_status=$?
-  case "$head_status" in
-    0) ;;
-    1) return 1 ;;
-    *) gg_collection_error "could not resolve HEAD while reading $BASELINE_FILE (git rev-parse exit $head_status); refusing to treat it as untracked" ;;
-  esac
-  entry="$(git ls-tree HEAD -- ":(literal)$BASELINE_FILE" 2>/dev/null)" || tree_status=$?
-  [ "$tree_status" -eq 0 ] \
-    || gg_collection_error "could not probe HEAD for $BASELINE_FILE (git ls-tree exit $tree_status); refusing to treat it as untracked"
-  [ -n "$entry" ]
-}
-
 BASELINE_FROM_INDEX=0
 if [ "$MODE" = "update" ] && [ -f "$BASELINE_FILE" ]; then
   validate_baseline "$BASELINE_FILE" "$BASELINE_FILE"
   cp -- "$BASELINE_FILE" "$GG_TMP/baseline.tsv"
-elif baseline_in_index; then
-  # No worktree copy to rewrite — what --update needs to know.
-  [ -f "$BASELINE_FILE" ] || BASELINE_FROM_INDEX=1
-  git show ":0:$BASELINE_FILE" >"$GG_TMP/baseline.tsv" || gg_config_error "failed to read tracked baseline from the index: $BASELINE_FILE"
-  validate_baseline "$GG_TMP/baseline.tsv" "$BASELINE_FILE (index copy)"
-elif baseline_in_head; then
-  # Staged for deletion: the commit freezes nothing.
-  : >"$GG_TMP/baseline.tsv"
-elif [ -f "$BASELINE_FILE" ]; then
-  validate_baseline "$BASELINE_FILE" "$BASELINE_FILE"
-  cp -- "$BASELINE_FILE" "$GG_TMP/baseline.tsv"
 else
-  : >"$GG_TMP/baseline.tsv"
+  baseline_status=0
+  gg_policy_content "$BASELINE_FILE" >"$GG_TMP/baseline.tsv" || baseline_status=$?
+  case "$baseline_status" in
+    0)
+      # A readable policy with no worktree file came from the index.
+      [ -f "$BASELINE_FILE" ] || BASELINE_FROM_INDEX=1
+      validate_baseline "$GG_TMP/baseline.tsv" "$BASELINE_FILE"
+      ;;
+    1) : >"$GG_TMP/baseline.tsv" ;;
+    *) gg_collection_error "could not read the baseline $BASELINE_FILE (exit $baseline_status, cause above)" ;;
+  esac
 fi
 
 evaluate() { # BASELINE-TSV — violations on stdout, one per line, tab-separated


### PR DESCRIPTION
suppression-ban duplicates the shared policy reader’s index and HEAD probes. It now uses that reader. Checks still use staged policy bytes; baseline updates still use the working copy and refuse a missing working copy.

Validation: suppression and shared-index suites pass. A worktree-first mutant fails the staged-policy controls. One local review and the full repository commit chain pass.

Hold for overseer review. Merge only after a new MERGE directive.

Part of KEN-1203.
