### PR TITLE
feat(KEN-1242): MCP servers install on Antigravity in mcp_config.json

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ Installing a package from a git repository needs git 2.41 or newer; kendex refus
 | Skills | ● | ● | ● | ●¹ | ● | ● | ● | ● |
 | Hooks | ● | ● | ●² | ●¹ ² | ●³ | ● | ● | ● |
 | Commands | ● | ●⁴ | ● | ○⁵ | ● | ● | -⁶ | - |
-| MCP servers | ● | ○ | ● | ● | - | ●⁷ | ● | ○ |
+| MCP servers | ● | ○ | ● | ● | - | ●⁷ | ● | ● |
 | Plugins | ◐ | ○ | ○ | ○ | - | ○ | ◐ | ○ |
 | Pi extensions | - | - | - | - | ● | - | - | - |
 

--- a/changelog.d/added/KEN-1242-antigravity-mcp.md
+++ b/changelog.d/added/KEN-1242-antigravity-mcp.md
@@ -1,0 +1,1 @@
+- MCP servers install on Antigravity in `mcp_config.json` at both scopes, a remote endpoint written as `serverUrl`, switched off on the entry's `disabled`.

--- a/crates/core/src/engine/antigravity.rs
+++ b/crates/core/src/engine/antigravity.rs
@@ -41,3 +41,48 @@ pub(super) fn hook(name: &str, hook: &HookSpec, state: &mut DesiredState) -> Opt
     }
     Some(registered.hook)
 }
+
+/// The server entry as Antigravity keys it: a remote endpoint is `serverUrl`
+/// whatever transport it speaks, with no `type` beside it, since its docs
+/// say "Legacy fields like `url` or `httpUrl` are not supported"
+/// (antigravity.google/docs/mcp). A command server is read as written.
+pub(super) fn server(value: &serde_json::Value) -> serde_json::Value {
+    let Some(url) = value.get("url").and_then(serde_json::Value::as_str) else {
+        return value.clone();
+    };
+    let mut entry = value.clone();
+    let Some(object) = entry.as_object_mut() else {
+        return entry;
+    };
+    object.remove("type");
+    object.remove("url");
+    object.insert(
+        "serverUrl".to_owned(),
+        serde_json::Value::String(url.to_owned()),
+    );
+    entry
+}
+
+#[cfg(test)]
+mod server_tests {
+    use serde_json::json;
+
+    #[test]
+    fn a_remote_server_is_keyed_server_url_and_a_command_server_kept() {
+        assert_eq!(
+            super::server(&json!({"type": "http", "url": "https://mcp.example"})),
+            json!({"serverUrl": "https://mcp.example"})
+        );
+        assert_eq!(
+            super::server(&json!({"type": "sse", "url": "https://mcp.example/sse"})),
+            json!({"serverUrl": "https://mcp.example/sse"})
+        );
+        let stdio = json!({"command": "gh-mcp", "args": ["--stdio"]});
+        assert_eq!(super::server(&stdio), stdio);
+        // The endpoint stays visible to the safety rules under its new key.
+        let scored = crate::quality::McpEntry::from_json(&super::server(
+            &json!({"type": "http", "url": "https://u:secret@mcp.example"}),
+        ));
+        assert_eq!(scored.url.as_deref(), Some("https://u:secret@mcp.example"));
+    }
+}

--- a/crates/core/src/engine/desired_mcp.rs
+++ b/crates/core/src/engine/desired_mcp.rs
@@ -47,6 +47,24 @@ pub(super) fn desired_mcp(ctx: &ItemCtx, state: &mut DesiredState) -> Result<()>
                 });
                 continue;
             }
+            // Antigravity's documentation says nothing about substituting a
+            // reference in an `env` value, and kendex writes only
+            // references, so a server carrying one is refused rather than
+            // handed a literal `$NAME` to run with.
+            if harness == HarnessId::Antigravity
+                && value
+                    .get("env")
+                    .and_then(Value::as_object)
+                    .is_some_and(|env| !env.is_empty())
+            {
+                state.refused.push(super::desired::Refused {
+                    kind: ItemKind::McpServer,
+                    name: ctx.name.to_owned(),
+                    harness,
+                    reason: "Antigravity documents no substitution for an environment value, so a $NAME reference would reach the server as text — declare the server without env, or drop Antigravity from its harnesses".to_owned(),
+                });
+                continue;
+            }
             // Each harness keys the entry its own way, so a server written in
             // another tool's shape would not load: Copilot names the
             // transport on the entry, OpenCode takes one argv, its own key
