### PR TITLE
test(KEN-1241): approval_wait.sh as tables; guard sees a move whole

### DIFF
--- a/.agents/skills/orch/tests/approval_wait.sh
+++ b/.agents/skills/orch/tests/approval_wait.sh
@@ -1,80 +1,16 @@
 #!/usr/bin/env bash
-# Tests for orch/scripts/approval-wait.
+# Tests for orch/scripts/approval-wait, the reviewer-gate poller. It reads
+# formal review verdicts (`gh pr view --json reviewDecision,latestReviews` in
+# approval mode; the REST reviews listing pinned to the current head in
+# --mode review), the unresolved review-thread count and, in review mode, the
+# trusted check-run or commit-status evidence PR_REVIEW_CHECK names; never
+# emoji reactions, sticky comments or checklist prose.
 #
-# approval-wait is the GitHub-native reviewer-gate poller: it reads ONLY
-# formal review verdicts
-# (`gh pr view --json reviewDecision,latestReviews`, and in --mode review the
-# REST pulls/reviews listing pinned to the current head) plus the unresolved
-# review-thread count — never emoji reactions, sticky comments, or checklist
-# prose. Cases:
-#   1. reviewDecision APPROVED               -> approved, exit 0
-#   2. empty reviewDecision + latest APPROVED -> approved via fallback, exit 0
-#   3. latest CHANGES_REQUESTED               -> changes_requested, exit 1
-#   4. COMMENTED-only latest reviews          -> no verdict, timeout, exit 1
-#   5. unresolved threads, no verdict         -> comments early return, exit 1
-#   6. nothing at all at the deadline         -> timeout, exit 1
-#   7. REVIEW_REQUIRED + latest APPROVED      -> NOT approved (protection wants
-#                                                more), timeout
-#   8. APPROVED with unresolved threads       -> approved, unresolved_count
-#                                                reported for the caller's gate
-#   9. verdict arriving on a later poll       -> approved after polling
-#  10. auth failure with --json               -> parseable error object, exit 3
-#  11. text mode always prints a result line; approval-mode lines for
-#      changes-requested, comments, and error pinned verbatim
-#  12. review mode: COMMENTED at head, 0 threads -> reviewed, exit 0
-#  13. review mode: review at head + threads     -> comments early return
-#  14. review mode: review at stale commit only  -> timeout (head pinning)
-#  15. review mode: PR author's own review only  -> timeout (author excluded)
-#  16. review mode: DISMISSED review only        -> timeout (dismissal excluded)
-#  17. review mode: standing CHANGES_REQUESTED   -> changes_requested, exit 1
-#  18. review mode: CHANGES_REQUESTED superseded by COMMENTED -> reviewed
-#  19. review mode: APPROVED counts as a review  -> reviewed, exit 0
-#  20. review mode: review arriving on a later poll -> reviewed after polling
-#  21. review mode text output names the review gate for reviewed,
-#      changes-requested, comments, timeout, and error — never "Approval"
-#  check1-8: PR_REVIEW_CHECK check-run evidence — a "success"
-#      conclusion of the configured check name on the CURRENT head opens the
-#      review gate (newest run of that name wins; review_evidence "check",
-#      review_evidence_surface "check_run"); stale-sha and failure
-#      conclusions do not; unresolved threads and a standing
-#      CHANGES_REQUESTED still block; empty PR_REVIEW_CHECK ignores
-#      check-runs entirely; the review-object path still works with the
-#      feature on (review_evidence "review"); text mode names the check-run
-#      and its app slug
-#  status1-8: PR_REVIEW_CHECK commit-status evidence — with no
-#      matching check-run, a "success" commit status with the configured
-#      context on the CURRENT head opens the gate (newest of the context
-#      wins; review_evidence "check", review_evidence_surface "status"); a
-#      matching check-run wins first and skips the status query entirely;
-#      pending/failure/error states are not evidence; stale-sha statuses
-#      never count; empty PR_REVIEW_CHECK ignores both surfaces; a review
-#      object still takes precedence (no surface field); unresolved threads
-#      still block; text mode names the status context and its creator
-#  22+ --resolve-mode precedence: PR_REVIEW_GATE beats PR_APPROVAL_GATE
-#      (on -> approval, off -> off), default approval, settings-file source,
-#      invalid value falls back to approval
-#  transient1-4: transient GitHub API failures — an HTTP 503
-#      from the reviews listing (or approval-mode pr view) is absorbed with
-#      backoff inside the wait budget and reported as transient_api_errors
-#      on the eventual success; a persistent 503 becomes terminal only when
-#      the budget expires, preserving the original error message plus the
-#      count; an HTTP 404 stays immediately terminal with no count
-#   proceed1-13: PR_REVIEW_ON_TIMEOUT reviewer-down flexibility — a deadline
-#      reached with zero unresolved threads AND no reviewer evidence AND an
-#      unchanged head degrades to "proceeded" (exit 0) under "proceed" (review
-#      and approval modes; also via the --on-timeout flag), while open threads
-#      still return "comments", a standing CHANGES_REQUESTED still blocks, an
-#      active COMMENTED review in approval mode still times out (not silence), a
-#      head change during the wait falls back to timeout (no fair window on the
-#      moved head), a present-but-not-success trusted check/status (failed or
-#      pending) in review mode still times out (engagement, not silence), a head
-#      that moved in the final last-poll->emit confirm window falls back to
-#      timeout (no proceed on a superseded head), the
-#      default is "proceed"; an unrecognized value falls back to block with a warning
-#   marker1: a proceed posts NO commit status and emits no outage_marker JSON
-#      field (orch never manufactures review evidence); PR_REVIEW_OUTAGE_CONTEXT
-#      is exported in the test to prove it is inert
-# Same always-emit-JSON discipline and exit-code contract as ci-wait.
+# One case per behaviour surface; shaped input is one table per case, one
+# asserted row per shape. A row's `expect` names the fields it pins; `observe`
+# reads exactly those from the run, so a row fails on the field it names.
+# The pre-poll CLI layer (--resolve-mode, --help, unknown flags) is
+# approval_wait_cli.sh.
 set -euo pipefail
 source "$(dirname "${BASH_SOURCE[0]}")/lib/git-env.sh"
 TEST_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
@@ -86,13 +22,15 @@ trap 'rm -rf "$TMP_ROOT"' EXIT
 # shellcheck source=lib/waiter-assertions.sh
 source "$TEST_DIR/lib/waiter-assertions.sh"
 
-mkdir -p "$TMP_ROOT/repo/.agents/skills" "$TMP_ROOT/bin"
+mkdir -p "$TMP_ROOT/repo/.agents/skills" "$TMP_ROOT/bin" "$TMP_ROOT/runs"
 ln -s "$REPO_ROOT/skills/orch" "$TMP_ROOT/repo/.agents/skills/orch"
 git -C "$TMP_ROOT/repo" init -q
 git -C "$TMP_ROOT/repo" config user.email test@example.com
 git -C "$TMP_ROOT/repo" config user.name Test
 
-# Parametrized `gh` stub (same auth model as the ci_wait stub).
+# Parametrized `gh` stub (same auth model as the ci_wait stub), a neutral fake
+# GitHub: every payload is selected per run by the STUB_* variables below, so
+# no case inherits another's world.
 #   STUB_APPROVAL_MODE selects the canned `pr view --json
 #   reviewDecision,latestReviews` payload; STUB_THREADS_UNRESOLVED sets the
 #   unresolved count returned by the `api graphql` reviewThreads query.
@@ -237,12 +175,6 @@ case "${1:-}" in
           ;;
         approved_at_head)
           echo '[{"user":{"login":"reviewer1"},"state":"APPROVED","commit_id":"headsha1"}]'
-          ;;
-        two_bots_at_head)
-          echo '[{"user":{"login":"bot-a"},"state":"COMMENTED","commit_id":"headsha1"},{"user":{"login":"bot-b"},"state":"APPROVED","commit_id":"headsha1"}]'
-          ;;
-        one_bot_at_head)
-          echo '[{"user":{"login":"bot-a"},"state":"COMMENTED","commit_id":"headsha1"}]'
           ;;
         none|*)
           echo '[]'
@@ -397,877 +329,220 @@ chmod +x "$TMP_ROOT/bin/gh"
 source "$TEST_DIR/lib/virtual-clock.sh"
 virtual_clock_install "$TMP_ROOT/bin" "$TMP_ROOT/clock"
 
-# Run approval-wait via the .agents symlink, exactly how it's invoked in
-# production. `env "$@"` injects test-controlled env tokens / stub flags.
+# The suite's own default for the reviewer-down setting; the on-timeout case
+# overrides or unsets it per row.
 export PR_REVIEW_ON_TIMEOUT=block
-run_wait_json() {
-  (cd "$TMP_ROOT/repo" \
-    && PATH="$TMP_ROOT/bin:$PATH" \
-       env "$@" .agents/skills/orch/scripts/approval-wait 1 1 30 --json)
+
+# run_wait ENV ARGS... — runs approval-wait via the .agents symlink, exactly
+# how production invokes it, in the fixture repo with the stub PATH. ENV is a
+# comma-separated list of `env` arguments (assignments or `-u NAME`), so a
+# value may carry a space. Every run gets its own count, log and stderr files
+# under $RUN, so no row reads another's polls or posts. Sets OUT and RC.
+RUN=""
+run_wait() {
+  local env_list="$1" env_args=()
+  shift
+  RUN="$TMP_ROOT/runs/$((++RUN_SEQ))"
+  mkdir -p "$RUN"
+  [[ -z "$env_list" ]] || IFS=',' read -ra env_args <<<"$env_list"
+  set +e
+  OUT=$(cd "$TMP_ROOT/repo" && PATH="$TMP_ROOT/bin:$PATH" \
+    env ${env_args[@]+"${env_args[@]}"} \
+        STUB_APPROVAL_COUNT_FILE="$RUN/approval-polls" \
+        STUB_REVIEWS_COUNT_FILE="$RUN/review-polls" \
+        STUB_HEAD_COUNT_FILE="$RUN/head-polls" \
+        STUB_STATUS_LOG="$RUN/status-queries" \
+        STUB_MARKER_LOG="$RUN/marker-posts" \
+        .agents/skills/orch/scripts/approval-wait "$@" 2>"$RUN/stderr")
+  RC=$?
+  set -e
+}
+RUN_SEQ=0
+
+count_lines() { # FILE — 0 when it was never written
+  [[ -f "$1" ]] && wc -l <"$1" | tr -d ' ' || echo 0
 }
 
-run_wait_json_short() {
-  (cd "$TMP_ROOT/repo" \
-    && PATH="$TMP_ROOT/bin:$PATH" \
-       env "$@" .agents/skills/orch/scripts/approval-wait 1 1 3 --json)
+# observe EXPECT — prints the run's value of every `name=` field EXPECT names,
+# in EXPECT's order, so a row compares as one string. Plain names are JSON
+# result fields; the derived names read the run's files or its timing:
+#   early     elapsed_seconds < 3, the return came before a 3s deadline
+#   spent     elapsed_seconds >= 3, the whole 3s budget was used
+#   stdout    `line` when anything was printed, `empty` otherwise
+#   approval_polls / review_polls   how often the stub answered that listing
+#   status_queries                  combined-status reads the stub served
+#   marker_posts                    commit-status POSTs the stub received
+#   outage_marker                   whether the JSON carries that field
+#   transient_errors_seen           transient_api_errors >= 1
+observe() {
+  local got="" token name
+  for token in $1; do
+    name="${token%%=*}"
+    case "$name" in
+      rc) got="$got rc=$RC" ;;
+      early) got="$got early=$(json '.elapsed_seconds < 3')" ;;
+      spent) got="$got spent=$(json '.elapsed_seconds >= 3')" ;;
+      stdout) got="$got stdout=$([[ -n "$OUT" ]] && echo line || echo empty)" ;;
+      approval_polls) got="$got approval_polls=$(cat "$RUN/approval-polls" 2>/dev/null || echo 0)" ;;
+      review_polls) got="$got review_polls=$(cat "$RUN/review-polls" 2>/dev/null || echo 0)" ;;
+      status_queries) got="$got status_queries=$(count_lines "$RUN/status-queries")" ;;
+      marker_posts) got="$got marker_posts=$(count_lines "$RUN/marker-posts")" ;;
+      outage_marker) got="$got outage_marker=$(json 'has("outage_marker")')" ;;
+      transient_errors_seen) got="$got transient_errors_seen=$(json '.transient_api_errors >= 1')" ;;
+      *) got="$got $name=$(json ".$name")" ;;
+    esac
+  done
+  printf '%s' "${got# }"
+}
+json() { jq -r "$1" <<<"$OUT" 2>/dev/null || echo UNPARSEABLE; }
+
+# table DEFAULT_ARGS ROW... — one run and one assertion per row. A row is
+# `label|args|env|expect`; empty args mean DEFAULT_ARGS. Positional args are
+# `<pr> <poll-interval> <budget-seconds>` plus flags, on the virtual clock.
+table() {
+  local default_args="$1" row label args env expect
+  shift
+  for row in "$@"; do
+    IFS='|' read -r label args env expect <<<"$row"
+    [[ -n "$args" ]] || args="$default_args"
+    # shellcheck disable=SC2086
+    run_wait "$env" $args
+    assert_eq "$(observe "$expect")" "$expect" "$label" "$RUN/stderr"
+  done
 }
 
