### PR TITLE
feat(KEN-1252): the chain runs the staged bot-instructions check

### DIFF
--- a/.agents/skills/bot-instructions/SKILL.md
+++ b/.agents/skills/bot-instructions/SKILL.md
@@ -31,7 +31,7 @@ Problems with a kendex-owned skill go through `kendex report`; check ownership i
 
 Flags: `--repo`, `--spec`, `--staged`, `--dry-run`; `bot-instructions --help`. Python 3.11+.
 
-Exit codes: 0 clean, 1 findings, 2 could not complete. A pre-commit lane blocks on both nonzero codes.
+Exit codes: 0 clean, 1 findings, 2 could not complete. A pre-commit lane blocks on both nonzero codes; the `commit-guards` chain runs `check --staged` itself where this package is installed.
 
 ## What reads what
 

--- a/.agents/skills/bot-instructions/references/checklist.md
+++ b/.agents/skills/bot-instructions/references/checklist.md
@@ -3,7 +3,7 @@
 ## Before the first pass
 
 - [ ] `python3 --version` is 3.11 or newer where the verbs run — locally and on whatever runs this repo's guards. The generator needs `tomllib` and nothing else, and it refuses to start on an older one rather than half-parsing a TOML.
-- [ ] `check` is wired into whatever runs this repo's other guards, with `--staged` in the commit lane so it judges one coherent staged state. This package ships no hook of its own: a repo that already has a commit chain does not need a second one.
+- [ ] `check --staged` runs at commit. Where `commit-guards` is installed its pre-commit chain runs it as a lane; write no wrapper for it. Elsewhere, wire `check --staged` into whatever runs this repo's other guards so it judges one coherent staged state.
 
 ## Adding a repo
 

--- a/.agents/skills/commit-guards/DEVELOPMENT.md
+++ b/.agents/skills/commit-guards/DEVELOPMENT.md
@@ -51,8 +51,9 @@ The installer writes into `.git/hooks`, never `core.hooksPath`:
 
 1. `doc-limits --staged` for document byte ceilings, from the committing work tree's copy first, then this install's; a stated skip where neither exists or the repo-local one rejects `--staged` in its first-line parser diagnostic.
 2. `preflight --staged`, resolved the same way; a first commit skips it with a note.
-3. `commit-guards all --staged`.
-4. The repo-root-relative executable `COMMIT_GUARDS_PRE_COMMIT_LOCAL` names, when set.
+3. `bot-instructions check --staged`, resolved the same way, so no consumer carries a wrapper for it.
+4. `commit-guards all --staged`.
+5. The repo-root-relative executable `COMMIT_GUARDS_PRE_COMMIT_LOCAL` names, when set.
 
 Every step runs before the verdict; any other companion failure blocks. The shims fail closed on `2` for a guard that could not run, naming what is missing.
 

--- a/.agents/skills/commit-guards/SKILL.md
+++ b/.agents/skills/commit-guards/SKILL.md
@@ -23,8 +23,9 @@ repo-effects:
   companions:
     - "doc-limits"
     - "preflight"
+    - "bot-instructions"
   notes:
-    - "A missing companion is announced and skipped, as is a repo-local doc-limits that rejects --staged and preflight on a first commit; every other companion or guard failure blocks the commit."
+    - "A missing companion is announced and skipped, as is a repo-local doc-limits that rejects --staged and preflight on a first commit; every other companion or guard failure blocks the commit, a bot-instructions check that finds a stale render included."
     - "Both hooks block on nonzero results; Git's no-verify flag bypasses both for one commit."
     - "Git does not clone hooks; arm every clone once."
 ---
@@ -71,7 +72,7 @@ Exit codes: `0` clean, `1` violations, `2` usage, configuration, or collection e
 
 Run `scripts/install-git-hooks [--repo PATH]` to arm the shims.
 
