### PR TITLE
ci(KEN-922): every skill suite runs on macOS /bin/bash 3.2

### DIFF
--- a/.agents/skills/bot-instructions/tests/repo-state.test.sh
+++ b/.agents/skills/bot-instructions/tests/repo-state.test.sh
@@ -26,18 +26,22 @@ expect_red 'agents-section orphan' 'the nested clause reds with every flag false
 rm -f "$repo/crates/core/AGENTS.md"
 cp "$BI_FIXTURES/canonical.toml" "$repo/kendex.toml"
 
-# The same nested file under a directory whose NAME is not UTF-8, which is a
-# legal name on every filesystem this runs on. A lossy decode replaces the
+# The same nested file under a directory whose NAME is not UTF-8, a legal
+# name on every Linux filesystem and one APFS refuses, so the case runs where
+# the name can exist and says so where it cannot. A lossy decode replaces the
 # byte: the name still ends `/AGENTS.md` and still passes the nested filter,
 # then addresses a DIFFERENT path on the read. Surrogates round-trip.
 odd="$repo/$(printf 'x\xffy')"
-mkdir -p "$odd"
-printf '# odd\n\n## Code Review Rules\n\nunmanaged\n' > "$odd/AGENTS.md"
-git -C "$repo" add -A >/dev/null 2>&1
-expect_red agents-section 'a nested AGENTS.md under a name that is not UTF-8' \
-  check --repo "$repo"
-rm -rf -- "${odd:?}"
-git -C "$repo" add -A >/dev/null 2>&1
+if mkdir -p "$odd" 2>/dev/null; then
+  printf '# odd\n\n## Code Review Rules\n\nunmanaged\n' > "$odd/AGENTS.md"
+  git -C "$repo" add -A >/dev/null 2>&1
+  expect_red agents-section 'a nested AGENTS.md under a name that is not UTF-8' \
+    check --repo "$repo"
+  rm -rf -- "${odd:?}"
+  git -C "$repo" add -A >/dev/null 2>&1
+else
+  printf '  skip a nested AGENTS.md under a name that is not UTF-8: this filesystem refuses the name\n'
+fi
 
 python3 - "$repo/AGENTS.md" <<'PY'
 import sys

--- a/.agents/skills/commit-guards/scripts/commit-msg
+++ b/.agents/skills/commit-guards/scripts/commit-msg
@@ -117,8 +117,10 @@ gg_settings_index_mode
 TYPES="$(gg_setting COMMIT_GUARDS_COMMIT_TYPES "build chore ci docs feat fix perf refactor revert style test")" || exit 2
 TYPE_ALT=""
 for t in $TYPES; do
+  # Classes, not a-z: Bash 3.2 reads a bracket range by locale collation,
+  # under which an uppercase letter sits inside [a-z].
   case "$t" in
-    "" | *[!a-z0-9-]*) gg_config_error "COMMIT_GUARDS_COMMIT_TYPES entry '$(gg_scrubbed "$t")' is not a lowercase type name" ;;
+    "" | *[![:lower:][:digit:]-]*) gg_config_error "COMMIT_GUARDS_COMMIT_TYPES entry '$(gg_scrubbed "$t")' is not a lowercase type name" ;;
   esac
   TYPE_ALT="${TYPE_ALT:+$TYPE_ALT|}$t"
 done

--- a/.agents/skills/commit-guards/scripts/commit-msg
+++ b/.agents/skills/commit-guards/scripts/commit-msg
@@ -117,11 +117,10 @@ gg_settings_index_mode
 TYPES="$(gg_setting COMMIT_GUARDS_COMMIT_TYPES "build chore ci docs feat fix perf refactor revert style test")" || exit 2
 TYPE_ALT=""
 for t in $TYPES; do
-  # Classes, not a-z: Bash 3.2 reads a bracket range by locale collation,
-  # under which an uppercase letter sits inside [a-z].
-  case "$t" in
-    "" | *[![:lower:][:digit:]-]*) gg_config_error "COMMIT_GUARDS_COMMIT_TYPES entry '$(gg_scrubbed "$t")' is not a lowercase type name" ;;
-  esac
+  # LC_ALL=C grep, as the header match below: a `case` range is a collation
+  # range in a UTF-8 locale, under which Bash 3.2 puts `F` inside [a-z].
+  printf '%s\n' "$t" | LC_ALL=C grep -qE '^[a-z0-9-]+$' ||
+    gg_config_error "COMMIT_GUARDS_COMMIT_TYPES entry '$(gg_scrubbed "$t")' is not a lowercase type name"
   TYPE_ALT="${TYPE_ALT:+$TYPE_ALT|}$t"
 done
 [ -n "$TYPE_ALT" ] || gg_config_error "COMMIT_GUARDS_COMMIT_TYPES resolved empty — at least one type is required"

--- a/.agents/skills/commit-guards/scripts/lib/hook-check.sh
+++ b/.agents/skills/commit-guards/scripts/lib/hook-check.sh
@@ -115,7 +115,9 @@ check_helper_head() { # HEAD -> 0 ours, 1 not
   esac
   inner="${head#"$prefix"}"
   inner="${inner%"$suffix"}"
-  value="${inner//"$esc"/"$sq"}"
+  # The replacement is unquoted: Bash 3.2 keeps the quotes of a quoted one
+  # as literal bytes, and a value rebuilt around them is never ours.
+  value="${inner//"$esc"/$sq}"
   [ "$(gg_shell_quote "$value")" = "$inner" ] || return 1
   gg_same_project_elsewhere "$value"
 }

--- a/.agents/skills/commit-guards/tests/lib/harness.bash
+++ b/.agents/skills/commit-guards/tests/lib/harness.bash
@@ -18,7 +18,11 @@ set -euo pipefail
 gg_suite="${0##*/}"
 gg_suite="${gg_suite%.test.sh}"
 
