### PR TITLE
test(KEN-1241): the shared index reads as three suites of rows

### DIFF
--- a/.agents/skills/commit-guards/tests/atomic-install.test.sh
+++ b/.agents/skills/commit-guards/tests/atomic-install.test.sh
@@ -1,0 +1,145 @@
+#!/usr/bin/env bash
+# lib/atomic-install.sh: gg_install_file replaces a policy file by a rename
+# inside its own directory, or not at all. One table over the destination's
+# shape (existing with a mode, absent, read-only, a symlink) and each step a
+# stub can fail (stat, chmod, mv, no scratch directory): a row reads back the
+# exit status and every line printed, then the destination's content and
+# mode and the staging files left beside it. The planted staging symlink is
+# the one scripted control below the table: it needs a writer that publishes
+# its pid before it stages.
+set -euo pipefail
+
+TEST_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=lib/harness.bash
+. "$TEST_DIR/lib/harness.bash"
+SKILL_DIR="$(cd "$TEST_DIR/.." && pwd)"
+SCRIPTS="$SKILL_DIR/scripts"
+COMMON="$SCRIPTS/lib/common.sh"
+INSTALL="$SCRIPTS/lib/atomic-install.sh"
+ROOT="$TMP"
+
+PASS=0
+FAIL=0
+assert_eq() { # LABEL EXPECT ACTUAL
+  if [ "$2" = "$3" ]; then
+    PASS=$((PASS + 1))
+    printf '  ok    %s\n' "$1"
+  else
+    FAIL=$((FAIL + 1))
+    printf '  FAIL  %s\n        want: %s\n        got:  %s\n' "$1" "$2" "$3"
+  fi
+}
+filemode() { stat -c '%a' "$1" 2>/dev/null || stat -f '%Lp' "$1"; }
+
+# A failing stub ahead of PATH for one step; each names itself on stderr so a
+# diagnostic that folds it in is read back with what it said.
+stub() { # NAME [MESSAGE]
+  mkdir -p "$ROOT/no$1"
+  printf '#!/bin/sh\n%s\nexit 1\n' "${2:+echo \"$2\" >&2}" >"$ROOT/no$1/$1"
+  chmod +x "$ROOT/no$1/$1"
+}
+stub stat
+stub chmod "chmod: refused by the test stub"
+stub mv
+
+printf 'REPLACEMENT\n' >"$ROOT/src.tsv"
+mkdir -p "$ROOT/outside"
+
+# A fresh fixture directory holding tools/dest.tsv as the row asks: a file
+# with a mode, a symlink to a file outside the tree, or nothing.
+fx() { # NAME SHAPE
+  R="$ROOT/$1"
+  mkdir -p "$R/tools"
+  case "$2" in
+    absent) ;;
+    link)
+      printf 'BEHIND THE LINK\n' >"$ROOT/outside/$1.tsv"
+      chmod 644 "$ROOT/outside/$1.tsv"
+      ln -s "$ROOT/outside/$1.tsv" "$R/tools/dest.tsv"
+      ;;
+    *)
+      printf 'ORIGINAL\n' >"$R/tools/dest.tsv"
+      chmod "$2" "$R/tools/dest.tsv"
+      ;;
+  esac
+}
+
+# One line for an install: the exit status and every printed line, then the
+# destination's content and mode (`-` when absent, the link's target content
+# beside it for a symlink fixture) and the count of staging files left in its
+# directory.
+install_line() { # SHIM-DIR ARM — ARM is `tmpdir` (gg_tmpdir first) or `bare`
+  local rc=0 out dest="$R/tools/dest.tsv" content="-" mode="-" target=""
+  out="$(cd "$R" && PATH="${1:+$1:}$PATH" GG_CHECK=probe bash -c '
+    set -euo pipefail
+    . "$1"
+    . "$2"
+    [ "$3" = bare ] || gg_tmpdir
+    gg_install_file "$4" tools/dest.tsv "the fixture"
+  ' _ "$COMMON" "$INSTALL" "$2" "$ROOT/src.tsv" 2>&1)" || rc=$?
+  out="${out//"$ROOT"/<root>}"
+  if [ -e "$dest" ]; then
+    content="$(cat "$dest")"
+    mode="$(filemode "$dest")"
+  fi
+  [ ! -L "$dest" ] || target=" link-target=$(cat "$ROOT/outside/${R##*/}.tsv")"
+  [ -e "$ROOT/outside/${R##*/}.tsv" ] && [ ! -L "$dest" ] && target=" former-target=$(cat "$ROOT/outside/${R##*/}.tsv")"
+  printf 'rc=%s%s dest=%s mode=%s%s staged=%s' "$rc" "${out:+ $(printf '%s\n' "$out" | paste -sd ';' -)}" "$content" "$mode" "$target" "$(find "$R/tools" -name '*gg-install*' | wc -l | tr -d ' ')"
+}
+
+echo "=== gg_install_file ==="
+# label | fixture shape | shim | arm | expect
+rows=(
+  "an existing destination is replaced and keeps its own mode|644||tmpdir|rc=0 dest=REPLACEMENT mode=644 staged=0"
+  "a mode neither the staging default nor the umask gives is kept too|755||tmpdir|rc=0 dest=REPLACEMENT mode=755 staged=0"
+  "a destination without owner-write is replaced and keeps its read-only mode|444||tmpdir|rc=0 dest=REPLACEMENT mode=444 staged=0"
+  "a destination that does not exist yet lands with the staging file's owner-only mode|absent||tmpdir|rc=0 dest=REPLACEMENT mode=600 staged=0"
+  "a symlink destination is replaced by a file with the mode of the file behind it; the file behind it is untouched|link||tmpdir|rc=0 dest=REPLACEMENT mode=644 former-target=BEHIND THE LINK staged=0"
+  "an unreadable mode is a loud refusal, the destination untouched|644|$ROOT/nostat|tmpdir|rc=2 ::error::probe: could not read the mode of tools/dest.tsv — the fixture was not replaced dest=ORIGINAL mode=644 staged=0"
+  "no scratch directory is a refusal before anything is staged|644||bare|rc=2 ::error::probe: gg_install_file needs gg_tmpdir called first — the fixture was not replaced dest=ORIGINAL mode=644 staged=0"
+  "a failed chmod names the mode it could not give and what chmod said, the destination untouched|644|$ROOT/nochmod|tmpdir|rc=2 ::error::probe: could not give the replacement for the fixture tools/dest.tsv's mode (644) (chmod: refused by the test stub) dest=ORIGINAL mode=644 staged=0"
+  "a failed rename is a loud collection error, the destination byte-identical|644|$ROOT/nomv|tmpdir|rc=2 ::error::probe: could not replace the fixture at tools/dest.tsv — inspect the file before trusting it dest=ORIGINAL mode=644 staged=0"
+)
+i=0
+for row in "${rows[@]}"; do
+  IFS='|' read -r label shape shim arm expect <<<"$row"
+  i=$((i + 1))
+  fx "install-$i" "$shape"
+  assert_eq "$label" "$expect" "$(install_line "$shim" "$arm")"
+done
+
+echo "=== a planted staging symlink does not redirect the write ==="
+# cp writes THROUGH a symlink, so a staging name the repository can predict is
+# an arbitrary-file overwrite waiting for the next --update. The writer
+# publishes its own pid and waits, so the symlink is planted at the EXACT name
+# a pid-derived scheme would choose: the control is aimed, not a guess.
+fx install-symlink 644
+printf 'VICTIM\n' >"$ROOT/victim.txt"
+pidfile="$ROOT/writer.pid"
+gofile="$ROOT/writer.go"
+(
+  cd "$R" && GG_CHECK=probe bash -c '
+    set -euo pipefail
+    echo "$$" >"$3"
+    i=0
+    while [ ! -e "$4" ] && [ "$i" -lt 200 ]; do i=$((i + 1)); sleep 0.05; done
+    . "$1"
+    . "$2"
+    gg_tmpdir
+    gg_install_file "$5" tools/dest.tsv "the fixture"
+  ' _ "$COMMON" "$INSTALL" "$pidfile" "$gofile" "$ROOT/src.tsv"
+) >"$ROOT/writer.out" 2>&1 &
+writer=$!
+i=0
+while [ ! -s "$pidfile" ] && [ "$i" -lt 200 ]; do i=$((i + 1)); sleep 0.05; done
+assert_eq "the control is aimed at the pid the writer actually uses" "published" "$([ -s "$pidfile" ] && echo published || echo none)"
+ln -s "$ROOT/victim.txt" "$R/tools/.gg-install.$(cat "$pidfile").dest.tsv"
+: >"$gofile"
+wait "$writer" || true
+rm -f "$R/tools/.gg-install.$(cat "$pidfile").dest.tsv"
+assert_eq "the victim is untouched, the install lands on its real destination, and no staging file is left" \
+  "victim=VICTIM dest=REPLACEMENT staged=0 out=" \
+  "victim=$(cat "$ROOT/victim.txt") dest=$(cat "$R/tools/dest.tsv") staged=$(find "$R/tools" -name '*gg-install*' | wc -l | tr -d ' ') out=$(cat "$ROOT/writer.out")"
+
+printf '\n%s passed, %s failed\n' "$PASS" "$FAIL"
+[ "$FAIL" -eq 0 ]

--- a/.agents/skills/commit-guards/tests/changelog-entries.test.sh
+++ b/.agents/skills/commit-guards/tests/changelog-entries.test.sh
@@ -7,8 +7,8 @@
 # write path is pinned next door in changelog-collate.test.sh.
 # The configured globs decide what is read and content comes from the index;
 # the index readers this family of checks shares are pinned once, in
-# index-reads.test.sh and lane-readers.test.sh. Every green assertion is paired with a control that
-# proves it can fail.
+# index-reads.test.sh and lane-readers.test.sh. Every green assertion is
+# paired with a control that proves it can fail.
 set -euo pipefail
 
 TEST_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"

--- a/.agents/skills/commit-guards/tests/changelog-entries.test.sh
+++ b/.agents/skills/commit-guards/tests/changelog-entries.test.sh
@@ -7,7 +7,7 @@
 # write path is pinned next door in changelog-collate.test.sh.
 # The configured globs decide what is read and content comes from the index;
 # the index readers this family of checks shares are pinned once, in
-# index-reads.test.sh. Every green assertion is paired with a control that
+# index-reads.test.sh and lane-readers.test.sh. Every green assertion is paired with a control that
 # proves it can fail.
 set -euo pipefail
 

--- a/.agents/skills/commit-guards/tests/comments.test.sh
+++ b/.agents/skills/commit-guards/tests/comments.test.sh
@@ -5,7 +5,7 @@
 # lanes', and --staged judges the lines the commit adds against comment
 # state read from the whole file. Every green assertion is paired with a
 # control that proves it can fail. The index readers this family shares are
-# pinned once, in index-reads.test.sh.
+# pinned once, in index-reads.test.sh and lane-readers.test.sh.
 set -euo pipefail
 
 TEST_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"

--- a/.agents/skills/commit-guards/tests/conflict-markers.test.sh
+++ b/.agents/skills/commit-guards/tests/conflict-markers.test.sh
@@ -4,7 +4,7 @@
 # separator do not, excludes need reasons, and the check's own source never
 # trips it. Every green assertion is paired with a control that proves it can
 # fail. The index readers this family of checks shares are pinned once, in
-# index-reads.test.sh.
+# index-reads.test.sh and lane-readers.test.sh.
 #
 # Marker runs are assembled with printf throughout so this test file never
 # contains a marker shape itself — the kendex repo runs conflict-markers

--- a/.agents/skills/commit-guards/tests/index-reads.test.sh
+++ b/.agents/skills/commit-guards/tests/index-reads.test.sh
@@ -82,27 +82,34 @@ fx_policy() { # NAME STAGED WORKTREE — tools/ex.tsv committed as STAGED, then 
   [ -z "$3" ] || printf '%s\treason\n' "$3" >"$R/tools/ex.tsv"
 }
 fx_staged_deletion() { fx_policy staged-deletion INDEX ""; git -C "$R" rm -q --cached tools/ex.tsv; }
-fx_never_tracked() { new_repo never-tracked; printf 'seed\n' >"$R/seed.txt"; commit_all base; mkdir -p "$R/tools"; printf 'ONDISK\treason\n' >"$R/tools/ex.tsv"; }
+fx_never_tracked() { new_repo "$1"; printf 'seed\n' >"$R/seed.txt"; commit_all base; mkdir -p "$R/tools"; printf 'ONDISK\treason\n' >"$R/tools/ex.tsv"; }
 fx_unborn() { new_repo unborn-head; mkdir -p "$R/tools"; printf 'ONDISK\treason\n' >"$R/tools/ex.tsv"; }
 fx_glob() { new_repo "$1"; mkdir -p "$R/tools"; printf 'REAL\treason\n' >"$R/tools/exA.tsv"; commit_all base; }
 printf 'not an index\n' >"$ROOT/corrupt.idx"
+# A git that cannot probe HEAD for the file: the probe's failure is never
+# read as "absent from HEAD".
+mkdir -p "$ROOT/git-shim-ls-tree"
+printf '#!/usr/bin/env bash\ncase " $* " in *" ls-tree "*) echo "git ls-tree: simulated failure" >&2; exit 128 ;; esac\nexec "%s" "$@"\n' "$(command -v git)" >"$ROOT/git-shim-ls-tree/git"
+chmod +x "$ROOT/git-shim-ls-tree/git"
 
 echo "=== gg_policy_content ==="
-# label | fixture | snippet | expect
+# label | fixture | shim | snippet | expect
 rows=(
-  "the staged copy governs over an unstaged edit|fx_policy staged-wins INDEX WORKTREE|gg_policy_content tools/ex.tsv|rc=0 INDEX\\treason"
-  "an unreadable index is a collection error, never the worktree copy|fx_policy corrupt INDEX WORKTREE|GIT_INDEX_FILE=$ROOT/corrupt.idx gg_policy_content tools/ex.tsv|rc=2 ::error::probe: could not query the index for tools/ex.tsv (git ls-files exit 128); refusing to treat it as untracked"
-  "a staged deletion governs as absent with the worktree copy present|fx_staged_deletion|gg_policy_content tools/ex.tsv|rc=1"
-  "a never-tracked policy file falls back to the worktree copy|fx_never_tracked|gg_policy_content tools/ex.tsv|rc=0 ONDISK\\treason"
-  "an unborn HEAD carries nothing and does not fail the read|fx_unborn|gg_policy_content tools/ex.tsv|rc=0 ONDISK\\treason"
-  "a glob-shaped path matches only itself|fx_glob glob-path|gg_policy_content 'tools/ex?.tsv'|rc=1"
-  "control: the literal path it names resolves|fx_glob literal-path|gg_policy_content tools/exA.tsv|rc=0 REAL\\treason"
+  "the staged copy governs over an unstaged edit|fx_policy staged-wins INDEX WORKTREE||gg_policy_content tools/ex.tsv|rc=0 INDEX\\treason"
+  "an unreadable index is a collection error, never the worktree copy|fx_policy corrupt INDEX WORKTREE||GIT_INDEX_FILE=$ROOT/corrupt.idx gg_policy_content tools/ex.tsv|rc=2 ::error::probe: could not query the index for tools/ex.tsv (git ls-files exit 128); refusing to treat it as untracked"
+  "a staged deletion governs as absent with the worktree copy present|fx_staged_deletion||gg_policy_content tools/ex.tsv|rc=1"
+  "a never-tracked policy file falls back to the worktree copy|fx_never_tracked never-tracked||gg_policy_content tools/ex.tsv|rc=0 ONDISK\\treason"
+  "a HEAD probe that failed is a collection error, never the worktree copy|fx_never_tracked head-probe|$ROOT/git-shim-ls-tree|gg_policy_content tools/ex.tsv|rc=2 ::error::probe: could not probe HEAD for tools/ex.tsv (git ls-tree exit 128); refusing to treat it as untracked"
+  "an unborn HEAD carries nothing and does not fail the read|fx_unborn||gg_policy_content tools/ex.tsv|rc=0 ONDISK\\treason"
+  "a glob-shaped path matches only itself|fx_glob glob-path||gg_policy_content 'tools/ex?.tsv'|rc=1"
+  "control: the literal path it names resolves|fx_glob literal-path||gg_policy_content tools/exA.tsv|rc=0 REAL\\treason"
 )
 for row in "${rows[@]}"; do
-  IFS='|' read -r label fixture snippet expect <<<"$row"
+  IFS='|' read -r label fixture SHIM snippet expect <<<"$row"
   $fixture
   assert_eq "$label" "$expect" "$(call "$SETTINGS" "$snippet")"
 done
+SHIM=""
 
 # --- gg_require_merged_index -------------------------------------------------
 

--- a/.agents/skills/commit-guards/tests/index-reads.test.sh
+++ b/.agents/skills/commit-guards/tests/index-reads.test.sh
@@ -1,39 +1,37 @@
 #!/usr/bin/env bash
-# Pins for the libs the checks share: lib/common.sh's index reads,
-# lib/configured-paths.sh's policy reads and content sniff,
-# lib/atomic-install.sh's policy writes, and the settings cache
-# lib/settings.sh materializes. A probe git could not answer never becomes an
-# answer, a configured path is matched literally, a --cached scan refuses an
-# unmerged index, a policy file is replaced by a same-directory rename or not
-# at all, and no partial cache file survives a resolve. Every clean assertion
-# is paired with a control that proves it can fail.
+# The index reads the checks share, one table per reader: gg_policy_content
+# (the index governs a policy file, a probe git could not answer is never an
+# answer, a configured path is literal), gg_require_merged_index (a --cached
+# scan refuses an unmerged index, for the paths it scans), the excludes read
+# a lane makes through them, and the settings cache lib/settings.sh
+# materializes by rename. Each row builds its own fixture repository, makes
+# one call, and reads back the exit status and every line printed, the
+# scratch roots aliased. lib/atomic-install.sh is atomic-install.test.sh; the
+# lanes end to end over these readers are lane-readers.test.sh.
 set -euo pipefail
 
 TEST_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-# The harness owns the scratch root, TMPDIR inside it, and the git isolation.
-# The root matters here beyond hygiene: an assertion over a namespace shared
-# with other processes cannot tell "the code under test leaked" from "someone
-# else's run moved".
 # shellcheck source=lib/harness.bash
 . "$TEST_DIR/lib/harness.bash"
 SKILL_DIR="$(cd "$TEST_DIR/.." && pwd)"
 SCRIPTS="$SKILL_DIR/scripts"
 COMMON="$SCRIPTS/lib/common.sh"
-# The lib holding the install helpers, which a probe exercising them sources
-# alongside COMMON: the writer lives beside common.sh rather than inside it,
-# and reaches back across that boundary for the staging file common.sh
-# declares and its exit trap removes.
-INSTALL="$SCRIPTS/lib/atomic-install.sh"
 SETTINGS="$SCRIPTS/lib/settings.sh"
 ROOT="$TMP"
 
 unset COMMIT_GUARDS_SETTINGS_FILE COMMIT_GUARDS_CONFLICT_EXCLUDES 2>/dev/null || true
 
-TAB="$(printf '\t')"
 PASS=0
 FAIL=0
-ok() { PASS=$((PASS + 1)); printf '  ok    %s\n' "$1"; }
-bad() { FAIL=$((FAIL + 1)); printf '  FAIL  %s\n        %s\n' "$1" "${2:-}"; }
+assert_eq() { # LABEL EXPECT ACTUAL
+  if [ "$2" = "$3" ]; then
+    PASS=$((PASS + 1))
+    printf '  ok    %s\n' "$1"
+  else
+    FAIL=$((FAIL + 1))
+    printf '  FAIL  %s\n        want: %s\n        got:  %s\n' "$1" "$2" "$3"
+  fi
+}
 
 new_repo() { # NAME — fresh fixture repo in $R, cwd unchanged
   R="$ROOT/$1"
@@ -42,108 +40,76 @@ new_repo() { # NAME — fresh fixture repo in $R, cwd unchanged
   git -C "$R" config user.email test@example.com
   git -C "$R" config user.name test
 }
+commit_all() { # MESSAGE
+  git -C "$R" add -A
+  git -C "$R" commit -qm "$1"
+}
 
-# Run a snippet with the libs sourced, inside $R. OUT captures stdout+stderr,
-# RC the exit status — a collection error is exit 2 and must be observable.
-call() { # SNIPPET
-  OUT=""
-  RC=0
-  OUT="$(cd "$R" && GG_CHECK=probe bash -c '
+# One line for a run: the exit status, then every printed line in order,
+# joined by ';' with the roots aliased and a tab spelled out, so a diagnostic
+# reads as the detector that wrote it and the path it names.
+line() { # RC OUT
+  local out="$2"
+  out="${out//"$R"/<repo>}"
+  out="${out//"$ROOT"/<root>}"
+  printf 'rc=%s' "$1"
+  [ -z "$out" ] || printf ' %s' "$(printf '%s\n' "$out" | sed -e 's/[[:space:]]*$//' -e 's/\t/\\t/g' | paste -sd ';' -)"
+}
+
+# A snippet with common.sh and one more lib sourced, run inside $R, with
+# $SHIM first on PATH when a row sets one.
+SHIM=""
+call() { # LIB SNIPPET
+  local rc=0 out
+  out="$(cd "$R" && PATH="${SHIM:+$SHIM:}$PATH" GG_CHECK=probe bash -c '
     set -euo pipefail
     . "$1"
     . "$2"
     shift 2
     eval "$1"
-  ' _ "$COMMON" "$INSTALL" "$1" 2>&1)" || RC=$?
+  ' _ "$COMMON" "$1" "$2" 2>&1)" || rc=$?
+  line "$rc" "$out"
 }
 
-echo "=== gg_policy_content: the index governs, and a probe that failed is not an answer ==="
+# --- gg_policy_content -------------------------------------------------------
 
-new_repo staged-wins
-printf 'seed\n' >"$R/seed.txt"
-mkdir -p "$R/tools"
-printf 'INDEX\treason\n' >"$R/tools/ex.tsv"
-git -C "$R" add -A
-git -C "$R" commit -qm base
-printf 'WORKTREE\treason\n' >"$R/tools/ex.tsv"
-call 'gg_policy_content tools/ex.tsv'
-[ "$RC" -eq 0 ] && [ "$OUT" = "INDEX${TAB}reason" ] \
-  && ok "the staged copy governs over an unstaged edit" \
-  || bad "the staged copy governs over an unstaged edit" "rc=$RC out=$OUT"
-
-# Control: the SAME fixture, with the index unreadable. Before this was
-# classified, the failed probe fell through to the worktree copy and the
-# commit was judged against policy it does not carry.
+fx_policy() { # NAME STAGED WORKTREE — tools/ex.tsv committed as STAGED, then edited to WORKTREE
+  new_repo "$1"
+  mkdir -p "$R/tools"
+  printf 'seed\n' >"$R/seed.txt"
+  printf '%s\treason\n' "$2" >"$R/tools/ex.tsv"
+  commit_all base
+  [ -z "$3" ] || printf '%s\treason\n' "$3" >"$R/tools/ex.tsv"
+}
+fx_staged_deletion() { fx_policy staged-deletion INDEX ""; git -C "$R" rm -q --cached tools/ex.tsv; }
+fx_never_tracked() { new_repo never-tracked; printf 'seed\n' >"$R/seed.txt"; commit_all base; mkdir -p "$R/tools"; printf 'ONDISK\treason\n' >"$R/tools/ex.tsv"; }
+fx_unborn() { new_repo unborn-head; mkdir -p "$R/tools"; printf 'ONDISK\treason\n' >"$R/tools/ex.tsv"; }
+fx_glob() { new_repo "$1"; mkdir -p "$R/tools"; printf 'REAL\treason\n' >"$R/tools/exA.tsv"; commit_all base; }
 printf 'not an index\n' >"$ROOT/corrupt.idx"
-call 'GIT_INDEX_FILE="'"$ROOT"'/corrupt.idx" gg_policy_content tools/ex.tsv'
-[ "$RC" -eq 2 ] && case "$OUT" in *"could not query the index"*) true ;; *) false ;; esac \
-  && ok "an unreadable index is a collection error, not a fall-through" \
-  || bad "an unreadable index is a collection error, not a fall-through" "rc=$RC out=$OUT"
-case "$OUT" in
-  *WORKTREE*) bad "the failed probe never emits the worktree copy" "out=$OUT" ;;
-  *) ok "the failed probe never emits the worktree copy" ;;
-esac
 
-new_repo staged-deletion
-mkdir -p "$R/tools"
-printf 'INDEX\treason\n' >"$R/tools/ex.tsv"
-git -C "$R" add -A
-git -C "$R" commit -qm base
-git -C "$R" rm -q --cached tools/ex.tsv
-call 'gg_policy_content tools/ex.tsv'
-[ "$RC" -eq 1 ] && [ -z "$OUT" ] \
-  && ok "a staged deletion governs as absent even with the worktree copy present" \
-  || bad "a staged deletion governs as absent even with the worktree copy present" "rc=$RC out=$OUT"
+echo "=== gg_policy_content ==="
+# label | fixture | snippet | expect
+rows=(
+  "the staged copy governs over an unstaged edit|fx_policy staged-wins INDEX WORKTREE|gg_policy_content tools/ex.tsv|rc=0 INDEX\\treason"
+  "an unreadable index is a collection error, never the worktree copy|fx_policy corrupt INDEX WORKTREE|GIT_INDEX_FILE=$ROOT/corrupt.idx gg_policy_content tools/ex.tsv|rc=2 ::error::probe: could not query the index for tools/ex.tsv (git ls-files exit 128); refusing to treat it as untracked"
+  "a staged deletion governs as absent with the worktree copy present|fx_staged_deletion|gg_policy_content tools/ex.tsv|rc=1"
+  "a never-tracked policy file falls back to the worktree copy|fx_never_tracked|gg_policy_content tools/ex.tsv|rc=0 ONDISK\\treason"
+  "an unborn HEAD carries nothing and does not fail the read|fx_unborn|gg_policy_content tools/ex.tsv|rc=0 ONDISK\\treason"
+  "a glob-shaped path matches only itself|fx_glob glob-path|gg_policy_content 'tools/ex?.tsv'|rc=1"
+  "control: the literal path it names resolves|fx_glob literal-path|gg_policy_content tools/exA.tsv|rc=0 REAL\\treason"
+)
+for row in "${rows[@]}"; do
+  IFS='|' read -r label fixture snippet expect <<<"$row"
+  $fixture
+  assert_eq "$label" "$expect" "$(call "$SETTINGS" "$snippet")"
+done
 
