### PR TITLE
test(KEN-1241): review_artifact_check.sh as tables over staged worktrees

### DIFF
--- a/.agents/skills/orch/tests/dev_artifact_check.sh
+++ b/.agents/skills/orch/tests/dev_artifact_check.sh
@@ -62,6 +62,8 @@ json() { jq -r "$1" <<<"$OUT" 2>/dev/null || echo UNPARSEABLE; }
 # key the result does not carry reads ABSENT, so `null` means a real null.
 #   rc              exit status
 #   stderr~<text>   whether stderr carries <text> (`+` reads as a space)
+#   hint_present    whether the result carries a non-empty string hint; an
+#                   unparseable result reads false, never fired
 #   help_sections   which of the routed --help sections are present: gates
 #                   (the ordering line), reasons (every ok=false reason the
 #                   check emits), items (the --expect-items confinement)
@@ -80,6 +82,7 @@ observe() {
         value="${value#,}"; value="${value:-none}"
         ;;
       stderr~*) needle="${name#stderr~}"; value="$(grep -qF -- "${needle//+/ }" "$ERR" && echo true || echo false)" ;;
+      hint_present) value="$(json '(.hint | type) == "string" and .hint != ""')" ;;
       *) value="$(json "if has(\"$name\") then .$name else \"ABSENT\" end")" ;;
     esac
     got="$got $name=$value"
@@ -249,7 +252,7 @@ done
 # when the shapes coincide (the inline form is the control).
 "$WRITE" --worktree "$RR" --kind fix --issue issue-9 --round-id 16-16 --branch b --commit "$RR_HEAD" --validate pass --item 1 Applied a --item 2 Applied b --item 3 Applied c >/dev/null
 run_check --file "$RR/tmp/dev-return-issue-9-16-16.json" --expect-items 3
-assert_eq "$([[ "$(json .hint)" != null ]] && echo fires || echo silent)" "fires" "control: file-mode --expect-items 3 against items 1..3 fires the count-vs-set hint" "$ERR"
+assert_eq "$(observe "reason=incomplete hint_present=true")" "reason=incomplete hint_present=true" "control: file-mode --expect-items 3 against items 1..3 fires the count-vs-set hint" "$ERR"
 round_write --worktree "$RR" --issue issue-9 --round-id 16-16 --item 3 "only item three" "tools/guard on a staged render" >/dev/null
 run_check --worktree "$RR" --issue issue-9 --round-id 16-16 --expect-items-from-round
 assert_eq "$(observe "reason=incomplete hint=null")" "reason=incomplete hint=null" "from-round never emits the hint and still reports incomplete" "$ERR"

--- a/.agents/skills/orch/tests/review_artifact_check.sh
+++ b/.agents/skills/orch/tests/review_artifact_check.sh
@@ -50,7 +50,7 @@ body() {
     badblk) printf '{"verdict":"action_required","blockers":[{"id":1,"title":"t","location":"l","recommendation":"r","priority":1,"estimate":2}],"suggestions":[],"qa_metadata":{}}' ;;
     okblk) printf '{"verdict":"action_required","blockers":[{"id":1,"title":"t","location":"l","description":"d","recommendation":"r","priority":1,"estimate":2}],"suggestions":[],"qa_metadata":{}}' ;;
     badpri) printf '{"verdict":"pass","blockers":[],"suggestions":[{"id":1,"title":"t","location":"l","description":"d","recommendation":"r","priority":5,"estimate":2,"category":"fix"}],"qa_metadata":{}}' ;;
-    badest) printf '{"verdict":"pass","blockers":[],"suggestions":[{"id":1,"title":"t","location":"l","description":"d","recommendation":"r","priority":2,"estimate":"2","category":"issue"}],"qa_metadata":{}}' ;;
+    badest) printf '{"verdict":"pass","blockers":[],"suggestions":[{"id":1,"title":"t","location":"l","description":"d","recommendation":"r","priority":2,"estimate":"2","category":"fix"}],"qa_metadata":{}}' ;;
     badblkpri) printf '{"verdict":"action_required","blockers":[{"id":1,"title":"t","location":"l","description":"d","recommendation":"r","priority":0,"estimate":3}],"suggestions":[],"qa_metadata":{}}' ;;
     okbound) printf '{"verdict":"pass","blockers":[],"suggestions":[{"id":1,"title":"t","location":"l","description":"d","recommendation":"r","priority":4,"estimate":5,"category":"fix"}],"qa_metadata":{}}' ;;
     noqa_bad) printf '{"verdict":"pass","suggestions":[{"title":"t","location":"l"}]}' ;;
@@ -169,6 +169,7 @@ table \
   "no artifact at all is missing||$GLOB|rc=1 ok=false path=null reason=missing" \
   "another agent's fresh artifact does not count|review-reviewer-arch-1@after=pass|$GLOB|rc=1 reason=missing" \
   "an artifact older than the boundary is stale and named|$Q-1@before=pass|$GLOB|rc=1 ok=false path=$Q-1.json reason=stale" \
+  "an mtime equal to the boundary is fresh in glob mode too|$Q-1@at=pass|$GLOB|rc=0 ok=true reason=valid" \
   "a fresh artifact without a verdict is invalid and named|$Q-1@before=pass;$Q-2@after=noverdict|$GLOB|rc=1 path=$Q-2.json reason=invalid" \
   "a fresh valid artifact wins over stale and invalid siblings|$Q-1@before=pass;$Q-2@after=noverdict;$Q-3@later=action|$GLOB|rc=0 ok=true path=$Q-3.json reason=valid" \
   "a newest unparseable file falls back to the older fresh valid one|$Q-3@later=action;$Q-4@later2=notjson|$GLOB|rc=0 ok=true path=$Q-3.json reason=valid"
@@ -190,9 +191,9 @@ table \
 
 echo "=== a self-reported no-review artifact is refused, and terminally ==="
 # review_performed=false, or a no-review reason alone, is an admission
-# whatever the verdict; no qa_metadata keeps the existence-plus-verdict
-# tolerance; an empty qa_metadata with the arrays, or review_performed=true,
-# validates. In glob mode the refusal is terminal: no_review is the
+# whatever the verdict (no qa_metadata at all keeps the existence-plus-verdict
+# tolerance the file-mode table proves); an empty qa_metadata with the arrays,
+# or review_performed=true, validates. In glob mode the refusal is terminal: no_review is the
 # reviewer's self-report about THIS run, so an older fresh sibling does not
 # rescue it; a STALE no-review artifact does not block a fresh valid one.
 E=review-reviewer-ext
@@ -200,7 +201,6 @@ table \
   "review_performed=false|F@after=noreview|--file %F|rc=1 ok=false path=review-external-F.json reason=no_review" \
   "a no-review reason alone|F@none=noreview_reason|--file %F|rc=1 reason=no_review" \
   "review_performed=false alone, arrays present, is still no_review|F@none=noreview_flag|--file %F|rc=1 reason=no_review" \
-  "no qa_metadata at all still validates|F@none=pass|--file %F|ok=true reason=valid" \
   "empty qa_metadata with the arrays validates|F@none=qa_ok|--file %F|reason=valid" \
   "review_performed=true validates|F@none=performed|--file %F|reason=valid" \
   "glob: a fresh no-review artifact is refused and named|$E-1@after=noreview|%W reviewer-ext %D|rc=1 path=$E-1.json reason=no_review" \
@@ -243,19 +243,18 @@ echo "=== a qa-shaped artifact must carry usable finding items, and the detail s
 # terminally, and a STALE one does not block a fresh well-formed one.
 T=review-reviewer-item
 table \
-  "the issue's malformed suggestion is incomplete, the detail names the item and the missing category|F@none=issue_bad|--file %F|rc=1 ok=false path=review-external-F.json reason=incomplete detail~suggestions[0]=true detail~category=true" \
+  "the issue's malformed suggestion is incomplete, the detail names the item and the missing category|F@none=issue_bad|--file %F|rc=1 ok=false path=review-external-F.json reason=incomplete detail~suggestions[0]=true detail~missing/invalid+id,+description,+recommendation,+priority,+estimate,+category=true" \
   "a fully compliant artifact is valid and carries no detail key|F@none=compliant|--file %F|ok=true reason=valid detail=ABSENT" \
-  "empty arrays carry no items and stay valid|F@none=qa_ok_noq|--file %F|reason=valid" \
-  "a suggestion missing only category|F@none=nocat|--file %F|rc=1 reason=incomplete detail~category=true" \
+  "a suggestion missing only category|F@none=nocat|--file %F|rc=1 reason=incomplete detail~missing/invalid+category=true" \
   "a category outside fix and issue|F@none=badcatval|--file %F|rc=1 reason=incomplete" \
-  "a blocker missing a base field, named|F@none=badblk|--file %F|rc=1 reason=incomplete detail~blockers[0]=true detail~description=true" \
+  "a blocker missing a base field, named|F@none=badblk|--file %F|rc=1 reason=incomplete detail~blockers[0]=true detail~missing/invalid+description=true" \
   "a blocker without category is valid|F@none=okblk|--file %F|reason=valid" \
-  "a priority outside 1..4, named|F@none=badpri|--file %F|rc=1 reason=incomplete detail~priority=true" \
-  "a string estimate, named|F@none=badest|--file %F|rc=1 detail~estimate=true" \
+  "a priority outside 1..4, named|F@none=badpri|--file %F|rc=1 reason=incomplete detail~missing/invalid+priority=true" \
+  "a string estimate, named|F@none=badest|--file %F|rc=1 reason=incomplete detail~missing/invalid+estimate(not+1..5)=true" \
   "a blocker priority below the range, named on its array|F@none=badblkpri|--file %F|rc=1 detail~blockers[0]=true" \
   "the boundary values priority 4 and estimate 5 are valid|F@none=okbound|--file %F|reason=valid" \
   "malformed items without qa_metadata stay tolerant|F@none=noqa_bad|--file %F|reason=valid" \
-  "arrays lost: the detail names both arrays as absent and the exempt shape|F@none=qa_inc|--file %F|reason=incomplete detail~blockers[]+is+absent=true detail~suggestions[]+is+absent=true detail~no+qa_metadata=true" \
+  "arrays lost: the detail names both arrays as absent and the exempt shape|F@none=qa_inc|--file %F|ok=false reason=incomplete detail~blockers[]+is+absent=true detail~suggestions[]+is+absent=true detail~no+qa_metadata=true" \
   "a null blockers is reported as null, and what an empty review writes|F@none=null_blockers|--file %F|rc=1 reason=incomplete detail~blockers[]+is+null=true detail~writes+[]=true" \
   "a missing blockers is reported as absent|F@none=inc_sugg|--file %F|detail~blockers[]+is+absent=false detail~suggestions[]+is+absent=true" \
   "an object blockers is reported by type|F@none=obj_blockers|--file %F|rc=1 reason=incomplete detail~blockers[]+is+object,+not+an+array=true detail~writes+[]=true" \
@@ -265,7 +264,6 @@ table \
   "a wrong-typed suggestions is reported on its own|F@none=str_sugg|--file %F|detail~suggestions[]+is+string,+not+an+array=true" \
   "chain: a missing verdict names its cause|F@none=chain_noverdict|--file %F|ok=false detail_present=true" \
   "chain: a no-review admission names its cause|F@none=chain_noreview|--file %F|ok=false detail_present=true" \
-  "chain: a qa-shape loss names its cause|F@none=qa_inc|--file %F|ok=false detail_present=true" \
   "chain: a malformed finding item names its cause|F@none=chain_item|--file %F|ok=false detail_present=true" \
   "chain: a bad measurement declaration names its cause|F@none=chain_decl|--file %F|ok=false detail_present=true" \
   "chain: a zero-sample measurement names its cause|F@none=chain_zero|--file %F|ok=false detail_present=true" \
@@ -309,8 +307,8 @@ now_epoch="$(date +%s)"
 ( sleep 2; body qa_ok > "$WT/tmp/review-cyc-20990101-000000.json" ) &
 writer_pid=$!
 run_check %W cyc "$now_epoch" --wait 20 --interval 1
-wait "$writer_pid" 2>/dev/null || true
 elapsed=$(( $(date +%s) - now_epoch ))
+wait "$writer_pid" 2>/dev/null || true
 assert_eq "$(observe "ok=true") polled=$([[ "$elapsed" -ge 1 && "$elapsed" -lt 15 ]] && echo true || echo false)" "ok=true polled=true" "--wait polls past a stale prior-round artifact to the fresh one, neither instantly nor to the deadline (${elapsed}s)" "$ERR"
 
 echo "=== -h and --help answer before any temp-file initialization ==="

--- a/.agents/skills/orch/tests/review_artifact_check.sh
+++ b/.agents/skills/orch/tests/review_artifact_check.sh
@@ -43,6 +43,7 @@ body() {
     qa_inc_agent) printf '{"agent":"external-codex","timestamp":"2026-07-18T00:00:00Z","verdict":"pass","summary":"looks fine","qa_metadata":{}}' ;;
     inc_type) printf '{"verdict":"pass","blockers":"none","suggestions":[],"qa_metadata":{}}' ;;
     inc_sugg) printf '{"verdict":"pass","blockers":[],"qa_metadata":{}}' ;;
+    inc_blk) printf '{"verdict":"pass","suggestions":[],"qa_metadata":{}}' ;;
     issue_bad) printf '{"agent":"reviewer-arch","verdict":"pass","blockers":[],"suggestions":[{"title":"Two resolvers coexist","location":"/abs/instrument_link.rs (instrument_name)","detail":"...","severity":"low"}],"qa_metadata":{"arch_review":{"overall_score":8.4,"pass":true}}}' ;;
     compliant) printf '{"verdict":"action_required","blockers":[{"id":1,"title":"t","location":"src/x.rs (`f`)","description":"d","recommendation":"r","priority":1,"estimate":2}],"suggestions":[{"id":1,"title":"t","location":"src/y.rs (`g`)","description":"d","recommendation":"r","priority":3,"estimate":2,"category":"fix"}],"qa_metadata":{}}' ;;
     nocat) printf '{"verdict":"pass","blockers":[],"suggestions":[{"id":1,"title":"t","location":"l","description":"d","recommendation":"r","priority":3,"estimate":2}],"qa_metadata":{}}' ;;
@@ -256,7 +257,7 @@ table \
   "malformed items without qa_metadata stay tolerant|F@none=noqa_bad|--file %F|reason=valid" \
   "arrays lost: the detail names both arrays as absent and the exempt shape|F@none=qa_inc|--file %F|ok=false reason=incomplete detail~blockers[]+is+absent=true detail~suggestions[]+is+absent=true detail~no+qa_metadata=true" \
   "a null blockers is reported as null, and what an empty review writes|F@none=null_blockers|--file %F|rc=1 reason=incomplete detail~blockers[]+is+null=true detail~writes+[]=true" \
-  "a missing blockers is reported as absent|F@none=inc_sugg|--file %F|detail~blockers[]+is+absent=false detail~suggestions[]+is+absent=true" \
+  "a missing blockers is reported as absent, and the present suggestions is not|F@none=inc_blk|--file %F|rc=1 reason=incomplete detail~blockers[]+is+absent=true detail~suggestions[]+is+absent=false" \
   "an object blockers is reported by type|F@none=obj_blockers|--file %F|rc=1 reason=incomplete detail~blockers[]+is+object,+not+an+array=true detail~writes+[]=true" \
   "a string blockers is reported by type|F@none=str_blockers|--file %F|rc=1 reason=incomplete detail~blockers[]+is+string,+not+an+array=true detail~writes+[]=true" \
   "a number blockers is reported by type|F@none=num_blockers|--file %F|rc=1 reason=incomplete detail~blockers[]+is+number,+not+an+array=true detail~writes+[]=true" \

--- a/.agents/skills/orch/tests/review_artifact_check.sh
+++ b/.agents/skills/orch/tests/review_artifact_check.sh
@@ -1,777 +1,329 @@
 #!/usr/bin/env bash
-# Tests for review-artifact-check: deterministic on-disk acceptance
-# of reviewer JSON artifacts in the orch review-pr workflow.
-
+# Tests for review-artifact-check: deterministic on-disk acceptance of
+# reviewer JSON artifacts in the orch review-pr workflow. Glob mode resolves
+# WT/tmp/review-<agent>-*.json against a delegation boundary; --file mode
+# validates one path, with an optional boundary. The measurement gate and the
+# selective jq shim are review_artifact_check_measurement.sh; the channel and
+# item-schema surfaces have their own suites beside it.
+#
+# One case per behaviour surface; shaped input is one table per case, one
+# asserted row per shape. A row stages its own worktree and artifacts; its
+# `expect` names the fields it pins and `observe` reads exactly those, so a
+# row fails on the field it names.
 set -euo pipefail
 source "$(dirname "${BASH_SOURCE[0]}")/lib/git-env.sh"
-
 TEST_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(cd "$TEST_DIR/../../.." && pwd)"
 CHECK="$REPO_ROOT/skills/orch/scripts/review-artifact-check"
+# shellcheck source=lib/waiter-assertions.sh
+source "$TEST_DIR/lib/waiter-assertions.sh"
 TMP_ROOT="$(mktemp -d)"
 trap 'rm -rf "$TMP_ROOT"' EXIT
 
-PASS=0
-FAIL=0
+DELEG=1750000000
+BEFORE=$((DELEG - 100))
+AFTER=$((DELEG + 100))
+LATER=$((DELEG + 200))
+LATER2=$((DELEG + 300))
 
-assert_eq() {
-  local got="$1" want="$2" name="$3"
-  if [[ "$got" == "$want" ]]; then
-    PASS=$((PASS + 1))
-    printf '  ok    %s\n' "$name"
-  else
-    FAIL=$((FAIL + 1))
-    printf '  FAIL  %s\n        expected: %s\n        got:      %s\n' "$name" "$want" "$got"
-  fi
+# body NAME — the artifact bodies the rows stage, by name.
+body() {
+  case "$1" in
+    pass) printf '{"verdict":"pass","items":[]}' ;;
+    action) printf '{"verdict":"action_required","items":[{"category":"fix"}]}' ;;
+    noverdict) printf '{"items":[]}' ;;
+    notjson) printf 'not json' ;;
+    noreview) printf '{"verdict":"pass","summary":"No review was actually performed","qa_metadata":{"review_performed":false,"reason":"no_scope_provided"}}' ;;
+    noreview_reason) printf '{"verdict":"pass","qa_metadata":{"reason":"no_scope_provided"}}' ;;
+    noreview_flag) printf '{"verdict":"pass","blockers":[],"suggestions":[],"qa_metadata":{"review_performed":false}}' ;;
+    qa_ok) printf '{"verdict":"pass","blockers":[],"suggestions":[],"questions":[],"qa_metadata":{}}' ;;
+    qa_ok_noq) printf '{"verdict":"pass","blockers":[],"suggestions":[],"qa_metadata":{}}' ;;
+    performed) printf '{"verdict":"pass","blockers":[],"suggestions":[],"qa_metadata":{"review_performed":true}}' ;;
+    qa_inc) printf '{"verdict":"pass","summary":"truncated","qa_metadata":{}}' ;;
+    qa_inc_agent) printf '{"agent":"external-codex","timestamp":"2026-07-18T00:00:00Z","verdict":"pass","summary":"looks fine","qa_metadata":{}}' ;;
+    inc_type) printf '{"verdict":"pass","blockers":"none","suggestions":[],"qa_metadata":{}}' ;;
+    inc_sugg) printf '{"verdict":"pass","blockers":[],"qa_metadata":{}}' ;;
+    issue_bad) printf '{"agent":"reviewer-arch","verdict":"pass","blockers":[],"suggestions":[{"title":"Two resolvers coexist","location":"/abs/instrument_link.rs (instrument_name)","detail":"...","severity":"low"}],"qa_metadata":{"arch_review":{"overall_score":8.4,"pass":true}}}' ;;
+    compliant) printf '{"verdict":"action_required","blockers":[{"id":1,"title":"t","location":"src/x.rs (`f`)","description":"d","recommendation":"r","priority":1,"estimate":2}],"suggestions":[{"id":1,"title":"t","location":"src/y.rs (`g`)","description":"d","recommendation":"r","priority":3,"estimate":2,"category":"fix"}],"qa_metadata":{}}' ;;
+    nocat) printf '{"verdict":"pass","blockers":[],"suggestions":[{"id":1,"title":"t","location":"l","description":"d","recommendation":"r","priority":3,"estimate":2}],"qa_metadata":{}}' ;;
+    badcatval) printf '{"verdict":"pass","blockers":[],"suggestions":[{"id":1,"title":"t","location":"l","description":"d","recommendation":"r","priority":3,"estimate":2,"category":"low"}],"qa_metadata":{}}' ;;
+    badblk) printf '{"verdict":"action_required","blockers":[{"id":1,"title":"t","location":"l","recommendation":"r","priority":1,"estimate":2}],"suggestions":[],"qa_metadata":{}}' ;;
+    okblk) printf '{"verdict":"action_required","blockers":[{"id":1,"title":"t","location":"l","description":"d","recommendation":"r","priority":1,"estimate":2}],"suggestions":[],"qa_metadata":{}}' ;;
+    badpri) printf '{"verdict":"pass","blockers":[],"suggestions":[{"id":1,"title":"t","location":"l","description":"d","recommendation":"r","priority":5,"estimate":2,"category":"fix"}],"qa_metadata":{}}' ;;
+    badest) printf '{"verdict":"pass","blockers":[],"suggestions":[{"id":1,"title":"t","location":"l","description":"d","recommendation":"r","priority":2,"estimate":"2","category":"issue"}],"qa_metadata":{}}' ;;
+    badblkpri) printf '{"verdict":"action_required","blockers":[{"id":1,"title":"t","location":"l","description":"d","recommendation":"r","priority":0,"estimate":3}],"suggestions":[],"qa_metadata":{}}' ;;
+    okbound) printf '{"verdict":"pass","blockers":[],"suggestions":[{"id":1,"title":"t","location":"l","description":"d","recommendation":"r","priority":4,"estimate":5,"category":"fix"}],"qa_metadata":{}}' ;;
+    noqa_bad) printf '{"verdict":"pass","suggestions":[{"title":"t","location":"l"}]}' ;;
+    null_blockers) printf '{"verdict":"pass","blockers":null,"suggestions":[],"qa_metadata":{}}' ;;
+    obj_blockers) printf '{"verdict":"pass","blockers":{},"suggestions":[],"qa_metadata":{}}' ;;
+    str_blockers) printf '{"verdict":"pass","blockers":"none","suggestions":[],"qa_metadata":{}}' ;;
+    num_blockers) printf '{"verdict":"pass","blockers":3,"suggestions":[],"qa_metadata":{}}' ;;
+    null_sugg) printf '{"verdict":"pass","blockers":[],"suggestions":null,"qa_metadata":{}}' ;;
+    str_sugg) printf '{"verdict":"pass","blockers":[],"suggestions":"x","qa_metadata":{}}' ;;
+    chain_noverdict) printf '{"agent":"r","summary":"no verdict field"}' ;;
+    chain_noreview) printf '{"verdict":"pass","qa_metadata":{"review_performed":false}}' ;;
+    chain_item) printf '{"verdict":"pass","blockers":[],"suggestions":[{"title":"t"}],"qa_metadata":{}}' ;;
+    chain_decl) printf '{"verdict":"pass","blockers":[],"suggestions":[],"measurement_failed":"n/a"}' ;;
+    chain_zero) printf '{"verdict":"pass","summary":"mutation: killed 0/0","blockers":[],"suggestions":[],"qa_metadata":{}}' ;;
+    item_bad) printf '{"verdict":"pass","blockers":[],"suggestions":[{"title":"t","location":"l","detail":"x","severity":"low"}],"qa_metadata":{}}' ;;
+    item_ok) printf '{"verdict":"pass","blockers":[],"suggestions":[{"id":1,"title":"t","location":"l","description":"d","recommendation":"r","priority":3,"estimate":2,"category":"issue","impact":"nightly importers hit it on every run"}],"qa_metadata":{}}' ;;
+    *) echo "body: unknown name $1" >&2; exit 1 ;;
+  esac
 }
 
