### PR TITLE
fix(pi-extensions): Pi 0.85.1 parity for summaries, SSE EOF, edit hook

### DIFF
--- a/pi-extensions/pi-codex-minimal-tools/src/provider-shim.ts
+++ b/pi-extensions/pi-codex-minimal-tools/src/provider-shim.ts
@@ -663,10 +663,12 @@ async function* parseSSE(response: Response): AsyncIterable<StreamEventShape> {
 	try {
 		while (true) {
 			const { done, value } = await reader.read();
-			if (done) break;
 
-			buffer += decoder.decode(value, { stream: true });
+			buffer += done ? decoder.decode() : decoder.decode(value, { stream: true });
 			buffer = buffer.replace(/\r\n/g, "\n").replace(/\r/g, "\n");
+			// EOF ends the residual frame: the backend may close right after the
+			// terminal event without the blank line that normally closes it.
+			if (done && buffer.trim()) buffer += "\n\n";
 			let idx = buffer.indexOf("\n\n");
 			while (idx !== -1) {
 				const chunk = buffer.slice(0, idx);
@@ -687,6 +689,7 @@ async function* parseSSE(response: Response): AsyncIterable<StreamEventShape> {
 				}
 				idx = buffer.indexOf("\n\n");
 			}
+			if (done) break;
 		}
 	} finally {
 		try {

--- a/pi-extensions/pi-codex-minimal-tools/tests/provider-shim-http-status.test.ts
+++ b/pi-extensions/pi-codex-minimal-tools/tests/provider-shim-http-status.test.ts
@@ -90,17 +90,49 @@ function errorResponse(status: number, body: unknown, statusText = "Error"): Res
 	return new Response(typeof body === "string" ? body : JSON.stringify(body), { status, statusText });
 }
 
-function successSseResponse(): Response {
-	const event = {
-		type: "response.completed",
-		response: {
-			id: "resp_ok",
-			status: "completed",
-			usage: { input_tokens: 0, output_tokens: 0, total_tokens: 0, input_tokens_details: { cached_tokens: 0 } },
-		},
-	};
-	return new Response(`data: ${JSON.stringify(event)}\n\n`, { status: 200, headers: { "content-type": "text/event-stream" } });
+const completedEvent = {
+	type: "response.completed",
+	response: {
+		id: "resp_ok",
+		status: "completed",
+		usage: { input_tokens: 0, output_tokens: 0, total_tokens: 0, input_tokens_details: { cached_tokens: 0 } },
+	},
+};
+
+function sseResponse(body: string): Response {
+	return new Response(body, { status: 200, headers: { "content-type": "text/event-stream" } });
 }
+
+function successSseResponse(): Response {
+	return sseResponse(`data: ${JSON.stringify(completedEvent)}\n\n`);
+}
+
+// The Codex backend can close the stream right after the terminal event
+// without the blank line that ends an SSE frame. EOF ends that frame.
+const unterminatedTerminalFrames: Array<{ name: string; body: string }> = [
+	{ name: "LF-terminated final line", body: `data: ${JSON.stringify(completedEvent)}\n` },
+	{ name: "CRLF-terminated final line", body: `data: ${JSON.stringify(completedEvent)}\r\n` },
+	{ name: "no line terminator", body: `data: ${JSON.stringify(completedEvent)}` },
+];
+
+for (const frame of unterminatedTerminalFrames) {
+	test(`SSE terminal event without a trailing blank line completes the stream (${frame.name})`, async () => {
+		globalThis.fetch = (async () => sseResponse(frame.body)) as typeof fetch;
+
+		const result = await runCodexProvider();
+
+		assert.equal(result.errorMessage, undefined);
+		assert.equal(result.stopReason, "stop");
+	});
+}
+
+test("malformed residual SSE data at EOF is ignored like any malformed frame", async () => {
+	globalThis.fetch = (async () => sseResponse(`data: ${JSON.stringify(completedEvent)}\n\ndata: {not json`)) as typeof fetch;
+
+	const result = await runCodexProvider();
+
+	assert.equal(result.stopReason, "stop");
+});
 
 test("SSE transport sends compressed tool choice and applies nullable header overrides", async () => {
 	let captured: RequestInit | undefined;

--- a/pi-extensions/pi-qol/extensions/qol/compaction.ts
+++ b/pi-extensions/pi-qol/extensions/qol/compaction.ts
@@ -186,6 +186,11 @@ async function singleShotSummary(ctx: ExtensionContext, request: SummarizeReques
 	if (response.stopReason === "error" || response.stopReason === "aborted") {
 		throw new Error(response.errorMessage || `Summary request stopped: ${response.stopReason}`);
 	}
+	// A length stop carries text, but the text ends wherever the cap fell; as a
+	// continuation checkpoint it would silently drop the rest of the context.
+	if (response.stopReason === "length") {
+		throw new Error("Summary generation hit the token cap and the summary is incomplete");
+	}
 	const summary = response.content
 		.filter((content): content is { type: "text"; text: string } => content.type === "text")
 		.map((content) => content.text)

--- a/pi-extensions/pi-qol/tests/compaction-length-stop.test.ts
+++ b/pi-extensions/pi-qol/tests/compaction-length-stop.test.ts
@@ -1,0 +1,75 @@
+// A summary whose generation stopped at the token cap is incomplete even when
+// it carries text. Pi's own compaction and branch-summary generators reject
+// that response; the QOL summarizer is the common path behind the compaction,
+// chunk/reduce and branch consumers, so the rejection lives there.
+
+import { afterEach, beforeEach, expect, mock, test } from "bun:test";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { generateQolSummary } from "../extensions/qol/compaction.ts";
+
+let workdir = "";
+const originalAgentDir = process.env.PI_CODING_AGENT_DIR;
+const originalHome = process.env.HOME;
+
+beforeEach(() => {
+	workdir = mkdtempSync(join(tmpdir(), "pi-qol-length-stop-"));
+	process.env.PI_CODING_AGENT_DIR = workdir;
+	process.env.HOME = workdir;
+});
+
+afterEach(() => {
+	if (workdir) rmSync(workdir, { force: true, recursive: true });
+	if (originalAgentDir === undefined) delete process.env.PI_CODING_AGENT_DIR;
+	else process.env.PI_CODING_AGENT_DIR = originalAgentDir;
+	if (originalHome === undefined) delete process.env.HOME;
+	else process.env.HOME = originalHome;
+	// Restore the preload stub so later files still get a complete summary.
+	mock.module("@earendil-works/pi-ai", () => ({
+		complete: async () => ({
+			content: [{ text: "stubbed summary text", type: "text" }],
+			stopReason: "end_turn",
+		}),
+	}));
+});
+
+function makeCtx(): any {
+	const model = { contextWindow: 200_000, id: "test-model", provider: "test" };
+	return {
+		cwd: workdir,
+		hasUI: false,
+		model,
+		modelRegistry: {
+			find: () => model,
+			getApiKeyAndHeaders: async () => ({ apiKey: "k", headers: {}, ok: true }),
+		},
+	};
+}
+
+function stubComplete(stopReason: string): void {
+	mock.module("@earendil-works/pi-ai", () => ({
+		complete: async () => ({
+			content: [{ text: "## Goal\nPartial summary that ran out of", type: "text" }],
+			stopReason,
+		}),
+	}));
+}
+
+const rows: Array<{ stopReason: string; accepted: boolean }> = [
+	{ accepted: false, stopReason: "length" },
+	{ accepted: true, stopReason: "stop" },
+];
+
+for (const row of rows) {
+	test(`generateQolSummary ${row.accepted ? "accepts" : "rejects"} a summary with stopReason ${row.stopReason}`, async () => {
+		stubComplete(row.stopReason);
+		const run = generateQolSummary(makeCtx(), { conversationText: "user: hello", purpose: "compaction" });
+		if (row.accepted) {
+			expect((await run).summary).toContain("Partial summary");
+		} else {
+			await expect(run).rejects.toThrow(/token cap/);
+		}
+	});
+}

--- a/pi-extensions/pi-tool-renderer/extensions/__tests__/edit-prepare-arguments.test.ts
+++ b/pi-extensions/pi-tool-renderer/extensions/__tests__/edit-prepare-arguments.test.ts
@@ -1,0 +1,41 @@
+// The edit renderer replaces Pi's edit tool definition. Pi's agent loop runs a
+// definition's prepareArguments hook before schema validation, so the
+// replacement must carry the original hook or the argument shapes Pi's own
+// tool accepts (legacy oldText/newText, a single edit object) fail validation
+// with the renderer active.
+
+import { expect, test } from "bun:test";
+import { mkdtempSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import * as agent from "@earendil-works/pi-coding-agent";
+
+import { registerEdit } from "../tool-renderer/tools.js";
+
+interface CapturedDef {
+	name: string;
+	prepareArguments?: (args: unknown) => unknown;
+}
+
+function registeredEdit(): CapturedDef {
+	const tools: CapturedDef[] = [];
+	const cwd = mkdtempSync(join(tmpdir(), "edit-prepare-"));
+	registerEdit({ registerTool: (def: CapturedDef) => tools.push(def) } as any, agent, cwd);
+	expect(tools.length).toBe(1);
+	return tools[0]!;
+}
+
+test("registered edit definition forwards Pi's prepareArguments hook", () => {
+	const def = registeredEdit();
+	const original = agent.createEditTool(process.cwd()) as unknown as CapturedDef;
+	expect(typeof original.prepareArguments).toBe("function");
+	expect(def.prepareArguments).toBe(original.prepareArguments);
+});
+
+test("legacy oldText/newText input is normalized before validation through the registered definition", () => {
+	const def = registeredEdit();
+	const prepared = def.prepareArguments!({ newText: "b", oldText: "a", path: "f.txt" }) as { edits?: unknown; path?: string };
+	expect(prepared.path).toBe("f.txt");
+	expect(prepared.edits).toEqual([{ newText: "b", oldText: "a" }]);
+});

--- a/pi-extensions/pi-tool-renderer/extensions/tool-renderer/tools.ts
+++ b/pi-extensions/pi-tool-renderer/extensions/tool-renderer/tools.ts
@@ -255,6 +255,10 @@ export function registerEdit(pi: ExtensionAPI, agent: any, cwd: string): void {
 		label: "edit",
 		description: original.description,
 		parameters: original.parameters,
+		// Pi's agent loop prepares arguments before schema validation; the
+		// replacement definition has to carry the hook or the shapes Pi's own
+		// tool accepts fail validation before execute() can delegate.
+		prepareArguments: original.prepareArguments,
 		async execute(id: string, params: any, signal: AbortSignal | undefined, onUpdate: unknown, context: any) {
 			const effectiveCwd = contextCwd(context, cwd);
 			const targetPath = params?.path ?? params?.file_path;

--- a/pi-extensions/pi-update.audit.md
+++ b/pi-extensions/pi-update.audit.md
@@ -1,64 +1,70 @@
-# Pi package update audit: 0.84.2
+# Pi package update audit: 0.84.3 to 0.85.1
 
-Marker `0.84.1` → `0.84.2`. Audited against base `82ecc517`. Sources fetched: `agent`, `ai`, `coding-agent`, `server`, `storage` (at `packages/session-backends/sqlite-node/` — the pre-0.84.0 `packages/storage/sqlite-node/` path 404s), `tui`, plus the curated release notes. `Unreleased` blocks scanned for heads-up only and excluded from the marker.
+Marker `0.84.2` → `0.85.1`. Audited against base `8d056a7f`. Sources fetched: every `*/CHANGELOG.md` in the Pi tree at `v0.85.1` (`agent`, `ai`, `client`, `coding-agent`, `protocol`, `server`, `session-backends/sqlite-node`, `telemetry`, `tui`), plus the curated release notes. The previous marker's `storage` key was an alias for the sqlite-node backend path; the marker now carries the path-derived key `session-backends/sqlite-node`, and `client`, `protocol` and `telemetry` are newly enumerated. `Unreleased` blocks scanned for heads-up only and excluded from the marker.
 
-In scope since the previous marker (`0.84.1`): one release, `0.84.2` (2026-08-14). After deduping the curated notes and the `inherited` restatements `coding-agent` publishes for `ai`/`agent`/`tui` changes, ~35 unique items. `server` and `storage` 0.84.2 sections are empty; `agent` 0.84.2 carries a single fix.
+In scope since the previous marker: four releases, `0.84.3` (2026-08-24), `0.84.4` (2026-08-28), `0.85.0` (2026-09-04), `0.85.1` (2026-09-05). `client`, `protocol`, `server`, `session-backends/sqlite-node` and `telemetry` sections are empty across the range. The `coding-agent` changelog restates `ai`, `agent` and `tui` entries as `inherited`; those restatements are not counted as separate items.
 
 ## Counts
 
 | Bucket | Count |
 |---|---:|
-| Required parity fix | 0 |
-| Optional improvement (deferred) | 1 |
-| Non-impact | ~34 |
+| Required parity fix | 3 |
+| Optional improvement (deferred) | 4 |
+| Non-impact | grouped below, not tallied |
 
 ## Shipped
 
-Nothing. No 0.84.2 entry changes a surface our extensions override, mirror, or duplicate.
+Three fixes, each with a test at the function that changed and a red-first control.
+
+| Item | Extension | Fix |
+|---|---|---|
+| Compaction and branch summaries reject token-capped generations (0.84.3, [#7048](https://github.com/earendil-works/pi/issues/7048)) | `pi-qol` | `singleShotSummary` in `extensions/qol/compaction.ts` now throws on `stopReason: "length"`, matching Pi's `getSummarizationFailure`. The single function feeds the direct, chunk/reduce and branch-summary consumers, so all three reject an incomplete summary before it can become the continuation checkpoint. Reachable with `compaction.customEnabled` off through the budget-guard sentinel. Test: `tests/compaction-length-stop.test.ts`. |
+| OpenAI Codex SSE parsing processes a terminal event not followed by a blank line (0.85.0, [#9047](https://github.com/earendil-works/pi/issues/9047)) | `pi-codex-minimal-tools` | `parseSSE` in `src/provider-shim.ts` flushes the decoder at EOF and treats EOF as the end of the residual frame, mirroring Pi's `openai-codex-responses.ts`. Before the fix a completed response whose last frame lacked the trailing blank line reported `Stream closed before response.completed` on the SSE transport, which is shipped both as an explicit setting and as the fallback after a pre-start WebSocket failure. CRLF normalization and the ignore-malformed-frame policy are unchanged. Test: `tests/provider-shim-http-status.test.ts`, one row per line-ending shape plus a malformed-residual control. |
+| Single-object `edit` inputs accepted as one-edit arrays (0.84.3, [#7835](https://github.com/earendil-works/pi/issues/7835)) | `pi-tool-renderer` | `registerEdit` in `extensions/tool-renderer/tools.ts` re-registers Pi's edit tool and copied only `description` and `parameters`, dropping `prepareArguments`. Pi's agent loop runs that hook before schema validation, so with `renderMutationTools` on, the shapes Pi's own tool normalizes (single edit object, JSON-string edits, legacy `oldText`/`newText`) failed validation before `execute` could delegate. The registered definition now forwards the original hook; nothing is duplicated locally. The 0.84.2 audit's "no extension ships an edits-array tool" was wrong for this source. Test: `extensions/__tests__/edit-prepare-arguments.test.ts`. |
+
+Not live-tested inside Pi; each fix is proven at its unit surface against the installed peer packages.
 
 ## Deferred (Optional)
 
 | Item | Reasoning |
 |---|---|
-| `expandPromptTemplates` on `pi.sendUserMessage()` (0.84.2, [#7857](https://github.com/earendil-works/pi/pull/7857)) | Pi's option covers exactly the kendex#13 workaround surface in `pi-session-bridge/extensions/session-bridge.ts:620-680`: extension-command dispatch plus skill and prompt-template expansion. Adopting it would retire the fragile tmux-paste path (`resolveOwnTmuxPaneByParentChain` + `pasteAndSubmitToPane`) in favor of a first-party API. Deferred from this run for two reasons: our client-side `/skill:` expansion carries the per-session skill-hash reminder cache (repeated sends deliver a short reminder instead of full skill content — a documented token-cost feature Pi's dispatch does not replicate), so full adoption is a regression there; and swapping the extension/TUI-command delivery path needs a live peer-session test that an audit run cannot provide. Right end state: keep client-side skill/template expansion first, replace only the tmux-paste fallback with `sendUserMessage(content, { …, expandPromptTemplates: true })`. The `session-bridge.ts:620` comment ("pi.sendUserMessage hardcodes expandPromptTemplates: false") becomes stale wording with that change and should be updated in the same commit. |
+| `ui_prompt_start` / `ui_prompt_end` and `session_compact_failed` extension events (0.84.3, 0.85.0) | `pi-session-bridge` republishes an explicit event allowlist (`extensions/session-bridge.ts:49-65`) and publishes `ctx.isIdle()`; a waiting-for-input distinction would help orchestration but the bridge never promised these events. `pi-qol` already has completion and error callbacks on the compactions it starts. Adopt with a bridge design, not in a parity round. |
+| RPC `clear_queue` (0.84.4) | Pi stdio RPC, not a method of kendex's socket bridge. Adding it is a bridge feature. |
+| `SessionManager.inMemory()` restorable sessions, summary routing ids, `detectSupportedImageMimeTypeFromFile` (0.85.0) | Additive SDK. The file-backed session manager and local image format detection stay correct; no net simplification without a redesign. |
+| Embedded working indicator in the default editor (0.85.0, [#8799](https://github.com/earendil-works/pi/pull/8799)) | `CustomEditor` defaults `embedWorkingStatus` to false, so `QolEditor` and `QolCompactPromptEditor` keep the standalone indicator; the compact editor strips its top border, so embedding needs a deliberate layout choice. |
+
+The 0.84.2 deferral of `sendUserMessage(..., { expandPromptTemplates: true })` stands unchanged; see the previous audit's reasoning (skill-hash reminder cache, live peer test).
 
 ## Non-impact
 
-Tools, settings, and extension API:
+Already protected or inherited beneath us:
 
-- **`defaultTools` setting + its fix for dropping extension/SDK custom tools** — our activation logic derives from the live active set, never a hardcoded built-in list: `pi-codex-minimal-tools/src/index.ts:76,87` and `pi-web-tools/src/index.ts:60` diff against `pi.getActiveTools()` before calling `setActiveTools()`. A user-configured startup selection flows through unchanged, and Pi's in-release fix protects our registered tools.
-- **Experimental strict JSON-schema constrained sampling for `read`/`bash`/`edit`/`write` under `PI_EXPERIMENTAL=1`** — Pi's default tools, opt-in; `pi-tool-renderer` renders their results and validates nothing.
-- **Single-object `edit` inputs accepted as one-edit arrays ([#7835](https://github.com/earendil-works/pi/issues/7835))** — no kendex extension ships an edits-array tool (grep zero); the validation lives in Pi's coding-agent and harness edit tools.
-- **Root Markdown files in skill dirs no longer reported as broken skills ([#7805](https://github.com/earendil-works/pi/issues/7805))** — `pi-skills-manager` discovers through Pi's own `DefaultPackageManager.resolve()` (`registry.ts:70-73`) and already null-drops files without name/description frontmatter (`registry.ts:23-39`); the upstream fix removes the bogus entries before we see them.
-- **Fallback rendering for extension tool results collapses long output ([#7979](https://github.com/earendil-works/pi/issues/7979))** — every custom tool we ship has its own renderer; the fallback only covers unrendered tools, so this is a strict improvement beneath us.
-- **`message_update` events regain cumulative usage in JSON/RPC ([#7982](https://github.com/earendil-works/pi/pull/7982))** — additive field. `pi-agents-tmux` reads usage from `agent_end`/`message_end`; `pi-session-bridge`'s sanitizer reduces `message_update` to role/contentIndex/delta preview and ignores extra fields (raw sidecar keeps them).
-- **`pi.sendMessage(..., { triggerTurn: false })` no longer steers an active run ([#8022](https://github.com/earendil-works/pi/pull/8022))** — our ten `triggerTurn: false` call sites are record-only by intent: `pi-hooks/extensions/hooks.ts` (drift report at session start), `pi-task-panel/extensions/task-panel.ts:1283`, `pi-qol/extensions/qol.ts:872` and `qol/session-search/{context.ts:135,index.ts:91,115}`, `pi-codex-minimal-tools/src/background-image-generation.ts:481,520` and `provider-shim.ts:1941,1957`. Pi now matches the intent; before the fix these could steer an active run we never meant to steer, so the change is strictly protective. One `sendMessage` call of ours is not in that set and must not be read into it: `pi-hooks/extensions/hooks.ts`'s end-of-turn clippy report passes `triggerTurn: true` because it has to steer — a recorded message reaches `agent.state.messages` but never the steering queue the loop drains, so a headless run that is ending never reads one.
-- **Custom system prompts no longer concatenate cwd with appended content ([#7887](https://github.com/earendil-works/pi/pull/7887))** — `pi-claude-bridge` assembles its own prompt context from `APPEND_SYSTEM.md` files (`src/prompt-context.ts:34-49`) and never routes through Pi's `customSystemPrompt` concatenation.
-- **Subagent example fixes: YAML `tools` arrays ([#7598](https://github.com/earendil-works/pi/pull/7598)), parent model/thinking/tool inheritance ([#7897](https://github.com/earendil-works/pi/pull/7897))** — Pi's example extension; ours is `pi-agents-tmux`.
-- **Managed-tool downloads no longer delay TUI startup; model selector no longer restarts an in-progress catalog refresh** — Pi startup orchestration outside any surface we hook.
+- **Built-in tools honor `ctx.cwd` (0.85.0, [#8627](https://github.com/earendil-works/pi/pull/8627))**: `pi-tool-renderer` caches built-in tools per normalized cwd and picks the execution context's cwd before delegating (`tools.ts:56-83`, `batch.ts:261-263`).
+- **Write tool byte-count removal (0.85.0, [#8979](https://github.com/earendil-works/pi/issues/8979))**: our write renderer reports line totals and diffs, never the UTF-16 count; raw output delegates to Pi.
+- **`NO_PROXY` root and subdomain matching (0.85.0, [#8737](https://github.com/earendil-works/pi/pull/8737))**: `provider-shim.ts` `noProxyMatches` already strips a leading dot and matches exact host or `.domain` suffix; `tests/provider-shim-proxy.test.ts` covers it.
+- **Record-only `sendMessage` ordering (0.84.4)**: benefits our `triggerTurn: false` sites; the hooks' end-of-turn report keeps `triggerTurn: true` on purpose.
+- **Session newline repair, fork compaction boundary, import collisions, concurrent share writes (0.85.0)**: `pi-session-manager` goes through `SessionManager.open` and SDK append on the normal path. Its exception-path `appendSessionInfoFallback` does no newline repair; that combination was not established as a shipped producer path.
+- **Truncated-response recovery no longer labeled context overflow (0.84.3, [#8130](https://github.com/earendil-works/pi/issues/8130))**: `pi-agents-tmux` matches explicit context-length errors, not the generic truncated text; no regex change.
+- **Skill discovery fixes, BOM tolerance, root Markdown in skill dirs**: `pi-skills-manager` resolves through Pi's package resolver and `parseFrontmatter`, then drops entries without name/description.
+- **Branch summary token cap raised to 4096, reasoning-consumed cap fix ([#8845](https://github.com/earendil-works/pi/issues/8845))**: QOL's default is 8192 (`constants.ts`); the length-stop rejection above is the part that mattered.
 
-Provider and model catalog (checked against our two provider overrides — `pi-claude-bridge`'s native provider and `pi-codex-minimal-tools`' shim, which owns its own transport):
+Provider and model catalog (our overrides are `openai-codex` in `pi-codex-minimal-tools` and the Claude native provider in `pi-claude-bridge`):
 
-- **OpenAI Responses namespace preservation during streaming/proxying/replay + message-anchored `additional_tools` ([#7709](https://github.com/earendil-works/pi/issues/7709))** — closes the 0.84.1 audit's heads-up: grep confirms zero namespace handling in `pi-codex-minimal-tools/src`; the shim never routes through Pi's Responses adapter or `streamProxy()`.
-- **`streamProxy()` finalized tool-call metadata fix (agent 0.84.2, [#7709](https://github.com/earendil-works/pi/issues/7709))** — no `streamProxy` usage anywhere in our source.
-- **Strict tool schemas auto-converted to closed objects with required-nullable optionals; `null` for optional non-nullable args treated as omitted** — provider-side transmission of tool schemas; our tools' TypeBox schemas are unchanged at registration, and the Claude bridge provider does not use strict schema mode.
-- **`createGatewayBindingFetch()` ([#7901](https://github.com/earendil-works/pi/pull/7901)); `AssistantMessage.endTurn` ([#7766](https://github.com/earendil-works/pi/pull/7766)); Kimi runtime User-Agent; native Mistral transport; DeepSeek `max_tokens`/hostname fixes; Bedrock empty-object-key replay ([#7882](https://github.com/earendil-works/pi/pull/7882)); Google/Vertex stop-classification ([#8059](https://github.com/earendil-works/pi/issues/8059)); Copilot policy rate limit ([#6187](https://github.com/earendil-works/pi/issues/6187)); upstream buffer-limit retries** — built-in provider transports and catalogs we neither register nor override; nothing consumes `endTurn`.
-- **`AI_AGENT=pi` marker documentation ([#7747](https://github.com/earendil-works/pi/issues/7747))** — docs only; our children are identified by `PI_SUBAGENT_CHILD_AGENT`/`PI_SUBAGENT_CHILD_PANE`.
+- **GPT-6 Astra (0.85.1)**: the Codex shim already recognizes `gpt-6-astra` (`provider-shim.ts:499`).
+- **Responses `prompt_cache_options.ttl` (0.85.1)**: the shim sends `prompt_cache_key` and neither `prompt_cache_retention` nor `prompt_cache_options`; it never emitted the obsolete field.
+- **Persistent Claude thinking effort, signed-thinking recovery, refusal fallback (0.84.3, 0.85.0)**: Anthropic Messages transport. The bridge drives the Claude Agent SDK and maps thinking levels itself (`query-options.ts`); parity with Pi's per-turn effort markers is not claimed and needs its own verification if wanted.
+- **Copilot Fable transport, Gemini/Vertex, Bedrock, xAI Responses, ZAI, DeepSeek, Qwen, Baseten, Fireworks, Mistral, Cerebras, Cloudflare, Kimi, Xiaomi, vLLM and llama.cpp catalog and adapter fixes; `vllmPriority`, `supportsMaxOutputTokens`; provider-neutral `toolChoice`; `GoogleThinkingLevel` rename; `createGatewayBindingFetch`; default `User-Agent`; CONNECT tunneling for proxied plain-HTTP**: built-in transports we neither register nor override. The QOL summary call passes no tools, so `toolChoice` does not apply to it.
 
-TUI and platform:
+Host, SDK and platform:
 
-- **Fullscreen transcript search (`Ctrl+Shift+F`, match themes, navigation), unbound single-line scroll actions ([#7903](https://github.com/earendil-works/pi/pull/7903)), fullscreen exit-output setting, `--use-theme` ([#7722](https://github.com/earendil-works/pi/pull/7722)), 9-18x alternate-screen paint reduction, SGR mouse release codes ([#7963](https://github.com/earendil-works/pi/issues/7963)), overlay wheel/PageUp scroll ([#7894](https://github.com/earendil-works/pi/issues/7894)), `Alt+Enter` over SSH + `PI_TUI_ESC_TIMEOUT` ([#7899](https://github.com/earendil-works/pi/pull/7899)), idle repaint on focus loss ([#7892](https://github.com/earendil-works/pi/pull/7892)), OSC 52 copy verification ([#8110](https://github.com/earendil-works/pi/pull/8110)), LaTeX newline-argument and control-space fixes ([#7760](https://github.com/earendil-works/pi/issues/7760)), Windows right-click paste** — Pi TUI internals and keybindings. Our popups and renderers build on Pi's components and return fresh render output each frame; no API we call changed, and the direct-line-reference paint change only affects rows Pi composes itself. Standing caveat from the 0.84.0 audit: our popups were not live-tested inside fullscreen mode this run either.
-- **`nanoid` transitive dev-dependency DoS bump** — no kendex extension lockfile contains `nanoid`.
+- **`prepareNextTurn` between-turn compaction, withdrawn `AgentHarness` controls (0.84.4)**: no consumer in extension TypeScript; QOL handles `agent_end`, `agent_settled` and `session_compact`.
+- **0.85.0 published experimental `client`/`experimental/plugin` subpaths; 0.85.1 made them source-only and repaired SDK imports ([#9132](https://github.com/earendil-works/pi/issues/9132))**: no import of either subpath in our extensions; the supported SDK and stdio RPC are unchanged.
+- **`pi update` registry-version comparison ([#8226](https://github.com/earendil-works/pi/issues/8226))**: reconciles `git:`/`npm:` entries only; kendex path packages stay out of scope.
+- **Agent CLI `--` task delimiter**: `pi-agents-tmux` prefixes tasks with `Task: ` (`runner.ts:672`), so a dash-prefixed task never reached the parser.
+- **Managed `fd`/ripgrep downloads, SEA extension loading, lazy runtime, package globs, update staging, clipboard packaging, auth-file ACLs, EXIF orientation, selector save keybindings, RPC `abort` cancelling manual compaction, skills with Bash-only tools, optional PowerShell tool**: Pi host behavior. PowerShell receives no kendex renderer or hook policy; adding Windows policy coverage is a separate choice.
+- **TUI: fullscreen transcript search caching, jump-to-latest label, Alt wheel acceleration, hover selection fix, drag selection, seccomp `SIGWINCH`, Zed image detection, LaTeX join symbols, `PI_DEBUG_REDRAW` → `PI_TUI_DEBUG_REDRAW`, renderer constructor defaults ([#8699](https://github.com/earendil-works/pi/pull/8699))**: no `new TUI`/`new TuiAltScreen` or `PI_DEBUG_REDRAW` in our extensions; our popups and renderers build on Pi's components. Standing caveat: popups were not live-tested in fullscreen this run either.
 
 ## Heads-up (`Unreleased`, not processed)
 
-Scanned for awareness only; the marker stays at `0.84.2`.
-
-- **Truncated-response recovery no longer mislabeled as context overflow ([#8130](https://github.com/earendil-works/pi/issues/8130))** — `pi-agents-tmux`'s bg-agent overflow retry matches context-overflow message strings; recheck the exact wording when this releases.
-- `session_compact_failed` extension events ([#8175](https://github.com/earendil-works/pi/issues/8175)) — possible future consumer in `pi-qol` compaction UX.
-- `pi update` no longer treats older registry versions as updates ([#8226](https://github.com/earendil-works/pi/issues/8226)) — `pi update` reconciles `git:`/`npm:` entries only; kendex path packages stay out of scope.
-- `pi.registerFlag()` default-type validation ([#8064](https://github.com/earendil-works/pi/issues/8064)); llama.cpp `/model` catalog fixes; pi.dev catalog refresh retry ([#8198](https://github.com/earendil-works/pi/issues/8198)); ai `GoogleThinkingLevel` rename (no usage on our side).
-
-## Run incident (not a changelog item)
-
-During this run's fetch phase the host session hit a `pi-claude-bridge` defect: a five-way parallel `web_fetch` batch containing one empty-args call cross-wired the bridge's result pairing — three results reaped as stale, one orphaned handler with no timeout, session deadlocked 5h39m until manual abort. Full forensics and fix directions filed as [kendex#1469](https://github.com/vanillagreencom/kendex/issues/1469).
+- **Strict-prefer JSON-schema sampling becomes the default for built-in `read`, `bash`, `powershell`, `edit`, `write`; extensions may set `constrainedSampling: false`**: `pi-tool-renderer` re-registers those tools and does not forward `constrainedSampling` today. Decide on forwarding when this releases.
+- Login waits for catalog discovery before declaring models missing; Radius defaults changed. Host only.

--- a/pi-extensions/pi-update.state.json
+++ b/pi-extensions/pi-update.state.json
@@ -1,14 +1,17 @@
 {
-  "lastVersion": "0.84.2",
-  "lastDate": "2026-08-14",
-  "lastRun": "2026-08-18T03:19:32Z",
-  "lastRunHead": "82ecc517781e788389008fc43d3b5f06f044e191",
+  "lastVersion": "0.85.1",
+  "lastDate": "2026-09-05",
+  "lastRun": "2026-09-06T03:39:09Z",
+  "lastRunHead": "8d056a7f518775d7f0a87b2b85416414c5a91c01",
   "sourcesCovered": [
     "agent",
     "ai",
+    "client",
     "coding-agent",
+    "protocol",
     "server",
-    "storage",
+    "session-backends/sqlite-node",
+    "telemetry",
     "tui",
     "releases"
   ]


### PR DESCRIPTION
## Summary

Pi 0.84.3 through 0.85.1 parity round for `pi-extensions/`. Three surfaces we override had fallen behind Pi's own behavior; each is fixed at the function that diverged, with a test at that surface and a red-first control. The marker advances to 0.85.1 and the audit records every disposition.

- **pi-qol**: `singleShotSummary` accepted a summary whose generation stopped at the token cap. Pi's compaction and branch-summary generators reject that response (0.84.3, earendil-works/pi#7048). The one function feeds the direct, chunk/reduce and branch consumers, so all three now reject an incomplete summary before it can become the continuation checkpoint. Reachable with `compaction.customEnabled` off through the budget-guard sentinel.
- **pi-codex-minimal-tools**: `parseSSE` dropped a final frame the backend closed without a trailing blank line, so a completed response on the SSE transport (explicit setting, or fallback after a pre-start WebSocket failure) reported `Stream closed before response.completed`. EOF now flushes the decoder and ends the residual frame, mirroring Pi's parser (0.85.0, earendil-works/pi#9047). CRLF normalization and the ignore-malformed-frame policy are unchanged.
- **pi-tool-renderer**: `registerEdit` re-registered Pi's edit tool with `description` and `parameters` only. Pi's agent loop runs `prepareArguments` before schema validation, so with `renderMutationTools` on, the shapes Pi's tool normalizes (single edit object, JSON-string edits, legacy `oldText`/`newText`) failed validation before `execute` could delegate (0.84.3, earendil-works/pi#7835). The hook is forwarded from the wrapped definition; nothing is duplicated locally.

Marker: `pi-extensions/pi-update.state.json` 0.84.2 → 0.85.1, `sourcesCovered` now uses the path-derived keys (`session-backends/sqlite-node` replaces the `storage` alias; `client`, `protocol`, `telemetry` added). Audit: `pi-extensions/pi-update.audit.md` rewritten for the range.

No package version bump; the release wave after this PR owns bumps. `[no-changelog]`: pi-extensions is outside the changelog-required paths.

## Tests

| Suite | Result |
|---|---|
| pi-qol `bun test ./tests` | 115 pass |
| pi-tool-renderer `npm test` | 45 pass |
| pi-codex-minimal-tools `npm test` + `npm run typecheck` | 79 pass, typecheck clean |
| `node --test pi-extensions/package-policy.test.mjs` | 8 pass |
| `tools/guard` and the pre-commit chain | clean |

Must-fail controls: each new test was run red against the unfixed source, green after the fix, and red again with the fix reverted (1, 3 and 2 failures respectively).

Not live-tested inside a running Pi session.
