### PR TITLE
test(KEN-1241): rate-limit watchdog as scripts read back one line a step

### DIFF
--- a/pi-extensions/pi-agents-tmux/tests/pi-invocation.test.ts
+++ b/pi-extensions/pi-agents-tmux/tests/pi-invocation.test.ts
@@ -161,18 +161,21 @@ test("an unreadable nearest manifest fails closed under a pi ancestor", () => {
 // The depth as read, the child generation the guard grants (or `refused`), and
 // the same through getPiInvocation, which runs the guard before resolving.
 function depthLine(env: NodeJS.ProcessEnv): string {
+	// Only the recursion guard's own error reads as `refused`; anything else
+	// prints whole.
+	const refusedOr = (error: unknown) => (/recursion guard/.test(String(error)) ? "refused" : `threw:${String(error)}`);
 	const guard = () => {
 		try {
 			return String(assertSubagentSpawnDepth(env));
-		} catch {
-			return "refused";
+		} catch (error) {
+			return refusedOr(error);
 		}
 	};
 	const viaInvocation = () => {
 		try {
 			return String(getPiInvocation([], runtime({ env })).childDepth);
-		} catch {
-			return "refused";
+		} catch (error) {
+			return refusedOr(error);
 		}
 	};
 	return `current=${currentSubagentDepth(env)} child=${guard()} invocation=${viaInvocation()}`;
@@ -293,26 +296,29 @@ async function launcherLine(world: SpawnWorld): Promise<string> {
 	return withProcessEnv(world.depth, entry?.value, async () => {
 		const paths = await writeLauncher(root, "parent-session-id", cwd, agent({ pane: true, systemPrompt: "You are iced.", ...world.agent }), world.parentModel, world.parentThinking);
 		const script = readFileSync(paths.launcherFile, "utf-8");
-		const depth = script.match(new RegExp(`^export ${PI_SUBAGENT_DEPTH_ENV}=(\\S+)$`, "m"))?.[1] ?? "-";
-		const exported = script.match(new RegExp(`^export ${PI_SUBAGENT_ENTRY_ENV}='([^']*)'$`, "m"))?.[1];
-		const unset = new RegExp(`^unset ${PI_SUBAGENT_ENTRY_ENV}$`, "m").test(script);
-		const entryLine = exported !== undefined && unset ? "export+unset" : exported !== undefined ? aliased(exported, entry?.alias ?? {}) : unset ? "unset" : "-";
+		// The environment at `exec` is the assignments before it: exactly one
+		// depth export and exactly one entry export or unset, or the counts print.
 		const execAt = script.indexOf("\nexec ");
-		const exportsBeforeExec = execAt > 0 && !/^(export|unset) /m.test(script.slice(execAt));
+		const before = execAt > 0 ? script.slice(0, execAt).split("\n") : [];
+		const depthWrites = before.map((line) => line.match(new RegExp(`^export ${PI_SUBAGENT_DEPTH_ENV}=(\\S+)$`))?.[1]).filter((v): v is string => v !== undefined);
+		const entryWrites = before.map((line) => line.match(new RegExp(`^export ${PI_SUBAGENT_ENTRY_ENV}='([^']*)'$`))?.[1] ?? (new RegExp(`^unset ${PI_SUBAGENT_ENTRY_ENV}$`).test(line) ? "unset" : undefined)).filter((v): v is string => v !== undefined);
+		const depth = depthWrites.length === 1 ? depthWrites[0] : `${depthWrites.length}-writes`;
+		const entryLine = entryWrites.length === 1 ? (entryWrites[0] === "unset" ? "unset" : aliased(entryWrites[0], entry?.alias ?? {})) : `${entryWrites.length}-writes`;
+		const afterExec = /^(export|unset) /m.test(script.slice(execAt + 1));
 		const execLine = script.slice(execAt + 1).split("\n")[0] ?? "";
 		const quoted = (name: string) => execLine.match(new RegExp(`'${name}' '([^']*)'`))?.[1] ?? "-";
-		return `depth=${depth} entry=${entryLine} exports-before-exec=${exportsBeforeExec} model=${quoted("--model")} thinking=${quoted("--thinking")}`;
+		return `depth=${depth} entry=${entryLine} exports-after-exec=${afterExec} model=${quoted("--model")} thinking=${quoted("--thinking")}`;
 	});
 }
 
 // label | the parent's env, agent and model | expect the launcher line
 const launcherRows: Array<[string, SpawnWorld, string]> = [
-	["the launcher exports the next depth and unsets a stale entry before the exec", { depth: "1" }, "depth=2 entry=unset exports-before-exec=true model=- thinking=-"],
-	["a relative entry override is exported resolved", { entry: relativeOverride }, "depth=1 entry=override exports-before-exec=true model=- thinking=-"],
-	["the frontmatter effort becomes the thinking flag", { agent: { effort: "high" }, parentModel: "anthropic/claude-opus-5" }, "depth=1 entry=unset exports-before-exec=true model=anthropic/claude-opus-5 thinking=high"],
-	["a model suffix wins over the effort key", { agent: { effort: "high" }, parentModel: "openai-codex/gpt-6-astra:low" }, "depth=1 entry=unset exports-before-exec=true model=openai-codex/gpt-6-astra:low thinking=low"],
-	["an effort of off passes no thinking flag", { agent: { effort: "off" }, parentModel: "anthropic/claude-opus-5" }, "depth=1 entry=unset exports-before-exec=true model=anthropic/claude-opus-5 thinking=-"],
-	["the parent's selected level wins over the effort key", { agent: { effort: "high" }, parentThinking: "low" }, "depth=1 entry=unset exports-before-exec=true model=- thinking=low"],
+	["the launcher exports the next depth and unsets a stale entry before the exec", { depth: "1" }, "depth=2 entry=unset exports-after-exec=false model=- thinking=-"],
+	["a relative entry override is exported resolved", { entry: relativeOverride }, "depth=1 entry=override exports-after-exec=false model=- thinking=-"],
+	["the frontmatter effort becomes the thinking flag", { agent: { effort: "high" }, parentModel: "anthropic/claude-opus-5" }, "depth=1 entry=unset exports-after-exec=false model=anthropic/claude-opus-5 thinking=high"],
+	["a model suffix wins over the effort key", { agent: { effort: "high" }, parentModel: "openai-codex/gpt-6-astra:low" }, "depth=1 entry=unset exports-after-exec=false model=openai-codex/gpt-6-astra:low thinking=low"],
+	["an effort of off passes no thinking flag", { agent: { effort: "off" }, parentModel: "anthropic/claude-opus-5" }, "depth=1 entry=unset exports-after-exec=false model=anthropic/claude-opus-5 thinking=-"],
+	["the parent's selected level wins over the effort key", { agent: { effort: "high" }, parentThinking: "low" }, "depth=1 entry=unset exports-after-exec=false model=- thinking=low"],
 ];
 
 test("what the pane launcher hands the child", async () => {

--- a/pi-extensions/pi-agents-tmux/tests/rate-limit-watchdog.test.ts
+++ b/pi-extensions/pi-agents-tmux/tests/rate-limit-watchdog.test.ts
@@ -1,498 +1,278 @@
-// Rate-limit retry-with-backoff watchdog for subagent panes.
-// The integration test injects deterministic clock + scheduler so the
-// per-pane attempt counter, retry-at scheduling, steer dispatch, and
-// exhaustion fallback all surface synchronously.
+// The pane rate-limit watchdog as a state machine on an injected clock and
+// scheduler: each row is a script of message_end events, fires and cancels on
+// one pane, read back after every step as one line.
 
-import { describe, expect, test } from "bun:test";
-
-import {
-	createSubagentRateLimitWatchdog,
-	type RateLimitOutcome,
-	type SubagentRateLimitWatchdogDeps,
-} from "../extensions/subagent/rate-limit-watchdog.js";
-import { RATE_LIMIT_RESET_MARGIN_MS } from "../extensions/subagent/rate-limit-decision.js";
-import { normalizeQuotaSnapshot } from "../extensions/subagent/rate-limit-quota-normalize.js";
+import assert from "node:assert/strict";
+import test from "node:test";
 import { buildSubagentActivity } from "../extensions/subagent/activity.js";
+import { RATE_LIMIT_RESET_MARGIN_MS, RATE_LIMIT_STEER_MESSAGE } from "../extensions/subagent/rate-limit-decision.js";
+import { normalizeQuotaSnapshot } from "../extensions/subagent/rate-limit-quota-normalize.js";
+import { createSubagentRateLimitWatchdog, type RateLimitOutcome, type SubagentRateLimitWatchdog, type SubagentRateLimitWatchdogDeps } from "../extensions/subagent/rate-limit-watchdog.js";
 
-const CANONICAL_RATE_LIMIT_MESSAGE_END = {
+const RATE_LIMITED = {
 	message: {
 		api: "claude-bridge",
-		content: [
-			{
-				text: "API Error: Server is temporarily limiting requests (not your usage limit) · Rate limited",
-				type: "text",
-			},
-		],
-		errorMessage:
-			"Claude Code returned an error result: API Error: Server is temporarily limiting requests (not your usage limit) · Rate limited",
+		content: [{ text: "API Error: Server is temporarily limiting requests (not your usage limit) · Rate limited", type: "text" }],
+		errorMessage: "Claude Code returned an error result: API Error: Server is temporarily limiting requests (not your usage limit) · Rate limited",
 		role: "assistant",
 		stopReason: "error",
 	},
 	type: "message_end",
 };
-
-const HEALTHY_MESSAGE_END = {
-	message: {
-		content: [{ text: "Done.", type: "text" }],
-		role: "assistant",
-		stopReason: "stop",
-	},
+const HEALTHY = { message: { content: [{ text: "Done.", type: "text" }], role: "assistant", stopReason: "stop" }, type: "message_end" };
+const SESSION_LIMIT = {
+	message: { api: "claude-bridge", errorMessage: "Claude Code returned an error result: You've hit your session limit · resets 7:50pm (America/Los_Angeles)", role: "assistant", stopReason: "error" },
 	type: "message_end",
 };
-
-const CLAUDE_SESSION_LIMIT_MESSAGE_END = {
-	message: {
-		api: "claude-bridge",
-		errorMessage:
-			"Claude Code returned an error result: You've hit your session limit · resets 7:50pm (America/Los_Angeles)",
-		role: "assistant",
-		stopReason: "error",
-	},
-	type: "message_end",
-};
+const STEER_ECHO = { message: { content: [{ text: RATE_LIMIT_STEER_MESSAGE, type: "text" }], role: "user" }, type: "message_end" };
+const NO_STOP_REASON = { message: { content: [{ text: "Still working.", type: "text" }], role: "assistant" }, type: "message_end" };
+const ERROR_WITHOUT_PROSE = { message: { content: [{ text: "Tool output attached below.", type: "text" }], errorMessage: "Tool execution failed", role: "assistant", stopReason: "error" }, type: "message_end" };
 
 const SESSION_LIMIT_NOW = Date.UTC(2026, 4, 31, 1, 54, 56);
 const SESSION_LIMIT_RESET_AT = Date.UTC(2026, 4, 31, 2, 50, 0) + RATE_LIMIT_RESET_MARGIN_MS;
-const STRUCTURED_USAGE_RESET_AT = Date.UTC(2026, 4, 31, 3, 30, 0) + RATE_LIMIT_RESET_MARGIN_MS;
+const USAGE_RESET_AT = Date.UTC(2026, 4, 31, 3, 30, 0) + RATE_LIMIT_RESET_MARGIN_MS;
+const claudeUsage = () => normalizeQuotaSnapshot("claude", "usage-endpoint", { five_hour: { utilization: 1, resets_at: new Date(USAGE_RESET_AT - RATE_LIMIT_RESET_MARGIN_MS).toISOString() } }, SESSION_LIMIT_NOW);
 
-const USER_STEER_ECHO_MESSAGE_END = {
-	message: {
-		content: [{ text: "API rate limit was detected. Try to continue from where you left off.", type: "text" }],
-		role: "user",
-	},
-	type: "message_end",
-};
+type Timer = { cancelled: boolean; delayMs: number; fn: () => void };
 
-const ASSISTANT_NO_STOP_REASON_MESSAGE_END = {
-	message: {
-		content: [{ text: "Still working.", type: "text" }],
-		role: "assistant",
-	},
-	type: "message_end",
-};
-
-const ASSISTANT_ERROR_NO_RATE_LIMIT_PROSE_MESSAGE_END = {
-	message: {
-		content: [{ text: "Tool output attached below.", type: "text" }],
-		errorMessage: "Tool execution failed",
-		role: "assistant",
-		stopReason: "error",
-	},
-	type: "message_end",
-};
-
-function makeDeps(overrides: Partial<SubagentRateLimitWatchdogDeps> = {}): {
-	deps: SubagentRateLimitWatchdogDeps;
-	scheduled: Array<{ delayMs: number; fn: () => void; cancelled: boolean }>;
-	steerCalls: string[];
-	activity: Array<{ event: string; payload: Record<string, unknown> }>;
-	exhausted: Array<{ paneId: string; attempt: number; reason: string }>;
-	warnings: string[];
-	clockMs: { value: number };
-} {
-	const scheduled: Array<{ delayMs: number; fn: () => void; cancelled: boolean }> = [];
-	const steerCalls: string[] = [];
+// The injected world: a clock, a scheduler that records timers, and sinks for
+// steers, activity, exhaustion callbacks, warnings and the persisted mirror.
+function world(overrides: Partial<SubagentRateLimitWatchdogDeps> = {}) {
+	const timers: Timer[] = [];
+	const steers: string[] = [];
 	const activity: Array<{ event: string; payload: Record<string, unknown> }> = [];
-	const exhausted: Array<{ paneId: string; attempt: number; reason: string }> = [];
+	const exhausted: string[] = [];
 	const warnings: string[] = [];
-	const clockMs = { value: 0 };
+	const persisted: Array<number | null> = [];
+	const clock = { value: 0 };
 	const deps: SubagentRateLimitWatchdogDeps = {
 		backoffLadderSec: () => [1, 2, 4],
 		emitActivity: (event, payload) => activity.push({ event, payload }),
 		isEnabled: () => true,
 		logWarn: (message) => warnings.push(message),
 		maxAttempts: () => 3,
-		now: () => clockMs.value,
-		onExhausted: (paneId, attempt, reason) => exhausted.push({ attempt, paneId, reason }),
+		now: () => clock.value,
+		onExhausted: (paneId, attempt, reason) => exhausted.push(`${paneId}#${attempt}:${reason}`),
+		persistRetryState: (_paneId, at) => persisted.push(at),
 		scheduleAfter: (delayMs, fn) => {
 			const entry = { cancelled: false, delayMs, fn };
-			scheduled.push(entry);
+			timers.push(entry);
 			return { cancel: () => { entry.cancelled = true; } };
 		},
-		sendUserMessage: (message) => steerCalls.push(message),
+		sendUserMessage: (message) => steers.push(message),
 		...overrides,
 	};
-	return { activity, clockMs, deps, exhausted, scheduled, steerCalls, warnings };
+	return { activity, clock, deps, exhausted, persisted, seen: { activity: 0, warnings: 0 }, steers, timers, warnings, watchdog: createSubagentRateLimitWatchdog(deps) };
+}
+type World = ReturnType<typeof world>;
+
+// Each warning by the failure it names; an unknown one prints whole.
+function warnTag(line: string): string {
+	for (const [needle, tag] of [["retry-state persist failed", "persist-failed"], ["steer dispatch failed", "steer-failed"], ["activity emit failed", "emit-failed"], ["usage endpoint lookup failed", "usage-failed"], ["onExhausted handler failed", "exhausted-failed"]] as const) {
+		if (line.includes(needle)) return tag;
+	}
+	return JSON.stringify(line);
 }
 
-describe("subagent rate-limit watchdog (kendex#108)", () => {
-	test("rate-limit skipped broker event maps to noisy debug activity", () => {
-		expect(buildSubagentActivity("subagents:rate_limit_skipped", {
-			agent: "rust",
-			paneId: "%41",
-			reason: "no-prose",
-			taskId: "task-1",
-		})).toMatchObject({
-			details: {
-				event_name: "subagents:rate_limit_skipped",
-				pane_id: "%41",
-				reason: "no-prose",
-			},
-			importance: "noisy",
-			refs: { agent: "rust", task_id: "task-1" },
-			severity: "debug",
-			source: "pi-agents",
-			summary: "rust rate-limit skipped: no-prose",
-			type: "agent.rate_limit_skipped",
-		});
-	});
+function activityTag(entry: { event: string; payload: Record<string, unknown> }): string {
+	const p = entry.payload;
+	const name = entry.event.replace(/^subagents:rate_limit(ed|_)?/, "") || "limited";
+	if (name === "skipped") return `skipped(${p.reason})`;
+	if (name === "limited" || name === "retry") return `${name}(a=${p.attempt},next=${p.next_retry_at},src=${p.reset_source ?? "-"}${p.degraded_reset_source ? ",degraded" : ""})`;
+	return `${name}(a=${p.attempt})`;
+}
 
-	for (const { event, reason } of [
-		{ event: USER_STEER_ECHO_MESSAGE_END, reason: "non-assistant" },
-		{ event: ASSISTANT_NO_STOP_REASON_MESSAGE_END, reason: "no-stopreason" },
-		{ event: HEALTHY_MESSAGE_END, reason: "stopreason-mismatch" },
-		{ event: ASSISTANT_ERROR_NO_RATE_LIMIT_PROSE_MESSAGE_END, reason: "no-prose" },
-	] as const) {
-		test(`classifier rejection emits subagents:rate_limit_skipped (${reason})`, () => {
-			const ctx = makeDeps();
-			const watchdog = createSubagentRateLimitWatchdog(ctx.deps);
-			const outcome = watchdog.onMessageEnd(event, "rust", "rust", "task-1");
-			expect(outcome).toEqual({ kind: "not-rate-limited", reason });
-			expect(ctx.activity).toHaveLength(1);
-			expect(ctx.activity[0]).toEqual({
-				event: "subagents:rate_limit_skipped",
-				payload: {
-					agent: "rust",
-					paneId: "rust",
-					reason,
-					taskId: "task-1",
-				},
-			});
-		});
+function outcomeTag(outcome: RateLimitOutcome): string {
+	switch (outcome.kind) {
+		case "scheduled-retry": return `retry#${outcome.attempt}@${outcome.at}:${outcome.resetSource ?? "-"}${outcome.degradedResetSource ? "(degraded)" : ""}`;
+		case "exhausted": return `exhausted#${outcome.attempt}`;
+		case "resolved": return `resolved#${outcome.previousAttempt}`;
+		case "not-rate-limited": return `skip:${outcome.reason}`;
+		case "skipped-disabled": return "disabled";
 	}
+}
 
-	test("retry-state persistence mirrors every transition: schedule, fire, cancel", () => {
-		const persisted: Array<{ paneId: string; at: number | null }> = [];
-		const ctx = makeDeps({ persistRetryState: (paneId, at) => persisted.push({ at, paneId }) });
-		const watchdog = createSubagentRateLimitWatchdog(ctx.deps);
-		ctx.clockMs.value = 1_000;
-		watchdog.onMessageEnd(CANONICAL_RATE_LIMIT_MESSAGE_END, "rust", "rust", "task-1");
-		expect(persisted).toEqual([{ at: 2_000, paneId: "rust" }]);
-		// Firing the retry clears the mirror.
-		ctx.scheduled[0]!.fn();
-		expect(persisted[1]).toEqual({ at: null, paneId: "rust" });
-		// A fresh schedule then an explicit cancel clears it again.
-		watchdog.onMessageEnd(CANONICAL_RATE_LIMIT_MESSAGE_END, "rust", "rust", "task-1");
-		watchdog.cancel("rust");
-		expect(persisted[persisted.length - 1]).toEqual({ at: null, paneId: "rust" });
-	});
+// One step's line: what the step returned, then the pane read back (awaiting,
+// timers armed/cancelled and the last delay, steers sent and whether they were
+// the canonical text, the last persisted mirror value, exhaustion callbacks),
+// then the activity and warnings the step added.
+type Step = { at?: number; do: (w: World) => string };
+function runScript(w: World, steps: Step[]): string {
+	const lines: string[] = [];
+	for (const step of steps) {
+		if (step.at !== undefined) w.clock.value = step.at;
+		const head = step.do(w);
+		const added = w.activity.slice(w.seen.activity).map(activityTag);
+		const warned = w.warnings.slice(w.seen.warnings).map(warnTag);
+		w.seen.activity = w.activity.length;
+		w.seen.warnings = w.warnings.length;
+		const steer = w.steers.length ? (w.steers.every((s) => s === RATE_LIMIT_STEER_MESSAGE) ? `${w.steers.length}/canonical` : `${w.steers.length}/other`) : "0";
+		const last = w.timers[w.timers.length - 1];
+		lines.push(`${head} await=${w.watchdog.isAwaitingRetry("rust")} timers=${w.timers.length}/${w.timers.filter((t) => t.cancelled).length}${last ? ` delay=${last.delayMs}` : ""} steers=${steer} persist=${w.persisted.length ? w.persisted[w.persisted.length - 1] : "-"} exhausted=${w.exhausted.length ? w.exhausted.join(";") : "-"} +[${added.join(",")}]${warned.length ? ` warn=[${warned.join(",")}]` : ""}`);
+	}
+	return lines.join("\n");
+}
 
-	test("a throwing persist hook is contained and warned, never fatal", () => {
-		const ctx = makeDeps({ persistRetryState: () => { throw new Error("disk gone"); } });
-		const watchdog = createSubagentRateLimitWatchdog(ctx.deps);
-		ctx.clockMs.value = 1_000;
-		const outcome = watchdog.onMessageEnd(CANONICAL_RATE_LIMIT_MESSAGE_END, "rust", "rust", "task-1");
-		expect(outcome.kind).toBe("scheduled-retry");
-		expect(ctx.warnings.some((w) => w.includes("retry-state persist failed"))).toBe(true);
-	});
+const msg = (event: unknown) => (w: World) => outcomeTag(w.watchdog.onMessageEnd(event, "rust", "rust", "task-1"));
+const fire = (w: World) => `fire=${w.watchdog.fireRetryNow("rust")}`;
+const cancel = (w: World) => `cancel=${w.watchdog.cancel("rust")}`;
+const fireTimer = (index: number) => (w: World) => { w.timers[index]!.fn(); return `timer[${index}]-fired`; };
 
-	test("first rate-limit detection schedules a retry and emits agent.rate_limited", () => {
-		const ctx = makeDeps();
-		const watchdog = createSubagentRateLimitWatchdog(ctx.deps);
-		ctx.clockMs.value = 1_000;
+const ARMED_1 = "retry#1@2000:backoff-only(degraded) await=true timers=1/0 delay=1000 steers=0 persist=2000 exhausted=- +[limited(a=1,next=2000,src=backoff-only,degraded)]";
 
-		const outcome = watchdog.onMessageEnd(CANONICAL_RATE_LIMIT_MESSAGE_END, "rust", "rust", "task-1");
-		expect(outcome.kind).toBe("scheduled-retry");
-		if (outcome.kind !== "scheduled-retry") throw new Error("expected scheduled-retry");
-		expect(outcome.attempt).toBe(1);
-		// First ladder step is 1s.
-		expect(outcome.at).toBe(1_000 + 1_000);
-		expect(watchdog.isAwaitingRetry("rust")).toBe(true);
-		expect(ctx.scheduled).toHaveLength(1);
-		expect(ctx.scheduled[0]!.delayMs).toBe(1_000);
-		expect(ctx.activity[0]?.event).toBe("subagents:rate_limited");
-		expect(ctx.activity[0]?.payload.attempt).toBe(1);
-		expect(ctx.activity[0]?.payload.next_retry_at).toBe(2_000);
-	});
+// label | deps overrides | the script | expect one line per step
+const rows: Array<[string, Partial<SubagentRateLimitWatchdogDeps>, Step[], string]> = [
+	["the first detection arms the first ladder step and mirrors the retry time", {}, [{ at: 1_000, do: msg(RATE_LIMITED) }], ARMED_1],
+	["the fired steer is the canonical text and clears the mirror", {}, [{ at: 1_000, do: msg(RATE_LIMITED) }, { do: fire }], [
+		ARMED_1,
+		"fire=true await=false timers=1/0 delay=1000 steers=1/canonical persist=null exhausted=- +[]",
+	].join("\n")],
+	["a second detection after the steer climbs the ladder", {}, [{ at: 1_000, do: msg(RATE_LIMITED) }, { do: fire }, { at: 5_000, do: msg(RATE_LIMITED) }], [
+		ARMED_1,
+		"fire=true await=false timers=1/0 delay=1000 steers=1/canonical persist=null exhausted=- +[]",
+		"retry#2@7000:backoff-only(degraded) await=true timers=2/0 delay=2000 steers=1/canonical persist=7000 exhausted=- +[retry(a=2,next=7000,src=backoff-only,degraded)]",
+	].join("\n")],
+	["a detection while a retry is pending re-arms on the latest decision", {}, [{ at: 1_000, do: msg(RATE_LIMITED) }, { at: 1_500, do: msg(RATE_LIMITED) }], [
+		ARMED_1,
+		"retry#2@3500:backoff-only(degraded) await=true timers=2/1 delay=2000 steers=0 persist=3500 exhausted=- +[retry(a=2,next=3500,src=backoff-only,degraded)]",
+	].join("\n")],
+	["the fourth detection exhausts the three attempts and calls the handler", {}, [
+		{ at: 1_000, do: msg(RATE_LIMITED) }, { do: fire }, { do: msg(RATE_LIMITED) }, { do: fire }, { do: msg(RATE_LIMITED) }, { do: fire }, { do: msg(RATE_LIMITED) },
+	], [
+		ARMED_1,
+		"fire=true await=false timers=1/0 delay=1000 steers=1/canonical persist=null exhausted=- +[]",
+		"retry#2@3000:backoff-only(degraded) await=true timers=2/0 delay=2000 steers=1/canonical persist=3000 exhausted=- +[retry(a=2,next=3000,src=backoff-only,degraded)]",
+		"fire=true await=false timers=2/0 delay=2000 steers=2/canonical persist=null exhausted=- +[]",
+		"retry#3@5000:backoff-only(degraded) await=true timers=3/0 delay=4000 steers=2/canonical persist=5000 exhausted=- +[retry(a=3,next=5000,src=backoff-only,degraded)]",
+		"fire=true await=false timers=3/0 delay=4000 steers=3/canonical persist=null exhausted=- +[]",
+		"exhausted#3 await=false timers=3/0 delay=4000 steers=3/canonical persist=null exhausted=rust#3:rate-limit retries exhausted after 3 attempts +[exhausted(a=3)]",
+	].join("\n")],
+	["a healthy turn after the steer resolves and resets the ladder", {}, [{ at: 1_000, do: msg(RATE_LIMITED) }, { do: fire }, { do: msg(HEALTHY) }, { do: msg(RATE_LIMITED) }], [
+		ARMED_1,
+		"fire=true await=false timers=1/0 delay=1000 steers=1/canonical persist=null exhausted=- +[]",
+		"resolved#1 await=false timers=1/0 delay=1000 steers=1/canonical persist=null exhausted=- +[skipped(stopreason-mismatch),resolved(a=1)]",
+		"retry#1@2000:backoff-only(degraded) await=true timers=2/0 delay=1000 steers=1/canonical persist=2000 exhausted=- +[limited(a=1,next=2000,src=backoff-only,degraded)]",
+	].join("\n")],
+	["a healthy turn before the steer cancels the timer and resolves", {}, [{ at: 1_000, do: msg(RATE_LIMITED) }, { do: msg(HEALTHY) }, { do: fire }], [
+		ARMED_1,
+		"resolved#1 await=false timers=1/1 delay=1000 steers=0 persist=null exhausted=- +[skipped(stopreason-mismatch),resolved(a=1)]",
+		"fire=false await=false timers=1/1 delay=1000 steers=0 persist=null exhausted=- +[]",
+	].join("\n")],
+	["the user-role echo of the steer neither resolves nor resets", {}, [{ at: 1_000, do: msg(RATE_LIMITED) }, { do: fire }, { do: msg(STEER_ECHO) }, { do: msg(RATE_LIMITED) }], [
+		ARMED_1,
+		"fire=true await=false timers=1/0 delay=1000 steers=1/canonical persist=null exhausted=- +[]",
+		"skip:non-assistant await=false timers=1/0 delay=1000 steers=1/canonical persist=null exhausted=- +[skipped(non-assistant)]",
+		"retry#2@3000:backoff-only(degraded) await=true timers=2/0 delay=2000 steers=1/canonical persist=3000 exhausted=- +[retry(a=2,next=3000,src=backoff-only,degraded)]",
+	].join("\n")],
+	["a healthy turn with nothing pending is only skipped", {}, [{ do: msg(HEALTHY) }], "skip:stopreason-mismatch await=false timers=0/0 steers=0 persist=- exhausted=- +[skipped(stopreason-mismatch)]"],
+	["an assistant turn without a stop reason after the steer does not resolve", {}, [{ at: 1_000, do: msg(RATE_LIMITED) }, { do: fire }, { do: msg(NO_STOP_REASON) }, { do: msg(RATE_LIMITED) }], [
+		ARMED_1,
+		"fire=true await=false timers=1/0 delay=1000 steers=1/canonical persist=null exhausted=- +[]",
+		"skip:no-stopreason await=false timers=1/0 delay=1000 steers=1/canonical persist=null exhausted=- +[skipped(no-stopreason)]",
+		"retry#2@3000:backoff-only(degraded) await=true timers=2/0 delay=2000 steers=1/canonical persist=3000 exhausted=- +[retry(a=2,next=3000,src=backoff-only,degraded)]",
+	].join("\n")],
+	["an error turn without rate-limit prose after the steer does not resolve", {}, [{ at: 1_000, do: msg(RATE_LIMITED) }, { do: fire }, { do: msg(ERROR_WITHOUT_PROSE) }, { do: msg(RATE_LIMITED) }], [
+		ARMED_1,
+		"fire=true await=false timers=1/0 delay=1000 steers=1/canonical persist=null exhausted=- +[]",
+		"skip:no-prose await=false timers=1/0 delay=1000 steers=1/canonical persist=null exhausted=- +[skipped(no-prose)]",
+		"retry#2@3000:backoff-only(degraded) await=true timers=2/0 delay=2000 steers=1/canonical persist=3000 exhausted=- +[retry(a=2,next=3000,src=backoff-only,degraded)]",
+	].join("\n")],
+	["an assistant turn without a stop reason is skipped", {}, [{ do: msg(NO_STOP_REASON) }], "skip:no-stopreason await=false timers=0/0 steers=0 persist=- exhausted=- +[skipped(no-stopreason)]"],
+	["an error turn without rate-limit prose is skipped", {}, [{ do: msg(ERROR_WITHOUT_PROSE) }], "skip:no-prose await=false timers=0/0 steers=0 persist=- exhausted=- +[skipped(no-prose)]"],
+	["a disabled watchdog does nothing", { isEnabled: () => false }, [{ at: 1_000, do: msg(RATE_LIMITED) }], "disabled await=false timers=0/0 steers=0 persist=- exhausted=- +[]"],
+	["cancel clears the pending retry, the mirror and the ladder", {}, [{ at: 1_000, do: msg(RATE_LIMITED) }, { do: cancel }, { do: cancel }, { do: msg(RATE_LIMITED) }], [
+		ARMED_1,
+		"cancel=true await=false timers=1/1 delay=1000 steers=0 persist=null exhausted=- +[]",
+		"cancel=false await=false timers=1/1 delay=1000 steers=0 persist=null exhausted=- +[]",
+		"retry#1@2000:backoff-only(degraded) await=true timers=2/1 delay=1000 steers=0 persist=2000 exhausted=- +[limited(a=1,next=2000,src=backoff-only,degraded)]",
+	].join("\n")],
+	["a stale timer firing after a re-arm does not steer", {}, [{ at: 1_000, do: msg(RATE_LIMITED) }, { at: 1_500, do: msg(RATE_LIMITED) }, { do: fireTimer(0) }], [
+		ARMED_1,
+		"retry#2@3500:backoff-only(degraded) await=true timers=2/1 delay=2000 steers=0 persist=3500 exhausted=- +[retry(a=2,next=3500,src=backoff-only,degraded)]",
+		"timer[0]-fired await=true timers=2/1 delay=2000 steers=0 persist=3500 exhausted=- +[]",
+	].join("\n")],
+	["a throwing persist hook is warned and the retry still arms", { persistRetryState: () => { throw new Error("disk gone"); } }, [{ at: 1_000, do: msg(RATE_LIMITED) }],
+		"retry#1@2000:backoff-only(degraded) await=true timers=1/0 delay=1000 steers=0 persist=- exhausted=- +[limited(a=1,next=2000,src=backoff-only,degraded)] warn=[persist-failed]"],
+	["a throwing steer is warned, not thrown", { sendUserMessage: () => { throw new Error("bridge socket gone"); } }, [{ at: 1_000, do: msg(RATE_LIMITED) }, { do: fire }], [
+		ARMED_1,
+		"fire=true await=false timers=1/0 delay=1000 steers=0 persist=null exhausted=- +[] warn=[steer-failed]",
+	].join("\n")],
+	["a throwing activity sink is warned, not thrown", { emitActivity: () => { throw new Error("broker offline"); } }, [{ at: 1_000, do: msg(RATE_LIMITED) }],
+		"retry#1@2000:backoff-only(degraded) await=true timers=1/0 delay=1000 steers=0 persist=2000 exhausted=- +[] warn=[emit-failed]"],
+	["a throwing exhaustion handler is warned, not thrown", { maxAttempts: () => 1, onExhausted: () => { throw new Error("outbox gone"); } }, [{ at: 1_000, do: msg(RATE_LIMITED) }, { do: fire }, { do: msg(RATE_LIMITED) }], [
+		ARMED_1,
+		"fire=true await=false timers=1/0 delay=1000 steers=1/canonical persist=null exhausted=- +[]",
+		"exhausted#1 await=false timers=1/0 delay=1000 steers=1/canonical persist=null exhausted=- +[exhausted(a=1)] warn=[exhausted-failed]",
+	].join("\n")],
+	["session-limit prose with no usage source schedules on the prose reset, degraded", { getUsageSnapshot: () => null }, [{ at: SESSION_LIMIT_NOW, do: msg(SESSION_LIMIT) }],
+		`retry#1@${SESSION_LIMIT_RESET_AT}:prose-fallback(degraded) await=true timers=1/0 delay=${SESSION_LIMIT_RESET_AT - SESSION_LIMIT_NOW} steers=0 persist=${SESSION_LIMIT_RESET_AT} exhausted=- +[limited(a=1,next=${SESSION_LIMIT_RESET_AT},src=prose-fallback,degraded)]`],
+	["a usage snapshot wins over the prose reset", { getUsageSnapshot: () => claudeUsage() }, [{ at: SESSION_LIMIT_NOW, do: msg(SESSION_LIMIT) }],
+		`retry#1@${USAGE_RESET_AT}:usage-endpoint await=true timers=1/0 delay=${USAGE_RESET_AT - SESSION_LIMIT_NOW} steers=0 persist=${USAGE_RESET_AT} exhausted=- +[limited(a=1,next=${USAGE_RESET_AT},src=usage-endpoint)]`],
+	["a Codex window carrying only a reset time still schedules on it", {
+		getUsageSnapshot: () => normalizeQuotaSnapshot("codex", "usage-endpoint", { rate_limit: { primary_window: { reset_after_seconds: (USAGE_RESET_AT - RATE_LIMIT_RESET_MARGIN_MS - SESSION_LIMIT_NOW) / 1000 } } }, SESSION_LIMIT_NOW),
+	}, [{ at: SESSION_LIMIT_NOW, do: msg(SESSION_LIMIT) }],
+		`retry#1@${USAGE_RESET_AT}:usage-endpoint await=true timers=1/0 delay=${USAGE_RESET_AT - SESSION_LIMIT_NOW} steers=0 persist=${USAGE_RESET_AT} exhausted=- +[limited(a=1,next=${USAGE_RESET_AT},src=usage-endpoint)]`],
+	["a failing usage source is warned with its secret redacted and the prose reset stands", {
+		getUsageSnapshot: () => ({ provider: "claude", reason: "http-401 bearer sk-ant-oauth-secret-token-warning-123456789", resetSource: "usage-endpoint", source: "quota-source-error", status: 401 }),
+	}, [{ at: SESSION_LIMIT_NOW, do: msg(SESSION_LIMIT) }, { do: (w) => `redacted=${!w.warnings.some((line) => line.includes("secret-token")) && w.warnings.some((line) => line.includes("http-401"))}` }], [
+		`retry#1@${SESSION_LIMIT_RESET_AT}:prose-fallback(degraded) await=true timers=1/0 delay=${SESSION_LIMIT_RESET_AT - SESSION_LIMIT_NOW} steers=0 persist=${SESSION_LIMIT_RESET_AT} exhausted=- +[limited(a=1,next=${SESSION_LIMIT_RESET_AT},src=prose-fallback,degraded)] warn=[usage-failed]`,
+		`redacted=true await=true timers=1/0 delay=${SESSION_LIMIT_RESET_AT - SESSION_LIMIT_NOW} steers=0 persist=${SESSION_LIMIT_RESET_AT} exhausted=- +[]`,
+	].join("\n")],
+];
 
-	test("Claude session-limit prose schedules as degraded fallback when usage source is unavailable", () => {
-		const ctx = makeDeps();
-		const watchdog = createSubagentRateLimitWatchdog(ctx.deps);
-		ctx.clockMs.value = SESSION_LIMIT_NOW;
+test("the pane rate-limit watchdog", () => {
+	for (const [label, overrides, steps, expect] of rows) {
+		assert.equal(runScript(world(overrides), steps), expect, label);
+	}
+});
 
-		const outcome = watchdog.onMessageEnd(CLAUDE_SESSION_LIMIT_MESSAGE_END, "rust", "rust", "task-1");
-		expect(outcome.kind).toBe("scheduled-retry");
-		if (outcome.kind !== "scheduled-retry") throw new Error("expected scheduled-retry");
-		expect(outcome.attempt).toBe(1);
-		expect(outcome.at).toBe(SESSION_LIMIT_RESET_AT);
-		expect(ctx.scheduled).toHaveLength(1);
-		expect(ctx.scheduled[0]!.delayMs).toBe(SESSION_LIMIT_RESET_AT - SESSION_LIMIT_NOW);
-		expect(ctx.activity[0]?.event).toBe("subagents:rate_limited");
-		expect(ctx.activity[0]?.payload.next_retry_at).toBe(SESSION_LIMIT_RESET_AT);
-		expect(ctx.activity[0]?.payload.reset_source).toBe("prose-fallback");
-		expect(ctx.activity[0]?.payload.degraded_reset_source).toBe(true);
-	});
+test("a usage snapshot that arrives late re-arms the degraded prose timer before it can steer", async () => {
+	let resolveSnapshot!: (value: unknown) => void;
+	const pending = new Promise<unknown>((resolve) => { resolveSnapshot = resolve; });
+	const w = world({ getUsageSnapshot: () => pending });
+	const first = runScript(w, [{ at: SESSION_LIMIT_NOW, do: msg(SESSION_LIMIT) }]);
+	resolveSnapshot(claudeUsage());
+	await pending;
+	await Promise.resolve();
+	await Promise.resolve();
+	const after = runScript(w, [{ do: fireTimer(0) }]);
+	assert.equal(`${first}\n${after}`, [
+		`retry#1@${SESSION_LIMIT_RESET_AT}:prose-fallback(degraded) await=true timers=1/0 delay=${SESSION_LIMIT_RESET_AT - SESSION_LIMIT_NOW} steers=0 persist=${SESSION_LIMIT_RESET_AT} exhausted=- +[limited(a=1,next=${SESSION_LIMIT_RESET_AT},src=prose-fallback,degraded)]`,
+		// The re-arm happened between the two scripts, so its `retry` event
+		// appears on the stale timer's line.
+		`timer[0]-fired await=true timers=2/1 delay=${USAGE_RESET_AT - SESSION_LIMIT_NOW} steers=0 persist=${USAGE_RESET_AT} exhausted=- +[retry(a=1,next=${USAGE_RESET_AT},src=usage-endpoint)]`,
+	].join("\n"));
+});
 
-	test("Claude usage snapshot overrides prose reset and persists resetSource", () => {
-		const usageSnapshot = normalizeQuotaSnapshot("claude", "usage-endpoint", {
-			five_hour: { utilization: 1, resets_at: new Date(STRUCTURED_USAGE_RESET_AT - RATE_LIMIT_RESET_MARGIN_MS).toISOString() },
-		}, SESSION_LIMIT_NOW);
-		const ctx = makeDeps({ getUsageSnapshot: () => usageSnapshot });
-		const watchdog = createSubagentRateLimitWatchdog(ctx.deps);
-		ctx.clockMs.value = SESSION_LIMIT_NOW;
+test("a usage snapshot that arrives after the pane resolved does not re-arm it", async () => {
+	let resolveSnapshot!: (value: unknown) => void;
+	const pending = new Promise<unknown>((resolve) => { resolveSnapshot = resolve; });
+	const w = world({ getUsageSnapshot: () => pending });
+	const before = runScript(w, [{ at: SESSION_LIMIT_NOW, do: msg(SESSION_LIMIT) }, { do: msg(HEALTHY) }]);
+	resolveSnapshot(claudeUsage());
+	await pending;
+	await Promise.resolve();
+	await Promise.resolve();
+	const after = runScript(w, [{ do: (w) => "settled" }]);
+	assert.equal(`${before}\n${after}`, [
+		`retry#1@${SESSION_LIMIT_RESET_AT}:prose-fallback(degraded) await=true timers=1/0 delay=${SESSION_LIMIT_RESET_AT - SESSION_LIMIT_NOW} steers=0 persist=${SESSION_LIMIT_RESET_AT} exhausted=- +[limited(a=1,next=${SESSION_LIMIT_RESET_AT},src=prose-fallback,degraded)]`,
+		`resolved#1 await=false timers=1/1 delay=${SESSION_LIMIT_RESET_AT - SESSION_LIMIT_NOW} steers=0 persist=null exhausted=- +[skipped(stopreason-mismatch),resolved(a=1)]`,
+		`settled await=false timers=1/1 delay=${SESSION_LIMIT_RESET_AT - SESSION_LIMIT_NOW} steers=0 persist=null exhausted=- +[]`,
+	].join("\n"));
+});
 
-		const outcome = watchdog.onMessageEnd(CLAUDE_SESSION_LIMIT_MESSAGE_END, "rust", "rust", "task-1");
-		expect(outcome.kind).toBe("scheduled-retry");
-		if (outcome.kind !== "scheduled-retry") throw new Error("expected scheduled-retry");
-		expect(outcome.at).toBe(STRUCTURED_USAGE_RESET_AT);
-		expect(outcome.resetSource).toBe("usage-endpoint");
-		expect(outcome.degradedResetSource).toBe(false);
-		expect(ctx.scheduled[0]!.delayMs).toBe(STRUCTURED_USAGE_RESET_AT - SESSION_LIMIT_NOW);
-		expect(ctx.activity[0]?.payload.reset_source).toBe("usage-endpoint");
-		expect(ctx.activity[0]?.payload.degraded_reset_source).toBe(false);
-	});
+test("an async steer rejection is warned with its cause", async () => {
+	const w = world({ sendUserMessage: () => Promise.reject(new Error("agent still streaming")) });
+	runScript(w, [{ at: 1_000, do: msg(RATE_LIMITED) }, { do: fire }]);
+	await Promise.resolve();
+	await Promise.resolve();
+	assert.equal(w.warnings.map((line) => `${warnTag(line)}:${line.includes("agent still streaming")}`).join(","), "steer-failed:true");
+});
 
-	// collectCodexQuotaWindows emits a window from a reset timestamp alone when the
-	// endpoint carries no utilization and no limit flag. Dropping it loses the
-	// usage-endpoint reset and falls back to the backoff ladder.
-	test("Codex usage window with a reset time and nothing else still schedules on it", () => {
-		const usageSnapshot = normalizeQuotaSnapshot("codex", "usage-endpoint", {
-			rate_limit: { primary_window: { reset_after_seconds: (STRUCTURED_USAGE_RESET_AT - RATE_LIMIT_RESET_MARGIN_MS - SESSION_LIMIT_NOW) / 1000 } },
-		}, SESSION_LIMIT_NOW);
-		expect(usageSnapshot.windows).toHaveLength(1);
-		expect(usageSnapshot.windows[0]!.usedPercent).toBeNull();
-		expect(usageSnapshot.windows[0]!.limitReached).toBeUndefined();
-
-		const ctx = makeDeps({ getUsageSnapshot: () => usageSnapshot });
-		const watchdog = createSubagentRateLimitWatchdog(ctx.deps);
-		ctx.clockMs.value = SESSION_LIMIT_NOW;
-
-		const outcome = watchdog.onMessageEnd(CLAUDE_SESSION_LIMIT_MESSAGE_END, "rust", "rust", "task-1");
-		expect(outcome.kind).toBe("scheduled-retry");
-		if (outcome.kind !== "scheduled-retry") throw new Error("expected scheduled-retry");
-		expect(outcome.at).toBe(STRUCTURED_USAGE_RESET_AT);
-		expect(outcome.resetSource).toBe("usage-endpoint");
-	});
-
-	test("async usage snapshot reschedules degraded prose timer before it can steer", async () => {
-		const usageSnapshot = normalizeQuotaSnapshot("claude", "usage-endpoint", {
-			five_hour: { utilization: 1, resets_at: new Date(STRUCTURED_USAGE_RESET_AT - RATE_LIMIT_RESET_MARGIN_MS).toISOString() },
-		}, SESSION_LIMIT_NOW);
-		let resolveSnapshot!: (value: unknown) => void;
-		const pendingSnapshot = new Promise<unknown>((resolve) => { resolveSnapshot = resolve; });
-		const ctx = makeDeps({ getUsageSnapshot: () => pendingSnapshot });
-		const watchdog = createSubagentRateLimitWatchdog(ctx.deps);
-		ctx.clockMs.value = SESSION_LIMIT_NOW;
-
-		const outcome = watchdog.onMessageEnd(CLAUDE_SESSION_LIMIT_MESSAGE_END, "rust", "rust", "task-1");
-		expect(outcome.kind).toBe("scheduled-retry");
-		if (outcome.kind !== "scheduled-retry") throw new Error("expected scheduled-retry");
-		expect(outcome.resetSource).toBe("prose-fallback");
-		expect(ctx.scheduled).toHaveLength(1);
-		const oldTimer = ctx.scheduled[0]!;
-
-		resolveSnapshot(usageSnapshot);
-		await pendingSnapshot;
-		await Promise.resolve();
-		await Promise.resolve();
-
-		expect(oldTimer.cancelled).toBe(true);
-		expect(ctx.scheduled).toHaveLength(2);
-		expect(ctx.scheduled[1]!.delayMs).toBe(STRUCTURED_USAGE_RESET_AT - SESSION_LIMIT_NOW);
-		expect(ctx.activity.map((entry) => entry.payload.reset_source)).toEqual(["prose-fallback", "usage-endpoint"]);
-		oldTimer.fn();
-		expect(ctx.steerCalls).toEqual([]);
-	});
-
-	test("usage source failure logs sanitized warning and keeps degraded fallback", () => {
-		const token = "sk-ant-oauth-secret-token-warning-123456789";
-		const ctx = makeDeps({
-			getUsageSnapshot: () => ({
-				provider: "claude",
-				reason: `http-401 bearer ${token}`,
-				resetSource: "usage-endpoint",
-				source: "quota-source-error",
-				status: 401,
-			}),
-		});
-		const watchdog = createSubagentRateLimitWatchdog(ctx.deps);
-		ctx.clockMs.value = SESSION_LIMIT_NOW;
-
-		const outcome = watchdog.onMessageEnd(CLAUDE_SESSION_LIMIT_MESSAGE_END, "rust", "rust", "task-1");
-		expect(outcome.kind).toBe("scheduled-retry");
-		if (outcome.kind !== "scheduled-retry") throw new Error("expected scheduled-retry");
-		expect(outcome.resetSource).toBe("prose-fallback");
-		expect(ctx.warnings).toHaveLength(1);
-		expect(ctx.warnings[0]).toContain("http-401");
-		expect(ctx.warnings[0]).not.toContain(token);
-	});
-
-	test("healthy assistant turn before a pending retry cancels the timer and resolves", () => {
-		const ctx = makeDeps();
-		const watchdog = createSubagentRateLimitWatchdog(ctx.deps);
-		watchdog.onMessageEnd(CANONICAL_RATE_LIMIT_MESSAGE_END, "rust", "rust", "task-1");
-		expect(watchdog.isAwaitingRetry("rust")).toBe(true);
-
-		const outcome = watchdog.onMessageEnd(HEALTHY_MESSAGE_END, "rust", "rust", "task-1");
-		expect(outcome.kind).toBe("resolved");
-		if (outcome.kind !== "resolved") throw new Error("expected resolved");
-		expect(outcome.previousAttempt).toBe(1);
-		expect(ctx.scheduled[0]!.cancelled).toBe(true);
-		expect(watchdog.isAwaitingRetry("rust")).toBe(false);
-		expect(watchdog.fireRetryNow("rust")).toBe(false);
-		expect(ctx.steerCalls).toEqual([]);
-		expect(ctx.activity.map((entry) => entry.event)).toEqual([
-			"subagents:rate_limited",
-			"subagents:rate_limit_skipped",
-			"subagents:rate_limit_resolved",
-		]);
-	});
-
-	test("scheduled steer fires the canonical recovery prose", () => {
-		const ctx = makeDeps();
-		const watchdog = createSubagentRateLimitWatchdog(ctx.deps);
-		watchdog.onMessageEnd(CANONICAL_RATE_LIMIT_MESSAGE_END, "rust");
-		expect(watchdog.fireRetryNow("rust")).toBe(true);
-		expect(ctx.steerCalls).toEqual([
-			"API rate limit was detected. Try to continue from where you left off.",
-		]);
-		expect(watchdog.isAwaitingRetry("rust")).toBe(false);
-	});
-
-	test("counter advances and second detection emits agent.rate_limit_retry", () => {
-		const ctx = makeDeps();
-		const watchdog = createSubagentRateLimitWatchdog(ctx.deps);
-		watchdog.onMessageEnd(CANONICAL_RATE_LIMIT_MESSAGE_END, "rust");
-		watchdog.fireRetryNow("rust");
-		ctx.clockMs.value = 5_000;
-		const second = watchdog.onMessageEnd(CANONICAL_RATE_LIMIT_MESSAGE_END, "rust");
-		expect(second.kind).toBe("scheduled-retry");
-		if (second.kind !== "scheduled-retry") throw new Error("expected scheduled-retry");
-		expect(second.attempt).toBe(2);
-		// Ladder[1]=2s
-		expect(second.at).toBe(5_000 + 2_000);
-		const events = ctx.activity.map((entry) => entry.event);
-		expect(events).toContain("subagents:rate_limited");
-		expect(events).toContain("subagents:rate_limit_retry");
-	});
-
-	test("exhaustion fires agent.rate_limit_exhausted and onExhausted handler", () => {
-		const ctx = makeDeps();
-		const watchdog = createSubagentRateLimitWatchdog(ctx.deps);
-		// Burn through all three retries.
-		for (let i = 0; i < 3; i += 1) {
-			watchdog.onMessageEnd(CANONICAL_RATE_LIMIT_MESSAGE_END, "rust");
-			watchdog.fireRetryNow("rust");
-		}
-		// 4th detection exhausts.
-		const outcome = watchdog.onMessageEnd(CANONICAL_RATE_LIMIT_MESSAGE_END, "rust", "rust", "task-1");
-		expect(outcome.kind).toBe("exhausted");
-		if (outcome.kind !== "exhausted") throw new Error("expected exhausted");
-		expect(outcome.attempt).toBe(3);
-		expect(ctx.exhausted).toEqual([{ attempt: 3, paneId: "rust", reason: outcome.reason }]);
-		const exhaustedEvent = ctx.activity.find((entry) => entry.event === "subagents:rate_limit_exhausted");
-		expect(exhaustedEvent).toBeDefined();
-		expect(exhaustedEvent!.payload.attempt).toBe(3);
-		expect(watchdog.isAwaitingRetry("rust")).toBe(false);
-	});
-
-	test("healthy turn after rate-limit emits agent.rate_limit_resolved and resets counter", () => {
-		const ctx = makeDeps();
-		const watchdog = createSubagentRateLimitWatchdog(ctx.deps);
-		watchdog.onMessageEnd(CANONICAL_RATE_LIMIT_MESSAGE_END, "rust");
-		watchdog.fireRetryNow("rust"); // pending cleared
-		ctx.activity.length = 0;
-		const outcome: RateLimitOutcome = watchdog.onMessageEnd(HEALTHY_MESSAGE_END, "rust");
-		expect(outcome.kind).toBe("resolved");
-		if (outcome.kind !== "resolved") throw new Error("expected resolved");
-		expect(outcome.previousAttempt).toBe(1);
-		expect(ctx.activity.map((entry) => entry.event)).toEqual([
-			"subagents:rate_limit_skipped",
-			"subagents:rate_limit_resolved",
-		]);
-		expect(ctx.activity[0]?.payload.reason).toBe("stopreason-mismatch");
-		// Counter reset → a subsequent rate-limit starts at attempt 1 again.
-		const second = watchdog.onMessageEnd(CANONICAL_RATE_LIMIT_MESSAGE_END, "rust");
-		if (second.kind !== "scheduled-retry") throw new Error("expected scheduled-retry");
-		expect(second.attempt).toBe(1);
-	});
-
-	test("user-role steer echo does not resolve or reset the retry ladder", () => {
-		const ctx = makeDeps();
-		const watchdog = createSubagentRateLimitWatchdog(ctx.deps);
-		watchdog.onMessageEnd(CANONICAL_RATE_LIMIT_MESSAGE_END, "rust");
-		watchdog.fireRetryNow("rust"); // pending cleared, attempt remains 1
-		ctx.activity.length = 0;
-		const echo = watchdog.onMessageEnd(USER_STEER_ECHO_MESSAGE_END, "rust");
-		expect(echo.kind).toBe("not-rate-limited");
-		expect(ctx.activity).toHaveLength(1);
-		expect(ctx.activity[0]).toMatchObject({
-			event: "subagents:rate_limit_skipped",
-			payload: { reason: "non-assistant" },
-		});
-		const second = watchdog.onMessageEnd(CANONICAL_RATE_LIMIT_MESSAGE_END, "rust");
-		if (second.kind !== "scheduled-retry") throw new Error("expected scheduled-retry");
-		expect(second.attempt).toBe(2);
-	});
-
-	test("non-rate-limit message_end leaves state untouched", () => {
-		const ctx = makeDeps();
-		const watchdog = createSubagentRateLimitWatchdog(ctx.deps);
-		const outcome = watchdog.onMessageEnd(HEALTHY_MESSAGE_END, "rust");
-		expect(outcome.kind).toBe("not-rate-limited");
-		expect(ctx.scheduled).toHaveLength(0);
-		expect(ctx.activity).toHaveLength(1);
-		expect(ctx.activity[0]).toMatchObject({
-			event: "subagents:rate_limit_skipped",
-			payload: { reason: "stopreason-mismatch" },
-		});
-		expect(watchdog.isAwaitingRetry("rust")).toBe(false);
-	});
-
-	test("disabled watchdog short-circuits with skipped-disabled", () => {
-		const ctx = makeDeps({ isEnabled: () => false });
-		const watchdog = createSubagentRateLimitWatchdog(ctx.deps);
-		const outcome = watchdog.onMessageEnd(CANONICAL_RATE_LIMIT_MESSAGE_END, "rust");
-		expect(outcome.kind).toBe("skipped-disabled");
-		expect(ctx.scheduled).toHaveLength(0);
-		expect(ctx.activity).toHaveLength(0);
-	});
-
-	test("cancel clears the pending retry and resets the counter", () => {
-		const ctx = makeDeps();
-		const watchdog = createSubagentRateLimitWatchdog(ctx.deps);
-		watchdog.onMessageEnd(CANONICAL_RATE_LIMIT_MESSAGE_END, "rust");
-		expect(watchdog.isAwaitingRetry("rust")).toBe(true);
-		expect(watchdog.cancel("rust")).toBe(true);
-		expect(watchdog.isAwaitingRetry("rust")).toBe(false);
-		expect(ctx.scheduled[0]!.cancelled).toBe(true);
-		// Subsequent detection restarts at attempt 1.
-		const outcome = watchdog.onMessageEnd(CANONICAL_RATE_LIMIT_MESSAGE_END, "rust");
-		if (outcome.kind !== "scheduled-retry") throw new Error("expected scheduled-retry");
-		expect(outcome.attempt).toBe(1);
-	});
-
-	test("steer dispatch errors are swallowed (best-effort recovery)", () => {
-		const ctx = makeDeps({
-			sendUserMessage: () => {
-				throw new Error("bridge socket gone");
-			},
-		});
-		const watchdog = createSubagentRateLimitWatchdog(ctx.deps);
-		watchdog.onMessageEnd(CANONICAL_RATE_LIMIT_MESSAGE_END, "rust");
-		expect(() => watchdog.fireRetryNow("rust")).not.toThrow();
-		expect(ctx.warnings.some((line) => line.includes("steer dispatch failed"))).toBe(true);
-	});
-
-	test("async steer dispatch rejections are logged (best-effort recovery)", async () => {
-		const ctx = makeDeps({
-			sendUserMessage: () => Promise.reject(new Error("agent still streaming")),
-		});
-		const watchdog = createSubagentRateLimitWatchdog(ctx.deps);
-		watchdog.onMessageEnd(CANONICAL_RATE_LIMIT_MESSAGE_END, "rust");
-		expect(() => watchdog.fireRetryNow("rust")).not.toThrow();
-		await Promise.resolve();
-		expect(ctx.warnings.some((line) => line.includes("steer dispatch failed") && line.includes("agent still streaming"))).toBe(true);
-	});
-
-	test("activity emit errors are swallowed (best-effort recovery)", () => {
-		const ctx = makeDeps({
-			emitActivity: () => {
-				throw new Error("broker offline");
-			},
-		});
-		const watchdog = createSubagentRateLimitWatchdog(ctx.deps);
-		expect(() => watchdog.onMessageEnd(CANONICAL_RATE_LIMIT_MESSAGE_END, "rust")).not.toThrow();
-		expect(ctx.warnings.some((line) => line.includes("activity emit failed"))).toBe(true);
-	});
+test("the skipped broker event renders as noisy debug activity", () => {
+	const record = buildSubagentActivity("subagents:rate_limit_skipped", { agent: "rust", paneId: "%41", reason: "no-prose", taskId: "task-1" }) as any;
+	assert.equal(
+		`type=${record.type} importance=${record.importance} severity=${record.severity} source=${record.source} agent=${record.refs?.agent} task=${record.refs?.task_id} pane=${record.details?.pane_id} reason=${record.details?.reason}`,
+		"type=agent.rate_limit_skipped importance=noisy severity=debug source=pi-agents agent=rust task=task-1 pane=%41 reason=no-prose",
+	);
 });

--- a/pi-extensions/pi-agents-tmux/tests/rate-limit-watchdog.test.ts
+++ b/pi-extensions/pi-agents-tmux/tests/rate-limit-watchdog.test.ts
@@ -43,7 +43,7 @@ function world(overrides: Partial<SubagentRateLimitWatchdogDeps> = {}) {
 	const activity: Array<{ event: string; payload: Record<string, unknown> }> = [];
 	const exhausted: string[] = [];
 	const warnings: string[] = [];
-	const persisted: Array<number | null> = [];
+	const persisted: string[] = [];
 	const clock = { value: 0 };
 	const deps: SubagentRateLimitWatchdogDeps = {
 		backoffLadderSec: () => [1, 2, 4],
@@ -53,7 +53,7 @@ function world(overrides: Partial<SubagentRateLimitWatchdogDeps> = {}) {
 		maxAttempts: () => 3,
 		now: () => clock.value,
 		onExhausted: (paneId, attempt, reason) => exhausted.push(`${paneId}#${attempt}:${reason}`),
-		persistRetryState: (_paneId, at) => persisted.push(at),
+		persistRetryState: (paneId, at) => persisted.push(`${paneId}=${at}`),
 		scheduleAfter: (delayMs, fn) => {
 			const entry = { cancelled: false, delayMs, fn };
 			timers.push(entry);
@@ -62,7 +62,7 @@ function world(overrides: Partial<SubagentRateLimitWatchdogDeps> = {}) {
 		sendUserMessage: (message) => steers.push(message),
 		...overrides,
 	};
-	return { activity, clock, deps, exhausted, persisted, seen: { activity: 0, warnings: 0 }, steers, timers, warnings, watchdog: createSubagentRateLimitWatchdog(deps) };
+	return { activity, clock, deps, exhausted, persisted, seen: { activity: 0, persisted: 0, warnings: 0 }, steers, timers, warnings, watchdog: createSubagentRateLimitWatchdog(deps) };
 }
 type World = ReturnType<typeof world>;
 
@@ -74,12 +74,16 @@ function warnTag(line: string): string {
 	return JSON.stringify(line);
 }
 
+// Each broker payload as its event, its own fields and its refs (agent, task,
+// pane), which the activity tab's attribution is built from.
 function activityTag(entry: { event: string; payload: Record<string, unknown> }): string {
 	const p = entry.payload;
+	const refs = `@${p.agent}/${p.taskId}/${p.paneId}`;
 	const name = entry.event.replace(/^subagents:rate_limit(ed|_)?/, "") || "limited";
-	if (name === "skipped") return `skipped(${p.reason})`;
-	if (name === "limited" || name === "retry") return `${name}(a=${p.attempt},next=${p.next_retry_at},src=${p.reset_source ?? "-"}${p.degraded_reset_source ? ",degraded" : ""})`;
-	return `${name}(a=${p.attempt})`;
+	if (name === "skipped") return `skipped(${p.reason})${refs}`;
+	if (name === "limited" || name === "retry") return `${name}(a=${p.attempt},next=${p.next_retry_at},src=${p.reset_source ?? "-"}${p.degraded_reset_source ? ",degraded" : ""})${refs}`;
+	if (name === "exhausted") return `exhausted(a=${p.attempt},${JSON.stringify(p.reason)})${refs}`;
+	return `${name}(a=${p.attempt})${refs}`;
 }
 
 function outcomeTag(outcome: RateLimitOutcome): string {
@@ -93,9 +97,9 @@ function outcomeTag(outcome: RateLimitOutcome): string {
 }
 
 // One step's line: what the step returned, then the pane read back (awaiting,
-// timers armed/cancelled and the last delay, steers sent and whether they were
-// the canonical text, the last persisted mirror value, exhaustion callbacks),
-// then the activity and warnings the step added.
+// timers armed and which were cancelled, the last delay, steers sent and
+// whether they were the canonical text, exhaustion callbacks), then the mirror
+// writes, activity and warnings the step added.
 type Step = { at?: number; do: (w: World) => string };
 function runScript(w: World, steps: Step[]): string {
 	const lines: string[] = [];
@@ -104,11 +108,14 @@ function runScript(w: World, steps: Step[]): string {
 		const head = step.do(w);
 		const added = w.activity.slice(w.seen.activity).map(activityTag);
 		const warned = w.warnings.slice(w.seen.warnings).map(warnTag);
+		const written = w.persisted.slice(w.seen.persisted);
 		w.seen.activity = w.activity.length;
 		w.seen.warnings = w.warnings.length;
+		w.seen.persisted = w.persisted.length;
 		const steer = w.steers.length ? (w.steers.every((s) => s === RATE_LIMIT_STEER_MESSAGE) ? `${w.steers.length}/canonical` : `${w.steers.length}/other`) : "0";
 		const last = w.timers[w.timers.length - 1];
-		lines.push(`${head} await=${w.watchdog.isAwaitingRetry("rust")} timers=${w.timers.length}/${w.timers.filter((t) => t.cancelled).length}${last ? ` delay=${last.delayMs}` : ""} steers=${steer} persist=${w.persisted.length ? w.persisted[w.persisted.length - 1] : "-"} exhausted=${w.exhausted.length ? w.exhausted.join(";") : "-"} +[${added.join(",")}]${warned.length ? ` warn=[${warned.join(",")}]` : ""}`);
+		const cancelled = w.timers.map((t, i) => (t.cancelled ? i : -1)).filter((i) => i >= 0);
+		lines.push(`${head} await=${w.watchdog.isAwaitingRetry("rust")} timers=${w.timers.length} cancelled=[${cancelled.join(",")}]${last ? ` delay=${last.delayMs}` : ""} steers=${steer} exhausted=${w.exhausted.length ? w.exhausted.join(";") : "-"} persist=[${written.join(",")}] +[${added.join(",")}]${warned.length ? ` warn=[${warned.join(",")}]` : ""}`);
 	}
 	return lines.join("\n");
 }
@@ -118,105 +125,112 @@ const fire = (w: World) => `fire=${w.watchdog.fireRetryNow("rust")}`;
 const cancel = (w: World) => `cancel=${w.watchdog.cancel("rust")}`;
 const fireTimer = (index: number) => (w: World) => { w.timers[index]!.fn(); return `timer[${index}]-fired`; };
 
-const ARMED_1 = "retry#1@2000:backoff-only(degraded) await=true timers=1/0 delay=1000 steers=0 persist=2000 exhausted=- +[limited(a=1,next=2000,src=backoff-only,degraded)]";
+const ARMED_1 = "retry#1@2000:backoff-only(degraded) await=true timers=1 cancelled=[] delay=1000 steers=0 exhausted=- persist=[rust=2000] +[limited(a=1,next=2000,src=backoff-only,degraded)@rust/task-1/rust]";
 
 // label | deps overrides | the script | expect one line per step
 const rows: Array<[string, Partial<SubagentRateLimitWatchdogDeps>, Step[], string]> = [
 	["the first detection arms the first ladder step and mirrors the retry time", {}, [{ at: 1_000, do: msg(RATE_LIMITED) }], ARMED_1],
 	["the fired steer is the canonical text and clears the mirror", {}, [{ at: 1_000, do: msg(RATE_LIMITED) }, { do: fire }], [
 		ARMED_1,
-		"fire=true await=false timers=1/0 delay=1000 steers=1/canonical persist=null exhausted=- +[]",
+		"fire=true await=false timers=1 cancelled=[] delay=1000 steers=1/canonical exhausted=- persist=[rust=null] +[]",
 	].join("\n")],
 	["a second detection after the steer climbs the ladder", {}, [{ at: 1_000, do: msg(RATE_LIMITED) }, { do: fire }, { at: 5_000, do: msg(RATE_LIMITED) }], [
 		ARMED_1,
-		"fire=true await=false timers=1/0 delay=1000 steers=1/canonical persist=null exhausted=- +[]",
-		"retry#2@7000:backoff-only(degraded) await=true timers=2/0 delay=2000 steers=1/canonical persist=7000 exhausted=- +[retry(a=2,next=7000,src=backoff-only,degraded)]",
+		"fire=true await=false timers=1 cancelled=[] delay=1000 steers=1/canonical exhausted=- persist=[rust=null] +[]",
+		"retry#2@7000:backoff-only(degraded) await=true timers=2 cancelled=[] delay=2000 steers=1/canonical exhausted=- persist=[rust=7000] +[retry(a=2,next=7000,src=backoff-only,degraded)@rust/task-1/rust]",
 	].join("\n")],
 	["a detection while a retry is pending re-arms on the latest decision", {}, [{ at: 1_000, do: msg(RATE_LIMITED) }, { at: 1_500, do: msg(RATE_LIMITED) }], [
 		ARMED_1,
-		"retry#2@3500:backoff-only(degraded) await=true timers=2/1 delay=2000 steers=0 persist=3500 exhausted=- +[retry(a=2,next=3500,src=backoff-only,degraded)]",
+		"retry#2@3500:backoff-only(degraded) await=true timers=2 cancelled=[0] delay=2000 steers=0 exhausted=- persist=[rust=3500] +[retry(a=2,next=3500,src=backoff-only,degraded)@rust/task-1/rust]",
 	].join("\n")],
 	["the fourth detection exhausts the three attempts and calls the handler", {}, [
 		{ at: 1_000, do: msg(RATE_LIMITED) }, { do: fire }, { do: msg(RATE_LIMITED) }, { do: fire }, { do: msg(RATE_LIMITED) }, { do: fire }, { do: msg(RATE_LIMITED) },
 	], [
 		ARMED_1,
-		"fire=true await=false timers=1/0 delay=1000 steers=1/canonical persist=null exhausted=- +[]",
-		"retry#2@3000:backoff-only(degraded) await=true timers=2/0 delay=2000 steers=1/canonical persist=3000 exhausted=- +[retry(a=2,next=3000,src=backoff-only,degraded)]",
-		"fire=true await=false timers=2/0 delay=2000 steers=2/canonical persist=null exhausted=- +[]",
-		"retry#3@5000:backoff-only(degraded) await=true timers=3/0 delay=4000 steers=2/canonical persist=5000 exhausted=- +[retry(a=3,next=5000,src=backoff-only,degraded)]",
-		"fire=true await=false timers=3/0 delay=4000 steers=3/canonical persist=null exhausted=- +[]",
-		"exhausted#3 await=false timers=3/0 delay=4000 steers=3/canonical persist=null exhausted=rust#3:rate-limit retries exhausted after 3 attempts +[exhausted(a=3)]",
+		"fire=true await=false timers=1 cancelled=[] delay=1000 steers=1/canonical exhausted=- persist=[rust=null] +[]",
+		"retry#2@3000:backoff-only(degraded) await=true timers=2 cancelled=[] delay=2000 steers=1/canonical exhausted=- persist=[rust=3000] +[retry(a=2,next=3000,src=backoff-only,degraded)@rust/task-1/rust]",
+		"fire=true await=false timers=2 cancelled=[] delay=2000 steers=2/canonical exhausted=- persist=[rust=null] +[]",
+		"retry#3@5000:backoff-only(degraded) await=true timers=3 cancelled=[] delay=4000 steers=2/canonical exhausted=- persist=[rust=5000] +[retry(a=3,next=5000,src=backoff-only,degraded)@rust/task-1/rust]",
+		"fire=true await=false timers=3 cancelled=[] delay=4000 steers=3/canonical exhausted=- persist=[rust=null] +[]",
+		"exhausted#3 await=false timers=3 cancelled=[] delay=4000 steers=3/canonical exhausted=rust#3:rate-limit retries exhausted after 3 attempts persist=[rust=null] +[exhausted(a=3,\"rate-limit retries exhausted after 3 attempts\")@rust/task-1/rust]",
+	].join("\n")],
+	["a detection with a retry still pending exhausts a one-attempt ladder and disarms it", { maxAttempts: () => 1 }, [{ at: 1_000, do: msg(RATE_LIMITED) }, { at: 1_500, do: msg(RATE_LIMITED) }], [
+		ARMED_1,
+		'exhausted#1 await=false timers=1 cancelled=[0] delay=1000 steers=0 exhausted=rust#1:rate-limit retries exhausted after 1 attempt persist=[rust=null] +[exhausted(a=1,"rate-limit retries exhausted after 1 attempt")@rust/task-1/rust]',
 	].join("\n")],
 	["a healthy turn after the steer resolves and resets the ladder", {}, [{ at: 1_000, do: msg(RATE_LIMITED) }, { do: fire }, { do: msg(HEALTHY) }, { do: msg(RATE_LIMITED) }], [
 		ARMED_1,
-		"fire=true await=false timers=1/0 delay=1000 steers=1/canonical persist=null exhausted=- +[]",
-		"resolved#1 await=false timers=1/0 delay=1000 steers=1/canonical persist=null exhausted=- +[skipped(stopreason-mismatch),resolved(a=1)]",
-		"retry#1@2000:backoff-only(degraded) await=true timers=2/0 delay=1000 steers=1/canonical persist=2000 exhausted=- +[limited(a=1,next=2000,src=backoff-only,degraded)]",
+		"fire=true await=false timers=1 cancelled=[] delay=1000 steers=1/canonical exhausted=- persist=[rust=null] +[]",
+		"resolved#1 await=false timers=1 cancelled=[] delay=1000 steers=1/canonical exhausted=- persist=[rust=null] +[skipped(stopreason-mismatch)@rust/task-1/rust,resolved(a=1)@rust/task-1/rust]",
+		"retry#1@2000:backoff-only(degraded) await=true timers=2 cancelled=[] delay=1000 steers=1/canonical exhausted=- persist=[rust=2000] +[limited(a=1,next=2000,src=backoff-only,degraded)@rust/task-1/rust]",
 	].join("\n")],
 	["a healthy turn before the steer cancels the timer and resolves", {}, [{ at: 1_000, do: msg(RATE_LIMITED) }, { do: msg(HEALTHY) }, { do: fire }], [
 		ARMED_1,
-		"resolved#1 await=false timers=1/1 delay=1000 steers=0 persist=null exhausted=- +[skipped(stopreason-mismatch),resolved(a=1)]",
-		"fire=false await=false timers=1/1 delay=1000 steers=0 persist=null exhausted=- +[]",
+		"resolved#1 await=false timers=1 cancelled=[0] delay=1000 steers=0 exhausted=- persist=[rust=null] +[skipped(stopreason-mismatch)@rust/task-1/rust,resolved(a=1)@rust/task-1/rust]",
+		"fire=false await=false timers=1 cancelled=[0] delay=1000 steers=0 exhausted=- persist=[] +[]",
 	].join("\n")],
 	["the user-role echo of the steer neither resolves nor resets", {}, [{ at: 1_000, do: msg(RATE_LIMITED) }, { do: fire }, { do: msg(STEER_ECHO) }, { do: msg(RATE_LIMITED) }], [
 		ARMED_1,
-		"fire=true await=false timers=1/0 delay=1000 steers=1/canonical persist=null exhausted=- +[]",
-		"skip:non-assistant await=false timers=1/0 delay=1000 steers=1/canonical persist=null exhausted=- +[skipped(non-assistant)]",
-		"retry#2@3000:backoff-only(degraded) await=true timers=2/0 delay=2000 steers=1/canonical persist=3000 exhausted=- +[retry(a=2,next=3000,src=backoff-only,degraded)]",
+		"fire=true await=false timers=1 cancelled=[] delay=1000 steers=1/canonical exhausted=- persist=[rust=null] +[]",
+		"skip:non-assistant await=false timers=1 cancelled=[] delay=1000 steers=1/canonical exhausted=- persist=[] +[skipped(non-assistant)@rust/task-1/rust]",
+		"retry#2@3000:backoff-only(degraded) await=true timers=2 cancelled=[] delay=2000 steers=1/canonical exhausted=- persist=[rust=3000] +[retry(a=2,next=3000,src=backoff-only,degraded)@rust/task-1/rust]",
 	].join("\n")],
-	["a healthy turn with nothing pending is only skipped", {}, [{ do: msg(HEALTHY) }], "skip:stopreason-mismatch await=false timers=0/0 steers=0 persist=- exhausted=- +[skipped(stopreason-mismatch)]"],
+	["a healthy turn with nothing pending is only skipped", {}, [{ do: msg(HEALTHY) }], "skip:stopreason-mismatch await=false timers=0 cancelled=[] steers=0 exhausted=- persist=[] +[skipped(stopreason-mismatch)@rust/task-1/rust]"],
 	["an assistant turn without a stop reason after the steer does not resolve", {}, [{ at: 1_000, do: msg(RATE_LIMITED) }, { do: fire }, { do: msg(NO_STOP_REASON) }, { do: msg(RATE_LIMITED) }], [
 		ARMED_1,
-		"fire=true await=false timers=1/0 delay=1000 steers=1/canonical persist=null exhausted=- +[]",
-		"skip:no-stopreason await=false timers=1/0 delay=1000 steers=1/canonical persist=null exhausted=- +[skipped(no-stopreason)]",
-		"retry#2@3000:backoff-only(degraded) await=true timers=2/0 delay=2000 steers=1/canonical persist=3000 exhausted=- +[retry(a=2,next=3000,src=backoff-only,degraded)]",
+		"fire=true await=false timers=1 cancelled=[] delay=1000 steers=1/canonical exhausted=- persist=[rust=null] +[]",
+		"skip:no-stopreason await=false timers=1 cancelled=[] delay=1000 steers=1/canonical exhausted=- persist=[] +[skipped(no-stopreason)@rust/task-1/rust]",
+		"retry#2@3000:backoff-only(degraded) await=true timers=2 cancelled=[] delay=2000 steers=1/canonical exhausted=- persist=[rust=3000] +[retry(a=2,next=3000,src=backoff-only,degraded)@rust/task-1/rust]",
 	].join("\n")],
 	["an error turn without rate-limit prose after the steer does not resolve", {}, [{ at: 1_000, do: msg(RATE_LIMITED) }, { do: fire }, { do: msg(ERROR_WITHOUT_PROSE) }, { do: msg(RATE_LIMITED) }], [
 		ARMED_1,
-		"fire=true await=false timers=1/0 delay=1000 steers=1/canonical persist=null exhausted=- +[]",
-		"skip:no-prose await=false timers=1/0 delay=1000 steers=1/canonical persist=null exhausted=- +[skipped(no-prose)]",
-		"retry#2@3000:backoff-only(degraded) await=true timers=2/0 delay=2000 steers=1/canonical persist=3000 exhausted=- +[retry(a=2,next=3000,src=backoff-only,degraded)]",
+		"fire=true await=false timers=1 cancelled=[] delay=1000 steers=1/canonical exhausted=- persist=[rust=null] +[]",
+		"skip:no-prose await=false timers=1 cancelled=[] delay=1000 steers=1/canonical exhausted=- persist=[] +[skipped(no-prose)@rust/task-1/rust]",
+		"retry#2@3000:backoff-only(degraded) await=true timers=2 cancelled=[] delay=2000 steers=1/canonical exhausted=- persist=[rust=3000] +[retry(a=2,next=3000,src=backoff-only,degraded)@rust/task-1/rust]",
 	].join("\n")],
-	["an assistant turn without a stop reason is skipped", {}, [{ do: msg(NO_STOP_REASON) }], "skip:no-stopreason await=false timers=0/0 steers=0 persist=- exhausted=- +[skipped(no-stopreason)]"],
-	["an error turn without rate-limit prose is skipped", {}, [{ do: msg(ERROR_WITHOUT_PROSE) }], "skip:no-prose await=false timers=0/0 steers=0 persist=- exhausted=- +[skipped(no-prose)]"],
-	["a disabled watchdog does nothing", { isEnabled: () => false }, [{ at: 1_000, do: msg(RATE_LIMITED) }], "disabled await=false timers=0/0 steers=0 persist=- exhausted=- +[]"],
+	["an assistant turn without a stop reason is skipped", {}, [{ do: msg(NO_STOP_REASON) }], "skip:no-stopreason await=false timers=0 cancelled=[] steers=0 exhausted=- persist=[] +[skipped(no-stopreason)@rust/task-1/rust]"],
+	["an error turn without rate-limit prose is skipped", {}, [{ do: msg(ERROR_WITHOUT_PROSE) }], "skip:no-prose await=false timers=0 cancelled=[] steers=0 exhausted=- persist=[] +[skipped(no-prose)@rust/task-1/rust]"],
+	["a disabled watchdog does nothing", { isEnabled: () => false }, [{ at: 1_000, do: msg(RATE_LIMITED) }], "disabled await=false timers=0 cancelled=[] steers=0 exhausted=- persist=[] +[]"],
 	["cancel clears the pending retry, the mirror and the ladder", {}, [{ at: 1_000, do: msg(RATE_LIMITED) }, { do: cancel }, { do: cancel }, { do: msg(RATE_LIMITED) }], [
 		ARMED_1,
-		"cancel=true await=false timers=1/1 delay=1000 steers=0 persist=null exhausted=- +[]",
-		"cancel=false await=false timers=1/1 delay=1000 steers=0 persist=null exhausted=- +[]",
-		"retry#1@2000:backoff-only(degraded) await=true timers=2/1 delay=1000 steers=0 persist=2000 exhausted=- +[limited(a=1,next=2000,src=backoff-only,degraded)]",
+		"cancel=true await=false timers=1 cancelled=[0] delay=1000 steers=0 exhausted=- persist=[rust=null] +[]",
+		"cancel=false await=false timers=1 cancelled=[0] delay=1000 steers=0 exhausted=- persist=[rust=null] +[]",
+		"retry#1@2000:backoff-only(degraded) await=true timers=2 cancelled=[0] delay=1000 steers=0 exhausted=- persist=[rust=2000] +[limited(a=1,next=2000,src=backoff-only,degraded)@rust/task-1/rust]",
 	].join("\n")],
 	["a stale timer firing after a re-arm does not steer", {}, [{ at: 1_000, do: msg(RATE_LIMITED) }, { at: 1_500, do: msg(RATE_LIMITED) }, { do: fireTimer(0) }], [
 		ARMED_1,
-		"retry#2@3500:backoff-only(degraded) await=true timers=2/1 delay=2000 steers=0 persist=3500 exhausted=- +[retry(a=2,next=3500,src=backoff-only,degraded)]",
-		"timer[0]-fired await=true timers=2/1 delay=2000 steers=0 persist=3500 exhausted=- +[]",
+		"retry#2@3500:backoff-only(degraded) await=true timers=2 cancelled=[0] delay=2000 steers=0 exhausted=- persist=[rust=3500] +[retry(a=2,next=3500,src=backoff-only,degraded)@rust/task-1/rust]",
+		"timer[0]-fired await=true timers=2 cancelled=[0] delay=2000 steers=0 exhausted=- persist=[] +[]",
 	].join("\n")],
 	["a throwing persist hook is warned and the retry still arms", { persistRetryState: () => { throw new Error("disk gone"); } }, [{ at: 1_000, do: msg(RATE_LIMITED) }],
-		"retry#1@2000:backoff-only(degraded) await=true timers=1/0 delay=1000 steers=0 persist=- exhausted=- +[limited(a=1,next=2000,src=backoff-only,degraded)] warn=[persist-failed]"],
+		"retry#1@2000:backoff-only(degraded) await=true timers=1 cancelled=[] delay=1000 steers=0 exhausted=- persist=[] +[limited(a=1,next=2000,src=backoff-only,degraded)@rust/task-1/rust] warn=[persist-failed]"],
 	["a throwing steer is warned, not thrown", { sendUserMessage: () => { throw new Error("bridge socket gone"); } }, [{ at: 1_000, do: msg(RATE_LIMITED) }, { do: fire }], [
 		ARMED_1,
-		"fire=true await=false timers=1/0 delay=1000 steers=0 persist=null exhausted=- +[] warn=[steer-failed]",
+		"fire=true await=false timers=1 cancelled=[] delay=1000 steers=0 exhausted=- persist=[rust=null] +[] warn=[steer-failed]",
 	].join("\n")],
 	["a throwing activity sink is warned, not thrown", { emitActivity: () => { throw new Error("broker offline"); } }, [{ at: 1_000, do: msg(RATE_LIMITED) }],
-		"retry#1@2000:backoff-only(degraded) await=true timers=1/0 delay=1000 steers=0 persist=2000 exhausted=- +[] warn=[emit-failed]"],
+		"retry#1@2000:backoff-only(degraded) await=true timers=1 cancelled=[] delay=1000 steers=0 exhausted=- persist=[rust=2000] +[] warn=[emit-failed]"],
 	["a throwing exhaustion handler is warned, not thrown", { maxAttempts: () => 1, onExhausted: () => { throw new Error("outbox gone"); } }, [{ at: 1_000, do: msg(RATE_LIMITED) }, { do: fire }, { do: msg(RATE_LIMITED) }], [
 		ARMED_1,
-		"fire=true await=false timers=1/0 delay=1000 steers=1/canonical persist=null exhausted=- +[]",
-		"exhausted#1 await=false timers=1/0 delay=1000 steers=1/canonical persist=null exhausted=- +[exhausted(a=1)] warn=[exhausted-failed]",
+		"fire=true await=false timers=1 cancelled=[] delay=1000 steers=1/canonical exhausted=- persist=[rust=null] +[]",
+		"exhausted#1 await=false timers=1 cancelled=[] delay=1000 steers=1/canonical exhausted=- persist=[rust=null] +[exhausted(a=1,\"rate-limit retries exhausted after 1 attempt\")@rust/task-1/rust] warn=[exhausted-failed]",
 	].join("\n")],
 	["session-limit prose with no usage source schedules on the prose reset, degraded", { getUsageSnapshot: () => null }, [{ at: SESSION_LIMIT_NOW, do: msg(SESSION_LIMIT) }],
-		`retry#1@${SESSION_LIMIT_RESET_AT}:prose-fallback(degraded) await=true timers=1/0 delay=${SESSION_LIMIT_RESET_AT - SESSION_LIMIT_NOW} steers=0 persist=${SESSION_LIMIT_RESET_AT} exhausted=- +[limited(a=1,next=${SESSION_LIMIT_RESET_AT},src=prose-fallback,degraded)]`],
+		`retry#1@${SESSION_LIMIT_RESET_AT}:prose-fallback(degraded) await=true timers=1 cancelled=[] delay=${SESSION_LIMIT_RESET_AT - SESSION_LIMIT_NOW} steers=0 exhausted=- persist=[rust=${SESSION_LIMIT_RESET_AT}] +[limited(a=1,next=${SESSION_LIMIT_RESET_AT},src=prose-fallback,degraded)@rust/task-1/rust]`],
 	["a usage snapshot wins over the prose reset", { getUsageSnapshot: () => claudeUsage() }, [{ at: SESSION_LIMIT_NOW, do: msg(SESSION_LIMIT) }],
-		`retry#1@${USAGE_RESET_AT}:usage-endpoint await=true timers=1/0 delay=${USAGE_RESET_AT - SESSION_LIMIT_NOW} steers=0 persist=${USAGE_RESET_AT} exhausted=- +[limited(a=1,next=${USAGE_RESET_AT},src=usage-endpoint)]`],
+		`retry#1@${USAGE_RESET_AT}:usage-endpoint await=true timers=1 cancelled=[] delay=${USAGE_RESET_AT - SESSION_LIMIT_NOW} steers=0 exhausted=- persist=[rust=${USAGE_RESET_AT}] +[limited(a=1,next=${USAGE_RESET_AT},src=usage-endpoint)@rust/task-1/rust]`],
+	// collectCodexQuotaWindows emits a window from a reset timestamp alone when
+	// the endpoint carries no utilization and no limit flag; dropping it would
+	// lose the usage-endpoint reset and fall back to the ladder.
 	["a Codex window carrying only a reset time still schedules on it", {
 		getUsageSnapshot: () => normalizeQuotaSnapshot("codex", "usage-endpoint", { rate_limit: { primary_window: { reset_after_seconds: (USAGE_RESET_AT - RATE_LIMIT_RESET_MARGIN_MS - SESSION_LIMIT_NOW) / 1000 } } }, SESSION_LIMIT_NOW),
 	}, [{ at: SESSION_LIMIT_NOW, do: msg(SESSION_LIMIT) }],
-		`retry#1@${USAGE_RESET_AT}:usage-endpoint await=true timers=1/0 delay=${USAGE_RESET_AT - SESSION_LIMIT_NOW} steers=0 persist=${USAGE_RESET_AT} exhausted=- +[limited(a=1,next=${USAGE_RESET_AT},src=usage-endpoint)]`],
+		`retry#1@${USAGE_RESET_AT}:usage-endpoint await=true timers=1 cancelled=[] delay=${USAGE_RESET_AT - SESSION_LIMIT_NOW} steers=0 exhausted=- persist=[rust=${USAGE_RESET_AT}] +[limited(a=1,next=${USAGE_RESET_AT},src=usage-endpoint)@rust/task-1/rust]`],
 	["a failing usage source is warned with its secret redacted and the prose reset stands", {
 		getUsageSnapshot: () => ({ provider: "claude", reason: "http-401 bearer sk-ant-oauth-secret-token-warning-123456789", resetSource: "usage-endpoint", source: "quota-source-error", status: 401 }),
-	}, [{ at: SESSION_LIMIT_NOW, do: msg(SESSION_LIMIT) }, { do: (w) => `redacted=${!w.warnings.some((line) => line.includes("secret-token")) && w.warnings.some((line) => line.includes("http-401"))}` }], [
-		`retry#1@${SESSION_LIMIT_RESET_AT}:prose-fallback(degraded) await=true timers=1/0 delay=${SESSION_LIMIT_RESET_AT - SESSION_LIMIT_NOW} steers=0 persist=${SESSION_LIMIT_RESET_AT} exhausted=- +[limited(a=1,next=${SESSION_LIMIT_RESET_AT},src=prose-fallback,degraded)] warn=[usage-failed]`,
-		`redacted=true await=true timers=1/0 delay=${SESSION_LIMIT_RESET_AT - SESSION_LIMIT_NOW} steers=0 persist=${SESSION_LIMIT_RESET_AT} exhausted=- +[]`,
+	}, [{ at: SESSION_LIMIT_NOW, do: msg(SESSION_LIMIT) }, { do: (w) => `status-kept=${w.warnings.some((line) => line.includes("http-401"))} token-redacted=${!w.warnings.some((line) => line.includes("secret-token"))}` }], [
+		`retry#1@${SESSION_LIMIT_RESET_AT}:prose-fallback(degraded) await=true timers=1 cancelled=[] delay=${SESSION_LIMIT_RESET_AT - SESSION_LIMIT_NOW} steers=0 exhausted=- persist=[rust=${SESSION_LIMIT_RESET_AT}] +[limited(a=1,next=${SESSION_LIMIT_RESET_AT},src=prose-fallback,degraded)@rust/task-1/rust] warn=[usage-failed]`,
+		`status-kept=true token-redacted=true await=true timers=1 cancelled=[] delay=${SESSION_LIMIT_RESET_AT - SESSION_LIMIT_NOW} steers=0 exhausted=- persist=[] +[]`,
 	].join("\n")],
 ];
 
@@ -237,10 +251,10 @@ test("a usage snapshot that arrives late re-arms the degraded prose timer before
 	await Promise.resolve();
 	const after = runScript(w, [{ do: fireTimer(0) }]);
 	assert.equal(`${first}\n${after}`, [
-		`retry#1@${SESSION_LIMIT_RESET_AT}:prose-fallback(degraded) await=true timers=1/0 delay=${SESSION_LIMIT_RESET_AT - SESSION_LIMIT_NOW} steers=0 persist=${SESSION_LIMIT_RESET_AT} exhausted=- +[limited(a=1,next=${SESSION_LIMIT_RESET_AT},src=prose-fallback,degraded)]`,
+		`retry#1@${SESSION_LIMIT_RESET_AT}:prose-fallback(degraded) await=true timers=1 cancelled=[] delay=${SESSION_LIMIT_RESET_AT - SESSION_LIMIT_NOW} steers=0 exhausted=- persist=[rust=${SESSION_LIMIT_RESET_AT}] +[limited(a=1,next=${SESSION_LIMIT_RESET_AT},src=prose-fallback,degraded)@rust/task-1/rust]`,
 		// The re-arm happened between the two scripts, so its `retry` event
 		// appears on the stale timer's line.
-		`timer[0]-fired await=true timers=2/1 delay=${USAGE_RESET_AT - SESSION_LIMIT_NOW} steers=0 persist=${USAGE_RESET_AT} exhausted=- +[retry(a=1,next=${USAGE_RESET_AT},src=usage-endpoint)]`,
+		`timer[0]-fired await=true timers=2 cancelled=[0] delay=${USAGE_RESET_AT - SESSION_LIMIT_NOW} steers=0 exhausted=- persist=[rust=${USAGE_RESET_AT}] +[retry(a=1,next=${USAGE_RESET_AT},src=usage-endpoint)@rust/task-1/rust]`,
 	].join("\n"));
 });
 
@@ -255,9 +269,9 @@ test("a usage snapshot that arrives after the pane resolved does not re-arm it",
 	await Promise.resolve();
 	const after = runScript(w, [{ do: (w) => "settled" }]);
 	assert.equal(`${before}\n${after}`, [
-		`retry#1@${SESSION_LIMIT_RESET_AT}:prose-fallback(degraded) await=true timers=1/0 delay=${SESSION_LIMIT_RESET_AT - SESSION_LIMIT_NOW} steers=0 persist=${SESSION_LIMIT_RESET_AT} exhausted=- +[limited(a=1,next=${SESSION_LIMIT_RESET_AT},src=prose-fallback,degraded)]`,
-		`resolved#1 await=false timers=1/1 delay=${SESSION_LIMIT_RESET_AT - SESSION_LIMIT_NOW} steers=0 persist=null exhausted=- +[skipped(stopreason-mismatch),resolved(a=1)]`,
-		`settled await=false timers=1/1 delay=${SESSION_LIMIT_RESET_AT - SESSION_LIMIT_NOW} steers=0 persist=null exhausted=- +[]`,
+		`retry#1@${SESSION_LIMIT_RESET_AT}:prose-fallback(degraded) await=true timers=1 cancelled=[] delay=${SESSION_LIMIT_RESET_AT - SESSION_LIMIT_NOW} steers=0 exhausted=- persist=[rust=${SESSION_LIMIT_RESET_AT}] +[limited(a=1,next=${SESSION_LIMIT_RESET_AT},src=prose-fallback,degraded)@rust/task-1/rust]`,
+		`resolved#1 await=false timers=1 cancelled=[0] delay=${SESSION_LIMIT_RESET_AT - SESSION_LIMIT_NOW} steers=0 exhausted=- persist=[rust=null] +[skipped(stopreason-mismatch)@rust/task-1/rust,resolved(a=1)@rust/task-1/rust]`,
+		`settled await=false timers=1 cancelled=[0] delay=${SESSION_LIMIT_RESET_AT - SESSION_LIMIT_NOW} steers=0 exhausted=- persist=[] +[]`,
 	].join("\n"));
 });
 


### PR DESCRIPTION
Reshapes `pi-extensions/pi-agents-tmux/tests/rate-limit-watchdog.test.ts` to code-quality § Tests: twenty-two cases, each a handful of expects on one or two transitions of the pane state machine, become one table of scripts on the injected clock and scheduler (each step a message_end, a fire, a cancel or a stale timer, read back as one line: the outcome, awaiting, timers armed and which were cancelled, the last delay, steers and whether they were the canonical text, exhaustion callbacks, the mirror writes, activity and warnings the step added) plus three single cases. Also carries the two Copilot findings tracked off #2239 on `pi-invocation.test.ts`.

## Folded and deleted cases, with the surviving row

| Former case | Surviving row |
|---|---|
| rate-limit skipped broker event maps to noisy debug activity | `the skipped broker event renders as noisy debug activity` (type, importance, severity, source, refs, details; the summary prose is dropped) |
| classifier rejection emits subagents:rate_limit_skipped (four reasons in one loop) | rows `a healthy turn with nothing pending is only skipped`, `an assistant turn without a stop reason is skipped`, `an error turn without rate-limit prose is skipped`, and the echo in `the user-role echo of the steer neither resolves nor resets` |
| retry-state persistence mirrors every transition: schedule, fire, cancel | the `persist=[rust=…]` field on every step: `the fired steer is the canonical text and clears the mirror`, `cancel clears the pending retry, the mirror and the ladder` |
| a throwing persist hook is contained and warned, never fatal | `a throwing persist hook is warned and the retry still arms` |
| first rate-limit detection schedules a retry and emits agent.rate_limited | `the first detection arms the first ladder step and mirrors the retry time` |
| Claude session-limit prose schedules as degraded fallback when usage source is unavailable | `session-limit prose with no usage source schedules on the prose reset, degraded` |
| Claude usage snapshot overrides prose reset and persists resetSource | `a usage snapshot wins over the prose reset` |
| Codex usage window with a reset time and nothing else still schedules on it | `a Codex window carrying only a reset time still schedules on it` (its why kept as the comment above it; nothing else in the package covers a reset-only Codex window) |
| async usage snapshot reschedules degraded prose timer before it can steer | `a usage snapshot that arrives late re-arms the degraded prose timer before it can steer` (single case; the stale timer's fire steers nothing) |
| usage source failure logs sanitized warning and keeps degraded fallback | `a failing usage source is warned with its secret redacted and the prose reset stands` |
| healthy assistant turn before a pending retry cancels the timer and resolves | `a healthy turn before the steer cancels the timer and resolves` |
| scheduled steer fires the canonical recovery prose | `the fired steer is the canonical text and clears the mirror` (`steers=1/canonical` against the exported constant) |
| counter advances and second detection emits agent.rate_limit_retry | `a second detection after the steer climbs the ladder` |
| exhaustion fires agent.rate_limit_exhausted and onExhausted handler | `the fourth detection exhausts the three attempts and calls the handler` |
| healthy turn after rate-limit emits agent.rate_limit_resolved and resets counter | `a healthy turn after the steer resolves and resets the ladder` |
| user-role steer echo does not resolve or reset the retry ladder | `the user-role echo of the steer neither resolves nor resets` |
| non-rate-limit message_end leaves state untouched | `a healthy turn with nothing pending is only skipped` |
| disabled watchdog short-circuits with skipped-disabled | `a disabled watchdog does nothing` |
| cancel clears the pending retry and resets the counter | `cancel clears the pending retry, the mirror and the ladder` (plus a second cancel reading false) |
| steer dispatch errors are swallowed | `a throwing steer is warned, not thrown` |
| async steer dispatch rejections are logged | `an async steer rejection is warned with its cause` (single case) |
| activity emit errors are swallowed | `a throwing activity sink is warned, not thrown` |

New rows with no former case, each the must-fail control of a guard that had none: `a detection while a retry is pending re-arms on the latest decision`, `a stale timer firing after a re-arm does not steer`, `a detection with a retry still pending exhausts a one-attempt ladder and disarms it` (the exhausted branch's disarm and mirror clear, and the singular reason), `a throwing exhaustion handler is warned, not thrown`, `an assistant turn without a stop reason after the steer does not resolve`, `an error turn without rate-limit prose after the steer does not resolve`, and `a usage snapshot that arrives after the pane resolved does not re-arm it`.

## Tracked off #2239 (`pi-invocation.test.ts`, commit d956e1657)

The depth line prints `refused` only for the recursion guard's own error and anything else whole; the launcher line collects the depth and entry writes before `exec` and prints their counts when there is not exactly one of each. Three mutants prove them (an unrelated throw at the cap, a depth overwrite and an entry unset before exec).

## Mutation

42 mutants over `rate-limit-watchdog.ts` and `rate-limit-decision.ts`, 42 killed, each by the row named for it. Two are two-edit mutants: the two guards on the resolve branch (dropping either alone is equivalent), and a re-arm that cancels the fresh timer and keeps the stale one. The reviewer round's probe left five survivors; the second commit answers all five (the cancelled-timer indices, the pane key on the mirror, the refs on every payload, the exhausted branch reached with a retry pending, the singular reason).

## Checks

- `bun test ./tests/rate-limit-watchdog.test.ts`: 5 pass. Package: 297 pass.
- `tools/guard --full`: exit 0.
- One reviewer-test round: accepted with three blockers, all applied with the suggestions.

KEN-1241

https://claude.ai/code/session_01TKCoMRNssSfe4qr3ik9VDa
