### PR TITLE
test(KEN-1241): oversee_watch_triage.sh reads each run once

### DIFF
--- a/.agents/skills/orch/tests/oversee_watch_triage.sh
+++ b/.agents/skills/orch/tests/oversee_watch_triage.sh
@@ -1,297 +1,203 @@
 #!/usr/bin/env bash
-# Tracker-side controls for oversee-watch triage events.
+# Tracker-side controls for oversee-watch triage events: what an unseen team
+# item emits, what acknowledges it, what the check refuses to run on, and the
+# `--since` form it accepts. One run, one comparison: `watch EXPECT` reads
+# exactly the facts EXPECT names, so a case fails on the fact it names.
 set -euo pipefail
 source "$(dirname "${BASH_SOURCE[0]}")/lib/git-env.sh"
-
 # shellcheck source=lib/oversee-watch-harness.sh
 source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/lib/oversee-watch-harness.sh"
 
+SINCE=2026-08-15T09:00:00Z
+HEARTBEAT1="EVENT+heartbeat+loops=1+interval=0s+since=$SINCE"
+STATE_FILE_NAME="owner_repo__2026-08-15T09_00_00Z"
+
+# run [ENV=VAL ...] -- ARGS... — one watch run; OUT, RC and ERR (a file) are
+# what `watch` reads. `--since` is supplied unless ARGS carry their own.
+RUN_SEQ=0
+run() {
+  local args=("$@") a since=yes
+  for a in "$@"; do [[ "$a" == --since* ]] && since=no; done
+  [[ "$since" == no ]] || args+=(--since "$SINCE")
+  ERR="$TMP_ROOT/run-$((++RUN_SEQ)).err"
+  OUT="$(run_watch "${args[@]}" 2>"$ERR")" && RC=0 || RC=$?
+}
+
+# watch EXPECT — prints the run's value of every `name=` field EXPECT names,
+# in EXPECT's order (in a needle `+` reads as a space and %e as `=`; %B is the
+# stub bin directory, %R the case's repository root, %S the stub directory):
+#   rc               exit status
+#   first            the first stdout line, or `none`
+#   events           how many `EVENT triage` lines stdout carries
+#   out~<text>       whether stdout carries <text>
+#   stdout           `empty` or `lines`
+#   stderr~<text>    whether stderr carries <text>
+#   notes~<text>     how many stderr lines carry <text>
+#   tracker~<text>   whether the tracker stub was called with <text>
+#   tracker          `read` or `unread`
+#   wsargs~<text>    whether the workflow-state stub was called with <text>
+#   state~<text>     whether the per-repo baseline file carries <text> (`%t`
+#                    reads as a tab)
+#   state_files      how many files the state directory holds
+watch() {
+  local got="" token name value needle state_file="$STATE_DIR/$STATE_FILE_NAME"
+  for token in $1; do
+    name="${token%%=*}"
+    needle="${name#*~}"; needle="${needle//+/ }"; needle="${needle//%e/=}"; needle="${needle//%B/$TMP_ROOT/bin}"
+    needle="${needle//%R/$CASE_REPO_ROOT}"; needle="${needle//%S/$STUB_DIR}"; needle="${needle//%t/$'\t'}"
+    case "$name" in
+      rc) value="$RC" ;;
+      first) value="$(head -n 1 <<<"$OUT")"; value="${value:-none}"; value="${value// /+}" ;;
+      events) value="$(grep -c '^EVENT triage ' <<<"$OUT" || true)" ;;
+      out~*) value="$(grep -qF -- "$needle" <<<"$OUT" && echo true || echo false)" ;;
+      stdout) value="$([[ -n "$OUT" ]] && echo lines || echo empty)" ;;
+      stderr~*) value="$(grep -qF -- "$needle" "$ERR" && echo true || echo false)" ;;
+      notes~*) value="$(grep -cF -- "$needle" "$ERR" || true)" ;;
+      tracker~*) value="$([[ -e "$STUB_DIR/tracker.args" ]] && grep -qF -- "$needle" "$STUB_DIR/tracker.args" && echo true || echo false)" ;;
+      tracker) value="$([[ -e "$STUB_DIR/tracker.args" ]] && echo read || echo unread)" ;;
+      wsargs~*) value="$([[ -e "$STUB_DIR/workflow-state.args" ]] && grep -qF -- "$needle" "$STUB_DIR/workflow-state.args" && echo true || echo false)" ;;
+      state~*) value="$([[ -e "$state_file" ]] && grep -qF -- "$needle" "$state_file" && echo true || echo false)" ;;
+      state_files) value="$(find "$STATE_DIR" -maxdepth 1 -type f 2>/dev/null | wc -l | tr -d '[:space:]')" ;;
+      *) echo "watch: unknown field $name" >&2; exit 1 ;;
+    esac
+    got="$got $name=$value"
+  done
+  printf '%s' "${got# }"
+}
+
+check() { assert_eq "$(watch "$2")" "$2" "$1" "$ERR"; }
+
+tracker_items() { printf '%s\n' "$1" > "$STUB_DIR/tracker.out"; }
+verdicts() { printf '{"triaged":%s}\n' "$1" > "$STUB_DIR/oversee-state.json"; }
+
 echo "=== oversee-watch triage ==="
 
+# A standing lane prompt first, so the state-file count below is taken on a
+# run that has a lane fingerprint persisted already; a second file class would
+# exist by then if lane-asking kept its own.
 new_case triage_new
 printf '1786957201\n' > "$STUB_DIR/now.epoch"
 printf '3\n' > "$STUB_DIR/tracker.want-created-since"
-# A standing lane prompt first, so the file count below is taken on a run that
-# has lanes with a fingerprint already persisted — the state class this suite
-# claims does not exist would exist by then if lane-asking kept its own file.
 printf 'Do you want to proceed?\n   ❯ 1. Yes\n     2. No\n' > "$STUB_DIR/pane-gh-2.txt"
-printf '[]\n' > "$STUB_DIR/tracker.out"
-err="$TMP_ROOT/triage-lane"
-out="$(run_watch -- --max-loops 1 --since 2026-08-15T09:00:00Z gh-1 gh-2 2>"$err")" && rc=0 || rc=$?
-assert_eq "$(head -1 <<<"$out")" "EVENT lane-asking gh-2" \
-  "a standing lane prompt wakes the watch before any tracker item" "$err"
-cat > "$STUB_DIR/tracker.out" <<'EOF'
-[
-  {"id":"KEN-1200","created_at":"2026-08-15T10:00:00.000Z"},
-  {"id":"KEN-1202","created_at":"2026-08-15T10:30:00.000Z"},
-  {"id":"KEN-1204","created_at":"2026-08-15T11:30:00.000Z"},
-  {"id":"KEN-1199","created_at":"2026-08-15T08:59:59.000Z"}
-]
-EOF
-err="$TMP_ROOT/triage-a"
-out="$(run_watch -- --since 2026-08-15T09:00:00Z gh-1 gh-2 2>"$err")" && rc=0 || rc=$?
-assert_eq "$rc" "0" "new triage item exits 0" "$err"
-assert_eq "$(head -1 <<<"$out")" "EVENT triage KEN-1200" \
-  "an item created after --since is a triage event" "$err"
-assert_contains "$out" "EVENT triage KEN-1202" \
-  "each new item gets its own triage event line" "$err"
-assert_contains "$out" "EVENT triage KEN-1204" \
-  "a team item with no lane authorship is still emitted" "$err"
-assert_eq "$(grep -c '^EVENT triage ' <<<"$out")" "3" \
-  "one wake emits one line per new tracker item" "$err"
-assert_not_contains "$out" "KEN-1199" "an item before --since is not emitted" "$err"
-tracker_args="$(cat "$STUB_DIR/tracker.args")"
-assert_contains "$tracker_args" "issues list --team kendex --created-since " \
-  "triage reads the live tracker list for the fleet's team" "$err"
-assert_contains "$tracker_args" "d --max --format=safe" \
-  "triage uses a created-since day window and fetches every result" "$err"
-state_file="$STATE_DIR/owner_repo__2026-08-15T09_00_00Z"
-assert_not_contains "$(cat "$state_file")" "$(printf 'triage\tKEN-1200')" \
-  "printing an event does not acknowledge the item" "$err"
-assert_contains "$(cat "$state_file")" "$(printf 'lane-asking\tgh-2\t')" \
-  "the standing lane fingerprint shares the one per-repo baseline" "$err"
-assert_eq "$(find "$STATE_DIR" -maxdepth 1 -type f | wc -l | tr -d '[:space:]')" "1" \
-  "triage creates no second state-file class" "$err"
-err="$TMP_ROOT/triage-b"
-out="$(run_watch -- --max-loops 1 --since 2026-08-15T09:00:00Z 2>"$err")" && rc=0 || rc=$?
-assert_eq "$(head -1 <<<"$out")" "EVENT triage KEN-1200" \
-  "an unacknowledged item repeats on the next run" "$err"
+tracker_items '[]'
+run -- --max-loops 1 gh-1 gh-2
+check "a standing lane prompt wakes the watch before any tracker item" "first=EVENT+lane-asking+gh-2"
 