-run_wait_text_short() {
-  (cd "$TMP_ROOT/repo" \
-    && PATH="$TMP_ROOT/bin:$PATH" \
-       env "$@" .agents/skills/orch/scripts/approval-wait 1 1 3)
-}
-
-run_review_json() {
-  (cd "$TMP_ROOT/repo" \
-    && PATH="$TMP_ROOT/bin:$PATH" \
-       env "$@" .agents/skills/orch/scripts/approval-wait 1 1 30 --json --mode review)
-}
-
-run_review_json_short() {
-  (cd "$TMP_ROOT/repo" \
-    && PATH="$TMP_ROOT/bin:$PATH" \
-       env "$@" .agents/skills/orch/scripts/approval-wait 1 1 3 --json --mode review)
-}
-
-run_review_text() {
-  (cd "$TMP_ROOT/repo" \
-    && PATH="$TMP_ROOT/bin:$PATH" \
-       env "$@" .agents/skills/orch/scripts/approval-wait 1 1 3 --mode review)
-}
-
-json_field() {
-  jq -r "$2" <<<"$1" 2>/dev/null || echo "UNPARSEABLE"
-}
-
-echo "=== approval-wait verdict detection ==="
-
-# Case 1: reviewDecision APPROVED (branch-protection aggregate).
-stderr="$TMP_ROOT/case1.err"
-set +e
-output=$(run_wait_json STUB_APPROVAL_MODE=approved_decision 2>"$stderr")
-rc=$?
-set -e
-assert_eq "$rc" "0" "case1: reviewDecision APPROVED exits 0" "$stderr"
-assert_eq "$(json_field "$output" '.status')" "approved" "case1: status approved" "$stderr"
-assert_eq "$(json_field "$output" '.review_decision')" "APPROVED" "case1: review_decision reported" "$stderr"
-assert_eq "$(json_field "$output" '.approvals')" "1" "case1: approvals counted" "$stderr"
-
-# Case 2: no required-review protection (empty reviewDecision); one latest
-# APPROVED and no CHANGES_REQUESTED approves via the latestReviews fallback.
-stderr="$TMP_ROOT/case2.err"
-set +e
-output=$(run_wait_json STUB_APPROVAL_MODE=approved_latest 2>"$stderr")
-rc=$?
-set -e
-assert_eq "$rc" "0" "case2: latestReviews fallback exits 0" "$stderr"
-assert_eq "$(json_field "$output" '.status')" "approved" "case2: status approved via fallback" "$stderr"
-assert_eq "$(json_field "$output" '.review_decision')" "" "case2: empty review_decision preserved" "$stderr"
-assert_eq "$(json_field "$output" '.approvals')" "1" "case2: COMMENTED latest review not counted as approval" "$stderr"
-
-# Case 3: a reviewer whose latest review is CHANGES_REQUESTED blocks even
-# when another reviewer approved.
-stderr="$TMP_ROOT/case3.err"
-set +e
-output=$(run_wait_json STUB_APPROVAL_MODE=changes 2>"$stderr")
-rc=$?
-set -e
-assert_eq "$rc" "1" "case3: changes requested exits 1" "$stderr"
-assert_eq "$(json_field "$output" '.status')" "changes_requested" "case3: status changes_requested" "$stderr"
-assert_eq "$(json_field "$output" '.changes_requested')" "1" "case3: changes_requested count reported" "$stderr"
-
-# Case 4: COMMENTED-only latest reviews are not a verdict — times out.
-stderr="$TMP_ROOT/case4.err"
-set +e
-output=$(run_wait_json_short STUB_APPROVAL_MODE=commented_only 2>"$stderr")
-rc=$?
-set -e
-assert_eq "$rc" "1" "case4: commented-only exits 1" "$stderr"
-assert_eq "$(json_field "$output" '.status')" "timeout" "case4: commented-only times out (no verdict)" "$stderr"
-assert_eq "$(json_field "$output" '.approvals')" "0" "case4: COMMENTED never counts as approval" "$stderr"
-
-# Case 5: unresolved threads with no verdict return early as "comments" so
-# the caller can triage instead of idling out the timeout.
-stderr="$TMP_ROOT/case5.err"
-set +e
-output=$(run_wait_json STUB_APPROVAL_MODE=none STUB_THREADS_UNRESOLVED=2 2>"$stderr")
-rc=$?
-set -e
-assert_eq "$rc" "1" "case5: pending comments exit 1" "$stderr"
-assert_eq "$(json_field "$output" '.status')" "comments" "case5: status comments" "$stderr"
-assert_eq "$(json_field "$output" '.unresolved_count')" "2" "case5: unresolved_count reported" "$stderr"
-assert_eq "$(json_field "$output" '.elapsed_seconds | . < 3')" "true" "case5: comments returns early, not at deadline" "$stderr"
-
-# Case 6: nothing at all by the deadline — timeout, never silent success.
-stderr="$TMP_ROOT/case6.err"
-set +e
-output=$(run_wait_json_short STUB_APPROVAL_MODE=none 2>"$stderr")
-rc=$?
-set -e
-assert_eq "$rc" "1" "case6: no verdict at deadline exits 1" "$stderr"
-assert_eq "$(json_field "$output" '.status')" "timeout" "case6: status timeout" "$stderr"
-
-# Case 7: REVIEW_REQUIRED means branch protection still wants approvals — a
-# latest APPROVED review must NOT approve via the fallback.
-stderr="$TMP_ROOT/case7.err"
-set +e
-output=$(run_wait_json_short STUB_APPROVAL_MODE=required_pending 2>"$stderr")
-rc=$?
-set -e
-assert_eq "$rc" "1" "case7: REVIEW_REQUIRED does not fall back to latestReviews" "$stderr"
-assert_eq "$(json_field "$output" '.status')" "timeout" "case7: status timeout while protection pending" "$stderr"
-assert_eq "$(json_field "$output" '.review_decision')" "REVIEW_REQUIRED" "case7: review_decision reported" "$stderr"
-
-# Case 8: approved with unresolved threads still reports approved — the
-# caller's zero-unresolved gate owns thread routing — and carries the count.
-stderr="$TMP_ROOT/case8.err"
-set +e
-output=$(run_wait_json STUB_APPROVAL_MODE=approved_decision STUB_THREADS_UNRESOLVED=1 2>"$stderr")
-rc=$?
-set -e
-assert_eq "$rc" "0" "case8: approved with open threads exits 0" "$stderr"
-assert_eq "$(json_field "$output" '.status')" "approved" "case8: status approved" "$stderr"
-assert_eq "$(json_field "$output" '.unresolved_count')" "1" "case8: unresolved_count carried for the merge gate" "$stderr"
-
-# Case 9: verdict arriving on a later poll is picked up (first poll empty,
-# second poll APPROVED).
-stderr="$TMP_ROOT/case9.err"
-count_file="$TMP_ROOT/case9-count"
-set +e
-output=$(run_wait_json STUB_APPROVAL_MODE=approved_later STUB_APPROVAL_COUNT_FILE="$count_file" 2>"$stderr")
-rc=$?
-set -e
-assert_eq "$rc" "0" "case9: later approval exits 0" "$stderr"
-assert_eq "$(json_field "$output" '.status')" "approved" "case9: status approved after polling" "$stderr"
-assert_eq "$(cat "$count_file")" "2" "case9: approval-wait polled again for the verdict" "$stderr"
-
-echo "=== approval-wait output contract ==="
-
-# Case 10: auth failure with --json still yields a parseable error object.
-stderr="$TMP_ROOT/case10.err"
-set +e
-output=$(run_wait_json GH_TOKEN=bad-token STUB_GH_DENY_KEYRING=1 2>"$stderr")
-rc=$?
-set -e
-assert_eq "$rc" "3" "case10: json auth failure exits 3" "$stderr"
-assert_eq "$(json_field "$output" '.status')" "error" "case10: json auth failure reports status error" "$stderr"
-assert_contains "$(json_field "$output" '.error')" "auth" "case10: json auth failure names auth in error"
-
-# Case 11: text mode always prints a result line.
-stderr="$TMP_ROOT/case11.err"
-set +e
-output=$(run_wait_text_short STUB_APPROVAL_MODE=none 2>"$stderr")
-rc=$?
-set -e
-assert_eq "$rc" "1" "case11: text-mode timeout exits 1" "$stderr"
-assert_contains "$output" "Approval timeout" "case11: text-mode timeout prints result on stdout"
-
-stderr="$TMP_ROOT/case11b.err"
-set +e
-output=$(run_wait_text_short STUB_APPROVAL_MODE=approved_decision 2>"$stderr")
-rc=$?
-set -e
-assert_eq "$rc" "0" "case11b: text-mode approval exits 0" "$stderr"
-assert_contains "$output" "Approval: approved" "case11b: text-mode approval prints result on stdout"
-
-# Cases 11c-11e: approval-mode text lines are pinned verbatim; review-mode
-# labeling never touches them.
-stderr="$TMP_ROOT/case11c.err"
-set +e
-output=$(run_wait_text_short STUB_APPROVAL_MODE=changes 2>"$stderr")
-rc=$?
-set -e
-assert_eq "$rc" "1" "case11c: text-mode changes requested exits 1" "$stderr"
-assert_contains "$output" "Approval: changes requested (1 reviewer(s), unresolved threads: 0)" "case11c: approval-mode changes-requested line unchanged"
-
-stderr="$TMP_ROOT/case11d.err"
-set +e
-output=$(run_wait_text_short STUB_APPROVAL_MODE=none STUB_THREADS_UNRESOLVED=2 2>"$stderr")
-rc=$?
-set -e
-assert_eq "$rc" "1" "case11d: text-mode pending comments exits 1" "$stderr"
-assert_contains "$output" "Approval: 2 unresolved review thread(s) pending triage, no approval verdict yet" "case11d: approval-mode comments line unchanged"
-
-stderr="$TMP_ROOT/case11e.err"
-set +e
-output=$(run_wait_text_short GH_TOKEN=bad-token STUB_GH_DENY_KEYRING=1 2>"$stderr")
-rc=$?
-set -e
-assert_eq "$rc" "3" "case11e: text-mode auth failure exits 3" "$stderr"
-assert_contains "$output" "Approval error: no working GitHub auth path" "case11e: approval-mode error line unchanged"
-
-echo "=== approval-wait --mode review gating ==="
-
-# Case 12: a COMMENTED review pinned to the current head with zero unresolved
-# threads satisfies the review gate — the commenting-only-bot happy path.
-stderr="$TMP_ROOT/case12.err"
-set +e
-output=$(run_review_json STUB_REVIEWS_MODE=commented_at_head 2>"$stderr")
-rc=$?
-set -e
-assert_eq "$rc" "0" "case12: COMMENTED at head exits 0" "$stderr"
-assert_eq "$(json_field "$output" '.status')" "reviewed" "case12: status reviewed" "$stderr"
-assert_eq "$(json_field "$output" '.mode')" "review" "case12: mode reported" "$stderr"
-assert_eq "$(json_field "$output" '.head_sha')" "headsha1" "case12: head_sha reported" "$stderr"
-assert_eq "$(json_field "$output" '.reviews_at_head')" "1" "case12: reviews_at_head counted" "$stderr"
-
-# Case 13: a review at head with unresolved threads is NOT the gate — early
-# "comments" return so the caller triages, replies, and resolves first.
-stderr="$TMP_ROOT/case13.err"
-set +e
-output=$(run_review_json STUB_REVIEWS_MODE=commented_at_head STUB_THREADS_UNRESOLVED=2 2>"$stderr")
-rc=$?
-set -e
-assert_eq "$rc" "1" "case13: review at head + open threads exits 1" "$stderr"
-assert_eq "$(json_field "$output" '.status')" "comments" "case13: status comments" "$stderr"
-assert_eq "$(json_field "$output" '.unresolved_count')" "2" "case13: unresolved_count reported" "$stderr"
-assert_eq "$(json_field "$output" '.elapsed_seconds | . < 3')" "true" "case13: comments returns early, not at deadline" "$stderr"
-
-# Case 14: head pinning — a review of a superseded commit never satisfies the
-# gate (this is also the force-push reset: the head is re-read every poll).
-stderr="$TMP_ROOT/case14.err"
-set +e
-output=$(run_review_json_short STUB_REVIEWS_MODE=commented_stale 2>"$stderr")
-rc=$?
-set -e
-assert_eq "$rc" "1" "case14: stale-commit review exits 1" "$stderr"
-assert_eq "$(json_field "$output" '.status')" "timeout" "case14: stale-commit review times out" "$stderr"
-assert_eq "$(json_field "$output" '.reviews_at_head')" "0" "case14: stale review not counted at head" "$stderr"
-
-# Case 15: the PR author's own review never satisfies the gate.
-stderr="$TMP_ROOT/case15.err"
-set +e
-output=$(run_review_json_short STUB_REVIEWS_MODE=author_only 2>"$stderr")
-rc=$?
-set -e
-assert_eq "$rc" "1" "case15: author-only review exits 1" "$stderr"
-assert_eq "$(json_field "$output" '.status')" "timeout" "case15: author-only review times out" "$stderr"
-assert_eq "$(json_field "$output" '.reviews_at_head')" "0" "case15: author review excluded from head count" "$stderr"
-
-# Case 16: DISMISSED reviews are excluded.
-stderr="$TMP_ROOT/case16.err"
-set +e
-output=$(run_review_json_short STUB_REVIEWS_MODE=dismissed_only 2>"$stderr")
-rc=$?
-set -e
-assert_eq "$rc" "1" "case16: dismissed-only review exits 1" "$stderr"
-assert_eq "$(json_field "$output" '.status')" "timeout" "case16: dismissed-only review times out" "$stderr"
-assert_eq "$(json_field "$output" '.reviews_at_head')" "0" "case16: dismissed review excluded from head count" "$stderr"
-
-# Case 17: a standing CHANGES_REQUESTED from a non-author reviewer blocks the
-# review gate even though it is also a review of the head.
-stderr="$TMP_ROOT/case17.err"
-set +e
-output=$(run_review_json STUB_REVIEWS_MODE=changes_standing 2>"$stderr")
-rc=$?
-set -e
-assert_eq "$rc" "1" "case17: standing CHANGES_REQUESTED exits 1" "$stderr"
-assert_eq "$(json_field "$output" '.status')" "changes_requested" "case17: status changes_requested" "$stderr"
-assert_eq "$(json_field "$output" '.changes_requested')" "1" "case17: changes_requested count reported" "$stderr"
-
-# Case 18: a later review by the same reviewer supersedes their prior
-# CHANGES_REQUESTED — latest-per-reviewer, same as GitHub's standing verdict.
-stderr="$TMP_ROOT/case18.err"
-set +e
-output=$(run_review_json STUB_REVIEWS_MODE=changes_superseded 2>"$stderr")
-rc=$?
-set -e
-assert_eq "$rc" "0" "case18: superseded CHANGES_REQUESTED exits 0" "$stderr"
-assert_eq "$(json_field "$output" '.status')" "reviewed" "case18: status reviewed after supersession" "$stderr"
-assert_eq "$(json_field "$output" '.changes_requested')" "0" "case18: superseded verdict no longer stands" "$stderr"
-
-# Case 19: an APPROVED review at head satisfies review mode too — an approval
-# is also a review.
-stderr="$TMP_ROOT/case19.err"
-set +e
-output=$(run_review_json STUB_REVIEWS_MODE=approved_at_head 2>"$stderr")
-rc=$?
-set -e
-assert_eq "$rc" "0" "case19: APPROVED at head exits 0 in review mode" "$stderr"
-assert_eq "$(json_field "$output" '.status')" "reviewed" "case19: status reviewed for an approval" "$stderr"
-
-# Case 20: a review arriving on a later poll is picked up (first poll no
-# reviews, second poll COMMENTED at head).
-stderr="$TMP_ROOT/case20.err"
-count_file="$TMP_ROOT/case20-count"
-set +e
-output=$(run_review_json STUB_REVIEWS_MODE=reviewed_later STUB_REVIEWS_COUNT_FILE="$count_file" 2>"$stderr")
-rc=$?
-set -e
-assert_eq "$rc" "0" "case20: later review exits 0" "$stderr"
-assert_eq "$(json_field "$output" '.status')" "reviewed" "case20: status reviewed after polling" "$stderr"
-assert_eq "$(cat "$count_file")" "2" "case20: approval-wait polled again for the review" "$stderr"
-
-# Case 21: review-mode text output prints a Review result line.
-stderr="$TMP_ROOT/case21.err"
-set +e
-output=$(run_review_text STUB_REVIEWS_MODE=commented_at_head 2>"$stderr")
-rc=$?
-set -e
-assert_eq "$rc" "0" "case21: text-mode reviewed exits 0" "$stderr"
-assert_contains "$output" "Review: reviewed" "case21: text-mode reviewed prints result on stdout"
-
-# Cases 21b-21e: every review-mode text line names the review gate, never the
-# approval gate.
-stderr="$TMP_ROOT/case21b.err"
-set +e
-output=$(run_review_text STUB_REVIEWS_MODE=changes_standing 2>"$stderr")
-rc=$?
-set -e
-assert_eq "$rc" "1" "case21b: text-mode review changes requested exits 1" "$stderr"
-assert_contains "$output" "Review: changes requested (1 reviewer(s), unresolved threads: 0)" "case21b: review-mode changes-requested names the review gate"
-
-stderr="$TMP_ROOT/case21c.err"
-set +e
-output=$(run_review_text STUB_REVIEWS_MODE=commented_at_head STUB_THREADS_UNRESOLVED=2 2>"$stderr")
-rc=$?
-set -e
-assert_eq "$rc" "1" "case21c: text-mode review comments exits 1" "$stderr"
-assert_contains "$output" "Review: 2 unresolved review thread(s) pending triage" "case21c: review-mode comments names the review gate"
-
-stderr="$TMP_ROOT/case21d.err"
-set +e
-output=$(run_review_text STUB_REVIEWS_MODE=none 2>"$stderr")
-rc=$?
-set -e
-assert_eq "$rc" "1" "case21d: text-mode review timeout exits 1" "$stderr"
-assert_contains "$output" "Review timeout after" "case21d: review-mode timeout names the review gate"
-
-stderr="$TMP_ROOT/case21e.err"
-set +e
-output=$(run_review_text GH_TOKEN=bad-token STUB_GH_DENY_KEYRING=1 2>"$stderr")
-rc=$?
-set -e
-assert_eq "$rc" "3" "case21e: text-mode review auth failure exits 3" "$stderr"
-assert_contains "$output" "Review error: no working GitHub auth path" "case21e: review-mode error names the review gate"
-
-echo "=== approval-wait PR_REVIEW_ON_TIMEOUT reviewer-down flexibility ==="
-
-# proceed1: review mode, no evidence, zero threads, setting=proceed — the
-# deadline degrades to "proceeded" (exit 0), so a credit-exhausted reviewer
-# that posted nothing does not block the fleet.
-stderr="$TMP_ROOT/proceed1.err"
-set +e
-output=$(run_review_json_short STUB_REVIEWS_MODE=none PR_REVIEW_ON_TIMEOUT=proceed 2>"$stderr")
-rc=$?
-set -e
-assert_eq "$rc" "0" "proceed1: reviewer-down proceed exits 0" "$stderr"
-assert_eq "$(json_field "$output" '.status')" "proceeded" "proceed1: status proceeded" "$stderr"
-assert_eq "$(json_field "$output" '.unresolved_count')" "0" "proceed1: proceeded only with zero unresolved threads" "$stderr"
-
-# proceed2: the --on-timeout proceed flag drives the same behavior without the
-# setting (and overrides it for explicit callers/tests).
-stderr="$TMP_ROOT/proceed2.err"
-set +e
-output=$( (cd "$TMP_ROOT/repo" && PATH="$TMP_ROOT/bin:$PATH" \
-  env STUB_REVIEWS_MODE=none .agents/skills/orch/scripts/approval-wait 1 1 3 --json --mode review --on-timeout proceed) 2>"$stderr")
-rc=$?
-set -e
-assert_eq "$rc" "0" "proceed2: --on-timeout proceed flag exits 0" "$stderr"
-assert_eq "$(json_field "$output" '.status')" "proceeded" "proceed2: flag yields status proceeded" "$stderr"
-
-# proceed3: an unresolved thread ALWAYS blocks, even under proceed — it returns
-# "comments" before the deadline, so a real open comment is never bypassed.
-stderr="$TMP_ROOT/proceed3.err"
-set +e
-output=$(run_review_json STUB_REVIEWS_MODE=none STUB_THREADS_UNRESOLVED=2 PR_REVIEW_ON_TIMEOUT=proceed 2>"$stderr")
-rc=$?
-set -e
-assert_eq "$rc" "1" "proceed3: open threads still block under proceed" "$stderr"
-assert_eq "$(json_field "$output" '.status')" "comments" "proceed3: status comments, not proceeded" "$stderr"
-
-# proceed4: a standing CHANGES_REQUESTED still blocks under proceed — proceed
-# only ever converts a no-verdict timeout, never a negative verdict.
-stderr="$TMP_ROOT/proceed4.err"
-set +e
-output=$(run_review_json STUB_REVIEWS_MODE=changes_standing PR_REVIEW_ON_TIMEOUT=proceed 2>"$stderr")
-rc=$?
-set -e
-assert_eq "$rc" "1" "proceed4: changes_requested still blocks under proceed" "$stderr"
-assert_eq "$(json_field "$output" '.status')" "changes_requested" "proceed4: status changes_requested, not proceeded" "$stderr"
-
-# proceed5: the default advances when no reviewer engaged and no thread is open.
-stderr="$TMP_ROOT/proceed5.err"
-set +e
-output=$(run_review_json_short -u PR_REVIEW_ON_TIMEOUT STUB_REVIEWS_MODE=none 2>"$stderr")
-rc=$?
-set -e
-assert_eq "$rc" "0" "proceed5: default proceeds after reviewer silence" "$stderr"
-assert_eq "$(json_field "$output" '.status')" "proceeded" "proceed5: default status proceeded" "$stderr"
-
-# proceed6: approval mode degrades symmetrically — no approval verdict, zero
-# threads, proceed -> proceeded, exit 0.
-stderr="$TMP_ROOT/proceed6.err"
-set +e
-output=$(run_wait_json_short STUB_APPROVAL_MODE=none PR_REVIEW_ON_TIMEOUT=proceed 2>"$stderr")
-rc=$?
-set -e
-assert_eq "$rc" "0" "proceed6: approval-mode proceed exits 0" "$stderr"
-assert_eq "$(json_field "$output" '.status')" "proceeded" "proceed6: approval-mode status proceeded" "$stderr"
-
-# proceed7: text output names the proceed reason instead of a timeout line.
-stderr="$TMP_ROOT/proceed7.err"
-set +e
-output=$( (cd "$TMP_ROOT/repo" && PATH="$TMP_ROOT/bin:$PATH" \
-  env STUB_REVIEWS_MODE=none PR_REVIEW_ON_TIMEOUT=proceed .agents/skills/orch/scripts/approval-wait 1 1 3 --mode review) 2>"$stderr")
-rc=$?
-set -e
-assert_eq "$rc" "0" "proceed7: review-mode proceed text exits 0" "$stderr"
-assert_contains "$output" "proceeding per PR_REVIEW_ON_TIMEOUT=proceed" "proceed7: text names the proceed reason"
-
-# proceed8: an unrecognized value falls back to block (timeout) and warns.
-stderr="$TMP_ROOT/proceed8.err"
-set +e
-output=$(run_review_json_short STUB_REVIEWS_MODE=none PR_REVIEW_ON_TIMEOUT=bogus 2>"$stderr")
-rc=$?
-set -e
-assert_eq "$rc" "1" "proceed8: invalid value falls back to block" "$stderr"
-assert_eq "$(json_field "$output" '.status')" "timeout" "proceed8: invalid value times out" "$stderr"
-assert_contains "$(cat "$stderr")" "unrecognized PR_REVIEW_ON_TIMEOUT value" "proceed8: invalid value warns"
-
-# proceed9: approval mode with an active COMMENTED review is NOT reviewer
-# silence — a reviewer engaged but did not approve. proceed must NOT convert it
-# (that would bypass a live approval gate), so it still times out. Guards the
-# "zero reviewer evidence" boundary in approval mode, where reaching the
-# deadline does not by itself imply no review.
-stderr="$TMP_ROOT/proceed9.err"
-set +e
-output=$(run_wait_json_short STUB_APPROVAL_MODE=commented_only PR_REVIEW_ON_TIMEOUT=proceed 2>"$stderr")
-rc=$?
-set -e
-assert_eq "$rc" "1" "proceed9: active COMMENTED review blocks proceed (approval mode)" "$stderr"
-assert_eq "$(json_field "$output" '.status')" "timeout" "proceed9: status timeout, not proceeded" "$stderr"
-
-# proceed10: a head change DURING the wait (force-push near the deadline)
-# disqualifies proceed — elapsed is measured from START_TIME, so proceed must
-# not fire seconds after a push before the reviewer could re-review it. Falls
-# back to timeout so the caller re-waits on the stable head.
-stderr="$TMP_ROOT/proceed10.err"
-head_count="$TMP_ROOT/proceed10-head-count"
-set +e
-output=$(cd "$TMP_ROOT/repo" \
-  && PATH="$TMP_ROOT/bin:$PATH" \
-     env STUB_REVIEWS_MODE=none STUB_HEAD_MODE=changes STUB_HEAD_COUNT_FILE="$head_count" \
-         PR_REVIEW_ON_TIMEOUT=proceed \
-         .agents/skills/orch/scripts/approval-wait 1 1 5 --json --mode review 2>"$stderr")
-rc=$?
-set -e
-assert_eq "$rc" "1" "proceed10: head change during wait blocks proceed" "$stderr"
-assert_eq "$(json_field "$output" '.status')" "timeout" "proceed10: status timeout, not proceeded (head moved)" "$stderr"
-
-# proceed11: review mode with a FAILED trusted check-run at head is a real
-# reviewer signal, not silence — the reviewer ran and did not pass. proceed
-# must not fire; it times out.
-stderr="$TMP_ROOT/proceed11.err"
-set +e
-output=$(run_review_json_short STUB_REVIEWS_MODE=none STUB_CHECKS_MODE=failure_at_head \
-  PR_REVIEW_CHECK="Review Bot" PR_REVIEW_ON_TIMEOUT=proceed 2>"$stderr")
-rc=$?
-set -e
-assert_eq "$rc" "1" "proceed11: failed trusted check blocks proceed (present, not silent)" "$stderr"
-assert_eq "$(json_field "$output" '.status')" "timeout" "proceed11: status timeout, not proceeded" "$stderr"
-
-# proceed12: review mode with a PENDING trusted commit status at head means the
-# reviewer is actively analyzing — presence, not silence. proceed must not fire
-# on the status surface either; it times out.
-stderr="$TMP_ROOT/proceed12.err"
-set +e
-output=$(run_review_json_short STUB_REVIEWS_MODE=none STUB_STATUS_MODE=pending_at_head \
-  PR_REVIEW_CHECK="Review Bot" PR_REVIEW_ON_TIMEOUT=proceed 2>"$stderr")
-rc=$?
-set -e
-assert_eq "$rc" "1" "proceed12: pending trusted status blocks proceed (present, not silent)" "$stderr"
-assert_eq "$(json_field "$output" '.status')" "timeout" "proceed12: status timeout, not proceeded" "$stderr"
-
-# proceed13: a push in the final last-poll -> emit window (head confirmed
-# different at the decision) falls back to timeout, preserving the head-unchanged
-# guarantee — no proceed on a superseded commit. The head is stable across
-# polls (so head_changed_during_wait stays false), only the emit-time confirm
-# differs.
-stderr="$TMP_ROOT/proceed13.err"
-set +e
-output=$(run_review_json_short STUB_REVIEWS_MODE=none PR_REVIEW_ON_TIMEOUT=proceed \
-  STUB_CONFIRM_HEAD=headsha2 2>"$stderr")
-rc=$?
-set -e
-assert_eq "$rc" "1" "proceed13: head moved in the confirm window blocks proceed" "$stderr"
-assert_eq "$(json_field "$output" '.status')" "timeout" "proceed13: status timeout, not proceeded" "$stderr"
-
-echo "=== approval-wait never posts review evidence ==="
-
-# marker1: a proceed posts NO commit status and its JSON carries no
-# outage_marker field: orch never manufactures review evidence.
-# PR_REVIEW_OUTAGE_CONTEXT is deliberately exported to prove it is inert; the
-# must-fail control is a status POST landing in the log.
-stderr="$TMP_ROOT/marker1.err"
-marker_log="$TMP_ROOT/marker1.log"; : > "$marker_log"
-set +e
-output=$(run_review_json_short STUB_REVIEWS_MODE=none PR_REVIEW_ON_TIMEOUT=proceed \
-  PR_REVIEW_OUTAGE_CONTEXT="kendex-reviewer-outage" STUB_MARKER_LOG="$marker_log" 2>"$stderr")
-rc=$?
-set -e
-assert_eq "$rc" "0" "marker1: proceed exits 0" "$stderr"
-assert_eq "$(json_field "$output" '.status')" "proceeded" "marker1: status proceeded" "$stderr"
-assert_eq "$(wc -l < "$marker_log" | tr -d ' ')" "0" "marker1: no commit status posted on proceed" "$stderr"
-assert_eq "$(json_field "$output" 'has("outage_marker")')" "false" "marker1: no outage_marker field in the JSON" "$stderr"
-
-echo "=== approval-wait --mode review check-run evidence (kendex#654) ==="
-
-# Check 1: with PR_REVIEW_CHECK set and no review object anywhere, a "success"
-# conclusion of that check name on the current head opens the gate. The stub
-# payload also pins newest-of-name selection (an older failed "Review Bot" run
-# precedes the success) and name filtering (an unrelated green check exists).
-stderr="$TMP_ROOT/check1.err"
-set +e
-output=$(run_review_json STUB_REVIEWS_MODE=none STUB_CHECKS_MODE=success_at_head \
-  PR_REVIEW_CHECK="Review Bot" 2>"$stderr")
-rc=$?
-set -e
-assert_eq "$rc" "0" "check1: trusted check success at head exits 0" "$stderr"
-assert_eq "$(json_field "$output" '.status')" "reviewed" "check1: status reviewed via check evidence" "$stderr"
-assert_eq "$(json_field "$output" '.review_evidence')" "check" "check1: review_evidence pinned to check" "$stderr"
-assert_eq "$(json_field "$output" '.review_evidence_surface')" "check_run" "check1: review_evidence_surface pinned to check_run" "$stderr"
-assert_eq "$(json_field "$output" '.reviews_at_head')" "0" "check1: no review object at head" "$stderr"
-assert_eq "$(json_field "$output" '.head_sha')" "headsha1" "check1: head_sha reported" "$stderr"
-
-# Check 2: a check success on a STALE sha never opens the gate — the query
-# targets the current head's check-runs, which report nothing.
-stderr="$TMP_ROOT/check2.err"
-set +e
-output=$(run_review_json_short STUB_REVIEWS_MODE=none STUB_CHECKS_MODE=success_stale \
-  PR_REVIEW_CHECK="Review Bot" 2>"$stderr")
-rc=$?
-set -e
-assert_eq "$rc" "1" "check2: stale-sha check success exits 1" "$stderr"
-assert_eq "$(json_field "$output" '.status')" "timeout" "check2: stale-sha check success times out" "$stderr"
-
-# Check 3: a non-success conclusion of the configured check is not evidence.
-stderr="$TMP_ROOT/check3.err"
-set +e
-output=$(run_review_json_short STUB_REVIEWS_MODE=none STUB_CHECKS_MODE=failure_at_head \
-  PR_REVIEW_CHECK="Review Bot" 2>"$stderr")
-rc=$?
-set -e
-assert_eq "$rc" "1" "check3: failed check conclusion exits 1" "$stderr"
-assert_eq "$(json_field "$output" '.status')" "timeout" "check3: failed check conclusion times out" "$stderr"
-
-# Check 4: unresolved threads still block — check evidence routes to the same
-# "comments" early return as a review object would.
-stderr="$TMP_ROOT/check4.err"
-set +e
-output=$(run_review_json STUB_REVIEWS_MODE=none STUB_CHECKS_MODE=success_at_head \
-  PR_REVIEW_CHECK="Review Bot" STUB_THREADS_UNRESOLVED=2 2>"$stderr")
-rc=$?
-set -e
-assert_eq "$rc" "1" "check4: check success + open threads exits 1" "$stderr"
-assert_eq "$(json_field "$output" '.status')" "comments" "check4: status comments despite check success" "$stderr"
-assert_eq "$(json_field "$output" '.unresolved_count')" "2" "check4: unresolved_count reported" "$stderr"
-assert_eq "$(json_field "$output" '.elapsed_seconds | . < 3')" "true" "check4: comments returns early, not at deadline" "$stderr"
-
-# Check 5: a standing CHANGES_REQUESTED still blocks despite check success.
-stderr="$TMP_ROOT/check5.err"
-set +e
-output=$(run_review_json STUB_REVIEWS_MODE=changes_standing STUB_CHECKS_MODE=success_at_head \
-  PR_REVIEW_CHECK="Review Bot" 2>"$stderr")
-rc=$?
-set -e
-assert_eq "$rc" "1" "check5: standing CHANGES_REQUESTED exits 1 despite check success" "$stderr"
-assert_eq "$(json_field "$output" '.status')" "changes_requested" "check5: status changes_requested despite check success" "$stderr"
-
-# Check 6: empty PR_REVIEW_CHECK ignores check-runs entirely — the published
-# success must not leak into the gate when the feature is off.
-stderr="$TMP_ROOT/check6.err"
-set +e
-output=$(run_review_json_short STUB_REVIEWS_MODE=none STUB_CHECKS_MODE=success_at_head 2>"$stderr")
-rc=$?
-set -e
-assert_eq "$rc" "1" "check6: empty PR_REVIEW_CHECK exits 1" "$stderr"
-assert_eq "$(json_field "$output" '.status')" "timeout" "check6: empty PR_REVIEW_CHECK ignores check-runs" "$stderr"
-
-# Check 7: the review-object path still works with the feature on, and wins
-# the review_evidence label when a review is pinned to the head.
-stderr="$TMP_ROOT/check7.err"
-set +e
-output=$(run_review_json STUB_REVIEWS_MODE=commented_at_head STUB_CHECKS_MODE=none \
-  PR_REVIEW_CHECK="Review Bot" 2>"$stderr")
-rc=$?
-set -e
-assert_eq "$rc" "0" "check7: review object still opens the gate with the feature on" "$stderr"
-assert_eq "$(json_field "$output" '.status')" "reviewed" "check7: status reviewed via review object" "$stderr"
-assert_eq "$(json_field "$output" '.review_evidence')" "review" "check7: review_evidence pinned to review" "$stderr"
-assert_eq "$(json_field "$output" '.review_evidence_surface')" "null" "check7: no surface field for review-object evidence" "$stderr"
-assert_eq "$(json_field "$output" '.reviews_at_head')" "1" "check7: reviews_at_head counted" "$stderr"
-
-# Check 8: text mode names the satisfying check-run and its app slug.
-stderr="$TMP_ROOT/check8.err"
-set +e
-output=$(run_review_text STUB_REVIEWS_MODE=none STUB_CHECKS_MODE=success_at_head \
-  PR_REVIEW_CHECK="Review Bot" 2>"$stderr")
-rc=$?
-set -e
-assert_eq "$rc" "0" "check8: text-mode check evidence exits 0" "$stderr"
-assert_contains "$output" "Review: reviewed" "check8: text mode still prints the reviewed line" "$stderr"
-assert_contains "$output" "check-run 'Review Bot'" "check8: text mode names the check-run" "$stderr"
-assert_contains "$output" "app: review-bot" "check8: text mode records the publishing app slug" "$stderr"
-
-echo "=== approval-wait --mode review commit-status evidence (kendex#681) ==="
-
-# Status 1: with PR_REVIEW_CHECK set, no review object, and no check-run of
-# that name anywhere, a "success" commit status with that context on the
-# current head opens the gate. The stub payload also pins newest-of-context
-# selection (an older pending entry precedes the success) and context
-# filtering (an unrelated green context exists).
-stderr="$TMP_ROOT/status1.err"
-set +e
-output=$(run_review_json STUB_REVIEWS_MODE=none STUB_CHECKS_MODE=none \
-  STUB_STATUS_MODE=success_at_head PR_REVIEW_CHECK="Review Bot" 2>"$stderr")
-rc=$?
-set -e
-assert_eq "$rc" "0" "status1: trusted status success at head exits 0" "$stderr"
-assert_eq "$(json_field "$output" '.status')" "reviewed" "status1: status reviewed via status evidence" "$stderr"
-assert_eq "$(json_field "$output" '.review_evidence')" "check" "status1: review_evidence stays check" "$stderr"
-assert_eq "$(json_field "$output" '.review_evidence_surface')" "status" "status1: review_evidence_surface pinned to status" "$stderr"
-assert_eq "$(json_field "$output" '.reviews_at_head')" "0" "status1: no review object at head" "$stderr"
-assert_eq "$(json_field "$output" '.head_sha')" "headsha1" "status1: head_sha reported" "$stderr"
-
-# Status 2: a matching check-run wins first — the status endpoint is never
-# queried, so bots that use check-runs cost no extra API call.
-stderr="$TMP_ROOT/status2.err"
-status_log="$TMP_ROOT/status2-status.log"
-set +e
-output=$(run_review_json STUB_REVIEWS_MODE=none STUB_CHECKS_MODE=success_at_head \
-  STUB_STATUS_MODE=success_at_head STUB_STATUS_LOG="$status_log" \
-  PR_REVIEW_CHECK="Review Bot" 2>"$stderr")
-rc=$?
-set -e
-assert_eq "$rc" "0" "status2: check-run match still exits 0 with a status present" "$stderr"
-assert_eq "$(json_field "$output" '.review_evidence_surface')" "check_run" "status2: check-run surface wins over status" "$stderr"
-assert_eq "$([[ -f "$status_log" ]] && wc -l < "$status_log" | tr -d ' ' || echo 0)" "0" "status2: status endpoint never queried when a check-run matches" "$stderr"
-
-# Status 3a-3c: non-success status states are not evidence — pending,
-# failure, and error all keep waiting to the timeout.
-stderr="$TMP_ROOT/status3a.err"
-set +e
-output=$(run_review_json_short STUB_REVIEWS_MODE=none STUB_CHECKS_MODE=none \
-  STUB_STATUS_MODE=pending_at_head PR_REVIEW_CHECK="Review Bot" 2>"$stderr")
-rc=$?
-set -e
-assert_eq "$rc" "1" "status3a: pending status exits 1" "$stderr"
-assert_eq "$(json_field "$output" '.status')" "timeout" "status3a: pending status times out" "$stderr"
-
-stderr="$TMP_ROOT/status3b.err"
-set +e
-output=$(run_review_json_short STUB_REVIEWS_MODE=none STUB_CHECKS_MODE=none \
-  STUB_STATUS_MODE=failure_at_head PR_REVIEW_CHECK="Review Bot" 2>"$stderr")
-rc=$?
-set -e
-assert_eq "$rc" "1" "status3b: failure status exits 1" "$stderr"
-assert_eq "$(json_field "$output" '.status')" "timeout" "status3b: failure status times out" "$stderr"
-
-stderr="$TMP_ROOT/status3c.err"
-set +e
-output=$(run_review_json_short STUB_REVIEWS_MODE=none STUB_CHECKS_MODE=none \
-  STUB_STATUS_MODE=error_at_head PR_REVIEW_CHECK="Review Bot" 2>"$stderr")
-rc=$?
-set -e
-assert_eq "$rc" "1" "status3c: error status exits 1" "$stderr"
-assert_eq "$(json_field "$output" '.status')" "timeout" "status3c: error status times out" "$stderr"
-
-# Status 4: a status success on a STALE sha never opens the gate — the query
-# targets the current head's combined status, which reports nothing.
-stderr="$TMP_ROOT/status4.err"
-set +e
-output=$(run_review_json_short STUB_REVIEWS_MODE=none STUB_CHECKS_MODE=none \
-  STUB_STATUS_MODE=success_stale PR_REVIEW_CHECK="Review Bot" 2>"$stderr")
-rc=$?
-set -e
-assert_eq "$rc" "1" "status4: stale-sha status success exits 1" "$stderr"
-assert_eq "$(json_field "$output" '.status')" "timeout" "status4: stale-sha status success times out" "$stderr"
-
-# Status 5: empty PR_REVIEW_CHECK ignores BOTH surfaces — neither the
-# published check-run success nor the status success leaks into the gate,
-# and the status endpoint is never queried.
-stderr="$TMP_ROOT/status5.err"
-status_log="$TMP_ROOT/status5-status.log"
-set +e
-output=$(run_review_json_short STUB_REVIEWS_MODE=none STUB_CHECKS_MODE=success_at_head \
-  STUB_STATUS_MODE=success_at_head STUB_STATUS_LOG="$status_log" 2>"$stderr")
-rc=$?
-set -e
-assert_eq "$rc" "1" "status5: empty PR_REVIEW_CHECK exits 1" "$stderr"
-assert_eq "$(json_field "$output" '.status')" "timeout" "status5: empty PR_REVIEW_CHECK ignores both surfaces" "$stderr"
-assert_eq "$([[ -f "$status_log" ]] && wc -l < "$status_log" | tr -d ' ' || echo 0)" "0" "status5: status endpoint never queried with the feature off" "$stderr"
-
-# Status 6: a review object pinned to the head still takes precedence over a
-# status success — review_evidence "review", no surface field.
-stderr="$TMP_ROOT/status6.err"
-set +e
-output=$(run_review_json STUB_REVIEWS_MODE=commented_at_head STUB_CHECKS_MODE=none \
-  STUB_STATUS_MODE=success_at_head PR_REVIEW_CHECK="Review Bot" 2>"$stderr")
-rc=$?
-set -e
-assert_eq "$rc" "0" "status6: review object still opens the gate over a status" "$stderr"
-assert_eq "$(json_field "$output" '.review_evidence')" "review" "status6: review_evidence pinned to review" "$stderr"
-assert_eq "$(json_field "$output" '.review_evidence_surface')" "null" "status6: no surface field for review-object evidence" "$stderr"
-
-# Status 7: unresolved threads still block — status evidence routes to the
-# same "comments" early return as a review object or check-run would.
-stderr="$TMP_ROOT/status7.err"
-set +e
-output=$(run_review_json STUB_REVIEWS_MODE=none STUB_CHECKS_MODE=none \
-  STUB_STATUS_MODE=success_at_head PR_REVIEW_CHECK="Review Bot" \
-  STUB_THREADS_UNRESOLVED=2 2>"$stderr")
-rc=$?
-set -e
-assert_eq "$rc" "1" "status7: status success + open threads exits 1" "$stderr"
-assert_eq "$(json_field "$output" '.status')" "comments" "status7: status comments despite status success" "$stderr"
-assert_eq "$(json_field "$output" '.elapsed_seconds | . < 3')" "true" "status7: comments returns early, not at deadline" "$stderr"
-
-# Status 8: text mode names the satisfying status context and its creator.
-stderr="$TMP_ROOT/status8.err"
-set +e
-output=$(run_review_text STUB_REVIEWS_MODE=none STUB_CHECKS_MODE=none \
-  STUB_STATUS_MODE=success_at_head PR_REVIEW_CHECK="Review Bot" 2>"$stderr")
-rc=$?
-set -e
-assert_eq "$rc" "0" "status8: text-mode status evidence exits 0" "$stderr"
-assert_contains "$output" "Review: reviewed" "status8: text mode still prints the reviewed line" "$stderr"
-assert_contains "$output" "via status 'Review Bot'" "status8: text mode names the status context" "$stderr"
-assert_contains "$output" "creator: review-bot[bot]" "status8: text mode records the publishing creator" "$stderr"
-
-echo "=== approval-wait transient GitHub API errors (kendex#748) ==="
-
-stderr="$TMP_ROOT/transient1.err"
-count_file="$TMP_ROOT/transient1-count"
-set +e
-output=$(run_review_json STUB_REVIEWS_MODE=flaky_503 STUB_REVIEWS_COUNT_FILE="$count_file" 2>"$stderr")
-rc=$?
-set -e
-assert_eq "$rc" "0" "transient1: 503 twice then success exits 0" "$stderr"
-assert_eq "$(json_field "$output" '.status')" "reviewed" "transient1: status reviewed despite transient 503s" "$stderr"
-assert_eq "$(json_field "$output" '.transient_api_errors')" "2" "transient1: transient_api_errors counts the absorbed 503s" "$stderr"
-assert_eq "$(cat "$count_file")" "3" "transient1: reviews endpoint retried until it recovered" "$stderr"
-assert_contains "$(cat "$stderr")" "transient GitHub error" "transient1: each transient failure is logged to stderr"
-
-# Transient 1b: HTTP 429 rate limits are transient too — twice
-# then success recovers exactly like a 5xx.
-stderr="$TMP_ROOT/transient1b.err"
-count_file="$TMP_ROOT/transient1b-count"
-set +e
-output=$(run_review_json STUB_REVIEWS_MODE=flaky_429 STUB_REVIEWS_COUNT_FILE="$count_file" 2>"$stderr")
-rc=$?
-set -e
-assert_eq "$rc" "0" "transient1b: 429 twice then success exits 0" "$stderr"
-assert_eq "$(json_field "$output" '.status')" "reviewed" "transient1b: status reviewed despite rate limits" "$stderr"
-assert_eq "$(json_field "$output" '.transient_api_errors')" "2" "transient1b: transient_api_errors counts the absorbed 429s" "$stderr"
-
-# Transient 2: a persistent 503 becomes terminal only when the wait budget
-# expires — the listing's own error message is preserved, plus the count.
-stderr="$TMP_ROOT/transient2.err"
-set +e
-output=$(run_review_json_short STUB_REVIEWS_MODE=http_503 2>"$stderr")
-rc=$?
-set -e
-assert_eq "$rc" "1" "transient2: persistent 503 exits 1 at the deadline" "$stderr"
-assert_eq "$(json_field "$output" '.status')" "error" "transient2: persistent 503 ends in status error" "$stderr"
-assert_contains "$(json_field "$output" '.error')" "review listing failed" "transient2: terminal error message preserved" "$stderr"
-assert_eq "$(json_field "$output" '.transient_api_errors >= 1')" "true" "transient2: transient_api_errors reported at the deadline" "$stderr"
-assert_eq "$(json_field "$output" '.elapsed_seconds >= 3')" "true" "transient2: the full wait budget was spent retrying" "$stderr"
-
-# Transient 3: an HTTP 404 is NOT transient — immediately terminal, with no
-# transient_api_errors field.
-stderr="$TMP_ROOT/transient3.err"
-set +e
-output=$(run_review_json STUB_REVIEWS_MODE=http_404 2>"$stderr")
-rc=$?
-set -e
-assert_eq "$rc" "1" "transient3: 404 exits 1" "$stderr"
-assert_eq "$(json_field "$output" '.status')" "error" "transient3: 404 reports status error" "$stderr"
-assert_contains "$(json_field "$output" '.error')" "review listing failed" "transient3: 404 keeps the terminal error message" "$stderr"
-assert_eq "$(json_field "$output" '.transient_api_errors')" "null" "transient3: no transient count for a non-transient failure" "$stderr"
-assert_eq "$(json_field "$output" '.elapsed_seconds | . < 3')" "true" "transient3: 404 terminates immediately, not at the deadline" "$stderr"
-
-# Transient 4: approval-mode gh pr view gets the same treatment — 503 twice,
-# then the APPROVED verdict lands.
-stderr="$TMP_ROOT/transient4.err"
-count_file="$TMP_ROOT/transient4-count"
-set +e
-output=$(run_wait_json STUB_APPROVAL_MODE=approved_after_503 STUB_APPROVAL_COUNT_FILE="$count_file" 2>"$stderr")
-rc=$?
-set -e
-assert_eq "$rc" "0" "transient4: approval-mode 503s then approval exits 0" "$stderr"
-assert_eq "$(json_field "$output" '.status')" "approved" "transient4: status approved despite transient 503s" "$stderr"
-assert_eq "$(json_field "$output" '.transient_api_errors')" "2" "transient4: approval-mode pr view retries counted" "$stderr"
-
-echo "=== PR_REVIEW_WAIT_SECS (absent max_wait positional resolves via settings) ==="
-
-# No 3rd positional: the deadline comes from PR_REVIEW_WAIT_SECS through
-# orch-env (env > kendex.settings.toml > 900). These cases pin every layer
-# without ever waiting the 900s built-in default.
-run_wait_json_nomax() {
-  (cd "$TMP_ROOT/repo" \
-    && PATH="$TMP_ROOT/bin:$PATH" \
-       env "$@" .agents/skills/orch/scripts/approval-wait 1 1 --json)
-}
-
-# Env layer: a 1-second setting times the wait out promptly (a broken
-# resolution would idle toward the 900s default and hang the suite).
-stderr="$TMP_ROOT/waitsecs1.err"
-set +e
-output=$(run_wait_json_nomax STUB_APPROVAL_MODE=none PR_REVIEW_WAIT_SECS=1 2>"$stderr")
-rc=$?
-set -e
-assert_eq "$rc" "1" "waitsecs: env PR_REVIEW_WAIT_SECS drives the deadline" "$stderr"
-assert_eq "$(json_field "$output" '.status')" "timeout" "waitsecs: env-resolved deadline reports timeout" "$stderr"
-assert_eq "$(json_field "$output" '.elapsed_seconds | . < 5')" "true" "waitsecs: env deadline is the 1s setting, not the 900s default" "$stderr"
-
-# Settings layer: the same key from kendex.settings.toml [env] applies when
-# the process env is silent.
-cat > "$TMP_ROOT/repo/kendex.settings.toml" <<'EOF'
-[env]
-PR_REVIEW_WAIT_SECS = "1"
-EOF
-stderr="$TMP_ROOT/waitsecs2.err"
-set +e
-output=$(run_wait_json_nomax STUB_APPROVAL_MODE=none 2>"$stderr")
-rc=$?
-set -e
-assert_eq "$rc" "1" "waitsecs: settings-file PR_REVIEW_WAIT_SECS applies" "$stderr"
-assert_eq "$(json_field "$output" '.status')" "timeout" "waitsecs: settings-resolved deadline reports timeout" "$stderr"
-assert_eq "$(json_field "$output" '.elapsed_seconds | . < 5')" "true" "waitsecs: settings deadline is the 1s value, not the 900s default" "$stderr"
-
-# Process env beats the settings file (orch-env precedence): with the file
-# saying 1 and the env saying 3, the wait must run past 1s.
-stderr="$TMP_ROOT/waitsecs3.err"
-set +e
-output=$(run_wait_json_nomax STUB_APPROVAL_MODE=none PR_REVIEW_WAIT_SECS=3 2>"$stderr")
-rc=$?
-set -e
-assert_eq "$rc" "1" "waitsecs: env beats settings file (still times out)" "$stderr"
-assert_eq "$(json_field "$output" '.elapsed_seconds | . >= 2')" "true" "waitsecs: env 3s outlives the settings file's 1s" "$stderr"
-
-# An explicit positional max_wait always wins over the setting.
-stderr="$TMP_ROOT/waitsecs4.err"
-set +e
-output=$(run_wait_json_short STUB_APPROVAL_MODE=none PR_REVIEW_WAIT_SECS=600 2>"$stderr")
-rc=$?
-set -e
-assert_eq "$rc" "1" "waitsecs: explicit positional wins over the setting" "$stderr"
-assert_eq "$(json_field "$output" '.elapsed_seconds | . < 600')" "true" "waitsecs: positional 3s deadline, not the setting's 600" "$stderr"
+APPROVAL='1 1 3 --json'
+REVIEW='1 1 3 --json --mode review'
+
+echo "=== approval mode: the verdict rule over the pr view payload and the thread count ==="
+# A reviewDecision decides; with none, the latest review per reviewer does,
+# and REVIEW_REQUIRED means protection still wants more. COMMENTED is never a
+# verdict. Open threads with no verdict return before the deadline so the
+# caller triages; open threads beside an approval ride along as a count for
+# the caller's own gate. A later poll picks up a verdict the first missed.
+table "$APPROVAL" \
+  'reviewDecision APPROVED approves||STUB_APPROVAL_MODE=approved_decision|rc=0 status=approved review_decision=APPROVED approvals=1' \
+  'no reviewDecision, a latest APPROVED approves via latestReviews||STUB_APPROVAL_MODE=approved_latest|rc=0 status=approved review_decision= approvals=1' \
+  'a latest CHANGES_REQUESTED blocks beside another approval||STUB_APPROVAL_MODE=changes|rc=1 status=changes_requested changes_requested=1' \
+  'COMMENTED-only latest reviews are no verdict||STUB_APPROVAL_MODE=commented_only|rc=1 status=timeout approvals=0' \
+  'open threads with no verdict return comments before the deadline||STUB_APPROVAL_MODE=none,STUB_THREADS_UNRESOLVED=2|rc=1 status=comments unresolved_count=2 early=true' \
+  'nothing at the deadline is a timeout||STUB_APPROVAL_MODE=none|rc=1 status=timeout' \
+  'REVIEW_REQUIRED keeps a latest APPROVED from approving||STUB_APPROVAL_MODE=required_pending|rc=1 status=timeout review_decision=REVIEW_REQUIRED' \
+  'approved with open threads stays approved and carries the count||STUB_APPROVAL_MODE=approved_decision,STUB_THREADS_UNRESOLVED=1|rc=0 status=approved unresolved_count=1' \
+  'a verdict arriving on the second poll approves||STUB_APPROVAL_MODE=approved_later|rc=0 status=approved approval_polls=2' \
+  'an auth failure is a parseable error object||GH_TOKEN=bad-token,STUB_GH_DENY_KEYRING=1|rc=3 status=error'
+
+echo "=== review mode: the evidence rule over reviews, check-runs and commit statuses at the head ==="
+# A review counts only at the current head, from someone other than the
+# author, not dismissed; the latest per reviewer stands, so a standing
+# CHANGES_REQUESTED blocks and a superseded one does not. With PR_REVIEW_CHECK
+# set, a success of that name on the head is evidence too: check-runs first,
+# then the combined status, newest of the name winning and unrelated names
+# ignored (the stub publishes both distractors). A review object outranks
+# either surface; open threads and a standing CHANGES_REQUESTED block whatever
+# the evidence; an empty PR_REVIEW_CHECK reads neither surface.
+table "$REVIEW" \
+  'a COMMENTED review at head with no open threads is reviewed||STUB_REVIEWS_MODE=commented_at_head|rc=0 status=reviewed mode=review head_sha=headsha1 reviews_at_head=1' \
+  'a review at head with open threads returns comments before the deadline||STUB_REVIEWS_MODE=commented_at_head,STUB_THREADS_UNRESOLVED=2|rc=1 status=comments unresolved_count=2 early=true' \
+  'a review of a superseded commit is not at head||STUB_REVIEWS_MODE=commented_stale|rc=1 status=timeout reviews_at_head=0' \
+  "the author's own review is excluded||STUB_REVIEWS_MODE=author_only|rc=1 status=timeout reviews_at_head=0" \
+  'a DISMISSED review is excluded||STUB_REVIEWS_MODE=dismissed_only|rc=1 status=timeout reviews_at_head=0' \
+  'a standing CHANGES_REQUESTED blocks the review gate||STUB_REVIEWS_MODE=changes_standing|rc=1 status=changes_requested changes_requested=1' \
+  'a CHANGES_REQUESTED superseded by the same reviewer no longer stands||STUB_REVIEWS_MODE=changes_superseded|rc=0 status=reviewed changes_requested=0' \
+  'an APPROVED review at head is a review||STUB_REVIEWS_MODE=approved_at_head|rc=0 status=reviewed' \
+  'a review arriving on the second poll is picked up||STUB_REVIEWS_MODE=reviewed_later|rc=0 status=reviewed review_polls=2' \
+  'a trusted check-run success at head opens the gate||STUB_REVIEWS_MODE=none,STUB_CHECKS_MODE=success_at_head,PR_REVIEW_CHECK=Review Bot|rc=0 status=reviewed review_evidence=check review_evidence_surface=check_run reviews_at_head=0 head_sha=headsha1' \
+  'a check-run success on a stale sha is not evidence||STUB_REVIEWS_MODE=none,STUB_CHECKS_MODE=success_stale,PR_REVIEW_CHECK=Review Bot|rc=1 status=timeout' \
+  'a failed check-run conclusion is not evidence||STUB_REVIEWS_MODE=none,STUB_CHECKS_MODE=failure_at_head,PR_REVIEW_CHECK=Review Bot|rc=1 status=timeout' \
+  'check-run success with open threads returns comments||STUB_REVIEWS_MODE=none,STUB_CHECKS_MODE=success_at_head,PR_REVIEW_CHECK=Review Bot,STUB_THREADS_UNRESOLVED=2|rc=1 status=comments unresolved_count=2 early=true' \
+  'check-run success beside a standing CHANGES_REQUESTED still blocks||STUB_REVIEWS_MODE=changes_standing,STUB_CHECKS_MODE=success_at_head,PR_REVIEW_CHECK=Review Bot|rc=1 status=changes_requested' \
+  'an empty PR_REVIEW_CHECK ignores a check-run success||STUB_REVIEWS_MODE=none,STUB_CHECKS_MODE=success_at_head|rc=1 status=timeout' \
+  'a review object outranks the check surface with the feature on||STUB_REVIEWS_MODE=commented_at_head,STUB_CHECKS_MODE=none,PR_REVIEW_CHECK=Review Bot|rc=0 status=reviewed review_evidence=review review_evidence_surface=null reviews_at_head=1' \
+  'a trusted commit-status success at head opens the gate when no check-run matches||STUB_REVIEWS_MODE=none,STUB_CHECKS_MODE=none,STUB_STATUS_MODE=success_at_head,PR_REVIEW_CHECK=Review Bot|rc=0 status=reviewed review_evidence=check review_evidence_surface=status reviews_at_head=0 head_sha=headsha1' \
+  'a matching check-run wins and the status endpoint is never read||STUB_REVIEWS_MODE=none,STUB_CHECKS_MODE=success_at_head,STUB_STATUS_MODE=success_at_head,PR_REVIEW_CHECK=Review Bot|rc=0 review_evidence_surface=check_run status_queries=0' \
+  'a pending status is not evidence||STUB_REVIEWS_MODE=none,STUB_CHECKS_MODE=none,STUB_STATUS_MODE=pending_at_head,PR_REVIEW_CHECK=Review Bot|rc=1 status=timeout' \
+  'a failure status is not evidence||STUB_REVIEWS_MODE=none,STUB_CHECKS_MODE=none,STUB_STATUS_MODE=failure_at_head,PR_REVIEW_CHECK=Review Bot|rc=1 status=timeout' \
+  'an error status is not evidence||STUB_REVIEWS_MODE=none,STUB_CHECKS_MODE=none,STUB_STATUS_MODE=error_at_head,PR_REVIEW_CHECK=Review Bot|rc=1 status=timeout' \
+  'a status success on a stale sha is not evidence||STUB_REVIEWS_MODE=none,STUB_CHECKS_MODE=none,STUB_STATUS_MODE=success_stale,PR_REVIEW_CHECK=Review Bot|rc=1 status=timeout' \
+  'an empty PR_REVIEW_CHECK reads neither surface||STUB_REVIEWS_MODE=none,STUB_CHECKS_MODE=success_at_head,STUB_STATUS_MODE=success_at_head|rc=1 status=timeout status_queries=0' \
+  'a review object outranks a status success||STUB_REVIEWS_MODE=commented_at_head,STUB_CHECKS_MODE=none,STUB_STATUS_MODE=success_at_head,PR_REVIEW_CHECK=Review Bot|rc=0 review_evidence=review review_evidence_surface=null' \
+  'status success with open threads returns comments||STUB_REVIEWS_MODE=none,STUB_CHECKS_MODE=none,STUB_STATUS_MODE=success_at_head,PR_REVIEW_CHECK=Review Bot,STUB_THREADS_UNRESOLVED=2|rc=1 status=comments early=true'
+
+echo "=== PR_REVIEW_ON_TIMEOUT: a deadline degrades to proceeded only on reviewer silence over an unchanged head ==="
+# Silence is no review, no trusted check or status of any state, and no open
+# thread; the head is the one the wait started on, confirmed again at the
+# decision. Everything else at the deadline stays a timeout or its verdict,
+# and a proceed never manufactures review evidence: no commit status is
+# posted and the JSON carries no marker field even with an outage context
+# exported.
+table "$REVIEW" \
+  'no evidence and zero threads under proceed exits 0 as proceeded||STUB_REVIEWS_MODE=none,PR_REVIEW_ON_TIMEOUT=proceed|rc=0 status=proceeded unresolved_count=0' \
+  'the --on-timeout flag proceeds over the exported block|1 1 3 --json --mode review --on-timeout proceed|STUB_REVIEWS_MODE=none|rc=0 status=proceeded' \
+  'the unset default proceeds||-u,PR_REVIEW_ON_TIMEOUT,STUB_REVIEWS_MODE=none|rc=0 status=proceeded' \
+  'approval mode degrades the same way|1 1 3 --json|STUB_APPROVAL_MODE=none,PR_REVIEW_ON_TIMEOUT=proceed|rc=0 status=proceeded' \
+  'an unrecognized value falls back to block||STUB_REVIEWS_MODE=none,PR_REVIEW_ON_TIMEOUT=bogus|rc=1 status=timeout' \
+  'open threads still return comments under proceed||STUB_REVIEWS_MODE=none,STUB_THREADS_UNRESOLVED=2,PR_REVIEW_ON_TIMEOUT=proceed|rc=1 status=comments' \
+  'a standing CHANGES_REQUESTED still blocks under proceed||STUB_REVIEWS_MODE=changes_standing,PR_REVIEW_ON_TIMEOUT=proceed|rc=1 status=changes_requested' \
+  'an active COMMENTED review in approval mode is engagement, not silence|1 1 3 --json|STUB_APPROVAL_MODE=commented_only,PR_REVIEW_ON_TIMEOUT=proceed|rc=1 status=timeout' \
+  'a failed trusted check-run at head is engagement, not silence||STUB_REVIEWS_MODE=none,STUB_CHECKS_MODE=failure_at_head,PR_REVIEW_CHECK=Review Bot,PR_REVIEW_ON_TIMEOUT=proceed|rc=1 status=timeout' \
+  'a pending trusted status at head is engagement, not silence||STUB_REVIEWS_MODE=none,STUB_STATUS_MODE=pending_at_head,PR_REVIEW_CHECK=Review Bot,PR_REVIEW_ON_TIMEOUT=proceed|rc=1 status=timeout' \
+  'a head that moved during the wait falls back to timeout even when the confirm agrees with the new head|1 1 5 --json --mode review|STUB_REVIEWS_MODE=none,STUB_HEAD_MODE=changes,STUB_CONFIRM_HEAD=headsha2,PR_REVIEW_ON_TIMEOUT=proceed|rc=1 status=timeout' \
+  'a head that moved in the last-poll to emit window falls back to timeout||STUB_REVIEWS_MODE=none,STUB_CONFIRM_HEAD=headsha2,PR_REVIEW_ON_TIMEOUT=proceed|rc=1 status=timeout' \
+  'a proceed posts no commit status and emits no outage marker||STUB_REVIEWS_MODE=none,PR_REVIEW_ON_TIMEOUT=proceed,PR_REVIEW_OUTAGE_CONTEXT=kendex-reviewer-outage|rc=0 status=proceeded marker_posts=0 outage_marker=false'
+
+echo "=== transient GitHub API failures are retried inside the budget and counted ==="
+# A 5xx or 429 from the reviews listing, or from the approval-mode pr view, is
+# absorbed with backoff and reported as transient_api_errors on the eventual
+# result; one that never clears becomes terminal only when the budget is
+# spent. A 404 is terminal at once and carries no count.
+table "$REVIEW" \
+  '503 twice then a review at head is reviewed with the count||STUB_REVIEWS_MODE=flaky_503|rc=0 status=reviewed transient_api_errors=2 review_polls=3' \
+  '429 twice then a review at head is reviewed with the count||STUB_REVIEWS_MODE=flaky_429|rc=0 status=reviewed transient_api_errors=2' \
+  'a persistent 503 is an error only once the budget is spent||STUB_REVIEWS_MODE=http_503|rc=1 status=error transient_errors_seen=true spent=true' \
+  'a 404 is terminal at once with no transient count||STUB_REVIEWS_MODE=http_404|rc=1 status=error transient_api_errors=null early=true' \
+  'approval-mode pr view 503s then an approval is approved with the count|1 1 3 --json|STUB_APPROVAL_MODE=approved_after_503|rc=0 status=approved transient_api_errors=2'
+
+echo "=== text mode prints a result line for every terminal status ==="
+# The line's wording is not a contract anything parses; what holds is that no
+# terminal status leaves stdout empty, with the same exit code as --json.
+table '1 1 3' \
+  'approved||STUB_APPROVAL_MODE=approved_decision|rc=0 stdout=line' \
+  'changes requested||STUB_APPROVAL_MODE=changes|rc=1 stdout=line' \
+  'comments||STUB_APPROVAL_MODE=none,STUB_THREADS_UNRESOLVED=2|rc=1 stdout=line' \
+  'timeout||STUB_APPROVAL_MODE=none|rc=1 stdout=line' \
+  'error||GH_TOKEN=bad-token,STUB_GH_DENY_KEYRING=1|rc=3 stdout=line' \
+  'reviewed via a check-run|1 1 3 --mode review|STUB_REVIEWS_MODE=none,STUB_CHECKS_MODE=success_at_head,PR_REVIEW_CHECK=Review Bot|rc=0 stdout=line' \
+  'proceeded|1 1 3 --mode review|STUB_REVIEWS_MODE=none,PR_REVIEW_ON_TIMEOUT=proceed|rc=0 stdout=line'
+
+echo "=== PR_REVIEW_WAIT_SECS: an absent max_wait positional resolves through orch-env ==="
+# Process env beats kendex.settings.toml [env], and an explicit positional
+# beats both; each row's deadline is one it could not have reached from the
+# 900s built-in default. The settings file is this case's private fixture.
+# Row: `label|settings value or empty|args|env|expect`.
+waitsecs_rows=(
+  'the env value drives the deadline||1 1 --json|STUB_APPROVAL_MODE=none,PR_REVIEW_WAIT_SECS=1|rc=1 status=timeout early=true'
+  'the settings-file value applies when the env is silent|1|1 1 --json|STUB_APPROVAL_MODE=none|rc=1 status=timeout early=true'
+  'the env value outlives the settings file|1|1 1 --json|STUB_APPROVAL_MODE=none,PR_REVIEW_WAIT_SECS=3|rc=1 status=timeout spent=true'
+  'an explicit positional wins over the setting|600|1 1 3 --json|STUB_APPROVAL_MODE=none|rc=1 status=timeout spent=true'
+)
+for row in "${waitsecs_rows[@]}"; do
+  IFS='|' read -r label setting args env expect <<<"$row"
+  rm -f "$TMP_ROOT/repo/kendex.settings.toml"
+  [[ -z "$setting" ]] || printf '[env]\nPR_REVIEW_WAIT_SECS = "%s"\n' "$setting" >"$TMP_ROOT/repo/kendex.settings.toml"
+  # shellcheck disable=SC2086
+  run_wait "$env" $args
+  assert_eq "$(observe "$expect")" "$expect" "waitsecs: $label" "$RUN/stderr"
+done
 rm -f "$TMP_ROOT/repo/kendex.settings.toml"
 
