### PR TITLE
fix(KEN-1178): a sweep opens the catalog it would delete files for

### DIFF
--- a/changelog.d/fixed/KEN-1178.md
+++ b/changelog.d/fixed/KEN-1178.md
@@ -1,0 +1,1 @@
+- `kendex apply` keeps what a catalog installed when nothing declares it now and the catalog will not read, is gone, or is off — a member also declared by name included — and names what it kept.

--- a/changelog.d/fixed/KEN-1178.md
+++ b/changelog.d/fixed/KEN-1178.md
@@ -1,1 +1,1 @@
-- `kendex apply` keeps what a catalog installed when nothing declares it now and the catalog will not read, is gone, or is off — a member also declared by name included — and names what it kept.
+- `kendex apply` keeps what a catalog installed when nothing declares it now and the catalog will not read, is gone, or is off — one declared by name included — and the plan names that catalog.

--- a/crates/core/src/engine/expansion.rs
+++ b/crates/core/src/engine/expansion.rs
@@ -318,12 +318,30 @@ impl Catalogs<'_> {
         // failed — a symlinked control file, bytes that are not text, a file
         // past the cap — answered with nothing, and dropping that error would
         // make the silence look like a catalog that offers nothing.
+        //
+        // This is the narrower of the two readings, on purpose: what a set
+        // holds is read per declaration below, which reports its own
+        // failures. `origin::origin` is the wider one, and a failure shape
+        // added here has to be added there too or a sweep keeps answering
+        // that a catalog reads.
         let leaf = crate::source::repo_leaf(&ready.provenance);
         let opened = SealedSource::open(&ready.root)
             .and_then(|sealed| Ok((source_config(&sealed, leaf)?, sealed)));