-assert_file_contains() {
-  local file="$1" pattern="$2" name="$3"
-  if grep -Fq -- "$pattern" "$file"; then
-    PASS=$((PASS + 1))
-    printf '  ok    %s\n' "$name"
-  else
-    FAIL=$((FAIL + 1))
-    printf '  FAIL  %s\n        missing pattern: %s\n        file: %s\n' "$name" "$pattern" "$file"
-  fi
+# --- harness -----------------------------------------------------------------
+
+# stage SPEC — a fresh worktree for one row with the artifacts SPEC names:
+# `;`-separated `file@when=body` items, file a name under tmp/ (`F` is the
+# --file target review-external-F.json), when one of before, at, after, later,
+# later2 (the mtime against the delegation boundary) or none. Sets WT and F.
+RUN_SEQ=0
+stage() {
+  local spec="$1" items item file when name mtime
+  RUN="$TMP_ROOT/runs/$((++RUN_SEQ))"
+  WT="$RUN/wt"
+  mkdir -p "$WT/tmp"
+  F="$WT/tmp/review-external-F.json"
+  [[ -n "$spec" ]] || return 0
+  IFS=';' read -ra items <<<"$spec"
+  for item in "${items[@]}"; do
+    file="${item%%@*}"; when="${item#*@}"; when="${when%%=*}"; name="${item#*=}"
+    [[ "$file" != F ]] || file="review-external-F"
+    body "$name" > "$WT/tmp/$file.json"
+    case "$when" in
+      before) mtime=$BEFORE ;; at) mtime=$DELEG ;; after) mtime=$AFTER ;; later) mtime=$LATER ;; later2) mtime=$LATER2 ;;
+      none) continue ;;
+      *) echo "stage: unknown time $when in $item" >&2; exit 1 ;;
+    esac
+    touch -d "@$mtime" "$WT/tmp/$file.json"
+  done
 }
 
-assert_substr() {
-  local haystack="$1" needle="$2" name="$3"
-  if [[ "$haystack" == *"$needle"* ]]; then
-    PASS=$((PASS + 1))
-    printf '  ok    %s\n' "$name"
-  else
-    FAIL=$((FAIL + 1))
-    printf '  FAIL  %s\n        expected substring: %s\n        in:                 %s\n' "$name" "$needle" "$haystack"
-  fi
-}
-
-assert_file_not_contains() {
-  local file="$1" pattern="$2" name="$3"
-  if grep -Fq -- "$pattern" "$file"; then
-    FAIL=$((FAIL + 1))
-    printf '  FAIL  %s\n        unexpected pattern: %s\n        file: %s\n' "$name" "$pattern" "$file"
-  else
-    PASS=$((PASS + 1))
-    printf '  ok    %s\n' "$name"
-  fi
-}
-
-# expect_valid <artifact-path> <desc> — accepting-direction assertion that
-# survives a mutant. A bare `out="$("$CHECK" ...)"` aborts the whole run under
-# set -e the moment a guard starts over-rejecting, which truncates the suite
-# instead of naming what broke; the accepting direction is exactly where that
-# matters, because it is what pins WHICH number a guard reads.
-expect_valid() {
-  local path="$1" desc="$2" out rc=0
+# run_check ARGS... — runs the check with %W, %F and %D in ARGS replaced by
+# the staged worktree, the --file target and the delegation boundary; OUT is
+# the JSON, RC the exit, ERR the stderr file.
+run_check() {
+  local args=() a
+  for a in "$@"; do a="${a//%W/$WT}"; a="${a//%F/$F}"; a="${a//%D/$DELEG}"; args+=("$a"); done
+  ERR="$RUN/stderr"
   set +e
-  out="$("$CHECK" --file "$path")"
-  rc=$?
+  OUT=$("$CHECK" ${args[@]+"${args[@]}"} 2>"$ERR")
+  RC=$?
   set -e
-  assert_eq "$rc" "0" "$desc (exits 0)"
-  assert_eq "$(jq -r '.reason' <<<"$out")" "valid" "$desc"
 }
 
-# expect_glob_valid <worktree> <agent> <boundary> <expected-path> <desc>
-expect_glob_valid() {
-  local wt="$1" ag="$2" bound="$3" want="$4" desc="$5" out rc=0
-  set +e
-  out="$("$CHECK" "$wt" "$ag" "$bound")"
-  rc=$?
-  set -e
-  assert_eq "$rc" "0" "$desc (exits 0)"
-  assert_eq "$(jq -r '.path' <<<"$out")" "$want" "$desc"
+json() { jq -r "$1" <<<"$OUT" 2>/dev/null || echo UNPARSEABLE; }
+
+# observe EXPECT — prints the run's value of every `name=` field EXPECT names,
+# in EXPECT's order. Plain names are JSON result fields, a key the result does
+# not carry reads ABSENT;
+#   rc              exit status
+#   path            the basename of the reported path, or null
+#   detail~<text>   whether the detail names <text> (`+` reads as a space):
+#                   the detail is what the rejected reviewer acts on, and
+#                   which shape it saw lives nowhere else
+#   detail_present  whether a detail is a non-empty string
+#   stdout~<text>   whether stdout carries <text>
+#   stderr          `line` when anything was written there, else `empty`
+observe() {
+  local got="" token name value needle
+  for token in $1; do
+    name="${token%%=*}"
+    case "$name" in
+      rc) value="$RC" ;;
+      path) value="$(json '.path | if . == null then "null" else sub(".*/"; "") end')" ;;
+      detail~*) needle="${name#detail~}"; value="$(json '.detail // ""' | grep -qF -- "${needle//+/ }" && echo true || echo false)" ;;
+      detail_present) value="$(json '(.detail | type) == "string" and .detail != ""')" ;;
+      stdout~*) needle="${name#stdout~}"; value="$(grep -qF -- "${needle//+/ }" <<<"$OUT" && echo true || echo false)" ;;
+      stderr) value="$([[ -s "$ERR" ]] && echo line || echo empty)" ;;
+      *) value="$(json "if has(\"$name\") then .$name else \"ABSENT\" end")" ;;
+    esac
+    got="$got $name=$value"
+  done
+  printf '%s' "${got# }"
 }
 
-echo "=== review-artifact-check ==="
+# table ROW... — one staged worktree, one run and one assertion per row:
+# `label|stage|args|expect`.
+table() {
+  local row label spec args expect
+  for row in "$@"; do
+    IFS='|' read -r label spec args expect <<<"$row"
+    [[ -n "$expect" ]] || { printf 'table: a row with no expect asserts nothing: %s\n' "$row" >&2; exit 1; }
+    stage "$spec"
+    # shellcheck disable=SC2086
+    run_check $args
+    assert_eq "$(observe "$expect")" "$expect" "$label" "$ERR"
+  done
+}
 
-worktree="$TMP_ROOT/wt"
-mkdir -p "$worktree/tmp"
-delegated_at=1750000000
-before=$((delegated_at - 100))
-after=$((delegated_at + 100))
-later=$((delegated_at + 200))
+GLOB='%W reviewer-quality %D'
+Q=review-reviewer-quality
 
-# --- missing: no artifacts at all ---
-set +e
-out="$("$CHECK" "$worktree" reviewer-quality "$delegated_at")"
-rc=$?
-set -e
-assert_eq "$rc" "1" "missing artifact exits 1"
-assert_eq "$(jq -r '.ok' <<<"$out")" "false" "missing artifact reports ok=false"
-assert_eq "$(jq -r '.path' <<<"$out")" "null" "missing artifact reports null path"
-assert_eq "$(jq -r '.reason' <<<"$out")" "missing" "missing artifact reports reason=missing"
+echo "=== glob mode resolves the newest fresh artifact of the agent ==="
+# Another agent's file does not count; an artifact older than the boundary is
+# stale; a fresh one without a verdict is invalid and named; a fresh valid one
+# wins over stale and invalid siblings; a newest-but-unparseable file falls
+# back to an older fresh valid one.
+table \
+  "no artifact at all is missing||$GLOB|rc=1 ok=false path=null reason=missing" \
+  "another agent's fresh artifact does not count|review-reviewer-arch-1@after=pass|$GLOB|rc=1 reason=missing" \
+  "an artifact older than the boundary is stale and named|$Q-1@before=pass|$GLOB|rc=1 ok=false path=$Q-1.json reason=stale" \
+  "a fresh artifact without a verdict is invalid and named|$Q-1@before=pass;$Q-2@after=noverdict|$GLOB|rc=1 path=$Q-2.json reason=invalid" \
+  "a fresh valid artifact wins over stale and invalid siblings|$Q-1@before=pass;$Q-2@after=noverdict;$Q-3@later=action|$GLOB|rc=0 ok=true path=$Q-3.json reason=valid" \
+  "a newest unparseable file falls back to the older fresh valid one|$Q-3@later=action;$Q-4@later2=notjson|$GLOB|rc=0 ok=true path=$Q-3.json reason=valid"
 
-# --- other agent's artifact does not count ---
-other="$worktree/tmp/review-reviewer-arch-20260709-010101.json"
-printf '{"verdict":"pass","items":[]}' > "$other"
-touch -d "@$after" "$other"
-set +e
-out="$("$CHECK" "$worktree" reviewer-quality "$delegated_at")"
-rc=$?
-set -e
-assert_eq "$rc" "1" "other agent's artifact exits 1"
-assert_eq "$(jq -r '.reason' <<<"$out")" "missing" "other agent's artifact still reason=missing"
+echo "=== file mode validates one path, the boundary optional ==="
+# Without a boundary the mtime is ignored; with one, glob mode's freshness
+# gate applies with >= semantics; existence is checked before freshness and
+# freshness before the verdict.
+table \
+  "a valid file|F@none=pass|--file %F|rc=0 ok=true path=review-external-F.json reason=valid" \
+  "an old mtime validates without a boundary|F@before=pass|--file %F|rc=0 ok=true reason=valid" \
+  "an mtime before the boundary is stale|F@before=pass|--file %F %D|rc=1 ok=false path=review-external-F.json reason=stale" \
+  "an mtime after the boundary is fresh|F@after=pass|--file %F %D|rc=0 ok=true reason=valid" \
+  "an mtime equal to the boundary is fresh|F@at=pass|--file %F %D|reason=valid" \
+  "fresh but without a verdict is invalid|F@after=noverdict|--file %F %D|rc=1 reason=invalid" \
+  "a missing file with a boundary is missing|F@none=pass|--file %W/tmp/nope.json %D|rc=1 reason=missing" \
+  "a missing file|F@none=pass|--file %W/tmp/nope.json|rc=1 ok=false path=null reason=missing" \
+  "a file without a verdict is invalid and named|F@none=noverdict|--file %F|rc=1 path=review-external-F.json reason=invalid"
 
-# --- stale: artifact predates delegation ---
-stale="$worktree/tmp/review-reviewer-quality-20260709-010101.json"
-printf '{"verdict":"pass","items":[]}' > "$stale"
-touch -d "@$before" "$stale"
-set +e
-out="$("$CHECK" "$worktree" reviewer-quality "$delegated_at")"
-rc=$?
-set -e
-assert_eq "$rc" "1" "stale artifact exits 1"
-assert_eq "$(jq -r '.ok' <<<"$out")" "false" "stale artifact reports ok=false"
-assert_eq "$(jq -r '.path' <<<"$out")" "$stale" "stale artifact reports its path"
-assert_eq "$(jq -r '.reason' <<<"$out")" "stale" "stale artifact reports reason=stale"
+echo "=== a self-reported no-review artifact is refused, and terminally ==="
+# review_performed=false, or a no-review reason alone, is an admission
+# whatever the verdict; no qa_metadata keeps the existence-plus-verdict
+# tolerance; an empty qa_metadata with the arrays, or review_performed=true,
+# validates. In glob mode the refusal is terminal: no_review is the
+# reviewer's self-report about THIS run, so an older fresh sibling does not
+# rescue it; a STALE no-review artifact does not block a fresh valid one.
+E=review-reviewer-ext
+table \
+  "review_performed=false|F@after=noreview|--file %F|rc=1 ok=false path=review-external-F.json reason=no_review" \
+  "a no-review reason alone|F@none=noreview_reason|--file %F|rc=1 reason=no_review" \
+  "review_performed=false alone, arrays present, is still no_review|F@none=noreview_flag|--file %F|rc=1 reason=no_review" \
+  "no qa_metadata at all still validates|F@none=pass|--file %F|ok=true reason=valid" \
+  "empty qa_metadata with the arrays validates|F@none=qa_ok|--file %F|reason=valid" \
+  "review_performed=true validates|F@none=performed|--file %F|reason=valid" \
+  "glob: a fresh no-review artifact is refused and named|$E-1@after=noreview|%W reviewer-ext %D|rc=1 path=$E-1.json reason=no_review" \
+  "glob: terminal, an older fresh valid sibling does not rescue it|$E-0@after=qa_ok_noq;$E-1@later=noreview|%W reviewer-ext %D|rc=1 path=$E-1.json reason=no_review" \
+  "glob control: a stale no-review artifact does not block a fresh valid one|$E-0@after=qa_ok_noq;$E-1@before=noreview|%W reviewer-ext %D|rc=0 path=$E-0.json reason=valid"
 
-# --- invalid: fresh artifact without verdict field ---
-invalid="$worktree/tmp/review-reviewer-quality-20260709-020202.json"
-printf '{"items":[]}' > "$invalid"
-touch -d "@$after" "$invalid"
-set +e
-out="$("$CHECK" "$worktree" reviewer-quality "$delegated_at")"
-rc=$?
-set -e
-assert_eq "$rc" "1" "fresh artifact missing verdict exits 1"
-assert_eq "$(jq -r '.reason' <<<"$out")" "invalid" "fresh artifact missing verdict reports reason=invalid"
-assert_eq "$(jq -r '.path' <<<"$out")" "$invalid" "invalid report points at newest fresh artifact"
-
-# --- valid: fresh artifact with verdict wins over stale/invalid siblings ---
-valid="$worktree/tmp/review-reviewer-quality-20260709-030303.json"
-printf '{"verdict":"action_required","items":[{"category":"fix"}]}' > "$valid"
-touch -d "@$later" "$valid"
-out="$("$CHECK" "$worktree" reviewer-quality "$delegated_at")"
-assert_eq "$(jq -r '.ok' <<<"$out")" "true" "valid fresh artifact reports ok=true"
-assert_eq "$(jq -r '.path' <<<"$out")" "$valid" "valid fresh artifact reports its path"
-assert_eq "$(jq -r '.reason' <<<"$out")" "valid" "valid fresh artifact reports reason=valid"
-
-# --- newest artifact invalid: falls back to older fresh valid artifact ---
-newest_invalid="$worktree/tmp/review-reviewer-quality-20260709-040404.json"
-printf 'not json' > "$newest_invalid"
-touch -d "@$((later + 100))" "$newest_invalid"
-out="$("$CHECK" "$worktree" reviewer-quality "$delegated_at")"
-assert_eq "$(jq -r '.ok' <<<"$out")" "true" "newest-invalid falls back to older valid artifact"
-assert_eq "$(jq -r '.path' <<<"$out")" "$valid" "fallback selects the older fresh valid artifact"
-
-# --- --file mode: explicit path validation (external review output) ---
-ext_valid="$worktree/tmp/review-external-20260709-050505.json"
-printf '{"verdict":"pass","items":[]}' > "$ext_valid"
-out="$("$CHECK" --file "$ext_valid")"
-rc=$?
-assert_eq "$rc" "0" "--file valid artifact exits 0"
-assert_eq "$(jq -r '.ok' <<<"$out")" "true" "--file valid reports ok=true"
-assert_eq "$(jq -r '.path' <<<"$out")" "$ext_valid" "--file valid reports its path"
-assert_eq "$(jq -r '.reason' <<<"$out")" "valid" "--file valid reports reason=valid"
-
-# --file with NO boundary does not apply the staleness gate — an old mtime still validates
-touch -d "@$before" "$ext_valid"
-out="$("$CHECK" --file "$ext_valid")"
-assert_eq "$(jq -r '.ok' <<<"$out")" "true" "--file without boundary ignores mtime (existence+verdict only)"
-
-# --- --file mode: OPTIONAL delegated_at boundary applies glob mode's freshness gate ---
-# older-than-boundary mtime → stale
-touch -d "@$before" "$ext_valid"
-set +e
-out="$("$CHECK" --file "$ext_valid" "$delegated_at")"
-rc=$?
-set -e
-assert_eq "$rc" "1" "--file with boundary, older mtime exits 1"
-assert_eq "$(jq -r '.ok' <<<"$out")" "false" "--file stale reports ok=false"
-assert_eq "$(jq -r '.path' <<<"$out")" "$ext_valid" "--file stale reports its path"
-assert_eq "$(jq -r '.reason' <<<"$out")" "stale" "--file older-than-boundary reports reason=stale"
-
-# newer-than-boundary mtime → valid
-touch -d "@$after" "$ext_valid"
-out="$("$CHECK" --file "$ext_valid" "$delegated_at")"
-rc=$?
-assert_eq "$rc" "0" "--file with boundary, newer mtime exits 0"
-assert_eq "$(jq -r '.ok' <<<"$out")" "true" "--file fresh (mtime >= boundary) reports ok=true"
-assert_eq "$(jq -r '.reason' <<<"$out")" "valid" "--file newer-than-boundary reports reason=valid"
-
-# mtime exactly equal to boundary is fresh (not stale) — matches glob mode's >= semantics
-touch -d "@$delegated_at" "$ext_valid"
-out="$("$CHECK" --file "$ext_valid" "$delegated_at")"
-assert_eq "$(jq -r '.reason' <<<"$out")" "valid" "--file mtime == boundary is fresh"
-
-# fresh mtime but missing verdict → invalid (freshness passes, verdict gate fails)
-ext_fresh_noverdict="$worktree/tmp/review-external-20260709-070707.json"
-printf '{"items":[]}' > "$ext_fresh_noverdict"
-touch -d "@$after" "$ext_fresh_noverdict"
-set +e
-out="$("$CHECK" --file "$ext_fresh_noverdict" "$delegated_at")"
-rc=$?
-set -e
-assert_eq "$rc" "1" "--file fresh-but-no-verdict with boundary exits 1"
-assert_eq "$(jq -r '.reason' <<<"$out")" "invalid" "--file fresh-but-no-verdict with boundary reports reason=invalid"
-
-# missing file with a boundary still reports missing (existence checked before freshness)
-set +e
-out="$("$CHECK" --file "$worktree/tmp/review-external-nope.json" "$delegated_at")"
-rc=$?
-set -e
-assert_eq "$rc" "1" "--file missing with boundary exits 1"
-assert_eq "$(jq -r '.reason' <<<"$out")" "missing" "--file missing with boundary reports reason=missing"
-
-# --file: missing file
-set +e
-out="$("$CHECK" --file "$worktree/tmp/review-external-does-not-exist.json")"
-rc=$?
-set -e
-assert_eq "$rc" "1" "--file missing artifact exits 1"
-assert_eq "$(jq -r '.ok' <<<"$out")" "false" "--file missing reports ok=false"
-assert_eq "$(jq -r '.path' <<<"$out")" "null" "--file missing reports null path"
-assert_eq "$(jq -r '.reason' <<<"$out")" "missing" "--file missing reports reason=missing"
-
-# --file: exists but no verdict field
-ext_invalid="$worktree/tmp/review-external-20260709-060606.json"
-printf '{"items":[]}' > "$ext_invalid"
-set +e
-out="$("$CHECK" --file "$ext_invalid")"
-rc=$?
-set -e
-assert_eq "$rc" "1" "--file missing verdict exits 1"
-assert_eq "$(jq -r '.reason' <<<"$out")" "invalid" "--file missing verdict reports reason=invalid"
-assert_eq "$(jq -r '.path' <<<"$out")" "$ext_invalid" "--file invalid reports the file path"
-
-# --- no_review: self-reported no-review artifacts are rejected ---
-# A schema-valid pass verdict whose qa_metadata admits no review happened must
-# never validate, regardless of verdict.
-noreview="$worktree/tmp/review-external-20260718-010101.json"
-printf '{"verdict":"pass","summary":"No review was actually performed","qa_metadata":{"review_performed":false,"reason":"no_scope_provided"}}' > "$noreview"
-touch -d "@$after" "$noreview"
-set +e
-out="$("$CHECK" --file "$noreview")"
-rc=$?
-set -e
-assert_eq "$rc" "1" "--file review_performed=false exits 1"
-assert_eq "$(jq -r '.ok' <<<"$out")" "false" "--file review_performed=false reports ok=false"
-assert_eq "$(jq -r '.path' <<<"$out")" "$noreview" "--file review_performed=false reports its path"
-assert_eq "$(jq -r '.reason' <<<"$out")" "no_review" "--file review_performed=false reports reason=no_review"
-
-# a no-review reason alone (without review_performed) is also an admission
-noreview_reason="$worktree/tmp/review-external-20260718-020202.json"
-printf '{"verdict":"pass","qa_metadata":{"reason":"no_scope_provided"}}' > "$noreview_reason"
-set +e
-out="$("$CHECK" --file "$noreview_reason")"
-rc=$?
-set -e
-assert_eq "$rc" "1" "--file no-scope reason alone exits 1"
-assert_eq "$(jq -r '.reason' <<<"$out")" "no_review" "--file no-scope reason alone reports reason=no_review"
-
-# backward compat: no qa_metadata at all still validates on existence + verdict
-no_qa="$worktree/tmp/review-external-20260718-030303.json"
-printf '{"verdict":"pass","items":[]}' > "$no_qa"
-out="$("$CHECK" --file "$no_qa")"
-assert_eq "$(jq -r '.ok' <<<"$out")" "true" "--file artifact without qa_metadata still validates"
-assert_eq "$(jq -r '.reason' <<<"$out")" "valid" "--file artifact without qa_metadata reports reason=valid"
-
-# empty qa_metadata (the schema's performed-review shape) with the finding
-# arrays validates — declaring qa_metadata requires the arrays
-empty_qa="$worktree/tmp/review-external-20260718-040404.json"
-printf '{"verdict":"pass","blockers":[],"suggestions":[],"questions":[],"qa_metadata":{}}' > "$empty_qa"
-out="$("$CHECK" --file "$empty_qa")"
-assert_eq "$(jq -r '.reason' <<<"$out")" "valid" "--file empty qa_metadata with arrays reports reason=valid"
-
-# explicit review_performed=true validates
-performed="$worktree/tmp/review-external-20260718-050505.json"
-printf '{"verdict":"pass","blockers":[],"suggestions":[],"qa_metadata":{"review_performed":true}}' > "$performed"
-out="$("$CHECK" --file "$performed")"
-assert_eq "$(jq -r '.reason' <<<"$out")" "valid" "--file review_performed=true reports reason=valid"
-
-# glob mode applies the same gate: a fresh no-review artifact is rejected...
-glob_noreview="$worktree/tmp/review-reviewer-ext-20260718-060606.json"
-printf '{"verdict":"pass","qa_metadata":{"review_performed":false,"reason":"no_scope_provided"}}' > "$glob_noreview"
-touch -d "@$after" "$glob_noreview"
-set +e
-out="$("$CHECK" "$worktree" reviewer-ext "$delegated_at")"
-rc=$?
-set -e
-assert_eq "$rc" "1" "glob no-review artifact exits 1"
-assert_eq "$(jq -r '.reason' <<<"$out")" "no_review" "glob no-review artifact reports reason=no_review"
-assert_eq "$(jq -r '.path' <<<"$out")" "$glob_noreview" "glob no-review report points at the artifact"
-
-# ...and it is TERMINAL: an older fresh sibling does NOT rescue it. no_review is
-# the reviewer's self-report about the RUN, and the prescribed self-check
-# boundary of 0 makes every prior artifact fresh, so falling back would answer
-# "did some prior round leave a file?" instead of "did this review happen?"
-glob_valid="$worktree/tmp/review-reviewer-ext-20260718-000000.json"
-printf '{"verdict":"pass","blockers":[],"suggestions":[],"qa_metadata":{}}' > "$glob_valid"
-touch -d "@$after" "$glob_valid"
-touch -d "@$later" "$glob_noreview"
-set +e
-out="$("$CHECK" "$worktree" reviewer-ext "$delegated_at")"
-rc=$?
-set -e
-assert_eq "$rc" "1" "glob no-review is terminal, not rescued by an older sibling"
-assert_eq "$(jq -r '.reason' <<<"$out")" "no_review" "glob terminal no-review keeps reason=no_review"
-assert_eq "$(jq -r '.path' <<<"$out")" "$glob_noreview" "glob terminal no-review points at the rejected artifact"
-
-# MUST-FAIL CONTROL for the terminal rule: with the no-review artifact STALE
-# (not fresh), the older-but-fresh valid sibling is still the answer — terminal
-# means "this run is refused", not "this agent is refused forever".
-touch -d "@$before" "$glob_noreview"
-expect_glob_valid "$worktree" reviewer-ext "$delegated_at" "$glob_valid" "a STALE no-review artifact does not block a fresh valid one"
-touch -d "@$later" "$glob_noreview"
-
-# --- incomplete: qa-shaped artifacts must carry the finding arrays ---
-# A truncated write can keep verdict/summary while losing blockers/suggestions —
-# schema-valid on the `.verdict` gate, but the findings are gone. An artifact
-# that declares qa_metadata without the arrays is rejected reason=incomplete;
-# artifacts without qa_metadata keep the pre-existing tolerance (see no_qa above).
-inc="$worktree/tmp/review-external-20260718-070707.json"
-printf '{"agent":"external-codex","timestamp":"2026-07-18T00:00:00Z","verdict":"pass","summary":"looks fine","qa_metadata":{}}' > "$inc"
-set +e
-out="$("$CHECK" --file "$inc")"
-rc=$?
-set -e
-assert_eq "$rc" "1" "--file qa-shaped artifact without arrays exits 1"
-assert_eq "$(jq -r '.ok' <<<"$out")" "false" "--file qa-shaped without arrays reports ok=false"
-assert_eq "$(jq -r '.path' <<<"$out")" "$inc" "--file qa-shaped without arrays reports its path"
-assert_eq "$(jq -r '.reason' <<<"$out")" "incomplete" "--file qa-shaped without arrays reports reason=incomplete"
-
-# a mistyped array is as lost as a missing one
-inc_type="$worktree/tmp/review-external-20260718-080808.json"
-printf '{"verdict":"pass","blockers":"none","suggestions":[],"qa_metadata":{}}' > "$inc_type"
-set +e
-out="$("$CHECK" --file "$inc_type")"
-rc=$?
-set -e
-assert_eq "$rc" "1" "--file non-array blockers exits 1"
-assert_eq "$(jq -r '.reason' <<<"$out")" "incomplete" "--file non-array blockers reports reason=incomplete"
-
-# missing suggestions alone is incomplete too
-inc_sugg="$worktree/tmp/review-external-20260718-090909.json"
-printf '{"verdict":"pass","blockers":[],"qa_metadata":{}}' > "$inc_sugg"
-set +e
-out="$("$CHECK" --file "$inc_sugg")"
-rc=$?
-set -e
-assert_eq "$rc" "1" "--file missing suggestions exits 1"
-assert_eq "$(jq -r '.reason' <<<"$out")" "incomplete" "--file missing suggestions reports reason=incomplete"
-
-# questions[] is NOT required (PR-comment-triage-only; the QA standard fields omit it)
-no_questions="$worktree/tmp/review-external-20260718-101010.json"
-printf '{"verdict":"pass","blockers":[],"suggestions":[],"qa_metadata":{}}' > "$no_questions"
-out="$("$CHECK" --file "$no_questions")"
-assert_eq "$(jq -r '.reason' <<<"$out")" "valid" "--file qa-shaped without questions still validates"
-
-# glob mode applies the same gate: a fresh qa-shaped incomplete artifact is rejected...
-glob_inc="$worktree/tmp/review-reviewer-inc-20260718-111111.json"
-printf '{"verdict":"pass","summary":"truncated","qa_metadata":{}}' > "$glob_inc"
-touch -d "@$after" "$glob_inc"
-set +e
-out="$("$CHECK" "$worktree" reviewer-inc "$delegated_at")"
-rc=$?
-set -e
-assert_eq "$rc" "1" "glob qa-shaped artifact without arrays exits 1"
-assert_eq "$(jq -r '.reason' <<<"$out")" "incomplete" "glob qa-shaped without arrays reports reason=incomplete"
-assert_eq "$(jq -r '.path' <<<"$out")" "$glob_inc" "glob incomplete report points at the artifact"
-
-# ...and it is TERMINAL. This gate was filed as the truncated-write shape until
-# the argument was checked: a truncated JSON object is not a JSON object, so
-# every torn or partial write fails the `.verdict` parse before any content gate
-# runs. What reaches this gate is well-formed JSON the writer produced, which no
-# older artifact answers for.
-glob_inc_valid="$worktree/tmp/review-reviewer-inc-20260718-000000.json"
-printf '{"verdict":"pass","blockers":[],"suggestions":[],"qa_metadata":{}}' > "$glob_inc_valid"
-touch -d "@$after" "$glob_inc_valid"
-touch -d "@$later" "$glob_inc"
-set +e
-out="$("$CHECK" "$worktree" reviewer-inc "$delegated_at")"
-rc=$?
-set -e
-assert_eq "$rc" "1" "glob qa-shape incomplete is terminal, not rescued by an older sibling"
-assert_eq "$(jq -r '.path' <<<"$out")" "$glob_inc" "glob terminal qa-shape points at the rejected artifact"
-
-# MUST-FAIL CONTROL: stale, and the fresh complete one is the answer again.
-touch -d "@$before" "$glob_inc"
-expect_glob_valid "$worktree" reviewer-inc "$delegated_at" "$glob_inc_valid" "a STALE qa-shape artifact does not block a fresh complete one"
-touch -d "@$later" "$glob_inc"
-
-# THE PREMISE, ASSERTED: no prefix truncation of a review artifact ever reaches
-# a content gate, because it is not parseable JSON. If this ever stopped
-# holding, the disposition above would be wrong.
+echo "=== a qa-shaped artifact must carry the finding arrays ==="
+# Declaring qa_metadata requires blockers[] and suggestions[] (questions[] is
+# not required); a mistyped array is as lost as a missing one. In glob mode
+# the refusal is terminal, and a STALE incomplete artifact does not block a
+# fresh complete one. A prefix truncation never reaches this gate: it is not
+# JSON, so every one is invalid first.
+I=review-reviewer-inc
+table \
+  "qa-shaped without the arrays is incomplete and named|F@none=qa_inc_agent|--file %F|rc=1 ok=false path=review-external-F.json reason=incomplete" \
+  "a non-array blockers|F@none=inc_type|--file %F|rc=1 reason=incomplete" \
+  "missing suggestions alone|F@none=inc_sugg|--file %F|rc=1 reason=incomplete" \
+  "questions[] is not required|F@none=qa_ok_noq|--file %F|reason=valid" \
+  "glob: a fresh qa-shaped incomplete artifact is refused and named|$I-1@after=qa_inc|%W reviewer-inc %D|rc=1 path=$I-1.json reason=incomplete" \
+  "glob: terminal, an older fresh complete sibling does not rescue it|$I-0@after=qa_ok_noq;$I-1@later=qa_inc|%W reviewer-inc %D|rc=1 path=$I-1.json" \
+  "glob control: a stale incomplete artifact does not block a fresh complete one|$I-0@after=qa_ok_noq;$I-1@before=qa_inc|%W reviewer-inc %D|rc=0 path=$I-0.json"
 trunc_src='{"agent":"r","verdict":"pass","summary":"s","blockers":[{"id":1,"title":"t","location":"l","description":"d","recommendation":"r","priority":1,"estimate":1}],"suggestions":[],"qa_metadata":{"x":1}}'
 trunc_bad=""