@@ -63,12 +81,26 @@ pub(super) fn desired_mcp(ctx: &ItemCtx, state: &mut DesiredState) -> Result<()>
                     mcp_upsert(harness, ctx.name, super::copilot::server(&value))
                 }
                 (true, HarnessId::Cursor) => mcp_upsert(harness, ctx.name, cursor_server(&value)),
+                // Antigravity names a remote endpoint `serverUrl` and switches
+                // a server off with `disabled: true` on the entry, so its
+                // declaration stays in the file either way.
+                (true, HarnessId::Antigravity) => {
+                    mcp_upsert(harness, ctx.name, super::antigravity::server(&value))
+                }
+                (false, HarnessId::Antigravity) => {
+                    let mut off = super::antigravity::server(&value);
+                    if let Some(object) = off.as_object_mut() {
+                        object.insert("disabled".into(), Value::Bool(true));
+                    }
+                    mcp_upsert(harness, ctx.name, off)
+                }
                 (true, _) => mcp_upsert(harness, ctx.name, value.clone()),
                 (false, _) => mcp_remove(harness, ctx.name),
             };
-            // A switched-off OpenCode entry is still a write, so it is
-            // planned whether or not the file exists yet.
-            let writes = ctx.decl.enabled || harness == HarnessId::Opencode;
+            // A switched-off OpenCode or Antigravity entry is still a write,
+            // so it is planned whether or not the file exists yet.
+            let writes =
+                ctx.decl.enabled || matches!(harness, HarnessId::Opencode | HarnessId::Antigravity);
             registration_edits(&registry, edit, writes)
         };
         let artifact = Artifact::Registration {

--- a/crates/core/src/engine/scoring/input.rs
+++ b/crates/core/src/engine/scoring/input.rs
@@ -48,8 +48,9 @@ fn registration(
     let content = match item.kind {
         ItemKind::McpServer => match mcp_entry(edits) {
             Some(entry) => Content::Mcp(entry),
-            // A disabled server is planned as a removal, so the plan holds
-            // no entry to read and nothing about it can be judged.
+            // A disabled server is planned as a removal on every harness but
+            // Antigravity, which keeps the entry with its switch, so a plan
+            // holding no entry has nothing to judge.
             None => Content::Unread {
                 why: "this server is being removed from the harness's configuration, not written to it",
             },

--- a/crates/core/src/engine/targets.rs
+++ b/crates/core/src/engine/targets.rs
@@ -332,6 +332,14 @@ pub(super) fn mcp_registry(env: &Env, scope: &Scope, harness: HarnessId) -> Opti
             Scope::Global => adapter(harness).default_global_root(env).join("mcp.json"),
             Scope::Project { root } => root.join(".cursor/mcp.json"),
         }),
+        // Antigravity reads `mcp_config.json` under the customization root
+        // of either scope (antigravity.google/docs/mcp).
+        HarnessId::Antigravity => Some(match scope {
+            Scope::Global => adapter(harness)
+                .default_global_root(env)
+                .join("mcp_config.json"),
+            Scope::Project { root } => root.join(".agents/mcp_config.json"),
+        }),
         // Copilot reads a repository's servers from `.github/mcp.json` and a
         // machine's from its own config root (matrix §2). A `.mcp.json` at
         // the repo root is Claude Code's file, which Copilot also reads —

--- a/crates/core/src/harness/antigravity.rs
+++ b/crates/core/src/harness/antigravity.rs
@@ -44,8 +44,7 @@ fn surfaces(kind: ItemKind, root: &Path, shared: Option<&Path>) -> Vec<Surface> 
         ItemKind::Agent => vec![Surface::files(root.join("agents"), &["md"])],
         ItemKind::Skill => super::shared_first(shared, root.join("skills")),
         // `mcp_config.json` carries the `mcpServers` map every other tool
-        // reads; a remote server is keyed `serverUrl`, so it is read here
-        // and never written.
+        // reads, a remote server keyed `serverUrl`.
         ItemKind::McpServer => vec![Surface::Structured {
             path: root.join("mcp_config.json"),
             reader: Reader::McpServersJson,

--- a/crates/core/src/harness/caps.rs
+++ b/crates/core/src/harness/caps.rs
@@ -195,12 +195,9 @@ pub const fn format_caps(harness: HarnessId) -> FormatCaps {
             ..format_defaults()
         },
         // Antigravity's `mcp_config.json` carries `command` or a
-        // `serverUrl` it reads over SSE, and is read, never written; its
-        // names are unconstrained.
-        HarnessId::Antigravity => FormatCaps {
-            mcp_transports: &[Stdio, Sse],
-            ..format_defaults()
-        },
+        // `serverUrl` it reaches over SSE or streamable HTTP
+        // (antigravity.google/docs/mcp); its names are unconstrained.
+        HarnessId::Antigravity => format_defaults(),
     }
 }
 
@@ -416,12 +413,15 @@ pub fn capabilities(harness: HarnessId, kind: ItemKind) -> KindCaps {
 
         // Agents load from `agents/*.md` and skills from the shared tree at
         // either scope. Hooks run from `hooks.json` at either scope, the
-        // loader honouring the `decision` a command writes; MCP servers and
-        // plugins are read and never written.
+        // loader honouring the `decision` a command writes; plugins are read
+        // and never written.
         (Antigravity, Agent | Skill) => managed(BOTH),
         (Antigravity, Hook) => enforced(managed(BOTH)),
         (Antigravity, Command) => unsupported(),
-        (Antigravity, McpServer) => observe_only(BOTH),
+        // `mcp_config.json` under either root, `mcpServers.<name>` with a
+        // remote endpoint keyed `serverUrl` and a `disabled` switch on the
+        // entry (antigravity.google/docs/mcp).
+        (Antigravity, McpServer) => managed(BOTH),
         (Antigravity, Plugin) => observe_only(BOTH),
         (Antigravity, PiExtension) => unsupported(),
     }

--- a/crates/core/src/quality/mod.rs
+++ b/crates/core/src/quality/mod.rs
@@ -206,7 +206,11 @@ impl McpEntry {
             args,
             env,
             headers: map("headers"),
-            url: string("url"),
+            // Antigravity keys the endpoint `serverUrl` and Gemini's
+            // streamable-HTTP one is `httpUrl`; the secret scan reads all.
+            url: string("url")
+                .or_else(|| string("serverUrl"))
+                .or_else(|| string("httpUrl")),
         }
     }
 }