-cat > "$STUB_DIR/oversee-state.json" <<'EOF'
-{"triaged":[
-  {"issue":"KEN-1200","verdict":"kept"},
-  {"issue":"KEN-1202","verdict":"canceled"},
-  {"issue":"KEN-1204","verdict":"pending"}
-]}
-EOF
-err="$TMP_ROOT/triage-b2"
-out="$(run_watch -- --max-loops 1 --since 2026-08-15T09:00:00Z 2>"$err")" && rc=0 || rc=$?
-assert_eq "$(head -1 <<<"$out")" "EVENT triage KEN-1204" \
-  "a pending verdict does not acknowledge the item" "$err"
-assert_contains "$(cat "$state_file")" "$(printf 'triage\tKEN-1200')" \
-  "a kept verdict rebuilds the watcher baseline" "$err"
-assert_contains "$(cat "$state_file")" "$(printf 'triage\tKEN-1202')" \
-  "a canceled verdict rebuilds the watcher baseline" "$err"
-assert_not_contains "$(cat "$state_file")" "$(printf 'triage\tKEN-1204')" \
-  "a pending verdict stays out of watcher dedup" "$err"
-assert_contains "$(cat "$STUB_DIR/workflow-state.args")" "kept" \
-  "the verdict read accepts kept outcomes" "$err"
-assert_contains "$(cat "$STUB_DIR/workflow-state.args")" "canceled" \
-  "the verdict read accepts canceled outcomes" "$err"
-assert_contains "$(cat "$STUB_DIR/workflow-state.args")" "--state-dir $CASE_REPO_ROOT/tmp get oversee" \
-  "the verdict read anchors default state to the project tmp directory" "$err"
+# Items created after --since are one event each, in one wake, read from the
+# live list for the fleet's team over a created-since day window; printing an
+# event does not acknowledge it, and the fingerprints share the one per-repo
+# baseline.
+tracker_items '[{"id":"KEN-1200","created_at":"2026-08-15T10:00:00.000Z"},{"id":"KEN-1202","created_at":"2026-08-15T10:30:00.000Z"},{"id":"KEN-1204","created_at":"2026-08-15T11:30:00.000Z"},{"id":"KEN-1199","created_at":"2026-08-15T08:59:59.000Z"}]'
+run -- gh-1 gh-2
+check "three items after --since are three triage events in one wake, the earlier item not among them, read from the team's created-since list, none acknowledged by printing" \
+  "rc=0 first=EVENT+triage+KEN-1200 events=3 out~EVENT+triage+KEN-1202=true out~EVENT+triage+KEN-1204=true out~KEN-1199=false tracker~issues+list+--team+kendex+--created-since+=true tracker~d+--max+--format%esafe=true state~triage%tKEN-1200=false state~lane-asking%tgh-2%t=true state_files=1"
+run -- --max-loops 1
+check "an unacknowledged item repeats on the next run" "first=EVENT+triage+KEN-1200"
 
-cat > "$STUB_DIR/oversee-state.json" <<'EOF'
-{"triaged":[
-  {"issue":"KEN-1200","verdict":"kept"},
-  {"issue":"KEN-1202","verdict":"canceled"},
-  {"issue":"KEN-1204","verdict":"kept"}
-]}
-EOF
-err="$TMP_ROOT/triage-b3"
-out="$(run_watch -- --max-loops 1 --since 2026-08-15T09:00:00Z 2>"$err")" && rc=0 || rc=$?
-assert_eq "$(head -1 <<<"$out")" "EVENT heartbeat loops=1 interval=0s since=2026-08-15T09:00:00Z" \
-  "terminal verdicts close every repeated event" "$err"
+# A kept or canceled verdict acknowledges the item into the watcher baseline,
+# read from the oversee state under the project tmp directory; a pending
+# verdict does neither.
+verdicts '[{"issue":"KEN-1200","verdict":"kept"},{"issue":"KEN-1202","verdict":"canceled"},{"issue":"KEN-1204","verdict":"pending"}]'
+run -- --max-loops 1
+check "kept and canceled verdicts rebuild the baseline, pending stays out and repeats, the read anchored to the project tmp directory" \
+  "first=EVENT+triage+KEN-1204 state~triage%tKEN-1200=true state~triage%tKEN-1202=true state~triage%tKEN-1204=false wsargs~kept=true wsargs~canceled=true wsargs~--state-dir+%R/tmp+get+oversee=true"
+verdicts '[{"issue":"KEN-1200","verdict":"kept"},{"issue":"KEN-1202","verdict":"canceled"},{"issue":"KEN-1204","verdict":"kept"}]'
+run -- --max-loops 1
+check "terminal verdicts close every repeated event" "first=$HEARTBEAT1"
+tracker_items '[{"id":"KEN-1201","created_at":"2026-08-15T11:00:00.000Z"},{"id":"KEN-1200","created_at":"2026-08-15T10:00:00.000Z"}]'
+run --
+check "a later item fires on the next run and the acknowledged one stays deduplicated" "first=EVENT+triage+KEN-1201 out~EVENT+triage+KEN-1200=false"
 
-cat > "$STUB_DIR/tracker.out" <<'EOF'
-[
-  {"id":"KEN-1201","created_at":"2026-08-15T11:00:00.000Z"},
-  {"id":"KEN-1200","created_at":"2026-08-15T10:00:00.000Z"}
-]
-EOF
-err="$TMP_ROOT/triage-c"
-out="$(run_watch -- --since 2026-08-15T09:00:00Z 2>"$err")" && rc=0 || rc=$?
-assert_eq "$(head -1 <<<"$out")" "EVENT triage KEN-1201" \
-  "a later tracker item fires on the next run" "$err"
-assert_not_contains "$out" "EVENT triage KEN-1200" "the prior item stays deduplicated" "$err"
-
-# Control: no unseen item emits no triage event.
 new_case triage_empty
-printf '[]\n' > "$STUB_DIR/tracker.out"
-err="$TMP_ROOT/triage-d"
-out="$(run_watch -- --max-loops 1 --since 2026-08-15T09:00:00Z 2>"$err")" && rc=0 || rc=$?
-assert_eq "$(head -1 <<<"$out")" "EVENT heartbeat loops=1 interval=0s since=2026-08-15T09:00:00Z" \
-  "an empty tracker list reaches the heartbeat" "$err"
-assert_not_contains "$out" "EVENT triage" "no new item emits no triage event" "$err"
-
-# A missing CLI is a broken install: triage fails closed rather than dropping
-# every unseen team item on a stderr note.
-new_case triage_requires_tracker
-printf '[{"id":"KEN-1200","created_at":"2026-08-15T10:00:00.000Z"}]\n' > "$STUB_DIR/tracker.out"
-err="$TMP_ROOT/triage-needs-tracker"
-out="$(run_watch OVERSEE_WATCH_TRACKER="$TMP_ROOT/bin/absent-tracker" -- --since 2026-08-15T09:00:00Z 2>"$err")" && rc=0 || rc=$?
-assert_eq "$rc" "2" "a missing tracker CLI exits 2 under --since" "$err"
-assert_eq "$out" "" "a missing tracker CLI emits no event" "$err"
-assert_contains "$(cat "$err")" "tracker CLI not found at $TMP_ROOT/bin/absent-tracker" \
-  "the missing tracker CLI is named" "$err"
-assert_contains "$(cat "$err")" "OVERSEE_WATCH_TRACKER" \
-  "the tracker refusal names its remedy" "$err"
-
-new_case triage_requires_workflow_state
-printf '[{"id":"KEN-1200","created_at":"2026-08-15T10:00:00.000Z"}]\n' > "$STUB_DIR/tracker.out"
-err="$TMP_ROOT/triage-needs-workflow-state"
-out="$(run_watch OVERSEE_WATCH_WORKFLOW_STATE="$TMP_ROOT/bin/absent-workflow-state" -- --since 2026-08-15T09:00:00Z 2>"$err")" && rc=0 || rc=$?
-assert_eq "$rc" "2" "a missing workflow-state CLI exits 2 under --since" "$err"
-assert_eq "$out" "" "a missing workflow-state CLI emits no event" "$err"
-assert_contains "$(cat "$err")" "workflow-state CLI not found at $TMP_ROOT/bin/absent-workflow-state" \
-  "the missing workflow-state CLI is named" "$err"
-assert_contains "$(cat "$err")" "OVERSEE_WATCH_WORKFLOW_STATE" \
-  "the workflow-state refusal names its remedy" "$err"
+tracker_items '[]'
+run -- --max-loops 1
+check "control: an empty tracker list reaches the heartbeat with no triage event" "first=$HEARTBEAT1 events=0"
 
 # A fleet with no tracker team is not a broken install: triage is skipped and
-# named once, and every other check — merged included, which --since also
-# serves — keeps running. This is the documented invocation on a repo that
-# tracks its work in GitHub.
+# named once, whether the name is absent or exported empty, and every other
+# check --since serves keeps running, merged included. The first case exits on
+# the merged event before the triage check; the second reaches it with a live
+# tracker and an unseen item, and the tracker goes unread.
 new_case triage_skipped_without_team
-printf '[{"id":"KEN-1200","created_at":"2026-08-15T10:00:00.000Z"}]\n' > "$STUB_DIR/tracker.out"
+tracker_items '[{"id":"KEN-1200","created_at":"2026-08-15T10:00:00.000Z"}]'
 printf '[{"number":5,"headRefName":"issue-5","mergedAt":"2026-08-15T10:00:00Z"}]\n' > "$STUB_DIR/merged.json"
-err="$TMP_ROOT/triage-no-team"
-out="$(run_watch LINEAR_TEAM -- --max-loops 1 --item issue-5 --since 2026-08-15T09:00:00Z 2>"$err")" && rc=0 || rc=$?
-assert_eq "$rc" "0" "an unset LINEAR_TEAM keeps the watch running" "$err"
-assert_eq "$(head -1 <<<"$out")" "EVENT merged 5 issue-5" \
-  "--since still serves the merged check with no team" "$err"
-assert_contains "$(cat "$err")" "LINEAR_TEAM is unset or empty" \
-  "the note names an empty team as well as an absent one" "$err"
-
-# The case above exits on the merged event before check_triage runs, so triage
-# being off is proved here instead: a live tracker stub with an unseen item, and
-# nothing to wake the watch before the triage check.
+run LINEAR_TEAM -- --max-loops 1 --item issue-5
+check "an unset LINEAR_TEAM keeps the watch running and --since still serves the merged check" \
+  "rc=0 first=EVENT+merged+5+issue-5 stderr~LINEAR_TEAM+is+unset+or+empty=true"
 new_case triage_no_team_reaches_the_triage_check
-printf '[{"id":"KEN-1200","created_at":"2026-08-15T10:00:00.000Z"}]\n' > "$STUB_DIR/tracker.out"
-err="$TMP_ROOT/triage-no-team-reached"
-out="$(run_watch LINEAR_TEAM -- --max-loops 1 --since 2026-08-15T09:00:00Z 2>"$err")" && rc=0 || rc=$?
-assert_eq "$(head -1 <<<"$out")" "EVENT heartbeat loops=1 interval=0s since=2026-08-15T09:00:00Z" \
-  "the run reaches the triage check and falls through to the heartbeat" "$err"
-assert_not_contains "$out" "EVENT triage" \
-  "a new tracker item emits no triage event with no team" "$err"
-tracker_called=no
-if [[ -e "$STUB_DIR/tracker.args" ]]; then tracker_called=yes; fi
-assert_eq "$tracker_called" "no" "a working tracker goes unread with no team" "$err"
-
-# The bare sentinel above drops the name entirely. An exported empty value is
-# the other spelling of no team, and the one this change moved: it would die
-# on the removed check. It takes the same skip path.
+tracker_items '[{"id":"KEN-1200","created_at":"2026-08-15T10:00:00.000Z"}]'
+run LINEAR_TEAM -- --max-loops 1
+check "with no team the run reaches the triage check, emits nothing for the unseen item and leaves the tracker unread" \
+  "first=$HEARTBEAT1 events=0 tracker=unread"
 new_case triage_skipped_by_an_empty_export