-        let Ok((config, sealed)) = opened else {
-            state.unreadable_catalogs.insert(source.to_owned());
-            return None;
+        let (config, sealed) = match opened {
+            Ok(opened) => opened,
+            // The removal pass reads the mark and stays quiet, because this
+            // is the one place holding the error: the callers below get a
+            // `None` that says only that nothing was derived, and a plan
+            // that keeps a broken catalog's files while saying nothing is
+            // the silence this whole read exists to end.
+            Err(problem) => {
+                state.unreadable_catalogs.insert(source.to_owned());
+                state.notes.push(format!(
+                    "the catalog '{source}' could not be read — {}",
+                    super::origin::said(problem)
+                ));
+                return None;
+            }
         };
         if config.hides_content() {
             state.unreadable_catalogs.insert(source.to_owned());

--- a/crates/core/src/engine/mod.rs
+++ b/crates/core/src/engine/mod.rs
@@ -44,6 +44,7 @@ mod item_source;
 mod observed;
 mod opencode;
 pub mod ops;
+mod origin;
 mod owned;
 mod plan_pass;
 mod planned;
@@ -208,6 +209,7 @@ pub fn plan_scope(
         &mut ops,
         &mut config_edits,
         &mut new_lock,
+        &mut scope_notes,
     )?;
 
     stale::stale_instruction_rows(env, scope, lock, &new_lock, &mut config_edits)?;

--- a/crates/core/src/engine/origin.rs
+++ b/crates/core/src/engine/origin.rs
@@ -1,0 +1,165 @@
+//! Whether the catalog behind an installation can be read right now.
+//!
+//! A removal that takes files nothing accounts for has to know the
+//! difference between a catalog that says nothing requires them any more
+//! and one that could not say anything at all. The expansion answers that
+//! for the catalogs a declaration reaches, and records them on the pass;
+//! this opens the rest, which is where a sweep with no declaration left
+//! would otherwise read silence as consent.
+
+use std::collections::BTreeMap;
+
+use crate::env::Env;
+use crate::manifest::Manifest;
+use crate::model::Scope;
+use crate::source::{SourceState, source_config};
+use crate::source_read::SealedSource;
+
+use super::desired::DesiredState;
+
+/// How the catalog behind an installation reads right now.
+enum Origin {
+    /// It answered with everything it offers.
+    Readable,
+    /// It did not, and the expansion is what found that: the pass records
+    /// the source and not why, so this sweep has nothing to say about it
+    /// beyond keeping what it installed. A set-only declaration whose
+    /// catalog will not open is that shape, and it is silent — no note
+    /// this branch writes and none the expansion writes either.
+    Marked,
+    /// It did not, and this is the clause that follows the catalog's name
+    /// where the sweep says what it kept.
+    Unread(String),
+}
+
+/// The catalogs one sweep asked about, and what it held on each. A source is
+/// opened once however many of its installations come up for removal, and
+/// the retention is reported once, after the pass has decided all of them:
+/// a note written mid-loop could only claim what the whole pass did, and a
+/// pass that keeps one entry can sweep the next.
+#[derive(Default)]
+pub(super) struct Origins {
+    asked: BTreeMap<String, Origin>,
+    kept: BTreeMap<String, usize>,
+}
+
+impl Origins {
+    /// Whether this source's catalog reads, counting the retention where it
+    /// does not: every caller is a removal the gate is about to hold.
+    pub(super) fn readable(
+        &mut self,
+        env: &Env,
+        scope: &Scope,
+        manifest: &Manifest,
+        state: &DesiredState,
+        source: &str,
+    ) -> bool {
+        let verdict = self
+            .asked
+            .entry(source.to_owned())
+            .or_insert_with(|| origin(env, scope, manifest, state, source));
+        if matches!(verdict, Origin::Readable) {
+            return true;
+        }
+        *self.kept.entry(source.to_owned()).or_default() += 1;
+        false
+    }
+
+    /// What this sweep held and why, one line per source it could not read
+    /// and nothing else accounts for.
+    pub(super) fn notes(&self, notes: &mut Vec<String>) {
+        for (source, verdict) in &self.asked {
+            let Origin::Unread(problem) = verdict else {
+                continue;
+            };
+            let held = match self.kept.get(source) {
+                None | Some(0) => continue,
+                Some(1) => "the installation it brought in was kept".to_owned(),
+                Some(kept) => format!("the {kept} installations it brought in were kept"),
+            };
+            notes.push(format!("the catalog '{source}' {problem}; {held}"));
+        }
+    }
+}
+
+/// A read failure as the clause following "could not be read". The sealed
+/// reader's refusal opens with those same words, and `kendex refresh` reads
+/// that phrase as one declared item failing to install — which is not what
+/// an unreadable origin is, since it is reached without a declaration.
+fn said(problem: crate::error::CoreError) -> String {
+    match problem {
+        crate::error::CoreError::SourceEscape { path, reason } => {
+            format!("{} — {reason}", path.display())
+        }
+        problem => problem.to_string(),
+    }
+}
+
+/// How the catalog behind an installation reads, decided here rather than
+/// taken from whatever some declaration left behind: a sweep with no current
+/// declaration from a catalog never opens it during expansion, and an origin
+/// nothing looked at must not read as one that answered.
+fn origin(
+    env: &Env,
+    scope: &Scope,
+    manifest: &Manifest,
+    state: &DesiredState,
+    source: &str,
+) -> Origin {
+    // A catalog that resolved and could not say what it offers is not a
+    // readable origin: what it derived this pass is short through no choice
+    // of the person's, and "nothing requires it anymore" is exactly what
+    // this pass does not know about the difference.
+    if state.unreadable_catalogs.contains(source) {
+        return Origin::Marked;
+    }
+    let resolution = match state.sources.get(source) {
+        Some(resolution) => resolution.clone(),
+        None => match crate::source::resolve(env, scope, source, manifest) {
+            Ok(resolution) => resolution,
+            // Every note about a source's state is written per declaration,
+            // and this branch is reached because no declaration names this
+            // one: unsaid here is unsaid in the whole plan.
+            Err(problem) => {
+                return Origin::Unread(format!("could not be read — {}", said(problem)));
+            }
+        },
+    };
+    let ready = match resolution {
+        SourceState::Ready(ready) => ready,
+        SourceState::Missing { path, .. } => {
+            return Origin::Unread(format!(
+                "is not on this machine ({}) — restore it, or remove what it installed by name",
+                path.display()
+            ));
+        }
+        SourceState::Pending { repo, .. } => {
+            return Origin::Unread(format!(
+                "({repo}) has no content here yet — run kendex refresh, or remove what it installed by name"
+            ));
+        }
+        SourceState::Disabled { .. } => {
+            return Origin::Unread(
+                "is switched off — switch it back on in kendex.toml, or remove what it installed by name"
+                    .to_owned(),
+            );
+        }
+    };
+    let read = SealedSource::open(&ready.root).and_then(|sealed| {
+        let config = source_config(&sealed, crate::source::repo_leaf(&ready.provenance))?;
+        // A plugin-registry catalog's sets are its plugins, and enumerating
+        // their members is the only read that can fail for one — the config
+        // below reports nothing about a plugin whose items will not list. A
+        // plain catalog's unreadable set bodies are `hidden_content`'s to
+        // report, and this call cannot fail for one.
+        crate::source::bundles::offered(&sealed, &config)?;
+        Ok(config)
+    });
+    match read {
+        Err(problem) => Origin::Unread(format!("could not be read — {}", said(problem))),
+        Ok(config) => match config.hidden_content() {
+            Some(problem) => Origin::Unread(format!("could not be read — {problem}")),
+            None => Origin::Readable,
+        },
+    }
+}

--- a/crates/core/src/engine/origin.rs
+++ b/crates/core/src/engine/origin.rs
@@ -22,10 +22,11 @@ enum Origin {
     /// It answered with everything it offers.
     Readable,
     /// It did not, and the expansion is what found that: the pass records
-    /// the source and not why, so this sweep has nothing to say about it
-    /// beyond keeping what it installed. A set-only declaration whose
-    /// catalog will not open is that shape, and it is silent — no note
-    /// this branch writes and none the expansion writes either.
+    /// the source and not why, because whichever of its two reads marked it
+    /// has already put the reason on the plan — the open that failed says
+    /// so where it holds the error, and a catalog that opened and hid
+    /// content is reported by its own findings. Saying it again here would
+    /// say it twice.
     Marked,
     /// It did not, and this is the clause that follows the catalog's name
     /// where the sweep says what it kept.
@@ -86,7 +87,7 @@ impl Origins {
 /// reader's refusal opens with those same words, and `kendex refresh` reads
 /// that phrase as one declared item failing to install — which is not what
 /// an unreadable origin is, since it is reached without a declaration.
-fn said(problem: crate::error::CoreError) -> String {
+pub(super) fn said(problem: crate::error::CoreError) -> String {
     match problem {
         crate::error::CoreError::SourceEscape { path, reason } => {
             format!("{} — {reason}", path.display())

--- a/crates/core/src/engine/removal.rs
+++ b/crates/core/src/engine/removal.rs
@@ -205,7 +205,11 @@ pub(super) fn orphans(
         // written down. With that catalog offline, "nothing requires it" is not
         // something this pass knows — so it keeps what it cannot account for.
         // Being named is not that judgement, and it still goes.
-        let unreadable_origin = derived_at_all(entry)
+        // `unreachable_source` has already decided to keep this one and is
+        // reported per declaration, so asking here would only count it into
+        // a retention it is not part of.
+        let unreadable_origin = !unreachable_source
+            && derived_at_all(entry)
             && !named
             && !origins.readable(env, scope, manifest, state, &entry.source);
         if unreachable_source || unreadable_origin {

--- a/crates/core/src/engine/removal.rs
+++ b/crates/core/src/engine/removal.rs
@@ -8,9 +8,11 @@ use super::{DriftRow, DriftState, PlanOptions};
 use crate::apply::{Description, Op, PlannedOp, Pre};
 use crate::env::Env;
 use crate::error::Result;
-use crate::lock::{Lock, LockEntry};
+use crate::lock::{Lock, LockEntry, Reason};
 use crate::manifest::Manifest;
 use crate::model::{ItemKind, Scope};
+
+use super::origin::Origins;
 
 /// Whether the user's hands are (or may be) on this installation's bytes.
 /// Automatic removals — refusals, sweeps, orphan cleanup nobody named —
@@ -180,9 +182,11 @@ pub(super) fn orphans(
     ops: &mut Vec<PlannedOp>,
     config_edits: &mut super::config_edits::ConfigEditPlan,
     new_lock: &mut Lock,
+    notes: &mut Vec<String>,
 ) -> Result<Vec<super::SetChange>> {
     let desired_keys: BTreeSet<&String> = state.items.iter().map(|d| &d.key).collect();
     let mut sweepable = Vec::new();
+    let mut origins = Origins::default();
 
     for (key, entry) in &lock.entries {
         if desired_keys.contains(key) || refused_keys.contains(key) {
@@ -196,14 +200,14 @@ pub(super) fn orphans(
         let unreachable_source = manifest.declared(entry.kind).contains_key(&entry.name)
             && !state.processed.contains(&(entry.kind, entry.name.clone()));
         let named = options.named_for_removal(entry.kind, &entry.name);
-        // An installation nobody declared was derived from one that was, and
-        // the catalog it came from is where its reason is written down. With
-        // that catalog offline, "nothing requires it anymore" is not
+        // An installation something else brought in was derived from a
+        // declaration, and the catalog it came from is where that reason is
+        // written down. With that catalog offline, "nothing requires it" is not
         // something this pass knows — so it keeps what it cannot account for.
         // Being named is not that judgement, and it still goes.
-        let unreadable_origin = derived_only(entry)
+        let unreadable_origin = derived_at_all(entry)
             && !named
-            && !origin_readable(env, scope, manifest, state, &entry.source);
+            && !origins.readable(env, scope, manifest, state, &entry.source);
         if unreachable_source || unreadable_origin {
             new_lock.entries.insert(key.clone(), entry.clone());
             continue;
@@ -265,38 +269,28 @@ pub(super) fn orphans(
         }
         guard.extend(ops, removal_ops(env, scope, entry, config_edits)?);
     }
+    origins.notes(notes);
     Ok(sweepable)
 }
 
 /// Whether this installation only ever existed for another item's sake —
 /// nobody asked for it by name, so once nothing needs it, nothing does.
-pub(super) fn derived_only(entry: &crate::lock::LockEntry) -> bool {
-    !entry.reasons.contains(&crate::lock::Reason::Requested)
+fn derived_only(entry: &LockEntry) -> bool {
+    !entry.reasons.contains(&Reason::Requested)
 }
 
-/// Whether the catalog behind an installation can be read right now. The
-/// pass has usually resolved it already; a source no declaration named this
-/// time is resolved here, because the last item that needed it going away is
-/// exactly when this question gets asked.
-pub(super) fn origin_readable(
-    env: &Env,
-    scope: &Scope,
-    manifest: &Manifest,
-    state: &desired::DesiredState,
-    source: &str,
-) -> bool {
-    // A catalog that resolved and could not say what it offers is not a
-    // readable origin: what it derived this pass is short through no choice
-    // of the person's, and "nothing requires it anymore" is exactly what
-    // this pass does not know about the difference.
-    if state.unreadable_catalogs.contains(source) {
-        return false;
-    }
-    match state.sources.get(source) {
-        Some(resolution) => matches!(resolution, crate::source::SourceState::Ready(_)),
-        None => matches!(
-            crate::source::resolve(env, scope, source, manifest),
-            Ok(crate::source::SourceState::Ready(_))
-        ),
-    }
+/// Whether anything derived this installation at all — a set carries it, or
+/// something requires it.
+///
+/// One entry can be both asked for by name and derived, and a declaration
+/// dropped while its catalog will not read leaves exactly that entry: out of
+/// desired state, with a derivation this pass cannot check. What a removal
+/// gated on an unreadable origin has to know is whether a derivation is at
+/// stake, which is not the same question as whether the person also asked
+/// for it.
+fn derived_at_all(entry: &LockEntry) -> bool {
+    entry.reasons.iter().any(|reason| match reason {
+        Reason::MemberOf { .. } | Reason::RequiredBy { .. } => true,
+        Reason::Requested => false,
+    })
 }

--- a/crates/core/src/source/config.rs
+++ b/crates/core/src/source/config.rs
@@ -74,6 +74,34 @@ impl SourceConfig {
         self.mode == CatalogMode::Unusable || !self.unreadable_bundles.is_empty()
     }
 
+    /// What [`SourceConfig::hides_content`] turned on, in the catalog's own
+    /// words, and `None` on exactly the readings where it answers no.
+    ///
+    /// A removal that keeps files says why, and it must not name a cause the
+    /// verdict did not turn on. [`SourceConfig::findings`] is not that
+    /// answer: it carries advisory findings a working catalog also has, in
+    /// the order they were read, so its head is `[marketplace]` for a
+    /// catalog whose sets are what will not read.
+    pub fn hidden_content(&self) -> Option<String> {
+        if !self.hides_content() {
+            return None;
+        }
+        // Each problem opens with the `[bundles.<name>]` it belongs to.
+        let mut hidden: Vec<String> = self.unreadable_bundles.values().cloned().collect();
+        if self.mode == CatalogMode::Unusable {
+            // `unusable` is the only place this mode is set, and it pushes
+            // the finding saying why in the same call and then returns, so
+            // nothing advisory has been read into the list yet.
+            hidden.extend(self.config_findings.iter().map(CatalogFinding::to_string));
+        }
+        // A verdict reached on something neither of those reports would
+        // leave a kept file with no account of itself.
+        if hidden.is_empty() {
+            hidden.push("it answered with less than it offers".to_owned());
+        }
+        Some(hidden.join("; "))
+    }
+
     fn unusable(&mut self, file: &'static str, problem: String, fix: &str) {
         self.config_findings
             .push(CatalogFinding::new(file, problem, fix));

--- a/crates/core/tests/install_seam/bundles.rs
+++ b/crates/core/tests/install_seam/bundles.rs
@@ -309,10 +309,27 @@ fn an_unreadable_set_keeps_its_member_and_what_that_member_requires() {
 
     fs::remove_file(catalog.join("kendex.toml")).unwrap();
     std::os::unix::fs::symlink(f.home.join("away.toml"), catalog.join("kendex.toml")).unwrap();
-    sweep(&f);
+    let report = sweep(&f);
     assert!(
         member.exists(),
         "a catalog that would not open lost its member"
+    );
+    // The open is the only thing holding this error: the set declaration
+    // reaches a catalog that gives back nothing, and every caller below sees
+    // a plan that derived nothing rather than one that could not read. A
+    // retention nothing accounts for is what the removal pass then keeps.
+    assert_eq!(
+        report
+            .notes
+            .iter()
+            .filter(
+                |note| note.starts_with("the catalog 'cat' could not be read")
+                    && note.contains("kendex.toml")
+            )
+            .count(),
+        1,
+        "a catalog that would not open kept files with nothing said: {:?}",
+        report.notes
     );
 }
 
@@ -459,20 +476,17 @@ fn a_sweep_with_no_declaration_left_reads_the_catalog_itself() {
 
 /// A catalog that cannot be resolved at all keeps what it installed, and the
 /// plan says so. Every note about a source's state is written per
-/// declaration, and both steps here have none — the subscription is gone,
-/// then the directory is — so without this the person sees `kendex apply`
-/// do nothing while a stale package sits there with no line about it.
+/// declaration, and the first step here has none — the subscription is gone
+/// — so without this the person sees `kendex apply` do nothing while a stale
+/// package sits there with no line about it. The second step is the count:
+/// one member is held by a declaration that could not be processed and is
+/// reported against that declaration, so the retention must not add it to
+/// what it says is riding on the catalog.
 #[test]
 #[allow(clippy::unwrap_used)]
 fn a_sweep_with_no_subscription_left_says_what_it_kept() {
     let f = world();
-    let catalog = f.home.join("catalog");
-    skill(&catalog, "dev");
-    write(
-        &catalog,
-        "kendex.toml",
-        "[bundles.starter]\nskills = [\"dev\"]\n",
-    );
+    let catalog = starter_catalog(&f, "catalog");
     manifest_with(
         &f,
         &[("cat", &catalog)],
@@ -480,35 +494,46 @@ fn a_sweep_with_no_subscription_left_says_what_it_kept() {
     );
     apply_now(&f);
     let member = f.project.join(".claude/skills/dev");
-    assert!(member.exists(), "the member installs first");
+    let other = f.project.join(".claude/skills/docs");
+    assert!(member.exists() && other.exists(), "both install first");
 
     manifest_with(&f, &[], "");
     let report = sweep(&f);
-    assert!(member.exists(), "an unsubscribed catalog lost its member");
+    assert!(
+        member.exists() && other.exists(),
+        "an unsubscribed catalog lost its members"
+    );
     assert_eq!(
         report
             .notes
             .iter()
             .filter(|note| note.starts_with("the catalog 'cat' ")
-                && note.ends_with("; the installation it brought in was kept"))
+                && note.ends_with("; the 2 installations it brought in were kept"))
             .count(),
         1,
-        "the plan says which catalog it kept a file for: {:?}",
+        "the plan says which catalog it kept files for, and how many: {:?}",
         report.notes
     );
 
-    manifest_with(&f, &[("cat", &catalog)], "");
+    manifest_with(&f, &[("cat", &catalog)], "[skills.dev]\nsource = \"cat\"\n");
     fs::remove_dir_all(&catalog).unwrap();
     let report = sweep(&f);
-    assert!(member.exists(), "a catalog that is gone lost its member");
+    assert!(
+        member.exists(),
+        "a catalog that is gone lost the named member"
+    );
+    assert!(other.exists(), "it lost the member only the set brought in");
     assert_eq!(
         report
             .notes
             .iter()
-            .filter(|note| note.starts_with("the catalog 'cat' is not on this machine"))
+            .filter(
+                |note| note.starts_with("the catalog 'cat' is not on this machine")
+                    && note.ends_with("; the installation it brought in was kept")
+            )
             .count(),
         1,
-        "the plan says the catalog is not here: {:?}",
+        "the plan says the catalog is gone, and counts only what it held: {:?}",
         report.notes
     );
 }

--- a/crates/core/tests/install_seam/bundles.rs
+++ b/crates/core/tests/install_seam/bundles.rs
@@ -316,6 +316,19 @@ fn an_unreadable_set_keeps_its_member_and_what_that_member_requires() {
     );
 }
 
+/// The lines saying this plan kept a catalog's installations rather than
+/// sweeping them — one per catalog it could not read.
+fn kept_notes<'a>(report: &'a kendex_core::engine::EngineReport, source: &str) -> Vec<&'a String> {
+    report
+        .notes
+        .iter()
+        .filter(|note| {
+            note.starts_with(&format!("the catalog '{source}' "))
+                && note.contains(" it brought in ")
+        })
+        .collect()
+}
+
 /// The must-fail counterpart: a catalog that reads still sweeps what its set
 /// stopped carrying, so the retention above is not "keep everything".
 #[test]
@@ -337,13 +350,290 @@ fn a_readable_catalog_sweeps_what_its_set_dropped() {
         "kendex.toml",
         "[bundles.starter]\nskills = [\"docs\"]\n",
     );
-    sweep(&f);
+    let report = sweep(&f);
     assert!(!member.exists(), "a set that reads kept what it dropped");
+    assert!(
+        !report
+            .notes
+            .iter()
+            .any(|note| note.contains("could not be read")),
+        "a catalog that reads was reported as one that would not: {:?}",
+        report.notes
+    );
+}
+
+/// A sweep that reaches no declaration from the catalog it is about to
+/// delete files for, against each shape the read can fail in: a control file
+/// that will not open, and one that parses carrying a set body that will not
+/// read. Nothing opens the catalog during expansion, so "can this origin
+/// still be read" arrives at the removal pass with nothing behind it, and a
+/// catalog nobody looked at must not answer as one that read. Two members,
+/// because the retention is reported per catalog and a one-member set cannot
+/// tell one note from one per file kept. The last step is the must-fail
+/// counterpart: the same orphans and the same absent declaration against a
+/// catalog that reads, which go.
+#[test]
+#[allow(clippy::unwrap_used)]
+fn a_sweep_with_no_declaration_left_reads_the_catalog_itself() {
+    let f = world();
+    let catalog = starter_catalog(&f, "catalog");
+    manifest_with(
+        &f,
+        &[("cat", &catalog)],
+        "[bundles.starter]\nsource = \"cat\"\n",
+    );
+    apply_now(&f);
+    let members = [
+        f.project.join(".claude/skills/dev"),
+        f.project.join(".claude/skills/docs"),
+    ];
+    assert!(members.iter().all(|path| path.exists()), "both install");
+
+    manifest_with(&f, &[("cat", &catalog)], "");
+    fs::remove_file(catalog.join("kendex.toml")).unwrap();
+    std::os::unix::fs::symlink(f.home.join("away.toml"), catalog.join("kendex.toml")).unwrap();
+    let report = sweep(&f);
+    assert!(
+        members.iter().all(|path| path.exists()),
+        "a catalog no declaration opened lost its members"
+    );
+    let kept = kept_notes(&report, "cat");
+    assert_eq!(
+        kept.len(),
+        1,
+        "one catalog it could not read is one note: {:?}",
+        report.notes
+    );
+    assert!(
+        kept[0].contains("kendex.toml") && kept[0].contains("symlink in a catalog"),
+        "the note carries the read failure: {}",
+        kept[0]
+    );
+    assert!(
+        kept[0].ends_with("; the 2 installations it brought in were kept"),
+        "the note says what it held, and how much: {}",
+        kept[0]
+    );
+
+    // A control file that parses, carrying a set body this reader will not
+    // read — and a broken `[marketplace]` ahead of it, an advisory problem a
+    // working catalog also has, so the cause has to be the one the verdict
+    // turned on rather than the first one on the display list.
+    fs::remove_file(catalog.join("kendex.toml")).unwrap();
+    write(
+        &catalog,
+        "kendex.toml",
+        "[marketplace]\ntags = \"analysis\"\n\n[bundles.starter]\nskills = [\"dev\"]\nversion = \"1.0\"\n",
+    );
+    let report = sweep(&f);
+    assert!(
+        members.iter().all(|path| path.exists()),
+        "an unreadable set body lost the members"
+    );
+    let kept = kept_notes(&report, "cat");
+    assert_eq!(
+        kept.len(),
+        1,
+        "one note for the catalog: {:?}",
+        report.notes
+    );
+    assert!(
+        kept[0].contains("[bundles.starter]")
+            && kept[0].contains("version")
+            && !kept[0].contains("[marketplace]"),
+        "the note names the set the verdict turned on: {}",
+        kept[0]
+    );
+
+    write(
+        &catalog,
+        "kendex.toml",
+        "[bundles.starter]\ndescription = \"the starter set\"\nskills = [\"dev\", \"docs\"]\n",
+    );
+    sweep(&f);
+    assert!(
+        members.iter().all(|path| !path.exists()),
+        "a catalog that reads kept orphans nothing declares"
+    );
+}
+
+/// A catalog that cannot be resolved at all keeps what it installed, and the
+/// plan says so. Every note about a source's state is written per
+/// declaration, and both steps here have none — the subscription is gone,
+/// then the directory is — so without this the person sees `kendex apply`
+/// do nothing while a stale package sits there with no line about it.
+#[test]
+#[allow(clippy::unwrap_used)]
+fn a_sweep_with_no_subscription_left_says_what_it_kept() {
+    let f = world();
+    let catalog = f.home.join("catalog");
+    skill(&catalog, "dev");
+    write(
+        &catalog,
+        "kendex.toml",
+        "[bundles.starter]\nskills = [\"dev\"]\n",
+    );
+    manifest_with(
+        &f,
+        &[("cat", &catalog)],
+        "[bundles.starter]\nsource = \"cat\"\n",
+    );
+    apply_now(&f);
+    let member = f.project.join(".claude/skills/dev");
+    assert!(member.exists(), "the member installs first");
+
+    manifest_with(&f, &[], "");
+    let report = sweep(&f);
+    assert!(member.exists(), "an unsubscribed catalog lost its member");
+    assert_eq!(
+        report
+            .notes
+            .iter()
+            .filter(|note| note.starts_with("the catalog 'cat' ")
+                && note.ends_with("; the installation it brought in was kept"))
+            .count(),
+        1,
+        "the plan says which catalog it kept a file for: {:?}",
+        report.notes
+    );
+
+    manifest_with(&f, &[("cat", &catalog)], "");
+    fs::remove_dir_all(&catalog).unwrap();
+    let report = sweep(&f);
+    assert!(member.exists(), "a catalog that is gone lost its member");
+    assert_eq!(
+        report
+            .notes
+            .iter()
+            .filter(|note| note.starts_with("the catalog 'cat' is not on this machine"))
+            .count(),
+        1,
+        "the plan says the catalog is not here: {:?}",
+        report.notes
+    );
+}
+
+/// A plugin-registry catalog's sets are its plugins, and what a plugin holds
+/// is a second read that can fail on its own — the registry and the control
+/// file both read fine and say nothing about it. The same no-declaration
+/// sweep must not take a plugin's items because the plugin would not
+/// enumerate. What keeps this from reading as "keep everything" is the
+/// readable step the two tests above end on.
+#[test]
+#[allow(clippy::unwrap_used)]
+fn a_sweep_with_no_declaration_left_reads_a_plugins_own_members() {
+    let f = world();
+    let catalog = f.home.join("market");
+    write(
+        &catalog,
+        ".claude-plugin/marketplace.json",
+        r#"{"name": "market", "owner": {"name": "someone"},
+  "plugins": [{"name": "tools", "source": "./plugins/tools"}]}"#,
+    );
+    write(
+        &catalog,
+        "plugins/tools/.claude-plugin/plugin.json",
+        r#"{"name": "tools"}"#,
+    );
+    skill(&catalog.join("plugins/tools"), "dev");
+    manifest_with(
+        &f,
+        &[("cat", &catalog)],
+        "[bundles.tools]\nsource = \"cat\"\n",
+    );
+    apply_now(&f);
+    let member = f.project.join(".claude/skills/tools__dev");
+    assert!(member.exists(), "the plugin's skill installs first");
+
+    manifest_with(&f, &[("cat", &catalog)], "");
+    let manifest = catalog.join("plugins/tools/.claude-plugin/plugin.json");
+    fs::remove_file(&manifest).unwrap();
+    std::os::unix::fs::symlink(f.home.join("away.json"), &manifest).unwrap();
+    let report = sweep(&f);
+    assert!(
+        member.exists(),
+        "a plugin that would not enumerate lost its skill"
+    );
+    assert_eq!(
+        kept_notes(&report, "cat").len(),
+        1,
+        "the plan names the catalog it kept files for: {:?}",
+        report.notes
+    );
+}
+
+/// A member the person also declared by name carries `Requested` beside the
+/// set's edge. Dropping that declaration while the set stops reading leaves
+/// exactly one entry: out of desired state, with a derivation this pass
+/// cannot check — and the set may still require it. The last step is the
+/// must-fail counterpart: a set that reads and no longer carries it goes,
+/// so the retention is not "keep everything the person once declared".
+#[test]
+#[allow(clippy::unwrap_used)]
+fn a_declared_member_keeps_its_set_edge_when_the_set_stops_reading() {
+    let f = world();
+    let catalog = f.home.join("catalog");
+    skill(&catalog, "dev");
+    skill(&catalog, "docs");
+    write(
+        &catalog,
+        "kendex.toml",
+        "[bundles.starter]\nskills = [\"dev\"]\n",
+    );
+    manifest_with(
+        &f,
+        &[("cat", &catalog)],
+        "[skills.dev]\nsource = \"cat\"\n\n[bundles.starter]\nsource = \"cat\"\n",
+    );
+    apply_now(&f);
+    let member = f.project.join(".claude/skills/dev");
+    assert!(member.exists(), "the member installs first");
+    let lock = load_lock(&lock_path(&f.env, &f.scope)).unwrap();
+    assert_eq!(
+        lock.entries["skill:dev:claude"].reasons,
+        BTreeSet::from([
+            Reason::Requested,
+            Reason::MemberOf {
+                bundle: BundleRef {
+                    source: "cat".to_owned(),
+                    name: "starter".to_owned(),
+                },
+            },
+        ]),
+        "the entry is both asked for and carried"
+    );
+
+    manifest_with(
+        &f,
+        &[("cat", &catalog)],
+        "[bundles.starter]\nsource = \"cat\"\n",
+    );
+    write(
+        &catalog,
+        "kendex.toml",
+        "[bundles.starter]\nskills = [\"dev\"]\nversion = \"1.0\"\n",
+    );
+    sweep(&f);
+    assert!(
+        member.exists(),
+        "an unreadable set trashed the member the person had also declared"
+    );
+
+    write(
+        &catalog,
+        "kendex.toml",
+        "[bundles.starter]\nskills = [\"docs\"]\n",
+    );
+    sweep(&f);
+    assert!(
+        !member.exists(),
+        "a set that reads kept a member it no longer carries"
+    );
 }
 
 /// One `kendex apply` sweep of this scope, orphans and all.
 #[allow(clippy::unwrap_used)]
-fn sweep(f: &Fixture) {
+fn sweep(f: &Fixture) -> kendex_core::engine::EngineReport {
     let report = kendex_core::engine::plan_apply(
         &f.env,
         &f.scope,
@@ -355,4 +645,5 @@ fn sweep(f: &Fixture) {
     )
     .unwrap();
     apply::execute(&f.env, &report.plan).unwrap();
+    report
 }


### PR DESCRIPTION
Closes KEN-1178.

`kendex apply` sets `remove_orphans: true`. The retention that keeps a catalog's installations when that catalog will not read was armed only on catalogs some declaration happened to open during expansion, so two sweeps reached it with nothing behind them and deleted.

**Arm A — an orphan-only sweep never opened the catalog.** No declaration from the catalog means nothing writes `unreadable_catalogs`, so the origin check saw `SourceState::Ready` and answered that a catalog nobody looked at reads. `Origins` (new `crates/core/src/engine/origin.rs`) decides for itself, opening the source, its control file and `bundles::offered` where the removal asks, memoized per source.

**Arm B — the gate read `derived_only`.** That is false for an entry the person also declared by name. Dropping the declaration while the set stops reading left exactly that entry out of desired state with a derivation the pass cannot check, and it was swept. `derived_at_all` asks whether a derivation is at stake, over an exhaustive match on `Reason`.

**Arm C is closed here rather than left standing, and needed no separate mark.** A plugin-registry catalog whose plugin will not enumerate fails `source::bundles::find` after `hides_content()` has already answered false. That failure is a strict subset of `bundles::offered` failing, which arm A's read already performs, so the removal-side determination reaches it without a second mark in `bundles.rs`. It costs no extra code.

**The plan says what it kept.** `the catalog '<source>' <problem>; the N installations it brought in were kept`, once per catalog after the pass has decided every entry. `SourceConfig::hidden_content` answers what `hides_content` turned on, so the cause named is the one the verdict turned on rather than the head of the display list. A source that will not resolve, is missing, is pending or is off gets its own clause and a way out.

**Second commit, from the local review round.** `Catalogs::read` marked a source and returned `None`, and both callers turned that into `mark_incomplete()` and nothing else, so a symlinked control file with one declaration dropped retained three installations and printed nothing at all. The note is now pushed where the error is held. Separately the kept count included entries `unreachable_source` had already held and reported elsewhere; the gate short-circuits on it first.

Four install-seam controls through the real `plan_apply(remove_orphans: true)` then `apply::execute` seam, each with its must-fail step. Seven mutations run, each red on exactly its own control.

`tools/guard --full` exit 0.

Not done here, recorded as a class comment on the issue: `Catalogs::read` and `origin::origin` are two readings of "does this catalog read" and already differ, since only the latter calls `bundles::offered`. A comment names the asymmetry; collapsing them into one reader is a restructure past this issue's scope.

Architecture-docs program: KEN-1203.

https://claude.ai/code/session_01U6QNApzCtdU99TFnoVVXZJ
