### PR TITLE
test(KEN-1241): idle-stall watchdog as scripts of ticks over one clock

### DIFF
--- a/pi-extensions/pi-agents-tmux/tests/idle-stall-watchdog.test.ts
+++ b/pi-extensions/pi-agents-tmux/tests/idle-stall-watchdog.test.ts
@@ -29,6 +29,7 @@ type Rec = { taskId?: string; status?: PaneTaskStatus; agent?: string; activityA
 interface WorldOpts {
 	enabled?: boolean;
 	now?: number;
+	threshold?: number;
 	records?: Rec[] | "throws";
 	awaitingRetry?: boolean;
 	outboxPresent?: boolean;
@@ -41,7 +42,7 @@ interface World {
 	watchdog: ReturnType<typeof createIdleStallWatchdog>;
 	opts: WorldOpts;
 	probes: { outbox: number; idle: number };
-	writes: StallSyntheticOutboxPayload[];
+	writes: Array<{ file: string; payload: StallSyntheticOutboxPayload }>;
 	marked: string[];
 	warnings: string[];
 	intervals: Array<{ ms: number; handler: () => void; handle: number }>;
@@ -73,10 +74,9 @@ function world(opts: WorldOpts): World {
 		seen: { writes: 0, marked: 0, warnings: 0, probes: { outbox: 0, idle: 0 } },
 	};
 	let nextHandle = 1;
-	const written = new Set<string>();
 	const deps: IdleStallWatchdogDeps = {
 		intervalMs: 60_000,
-		thresholdMs: THRESHOLD_MS,
+		thresholdMs: opts.threshold ?? THRESHOLD_MS,
 		isEnabled: () => w.opts.enabled ?? true,
 		now: () => w.opts.now ?? STALE_NOW,
 		listActiveTasks: async () => {
@@ -88,7 +88,8 @@ function world(opts: WorldOpts): World {
 		outboxExists: async (file) => {
 			w.probes.outbox += 1;
 			if (w.opts.outboxThrows) throw new Error("outbox unreadable");
-			return (w.opts.outboxPresent ?? false) || written.has(file);
+			void file;
+			return w.opts.outboxPresent ?? false;
 		},
 		isPaneIdle: async () => {
 			w.probes.idle += 1;
@@ -98,13 +99,12 @@ function world(opts: WorldOpts): World {
 		writeSyntheticOutbox: opts.writeFails
 			? failing(opts.writeFails)
 			: async (file, payload) => {
-					written.add(file);
-					w.writes.push(payload);
+					w.writes.push({ file, payload });
 				},
 		markFired: opts.markFails
 			? failing(opts.markFails)
-			: async (rec) => {
-					w.marked.push(rec.taskId);
+			: async (rec, payload) => {
+					w.marked.push(payload === w.writes.at(-1)?.payload ? rec.taskId : `${rec.taskId}!payload-mismatch`);
 				},
 		logWarn: (msg) => void w.warnings.push(msg),
 		setInterval: (handler, ms) => {
@@ -120,20 +120,26 @@ function world(opts: WorldOpts): World {
 	return w;
 }
 
-// A warning by the failure it names, with the message it carries; any other
-// line printed whole.
+// A warning by the failure it names, the pair it names and the message it
+// carries; any other line printed whole.
 function warnTag(line: string): string {
-	for (const [needle, tag] of [["writeSyntheticOutbox failed", "write-failed"], ["markFired failed", "mark-failed"], ["unexpected error", "unexpected"], ["listActiveTasks threw", "list-failed"], ["tick threw", "tick-failed"]] as const) {
-		if (line.includes(needle)) return `${tag}(${JSON.stringify(line.slice(line.indexOf(needle) + needle.length).replace(/^.*?: /, ""))})`;
+	for (const [needle, tag] of [["writeSyntheticOutbox failed", "write-failed"], ["markFired failed", "mark-failed"], ["unexpected error", "unexpected"], ["listActiveTasks threw", "list-failed"]] as const) {
+		if (!line.includes(needle)) continue;
+		const rest = line.slice(line.indexOf(needle) + needle.length);
+		const m = /^(?: for (\S+))?: ([\s\S]*)$/.exec(rest);
+		return m ? `${tag}(${m[1] ?? "-"}, ${JSON.stringify(m[2])})` : JSON.stringify(line);
 	}
 	return JSON.stringify(line);
 }
 
-// The payload by its status, reason, refs and synthetic mark, and the one
-// datum it carries about the stall: the seconds in its summary.
-function payloadTag(p: StallSyntheticOutboxPayload): string {
+// The payload by its status, reason, refs and synthetic mark, the one datum
+// it carries about the stall (the seconds in its summary), the fields it
+// carries at all, and the file it was written to.
+function payloadTag(w: { file: string; payload: StallSyntheticOutboxPayload }): string {
+	const p = w.payload;
 	const stale = /for (\d+)s/.exec(p.summary)?.[1] ?? JSON.stringify(p.summary);
-	return `${p.status}/${p.reason}@${p.agent}/${p.taskId}${p.synthetic === true ? "/synthetic" : "/NOT-SYNTHETIC"} stale=${stale}s`;
+	const fields = Object.keys(p).sort().join("+");
+	return `${p.status}/${p.reason}@${p.agent}/${p.taskId}${p.synthetic === true ? "/synthetic" : "/NOT-SYNTHETIC"} stale=${stale}s ${fields} -> ${w.file}`;
 }
 function outcomeTag(o: StallCheckOutcome): string {
 	if (o.fired) return `${o.taskId}:fired`;
@@ -164,15 +170,19 @@ async function runScript(w: World, steps: Step[]): Promise<string> {
 	return lines.join("\n");
 }
 
-const FIRED = `task-1:fired probes=o1i1 +writes=[needs_completion/${STALL_WATCHDOG_REASON}@planner/task-1/synthetic stale=600s] +marked=[task-1]`;
+const FIELDS = "agent+filesChanged+notes+reason+status+summary+synthetic+taskId+validation";
+const PAYLOAD = (agent: string, task: string, stale: number) => `needs_completion/${STALL_WATCHDOG_REASON}@${agent}/${task}/synthetic stale=${stale}s ${FIELDS} -> /outbox/${agent}/${task}.json`;
+const FIRED = `task-1:fired probes=o1i1 +writes=[${PAYLOAD("planner", "task-1", 600)}] +marked=[task-1]`;
 const QUIET = "+writes=[] +marked=[]";
 
 // label | world | ticks | expect (one line per tick)
 const rows: Array<[string, WorldOpts, Step[], string]> = [
 	["an idle task past the threshold with no outbox fires", {}, [tick], FIRED],
-	["exactly at the threshold is stale", { now: LAST_ACTIVITY + THRESHOLD_MS }, [tick], `task-1:fired probes=o1i1 +writes=[needs_completion/${STALL_WATCHDOG_REASON}@planner/task-1/synthetic stale=300s] +marked=[task-1]`],
+	["exactly at the threshold is stale", { now: LAST_ACTIVITY + THRESHOLD_MS }, [tick], `task-1:fired probes=o1i1 +writes=[${PAYLOAD("planner", "task-1", 300)}] +marked=[task-1]`],
 	["one millisecond under the threshold is not", { now: LAST_ACTIVITY + THRESHOLD_MS - 1 }, [tick], `task-1:skip:not-stale probes=o1i0 ${QUIET}`],
 	["activity far in the future is not stale", { now: LAST_ACTIVITY - 600_000 }, [tick], `task-1:skip:not-stale probes=o1i0 ${QUIET}`],
+	["a part second is not counted", { now: LAST_ACTIVITY + 600_999 }, [tick], FIRED],
+	["at a zero threshold activity in the future counts as no stall and fires", { now: LAST_ACTIVITY - 600_000, threshold: 0 }, [tick], `task-1:fired probes=o1i1 +writes=[${PAYLOAD("planner", "task-1", 0)}] +marked=[task-1]`],
 	["a pane awaiting a rate-limit retry is not condemned until the retry state clears", { awaitingRetry: true }, [tick, retryCleared, tick], [`task-1:skip:rate-limited probes=o0i0 ${QUIET}`, `retry-cleared probes=o0i0 ${QUIET}`, FIRED].join("\n")],
 	["an outbox already present", { outboxPresent: true }, [tick], `task-1:skip:outbox-present probes=o1i0 ${QUIET}`],
 	["a busy pane", { paneIdle: false }, [tick], `task-1:skip:pane-busy probes=o1i1 ${QUIET}`],
@@ -185,12 +195,12 @@ const rows: Array<[string, WorldOpts, Step[], string]> = [
 	["a task of unknown status is judged", { records: [{ status: "unknown" }] }, [tick], FIRED],
 	["a record without a task id", { records: [{ taskId: "" }] }, [tick], `:skip:missing-task-id probes=o0i0 ${QUIET}`],
 	["a fired task is not fired again on the next tick", {}, [tick, tick], [FIRED, `task-1:skip:already-fired probes=o0i0 ${QUIET}`].join("\n")],
-	["every listed task is judged in order and on its own", { records: [{}, { activityAt: STALE_NOW, taskId: "task-2" }, { agent: "scout", taskId: "task-3" }] }, [tick], `task-1:fired task-2:skip:not-stale task-3:fired probes=o3i2 +writes=[needs_completion/${STALL_WATCHDOG_REASON}@planner/task-1/synthetic stale=600s,needs_completion/${STALL_WATCHDOG_REASON}@scout/task-3/synthetic stale=600s] +marked=[task-1,task-3]`],
+	["every listed task is judged in order and on its own", { records: [{}, { activityAt: STALE_NOW, taskId: "task-2" }, { agent: "scout", taskId: "task-3" }] }, [tick], `task-1:fired task-2:skip:not-stale task-3:fired probes=o3i2 +writes=[${PAYLOAD("planner", "task-1", 600)},${PAYLOAD("scout", "task-3", 600)}] +marked=[task-1,task-3]`],
 	["a writer losing the O_EXCL race is a quiet race-lost and the task may fire later", { writeFails: { code: "EEXIST", message: "outbox already exists" } }, [tick, tick], [`task-1:skip:race-lost probes=o1i1 ${QUIET}`, `task-1:skip:race-lost probes=o1i1 ${QUIET}`].join("\n")],
-	["a writer failing otherwise is warned and the task stays unfired", { writeFails: { code: "ENOSPC", message: "disk full" } }, [tick], `task-1:error("disk full") probes=o1i1 ${QUIET} warn=[write-failed("disk full")]`],
-	["a failing mark is warned after the write and the task counts as fired", { markFails: { message: "registry locked" } }, [tick, tick], [`task-1:fired probes=o1i1 +writes=[needs_completion/${STALL_WATCHDOG_REASON}@planner/task-1/synthetic stale=600s] +marked=[] warn=[mark-failed("registry locked")]`, `task-1:skip:already-fired probes=o0i0 ${QUIET}`].join("\n")],
-	["an unreadable registry is warned and the tick judges nothing", { records: "throws" }, [tick], `none probes=o0i0 ${QUIET} warn=[list-failed("registry unreadable")]`],
-	["a probe that throws is warned and the task stays unfired", { outboxThrows: true }, [tick], `task-1:error("outbox unreadable") probes=o1i0 ${QUIET} warn=[unexpected("outbox unreadable")]`],
+	["a writer failing otherwise is warned and the task stays unfired", { writeFails: { code: "ENOSPC", message: "disk full" } }, [tick], `task-1:error("disk full") probes=o1i1 ${QUIET} warn=[write-failed(planner/task-1, "disk full")]`],
+	["a failing mark is warned after the write and the task counts as fired", { markFails: { message: "registry locked" } }, [tick, tick], [`task-1:fired probes=o1i1 +writes=[${PAYLOAD("planner", "task-1", 600)}] +marked=[] warn=[mark-failed(planner/task-1, "registry locked")]`, `task-1:skip:already-fired probes=o0i0 ${QUIET}`].join("\n")],
+	["an unreadable registry is warned and the tick judges nothing", { records: "throws" }, [tick], `none probes=o0i0 ${QUIET} warn=[list-failed(-, "registry unreadable")]`],
+	["a probe that throws is warned and the task stays unfired", { outboxThrows: true }, [tick], `task-1:error("outbox unreadable") probes=o1i0 ${QUIET} warn=[unexpected(planner/task-1, "outbox unreadable")]`],
 ];
 
 test("the idle-stall watchdog", async () => {

--- a/pi-extensions/pi-agents-tmux/tests/idle-stall-watchdog.test.ts
+++ b/pi-extensions/pi-agents-tmux/tests/idle-stall-watchdog.test.ts
@@ -1,300 +1,272 @@
-// The polling watchdog detects subagent tasks that
-// stall after pi-core auto-compaction (no agent_end ever fires) and
-// writes a synthetic needs_completion outbox so the parent's existing
-// wake path takes over.
+// The idle-stall watchdog as scripts over an injected clock and registry:
+// each row is a world (the records the registry lists, whether the pane is
+// idle, what the outbox and the writer do) and a script of ticks, read back
+// after every tick as one line. The poll timer and the three env parsers are
+// tables of their own.
 
 import assert from "node:assert/strict";
 import test from "node:test";
 import {
 	createIdleStallWatchdog,
-	stallWatchdogEnabledFromEnv,
-	stallWatchdogIntervalMsFromEnv,
-	stallWatchdogThresholdMsFromEnv,
+	type IdleStallWatchdogDeps,
 	STALL_WATCHDOG_DEFAULT_INTERVAL_SEC,
 	STALL_WATCHDOG_DEFAULT_THRESHOLD_SEC,
 	STALL_WATCHDOG_REASON,
-	type IdleStallWatchdogDeps,
+	type StallCheckOutcome,
 	type StallSyntheticOutboxPayload,
+	stallWatchdogEnabledFromEnv,
+	stallWatchdogIntervalMsFromEnv,
+	stallWatchdogThresholdMsFromEnv,
 } from "../extensions/subagent/idle-stall-watchdog.js";
-import type { PaneTaskRecord } from "../extensions/subagent/types.js";
+import type { PaneTaskRecord, PaneTaskStatus } from "../extensions/subagent/types.js";
 
-interface HarnessOptions {
-	awaitingRetry?: (rec: PaneTaskRecord) => boolean;
+const LAST_ACTIVITY = Date.parse("2026-05-15T12:00:00.000Z");
+const THRESHOLD_MS = 300_000;
+const STALE_NOW = LAST_ACTIVITY + 600_000;
+
+type Failure = { code?: string; message: string };
+type Rec = { taskId?: string; status?: PaneTaskStatus; agent?: string; activityAt?: number };
+interface WorldOpts {
 	enabled?: boolean;
-	thresholdMs?: number;
-	intervalMs?: number;
-	nowEpochMs?: number;
-	records?: PaneTaskRecord[];
-	outboxExisting?: Set<string>;
-	paneIdle?: (record: PaneTaskRecord) => boolean;
-	writeFails?: (outboxFile: string) => Error | null;
+	now?: number;
+	records?: Rec[] | "throws";
+	awaitingRetry?: boolean;
+	outboxPresent?: boolean;
+	outboxThrows?: boolean;
+	paneIdle?: boolean;
+	writeFails?: Failure;
+	markFails?: Failure;
 }
-
-interface Harness {
-	deps: IdleStallWatchdogDeps;
-	writes: Array<{ outboxFile: string; payload: StallSyntheticOutboxPayload }>;
-	markFiredCalls: Array<{ taskId: string; payload: StallSyntheticOutboxPayload }>;
+interface World {
+	watchdog: ReturnType<typeof createIdleStallWatchdog>;
+	opts: WorldOpts;
+	probes: { outbox: number; idle: number };
+	writes: StallSyntheticOutboxPayload[];
+	marked: string[];
 	warnings: string[];
-	outboxExisting: Set<string>;
-	scheduled: Array<{ ms: number; handler: () => void; handle: number }>;
+	intervals: Array<{ ms: number; handler: () => void; handle: number }>;
+	seen: { writes: number; marked: number; warnings: number; probes: { outbox: number; idle: number } };
 }
 
-function record(overrides: Partial<PaneTaskRecord>): PaneTaskRecord {
-	return {
-		taskId: "task-1",
-		agent: "planner",
-		task: "Plan.",
-		status: "running",
-		createdAt: "2026-05-15T12:00:00.000Z",
-		updatedAt: "2026-05-15T12:00:00.000Z",
-		...overrides,
+function failing(failure: Failure): () => Promise<never> {
+	return async () => {
+		const err: NodeJS.ErrnoException = new Error(failure.message);
+		if (failure.code) err.code = failure.code;
+		throw err;
 	};
 }
 
-function outboxPathFor(rec: PaneTaskRecord): string {
-	return rec.outboxFile ?? `/tmp/${rec.agent}/${rec.taskId}.json`;
+function record(rec: Rec): PaneTaskRecord {
+	const activity = new Date(rec.activityAt ?? LAST_ACTIVITY).toISOString();
+	return { agent: rec.agent ?? "planner", createdAt: activity, status: rec.status ?? "running", task: "Plan.", taskId: rec.taskId ?? "task-1", updatedAt: activity };
 }
 
-function makeHarness(opts: HarnessOptions = {}): Harness {
-	const writes: Harness["writes"] = [];
-	const markFiredCalls: Harness["markFiredCalls"] = [];
-	const warnings: string[] = [];
-	const outboxExisting = opts.outboxExisting ?? new Set<string>();
-	const scheduled: Harness["scheduled"] = [];
+function world(opts: WorldOpts): World {
+	const w: World = {
+		watchdog: undefined as never,
+		opts,
+		probes: { outbox: 0, idle: 0 },
+		writes: [],
+		marked: [],
+		warnings: [],
+		intervals: [],
+		seen: { writes: 0, marked: 0, warnings: 0, probes: { outbox: 0, idle: 0 } },
+	};
 	let nextHandle = 1;
-	const records = opts.records ?? [];
+	const written = new Set<string>();
 	const deps: IdleStallWatchdogDeps = {
-		intervalMs: opts.intervalMs ?? 60_000,
-		thresholdMs: opts.thresholdMs ?? 300_000,
-		isEnabled: () => opts.enabled ?? true,
-		now: () => opts.nowEpochMs ?? Date.now(),
-		listActiveTasks: async () => records,
-		isAwaitingRateLimitRetry: (rec) => (opts.awaitingRetry ? opts.awaitingRetry(rec) : false),
-		outboxExists: async (file) => outboxExisting.has(file),
-		outboxPathFor,
-		isPaneIdle: async (rec) => (opts.paneIdle ? opts.paneIdle(rec) : true),
-		lastActivityAt: (rec) => {
-			const raw = rec.updatedAt ?? rec.completedAt ?? rec.createdAt;
-			if (!raw) return 0;
-			const ts = Date.parse(raw);
-			return Number.isFinite(ts) ? ts : 0;
+		intervalMs: 60_000,
+		thresholdMs: THRESHOLD_MS,
+		isEnabled: () => w.opts.enabled ?? true,
+		now: () => w.opts.now ?? STALE_NOW,
+		listActiveTasks: async () => {
+			if (w.opts.records === "throws") throw new Error("registry unreadable");
+			return (w.opts.records ?? [{}]).map(record);
 		},
-		writeSyntheticOutbox: async (file, payload) => {
-			const err = opts.writeFails?.(file);
-			if (err) throw err;
-			outboxExisting.add(file);
-			writes.push({ outboxFile: file, payload });
+		isAwaitingRateLimitRetry: () => w.opts.awaitingRetry ?? false,
+		outboxPathFor: (rec) => `/outbox/${rec.agent}/${rec.taskId}.json`,
+		outboxExists: async (file) => {
+			w.probes.outbox += 1;
+			if (w.opts.outboxThrows) throw new Error("outbox unreadable");
+			return (w.opts.outboxPresent ?? false) || written.has(file);
 		},
-		markFired: async (rec, payload) => {
-			markFiredCalls.push({ taskId: rec.taskId, payload });
+		isPaneIdle: async () => {
+			w.probes.idle += 1;
+			return w.opts.paneIdle ?? true;
 		},
-		logWarn: (msg) => warnings.push(msg),
+		lastActivityAt: (rec) => Date.parse(rec.updatedAt ?? ""),
+		writeSyntheticOutbox: opts.writeFails
+			? failing(opts.writeFails)
+			: async (file, payload) => {
+					written.add(file);
+					w.writes.push(payload);
+				},
+		markFired: opts.markFails
+			? failing(opts.markFails)
+			: async (rec) => {
+					w.marked.push(rec.taskId);
+				},
+		logWarn: (msg) => void w.warnings.push(msg),
 		setInterval: (handler, ms) => {
 			const handle = nextHandle++;
-			scheduled.push({ ms, handler, handle });
+			w.intervals.push({ handle, handler, ms });
 			return handle;
 		},
 		clearInterval: (handle) => {
-			const idx = scheduled.findIndex((entry) => entry.handle === handle);
-			if (idx >= 0) scheduled.splice(idx, 1);
+			w.intervals = w.intervals.filter((entry) => entry.handle !== handle);
 		},
 	};
-	return { deps, writes, markFiredCalls, warnings, outboxExisting, scheduled };
+	w.watchdog = createIdleStallWatchdog(deps);
+	return w;
 }
 
-test("task idle past threshold with no outbox -> writes synthetic outbox", async () => {
-	const now = Date.parse("2026-05-15T12:10:00.000Z"); // 600s after last activity
-	const harness = makeHarness({
-		nowEpochMs: now,
-		thresholdMs: 300_000,
-		records: [record({ updatedAt: "2026-05-15T12:00:00.000Z" })],
-	});
-	const watchdog = createIdleStallWatchdog(harness.deps);
-	const outcomes = await watchdog.checkAll();
-	assert.equal(outcomes.length, 1);
-	assert.equal(outcomes[0]?.fired, true);
-	assert.equal(harness.writes.length, 1);
-	const payload = harness.writes[0]?.payload!;
-	assert.equal(payload.status, "needs_completion");
-	assert.equal(payload.reason, STALL_WATCHDOG_REASON);
-	assert.equal(payload.synthetic, true);
-	assert.match(payload.summary, /idle with no progress .*cause undetermined/);
-	assert.equal(harness.markFiredCalls.length, 1);
+// A warning by the failure it names, with the message it carries; any other
+// line printed whole.
+function warnTag(line: string): string {
+	for (const [needle, tag] of [["writeSyntheticOutbox failed", "write-failed"], ["markFired failed", "mark-failed"], ["unexpected error", "unexpected"], ["listActiveTasks threw", "list-failed"], ["tick threw", "tick-failed"]] as const) {
+		if (line.includes(needle)) return `${tag}(${JSON.stringify(line.slice(line.indexOf(needle) + needle.length).replace(/^.*?: /, ""))})`;
+	}
+	return JSON.stringify(line);
+}
+
+// The payload by its status, reason, refs and synthetic mark, and the one
+// datum it carries about the stall: the seconds in its summary.
+function payloadTag(p: StallSyntheticOutboxPayload): string {
+	const stale = /for (\d+)s/.exec(p.summary)?.[1] ?? JSON.stringify(p.summary);
+	return `${p.status}/${p.reason}@${p.agent}/${p.taskId}${p.synthetic === true ? "/synthetic" : "/NOT-SYNTHETIC"} stale=${stale}s`;
+}
+function outcomeTag(o: StallCheckOutcome): string {
+	if (o.fired) return `${o.taskId}:fired`;
+	if (o.error !== undefined) return `${o.taskId}:error(${JSON.stringify(o.error)})`;
+	return `${o.taskId}:skip:${o.skipped}`;
+}
+
+// A tick is one checkAll; its line is the outcomes in registry order, then
+// the probes, writes, marks and warnings the tick added.
+type Step = (w: World) => Promise<string> | string;
+const tick: Step = async (w) => (await w.watchdog.checkAll()).map(outcomeTag).join(" ") || "none";
+const retryCleared: Step = (w) => {
+	w.opts.awaitingRetry = false;
+	return "retry-cleared";
+};
+
+async function runScript(w: World, steps: Step[]): Promise<string> {
+	const lines: string[] = [];
+	for (const step of steps) {
+		const head = await step(w);
+		const probes = `o${w.probes.outbox - w.seen.probes.outbox}i${w.probes.idle - w.seen.probes.idle}`;
+		const wrote = w.writes.slice(w.seen.writes).map(payloadTag);
+		const marks = w.marked.slice(w.seen.marked);
+		const warned = w.warnings.slice(w.seen.warnings).map(warnTag);
+		w.seen = { writes: w.writes.length, marked: w.marked.length, warnings: w.warnings.length, probes: { ...w.probes } };
+		lines.push(`${head} probes=${probes} +writes=[${wrote.join(",")}] +marked=[${marks.join(",")}]${warned.length ? ` warn=[${warned.join(",")}]` : ""}`);
+	}
+	return lines.join("\n");
+}
+
+const FIRED = `task-1:fired probes=o1i1 +writes=[needs_completion/${STALL_WATCHDOG_REASON}@planner/task-1/synthetic stale=600s] +marked=[task-1]`;
+const QUIET = "+writes=[] +marked=[]";
+
+// label | world | ticks | expect (one line per tick)
+const rows: Array<[string, WorldOpts, Step[], string]> = [
+	["an idle task past the threshold with no outbox fires", {}, [tick], FIRED],
+	["exactly at the threshold is stale", { now: LAST_ACTIVITY + THRESHOLD_MS }, [tick], `task-1:fired probes=o1i1 +writes=[needs_completion/${STALL_WATCHDOG_REASON}@planner/task-1/synthetic stale=300s] +marked=[task-1]`],
+	["one millisecond under the threshold is not", { now: LAST_ACTIVITY + THRESHOLD_MS - 1 }, [tick], `task-1:skip:not-stale probes=o1i0 ${QUIET}`],
+	["activity far in the future is not stale", { now: LAST_ACTIVITY - 600_000 }, [tick], `task-1:skip:not-stale probes=o1i0 ${QUIET}`],
+	["a pane awaiting a rate-limit retry is not condemned until the retry state clears", { awaitingRetry: true }, [tick, retryCleared, tick], [`task-1:skip:rate-limited probes=o0i0 ${QUIET}`, `retry-cleared probes=o0i0 ${QUIET}`, FIRED].join("\n")],
+	["an outbox already present", { outboxPresent: true }, [tick], `task-1:skip:outbox-present probes=o1i0 ${QUIET}`],
+	["a busy pane", { paneIdle: false }, [tick], `task-1:skip:pane-busy probes=o1i1 ${QUIET}`],
+	["a disabled watchdog checks nothing", { enabled: false }, [tick], `:skip:disabled probes=o0i0 ${QUIET}`],
+	["a completed task is terminal", { records: [{ status: "completed" }] }, [tick], `task-1:skip:task-terminal probes=o0i0 ${QUIET}`],
+	["a failed task is terminal", { records: [{ status: "failed" }] }, [tick], `task-1:skip:task-terminal probes=o0i0 ${QUIET}`],
+	["a blocked task is terminal", { records: [{ status: "blocked" }] }, [tick], `task-1:skip:task-terminal probes=o0i0 ${QUIET}`],
+	["a task already needing completion", { records: [{ status: "needs_completion" }] }, [tick], `task-1:skip:task-needs-completion probes=o0i0 ${QUIET}`],
+	["a queued task is judged", { records: [{ status: "queued" }] }, [tick], FIRED],
+	["a task of unknown status is judged", { records: [{ status: "unknown" }] }, [tick], FIRED],
+	["a record without a task id", { records: [{ taskId: "" }] }, [tick], `:skip:missing-task-id probes=o0i0 ${QUIET}`],
+	["a fired task is not fired again on the next tick", {}, [tick, tick], [FIRED, `task-1:skip:already-fired probes=o0i0 ${QUIET}`].join("\n")],
+	["every listed task is judged in order and on its own", { records: [{}, { activityAt: STALE_NOW, taskId: "task-2" }, { agent: "scout", taskId: "task-3" }] }, [tick], `task-1:fired task-2:skip:not-stale task-3:fired probes=o3i2 +writes=[needs_completion/${STALL_WATCHDOG_REASON}@planner/task-1/synthetic stale=600s,needs_completion/${STALL_WATCHDOG_REASON}@scout/task-3/synthetic stale=600s] +marked=[task-1,task-3]`],
+	["a writer losing the O_EXCL race is a quiet race-lost and the task may fire later", { writeFails: { code: "EEXIST", message: "outbox already exists" } }, [tick, tick], [`task-1:skip:race-lost probes=o1i1 ${QUIET}`, `task-1:skip:race-lost probes=o1i1 ${QUIET}`].join("\n")],
+	["a writer failing otherwise is warned and the task stays unfired", { writeFails: { code: "ENOSPC", message: "disk full" } }, [tick], `task-1:error("disk full") probes=o1i1 ${QUIET} warn=[write-failed("disk full")]`],
+	["a failing mark is warned after the write and the task counts as fired", { markFails: { message: "registry locked" } }, [tick, tick], [`task-1:fired probes=o1i1 +writes=[needs_completion/${STALL_WATCHDOG_REASON}@planner/task-1/synthetic stale=600s] +marked=[] warn=[mark-failed("registry locked")]`, `task-1:skip:already-fired probes=o0i0 ${QUIET}`].join("\n")],
+	["an unreadable registry is warned and the tick judges nothing", { records: "throws" }, [tick], `none probes=o0i0 ${QUIET} warn=[list-failed("registry unreadable")]`],
+	["a probe that throws is warned and the task stays unfired", { outboxThrows: true }, [tick], `task-1:error("outbox unreadable") probes=o1i0 ${QUIET} warn=[unexpected("outbox unreadable")]`],
+];
+
+test("the idle-stall watchdog", async () => {
+	for (const [label, opts, steps, expect] of rows) assert.equal(await runScript(world(opts), steps), expect, label);
 });
 
-test("a pane is not condemned while awaiting a rate-limit retry (skipped: rate-limited)", async () => {
-	const now = Date.parse("2026-05-15T12:10:00.000Z");
-	const harness = makeHarness({
-		awaitingRetry: (rec) => rec.agent === "planner",
-		nowEpochMs: now,
-		records: [record({ updatedAt: "2026-05-15T12:00:00.000Z" })],
-	});
-	const watchdog = createIdleStallWatchdog(harness.deps);
-	const outcomes = await watchdog.checkAll();
-	assert.equal(outcomes[0]?.fired, false);
-	assert.equal(outcomes[0]?.skipped, "rate-limited");
-	assert.equal(harness.writes.length, 0);
-	// The gate clears once the retry state does — the same pane is judged
-	// normally on the next tick.
-	const after = makeHarness({ nowEpochMs: now, records: [record({ updatedAt: "2026-05-15T12:00:00.000Z" })] });
-	const second = createIdleStallWatchdog(after.deps);
-	const later = await second.checkAll();
-	assert.equal(later[0]?.fired, true);
+// The poll: start arms one interval at the configured cadence, its handler
+// runs a tick, stop clears it; each step reads back the timer state and what
+// the step wrote.
+const start: Step = (w) => (w.watchdog.start(), "start");
+const stop: Step = (w) => (w.watchdog.stop(), "stop");
+const fireTimer: Step = async (w) => {
+	for (const entry of w.intervals) entry.handler();
+	await new Promise((resolve) => setTimeout(resolve, 0));
+	await new Promise((resolve) => setTimeout(resolve, 0));
+	return `fire(${w.intervals.map((e) => e.ms).join(",") || "none"})`;
+};
+async function runPoll(w: World, steps: Step[]): Promise<string> {
+	const lines: string[] = [];
+	for (const step of steps) {
+		const head = await step(w);
+		const wrote = w.writes.slice(w.seen.writes).length;
+		w.seen.writes = w.writes.length;
+		lines.push(`${head} running=${w.watchdog.isRunning()} intervals=[${w.intervals.map((e) => e.ms).join(",")}] +writes=${wrote}`);
+	}
+	return lines.join("\n");
+}
+
+// label | world | steps | expect
+const pollRows: Array<[string, WorldOpts, Step[], string]> = [
+	["start arms one interval whose handler ticks, and stop clears it", {}, [start, fireTimer, stop, fireTimer], ["start running=true intervals=[60000] +writes=0", "fire(60000) running=true intervals=[60000] +writes=1", "stop running=false intervals=[] +writes=0", "fire(none) running=false intervals=[] +writes=0"].join("\n")],
+	["a second start does not arm a second interval, a second stop is idle", {}, [start, start, stop, stop], ["start running=true intervals=[60000] +writes=0", "start running=true intervals=[60000] +writes=0", "stop running=false intervals=[] +writes=0", "stop running=false intervals=[] +writes=0"].join("\n")],
+	["a disabled watchdog does not start", { enabled: false }, [start], "start running=false intervals=[] +writes=0"],
+];
+
+test("the poll timer", async () => {
+	for (const [label, opts, steps, expect] of pollRows) assert.equal(await runPoll(world(opts), steps), expect, label);
 });
 
-test("task with existing outbox -> no synthetic write (skipped: outbox-present)", async () => {
-	const now = Date.parse("2026-05-15T12:10:00.000Z");
-	const harness = makeHarness({
-		nowEpochMs: now,
-		records: [record({ updatedAt: "2026-05-15T12:00:00.000Z" })],
-		outboxExisting: new Set([outboxPathFor(record({}))]),
-	});
-	const watchdog = createIdleStallWatchdog(harness.deps);
-	const outcomes = await watchdog.checkAll();
-	assert.equal(outcomes[0]?.fired, false);
-	assert.equal(outcomes[0]?.skipped, "outbox-present");
-	assert.equal(harness.writes.length, 0);
+// label | KENDEX_STALL_WATCHDOG | expect
+const enabledRows: Array<[string, string | undefined, boolean]> = [
+	["unset is on", undefined, true],
+	["empty is on", "", true],
+	["1 is on", "1", true],
+	["0 is off", "0", false],
+	["false is off", "false", false],
+	["OFF is off", "OFF", false],
+	["a padded 0 is off", " 0 ", false],
+];
+
+test("KENDEX_STALL_WATCHDOG", () => {
+	for (const [label, value, expect] of enabledRows) assert.equal(stallWatchdogEnabledFromEnv(value === undefined ? {} : { KENDEX_STALL_WATCHDOG: value }), expect, label);
 });
 
-test("task pane busy (not idle) -> no synthetic write", async () => {
-	const now = Date.parse("2026-05-15T12:10:00.000Z");
-	const harness = makeHarness({
-		nowEpochMs: now,
-		records: [record({ updatedAt: "2026-05-15T12:00:00.000Z" })],
-		paneIdle: () => false,
-	});
-	const watchdog = createIdleStallWatchdog(harness.deps);
-	const outcomes = await watchdog.checkAll();
-	assert.equal(outcomes[0]?.skipped, "pane-busy");
-	assert.equal(harness.writes.length, 0);
-});
+// The interval and threshold parsers share one grammar and differ in their
+// default; every row runs through both.
+const parsers: Array<[string, (env: NodeJS.ProcessEnv) => number, string, number]> = [
+	["interval", stallWatchdogIntervalMsFromEnv, "KENDEX_STALL_WATCHDOG_INTERVAL_SEC", STALL_WATCHDOG_DEFAULT_INTERVAL_SEC * 1000],
+	["threshold", stallWatchdogThresholdMsFromEnv, "KENDEX_STALL_WATCHDOG_THRESHOLD_SEC", STALL_WATCHDOG_DEFAULT_THRESHOLD_SEC * 1000],
+];
 
-test("task not yet stale (within threshold) -> no synthetic write", async () => {
-	const now = Date.parse("2026-05-15T12:02:00.000Z"); // 120s after last activity
-	const harness = makeHarness({
-		nowEpochMs: now,
-		thresholdMs: 300_000,
-		records: [record({ updatedAt: "2026-05-15T12:00:00.000Z" })],
-	});
-	const watchdog = createIdleStallWatchdog(harness.deps);
-	const outcomes = await watchdog.checkAll();
-	assert.equal(outcomes[0]?.skipped, "not-stale");
-	assert.equal(harness.writes.length, 0);
-});
+// label | value | expect (ms, or "default")
+const secondsRows: Array<[string, string | undefined, number | "default"]> = [
+	["unset is the default", undefined, "default"],
+	["empty is the default", "", "default"],
+	["seconds are milliseconds", "10", 10_000],
+	["a fraction keeps whole milliseconds", "0.0015", 1],
+	["zero is zero", "0", 0],
+	["a negative is the default", "-1", "default"],
+	["garbage is the default", "garbage", "default"],
+	["Infinity is the default", "Infinity", "default"],
+];
 
-test("watchdog disabled via env flag -> no checkAll, no writes", async () => {
-	const harness = makeHarness({
-		enabled: false,
-		records: [record({ updatedAt: "2026-01-01T00:00:00.000Z" })],
-	});
-	const watchdog = createIdleStallWatchdog(harness.deps);
-	const outcomes = await watchdog.checkAll();
-	assert.equal(outcomes.length, 1);
-	assert.equal(outcomes[0]?.skipped, "disabled");
-	assert.equal(harness.writes.length, 0);
-});
-
-test("terminal status (completed) is skipped", async () => {
-	const now = Date.parse("2026-05-15T13:00:00.000Z");
-	const harness = makeHarness({
-		nowEpochMs: now,
-		records: [record({ status: "completed", updatedAt: "2026-05-15T12:00:00.000Z" })],
-	});
-	const watchdog = createIdleStallWatchdog(harness.deps);
-	const outcomes = await watchdog.checkAll();
-	assert.equal(outcomes[0]?.skipped, "task-terminal");
-});
-
-test("status already needs_completion is skipped", async () => {
-	const now = Date.parse("2026-05-15T13:00:00.000Z");
-	const harness = makeHarness({
-		nowEpochMs: now,
-		records: [record({ status: "needs_completion", updatedAt: "2026-05-15T12:00:00.000Z" })],
-	});
-	const watchdog = createIdleStallWatchdog(harness.deps);
-	const outcomes = await watchdog.checkAll();
-	assert.equal(outcomes[0]?.skipped, "task-needs-completion");
-});
-
-test("successive checks for same task fire only once", async () => {
-	const now = Date.parse("2026-05-15T13:00:00.000Z");
-	const harness = makeHarness({
-		nowEpochMs: now,
-		records: [record({ updatedAt: "2026-05-15T12:00:00.000Z" })],
-	});
-	const watchdog = createIdleStallWatchdog(harness.deps);
-	await watchdog.checkAll();
-	const second = await watchdog.checkAll();
-	assert.equal(second[0]?.fired, false);
-	assert.equal(second[0]?.skipped, "already-fired");
-	assert.equal(harness.writes.length, 1, "exactly one synthetic outbox over two ticks");
-});
-
-test("write EEXIST is treated as race-lost (no error log)", async () => {
-	const now = Date.parse("2026-05-15T13:00:00.000Z");
-	const harness = makeHarness({
-		nowEpochMs: now,
-		records: [record({ updatedAt: "2026-05-15T12:00:00.000Z" })],
-		writeFails: () => {
-			const err: NodeJS.ErrnoException = new Error("EEXIST race-loss");
-			err.code = "EEXIST";
-			return err;
-		},
-	});
-	const watchdog = createIdleStallWatchdog(harness.deps);
-	const outcomes = await watchdog.checkAll();
-	assert.equal(outcomes[0]?.fired, false);
-	assert.equal(outcomes[0]?.skipped, "race-lost");
-	assert.equal(harness.warnings.length, 0, "EEXIST is healthy race-loss; no warn-log");
-});
-
-test("write ENOSPC (non-EEXIST) logs warning and records error", async () => {
-	const now = Date.parse("2026-05-15T13:00:00.000Z");
-	const harness = makeHarness({
-		nowEpochMs: now,
-		records: [record({ updatedAt: "2026-05-15T12:00:00.000Z" })],
-		writeFails: () => {
-			const err: NodeJS.ErrnoException = new Error("disk full");
-			err.code = "ENOSPC";
-			return err;
-		},
-	});
-	const watchdog = createIdleStallWatchdog(harness.deps);
-	const outcomes = await watchdog.checkAll();
-	assert.equal(outcomes[0]?.fired, false);
-	assert.ok(outcomes[0]?.error);
-	assert.ok(
-		harness.warnings.some((w) => w.includes("writeSyntheticOutbox failed") && w.includes("disk full")),
-		`expected disk-full warn, got: ${JSON.stringify(harness.warnings)}`,
-	);
-});
-
-test("start() schedules a poll on the injected setInterval", () => {
-	const harness = makeHarness({ intervalMs: 60_000 });
-	const watchdog = createIdleStallWatchdog(harness.deps);
-	watchdog.start();
-	assert.equal(harness.scheduled.length, 1);
-	assert.equal(harness.scheduled[0]?.ms, 60_000);
-	assert.equal(watchdog.isRunning(), true);
-	watchdog.stop();
-	assert.equal(harness.scheduled.length, 0);
-	assert.equal(watchdog.isRunning(), false);
-});
-
-test("start() is a no-op when watchdog is disabled", () => {
-	const harness = makeHarness({ enabled: false });
-	const watchdog = createIdleStallWatchdog(harness.deps);
-	watchdog.start();
-	assert.equal(harness.scheduled.length, 0);
-	assert.equal(watchdog.isRunning(), false);
-});
-
-test("env parsers honor defaults and overrides", () => {
-	assert.equal(stallWatchdogEnabledFromEnv({} as NodeJS.ProcessEnv), true);
-	assert.equal(stallWatchdogEnabledFromEnv({ KENDEX_STALL_WATCHDOG: "0" } as any), false);
-	assert.equal(stallWatchdogEnabledFromEnv({ KENDEX_STALL_WATCHDOG: "false" } as any), false);
-	assert.equal(stallWatchdogIntervalMsFromEnv({} as NodeJS.ProcessEnv), STALL_WATCHDOG_DEFAULT_INTERVAL_SEC * 1000);
-	assert.equal(stallWatchdogIntervalMsFromEnv({ KENDEX_STALL_WATCHDOG_INTERVAL_SEC: "10" } as any), 10_000);
-	assert.equal(stallWatchdogThresholdMsFromEnv({} as NodeJS.ProcessEnv), STALL_WATCHDOG_DEFAULT_THRESHOLD_SEC * 1000);
-	assert.equal(stallWatchdogThresholdMsFromEnv({ KENDEX_STALL_WATCHDOG_THRESHOLD_SEC: "30" } as any), 30_000);
+test("KENDEX_STALL_WATCHDOG_INTERVAL_SEC and _THRESHOLD_SEC", () => {
+	for (const [name, parse, key, defaultMs] of parsers) {
+		for (const [label, value, expect] of secondsRows) assert.equal(parse(value === undefined ? {} : { [key]: value }), expect === "default" ? defaultMs : expect, `${name}: ${label}`);
+	}
+	assert.notEqual(stallWatchdogIntervalMsFromEnv({}), stallWatchdogThresholdMsFromEnv({}), "the two defaults differ");
 });


### PR DESCRIPTION
Reshapes `pi-extensions/pi-agents-tmux/tests/idle-stall-watchdog.test.ts` to code-quality § Tests: fourteen cases, each a few asserts on one checkAll, plus one list of bare asserts over three env parsers, become four tables. The watchdog is one table of scripts over an injected clock and registry: each tick reads back the outcomes in registry order (fired, the skip reason, or the error), the probes the tick made, the payloads written (status, reason, refs, the stall seconds, the fields carried, the file), the marks and the warnings by the failure, the pair and the message they name. The poll timer is a table of scripts (start, the handler firing a tick, stop); the three parsers are tables with a label per value, the two seconds parsers sharing one row list.

## Folded and deleted cases, with the surviving row

| Former case | Surviving row |
|---|---|
| task idle past threshold with no outbox writes synthetic outbox | `an idle task past the threshold with no outbox fires`; the `/idle with no progress .*cause undetermined/` regex is dropped, the summary's seconds are extracted as the one datum it carries; new `exactly at the threshold is stale`, `one millisecond under the threshold is not`, `a part second is not counted` |
| a pane is not condemned while awaiting a rate-limit retry | `a pane awaiting a rate-limit retry is not condemned until the retry state clears` (three steps on the same watchdog; the old case built a second one) |
| task with existing outbox | `an outbox already present` (`probes=o1i0`) |
| task pane busy | `a busy pane` (`probes=o1i1`) |
| task not yet stale | `one millisecond under the threshold is not`; new `activity far in the future is not stale`, `at a zero threshold activity in the future counts as no stall and fires` (the clamp) |
| watchdog disabled via env flag | `a disabled watchdog checks nothing` |
| terminal status (completed) is skipped | `a completed task is terminal`; new `a failed task is terminal`, `a blocked task is terminal`, `a queued task is judged`, `a task of unknown status is judged` |
| status already needs_completion is skipped | `a task already needing completion` |
| successive checks for same task fire only once | `a fired task is not fired again on the next tick` |
| write EEXIST is treated as race-lost | `a writer losing the O_EXCL race is a quiet race-lost and the task may fire later` (two ticks) |
| write ENOSPC logs warning and records error | `a writer failing otherwise is warned and the task stays unfired` (`error("disk full")`, the warning with its pair and message; the old `assert.ok(error)` truthiness pin is the message rendered whole) |
| start() schedules a poll on the injected setInterval | poll row `start arms one interval whose handler ticks, and stop clears it` (the handler is fired and its tick's write counted) |
| start() is a no-op when watchdog is disabled | poll row `a disabled watchdog does not start`; new `a second start does not arm a second interval, a second stop is idle` |
| env parsers honor defaults and overrides | the `KENDEX_STALL_WATCHDOG` table (seven rows) and the shared seconds table (eight rows through both parsers, plus the assert that their defaults differ) |

New rows with no former case: a record without a task id, several tasks judged in order and on their own in one tick, a failing mark (warned, the task still counts as fired), an unreadable registry (warned, the tick judges nothing), a throwing probe (warned, unfired).

## Recorded, not fixed

- The second `fired.has` check inside checkOne is reachable with two overlapping checks on one task (the reviewer round showed a deferred pane probe reaches it, and `start()` has no in-flight lock, so a checkAll slower than the interval overlaps the next tick); the real O_EXCL writer bounds the cost to a race-lost. Not covered by a row.
- `checkOne` and `hasFired` are exported but only `start` is called by production.
- `extensions/subagent/pane.ts` carries a second `mapWithConcurrencyLimit` identical to `dispatch.ts`'s but for the floor on the limit (noticed while reading the neighbouring suite; out of this PR's scope).

## Mutation

56 mutants over `idle-stall-watchdog.ts`, 56 killed, each by the row named for it. The first batch left one survivor (the clamp read as an absolute value); a far-future row answers it. The reviewer round's probe left eight survivors of its own; the second commit answers the three blockers (the write target, the rounding, the warning's pair) and four suggestions (the clamp at a zero threshold, the mark's payload, the payload's fields, the dead fixture arms).

## Checks

- `bun test ./tests/idle-stall-watchdog.test.ts`: 4 pass (24 + 3 + 7 + 16 rows). Package: 287 pass.
- `tools/guard --full`: exit 0.
- One reviewer-test round: accepted with three blockers and six suggestions; the blockers and four suggestions applied, the rest recorded above.

KEN-1241

https://claude.ai/code/session_01D6wb5KLMMnPv7njYdSSTzL