-Pre-commit order: `doc-limits --staged` when installed -> `preflight --staged` when installed -> `commit-guards all --staged` -> `COMMIT_GUARDS_PRE_COMMIT_LOCAL` when configured. `commit-msg` runs the message gate.
+Pre-commit order: `doc-limits --staged` when installed -> `preflight --staged` when installed -> `bot-instructions check --staged` when installed -> `commit-guards all --staged` -> `COMMIT_GUARDS_PRE_COMMIT_LOCAL` when configured. `commit-msg` runs the message gate.
 
 Arming and disarming apply to the whole repository. Disarm before removing the skill. Ownership and layering: [README.md § Git hooks](README.md#git-hooks); install mechanics: [DEVELOPMENT.md § Git hook install contract](DEVELOPMENT.md#git-hook-install-contract).
 

--- a/.agents/skills/commit-guards/scripts/pre-commit
+++ b/.agents/skills/commit-guards/scripts/pre-commit
@@ -1,9 +1,9 @@
 #!/usr/bin/env bash
 # pre-commit — the staged-scope guard chain, shaped for the git pre-commit
-# hook (the installed .git/hooks/kendex-guards shim execs it): doc-limits
-# and preflight when the committing work tree or this install carries those
-# sibling skills, then `commit-guards all --staged`, then the repo-local
-# entry named by COMMIT_GUARDS_PRE_COMMIT_LOCAL. Every lane announces itself,
+# hook (the installed .git/hooks/kendex-guards shim execs it): doc-limits,
+# preflight and bot-instructions when the committing work tree or this
+# install carries those sibling skills, then `commit-guards all --staged`,
+# then the repo-local entry named by COMMIT_GUARDS_PRE_COMMIT_LOCAL. Every lane announces itself,
 # a skipped or unconfigured one included.
 #
 # Every step runs before the verdict, so one commit attempt reports every
@@ -29,10 +29,10 @@ usage() {
   cat <<'EOF'
 usage: pre-commit
 
-Runs the staged-scope guard chain: doc-limits and preflight (each resolved
-from the committing work tree first, then from the install beside this
-skill), the commit-guards batch at commit scope, then the optional repo-local
-entry. Takes no arguments — git passes none to pre-commit. Wire it through
+Runs the staged-scope guard chain: doc-limits, preflight and bot-instructions
+check (each resolved from the committing work tree first, then from the
+install beside this skill), the commit-guards batch at commit scope, then the
+optional repo-local entry. Takes no arguments — git passes none to pre-commit. Wire it through
 the installed shim: `install-git-hooks --repo <root>`.
 
 Configuration (env > .env.local > .kendex/settings.toml >
@@ -190,6 +190,17 @@ if PREFLIGHT_SKILL="$(resolve_sibling preflight)"; then
   fi
 else
   echo "=== pre-commit: preflight not installed — skipped (no preflight skill under $(gg_searched_roots) ($GG_SKILL_ROOTS), nor at $SCRIPT_DIR/../../preflight)"
+fi
+
+# Same sibling contract for the bot-instructions check: the rendered review
+# bot instruction files are judged against the staged doctrine and manifest,
+# one coherent staged state, so no consumer wires a wrapper of its own.
+if BOT_SKILL="$(resolve_sibling bot-instructions)"; then
+  BOT_CHECK="$BOT_SKILL/scripts/bot-instructions"
+  [ -x "$BOT_CHECK" ] || gg_config_error "the bot-instructions skill is installed at $BOT_SKILL but $BOT_CHECK is missing or not executable — reinstall it"
+  run_step "bot-instructions check --staged" "$BOT_CHECK" check --staged
+else
+  echo "=== pre-commit: bot-instructions not installed — skipped (no bot-instructions skill under $(gg_searched_roots) ($GG_SKILL_ROOTS), nor at $SCRIPT_DIR/../../bot-instructions)"
 fi
 
 BATCH="$SCRIPT_DIR/commit-guards"

--- a/.agents/skills/commit-guards/tests/cleanup-scope.test.sh
+++ b/.agents/skills/commit-guards/tests/cleanup-scope.test.sh
@@ -9,8 +9,15 @@ set -euo pipefail
 TEST_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 SKILL_DIR="$(cd "$TEST_DIR/.." && pwd)"
 TB="$SKILL_DIR/scripts/todo-ban"
-PC="$SKILL_DIR/scripts/pre-commit"
 . "$TEST_DIR/lib/harness.bash"
+
+# The chain runs from an install that carries no sibling skills: this suite
+# pins cleanup state, and a sibling resolved from the source tree beside
+# this package would judge the fixture repositories on its own terms.
+BARE_INSTALL="$TMP/install/skills"
+mkdir -p "$BARE_INSTALL"
+cp -R "$SKILL_DIR" "$BARE_INSTALL/commit-guards"
+PC="$BARE_INSTALL/commit-guards/scripts/pre-commit"
 
 unset COMMIT_GUARDS_CHECKS COMMIT_GUARDS_SETTINGS_FILE GG_TMP \
   GG_SETTINGS_INDEX_OWNED GG_SETTINGS_INDEX_DIR GG_SETTINGS_FROM_INDEX 2>/dev/null || true

--- a/.agents/skills/commit-guards/tests/pre-commit-chain.test.sh
+++ b/.agents/skills/commit-guards/tests/pre-commit-chain.test.sh
@@ -51,6 +51,7 @@ fake_skill() { # ROOT NAME MARKER RC — a gate that proves which copy ran
 }
 fake_skill "$FULL_INSTALL" doc-limits "install doc-limits ran" 0
 fake_skill "$FULL_INSTALL" preflight "install preflight ran" 0
+fake_skill "$FULL_INSTALL" bot-instructions "install bot-instructions ran" 0
 
 new_repo() { # NAME -> repo path on stdout; seeded, with one file staged
   local r="$TMP/$1"
@@ -133,6 +134,22 @@ case "$OUT" in
   *"install preflight ran"*) ok "the install's preflight ran" ;;
   *) bad "install preflight ran" "out=$OUT" ;;
 esac
+case "$OUT" in
+  *"install bot-instructions ran"*) ok "the install's bot-instructions check ran" ;;
+  *) bad "install bot-instructions ran" "out=$OUT" ;;
+esac
+
+echo "=== a failing tree-carried bot-instructions check blocks ==="
+RBOT="$(new_repo tree-bot-check)"
+fake_skill "$RBOT/.agents/skills" bot-instructions "bot-instructions: AGENTS.md differs from a fresh render" 1
+RC=0
+OUT="$(cd "$RBOT" && "$PC" 2>&1)" || RC=$?
+[ "$RC" -eq 1 ] && ok "the tree's bot-instructions verdict blocks (exit 1)" \
+  || bad "tree bot-instructions verdict blocks" "rc=$RC out=$OUT"
+case "$OUT" in
+  *"=== pre-commit: bot-instructions check --staged"*) ok "the lane announces itself" ;;
+  *) bad "bot-instructions lane announces itself" "out=$OUT" ;;
+esac
 
 echo "=== genuine absence on both sides is a stated skip naming both probes ==="
 R5="$(new_repo double-absence)"
