### PR TITLE
feat(KEN-1242): MCP servers install on Codex as config.toml tables

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ Installing a package from a git repository needs git 2.41 or newer; kendex refus
 | Skills | ● | ● | ● | ●¹ | ● | ● | ● | ● |
 | Hooks | ● | ● | ●² | ●¹ ² | ●³ | ● | ● | ● |
 | Commands | ● | ●⁴ | ● | ○⁵ | ● | ● | -⁶ | - |
-| MCP servers | ● | ○ | ● | ● | - | ●⁷ | ● | ● |
+| MCP servers | ● | ● | ● | ● | - | ●⁷ | ● | ● |
 | Plugins | ◐ | ○ | ○ | ○ | - | ○ | ◐ | ○ |
 | Pi extensions | - | - | - | - | ● | - | - | - |
 

--- a/changelog.d/added/KEN-1242-codex-mcp.md
+++ b/changelog.d/added/KEN-1242-codex-mcp.md
@@ -1,0 +1,1 @@
+- MCP servers install on Codex as `[mcp_servers.<name>]` tables in `config.toml` at both scopes through a comment-preserving edit, switched off with `enabled = false`.

--- a/crates/core/src/configedit/codex_mcp.rs
+++ b/crates/core/src/configedit/codex_mcp.rs
@@ -1,0 +1,245 @@
+//! One `[mcp_servers.<name>]` table in Codex's `config.toml`, edited the way
+//! Codex edits it: through `toml_edit`, so the user's comments, ordering
+//! and every other table survive (codex-rs/core/src/config/edit.rs does the
+//! same). The table is written from the declared value in Codex's keys:
+//! `command`, `args` and an `env` sub-table for a stdio server, `url` for a
+//! streamable-HTTP one, never a `type`, and `enabled = false` when the
+//! declaration is switched off (learn.chatgpt.com/docs/extend/mcp). Codex
+//! reads an `env` value literally and passes a parent variable through by
+//! its own name under `env_vars`, so the catalog's `$NAME` references become
+//! that list; a reference under another name has no Codex spelling and the
+//! table is refused.
+
+use serde_json::Value as Json;
+use toml_edit::{Array, DocumentMut, Item, Table, Value};
+
+const SERVERS: &str = "mcp_servers";
+
+pub(super) fn upsert(
+    current: &str,
+    name: &str,
+    value: &Json,
+    enabled: bool,
+) -> Result<String, String> {
+    let mut document: DocumentMut = current
+        .parse()
+        .map_err(|e: toml_edit::TomlError| e.to_string())?;
+    let mut table = server_table(value)?;
+    if !enabled {
+        table.insert("enabled", Item::Value(Value::from(false)));
+    }
+    let servers = document
+        .entry(SERVERS)
+        .or_insert_with(|| {
+            let mut parent = Table::new();
+            parent.set_implicit(true);
+            Item::Table(parent)
+        })
+        .as_table_mut()
+        .ok_or(format!("{SERVERS} is not a table"))?;
+    // A table already there keeps its place and the comment above it: the
+    // fields are replaced inside it, the way Codex's own editor keeps decor.
+    match servers.get_mut(name).and_then(Item::as_table_mut) {
+        Some(existing) => {
+            existing.clear();
+            for (key, item) in table.iter() {
+                existing.insert(key, item.clone());
+            }
+        }
+        None => {
+            servers.insert(name, Item::Table(table));
+        }
+    }
+    Ok(document.to_string())
+}
+
+pub(super) fn remove(current: &str, name: &str) -> Result<String, String> {
+    let mut document: DocumentMut = current
+        .parse()
+        .map_err(|e: toml_edit::TomlError| e.to_string())?;
+    let Some(servers) = document.get_mut(SERVERS) else {
+        return Ok(current.to_owned());
+    };
+    let servers = servers
+        .as_table_mut()
+        .ok_or(format!("{SERVERS} is not a table"))?;
+    servers.remove(name);
+    // A parent kendex itself brought in goes with its last child; one the
+    // user wrote, with a header of their own, stays.
+    if servers.is_empty() && servers.is_implicit() {
+        document.remove(SERVERS);
+    }
+    Ok(document.to_string())
+}
+
+/// The declared server as Codex's table. `type` names the transport in the
+/// catalog's shape and Codex reads the transport off which key is present,
+/// so it is not carried over; `env` becomes `env_vars`.
+fn server_table(value: &Json) -> Result<Table, String> {
+    let object = value.as_object().ok_or("the server is not an object")?;
+    let mut table = Table::new();
+    for (key, entry) in object {
+        match key.as_str() {
+            "type" => {}
+            "env" => {
+                let mut names = Array::new();
+                for name in env_vars(entry)? {
+                    names.push(name);
+                }
+                table.insert("env_vars", Item::Value(Value::Array(names)));
+            }
+            _ => {
+                table.insert(key, item(entry)?);
+            }
+        }
+    }
+    Ok(table)
+}
+
+/// The variables a catalog `env` table passes through, as Codex names them.
+/// Codex has no rename: `env_vars = ["NAME"]` hands the process the parent's
+/// `NAME`, so a reference that would land under another key is refused with
+/// the reason rather than written as a literal the process would read.
+pub(super) fn env_vars(env: &Json) -> Result<Vec<String>, String> {
+    let Some(env) = env.as_object() else {
+        return Err("env is not a table".into());
+    };
+    let mut names = Vec::new();
+    for (key, value) in env {
+        let reference = value.as_str().unwrap_or_default();
+        let name = reference
+            .strip_prefix("${")
+            .and_then(|rest| rest.strip_suffix('}'))
+            .or_else(|| reference.strip_prefix('$'))
+            .unwrap_or(reference);
+        if name != key {
+            return Err(format!(
+                "Codex passes an environment variable through under its own name only, and {key} would come from {reference} — name the variable {name} in the catalog, or drop Codex from this server's harnesses"
+            ));
+        }
+        names.push(key.clone());
+    }
+    Ok(names)
+}
+
+fn item(value: &Json) -> Result<Item, String> {
+    Ok(match value {
+        Json::String(text) => Item::Value(Value::from(text.as_str())),
+        Json::Bool(flag) => Item::Value(Value::from(*flag)),
+        Json::Number(number) => match (number.as_i64(), number.as_f64()) {
+            (Some(whole), _) => Item::Value(Value::from(whole)),
+            (None, Some(real)) => Item::Value(Value::from(real)),
+            (None, None) => return Err(format!("{number} is not a TOML number")),
+        },
+        Json::Array(items) => {
+            let mut array = Array::new();
+            for entry in items {
+                match item(entry)? {
+                    Item::Value(scalar) => array.push(scalar),
+                    _ => return Err("a nested table inside an array is not a server field".into()),
+                }
+            }
+            Item::Value(Value::Array(array))
+        }
+        Json::Object(map) => {
+            let mut table = Table::new();
+            for (key, entry) in map {
+                table.insert(key, item(entry)?);
+            }
+            Item::Table(table)
+        }
+        Json::Null => return Err("a null is not a server field".into()),
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    const THEIRS: &str = "# the user's file\nmodel = \"gpt-6-astra\"\n\n[features]\nhooks = true # keep\n\n[mcp_servers.other]\ncommand = \"x\"\n";
+
+    #[test]
+    fn a_server_table_is_added_beside_the_users_tables_and_comments() {
+        let gh =
+            json!({"command": "gh-mcp", "args": ["--stdio"], "env": {"GH_TOKEN": "$GH_TOKEN"}});
+        let once = upsert(THEIRS, "gh", &gh, true).unwrap();
+        assert!(
+            once.starts_with("# the user's file\nmodel = \"gpt-6-astra\"\n"),
+            "{once}"
+        );
+        assert!(once.contains("hooks = true # keep\n"), "{once}");
+        let parsed: toml::Table = once.parse().unwrap();
+        assert_eq!(
+            parsed["mcp_servers"]["other"]["command"].as_str(),
+            Some("x")
+        );
+        assert_eq!(
+            parsed["mcp_servers"]["gh"]["command"].as_str(),
+            Some("gh-mcp")
+        );
+        assert_eq!(
+            parsed["mcp_servers"]["gh"]["args"][0].as_str(),
+            Some("--stdio")
+        );
+        assert_eq!(
+            parsed["mcp_servers"]["gh"]["env_vars"][0].as_str(),
+            Some("GH_TOKEN")
+        );
+        assert!(parsed["mcp_servers"]["gh"].get("env").is_none());
+        let renamed = json!({"command": "gh-mcp", "env": {"GITHUB_TOKEN": "$GH_TOKEN"}});
+        assert!(
+            upsert(THEIRS, "gh", &renamed, true)
+                .unwrap_err()
+                .contains("GITHUB_TOKEN")
+        );
+        assert_eq!(upsert(&once, "gh", &gh, true).unwrap(), once);
+
+        let off = upsert(&once, "gh", &gh, false).unwrap();
+        let parsed: toml::Table = off.parse().unwrap();
+        assert_eq!(
+            parsed["mcp_servers"]["gh"]["enabled"].as_bool(),
+            Some(false)
+        );
+        assert_eq!(upsert(&off, "gh", &gh, true).unwrap(), once);
+
+        let removed = remove(&once, "gh").unwrap();
+        assert_eq!(removed, THEIRS);
+    }
+
+    #[test]
+    fn a_replaced_table_keeps_its_comment_and_place_and_an_explicit_parent_stays() {
+        let theirs = "# my notes\n[mcp_servers.gh]\ncommand = \"old\"\n\n[tools]\nx = 1\n";
+        let replaced = upsert(theirs, "gh", &json!({"command": "gh-mcp"}), true).unwrap();
+        assert_eq!(
+            replaced,
+            "# my notes\n[mcp_servers.gh]\ncommand = \"gh-mcp\"\n\n[tools]\nx = 1\n"
+        );
+
+        let explicit = "# servers I keep\n[mcp_servers]\n\n[mcp_servers.gh]\ncommand = \"gh-mcp\"\n\n[features]\nk = 1\n";
+        let removed = remove(explicit, "gh").unwrap();
+        assert!(
+            removed.contains("# servers I keep\n[mcp_servers]\n"),
+            "{removed}"
+        );
+        assert!(removed.contains("[features]\nk = 1\n"), "{removed}");
+    }
+
+    #[test]
+    fn a_url_server_keeps_the_url_and_not_the_type_and_an_empty_parent_leaves() {
+        let docs = json!({"type": "http", "url": "https://mcp.example"});
+        let text = upsert("", "docs", &docs, true).unwrap();
+        assert_eq!(text, "[mcp_servers.docs]\nurl = \"https://mcp.example\"\n");
+        assert_eq!(remove(&text, "docs").unwrap(), "");
+        assert_eq!(
+            remove("model = \"x\"\n", "docs").unwrap(),
+            "model = \"x\"\n"
+        );
+    }
+
+    #[test]
+    fn an_inline_servers_table_is_refused_rather_than_rewritten() {
+        let inline = "mcp_servers = { other = { command = \"x\" } }\n";
+        assert!(upsert(inline, "gh", &json!({"command": "gh-mcp"}), true).is_err());
+    }
+}

--- a/crates/core/src/configedit/mod.rs
+++ b/crates/core/src/configedit/mod.rs
@@ -2,6 +2,7 @@ use serde::{Deserialize, Serialize};
 use serde_json::{Map, Value, json};
 
 mod antigravity;
+mod codex_mcp;
 mod copilot;
 mod nested;
 mod text;
@@ -10,6 +11,11 @@ use antigravity::{remove_antigravity_hook, upsert_antigravity_hook};
 use copilot::{remove_copilot_hook, upsert_copilot_hook};
 use nested::{remove_hook, upsert_hook};
 use text::codex_enable_hooks;
+
+/// The `env_vars` Codex takes for a catalog `env` table, or why it cannot.
+pub(crate) fn codex_env_vars(env: &Value) -> Result<Vec<String>, String> {
+    codex_mcp::env_vars(env)
+}
 pub use text::{remove_marker_block, upsert_marker_block};
 
 /// A deterministic, idempotent structured edit. Applied to the file's
@@ -91,6 +97,17 @@ pub enum ConfigEdit {
     RemoveOpencodeMcpServer {
         name: String,
     },
+    /// codex `config.toml` `[mcp_servers.<name>]` written from the declared
+    /// value through a comment-preserving TOML edit, `enabled = false` when
+    /// the declaration is switched off.
+    UpsertCodexMcpServer {
+        name: String,
+        value: Value,
+        enabled: bool,
+    },
+    RemoveCodexMcpServer {
+        name: String,
+    },
     /// `enabledPlugins.<key>` set/remove.
     SetPluginEnabled {
         key: String,
@@ -145,6 +162,12 @@ impl ConfigEdit {
     pub fn apply(&self, current: &str) -> Result<String, String> {
         match self {
             ConfigEdit::CodexEnableHooksFeature => Ok(codex_enable_hooks(current)),
+            ConfigEdit::UpsertCodexMcpServer {
+                name,
+                value,
+                enabled,
+            } => codex_mcp::upsert(current, name, value, *enabled),
+            ConfigEdit::RemoveCodexMcpServer { name } => codex_mcp::remove(current, name),
             ConfigEdit::UpsertMarkerBlock { name, block } => {
                 Ok(upsert_marker_block(current, name, block))
             }

--- a/crates/core/src/engine/desired_mcp.rs
+++ b/crates/core/src/engine/desired_mcp.rs
@@ -7,6 +7,7 @@ use serde_json::{Map, Value, json};
 use super::desired::{Artifact, DesiredState, ItemCtx};
 use super::desired_kinds::{declared, registration_edits};
 use super::targets::{mcp_registry, mcp_remove, mcp_upsert};
+use crate::configedit::ConfigEdit;
 use crate::error::Result;
 use crate::model::{HarnessId, ItemKind};
 
@@ -38,30 +39,12 @@ pub(super) fn desired_mcp(ctx: &ItemCtx, state: &mut DesiredState) -> Result<()>
             if harness == HarnessId::Copilot {
                 super::copilot::switched_off_elsewhere(ctx, ItemKind::McpServer, state);
             }
-            if let Some(reason) = transport_refusal(harness, &value) {
+            if let Some(reason) = refusal(harness, &value) {
                 state.refused.push(super::desired::Refused {
                     kind: ItemKind::McpServer,
                     name: ctx.name.to_owned(),
                     harness,
                     reason,
-                });
-                continue;
-            }
-            // Antigravity's documentation says nothing about substituting a
-            // reference in an `env` value, and kendex writes only
-            // references, so a server carrying one is refused rather than
-            // handed a literal `$NAME` to run with.
-            if harness == HarnessId::Antigravity
-                && value
-                    .get("env")
-                    .and_then(Value::as_object)
-                    .is_some_and(|env| !env.is_empty())
-            {
-                state.refused.push(super::desired::Refused {
-                    kind: ItemKind::McpServer,
-                    name: ctx.name.to_owned(),
-                    harness,
-                    reason: "Antigravity documents no substitution for an environment value, so a $NAME reference would reach the server as text — declare the server without env, or drop Antigravity from its harnesses".to_owned(),
                 });
                 continue;
             }
@@ -72,6 +55,13 @@ pub(super) fn desired_mcp(ctx: &ItemCtx, state: &mut DesiredState) -> Result<()>
             // stays in the file either way; everywhere else the entry comes
             // out when switched off.
             let edit = match (ctx.decl.enabled, harness) {
+                // Codex keeps a server as its own TOML table and switches it
+                // off on the table itself, so the edit carries the switch.
+                (_, HarnessId::Codex) => ConfigEdit::UpsertCodexMcpServer {
+                    name: ctx.name.to_owned(),
+                    value: value.clone(),
+                    enabled: ctx.decl.enabled,
+                },
                 (_, HarnessId::Opencode) => mcp_upsert(
                     harness,
                     ctx.name,
@@ -97,10 +87,13 @@ pub(super) fn desired_mcp(ctx: &ItemCtx, state: &mut DesiredState) -> Result<()>
                 (true, _) => mcp_upsert(harness, ctx.name, value.clone()),
                 (false, _) => mcp_remove(harness, ctx.name),
             };
-            // A switched-off OpenCode or Antigravity entry is still a write,
+            // A switched-off OpenCode, Antigravity or Codex entry is still a write,
             // so it is planned whether or not the file exists yet.
-            let writes =
-                ctx.decl.enabled || matches!(harness, HarnessId::Opencode | HarnessId::Antigravity);
+            let writes = ctx.decl.enabled
+                || matches!(
+                    harness,
+                    HarnessId::Opencode | HarnessId::Antigravity | HarnessId::Codex
+                );
             registration_edits(&registry, edit, writes)
         };
         let artifact = Artifact::Registration {
@@ -112,6 +105,31 @@ pub(super) fn desired_mcp(ctx: &ItemCtx, state: &mut DesiredState) -> Result<()>
             .push(declared(ctx, ItemKind::McpServer, harness, artifact)?);
     }
     Ok(())
+}
+
+/// Why this harness cannot take the server as declared, or `None`: a
+/// transport its client does not speak, or an `env` table it has no
+/// spelling for. Antigravity's documentation says nothing about substituting
+/// a reference in an `env` value, and kendex writes only references, so a
+/// server carrying one is refused rather than handed a literal `$NAME`;
+/// Codex passes a variable through by its own name only, so a reference
+/// under another key is refused with the fix.
+fn refusal(harness: HarnessId, value: &Value) -> Option<String> {
+    if let Some(reason) = transport_refusal(harness, value) {
+        return Some(reason);
+    }
+    let env = value.get("env");
+    match harness {
+        HarnessId::Antigravity
+            if env
+                .and_then(Value::as_object)
+                .is_some_and(|env| !env.is_empty()) =>
+        {
+            Some("Antigravity documents no substitution for an environment value, so a $NAME reference would reach the server as text — declare the server without env, or drop Antigravity from its harnesses".to_owned())
+        }
+        HarnessId::Codex => env.and_then(|env| crate::configedit::codex_env_vars(env).err()),
+        _ => None,
+    }
 }
 
 /// Why this harness cannot take the server as declared: a transport its

--- a/crates/core/src/engine/scoring/input.rs
+++ b/crates/core/src/engine/scoring/input.rs
@@ -122,7 +122,8 @@ fn mcp_entry(edits: &[(std::path::PathBuf, ConfigEdit)]) -> Option<McpEntry> {
         .iter()
         .find_map(|(_, edit)| match edit {
             ConfigEdit::UpsertMcpServer { value, .. }
-            | ConfigEdit::UpsertOpencodeMcpServer { value, .. } => Some(value),
+            | ConfigEdit::UpsertOpencodeMcpServer { value, .. }
+            | ConfigEdit::UpsertCodexMcpServer { value, .. } => Some(value),
             _ => None,
         })
         .map(McpEntry::from_json)

--- a/crates/core/src/engine/targets.rs
+++ b/crates/core/src/engine/targets.rs
@@ -340,6 +340,15 @@ pub(super) fn mcp_registry(env: &Env, scope: &Scope, harness: HarnessId) -> Opti
                 .join("mcp_config.json"),
             Scope::Project { root } => root.join(".agents/mcp_config.json"),
         }),
+        // Codex reads `[mcp_servers.<name>]` from `config.toml` under
+        // `CODEX_HOME` and, in a trusted project, from `.codex/config.toml`
+        // (learn.chatgpt.com/docs/extend/mcp).
+        HarnessId::Codex => Some(match scope {
+            Scope::Global => adapter(harness)
+                .default_global_root(env)
+                .join("config.toml"),
+            Scope::Project { root } => root.join(".codex/config.toml"),
+        }),
         // Copilot reads a repository's servers from `.github/mcp.json` and a
         // machine's from its own config root (matrix §2). A `.mcp.json` at
         // the repo root is Claude Code's file, which Copilot also reads —
@@ -369,6 +378,7 @@ pub(super) fn mcp_remove(harness: HarnessId, name: &str) -> ConfigEdit {
     let name = name.to_owned();
     match harness {
         HarnessId::Opencode => ConfigEdit::RemoveOpencodeMcpServer { name },
+        HarnessId::Codex => ConfigEdit::RemoveCodexMcpServer { name },
         _ => ConfigEdit::RemoveMcpServer { name },
     }
 }

--- a/crates/core/src/harness/caps.rs
+++ b/crates/core/src/harness/caps.rs
@@ -306,7 +306,11 @@ pub fn capabilities(harness: HarnessId, kind: ItemKind) -> KindCaps {
             installs_as: Some(Skill),
             ..unsupported()
         },
-        (Codex, McpServer) => observe_only(BOTH),
+        // `[mcp_servers.<name>]` in `config.toml` at either scope, written
+        // through a comment-preserving TOML edit the way Codex's own
+        // `mcp add` writes it, `enabled = false` the switch
+        // (learn.chatgpt.com/docs/extend/mcp).
+        (Codex, McpServer) => managed(BOTH),
         (Codex, Plugin) => observe_only(GLOBAL),
         (Codex, PiExtension) => unsupported(),
 

--- a/crates/core/src/scan/readers.rs
+++ b/crates/core/src/scan/readers.rs
@@ -131,7 +131,13 @@ fn mcp_toml(path: &Path) -> Result<Vec<RawEntry>, String> {
         .iter()
         .map(|(name, entry)| RawEntry {
             name: name.clone(),
-            enabled: None,
+            // Codex's own default: on unless the table says otherwise.
+            enabled: Some(
+                entry
+                    .get("enabled")
+                    .and_then(toml::Value::as_bool)
+                    .unwrap_or(true),
+            ),
             description: entry
                 .get("command")
                 .or_else(|| entry.get("url"))

--- a/crates/core/tests/codex_mcp.rs
+++ b/crates/core/tests/codex_mcp.rs
@@ -1,0 +1,267 @@
+//! Codex as a managed tool for MCP servers: a declared server lands as its
+//! own `[mcp_servers.<name>]` table in the scope's `config.toml`, the user's
+//! comments and other tables kept as they were; switches off on the table
+//! itself; comes out on request; and a transport Codex does not speak is
+//! refused before anything is written.
+#![cfg(unix)]
+
+#[path = "../../test_util.rs"]
+mod test_util;
+use test_util::{rooted, source_path};
+
+use std::fs;
+use std::path::{Path, PathBuf};
+
+use kendex_core::apply;
+use kendex_core::engine::{EngineReport, audit, ops};
+use kendex_core::env::{Env, FakeOs};
+use kendex_core::model::{HarnessId, ItemKind, Scope};
+
+const GH_MCP: &str =
+    "command = \"gh-mcp\"\nargs = [\"--stdio\"]\n[env]\nGH_TOKEN = \"$GH_TOKEN\"\n";
+const RENAMED_MCP: &str = "command = \"gh-mcp\"\n[env]\nGITHUB_TOKEN = \"$GH_TOKEN\"\n";
+const DOCS_MCP: &str = "transport = \"http\"\nurl = \"https://mcp.example/docs\"\n";
+const LEGACY_MCP: &str = "transport = \"sse\"\nurl = \"https://mcp.example/sse\"\n";
+
+/// What the user already keeps in the project's file: a comment, a model, a
+/// feature flag with a trailing comment, and a server of their own.
+const THEIRS: &str = "# the user's file\nmodel = \"gpt-6-astra\"\n\n[features]\nhooks = true # keep\n\n[mcp_servers.other]\ncommand = \"x\"\n";
+
+struct Fixture {
+    _tmp: tempfile::TempDir,
+    env: Env,
+    scope: Scope,
+    project: PathBuf,
+    source: PathBuf,
+}
+
+/// A Codex-only project whose catalog carries three servers, one per
+/// transport; `declarations` is appended to the manifest verbatim.
+#[allow(clippy::unwrap_used)]
+fn fixture(declarations: &str) -> Fixture {
+    let tmp = tempfile::tempdir().unwrap();
+    let home = rooted(&tmp);
+    let env = Env::fake(&home, FakeOs::Linux);
+    let project = home.join("dev/app");
+    fs::create_dir_all(project.join(".codex")).unwrap();
+    fs::create_dir_all(home.join(".codex")).unwrap();
+
+    let source = home.join("catalog");
+    fs::create_dir_all(source.join("mcp")).unwrap();
+    fs::write(source.join("mcp/gh.toml"), GH_MCP).unwrap();
+    fs::write(source.join("mcp/docs.toml"), DOCS_MCP).unwrap();
+    fs::write(source.join("mcp/legacy.toml"), LEGACY_MCP).unwrap();
+    fs::write(source.join("mcp/renamed.toml"), RENAMED_MCP).unwrap();
+    fs::write(source.join("kendex.toml"), "is_source_catalog = true\n").unwrap();
+
+    fs::write(
+        project.join("kendex.toml"),
+        format!(
+            "schema = 6\n\n[sources.cat]\n{}\n\n[install]\nharnesses = [\"codex\"]\nmethod = \"symlink\"\n\n{declarations}",
+            source_path(&source)
+        ),
+    )
+    .unwrap();
+
+    Fixture {
+        env,
+        scope: Scope::Project {
+            root: project.clone(),
+        },
+        project,
+        source,
+        _tmp: tmp,
+    }
+}
+
+#[allow(clippy::unwrap_used)]
+fn apply_now(f: &Fixture) -> EngineReport {
+    let report = audit(&f.env, &f.scope).unwrap();
+    apply::execute(&f.env, &report.plan).unwrap();
+    report
+}
+
+#[allow(clippy::unwrap_used)]
+fn toggle(f: &Fixture, name: &str, enabled: bool) {
+    let report = ops::toggle(&f.env, &f.scope, &[name.to_owned()], None, enabled).unwrap();
+    apply::execute(&f.env, &report.plan).unwrap();
+}
+
+#[allow(clippy::unwrap_used)]
+fn remove(f: &Fixture, name: &str) {
+    let report = ops::remove(&f.env, &f.scope, &[name.to_owned()], None, false).unwrap();
+    apply::execute(&f.env, &report.plan).unwrap();
+}
+
+#[allow(clippy::unwrap_used)]
+fn table(path: &Path) -> toml::Table {
+    fs::read_to_string(path).unwrap().parse().unwrap()
+}
+
+#[allow(clippy::unwrap_used)]
+fn is_clean(f: &Fixture) -> bool {
+    audit(&f.env, &f.scope).unwrap().drift.is_empty()
+}
+
+/// The server names Codex's scan reports for a scope, with their switch.
+fn scanned(f: &Fixture, scope: &Scope) -> Vec<(String, Option<bool>)> {
+    let scanned = kendex_core::scan::scan_scopes(
+        &f.env,
+        &std::collections::BTreeMap::new(),
+        std::slice::from_ref(scope),
+    );
+    let mut rows: Vec<_> = scanned
+        .items
+        .iter()
+        .filter(|item| item.harness == HarnessId::Codex && item.kind == ItemKind::McpServer)
+        .map(|item| (item.name.clone(), item.enabled))
+        .collect();
+    rows.sort();
+    rows
+}
+
+/// A stdio server is a table whose `env` references become `env_vars`, a url server a table
+/// holding `url` and no `type`; the user's comment, model, feature flag and
+/// own server survive byte for byte. Off writes `enabled = false` on the
+/// table and on takes it away, so the declaration stays until removal.
+#[test]
+#[allow(clippy::unwrap_used)]
+fn a_server_is_its_own_table_beside_the_users_and_toggles_on_the_table() {
+    let f = fixture("[mcp-servers.gh]\nsource = \"cat\"\n\n[mcp-servers.docs]\nsource = \"cat\"\n");
+    let config = f.project.join(".codex/config.toml");
+    fs::write(&config, THEIRS).unwrap();
+    let report = apply_now(&f);
+    assert_eq!(report.warnings, Vec::new());
+
+    let text = fs::read_to_string(&config).unwrap();
+    assert!(text.starts_with(THEIRS), "{text}");
+    let installed = table(&config);
+    let gh = &installed["mcp_servers"]["gh"];
+    assert_eq!(gh["command"].as_str(), Some("gh-mcp"));
+    assert_eq!(gh["args"][0].as_str(), Some("--stdio"));
+    assert_eq!(gh["env_vars"][0].as_str(), Some("GH_TOKEN"));
+    assert!(gh.get("env").is_none());
+    assert!(gh.get("enabled").is_none());
+    let docs = &installed["mcp_servers"]["docs"];
+    assert_eq!(docs["url"].as_str(), Some("https://mcp.example/docs"));
+    assert!(docs.get("type").is_none());
+    assert_eq!(installed["features"]["hooks"].as_bool(), Some(true));
+    assert!(is_clean(&f));
+    assert_eq!(
+        scanned(&f, &f.scope),
+        [
+            ("docs".to_owned(), Some(true)),
+            ("gh".to_owned(), Some(true)),
+            ("other".to_owned(), Some(true)),
+        ]
+    );
+
+    toggle(&f, "gh", false);
+    let off = table(&config);
+    assert_eq!(off["mcp_servers"]["gh"]["enabled"].as_bool(), Some(false));
+    assert_eq!(off["mcp_servers"]["gh"]["command"].as_str(), Some("gh-mcp"));
+    assert_eq!(off["mcp_servers"]["other"]["command"].as_str(), Some("x"));
+    assert!(is_clean(&f));
+    assert_eq!(scanned(&f, &f.scope)[1], ("gh".to_owned(), Some(false)));
+
+    toggle(&f, "gh", true);
+    assert_eq!(fs::read_to_string(&config).unwrap(), text);
+
+    remove(&f, "gh");
+    let after = fs::read_to_string(&config).unwrap();
+    assert!(after.starts_with(THEIRS), "{after}");
+    let after = table(&config);
+    assert!(after["mcp_servers"].get("gh").is_none(), "{after}");
+    assert_eq!(
+        after["mcp_servers"]["docs"]["url"].as_str(),
+        Some("https://mcp.example/docs")
+    );
+    assert!(is_clean(&f));
+}
+
+/// The global scope writes `config.toml` under Codex's own root, the file
+/// `codex mcp add` writes too.
+#[test]
+#[allow(clippy::unwrap_used)]
+fn a_global_server_lands_in_the_users_config_toml() {
+    let f = fixture("");
+    let manifest = f.env.global_manifest_file();
+    fs::create_dir_all(manifest.parent().unwrap()).unwrap();
+    fs::write(
+        &manifest,
+        format!(
+            "schema = 6\n\n[sources.cat]\n{}\n\n[install]\nharnesses = [\"codex\"]\nmethod = \"symlink\"\n\n[mcp-servers.gh]\nsource = \"cat\"\n",
+            source_path(&f.source)
+        ),
+    )
+    .unwrap();
+
+    let report = audit(&f.env, &Scope::Global).unwrap();
+    apply::execute(&f.env, &report.plan).unwrap();
+
+    let config = f.env.home.join(".codex/config.toml");
+    assert_eq!(
+        table(&config)["mcp_servers"]["gh"]["command"].as_str(),
+        Some("gh-mcp")
+    );
+    assert!(audit(&f.env, &Scope::Global).unwrap().drift.is_empty());
+    assert_eq!(scanned(&f, &Scope::Global), [("gh".to_owned(), Some(true))]);
+}
+
+/// Codex speaks stdio and streamable HTTP and never SSE, so an SSE
+/// declaration is refused for this harness with that reason and nothing is
+/// written for it.
+#[test]
+#[allow(clippy::unwrap_used)]
+fn an_sse_server_is_refused_for_codex_with_the_reason() {
+    let f = fixture("[mcp-servers.legacy]\nsource = \"cat\"\n");
+    let report = apply_now(&f);
+    assert!(
+        report.drift.iter().any(|row| row.name == "legacy"
+            && row
+                .detail
+                .contains("Codex speaks stdio and streamable HTTP and not SSE")),
+        "{:?}",
+        report.drift
+    );
+    assert!(!f.project.join(".codex/config.toml").exists());
+}
+
+/// Codex passes a variable through under its own name only, so a reference
+/// that would land under another key is refused with the fix rather than
+/// written as a literal the process would read.
+#[test]
+#[allow(clippy::unwrap_used)]
+fn a_renamed_env_reference_is_refused_for_codex_with_the_fix() {
+    let f = fixture("[mcp-servers.renamed]\nsource = \"cat\"\n");
+    let report = apply_now(&f);
+    assert!(
+        report.drift.iter().any(|row| row.name == "renamed"
+            && row.detail.contains("under its own name only")
+            && row.detail.contains("name the variable GH_TOKEN")),
+        "{:?}",
+        report.drift
+    );
+    assert!(!f.project.join(".codex/config.toml").exists());
+}
+
+/// A declaration switched off before Codex's file exists still writes the
+/// whole table with its switch, so the file says what the manifest says.
+#[test]
+#[allow(clippy::unwrap_used)]
+fn a_server_declared_off_writes_its_table_into_a_fresh_file() {
+    let f = fixture("[mcp-servers.gh]\nsource = \"cat\"\nenabled = false\n");
+    apply_now(&f);
+    let config = f.project.join(".codex/config.toml");
+    let installed = table(&config);
+    assert_eq!(
+        installed["mcp_servers"]["gh"]["command"].as_str(),
+        Some("gh-mcp")
+    );
+    assert_eq!(
+        installed["mcp_servers"]["gh"]["enabled"].as_bool(),
+        Some(false)
+    );
+    assert!(is_clean(&f));
+    assert_eq!(scanned(&f, &f.scope), [("gh".to_owned(), Some(false))]);
+}

--- a/docs/adapters/codex.md
+++ b/docs/adapters/codex.md
@@ -19,7 +19,7 @@ Project markers: a `.codex/` or `.agents/` directory.
 | skill | `~/.codex/skills/<name>/SKILL.md` | `.agents/skills/<name>/SKILL.md`, shared with Pi and Antigravity | managed, both |
 | command | — | — | install, toggle, remove, refresh both; `installs_as: skill` |
 | hook | `~/.codex/hooks.json` | `.codex/hooks.json` | managed, both, enforced |
-| mcp-server | `~/.codex/config.toml` `[mcp_servers.<name>]` | `.codex/config.toml` | observe only, both |
+| mcp-server | `~/.codex/config.toml` `[mcp_servers.<name>]` | `.codex/config.toml` | managed, both |
 | plugin | `~/.codex/plugins/` cache tree with `.codex-plugin/plugin.json`, toggles in `config.toml` `[plugins]` | — | observe only, global |
 | pi-extension | — | — | unsupported |
 
@@ -29,7 +29,7 @@ Codex removed custom prompts in 0.118 (2026-03), so `~/.codex/prompts` is read b
 
 - Skill description at most 1024 characters; a longer one is refused for this harness alone, naming the skill (`crates/core/src/render/validate/skill.rs`). No body cap.
 - Name rule `Any`; namespace separator `__`.
-- MCP transports: stdio and streamable HTTP, never SSE.
+- MCP transports: stdio and streamable HTTP, never SSE, and an SSE declaration is refused for this harness with that reason. A server is its own `[mcp_servers.<name>]` table, written through a `toml_edit` pass that keeps the file's comments, ordering and other tables (`crates/core/src/configedit/codex_mcp.rs`): `command` and `args` for a stdio server, `url` for a streamable-HTTP one, no `type`. Codex reads an `env` value literally and passes a parent variable through by its own name under `env_vars`, so a catalog `env` table becomes that list, and a `$NAME` reference that would land under another key is refused with the name to use. Switching off writes `enabled = false` on the table and switching on takes it away, so the declaration stays until removal. A project's file loads only once Codex trusts the project, which the TUI grants an undecided local project on first launch; `codex mcp add` writes the user file alone and rewrites its whole `mcp_servers` table, so kendex does not go through it.
 - Agent file: TOML, `<name>.toml`. Fields written: `name`, `nickname_candidates`, `description`, `model`, `model_reasoning_effort`, `sandbox_mode`, and `developer_instructions` as a triple-quoted string carrying the whole prompt (`crates/core/src/render/agent/codex.rs`).
 - Model dialect: every tier resolves to `gpt-6-astra`; an omitted key is Codex's spelling of inherit (`crates/core/src/harness/models.rs`). `model_reasoning_effort` is written as given (`minimal`, `low`, `medium`, `high`, `xhigh`); an absent key takes the model's own default.
 - Permissions: Codex has no tool allowlist. A read-only allowlist caps `sandbox_mode` at `read-only`, any other allowlist at `workspace-write`, and only an explicit Engineer role with no allowlist earns `danger-full-access`; an allowlist always warns that the list itself is not enforced.


### PR DESCRIPTION
Codex reads `[mcp_servers.<name>]` from `config.toml` under `CODEX_HOME` and, in a trusted project, from `.codex/config.toml`, with `enabled = false` the switch and `env_vars` the way a parent variable reaches the server. A declared server is written as its own table through a comment-preserving `toml_edit` pass, the way Codex's own `mcp add` writes it: `command` and `args` or `url`, no `type`, a catalog `env` table as `env_vars`, off on the table itself so the declaration stays until removal, and the user's comments, other tables and an explicit `[mcp_servers]` header kept. A transport Codex does not speak (SSE) and an env reference that would land under another name are refused with the reason. The cap moves from observe-only to managed.

- `crates/core/src/harness/caps.rs`: `(Codex, McpServer) => managed(BOTH)`.
- `crates/core/src/configedit/codex_mcp.rs`: the TOML upsert and removal. `crates/core/src/engine/desired_mcp.rs`: transport and env refusals. `crates/core/src/scan/readers.rs`: `enabled` read back.
- `crates/core/tests/codex_mcp.rs`: install beside the user's comments and tables, toggle on the table, remove, global scope, SSE refusal, renamed env refusal. Must-fail control: all fail against the observe-only row.
- `docs/adapters/codex.md`, README cell, changelog fragment.

Reviewer round: no blocking findings; two suggestions applied (a replaced table keeps its comment and place; an explicit `[mcp_servers]` header the user wrote stays). No live proof yet: `codex mcp list` shows project servers only inside a trusted project, and the session did not write the owner's global config; the next session can prove it from a trusted scratch project. Research: `/var/tmp/arch-rewrite/kendex/commands-mcp/REPORT.md`.

Tracking issue: KEN-1242

https://claude.ai/code/session_01KKVjeGes9mQESaqLzR6TVp
