### PR TITLE
fix(KEN-1152): the file list says when its read did not land

### DIFF
--- a/changelog.d/fixed/KEN-1152.md
+++ b/changelog.d/fixed/KEN-1152.md
@@ -1,0 +1,1 @@
+- The package page's file list says when its read did not land and offers it again, instead of drawing a package with no files.

--- a/ui/src/components/package/package-body.tsx
+++ b/ui/src/components/package/package-body.tsx
@@ -27,11 +27,13 @@ export function PackageBody({
   meta,
   versions,
   files,
+  filesNote,
   installed,
   view,
   setView,
   diff,
   busy,
+  reading,
   onToggle,
   onSwitchVersion,
   onCompare,
@@ -44,11 +46,15 @@ export function PackageBody({
   meta: PackageMeta_Serialize | null;
   versions: VersionRow[];
   files: PackageFile[];
+  /** Why the file list has no files, where its read did not land. */
+  filesNote: string | null;
   installed: VersionRow | undefined;
   view: PackageView;
   setView: (view: PackageView) => void;
   diff: PackageDiff | null;
   busy: boolean;
+  /** Whether the page's own reads are out. */
+  reading: boolean;
   onToggle: (enable: boolean) => void;
   onSwitchVersion: (row: VersionRow) => void;
   onCompare: (row: VersionRow) => void;
@@ -100,13 +106,16 @@ export function PackageBody({
               meta={meta}
               versions={versions}
               files={files}
+              filesNote={filesNote}
               selectedFile={view.file}
               busy={busy}
+              retryRunning={reading}
               onToggle={(_, enable) => onToggle(enable)}
               onSwitchVersion={onSwitchVersion}
               onCompare={onCompare}
               onFollow={onFollow}
               onSelectFile={(file) => setView({ mode: "files", file })}
+              onRetryFiles={onReload}
             />
             <div className="min-w-0 flex-1">
               <FilePreview

--- a/ui/src/components/package/package-sidebar.tsx
+++ b/ui/src/components/package/package-sidebar.tsx
@@ -9,12 +9,14 @@ import { FileList } from "@/components/package/file-list";
 import { PackageMetaBlock } from "@/components/package/package-meta";
 import { VersionMenu } from "@/components/package/version-menu";
 import { SectionHeading, SettingRow } from "@/components/section";
+import { Button } from "@/components/ui/button";
 import { Switch } from "@/components/ui/switch";
 import {
   ENABLED_HELP,
   ENABLED_LABEL,
   PACKAGE_FILES_TITLE,
   PACKAGE_VERSION_TITLE,
+  TRY_AGAIN_LABEL,
 } from "@/lib/copy";
 import type { ItemGroup } from "@/lib/derive";
 
@@ -26,26 +28,40 @@ export function PackageSidebar({
   meta,
   versions,
   files,
+  filesNote,
   selectedFile,
   busy,
+  retryRunning,
   onToggle,
   onSwitchVersion,
   onCompare,
   onFollow,
   onSelectFile,
+  onRetryFiles,
 }: {
   group: ItemGroup;
   primary: ObservedItem;
   meta: PackageMeta_Serialize | null;
   versions: VersionRow[];
   files: PackageFile[];
+  /** Why there are no files to list, where the read did not land:
+   *  `package-read-state.ts` [`packageFilesNote`]. Null while the read is
+   *  pending or once it landed, and a landed read with nothing in it is a
+   *  package that ships no files, which draws no section at all. */
+  filesNote: string | null;
   selectedFile: string | null;
   busy: boolean;
+  /** Whether the page's reads are out again. The note stays put while they
+   *  run — it is still the last answer — so the button is what says the
+   *  page is doing something about it. */
+  retryRunning: boolean;
   onToggle: (scope: Scope, enable: boolean) => void;
   onSwitchVersion: (row: VersionRow) => void;
   onCompare: (row: VersionRow) => void;
   onFollow: () => void;
   onSelectFile: (path: string) => void;
+  /** Read this package again, offered beside the note above. */
+  onRetryFiles: () => void;
 }) {
   const managed = group.kind === "agent" || group.kind === "skill";
   const anyDisabled = group.installations.some((i) => i.enabled === false);
@@ -80,7 +96,20 @@ export function PackageSidebar({
           />
         </div>
       ) : null}
-      {files.length > 0 ? (
+      {filesNote !== null ? (
+        <div className="space-y-2.5">
+          <SectionHeading>{PACKAGE_FILES_TITLE}</SectionHeading>
+          <p className="text-sm text-muted-foreground">{filesNote}</p>
+          <Button
+            size="sm"
+            variant="outline"
+            disabled={retryRunning}
+            onClick={onRetryFiles}
+          >
+            {TRY_AGAIN_LABEL}
+          </Button>
+        </div>
+      ) : files.length > 0 ? (
         <div className="space-y-2.5">
           <SectionHeading>{PACKAGE_FILES_TITLE}</SectionHeading>
           <FileList

--- a/ui/src/components/package/use-package-data.ts
+++ b/ui/src/components/package/use-package-data.ts
@@ -65,11 +65,12 @@ export function usePackageData(ref: PackageRef | null): {
   const [meta, setMeta] = useState<PackageMeta_Serialize | null>(null);
   const [files, setFiles] = useState<PackageFile[]>([]);
   const [versions, setVersions] = useState<VersionRow[]>([]);
-  // How each of the two went, kept beside the values: a read that failed
+  // How each of the three went, kept beside the values: a read that failed
   // leaves the same empty page as one that found nothing, and the reason it
   // came back with is the only thing that tells them apart.
   const [record, setRecord] = useState<ReadState>(READ_PENDING);
   const [timeline, setTimeline] = useState<ReadState>(READ_PENDING);
+  const [filesRead, setFilesRead] = useState<ReadState>(READ_PENDING);
   // Whether the newest load is still out. Counted here rather than read off
   // the order below: one ticket covers three answers, and `outstanding` flips
   // on the first of them to land, so it is not this order's question to ask.
@@ -123,6 +124,7 @@ export function usePackageData(ref: PackageRef | null): {
       (response) => {
         if (!lands()) return;
         setFiles(response.status === "ok" ? response.data : []);
+        setFilesRead(readOf(response));
       },
     );
     void settled(commands.packageVersions(ref.scope, ref.kind, ref.name)).then(
@@ -136,7 +138,13 @@ export function usePackageData(ref: PackageRef | null): {
 
   // biome-ignore lint/correctness/useExhaustiveDependencies: what a landed update moves, not values `load` closes over
   useEffect(load, [load, commit, written]);
-  return { meta, files, versions, reads: { record, timeline, reading }, load };
+  return {
+    meta,
+    files,
+    versions,
+    reads: { record, timeline, files: filesRead, reading },
+    load,
+  };
 }
 
 /** The diff behind a diff view, fetched when the view asks for one. The

--- a/ui/src/lib/copy.ts
+++ b/ui/src/lib/copy.ts
@@ -106,6 +106,14 @@ export const TRY_AGAIN_LABEL = "Try again";
 
 // Package page: files, versions, and the diff between them.
 export const PACKAGE_FILES_TITLE = "Files";
+// The file list is the page's third read and the one no Update turns on. A
+// package that ships no files and one whose files could not be read leave
+// the same empty column, so a read that did not land says so where the list
+// would be, with the reason the read came back with, and offers the read
+// again.
+export const PACKAGE_FILES_READ_FAILED = "Couldn't read this package's files";
+export const packageFilesReadFailedNote = (reason: string): string =>
+  `${PACKAGE_FILES_READ_FAILED} — ${reason}`;
 export const PACKAGE_VERSION_TITLE = "Version";
 export const README_TAG = "readme";
 export const UPDATE_LABEL = "Update";

--- a/ui/src/lib/package-read-state.ts
+++ b/ui/src/lib/package-read-state.ts
@@ -1,21 +1,28 @@
-// How the package page's own reads of one package went, and what the header
-// says when one of them did not land. The update read's side of that same
-// question is `updates-read-state.ts` [`packageUpdateNote`]; `versions.ts`
-// [`updateOffer`] ranks the two into the one string the header renders.
+// How the package page's own reads of one package went, and what the page
+// says when one of them did not land: the header for the two reads Update
+// turns on, the Overview's file list for the third. The update read's side
+// of the header's question is `updates-read-state.ts` [`packageUpdateNote`];
+// `versions.ts` [`updateOffer`] ranks the two into the one string the header
+// renders.
+import { packageFilesReadFailedNote } from "@/lib/copy";
 import { packageReadFailedNote } from "@/lib/copy-updates";
 import type { ReadState } from "@/lib/read-state";
 
-/** How the page's own two gating reads went. Kept apart rather than folded
- *  into one answer: either one failing is a package this page could not
- *  read, and the timeline's failing on its own is separately why "there is
- *  nothing newer to move to" cannot be read off an empty version list. The
- *  file list is in neither — no Update ever turned on it, and folding it in
- *  would withhold the button over a read it does not depend on. */
+/** How the page's own three reads went. The two that gate Update are kept
+ *  apart rather than folded into one answer: either one failing is a
+ *  package this page could not read, and the timeline's failing on its own
+ *  is separately why "there is nothing newer to move to" cannot be read off
+ *  an empty version list. The file list gates nothing — no Update ever
+ *  turned on it, and folding it into the header would withhold the button
+ *  over a read it does not depend on — but it is a read all the same, and a
+ *  refusal there is not a package that ships no files. */
 export interface PackageReads {
   /** The record that says held or following. */
   record: ReadState;
   /** The timeline Update moves along. */
   timeline: ReadState;
+  /** The files the Overview lists. */
+  files: ReadState;
   /** Whether the newest of these reads is still out. The last answer stays
    *  on screen while it runs — a failure that has not been disproved is
    *  still the truth about this package — so this is what says the reason
@@ -34,3 +41,12 @@ const failedNote = ({ status, error }: ReadState): string | null =>
  *  this ranks and why. */
 export const packageReadNote = (reads: PackageReads): string | null =>
   failedNote(reads.record) ?? failedNote(reads.timeline);
+
+/** What the Overview's file list says instead of files when its read did
+ *  not land, or null while it is pending or once it landed. Its own note,
+ *  not the header's: the header's says why there is no Update, and this read
+ *  never withholds one. */
+export const packageFilesNote = ({ files }: PackageReads): string | null =>
+  files.status === "failed" && files.error !== null
+    ? packageFilesReadFailedNote(files.error)
+    : null;

--- a/ui/src/pages/package.test.tsx
+++ b/ui/src/pages/package.test.tsx
@@ -17,6 +17,10 @@ import {
   OPEN_IN_EDITOR_LABEL,
   OPEN_IN_FILE_BROWSER_LABEL,
   OPEN_IN_LABEL,
+  PACKAGE_FILES_READ_FAILED,
+  PACKAGE_FILES_TITLE,
+  TRY_AGAIN_LABEL,
+  UPDATE_LABEL,
 } from "@/lib/copy";
 import { SAFETY_TAB, SAFETY_VENDOR } from "@/lib/copy-safety";
 import {
@@ -395,6 +399,124 @@ describe("what the package page says instead of Update", () => {
     expect(host.textContent).toContain(EDITED_CANT_UPDATE_NOTE);
     expect(host.textContent).not.toContain(NO_UPDATE_STANDING_NOTE);
     expect(host.textContent).not.toContain(UPDATES_CHECKING);
+  });
+});
+
+// The Overview's file list is the page's third read, and a read that did not
+// land is not a package that ships no files: only a landed read may leave the
+// column empty. The read gates nothing, so it says so where the list would
+// be and offers the read again, while the header's Update stays put.
+describe("the package page's file list", () => {
+  /** A timeline and a record that together earn an Update, so the header
+   *  is what shows whether the file read withholds one. */
+  const openWithUpdate = async () => {
+    vi.mocked(commands.packageVersions).mockResolvedValue({
+      status: "ok",
+      data: [
+        {
+          id: "b".repeat(40),
+          label: "v2",
+          date: "2026-08-28T12:00:00Z",
+          summary: "newer",
+          installed: false,
+          newerThanInstalled: true,
+        },
+        {
+          id: "a".repeat(40),
+          label: "v1",
+          date: "2026-08-01T12:00:00Z",
+          summary: "what is installed",
+          installed: true,
+          newerThanInstalled: false,
+        },
+      ],
+    });
+    vi.mocked(commands.packageMeta).mockResolvedValue({
+      status: "ok",
+      data: {
+        source: "cat",
+        repo: "o/r",
+        repoUrl: null,
+        rev: null,
+        current: null,
+        installedAt: null,
+        harnesses: ["claude"],
+        enabled: true,
+        fork: null,
+        catalog: null,
+      },
+    });
+    useUpdatesStore.setState({ rows: [updateRow(VG)], read: READ_LANDED });
+    return openPage(VG, [VG], { [scopeKey(VG)]: PLAIN });
+  };
+
+  /** The Files section's own Try again, apart from the header's. */
+  const filesRetry = (host: HTMLElement) =>
+    Array.from(host.querySelectorAll("button")).filter(
+      (button) =>
+        button.textContent === TRY_AGAIN_LABEL &&
+        button.closest("header") === null,
+    );
+
+  /** A refusal core sent. Pass-through is the property, so the wording is
+   *  one core never uses. */
+  const REFUSED = "REFUSED-BY-CORE: the install directory is gone";
+
+  it("says the read was refused, offers it again, and keeps Update", async () => {
+    vi.mocked(commands.packageFiles).mockResolvedValue({
+      status: "error",
+      error: REFUSED,
+    });
+    const host = await openWithUpdate();
+
+    expect(host.textContent).toContain(PACKAGE_FILES_TITLE);
+    expect(host.textContent).toContain(
+      `${PACKAGE_FILES_READ_FAILED} — ${REFUSED}`,
+    );
+    expect(filesRetry(host)).toHaveLength(1);
+    expect(header(host)).toContain(UPDATE_LABEL);
+    expect(header(host)).not.toContain(REFUSED);
+
+    // The read again lands, and the list takes the note's place.
+    vi.mocked(commands.packageFiles).mockResolvedValue({
+      status: "ok",
+      data: [{ path: "SKILL.md", size: 10, isReadme: false }],
+    });
+    await userEvent.click(filesRetry(host)[0] as HTMLElement);
+    await settle();
+    expect(host.textContent).toContain("SKILL.md");
+    expect(host.textContent).not.toContain(PACKAGE_FILES_READ_FAILED);
+    expect(filesRetry(host)).toHaveLength(0);
+  });
+
+  // A rejection is the transport failing rather than the engine refusing,
+  // and it reaches the page as the same failed read with the message it
+  // was thrown with.
+  it("says the read was rejected, with the reason it was thrown with", async () => {
+    vi.mocked(commands.packageFiles).mockRejectedValue(
+      new Error("REJECTED-BY-TRANSPORT: bridge closed"),
+    );
+    const host = await openWithUpdate();
+
+    expect(host.textContent).toContain(
+      `${PACKAGE_FILES_READ_FAILED} — REJECTED-BY-TRANSPORT: bridge closed`,
+    );
+    expect(filesRetry(host)).toHaveLength(1);
+    expect(header(host)).toContain(UPDATE_LABEL);
+  });
+
+  // The control: a landed read with nothing in it is the one answer that
+  // may leave the column empty, and it draws no heading and no retry.
+  it("draws nothing for a package that ships no files", async () => {
+    vi.mocked(commands.packageFiles).mockResolvedValue({
+      status: "ok",
+      data: [],
+    });
+    const host = await openWithUpdate();
+
+    expect(host.textContent).not.toContain(PACKAGE_FILES_TITLE);
+    expect(host.textContent).not.toContain(PACKAGE_FILES_READ_FAILED);
+    expect(filesRetry(host)).toHaveLength(0);
   });
 });
 

--- a/ui/src/pages/package.tsx
+++ b/ui/src/pages/package.tsx
@@ -18,7 +18,7 @@ import { groupItems, groupScopes, installationAt } from "@/lib/derive";
 import { packageDisplayName } from "@/lib/labels";
 import { usePackageMark } from "@/lib/package-mark";
 import { vendorAt } from "@/lib/package-places";
-import { packageReadNote } from "@/lib/package-read-state";
+import { packageFilesNote, packageReadNote } from "@/lib/package-read-state";
 import {
   packageRequiredBy,
   packageUpdateNote,
@@ -174,11 +174,13 @@ export function PackagePage() {
       meta={meta}
       versions={versions}
       files={files}
+      filesNote={packageFilesNote(reads)}
       installed={installed}
       view={view}
       setView={setView}
       diff={diff}
       busy={mutating}
+      reading={reads.reading}
       onToggle={(enable) =>
         void inEveryScope((scope) =>
           toggle(scope, group.kind, group.name, enable),


### PR DESCRIPTION
Fixes KEN-1152.

The package page's file read gets its own `ReadState` in `ui/src/lib/package-read-state.ts`, beside the record and timeline reads. A refused or rejected `packageFiles` read now draws the Files heading with the reason the read came back with and a Try again, instead of dropping the section as if the package shipped no files. The read stays out of the Update gate: `packageReadNote` still reads only the record and timeline.

Tests in `ui/src/pages/package.test.tsx` cover a refused read, a rejected read, and the control: a landed read with no files draws no section and no retry. Both new tests fail against the old sidebar.

Local review (reviewer-correctness): pass, 4/4 mutants killed. One suggestion declined for this PR: keeping the last-known file list through a failed re-read. That clearing predates the branch, the record and timeline reads in the same hook clear the same way, and the issue's Requirements name a note and a retry.

Architecture-docs program: KEN-1203.

https://claude.ai/code/session_01P8A1zLbXFHoz8gBEiksGAC