@@ -169,6 +186,11 @@ case "$OUT" in
   *"nor at $BARE_INSTALL/commit-guards/scripts/../../preflight)"*)
     ok "the preflight skip names the install probe" ;;
   *) bad "preflight skip names the install probe" "out=$OUT" ;;
+esac
+case "$OUT" in
+  *"bot-instructions not installed — skipped (no bot-instructions skill under "*)
+    ok "the bot-instructions skip names the work-tree probe" ;;
+  *) bad "bot-instructions skip names the tree probe" "out=$OUT" ;;
 esac
 
 echo "=== a tree-carried skill without a runnable script blocks, never skips ==="

--- a/changelog.d/added/KEN-1252-bot-lane.md
+++ b/changelog.d/added/KEN-1252-bot-lane.md
@@ -1,0 +1,1 @@
+- The commit-guards pre-commit chain runs `bot-instructions check --staged` itself where that package is installed, resolved like doc-limits and preflight; consumers drop their wrapper scripts.

--- a/kendex.settings.toml
+++ b/kendex.settings.toml
@@ -219,8 +219,8 @@ DECISIONS_DIR = "docs/decisions"
 # for the same commit; CI runs the full suites independently.
 DEV_VALIDATE_CMD = "tools/guard --full"
 
-# The repo-root executable the guard chain runs last, after doc-limits,
-# preflight and the commit-guards batch. tools/guard holds this repository's
+# The repo-root executable the guard chain runs last, after doc-limits, preflight,
+# the bot-instructions check and the commit-guards batch. tools/guard holds this repository's
 # own scans and compile checks for changed crates or UI files. Expensive
 # tests, documentation builds and cross-target checks run through DEV_VALIDATE_CMD.
 COMMIT_GUARDS_PRE_COMMIT_LOCAL = "tools/guard"