+stage ""
 for pct in 20 40 60 80 90 95 99; do
-  trunc_path="$worktree/tmp/review-external-20260813-0000$pct.json"
-  printf '%s' "${trunc_src:0:$(( ${#trunc_src} * pct / 100 ))}" > "$trunc_path"
-  set +e
-  trunc_out="$("$CHECK" --file "$trunc_path")"
-  set -e
-  trunc_reason="$(jq -r '.reason' <<<"$trunc_out" 2>/dev/null || printf 'unparseable')"
-  [[ "$trunc_reason" == "invalid" ]] || trunc_bad="$trunc_bad ${pct}%:$trunc_reason"
+  printf '%s' "${trunc_src:0:$(( ${#trunc_src} * pct / 100 ))}" > "$WT/tmp/trunc-$pct.json"
+  run_check --file "$WT/tmp/trunc-$pct.json"
+  [[ "$(json .reason)" == "invalid" ]] || trunc_bad="$trunc_bad ${pct}%:$(json .reason)"
 done
 assert_eq "$trunc_bad" "" "every prefix truncation is rejected as invalid before any content gate"
 
-# --- incomplete: qa-shaped artifacts must carry USABLE finding items ---
-# qa_shaped_incomplete only catches arrays lost wholesale. An artifact can carry
-# present, non-empty blockers[]/suggestions[] whose ITEMS omit the required
-# review-finding fields — present in prose but unroutable, because the
-# orchestrator routes suggestions on `category`. Required item set (from
-# reviewer/schemas/review-finding.md § Item Fields): id, title, location,
-# description, recommendation, priority, estimate — plus category (∈ fix|issue)
-# for suggestions. Reason reuses `incomplete`; a `detail` field names the first
-# offending item and field.
+echo "=== a qa-shaped artifact must carry usable finding items, and the detail says which ==="
+# Items need id, title, location, description, recommendation, priority
+# (1..4) and estimate (1..5), suggestions also category in {fix, issue}; the
+# detail names the first offending item and field. Artifacts without
+# qa_metadata keep the tolerant shape. A missing array, a null one and a
+# wrong-typed one are three different things the agent did and the detail
+# says which, and what an empty review writes. Every rejection in the chain
+# names its cause. In glob mode a malformed-item artifact is refused
+# terminally, and a STALE one does not block a fresh well-formed one.
+T=review-reviewer-item
+table \
+  "the issue's malformed suggestion is incomplete, the detail names the item and the missing category|F@none=issue_bad|--file %F|rc=1 ok=false path=review-external-F.json reason=incomplete detail~suggestions[0]=true detail~category=true" \
+  "a fully compliant artifact is valid and carries no detail key|F@none=compliant|--file %F|ok=true reason=valid detail=ABSENT" \
+  "empty arrays carry no items and stay valid|F@none=qa_ok_noq|--file %F|reason=valid" \
+  "a suggestion missing only category|F@none=nocat|--file %F|rc=1 reason=incomplete detail~category=true" \
+  "a category outside fix and issue|F@none=badcatval|--file %F|rc=1 reason=incomplete" \
+  "a blocker missing a base field, named|F@none=badblk|--file %F|rc=1 reason=incomplete detail~blockers[0]=true detail~description=true" \
+  "a blocker without category is valid|F@none=okblk|--file %F|reason=valid" \
+  "a priority outside 1..4, named|F@none=badpri|--file %F|rc=1 reason=incomplete detail~priority=true" \
+  "a string estimate, named|F@none=badest|--file %F|rc=1 detail~estimate=true" \
+  "a blocker priority below the range, named on its array|F@none=badblkpri|--file %F|rc=1 detail~blockers[0]=true" \
+  "the boundary values priority 4 and estimate 5 are valid|F@none=okbound|--file %F|reason=valid" \
+  "malformed items without qa_metadata stay tolerant|F@none=noqa_bad|--file %F|reason=valid" \
+  "arrays lost: the detail names both arrays as absent and the exempt shape|F@none=qa_inc|--file %F|reason=incomplete detail~blockers[]+is+absent=true detail~suggestions[]+is+absent=true detail~no+qa_metadata=true" \
+  "a null blockers is reported as null, and what an empty review writes|F@none=null_blockers|--file %F|rc=1 reason=incomplete detail~blockers[]+is+null=true detail~writes+[]=true" \
+  "a missing blockers is reported as absent|F@none=inc_sugg|--file %F|detail~blockers[]+is+absent=false detail~suggestions[]+is+absent=true" \
+  "an object blockers is reported by type|F@none=obj_blockers|--file %F|rc=1 reason=incomplete detail~blockers[]+is+object,+not+an+array=true detail~writes+[]=true" \
+  "a string blockers is reported by type|F@none=str_blockers|--file %F|rc=1 reason=incomplete detail~blockers[]+is+string,+not+an+array=true detail~writes+[]=true" \
+  "a number blockers is reported by type|F@none=num_blockers|--file %F|rc=1 reason=incomplete detail~blockers[]+is+number,+not+an+array=true detail~writes+[]=true" \
+  "a null suggestions is reported on its own|F@none=null_sugg|--file %F|detail~suggestions[]+is+null=true" \
+  "a wrong-typed suggestions is reported on its own|F@none=str_sugg|--file %F|detail~suggestions[]+is+string,+not+an+array=true" \
+  "chain: a missing verdict names its cause|F@none=chain_noverdict|--file %F|ok=false detail_present=true" \
+  "chain: a no-review admission names its cause|F@none=chain_noreview|--file %F|ok=false detail_present=true" \
+  "chain: a qa-shape loss names its cause|F@none=qa_inc|--file %F|ok=false detail_present=true" \
+  "chain: a malformed finding item names its cause|F@none=chain_item|--file %F|ok=false detail_present=true" \
+  "chain: a bad measurement declaration names its cause|F@none=chain_decl|--file %F|ok=false detail_present=true" \
+  "chain: a zero-sample measurement names its cause|F@none=chain_zero|--file %F|ok=false detail_present=true" \
+  "glob missing names the glob that matched nothing||%W ghost-agent 0|reason=missing detail~review-ghost-agent-=true" \
+  "glob stale names the mtime against the boundary|review-staleonly-1@before=pass|%W staleonly %D|reason=stale detail~predates+the+boundary=true" \
+  "file missing names the path||--file %W/definitely-not-here.json|reason=missing detail~no+file+at=true" \
+  "file stale names the mtime against the boundary|F@before=pass|--file %F %D|reason=stale detail~predates+the+boundary=true" \
+  "glob: a fresh malformed-item artifact is refused and named|$T-1@after=item_bad|%W reviewer-item %D|rc=1 path=$T-1.json reason=incomplete detail~suggestions[0]=true" \
+  "glob: terminal, an older fresh well-formed sibling does not rescue it|$T-0@after=item_ok;$T-1@later=item_bad|%W reviewer-item %D|rc=1 path=$T-1.json reason=incomplete" \
+  "glob control: a stale malformed-item artifact does not block a fresh well-formed one|$T-0@after=item_ok;$T-1@before=item_bad|%W reviewer-item %D|rc=0 path=$T-0.json"
 
-# the exact malformed shape from the issue: {title, location, detail, severity}
-issue_bad="$worktree/tmp/review-external-20260810-010101.json"
-printf '{"agent":"reviewer-arch","verdict":"pass","blockers":[],"suggestions":[{"title":"Two resolvers coexist","location":"/abs/instrument_link.rs (instrument_name)","detail":"...","severity":"low"}],"qa_metadata":{"arch_review":{"overall_score":8.4,"pass":true}}}' > "$issue_bad"
-set +e
-out="$("$CHECK" --file "$issue_bad")"
-rc=$?
-set -e
-assert_eq "$rc" "1" "--file issue malformed suggestion exits 1"
-assert_eq "$(jq -r '.ok' <<<"$out")" "false" "--file issue malformed suggestion reports ok=false"
-assert_eq "$(jq -r '.path' <<<"$out")" "$issue_bad" "--file issue malformed suggestion reports its path"
-assert_eq "$(jq -r '.reason' <<<"$out")" "incomplete" "--file issue malformed suggestion reports reason=incomplete"
-assert_substr "$(jq -r '.detail' <<<"$out")" "suggestions[0]" "--file issue malformed detail names the offending item"
-assert_substr "$(jq -r '.detail' <<<"$out")" "category" "--file issue malformed detail names the missing category field"
+echo "=== usage errors ==="
+table \
+  "missing arguments|F@none=pass|%W reviewer-quality|rc=2" \
+  "a non-numeric delegated_at|F@none=pass|%W reviewer-quality not-a-number|rc=2" \
+  "a nonexistent worktree||%W/does-not-exist reviewer-quality %D|rc=2" \
+  "--file with no path||--file|rc=2" \
+  "--file with a non-numeric boundary|F@none=pass|--file %F not-a-number|rc=2" \
+  "--file with too many arguments|F@none=pass|--file %F %D extra-arg|rc=2" \
+  "a non-integer --wait|F@none=pass|%W waitrev 0 --wait nope|rc=2" \
+  "the bare three-positional contract still validates|review-waitrev-1@after=qa_ok|%W waitrev 0|rc=0"
 