-# Numeric-default guard (orch-env layer): a non-numeric setting value falls
-# back to the numeric default instead of poisoning the deadline arithmetic.
-guard_out="$( (cd "$TMP_ROOT/repo" && PATH="$TMP_ROOT/bin:$PATH" \
-  env PR_REVIEW_WAIT_SECS=soon .agents/skills/orch/scripts/orch-env PR_REVIEW_WAIT_SECS 900) )"
-assert_eq "$guard_out" "900" "waitsecs: non-numeric value falls back to the numeric default"
-
 echo "=== a failed emit_result never reports a successful gate ==="
-
-# The waiter must never exit 0 having written no result. emit_result builds the
-# --json object with `jq -n`, so this stub fails EXACTLY that call and passes
-# every parse through to the real jq: the emission fails while the poll that
-# reached the approved verdict succeeds — a closed pipe or a write failure.
+# emit_result builds the --json object with `jq -n`, so this stub fails
+# EXACTLY that call and passes every parse through to the real jq: the
+# emission fails while the poll that reached the verdict succeeds — a closed
+# pipe or a write failure. Each emit site must propagate jq's status 5 and
+# write nothing: the two run_approved_gate sites, and the bare deadline
+# `emit_result "timeout"` where nothing but errexit stands before `exit 1`,
+# so a 1 there would mean a `set +e` had migrated above the emit.
 REAL_JQ="$(command -v jq)"
 cat > "$TMP_ROOT/bin/jq" <<EOF
 #!/usr/bin/env bash