-printf '[{"id":"KEN-1200","created_at":"2026-08-15T10:00:00.000Z"}]\n' > "$STUB_DIR/tracker.out"
-err="$TMP_ROOT/triage-empty-export"
-out="$(run_watch LINEAR_TEAM= -- --max-loops 1 --since 2026-08-15T09:00:00Z 2>"$err")" && rc=0 || rc=$?
-assert_eq "$rc" "0" "an exported-empty LINEAR_TEAM keeps the watch running" "$err"
-assert_eq "$(grep -c 'skipping the team triage check' "$err")" "1" \
-  "the empty export takes the skip path the absent name takes" "$err"
-
+tracker_items '[{"id":"KEN-1200","created_at":"2026-08-15T10:00:00.000Z"}]'
+run LINEAR_TEAM= -- --max-loops 1
+check "an exported-empty LINEAR_TEAM takes the skip path the absent name takes" "rc=0 notes~skipping+the+team+triage+check=1"
 new_case triage_skipped_without_team_or_tracker
-err="$TMP_ROOT/triage-no-team-no-tracker"
-out="$(run_watch LINEAR_TEAM OVERSEE_WATCH_TRACKER="$TMP_ROOT/bin/absent-tracker" -- --max-loops 2 --since 2026-08-15T09:00:00Z 2>"$err")" && rc=0 || rc=$?
-assert_eq "$rc" "0" "an unset LINEAR_TEAM runs a fleet with no tracker CLI" "$err"
-assert_eq "$(head -1 <<<"$out")" "EVENT heartbeat loops=2 interval=0s since=2026-08-15T09:00:00Z" \
-  "no team disarms the gate a missing dependency would close" "$err"
-assert_eq "$(grep -c 'skipping the team triage check' "$err")" "1" \
-  "the skip note is printed once, not once per pass" "$err"
+run LINEAR_TEAM OVERSEE_WATCH_TRACKER="$TMP_ROOT/bin/absent-tracker" -- --max-loops 2
+check "no team disarms the gate a missing tracker CLI would close, and the skip note prints once over two passes" \
+  "rc=0 first=EVENT+heartbeat+loops=2+interval=0s+since=$SINCE notes~skipping+the+team+triage+check=1"
 
-new_case triage_unsets_inherited_state
-err="$TMP_ROOT/triage-state-inherited"
-out="$(ORCH_STATE_DIR=leaked run_watch -- --max-loops 1 --since 2026-08-15T09:00:00Z 2>"$err")" && rc=0 || rc=$?
-assert_contains "$(cat "$STUB_DIR/workflow-state.args")" "--state-dir $CASE_REPO_ROOT/tmp get oversee" \
-  "the common harness clears an inherited state directory" "$err"
+# The verdict read's state directory: an inherited one is cleared by the
+# harness, a relative configured one joins the project root, an absolute one
+# is kept.
+for row in \
+  "the common harness clears an inherited state directory|ORCH_STATE_DIR=leaked|wsargs~--state-dir+%R/tmp+get+oversee=true" \
+  "a relative configured state directory joins the project root|ORCH_STATE_DIR=custom/state|wsargs~--state-dir+%R/custom/state+get+oversee=true" \
+  "an absolute configured state directory is preserved|ORCH_STATE_DIR=%S/absolute-state|wsargs~--state-dir+%S/absolute-state+get+oversee=true"; do
+  IFS='|' read -r label env expect <<<"$row"
+  new_case triage_state_dir
+  env="${env//%S/$STUB_DIR}"
+  if [[ "$env" == ORCH_STATE_DIR=leaked ]]; then
+    ORCH_STATE_DIR=leaked run -- --max-loops 1
+  else
+    run "$env" -- --max-loops 1
+  fi
+  check "$label" "$expect"
+done
 
-new_case triage_relative_state
-err="$TMP_ROOT/triage-state-relative"
-out="$(run_watch ORCH_STATE_DIR=custom/state -- --max-loops 1 --since 2026-08-15T09:00:00Z 2>"$err")" && rc=0 || rc=$?
-assert_contains "$(cat "$STUB_DIR/workflow-state.args")" "--state-dir $CASE_REPO_ROOT/custom/state get oversee" \
-  "a relative configured state directory joins the project root" "$err"
+# Refusals: a missing CLI is a broken install, a read failure or malformed
+# output is unknown fleet state, an unwritable baseline cannot acknowledge, and
+# --since takes one form. Each exits 2 with no event and names its cause:
+# `label|env|stubs|args|expect`, stubs `;`-separated `file=content` under the
+# stub directory or `dir=<name>` under the state directory.
+for row in \
+  "a missing tracker CLI is named with its remedy|OVERSEE_WATCH_TRACKER=%B/absent-tracker|tracker.out=[{\"id\":\"KEN-1200\",\"created_at\":\"2026-08-15T10:00:00.000Z\"}]||rc=2 stdout=empty stderr~tracker+CLI+not+found+at+%B/absent-tracker=true stderr~OVERSEE_WATCH_TRACKER=true" \
+  "a missing workflow-state CLI is named with its remedy|OVERSEE_WATCH_WORKFLOW_STATE=%B/absent-workflow-state|tracker.out=[{\"id\":\"KEN-1200\",\"created_at\":\"2026-08-15T10:00:00.000Z\"}]||rc=2 stdout=empty stderr~workflow-state+CLI+not+found+at+%B/absent-workflow-state=true stderr~OVERSEE_WATCH_WORKFLOW_STATE=true" \
+  "a tracker list failure keeps its real cause||tracker.rc=2;tracker.err=Linear API unavailable||rc=2 stdout=empty stderr~Linear+API+unavailable=true" \
+  "malformed tracker output is named||tracker.out={}||rc=2 stdout=empty stderr~tracker+output+is+not+an+array=true" \
+  "an unwritable triage baseline names the shared state file|OVERSEE_WATCH_PR_WATCH=%B/absent-pr-watch|tracker.out=[{\"id\":\"KEN-1200\",\"created_at\":\"2026-08-15T10:00:00.000Z\"}];oversee-state.json={\"triaged\":[{\"issue\":\"KEN-1200\",\"verdict\":\"kept\"}]};dir=$STATE_FILE_NAME||rc=2 stdout=empty stderr~could+not+write+the+pr-watch+state+file=true" \
+  "an unreadable verdict log keeps its original cause||workflow-state.rc=2;workflow-state.err=oversee state unreadable||rc=2 stdout=empty stderr~oversee+state+unreadable=true" \
+  "an invalid verdict issue id is named||oversee-state.json={\"triaged\":[{\"issue\":\"bad id\",\"verdict\":\"kept\"}]}||rc=2 stdout=empty stderr~invalid+issue+id:+'bad+id'=true" \
+  "a date-only --since is refused, naming the documented form|||--since 2026-08-15|rc=2 stdout=empty stderr~UTC+timestamp+ending+in+Z=true" \
+  "an offset --since is refused, naming the documented form|||--since 2026-08-15T09:00:00+00:00|rc=2 stdout=empty stderr~UTC+timestamp+ending+in+Z=true"; do
+  IFS='|' read -r label env stubs args expect <<<"$row"
+  [[ -n "$expect" ]] || { printf 'refusals: a row with no expect asserts nothing: %s\n' "$row" >&2; exit 1; }
+  new_case triage_refusal
+  if [[ -n "$stubs" ]]; then
+    IFS=';' read -ra items <<<"$stubs"
+    for item in "${items[@]}"; do
+      if [[ "$item" == dir=* ]]; then mkdir -p "$STATE_DIR/${item#dir=}"; else printf '%s\n' "${item#*=}" > "$STUB_DIR/${item%%=*}"; fi
+    done
+  fi
+  env="${env//%B/$TMP_ROOT/bin}"
+  # shellcheck disable=SC2086
+  if [[ -n "$env" ]]; then run "$env" -- $args; else run -- $args; fi
+  check "$label" "$expect"
+done
 