-# a fully schema-compliant artifact with populated items still validates
-compliant="$worktree/tmp/review-external-20260810-020202.json"
-printf '{"verdict":"action_required","blockers":[{"id":1,"title":"t","location":"src/x.rs (`f`)","description":"d","recommendation":"r","priority":1,"estimate":2}],"suggestions":[{"id":1,"title":"t","location":"src/y.rs (`g`)","description":"d","recommendation":"r","priority":3,"estimate":2,"category":"fix"}],"qa_metadata":{}}' > "$compliant"
-out="$("$CHECK" --file "$compliant")"
-assert_eq "$(jq -r '.ok' <<<"$out")" "true" "--file fully compliant items reports ok=true"
-assert_eq "$(jq -r '.reason' <<<"$out")" "valid" "--file fully compliant items reports reason=valid"
-assert_eq "$(jq -r '.detail' <<<"$out")" "null" "--file valid artifact carries no detail field"
-
-# empty blockers[]/suggestions[] carry no items and stay valid (do not regress)
-empty_items="$worktree/tmp/review-external-20260810-030303.json"
-printf '{"verdict":"pass","blockers":[],"suggestions":[],"qa_metadata":{}}' > "$empty_items"
-out="$("$CHECK" --file "$empty_items")"
-assert_eq "$(jq -r '.reason' <<<"$out")" "valid" "--file empty arrays stay valid under item check"
-
-# an item missing ONLY category (routing-critical) is rejected
-nocat="$worktree/tmp/review-external-20260810-040404.json"
-printf '{"verdict":"pass","blockers":[],"suggestions":[{"id":1,"title":"t","location":"l","description":"d","recommendation":"r","priority":3,"estimate":2}],"qa_metadata":{}}' > "$nocat"
-set +e
-out="$("$CHECK" --file "$nocat")"
-rc=$?
-set -e
-assert_eq "$rc" "1" "--file suggestion missing only category exits 1"
-assert_eq "$(jq -r '.reason' <<<"$out")" "incomplete" "--file suggestion missing only category reports reason=incomplete"
-assert_substr "$(jq -r '.detail' <<<"$out")" "category" "--file missing-category detail names category"
-
-# category present but not in {fix,issue} is rejected (routing keys on the value)
-badcatval="$worktree/tmp/review-external-20260810-050505.json"
-printf '{"verdict":"pass","blockers":[],"suggestions":[{"id":1,"title":"t","location":"l","description":"d","recommendation":"r","priority":3,"estimate":2,"category":"low"}],"qa_metadata":{}}' > "$badcatval"
-set +e
-out="$("$CHECK" --file "$badcatval")"
-rc=$?
-set -e
-assert_eq "$rc" "1" "--file suggestion category not in {fix,issue} exits 1"
-assert_eq "$(jq -r '.reason' <<<"$out")" "incomplete" "--file bad category value reports reason=incomplete"
-
-# blockers require the base fields but NOT category — a blocker missing a base
-# field is rejected, a blocker without category is fine
-badblk="$worktree/tmp/review-external-20260810-060606.json"
-printf '{"verdict":"action_required","blockers":[{"id":1,"title":"t","location":"l","recommendation":"r","priority":1,"estimate":2}],"suggestions":[],"qa_metadata":{}}' > "$badblk"
-set +e
-out="$("$CHECK" --file "$badblk")"
-rc=$?
-set -e
-assert_eq "$rc" "1" "--file blocker missing description exits 1"
-assert_eq "$(jq -r '.reason' <<<"$out")" "incomplete" "--file blocker missing base field reports reason=incomplete"
-assert_substr "$(jq -r '.detail' <<<"$out")" "blockers[0]" "--file blocker detail names the blockers array"
-assert_substr "$(jq -r '.detail' <<<"$out")" "description" "--file blocker detail names the missing field"
-
-okblk="$worktree/tmp/review-external-20260810-070707.json"
-printf '{"verdict":"action_required","blockers":[{"id":1,"title":"t","location":"l","description":"d","recommendation":"r","priority":1,"estimate":2}],"suggestions":[],"qa_metadata":{}}' > "$okblk"
-out="$("$CHECK" --file "$okblk")"
-assert_eq "$(jq -r '.reason' <<<"$out")" "valid" "--file blocker without category is valid (category is suggestions-only)"
-
-# priority/estimate range + type per review-finding.md (priority 1..4, estimate
-# 1..5: a present-but-out-of-range or non-numeric value is unusable
-badpri="$worktree/tmp/review-external-20260810-090909.json"
-printf '{"verdict":"pass","blockers":[],"suggestions":[{"id":1,"title":"t","location":"l","description":"d","recommendation":"r","priority":5,"estimate":2,"category":"fix"}],"qa_metadata":{}}' > "$badpri"
-set +e; out="$("$CHECK" --file "$badpri")"; rc=$?; set -e
-assert_eq "$rc" "1" "--file priority out of 1..4 exits 1"
-assert_eq "$(jq -r '.reason' <<<"$out")" "incomplete" "--file out-of-range priority reports reason=incomplete"
-assert_substr "$(jq -r '.detail' <<<"$out")" "priority" "--file out-of-range priority detail names priority"
-
-badest="$worktree/tmp/review-external-20260810-101010.json"
-printf '{"verdict":"pass","blockers":[],"suggestions":[{"id":1,"title":"t","location":"l","description":"d","recommendation":"r","priority":2,"estimate":"2","category":"issue"}],"qa_metadata":{}}' > "$badest"
-set +e; out="$("$CHECK" --file "$badest")"; rc=$?; set -e
-assert_eq "$rc" "1" "--file non-numeric estimate exits 1"
-assert_substr "$(jq -r '.detail' <<<"$out")" "estimate" "--file string estimate detail names estimate"
-
-# blockers carry the same numeric constraint (priority 0 is below range)
-badblkpri="$worktree/tmp/review-external-20260810-111111.json"
-printf '{"verdict":"action_required","blockers":[{"id":1,"title":"t","location":"l","description":"d","recommendation":"r","priority":0,"estimate":3}],"suggestions":[],"qa_metadata":{}}' > "$badblkpri"
-set +e; out="$("$CHECK" --file "$badblkpri")"; rc=$?; set -e
-assert_eq "$rc" "1" "--file blocker priority below 1..4 exits 1"
-assert_substr "$(jq -r '.detail' <<<"$out")" "blockers[0]" "--file blocker out-of-range detail names the blockers array"
-
-# boundary values (priority 1 and 4, estimate 1 and 5) are valid — not off-by-one rejected
-okbound="$worktree/tmp/review-external-20260810-121212.json"
-printf '{"verdict":"pass","blockers":[],"suggestions":[{"id":1,"title":"t","location":"l","description":"d","recommendation":"r","priority":4,"estimate":5,"category":"fix"}],"qa_metadata":{}}' > "$okbound"
-out="$("$CHECK" --file "$okbound")"
-assert_eq "$(jq -r '.reason' <<<"$out")" "valid" "--file priority=4 estimate=5 boundary values are valid"
-
-# artifacts WITHOUT qa_metadata keep the pre-existing tolerance — malformed items
-# do NOT trip the check (parity with qa_shaped_incomplete's gating)
-noqa_bad="$worktree/tmp/review-external-20260810-080808.json"
-printf '{"verdict":"pass","suggestions":[{"title":"t","location":"l"}]}' > "$noqa_bad"
-out="$("$CHECK" --file "$noqa_bad")"
-assert_eq "$(jq -r '.reason' <<<"$out")" "valid" "--file malformed items without qa_metadata stay tolerant (valid)"
-
-# array-lost incomplete still precedes the item check: a qa-shaped artifact whose
-# arrays are entirely missing is reason=incomplete, and it names WHICH arrays.
-# This was the chain's one detail-free rejection, so an artifact that adopted
-# qa_metadata to reach the measurement declaration got a second, unexplained
-# refusal after doing exactly what the first rejection instructed — and § 3.1
-# permits one re-delegation before `unresponsive`.
-arrays_lost="$worktree/tmp/review-external-20260810-090909.json"
-printf '{"verdict":"pass","summary":"truncated","qa_metadata":{}}' > "$arrays_lost"
-set +e
-out="$("$CHECK" --file "$arrays_lost")"
-rc=$?
-set -e
-assert_eq "$(jq -r '.reason' <<<"$out")" "incomplete" "--file arrays-lost still reason=incomplete"
-assert_substr "$(jq -r '.detail' <<<"$out")" "blockers[] is absent" "--file arrays-lost detail names the first missing array and what it was"
-assert_substr "$(jq -r '.detail' <<<"$out")" "suggestions[] is absent" "--file arrays-lost detail names the second"
-assert_substr "$(jq -r '.detail' <<<"$out")" "no qa_metadata" "--file arrays-lost detail says the tolerant shape is exempt"
-
-# A key that is missing and a key written as null are different things an agent
-# did; `has()` is what tells them apart, and the remedy reads better for both
-# when the report says which one it saw. Kept BELOW the arrays-lost assertions:
-# each of these reassigns `out`, so sitting above them made the last one read
-# this fixture while claiming to describe $arrays_lost.
-qa_absent_vs_null="$worktree/tmp/review-external-20260812-950001.json"
-printf '{"verdict":"pass","blockers":null,"suggestions":[],"qa_metadata":{}}' > "$qa_absent_vs_null"
-set +e
-out="$("$CHECK" --file "$qa_absent_vs_null")"
-set -e
-assert_substr "$(jq -r '.detail' <<<"$out")" "blockers[] is null" "--file a null array is reported as null, not as absent"
-printf '{"verdict":"pass","suggestions":[],"qa_metadata":{}}' > "$qa_absent_vs_null"
-set +e
-out="$("$CHECK" --file "$qa_absent_vs_null")"
-set -e
-assert_substr "$(jq -r '.detail' <<<"$out")" "blockers[] is absent" "--file a missing key is reported as absent, not as null"
-
-# A field PRESENT with the wrong type is this run's output shape, not a damaged
-# write, and the detail has to say which it was — an agent that wrote `null`
-# meaning "no findings" needs to be told to write [].
-qa_shape_case() {
-  local name="$1" literal="$2" want_detail="$3" path out
-  path="$worktree/tmp/review-external-20260812-$(printf '%06d' "$SHAPE_N").json"
-  SHAPE_N=$((SHAPE_N + 1))
-  printf '{"verdict":"pass","blockers":%s,"suggestions":[],"qa_metadata":{}}' "$literal" > "$path"
-  set +e
-  out="$("$CHECK" --file "$path")"
-  rc=$?
-  set -e
-  assert_eq "$rc" "1" "--file blockers:$name exits 1"
-  assert_eq "$(jq -r '.reason' <<<"$out")" "incomplete" "--file blockers:$name reports reason=incomplete"
-  assert_substr "$(jq -r '.detail' <<<"$out")" "$want_detail" "--file blockers:$name detail names what it found"
-  assert_substr "$(jq -r '.detail' <<<"$out")" "writes []" "--file blockers:$name detail says what an empty review writes"
-}
-SHAPE_N=1
-qa_shape_case "null"    'null'     "blockers[] is null"
-qa_shape_case "object"  '{}'       "blockers[] is object, not an array"
-qa_shape_case "string"  '"none"'   "blockers[] is string, not an array"
-qa_shape_case "number"  '3'        "blockers[] is number, not an array"
-# the same shapes on the OTHER array, so neither is checked by accident
-sugg_shape="$worktree/tmp/review-external-20260812-900001.json"
-printf '{"verdict":"pass","blockers":[],"suggestions":null,"qa_metadata":{}}' > "$sugg_shape"
-set +e
-out="$("$CHECK" --file "$sugg_shape")"
-set -e
-assert_substr "$(jq -r '.detail' <<<"$out")" "suggestions[] is null" "--file suggestions:null is reported on its own"
-printf '{"verdict":"pass","blockers":[],"suggestions":"x","qa_metadata":{}}' > "$sugg_shape"
-set +e
-out="$("$CHECK" --file "$sugg_shape")"
-set -e
-assert_substr "$(jq -r '.detail' <<<"$out")" "suggestions[] is string, not an array" "--file suggestions with a wrong type is reported on its own"
-
-# EVERY rejection in the chain names its cause. A reason with no detail is a
-# dead end for the agent that has to fix it.
-chain_no_detail=""
-chain_case() {
-  local body="$1" label="$2" path out
-  path="$worktree/tmp/review-external-20260811-$(printf '%06d' "$CHAIN_N").json"
-  CHAIN_N=$((CHAIN_N + 1))
-  printf '%s' "$body" > "$path"
-  set +e
-  out="$("$CHECK" --file "$path")"
-  set -e
-  if [[ "$(jq -r '.ok' <<<"$out")" == "false" ]] && [[ "$(jq -r '.detail // ""' <<<"$out")" == "" ]]; then
-    chain_no_detail="$chain_no_detail $label($(jq -r '.reason' <<<"$out"))"
-  fi
-}
-CHAIN_N=1
-chain_case '{"agent":"r","summary":"no verdict field"}' missing-verdict
-chain_case '{"verdict":"pass","qa_metadata":{"review_performed":false}}' no-review
-chain_case '{"verdict":"pass","summary":"s","qa_metadata":{}}' qa-shape
-chain_case '{"verdict":"pass","blockers":[],"suggestions":[{"title":"t"}],"qa_metadata":{}}' finding-item
-chain_case '{"verdict":"pass","blockers":[],"suggestions":[],"measurement_failed":"n/a"}' bad-declaration
-chain_case '{"verdict":"pass","summary":"mutation: killed 0/0","blockers":[],"suggestions":[],"qa_metadata":{}}' zero-sample
-assert_eq "$chain_no_detail" "" "every content-gate rejection names its cause in detail"
-
-# ...and the two reasons an agent reads BEFORE it knows what it did wrong. The
-# --help claim is unconditional, and these were the two carrying nothing.
-detail_of() {
-  set +e
-  local out
-  out="$("$CHECK" "$@")"
-  set -e
-  jq -r '.detail // ""' <<<"$out"
-}
-empty_wt="$TMP_ROOT/emptywt"
-mkdir -p "$empty_wt/tmp"
-assert_substr "$(detail_of "$empty_wt" ghost-agent 0)" "review-ghost-agent-" "glob missing names the glob that matched nothing"
-stale_only="$empty_wt/tmp/review-staleonly-20200101-000000.json"
-printf '{"verdict":"pass"}' > "$stale_only"
-touch -d "@$before" "$stale_only"
-assert_substr "$(detail_of "$empty_wt" staleonly "$delegated_at")" "predates the boundary" "glob stale names the mtime against the boundary"
-assert_substr "$(detail_of --file "$TMP_ROOT/definitely-not-here.json")" "no file at" "--file missing names the path"
-assert_substr "$(detail_of --file "$stale_only" "$delegated_at")" "predates the boundary" "--file stale names the mtime against the boundary"
-
-# glob mode applies the same item gate: a fresh malformed-item artifact is rejected...
-glob_item_bad="$worktree/tmp/review-reviewer-item-20260810-111111.json"
-printf '{"verdict":"pass","blockers":[],"suggestions":[{"title":"t","location":"l","detail":"x","severity":"low"}],"qa_metadata":{}}' > "$glob_item_bad"
-touch -d "@$after" "$glob_item_bad"
-set +e
-out="$("$CHECK" "$worktree" reviewer-item "$delegated_at")"
-rc=$?
-set -e
-assert_eq "$rc" "1" "glob malformed-item artifact exits 1"
-assert_eq "$(jq -r '.reason' <<<"$out")" "incomplete" "glob malformed-item reports reason=incomplete"
-assert_eq "$(jq -r '.path' <<<"$out")" "$glob_item_bad" "glob malformed-item report points at the artifact"
-assert_substr "$(jq -r '.detail' <<<"$out")" "suggestions[0]" "glob malformed-item detail names the item"
-
-# ...and it is TERMINAL, not answered by an older sibling. Items carrying wrong
-# field names are what THIS run produced — a truncated write does not rename
-# fields — so the disposition rule puts this on the self-report side. Falling
-# back here told a reviewer whose items were unroutable that someone else's
-# artifact was valid, and it never saw a reason at all.
-glob_item_ok="$worktree/tmp/review-reviewer-item-20260810-000000.json"
-printf '{"verdict":"pass","blockers":[],"suggestions":[{"id":1,"title":"t","location":"l","description":"d","recommendation":"r","priority":3,"estimate":2,"category":"issue","impact":"nightly importers hit it on every run"}],"qa_metadata":{}}' > "$glob_item_ok"
-touch -d "@$after" "$glob_item_ok"
-touch -d "@$later" "$glob_item_bad"
-set +e
-out="$("$CHECK" "$worktree" reviewer-item "$delegated_at")"
-rc=$?
-set -e
-assert_eq "$rc" "1" "glob malformed-item is terminal, not rescued by an older sibling"
-assert_eq "$(jq -r '.reason' <<<"$out")" "incomplete" "glob terminal malformed-item keeps reason=incomplete"
-assert_eq "$(jq -r '.path' <<<"$out")" "$glob_item_bad" "glob terminal malformed-item points at the rejected artifact"
-
-# MUST-FAIL CONTROL: with the malformed artifact STALE, the fresh well-formed
-# one is the answer — terminal refuses THIS run, not the agent forever.
-touch -d "@$before" "$glob_item_bad"
-expect_glob_valid "$worktree" reviewer-item "$delegated_at" "$glob_item_ok" "a STALE malformed-item artifact does not block a fresh well-formed one"
-touch -d "@$later" "$glob_item_bad"
-
-# THE OTHER SIDE OF THE RULE now has exactly one member — a gate that could not
-# run — and it is pinned in review_artifact_check_measurement.sh, where the
-# selective jq shim lives.
-
-# --- usage errors ---
-set +e
-"$CHECK" "$worktree" reviewer-quality >/dev/null 2>&1
-assert_eq "$?" "2" "missing arguments exit 2"
-"$CHECK" "$worktree" reviewer-quality not-a-number >/dev/null 2>&1
-assert_eq "$?" "2" "non-numeric delegated_at exits 2"
-"$CHECK" "$TMP_ROOT/does-not-exist" reviewer-quality "$delegated_at" >/dev/null 2>&1
-assert_eq "$?" "2" "nonexistent worktree exits 2"
-"$CHECK" --file >/dev/null 2>&1
-assert_eq "$?" "2" "--file with no path exits 2"
-"$CHECK" --file "$ext_valid" not-a-number >/dev/null 2>&1
-assert_eq "$?" "2" "--file non-numeric boundary exits 2"
-"$CHECK" --file "$ext_valid" "$delegated_at" extra-arg >/dev/null 2>&1
-assert_eq "$?" "2" "--file with too many args exits 2"
-set -e
-
-echo "=== --wait blocking mode (glob) ==="
-
-# A reviewer artifact landing mid-wait ends the wait immediately with its
-# verdict — valid here; a rejected artifact would return equally fast.
-wwt="$TMP_ROOT/waitwt"
-mkdir -p "$wwt/tmp"
+echo "=== --wait blocks until an artifact lands or the deadline ==="
+# A valid artifact landing after about two seconds ends a 20-second wait with
+# its verdict; nothing landed at the deadline is missing, exit 1; a STALE
+# prior-round artifact keeps the wait polling for the fresh one rather than
+# ending it instantly.
+stage ""
 start_epoch="$(date +%s)"
-( sleep 2; printf '{"agent":"waitrev","verdict":"pass","summary":"s","blockers":[],"suggestions":[],"questions":[]}' \
-    > "$wwt/tmp/review-waitrev-20260101-000001.json" ) &
+( sleep 2; body qa_ok > "$WT/tmp/review-waitrev-20260101-000001.json" ) &
 writer_pid=$!
-rc=0
-wait_out="$("$CHECK" "$wwt" waitrev 0 --wait 20 --interval 1 2>/dev/null)" || rc=$?
+run_check %W waitrev 0 --wait 20 --interval 1
 wait "$writer_pid" 2>/dev/null || true
 elapsed=$(( $(date +%s) - start_epoch ))
-assert_eq "$(jq -r '.ok' <<<"$wait_out")" "true" "--wait returns the landed artifact as ok"
-assert_eq "$rc" "0" "--wait exit 0 on a valid landing"
-if (( elapsed < 15 )); then
-  PASS=$((PASS + 1)); printf '  ok    %s\n' "--wait returned on the landing, not the deadline (${elapsed}s)"
-else
-  FAIL=$((FAIL + 1)); printf '  FAIL  %s\n' "--wait burned toward its deadline (${elapsed}s)"
-fi
-
-# Deadline with nothing landed: reason missing, exit 1.
-rc=0
-wait_out="$("$CHECK" "$wwt" ghostrev 0 --wait 2 --interval 1 2>/dev/null)" || rc=$?
-assert_eq "$(jq -r '.reason' <<<"$wait_out")" "missing" "--wait deadline reports missing"
-assert_eq "$rc" "1" "--wait deadline exits 1"
-
-# The production shape from cycle 2 onward: a STALE prior-round artifact on
-# disk must keep the wait polling for the fresh one, not end it instantly.
-swt="$TMP_ROOT/stalewt"
-mkdir -p "$swt/tmp"
-printf '{"agent":"cyc","verdict":"pass","summary":"old","blockers":[],"suggestions":[],"questions":[]}' \
-  > "$swt/tmp/review-cyc-20200101-000000.json"
-touch -t 202001010000 "$swt/tmp/review-cyc-20200101-000000.json"
+assert_eq "$(observe "rc=0 ok=true") early=$([[ "$elapsed" -lt 15 ]] && echo true || echo false)" "rc=0 ok=true early=true" "--wait returns the landed artifact before the deadline (${elapsed}s)" "$ERR"
+stage ""
+run_check %W ghostrev 0 --wait 2 --interval 1
+assert_eq "$(observe "rc=1 reason=missing")" "rc=1 reason=missing" "--wait at the deadline with nothing landed is missing" "$ERR"
+stage "review-cyc-20200101-000000@before=qa_ok"
 now_epoch="$(date +%s)"
-start_epoch="$now_epoch"
-( sleep 2; printf '{"agent":"cyc","verdict":"pass","summary":"fresh","blockers":[],"suggestions":[],"questions":[]}' \
-    > "$swt/tmp/review-cyc-20990101-000000.json" ) &
+( sleep 2; body qa_ok > "$WT/tmp/review-cyc-20990101-000000.json" ) &
 writer_pid=$!
-rc=0
-wait_out="$("$CHECK" "$swt" cyc "$now_epoch" --wait 20 --interval 1 2>/dev/null)" || rc=$?
+run_check %W cyc "$now_epoch" --wait 20 --interval 1
 wait "$writer_pid" 2>/dev/null || true
-elapsed=$(( $(date +%s) - start_epoch ))
-assert_eq "$(jq -r '.ok' <<<"$wait_out")" "true" "--wait polls past a stale prior-round artifact to the fresh one"
-if (( elapsed >= 1 && elapsed < 15 )); then
-  PASS=$((PASS + 1)); printf '  ok    %s\n' "--wait neither returned instantly on stale nor burned the deadline (${elapsed}s)"
-else
-  FAIL=$((FAIL + 1)); printf '  FAIL  %s\n' "--wait stale handling wrong (${elapsed}s: 0s = instant-stale regression, >=15s = deadline burn)"
-fi
+elapsed=$(( $(date +%s) - now_epoch ))
+assert_eq "$(observe "ok=true") polled=$([[ "$elapsed" -ge 1 && "$elapsed" -lt 15 ]] && echo true || echo false)" "ok=true polled=true" "--wait polls past a stale prior-round artifact to the fresh one, neither instantly nor to the deadline (${elapsed}s)" "$ERR"
 
-# Flag validation is a usage error; the frozen 3-positional call is untouched.
-rc=0; "$CHECK" "$wwt" waitrev 0 --wait nope >/dev/null 2>&1 || rc=$?
-assert_eq "$rc" "2" "a non-integer --wait is a usage error"
-rc=0; "$CHECK" "$wwt" waitrev 0 >/dev/null 2>&1 || rc=$?
-assert_eq "$rc" "0" "the bare three-positional contract still validates"
+echo "=== -h and --help answer before any temp-file initialization ==="
+# The heredoc is the contract's sole home; the dispatch runs before the gates
+# lib is sourced, so --help prints under an unusable TMPDIR too.
+stage ""
+run_check --help
+assert_eq "$(observe "rc=0 stderr=empty stdout~Usage:=true stdout~zero_sample=true stdout~measurement_failed=true")" "rc=0 stderr=empty stdout~Usage:=true stdout~zero_sample=true stdout~measurement_failed=true" "--help exits 0 on stdout alone with the reason vocabulary and the declaration contract"
+run_check -h
+assert_eq "$(observe "rc=0 stdout~Usage:=true")" "rc=0 stdout~Usage:=true" "-h prints usage"
+TMPDIR="$TMP_ROOT/does-not-exist/nope" run_check --help
+assert_eq "$(observe "rc=0 stdout~Usage:=true")" "rc=0 stdout~Usage:=true" "--help still prints the contract under an unusable TMPDIR"
 
-echo "=== -h/--help answers before any temp-file initialization (KEN-556) ==="
-
-# Token pins per: the heredoc is the contract's sole home.
-set +e
-help_out="$("$CHECK" --help 2>"$TMP_ROOT/help.err")"
-rc=$?
-set -e
-assert_eq "$rc" "0" "--help exits 0"
-assert_substr "$help_out" "Usage:" "--help prints usage on stdout"
-assert_eq "$(cat "$TMP_ROOT/help.err")" "" "--help writes nothing to stderr"
-assert_substr "$help_out" "zero_sample" "--help carries the reason vocabulary"
-assert_substr "$help_out" "measurement_failed" "--help carries the declaration contract"
-
-set +e
-help_out="$("$CHECK" -h 2>/dev/null)"
-rc=$?
-set -e
-assert_eq "$rc" "0" "-h exits 0"
-assert_substr "$help_out" "Usage:" "-h prints usage"
-
-# The dispatch runs BEFORE the gates lib is sourced: its source-time mktemp
-# fails under an unusable TMPDIR, and --help must still print the contract.
-set +e
-help_out="$(TMPDIR="$TMP_ROOT/does-not-exist/nope" "$CHECK" --help 2>"$TMP_ROOT/help2.err")"
-rc=$?
-set -e
-assert_eq "$rc" "0" "--help exits 0 with an unusable TMPDIR"
-assert_substr "$help_out" "Usage:" "--help still prints the contract under it"
-
+echo
 printf 'pass: %d   fail: %d\n' "$PASS" "$FAIL"
 [[ "$FAIL" -eq 0 ]]

--- a/.agents/skills/orch/tests/review_artifact_check.sh
+++ b/.agents/skills/orch/tests/review_artifact_check.sh
@@ -113,13 +113,15 @@ run_check() {
   set -e
 }
 
-json() { jq -r "$1" <<<"$OUT" 2>/dev/null || echo UNPARSEABLE; }
+json() { jq -r "$@" <<<"$OUT" 2>/dev/null || echo UNPARSEABLE; }
 
 # observe EXPECT — prints the run's value of every `name=` field EXPECT names,
 # in EXPECT's order. Plain names are JSON result fields, a key the result does
 # not carry reads ABSENT;
 #   rc              exit status
-#   path            the basename of the reported path, or null
+#   path            the reported path with the staged worktree's tmp/ prefix
+#                   removed, or null; a path anywhere else prints whole and
+#                   fails the row
 #   detail~<text>   whether the detail names <text> (`+` reads as a space):
 #                   the detail is what the rejected reviewer acts on, and
 #                   which shape it saw lives nowhere else
@@ -132,7 +134,7 @@ observe() {
     name="${token%%=*}"
     case "$name" in
       rc) value="$RC" ;;
-      path) value="$(json '.path | if . == null then "null" else sub(".*/"; "") end')" ;;
+      path) value="$(json --arg tmp "$WT/tmp/" '.path | if . == null then "null" else ltrimstr($tmp) end')" ;;
       detail~*) needle="${name#detail~}"; value="$(json '.detail // ""' | grep -qF -- "${needle//+/ }" && echo true || echo false)" ;;
       detail_present) value="$(json '(.detail | type) == "string" and .detail != ""')" ;;
       stdout~*) needle="${name#stdout~}"; value="$(grep -qF -- "${needle//+/ }" <<<"$OUT" && echo true || echo false)" ;;

--- a/skills/orch/tests/dev_artifact_check.sh
+++ b/skills/orch/tests/dev_artifact_check.sh
@@ -62,6 +62,8 @@ json() { jq -r "$1" <<<"$OUT" 2>/dev/null || echo UNPARSEABLE; }
 # key the result does not carry reads ABSENT, so `null` means a real null.
 #   rc              exit status
 #   stderr~<text>   whether stderr carries <text> (`+` reads as a space)
+#   hint_present    whether the result carries a non-empty string hint; an
+#                   unparseable result reads false, never fired
 #   help_sections   which of the routed --help sections are present: gates
 #                   (the ordering line), reasons (every ok=false reason the
 #                   check emits), items (the --expect-items confinement)
@@ -80,6 +82,7 @@ observe() {
         value="${value#,}"; value="${value:-none}"
         ;;
       stderr~*) needle="${name#stderr~}"; value="$(grep -qF -- "${needle//+/ }" "$ERR" && echo true || echo false)" ;;
+      hint_present) value="$(json '(.hint | type) == "string" and .hint != ""')" ;;
       *) value="$(json "if has(\"$name\") then .$name else \"ABSENT\" end")" ;;
     esac
     got="$got $name=$value"
@@ -249,7 +252,7 @@ done
 # when the shapes coincide (the inline form is the control).
 "$WRITE" --worktree "$RR" --kind fix --issue issue-9 --round-id 16-16 --branch b --commit "$RR_HEAD" --validate pass --item 1 Applied a --item 2 Applied b --item 3 Applied c >/dev/null
 run_check --file "$RR/tmp/dev-return-issue-9-16-16.json" --expect-items 3
-assert_eq "$([[ "$(json .hint)" != null ]] && echo fires || echo silent)" "fires" "control: file-mode --expect-items 3 against items 1..3 fires the count-vs-set hint" "$ERR"
+assert_eq "$(observe "reason=incomplete hint_present=true")" "reason=incomplete hint_present=true" "control: file-mode --expect-items 3 against items 1..3 fires the count-vs-set hint" "$ERR"
 round_write --worktree "$RR" --issue issue-9 --round-id 16-16 --item 3 "only item three" "tools/guard on a staged render" >/dev/null
 run_check --worktree "$RR" --issue issue-9 --round-id 16-16 --expect-items-from-round
 assert_eq "$(observe "reason=incomplete hint=null")" "reason=incomplete hint=null" "from-round never emits the hint and still reports incomplete" "$ERR"