@@ -1278,73 +553,15 @@ fi
 exec "$REAL_JQ" "\$@"
 EOF
 chmod +x "$TMP_ROOT/bin/jq"
-
-# run_approved_gate has two call sites, each of which must propagate a failed
-# emission. First: the reviewDecision site, GitHub reporting the PR APPROVED.
-stderr="$TMP_ROOT/emitfail.err"
-set +e
-output=$( (cd "$TMP_ROOT/repo" && PATH="$TMP_ROOT/bin:$PATH" \
-  env STUB_APPROVAL_MODE=approved_decision \
-    .agents/skills/orch/scripts/approval-wait 1 1 3 --json) 2>"$stderr")
-emitfail_code=$?
-set -e
-if [ "$emitfail_code" -ne 0 ]; then
-  pass "a failed emit_result at the reviewDecision gate site does not exit 0 (exit $emitfail_code)"
-else
-  FAIL=$((FAIL + 1))
-  printf '  FAIL  %s\n        exit was 0 with stdout: %s\n' \
-    "a failed emit_result at the reviewDecision gate site does not exit 0" "$output"
-  dump_stderr "$stderr"
-fi
-if [ -z "$output" ]; then
-  pass "a failed emit_result at the reviewDecision gate site writes no result to stdout"
-else
-  FAIL=$((FAIL + 1))
-  printf '  FAIL  %s\n        stdout: %s\n' "a failed emit_result at the reviewDecision gate site writes no result to stdout" "$output"
-fi
-assert_contains "$(cat "$stderr")" "could not emit the gate result" "the reviewDecision gate site names the emission failure on stderr"
-
-# Second: the latestReviews site — no reviewDecision, a reviewer's latest
-# review APPROVED. Each site reads the gate's status, disabling errexit.
-stderr="$TMP_ROOT/emitfail-gate.err"
-set +e
-output=$( (cd "$TMP_ROOT/repo" && PATH="$TMP_ROOT/bin:$PATH" \
-  env STUB_APPROVAL_MODE=approved_latest \
-    .agents/skills/orch/scripts/approval-wait 1 1 3 --json) 2>"$stderr")
-gate_emitfail_code=$?
-set -e
-if [ "$gate_emitfail_code" -ne 0 ]; then
-  pass "a failed emit_result at the latestReviews gate site does not exit 0 (exit $gate_emitfail_code)"
-else
-  FAIL=$((FAIL + 1))
-  printf '  FAIL  %s\n        exit was 0 with stdout: %s\n' \
-    "a failed emit_result at the latestReviews gate site does not exit 0" "$output"
-  dump_stderr "$stderr"
-fi
-assert_contains "$(cat "$stderr")" "could not emit the gate result" \
-  "the latestReviews gate site names the emission failure on stderr"
-
-# The deadline's `emit_result "timeout"` is a BARE call followed by `exit 1`,
-# so nothing but errexit stands between a failed emission and that exit 1.
-# Exit 5 (jq's status) proves errexit was in force there; a 1 would mean a
-# `set +e` had migrated above the emit and the propagation was undone.
-stderr="$TMP_ROOT/emitfail-timeout.err"
-set +e
-output=$( (cd "$TMP_ROOT/repo" && PATH="$TMP_ROOT/bin:$PATH" \
-  env STUB_APPROVAL_MODE=none \
-    .agents/skills/orch/scripts/approval-wait 1 1 2 --json) 2>"$stderr")
-timeout_emitfail_code=$?
-set -e
-assert_eq "$timeout_emitfail_code" "5" \
-  "a failed emit_result on the bare timeout path propagates jq's status (errexit in force)" "$stderr"
-
+table "$APPROVAL" \
+  'emit failure at the reviewDecision gate site||STUB_APPROVAL_MODE=approved_decision|rc=5 stdout=empty' \
+  'emit failure at the latestReviews gate site||STUB_APPROVAL_MODE=approved_latest|rc=5 stdout=empty' \
+  'emit failure on the bare timeout path|1 1 2 --json|STUB_APPROVAL_MODE=none|rc=5 stdout=empty'
 rm -f "$TMP_ROOT/bin/jq"
-
-# Control: with the real jq back, the same invocations DO reach exit 0 — so the
-# two assertions above are proving the emission failure, not a broken fixture.
-output=$(run_wait_json STUB_APPROVAL_MODE=approved_decision 2>"$TMP_ROOT/emitok.err")
-assert_eq "$(json_field "$output" '.status')" "approved" \
-  "control: the same poll approves once emission works again" "$TMP_ROOT/emitok.err"
+# Control: with the real jq back the same poll approves, so the rows above
+# prove the emission failure and not a broken fixture.
+table "$APPROVAL" \
+  'control: the same poll approves once emission works||STUB_APPROVAL_MODE=approved_decision|rc=0 status=approved'
 
 echo
 printf 'pass: %d   fail: %d\n' "$PASS" "$FAIL"

--- a/.agents/skills/orch/tests/approval_wait.sh
+++ b/.agents/skills/orch/tests/approval_wait.sh
@@ -404,6 +404,7 @@ table() {
   shift
   for row in "$@"; do
     IFS='|' read -r label args env expect <<<"$row"
+    [[ -n "$expect" ]] || { printf 'table: a row with no expect asserts nothing: %s\n' "$row" >&2; exit 1; }
     [[ -n "$args" ]] || args="$default_args"
     # shellcheck disable=SC2086
     run_wait "$env" $args
@@ -456,7 +457,6 @@ table "$REVIEW" \
   'a failed check-run conclusion is not evidence||STUB_REVIEWS_MODE=none,STUB_CHECKS_MODE=failure_at_head,PR_REVIEW_CHECK=Review Bot|rc=1 status=timeout' \
   'check-run success with open threads returns comments||STUB_REVIEWS_MODE=none,STUB_CHECKS_MODE=success_at_head,PR_REVIEW_CHECK=Review Bot,STUB_THREADS_UNRESOLVED=2|rc=1 status=comments unresolved_count=2 early=true' \
   'check-run success beside a standing CHANGES_REQUESTED still blocks||STUB_REVIEWS_MODE=changes_standing,STUB_CHECKS_MODE=success_at_head,PR_REVIEW_CHECK=Review Bot|rc=1 status=changes_requested' \
-  'an empty PR_REVIEW_CHECK ignores a check-run success||STUB_REVIEWS_MODE=none,STUB_CHECKS_MODE=success_at_head|rc=1 status=timeout' \
   'a review object outranks the check surface with the feature on||STUB_REVIEWS_MODE=commented_at_head,STUB_CHECKS_MODE=none,PR_REVIEW_CHECK=Review Bot|rc=0 status=reviewed review_evidence=review review_evidence_surface=null reviews_at_head=1' \
   'a trusted commit-status success at head opens the gate when no check-run matches||STUB_REVIEWS_MODE=none,STUB_CHECKS_MODE=none,STUB_STATUS_MODE=success_at_head,PR_REVIEW_CHECK=Review Bot|rc=0 status=reviewed review_evidence=check review_evidence_surface=status reviews_at_head=0 head_sha=headsha1' \
   'a matching check-run wins and the status endpoint is never read||STUB_REVIEWS_MODE=none,STUB_CHECKS_MODE=success_at_head,STUB_STATUS_MODE=success_at_head,PR_REVIEW_CHECK=Review Bot|rc=0 review_evidence_surface=check_run status_queries=0' \
@@ -502,31 +502,43 @@ table "$REVIEW" \
   'a 404 is terminal at once with no transient count||STUB_REVIEWS_MODE=http_404|rc=1 status=error transient_api_errors=null early=true' \
   'approval-mode pr view 503s then an approval is approved with the count|1 1 3 --json|STUB_APPROVAL_MODE=approved_after_503|rc=0 status=approved transient_api_errors=2'
 
-echo "=== text mode prints a result line for every terminal status ==="
+echo "=== text mode prints a result line for every branch the emitter has ==="
 # The line's wording is not a contract anything parses; what holds is that no
-# terminal status leaves stdout empty, with the same exit code as --json.
+# terminal status leaves stdout empty, with the same exit code as --json. The
+# emitter branches per mode for every status and per evidence surface for
+# reviewed, so each branch is a row.
+TEXT_REVIEW='1 1 3 --mode review'
 table '1 1 3' \
-  'approved||STUB_APPROVAL_MODE=approved_decision|rc=0 stdout=line' \
-  'changes requested||STUB_APPROVAL_MODE=changes|rc=1 stdout=line' \
-  'comments||STUB_APPROVAL_MODE=none,STUB_THREADS_UNRESOLVED=2|rc=1 stdout=line' \
-  'timeout||STUB_APPROVAL_MODE=none|rc=1 stdout=line' \
-  'error||GH_TOKEN=bad-token,STUB_GH_DENY_KEYRING=1|rc=3 stdout=line' \
-  'reviewed via a check-run|1 1 3 --mode review|STUB_REVIEWS_MODE=none,STUB_CHECKS_MODE=success_at_head,PR_REVIEW_CHECK=Review Bot|rc=0 stdout=line' \
-  'proceeded|1 1 3 --mode review|STUB_REVIEWS_MODE=none,PR_REVIEW_ON_TIMEOUT=proceed|rc=0 stdout=line'
+  'approval: approved||STUB_APPROVAL_MODE=approved_decision|rc=0 stdout=line' \
+  'approval: changes requested||STUB_APPROVAL_MODE=changes|rc=1 stdout=line' \
+  'approval: comments||STUB_APPROVAL_MODE=none,STUB_THREADS_UNRESOLVED=2|rc=1 stdout=line' \
+  'approval: timeout||STUB_APPROVAL_MODE=none|rc=1 stdout=line' \
+  'approval: error||GH_TOKEN=bad-token,STUB_GH_DENY_KEYRING=1|rc=3 stdout=line' \
+  'approval: proceeded||STUB_APPROVAL_MODE=none,PR_REVIEW_ON_TIMEOUT=proceed|rc=0 stdout=line' \
+  "review: reviewed via a review object|$TEXT_REVIEW|STUB_REVIEWS_MODE=commented_at_head|rc=0 stdout=line" \
+  "review: reviewed via a check-run|$TEXT_REVIEW|STUB_REVIEWS_MODE=none,STUB_CHECKS_MODE=success_at_head,PR_REVIEW_CHECK=Review Bot|rc=0 stdout=line" \
+  "review: reviewed via a commit status|$TEXT_REVIEW|STUB_REVIEWS_MODE=none,STUB_STATUS_MODE=success_at_head,PR_REVIEW_CHECK=Review Bot|rc=0 stdout=line" \
+  "review: changes requested|$TEXT_REVIEW|STUB_REVIEWS_MODE=changes_standing|rc=1 stdout=line" \
+  "review: comments|$TEXT_REVIEW|STUB_REVIEWS_MODE=commented_at_head,STUB_THREADS_UNRESOLVED=2|rc=1 stdout=line" \
+  "review: timeout|$TEXT_REVIEW|STUB_REVIEWS_MODE=none|rc=1 stdout=line" \
+  "review: error|$TEXT_REVIEW|GH_TOKEN=bad-token,STUB_GH_DENY_KEYRING=1|rc=3 stdout=line" \
+  "review: proceeded|$TEXT_REVIEW|STUB_REVIEWS_MODE=none,PR_REVIEW_ON_TIMEOUT=proceed|rc=0 stdout=line"
 
 echo "=== PR_REVIEW_WAIT_SECS: an absent max_wait positional resolves through orch-env ==="
 # Process env beats kendex.settings.toml [env], and an explicit positional
-# beats both; each row's deadline is one it could not have reached from the
-# 900s built-in default. The settings file is this case's private fixture.
+# beats both. On the virtual clock a timeout lands on its deadline exactly, so
+# each row pins the deadline it resolved, none of them the 900s built-in
+# default. The settings file is this case's private fixture.
 # Row: `label|settings value or empty|args|env|expect`.
 waitsecs_rows=(
-  'the env value drives the deadline||1 1 --json|STUB_APPROVAL_MODE=none,PR_REVIEW_WAIT_SECS=1|rc=1 status=timeout early=true'
-  'the settings-file value applies when the env is silent|1|1 1 --json|STUB_APPROVAL_MODE=none|rc=1 status=timeout early=true'
-  'the env value outlives the settings file|1|1 1 --json|STUB_APPROVAL_MODE=none,PR_REVIEW_WAIT_SECS=3|rc=1 status=timeout spent=true'
-  'an explicit positional wins over the setting|600|1 1 3 --json|STUB_APPROVAL_MODE=none|rc=1 status=timeout spent=true'
+  'the env value drives the deadline||1 1 --json|STUB_APPROVAL_MODE=none,PR_REVIEW_WAIT_SECS=1|rc=1 status=timeout elapsed_seconds=1'
+  'the settings-file value applies when the env is silent|1|1 1 --json|STUB_APPROVAL_MODE=none|rc=1 status=timeout elapsed_seconds=1'
+  'the env value outlives the settings file|1|1 1 --json|STUB_APPROVAL_MODE=none,PR_REVIEW_WAIT_SECS=3|rc=1 status=timeout elapsed_seconds=3'
+  'an explicit positional wins over the setting|600|1 1 3 --json|STUB_APPROVAL_MODE=none|rc=1 status=timeout elapsed_seconds=3'
 )
 for row in "${waitsecs_rows[@]}"; do
   IFS='|' read -r label setting args env expect <<<"$row"
+  [[ -n "$expect" ]] || { printf 'waitsecs: a row with no expect asserts nothing: %s\n' "$row" >&2; exit 1; }
   rm -f "$TMP_ROOT/repo/kendex.settings.toml"
   [[ -z "$setting" ]] || printf '[env]\nPR_REVIEW_WAIT_SECS = "%s"\n' "$setting" >"$TMP_ROOT/repo/kendex.settings.toml"
   # shellcheck disable=SC2086

--- a/.github/workflows/skill-tests.yml
+++ b/.github/workflows/skill-tests.yml
@@ -484,9 +484,11 @@ jobs:
   # AGGREGATOR — this job's name is the ruleset's required context, so the
   # `(shell + node)` in it is frozen history: renaming it to match today's
   # shards leaves the ruleset waiting on a context nothing creates. It runs on
-  # every event, pull_request included: GitHub counts a SKIPPED required
-  # context as satisfied, so an event-scoped condition here would let a PR with
-  # a red shard enter the queue and be ejected there. `always()` is required
+  # pull_request and merge_group, the two events the ruleset gates; not on
+  # push, where the shards are skipped and nothing requires a context. GitHub
+  # counts a SKIPPED required context as satisfied, so on the gated events no
+  # further condition may skip this job: a PR with a red shard would enter the
+  # queue and be ejected there. `always()` is required
   # because skipped/failed needs would otherwise skip this job too, and a
   # skipped required context would satisfy the ruleset without any suite having
   # run (the fail-open this line exists to close).

--- a/skills/orch/tests/approval_wait.sh
+++ b/skills/orch/tests/approval_wait.sh
@@ -1,80 +1,16 @@
 #!/usr/bin/env bash
-# Tests for orch/scripts/approval-wait.
+# Tests for orch/scripts/approval-wait, the reviewer-gate poller. It reads
+# formal review verdicts (`gh pr view --json reviewDecision,latestReviews` in
+# approval mode; the REST reviews listing pinned to the current head in
+# --mode review), the unresolved review-thread count and, in review mode, the
+# trusted check-run or commit-status evidence PR_REVIEW_CHECK names; never
+# emoji reactions, sticky comments or checklist prose.
 #
-# approval-wait is the GitHub-native reviewer-gate poller: it reads ONLY
-# formal review verdicts
-# (`gh pr view --json reviewDecision,latestReviews`, and in --mode review the
-# REST pulls/reviews listing pinned to the current head) plus the unresolved
-# review-thread count — never emoji reactions, sticky comments, or checklist
-# prose. Cases:
-#   1. reviewDecision APPROVED               -> approved, exit 0
-#   2. empty reviewDecision + latest APPROVED -> approved via fallback, exit 0
-#   3. latest CHANGES_REQUESTED               -> changes_requested, exit 1
-#   4. COMMENTED-only latest reviews          -> no verdict, timeout, exit 1
-#   5. unresolved threads, no verdict         -> comments early return, exit 1
-#   6. nothing at all at the deadline         -> timeout, exit 1
-#   7. REVIEW_REQUIRED + latest APPROVED      -> NOT approved (protection wants
-#                                                more), timeout
-#   8. APPROVED with unresolved threads       -> approved, unresolved_count
-#                                                reported for the caller's gate
-#   9. verdict arriving on a later poll       -> approved after polling
-#  10. auth failure with --json               -> parseable error object, exit 3
-#  11. text mode always prints a result line; approval-mode lines for
-#      changes-requested, comments, and error pinned verbatim
-#  12. review mode: COMMENTED at head, 0 threads -> reviewed, exit 0
-#  13. review mode: review at head + threads     -> comments early return
-#  14. review mode: review at stale commit only  -> timeout (head pinning)
-#  15. review mode: PR author's own review only  -> timeout (author excluded)
-#  16. review mode: DISMISSED review only        -> timeout (dismissal excluded)
-#  17. review mode: standing CHANGES_REQUESTED   -> changes_requested, exit 1
-#  18. review mode: CHANGES_REQUESTED superseded by COMMENTED -> reviewed
-#  19. review mode: APPROVED counts as a review  -> reviewed, exit 0
-#  20. review mode: review arriving on a later poll -> reviewed after polling
-#  21. review mode text output names the review gate for reviewed,
-#      changes-requested, comments, timeout, and error — never "Approval"
-#  check1-8: PR_REVIEW_CHECK check-run evidence — a "success"
-#      conclusion of the configured check name on the CURRENT head opens the
-#      review gate (newest run of that name wins; review_evidence "check",
-#      review_evidence_surface "check_run"); stale-sha and failure
-#      conclusions do not; unresolved threads and a standing
-#      CHANGES_REQUESTED still block; empty PR_REVIEW_CHECK ignores
-#      check-runs entirely; the review-object path still works with the
-#      feature on (review_evidence "review"); text mode names the check-run
-#      and its app slug
-#  status1-8: PR_REVIEW_CHECK commit-status evidence — with no
-#      matching check-run, a "success" commit status with the configured
-#      context on the CURRENT head opens the gate (newest of the context
-#      wins; review_evidence "check", review_evidence_surface "status"); a
-#      matching check-run wins first and skips the status query entirely;
-#      pending/failure/error states are not evidence; stale-sha statuses
-#      never count; empty PR_REVIEW_CHECK ignores both surfaces; a review
-#      object still takes precedence (no surface field); unresolved threads
-#      still block; text mode names the status context and its creator
-#  22+ --resolve-mode precedence: PR_REVIEW_GATE beats PR_APPROVAL_GATE
-#      (on -> approval, off -> off), default approval, settings-file source,
-#      invalid value falls back to approval
-#  transient1-4: transient GitHub API failures — an HTTP 503
-#      from the reviews listing (or approval-mode pr view) is absorbed with
-#      backoff inside the wait budget and reported as transient_api_errors
-#      on the eventual success; a persistent 503 becomes terminal only when
-#      the budget expires, preserving the original error message plus the
-#      count; an HTTP 404 stays immediately terminal with no count
-#   proceed1-13: PR_REVIEW_ON_TIMEOUT reviewer-down flexibility — a deadline
-#      reached with zero unresolved threads AND no reviewer evidence AND an
-#      unchanged head degrades to "proceeded" (exit 0) under "proceed" (review
-#      and approval modes; also via the --on-timeout flag), while open threads
-#      still return "comments", a standing CHANGES_REQUESTED still blocks, an
-#      active COMMENTED review in approval mode still times out (not silence), a
-#      head change during the wait falls back to timeout (no fair window on the
-#      moved head), a present-but-not-success trusted check/status (failed or
-#      pending) in review mode still times out (engagement, not silence), a head
-#      that moved in the final last-poll->emit confirm window falls back to
-#      timeout (no proceed on a superseded head), the
-#      default is "proceed"; an unrecognized value falls back to block with a warning
-#   marker1: a proceed posts NO commit status and emits no outage_marker JSON
-#      field (orch never manufactures review evidence); PR_REVIEW_OUTAGE_CONTEXT
-#      is exported in the test to prove it is inert
-# Same always-emit-JSON discipline and exit-code contract as ci-wait.
+# One case per behaviour surface; shaped input is one table per case, one
+# asserted row per shape. A row's `expect` names the fields it pins; `observe`
+# reads exactly those from the run, so a row fails on the field it names.
+# The pre-poll CLI layer (--resolve-mode, --help, unknown flags) is
+# approval_wait_cli.sh.
 set -euo pipefail
 source "$(dirname "${BASH_SOURCE[0]}")/lib/git-env.sh"
 TEST_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
@@ -86,13 +22,15 @@ trap 'rm -rf "$TMP_ROOT"' EXIT
 # shellcheck source=lib/waiter-assertions.sh
 source "$TEST_DIR/lib/waiter-assertions.sh"
 
-mkdir -p "$TMP_ROOT/repo/.agents/skills" "$TMP_ROOT/bin"
+mkdir -p "$TMP_ROOT/repo/.agents/skills" "$TMP_ROOT/bin" "$TMP_ROOT/runs"
 ln -s "$REPO_ROOT/skills/orch" "$TMP_ROOT/repo/.agents/skills/orch"
 git -C "$TMP_ROOT/repo" init -q
 git -C "$TMP_ROOT/repo" config user.email test@example.com
 git -C "$TMP_ROOT/repo" config user.name Test
 
-# Parametrized `gh` stub (same auth model as the ci_wait stub).
+# Parametrized `gh` stub (same auth model as the ci_wait stub), a neutral fake
+# GitHub: every payload is selected per run by the STUB_* variables below, so
+# no case inherits another's world.
 #   STUB_APPROVAL_MODE selects the canned `pr view --json
 #   reviewDecision,latestReviews` payload; STUB_THREADS_UNRESOLVED sets the
 #   unresolved count returned by the `api graphql` reviewThreads query.
@@ -237,12 +175,6 @@ case "${1:-}" in
           ;;
         approved_at_head)
           echo '[{"user":{"login":"reviewer1"},"state":"APPROVED","commit_id":"headsha1"}]'