--- a/skills/bot-instructions/SKILL.md
+++ b/skills/bot-instructions/SKILL.md
@@ -23,7 +23,7 @@ tags: [review]
 
 Flags: `--repo`, `--spec`, `--staged`, `--dry-run`; `bot-instructions --help`. Python 3.11+.
 
-Exit codes: 0 clean, 1 findings, 2 could not complete. A pre-commit lane blocks on both nonzero codes.
+Exit codes: 0 clean, 1 findings, 2 could not complete. A pre-commit lane blocks on both nonzero codes; the `commit-guards` chain runs `check --staged` itself where this package is installed.
 
 ## What reads what
 

--- a/skills/bot-instructions/references/checklist.md
+++ b/skills/bot-instructions/references/checklist.md
@@ -3,7 +3,7 @@
 ## Before the first pass
 
 - [ ] `python3 --version` is 3.11 or newer where the verbs run — locally and on whatever runs this repo's guards. The generator needs `tomllib` and nothing else, and it refuses to start on an older one rather than half-parsing a TOML.
-- [ ] `check` is wired into whatever runs this repo's other guards, with `--staged` in the commit lane so it judges one coherent staged state. This package ships no hook of its own: a repo that already has a commit chain does not need a second one.
+- [ ] `check --staged` runs at commit. Where `commit-guards` is installed its pre-commit chain runs it as a lane; write no wrapper for it. Elsewhere, wire `check --staged` into whatever runs this repo's other guards so it judges one coherent staged state.
 
 ## Adding a repo
 

--- a/skills/commit-guards/DEVELOPMENT.md
+++ b/skills/commit-guards/DEVELOPMENT.md
@@ -51,8 +51,9 @@ The installer writes into `.git/hooks`, never `core.hooksPath`:
 
 1. `doc-limits --staged` for document byte ceilings, from the committing work tree's copy first, then this install's; a stated skip where neither exists or the repo-local one rejects `--staged` in its first-line parser diagnostic.
 2. `preflight --staged`, resolved the same way; a first commit skips it with a note.
-3. `commit-guards all --staged`.
-4. The repo-root-relative executable `COMMIT_GUARDS_PRE_COMMIT_LOCAL` names, when set.
+3. `bot-instructions check --staged`, resolved the same way, so no consumer carries a wrapper for it.
+4. `commit-guards all --staged`.
+5. The repo-root-relative executable `COMMIT_GUARDS_PRE_COMMIT_LOCAL` names, when set.
 
 Every step runs before the verdict; any other companion failure blocks. The shims fail closed on `2` for a guard that could not run, naming what is missing.
 

--- a/skills/commit-guards/SKILL.md
+++ b/skills/commit-guards/SKILL.md
@@ -23,8 +23,9 @@ repo-effects:
   companions:
     - "doc-limits"
     - "preflight"
+    - "bot-instructions"
   notes:
-    - "A missing companion is announced and skipped, as is a repo-local doc-limits that rejects --staged and preflight on a first commit; every other companion or guard failure blocks the commit."
+    - "A missing companion is announced and skipped, as is a repo-local doc-limits that rejects --staged and preflight on a first commit; every other companion or guard failure blocks the commit, a bot-instructions check that finds a stale render included."
     - "Both hooks block on nonzero results; Git's no-verify flag bypasses both for one commit."
     - "Git does not clone hooks; arm every clone once."
 ---
@@ -63,7 +64,7 @@ Exit codes: `0` clean, `1` violations, `2` usage, configuration, or collection e
 
 Run `scripts/install-git-hooks [--repo PATH]` to arm the shims.
 
