### PR TITLE
fix(KEN-1142): marketplace identity is core's on every host and drive

### DIFF
--- a/changelog.d/fixed/1142.md
+++ b/changelog.d/fixed/1142.md
@@ -1,0 +1,1 @@
+- Match marketplace pages and the Community list against subscriptions by repository identity on any host, and keep two Windows drives declaring the same folder path as two marketplaces.

--- a/crates/app/src/marketplaces.rs
+++ b/crates/app/src/marketplaces.rs
@@ -73,11 +73,13 @@ pub struct MarketplaceRow {
     /// Where that folder is on this machine, from
     /// [`kendex_core::source::path_root`]: the declaration resolved against
     /// the place that declares it, slashed. A folder marketplace's
-    /// identity, the way `repo_identity` is a repository's — two places
-    /// naming one directory agree here, and two directories never share a
-    /// string, which the spelling alone cannot promise: rootedness is the
-    /// running platform's answer, and a POSIX-rooted path on Windows joins
-    /// onto each declaring scope's own drive.
+    /// identity, the way `repo_identity` is a repository's. Two directories
+    /// never share a string, which the spelling alone cannot promise:
+    /// rootedness is the running platform's answer, and a POSIX-rooted path
+    /// on Windows joins onto each declaring scope's own drive. The join is
+    /// lexical — no `.`/`..` collapse, no symlink or case folding — so one
+    /// directory reached by a `..` spelling is a second card, which only
+    /// over-splits; that card's own places and controls stay right.
     pub resolved_path: Option<String>,
     pub rev: Option<String>,
     /// The commit the subscription reads right now, when the cache holds one.

--- a/crates/app/src/marketplaces.rs
+++ b/crates/app/src/marketplaces.rs
@@ -68,7 +68,17 @@ pub struct MarketplaceRow {
     /// else; this is what a surface folding declarations into one
     /// marketplace has to key on.
     pub repo_identity: Option<String>,
+    /// The declared folder, as the person typed it.
     pub path: Option<String>,
+    /// Where that folder is on this machine, from
+    /// [`kendex_core::source::path_root`]: the declaration resolved against
+    /// the place that declares it, slashed. A folder marketplace's
+    /// identity, the way `repo_identity` is a repository's — two places
+    /// naming one directory agree here, and two directories never share a
+    /// string, which the spelling alone cannot promise: rootedness is the
+    /// running platform's answer, and a POSIX-rooted path on Windows joins
+    /// onto each declaring scope's own drive.
+    pub resolved_path: Option<String>,
     pub rev: Option<String>,
     /// The commit the subscription reads right now, when the cache holds one.
     pub commit: Option<String>,
@@ -136,6 +146,9 @@ pub fn rows(env: &Env, scopes: &[Scope]) -> Result<Vec<MarketplaceRow>, String> 
                     .as_deref()
                     .map(kendex_core::source_ref::repo_identity),
                 repo: row.repo,
+                resolved_path: row.path.as_deref().map(|path| {
+                    kendex_core::paths::slashed(&kendex_core::source::path_root(env, scope, path))
+                }),
                 path: row.path,
                 rev: row.rev,
                 commit: row.commit,

--- a/crates/app/tests/marketplace_rows_resolved_path.rs
+++ b/crates/app/tests/marketplace_rows_resolved_path.rs
@@ -1,0 +1,72 @@
+//! A folder subscription's row carries where the folder is, not only what
+//! was typed.
+//!
+//! The Subscribed grid folds declarations into one card by identity, and a
+//! folder's identity is the directory it resolves to: a relative
+//! declaration under the place that declares it, an absolute one as
+//! written. Which spellings count as absolute is the platform's answer,
+//! carried here from core so no surface above re-derives it — ship the
+//! spelling in this field and this file is what goes red.
+#![cfg(unix)]
+
+#[path = "../../test_util.rs"]
+mod test_util;
+use test_util::{rooted, source_path};
+
+use std::fs;
+use std::path::Path;
+
+use kendex_app::marketplaces::rows;
+use kendex_core::env::{Env, FakeOs};
+use kendex_core::model::Scope;
+
+#[allow(clippy::unwrap_used)]
+fn project(home: &Path, name: &str, source: &str) -> Scope {
+    let root = home.join("dev").join(name);
+    fs::create_dir_all(root.join(".claude")).unwrap();
+    fs::write(
+        root.join("kendex.toml"),
+        format!(
+            "schema = {}\n\n[sources.cat]\n{}\n\n[install]\nharnesses = [\"claude\"]\nmethod = \"symlink\"\n",
+            kendex_core::manifest::MANIFEST_SCHEMA,
+            source
+        ),
+    )
+    .unwrap();
+    Scope::Project { root }
+}
+
+/// Two projects declaring the same relative folder name two directories;
+/// a project declaring an absolute path names that one. Both read off the
+/// row, both distinct from the spelling.
+#[test]
+#[allow(clippy::unwrap_used)]
+fn a_folder_row_resolves_its_path_against_the_declaring_place() {
+    let tmp = tempfile::tempdir().unwrap();
+    let home = rooted(&tmp);
+    let shared = home.join("srv").join("catalog");
+    fs::create_dir_all(&shared).unwrap();
+    let projects = vec![
+        project(&home, "alpha", "path = \"catalog\""),
+        project(&home, "beta", "path = \"catalog\""),
+        project(&home, "gamma", &source_path(&shared)),
+    ];
+    let env = Env::fake(&home, FakeOs::Linux);
+
+    let listed = rows(&env, &projects).unwrap();
+    let resolved: Vec<(Option<&str>, Option<&str>)> = listed
+        .iter()
+        .map(|row| (row.path.as_deref(), row.resolved_path.as_deref()))
+        .collect();
+    let under =
+        |name: &str| kendex_core::paths::slashed(&home.join("dev").join(name).join("catalog"));
+    let shared_slashed = kendex_core::paths::slashed(&shared);
+    assert_eq!(
+        resolved,
+        vec![
+            (Some("catalog"), Some(under("alpha").as_str())),
+            (Some("catalog"), Some(under("beta").as_str())),
+            (Some(shared_slashed.as_str()), Some(shared_slashed.as_str())),
+        ]
+    );
+}

--- a/crates/core/src/registry/view.rs
+++ b/crates/core/src/registry/view.rs
@@ -25,9 +25,14 @@ pub struct DirectoryView {
 #[serde(rename_all = "camelCase")]
 pub struct DirectoryRow {
     pub repo: String,
-    /// The canonical key a subscription's `repo_key` is compared with, so
-    /// the row can flip to Subscribed from the live subscription list.
+    /// The canonical `owner/repo` a blind browse of this row fetches by, and
+    /// what Subscribe is prefilled with.
     pub repo_key: Option<String>,
+    /// One string per repository on any host, from
+    /// [`crate::source_ref::repo_identity`] — what the live subscription
+    /// list's own `repo_identity` is compared with, so the row flips to
+    /// Subscribed however the subscription spells the repository.
+    pub repo_identity: String,
     pub name: String,
     pub description: Option<String>,
     pub tags: Vec<String>,
@@ -48,13 +53,12 @@ pub fn directory(env: &Env, fetch: &dyn Fetch, force_refresh: bool) -> Result<Di
         .into_iter()
         .map(|market| {
             let name = market.name.clone().unwrap_or_else(|| leaf_of(&market.repo));
-            let repo_key = crate::source_ref::owner_repo(&market.repo);
-            let is_subscribed = repo_key
-                .as_ref()
-                .is_some_and(|key| subscribed.contains(key));
+            let repo_identity = crate::source_ref::repo_identity(&market.repo);
+            let is_subscribed = subscribed.contains(&repo_identity);
             DirectoryRow {
+                repo_key: crate::source_ref::owner_repo(&market.repo),
                 repo: market.repo,
-                repo_key,
+                repo_identity,
                 name,
                 description: market.description,
                 tags: market.tags,
@@ -74,12 +78,11 @@ pub fn directory(env: &Env, fetch: &dyn Fetch, force_refresh: bool) -> Result<Di
     })
 }
 
-/// Every repository any scope subscribes to, spelled the one canonical
-/// way.
+/// Every repository any scope subscribes to, by identity.
 fn subscribed_repos(env: &Env) -> Result<BTreeSet<String>> {
     Ok(crate::source_ops::repo_subscriptions(env)?
         .into_iter()
-        .filter_map(|row| row.repo_key)
+        .map(|row| row.repo_identity)
         .collect())
 }
 

--- a/crates/core/src/source.rs
+++ b/crates/core/src/source.rs
@@ -81,9 +81,14 @@ pub fn local_source_root(env: &Env, scope: &Scope) -> PathBuf {
     }
 }
 
-/// Where a declared source's checkout sits on this machine, before asking
-/// whether anything is there.
-fn path_root(env: &Env, scope: &Scope, path: &str) -> PathBuf {
+/// Where a declared folder sits on this machine, before asking whether
+/// anything is there: an absolute path as written, a relative one under the
+/// declaring scope's own root. Rootedness is the platform's answer
+/// (`Path::is_absolute`), so on Windows a POSIX-rooted `/srv/catalog` is
+/// root-relative and joins onto the scope's drive — two scopes on two
+/// drives name two directories, and a surface folding declarations into one
+/// marketplace has to key on this, never on the spelling.
+pub fn path_root(env: &Env, scope: &Scope, path: &str) -> PathBuf {
     if Path::new(path).is_absolute() {
         return PathBuf::from(path);
     }

--- a/crates/core/src/source/browse/opened.rs
+++ b/crates/core/src/source/browse/opened.rs
@@ -25,6 +25,11 @@ pub(crate) struct Browsed {
     pub(crate) config: SourceConfig,
     /// The subscription's name when there is one — see [`Browsed::owned_here`].
     subscription: Option<String>,
+    /// The repository the catalog is declared as, for a remote: the
+    /// declaration's own spelling for a subscription, the canonical
+    /// `owner/repo` for a blind browse. None for a folder or a reserved
+    /// source. What the summary folds into `repo_key` and `repo_identity`.
+    pub(crate) repo: Option<String>,
 }
 
 /// One scope's records, as every installed-state join reads them: what is
@@ -114,7 +119,12 @@ pub(crate) fn open(env: &Env, catalog: &Catalog) -> Result<Browsed> {
         Catalog::Subscription { scope, source } => {
             let records = records(env, scope)?;
             let resolved = require_ready(env, scope, source, &records.manifest)?;
-            browsed(records, resolved, Some(source.clone()))
+            let repo = records
+                .manifest
+                .sources
+                .get(source)
+                .and_then(|decl| decl.repo.clone());
+            browsed(records, resolved, Some(source.clone()), repo)
         }
         Catalog::Repo { repo } => {
             let key = browsable(repo)?;
@@ -143,16 +153,17 @@ pub(crate) fn open_repo(
     let source = ResolvedSource {
         name: key.clone(),
         root: resolution.root,
-        provenance: key,
+        provenance: key.clone(),
         commit: Some(resolution.commit),
     };
-    browsed(records, source, None)
+    browsed(records, source, None, Some(key))
 }
 
 fn browsed(
     records: Records,
     source: ResolvedSource,
     subscription: Option<String>,
+    repo: Option<String>,
 ) -> Result<Browsed> {
     let sealed = SealedSource::open(&source.root)?;
     let config = source_config_for(&sealed, &source.provenance)?;
@@ -162,6 +173,7 @@ fn browsed(
         sealed,
         config,
         subscription,
+        repo,
     })
 }
 

--- a/crates/core/src/source/browse/summary.rs
+++ b/crates/core/src/source/browse/summary.rs
@@ -28,12 +28,18 @@ pub struct SubscriptionRef {
 pub struct CatalogSummary {
     /// What the catalog is, as its declaration spelled it: `owner/repo`
     /// only where it was written that way, a full URL where it was not, a
-    /// path, or `local`. Opaque — `repo_key` below is the folded form.
+    /// path, or `local`. Opaque — the two fields below are the folded forms.
     pub provenance: String,
-    /// The canonical `owner/repo` the provenance folds to on GitHub — what
-    /// a subscription's `repo_key` and a directory row are matched by,
-    /// however the declaration spells it.
+    /// The canonical `owner/repo` the repository folds to on GitHub — what
+    /// a blind browse fetches by and Subscribe is prefilled with. None on
+    /// every other host.
     pub repo_key: Option<String>,
+    /// One string per repository on any host, from
+    /// [`crate::source_ref::repo_identity`] — what a subscription row's
+    /// `repo_identity` is matched against, so a page can tell which
+    /// subscription declares the repository it is looking at wherever it
+    /// is hosted. None for a folder.
+    pub repo_identity: Option<String>,
     /// The commit being read, for a remote.
     pub commit: Option<String>,
     /// `[marketplace]` from the catalog's own kendex.toml.
@@ -65,11 +71,12 @@ pub fn summary(env: &Env, catalog: &Catalog) -> Result<CatalogSummary> {
         ),
         Catalog::Repo { repo } => {
             let key = super::browsable(repo)?;
+            let identity = crate::source_ref::repo_identity(&key);
             // A readable subscription already holds this repository: the
             // page carries on as it, from its own store and without the
             // network — a spelling that keys a different store entry must
             // not turn an offline open into a failed fetch.
-            if let Some(held) = subscribed_as(env, &key)? {
+            if let Some(held) = subscribed_as(env, &identity)? {
                 (open_held(env, &held)?, None, Some(held))
             } else {
                 let resolution = crate::remote::sync(env, &key, None)?;
@@ -77,7 +84,7 @@ pub fn summary(env: &Env, catalog: &Catalog) -> Result<CatalogSummary> {
                 // The fetch may be the one a never-fetched subscription
                 // under this spelling was waiting for: it is Ready now, and
                 // the page carries on as it rather than offering Subscribe.
-                match subscribed_as(env, &key)? {
+                match subscribed_as(env, &identity)? {
                     Some(held) => (open_held(env, &held)?, warning, Some(held)),
                     None => (super::open_repo(env, key, resolution)?, warning, None),
                 }
@@ -95,7 +102,14 @@ pub fn summary(env: &Env, catalog: &Catalog) -> Result<CatalogSummary> {
         }
     }
     Ok(CatalogSummary {
-        repo_key: crate::source_ref::owner_repo(&browsed.source.provenance),
+        repo_key: browsed
+            .repo
+            .as_deref()
+            .and_then(crate::source_ref::owner_repo),
+        repo_identity: browsed
+            .repo
+            .as_deref()
+            .map(crate::source_ref::repo_identity),
         provenance: browsed.source.provenance.clone(),
         commit: browsed.source.commit.clone(),
         meta: browsed.config.marketplace.clone(),
@@ -144,15 +158,15 @@ pub fn about(env: &Env, catalog: &Catalog) -> Result<CatalogAbout> {
 }
 
 /// The first subscription, personal scope first, that points at this
-/// repository however it spells it and can be read right now. One that is
-/// turned off or never fetched resolves as not Ready and is passed over:
-/// the page just read the repository, and switching onto a subscription
-/// whose content is unreachable would trade that for an empty page. A
-/// manifest that cannot be read fails the summary instead of making its
-/// subscription disappear.
-fn subscribed_as(env: &Env, key: &str) -> Result<Option<SubscriptionRef>> {
+/// repository — matched by identity, so however it spells it — and can be
+/// read right now. One that is turned off or never fetched resolves as not
+/// Ready and is passed over: the page just read the repository, and
+/// switching onto a subscription whose content is unreachable would trade
+/// that for an empty page. A manifest that cannot be read fails the summary
+/// instead of making its subscription disappear.
+fn subscribed_as(env: &Env, identity: &str) -> Result<Option<SubscriptionRef>> {
     for row in crate::source_ops::repo_subscriptions(env)? {
-        if row.repo_key.as_deref() != Some(key) {
+        if row.repo_identity != identity {
             continue;
         }
         let Some(manifest) =

--- a/crates/core/src/source/browse/tests/repo.rs
+++ b/crates/core/src/source/browse/tests/repo.rs
@@ -84,6 +84,10 @@ fn the_summary_counts_and_names_the_head_and_knows_no_subscription() {
     let first = summary(&env, &repo()).unwrap();
     assert_eq!(first.provenance, REPO);
     assert_eq!(first.repo_key.as_deref(), Some(REPO));
+    assert_eq!(
+        first.repo_identity.as_deref(),
+        Some("github.com/owner/repo")
+    );
     assert!(first.commit.is_some());
     assert_eq!(first.counts.get("skill"), Some(&1));
     assert_eq!(

--- a/crates/core/src/source/browse/tests/summary.rs
+++ b/crates/core/src/source/browse/tests/summary.rs
@@ -27,6 +27,7 @@ fn a_subscription_summary_answers_with_itself_and_counts_its_offer() {
     );
     assert_eq!(report.provenance, crate::paths::slashed(&catalog));
     assert_eq!(report.repo_key, None, "a path is no GitHub repository");
+    assert_eq!(report.repo_identity, None, "a path is no repository at all");
     assert_eq!(report.commit, None);
     assert_eq!(report.warning, None);
     assert_eq!(report.counts.get("skill"), Some(&2));

--- a/crates/core/src/source/tests.rs
+++ b/crates/core/src/source/tests.rs
@@ -80,6 +80,10 @@ fn an_absolute_path_is_one_directory_from_every_scope() {
     };
     assert_eq!(
         path_root(&env, &alpha, "/srv/catalog"),
+        PathBuf::from("/srv/catalog")
+    );
+    assert_eq!(
+        path_root(&env, &alpha, "/srv/catalog"),
         path_root(&env, &beta, "/srv/catalog")
     );
     assert_eq!(

--- a/crates/core/src/source/tests.rs
+++ b/crates/core/src/source/tests.rs
@@ -34,6 +34,68 @@ fn remote_without_cache_is_pending_not_an_error() {
     ));
 }
 
+/// Rootedness is the platform's answer, not the spelling's. On Windows a
+/// POSIX-rooted declaration is root-relative, so two scopes on two drives
+/// declaring `/srv/catalog` name two directories; a surface keying on the
+/// spelling would fold them into one marketplace.
+#[cfg(windows)]
+#[test]
+fn a_posix_rooted_path_joins_onto_each_scopes_own_drive() {
+    let tmp = tempfile::tempdir().unwrap();
+    let env = Env::fake(tmp.path(), FakeOs::Windows);
+    let on_c = Scope::Project {
+        root: PathBuf::from(r"C:\work\alpha"),
+    };
+    let on_d = Scope::Project {
+        root: PathBuf::from(r"D:\work\beta"),
+    };
+    assert_eq!(
+        path_root(&env, &on_c, "/srv/catalog"),
+        PathBuf::from(r"C:\srv\catalog")
+    );
+    assert_eq!(
+        path_root(&env, &on_d, "/srv/catalog"),
+        PathBuf::from(r"D:\srv\catalog")
+    );
+    assert_eq!(
+        path_root(&env, &on_d, r"E:\srv\catalog"),
+        PathBuf::from(r"E:\srv\catalog"),
+        "a drive-rooted path is absolute and stays as written"
+    );
+}
+
+/// The portable twin: where the platform reads `/srv/catalog` as absolute,
+/// every scope resolves it to the one directory, and only a relative
+/// declaration is re-rooted per scope.
+#[cfg(not(windows))]
+#[test]
+fn an_absolute_path_is_one_directory_from_every_scope() {
+    let tmp = tempfile::tempdir().unwrap();
+    let env = Env::fake(tmp.path(), FakeOs::Linux);
+    let alpha = Scope::Project {
+        root: PathBuf::from("/work/alpha"),
+    };
+    let beta = Scope::Project {
+        root: PathBuf::from("/work/beta"),
+    };
+    assert_eq!(
+        path_root(&env, &alpha, "/srv/catalog"),
+        path_root(&env, &beta, "/srv/catalog")
+    );
+    assert_eq!(
+        path_root(&env, &alpha, "catalog"),
+        PathBuf::from("/work/alpha/catalog")
+    );
+    assert_eq!(
+        path_root(&env, &beta, "catalog"),
+        PathBuf::from("/work/beta/catalog")
+    );
+    assert_eq!(
+        path_root(&env, &Scope::Global, "catalog"),
+        env.home.join("catalog")
+    );
+}
+
 #[test]
 fn path_sources_resolve_relative_to_scope_root() {
     let tmp = tempfile::tempdir().unwrap();

--- a/crates/core/src/source_ops/repos.rs
+++ b/crates/core/src/source_ops/repos.rs
@@ -13,8 +13,14 @@ pub struct RepoSubscription {
     pub scope: Scope,
     pub name: String,
     /// The declaration's repository, canonical `owner/repo` where it is one
-    /// on GitHub — the key the directory and the blind browse match by.
+    /// on GitHub — the shorthand a blind browse fetches by.
     pub repo_key: Option<String>,
+    /// One string per repository on any host, from
+    /// [`crate::source_ref::repo_identity`] — what the directory join and
+    /// the blind browse match a declaration by. `repo_key` answers only for
+    /// GitHub, so it cannot tell a GitLab or self-hosted declaration from
+    /// no declaration at all.
+    pub repo_identity: String,
 }
 
 /// Every remote subscription across the personal scope and every project,
@@ -43,6 +49,7 @@ pub fn repo_subscriptions(env: &Env) -> Result<Vec<RepoSubscription>> {
                 scope: scope.clone(),
                 name: name.clone(),
                 repo_key: crate::source_ref::owner_repo(repo),
+                repo_identity: crate::source_ref::repo_identity(repo),
             });
         }
     }
@@ -72,16 +79,19 @@ mod tests {
         .unwrap();
 
         let rows = repo_subscriptions(&env).unwrap();
-        let key_of = |name: &str| {
-            rows.iter()
-                .find(|row| row.name == name)
-                .expect(name)
-                .repo_key
-                .clone()
-        };
-        assert_eq!(key_of("https").as_deref(), Some("owner/repo"));
-        assert_eq!(key_of("ssh").as_deref(), Some("owner/repo"));
-        assert_eq!(key_of("elsewhere"), None);
+        let row_of = |name: &str| rows.iter().find(|row| row.name == name).expect(name);
+        assert_eq!(row_of("https").repo_key.as_deref(), Some("owner/repo"));
+        assert_eq!(row_of("ssh").repo_key.as_deref(), Some("owner/repo"));
+        assert_eq!(row_of("elsewhere").repo_key, None);
+        // The key stops at GitHub; the identity names every host, so a
+        // GitLab declaration is matchable rather than indistinguishable
+        // from no declaration.
+        assert_eq!(row_of("https").repo_identity, "github.com/owner/repo");
+        assert_eq!(row_of("ssh").repo_identity, "github.com/owner/repo");
+        assert_eq!(
+            row_of("elsewhere").repo_identity,
+            "git@gitlab.com:owner/repo"
+        );
         assert!(
             rows.iter().all(|row| row.name != "here"),
             "a path is not a repository"

--- a/crates/core/tests/registry.rs
+++ b/crates/core/tests/registry.rs
@@ -95,6 +95,60 @@ fn a_malformed_manifest_fails_the_directory_subscription_join() {
     ));
 }
 
+/// The join matches by identity, so a subscription spelled as a URL flips
+/// the row the directory lists as `owner/repo`; the row also carries the
+/// identity itself, for the live list the app compares it with later, and
+/// the shorthand a blind browse fetches by.
+#[test]
+fn a_directory_row_is_subscribed_by_identity_however_the_manifest_spells_it() {
+    let dir = tempfile::tempdir().unwrap();
+    let root = rooted(&dir);
+    let env = env_in(&root);
+    let manifest = env.global_manifest_file();
+    std::fs::create_dir_all(manifest.parent().unwrap()).unwrap();
+    std::fs::write(
+        &manifest,
+        "schema = 6\n[sources.tools]\nrepo = \"https://github.com/Owner/Repo.git\"\n",
+    )
+    .unwrap();
+    let fetch = Canned::new(vec![ok(
+        200,
+        None,
+        &body_with(r#"{"repo":"owner/repo","name":"repo"},{"repo":"owner/other","name":"other"}"#),
+    )]);
+
+    let view = kendex_core::registry::view::directory(&env, &fetch, true).unwrap();
+    let flags: Vec<(&str, &str, Option<&str>, bool)> = view
+        .rows
+        .iter()
+        .map(|row| {
+            (
+                row.repo.as_str(),
+                row.repo_identity.as_str(),
+                row.repo_key.as_deref(),
+                row.subscribed,
+            )
+        })
+        .collect();
+    assert_eq!(
+        flags,
+        vec![
+            (
+                "owner/repo",
+                "github.com/owner/repo",
+                Some("owner/repo"),
+                true
+            ),
+            (
+                "owner/other",
+                "github.com/owner/other",
+                Some("owner/other"),
+                false
+            ),
+        ]
+    );
+}
+
 #[test]
 fn parse_caps_and_drops_unusable_rows() {
     let many_tags: Vec<String> = (0..20).map(|n| format!(r#""t{n}""#)).collect();

--- a/ui/src/bindings.ts
+++ b/ui/src/bindings.ts
@@ -928,15 +928,23 @@ export type CatalogSummary = {
 	/**
 	 *  What the catalog is, as its declaration spelled it: `owner/repo`
 	 *  only where it was written that way, a full URL where it was not, a
-	 *  path, or `local`. Opaque — `repo_key` below is the folded form.
+	 *  path, or `local`. Opaque — the two fields below are the folded forms.
 	 */
 	provenance: string,
 	/**
-	 *  The canonical `owner/repo` the provenance folds to on GitHub — what
-	 *  a subscription's `repo_key` and a directory row are matched by,
-	 *  however the declaration spells it.
+	 *  The canonical `owner/repo` the repository folds to on GitHub — what
+	 *  a blind browse fetches by and Subscribe is prefilled with. None on
+	 *  every other host.
 	 */
 	repoKey: string | null,
+	/**
+	 *  One string per repository on any host, from
+	 *  [`crate::source_ref::repo_identity`] — what a subscription row's
+	 *  `repo_identity` is matched against, so a page can tell which
+	 *  subscription declares the repository it is looking at wherever it
+	 *  is hosted. None for a folder.
+	 */
+	repoIdentity: string | null,
 	/**  The commit being read, for a remote. */
 	commit: string | null,
 	/**  `[marketplace]` from the catalog's own kendex.toml. */
@@ -1177,10 +1185,17 @@ export type DirectoryPackage = {
 export type DirectoryRow = {
 	repo: string,
 	/**
-	 *  The canonical key a subscription's `repo_key` is compared with, so
-	 *  the row can flip to Subscribed from the live subscription list.
+	 *  The canonical `owner/repo` a blind browse of this row fetches by, and
+	 *  what Subscribe is prefilled with.
 	 */
 	repoKey: string | null,
+	/**
+	 *  One string per repository on any host, from
+	 *  [`crate::source_ref::repo_identity`] — what the live subscription
+	 *  list's own `repo_identity` is compared with, so the row flips to
+	 *  Subscribed however the subscription spells the repository.
+	 */
+	repoIdentity: string,
 	name: string,
 	description: string | null,
 	tags: string[],
@@ -2138,7 +2153,19 @@ export type MarketplaceRow = {
 	 *  marketplace has to key on.
 	 */
 	repoIdentity: string | null,
+	/**  The declared folder, as the person typed it. */
 	path: string | null,
+	/**
+	 *  Where that folder is on this machine, from
+	 *  [`kendex_core::source::path_root`]: the declaration resolved against
+	 *  the place that declares it, slashed. A folder marketplace's
+	 *  identity, the way `repo_identity` is a repository's — two places
+	 *  naming one directory agree here, and two directories never share a
+	 *  string, which the spelling alone cannot promise: rootedness is the
+	 *  running platform's answer, and a POSIX-rooted path on Windows joins
+	 *  onto each declaring scope's own drive.
+	 */
+	resolvedPath: string | null,
 	rev: string | null,
 	/**  The commit the subscription reads right now, when the cache holds one. */
 	commit: string | null,

--- a/ui/src/bindings.ts
+++ b/ui/src/bindings.ts
@@ -2159,11 +2159,13 @@ export type MarketplaceRow = {
 	 *  Where that folder is on this machine, from
 	 *  [`kendex_core::source::path_root`]: the declaration resolved against
 	 *  the place that declares it, slashed. A folder marketplace's
-	 *  identity, the way `repo_identity` is a repository's — two places
-	 *  naming one directory agree here, and two directories never share a
-	 *  string, which the spelling alone cannot promise: rootedness is the
-	 *  running platform's answer, and a POSIX-rooted path on Windows joins
-	 *  onto each declaring scope's own drive.
+	 *  identity, the way `repo_identity` is a repository's. Two directories
+	 *  never share a string, which the spelling alone cannot promise:
+	 *  rootedness is the running platform's answer, and a POSIX-rooted path
+	 *  on Windows joins onto each declaring scope's own drive. The join is
+	 *  lexical — no `.`/`..` collapse, no symlink or case folding — so one
+	 *  directory reached by a `..` spelling is a second card, which only
+	 *  over-splits; that card's own places and controls stay right.
 	 */
 	resolvedPath: string | null,
 	rev: string | null,

--- a/ui/src/components/marketplaces/community-tab.test.tsx
+++ b/ui/src/components/marketplaces/community-tab.test.tsx
@@ -15,6 +15,7 @@ vi.mock("./skillssh-search", () => ({
 const listed = (over: Partial<DirectoryRow> = {}): DirectoryRow => ({
   repo: "acme/kit",
   repoKey: "acme/kit",
+  repoIdentity: "github.com/acme/kit",
   name: "kit",
   description: null,
   tags: [],

--- a/ui/src/components/marketplaces/detail-header.test.tsx
+++ b/ui/src/components/marketplaces/detail-header.test.tsx
@@ -53,6 +53,7 @@ const BASE: MarketplaceRow = {
   repoIdentity: "github.com/acme/kit",
   provenance: null,
   path: null,
+  resolvedPath: null,
   rev: null,
   commit: null,
   enabled: true,
@@ -115,6 +116,7 @@ describe("the header's links out", () => {
     const listed: DirectoryRow = {
       repo: LISTED_REPO,
       repoKey: null,
+      repoIdentity: "https://gitlab.example/acme/kit",
       name: "Kit",
       description: null,
       tags: [],

--- a/ui/src/components/marketplaces/directory-card.test.tsx
+++ b/ui/src/components/marketplaces/directory-card.test.tsx
@@ -7,6 +7,7 @@ import { DirectoryCard } from "./directory-card";
 const listed = (over: Partial<DirectoryRow> = {}): DirectoryRow => ({
   repo: "Acme/Kit",
   repoKey: "acme/kit",
+  repoIdentity: "github.com/acme/kit",
   name: "kit",
   description: "Skills for the Acme stack.",
   tags: [],

--- a/ui/src/components/marketplaces/marketplace-places.test.tsx
+++ b/ui/src/components/marketplaces/marketplace-places.test.tsx
@@ -17,6 +17,7 @@ const row = (over: Partial<MarketplaceRow> = {}): MarketplaceRow => ({
   repoIdentity: "github.com/acme/kit",
   provenance: "Acme/Kit",
   path: null,
+  resolvedPath: null,
   rev: null,
   commit: null,
   enabled: true,

--- a/ui/src/components/marketplaces/packages-tab.test.tsx
+++ b/ui/src/components/marketplaces/packages-tab.test.tsx
@@ -20,6 +20,7 @@ const kit: MarketplaceRow = {
   repoIdentity: "github.com/acme/kit",
   provenance: null,
   path: null,
+  resolvedPath: null,
   rev: null,
   commit: null,
   enabled: true,

--- a/ui/src/components/marketplaces/packages-table.test.tsx
+++ b/ui/src/components/marketplaces/packages-table.test.tsx
@@ -297,6 +297,7 @@ describe("the row action on a repository nobody subscribes to", () => {
     // spelling — without it the table cannot tell whether anything already
     // declares the repository, and offers nothing.
     repoKey: "acme/kit",
+    repoIdentity: "github.com/acme/kit",
     name: "kit",
     description: null,
     tags: [],
@@ -316,6 +317,7 @@ describe("the row action on a repository nobody subscribes to", () => {
     repoIdentity: "github.com/acme/kit",
     provenance: repo,
     path: null,
+    resolvedPath: null,
     rev: null,
     commit: null,
     enabled: false,

--- a/ui/src/components/marketplaces/packages-table.tsx
+++ b/ui/src/components/marketplaces/packages-table.tsx
@@ -5,7 +5,7 @@ import {
   type PackageEntry,
   PackageRow,
 } from "@/components/marketplaces/package-row";
-import { useRepoKey } from "@/components/marketplaces/repo-action";
+import { useBrowsedRepo } from "@/components/marketplaces/repo-action";
 import {
   Table,
   TableBody,
@@ -95,7 +95,7 @@ export function PackagesTable({
 }) {
   // A bare repository's table is one catalog's; the cross-marketplace tab
   // only ever carries subscriptions. So what the repository offers is
-  // decided once for the table, from the same key and the same
+  // decided once for the table, from the same identity and the same
   // `repoAction` the page header reads — a cell deciding for itself would
   // offer a Subscribe the engine refuses whenever a switched-off
   // subscription already declared the repository. The sentence is said
@@ -110,8 +110,8 @@ export function PackagesTable({
   const summary = useMarketplacesStore(
     (s) => s.summaries[catalogKey({ by: "repo", repo: browsedRepo })] ?? null,
   );
-  const repoKey = useRepoKey(browsedRepo, summary);
-  const { kind } = repoAction(rows, read, repoKey);
+  const { identity } = useBrowsedRepo(browsedRepo, summary);
+  const { kind } = repoAction(rows, read, identity);
   // Only an undeclared repository can be subscribed from a row. A declared
   // one — switched off, or unreadable — is the header's Turn on or
   // Refresh, and a second control here would race it.

--- a/ui/src/components/marketplaces/repo-action.dom.test.tsx
+++ b/ui/src/components/marketplaces/repo-action.dom.test.tsx
@@ -30,6 +30,7 @@ const listing: DirectoryView = {
     {
       repo: "acme/kit",
       repoKey: "acme/kit",
+      repoIdentity: "github.com/acme/kit",
       name: "kit",
       description: null,
       tags: [],
@@ -133,6 +134,7 @@ describe("turning a declared repository back on", () => {
     repoIdentity: "github.com/acme/kit",
     provenance: "acme/kit",
     path: null,
+    resolvedPath: null,
     rev: null,
     commit: null,
     enabled: false,
@@ -167,5 +169,52 @@ describe("turning a declared repository back on", () => {
     toggle.mockReset();
     await userEvent.click(turnOn());
     expect(toggle).toHaveBeenCalledWith(holder.scope, "beta-kit", true);
+  });
+});
+
+// A repository on another host has no GitHub key, so the page matches it
+// by the identity the listing and the live list both carry from core. Read
+// off the key, the page would see nothing to match and offer a Subscribe
+// the engine refuses as a duplicate.
+describe("a repository page on another host", () => {
+  const gitlab = "https://gitlab.com/acme/kit";
+  const listedElsewhere: DirectoryView = {
+    ...listing,
+    rows: [
+      { ...listing.rows[0], repo: gitlab, repoKey: null, repoIdentity: gitlab },
+    ],
+  };
+  const holder: MarketplaceRow = {
+    scope: { scope: "project", root: "/w/beta" },
+    name: "kit",
+    repo: gitlab,
+    repoKey: null,
+    repoIdentity: gitlab,
+    provenance: gitlab,
+    path: null,
+    resolvedPath: null,
+    rev: null,
+    commit: null,
+    enabled: false,
+    counts: null,
+    meta: null,
+    mode: null,
+    recordsUnreadable: false,
+  };
+
+  const drawElsewhere = (rows: MarketplaceRow[]) => {
+    useCommunityStore.setState({ directory: listedElsewhere });
+    useMarketplacesStore.setState({ rows, read: READ_LANDED });
+    return mount(
+      <RepoAction repo={gitlab} summary={null} subscribeLabel="Subscribe" />,
+    );
+  };
+
+  it("turns on the declaration that holds it", () => {
+    expect(buttons(drawElsewhere([holder]))).toEqual(["Turn on in beta"]);
+  });
+
+  it("offers Subscribe where nothing declares it", () => {
+    expect(buttons(drawElsewhere([]))).toEqual(["Subscribe"]);
   });
 });

--- a/ui/src/components/marketplaces/repo-action.tsx
+++ b/ui/src/components/marketplaces/repo-action.tsx
@@ -10,19 +10,26 @@ import { cn } from "@/lib/utils";
 import { useCommunityStore } from "@/stores/community";
 import { repoAction, useMarketplacesStore } from "@/stores/marketplaces";
 
-/** The canonical key for a bare repository, from core rather than from the
- * spelling the page was opened with: the summary's once the fetch lands,
- * the directory listing's until then. Every surface deciding what a bare
- * repository offers reads it here — spelled twice, one of the two settles
- * on a spelling of its own and offers a Subscribe the engine refuses. */
-export function useRepoKey(
+/** How a bare repository is known, from core rather than from the spelling
+ * the page was opened with: the summary's answer once the fetch lands, the
+ * directory listing's until then. `identity` is core's `repo_identity`, the
+ * one string per repository on any host that the live subscription list is
+ * matched by; `key` is the GitHub `owner/repo` a subscription is prefilled
+ * with, null on every other host. Every surface deciding what a bare
+ * repository offers reads both here — spelled twice, one of the two
+ * settles on a spelling of its own and offers a Subscribe the engine
+ * refuses. */
+export function useBrowsedRepo(
   repo: string,
   summary: CatalogSummary | null,
-): string | null {
-  const listedKey = useCommunityStore(
-    (s) => s.directory?.rows.find((r) => r.repo === repo)?.repoKey ?? null,
+): { identity: string | null; key: string | null } {
+  const listed = useCommunityStore(
+    (s) => s.directory?.rows.find((r) => r.repo === repo) ?? null,
   );
-  return summary?.repoKey ?? listedKey;
+  return {
+    identity: summary?.repoIdentity ?? listed?.repoIdentity ?? null,
+    key: summary?.repoKey ?? listed?.repoKey ?? null,
+  };
 }
 
 /** What one place is called among every place the overview knows. The
@@ -56,19 +63,19 @@ export function RepoAction({
   const checkForUpdates = useMarketplacesStore((s) => s.checkForUpdates);
   const busy = useMarketplacesStore((s) => s.busy);
   const load = useMarketplacesStore((s) => s.load);
-  const key = useRepoKey(repo, summary);
-  const { kind, holder } = repoAction(rows, read, key);
+  const { identity, key } = useBrowsedRepo(repo, summary);
+  const { kind, holder } = repoAction(rows, read, identity);
 
   switch (kind) {
     // Nothing to match the repository against yet, for either of two
-    // reasons: no canonical key, or no rows any read produced. Only the
-    // second is the overview's to fix, and `load` is the only thing that
-    // writes `read` — so Try again is offered where pressing it can lift
-    // the state, and a key still on its way keeps the wait it is really
+    // reasons: no identity, or no rows any read produced. Only the second
+    // is the overview's to fix, and `load` is the only thing that writes
+    // `read` — so Try again is offered where pressing it can lift the
+    // state, and an identity still on its way keeps the wait it is really
     // in. A retry that changed nothing visible would be the same dead
     // control under a friendlier word.
     case "checking":
-      return read.status === "failed" && key !== null ? (
+      return read.status === "failed" && identity !== null ? (
         <Button
           size="sm"
           variant="outline"

--- a/ui/src/components/marketplaces/subscribed-card.test.tsx
+++ b/ui/src/components/marketplaces/subscribed-card.test.tsx
@@ -18,6 +18,7 @@ const row = (over: Partial<MarketplaceRow> = {}): MarketplaceRow => ({
   repoIdentity: "github.com/acme/kit",
   provenance: "Acme/Kit",
   path: null,
+  resolvedPath: null,
   rev: null,
   commit: null,
   enabled: true,

--- a/ui/src/components/marketplaces/subscribed-grouping.test.ts
+++ b/ui/src/components/marketplaces/subscribed-grouping.test.ts
@@ -12,6 +12,7 @@ const row = (over: Partial<MarketplaceRow> = {}): MarketplaceRow => ({
   repoIdentity: "github.com/acme/kit",
   provenance: "Acme/Kit",
   path: null,
+  resolvedPath: null,
   rev: null,
   commit: null,
   enabled: true,
@@ -58,6 +59,52 @@ describe("what makes two declarations one marketplace", () => {
       }),
     ]);
     expect(groups).toHaveLength(2);
+  });
+});
+
+// A folder's identity is the directory core resolved it to, never the
+// spelling. Which spellings are absolute is the running platform's answer:
+// on Windows `/srv/catalog` is root-relative and joins onto each declaring
+// scope's own drive, so a personal manifest on `C:` and a project on `D:`
+// name two directories under one spelling. Read off the spelling, the two
+// fold into one card whose switch and Unsubscribe aim at the other's
+// subscription; read off the resolved path, one directory declared twice
+// still folds.
+describe("what makes two folder declarations one marketplace", () => {
+  const folder = (
+    scope: Scope,
+    path: string,
+    resolvedPath: string,
+  ): MarketplaceRow =>
+    row({
+      scope,
+      name: "catalog",
+      repo: null,
+      repoKey: null,
+      repoIdentity: null,
+      provenance: resolvedPath,
+      path,
+      resolvedPath,
+    });
+
+  it("keeps one spelling apart where it resolves to two directories", () => {
+    const groups = groupByMarketplace([
+      folder({ scope: "global" }, "/srv/catalog", "C:/srv/catalog"),
+      folder(project("D:/work/beta"), "/srv/catalog", "D:/srv/catalog"),
+    ]);
+    expect(groups.map((group) => group.key)).toEqual([
+      "C:/srv/catalog",
+      "D:/srv/catalog",
+    ]);
+  });
+
+  it("folds two places resolving to one directory", () => {
+    const groups = groupByMarketplace([
+      folder({ scope: "global" }, "/srv/catalog", "/srv/catalog"),
+      folder(project("/work/beta"), "../../srv/catalog", "/srv/catalog"),
+    ]);
+    expect(groups).toHaveLength(1);
+    expect(groups[0].places).toHaveLength(2);
   });
 });
 

--- a/ui/src/components/marketplaces/subscribed-grouping.test.ts
+++ b/ui/src/components/marketplaces/subscribed-grouping.test.ts
@@ -100,10 +100,10 @@ describe("what makes two folder declarations one marketplace", () => {
 
   it("folds two places resolving to one directory", () => {
     const groups = groupByMarketplace([
-      folder({ scope: "global" }, "/srv/catalog", "/srv/catalog"),
-      folder(project("/work/beta"), "../../srv/catalog", "/srv/catalog"),
+      folder({ scope: "global" }, "/work/beta/catalog", "/work/beta/catalog"),
+      folder(project("/work/beta"), "catalog", "/work/beta/catalog"),
     ]);
-    expect(groups).toHaveLength(1);
+    expect(groups.map((group) => group.key)).toEqual(["/work/beta/catalog"]);
     expect(groups[0].places).toHaveLength(2);
   });
 });

--- a/ui/src/components/marketplaces/subscribed-grouping.ts
+++ b/ui/src/components/marketplaces/subscribed-grouping.ts
@@ -43,13 +43,15 @@ export interface SubscribedMarketplace {
  * A local folder has no repository, so the directory it resolves to is the
  * identity: `resolvedPath` is core's `source::path_root` over the
  * declaration, an absolute path as written and a relative one under the
- * declaring scope's own root. So `./catalog` in three places is three
+ * declaring scope's own root. So `catalog` in three places is three
  * strings, and `/srv/catalog` declared twice is one — where the running
  * platform reads it as absolute. Which spellings are absolute is that
  * platform's answer, which is why this reads the resolved path rather than
  * the declaration: on Windows `/srv/catalog` is root-relative and joins
  * onto each declaring scope's own drive, so a personal manifest on `C:`
- * and a project on `D:` name two directories, and core says so.
+ * and a project on `D:` name two directories, and core says so. The join
+ * is lexical, so a `..` spelling of a directory another place names
+ * outright is a second card: over-split, never the under-split above.
  *
  * The alias is the last resort for a declaration carrying neither. It
  * usually over-splits, which is harmless — but two scopes declaring such a

--- a/ui/src/components/marketplaces/subscribed-grouping.ts
+++ b/ui/src/components/marketplaces/subscribed-grouping.ts
@@ -26,7 +26,8 @@ export interface SubscribedMarketplace {
 
 /** What makes two declarations the same marketplace, spelled once for
  * every surface that folds them: the card grid, the Projects section, and
- * the page that asks the section which marketplace it is looking at.
+ * the page that asks the section which marketplace it is looking at. Both
+ * halves are core's answer, read off the row and never re-derived here.
  *
  * `repoIdentity` is core's `source_ref::repo_identity` — one string per
  * repository on any host, the same value subscription dedup and update
@@ -39,45 +40,24 @@ export interface SubscribedMarketplace {
  * become `kit` — two unrelated marketplaces in one card, with the Projects
  * section aiming its switch and its Unsubscribe at the wrong subscription.
  *
- * A local folder has no repository, so its path is the identity — but only
- * an absolute one names the same directory from every place. `row.path` is
- * the declaration verbatim, and `source::path_root` resolves a relative one
- * against each scope's own root: `env.home` personally, the project root in
- * a project. So `./catalog` is three different folders across three places
- * under one string, and the scope has to be part of the key. Absolute paths
- * stay shared, because two places naming `/srv/catalog` really are looking
- * at one catalog.
- *
- * That holds for a path spelled in the running platform's own shape, and
- * only there: this reads rootedness from the string, accepting both
- * platforms' shapes, while `path_root` asks `Path::is_absolute`, which
- * answers for one. On Unix `C:/catalog` is re-rooted per scope and keyed
- * here as one folder; a POSIX-rooted path on Windows mirrors it. Core
- * shipping the resolved path would close that.
+ * A local folder has no repository, so the directory it resolves to is the
+ * identity: `resolvedPath` is core's `source::path_root` over the
+ * declaration, an absolute path as written and a relative one under the
+ * declaring scope's own root. So `./catalog` in three places is three
+ * strings, and `/srv/catalog` declared twice is one — where the running
+ * platform reads it as absolute. Which spellings are absolute is that
+ * platform's answer, which is why this reads the resolved path rather than
+ * the declaration: on Windows `/srv/catalog` is root-relative and joins
+ * onto each declaring scope's own drive, so a personal manifest on `C:`
+ * and a project on `D:` name two directories, and core says so.
  *
  * The alias is the last resort for a declaration carrying neither. It
  * usually over-splits, which is harmless — but two scopes declaring such a
  * source under one alias share `row.name`, so it can under-split too;
  * `list_subscriptions` emits those rows rather than skipping them, though
  * they resolve to nothing and offer no packages. */
-export const marketplaceIdentity = (row: MarketplaceRow): string => {
-  if (row.repoIdentity) return row.repoIdentity;
-  if (row.path)
-    return absolutePath(row.path)
-      ? row.path
-      : `${scopeLabel(row.scope)}:${row.path}`;
-  return row.name;
-};
-
-/** A path spelled as rooted: POSIX-rooted, a Windows drive, or a UNC share.
- * Everything else — `./x`, `~/x`, `x/y` — is resolved against the reading
- * scope's own root. Both platforms' shapes are accepted here, so this
- * answers what a path is spelled as, not what the running platform will
- * treat it as; the block above says what that costs. */
-const absolutePath = (path: string): boolean =>
-  path.startsWith("/") ||
-  /^[a-zA-Z]:[\\/]/.test(path) ||
-  path.startsWith("\\\\");
+export const marketplaceIdentity = (row: MarketplaceRow): string =>
+  row.repoIdentity ?? row.resolvedPath ?? row.name;
 
 /** Personal leads, then projects in the order the overview listed them.
  * Total, so a sort cannot be handed -1 for both (a,b) and (b,a): shared

--- a/ui/src/components/marketplaces/subscribed-tab.test.tsx
+++ b/ui/src/components/marketplaces/subscribed-tab.test.tsx
@@ -49,6 +49,7 @@ const kept: MarketplaceRow = {
   repoIdentity: "github.com/acme/kit",
   provenance: null,
   path: null,
+  resolvedPath: null,
   rev: null,
   commit: null,
   enabled: true,

--- a/ui/src/stores/marketplaces-load.test.ts
+++ b/ui/src/stores/marketplaces-load.test.ts
@@ -28,6 +28,7 @@ const kept: MarketplaceRow = {
   repoIdentity: "github.com/acme/kit",
   provenance: null,
   path: null,
+  resolvedPath: null,
   rev: null,
   commit: null,
   enabled: true,

--- a/ui/src/stores/marketplaces-shared.ts
+++ b/ui/src/stores/marketplaces-shared.ts
@@ -60,11 +60,15 @@ export const catalogKey = (catalog: Catalog): string =>
     ? marketKey(catalog.scope, catalog.source)
     : JSON.stringify(["repo", catalog.repo]);
 
-/** The repositories the live subscription list holds, by canonical key —
- * what a Community row's Subscribed marker reads, so it flips the moment
- * a subscription lands or goes, wherever that happened. */
+/** The repositories the live subscription list holds, by identity — core's
+ * `repo_identity`, one string per repository on any host, the same value a
+ * directory row and a summary carry. What a Community row's Subscribed
+ * marker reads, so it flips the moment a subscription lands or goes,
+ * wherever that happened. Never `repoKey`: that is the GitHub `owner/repo`
+ * and null everywhere else, so keying on it would read a GitLab or
+ * self-hosted subscription as no subscription at all. */
 export const subscribedKeys = (rows: MarketplaceRow[]): Set<string> =>
-  new Set(rows.flatMap((row) => (row.repoKey ? [row.repoKey] : [])));
+  new Set(rows.flatMap((row) => (row.repoIdentity ? [row.repoIdentity] : [])));
 
 /** The subscription the live list already declares for a repository the
  * page is browsing bare — `summary` left it bare because that subscription
@@ -72,10 +76,10 @@ export const subscribedKeys = (rows: MarketplaceRow[]): Set<string> =>
  * duplicate. An enabled one outranks a disabled one. */
 export const declaredHolder = (
   rows: MarketplaceRow[],
-  repoKey: string,
+  identity: string,
 ): MarketplaceRow | null =>
-  rows.find((row) => row.repoKey === repoKey && row.enabled) ??
-  rows.find((row) => row.repoKey === repoKey) ??
+  rows.find((row) => row.repoIdentity === identity && row.enabled) ??
+  rows.find((row) => row.repoIdentity === identity) ??
   null;
 
 /** A Community row's Subscribed marker. The directory's own flag is only
@@ -83,10 +87,9 @@ export const declaredHolder = (
  * list alone decides, so an unsubscribe clears the marker as surely as a
  * subscribe sets it. */
 export const rowSubscribed = (
-  row: { repoKey: string | null; subscribed: boolean },
+  row: { repoIdentity: string; subscribed: boolean },
   live: Set<string> | null,
-): boolean =>
-  live ? row.repoKey !== null && live.has(row.repoKey) : row.subscribed;
+): boolean => (live ? live.has(row.repoIdentity) : row.subscribed);
 
 /** One curated set's cache and error key, in its own namespace so a set
  * named like a read ("packages") can never land on that read's key.
@@ -196,10 +199,10 @@ export async function openLead(scope: Scope, source: string, lead: string) {
 }
 
 /** What a page browsing a bare repository offers, decided from the live
- * subscription list and the repository's canonical key.
+ * subscription list and the repository's identity.
  *
  * Two things have to be known first, or Subscribe is offered on a guess and
- * a declared repository refuses it. The key, which comes from the
+ * a declared repository refuses it. The identity, which comes from the
  * directory's row or the summary and never from the requested spelling,
  * which may differ in case. And rows some read actually produced: with none,
  * every repository looks undeclared, and a read that has not landed is no
@@ -208,33 +211,30 @@ export async function openLead(scope: Scope, source: string, lead: string) {
  * whatever they were wrong about — so it is the emptiness that holds the
  * page neutral, not the failure.
  *
- * A key that never arrives is a different thing from one still on its way.
- * `repoKey` is the GitHub `owner/repo` and is null on every other host, so
- * a bare GitLab or self-hosted page waits on an answer no read will ever
- * bring: "Checking subscriptions…", disabled, for as long as the page is
- * open. Once the read has settled, that page is told what this build can
- * actually tell it — nothing here declares the repository — and Subscribe
- * is offered. Being wrong there costs a refusal the engine spells out;
- * being permanently pending costs the page its only control. An exact
- * answer needs `repo_identity` carried onto the summary and the directory
- * row. */
+ * An identity that never arrives is a different thing from one still on its
+ * way. A page the directory does not list waits on its summary, and a
+ * summary that failed brings none: once the list read has settled, that
+ * page is told what this build can tell it — nothing here declares the
+ * repository — and Subscribe is offered. Being wrong there costs a refusal
+ * the engine spells out; being permanently pending costs the page its only
+ * control. */
 type RepoActionKind = "checking" | "subscribe" | "turn-on" | "refresh";
 
 export function repoAction(
   rows: MarketplaceRow[],
   read: ReadState,
-  repoKey: string | null,
+  identity: string | null,
 ): { kind: RepoActionKind; holder: MarketplaceRow | null } {
-  // Unanswered: a key a read still out may yet bring, or rows no read has
-  // produced.
-  if (repoKey === null && read.status === "pending") {
+  // Unanswered: an identity a read still out may yet bring, or rows no read
+  // has produced.
+  if (identity === null && read.status === "pending") {
     return { kind: "checking", holder: null };
   }
   if (read.status !== "landed" && rows.length === 0) {
     return { kind: "checking", holder: null };
   }
-  if (repoKey === null) return { kind: "subscribe", holder: null };
-  const holder = declaredHolder(rows, repoKey);
+  if (identity === null) return { kind: "subscribe", holder: null };
+  const holder = declaredHolder(rows, identity);
   if (!holder) return { kind: "subscribe", holder: null };
   return { kind: holder.enabled ? "refresh" : "turn-on", holder };
 }

--- a/ui/src/stores/marketplaces-subscribed.test.ts
+++ b/ui/src/stores/marketplaces-subscribed.test.ts
@@ -27,6 +27,7 @@ vi.mock("./scan", () => ({
 const listed: DirectoryRow = {
   repo: "Acme/Kit",
   repoKey: "acme/kit",
+  repoIdentity: "github.com/acme/kit",
   name: "kit",
   description: null,
   tags: [],
@@ -48,6 +49,7 @@ const row = (repo: string, repoKey: string | null): MarketplaceRow => ({
   repoIdentity: repoKey ? `github.com/${repoKey}` : repo,
   provenance: repo,
   path: null,
+  resolvedPath: null,
   rev: null,
   commit: null,
   enabled: true,
@@ -83,7 +85,9 @@ describe("a Community row's Subscribed marker", () => {
       data: [row("https://github.com/Acme/Kit.git", "acme/kit")],
     });
     expect(
-      subscribedKeys(useMarketplacesStore.getState().rows).has("acme/kit"),
+      subscribedKeys(useMarketplacesStore.getState().rows).has(
+        "github.com/acme/kit",
+      ),
     ).toBe(false);
 
     // Subscribe answers with the alias it declared, so a caller that goes
@@ -94,7 +98,25 @@ describe("a Community row's Subscribed marker", () => {
 
     expect(outcome).toEqual({ name: "kit" });
     const held = subscribedKeys(useMarketplacesStore.getState().rows);
-    expect(listed.repoKey !== null && held.has(listed.repoKey)).toBe(true);
+    expect(held.has(listed.repoIdentity)).toBe(true);
+  });
+
+  // The set holds identities, not GitHub keys: a GitLab subscription has
+  // no `repoKey`, and a set built from keys would read it as no
+  // subscription — a card never marked Subscribed for it, and a Subscribe
+  // offered that the engine refuses as a duplicate.
+  it("marks a non-GitHub row Subscribed from its identity", () => {
+    const gitlab = "https://gitlab.com/acme/kit";
+    const live = subscribedKeys([row(gitlab, null)]);
+    expect(
+      rowSubscribed({ repoIdentity: gitlab, subscribed: false }, live),
+    ).toBe(true);
+    expect(
+      rowSubscribed(
+        { repoIdentity: "https://gitlab.com/acme/other", subscribed: true },
+        live,
+      ),
+    ).toBe(false);
   });
 
   // A subscribe plans the whole scope, so its plan can take a package away

--- a/ui/src/stores/marketplaces-summary.test.ts
+++ b/ui/src/stores/marketplaces-summary.test.ts
@@ -41,6 +41,7 @@ describe("a repository's summary", () => {
       data: {
         provenance: "acme/kit",
         repoKey: "acme/kit",
+        repoIdentity: "github.com/acme/kit",
         commit: null,
         meta: null,
         mode: "discovered",

--- a/ui/src/stores/marketplaces-toggle.test.ts
+++ b/ui/src/stores/marketplaces-toggle.test.ts
@@ -35,6 +35,7 @@ const row = (repo: string, repoKey: string | null): MarketplaceRow => ({
   repoIdentity: repoKey ? `github.com/${repoKey}` : repo,
   provenance: repo,
   path: null,
+  resolvedPath: null,
   rev: null,
   commit: null,
   enabled: true,
@@ -91,7 +92,7 @@ describe("a bare repository page's action", () => {
 
     const held = declaredHolder(
       useMarketplacesStore.getState().rows,
-      "acme/kit",
+      "github.com/acme/kit",
     );
     expect(held?.enabled).toBe(false);
     expect(held?.name).toBe("kit");
@@ -141,23 +142,43 @@ describe("a bare repository page's action", () => {
     expect(toast.message).not.toHaveBeenCalled();
   });
 
-  it("stays neutral until the canonical key is known, then matches by it", () => {
+  it("stays neutral until the identity is known, then matches by it", () => {
     const disabled = { ...row("acme/kit", "acme/kit"), enabled: false };
     // The page was opened as "Acme/Kit": before the summary or the directory
-    // row supplies the canonical key, no spelling is compared.
+    // row supplies the identity, no spelling is compared.
     expect(repoAction([disabled], READ_PENDING, null).kind).toBe("checking");
-    expect(repoAction([disabled], READ_LANDED, "acme/kit").kind).toBe(
-      "turn-on",
-    );
+    expect(
+      repoAction([disabled], READ_LANDED, "github.com/acme/kit").kind,
+    ).toBe("turn-on");
   });
 
-  // A key that never arrives is not a key still on its way. `repoKey` is
-  // the GitHub owner/repo and is null on every other host, so waiting on it
-  // leaves a bare GitLab page disabled for as long as it is open. Once the
-  // read has settled the page is told what this build can tell it.
-  it("settles rather than waiting for a key no read will bring", () => {
+  // An identity that never arrives is not one still on its way: a page the
+  // directory does not list waits on its summary, and a failed summary
+  // brings none. Once the list read has settled the page is told what this
+  // build can tell it.
+  it("settles rather than waiting for an identity no read will bring", () => {
     const disabled = { ...row("acme/kit", "acme/kit"), enabled: false };
     expect(repoAction([disabled], READ_LANDED, null).kind).toBe("subscribe");
+  });
+
+  // The identity is core's `repo_identity`, one string per repository on
+  // any host — so a GitLab declaration is found the way a GitHub one is.
+  // `repoKey` is null there, and matching on it would offer a Subscribe the
+  // engine refuses as a duplicate, and never a Turn on for a switched-off
+  // declaration. One declared row and one undeclared repository, so a
+  // comparison that never matches and one that always does each redden a
+  // row.
+  it("matches a non-GitHub repository by identity, declared or not", () => {
+    const gitlab = "https://gitlab.com/acme/kit";
+    const declared = row(gitlab, null);
+    const table: [MarketplaceRow[], string, string][] = [
+      [[declared], gitlab, "refresh"],
+      [[{ ...declared, enabled: false }], gitlab, "turn-on"],
+      [[declared], "https://gitlab.com/acme/other", "subscribe"],
+    ];
+    for (const [rows, identity, kind] of table) {
+      expect(repoAction(rows, READ_LANDED, identity).kind).toBe(kind);
+    }
   });
 
   // Before the first read answers there are no rows to look in, so every
@@ -165,8 +186,12 @@ describe("a bare repository page's action", () => {
   // one this machine already holds — which the engine then refuses as a
   // duplicate, with the person having pressed a button for nothing.
   it("stays neutral while the first read of the list is still out", () => {
-    expect(repoAction([], READ_PENDING, "acme/kit").kind).toBe("checking");
-    expect(repoAction([], READ_LANDED, "acme/kit").kind).toBe("subscribe");
+    expect(repoAction([], READ_PENDING, "github.com/acme/kit").kind).toBe(
+      "checking",
+    );
+    expect(repoAction([], READ_LANDED, "github.com/acme/kit").kind).toBe(
+      "subscribe",
+    );
   });
 
   // A FIRST read that failed leaves no rows at all, so every repository
@@ -174,9 +199,9 @@ describe("a bare repository page's action", () => {
   // then refuses as a duplicate, with the person having pressed a button
   // for nothing.
   it("stays neutral when the first read failed and left no rows", () => {
-    expect(repoAction([], readFailed("offline"), "acme/kit").kind).toBe(
-      "checking",
-    );
+    expect(
+      repoAction([], readFailed("offline"), "github.com/acme/kit").kind,
+    ).toBe("checking");
   });
 
   // A read that failed is not the same: the rows it kept are what this
@@ -184,18 +209,20 @@ describe("a bare repository page's action", () => {
   // about. Holding the page neutral there would leave no way back.
   it("acts on rows a failed read left, rather than going neutral", () => {
     const declared = row("acme/kit", "acme/kit");
-    expect(repoAction([declared], readFailed("offline"), "acme/kit").kind).toBe(
-      "refresh",
-    );
+    expect(
+      repoAction([declared], readFailed("offline"), "github.com/acme/kit").kind,
+    ).toBe("refresh");
   });
 
   it("offers Subscribe only when nothing declares the repository", () => {
     expect(
-      declaredHolder([row("acme/kit", "acme/kit")], "other/repo"),
+      declaredHolder([row("acme/kit", "acme/kit")], "github.com/other/repo"),
     ).toBeNull();
     const enabled = row("acme/kit", "acme/kit");
     const disabled = { ...enabled, name: "old", enabled: false };
-    expect(declaredHolder([disabled, enabled], "acme/kit")?.name).toBe("kit");
+    expect(
+      declaredHolder([disabled, enabled], "github.com/acme/kit")?.name,
+    ).toBe("kit");
   });
 });
 
@@ -206,6 +233,7 @@ describe("a repository page carried on as a subscription", () => {
     const summary = {
       provenance: "acme/kit",
       repoKey: "acme/kit",
+      repoIdentity: "github.com/acme/kit",
       commit: null,
       meta: null,
       mode: "discovered" as const,
@@ -223,6 +251,7 @@ describe("a repository page carried on as a subscription", () => {
           ...summary,
           provenance: "other/repo",
           repoKey: "other/repo",
+          repoIdentity: "github.com/other/repo",
           subscription: { scope: { scope: "global" }, source: "other" },
         },
       },
@@ -254,6 +283,7 @@ describe("a repository page carried on as a subscription", () => {
           // Carried on as the subscription: provenance is its declaration.
           provenance: "git@github.com:acme/kit.git",
           repoKey: "acme/kit",
+          repoIdentity: "github.com/acme/kit",
           commit: null,
           meta: null,
           mode: "discovered",
@@ -288,6 +318,7 @@ describe("a repository page carried on as a subscription", () => {
         [repoKey]: {
           provenance: "acme/kit",
           repoKey: "acme/kit",
+          repoIdentity: "github.com/acme/kit",
           commit: null,
           meta: null,
           mode: "discovered",


### PR DESCRIPTION
Closes KEN-1142.

Core's `source_ref::repo_identity` now rides on `RepoSubscription`, `DirectoryRow` and `CatalogSummary`, and the UI compares it in `repoAction`, `declaredHolder`, `subscribedKeys` and `rowSubscribed` against `MarketplaceRow.repoIdentity`. `subscribed_as` matches by identity. `MarketplaceRow.resolved_path` carries the folder path core resolved (`source::path_root`, slashed), and `marketplaceIdentity` reads it; the UI's `absolutePath` re-derivation is deleted.

Scope note: every shipped producer of a bare repository page validates GitHub `owner/repo` (the directory parser's `repo_ok`, the deep-link parser, `browse::browsable`), so the non-GitHub bare-page symptom in the issue has no producer today. That half unifies the comparison vocabulary. The Windows folder half is reachable from any manifest: `/srv/catalog` declared on `C:` and `D:` now stays two cards.

Controls, each with a must-fail mutation run red: directory join by identity (`crates/core/tests/registry.rs`), summary identity (`browse/tests/{repo,summary}.rs`), `path_root` two-drive case as `#[cfg(windows)]` with a portable twin (`source/tests.rs`), the row's resolved path (`crates/app/tests/marketplace_rows_resolved_path.rs`), non-GitHub declared and undeclared by identity (`marketplaces-toggle.test.ts`, `marketplaces-subscribed.test.ts`, `repo-action.dom.test.tsx`), two drives one spelling two cards (`subscribed-grouping.test.ts`).

Program tracker: KEN-1203.

https://claude.ai/code/session_01VBbkYV7hRJBFeJBq7gJa8y