-new_case triage_absolute_state
-absolute_state="$STUB_DIR/absolute-state"
-err="$TMP_ROOT/triage-state-absolute"
-out="$(run_watch ORCH_STATE_DIR="$absolute_state" -- --max-loops 1 --since 2026-08-15T09:00:00Z 2>"$err")" && rc=0 || rc=$?
-assert_contains "$(cat "$STUB_DIR/workflow-state.args")" "--state-dir $absolute_state get oversee" \
-  "an absolute configured state directory is preserved" "$err"
-
-# Read failures and malformed output are unknown fleet state, never empty.
-new_case triage_list_failure
-printf '2\n' > "$STUB_DIR/tracker.rc"
-printf 'Linear API unavailable\n' > "$STUB_DIR/tracker.err"
-err="$TMP_ROOT/triage-e"
-out="$(run_watch -- --since 2026-08-15T09:00:00Z 2>"$err")" && rc=0 || rc=$?
-assert_eq "$rc" "2" "a tracker list failure exits 2" "$err"
-assert_eq "$out" "" "a tracker list failure emits no event" "$err"
-assert_contains "$(cat "$err")" "Linear API unavailable" \
-  "the tracker failure keeps its real cause" "$err"
-
-new_case triage_malformed
-printf '{}\n' > "$STUB_DIR/tracker.out"
-err="$TMP_ROOT/triage-f"
-out="$(run_watch -- --since 2026-08-15T09:00:00Z 2>"$err")" && rc=0 || rc=$?
-assert_eq "$rc" "2" "malformed tracker output exits 2" "$err"
-assert_eq "$out" "" "malformed tracker output emits no event" "$err"
-assert_contains "$(cat "$err")" "tracker output is not an array" \
-  "the malformed shape is named" "$err"
-
-new_case triage_state_failure
-printf '[{"id":"KEN-1200","created_at":"2026-08-15T10:00:00.000Z"}]\n' > "$STUB_DIR/tracker.out"
-printf '{"triaged":[{"issue":"KEN-1200","verdict":"kept"}]}\n' > "$STUB_DIR/oversee-state.json"
-mkdir -p "$STATE_DIR/owner_repo__2026-08-15T09_00_00Z"
-err="$TMP_ROOT/triage-g"
-out="$(run_watch OVERSEE_WATCH_PR_WATCH="$TMP_ROOT/bin/absent-pr-watch" -- --since 2026-08-15T09:00:00Z 2>"$err")" && rc=0 || rc=$?
-assert_eq "$rc" "2" "an unwritable triage baseline exits 2" "$err"
-assert_eq "$out" "" "a verdict baseline write failure emits no event" "$err"
-assert_contains "$(cat "$err")" "could not write the pr-watch state file" \
-  "the triage failure names the shared baseline" "$err"
-
-new_case triage_verdict_read_failure
-printf '2\n' > "$STUB_DIR/workflow-state.rc"
-printf 'oversee state unreadable\n' > "$STUB_DIR/workflow-state.err"
-err="$TMP_ROOT/triage-verdict-read"
-out="$(run_watch -- --since 2026-08-15T09:00:00Z 2>"$err")" && rc=0 || rc=$?
-assert_eq "$rc" "2" "an unreadable verdict log exits 2" "$err"
-assert_eq "$out" "" "an unreadable verdict log emits no event" "$err"
-assert_contains "$(cat "$err")" "oversee state unreadable" \
-  "the verdict read keeps its original cause" "$err"
-
-new_case triage_invalid_verdict_id
-printf '{"triaged":[{"issue":"bad id","verdict":"kept"}]}\n' > "$STUB_DIR/oversee-state.json"
-err="$TMP_ROOT/triage-invalid-id"
-out="$(run_watch -- --since 2026-08-15T09:00:00Z 2>"$err")" && rc=0 || rc=$?
-assert_eq "$rc" "2" "an invalid verdict issue id exits 2" "$err"
-assert_eq "$out" "" "an invalid verdict issue id emits no event" "$err"
-assert_contains "$(cat "$err")" "invalid issue id: 'bad id'" \
-  "the invalid verdict id is named" "$err"
-
-# Triage keys and reducer keys coexist in the one first-repository baseline.
-# A triage rewrite that starts from empty loses the standing reducer edge and
-# the next run incorrectly emits pr-watch.
+# Triage keys and reducer keys coexist in the one first-repository baseline. A
+# triage rewrite that started from empty lost the standing reducer edge, and
+# the next run emitted pr-watch again.
 new_case triage_preserves_pr_keys
 printf '12\tabcdef01\tthreads-open\t2 unresolved\n' > "$STUB_DIR/prwatch.out"
 printf '1\n' > "$STUB_DIR/prwatch.rc"
-printf '[{"id":"KEN-1200","created_at":"2026-08-15T10:00:00.000Z"}]\n' > "$STUB_DIR/tracker.out"
-printf '{"triaged":[{"issue":"KEN-1200","verdict":"kept"}]}\n' > "$STUB_DIR/oversee-state.json"
-err="$TMP_ROOT/triage-coexist-a"
-out="$(run_watch -- --max-loops 1 --since 2026-08-15T09:00:00Z 2>"$err")" && rc=0 || rc=$?
-state_file="$STATE_DIR/owner_repo__2026-08-15T09_00_00Z"
-assert_contains "$(cat "$state_file")" "$(printf '12\tthreads-open')" \
-  "triage reconciliation preserves the reducer key" "$err"
-assert_contains "$(cat "$state_file")" "$(printf 'triage\tKEN-1200')" \
-  "the verdict key shares the reducer baseline" "$err"
-err="$TMP_ROOT/triage-coexist-b"
-out="$(run_watch -- --max-loops 1 --since 2026-08-15T09:00:00Z 2>"$err")" && rc=0 || rc=$?
-assert_eq "$(head -1 <<<"$out")" "EVENT heartbeat loops=1 interval=0s since=2026-08-15T09:00:00Z" \
-  "unchanged reducer attention stays baselined after triage" "$err"
-
-new_case since_requires_utc_z
-err="$TMP_ROOT/triage-h"
-out="$(run_watch -- --since 2026-08-15 2>"$err")" && rc=0 || rc=$?
-assert_eq "$rc" "2" "a date-only --since is rejected" "$err"
-assert_eq "$out" "" "a date-only --since emits no event" "$err"
-assert_contains "$(cat "$err")" "UTC timestamp ending in Z" \
-  "the date-only refusal names the documented form" "$err"
-
-new_case since_rejects_offset
-err="$TMP_ROOT/triage-i"
-out="$(run_watch -- --since 2026-08-15T09:00:00+00:00 2>"$err")" && rc=0 || rc=$?
-assert_eq "$rc" "2" "an offset --since is rejected" "$err"
-assert_eq "$out" "" "an offset --since emits no event" "$err"
-assert_contains "$(cat "$err")" "UTC timestamp ending in Z" \
-  "the offset refusal names the documented form" "$err"
+tracker_items '[{"id":"KEN-1200","created_at":"2026-08-15T10:00:00.000Z"}]'
+verdicts '[{"issue":"KEN-1200","verdict":"kept"}]'
+run -- --max-loops 1
+check "triage reconciliation preserves the reducer key beside the verdict key" "state~12%tthreads-open=true state~triage%tKEN-1200=true"
+run -- --max-loops 1
+check "unchanged reducer attention stays baselined after triage" "first=$HEARTBEAT1"
 
 printf 'pass: %d   fail: %d\n' "$PASS" "$FAIL"
 [[ "$FAIL" -eq 0 ]]

--- a/.agents/skills/orch/tests/oversee_watch_triage.sh
+++ b/.agents/skills/orch/tests/oversee_watch_triage.sh
@@ -65,7 +65,10 @@ watch() {
   printf '%s' "${got# }"
 }
 
-check() { assert_eq "$(watch "$2")" "$2" "$1" "$ERR"; }
+check() {
+  [[ -n "$2" ]] || { printf 'check: a case with no expect asserts nothing: %s\n' "$1" >&2; exit 1; }
+  assert_eq "$(watch "$2")" "$2" "$1" "$ERR"
+}
 
 tracker_items() { printf '%s\n' "$1" > "$STUB_DIR/tracker.out"; }
 verdicts() { printf '{"triaged":%s}\n' "$1" > "$STUB_DIR/oversee-state.json"; }
@@ -100,7 +103,7 @@ check "an unacknowledged item repeats on the next run" "first=EVENT+triage+KEN-1
 verdicts '[{"issue":"KEN-1200","verdict":"kept"},{"issue":"KEN-1202","verdict":"canceled"},{"issue":"KEN-1204","verdict":"pending"}]'
 run -- --max-loops 1
 check "kept and canceled verdicts rebuild the baseline, pending stays out and repeats, the read anchored to the project tmp directory" \
-  "first=EVENT+triage+KEN-1204 state~triage%tKEN-1200=true state~triage%tKEN-1202=true state~triage%tKEN-1204=false wsargs~kept=true wsargs~canceled=true wsargs~--state-dir+%R/tmp+get+oversee=true"
+  "first=EVENT+triage+KEN-1204 state~triage%tKEN-1200=true state~triage%tKEN-1202=true state~triage%tKEN-1204=false wsargs~--state-dir+%R/tmp+get+oversee=true"
 verdicts '[{"issue":"KEN-1200","verdict":"kept"},{"issue":"KEN-1202","verdict":"canceled"},{"issue":"KEN-1204","verdict":"kept"}]'
 run -- --max-loops 1
 check "terminal verdicts close every repeated event" "first=$HEARTBEAT1"
@@ -172,7 +175,6 @@ for row in \
   "a date-only --since is refused, naming the documented form|||--since 2026-08-15|rc=2 stdout=empty stderr~UTC+timestamp+ending+in+Z=true" \
   "an offset --since is refused, naming the documented form|||--since 2026-08-15T09:00:00+00:00|rc=2 stdout=empty stderr~UTC+timestamp+ending+in+Z=true"; do
   IFS='|' read -r label env stubs args expect <<<"$row"
-  [[ -n "$expect" ]] || { printf 'refusals: a row with no expect asserts nothing: %s\n' "$row" >&2; exit 1; }
   new_case triage_refusal
   if [[ -n "$stubs" ]]; then
     IFS=';' read -ra items <<<"$stubs"

--- a/skills/orch/tests/oversee_watch_triage.sh
+++ b/skills/orch/tests/oversee_watch_triage.sh
@@ -1,297 +1,203 @@
 #!/usr/bin/env bash
-# Tracker-side controls for oversee-watch triage events.
+# Tracker-side controls for oversee-watch triage events: what an unseen team
+# item emits, what acknowledges it, what the check refuses to run on, and the
+# `--since` form it accepts. One run, one comparison: `watch EXPECT` reads
+# exactly the facts EXPECT names, so a case fails on the fact it names.
 set -euo pipefail
 source "$(dirname "${BASH_SOURCE[0]}")/lib/git-env.sh"
-
 # shellcheck source=lib/oversee-watch-harness.sh
 source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/lib/oversee-watch-harness.sh"
 
