### PR TITLE
test(KEN-1241): delegate_subagent as one table of guards and the spawn

### DIFF
--- a/pi-extensions/pi-agents-tmux/tests/delegate-subagent-runtime.test.ts
+++ b/pi-extensions/pi-agents-tmux/tests/delegate-subagent-runtime.test.ts
@@ -13,12 +13,12 @@ import { setSingleAgentSpawnForTests } from "../extensions/subagent/runner.js";
 import { removeSettled } from "./remove-settled.js";
 
 type Execute = (toolCallId: string, params: Record<string, unknown>, signal: undefined, onUpdate: undefined, ctx: unknown) => Promise<{ content: Array<{ text?: string }>; isError?: boolean }>;
-type Spawn = { env: NodeJS.ProcessEnv | undefined };
+type Spawn = { args: string[]; env: NodeJS.ProcessEnv | undefined };
 type Agents = Record<string, string[]>;
 
 // Every pane-only marker the parent may carry is set to a sentinel so the
 // success row can read that the child was handed none of them.
-const PARENT_ENV = { PI_BRIDGE_CHILD_ROLE: "bridge-role", PI_BRIDGE_PARENT_SESSION_ID: "bridge-parent", PI_SUBAGENT_PARENT_SESSION_ID: "parent-session" };
+const PARENT_ENV = { PI_BRIDGE_CHILD_ROLE: "bridge-role", PI_BRIDGE_PARENT_SESSION_ID: "bridge-parent", PI_SUBAGENT_CHILD_PANE: "%9", PI_SUBAGENT_PARENT_SESSION_ID: "parent-session" };
 const ENV_KEYS = ["PI_SUBAGENT_CHILD_AGENT", "PI_CODING_AGENT_DIR", ...Object.keys(PARENT_ENV)] as const;
 
 const tempDirs: string[] = [];