-new_repo never-tracked
-printf 'seed\n' >"$R/seed.txt"
-git -C "$R" add -A
-git -C "$R" commit -qm base
-mkdir -p "$R/tools"
-printf 'ONDISK\treason\n' >"$R/tools/ex.tsv"
-call 'gg_policy_content tools/ex.tsv'
-[ "$RC" -eq 0 ] && case "$OUT" in ONDISK*) true ;; *) false ;; esac \
-  && ok "a never-tracked policy file falls back to the worktree copy" \
-  || bad "a never-tracked policy file falls back to the worktree copy" "rc=$RC out=$OUT"
-
-new_repo unborn-head
-mkdir -p "$R/tools"
-printf 'ONDISK\treason\n' >"$R/tools/ex.tsv"
-call 'gg_policy_content tools/ex.tsv'
-[ "$RC" -eq 0 ] && case "$OUT" in ONDISK*) true ;; *) false ;; esac \
-  && ok "an unborn HEAD carries nothing and does not fail the read" \
-  || bad "an unborn HEAD carries nothing and does not fail the read" "rc=$RC out=$OUT"
-
-echo "=== gg_policy_content: a configured path is a literal path, never a glob ==="
-
-new_repo glob-path
-mkdir -p "$R/tools"
-printf 'REAL\treason\n' >"$R/tools/exA.tsv"
-git -C "$R" add -A
-git -C "$R" commit -qm base
-call "gg_policy_content 'tools/ex?.tsv'"
-[ "$RC" -eq 1 ] && [ -z "$OUT" ] \
-  && ok "a glob-shaped path matches only itself, and it does not exist" \
-  || bad "a glob-shaped path matches only itself, and it does not exist" "rc=$RC out=$OUT"
-case "$OUT" in
-  *REAL* | *"diff --git"*)
-    bad "a glob-shaped path never yields another entry's content" "out=$OUT"
-    ;;
-  *) ok "a glob-shaped path never yields another entry's content" ;;
-esac
-# Control: the literal path this repo does carry still resolves.
-call 'gg_policy_content tools/exA.tsv'
-[ "$RC" -eq 0 ] && case "$OUT" in REAL*) true ;; *) false ;; esac \
-  && ok "the literal path it names still resolves" \
-  || bad "the literal path it names still resolves" "rc=$RC out=$OUT"
-
-echo "=== gg_require_merged_index: a --cached scan refuses an unmerged index ==="
+# --- gg_require_merged_index -------------------------------------------------
 
 conflicted_repo() { # NAME — fixture left mid-merge, f.txt unmerged
   new_repo "$1"
   printf 'line1\nbase\nline3\n' >"$R/f.txt"
-  git -C "$R" add -A
-  git -C "$R" commit -qm base
+  commit_all base
   git -C "$R" checkout -q -b other
   printf 'line1\ntheirs\nline3\n' >"$R/f.txt"
   git -C "$R" commit -qam other
@@ -152,150 +118,30 @@ conflicted_repo() { # NAME — fixture left mid-merge, f.txt unmerged
   git -C "$R" commit -qam ours
   git -C "$R" merge other >/dev/null 2>&1 || true
 }
-
 conflicted_repo unmerged
-[ "$(git -C "$R" ls-files -u | wc -l)" -eq 3 ] \
-  && ok "the fixture really is mid-merge (three index stages)" \
-  || bad "the fixture really is mid-merge (three index stages)" "stages=$(git -C "$R" ls-files -u | wc -l)"
+assert_eq "the fixture really is mid-merge (three index stages)" 3 "$(git -C "$R" ls-files -u | wc -l | tr -d ' ')"
+# A git that cannot list the unmerged paths at all: the probe's failure is
+# never read as "nothing unmerged".
+mkdir -p "$ROOT/git-shim-unmerged"
+printf '#!/usr/bin/env bash\ncase " $* " in *" --unmerged "*) echo "git ls-files: simulated failure" >&2; exit 128 ;; esac\nexec "%s" "$@"\n' "$(command -v git)" >"$ROOT/git-shim-unmerged/git"
+chmod +x "$ROOT/git-shim-unmerged/git"
 
-call 'gg_require_merged_index'
-[ "$RC" -eq 2 ] && case "$OUT" in *"unmerged path"*"finish or abort the merge"*) true ;; *) false ;; esac \
-  && ok "an unmerged index is a collection error naming the remedy" \
-  || bad "an unmerged index is a collection error naming the remedy" "rc=$RC out=$OUT"
-case "$OUT" in
-  *f.txt*) ok "the refusal names the unmerged path" ;;
-  *) bad "the refusal names the unmerged path" "out=$OUT" ;;
-esac
+echo "=== gg_require_merged_index ==="
+REFUSAL="f.txt;::error::probe: the index carries 1 unmerged path(s) (listed above) and a --cached scan skips them silently — finish or abort the merge, then re-run"
+# label | shim | pathspec | expect
+rows=(
+  "an unmerged index is a collection error naming the path and the remedy|||rc=2 $REFUSAL"
+  "an unmerged path outside the pathspec does not block that scan||'*.rs'|rc=0"
+  "an unmerged path inside the pathspec does block it||'f.txt'|rc=2 $REFUSAL"
+  "a probe that could not list the unmerged paths is a collection error, never an empty list|$ROOT/git-shim-unmerged||rc=2 git ls-files: simulated failure;::error::probe: could not read the index for unmerged paths (git ls-files exit 128)"
+)
+for row in "${rows[@]}"; do
+  IFS='|' read -r label SHIM pathspec expect <<<"$row"
+  assert_eq "$label" "$expect" "$(call "$SETTINGS" "gg_require_merged_index $pathspec")"
+done
+SHIM=""
 
-# Scope: the guard answers for the paths the lane actually scans. An unmerged
-# path outside the pathspec leaves that scan complete.
-call "gg_require_merged_index '*.rs'"
-[ "$RC" -eq 0 ] \
-  && ok "an unmerged path outside the pathspec does not block that scan" \
-  || bad "an unmerged path outside the pathspec does not block that scan" "rc=$RC out=$OUT"
-call "gg_require_merged_index 'f.txt'"
-[ "$RC" -eq 2 ] \
-  && ok "an unmerged path inside the pathspec does block it" \
-  || bad "an unmerged path inside the pathspec does block it" "rc=$RC out=$OUT"
-
-echo "=== end to end: conflict-markers over an unmerged index ==="
-
-conflicted_repo cm-unmerged
-RC=0
-OUT="$(cd "$R" && "$SCRIPTS/conflict-markers" 2>&1)" || RC=$?
-[ "$RC" -eq 2 ] \
-  && ok "conflict-markers refuses rather than reporting OK over an unmerged index" \
-  || bad "conflict-markers refuses rather than reporting OK over an unmerged index" "rc=$RC out=$OUT"
-case "$OUT" in
-  *"OK — no conflict markers"*)
-    bad "the refusal is not dressed as a clean verdict" "out=$OUT"
-    ;;
-  *) ok "the refusal is not dressed as a clean verdict" ;;
-esac
-
-echo "=== end to end: prose over an unmerged index ==="
-
-# prose walks `ls-files -s`, which emits one record per STAGE, so an
-# unresolved merge would hand it rival blobs for one path. Its guard runs
-# over the whole index before the walk: the fixture carries no file the
-# default path list matches, so a lane that skipped the guard would report
-# the clean "no tracked file matches" verdict instead of refusing.
-conflicted_repo prose-unmerged
-RC=0
-OUT="$(cd "$R" && "$SCRIPTS/prose" 2>&1)" || RC=$?
-[ "$RC" -eq 2 ] \
-  && ok "prose refuses rather than reporting OK over an unmerged index" \
-  || bad "prose refuses rather than reporting OK over an unmerged index" "rc=$RC out=$OUT"
-case "$OUT" in
-  *"prose: OK"*)
-    bad "prose's refusal is not dressed as a clean verdict" "out=$OUT"
-    ;;
-  *) ok "prose's refusal is not dressed as a clean verdict" ;;
-esac
-
-# Control: staging the conflicted content resolves the index, and the SAME
-# bytes then fail as the violation they are — the guard did not replace the
-# measurement, it unblocked it.
-git -C "$R" add f.txt
-RC=0
-OUT="$(cd "$R" && "$SCRIPTS/conflict-markers" 2>&1)" || RC=$?
-[ "$RC" -eq 1 ] && case "$OUT" in *"conflict marker: f.txt:"*) true ;; *) false ;; esac \
-  && ok "once staged, the same markers fail as violations" \
-  || bad "once staged, the same markers fail as violations" "rc=$RC out=$OUT"
-
-# Control: a resolved, marker-free tree passes.
-printf 'line1\nmerged\nline3\n' >"$R/f.txt"
-git -C "$R" add f.txt
-RC=0
-OUT="$(cd "$R" && "$SCRIPTS/conflict-markers" 2>&1)" || RC=$?
-[ "$RC" -eq 0 ] && case "$OUT" in *"conflict-markers: OK"*) true ;; *) false ;; esac \
-  && ok "a resolved tree passes" \
-  || bad "a resolved tree passes" "rc=$RC out=$OUT"
-
-echo "=== byte-ceiling: an add/add conflict is not a zero-addition diff ==="
-
-# An add/add conflict is status U, which --diff-filter=A drops entirely: the
-# addition vanishes from the record set and the ceiling measures nothing.
-new_repo bc-addadd
-printf 'seed\n' >"$R/seed.txt"
-git -C "$R" add -A
-git -C "$R" commit -qm base
-git -C "$R" checkout -q -b other
-head -c 400000 /dev/zero | tr '\0' 'b' >"$R/big.txt"
-git -C "$R" add -A
-git -C "$R" commit -qm other
-git -C "$R" checkout -q main
-head -c 400000 /dev/zero | tr '\0' 'a' >"$R/big.txt"
-git -C "$R" add -A
-git -C "$R" commit -qm ours
-git -C "$R" merge other >/dev/null 2>&1 || true
-[ "$(git -C "$R" diff --cached --raw --diff-filter=A | wc -l)" -eq 0 ] \
-  && ok "the fixture really does hide the addition from --diff-filter=A" \
-  || bad "the fixture really does hide the addition from --diff-filter=A" "$(git -C "$R" diff --cached --raw --diff-filter=A)"
-
-RC=0
-OUT="$(cd "$R" && "$SCRIPTS/byte-ceiling" 2>&1)" || RC=$?
-[ "$RC" -eq 2 ] \
-  && ok "byte-ceiling refuses the unmerged index instead of measuring around it" \
-  || bad "byte-ceiling refuses the unmerged index instead of measuring around it" "rc=$RC out=$OUT"
-case "$OUT" in
-  *"0 staged addition(s) checked"* | *"byte-ceiling: OK"*)
-    bad "the refusal is not dressed as a clean measurement" "out=$OUT"
-    ;;
-  *) ok "the refusal is not dressed as a clean measurement" ;;
-esac
-
-RC=0
-OUT="$(cd "$R" && "$SCRIPTS/byte-ceiling" --all 2>&1)" || RC=$?
-[ "$RC" -eq 2 ] \
-  && ok "--all refuses it too, where ls-files emits one record per stage" \
-  || bad "--all refuses it too, where ls-files emits one record per stage" "rc=$RC out=$OUT"
-
-# Control: the guard did not replace the measurement. A merged index with a
-# genuinely new oversized file still fails the ceiling, and a merged index
-# with nothing oversized still passes.
-new_repo bc-merged
-printf 'seed\n' >"$R/seed.txt"
-git -C "$R" add -A
-git -C "$R" commit -qm base
-head -c 400000 /dev/zero | tr '\0' 'a' >"$R/big.txt"
-git -C "$R" add -A
-RC=0
-OUT="$(cd "$R" && "$SCRIPTS/byte-ceiling" 2>&1)" || RC=$?
-[ "$RC" -eq 1 ] && case "$OUT" in *big.txt*) true ;; *) false ;; esac \
-  && ok "a merged index still fails an oversized addition" \
-  || bad "a merged index still fails an oversized addition" "rc=$RC out=$OUT"
-git -C "$R" rm -q --cached big.txt
-rm -f "$R/big.txt"
-printf 'small\n' >"$R/small.txt"
-git -C "$R" add -A
-RC=0
-OUT="$(cd "$R" && "$SCRIPTS/byte-ceiling" 2>&1)" || RC=$?
-[ "$RC" -eq 0 ] && case "$OUT" in *"byte-ceiling: OK"*) true ;; *) false ;; esac \
-  && ok "a merged index with nothing oversized still passes" \
-  || bad "a merged index with nothing oversized still passes" "rc=$RC out=$OUT"
-
-echo "=== a failed policy read stops the gate, it does not become an empty list ==="
+# --- a failed policy read stops the gate ------------------------------------
 
 # gg_policy_content runs inside a command substitution, so its exit 2 dies in
 # that subshell and reaches gg_load_excludes as a bare status. This shim fails
@@ -319,548 +165,38 @@ printf 'seed\n' >"$R/seed.txt"
 mkdir -p "$R/tools"
 printf '# notes\n\nTODO: an unlinked work marker\n' >"$R/bad.md"
 printf 'bad.md\tallowed to carry markers\n' >"$R/tools/todo-ban-excludes"
-git -C "$R" add -A
-git -C "$R" commit -qm base
+commit_all base
 
-RC=0
-OUT="$(cd "$R" && "$SCRIPTS/todo-ban" 2>&1)" || RC=$?
-[ "$RC" -eq 0 ] && case "$OUT" in *"todo-ban: OK"*) true ;; *) false ;; esac \
-  && ok "control: with the excludes readable, the excluded marker passes" \
-  || bad "control: with the excludes readable, the excluded marker passes" "rc=$RC out=$OUT"
+lane() { # SHIM-DIR SCRIPT [ARG...] — one line for a lane run inside $R, SHIM-DIR first on PATH when given
+  local dir="$1" script="$2" rc=0 out
+  shift 2
+  out="$(cd "$R" && PATH="${dir:+$dir:}$PATH" "$SCRIPTS/$script" "$@" 2>&1)" || rc=$?
+  line "$rc" "$out"
+}
 
-RC=0
-OUT="$(cd "$R" && PATH="$ROOT/gitstub:$PATH" "$SCRIPTS/todo-ban" 2>&1)" || RC=$?
-[ "$RC" -eq 2 ] \
-  && ok "an unreadable exclusion list stops the run at exit 2" \
-  || bad "an unreadable exclusion list stops the run at exit 2" "rc=$RC out=$OUT"
-case "$OUT" in
-  *"refusing to run on an unread exclusion list"*)
-    ok "the refusal names the unread exclusion list"
-    ;;
-  *) bad "the refusal names the unread exclusion list" "out=$OUT" ;;
-esac
-# The failure mode this closes: an empty list is not "no exclusions apply".
-case "$OUT" in
-  *"work marker(s)"* | *"todo-ban: OK"*)
-    bad "the failed read never produces a verdict" "out=$OUT"
-    ;;
-  *) ok "the failed read never produces a verdict" ;;
-esac
+echo "=== a failed policy read stops the gate, it does not become an empty list ==="
+assert_eq "control: with the excludes readable, the excluded marker passes" \
+  "rc=0 todo-ban: OK — no work markers in tracked files" "$(lane "" todo-ban)"
+assert_eq "an unreadable exclusion list stops the run at exit 2, with no verdict" \
+  "rc=2 ::error::todo-ban: could not query the index for tools/todo-ban-excludes (git ls-files exit 128); refusing to treat it as untracked;::error::todo-ban: refusing to run on an unread exclusion list: tools/todo-ban-excludes (exit 2, cause above)" \
+  "$(lane "$ROOT/gitstub" todo-ban)"
 
-echo "=== gg_install_file: the destination is replaced whole, or not at all ==="
+# --- the settings cache ------------------------------------------------------
 
-new_repo install-file
-mkdir -p "$R/tools"
-printf 'ORIGINAL\n' >"$R/tools/dest.tsv"
-printf 'REPLACEMENT\n' >"$ROOT/src.tsv"
-call 'gg_tmpdir; gg_install_file "'"$ROOT"'/src.tsv" tools/dest.tsv "the fixture"'
-[ "$RC" -eq 0 ] && [ "$(cat "$R/tools/dest.tsv")" = "REPLACEMENT" ] \
-  && ok "a successful install replaces the destination" \
-  || bad "a successful install replaces the destination" "rc=$RC out=$OUT content=$(cat "$R/tools/dest.tsv")"
-[ -z "$(find "$R/tools" -name '*gg-install*')" ] \
-  && ok "a successful install leaves no residue beside the destination" \
-  || bad "a successful install leaves no residue beside the destination" "$(find "$R/tools" -name '*gg-install*')"
-
-# mktemp creates the staging file readable by its owner alone, so a rename
-# that does not take the destination's mode narrows a tracked file every
-# clone reads. The control is the same call against a destination that does
-# not exist yet, where there is no mode to take.
-filemode() { stat -c '%a' "$1" 2>/dev/null || stat -f '%Lp' "$1"; }
-chmod 644 "$R/tools/dest.tsv"
-call 'gg_tmpdir; gg_install_file "'"$ROOT"'/src.tsv" tools/dest.tsv "the fixture"'
-[ "$RC" -eq 0 ] && [ "$(filemode "$R/tools/dest.tsv")" = 644 ] \
-  && ok "an existing destination keeps its own mode" \
-  || bad "an existing destination keeps its own mode" "rc=$RC mode=$(filemode "$R/tools/dest.tsv")"
-chmod 755 "$R/tools/dest.tsv"
-call 'gg_tmpdir; gg_install_file "'"$ROOT"'/src.tsv" tools/dest.tsv "the fixture"'
-[ "$RC" -eq 0 ] && [ "$(filemode "$R/tools/dest.tsv")" = 755 ] \
-  && ok "control: a mode neither the staging default nor the umask gives is kept too" \
-  || bad "control: a mode neither the staging default nor the umask gives is kept too" "rc=$RC mode=$(filemode "$R/tools/dest.tsv")"
-rm -f "$R/tools/fresh.tsv"
-call 'gg_tmpdir; gg_install_file "'"$ROOT"'/src.tsv" tools/fresh.tsv "the fixture"'
-[ "$RC" -eq 0 ] && [ "$(cat "$R/tools/fresh.tsv")" = "REPLACEMENT" ] \
-  && ok "control: a destination that does not exist yet installs with no mode to take" \
-  || bad "control: a destination that does not exist yet installs with no mode to take" "rc=$RC out=$OUT"
-
-# A destination without owner-write. The mode is READ before the staging file
-# is written and applied after, never carried onto it in between: staging
-# under the destination's own mode makes the write fail on a file this
-# process just created, and reports a staging error for what is the
-# destination's mode.
-printf 'REPLACED THROUGH A READ-ONLY DESTINATION\n' >"$ROOT/ro.tsv"
-chmod 444 "$R/tools/dest.tsv"
-call 'gg_tmpdir; gg_install_file "'"$ROOT"'/ro.tsv" tools/dest.tsv "the fixture"'
-[ "$RC" -eq 0 ] && [ "$(cat "$R/tools/dest.tsv")" = "REPLACED THROUGH A READ-ONLY DESTINATION" ] \
-  && ok "a destination without owner-write is still replaced" \
-  || bad "a destination without owner-write is still replaced" "rc=$RC out=$OUT content=$(cat "$R/tools/dest.tsv")"
-# Content AND mode in one condition: 444 survives an install that never
-# happened just as well as one that did, so a mode assertion standing alone
-# here cannot tell a preserved mode from a rename that stopped at a prompt.
-[ "$(filemode "$R/tools/dest.tsv")" = 444 ] \
-  && [ "$(cat "$R/tools/dest.tsv")" = "REPLACED THROUGH A READ-ONLY DESTINATION" ] \
-  && ok "and keeps its read-only mode across the rename that replaced it" \
-  || bad "and keeps its read-only mode across the rename that replaced it" "mode=$(filemode "$R/tools/dest.tsv") content=$(cat "$R/tools/dest.tsv")"
-chmod 644 "$R/tools/dest.tsv"
-
-# A SYMLINK destination. `[ -f "$dest" ]` follows the link and the mode read
-# must follow it too: reading the link's own 0777 instead would publish a
-# world-writable file where a 0644 one stood — and for the suppression
-# baseline this helper writes, world-writable means any local account can
-# lower the ratchet without repository write access.
-mkdir -p "$ROOT/outside"
-printf 'BEHIND THE LINK\n' >"$ROOT/outside/target.tsv"
-chmod 644 "$ROOT/outside/target.tsv"
-ln -sf "$ROOT/outside/target.tsv" "$R/tools/linked.tsv"
-[ "$(filemode "$R/tools/linked.tsv")" != 644 ] \
-  && ok "the fixture link really carries a mode of its own, unlike its target" \
-  || bad "the fixture link really carries a mode of its own, unlike its target" "link=$(filemode "$R/tools/linked.tsv")"
-call 'gg_tmpdir; gg_install_file "'"$ROOT"'/src.tsv" tools/linked.tsv "the fixture"'
-[ "$RC" -eq 0 ] && [ "$(filemode "$R/tools/linked.tsv")" = 644 ] \
-  && [ "$(cat "$R/tools/linked.tsv")" = "REPLACEMENT" ] \
-  && ok "a symlink destination takes the mode of the file behind it, not the link's" \
-  || bad "a symlink destination takes the mode of the file behind it, not the link's" "rc=$RC mode=$(filemode "$R/tools/linked.tsv") out=$OUT"
-
-# A mode that cannot be read is a loud refusal, never a rename that narrows
-# the destination to the staging file's owner-only bits. `stat` shadowed by a
-# failing stub is the only way to reach it: every real file has a mode.
-mkdir -p "$ROOT/nostat"
-printf '#!/bin/sh\nexit 1\n' >"$ROOT/nostat/stat"
-chmod +x "$ROOT/nostat/stat"
-RC=0
-OUT="$(cd "$R" && PATH="$ROOT/nostat:$PATH" GG_CHECK=probe bash -c '
-  set -euo pipefail
-  . "$1"
-  . "$2"
-  gg_tmpdir
-  gg_install_file "$3" tools/dest.tsv "the fixture"
-' _ "$COMMON" "$INSTALL" "$ROOT/src.tsv" 2>&1)" || RC=$?
-[ "$RC" -eq 2 ] && case "$OUT" in *"could not read the mode of tools/dest.tsv"*) true ;; *) false ;; esac \
-  && ok "an unreadable mode is a loud refusal, not a narrowing rename" \
-  || bad "an unreadable mode is a loud refusal, not a narrowing rename" "rc=$RC out=$OUT"
-[ "$(filemode "$R/tools/dest.tsv")" = 644 ] \
-  && ok "and the destination keeps the mode it had" \
-  || bad "and the destination keeps the mode it had" "mode=$(filemode "$R/tools/dest.tsv")"
-
-# The scratch directory each step's stderr is captured into. Without one,
-# GG_TMP is set-but-EMPTY, so the capture would resolve to /install.err — a
-# path outside the repository, and one whose failure would itself be the bare
-# shell line this capture exists to stop. Every caller in the family arms
-# gg_tmpdir; one that has not is a programming error that says so.
-RC=0
-OUT="$(cd "$R" && GG_CHECK=probe bash -c '
-  set -euo pipefail
-  . "$1"
-  . "$2"
-  gg_install_file "$3" tools/dest.tsv "the fixture"
-' _ "$COMMON" "$INSTALL" "$ROOT/src.tsv" 2>&1)" || RC=$?
-[ "$RC" -eq 2 ] && case "$OUT" in *"needs gg_tmpdir called first"*) true ;; *) false ;; esac \
-  && ok "an install with no scratch directory refuses rather than writing beside the root" \
-  || bad "an install with no scratch directory refuses rather than writing beside the root" "rc=$RC out=$OUT"
-[ -z "$(find "$R/tools" -name '*gg-install*')" ] \
-  && ok "and stages nothing before refusing" \
-  || bad "and stages nothing before refusing" "$(find "$R/tools" -name '*gg-install*')"
-
-# The chmod branch: its whole diagnostic — the mode it could not give, and
-# what chmod said — is otherwise unpinned, so it could regress to a bare
-# symptom line with every suite green. A failing stub ahead of PATH, in the
-# same shape as the stat and mv stubs.
-mkdir -p "$ROOT/nochmod"
-printf '#!/bin/sh\necho "chmod: refused by the test stub" >&2\nexit 1\n' >"$ROOT/nochmod/chmod"
-chmod +x "$ROOT/nochmod/chmod"
-# Its own known destination state, so this case reports on the chmod branch
-# rather than on whatever the case above it managed to install.
-printf 'BEFORE THE CHMOD REFUSAL\n' >"$R/tools/dest.tsv"
-chmod 644 "$R/tools/dest.tsv"
-RC=0
-OUT="$(cd "$R" && PATH="$ROOT/nochmod:$PATH" GG_CHECK=probe bash -c '
-  set -euo pipefail
-  . "$1"
-  . "$2"
-  gg_tmpdir
-  gg_install_file "$3" tools/dest.tsv "the fixture"
-' _ "$COMMON" "$INSTALL" "$ROOT/src.tsv" 2>&1)" || RC=$?
-[ "$RC" -eq 2 ] && case "$OUT" in *"could not give the replacement for the fixture tools/dest.tsv's mode (644)"*) true ;; *) false ;; esac \
-  && ok "a failed chmod names the mode it could not give" \
-  || bad "a failed chmod names the mode it could not give" "rc=$RC out=$OUT"
-case "$OUT" in
-  *"could not give the replacement"*"refused by the test stub"*)
-    ok "and carries what chmod said inside its own line" ;;
-  *) bad "and carries what chmod said inside its own line" "$OUT" ;;
-esac
-[ "$(cat "$R/tools/dest.tsv")" = "BEFORE THE CHMOD REFUSAL" ] \
-  && ok "and the destination is untouched by that refusal" \
-  || bad "and the destination is untouched by that refusal" "content=$(cat "$R/tools/dest.tsv")"
-
-# A planted staging file must not redirect the write. cp writes THROUGH a
-# symlink, so a staging name the repository can predict is an arbitrary-file
-# overwrite waiting for the next --update. The writer publishes its own pid
-# and waits, so the symlink is planted at the EXACT name a pid-derived
-# scheme would choose — the control is aimed, not a guess.
-new_repo install-symlink
-mkdir -p "$R/tools"
-printf 'ORIGINAL\n' >"$R/tools/dest.tsv"
-printf 'VICTIM\n' >"$ROOT/victim.txt"
-pidfile="$ROOT/writer.pid"
-gofile="$ROOT/writer.go"
-rm -f "$pidfile" "$gofile"
-(
-  cd "$R" && GG_CHECK=probe bash -c '
-    set -euo pipefail
-    echo "$$" >"$3"
-    i=0
-    while [ ! -e "$4" ] && [ "$i" -lt 200 ]; do i=$((i + 1)); sleep 0.05; done
-    . "$1"
-    . "$2"
-    gg_tmpdir
-    gg_install_file "$5" tools/dest.tsv "the fixture"
-  ' _ "$COMMON" "$INSTALL" "$pidfile" "$gofile" "$ROOT/src.tsv"
-) >"$ROOT/writer.out" 2>&1 &
-writer=$!
-i=0
-while [ ! -s "$pidfile" ] && [ "$i" -lt 200 ]; do i=$((i + 1)); sleep 0.05; done
-if [ -s "$pidfile" ]; then
-  ln -s "$ROOT/victim.txt" "$R/tools/.gg-install.$(cat "$pidfile").dest.tsv"
-  ok "the control is aimed at the pid the writer actually uses"
-else
-  bad "the control is aimed at the pid the writer actually uses" "no pid published"
-fi
-: >"$gofile"
-wait "$writer" || true
-[ "$(cat "$ROOT/victim.txt")" = "VICTIM" ] \
-  && ok "a planted staging symlink does not redirect the write" \
-  || bad "a planted staging symlink does not redirect the write" "victim=$(cat "$ROOT/victim.txt")"
-[ "$(cat "$R/tools/dest.tsv")" = "REPLACEMENT" ] \
-  && ok "the install still lands on its real destination" \
-  || bad "the install still lands on its real destination" "content=$(cat "$R/tools/dest.tsv") out=$(cat "$ROOT/writer.out")"
-[ -z "$(find "$R/tools" -name '.gg-install.*.XXXXXX' -o -name '*.gg-install.??????')" ] \
-  && ok "no staging file is left behind beside the destination" \
-  || bad "no staging file is left behind beside the destination" "$(find "$R/tools" -name '*gg-install*')"
-
-# Control: interrupt the install at the rename. The destination must still
-# carry the reviewed bytes — a truncated ratchet file loosens the gate
-# instead of failing it, so a half-done replace is worse than none.
-new_repo install-fails
-mkdir -p "$R/tools" "$ROOT/stub"
-printf 'ORIGINAL\n' >"$R/tools/dest.tsv"
-printf '#!/bin/sh\nexit 1\n' >"$ROOT/stub/mv"
-chmod +x "$ROOT/stub/mv"
-RC=0
-OUT="$(cd "$R" && PATH="$ROOT/stub:$PATH" GG_CHECK=probe bash -c '
-  set -euo pipefail
-  . "$1"
-  . "$2"
-  gg_tmpdir
-  gg_install_file "$3" tools/dest.tsv "the fixture"
-' _ "$COMMON" "$INSTALL" "$ROOT/src.tsv" 2>&1)" || RC=$?
-[ "$RC" -eq 2 ] && case "$OUT" in *"could not replace the fixture"*) true ;; *) false ;; esac \
-  && ok "a failed rename is a loud collection error" \
-  || bad "a failed rename is a loud collection error" "rc=$RC out=$OUT"
-[ "$(cat "$R/tools/dest.tsv")" = "ORIGINAL" ] \
-  && ok "a failed install leaves the destination byte-identical" \
-  || bad "a failed install leaves the destination byte-identical" "content=$(cat "$R/tools/dest.tsv")"
-
-echo "=== the settings cache is materialized by rename, never by a live redirect ==="
-
+mkdir -p "$ROOT/nomv"
+printf '#!/bin/sh\nexit 1\n' >"$ROOT/nomv/mv"
+chmod +x "$ROOT/nomv/mv"
 new_repo settings-cache
 printf 'COMMIT_GUARDS_TODO_MAX=7\n' >"$R/kendex.settings.toml"
