### PR TITLE
fix(hooks): read Copilot's toolArgs in the shell guards

### DIFF
--- a/.claude/hooks/block-bare-cd.sh
+++ b/.claude/hooks/block-bare-cd.sh
@@ -22,11 +22,20 @@ INPUT=$(cat)
 
 # A payload that does not parse, or that names a command which is not a
 # string, is refused rather than skipped. An absent command is the empty
-# string and passes. The null tests are spelled out because jq's `//` reads
-# `false` as absent, and `false` is not a command either.
+# string and passes. The command is read where each harness carries it:
+# `tool_input.command` (Claude Code, Codex, Gemini CLI and the Pi carrier), a
+# bare `command`, or Copilot's `toolArgs.command`, whose `toolArgs` arrives as
+# an object or as one JSON-encoded string. The null tests are spelled out
+# because jq's `//` reads `false` as absent, and `false` is not a command
+# either.
 if ! COMMAND=$(printf '%s' "$INPUT" \
-  | jq -r 'if .tool_input.command == null then (if .command == null then "" else .command end)
-           else .tool_input.command end
+  | jq -r 'def copilot: .toolArgs
+             | if . == null then null elif type == "string" then fromjson else . end
+             | if . == null then null elif type == "object" then .command else error end;
+           if .tool_input.command != null then .tool_input.command
+           elif .command != null then .command
+           elif copilot != null then copilot
+           else "" end
            | if type == "string" then . else error end' 2>/dev/null); then
   echo "block-bare-cd: hook payload is not valid JSON, or names a command that is not a string; refusing rather than skipping the guard" >&2
   exit 2

--- a/.claude/hooks/block-repo-copy.sh
+++ b/.claude/hooks/block-repo-copy.sh
@@ -20,11 +20,20 @@ INPUT=$(cat)
 
 # A payload that does not parse, or that names a command which is not a
 # string, is refused rather than skipped. An absent command is the empty
-# string and passes. The null tests are spelled out because jq's `//` reads
-# `false` as absent, and `false` is not a command either.
+# string and passes. The command is read where each harness carries it:
+# `tool_input.command` (Claude Code, Codex, Gemini CLI and the Pi carrier), a
+# bare `command`, or Copilot's `toolArgs.command`, whose `toolArgs` arrives as
+# an object or as one JSON-encoded string. The null tests are spelled out
+# because jq's `//` reads `false` as absent, and `false` is not a command
+# either.
 if ! COMMAND=$(printf '%s' "$INPUT" \
-  | jq -r 'if .tool_input.command == null then (if .command == null then "" else .command end)
-           else .tool_input.command end
+  | jq -r 'def copilot: .toolArgs
+             | if . == null then null elif type == "string" then fromjson else . end
+             | if . == null then null elif type == "object" then .command else error end;
+           if .tool_input.command != null then .tool_input.command
+           elif .command != null then .command
+           elif copilot != null then copilot
+           else "" end
            | if type == "string" then . else error end' 2>/dev/null); then
   echo "block-repo-copy: hook payload is not valid JSON, or names a command that is not a string; refusing rather than skipping the guard" >&2
   exit 2

--- a/.claude/hooks/block-unsafe-rm.sh
+++ b/.claude/hooks/block-unsafe-rm.sh
@@ -22,11 +22,20 @@ INPUT=$(cat)
 
 # A payload that does not parse, or that names a command which is not a
 # string, is refused rather than skipped. An absent command is the empty
-# string and passes. The null tests are spelled out because jq's `//` reads
-# `false` as absent, and `false` is not a command either.
+# string and passes. The command is read where each harness carries it:
+# `tool_input.command` (Claude Code, Codex, Gemini CLI and the Pi carrier), a
+# bare `command`, or Copilot's `toolArgs.command`, whose `toolArgs` arrives as
+# an object or as one JSON-encoded string. The null tests are spelled out
+# because jq's `//` reads `false` as absent, and `false` is not a command
+# either.
 if ! COMMAND=$(printf '%s' "$INPUT" \
-  | jq -r 'if .tool_input.command == null then (if .command == null then "" else .command end)
-           else .tool_input.command end
+  | jq -r 'def copilot: .toolArgs
+             | if . == null then null elif type == "string" then fromjson else . end
+             | if . == null then null elif type == "object" then .command else error end;
+           if .tool_input.command != null then .tool_input.command
+           elif .command != null then .command
+           elif copilot != null then copilot
+           else "" end
            | if type == "string" then . else error end' 2>/dev/null); then
   echo "block-unsafe-rm: hook payload is not valid JSON, or names a command that is not a string; refusing rather than skipping the guard" >&2
   exit 2

--- a/.claude/hooks/pre-commit-check.sh
+++ b/.claude/hooks/pre-commit-check.sh
@@ -26,11 +26,20 @@ INPUT=$(cat)
 
 # A payload that does not parse, or that names a command which is not a
 # string, is refused rather than skipped. An absent command is the empty
-# string and passes. The null tests are spelled out because jq's `//` reads
-# `false` as absent, and `false` is not a command either.
+# string and passes. The command is read where each harness carries it:
+# `tool_input.command` (Claude Code, Codex, Gemini CLI and the Pi carrier), a
+# bare `command`, or Copilot's `toolArgs.command`, whose `toolArgs` arrives as
+# an object or as one JSON-encoded string. The null tests are spelled out
+# because jq's `//` reads `false` as absent, and `false` is not a command
+# either.
 if ! COMMAND=$(printf '%s' "$INPUT" \
-  | jq -r 'if .tool_input.command == null then (if .command == null then "" else .command end)
-           else .tool_input.command end
+  | jq -r 'def copilot: .toolArgs
+             | if . == null then null elif type == "string" then fromjson else . end
+             | if . == null then null elif type == "object" then .command else error end;
+           if .tool_input.command != null then .tool_input.command
+           elif .command != null then .command
+           elif copilot != null then copilot
+           else "" end
            | if type == "string" then . else error end' 2>/dev/null); then
   echo "pre-commit-check: hook payload is not valid JSON, or names a command that is not a string; refusing rather than skipping the guard" >&2
   exit 2

--- a/.codex/hooks/block-bare-cd.sh
+++ b/.codex/hooks/block-bare-cd.sh
@@ -22,11 +22,20 @@ INPUT=$(cat)
 
 # A payload that does not parse, or that names a command which is not a
 # string, is refused rather than skipped. An absent command is the empty
-# string and passes. The null tests are spelled out because jq's `//` reads
-# `false` as absent, and `false` is not a command either.
+# string and passes. The command is read where each harness carries it:
+# `tool_input.command` (Claude Code, Codex, Gemini CLI and the Pi carrier), a
+# bare `command`, or Copilot's `toolArgs.command`, whose `toolArgs` arrives as
+# an object or as one JSON-encoded string. The null tests are spelled out
+# because jq's `//` reads `false` as absent, and `false` is not a command
+# either.
 if ! COMMAND=$(printf '%s' "$INPUT" \
-  | jq -r 'if .tool_input.command == null then (if .command == null then "" else .command end)
-           else .tool_input.command end
+  | jq -r 'def copilot: .toolArgs
+             | if . == null then null elif type == "string" then fromjson else . end
+             | if . == null then null elif type == "object" then .command else error end;
+           if .tool_input.command != null then .tool_input.command
+           elif .command != null then .command
+           elif copilot != null then copilot
+           else "" end
            | if type == "string" then . else error end' 2>/dev/null); then
   echo "block-bare-cd: hook payload is not valid JSON, or names a command that is not a string; refusing rather than skipping the guard" >&2
   exit 2

--- a/.codex/hooks/block-repo-copy.sh
+++ b/.codex/hooks/block-repo-copy.sh
@@ -20,11 +20,20 @@ INPUT=$(cat)
 
 # A payload that does not parse, or that names a command which is not a
 # string, is refused rather than skipped. An absent command is the empty
-# string and passes. The null tests are spelled out because jq's `//` reads
-# `false` as absent, and `false` is not a command either.
+# string and passes. The command is read where each harness carries it:
+# `tool_input.command` (Claude Code, Codex, Gemini CLI and the Pi carrier), a
+# bare `command`, or Copilot's `toolArgs.command`, whose `toolArgs` arrives as
+# an object or as one JSON-encoded string. The null tests are spelled out
+# because jq's `//` reads `false` as absent, and `false` is not a command
+# either.
 if ! COMMAND=$(printf '%s' "$INPUT" \
-  | jq -r 'if .tool_input.command == null then (if .command == null then "" else .command end)
-           else .tool_input.command end
+  | jq -r 'def copilot: .toolArgs
+             | if . == null then null elif type == "string" then fromjson else . end
+             | if . == null then null elif type == "object" then .command else error end;
+           if .tool_input.command != null then .tool_input.command
+           elif .command != null then .command
+           elif copilot != null then copilot
+           else "" end
            | if type == "string" then . else error end' 2>/dev/null); then
   echo "block-repo-copy: hook payload is not valid JSON, or names a command that is not a string; refusing rather than skipping the guard" >&2
   exit 2

--- a/.codex/hooks/block-unsafe-rm.sh
+++ b/.codex/hooks/block-unsafe-rm.sh
@@ -22,11 +22,20 @@ INPUT=$(cat)
 
 # A payload that does not parse, or that names a command which is not a
 # string, is refused rather than skipped. An absent command is the empty
-# string and passes. The null tests are spelled out because jq's `//` reads
-# `false` as absent, and `false` is not a command either.
+# string and passes. The command is read where each harness carries it:
+# `tool_input.command` (Claude Code, Codex, Gemini CLI and the Pi carrier), a
+# bare `command`, or Copilot's `toolArgs.command`, whose `toolArgs` arrives as
+# an object or as one JSON-encoded string. The null tests are spelled out
+# because jq's `//` reads `false` as absent, and `false` is not a command
+# either.
 if ! COMMAND=$(printf '%s' "$INPUT" \
-  | jq -r 'if .tool_input.command == null then (if .command == null then "" else .command end)
-           else .tool_input.command end
+  | jq -r 'def copilot: .toolArgs
+             | if . == null then null elif type == "string" then fromjson else . end
+             | if . == null then null elif type == "object" then .command else error end;
+           if .tool_input.command != null then .tool_input.command
+           elif .command != null then .command
+           elif copilot != null then copilot
+           else "" end
            | if type == "string" then . else error end' 2>/dev/null); then
   echo "block-unsafe-rm: hook payload is not valid JSON, or names a command that is not a string; refusing rather than skipping the guard" >&2
   exit 2

--- a/.codex/hooks/pre-commit-check.sh
+++ b/.codex/hooks/pre-commit-check.sh
@@ -26,11 +26,20 @@ INPUT=$(cat)
 
 # A payload that does not parse, or that names a command which is not a
 # string, is refused rather than skipped. An absent command is the empty
-# string and passes. The null tests are spelled out because jq's `//` reads
-# `false` as absent, and `false` is not a command either.
+# string and passes. The command is read where each harness carries it:
+# `tool_input.command` (Claude Code, Codex, Gemini CLI and the Pi carrier), a
+# bare `command`, or Copilot's `toolArgs.command`, whose `toolArgs` arrives as
+# an object or as one JSON-encoded string. The null tests are spelled out
+# because jq's `//` reads `false` as absent, and `false` is not a command
+# either.
 if ! COMMAND=$(printf '%s' "$INPUT" \
-  | jq -r 'if .tool_input.command == null then (if .command == null then "" else .command end)
-           else .tool_input.command end
+  | jq -r 'def copilot: .toolArgs
+             | if . == null then null elif type == "string" then fromjson else . end
+             | if . == null then null elif type == "object" then .command else error end;
+           if .tool_input.command != null then .tool_input.command
+           elif .command != null then .command
+           elif copilot != null then copilot
+           else "" end
            | if type == "string" then . else error end' 2>/dev/null); then
   echo "pre-commit-check: hook payload is not valid JSON, or names a command that is not a string; refusing rather than skipping the guard" >&2
   exit 2

--- a/.pi/kendex/hooks/block-bare-cd.sh
+++ b/.pi/kendex/hooks/block-bare-cd.sh
@@ -22,11 +22,20 @@ INPUT=$(cat)
 
 # A payload that does not parse, or that names a command which is not a
 # string, is refused rather than skipped. An absent command is the empty
-# string and passes. The null tests are spelled out because jq's `//` reads
-# `false` as absent, and `false` is not a command either.
+# string and passes. The command is read where each harness carries it:
+# `tool_input.command` (Claude Code, Codex, Gemini CLI and the Pi carrier), a
+# bare `command`, or Copilot's `toolArgs.command`, whose `toolArgs` arrives as
+# an object or as one JSON-encoded string. The null tests are spelled out
+# because jq's `//` reads `false` as absent, and `false` is not a command
+# either.
 if ! COMMAND=$(printf '%s' "$INPUT" \
-  | jq -r 'if .tool_input.command == null then (if .command == null then "" else .command end)
-           else .tool_input.command end
+  | jq -r 'def copilot: .toolArgs
+             | if . == null then null elif type == "string" then fromjson else . end
+             | if . == null then null elif type == "object" then .command else error end;
+           if .tool_input.command != null then .tool_input.command
+           elif .command != null then .command
+           elif copilot != null then copilot
+           else "" end
            | if type == "string" then . else error end' 2>/dev/null); then
   echo "block-bare-cd: hook payload is not valid JSON, or names a command that is not a string; refusing rather than skipping the guard" >&2
   exit 2

--- a/.pi/kendex/hooks/block-repo-copy.sh
+++ b/.pi/kendex/hooks/block-repo-copy.sh
@@ -20,11 +20,20 @@ INPUT=$(cat)
 
 # A payload that does not parse, or that names a command which is not a
 # string, is refused rather than skipped. An absent command is the empty
-# string and passes. The null tests are spelled out because jq's `//` reads
-# `false` as absent, and `false` is not a command either.
+# string and passes. The command is read where each harness carries it:
+# `tool_input.command` (Claude Code, Codex, Gemini CLI and the Pi carrier), a
+# bare `command`, or Copilot's `toolArgs.command`, whose `toolArgs` arrives as
+# an object or as one JSON-encoded string. The null tests are spelled out
+# because jq's `//` reads `false` as absent, and `false` is not a command
+# either.
 if ! COMMAND=$(printf '%s' "$INPUT" \
-  | jq -r 'if .tool_input.command == null then (if .command == null then "" else .command end)
-           else .tool_input.command end
+  | jq -r 'def copilot: .toolArgs
+             | if . == null then null elif type == "string" then fromjson else . end
+             | if . == null then null elif type == "object" then .command else error end;
+           if .tool_input.command != null then .tool_input.command
+           elif .command != null then .command
+           elif copilot != null then copilot
+           else "" end
            | if type == "string" then . else error end' 2>/dev/null); then
   echo "block-repo-copy: hook payload is not valid JSON, or names a command that is not a string; refusing rather than skipping the guard" >&2
   exit 2

--- a/.pi/kendex/hooks/pre-commit-check.sh
+++ b/.pi/kendex/hooks/pre-commit-check.sh
@@ -26,11 +26,20 @@ INPUT=$(cat)
 
 # A payload that does not parse, or that names a command which is not a
 # string, is refused rather than skipped. An absent command is the empty
-# string and passes. The null tests are spelled out because jq's `//` reads
-# `false` as absent, and `false` is not a command either.
+# string and passes. The command is read where each harness carries it:
+# `tool_input.command` (Claude Code, Codex, Gemini CLI and the Pi carrier), a
+# bare `command`, or Copilot's `toolArgs.command`, whose `toolArgs` arrives as
+# an object or as one JSON-encoded string. The null tests are spelled out
+# because jq's `//` reads `false` as absent, and `false` is not a command
+# either.
 if ! COMMAND=$(printf '%s' "$INPUT" \
-  | jq -r 'if .tool_input.command == null then (if .command == null then "" else .command end)
-           else .tool_input.command end
+  | jq -r 'def copilot: .toolArgs
+             | if . == null then null elif type == "string" then fromjson else . end
+             | if . == null then null elif type == "object" then .command else error end;
+           if .tool_input.command != null then .tool_input.command
+           elif .command != null then .command
+           elif copilot != null then copilot
+           else "" end
            | if type == "string" then . else error end' 2>/dev/null); then
   echo "pre-commit-check: hook payload is not valid JSON, or names a command that is not a string; refusing rather than skipping the guard" >&2
   exit 2

--- a/hooks/block-bare-cd.sh
+++ b/hooks/block-bare-cd.sh
@@ -22,11 +22,20 @@ INPUT=$(cat)
 
 # A payload that does not parse, or that names a command which is not a
 # string, is refused rather than skipped. An absent command is the empty
-# string and passes. The null tests are spelled out because jq's `//` reads
-# `false` as absent, and `false` is not a command either.
+# string and passes. The command is read where each harness carries it:
+# `tool_input.command` (Claude Code, Codex, Gemini CLI and the Pi carrier), a
+# bare `command`, or Copilot's `toolArgs.command`, whose `toolArgs` arrives as
+# an object or as one JSON-encoded string. The null tests are spelled out
+# because jq's `//` reads `false` as absent, and `false` is not a command
+# either.
 if ! COMMAND=$(printf '%s' "$INPUT" \
-  | jq -r 'if .tool_input.command == null then (if .command == null then "" else .command end)
-           else .tool_input.command end
+  | jq -r 'def copilot: .toolArgs
+             | if . == null then null elif type == "string" then fromjson else . end
+             | if . == null then null elif type == "object" then .command else error end;
+           if .tool_input.command != null then .tool_input.command
+           elif .command != null then .command
+           elif copilot != null then copilot
+           else "" end
            | if type == "string" then . else error end' 2>/dev/null); then
   echo "block-bare-cd: hook payload is not valid JSON, or names a command that is not a string; refusing rather than skipping the guard" >&2
   exit 2

--- a/hooks/block-repo-copy.sh
+++ b/hooks/block-repo-copy.sh
@@ -20,11 +20,20 @@ INPUT=$(cat)
 
 # A payload that does not parse, or that names a command which is not a
 # string, is refused rather than skipped. An absent command is the empty
-# string and passes. The null tests are spelled out because jq's `//` reads
-# `false` as absent, and `false` is not a command either.
+# string and passes. The command is read where each harness carries it:
+# `tool_input.command` (Claude Code, Codex, Gemini CLI and the Pi carrier), a
+# bare `command`, or Copilot's `toolArgs.command`, whose `toolArgs` arrives as
+# an object or as one JSON-encoded string. The null tests are spelled out
+# because jq's `//` reads `false` as absent, and `false` is not a command
+# either.
 if ! COMMAND=$(printf '%s' "$INPUT" \
-  | jq -r 'if .tool_input.command == null then (if .command == null then "" else .command end)
-           else .tool_input.command end
+  | jq -r 'def copilot: .toolArgs
+             | if . == null then null elif type == "string" then fromjson else . end
+             | if . == null then null elif type == "object" then .command else error end;
+           if .tool_input.command != null then .tool_input.command
+           elif .command != null then .command
+           elif copilot != null then copilot
+           else "" end
            | if type == "string" then . else error end' 2>/dev/null); then
   echo "block-repo-copy: hook payload is not valid JSON, or names a command that is not a string; refusing rather than skipping the guard" >&2
   exit 2

--- a/hooks/block-unsafe-rm.sh
+++ b/hooks/block-unsafe-rm.sh
@@ -22,11 +22,20 @@ INPUT=$(cat)
 
 # A payload that does not parse, or that names a command which is not a
 # string, is refused rather than skipped. An absent command is the empty
-# string and passes. The null tests are spelled out because jq's `//` reads
-# `false` as absent, and `false` is not a command either.
+# string and passes. The command is read where each harness carries it:
+# `tool_input.command` (Claude Code, Codex, Gemini CLI and the Pi carrier), a
+# bare `command`, or Copilot's `toolArgs.command`, whose `toolArgs` arrives as
+# an object or as one JSON-encoded string. The null tests are spelled out
+# because jq's `//` reads `false` as absent, and `false` is not a command
+# either.
 if ! COMMAND=$(printf '%s' "$INPUT" \
-  | jq -r 'if .tool_input.command == null then (if .command == null then "" else .command end)
-           else .tool_input.command end
+  | jq -r 'def copilot: .toolArgs
+             | if . == null then null elif type == "string" then fromjson else . end
+             | if . == null then null elif type == "object" then .command else error end;
+           if .tool_input.command != null then .tool_input.command
+           elif .command != null then .command
+           elif copilot != null then copilot
+           else "" end
            | if type == "string" then . else error end' 2>/dev/null); then
   echo "block-unsafe-rm: hook payload is not valid JSON, or names a command that is not a string; refusing rather than skipping the guard" >&2
   exit 2

--- a/hooks/pre-commit-check.sh
+++ b/hooks/pre-commit-check.sh
@@ -26,11 +26,20 @@ INPUT=$(cat)
 
 # A payload that does not parse, or that names a command which is not a
 # string, is refused rather than skipped. An absent command is the empty
-# string and passes. The null tests are spelled out because jq's `//` reads
-# `false` as absent, and `false` is not a command either.
+# string and passes. The command is read where each harness carries it:
+# `tool_input.command` (Claude Code, Codex, Gemini CLI and the Pi carrier), a
+# bare `command`, or Copilot's `toolArgs.command`, whose `toolArgs` arrives as
+# an object or as one JSON-encoded string. The null tests are spelled out
+# because jq's `//` reads `false` as absent, and `false` is not a command
+# either.
 if ! COMMAND=$(printf '%s' "$INPUT" \
-  | jq -r 'if .tool_input.command == null then (if .command == null then "" else .command end)
-           else .tool_input.command end
+  | jq -r 'def copilot: .toolArgs
+             | if . == null then null elif type == "string" then fromjson else . end
+             | if . == null then null elif type == "object" then .command else error end;
+           if .tool_input.command != null then .tool_input.command
+           elif .command != null then .command
+           elif copilot != null then copilot
+           else "" end
            | if type == "string" then . else error end' 2>/dev/null); then
   echo "pre-commit-check: hook payload is not valid JSON, or names a command that is not a string; refusing rather than skipping the guard" >&2
   exit 2

--- a/hooks/tests/block-bare-cd.test.sh
+++ b/hooks/tests/block-bare-cd.test.sh
@@ -100,6 +100,16 @@ assert_eq "$rc" 0 'an empty command is read, not a read failure'
 run_payload '{"tool_name":"Bash","tool_input":{}}'
 assert_eq "$rc" 0 'a payload naming no command passes'
 
+echo "=== block-bare-cd: Copilot carries the command under toolArgs ==="
+run_payload '{"sessionId":"s","timestamp":1,"cwd":"/w","toolName":"bash","toolArgs":{"command":"cd /tmp"}}'
+assert_eq "$rc" 2 'a Copilot toolArgs object is read'
+run_payload '{"toolName":"bash","toolArgs":"{\"command\":\"cd /tmp\"}"}'
+assert_eq "$rc" 2 'a Copilot toolArgs JSON string is read'
+run_payload '{"toolName":"bash","toolArgs":{"command":"(cd /tmp && ls)"}}'
+assert_eq "$rc" 0 'a scoped cd under toolArgs passes, so the shape is read rather than refused'
+run_payload '{"toolName":"bash","toolArgs":"not json"}'
+assert_eq "$rc" 2 'a toolArgs string that is not JSON refuses rather than skipping the guard'
+
 echo "=== block-bare-cd: without the tools that read the payload ==="
 NOJQ_BIN="$TMP_ROOT/nojq"
 mkdir -p "$NOJQ_BIN"

--- a/hooks/tests/block-repo-copy.test.sh
+++ b/hooks/tests/block-repo-copy.test.sh
@@ -213,6 +213,16 @@ assert_eq "$rc" 0 'an empty command is read, not a read failure'
 # top level is read the same way, and that fallback is a branch of its own.
 run_payload "{\"command\":\"cp -r $REPO/.git /tmp/copy\"}"
 assert_eq "$rc" 2 'a top-level command field is read like a nested one'
+# Copilot carries the command under toolArgs, as an object or as one
+# JSON-encoded string.
+run_payload "{\"sessionId\":\"s\",\"timestamp\":1,\"cwd\":\"/w\",\"toolName\":\"bash\",\"toolArgs\":{\"command\":\"cp -r $REPO/.git /tmp/copy\"}}"
+assert_eq "$rc" 2 'a Copilot toolArgs object is read'
+run_payload "{\"toolName\":\"bash\",\"toolArgs\":\"{\\\"command\\\":\\\"cp -r $REPO/.git /tmp/copy\\\"}\"}"
+assert_eq "$rc" 2 'a Copilot toolArgs JSON string is read'
+run_payload "{\"toolName\":\"bash\",\"toolArgs\":{\"command\":\"cp -r $REPO/src /tmp/copy\"}}"
+assert_eq "$rc" 0 'a harmless copy under toolArgs passes, so the shape is read rather than refused'
+run_payload '{"toolName":"bash","toolArgs":"not json"}'
+assert_eq "$rc" 2 'a toolArgs string that is not JSON refuses rather than skipping the guard'
 
 NOJQ_BIN="$TMP_ROOT/nojq"
 mkdir -p "$NOJQ_BIN"

--- a/hooks/tests/block-unsafe-rm.test.sh
+++ b/hooks/tests/block-unsafe-rm.test.sh
@@ -151,6 +151,16 @@ run_payload '{"command":"rm -rf $X"}'
 assert_eq "$rc" 2 'a top-level command field is read like a nested one'
 run_payload '{"command":false}'
 assert_eq "$rc" 2 'and a top-level false is refused, not read as an absent one'
+# Copilot carries the command under toolArgs, as an object or as one
+# JSON-encoded string.
+run_payload '{"sessionId":"s","timestamp":1,"cwd":"/w","toolName":"bash","toolArgs":{"command":"rm -rf $X/sub"}}'
+assert_eq "$rc" 2 'a Copilot toolArgs object is read'
+run_payload '{"toolName":"bash","toolArgs":"{\"command\":\"rm -rf $X/sub\"}"}'
+assert_eq "$rc" 2 'a Copilot toolArgs JSON string is read'
+run_payload '{"toolName":"bash","toolArgs":{"command":"rm -rf -- \"${X:?}/sub\""}}'
+assert_eq "$rc" 0 'the accepted rewrite under toolArgs passes, so the shape is read rather than refused'
+run_payload '{"toolName":"bash","toolArgs":"not json"}'
+assert_eq "$rc" 2 'a toolArgs string that is not JSON refuses rather than skipping the guard'
 
 NOJQ_BIN="$TMP_ROOT/nojq"
 mkdir -p "$NOJQ_BIN"

--- a/hooks/tests/pre-commit-check.test.sh
+++ b/hooks/tests/pre-commit-check.test.sh
@@ -239,6 +239,19 @@ assert_eq "$rc" "2" "a command that is not a string is refused"
 assert_contains "$err" "not valid JSON, or names a command that is not a string" "the refusal names the payload"
 assert_eq "$log" "" "nothing ran for the unreadable payload"
 
+echo
+echo "Copilot carries the command under toolArgs, as an object or as one JSON-encoded string"
+
+run_hook "$ARMED" '{"sessionId":"s","timestamp":1,"cwd":"/w","toolName":"bash","toolArgs":{"command":"git commit '"$NV"' -m x"}}'
+assert_eq "$rc" "2" "a Copilot toolArgs object is read"
+assert_contains "$err" "would skip this repository's armed git hooks" "the bypass under toolArgs is named"
+run_hook "$ARMED" '{"toolName":"bash","toolArgs":"{\"command\":\"git commit '"$NV"' -m x\"}"}'
+assert_eq "$rc" "2" "a Copilot toolArgs JSON string is read"
+run_hook "$ARMED" '{"toolName":"bash","toolArgs":{"command":"git commit -m x"}}'
+assert_eq "$rc" "0" "a plain commit under toolArgs passes, so the shape is read rather than refused"
+run_hook "$ARMED" '{"toolName":"bash","toolArgs":"not json"}'
+assert_eq "$rc" "2" "a toolArgs string that is not JSON refuses rather than skipping the guard"
+
 run_hook "$UNARMED" '{"tool_input":{"command":"git commit -m x'
 assert_eq "$rc" "2" "a command string that never ends is refused"
 


### PR DESCRIPTION
Copilot registers the shell guards as enforced `preToolUse` hooks but carries the command as `toolArgs.command` (an object, or one JSON-encoded string) where every other harness sends `tool_input.command`. block-bare-cd, block-repo-copy and pre-commit-check read only the latter, so on Copilot each read an empty command and passed everything it guards. block-unsafe-rm is not delivered to Copilot (its `harnesses:` line leaves it out) and takes the same reader so the four guards keep one reading of the payload.

The hooks now read the command where each harness carries it, the way command-safety already does. A `toolArgs` string that is not JSON is a payload that cannot be read and refuses.

Each suite gains the Copilot shapes (object, JSON string, a harmless command that passes, an unreadable string). Run against the previous hooks with `HOOK_UNDER_TEST`, those rows go red. All four suites pass under bash 5.3 and bash 3.2.57. The tracked renders under `.claude/hooks`, `.codex/hooks` and `.pi/kendex/hooks` carry the same bytes.

Found by the hooks audit, KEN-1232.

https://claude.ai/code/session_01G8mGZKa8sxjow9QaQuMAWp