--- a/skills/orch/tests/review_artifact_check.sh
+++ b/skills/orch/tests/review_artifact_check.sh
@@ -50,7 +50,7 @@ body() {
     badblk) printf '{"verdict":"action_required","blockers":[{"id":1,"title":"t","location":"l","recommendation":"r","priority":1,"estimate":2}],"suggestions":[],"qa_metadata":{}}' ;;
     okblk) printf '{"verdict":"action_required","blockers":[{"id":1,"title":"t","location":"l","description":"d","recommendation":"r","priority":1,"estimate":2}],"suggestions":[],"qa_metadata":{}}' ;;
     badpri) printf '{"verdict":"pass","blockers":[],"suggestions":[{"id":1,"title":"t","location":"l","description":"d","recommendation":"r","priority":5,"estimate":2,"category":"fix"}],"qa_metadata":{}}' ;;
-    badest) printf '{"verdict":"pass","blockers":[],"suggestions":[{"id":1,"title":"t","location":"l","description":"d","recommendation":"r","priority":2,"estimate":"2","category":"issue"}],"qa_metadata":{}}' ;;
+    badest) printf '{"verdict":"pass","blockers":[],"suggestions":[{"id":1,"title":"t","location":"l","description":"d","recommendation":"r","priority":2,"estimate":"2","category":"fix"}],"qa_metadata":{}}' ;;
     badblkpri) printf '{"verdict":"action_required","blockers":[{"id":1,"title":"t","location":"l","description":"d","recommendation":"r","priority":0,"estimate":3}],"suggestions":[],"qa_metadata":{}}' ;;
     okbound) printf '{"verdict":"pass","blockers":[],"suggestions":[{"id":1,"title":"t","location":"l","description":"d","recommendation":"r","priority":4,"estimate":5,"category":"fix"}],"qa_metadata":{}}' ;;
     noqa_bad) printf '{"verdict":"pass","suggestions":[{"title":"t","location":"l"}]}' ;;
@@ -169,6 +169,7 @@ table \
   "no artifact at all is missing||$GLOB|rc=1 ok=false path=null reason=missing" \
   "another agent's fresh artifact does not count|review-reviewer-arch-1@after=pass|$GLOB|rc=1 reason=missing" \
   "an artifact older than the boundary is stale and named|$Q-1@before=pass|$GLOB|rc=1 ok=false path=$Q-1.json reason=stale" \
+  "an mtime equal to the boundary is fresh in glob mode too|$Q-1@at=pass|$GLOB|rc=0 ok=true reason=valid" \
   "a fresh artifact without a verdict is invalid and named|$Q-1@before=pass;$Q-2@after=noverdict|$GLOB|rc=1 path=$Q-2.json reason=invalid" \
   "a fresh valid artifact wins over stale and invalid siblings|$Q-1@before=pass;$Q-2@after=noverdict;$Q-3@later=action|$GLOB|rc=0 ok=true path=$Q-3.json reason=valid" \
   "a newest unparseable file falls back to the older fresh valid one|$Q-3@later=action;$Q-4@later2=notjson|$GLOB|rc=0 ok=true path=$Q-3.json reason=valid"
@@ -190,9 +191,9 @@ table \
 
 echo "=== a self-reported no-review artifact is refused, and terminally ==="
 # review_performed=false, or a no-review reason alone, is an admission
-# whatever the verdict; no qa_metadata keeps the existence-plus-verdict
-# tolerance; an empty qa_metadata with the arrays, or review_performed=true,
-# validates. In glob mode the refusal is terminal: no_review is the
+# whatever the verdict (no qa_metadata at all keeps the existence-plus-verdict
+# tolerance the file-mode table proves); an empty qa_metadata with the arrays,
+# or review_performed=true, validates. In glob mode the refusal is terminal: no_review is the
 # reviewer's self-report about THIS run, so an older fresh sibling does not
 # rescue it; a STALE no-review artifact does not block a fresh valid one.
 E=review-reviewer-ext
@@ -200,7 +201,6 @@ table \
   "review_performed=false|F@after=noreview|--file %F|rc=1 ok=false path=review-external-F.json reason=no_review" \
   "a no-review reason alone|F@none=noreview_reason|--file %F|rc=1 reason=no_review" \
   "review_performed=false alone, arrays present, is still no_review|F@none=noreview_flag|--file %F|rc=1 reason=no_review" \
-  "no qa_metadata at all still validates|F@none=pass|--file %F|ok=true reason=valid" \
   "empty qa_metadata with the arrays validates|F@none=qa_ok|--file %F|reason=valid" \
   "review_performed=true validates|F@none=performed|--file %F|reason=valid" \
   "glob: a fresh no-review artifact is refused and named|$E-1@after=noreview|%W reviewer-ext %D|rc=1 path=$E-1.json reason=no_review" \
@@ -243,19 +243,18 @@ echo "=== a qa-shaped artifact must carry usable finding items, and the detail s
 # terminally, and a STALE one does not block a fresh well-formed one.
 T=review-reviewer-item
 table \
-  "the issue's malformed suggestion is incomplete, the detail names the item and the missing category|F@none=issue_bad|--file %F|rc=1 ok=false path=review-external-F.json reason=incomplete detail~suggestions[0]=true detail~category=true" \
+  "the issue's malformed suggestion is incomplete, the detail names the item and the missing category|F@none=issue_bad|--file %F|rc=1 ok=false path=review-external-F.json reason=incomplete detail~suggestions[0]=true detail~missing/invalid+id,+description,+recommendation,+priority,+estimate,+category=true" \
   "a fully compliant artifact is valid and carries no detail key|F@none=compliant|--file %F|ok=true reason=valid detail=ABSENT" \
-  "empty arrays carry no items and stay valid|F@none=qa_ok_noq|--file %F|reason=valid" \
-  "a suggestion missing only category|F@none=nocat|--file %F|rc=1 reason=incomplete detail~category=true" \
+  "a suggestion missing only category|F@none=nocat|--file %F|rc=1 reason=incomplete detail~missing/invalid+category=true" \
   "a category outside fix and issue|F@none=badcatval|--file %F|rc=1 reason=incomplete" \
-  "a blocker missing a base field, named|F@none=badblk|--file %F|rc=1 reason=incomplete detail~blockers[0]=true detail~description=true" \
+  "a blocker missing a base field, named|F@none=badblk|--file %F|rc=1 reason=incomplete detail~blockers[0]=true detail~missing/invalid+description=true" \
   "a blocker without category is valid|F@none=okblk|--file %F|reason=valid" \
-  "a priority outside 1..4, named|F@none=badpri|--file %F|rc=1 reason=incomplete detail~priority=true" \
-  "a string estimate, named|F@none=badest|--file %F|rc=1 detail~estimate=true" \
+  "a priority outside 1..4, named|F@none=badpri|--file %F|rc=1 reason=incomplete detail~missing/invalid+priority=true" \
+  "a string estimate, named|F@none=badest|--file %F|rc=1 reason=incomplete detail~missing/invalid+estimate(not+1..5)=true" \
   "a blocker priority below the range, named on its array|F@none=badblkpri|--file %F|rc=1 detail~blockers[0]=true" \
   "the boundary values priority 4 and estimate 5 are valid|F@none=okbound|--file %F|reason=valid" \
   "malformed items without qa_metadata stay tolerant|F@none=noqa_bad|--file %F|reason=valid" \
-  "arrays lost: the detail names both arrays as absent and the exempt shape|F@none=qa_inc|--file %F|reason=incomplete detail~blockers[]+is+absent=true detail~suggestions[]+is+absent=true detail~no+qa_metadata=true" \
+  "arrays lost: the detail names both arrays as absent and the exempt shape|F@none=qa_inc|--file %F|ok=false reason=incomplete detail~blockers[]+is+absent=true detail~suggestions[]+is+absent=true detail~no+qa_metadata=true" \
   "a null blockers is reported as null, and what an empty review writes|F@none=null_blockers|--file %F|rc=1 reason=incomplete detail~blockers[]+is+null=true detail~writes+[]=true" \
   "a missing blockers is reported as absent|F@none=inc_sugg|--file %F|detail~blockers[]+is+absent=false detail~suggestions[]+is+absent=true" \
   "an object blockers is reported by type|F@none=obj_blockers|--file %F|rc=1 reason=incomplete detail~blockers[]+is+object,+not+an+array=true detail~writes+[]=true" \
@@ -265,7 +264,6 @@ table \
   "a wrong-typed suggestions is reported on its own|F@none=str_sugg|--file %F|detail~suggestions[]+is+string,+not+an+array=true" \
   "chain: a missing verdict names its cause|F@none=chain_noverdict|--file %F|ok=false detail_present=true" \
   "chain: a no-review admission names its cause|F@none=chain_noreview|--file %F|ok=false detail_present=true" \
-  "chain: a qa-shape loss names its cause|F@none=qa_inc|--file %F|ok=false detail_present=true" \
   "chain: a malformed finding item names its cause|F@none=chain_item|--file %F|ok=false detail_present=true" \
   "chain: a bad measurement declaration names its cause|F@none=chain_decl|--file %F|ok=false detail_present=true" \
   "chain: a zero-sample measurement names its cause|F@none=chain_zero|--file %F|ok=false detail_present=true" \
@@ -309,8 +307,8 @@ now_epoch="$(date +%s)"
 ( sleep 2; body qa_ok > "$WT/tmp/review-cyc-20990101-000000.json" ) &
 writer_pid=$!
 run_check %W cyc "$now_epoch" --wait 20 --interval 1
-wait "$writer_pid" 2>/dev/null || true
 elapsed=$(( $(date +%s) - now_epoch ))
+wait "$writer_pid" 2>/dev/null || true
 assert_eq "$(observe "ok=true") polled=$([[ "$elapsed" -ge 1 && "$elapsed" -lt 15 ]] && echo true || echo false)" "ok=true polled=true" "--wait polls past a stale prior-round artifact to the fresh one, neither instantly nor to the deadline (${elapsed}s)" "$ERR"
 
 echo "=== -h and --help answer before any temp-file initialization ==="

--- a/skills/orch/tests/review_artifact_check.sh
+++ b/skills/orch/tests/review_artifact_check.sh
@@ -43,6 +43,7 @@ body() {
     qa_inc_agent) printf '{"agent":"external-codex","timestamp":"2026-07-18T00:00:00Z","verdict":"pass","summary":"looks fine","qa_metadata":{}}' ;;
     inc_type) printf '{"verdict":"pass","blockers":"none","suggestions":[],"qa_metadata":{}}' ;;
     inc_sugg) printf '{"verdict":"pass","blockers":[],"qa_metadata":{}}' ;;
+    inc_blk) printf '{"verdict":"pass","suggestions":[],"qa_metadata":{}}' ;;
     issue_bad) printf '{"agent":"reviewer-arch","verdict":"pass","blockers":[],"suggestions":[{"title":"Two resolvers coexist","location":"/abs/instrument_link.rs (instrument_name)","detail":"...","severity":"low"}],"qa_metadata":{"arch_review":{"overall_score":8.4,"pass":true}}}' ;;
     compliant) printf '{"verdict":"action_required","blockers":[{"id":1,"title":"t","location":"src/x.rs (`f`)","description":"d","recommendation":"r","priority":1,"estimate":2}],"suggestions":[{"id":1,"title":"t","location":"src/y.rs (`g`)","description":"d","recommendation":"r","priority":3,"estimate":2,"category":"fix"}],"qa_metadata":{}}' ;;
     nocat) printf '{"verdict":"pass","blockers":[],"suggestions":[{"id":1,"title":"t","location":"l","description":"d","recommendation":"r","priority":3,"estimate":2}],"qa_metadata":{}}' ;;
@@ -256,7 +257,7 @@ table \
   "malformed items without qa_metadata stay tolerant|F@none=noqa_bad|--file %F|reason=valid" \
   "arrays lost: the detail names both arrays as absent and the exempt shape|F@none=qa_inc|--file %F|ok=false reason=incomplete detail~blockers[]+is+absent=true detail~suggestions[]+is+absent=true detail~no+qa_metadata=true" \
   "a null blockers is reported as null, and what an empty review writes|F@none=null_blockers|--file %F|rc=1 reason=incomplete detail~blockers[]+is+null=true detail~writes+[]=true" \
-  "a missing blockers is reported as absent|F@none=inc_sugg|--file %F|detail~blockers[]+is+absent=false detail~suggestions[]+is+absent=true" \
+  "a missing blockers is reported as absent, and the present suggestions is not|F@none=inc_blk|--file %F|rc=1 reason=incomplete detail~blockers[]+is+absent=true detail~suggestions[]+is+absent=false" \
   "an object blockers is reported by type|F@none=obj_blockers|--file %F|rc=1 reason=incomplete detail~blockers[]+is+object,+not+an+array=true detail~writes+[]=true" \
   "a string blockers is reported by type|F@none=str_blockers|--file %F|rc=1 reason=incomplete detail~blockers[]+is+string,+not+an+array=true detail~writes+[]=true" \
   "a number blockers is reported by type|F@none=num_blockers|--file %F|rc=1 reason=incomplete detail~blockers[]+is+number,+not+an+array=true detail~writes+[]=true" \

--- a/skills/orch/tests/review_artifact_check.sh
+++ b/skills/orch/tests/review_artifact_check.sh
@@ -1,777 +1,329 @@
 #!/usr/bin/env bash
-# Tests for review-artifact-check: deterministic on-disk acceptance
-# of reviewer JSON artifacts in the orch review-pr workflow.
-
+# Tests for review-artifact-check: deterministic on-disk acceptance of
+# reviewer JSON artifacts in the orch review-pr workflow. Glob mode resolves
+# WT/tmp/review-<agent>-*.json against a delegation boundary; --file mode
+# validates one path, with an optional boundary. The measurement gate and the
+# selective jq shim are review_artifact_check_measurement.sh; the channel and
+# item-schema surfaces have their own suites beside it.
+#
+# One case per behaviour surface; shaped input is one table per case, one
+# asserted row per shape. A row stages its own worktree and artifacts; its
+# `expect` names the fields it pins and `observe` reads exactly those, so a
+# row fails on the field it names.
 set -euo pipefail
 source "$(dirname "${BASH_SOURCE[0]}")/lib/git-env.sh"
-
 TEST_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(cd "$TEST_DIR/../../.." && pwd)"
 CHECK="$REPO_ROOT/skills/orch/scripts/review-artifact-check"
+# shellcheck source=lib/waiter-assertions.sh
+source "$TEST_DIR/lib/waiter-assertions.sh"
 TMP_ROOT="$(mktemp -d)"
 trap 'rm -rf "$TMP_ROOT"' EXIT
 
-PASS=0
-FAIL=0
+DELEG=1750000000
+BEFORE=$((DELEG - 100))
+AFTER=$((DELEG + 100))
+LATER=$((DELEG + 200))
+LATER2=$((DELEG + 300))
 
-assert_eq() {
-  local got="$1" want="$2" name="$3"
-  if [[ "$got" == "$want" ]]; then
-    PASS=$((PASS + 1))
-    printf '  ok    %s\n' "$name"
-  else
-    FAIL=$((FAIL + 1))
-    printf '  FAIL  %s\n        expected: %s\n        got:      %s\n' "$name" "$want" "$got"
-  fi
+# body NAME — the artifact bodies the rows stage, by name.
+body() {
+  case "$1" in
+    pass) printf '{"verdict":"pass","items":[]}' ;;
+    action) printf '{"verdict":"action_required","items":[{"category":"fix"}]}' ;;
+    noverdict) printf '{"items":[]}' ;;
+    notjson) printf 'not json' ;;
+    noreview) printf '{"verdict":"pass","summary":"No review was actually performed","qa_metadata":{"review_performed":false,"reason":"no_scope_provided"}}' ;;
+    noreview_reason) printf '{"verdict":"pass","qa_metadata":{"reason":"no_scope_provided"}}' ;;
+    noreview_flag) printf '{"verdict":"pass","blockers":[],"suggestions":[],"qa_metadata":{"review_performed":false}}' ;;
+    qa_ok) printf '{"verdict":"pass","blockers":[],"suggestions":[],"questions":[],"qa_metadata":{}}' ;;
+    qa_ok_noq) printf '{"verdict":"pass","blockers":[],"suggestions":[],"qa_metadata":{}}' ;;
+    performed) printf '{"verdict":"pass","blockers":[],"suggestions":[],"qa_metadata":{"review_performed":true}}' ;;
+    qa_inc) printf '{"verdict":"pass","summary":"truncated","qa_metadata":{}}' ;;
+    qa_inc_agent) printf '{"agent":"external-codex","timestamp":"2026-07-18T00:00:00Z","verdict":"pass","summary":"looks fine","qa_metadata":{}}' ;;
+    inc_type) printf '{"verdict":"pass","blockers":"none","suggestions":[],"qa_metadata":{}}' ;;
+    inc_sugg) printf '{"verdict":"pass","blockers":[],"qa_metadata":{}}' ;;
+    issue_bad) printf '{"agent":"reviewer-arch","verdict":"pass","blockers":[],"suggestions":[{"title":"Two resolvers coexist","location":"/abs/instrument_link.rs (instrument_name)","detail":"...","severity":"low"}],"qa_metadata":{"arch_review":{"overall_score":8.4,"pass":true}}}' ;;
+    compliant) printf '{"verdict":"action_required","blockers":[{"id":1,"title":"t","location":"src/x.rs (`f`)","description":"d","recommendation":"r","priority":1,"estimate":2}],"suggestions":[{"id":1,"title":"t","location":"src/y.rs (`g`)","description":"d","recommendation":"r","priority":3,"estimate":2,"category":"fix"}],"qa_metadata":{}}' ;;
+    nocat) printf '{"verdict":"pass","blockers":[],"suggestions":[{"id":1,"title":"t","location":"l","description":"d","recommendation":"r","priority":3,"estimate":2}],"qa_metadata":{}}' ;;
+    badcatval) printf '{"verdict":"pass","blockers":[],"suggestions":[{"id":1,"title":"t","location":"l","description":"d","recommendation":"r","priority":3,"estimate":2,"category":"low"}],"qa_metadata":{}}' ;;
+    badblk) printf '{"verdict":"action_required","blockers":[{"id":1,"title":"t","location":"l","recommendation":"r","priority":1,"estimate":2}],"suggestions":[],"qa_metadata":{}}' ;;
+    okblk) printf '{"verdict":"action_required","blockers":[{"id":1,"title":"t","location":"l","description":"d","recommendation":"r","priority":1,"estimate":2}],"suggestions":[],"qa_metadata":{}}' ;;
+    badpri) printf '{"verdict":"pass","blockers":[],"suggestions":[{"id":1,"title":"t","location":"l","description":"d","recommendation":"r","priority":5,"estimate":2,"category":"fix"}],"qa_metadata":{}}' ;;
+    badest) printf '{"verdict":"pass","blockers":[],"suggestions":[{"id":1,"title":"t","location":"l","description":"d","recommendation":"r","priority":2,"estimate":"2","category":"issue"}],"qa_metadata":{}}' ;;
+    badblkpri) printf '{"verdict":"action_required","blockers":[{"id":1,"title":"t","location":"l","description":"d","recommendation":"r","priority":0,"estimate":3}],"suggestions":[],"qa_metadata":{}}' ;;
+    okbound) printf '{"verdict":"pass","blockers":[],"suggestions":[{"id":1,"title":"t","location":"l","description":"d","recommendation":"r","priority":4,"estimate":5,"category":"fix"}],"qa_metadata":{}}' ;;
+    noqa_bad) printf '{"verdict":"pass","suggestions":[{"title":"t","location":"l"}]}' ;;
+    null_blockers) printf '{"verdict":"pass","blockers":null,"suggestions":[],"qa_metadata":{}}' ;;
+    obj_blockers) printf '{"verdict":"pass","blockers":{},"suggestions":[],"qa_metadata":{}}' ;;
+    str_blockers) printf '{"verdict":"pass","blockers":"none","suggestions":[],"qa_metadata":{}}' ;;
+    num_blockers) printf '{"verdict":"pass","blockers":3,"suggestions":[],"qa_metadata":{}}' ;;
+    null_sugg) printf '{"verdict":"pass","blockers":[],"suggestions":null,"qa_metadata":{}}' ;;
+    str_sugg) printf '{"verdict":"pass","blockers":[],"suggestions":"x","qa_metadata":{}}' ;;
+    chain_noverdict) printf '{"agent":"r","summary":"no verdict field"}' ;;
+    chain_noreview) printf '{"verdict":"pass","qa_metadata":{"review_performed":false}}' ;;
+    chain_item) printf '{"verdict":"pass","blockers":[],"suggestions":[{"title":"t"}],"qa_metadata":{}}' ;;
+    chain_decl) printf '{"verdict":"pass","blockers":[],"suggestions":[],"measurement_failed":"n/a"}' ;;
+    chain_zero) printf '{"verdict":"pass","summary":"mutation: killed 0/0","blockers":[],"suggestions":[],"qa_metadata":{}}' ;;
+    item_bad) printf '{"verdict":"pass","blockers":[],"suggestions":[{"title":"t","location":"l","detail":"x","severity":"low"}],"qa_metadata":{}}' ;;
+    item_ok) printf '{"verdict":"pass","blockers":[],"suggestions":[{"id":1,"title":"t","location":"l","description":"d","recommendation":"r","priority":3,"estimate":2,"category":"issue","impact":"nightly importers hit it on every run"}],"qa_metadata":{}}' ;;
+    *) echo "body: unknown name $1" >&2; exit 1 ;;
+  esac
 }
 
-assert_file_contains() {
-  local file="$1" pattern="$2" name="$3"
-  if grep -Fq -- "$pattern" "$file"; then
-    PASS=$((PASS + 1))
-    printf '  ok    %s\n' "$name"
-  else
-    FAIL=$((FAIL + 1))
-    printf '  FAIL  %s\n        missing pattern: %s\n        file: %s\n' "$name" "$pattern" "$file"
-  fi
+# --- harness -----------------------------------------------------------------
+
+# stage SPEC — a fresh worktree for one row with the artifacts SPEC names:
+# `;`-separated `file@when=body` items, file a name under tmp/ (`F` is the
+# --file target review-external-F.json), when one of before, at, after, later,
+# later2 (the mtime against the delegation boundary) or none. Sets WT and F.
+RUN_SEQ=0
+stage() {
+  local spec="$1" items item file when name mtime
+  RUN="$TMP_ROOT/runs/$((++RUN_SEQ))"
+  WT="$RUN/wt"
+  mkdir -p "$WT/tmp"
+  F="$WT/tmp/review-external-F.json"
+  [[ -n "$spec" ]] || return 0
+  IFS=';' read -ra items <<<"$spec"
+  for item in "${items[@]}"; do
+    file="${item%%@*}"; when="${item#*@}"; when="${when%%=*}"; name="${item#*=}"
+    [[ "$file" != F ]] || file="review-external-F"
+    body "$name" > "$WT/tmp/$file.json"
+    case "$when" in
+      before) mtime=$BEFORE ;; at) mtime=$DELEG ;; after) mtime=$AFTER ;; later) mtime=$LATER ;; later2) mtime=$LATER2 ;;
+      none) continue ;;
+      *) echo "stage: unknown time $when in $item" >&2; exit 1 ;;
+    esac
+    touch -d "@$mtime" "$WT/tmp/$file.json"
+  done
 }
 