+SINCE=2026-08-15T09:00:00Z
+HEARTBEAT1="EVENT+heartbeat+loops=1+interval=0s+since=$SINCE"
+STATE_FILE_NAME="owner_repo__2026-08-15T09_00_00Z"
+
+# run [ENV=VAL ...] -- ARGS... — one watch run; OUT, RC and ERR (a file) are
+# what `watch` reads. `--since` is supplied unless ARGS carry their own.
+RUN_SEQ=0
+run() {
+  local args=("$@") a since=yes
+  for a in "$@"; do [[ "$a" == --since* ]] && since=no; done
+  [[ "$since" == no ]] || args+=(--since "$SINCE")
+  ERR="$TMP_ROOT/run-$((++RUN_SEQ)).err"
+  OUT="$(run_watch "${args[@]}" 2>"$ERR")" && RC=0 || RC=$?
+}
+
+# watch EXPECT — prints the run's value of every `name=` field EXPECT names,
+# in EXPECT's order (in a needle `+` reads as a space and %e as `=`; %B is the
+# stub bin directory, %R the case's repository root, %S the stub directory):
+#   rc               exit status
+#   first            the first stdout line, or `none`
+#   events           how many `EVENT triage` lines stdout carries
+#   out~<text>       whether stdout carries <text>
+#   stdout           `empty` or `lines`
+#   stderr~<text>    whether stderr carries <text>
+#   notes~<text>     how many stderr lines carry <text>
+#   tracker~<text>   whether the tracker stub was called with <text>
+#   tracker          `read` or `unread`
+#   wsargs~<text>    whether the workflow-state stub was called with <text>
+#   state~<text>     whether the per-repo baseline file carries <text> (`%t`
+#                    reads as a tab)
+#   state_files      how many files the state directory holds
+watch() {
+  local got="" token name value needle state_file="$STATE_DIR/$STATE_FILE_NAME"
+  for token in $1; do
+    name="${token%%=*}"
+    needle="${name#*~}"; needle="${needle//+/ }"; needle="${needle//%e/=}"; needle="${needle//%B/$TMP_ROOT/bin}"
+    needle="${needle//%R/$CASE_REPO_ROOT}"; needle="${needle//%S/$STUB_DIR}"; needle="${needle//%t/$'\t'}"
+    case "$name" in
+      rc) value="$RC" ;;
+      first) value="$(head -n 1 <<<"$OUT")"; value="${value:-none}"; value="${value// /+}" ;;
+      events) value="$(grep -c '^EVENT triage ' <<<"$OUT" || true)" ;;
+      out~*) value="$(grep -qF -- "$needle" <<<"$OUT" && echo true || echo false)" ;;
+      stdout) value="$([[ -n "$OUT" ]] && echo lines || echo empty)" ;;
+      stderr~*) value="$(grep -qF -- "$needle" "$ERR" && echo true || echo false)" ;;
+      notes~*) value="$(grep -cF -- "$needle" "$ERR" || true)" ;;
+      tracker~*) value="$([[ -e "$STUB_DIR/tracker.args" ]] && grep -qF -- "$needle" "$STUB_DIR/tracker.args" && echo true || echo false)" ;;
+      tracker) value="$([[ -e "$STUB_DIR/tracker.args" ]] && echo read || echo unread)" ;;
+      wsargs~*) value="$([[ -e "$STUB_DIR/workflow-state.args" ]] && grep -qF -- "$needle" "$STUB_DIR/workflow-state.args" && echo true || echo false)" ;;
+      state~*) value="$([[ -e "$state_file" ]] && grep -qF -- "$needle" "$state_file" && echo true || echo false)" ;;
+      state_files) value="$(find "$STATE_DIR" -maxdepth 1 -type f 2>/dev/null | wc -l | tr -d '[:space:]')" ;;
+      *) echo "watch: unknown field $name" >&2; exit 1 ;;
+    esac
+    got="$got $name=$value"
+  done
+  printf '%s' "${got# }"
+}
+
+check() { assert_eq "$(watch "$2")" "$2" "$1" "$ERR"; }
+
+tracker_items() { printf '%s\n' "$1" > "$STUB_DIR/tracker.out"; }
+verdicts() { printf '{"triaged":%s}\n' "$1" > "$STUB_DIR/oversee-state.json"; }
+
 echo "=== oversee-watch triage ==="
 
+# A standing lane prompt first, so the state-file count below is taken on a
+# run that has a lane fingerprint persisted already; a second file class would
+# exist by then if lane-asking kept its own.
 new_case triage_new
 printf '1786957201\n' > "$STUB_DIR/now.epoch"
 printf '3\n' > "$STUB_DIR/tracker.want-created-since"
-# A standing lane prompt first, so the file count below is taken on a run that
-# has lanes with a fingerprint already persisted — the state class this suite
-# claims does not exist would exist by then if lane-asking kept its own file.
 printf 'Do you want to proceed?\n   ❯ 1. Yes\n     2. No\n' > "$STUB_DIR/pane-gh-2.txt"
-printf '[]\n' > "$STUB_DIR/tracker.out"
-err="$TMP_ROOT/triage-lane"
-out="$(run_watch -- --max-loops 1 --since 2026-08-15T09:00:00Z gh-1 gh-2 2>"$err")" && rc=0 || rc=$?
-assert_eq "$(head -1 <<<"$out")" "EVENT lane-asking gh-2" \
-  "a standing lane prompt wakes the watch before any tracker item" "$err"
-cat > "$STUB_DIR/tracker.out" <<'EOF'
-[
-  {"id":"KEN-1200","created_at":"2026-08-15T10:00:00.000Z"},
-  {"id":"KEN-1202","created_at":"2026-08-15T10:30:00.000Z"},
-  {"id":"KEN-1204","created_at":"2026-08-15T11:30:00.000Z"},
-  {"id":"KEN-1199","created_at":"2026-08-15T08:59:59.000Z"}
-]
-EOF
-err="$TMP_ROOT/triage-a"
-out="$(run_watch -- --since 2026-08-15T09:00:00Z gh-1 gh-2 2>"$err")" && rc=0 || rc=$?
-assert_eq "$rc" "0" "new triage item exits 0" "$err"
-assert_eq "$(head -1 <<<"$out")" "EVENT triage KEN-1200" \
-  "an item created after --since is a triage event" "$err"
-assert_contains "$out" "EVENT triage KEN-1202" \
-  "each new item gets its own triage event line" "$err"
-assert_contains "$out" "EVENT triage KEN-1204" \
-  "a team item with no lane authorship is still emitted" "$err"
-assert_eq "$(grep -c '^EVENT triage ' <<<"$out")" "3" \
-  "one wake emits one line per new tracker item" "$err"
-assert_not_contains "$out" "KEN-1199" "an item before --since is not emitted" "$err"
-tracker_args="$(cat "$STUB_DIR/tracker.args")"
-assert_contains "$tracker_args" "issues list --team kendex --created-since " \
-  "triage reads the live tracker list for the fleet's team" "$err"
-assert_contains "$tracker_args" "d --max --format=safe" \
-  "triage uses a created-since day window and fetches every result" "$err"
-state_file="$STATE_DIR/owner_repo__2026-08-15T09_00_00Z"
-assert_not_contains "$(cat "$state_file")" "$(printf 'triage\tKEN-1200')" \
-  "printing an event does not acknowledge the item" "$err"
-assert_contains "$(cat "$state_file")" "$(printf 'lane-asking\tgh-2\t')" \
-  "the standing lane fingerprint shares the one per-repo baseline" "$err"
-assert_eq "$(find "$STATE_DIR" -maxdepth 1 -type f | wc -l | tr -d '[:space:]')" "1" \
-  "triage creates no second state-file class" "$err"
-err="$TMP_ROOT/triage-b"
-out="$(run_watch -- --max-loops 1 --since 2026-08-15T09:00:00Z 2>"$err")" && rc=0 || rc=$?
-assert_eq "$(head -1 <<<"$out")" "EVENT triage KEN-1200" \
-  "an unacknowledged item repeats on the next run" "$err"
+tracker_items '[]'
+run -- --max-loops 1 gh-1 gh-2
+check "a standing lane prompt wakes the watch before any tracker item" "first=EVENT+lane-asking+gh-2"
 
-cat > "$STUB_DIR/oversee-state.json" <<'EOF'
-{"triaged":[
-  {"issue":"KEN-1200","verdict":"kept"},
-  {"issue":"KEN-1202","verdict":"canceled"},
-  {"issue":"KEN-1204","verdict":"pending"}
-]}
-EOF
-err="$TMP_ROOT/triage-b2"
-out="$(run_watch -- --max-loops 1 --since 2026-08-15T09:00:00Z 2>"$err")" && rc=0 || rc=$?
-assert_eq "$(head -1 <<<"$out")" "EVENT triage KEN-1204" \
-  "a pending verdict does not acknowledge the item" "$err"
-assert_contains "$(cat "$state_file")" "$(printf 'triage\tKEN-1200')" \
-  "a kept verdict rebuilds the watcher baseline" "$err"
-assert_contains "$(cat "$state_file")" "$(printf 'triage\tKEN-1202')" \
-  "a canceled verdict rebuilds the watcher baseline" "$err"
-assert_not_contains "$(cat "$state_file")" "$(printf 'triage\tKEN-1204')" \
-  "a pending verdict stays out of watcher dedup" "$err"
-assert_contains "$(cat "$STUB_DIR/workflow-state.args")" "kept" \
-  "the verdict read accepts kept outcomes" "$err"
-assert_contains "$(cat "$STUB_DIR/workflow-state.args")" "canceled" \
-  "the verdict read accepts canceled outcomes" "$err"
-assert_contains "$(cat "$STUB_DIR/workflow-state.args")" "--state-dir $CASE_REPO_ROOT/tmp get oversee" \
-  "the verdict read anchors default state to the project tmp directory" "$err"
+# Items created after --since are one event each, in one wake, read from the
+# live list for the fleet's team over a created-since day window; printing an
+# event does not acknowledge it, and the fingerprints share the one per-repo
+# baseline.
+tracker_items '[{"id":"KEN-1200","created_at":"2026-08-15T10:00:00.000Z"},{"id":"KEN-1202","created_at":"2026-08-15T10:30:00.000Z"},{"id":"KEN-1204","created_at":"2026-08-15T11:30:00.000Z"},{"id":"KEN-1199","created_at":"2026-08-15T08:59:59.000Z"}]'
+run -- gh-1 gh-2
+check "three items after --since are three triage events in one wake, the earlier item not among them, read from the team's created-since list, none acknowledged by printing" \
+  "rc=0 first=EVENT+triage+KEN-1200 events=3 out~EVENT+triage+KEN-1202=true out~EVENT+triage+KEN-1204=true out~KEN-1199=false tracker~issues+list+--team+kendex+--created-since+=true tracker~d+--max+--format%esafe=true state~triage%tKEN-1200=false state~lane-asking%tgh-2%t=true state_files=1"
+run -- --max-loops 1
+check "an unacknowledged item repeats on the next run" "first=EVENT+triage+KEN-1200"
 
