### PR TITLE
fix(pi-background-tasks): expire finished widgets safely

### DIFF
--- a/changelog.d/fixed/2071.md
+++ b/changelog.d/fixed/2071.md
@@ -1,0 +1,1 @@
+- Background task widgets disappear when their last finished task reaches its configured retention limit instead of showing zero tasks. — thanks @lhl

--- a/pi-extensions/pi-background-tasks/extensions/background-tasks.ts
+++ b/pi-extensions/pi-background-tasks/extensions/background-tasks.ts
@@ -79,6 +79,7 @@ import {
 } from "./snapshot.js";
 import { MINI_DASHBOARD_RANK, setMiniDashboardWidget } from "./stacked-widget.js";
 import {
+	createBackgroundWidgetExpiryScheduler,
 	createBackgroundWidgetVisibility,
 	shouldRenderBackgroundWidget,
 	toggleBackgroundWidgetVisibility,
@@ -253,7 +254,9 @@ export default function backgroundTasks(pi: ExtensionAPI): void {
 		task.forceKillTimer = null;
 	};
 
+	const widgetExpiry = createBackgroundWidgetExpiryScheduler(() => activeCtx ? syncWidget(activeCtx) : undefined);
 	const clearWidget = () => {
+		widgetExpiry.clear();
 		if (activeCtx) setMiniDashboardWidget(activeCtx, BG_WIDGET_KEY, MINI_DASHBOARD_RANK.BACKGROUND_TASKS, undefined);
 		requestWidgetRender = null;
 	};
@@ -293,15 +296,17 @@ export default function backgroundTasks(pi: ExtensionAPI): void {
 		return lines;
 	};
 
-	const syncWidget = (ctx: ExtensionContext) => {
+	function syncWidget(ctx: ExtensionContext): void {
 		activeCtx = ctx;
-		const visibleTaskCount = widgetTasks().length;
+		widgetExpiry.clear();
+		const now = Date.now();
+		const visibleTasks = widgetTasks(now);
 		if (!shouldRenderBackgroundWidget({
 			hasUi: ctx.hasUI,
 			mode: widgetVisibility.mode,
 			showWidget: settingBoolean("showWidget", true, ctx.cwd),
 			trackedTaskCount: tasks.size,
-			visibleTaskCount,
+			visibleTaskCount: visibleTasks.length,
 		})) {
 			clearWidget();
 			return;
@@ -313,9 +318,9 @@ export default function backgroundTasks(pi: ExtensionAPI): void {
 			MINI_DASHBOARD_RANK.BACKGROUND_TASKS,
 			(tui, theme) => {
 				requestWidgetRender = () => tui.requestRender();
-				// Refresh relative-time text only on task events. A timer would redraw the
-				// full screen for each label change and cause above-viewport flicker when
-				// the chat overflows. Labels can stay stale between task events.
+				// No recurring redraw for relative-time labels: full-screen redraws cause
+				// above-viewport flicker. Labels can stay stale between task events;
+				// the one-shot expiry refresh only updates task visibility.
 				return {
 					dispose() {
 						if (requestWidgetRender) requestWidgetRender = null;
@@ -328,7 +333,9 @@ export default function backgroundTasks(pi: ExtensionAPI): void {
 			},
 			{ placement: settingString("widgetPlacement", "aboveEditor", ctx.cwd) === "belowEditor" ? "belowEditor" : "aboveEditor" },
 		);
-	};
+
+		widgetExpiry.schedule(visibleTasks, widgetFinishedRetentionMs(ctx.cwd), now);
+	}
 
 	const refreshUi = () => {
 		for (const task of tasks.values()) rememberSnapshot(task);

--- a/pi-extensions/pi-background-tasks/extensions/widget-visibility.ts
+++ b/pi-extensions/pi-background-tasks/extensions/widget-visibility.ts
@@ -64,10 +64,13 @@ export function createBackgroundWidgetExpiryScheduler(
 			clear();
 			const delay = nextBackgroundWidgetExpiryDelay(tasks, retentionMs, now);
 			if (delay === null) return;
+			// Node/Bun turn overflowing waits (including Infinity from seconds-to-ms
+			// conversion) into 1ms. Bound the wait, not retention: refresh rechecks
+			// the remaining lifetime and schedules again if the task is still visible.
 			timer = scheduleTimer(() => {
 				timer = null;
 				refresh();
-			}, delay);
+			}, Math.min(delay, 2_147_483_647));
 			timer.unref?.();
 		},
 	};

--- a/pi-extensions/pi-background-tasks/extensions/widget-visibility.ts
+++ b/pi-extensions/pi-background-tasks/extensions/widget-visibility.ts
@@ -26,3 +26,49 @@ export function toggleBackgroundWidgetVisibility(state: BackgroundWidgetVisibili
 export function shouldRenderBackgroundWidget(input: { hasUi: boolean; trackedTaskCount: number; visibleTaskCount: number; showWidget: boolean; mode: BackgroundWidgetMode }): boolean {
 	return input.hasUi && input.trackedTaskCount > 0 && input.visibleTaskCount > 0 && input.showWidget && input.mode !== "hidden";
 }
+
+export function nextBackgroundWidgetExpiryDelay(
+	tasks: Iterable<{ status: string; updatedAt: number }>,
+	retentionMs: number,
+	now: number,
+): number | null {
+	let delay: number | null = null;
+	for (const task of tasks) {
+		if (task.status === "running") continue;
+		const remaining = task.updatedAt + retentionMs - now;
+		if (remaining < 0) continue;
+		const candidate = remaining + 1;
+		delay = delay === null ? candidate : Math.min(delay, candidate);
+	}
+	return delay;
+}
+
+// Expiry uses one-shot timers so relative-time labels do not restore the old
+// per-second full-screen render interval.
+export function createBackgroundWidgetExpiryScheduler(
+	refresh: () => void,
+	scheduleTimer: typeof setTimeout = setTimeout,
+	clearTimer: typeof clearTimeout = clearTimeout,
+): {
+	clear: () => void;
+	schedule: (tasks: Iterable<{ status: string; updatedAt: number }>, retentionMs: number, now: number) => void;
+} {
+	let timer: ReturnType<typeof setTimeout> | null = null;
+	const clear = () => {
+		if (timer) clearTimer(timer);
+		timer = null;
+	};
+	return {
+		clear,
+		schedule(tasks, retentionMs, now) {
+			clear();
+			const delay = nextBackgroundWidgetExpiryDelay(tasks, retentionMs, now);
+			if (delay === null) return;
+			timer = scheduleTimer(() => {
+				timer = null;
+				refresh();
+			}, delay);
+			timer.unref?.();
+		},
+	};
+}

--- a/pi-extensions/pi-background-tasks/tests/fixtures/widget-lifecycle.ts
+++ b/pi-extensions/pi-background-tasks/tests/fixtures/widget-lifecycle.ts
@@ -1,0 +1,171 @@
+import { mock } from "bun:test";
+import assert from "node:assert/strict";
+import { writeFileSync } from "node:fs";
+import { join } from "node:path";
+import type { ExtensionAPI, ExtensionContext, Theme } from "@earendil-works/pi-coding-agent";
+import type { BackgroundTaskSnapshot } from "../../extensions/types.js";
+import type { TUI } from "@earendil-works/pi-tui";
+import type { MiniDashboardComponent, MiniDashboardFactory } from "../../extensions/stacked-widget.js";
+
+// Only external peer exports and the Pi host boundary are mocked. Settings,
+// restore, syncWidget, expiry and the shared stack run their production code.
+mock.module("@earendil-works/pi-coding-agent", () => ({ getShellConfig: () => { throw new Error("unexpected spawn"); } }));
+mock.module("@earendil-works/pi-ai", () => ({ StringEnum: (values: readonly string[]) => ({ enum: values }) }));
+mock.module("@earendil-works/pi-tui", () => ({
+	truncateToWidth: (text: string, width: number) => text.slice(0, width),
+	visibleWidth: (text: string) => text.length,
+	wrapTextWithAnsi: (text: string) => [text],
+	matchesKey: () => false,
+}));
+mock.module("typebox", () => {
+	const schema = (value?: unknown) => ({ schema: value });
+	return { Type: { Object: schema, Optional: schema, String: schema, Number: schema, Boolean: schema } };
+});
+
+const { default: backgroundTasks } = await import("../../extensions/background-tasks.js");
+const { setMiniDashboardWidget } = await import("../../extensions/stacked-widget.js");
+const { BG_WIDGET_KEY, CONFIG_ID } = await import("../../extensions/constants.js");
+const scenario = process.argv[2];
+const seconds = Number(process.argv[3]);
+const placement = scenario === "expiry-below" ? "belowEditor" : "aboveEditor";
+writeFileSync(join(process.cwd(), "settings.json"), JSON.stringify({
+	kendex: { extensionManager: { config: { [CONFIG_ID]: { widgetFinishedRetentionSeconds: seconds, widgetPlacement: placement } } } },
+}));
+
+const start = 1_700_000_000_000;
+let now = start;
+Date.now = () => now;
+type Timer = { callback: () => void; delay: number; unref(): void };
+const timers = new Set<Timer>();
+globalThis.setTimeout = ((callback: () => void, delay: number) => {
+	assert.ok(delay >= 1 && delay <= 2_147_483_647, `native-unsafe expiry delay: ${delay}`);
+	const timer = { callback, delay, unref() {} };
+	timers.add(timer);
+	return timer;
+}) as unknown as typeof setTimeout;
+globalThis.clearTimeout = ((timer: Timer) => { timers.delete(timer); }) as unknown as typeof clearTimeout;
+const nextTimer = () => {
+	assert.equal(timers.size, 1, "exactly one pending expiry");
+	return [...timers][0];
+};
+const fire = () => {
+	const timer = nextTimer();
+	timers.delete(timer);
+	now += timer.delay;
+	timer.callback();
+};
+
+const widgets = new Map<string, MiniDashboardComponent>();
+const removals: string[] = [];
+const theme = { fg: (_color: string, text: string) => text, bold: (text: string) => text } as unknown as Theme;
+const tui = { terminal: { rows: 40 }, requestRender() {} } as unknown as TUI;
+const stackKey = `kendex-mini-dashboard-stack-${placement === "aboveEditor" ? "above" : "below"}`;
+const registry = () => (globalThis as unknown as Record<symbol, { entries: Map<string, unknown> }>)[Symbol.for("kendex.pi.mini-dashboard-stack")];
+let session = 0;
+function createSession(completed: boolean) {
+	const id = `widget-${++session}`;
+	const handlers = new Map<string, (event: unknown, ctx: ExtensionContext) => unknown>();
+	const shortcuts = new Map<string, { handler: (ctx: ExtensionContext) => unknown }>();
+	const pi = {
+		on: (event: string, handler: (event: unknown, ctx: ExtensionContext) => unknown) => handlers.set(event, handler),
+		registerShortcut: (key: string, definition: { handler: (ctx: ExtensionContext) => unknown }) => shortcuts.set(key, definition),
+		registerTool() {}, registerCommand() {}, registerMessageRenderer() {}, appendEntry() {},
+		sendMessage() { throw new Error("unexpected wake"); },
+	} as unknown as ExtensionAPI;
+	const ctx = {
+		cwd: process.cwd(), hasUI: true, isIdle: () => true, isProjectTrusted: () => false,
+		sessionManager: {
+			getSessionId: () => id,
+			getSessionFile: () => join(process.cwd(), `${id}.jsonl`),
+			getBranch: () => completed ? [{ type: "message", message: { role: "toolResult", toolName: "bg_task", details: { tasks: [{
+				id: "bg-1", title: "true", command: "true", cwd: process.cwd(), pid: 0, status: "completed", exitCode: 0,
+				startedAt: start, updatedAt: start, lastOutputAt: null, expiresAt: null, outputBytes: 0,
+				logFile: join(process.cwd(), "task.log"), notifyOnExit: false, notifyOnOutput: false, exitNotified: true,
+			} satisfies BackgroundTaskSnapshot] } } }] : [],
+		},
+		ui: {
+			notify(message: string) { throw new Error(message); },
+			setWidget(key: string, factory: MiniDashboardFactory | undefined) {
+				widgets.get(key)?.dispose?.();
+				widgets.delete(key);
+				if (factory) widgets.set(key, factory(tui, theme));
+				else removals.push(key);
+			},
+		},
+	} as unknown as ExtensionContext;
+	backgroundTasks(pi);
+	return {
+		emit(event: string) {
+			const handler = handlers.get(event);
+			assert.ok(handler, `missing ${event} handler`);
+			return handler({}, ctx);
+		},
+		hide() {
+			const shortcut = shortcuts.get("alt+h");
+			assert.ok(shortcut, "missing widget shortcut");
+			return shortcut.handler(ctx);
+		},
+		ctx,
+	};
+}
+
+let active = createSession(true);
+try {
+	await active.emit("session_start");
+	assert.ok(registry().entries.has(BG_WIDGET_KEY));
+	assert.match(widgets.get(stackKey)!.render(120).join("\n"), /bg-1/);
+	const first = nextTimer();
+	assert.equal(first.delay, Math.min(Math.floor(seconds * 1_000) + 1, 2_147_483_647));
+	await active.emit("session_compact");
+	assert.ok(!timers.has(first), "resync cancels previous expiry");
+	nextTimer();
+	if (scenario === "sibling") {
+		setMiniDashboardWidget(active.ctx, "sibling", 20, () => ({ render: () => ["sibling"], invalidate() {} }));
+	}
+	if (["hide", "shutdown", "switch"].includes(scenario)) {
+		if (scenario === "hide") await active.hide();
+		else await active.emit("session_shutdown");
+		assert.equal(timers.size, 0, "cleanup cancels expiry");
+		assert.ok(!registry().entries.has(BG_WIDGET_KEY));
+		assert.ok(removals.includes(stackKey), "host widget unregistered");
+		if (scenario === "switch") {
+			// Pi replaces the extension instance between shutdown and session_start.
+			active = createSession(false);
+			await active.emit("session_start");
+		}
+		now += 60_000;
+		assert.equal(timers.size, 0);
+		assert.ok(!registry().entries.has(BG_WIDGET_KEY));
+	} else if (scenario === "overflow") {
+		fire();
+		assert.ok(registry().entries.has(BG_WIDGET_KEY));
+		assert.equal(nextTimer().delay, 2_147_483_647);
+	} else {
+		const retention = Math.floor(seconds * 1_000);
+		if (retention + 1 > 2_147_483_647) {
+			fire();
+			assert.ok(registry().entries.has(BG_WIDGET_KEY), "bounded recheck must preserve retention");
+			assert.equal(nextTimer().delay, start + retention - now + 1, "recompute remaining delay");
+		}
+		// Inclusive boundary: rendering at the deadline still includes the task.
+		now = start + retention;
+		assert.match(widgets.get(stackKey)!.render(120).join("\n"), /bg-1/);
+		const last = nextTimer();
+		timers.delete(last);
+		now++;
+		last.callback();
+		assert.ok(!registry().entries.has(BG_WIDGET_KEY), "expiry removes registry entry without a task event");
+		assert.equal(timers.size, 0);
+		if (scenario === "sibling") {
+			assert.ok(registry().entries.has("sibling"));
+			assert.deepEqual(widgets.get(stackKey)!.render(120), ["sibling"]);
+			assert.ok(!removals.includes(stackKey), "sibling keeps host stack registered");
+			setMiniDashboardWidget(active.ctx, "sibling", 20, undefined);
+		} else {
+			assert.ok(removals.includes(stackKey), "expiry calls host unregister");
+			assert.ok(!widgets.has(stackKey));
+		}
+	}
+} finally {
+	await active.emit("session_shutdown");
+}

--- a/pi-extensions/pi-background-tasks/tests/widget-lifecycle.test.ts
+++ b/pi-extensions/pi-background-tasks/tests/widget-lifecycle.test.ts
@@ -1,0 +1,36 @@
+import { expect, test } from "bun:test";
+import { spawnSync } from "node:child_process";
+import { mkdirSync, mkdtempSync, rmSync } from "node:fs";
+import { resolve } from "node:path";
+
+// Separate processes isolate peer mocks, the stack registry, settings and the clock
+// from other suites that run real background tasks.
+for (const [scenario, seconds] of [
+	["expiry-above", 15],
+	["expiry-below", 15],
+	["sibling", 15],
+	["hide", 15],
+	["shutdown", 15],
+	["switch", 15],
+	["boundary-before", 2_147_483.646],
+	["boundary-at", 2_147_483.647],
+	["thirty-days", 2_592_000],
+	["overflow", 1e308],
+] as const) {
+	test(`widget lifecycle: ${scenario}`, () => {
+		const root = resolve(import.meta.dir, "../../../tmp");
+		mkdirSync(root, { recursive: true });
+		const dir = mkdtempSync(resolve(root, "widget-lifecycle-"));
+		try {
+			const result = spawnSync(process.execPath, [resolve(import.meta.dir, "fixtures/widget-lifecycle.ts"), scenario, String(seconds)], {
+				cwd: dir,
+				env: { ...process.env, PI_CODING_AGENT_DIR: dir, PI_BG_TASK_DIR: dir },
+				encoding: "utf8",
+				timeout: 10_000,
+			});
+			expect({ error: result.error?.message, status: result.status, stderr: result.stderr }).toEqual({ error: undefined, status: 0, stderr: "" });
+		} finally {
+			rmSync(dir, { recursive: true, force: true });
+		}
+	});
+}

--- a/pi-extensions/pi-background-tasks/tests/widget-visibility.test.ts
+++ b/pi-extensions/pi-background-tasks/tests/widget-visibility.test.ts
@@ -1,6 +1,8 @@
 import { describe, expect, test } from "bun:test";
 import {
+	createBackgroundWidgetExpiryScheduler,
 	createBackgroundWidgetVisibility,
+	nextBackgroundWidgetExpiryDelay,
 	shouldRenderBackgroundWidget,
 	toggleBackgroundWidgetVisibility,
 } from "../extensions/widget-visibility.js";
@@ -28,5 +30,38 @@ describe("background task mini-dashboard visibility", () => {
 		toggleBackgroundWidgetVisibility(visibility);
 		expect(visibility.mode).toBe("expanded");
 		expect(lifecycleRefreshRenders(visibility.mode)).toBe(true);
+	});
+
+	test("refreshes after the earliest finished task expires", () => {
+		const tasks = [
+			{ status: "running", updatedAt: 500 },
+			{ status: "completed", updatedAt: 1_000 },
+			{ status: "failed", updatedAt: 2_000 },
+		];
+		expect(nextBackgroundWidgetExpiryDelay(tasks, 15_000, 10_000)).toBe(6_001);
+		expect(nextBackgroundWidgetExpiryDelay(tasks, 15_000, 16_001)).toBe(1_000);
+		expect(nextBackgroundWidgetExpiryDelay(tasks, 15_000, 17_001)).toBeNull();
+
+		let refreshes = 0;
+		let scheduledDelay = 0;
+		let callback = () => {};
+		let clears = 0;
+		const timer = { unref() {} } as ReturnType<typeof setTimeout>;
+		const expiry = createBackgroundWidgetExpiryScheduler(
+			() => refreshes++,
+			(nextCallback, delay) => {
+				callback = nextCallback;
+				scheduledDelay = delay;
+				return timer;
+			},
+			() => clears++,
+		);
+		expiry.schedule(tasks, 15_000, 10_000);
+		expect(scheduledDelay).toBe(6_001);
+		callback();
+		expect(refreshes).toBe(1);
+		expiry.schedule(tasks, 15_000, 10_000);
+		expiry.clear();
+		expect(clears).toBe(1);
 	});
 });


### PR DESCRIPTION
## Summary

Closes #2071.

Supersedes #2072. Carries forward @lhl's finished-widget expiry fix, preserving the original author on the cherry-pick. Thank you @lhl for the fix and regression test.

- Unregister the background-task widget when its last finished task expires, without a recurring relative-time redraw.
- Bound each expiry wait to the native timer limit, including the inclusive-boundary millisecond and finite seconds that overflow during conversion. Rechecks preserve the configured retention.
- Exercise the production extension, settings reader and stack through expiry, sibling preservation, hide, shutdown and session replacement.

## Validation

- Package tests: 184 passed.
- Package policy: 8 passed.
- Preflight, size-ratchet, scoped `tools/guard` and commit hook chain passed.
- Removing the clamp fails the boundary, 30-day and overflow cases. Disconnecting production scheduling fails the lifecycle regression.

Pi host registration and peer rendering/schema exports are mocked in isolated subprocesses. No live-terminal, full Pi-runtime or TypeScript typecheck claim.

Co-authored-by: lhl <lhl@randomfoo.net>
