### PR TITLE
fix(ci): the source repo runs the candidate bot-instructions checker

### DIFF
--- a/.agents/skills/bot-instructions/SKILL.md
+++ b/.agents/skills/bot-instructions/SKILL.md
@@ -63,7 +63,7 @@ A repo enables `[bot-instructions.exclusions] derive_render` or lists every rend
 
 - Treat every policy path below as invalidating prior review evidence.
 - Require trusted human approval on a pull request that touches a policy path.
-- Run `check` in CI from the default branch copy, with `--spec` naming the pull request tree's package copy.
+- Run `check` in CI from the default branch copy, with `--spec` naming the pull request tree's package copy. The package's own source repository runs the pull request's checker instead: a renderer change judged by the default-branch copy drifts by construction.
 
 ## The render inputs
 

--- a/.github/workflows/skill-tests.yml
+++ b/.github/workflows/skill-tests.yml
@@ -34,6 +34,12 @@ permissions:
   contents: read
 
 jobs:
+  # This repository is the package's source, so the candidate's own checker
+  # judges the candidate's renders: a change to the renderer or the derivation
+  # is judged by itself. The trusted default-branch checker is the consumer
+  # rule (SKILL.md § A pull request changing its own review); here it would
+  # report drift by construction on every such change. Code review covers the
+  # checker, and the review gate holds every policy path.
   bot-instructions:
     name: Bot instructions
     runs-on: ubuntu-latest
@@ -43,13 +49,8 @@ jobs:
         with:
           path: candidate
           persist-credentials: false
-      - uses: actions/checkout@v4
-        with:
-          ref: ${{ github.event.repository.default_branch }}
-          path: bot-checker
-          persist-credentials: false
       - id: bot-instructions-check
