### PR TITLE
fix(KEN-1195): restack names its real cause and keeps a guarded exit

### DIFF
--- a/.agents/skills/worktree/scripts/worktree
+++ b/.agents/skills/worktree/scripts/worktree
@@ -133,16 +133,18 @@ Actions:
              and clear the pending authorization; with the paused restack
              already gone, clear the record it left behind
 
-Guarded-restack contract: the actions accept only a registered worktree whose
-worktree-local restack authorization, tool-created state token, and Git
-sequencer metadata agree on the exact remote, branch, observed remote OID,
-original head, and target base. continue and skip re-check the remote before
-and after replay, finalize the exact rewritten-head lease when complete, and
-fail closed on missing, stale, or unrelated state. abort requires the same
-matching local state and clears only the pending authorization; neither remote
-movement nor a HEAD moved off the recorded base blocks it. When no restack is
-paused at all, abort clears the record alone, and only while the recorded
-branch still sits at its recorded original head.
+Guarded-restack contract: while a restack is paused, the actions accept only a
+registered worktree whose worktree-local restack authorization, tool-created
+state token, and Git sequencer metadata agree on the exact remote, branch,
+observed remote OID, original head, and target base. continue and skip re-check
+the remote before and after replay, finalize the exact rewritten-head lease when
+complete, and fail closed on missing, stale, or unrelated state. abort requires
+that same state except HEAD's own position, which it restores, and remote
+movement does not block it. With no restack paused there is no sequencer state
+to agree with, so abort takes the record alone: it requires the recorded branch
+to still be at its recorded original head, checks that branch out, clears the
+record, and re-applies worktree setup, refusing and keeping the record when the
+branch has moved or the checkout fails.
 EOF
 }
 