-TMP="$(mktemp -d "${TMPDIR:-/tmp}/gg-${gg_suite}.XXXXXX")" || {
+# The trailing slash macOS puts on TMPDIR is dropped first: a `//` in a
+# fixture path never matches the path a script normalises and prints back.
+gg_tmpdir="${TMPDIR:-/tmp}"
+gg_tmpdir="${gg_tmpdir%/}"
+TMP="$(mktemp -d "$gg_tmpdir/gg-${gg_suite}.XXXXXX")" || {
   echo "harness: could not create a scratch root under ${TMPDIR:-/tmp}" >&2
   exit 2
 }

--- a/.agents/skills/github/scripts/git-diff-summary
+++ b/.agents/skills/github/scripts/git-diff-summary
@@ -323,9 +323,12 @@ is_cfg_test_declared() {
     # target, so a route discovered by any scan is genuine no matter which
     # candidate prompted it; ERR (unreadable module) fails this candidate
     # closed only when the file sits in its consulted set.
+    # The directory list crosses into awk tab-joined: BWK awk (macOS) refuses
+    # a -v value carrying a newline, and a tab cannot sit in a path the
+    # tab-separated cache already holds.
     routes=$(printf '%s\n' "$DECL_CACHE" | awk -F'\t' \
-        -v cand="$candidate" -v dirs="$relevant_dirs" '
-        BEGIN { n = split(dirs, a, "\n"); for (i = 1; i <= n; i++) rd[a[i]] = 1 }
+        -v cand="$candidate" -v dirs="$(printf '%s' "$relevant_dirs" | tr '\n' '\t')" '
+        BEGIN { n = split(dirs, a, "\t"); for (i = 1; i <= n; i++) rd[a[i]] = 1 }
         $1 == cand { next }
         $3 == "ERR" { if ($2 in rd) print "err"; next }
         $4 != cand { next }

--- a/.agents/skills/orch/tests/lanes.sh
+++ b/.agents/skills/orch/tests/lanes.sh
@@ -216,7 +216,8 @@ stage_panes() {
   PANES_PATH="$CLAIM_BIN"
   [[ "$spec" != broken ]] || { PANES_PATH="$FAIL_BIN"; return; }
   IFS=';' read -ra parts <<<"$spec"
-  for part in "${parts[@]}"; do
+  # An empty spec leaves the array empty, which Bash 3.2 reads as unbound.
+  for part in ${parts[@]+"${parts[@]}"}; do
     target="$PANES"
     entries="$part"
     if [[ "$part" == *=* ]]; then

--- a/.agents/skills/orch/tests/open-terminal-lane.sh
+++ b/.agents/skills/orch/tests/open-terminal-lane.sh
@@ -15,7 +15,9 @@ TEST_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 SCRIPTS_DIR="$(cd "$TEST_DIR/.." && pwd)/scripts"
 OPEN_TERMINAL="$SCRIPTS_DIR/open-terminal"
 
-TMP_ROOT="$(mktemp -d)"
+# Physical: on macOS the temp root sits under /var -> /private/var, and the
+# scripts print the resolved path.
+TMP_ROOT="$(cd "$(mktemp -d)" && pwd -P)"
 trap 'rm -rf "$TMP_ROOT"' EXIT
 
 # shellcheck source=lib/waiter-assertions.sh

--- a/.agents/skills/orch/tests/worktree_push.sh
+++ b/.agents/skills/orch/tests/worktree_push.sh
@@ -21,7 +21,9 @@ ARTIFACT_CHECK="$REPO_ROOT/skills/orch/scripts/dev-artifact-check"
 # shellcheck source=lib/growth-state.sh
 source "$TEST_DIR/lib/growth-state.sh"
 
-TMP_ROOT="$(mktemp -d)"
+# Physical: on macOS the temp root sits under /var -> /private/var, and the
+# scripts print the resolved path.
+TMP_ROOT="$(cd "$(mktemp -d)" && pwd -P)"
 trap 'rm -rf "$TMP_ROOT"' EXIT
 
 PASS=0

--- a/.agents/skills/orch/tests/worktree_push.sh
+++ b/.agents/skills/orch/tests/worktree_push.sh
@@ -326,9 +326,12 @@ for arg in "$@"; do
     ;;
   esac
 done
+# The honest answer is a variable, not a default word: Bash 3.2 keeps the
+# backslash of a `\}` inside `${var:-word}`, which is not JSON.
+honest='{"path":"/x","exists":true}'
 if [[ "$mode" == exists ]]; then
   [[ "${STUB_EXISTS:-}" == fail ]] && exit 7
-  printf '%s\n' "${STUB_EXISTS_JSON:-{\"path\":\"/x\",\"exists\":true\}}"
+  printf '%s\n' "${STUB_EXISTS_JSON:-$honest}"
 fi
 exit 0
 EOF

--- a/.agents/skills/project-management/scripts/verification-scope
+++ b/.agents/skills/project-management/scripts/verification-scope
@@ -222,7 +222,7 @@ candidates=(${unique_candidates[@]+"${unique_candidates[@]}"})
 
 mode="repository"
 if [[ "$force_docs_only" == true ]]; then
-  for path in "${candidates[@]}"; do
+  for path in ${candidates[@]+"${candidates[@]}"}; do
     is_doc_path "$path" \
       || fail "--docs-only path is not documentation: $path"
   done
@@ -276,7 +276,7 @@ declare -a verification_paths=()
 if [[ "$mode" == "repository" ]]; then
   verification_paths=("${source_roots[@]}")
 else
-  verification_paths=("${candidates[@]}")
+  verification_paths=(${candidates[@]+"${candidates[@]}"})
 fi
 
 json_array() {
@@ -287,9 +287,10 @@ json_array() {
   fi
 }
 
-changed_json="$(json_array "${candidates[@]}")"
-roots_json="$(json_array "${source_roots[@]}")"
-paths_json="$(json_array "${verification_paths[@]}")"
+# Each list may be empty, which Bash 3.2 reads as unbound under set -u.
+changed_json="$(json_array ${candidates[@]+"${candidates[@]}"})"
+roots_json="$(json_array ${source_roots[@]+"${source_roots[@]}"})"
+paths_json="$(json_array ${verification_paths[@]+"${verification_paths[@]}"})"
 code_verification_required=true
 if [[ "$mode" == "docs-only" ]]; then
   code_verification_required=false

--- a/.agents/skills/review-gate/tests/predicate-re2-engine.test.sh
+++ b/.agents/skills/review-gate/tests/predicate-re2-engine.test.sh
@@ -102,9 +102,11 @@ fi
 : >"$work/httpd.log"
 python3 -u -m http.server 0 --bind 127.0.0.1 --directory "$srv" >"$work/httpd.log" 2>&1 &
 server_pid=$!
+# A minute, not ten seconds: the first python3 on a macOS runner takes
+# longer than that to print its banner.
 port=""
 i=0
-while [ "$i" -lt 100 ]; do
+while [ "$i" -lt 600 ]; do
   port="$(sed -n 's/.*port \([0-9][0-9]*\).*/\1/p' "$work/httpd.log" | head -1)"
   [ -n "$port" ] && break
   kill -0 "$server_pid" 2>/dev/null || break

--- a/.agents/skills/review-gate/tests/validate-workflow.test.sh
+++ b/.agents/skills/review-gate/tests/validate-workflow.test.sh
@@ -288,10 +288,10 @@ expect_fail "trailing space after a backslash continuation is a divergence" "$di
 sandbox
 dir="$DIR"
 # An `s` with an escaped newline, not a `0,/re/` range: that address is GNU
-# sed's, and BSD sed reads it as something else and changes nothing. `#` is
+# sed's, and BSD sed reads it as something else and changes nothing. `@` is
 # the delimiter so `&` never follows `|`, a spelling the portability lint reads.
-mutate "$dir" "s#^          set -u\$#&\\
-          # a shell comment inside the payload#"
+mutate "$dir" "s@^          set -u\$@&\\
+          # a shell comment inside the payload@"
 expect_fail "a comment inside a run: payload is a divergence" "$dir" "has diverged from the shipped template"
 
 # The BOUNDARY, stated rather than left to be discovered: comments are

--- a/.agents/skills/review-gate/tests/validate-workflow.test.sh
+++ b/.agents/skills/review-gate/tests/validate-workflow.test.sh
@@ -287,9 +287,11 @@ expect_fail "trailing space after a backslash continuation is a divergence" "$di
 
 sandbox
 dir="$DIR"
-mutate "$dir" "0,/^          set -u\$/{/^          set -u\$/a\\
-          # a shell comment inside the payload
-}"
+# An `s` with an escaped newline, not a `0,/re/` range: that address is GNU
+# sed's, and BSD sed reads it as something else and changes nothing. `#` is
+# the delimiter so `&` never follows `|`, a spelling the portability lint reads.
+mutate "$dir" "s#^          set -u\$#&\\
+          # a shell comment inside the payload#"
 expect_fail "a comment inside a run: payload is a divergence" "$dir" "has diverged from the shipped template"
 
 # The BOUNDARY, stated rather than left to be discovered: comments are

--- a/.agents/skills/reviewer/tests/measurement-fail-closed.test.sh
+++ b/.agents/skills/reviewer/tests/measurement-fail-closed.test.sh
@@ -209,9 +209,12 @@ else
 
   # MUST-FAIL CONTROLS on the escape: it has to SAY something, and it is
   # refused on its own terms rather than silently ignored.
+  # The body is assembled outside the substitution: Bash 3.2 splits a `\"`
+  # inside "$( )" at the quote and hands expect_reason the wrong words.
   for degenerate in '"."' '"n/a"' '"none"' '"unknown"' '"   "' '"---"' 'true' '0'; do
+    degenerate_body='{"agent":"reviewer-test","verdict":"pass","summary":"mutation: killed 0/0","blockers":[],"suggestions":[],"measurement_failed":'"$degenerate"'}'
     expect_reason \
-      "$(artifact "degenerate-$DEGEN_N" "{\"agent\":\"reviewer-test\",\"verdict\":\"pass\",\"summary\":\"mutation: killed 0/0\",\"blockers\":[],\"suggestions\":[],\"measurement_failed\":$degenerate}")" \
+      "$(artifact "degenerate-$DEGEN_N" "$degenerate_body")" \
       invalid_declaration "a declaration of $degenerate names no instrument and is refused"
     DEGEN_N=$((DEGEN_N + 1))
   done

--- a/.agents/skills/reviewer/tests/mutation-stability.test.sh
+++ b/.agents/skills/reviewer/tests/mutation-stability.test.sh
@@ -49,11 +49,14 @@ echo $$ > "$HANG_PID_FILE"
 trap '' TERM
 while :; do :; done
 T
+# The launcher is told apart inside the trap, not while this file is sourced:
+# Bash 3.2 reports $0 as `bash` at that point, whatever script it is starting.
+# Every other shell disarms itself on its first command.
 cat > "$TMP/launch-window.bashenv" <<'T'
-case "$0" in
-  *mutation-stability)
-    set -T
-    trap '
+set -T
+trap '
+  case "$0" in
+    *mutation-stability)
       if [ "$BASH_COMMAND" = "ACTIVE_PID=\$!" ]; then
         trap - DEBUG
         tries=0
@@ -64,9 +67,10 @@ case "$0" in
         : > "$LAUNCH_WINDOW_SIGNALLED"
         kill -TERM "$$"
       fi
-    ' DEBUG
-    ;;
-esac
+      ;;
+    *) trap - DEBUG ;;
+  esac
+' DEBUG
 T
 git -C "$REPO" add -A
 git -C "$REPO" -c user.email=t@t -c user.name=t commit -qm x

--- a/.agents/skills/second-opinion/scripts/second-opinion
+++ b/.agents/skills/second-opinion/scripts/second-opinion
@@ -1209,12 +1209,13 @@ ARTIFACT_PATH=""
 #
 # Order is load-bearing: repeated slashes collapse FIRST, or `.//x` strips its
 # leading `./` into the absolute-looking `/x`. Purely lexical — a `..` that
-# survives is still the vet's to refuse.
+# survives is still the vet's to refuse. The replacement is a bare `/`: Bash
+# 3.2 keeps the backslash of an escaped `\/` there, and wrote `.\/tmp`.
 normalize_relative_home() {
   local rel="$1"
-  while [[ "$rel" == *//* ]]; do rel="${rel//\/\//\/}"; done
+  while [[ "$rel" == *//* ]]; do rel="${rel//\/\///}"; done
   while [[ "$rel" == ./* ]]; do rel="${rel#./}"; done
-  while [[ "$rel" == */./* ]]; do rel="${rel//\/.\//\/}"; done
+  while [[ "$rel" == */./* ]]; do rel="${rel//\/.\///}"; done
   while [[ "$rel" == */. ]]; do rel="${rel%/.}"; done
   while [[ "$rel" == */ ]]; do rel="${rel%/}"; done
   if [[ "$rel" == "." ]]; then rel=""; fi

--- a/.agents/skills/second-opinion/scripts/second-opinion-runtime
+++ b/.agents/skills/second-opinion/scripts/second-opinion-runtime
@@ -1,5 +1,13 @@
 #!/usr/bin/env bash
 set -euo pipefail
+# What the EXIT handlers below read lives here, not in a frame: Bash 3.2 pops
+# a function's locals before it runs the EXIT trap an `exit` inside that
+# function fires, so a handler reading a local of the frame faults under
+# `set -u` instead of reclaiming the run. Each is assigned by the frame that
+# arms its handler and read by nothing else.
+GROUP_CLI_PID=""
+LAUNCH_WORKER_PID=""
+LAUNCH_RUNTIME_DIR=""
 RUNTIME_SELF="$(cd -- "$(dirname "${BASH_SOURCE[0]}")" && pwd)/${BASH_SOURCE[0]##*/}"
 die() { echo "second-opinion-runtime: $1" >&2; exit 1; }
 runtime_dir_valid() { [[ -d "$1" && ! -L "$1" ]]; }
@@ -87,8 +95,9 @@ group_run() {
   local stderr_file="$1"
   shift
   [[ $# -gt 0 ]] || die "group command is missing"
-  local cli_pid="" rc=0 cancel_rc=""
-  stop_cli() { [[ -z "$cli_pid" ]] || stop_process_group "$cli_pid" 25; }
+  local rc=0 cancel_rc=""
+  GROUP_CLI_PID=""
+  stop_cli() { [[ -z "$GROUP_CLI_PID" ]] || stop_process_group "$GROUP_CLI_PID" 25; }
   # OWN THE CHILD BEFORE A HANDLER MAY EXIT. Between the fork below and the
   # assignment that follows it there is no pid to act on, and a handler that
   # exited there would leave a live process group behind with nothing left to
@@ -107,13 +116,13 @@ group_run() {
   exec 8<&0
   set -m
   "$@" <&8 2>"$stderr_file" &
-  cli_pid=$!
+  GROUP_CLI_PID=$!
   set +m
   exec 8<&-
   trap 'stop_cli; exit 143' TERM HUP
   trap 'stop_cli; exit 130' INT
   [[ -z "$cancel_rc" ]] || { stop_cli; exit "$cancel_rc"; }
-  wait "$cli_pid" || rc=$?
+  wait "$GROUP_CLI_PID" || rc=$?
   stop_cli
   exit "$rc"
 }
@@ -142,11 +151,13 @@ launch() {
   [[ "$owned" == true || "$owned" == false ]] || die "owned must be true or false"
   [[ "$wait_slice" =~ ^[1-9][0-9]*$ && $wait_slice -lt 600 ]] \
     || die "wait slice must be positive and below 600 seconds"
-  # worker_pid is initialised, not merely declared: the cleanup below
+  # LAUNCH_WORKER_PID is cleared, not merely declared: the cleanup below
   # reads it, and it is armed before it is assigned. Under `set -u` a
-  # declared-but-unassigned local is still unbound, so a signal arriving in that
-  # first instant would fault the handler instead of running it.
-  local deadline worker_pid="" cancel_rc="" log="$runtime_dir/worker.log"
+  # declared-but-unassigned variable is still unbound, so a signal arriving in
+  # that first instant would fault the handler instead of running it.
+  LAUNCH_WORKER_PID=""
+  LAUNCH_RUNTIME_DIR="$runtime_dir"
+  local deadline cancel_rc="" log="$runtime_dir/worker.log"
   local status_file="$runtime_dir/worker.status" launch_umask
   local worker_args launch_model="${SECOND_OPINION_LAUNCH_MODEL:-}"
   # THE WINDOW BETWEEN THE FORK AND THE PROTOCOL. Once the worker exists it can
@@ -155,19 +166,20 @@ launch() {
   # cancelled or failed launch there strands a run nobody can wait on or stop.
   # Armed before the fork, cleared after the last protocol line.
   #
-  # It reads locals of this frame, so it must never run after launch RETURNS.
-  # That is why the traps are cleared at the end rather than gated on a flag:
-  # every path that reaches it — a signal, or `die` on a failed publish — is
-  # still inside the frame, where a flag would be readable but pointless.
+  # It reads the state this frame publishes for it, so it must never run
+  # after launch RETURNS. That is why the traps are cleared at the end rather
+  # than gated on a flag: every path that reaches it — a signal, or `die` on
+  # a failed publish — is still this launch's, where a flag would be readable
+  # but pointless.
   cleanup_launch() {
-    if [[ -n "$worker_pid" ]] && ! stop_process_group "$worker_pid" 30; then
-      echo "second-opinion-runtime: launch cleanup failed; runtime state preserved: $runtime_dir" >&2
+    if [[ -n "$LAUNCH_WORKER_PID" ]] && ! stop_process_group "$LAUNCH_WORKER_PID" 30; then
+      echo "second-opinion-runtime: launch cleanup failed; runtime state preserved: $LAUNCH_RUNTIME_DIR" >&2
       return 1
     fi
-    ! runtime_dir_valid "$runtime_dir" || rm -rf -- "${runtime_dir:?}" || true
+    ! runtime_dir_valid "$LAUNCH_RUNTIME_DIR" || rm -rf -- "${LAUNCH_RUNTIME_DIR:?}" || true
   }
   # Deferred across the fork window for the same reason as group_run: until
-  # worker_pid is assigned there is no group to stop, and a handler exiting
+  # LAUNCH_WORKER_PID is assigned there is no group to stop, and a handler exiting
   # there would strand the very run this cleanup exists to reclaim.
   request_cancel() { cancel_rc="$1"; }
   trap 'request_cancel 143' TERM HUP
@@ -202,13 +214,13 @@ launch() {
       exit "$rc"
     ' second-opinion-worker "$script" "${worker_args[@]}" \
     < /dev/null > "$log" 2>&1 &
-  worker_pid=$!
+  LAUNCH_WORKER_PID=$!
   set +m
   exec 9>&-
   trap 'cleanup_launch; exit 143' TERM HUP
   trap 'cleanup_launch; exit 130' INT
   [[ -z "$cancel_rc" ]] || { cleanup_launch; exit "$cancel_rc"; }
-  (umask 077 && set -C && printf '%s\n' "$worker_pid" > "$runtime_dir/pid") \
+  (umask 077 && set -C && printf '%s\n' "$LAUNCH_WORKER_PID" > "$runtime_dir/pid") \
     || die "cannot record detached worker pid: $runtime_dir/pid"
   printf 'artifact: %s\n' "$artifact"
   printf 'deadline: %s\n' "$deadline"

--- a/.agents/skills/second-opinion/tests/signal-kill-gate.test.sh
+++ b/.agents/skills/second-opinion/tests/signal-kill-gate.test.sh
@@ -105,12 +105,26 @@ chmod +x "$TMP_ROOT/bin/lane-good"
 # path in STUB_LANE_PATTERN; nothing else on the host does — then stays alive
 # only until that lane is gone, so its own exit can never race the
 # classification and the chain above it collapses as soon as the lane is dead.
+# The lane to kill is this stub's own ancestor, found by walking up the
+# parent chain: BSD pkill excludes the caller's ancestors from an argv match
+# by default, so a pattern kill from inside the lane reaches nothing on macOS.
 cat > "$TMP_ROOT/bin/kill-lane" <<'SH'
 #!/usr/bin/env bash
 cat > /dev/null
 echo $$ >> "$STUB_PIDS"
-pkill -TERM -f -- "$STUB_LANE_PATTERN"
-for _ in $(seq 50); do pgrep -f -- "$STUB_LANE_PATTERN" >/dev/null || break; sleep 0.1; done
+# Every matching ancestor, the lane child included, as the pattern kill
+# reached; /bin/ps by path, since the ps on PATH is this suite's stand-in.
+pid=$PPID
+targets=""
+while [ "$pid" -gt 1 ]; do
+  case "$(/bin/ps -o args= -p "$pid")" in
+    *"$STUB_LANE_PATTERN"*) targets="$targets $pid" ;;
+  esac
+  pid=$(/bin/ps -o ppid= -p "$pid" | tr -d ' ')
+  [ -n "$pid" ] || break
+done
+[ -z "$targets" ] || kill -TERM $targets
+for _ in $(seq 50); do kill -0 $targets 2>/dev/null || break; sleep 0.1; done
 SH
 chmod +x "$TMP_ROOT/bin/kill-lane"
 

--- a/.github/workflows/skill-tests.yml
+++ b/.github/workflows/skill-tests.yml
@@ -177,28 +177,44 @@ jobs:
           done
           exit "$fail"
 
-      # The must-fail control. The construct is read out of the fixture that
-      # pins it as a miss of the text scan, so the probe is by construction
-      # one the scan cannot catch and the shell can: the scan is run on it
-      # and must be clean, and under Bash 3.2 a quoted name of a builtin the
-      # shell does not have is `command not found`, exit 127. Any other exit
-      # — 0 on a shell that has mapfile — fails the leg.
-      - name: probe — a quoted Bash 4 builtin fails under this shell
+      # The must-fail control, one row per axis the text scan cannot reach:
+      # a builtin name behind quote removal, and one behind word splitting —
+      # a redirection standing where the scan expects a separator. Each line
+      # is read out of the fixture that pins it as a miss of the scan, so the
+      # probe is by construction one the scan cannot catch and the shell can:
+      # the scan is run on the pair and must be clean, and Bash 3.2 gives a
+      # quoted name of a builtin it lacks `command not found`, 127, and the
+      # `-A` it never had `invalid option`, 2. Any other exit — 0 on a shell
+      # that has both — fails the leg.
+      - name: probe — Bash 4 constructs the scan cannot see fail under this shell
         if: matrix.os == 'macos-latest'
         run: |
           set -u
           fixture=tools/tests/data/bash32-uncatchable.txt
-          line="$(grep -xF -- "'mapfile' -t values" "$fixture")" ||
-            { echo "$fixture no longer pins the quoted builtin this probe runs"; exit 1; }
           dir="$RUNNER_TEMP/bash32-probe"
           mkdir "$dir"
-          printf '%s\n' '#!/usr/bin/env bash' 'set -u' "$line" >"$dir/quoted-builtin.sh"
+          fail=0
+          n=0
+          while IFS='|' read -r construct want; do
+            n=$((n + 1))
+            line="$(grep -xF -- "$construct" "$fixture")" ||
+              { echo "$fixture no longer pins '$construct' as a miss, so it is no probe"; exit 1; }
+            printf '%s\n' '#!/usr/bin/env bash' 'set -u' "$line" >"$dir/probe-$n.sh"
+            status=0
+            bash "$dir/probe-$n.sh" </dev/null || status=$?
+            if [ "$status" -eq "$want" ]; then
+              echo "probe $n failed under Bash 3.2 as it must: $construct (exit $status)"
+            else
+              echo "probe $n exited $status under Bash $BASH_VERSION; 3.2 gives '$construct' exit $want"
+              fail=1
+            fi
+          done <<'EOF'
+          'mapfile' -t values|127
+          declare>/dev/null -A cache|2
+          EOF
+          [ "$n" -eq 2 ] || { echo "the probe table read $n rows, not 2"; exit 1; }
           tools/bash32-lint "$dir"
-          status=0
-          bash "$dir/quoted-builtin.sh" </dev/null || status=$?
-          [ "$status" -eq 127 ] ||
-            { echo "the probe exited $status under Bash $BASH_VERSION; 3.2 gives it 127, command not found"; exit 1; }
-          echo "the probe failed under Bash 3.2 as it must (exit $status)"
+          exit "$fail"
 
       - name: shard names agree with the matrix
         env:

--- a/.github/workflows/skill-tests.yml
+++ b/.github/workflows/skill-tests.yml
@@ -91,8 +91,9 @@ jobs:
   #
   # The leg swaps the shell and nothing else on purpose: it installs the GNU
   # userland the suites are written against — coreutils, sed, grep, awk,
-  # find, diff and flock, which macOS lacks outright (workflow-state and
-  # lanes take flock with no fallback) or ships as BSD — and asserts each
+  # find, diff, and util-linux for flock and setsid, which macOS lacks
+  # outright (workflow-state and lanes take flock with no fallback, and
+  # open-terminal detaches with setsid) or ships as BSD — and asserts each
   # beside the shell, so a red leg is a Bash 3.2 finding and not a utility
   # difference. What the suites do on the BSD userland is a property of its
   # own that this leg does not prove.
@@ -126,11 +127,12 @@ jobs:
           HOMEBREW_NO_INSTALL_CLEANUP: '1'
         run: |
           set -u
-          brew install coreutils gnu-sed grep gawk findutils diffutils flock
+          brew install coreutils gnu-sed grep gawk findutils diffutils util-linux
           prefix="$(brew --prefix)"
           for f in coreutils gnu-sed grep gawk findutils; do
             echo "$prefix/opt/$f/libexec/gnubin" >>"$GITHUB_PATH"
           done
+          echo "$prefix/opt/util-linux/bin" >>"$GITHUB_PATH"
 
       - name: /bin/bash first on PATH
         if: matrix.os == 'macos-latest'
@@ -162,7 +164,7 @@ jobs:
           got "/usr/bin/env bash" "$(version_of /usr/bin/env bash)"
           # The utilities the step above installed, resolved the way a suite
           # resolves them: present, and the GNU one where macOS ships a BSD one.
-          for c in flock timeout sha256sum; do
+          for c in flock setsid timeout sha256sum; do
             command -v "$c" || { echo "$c is not on PATH; the suites that call it would fail for the wrong reason"; fail=1; }
           done
           for c in sed grep awk find diff; do

--- a/.github/workflows/skill-tests.yml
+++ b/.github/workflows/skill-tests.yml
@@ -18,9 +18,10 @@ name: Skill Tests
 # answers review-only; see the review-gate skill) — no gate job reads the
 # predicate.
 #
-# Every job names its GitHub-hosted runner in `runs-on:`, the same label on
-# every event. The repository is public, so those runners are free, and shard
-# durations compare across events.
+# Every job names its GitHub-hosted runner in `runs-on:`, directly or through
+# its matrix's `os` list, the same label on every event. The repository is
+# public, so those runners are free, and shard durations compare across
+# events.
 #
 # SHARD BUDGET: a shard whose measured wall time passes five minutes is split,
 # not widened. Each test step carries a `timeout-minutes` set from the last
@@ -74,17 +75,91 @@ jobs:
   # ten runs before the split: review-gate 58s, orch 250s, node 101s,
   # pi-claude-bridge 45s; after it the shell shards are guards ~230s, linear
   # ~205s, rest ~170s.
+  #
+  # THE macOS LEG runs the five shell shards a second time on the runner whose
+  # /bin/bash is 3.2.57, the shell every skill claims to support (skills/
+  # AGENTS.md). tools/bash32-lint scans the source for that claim; this leg
+  # runs it, which is the only way to reach what a text scan cannot — a
+  # quoted builtin name, a construct assembled at runtime. The image's only
+  # bash is that one today, and the leg does not rely on it: a symlink to
+  # /bin/bash goes first on PATH, so the step shell, a `bash "$t"` in a loop
+  # and every `#!/usr/bin/env bash` under it resolve to the same interpreter,
+  # and a step asserts the version each of those resolutions got before any
+  # suite runs — a leg that ran Bash 5 in silence would report a property it
+  # never tested. The probe step after it is the leg's must-fail control. The
+  # node shards are excluded: nothing in them is bash.
   skill-suites-shard:
-    name: Skill suites shard (${{ matrix.shard }})
+    name: Skill suites shard (${{ matrix.shard }}, ${{ matrix.os }})
     if: github.event_name != 'push'
     strategy:
       fail-fast: false
       matrix:
         shard: [review-gate, orch, guards, linear, rest, node, pi-claude-bridge]
-    runs-on: ubuntu-latest
+        os: [ubuntu-latest, macos-latest]
+        exclude:
+          - os: macos-latest
+            shard: node
+          - os: macos-latest
+            shard: pi-claude-bridge
+    runs-on: ${{ matrix.os }}
     timeout-minutes: 15
     steps:
       - uses: actions/checkout@v4
+
+      # ---- macOS leg: Bash 3.2 first on PATH, asserted, and its probe -----
+      - name: /bin/bash first on PATH
+        if: matrix.os == 'macos-latest'
+        run: |
+          set -u
+          mkdir "$RUNNER_TEMP/bash32"
+          ln -s /bin/bash "$RUNNER_TEMP/bash32/bash"
+          echo "$RUNNER_TEMP/bash32" >>"$GITHUB_PATH"
+
+      # Its own step, so the PATH above is in force. A suite reaches the
+      # shell three ways — the step shell that runs the loop, the `bash` the
+      # loop names, and the `/usr/bin/env bash` in a script's shebang — and
+      # each is asked what it is. One that is not 3.2 ends the leg.
+      - name: the interpreter is Bash 3.2
+        if: matrix.os == 'macos-latest'
+        run: |
+          set -u
+          fail=0
+          # shellcheck disable=SC2016 # the child expands it, which is the point
+          version_of() { "$@" -c 'printf %s "$BASH_VERSION"'; }
+          got() { # got WHAT VERSION
+            case "$2" in
+              3.2.*) echo "$1: Bash $2" ;;
+              *) echo "$1: Bash $2, not 3.2 — this leg would test nothing"; fail=1 ;;
+            esac
+          }
+          got "the step shell" "$BASH_VERSION"
+          got "bash on PATH, $(command -v bash)" "$(version_of bash)"
+          got "/usr/bin/env bash" "$(version_of /usr/bin/env bash)"
+          exit "$fail"
+
+      # The must-fail control. The construct is read out of the fixture that
+      # pins it as a miss of the text scan, so the probe is by construction
+      # one the scan cannot catch and the shell can: the scan is run on it
+      # and must be clean, and under Bash 3.2 a quoted name of a builtin the
+      # shell does not have is `command not found`, exit 127. Any other exit
+      # — 0 on a shell that has mapfile — fails the leg.
+      - name: probe — a quoted Bash 4 builtin fails under this shell
+        if: matrix.os == 'macos-latest'
+        run: |
+          set -u
+          fixture=tools/tests/data/bash32-uncatchable.txt
+          line="$(grep -xF -- "'mapfile' -t values" "$fixture")" ||
+            { echo "$fixture no longer pins the quoted builtin this probe runs"; exit 1; }
+          dir="$RUNNER_TEMP/bash32-probe"
+          mkdir "$dir"
+          printf '%s\n' '#!/usr/bin/env bash' 'set -u' "$line" >"$dir/quoted-builtin.sh"
+          tools/bash32-lint "$dir"
+          status=0
+          bash "$dir/quoted-builtin.sh" </dev/null || status=$?
+          [ "$status" -eq 127 ] ||
+            { echo "the probe exited $status under Bash $BASH_VERSION; 3.2 gives it 127, command not found"; exit 1; }
+          echo "the probe failed under Bash 3.2 as it must (exit $status)"
+
       - name: shard names agree with the matrix
         env:
           SHARD: ${{ matrix.shard }}
@@ -190,13 +265,22 @@ jobs:
 
       # ---- shard: linear — the linear suites, and the two mid-sized
       # packages that balance the shard against `guards` ------------------
+      # The linear CLI's contract is Bash 4 or newer (skills/linear/scripts
+      # is tools/bash32-lint's NO_SCAN entry), so under Bash 3 its suites
+      # cannot pass and the one that runs is the contract suite, which under
+      # that shell proves the preflight diagnostic the contract promises.
       - name: linear, bot-instructions and preflight suites
         if: matrix.shard == 'linear'
         run: |
           set -u
+          if [ "${BASH_VERSINFO[0]}" -lt 4 ]; then
+            set -- skills/linear/tests/bash4-runtime-contract.test.sh
+          else
+            set -- skills/linear/tests/*.sh
+          fi
           fail=0
           failed=""
-          for t in skills/linear/tests/*.sh skills/bot-instructions/tests/*.sh skills/preflight/tests/*.sh; do
+          for t in "$@" skills/bot-instructions/tests/*.sh skills/preflight/tests/*.sh; do
             echo "=== $t"
             if ! bash "$t"; then
               echo "FAILED: $t"

--- a/.github/workflows/skill-tests.yml
+++ b/.github/workflows/skill-tests.yml
@@ -28,6 +28,9 @@ name: Skill Tests
 # ten runs' maximum with headroom, so a hang fails inside the budget instead
 # of running to the job ceiling; the compile steps carry their own for a cold
 # cache. The per-shard figures behind each budget are in the comment above it.
+# The budget is measured on the Linux leg: the macOS leg runs the same shards
+# on a runner that forks and spawns at less than half the pace, and carries
+# its own ceiling rather than a split of its own.
 
 "on":
   pull_request:
@@ -111,8 +114,9 @@ jobs:
           - os: macos-latest
             shard: pi-claude-bridge
     runs-on: ${{ matrix.os }}
-    # The macOS legs fork and spawn slower than the Linux ones on the same
-    # suites: first run, orch 13 min and guards 11 min against 4 and 4.
+    # The macOS legs on the same suites, first green run: orch 10m45s
+    # against 4m45s on Linux, guards 9m09s against 3m13s, rest 7m39s against
+    # 3m07s, review-gate 3m45s against 1m05s, linear 2m47s against 3m30s.
     timeout-minutes: ${{ matrix.os == 'macos-latest' && 30 || 15 }}
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/skill-tests.yml
+++ b/.github/workflows/skill-tests.yml
@@ -128,7 +128,7 @@ jobs:
           set -u
           brew install coreutils gnu-sed grep gawk findutils diffutils flock
           prefix="$(brew --prefix)"
-          for f in coreutils gnu-sed grep findutils; do
+          for f in coreutils gnu-sed grep gawk findutils; do
             echo "$prefix/opt/$f/libexec/gnubin" >>"$GITHUB_PATH"
           done
 

--- a/.github/workflows/skill-tests.yml
+++ b/.github/workflows/skill-tests.yml
@@ -88,6 +88,13 @@ jobs:
   # suite runs — a leg that ran Bash 5 in silence would report a property it
   # never tested. The probe step after it is the leg's must-fail control. The
   # node shards are excluded: nothing in them is bash.
+  #
+  # The leg swaps the shell and nothing else on purpose: the suites and the
+  # scripts they run call flock, timeout and sha256sum, which macOS does not
+  # ship (workflow-state and lanes take flock with no fallback), so the leg
+  # installs GNU coreutils and flock and asserts them beside the shell. A red
+  # leg is then a Bash 3.2 finding, not a missing utility. BSD sed, grep and
+  # awk stay the runner's: no suite has needed the GNU ones there.
   skill-suites-shard:
     name: Skill suites shard (${{ matrix.shard }}, ${{ matrix.os }})
     if: github.event_name != 'push'
@@ -107,6 +114,18 @@ jobs:
       - uses: actions/checkout@v4
 
       # ---- macOS leg: Bash 3.2 first on PATH, asserted, and its probe -----
+      # gnubin goes on PATH before the shell's directory does, so the
+      # directory added last, the shell's, is searched first.
+      - name: GNU coreutils and flock, which the suites call and macOS lacks
+        if: matrix.os == 'macos-latest'
+        env:
+          HOMEBREW_NO_AUTO_UPDATE: '1'
+          HOMEBREW_NO_INSTALL_CLEANUP: '1'
+        run: |
+          set -u
+          brew install coreutils flock
+          echo "$(brew --prefix)/opt/coreutils/libexec/gnubin" >>"$GITHUB_PATH"
+
       - name: /bin/bash first on PATH
         if: matrix.os == 'macos-latest'
         run: |
@@ -135,6 +154,11 @@ jobs:
           got "the step shell" "$BASH_VERSION"
           got "bash on PATH, $(command -v bash)" "$(version_of bash)"
           got "/usr/bin/env bash" "$(version_of /usr/bin/env bash)"
+          # The utilities the step above installed, resolved the way a suite
+          # resolves them.
+          for c in flock timeout sha256sum; do
+            command -v "$c" || { echo "$c is not on PATH; the suites that call it would fail for the wrong reason"; fail=1; }
+          done
           exit "$fail"
 
       # The must-fail control. The construct is read out of the fixture that

--- a/.github/workflows/skill-tests.yml
+++ b/.github/workflows/skill-tests.yml
@@ -89,12 +89,13 @@ jobs:
   # never tested. The probe step after it is the leg's must-fail control. The
   # node shards are excluded: nothing in them is bash.
   #
-  # The leg swaps the shell and nothing else on purpose: the suites and the
-  # scripts they run call flock, timeout and sha256sum, which macOS does not
-  # ship (workflow-state and lanes take flock with no fallback), so the leg
-  # installs GNU coreutils and flock and asserts them beside the shell. A red
-  # leg is then a Bash 3.2 finding, not a missing utility. BSD sed, grep and
-  # awk stay the runner's: no suite has needed the GNU ones there.
+  # The leg swaps the shell and nothing else on purpose: it installs the GNU
+  # userland the suites are written against — coreutils, sed, grep, awk,
+  # find, diff and flock, which macOS lacks outright (workflow-state and
+  # lanes take flock with no fallback) or ships as BSD — and asserts each
+  # beside the shell, so a red leg is a Bash 3.2 finding and not a utility
+  # difference. What the suites do on the BSD userland is a property of its
+  # own that this leg does not prove.
   skill-suites-shard:
     name: Skill suites shard (${{ matrix.shard }}, ${{ matrix.os }})
     if: github.event_name != 'push'
@@ -109,22 +110,27 @@ jobs:
           - os: macos-latest
             shard: pi-claude-bridge
     runs-on: ${{ matrix.os }}
-    timeout-minutes: 15
+    # The macOS legs fork and spawn slower than the Linux ones on the same
+    # suites: first run, orch 13 min and guards 11 min against 4 and 4.
+    timeout-minutes: ${{ matrix.os == 'macos-latest' && 30 || 15 }}
     steps:
       - uses: actions/checkout@v4
 
       # ---- macOS leg: Bash 3.2 first on PATH, asserted, and its probe -----
       # gnubin goes on PATH before the shell's directory does, so the
       # directory added last, the shell's, is searched first.
-      - name: GNU coreutils and flock, which the suites call and macOS lacks
+      - name: the GNU userland the suites are written against
         if: matrix.os == 'macos-latest'
         env:
           HOMEBREW_NO_AUTO_UPDATE: '1'
           HOMEBREW_NO_INSTALL_CLEANUP: '1'
         run: |
           set -u
-          brew install coreutils flock
-          echo "$(brew --prefix)/opt/coreutils/libexec/gnubin" >>"$GITHUB_PATH"
+          brew install coreutils gnu-sed grep gawk findutils diffutils flock
+          prefix="$(brew --prefix)"
+          for f in coreutils gnu-sed grep findutils; do
+            echo "$prefix/opt/$f/libexec/gnubin" >>"$GITHUB_PATH"
+          done
 
       - name: /bin/bash first on PATH
         if: matrix.os == 'macos-latest'
@@ -155,9 +161,13 @@ jobs:
           got "bash on PATH, $(command -v bash)" "$(version_of bash)"
           got "/usr/bin/env bash" "$(version_of /usr/bin/env bash)"
           # The utilities the step above installed, resolved the way a suite
-          # resolves them.
+          # resolves them: present, and the GNU one where macOS ships a BSD one.
           for c in flock timeout sha256sum; do
             command -v "$c" || { echo "$c is not on PATH; the suites that call it would fail for the wrong reason"; fail=1; }
+          done
+          for c in sed grep awk find diff; do
+            "$c" --version 2>/dev/null | head -n 1 | grep -q GNU ||
+              { echo "$c on PATH is $(command -v "$c"), not the GNU one; a suite red there would be a userland difference"; fail=1; }
           done
           exit "$fail"
 

--- a/changelog.d/fixed/KEN-922-bash32-scripts.md
+++ b/changelog.d/fixed/KEN-922-bash32-scripts.md
@@ -1,0 +1,1 @@
+- On Bash 3.2, commit-guards admitted an uppercase commit type and refused its own helper on an apostrophe path; second-opinion, verification-scope and tools/guard aborted or misspelt a path.

--- a/changelog.d/fixed/KEN-922.md
+++ b/changelog.d/fixed/KEN-922.md
@@ -1,1 +1,1 @@
-- Every skill suite runs on macOS `/bin/bash` 3.2 in CI, where a quoted Bash 4 builtin the text scan cannot see fails.
+- Every shell suite but linear's runs on macOS `/bin/bash` 3.2 in CI, where a quoted Bash 4 builtin the text scan cannot see fails.

--- a/changelog.d/fixed/KEN-922.md
+++ b/changelog.d/fixed/KEN-922.md
@@ -1,1 +1,1 @@
-- Every shell suite but linear's runs on macOS `/bin/bash` 3.2 in CI, where a quoted Bash 4 builtin the text scan cannot see fails.
+- Every shell suite but linear's runs on macOS `/bin/bash` 3.2 in CI, where the Bash 4 constructs the text scan cannot see fail.

--- a/changelog.d/fixed/KEN-922.md
+++ b/changelog.d/fixed/KEN-922.md
@@ -1,0 +1,1 @@
+- Every skill suite runs on macOS `/bin/bash` 3.2 in CI, where a quoted Bash 4 builtin the text scan cannot see fails.

--- a/skills/AGENTS.md
+++ b/skills/AGENTS.md
@@ -4,6 +4,6 @@ The catalog's skills, one directory per skill, each rendered under `.agents/skil
 
 - A change to a source with a tracked render lands the render in the same commit; a `tools/guard` lane checks presence, not bytes, because a render may carry an injected instructions block the source has no copy of. A source with no tracked render has nothing to land.
 - Sync a render by replaying the source diff onto the render, never by copying the source file over it.
-- Shell stays Bash 3.2 compatible; `tools/bash32-lint` runs in the guard, and the macOS leg of the skill suites shard runs every suite on the runner's `/bin/bash` 3.2.
+- Shell stays Bash 3.2 compatible; `tools/bash32-lint` runs in the guard, and the macOS leg of the skill suites shard runs every shell suite but linear's, whose CLI has its own Bash 4 contract, on the runner's `/bin/bash` 3.2.
 - A test that shells out to git clears `GIT_DIR`, `GIT_COMMON_DIR`, `GIT_WORK_TREE` and `GIT_INDEX_FILE` together. Under `orch/tests/` that clearing is `skills/orch/tests/lib/git-env.sh`, sourced on the line under each suite's `set -...o pipefail`.
 - Every skill suite runs on the pull request and in the merge queue through `.github/workflows/skill-tests.yml`.

--- a/skills/AGENTS.md
+++ b/skills/AGENTS.md
@@ -4,6 +4,6 @@ The catalog's skills, one directory per skill, each rendered under `.agents/skil
 
 - A change to a source with a tracked render lands the render in the same commit; a `tools/guard` lane checks presence, not bytes, because a render may carry an injected instructions block the source has no copy of. A source with no tracked render has nothing to land.
 - Sync a render by replaying the source diff onto the render, never by copying the source file over it.
-- Shell stays Bash 3.2 compatible; `tools/bash32-lint` runs in the guard.
+- Shell stays Bash 3.2 compatible; `tools/bash32-lint` runs in the guard, and the macOS leg of the skill suites shard runs every suite on the runner's `/bin/bash` 3.2.
 - A test that shells out to git clears `GIT_DIR`, `GIT_COMMON_DIR`, `GIT_WORK_TREE` and `GIT_INDEX_FILE` together. Under `orch/tests/` that clearing is `skills/orch/tests/lib/git-env.sh`, sourced on the line under each suite's `set -...o pipefail`.
 - Every skill suite runs on the pull request and in the merge queue through `.github/workflows/skill-tests.yml`.

--- a/skills/bot-instructions/tests/repo-state.test.sh
+++ b/skills/bot-instructions/tests/repo-state.test.sh
@@ -26,18 +26,22 @@ expect_red 'agents-section orphan' 'the nested clause reds with every flag false
 rm -f "$repo/crates/core/AGENTS.md"
 cp "$BI_FIXTURES/canonical.toml" "$repo/kendex.toml"
 
-# The same nested file under a directory whose NAME is not UTF-8, which is a
-# legal name on every filesystem this runs on. A lossy decode replaces the
+# The same nested file under a directory whose NAME is not UTF-8, a legal
+# name on every Linux filesystem and one APFS refuses, so the case runs where
+# the name can exist and says so where it cannot. A lossy decode replaces the
 # byte: the name still ends `/AGENTS.md` and still passes the nested filter,
 # then addresses a DIFFERENT path on the read. Surrogates round-trip.
 odd="$repo/$(printf 'x\xffy')"
-mkdir -p "$odd"
-printf '# odd\n\n## Code Review Rules\n\nunmanaged\n' > "$odd/AGENTS.md"
-git -C "$repo" add -A >/dev/null 2>&1
-expect_red agents-section 'a nested AGENTS.md under a name that is not UTF-8' \
-  check --repo "$repo"
-rm -rf -- "${odd:?}"
-git -C "$repo" add -A >/dev/null 2>&1
+if mkdir -p "$odd" 2>/dev/null; then
+  printf '# odd\n\n## Code Review Rules\n\nunmanaged\n' > "$odd/AGENTS.md"
+  git -C "$repo" add -A >/dev/null 2>&1
+  expect_red agents-section 'a nested AGENTS.md under a name that is not UTF-8' \
+    check --repo "$repo"
+  rm -rf -- "${odd:?}"
+  git -C "$repo" add -A >/dev/null 2>&1
+else
+  printf '  skip a nested AGENTS.md under a name that is not UTF-8: this filesystem refuses the name\n'
+fi
 
 python3 - "$repo/AGENTS.md" <<'PY'
 import sys

--- a/skills/commit-guards/scripts/commit-msg
+++ b/skills/commit-guards/scripts/commit-msg
@@ -117,8 +117,10 @@ gg_settings_index_mode
 TYPES="$(gg_setting COMMIT_GUARDS_COMMIT_TYPES "build chore ci docs feat fix perf refactor revert style test")" || exit 2
 TYPE_ALT=""
 for t in $TYPES; do
+  # Classes, not a-z: Bash 3.2 reads a bracket range by locale collation,
+  # under which an uppercase letter sits inside [a-z].
   case "$t" in
-    "" | *[!a-z0-9-]*) gg_config_error "COMMIT_GUARDS_COMMIT_TYPES entry '$(gg_scrubbed "$t")' is not a lowercase type name" ;;
+    "" | *[![:lower:][:digit:]-]*) gg_config_error "COMMIT_GUARDS_COMMIT_TYPES entry '$(gg_scrubbed "$t")' is not a lowercase type name" ;;
   esac
   TYPE_ALT="${TYPE_ALT:+$TYPE_ALT|}$t"
 done

--- a/skills/commit-guards/scripts/commit-msg
+++ b/skills/commit-guards/scripts/commit-msg
@@ -117,11 +117,10 @@ gg_settings_index_mode
 TYPES="$(gg_setting COMMIT_GUARDS_COMMIT_TYPES "build chore ci docs feat fix perf refactor revert style test")" || exit 2
 TYPE_ALT=""
 for t in $TYPES; do
-  # Classes, not a-z: Bash 3.2 reads a bracket range by locale collation,
-  # under which an uppercase letter sits inside [a-z].
-  case "$t" in
-    "" | *[![:lower:][:digit:]-]*) gg_config_error "COMMIT_GUARDS_COMMIT_TYPES entry '$(gg_scrubbed "$t")' is not a lowercase type name" ;;
-  esac
+  # LC_ALL=C grep, as the header match below: a `case` range is a collation
+  # range in a UTF-8 locale, under which Bash 3.2 puts `F` inside [a-z].
+  printf '%s\n' "$t" | LC_ALL=C grep -qE '^[a-z0-9-]+$' ||
+    gg_config_error "COMMIT_GUARDS_COMMIT_TYPES entry '$(gg_scrubbed "$t")' is not a lowercase type name"
   TYPE_ALT="${TYPE_ALT:+$TYPE_ALT|}$t"
 done
 [ -n "$TYPE_ALT" ] || gg_config_error "COMMIT_GUARDS_COMMIT_TYPES resolved empty — at least one type is required"

--- a/skills/commit-guards/scripts/lib/hook-check.sh
+++ b/skills/commit-guards/scripts/lib/hook-check.sh
@@ -115,7 +115,9 @@ check_helper_head() { # HEAD -> 0 ours, 1 not
   esac
   inner="${head#"$prefix"}"
   inner="${inner%"$suffix"}"
-  value="${inner//"$esc"/"$sq"}"
+  # The replacement is unquoted: Bash 3.2 keeps the quotes of a quoted one
+  # as literal bytes, and a value rebuilt around them is never ours.
+  value="${inner//"$esc"/$sq}"
   [ "$(gg_shell_quote "$value")" = "$inner" ] || return 1
   gg_same_project_elsewhere "$value"
 }

--- a/skills/commit-guards/tests/lib/harness.bash
+++ b/skills/commit-guards/tests/lib/harness.bash
@@ -18,7 +18,11 @@ set -euo pipefail
 gg_suite="${0##*/}"
 gg_suite="${gg_suite%.test.sh}"
 
-TMP="$(mktemp -d "${TMPDIR:-/tmp}/gg-${gg_suite}.XXXXXX")" || {
+# The trailing slash macOS puts on TMPDIR is dropped first: a `//` in a
+# fixture path never matches the path a script normalises and prints back.
+gg_tmpdir="${TMPDIR:-/tmp}"
+gg_tmpdir="${gg_tmpdir%/}"
+TMP="$(mktemp -d "$gg_tmpdir/gg-${gg_suite}.XXXXXX")" || {
   echo "harness: could not create a scratch root under ${TMPDIR:-/tmp}" >&2
   exit 2
 }

--- a/skills/github/scripts/git-diff-summary
+++ b/skills/github/scripts/git-diff-summary
@@ -323,9 +323,12 @@ is_cfg_test_declared() {
     # target, so a route discovered by any scan is genuine no matter which
     # candidate prompted it; ERR (unreadable module) fails this candidate
     # closed only when the file sits in its consulted set.
+    # The directory list crosses into awk tab-joined: BWK awk (macOS) refuses
+    # a -v value carrying a newline, and a tab cannot sit in a path the
+    # tab-separated cache already holds.
     routes=$(printf '%s\n' "$DECL_CACHE" | awk -F'\t' \
-        -v cand="$candidate" -v dirs="$relevant_dirs" '
-        BEGIN { n = split(dirs, a, "\n"); for (i = 1; i <= n; i++) rd[a[i]] = 1 }
+        -v cand="$candidate" -v dirs="$(printf '%s' "$relevant_dirs" | tr '\n' '\t')" '
+        BEGIN { n = split(dirs, a, "\t"); for (i = 1; i <= n; i++) rd[a[i]] = 1 }
         $1 == cand { next }
         $3 == "ERR" { if ($2 in rd) print "err"; next }
         $4 != cand { next }

--- a/skills/harness-ci/tests/bash4-plant.test.sh
+++ b/skills/harness-ci/tests/bash4-plant.test.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+# Teeth for the macOS Bash 3.2 leg: a quoted builtin name the text scan does
+# not see. Bash 5 runs it; Bash 3.2 has no such command. Removed next commit.
+set -euo pipefail
+'mapfile' -t values </dev/null
+printf 'ran under Bash %s\n' "$BASH_VERSION"

--- a/skills/harness-ci/tests/bash4-plant.test.sh
+++ b/skills/harness-ci/tests/bash4-plant.test.sh
@@ -1,6 +1,0 @@
-#!/usr/bin/env bash
-# Teeth for the macOS Bash 3.2 leg: a quoted builtin name the text scan does
-# not see. Bash 5 runs it; Bash 3.2 has no such command. Removed next commit.
-set -euo pipefail
-'mapfile' -t values </dev/null
-printf 'ran under Bash %s\n' "$BASH_VERSION"

--- a/skills/orch/tests/lanes.sh
+++ b/skills/orch/tests/lanes.sh
@@ -216,7 +216,8 @@ stage_panes() {
   PANES_PATH="$CLAIM_BIN"
   [[ "$spec" != broken ]] || { PANES_PATH="$FAIL_BIN"; return; }
   IFS=';' read -ra parts <<<"$spec"
-  for part in "${parts[@]}"; do
+  # An empty spec leaves the array empty, which Bash 3.2 reads as unbound.
+  for part in ${parts[@]+"${parts[@]}"}; do
     target="$PANES"
     entries="$part"
     if [[ "$part" == *=* ]]; then

--- a/skills/orch/tests/open-terminal-lane.sh
+++ b/skills/orch/tests/open-terminal-lane.sh
@@ -15,7 +15,9 @@ TEST_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 SCRIPTS_DIR="$(cd "$TEST_DIR/.." && pwd)/scripts"
 OPEN_TERMINAL="$SCRIPTS_DIR/open-terminal"
 
-TMP_ROOT="$(mktemp -d)"
+# Physical: on macOS the temp root sits under /var -> /private/var, and the
+# scripts print the resolved path.
+TMP_ROOT="$(cd "$(mktemp -d)" && pwd -P)"
 trap 'rm -rf "$TMP_ROOT"' EXIT
 
 # shellcheck source=lib/waiter-assertions.sh

--- a/skills/orch/tests/worktree_push.sh
+++ b/skills/orch/tests/worktree_push.sh
@@ -21,7 +21,9 @@ ARTIFACT_CHECK="$REPO_ROOT/skills/orch/scripts/dev-artifact-check"
 # shellcheck source=lib/growth-state.sh
 source "$TEST_DIR/lib/growth-state.sh"
 
-TMP_ROOT="$(mktemp -d)"
+# Physical: on macOS the temp root sits under /var -> /private/var, and the
+# scripts print the resolved path.
+TMP_ROOT="$(cd "$(mktemp -d)" && pwd -P)"
 trap 'rm -rf "$TMP_ROOT"' EXIT
 
 PASS=0

--- a/skills/orch/tests/worktree_push.sh
+++ b/skills/orch/tests/worktree_push.sh
@@ -326,9 +326,12 @@ for arg in "$@"; do
     ;;
   esac
 done
+# The honest answer is a variable, not a default word: Bash 3.2 keeps the
+# backslash of a `\}` inside `${var:-word}`, which is not JSON.
+honest='{"path":"/x","exists":true}'
 if [[ "$mode" == exists ]]; then
   [[ "${STUB_EXISTS:-}" == fail ]] && exit 7
-  printf '%s\n' "${STUB_EXISTS_JSON:-{\"path\":\"/x\",\"exists\":true\}}"
+  printf '%s\n' "${STUB_EXISTS_JSON:-$honest}"
 fi
 exit 0
 EOF

--- a/skills/project-management/scripts/verification-scope
+++ b/skills/project-management/scripts/verification-scope
@@ -222,7 +222,7 @@ candidates=(${unique_candidates[@]+"${unique_candidates[@]}"})
 
 mode="repository"
 if [[ "$force_docs_only" == true ]]; then
-  for path in "${candidates[@]}"; do
+  for path in ${candidates[@]+"${candidates[@]}"}; do
     is_doc_path "$path" \
       || fail "--docs-only path is not documentation: $path"
   done
@@ -276,7 +276,7 @@ declare -a verification_paths=()
 if [[ "$mode" == "repository" ]]; then
   verification_paths=("${source_roots[@]}")
 else
-  verification_paths=("${candidates[@]}")
+  verification_paths=(${candidates[@]+"${candidates[@]}"})
 fi
 
 json_array() {
@@ -287,9 +287,10 @@ json_array() {
   fi
 }
 
-changed_json="$(json_array "${candidates[@]}")"
-roots_json="$(json_array "${source_roots[@]}")"
-paths_json="$(json_array "${verification_paths[@]}")"
+# Each list may be empty, which Bash 3.2 reads as unbound under set -u.
+changed_json="$(json_array ${candidates[@]+"${candidates[@]}"})"
+roots_json="$(json_array ${source_roots[@]+"${source_roots[@]}"})"
+paths_json="$(json_array ${verification_paths[@]+"${verification_paths[@]}"})"
 code_verification_required=true
 if [[ "$mode" == "docs-only" ]]; then
   code_verification_required=false

--- a/skills/review-gate/tests/predicate-re2-engine.test.sh
+++ b/skills/review-gate/tests/predicate-re2-engine.test.sh
@@ -102,9 +102,11 @@ fi
 : >"$work/httpd.log"
 python3 -u -m http.server 0 --bind 127.0.0.1 --directory "$srv" >"$work/httpd.log" 2>&1 &
 server_pid=$!
+# A minute, not ten seconds: the first python3 on a macOS runner takes
+# longer than that to print its banner.
 port=""
 i=0
-while [ "$i" -lt 100 ]; do
+while [ "$i" -lt 600 ]; do
   port="$(sed -n 's/.*port \([0-9][0-9]*\).*/\1/p' "$work/httpd.log" | head -1)"
   [ -n "$port" ] && break
   kill -0 "$server_pid" 2>/dev/null || break

--- a/skills/review-gate/tests/validate-workflow.test.sh
+++ b/skills/review-gate/tests/validate-workflow.test.sh
@@ -288,10 +288,10 @@ expect_fail "trailing space after a backslash continuation is a divergence" "$di
 sandbox
 dir="$DIR"
 # An `s` with an escaped newline, not a `0,/re/` range: that address is GNU
-# sed's, and BSD sed reads it as something else and changes nothing. `#` is
+# sed's, and BSD sed reads it as something else and changes nothing. `@` is
 # the delimiter so `&` never follows `|`, a spelling the portability lint reads.
-mutate "$dir" "s#^          set -u\$#&\\
-          # a shell comment inside the payload#"
+mutate "$dir" "s@^          set -u\$@&\\
+          # a shell comment inside the payload@"
 expect_fail "a comment inside a run: payload is a divergence" "$dir" "has diverged from the shipped template"
 
 # The BOUNDARY, stated rather than left to be discovered: comments are

--- a/skills/review-gate/tests/validate-workflow.test.sh
+++ b/skills/review-gate/tests/validate-workflow.test.sh
@@ -287,9 +287,11 @@ expect_fail "trailing space after a backslash continuation is a divergence" "$di
 
 sandbox
 dir="$DIR"
-mutate "$dir" "0,/^          set -u\$/{/^          set -u\$/a\\
-          # a shell comment inside the payload
-}"
+# An `s` with an escaped newline, not a `0,/re/` range: that address is GNU
+# sed's, and BSD sed reads it as something else and changes nothing. `#` is
+# the delimiter so `&` never follows `|`, a spelling the portability lint reads.
+mutate "$dir" "s#^          set -u\$#&\\
+          # a shell comment inside the payload#"
 expect_fail "a comment inside a run: payload is a divergence" "$dir" "has diverged from the shipped template"
 
 # The BOUNDARY, stated rather than left to be discovered: comments are

--- a/skills/reviewer/tests/measurement-fail-closed.test.sh
+++ b/skills/reviewer/tests/measurement-fail-closed.test.sh
@@ -209,9 +209,12 @@ else
 
   # MUST-FAIL CONTROLS on the escape: it has to SAY something, and it is
   # refused on its own terms rather than silently ignored.
+  # The body is assembled outside the substitution: Bash 3.2 splits a `\"`
+  # inside "$( )" at the quote and hands expect_reason the wrong words.
   for degenerate in '"."' '"n/a"' '"none"' '"unknown"' '"   "' '"---"' 'true' '0'; do
+    degenerate_body='{"agent":"reviewer-test","verdict":"pass","summary":"mutation: killed 0/0","blockers":[],"suggestions":[],"measurement_failed":'"$degenerate"'}'
     expect_reason \
-      "$(artifact "degenerate-$DEGEN_N" "{\"agent\":\"reviewer-test\",\"verdict\":\"pass\",\"summary\":\"mutation: killed 0/0\",\"blockers\":[],\"suggestions\":[],\"measurement_failed\":$degenerate}")" \
+      "$(artifact "degenerate-$DEGEN_N" "$degenerate_body")" \
       invalid_declaration "a declaration of $degenerate names no instrument and is refused"
     DEGEN_N=$((DEGEN_N + 1))
   done

--- a/skills/reviewer/tests/mutation-stability.test.sh
+++ b/skills/reviewer/tests/mutation-stability.test.sh
@@ -49,11 +49,14 @@ echo $$ > "$HANG_PID_FILE"
 trap '' TERM
 while :; do :; done
 T
+# The launcher is told apart inside the trap, not while this file is sourced:
+# Bash 3.2 reports $0 as `bash` at that point, whatever script it is starting.
+# Every other shell disarms itself on its first command.
 cat > "$TMP/launch-window.bashenv" <<'T'
-case "$0" in
-  *mutation-stability)
-    set -T
-    trap '
+set -T
+trap '
+  case "$0" in
+    *mutation-stability)
       if [ "$BASH_COMMAND" = "ACTIVE_PID=\$!" ]; then
         trap - DEBUG
         tries=0
@@ -64,9 +67,10 @@ case "$0" in
         : > "$LAUNCH_WINDOW_SIGNALLED"
         kill -TERM "$$"
       fi
-    ' DEBUG
-    ;;
-esac
+      ;;
+    *) trap - DEBUG ;;
+  esac
+' DEBUG
 T
 git -C "$REPO" add -A
 git -C "$REPO" -c user.email=t@t -c user.name=t commit -qm x

--- a/skills/second-opinion/scripts/second-opinion
+++ b/skills/second-opinion/scripts/second-opinion
@@ -1209,12 +1209,13 @@ ARTIFACT_PATH=""
 #
 # Order is load-bearing: repeated slashes collapse FIRST, or `.//x` strips its
 # leading `./` into the absolute-looking `/x`. Purely lexical — a `..` that
-# survives is still the vet's to refuse.
+# survives is still the vet's to refuse. The replacement is a bare `/`: Bash
+# 3.2 keeps the backslash of an escaped `\/` there, and wrote `.\/tmp`.
 normalize_relative_home() {
   local rel="$1"
-  while [[ "$rel" == *//* ]]; do rel="${rel//\/\//\/}"; done
+  while [[ "$rel" == *//* ]]; do rel="${rel//\/\///}"; done
   while [[ "$rel" == ./* ]]; do rel="${rel#./}"; done
-  while [[ "$rel" == */./* ]]; do rel="${rel//\/.\//\/}"; done
+  while [[ "$rel" == */./* ]]; do rel="${rel//\/.\///}"; done
   while [[ "$rel" == */. ]]; do rel="${rel%/.}"; done
   while [[ "$rel" == */ ]]; do rel="${rel%/}"; done
   if [[ "$rel" == "." ]]; then rel=""; fi

--- a/skills/second-opinion/scripts/second-opinion-runtime
+++ b/skills/second-opinion/scripts/second-opinion-runtime
@@ -1,5 +1,13 @@
 #!/usr/bin/env bash
 set -euo pipefail
+# What the EXIT handlers below read lives here, not in a frame: Bash 3.2 pops
+# a function's locals before it runs the EXIT trap an `exit` inside that
+# function fires, so a handler reading a local of the frame faults under
+# `set -u` instead of reclaiming the run. Each is assigned by the frame that
+# arms its handler and read by nothing else.
+GROUP_CLI_PID=""
+LAUNCH_WORKER_PID=""
+LAUNCH_RUNTIME_DIR=""
 RUNTIME_SELF="$(cd -- "$(dirname "${BASH_SOURCE[0]}")" && pwd)/${BASH_SOURCE[0]##*/}"
 die() { echo "second-opinion-runtime: $1" >&2; exit 1; }
 runtime_dir_valid() { [[ -d "$1" && ! -L "$1" ]]; }
@@ -87,8 +95,9 @@ group_run() {
   local stderr_file="$1"
   shift
   [[ $# -gt 0 ]] || die "group command is missing"
-  local cli_pid="" rc=0 cancel_rc=""
-  stop_cli() { [[ -z "$cli_pid" ]] || stop_process_group "$cli_pid" 25; }
+  local rc=0 cancel_rc=""
+  GROUP_CLI_PID=""
+  stop_cli() { [[ -z "$GROUP_CLI_PID" ]] || stop_process_group "$GROUP_CLI_PID" 25; }
   # OWN THE CHILD BEFORE A HANDLER MAY EXIT. Between the fork below and the
   # assignment that follows it there is no pid to act on, and a handler that
   # exited there would leave a live process group behind with nothing left to
@@ -107,13 +116,13 @@ group_run() {
   exec 8<&0
   set -m
   "$@" <&8 2>"$stderr_file" &
-  cli_pid=$!
+  GROUP_CLI_PID=$!
   set +m
   exec 8<&-
   trap 'stop_cli; exit 143' TERM HUP
   trap 'stop_cli; exit 130' INT
   [[ -z "$cancel_rc" ]] || { stop_cli; exit "$cancel_rc"; }
-  wait "$cli_pid" || rc=$?
+  wait "$GROUP_CLI_PID" || rc=$?
   stop_cli
   exit "$rc"
 }
@@ -142,11 +151,13 @@ launch() {
   [[ "$owned" == true || "$owned" == false ]] || die "owned must be true or false"
   [[ "$wait_slice" =~ ^[1-9][0-9]*$ && $wait_slice -lt 600 ]] \
     || die "wait slice must be positive and below 600 seconds"
-  # worker_pid is initialised, not merely declared: the cleanup below
+  # LAUNCH_WORKER_PID is cleared, not merely declared: the cleanup below
   # reads it, and it is armed before it is assigned. Under `set -u` a
-  # declared-but-unassigned local is still unbound, so a signal arriving in that
-  # first instant would fault the handler instead of running it.
-  local deadline worker_pid="" cancel_rc="" log="$runtime_dir/worker.log"
+  # declared-but-unassigned variable is still unbound, so a signal arriving in
+  # that first instant would fault the handler instead of running it.
+  LAUNCH_WORKER_PID=""
+  LAUNCH_RUNTIME_DIR="$runtime_dir"
+  local deadline cancel_rc="" log="$runtime_dir/worker.log"
   local status_file="$runtime_dir/worker.status" launch_umask
   local worker_args launch_model="${SECOND_OPINION_LAUNCH_MODEL:-}"
   # THE WINDOW BETWEEN THE FORK AND THE PROTOCOL. Once the worker exists it can
@@ -155,19 +166,20 @@ launch() {
   # cancelled or failed launch there strands a run nobody can wait on or stop.
   # Armed before the fork, cleared after the last protocol line.
   #
-  # It reads locals of this frame, so it must never run after launch RETURNS.
-  # That is why the traps are cleared at the end rather than gated on a flag:
-  # every path that reaches it — a signal, or `die` on a failed publish — is
-  # still inside the frame, where a flag would be readable but pointless.
+  # It reads the state this frame publishes for it, so it must never run
+  # after launch RETURNS. That is why the traps are cleared at the end rather
+  # than gated on a flag: every path that reaches it — a signal, or `die` on
+  # a failed publish — is still this launch's, where a flag would be readable
+  # but pointless.
   cleanup_launch() {
-    if [[ -n "$worker_pid" ]] && ! stop_process_group "$worker_pid" 30; then
-      echo "second-opinion-runtime: launch cleanup failed; runtime state preserved: $runtime_dir" >&2
+    if [[ -n "$LAUNCH_WORKER_PID" ]] && ! stop_process_group "$LAUNCH_WORKER_PID" 30; then
+      echo "second-opinion-runtime: launch cleanup failed; runtime state preserved: $LAUNCH_RUNTIME_DIR" >&2
       return 1
     fi
-    ! runtime_dir_valid "$runtime_dir" || rm -rf -- "${runtime_dir:?}" || true
+    ! runtime_dir_valid "$LAUNCH_RUNTIME_DIR" || rm -rf -- "${LAUNCH_RUNTIME_DIR:?}" || true
   }
   # Deferred across the fork window for the same reason as group_run: until
-  # worker_pid is assigned there is no group to stop, and a handler exiting
+  # LAUNCH_WORKER_PID is assigned there is no group to stop, and a handler exiting
   # there would strand the very run this cleanup exists to reclaim.
   request_cancel() { cancel_rc="$1"; }
   trap 'request_cancel 143' TERM HUP
@@ -202,13 +214,13 @@ launch() {
       exit "$rc"
     ' second-opinion-worker "$script" "${worker_args[@]}" \
     < /dev/null > "$log" 2>&1 &
-  worker_pid=$!
+  LAUNCH_WORKER_PID=$!
   set +m
   exec 9>&-
   trap 'cleanup_launch; exit 143' TERM HUP
   trap 'cleanup_launch; exit 130' INT
   [[ -z "$cancel_rc" ]] || { cleanup_launch; exit "$cancel_rc"; }
-  (umask 077 && set -C && printf '%s\n' "$worker_pid" > "$runtime_dir/pid") \
+  (umask 077 && set -C && printf '%s\n' "$LAUNCH_WORKER_PID" > "$runtime_dir/pid") \
     || die "cannot record detached worker pid: $runtime_dir/pid"
   printf 'artifact: %s\n' "$artifact"
   printf 'deadline: %s\n' "$deadline"

--- a/skills/second-opinion/tests/signal-kill-gate.test.sh
+++ b/skills/second-opinion/tests/signal-kill-gate.test.sh
@@ -105,12 +105,26 @@ chmod +x "$TMP_ROOT/bin/lane-good"
 # path in STUB_LANE_PATTERN; nothing else on the host does — then stays alive
 # only until that lane is gone, so its own exit can never race the
 # classification and the chain above it collapses as soon as the lane is dead.
+# The lane to kill is this stub's own ancestor, found by walking up the
+# parent chain: BSD pkill excludes the caller's ancestors from an argv match
+# by default, so a pattern kill from inside the lane reaches nothing on macOS.
 cat > "$TMP_ROOT/bin/kill-lane" <<'SH'
 #!/usr/bin/env bash
 cat > /dev/null
 echo $$ >> "$STUB_PIDS"
-pkill -TERM -f -- "$STUB_LANE_PATTERN"
-for _ in $(seq 50); do pgrep -f -- "$STUB_LANE_PATTERN" >/dev/null || break; sleep 0.1; done
+# Every matching ancestor, the lane child included, as the pattern kill
+# reached; /bin/ps by path, since the ps on PATH is this suite's stand-in.
+pid=$PPID
+targets=""
+while [ "$pid" -gt 1 ]; do
+  case "$(/bin/ps -o args= -p "$pid")" in
+    *"$STUB_LANE_PATTERN"*) targets="$targets $pid" ;;
+  esac
+  pid=$(/bin/ps -o ppid= -p "$pid" | tr -d ' ')
+  [ -n "$pid" ] || break
+done
+[ -z "$targets" ] || kill -TERM $targets
+for _ in $(seq 50); do kill -0 $targets 2>/dev/null || break; sleep 0.1; done
 SH
 chmod +x "$TMP_ROOT/bin/kill-lane"
 

--- a/tools/bash32-lint
+++ b/tools/bash32-lint
@@ -133,9 +133,12 @@ PATTERN="$PATTERN"'|\$('"$BASH4_VARS"')([^A-Za-z0-9_]|$)|\$\{('"$BASH4_VARS"')\}
 #     skills/commit-guards/tests/bsd-argv-install.test.sh executes the real
 #     installer under a BSD chmod shim. `dirname --` and `basename --` have
 #     neither a rule here nor a shim there, and are live in shipped scripts.
-#   - whether a script RUNS under Bash 3.2. Nothing here does; CI is Linux on
-#     Bash 5 and `bash -n` is that same shell. A clean scan says the source
-#     carries no construct named above, and says nothing further.
+#   - whether a script RUNS under Bash 3.2. Nothing here does; `bash -n` is
+#     the host's shell. A clean scan says the source carries no construct
+#     named above, and says nothing further. The macOS leg of the skill
+#     suites shard in .github/workflows/skill-tests.yml runs every suite on
+#     /bin/bash 3.2.57, asserting the version it got, and is what reaches
+#     the misses above.
 
 die() {
   printf 'bash32-lint: %s\n' "$1" >&2

--- a/tools/bash32-lint
+++ b/tools/bash32-lint
@@ -136,9 +136,9 @@ PATTERN="$PATTERN"'|\$('"$BASH4_VARS"')([^A-Za-z0-9_]|$)|\$\{('"$BASH4_VARS"')\}
 #   - whether a script RUNS under Bash 3.2. Nothing here does; `bash -n` is
 #     the host's shell. A clean scan says the source carries no construct
 #     named above, and says nothing further. The macOS leg of the skill
-#     suites shard in .github/workflows/skill-tests.yml runs every suite on
-#     /bin/bash 3.2.57, asserting the version it got, and is what reaches
-#     the misses above.
+#     suites shard in .github/workflows/skill-tests.yml runs every shell
+#     suite but linear's on /bin/bash 3.2.57, asserting the version it got,
+#     and is what reaches the misses above.
 
 die() {
   printf 'bash32-lint: %s\n' "$1" >&2

--- a/tools/guard
+++ b/tools/guard
@@ -306,7 +306,8 @@ if [ "$FULL" -eq 0 ]; then
         manifest="crates/${crate%%/*}/Cargo.toml"
         if [ ! -f "$manifest" ]; then rust_all=1; continue; fi
         seen=0
-        for existing in "${rust_manifests[@]}"; do
+        # Guarded: an empty array is unbound under set -u on Bash 3.2.
+        for existing in ${rust_manifests[@]+"${rust_manifests[@]}"}; do
           [ "$existing" != "$manifest" ] || seen=1
         done
         [ "$seen" -eq 1 ] || rust_manifests+=("$manifest")
@@ -329,7 +330,7 @@ if [ -f Cargo.toml ] && { [ "$rust_all" -eq 1 ] || [ "${#rust_manifests[@]}" -gt
     cargo check --workspace --all-targets || say "cargo check failed"
     cargo clippy --workspace --all-targets --quiet -- -D warnings || say "clippy failed"
   else
-    for manifest in "${rust_manifests[@]}"; do
+    for manifest in ${rust_manifests[@]+"${rust_manifests[@]}"}; do
       cargo check --manifest-path "$manifest" --all-targets || say "$manifest failed to compile"
       cargo clippy --manifest-path "$manifest" --all-targets --quiet -- -D warnings || say "$manifest clippy failed"
     done

--- a/tools/tests/data/bash32-uncatchable.txt
+++ b/tools/tests/data/bash32-uncatchable.txt
@@ -4,3 +4,4 @@ v="${arr[${x%]}]^}"
 'mapfile' -t values
 map\file -t values
 "declare" -A cache
+declare>/dev/null -A cache

--- a/tools/tests/help-inert.test.sh
+++ b/tools/tests/help-inert.test.sh
@@ -43,9 +43,18 @@ chmod +x "$FIXTURE/bin/blocked" "$FIXTURE/bin/gh" "$FIXTURE/bin/codex" \
     "$FIXTURE/.agents/skills/control/scripts/environment-load"
 export HELP_INERT_CALLS="$CALLS"
 
+# The linear CLI's contract is Bash 4 or newer (skills/linear/tests/
+# bash4-runtime-contract.test.sh): under Bash 3 it refuses before serving
+# help, so its rows are out of this suite's reach on that shell.
+LINEAR_SKIPPED=0
 # skill, script, expected output, arguments, expected violation. A dash means no arguments.
 while IFS=$'\t' read -r skill script token args expected; do
     [ -n "$skill" ] || continue
+    if [ "$skill" = linear ] && [ "${BASH_VERSINFO[0]}" -lt 4 ]; then
+        [ "$LINEAR_SKIPPED" -eq 1 ] || printf 'skipping linear rows: its contract is Bash 4 or newer, this is %s\n' "$BASH_VERSION"
+        LINEAR_SKIPPED=1
+        continue
+    fi
     expected="${expected:-clean}"
     rm -f "$MARKER"
     : >"$CALLS"


### PR DESCRIPTION
Closes KEN-922.

The skill-suites shard matrix gains an `os` axis: the five shell shards run a second time on `macos-latest`, where a symlink to `/bin/bash` goes first on PATH so the step shell, `bash "$t"` and every `#!/usr/bin/env bash` resolve to 3.2.57. A step asserts the version each of those three resolutions got and ends the leg on any other. A probe step takes two lines from `tools/tests/data/bash32-uncatchable.txt`, one the scan misses through quote removal (`'mapfile' -t values`, exit 127 under 3.2) and one through word splitting (`declare>/dev/null -A cache`, the redirection form the owner's comment names, exit 2), proves `tools/bash32-lint` is clean on both, and requires those exits from the shell. Both steps go red under Bash 5, verified locally with a Bash 5 shim. The linear shard runs only its Bash 4 contract suite under Bash 3. The node shards are excluded from the leg.

The leg swaps the shell and nothing else: it installs the GNU userland the suites are written against (coreutils, gnu-sed, grep, gawk, findutils, diffutils, util-linux for flock and setsid) and asserts each names GNU beside the shell, so a red leg is a Bash 3.2 finding. What the suites do on the BSD userland is a separate property this leg does not prove.

Teeth, watched rather than reasoned: a suite carrying `'mapfile' -t values` was pushed at f69341cad. The Linux rest leg stayed green and the text scan read it as clean; the macOS rest leg failed it with `mapfile: command not found` (run 34024055392, job 101461768280). The next commit removed it.

Running the whole battery under a source-built Bash 3.2.57 found what the text scan cannot, all fixed at the source with a comment naming the 3.2 behaviour and the tracked render replayed:

- `commit-msg`: a locale-collated `[a-z]` admitted an uppercase commit type; the type check now runs under `LC_ALL=C grep`, the file's own ASCII mechanism.
- `hook-check.sh`: a quoted replacement in `${x//p/"r"}` keeps its quotes as bytes, so the installer refused its own helper on a path with an apostrophe.
- `second-opinion`: `\/` in a replacement keeps the backslash, so `.//tmp` became `.\/tmp`.
- `second-opinion-runtime`: locals are popped before the EXIT trap an `exit` inside the frame fires; the handler state is now script level.
- `verification-scope`, `tools/guard`, `orch/tests/lanes.sh`: an empty array is unbound under `set -u`.
- Test-side only: `\"` split inside `"$( )"`, `$0` reading `bash` while `BASH_ENV` is sourced, a `\}` kept in a default word, and help-inert skipping linear's rows under Bash 3 by that skill's contract.

Running on the real runner found what a Linux Bash 3.2 cannot, fixed at the smallest surface:

- `git-diff-summary` (shipped): BWK awk refuses a `-v` value carrying a newline; the directory list crosses tab-joined.
- APFS refuses a non-UTF-8 name, so that repo-state case runs where the name can exist and says so where it cannot.
- python3 on the runner takes more than ten seconds to print its `http.server` banner.
- A `0,/re/` sed address is GNU's; BSD sed changed nothing, so the divergence case is an `s` with an escaped newline.
- The BSD process-pattern kill excludes the caller's ancestors from an argv match, so the kill-lane stub walks its parent chain with `/bin/ps`.
- The runner's TMPDIR ends in a slash and sits under `/var -> /private/var`: the commit-guards harness drops the slash, and worktree_push and open-terminal-lane start from a physical root.

Local battery (266 suites): Bash 5 all green; Bash 3.2 all 221 non-linear suites green, the 45 linear suites red by their stated Bash 4 contract. `tools/guard --full` exit 0. macOS legs on the first green run: orch 10m45s, guards 9m09s, rest 7m39s, review-gate 3m45s, linear 2m47s, under a 30-minute ceiling.

Not in this PR, found by the first run on the stock macOS userland and left for their own issue: six guards-shard suites and the orch battery red on BSD sed, grep and awk (todo-ban's awk exits 2 on a binary blob in the index under BWK awk; the bash32-lint suite cannot read the lint's exception lists with BSD sed), and open-terminal's GUI arm reports a launch that never happened on a Mac without setsid.

https://claude.ai/code/session_01JEut1jpP4yTPKaJg8cUJXB