-          ;;
-        two_bots_at_head)
-          echo '[{"user":{"login":"bot-a"},"state":"COMMENTED","commit_id":"headsha1"},{"user":{"login":"bot-b"},"state":"APPROVED","commit_id":"headsha1"}]'
-          ;;
-        one_bot_at_head)
-          echo '[{"user":{"login":"bot-a"},"state":"COMMENTED","commit_id":"headsha1"}]'
           ;;
         none|*)
           echo '[]'
@@ -397,877 +329,220 @@ chmod +x "$TMP_ROOT/bin/gh"
 source "$TEST_DIR/lib/virtual-clock.sh"
 virtual_clock_install "$TMP_ROOT/bin" "$TMP_ROOT/clock"
 
-# Run approval-wait via the .agents symlink, exactly how it's invoked in
-# production. `env "$@"` injects test-controlled env tokens / stub flags.
+# The suite's own default for the reviewer-down setting; the on-timeout case
+# overrides or unsets it per row.
 export PR_REVIEW_ON_TIMEOUT=block
-run_wait_json() {
-  (cd "$TMP_ROOT/repo" \
-    && PATH="$TMP_ROOT/bin:$PATH" \
-       env "$@" .agents/skills/orch/scripts/approval-wait 1 1 30 --json)
+
+# run_wait ENV ARGS... — runs approval-wait via the .agents symlink, exactly
+# how production invokes it, in the fixture repo with the stub PATH. ENV is a
+# comma-separated list of `env` arguments (assignments or `-u NAME`), so a
+# value may carry a space. Every run gets its own count, log and stderr files
+# under $RUN, so no row reads another's polls or posts. Sets OUT and RC.
+RUN=""
+run_wait() {
+  local env_list="$1" env_args=()
+  shift
+  RUN="$TMP_ROOT/runs/$((++RUN_SEQ))"
+  mkdir -p "$RUN"
+  [[ -z "$env_list" ]] || IFS=',' read -ra env_args <<<"$env_list"
+  set +e
+  OUT=$(cd "$TMP_ROOT/repo" && PATH="$TMP_ROOT/bin:$PATH" \
+    env ${env_args[@]+"${env_args[@]}"} \
+        STUB_APPROVAL_COUNT_FILE="$RUN/approval-polls" \
+        STUB_REVIEWS_COUNT_FILE="$RUN/review-polls" \
+        STUB_HEAD_COUNT_FILE="$RUN/head-polls" \
+        STUB_STATUS_LOG="$RUN/status-queries" \
+        STUB_MARKER_LOG="$RUN/marker-posts" \
+        .agents/skills/orch/scripts/approval-wait "$@" 2>"$RUN/stderr")
+  RC=$?
+  set -e
+}
+RUN_SEQ=0
+
+count_lines() { # FILE — 0 when it was never written
+  [[ -f "$1" ]] && wc -l <"$1" | tr -d ' ' || echo 0
 }
 
-run_wait_json_short() {
-  (cd "$TMP_ROOT/repo" \
-    && PATH="$TMP_ROOT/bin:$PATH" \
-       env "$@" .agents/skills/orch/scripts/approval-wait 1 1 3 --json)
+# observe EXPECT — prints the run's value of every `name=` field EXPECT names,
+# in EXPECT's order, so a row compares as one string. Plain names are JSON
+# result fields; the derived names read the run's files or its timing:
+#   early     elapsed_seconds < 3, the return came before a 3s deadline
+#   spent     elapsed_seconds >= 3, the whole 3s budget was used
+#   stdout    `line` when anything was printed, `empty` otherwise
+#   approval_polls / review_polls   how often the stub answered that listing
+#   status_queries                  combined-status reads the stub served
+#   marker_posts                    commit-status POSTs the stub received
+#   outage_marker                   whether the JSON carries that field
+#   transient_errors_seen           transient_api_errors >= 1
+observe() {
+  local got="" token name
+  for token in $1; do
+    name="${token%%=*}"
+    case "$name" in
+      rc) got="$got rc=$RC" ;;
+      early) got="$got early=$(json '.elapsed_seconds < 3')" ;;
+      spent) got="$got spent=$(json '.elapsed_seconds >= 3')" ;;
+      stdout) got="$got stdout=$([[ -n "$OUT" ]] && echo line || echo empty)" ;;
+      approval_polls) got="$got approval_polls=$(cat "$RUN/approval-polls" 2>/dev/null || echo 0)" ;;
+      review_polls) got="$got review_polls=$(cat "$RUN/review-polls" 2>/dev/null || echo 0)" ;;
+      status_queries) got="$got status_queries=$(count_lines "$RUN/status-queries")" ;;
+      marker_posts) got="$got marker_posts=$(count_lines "$RUN/marker-posts")" ;;
+      outage_marker) got="$got outage_marker=$(json 'has("outage_marker")')" ;;
+      transient_errors_seen) got="$got transient_errors_seen=$(json '.transient_api_errors >= 1')" ;;
+      *) got="$got $name=$(json ".$name")" ;;
+    esac
+  done
+  printf '%s' "${got# }"
+}
+json() { jq -r "$1" <<<"$OUT" 2>/dev/null || echo UNPARSEABLE; }
+
+# table DEFAULT_ARGS ROW... — one run and one assertion per row. A row is
+# `label|args|env|expect`; empty args mean DEFAULT_ARGS. Positional args are
+# `<pr> <poll-interval> <budget-seconds>` plus flags, on the virtual clock.
+table() {
+  local default_args="$1" row label args env expect
+  shift
+  for row in "$@"; do
+    IFS='|' read -r label args env expect <<<"$row"
+    [[ -n "$args" ]] || args="$default_args"
+    # shellcheck disable=SC2086
+    run_wait "$env" $args
+    assert_eq "$(observe "$expect")" "$expect" "$label" "$RUN/stderr"
+  done
 }
 