-assert_substr() {
-  local haystack="$1" needle="$2" name="$3"
-  if [[ "$haystack" == *"$needle"* ]]; then
-    PASS=$((PASS + 1))
-    printf '  ok    %s\n' "$name"
-  else
-    FAIL=$((FAIL + 1))
-    printf '  FAIL  %s\n        expected substring: %s\n        in:                 %s\n' "$name" "$needle" "$haystack"
-  fi
-}
-
-assert_file_not_contains() {
-  local file="$1" pattern="$2" name="$3"
-  if grep -Fq -- "$pattern" "$file"; then
-    FAIL=$((FAIL + 1))
-    printf '  FAIL  %s\n        unexpected pattern: %s\n        file: %s\n' "$name" "$pattern" "$file"
-  else
-    PASS=$((PASS + 1))
-    printf '  ok    %s\n' "$name"
-  fi
-}
-
-# expect_valid <artifact-path> <desc> — accepting-direction assertion that
-# survives a mutant. A bare `out="$("$CHECK" ...)"` aborts the whole run under
-# set -e the moment a guard starts over-rejecting, which truncates the suite
-# instead of naming what broke; the accepting direction is exactly where that
-# matters, because it is what pins WHICH number a guard reads.
-expect_valid() {
-  local path="$1" desc="$2" out rc=0
+# run_check ARGS... — runs the check with %W, %F and %D in ARGS replaced by
+# the staged worktree, the --file target and the delegation boundary; OUT is
+# the JSON, RC the exit, ERR the stderr file.
+run_check() {
+  local args=() a
+  for a in "$@"; do a="${a//%W/$WT}"; a="${a//%F/$F}"; a="${a//%D/$DELEG}"; args+=("$a"); done
+  ERR="$RUN/stderr"
   set +e
-  out="$("$CHECK" --file "$path")"
-  rc=$?
+  OUT=$("$CHECK" ${args[@]+"${args[@]}"} 2>"$ERR")
+  RC=$?
   set -e
-  assert_eq "$rc" "0" "$desc (exits 0)"
-  assert_eq "$(jq -r '.reason' <<<"$out")" "valid" "$desc"
 }
 
-# expect_glob_valid <worktree> <agent> <boundary> <expected-path> <desc>
-expect_glob_valid() {
-  local wt="$1" ag="$2" bound="$3" want="$4" desc="$5" out rc=0
-  set +e
-  out="$("$CHECK" "$wt" "$ag" "$bound")"
-  rc=$?
-  set -e
-  assert_eq "$rc" "0" "$desc (exits 0)"
-  assert_eq "$(jq -r '.path' <<<"$out")" "$want" "$desc"
+json() { jq -r "$1" <<<"$OUT" 2>/dev/null || echo UNPARSEABLE; }
+
+# observe EXPECT — prints the run's value of every `name=` field EXPECT names,
+# in EXPECT's order. Plain names are JSON result fields, a key the result does
+# not carry reads ABSENT;
+#   rc              exit status
+#   path            the basename of the reported path, or null
+#   detail~<text>   whether the detail names <text> (`+` reads as a space):
+#                   the detail is what the rejected reviewer acts on, and
+#                   which shape it saw lives nowhere else
+#   detail_present  whether a detail is a non-empty string
+#   stdout~<text>   whether stdout carries <text>
+#   stderr          `line` when anything was written there, else `empty`
+observe() {
+  local got="" token name value needle
+  for token in $1; do
+    name="${token%%=*}"
+    case "$name" in
+      rc) value="$RC" ;;
+      path) value="$(json '.path | if . == null then "null" else sub(".*/"; "") end')" ;;
+      detail~*) needle="${name#detail~}"; value="$(json '.detail // ""' | grep -qF -- "${needle//+/ }" && echo true || echo false)" ;;
+      detail_present) value="$(json '(.detail | type) == "string" and .detail != ""')" ;;
+      stdout~*) needle="${name#stdout~}"; value="$(grep -qF -- "${needle//+/ }" <<<"$OUT" && echo true || echo false)" ;;
+      stderr) value="$([[ -s "$ERR" ]] && echo line || echo empty)" ;;
+      *) value="$(json "if has(\"$name\") then .$name else \"ABSENT\" end")" ;;
+    esac
+    got="$got $name=$value"
+  done
+  printf '%s' "${got# }"
 }
 
-echo "=== review-artifact-check ==="
+# table ROW... — one staged worktree, one run and one assertion per row:
+# `label|stage|args|expect`.
+table() {
+  local row label spec args expect
+  for row in "$@"; do
+    IFS='|' read -r label spec args expect <<<"$row"
+    [[ -n "$expect" ]] || { printf 'table: a row with no expect asserts nothing: %s\n' "$row" >&2; exit 1; }
+    stage "$spec"
+    # shellcheck disable=SC2086
+    run_check $args
+    assert_eq "$(observe "$expect")" "$expect" "$label" "$ERR"
+  done
+}
 
-worktree="$TMP_ROOT/wt"
-mkdir -p "$worktree/tmp"
-delegated_at=1750000000
-before=$((delegated_at - 100))
-after=$((delegated_at + 100))
-later=$((delegated_at + 200))
+GLOB='%W reviewer-quality %D'
+Q=review-reviewer-quality
 
-# --- missing: no artifacts at all ---
-set +e
-out="$("$CHECK" "$worktree" reviewer-quality "$delegated_at")"
-rc=$?
-set -e
-assert_eq "$rc" "1" "missing artifact exits 1"
-assert_eq "$(jq -r '.ok' <<<"$out")" "false" "missing artifact reports ok=false"
-assert_eq "$(jq -r '.path' <<<"$out")" "null" "missing artifact reports null path"
-assert_eq "$(jq -r '.reason' <<<"$out")" "missing" "missing artifact reports reason=missing"
+echo "=== glob mode resolves the newest fresh artifact of the agent ==="
+# Another agent's file does not count; an artifact older than the boundary is
+# stale; a fresh one without a verdict is invalid and named; a fresh valid one
+# wins over stale and invalid siblings; a newest-but-unparseable file falls
+# back to an older fresh valid one.
+table \
+  "no artifact at all is missing||$GLOB|rc=1 ok=false path=null reason=missing" \
+  "another agent's fresh artifact does not count|review-reviewer-arch-1@after=pass|$GLOB|rc=1 reason=missing" \
+  "an artifact older than the boundary is stale and named|$Q-1@before=pass|$GLOB|rc=1 ok=false path=$Q-1.json reason=stale" \
+  "a fresh artifact without a verdict is invalid and named|$Q-1@before=pass;$Q-2@after=noverdict|$GLOB|rc=1 path=$Q-2.json reason=invalid" \
+  "a fresh valid artifact wins over stale and invalid siblings|$Q-1@before=pass;$Q-2@after=noverdict;$Q-3@later=action|$GLOB|rc=0 ok=true path=$Q-3.json reason=valid" \
+  "a newest unparseable file falls back to the older fresh valid one|$Q-3@later=action;$Q-4@later2=notjson|$GLOB|rc=0 ok=true path=$Q-3.json reason=valid"
 
-# --- other agent's artifact does not count ---
-other="$worktree/tmp/review-reviewer-arch-20260709-010101.json"
-printf '{"verdict":"pass","items":[]}' > "$other"
-touch -d "@$after" "$other"
-set +e
-out="$("$CHECK" "$worktree" reviewer-quality "$delegated_at")"
-rc=$?
-set -e
-assert_eq "$rc" "1" "other agent's artifact exits 1"
-assert_eq "$(jq -r '.reason' <<<"$out")" "missing" "other agent's artifact still reason=missing"
+echo "=== file mode validates one path, the boundary optional ==="
+# Without a boundary the mtime is ignored; with one, glob mode's freshness
+# gate applies with >= semantics; existence is checked before freshness and
+# freshness before the verdict.
+table \
+  "a valid file|F@none=pass|--file %F|rc=0 ok=true path=review-external-F.json reason=valid" \
+  "an old mtime validates without a boundary|F@before=pass|--file %F|rc=0 ok=true reason=valid" \
+  "an mtime before the boundary is stale|F@before=pass|--file %F %D|rc=1 ok=false path=review-external-F.json reason=stale" \
+  "an mtime after the boundary is fresh|F@after=pass|--file %F %D|rc=0 ok=true reason=valid" \
+  "an mtime equal to the boundary is fresh|F@at=pass|--file %F %D|reason=valid" \
+  "fresh but without a verdict is invalid|F@after=noverdict|--file %F %D|rc=1 reason=invalid" \
+  "a missing file with a boundary is missing|F@none=pass|--file %W/tmp/nope.json %D|rc=1 reason=missing" \
+  "a missing file|F@none=pass|--file %W/tmp/nope.json|rc=1 ok=false path=null reason=missing" \
+  "a file without a verdict is invalid and named|F@none=noverdict|--file %F|rc=1 path=review-external-F.json reason=invalid"
 
-# --- stale: artifact predates delegation ---
-stale="$worktree/tmp/review-reviewer-quality-20260709-010101.json"
-printf '{"verdict":"pass","items":[]}' > "$stale"
-touch -d "@$before" "$stale"
-set +e
-out="$("$CHECK" "$worktree" reviewer-quality "$delegated_at")"
-rc=$?
-set -e
-assert_eq "$rc" "1" "stale artifact exits 1"
-assert_eq "$(jq -r '.ok' <<<"$out")" "false" "stale artifact reports ok=false"
-assert_eq "$(jq -r '.path' <<<"$out")" "$stale" "stale artifact reports its path"
-assert_eq "$(jq -r '.reason' <<<"$out")" "stale" "stale artifact reports reason=stale"
+echo "=== a self-reported no-review artifact is refused, and terminally ==="
+# review_performed=false, or a no-review reason alone, is an admission
+# whatever the verdict; no qa_metadata keeps the existence-plus-verdict
+# tolerance; an empty qa_metadata with the arrays, or review_performed=true,
+# validates. In glob mode the refusal is terminal: no_review is the
+# reviewer's self-report about THIS run, so an older fresh sibling does not
+# rescue it; a STALE no-review artifact does not block a fresh valid one.
+E=review-reviewer-ext
+table \
+  "review_performed=false|F@after=noreview|--file %F|rc=1 ok=false path=review-external-F.json reason=no_review" \
+  "a no-review reason alone|F@none=noreview_reason|--file %F|rc=1 reason=no_review" \
+  "review_performed=false alone, arrays present, is still no_review|F@none=noreview_flag|--file %F|rc=1 reason=no_review" \
+  "no qa_metadata at all still validates|F@none=pass|--file %F|ok=true reason=valid" \
+  "empty qa_metadata with the arrays validates|F@none=qa_ok|--file %F|reason=valid" \
+  "review_performed=true validates|F@none=performed|--file %F|reason=valid" \
+  "glob: a fresh no-review artifact is refused and named|$E-1@after=noreview|%W reviewer-ext %D|rc=1 path=$E-1.json reason=no_review" \
+  "glob: terminal, an older fresh valid sibling does not rescue it|$E-0@after=qa_ok_noq;$E-1@later=noreview|%W reviewer-ext %D|rc=1 path=$E-1.json reason=no_review" \
+  "glob control: a stale no-review artifact does not block a fresh valid one|$E-0@after=qa_ok_noq;$E-1@before=noreview|%W reviewer-ext %D|rc=0 path=$E-0.json reason=valid"
 
-# --- invalid: fresh artifact without verdict field ---
-invalid="$worktree/tmp/review-reviewer-quality-20260709-020202.json"
-printf '{"items":[]}' > "$invalid"
-touch -d "@$after" "$invalid"
-set +e
-out="$("$CHECK" "$worktree" reviewer-quality "$delegated_at")"
-rc=$?
-set -e
-assert_eq "$rc" "1" "fresh artifact missing verdict exits 1"
-assert_eq "$(jq -r '.reason' <<<"$out")" "invalid" "fresh artifact missing verdict reports reason=invalid"
-assert_eq "$(jq -r '.path' <<<"$out")" "$invalid" "invalid report points at newest fresh artifact"
-
-# --- valid: fresh artifact with verdict wins over stale/invalid siblings ---
-valid="$worktree/tmp/review-reviewer-quality-20260709-030303.json"
-printf '{"verdict":"action_required","items":[{"category":"fix"}]}' > "$valid"
-touch -d "@$later" "$valid"
-out="$("$CHECK" "$worktree" reviewer-quality "$delegated_at")"
-assert_eq "$(jq -r '.ok' <<<"$out")" "true" "valid fresh artifact reports ok=true"
-assert_eq "$(jq -r '.path' <<<"$out")" "$valid" "valid fresh artifact reports its path"
-assert_eq "$(jq -r '.reason' <<<"$out")" "valid" "valid fresh artifact reports reason=valid"
-
-# --- newest artifact invalid: falls back to older fresh valid artifact ---
-newest_invalid="$worktree/tmp/review-reviewer-quality-20260709-040404.json"
-printf 'not json' > "$newest_invalid"
-touch -d "@$((later + 100))" "$newest_invalid"
-out="$("$CHECK" "$worktree" reviewer-quality "$delegated_at")"
-assert_eq "$(jq -r '.ok' <<<"$out")" "true" "newest-invalid falls back to older valid artifact"
-assert_eq "$(jq -r '.path' <<<"$out")" "$valid" "fallback selects the older fresh valid artifact"
-
-# --- --file mode: explicit path validation (external review output) ---
-ext_valid="$worktree/tmp/review-external-20260709-050505.json"
-printf '{"verdict":"pass","items":[]}' > "$ext_valid"
-out="$("$CHECK" --file "$ext_valid")"
-rc=$?
-assert_eq "$rc" "0" "--file valid artifact exits 0"
-assert_eq "$(jq -r '.ok' <<<"$out")" "true" "--file valid reports ok=true"
-assert_eq "$(jq -r '.path' <<<"$out")" "$ext_valid" "--file valid reports its path"
-assert_eq "$(jq -r '.reason' <<<"$out")" "valid" "--file valid reports reason=valid"
-
-# --file with NO boundary does not apply the staleness gate — an old mtime still validates
-touch -d "@$before" "$ext_valid"
-out="$("$CHECK" --file "$ext_valid")"
-assert_eq "$(jq -r '.ok' <<<"$out")" "true" "--file without boundary ignores mtime (existence+verdict only)"
-
-# --- --file mode: OPTIONAL delegated_at boundary applies glob mode's freshness gate ---
-# older-than-boundary mtime → stale
-touch -d "@$before" "$ext_valid"
-set +e
-out="$("$CHECK" --file "$ext_valid" "$delegated_at")"
-rc=$?
-set -e
-assert_eq "$rc" "1" "--file with boundary, older mtime exits 1"
-assert_eq "$(jq -r '.ok' <<<"$out")" "false" "--file stale reports ok=false"
-assert_eq "$(jq -r '.path' <<<"$out")" "$ext_valid" "--file stale reports its path"
-assert_eq "$(jq -r '.reason' <<<"$out")" "stale" "--file older-than-boundary reports reason=stale"
-
-# newer-than-boundary mtime → valid
-touch -d "@$after" "$ext_valid"
-out="$("$CHECK" --file "$ext_valid" "$delegated_at")"
-rc=$?
-assert_eq "$rc" "0" "--file with boundary, newer mtime exits 0"
-assert_eq "$(jq -r '.ok' <<<"$out")" "true" "--file fresh (mtime >= boundary) reports ok=true"
-assert_eq "$(jq -r '.reason' <<<"$out")" "valid" "--file newer-than-boundary reports reason=valid"
-
-# mtime exactly equal to boundary is fresh (not stale) — matches glob mode's >= semantics
-touch -d "@$delegated_at" "$ext_valid"
-out="$("$CHECK" --file "$ext_valid" "$delegated_at")"
-assert_eq "$(jq -r '.reason' <<<"$out")" "valid" "--file mtime == boundary is fresh"
-
-# fresh mtime but missing verdict → invalid (freshness passes, verdict gate fails)
-ext_fresh_noverdict="$worktree/tmp/review-external-20260709-070707.json"
-printf '{"items":[]}' > "$ext_fresh_noverdict"
-touch -d "@$after" "$ext_fresh_noverdict"
-set +e
-out="$("$CHECK" --file "$ext_fresh_noverdict" "$delegated_at")"
-rc=$?
-set -e
-assert_eq "$rc" "1" "--file fresh-but-no-verdict with boundary exits 1"
-assert_eq "$(jq -r '.reason' <<<"$out")" "invalid" "--file fresh-but-no-verdict with boundary reports reason=invalid"
-
-# missing file with a boundary still reports missing (existence checked before freshness)
-set +e
-out="$("$CHECK" --file "$worktree/tmp/review-external-nope.json" "$delegated_at")"
-rc=$?
-set -e
-assert_eq "$rc" "1" "--file missing with boundary exits 1"
-assert_eq "$(jq -r '.reason' <<<"$out")" "missing" "--file missing with boundary reports reason=missing"
-
-# --file: missing file
-set +e
-out="$("$CHECK" --file "$worktree/tmp/review-external-does-not-exist.json")"
-rc=$?
-set -e
-assert_eq "$rc" "1" "--file missing artifact exits 1"
-assert_eq "$(jq -r '.ok' <<<"$out")" "false" "--file missing reports ok=false"
-assert_eq "$(jq -r '.path' <<<"$out")" "null" "--file missing reports null path"
-assert_eq "$(jq -r '.reason' <<<"$out")" "missing" "--file missing reports reason=missing"
-
-# --file: exists but no verdict field
-ext_invalid="$worktree/tmp/review-external-20260709-060606.json"
-printf '{"items":[]}' > "$ext_invalid"
-set +e
-out="$("$CHECK" --file "$ext_invalid")"
-rc=$?
-set -e
-assert_eq "$rc" "1" "--file missing verdict exits 1"
-assert_eq "$(jq -r '.reason' <<<"$out")" "invalid" "--file missing verdict reports reason=invalid"
-assert_eq "$(jq -r '.path' <<<"$out")" "$ext_invalid" "--file invalid reports the file path"
-
-# --- no_review: self-reported no-review artifacts are rejected ---
-# A schema-valid pass verdict whose qa_metadata admits no review happened must
-# never validate, regardless of verdict.
-noreview="$worktree/tmp/review-external-20260718-010101.json"
-printf '{"verdict":"pass","summary":"No review was actually performed","qa_metadata":{"review_performed":false,"reason":"no_scope_provided"}}' > "$noreview"
-touch -d "@$after" "$noreview"
-set +e
-out="$("$CHECK" --file "$noreview")"
-rc=$?
-set -e
-assert_eq "$rc" "1" "--file review_performed=false exits 1"
-assert_eq "$(jq -r '.ok' <<<"$out")" "false" "--file review_performed=false reports ok=false"
-assert_eq "$(jq -r '.path' <<<"$out")" "$noreview" "--file review_performed=false reports its path"
-assert_eq "$(jq -r '.reason' <<<"$out")" "no_review" "--file review_performed=false reports reason=no_review"
-
-# a no-review reason alone (without review_performed) is also an admission
-noreview_reason="$worktree/tmp/review-external-20260718-020202.json"
-printf '{"verdict":"pass","qa_metadata":{"reason":"no_scope_provided"}}' > "$noreview_reason"
-set +e
-out="$("$CHECK" --file "$noreview_reason")"
-rc=$?
-set -e
-assert_eq "$rc" "1" "--file no-scope reason alone exits 1"
-assert_eq "$(jq -r '.reason' <<<"$out")" "no_review" "--file no-scope reason alone reports reason=no_review"
-
-# backward compat: no qa_metadata at all still validates on existence + verdict
-no_qa="$worktree/tmp/review-external-20260718-030303.json"
-printf '{"verdict":"pass","items":[]}' > "$no_qa"
-out="$("$CHECK" --file "$no_qa")"
-assert_eq "$(jq -r '.ok' <<<"$out")" "true" "--file artifact without qa_metadata still validates"
-assert_eq "$(jq -r '.reason' <<<"$out")" "valid" "--file artifact without qa_metadata reports reason=valid"
-
-# empty qa_metadata (the schema's performed-review shape) with the finding
-# arrays validates — declaring qa_metadata requires the arrays
-empty_qa="$worktree/tmp/review-external-20260718-040404.json"
-printf '{"verdict":"pass","blockers":[],"suggestions":[],"questions":[],"qa_metadata":{}}' > "$empty_qa"
-out="$("$CHECK" --file "$empty_qa")"
-assert_eq "$(jq -r '.reason' <<<"$out")" "valid" "--file empty qa_metadata with arrays reports reason=valid"
-
-# explicit review_performed=true validates
-performed="$worktree/tmp/review-external-20260718-050505.json"
-printf '{"verdict":"pass","blockers":[],"suggestions":[],"qa_metadata":{"review_performed":true}}' > "$performed"
-out="$("$CHECK" --file "$performed")"
-assert_eq "$(jq -r '.reason' <<<"$out")" "valid" "--file review_performed=true reports reason=valid"
-
-# glob mode applies the same gate: a fresh no-review artifact is rejected...
-glob_noreview="$worktree/tmp/review-reviewer-ext-20260718-060606.json"
-printf '{"verdict":"pass","qa_metadata":{"review_performed":false,"reason":"no_scope_provided"}}' > "$glob_noreview"
-touch -d "@$after" "$glob_noreview"
-set +e
-out="$("$CHECK" "$worktree" reviewer-ext "$delegated_at")"
-rc=$?
-set -e
-assert_eq "$rc" "1" "glob no-review artifact exits 1"
-assert_eq "$(jq -r '.reason' <<<"$out")" "no_review" "glob no-review artifact reports reason=no_review"
-assert_eq "$(jq -r '.path' <<<"$out")" "$glob_noreview" "glob no-review report points at the artifact"
-
-# ...and it is TERMINAL: an older fresh sibling does NOT rescue it. no_review is
-# the reviewer's self-report about the RUN, and the prescribed self-check
-# boundary of 0 makes every prior artifact fresh, so falling back would answer
-# "did some prior round leave a file?" instead of "did this review happen?"
-glob_valid="$worktree/tmp/review-reviewer-ext-20260718-000000.json"
-printf '{"verdict":"pass","blockers":[],"suggestions":[],"qa_metadata":{}}' > "$glob_valid"
-touch -d "@$after" "$glob_valid"
-touch -d "@$later" "$glob_noreview"
-set +e
-out="$("$CHECK" "$worktree" reviewer-ext "$delegated_at")"
-rc=$?
-set -e
-assert_eq "$rc" "1" "glob no-review is terminal, not rescued by an older sibling"
-assert_eq "$(jq -r '.reason' <<<"$out")" "no_review" "glob terminal no-review keeps reason=no_review"
-assert_eq "$(jq -r '.path' <<<"$out")" "$glob_noreview" "glob terminal no-review points at the rejected artifact"
-
-# MUST-FAIL CONTROL for the terminal rule: with the no-review artifact STALE
-# (not fresh), the older-but-fresh valid sibling is still the answer — terminal
-# means "this run is refused", not "this agent is refused forever".
-touch -d "@$before" "$glob_noreview"
-expect_glob_valid "$worktree" reviewer-ext "$delegated_at" "$glob_valid" "a STALE no-review artifact does not block a fresh valid one"
-touch -d "@$later" "$glob_noreview"
-
-# --- incomplete: qa-shaped artifacts must carry the finding arrays ---
-# A truncated write can keep verdict/summary while losing blockers/suggestions —
-# schema-valid on the `.verdict` gate, but the findings are gone. An artifact
-# that declares qa_metadata without the arrays is rejected reason=incomplete;
-# artifacts without qa_metadata keep the pre-existing tolerance (see no_qa above).
-inc="$worktree/tmp/review-external-20260718-070707.json"
-printf '{"agent":"external-codex","timestamp":"2026-07-18T00:00:00Z","verdict":"pass","summary":"looks fine","qa_metadata":{}}' > "$inc"
-set +e
-out="$("$CHECK" --file "$inc")"
-rc=$?
-set -e
-assert_eq "$rc" "1" "--file qa-shaped artifact without arrays exits 1"
-assert_eq "$(jq -r '.ok' <<<"$out")" "false" "--file qa-shaped without arrays reports ok=false"
-assert_eq "$(jq -r '.path' <<<"$out")" "$inc" "--file qa-shaped without arrays reports its path"
-assert_eq "$(jq -r '.reason' <<<"$out")" "incomplete" "--file qa-shaped without arrays reports reason=incomplete"
-
-# a mistyped array is as lost as a missing one
-inc_type="$worktree/tmp/review-external-20260718-080808.json"
-printf '{"verdict":"pass","blockers":"none","suggestions":[],"qa_metadata":{}}' > "$inc_type"
-set +e
-out="$("$CHECK" --file "$inc_type")"
-rc=$?
-set -e
-assert_eq "$rc" "1" "--file non-array blockers exits 1"
-assert_eq "$(jq -r '.reason' <<<"$out")" "incomplete" "--file non-array blockers reports reason=incomplete"
-
-# missing suggestions alone is incomplete too
-inc_sugg="$worktree/tmp/review-external-20260718-090909.json"
-printf '{"verdict":"pass","blockers":[],"qa_metadata":{}}' > "$inc_sugg"
-set +e
-out="$("$CHECK" --file "$inc_sugg")"
-rc=$?
-set -e
-assert_eq "$rc" "1" "--file missing suggestions exits 1"
-assert_eq "$(jq -r '.reason' <<<"$out")" "incomplete" "--file missing suggestions reports reason=incomplete"
-
-# questions[] is NOT required (PR-comment-triage-only; the QA standard fields omit it)
-no_questions="$worktree/tmp/review-external-20260718-101010.json"
-printf '{"verdict":"pass","blockers":[],"suggestions":[],"qa_metadata":{}}' > "$no_questions"
-out="$("$CHECK" --file "$no_questions")"
-assert_eq "$(jq -r '.reason' <<<"$out")" "valid" "--file qa-shaped without questions still validates"
-
-# glob mode applies the same gate: a fresh qa-shaped incomplete artifact is rejected...
-glob_inc="$worktree/tmp/review-reviewer-inc-20260718-111111.json"
-printf '{"verdict":"pass","summary":"truncated","qa_metadata":{}}' > "$glob_inc"
-touch -d "@$after" "$glob_inc"
-set +e
-out="$("$CHECK" "$worktree" reviewer-inc "$delegated_at")"
-rc=$?
-set -e
-assert_eq "$rc" "1" "glob qa-shaped artifact without arrays exits 1"
-assert_eq "$(jq -r '.reason' <<<"$out")" "incomplete" "glob qa-shaped without arrays reports reason=incomplete"
-assert_eq "$(jq -r '.path' <<<"$out")" "$glob_inc" "glob incomplete report points at the artifact"
-
-# ...and it is TERMINAL. This gate was filed as the truncated-write shape until
-# the argument was checked: a truncated JSON object is not a JSON object, so
-# every torn or partial write fails the `.verdict` parse before any content gate
-# runs. What reaches this gate is well-formed JSON the writer produced, which no
-# older artifact answers for.
-glob_inc_valid="$worktree/tmp/review-reviewer-inc-20260718-000000.json"
-printf '{"verdict":"pass","blockers":[],"suggestions":[],"qa_metadata":{}}' > "$glob_inc_valid"
-touch -d "@$after" "$glob_inc_valid"
-touch -d "@$later" "$glob_inc"
-set +e
-out="$("$CHECK" "$worktree" reviewer-inc "$delegated_at")"
-rc=$?
-set -e
-assert_eq "$rc" "1" "glob qa-shape incomplete is terminal, not rescued by an older sibling"
-assert_eq "$(jq -r '.path' <<<"$out")" "$glob_inc" "glob terminal qa-shape points at the rejected artifact"
-
-# MUST-FAIL CONTROL: stale, and the fresh complete one is the answer again.
-touch -d "@$before" "$glob_inc"
-expect_glob_valid "$worktree" reviewer-inc "$delegated_at" "$glob_inc_valid" "a STALE qa-shape artifact does not block a fresh complete one"
-touch -d "@$later" "$glob_inc"
-
-# THE PREMISE, ASSERTED: no prefix truncation of a review artifact ever reaches
-# a content gate, because it is not parseable JSON. If this ever stopped
-# holding, the disposition above would be wrong.
+echo "=== a qa-shaped artifact must carry the finding arrays ==="
+# Declaring qa_metadata requires blockers[] and suggestions[] (questions[] is
+# not required); a mistyped array is as lost as a missing one. In glob mode
+# the refusal is terminal, and a STALE incomplete artifact does not block a
+# fresh complete one. A prefix truncation never reaches this gate: it is not
+# JSON, so every one is invalid first.
+I=review-reviewer-inc
+table \
+  "qa-shaped without the arrays is incomplete and named|F@none=qa_inc_agent|--file %F|rc=1 ok=false path=review-external-F.json reason=incomplete" \
+  "a non-array blockers|F@none=inc_type|--file %F|rc=1 reason=incomplete" \
+  "missing suggestions alone|F@none=inc_sugg|--file %F|rc=1 reason=incomplete" \
+  "questions[] is not required|F@none=qa_ok_noq|--file %F|reason=valid" \
+  "glob: a fresh qa-shaped incomplete artifact is refused and named|$I-1@after=qa_inc|%W reviewer-inc %D|rc=1 path=$I-1.json reason=incomplete" \
+  "glob: terminal, an older fresh complete sibling does not rescue it|$I-0@after=qa_ok_noq;$I-1@later=qa_inc|%W reviewer-inc %D|rc=1 path=$I-1.json" \
+  "glob control: a stale incomplete artifact does not block a fresh complete one|$I-0@after=qa_ok_noq;$I-1@before=qa_inc|%W reviewer-inc %D|rc=0 path=$I-0.json"
 trunc_src='{"agent":"r","verdict":"pass","summary":"s","blockers":[{"id":1,"title":"t","location":"l","description":"d","recommendation":"r","priority":1,"estimate":1}],"suggestions":[],"qa_metadata":{"x":1}}'
 trunc_bad=""