-        run: bot-checker/skills/bot-instructions/scripts/bot-instructions check --repo candidate --spec candidate/skills/bot-instructions
+        run: candidate/skills/bot-instructions/scripts/bot-instructions check --repo candidate --spec candidate/skills/bot-instructions
 
   # SHARDED: five shards bound wall time at the slowest shard and give suite
   # growth per-shard headroom instead of a shared cliff. `orch` and `rest`

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -44,7 +44,7 @@ From a worktree, `kendex apply`, `kendex refresh` and `kendex verify --scope pro
 
 ## Review bot files
 
-Edit `[bot-instructions]` in `kendex-local.toml`. The installed [bot-instructions skill](../skills/bot-instructions/SKILL.md) owns the root review section and Copilot files. The commit guard checks their staged state; full validation checks their worktree state. CI runs the default-branch checker against the candidate configuration and doctrine.
+Edit `[bot-instructions]` in `kendex-local.toml`. The installed [bot-instructions skill](../skills/bot-instructions/SKILL.md) owns the root review section and Copilot files. The commit guard checks their staged state; full validation checks their worktree state. CI runs the candidate's own checker against the candidate configuration and doctrine; the default-branch checker is the consumer rule.
 
 Codex and Copilot retain their existing review capability. Other vendor capabilities are off because their settings are unconfirmed. Local checks prove generated file consistency, not vendor enablement, instruction loading, content exclusions, or automatic review settings. Confirm those through the [settings checklist](../skills/bot-instructions/references/checklist.md#the-settings).
 

--- a/skills/bot-instructions/SKILL.md
+++ b/skills/bot-instructions/SKILL.md
@@ -55,7 +55,7 @@ A repo enables `[bot-instructions.exclusions] derive_render` or lists every rend
 
 - Treat every policy path below as invalidating prior review evidence.
 - Require trusted human approval on a pull request that touches a policy path.
-- Run `check` in CI from the default branch copy, with `--spec` naming the pull request tree's package copy.
+- Run `check` in CI from the default branch copy, with `--spec` naming the pull request tree's package copy. The package's own source repository runs the pull request's checker instead: a renderer change judged by the default-branch copy drifts by construction.
 
 ## The render inputs
 

--- a/tools/tests/bot-instructions.test.sh
+++ b/tools/tests/bot-instructions.test.sh
@@ -1,5 +1,9 @@
 #!/usr/bin/env bash
-# The CI command must use candidate doctrine and reject stale generated files.
+# The CI command runs the CANDIDATE's checker on the candidate spec and
+# rejects stale generated files. This repository is the package's source, so
+# a change to the renderer or the derivation is judged by itself; the trusted
+# default-branch checker is the consumer rule, and here it reported drift by
+# construction on every such change.
 set -euo pipefail
 REPO="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 source "$REPO/skills/bot-instructions/tests/lib/harness.sh"
@@ -18,11 +22,6 @@ changed, count = re.subn(r'(?m)^  version: "[^"]+"$', '  version: "candidate"', 
 assert count == 1 and changed != s
 p.write_text(changed)
 PY
-# A pull request can replace its checker with a passing script. CI must use
-# the trusted checkout's executable while reading this candidate's doctrine.
-mkdir -p "$spec/scripts" || exit 1
-printf '#!/usr/bin/env bash\nexit 0\n' >"$spec/scripts/bot-instructions"
-chmod +x "$spec/scripts/bot-instructions" || exit 1
 bi_must adopt --repo "$candidate" --spec "$spec" || exit 1
 bi_must render --repo "$candidate" --spec "$spec" || exit 1
 bi_commit "$candidate"
@@ -35,20 +34,31 @@ command="$(awk '
 runner="$BI_TMP/runner"
 mkdir -p "$runner" || exit 1
 ln -s "$candidate" "$runner/candidate" || exit 1
-checker="$runner/bot-checker/skills/bot-instructions"
-python3 - "$BI_ROOT/skills/bot-instructions" "$checker" <<'PY' || exit 1
+
+# The candidate's checker is what runs: a stub in the candidate's own package
+# copy decides the exit code. With a trusted-checkout checker this stub would
+# never be reached.
+mkdir -p "$spec/scripts" || exit 1
+printf '#!/usr/bin/env bash\nexit 3\n' >"$spec/scripts/bot-instructions"
+chmod +x "$spec/scripts/bot-instructions" || exit 1
+output="$(cd "$runner" && bash -c "$command" 2>&1)" && status=0 || status=$?
+[ "$status" -eq 3 ] && ok "CI runs the candidate's checker" \
+  || bad "CI runs the candidate's checker" "exit $status: $output"
+
+# The real package in the candidate's copy: a clean candidate passes and a
+# stale one is refused, so the wiring judges what it reads.
+rm -rf -- "${spec:?}/scripts"
+python3 - "$BI_ROOT/skills/bot-instructions/scripts" "$spec/scripts" <<'PY' || exit 1
 import shutil, sys
 shutil.copytree(sys.argv[1], sys.argv[2], ignore=shutil.ignore_patterns('__pycache__', '*.pyc'))
 PY
-
-output="$(cd "$runner" && bash -c "$command" 2>&1)"
-status=$?
-[ "$status" -eq 0 ] && ok "CI reads the candidate spec through the trusted checker" \
-  || bad "CI reads the candidate spec through the trusted checker" "$output"
-if python3 - "$checker" <<'PY'; then
+output="$(cd "$runner" && bash -c "$command" 2>&1)" && status=0 || status=$?
+[ "$status" -eq 0 ] && ok "a clean candidate passes its own checker" \
+  || bad "a clean candidate passes its own checker" "exit $status: $output"
+if python3 - "$spec" <<'PY'; then
 from pathlib import Path
 import sys
-assert not list(Path(sys.argv[1]).rglob('*.pyc')), 'the checker wrote bytecode into its installed files'
+assert not list(Path(sys.argv[1]).rglob('*.pyc')), 'the checker wrote bytecode into its package files'
 PY
   ok "running the checker leaves its package files unchanged"
 else
@@ -56,8 +66,7 @@ else
 fi
 
 printf '\nStale instructions.\n' >>"$candidate/.github/copilot-instructions.md"
-output="$(cd "$runner" && bash -c "$command" 2>&1)"
-status=$?
+output="$(cd "$runner" && bash -c "$command" 2>&1)" && status=0 || status=$?
 if [ "$status" -eq 1 ] && [[ "$output" == *"drift:"*".github/copilot-instructions.md"* ]]; then
   ok "CI refuses stale candidate output"
 else


### PR DESCRIPTION
Class: CI wiring from #2139 applied the consumer rule to the package's source repository. The `Bot instructions` job ran the default-branch checker against the candidate spec, so any PR changing the renderer or the derivation (#2146, #2147) reports drift by construction, and the `Skill suites` aggregator fails with it. kendex is the package source: the candidate's own checker judges the candidate's renders. The trusted default-branch checker stays the consumer rule in SKILL.md.

- `.github/workflows/skill-tests.yml`: one checkout, the candidate's checker on the candidate spec, with the reason above the job.
- `tools/tests/bot-instructions.test.sh`: a stub checker in the candidate copy decides the exit code (fails on main's wiring, which never reaches it); the real package copied into the candidate passes clean and refuses stale output; no bytecode written into the package.
- `skills/bot-instructions/SKILL.md` § A pull request changing its own review: the source-repo sentence. `docs/DEVELOPMENT.md`: the CI line.

Checks: `tools/tests/bot-instructions.test.sh` 4 passed; against the old workflow 3 of 4 fail. Pre-commit chain and `tools/guard` clean.

Unblocks #2146 and #2147; held for the overseer's MERGE.

https://claude.ai/code/session_01P2PmJhqV1CYhWB4yDJdv3q