-git -C "$R" add -A
-git -C "$R" commit -qm base
-RC=0
-OUT="$(cd "$R" && PATH="$ROOT/stub:$PATH" GG_CHECK=probe bash -c '
-  set -euo pipefail
-  . "$1"
-  . "$2"
-  gg_settings_index_mode
-  src="$(gg_settings_source kendex.settings.toml)" || exit 3
-  printf "SRC=%s\n" "$src"
-  ls -A "$GG_SETTINGS_INDEX_DIR"
-' _ "$COMMON" "$SETTINGS" 2>&1)" || RC=$?
-[ "$RC" -eq 3 ] && case "$OUT" in *"could not materialize the staged copy"*) true ;; *) false ;; esac \
-  && ok "a failed rename fails the settings resolve loudly" \
-  || bad "a failed rename fails the settings resolve loudly" "rc=$RC out=$OUT"
-case "$OUT" in
-  *SRC=*) bad "no cache path is handed out when the rename failed" "out=$OUT" ;;
-  *) ok "no cache path is handed out when the rename failed" ;;
-esac
+commit_all base
+RESOLVE='gg_settings_index_mode; src="$(gg_settings_source kendex.settings.toml)" || exit 3; cat "$src"; find "$GG_SETTINGS_INDEX_DIR" -name "*.part" -print | sed "s/^/PART:/"'
 
-# Control: with mv working, the same resolve materializes a complete cache.
-RC=0
-OUT="$(cd "$R" && GG_CHECK=probe bash -c '
-  set -euo pipefail
-  . "$1"
-  . "$2"
-  gg_settings_index_mode
-  src="$(gg_settings_source kendex.settings.toml)"
-  cat "$src"
-  find "$GG_SETTINGS_INDEX_DIR" -name "*.part" -print | sed "s/^/PART:/"
-' _ "$COMMON" "$SETTINGS" 2>&1)" || RC=$?
-[ "$RC" -eq 0 ] && case "$OUT" in *COMMIT_GUARDS_TODO_MAX=7*) true ;; *) false ;; esac \
-  && ok "the cache resolves the staged value when the rename succeeds" \
-  || bad "the cache resolves the staged value when the rename succeeds" "rc=$RC out=$OUT"
-case "$OUT" in
-  *PART:*) bad "no partial cache file survives the resolve" "out=$OUT" ;;
-  *) ok "no partial cache file survives the resolve" ;;
-esac
-
-echo "=== gg_grep_lane: content decides what is scanned, an attributes rule never does ==="
-
-# Every index-wide lane in the family scans through gg_grep_lane. `git grep
-# -I` takes its binary verdict from the path's userdiff driver, so ONE
-# committed attributes row would put a whole extension outside the scan with
-# no status and no stderr — a clean verdict over content never read. Each
-# lane is pinned end to end, each against a control proving the same fixture
-# fails without the row.
-run_check() { # SCRIPT [ARG...] — RC and OUT from a run inside $R
-  local script="$1"; shift; RC=0
-  OUT="$(cd "$R" && "$SCRIPTS/$script" "$@" 2>&1)" || RC=$?
-}
-
-new_repo attrs-todo
-# Spelled in halves so this suite is not itself a work marker.
-MARKER="TO""DO"
-printf 'x = 1  # %s: real\n' "$MARKER" >"$R/code.py"
-git -C "$R" add -A
-run_check todo-ban
-[ "$RC" -eq 1 ] && case "$OUT" in *"work marker: code.py:1:"*) true ;; *) false ;; esac \
-  && ok "control: the marker fails with no attributes row" \
-  || bad "control: the marker fails with no attributes row" "rc=$RC out=$OUT"
-printf '*.py -diff\n' >"$R/.gitattributes"
-git -C "$R" add -A
-# The fixture is real only if git's own -I judgement has in fact flipped.
-RC=0
-OUT="$(cd "$R" && git grep --cached -nIE "$MARKER" -- 'code.py' 2>&1)" || RC=$?
-[ "$RC" -eq 1 ] && [ -z "$OUT" ] \
-  && ok "fixture: with '*.py -diff' a bare -I grep drops the file silently" \
-  || bad "fixture: -diff makes a bare -I grep drop the file" "rc=$RC out=$OUT"
-run_check todo-ban
-[ "$RC" -eq 1 ] && case "$OUT" in *"work marker: code.py:1:"*) true ;; *) false ;; esac \
-  && ok "the index-wide todo-ban lane still reads a '-diff' path" \
-  || bad "index-wide todo-ban reads a '-diff' path" "rc=$RC out=$OUT"
-case "$OUT" in *"OK — no work markers"*) bad "no clean verdict may accompany the hidden marker" "$OUT" ;; *) ok "no clean verdict accompanies the hidden marker" ;; esac
-printf '*.py binary\n' >"$R/.gitattributes"
-git -C "$R" add -A
-run_check todo-ban
-[ "$RC" -eq 1 ] && case "$OUT" in *"work marker: code.py:1:"*) true ;; *) false ;; esac \
-  && ok "the 'binary' attribute macro cannot hide it either" \
-  || bad "'binary' macro cannot hide the marker" "rc=$RC out=$OUT"
-
-new_repo attrs-conflict
-printf '<<<<<<< HEAD\na\n=======\nb\n>>>>>>> other\n' >"$R/merge.txt"
-git -C "$R" add -A
-run_check conflict-markers
-[ "$RC" -eq 1 ] && case "$OUT" in *"conflict marker: merge.txt:1:"*) true ;; *) false ;; esac \
-  && ok "control: the conflict markers fail with no attributes row" \
-  || bad "control: conflict markers fail without the row" "rc=$RC out=$OUT"
-printf '*.txt -diff\n' >"$R/.gitattributes"
-git -C "$R" add -A
-run_check conflict-markers
-[ "$RC" -eq 1 ] && case "$OUT" in *"conflict marker: merge.txt:1:"*) true ;; *) false ;; esac \
-  && ok "a '-diff' row cannot hide a conflict marker" \
-  || bad "'-diff' row cannot hide a conflict marker" "rc=$RC out=$OUT"
-
-new_repo attrs-suppression
-printf '#![allow(dead_code)]\n' >"$R/lib.rs"
-git -C "$R" add -A
-run_check suppression-ban
-[ "$RC" -eq 1 ] && case "$OUT" in *"module-wide rust allow: lib.rs:1:"*) true ;; *) false ;; esac \
-  && ok "control: the blanket allow fails with no attributes row" \
-  || bad "control: blanket allow fails without the row" "rc=$RC out=$OUT"
-printf '*.rs -diff\n' >"$R/.gitattributes"
-git -C "$R" add -A
-run_check suppression-ban
-[ "$RC" -eq 1 ] && case "$OUT" in *"module-wide rust allow: lib.rs:1:"*) true ;; *) false ;; esac \
-  && ok "a '-diff' row cannot hide a blanket suppression" \
-  || bad "'-diff' row cannot hide a blanket suppression" "rc=$RC out=$OUT"
-
-# Gate 2, the bare-allow ratchet, counts over that same content rule. An
-# attributes row that emptied its count file would read as "no bare allows
-# anywhere", and the stale rows that follow print a remedy — `--update` —
-# that erases the ratchet while the violations stand.
-new_repo attrs-ratchet
-mkdir -p "$R/tools"
-printf '#[allow(dead_code)]\nfn a() {}\n' >"$R/a.rs"
-printf '#[allow(dead_code)]\nfn b() {}\n' >"$R/b.rs"
-printf 'b.rs\t1\n' >"$R/tools/suppression-baseline.tsv"
-git -C "$R" add -A
-run_check suppression-ban
-[ "$RC" -eq 1 ] && case "$OUT" in *"new bare allow: a.rs"*) true ;; *) false ;; esac \
-  && ok "control: the unbaselined bare allow fails with no attributes row" \
-  || bad "control: unbaselined bare allow fails without the row" "rc=$RC out=$OUT"
-case "$OUT" in
-  *"stale baseline row: b.rs"*) bad "control: a live baseline row is not called stale" "out=$OUT" ;;
-  *) ok "control: a live baseline row is not called stale" ;;
-esac
-
-printf '*.rs -diff\n' >"$R/.gitattributes"
-git -C "$R" add -A
-run_check suppression-ban
-[ "$RC" -eq 1 ] && case "$OUT" in *"new bare allow: a.rs"*) true ;; *) false ;; esac \
-  && ok "a '-diff' row cannot hide a bare allow from the ratchet count" \
-  || bad "'-diff' row cannot hide a bare allow" "rc=$RC out=$OUT"
-case "$OUT" in
-  *"stale baseline row: b.rs"*) bad "an emptied count never turns a live row stale" "out=$OUT" ;;
-  *) ok "an emptied count never turns a live row stale" ;;
-esac
-case "$OUT" in
-  *"suppression-ban: OK"*) bad "no clean verdict accompanies the hidden bare allows" "out=$OUT" ;;
-  *) ok "no clean verdict accompanies the hidden bare allows" ;;
-esac
-
-# The remedy those stale rows print, followed to its end: --update must not
-# be able to write a 0-row baseline while both files still carry bare
-# allows. The baseline is tighten-only, so a row dropped here never returns.
-RC=0
-OUT="$(cd "$R" && "$SCRIPTS/suppression-ban" --update 2>&1)" || RC=$?
-[ "$(cat "$R/tools/suppression-baseline.tsv")" = "b.rs${TAB}1" ] \
-  && ok "--update cannot be led into erasing the ratchet" \
-  || bad "--update cannot be led into erasing the ratchet" "baseline=$(cat "$R/tools/suppression-baseline.tsv") out=$OUT"
-[ "$RC" -eq 1 ] && case "$OUT" in *"new bare allow: a.rs"*) true ;; *) false ;; esac \
-  && ok "the re-check after --update still fails the bare allow" \
-  || bad "the re-check after --update still fails" "rc=$RC out=$OUT"
-
-# The other half of forcing text: what the scan may NOT decode. The judgement
-# is the blob's own bytes — a NUL in its leading block, git's content rule —
-# so an asset whose bytes happen to spell the shape is skipped rather than
-# reported as a violation record full of raw bytes.
-new_repo attrs-binary
-printf 'PNG\000 %s: not a marker\n' "$MARKER" >"$R/logo.png"
-git -C "$R" add -A
-run_check todo-ban
-[ "$RC" -eq 0 ] && case "$OUT" in *"OK — no work markers"*) true ;; *) false ;; esac \
-  && ok "a blob whose leading bytes carry a NUL is not scanned" \
-  || bad "binary blob is not scanned" "rc=$RC out=$OUT"
-case "$OUT" in *"$MARKER"*) bad "no raw bytes from the asset reach the output" "$OUT" ;; *) ok "no raw bytes from the asset reach the output" ;; esac
-# The path MATCHED the banned shape and was then left unread, so it is named
-# and counted apart: an unqualified OK here would be a clean verdict over
-# content the lane deliberately did not scan.
-case "$OUT" in
-  *"todo-ban: not measured: logo.png — binary content"*)
-    ok "the unread match is named, not silently dropped"
-    ;;
-  *) bad "the unread match is named" "out=$OUT" ;;
-esac
-case "$OUT" in
-  *"OK — no work markers in tracked files; 1 matched path(s) not measured"*)
-    ok "the verdict carries the qualifier rather than reading as a plain OK"
-    ;;
-  *) bad "the verdict carries the qualifier" "out=$OUT" ;;
-esac
-# Control: the same bytes without the NUL are text, and text is scanned.
-printf 'PNG  %s: not a marker\n' "$MARKER" >"$R/logo.png"
-git -C "$R" add -A
-run_check todo-ban
-[ "$RC" -eq 1 ] && case "$OUT" in *"work marker: logo.png:1:"*) true ;; *) false ;; esac \
-  && ok "control: the same bytes without the NUL are scanned as text" \
-  || bad "control: same bytes without the NUL are scanned" "rc=$RC out=$OUT"
-case "$OUT" in
-  *"not measured"*) bad "control: a scanned path is never named as unmeasured" "out=$OUT" ;;
-  *) ok "control: a scanned path is never named as unmeasured" ;;
-esac
-
-echo "=== the shared readers fail closed, once, for every lane that uses them ==="
-
-# gg_grep_guard, gg_read_blob and gg_blob_is_binary are the family's index
-# readers: every lane collects through them, so an incomplete scan is refused
-# HERE, once — including the call sites no default-lane run reaches, which
-# the arms below drive through the lane that owns them.
-REAL_GIT="$(command -v git)"
-git_failing_on() { # ARG [LANE-ARG...] — todo-ban under a git that exits 128 for ARG
-  local a="$1" dir="$TMP/git-shim-$1"; shift; mkdir -p "$dir"
-  printf '#!/usr/bin/env bash\ncase " $* " in *" %s "*) echo "git %s: simulated failure" >&2; exit 128 ;; esac\nexec "%s" "$@"\n' "$a" "$a" "$REAL_GIT" >"$dir/git"
-  chmod +x "$dir/git"
-  under_shim "$dir" todo-ban "$@"
-}
-under_shim() { # SHIM-DIR SCRIPT [ARG...] — run SCRIPT with SHIM-DIR first on PATH
-  local dir="$1"; shift; local script="$1"; shift; RC=0
-  OUT="$(cd "$R" && PATH="$dir:$PATH" "$SCRIPTS/$script" "$@" 2>&1)" || RC=$?
-}
-refused() { # LABEL NEEDLE [CHECK] — exit 2 carrying NEEDLE, and never a clean verdict
-  [ "$RC" -eq 2 ] && case "$OUT" in *"$2"*) true ;; *) false ;; esac \
-    && ok "$1" || bad "$1" "rc=$RC out=$OUT"
-  case "$OUT" in *"${3:-todo-ban}: OK"*) bad "no OK verdict may accompany $1" "$OUT" ;; *) ok "and no OK verdict accompanies it" ;; esac
-}
-
-new_repo readers
-printf '// %s: stranded work\n' "$MARKER" >"$R/a.rs"
-git -C "$R" add -A
-run_check todo-ban
-[ "$RC" -eq 1 ] && ok "control: the staged marker trips with the real git" \
-  || bad "control: the staged marker trips" "rc=$RC out=$OUT"
-git_failing_on grep
-refused "a git grep execution failure is a collection error, never OK" "git grep failed scanning tracked files"
-git_failing_on cat-file
-refused "a blob read that cannot run is exit 2, never a path skipped" "refusing to skip an unread work marker"
-# git spends no error status on a staged blob it cannot read: the `error:`
-# line on stderr is all that separates a partial scan from a clean one.
-OID="$(git -C "$R" rev-parse :a.rs)"
-[ -f "$R/.git/objects/${OID:0:2}/${OID:2}" ] || bad "fixture: the staged blob is a loose object" "$OID"
-rm -f -- "$R/.git/objects/${OID:0:2}/${OID:2}"
-run_check todo-ban
-refused "a vanished staged blob is exit 2 carrying git's own error line" "unable to read"
-printf '// %s: readable\n' "$MARKER" >"$R/b.rs"
-git -C "$R" add b.rs
-run_check todo-ban
-refused "a scan matching one file it read and one it could not is exit 2, never a violation" "unable to read"
-
-# The --staged lane reaches the same readers through calls of its own that
-# the default lane never makes: the carriers pre-filter grep, and the
-# per-file content sniff that reads each staged blob. The fixture stages a
-# marker, so no arm below can be clean by construction.
-new_repo readers-staged
-printf 'fn main() {}\n' >"$R/ok.rs"
-git -C "$R" add -A
-git -C "$R" commit -qm seed
-printf '// %s: staged for the pre-filter to find\n' "$MARKER" >>"$R/ok.rs"
-git -C "$R" add ok.rs
-run_check todo-ban --staged
-[ "$RC" -eq 1 ] && ok "control: the staged marker fires with the real tools" \
-  || bad "control: the staged marker fires" "rc=$RC out=$OUT"
-git_failing_on grep --staged
-refused "a broken staged pre-filter is a collection error, never OK" "git grep failed listing the staged files that carry a work marker"
-git_failing_on cat-file --staged
-refused "a staged blob the sniff cannot read is exit 2, never a path skipped" "refusing to skip an unread work marker"
-
-# gg_blob_is_binary sizes the leading bytes twice, and neither count may
-# decide the verdict after failing: a silent zero out of the NUL strip reads
-# as "every byte was a NUL" and folds an unread blob into a clean pass. One
-# shim per count — the wc shim fails once, so the first count fails while
-# the second succeeds; the tr shim breaks only the strip inside the second.
-COUNT_SHIM="$TMP/count-shim"
-mkdir -p "$COUNT_SHIM"
-printf '#!/usr/bin/env bash\nif [ ! -e "%s" ]; then : >"%s"; echo "wc: simulated execution failure" >&2; exit 1; fi\nexec "%s" "$@"\n' \
-  "$TMP/wc-fired" "$TMP/wc-fired" "$(command -v wc)" >"$COUNT_SHIM/wc"
-chmod +x "$COUNT_SHIM/wc"
-rm -f "$TMP/wc-fired"
-under_shim "$COUNT_SHIM" todo-ban --staged
-refused "a first block that cannot be sized is exit 2, never OK" "could not sample ok.rs to classify its content"
-TR_SHIM="$TMP/tr-shim"
-mkdir -p "$TR_SHIM"
-printf '#!/usr/bin/env bash\necho "tr: simulated execution failure" >&2\nexit 1\n' >"$TR_SHIM/tr"
-chmod +x "$TR_SHIM/tr"
-under_shim "$TR_SHIM" todo-ban --staged
-refused "a NUL-free count that cannot run is exit 2, never OK" "could not sample ok.rs to classify its content"
-
-# suppression-ban's per-carrier count is its own call, made after the shared
-# listing has already named the carrier, and it is the one gg_grep_guard site
-# outside lib/. The shim errors that call alone and exits 0, so the `error:`
-# line gg_grep_guard reads off stderr is the only thing left that can refuse
-# a count which would otherwise read as a clean zero.
-new_repo readers-count
-mkdir -p "$R/tools"
-printf 'fn main() {}\n' >"$R/ok.rs"
-printf '#[allow(dead_code)]\nfn b() {}\n' >"$R/bare.rs"
-printf 'bare.rs\t1\n' >"$R/tools/suppression-baseline.tsv"
-git -C "$R" add -A
-run_check suppression-ban
-[ "$RC" -eq 0 ] && ok "control: the baselined bare allow passes with the real git" \
-  || bad "control: the baselined bare allow passes" "rc=$RC out=$OUT"
-SB_COUNT_SHIM="$TMP/git-shim-count"
-mkdir -p "$SB_COUNT_SHIM"
-printf '#!/usr/bin/env bash\ncase " $* " in *" -acE "*) echo "error: %s: unable to read %s" >&2; exit 0 ;; esac\nexec "%s" "$@"\n' \
-  "'phantom.rs'" "0000000000000000000000000000000000000000" "$REAL_GIT" >"$SB_COUNT_SHIM/git"
-chmod +x "$SB_COUNT_SHIM/git"
-under_shim "$SB_COUNT_SHIM" suppression-ban
-refused "a count whose stderr carries an error line is exit 2, never a clean zero" "could not read staged content while counting the bare allows" suppression-ban
+echo "=== the settings cache is materialized by rename, never by a live redirect ==="
+assert_eq "the cache resolves the staged value when the rename succeeds, leaving no partial file" \
+  "rc=0 COMMIT_GUARDS_TODO_MAX=7" "$(call "$SETTINGS" "$RESOLVE")"
+assert_eq "a failed rename fails the resolve loudly and hands out no cache path" \
+  "rc=3 ::error::kendex.settings.toml: could not materialize the staged copy while resolving a setting" \
+  "$(call "$SETTINGS" "PATH=$ROOT/nomv:\$PATH; $RESOLVE")"
 
 printf '\n%s passed, %s failed\n' "$PASS" "$FAIL"
 [ "$FAIL" -eq 0 ]