-run_wait_text_short() {
-  (cd "$TMP_ROOT/repo" \
-    && PATH="$TMP_ROOT/bin:$PATH" \
-       env "$@" .agents/skills/orch/scripts/approval-wait 1 1 3)
-}
-
-run_review_json() {
-  (cd "$TMP_ROOT/repo" \
-    && PATH="$TMP_ROOT/bin:$PATH" \
-       env "$@" .agents/skills/orch/scripts/approval-wait 1 1 30 --json --mode review)
-}
-
-run_review_json_short() {
-  (cd "$TMP_ROOT/repo" \
-    && PATH="$TMP_ROOT/bin:$PATH" \
-       env "$@" .agents/skills/orch/scripts/approval-wait 1 1 3 --json --mode review)
-}
-
-run_review_text() {
-  (cd "$TMP_ROOT/repo" \
-    && PATH="$TMP_ROOT/bin:$PATH" \
-       env "$@" .agents/skills/orch/scripts/approval-wait 1 1 3 --mode review)
-}
-
-json_field() {
-  jq -r "$2" <<<"$1" 2>/dev/null || echo "UNPARSEABLE"
-}
-
-echo "=== approval-wait verdict detection ==="
-
-# Case 1: reviewDecision APPROVED (branch-protection aggregate).
-stderr="$TMP_ROOT/case1.err"
-set +e
-output=$(run_wait_json STUB_APPROVAL_MODE=approved_decision 2>"$stderr")
-rc=$?
-set -e
-assert_eq "$rc" "0" "case1: reviewDecision APPROVED exits 0" "$stderr"
-assert_eq "$(json_field "$output" '.status')" "approved" "case1: status approved" "$stderr"
-assert_eq "$(json_field "$output" '.review_decision')" "APPROVED" "case1: review_decision reported" "$stderr"
-assert_eq "$(json_field "$output" '.approvals')" "1" "case1: approvals counted" "$stderr"
-
-# Case 2: no required-review protection (empty reviewDecision); one latest
-# APPROVED and no CHANGES_REQUESTED approves via the latestReviews fallback.
-stderr="$TMP_ROOT/case2.err"
-set +e
-output=$(run_wait_json STUB_APPROVAL_MODE=approved_latest 2>"$stderr")
-rc=$?
-set -e
-assert_eq "$rc" "0" "case2: latestReviews fallback exits 0" "$stderr"
-assert_eq "$(json_field "$output" '.status')" "approved" "case2: status approved via fallback" "$stderr"
-assert_eq "$(json_field "$output" '.review_decision')" "" "case2: empty review_decision preserved" "$stderr"
-assert_eq "$(json_field "$output" '.approvals')" "1" "case2: COMMENTED latest review not counted as approval" "$stderr"
-
-# Case 3: a reviewer whose latest review is CHANGES_REQUESTED blocks even
-# when another reviewer approved.
-stderr="$TMP_ROOT/case3.err"
-set +e
-output=$(run_wait_json STUB_APPROVAL_MODE=changes 2>"$stderr")
-rc=$?
-set -e
-assert_eq "$rc" "1" "case3: changes requested exits 1" "$stderr"
-assert_eq "$(json_field "$output" '.status')" "changes_requested" "case3: status changes_requested" "$stderr"
-assert_eq "$(json_field "$output" '.changes_requested')" "1" "case3: changes_requested count reported" "$stderr"
-
-# Case 4: COMMENTED-only latest reviews are not a verdict — times out.
-stderr="$TMP_ROOT/case4.err"
-set +e
-output=$(run_wait_json_short STUB_APPROVAL_MODE=commented_only 2>"$stderr")
-rc=$?
-set -e
-assert_eq "$rc" "1" "case4: commented-only exits 1" "$stderr"
-assert_eq "$(json_field "$output" '.status')" "timeout" "case4: commented-only times out (no verdict)" "$stderr"
-assert_eq "$(json_field "$output" '.approvals')" "0" "case4: COMMENTED never counts as approval" "$stderr"
-
-# Case 5: unresolved threads with no verdict return early as "comments" so
-# the caller can triage instead of idling out the timeout.
-stderr="$TMP_ROOT/case5.err"
-set +e
-output=$(run_wait_json STUB_APPROVAL_MODE=none STUB_THREADS_UNRESOLVED=2 2>"$stderr")
-rc=$?
-set -e
-assert_eq "$rc" "1" "case5: pending comments exit 1" "$stderr"
-assert_eq "$(json_field "$output" '.status')" "comments" "case5: status comments" "$stderr"
-assert_eq "$(json_field "$output" '.unresolved_count')" "2" "case5: unresolved_count reported" "$stderr"
-assert_eq "$(json_field "$output" '.elapsed_seconds | . < 3')" "true" "case5: comments returns early, not at deadline" "$stderr"
-
-# Case 6: nothing at all by the deadline — timeout, never silent success.
-stderr="$TMP_ROOT/case6.err"
-set +e
-output=$(run_wait_json_short STUB_APPROVAL_MODE=none 2>"$stderr")
-rc=$?
-set -e
-assert_eq "$rc" "1" "case6: no verdict at deadline exits 1" "$stderr"
-assert_eq "$(json_field "$output" '.status')" "timeout" "case6: status timeout" "$stderr"
-
-# Case 7: REVIEW_REQUIRED means branch protection still wants approvals — a
-# latest APPROVED review must NOT approve via the fallback.
-stderr="$TMP_ROOT/case7.err"
-set +e
-output=$(run_wait_json_short STUB_APPROVAL_MODE=required_pending 2>"$stderr")
-rc=$?
-set -e
-assert_eq "$rc" "1" "case7: REVIEW_REQUIRED does not fall back to latestReviews" "$stderr"
-assert_eq "$(json_field "$output" '.status')" "timeout" "case7: status timeout while protection pending" "$stderr"
-assert_eq "$(json_field "$output" '.review_decision')" "REVIEW_REQUIRED" "case7: review_decision reported" "$stderr"
-
-# Case 8: approved with unresolved threads still reports approved — the
-# caller's zero-unresolved gate owns thread routing — and carries the count.
-stderr="$TMP_ROOT/case8.err"
-set +e
-output=$(run_wait_json STUB_APPROVAL_MODE=approved_decision STUB_THREADS_UNRESOLVED=1 2>"$stderr")
-rc=$?
-set -e
-assert_eq "$rc" "0" "case8: approved with open threads exits 0" "$stderr"
-assert_eq "$(json_field "$output" '.status')" "approved" "case8: status approved" "$stderr"
-assert_eq "$(json_field "$output" '.unresolved_count')" "1" "case8: unresolved_count carried for the merge gate" "$stderr"
-
-# Case 9: verdict arriving on a later poll is picked up (first poll empty,
-# second poll APPROVED).
-stderr="$TMP_ROOT/case9.err"
-count_file="$TMP_ROOT/case9-count"
-set +e
-output=$(run_wait_json STUB_APPROVAL_MODE=approved_later STUB_APPROVAL_COUNT_FILE="$count_file" 2>"$stderr")
-rc=$?
-set -e
-assert_eq "$rc" "0" "case9: later approval exits 0" "$stderr"
-assert_eq "$(json_field "$output" '.status')" "approved" "case9: status approved after polling" "$stderr"
-assert_eq "$(cat "$count_file")" "2" "case9: approval-wait polled again for the verdict" "$stderr"
-
-echo "=== approval-wait output contract ==="
-
-# Case 10: auth failure with --json still yields a parseable error object.
-stderr="$TMP_ROOT/case10.err"
-set +e
-output=$(run_wait_json GH_TOKEN=bad-token STUB_GH_DENY_KEYRING=1 2>"$stderr")
-rc=$?
-set -e
-assert_eq "$rc" "3" "case10: json auth failure exits 3" "$stderr"
-assert_eq "$(json_field "$output" '.status')" "error" "case10: json auth failure reports status error" "$stderr"
-assert_contains "$(json_field "$output" '.error')" "auth" "case10: json auth failure names auth in error"
-
-# Case 11: text mode always prints a result line.
-stderr="$TMP_ROOT/case11.err"
-set +e
-output=$(run_wait_text_short STUB_APPROVAL_MODE=none 2>"$stderr")
-rc=$?
-set -e
-assert_eq "$rc" "1" "case11: text-mode timeout exits 1" "$stderr"
-assert_contains "$output" "Approval timeout" "case11: text-mode timeout prints result on stdout"
-
-stderr="$TMP_ROOT/case11b.err"
-set +e
-output=$(run_wait_text_short STUB_APPROVAL_MODE=approved_decision 2>"$stderr")
-rc=$?
-set -e
-assert_eq "$rc" "0" "case11b: text-mode approval exits 0" "$stderr"
-assert_contains "$output" "Approval: approved" "case11b: text-mode approval prints result on stdout"
-
-# Cases 11c-11e: approval-mode text lines are pinned verbatim; review-mode
-# labeling never touches them.
-stderr="$TMP_ROOT/case11c.err"
-set +e
-output=$(run_wait_text_short STUB_APPROVAL_MODE=changes 2>"$stderr")
-rc=$?
-set -e
-assert_eq "$rc" "1" "case11c: text-mode changes requested exits 1" "$stderr"
-assert_contains "$output" "Approval: changes requested (1 reviewer(s), unresolved threads: 0)" "case11c: approval-mode changes-requested line unchanged"
-
-stderr="$TMP_ROOT/case11d.err"
-set +e
-output=$(run_wait_text_short STUB_APPROVAL_MODE=none STUB_THREADS_UNRESOLVED=2 2>"$stderr")
-rc=$?
-set -e
-assert_eq "$rc" "1" "case11d: text-mode pending comments exits 1" "$stderr"
-assert_contains "$output" "Approval: 2 unresolved review thread(s) pending triage, no approval verdict yet" "case11d: approval-mode comments line unchanged"
-
-stderr="$TMP_ROOT/case11e.err"
-set +e
-output=$(run_wait_text_short GH_TOKEN=bad-token STUB_GH_DENY_KEYRING=1 2>"$stderr")
-rc=$?
-set -e
-assert_eq "$rc" "3" "case11e: text-mode auth failure exits 3" "$stderr"
-assert_contains "$output" "Approval error: no working GitHub auth path" "case11e: approval-mode error line unchanged"
-
-echo "=== approval-wait --mode review gating ==="
-
-# Case 12: a COMMENTED review pinned to the current head with zero unresolved
-# threads satisfies the review gate — the commenting-only-bot happy path.
-stderr="$TMP_ROOT/case12.err"
-set +e
-output=$(run_review_json STUB_REVIEWS_MODE=commented_at_head 2>"$stderr")
-rc=$?
-set -e
-assert_eq "$rc" "0" "case12: COMMENTED at head exits 0" "$stderr"
-assert_eq "$(json_field "$output" '.status')" "reviewed" "case12: status reviewed" "$stderr"
-assert_eq "$(json_field "$output" '.mode')" "review" "case12: mode reported" "$stderr"
-assert_eq "$(json_field "$output" '.head_sha')" "headsha1" "case12: head_sha reported" "$stderr"
-assert_eq "$(json_field "$output" '.reviews_at_head')" "1" "case12: reviews_at_head counted" "$stderr"
-
-# Case 13: a review at head with unresolved threads is NOT the gate — early
-# "comments" return so the caller triages, replies, and resolves first.
-stderr="$TMP_ROOT/case13.err"
-set +e
-output=$(run_review_json STUB_REVIEWS_MODE=commented_at_head STUB_THREADS_UNRESOLVED=2 2>"$stderr")
-rc=$?
-set -e
-assert_eq "$rc" "1" "case13: review at head + open threads exits 1" "$stderr"
-assert_eq "$(json_field "$output" '.status')" "comments" "case13: status comments" "$stderr"
-assert_eq "$(json_field "$output" '.unresolved_count')" "2" "case13: unresolved_count reported" "$stderr"
-assert_eq "$(json_field "$output" '.elapsed_seconds | . < 3')" "true" "case13: comments returns early, not at deadline" "$stderr"
-
-# Case 14: head pinning — a review of a superseded commit never satisfies the
-# gate (this is also the force-push reset: the head is re-read every poll).
-stderr="$TMP_ROOT/case14.err"
-set +e
-output=$(run_review_json_short STUB_REVIEWS_MODE=commented_stale 2>"$stderr")
-rc=$?
-set -e
-assert_eq "$rc" "1" "case14: stale-commit review exits 1" "$stderr"
-assert_eq "$(json_field "$output" '.status')" "timeout" "case14: stale-commit review times out" "$stderr"
-assert_eq "$(json_field "$output" '.reviews_at_head')" "0" "case14: stale review not counted at head" "$stderr"
-
-# Case 15: the PR author's own review never satisfies the gate.
-stderr="$TMP_ROOT/case15.err"
-set +e
-output=$(run_review_json_short STUB_REVIEWS_MODE=author_only 2>"$stderr")
-rc=$?
-set -e
-assert_eq "$rc" "1" "case15: author-only review exits 1" "$stderr"
-assert_eq "$(json_field "$output" '.status')" "timeout" "case15: author-only review times out" "$stderr"
-assert_eq "$(json_field "$output" '.reviews_at_head')" "0" "case15: author review excluded from head count" "$stderr"
-
-# Case 16: DISMISSED reviews are excluded.
-stderr="$TMP_ROOT/case16.err"
-set +e
-output=$(run_review_json_short STUB_REVIEWS_MODE=dismissed_only 2>"$stderr")
-rc=$?
-set -e
-assert_eq "$rc" "1" "case16: dismissed-only review exits 1" "$stderr"
-assert_eq "$(json_field "$output" '.status')" "timeout" "case16: dismissed-only review times out" "$stderr"
-assert_eq "$(json_field "$output" '.reviews_at_head')" "0" "case16: dismissed review excluded from head count" "$stderr"
-
-# Case 17: a standing CHANGES_REQUESTED from a non-author reviewer blocks the
-# review gate even though it is also a review of the head.
-stderr="$TMP_ROOT/case17.err"
-set +e
-output=$(run_review_json STUB_REVIEWS_MODE=changes_standing 2>"$stderr")
-rc=$?
-set -e
-assert_eq "$rc" "1" "case17: standing CHANGES_REQUESTED exits 1" "$stderr"
-assert_eq "$(json_field "$output" '.status')" "changes_requested" "case17: status changes_requested" "$stderr"
-assert_eq "$(json_field "$output" '.changes_requested')" "1" "case17: changes_requested count reported" "$stderr"
-
-# Case 18: a later review by the same reviewer supersedes their prior
-# CHANGES_REQUESTED — latest-per-reviewer, same as GitHub's standing verdict.
-stderr="$TMP_ROOT/case18.err"
-set +e
-output=$(run_review_json STUB_REVIEWS_MODE=changes_superseded 2>"$stderr")
-rc=$?
-set -e
-assert_eq "$rc" "0" "case18: superseded CHANGES_REQUESTED exits 0" "$stderr"
-assert_eq "$(json_field "$output" '.status')" "reviewed" "case18: status reviewed after supersession" "$stderr"
-assert_eq "$(json_field "$output" '.changes_requested')" "0" "case18: superseded verdict no longer stands" "$stderr"
-
-# Case 19: an APPROVED review at head satisfies review mode too — an approval
-# is also a review.
-stderr="$TMP_ROOT/case19.err"
-set +e
-output=$(run_review_json STUB_REVIEWS_MODE=approved_at_head 2>"$stderr")
-rc=$?
-set -e
-assert_eq "$rc" "0" "case19: APPROVED at head exits 0 in review mode" "$stderr"
-assert_eq "$(json_field "$output" '.status')" "reviewed" "case19: status reviewed for an approval" "$stderr"
-
-# Case 20: a review arriving on a later poll is picked up (first poll no
-# reviews, second poll COMMENTED at head).
-stderr="$TMP_ROOT/case20.err"
-count_file="$TMP_ROOT/case20-count"
-set +e
-output=$(run_review_json STUB_REVIEWS_MODE=reviewed_later STUB_REVIEWS_COUNT_FILE="$count_file" 2>"$stderr")
-rc=$?
-set -e
-assert_eq "$rc" "0" "case20: later review exits 0" "$stderr"
-assert_eq "$(json_field "$output" '.status')" "reviewed" "case20: status reviewed after polling" "$stderr"
-assert_eq "$(cat "$count_file")" "2" "case20: approval-wait polled again for the review" "$stderr"
-
-# Case 21: review-mode text output prints a Review result line.
-stderr="$TMP_ROOT/case21.err"
-set +e
-output=$(run_review_text STUB_REVIEWS_MODE=commented_at_head 2>"$stderr")
-rc=$?
-set -e
-assert_eq "$rc" "0" "case21: text-mode reviewed exits 0" "$stderr"
-assert_contains "$output" "Review: reviewed" "case21: text-mode reviewed prints result on stdout"
-
-# Cases 21b-21e: every review-mode text line names the review gate, never the
-# approval gate.
-stderr="$TMP_ROOT/case21b.err"
-set +e
-output=$(run_review_text STUB_REVIEWS_MODE=changes_standing 2>"$stderr")
-rc=$?
-set -e
-assert_eq "$rc" "1" "case21b: text-mode review changes requested exits 1" "$stderr"
-assert_contains "$output" "Review: changes requested (1 reviewer(s), unresolved threads: 0)" "case21b: review-mode changes-requested names the review gate"
-
-stderr="$TMP_ROOT/case21c.err"
-set +e
-output=$(run_review_text STUB_REVIEWS_MODE=commented_at_head STUB_THREADS_UNRESOLVED=2 2>"$stderr")
-rc=$?
-set -e
-assert_eq "$rc" "1" "case21c: text-mode review comments exits 1" "$stderr"
-assert_contains "$output" "Review: 2 unresolved review thread(s) pending triage" "case21c: review-mode comments names the review gate"
-
-stderr="$TMP_ROOT/case21d.err"
-set +e
-output=$(run_review_text STUB_REVIEWS_MODE=none 2>"$stderr")
-rc=$?
-set -e
-assert_eq "$rc" "1" "case21d: text-mode review timeout exits 1" "$stderr"
-assert_contains "$output" "Review timeout after" "case21d: review-mode timeout names the review gate"
-
-stderr="$TMP_ROOT/case21e.err"
-set +e
-output=$(run_review_text GH_TOKEN=bad-token STUB_GH_DENY_KEYRING=1 2>"$stderr")
-rc=$?
-set -e
-assert_eq "$rc" "3" "case21e: text-mode review auth failure exits 3" "$stderr"
-assert_contains "$output" "Review error: no working GitHub auth path" "case21e: review-mode error names the review gate"
-
-echo "=== approval-wait PR_REVIEW_ON_TIMEOUT reviewer-down flexibility ==="
-
-# proceed1: review mode, no evidence, zero threads, setting=proceed — the
-# deadline degrades to "proceeded" (exit 0), so a credit-exhausted reviewer
-# that posted nothing does not block the fleet.
-stderr="$TMP_ROOT/proceed1.err"
-set +e
-output=$(run_review_json_short STUB_REVIEWS_MODE=none PR_REVIEW_ON_TIMEOUT=proceed 2>"$stderr")
-rc=$?
-set -e
-assert_eq "$rc" "0" "proceed1: reviewer-down proceed exits 0" "$stderr"
-assert_eq "$(json_field "$output" '.status')" "proceeded" "proceed1: status proceeded" "$stderr"
-assert_eq "$(json_field "$output" '.unresolved_count')" "0" "proceed1: proceeded only with zero unresolved threads" "$stderr"
-
-# proceed2: the --on-timeout proceed flag drives the same behavior without the
-# setting (and overrides it for explicit callers/tests).
-stderr="$TMP_ROOT/proceed2.err"
-set +e
-output=$( (cd "$TMP_ROOT/repo" && PATH="$TMP_ROOT/bin:$PATH" \
-  env STUB_REVIEWS_MODE=none .agents/skills/orch/scripts/approval-wait 1 1 3 --json --mode review --on-timeout proceed) 2>"$stderr")
-rc=$?
-set -e
-assert_eq "$rc" "0" "proceed2: --on-timeout proceed flag exits 0" "$stderr"
-assert_eq "$(json_field "$output" '.status')" "proceeded" "proceed2: flag yields status proceeded" "$stderr"
-
-# proceed3: an unresolved thread ALWAYS blocks, even under proceed — it returns
-# "comments" before the deadline, so a real open comment is never bypassed.
-stderr="$TMP_ROOT/proceed3.err"
-set +e
-output=$(run_review_json STUB_REVIEWS_MODE=none STUB_THREADS_UNRESOLVED=2 PR_REVIEW_ON_TIMEOUT=proceed 2>"$stderr")
-rc=$?
-set -e
-assert_eq "$rc" "1" "proceed3: open threads still block under proceed" "$stderr"
-assert_eq "$(json_field "$output" '.status')" "comments" "proceed3: status comments, not proceeded" "$stderr"
-
-# proceed4: a standing CHANGES_REQUESTED still blocks under proceed — proceed
-# only ever converts a no-verdict timeout, never a negative verdict.
-stderr="$TMP_ROOT/proceed4.err"
-set +e
-output=$(run_review_json STUB_REVIEWS_MODE=changes_standing PR_REVIEW_ON_TIMEOUT=proceed 2>"$stderr")
-rc=$?
-set -e
-assert_eq "$rc" "1" "proceed4: changes_requested still blocks under proceed" "$stderr"
-assert_eq "$(json_field "$output" '.status')" "changes_requested" "proceed4: status changes_requested, not proceeded" "$stderr"
-
-# proceed5: the default advances when no reviewer engaged and no thread is open.
-stderr="$TMP_ROOT/proceed5.err"
-set +e
-output=$(run_review_json_short -u PR_REVIEW_ON_TIMEOUT STUB_REVIEWS_MODE=none 2>"$stderr")
-rc=$?
-set -e
-assert_eq "$rc" "0" "proceed5: default proceeds after reviewer silence" "$stderr"
-assert_eq "$(json_field "$output" '.status')" "proceeded" "proceed5: default status proceeded" "$stderr"
-
-# proceed6: approval mode degrades symmetrically — no approval verdict, zero
-# threads, proceed -> proceeded, exit 0.
-stderr="$TMP_ROOT/proceed6.err"
-set +e
-output=$(run_wait_json_short STUB_APPROVAL_MODE=none PR_REVIEW_ON_TIMEOUT=proceed 2>"$stderr")
-rc=$?
-set -e
-assert_eq "$rc" "0" "proceed6: approval-mode proceed exits 0" "$stderr"
-assert_eq "$(json_field "$output" '.status')" "proceeded" "proceed6: approval-mode status proceeded" "$stderr"
-
-# proceed7: text output names the proceed reason instead of a timeout line.
-stderr="$TMP_ROOT/proceed7.err"
-set +e
-output=$( (cd "$TMP_ROOT/repo" && PATH="$TMP_ROOT/bin:$PATH" \
-  env STUB_REVIEWS_MODE=none PR_REVIEW_ON_TIMEOUT=proceed .agents/skills/orch/scripts/approval-wait 1 1 3 --mode review) 2>"$stderr")
-rc=$?
-set -e
-assert_eq "$rc" "0" "proceed7: review-mode proceed text exits 0" "$stderr"
-assert_contains "$output" "proceeding per PR_REVIEW_ON_TIMEOUT=proceed" "proceed7: text names the proceed reason"
-
-# proceed8: an unrecognized value falls back to block (timeout) and warns.
-stderr="$TMP_ROOT/proceed8.err"
-set +e
-output=$(run_review_json_short STUB_REVIEWS_MODE=none PR_REVIEW_ON_TIMEOUT=bogus 2>"$stderr")
-rc=$?
-set -e
-assert_eq "$rc" "1" "proceed8: invalid value falls back to block" "$stderr"
-assert_eq "$(json_field "$output" '.status')" "timeout" "proceed8: invalid value times out" "$stderr"
-assert_contains "$(cat "$stderr")" "unrecognized PR_REVIEW_ON_TIMEOUT value" "proceed8: invalid value warns"
-
-# proceed9: approval mode with an active COMMENTED review is NOT reviewer
-# silence — a reviewer engaged but did not approve. proceed must NOT convert it
-# (that would bypass a live approval gate), so it still times out. Guards the
-# "zero reviewer evidence" boundary in approval mode, where reaching the
-# deadline does not by itself imply no review.
-stderr="$TMP_ROOT/proceed9.err"
-set +e
-output=$(run_wait_json_short STUB_APPROVAL_MODE=commented_only PR_REVIEW_ON_TIMEOUT=proceed 2>"$stderr")
-rc=$?
-set -e
-assert_eq "$rc" "1" "proceed9: active COMMENTED review blocks proceed (approval mode)" "$stderr"
-assert_eq "$(json_field "$output" '.status')" "timeout" "proceed9: status timeout, not proceeded" "$stderr"
-
-# proceed10: a head change DURING the wait (force-push near the deadline)
-# disqualifies proceed — elapsed is measured from START_TIME, so proceed must
-# not fire seconds after a push before the reviewer could re-review it. Falls
-# back to timeout so the caller re-waits on the stable head.
-stderr="$TMP_ROOT/proceed10.err"
-head_count="$TMP_ROOT/proceed10-head-count"
-set +e
-output=$(cd "$TMP_ROOT/repo" \
-  && PATH="$TMP_ROOT/bin:$PATH" \
-     env STUB_REVIEWS_MODE=none STUB_HEAD_MODE=changes STUB_HEAD_COUNT_FILE="$head_count" \
-         PR_REVIEW_ON_TIMEOUT=proceed \
-         .agents/skills/orch/scripts/approval-wait 1 1 5 --json --mode review 2>"$stderr")
-rc=$?
-set -e
-assert_eq "$rc" "1" "proceed10: head change during wait blocks proceed" "$stderr"
-assert_eq "$(json_field "$output" '.status')" "timeout" "proceed10: status timeout, not proceeded (head moved)" "$stderr"
-
-# proceed11: review mode with a FAILED trusted check-run at head is a real
-# reviewer signal, not silence — the reviewer ran and did not pass. proceed
-# must not fire; it times out.
-stderr="$TMP_ROOT/proceed11.err"
-set +e
-output=$(run_review_json_short STUB_REVIEWS_MODE=none STUB_CHECKS_MODE=failure_at_head \
-  PR_REVIEW_CHECK="Review Bot" PR_REVIEW_ON_TIMEOUT=proceed 2>"$stderr")
-rc=$?
-set -e
-assert_eq "$rc" "1" "proceed11: failed trusted check blocks proceed (present, not silent)" "$stderr"
-assert_eq "$(json_field "$output" '.status')" "timeout" "proceed11: status timeout, not proceeded" "$stderr"
-
-# proceed12: review mode with a PENDING trusted commit status at head means the
-# reviewer is actively analyzing — presence, not silence. proceed must not fire
-# on the status surface either; it times out.
-stderr="$TMP_ROOT/proceed12.err"
-set +e
-output=$(run_review_json_short STUB_REVIEWS_MODE=none STUB_STATUS_MODE=pending_at_head \
-  PR_REVIEW_CHECK="Review Bot" PR_REVIEW_ON_TIMEOUT=proceed 2>"$stderr")
-rc=$?
-set -e
-assert_eq "$rc" "1" "proceed12: pending trusted status blocks proceed (present, not silent)" "$stderr"
-assert_eq "$(json_field "$output" '.status')" "timeout" "proceed12: status timeout, not proceeded" "$stderr"
-
-# proceed13: a push in the final last-poll -> emit window (head confirmed
-# different at the decision) falls back to timeout, preserving the head-unchanged
-# guarantee — no proceed on a superseded commit. The head is stable across
-# polls (so head_changed_during_wait stays false), only the emit-time confirm
-# differs.
-stderr="$TMP_ROOT/proceed13.err"
-set +e
-output=$(run_review_json_short STUB_REVIEWS_MODE=none PR_REVIEW_ON_TIMEOUT=proceed \
-  STUB_CONFIRM_HEAD=headsha2 2>"$stderr")
-rc=$?
-set -e
-assert_eq "$rc" "1" "proceed13: head moved in the confirm window blocks proceed" "$stderr"
-assert_eq "$(json_field "$output" '.status')" "timeout" "proceed13: status timeout, not proceeded" "$stderr"
-
-echo "=== approval-wait never posts review evidence ==="
-
-# marker1: a proceed posts NO commit status and its JSON carries no
-# outage_marker field: orch never manufactures review evidence.
-# PR_REVIEW_OUTAGE_CONTEXT is deliberately exported to prove it is inert; the
-# must-fail control is a status POST landing in the log.
-stderr="$TMP_ROOT/marker1.err"
-marker_log="$TMP_ROOT/marker1.log"; : > "$marker_log"
-set +e
-output=$(run_review_json_short STUB_REVIEWS_MODE=none PR_REVIEW_ON_TIMEOUT=proceed \
-  PR_REVIEW_OUTAGE_CONTEXT="kendex-reviewer-outage" STUB_MARKER_LOG="$marker_log" 2>"$stderr")
-rc=$?
-set -e
-assert_eq "$rc" "0" "marker1: proceed exits 0" "$stderr"
-assert_eq "$(json_field "$output" '.status')" "proceeded" "marker1: status proceeded" "$stderr"
-assert_eq "$(wc -l < "$marker_log" | tr -d ' ')" "0" "marker1: no commit status posted on proceed" "$stderr"
-assert_eq "$(json_field "$output" 'has("outage_marker")')" "false" "marker1: no outage_marker field in the JSON" "$stderr"
-
-echo "=== approval-wait --mode review check-run evidence (kendex#654) ==="
-
-# Check 1: with PR_REVIEW_CHECK set and no review object anywhere, a "success"
-# conclusion of that check name on the current head opens the gate. The stub
-# payload also pins newest-of-name selection (an older failed "Review Bot" run
-# precedes the success) and name filtering (an unrelated green check exists).
-stderr="$TMP_ROOT/check1.err"
-set +e
-output=$(run_review_json STUB_REVIEWS_MODE=none STUB_CHECKS_MODE=success_at_head \
-  PR_REVIEW_CHECK="Review Bot" 2>"$stderr")
-rc=$?
-set -e
-assert_eq "$rc" "0" "check1: trusted check success at head exits 0" "$stderr"
-assert_eq "$(json_field "$output" '.status')" "reviewed" "check1: status reviewed via check evidence" "$stderr"
-assert_eq "$(json_field "$output" '.review_evidence')" "check" "check1: review_evidence pinned to check" "$stderr"
-assert_eq "$(json_field "$output" '.review_evidence_surface')" "check_run" "check1: review_evidence_surface pinned to check_run" "$stderr"
-assert_eq "$(json_field "$output" '.reviews_at_head')" "0" "check1: no review object at head" "$stderr"
-assert_eq "$(json_field "$output" '.head_sha')" "headsha1" "check1: head_sha reported" "$stderr"
-
-# Check 2: a check success on a STALE sha never opens the gate — the query
-# targets the current head's check-runs, which report nothing.
-stderr="$TMP_ROOT/check2.err"
-set +e
-output=$(run_review_json_short STUB_REVIEWS_MODE=none STUB_CHECKS_MODE=success_stale \
-  PR_REVIEW_CHECK="Review Bot" 2>"$stderr")
-rc=$?
-set -e
-assert_eq "$rc" "1" "check2: stale-sha check success exits 1" "$stderr"
-assert_eq "$(json_field "$output" '.status')" "timeout" "check2: stale-sha check success times out" "$stderr"
-
-# Check 3: a non-success conclusion of the configured check is not evidence.
-stderr="$TMP_ROOT/check3.err"
-set +e
-output=$(run_review_json_short STUB_REVIEWS_MODE=none STUB_CHECKS_MODE=failure_at_head \
-  PR_REVIEW_CHECK="Review Bot" 2>"$stderr")
-rc=$?
-set -e
-assert_eq "$rc" "1" "check3: failed check conclusion exits 1" "$stderr"
-assert_eq "$(json_field "$output" '.status')" "timeout" "check3: failed check conclusion times out" "$stderr"
-
-# Check 4: unresolved threads still block — check evidence routes to the same
-# "comments" early return as a review object would.
-stderr="$TMP_ROOT/check4.err"
-set +e
-output=$(run_review_json STUB_REVIEWS_MODE=none STUB_CHECKS_MODE=success_at_head \
-  PR_REVIEW_CHECK="Review Bot" STUB_THREADS_UNRESOLVED=2 2>"$stderr")
-rc=$?
-set -e
-assert_eq "$rc" "1" "check4: check success + open threads exits 1" "$stderr"
-assert_eq "$(json_field "$output" '.status')" "comments" "check4: status comments despite check success" "$stderr"
-assert_eq "$(json_field "$output" '.unresolved_count')" "2" "check4: unresolved_count reported" "$stderr"
-assert_eq "$(json_field "$output" '.elapsed_seconds | . < 3')" "true" "check4: comments returns early, not at deadline" "$stderr"
-
-# Check 5: a standing CHANGES_REQUESTED still blocks despite check success.
-stderr="$TMP_ROOT/check5.err"
-set +e
-output=$(run_review_json STUB_REVIEWS_MODE=changes_standing STUB_CHECKS_MODE=success_at_head \
-  PR_REVIEW_CHECK="Review Bot" 2>"$stderr")
-rc=$?
-set -e
-assert_eq "$rc" "1" "check5: standing CHANGES_REQUESTED exits 1 despite check success" "$stderr"
-assert_eq "$(json_field "$output" '.status')" "changes_requested" "check5: status changes_requested despite check success" "$stderr"
-
-# Check 6: empty PR_REVIEW_CHECK ignores check-runs entirely — the published
-# success must not leak into the gate when the feature is off.
-stderr="$TMP_ROOT/check6.err"
-set +e
-output=$(run_review_json_short STUB_REVIEWS_MODE=none STUB_CHECKS_MODE=success_at_head 2>"$stderr")
-rc=$?
-set -e
-assert_eq "$rc" "1" "check6: empty PR_REVIEW_CHECK exits 1" "$stderr"
-assert_eq "$(json_field "$output" '.status')" "timeout" "check6: empty PR_REVIEW_CHECK ignores check-runs" "$stderr"
-
-# Check 7: the review-object path still works with the feature on, and wins
-# the review_evidence label when a review is pinned to the head.
-stderr="$TMP_ROOT/check7.err"
-set +e
-output=$(run_review_json STUB_REVIEWS_MODE=commented_at_head STUB_CHECKS_MODE=none \
-  PR_REVIEW_CHECK="Review Bot" 2>"$stderr")
-rc=$?
-set -e
-assert_eq "$rc" "0" "check7: review object still opens the gate with the feature on" "$stderr"
-assert_eq "$(json_field "$output" '.status')" "reviewed" "check7: status reviewed via review object" "$stderr"
-assert_eq "$(json_field "$output" '.review_evidence')" "review" "check7: review_evidence pinned to review" "$stderr"
-assert_eq "$(json_field "$output" '.review_evidence_surface')" "null" "check7: no surface field for review-object evidence" "$stderr"
-assert_eq "$(json_field "$output" '.reviews_at_head')" "1" "check7: reviews_at_head counted" "$stderr"
-
-# Check 8: text mode names the satisfying check-run and its app slug.
-stderr="$TMP_ROOT/check8.err"
-set +e
-output=$(run_review_text STUB_REVIEWS_MODE=none STUB_CHECKS_MODE=success_at_head \
-  PR_REVIEW_CHECK="Review Bot" 2>"$stderr")
-rc=$?
-set -e
-assert_eq "$rc" "0" "check8: text-mode check evidence exits 0" "$stderr"
-assert_contains "$output" "Review: reviewed" "check8: text mode still prints the reviewed line" "$stderr"
-assert_contains "$output" "check-run 'Review Bot'" "check8: text mode names the check-run" "$stderr"
-assert_contains "$output" "app: review-bot" "check8: text mode records the publishing app slug" "$stderr"
-
-echo "=== approval-wait --mode review commit-status evidence (kendex#681) ==="
-
-# Status 1: with PR_REVIEW_CHECK set, no review object, and no check-run of
-# that name anywhere, a "success" commit status with that context on the
-# current head opens the gate. The stub payload also pins newest-of-context
-# selection (an older pending entry precedes the success) and context
-# filtering (an unrelated green context exists).
-stderr="$TMP_ROOT/status1.err"
-set +e
-output=$(run_review_json STUB_REVIEWS_MODE=none STUB_CHECKS_MODE=none \
-  STUB_STATUS_MODE=success_at_head PR_REVIEW_CHECK="Review Bot" 2>"$stderr")
-rc=$?
-set -e
-assert_eq "$rc" "0" "status1: trusted status success at head exits 0" "$stderr"
-assert_eq "$(json_field "$output" '.status')" "reviewed" "status1: status reviewed via status evidence" "$stderr"
-assert_eq "$(json_field "$output" '.review_evidence')" "check" "status1: review_evidence stays check" "$stderr"
-assert_eq "$(json_field "$output" '.review_evidence_surface')" "status" "status1: review_evidence_surface pinned to status" "$stderr"
-assert_eq "$(json_field "$output" '.reviews_at_head')" "0" "status1: no review object at head" "$stderr"
-assert_eq "$(json_field "$output" '.head_sha')" "headsha1" "status1: head_sha reported" "$stderr"
-
-# Status 2: a matching check-run wins first — the status endpoint is never
-# queried, so bots that use check-runs cost no extra API call.
-stderr="$TMP_ROOT/status2.err"
-status_log="$TMP_ROOT/status2-status.log"
-set +e
-output=$(run_review_json STUB_REVIEWS_MODE=none STUB_CHECKS_MODE=success_at_head \
-  STUB_STATUS_MODE=success_at_head STUB_STATUS_LOG="$status_log" \
-  PR_REVIEW_CHECK="Review Bot" 2>"$stderr")
-rc=$?
-set -e
-assert_eq "$rc" "0" "status2: check-run match still exits 0 with a status present" "$stderr"
-assert_eq "$(json_field "$output" '.review_evidence_surface')" "check_run" "status2: check-run surface wins over status" "$stderr"
-assert_eq "$([[ -f "$status_log" ]] && wc -l < "$status_log" | tr -d ' ' || echo 0)" "0" "status2: status endpoint never queried when a check-run matches" "$stderr"
-
-# Status 3a-3c: non-success status states are not evidence — pending,
-# failure, and error all keep waiting to the timeout.
-stderr="$TMP_ROOT/status3a.err"
-set +e
-output=$(run_review_json_short STUB_REVIEWS_MODE=none STUB_CHECKS_MODE=none \
-  STUB_STATUS_MODE=pending_at_head PR_REVIEW_CHECK="Review Bot" 2>"$stderr")
-rc=$?
-set -e
-assert_eq "$rc" "1" "status3a: pending status exits 1" "$stderr"
-assert_eq "$(json_field "$output" '.status')" "timeout" "status3a: pending status times out" "$stderr"
-
-stderr="$TMP_ROOT/status3b.err"
-set +e
-output=$(run_review_json_short STUB_REVIEWS_MODE=none STUB_CHECKS_MODE=none \
-  STUB_STATUS_MODE=failure_at_head PR_REVIEW_CHECK="Review Bot" 2>"$stderr")
-rc=$?
-set -e
-assert_eq "$rc" "1" "status3b: failure status exits 1" "$stderr"
-assert_eq "$(json_field "$output" '.status')" "timeout" "status3b: failure status times out" "$stderr"
-
-stderr="$TMP_ROOT/status3c.err"
-set +e
-output=$(run_review_json_short STUB_REVIEWS_MODE=none STUB_CHECKS_MODE=none \
-  STUB_STATUS_MODE=error_at_head PR_REVIEW_CHECK="Review Bot" 2>"$stderr")
-rc=$?
-set -e
-assert_eq "$rc" "1" "status3c: error status exits 1" "$stderr"
-assert_eq "$(json_field "$output" '.status')" "timeout" "status3c: error status times out" "$stderr"
-
-# Status 4: a status success on a STALE sha never opens the gate — the query
-# targets the current head's combined status, which reports nothing.
-stderr="$TMP_ROOT/status4.err"
-set +e
-output=$(run_review_json_short STUB_REVIEWS_MODE=none STUB_CHECKS_MODE=none \
-  STUB_STATUS_MODE=success_stale PR_REVIEW_CHECK="Review Bot" 2>"$stderr")
-rc=$?
-set -e
-assert_eq "$rc" "1" "status4: stale-sha status success exits 1" "$stderr"
-assert_eq "$(json_field "$output" '.status')" "timeout" "status4: stale-sha status success times out" "$stderr"
-
-# Status 5: empty PR_REVIEW_CHECK ignores BOTH surfaces — neither the
-# published check-run success nor the status success leaks into the gate,
-# and the status endpoint is never queried.
-stderr="$TMP_ROOT/status5.err"
-status_log="$TMP_ROOT/status5-status.log"
-set +e
-output=$(run_review_json_short STUB_REVIEWS_MODE=none STUB_CHECKS_MODE=success_at_head \
-  STUB_STATUS_MODE=success_at_head STUB_STATUS_LOG="$status_log" 2>"$stderr")
-rc=$?
-set -e
-assert_eq "$rc" "1" "status5: empty PR_REVIEW_CHECK exits 1" "$stderr"
-assert_eq "$(json_field "$output" '.status')" "timeout" "status5: empty PR_REVIEW_CHECK ignores both surfaces" "$stderr"
-assert_eq "$([[ -f "$status_log" ]] && wc -l < "$status_log" | tr -d ' ' || echo 0)" "0" "status5: status endpoint never queried with the feature off" "$stderr"
-
-# Status 6: a review object pinned to the head still takes precedence over a
-# status success — review_evidence "review", no surface field.
-stderr="$TMP_ROOT/status6.err"
-set +e
-output=$(run_review_json STUB_REVIEWS_MODE=commented_at_head STUB_CHECKS_MODE=none \
-  STUB_STATUS_MODE=success_at_head PR_REVIEW_CHECK="Review Bot" 2>"$stderr")
-rc=$?
-set -e
-assert_eq "$rc" "0" "status6: review object still opens the gate over a status" "$stderr"
-assert_eq "$(json_field "$output" '.review_evidence')" "review" "status6: review_evidence pinned to review" "$stderr"
-assert_eq "$(json_field "$output" '.review_evidence_surface')" "null" "status6: no surface field for review-object evidence" "$stderr"
-
-# Status 7: unresolved threads still block — status evidence routes to the
-# same "comments" early return as a review object or check-run would.
-stderr="$TMP_ROOT/status7.err"
-set +e
-output=$(run_review_json STUB_REVIEWS_MODE=none STUB_CHECKS_MODE=none \
-  STUB_STATUS_MODE=success_at_head PR_REVIEW_CHECK="Review Bot" \
-  STUB_THREADS_UNRESOLVED=2 2>"$stderr")
-rc=$?
-set -e
-assert_eq "$rc" "1" "status7: status success + open threads exits 1" "$stderr"
-assert_eq "$(json_field "$output" '.status')" "comments" "status7: status comments despite status success" "$stderr"
-assert_eq "$(json_field "$output" '.elapsed_seconds | . < 3')" "true" "status7: comments returns early, not at deadline" "$stderr"
-
-# Status 8: text mode names the satisfying status context and its creator.
-stderr="$TMP_ROOT/status8.err"
-set +e
-output=$(run_review_text STUB_REVIEWS_MODE=none STUB_CHECKS_MODE=none \
-  STUB_STATUS_MODE=success_at_head PR_REVIEW_CHECK="Review Bot" 2>"$stderr")
-rc=$?
-set -e
-assert_eq "$rc" "0" "status8: text-mode status evidence exits 0" "$stderr"
-assert_contains "$output" "Review: reviewed" "status8: text mode still prints the reviewed line" "$stderr"
-assert_contains "$output" "via status 'Review Bot'" "status8: text mode names the status context" "$stderr"
-assert_contains "$output" "creator: review-bot[bot]" "status8: text mode records the publishing creator" "$stderr"
-
-echo "=== approval-wait transient GitHub API errors (kendex#748) ==="
-
-stderr="$TMP_ROOT/transient1.err"
-count_file="$TMP_ROOT/transient1-count"
-set +e
-output=$(run_review_json STUB_REVIEWS_MODE=flaky_503 STUB_REVIEWS_COUNT_FILE="$count_file" 2>"$stderr")
-rc=$?
-set -e
-assert_eq "$rc" "0" "transient1: 503 twice then success exits 0" "$stderr"
-assert_eq "$(json_field "$output" '.status')" "reviewed" "transient1: status reviewed despite transient 503s" "$stderr"
-assert_eq "$(json_field "$output" '.transient_api_errors')" "2" "transient1: transient_api_errors counts the absorbed 503s" "$stderr"
-assert_eq "$(cat "$count_file")" "3" "transient1: reviews endpoint retried until it recovered" "$stderr"
-assert_contains "$(cat "$stderr")" "transient GitHub error" "transient1: each transient failure is logged to stderr"
-
-# Transient 1b: HTTP 429 rate limits are transient too — twice
-# then success recovers exactly like a 5xx.
-stderr="$TMP_ROOT/transient1b.err"
-count_file="$TMP_ROOT/transient1b-count"
-set +e
-output=$(run_review_json STUB_REVIEWS_MODE=flaky_429 STUB_REVIEWS_COUNT_FILE="$count_file" 2>"$stderr")
-rc=$?
-set -e
-assert_eq "$rc" "0" "transient1b: 429 twice then success exits 0" "$stderr"
-assert_eq "$(json_field "$output" '.status')" "reviewed" "transient1b: status reviewed despite rate limits" "$stderr"
-assert_eq "$(json_field "$output" '.transient_api_errors')" "2" "transient1b: transient_api_errors counts the absorbed 429s" "$stderr"
-
-# Transient 2: a persistent 503 becomes terminal only when the wait budget
-# expires — the listing's own error message is preserved, plus the count.
-stderr="$TMP_ROOT/transient2.err"
-set +e
-output=$(run_review_json_short STUB_REVIEWS_MODE=http_503 2>"$stderr")
-rc=$?
-set -e
-assert_eq "$rc" "1" "transient2: persistent 503 exits 1 at the deadline" "$stderr"
-assert_eq "$(json_field "$output" '.status')" "error" "transient2: persistent 503 ends in status error" "$stderr"
-assert_contains "$(json_field "$output" '.error')" "review listing failed" "transient2: terminal error message preserved" "$stderr"
-assert_eq "$(json_field "$output" '.transient_api_errors >= 1')" "true" "transient2: transient_api_errors reported at the deadline" "$stderr"
-assert_eq "$(json_field "$output" '.elapsed_seconds >= 3')" "true" "transient2: the full wait budget was spent retrying" "$stderr"
-
-# Transient 3: an HTTP 404 is NOT transient — immediately terminal, with no
-# transient_api_errors field.
-stderr="$TMP_ROOT/transient3.err"
-set +e
-output=$(run_review_json STUB_REVIEWS_MODE=http_404 2>"$stderr")
-rc=$?
-set -e
-assert_eq "$rc" "1" "transient3: 404 exits 1" "$stderr"
-assert_eq "$(json_field "$output" '.status')" "error" "transient3: 404 reports status error" "$stderr"
-assert_contains "$(json_field "$output" '.error')" "review listing failed" "transient3: 404 keeps the terminal error message" "$stderr"
-assert_eq "$(json_field "$output" '.transient_api_errors')" "null" "transient3: no transient count for a non-transient failure" "$stderr"
-assert_eq "$(json_field "$output" '.elapsed_seconds | . < 3')" "true" "transient3: 404 terminates immediately, not at the deadline" "$stderr"
-
-# Transient 4: approval-mode gh pr view gets the same treatment — 503 twice,
-# then the APPROVED verdict lands.
-stderr="$TMP_ROOT/transient4.err"
-count_file="$TMP_ROOT/transient4-count"
-set +e
-output=$(run_wait_json STUB_APPROVAL_MODE=approved_after_503 STUB_APPROVAL_COUNT_FILE="$count_file" 2>"$stderr")
-rc=$?
-set -e
-assert_eq "$rc" "0" "transient4: approval-mode 503s then approval exits 0" "$stderr"
-assert_eq "$(json_field "$output" '.status')" "approved" "transient4: status approved despite transient 503s" "$stderr"
-assert_eq "$(json_field "$output" '.transient_api_errors')" "2" "transient4: approval-mode pr view retries counted" "$stderr"
-
-echo "=== PR_REVIEW_WAIT_SECS (absent max_wait positional resolves via settings) ==="
-
-# No 3rd positional: the deadline comes from PR_REVIEW_WAIT_SECS through
-# orch-env (env > kendex.settings.toml > 900). These cases pin every layer
-# without ever waiting the 900s built-in default.
-run_wait_json_nomax() {
-  (cd "$TMP_ROOT/repo" \
-    && PATH="$TMP_ROOT/bin:$PATH" \
-       env "$@" .agents/skills/orch/scripts/approval-wait 1 1 --json)
-}
-
-# Env layer: a 1-second setting times the wait out promptly (a broken
-# resolution would idle toward the 900s default and hang the suite).
-stderr="$TMP_ROOT/waitsecs1.err"
-set +e
-output=$(run_wait_json_nomax STUB_APPROVAL_MODE=none PR_REVIEW_WAIT_SECS=1 2>"$stderr")
-rc=$?
-set -e
-assert_eq "$rc" "1" "waitsecs: env PR_REVIEW_WAIT_SECS drives the deadline" "$stderr"
-assert_eq "$(json_field "$output" '.status')" "timeout" "waitsecs: env-resolved deadline reports timeout" "$stderr"
-assert_eq "$(json_field "$output" '.elapsed_seconds | . < 5')" "true" "waitsecs: env deadline is the 1s setting, not the 900s default" "$stderr"
-
-# Settings layer: the same key from kendex.settings.toml [env] applies when
-# the process env is silent.
-cat > "$TMP_ROOT/repo/kendex.settings.toml" <<'EOF'
-[env]
-PR_REVIEW_WAIT_SECS = "1"
-EOF
-stderr="$TMP_ROOT/waitsecs2.err"
-set +e
-output=$(run_wait_json_nomax STUB_APPROVAL_MODE=none 2>"$stderr")
-rc=$?
-set -e
-assert_eq "$rc" "1" "waitsecs: settings-file PR_REVIEW_WAIT_SECS applies" "$stderr"
-assert_eq "$(json_field "$output" '.status')" "timeout" "waitsecs: settings-resolved deadline reports timeout" "$stderr"
-assert_eq "$(json_field "$output" '.elapsed_seconds | . < 5')" "true" "waitsecs: settings deadline is the 1s value, not the 900s default" "$stderr"
-
-# Process env beats the settings file (orch-env precedence): with the file
-# saying 1 and the env saying 3, the wait must run past 1s.
-stderr="$TMP_ROOT/waitsecs3.err"
-set +e
-output=$(run_wait_json_nomax STUB_APPROVAL_MODE=none PR_REVIEW_WAIT_SECS=3 2>"$stderr")
-rc=$?
-set -e
-assert_eq "$rc" "1" "waitsecs: env beats settings file (still times out)" "$stderr"
-assert_eq "$(json_field "$output" '.elapsed_seconds | . >= 2')" "true" "waitsecs: env 3s outlives the settings file's 1s" "$stderr"
-
-# An explicit positional max_wait always wins over the setting.
-stderr="$TMP_ROOT/waitsecs4.err"
-set +e
-output=$(run_wait_json_short STUB_APPROVAL_MODE=none PR_REVIEW_WAIT_SECS=600 2>"$stderr")
-rc=$?
-set -e
-assert_eq "$rc" "1" "waitsecs: explicit positional wins over the setting" "$stderr"
-assert_eq "$(json_field "$output" '.elapsed_seconds | . < 600')" "true" "waitsecs: positional 3s deadline, not the setting's 600" "$stderr"
+APPROVAL='1 1 3 --json'
+REVIEW='1 1 3 --json --mode review'
+
+echo "=== approval mode: the verdict rule over the pr view payload and the thread count ==="
+# A reviewDecision decides; with none, the latest review per reviewer does,
+# and REVIEW_REQUIRED means protection still wants more. COMMENTED is never a
+# verdict. Open threads with no verdict return before the deadline so the
+# caller triages; open threads beside an approval ride along as a count for
+# the caller's own gate. A later poll picks up a verdict the first missed.
+table "$APPROVAL" \
+  'reviewDecision APPROVED approves||STUB_APPROVAL_MODE=approved_decision|rc=0 status=approved review_decision=APPROVED approvals=1' \
+  'no reviewDecision, a latest APPROVED approves via latestReviews||STUB_APPROVAL_MODE=approved_latest|rc=0 status=approved review_decision= approvals=1' \
+  'a latest CHANGES_REQUESTED blocks beside another approval||STUB_APPROVAL_MODE=changes|rc=1 status=changes_requested changes_requested=1' \
+  'COMMENTED-only latest reviews are no verdict||STUB_APPROVAL_MODE=commented_only|rc=1 status=timeout approvals=0' \
+  'open threads with no verdict return comments before the deadline||STUB_APPROVAL_MODE=none,STUB_THREADS_UNRESOLVED=2|rc=1 status=comments unresolved_count=2 early=true' \
+  'nothing at the deadline is a timeout||STUB_APPROVAL_MODE=none|rc=1 status=timeout' \
+  'REVIEW_REQUIRED keeps a latest APPROVED from approving||STUB_APPROVAL_MODE=required_pending|rc=1 status=timeout review_decision=REVIEW_REQUIRED' \
+  'approved with open threads stays approved and carries the count||STUB_APPROVAL_MODE=approved_decision,STUB_THREADS_UNRESOLVED=1|rc=0 status=approved unresolved_count=1' \
+  'a verdict arriving on the second poll approves||STUB_APPROVAL_MODE=approved_later|rc=0 status=approved approval_polls=2' \
+  'an auth failure is a parseable error object||GH_TOKEN=bad-token,STUB_GH_DENY_KEYRING=1|rc=3 status=error'
+
+echo "=== review mode: the evidence rule over reviews, check-runs and commit statuses at the head ==="
+# A review counts only at the current head, from someone other than the
+# author, not dismissed; the latest per reviewer stands, so a standing
+# CHANGES_REQUESTED blocks and a superseded one does not. With PR_REVIEW_CHECK
+# set, a success of that name on the head is evidence too: check-runs first,
+# then the combined status, newest of the name winning and unrelated names
+# ignored (the stub publishes both distractors). A review object outranks
+# either surface; open threads and a standing CHANGES_REQUESTED block whatever
+# the evidence; an empty PR_REVIEW_CHECK reads neither surface.
+table "$REVIEW" \
+  'a COMMENTED review at head with no open threads is reviewed||STUB_REVIEWS_MODE=commented_at_head|rc=0 status=reviewed mode=review head_sha=headsha1 reviews_at_head=1' \
+  'a review at head with open threads returns comments before the deadline||STUB_REVIEWS_MODE=commented_at_head,STUB_THREADS_UNRESOLVED=2|rc=1 status=comments unresolved_count=2 early=true' \
+  'a review of a superseded commit is not at head||STUB_REVIEWS_MODE=commented_stale|rc=1 status=timeout reviews_at_head=0' \
+  "the author's own review is excluded||STUB_REVIEWS_MODE=author_only|rc=1 status=timeout reviews_at_head=0" \
+  'a DISMISSED review is excluded||STUB_REVIEWS_MODE=dismissed_only|rc=1 status=timeout reviews_at_head=0' \
+  'a standing CHANGES_REQUESTED blocks the review gate||STUB_REVIEWS_MODE=changes_standing|rc=1 status=changes_requested changes_requested=1' \
+  'a CHANGES_REQUESTED superseded by the same reviewer no longer stands||STUB_REVIEWS_MODE=changes_superseded|rc=0 status=reviewed changes_requested=0' \
+  'an APPROVED review at head is a review||STUB_REVIEWS_MODE=approved_at_head|rc=0 status=reviewed' \
+  'a review arriving on the second poll is picked up||STUB_REVIEWS_MODE=reviewed_later|rc=0 status=reviewed review_polls=2' \
+  'a trusted check-run success at head opens the gate||STUB_REVIEWS_MODE=none,STUB_CHECKS_MODE=success_at_head,PR_REVIEW_CHECK=Review Bot|rc=0 status=reviewed review_evidence=check review_evidence_surface=check_run reviews_at_head=0 head_sha=headsha1' \
+  'a check-run success on a stale sha is not evidence||STUB_REVIEWS_MODE=none,STUB_CHECKS_MODE=success_stale,PR_REVIEW_CHECK=Review Bot|rc=1 status=timeout' \
+  'a failed check-run conclusion is not evidence||STUB_REVIEWS_MODE=none,STUB_CHECKS_MODE=failure_at_head,PR_REVIEW_CHECK=Review Bot|rc=1 status=timeout' \
+  'check-run success with open threads returns comments||STUB_REVIEWS_MODE=none,STUB_CHECKS_MODE=success_at_head,PR_REVIEW_CHECK=Review Bot,STUB_THREADS_UNRESOLVED=2|rc=1 status=comments unresolved_count=2 early=true' \
+  'check-run success beside a standing CHANGES_REQUESTED still blocks||STUB_REVIEWS_MODE=changes_standing,STUB_CHECKS_MODE=success_at_head,PR_REVIEW_CHECK=Review Bot|rc=1 status=changes_requested' \
+  'an empty PR_REVIEW_CHECK ignores a check-run success||STUB_REVIEWS_MODE=none,STUB_CHECKS_MODE=success_at_head|rc=1 status=timeout' \
+  'a review object outranks the check surface with the feature on||STUB_REVIEWS_MODE=commented_at_head,STUB_CHECKS_MODE=none,PR_REVIEW_CHECK=Review Bot|rc=0 status=reviewed review_evidence=review review_evidence_surface=null reviews_at_head=1' \
+  'a trusted commit-status success at head opens the gate when no check-run matches||STUB_REVIEWS_MODE=none,STUB_CHECKS_MODE=none,STUB_STATUS_MODE=success_at_head,PR_REVIEW_CHECK=Review Bot|rc=0 status=reviewed review_evidence=check review_evidence_surface=status reviews_at_head=0 head_sha=headsha1' \
+  'a matching check-run wins and the status endpoint is never read||STUB_REVIEWS_MODE=none,STUB_CHECKS_MODE=success_at_head,STUB_STATUS_MODE=success_at_head,PR_REVIEW_CHECK=Review Bot|rc=0 review_evidence_surface=check_run status_queries=0' \
+  'a pending status is not evidence||STUB_REVIEWS_MODE=none,STUB_CHECKS_MODE=none,STUB_STATUS_MODE=pending_at_head,PR_REVIEW_CHECK=Review Bot|rc=1 status=timeout' \
+  'a failure status is not evidence||STUB_REVIEWS_MODE=none,STUB_CHECKS_MODE=none,STUB_STATUS_MODE=failure_at_head,PR_REVIEW_CHECK=Review Bot|rc=1 status=timeout' \
+  'an error status is not evidence||STUB_REVIEWS_MODE=none,STUB_CHECKS_MODE=none,STUB_STATUS_MODE=error_at_head,PR_REVIEW_CHECK=Review Bot|rc=1 status=timeout' \
+  'a status success on a stale sha is not evidence||STUB_REVIEWS_MODE=none,STUB_CHECKS_MODE=none,STUB_STATUS_MODE=success_stale,PR_REVIEW_CHECK=Review Bot|rc=1 status=timeout' \
+  'an empty PR_REVIEW_CHECK reads neither surface||STUB_REVIEWS_MODE=none,STUB_CHECKS_MODE=success_at_head,STUB_STATUS_MODE=success_at_head|rc=1 status=timeout status_queries=0' \
+  'a review object outranks a status success||STUB_REVIEWS_MODE=commented_at_head,STUB_CHECKS_MODE=none,STUB_STATUS_MODE=success_at_head,PR_REVIEW_CHECK=Review Bot|rc=0 review_evidence=review review_evidence_surface=null' \
+  'status success with open threads returns comments||STUB_REVIEWS_MODE=none,STUB_CHECKS_MODE=none,STUB_STATUS_MODE=success_at_head,PR_REVIEW_CHECK=Review Bot,STUB_THREADS_UNRESOLVED=2|rc=1 status=comments early=true'
+
+echo "=== PR_REVIEW_ON_TIMEOUT: a deadline degrades to proceeded only on reviewer silence over an unchanged head ==="
+# Silence is no review, no trusted check or status of any state, and no open
+# thread; the head is the one the wait started on, confirmed again at the
+# decision. Everything else at the deadline stays a timeout or its verdict,
+# and a proceed never manufactures review evidence: no commit status is
+# posted and the JSON carries no marker field even with an outage context
+# exported.
+table "$REVIEW" \
+  'no evidence and zero threads under proceed exits 0 as proceeded||STUB_REVIEWS_MODE=none,PR_REVIEW_ON_TIMEOUT=proceed|rc=0 status=proceeded unresolved_count=0' \
+  'the --on-timeout flag proceeds over the exported block|1 1 3 --json --mode review --on-timeout proceed|STUB_REVIEWS_MODE=none|rc=0 status=proceeded' \
+  'the unset default proceeds||-u,PR_REVIEW_ON_TIMEOUT,STUB_REVIEWS_MODE=none|rc=0 status=proceeded' \
+  'approval mode degrades the same way|1 1 3 --json|STUB_APPROVAL_MODE=none,PR_REVIEW_ON_TIMEOUT=proceed|rc=0 status=proceeded' \
+  'an unrecognized value falls back to block||STUB_REVIEWS_MODE=none,PR_REVIEW_ON_TIMEOUT=bogus|rc=1 status=timeout' \
+  'open threads still return comments under proceed||STUB_REVIEWS_MODE=none,STUB_THREADS_UNRESOLVED=2,PR_REVIEW_ON_TIMEOUT=proceed|rc=1 status=comments' \
+  'a standing CHANGES_REQUESTED still blocks under proceed||STUB_REVIEWS_MODE=changes_standing,PR_REVIEW_ON_TIMEOUT=proceed|rc=1 status=changes_requested' \
+  'an active COMMENTED review in approval mode is engagement, not silence|1 1 3 --json|STUB_APPROVAL_MODE=commented_only,PR_REVIEW_ON_TIMEOUT=proceed|rc=1 status=timeout' \
+  'a failed trusted check-run at head is engagement, not silence||STUB_REVIEWS_MODE=none,STUB_CHECKS_MODE=failure_at_head,PR_REVIEW_CHECK=Review Bot,PR_REVIEW_ON_TIMEOUT=proceed|rc=1 status=timeout' \
+  'a pending trusted status at head is engagement, not silence||STUB_REVIEWS_MODE=none,STUB_STATUS_MODE=pending_at_head,PR_REVIEW_CHECK=Review Bot,PR_REVIEW_ON_TIMEOUT=proceed|rc=1 status=timeout' \
+  'a head that moved during the wait falls back to timeout even when the confirm agrees with the new head|1 1 5 --json --mode review|STUB_REVIEWS_MODE=none,STUB_HEAD_MODE=changes,STUB_CONFIRM_HEAD=headsha2,PR_REVIEW_ON_TIMEOUT=proceed|rc=1 status=timeout' \
+  'a head that moved in the last-poll to emit window falls back to timeout||STUB_REVIEWS_MODE=none,STUB_CONFIRM_HEAD=headsha2,PR_REVIEW_ON_TIMEOUT=proceed|rc=1 status=timeout' \
+  'a proceed posts no commit status and emits no outage marker||STUB_REVIEWS_MODE=none,PR_REVIEW_ON_TIMEOUT=proceed,PR_REVIEW_OUTAGE_CONTEXT=kendex-reviewer-outage|rc=0 status=proceeded marker_posts=0 outage_marker=false'
+
+echo "=== transient GitHub API failures are retried inside the budget and counted ==="
+# A 5xx or 429 from the reviews listing, or from the approval-mode pr view, is
+# absorbed with backoff and reported as transient_api_errors on the eventual
+# result; one that never clears becomes terminal only when the budget is
+# spent. A 404 is terminal at once and carries no count.
+table "$REVIEW" \
+  '503 twice then a review at head is reviewed with the count||STUB_REVIEWS_MODE=flaky_503|rc=0 status=reviewed transient_api_errors=2 review_polls=3' \
+  '429 twice then a review at head is reviewed with the count||STUB_REVIEWS_MODE=flaky_429|rc=0 status=reviewed transient_api_errors=2' \
+  'a persistent 503 is an error only once the budget is spent||STUB_REVIEWS_MODE=http_503|rc=1 status=error transient_errors_seen=true spent=true' \
+  'a 404 is terminal at once with no transient count||STUB_REVIEWS_MODE=http_404|rc=1 status=error transient_api_errors=null early=true' \
+  'approval-mode pr view 503s then an approval is approved with the count|1 1 3 --json|STUB_APPROVAL_MODE=approved_after_503|rc=0 status=approved transient_api_errors=2'
+
+echo "=== text mode prints a result line for every terminal status ==="
+# The line's wording is not a contract anything parses; what holds is that no
+# terminal status leaves stdout empty, with the same exit code as --json.
+table '1 1 3' \
+  'approved||STUB_APPROVAL_MODE=approved_decision|rc=0 stdout=line' \
+  'changes requested||STUB_APPROVAL_MODE=changes|rc=1 stdout=line' \
+  'comments||STUB_APPROVAL_MODE=none,STUB_THREADS_UNRESOLVED=2|rc=1 stdout=line' \
+  'timeout||STUB_APPROVAL_MODE=none|rc=1 stdout=line' \
+  'error||GH_TOKEN=bad-token,STUB_GH_DENY_KEYRING=1|rc=3 stdout=line' \
+  'reviewed via a check-run|1 1 3 --mode review|STUB_REVIEWS_MODE=none,STUB_CHECKS_MODE=success_at_head,PR_REVIEW_CHECK=Review Bot|rc=0 stdout=line' \
+  'proceeded|1 1 3 --mode review|STUB_REVIEWS_MODE=none,PR_REVIEW_ON_TIMEOUT=proceed|rc=0 stdout=line'
+
+echo "=== PR_REVIEW_WAIT_SECS: an absent max_wait positional resolves through orch-env ==="
+# Process env beats kendex.settings.toml [env], and an explicit positional
+# beats both; each row's deadline is one it could not have reached from the
+# 900s built-in default. The settings file is this case's private fixture.
+# Row: `label|settings value or empty|args|env|expect`.
+waitsecs_rows=(
+  'the env value drives the deadline||1 1 --json|STUB_APPROVAL_MODE=none,PR_REVIEW_WAIT_SECS=1|rc=1 status=timeout early=true'
+  'the settings-file value applies when the env is silent|1|1 1 --json|STUB_APPROVAL_MODE=none|rc=1 status=timeout early=true'
+  'the env value outlives the settings file|1|1 1 --json|STUB_APPROVAL_MODE=none,PR_REVIEW_WAIT_SECS=3|rc=1 status=timeout spent=true'
+  'an explicit positional wins over the setting|600|1 1 3 --json|STUB_APPROVAL_MODE=none|rc=1 status=timeout spent=true'
+)
+for row in "${waitsecs_rows[@]}"; do
+  IFS='|' read -r label setting args env expect <<<"$row"
+  rm -f "$TMP_ROOT/repo/kendex.settings.toml"
+  [[ -z "$setting" ]] || printf '[env]\nPR_REVIEW_WAIT_SECS = "%s"\n' "$setting" >"$TMP_ROOT/repo/kendex.settings.toml"
+  # shellcheck disable=SC2086
+  run_wait "$env" $args
+  assert_eq "$(observe "$expect")" "$expect" "waitsecs: $label" "$RUN/stderr"
+done
 rm -f "$TMP_ROOT/repo/kendex.settings.toml"
 
