### PR TITLE
test(KEN-1241): pi-invocation as four tables over one spawn line each

### DIFF
--- a/pi-extensions/pi-agents-tmux/tests/pi-invocation.test.ts
+++ b/pi-extensions/pi-agents-tmux/tests/pi-invocation.test.ts
@@ -1,13 +1,17 @@
-import { afterAll, describe, expect, test } from "bun:test";
+// How a child pi is invoked: which entry re-invokes (pi's own package, an
+// override, or `pi` on PATH), the depth guard, and what the one-shot runner
+// and the pane launcher hand the child (depth, entry, model, thinking).
+
+import assert from "node:assert/strict";
 import { spawnSync } from "node:child_process";
 import { createHash } from "node:crypto";
 import { EventEmitter } from "node:events";
-import { chmodSync, mkdirSync, mkdtempSync, readdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { chmodSync, mkdirSync, readdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { isAbsolute, join, relative } from "node:path";
+import test, { after } from "node:test";
 import type { AgentConfig } from "../extensions/subagent/agents.js";
 import { shellQuote } from "../extensions/subagent/names.js";
-import { PANE_LAUNCHER_VERSION } from "../extensions/subagent/types.js";
 import {
 	assertSubagentSpawnDepth,
 	currentSubagentDepth,
@@ -16,332 +20,193 @@ import {
 	PI_PACKAGE_NAME,
 	PI_SUBAGENT_DEPTH_ENV,
 	PI_SUBAGENT_ENTRY_ENV,
-	writeLauncher,
+	type PiInvocation,
 	type PiInvocationRuntime,
+	writeLauncher,
 } from "../extensions/subagent/pane.js";
 import { runSingleAgent, setSingleAgentSpawnForTests } from "../extensions/subagent/runner.js";
-import type { SingleResult, SubagentDetails } from "../extensions/subagent/types.js";
+import { PANE_LAUNCHER_VERSION } from "../extensions/subagent/types.js";
+import { cleanupTempRuntimes, makeDetails, tempRuntime, testAgent } from "./single-agent-fixture.js";
 
-const tempDirs = new Set<string>();
+after(cleanupTempRuntimes);
 
-afterAll(() => {
-	for (const dir of tempDirs) rmSync(dir, { force: true, recursive: true });
-});
+const BUN = "/usr/bin/bun";
 
-function tempDir(prefix = "pi-agents-invocation-"): string {
-	const dir = mkdtempSync(join(tmpdir(), prefix));
-	tempDirs.add(dir);
-	return dir;
-}
-
-function existingScript(basename: string, dir = tempDir()): string {
+function existingScript(basename: string, dir = tempRuntime()): string {
 	const filePath = join(dir, basename);
 	writeFileSync(filePath, "// test entry\n");
 	return filePath;
 }
 
 // A script inside a fixture package: nearest-package.json identity is what
-// getPiInvocation trusts, so tests place entries under explicit manifests.
+// getPiInvocation trusts, so entries sit under explicit manifests.
 function scriptInPackage(basename: string, manifest: Record<string, unknown>): string {
-	const dir = join(tempDir(), "pkg");
+	const dir = join(tempRuntime(), "pkg");
 	mkdirSync(dir, { recursive: true });
 	writeFileSync(join(dir, "package.json"), JSON.stringify(manifest));
 	return existingScript(basename, dir);
 }
 
 function runtime(overrides: Partial<PiInvocationRuntime>): PiInvocationRuntime {
-	return { argv1: undefined, execPath: "/usr/bin/bun", env: {}, ...overrides };
+	return { argv1: undefined, execPath: BUN, env: {}, ...overrides };
 }
 
-describe("getPiInvocation entry resolution (kendex#192)", () => {
-	test("harness-like argv[1] (existing non-pi script) does NOT self-re-invoke", () => {
-		// The fork-bomb shape: a standalone `bun harness.mjs` imported runner.ts
-		// directly, so argv[1] is the harness. Re-invoking it spawns the harness
-		// recursively; the resolver must fall back to pi on PATH instead.
-		const harness = existingScript("harness.mjs");
-		const invocation = getPiInvocation(["--mode", "json"], runtime({ argv1: harness }));
-		expect(invocation.command).toBe("pi");
-		expect(invocation.args).toEqual(["--mode", "json"]);
-		expect(invocation.args).not.toContain(harness);
-	});
+// Absolute fixture paths print as their alias; a relative or unexpected path
+// prints as itself, so a row expecting `entry` reddens on either.
+type Alias = Record<string, string>;
+const aliased = (value: string | undefined, alias: Alias) => (value === undefined ? "-" : value === BUN ? "bun" : alias[value] ?? value);
 
-	test("a pi-looking basename outside the pi package does NOT self-re-invoke (PR #1178 f1)", () => {
-		// Basenames are spoofable: a harness literally named cli.ts must still be
-		// rejected because its nearest package.json is not pi's.
-		const spoofed = scriptInPackage("cli.ts", { name: "some-harness", version: "0.0.1" });
-		const invocation = getPiInvocation(["-p"], runtime({ argv1: spoofed }));
-		expect(invocation.command).toBe("pi");
-		expect(invocation.args).toEqual(["-p"]);
-	});
+function invocationLine(invocation: PiInvocation, alias: Alias): string {
+	return `cmd=${aliased(invocation.command, alias)} args=[${invocation.args.map((arg) => aliased(arg, alias)).join(",")}] child-entry=${aliased(invocation.childEntryOverride, alias)} depth=${invocation.childDepth}`;
+}
 
-	test("a pi-looking basename with NO reachable package.json does NOT self-re-invoke", () => {
-		const orphan = existingScript("cli.ts");
-		const invocation = getPiInvocation(["-p"], runtime({ argv1: orphan }));
-		expect(invocation.command).toBe("pi");
-	});
+type Resolution = () => { alias: Alias; args?: string[]; runtime: PiInvocationRuntime };
 
-	test("pi dev-mode entries under pi's own package keep self-re-invoking", () => {
-		// Three legitimate pi shapes: the canonical package name, a bin map whose
-		// `pi` entry resolves to this very script, and a package literally named
-		// `pi` whose string-form bin resolves to it.
-		for (const entry of [
-			scriptInPackage("cli.ts", { name: PI_PACKAGE_NAME, version: "0.0.0" }),
-			scriptInPackage("cli.js", { name: "pi-fork", bin: { pi: "./cli.js" } }),
-			scriptInPackage("cli.js", { name: "pi", bin: "./cli.js" }),
-		]) {
-			const invocation = getPiInvocation(["-p"], runtime({ argv1: entry }));
-			expect(invocation.command).toBe("/usr/bin/bun");
-			expect(invocation.args).toEqual([entry, "-p"]);
-		}
-	});
+const withEntry = (entry: string, extra: Partial<PiInvocationRuntime> = {}) => ({ alias: { [entry]: "entry" }, runtime: runtime({ argv1: entry, ...extra }) });
+const ON_PATH = "cmd=pi args=[-p] child-entry=- depth=1";
+const SELF = "cmd=bun args=[entry,-p] child-entry=- depth=1";
 
-	test("a foreign package declaring bin.pi that points ELSEWHERE does not self-re-invoke (PR #1178 r3)", () => {
-		// Declaring a `pi` bin is not identity: the bin entry must resolve to the
-		// realpathed argv[1] script itself. Here bin.pi names cli.js but argv[1]
-		// is cli.ts, so a harness hiding inside such a package stays rejected.
-		const spoofedObjectBin = scriptInPackage("cli.ts", { name: "some-fork-of-pi", bin: { pi: "./cli.js" } });
-		expect(getPiInvocation(["-p"], runtime({ argv1: spoofedObjectBin })).command).toBe("pi");
-		const spoofedStringBin = scriptInPackage("cli.ts", { name: "pi", bin: "./cli.js" });
-		expect(getPiInvocation(["-p"], runtime({ argv1: spoofedStringBin })).command).toBe("pi");
-	});
-
-	test("a manifest-less entry dir walks up to pi's own manifest (ENOENT keeps walking)", () => {
-		const pkgDir = join(tempDir(), "pkg");
+// label | the process's argv[1], execPath and env | expect the invocation line
+const resolutionRows: Array<[string, Resolution, string]> = [
+	["a harness script as argv[1] falls back to pi on PATH (the fork-bomb shape)", () => withEntry(existingScript("harness.mjs")), ON_PATH],
+	["a pi-looking basename in a foreign package falls back", () => withEntry(scriptInPackage("cli.ts", { name: "some-harness", version: "0.0.1" })), ON_PATH],
+	["a pi-looking basename with no reachable manifest falls back", () => withEntry(existingScript("cli.ts")), ON_PATH],
+	["pi's own package name re-invokes the script", () => withEntry(scriptInPackage("cli.ts", { name: PI_PACKAGE_NAME, version: "0.0.0" })), SELF],
+	["a bin map whose pi entry is this script re-invokes", () => withEntry(scriptInPackage("cli.js", { name: "pi-fork", bin: { pi: "./cli.js" } })), SELF],
+	["a package named pi whose string bin is this script re-invokes", () => withEntry(scriptInPackage("cli.js", { name: "pi", bin: "./cli.js" })), SELF],
+	["a bin map whose pi entry is another file falls back", () => withEntry(scriptInPackage("cli.ts", { name: "some-fork-of-pi", bin: { pi: "./cli.js" } })), ON_PATH],
+	["a package named pi whose string bin is another file falls back", () => withEntry(scriptInPackage("cli.ts", { name: "pi", bin: "./cli.js" })), ON_PATH],
+	["a manifest-less entry dir walks up to pi's manifest", () => {
+		const pkgDir = join(tempRuntime(), "pkg");
 		const srcDir = join(pkgDir, "src");
 		mkdirSync(srcDir, { recursive: true });
 		writeFileSync(join(pkgDir, "package.json"), JSON.stringify({ name: PI_PACKAGE_NAME }));
-		const entry = existingScript("cli.ts", srcDir);
-		const invocation = getPiInvocation(["-p"], runtime({ argv1: entry }));
-		expect(invocation.command).toBe("/usr/bin/bun");
-		expect(invocation.args).toEqual([entry, "-p"]);
-	});
-
-	test("an unreadable nearest manifest fails closed even under a pi ancestor (PR #1178 r3)", () => {
-		// EACCES or any non-ENOENT read failure must reject immediately instead of
-		// falling through to a pi-named ancestor. Root ignores file modes, so the EACCES
-		// path cannot be exercised.
-		if (typeof process.getuid === "function" && process.getuid() === 0) return;
-		const outer = join(tempDir(), "pkg");
-		const inner = join(outer, "vendor");
-		mkdirSync(inner, { recursive: true });
-		writeFileSync(join(outer, "package.json"), JSON.stringify({ name: PI_PACKAGE_NAME }));
-		const innerManifest = join(inner, "package.json");
-		writeFileSync(innerManifest, JSON.stringify({ name: PI_PACKAGE_NAME }));
-		chmodSync(innerManifest, 0o000);
-		try {
-			// Probe that mode bits actually deny reads here. Some
-			// CI filesystems ignore them — so the assertion only runs where the
-			// EACCES path is genuinely exercisable.
-			try {
-				readFileSync(innerManifest, "utf-8");
-				return; // filesystem does not enforce modes; skip
-			} catch {
-				/* unreadable as intended */
-			}
-			const entry = existingScript("cli.ts", inner);
-			expect(getPiInvocation(["-p"], runtime({ argv1: entry })).command).toBe("pi");
-		} finally {
-			chmodSync(innerManifest, 0o600);
-		}
-	});
-
-	test("PI_SUBAGENT_ENTRY script override wins over a pi-package argv[1]", () => {
+		return withEntry(existingScript("cli.ts", srcDir));
+	}, SELF],
+	["a script override wins over pi's own argv[1] and is handed down", () => {
 		const override = existingScript("custom-entry.mjs");
 		const argv1 = scriptInPackage("cli.ts", { name: PI_PACKAGE_NAME });
-		const invocation = getPiInvocation(["-p"], runtime({ argv1, env: { [PI_SUBAGENT_ENTRY_ENV]: override } }));
-		expect(invocation.command).toBe("/usr/bin/bun");
-		expect(invocation.args).toEqual([override, "-p"]);
-	});
-
-	test("relative PI_SUBAGENT_ENTRY resolves to an absolute path against the parent cwd (PR #1178 f2/f3)", () => {
-		// The child spawns from the delegated agent cwd; a relative script arg
-		// would ENOENT there. The returned arg must already be absolute.
+		return { alias: { [override]: "override", [argv1]: "entry" }, runtime: runtime({ argv1, env: { [PI_SUBAGENT_ENTRY_ENV]: override } }) };
+	}, "cmd=bun args=[override,-p] child-entry=override depth=1"],
+	["a relative script override resolves against the parent cwd and is handed down resolved", () => {
 		const override = existingScript("custom-entry.mjs");
-		const relativeOverride = relative(process.cwd(), override);
-		expect(isAbsolute(relativeOverride)).toBe(false);
-		const invocation = getPiInvocation(["-p"], runtime({ env: { [PI_SUBAGENT_ENTRY_ENV]: relativeOverride } }));
-		expect(invocation.command).toBe("/usr/bin/bun");
-		expect(invocation.args[0]).toBe(override);
-		expect(isAbsolute(invocation.args[0])).toBe(true);
-		// Children must inherit the RESOLVED form, not the
-		// relative one, or a delegating child re-resolves from ITS cwd.
-		expect(invocation.childEntryOverride).toBe(override);
-	});
-
-	test("bare-command overrides propagate to children unchanged", () => {
-		const invocation = getPiInvocation([], runtime({ env: { [PI_SUBAGENT_ENTRY_ENV]: "/opt/pi/bin/pi" } }));
-		expect(invocation.childEntryOverride).toBe("/opt/pi/bin/pi");
-		expect(getPiInvocation([], runtime({})).childEntryOverride).toBeUndefined();
-	});
-
-	test("PI_SUBAGENT_ENTRY executable override is used as the command itself", () => {
-		const invocation = getPiInvocation(["-p"], runtime({ env: { [PI_SUBAGENT_ENTRY_ENV]: "/opt/pi/bin/pi" } }));
-		expect(invocation.command).toBe("/opt/pi/bin/pi");
-		expect(invocation.args).toEqual(["-p"]);
-	});
-
-	test("relative separator-bearing executable override resolves to absolute and propagates resolved (PR #1178 r4)", () => {
-		// A command containing a path separator is never PATH-resolved, so a
-		// relative ./bin/pi would ENOENT from the delegated agent cwd — and pane
-		// descendants would inherit the broken relative value.
-		const binDir = join(tempDir(), "bin");
+		const rel = relative(process.cwd(), override);
+		assert.equal(isAbsolute(rel), false);
+		return { alias: { [override]: "override" }, runtime: runtime({ env: { [PI_SUBAGENT_ENTRY_ENV]: rel } }) };
+	}, "cmd=bun args=[override,-p] child-entry=override depth=1"],
+	["a script override that does not exist is taken as an executable path", () => {
+		const missing = join(tempRuntime(), "gone.mjs");
+		return { alias: { [missing]: "missing" }, runtime: runtime({ env: { [PI_SUBAGENT_ENTRY_ENV]: missing } }) };
+	}, "cmd=missing args=[-p] child-entry=missing depth=1"],
+	["an absolute executable override is the command and is handed down", () => ({ alias: {}, runtime: runtime({ env: { [PI_SUBAGENT_ENTRY_ENV]: "/opt/pi/bin/pi" } }) }), "cmd=/opt/pi/bin/pi args=[-p] child-entry=/opt/pi/bin/pi depth=1"],
+	["a relative separator-bearing executable override resolves and is handed down resolved", () => {
+		const binDir = join(tempRuntime(), "bin");
 		mkdirSync(binDir, { recursive: true });
 		const executable = join(binDir, "pi");
 		writeFileSync(executable, "#!/bin/sh\n");
-		const relativeExecutable = relative(process.cwd(), executable);
-		expect(isAbsolute(relativeExecutable)).toBe(false);
-		const invocation = getPiInvocation(["-p"], runtime({ env: { [PI_SUBAGENT_ENTRY_ENV]: relativeExecutable } }));
-		expect(invocation.command).toBe(executable);
-		expect(isAbsolute(invocation.command)).toBe(true);
-		expect(invocation.childEntryOverride).toBe(executable);
-		expect(invocation.args).toEqual(["-p"]);
-	});
+		const rel = relative(process.cwd(), executable);
+		assert.equal(isAbsolute(rel), false);
+		return { alias: { [executable]: "executable" }, runtime: runtime({ env: { [PI_SUBAGENT_ENTRY_ENV]: rel } }) };
+	}, "cmd=executable args=[-p] child-entry=executable depth=1"],
+	["a separator-free override stays verbatim for PATH resolution", () => ({ alias: {}, runtime: runtime({ env: { [PI_SUBAGENT_ENTRY_ENV]: "pi-custom" } }) }), "cmd=pi-custom args=[-p] child-entry=pi-custom depth=1"],
+	["a blank override is no override", () => ({ alias: {}, runtime: runtime({ env: { [PI_SUBAGENT_ENTRY_ENV]: "  " } }) }), ON_PATH],
+	["the compiled binary (bun's virtual argv[1]) re-invokes execPath", () => ({ alias: {}, runtime: runtime({ argv1: "/$bunfs/root/cli.js", execPath: "/usr/lib/pi/pi" }) }), "cmd=/usr/lib/pi/pi args=[-p] child-entry=- depth=1"],
+	["a non-runtime execPath is re-invoked even with a harness argv[1]", () => ({ ...withEntry(existingScript("harness.mjs"), { execPath: "/usr/lib/pi/pi" }) }), "cmd=/usr/lib/pi/pi args=[-p] child-entry=- depth=1"],
+	["node as execPath with no script falls back", () => ({ alias: {}, runtime: runtime({ execPath: "/usr/bin/node" }) }), ON_PATH],
+];
 
-	test("separator-free bare-name override stays verbatim for PATH resolution", () => {
-		const invocation = getPiInvocation([], runtime({ env: { [PI_SUBAGENT_ENTRY_ENV]: "pi-custom" } }));
-		expect(invocation.command).toBe("pi-custom");
-		expect(invocation.childEntryOverride).toBe("pi-custom");
-	});
-
-	test("resolved relative executable actually runs from a different delegated cwd (PR #1178 r5, real spawn)", () => {
-		// The mocked-spawn coverage never exercises OS command resolution. This
-		// spawns the resolved invocation for real: a relative ./…/bin/pi
-		// override, resolved against the parent cwd, must execute when the
-		// child's cwd is a DIFFERENT delegated directory. Shell-script fixture
-		// needs a shebang, so skip on Windows.
-		if (process.platform === "win32") return;
-		const fixtureRoot = tempDir("pi-agents-real-spawn-");
-		// Probe that this environment can exec shebang scripts from
-		// the temp dir at all — noexec temp mounts or bashless CI would
-		// false-fail the assertions below. Same pattern as the chmod probe.
-		const probe = join(fixtureRoot, "probe.sh");
-		writeFileSync(probe, "#!/usr/bin/env bash\nexit 0\n");
-		chmodSync(probe, 0o755);
-		const probeRun = spawnSync(probe, []);
-		if (probeRun.error || probeRun.status !== 0) return; // temp dir not executable or bash unavailable; skip
-
-		const binDir = join(fixtureRoot, "bin");
-		mkdirSync(binDir, { recursive: true });
-		const marker = join(fixtureRoot, "marker.txt");
-		const executable = join(binDir, "pi");
-		writeFileSync(executable, `#!/bin/sh\nprintf ran > ${JSON.stringify(marker)}\n`);
-		chmodSync(executable, 0o755);
-		const relativeExecutable = relative(process.cwd(), executable);
-		expect(isAbsolute(relativeExecutable)).toBe(false);
-		// The delegated cwd must sit DEEPER than the relative path's ".." climb;
-		// from a shallow cwd the excess ".." segments clamp at / and the
-		// relative form would accidentally still resolve.
-		const upLevels = relativeExecutable.split("/").filter((segment) => segment === "..").length;
-		let delegatedCwd = tempDir("pi-agents-real-spawn-cwd-");
-		for (let i = 0; i < upLevels; i++) delegatedCwd = join(delegatedCwd, `depth-${i}`);
-		mkdirSync(delegatedCwd, { recursive: true });
-
-		const invocation = getPiInvocation([], runtime({ env: { [PI_SUBAGENT_ENTRY_ENV]: relativeExecutable } }));
-		const result = spawnSync(invocation.command, invocation.args, { cwd: delegatedCwd });
-		expect(result.error).toBeUndefined();
-		expect(result.status).toBe(0);
-		expect(readFileSync(marker, "utf-8")).toBe("ran");
-
-		// Same command through the production boundary: a launcher script FILE
-		// embedding the invocation via the same shellQuote writeLauncher uses,
-		// executed with cwd = the delegated dir, which resolves the command from
-		// that cwd. Bun's own spawnSync resolves relative commands against the
-		// parent cwd, so only this form can distinguish a resolved absolute
-		// absolute entry from a relative one.
-		const writeTestLauncher = (name: string, command: string, args: string[]): string => {
-			const launcherPath = join(fixtureRoot, name);
-			writeFileSync(launcherPath, `#!/usr/bin/env bash\nset -euo pipefail\nexec ${[command, ...args].map(shellQuote).join(" ")}\n`);
-			chmodSync(launcherPath, 0o755);
-			return launcherPath;
-		};
-		rmSync(marker, { force: true });
-		const viaLauncher = spawnSync(writeTestLauncher("launcher.sh", invocation.command, invocation.args), [], { cwd: delegatedCwd });
-		expect(viaLauncher.status).toBe(0);
-		expect(readFileSync(marker, "utf-8")).toBe("ran");
-
-		// Negative control: a launcher embedding the RELATIVE form fails
-		// command lookup from the delegated cwd (exit 127).
-		const broken = spawnSync(writeTestLauncher("launcher-broken.sh", relativeExecutable, []), [], { cwd: delegatedCwd });
-		expect(broken.status).toBe(127);
-	});
-
-	test("compiled pi binary (/$bunfs argv[1]) still re-invokes execPath directly", () => {
-		const invocation = getPiInvocation(["-p"], runtime({ argv1: "/$bunfs/root/cli.js", execPath: "/usr/lib/pi/pi" }));
-		expect(invocation.command).toBe("/usr/lib/pi/pi");
-		expect(invocation.args).toEqual(["-p"]);
-	});
+test("which pi a child re-invokes", () => {
+	for (const [label, build, expect] of resolutionRows) {
+		const { alias, args, runtime: rt } = build();
+		assert.equal(invocationLine(getPiInvocation(args ?? ["-p"], rt), alias), expect, label);
+	}
 });
 
-describe("PI_SUBAGENT_DEPTH recursion guard (kendex#192)", () => {
-	test("currentSubagentDepth parses the env var defensively", () => {
-		expect(currentSubagentDepth({})).toBe(0);
-		expect(currentSubagentDepth({ [PI_SUBAGENT_DEPTH_ENV]: "2" })).toBe(2);
-		expect(currentSubagentDepth({ [PI_SUBAGENT_DEPTH_ENV]: "banana" })).toBe(0);
-		expect(currentSubagentDepth({ [PI_SUBAGENT_DEPTH_ENV]: "-4" })).toBe(0);
-	});
-
-	test("assertSubagentSpawnDepth increments below the cap and refuses at it", () => {
-		expect(assertSubagentSpawnDepth({})).toBe(1);
-		expect(assertSubagentSpawnDepth({ [PI_SUBAGENT_DEPTH_ENV]: String(MAX_SUBAGENT_DEPTH - 1) })).toBe(MAX_SUBAGENT_DEPTH);
-		expect(() => assertSubagentSpawnDepth({ [PI_SUBAGENT_DEPTH_ENV]: String(MAX_SUBAGENT_DEPTH) })).toThrow(
-			new RegExp(`${PI_SUBAGENT_DEPTH_ENV} recursion guard`),
-		);
-	});
-
-	test("the guard is independent of entry resolution: a valid override still refuses at cap", () => {
-		const override = existingScript("custom-entry.mjs");
-		expect(() =>
-			getPiInvocation([], runtime({ env: { [PI_SUBAGENT_ENTRY_ENV]: override, [PI_SUBAGENT_DEPTH_ENV]: String(MAX_SUBAGENT_DEPTH) } })),
-		).toThrow(new RegExp(`refusing to spawn a subagent at depth ${MAX_SUBAGENT_DEPTH + 1}`));
-	});
-
-	test("getPiInvocation reports the child generation for the spawn env", () => {
-		expect(getPiInvocation([], runtime({})).childDepth).toBe(1);
-		expect(getPiInvocation([], runtime({ env: { [PI_SUBAGENT_DEPTH_ENV]: "1" } })).childDepth).toBe(2);
-	});
+test("an unreadable nearest manifest fails closed under a pi ancestor", () => {
+	// Root ignores file modes, and some CI filesystems do too; the case only
+	// asserts where the read is genuinely refused.
+	if (typeof process.getuid === "function" && process.getuid() === 0) return;
+	const outer = join(tempRuntime(), "pkg");
+	const inner = join(outer, "vendor");
+	mkdirSync(inner, { recursive: true });
+	writeFileSync(join(outer, "package.json"), JSON.stringify({ name: PI_PACKAGE_NAME }));
+	const innerManifest = join(inner, "package.json");
+	writeFileSync(innerManifest, JSON.stringify({ name: PI_PACKAGE_NAME }));
+	chmodSync(innerManifest, 0o000);
+	try {
+		try {
+			readFileSync(innerManifest, "utf-8");
+			return;
+		} catch {
+			/* unreadable as intended */
+		}
+		const entry = existingScript("cli.ts", inner);
+		assert.equal(invocationLine(getPiInvocation(["-p"], runtime({ argv1: entry })), { [entry]: "entry" }), ON_PATH);
+	} finally {
+		chmodSync(innerManifest, 0o600);
+	}
 });
 
-function makeDetails(results: SingleResult[]): SubagentDetails {
-	return { mode: "single", agentScope: "project", projectAgentsDir: null, results };
-}
-
-function agent(name: string, systemPrompt = "", pane = false): AgentConfig {
-	return {
-		name,
-		description: `${name} test agent`,
-		pane,
-		systemPrompt,
-		source: "project",
-		filePath: `${name}.md`,
+// The depth as read, the child generation the guard grants (or `refused`), and
+// the same through getPiInvocation, which runs the guard before resolving.
+function depthLine(env: NodeJS.ProcessEnv): string {
+	const guard = () => {
+		try {
+			return String(assertSubagentSpawnDepth(env));
+		} catch {
+			return "refused";
+		}
 	};
+	const viaInvocation = () => {
+		try {
+			return String(getPiInvocation([], runtime({ env })).childDepth);
+		} catch {
+			return "refused";
+		}
+	};
+	return `current=${currentSubagentDepth(env)} child=${guard()} invocation=${viaInvocation()}`;
 }
 
-function captureSpawnedEnv(): Array<NodeJS.ProcessEnv | undefined> {
-	const envs: Array<NodeJS.ProcessEnv | undefined> = [];
+// label | env | expect the depth line
+const depthRows: Array<[string, NodeJS.ProcessEnv, string]> = [
+	["no depth var is generation zero", {}, "current=0 child=1 invocation=1"],
+	["a depth is read", { [PI_SUBAGENT_DEPTH_ENV]: "2" }, "current=2 child=3 invocation=3"],
+	["a non-number is zero", { [PI_SUBAGENT_DEPTH_ENV]: "banana" }, "current=0 child=1 invocation=1"],
+	["a negative number is zero", { [PI_SUBAGENT_DEPTH_ENV]: "-4" }, "current=0 child=1 invocation=1"],
+	["one below the cap spawns the last generation", { [PI_SUBAGENT_DEPTH_ENV]: String(MAX_SUBAGENT_DEPTH - 1) }, `current=${MAX_SUBAGENT_DEPTH - 1} child=${MAX_SUBAGENT_DEPTH} invocation=${MAX_SUBAGENT_DEPTH}`],
+	["at the cap the guard refuses", { [PI_SUBAGENT_DEPTH_ENV]: String(MAX_SUBAGENT_DEPTH) }, `current=${MAX_SUBAGENT_DEPTH} child=refused invocation=refused`],
+	["a valid override does not bypass the cap", { [PI_SUBAGENT_DEPTH_ENV]: String(MAX_SUBAGENT_DEPTH), [PI_SUBAGENT_ENTRY_ENV]: "/opt/pi/bin/pi" }, `current=${MAX_SUBAGENT_DEPTH} child=refused invocation=refused`],
+];
+
+test("the recursion depth guard", () => {
+	for (const [label, env, expect] of depthRows) assert.equal(depthLine(env), expect, label);
+});
+
+// The two env vars the runner and launcher read from their own process.
+function withProcessEnv<T>(depth: string | undefined, entry: string | undefined, fn: () => Promise<T>): Promise<T> {
+	const previousDepth = process.env[PI_SUBAGENT_DEPTH_ENV];
+	const previousEntry = process.env[PI_SUBAGENT_ENTRY_ENV];
+	if (depth === undefined) delete process.env[PI_SUBAGENT_DEPTH_ENV];
+	else process.env[PI_SUBAGENT_DEPTH_ENV] = depth;
+	if (entry === undefined) delete process.env[PI_SUBAGENT_ENTRY_ENV];
+	else process.env[PI_SUBAGENT_ENTRY_ENV] = entry;
+	return fn().finally(() => {
+		if (previousDepth === undefined) delete process.env[PI_SUBAGENT_DEPTH_ENV];
+		else process.env[PI_SUBAGENT_DEPTH_ENV] = previousDepth;
+		if (previousEntry === undefined) delete process.env[PI_SUBAGENT_ENTRY_ENV];
+		else process.env[PI_SUBAGENT_ENTRY_ENV] = previousEntry;
+	});
+}
+
+function agent(overrides: Partial<AgentConfig> = {}): AgentConfig {
+	return { ...testAgent(), name: "scout", description: "scout test agent", filePath: "scout.md", ...overrides };
+}
+
+function captureSpawn(): Array<{ args: string[]; env: NodeJS.ProcessEnv | undefined }> {
+	const calls: Array<{ args: string[]; env: NodeJS.ProcessEnv | undefined }> = [];
 	setSingleAgentSpawnForTests(((command: string, args: string[], options?: { env?: NodeJS.ProcessEnv }) => {
 		void command;
-		void args;
-		envs.push(options?.env);
-		const proc = new EventEmitter() as any;
-		proc.stdout = new EventEmitter();
-		proc.stderr = new EventEmitter();
-		proc.killed = false;
-		proc.kill = () => { proc.killed = true; return true; };
-		queueMicrotask(() => proc.emit("close", 0, null));
-		return proc;
-	}) as any);
-	return envs;
-}
-
-function promptTempDirs(): string[] {
-	return readdirSync(tmpdir()).filter((name) => name.startsWith("pi-subagent-"));
-}
-
-function captureSpawnedArgs(): string[][] {
-	const calls: string[][] = [];
-	setSingleAgentSpawnForTests(((command: string, args: string[]) => {
-		void command;
-		calls.push(args);
+		calls.push({ args, env: options?.env });
 		const proc = new EventEmitter() as any;
 		proc.stdout = new EventEmitter();
 		proc.stderr = new EventEmitter();
@@ -353,195 +218,148 @@ function captureSpawnedArgs(): string[][] {
 	return calls;
 }
 
-function thinkingFlag(args: string[]): string | undefined {
-	const at = args.indexOf("--thinking");
-	return at < 0 ? undefined : args[at + 1];
+const promptTempDirs = () => readdirSync(tmpdir()).filter((name) => name.startsWith("pi-subagent-"));
+const flag = (args: string[], name: string) => { const at = args.indexOf(name); return at < 0 ? "-" : args[at + 1]; };
+
+type SpawnWorld = { agent?: Partial<AgentConfig>; depth?: string; entry?: (cwd: string) => { alias: Alias; value: string }; parentModel?: string };
+
+// The spawn as one line: spawns, the child's depth and entry vars, the model
+// and thinking flags, or `refused` with what the refusal left behind.
+async function runnerLine(world: SpawnWorld): Promise<string> {
+	const root = tempRuntime();
+	const entry = world.entry?.(root);
+	return withProcessEnv(world.depth, entry?.value, async () => {
+		const calls = captureSpawn();
+		const emitted: string[] = [];
+		const pi = { getActiveTools: () => [], events: { emit: (name: string) => { emitted.push(name); } } } as any;
+		const before = promptTempDirs();
+		try {
+			const config = agent(world.agent);
+			await runSingleAgent(root, root, [config], config.name, "recon", undefined, world.parentModel, undefined, undefined, pi, undefined, undefined, makeDetails);
+		} catch (error) {
+			const same = JSON.stringify(promptTempDirs()) === JSON.stringify(before);
+			return `refused=${/recursion guard/.test(String(error))} spawns=${calls.length} prompt-tmp=${same ? "unchanged" : "leaked"} events=${emitted.length ? emitted.join(",") : "none"}`;
+		} finally {
+			setSingleAgentSpawnForTests();
+		}
+		const call = calls[0];
+		return `spawns=${calls.length} depth=${call?.env?.[PI_SUBAGENT_DEPTH_ENV] ?? "-"} entry=${aliased(call?.env?.[PI_SUBAGENT_ENTRY_ENV], entry?.alias ?? {})} model=${flag(call?.args ?? [], "--model")} thinking=${flag(call?.args ?? [], "--thinking")}`;
+	});
 }
 
-describe("bg one-shot runner effort wiring (KEN-1233)", () => {
-	const noPi = { getActiveTools: () => [], events: { emit: () => undefined } } as any;
-	const previousDepth = process.env[PI_SUBAGENT_DEPTH_ENV];
+const relativeOverride = () => {
+	const override = existingScript("custom-entry.mjs");
+	return { alias: { [override]: "override" }, value: relative(process.cwd(), override) };
+};
 
-	async function spawnedArgs(config: AgentConfig, parentModel: string | undefined): Promise<string[]> {
-		const calls = captureSpawnedArgs();
-		try {
-			delete process.env[PI_SUBAGENT_DEPTH_ENV];
-			const root = tempDir("pi-agents-effort-");
-			await runSingleAgent(root, root, [config], config.name, "recon", undefined, parentModel, undefined, undefined, noPi, undefined, undefined, makeDetails);
-			expect(calls).toHaveLength(1);
-			return calls[0]!;
-		} finally {
-			setSingleAgentSpawnForTests();
-			if (previousDepth === undefined) delete process.env[PI_SUBAGENT_DEPTH_ENV];
-			else process.env[PI_SUBAGENT_DEPTH_ENV] = previousDepth;
-		}
-	}
+// label | the parent's env, agent and model | expect the spawn line
+const runnerRows: Array<[string, SpawnWorld, string]> = [
+	["a first-generation parent spawns the child at depth 1", { parentModel: "anthropic/claude-opus-5" }, "spawns=1 depth=1 entry=- model=anthropic/claude-opus-5 thinking=-"],
+	["the child's depth is the parent's plus one", { depth: "1" }, "spawns=1 depth=2 entry=- model=- thinking=-"],
+	["a relative entry override reaches the child resolved", { entry: relativeOverride }, "spawns=1 depth=1 entry=override model=- thinking=-"],
+	["the frontmatter effort becomes the thinking flag", { agent: { effort: "high" }, parentModel: "anthropic/claude-opus-5" }, "spawns=1 depth=1 entry=- model=anthropic/claude-opus-5 thinking=high"],
+	["a model suffix wins over the effort key", { agent: { effort: "high", model: "openai-codex/gpt-6-astra:low" } }, "spawns=1 depth=1 entry=- model=openai-codex/gpt-6-astra:low thinking=low"],
+	// A non-empty systemPrompt creates the prompt tmp dir before the guard
+	// throws, so the refusal has something to clean up.
+	["at the cap the runner refuses before the spawn, cleans its prompt dir and announces nothing", { agent: { systemPrompt: "You are scout." }, depth: String(MAX_SUBAGENT_DEPTH) }, "refused=true spawns=0 prompt-tmp=unchanged events=none"],
+];
 
-	test("an inherited model runs at the frontmatter effort", async () => {
-		const args = await spawnedArgs({ ...agent("scout"), effort: "high" }, "anthropic/claude-opus-5");
-		expect(args).toContain("anthropic/claude-opus-5");
-		expect(thinkingFlag(args)).toBe("high");
-	});
-
-	test("a model suffix wins over the effort key", async () => {
-		const args = await spawnedArgs({ ...agent("scout"), model: "openai-codex/gpt-6-astra:low", effort: "high" }, undefined);
-		expect(thinkingFlag(args)).toBe("low");
-	});
-
-	test("no effort anywhere passes no --thinking", async () => {
-		const args = await spawnedArgs(agent("scout"), "anthropic/claude-opus-5");
-		expect(thinkingFlag(args)).toBeUndefined();
-	});
+test("what the one-shot runner hands the child", async () => {
+	for (const [label, world, expect] of runnerRows) assert.equal(await runnerLine(world), expect, label);
 });
 
-describe("bg one-shot runner depth guard wiring (kendex#192)", () => {
-	test("spawned child env carries the incremented PI_SUBAGENT_DEPTH", async () => {
-		const envs = captureSpawnedEnv();
-		const previous = process.env[PI_SUBAGENT_DEPTH_ENV];
-		try {
-			delete process.env[PI_SUBAGENT_DEPTH_ENV];
-			const root = tempDir("pi-agents-depth-env-");
-			await runSingleAgent(root, root, [agent("scout")], "scout", "recon", undefined, undefined, undefined, undefined, { getActiveTools: () => [], events: { emit: () => undefined } } as any, undefined, undefined, makeDetails);
-			expect(envs).toHaveLength(1);
-			expect(envs[0]?.[PI_SUBAGENT_DEPTH_ENV]).toBe("1");
-		} finally {
-			setSingleAgentSpawnForTests();
-			if (previous === undefined) delete process.env[PI_SUBAGENT_DEPTH_ENV];
-			else process.env[PI_SUBAGENT_DEPTH_ENV] = previous;
-		}
-	});
-
-	test("child env carries the RESOLVED absolute entry when the parent had a relative override (PR #1178 r3)", async () => {
-		const envs = captureSpawnedEnv();
-		const previousEntry = process.env[PI_SUBAGENT_ENTRY_ENV];
-		const previousDepth = process.env[PI_SUBAGENT_DEPTH_ENV];
-		try {
-			delete process.env[PI_SUBAGENT_DEPTH_ENV];
-			const override = existingScript("custom-entry.mjs");
-			const relativeOverride = relative(process.cwd(), override);
-			expect(isAbsolute(relativeOverride)).toBe(false);
-			process.env[PI_SUBAGENT_ENTRY_ENV] = relativeOverride;
-			const root = tempDir("pi-agents-entry-env-");
-			await runSingleAgent(root, root, [agent("scout")], "scout", "recon", undefined, undefined, undefined, undefined, { getActiveTools: () => [], events: { emit: () => undefined } } as any, undefined, undefined, makeDetails);
-			expect(envs).toHaveLength(1);
-			expect(envs[0]?.[PI_SUBAGENT_ENTRY_ENV]).toBe(override);
-		} finally {
-			setSingleAgentSpawnForTests();
-			if (previousEntry === undefined) delete process.env[PI_SUBAGENT_ENTRY_ENV];
-			else process.env[PI_SUBAGENT_ENTRY_ENV] = previousEntry;
-			if (previousDepth === undefined) delete process.env[PI_SUBAGENT_DEPTH_ENV];
-			else process.env[PI_SUBAGENT_DEPTH_ENV] = previousDepth;
-		}
-	});
-
-	test("at the depth cap the runner refuses before spawning and reclaims the prompt tmp dir", async () => {
-		const envs = captureSpawnedEnv();
-		const emitted: string[] = [];
-		const previous = process.env[PI_SUBAGENT_DEPTH_ENV];
-		try {
-			process.env[PI_SUBAGENT_DEPTH_ENV] = String(MAX_SUBAGENT_DEPTH);
-			const root = tempDir("pi-agents-depth-cap-");
-			const before = promptTempDirs();
-			// A non-empty systemPrompt forces the tmp prompt dir to be created
-			// before invocation resolution throws, exercising the failure-path
-			// cleanup in runSingleAgentAttempt's finally.
-			await expect(
-				runSingleAgent(root, root, [agent("scout", "You are scout.")], "scout", "recon", undefined, undefined, undefined, undefined, { getActiveTools: () => [], events: { emit: (name: string) => { emitted.push(name); } } } as any, undefined, undefined, makeDetails),
-			).rejects.toThrow(new RegExp(`${PI_SUBAGENT_DEPTH_ENV} recursion guard`));
-			expect(envs).toHaveLength(0);
-			expect(promptTempDirs()).toEqual(before);
-			// A refusal must not announce the task. A
-			// subagents:started with no terminal event would persist the task as
-			// permanently "running" in the dashboard/registry.
-			expect(emitted.filter((name) => name.startsWith("subagents:"))).toEqual([]);
-		} finally {
-			setSingleAgentSpawnForTests();
-			if (previous === undefined) delete process.env[PI_SUBAGENT_DEPTH_ENV];
-			else process.env[PI_SUBAGENT_DEPTH_ENV] = previous;
-		}
-	});
-});
-
-describe("persistent pane launcher effort wiring (KEN-1233)", () => {
-	test("an inherited model runs at the frontmatter effort", async () => {
-		const root = tempDir("pi-agents-launcher-effort-");
-		const cwd = tempDir("pi-agents-launcher-effort-cwd-");
-		const paths = await writeLauncher(root, "parent-session-id", cwd, { ...agent("iced", "You are iced.", true), effort: "high" }, "anthropic/claude-opus-5", undefined);
+// The launcher script as one line: the depth it exports, the entry it exports
+// or unsets, whether those exports precede the exec, and the exec line's model
+// and thinking flags.
+async function launcherLine(world: SpawnWorld): Promise<string> {
+	const root = tempRuntime();
+	const cwd = tempRuntime();
+	const entry = world.entry?.(root);
+	return withProcessEnv(world.depth, entry?.value, async () => {
+		const paths = await writeLauncher(root, "parent-session-id", cwd, agent({ pane: true, systemPrompt: "You are iced.", ...world.agent }), world.parentModel, undefined);
 		const script = readFileSync(paths.launcherFile, "utf-8");
-		expect(script).toContain("'--thinking' 'high'");
-		expect(script).toContain("anthropic/claude-opus-5");
+		const depth = script.match(new RegExp(`^export ${PI_SUBAGENT_DEPTH_ENV}=(\\S+)$`, "m"))?.[1] ?? "-";
+		const exported = script.match(new RegExp(`^export ${PI_SUBAGENT_ENTRY_ENV}='([^']*)'$`, "m"))?.[1];
+		const unset = new RegExp(`^unset ${PI_SUBAGENT_ENTRY_ENV}$`, "m").test(script);
+		const entryLine = exported !== undefined ? aliased(exported, entry?.alias ?? {}) : unset ? "unset" : "-";
+		const execAt = script.indexOf("\nexec ");
+		const exportsBeforeExec = execAt > 0 && !/^(export|unset) /m.test(script.slice(execAt));
+		const execLine = script.slice(execAt + 1).split("\n")[0] ?? "";
+		const quoted = (name: string) => execLine.match(new RegExp(`'${name}' '([^']*)'`))?.[1] ?? "-";
+		return `depth=${depth} entry=${entryLine} exports-before-exec=${exportsBeforeExec} model=${quoted("--model")} thinking=${quoted("--thinking")}`;
 	});
+}
 
-	test("a model suffix wins over the effort key, and no effort passes no flag", async () => {
-		const root = tempDir("pi-agents-launcher-effort-");
-		const cwd = tempDir("pi-agents-launcher-effort-cwd-");
-		const suffixed = await writeLauncher(root, "parent-session-id", cwd, { ...agent("iced", "You are iced.", true), effort: "high" }, "openai-codex/gpt-6-astra:low", undefined);
-		expect(readFileSync(suffixed.launcherFile, "utf-8")).toContain("'--thinking' 'low'");
-		const bare = await writeLauncher(root, "parent-session-id", cwd, agent("iced", "You are iced.", true), "anthropic/claude-opus-5", undefined);
-		expect(readFileSync(bare.launcherFile, "utf-8")).not.toContain("'--thinking'");
-	});
+// label | the parent's env, agent and model | expect the launcher line
+const launcherRows: Array<[string, SpawnWorld, string]> = [
+	["the launcher exports the next depth and unsets a stale entry before the exec", { depth: "1" }, "depth=2 entry=unset exports-before-exec=true model=- thinking=-"],
+	["a relative entry override is exported resolved", { entry: relativeOverride }, "depth=1 entry=override exports-before-exec=true model=- thinking=-"],
+	["the frontmatter effort becomes the thinking flag", { agent: { effort: "high" }, parentModel: "anthropic/claude-opus-5" }, "depth=1 entry=unset exports-before-exec=true model=anthropic/claude-opus-5 thinking=high"],
+	["a model suffix wins over the effort key", { agent: { effort: "high" }, parentModel: "openai-codex/gpt-6-astra:low" }, "depth=1 entry=unset exports-before-exec=true model=openai-codex/gpt-6-astra:low thinking=low"],
+];
+
+test("what the pane launcher hands the child", async () => {
+	for (const [label, world, expect] of launcherRows) assert.equal(await launcherLine(world), expect, label);
 });
 
-describe("persistent pane launcher depth export (kendex#192 / PR #1178 f4)", () => {
-	test("generated launcher script exports the incremented PI_SUBAGENT_DEPTH before exec", async () => {
-		const previousDepth = process.env[PI_SUBAGENT_DEPTH_ENV];
-		const previousEntry = process.env[PI_SUBAGENT_ENTRY_ENV];
-		try {
-			process.env[PI_SUBAGENT_DEPTH_ENV] = "1";
-			delete process.env[PI_SUBAGENT_ENTRY_ENV];
-			const root = tempDir("pi-agents-launcher-depth-");
-			const cwd = tempDir("pi-agents-launcher-cwd-");
-			const paths = await writeLauncher(root, "parent-session-id", cwd, agent("iced", "You are iced.", true), undefined, undefined);
-			const script = readFileSync(paths.launcherFile, "utf-8");
-			// Omitting this export would silently reset pane descendants to depth
-			// 0 and disarm the recursion guard for the whole pane subtree.
-			expect(script).toMatch(new RegExp(`^export ${PI_SUBAGENT_DEPTH_ENV}=2$`, "m"));
-			const exportIndex = script.indexOf(`export ${PI_SUBAGENT_DEPTH_ENV}=`);
-			const execIndex = script.indexOf("exec ");
-			expect(exportIndex).toBeGreaterThanOrEqual(0);
-			expect(execIndex).toBeGreaterThan(exportIndex);
-			// Without an active override the launcher must clear any stale
-			// tmux-server-level value rather than let it leak into the pane child.
-			expect(script).toMatch(new RegExp(`^unset ${PI_SUBAGENT_ENTRY_ENV}$`, "m"));
-		} finally {
-			if (previousDepth === undefined) delete process.env[PI_SUBAGENT_DEPTH_ENV];
-			else process.env[PI_SUBAGENT_DEPTH_ENV] = previousDepth;
-			if (previousEntry === undefined) delete process.env[PI_SUBAGENT_ENTRY_ENV];
-			else process.env[PI_SUBAGENT_ENTRY_ENV] = previousEntry;
-		}
-	});
+test("a resolved relative executable runs from a different delegated cwd", () => {
+	// The mocked spawn never exercises OS command resolution. A relative
+	// ./…/bin/pi override, resolved against the parent cwd, must execute when
+	// the child's cwd is a different directory, both directly and through a
+	// launcher file quoted the way writeLauncher quotes. Shebang scripts need a
+	// POSIX shell; a noexec temp mount or bashless host skips the case.
+	if (process.platform === "win32") return;
+	const fixtureRoot = tempRuntime();
+	const probe = join(fixtureRoot, "probe.sh");
+	writeFileSync(probe, "#!/usr/bin/env bash\nexit 0\n");
+	chmodSync(probe, 0o755);
+	const probeRun = spawnSync(probe, []);
+	if (probeRun.error || probeRun.status !== 0) return;
 
-	test("PANE_LAUNCHER_VERSION is bumped when the launcher template changes (PR #1178 r7)", () => {
-		// cleanupPaneRegistry recycles live panes only when their recorded
-		// launcherVersion differs from this constant — a template change
-		// without a bump leaves running panes on the OLD launcher (the depth
-		// guard shipped exactly that way at first). If this test fails: bump
-		// PANE_LAUNCHER_VERSION in types.ts AND update the pinned digest here.
-		const paneSource = readFileSync(join(import.meta.dir, "..", "extensions", "subagent", "pane.ts"), "utf-8");
-		const templateStart = paneSource.indexOf("const script = `#!/usr/bin/env bash");
-		expect(templateStart).toBeGreaterThan(-1);
-		const templateEnd = paneSource.indexOf("`;", templateStart);
-		expect(templateEnd).toBeGreaterThan(templateStart);
-		const templateDigest = createHash("sha256").update(paneSource.slice(templateStart, templateEnd)).digest("hex").slice(0, 16);
-		expect({ version: PANE_LAUNCHER_VERSION, templateDigest }).toEqual({ version: 11, templateDigest: "38837c68b7dc5b2a" });
-	});
+	const binDir = join(fixtureRoot, "bin");
+	mkdirSync(binDir, { recursive: true });
+	const marker = join(fixtureRoot, "marker.txt");
+	const executable = join(binDir, "pi");
+	writeFileSync(executable, `#!/bin/sh\nprintf ran > ${JSON.stringify(marker)}\n`);
+	chmodSync(executable, 0o755);
+	const relativeExecutable = relative(process.cwd(), executable);
+	assert.equal(isAbsolute(relativeExecutable), false);
+	// The delegated cwd sits deeper than the relative path's ".." climb; from a
+	// shallow cwd the excess ".." segments clamp at / and the relative form
+	// would accidentally still resolve.
+	const upLevels = relativeExecutable.split("/").filter((segment) => segment === "..").length;
+	let delegatedCwd = tempRuntime();
+	for (let i = 0; i < upLevels; i++) delegatedCwd = join(delegatedCwd, `depth-${i}`);
+	mkdirSync(delegatedCwd, { recursive: true });
 
-	test("launcher exports the RESOLVED absolute entry when the parent had a relative override (PR #1178 r3)", async () => {
-		const previousEntry = process.env[PI_SUBAGENT_ENTRY_ENV];
-		try {
-			const override = existingScript("custom-entry.mjs");
-			const relativeOverride = relative(process.cwd(), override);
-			expect(isAbsolute(relativeOverride)).toBe(false);
-			process.env[PI_SUBAGENT_ENTRY_ENV] = relativeOverride;
-			const root = tempDir("pi-agents-launcher-entry-");
-			const cwd = tempDir("pi-agents-launcher-entry-cwd-");
-			const paths = await writeLauncher(root, "parent-session-id", cwd, agent("iced", "You are iced.", true), undefined, undefined);
-			const script = readFileSync(paths.launcherFile, "utf-8");
-			expect(script).toContain(`export ${PI_SUBAGENT_ENTRY_ENV}='${override}'`);
-			expect(script).not.toContain(`='${relativeOverride}'`);
-		} finally {
-			if (previousEntry === undefined) delete process.env[PI_SUBAGENT_ENTRY_ENV];
-			else process.env[PI_SUBAGENT_ENTRY_ENV] = previousEntry;
-		}
-	});
+	const launcher = (name: string, command: string, args: string[]): string => {
+		const launcherPath = join(fixtureRoot, name);
+		writeFileSync(launcherPath, `#!/usr/bin/env bash\nset -euo pipefail\nexec ${[command, ...args].map(shellQuote).join(" ")}\n`);
+		chmodSync(launcherPath, 0o755);
+		return launcherPath;
+	};
+	const ran = () => { const text = readFileSync(marker, "utf-8"); rmSync(marker, { force: true }); return text; };
+
+	const invocation = getPiInvocation([], runtime({ env: { [PI_SUBAGENT_ENTRY_ENV]: relativeExecutable } }));
+	const direct = spawnSync(invocation.command, invocation.args, { cwd: delegatedCwd });
+	const directLine = `direct=${direct.error ? "error" : direct.status}/${ran()}`;
+	const viaLauncher = spawnSync(launcher("launcher.sh", invocation.command, invocation.args), [], { cwd: delegatedCwd });
+	const launcherLine = `launcher=${viaLauncher.status}/${ran()}`;
+	// Control: the relative form fails command lookup from the delegated cwd.
+	const broken = spawnSync(launcher("launcher-broken.sh", relativeExecutable, []), [], { cwd: delegatedCwd });
+	assert.equal(`${directLine} ${launcherLine} relative=${broken.status}`, "direct=0/ran launcher=0/ran relative=127");
+});
+
+test("PANE_LAUNCHER_VERSION is bumped when the launcher template changes", () => {
+	// Kept as a guard, not a behaviour test: cleanupPaneRegistry recycles live
+	// panes only when their recorded launcherVersion differs from this
+	// constant, so a template change without a bump leaves running panes on
+	// the old launcher (the depth guard shipped that way once). On failure:
+	// bump PANE_LAUNCHER_VERSION in types.ts and update the digest here.
+	const paneSource = readFileSync(join(import.meta.dir, "..", "extensions", "subagent", "pane.ts"), "utf-8");
+	const templateStart = paneSource.indexOf("const script = `#!/usr/bin/env bash");
+	const templateEnd = paneSource.indexOf("`;", templateStart);
+	assert.ok(templateStart > -1 && templateEnd > templateStart);
+	const templateDigest = createHash("sha256").update(paneSource.slice(templateStart, templateEnd)).digest("hex").slice(0, 16);
+	assert.equal(`version=${PANE_LAUNCHER_VERSION} template=${templateDigest}`, "version=11 template=38837c68b7dc5b2a");
 });

--- a/pi-extensions/pi-agents-tmux/tests/pi-invocation.test.ts
+++ b/pi-extensions/pi-agents-tmux/tests/pi-invocation.test.ts
@@ -6,7 +6,7 @@ import assert from "node:assert/strict";
 import { spawnSync } from "node:child_process";
 import { createHash } from "node:crypto";
 import { EventEmitter } from "node:events";
-import { chmodSync, mkdirSync, readdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { chmodSync, existsSync, mkdirSync, readdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { isAbsolute, join, relative } from "node:path";
 import test, { after } from "node:test";
@@ -26,7 +26,7 @@ import {
 } from "../extensions/subagent/pane.js";
 import { runSingleAgent, setSingleAgentSpawnForTests } from "../extensions/subagent/runner.js";
 import { PANE_LAUNCHER_VERSION } from "../extensions/subagent/types.js";
-import { cleanupTempRuntimes, makeDetails, tempRuntime, testAgent } from "./single-agent-fixture.js";
+import { cleanupTempRuntimes, makeDetails, tempRuntime, testAgent, writeSettings } from "./single-agent-fixture.js";
 
 after(cleanupTempRuntimes);
 
@@ -76,6 +76,14 @@ const resolutionRows: Array<[string, Resolution, string]> = [
 	["a package named pi whose string bin is this script re-invokes", () => withEntry(scriptInPackage("cli.js", { name: "pi", bin: "./cli.js" })), SELF],
 	["a bin map whose pi entry is another file falls back", () => withEntry(scriptInPackage("cli.ts", { name: "some-fork-of-pi", bin: { pi: "./cli.js" } })), ON_PATH],
 	["a package named pi whose string bin is another file falls back", () => withEntry(scriptInPackage("cli.ts", { name: "pi", bin: "./cli.js" })), ON_PATH],
+	["an unparseable nearest manifest fails closed under a pi ancestor", () => {
+		const outer = join(tempRuntime(), "pkg");
+		const inner = join(outer, "vendor");
+		mkdirSync(inner, { recursive: true });
+		writeFileSync(join(outer, "package.json"), JSON.stringify({ name: PI_PACKAGE_NAME }));
+		writeFileSync(join(inner, "package.json"), "{ not json");
+		return withEntry(existingScript("cli.ts", inner));
+	}, ON_PATH],
 	["a manifest-less entry dir walks up to pi's manifest", () => {
 		const pkgDir = join(tempRuntime(), "pkg");
 		const srcDir = join(pkgDir, "src");
@@ -110,6 +118,9 @@ const resolutionRows: Array<[string, Resolution, string]> = [
 	}, "cmd=executable args=[-p] child-entry=executable depth=1"],
 	["a separator-free override stays verbatim for PATH resolution", () => ({ alias: {}, runtime: runtime({ env: { [PI_SUBAGENT_ENTRY_ENV]: "pi-custom" } }) }), "cmd=pi-custom args=[-p] child-entry=pi-custom depth=1"],
 	["a blank override is no override", () => ({ alias: {}, runtime: runtime({ env: { [PI_SUBAGENT_ENTRY_ENV]: "  " } }) }), ON_PATH],
+	// The `!isBunVirtualScript` guard itself is only reachable inside a compiled
+	// binary, where the virtual path exists; here the row reaches execPath
+	// through the missing file and the non-runtime execPath.
 	["the compiled binary (bun's virtual argv[1]) re-invokes execPath", () => ({ alias: {}, runtime: runtime({ argv1: "/$bunfs/root/cli.js", execPath: "/usr/lib/pi/pi" }) }), "cmd=/usr/lib/pi/pi args=[-p] child-entry=- depth=1"],
 	["a non-runtime execPath is re-invoked even with a harness argv[1]", () => ({ ...withEntry(existingScript("harness.mjs"), { execPath: "/usr/lib/pi/pi" }) }), "cmd=/usr/lib/pi/pi args=[-p] child-entry=- depth=1"],
 	["node as execPath with no script falls back", () => ({ alias: {}, runtime: runtime({ execPath: "/usr/bin/node" }) }), ON_PATH],
@@ -221,7 +232,7 @@ function captureSpawn(): Array<{ args: string[]; env: NodeJS.ProcessEnv | undefi
 const promptTempDirs = () => readdirSync(tmpdir()).filter((name) => name.startsWith("pi-subagent-"));
 const flag = (args: string[], name: string) => { const at = args.indexOf(name); return at < 0 ? "-" : args[at + 1]; };
 
-type SpawnWorld = { agent?: Partial<AgentConfig>; depth?: string; entry?: (cwd: string) => { alias: Alias; value: string }; parentModel?: string };
+type SpawnWorld = { agent?: Partial<AgentConfig>; depth?: string; entry?: (cwd: string) => { alias: Alias; value: string }; parentModel?: string; parentThinking?: string; settings?: Record<string, unknown> };
 
 // The spawn as one line: spawns, the child's depth and entry vars, the model
 // and thinking flags, or `refused` with what the refusal left behind.
@@ -235,7 +246,8 @@ async function runnerLine(world: SpawnWorld): Promise<string> {
 		const before = promptTempDirs();
 		try {
 			const config = agent(world.agent);
-			await runSingleAgent(root, root, [config], config.name, "recon", undefined, world.parentModel, undefined, undefined, pi, undefined, undefined, makeDetails);
+			if (world.settings) writeSettings(root, world.settings);
+			await runSingleAgent(root, root, [config], config.name, "recon", undefined, world.parentModel, world.parentThinking, undefined, pi, undefined, undefined, makeDetails);
 		} catch (error) {
 			const same = JSON.stringify(promptTempDirs()) === JSON.stringify(before);
 			return `refused=${/recursion guard/.test(String(error))} spawns=${calls.length} prompt-tmp=${same ? "unchanged" : "leaked"} events=${emitted.length ? emitted.join(",") : "none"}`;
@@ -243,7 +255,7 @@ async function runnerLine(world: SpawnWorld): Promise<string> {
 			setSingleAgentSpawnForTests();
 		}
 		const call = calls[0];
-		return `spawns=${calls.length} depth=${call?.env?.[PI_SUBAGENT_DEPTH_ENV] ?? "-"} entry=${aliased(call?.env?.[PI_SUBAGENT_ENTRY_ENV], entry?.alias ?? {})} model=${flag(call?.args ?? [], "--model")} thinking=${flag(call?.args ?? [], "--thinking")}`;
+		return `events=${emitted.length ? emitted.join(",") : "none"} spawns=${calls.length} depth=${call?.env?.[PI_SUBAGENT_DEPTH_ENV] ?? "-"} entry=${aliased(call?.env?.[PI_SUBAGENT_ENTRY_ENV], entry?.alias ?? {})} model=${flag(call?.args ?? [], "--model")} thinking=${flag(call?.args ?? [], "--thinking")}`;
 	});
 }
 
@@ -254,11 +266,14 @@ const relativeOverride = () => {
 
 // label | the parent's env, agent and model | expect the spawn line
 const runnerRows: Array<[string, SpawnWorld, string]> = [
-	["a first-generation parent spawns the child at depth 1", { parentModel: "anthropic/claude-opus-5" }, "spawns=1 depth=1 entry=- model=anthropic/claude-opus-5 thinking=-"],
-	["the child's depth is the parent's plus one", { depth: "1" }, "spawns=1 depth=2 entry=- model=- thinking=-"],
-	["a relative entry override reaches the child resolved", { entry: relativeOverride }, "spawns=1 depth=1 entry=override model=- thinking=-"],
-	["the frontmatter effort becomes the thinking flag", { agent: { effort: "high" }, parentModel: "anthropic/claude-opus-5" }, "spawns=1 depth=1 entry=- model=anthropic/claude-opus-5 thinking=high"],
-	["a model suffix wins over the effort key", { agent: { effort: "high", model: "openai-codex/gpt-6-astra:low" } }, "spawns=1 depth=1 entry=- model=openai-codex/gpt-6-astra:low thinking=low"],
+	["a first-generation parent spawns the child at depth 1", { parentModel: "anthropic/claude-opus-5" }, "events=subagents:started,subagents:completed spawns=1 depth=1 entry=- model=anthropic/claude-opus-5 thinking=-"],
+	["the child's depth is the parent's plus one", { depth: "1" }, "events=subagents:started,subagents:completed spawns=1 depth=2 entry=- model=- thinking=-"],
+	["a relative entry override reaches the child resolved", { entry: relativeOverride }, "events=subagents:started,subagents:completed spawns=1 depth=1 entry=override model=- thinking=-"],
+	["the frontmatter effort becomes the thinking flag", { agent: { effort: "high" }, parentModel: "anthropic/claude-opus-5" }, "events=subagents:started,subagents:completed spawns=1 depth=1 entry=- model=anthropic/claude-opus-5 thinking=high"],
+	["a model suffix wins over the effort key", { agent: { effort: "high", model: "openai-codex/gpt-6-astra:low" } }, "events=subagents:started,subagents:completed spawns=1 depth=1 entry=- model=openai-codex/gpt-6-astra:low thinking=low"],
+	["an effort of off passes no thinking flag", { agent: { effort: "off" }, parentModel: "anthropic/claude-opus-5" }, "events=subagents:started,subagents:completed spawns=1 depth=1 entry=- model=anthropic/claude-opus-5 thinking=-"],
+	["the parent's level is ignored under the frontmatter source", { agent: { effort: "high" }, parentThinking: "low" }, "events=subagents:started,subagents:completed spawns=1 depth=1 entry=- model=- thinking=high"],
+	["the parent's level wins under the parent source", { agent: { effort: "high" }, parentThinking: "low", settings: { subagentThinkingSource: "parent" } }, "events=subagents:started,subagents:completed spawns=1 depth=1 entry=- model=- thinking=low"],
 	// A non-empty systemPrompt creates the prompt tmp dir before the guard
 	// throws, so the refusal has something to clean up.
 	["at the cap the runner refuses before the spawn, cleans its prompt dir and announces nothing", { agent: { systemPrompt: "You are scout." }, depth: String(MAX_SUBAGENT_DEPTH) }, "refused=true spawns=0 prompt-tmp=unchanged events=none"],
@@ -276,12 +291,12 @@ async function launcherLine(world: SpawnWorld): Promise<string> {
 	const cwd = tempRuntime();
 	const entry = world.entry?.(root);
 	return withProcessEnv(world.depth, entry?.value, async () => {
-		const paths = await writeLauncher(root, "parent-session-id", cwd, agent({ pane: true, systemPrompt: "You are iced.", ...world.agent }), world.parentModel, undefined);
+		const paths = await writeLauncher(root, "parent-session-id", cwd, agent({ pane: true, systemPrompt: "You are iced.", ...world.agent }), world.parentModel, world.parentThinking);
 		const script = readFileSync(paths.launcherFile, "utf-8");
 		const depth = script.match(new RegExp(`^export ${PI_SUBAGENT_DEPTH_ENV}=(\\S+)$`, "m"))?.[1] ?? "-";
 		const exported = script.match(new RegExp(`^export ${PI_SUBAGENT_ENTRY_ENV}='([^']*)'$`, "m"))?.[1];
 		const unset = new RegExp(`^unset ${PI_SUBAGENT_ENTRY_ENV}$`, "m").test(script);
-		const entryLine = exported !== undefined ? aliased(exported, entry?.alias ?? {}) : unset ? "unset" : "-";
+		const entryLine = exported !== undefined && unset ? "export+unset" : exported !== undefined ? aliased(exported, entry?.alias ?? {}) : unset ? "unset" : "-";
 		const execAt = script.indexOf("\nexec ");
 		const exportsBeforeExec = execAt > 0 && !/^(export|unset) /m.test(script.slice(execAt));
 		const execLine = script.slice(execAt + 1).split("\n")[0] ?? "";
@@ -296,6 +311,8 @@ const launcherRows: Array<[string, SpawnWorld, string]> = [
 	["a relative entry override is exported resolved", { entry: relativeOverride }, "depth=1 entry=override exports-before-exec=true model=- thinking=-"],
 	["the frontmatter effort becomes the thinking flag", { agent: { effort: "high" }, parentModel: "anthropic/claude-opus-5" }, "depth=1 entry=unset exports-before-exec=true model=anthropic/claude-opus-5 thinking=high"],
 	["a model suffix wins over the effort key", { agent: { effort: "high" }, parentModel: "openai-codex/gpt-6-astra:low" }, "depth=1 entry=unset exports-before-exec=true model=openai-codex/gpt-6-astra:low thinking=low"],
+	["an effort of off passes no thinking flag", { agent: { effort: "off" }, parentModel: "anthropic/claude-opus-5" }, "depth=1 entry=unset exports-before-exec=true model=anthropic/claude-opus-5 thinking=-"],
+	["the parent's selected level wins over the effort key", { agent: { effort: "high" }, parentThinking: "low" }, "depth=1 entry=unset exports-before-exec=true model=- thinking=low"],
 ];
 
 test("what the pane launcher hands the child", async () => {
@@ -338,16 +355,21 @@ test("a resolved relative executable runs from a different delegated cwd", () =>
 		chmodSync(launcherPath, 0o755);
 		return launcherPath;
 	};
-	const ran = () => { const text = readFileSync(marker, "utf-8"); rmSync(marker, { force: true }); return text; };
+	const ran = () => {
+		if (!existsSync(marker)) return "no-marker";
+		const text = readFileSync(marker, "utf-8");
+		rmSync(marker, { force: true });
+		return text;
+	};
 
 	const invocation = getPiInvocation([], runtime({ env: { [PI_SUBAGENT_ENTRY_ENV]: relativeExecutable } }));
 	const direct = spawnSync(invocation.command, invocation.args, { cwd: delegatedCwd });
 	const directLine = `direct=${direct.error ? "error" : direct.status}/${ran()}`;
 	const viaLauncher = spawnSync(launcher("launcher.sh", invocation.command, invocation.args), [], { cwd: delegatedCwd });
-	const launcherLine = `launcher=${viaLauncher.status}/${ran()}`;
+	const viaLauncherLine = `launcher=${viaLauncher.status}/${ran()}`;
 	// Control: the relative form fails command lookup from the delegated cwd.
 	const broken = spawnSync(launcher("launcher-broken.sh", relativeExecutable, []), [], { cwd: delegatedCwd });
-	assert.equal(`${directLine} ${launcherLine} relative=${broken.status}`, "direct=0/ran launcher=0/ran relative=127");
+	assert.equal(`${directLine} ${viaLauncherLine} relative=${broken.status}`, "direct=0/ran launcher=0/ran relative=127");
 });
 
 test("PANE_LAUNCHER_VERSION is bumped when the launcher template changes", () => {
@@ -359,7 +381,8 @@ test("PANE_LAUNCHER_VERSION is bumped when the launcher template changes", () =>
 	const paneSource = readFileSync(join(import.meta.dir, "..", "extensions", "subagent", "pane.ts"), "utf-8");
 	const templateStart = paneSource.indexOf("const script = `#!/usr/bin/env bash");
 	const templateEnd = paneSource.indexOf("`;", templateStart);
-	assert.ok(templateStart > -1 && templateEnd > templateStart);
+	assert.notEqual(templateStart, -1, "launcher template start");
+	assert.ok(templateEnd > templateStart, "launcher template end");
 	const templateDigest = createHash("sha256").update(paneSource.slice(templateStart, templateEnd)).digest("hex").slice(0, 16);
 	assert.equal(`version=${PANE_LAUNCHER_VERSION} template=${templateDigest}`, "version=11 template=38837c68b7dc5b2a");
 });


### PR DESCRIPTION
Reshapes `pi-extensions/pi-agents-tmux/tests/pi-invocation.test.ts` to code-quality § Tests: thirty cases in six describe blocks (two sharing a name) become four tables, each row one line read back from the invocation, the env, the spawn or the launcher script, plus three single cases kept.

## Folded and deleted cases, with the surviving row

| Former case | Surviving row |
|---|---|
| harness-like argv[1] does NOT self-re-invoke | resolution table `a harness script as argv[1] falls back to pi on PATH`; the `not.toContain(harness)` negative is the aliased args list |
| a pi-looking basename outside the pi package does NOT self-re-invoke | `a pi-looking basename in a foreign package falls back` |
| a pi-looking basename with NO reachable package.json does NOT self-re-invoke | `a pi-looking basename with no reachable manifest falls back` |
| pi dev-mode entries under pi's own package keep self-re-invoking (three shapes in one loop) | `pi's own package name re-invokes the script`, `a bin map whose pi entry is this script re-invokes`, `a package named pi whose string bin is this script re-invokes` |
| a foreign package declaring bin.pi that points ELSEWHERE does not self-re-invoke (two shapes) | `a bin map whose pi entry is another file falls back`, `a package named pi whose string bin is another file falls back` |
| a manifest-less entry dir walks up to pi's own manifest | `a manifest-less entry dir walks up to pi's manifest` |
| an unreadable nearest manifest fails closed even under a pi ancestor | kept as its own case (skips as root or where modes are not enforced) |
| PI_SUBAGENT_ENTRY script override wins over a pi-package argv[1] | `a script override wins over pi's own argv[1] and is handed down` |
| relative PI_SUBAGENT_ENTRY resolves to an absolute path against the parent cwd | `a relative script override resolves against the parent cwd and is handed down resolved` (the alias map prints a relative path verbatim, so the row reddens on it) |
| bare-command overrides propagate to children unchanged (two asserts) | `an absolute executable override is the command and is handed down`; the no-override half is `child-entry=-` on every other row |
| PI_SUBAGENT_ENTRY executable override is used as the command itself | same row |
| relative separator-bearing executable override resolves to absolute and propagates resolved | `a relative separator-bearing executable override resolves and is handed down resolved` |
| separator-free bare-name override stays verbatim for PATH resolution | `a separator-free override stays verbatim for PATH resolution` |
| resolved relative executable actually runs from a different delegated cwd (real spawn) | kept as its own case, one packed assertion carrying the direct form, the launcher form and the exit-127 control for the relative form |
| compiled pi binary (/$bunfs argv[1]) still re-invokes execPath directly | `the compiled binary (bun's virtual argv[1]) re-invokes execPath`, with a comment that the virtual-script guard itself is only reachable inside a compiled binary |
| currentSubagentDepth parses the env var defensively (four asserts) | depth table rows `no depth var is generation zero`, `a depth is read`, `a non-number is zero`, `a negative number is zero` (each also read through the guard and through getPiInvocation) |
| assertSubagentSpawnDepth increments below the cap and refuses at it (three asserts) | `no depth var…`, `one below the cap spawns the last generation`, `at the cap the guard refuses` |
| the guard is independent of entry resolution: a valid override still refuses at cap | `a valid override does not bypass the cap` |
| getPiInvocation reports the child generation for the spawn env (two asserts) | the `invocation=` field of every depth row |
| bg runner: an inherited model runs at the frontmatter effort | runner table `the frontmatter effort becomes the thinking flag` |
| bg runner: a model suffix wins over the effort key | `a model suffix wins over the effort key` |
| bg runner: no effort anywhere passes no --thinking | `a first-generation parent spawns the child at depth 1` (thinking=-) |
| spawned child env carries the incremented PI_SUBAGENT_DEPTH | `a first-generation parent spawns the child at depth 1`; new `the child's depth is the parent's plus one` |
| child env carries the RESOLVED absolute entry when the parent had a relative override | `a relative entry override reaches the child resolved` |
| at the depth cap the runner refuses before spawning and reclaims the prompt tmp dir | `at the cap the runner refuses before the spawn, cleans its prompt dir and announces nothing` |
| launcher: an inherited model runs at the frontmatter effort (duplicate name) | launcher table `the frontmatter effort becomes the thinking flag` |
| launcher: a model suffix wins over the effort key, and no effort passes no flag | `a model suffix wins over the effort key`; thinking=- on the two env rows |
| generated launcher script exports the incremented PI_SUBAGENT_DEPTH before exec (four asserts) | `the launcher exports the next depth and unsets a stale entry before the exec` |
| PANE_LAUNCHER_VERSION is bumped when the launcher template changes | kept as its own case: it pins source text, but it is the guard on the pane-recycle rule (a template change without a bump leaves live panes on the old launcher) and deleting it fails open |
| launcher exports the RESOLVED absolute entry when the parent had a relative override | `a relative entry override is exported resolved` |

New rows with no former case, each the must-fail control of a guard that had none: `a script override that does not exist is taken as an executable path`, `a blank override is no override`, `an unparseable nearest manifest fails closed under a pi ancestor`, `a non-runtime execPath is re-invoked even with a harness argv[1]`, `node as execPath with no script falls back`; on both spawn surfaces `an effort of off passes no thinking flag` and the parent's level under each thinking source; the runner's spawning rows read the bus (`started,completed`) so the refusal row's `events=none` has its control.

Removed with a reason: a blank-depth row (parseInt of a blank is NaN and reads as zero with or without the blank check; equivalent mutant).

## Mutation

39 mutants over `pane.ts`, `runner.ts` and `settings.ts`, 39 killed, each by the row named for it. Unkillable at this seam and recorded: dropping the `!isBunVirtualScript` guard (the virtual path only exists inside a compiled binary; `fs.existsSync` is not injected through the runtime). The reviewer's own 18-mutant probe left eleven survivors; the second commit answers eight with rows or observer fields, and three are declined as inputs no shipped producer emits (case-insensitive basenames, unknown effort values past agents.ts's normalisation, a first-versus-last colon in the model id).

## Checks

- `bun test ./tests/pi-invocation.test.ts`: 7 pass. Package: 317 pass.
- `tools/guard --full`: exit 0.
- One reviewer-test round: accepted with three blockers (the launcher entry field masking an export followed by an unset, the `off` effort on both surfaces, the bus on the spawning rows), all applied in the second commit with the suggestions (the unparseable manifest, the parent level, the compiled-binary label, the real-spawn nits).

KEN-1241

https://claude.ai/code/session_01TKCoMRNssSfe4qr3ik9VDa