--- a/.agents/skills/commit-guards/tests/lane-readers.test.sh
+++ b/.agents/skills/commit-guards/tests/lane-readers.test.sh
@@ -1,0 +1,249 @@
+#!/usr/bin/env bash
+# The lanes end to end over the readers lib/common.sh and
+# lib/configured-paths.sh share: an unmerged index is refused rather than
+# scanned around, content decides what gg_grep_lane scans and an attributes
+# rule never does, a blob whose leading bytes carry a NUL is named unmeasured
+# rather than scanned or dropped, and a reader git or a tool could not run is
+# a collection error, never a clean verdict. One table per family: a row
+# builds its own fixture repository, runs one lane under an optional PATH
+# shim, and reads back the exit status and every line printed.
+set -euo pipefail
+
+TEST_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=lib/harness.bash
+. "$TEST_DIR/lib/harness.bash"
+SKILL_DIR="$(cd "$TEST_DIR/.." && pwd)"
+SCRIPTS="$SKILL_DIR/scripts"
+ROOT="$TMP"
+REAL_GIT="$(command -v git)"
+
+unset COMMIT_GUARDS_SETTINGS_FILE COMMIT_GUARDS_CONFLICT_EXCLUDES 2>/dev/null || true
+
+PASS=0
+FAIL=0
+assert_eq() { # LABEL EXPECT ACTUAL
+  if [ "$2" = "$3" ]; then
+    PASS=$((PASS + 1))
+    printf '  ok    %s\n' "$1"
+  else
+    FAIL=$((FAIL + 1))
+    printf '  FAIL  %s\n        want: %s\n        got:  %s\n' "$1" "$2" "$3"
+  fi
+}
+
+new_repo() { # NAME — fresh fixture repo in $R, cwd unchanged
+  R="$ROOT/$1"
+  mkdir -p "$R"
+  git -C "$R" -c init.defaultBranch=main init -q
+  git -C "$R" config user.email test@example.com
+  git -C "$R" config user.name test
+}
+commit_all() { # MESSAGE
+  git -C "$R" add -A
+  git -C "$R" commit -qm "$1"
+}
+
+# One line for a lane run inside $R, SHIM-DIR first on PATH when given: the
+# exit status, then every printed line in order joined by ';', so a refusal
+# reads with git's own line above it and a verdict with its qualifier.
+lane() { # SHIM-DIR SCRIPT [ARG...]
+  local dir="$1" script="$2" rc=0 out
+  shift 2
+  out="$(cd "$R" && PATH="${dir:+$dir:}$PATH" "$SCRIPTS/$script" "$@" 2>&1)" || rc=$?
+  out="${out//"$R"/<repo>}"
+  out="${out//"$ROOT"/<root>}"
+  printf 'rc=%s%s' "$rc" "${out:+ $(printf '%s\n' "$out" | sed 's/[[:space:]]*$//' | paste -sd ';' -)}"
+}
+
+# Spelled in halves so this suite is not itself a work marker.
+MARKER="TO""DO"
+
+# --- an unmerged index -------------------------------------------------------
+
+conflicted_repo() { # NAME — fixture left mid-merge, f.txt unmerged
+  new_repo "$1"
+  printf 'line1\nbase\nline3\n' >"$R/f.txt"
+  commit_all base
+  git -C "$R" checkout -q -b other
+  printf 'line1\ntheirs\nline3\n' >"$R/f.txt"
+  git -C "$R" commit -qam other
+  git -C "$R" checkout -q main
+  printf 'line1\nours\nline3\n' >"$R/f.txt"
+  git -C "$R" commit -qam ours
+  git -C "$R" merge other >/dev/null 2>&1 || true
+}
+fx_conflict_staged() { conflicted_repo "$1"; git -C "$R" add f.txt; }
+fx_conflict_resolved() { conflicted_repo "$1"; printf 'line1\nmerged\nline3\n' >"$R/f.txt"; git -C "$R" add f.txt; }
+# An add/add conflict is status U, which --diff-filter=A drops entirely: the
+# addition vanishes from the record set and a ceiling measures nothing.
+fx_addadd() {
+  new_repo "$1"
+  printf 'seed\n' >"$R/seed.txt"
+  commit_all base
+  git -C "$R" checkout -q -b other
+  head -c 400000 /dev/zero | tr '\0' 'b' >"$R/big.txt"
+  commit_all other
+  git -C "$R" checkout -q main
+  head -c 400000 /dev/zero | tr '\0' 'a' >"$R/big.txt"
+  commit_all ours
+  git -C "$R" merge other >/dev/null 2>&1 || true
+}
+fx_merged_big() { new_repo "$1"; printf 'seed\n' >"$R/seed.txt"; commit_all base; head -c 400000 /dev/zero | tr '\0' 'a' >"$R/big.txt"; git -C "$R" add -A; }
+fx_merged_small() { new_repo "$1"; printf 'seed\n' >"$R/seed.txt"; commit_all base; printf 'small\n' >"$R/small.txt"; git -C "$R" add -A; }
+
+fx_addadd addadd-fixture
+assert_eq "the add/add fixture really hides the addition from --diff-filter=A" 0 "$(git -C "$R" diff --cached --raw --diff-filter=A | wc -l | tr -d ' ')"
+
+echo "=== an unmerged index is refused, never scanned around ==="
+UNMERGED="f.txt;::error::CHECK: the index carries 1 unmerged path(s) (listed above) and a --cached scan skips them silently — finish or abort the merge, then re-run"
+BIG_UNMERGED="big.txt;::error::byte-ceiling: the index carries 1 unmerged path(s) (listed above) and a --cached scan skips them silently — finish or abort the merge, then re-run"
+# label | fixture | lane args | expect
+rows=(
+  "conflict-markers refuses the unmerged index|conflicted_repo cm-unmerged|conflict-markers|rc=2 ${UNMERGED//CHECK/conflict-markers}"
+  "prose refuses it before its walk, though no default path matches|conflicted_repo prose-unmerged|prose|rc=2 ${UNMERGED//CHECK/prose}"
+  "control: once staged, the same markers fail as violations|fx_conflict_staged cm-staged|conflict-markers|rc=1 conflict-markers FAIL conflict marker: f.txt:2:<<<<<<< HEAD;  remedies: finish the merge and delete the marker lines; a file that legitimately carries the trio at column 0 belongs in tools/conflict-markers-excludes with a reason;conflict-markers FAIL conflict marker: f.txt:6:>>>>>>> other;  remedies: finish the merge and delete the marker lines; a file that legitimately carries the trio at column 0 belongs in tools/conflict-markers-excludes with a reason;conflict-markers: 2 conflict marker(s) — excludes tools/conflict-markers-excludes"
+  "control: a resolved, marker-free tree passes|fx_conflict_resolved cm-resolved|conflict-markers|rc=0 conflict-markers: OK — no conflict markers in tracked files"
+  "byte-ceiling refuses an add/add conflict instead of measuring around it|fx_addadd bc-addadd|byte-ceiling|rc=2 $BIG_UNMERGED"
+  "--all refuses it too, where ls-files emits one record per stage|fx_addadd bc-addadd-all|byte-ceiling --all|rc=2 $BIG_UNMERGED"
+  "control: a merged index still fails an oversized addition|fx_merged_big bc-merged-big|byte-ceiling|rc=1 byte-ceiling FAIL oversized file: big.txt — 400000 bytes (~391 KB) > ceiling 200 KB;  remedies: keep big artifacts out of the repo (asset store, Git LFS, build-time generation); a file that genuinely belongs gets a row in tools/byte-ceiling-excludes with its reason;byte-ceiling: 1 violation(s) — ceiling 200 KB, 1 staged file(s) checked"
+  "control: a merged index with nothing oversized passes|fx_merged_small bc-merged-small|byte-ceiling|rc=0 byte-ceiling: OK — 1 staged file(s) checked, ceiling 200 KB"
+)
+for row in "${rows[@]}"; do
+  IFS='|' read -r label fixture args expect <<<"$row"
+  $fixture
+  # shellcheck disable=SC2086
+  assert_eq "$label" "$expect" "$(lane "" $args)"
+done
+
+# --- content decides what is scanned ----------------------------------------
+
+# `git grep -I` takes its binary verdict from the path's userdiff driver, so
+# ONE committed attributes row would put a whole extension outside the scan
+# with no status and no stderr. Each lane is read with and without the row.
+fx_attrs() { # NAME FILE CONTENT [ATTR-ROW]
+  new_repo "$1"
+  printf '%b' "$3" >"$R/$2"
+  [ -z "${4:-}" ] || printf '%s\n' "$4" >"$R/.gitattributes"
+  git -C "$R" add -A
+}
+fx_ratchet() { # NAME [ATTR-ROW]
+  new_repo "$1"
+  mkdir -p "$R/tools"
+  printf '#[allow(dead_code)]\nfn a() {}\n' >"$R/a.rs"
+  printf '#[allow(dead_code)]\nfn b() {}\n' >"$R/b.rs"
+  printf 'b.rs\t1\n' >"$R/tools/suppression-baseline.tsv"
+  [ -z "${2:-}" ] || printf '%s\n' "$2" >"$R/.gitattributes"
+  git -C "$R" add -A
+}
+
+fx_attrs attrs-probe code.py "x = 1  # $MARKER: real\n" '*.py -diff'
+assert_eq "fixture: with '*.py -diff' a bare -I grep drops the file silently" "rc=1" \
+  "$(rc=0; out="$(cd "$R" && git grep --cached -nIE "$MARKER" -- code.py 2>&1)" || rc=$?; printf 'rc=%s%s' "$rc" "${out:+ $out}")"
+
+echo "=== content decides what is scanned, an attributes rule never does ==="
+TODO_HIT="todo-ban FAIL work marker: code.py:1:x = 1  # $MARKER: real;  remedies: do the work now, or move it to the tracker and delete the marker; vendored/generated trees belong in tools/todo-ban-excludes with a reason;todo-ban: 1 work marker(s) — excludes tools/todo-ban-excludes"
+SUPP_HIT="suppression-ban FAIL module-wide rust allow: lib.rs:1:#![allow(dead_code)];  remedies: delete the module-wide attribute and fix the findings, or annotate the surviving sites per line with a stated reason; vendored trees belong in tools/suppression-ban-excludes with a reason;suppression-ban: 1 violation(s) — 1 blanket, 0 ratchet (baseline tools/suppression-baseline.tsv)"
+RATCHET_HIT="suppression-ban FAIL new bare allow: a.rs — 1 reasonless allow(dead_code)/allow(unused) attribute(s), no baseline row;  remedies: state a reason on each attribute or fix the code; freezing a legacy count is a hand-added baseline row in this diff with justification;suppression-ban: 1 violation(s) — 0 blanket, 1 ratchet (baseline tools/suppression-baseline.tsv)"
+CM_HITS="conflict-markers FAIL conflict marker: merge.txt:1:<<<<<<< HEAD;  remedies: finish the merge and delete the marker lines; a file that legitimately carries the trio at column 0 belongs in tools/conflict-markers-excludes with a reason;conflict-markers FAIL conflict marker: merge.txt:5:>>>>>>> other;  remedies: finish the merge and delete the marker lines; a file that legitimately carries the trio at column 0 belongs in tools/conflict-markers-excludes with a reason;conflict-markers: 2 conflict marker(s) — excludes tools/conflict-markers-excludes"
+CONFLICT='<<<<<<< HEAD\na\n=======\nb\n>>>>>>> other\n'
+# label | file | content (%b) | attributes row | lane args | expect
+rows=(
+  "control: the marker fails with no attributes row|code.py|x = 1  # $MARKER: real\\n||todo-ban|rc=1 $TODO_HIT"
+  "the index-wide todo-ban lane still reads a '-diff' path|code.py|x = 1  # $MARKER: real\\n|*.py -diff|todo-ban|rc=1 $TODO_HIT"
+  "the 'binary' attribute macro cannot hide it either|code.py|x = 1  # $MARKER: real\\n|*.py binary|todo-ban|rc=1 $TODO_HIT"
+  "control: conflict markers fail with no attributes row|merge.txt|$CONFLICT||conflict-markers|rc=1 $CM_HITS"
+  "a '-diff' row cannot hide a conflict marker|merge.txt|$CONFLICT|*.txt -diff|conflict-markers|rc=1 $CM_HITS"
+  "control: the blanket allow fails with no attributes row|lib.rs|#![allow(dead_code)]\\n||suppression-ban|rc=1 $SUPP_HIT"
+  "a '-diff' row cannot hide a blanket suppression|lib.rs|#![allow(dead_code)]\\n|*.rs -diff|suppression-ban|rc=1 $SUPP_HIT"
+  "control: the unbaselined bare allow fails with no attributes row, the live row not called stale|ratchet|||suppression-ban|rc=1 $RATCHET_HIT"
+  "a '-diff' row cannot hide a bare allow from the ratchet count|ratchet||*.rs -diff|suppression-ban|rc=1 $RATCHET_HIT"
+  "--update cannot be led into erasing the ratchet: the re-check still fails|ratchet||*.rs -diff|suppression-ban --update|rc=1 suppression-ban --update: baseline tightened at tools/suppression-baseline.tsv (1 row(s));$RATCHET_HIT"
+)
+i=0
+for row in "${rows[@]}"; do
+  IFS='|' read -r label file content attr args expect <<<"$row"
+  i=$((i + 1))
+  if [ "$file" = ratchet ]; then fx_ratchet "attrs-$i" "$attr"; else fx_attrs "attrs-$i" "$file" "$content" "$attr"; fi
+  # shellcheck disable=SC2086
+  assert_eq "$label" "$expect" "$(lane "" $args)"
+done
+assert_eq "--update left the baseline as it was" "b.rs	1" "$(cat "$R/tools/suppression-baseline.tsv")"
+
+echo "=== a blob whose leading bytes carry a NUL is named unmeasured, not scanned ==="
+fx_attrs attrs-binary logo.png "PNG\0 $MARKER: not a marker\n"
+assert_eq "the unread match is named, counted apart, and the verdict carries the qualifier" \
+  "rc=0 todo-ban: not measured: logo.png — binary content, not text;todo-ban: OK — no work markers in tracked files; 1 matched path(s) not measured" "$(lane "" todo-ban)"
+fx_attrs attrs-text logo.png "PNG  $MARKER: not a marker\n"
+assert_eq "control: the same bytes without the NUL are scanned as text" \
+  "rc=1 todo-ban FAIL work marker: logo.png:1:PNG  $MARKER: not a marker;  remedies: do the work now, or move it to the tracker and delete the marker; vendored/generated trees belong in tools/todo-ban-excludes with a reason;todo-ban: 1 work marker(s) — excludes tools/todo-ban-excludes" "$(lane "" todo-ban)"
+
+# --- the shared readers fail closed -----------------------------------------
+
+# gg_grep_guard, gg_read_blob and gg_blob_is_binary are the family's index
+# readers: every lane collects through them, so an incomplete scan is refused
+# HERE, once, including the call sites no default-lane run reaches.
+git_shim() { # ARG — a git that exits 128 for any call carrying ARG
+  local dir="$ROOT/git-shim-$1"
+  mkdir -p "$dir"
+  printf '#!/usr/bin/env bash\ncase " $* " in *" %s "*) echo "git %s: simulated failure" >&2; exit 128 ;; esac\nexec "%s" "$@"\n' "$1" "$1" "$REAL_GIT" >"$dir/git"
+  chmod +x "$dir/git"
+}
+git_shim grep
+git_shim cat-file
+# A wc that fails once, so the first count fails while the second succeeds;
+# a tr that fails every time, breaking only the strip inside the second count.
+mkdir -p "$ROOT/wc-shim" "$ROOT/tr-shim" "$ROOT/count-shim"
+printf '#!/usr/bin/env bash\nif [ ! -e "%s" ]; then : >"%s"; echo "wc: simulated execution failure" >&2; exit 1; fi\nexec "%s" "$@"\n' \
+  "$ROOT/wc-fired" "$ROOT/wc-fired" "$(command -v wc)" >"$ROOT/wc-shim/wc"
+printf '#!/usr/bin/env bash\necho "tr: simulated execution failure" >&2\nexit 1\n' >"$ROOT/tr-shim/tr"
+# suppression-ban's per-carrier count is its own call, made after the shared
+# listing has named the carrier; the shim errors that call alone and exits 0,
+# so the `error:` line on stderr is the only thing left that can refuse it.
+printf '#!/usr/bin/env bash\ncase " $* " in *" -acE "*) echo "error: %s: unable to read %s" >&2; exit 0 ;; esac\nexec "%s" "$@"\n' \
+  "'phantom.rs'" "0000000000000000000000000000000000000000" "$REAL_GIT" >"$ROOT/count-shim/git"
+chmod +x "$ROOT/wc-shim/wc" "$ROOT/tr-shim/tr" "$ROOT/count-shim/git"
+
+# A sed script aliasing every staged blob's sha to OID(path): a reader that
+# names the blob it could not read is read back by the path it stands for.
+oid_aliases() {
+  git -C "$R" ls-files -s | awk '{ printf "s|%s|OID(%s)|g\n", $2, $4 }' >"$ROOT/oids.sed"
+  printf '%s' "$ROOT/oids.sed"
+}
+fx_readers() { new_repo "$1"; printf '// %s: stranded work\n' "$MARKER" >"$R/a.rs"; git -C "$R" add -A; }
+fx_vanished() { # NAME [SECOND] — the staged blob's loose object removed; a readable second file when asked
+  fx_readers "$1"
+  local oid
+  oid="$(git -C "$R" rev-parse :a.rs)"
+  [ -f "$R/.git/objects/${oid:0:2}/${oid:2}" ] || echo "fixture: the staged blob is not a loose object" >&2
+  rm -f -- "$R/.git/objects/${oid:0:2}/${oid:2}"
+  [ -z "${2:-}" ] || { printf '// %s: readable\n' "$MARKER" >"$R/b.rs"; git -C "$R" add b.rs; }
+}
+fx_staged() { new_repo "$1"; printf 'fn main() {}\n' >"$R/ok.rs"; commit_all seed; printf '// %s: staged for the pre-filter to find\n' "$MARKER" >>"$R/ok.rs"; git -C "$R" add ok.rs; rm -f "$ROOT/wc-fired"; }
+fx_count() { new_repo "$1"; mkdir -p "$R/tools"; printf 'fn main() {}\n' >"$R/ok.rs"; printf '#[allow(dead_code)]\nfn b() {}\n' >"$R/bare.rs"; printf 'bare.rs\t1\n' >"$R/tools/suppression-baseline.tsv"; git -C "$R" add -A; }
+
+echo "=== the shared readers fail closed, once, for every lane that uses them ==="
+A_HIT="todo-ban FAIL work marker: a.rs:1:// $MARKER: stranded work;  remedies: do the work now, or move it to the tracker and delete the marker; vendored/generated trees belong in tools/todo-ban-excludes with a reason;todo-ban: 1 work marker(s) — excludes tools/todo-ban-excludes"
+# label | fixture | shim | lane args | expect
+rows=(
+  "control: the staged marker trips with the real git|fx_readers readers-0||todo-ban|rc=1 $A_HIT"
+  "a git grep execution failure is a collection error, never OK|fx_readers readers-1|$ROOT/git-shim-grep|todo-ban|rc=2 git grep: simulated failure;::error::todo-ban: git grep failed scanning tracked files for work marker (exit 128)"
+  "a blob read that cannot run is exit 2, never a path skipped|fx_readers readers-2|$ROOT/git-shim-cat-file|todo-ban|rc=2 git cat-file: simulated failure;::error::todo-ban: cannot read blob :0:a.rs for a.rs — refusing to skip an unread work marker"
+  "a vanished staged blob is exit 2 carrying git's own error line|fx_vanished readers-3||todo-ban|rc=2 error: 'a.rs': unable to read OID(a.rs);::error::todo-ban: git grep could not read staged content while scanning tracked files for work marker (error: 'a.rs': unable to read OID(a.rs))"
+  "a scan matching one file it read and one it could not is exit 2, never a violation|fx_vanished readers-4 second||todo-ban|rc=2 error: 'a.rs': unable to read OID(a.rs);::error::todo-ban: git grep could not read staged content while scanning tracked files for work marker (error: 'a.rs': unable to read OID(a.rs))"
+  "control: the staged marker fires with the real tools|fx_staged staged-0||todo-ban --staged|rc=1 todo-ban FAIL work marker: ok.rs:2:// $MARKER: staged for the pre-filter to find;  remedies: do the work now, or move it to the tracker and delete the marker; vendored/generated trees belong in tools/todo-ban-excludes with a reason;todo-ban: 1 work marker(s) added by the staged diff — excludes tools/todo-ban-excludes"
+  "a broken staged pre-filter is a collection error, never OK|fx_staged staged-1|$ROOT/git-shim-grep|todo-ban --staged|rc=2 git grep: simulated failure;::error::todo-ban: git grep failed listing the staged files that carry a work marker (exit 128)"
+  "a staged blob the sniff cannot read is exit 2, never a path skipped|fx_staged staged-2|$ROOT/git-shim-cat-file|todo-ban --staged|rc=2 git cat-file: simulated failure;::error::todo-ban: cannot read blob OID(ok.rs) for ok.rs — refusing to skip an unread work marker"
+  "a first block that cannot be sized is exit 2, never OK|fx_staged staged-3|$ROOT/wc-shim|todo-ban --staged|rc=2 wc: simulated execution failure;::error::todo-ban: could not sample ok.rs to classify its content"
+  "a NUL-free count that cannot run is exit 2, never OK|fx_staged staged-4|$ROOT/tr-shim|todo-ban --staged|rc=2 tr: simulated execution failure;::error::todo-ban: could not sample ok.rs to classify its content"
+  "control: the baselined bare allow passes with the real git|fx_count count-0||suppression-ban|rc=0 suppression-ban: OK — no blanket suppressions, bare allows within baseline tools/suppression-baseline.tsv"
+  "a count whose stderr carries an error line is exit 2, never a clean zero|fx_count count-1|$ROOT/count-shim|suppression-ban|rc=2 error: 'phantom.rs': unable to read 0000000000000000000000000000000000000000;::error::suppression-ban: git grep could not read staged content while counting the bare allows in 'bare.rs' (error: 'phantom.rs': unable to read 0000000000000000000000000000000000000000)"
+)
+for row in "${rows[@]}"; do
+  IFS='|' read -r label fixture shim args expect <<<"$row"
+  $fixture
+  # shellcheck disable=SC2086
+  assert_eq "$label" "$expect" "$(lane "$shim" $args | sed -f "$(oid_aliases)")"
+done
+
+printf '\n%s passed, %s failed\n' "$PASS" "$FAIL"
+[ "$FAIL" -eq 0 ]

--- a/.agents/skills/commit-guards/tests/md-format.test.sh
+++ b/.agents/skills/commit-guards/tests/md-format.test.sh
@@ -4,7 +4,7 @@
 # files the docs say, the remedy names md-reflow, and what cannot be judged
 # is named rather than passed. Every green assertion is paired with a
 # control that proves it can fail. The index readers this family shares are
-# pinned once, in index-reads.test.sh.
+# pinned once, in index-reads.test.sh and lane-readers.test.sh.
 set -euo pipefail
 
 TEST_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"

--- a/.agents/skills/commit-guards/tests/prose.test.sh
+++ b/.agents/skills/commit-guards/tests/prose.test.sh
@@ -4,7 +4,7 @@
 # replaceable and validated, and ordinary wording passes.
 # Every green assertion is paired with a control that proves it
 # can fail. The index readers this family of checks shares are pinned once,
-# in index-reads.test.sh.
+# in index-reads.test.sh and lane-readers.test.sh.
 set -euo pipefail
 
 TEST_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"

--- a/.agents/skills/commit-guards/tests/suppression-ban.test.sh
+++ b/.agents/skills/commit-guards/tests/suppression-ban.test.sh
@@ -3,7 +3,7 @@
 # per-line counterpart proven to pass, the bare-allow ratchet fails in all
 # directions (new, grow, loose, stale), --update tightens only, and baseline
 # hygiene is enforced. The index readers this family of checks shares — the
-# per-carrier count among them — are pinned once, in index-reads.test.sh,
+# per-carrier count among them — are pinned once, in lane-readers.test.sh,
 # which drives them through this check.
 #
 # Suppression pragmas appear verbatim in fixtures below: the check is

--- a/.agents/skills/commit-guards/tests/terminal-paths.test.sh
+++ b/.agents/skills/commit-guards/tests/terminal-paths.test.sh
@@ -28,7 +28,7 @@ filemode() { stat -c '%a' "$1" 2>/dev/null || stat -f '%Lp' "$1"; }
 R="$ROOT/install-file"
 mkdir -p "$R/tools"
 
-# index-reads.test.sh's `call`, with the session's fds on a pty. LIB is a
+# atomic-install.test.sh's `install_line`, with the session's fds on a pty. LIB is a
 # parameter so a mutant copy of the tree can be run through the same probe.
 #
 # SRC is a parameter for a different reason: every path this helper writes

--- a/.agents/skills/commit-guards/tests/todo-ban.test.sh
+++ b/.agents/skills/commit-guards/tests/todo-ban.test.sh
@@ -6,7 +6,7 @@
 # errors — never a pass. Every green assertion is paired with a control that
 # proves it can fail. The index readers this family of checks shares — the
 # staged lane's carriers pre-filter and content sniff among them — are
-# pinned once, in index-reads.test.sh, which drives them through this check.
+# pinned once, in lane-readers.test.sh, which drives them through this check.
 #
 # Marker words are assembled from split tokens throughout so this test
 # file never contains a marker shape itself — the kendex repo runs