-Pre-commit order: `doc-limits --staged` when installed -> `preflight --staged` when installed -> `commit-guards all --staged` -> `COMMIT_GUARDS_PRE_COMMIT_LOCAL` when configured. `commit-msg` runs the message gate.
+Pre-commit order: `doc-limits --staged` when installed -> `preflight --staged` when installed -> `bot-instructions check --staged` when installed -> `commit-guards all --staged` -> `COMMIT_GUARDS_PRE_COMMIT_LOCAL` when configured. `commit-msg` runs the message gate.
 
 Arming and disarming apply to the whole repository. Disarm before removing the skill. Ownership and layering: [README.md § Git hooks](README.md#git-hooks); install mechanics: [DEVELOPMENT.md § Git hook install contract](DEVELOPMENT.md#git-hook-install-contract).
 

--- a/skills/commit-guards/scripts/pre-commit
+++ b/skills/commit-guards/scripts/pre-commit
@@ -1,9 +1,9 @@
 #!/usr/bin/env bash
 # pre-commit — the staged-scope guard chain, shaped for the git pre-commit
-# hook (the installed .git/hooks/kendex-guards shim execs it): doc-limits
-# and preflight when the committing work tree or this install carries those
-# sibling skills, then `commit-guards all --staged`, then the repo-local
-# entry named by COMMIT_GUARDS_PRE_COMMIT_LOCAL. Every lane announces itself,
+# hook (the installed .git/hooks/kendex-guards shim execs it): doc-limits,
+# preflight and bot-instructions when the committing work tree or this
+# install carries those sibling skills, then `commit-guards all --staged`,
+# then the repo-local entry named by COMMIT_GUARDS_PRE_COMMIT_LOCAL. Every lane announces itself,
 # a skipped or unconfigured one included.
 #
 # Every step runs before the verdict, so one commit attempt reports every
@@ -29,10 +29,10 @@ usage() {
   cat <<'EOF'
 usage: pre-commit
 
-Runs the staged-scope guard chain: doc-limits and preflight (each resolved
-from the committing work tree first, then from the install beside this
-skill), the commit-guards batch at commit scope, then the optional repo-local
-entry. Takes no arguments — git passes none to pre-commit. Wire it through
+Runs the staged-scope guard chain: doc-limits, preflight and bot-instructions
+check (each resolved from the committing work tree first, then from the
+install beside this skill), the commit-guards batch at commit scope, then the
+optional repo-local entry. Takes no arguments — git passes none to pre-commit. Wire it through
 the installed shim: `install-git-hooks --repo <root>`.
 
 Configuration (env > .env.local > .kendex/settings.toml >
@@ -190,6 +190,17 @@ if PREFLIGHT_SKILL="$(resolve_sibling preflight)"; then
   fi
 else
   echo "=== pre-commit: preflight not installed — skipped (no preflight skill under $(gg_searched_roots) ($GG_SKILL_ROOTS), nor at $SCRIPT_DIR/../../preflight)"
+fi
+
+# Same sibling contract for the bot-instructions check: the rendered review
+# bot instruction files are judged against the staged doctrine and manifest,
+# one coherent staged state, so no consumer wires a wrapper of its own.
+if BOT_SKILL="$(resolve_sibling bot-instructions)"; then
+  BOT_CHECK="$BOT_SKILL/scripts/bot-instructions"
+  [ -x "$BOT_CHECK" ] || gg_config_error "the bot-instructions skill is installed at $BOT_SKILL but $BOT_CHECK is missing or not executable — reinstall it"
+  run_step "bot-instructions check --staged" "$BOT_CHECK" check --staged
+else
+  echo "=== pre-commit: bot-instructions not installed — skipped (no bot-instructions skill under $(gg_searched_roots) ($GG_SKILL_ROOTS), nor at $SCRIPT_DIR/../../bot-instructions)"
 fi
 
 BATCH="$SCRIPT_DIR/commit-guards"

--- a/skills/commit-guards/tests/cleanup-scope.test.sh
+++ b/skills/commit-guards/tests/cleanup-scope.test.sh
@@ -9,8 +9,15 @@ set -euo pipefail
 TEST_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 SKILL_DIR="$(cd "$TEST_DIR/.." && pwd)"
 TB="$SKILL_DIR/scripts/todo-ban"
-PC="$SKILL_DIR/scripts/pre-commit"
 . "$TEST_DIR/lib/harness.bash"
+
+# The chain runs from an install that carries no sibling skills: this suite
+# pins cleanup state, and a sibling resolved from the source tree beside
+# this package would judge the fixture repositories on its own terms.
+BARE_INSTALL="$TMP/install/skills"
+mkdir -p "$BARE_INSTALL"
+cp -R "$SKILL_DIR" "$BARE_INSTALL/commit-guards"
+PC="$BARE_INSTALL/commit-guards/scripts/pre-commit"
 
 unset COMMIT_GUARDS_CHECKS COMMIT_GUARDS_SETTINGS_FILE GG_TMP \
   GG_SETTINGS_INDEX_OWNED GG_SETTINGS_INDEX_DIR GG_SETTINGS_FROM_INDEX 2>/dev/null || true

--- a/skills/commit-guards/tests/pre-commit-chain.test.sh
+++ b/skills/commit-guards/tests/pre-commit-chain.test.sh
@@ -51,6 +51,7 @@ fake_skill() { # ROOT NAME MARKER RC — a gate that proves which copy ran
 }
 fake_skill "$FULL_INSTALL" doc-limits "install doc-limits ran" 0
 fake_skill "$FULL_INSTALL" preflight "install preflight ran" 0
+fake_skill "$FULL_INSTALL" bot-instructions "install bot-instructions ran" 0
 
 new_repo() { # NAME -> repo path on stdout; seeded, with one file staged
   local r="$TMP/$1"
@@ -133,6 +134,22 @@ case "$OUT" in
   *"install preflight ran"*) ok "the install's preflight ran" ;;
   *) bad "install preflight ran" "out=$OUT" ;;
 esac
+case "$OUT" in
+  *"install bot-instructions ran"*) ok "the install's bot-instructions check ran" ;;
+  *) bad "install bot-instructions ran" "out=$OUT" ;;
+esac
+
+echo "=== a failing tree-carried bot-instructions check blocks ==="
+RBOT="$(new_repo tree-bot-check)"
+fake_skill "$RBOT/.agents/skills" bot-instructions "bot-instructions: AGENTS.md differs from a fresh render" 1
+RC=0
+OUT="$(cd "$RBOT" && "$PC" 2>&1)" || RC=$?
+[ "$RC" -eq 1 ] && ok "the tree's bot-instructions verdict blocks (exit 1)" \
+  || bad "tree bot-instructions verdict blocks" "rc=$RC out=$OUT"
+case "$OUT" in
+  *"=== pre-commit: bot-instructions check --staged"*) ok "the lane announces itself" ;;
+  *) bad "bot-instructions lane announces itself" "out=$OUT" ;;
+esac
 
 echo "=== genuine absence on both sides is a stated skip naming both probes ==="
 R5="$(new_repo double-absence)"
