### PR TITLE
fix(growth-guards): preserve sibling source paths

### DIFF
--- a/.agents/skills/growth-guards/scripts/lib/commit-changes.sh
+++ b/.agents/skills/growth-guards/scripts/lib/commit-changes.sh
@@ -1,8 +1,9 @@
 # shellcheck shell=bash
 # Shared commit changes for the changelog gate and repository compile checks.
 # Call after common.sh and settings.sh, from the repository root.
+gg_path GG_COMMIT_LIB dirname -- "${BASH_SOURCE[0]}"
 # shellcheck source=commit-parent.sh
-source "$(dirname -- "${BASH_SOURCE[0]}")/commit-parent.sh"
+source "$GG_COMMIT_LIB/commit-parent.sh"
 
 gg_commit_changes() { # sets GG_TMP/staged.z, written.z and product.z
   local meta src dest srcmode dstmode srcsha dstsha status f required_raw required

--- a/skills/growth-guards/scripts/lib/commit-changes.sh
+++ b/skills/growth-guards/scripts/lib/commit-changes.sh
@@ -1,8 +1,9 @@
 # shellcheck shell=bash
 # Shared commit changes for the changelog gate and repository compile checks.
 # Call after common.sh and settings.sh, from the repository root.
+gg_path GG_COMMIT_LIB dirname -- "${BASH_SOURCE[0]}"
 # shellcheck source=commit-parent.sh
-source "$(dirname -- "${BASH_SOURCE[0]}")/commit-parent.sh"
+source "$GG_COMMIT_LIB/commit-parent.sh"
 
 gg_commit_changes() { # sets GG_TMP/staged.z, written.z and product.z
   local meta src dest srcmode dstmode srcsha dstsha status f required_raw required


### PR DESCRIPTION
The commit-change helper loads its sibling through the existing path helper. This fixes the path-capture test failure reported by PR 2136 CI on a line added in PR 2132. The source and its installed render change together.

The existing test fails before the change and passes after it. Commit-message, amend and repository-guard tests pass. Full validation and normal commit hooks pass.

Hold for overseer MERGE.

Program: KEN-1203.