--- a/skills/commit-guards/tests/atomic-install.test.sh
+++ b/skills/commit-guards/tests/atomic-install.test.sh
@@ -1,0 +1,145 @@
+#!/usr/bin/env bash
+# lib/atomic-install.sh: gg_install_file replaces a policy file by a rename
+# inside its own directory, or not at all. One table over the destination's
+# shape (existing with a mode, absent, read-only, a symlink) and each step a
+# stub can fail (stat, chmod, mv, no scratch directory): a row reads back the
+# exit status and every line printed, then the destination's content and
+# mode and the staging files left beside it. The planted staging symlink is
+# the one scripted control below the table: it needs a writer that publishes
+# its pid before it stages.
+set -euo pipefail
+
+TEST_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=lib/harness.bash
+. "$TEST_DIR/lib/harness.bash"
+SKILL_DIR="$(cd "$TEST_DIR/.." && pwd)"
+SCRIPTS="$SKILL_DIR/scripts"
+COMMON="$SCRIPTS/lib/common.sh"
+INSTALL="$SCRIPTS/lib/atomic-install.sh"
+ROOT="$TMP"
+
+PASS=0
+FAIL=0
+assert_eq() { # LABEL EXPECT ACTUAL
+  if [ "$2" = "$3" ]; then
+    PASS=$((PASS + 1))
+    printf '  ok    %s\n' "$1"
+  else
+    FAIL=$((FAIL + 1))
+    printf '  FAIL  %s\n        want: %s\n        got:  %s\n' "$1" "$2" "$3"
+  fi
+}
+filemode() { stat -c '%a' "$1" 2>/dev/null || stat -f '%Lp' "$1"; }
+
+# A failing stub ahead of PATH for one step; each names itself on stderr so a
+# diagnostic that folds it in is read back with what it said.
+stub() { # NAME [MESSAGE]
+  mkdir -p "$ROOT/no$1"
+  printf '#!/bin/sh\n%s\nexit 1\n' "${2:+echo \"$2\" >&2}" >"$ROOT/no$1/$1"
+  chmod +x "$ROOT/no$1/$1"
+}
+stub stat
+stub chmod "chmod: refused by the test stub"
+stub mv
+
+printf 'REPLACEMENT\n' >"$ROOT/src.tsv"
+mkdir -p "$ROOT/outside"
+
+# A fresh fixture directory holding tools/dest.tsv as the row asks: a file
+# with a mode, a symlink to a file outside the tree, or nothing.
+fx() { # NAME SHAPE
+  R="$ROOT/$1"
+  mkdir -p "$R/tools"
+  case "$2" in
+    absent) ;;
+    link)
+      printf 'BEHIND THE LINK\n' >"$ROOT/outside/$1.tsv"
+      chmod 644 "$ROOT/outside/$1.tsv"
+      ln -s "$ROOT/outside/$1.tsv" "$R/tools/dest.tsv"
+      ;;
+    *)
+      printf 'ORIGINAL\n' >"$R/tools/dest.tsv"
+      chmod "$2" "$R/tools/dest.tsv"
+      ;;
+  esac
+}
+
+# One line for an install: the exit status and every printed line, then the
+# destination's content and mode (`-` when absent, the link's target content
+# beside it for a symlink fixture) and the count of staging files left in its
+# directory.
+install_line() { # SHIM-DIR ARM — ARM is `tmpdir` (gg_tmpdir first) or `bare`
+  local rc=0 out dest="$R/tools/dest.tsv" content="-" mode="-" target=""
+  out="$(cd "$R" && PATH="${1:+$1:}$PATH" GG_CHECK=probe bash -c '
+    set -euo pipefail
+    . "$1"
+    . "$2"
+    [ "$3" = bare ] || gg_tmpdir
+    gg_install_file "$4" tools/dest.tsv "the fixture"
+  ' _ "$COMMON" "$INSTALL" "$2" "$ROOT/src.tsv" 2>&1)" || rc=$?
+  out="${out//"$ROOT"/<root>}"
+  if [ -e "$dest" ]; then
+    content="$(cat "$dest")"
+    mode="$(filemode "$dest")"
+  fi
+  [ ! -L "$dest" ] || target=" link-target=$(cat "$ROOT/outside/${R##*/}.tsv")"
+  [ -e "$ROOT/outside/${R##*/}.tsv" ] && [ ! -L "$dest" ] && target=" former-target=$(cat "$ROOT/outside/${R##*/}.tsv")"
+  printf 'rc=%s%s dest=%s mode=%s%s staged=%s' "$rc" "${out:+ $(printf '%s\n' "$out" | paste -sd ';' -)}" "$content" "$mode" "$target" "$(find "$R/tools" -name '*gg-install*' | wc -l | tr -d ' ')"
+}
+
+echo "=== gg_install_file ==="
+# label | fixture shape | shim | arm | expect
+rows=(
+  "an existing destination is replaced and keeps its own mode|644||tmpdir|rc=0 dest=REPLACEMENT mode=644 staged=0"
+  "a mode neither the staging default nor the umask gives is kept too|755||tmpdir|rc=0 dest=REPLACEMENT mode=755 staged=0"
+  "a destination without owner-write is replaced and keeps its read-only mode|444||tmpdir|rc=0 dest=REPLACEMENT mode=444 staged=0"
+  "a destination that does not exist yet lands with the staging file's owner-only mode|absent||tmpdir|rc=0 dest=REPLACEMENT mode=600 staged=0"
+  "a symlink destination is replaced by a file with the mode of the file behind it; the file behind it is untouched|link||tmpdir|rc=0 dest=REPLACEMENT mode=644 former-target=BEHIND THE LINK staged=0"
+  "an unreadable mode is a loud refusal, the destination untouched|644|$ROOT/nostat|tmpdir|rc=2 ::error::probe: could not read the mode of tools/dest.tsv — the fixture was not replaced dest=ORIGINAL mode=644 staged=0"
+  "no scratch directory is a refusal before anything is staged|644||bare|rc=2 ::error::probe: gg_install_file needs gg_tmpdir called first — the fixture was not replaced dest=ORIGINAL mode=644 staged=0"
+  "a failed chmod names the mode it could not give and what chmod said, the destination untouched|644|$ROOT/nochmod|tmpdir|rc=2 ::error::probe: could not give the replacement for the fixture tools/dest.tsv's mode (644) (chmod: refused by the test stub) dest=ORIGINAL mode=644 staged=0"
+  "a failed rename is a loud collection error, the destination byte-identical|644|$ROOT/nomv|tmpdir|rc=2 ::error::probe: could not replace the fixture at tools/dest.tsv — inspect the file before trusting it dest=ORIGINAL mode=644 staged=0"
+)
+i=0
+for row in "${rows[@]}"; do
+  IFS='|' read -r label shape shim arm expect <<<"$row"
+  i=$((i + 1))
+  fx "install-$i" "$shape"
+  assert_eq "$label" "$expect" "$(install_line "$shim" "$arm")"
+done
+
+echo "=== a planted staging symlink does not redirect the write ==="
+# cp writes THROUGH a symlink, so a staging name the repository can predict is
+# an arbitrary-file overwrite waiting for the next --update. The writer
+# publishes its own pid and waits, so the symlink is planted at the EXACT name
+# a pid-derived scheme would choose: the control is aimed, not a guess.
+fx install-symlink 644
+printf 'VICTIM\n' >"$ROOT/victim.txt"
+pidfile="$ROOT/writer.pid"
+gofile="$ROOT/writer.go"
+(
+  cd "$R" && GG_CHECK=probe bash -c '
+    set -euo pipefail
+    echo "$$" >"$3"
+    i=0
+    while [ ! -e "$4" ] && [ "$i" -lt 200 ]; do i=$((i + 1)); sleep 0.05; done
+    . "$1"
+    . "$2"
+    gg_tmpdir
+    gg_install_file "$5" tools/dest.tsv "the fixture"
+  ' _ "$COMMON" "$INSTALL" "$pidfile" "$gofile" "$ROOT/src.tsv"
+) >"$ROOT/writer.out" 2>&1 &
+writer=$!
+i=0
+while [ ! -s "$pidfile" ] && [ "$i" -lt 200 ]; do i=$((i + 1)); sleep 0.05; done
+assert_eq "the control is aimed at the pid the writer actually uses" "published" "$([ -s "$pidfile" ] && echo published || echo none)"
+ln -s "$ROOT/victim.txt" "$R/tools/.gg-install.$(cat "$pidfile").dest.tsv"
+: >"$gofile"
+wait "$writer" || true
+rm -f "$R/tools/.gg-install.$(cat "$pidfile").dest.tsv"
+assert_eq "the victim is untouched, the install lands on its real destination, and no staging file is left" \
+  "victim=VICTIM dest=REPLACEMENT staged=0 out=" \
+  "victim=$(cat "$ROOT/victim.txt") dest=$(cat "$R/tools/dest.tsv") staged=$(find "$R/tools" -name '*gg-install*' | wc -l | tr -d ' ') out=$(cat "$ROOT/writer.out")"
+
+printf '\n%s passed, %s failed\n' "$PASS" "$FAIL"
+[ "$FAIL" -eq 0 ]

--- a/skills/commit-guards/tests/changelog-entries.test.sh
+++ b/skills/commit-guards/tests/changelog-entries.test.sh
@@ -7,8 +7,8 @@
 # write path is pinned next door in changelog-collate.test.sh.
 # The configured globs decide what is read and content comes from the index;
 # the index readers this family of checks shares are pinned once, in
-# index-reads.test.sh and lane-readers.test.sh. Every green assertion is paired with a control that
-# proves it can fail.
+# index-reads.test.sh and lane-readers.test.sh. Every green assertion is
+# paired with a control that proves it can fail.
 set -euo pipefail
 
 TEST_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"

--- a/skills/commit-guards/tests/changelog-entries.test.sh
+++ b/skills/commit-guards/tests/changelog-entries.test.sh
@@ -7,7 +7,7 @@
 # write path is pinned next door in changelog-collate.test.sh.
 # The configured globs decide what is read and content comes from the index;
 # the index readers this family of checks shares are pinned once, in
-# index-reads.test.sh. Every green assertion is paired with a control that
+# index-reads.test.sh and lane-readers.test.sh. Every green assertion is paired with a control that
 # proves it can fail.
 set -euo pipefail
 

--- a/skills/commit-guards/tests/comments.test.sh
+++ b/skills/commit-guards/tests/comments.test.sh
@@ -5,7 +5,7 @@
 # lanes', and --staged judges the lines the commit adds against comment
 # state read from the whole file. Every green assertion is paired with a
 # control that proves it can fail. The index readers this family shares are
-# pinned once, in index-reads.test.sh.
+# pinned once, in index-reads.test.sh and lane-readers.test.sh.
 set -euo pipefail
 
 TEST_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"

--- a/skills/commit-guards/tests/conflict-markers.test.sh
+++ b/skills/commit-guards/tests/conflict-markers.test.sh
@@ -4,7 +4,7 @@
 # separator do not, excludes need reasons, and the check's own source never
 # trips it. Every green assertion is paired with a control that proves it can
 # fail. The index readers this family of checks shares are pinned once, in
-# index-reads.test.sh.
+# index-reads.test.sh and lane-readers.test.sh.
 #
 # Marker runs are assembled with printf throughout so this test file never
 # contains a marker shape itself — the kendex repo runs conflict-markers

--- a/skills/commit-guards/tests/index-reads.test.sh
+++ b/skills/commit-guards/tests/index-reads.test.sh
@@ -82,27 +82,34 @@ fx_policy() { # NAME STAGED WORKTREE — tools/ex.tsv committed as STAGED, then 
   [ -z "$3" ] || printf '%s\treason\n' "$3" >"$R/tools/ex.tsv"
 }
 fx_staged_deletion() { fx_policy staged-deletion INDEX ""; git -C "$R" rm -q --cached tools/ex.tsv; }
-fx_never_tracked() { new_repo never-tracked; printf 'seed\n' >"$R/seed.txt"; commit_all base; mkdir -p "$R/tools"; printf 'ONDISK\treason\n' >"$R/tools/ex.tsv"; }
+fx_never_tracked() { new_repo "$1"; printf 'seed\n' >"$R/seed.txt"; commit_all base; mkdir -p "$R/tools"; printf 'ONDISK\treason\n' >"$R/tools/ex.tsv"; }
 fx_unborn() { new_repo unborn-head; mkdir -p "$R/tools"; printf 'ONDISK\treason\n' >"$R/tools/ex.tsv"; }
 fx_glob() { new_repo "$1"; mkdir -p "$R/tools"; printf 'REAL\treason\n' >"$R/tools/exA.tsv"; commit_all base; }
 printf 'not an index\n' >"$ROOT/corrupt.idx"
+# A git that cannot probe HEAD for the file: the probe's failure is never
+# read as "absent from HEAD".
+mkdir -p "$ROOT/git-shim-ls-tree"
+printf '#!/usr/bin/env bash\ncase " $* " in *" ls-tree "*) echo "git ls-tree: simulated failure" >&2; exit 128 ;; esac\nexec "%s" "$@"\n' "$(command -v git)" >"$ROOT/git-shim-ls-tree/git"
+chmod +x "$ROOT/git-shim-ls-tree/git"
 
 echo "=== gg_policy_content ==="
-# label | fixture | snippet | expect
+# label | fixture | shim | snippet | expect
 rows=(
-  "the staged copy governs over an unstaged edit|fx_policy staged-wins INDEX WORKTREE|gg_policy_content tools/ex.tsv|rc=0 INDEX\\treason"
-  "an unreadable index is a collection error, never the worktree copy|fx_policy corrupt INDEX WORKTREE|GIT_INDEX_FILE=$ROOT/corrupt.idx gg_policy_content tools/ex.tsv|rc=2 ::error::probe: could not query the index for tools/ex.tsv (git ls-files exit 128); refusing to treat it as untracked"
-  "a staged deletion governs as absent with the worktree copy present|fx_staged_deletion|gg_policy_content tools/ex.tsv|rc=1"
-  "a never-tracked policy file falls back to the worktree copy|fx_never_tracked|gg_policy_content tools/ex.tsv|rc=0 ONDISK\\treason"
-  "an unborn HEAD carries nothing and does not fail the read|fx_unborn|gg_policy_content tools/ex.tsv|rc=0 ONDISK\\treason"
-  "a glob-shaped path matches only itself|fx_glob glob-path|gg_policy_content 'tools/ex?.tsv'|rc=1"
-  "control: the literal path it names resolves|fx_glob literal-path|gg_policy_content tools/exA.tsv|rc=0 REAL\\treason"
+  "the staged copy governs over an unstaged edit|fx_policy staged-wins INDEX WORKTREE||gg_policy_content tools/ex.tsv|rc=0 INDEX\\treason"
+  "an unreadable index is a collection error, never the worktree copy|fx_policy corrupt INDEX WORKTREE||GIT_INDEX_FILE=$ROOT/corrupt.idx gg_policy_content tools/ex.tsv|rc=2 ::error::probe: could not query the index for tools/ex.tsv (git ls-files exit 128); refusing to treat it as untracked"
+  "a staged deletion governs as absent with the worktree copy present|fx_staged_deletion||gg_policy_content tools/ex.tsv|rc=1"
+  "a never-tracked policy file falls back to the worktree copy|fx_never_tracked never-tracked||gg_policy_content tools/ex.tsv|rc=0 ONDISK\\treason"
+  "a HEAD probe that failed is a collection error, never the worktree copy|fx_never_tracked head-probe|$ROOT/git-shim-ls-tree|gg_policy_content tools/ex.tsv|rc=2 ::error::probe: could not probe HEAD for tools/ex.tsv (git ls-tree exit 128); refusing to treat it as untracked"
+  "an unborn HEAD carries nothing and does not fail the read|fx_unborn||gg_policy_content tools/ex.tsv|rc=0 ONDISK\\treason"
+  "a glob-shaped path matches only itself|fx_glob glob-path||gg_policy_content 'tools/ex?.tsv'|rc=1"
+  "control: the literal path it names resolves|fx_glob literal-path||gg_policy_content tools/exA.tsv|rc=0 REAL\\treason"
 )
 for row in "${rows[@]}"; do
-  IFS='|' read -r label fixture snippet expect <<<"$row"
+  IFS='|' read -r label fixture SHIM snippet expect <<<"$row"
   $fixture
   assert_eq "$label" "$expect" "$(call "$SETTINGS" "$snippet")"
 done
+SHIM=""
 
 # --- gg_require_merged_index -------------------------------------------------
 

--- a/skills/commit-guards/tests/index-reads.test.sh
+++ b/skills/commit-guards/tests/index-reads.test.sh
@@ -1,39 +1,37 @@
 #!/usr/bin/env bash
-# Pins for the libs the checks share: lib/common.sh's index reads,
-# lib/configured-paths.sh's policy reads and content sniff,
-# lib/atomic-install.sh's policy writes, and the settings cache
-# lib/settings.sh materializes. A probe git could not answer never becomes an
-# answer, a configured path is matched literally, a --cached scan refuses an
-# unmerged index, a policy file is replaced by a same-directory rename or not
-# at all, and no partial cache file survives a resolve. Every clean assertion
-# is paired with a control that proves it can fail.
+# The index reads the checks share, one table per reader: gg_policy_content
+# (the index governs a policy file, a probe git could not answer is never an
+# answer, a configured path is literal), gg_require_merged_index (a --cached
+# scan refuses an unmerged index, for the paths it scans), the excludes read
+# a lane makes through them, and the settings cache lib/settings.sh
+# materializes by rename. Each row builds its own fixture repository, makes
+# one call, and reads back the exit status and every line printed, the
+# scratch roots aliased. lib/atomic-install.sh is atomic-install.test.sh; the
+# lanes end to end over these readers are lane-readers.test.sh.
 set -euo pipefail
 
 TEST_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-# The harness owns the scratch root, TMPDIR inside it, and the git isolation.
-# The root matters here beyond hygiene: an assertion over a namespace shared
-# with other processes cannot tell "the code under test leaked" from "someone
-# else's run moved".
 # shellcheck source=lib/harness.bash
 . "$TEST_DIR/lib/harness.bash"
 SKILL_DIR="$(cd "$TEST_DIR/.." && pwd)"
 SCRIPTS="$SKILL_DIR/scripts"
 COMMON="$SCRIPTS/lib/common.sh"
-# The lib holding the install helpers, which a probe exercising them sources
-# alongside COMMON: the writer lives beside common.sh rather than inside it,
-# and reaches back across that boundary for the staging file common.sh
-# declares and its exit trap removes.
-INSTALL="$SCRIPTS/lib/atomic-install.sh"
 SETTINGS="$SCRIPTS/lib/settings.sh"
 ROOT="$TMP"
 
 unset COMMIT_GUARDS_SETTINGS_FILE COMMIT_GUARDS_CONFLICT_EXCLUDES 2>/dev/null || true
 
-TAB="$(printf '\t')"
 PASS=0
 FAIL=0
-ok() { PASS=$((PASS + 1)); printf '  ok    %s\n' "$1"; }
-bad() { FAIL=$((FAIL + 1)); printf '  FAIL  %s\n        %s\n' "$1" "${2:-}"; }
+assert_eq() { # LABEL EXPECT ACTUAL
+  if [ "$2" = "$3" ]; then
+    PASS=$((PASS + 1))
+    printf '  ok    %s\n' "$1"
+  else
+    FAIL=$((FAIL + 1))
+    printf '  FAIL  %s\n        want: %s\n        got:  %s\n' "$1" "$2" "$3"
+  fi
+}
 
 new_repo() { # NAME — fresh fixture repo in $R, cwd unchanged
   R="$ROOT/$1"
@@ -42,108 +40,76 @@ new_repo() { # NAME — fresh fixture repo in $R, cwd unchanged
   git -C "$R" config user.email test@example.com
   git -C "$R" config user.name test
 }
+commit_all() { # MESSAGE
+  git -C "$R" add -A
+  git -C "$R" commit -qm "$1"
+}
 
-# Run a snippet with the libs sourced, inside $R. OUT captures stdout+stderr,
-# RC the exit status — a collection error is exit 2 and must be observable.
-call() { # SNIPPET
-  OUT=""
-  RC=0
-  OUT="$(cd "$R" && GG_CHECK=probe bash -c '
+# One line for a run: the exit status, then every printed line in order,
+# joined by ';' with the roots aliased and a tab spelled out, so a diagnostic
+# reads as the detector that wrote it and the path it names.
+line() { # RC OUT
+  local out="$2"
+  out="${out//"$R"/<repo>}"
+  out="${out//"$ROOT"/<root>}"
+  printf 'rc=%s' "$1"
+  [ -z "$out" ] || printf ' %s' "$(printf '%s\n' "$out" | sed -e 's/[[:space:]]*$//' -e 's/\t/\\t/g' | paste -sd ';' -)"
+}
+
+# A snippet with common.sh and one more lib sourced, run inside $R, with
+# $SHIM first on PATH when a row sets one.
+SHIM=""
+call() { # LIB SNIPPET
+  local rc=0 out
+  out="$(cd "$R" && PATH="${SHIM:+$SHIM:}$PATH" GG_CHECK=probe bash -c '
     set -euo pipefail
     . "$1"
     . "$2"
     shift 2
     eval "$1"
-  ' _ "$COMMON" "$INSTALL" "$1" 2>&1)" || RC=$?
+  ' _ "$COMMON" "$1" "$2" 2>&1)" || rc=$?
+  line "$rc" "$out"
 }
 
-echo "=== gg_policy_content: the index governs, and a probe that failed is not an answer ==="
+# --- gg_policy_content -------------------------------------------------------
 
-new_repo staged-wins
-printf 'seed\n' >"$R/seed.txt"
-mkdir -p "$R/tools"
-printf 'INDEX\treason\n' >"$R/tools/ex.tsv"
-git -C "$R" add -A
-git -C "$R" commit -qm base
-printf 'WORKTREE\treason\n' >"$R/tools/ex.tsv"
-call 'gg_policy_content tools/ex.tsv'
-[ "$RC" -eq 0 ] && [ "$OUT" = "INDEX${TAB}reason" ] \
-  && ok "the staged copy governs over an unstaged edit" \
-  || bad "the staged copy governs over an unstaged edit" "rc=$RC out=$OUT"
-
-# Control: the SAME fixture, with the index unreadable. Before this was
-# classified, the failed probe fell through to the worktree copy and the
-# commit was judged against policy it does not carry.
+fx_policy() { # NAME STAGED WORKTREE — tools/ex.tsv committed as STAGED, then edited to WORKTREE
+  new_repo "$1"
+  mkdir -p "$R/tools"
+  printf 'seed\n' >"$R/seed.txt"
+  printf '%s\treason\n' "$2" >"$R/tools/ex.tsv"
+  commit_all base
+  [ -z "$3" ] || printf '%s\treason\n' "$3" >"$R/tools/ex.tsv"
+}
+fx_staged_deletion() { fx_policy staged-deletion INDEX ""; git -C "$R" rm -q --cached tools/ex.tsv; }
+fx_never_tracked() { new_repo never-tracked; printf 'seed\n' >"$R/seed.txt"; commit_all base; mkdir -p "$R/tools"; printf 'ONDISK\treason\n' >"$R/tools/ex.tsv"; }
+fx_unborn() { new_repo unborn-head; mkdir -p "$R/tools"; printf 'ONDISK\treason\n' >"$R/tools/ex.tsv"; }
+fx_glob() { new_repo "$1"; mkdir -p "$R/tools"; printf 'REAL\treason\n' >"$R/tools/exA.tsv"; commit_all base; }
 printf 'not an index\n' >"$ROOT/corrupt.idx"
-call 'GIT_INDEX_FILE="'"$ROOT"'/corrupt.idx" gg_policy_content tools/ex.tsv'
-[ "$RC" -eq 2 ] && case "$OUT" in *"could not query the index"*) true ;; *) false ;; esac \
-  && ok "an unreadable index is a collection error, not a fall-through" \
-  || bad "an unreadable index is a collection error, not a fall-through" "rc=$RC out=$OUT"
-case "$OUT" in
-  *WORKTREE*) bad "the failed probe never emits the worktree copy" "out=$OUT" ;;
-  *) ok "the failed probe never emits the worktree copy" ;;
-esac
 
-new_repo staged-deletion
-mkdir -p "$R/tools"
-printf 'INDEX\treason\n' >"$R/tools/ex.tsv"
-git -C "$R" add -A
-git -C "$R" commit -qm base
-git -C "$R" rm -q --cached tools/ex.tsv
-call 'gg_policy_content tools/ex.tsv'
-[ "$RC" -eq 1 ] && [ -z "$OUT" ] \
-  && ok "a staged deletion governs as absent even with the worktree copy present" \
-  || bad "a staged deletion governs as absent even with the worktree copy present" "rc=$RC out=$OUT"
+echo "=== gg_policy_content ==="
+# label | fixture | snippet | expect
+rows=(
+  "the staged copy governs over an unstaged edit|fx_policy staged-wins INDEX WORKTREE|gg_policy_content tools/ex.tsv|rc=0 INDEX\\treason"
+  "an unreadable index is a collection error, never the worktree copy|fx_policy corrupt INDEX WORKTREE|GIT_INDEX_FILE=$ROOT/corrupt.idx gg_policy_content tools/ex.tsv|rc=2 ::error::probe: could not query the index for tools/ex.tsv (git ls-files exit 128); refusing to treat it as untracked"
+  "a staged deletion governs as absent with the worktree copy present|fx_staged_deletion|gg_policy_content tools/ex.tsv|rc=1"
+  "a never-tracked policy file falls back to the worktree copy|fx_never_tracked|gg_policy_content tools/ex.tsv|rc=0 ONDISK\\treason"
+  "an unborn HEAD carries nothing and does not fail the read|fx_unborn|gg_policy_content tools/ex.tsv|rc=0 ONDISK\\treason"
+  "a glob-shaped path matches only itself|fx_glob glob-path|gg_policy_content 'tools/ex?.tsv'|rc=1"
+  "control: the literal path it names resolves|fx_glob literal-path|gg_policy_content tools/exA.tsv|rc=0 REAL\\treason"
+)
+for row in "${rows[@]}"; do
+  IFS='|' read -r label fixture snippet expect <<<"$row"
+  $fixture
+  assert_eq "$label" "$expect" "$(call "$SETTINGS" "$snippet")"
+done
 