@@ -169,6 +186,11 @@ case "$OUT" in
   *"nor at $BARE_INSTALL/commit-guards/scripts/../../preflight)"*)
     ok "the preflight skip names the install probe" ;;
   *) bad "preflight skip names the install probe" "out=$OUT" ;;
+esac
+case "$OUT" in
+  *"bot-instructions not installed — skipped (no bot-instructions skill under "*)
+    ok "the bot-instructions skip names the work-tree probe" ;;
+  *) bad "bot-instructions skip names the tree probe" "out=$OUT" ;;
 esac
 
 echo "=== a tree-carried skill without a runnable script blocks, never skips ==="

--- a/tools/guard
+++ b/tools/guard
@@ -33,9 +33,11 @@ say() {
   fail=1
 }
 
-bot_args=(check)
-[ "$FULL" -eq 1 ] || bot_args+=(--staged)
-"$TOOLS_DIR/../.agents/skills/bot-instructions/scripts/bot-instructions" "${bot_args[@]}" || say "bot instruction check failed"
+# The staged bot-instructions check is a lane of the commit-guards chain that
+# runs this script; --full judges the working tree, which the chain does not.
+if [ "$FULL" -eq 1 ]; then
+  "$TOOLS_DIR/../.agents/skills/bot-instructions/scripts/bot-instructions" check || say "bot instruction check failed"
+fi
 
 # The hit lines below are a tracked file's own bytes, and a source file may
 # carry an ESC or another C0 control as legitimate content. Printed raw they