--- a/crates/core/src/scan/readers.rs
+++ b/crates/core/src/scan/readers.rs
@@ -49,7 +49,12 @@ fn mcp_object(servers: Option<&serde_json::Value>) -> Vec<RawEntry> {
     map.iter()
         .map(|(name, entry)| RawEntry {
             name: name.clone(),
-            enabled: None,
+            // Antigravity holds a switched-off server in the file under
+            // `disabled: true`; a file with no such key says nothing.
+            enabled: entry
+                .get("disabled")
+                .and_then(serde_json::Value::as_bool)
+                .map(|disabled| !disabled),
             description: mcp_summary(entry),
             source_path: None,
         })

--- a/crates/core/tests/antigravity.rs
+++ b/crates/core/tests/antigravity.rs
@@ -1,4 +1,4 @@
-//! Antigravity as a managed tool: an agent, a skill and a hook each install
+//! Antigravity as a managed tool: an agent, a skill, a hook and an MCP server each install
 //! in the shape its loader reads, switch on and off without losing
 //! anything, and come off disk on request — leaving the keys around ours in
 //! its registry untouched.
@@ -27,6 +27,12 @@ const UNNAMED_HOOK: &str = "#!/usr/bin/env bash\n# ---\n# name: audit\n# event: 
 
 const COMMAND: &str = "---\ndescription: Ship the branch\n---\n\nRun the checklist.\n";
 
+const GH_MCP: &str = "command = \"gh-mcp\"\nargs = [\"--stdio\"]\n";
+
+const DOCS_MCP: &str = "transport = \"http\"\nurl = \"https://mcp.example/docs\"\n";
+
+const ENV_MCP: &str = "command = \"gh-mcp\"\n[env]\nGH_TOKEN = \"$GH_TOKEN\"\n";
+
 struct Fixture {
     _tmp: tempfile::TempDir,
     env: Env,
@@ -46,7 +52,7 @@ fn fixture(declarations: &str) -> Fixture {
     fs::create_dir_all(home.join(".gemini/config")).unwrap();
 
     let source = home.join("catalog");
-    for dir in ["agents", "hooks", "commands", "skills/deploy"] {
+    for dir in ["agents", "hooks", "commands", "mcp", "skills/deploy"] {
         fs::create_dir_all(source.join(dir)).unwrap();
     }
     fs::write(
@@ -57,6 +63,9 @@ fn fixture(declarations: &str) -> Fixture {
     fs::write(source.join("agents/rust.md"), AGENT).unwrap();
     fs::write(source.join("hooks/audit.sh"), AUDIT_HOOK).unwrap();
     fs::write(source.join("commands/ship.md"), COMMAND).unwrap();
+    fs::write(source.join("mcp/gh.toml"), GH_MCP).unwrap();
+    fs::write(source.join("mcp/docs.toml"), DOCS_MCP).unwrap();
+    fs::write(source.join("mcp/tokened.toml"), ENV_MCP).unwrap();
     fs::write(source.join("kendex.toml"), "is_source_catalog = true\n").unwrap();
 
     fs::write(
@@ -290,33 +299,137 @@ fn a_command_declared_for_antigravity_writes_nothing() {
     assert!(is_clean(&f));
 }
 
-/// A remote server in `mcp_config.json` names its endpoint `serverUrl`, and
-/// the read-only list shows that endpoint rather than a bare name.
+/// A command server is written as declared and a url server under
+/// `serverUrl`, beside the entry somebody else keeps in the file. Off writes
+/// `disabled: true` on the entry and on takes the key away, so the
+/// declaration stays until removal; the scan lists each by its endpoint.
 #[test]
 #[allow(clippy::unwrap_used)]
-fn a_remote_server_is_listed_by_its_endpoint() {
-    let f = fixture("");
+fn a_server_is_declared_in_mcp_config_json_and_toggles_on_the_entry() {
+    let f = fixture("[mcp-servers.gh]\nsource = \"cat\"\n\n[mcp-servers.docs]\nsource = \"cat\"\n");
+    let config = f.project.join(".agents/mcp_config.json");
     fs::write(
-        f.project.join(".agents/mcp_config.json"),
-        r#"{"mcpServers": {"docs": {"serverUrl": "https://docs.example/sse"}, "gh": {"command": "gh-mcp"}}}"#,
+        &config,
+        r#"{"mcpServers": {"other": {"serverUrl": "https://docs.example/sse", "disabled": true}}}"#,
     )
     .unwrap();
+    let report = apply_now(&f);
+    assert_eq!(report.warnings, Vec::new());
+
+    let installed = json(&config);
+    assert_eq!(
+        installed["mcpServers"]["other"],
+        serde_json::json!({"serverUrl": "https://docs.example/sse", "disabled": true})
+    );
+    assert_eq!(
+        installed["mcpServers"]["gh"],
+        serde_json::json!({"command": "gh-mcp", "args": ["--stdio"]})
+    );
+    assert_eq!(
+        installed["mcpServers"]["docs"],
+        serde_json::json!({"serverUrl": "https://mcp.example/docs"})
+    );
+    assert!(is_clean(&f));
+
     let scanned = kendex_core::scan::scan_scopes(
         &f.env,
         &std::collections::BTreeMap::new(),
         std::slice::from_ref(&f.scope),
     );
-    let servers: Vec<_> = scanned
+    let mut servers: Vec<_> = scanned
         .items
         .iter()
         .filter(|item| item.kind == kendex_core::model::ItemKind::McpServer)
         .map(|item| (item.name.as_str(), item.description.as_deref()))
         .collect();
+    servers.sort();
     assert_eq!(
         servers,
         [
-            ("docs", Some("https://docs.example/sse")),
+            ("docs", Some("https://mcp.example/docs")),
             ("gh", Some("gh-mcp")),
+            ("other", Some("https://docs.example/sse")),
         ]
     );
+
+    toggle(&f, "gh", false);
+    let off = json(&config);
+    assert_eq!(off["mcpServers"]["gh"]["disabled"], true);
+    assert_eq!(off["mcpServers"]["gh"]["command"], "gh-mcp");
+    assert_eq!(off["mcpServers"]["other"]["disabled"], true);
+    assert!(is_clean(&f));
+    let scanned = kendex_core::scan::scan_scopes(
+        &f.env,
+        &std::collections::BTreeMap::new(),
+        std::slice::from_ref(&f.scope),
+    );
+    let mut switches: Vec<_> = scanned
+        .items
+        .iter()
+        .filter(|item| item.kind == kendex_core::model::ItemKind::McpServer)
+        .map(|item| (item.name.as_str(), item.enabled))
+        .collect();
+    switches.sort();
+    assert_eq!(
+        switches,
+        [("docs", None), ("gh", Some(false)), ("other", Some(false)),]
+    );
+
+    toggle(&f, "gh", true);
+    assert_eq!(json(&config), installed);
+
+    remove(&f, "gh");
+    let after = json(&config);
+    assert!(after["mcpServers"].get("gh").is_none(), "{after}");
+    assert_eq!(
+        after["mcpServers"]["docs"]["serverUrl"],
+        "https://mcp.example/docs"
+    );
+    assert_eq!(after["mcpServers"]["other"]["disabled"], true);
+    assert!(is_clean(&f));
+}
+
+/// The global scope writes `mcp_config.json` under the customization root
+/// Antigravity shares with its IDE, the file `agy mcp list` reads.
+#[test]
+#[allow(clippy::unwrap_used)]
+fn a_global_server_lands_under_the_customization_root() {
+    let f = fixture("");
+    let manifest = f.env.global_manifest_file();
+    fs::create_dir_all(manifest.parent().unwrap()).unwrap();
+    let source = f.env.home.join("catalog");
+    fs::write(
+        &manifest,
+        format!(
+            "schema = 6\n\n[sources.cat]\n{}\n\n[install]\nharnesses = [\"antigravity\"]\nmethod = \"symlink\"\n\n[mcp-servers.gh]\nsource = \"cat\"\n",
+            source_path(&source)
+        ),
+    )
+    .unwrap();
+
+    let report = audit(&f.env, &Scope::Global).unwrap();
+    apply::execute(&f.env, &report.plan).unwrap();
+
+    let config = f.env.home.join(".gemini/config/mcp_config.json");
+    assert_eq!(json(&config)["mcpServers"]["gh"]["command"], "gh-mcp");
+    assert!(audit(&f.env, &Scope::Global).unwrap().drift.is_empty());
+}
+
+/// Nothing in Antigravity's documentation substitutes a reference in an
+/// `env` value, so a server carrying one is refused with the reason rather
+/// than handed a literal to run with.
+#[test]
+#[allow(clippy::unwrap_used)]
+fn a_server_with_env_references_is_refused_with_the_reason() {
+    let f = fixture("[mcp-servers.tokened]\nsource = \"cat\"\n");
+    let report = apply_now(&f);
+    assert!(
+        report
+            .drift
+            .iter()
+            .any(|row| row.name == "tokened" && row.detail.contains("documents no substitution")),
+        "{:?}",
+        report.drift
+    );
+    assert!(!f.project.join(".agents/mcp_config.json").exists());
 }

--- a/docs/adapters/antigravity.md
+++ b/docs/adapters/antigravity.md
@@ -21,14 +21,14 @@ Project markers: `.agents/agents/`, `.agents/rules/`, `.agents/hooks.json`, `.ag
 | skill | `~/.gemini/config/skills/<name>/SKILL.md` | `.agents/skills/<name>/SKILL.md`, shared with Codex and Pi | managed, both |
 | command | — | — | unsupported: a skill is the slash command |
 | hook | `~/.gemini/config/hooks.json`, scripts under `~/.gemini/config/hooks/` | `.agents/hooks.json`, scripts under `.agents/hooks/` | managed, both, enforced |
-| mcp-server | `~/.gemini/config/mcp_config.json` | `.agents/mcp_config.json` | observe only, both |
+| mcp-server | `~/.gemini/config/mcp_config.json` | `.agents/mcp_config.json` | managed, both |
 | plugin | `~/.gemini/config/plugins/<name>/plugin.json` | `.agents/plugins/<name>/plugin.json` | observe only, both |
 | pi-extension | — | — | unsupported |
 
 ## Format
 
 - Name rule `Any`; namespace separator `__`.
-- MCP transports: stdio (`command`) and SSE (`serverUrl`); the file is read, never written.
+- MCP transports: stdio (`command`, `args`, `env`) and, under one `serverUrl` key, SSE and streamable HTTP; the docs refuse `url` and `httpUrl`, so a url server is rewritten to `serverUrl` with no `type` beside it (`server`, `crates/core/src/engine/antigravity.rs`). Switching a server off writes `disabled: true` on the entry and switching it on takes the key away, so the declaration stays until removal, and the scan reads that key back as the switch; other entries stay. A file the strict JSON edit cannot parse, comments, trailing commas or a byte-order mark the loader itself tolerates, is not edited, the registration reports the conflict instead. Antigravity documents no substitution for an `env` value, so a server declaring one is refused for this harness with the reason. The `agy mcp` subcommands write only the user-level file.
 - Agent file: YAML frontmatter and a markdown body, `<name>.md`. Fields written: `name`, `description`, `model` (only when a tier was asked for), `subagent: true`, `tools` (allowlist) (`crates/core/src/render/agent/antigravity.rs`). Skills travel as prose: the frontmatter's `skills:` list names paths under the customization root, and kendex does not yet write it. An agent may also be a directory, `agents/<name>/agent.md`; kendex writes the file form and reads the directory form as the item `<name>/agent`.
 - Model dialect: `inherit` omits the key; `fable` and `opus` are `pro`, `sonnet` and `haiku` are `flash`; any other value is refused at render, since the loader reads no ids (`crates/core/src/harness/models.rs`, `crates/core/src/render/validate/agent.rs`). The file has no effort key, so an effort setting renders nothing; the session's `--effort` (`low`, `medium`, `high`) and the model's own `-high`/`-medium`/`-low` id suffix decide reasoning.
 - Permissions: an allowlist renders as `tools:` in Antigravity's own names; a name it has no word for is left out with a warning, since its documentation says an unknown name in the list can hang the subagent; a deny list cannot be expressed and warns.
@@ -44,4 +44,4 @@ Agent scoping: none; only `agents = "all"` custom hooks are enforced.
 
 ## Not supported
 
-Commands (a skill is the slash command), Pi extensions, writing MCP servers or plugins, and the `skills:` frontmatter list.
+Commands (a skill is the slash command; workflows under `.agents/workflows/` still run but retire on 2026-11-01), Pi extensions, writing plugins, and the `skills:` frontmatter list.


### PR DESCRIPTION
Antigravity reads `mcpServers.<name>` from `mcp_config.json` under the customization root of either scope, a remote endpoint keyed `serverUrl` for SSE and streamable HTTP alike, and switches a server off with `disabled: true` on the entry. A declared server is written there in that shape, off writes the switch and on takes it away so the declaration stays until removal, the scan reads the switch back, and other entries stay. Antigravity documents no substitution for an `env` value, so a server declaring one is refused for it with the reason. The cap moves from observe-only to managed and the transport list gains streamable HTTP.

- `crates/core/src/harness/caps.rs`: `(Antigravity, McpServer) => managed(BOTH)`; `format_caps` default transports.
- `crates/core/src/engine/antigravity.rs`: `server` (`serverUrl`). `crates/core/src/engine/desired_mcp.rs`: the `disabled` toggle and the env refusal. `crates/core/src/scan/readers.rs`: `disabled` read back.
- `crates/core/tests/antigravity.rs`: install beside the user's entry, toggle on the entry with the scan reading it, remove, global scope, env refusal. Must-fail control: the two writer tests fail against the observe-only row.
- `docs/adapters/antigravity.md`, README cell, changelog fragment.

Reviewer round: one blocking finding fixed (a switched-off server scanned as on), the stale group comment and the doc sentence corrected. Live proof: `kendex apply` wrote `mcpServers.kendex-proof-mcp` into a scratch project's `.agents/mcp_config.json`; `agy --add-dir <project> -p` asked for its connected servers answered `kendex-proof-mcp: echo`. Research: `/var/tmp/arch-rewrite/kendex/commands-mcp/REPORT.md`.

Tracking issue: KEN-1242

https://claude.ai/code/session_01KKVjeGes9mQESaqLzR6TVp