-new_repo never-tracked
-printf 'seed\n' >"$R/seed.txt"
-git -C "$R" add -A
-git -C "$R" commit -qm base
-mkdir -p "$R/tools"
-printf 'ONDISK\treason\n' >"$R/tools/ex.tsv"
-call 'gg_policy_content tools/ex.tsv'
-[ "$RC" -eq 0 ] && case "$OUT" in ONDISK*) true ;; *) false ;; esac \
-  && ok "a never-tracked policy file falls back to the worktree copy" \
-  || bad "a never-tracked policy file falls back to the worktree copy" "rc=$RC out=$OUT"
-
-new_repo unborn-head
-mkdir -p "$R/tools"
-printf 'ONDISK\treason\n' >"$R/tools/ex.tsv"
-call 'gg_policy_content tools/ex.tsv'
-[ "$RC" -eq 0 ] && case "$OUT" in ONDISK*) true ;; *) false ;; esac \
-  && ok "an unborn HEAD carries nothing and does not fail the read" \
-  || bad "an unborn HEAD carries nothing and does not fail the read" "rc=$RC out=$OUT"
-
-echo "=== gg_policy_content: a configured path is a literal path, never a glob ==="
-
-new_repo glob-path
-mkdir -p "$R/tools"
-printf 'REAL\treason\n' >"$R/tools/exA.tsv"
-git -C "$R" add -A
-git -C "$R" commit -qm base
-call "gg_policy_content 'tools/ex?.tsv'"
-[ "$RC" -eq 1 ] && [ -z "$OUT" ] \
-  && ok "a glob-shaped path matches only itself, and it does not exist" \
-  || bad "a glob-shaped path matches only itself, and it does not exist" "rc=$RC out=$OUT"
-case "$OUT" in
-  *REAL* | *"diff --git"*)
-    bad "a glob-shaped path never yields another entry's content" "out=$OUT"
-    ;;
-  *) ok "a glob-shaped path never yields another entry's content" ;;
-esac
-# Control: the literal path this repo does carry still resolves.
-call 'gg_policy_content tools/exA.tsv'
-[ "$RC" -eq 0 ] && case "$OUT" in REAL*) true ;; *) false ;; esac \
-  && ok "the literal path it names still resolves" \
-  || bad "the literal path it names still resolves" "rc=$RC out=$OUT"
-
-echo "=== gg_require_merged_index: a --cached scan refuses an unmerged index ==="
+# --- gg_require_merged_index -------------------------------------------------
 
 conflicted_repo() { # NAME — fixture left mid-merge, f.txt unmerged
   new_repo "$1"
   printf 'line1\nbase\nline3\n' >"$R/f.txt"
-  git -C "$R" add -A
-  git -C "$R" commit -qm base
+  commit_all base
   git -C "$R" checkout -q -b other
   printf 'line1\ntheirs\nline3\n' >"$R/f.txt"
   git -C "$R" commit -qam other
@@ -152,150 +118,30 @@ conflicted_repo() { # NAME — fixture left mid-merge, f.txt unmerged
   git -C "$R" commit -qam ours
   git -C "$R" merge other >/dev/null 2>&1 || true
 }
-
 conflicted_repo unmerged
-[ "$(git -C "$R" ls-files -u | wc -l)" -eq 3 ] \
-  && ok "the fixture really is mid-merge (three index stages)" \
-  || bad "the fixture really is mid-merge (three index stages)" "stages=$(git -C "$R" ls-files -u | wc -l)"
+assert_eq "the fixture really is mid-merge (three index stages)" 3 "$(git -C "$R" ls-files -u | wc -l | tr -d ' ')"
+# A git that cannot list the unmerged paths at all: the probe's failure is
+# never read as "nothing unmerged".
+mkdir -p "$ROOT/git-shim-unmerged"
+printf '#!/usr/bin/env bash\ncase " $* " in *" --unmerged "*) echo "git ls-files: simulated failure" >&2; exit 128 ;; esac\nexec "%s" "$@"\n' "$(command -v git)" >"$ROOT/git-shim-unmerged/git"
+chmod +x "$ROOT/git-shim-unmerged/git"
 
-call 'gg_require_merged_index'
-[ "$RC" -eq 2 ] && case "$OUT" in *"unmerged path"*"finish or abort the merge"*) true ;; *) false ;; esac \
-  && ok "an unmerged index is a collection error naming the remedy" \
-  || bad "an unmerged index is a collection error naming the remedy" "rc=$RC out=$OUT"
-case "$OUT" in
-  *f.txt*) ok "the refusal names the unmerged path" ;;
-  *) bad "the refusal names the unmerged path" "out=$OUT" ;;
-esac
+echo "=== gg_require_merged_index ==="
+REFUSAL="f.txt;::error::probe: the index carries 1 unmerged path(s) (listed above) and a --cached scan skips them silently — finish or abort the merge, then re-run"
+# label | shim | pathspec | expect
+rows=(
+  "an unmerged index is a collection error naming the path and the remedy|||rc=2 $REFUSAL"
+  "an unmerged path outside the pathspec does not block that scan||'*.rs'|rc=0"
+  "an unmerged path inside the pathspec does block it||'f.txt'|rc=2 $REFUSAL"
+  "a probe that could not list the unmerged paths is a collection error, never an empty list|$ROOT/git-shim-unmerged||rc=2 git ls-files: simulated failure;::error::probe: could not read the index for unmerged paths (git ls-files exit 128)"
+)
+for row in "${rows[@]}"; do
+  IFS='|' read -r label SHIM pathspec expect <<<"$row"
+  assert_eq "$label" "$expect" "$(call "$SETTINGS" "gg_require_merged_index $pathspec")"
+done
+SHIM=""
 
-# Scope: the guard answers for the paths the lane actually scans. An unmerged
-# path outside the pathspec leaves that scan complete.
-call "gg_require_merged_index '*.rs'"
-[ "$RC" -eq 0 ] \
-  && ok "an unmerged path outside the pathspec does not block that scan" \
-  || bad "an unmerged path outside the pathspec does not block that scan" "rc=$RC out=$OUT"
-call "gg_require_merged_index 'f.txt'"
-[ "$RC" -eq 2 ] \
-  && ok "an unmerged path inside the pathspec does block it" \
-  || bad "an unmerged path inside the pathspec does block it" "rc=$RC out=$OUT"
-
-echo "=== end to end: conflict-markers over an unmerged index ==="
-
-conflicted_repo cm-unmerged
-RC=0
-OUT="$(cd "$R" && "$SCRIPTS/conflict-markers" 2>&1)" || RC=$?
-[ "$RC" -eq 2 ] \
-  && ok "conflict-markers refuses rather than reporting OK over an unmerged index" \
-  || bad "conflict-markers refuses rather than reporting OK over an unmerged index" "rc=$RC out=$OUT"
-case "$OUT" in
-  *"OK — no conflict markers"*)
-    bad "the refusal is not dressed as a clean verdict" "out=$OUT"
-    ;;
-  *) ok "the refusal is not dressed as a clean verdict" ;;
-esac
-
-echo "=== end to end: prose over an unmerged index ==="
-
-# prose walks `ls-files -s`, which emits one record per STAGE, so an
-# unresolved merge would hand it rival blobs for one path. Its guard runs
-# over the whole index before the walk: the fixture carries no file the
-# default path list matches, so a lane that skipped the guard would report
-# the clean "no tracked file matches" verdict instead of refusing.
-conflicted_repo prose-unmerged
-RC=0
-OUT="$(cd "$R" && "$SCRIPTS/prose" 2>&1)" || RC=$?
-[ "$RC" -eq 2 ] \
-  && ok "prose refuses rather than reporting OK over an unmerged index" \
-  || bad "prose refuses rather than reporting OK over an unmerged index" "rc=$RC out=$OUT"
-case "$OUT" in
-  *"prose: OK"*)
-    bad "prose's refusal is not dressed as a clean verdict" "out=$OUT"
-    ;;
-  *) ok "prose's refusal is not dressed as a clean verdict" ;;
-esac
-
-# Control: staging the conflicted content resolves the index, and the SAME
-# bytes then fail as the violation they are — the guard did not replace the
-# measurement, it unblocked it.
-git -C "$R" add f.txt
-RC=0
-OUT="$(cd "$R" && "$SCRIPTS/conflict-markers" 2>&1)" || RC=$?
-[ "$RC" -eq 1 ] && case "$OUT" in *"conflict marker: f.txt:"*) true ;; *) false ;; esac \
-  && ok "once staged, the same markers fail as violations" \
-  || bad "once staged, the same markers fail as violations" "rc=$RC out=$OUT"
-
-# Control: a resolved, marker-free tree passes.
-printf 'line1\nmerged\nline3\n' >"$R/f.txt"
-git -C "$R" add f.txt
-RC=0
-OUT="$(cd "$R" && "$SCRIPTS/conflict-markers" 2>&1)" || RC=$?
-[ "$RC" -eq 0 ] && case "$OUT" in *"conflict-markers: OK"*) true ;; *) false ;; esac \
-  && ok "a resolved tree passes" \
-  || bad "a resolved tree passes" "rc=$RC out=$OUT"
-
-echo "=== byte-ceiling: an add/add conflict is not a zero-addition diff ==="
-
-# An add/add conflict is status U, which --diff-filter=A drops entirely: the
-# addition vanishes from the record set and the ceiling measures nothing.
-new_repo bc-addadd
-printf 'seed\n' >"$R/seed.txt"
-git -C "$R" add -A
-git -C "$R" commit -qm base
-git -C "$R" checkout -q -b other
-head -c 400000 /dev/zero | tr '\0' 'b' >"$R/big.txt"
-git -C "$R" add -A
-git -C "$R" commit -qm other
-git -C "$R" checkout -q main
-head -c 400000 /dev/zero | tr '\0' 'a' >"$R/big.txt"
-git -C "$R" add -A
-git -C "$R" commit -qm ours
-git -C "$R" merge other >/dev/null 2>&1 || true
-[ "$(git -C "$R" diff --cached --raw --diff-filter=A | wc -l)" -eq 0 ] \
-  && ok "the fixture really does hide the addition from --diff-filter=A" \
-  || bad "the fixture really does hide the addition from --diff-filter=A" "$(git -C "$R" diff --cached --raw --diff-filter=A)"
-
-RC=0
-OUT="$(cd "$R" && "$SCRIPTS/byte-ceiling" 2>&1)" || RC=$?
-[ "$RC" -eq 2 ] \
-  && ok "byte-ceiling refuses the unmerged index instead of measuring around it" \
-  || bad "byte-ceiling refuses the unmerged index instead of measuring around it" "rc=$RC out=$OUT"
-case "$OUT" in
-  *"0 staged addition(s) checked"* | *"byte-ceiling: OK"*)
-    bad "the refusal is not dressed as a clean measurement" "out=$OUT"
-    ;;
-  *) ok "the refusal is not dressed as a clean measurement" ;;
-esac
-
-RC=0
-OUT="$(cd "$R" && "$SCRIPTS/byte-ceiling" --all 2>&1)" || RC=$?
-[ "$RC" -eq 2 ] \
-  && ok "--all refuses it too, where ls-files emits one record per stage" \
-  || bad "--all refuses it too, where ls-files emits one record per stage" "rc=$RC out=$OUT"
-
-# Control: the guard did not replace the measurement. A merged index with a
-# genuinely new oversized file still fails the ceiling, and a merged index
-# with nothing oversized still passes.
-new_repo bc-merged
-printf 'seed\n' >"$R/seed.txt"
-git -C "$R" add -A
-git -C "$R" commit -qm base
-head -c 400000 /dev/zero | tr '\0' 'a' >"$R/big.txt"
-git -C "$R" add -A
-RC=0
-OUT="$(cd "$R" && "$SCRIPTS/byte-ceiling" 2>&1)" || RC=$?
-[ "$RC" -eq 1 ] && case "$OUT" in *big.txt*) true ;; *) false ;; esac \
-  && ok "a merged index still fails an oversized addition" \
-  || bad "a merged index still fails an oversized addition" "rc=$RC out=$OUT"
-git -C "$R" rm -q --cached big.txt
-rm -f "$R/big.txt"
-printf 'small\n' >"$R/small.txt"
-git -C "$R" add -A
-RC=0
-OUT="$(cd "$R" && "$SCRIPTS/byte-ceiling" 2>&1)" || RC=$?
-[ "$RC" -eq 0 ] && case "$OUT" in *"byte-ceiling: OK"*) true ;; *) false ;; esac \
-  && ok "a merged index with nothing oversized still passes" \
-  || bad "a merged index with nothing oversized still passes" "rc=$RC out=$OUT"
-
-echo "=== a failed policy read stops the gate, it does not become an empty list ==="
+# --- a failed policy read stops the gate ------------------------------------
 
 # gg_policy_content runs inside a command substitution, so its exit 2 dies in
 # that subshell and reaches gg_load_excludes as a bare status. This shim fails
@@ -319,548 +165,38 @@ printf 'seed\n' >"$R/seed.txt"
 mkdir -p "$R/tools"
 printf '# notes\n\nTODO: an unlinked work marker\n' >"$R/bad.md"
 printf 'bad.md\tallowed to carry markers\n' >"$R/tools/todo-ban-excludes"
-git -C "$R" add -A
-git -C "$R" commit -qm base
+commit_all base
 
-RC=0
-OUT="$(cd "$R" && "$SCRIPTS/todo-ban" 2>&1)" || RC=$?
-[ "$RC" -eq 0 ] && case "$OUT" in *"todo-ban: OK"*) true ;; *) false ;; esac \
-  && ok "control: with the excludes readable, the excluded marker passes" \
-  || bad "control: with the excludes readable, the excluded marker passes" "rc=$RC out=$OUT"
+lane() { # SHIM-DIR SCRIPT [ARG...] — one line for a lane run inside $R, SHIM-DIR first on PATH when given
+  local dir="$1" script="$2" rc=0 out
+  shift 2
+  out="$(cd "$R" && PATH="${dir:+$dir:}$PATH" "$SCRIPTS/$script" "$@" 2>&1)" || rc=$?
+  line "$rc" "$out"
+}
 
-RC=0
-OUT="$(cd "$R" && PATH="$ROOT/gitstub:$PATH" "$SCRIPTS/todo-ban" 2>&1)" || RC=$?
-[ "$RC" -eq 2 ] \
-  && ok "an unreadable exclusion list stops the run at exit 2" \
-  || bad "an unreadable exclusion list stops the run at exit 2" "rc=$RC out=$OUT"
-case "$OUT" in
-  *"refusing to run on an unread exclusion list"*)
-    ok "the refusal names the unread exclusion list"
-    ;;
-  *) bad "the refusal names the unread exclusion list" "out=$OUT" ;;
-esac
-# The failure mode this closes: an empty list is not "no exclusions apply".
-case "$OUT" in
-  *"work marker(s)"* | *"todo-ban: OK"*)
-    bad "the failed read never produces a verdict" "out=$OUT"
-    ;;
-  *) ok "the failed read never produces a verdict" ;;
-esac
+echo "=== a failed policy read stops the gate, it does not become an empty list ==="
+assert_eq "control: with the excludes readable, the excluded marker passes" \
+  "rc=0 todo-ban: OK — no work markers in tracked files" "$(lane "" todo-ban)"
+assert_eq "an unreadable exclusion list stops the run at exit 2, with no verdict" \
+  "rc=2 ::error::todo-ban: could not query the index for tools/todo-ban-excludes (git ls-files exit 128); refusing to treat it as untracked;::error::todo-ban: refusing to run on an unread exclusion list: tools/todo-ban-excludes (exit 2, cause above)" \
+  "$(lane "$ROOT/gitstub" todo-ban)"
 
-echo "=== gg_install_file: the destination is replaced whole, or not at all ==="
+# --- the settings cache ------------------------------------------------------
 
-new_repo install-file
-mkdir -p "$R/tools"
-printf 'ORIGINAL\n' >"$R/tools/dest.tsv"
-printf 'REPLACEMENT\n' >"$ROOT/src.tsv"
-call 'gg_tmpdir; gg_install_file "'"$ROOT"'/src.tsv" tools/dest.tsv "the fixture"'
-[ "$RC" -eq 0 ] && [ "$(cat "$R/tools/dest.tsv")" = "REPLACEMENT" ] \
-  && ok "a successful install replaces the destination" \
-  || bad "a successful install replaces the destination" "rc=$RC out=$OUT content=$(cat "$R/tools/dest.tsv")"
-[ -z "$(find "$R/tools" -name '*gg-install*')" ] \
-  && ok "a successful install leaves no residue beside the destination" \
-  || bad "a successful install leaves no residue beside the destination" "$(find "$R/tools" -name '*gg-install*')"
-
-# mktemp creates the staging file readable by its owner alone, so a rename
-# that does not take the destination's mode narrows a tracked file every
-# clone reads. The control is the same call against a destination that does
-# not exist yet, where there is no mode to take.
-filemode() { stat -c '%a' "$1" 2>/dev/null || stat -f '%Lp' "$1"; }
-chmod 644 "$R/tools/dest.tsv"
-call 'gg_tmpdir; gg_install_file "'"$ROOT"'/src.tsv" tools/dest.tsv "the fixture"'
-[ "$RC" -eq 0 ] && [ "$(filemode "$R/tools/dest.tsv")" = 644 ] \
-  && ok "an existing destination keeps its own mode" \
-  || bad "an existing destination keeps its own mode" "rc=$RC mode=$(filemode "$R/tools/dest.tsv")"
-chmod 755 "$R/tools/dest.tsv"
-call 'gg_tmpdir; gg_install_file "'"$ROOT"'/src.tsv" tools/dest.tsv "the fixture"'
-[ "$RC" -eq 0 ] && [ "$(filemode "$R/tools/dest.tsv")" = 755 ] \
-  && ok "control: a mode neither the staging default nor the umask gives is kept too" \
-  || bad "control: a mode neither the staging default nor the umask gives is kept too" "rc=$RC mode=$(filemode "$R/tools/dest.tsv")"
-rm -f "$R/tools/fresh.tsv"
-call 'gg_tmpdir; gg_install_file "'"$ROOT"'/src.tsv" tools/fresh.tsv "the fixture"'
-[ "$RC" -eq 0 ] && [ "$(cat "$R/tools/fresh.tsv")" = "REPLACEMENT" ] \
-  && ok "control: a destination that does not exist yet installs with no mode to take" \
-  || bad "control: a destination that does not exist yet installs with no mode to take" "rc=$RC out=$OUT"
-
-# A destination without owner-write. The mode is READ before the staging file
-# is written and applied after, never carried onto it in between: staging
-# under the destination's own mode makes the write fail on a file this
-# process just created, and reports a staging error for what is the
-# destination's mode.
-printf 'REPLACED THROUGH A READ-ONLY DESTINATION\n' >"$ROOT/ro.tsv"
-chmod 444 "$R/tools/dest.tsv"
-call 'gg_tmpdir; gg_install_file "'"$ROOT"'/ro.tsv" tools/dest.tsv "the fixture"'
-[ "$RC" -eq 0 ] && [ "$(cat "$R/tools/dest.tsv")" = "REPLACED THROUGH A READ-ONLY DESTINATION" ] \
-  && ok "a destination without owner-write is still replaced" \
-  || bad "a destination without owner-write is still replaced" "rc=$RC out=$OUT content=$(cat "$R/tools/dest.tsv")"
-# Content AND mode in one condition: 444 survives an install that never
-# happened just as well as one that did, so a mode assertion standing alone
-# here cannot tell a preserved mode from a rename that stopped at a prompt.
-[ "$(filemode "$R/tools/dest.tsv")" = 444 ] \
-  && [ "$(cat "$R/tools/dest.tsv")" = "REPLACED THROUGH A READ-ONLY DESTINATION" ] \
-  && ok "and keeps its read-only mode across the rename that replaced it" \
-  || bad "and keeps its read-only mode across the rename that replaced it" "mode=$(filemode "$R/tools/dest.tsv") content=$(cat "$R/tools/dest.tsv")"
-chmod 644 "$R/tools/dest.tsv"
-
-# A SYMLINK destination. `[ -f "$dest" ]` follows the link and the mode read
-# must follow it too: reading the link's own 0777 instead would publish a
-# world-writable file where a 0644 one stood — and for the suppression
-# baseline this helper writes, world-writable means any local account can
-# lower the ratchet without repository write access.
-mkdir -p "$ROOT/outside"
-printf 'BEHIND THE LINK\n' >"$ROOT/outside/target.tsv"
-chmod 644 "$ROOT/outside/target.tsv"
-ln -sf "$ROOT/outside/target.tsv" "$R/tools/linked.tsv"
-[ "$(filemode "$R/tools/linked.tsv")" != 644 ] \
-  && ok "the fixture link really carries a mode of its own, unlike its target" \
-  || bad "the fixture link really carries a mode of its own, unlike its target" "link=$(filemode "$R/tools/linked.tsv")"
-call 'gg_tmpdir; gg_install_file "'"$ROOT"'/src.tsv" tools/linked.tsv "the fixture"'
-[ "$RC" -eq 0 ] && [ "$(filemode "$R/tools/linked.tsv")" = 644 ] \
-  && [ "$(cat "$R/tools/linked.tsv")" = "REPLACEMENT" ] \
-  && ok "a symlink destination takes the mode of the file behind it, not the link's" \
-  || bad "a symlink destination takes the mode of the file behind it, not the link's" "rc=$RC mode=$(filemode "$R/tools/linked.tsv") out=$OUT"
-
-# A mode that cannot be read is a loud refusal, never a rename that narrows
-# the destination to the staging file's owner-only bits. `stat` shadowed by a
-# failing stub is the only way to reach it: every real file has a mode.
-mkdir -p "$ROOT/nostat"
-printf '#!/bin/sh\nexit 1\n' >"$ROOT/nostat/stat"
-chmod +x "$ROOT/nostat/stat"
-RC=0
-OUT="$(cd "$R" && PATH="$ROOT/nostat:$PATH" GG_CHECK=probe bash -c '
-  set -euo pipefail
-  . "$1"
-  . "$2"
-  gg_tmpdir
-  gg_install_file "$3" tools/dest.tsv "the fixture"
-' _ "$COMMON" "$INSTALL" "$ROOT/src.tsv" 2>&1)" || RC=$?
-[ "$RC" -eq 2 ] && case "$OUT" in *"could not read the mode of tools/dest.tsv"*) true ;; *) false ;; esac \
-  && ok "an unreadable mode is a loud refusal, not a narrowing rename" \
-  || bad "an unreadable mode is a loud refusal, not a narrowing rename" "rc=$RC out=$OUT"
-[ "$(filemode "$R/tools/dest.tsv")" = 644 ] \
-  && ok "and the destination keeps the mode it had" \
-  || bad "and the destination keeps the mode it had" "mode=$(filemode "$R/tools/dest.tsv")"
-
-# The scratch directory each step's stderr is captured into. Without one,
-# GG_TMP is set-but-EMPTY, so the capture would resolve to /install.err — a
-# path outside the repository, and one whose failure would itself be the bare
-# shell line this capture exists to stop. Every caller in the family arms
-# gg_tmpdir; one that has not is a programming error that says so.
-RC=0
-OUT="$(cd "$R" && GG_CHECK=probe bash -c '
-  set -euo pipefail
-  . "$1"
-  . "$2"
-  gg_install_file "$3" tools/dest.tsv "the fixture"
-' _ "$COMMON" "$INSTALL" "$ROOT/src.tsv" 2>&1)" || RC=$?
-[ "$RC" -eq 2 ] && case "$OUT" in *"needs gg_tmpdir called first"*) true ;; *) false ;; esac \
-  && ok "an install with no scratch directory refuses rather than writing beside the root" \
-  || bad "an install with no scratch directory refuses rather than writing beside the root" "rc=$RC out=$OUT"
-[ -z "$(find "$R/tools" -name '*gg-install*')" ] \
-  && ok "and stages nothing before refusing" \
-  || bad "and stages nothing before refusing" "$(find "$R/tools" -name '*gg-install*')"
-
-# The chmod branch: its whole diagnostic — the mode it could not give, and
-# what chmod said — is otherwise unpinned, so it could regress to a bare
-# symptom line with every suite green. A failing stub ahead of PATH, in the
-# same shape as the stat and mv stubs.
-mkdir -p "$ROOT/nochmod"
-printf '#!/bin/sh\necho "chmod: refused by the test stub" >&2\nexit 1\n' >"$ROOT/nochmod/chmod"
-chmod +x "$ROOT/nochmod/chmod"
-# Its own known destination state, so this case reports on the chmod branch
-# rather than on whatever the case above it managed to install.
-printf 'BEFORE THE CHMOD REFUSAL\n' >"$R/tools/dest.tsv"
-chmod 644 "$R/tools/dest.tsv"
-RC=0
-OUT="$(cd "$R" && PATH="$ROOT/nochmod:$PATH" GG_CHECK=probe bash -c '
-  set -euo pipefail
-  . "$1"
-  . "$2"
-  gg_tmpdir
-  gg_install_file "$3" tools/dest.tsv "the fixture"
-' _ "$COMMON" "$INSTALL" "$ROOT/src.tsv" 2>&1)" || RC=$?
-[ "$RC" -eq 2 ] && case "$OUT" in *"could not give the replacement for the fixture tools/dest.tsv's mode (644)"*) true ;; *) false ;; esac \
-  && ok "a failed chmod names the mode it could not give" \
-  || bad "a failed chmod names the mode it could not give" "rc=$RC out=$OUT"
-case "$OUT" in
-  *"could not give the replacement"*"refused by the test stub"*)
-    ok "and carries what chmod said inside its own line" ;;
-  *) bad "and carries what chmod said inside its own line" "$OUT" ;;
-esac
-[ "$(cat "$R/tools/dest.tsv")" = "BEFORE THE CHMOD REFUSAL" ] \
-  && ok "and the destination is untouched by that refusal" \
-  || bad "and the destination is untouched by that refusal" "content=$(cat "$R/tools/dest.tsv")"
-
-# A planted staging file must not redirect the write. cp writes THROUGH a
-# symlink, so a staging name the repository can predict is an arbitrary-file
-# overwrite waiting for the next --update. The writer publishes its own pid
-# and waits, so the symlink is planted at the EXACT name a pid-derived
-# scheme would choose — the control is aimed, not a guess.
-new_repo install-symlink
-mkdir -p "$R/tools"
-printf 'ORIGINAL\n' >"$R/tools/dest.tsv"
-printf 'VICTIM\n' >"$ROOT/victim.txt"
-pidfile="$ROOT/writer.pid"
-gofile="$ROOT/writer.go"
-rm -f "$pidfile" "$gofile"
-(
-  cd "$R" && GG_CHECK=probe bash -c '
-    set -euo pipefail
-    echo "$$" >"$3"
-    i=0
-    while [ ! -e "$4" ] && [ "$i" -lt 200 ]; do i=$((i + 1)); sleep 0.05; done
-    . "$1"
-    . "$2"
-    gg_tmpdir
-    gg_install_file "$5" tools/dest.tsv "the fixture"
-  ' _ "$COMMON" "$INSTALL" "$pidfile" "$gofile" "$ROOT/src.tsv"
-) >"$ROOT/writer.out" 2>&1 &
-writer=$!
-i=0
-while [ ! -s "$pidfile" ] && [ "$i" -lt 200 ]; do i=$((i + 1)); sleep 0.05; done
-if [ -s "$pidfile" ]; then
-  ln -s "$ROOT/victim.txt" "$R/tools/.gg-install.$(cat "$pidfile").dest.tsv"
-  ok "the control is aimed at the pid the writer actually uses"
-else
-  bad "the control is aimed at the pid the writer actually uses" "no pid published"
-fi
-: >"$gofile"
-wait "$writer" || true
-[ "$(cat "$ROOT/victim.txt")" = "VICTIM" ] \
-  && ok "a planted staging symlink does not redirect the write" \
-  || bad "a planted staging symlink does not redirect the write" "victim=$(cat "$ROOT/victim.txt")"
-[ "$(cat "$R/tools/dest.tsv")" = "REPLACEMENT" ] \
-  && ok "the install still lands on its real destination" \
-  || bad "the install still lands on its real destination" "content=$(cat "$R/tools/dest.tsv") out=$(cat "$ROOT/writer.out")"
-[ -z "$(find "$R/tools" -name '.gg-install.*.XXXXXX' -o -name '*.gg-install.??????')" ] \
-  && ok "no staging file is left behind beside the destination" \
-  || bad "no staging file is left behind beside the destination" "$(find "$R/tools" -name '*gg-install*')"
-
-# Control: interrupt the install at the rename. The destination must still
-# carry the reviewed bytes — a truncated ratchet file loosens the gate
-# instead of failing it, so a half-done replace is worse than none.
-new_repo install-fails
-mkdir -p "$R/tools" "$ROOT/stub"
-printf 'ORIGINAL\n' >"$R/tools/dest.tsv"
-printf '#!/bin/sh\nexit 1\n' >"$ROOT/stub/mv"
-chmod +x "$ROOT/stub/mv"
-RC=0
-OUT="$(cd "$R" && PATH="$ROOT/stub:$PATH" GG_CHECK=probe bash -c '
-  set -euo pipefail
-  . "$1"
-  . "$2"
-  gg_tmpdir
-  gg_install_file "$3" tools/dest.tsv "the fixture"
-' _ "$COMMON" "$INSTALL" "$ROOT/src.tsv" 2>&1)" || RC=$?
-[ "$RC" -eq 2 ] && case "$OUT" in *"could not replace the fixture"*) true ;; *) false ;; esac \
-  && ok "a failed rename is a loud collection error" \
-  || bad "a failed rename is a loud collection error" "rc=$RC out=$OUT"
-[ "$(cat "$R/tools/dest.tsv")" = "ORIGINAL" ] \
-  && ok "a failed install leaves the destination byte-identical" \
-  || bad "a failed install leaves the destination byte-identical" "content=$(cat "$R/tools/dest.tsv")"
-
-echo "=== the settings cache is materialized by rename, never by a live redirect ==="
-
+mkdir -p "$ROOT/nomv"
+printf '#!/bin/sh\nexit 1\n' >"$ROOT/nomv/mv"
+chmod +x "$ROOT/nomv/mv"
 new_repo settings-cache
 printf 'COMMIT_GUARDS_TODO_MAX=7\n' >"$R/kendex.settings.toml"