-cat > "$STUB_DIR/oversee-state.json" <<'EOF'
-{"triaged":[
-  {"issue":"KEN-1200","verdict":"kept"},
-  {"issue":"KEN-1202","verdict":"canceled"},
-  {"issue":"KEN-1204","verdict":"kept"}
-]}
-EOF
-err="$TMP_ROOT/triage-b3"
-out="$(run_watch -- --max-loops 1 --since 2026-08-15T09:00:00Z 2>"$err")" && rc=0 || rc=$?
-assert_eq "$(head -1 <<<"$out")" "EVENT heartbeat loops=1 interval=0s since=2026-08-15T09:00:00Z" \
-  "terminal verdicts close every repeated event" "$err"
+# A kept or canceled verdict acknowledges the item into the watcher baseline,
+# read from the oversee state under the project tmp directory; a pending
+# verdict does neither.
+verdicts '[{"issue":"KEN-1200","verdict":"kept"},{"issue":"KEN-1202","verdict":"canceled"},{"issue":"KEN-1204","verdict":"pending"}]'
+run -- --max-loops 1
+check "kept and canceled verdicts rebuild the baseline, pending stays out and repeats, the read anchored to the project tmp directory" \
+  "first=EVENT+triage+KEN-1204 state~triage%tKEN-1200=true state~triage%tKEN-1202=true state~triage%tKEN-1204=false wsargs~kept=true wsargs~canceled=true wsargs~--state-dir+%R/tmp+get+oversee=true"
+verdicts '[{"issue":"KEN-1200","verdict":"kept"},{"issue":"KEN-1202","verdict":"canceled"},{"issue":"KEN-1204","verdict":"kept"}]'
+run -- --max-loops 1
+check "terminal verdicts close every repeated event" "first=$HEARTBEAT1"
+tracker_items '[{"id":"KEN-1201","created_at":"2026-08-15T11:00:00.000Z"},{"id":"KEN-1200","created_at":"2026-08-15T10:00:00.000Z"}]'
+run --
+check "a later item fires on the next run and the acknowledged one stays deduplicated" "first=EVENT+triage+KEN-1201 out~EVENT+triage+KEN-1200=false"
 
-cat > "$STUB_DIR/tracker.out" <<'EOF'
-[
-  {"id":"KEN-1201","created_at":"2026-08-15T11:00:00.000Z"},
-  {"id":"KEN-1200","created_at":"2026-08-15T10:00:00.000Z"}
-]
-EOF
-err="$TMP_ROOT/triage-c"
-out="$(run_watch -- --since 2026-08-15T09:00:00Z 2>"$err")" && rc=0 || rc=$?
-assert_eq "$(head -1 <<<"$out")" "EVENT triage KEN-1201" \
-  "a later tracker item fires on the next run" "$err"
-assert_not_contains "$out" "EVENT triage KEN-1200" "the prior item stays deduplicated" "$err"
-
-# Control: no unseen item emits no triage event.
 new_case triage_empty
-printf '[]\n' > "$STUB_DIR/tracker.out"
-err="$TMP_ROOT/triage-d"
-out="$(run_watch -- --max-loops 1 --since 2026-08-15T09:00:00Z 2>"$err")" && rc=0 || rc=$?
-assert_eq "$(head -1 <<<"$out")" "EVENT heartbeat loops=1 interval=0s since=2026-08-15T09:00:00Z" \
-  "an empty tracker list reaches the heartbeat" "$err"
-assert_not_contains "$out" "EVENT triage" "no new item emits no triage event" "$err"
-
-# A missing CLI is a broken install: triage fails closed rather than dropping
-# every unseen team item on a stderr note.
-new_case triage_requires_tracker
-printf '[{"id":"KEN-1200","created_at":"2026-08-15T10:00:00.000Z"}]\n' > "$STUB_DIR/tracker.out"
-err="$TMP_ROOT/triage-needs-tracker"
-out="$(run_watch OVERSEE_WATCH_TRACKER="$TMP_ROOT/bin/absent-tracker" -- --since 2026-08-15T09:00:00Z 2>"$err")" && rc=0 || rc=$?
-assert_eq "$rc" "2" "a missing tracker CLI exits 2 under --since" "$err"
-assert_eq "$out" "" "a missing tracker CLI emits no event" "$err"
-assert_contains "$(cat "$err")" "tracker CLI not found at $TMP_ROOT/bin/absent-tracker" \
-  "the missing tracker CLI is named" "$err"
-assert_contains "$(cat "$err")" "OVERSEE_WATCH_TRACKER" \
-  "the tracker refusal names its remedy" "$err"
-
-new_case triage_requires_workflow_state
-printf '[{"id":"KEN-1200","created_at":"2026-08-15T10:00:00.000Z"}]\n' > "$STUB_DIR/tracker.out"
-err="$TMP_ROOT/triage-needs-workflow-state"
-out="$(run_watch OVERSEE_WATCH_WORKFLOW_STATE="$TMP_ROOT/bin/absent-workflow-state" -- --since 2026-08-15T09:00:00Z 2>"$err")" && rc=0 || rc=$?
-assert_eq "$rc" "2" "a missing workflow-state CLI exits 2 under --since" "$err"
-assert_eq "$out" "" "a missing workflow-state CLI emits no event" "$err"
-assert_contains "$(cat "$err")" "workflow-state CLI not found at $TMP_ROOT/bin/absent-workflow-state" \
-  "the missing workflow-state CLI is named" "$err"
-assert_contains "$(cat "$err")" "OVERSEE_WATCH_WORKFLOW_STATE" \
-  "the workflow-state refusal names its remedy" "$err"
+tracker_items '[]'
+run -- --max-loops 1
+check "control: an empty tracker list reaches the heartbeat with no triage event" "first=$HEARTBEAT1 events=0"
 
 # A fleet with no tracker team is not a broken install: triage is skipped and
-# named once, and every other check — merged included, which --since also
-# serves — keeps running. This is the documented invocation on a repo that
-# tracks its work in GitHub.
+# named once, whether the name is absent or exported empty, and every other
+# check --since serves keeps running, merged included. The first case exits on
+# the merged event before the triage check; the second reaches it with a live
+# tracker and an unseen item, and the tracker goes unread.
 new_case triage_skipped_without_team
-printf '[{"id":"KEN-1200","created_at":"2026-08-15T10:00:00.000Z"}]\n' > "$STUB_DIR/tracker.out"
+tracker_items '[{"id":"KEN-1200","created_at":"2026-08-15T10:00:00.000Z"}]'
 printf '[{"number":5,"headRefName":"issue-5","mergedAt":"2026-08-15T10:00:00Z"}]\n' > "$STUB_DIR/merged.json"
-err="$TMP_ROOT/triage-no-team"
-out="$(run_watch LINEAR_TEAM -- --max-loops 1 --item issue-5 --since 2026-08-15T09:00:00Z 2>"$err")" && rc=0 || rc=$?
-assert_eq "$rc" "0" "an unset LINEAR_TEAM keeps the watch running" "$err"
-assert_eq "$(head -1 <<<"$out")" "EVENT merged 5 issue-5" \
-  "--since still serves the merged check with no team" "$err"
-assert_contains "$(cat "$err")" "LINEAR_TEAM is unset or empty" \
-  "the note names an empty team as well as an absent one" "$err"
-
-# The case above exits on the merged event before check_triage runs, so triage
-# being off is proved here instead: a live tracker stub with an unseen item, and
-# nothing to wake the watch before the triage check.
+run LINEAR_TEAM -- --max-loops 1 --item issue-5
+check "an unset LINEAR_TEAM keeps the watch running and --since still serves the merged check" \
+  "rc=0 first=EVENT+merged+5+issue-5 stderr~LINEAR_TEAM+is+unset+or+empty=true"
 new_case triage_no_team_reaches_the_triage_check
-printf '[{"id":"KEN-1200","created_at":"2026-08-15T10:00:00.000Z"}]\n' > "$STUB_DIR/tracker.out"
-err="$TMP_ROOT/triage-no-team-reached"
-out="$(run_watch LINEAR_TEAM -- --max-loops 1 --since 2026-08-15T09:00:00Z 2>"$err")" && rc=0 || rc=$?
-assert_eq "$(head -1 <<<"$out")" "EVENT heartbeat loops=1 interval=0s since=2026-08-15T09:00:00Z" \
-  "the run reaches the triage check and falls through to the heartbeat" "$err"
-assert_not_contains "$out" "EVENT triage" \
-  "a new tracker item emits no triage event with no team" "$err"
-tracker_called=no
-if [[ -e "$STUB_DIR/tracker.args" ]]; then tracker_called=yes; fi
-assert_eq "$tracker_called" "no" "a working tracker goes unread with no team" "$err"
-
-# The bare sentinel above drops the name entirely. An exported empty value is
-# the other spelling of no team, and the one this change moved: it would die
-# on the removed check. It takes the same skip path.
+tracker_items '[{"id":"KEN-1200","created_at":"2026-08-15T10:00:00.000Z"}]'
+run LINEAR_TEAM -- --max-loops 1
+check "with no team the run reaches the triage check, emits nothing for the unseen item and leaves the tracker unread" \
+  "first=$HEARTBEAT1 events=0 tracker=unread"
 new_case triage_skipped_by_an_empty_export
-printf '[{"id":"KEN-1200","created_at":"2026-08-15T10:00:00.000Z"}]\n' > "$STUB_DIR/tracker.out"
-err="$TMP_ROOT/triage-empty-export"
-out="$(run_watch LINEAR_TEAM= -- --max-loops 1 --since 2026-08-15T09:00:00Z 2>"$err")" && rc=0 || rc=$?
-assert_eq "$rc" "0" "an exported-empty LINEAR_TEAM keeps the watch running" "$err"
-assert_eq "$(grep -c 'skipping the team triage check' "$err")" "1" \
-  "the empty export takes the skip path the absent name takes" "$err"
-
+tracker_items '[{"id":"KEN-1200","created_at":"2026-08-15T10:00:00.000Z"}]'
+run LINEAR_TEAM= -- --max-loops 1
+check "an exported-empty LINEAR_TEAM takes the skip path the absent name takes" "rc=0 notes~skipping+the+team+triage+check=1"
 new_case triage_skipped_without_team_or_tracker