-# Numeric-default guard (orch-env layer): a non-numeric setting value falls
-# back to the numeric default instead of poisoning the deadline arithmetic.
-guard_out="$( (cd "$TMP_ROOT/repo" && PATH="$TMP_ROOT/bin:$PATH" \
-  env PR_REVIEW_WAIT_SECS=soon .agents/skills/orch/scripts/orch-env PR_REVIEW_WAIT_SECS 900) )"
-assert_eq "$guard_out" "900" "waitsecs: non-numeric value falls back to the numeric default"
-
 echo "=== a failed emit_result never reports a successful gate ==="
-
-# The waiter must never exit 0 having written no result. emit_result builds the
-# --json object with `jq -n`, so this stub fails EXACTLY that call and passes
-# every parse through to the real jq: the emission fails while the poll that
-# reached the approved verdict succeeds — a closed pipe or a write failure.
+# emit_result builds the --json object with `jq -n`, so this stub fails
+# EXACTLY that call and passes every parse through to the real jq: the
+# emission fails while the poll that reached the verdict succeeds — a closed
+# pipe or a write failure. Each emit site must propagate jq's status 5 and
+# write nothing: the two run_approved_gate sites, and the bare deadline
+# `emit_result "timeout"` where nothing but errexit stands before `exit 1`,
+# so a 1 there would mean a `set +e` had migrated above the emit.
 REAL_JQ="$(command -v jq)"
 cat > "$TMP_ROOT/bin/jq" <<EOF
 #!/usr/bin/env bash
@@ -1278,73 +553,15 @@ fi
 exec "$REAL_JQ" "\$@"
 EOF
 chmod +x "$TMP_ROOT/bin/jq"