+stage ""
 for pct in 20 40 60 80 90 95 99; do
-  trunc_path="$worktree/tmp/review-external-20260813-0000$pct.json"
-  printf '%s' "${trunc_src:0:$(( ${#trunc_src} * pct / 100 ))}" > "$trunc_path"
-  set +e
-  trunc_out="$("$CHECK" --file "$trunc_path")"
-  set -e
-  trunc_reason="$(jq -r '.reason' <<<"$trunc_out" 2>/dev/null || printf 'unparseable')"
-  [[ "$trunc_reason" == "invalid" ]] || trunc_bad="$trunc_bad ${pct}%:$trunc_reason"
+  printf '%s' "${trunc_src:0:$(( ${#trunc_src} * pct / 100 ))}" > "$WT/tmp/trunc-$pct.json"
+  run_check --file "$WT/tmp/trunc-$pct.json"
+  [[ "$(json .reason)" == "invalid" ]] || trunc_bad="$trunc_bad ${pct}%:$(json .reason)"
 done
 assert_eq "$trunc_bad" "" "every prefix truncation is rejected as invalid before any content gate"
 
-# --- incomplete: qa-shaped artifacts must carry USABLE finding items ---
-# qa_shaped_incomplete only catches arrays lost wholesale. An artifact can carry
-# present, non-empty blockers[]/suggestions[] whose ITEMS omit the required
-# review-finding fields — present in prose but unroutable, because the
-# orchestrator routes suggestions on `category`. Required item set (from
-# reviewer/schemas/review-finding.md § Item Fields): id, title, location,
-# description, recommendation, priority, estimate — plus category (∈ fix|issue)
-# for suggestions. Reason reuses `incomplete`; a `detail` field names the first
-# offending item and field.
+echo "=== a qa-shaped artifact must carry usable finding items, and the detail says which ==="
+# Items need id, title, location, description, recommendation, priority
+# (1..4) and estimate (1..5), suggestions also category in {fix, issue}; the
+# detail names the first offending item and field. Artifacts without
+# qa_metadata keep the tolerant shape. A missing array, a null one and a
+# wrong-typed one are three different things the agent did and the detail
+# says which, and what an empty review writes. Every rejection in the chain
+# names its cause. In glob mode a malformed-item artifact is refused
+# terminally, and a STALE one does not block a fresh well-formed one.
+T=review-reviewer-item
+table \
+  "the issue's malformed suggestion is incomplete, the detail names the item and the missing category|F@none=issue_bad|--file %F|rc=1 ok=false path=review-external-F.json reason=incomplete detail~suggestions[0]=true detail~category=true" \
+  "a fully compliant artifact is valid and carries no detail key|F@none=compliant|--file %F|ok=true reason=valid detail=ABSENT" \
+  "empty arrays carry no items and stay valid|F@none=qa_ok_noq|--file %F|reason=valid" \
+  "a suggestion missing only category|F@none=nocat|--file %F|rc=1 reason=incomplete detail~category=true" \
+  "a category outside fix and issue|F@none=badcatval|--file %F|rc=1 reason=incomplete" \
+  "a blocker missing a base field, named|F@none=badblk|--file %F|rc=1 reason=incomplete detail~blockers[0]=true detail~description=true" \
+  "a blocker without category is valid|F@none=okblk|--file %F|reason=valid" \
+  "a priority outside 1..4, named|F@none=badpri|--file %F|rc=1 reason=incomplete detail~priority=true" \
+  "a string estimate, named|F@none=badest|--file %F|rc=1 detail~estimate=true" \
+  "a blocker priority below the range, named on its array|F@none=badblkpri|--file %F|rc=1 detail~blockers[0]=true" \
+  "the boundary values priority 4 and estimate 5 are valid|F@none=okbound|--file %F|reason=valid" \
+  "malformed items without qa_metadata stay tolerant|F@none=noqa_bad|--file %F|reason=valid" \
+  "arrays lost: the detail names both arrays as absent and the exempt shape|F@none=qa_inc|--file %F|reason=incomplete detail~blockers[]+is+absent=true detail~suggestions[]+is+absent=true detail~no+qa_metadata=true" \
+  "a null blockers is reported as null, and what an empty review writes|F@none=null_blockers|--file %F|rc=1 reason=incomplete detail~blockers[]+is+null=true detail~writes+[]=true" \
+  "a missing blockers is reported as absent|F@none=inc_sugg|--file %F|detail~blockers[]+is+absent=false detail~suggestions[]+is+absent=true" \
+  "an object blockers is reported by type|F@none=obj_blockers|--file %F|rc=1 reason=incomplete detail~blockers[]+is+object,+not+an+array=true detail~writes+[]=true" \
+  "a string blockers is reported by type|F@none=str_blockers|--file %F|rc=1 reason=incomplete detail~blockers[]+is+string,+not+an+array=true detail~writes+[]=true" \
+  "a number blockers is reported by type|F@none=num_blockers|--file %F|rc=1 reason=incomplete detail~blockers[]+is+number,+not+an+array=true detail~writes+[]=true" \
+  "a null suggestions is reported on its own|F@none=null_sugg|--file %F|detail~suggestions[]+is+null=true" \
+  "a wrong-typed suggestions is reported on its own|F@none=str_sugg|--file %F|detail~suggestions[]+is+string,+not+an+array=true" \
+  "chain: a missing verdict names its cause|F@none=chain_noverdict|--file %F|ok=false detail_present=true" \
+  "chain: a no-review admission names its cause|F@none=chain_noreview|--file %F|ok=false detail_present=true" \
+  "chain: a qa-shape loss names its cause|F@none=qa_inc|--file %F|ok=false detail_present=true" \
+  "chain: a malformed finding item names its cause|F@none=chain_item|--file %F|ok=false detail_present=true" \
+  "chain: a bad measurement declaration names its cause|F@none=chain_decl|--file %F|ok=false detail_present=true" \
+  "chain: a zero-sample measurement names its cause|F@none=chain_zero|--file %F|ok=false detail_present=true" \
+  "glob missing names the glob that matched nothing||%W ghost-agent 0|reason=missing detail~review-ghost-agent-=true" \
+  "glob stale names the mtime against the boundary|review-staleonly-1@before=pass|%W staleonly %D|reason=stale detail~predates+the+boundary=true" \
+  "file missing names the path||--file %W/definitely-not-here.json|reason=missing detail~no+file+at=true" \
+  "file stale names the mtime against the boundary|F@before=pass|--file %F %D|reason=stale detail~predates+the+boundary=true" \
+  "glob: a fresh malformed-item artifact is refused and named|$T-1@after=item_bad|%W reviewer-item %D|rc=1 path=$T-1.json reason=incomplete detail~suggestions[0]=true" \
+  "glob: terminal, an older fresh well-formed sibling does not rescue it|$T-0@after=item_ok;$T-1@later=item_bad|%W reviewer-item %D|rc=1 path=$T-1.json reason=incomplete" \
+  "glob control: a stale malformed-item artifact does not block a fresh well-formed one|$T-0@after=item_ok;$T-1@before=item_bad|%W reviewer-item %D|rc=0 path=$T-0.json"
 
-# the exact malformed shape from the issue: {title, location, detail, severity}
-issue_bad="$worktree/tmp/review-external-20260810-010101.json"
-printf '{"agent":"reviewer-arch","verdict":"pass","blockers":[],"suggestions":[{"title":"Two resolvers coexist","location":"/abs/instrument_link.rs (instrument_name)","detail":"...","severity":"low"}],"qa_metadata":{"arch_review":{"overall_score":8.4,"pass":true}}}' > "$issue_bad"
-set +e
-out="$("$CHECK" --file "$issue_bad")"
-rc=$?
-set -e
-assert_eq "$rc" "1" "--file issue malformed suggestion exits 1"
-assert_eq "$(jq -r '.ok' <<<"$out")" "false" "--file issue malformed suggestion reports ok=false"
-assert_eq "$(jq -r '.path' <<<"$out")" "$issue_bad" "--file issue malformed suggestion reports its path"
-assert_eq "$(jq -r '.reason' <<<"$out")" "incomplete" "--file issue malformed suggestion reports reason=incomplete"
-assert_substr "$(jq -r '.detail' <<<"$out")" "suggestions[0]" "--file issue malformed detail names the offending item"
-assert_substr "$(jq -r '.detail' <<<"$out")" "category" "--file issue malformed detail names the missing category field"
+echo "=== usage errors ==="
+table \
+  "missing arguments|F@none=pass|%W reviewer-quality|rc=2" \
+  "a non-numeric delegated_at|F@none=pass|%W reviewer-quality not-a-number|rc=2" \
+  "a nonexistent worktree||%W/does-not-exist reviewer-quality %D|rc=2" \
+  "--file with no path||--file|rc=2" \
+  "--file with a non-numeric boundary|F@none=pass|--file %F not-a-number|rc=2" \
+  "--file with too many arguments|F@none=pass|--file %F %D extra-arg|rc=2" \
+  "a non-integer --wait|F@none=pass|%W waitrev 0 --wait nope|rc=2" \
+  "the bare three-positional contract still validates|review-waitrev-1@after=qa_ok|%W waitrev 0|rc=0"
 
