### PR TITLE
docs: limit per-tool settings to agents

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Installing a package from a git repository needs git 2.41 or newer; kendex refus
 - Manage customizations you already have.
 - Browse the [community marketplace](https://kendex.ai) and subscribe to package repositories.
 - Find outdated packages and update them.
-- Add your own instructions and tool settings to agents and skills.
+- Add your own instructions to agents and skills, and per-tool settings to agents.
 - Enable, disable or remove installed customizations.
 - See where an installed package came from.
 


### PR DESCRIPTION
The README claimed that users can set per-tool settings on both agents and skills. Limit that claim to agents while keeping additional instructions available for both.

Validation: full commit checks passed. This is the selected follow-up from PR #2119. Hold for overseer review.

KEN-1203