-git -C "$R" add -A
-git -C "$R" commit -qm base
-RC=0
-OUT="$(cd "$R" && PATH="$ROOT/stub:$PATH" GG_CHECK=probe bash -c '
-  set -euo pipefail
-  . "$1"
-  . "$2"
-  gg_settings_index_mode
-  src="$(gg_settings_source kendex.settings.toml)" || exit 3
-  printf "SRC=%s\n" "$src"
-  ls -A "$GG_SETTINGS_INDEX_DIR"
-' _ "$COMMON" "$SETTINGS" 2>&1)" || RC=$?
-[ "$RC" -eq 3 ] && case "$OUT" in *"could not materialize the staged copy"*) true ;; *) false ;; esac \
-  && ok "a failed rename fails the settings resolve loudly" \
-  || bad "a failed rename fails the settings resolve loudly" "rc=$RC out=$OUT"
-case "$OUT" in
-  *SRC=*) bad "no cache path is handed out when the rename failed" "out=$OUT" ;;
-  *) ok "no cache path is handed out when the rename failed" ;;
-esac
+commit_all base
+RESOLVE='gg_settings_index_mode; src="$(gg_settings_source kendex.settings.toml)" || exit 3; cat "$src"; find "$GG_SETTINGS_INDEX_DIR" -name "*.part" -print | sed "s/^/PART:/"'
 
-# Control: with mv working, the same resolve materializes a complete cache.
-RC=0
-OUT="$(cd "$R" && GG_CHECK=probe bash -c '
-  set -euo pipefail
-  . "$1"
-  . "$2"
-  gg_settings_index_mode
-  src="$(gg_settings_source kendex.settings.toml)"
-  cat "$src"
-  find "$GG_SETTINGS_INDEX_DIR" -name "*.part" -print | sed "s/^/PART:/"
-' _ "$COMMON" "$SETTINGS" 2>&1)" || RC=$?
-[ "$RC" -eq 0 ] && case "$OUT" in *COMMIT_GUARDS_TODO_MAX=7*) true ;; *) false ;; esac \
-  && ok "the cache resolves the staged value when the rename succeeds" \
-  || bad "the cache resolves the staged value when the rename succeeds" "rc=$RC out=$OUT"
-case "$OUT" in
-  *PART:*) bad "no partial cache file survives the resolve" "out=$OUT" ;;
-  *) ok "no partial cache file survives the resolve" ;;
-esac
-
-echo "=== gg_grep_lane: content decides what is scanned, an attributes rule never does ==="
-
-# Every index-wide lane in the family scans through gg_grep_lane. `git grep
-# -I` takes its binary verdict from the path's userdiff driver, so ONE
-# committed attributes row would put a whole extension outside the scan with
-# no status and no stderr — a clean verdict over content never read. Each
-# lane is pinned end to end, each against a control proving the same fixture
-# fails without the row.
-run_check() { # SCRIPT [ARG...] — RC and OUT from a run inside $R
-  local script="$1"; shift; RC=0
-  OUT="$(cd "$R" && "$SCRIPTS/$script" "$@" 2>&1)" || RC=$?
-}
-
-new_repo attrs-todo
-# Spelled in halves so this suite is not itself a work marker.
-MARKER="TO""DO"
-printf 'x = 1  # %s: real\n' "$MARKER" >"$R/code.py"
-git -C "$R" add -A
-run_check todo-ban
-[ "$RC" -eq 1 ] && case "$OUT" in *"work marker: code.py:1:"*) true ;; *) false ;; esac \
-  && ok "control: the marker fails with no attributes row" \
-  || bad "control: the marker fails with no attributes row" "rc=$RC out=$OUT"
-printf '*.py -diff\n' >"$R/.gitattributes"
-git -C "$R" add -A
-# The fixture is real only if git's own -I judgement has in fact flipped.
-RC=0
-OUT="$(cd "$R" && git grep --cached -nIE "$MARKER" -- 'code.py' 2>&1)" || RC=$?
-[ "$RC" -eq 1 ] && [ -z "$OUT" ] \
-  && ok "fixture: with '*.py -diff' a bare -I grep drops the file silently" \
-  || bad "fixture: -diff makes a bare -I grep drop the file" "rc=$RC out=$OUT"
-run_check todo-ban
-[ "$RC" -eq 1 ] && case "$OUT" in *"work marker: code.py:1:"*) true ;; *) false ;; esac \
-  && ok "the index-wide todo-ban lane still reads a '-diff' path" \
-  || bad "index-wide todo-ban reads a '-diff' path" "rc=$RC out=$OUT"
-case "$OUT" in *"OK — no work markers"*) bad "no clean verdict may accompany the hidden marker" "$OUT" ;; *) ok "no clean verdict accompanies the hidden marker" ;; esac
-printf '*.py binary\n' >"$R/.gitattributes"
-git -C "$R" add -A
-run_check todo-ban
-[ "$RC" -eq 1 ] && case "$OUT" in *"work marker: code.py:1:"*) true ;; *) false ;; esac \
-  && ok "the 'binary' attribute macro cannot hide it either" \
-  || bad "'binary' macro cannot hide the marker" "rc=$RC out=$OUT"
-
-new_repo attrs-conflict
-printf '<<<<<<< HEAD\na\n=======\nb\n>>>>>>> other\n' >"$R/merge.txt"
-git -C "$R" add -A
-run_check conflict-markers
-[ "$RC" -eq 1 ] && case "$OUT" in *"conflict marker: merge.txt:1:"*) true ;; *) false ;; esac \
-  && ok "control: the conflict markers fail with no attributes row" \
-  || bad "control: conflict markers fail without the row" "rc=$RC out=$OUT"
-printf '*.txt -diff\n' >"$R/.gitattributes"
-git -C "$R" add -A
-run_check conflict-markers
-[ "$RC" -eq 1 ] && case "$OUT" in *"conflict marker: merge.txt:1:"*) true ;; *) false ;; esac \
-  && ok "a '-diff' row cannot hide a conflict marker" \
-  || bad "'-diff' row cannot hide a conflict marker" "rc=$RC out=$OUT"
-
-new_repo attrs-suppression
-printf '#![allow(dead_code)]\n' >"$R/lib.rs"
-git -C "$R" add -A
-run_check suppression-ban
-[ "$RC" -eq 1 ] && case "$OUT" in *"module-wide rust allow: lib.rs:1:"*) true ;; *) false ;; esac \
-  && ok "control: the blanket allow fails with no attributes row" \
-  || bad "control: blanket allow fails without the row" "rc=$RC out=$OUT"
-printf '*.rs -diff\n' >"$R/.gitattributes"
-git -C "$R" add -A
-run_check suppression-ban
-[ "$RC" -eq 1 ] && case "$OUT" in *"module-wide rust allow: lib.rs:1:"*) true ;; *) false ;; esac \
-  && ok "a '-diff' row cannot hide a blanket suppression" \
-  || bad "'-diff' row cannot hide a blanket suppression" "rc=$RC out=$OUT"
-
-# Gate 2, the bare-allow ratchet, counts over that same content rule. An
-# attributes row that emptied its count file would read as "no bare allows
-# anywhere", and the stale rows that follow print a remedy — `--update` —
-# that erases the ratchet while the violations stand.
-new_repo attrs-ratchet
-mkdir -p "$R/tools"
-printf '#[allow(dead_code)]\nfn a() {}\n' >"$R/a.rs"
-printf '#[allow(dead_code)]\nfn b() {}\n' >"$R/b.rs"
-printf 'b.rs\t1\n' >"$R/tools/suppression-baseline.tsv"
-git -C "$R" add -A
-run_check suppression-ban
-[ "$RC" -eq 1 ] && case "$OUT" in *"new bare allow: a.rs"*) true ;; *) false ;; esac \
-  && ok "control: the unbaselined bare allow fails with no attributes row" \
-  || bad "control: unbaselined bare allow fails without the row" "rc=$RC out=$OUT"
-case "$OUT" in
-  *"stale baseline row: b.rs"*) bad "control: a live baseline row is not called stale" "out=$OUT" ;;
-  *) ok "control: a live baseline row is not called stale" ;;
-esac
-
-printf '*.rs -diff\n' >"$R/.gitattributes"
-git -C "$R" add -A
-run_check suppression-ban
-[ "$RC" -eq 1 ] && case "$OUT" in *"new bare allow: a.rs"*) true ;; *) false ;; esac \
-  && ok "a '-diff' row cannot hide a bare allow from the ratchet count" \
-  || bad "'-diff' row cannot hide a bare allow" "rc=$RC out=$OUT"
-case "$OUT" in
-  *"stale baseline row: b.rs"*) bad "an emptied count never turns a live row stale" "out=$OUT" ;;
-  *) ok "an emptied count never turns a live row stale" ;;
-esac
-case "$OUT" in
-  *"suppression-ban: OK"*) bad "no clean verdict accompanies the hidden bare allows" "out=$OUT" ;;
-  *) ok "no clean verdict accompanies the hidden bare allows" ;;
-esac
-
-# The remedy those stale rows print, followed to its end: --update must not
-# be able to write a 0-row baseline while both files still carry bare
-# allows. The baseline is tighten-only, so a row dropped here never returns.
-RC=0
-OUT="$(cd "$R" && "$SCRIPTS/suppression-ban" --update 2>&1)" || RC=$?
-[ "$(cat "$R/tools/suppression-baseline.tsv")" = "b.rs${TAB}1" ] \
-  && ok "--update cannot be led into erasing the ratchet" \
-  || bad "--update cannot be led into erasing the ratchet" "baseline=$(cat "$R/tools/suppression-baseline.tsv") out=$OUT"
-[ "$RC" -eq 1 ] && case "$OUT" in *"new bare allow: a.rs"*) true ;; *) false ;; esac \
-  && ok "the re-check after --update still fails the bare allow" \
-  || bad "the re-check after --update still fails" "rc=$RC out=$OUT"
-
-# The other half of forcing text: what the scan may NOT decode. The judgement
-# is the blob's own bytes — a NUL in its leading block, git's content rule —
-# so an asset whose bytes happen to spell the shape is skipped rather than
-# reported as a violation record full of raw bytes.
-new_repo attrs-binary
-printf 'PNG\000 %s: not a marker\n' "$MARKER" >"$R/logo.png"
-git -C "$R" add -A
-run_check todo-ban
-[ "$RC" -eq 0 ] && case "$OUT" in *"OK — no work markers"*) true ;; *) false ;; esac \
-  && ok "a blob whose leading bytes carry a NUL is not scanned" \
-  || bad "binary blob is not scanned" "rc=$RC out=$OUT"
-case "$OUT" in *"$MARKER"*) bad "no raw bytes from the asset reach the output" "$OUT" ;; *) ok "no raw bytes from the asset reach the output" ;; esac
-# The path MATCHED the banned shape and was then left unread, so it is named
-# and counted apart: an unqualified OK here would be a clean verdict over
-# content the lane deliberately did not scan.
-case "$OUT" in
-  *"todo-ban: not measured: logo.png — binary content"*)
-    ok "the unread match is named, not silently dropped"
-    ;;
-  *) bad "the unread match is named" "out=$OUT" ;;
-esac
-case "$OUT" in
-  *"OK — no work markers in tracked files; 1 matched path(s) not measured"*)
-    ok "the verdict carries the qualifier rather than reading as a plain OK"
-    ;;
-  *) bad "the verdict carries the qualifier" "out=$OUT" ;;
-esac
-# Control: the same bytes without the NUL are text, and text is scanned.
-printf 'PNG  %s: not a marker\n' "$MARKER" >"$R/logo.png"
-git -C "$R" add -A
-run_check todo-ban
-[ "$RC" -eq 1 ] && case "$OUT" in *"work marker: logo.png:1:"*) true ;; *) false ;; esac \
-  && ok "control: the same bytes without the NUL are scanned as text" \
-  || bad "control: same bytes without the NUL are scanned" "rc=$RC out=$OUT"
-case "$OUT" in
-  *"not measured"*) bad "control: a scanned path is never named as unmeasured" "out=$OUT" ;;
-  *) ok "control: a scanned path is never named as unmeasured" ;;
-esac
-
-echo "=== the shared readers fail closed, once, for every lane that uses them ==="
-
-# gg_grep_guard, gg_read_blob and gg_blob_is_binary are the family's index
-# readers: every lane collects through them, so an incomplete scan is refused
-# HERE, once — including the call sites no default-lane run reaches, which
-# the arms below drive through the lane that owns them.
-REAL_GIT="$(command -v git)"
-git_failing_on() { # ARG [LANE-ARG...] — todo-ban under a git that exits 128 for ARG
-  local a="$1" dir="$TMP/git-shim-$1"; shift; mkdir -p "$dir"
-  printf '#!/usr/bin/env bash\ncase " $* " in *" %s "*) echo "git %s: simulated failure" >&2; exit 128 ;; esac\nexec "%s" "$@"\n' "$a" "$a" "$REAL_GIT" >"$dir/git"
-  chmod +x "$dir/git"
-  under_shim "$dir" todo-ban "$@"
-}
-under_shim() { # SHIM-DIR SCRIPT [ARG...] — run SCRIPT with SHIM-DIR first on PATH
-  local dir="$1"; shift; local script="$1"; shift; RC=0
-  OUT="$(cd "$R" && PATH="$dir:$PATH" "$SCRIPTS/$script" "$@" 2>&1)" || RC=$?
-}
-refused() { # LABEL NEEDLE [CHECK] — exit 2 carrying NEEDLE, and never a clean verdict
-  [ "$RC" -eq 2 ] && case "$OUT" in *"$2"*) true ;; *) false ;; esac \
-    && ok "$1" || bad "$1" "rc=$RC out=$OUT"
-  case "$OUT" in *"${3:-todo-ban}: OK"*) bad "no OK verdict may accompany $1" "$OUT" ;; *) ok "and no OK verdict accompanies it" ;; esac
-}
-
-new_repo readers
-printf '// %s: stranded work\n' "$MARKER" >"$R/a.rs"
-git -C "$R" add -A
-run_check todo-ban
-[ "$RC" -eq 1 ] && ok "control: the staged marker trips with the real git" \
-  || bad "control: the staged marker trips" "rc=$RC out=$OUT"
-git_failing_on grep
-refused "a git grep execution failure is a collection error, never OK" "git grep failed scanning tracked files"
-git_failing_on cat-file
-refused "a blob read that cannot run is exit 2, never a path skipped" "refusing to skip an unread work marker"
-# git spends no error status on a staged blob it cannot read: the `error:`
-# line on stderr is all that separates a partial scan from a clean one.
-OID="$(git -C "$R" rev-parse :a.rs)"
-[ -f "$R/.git/objects/${OID:0:2}/${OID:2}" ] || bad "fixture: the staged blob is a loose object" "$OID"
-rm -f -- "$R/.git/objects/${OID:0:2}/${OID:2}"
-run_check todo-ban
-refused "a vanished staged blob is exit 2 carrying git's own error line" "unable to read"
-printf '// %s: readable\n' "$MARKER" >"$R/b.rs"
-git -C "$R" add b.rs
-run_check todo-ban
-refused "a scan matching one file it read and one it could not is exit 2, never a violation" "unable to read"
-
-# The --staged lane reaches the same readers through calls of its own that
-# the default lane never makes: the carriers pre-filter grep, and the
-# per-file content sniff that reads each staged blob. The fixture stages a
-# marker, so no arm below can be clean by construction.
-new_repo readers-staged
-printf 'fn main() {}\n' >"$R/ok.rs"
-git -C "$R" add -A
-git -C "$R" commit -qm seed
-printf '// %s: staged for the pre-filter to find\n' "$MARKER" >>"$R/ok.rs"
-git -C "$R" add ok.rs
-run_check todo-ban --staged
-[ "$RC" -eq 1 ] && ok "control: the staged marker fires with the real tools" \
-  || bad "control: the staged marker fires" "rc=$RC out=$OUT"
-git_failing_on grep --staged
-refused "a broken staged pre-filter is a collection error, never OK" "git grep failed listing the staged files that carry a work marker"
-git_failing_on cat-file --staged
-refused "a staged blob the sniff cannot read is exit 2, never a path skipped" "refusing to skip an unread work marker"
-
-# gg_blob_is_binary sizes the leading bytes twice, and neither count may
-# decide the verdict after failing: a silent zero out of the NUL strip reads
-# as "every byte was a NUL" and folds an unread blob into a clean pass. One
-# shim per count — the wc shim fails once, so the first count fails while
-# the second succeeds; the tr shim breaks only the strip inside the second.
-COUNT_SHIM="$TMP/count-shim"
-mkdir -p "$COUNT_SHIM"
-printf '#!/usr/bin/env bash\nif [ ! -e "%s" ]; then : >"%s"; echo "wc: simulated execution failure" >&2; exit 1; fi\nexec "%s" "$@"\n' \
-  "$TMP/wc-fired" "$TMP/wc-fired" "$(command -v wc)" >"$COUNT_SHIM/wc"
-chmod +x "$COUNT_SHIM/wc"
-rm -f "$TMP/wc-fired"
-under_shim "$COUNT_SHIM" todo-ban --staged
-refused "a first block that cannot be sized is exit 2, never OK" "could not sample ok.rs to classify its content"
-TR_SHIM="$TMP/tr-shim"
-mkdir -p "$TR_SHIM"
-printf '#!/usr/bin/env bash\necho "tr: simulated execution failure" >&2\nexit 1\n' >"$TR_SHIM/tr"
-chmod +x "$TR_SHIM/tr"
-under_shim "$TR_SHIM" todo-ban --staged
-refused "a NUL-free count that cannot run is exit 2, never OK" "could not sample ok.rs to classify its content"
-
-# suppression-ban's per-carrier count is its own call, made after the shared
-# listing has already named the carrier, and it is the one gg_grep_guard site
-# outside lib/. The shim errors that call alone and exits 0, so the `error:`
-# line gg_grep_guard reads off stderr is the only thing left that can refuse
-# a count which would otherwise read as a clean zero.
-new_repo readers-count
-mkdir -p "$R/tools"
-printf 'fn main() {}\n' >"$R/ok.rs"
-printf '#[allow(dead_code)]\nfn b() {}\n' >"$R/bare.rs"
-printf 'bare.rs\t1\n' >"$R/tools/suppression-baseline.tsv"
-git -C "$R" add -A
-run_check suppression-ban
-[ "$RC" -eq 0 ] && ok "control: the baselined bare allow passes with the real git" \
-  || bad "control: the baselined bare allow passes" "rc=$RC out=$OUT"
-SB_COUNT_SHIM="$TMP/git-shim-count"
-mkdir -p "$SB_COUNT_SHIM"
-printf '#!/usr/bin/env bash\ncase " $* " in *" -acE "*) echo "error: %s: unable to read %s" >&2; exit 0 ;; esac\nexec "%s" "$@"\n' \
-  "'phantom.rs'" "0000000000000000000000000000000000000000" "$REAL_GIT" >"$SB_COUNT_SHIM/git"
-chmod +x "$SB_COUNT_SHIM/git"
-under_shim "$SB_COUNT_SHIM" suppression-ban
-refused "a count whose stderr carries an error line is exit 2, never a clean zero" "could not read staged content while counting the bare allows" suppression-ban
+echo "=== the settings cache is materialized by rename, never by a live redirect ==="
+assert_eq "the cache resolves the staged value when the rename succeeds, leaving no partial file" \
+  "rc=0 COMMIT_GUARDS_TODO_MAX=7" "$(call "$SETTINGS" "$RESOLVE")"
+assert_eq "a failed rename fails the resolve loudly and hands out no cache path" \
+  "rc=3 ::error::kendex.settings.toml: could not materialize the staged copy while resolving a setting" \
+  "$(call "$SETTINGS" "PATH=$ROOT/nomv:\$PATH; $RESOLVE")"
 
 printf '\n%s passed, %s failed\n' "$PASS" "$FAIL"
 [ "$FAIL" -eq 0 ]

