### PR TITLE
test(KEN-1241): agent-end watchdog as scripts read back one line a step

### DIFF
--- a/pi-extensions/pi-agents-tmux/tests/agent-end-watchdog.test.ts
+++ b/pi-extensions/pi-agents-tmux/tests/agent-end-watchdog.test.ts
@@ -43,7 +43,7 @@ const REAL_OUTBOX = { agent: AGENT, filesChanged: [], status: "completed", summa
 type Failure = { code?: string; message: string };
 interface WorldOpts {
 	enabled?: boolean;
-	record?: PaneTaskRecord["status"] | "no-status" | "none" | "throws";
+	record?: PaneTaskRecord["status"] | "no-status" | "no-outbox" | "none" | "throws";
 	paneIdle?: boolean;
 	writeFails?: Failure;
 	markFails?: Failure;
@@ -52,6 +52,7 @@ interface World {
 	watchdog: ReturnType<typeof createAgentEndWatchdog>;
 	runtimeRoot: string;
 	outboxFile: string;
+	defaultOutboxFile: string;
 	timers: Array<{ fn: () => void; cancelled: boolean; delayMs: number }>;
 	probes: { record: number; outbox: number; idle: number };
 	writes: SyntheticOutboxPayload[];
@@ -71,10 +72,13 @@ function failing(failure: Failure): () => Promise<never> {
 function world(opts: WorldOpts = {}): World {
 	const runtimeRoot = tempRuntime();
 	const outboxFile = join(runtimeRoot, "outbox", AGENT, `${TASK}.json`);
+	// The path the watchdog computes itself, distinct from the record's own.
+	const defaultOutboxFile = join(runtimeRoot, "outbox", AGENT, `${TASK}.default.json`);
 	const w: World = {
 		watchdog: undefined as never,
 		runtimeRoot,
 		outboxFile,
+		defaultOutboxFile,
 		timers: [],
 		probes: { record: 0, outbox: 0, idle: 0 },
 		writes: [],
@@ -92,18 +96,22 @@ function world(opts: WorldOpts = {}): World {
 			return { cancel: () => void (entry.cancelled = true) };
 		},
 		isEnabled: () => opts.enabled ?? true,
-		outboxPathFor: () => outboxFile,
+		outboxPathFor: () => defaultOutboxFile,
 		readTaskRecord: async () => {
 			w.probes.record += 1;
 			if (record === "throws") throw new Error("registry unreadable");
 			if (record === "none") return undefined;
 			const rec: PaneTaskRecord = { agent: AGENT, createdAt: "2026-05-15T00:00:00.000Z", outboxFile, status: record as PaneTaskRecord["status"], task: "Plan.", taskId: TASK };
 			if (record === "no-status") delete (rec as Partial<PaneTaskRecord>).status;
+			if (record === "no-outbox") {
+				rec.status = "running";
+				delete rec.outboxFile;
+			}
 			return rec;
 		},
-		outboxExists: async () => {
+		outboxExists: async (file) => {
 			w.probes.outbox += 1;
-			return existsSync(outboxFile);
+			return existsSync(file);
 		},
 		isPaneIdle: async () => {
 			w.probes.idle += 1;
@@ -127,18 +135,20 @@ function world(opts: WorldOpts = {}): World {
 	return w;
 }
 
-// A warning by the failure it names; any other line printed whole.
+// A warning by the failure it names, with the pair and message it carries;
+// any other line printed whole.
 function warnTag(line: string): string {
 	for (const [needle, tag] of [["writeSyntheticOutbox failed", "write-failed"], ["markFired failed", "mark-failed"], ["unexpected error", "unexpected"], ["runCheck threw", "check-threw"]] as const) {
-		if (line.includes(needle)) return `${tag}(${JSON.stringify(line.slice(line.lastIndexOf(": ") + 2))})`;
+		if (line.includes(needle)) return `${tag}(${JSON.stringify(line.slice(line.indexOf(" for ") + 5))})`;
 	}
 	return JSON.stringify(line);
 }
 
-// The synthetic payload by its status, reason, refs and synthetic mark; the
-// disk by what sits at the outbox path.
+// The synthetic payload by its status, reason, refs, synthetic mark and
+// whether it carries a summary at all; the disk by what sits at the record's
+// outbox path, and at the computed one when anything does.
 function payloadTag(p: SyntheticOutboxPayload): string {
-	return `${p.status}/${p.reason}@${p.agent}/${p.taskId}${p.synthetic === true ? "/synthetic" : "/NOT-SYNTHETIC"}`;
+	return `${p.status}/${p.reason}@${p.agent}/${p.taskId}${p.synthetic === true ? "/synthetic" : "/NOT-SYNTHETIC"}${p.summary ? "" : "/EMPTY-SUMMARY"}`;
 }
 function diskTag(file: string): string {
 	if (!existsSync(file)) return "absent";
@@ -197,7 +207,8 @@ async function runScript(w: World, steps: Step[]): Promise<string> {
 		const warned = w.warnings.slice(w.seen.warnings).map(warnTag);
 		w.seen = { writes: w.writes.length, marked: w.marked.length, warnings: w.warnings.length, probes: { ...w.probes } };
 		const live = w.timers.filter((t) => !t.cancelled).length;
-		lines.push(`${head} fired=${w.watchdog.hasFired(TASK)} pending=${w.watchdog.hasPending(TASK)} timers=${live} probes=${probes} +writes=[${wrote.join(",")}] +marked=[${marks.join(",")}] disk=${diskTag(w.outboxFile)}${warned.length ? ` warn=[${warned.join(",")}]` : ""}`);
+		const fallback = existsSync(w.defaultOutboxFile) ? ` default=${diskTag(w.defaultOutboxFile)}` : "";
+		lines.push(`${head} fired=${w.watchdog.hasFired(TASK)} pending=${w.watchdog.hasPending(TASK)} timers=${live} probes=${probes} +writes=[${wrote.join(",")}] +marked=[${marks.join(",")}] disk=${diskTag(w.outboxFile)}${fallback}${warned.length ? ` warn=[${warned.join(",")}]` : ""}`);
 	}
 	return lines.join("\n");
 }
@@ -269,20 +280,24 @@ const rows: Array<[string, WorldOpts, Step[], string]> = [
 	["a task with no status yet is active", { record: "no-status" }, [check], `fired fired=true pending=false timers=0 probes=r1o1i1 +writes=[${SYNTHETIC}] +marked=[${TASK}] disk=synthetic`],
 	["a queued task is active", { record: "queued" }, [check], `fired fired=true pending=false timers=0 probes=r1o1i1 +writes=[${SYNTHETIC}] +marked=[${TASK}] disk=synthetic`],
 	["a blocked task is terminal", { record: "blocked" }, [check], "skip:task-terminal fired=false pending=false timers=0 probes=r1o0i0 +writes=[] +marked=[] disk=absent"],
+	["a failed task is terminal", { record: "failed" }, [check], "skip:task-terminal fired=false pending=false timers=0 probes=r1o0i0 +writes=[] +marked=[] disk=absent"],
+	["a task already needing completion is terminal", { record: "needs_completion" }, [check], "skip:task-terminal fired=false pending=false timers=0 probes=r1o0i0 +writes=[] +marked=[] disk=absent"],
+	["a task of unknown status is active", { record: "unknown" }, [check], `fired fired=true pending=false timers=0 probes=r1o1i1 +writes=[${SYNTHETIC}] +marked=[${TASK}] disk=synthetic`],
+	["a record without an outbox path is written at the computed one", { record: "no-outbox" }, [check], `fired fired=true pending=false timers=0 probes=r1o1i1 +writes=[${SYNTHETIC}] +marked=[${TASK}] disk=absent default=synthetic`],
 	["an outbox already on disk", {}, [realCompletion, check], ["real-completion fired=false pending=false timers=0 probes=r0o0i0 +writes=[] +marked=[] disk=real(real completion)", "skip:outbox-present fired=false pending=false timers=0 probes=r1o1i0 +writes=[] +marked=[] disk=real(real completion)"].join("\n")],
 	["a busy pane", { paneIdle: false }, [check], "skip:pane-busy fired=false pending=false timers=0 probes=r1o1i1 +writes=[] +marked=[] disk=absent"],
 	["a writer losing the O_EXCL race is a quiet outbox-present", { writeFails: { code: "EEXIST", message: "outbox already exists" } }, [check, check], ["skip:outbox-present fired=false pending=false timers=0 probes=r1o1i1 +writes=[] +marked=[] disk=absent", "skip:outbox-present fired=false pending=false timers=0 probes=r1o1i1 +writes=[] +marked=[] disk=absent"].join("\n")],
-	["a writer failing otherwise is warned and the task stays unfired", { writeFails: { code: "ENOSPC", message: "disk full" } }, [check], 'error("disk full") fired=false pending=false timers=0 probes=r1o1i1 +writes=[] +marked=[] disk=absent warn=[write-failed("disk full")]'],
-	["a failing mark is warned after the outbox is written and the task counts as fired", { markFails: { message: "registry locked" } }, [check, check], [`fired fired=true pending=false timers=0 probes=r1o1i1 +writes=[${SYNTHETIC}] +marked=[] disk=synthetic warn=[mark-failed("registry locked")]`, "skip:already-fired fired=true pending=false timers=0 probes=r0o0i0 +writes=[] +marked=[] disk=synthetic"].join("\n")],
-	["an unreadable registry is warned and the task stays unfired", { record: "throws" }, [check], 'error("registry unreadable") fired=false pending=false timers=0 probes=r1o0i0 +writes=[] +marked=[] disk=absent warn=[unexpected("registry unreadable")]'],
+	["a writer failing otherwise is warned and the task stays unfired", { writeFails: { code: "ENOSPC", message: "disk full" } }, [check], 'error("disk full") fired=false pending=false timers=0 probes=r1o1i1 +writes=[] +marked=[] disk=absent warn=[write-failed("planner/task-watchdog-1: disk full")]'],
+	["a failing mark is warned after the outbox is written and the task counts as fired", { markFails: { message: "registry locked" } }, [check, check], [`fired fired=true pending=false timers=0 probes=r1o1i1 +writes=[${SYNTHETIC}] +marked=[] disk=synthetic warn=[mark-failed("planner/task-watchdog-1: registry locked")]`, "skip:already-fired fired=true pending=false timers=0 probes=r0o0i0 +writes=[] +marked=[] disk=synthetic"].join("\n")],
+	["an unreadable registry is warned and the task stays unfired", { record: "throws" }, [check], 'error("registry unreadable") fired=false pending=false timers=0 probes=r1o0i0 +writes=[] +marked=[] disk=absent warn=[unexpected("planner/task-watchdog-1: registry unreadable")]'],
 ];
 
 test("the settled-run watchdog", async () => {
 	for (const [label, opts, steps, expect] of rows) assert.equal(await runScript(world(opts), steps), expect, label);
 });
 
-// The real writer: an O_EXCL create, so a completion already on disk is kept
-// and the loss is reported by its code.
+// The real writer and existence probe: an O_EXCL create, so a completion
+// already on disk is kept and the loss is reported by its code.
 async function writerLine(existing: string | undefined): Promise<string> {
 	const runtimeRoot = tempRuntime();
 	const outboxFile = join(runtimeRoot, "outbox", AGENT, `${TASK}.json`);
@@ -290,6 +305,7 @@ async function writerLine(existing: string | undefined): Promise<string> {
 		mkdirSync(join(runtimeRoot, "outbox", AGENT), { recursive: true });
 		writeFileSync(outboxFile, existing);
 	}
+	const existed = await defaultOutboxExists(outboxFile);
 	let head: string;
 	try {
 		await defaultWriteSyntheticOutbox(outboxFile, buildSyntheticOutbox(AGENT, TASK));
@@ -299,13 +315,13 @@ async function writerLine(existing: string | undefined): Promise<string> {
 	}
 	const parsed = JSON.parse(readFileSync(outboxFile, "utf8"));
 	const disk = parsed.synthetic === true ? payloadTag(parsed) : `real(${parsed.summary})`;
-	return `${head} exists=${await defaultOutboxExists(outboxFile)} disk=${disk}`;
+	return `existed=${existed} ${head} exists=${await defaultOutboxExists(outboxFile)} disk=${disk}`;
 }
 
 // label | what is on disk | expect
 const writerRows: Array<[string, string | undefined, string]> = [
-	["a free path is created with the synthetic payload", undefined, `written exists=true disk=${SYNTHETIC}`],
-	["an outbox already on disk is kept and the loss carries EEXIST", JSON.stringify({ summary: "real" }), "rejected:EEXIST exists=true disk=real(real)"],
+	["a free path is created with the synthetic payload", undefined, `existed=false written exists=true disk=${SYNTHETIC}`],
+	["an outbox already on disk is kept and the loss carries EEXIST", JSON.stringify({ summary: "real" }), "existed=true rejected:EEXIST exists=true disk=real(real)"],
 ];
 
 test("the O_EXCL synthetic outbox writer", async () => {
@@ -334,6 +350,7 @@ const DEFAULT_GRACE_MS = WATCHDOG_DEFAULT_GRACE_SEC * 1000;
 const graceRows: Array<[string, string | undefined, number]> = [
 	["unset is the default", undefined, DEFAULT_GRACE_MS],
 	["empty is the default", "", DEFAULT_GRACE_MS],
+	["whitespace is the default", " ", DEFAULT_GRACE_MS],
 	["seconds are milliseconds", "3", 3000],
 	["a fraction keeps whole milliseconds", "0.0015", 1],
 	["zero is zero", "0", 0],

--- a/pi-extensions/pi-agents-tmux/tests/agent-end-watchdog.test.ts
+++ b/pi-extensions/pi-agents-tmux/tests/agent-end-watchdog.test.ts
@@ -1,302 +1,347 @@
+// The settled-run watchdog as a state machine on a manual scheduler: each row
+// is a script of agent_end events, grace expiries and direct checks on one
+// task, read back after every step as one line. The real O_EXCL writer and
+// the two env parsers are tables of their own.
+
 import assert from "node:assert/strict";
-import { mkdtempSync, existsSync, readFileSync, rmSync, writeFileSync, mkdirSync } from "node:fs";
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import test, { after } from "node:test";
 import {
+	type AgentEndWatchdogDeps,
 	buildSyntheticOutbox,
 	createAgentEndWatchdog,
 	defaultOutboxExists,
 	defaultWriteSyntheticOutbox,
-	watchdogEnabledFromEnv,
-	watchdogGraceMsFromEnv,
+	type OnAgentEndCheckResult,
+	type OnAgentEndOutcome,
+	type SyntheticOutboxPayload,
 	WATCHDOG_DEFAULT_GRACE_SEC,
 	WATCHDOG_REASON,
-	type AgentEndWatchdogDeps,
-	type SyntheticOutboxPayload,
+	watchdogEnabledFromEnv,
+	watchdogGraceMsFromEnv,
 } from "../extensions/subagent/agent-end-watchdog.js";
 import type { PaneTaskRecord } from "../extensions/subagent/types.js";
 
-interface ManualScheduler {
-	scheduleAfter: AgentEndWatchdogDeps["scheduleAfter"];
-	advance: () => Promise<void>;
-	pending: () => number;
-}
-
-function manualScheduler(): ManualScheduler {
-	const queue: Array<{ fn: () => void; cancelled: boolean }> = [];
-	return {
-		scheduleAfter(_delayMs, fn) {
-			const entry = { fn, cancelled: false };
-			queue.push(entry);
-			return {
-				cancel: () => {
-					entry.cancelled = true;
-				},
-			};
-		},
-		async advance() {
-			const snapshot = queue.splice(0, queue.length);
-			for (const entry of snapshot) {
-				if (entry.cancelled) continue;
-				entry.fn();
-			}
-			// Yield once so scheduled microtasks (the runCheck promise chain
-			// fired inside the timer callback) finish before the test asserts.
-			await new Promise((resolve) => setTimeout(resolve, 0));
-			await new Promise((resolve) => setTimeout(resolve, 0));
-		},
-		pending() {
-			return queue.filter((entry) => !entry.cancelled).length;
-		},
-	};
-}
-
-interface BuildOpts {
-	enabled?: boolean;
-	graceMs?: number;
-	status?: PaneTaskRecord["status"];
-	outboxAlreadyExists?: boolean;
-	paneIdle?: boolean;
-	scheduler?: ManualScheduler;
-	taskId?: string;
-}
-
-interface TestHarness {
-	deps: AgentEndWatchdogDeps;
-	watchdog: ReturnType<typeof createAgentEndWatchdog>;
-	scheduler: ManualScheduler;
-	writes: SyntheticOutboxPayload[];
-	markFiredCalls: Array<{ taskId: string; payload: SyntheticOutboxPayload }>;
-	warnings: string[];
-	idleProbe: { calls: number; next: boolean };
-	outboxFile: string;
-	runtimeRoot: string;
-	agentName: string;
-	taskId: string;
-}
-
 const tempDirs: string[] = [];
-
 after(() => {
 	for (const dir of tempDirs) rmSync(dir, { force: true, recursive: true });
 });
-
 function tempRuntime(): string {
 	const dir = mkdtempSync(join(tmpdir(), "pi-agents-watchdog-"));
 	tempDirs.push(dir);
 	return dir;
 }
 
-function buildHarness(opts: BuildOpts = {}): TestHarness {
-	const runtimeRoot = tempRuntime();
-	const agentName = "planner";
-	const taskId = opts.taskId ?? "task-watchdog-1";
-	const outboxFile = join(runtimeRoot, "outbox", agentName, `${taskId}.json`);
-	const scheduler = opts.scheduler ?? manualScheduler();
-	const writes: SyntheticOutboxPayload[] = [];
-	const markFiredCalls: Array<{ taskId: string; payload: SyntheticOutboxPayload }> = [];
-	const warnings: string[] = [];
-	const status: PaneTaskRecord["status"] = opts.status ?? "running";
-	const idleProbe = { calls: 0, next: opts.paneIdle ?? true };
-	let outboxOnDisk = Boolean(opts.outboxAlreadyExists);
-	const deps: AgentEndWatchdogDeps = {
-		graceMs: opts.graceMs ?? 10_000,
-		now: () => Date.now(),
-		scheduleAfter: scheduler.scheduleAfter,
-		isEnabled: () => opts.enabled ?? true,
-		outboxPathFor: () => outboxFile,
-		readTaskRecord: async () => ({
-			taskId,
-			agent: agentName,
-			task: "Plan.",
-			status,
-			outboxFile,
-			createdAt: "2026-05-15T00:00:00.000Z",
-		}),
-		outboxExists: async () => outboxOnDisk || existsSync(outboxFile),
-		isPaneIdle: async () => {
-			idleProbe.calls += 1;
-			return idleProbe.next;
-		},
-		writeSyntheticOutbox: async (file, payload) => {
-			mkdirSync(join(runtimeRoot, "outbox", agentName), { recursive: true });
-			writeFileSync(file, `${JSON.stringify(payload, null, "\t")}\n`);
-			outboxOnDisk = true;
-			writes.push(payload);
-		},
-		markFired: async (_root, _agent, id, payload) => {
-			markFiredCalls.push({ taskId: id, payload });
-		},
-		logWarn: (msg) => {
-			warnings.push(msg);
-		},
-	};
-	const watchdog = createAgentEndWatchdog(deps);
-	return { deps, watchdog, scheduler, writes, markFiredCalls, warnings, idleProbe, outboxFile, runtimeRoot, agentName, taskId };
+const AGENT = "planner";
+const TASK = "task-watchdog-1";
+const REAL_OUTBOX = { agent: AGENT, filesChanged: [], status: "completed", summary: "real completion", taskId: TASK, validation: [] };
+
+// The world a script runs in: the task record the registry answers (or none,
+// or a throw), whether the pane reads idle, and a writer or marker that fails.
+type Failure = { code?: string; message: string };
+interface WorldOpts {
+	enabled?: boolean;
+	record?: PaneTaskRecord["status"] | "no-status" | "none" | "throws";
+	paneIdle?: boolean;
+	writeFails?: Failure;
+	markFails?: Failure;
+}
+interface World {
+	watchdog: ReturnType<typeof createAgentEndWatchdog>;
+	runtimeRoot: string;
+	outboxFile: string;
+	timers: Array<{ fn: () => void; cancelled: boolean; delayMs: number }>;
+	probes: { record: number; outbox: number; idle: number };
+	writes: SyntheticOutboxPayload[];
+	marked: string[];
+	warnings: string[];
+	seen: { writes: number; marked: number; warnings: number; probes: { record: number; outbox: number; idle: number } };
 }
 
-test("agent_end without complete_subagent writes synthetic needs_completion outbox after grace", async () => {
-	const harness = buildHarness({ graceMs: 50 });
-	const outcome = harness.watchdog.onAgentEnd({ runtimeRoot: harness.runtimeRoot, agentName: harness.agentName, taskId: harness.taskId });
-	assert.equal(outcome.scheduled, true);
-	assert.equal(harness.watchdog.hasPending(harness.taskId), true);
-	await harness.scheduler.advance();
-	assert.equal(harness.watchdog.hasFired(harness.taskId), true);
-	assert.equal(harness.writes.length, 1, "exactly one synthetic outbox written");
-	const payload = harness.writes[0];
-	assert.equal(payload.status, "needs_completion");
-	assert.equal(payload.reason, WATCHDOG_REASON);
-	assert.equal(payload.synthetic, true);
-	assert.match(payload.summary, /Agent fully settled/);
-	assert.ok(existsSync(harness.outboxFile), "outbox file present on disk");
-	const onDisk = JSON.parse(readFileSync(harness.outboxFile, "utf-8"));
-	assert.equal(onDisk.reason, WATCHDOG_REASON);
-	assert.equal(harness.markFiredCalls.length, 1);
-});
-
-test("KENDEX_AGENT_END_WATCHDOG=0 disables the watchdog entirely", async () => {
-	const harness = buildHarness({ enabled: false, graceMs: 50 });
-	const outcome = harness.watchdog.onAgentEnd({ runtimeRoot: harness.runtimeRoot, agentName: harness.agentName, taskId: harness.taskId });
-	assert.equal(outcome.scheduled, false);
-	if (outcome.scheduled === false) assert.equal(outcome.reason, "disabled");
-	assert.equal(harness.scheduler.pending(), 0, "no grace timer scheduled");
-	await harness.scheduler.advance();
-	assert.equal(harness.writes.length, 0, "no synthetic outbox written");
-	assert.equal(harness.watchdog.hasFired(harness.taskId), false);
-});
-
-test("race: complete_subagent writes outbox before grace expires -> watchdog skips", async () => {
-	const harness = buildHarness({ graceMs: 50 });
-	const outcome = harness.watchdog.onAgentEnd({ runtimeRoot: harness.runtimeRoot, agentName: harness.agentName, taskId: harness.taskId });
-	assert.equal(outcome.scheduled, true);
-	// Real complete_subagent writes a non-synthetic outbox during the grace window.
-	mkdirSync(join(harness.runtimeRoot, "outbox", harness.agentName), { recursive: true });
-	writeFileSync(
-		harness.outboxFile,
-		JSON.stringify({ agent: harness.agentName, taskId: harness.taskId, status: "completed", summary: "real completion", filesChanged: [], validation: [] }),
-	);
-	await harness.scheduler.advance();
-	assert.equal(harness.writes.length, 0, "watchdog did not overwrite real outbox");
-	assert.equal(harness.watchdog.hasFired(harness.taskId), false);
-	const onDisk = JSON.parse(readFileSync(harness.outboxFile, "utf-8"));
-	assert.equal(onDisk.summary, "real completion", "real outbox preserved");
-});
-
-test("multi-turn: pane is busy when grace expires -> watchdog does NOT fire", async () => {
-	const harness = buildHarness({ graceMs: 50, paneIdle: false });
-	const outcome = harness.watchdog.onAgentEnd({ runtimeRoot: harness.runtimeRoot, agentName: harness.agentName, taskId: harness.taskId });
-	assert.equal(outcome.scheduled, true);
-	await harness.scheduler.advance();
-	assert.equal(harness.writes.length, 0, "no outbox written while pane busy");
-	assert.equal(harness.watchdog.hasFired(harness.taskId), false);
-	assert.ok(harness.idleProbe.calls >= 1, "isPaneIdle was probed");
-});
-
-test("successive agent_end events for same task fire only once", async () => {
-	const harness = buildHarness({ graceMs: 50 });
-	const first = harness.watchdog.onAgentEnd({ runtimeRoot: harness.runtimeRoot, agentName: harness.agentName, taskId: harness.taskId });
-	const second = harness.watchdog.onAgentEnd({ runtimeRoot: harness.runtimeRoot, agentName: harness.agentName, taskId: harness.taskId });
-	assert.equal(first.scheduled, true);
-	assert.equal(second.scheduled, false);
-	if (second.scheduled === false) assert.equal(second.reason, "already-scheduled");
-	await harness.scheduler.advance();
-	assert.equal(harness.writes.length, 1, "first scheduled run fired exactly once");
-	const third = harness.watchdog.onAgentEnd({ runtimeRoot: harness.runtimeRoot, agentName: harness.agentName, taskId: harness.taskId });
-	assert.equal(third.scheduled, false);
-	if (third.scheduled === false) assert.equal(third.reason, "already-fired");
-	await harness.scheduler.advance();
-	assert.equal(harness.writes.length, 1, "subsequent agent_end did not duplicate outbox");
-});
-
-test("task record already terminal -> watchdog skips and writes nothing", async () => {
-	const harness = buildHarness({ graceMs: 50, status: "completed" });
-	harness.watchdog.onAgentEnd({ runtimeRoot: harness.runtimeRoot, agentName: harness.agentName, taskId: harness.taskId });
-	await harness.scheduler.advance();
-	assert.equal(harness.writes.length, 0, "no synthetic outbox for terminal task");
-	assert.equal(harness.watchdog.hasFired(harness.taskId), false);
-});
-
-test("defaultWriteSyntheticOutbox refuses to overwrite existing outbox (O_EXCL race-safety)", async () => {
-	const runtimeRoot = tempRuntime();
-	const outboxFile = join(runtimeRoot, "outbox", "planner", "task-excl.json");
-	mkdirSync(join(runtimeRoot, "outbox", "planner"), { recursive: true });
-	writeFileSync(outboxFile, JSON.stringify({ summary: "real" }));
-	const payload = buildSyntheticOutbox("planner", "task-excl");
-	await assert.rejects(() => defaultWriteSyntheticOutbox(outboxFile, payload), /outbox already exists/);
-	const onDisk = JSON.parse(readFileSync(outboxFile, "utf-8"));
-	assert.equal(onDisk.summary, "real", "existing outbox untouched");
-});
-
-test("defaultWriteSyntheticOutbox writes payload when path is free", async () => {
-	const runtimeRoot = tempRuntime();
-	const outboxFile = join(runtimeRoot, "outbox", "planner", "task-new.json");
-	const payload = buildSyntheticOutbox("planner", "task-new");
-	await defaultWriteSyntheticOutbox(outboxFile, payload);
-	assert.equal(await defaultOutboxExists(outboxFile), true);
-	const onDisk = JSON.parse(readFileSync(outboxFile, "utf-8"));
-	assert.equal(onDisk.reason, WATCHDOG_REASON);
-	assert.equal(onDisk.synthetic, true);
-});
-
-test("writeSyntheticOutbox EEXIST race -> skipped:outbox-present, no warn-log", async () => {
-	const harness = buildHarness({ graceMs: 50 });
-	// Stub the writer to mimic a real complete_subagent winning the race:
-	// fs.open(path, 'wx') threw EEXIST after the existence check raced.
-	harness.deps.writeSyntheticOutbox = async () => {
-		const err: NodeJS.ErrnoException = new Error("outbox already exists");
-		err.code = "EEXIST";
+function failing(failure: Failure): () => Promise<never> {
+	return async () => {
+		const err: NodeJS.ErrnoException = new Error(failure.message);
+		if (failure.code) err.code = failure.code;
 		throw err;
 	};
-	harness.watchdog.onAgentEnd({ runtimeRoot: harness.runtimeRoot, agentName: harness.agentName, taskId: harness.taskId });
-	await harness.scheduler.advance();
-	assert.equal(harness.watchdog.hasFired(harness.taskId), false, "fired stays false on EEXIST race-loss");
-	assert.equal(harness.writes.length, 0);
-	assert.equal(harness.warnings.length, 0, "EEXIST is healthy race-loss; no warn-log");
-});
+}
 
-test("writeSyntheticOutbox non-EEXIST error -> warn-log retained", async () => {
-	const harness = buildHarness({ graceMs: 50 });
-	harness.deps.writeSyntheticOutbox = async () => {
-		const err: NodeJS.ErrnoException = new Error("disk full");
-		err.code = "ENOSPC";
-		throw err;
-	};
-	harness.watchdog.onAgentEnd({ runtimeRoot: harness.runtimeRoot, agentName: harness.agentName, taskId: harness.taskId });
-	await harness.scheduler.advance();
-	assert.equal(harness.watchdog.hasFired(harness.taskId), false);
-	assert.ok(
-		harness.warnings.some((w) => w.includes("writeSyntheticOutbox failed") && w.includes("disk full")),
-		`expected disk-full warn-log, got: ${JSON.stringify(harness.warnings)}`,
-	);
-});
-
-test("defaultWriteSyntheticOutbox throws ErrnoException with code=EEXIST on race", async () => {
+function world(opts: WorldOpts = {}): World {
 	const runtimeRoot = tempRuntime();
-	const outboxFile = join(runtimeRoot, "outbox", "planner", "task-race.json");
-	mkdirSync(join(runtimeRoot, "outbox", "planner"), { recursive: true });
-	writeFileSync(outboxFile, JSON.stringify({ summary: "real" }));
-	const payload = buildSyntheticOutbox("planner", "task-race");
-	try {
-		await defaultWriteSyntheticOutbox(outboxFile, payload);
-		assert.fail("defaultWriteSyntheticOutbox should have thrown");
-	} catch (err) {
-		assert.equal((err as NodeJS.ErrnoException).code, "EEXIST", "rethrow must preserve code=EEXIST");
+	const outboxFile = join(runtimeRoot, "outbox", AGENT, `${TASK}.json`);
+	const w: World = {
+		watchdog: undefined as never,
+		runtimeRoot,
+		outboxFile,
+		timers: [],
+		probes: { record: 0, outbox: 0, idle: 0 },
+		writes: [],
+		marked: [],
+		warnings: [],
+		seen: { writes: 0, marked: 0, warnings: 0, probes: { record: 0, outbox: 0, idle: 0 } },
+	};
+	const record = opts.record ?? "running";
+	const deps: AgentEndWatchdogDeps = {
+		graceMs: 10_000,
+		now: () => 0,
+		scheduleAfter: (delayMs, fn) => {
+			const entry = { fn, cancelled: false, delayMs };
+			w.timers.push(entry);
+			return { cancel: () => void (entry.cancelled = true) };
+		},
+		isEnabled: () => opts.enabled ?? true,
+		outboxPathFor: () => outboxFile,
+		readTaskRecord: async () => {
+			w.probes.record += 1;
+			if (record === "throws") throw new Error("registry unreadable");
+			if (record === "none") return undefined;
+			const rec: PaneTaskRecord = { agent: AGENT, createdAt: "2026-05-15T00:00:00.000Z", outboxFile, status: record as PaneTaskRecord["status"], task: "Plan.", taskId: TASK };
+			if (record === "no-status") delete (rec as Partial<PaneTaskRecord>).status;
+			return rec;
+		},
+		outboxExists: async () => {
+			w.probes.outbox += 1;
+			return existsSync(outboxFile);
+		},
+		isPaneIdle: async () => {
+			w.probes.idle += 1;
+			return opts.paneIdle ?? true;
+		},
+		writeSyntheticOutbox: opts.writeFails
+			? failing(opts.writeFails)
+			: async (file, payload) => {
+					mkdirSync(join(runtimeRoot, "outbox", AGENT), { recursive: true });
+					writeFileSync(file, `${JSON.stringify(payload, null, "\t")}\n`);
+					w.writes.push(payload);
+				},
+		markFired: opts.markFails
+			? failing(opts.markFails)
+			: async (_root, _agent, id) => {
+					w.marked.push(id);
+				},
+		logWarn: (msg) => void w.warnings.push(msg),
+	};
+	w.watchdog = createAgentEndWatchdog(deps);
+	return w;
+}
+
+// A warning by the failure it names; any other line printed whole.
+function warnTag(line: string): string {
+	for (const [needle, tag] of [["writeSyntheticOutbox failed", "write-failed"], ["markFired failed", "mark-failed"], ["unexpected error", "unexpected"], ["runCheck threw", "check-threw"]] as const) {
+		if (line.includes(needle)) return `${tag}(${JSON.stringify(line.slice(line.lastIndexOf(": ") + 2))})`;
 	}
+	return JSON.stringify(line);
+}
+
+// The synthetic payload by its status, reason, refs and synthetic mark; the
+// disk by what sits at the outbox path.
+function payloadTag(p: SyntheticOutboxPayload): string {
+	return `${p.status}/${p.reason}@${p.agent}/${p.taskId}${p.synthetic === true ? "/synthetic" : "/NOT-SYNTHETIC"}`;
+}
+function diskTag(file: string): string {
+	if (!existsSync(file)) return "absent";
+	const parsed = JSON.parse(readFileSync(file, "utf8"));
+	return parsed.synthetic === true ? "synthetic" : `real(${parsed.summary})`;
+}
+function outcomeTag(o: OnAgentEndOutcome): string {
+	return o.scheduled ? "scheduled" : `refused:${o.reason}`;
+}
+function checkTag(r: OnAgentEndCheckResult): string {
+	if (r.fired) return "fired";
+	if (r.error !== undefined) return `error(${JSON.stringify(r.error)})`;
+	return `skip:${r.skipped}`;
+}
+
+// Steps: an agent_end, the grace expiring (every live timer fires, then two
+// macrotask turns so the check's promise chain settles), a direct check, and
+// a real completion landing on disk.
+type Step = (w: World) => Promise<string> | string;
+const end: Step = (w) => outcomeTag(w.watchdog.onAgentEnd({ agentName: AGENT, runtimeRoot: w.runtimeRoot, taskId: TASK }));
+const endWithoutTask: Step = (w) => outcomeTag(w.watchdog.onAgentEnd({ agentName: AGENT, runtimeRoot: w.runtimeRoot, taskId: "" }));
+const grace: Step = async (w) => {
+	const live = w.timers.filter((t) => !t.cancelled);
+	for (const t of live) {
+		t.cancelled = true;
+		t.fn();
+	}
+	await new Promise((resolve) => setTimeout(resolve, 0));
+	await new Promise((resolve) => setTimeout(resolve, 0));
+	return `grace(${live.map((t) => t.delayMs).join(",") || "none"})`;
+};
+const check: Step = async (w) => {
+	try {
+		return checkTag(await w.watchdog.checkNow({ agentName: AGENT, runtimeRoot: w.runtimeRoot, taskId: TASK }));
+	} catch (err) {
+		return `threw(${JSON.stringify((err as Error).message)})`;
+	}
+};
+const realCompletion: Step = (w) => {
+	mkdirSync(join(w.runtimeRoot, "outbox", AGENT), { recursive: true });
+	writeFileSync(w.outboxFile, JSON.stringify(REAL_OUTBOX));
+	return "real-completion";
+};
+
+// One step's line: what the step returned, then the task read back (fired,
+// pending in the watchdog's own map, live timers in the scheduler), then what
+// the step added: probes made, payloads written,
+// marks, warnings, and the disk.
+async function runScript(w: World, steps: Step[]): Promise<string> {
+	const lines: string[] = [];
+	for (const step of steps) {
+		const head = await step(w);
+		const probes = (["record", "outbox", "idle"] as const).map((k) => `${k[0]}${w.probes[k] - w.seen.probes[k]}`).join("");
+		const wrote = w.writes.slice(w.seen.writes).map(payloadTag);
+		const marks = w.marked.slice(w.seen.marked);
+		const warned = w.warnings.slice(w.seen.warnings).map(warnTag);
+		w.seen = { writes: w.writes.length, marked: w.marked.length, warnings: w.warnings.length, probes: { ...w.probes } };
+		const live = w.timers.filter((t) => !t.cancelled).length;
+		lines.push(`${head} fired=${w.watchdog.hasFired(TASK)} pending=${w.watchdog.hasPending(TASK)} timers=${live} probes=${probes} +writes=[${wrote.join(",")}] +marked=[${marks.join(",")}] disk=${diskTag(w.outboxFile)}${warned.length ? ` warn=[${warned.join(",")}]` : ""}`);
+	}
+	return lines.join("\n");
+}
+
+const SYNTHETIC = `needs_completion/${WATCHDOG_REASON}@${AGENT}/${TASK}/synthetic`;
+
+// label | world | steps | expect (one line per step)
+const rows: Array<[string, WorldOpts, Step[], string]> = [
+	[
+		"a settled turn with no outbox fires after the grace, writes the synthetic outbox and marks the task",
+		{},
+		[end, grace],
+		[
+			"scheduled fired=false pending=true timers=1 probes=r0o0i0 +writes=[] +marked=[] disk=absent",
+			`grace(10000) fired=true pending=false timers=0 probes=r1o1i1 +writes=[${SYNTHETIC}] +marked=[${TASK}] disk=synthetic`,
+		].join("\n"),
+	],
+	[
+		"a disabled watchdog arms nothing",
+		{ enabled: false },
+		[end, grace],
+		["refused:disabled fired=false pending=false timers=0 probes=r0o0i0 +writes=[] +marked=[] disk=absent", "grace(none) fired=false pending=false timers=0 probes=r0o0i0 +writes=[] +marked=[] disk=absent"].join("\n"),
+	],
+	[
+		"an agent_end without a task id is refused",
+		{},
+		[endWithoutTask],
+		"refused:missing-task-id fired=false pending=false timers=0 probes=r0o0i0 +writes=[] +marked=[] disk=absent",
+	],
+	[
+		"a real completion during the grace wins and is kept",
+		{},
+		[end, realCompletion, grace],
+		[
+			"scheduled fired=false pending=true timers=1 probes=r0o0i0 +writes=[] +marked=[] disk=absent",
+			"real-completion fired=false pending=true timers=1 probes=r0o0i0 +writes=[] +marked=[] disk=real(real completion)",
+			"grace(10000) fired=false pending=false timers=0 probes=r1o1i0 +writes=[] +marked=[] disk=real(real completion)",
+		].join("\n"),
+	],
+	[
+		"a busy pane at the grace is probed and left alone",
+		{ paneIdle: false },
+		[end, grace],
+		["scheduled fired=false pending=true timers=1 probes=r0o0i0 +writes=[] +marked=[] disk=absent", "grace(10000) fired=false pending=false timers=0 probes=r1o1i1 +writes=[] +marked=[] disk=absent"].join("\n"),
+	],
+	[
+		"a second agent_end while pending is already scheduled; after the grace it is already fired and checks nothing",
+		{},
+		[end, end, grace, end, grace],
+		[
+			"scheduled fired=false pending=true timers=1 probes=r0o0i0 +writes=[] +marked=[] disk=absent",
+			"refused:already-scheduled fired=false pending=true timers=1 probes=r0o0i0 +writes=[] +marked=[] disk=absent",
+			`grace(10000) fired=true pending=false timers=0 probes=r1o1i1 +writes=[${SYNTHETIC}] +marked=[${TASK}] disk=synthetic`,
+			"refused:already-fired fired=true pending=false timers=0 probes=r0o0i0 +writes=[] +marked=[] disk=synthetic",
+			"grace(none) fired=true pending=false timers=0 probes=r0o0i0 +writes=[] +marked=[] disk=synthetic",
+		].join("\n"),
+	],
+	[
+		"a direct check cancels the pending timer and reads the task terminal",
+		{ record: "completed" },
+		[end, check, grace],
+		[
+			"scheduled fired=false pending=true timers=1 probes=r0o0i0 +writes=[] +marked=[] disk=absent",
+			"skip:task-terminal fired=false pending=false timers=0 probes=r1o0i0 +writes=[] +marked=[] disk=absent",
+			"grace(none) fired=false pending=false timers=0 probes=r0o0i0 +writes=[] +marked=[] disk=absent",
+		].join("\n"),
+	],
+	["a task with no record", { record: "none" }, [check], "skip:no-record fired=false pending=false timers=0 probes=r1o0i0 +writes=[] +marked=[] disk=absent"],
+	["a task with no status yet is active", { record: "no-status" }, [check], `fired fired=true pending=false timers=0 probes=r1o1i1 +writes=[${SYNTHETIC}] +marked=[${TASK}] disk=synthetic`],
+	["a queued task is active", { record: "queued" }, [check], `fired fired=true pending=false timers=0 probes=r1o1i1 +writes=[${SYNTHETIC}] +marked=[${TASK}] disk=synthetic`],
+	["a blocked task is terminal", { record: "blocked" }, [check], "skip:task-terminal fired=false pending=false timers=0 probes=r1o0i0 +writes=[] +marked=[] disk=absent"],
+	["an outbox already on disk", {}, [realCompletion, check], ["real-completion fired=false pending=false timers=0 probes=r0o0i0 +writes=[] +marked=[] disk=real(real completion)", "skip:outbox-present fired=false pending=false timers=0 probes=r1o1i0 +writes=[] +marked=[] disk=real(real completion)"].join("\n")],
+	["a busy pane", { paneIdle: false }, [check], "skip:pane-busy fired=false pending=false timers=0 probes=r1o1i1 +writes=[] +marked=[] disk=absent"],
+	["a writer losing the O_EXCL race is a quiet outbox-present", { writeFails: { code: "EEXIST", message: "outbox already exists" } }, [check, check], ["skip:outbox-present fired=false pending=false timers=0 probes=r1o1i1 +writes=[] +marked=[] disk=absent", "skip:outbox-present fired=false pending=false timers=0 probes=r1o1i1 +writes=[] +marked=[] disk=absent"].join("\n")],
+	["a writer failing otherwise is warned and the task stays unfired", { writeFails: { code: "ENOSPC", message: "disk full" } }, [check], 'error("disk full") fired=false pending=false timers=0 probes=r1o1i1 +writes=[] +marked=[] disk=absent warn=[write-failed("disk full")]'],
+	["a failing mark is warned after the outbox is written and the task counts as fired", { markFails: { message: "registry locked" } }, [check, check], [`fired fired=true pending=false timers=0 probes=r1o1i1 +writes=[${SYNTHETIC}] +marked=[] disk=synthetic warn=[mark-failed("registry locked")]`, "skip:already-fired fired=true pending=false timers=0 probes=r0o0i0 +writes=[] +marked=[] disk=synthetic"].join("\n")],
+	["an unreadable registry is warned and the task stays unfired", { record: "throws" }, [check], 'error("registry unreadable") fired=false pending=false timers=0 probes=r1o0i0 +writes=[] +marked=[] disk=absent warn=[unexpected("registry unreadable")]'],
+];
+
+test("the settled-run watchdog", async () => {
+	for (const [label, opts, steps, expect] of rows) assert.equal(await runScript(world(opts), steps), expect, label);
 });
 
-test("watchdogEnabledFromEnv parses KENDEX_AGENT_END_WATCHDOG truthy/falsy values", () => {
-	assert.equal(watchdogEnabledFromEnv({} as NodeJS.ProcessEnv), true);
-	assert.equal(watchdogEnabledFromEnv({ KENDEX_AGENT_END_WATCHDOG: "" } as any), true);
-	assert.equal(watchdogEnabledFromEnv({ KENDEX_AGENT_END_WATCHDOG: "1" } as any), true);
-	assert.equal(watchdogEnabledFromEnv({ KENDEX_AGENT_END_WATCHDOG: "0" } as any), false);
-	assert.equal(watchdogEnabledFromEnv({ KENDEX_AGENT_END_WATCHDOG: "false" } as any), false);
-	assert.equal(watchdogEnabledFromEnv({ KENDEX_AGENT_END_WATCHDOG: "off" } as any), false);
+// The real writer: an O_EXCL create, so a completion already on disk is kept
+// and the loss is reported by its code.
+async function writerLine(existing: string | undefined): Promise<string> {
+	const runtimeRoot = tempRuntime();
+	const outboxFile = join(runtimeRoot, "outbox", AGENT, `${TASK}.json`);
+	if (existing !== undefined) {
+		mkdirSync(join(runtimeRoot, "outbox", AGENT), { recursive: true });
+		writeFileSync(outboxFile, existing);
+	}
+	let head: string;
+	try {
+		await defaultWriteSyntheticOutbox(outboxFile, buildSyntheticOutbox(AGENT, TASK));
+		head = "written";
+	} catch (err) {
+		head = `rejected:${(err as NodeJS.ErrnoException).code ?? JSON.stringify((err as Error).message)}`;
+	}
+	const parsed = JSON.parse(readFileSync(outboxFile, "utf8"));
+	const disk = parsed.synthetic === true ? payloadTag(parsed) : `real(${parsed.summary})`;
+	return `${head} exists=${await defaultOutboxExists(outboxFile)} disk=${disk}`;
+}
+
+// label | what is on disk | expect
+const writerRows: Array<[string, string | undefined, string]> = [
+	["a free path is created with the synthetic payload", undefined, `written exists=true disk=${SYNTHETIC}`],
+	["an outbox already on disk is kept and the loss carries EEXIST", JSON.stringify({ summary: "real" }), "rejected:EEXIST exists=true disk=real(real)"],
+];
+
+test("the O_EXCL synthetic outbox writer", async () => {
+	for (const [label, existing, expect] of writerRows) assert.equal(await writerLine(existing), expect, label);
 });
 
-test("watchdogGraceMsFromEnv uses default 10s and parses overrides", () => {
-	assert.equal(watchdogGraceMsFromEnv({} as NodeJS.ProcessEnv), WATCHDOG_DEFAULT_GRACE_SEC * 1000);
-	assert.equal(watchdogGraceMsFromEnv({ KENDEX_AGENT_END_WATCHDOG_GRACE_SEC: "3" } as any), 3000);
-	assert.equal(watchdogGraceMsFromEnv({ KENDEX_AGENT_END_WATCHDOG_GRACE_SEC: "" } as any), WATCHDOG_DEFAULT_GRACE_SEC * 1000);
-	assert.equal(watchdogGraceMsFromEnv({ KENDEX_AGENT_END_WATCHDOG_GRACE_SEC: "garbage" } as any), WATCHDOG_DEFAULT_GRACE_SEC * 1000);
+// label | KENDEX_AGENT_END_WATCHDOG | expect
+const enabledRows: Array<[string, string | undefined, boolean]> = [
+	["unset is on", undefined, true],
+	["empty is on", "", true],
+	["1 is on", "1", true],
+	["0 is off", "0", false],
+	["false is off", "false", false],
+	["off is off", "off", false],
+	["OFF is off", "OFF", false],
+	["a padded 0 is off", " 0 ", false],
+];
+
+test("KENDEX_AGENT_END_WATCHDOG", () => {
+	for (const [label, value, expect] of enabledRows) assert.equal(watchdogEnabledFromEnv(value === undefined ? {} : { KENDEX_AGENT_END_WATCHDOG: value }), expect, label);
+});
+
+const DEFAULT_GRACE_MS = WATCHDOG_DEFAULT_GRACE_SEC * 1000;
+
+// label | KENDEX_AGENT_END_WATCHDOG_GRACE_SEC | expect (ms)
+const graceRows: Array<[string, string | undefined, number]> = [
+	["unset is the default", undefined, DEFAULT_GRACE_MS],
+	["empty is the default", "", DEFAULT_GRACE_MS],
+	["seconds are milliseconds", "3", 3000],
+	["a fraction keeps whole milliseconds", "0.0015", 1],
+	["zero is zero", "0", 0],
+	["a negative is the default", "-1", DEFAULT_GRACE_MS],
+	["garbage is the default", "garbage", DEFAULT_GRACE_MS],
+	["Infinity is the default", "Infinity", DEFAULT_GRACE_MS],
+];
+
+test("KENDEX_AGENT_END_WATCHDOG_GRACE_SEC", () => {
+	for (const [label, value, expect] of graceRows) assert.equal(watchdogGraceMsFromEnv(value === undefined ? {} : { KENDEX_AGENT_END_WATCHDOG_GRACE_SEC: value }), expect, label);
 });


### PR DESCRIPTION
Reshapes `pi-extensions/pi-agents-tmux/tests/agent-end-watchdog.test.ts` to code-quality § Tests: thirteen cases, each a handful of asserts on one grace expiry, plus two lists of bare asserts over the env parsers, become four tables. The watchdog is one table of scripts on a manual scheduler: each step (an agent_end, the grace expiring, a direct check, a real completion landing) reads the task back as one line (the outcome or the check's own reason, fired, pending, live timers, the probes the step made, the payloads written, the marks, the disk at the record's path and at the computed one, the warnings added). The real O_EXCL writer and existence probe are a table of two rows read by the code the loss carries; the two env parsers are tables with a label per value.

## Folded and deleted cases, with the surviving row

| Former case | Surviving row |
|---|---|
| agent_end without complete_subagent writes synthetic needs_completion outbox after grace | `a settled turn with no outbox fires after the grace, writes the synthetic outbox and marks the task` (two lines: armed, then fired with the payload, the mark and the disk); the `/Agent fully settled/` regex is dropped, the payload is pinned by status, reason, refs, the synthetic mark and carrying a summary at all |
| KENDEX_AGENT_END_WATCHDOG=0 disables the watchdog entirely | `a disabled watchdog arms nothing` (refused:disabled, no timer, a grace that fires nothing) |
| race: complete_subagent writes outbox before grace expires | `a real completion during the grace wins and is kept` (the pane is not probed, the disk still reads the real summary) |
| multi-turn: pane is busy when grace expires | `a busy pane at the grace is probed and left alone` (`probes=r1o1i1`, nothing written) |
| successive agent_end events for same task fire only once | `a second agent_end while pending is already scheduled; after the grace it is already fired and checks nothing` (five lines) |
| task record already terminal | `a direct check cancels the pending timer and reads the task terminal` (`skip:task-terminal`, `probes=r1o0i0`); new `a blocked task is terminal`, `a failed task is terminal`, `a task already needing completion is terminal`, `a queued task is active`, `a task with no status yet is active`, `a task of unknown status is active` |
| defaultWriteSyntheticOutbox refuses to overwrite existing outbox; throws ErrnoException with code=EEXIST on race | one writer row `an outbox already on disk is kept and the loss carries EEXIST` (the message regex is dropped: runCheck reads only the code) |
| defaultWriteSyntheticOutbox writes payload when path is free | writer row `a free path is created with the synthetic payload` (`existed=false written exists=true`, the probe read on both sides of the write) |
| writeSyntheticOutbox EEXIST race | `a writer losing the O_EXCL race is a quiet outbox-present` (two checks, no warning, the task may fire later) |
| writeSyntheticOutbox non-EEXIST error | `a writer failing otherwise is warned and the task stays unfired` (`error("disk full")`, `warn=[write-failed("planner/task-watchdog-1: disk full")]`) |
| watchdogEnabledFromEnv parses truthy/falsy values | the `KENDEX_AGENT_END_WATCHDOG` table, eight rows (new: OFF, a padded 0) |
| watchdogGraceMsFromEnv uses default 10s and parses overrides | the `KENDEX_AGENT_END_WATCHDOG_GRACE_SEC` table, nine rows (new: whitespace, a fraction, zero, a negative, Infinity) |

New rows with no former case: a missing task id, a record without an outbox path written at the computed one, a failing mark (warned, the task still counts as fired), an unreadable registry (warned, unfired).

## Recorded, not fixed

- `deps.now` is never read by the watchdog. `checkNow`, `cancel`, `hasPending` and `_atomicWriteSyntheticOutboxFallback` have no production caller (index.ts calls only `onAgentEnd`); the suite drives `checkNow` to read the check's reason enum, which the timer path drops. `cancel` and the fallback writer have no row.
- The second `fired.has` check inside runCheck is reachable only under two concurrent checks on one task (a deferred idle probe would reach it); not covered.
- The writer's permission bits (0o600 file, 0o700 directory) are not read.
- The `raw === ""` clause in `watchdogEnabledFromEnv` is an equivalent mutant: an empty string passes every later comparison.

## Mutation

52 mutants over `agent-end-watchdog.ts`, 51 killed, each by the row named for it; the survivor is the equivalent mutant above. The reviewer round's probe left seventeen survivors, the three blockers among them (the outbox fallback both ways, unknown as terminal, the existence probe failing open); the second commit answers those and the pair-swapped warning, failed and needs_completion as active, the dropped grace trim and a blank summary.

## Checks

- `bun test ./tests/agent-end-watchdog.test.ts`: 4 pass (22 + 2 + 8 + 9 rows). Package: 288 pass.
- `tools/guard --full`: exit 0.
- One reviewer-test round: accepted with three blockers and seven suggestions; the blockers and four of the suggestions applied, the rest recorded above.

KEN-1241

https://claude.ai/code/session_01D6wb5KLMMnPv7njYdSSTzL
