### PR TITLE
test(KEN-1241): the dispatch pool as scripts over deferred mappers

### DIFF
--- a/pi-extensions/pi-agents-tmux/tests/dispatch-concurrency.test.ts
+++ b/pi-extensions/pi-agents-tmux/tests/dispatch-concurrency.test.ts
@@ -30,6 +30,12 @@ async function poolLine(count: number, concurrency: number, script: Step[]): Pro
 		(results) => (settled = `results=[${results.join(",")}]`),
 		(error: Error) => (settled = `rejected(${error.message})`),
 	);
+	// A step naming a mapper that never started is a mis-scripted row, not a line.
+	const release = (index: number) => {
+		const r = releases.get(index);
+		if (!r) throw new Error(`script releases ${items[index]}${index} before it started`);
+		return r;
+	};
 	const lines: string[] = [];
 	let seen = 0;
 	const step = async (event: string) => {
@@ -40,10 +46,10 @@ async function poolLine(count: number, concurrency: number, script: Step[]): Pro
 	await step("start");
 	for (const s of script) {
 		if (typeof s === "number") {
-			releases.get(s)?.resolve(`${items[s]}${s}`);
+			release(s).resolve(`${items[s]}${s}`);
 			await step(`${items[s]}${s} done ->`);
 		} else {
-			releases.get(s.throws)?.reject(new Error(`${items[s.throws]} boom`));
+			release(s.throws).reject(new Error(`${items[s.throws]} boom`));
 			await step(`${items[s.throws]}${s.throws} threw ->`);
 		}
 	}

--- a/pi-extensions/pi-agents-tmux/tests/dispatch-concurrency.test.ts
+++ b/pi-extensions/pi-agents-tmux/tests/dispatch-concurrency.test.ts
@@ -1,163 +1,69 @@
-// mapWithConcurrencyLimit and the dispatch wrapper over it.
+// mapWithConcurrencyLimit as a table of scripts over deferred mappers: the
+// pool starts, the script finishes one mapper at a time, and each step reads
+// back as one line naming the mappers that started since the last step and,
+// on the step where the pool settles, what it settled with. No mapper runs
+// on a clock; the script is the only thing that releases one.
 
 import assert from "node:assert/strict";
-import { mapWithConcurrencyLimit } from "../extensions/subagent/dispatch.js";
 import test from "node:test";
+import { mapWithConcurrencyLimit } from "../extensions/subagent/dispatch.js";
 
-test("mapWithConcurrencyLimit returns empty array for empty input without invoking fn", async () => {
-	let invoked = 0;
-	const results = await mapWithConcurrencyLimit<number, number>([], 4, async () => {
-		invoked += 1;
-		return 0;
+// Each step finishes the mapper of one item, with a value or a throw.
+type Step = number | { throws: number };
+
+function flush(): Promise<void> {
+	return new Promise((resolve) => setImmediate(resolve));
+}
+
+// Items are letters; a mapper records itself as the item with the index it
+// was handed, so a mapper called with a stale or shifted index reddens.
+async function poolLine(count: number, concurrency: number, script: Step[]): Promise<string> {
+	const items = Array.from({ length: count }, (_, i) => String.fromCharCode(97 + i));
+	const releases = new Map<number, { resolve: (value: string) => void; reject: (error: Error) => void }>();
+	const started: string[] = [];
+	let settled: string | undefined;
+	const pool = mapWithConcurrencyLimit(items, concurrency, (item, index) => {
+		started.push(`${item}${index}`);
+		return new Promise<string>((resolve, reject) => releases.set(index, { reject, resolve }));
 	});
-	assert.deepEqual(results, []);
-	assert.equal(invoked, 0);
-});
-
-test("mapWithConcurrencyLimit handles a single item with concurrency > items", async () => {
-	let active = 0;
-	let maxActive = 0;
-	const results = await mapWithConcurrencyLimit([42], 8, async (item) => {
-		active += 1;
-		maxActive = Math.max(maxActive, active);
-		await new Promise((resolve) => setTimeout(resolve, 1));
-		active -= 1;
-		return item * 2;
-	});
-	assert.deepEqual(results, [84]);
-	assert.equal(maxActive, 1);
-});
-
-test("mapWithConcurrencyLimit caps active workers at items.length when items < concurrency", async () => {
-	const items = [1, 2, 3];
-	let active = 0;
-	let maxActive = 0;
-	const results = await mapWithConcurrencyLimit(items, 8, async (item) => {
-		active += 1;
-		maxActive = Math.max(maxActive, active);
-		await new Promise((resolve) => setTimeout(resolve, 5));
-		active -= 1;
-		return item * 2;
-	});
-	assert.deepEqual(results, [2, 4, 6]);
-	assert.equal(maxActive, 3);
-});
-
-test("mapWithConcurrencyLimit preserves submission order with items >> concurrency", async () => {
-	const items = Array.from({ length: 24 }, (_, index) => index);
-	let active = 0;
-	let maxActive = 0;
-	const results = await mapWithConcurrencyLimit(items, 4, async (item) => {
-		active += 1;
-		maxActive = Math.max(maxActive, active);
-		await new Promise((resolve) => setTimeout(resolve, 1 + (item % 3)));
-		active -= 1;
-		return item * 2;
-	});
-	assert.deepEqual(results, items.map((item) => item * 2));
-	assert.equal(maxActive, 4);
-});
-
-test("mapWithConcurrencyLimit keeps workers saturated across an uneven workload", async () => {
-	// Every 4th task takes 5x as long as the others. The old batched
-	// dispatch would idle 3 workers for the slow task's tail before the
-	// next batch started; the flat pool should keep min(K, remaining)
-	// workers active until all tasks complete.
-	const items = Array.from({ length: 16 }, (_, index) => index);
-	const fastMs = 5;
-	const slowMs = 25;
-	const concurrency = 4;
-	let active = 0;
-	let maxActive = 0;
-	let started = 0;
-	let finished = 0;
-	let saturatedSamples = 0;
-	let unsaturatedSamples = 0;
-	const sampler = setInterval(() => {
-		const remaining = items.length - finished;
-		const expectedActive = Math.min(concurrency, remaining);
-		if (remaining <= concurrency) return; // tail decrescendo is expected
-		if (started < items.length && active < expectedActive) unsaturatedSamples += 1;
-		else saturatedSamples += 1;
-	}, 2);
-	const start = Date.now();
-	const results = await mapWithConcurrencyLimit(items, concurrency, async (item) => {
-		started += 1;
-		active += 1;
-		maxActive = Math.max(maxActive, active);
-		await new Promise((resolve) => setTimeout(resolve, item % 4 === 0 ? slowMs : fastMs));
-		active -= 1;
-		finished += 1;
-		return item;
-	});
-	clearInterval(sampler);
-	const elapsed = Date.now() - start;
-	assert.deepEqual(results, items);
-	assert.equal(maxActive, concurrency);
-	// Flat-pool wall-clock is ~max(slowest_task, totalWork/K). The batched
-	// baseline with batchSize=8 idled workers for slow-task tails between
-	// batches; the flat pool removes that dead time. Generous bounds keep
-	// the assertion stable on slow CI runners.
-	const totalWork = items.reduce((sum, item) => sum + (item % 4 === 0 ? slowMs : fastMs), 0);
-	const flatLowerBound = totalWork / concurrency;
-	assert.ok(elapsed >= flatLowerBound * 0.5, `elapsed ${elapsed}ms below realistic flat-pool floor ${flatLowerBound}ms`);
-	assert.ok(saturatedSamples > 0, "expected at least one saturated sample mid-run");
-	// While remaining items > concurrency, the pool must stay saturated.
-	// Allow a tiny number of races (sampler firing between a task's
-	// completion-increment and the worker's next pickup).
-	assert.ok(unsaturatedSamples <= 1, `flat pool dropped below concurrency mid-run (${unsaturatedSamples} unsaturated samples, ${saturatedSamples} saturated)`);
-});
-
-test("mapWithConcurrencyLimit rejects when the mapper throws (callers must catch)", async () => {
-	const items = [0, 1, 2, 3];
-	const invoked: number[] = [];
-	await assert.rejects(
-		mapWithConcurrencyLimit(items, 2, async (item) => {
-			invoked.push(item);
-			if (item === 1) throw new Error("boom");
-			await new Promise((resolve) => setTimeout(resolve, 1));
-			return item;
-		}),
-		/boom/,
+	pool.then(
+		(results) => (settled = `results=[${results.join(",")}]`),
+		(error: Error) => (settled = `rejected(${error.message})`),
 	);
-	// Helper does not swallow thrown mappers — this is why runParallelDispatch
-	// wraps its per-task body in try/catch before handing it to the pool.
-	assert.ok(invoked.includes(1), "mapper should have run for the throwing item before rejection");
-});
-
-test("dispatch-style try/catch wrapper drains the pool and keeps indexed order on throw", async () => {
-	// Mirrors the wrapper pattern in runParallelDispatch: each task body is
-	// wrapped in try/catch so a single thrown mapper becomes a failed entry
-	// at its index instead of aborting the whole pool.
-	const items = Array.from({ length: 8 }, (_, index) => index);
-	let active = 0;
-	let maxActive = 0;
-	let completedAfterThrow = 0;
-	const throwingIndex = 2;
-	const wrap = async (index: number) => {
-		active += 1;
-		maxActive = Math.max(maxActive, active);
-		try {
-			if (index === throwingIndex) throw new Error(`task ${index} exploded`);
-			await new Promise((resolve) => setTimeout(resolve, 2));
-			if (index > throwingIndex) completedAfterThrow += 1;
-			return { kind: "ok" as const, index };
-		} catch (error) {
-			return { kind: "failed" as const, index, errorMessage: (error as Error).message };
-		} finally {
-			active -= 1;
-		}
+	const lines: string[] = [];
+	let seen = 0;
+	const step = async (event: string) => {
+		await flush();
+		lines.push(`${event} [${started.slice(seen).join(",")}]${settled ? ` ${settled}` : ""}`);
+		seen = started.length;
 	};
-	const results = await mapWithConcurrencyLimit(items, 3, (item) => wrap(item));
-	assert.deepEqual(results.map((r) => r.index), items, "result order must match submission order");
-	assert.equal(maxActive, 3);
-	for (const result of results) {
-		if (result.index === throwingIndex) {
-			assert.equal(result.kind, "failed");
-			assert.equal((result as { kind: "failed"; errorMessage: string }).errorMessage, `task ${throwingIndex} exploded`);
+	await step("start");
+	for (const s of script) {
+		if (typeof s === "number") {
+			releases.get(s)?.resolve(`${items[s]}${s}`);
+			await step(`${items[s]}${s} done ->`);
 		} else {
-			assert.equal(result.kind, "ok");
+			releases.get(s.throws)?.reject(new Error(`${items[s.throws]} boom`));
+			await step(`${items[s.throws]}${s.throws} threw ->`);
 		}
 	}
-	assert.ok(completedAfterThrow >= items.length - throwingIndex - 1, `every task after index ${throwingIndex} must still complete after a peer throws; saw ${completedAfterThrow}`);
+	if (!settled) lines.push("pending");
+	return lines.join("; ");
+}
+
+// label | items | concurrency | script | expect
+const rows: Array<[string, number, number, Step[], string]> = [
+	["no items settle empty without a mapper call", 0, 4, [], "start [] results=[]"],
+	["one item under a wide limit", 1, 8, [0], "start [a0]; a0 done -> [] results=[a0]"],
+	["a limit above the item count starts every item", 3, 8, [2, 0, 1], "start [a0,b1,c2]; c2 done -> []; a0 done -> []; b1 done -> [] results=[a0,b1,c2]"],
+	["each finish picks up the next index, results by submission index", 6, 2, [1, 0, 2, 3, 5, 4], "start [a0,b1]; b1 done -> [c2]; a0 done -> [d3]; c2 done -> [e4]; d3 done -> [f5]; f5 done -> []; e4 done -> [] results=[a0,b1,c2,d3,e4,f5]"],
+	["the pool settles only when the last mapper finishes", 3, 2, [0, 2], "start [a0,b1]; a0 done -> [c2]; c2 done -> []; pending"],
+	["a fractional limit floors", 4, 2.7, [0, 1], "start [a0,b1]; a0 done -> [c2]; b1 done -> [d3]; pending"],
+	["a limit of zero runs one worker", 3, 0, [0, 1, 2], "start [a0]; a0 done -> [b1]; b1 done -> [c2]; c2 done -> [] results=[a0,b1,c2]"],
+	["a throw rejects the pool with the mapper's error", 4, 2, [{ throws: 1 }], "start [a0,b1]; b1 threw -> [] rejected(b boom)"],
+	["a throw after the pool is full rejects with that item's error", 4, 2, [0, { throws: 2 }], "start [a0,b1]; a0 done -> [c2]; c2 threw -> [] rejected(c boom)"],
+];
+
+test("mapWithConcurrencyLimit", async () => {
+	for (const [label, count, concurrency, script, expect] of rows) assert.equal(await poolLine(count, concurrency, script), expect, label);
 });

--- a/pi-extensions/pi-agents-tmux/tests/idle-stall-probe.test.ts
+++ b/pi-extensions/pi-agents-tmux/tests/idle-stall-probe.test.ts
@@ -47,7 +47,7 @@ async function probeLine(opts: Opts): Promise<string> {
 	const deps: ProbePaneIdleDeps = {
 		resolveBridgeBin: async () => (opts.bin === null ? undefined : (opts.bin ?? BIN)),
 		execCapture: async (command, args, options) => {
-			execs.push(`${command === BIN ? "bin" : JSON.stringify(command)} ${args.join(",")} cwd=${options?.cwd} timeout=${options?.timeoutMs}`);
+			execs.push(`${command === BIN ? "bin" : JSON.stringify(command)} ${JSON.stringify(args)} cwd=${options?.cwd} timeout=${options?.timeoutMs}`);
 			if (opts.throws !== undefined) throw opts.throws;
 			return opts.exec ?? { code: 0, stderr: "", stdout: "" };
 		},
@@ -64,7 +64,7 @@ async function probeLine(opts: Opts): Promise<string> {
 	return `${result.idle ? "idle" : "busy"}:${result.reason} exec=[${execs.join(";")}]${warnings.length ? ` warn=[${warnings.map(warnTag).join(",")}]` : ""}`;
 }
 
-const SOCKET_EXEC = "exec=[bin state,--socket,/tmp/pi-bridge.sock cwd=/tmp/cwd timeout=2000]";
+const SOCKET_EXEC = 'exec=[bin ["state","--socket","/tmp/pi-bridge.sock"] cwd=/tmp/cwd timeout=2000]';
 
 // label | deps | expect
 const rows: Array<[string, Opts, string]> = [
@@ -93,10 +93,10 @@ const rows: Array<[string, Opts, string]> = [
 	["a record without an agent", { record: { ...RECORD, agent: "" } }, "busy:registry-miss exec=[]"],
 	["an entry without bridge metadata", { entry: { bridgePid: undefined, bridgeSocket: undefined } }, "busy:bridge-missing-metadata exec=[]"],
 	["no bridge binary", { bin: null }, "busy:bridge-bin-not-found exec=[]"],
-	["a pid alone is probed by pid", { entry: { bridgePid: "9999", bridgeSocket: undefined }, exec: state({ data: { isIdle: true } }) }, "idle:bridge-idle exec=[bin state,--pid,9999 cwd=/tmp/cwd timeout=2000]"],
-	["a socket beside a pid wins", { entry: { bridgePid: "9999", bridgeSocket: "/run/b.sock" }, exec: state({ data: { isIdle: true } }) }, "idle:bridge-idle exec=[bin state,--socket,/run/b.sock cwd=/tmp/cwd timeout=2000]"],
-	["an injected timeout is handed to the exec", { exec: state({ data: { isIdle: true } }), timeoutMs: 500 }, "idle:bridge-idle exec=[bin state,--socket,/tmp/pi-bridge.sock cwd=/tmp/cwd timeout=500]"],
-	["the resolved binary is the command", { bin: "/opt/pi-bridge", exec: state({ data: { isIdle: true } }) }, 'idle:bridge-idle exec=["/opt/pi-bridge" state,--socket,/tmp/pi-bridge.sock cwd=/tmp/cwd timeout=2000]'],
+	["a pid alone is probed by pid", { entry: { bridgePid: "9999", bridgeSocket: undefined }, exec: state({ data: { isIdle: true } }) }, 'idle:bridge-idle exec=[bin ["state","--pid","9999"] cwd=/tmp/cwd timeout=2000]'],
+	["a socket beside a pid wins", { entry: { bridgePid: "9999", bridgeSocket: "/run/b.sock" }, exec: state({ data: { isIdle: true } }) }, 'idle:bridge-idle exec=[bin ["state","--socket","/run/b.sock"] cwd=/tmp/cwd timeout=2000]'],
+	["an injected timeout is handed to the exec", { exec: state({ data: { isIdle: true } }), timeoutMs: 500 }, 'idle:bridge-idle exec=[bin ["state","--socket","/tmp/pi-bridge.sock"] cwd=/tmp/cwd timeout=500]'],
+	["the resolved binary is the command", { bin: "/opt/pi-bridge", exec: state({ data: { isIdle: true } }) }, 'idle:bridge-idle exec=["/opt/pi-bridge" ["state","--socket","/tmp/pi-bridge.sock"] cwd=/tmp/cwd timeout=2000]'],
 ];
 
 test("probePaneIdle", async () => {


### PR DESCRIPTION
Reshapes `pi-extensions/pi-agents-tmux/tests/dispatch-concurrency.test.ts` to code-quality § Tests: seven timer-driven cases (sleeping mappers, a two-millisecond sampler, elapsed wall-time bounds) over `mapWithConcurrencyLimit` become one table of nine scripts over deferred mappers. Every mapper is a promise the script finishes one at a time, and each step reads back as one line naming the mappers that started since the last step (the item with the index it was handed), with the settle on the step it happens: the results by submission index, or the rejection with the mapper's error. Nothing reads a clock.

Also closes the thread tracked off #2244: `idle-stall-probe.test.ts` renders the exec arguments as JSON, so one comma-packed argument no longer reads as three.

## Folded and deleted cases, with the surviving row

| Former case | Surviving row |
|---|---|
| returns empty array for empty input without invoking fn | `no items settle empty without a mapper call` |
| handles a single item with concurrency > items | `one item under a wide limit` |
| caps active workers at items.length when items < concurrency | `a limit above the item count starts every item` |
| preserves submission order with items >> concurrency | `each finish picks up the next index, results by submission index` (finish order 1,0,2,3,5,4; the started delta per finish is exactly the next index) |
| keeps workers saturated across an uneven workload | the same row: every finish starts exactly one mapper while items remain, read per step instead of sampled; new `the pool settles only when the last mapper finishes` |
| rejects when the mapper throws (callers must catch) | `a throw rejects the pool with the mapper's error`; new `a throw after the pool is full rejects with that item's error` |
| dispatch-style try/catch wrapper drains the pool and keeps indexed order on throw | deleted: it tested a wrapper defined in the test; the production wrapper is inside `runParallelDispatch` and catches before the pool sees a throw |

New with no former case: `a fractional limit floors`, `a limit of zero runs one worker`.

## Recorded, not fixed

- `pane.ts` exports a second `mapWithConcurrencyLimit`, identical but for the floor on the limit, with no caller anywhere.
- Two equivalent mutants: dropping the empty-input early return (one worker then returns at once) and dropping the cap of the worker count at the item count (surplus workers return at once).

## Mutation

22 mutants over `mapWithConcurrencyLimit` in `dispatch.ts`, 20 killed, each by a row of the table; the two survivors are the equivalent mutants above. The comma-packed and space-packed argv mutants over `idle-stall-probe.ts` are both killed by the probe table's first row.

## Checks

- `bun test ./tests/dispatch-concurrency.test.ts`: 1 pass (9 rows). Package: 249 pass across 52 files.
- `tools/guard --full`: exit 0.
- One reviewer-test round: accept, no blockers. The reviewer's 16 mutants: 14 killed; its two survivors defer only when a worker starts (a macrotask or a microtask late) and render the same lines. Its one suggestion, a mis-scripted release throwing rather than rendering a line, is the second commit.

KEN-1241

https://claude.ai/code/session_01ULbexacZGFxLY8bofQfvkp