--- a/skills/commit-guards/tests/lane-readers.test.sh
+++ b/skills/commit-guards/tests/lane-readers.test.sh
@@ -1,0 +1,249 @@
+#!/usr/bin/env bash
+# The lanes end to end over the readers lib/common.sh and
+# lib/configured-paths.sh share: an unmerged index is refused rather than
+# scanned around, content decides what gg_grep_lane scans and an attributes
+# rule never does, a blob whose leading bytes carry a NUL is named unmeasured
+# rather than scanned or dropped, and a reader git or a tool could not run is
+# a collection error, never a clean verdict. One table per family: a row
+# builds its own fixture repository, runs one lane under an optional PATH
+# shim, and reads back the exit status and every line printed.
+set -euo pipefail
+
+TEST_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=lib/harness.bash
+. "$TEST_DIR/lib/harness.bash"
+SKILL_DIR="$(cd "$TEST_DIR/.." && pwd)"
+SCRIPTS="$SKILL_DIR/scripts"
+ROOT="$TMP"
+REAL_GIT="$(command -v git)"
+
+unset COMMIT_GUARDS_SETTINGS_FILE COMMIT_GUARDS_CONFLICT_EXCLUDES 2>/dev/null || true
+
+PASS=0
+FAIL=0
+assert_eq() { # LABEL EXPECT ACTUAL
+  if [ "$2" = "$3" ]; then
+    PASS=$((PASS + 1))
+    printf '  ok    %s\n' "$1"
+  else
+    FAIL=$((FAIL + 1))
+    printf '  FAIL  %s\n        want: %s\n        got:  %s\n' "$1" "$2" "$3"
+  fi
+}
+
+new_repo() { # NAME — fresh fixture repo in $R, cwd unchanged
+  R="$ROOT/$1"
+  mkdir -p "$R"
+  git -C "$R" -c init.defaultBranch=main init -q
+  git -C "$R" config user.email test@example.com
+  git -C "$R" config user.name test
+}
+commit_all() { # MESSAGE
+  git -C "$R" add -A
+  git -C "$R" commit -qm "$1"
+}
+
+# One line for a lane run inside $R, SHIM-DIR first on PATH when given: the
+# exit status, then every printed line in order joined by ';', so a refusal
+# reads with git's own line above it and a verdict with its qualifier.
+lane() { # SHIM-DIR SCRIPT [ARG...]
+  local dir="$1" script="$2" rc=0 out
+  shift 2
+  out="$(cd "$R" && PATH="${dir:+$dir:}$PATH" "$SCRIPTS/$script" "$@" 2>&1)" || rc=$?
+  out="${out//"$R"/<repo>}"
+  out="${out//"$ROOT"/<root>}"
+  printf 'rc=%s%s' "$rc" "${out:+ $(printf '%s\n' "$out" | sed 's/[[:space:]]*$//' | paste -sd ';' -)}"
+}
+
+# Spelled in halves so this suite is not itself a work marker.
+MARKER="TO""DO"
+
+# --- an unmerged index -------------------------------------------------------
+
+conflicted_repo() { # NAME — fixture left mid-merge, f.txt unmerged
+  new_repo "$1"
+  printf 'line1\nbase\nline3\n' >"$R/f.txt"
+  commit_all base
+  git -C "$R" checkout -q -b other
+  printf 'line1\ntheirs\nline3\n' >"$R/f.txt"
+  git -C "$R" commit -qam other
+  git -C "$R" checkout -q main
+  printf 'line1\nours\nline3\n' >"$R/f.txt"
+  git -C "$R" commit -qam ours
+  git -C "$R" merge other >/dev/null 2>&1 || true
+}
+fx_conflict_staged() { conflicted_repo "$1"; git -C "$R" add f.txt; }
+fx_conflict_resolved() { conflicted_repo "$1"; printf 'line1\nmerged\nline3\n' >"$R/f.txt"; git -C "$R" add f.txt; }
+# An add/add conflict is status U, which --diff-filter=A drops entirely: the
+# addition vanishes from the record set and a ceiling measures nothing.
+fx_addadd() {
+  new_repo "$1"
+  printf 'seed\n' >"$R/seed.txt"
+  commit_all base
+  git -C "$R" checkout -q -b other
+  head -c 400000 /dev/zero | tr '\0' 'b' >"$R/big.txt"
+  commit_all other
+  git -C "$R" checkout -q main
+  head -c 400000 /dev/zero | tr '\0' 'a' >"$R/big.txt"
+  commit_all ours
+  git -C "$R" merge other >/dev/null 2>&1 || true
+}
+fx_merged_big() { new_repo "$1"; printf 'seed\n' >"$R/seed.txt"; commit_all base; head -c 400000 /dev/zero | tr '\0' 'a' >"$R/big.txt"; git -C "$R" add -A; }
+fx_merged_small() { new_repo "$1"; printf 'seed\n' >"$R/seed.txt"; commit_all base; printf 'small\n' >"$R/small.txt"; git -C "$R" add -A; }
+
+fx_addadd addadd-fixture
+assert_eq "the add/add fixture really hides the addition from --diff-filter=A" 0 "$(git -C "$R" diff --cached --raw --diff-filter=A | wc -l | tr -d ' ')"
+
+echo "=== an unmerged index is refused, never scanned around ==="
+UNMERGED="f.txt;::error::CHECK: the index carries 1 unmerged path(s) (listed above) and a --cached scan skips them silently — finish or abort the merge, then re-run"
+BIG_UNMERGED="big.txt;::error::byte-ceiling: the index carries 1 unmerged path(s) (listed above) and a --cached scan skips them silently — finish or abort the merge, then re-run"
+# label | fixture | lane args | expect
+rows=(
+  "conflict-markers refuses the unmerged index|conflicted_repo cm-unmerged|conflict-markers|rc=2 ${UNMERGED//CHECK/conflict-markers}"
+  "prose refuses it before its walk, though no default path matches|conflicted_repo prose-unmerged|prose|rc=2 ${UNMERGED//CHECK/prose}"
+  "control: once staged, the same markers fail as violations|fx_conflict_staged cm-staged|conflict-markers|rc=1 conflict-markers FAIL conflict marker: f.txt:2:<<<<<<< HEAD;  remedies: finish the merge and delete the marker lines; a file that legitimately carries the trio at column 0 belongs in tools/conflict-markers-excludes with a reason;conflict-markers FAIL conflict marker: f.txt:6:>>>>>>> other;  remedies: finish the merge and delete the marker lines; a file that legitimately carries the trio at column 0 belongs in tools/conflict-markers-excludes with a reason;conflict-markers: 2 conflict marker(s) — excludes tools/conflict-markers-excludes"
+  "control: a resolved, marker-free tree passes|fx_conflict_resolved cm-resolved|conflict-markers|rc=0 conflict-markers: OK — no conflict markers in tracked files"
+  "byte-ceiling refuses an add/add conflict instead of measuring around it|fx_addadd bc-addadd|byte-ceiling|rc=2 $BIG_UNMERGED"
+  "--all refuses it too, where ls-files emits one record per stage|fx_addadd bc-addadd-all|byte-ceiling --all|rc=2 $BIG_UNMERGED"
+  "control: a merged index still fails an oversized addition|fx_merged_big bc-merged-big|byte-ceiling|rc=1 byte-ceiling FAIL oversized file: big.txt — 400000 bytes (~391 KB) > ceiling 200 KB;  remedies: keep big artifacts out of the repo (asset store, Git LFS, build-time generation); a file that genuinely belongs gets a row in tools/byte-ceiling-excludes with its reason;byte-ceiling: 1 violation(s) — ceiling 200 KB, 1 staged file(s) checked"
+  "control: a merged index with nothing oversized passes|fx_merged_small bc-merged-small|byte-ceiling|rc=0 byte-ceiling: OK — 1 staged file(s) checked, ceiling 200 KB"
+)
+for row in "${rows[@]}"; do
+  IFS='|' read -r label fixture args expect <<<"$row"
+  $fixture
+  # shellcheck disable=SC2086
+  assert_eq "$label" "$expect" "$(lane "" $args)"
+done
+
+# --- content decides what is scanned ----------------------------------------
+
+# `git grep -I` takes its binary verdict from the path's userdiff driver, so
+# ONE committed attributes row would put a whole extension outside the scan
+# with no status and no stderr. Each lane is read with and without the row.
+fx_attrs() { # NAME FILE CONTENT [ATTR-ROW]
+  new_repo "$1"
+  printf '%b' "$3" >"$R/$2"
+  [ -z "${4:-}" ] || printf '%s\n' "$4" >"$R/.gitattributes"
+  git -C "$R" add -A
+}
+fx_ratchet() { # NAME [ATTR-ROW]
+  new_repo "$1"
+  mkdir -p "$R/tools"
+  printf '#[allow(dead_code)]\nfn a() {}\n' >"$R/a.rs"
+  printf '#[allow(dead_code)]\nfn b() {}\n' >"$R/b.rs"
+  printf 'b.rs\t1\n' >"$R/tools/suppression-baseline.tsv"
+  [ -z "${2:-}" ] || printf '%s\n' "$2" >"$R/.gitattributes"
+  git -C "$R" add -A
+}
+
+fx_attrs attrs-probe code.py "x = 1  # $MARKER: real\n" '*.py -diff'
+assert_eq "fixture: with '*.py -diff' a bare -I grep drops the file silently" "rc=1" \
+  "$(rc=0; out="$(cd "$R" && git grep --cached -nIE "$MARKER" -- code.py 2>&1)" || rc=$?; printf 'rc=%s%s' "$rc" "${out:+ $out}")"
+
+echo "=== content decides what is scanned, an attributes rule never does ==="
+TODO_HIT="todo-ban FAIL work marker: code.py:1:x = 1  # $MARKER: real;  remedies: do the work now, or move it to the tracker and delete the marker; vendored/generated trees belong in tools/todo-ban-excludes with a reason;todo-ban: 1 work marker(s) — excludes tools/todo-ban-excludes"
+SUPP_HIT="suppression-ban FAIL module-wide rust allow: lib.rs:1:#![allow(dead_code)];  remedies: delete the module-wide attribute and fix the findings, or annotate the surviving sites per line with a stated reason; vendored trees belong in tools/suppression-ban-excludes with a reason;suppression-ban: 1 violation(s) — 1 blanket, 0 ratchet (baseline tools/suppression-baseline.tsv)"
+RATCHET_HIT="suppression-ban FAIL new bare allow: a.rs — 1 reasonless allow(dead_code)/allow(unused) attribute(s), no baseline row;  remedies: state a reason on each attribute or fix the code; freezing a legacy count is a hand-added baseline row in this diff with justification;suppression-ban: 1 violation(s) — 0 blanket, 1 ratchet (baseline tools/suppression-baseline.tsv)"
+CM_HITS="conflict-markers FAIL conflict marker: merge.txt:1:<<<<<<< HEAD;  remedies: finish the merge and delete the marker lines; a file that legitimately carries the trio at column 0 belongs in tools/conflict-markers-excludes with a reason;conflict-markers FAIL conflict marker: merge.txt:5:>>>>>>> other;  remedies: finish the merge and delete the marker lines; a file that legitimately carries the trio at column 0 belongs in tools/conflict-markers-excludes with a reason;conflict-markers: 2 conflict marker(s) — excludes tools/conflict-markers-excludes"
+CONFLICT='<<<<<<< HEAD\na\n=======\nb\n>>>>>>> other\n'
+# label | file | content (%b) | attributes row | lane args | expect
+rows=(
+  "control: the marker fails with no attributes row|code.py|x = 1  # $MARKER: real\\n||todo-ban|rc=1 $TODO_HIT"
+  "the index-wide todo-ban lane still reads a '-diff' path|code.py|x = 1  # $MARKER: real\\n|*.py -diff|todo-ban|rc=1 $TODO_HIT"
+  "the 'binary' attribute macro cannot hide it either|code.py|x = 1  # $MARKER: real\\n|*.py binary|todo-ban|rc=1 $TODO_HIT"
+  "control: conflict markers fail with no attributes row|merge.txt|$CONFLICT||conflict-markers|rc=1 $CM_HITS"
+  "a '-diff' row cannot hide a conflict marker|merge.txt|$CONFLICT|*.txt -diff|conflict-markers|rc=1 $CM_HITS"
+  "control: the blanket allow fails with no attributes row|lib.rs|#![allow(dead_code)]\\n||suppression-ban|rc=1 $SUPP_HIT"
+  "a '-diff' row cannot hide a blanket suppression|lib.rs|#![allow(dead_code)]\\n|*.rs -diff|suppression-ban|rc=1 $SUPP_HIT"
+  "control: the unbaselined bare allow fails with no attributes row, the live row not called stale|ratchet|||suppression-ban|rc=1 $RATCHET_HIT"
+  "a '-diff' row cannot hide a bare allow from the ratchet count|ratchet||*.rs -diff|suppression-ban|rc=1 $RATCHET_HIT"
+  "--update cannot be led into erasing the ratchet: the re-check still fails|ratchet||*.rs -diff|suppression-ban --update|rc=1 suppression-ban --update: baseline tightened at tools/suppression-baseline.tsv (1 row(s));$RATCHET_HIT"
+)
+i=0
+for row in "${rows[@]}"; do
+  IFS='|' read -r label file content attr args expect <<<"$row"
+  i=$((i + 1))
+  if [ "$file" = ratchet ]; then fx_ratchet "attrs-$i" "$attr"; else fx_attrs "attrs-$i" "$file" "$content" "$attr"; fi
+  # shellcheck disable=SC2086
+  assert_eq "$label" "$expect" "$(lane "" $args)"
+done
+assert_eq "--update left the baseline as it was" "b.rs	1" "$(cat "$R/tools/suppression-baseline.tsv")"
+
+echo "=== a blob whose leading bytes carry a NUL is named unmeasured, not scanned ==="
+fx_attrs attrs-binary logo.png "PNG\0 $MARKER: not a marker\n"
+assert_eq "the unread match is named, counted apart, and the verdict carries the qualifier" \
+  "rc=0 todo-ban: not measured: logo.png — binary content, not text;todo-ban: OK — no work markers in tracked files; 1 matched path(s) not measured" "$(lane "" todo-ban)"
+fx_attrs attrs-text logo.png "PNG  $MARKER: not a marker\n"
+assert_eq "control: the same bytes without the NUL are scanned as text" \
+  "rc=1 todo-ban FAIL work marker: logo.png:1:PNG  $MARKER: not a marker;  remedies: do the work now, or move it to the tracker and delete the marker; vendored/generated trees belong in tools/todo-ban-excludes with a reason;todo-ban: 1 work marker(s) — excludes tools/todo-ban-excludes" "$(lane "" todo-ban)"
+
+# --- the shared readers fail closed -----------------------------------------
+
+# gg_grep_guard, gg_read_blob and gg_blob_is_binary are the family's index
+# readers: every lane collects through them, so an incomplete scan is refused
+# HERE, once, including the call sites no default-lane run reaches.
+git_shim() { # ARG — a git that exits 128 for any call carrying ARG
+  local dir="$ROOT/git-shim-$1"
+  mkdir -p "$dir"
+  printf '#!/usr/bin/env bash\ncase " $* " in *" %s "*) echo "git %s: simulated failure" >&2; exit 128 ;; esac\nexec "%s" "$@"\n' "$1" "$1" "$REAL_GIT" >"$dir/git"
+  chmod +x "$dir/git"
+}
+git_shim grep
+git_shim cat-file
+# A wc that fails once, so the first count fails while the second succeeds;
+# a tr that fails every time, breaking only the strip inside the second count.
+mkdir -p "$ROOT/wc-shim" "$ROOT/tr-shim" "$ROOT/count-shim"
+printf '#!/usr/bin/env bash\nif [ ! -e "%s" ]; then : >"%s"; echo "wc: simulated execution failure" >&2; exit 1; fi\nexec "%s" "$@"\n' \
+  "$ROOT/wc-fired" "$ROOT/wc-fired" "$(command -v wc)" >"$ROOT/wc-shim/wc"
+printf '#!/usr/bin/env bash\necho "tr: simulated execution failure" >&2\nexit 1\n' >"$ROOT/tr-shim/tr"
+# suppression-ban's per-carrier count is its own call, made after the shared
+# listing has named the carrier; the shim errors that call alone and exits 0,
+# so the `error:` line on stderr is the only thing left that can refuse it.
+printf '#!/usr/bin/env bash\ncase " $* " in *" -acE "*) echo "error: %s: unable to read %s" >&2; exit 0 ;; esac\nexec "%s" "$@"\n' \
+  "'phantom.rs'" "0000000000000000000000000000000000000000" "$REAL_GIT" >"$ROOT/count-shim/git"
+chmod +x "$ROOT/wc-shim/wc" "$ROOT/tr-shim/tr" "$ROOT/count-shim/git"
+
+# A sed script aliasing every staged blob's sha to OID(path): a reader that
+# names the blob it could not read is read back by the path it stands for.
+oid_aliases() {
+  git -C "$R" ls-files -s | awk '{ printf "s|%s|OID(%s)|g\n", $2, $4 }' >"$ROOT/oids.sed"
+  printf '%s' "$ROOT/oids.sed"
+}
+fx_readers() { new_repo "$1"; printf '// %s: stranded work\n' "$MARKER" >"$R/a.rs"; git -C "$R" add -A; }
+fx_vanished() { # NAME [SECOND] — the staged blob's loose object removed; a readable second file when asked
+  fx_readers "$1"
+  local oid
+  oid="$(git -C "$R" rev-parse :a.rs)"
+  [ -f "$R/.git/objects/${oid:0:2}/${oid:2}" ] || echo "fixture: the staged blob is not a loose object" >&2
+  rm -f -- "$R/.git/objects/${oid:0:2}/${oid:2}"
+  [ -z "${2:-}" ] || { printf '// %s: readable\n' "$MARKER" >"$R/b.rs"; git -C "$R" add b.rs; }
+}
+fx_staged() { new_repo "$1"; printf 'fn main() {}\n' >"$R/ok.rs"; commit_all seed; printf '// %s: staged for the pre-filter to find\n' "$MARKER" >>"$R/ok.rs"; git -C "$R" add ok.rs; rm -f "$ROOT/wc-fired"; }
+fx_count() { new_repo "$1"; mkdir -p "$R/tools"; printf 'fn main() {}\n' >"$R/ok.rs"; printf '#[allow(dead_code)]\nfn b() {}\n' >"$R/bare.rs"; printf 'bare.rs\t1\n' >"$R/tools/suppression-baseline.tsv"; git -C "$R" add -A; }
+
+echo "=== the shared readers fail closed, once, for every lane that uses them ==="
+A_HIT="todo-ban FAIL work marker: a.rs:1:// $MARKER: stranded work;  remedies: do the work now, or move it to the tracker and delete the marker; vendored/generated trees belong in tools/todo-ban-excludes with a reason;todo-ban: 1 work marker(s) — excludes tools/todo-ban-excludes"
+# label | fixture | shim | lane args | expect
+rows=(
+  "control: the staged marker trips with the real git|fx_readers readers-0||todo-ban|rc=1 $A_HIT"
+  "a git grep execution failure is a collection error, never OK|fx_readers readers-1|$ROOT/git-shim-grep|todo-ban|rc=2 git grep: simulated failure;::error::todo-ban: git grep failed scanning tracked files for work marker (exit 128)"
+  "a blob read that cannot run is exit 2, never a path skipped|fx_readers readers-2|$ROOT/git-shim-cat-file|todo-ban|rc=2 git cat-file: simulated failure;::error::todo-ban: cannot read blob :0:a.rs for a.rs — refusing to skip an unread work marker"
+  "a vanished staged blob is exit 2 carrying git's own error line|fx_vanished readers-3||todo-ban|rc=2 error: 'a.rs': unable to read OID(a.rs);::error::todo-ban: git grep could not read staged content while scanning tracked files for work marker (error: 'a.rs': unable to read OID(a.rs))"
+  "a scan matching one file it read and one it could not is exit 2, never a violation|fx_vanished readers-4 second||todo-ban|rc=2 error: 'a.rs': unable to read OID(a.rs);::error::todo-ban: git grep could not read staged content while scanning tracked files for work marker (error: 'a.rs': unable to read OID(a.rs))"
+  "control: the staged marker fires with the real tools|fx_staged staged-0||todo-ban --staged|rc=1 todo-ban FAIL work marker: ok.rs:2:// $MARKER: staged for the pre-filter to find;  remedies: do the work now, or move it to the tracker and delete the marker; vendored/generated trees belong in tools/todo-ban-excludes with a reason;todo-ban: 1 work marker(s) added by the staged diff — excludes tools/todo-ban-excludes"
+  "a broken staged pre-filter is a collection error, never OK|fx_staged staged-1|$ROOT/git-shim-grep|todo-ban --staged|rc=2 git grep: simulated failure;::error::todo-ban: git grep failed listing the staged files that carry a work marker (exit 128)"
+  "a staged blob the sniff cannot read is exit 2, never a path skipped|fx_staged staged-2|$ROOT/git-shim-cat-file|todo-ban --staged|rc=2 git cat-file: simulated failure;::error::todo-ban: cannot read blob OID(ok.rs) for ok.rs — refusing to skip an unread work marker"
+  "a first block that cannot be sized is exit 2, never OK|fx_staged staged-3|$ROOT/wc-shim|todo-ban --staged|rc=2 wc: simulated execution failure;::error::todo-ban: could not sample ok.rs to classify its content"
+  "a NUL-free count that cannot run is exit 2, never OK|fx_staged staged-4|$ROOT/tr-shim|todo-ban --staged|rc=2 tr: simulated execution failure;::error::todo-ban: could not sample ok.rs to classify its content"
+  "control: the baselined bare allow passes with the real git|fx_count count-0||suppression-ban|rc=0 suppression-ban: OK — no blanket suppressions, bare allows within baseline tools/suppression-baseline.tsv"
+  "a count whose stderr carries an error line is exit 2, never a clean zero|fx_count count-1|$ROOT/count-shim|suppression-ban|rc=2 error: 'phantom.rs': unable to read 0000000000000000000000000000000000000000;::error::suppression-ban: git grep could not read staged content while counting the bare allows in 'bare.rs' (error: 'phantom.rs': unable to read 0000000000000000000000000000000000000000)"
+)
+for row in "${rows[@]}"; do
+  IFS='|' read -r label fixture shim args expect <<<"$row"
+  $fixture
+  # shellcheck disable=SC2086
+  assert_eq "$label" "$expect" "$(lane "$shim" $args | sed -f "$(oid_aliases)")"
+done
+
+printf '\n%s passed, %s failed\n' "$PASS" "$FAIL"
+[ "$FAIL" -eq 0 ]

--- a/skills/commit-guards/tests/md-format.test.sh
+++ b/skills/commit-guards/tests/md-format.test.sh
@@ -4,7 +4,7 @@
 # files the docs say, the remedy names md-reflow, and what cannot be judged
 # is named rather than passed. Every green assertion is paired with a
 # control that proves it can fail. The index readers this family shares are
-# pinned once, in index-reads.test.sh.
+# pinned once, in index-reads.test.sh and lane-readers.test.sh.
 set -euo pipefail
 
 TEST_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"

--- a/skills/commit-guards/tests/prose.test.sh
+++ b/skills/commit-guards/tests/prose.test.sh
@@ -4,7 +4,7 @@
 # replaceable and validated, and ordinary wording passes.
 # Every green assertion is paired with a control that proves it
 # can fail. The index readers this family of checks shares are pinned once,
-# in index-reads.test.sh.
+# in index-reads.test.sh and lane-readers.test.sh.
 set -euo pipefail
 
 TEST_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"

--- a/skills/commit-guards/tests/suppression-ban.test.sh
+++ b/skills/commit-guards/tests/suppression-ban.test.sh
@@ -3,7 +3,7 @@
 # per-line counterpart proven to pass, the bare-allow ratchet fails in all
 # directions (new, grow, loose, stale), --update tightens only, and baseline
 # hygiene is enforced. The index readers this family of checks shares — the
-# per-carrier count among them — are pinned once, in index-reads.test.sh,
+# per-carrier count among them — are pinned once, in lane-readers.test.sh,
 # which drives them through this check.
 #
 # Suppression pragmas appear verbatim in fixtures below: the check is

--- a/skills/commit-guards/tests/terminal-paths.test.sh
+++ b/skills/commit-guards/tests/terminal-paths.test.sh
@@ -28,7 +28,7 @@ filemode() { stat -c '%a' "$1" 2>/dev/null || stat -f '%Lp' "$1"; }
 R="$ROOT/install-file"
 mkdir -p "$R/tools"
 
-# index-reads.test.sh's `call`, with the session's fds on a pty. LIB is a
+# atomic-install.test.sh's `install_line`, with the session's fds on a pty. LIB is a
 # parameter so a mutant copy of the tree can be run through the same probe.
 #
 # SRC is a parameter for a different reason: every path this helper writes

--- a/skills/commit-guards/tests/todo-ban.test.sh
+++ b/skills/commit-guards/tests/todo-ban.test.sh
@@ -6,7 +6,7 @@
 # errors — never a pass. Every green assertion is paired with a control that
 # proves it can fail. The index readers this family of checks shares — the
 # staged lane's carriers pre-filter and content sniff among them — are
-# pinned once, in index-reads.test.sh, which drives them through this check.
+# pinned once, in lane-readers.test.sh, which drives them through this check.
 #
 # Marker words are assembled from split tokens throughout so this test
 # file never contains a marker shape itself — the kendex repo runs


### PR DESCRIPTION
Reshapes `skills/commit-guards/tests/index-reads.test.sh` to code-quality § Tests. It pinned four libs and three lane families in one 866-line linear script (62 assertions, each a status test plus a substring match over one long-lived fixture, controls folded into their neighbours). It is now three suites split at the seam between the index reads, the atomic install and the lanes end to end, 63 rows, each row its own fixture repository read back as the exit status and every line printed with the scratch roots aliased:

- `index-reads.test.sh`: the index reads themselves. `gg_policy_content` (8 rows), `gg_require_merged_index` (4 rows), the excludes read `todo-ban` makes through them under a git that fails the index probe (2 rows), the settings cache materialized by rename (2 rows).
- `atomic-install.test.sh`: `gg_install_file` as one table over the destination's shape (a mode, absent, read-only, a symlink) and each step a stub can fail (stat, chmod, mv, no scratch directory), read back with the destination's content and mode and the staging files left beside it (9 rows), plus the planted staging symlink as the one scripted control (its writer publishes a pid).
- `lane-readers.test.sh`: the lanes end to end over the shared readers: the unmerged-index refusals with their staged and resolved controls (8 rows), the attributes rows that cannot hide content from `todo-ban`, `conflict-markers` and `suppression-ban` including the ratchet and `--update` (10 rows), the NUL sniff (2 rows), and every reader git or a tool could not run, through the default lane, the `--staged` lane and the per-carrier count (12 rows).

The seven sibling suites whose headers pointed at `index-reads.test.sh` for the readers now point at the file that holds them. The tracked render under `.agents/skills/commit-guards/tests` is replayed with `patch`.

## Folded cases, with the surviving row

Every former assertion has a row; the ones that changed shape:

| Former assertion | Surviving row |
|---|---|
| the failed probe never emits the worktree copy; the refusal is not dressed as a clean verdict; no clean verdict accompanies the hidden marker (and the other absence checks) | absorbed: every row reads the whole output, so a verdict line that should be absent reddens the row it would appear in |
| the refusal names the unmerged path | `an unmerged index is a collection error naming the path and the remedy` (the path line is part of the expectation) |
| a staged-then-resolved sequence on one fixture | `control: once staged, the same markers fail as violations` and `control: a resolved, marker-free tree passes`, each on its own fixture |
| the `--update` remedy followed to its end (baseline unchanged, re-check fails) | `--update cannot be led into erasing the ratchet: the re-check still fails` plus `--update left the baseline as it was` |
| a symlink destination takes the mode of the file behind it | `a symlink destination is replaced by a file with the mode of the file behind it; the file behind it is untouched` (the target's content is read back too) |

New with no former case: `a probe that could not list the unmerged paths is a collection error, never an empty list` (the mutation batch's one survivor), `a HEAD probe that failed is a collection error, never the worktree copy` (the reviewer's), `a destination that does not exist yet lands with the staging file's owner-only mode`.

## Recorded, not fixed

- A fresh install (no destination yet) lands at mode 600, the staging file's default: the helper takes a mode only from an existing destination. Every shipped caller replaces a tracked file, so no caller reaches it.
- A symlink destination is replaced by a regular file at the link's path; the file behind the link keeps its bytes. That is rename semantics, and the row pins it.

## Mutation

32 exact-substring mutants over `common.sh`, `configured-paths.sh`, `atomic-install.sh` and `settings.sh` (the merged-index guard, the policy reader's four arms, the excludes read, the cache rename, every install step, the grep guard, the carriers listing, the blob sniff and read), 32 killed, each by a row of one of the three suites. The batch's first survivor (a failing `git ls-files --unmerged` read as no unmerged paths) is answered by a row. The reviewer's 15 mutants: 12 killed here, two killed by suppression-ban.test.sh (the skip dedupe that suite owns), one survivor (a failing ls-tree probe read as absent from HEAD) answered by the second commit; its other two survivors (a policy file literally named `0:x`; the listing and detail scans disagreeing) have no producer in the family.

## Checks

- The three suites: 17, 11 and 35 rows pass. `skills/commit-guards/tests/*.sh`: all 27 suites pass.
- `tools/guard --full`: exit 0 (on 3a0d7091d; the second commit adds one row and moves two comment lines).
- One reviewer-test round: accept, no blockers; every former assertion mapped onto a row, the absorbed absence checks confirmed strictly stronger. Its suggestions applied in the second commit: the ls-tree row, the eighth pointer (terminal-paths.test.sh), a header wrap. Not applied: pinning the pid value in the planted-symlink control, which is a fixture-liveness check, not a behaviour of the lib.

KEN-1241

https://claude.ai/code/session_01ULbexacZGFxLY8bofQfvkp