-err="$TMP_ROOT/triage-no-team-no-tracker"
-out="$(run_watch LINEAR_TEAM OVERSEE_WATCH_TRACKER="$TMP_ROOT/bin/absent-tracker" -- --max-loops 2 --since 2026-08-15T09:00:00Z 2>"$err")" && rc=0 || rc=$?
-assert_eq "$rc" "0" "an unset LINEAR_TEAM runs a fleet with no tracker CLI" "$err"
-assert_eq "$(head -1 <<<"$out")" "EVENT heartbeat loops=2 interval=0s since=2026-08-15T09:00:00Z" \
-  "no team disarms the gate a missing dependency would close" "$err"
-assert_eq "$(grep -c 'skipping the team triage check' "$err")" "1" \
-  "the skip note is printed once, not once per pass" "$err"
+run LINEAR_TEAM OVERSEE_WATCH_TRACKER="$TMP_ROOT/bin/absent-tracker" -- --max-loops 2
+check "no team disarms the gate a missing tracker CLI would close, and the skip note prints once over two passes" \
+  "rc=0 first=EVENT+heartbeat+loops=2+interval=0s+since=$SINCE notes~skipping+the+team+triage+check=1"
 
-new_case triage_unsets_inherited_state
-err="$TMP_ROOT/triage-state-inherited"
-out="$(ORCH_STATE_DIR=leaked run_watch -- --max-loops 1 --since 2026-08-15T09:00:00Z 2>"$err")" && rc=0 || rc=$?
-assert_contains "$(cat "$STUB_DIR/workflow-state.args")" "--state-dir $CASE_REPO_ROOT/tmp get oversee" \
-  "the common harness clears an inherited state directory" "$err"
+# The verdict read's state directory: an inherited one is cleared by the
+# harness, a relative configured one joins the project root, an absolute one
+# is kept.
+for row in \
+  "the common harness clears an inherited state directory|ORCH_STATE_DIR=leaked|wsargs~--state-dir+%R/tmp+get+oversee=true" \
+  "a relative configured state directory joins the project root|ORCH_STATE_DIR=custom/state|wsargs~--state-dir+%R/custom/state+get+oversee=true" \
+  "an absolute configured state directory is preserved|ORCH_STATE_DIR=%S/absolute-state|wsargs~--state-dir+%S/absolute-state+get+oversee=true"; do
+  IFS='|' read -r label env expect <<<"$row"
+  new_case triage_state_dir
+  env="${env//%S/$STUB_DIR}"
+  if [[ "$env" == ORCH_STATE_DIR=leaked ]]; then
+    ORCH_STATE_DIR=leaked run -- --max-loops 1
+  else
+    run "$env" -- --max-loops 1
+  fi
+  check "$label" "$expect"
+done
 
-new_case triage_relative_state
-err="$TMP_ROOT/triage-state-relative"
-out="$(run_watch ORCH_STATE_DIR=custom/state -- --max-loops 1 --since 2026-08-15T09:00:00Z 2>"$err")" && rc=0 || rc=$?
-assert_contains "$(cat "$STUB_DIR/workflow-state.args")" "--state-dir $CASE_REPO_ROOT/custom/state get oversee" \
-  "a relative configured state directory joins the project root" "$err"
+# Refusals: a missing CLI is a broken install, a read failure or malformed
+# output is unknown fleet state, an unwritable baseline cannot acknowledge, and
+# --since takes one form. Each exits 2 with no event and names its cause:
+# `label|env|stubs|args|expect`, stubs `;`-separated `file=content` under the
+# stub directory or `dir=<name>` under the state directory.
+for row in \
+  "a missing tracker CLI is named with its remedy|OVERSEE_WATCH_TRACKER=%B/absent-tracker|tracker.out=[{\"id\":\"KEN-1200\",\"created_at\":\"2026-08-15T10:00:00.000Z\"}]||rc=2 stdout=empty stderr~tracker+CLI+not+found+at+%B/absent-tracker=true stderr~OVERSEE_WATCH_TRACKER=true" \
+  "a missing workflow-state CLI is named with its remedy|OVERSEE_WATCH_WORKFLOW_STATE=%B/absent-workflow-state|tracker.out=[{\"id\":\"KEN-1200\",\"created_at\":\"2026-08-15T10:00:00.000Z\"}]||rc=2 stdout=empty stderr~workflow-state+CLI+not+found+at+%B/absent-workflow-state=true stderr~OVERSEE_WATCH_WORKFLOW_STATE=true" \
+  "a tracker list failure keeps its real cause||tracker.rc=2;tracker.err=Linear API unavailable||rc=2 stdout=empty stderr~Linear+API+unavailable=true" \
+  "malformed tracker output is named||tracker.out={}||rc=2 stdout=empty stderr~tracker+output+is+not+an+array=true" \
+  "an unwritable triage baseline names the shared state file|OVERSEE_WATCH_PR_WATCH=%B/absent-pr-watch|tracker.out=[{\"id\":\"KEN-1200\",\"created_at\":\"2026-08-15T10:00:00.000Z\"}];oversee-state.json={\"triaged\":[{\"issue\":\"KEN-1200\",\"verdict\":\"kept\"}]};dir=$STATE_FILE_NAME||rc=2 stdout=empty stderr~could+not+write+the+pr-watch+state+file=true" \
+  "an unreadable verdict log keeps its original cause||workflow-state.rc=2;workflow-state.err=oversee state unreadable||rc=2 stdout=empty stderr~oversee+state+unreadable=true" \
+  "an invalid verdict issue id is named||oversee-state.json={\"triaged\":[{\"issue\":\"bad id\",\"verdict\":\"kept\"}]}||rc=2 stdout=empty stderr~invalid+issue+id:+'bad+id'=true" \
+  "a date-only --since is refused, naming the documented form|||--since 2026-08-15|rc=2 stdout=empty stderr~UTC+timestamp+ending+in+Z=true" \
+  "an offset --since is refused, naming the documented form|||--since 2026-08-15T09:00:00+00:00|rc=2 stdout=empty stderr~UTC+timestamp+ending+in+Z=true"; do
+  IFS='|' read -r label env stubs args expect <<<"$row"
+  [[ -n "$expect" ]] || { printf 'refusals: a row with no expect asserts nothing: %s\n' "$row" >&2; exit 1; }
+  new_case triage_refusal
+  if [[ -n "$stubs" ]]; then
+    IFS=';' read -ra items <<<"$stubs"
+    for item in "${items[@]}"; do
+      if [[ "$item" == dir=* ]]; then mkdir -p "$STATE_DIR/${item#dir=}"; else printf '%s\n' "${item#*=}" > "$STUB_DIR/${item%%=*}"; fi
+    done
+  fi
+  env="${env//%B/$TMP_ROOT/bin}"
+  # shellcheck disable=SC2086
+  if [[ -n "$env" ]]; then run "$env" -- $args; else run -- $args; fi
+  check "$label" "$expect"
+done
 
-new_case triage_absolute_state
-absolute_state="$STUB_DIR/absolute-state"
-err="$TMP_ROOT/triage-state-absolute"
-out="$(run_watch ORCH_STATE_DIR="$absolute_state" -- --max-loops 1 --since 2026-08-15T09:00:00Z 2>"$err")" && rc=0 || rc=$?
-assert_contains "$(cat "$STUB_DIR/workflow-state.args")" "--state-dir $absolute_state get oversee" \
-  "an absolute configured state directory is preserved" "$err"
-
-# Read failures and malformed output are unknown fleet state, never empty.
-new_case triage_list_failure
-printf '2\n' > "$STUB_DIR/tracker.rc"
-printf 'Linear API unavailable\n' > "$STUB_DIR/tracker.err"
-err="$TMP_ROOT/triage-e"
-out="$(run_watch -- --since 2026-08-15T09:00:00Z 2>"$err")" && rc=0 || rc=$?
-assert_eq "$rc" "2" "a tracker list failure exits 2" "$err"
-assert_eq "$out" "" "a tracker list failure emits no event" "$err"
-assert_contains "$(cat "$err")" "Linear API unavailable" \
-  "the tracker failure keeps its real cause" "$err"
-
-new_case triage_malformed
-printf '{}\n' > "$STUB_DIR/tracker.out"
-err="$TMP_ROOT/triage-f"
-out="$(run_watch -- --since 2026-08-15T09:00:00Z 2>"$err")" && rc=0 || rc=$?
-assert_eq "$rc" "2" "malformed tracker output exits 2" "$err"
-assert_eq "$out" "" "malformed tracker output emits no event" "$err"
-assert_contains "$(cat "$err")" "tracker output is not an array" \
-  "the malformed shape is named" "$err"
-
-new_case triage_state_failure
-printf '[{"id":"KEN-1200","created_at":"2026-08-15T10:00:00.000Z"}]\n' > "$STUB_DIR/tracker.out"
-printf '{"triaged":[{"issue":"KEN-1200","verdict":"kept"}]}\n' > "$STUB_DIR/oversee-state.json"
-mkdir -p "$STATE_DIR/owner_repo__2026-08-15T09_00_00Z"
-err="$TMP_ROOT/triage-g"
-out="$(run_watch OVERSEE_WATCH_PR_WATCH="$TMP_ROOT/bin/absent-pr-watch" -- --since 2026-08-15T09:00:00Z 2>"$err")" && rc=0 || rc=$?
-assert_eq "$rc" "2" "an unwritable triage baseline exits 2" "$err"
-assert_eq "$out" "" "a verdict baseline write failure emits no event" "$err"
-assert_contains "$(cat "$err")" "could not write the pr-watch state file" \
-  "the triage failure names the shared baseline" "$err"
-
-new_case triage_verdict_read_failure
-printf '2\n' > "$STUB_DIR/workflow-state.rc"
-printf 'oversee state unreadable\n' > "$STUB_DIR/workflow-state.err"
-err="$TMP_ROOT/triage-verdict-read"
-out="$(run_watch -- --since 2026-08-15T09:00:00Z 2>"$err")" && rc=0 || rc=$?
-assert_eq "$rc" "2" "an unreadable verdict log exits 2" "$err"
-assert_eq "$out" "" "an unreadable verdict log emits no event" "$err"
-assert_contains "$(cat "$err")" "oversee state unreadable" \
-  "the verdict read keeps its original cause" "$err"
-
-new_case triage_invalid_verdict_id
-printf '{"triaged":[{"issue":"bad id","verdict":"kept"}]}\n' > "$STUB_DIR/oversee-state.json"
-err="$TMP_ROOT/triage-invalid-id"
-out="$(run_watch -- --since 2026-08-15T09:00:00Z 2>"$err")" && rc=0 || rc=$?
-assert_eq "$rc" "2" "an invalid verdict issue id exits 2" "$err"
-assert_eq "$out" "" "an invalid verdict issue id emits no event" "$err"
-assert_contains "$(cat "$err")" "invalid issue id: 'bad id'" \
-  "the invalid verdict id is named" "$err"
-
-# Triage keys and reducer keys coexist in the one first-repository baseline.
-# A triage rewrite that starts from empty loses the standing reducer edge and
-# the next run incorrectly emits pr-watch.
+# Triage keys and reducer keys coexist in the one first-repository baseline. A
+# triage rewrite that started from empty lost the standing reducer edge, and
+# the next run emitted pr-watch again.
 new_case triage_preserves_pr_keys
 printf '12\tabcdef01\tthreads-open\t2 unresolved\n' > "$STUB_DIR/prwatch.out"
 printf '1\n' > "$STUB_DIR/prwatch.rc"