-
-# run_approved_gate has two call sites, each of which must propagate a failed
-# emission. First: the reviewDecision site, GitHub reporting the PR APPROVED.
-stderr="$TMP_ROOT/emitfail.err"
-set +e
-output=$( (cd "$TMP_ROOT/repo" && PATH="$TMP_ROOT/bin:$PATH" \
-  env STUB_APPROVAL_MODE=approved_decision \
-    .agents/skills/orch/scripts/approval-wait 1 1 3 --json) 2>"$stderr")
-emitfail_code=$?
-set -e
-if [ "$emitfail_code" -ne 0 ]; then
-  pass "a failed emit_result at the reviewDecision gate site does not exit 0 (exit $emitfail_code)"
-else
-  FAIL=$((FAIL + 1))
-  printf '  FAIL  %s\n        exit was 0 with stdout: %s\n' \
-    "a failed emit_result at the reviewDecision gate site does not exit 0" "$output"
-  dump_stderr "$stderr"
-fi
-if [ -z "$output" ]; then
-  pass "a failed emit_result at the reviewDecision gate site writes no result to stdout"
-else
-  FAIL=$((FAIL + 1))
-  printf '  FAIL  %s\n        stdout: %s\n' "a failed emit_result at the reviewDecision gate site writes no result to stdout" "$output"
-fi
-assert_contains "$(cat "$stderr")" "could not emit the gate result" "the reviewDecision gate site names the emission failure on stderr"
-
-# Second: the latestReviews site — no reviewDecision, a reviewer's latest
-# review APPROVED. Each site reads the gate's status, disabling errexit.
-stderr="$TMP_ROOT/emitfail-gate.err"
-set +e
-output=$( (cd "$TMP_ROOT/repo" && PATH="$TMP_ROOT/bin:$PATH" \
-  env STUB_APPROVAL_MODE=approved_latest \
-    .agents/skills/orch/scripts/approval-wait 1 1 3 --json) 2>"$stderr")
-gate_emitfail_code=$?
-set -e
-if [ "$gate_emitfail_code" -ne 0 ]; then
-  pass "a failed emit_result at the latestReviews gate site does not exit 0 (exit $gate_emitfail_code)"
-else
-  FAIL=$((FAIL + 1))
-  printf '  FAIL  %s\n        exit was 0 with stdout: %s\n' \
-    "a failed emit_result at the latestReviews gate site does not exit 0" "$output"
-  dump_stderr "$stderr"
-fi
-assert_contains "$(cat "$stderr")" "could not emit the gate result" \
-  "the latestReviews gate site names the emission failure on stderr"
-
-# The deadline's `emit_result "timeout"` is a BARE call followed by `exit 1`,
-# so nothing but errexit stands between a failed emission and that exit 1.
-# Exit 5 (jq's status) proves errexit was in force there; a 1 would mean a
-# `set +e` had migrated above the emit and the propagation was undone.
-stderr="$TMP_ROOT/emitfail-timeout.err"
-set +e
-output=$( (cd "$TMP_ROOT/repo" && PATH="$TMP_ROOT/bin:$PATH" \
-  env STUB_APPROVAL_MODE=none \
-    .agents/skills/orch/scripts/approval-wait 1 1 2 --json) 2>"$stderr")
-timeout_emitfail_code=$?
-set -e
-assert_eq "$timeout_emitfail_code" "5" \
-  "a failed emit_result on the bare timeout path propagates jq's status (errexit in force)" "$stderr"
-
+table "$APPROVAL" \
+  'emit failure at the reviewDecision gate site||STUB_APPROVAL_MODE=approved_decision|rc=5 stdout=empty' \
+  'emit failure at the latestReviews gate site||STUB_APPROVAL_MODE=approved_latest|rc=5 stdout=empty' \
+  'emit failure on the bare timeout path|1 1 2 --json|STUB_APPROVAL_MODE=none|rc=5 stdout=empty'
 rm -f "$TMP_ROOT/bin/jq"
-
-# Control: with the real jq back, the same invocations DO reach exit 0 — so the
-# two assertions above are proving the emission failure, not a broken fixture.
-output=$(run_wait_json STUB_APPROVAL_MODE=approved_decision 2>"$TMP_ROOT/emitok.err")
-assert_eq "$(json_field "$output" '.status')" "approved" \
-  "control: the same poll approves once emission works again" "$TMP_ROOT/emitok.err"
+# Control: with the real jq back the same poll approves, so the rows above
+# prove the emission failure and not a broken fixture.
+table "$APPROVAL" \
+  'control: the same poll approves once emission works||STUB_APPROVAL_MODE=approved_decision|rc=0 status=approved'
 
 echo
 printf 'pass: %d   fail: %d\n' "$PASS" "$FAIL"

--- a/skills/orch/tests/approval_wait.sh
+++ b/skills/orch/tests/approval_wait.sh
@@ -404,6 +404,7 @@ table() {
   shift
   for row in "$@"; do
     IFS='|' read -r label args env expect <<<"$row"
+    [[ -n "$expect" ]] || { printf 'table: a row with no expect asserts nothing: %s\n' "$row" >&2; exit 1; }
     [[ -n "$args" ]] || args="$default_args"
     # shellcheck disable=SC2086
     run_wait "$env" $args
@@ -456,7 +457,6 @@ table "$REVIEW" \
   'a failed check-run conclusion is not evidence||STUB_REVIEWS_MODE=none,STUB_CHECKS_MODE=failure_at_head,PR_REVIEW_CHECK=Review Bot|rc=1 status=timeout' \
   'check-run success with open threads returns comments||STUB_REVIEWS_MODE=none,STUB_CHECKS_MODE=success_at_head,PR_REVIEW_CHECK=Review Bot,STUB_THREADS_UNRESOLVED=2|rc=1 status=comments unresolved_count=2 early=true' \
   'check-run success beside a standing CHANGES_REQUESTED still blocks||STUB_REVIEWS_MODE=changes_standing,STUB_CHECKS_MODE=success_at_head,PR_REVIEW_CHECK=Review Bot|rc=1 status=changes_requested' \
-  'an empty PR_REVIEW_CHECK ignores a check-run success||STUB_REVIEWS_MODE=none,STUB_CHECKS_MODE=success_at_head|rc=1 status=timeout' \
   'a review object outranks the check surface with the feature on||STUB_REVIEWS_MODE=commented_at_head,STUB_CHECKS_MODE=none,PR_REVIEW_CHECK=Review Bot|rc=0 status=reviewed review_evidence=review review_evidence_surface=null reviews_at_head=1' \
   'a trusted commit-status success at head opens the gate when no check-run matches||STUB_REVIEWS_MODE=none,STUB_CHECKS_MODE=none,STUB_STATUS_MODE=success_at_head,PR_REVIEW_CHECK=Review Bot|rc=0 status=reviewed review_evidence=check review_evidence_surface=status reviews_at_head=0 head_sha=headsha1' \
   'a matching check-run wins and the status endpoint is never read||STUB_REVIEWS_MODE=none,STUB_CHECKS_MODE=success_at_head,STUB_STATUS_MODE=success_at_head,PR_REVIEW_CHECK=Review Bot|rc=0 review_evidence_surface=check_run status_queries=0' \
@@ -502,31 +502,43 @@ table "$REVIEW" \
   'a 404 is terminal at once with no transient count||STUB_REVIEWS_MODE=http_404|rc=1 status=error transient_api_errors=null early=true' \
   'approval-mode pr view 503s then an approval is approved with the count|1 1 3 --json|STUB_APPROVAL_MODE=approved_after_503|rc=0 status=approved transient_api_errors=2'
 
-echo "=== text mode prints a result line for every terminal status ==="
+echo "=== text mode prints a result line for every branch the emitter has ==="
 # The line's wording is not a contract anything parses; what holds is that no
-# terminal status leaves stdout empty, with the same exit code as --json.
+# terminal status leaves stdout empty, with the same exit code as --json. The
+# emitter branches per mode for every status and per evidence surface for
+# reviewed, so each branch is a row.
+TEXT_REVIEW='1 1 3 --mode review'
 table '1 1 3' \
-  'approved||STUB_APPROVAL_MODE=approved_decision|rc=0 stdout=line' \
-  'changes requested||STUB_APPROVAL_MODE=changes|rc=1 stdout=line' \
-  'comments||STUB_APPROVAL_MODE=none,STUB_THREADS_UNRESOLVED=2|rc=1 stdout=line' \
-  'timeout||STUB_APPROVAL_MODE=none|rc=1 stdout=line' \
-  'error||GH_TOKEN=bad-token,STUB_GH_DENY_KEYRING=1|rc=3 stdout=line' \
-  'reviewed via a check-run|1 1 3 --mode review|STUB_REVIEWS_MODE=none,STUB_CHECKS_MODE=success_at_head,PR_REVIEW_CHECK=Review Bot|rc=0 stdout=line' \
-  'proceeded|1 1 3 --mode review|STUB_REVIEWS_MODE=none,PR_REVIEW_ON_TIMEOUT=proceed|rc=0 stdout=line'
+  'approval: approved||STUB_APPROVAL_MODE=approved_decision|rc=0 stdout=line' \
+  'approval: changes requested||STUB_APPROVAL_MODE=changes|rc=1 stdout=line' \
+  'approval: comments||STUB_APPROVAL_MODE=none,STUB_THREADS_UNRESOLVED=2|rc=1 stdout=line' \
+  'approval: timeout||STUB_APPROVAL_MODE=none|rc=1 stdout=line' \
+  'approval: error||GH_TOKEN=bad-token,STUB_GH_DENY_KEYRING=1|rc=3 stdout=line' \
+  'approval: proceeded||STUB_APPROVAL_MODE=none,PR_REVIEW_ON_TIMEOUT=proceed|rc=0 stdout=line' \
+  "review: reviewed via a review object|$TEXT_REVIEW|STUB_REVIEWS_MODE=commented_at_head|rc=0 stdout=line" \
+  "review: reviewed via a check-run|$TEXT_REVIEW|STUB_REVIEWS_MODE=none,STUB_CHECKS_MODE=success_at_head,PR_REVIEW_CHECK=Review Bot|rc=0 stdout=line" \
+  "review: reviewed via a commit status|$TEXT_REVIEW|STUB_REVIEWS_MODE=none,STUB_STATUS_MODE=success_at_head,PR_REVIEW_CHECK=Review Bot|rc=0 stdout=line" \
+  "review: changes requested|$TEXT_REVIEW|STUB_REVIEWS_MODE=changes_standing|rc=1 stdout=line" \
+  "review: comments|$TEXT_REVIEW|STUB_REVIEWS_MODE=commented_at_head,STUB_THREADS_UNRESOLVED=2|rc=1 stdout=line" \
+  "review: timeout|$TEXT_REVIEW|STUB_REVIEWS_MODE=none|rc=1 stdout=line" \
+  "review: error|$TEXT_REVIEW|GH_TOKEN=bad-token,STUB_GH_DENY_KEYRING=1|rc=3 stdout=line" \
+  "review: proceeded|$TEXT_REVIEW|STUB_REVIEWS_MODE=none,PR_REVIEW_ON_TIMEOUT=proceed|rc=0 stdout=line"
 
 echo "=== PR_REVIEW_WAIT_SECS: an absent max_wait positional resolves through orch-env ==="
 # Process env beats kendex.settings.toml [env], and an explicit positional
-# beats both; each row's deadline is one it could not have reached from the
-# 900s built-in default. The settings file is this case's private fixture.
+# beats both. On the virtual clock a timeout lands on its deadline exactly, so
+# each row pins the deadline it resolved, none of them the 900s built-in
+# default. The settings file is this case's private fixture.
 # Row: `label|settings value or empty|args|env|expect`.
 waitsecs_rows=(
-  'the env value drives the deadline||1 1 --json|STUB_APPROVAL_MODE=none,PR_REVIEW_WAIT_SECS=1|rc=1 status=timeout early=true'
-  'the settings-file value applies when the env is silent|1|1 1 --json|STUB_APPROVAL_MODE=none|rc=1 status=timeout early=true'
-  'the env value outlives the settings file|1|1 1 --json|STUB_APPROVAL_MODE=none,PR_REVIEW_WAIT_SECS=3|rc=1 status=timeout spent=true'
-  'an explicit positional wins over the setting|600|1 1 3 --json|STUB_APPROVAL_MODE=none|rc=1 status=timeout spent=true'
+  'the env value drives the deadline||1 1 --json|STUB_APPROVAL_MODE=none,PR_REVIEW_WAIT_SECS=1|rc=1 status=timeout elapsed_seconds=1'
+  'the settings-file value applies when the env is silent|1|1 1 --json|STUB_APPROVAL_MODE=none|rc=1 status=timeout elapsed_seconds=1'
+  'the env value outlives the settings file|1|1 1 --json|STUB_APPROVAL_MODE=none,PR_REVIEW_WAIT_SECS=3|rc=1 status=timeout elapsed_seconds=3'
+  'an explicit positional wins over the setting|600|1 1 3 --json|STUB_APPROVAL_MODE=none|rc=1 status=timeout elapsed_seconds=3'
 )
 for row in "${waitsecs_rows[@]}"; do
   IFS='|' read -r label setting args env expect <<<"$row"
+  [[ -n "$expect" ]] || { printf 'waitsecs: a row with no expect asserts nothing: %s\n' "$row" >&2; exit 1; }
   rm -f "$TMP_ROOT/repo/kendex.settings.toml"
   [[ -z "$setting" ]] || printf '[env]\nPR_REVIEW_WAIT_SECS = "%s"\n' "$setting" >"$TMP_ROOT/repo/kendex.settings.toml"
   # shellcheck disable=SC2086

--- a/tools/guard
+++ b/tools/guard
@@ -349,8 +349,16 @@ if [ "$FULL" -eq 1 ]; then
   if git rev-parse --verify -q origin/main >/dev/null; then
     suites_base=$(git merge-base HEAD origin/main) || suites_base=HEAD
   fi
-  touched=$({ git -c core.quotePath=false diff --name-only "$suites_base" --; git -c core.quotePath=false status --porcelain --untracked-files=all | cut -c4- | sed 's/^.* -> //'; } | sort -u) ||
-    say "the touched-file set for the suite lane could not be read"
+  # --no-renames: a move between two trees names its source and its
+  # destination, so the tree a file left runs its suite too. Each read checks
+  # its own status; a group's status is its last command's, which would let a
+  # failed diff pass on a good `git status`. The status read adds what the
+  # diff against the working tree cannot see: untracked files.
+  branch_touched=$(git -c core.quotePath=false diff --no-renames --name-only "$suites_base" --) ||
+    { branch_touched=""; say "the touched-file set for the suite lane could not be read (branch diff)"; }
+  tree_touched=$(git -c core.quotePath=false status --porcelain --untracked-files=all | cut -c4- | sed 's/^.* -> //') ||
+    { tree_touched=""; say "the touched-file set for the suite lane could not be read (working tree)"; }
+  touched=$(printf '%s\n%s\n' "$branch_touched" "$tree_touched" | sort -u)
   suite_dirs=""
   while IFS= read -r f; do
     [ -n "$f" ] || continue

--- a/tools/guard
+++ b/tools/guard
@@ -358,7 +358,8 @@ if [ "$FULL" -eq 1 ]; then
     { branch_touched=""; say "the touched-file set for the suite lane could not be read (branch diff)"; }
   tree_touched=$(git -c core.quotePath=false status --porcelain --untracked-files=all | cut -c4- | sed 's/^.* -> //') ||
     { tree_touched=""; say "the touched-file set for the suite lane could not be read (working tree)"; }
-  touched=$(printf '%s\n%s\n' "$branch_touched" "$tree_touched" | sort -u)
+  touched=$(printf '%s\n%s\n' "$branch_touched" "$tree_touched" | sort -u) ||
+    { touched=""; say "the touched-file set for the suite lane could not be read (merge)"; }
   suite_dirs=""
   while IFS= read -r f; do
     [ -n "$f" ] || continue

--- a/tools/tests/guard.test.sh
+++ b/tools/tests/guard.test.sh
@@ -370,6 +370,71 @@ fi
 FULL_GUARD=0
 git -C "$R" checkout -q -- skills .agents
 
+# The touched set is the branch diff against origin/main plus the working
+# tree. A move out of one tree into another, committed past origin/main so the
+# working tree is clean and the branch diff is the only read that sees it,
+# names the tree it left: that tree's suite runs.
+FULL_GUARD=1
+suite_lane_head="$(git -C "$R" rev-parse HEAD)"
+mkdir -p "$R/skills/quiet/scripts"
+printf '#!/usr/bin/env bash\necho quiet\n' >"$R/skills/quiet/scripts/quiet.sh"
+# A second script stays behind so the move leaves no empty roster directory.
+printf '#!/usr/bin/env bash\necho stays\n' >"$R/skills/quiet/scripts/stays.sh"
+git -C "$R" add skills/quiet
+git -C "$R" commit -q -m "chore: a script in the quiet skill"
+git -C "$R" update-ref refs/remotes/origin/main HEAD
+git -C "$R" mv skills/quiet/scripts/quiet.sh hooks/quiet.sh
+git -C "$R" commit -q -m "chore: move the quiet script into hooks"
+run_guard
+[ "$RC" != 0 ] && [[ "$OUT" == *"skills/quiet suite failed"* ]] \
+  && ok "a committed move out of a skill runs the suite of the tree it left" \
+  || bad "a committed move out of a skill runs the suite of the tree it left" "rc=$RC out=$OUT"
+if mutant_guard 's/diff --no-renames --name-only "\$suites_base"/diff --name-only "$suites_base"/'; then
+  OUT=""
+  RC=0
+  OUT="$(cd "$R" && "$MUTANT_TOOLS/guard" --full 2>&1)" || RC=$?
+  [ "$RC" -eq 0 ] \
+    && ok "control: with rename detection back on the branch diff the source tree's suite stays silent" \
+    || bad "control: with rename detection back on the branch diff the source tree's suite stays silent" "rc=$RC out=$OUT"
+else
+  bad "control: --no-renames could not be removed from the branch diff in a guard copy"
+fi
+
+# A branch diff that fails must red the lane by itself: the working-tree read
+# beside it succeeds, so only the diff's own status can carry the failure.
+git -C "$R" update-ref refs/remotes/origin/main HEAD
+cat >"$R/fake-bin/git" <<'SH'
+#!/usr/bin/env bash
+set -euo pipefail
+is_suite_diff=0
+last=""
+for arg in "$@"; do last="$arg"; done
+if [[ " $* " == *" diff "* && " $* " == *" --no-renames "* && "$last" == "--" ]]; then
+  is_suite_diff=1
+fi
+[ "${FAIL_SUITE_DIFF:-0}" -eq 1 ] && [ "$is_suite_diff" -eq 1 ] && exit 2
+exec "$REAL_GIT" "$@"
+SH
+chmod +x "$R/fake-bin/git"
+run_guard PATH="$R/fake-bin:$PATH" REAL_GIT="$REAL_GIT" FAIL_SUITE_DIFF=1
+[ "$RC" != 0 ] && [[ "$OUT" == *"the touched-file set for the suite lane could not be read"* ]] \
+  && ok "a failed branch diff reds the suite lane beside a good working-tree read" \
+  || bad "a failed branch diff reds the suite lane beside a good working-tree read" "rc=$RC out=$OUT"
+if mutant_guard 's/{ branch_touched=""; say "the touched-file set for the suite lane could not be read (branch diff)"; }/branch_touched=""/'; then
+  OUT=""
+  RC=0
+  OUT="$(cd "$R" && PATH="$R/fake-bin:$PATH" REAL_GIT="$REAL_GIT" FAIL_SUITE_DIFF=1 "$MUTANT_TOOLS/guard" --full 2>&1)" || RC=$?
+  [ "$RC" -eq 0 ] \
+    && ok "control: with the diff's status unchecked the failed diff passes" \
+    || bad "control: with the diff's status unchecked the failed diff passes" "rc=$RC out=$OUT"
+else
+  bad "control: the branch diff's status check could not be removed from a guard copy"
+fi
+rm -f "$R/fake-bin/git"
+git -C "$R" reset -q --hard "$suite_lane_head"
+git -C "$R" update-ref -d refs/remotes/origin/main
+FULL_GUARD=0
+
 BASH4_LINE='mapfile -t demo_lines <"$0"'
 printf '%s\n' "$BASH4_LINE" >>"$R/skills/demo/tests/demo.test.sh"
 printf '%s\n' "$BASH4_LINE" >>"$R/.agents/skills/demo/tests/demo.test.sh"


### PR DESCRIPTION
Tests audit, second file (wave 2, `BRIEF-TESTS-AUDIT.md`): `skills/orch/tests/approval_wait.sh`, 1,351 lines and 209 assertions in one linear script, judged against code-quality § Tests. Carries the two owed fixes from #2175's bot triage. Held for the overseer.

## What changed

- **One table per behaviour surface, one asserted row per shape.** Seven tables: approval-mode verdicts, review-mode evidence (review objects, check-runs, commit statuses), `PR_REVIEW_ON_TIMEOUT`, transient API failures, text mode (one row per emit branch), `PR_REVIEW_WAIT_SECS` resolution, failed emission. A row is `label|args|env|expect`; `observe` reads exactly the fields the expect names, so a row fails on the field it names, and a row with no expect is refused. 74 rows, 574 lines. The `gh` stub is unchanged apart from two modes no case selected.
- **Dropped pins.** Text-line wording (`Approval: ...`, `Review: ...`, `proceeding per ...`, `check-run '...'`, `via status '...'`): nothing under `skills/orch` outside tests parses the text lines (every documented call uses `--json`). The `.error` and stderr substrings (`auth`, `review listing failed`, `transient GitHub error`, `unrecognized PR_REVIEW_ON_TIMEOUT value`, `could not emit the gate result`): diagnostics, not a parsed contract; the exit status and status field carry each fact. The orch-env numeric-default guard: a duplicate of `orch_env.sh` Test 5.
- **Tightened.** The "head moved during the wait" row now sets the confirm head to the moved head. The old proceed10 was satisfied by the emit-time confirm alone, so the during-wait guard was unproven: a mutation deleting it survived until this change.
- **Hermetic timing.** Every timeout row runs on a 3-second virtual budget and the `PR_REVIEW_WAIT_SECS` rows pin `elapsed_seconds` exactly, so a resolution that ignored the positional or the settings file fails on the number.
- **Owed from #2175.** `tools/guard`, the `--full` suite lane's touched-set collector: `--no-renames` on the branch diff, so a move between two trees names the tree it left and that suite runs; each read checks its own status (a failed diff was masked by the group's status, which was `git status`'s); the merge checks its own too. Two `guard.test.sh` cases with mutant controls (72 to 76 ok). `.github/workflows/skill-tests.yml`: the Skill suites aggregator comment names the two events it runs on. The `.kendex-generated.json` line for `open-terminal-mode.sh` landed through #2181 meanwhile and drops out at rebase.

## Folded cases and the row that fails when the behaviour breaks

| Former case | Surviving row |
|---|---|
| case1 reviewDecision APPROVED | reviewDecision APPROVED approves |
| case2 latestReviews fallback | no reviewDecision, a latest APPROVED approves via latestReviews |
| case3 CHANGES_REQUESTED beside an approval | a latest CHANGES_REQUESTED blocks beside another approval |
| case4 COMMENTED-only | COMMENTED-only latest reviews are no verdict |
| case5 unresolved threads, no verdict | open threads with no verdict return comments before the deadline |
| case6 nothing at the deadline | nothing at the deadline is a timeout |
| case7 REVIEW_REQUIRED | REVIEW_REQUIRED keeps a latest APPROVED from approving |
| case8 approved with open threads | approved with open threads stays approved and carries the count |
| case9 verdict on a later poll | a verdict arriving on the second poll approves |
| case10 auth failure --json | an auth failure is a parseable error object |
| case11, 11b-11e, case21, 21b-21e, check8, status8, proceed7 (text lines) | text mode: one row per emit branch (14 rows) |
| case12-19 review mode | review mode table, one row each (COMMENTED at head, open threads, stale commit, author, DISMISSED, standing CHANGES_REQUESTED, superseded, APPROVED) |
| case20 review on a later poll | a review arriving on the second poll is picked up |
| check1-7 | review mode table: trusted check-run success at head; stale sha; failed conclusion; open threads; standing CHANGES_REQUESTED; review object outranks the check surface |
| check6 empty PR_REVIEW_CHECK ignores check-runs | an empty PR_REVIEW_CHECK reads neither surface (check6 was a strict subset of status5 on the same input) |
| status1-7 | review mode table: status success when no check-run matches; check-run wins and the status endpoint is never read; pending, failure, error; stale sha; empty PR_REVIEW_CHECK reads neither surface; review object outranks a status; open threads |
| proceed1-13, marker1 | PR_REVIEW_ON_TIMEOUT table, one row each; marker1 is the row `a proceed posts no commit status and emits no outage marker` |
| transient1, 1b, 2, 3, 4 | transient table, one row each |
| waitsecs1-4 | PR_REVIEW_WAIT_SECS rows, one each, pinning `elapsed_seconds` |
| waitsecs numeric-default guard | deleted: `orch_env.sh` Test 5 covers orch-env's non-numeric fallback |
| emitfail x3 + control | failed emission rows (exit 5, empty stdout) and the control row |

## Mutations against `skills/orch/scripts/approval-wait`, one per table

COMMENTED counted as an approval (3 rows red); author exclusion dropped from the head count (1 red); the during-wait head guard dropped (1 red after the tightening above; 0 before); HTTP 404 treated as transient (1 red); the approved text line blanked (1 red); the `PR_REVIEW_WAIT_SECS` resolution replaced by a constant (2 red); the bare timeout emit given `|| true` (1 red). Script restored after each.

## Checks

`approval_wait.sh` 74 pass / 0 fail; `tools/tests/guard.test.sh` 76 ok / 0 fail (baseline 72); `tools/bash32-lint` clean; pre-commit chain on each commit. One reviewer-test round: its three blockers (six review-mode text branches unpinned, a waitsecs row that could not fail, an empty expect passing) and two of three suggestions (a subset row, the unchecked merge in the guard) are in the second commit; restoring the `could not emit the gate result` stderr pin is not taken: the exit status and empty stdout are the contract, the wording is a diagnostic nothing parses.

Remaining files for this audit are in the status file. Tracking: KEN-1241.

https://claude.ai/code/session_01PSdX2AT5yWYYBbBBjbAUnP