-# a fully schema-compliant artifact with populated items still validates
-compliant="$worktree/tmp/review-external-20260810-020202.json"
-printf '{"verdict":"action_required","blockers":[{"id":1,"title":"t","location":"src/x.rs (`f`)","description":"d","recommendation":"r","priority":1,"estimate":2}],"suggestions":[{"id":1,"title":"t","location":"src/y.rs (`g`)","description":"d","recommendation":"r","priority":3,"estimate":2,"category":"fix"}],"qa_metadata":{}}' > "$compliant"
-out="$("$CHECK" --file "$compliant")"
-assert_eq "$(jq -r '.ok' <<<"$out")" "true" "--file fully compliant items reports ok=true"
-assert_eq "$(jq -r '.reason' <<<"$out")" "valid" "--file fully compliant items reports reason=valid"
-assert_eq "$(jq -r '.detail' <<<"$out")" "null" "--file valid artifact carries no detail field"
-
-# empty blockers[]/suggestions[] carry no items and stay valid (do not regress)
-empty_items="$worktree/tmp/review-external-20260810-030303.json"
-printf '{"verdict":"pass","blockers":[],"suggestions":[],"qa_metadata":{}}' > "$empty_items"
-out="$("$CHECK" --file "$empty_items")"
-assert_eq "$(jq -r '.reason' <<<"$out")" "valid" "--file empty arrays stay valid under item check"
-
-# an item missing ONLY category (routing-critical) is rejected
-nocat="$worktree/tmp/review-external-20260810-040404.json"
-printf '{"verdict":"pass","blockers":[],"suggestions":[{"id":1,"title":"t","location":"l","description":"d","recommendation":"r","priority":3,"estimate":2}],"qa_metadata":{}}' > "$nocat"
-set +e
-out="$("$CHECK" --file "$nocat")"
-rc=$?
-set -e
-assert_eq "$rc" "1" "--file suggestion missing only category exits 1"
-assert_eq "$(jq -r '.reason' <<<"$out")" "incomplete" "--file suggestion missing only category reports reason=incomplete"
-assert_substr "$(jq -r '.detail' <<<"$out")" "category" "--file missing-category detail names category"
-
-# category present but not in {fix,issue} is rejected (routing keys on the value)
-badcatval="$worktree/tmp/review-external-20260810-050505.json"
-printf '{"verdict":"pass","blockers":[],"suggestions":[{"id":1,"title":"t","location":"l","description":"d","recommendation":"r","priority":3,"estimate":2,"category":"low"}],"qa_metadata":{}}' > "$badcatval"
-set +e
-out="$("$CHECK" --file "$badcatval")"
-rc=$?
-set -e
-assert_eq "$rc" "1" "--file suggestion category not in {fix,issue} exits 1"
-assert_eq "$(jq -r '.reason' <<<"$out")" "incomplete" "--file bad category value reports reason=incomplete"
-
-# blockers require the base fields but NOT category — a blocker missing a base
-# field is rejected, a blocker without category is fine
-badblk="$worktree/tmp/review-external-20260810-060606.json"
-printf '{"verdict":"action_required","blockers":[{"id":1,"title":"t","location":"l","recommendation":"r","priority":1,"estimate":2}],"suggestions":[],"qa_metadata":{}}' > "$badblk"
-set +e
-out="$("$CHECK" --file "$badblk")"
-rc=$?
-set -e
-assert_eq "$rc" "1" "--file blocker missing description exits 1"
-assert_eq "$(jq -r '.reason' <<<"$out")" "incomplete" "--file blocker missing base field reports reason=incomplete"
-assert_substr "$(jq -r '.detail' <<<"$out")" "blockers[0]" "--file blocker detail names the blockers array"
-assert_substr "$(jq -r '.detail' <<<"$out")" "description" "--file blocker detail names the missing field"
-
-okblk="$worktree/tmp/review-external-20260810-070707.json"
-printf '{"verdict":"action_required","blockers":[{"id":1,"title":"t","location":"l","description":"d","recommendation":"r","priority":1,"estimate":2}],"suggestions":[],"qa_metadata":{}}' > "$okblk"
-out="$("$CHECK" --file "$okblk")"
-assert_eq "$(jq -r '.reason' <<<"$out")" "valid" "--file blocker without category is valid (category is suggestions-only)"
-
-# priority/estimate range + type per review-finding.md (priority 1..4, estimate
-# 1..5: a present-but-out-of-range or non-numeric value is unusable
-badpri="$worktree/tmp/review-external-20260810-090909.json"
-printf '{"verdict":"pass","blockers":[],"suggestions":[{"id":1,"title":"t","location":"l","description":"d","recommendation":"r","priority":5,"estimate":2,"category":"fix"}],"qa_metadata":{}}' > "$badpri"
-set +e; out="$("$CHECK" --file "$badpri")"; rc=$?; set -e
-assert_eq "$rc" "1" "--file priority out of 1..4 exits 1"
-assert_eq "$(jq -r '.reason' <<<"$out")" "incomplete" "--file out-of-range priority reports reason=incomplete"
-assert_substr "$(jq -r '.detail' <<<"$out")" "priority" "--file out-of-range priority detail names priority"
-
-badest="$worktree/tmp/review-external-20260810-101010.json"
-printf '{"verdict":"pass","blockers":[],"suggestions":[{"id":1,"title":"t","location":"l","description":"d","recommendation":"r","priority":2,"estimate":"2","category":"issue"}],"qa_metadata":{}}' > "$badest"
-set +e; out="$("$CHECK" --file "$badest")"; rc=$?; set -e
-assert_eq "$rc" "1" "--file non-numeric estimate exits 1"
-assert_substr "$(jq -r '.detail' <<<"$out")" "estimate" "--file string estimate detail names estimate"
-
-# blockers carry the same numeric constraint (priority 0 is below range)
-badblkpri="$worktree/tmp/review-external-20260810-111111.json"
-printf '{"verdict":"action_required","blockers":[{"id":1,"title":"t","location":"l","description":"d","recommendation":"r","priority":0,"estimate":3}],"suggestions":[],"qa_metadata":{}}' > "$badblkpri"
-set +e; out="$("$CHECK" --file "$badblkpri")"; rc=$?; set -e
-assert_eq "$rc" "1" "--file blocker priority below 1..4 exits 1"
-assert_substr "$(jq -r '.detail' <<<"$out")" "blockers[0]" "--file blocker out-of-range detail names the blockers array"
-
-# boundary values (priority 1 and 4, estimate 1 and 5) are valid — not off-by-one rejected
-okbound="$worktree/tmp/review-external-20260810-121212.json"
-printf '{"verdict":"pass","blockers":[],"suggestions":[{"id":1,"title":"t","location":"l","description":"d","recommendation":"r","priority":4,"estimate":5,"category":"fix"}],"qa_metadata":{}}' > "$okbound"
-out="$("$CHECK" --file "$okbound")"
-assert_eq "$(jq -r '.reason' <<<"$out")" "valid" "--file priority=4 estimate=5 boundary values are valid"
-
-# artifacts WITHOUT qa_metadata keep the pre-existing tolerance — malformed items
-# do NOT trip the check (parity with qa_shaped_incomplete's gating)
-noqa_bad="$worktree/tmp/review-external-20260810-080808.json"
-printf '{"verdict":"pass","suggestions":[{"title":"t","location":"l"}]}' > "$noqa_bad"
-out="$("$CHECK" --file "$noqa_bad")"
-assert_eq "$(jq -r '.reason' <<<"$out")" "valid" "--file malformed items without qa_metadata stay tolerant (valid)"
-
-# array-lost incomplete still precedes the item check: a qa-shaped artifact whose
-# arrays are entirely missing is reason=incomplete, and it names WHICH arrays.
-# This was the chain's one detail-free rejection, so an artifact that adopted
-# qa_metadata to reach the measurement declaration got a second, unexplained
-# refusal after doing exactly what the first rejection instructed — and § 3.1
-# permits one re-delegation before `unresponsive`.
-arrays_lost="$worktree/tmp/review-external-20260810-090909.json"
-printf '{"verdict":"pass","summary":"truncated","qa_metadata":{}}' > "$arrays_lost"
-set +e
-out="$("$CHECK" --file "$arrays_lost")"
-rc=$?
-set -e
-assert_eq "$(jq -r '.reason' <<<"$out")" "incomplete" "--file arrays-lost still reason=incomplete"
-assert_substr "$(jq -r '.detail' <<<"$out")" "blockers[] is absent" "--file arrays-lost detail names the first missing array and what it was"
-assert_substr "$(jq -r '.detail' <<<"$out")" "suggestions[] is absent" "--file arrays-lost detail names the second"
-assert_substr "$(jq -r '.detail' <<<"$out")" "no qa_metadata" "--file arrays-lost detail says the tolerant shape is exempt"
-
-# A key that is missing and a key written as null are different things an agent
-# did; `has()` is what tells them apart, and the remedy reads better for both
-# when the report says which one it saw. Kept BELOW the arrays-lost assertions:
-# each of these reassigns `out`, so sitting above them made the last one read
-# this fixture while claiming to describe $arrays_lost.
-qa_absent_vs_null="$worktree/tmp/review-external-20260812-950001.json"
-printf '{"verdict":"pass","blockers":null,"suggestions":[],"qa_metadata":{}}' > "$qa_absent_vs_null"
-set +e
-out="$("$CHECK" --file "$qa_absent_vs_null")"
-set -e
-assert_substr "$(jq -r '.detail' <<<"$out")" "blockers[] is null" "--file a null array is reported as null, not as absent"
-printf '{"verdict":"pass","suggestions":[],"qa_metadata":{}}' > "$qa_absent_vs_null"
-set +e
-out="$("$CHECK" --file "$qa_absent_vs_null")"
-set -e
-assert_substr "$(jq -r '.detail' <<<"$out")" "blockers[] is absent" "--file a missing key is reported as absent, not as null"
-
-# A field PRESENT with the wrong type is this run's output shape, not a damaged
-# write, and the detail has to say which it was — an agent that wrote `null`
-# meaning "no findings" needs to be told to write [].
-qa_shape_case() {
-  local name="$1" literal="$2" want_detail="$3" path out
-  path="$worktree/tmp/review-external-20260812-$(printf '%06d' "$SHAPE_N").json"
-  SHAPE_N=$((SHAPE_N + 1))
-  printf '{"verdict":"pass","blockers":%s,"suggestions":[],"qa_metadata":{}}' "$literal" > "$path"
-  set +e
-  out="$("$CHECK" --file "$path")"
-  rc=$?
-  set -e
-  assert_eq "$rc" "1" "--file blockers:$name exits 1"
-  assert_eq "$(jq -r '.reason' <<<"$out")" "incomplete" "--file blockers:$name reports reason=incomplete"
-  assert_substr "$(jq -r '.detail' <<<"$out")" "$want_detail" "--file blockers:$name detail names what it found"
-  assert_substr "$(jq -r '.detail' <<<"$out")" "writes []" "--file blockers:$name detail says what an empty review writes"
-}
-SHAPE_N=1
-qa_shape_case "null"    'null'     "blockers[] is null"
-qa_shape_case "object"  '{}'       "blockers[] is object, not an array"
-qa_shape_case "string"  '"none"'   "blockers[] is string, not an array"
-qa_shape_case "number"  '3'        "blockers[] is number, not an array"
-# the same shapes on the OTHER array, so neither is checked by accident
-sugg_shape="$worktree/tmp/review-external-20260812-900001.json"
-printf '{"verdict":"pass","blockers":[],"suggestions":null,"qa_metadata":{}}' > "$sugg_shape"
-set +e
-out="$("$CHECK" --file "$sugg_shape")"
-set -e
-assert_substr "$(jq -r '.detail' <<<"$out")" "suggestions[] is null" "--file suggestions:null is reported on its own"
-printf '{"verdict":"pass","blockers":[],"suggestions":"x","qa_metadata":{}}' > "$sugg_shape"
-set +e
-out="$("$CHECK" --file "$sugg_shape")"
-set -e
-assert_substr "$(jq -r '.detail' <<<"$out")" "suggestions[] is string, not an array" "--file suggestions with a wrong type is reported on its own"
-
-# EVERY rejection in the chain names its cause. A reason with no detail is a
-# dead end for the agent that has to fix it.
-chain_no_detail=""
-chain_case() {
-  local body="$1" label="$2" path out
-  path="$worktree/tmp/review-external-20260811-$(printf '%06d' "$CHAIN_N").json"
-  CHAIN_N=$((CHAIN_N + 1))
-  printf '%s' "$body" > "$path"
-  set +e
-  out="$("$CHECK" --file "$path")"
-  set -e
-  if [[ "$(jq -r '.ok' <<<"$out")" == "false" ]] && [[ "$(jq -r '.detail // ""' <<<"$out")" == "" ]]; then
-    chain_no_detail="$chain_no_detail $label($(jq -r '.reason' <<<"$out"))"
-  fi
-}
-CHAIN_N=1
-chain_case '{"agent":"r","summary":"no verdict field"}' missing-verdict
-chain_case '{"verdict":"pass","qa_metadata":{"review_performed":false}}' no-review
-chain_case '{"verdict":"pass","summary":"s","qa_metadata":{}}' qa-shape
-chain_case '{"verdict":"pass","blockers":[],"suggestions":[{"title":"t"}],"qa_metadata":{}}' finding-item
-chain_case '{"verdict":"pass","blockers":[],"suggestions":[],"measurement_failed":"n/a"}' bad-declaration
-chain_case '{"verdict":"pass","summary":"mutation: killed 0/0","blockers":[],"suggestions":[],"qa_metadata":{}}' zero-sample
-assert_eq "$chain_no_detail" "" "every content-gate rejection names its cause in detail"
-
-# ...and the two reasons an agent reads BEFORE it knows what it did wrong. The
-# --help claim is unconditional, and these were the two carrying nothing.
-detail_of() {
-  set +e
-  local out
-  out="$("$CHECK" "$@")"
-  set -e
-  jq -r '.detail // ""' <<<"$out"
-}
-empty_wt="$TMP_ROOT/emptywt"
-mkdir -p "$empty_wt/tmp"
-assert_substr "$(detail_of "$empty_wt" ghost-agent 0)" "review-ghost-agent-" "glob missing names the glob that matched nothing"
-stale_only="$empty_wt/tmp/review-staleonly-20200101-000000.json"
-printf '{"verdict":"pass"}' > "$stale_only"
-touch -d "@$before" "$stale_only"
-assert_substr "$(detail_of "$empty_wt" staleonly "$delegated_at")" "predates the boundary" "glob stale names the mtime against the boundary"
-assert_substr "$(detail_of --file "$TMP_ROOT/definitely-not-here.json")" "no file at" "--file missing names the path"
-assert_substr "$(detail_of --file "$stale_only" "$delegated_at")" "predates the boundary" "--file stale names the mtime against the boundary"
-
-# glob mode applies the same item gate: a fresh malformed-item artifact is rejected...
-glob_item_bad="$worktree/tmp/review-reviewer-item-20260810-111111.json"
-printf '{"verdict":"pass","blockers":[],"suggestions":[{"title":"t","location":"l","detail":"x","severity":"low"}],"qa_metadata":{}}' > "$glob_item_bad"
-touch -d "@$after" "$glob_item_bad"
-set +e
-out="$("$CHECK" "$worktree" reviewer-item "$delegated_at")"
-rc=$?
-set -e
-assert_eq "$rc" "1" "glob malformed-item artifact exits 1"
-assert_eq "$(jq -r '.reason' <<<"$out")" "incomplete" "glob malformed-item reports reason=incomplete"
-assert_eq "$(jq -r '.path' <<<"$out")" "$glob_item_bad" "glob malformed-item report points at the artifact"
-assert_substr "$(jq -r '.detail' <<<"$out")" "suggestions[0]" "glob malformed-item detail names the item"
-
-# ...and it is TERMINAL, not answered by an older sibling. Items carrying wrong
-# field names are what THIS run produced — a truncated write does not rename
-# fields — so the disposition rule puts this on the self-report side. Falling
-# back here told a reviewer whose items were unroutable that someone else's
-# artifact was valid, and it never saw a reason at all.
-glob_item_ok="$worktree/tmp/review-reviewer-item-20260810-000000.json"
-printf '{"verdict":"pass","blockers":[],"suggestions":[{"id":1,"title":"t","location":"l","description":"d","recommendation":"r","priority":3,"estimate":2,"category":"issue","impact":"nightly importers hit it on every run"}],"qa_metadata":{}}' > "$glob_item_ok"
-touch -d "@$after" "$glob_item_ok"
-touch -d "@$later" "$glob_item_bad"
-set +e
-out="$("$CHECK" "$worktree" reviewer-item "$delegated_at")"
-rc=$?
-set -e
-assert_eq "$rc" "1" "glob malformed-item is terminal, not rescued by an older sibling"
-assert_eq "$(jq -r '.reason' <<<"$out")" "incomplete" "glob terminal malformed-item keeps reason=incomplete"
-assert_eq "$(jq -r '.path' <<<"$out")" "$glob_item_bad" "glob terminal malformed-item points at the rejected artifact"
-
-# MUST-FAIL CONTROL: with the malformed artifact STALE, the fresh well-formed
-# one is the answer — terminal refuses THIS run, not the agent forever.
-touch -d "@$before" "$glob_item_bad"
-expect_glob_valid "$worktree" reviewer-item "$delegated_at" "$glob_item_ok" "a STALE malformed-item artifact does not block a fresh well-formed one"
-touch -d "@$later" "$glob_item_bad"
-
-# THE OTHER SIDE OF THE RULE now has exactly one member — a gate that could not
-# run — and it is pinned in review_artifact_check_measurement.sh, where the
-# selective jq shim lives.
-
-# --- usage errors ---
-set +e
-"$CHECK" "$worktree" reviewer-quality >/dev/null 2>&1
-assert_eq "$?" "2" "missing arguments exit 2"
-"$CHECK" "$worktree" reviewer-quality not-a-number >/dev/null 2>&1
-assert_eq "$?" "2" "non-numeric delegated_at exits 2"
-"$CHECK" "$TMP_ROOT/does-not-exist" reviewer-quality "$delegated_at" >/dev/null 2>&1
-assert_eq "$?" "2" "nonexistent worktree exits 2"
-"$CHECK" --file >/dev/null 2>&1
-assert_eq "$?" "2" "--file with no path exits 2"
-"$CHECK" --file "$ext_valid" not-a-number >/dev/null 2>&1
-assert_eq "$?" "2" "--file non-numeric boundary exits 2"
-"$CHECK" --file "$ext_valid" "$delegated_at" extra-arg >/dev/null 2>&1
-assert_eq "$?" "2" "--file with too many args exits 2"
-set -e
-
-echo "=== --wait blocking mode (glob) ==="
-
-# A reviewer artifact landing mid-wait ends the wait immediately with its
-# verdict — valid here; a rejected artifact would return equally fast.
-wwt="$TMP_ROOT/waitwt"
-mkdir -p "$wwt/tmp"
+echo "=== --wait blocks until an artifact lands or the deadline ==="
+# A valid artifact landing after about two seconds ends a 20-second wait with
+# its verdict; nothing landed at the deadline is missing, exit 1; a STALE
+# prior-round artifact keeps the wait polling for the fresh one rather than
+# ending it instantly.
+stage ""
 start_epoch="$(date +%s)"
-( sleep 2; printf '{"agent":"waitrev","verdict":"pass","summary":"s","blockers":[],"suggestions":[],"questions":[]}' \
-    > "$wwt/tmp/review-waitrev-20260101-000001.json" ) &
+( sleep 2; body qa_ok > "$WT/tmp/review-waitrev-20260101-000001.json" ) &
 writer_pid=$!
-rc=0
-wait_out="$("$CHECK" "$wwt" waitrev 0 --wait 20 --interval 1 2>/dev/null)" || rc=$?
+run_check %W waitrev 0 --wait 20 --interval 1
 wait "$writer_pid" 2>/dev/null || true
 elapsed=$(( $(date +%s) - start_epoch ))
-assert_eq "$(jq -r '.ok' <<<"$wait_out")" "true" "--wait returns the landed artifact as ok"
-assert_eq "$rc" "0" "--wait exit 0 on a valid landing"
-if (( elapsed < 15 )); then
-  PASS=$((PASS + 1)); printf '  ok    %s\n' "--wait returned on the landing, not the deadline (${elapsed}s)"
-else
-  FAIL=$((FAIL + 1)); printf '  FAIL  %s\n' "--wait burned toward its deadline (${elapsed}s)"
-fi
-
-# Deadline with nothing landed: reason missing, exit 1.
-rc=0
-wait_out="$("$CHECK" "$wwt" ghostrev 0 --wait 2 --interval 1 2>/dev/null)" || rc=$?
-assert_eq "$(jq -r '.reason' <<<"$wait_out")" "missing" "--wait deadline reports missing"
-assert_eq "$rc" "1" "--wait deadline exits 1"
-
-# The production shape from cycle 2 onward: a STALE prior-round artifact on
-# disk must keep the wait polling for the fresh one, not end it instantly.
-swt="$TMP_ROOT/stalewt"
-mkdir -p "$swt/tmp"
-printf '{"agent":"cyc","verdict":"pass","summary":"old","blockers":[],"suggestions":[],"questions":[]}' \
-  > "$swt/tmp/review-cyc-20200101-000000.json"
-touch -t 202001010000 "$swt/tmp/review-cyc-20200101-000000.json"
+assert_eq "$(observe "rc=0 ok=true") early=$([[ "$elapsed" -lt 15 ]] && echo true || echo false)" "rc=0 ok=true early=true" "--wait returns the landed artifact before the deadline (${elapsed}s)" "$ERR"
+stage ""
+run_check %W ghostrev 0 --wait 2 --interval 1
+assert_eq "$(observe "rc=1 reason=missing")" "rc=1 reason=missing" "--wait at the deadline with nothing landed is missing" "$ERR"
+stage "review-cyc-20200101-000000@before=qa_ok"
 now_epoch="$(date +%s)"
-start_epoch="$now_epoch"
-( sleep 2; printf '{"agent":"cyc","verdict":"pass","summary":"fresh","blockers":[],"suggestions":[],"questions":[]}' \
-    > "$swt/tmp/review-cyc-20990101-000000.json" ) &
+( sleep 2; body qa_ok > "$WT/tmp/review-cyc-20990101-000000.json" ) &
 writer_pid=$!
-rc=0
-wait_out="$("$CHECK" "$swt" cyc "$now_epoch" --wait 20 --interval 1 2>/dev/null)" || rc=$?
+run_check %W cyc "$now_epoch" --wait 20 --interval 1
 wait "$writer_pid" 2>/dev/null || true
-elapsed=$(( $(date +%s) - start_epoch ))
-assert_eq "$(jq -r '.ok' <<<"$wait_out")" "true" "--wait polls past a stale prior-round artifact to the fresh one"
-if (( elapsed >= 1 && elapsed < 15 )); then
-  PASS=$((PASS + 1)); printf '  ok    %s\n' "--wait neither returned instantly on stale nor burned the deadline (${elapsed}s)"
-else
-  FAIL=$((FAIL + 1)); printf '  FAIL  %s\n' "--wait stale handling wrong (${elapsed}s: 0s = instant-stale regression, >=15s = deadline burn)"
-fi
+elapsed=$(( $(date +%s) - now_epoch ))
+assert_eq "$(observe "ok=true") polled=$([[ "$elapsed" -ge 1 && "$elapsed" -lt 15 ]] && echo true || echo false)" "ok=true polled=true" "--wait polls past a stale prior-round artifact to the fresh one, neither instantly nor to the deadline (${elapsed}s)" "$ERR"
 
-# Flag validation is a usage error; the frozen 3-positional call is untouched.
-rc=0; "$CHECK" "$wwt" waitrev 0 --wait nope >/dev/null 2>&1 || rc=$?
-assert_eq "$rc" "2" "a non-integer --wait is a usage error"
-rc=0; "$CHECK" "$wwt" waitrev 0 >/dev/null 2>&1 || rc=$?
-assert_eq "$rc" "0" "the bare three-positional contract still validates"
+echo "=== -h and --help answer before any temp-file initialization ==="
+# The heredoc is the contract's sole home; the dispatch runs before the gates
+# lib is sourced, so --help prints under an unusable TMPDIR too.
+stage ""
+run_check --help
+assert_eq "$(observe "rc=0 stderr=empty stdout~Usage:=true stdout~zero_sample=true stdout~measurement_failed=true")" "rc=0 stderr=empty stdout~Usage:=true stdout~zero_sample=true stdout~measurement_failed=true" "--help exits 0 on stdout alone with the reason vocabulary and the declaration contract"
+run_check -h
+assert_eq "$(observe "rc=0 stdout~Usage:=true")" "rc=0 stdout~Usage:=true" "-h prints usage"
+TMPDIR="$TMP_ROOT/does-not-exist/nope" run_check --help
+assert_eq "$(observe "rc=0 stdout~Usage:=true")" "rc=0 stdout~Usage:=true" "--help still prints the contract under an unusable TMPDIR"
 
-echo "=== -h/--help answers before any temp-file initialization (KEN-556) ==="
-
-# Token pins per: the heredoc is the contract's sole home.
-set +e
-help_out="$("$CHECK" --help 2>"$TMP_ROOT/help.err")"
-rc=$?
-set -e
-assert_eq "$rc" "0" "--help exits 0"
-assert_substr "$help_out" "Usage:" "--help prints usage on stdout"
-assert_eq "$(cat "$TMP_ROOT/help.err")" "" "--help writes nothing to stderr"
-assert_substr "$help_out" "zero_sample" "--help carries the reason vocabulary"
-assert_substr "$help_out" "measurement_failed" "--help carries the declaration contract"
-
-set +e
-help_out="$("$CHECK" -h 2>/dev/null)"
-rc=$?
-set -e
-assert_eq "$rc" "0" "-h exits 0"
-assert_substr "$help_out" "Usage:" "-h prints usage"
-
-# The dispatch runs BEFORE the gates lib is sourced: its source-time mktemp
-# fails under an unusable TMPDIR, and --help must still print the contract.
-set +e
-help_out="$(TMPDIR="$TMP_ROOT/does-not-exist/nope" "$CHECK" --help 2>"$TMP_ROOT/help2.err")"
-rc=$?
-set -e
-assert_eq "$rc" "0" "--help exits 0 with an unusable TMPDIR"
-assert_substr "$help_out" "Usage:" "--help still prints the contract under it"
-
+echo
 printf 'pass: %d   fail: %d\n' "$PASS" "$FAIL"
 [[ "$FAIL" -eq 0 ]]

--- a/skills/orch/tests/review_artifact_check.sh
+++ b/skills/orch/tests/review_artifact_check.sh
@@ -113,13 +113,15 @@ run_check() {
   set -e
 }
 
-json() { jq -r "$1" <<<"$OUT" 2>/dev/null || echo UNPARSEABLE; }
+json() { jq -r "$@" <<<"$OUT" 2>/dev/null || echo UNPARSEABLE; }
 
 # observe EXPECT — prints the run's value of every `name=` field EXPECT names,
 # in EXPECT's order. Plain names are JSON result fields, a key the result does
 # not carry reads ABSENT;
 #   rc              exit status
-#   path            the basename of the reported path, or null
+#   path            the reported path with the staged worktree's tmp/ prefix
+#                   removed, or null; a path anywhere else prints whole and
+#                   fails the row
 #   detail~<text>   whether the detail names <text> (`+` reads as a space):
 #                   the detail is what the rejected reviewer acts on, and
 #                   which shape it saw lives nowhere else
@@ -132,7 +134,7 @@ observe() {
     name="${token%%=*}"
     case "$name" in
       rc) value="$RC" ;;
-      path) value="$(json '.path | if . == null then "null" else sub(".*/"; "") end')" ;;
+      path) value="$(json --arg tmp "$WT/tmp/" '.path | if . == null then "null" else ltrimstr($tmp) end')" ;;
       detail~*) needle="${name#detail~}"; value="$(json '.detail // ""' | grep -qF -- "${needle//+/ }" && echo true || echo false)" ;;
       detail_present) value="$(json '(.detail | type) == "string" and .detail != ""')" ;;
       stdout~*) needle="${name#stdout~}"; value="$(grep -qF -- "${needle//+/ }" <<<"$OUT" && echo true || echo false)" ;;


### PR DESCRIPTION
Tests audit, eighth file (wave 2, `BRIEF-TESTS-AUDIT.md`): `skills/orch/tests/review_artifact_check.sh`, 777 lines and 168 assertions at run time, judged against code-quality § Tests. Held for the overseer.

## What changed

- **One table per gate, one asserted row per shape.** Every case that ran the check against a staged worktree is a row of `label|stage|args|expect`: `stage` lists the artifacts as `file@when=body` (`when` is `before`, `at`, `after` or `none` against the boundary; `body` names one of the bodies at the top of the file), `args` carries `%W`, `%F` and `%D` for the worktree, the file and the boundary, and `observe` reads exactly the fields the `expect` names (`rc`, `ok`, `path`, `reason`, `detail_present`, `detail~text`, `stdout~text`, `stderr=empty`). A row with an empty expect aborts the suite.
- **Fixtures plant one defect.** The string-estimate artifact also lacked `impact`, so it was refused whatever the estimate check did, and its `detail~estimate` pin matched the required-field sentence every item rejection appends. The fixture carries the estimate defect alone and the row pins `missing/invalid estimate (not 1..5)`; the category, priority, description and issue-shape rows pin their own `missing/invalid <field>` clause the same way.
- **Glob mode gets its boundary row.** `mtime == boundary` was pinned in file mode only, so `<` against `<=` in the glob scan was unproven; one row.
- **Folded on identical input**: `no qa_metadata at all still validates` (the file-mode `a valid file` row runs that body and pins `reason=valid`); `empty arrays carry no items and stay valid` (the complete-items row); `chain: a qa-shape loss names its cause` (the arrays-lost row now pins `ok=false` beside its three detail clauses). Every other former assertion is a field of a surviving row.
- **The stale `--wait` case measures the check**, taking `elapsed` before waiting on the background writer rather than after its sleep.
- **Dev-artifact-check hint control** (tracked from #2205): the count-vs-set hint row in `skills/orch/tests/dev_artifact_check.sh` read `hint != null` as fired, which UNPARSEABLE also satisfies; it now pins `hint_present=true`, an observer true only for a non-empty string `hint`.

## Folded cases and the row that fails when the behaviour breaks

| Former case | Surviving row |
|---|---|
| missing (4 assertions), other agent's (2), stale (4), invalid (3), valid (3), fallback (2) | glob table, one row each, `rc ok path reason` in one comparison |
| `--file` valid (4), no boundary, older (4), newer (3), equal, fresh-no-verdict (2), missing with boundary (2), missing (4), no verdict (3) | file-mode table, one row each |
| review_performed=false (4), no-scope reason alone (2), no qa_metadata (2), empty qa_metadata (1), review_performed=true (1), glob no-review (3), glob terminal (2) | no-review table; `no qa_metadata` is the file-mode valid row |
| qa-shaped without arrays (4), non-array blockers (2), missing suggestions (2), no questions (1), glob incomplete (3), glob terminal (2) | qa-shape table |
| every prefix truncation | one direct assertion over the truncation loop, unchanged |
| issue malformed (6), compliant (3), empty arrays (1), missing category (3), bad category (2), blocker base field (4), blocker no category (1), priority (3), estimate (2), blocker priority (2), boundary values (1), tolerant (1), arrays-lost (4), null vs absent (2), blockers by type (4×4), suggestions null / wrong type (2), every rejection names its cause (1 loop), naming rows (4), glob malformed (7) | items table, one row each; the blockers-by-type loop is four rows; the cause loop is the five `chain:` rows |
| usage errors (6), bare three-positional | usage table |
| `--wait` (5), `--help` (10) | two timing cases and one polling case, one assertion each; three `--help` assertions, the first pinning stdout, empty stderr and the two reason tokens the workflow quotes |

## Mutations against `review-artifact-check` and `lib/review-artifact-gates.sh`, one per table

Glob stale bound dropped (3 rows red); file stale bound dropped (2); `review_performed == false` unmatched (1, after the review round; the first pin was satisfied by the reason-only arm); the absent-array wording changed (2); the suggestions-only category requirement dropped (1); the argument-count gate widened (1); the `--wait` integer regex loosened (1); a `--help` reason token misspelt (1).

## Checks

`review_artifact_check.sh` 77 pass / 0 fail (baseline 168 / 0); `dev_artifact_check.sh` 91 / 0 with the hint observer; `tools/bash32-lint` clean; pre-commit chain on each commit. One reviewer-test round (one blocker, the estimate fixture; suggestions applied: glob boundary row, elapsed measurement, `ok=false` on the arrays-lost row, three folds).

Tracking: KEN-1241.

https://claude.ai/code/session_01PSdX2AT5yWYYBbBBjbAUnP