-printf '[{"id":"KEN-1200","created_at":"2026-08-15T10:00:00.000Z"}]\n' > "$STUB_DIR/tracker.out"
-printf '{"triaged":[{"issue":"KEN-1200","verdict":"kept"}]}\n' > "$STUB_DIR/oversee-state.json"
-err="$TMP_ROOT/triage-coexist-a"
-out="$(run_watch -- --max-loops 1 --since 2026-08-15T09:00:00Z 2>"$err")" && rc=0 || rc=$?
-state_file="$STATE_DIR/owner_repo__2026-08-15T09_00_00Z"
-assert_contains "$(cat "$state_file")" "$(printf '12\tthreads-open')" \
-  "triage reconciliation preserves the reducer key" "$err"
-assert_contains "$(cat "$state_file")" "$(printf 'triage\tKEN-1200')" \
-  "the verdict key shares the reducer baseline" "$err"
-err="$TMP_ROOT/triage-coexist-b"
-out="$(run_watch -- --max-loops 1 --since 2026-08-15T09:00:00Z 2>"$err")" && rc=0 || rc=$?
-assert_eq "$(head -1 <<<"$out")" "EVENT heartbeat loops=1 interval=0s since=2026-08-15T09:00:00Z" \
-  "unchanged reducer attention stays baselined after triage" "$err"
-
-new_case since_requires_utc_z
-err="$TMP_ROOT/triage-h"
-out="$(run_watch -- --since 2026-08-15 2>"$err")" && rc=0 || rc=$?
-assert_eq "$rc" "2" "a date-only --since is rejected" "$err"
-assert_eq "$out" "" "a date-only --since emits no event" "$err"
-assert_contains "$(cat "$err")" "UTC timestamp ending in Z" \
-  "the date-only refusal names the documented form" "$err"
-
-new_case since_rejects_offset
-err="$TMP_ROOT/triage-i"
-out="$(run_watch -- --since 2026-08-15T09:00:00+00:00 2>"$err")" && rc=0 || rc=$?
-assert_eq "$rc" "2" "an offset --since is rejected" "$err"
-assert_eq "$out" "" "an offset --since emits no event" "$err"
-assert_contains "$(cat "$err")" "UTC timestamp ending in Z" \
-  "the offset refusal names the documented form" "$err"
+tracker_items '[{"id":"KEN-1200","created_at":"2026-08-15T10:00:00.000Z"}]'
+verdicts '[{"issue":"KEN-1200","verdict":"kept"}]'
+run -- --max-loops 1
+check "triage reconciliation preserves the reducer key beside the verdict key" "state~12%tthreads-open=true state~triage%tKEN-1200=true"
+run -- --max-loops 1
+check "unchanged reducer attention stays baselined after triage" "first=$HEARTBEAT1"
 
 printf 'pass: %d   fail: %d\n' "$PASS" "$FAIL"
 [[ "$FAIL" -eq 0 ]]

--- a/skills/orch/tests/oversee_watch_triage.sh
+++ b/skills/orch/tests/oversee_watch_triage.sh
@@ -65,7 +65,10 @@ watch() {
   printf '%s' "${got# }"
 }
 
-check() { assert_eq "$(watch "$2")" "$2" "$1" "$ERR"; }
+check() {
+  [[ -n "$2" ]] || { printf 'check: a case with no expect asserts nothing: %s\n' "$1" >&2; exit 1; }
+  assert_eq "$(watch "$2")" "$2" "$1" "$ERR"
+}
 
 tracker_items() { printf '%s\n' "$1" > "$STUB_DIR/tracker.out"; }
 verdicts() { printf '{"triaged":%s}\n' "$1" > "$STUB_DIR/oversee-state.json"; }
@@ -100,7 +103,7 @@ check "an unacknowledged item repeats on the next run" "first=EVENT+triage+KEN-1
 verdicts '[{"issue":"KEN-1200","verdict":"kept"},{"issue":"KEN-1202","verdict":"canceled"},{"issue":"KEN-1204","verdict":"pending"}]'
 run -- --max-loops 1
 check "kept and canceled verdicts rebuild the baseline, pending stays out and repeats, the read anchored to the project tmp directory" \
-  "first=EVENT+triage+KEN-1204 state~triage%tKEN-1200=true state~triage%tKEN-1202=true state~triage%tKEN-1204=false wsargs~kept=true wsargs~canceled=true wsargs~--state-dir+%R/tmp+get+oversee=true"
+  "first=EVENT+triage+KEN-1204 state~triage%tKEN-1200=true state~triage%tKEN-1202=true state~triage%tKEN-1204=false wsargs~--state-dir+%R/tmp+get+oversee=true"
 verdicts '[{"issue":"KEN-1200","verdict":"kept"},{"issue":"KEN-1202","verdict":"canceled"},{"issue":"KEN-1204","verdict":"kept"}]'
 run -- --max-loops 1
 check "terminal verdicts close every repeated event" "first=$HEARTBEAT1"
@@ -172,7 +175,6 @@ for row in \
   "a date-only --since is refused, naming the documented form|||--since 2026-08-15|rc=2 stdout=empty stderr~UTC+timestamp+ending+in+Z=true" \
   "an offset --since is refused, naming the documented form|||--since 2026-08-15T09:00:00+00:00|rc=2 stdout=empty stderr~UTC+timestamp+ending+in+Z=true"; do
   IFS='|' read -r label env stubs args expect <<<"$row"
-  [[ -n "$expect" ]] || { printf 'refusals: a row with no expect asserts nothing: %s\n' "$row" >&2; exit 1; }
   new_case triage_refusal
   if [[ -n "$stubs" ]]; then
     IFS=';' read -ra items <<<"$stubs"


### PR DESCRIPTION
Tests audit, twelfth file (wave 2, `BRIEF-TESTS-AUDIT.md`): `skills/orch/tests/oversee_watch_triage.sh`, 297 lines and 71 assertions over the tracker-side triage check, judged against code-quality § Tests. Held for the overseer.

## What changed

- **One run, one comparison.** Every triage run was asserted three to eleven times over the same stdout, stderr and state file. `run [ENV..] -- ARGS` wraps the harness's `run_watch` (supplying `--since` unless the args carry one) and `watch EXPECT` reads exactly the facts the case names: `rc`, `first` (the first stdout line), `events` (the count of `EVENT triage` lines over the whole of stdout), `out~`/`stderr~` needles, `notes~` (a stderr line count), `tracker~` and `tracker` (read or unread), `wsargs~` over the workflow-state stub's arguments, `state~` over the per-repo baseline file, `state_files`. An unknown field or an empty expect aborts the case.
- **The refusals are one table** (`label|env|stubs|args|expect`, nine rows: missing tracker CLI, missing workflow-state CLI, list failure, malformed output, unwritable baseline, unreadable verdict log, invalid verdict id, date-only `--since`, offset `--since`), each staging its own stubs on a fresh case. The three `ORCH_STATE_DIR` spellings are a second table.
- **The sequence cases stay ordered** (three events in one wake, repeat until acknowledged, kept/canceled/pending verdicts, a later item, the no-team skip variants, reducer-key coexistence), one comparison per run.
- **Deleted**: the two argv pins on the verdict words `kept` and `canceled` (they survive an inverted filter while the state-file pins beside them flip, so they were a strict subset). The 28-line per-case header narrative is gone; the case labels carry it.

## Folded cases and the row that fails when the behaviour breaks

| Former case | Surviving comparison |
|---|---|
| lane prompt first (1) | `a standing lane prompt wakes the watch before any tracker item` |
| new triage items (11 assertions on one run) | one comparison: rc, first line, event count, the two other items, the pre-`--since` item absent, the tracker's team and window arguments, no acknowledgment by printing, the shared baseline, one state-file class |
| unacknowledged repeats (1) | `an unacknowledged item repeats on the next run` |
| verdicts (7) | one comparison: first line, three baseline facts, the state-dir argument |
| terminal verdicts (1), later item (2) | one comparison each |
| empty tracker (2) | `control: an empty tracker list reaches the heartbeat with no triage event` |
| no team: merged still served (3), triage check reached (3), empty export (2), no team and no tracker (3) | one comparison each |
| inherited, relative, absolute state dir (1 each) | the state-directory table |
| missing tracker (4), missing workflow-state (4), list failure (3), malformed (3), state failure (3), verdict read failure (3), invalid id (3), date-only (3), offset (3) | the refusals table, one row each |
| preserves pr keys (3) | two comparisons, one per run |

## Mutations against `skills/orch/scripts/oversee-watch`, one per table

Pending verdicts acknowledging (1 row red); the state-dir arguments dropped from the verdict read (4); the `--since` form check loosened (2); the invalid-id check loosened (1); the empty-export team read as a team (1). The reviewer ran ten more (skip note per pass, the `--since` floor, the day window, first item only, reducer keys dropped, printing persisting, a sidecar state file, wrong team, a triage line after the heartbeat), all killed.

## Checks

`oversee_watch_triage.sh` 25 pass / 0 fail (baseline 71 / 0); `tools/bash32-lint` clean; pre-commit chain on each commit. One reviewer-test round (approve, two suggestions, both in the second commit: the empty-expect guard moved into `check`, the two argv pins deleted).

Tracking: KEN-1241.

https://claude.ai/code/session_01PSdX2AT5yWYYBbBBjbAUnP