@@ -78,8 +78,8 @@ async function installTool(): Promise<Execute | undefined> {
 // A child that announces itself, reports once and exits clean.
 function fakeSpawns(): Spawn[] {
 	const spawns: Spawn[] = [];
-	setSingleAgentSpawnForTests(((_command: string, _args: string[], options?: { env?: NodeJS.ProcessEnv }) => {
-		spawns.push({ env: options?.env });
+	setSingleAgentSpawnForTests(((_command: string, args: string[], options?: { env?: NodeJS.ProcessEnv }) => {
+		spawns.push({ args, env: options?.env });
 		const proc = Object.assign(new EventEmitter(), { killed: false, stderr: new EventEmitter(), stdout: new EventEmitter() });
 		proc.kill = () => ((proc.killed = true), true);
 		queueMicrotask(() => {
@@ -108,8 +108,8 @@ async function settleRegistry(cwd: string): Promise<void> {
 }
 
 // A refusal by the guard that wrote it, any other text printed whole; a
-// dispatch by the identity and markers the child was handed and the report
-// it returned.
+// dispatch by the identity and markers the child was handed, the task it was
+// given (the last spawn argument) and the report it returned.
 const REFUSALS: Array<[string, string]> = [
 	["PI_SUBAGENT_CHILD_AGENT must be set", "no-caller"],
 	["is not in the discovered project inventory", "caller-unknown"],
@@ -128,7 +128,7 @@ function resultLine(result: Awaited<ReturnType<Execute>>, spawns: Spawn[]): stri
 	}
 	const env = spawns[0]?.env ?? {};
 	const markers = Object.keys(PARENT_ENV).filter((key) => key in env);
-	return `spawned:${env.PI_SUBAGENT_CHILD_AGENT} markers=[${markers.join(",")}] spawns=${spawns.length} text=${JSON.stringify(text)}`;
+	return `spawned:${env.PI_SUBAGENT_CHILD_AGENT} markers=[${markers.join(",")}] spawns=${spawns.length} task=${JSON.stringify(spawns[0]?.args.at(-1))} text=${JSON.stringify(text)}`;
 }
 
 async function delegateLine(caller: string | undefined, agents: Agents, params: Record<string, unknown>): Promise<string> {
@@ -149,7 +149,7 @@ async function delegateLine(caller: string | undefined, agents: Agents, params: 
 		if (!result.isError) await settleRegistry(cwd);
 		return resultLine(result, spawns);
 	} catch (error) {
-		return `threw:${(error as Error).constructor.name}`;
+		return `threw:${(error as Error).constructor.name}: ${(error as Error).message}`;
 	} finally {
 		setSingleAgentSpawnForTests();
 		for (const key of ENV_KEYS) {
@@ -167,6 +167,7 @@ const rows: Array<[string, string | undefined, Agents, Record<string, unknown>, 
 	["a root session has no caller identity", undefined, RUST_TO_SCOUT, { agent: "scout", task: "Map." }, "refused:no-caller spawns=0"],
 	["a blank caller identity is none", "  ", RUST_TO_SCOUT, { agent: "scout", task: "Map." }, "refused:no-caller spawns=0"],
 	["a caller not on disk cannot authorize", "ghost-caller", { scout: [] }, { agent: "scout", task: "Recon." }, "refused:caller-unknown spawns=0"],
+	["a caller identity that only extends a discovered name", "scout-2", { rust: [], scout: ["allowed-subagents: rust"] }, { agent: "rust", task: "Recon." }, "refused:caller-unknown spawns=0"],
 	["a caller without an allowlist", "scout", { researcher: [], scout: [] }, { agent: "researcher", task: "Recurse." }, "refused:no-allowlist spawns=0"],
 	["a blank agent parameter", "rust", RUST_TO_SCOUT, { agent: "  ", task: "Real task." }, "refused:no-agent spawns=0"],
 	["a target outside the allowlist", "rust", { ...RUST_TO_SCOUT, researcher: [] }, { agent: "researcher", task: "Do research." }, "refused:not-allowed spawns=0"],
@@ -174,7 +175,7 @@ const rows: Array<[string, string | undefined, Agents, Record<string, unknown>, 
 	["an allowlisted target not on disk", "rust", { rust: ["allowed-subagents: ghost"] }, { agent: "ghost", task: "Ghostly task." }, "refused:target-unknown spawns=0"],
 	["an allowlisted pane target", "rust", { planner: ["pane: true"], rust: ["allowed-subagents: planner"] }, { agent: "planner", task: "Plan a thing." }, "refused:pane-target spawns=0"],
 	["a blank task", "rust", RUST_TO_SCOUT, { agent: "scout", task: "  " }, "refused:no-task spawns=0"],
-	["an allowlisted bg target is spawned as the child with the pane markers stripped", "rust", RUST_TO_SCOUT, { agent: "scout", task: "Map the unknown area." }, 'spawned:scout markers=[] spawns=1 text="scout report"'],
+	["an allowlisted bg target is spawned as the child with the pane markers stripped", "rust", RUST_TO_SCOUT, { agent: "scout", task: "Map the unknown area." }, 'spawned:scout markers=[] spawns=1 task="Task: Map the unknown area." text="scout report"'],
 ];
 
 test("delegate_subagent refuses by guard or spawns the child", async () => {

--- a/pi-extensions/pi-agents-tmux/tests/delegate-subagent-runtime.test.ts
+++ b/pi-extensions/pi-agents-tmux/tests/delegate-subagent-runtime.test.ts
@@ -1,138 +1,63 @@
-import { afterAll, afterEach, describe, expect, test } from "bun:test";
+// delegate_subagent, the restricted delegation tool, as one table over the
+// caller's identity, the agents on disk and the call: each row is read back
+// as the guard that refused it, or the child it spawned and the environment
+// that child was handed.
+
+import assert from "node:assert/strict";
 import { EventEmitter } from "node:events";
-import { mkdirSync, mkdtempSync, readdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { mkdirSync, mkdtempSync, readdirSync, readFileSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+import test, { after } from "node:test";
 import { setSingleAgentSpawnForTests } from "../extensions/subagent/runner.js";
 import { removeSettled } from "./remove-settled.js";
 
-interface RegisteredTool {
-	name: string;
-	execute: (
-		toolCallId: string,
-		params: Record<string, any>,
-		signal: AbortSignal | undefined,
-		onUpdate: undefined,
-		ctx: any,
-	) => Promise<any>;
-}
+type Execute = (toolCallId: string, params: Record<string, unknown>, signal: undefined, onUpdate: undefined, ctx: unknown) => Promise<{ content: Array<{ text?: string }>; isError?: boolean }>;
+type Spawn = { env: NodeJS.ProcessEnv | undefined };
+type Agents = Record<string, string[]>;
 
-interface Harness {
-	cwd: string;
-	piUserDir: string;
-	tools: Map<string, RegisteredTool>;
-	previousEnv: {
-		child?: string;
-		dir?: string;
-		bridgeParent?: string;
-		bridgeRole?: string;
-		parentSession?: string;
-	};
-}
+// Every pane-only marker the parent may carry is set to a sentinel so the
+// success row can read that the child was handed none of them.
+const PARENT_ENV = { PI_BRIDGE_CHILD_ROLE: "bridge-role", PI_BRIDGE_PARENT_SESSION_ID: "bridge-parent", PI_SUBAGENT_PARENT_SESSION_ID: "parent-session" };
+const ENV_KEYS = ["PI_SUBAGENT_CHILD_AGENT", "PI_CODING_AGENT_DIR", ...Object.keys(PARENT_ENV)] as const;
 
 const tempDirs: string[] = [];
 
-// Post-dispatch task-registry persistence is fire-and-forget and can recreate
-// a harness cwd after the per-test teardown rmSync; sweep again once the file
-// is done so nothing is left in tmpdir.
-afterAll(async () => {
+// The task-registry writes behind a dispatch are fire-and-forget and can
+// recreate a row's cwd after its removal; sweep once more when the file is
+// done so nothing is left in tmpdir.
+after(async () => {
 	for (const dir of tempDirs) await removeSettled(dir);
 });
 
-function createTempProject(): { cwd: string; piUserDir: string } {
-	const cwd = mkdtempSync(join(tmpdir(), "delegate-subagent-runtime-"));
-	tempDirs.push(cwd);
-	mkdirSync(join(cwd, ".pi", "agents"), { recursive: true });
-	const piUserDir = join(cwd, ".pi-agent-home");
-	mkdirSync(piUserDir, { recursive: true });
-	return { cwd, piUserDir };
-}
-
-// The queued/running/completed task-registry updates behind a dispatch are
-// fire-and-forget (`void updateTaskRegistry(...)`); the terminal write can
-// land after teardown's rmSync and recreate the harness cwd in tmpdir. Wait
-// for it so teardown deletes settled state.
-async function waitForTerminalRegistryWrite(cwd: string): Promise<void> {
-	const deadline = Date.now() + 2000;
-	while (Date.now() < deadline) {
-		const registry = (readdirSync(cwd, { recursive: true }) as string[])
-			.map((entry) => entry.toString())
-			.find((entry) => entry.endsWith("tasks.json"));
-		if (registry && readFileSync(join(cwd, registry), "utf8").includes('"completed"')) return;
-		await new Promise((resolve) => setTimeout(resolve, 10));
+function writeAgents(cwd: string, agents: Agents): void {
+	for (const [name, frontmatter] of Object.entries(agents)) {
+		const lines = ["---", `name: ${name}`, `description: ${name} test agent`, ...frontmatter, "---", ""];
+		writeFileSync(join(cwd, ".pi", "agents", `${name}.md`), `${lines.join("\n")}\n`, "utf8");
 	}
-	throw new Error("task registry never recorded a completed dispatch (VST-199)");
 }
 
-function writeAgent(cwd: string, name: string, frontmatter: string[]): void {
-	const lines = ["---", `name: ${name}`, `description: ${name} test agent`, ...frontmatter, "---", ""];
-	writeFileSync(join(cwd, ".pi", "agents", `${name}.md`), `${lines.join("\n")}\n`, "utf8");
-}
-
-function makeFakeCtx(cwd: string): any {
+function fakeCtx(cwd: string): unknown {
 	return {
 		cwd,
 		hasUI: false,
 		isIdle: () => true,
 		model: undefined,
-		sessionManager: {
-			getSessionFile: () => undefined,
-			getSessionId: () => "test-session-id",
-			getBranch: () => [],
-		},
-		ui: {
-			confirm: async () => true,
-			setStatus: () => undefined,
-			setTitle: () => undefined,
-			setWidget: () => undefined,
-		},
+		sessionManager: { getBranch: () => [], getSessionFile: () => undefined, getSessionId: () => "test-session-id" },
+		ui: { confirm: async () => true, setStatus: () => undefined, setTitle: () => undefined, setWidget: () => undefined },
 	};
 }
 
-function setup(callerEnv: string | undefined): Harness {
-	const { cwd, piUserDir } = createTempProject();
-	const previousEnv = {
-		child: process.env.PI_SUBAGENT_CHILD_AGENT,
-		dir: process.env.PI_CODING_AGENT_DIR,
-		bridgeParent: process.env.PI_BRIDGE_PARENT_SESSION_ID,
-		bridgeRole: process.env.PI_BRIDGE_CHILD_ROLE,
-		parentSession: process.env.PI_SUBAGENT_PARENT_SESSION_ID,
-	};
-	if (callerEnv === undefined) delete process.env.PI_SUBAGENT_CHILD_AGENT;
-	else process.env.PI_SUBAGENT_CHILD_AGENT = callerEnv;
-	process.env.PI_CODING_AGENT_DIR = piUserDir;
-	delete process.env.PI_BRIDGE_PARENT_SESSION_ID;
-	delete process.env.PI_BRIDGE_CHILD_ROLE;
-	delete process.env.PI_SUBAGENT_PARENT_SESSION_ID;
-	return { cwd, piUserDir, tools: new Map(), previousEnv };
-}
-
-function teardown(harness: Harness): void {
-	const { previousEnv, cwd } = harness;
-	setSingleAgentSpawnForTests();
-	if (previousEnv.child === undefined) delete process.env.PI_SUBAGENT_CHILD_AGENT;
-	else process.env.PI_SUBAGENT_CHILD_AGENT = previousEnv.child;
-	if (previousEnv.dir === undefined) delete process.env.PI_CODING_AGENT_DIR;
-	else process.env.PI_CODING_AGENT_DIR = previousEnv.dir;
-	if (previousEnv.bridgeParent === undefined) delete process.env.PI_BRIDGE_PARENT_SESSION_ID;
-	else process.env.PI_BRIDGE_PARENT_SESSION_ID = previousEnv.bridgeParent;
-	if (previousEnv.bridgeRole === undefined) delete process.env.PI_BRIDGE_CHILD_ROLE;
-	else process.env.PI_BRIDGE_CHILD_ROLE = previousEnv.bridgeRole;
-	if (previousEnv.parentSession === undefined) delete process.env.PI_SUBAGENT_PARENT_SESSION_ID;
-	else process.env.PI_SUBAGENT_PARENT_SESSION_ID = previousEnv.parentSession;
-	rmSync(cwd, { force: true, recursive: true });
-}
-
-async function installExtension(harness: Harness): Promise<void> {
-	// Re-import so module-level `childAgentName` snapshot reflects the
-	// per-test PI_SUBAGENT_CHILD_AGENT env we set in setup(). bun's import
-	// cache is keyed by URL; a query parameter forces a fresh evaluation.
+// The extension reads PI_SUBAGENT_CHILD_AGENT once at module load, so each
+// row imports it afresh under its own environment (bun keys its import cache
+// by URL; the query parameter forces a new evaluation).
+async function installTool(): Promise<Execute | undefined> {
 	const url = new URL("../extensions/subagent/index.ts", import.meta.url);
-	url.searchParams.set("t", String(Date.now()) + Math.random().toString(36).slice(2));
-	const mod = await import(url.href);
-	const subagentExtension = mod.default;
+	url.searchParams.set("t", `${Date.now()}${Math.random().toString(36).slice(2)}`);
+	const extension = (await import(url.href)).default;
 	const bus = new EventEmitter();
-	const pi = {
+	let execute: Execute | undefined;
+	extension({
 		appendEntry: () => undefined,
 		events: { emit: bus.emit.bind(bus), on: bus.on.bind(bus) },
 		getActiveTools: () => ["delegate_subagent"],
@@ -141,222 +66,117 @@ async function installExtension(harness: Harness): Promise<void> {
 		registerCommand: () => undefined,
 		registerMessageRenderer: () => undefined,
 		registerShortcut: () => undefined,
-		registerTool: (def: any) => {
-			if (def.name && typeof def.execute === "function") {
-				harness.tools.set(def.name, { name: def.name, execute: def.execute });
-			}
+		registerTool: (def: { name?: string; execute?: Execute }) => {
+			if (def.name === "delegate_subagent" && typeof def.execute === "function") execute = def.execute;
 		},
 		sendMessage: () => undefined,
 		sendUserMessage: async () => undefined,
-	} as any;
-	subagentExtension(pi);
+	});
+	return execute;
 }
 
-function installSpawnSuccess(): Array<{ args: string[]; env: NodeJS.ProcessEnv | undefined }> {
-	const calls: Array<{ args: string[]; env: NodeJS.ProcessEnv | undefined }> = [];
-	setSingleAgentSpawnForTests(((command: string, args: string[], options?: { env?: NodeJS.ProcessEnv }) => {
-		void command;
-		calls.push({ args, env: options?.env });
-		const proc = new EventEmitter() as any;
-		proc.stdout = new EventEmitter();
-		proc.stderr = new EventEmitter();
-		proc.killed = false;
-		proc.kill = () => {
-			proc.killed = true;
-			return true;
-		};
+// A child that announces itself, reports once and exits clean.
+function fakeSpawns(): Spawn[] {
+	const spawns: Spawn[] = [];
+	setSingleAgentSpawnForTests(((_command: string, _args: string[], options?: { env?: NodeJS.ProcessEnv }) => {
+		spawns.push({ env: options?.env });
+		const proc = Object.assign(new EventEmitter(), { killed: false, stderr: new EventEmitter(), stdout: new EventEmitter() });
+		proc.kill = () => ((proc.killed = true), true);
 		queueMicrotask(() => {
 			const events = [
 				JSON.stringify({ type: "event", event: "agent_start", data: {} }),
-				JSON.stringify({
-					type: "event",
-					event: "message_end",
-					data: {
-						message: {
-							role: "assistant",
-							content: [{ type: "text", text: "scout report" }],
-							usage: { input: 1, output: 1, cacheRead: 0, cacheWrite: 0, totalTokens: 2 },
-						},
-					},
-				}),
+				JSON.stringify({ type: "event", event: "message_end", data: { message: { role: "assistant", content: [{ type: "text", text: "scout report" }], usage: { input: 1, output: 1, cacheRead: 0, cacheWrite: 0, totalTokens: 2 } } } }),
 			];
 			proc.stdout.emit("data", Buffer.from(`${events.join("\n")}\n`));
 			proc.emit("close", 0, null);
 		});
 		return proc;
-	}) as any);
-	return calls;
+	}) as never);
+	return spawns;
 }
 
-describe("delegate_subagent runtime behavior (issue #228)", () => {
-	let harness: Harness | undefined;
+// The queued/running/completed registry updates behind a dispatch are
+// fire-and-forget; wait for the terminal one so the row's cwd is settled.
+async function settleRegistry(cwd: string): Promise<void> {
+	const deadline = Date.now() + 2000;
+	while (Date.now() < deadline) {
+		const registry = readdirSync(cwd, { recursive: true }).map(String).find((entry) => entry.endsWith("tasks.json"));
+		if (registry && readFileSync(join(cwd, registry), "utf8").includes('"completed"')) return;
+		await new Promise((resolve) => setTimeout(resolve, 10));
+	}
+	throw new Error("task registry never recorded a completed dispatch");
+}
 
-	afterEach(() => {
-		if (harness) {
-			teardown(harness);
-			harness = undefined;
+// A refusal by the guard that wrote it, any other text printed whole; a
+// dispatch by the identity and markers the child was handed and the report
+// it returned.
+const REFUSALS: Array<[string, string]> = [
+	["PI_SUBAGENT_CHILD_AGENT must be set", "no-caller"],
+	["is not in the discovered project inventory", "caller-unknown"],
+	["has no allowed-subagents configured", "no-allowlist"],
+	["'agent' parameter is required", "no-agent"],
+	["allowed-subagents list. Allowed:", "not-allowed"],
+	["is not discovered in project agents", "target-unknown"],
+	["is a persistent pane agent", "pane-target"],
+	["'task' parameter is required", "no-task"],
+];
+function resultLine(result: Awaited<ReturnType<Execute>>, spawns: Spawn[]): string {
+	const text = result.content[0]?.text ?? "";
+	if (result.isError) {
+		const guard = REFUSALS.find(([needle]) => text.includes(needle))?.[1] ?? JSON.stringify(text);
+		return `refused:${guard} spawns=${spawns.length}`;
+	}
+	const env = spawns[0]?.env ?? {};
+	const markers = Object.keys(PARENT_ENV).filter((key) => key in env);
+	return `spawned:${env.PI_SUBAGENT_CHILD_AGENT} markers=[${markers.join(",")}] spawns=${spawns.length} text=${JSON.stringify(text)}`;
+}
+
+async function delegateLine(caller: string | undefined, agents: Agents, params: Record<string, unknown>): Promise<string> {
+	const cwd = mkdtempSync(join(tmpdir(), "delegate-subagent-runtime-"));
+	tempDirs.push(cwd);
+	mkdirSync(join(cwd, ".pi", "agents"), { recursive: true });
+	mkdirSync(join(cwd, ".pi-agent-home"), { recursive: true });
+	writeAgents(cwd, agents);
+	const saved = Object.fromEntries(ENV_KEYS.map((key) => [key, process.env[key]]));
+	Object.assign(process.env, PARENT_ENV, { PI_CODING_AGENT_DIR: join(cwd, ".pi-agent-home") });
+	if (caller === undefined) delete process.env.PI_SUBAGENT_CHILD_AGENT;
+	else process.env.PI_SUBAGENT_CHILD_AGENT = caller;
+	try {
+		const execute = await installTool();
+		if (!execute) return "unregistered";
+		const spawns = fakeSpawns();
+		const result = await execute("call-1", params, undefined, undefined, fakeCtx(cwd));
+		if (!result.isError) await settleRegistry(cwd);
+		return resultLine(result, spawns);
+	} catch (error) {
+		return `threw:${(error as Error).constructor.name}`;
+	} finally {
+		setSingleAgentSpawnForTests();
+		for (const key of ENV_KEYS) {
+			if (saved[key] === undefined) delete process.env[key];
+			else process.env[key] = saved[key];
 		}
-	});
+		await removeSettled(cwd);
+	}
+}
 
-	test("registers when imported and is callable via the captured execute fn", async () => {
-		harness = setup("rust");
-		writeAgent(harness.cwd, "rust", ["allowed-subagents: scout"]);
-		writeAgent(harness.cwd, "scout", []);
-		await installExtension(harness);
-		expect(harness.tools.has("delegate_subagent")).toBe(true);
-	});
+const RUST_TO_SCOUT: Agents = { rust: ["allowed-subagents: scout"], scout: [] };
 
-	test("allowed target spawns the child via single-mode dispatch", async () => {
-		harness = setup("rust");
-		writeAgent(harness.cwd, "rust", ["allowed-subagents: scout"]);
-		writeAgent(harness.cwd, "scout", []);
-		await installExtension(harness);
-		const calls = installSpawnSuccess();
-		const tool = harness.tools.get("delegate_subagent")!;
-		const result = await tool.execute(
-			"call-1",
-			{ agent: "scout", task: "Map the unknown area." },
-			undefined,
-			undefined,
-			makeFakeCtx(harness.cwd),
-		);
-		expect(result.isError).toBeFalsy();
-		expect(calls).toHaveLength(1);
-		// Child identity environment is set, and bridge environment is stripped.
-		expect(calls[0]?.env?.PI_SUBAGENT_CHILD_AGENT).toBe("scout");
-		expect(calls[0]?.env?.PI_BRIDGE_PARENT_SESSION_ID).toBeUndefined();
-		await waitForTerminalRegistryWrite(harness.cwd);
-	});
+// label | PI_SUBAGENT_CHILD_AGENT | agents on disk | params | expect
+const rows: Array<[string, string | undefined, Agents, Record<string, unknown>, string]> = [
+	["a root session has no caller identity", undefined, RUST_TO_SCOUT, { agent: "scout", task: "Map." }, "refused:no-caller spawns=0"],
+	["a blank caller identity is none", "  ", RUST_TO_SCOUT, { agent: "scout", task: "Map." }, "refused:no-caller spawns=0"],
+	["a caller not on disk cannot authorize", "ghost-caller", { scout: [] }, { agent: "scout", task: "Recon." }, "refused:caller-unknown spawns=0"],
+	["a caller without an allowlist", "scout", { researcher: [], scout: [] }, { agent: "researcher", task: "Recurse." }, "refused:no-allowlist spawns=0"],
+	["a blank agent parameter", "rust", RUST_TO_SCOUT, { agent: "  ", task: "Real task." }, "refused:no-agent spawns=0"],
+	["a target outside the allowlist", "rust", { ...RUST_TO_SCOUT, researcher: [] }, { agent: "researcher", task: "Do research." }, "refused:not-allowed spawns=0"],
+	["a target that only extends an allowlisted name", "rust", { ...RUST_TO_SCOUT, "scout-2": [] }, { agent: "scout-2", task: "Do research." }, "refused:not-allowed spawns=0"],
+	["an allowlisted target not on disk", "rust", { rust: ["allowed-subagents: ghost"] }, { agent: "ghost", task: "Ghostly task." }, "refused:target-unknown spawns=0"],
+	["an allowlisted pane target", "rust", { planner: ["pane: true"], rust: ["allowed-subagents: planner"] }, { agent: "planner", task: "Plan a thing." }, "refused:pane-target spawns=0"],
+	["a blank task", "rust", RUST_TO_SCOUT, { agent: "scout", task: "  " }, "refused:no-task spawns=0"],
+	["an allowlisted bg target is spawned as the child with the pane markers stripped", "rust", RUST_TO_SCOUT, { agent: "scout", task: "Map the unknown area." }, 'spawned:scout markers=[] spawns=1 text="scout report"'],
+];
 
-	test("refuses when caller identity is missing (no PI_SUBAGENT_CHILD_AGENT)", async () => {
-		harness = setup(undefined);
-		writeAgent(harness.cwd, "rust", ["allowed-subagents: scout"]);
-		writeAgent(harness.cwd, "scout", []);
-		await installExtension(harness);
-		const tool = harness.tools.get("delegate_subagent")!;
-		const result = await tool.execute(
-			"call-1",
-			{ agent: "scout", task: "Map." },
-			undefined,
-			undefined,
-			makeFakeCtx(harness.cwd),
-		);
-		expect(result.isError).toBe(true);
-		expect(result.content[0]?.text).toContain("PI_SUBAGENT_CHILD_AGENT");
-	});
-
-	test("refuses when caller has no allowed-subagents configured", async () => {
-		harness = setup("scout");
-		writeAgent(harness.cwd, "scout", []);
-		writeAgent(harness.cwd, "researcher", []);
-		await installExtension(harness);
-		const tool = harness.tools.get("delegate_subagent")!;
-		const result = await tool.execute(
-			"call-1",
-			{ agent: "researcher", task: "Recurse." },
-			undefined,
-			undefined,
-			makeFakeCtx(harness.cwd),
-		);
-		expect(result.isError).toBe(true);
-		expect(result.content[0]?.text).toMatch(/no allowed-subagents/);
-	});
-
-	test("refuses target not in caller's allowlist", async () => {
-		harness = setup("rust");
-		writeAgent(harness.cwd, "rust", ["allowed-subagents: scout"]);
-		writeAgent(harness.cwd, "scout", []);
-		writeAgent(harness.cwd, "researcher", []);
-		await installExtension(harness);
-		const tool = harness.tools.get("delegate_subagent")!;
-		const result = await tool.execute(
-			"call-1",
-			{ agent: "researcher", task: "Do research." },
-			undefined,
-			undefined,
-			makeFakeCtx(harness.cwd),
-		);
-		expect(result.isError).toBe(true);
-		expect(result.content[0]?.text).toMatch(/not in rust's allowed-subagents/);
-	});
-
-	test("refuses target that is not in discovered project inventory", async () => {
-		harness = setup("rust");
-		writeAgent(harness.cwd, "rust", ["allowed-subagents: ghost"]);
-		// Note: no ghost agent on disk.
-		await installExtension(harness);
-		const tool = harness.tools.get("delegate_subagent")!;
-		const result = await tool.execute(
-			"call-1",
-			{ agent: "ghost", task: "Ghostly task." },
-			undefined,
-			undefined,
-			makeFakeCtx(harness.cwd),
-		);
-		expect(result.isError).toBe(true);
-		expect(result.content[0]?.text).toMatch(/not discovered in project agents/);
-	});
-
-	test("refuses pane target even when allowlisted", async () => {
-		harness = setup("rust");
-		writeAgent(harness.cwd, "rust", ["allowed-subagents: planner"]);
-		writeAgent(harness.cwd, "planner", ["pane: true"]);
-		await installExtension(harness);
-		const tool = harness.tools.get("delegate_subagent")!;
-		const result = await tool.execute(
-			"call-1",
-			{ agent: "planner", task: "Plan a thing." },
-			undefined,
-			undefined,
-			makeFakeCtx(harness.cwd),
-		);
-		expect(result.isError).toBe(true);
-		expect(result.content[0]?.text).toMatch(/persistent pane agent/);
-	});
-
-	test("refuses when caller agent itself is not in project inventory", async () => {
-		// Pane launches set PI_SUBAGENT_CHILD_AGENT to an agent name, but a
-		// stale env (or local repo override missing the agent file) must not
-		// auto-authorize.
-		harness = setup("ghost-caller");
-		writeAgent(harness.cwd, "scout", []);
-		await installExtension(harness);
-		const tool = harness.tools.get("delegate_subagent")!;
-		const result = await tool.execute(
-			"call-1",
-			{ agent: "scout", task: "Recon." },
-			undefined,
-			undefined,
-			makeFakeCtx(harness.cwd),
-		);
-		expect(result.isError).toBe(true);
-		expect(result.content[0]?.text).toMatch(/not in the discovered project inventory/);
-	});
-
-	test("refuses empty task / empty agent params", async () => {
-		harness = setup("rust");
-		writeAgent(harness.cwd, "rust", ["allowed-subagents: scout"]);
-		writeAgent(harness.cwd, "scout", []);
-		await installExtension(harness);
-		const tool = harness.tools.get("delegate_subagent")!;
-		const noTask = await tool.execute(
-			"call-1",
-			{ agent: "scout", task: "  " },
-			undefined,
-			undefined,
-			makeFakeCtx(harness.cwd),
-		);
-		expect(noTask.isError).toBe(true);
-		expect(noTask.content[0]?.text).toMatch(/'task' parameter is required/);
-
-		const noAgent = await tool.execute(
-			"call-2",
-			{ agent: "  ", task: "Real task." },
-			undefined,
-			undefined,
-			makeFakeCtx(harness.cwd),
-		);
-		expect(noAgent.isError).toBe(true);
-		expect(noAgent.content[0]?.text).toMatch(/'agent' parameter is required/);
-	});
+test("delegate_subagent refuses by guard or spawns the child", async () => {
+	for (const [label, caller, agents, params, expect] of rows) assert.equal(await delegateLine(caller, agents, params), expect, label);
 });

--- a/pi-extensions/pi-agents-tmux/tests/rate-limit-watchdog.test.ts
+++ b/pi-extensions/pi-agents-tmux/tests/rate-limit-watchdog.test.ts
@@ -75,11 +75,21 @@ function warnTag(line: string): string {
 }
 
 // Each broker payload as its event, its own fields and its refs (agent, task,
-// pane), which the activity tab's attribution is built from.
+// pane), which the activity tab's attribution is built from. The five event
+// names the watchdog emits map to their tags; any other name is printed
+// whole so a misspelled emit reddens its row.
+const EVENT_TAGS: Record<string, string> = {
+	"subagents:rate_limit_exhausted": "exhausted",
+	"subagents:rate_limit_resolved": "resolved",
+	"subagents:rate_limit_retry": "retry",
+	"subagents:rate_limit_skipped": "skipped",
+	"subagents:rate_limited": "limited",
+};
 function activityTag(entry: { event: string; payload: Record<string, unknown> }): string {
 	const p = entry.payload;
 	const refs = `@${p.agent}/${p.taskId}/${p.paneId}`;
-	const name = entry.event.replace(/^subagents:rate_limit(ed|_)?/, "") || "limited";
+	const name = EVENT_TAGS[entry.event];
+	if (name === undefined) return `${entry.event}${refs}`;
 	if (name === "skipped") return `skipped(${p.reason})${refs}`;
 	if (name === "limited" || name === "retry") return `${name}(a=${p.attempt},next=${p.next_retry_at},src=${p.reset_source ?? "-"}${p.degraded_reset_source ? ",degraded" : ""})${refs}`;
 	if (name === "exhausted") return `exhausted(a=${p.attempt},${JSON.stringify(p.reason)})${refs}`;


### PR DESCRIPTION
Reshapes `pi-extensions/pi-agents-tmux/tests/delegate-subagent-runtime.test.ts` to code-quality § Tests: nine cases, each a fixture, an execute and a regex on the refusal text or a truthiness bit on the result, become one table of twelve rows over the caller's identity, the agents on disk and the call. Each row reads back as the guard that refused it (by the detector that wrote it, any other text printed whole) with the spawn count, or as the child it spawned, the pane markers that child kept out of a parent carrying every one of them, and the report it returned. Also lands the thread tracked off #2240 on `rate-limit-watchdog.test.ts`.

## Folded and deleted cases, with the surviving row

| Former case | Surviving row |
|---|---|
| registers when imported and is callable via the captured execute fn | deleted as subsumed: every row reads `unregistered` when the tool is missing |
| allowed target spawns the child via single-mode dispatch | `an allowlisted bg target is spawned as the child with the pane markers stripped` (`spawned:scout markers=[] spawns=1 task="Task: Map the unknown area." text="scout report"`); the bridge-env absence was a non-pin (the fixture had deleted it), the parent now carries sentinels for the four pane-only markers and the row reads the list the child kept, and the task handed down is the last spawn argument (the reviewer round's constant-task mutant) |
| refuses when caller identity is missing | `a root session has no caller identity`; new `a blank caller identity is none` (the trim had no control) |
| refuses when caller has no allowed-subagents configured | `a caller without an allowlist` |
| refuses target not in caller's allowlist | `a target outside the allowlist`; new `a target that only extends an allowlisted name` (a prefix-match mutant survived the first batch) |
| refuses target that is not in discovered project inventory | `an allowlisted target not on disk` |
| refuses pane target even when allowlisted | `an allowlisted pane target` |
| refuses when caller agent itself is not in project inventory | `a caller not on disk cannot authorize`; new `a caller identity that only extends a discovered name` (the reviewer round's prefix-match mutant on the caller lookup) |
| refuses empty task / empty agent params | `a blank task` and `a blank agent parameter`, one row each |

Every refusal row carries `spawns=0`, so a guard that refuses after dispatching reddens.

## Deleted with a reason

- The registration case (above).
- The regex pins on the refusal wording: the tool result text is read by a model, not parsed by a consumer. The pin is the guard's identity through the one clause only it emits; an unknown text is printed whole.

## Recorded, not fixed

- `index.ts` trims and filters `allowedSubagents` again after `parseAllowedSubagents` in `agents.ts` already did; an equivalent mutant.

## The tracked thread from #2240

`rate-limit-watchdog.test.ts`'s `activityTag` stripped the event name with `/^subagents:rate_limit(ed|_)?/`, so a misspelled emit (`subagents:rate_limitretry`) read as `retry`. It now maps the five emitted names exactly and prints any other name whole; two mutants misspelling an emit are killed by the rows that read those events.

## Mutation

20 mutants over `index.ts` (the delegate guards, the task and the dispatch return), `runner.ts` (the child env) and `rate-limit-watchdog.ts` (the two misspelled emits), 20 killed, each by the row named for it. The first batch left one survivor (the allowlist matched by prefix); the exact-match row answers it. The reviewer round's probe found two more (the caller matched by prefix, a constant task handed to the child); the second commit answers both.

## Checks

- `bun test ./tests/delegate-subagent-runtime.test.ts`: 1 pass (12 rows). Package: 289 pass.
- `tools/guard --full`: exit 0.
- One reviewer-test round: accepted with two blockers and two suggestions, all four applied.

KEN-1241

https://claude.ai/code/session_01D6wb5KLMMnPv7njYdSSTzL