@@ -2649,16 +2651,17 @@ validate_pending_restack_state() {
   fi
   if [[ "$mode" == replay ]]; then
     # Replay analog of the rebase metadata cross-check: the sequencer's head
-    # is the detach point (the recorded base), HEAD is still detached, and the
-    # branch ref has not moved off the recorded original head — the replay
-    # moves it only after the whole range succeeds.
+    # is the detach point (the recorded base) and the branch ref has not moved
+    # off the recorded original head — the replay moves it only after the whole
+    # range succeeds. Those two pin the state for every action. HEAD being
+    # detached is where continue and skip pick onto, so only they require it.
     if [[ ! -f "$state_dir/head" ]]; then
       restack_state_refusal "$wt" "missing required Git sequencer metadata"
       return 1
     fi
     replay_head="$(head -n 1 "$state_dir/head" 2>/dev/null || true)"
     if [[ "$replay_head" != "$base_oid" ]] || \
-       [[ -n "$(git -C "$wt" branch --show-current 2>/dev/null || true)" ]] || \
+       { [[ "$action" != abort ]] && [[ -n "$(git -C "$wt" branch --show-current 2>/dev/null || true)" ]]; } || \
        [[ "$(git -C "$wt" rev-parse "refs/heads/$stored_branch" 2>/dev/null || true)" != "$original_head" ]]; then
       restack_state_refusal "$wt" "not the replay recorded by the worktree tool"
       return 1
@@ -2678,9 +2681,10 @@ validate_pending_restack_state() {
     fi
   fi
   # continue and skip replay onto the recorded base, so HEAD has to still sit
-  # on it. abort restores the recorded original head out of the paused state's
-  # own metadata, which the cross-check above already matched, whatever HEAD
-  # reached in between: refusing there leaves no guarded exit at all (#1195).
+  # on it. abort unwinds through Git's own paused state, which the cross-check
+  # above matched against the record, and its post-conditions verify the
+  # restored branch and head: refusing here on HEAD's position alone left the
+  # worktree with no guarded exit (#1195).
   if ! git -C "$wt" cat-file -e "${original_head}^{commit}" 2>/dev/null || \
      ! git -C "$wt" cat-file -e "${base_oid}^{commit}" 2>/dev/null || \
      { [[ "$action" != abort ]] && ! git -C "$wt" merge-base --is-ancestor "$base_oid" HEAD; }; then
@@ -2751,6 +2755,64 @@ report_paused_restack() {
   fi
   echo "To restore the pre-restack branch: $0 restack abort \"$wt\"" >&2
   echo "Recorded branch: $branch" >&2
+}
+
+# The tail both abort paths share: drop the pending authorization, release the
+# claim lock, and re-apply the setup a paused restack un-shadowed. Only the
+# closing message differs.
+finish_guarded_restack_abort() {
+  local wt="$1" done_message="$2"
+  cancel_pending_restack_authorization "$wt"
+  release_issue_claim_lock
+  if ! setup_app_worktree "$wt"; then
+    echo "Warning: Restack was aborted successfully, but worktree setup could not be reapplied. Fix the WORKTREE_* configuration, then run: $0 fix-links '$wt'" >&2
+  fi
+  echo "$done_message"
+}
+
+# Git's paused state can be gone while the tool's own record stands: an
+# out-of-band 'git rebase --abort' or '--quit', or an abort whose restore check
+# refused after Git had already unwound. Nothing can continue or abort a rebase
+# that is not running, and every guarded control refuses a missing paused
+# state, so abort is the only way to drop that record — without it the exit is
+# unsetting the kendex-restack keys by hand (#1195). Returns 2 when the record
+# is not orphaned after all, for the caller to hand to the guarded controls.
+abort_orphaned_restack_record() {
+  local wt="$1" branch="" head="" checkout_err=""
+  if ! is_registered_project_worktree "$wt"; then
+    restack_state_refusal "$wt" "not a registered worktree of this repository"
+    return 1
+  fi
+  branch="$(restack_state_get "$wt" branch)"
+  head="$(restack_state_get "$wt" originalHead)"
+  if [[ -z "$branch" || -z "$head" ]]; then
+    restack_state_refusal "$wt" "missing its tool-created authorization"
+    return 1
+  fi
+  acquire_issue_claim_lock "$branch" || return 1
+  # The lock is what makes the precondition durable. A concurrent
+  # 'create <ID> --restack' holds it across the window where it writes the
+  # record and starts the rebase, so a sample taken before the lock can name a
+  # restack that is live by now, and clearing a live restack's record is not a
+  # closed failure. Re-read both under the lock.
+  if restack_engine_in_progress "$wt" || [[ "$(restack_state_get "$wt" pending)" != true ]]; then
+    release_issue_claim_lock
+    return 2
+  fi
+  if [[ "$(git -C "$wt" rev-parse "refs/heads/$branch" 2>/dev/null || true)" != "$head" ]]; then
+    echo "Error: No restack is paused in $wt, and '$branch' is no longer at its recorded pre-restack commit $head; refusing to clear the recorded state." >&2
+    echo "Something rewrote the branch outside the guarded restack; inspect it before retrying." >&2
+    return 1
+  fi
+  if [[ "$(git -C "$wt" branch --show-current 2>/dev/null || true)" != "$branch" ]] && \
+     ! checkout_err="$(git -C "$wt" checkout "$branch" 2>&1)"; then
+    [[ -n "$checkout_err" ]] && sed 's/^/  git: /' <<<"$checkout_err" >&2
+    echo "Error: Could not reattach $wt to '$branch'; the recorded restack state was preserved." >&2
+    echo "A 'rebase --quit' or 'cherry-pick --quit' leaves the conflicted index in place: stage or discard the paths Git names above." >&2
+    echo "Then re-run: $0 restack abort \"$wt\"" >&2
+    return 1
+  fi
+  finish_guarded_restack_abort "$wt" "No restack was paused; cleared the recorded restack state for $branch: $wt"
 }
 
 open_pr_for_branch() {
@@ -3506,42 +3568,11 @@ case "${1:-}" in
     esac
 
     WT_PATH="$(resolve_restack_worktree "$ARG")"
-    # Git's state can be gone while the tool's own record stands: an
-    # out-of-band `git rebase --abort`, or an abort whose restore check
-    # refused after Git had already unwound. Nothing can continue or abort a
-    # rebase that is not running, and every control below refuses a missing
-    # paused state, so abort is the only guarded way to drop that record —
-    # without it the exit is unsetting the kendex-restack keys by hand (#1195).
     if [[ "$ACTION" == abort ]] && [[ "$(restack_state_get "$WT_PATH" pending)" == true ]] && \
        ! restack_engine_in_progress "$WT_PATH"; then
-      if ! is_registered_project_worktree "$WT_PATH"; then
-        restack_state_refusal "$WT_PATH" "not a registered worktree of this repository"
-        exit 1
-      fi
-      ORPHAN_BRANCH="$(restack_state_get "$WT_PATH" branch)"
-      ORPHAN_HEAD="$(restack_state_get "$WT_PATH" originalHead)"
-      if [[ -z "$ORPHAN_BRANCH" || -z "$ORPHAN_HEAD" ]]; then
-        restack_state_refusal "$WT_PATH" "missing its tool-created authorization"
-        exit 1
-      fi
-      acquire_issue_claim_lock "$ORPHAN_BRANCH" || exit 1
-      if [[ "$(git -C "$WT_PATH" rev-parse "refs/heads/$ORPHAN_BRANCH" 2>/dev/null || true)" != "$ORPHAN_HEAD" ]]; then
-        echo "Error: No restack is paused in $WT_PATH, and '$ORPHAN_BRANCH' is no longer at its recorded pre-restack commit $ORPHAN_HEAD; refusing to clear the recorded state." >&2
-        echo "Something rewrote the branch outside the guarded restack; inspect it before retrying." >&2
-        exit 1
-      fi
-      if [[ "$(git -C "$WT_PATH" branch --show-current 2>/dev/null || true)" != "$ORPHAN_BRANCH" ]] && \
-         ! git -C "$WT_PATH" checkout "$ORPHAN_BRANCH" >/dev/null 2>&1; then
-        echo "Error: Could not reattach $WT_PATH to '$ORPHAN_BRANCH'; the recorded restack state was preserved." >&2
-        exit 1
-      fi
-      cancel_pending_restack_authorization "$WT_PATH"
-      release_issue_claim_lock
-      if ! setup_app_worktree "$WT_PATH"; then
-        echo "Warning: The record was cleared, but worktree setup could not be reapplied. Fix the WORKTREE_* configuration, then run: $0 fix-links '$WT_PATH'" >&2
-      fi
-      echo "No restack was paused; cleared the recorded restack state for $ORPHAN_BRANCH: $WT_PATH"
-      exit 0
+      ORPHAN_STATUS=0
+      abort_orphaned_restack_record "$WT_PATH" || ORPHAN_STATUS=$?
+      [[ "$ORPHAN_STATUS" -eq 2 ]] || exit "$ORPHAN_STATUS"
     fi
     validate_pending_restack_state "$WT_PATH" "$ACTION" || exit 1
     RESTACK_BRANCH="$(restack_state_get "$WT_PATH" branch)"
@@ -3581,12 +3612,7 @@ case "${1:-}" in
           exit 1
         fi
       fi
-      cancel_pending_restack_authorization "$WT_PATH"
-      release_issue_claim_lock
-      if ! setup_app_worktree "$WT_PATH"; then
-        echo "Warning: Restack was aborted successfully, but worktree setup could not be reapplied. Fix the WORKTREE_* configuration, then run: $0 fix-links '$WT_PATH'" >&2
-      fi
-      echo "Aborted guarded restack and restored $RESTACK_BRANCH: $WT_PATH"
+      finish_guarded_restack_abort "$WT_PATH" "Aborted guarded restack and restored $RESTACK_BRANCH: $WT_PATH"
       exit 0
     fi
 
@@ -3624,7 +3650,7 @@ case "${1:-}" in
     fi
 
     if restack_engine_in_progress "$WT_PATH"; then
-      if ! validate_pending_restack_state "$WT_PATH"; then
+      if ! validate_pending_restack_state "$WT_PATH" "$ACTION"; then
         echo "Error: Git changed the paused rebase outside the recorded restack boundary; refusing further control." >&2
         exit 1
       fi

--- a/.agents/skills/worktree/scripts/worktree
+++ b/.agents/skills/worktree/scripts/worktree
@@ -2684,7 +2684,7 @@ validate_pending_restack_state() {
   # on it. abort unwinds through Git's own paused state, which the cross-check
   # above matched against the record, and its post-conditions verify the
   # restored branch and head: refusing here on HEAD's position alone left the
-  # worktree with no guarded exit (#1195).
+  # worktree with no guarded exit.
   if ! git -C "$wt" cat-file -e "${original_head}^{commit}" 2>/dev/null || \
      ! git -C "$wt" cat-file -e "${base_oid}^{commit}" 2>/dev/null || \
      { [[ "$action" != abort ]] && ! git -C "$wt" merge-base --is-ancestor "$base_oid" HEAD; }; then
@@ -2746,7 +2746,7 @@ report_paused_restack() {
     # Git refuses to continue while a tracked file differs from the index and
     # names merge conflicts whatever the real cause. With nothing unmerged,
     # repeating that sends the resolver back to files already staged, and the
-    # empty-commit skip below would drop the commit they just resolved (#1195).
+    # empty-commit skip below would drop the commit they just resolved.
     echo "Restack stopped on unstaged changes, not on unresolved conflicts:" >&2
     sed 's/^/  /' <<<"$unstaged_files" >&2
     echo "Stage or discard them, then run: $0 restack continue \"$wt\"" >&2
@@ -2775,7 +2775,7 @@ finish_guarded_restack_abort() {
 # refused after Git had already unwound. Nothing can continue or abort a rebase
 # that is not running, and every guarded control refuses a missing paused
 # state, so abort is the only way to drop that record — without it the exit is
-# unsetting the kendex-restack keys by hand (#1195). Returns 2 when the record
+# unsetting the kendex-restack keys by hand. Returns 2 when the record
 # is not orphaned after all, for the caller to hand to the guarded controls.
 abort_orphaned_restack_record() {
   local wt="$1" branch="" head="" checkout_err=""

--- a/.agents/skills/worktree/scripts/worktree
+++ b/.agents/skills/worktree/scripts/worktree
@@ -130,7 +130,8 @@ Actions:
   skip       Skip the current commit in that paused restack (use when the
              commit is already represented by the new base)
   abort      Abort that paused restack, restore the recorded original head,
-             and clear the pending authorization
+             and clear the pending authorization; with the paused restack
+             already gone, clear the record it left behind
 
 Guarded-restack contract: the actions accept only a registered worktree whose
 worktree-local restack authorization, tool-created state token, and Git
@@ -138,8 +139,10 @@ sequencer metadata agree on the exact remote, branch, observed remote OID,
 original head, and target base. continue and skip re-check the remote before
 and after replay, finalize the exact rewritten-head lease when complete, and
 fail closed on missing, stale, or unrelated state. abort requires the same
-matching local state and clears only the pending authorization; remote
-movement does not block it.
+matching local state and clears only the pending authorization; neither remote
+movement nor a HEAD moved off the recorded base blocks it. When no restack is
+paused at all, abort clears the record alone, and only while the recorded
+branch still sits at its recorded original head.
 EOF
 }
 
@@ -2601,7 +2604,7 @@ restack_state_refusal() {
 }
 
 validate_pending_restack_state() {
-  local wt="$1" state_dir="" stored_remote="" stored_branch="" stored_expected=""
+  local wt="$1" action="${2:-continue}" state_dir="" stored_remote="" stored_branch="" stored_expected=""
   local original_head="" base_oid="" pending="" state_token="" marker_token=""
   local head_name="" rebase_original="" rebase_onto="" mode="" replay_head=""
 
@@ -2674,9 +2677,13 @@ validate_pending_restack_state() {
       return 1
     fi
   fi
+  # continue and skip replay onto the recorded base, so HEAD has to still sit
+  # on it. abort restores the recorded original head out of the paused state's
+  # own metadata, which the cross-check above already matched, whatever HEAD
+  # reached in between: refusing there leaves no guarded exit at all (#1195).
   if ! git -C "$wt" cat-file -e "${original_head}^{commit}" 2>/dev/null || \
      ! git -C "$wt" cat-file -e "${base_oid}^{commit}" 2>/dev/null || \
-     ! git -C "$wt" merge-base --is-ancestor "$base_oid" HEAD; then
+     { [[ "$action" != abort ]] && ! git -C "$wt" merge-base --is-ancestor "$base_oid" HEAD; }; then
     restack_state_refusal "$wt" "stale or no longer based on its recorded commits"
     return 1
   fi
@@ -2723,13 +2730,22 @@ resolve_restack_worktree() {
 }
 
 report_paused_restack() {
-  local wt="$1" branch="$2" output="$3" conflict_files=""
+  local wt="$1" branch="$2" output="$3" conflict_files="" unstaged_files=""
   [[ -n "$output" ]] && sed 's/^/  git: /' <<<"$output" >&2
   conflict_files="$(git -C "$wt" diff --name-only --diff-filter=U 2>/dev/null || true)"
+  unstaged_files="$(git -C "$wt" diff --name-only 2>/dev/null || true)"
   if [[ -n "$conflict_files" ]]; then
     echo "Restack stopped on conflicts:" >&2
     sed 's/^/  /' <<<"$conflict_files" >&2
     echo "Resolve and stage each file, then run: $0 restack continue \"$wt\"" >&2
+  elif [[ -n "$unstaged_files" ]]; then
+    # Git refuses to continue while a tracked file differs from the index and
+    # names merge conflicts whatever the real cause. With nothing unmerged,
+    # repeating that sends the resolver back to files already staged, and the
+    # empty-commit skip below would drop the commit they just resolved (#1195).
+    echo "Restack stopped on unstaged changes, not on unresolved conflicts:" >&2
+    sed 's/^/  /' <<<"$unstaged_files" >&2
+    echo "Stage or discard them, then run: $0 restack continue \"$wt\"" >&2
   else
     echo "The current replayed commit may be empty; inspect it, then run: $0 restack skip \"$wt\"" >&2
   fi
@@ -3490,12 +3506,49 @@ case "${1:-}" in
     esac
 
     WT_PATH="$(resolve_restack_worktree "$ARG")"
-    validate_pending_restack_state "$WT_PATH" || exit 1
+    # Git's state can be gone while the tool's own record stands: an
+    # out-of-band `git rebase --abort`, or an abort whose restore check
+    # refused after Git had already unwound. Nothing can continue or abort a
+    # rebase that is not running, and every control below refuses a missing
+    # paused state, so abort is the only guarded way to drop that record —
+    # without it the exit is unsetting the kendex-restack keys by hand (#1195).
+    if [[ "$ACTION" == abort ]] && [[ "$(restack_state_get "$WT_PATH" pending)" == true ]] && \
+       ! restack_engine_in_progress "$WT_PATH"; then
+      if ! is_registered_project_worktree "$WT_PATH"; then
+        restack_state_refusal "$WT_PATH" "not a registered worktree of this repository"
+        exit 1
+      fi
+      ORPHAN_BRANCH="$(restack_state_get "$WT_PATH" branch)"
+      ORPHAN_HEAD="$(restack_state_get "$WT_PATH" originalHead)"
+      if [[ -z "$ORPHAN_BRANCH" || -z "$ORPHAN_HEAD" ]]; then
+        restack_state_refusal "$WT_PATH" "missing its tool-created authorization"
+        exit 1
+      fi
+      acquire_issue_claim_lock "$ORPHAN_BRANCH" || exit 1
+      if [[ "$(git -C "$WT_PATH" rev-parse "refs/heads/$ORPHAN_BRANCH" 2>/dev/null || true)" != "$ORPHAN_HEAD" ]]; then
+        echo "Error: No restack is paused in $WT_PATH, and '$ORPHAN_BRANCH' is no longer at its recorded pre-restack commit $ORPHAN_HEAD; refusing to clear the recorded state." >&2
+        echo "Something rewrote the branch outside the guarded restack; inspect it before retrying." >&2
+        exit 1
+      fi
+      if [[ "$(git -C "$WT_PATH" branch --show-current 2>/dev/null || true)" != "$ORPHAN_BRANCH" ]] && \
+         ! git -C "$WT_PATH" checkout "$ORPHAN_BRANCH" >/dev/null 2>&1; then
+        echo "Error: Could not reattach $WT_PATH to '$ORPHAN_BRANCH'; the recorded restack state was preserved." >&2
+        exit 1
+      fi
+      cancel_pending_restack_authorization "$WT_PATH"
+      release_issue_claim_lock
+      if ! setup_app_worktree "$WT_PATH"; then
+        echo "Warning: The record was cleared, but worktree setup could not be reapplied. Fix the WORKTREE_* configuration, then run: $0 fix-links '$WT_PATH'" >&2
+      fi
+      echo "No restack was paused; cleared the recorded restack state for $ORPHAN_BRANCH: $WT_PATH"
+      exit 0
+    fi
+    validate_pending_restack_state "$WT_PATH" "$ACTION" || exit 1
     RESTACK_BRANCH="$(restack_state_get "$WT_PATH" branch)"
     acquire_issue_claim_lock "$RESTACK_BRANCH" || exit 1
     # The first validation gives a useful error without taking a lock. Repeat
     # under the branch claim lock immediately before controlling the rebase.
-    validate_pending_restack_state "$WT_PATH" || exit 1
+    validate_pending_restack_state "$WT_PATH" "$ACTION" || exit 1
     RESTACK_MODE="$(restack_state_get "$WT_PATH" mode)"
 
     if [[ "$ACTION" == abort ]]; then

--- a/.agents/skills/worktree/tests/worktree_atomic_symlink_swap.sh
+++ b/.agents/skills/worktree/tests/worktree_atomic_symlink_swap.sh
@@ -10,6 +10,9 @@
 # and teardown semantics as the Codex pair, for worktrees Claude Code creates
 # itself via its WorktreeCreate hook.
 set -euo pipefail
+# A pre-commit hook exports GIT_DIR and GIT_INDEX_FILE, which point every git
+# call below at the real repository; -C overrides neither.
+unset GIT_DIR GIT_COMMON_DIR GIT_WORK_TREE GIT_INDEX_FILE
 
 TEST_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 WORKTREE_SCRIPT="${WORKTREE_SCRIPT:-$(cd "$TEST_DIR/.." && pwd)/scripts/worktree}"

--- a/.agents/skills/worktree/tests/worktree_autorepair_hooks.sh
+++ b/.agents/skills/worktree/tests/worktree_autorepair_hooks.sh
@@ -16,6 +16,9 @@
 #      the hook warns loudly and names fix-links instead;
 #   4. repair-links is quiet and safe when addressed at the main checkout.
 set -euo pipefail
+# A pre-commit hook exports GIT_DIR and GIT_INDEX_FILE, which point every git
+# call below at the real repository; -C overrides neither.
+unset GIT_DIR GIT_COMMON_DIR GIT_WORK_TREE GIT_INDEX_FILE
 
 TEST_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 SKILL_DIR="$(cd "$TEST_DIR/.." && pwd)"

--- a/.agents/skills/worktree/tests/worktree_base_dir.sh
+++ b/.agents/skills/worktree/tests/worktree_base_dir.sh
@@ -4,6 +4,9 @@
 # canonical (symlink-resolved) path comparisons, and compatibility with
 # worktrees registered under an older base-dir convention.
 set -euo pipefail
+# A pre-commit hook exports GIT_DIR and GIT_INDEX_FILE, which point every git
+# call below at the real repository; -C overrides neither.
+unset GIT_DIR GIT_COMMON_DIR GIT_WORK_TREE GIT_INDEX_FILE
 
 TEST_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 WORKTREE_SCRIPT="${WORKTREE_SCRIPT:-$(cd "$TEST_DIR/.." && pwd)/scripts/worktree}"

--- a/.agents/skills/worktree/tests/worktree_cleanup_merged_pr.sh
+++ b/.agents/skills/worktree/tests/worktree_cleanup_merged_pr.sh
@@ -30,6 +30,9 @@
 #     a moved-on one, and one merged only into its own tracking upstream —
 #     `git branch -d` accepts that last case and does not decide anything.
 set -euo pipefail
+# A pre-commit hook exports GIT_DIR and GIT_INDEX_FILE, which point every git
+# call below at the real repository; -C overrides neither.
+unset GIT_DIR GIT_COMMON_DIR GIT_WORK_TREE GIT_INDEX_FILE
 
 TEST_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 WORKTREE_SCRIPT="$(cd "$TEST_DIR/.." && pwd)/scripts/worktree"

--- a/.agents/skills/worktree/tests/worktree_create_active_guard.sh
+++ b/.agents/skills/worktree/tests/worktree_create_active_guard.sh
@@ -1,6 +1,9 @@
 #!/usr/bin/env bash
 # Tests for active-work ownership guards.
 set -euo pipefail
+# A pre-commit hook exports GIT_DIR and GIT_INDEX_FILE, which point every git
+# call below at the real repository; -C overrides neither.
+unset GIT_DIR GIT_COMMON_DIR GIT_WORK_TREE GIT_INDEX_FILE
 
 TEST_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 WORKTREE_SCRIPT="${WORKTREE_SCRIPT:-$(cd "$TEST_DIR/.." && pwd)/scripts/worktree}"

--- a/.agents/skills/worktree/tests/worktree_create_restack.sh
+++ b/.agents/skills/worktree/tests/worktree_create_restack.sh
@@ -9,8 +9,9 @@
 # delete/recreate). `--restack` must redo the rebase and stop IN the conflict
 # state with guarded continue/skip/abort guidance. A completed supported rewrite must carry
 # an exact, one-worktree push authorization without weakening remote-movement
-# or unexpected-local-divergence rejection. Clean-rebase reuse must keep
-# working unchanged.
+# or unexpected-local-divergence rejection. A sibling suite run under a git
+# hook's exported environment must keep its own sandbox and leave a live
+# authorization alone. Clean-rebase reuse must keep working unchanged.
 set -euo pipefail
 # A pre-commit hook exports GIT_DIR and GIT_INDEX_FILE, which point every git
 # call below at the real repository; -C overrides neither.
@@ -447,7 +448,7 @@ assert_eq "$(git -C "$CHAINED_WT" config --worktree --get kendex-restack.authori
 # `git diff --name-only` lists unmerged paths too, so on a conflicted pause both
 # arms of report_paused_restack match and only their order keeps the conflict
 # message. Nothing else in the repo asserts it, so swapping them would ship the
-# wrong cause green (kendex#1195).
+# wrong cause green.
 PRECEDENCE_ROOT="$TMP_ROOT/precedence"
 make_conflict_pair "$PRECEDENCE_ROOT" issue-precedence
 PRECEDENCE_WT="$PRECEDENCE_ROOT/trees/issue-precedence"
@@ -468,7 +469,7 @@ assert_not_contains "$precedence_err" "unstaged changes" "an unmerged index is n
 # "You must edit all merge conflicts" whatever the real cause. Repeating that
 # against an index with no unmerged paths sends the resolver back to files it
 # already staged, and the empty-commit skip beside it would drop the commit
-# whose conflicts they just resolved (kendex#1195).
+# whose conflicts they just resolved.
 UNSTAGED_ROOT="$TMP_ROOT/unstaged"
 make_conflict_pair "$UNSTAGED_ROOT" issue-unstaged
 UNSTAGED_WT="$UNSTAGED_ROOT/trees/issue-unstaged"
@@ -499,7 +500,7 @@ assert_eq "$(cat "$UNSTAGED_WT/file.txt")" "resolved" "the resumed restack keeps
 # --- A recorded restack whose Git state is gone still has a guarded exit ------
 # Nothing can continue or abort a rebase that is not running, and every control
 # refuses a missing paused state, so without this the tool's own record can only
-# be unset by hand (kendex#1195).
+# be unset by hand.
 ORPHAN_ROOT="$TMP_ROOT/orphan"
 make_conflict_pair "$ORPHAN_ROOT" issue-orphan
 ORPHAN_WT="$ORPHAN_ROOT/trees/issue-orphan"
@@ -523,7 +524,7 @@ assert_eq "$(git -C "$ORPHAN_WT" rev-parse HEAD)" "$orphan_original_head" "guard
 # A live paused restack whose HEAD was moved off the base still aborts. continue
 # and skip replay onto that base and must refuse, but abort restores the
 # recorded original head from the paused state's own metadata, and refusing it
-# here left raw git as the only way out (kendex#1195).
+# here left raw git as the only way out.
 MOVED_HEAD_ROOT="$TMP_ROOT/moved-head"
 make_conflict_pair "$MOVED_HEAD_ROOT" issue-moved-head
 MOVED_HEAD_WT="$MOVED_HEAD_ROOT/trees/issue-moved-head"
@@ -551,7 +552,7 @@ assert_eq "$(git -C "$MOVED_HEAD_WT" config --worktree --get-regexp '^kendex-res
 
 # `--quit` removes Git's state and leaves the index unmerged, so the reattach
 # fails. The refusal must carry Git's own reason and a next step, and must not
-# force the checkout over a resolver's staged work (kendex#1195).
+# force the checkout over a resolver's staged work.
 QUIT_ROOT="$TMP_ROOT/quit"
 make_conflict_pair "$QUIT_ROOT" issue-quit
 QUIT_WT="$QUIT_ROOT/trees/issue-quit"
@@ -575,7 +576,7 @@ assert_ne "$(git -C "$QUIT_WT" ls-files -u)" "" "the refused abort leaves the st
 
 # A foreign repository carrying the same keys is never written to. The orphan
 # block runs before validate_pending_restack_state, so its own registration
-# check is the only thing containing it (kendex#1195).
+# check is the only thing containing it.
 FOREIGN_ROOT="$TMP_ROOT/foreign"
 make_conflict_pair "$FOREIGN_ROOT" issue-foreign
 git init -q -b main "$FOREIGN_ROOT/outsider"
@@ -687,6 +688,34 @@ set -e
 assert_eq "$local_move_code" "1" "unexpected local rewrite is not covered by prior restack authorization"
 assert_eq "$(git --git-dir="$LOCAL_MOVE_ROOT/origin.git" rev-parse refs/heads/issue-local-move)" "$local_move_remote_before" "unexpected local rewrite leaves remote unchanged"
 assert_contains "$(cat "$LOCAL_MOVE_ROOT/push.err")" "not contained in local branch" "unexpected local rewrite reports divergence"
+
+# --- A suite run under a git hook's environment keeps its own sandbox --------
+# A git hook exports GIT_DIR and GIT_INDEX_FILE at the worktree it fires in,
+# and both outrank -C, so a sibling suite run from that context builds its
+# fixtures at that worktree unless it clears them first: it dies at its first
+# fixture, or worse, lands commits there. The battery a restack is verified
+# with runs beside a live authorization, so one is held here across such a
+# run.
+ENV_ROOT="$TMP_ROOT/env-live"
+make_published_clean_pair "$ENV_ROOT" issue-env-live
+ENV_WT="$ENV_ROOT/trees/issue-env-live"
+(cd "$ENV_ROOT/main" && "$WORKTREE_SCRIPT" create issue-env-live --restack >/dev/null 2>"$ENV_ROOT/restack.err")
+env_head="$(git -C "$ENV_WT" rev-parse HEAD)"
+assert_eq "$(git -C "$ENV_WT" config --worktree --get kendex-restack.authorizedHead)" "$env_head" "restack authorizes the live worktree before a suite runs under its environment"
+env_git_dir="$(git -C "$ENV_WT" rev-parse --absolute-git-dir)"
+env_fingerprint() {
+  git -C "$ENV_WT" log --format=%H
+  echo '--'
+  git -C "$ENV_WT" ls-files --stage
+  echo '--'
+  git -C "$ENV_WT" config --worktree --list
+}
+env_before="$(env_fingerprint)"
+env_suite_rc=0
+env GIT_DIR="$env_git_dir" GIT_INDEX_FILE="$env_git_dir/index" \
+  bash "$TEST_DIR/worktree_push_rebase.sh" >"$ENV_ROOT/suite.out" 2>&1 || env_suite_rc=$?
+assert_eq "$env_suite_rc" "0" "a sibling suite passes under an exported git environment"
+assert_eq "$(env_fingerprint)" "$env_before" "that suite left the live worktree's log, index and restack authorization untouched"
 
 # --- Clean-rebase reuse unchanged ----------------------------------------------
 CLEAN_ROOT="$TMP_ROOT/clean"

--- a/.agents/skills/worktree/tests/worktree_create_restack.sh
+++ b/.agents/skills/worktree/tests/worktree_create_restack.sh
@@ -153,7 +153,10 @@ make_repo() {
   git -C "$repo" config user.name Test
   git -C "$repo" config commit.gpgsign false
   printf 'orig\n' > "$repo/file.txt"
-  git -C "$repo" add file.txt
+  # A second tracked file no rebase in this suite touches, so a test can dirty
+  # the worktree without touching the conflicting path.
+  printf 'orig\n' > "$repo/other.txt"
+  git -C "$repo" add file.txt other.txt
   git -C "$repo" commit -q -m base
   # Pin the historical sibling trees/ base so this file's path assertions stay
   # explicit; default base-dir resolution is covered by worktree_base_dir.sh.
@@ -436,6 +439,111 @@ set -e
 assert_eq "$chained_push_code" "0" "consecutive clean restacks push with the original exact lease"
 assert_eq "$(git --git-dir="$CHAINED_ROOT/origin.git" rev-parse refs/heads/issue-chained-restack)" "$chained_second_head" "consecutive restack push publishes the final rewritten head"
 assert_eq "$(git -C "$CHAINED_WT" config --worktree --get kendex-restack.authorizedHead 2>/dev/null || true)" "" "consecutive restack push consumes authorization"
+
+# --- A clean index with unstaged changes is not an unresolved conflict --------
+# Git refuses to continue while a tracked file differs from the index, and says
+# "You must edit all merge conflicts" whatever the real cause. Repeating that
+# against an index with no unmerged paths sends the resolver back to files it
+# already staged, and the empty-commit skip beside it would drop the commit
+# whose conflicts they just resolved (kendex#1195).
+UNSTAGED_ROOT="$TMP_ROOT/unstaged"
+make_conflict_pair "$UNSTAGED_ROOT" issue-unstaged
+UNSTAGED_WT="$UNSTAGED_ROOT/trees/issue-unstaged"
+set +e
+(cd "$UNSTAGED_ROOT/main" && "$WORKTREE_SCRIPT" create issue-unstaged --restack >/dev/null 2>&1)
+set -e
+printf 'resolved\n' > "$UNSTAGED_WT/file.txt"
+git -C "$UNSTAGED_WT" add file.txt
+printf 'edited after staging\n' > "$UNSTAGED_WT/other.txt"
+assert_eq "$(git -C "$UNSTAGED_WT" ls-files -u)" "" "the unstaged-change fixture leaves no unmerged index entry"
+set +e
+(cd "$UNSTAGED_ROOT/main" && "$WORKTREE_SCRIPT" restack continue issue-unstaged >/dev/null 2>"$UNSTAGED_ROOT/continue.err")
+unstaged_code=$?
+set -e
+unstaged_err="$(cat "$UNSTAGED_ROOT/continue.err")"
+assert_eq "$unstaged_code" "1" "guarded continue over unstaged changes exits 1"
+assert_contains "$unstaged_err" "unstaged changes" "the refusal names unstaged changes as the real cause"
+assert_contains "$unstaged_err" "other.txt" "the refusal names the unstaged file"
+assert_not_contains "$unstaged_err" "may be empty" "a clean index is not reported as an empty commit"
+assert_not_contains "$unstaged_err" "restack skip" "a clean index does not offer the skip that would drop the resolved commit"
+assert_rebase_in_progress "$UNSTAGED_WT" "the refused continuation leaves the restack paused"
+assert_eq "$(git -C "$UNSTAGED_WT" config --worktree --get kendex-restack.pending)" "true" "the refused continuation keeps its pending authorization"
+git -C "$UNSTAGED_WT" checkout -- other.txt
+unstaged_out=$(cd "$UNSTAGED_ROOT/main" && "$WORKTREE_SCRIPT" restack continue issue-unstaged 2>"$UNSTAGED_ROOT/resume.err")
+assert_contains "$unstaged_out" "Completed guarded restack" "discarding the unstaged change resumes the same guarded restack"
+assert_eq "$(cat "$UNSTAGED_WT/file.txt")" "resolved" "the resumed restack keeps the resolution staged before the refusal"
+
+# --- A recorded restack whose Git state is gone still has a guarded exit ------
+# Nothing can continue or abort a rebase that is not running, and every control
+# refuses a missing paused state, so without this the tool's own record can only
+# be unset by hand (kendex#1195).
+ORPHAN_ROOT="$TMP_ROOT/orphan"
+make_conflict_pair "$ORPHAN_ROOT" issue-orphan
+ORPHAN_WT="$ORPHAN_ROOT/trees/issue-orphan"
+set +e
+(cd "$ORPHAN_ROOT/main" && "$WORKTREE_SCRIPT" create issue-orphan --restack >/dev/null 2>&1)
+set -e
+orphan_original_head="$(git -C "$ORPHAN_WT" config --worktree --get kendex-restack.originalHead)"
+git -C "$ORPHAN_WT" rebase --abort
+assert_no_rebase_in_progress "$ORPHAN_WT" "the out-of-band abort removed the Git rebase state"
+assert_eq "$(git -C "$ORPHAN_WT" config --worktree --get kendex-restack.pending)" "true" "the tool's own restack record outlives the Git state"
+set +e
+orphan_out=$(cd "$ORPHAN_ROOT/main" && "$WORKTREE_SCRIPT" restack abort issue-orphan 2>"$ORPHAN_ROOT/abort.err")
+orphan_code=$?
+set -e
+assert_eq "$orphan_code" "0" "guarded abort exits 0 when only the tool's record is left"
+assert_contains "$orphan_out" "cleared the recorded restack state" "guarded abort clears a record whose paused rebase is gone"
+assert_eq "$(git -C "$ORPHAN_WT" config --worktree --get-regexp '^kendex-restack\.' || true)" "" "guarded abort leaves no kendex-restack key to unset by hand"
+assert_eq "$(git -C "$ORPHAN_WT" branch --show-current)" "issue-orphan" "guarded abort leaves the worktree on its recorded branch"
+assert_eq "$(git -C "$ORPHAN_WT" rev-parse HEAD)" "$orphan_original_head" "guarded abort leaves the branch at its recorded original head"
+
+# A live paused restack whose HEAD was moved off the base still aborts. continue
+# and skip replay onto that base and must refuse, but abort restores the
+# recorded original head from the paused state's own metadata, and refusing it
+# here left raw git as the only way out (kendex#1195).
+MOVED_HEAD_ROOT="$TMP_ROOT/moved-head"
+make_conflict_pair "$MOVED_HEAD_ROOT" issue-moved-head
+MOVED_HEAD_WT="$MOVED_HEAD_ROOT/trees/issue-moved-head"
+moved_head_original="$(git -C "$MOVED_HEAD_WT" rev-parse HEAD)"
+set +e
+(cd "$MOVED_HEAD_ROOT/main" && "$WORKTREE_SCRIPT" create issue-moved-head --restack >/dev/null 2>&1)
+set -e
+git -C "$MOVED_HEAD_WT" checkout -f issue-moved-head >/dev/null 2>&1
+assert_rebase_in_progress "$MOVED_HEAD_WT" "the raw checkout leaves the paused rebase in place"
+set +e
+(cd "$MOVED_HEAD_ROOT/main" && "$WORKTREE_SCRIPT" restack continue issue-moved-head >/dev/null 2>"$MOVED_HEAD_ROOT/continue.err")
+moved_head_continue_code=$?
+set -e
+assert_eq "$moved_head_continue_code" "1" "guarded continue still refuses a HEAD moved off the recorded base"
+assert_contains "$(cat "$MOVED_HEAD_ROOT/continue.err")" "no longer based on its recorded commits" "the continue refusal names the moved base"
+set +e
+moved_head_out=$(cd "$MOVED_HEAD_ROOT/main" && "$WORKTREE_SCRIPT" restack abort issue-moved-head 2>"$MOVED_HEAD_ROOT/abort.err")
+moved_head_abort_code=$?
+set -e
+assert_eq "$moved_head_abort_code" "0" "guarded abort exits 0 with HEAD moved off the recorded base"
+assert_contains "$moved_head_out" "Aborted guarded restack" "guarded abort reports the restored branch"
+assert_no_rebase_in_progress "$MOVED_HEAD_WT" "guarded abort clears the paused rebase"
+assert_eq "$(git -C "$MOVED_HEAD_WT" rev-parse HEAD)" "$moved_head_original" "guarded abort restores the recorded original head"
+assert_eq "$(git -C "$MOVED_HEAD_WT" config --worktree --get-regexp '^kendex-restack\.' || true)" "" "guarded abort leaves no kendex-restack key to unset by hand"
+
+# A record whose branch no longer matches is refused, not silently dropped.
+MOVED_ORPHAN_ROOT="$TMP_ROOT/orphan-moved"
+make_conflict_pair "$MOVED_ORPHAN_ROOT" issue-orphan-moved
+MOVED_ORPHAN_WT="$MOVED_ORPHAN_ROOT/trees/issue-orphan-moved"
+set +e
+(cd "$MOVED_ORPHAN_ROOT/main" && "$WORKTREE_SCRIPT" create issue-orphan-moved --restack >/dev/null 2>&1)
+set -e
+git -C "$MOVED_ORPHAN_WT" rebase --abort
+printf 'later\n' > "$MOVED_ORPHAN_WT/later.txt"
+git -C "$MOVED_ORPHAN_WT" add later.txt
+git -C "$MOVED_ORPHAN_WT" commit -q -m 'work committed after the restack record'
+set +e
+(cd "$MOVED_ORPHAN_ROOT/main" && "$WORKTREE_SCRIPT" restack abort issue-orphan-moved >/dev/null 2>"$MOVED_ORPHAN_ROOT/abort.err")
+moved_orphan_code=$?
+set -e
+assert_eq "$moved_orphan_code" "1" "a record whose branch moved off its recorded head is refused"
+assert_contains "$(cat "$MOVED_ORPHAN_ROOT/abort.err")" "no longer at its recorded pre-restack commit" "the refusal names why the record cannot be cleared"
+assert_eq "$(git -C "$MOVED_ORPHAN_WT" config --worktree --get kendex-restack.pending)" "true" "the refused abort preserves the recorded state"
 
 # --- Remote movement while conflict resolution is pending fails closed -------
 PENDING_MOVE_ROOT="$TMP_ROOT/pending-move"

--- a/.agents/skills/worktree/tests/worktree_create_restack.sh
+++ b/.agents/skills/worktree/tests/worktree_create_restack.sh
@@ -12,6 +12,9 @@
 # or unexpected-local-divergence rejection. Clean-rebase reuse must keep
 # working unchanged.
 set -euo pipefail
+# A pre-commit hook exports GIT_DIR and GIT_INDEX_FILE, which point every git
+# call below at the real repository; -C overrides neither.
+unset GIT_DIR GIT_COMMON_DIR GIT_WORK_TREE GIT_INDEX_FILE
 
 TEST_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 WORKTREE_SCRIPT="${WORKTREE_SCRIPT:-$(cd "$TEST_DIR/.." && pwd)/scripts/worktree}"
@@ -440,6 +443,26 @@ assert_eq "$chained_push_code" "0" "consecutive clean restacks push with the ori
 assert_eq "$(git --git-dir="$CHAINED_ROOT/origin.git" rev-parse refs/heads/issue-chained-restack)" "$chained_second_head" "consecutive restack push publishes the final rewritten head"
 assert_eq "$(git -C "$CHAINED_WT" config --worktree --get kendex-restack.authorizedHead 2>/dev/null || true)" "" "consecutive restack push consumes authorization"
 
+# --- A real conflict outranks the unstaged arm --------------------------------
+# `git diff --name-only` lists unmerged paths too, so on a conflicted pause both
+# arms of report_paused_restack match and only their order keeps the conflict
+# message. Nothing else in the repo asserts it, so swapping them would ship the
+# wrong cause green (kendex#1195).
+PRECEDENCE_ROOT="$TMP_ROOT/precedence"
+make_conflict_pair "$PRECEDENCE_ROOT" issue-precedence
+PRECEDENCE_WT="$PRECEDENCE_ROOT/trees/issue-precedence"
+set +e
+(cd "$PRECEDENCE_ROOT/main" && "$WORKTREE_SCRIPT" create issue-precedence --restack >/dev/null 2>&1)
+(cd "$PRECEDENCE_ROOT/main" && "$WORKTREE_SCRIPT" restack continue issue-precedence >/dev/null 2>"$PRECEDENCE_ROOT/continue.err")
+precedence_code=$?
+set -e
+precedence_err="$(cat "$PRECEDENCE_ROOT/continue.err")"
+assert_ne "$(git -C "$PRECEDENCE_WT" ls-files -u)" "" "the precedence fixture leaves the index unmerged"
+assert_eq "$precedence_code" "1" "guarded continue over an unresolved conflict exits 1"
+assert_contains "$precedence_err" "Restack stopped on conflicts:" "an unmerged index is reported as a conflict"
+assert_contains "$precedence_err" "file.txt" "the conflict report names the conflicting file"
+assert_not_contains "$precedence_err" "unstaged changes" "an unmerged index is never reported as unstaged changes"
+
 # --- A clean index with unstaged changes is not an unresolved conflict --------
 # Git refuses to continue while a tracked file differs from the index, and says
 # "You must edit all merge conflicts" whatever the real cause. Repeating that
@@ -525,6 +548,53 @@ assert_contains "$moved_head_out" "Aborted guarded restack" "guarded abort repor
 assert_no_rebase_in_progress "$MOVED_HEAD_WT" "guarded abort clears the paused rebase"
 assert_eq "$(git -C "$MOVED_HEAD_WT" rev-parse HEAD)" "$moved_head_original" "guarded abort restores the recorded original head"
 assert_eq "$(git -C "$MOVED_HEAD_WT" config --worktree --get-regexp '^kendex-restack\.' || true)" "" "guarded abort leaves no kendex-restack key to unset by hand"
+
+# `--quit` removes Git's state and leaves the index unmerged, so the reattach
+# fails. The refusal must carry Git's own reason and a next step, and must not
+# force the checkout over a resolver's staged work (kendex#1195).
+QUIT_ROOT="$TMP_ROOT/quit"
+make_conflict_pair "$QUIT_ROOT" issue-quit
+QUIT_WT="$QUIT_ROOT/trees/issue-quit"
+set +e
+(cd "$QUIT_ROOT/main" && "$WORKTREE_SCRIPT" create issue-quit --restack >/dev/null 2>&1)
+set -e
+git -C "$QUIT_WT" rebase --quit
+assert_no_rebase_in_progress "$QUIT_WT" "the out-of-band quit removed the Git rebase state"
+assert_ne "$(git -C "$QUIT_WT" ls-files -u)" "" "the quit left the index unmerged"
+set +e
+(cd "$QUIT_ROOT/main" && "$WORKTREE_SCRIPT" restack abort issue-quit >/dev/null 2>"$QUIT_ROOT/abort.err")
+quit_code=$?
+set -e
+quit_err="$(cat "$QUIT_ROOT/abort.err")"
+assert_eq "$quit_code" "1" "an unreattachable worktree refuses instead of forcing the checkout"
+assert_contains "$quit_err" "git: " "the refusal carries Git's own reason"
+assert_contains "$quit_err" "file.txt" "Git's reason names the unmerged path"
+assert_contains "$quit_err" "restack abort" "the refusal names the next step"
+assert_eq "$(git -C "$QUIT_WT" config --worktree --get kendex-restack.pending)" "true" "the refused abort preserves the recorded state"
+assert_ne "$(git -C "$QUIT_WT" ls-files -u)" "" "the refused abort leaves the staged resolution alone"
+
+# A foreign repository carrying the same keys is never written to. The orphan
+# block runs before validate_pending_restack_state, so its own registration
+# check is the only thing containing it (kendex#1195).
+FOREIGN_ROOT="$TMP_ROOT/foreign"
+make_conflict_pair "$FOREIGN_ROOT" issue-foreign
+git init -q -b main "$FOREIGN_ROOT/outsider"
+git -C "$FOREIGN_ROOT/outsider" config user.email test@example.com
+git -C "$FOREIGN_ROOT/outsider" config user.name Test
+printf 'outside\n' > "$FOREIGN_ROOT/outsider/file.txt"
+git -C "$FOREIGN_ROOT/outsider" add file.txt
+git -C "$FOREIGN_ROOT/outsider" commit -q -m base
+git -C "$FOREIGN_ROOT/outsider" config extensions.worktreeConfig true
+git -C "$FOREIGN_ROOT/outsider" config --worktree kendex-restack.pending true
+git -C "$FOREIGN_ROOT/outsider" config --worktree kendex-restack.branch main
+git -C "$FOREIGN_ROOT/outsider" config --worktree kendex-restack.originalHead "$(git -C "$FOREIGN_ROOT/outsider" rev-parse HEAD)"
+set +e
+(cd "$FOREIGN_ROOT/main" && "$WORKTREE_SCRIPT" restack abort "$FOREIGN_ROOT/outsider" >/dev/null 2>"$FOREIGN_ROOT/abort.err")
+foreign_code=$?
+set -e
+assert_eq "$foreign_code" "1" "an unregistered repository is refused by the orphan path"
+assert_contains "$(cat "$FOREIGN_ROOT/abort.err")" "not a registered worktree" "the refusal names the containment rule"
+assert_eq "$(git -C "$FOREIGN_ROOT/outsider" config --worktree --get kendex-restack.pending)" "true" "the foreign repository's keys survive"
 
 # A record whose branch no longer matches is refused, not silently dropped.
 MOVED_ORPHAN_ROOT="$TMP_ROOT/orphan-moved"

--- a/.agents/skills/worktree/tests/worktree_create_secondary_remote.sh
+++ b/.agents/skills/worktree/tests/worktree_create_secondary_remote.sh
@@ -3,6 +3,9 @@
 # an unreachable non-origin remote must not block new-work claims, a reachable
 # secondary remote must still count as ownership, and origin stays required.
 set -euo pipefail
+# A pre-commit hook exports GIT_DIR and GIT_INDEX_FILE, which point every git
+# call below at the real repository; -C overrides neither.
+unset GIT_DIR GIT_COMMON_DIR GIT_WORK_TREE GIT_INDEX_FILE
 
 TEST_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 WORKTREE_SCRIPT="${WORKTREE_SCRIPT:-$(cd "$TEST_DIR/.." && pwd)/scripts/worktree}"

--- a/.agents/skills/worktree/tests/worktree_exclude_tracked_paths.sh
+++ b/.agents/skills/worktree/tests/worktree_exclude_tracked_paths.sh
@@ -13,6 +13,9 @@
 # symlink pointing at one, so main regains the directory while the worktree's
 # symlink stays ignored. Runtime-only paths must keep the plain blanket entry.
 set -euo pipefail
+# A pre-commit hook exports GIT_DIR and GIT_INDEX_FILE, which point every git
+# call below at the real repository; -C overrides neither.
+unset GIT_DIR GIT_COMMON_DIR GIT_WORK_TREE GIT_INDEX_FILE
 
 TEST_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 WORKTREE_SCRIPT="${WORKTREE_SCRIPT:-$(cd "$TEST_DIR/.." && pwd)/scripts/worktree}"

--- a/.agents/skills/worktree/tests/worktree_fix_links_unrestored.sh
+++ b/.agents/skills/worktree/tests/worktree_fix_links_unrestored.sh
@@ -18,6 +18,9 @@
 # reports an untracked child only when one EXISTS as a non-symlink, so an
 # absent link and a wrong-target link both read healthy through it.
 set -euo pipefail
+# A pre-commit hook exports GIT_DIR and GIT_INDEX_FILE, which point every git
+# call below at the real repository; -C overrides neither.
+unset GIT_DIR GIT_COMMON_DIR GIT_WORK_TREE GIT_INDEX_FILE
 
 TEST_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 SKILL_DIR="$(cd "$TEST_DIR/.." && pwd)"

--- a/.agents/skills/worktree/tests/worktree_for_branch.sh
+++ b/.agents/skills/worktree/tests/worktree_for_branch.sh
@@ -3,6 +3,9 @@
 # always carry a non-empty worktree path, so command-substitution callers can
 # treat empty output as "no worktree" without also getting exit 0.
 set -euo pipefail
+# A pre-commit hook exports GIT_DIR and GIT_INDEX_FILE, which point every git
+# call below at the real repository; -C overrides neither.
+unset GIT_DIR GIT_COMMON_DIR GIT_WORK_TREE GIT_INDEX_FILE
 
 TEST_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 WORKTREE_SCRIPT="${WORKTREE_SCRIPT:-$(cd "$TEST_DIR/.." && pwd)/scripts/worktree}"

--- a/.agents/skills/worktree/tests/worktree_materialized_links.sh
+++ b/.agents/skills/worktree/tests/worktree_materialized_links.sh
@@ -12,6 +12,9 @@
 # Both messages must send the operator to the MAIN CHECKOUT because the
 # worktree's own copy of the script can be missing.
 set -euo pipefail
+# A pre-commit hook exports GIT_DIR and GIT_INDEX_FILE, which point every git
+# call below at the real repository; -C overrides neither.
+unset GIT_DIR GIT_COMMON_DIR GIT_WORK_TREE GIT_INDEX_FILE
 
 TEST_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 SKILL_DIR="$(cd "$TEST_DIR/.." && pwd)"

--- a/.agents/skills/worktree/tests/worktree_no_worktree_installs.sh
+++ b/.agents/skills/worktree/tests/worktree_no_worktree_installs.sh
@@ -21,6 +21,9 @@
 #   8. a configured node_modules entry with no package.json beside it in the
 #      worktree stays silent.
 set -euo pipefail
+# A pre-commit hook exports GIT_DIR and GIT_INDEX_FILE, which point every git
+# call below at the real repository; -C overrides neither.
+unset GIT_DIR GIT_COMMON_DIR GIT_WORK_TREE GIT_INDEX_FILE
 
 TEST_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 SKILL_DIR="$(cd "$TEST_DIR/.." && pwd)"

--- a/.agents/skills/worktree/tests/worktree_path_safety.sh
+++ b/.agents/skills/worktree/tests/worktree_path_safety.sh
@@ -3,6 +3,9 @@
 # path arguments. These cases must fail before writing outside the intended
 # worktree or mutating another repository's registered worktree.
 set -euo pipefail
+# A pre-commit hook exports GIT_DIR and GIT_INDEX_FILE, which point every git
+# call below at the real repository; -C overrides neither.
+unset GIT_DIR GIT_COMMON_DIR GIT_WORK_TREE GIT_INDEX_FILE
 
 TEST_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 WORKTREE_SCRIPT="${WORKTREE_SCRIPT:-$(cd "$TEST_DIR/.." && pwd)/scripts/worktree}"

--- a/.agents/skills/worktree/tests/worktree_push_rebase.sh
+++ b/.agents/skills/worktree/tests/worktree_push_rebase.sh
@@ -10,6 +10,9 @@
 # base is already contained. Rebase must still run when the branch is genuinely
 # behind (does not contain the base as an ancestor).
 set -euo pipefail
+# A pre-commit hook exports GIT_DIR and GIT_INDEX_FILE, which point every git
+# call below at the real repository; -C overrides neither.
+unset GIT_DIR GIT_COMMON_DIR GIT_WORK_TREE GIT_INDEX_FILE
 
 TEST_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 # Default to the real script; allow override so the unguarded failure can be

--- a/.agents/skills/worktree/tests/worktree_remove.sh
+++ b/.agents/skills/worktree/tests/worktree_remove.sh
@@ -1,6 +1,9 @@
 #!/usr/bin/env bash
 # Tests for worktree remove diagnostics and branch cleanup.
 set -euo pipefail
+# A pre-commit hook exports GIT_DIR and GIT_INDEX_FILE, which point every git
+# call below at the real repository; -C overrides neither.
+unset GIT_DIR GIT_COMMON_DIR GIT_WORK_TREE GIT_INDEX_FILE
 
 TEST_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 WORKTREE_PACKAGE_DIR="$(cd "$TEST_DIR/.." && pwd)"

--- a/.agents/skills/worktree/tests/worktree_restack_replay.sh
+++ b/.agents/skills/worktree/tests/worktree_restack_replay.sh
@@ -370,6 +370,30 @@ assert_eq "$(git -C "$ABORT_WT" branch --show-current)" "issue-replay-abort" "gu
 assert_eq "$(git -C "$ABORT_WT" status --porcelain)" "" "guarded abort leaves the worktree clean"
 assert_eq "$(git -C "$ABORT_WT" config --worktree --get-regexp '^kendex-restack\.' 2>/dev/null || true)" "" "guarded abort clears pending state without authorization"
 
+# --- An orphaned record is cleared from the detached replay base ---------------
+# A replay never moves the branch, so a sequencer state that disappears out of
+# band leaves HEAD detached at the base with the tool's record still standing.
+# The guarded exit has to reattach the recorded branch (kendex#1195).
+DETACHED_ROOT="$TMP_ROOT/detached"
+make_conflict_pair "$DETACHED_ROOT" issue-replay-detached
+DETACHED_WT="$DETACHED_ROOT/trees/issue-replay-detached"
+detached_pre_head="$(git -C "$DETACHED_WT" rev-parse HEAD)"
+set +e
+(cd "$DETACHED_ROOT/main" && "$WORKTREE_SCRIPT" create issue-replay-detached --restack --replay >/dev/null 2>&1)
+set -e
+git -C "$DETACHED_WT" cherry-pick --abort
+assert_no_replay_paused "$DETACHED_WT" "the out-of-band cherry-pick abort removed the sequencer state"
+assert_eq "$(git -C "$DETACHED_WT" branch --show-current)" "" "the out-of-band abort leaves HEAD detached at the replay base"
+set +e
+detached_out="$(cd "$DETACHED_ROOT/main" && PATH="$NOREBASE_PATH" "$WORKTREE_SCRIPT" restack abort issue-replay-detached 2>"$DETACHED_ROOT/abort.err")"
+detached_code=$?
+set -e
+assert_eq "$detached_code" "0" "guarded abort exits 0 when only the tool's record is left"
+assert_contains "$detached_out" "cleared the recorded restack state" "guarded abort clears the orphaned replay record"
+assert_eq "$(git -C "$DETACHED_WT" branch --show-current)" "issue-replay-detached" "guarded abort reattaches the recorded branch"
+assert_eq "$(git -C "$DETACHED_WT" rev-parse HEAD)" "$detached_pre_head" "guarded abort leaves the branch at its recorded original head"
+assert_eq "$(git -C "$DETACHED_WT" config --worktree --get-regexp '^kendex-restack\.' 2>/dev/null || true)" "" "guarded abort leaves no kendex-restack key to unset by hand"
+
 # --- Remote movement while paused refuses continuation, abort still works ------
 MOVED_ROOT="$TMP_ROOT/moved"
 make_conflict_pair "$MOVED_ROOT" issue-replay-moved

--- a/.agents/skills/worktree/tests/worktree_restack_replay.sh
+++ b/.agents/skills/worktree/tests/worktree_restack_replay.sh
@@ -377,7 +377,7 @@ assert_eq "$(git -C "$ABORT_WT" config --worktree --get-regexp '^kendex-restack\
 # The replay cross-check asserts HEAD is detached. continue and skip pick onto
 # that detach point and still need it; abort does not, and refusing there left
 # no guarded exit. A two-commit branch is what reaches this: a one-commit range
-# never pauses with a second pick outstanding (kendex#1195).
+# never pauses with a second pick outstanding.
 ONBRANCH_ROOT="$TMP_ROOT/onbranch"
 make_conflict_pair "$ONBRANCH_ROOT" issue-replay-onbranch
 ONBRANCH_WT="$ONBRANCH_ROOT/trees/issue-replay-onbranch"
@@ -407,7 +407,7 @@ assert_eq "$(git -C "$ONBRANCH_WT" config --worktree --get-regexp '^kendex-resta
 
 # `cherry-pick --quit` drops the sequencer and leaves the index unmerged, so the
 # orphan path cannot reattach. It refuses with Git's reason rather than forcing
-# the checkout over the resolver's staged work (kendex#1195).
+# the checkout over the resolver's staged work.
 REPLAY_QUIT_ROOT="$TMP_ROOT/replay-quit"
 make_conflict_pair "$REPLAY_QUIT_ROOT" issue-replay-quit
 REPLAY_QUIT_WT="$REPLAY_QUIT_ROOT/trees/issue-replay-quit"
@@ -430,7 +430,7 @@ assert_eq "$(git -C "$REPLAY_QUIT_WT" config --worktree --get kendex-restack.pen
 # --- An orphaned record is cleared from the detached replay base ---------------
 # A replay never moves the branch, so a sequencer state that disappears out of
 # band leaves HEAD detached at the base with the tool's record still standing.
-# The guarded exit has to reattach the recorded branch (kendex#1195).
+# The guarded exit has to reattach the recorded branch.
 DETACHED_ROOT="$TMP_ROOT/detached"
 make_conflict_pair "$DETACHED_ROOT" issue-replay-detached
 DETACHED_WT="$DETACHED_ROOT/trees/issue-replay-detached"

--- a/.agents/skills/worktree/tests/worktree_restack_replay.sh
+++ b/.agents/skills/worktree/tests/worktree_restack_replay.sh
@@ -11,6 +11,9 @@
 # token binding), and record the same pinned force-with-lease authorization
 # that `worktree push` consumes and the remote lease model fails closed on.
 set -euo pipefail
+# A pre-commit hook exports GIT_DIR and GIT_INDEX_FILE, which point every git
+# call below at the real repository; -C overrides neither.
+unset GIT_DIR GIT_COMMON_DIR GIT_WORK_TREE GIT_INDEX_FILE
 
 TEST_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 SKILL_DIR="$(cd "$TEST_DIR/.." && pwd)"
@@ -369,6 +372,60 @@ assert_eq "$(git -C "$ABORT_WT" rev-parse HEAD)" "$abort_pre_head" "guarded abor
 assert_eq "$(git -C "$ABORT_WT" branch --show-current)" "issue-replay-abort" "guarded abort reattaches the issue branch"
 assert_eq "$(git -C "$ABORT_WT" status --porcelain)" "" "guarded abort leaves the worktree clean"
 assert_eq "$(git -C "$ABORT_WT" config --worktree --get-regexp '^kendex-restack\.' 2>/dev/null || true)" "" "guarded abort clears pending state without authorization"
+
+# --- A paused replay whose HEAD moved onto the branch still aborts -------------
+# The replay cross-check asserts HEAD is detached. continue and skip pick onto
+# that detach point and still need it; abort does not, and refusing there left
+# no guarded exit. A two-commit branch is what reaches this: a one-commit range
+# never pauses with a second pick outstanding (kendex#1195).
+ONBRANCH_ROOT="$TMP_ROOT/onbranch"
+make_conflict_pair "$ONBRANCH_ROOT" issue-replay-onbranch
+ONBRANCH_WT="$ONBRANCH_ROOT/trees/issue-replay-onbranch"
+printf 'second\n' > "$ONBRANCH_WT/second.txt"
+git -C "$ONBRANCH_WT" add second.txt
+git -C "$ONBRANCH_WT" commit -q -m 'second commit'
+onbranch_pre_head="$(git -C "$ONBRANCH_WT" rev-parse HEAD)"
+set +e
+(cd "$ONBRANCH_ROOT/main" && "$WORKTREE_SCRIPT" create issue-replay-onbranch --restack --replay >/dev/null 2>&1)
+set -e
+assert_replay_paused "$ONBRANCH_WT" "the two-commit replay pauses on the first conflict"
+git -C "$ONBRANCH_WT" checkout -f issue-replay-onbranch >/dev/null 2>&1
+assert_eq "$(git -C "$ONBRANCH_WT" branch --show-current)" "issue-replay-onbranch" "the raw checkout moved HEAD onto the branch"
+set +e
+(cd "$ONBRANCH_ROOT/main" && "$WORKTREE_SCRIPT" restack continue issue-replay-onbranch >/dev/null 2>"$ONBRANCH_ROOT/continue.err")
+onbranch_continue_code=$?
+onbranch_out="$(cd "$ONBRANCH_ROOT/main" && PATH="$NOREBASE_PATH" "$WORKTREE_SCRIPT" restack abort issue-replay-onbranch 2>"$ONBRANCH_ROOT/abort.err")"
+onbranch_abort_code=$?
+set -e
+assert_eq "$onbranch_continue_code" "1" "guarded continue still requires the detached replay HEAD"
+assert_contains "$(cat "$ONBRANCH_ROOT/continue.err")" "not the replay recorded by the worktree tool" "the continue refusal names the moved HEAD"
+assert_eq "$onbranch_abort_code" "0" "guarded abort exits 0 with HEAD moved onto the branch"
+assert_contains "$onbranch_out" "Aborted guarded restack" "guarded abort reports the restored branch"
+assert_no_replay_paused "$ONBRANCH_WT" "guarded abort clears the sequencer state"
+assert_eq "$(git -C "$ONBRANCH_WT" rev-parse HEAD)" "$onbranch_pre_head" "guarded abort restores the recorded original head"
+assert_eq "$(git -C "$ONBRANCH_WT" config --worktree --get-regexp '^kendex-restack\.' 2>/dev/null || true)" "" "guarded abort leaves no kendex-restack key to unset by hand"
+
+# `cherry-pick --quit` drops the sequencer and leaves the index unmerged, so the
+# orphan path cannot reattach. It refuses with Git's reason rather than forcing
+# the checkout over the resolver's staged work (kendex#1195).
+REPLAY_QUIT_ROOT="$TMP_ROOT/replay-quit"
+make_conflict_pair "$REPLAY_QUIT_ROOT" issue-replay-quit
+REPLAY_QUIT_WT="$REPLAY_QUIT_ROOT/trees/issue-replay-quit"
+set +e
+(cd "$REPLAY_QUIT_ROOT/main" && "$WORKTREE_SCRIPT" create issue-replay-quit --restack --replay >/dev/null 2>&1)
+set -e
+git -C "$REPLAY_QUIT_WT" cherry-pick --quit
+assert_no_replay_paused "$REPLAY_QUIT_WT" "the out-of-band quit removed the sequencer state"
+assert_ne "$(git -C "$REPLAY_QUIT_WT" ls-files -u)" "" "the quit left the index unmerged"
+set +e
+(cd "$REPLAY_QUIT_ROOT/main" && "$WORKTREE_SCRIPT" restack abort issue-replay-quit >/dev/null 2>"$REPLAY_QUIT_ROOT/abort.err")
+replay_quit_code=$?
+set -e
+replay_quit_err="$(cat "$REPLAY_QUIT_ROOT/abort.err")"
+assert_eq "$replay_quit_code" "1" "an unreattachable replay refuses instead of forcing the checkout"
+assert_contains "$replay_quit_err" "git: " "the refusal carries Git's own reason"
+assert_contains "$replay_quit_err" "restack abort" "the refusal names the next step"
+assert_eq "$(git -C "$REPLAY_QUIT_WT" config --worktree --get kendex-restack.pending)" "true" "the refused abort preserves the recorded state"
 
 # --- An orphaned record is cleared from the detached replay base ---------------
 # A replay never moves the branch, so a sequencer state that disappears out of

--- a/.agents/skills/worktree/tests/worktree_reuse_shadowed_tracked.sh
+++ b/.agents/skills/worktree/tests/worktree_reuse_shadowed_tracked.sh
@@ -7,6 +7,9 @@
 # writes them directly. The reuse path must still succeed, and re-applying
 # setup afterwards must keep the per-child layout intact.
 set -euo pipefail
+# A pre-commit hook exports GIT_DIR and GIT_INDEX_FILE, which point every git
+# call below at the real repository; -C overrides neither.
+unset GIT_DIR GIT_COMMON_DIR GIT_WORK_TREE GIT_INDEX_FILE
 
 TEST_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 WORKTREE_SCRIPT="${WORKTREE_SCRIPT:-$(cd "$TEST_DIR/.." && pwd)/scripts/worktree}"

--- a/.agents/skills/worktree/tests/worktree_session_guard_lifecycle.sh
+++ b/.agents/skills/worktree/tests/worktree_session_guard_lifecycle.sh
@@ -21,6 +21,9 @@
 # mkdir mutex on hosts with no flock, reached here by running the guard on a
 # PATH built without flock.
 set -euo pipefail
+# A pre-commit hook exports GIT_DIR and GIT_INDEX_FILE, which point every git
+# call below at the real repository; -C overrides neither.
+unset GIT_DIR GIT_COMMON_DIR GIT_WORK_TREE GIT_INDEX_FILE
 
 TEST_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 WORKTREE_PACKAGE_DIR="$(cd "$TEST_DIR/.." && pwd)"

--- a/.agents/skills/worktree/tests/worktree_symlink_shadows_tracked.sh
+++ b/.agents/skills/worktree/tests/worktree_symlink_shadows_tracked.sh
@@ -8,6 +8,9 @@
 # tracked and untracked content. A fully untracked entry keeps the plain
 # parent symlink.
 set -euo pipefail
+# A pre-commit hook exports GIT_DIR and GIT_INDEX_FILE, which point every git
+# call below at the real repository; -C overrides neither.
+unset GIT_DIR GIT_COMMON_DIR GIT_WORK_TREE GIT_INDEX_FILE
 
 TEST_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 WORKTREE_SCRIPT="${WORKTREE_SCRIPT:-$(cd "$TEST_DIR/.." && pwd)/scripts/worktree}"

--- a/changelog.d/fixed/KEN-1195.md
+++ b/changelog.d/fixed/KEN-1195.md
@@ -1,1 +1,1 @@
-- `worktree restack continue` now names unstaged changes as the cause instead of reporting merge conflicts against a clean index, and `restack abort` works on a moved or already-gone paused restack.
+- `worktree restack continue` no longer offers a `skip` that drops the resolved commit when the index is clean; it names the unstaged files. `restack abort` now exits a restack Git moved or dropped.

--- a/changelog.d/fixed/KEN-1195.md
+++ b/changelog.d/fixed/KEN-1195.md
@@ -1,1 +1,1 @@
-- `worktree restack continue` no longer offers a `skip` that drops the resolved commit when the index is clean; it names the unstaged files. `restack abort` now exits a restack Git moved or dropped.
+- `worktree restack continue` names unstaged files instead of offering a `skip` that drops the resolved commit; `restack abort` exits a restack Git moved or dropped; suites drop an inherited git env.

--- a/changelog.d/fixed/KEN-1195.md
+++ b/changelog.d/fixed/KEN-1195.md
@@ -1,0 +1,1 @@
+- `worktree restack continue` now names unstaged changes as the cause instead of reporting merge conflicts against a clean index, and `restack abort` works on a moved or already-gone paused restack.

--- a/skills/worktree/scripts/worktree
+++ b/skills/worktree/scripts/worktree
@@ -133,16 +133,18 @@ Actions:
              and clear the pending authorization; with the paused restack
              already gone, clear the record it left behind
 
-Guarded-restack contract: the actions accept only a registered worktree whose
-worktree-local restack authorization, tool-created state token, and Git
-sequencer metadata agree on the exact remote, branch, observed remote OID,
-original head, and target base. continue and skip re-check the remote before
-and after replay, finalize the exact rewritten-head lease when complete, and
-fail closed on missing, stale, or unrelated state. abort requires the same
-matching local state and clears only the pending authorization; neither remote
-movement nor a HEAD moved off the recorded base blocks it. When no restack is
-paused at all, abort clears the record alone, and only while the recorded
-branch still sits at its recorded original head.
+Guarded-restack contract: while a restack is paused, the actions accept only a
+registered worktree whose worktree-local restack authorization, tool-created
+state token, and Git sequencer metadata agree on the exact remote, branch,
+observed remote OID, original head, and target base. continue and skip re-check
+the remote before and after replay, finalize the exact rewritten-head lease when
+complete, and fail closed on missing, stale, or unrelated state. abort requires
+that same state except HEAD's own position, which it restores, and remote
+movement does not block it. With no restack paused there is no sequencer state
+to agree with, so abort takes the record alone: it requires the recorded branch
+to still be at its recorded original head, checks that branch out, clears the
+record, and re-applies worktree setup, refusing and keeping the record when the
+branch has moved or the checkout fails.
 EOF
 }
 
@@ -2649,16 +2651,17 @@ validate_pending_restack_state() {
   fi
   if [[ "$mode" == replay ]]; then
     # Replay analog of the rebase metadata cross-check: the sequencer's head
-    # is the detach point (the recorded base), HEAD is still detached, and the
-    # branch ref has not moved off the recorded original head — the replay
-    # moves it only after the whole range succeeds.
+    # is the detach point (the recorded base) and the branch ref has not moved
+    # off the recorded original head — the replay moves it only after the whole
+    # range succeeds. Those two pin the state for every action. HEAD being
+    # detached is where continue and skip pick onto, so only they require it.
     if [[ ! -f "$state_dir/head" ]]; then
       restack_state_refusal "$wt" "missing required Git sequencer metadata"
       return 1
     fi
     replay_head="$(head -n 1 "$state_dir/head" 2>/dev/null || true)"
     if [[ "$replay_head" != "$base_oid" ]] || \
-       [[ -n "$(git -C "$wt" branch --show-current 2>/dev/null || true)" ]] || \
+       { [[ "$action" != abort ]] && [[ -n "$(git -C "$wt" branch --show-current 2>/dev/null || true)" ]]; } || \
        [[ "$(git -C "$wt" rev-parse "refs/heads/$stored_branch" 2>/dev/null || true)" != "$original_head" ]]; then
       restack_state_refusal "$wt" "not the replay recorded by the worktree tool"
       return 1
@@ -2678,9 +2681,10 @@ validate_pending_restack_state() {
     fi
   fi
   # continue and skip replay onto the recorded base, so HEAD has to still sit
-  # on it. abort restores the recorded original head out of the paused state's
-  # own metadata, which the cross-check above already matched, whatever HEAD
-  # reached in between: refusing there leaves no guarded exit at all (#1195).
+  # on it. abort unwinds through Git's own paused state, which the cross-check
+  # above matched against the record, and its post-conditions verify the
+  # restored branch and head: refusing here on HEAD's position alone left the
+  # worktree with no guarded exit (#1195).
   if ! git -C "$wt" cat-file -e "${original_head}^{commit}" 2>/dev/null || \
      ! git -C "$wt" cat-file -e "${base_oid}^{commit}" 2>/dev/null || \
      { [[ "$action" != abort ]] && ! git -C "$wt" merge-base --is-ancestor "$base_oid" HEAD; }; then
@@ -2751,6 +2755,64 @@ report_paused_restack() {
   fi
   echo "To restore the pre-restack branch: $0 restack abort \"$wt\"" >&2
   echo "Recorded branch: $branch" >&2
+}
+
+# The tail both abort paths share: drop the pending authorization, release the
+# claim lock, and re-apply the setup a paused restack un-shadowed. Only the
+# closing message differs.
+finish_guarded_restack_abort() {
+  local wt="$1" done_message="$2"
+  cancel_pending_restack_authorization "$wt"
+  release_issue_claim_lock
+  if ! setup_app_worktree "$wt"; then
+    echo "Warning: Restack was aborted successfully, but worktree setup could not be reapplied. Fix the WORKTREE_* configuration, then run: $0 fix-links '$wt'" >&2
+  fi
+  echo "$done_message"
+}
+
+# Git's paused state can be gone while the tool's own record stands: an
+# out-of-band 'git rebase --abort' or '--quit', or an abort whose restore check
+# refused after Git had already unwound. Nothing can continue or abort a rebase
+# that is not running, and every guarded control refuses a missing paused
+# state, so abort is the only way to drop that record — without it the exit is
+# unsetting the kendex-restack keys by hand (#1195). Returns 2 when the record
+# is not orphaned after all, for the caller to hand to the guarded controls.
+abort_orphaned_restack_record() {
+  local wt="$1" branch="" head="" checkout_err=""
+  if ! is_registered_project_worktree "$wt"; then
+    restack_state_refusal "$wt" "not a registered worktree of this repository"
+    return 1
+  fi
+  branch="$(restack_state_get "$wt" branch)"
+  head="$(restack_state_get "$wt" originalHead)"
+  if [[ -z "$branch" || -z "$head" ]]; then
+    restack_state_refusal "$wt" "missing its tool-created authorization"
+    return 1
+  fi
+  acquire_issue_claim_lock "$branch" || return 1
+  # The lock is what makes the precondition durable. A concurrent
+  # 'create <ID> --restack' holds it across the window where it writes the
+  # record and starts the rebase, so a sample taken before the lock can name a
+  # restack that is live by now, and clearing a live restack's record is not a
+  # closed failure. Re-read both under the lock.
+  if restack_engine_in_progress "$wt" || [[ "$(restack_state_get "$wt" pending)" != true ]]; then
+    release_issue_claim_lock
+    return 2
+  fi
+  if [[ "$(git -C "$wt" rev-parse "refs/heads/$branch" 2>/dev/null || true)" != "$head" ]]; then
+    echo "Error: No restack is paused in $wt, and '$branch' is no longer at its recorded pre-restack commit $head; refusing to clear the recorded state." >&2
+    echo "Something rewrote the branch outside the guarded restack; inspect it before retrying." >&2
+    return 1
+  fi
+  if [[ "$(git -C "$wt" branch --show-current 2>/dev/null || true)" != "$branch" ]] && \
+     ! checkout_err="$(git -C "$wt" checkout "$branch" 2>&1)"; then
+    [[ -n "$checkout_err" ]] && sed 's/^/  git: /' <<<"$checkout_err" >&2
+    echo "Error: Could not reattach $wt to '$branch'; the recorded restack state was preserved." >&2
+    echo "A 'rebase --quit' or 'cherry-pick --quit' leaves the conflicted index in place: stage or discard the paths Git names above." >&2
+    echo "Then re-run: $0 restack abort \"$wt\"" >&2
+    return 1
+  fi
+  finish_guarded_restack_abort "$wt" "No restack was paused; cleared the recorded restack state for $branch: $wt"
 }
 
 open_pr_for_branch() {
@@ -3506,42 +3568,11 @@ case "${1:-}" in
     esac
 
     WT_PATH="$(resolve_restack_worktree "$ARG")"
-    # Git's state can be gone while the tool's own record stands: an
-    # out-of-band `git rebase --abort`, or an abort whose restore check
-    # refused after Git had already unwound. Nothing can continue or abort a
-    # rebase that is not running, and every control below refuses a missing
-    # paused state, so abort is the only guarded way to drop that record —
-    # without it the exit is unsetting the kendex-restack keys by hand (#1195).
     if [[ "$ACTION" == abort ]] && [[ "$(restack_state_get "$WT_PATH" pending)" == true ]] && \
        ! restack_engine_in_progress "$WT_PATH"; then
-      if ! is_registered_project_worktree "$WT_PATH"; then
-        restack_state_refusal "$WT_PATH" "not a registered worktree of this repository"
-        exit 1
-      fi
-      ORPHAN_BRANCH="$(restack_state_get "$WT_PATH" branch)"
-      ORPHAN_HEAD="$(restack_state_get "$WT_PATH" originalHead)"
-      if [[ -z "$ORPHAN_BRANCH" || -z "$ORPHAN_HEAD" ]]; then
-        restack_state_refusal "$WT_PATH" "missing its tool-created authorization"
-        exit 1
-      fi
-      acquire_issue_claim_lock "$ORPHAN_BRANCH" || exit 1
-      if [[ "$(git -C "$WT_PATH" rev-parse "refs/heads/$ORPHAN_BRANCH" 2>/dev/null || true)" != "$ORPHAN_HEAD" ]]; then
-        echo "Error: No restack is paused in $WT_PATH, and '$ORPHAN_BRANCH' is no longer at its recorded pre-restack commit $ORPHAN_HEAD; refusing to clear the recorded state." >&2
-        echo "Something rewrote the branch outside the guarded restack; inspect it before retrying." >&2
-        exit 1
-      fi
-      if [[ "$(git -C "$WT_PATH" branch --show-current 2>/dev/null || true)" != "$ORPHAN_BRANCH" ]] && \
-         ! git -C "$WT_PATH" checkout "$ORPHAN_BRANCH" >/dev/null 2>&1; then
-        echo "Error: Could not reattach $WT_PATH to '$ORPHAN_BRANCH'; the recorded restack state was preserved." >&2
-        exit 1
-      fi
-      cancel_pending_restack_authorization "$WT_PATH"
-      release_issue_claim_lock
-      if ! setup_app_worktree "$WT_PATH"; then
-        echo "Warning: The record was cleared, but worktree setup could not be reapplied. Fix the WORKTREE_* configuration, then run: $0 fix-links '$WT_PATH'" >&2
-      fi
-      echo "No restack was paused; cleared the recorded restack state for $ORPHAN_BRANCH: $WT_PATH"
-      exit 0
+      ORPHAN_STATUS=0
+      abort_orphaned_restack_record "$WT_PATH" || ORPHAN_STATUS=$?
+      [[ "$ORPHAN_STATUS" -eq 2 ]] || exit "$ORPHAN_STATUS"
     fi
     validate_pending_restack_state "$WT_PATH" "$ACTION" || exit 1
     RESTACK_BRANCH="$(restack_state_get "$WT_PATH" branch)"
@@ -3581,12 +3612,7 @@ case "${1:-}" in
           exit 1
         fi
       fi
-      cancel_pending_restack_authorization "$WT_PATH"
-      release_issue_claim_lock
-      if ! setup_app_worktree "$WT_PATH"; then
-        echo "Warning: Restack was aborted successfully, but worktree setup could not be reapplied. Fix the WORKTREE_* configuration, then run: $0 fix-links '$WT_PATH'" >&2
-      fi
-      echo "Aborted guarded restack and restored $RESTACK_BRANCH: $WT_PATH"
+      finish_guarded_restack_abort "$WT_PATH" "Aborted guarded restack and restored $RESTACK_BRANCH: $WT_PATH"
       exit 0
     fi
 
@@ -3624,7 +3650,7 @@ case "${1:-}" in
     fi
 
     if restack_engine_in_progress "$WT_PATH"; then
-      if ! validate_pending_restack_state "$WT_PATH"; then
+      if ! validate_pending_restack_state "$WT_PATH" "$ACTION"; then
         echo "Error: Git changed the paused rebase outside the recorded restack boundary; refusing further control." >&2
         exit 1
       fi

--- a/skills/worktree/scripts/worktree
+++ b/skills/worktree/scripts/worktree
@@ -2684,7 +2684,7 @@ validate_pending_restack_state() {
   # on it. abort unwinds through Git's own paused state, which the cross-check
   # above matched against the record, and its post-conditions verify the
   # restored branch and head: refusing here on HEAD's position alone left the
-  # worktree with no guarded exit (#1195).
+  # worktree with no guarded exit.
   if ! git -C "$wt" cat-file -e "${original_head}^{commit}" 2>/dev/null || \
      ! git -C "$wt" cat-file -e "${base_oid}^{commit}" 2>/dev/null || \
      { [[ "$action" != abort ]] && ! git -C "$wt" merge-base --is-ancestor "$base_oid" HEAD; }; then
@@ -2746,7 +2746,7 @@ report_paused_restack() {
     # Git refuses to continue while a tracked file differs from the index and
     # names merge conflicts whatever the real cause. With nothing unmerged,
     # repeating that sends the resolver back to files already staged, and the
-    # empty-commit skip below would drop the commit they just resolved (#1195).
+    # empty-commit skip below would drop the commit they just resolved.
     echo "Restack stopped on unstaged changes, not on unresolved conflicts:" >&2
     sed 's/^/  /' <<<"$unstaged_files" >&2
     echo "Stage or discard them, then run: $0 restack continue \"$wt\"" >&2
@@ -2775,7 +2775,7 @@ finish_guarded_restack_abort() {
 # refused after Git had already unwound. Nothing can continue or abort a rebase
 # that is not running, and every guarded control refuses a missing paused
 # state, so abort is the only way to drop that record — without it the exit is
-# unsetting the kendex-restack keys by hand (#1195). Returns 2 when the record
+# unsetting the kendex-restack keys by hand. Returns 2 when the record
 # is not orphaned after all, for the caller to hand to the guarded controls.
 abort_orphaned_restack_record() {
   local wt="$1" branch="" head="" checkout_err=""

--- a/skills/worktree/scripts/worktree
+++ b/skills/worktree/scripts/worktree
@@ -130,7 +130,8 @@ Actions:
   skip       Skip the current commit in that paused restack (use when the
              commit is already represented by the new base)
   abort      Abort that paused restack, restore the recorded original head,
-             and clear the pending authorization
+             and clear the pending authorization; with the paused restack
+             already gone, clear the record it left behind
 
 Guarded-restack contract: the actions accept only a registered worktree whose
 worktree-local restack authorization, tool-created state token, and Git
@@ -138,8 +139,10 @@ sequencer metadata agree on the exact remote, branch, observed remote OID,
 original head, and target base. continue and skip re-check the remote before
 and after replay, finalize the exact rewritten-head lease when complete, and
 fail closed on missing, stale, or unrelated state. abort requires the same
-matching local state and clears only the pending authorization; remote
-movement does not block it.
+matching local state and clears only the pending authorization; neither remote
+movement nor a HEAD moved off the recorded base blocks it. When no restack is
+paused at all, abort clears the record alone, and only while the recorded
+branch still sits at its recorded original head.
 EOF
 }
 
@@ -2601,7 +2604,7 @@ restack_state_refusal() {
 }
 
 validate_pending_restack_state() {
-  local wt="$1" state_dir="" stored_remote="" stored_branch="" stored_expected=""
+  local wt="$1" action="${2:-continue}" state_dir="" stored_remote="" stored_branch="" stored_expected=""
   local original_head="" base_oid="" pending="" state_token="" marker_token=""
   local head_name="" rebase_original="" rebase_onto="" mode="" replay_head=""
 
@@ -2674,9 +2677,13 @@ validate_pending_restack_state() {
       return 1
     fi
   fi
+  # continue and skip replay onto the recorded base, so HEAD has to still sit
+  # on it. abort restores the recorded original head out of the paused state's
+  # own metadata, which the cross-check above already matched, whatever HEAD
+  # reached in between: refusing there leaves no guarded exit at all (#1195).
   if ! git -C "$wt" cat-file -e "${original_head}^{commit}" 2>/dev/null || \
      ! git -C "$wt" cat-file -e "${base_oid}^{commit}" 2>/dev/null || \
-     ! git -C "$wt" merge-base --is-ancestor "$base_oid" HEAD; then
+     { [[ "$action" != abort ]] && ! git -C "$wt" merge-base --is-ancestor "$base_oid" HEAD; }; then
     restack_state_refusal "$wt" "stale or no longer based on its recorded commits"
     return 1
   fi
@@ -2723,13 +2730,22 @@ resolve_restack_worktree() {
 }
 
 report_paused_restack() {
-  local wt="$1" branch="$2" output="$3" conflict_files=""
+  local wt="$1" branch="$2" output="$3" conflict_files="" unstaged_files=""
   [[ -n "$output" ]] && sed 's/^/  git: /' <<<"$output" >&2
   conflict_files="$(git -C "$wt" diff --name-only --diff-filter=U 2>/dev/null || true)"
+  unstaged_files="$(git -C "$wt" diff --name-only 2>/dev/null || true)"
   if [[ -n "$conflict_files" ]]; then
     echo "Restack stopped on conflicts:" >&2
     sed 's/^/  /' <<<"$conflict_files" >&2
     echo "Resolve and stage each file, then run: $0 restack continue \"$wt\"" >&2
+  elif [[ -n "$unstaged_files" ]]; then
+    # Git refuses to continue while a tracked file differs from the index and
+    # names merge conflicts whatever the real cause. With nothing unmerged,
+    # repeating that sends the resolver back to files already staged, and the
+    # empty-commit skip below would drop the commit they just resolved (#1195).
+    echo "Restack stopped on unstaged changes, not on unresolved conflicts:" >&2
+    sed 's/^/  /' <<<"$unstaged_files" >&2
+    echo "Stage or discard them, then run: $0 restack continue \"$wt\"" >&2
   else
     echo "The current replayed commit may be empty; inspect it, then run: $0 restack skip \"$wt\"" >&2
   fi
@@ -3490,12 +3506,49 @@ case "${1:-}" in
     esac
 
     WT_PATH="$(resolve_restack_worktree "$ARG")"
-    validate_pending_restack_state "$WT_PATH" || exit 1
+    # Git's state can be gone while the tool's own record stands: an
+    # out-of-band `git rebase --abort`, or an abort whose restore check
+    # refused after Git had already unwound. Nothing can continue or abort a
+    # rebase that is not running, and every control below refuses a missing
+    # paused state, so abort is the only guarded way to drop that record —
+    # without it the exit is unsetting the kendex-restack keys by hand (#1195).
+    if [[ "$ACTION" == abort ]] && [[ "$(restack_state_get "$WT_PATH" pending)" == true ]] && \
+       ! restack_engine_in_progress "$WT_PATH"; then
+      if ! is_registered_project_worktree "$WT_PATH"; then
+        restack_state_refusal "$WT_PATH" "not a registered worktree of this repository"
+        exit 1
+      fi
+      ORPHAN_BRANCH="$(restack_state_get "$WT_PATH" branch)"
+      ORPHAN_HEAD="$(restack_state_get "$WT_PATH" originalHead)"
+      if [[ -z "$ORPHAN_BRANCH" || -z "$ORPHAN_HEAD" ]]; then
+        restack_state_refusal "$WT_PATH" "missing its tool-created authorization"
+        exit 1
+      fi
+      acquire_issue_claim_lock "$ORPHAN_BRANCH" || exit 1
+      if [[ "$(git -C "$WT_PATH" rev-parse "refs/heads/$ORPHAN_BRANCH" 2>/dev/null || true)" != "$ORPHAN_HEAD" ]]; then
+        echo "Error: No restack is paused in $WT_PATH, and '$ORPHAN_BRANCH' is no longer at its recorded pre-restack commit $ORPHAN_HEAD; refusing to clear the recorded state." >&2
+        echo "Something rewrote the branch outside the guarded restack; inspect it before retrying." >&2
+        exit 1
+      fi
+      if [[ "$(git -C "$WT_PATH" branch --show-current 2>/dev/null || true)" != "$ORPHAN_BRANCH" ]] && \
+         ! git -C "$WT_PATH" checkout "$ORPHAN_BRANCH" >/dev/null 2>&1; then
+        echo "Error: Could not reattach $WT_PATH to '$ORPHAN_BRANCH'; the recorded restack state was preserved." >&2
+        exit 1
+      fi
+      cancel_pending_restack_authorization "$WT_PATH"
+      release_issue_claim_lock
+      if ! setup_app_worktree "$WT_PATH"; then
+        echo "Warning: The record was cleared, but worktree setup could not be reapplied. Fix the WORKTREE_* configuration, then run: $0 fix-links '$WT_PATH'" >&2
+      fi
+      echo "No restack was paused; cleared the recorded restack state for $ORPHAN_BRANCH: $WT_PATH"
+      exit 0
+    fi
+    validate_pending_restack_state "$WT_PATH" "$ACTION" || exit 1
     RESTACK_BRANCH="$(restack_state_get "$WT_PATH" branch)"
     acquire_issue_claim_lock "$RESTACK_BRANCH" || exit 1
     # The first validation gives a useful error without taking a lock. Repeat
     # under the branch claim lock immediately before controlling the rebase.
-    validate_pending_restack_state "$WT_PATH" || exit 1
+    validate_pending_restack_state "$WT_PATH" "$ACTION" || exit 1
     RESTACK_MODE="$(restack_state_get "$WT_PATH" mode)"
 
     if [[ "$ACTION" == abort ]]; then

--- a/skills/worktree/tests/worktree_atomic_symlink_swap.sh
+++ b/skills/worktree/tests/worktree_atomic_symlink_swap.sh
@@ -10,6 +10,9 @@
 # and teardown semantics as the Codex pair, for worktrees Claude Code creates
 # itself via its WorktreeCreate hook.
 set -euo pipefail
+# A pre-commit hook exports GIT_DIR and GIT_INDEX_FILE, which point every git
+# call below at the real repository; -C overrides neither.
+unset GIT_DIR GIT_COMMON_DIR GIT_WORK_TREE GIT_INDEX_FILE
 
 TEST_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 WORKTREE_SCRIPT="${WORKTREE_SCRIPT:-$(cd "$TEST_DIR/.." && pwd)/scripts/worktree}"

--- a/skills/worktree/tests/worktree_autorepair_hooks.sh
+++ b/skills/worktree/tests/worktree_autorepair_hooks.sh
@@ -16,6 +16,9 @@
 #      the hook warns loudly and names fix-links instead;
 #   4. repair-links is quiet and safe when addressed at the main checkout.
 set -euo pipefail
+# A pre-commit hook exports GIT_DIR and GIT_INDEX_FILE, which point every git
+# call below at the real repository; -C overrides neither.
+unset GIT_DIR GIT_COMMON_DIR GIT_WORK_TREE GIT_INDEX_FILE
 
 TEST_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 SKILL_DIR="$(cd "$TEST_DIR/.." && pwd)"

--- a/skills/worktree/tests/worktree_base_dir.sh
+++ b/skills/worktree/tests/worktree_base_dir.sh
@@ -4,6 +4,9 @@
 # canonical (symlink-resolved) path comparisons, and compatibility with
 # worktrees registered under an older base-dir convention.
 set -euo pipefail
+# A pre-commit hook exports GIT_DIR and GIT_INDEX_FILE, which point every git
+# call below at the real repository; -C overrides neither.
+unset GIT_DIR GIT_COMMON_DIR GIT_WORK_TREE GIT_INDEX_FILE
 
 TEST_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 WORKTREE_SCRIPT="${WORKTREE_SCRIPT:-$(cd "$TEST_DIR/.." && pwd)/scripts/worktree}"

--- a/skills/worktree/tests/worktree_cleanup_merged_pr.sh
+++ b/skills/worktree/tests/worktree_cleanup_merged_pr.sh
@@ -30,6 +30,9 @@
 #     a moved-on one, and one merged only into its own tracking upstream —
 #     `git branch -d` accepts that last case and does not decide anything.
 set -euo pipefail
+# A pre-commit hook exports GIT_DIR and GIT_INDEX_FILE, which point every git
+# call below at the real repository; -C overrides neither.
+unset GIT_DIR GIT_COMMON_DIR GIT_WORK_TREE GIT_INDEX_FILE
 
 TEST_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 WORKTREE_SCRIPT="$(cd "$TEST_DIR/.." && pwd)/scripts/worktree"

--- a/skills/worktree/tests/worktree_create_active_guard.sh
+++ b/skills/worktree/tests/worktree_create_active_guard.sh
@@ -1,6 +1,9 @@
 #!/usr/bin/env bash
 # Tests for active-work ownership guards.
 set -euo pipefail
+# A pre-commit hook exports GIT_DIR and GIT_INDEX_FILE, which point every git
+# call below at the real repository; -C overrides neither.
+unset GIT_DIR GIT_COMMON_DIR GIT_WORK_TREE GIT_INDEX_FILE
 
 TEST_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 WORKTREE_SCRIPT="${WORKTREE_SCRIPT:-$(cd "$TEST_DIR/.." && pwd)/scripts/worktree}"

--- a/skills/worktree/tests/worktree_create_restack.sh
+++ b/skills/worktree/tests/worktree_create_restack.sh
@@ -9,8 +9,9 @@
 # delete/recreate). `--restack` must redo the rebase and stop IN the conflict
 # state with guarded continue/skip/abort guidance. A completed supported rewrite must carry
 # an exact, one-worktree push authorization without weakening remote-movement
-# or unexpected-local-divergence rejection. Clean-rebase reuse must keep
-# working unchanged.
+# or unexpected-local-divergence rejection. A sibling suite run under a git
+# hook's exported environment must keep its own sandbox and leave a live
+# authorization alone. Clean-rebase reuse must keep working unchanged.
 set -euo pipefail
 # A pre-commit hook exports GIT_DIR and GIT_INDEX_FILE, which point every git
 # call below at the real repository; -C overrides neither.
@@ -447,7 +448,7 @@ assert_eq "$(git -C "$CHAINED_WT" config --worktree --get kendex-restack.authori
 # `git diff --name-only` lists unmerged paths too, so on a conflicted pause both
 # arms of report_paused_restack match and only their order keeps the conflict
 # message. Nothing else in the repo asserts it, so swapping them would ship the
-# wrong cause green (kendex#1195).
+# wrong cause green.
 PRECEDENCE_ROOT="$TMP_ROOT/precedence"
 make_conflict_pair "$PRECEDENCE_ROOT" issue-precedence
 PRECEDENCE_WT="$PRECEDENCE_ROOT/trees/issue-precedence"
@@ -468,7 +469,7 @@ assert_not_contains "$precedence_err" "unstaged changes" "an unmerged index is n
 # "You must edit all merge conflicts" whatever the real cause. Repeating that
 # against an index with no unmerged paths sends the resolver back to files it
 # already staged, and the empty-commit skip beside it would drop the commit
-# whose conflicts they just resolved (kendex#1195).
+# whose conflicts they just resolved.
 UNSTAGED_ROOT="$TMP_ROOT/unstaged"
 make_conflict_pair "$UNSTAGED_ROOT" issue-unstaged
 UNSTAGED_WT="$UNSTAGED_ROOT/trees/issue-unstaged"
@@ -499,7 +500,7 @@ assert_eq "$(cat "$UNSTAGED_WT/file.txt")" "resolved" "the resumed restack keeps
 # --- A recorded restack whose Git state is gone still has a guarded exit ------
 # Nothing can continue or abort a rebase that is not running, and every control
 # refuses a missing paused state, so without this the tool's own record can only
-# be unset by hand (kendex#1195).
+# be unset by hand.
 ORPHAN_ROOT="$TMP_ROOT/orphan"
 make_conflict_pair "$ORPHAN_ROOT" issue-orphan
 ORPHAN_WT="$ORPHAN_ROOT/trees/issue-orphan"
@@ -523,7 +524,7 @@ assert_eq "$(git -C "$ORPHAN_WT" rev-parse HEAD)" "$orphan_original_head" "guard
 # A live paused restack whose HEAD was moved off the base still aborts. continue
 # and skip replay onto that base and must refuse, but abort restores the
 # recorded original head from the paused state's own metadata, and refusing it
-# here left raw git as the only way out (kendex#1195).
+# here left raw git as the only way out.
 MOVED_HEAD_ROOT="$TMP_ROOT/moved-head"
 make_conflict_pair "$MOVED_HEAD_ROOT" issue-moved-head
 MOVED_HEAD_WT="$MOVED_HEAD_ROOT/trees/issue-moved-head"
@@ -551,7 +552,7 @@ assert_eq "$(git -C "$MOVED_HEAD_WT" config --worktree --get-regexp '^kendex-res
 
 # `--quit` removes Git's state and leaves the index unmerged, so the reattach
 # fails. The refusal must carry Git's own reason and a next step, and must not
-# force the checkout over a resolver's staged work (kendex#1195).
+# force the checkout over a resolver's staged work.
 QUIT_ROOT="$TMP_ROOT/quit"
 make_conflict_pair "$QUIT_ROOT" issue-quit
 QUIT_WT="$QUIT_ROOT/trees/issue-quit"
@@ -575,7 +576,7 @@ assert_ne "$(git -C "$QUIT_WT" ls-files -u)" "" "the refused abort leaves the st
 
 # A foreign repository carrying the same keys is never written to. The orphan
 # block runs before validate_pending_restack_state, so its own registration
-# check is the only thing containing it (kendex#1195).
+# check is the only thing containing it.
 FOREIGN_ROOT="$TMP_ROOT/foreign"
 make_conflict_pair "$FOREIGN_ROOT" issue-foreign
 git init -q -b main "$FOREIGN_ROOT/outsider"
@@ -687,6 +688,34 @@ set -e
 assert_eq "$local_move_code" "1" "unexpected local rewrite is not covered by prior restack authorization"
 assert_eq "$(git --git-dir="$LOCAL_MOVE_ROOT/origin.git" rev-parse refs/heads/issue-local-move)" "$local_move_remote_before" "unexpected local rewrite leaves remote unchanged"
 assert_contains "$(cat "$LOCAL_MOVE_ROOT/push.err")" "not contained in local branch" "unexpected local rewrite reports divergence"
+
+# --- A suite run under a git hook's environment keeps its own sandbox --------
+# A git hook exports GIT_DIR and GIT_INDEX_FILE at the worktree it fires in,
+# and both outrank -C, so a sibling suite run from that context builds its
+# fixtures at that worktree unless it clears them first: it dies at its first
+# fixture, or worse, lands commits there. The battery a restack is verified
+# with runs beside a live authorization, so one is held here across such a
+# run.
+ENV_ROOT="$TMP_ROOT/env-live"
+make_published_clean_pair "$ENV_ROOT" issue-env-live
+ENV_WT="$ENV_ROOT/trees/issue-env-live"
+(cd "$ENV_ROOT/main" && "$WORKTREE_SCRIPT" create issue-env-live --restack >/dev/null 2>"$ENV_ROOT/restack.err")
+env_head="$(git -C "$ENV_WT" rev-parse HEAD)"
+assert_eq "$(git -C "$ENV_WT" config --worktree --get kendex-restack.authorizedHead)" "$env_head" "restack authorizes the live worktree before a suite runs under its environment"
+env_git_dir="$(git -C "$ENV_WT" rev-parse --absolute-git-dir)"
+env_fingerprint() {
+  git -C "$ENV_WT" log --format=%H
+  echo '--'
+  git -C "$ENV_WT" ls-files --stage
+  echo '--'
+  git -C "$ENV_WT" config --worktree --list
+}
+env_before="$(env_fingerprint)"
+env_suite_rc=0
+env GIT_DIR="$env_git_dir" GIT_INDEX_FILE="$env_git_dir/index" \
+  bash "$TEST_DIR/worktree_push_rebase.sh" >"$ENV_ROOT/suite.out" 2>&1 || env_suite_rc=$?
+assert_eq "$env_suite_rc" "0" "a sibling suite passes under an exported git environment"
+assert_eq "$(env_fingerprint)" "$env_before" "that suite left the live worktree's log, index and restack authorization untouched"
 
 # --- Clean-rebase reuse unchanged ----------------------------------------------
 CLEAN_ROOT="$TMP_ROOT/clean"

--- a/skills/worktree/tests/worktree_create_restack.sh
+++ b/skills/worktree/tests/worktree_create_restack.sh
@@ -153,7 +153,10 @@ make_repo() {
   git -C "$repo" config user.name Test
   git -C "$repo" config commit.gpgsign false
   printf 'orig\n' > "$repo/file.txt"
-  git -C "$repo" add file.txt
+  # A second tracked file no rebase in this suite touches, so a test can dirty
+  # the worktree without touching the conflicting path.
+  printf 'orig\n' > "$repo/other.txt"
+  git -C "$repo" add file.txt other.txt
   git -C "$repo" commit -q -m base
   # Pin the historical sibling trees/ base so this file's path assertions stay
   # explicit; default base-dir resolution is covered by worktree_base_dir.sh.
@@ -436,6 +439,111 @@ set -e
 assert_eq "$chained_push_code" "0" "consecutive clean restacks push with the original exact lease"
 assert_eq "$(git --git-dir="$CHAINED_ROOT/origin.git" rev-parse refs/heads/issue-chained-restack)" "$chained_second_head" "consecutive restack push publishes the final rewritten head"
 assert_eq "$(git -C "$CHAINED_WT" config --worktree --get kendex-restack.authorizedHead 2>/dev/null || true)" "" "consecutive restack push consumes authorization"
+
+# --- A clean index with unstaged changes is not an unresolved conflict --------
+# Git refuses to continue while a tracked file differs from the index, and says
+# "You must edit all merge conflicts" whatever the real cause. Repeating that
+# against an index with no unmerged paths sends the resolver back to files it
+# already staged, and the empty-commit skip beside it would drop the commit
+# whose conflicts they just resolved (kendex#1195).
+UNSTAGED_ROOT="$TMP_ROOT/unstaged"
+make_conflict_pair "$UNSTAGED_ROOT" issue-unstaged
+UNSTAGED_WT="$UNSTAGED_ROOT/trees/issue-unstaged"
+set +e
+(cd "$UNSTAGED_ROOT/main" && "$WORKTREE_SCRIPT" create issue-unstaged --restack >/dev/null 2>&1)
+set -e
+printf 'resolved\n' > "$UNSTAGED_WT/file.txt"
+git -C "$UNSTAGED_WT" add file.txt
+printf 'edited after staging\n' > "$UNSTAGED_WT/other.txt"
+assert_eq "$(git -C "$UNSTAGED_WT" ls-files -u)" "" "the unstaged-change fixture leaves no unmerged index entry"
+set +e
+(cd "$UNSTAGED_ROOT/main" && "$WORKTREE_SCRIPT" restack continue issue-unstaged >/dev/null 2>"$UNSTAGED_ROOT/continue.err")
+unstaged_code=$?
+set -e
+unstaged_err="$(cat "$UNSTAGED_ROOT/continue.err")"
+assert_eq "$unstaged_code" "1" "guarded continue over unstaged changes exits 1"
+assert_contains "$unstaged_err" "unstaged changes" "the refusal names unstaged changes as the real cause"
+assert_contains "$unstaged_err" "other.txt" "the refusal names the unstaged file"
+assert_not_contains "$unstaged_err" "may be empty" "a clean index is not reported as an empty commit"
+assert_not_contains "$unstaged_err" "restack skip" "a clean index does not offer the skip that would drop the resolved commit"
+assert_rebase_in_progress "$UNSTAGED_WT" "the refused continuation leaves the restack paused"
+assert_eq "$(git -C "$UNSTAGED_WT" config --worktree --get kendex-restack.pending)" "true" "the refused continuation keeps its pending authorization"
+git -C "$UNSTAGED_WT" checkout -- other.txt
+unstaged_out=$(cd "$UNSTAGED_ROOT/main" && "$WORKTREE_SCRIPT" restack continue issue-unstaged 2>"$UNSTAGED_ROOT/resume.err")
+assert_contains "$unstaged_out" "Completed guarded restack" "discarding the unstaged change resumes the same guarded restack"
+assert_eq "$(cat "$UNSTAGED_WT/file.txt")" "resolved" "the resumed restack keeps the resolution staged before the refusal"
+
+# --- A recorded restack whose Git state is gone still has a guarded exit ------
+# Nothing can continue or abort a rebase that is not running, and every control
+# refuses a missing paused state, so without this the tool's own record can only
+# be unset by hand (kendex#1195).
+ORPHAN_ROOT="$TMP_ROOT/orphan"
+make_conflict_pair "$ORPHAN_ROOT" issue-orphan
+ORPHAN_WT="$ORPHAN_ROOT/trees/issue-orphan"
+set +e
+(cd "$ORPHAN_ROOT/main" && "$WORKTREE_SCRIPT" create issue-orphan --restack >/dev/null 2>&1)
+set -e
+orphan_original_head="$(git -C "$ORPHAN_WT" config --worktree --get kendex-restack.originalHead)"
+git -C "$ORPHAN_WT" rebase --abort
+assert_no_rebase_in_progress "$ORPHAN_WT" "the out-of-band abort removed the Git rebase state"
+assert_eq "$(git -C "$ORPHAN_WT" config --worktree --get kendex-restack.pending)" "true" "the tool's own restack record outlives the Git state"
+set +e
+orphan_out=$(cd "$ORPHAN_ROOT/main" && "$WORKTREE_SCRIPT" restack abort issue-orphan 2>"$ORPHAN_ROOT/abort.err")
+orphan_code=$?
+set -e
+assert_eq "$orphan_code" "0" "guarded abort exits 0 when only the tool's record is left"
+assert_contains "$orphan_out" "cleared the recorded restack state" "guarded abort clears a record whose paused rebase is gone"
+assert_eq "$(git -C "$ORPHAN_WT" config --worktree --get-regexp '^kendex-restack\.' || true)" "" "guarded abort leaves no kendex-restack key to unset by hand"
+assert_eq "$(git -C "$ORPHAN_WT" branch --show-current)" "issue-orphan" "guarded abort leaves the worktree on its recorded branch"
+assert_eq "$(git -C "$ORPHAN_WT" rev-parse HEAD)" "$orphan_original_head" "guarded abort leaves the branch at its recorded original head"
+
+# A live paused restack whose HEAD was moved off the base still aborts. continue
+# and skip replay onto that base and must refuse, but abort restores the
+# recorded original head from the paused state's own metadata, and refusing it
+# here left raw git as the only way out (kendex#1195).
+MOVED_HEAD_ROOT="$TMP_ROOT/moved-head"
+make_conflict_pair "$MOVED_HEAD_ROOT" issue-moved-head
+MOVED_HEAD_WT="$MOVED_HEAD_ROOT/trees/issue-moved-head"
+moved_head_original="$(git -C "$MOVED_HEAD_WT" rev-parse HEAD)"
+set +e
+(cd "$MOVED_HEAD_ROOT/main" && "$WORKTREE_SCRIPT" create issue-moved-head --restack >/dev/null 2>&1)
+set -e
+git -C "$MOVED_HEAD_WT" checkout -f issue-moved-head >/dev/null 2>&1
+assert_rebase_in_progress "$MOVED_HEAD_WT" "the raw checkout leaves the paused rebase in place"
+set +e
+(cd "$MOVED_HEAD_ROOT/main" && "$WORKTREE_SCRIPT" restack continue issue-moved-head >/dev/null 2>"$MOVED_HEAD_ROOT/continue.err")
+moved_head_continue_code=$?
+set -e
+assert_eq "$moved_head_continue_code" "1" "guarded continue still refuses a HEAD moved off the recorded base"
+assert_contains "$(cat "$MOVED_HEAD_ROOT/continue.err")" "no longer based on its recorded commits" "the continue refusal names the moved base"
+set +e
+moved_head_out=$(cd "$MOVED_HEAD_ROOT/main" && "$WORKTREE_SCRIPT" restack abort issue-moved-head 2>"$MOVED_HEAD_ROOT/abort.err")
+moved_head_abort_code=$?
+set -e
+assert_eq "$moved_head_abort_code" "0" "guarded abort exits 0 with HEAD moved off the recorded base"
+assert_contains "$moved_head_out" "Aborted guarded restack" "guarded abort reports the restored branch"
+assert_no_rebase_in_progress "$MOVED_HEAD_WT" "guarded abort clears the paused rebase"
+assert_eq "$(git -C "$MOVED_HEAD_WT" rev-parse HEAD)" "$moved_head_original" "guarded abort restores the recorded original head"
+assert_eq "$(git -C "$MOVED_HEAD_WT" config --worktree --get-regexp '^kendex-restack\.' || true)" "" "guarded abort leaves no kendex-restack key to unset by hand"
+
+# A record whose branch no longer matches is refused, not silently dropped.
+MOVED_ORPHAN_ROOT="$TMP_ROOT/orphan-moved"
+make_conflict_pair "$MOVED_ORPHAN_ROOT" issue-orphan-moved
+MOVED_ORPHAN_WT="$MOVED_ORPHAN_ROOT/trees/issue-orphan-moved"
+set +e
+(cd "$MOVED_ORPHAN_ROOT/main" && "$WORKTREE_SCRIPT" create issue-orphan-moved --restack >/dev/null 2>&1)
+set -e
+git -C "$MOVED_ORPHAN_WT" rebase --abort
+printf 'later\n' > "$MOVED_ORPHAN_WT/later.txt"
+git -C "$MOVED_ORPHAN_WT" add later.txt
+git -C "$MOVED_ORPHAN_WT" commit -q -m 'work committed after the restack record'
+set +e
+(cd "$MOVED_ORPHAN_ROOT/main" && "$WORKTREE_SCRIPT" restack abort issue-orphan-moved >/dev/null 2>"$MOVED_ORPHAN_ROOT/abort.err")
+moved_orphan_code=$?
+set -e
+assert_eq "$moved_orphan_code" "1" "a record whose branch moved off its recorded head is refused"
+assert_contains "$(cat "$MOVED_ORPHAN_ROOT/abort.err")" "no longer at its recorded pre-restack commit" "the refusal names why the record cannot be cleared"
+assert_eq "$(git -C "$MOVED_ORPHAN_WT" config --worktree --get kendex-restack.pending)" "true" "the refused abort preserves the recorded state"
 
 # --- Remote movement while conflict resolution is pending fails closed -------
 PENDING_MOVE_ROOT="$TMP_ROOT/pending-move"

--- a/skills/worktree/tests/worktree_create_restack.sh
+++ b/skills/worktree/tests/worktree_create_restack.sh
@@ -12,6 +12,9 @@
 # or unexpected-local-divergence rejection. Clean-rebase reuse must keep
 # working unchanged.
 set -euo pipefail
+# A pre-commit hook exports GIT_DIR and GIT_INDEX_FILE, which point every git
+# call below at the real repository; -C overrides neither.
+unset GIT_DIR GIT_COMMON_DIR GIT_WORK_TREE GIT_INDEX_FILE
 
 TEST_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 WORKTREE_SCRIPT="${WORKTREE_SCRIPT:-$(cd "$TEST_DIR/.." && pwd)/scripts/worktree}"
@@ -440,6 +443,26 @@ assert_eq "$chained_push_code" "0" "consecutive clean restacks push with the ori
 assert_eq "$(git --git-dir="$CHAINED_ROOT/origin.git" rev-parse refs/heads/issue-chained-restack)" "$chained_second_head" "consecutive restack push publishes the final rewritten head"
 assert_eq "$(git -C "$CHAINED_WT" config --worktree --get kendex-restack.authorizedHead 2>/dev/null || true)" "" "consecutive restack push consumes authorization"
 
+# --- A real conflict outranks the unstaged arm --------------------------------
+# `git diff --name-only` lists unmerged paths too, so on a conflicted pause both
+# arms of report_paused_restack match and only their order keeps the conflict
+# message. Nothing else in the repo asserts it, so swapping them would ship the
+# wrong cause green (kendex#1195).
+PRECEDENCE_ROOT="$TMP_ROOT/precedence"
+make_conflict_pair "$PRECEDENCE_ROOT" issue-precedence
+PRECEDENCE_WT="$PRECEDENCE_ROOT/trees/issue-precedence"
+set +e
+(cd "$PRECEDENCE_ROOT/main" && "$WORKTREE_SCRIPT" create issue-precedence --restack >/dev/null 2>&1)
+(cd "$PRECEDENCE_ROOT/main" && "$WORKTREE_SCRIPT" restack continue issue-precedence >/dev/null 2>"$PRECEDENCE_ROOT/continue.err")
+precedence_code=$?
+set -e
+precedence_err="$(cat "$PRECEDENCE_ROOT/continue.err")"
+assert_ne "$(git -C "$PRECEDENCE_WT" ls-files -u)" "" "the precedence fixture leaves the index unmerged"
+assert_eq "$precedence_code" "1" "guarded continue over an unresolved conflict exits 1"
+assert_contains "$precedence_err" "Restack stopped on conflicts:" "an unmerged index is reported as a conflict"
+assert_contains "$precedence_err" "file.txt" "the conflict report names the conflicting file"
+assert_not_contains "$precedence_err" "unstaged changes" "an unmerged index is never reported as unstaged changes"
+
 # --- A clean index with unstaged changes is not an unresolved conflict --------
 # Git refuses to continue while a tracked file differs from the index, and says
 # "You must edit all merge conflicts" whatever the real cause. Repeating that
@@ -525,6 +548,53 @@ assert_contains "$moved_head_out" "Aborted guarded restack" "guarded abort repor
 assert_no_rebase_in_progress "$MOVED_HEAD_WT" "guarded abort clears the paused rebase"
 assert_eq "$(git -C "$MOVED_HEAD_WT" rev-parse HEAD)" "$moved_head_original" "guarded abort restores the recorded original head"
 assert_eq "$(git -C "$MOVED_HEAD_WT" config --worktree --get-regexp '^kendex-restack\.' || true)" "" "guarded abort leaves no kendex-restack key to unset by hand"
+
+# `--quit` removes Git's state and leaves the index unmerged, so the reattach
+# fails. The refusal must carry Git's own reason and a next step, and must not
+# force the checkout over a resolver's staged work (kendex#1195).
+QUIT_ROOT="$TMP_ROOT/quit"
+make_conflict_pair "$QUIT_ROOT" issue-quit
+QUIT_WT="$QUIT_ROOT/trees/issue-quit"
+set +e
+(cd "$QUIT_ROOT/main" && "$WORKTREE_SCRIPT" create issue-quit --restack >/dev/null 2>&1)
+set -e
+git -C "$QUIT_WT" rebase --quit
+assert_no_rebase_in_progress "$QUIT_WT" "the out-of-band quit removed the Git rebase state"
+assert_ne "$(git -C "$QUIT_WT" ls-files -u)" "" "the quit left the index unmerged"
+set +e
+(cd "$QUIT_ROOT/main" && "$WORKTREE_SCRIPT" restack abort issue-quit >/dev/null 2>"$QUIT_ROOT/abort.err")
+quit_code=$?
+set -e
+quit_err="$(cat "$QUIT_ROOT/abort.err")"
+assert_eq "$quit_code" "1" "an unreattachable worktree refuses instead of forcing the checkout"
+assert_contains "$quit_err" "git: " "the refusal carries Git's own reason"
+assert_contains "$quit_err" "file.txt" "Git's reason names the unmerged path"
+assert_contains "$quit_err" "restack abort" "the refusal names the next step"
+assert_eq "$(git -C "$QUIT_WT" config --worktree --get kendex-restack.pending)" "true" "the refused abort preserves the recorded state"
+assert_ne "$(git -C "$QUIT_WT" ls-files -u)" "" "the refused abort leaves the staged resolution alone"
+
+# A foreign repository carrying the same keys is never written to. The orphan
+# block runs before validate_pending_restack_state, so its own registration
+# check is the only thing containing it (kendex#1195).
+FOREIGN_ROOT="$TMP_ROOT/foreign"
+make_conflict_pair "$FOREIGN_ROOT" issue-foreign
+git init -q -b main "$FOREIGN_ROOT/outsider"
+git -C "$FOREIGN_ROOT/outsider" config user.email test@example.com
+git -C "$FOREIGN_ROOT/outsider" config user.name Test
+printf 'outside\n' > "$FOREIGN_ROOT/outsider/file.txt"
+git -C "$FOREIGN_ROOT/outsider" add file.txt
+git -C "$FOREIGN_ROOT/outsider" commit -q -m base
+git -C "$FOREIGN_ROOT/outsider" config extensions.worktreeConfig true
+git -C "$FOREIGN_ROOT/outsider" config --worktree kendex-restack.pending true
+git -C "$FOREIGN_ROOT/outsider" config --worktree kendex-restack.branch main
+git -C "$FOREIGN_ROOT/outsider" config --worktree kendex-restack.originalHead "$(git -C "$FOREIGN_ROOT/outsider" rev-parse HEAD)"
+set +e
+(cd "$FOREIGN_ROOT/main" && "$WORKTREE_SCRIPT" restack abort "$FOREIGN_ROOT/outsider" >/dev/null 2>"$FOREIGN_ROOT/abort.err")
+foreign_code=$?
+set -e
+assert_eq "$foreign_code" "1" "an unregistered repository is refused by the orphan path"
+assert_contains "$(cat "$FOREIGN_ROOT/abort.err")" "not a registered worktree" "the refusal names the containment rule"
+assert_eq "$(git -C "$FOREIGN_ROOT/outsider" config --worktree --get kendex-restack.pending)" "true" "the foreign repository's keys survive"
 
 # A record whose branch no longer matches is refused, not silently dropped.
 MOVED_ORPHAN_ROOT="$TMP_ROOT/orphan-moved"

--- a/skills/worktree/tests/worktree_create_secondary_remote.sh
+++ b/skills/worktree/tests/worktree_create_secondary_remote.sh
@@ -3,6 +3,9 @@
 # an unreachable non-origin remote must not block new-work claims, a reachable
 # secondary remote must still count as ownership, and origin stays required.
 set -euo pipefail
+# A pre-commit hook exports GIT_DIR and GIT_INDEX_FILE, which point every git
+# call below at the real repository; -C overrides neither.
+unset GIT_DIR GIT_COMMON_DIR GIT_WORK_TREE GIT_INDEX_FILE
 
 TEST_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 WORKTREE_SCRIPT="${WORKTREE_SCRIPT:-$(cd "$TEST_DIR/.." && pwd)/scripts/worktree}"

--- a/skills/worktree/tests/worktree_exclude_tracked_paths.sh
+++ b/skills/worktree/tests/worktree_exclude_tracked_paths.sh
@@ -13,6 +13,9 @@
 # symlink pointing at one, so main regains the directory while the worktree's
 # symlink stays ignored. Runtime-only paths must keep the plain blanket entry.
 set -euo pipefail
+# A pre-commit hook exports GIT_DIR and GIT_INDEX_FILE, which point every git
+# call below at the real repository; -C overrides neither.
+unset GIT_DIR GIT_COMMON_DIR GIT_WORK_TREE GIT_INDEX_FILE
 
 TEST_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 WORKTREE_SCRIPT="${WORKTREE_SCRIPT:-$(cd "$TEST_DIR/.." && pwd)/scripts/worktree}"

--- a/skills/worktree/tests/worktree_fix_links_unrestored.sh
+++ b/skills/worktree/tests/worktree_fix_links_unrestored.sh
@@ -18,6 +18,9 @@
 # reports an untracked child only when one EXISTS as a non-symlink, so an
 # absent link and a wrong-target link both read healthy through it.
 set -euo pipefail
+# A pre-commit hook exports GIT_DIR and GIT_INDEX_FILE, which point every git
+# call below at the real repository; -C overrides neither.
+unset GIT_DIR GIT_COMMON_DIR GIT_WORK_TREE GIT_INDEX_FILE
 
 TEST_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 SKILL_DIR="$(cd "$TEST_DIR/.." && pwd)"

--- a/skills/worktree/tests/worktree_for_branch.sh
+++ b/skills/worktree/tests/worktree_for_branch.sh
@@ -3,6 +3,9 @@
 # always carry a non-empty worktree path, so command-substitution callers can
 # treat empty output as "no worktree" without also getting exit 0.
 set -euo pipefail
+# A pre-commit hook exports GIT_DIR and GIT_INDEX_FILE, which point every git
+# call below at the real repository; -C overrides neither.
+unset GIT_DIR GIT_COMMON_DIR GIT_WORK_TREE GIT_INDEX_FILE
 
 TEST_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 WORKTREE_SCRIPT="${WORKTREE_SCRIPT:-$(cd "$TEST_DIR/.." && pwd)/scripts/worktree}"

--- a/skills/worktree/tests/worktree_materialized_links.sh
+++ b/skills/worktree/tests/worktree_materialized_links.sh
@@ -12,6 +12,9 @@
 # Both messages must send the operator to the MAIN CHECKOUT because the
 # worktree's own copy of the script can be missing.
 set -euo pipefail
+# A pre-commit hook exports GIT_DIR and GIT_INDEX_FILE, which point every git
+# call below at the real repository; -C overrides neither.
+unset GIT_DIR GIT_COMMON_DIR GIT_WORK_TREE GIT_INDEX_FILE
 
 TEST_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 SKILL_DIR="$(cd "$TEST_DIR/.." && pwd)"

--- a/skills/worktree/tests/worktree_no_worktree_installs.sh
+++ b/skills/worktree/tests/worktree_no_worktree_installs.sh
@@ -21,6 +21,9 @@
 #   8. a configured node_modules entry with no package.json beside it in the
 #      worktree stays silent.
 set -euo pipefail
+# A pre-commit hook exports GIT_DIR and GIT_INDEX_FILE, which point every git
+# call below at the real repository; -C overrides neither.
+unset GIT_DIR GIT_COMMON_DIR GIT_WORK_TREE GIT_INDEX_FILE
 
 TEST_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 SKILL_DIR="$(cd "$TEST_DIR/.." && pwd)"

--- a/skills/worktree/tests/worktree_path_safety.sh
+++ b/skills/worktree/tests/worktree_path_safety.sh
@@ -3,6 +3,9 @@
 # path arguments. These cases must fail before writing outside the intended
 # worktree or mutating another repository's registered worktree.
 set -euo pipefail
+# A pre-commit hook exports GIT_DIR and GIT_INDEX_FILE, which point every git
+# call below at the real repository; -C overrides neither.
+unset GIT_DIR GIT_COMMON_DIR GIT_WORK_TREE GIT_INDEX_FILE
 
 TEST_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 WORKTREE_SCRIPT="${WORKTREE_SCRIPT:-$(cd "$TEST_DIR/.." && pwd)/scripts/worktree}"

--- a/skills/worktree/tests/worktree_push_rebase.sh
+++ b/skills/worktree/tests/worktree_push_rebase.sh
@@ -10,6 +10,9 @@
 # base is already contained. Rebase must still run when the branch is genuinely
 # behind (does not contain the base as an ancestor).
 set -euo pipefail
+# A pre-commit hook exports GIT_DIR and GIT_INDEX_FILE, which point every git
+# call below at the real repository; -C overrides neither.
+unset GIT_DIR GIT_COMMON_DIR GIT_WORK_TREE GIT_INDEX_FILE
 
 TEST_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 # Default to the real script; allow override so the unguarded failure can be

--- a/skills/worktree/tests/worktree_remove.sh
+++ b/skills/worktree/tests/worktree_remove.sh
@@ -1,6 +1,9 @@
 #!/usr/bin/env bash
 # Tests for worktree remove diagnostics and branch cleanup.
 set -euo pipefail
+# A pre-commit hook exports GIT_DIR and GIT_INDEX_FILE, which point every git
+# call below at the real repository; -C overrides neither.
+unset GIT_DIR GIT_COMMON_DIR GIT_WORK_TREE GIT_INDEX_FILE
 
 TEST_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 WORKTREE_PACKAGE_DIR="$(cd "$TEST_DIR/.." && pwd)"

--- a/skills/worktree/tests/worktree_restack_replay.sh
+++ b/skills/worktree/tests/worktree_restack_replay.sh
@@ -370,6 +370,30 @@ assert_eq "$(git -C "$ABORT_WT" branch --show-current)" "issue-replay-abort" "gu
 assert_eq "$(git -C "$ABORT_WT" status --porcelain)" "" "guarded abort leaves the worktree clean"
 assert_eq "$(git -C "$ABORT_WT" config --worktree --get-regexp '^kendex-restack\.' 2>/dev/null || true)" "" "guarded abort clears pending state without authorization"
 
+# --- An orphaned record is cleared from the detached replay base ---------------
+# A replay never moves the branch, so a sequencer state that disappears out of
+# band leaves HEAD detached at the base with the tool's record still standing.
+# The guarded exit has to reattach the recorded branch (kendex#1195).
+DETACHED_ROOT="$TMP_ROOT/detached"
+make_conflict_pair "$DETACHED_ROOT" issue-replay-detached
+DETACHED_WT="$DETACHED_ROOT/trees/issue-replay-detached"
+detached_pre_head="$(git -C "$DETACHED_WT" rev-parse HEAD)"
+set +e
+(cd "$DETACHED_ROOT/main" && "$WORKTREE_SCRIPT" create issue-replay-detached --restack --replay >/dev/null 2>&1)
+set -e
+git -C "$DETACHED_WT" cherry-pick --abort
+assert_no_replay_paused "$DETACHED_WT" "the out-of-band cherry-pick abort removed the sequencer state"
+assert_eq "$(git -C "$DETACHED_WT" branch --show-current)" "" "the out-of-band abort leaves HEAD detached at the replay base"
+set +e
+detached_out="$(cd "$DETACHED_ROOT/main" && PATH="$NOREBASE_PATH" "$WORKTREE_SCRIPT" restack abort issue-replay-detached 2>"$DETACHED_ROOT/abort.err")"
+detached_code=$?
+set -e
+assert_eq "$detached_code" "0" "guarded abort exits 0 when only the tool's record is left"
+assert_contains "$detached_out" "cleared the recorded restack state" "guarded abort clears the orphaned replay record"
+assert_eq "$(git -C "$DETACHED_WT" branch --show-current)" "issue-replay-detached" "guarded abort reattaches the recorded branch"
+assert_eq "$(git -C "$DETACHED_WT" rev-parse HEAD)" "$detached_pre_head" "guarded abort leaves the branch at its recorded original head"
+assert_eq "$(git -C "$DETACHED_WT" config --worktree --get-regexp '^kendex-restack\.' 2>/dev/null || true)" "" "guarded abort leaves no kendex-restack key to unset by hand"
+
 # --- Remote movement while paused refuses continuation, abort still works ------
 MOVED_ROOT="$TMP_ROOT/moved"
 make_conflict_pair "$MOVED_ROOT" issue-replay-moved

--- a/skills/worktree/tests/worktree_restack_replay.sh
+++ b/skills/worktree/tests/worktree_restack_replay.sh
@@ -377,7 +377,7 @@ assert_eq "$(git -C "$ABORT_WT" config --worktree --get-regexp '^kendex-restack\
 # The replay cross-check asserts HEAD is detached. continue and skip pick onto
 # that detach point and still need it; abort does not, and refusing there left
 # no guarded exit. A two-commit branch is what reaches this: a one-commit range
-# never pauses with a second pick outstanding (kendex#1195).
+# never pauses with a second pick outstanding.
 ONBRANCH_ROOT="$TMP_ROOT/onbranch"
 make_conflict_pair "$ONBRANCH_ROOT" issue-replay-onbranch
 ONBRANCH_WT="$ONBRANCH_ROOT/trees/issue-replay-onbranch"
@@ -407,7 +407,7 @@ assert_eq "$(git -C "$ONBRANCH_WT" config --worktree --get-regexp '^kendex-resta
 
 # `cherry-pick --quit` drops the sequencer and leaves the index unmerged, so the
 # orphan path cannot reattach. It refuses with Git's reason rather than forcing
-# the checkout over the resolver's staged work (kendex#1195).
+# the checkout over the resolver's staged work.
 REPLAY_QUIT_ROOT="$TMP_ROOT/replay-quit"
 make_conflict_pair "$REPLAY_QUIT_ROOT" issue-replay-quit
 REPLAY_QUIT_WT="$REPLAY_QUIT_ROOT/trees/issue-replay-quit"
@@ -430,7 +430,7 @@ assert_eq "$(git -C "$REPLAY_QUIT_WT" config --worktree --get kendex-restack.pen
 # --- An orphaned record is cleared from the detached replay base ---------------
 # A replay never moves the branch, so a sequencer state that disappears out of
 # band leaves HEAD detached at the base with the tool's record still standing.
-# The guarded exit has to reattach the recorded branch (kendex#1195).
+# The guarded exit has to reattach the recorded branch.
 DETACHED_ROOT="$TMP_ROOT/detached"
 make_conflict_pair "$DETACHED_ROOT" issue-replay-detached
 DETACHED_WT="$DETACHED_ROOT/trees/issue-replay-detached"

--- a/skills/worktree/tests/worktree_restack_replay.sh
+++ b/skills/worktree/tests/worktree_restack_replay.sh
@@ -11,6 +11,9 @@
 # token binding), and record the same pinned force-with-lease authorization
 # that `worktree push` consumes and the remote lease model fails closed on.
 set -euo pipefail
+# A pre-commit hook exports GIT_DIR and GIT_INDEX_FILE, which point every git
+# call below at the real repository; -C overrides neither.
+unset GIT_DIR GIT_COMMON_DIR GIT_WORK_TREE GIT_INDEX_FILE
 
 TEST_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 SKILL_DIR="$(cd "$TEST_DIR/.." && pwd)"
@@ -369,6 +372,60 @@ assert_eq "$(git -C "$ABORT_WT" rev-parse HEAD)" "$abort_pre_head" "guarded abor
 assert_eq "$(git -C "$ABORT_WT" branch --show-current)" "issue-replay-abort" "guarded abort reattaches the issue branch"
 assert_eq "$(git -C "$ABORT_WT" status --porcelain)" "" "guarded abort leaves the worktree clean"
 assert_eq "$(git -C "$ABORT_WT" config --worktree --get-regexp '^kendex-restack\.' 2>/dev/null || true)" "" "guarded abort clears pending state without authorization"
+
+# --- A paused replay whose HEAD moved onto the branch still aborts -------------
+# The replay cross-check asserts HEAD is detached. continue and skip pick onto
+# that detach point and still need it; abort does not, and refusing there left
+# no guarded exit. A two-commit branch is what reaches this: a one-commit range
+# never pauses with a second pick outstanding (kendex#1195).
+ONBRANCH_ROOT="$TMP_ROOT/onbranch"
+make_conflict_pair "$ONBRANCH_ROOT" issue-replay-onbranch
+ONBRANCH_WT="$ONBRANCH_ROOT/trees/issue-replay-onbranch"
+printf 'second\n' > "$ONBRANCH_WT/second.txt"
+git -C "$ONBRANCH_WT" add second.txt
+git -C "$ONBRANCH_WT" commit -q -m 'second commit'
+onbranch_pre_head="$(git -C "$ONBRANCH_WT" rev-parse HEAD)"
+set +e
+(cd "$ONBRANCH_ROOT/main" && "$WORKTREE_SCRIPT" create issue-replay-onbranch --restack --replay >/dev/null 2>&1)
+set -e
+assert_replay_paused "$ONBRANCH_WT" "the two-commit replay pauses on the first conflict"
+git -C "$ONBRANCH_WT" checkout -f issue-replay-onbranch >/dev/null 2>&1
+assert_eq "$(git -C "$ONBRANCH_WT" branch --show-current)" "issue-replay-onbranch" "the raw checkout moved HEAD onto the branch"
+set +e
+(cd "$ONBRANCH_ROOT/main" && "$WORKTREE_SCRIPT" restack continue issue-replay-onbranch >/dev/null 2>"$ONBRANCH_ROOT/continue.err")
+onbranch_continue_code=$?
+onbranch_out="$(cd "$ONBRANCH_ROOT/main" && PATH="$NOREBASE_PATH" "$WORKTREE_SCRIPT" restack abort issue-replay-onbranch 2>"$ONBRANCH_ROOT/abort.err")"
+onbranch_abort_code=$?
+set -e
+assert_eq "$onbranch_continue_code" "1" "guarded continue still requires the detached replay HEAD"
+assert_contains "$(cat "$ONBRANCH_ROOT/continue.err")" "not the replay recorded by the worktree tool" "the continue refusal names the moved HEAD"
+assert_eq "$onbranch_abort_code" "0" "guarded abort exits 0 with HEAD moved onto the branch"
+assert_contains "$onbranch_out" "Aborted guarded restack" "guarded abort reports the restored branch"
+assert_no_replay_paused "$ONBRANCH_WT" "guarded abort clears the sequencer state"
+assert_eq "$(git -C "$ONBRANCH_WT" rev-parse HEAD)" "$onbranch_pre_head" "guarded abort restores the recorded original head"
+assert_eq "$(git -C "$ONBRANCH_WT" config --worktree --get-regexp '^kendex-restack\.' 2>/dev/null || true)" "" "guarded abort leaves no kendex-restack key to unset by hand"
+
+# `cherry-pick --quit` drops the sequencer and leaves the index unmerged, so the
+# orphan path cannot reattach. It refuses with Git's reason rather than forcing
+# the checkout over the resolver's staged work (kendex#1195).
+REPLAY_QUIT_ROOT="$TMP_ROOT/replay-quit"
+make_conflict_pair "$REPLAY_QUIT_ROOT" issue-replay-quit
+REPLAY_QUIT_WT="$REPLAY_QUIT_ROOT/trees/issue-replay-quit"
+set +e
+(cd "$REPLAY_QUIT_ROOT/main" && "$WORKTREE_SCRIPT" create issue-replay-quit --restack --replay >/dev/null 2>&1)
+set -e
+git -C "$REPLAY_QUIT_WT" cherry-pick --quit
+assert_no_replay_paused "$REPLAY_QUIT_WT" "the out-of-band quit removed the sequencer state"
+assert_ne "$(git -C "$REPLAY_QUIT_WT" ls-files -u)" "" "the quit left the index unmerged"
+set +e
+(cd "$REPLAY_QUIT_ROOT/main" && "$WORKTREE_SCRIPT" restack abort issue-replay-quit >/dev/null 2>"$REPLAY_QUIT_ROOT/abort.err")
+replay_quit_code=$?
+set -e
+replay_quit_err="$(cat "$REPLAY_QUIT_ROOT/abort.err")"
+assert_eq "$replay_quit_code" "1" "an unreattachable replay refuses instead of forcing the checkout"
+assert_contains "$replay_quit_err" "git: " "the refusal carries Git's own reason"
+assert_contains "$replay_quit_err" "restack abort" "the refusal names the next step"
+assert_eq "$(git -C "$REPLAY_QUIT_WT" config --worktree --get kendex-restack.pending)" "true" "the refused abort preserves the recorded state"
 
 # --- An orphaned record is cleared from the detached replay base ---------------
 # A replay never moves the branch, so a sequencer state that disappears out of

--- a/skills/worktree/tests/worktree_reuse_shadowed_tracked.sh
+++ b/skills/worktree/tests/worktree_reuse_shadowed_tracked.sh
@@ -7,6 +7,9 @@
 # writes them directly. The reuse path must still succeed, and re-applying
 # setup afterwards must keep the per-child layout intact.
 set -euo pipefail
+# A pre-commit hook exports GIT_DIR and GIT_INDEX_FILE, which point every git
+# call below at the real repository; -C overrides neither.
+unset GIT_DIR GIT_COMMON_DIR GIT_WORK_TREE GIT_INDEX_FILE
 
 TEST_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 WORKTREE_SCRIPT="${WORKTREE_SCRIPT:-$(cd "$TEST_DIR/.." && pwd)/scripts/worktree}"

--- a/skills/worktree/tests/worktree_session_guard_lifecycle.sh
+++ b/skills/worktree/tests/worktree_session_guard_lifecycle.sh
@@ -21,6 +21,9 @@
 # mkdir mutex on hosts with no flock, reached here by running the guard on a
 # PATH built without flock.
 set -euo pipefail
+# A pre-commit hook exports GIT_DIR and GIT_INDEX_FILE, which point every git
+# call below at the real repository; -C overrides neither.
+unset GIT_DIR GIT_COMMON_DIR GIT_WORK_TREE GIT_INDEX_FILE
 
 TEST_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 WORKTREE_PACKAGE_DIR="$(cd "$TEST_DIR/.." && pwd)"

--- a/skills/worktree/tests/worktree_symlink_shadows_tracked.sh
+++ b/skills/worktree/tests/worktree_symlink_shadows_tracked.sh
@@ -8,6 +8,9 @@
 # tracked and untracked content. A fully untracked entry keeps the plain
 # parent symlink.
 set -euo pipefail
+# A pre-commit hook exports GIT_DIR and GIT_INDEX_FILE, which point every git
+# call below at the real repository; -C overrides neither.
+unset GIT_DIR GIT_COMMON_DIR GIT_WORK_TREE GIT_INDEX_FILE
 
 TEST_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 WORKTREE_SCRIPT="${WORKTREE_SCRIPT:-$(cd "$TEST_DIR/.." && pwd)/scripts/worktree}"


### PR DESCRIPTION
Closes KEN-1195.

`worktree restack continue` reported "unmerged conflicts" against a clean index because git's own message names merge conflicts whatever the cause; the real cause was an unstaged tracked file, and the tool's next line offered a `skip` that would drop the commit just resolved. `restack continue` now names the unstaged files. `restack abort` now works from the two states that had no guarded exit: a paused restack whose HEAD moved off the recorded base, and a record whose paused git state is gone.

The third item, a local test battery clearing the restack push authorization, has a different cause: a successful guarded `worktree push` consumes the authorization by design (`push --help` states it, the suite asserts it), and PR #2064's timeline shows the push landed before the observation. No suite on main touches another worktree's config; 226 suites were run one at a time beside a live authorization. The one route to another worktree's config is the git environment a hook exports, under which 19 of the 21 worktree suites died at their first fixture. They now carry the preamble the other two had, and one control holds a live authorization across a sibling suite run under that environment. Sixteen issue-number parentheticals left the prior round's comments for the comments lane.

Program: KEN-1203.

https://claude.ai/code/session_01Usy4MieuS46bh4aTooAXo2