--- a/tools/tests/guard.test.sh
+++ b/tools/tests/guard.test.sh
@@ -86,7 +86,7 @@ run_guard() { # [VAR=VALUE...] — sets OUT and RC
   OUT="$(cd "$R" && env "$@" "$GUARD" ${args[@]+"${args[@]}"} 2>&1)" || RC=$?
 }
 
-echo "=== bot instructions use the index at commit and the worktree in full validation ==="
+echo "=== bot instructions: full validation reads the worktree; the staged check is the chain's lane ==="
 BOT="$REPO/.agents/skills/bot-instructions/scripts/bot-instructions"
 printf '\n[bot-instructions.bots]\ncodex = true\ncopilot = true\n' >>"$R/kendex.toml"
 printf '\n## Code Review Rules\n\nFixture rules.\n' >>"$R/AGENTS.md"
@@ -108,9 +108,12 @@ FULL_GUARD=0
 git -C "$R" add .github/copilot-instructions.md
 "$BOT" render --repo "$R" >/dev/null
 run_guard
-[ "$RC" -eq 1 ] && [[ "$OUT" == *"drift:"*".github/copilot-instructions.md"* ]] \
-  && ok "commit checks reject stale staged bot output despite a repaired worktree" \
-  || bad "commit checks reject stale staged bot output despite a repaired worktree" "rc=$RC out=$OUT"
+# The commit-guards pre-commit chain runs `bot-instructions check --staged`
+# as its own lane before this script; a second staged run here would judge
+# the same index twice.
+[ "$RC" -eq 0 ] && [[ "$OUT" != *"drift:"* ]] \
+  && ok "commit checks leave the staged bot check to the chain's lane" \
+  || bad "commit checks leave the staged bot check to the chain's lane" "rc=$RC out=$OUT"
 git -C "$R" reset -q --hard HEAD
 rm -rf -- "$R/.github"
 


### PR DESCRIPTION
The commit-guards pre-commit chain runs `bot-instructions check --staged` itself where the bot-instructions package is installed, as a lane resolved exactly like doc-limits and preflight (the committing work tree's copy first, then the install beside the chain; a stated skip naming both probes where neither carries it). Every consumer hand-wrote the same wrapper because `COMMIT_GUARDS_PRE_COMMIT_LOCAL` takes one bare executable; the wrapper goes away.

Closes #2188.

- `skills/commit-guards/scripts/pre-commit`: the lane, after preflight and before the batch; a failing or incomplete check blocks like every other lane.
- `tools/guard`: kendex's own guard keeps only the working-tree check under `--full`; the staged run is the chain's.
- Docs: chain order in SKILL.md and DEVELOPMENT.md, the bot-instructions checklist and SKILL.md say the chain runs it.
- Tests: the chain suite covers the lane running from the install, blocking on a failing tree-carried check, and the skip naming its probes; the guard suite pins that the default mode leaves the staged check to the chain; the cleanup-scope suite now runs the chain from a bare install so no sibling judges its fixtures.

An installed but unconfigured bot-instructions (no `[bot-instructions]` table) blocks commits with the package's own finding until configured; all seven consumers are configured.

Consumer wrapper paths to delete in each adoption PR (from the wave-2 status files), with `COMMIT_GUARDS_PRE_COMMIT_LOCAL` emptied or pointed at the repo's remaining local lane:

1. hyprtrade: `tools/check-bots-staged`
2. hyprtrade-io: `scripts/check-bot-instructions-staged.sh`
3. kendex-web: `scripts/check-bot-instructions-staged.sh`
4. memsira: `scripts/check-bot-instructions-staged.sh`
5. vgs: `scripts/check-bot-instructions-staged.sh`
6. drovr: the staged bot-check section of `tools/guard`
7. vg: the staged bot-check call in `tools/guard`

Program tracking issue: KEN-1252.

https://claude.ai/code/session_01H55YyFukjz7nS9UdyXAAr4
