### PR TITLE
refactor(KEN-1028): one check and one refusal for the git 2.41 floor

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ curl -fsSL https://kendex.ai/install.sh | sh
 | macOS | the script above installs the CLI; `brew install vanillagreencom/kendex/kendex` installs the app |
 | Windows | the installer at [kendex.ai/download](https://kendex.ai/download), which also lists the CLI-only packages |
 
-Installing a package from a git repository needs git 2.41 or newer; kendex refuses an older one and names the version it found. A package on a local path needs no git. On Windows, `kendex guard` runs the commit guards through the `sh` that Git for Windows ships.
+A package on a local path needs no git. On Windows, `kendex guard` runs the commit guards through the `sh` that Git for Windows ships.
 
 ## Features
 

--- a/changelog.d/changed/KEN-1028.md
+++ b/changelog.d/changed/KEN-1028.md
@@ -1,0 +1,1 @@
+- A git older than 2.41 is refused with one sentence: what this host's git answered, that kendex needs git 2.41 or newer to write a checkout, and to install a newer git.

--- a/crates/core/src/remote/store/attribute_source.rs
+++ b/crates/core/src/remote/store/attribute_source.rs
@@ -3,35 +3,102 @@
 //!
 //! A checkout reads its `.gitattributes` out of a tree kendex names rather
 //! than out of the commit it is writing, so nothing a catalog committed is
-//! in force for any path. Naming that tree can fail two ways — no object
-//! format has ids of that length, or the git here cannot be told to read
-//! that tree — and both end the same: kendex refuses rather than writing a
+//! in force for any path. Naming that tree can fail two ways — the git
+//! here cannot be told to read a tree, or no object format has ids of that
+//! length — and both end the same: kendex refuses rather than writing a
 //! checkout git was free to convert.
-
-use std::sync::{Mutex, PoisonError};
 
 use crate::error::{CoreError, Result};
 use crate::process::Hardened;
+
+/// The first git that takes `--attr-source`, and so the first git kendex
+/// can write a checkout with. v2.41.0 introduced the option; v2.40 taught
+/// `git check-attr` an optional tree-ish, which is a different thing.
+///
+/// Older is refused, not worked around. The two settings that would do the
+/// same job — `attr.tree`, `GIT_ATTR_SOURCE` — are ignored without a word
+/// by a git that does not know them, and a checkout nothing told to skip
+/// attributes is one the catalog converted. Refusing is the only answer
+/// that cannot be wrong in silence.
+const GIT_FLOOR: (u32, u32) = (2, 41);
 
 /// This host's answer for this commit: the tree the write reads its
 /// attributes from, or the refusal that stops the write before a file
 /// exists.
 pub(super) fn for_commit(commit: &str) -> Result<&'static str> {
-    pinned(&git_version(), commit)
+    checked(&git_version(), commit)
 }
 
-/// Both halves of naming that tree are asked here — the id, and the git
-/// that has to take it — because both have the same answer when they
-/// cannot be met, and it is never "write it anyway".
+/// The floor is asked before anything else about the checkout, and a git
+/// below it stops the write whatever the commit is.
 ///
 /// The reading arrives as an argument so that this order can be held to
 /// from a test: no host that runs the suite has a git below the floor, so
 /// nothing else could show that the floor is asked about at all.
-fn pinned(probe: &Probe, commit: &str) -> Result<&'static str> {
-    if let Some(refusal) = below_floor(probe) {
-        return Err(refused(commit, refusal));
+fn checked(reported: &str, commit: &str) -> Result<&'static str> {
+    if !clears(reported) {
+        return Err(refused(commit, too_old(reported)));
     }
     no_attributes(commit)
+}
+
+/// What git said here when asked its version, on one line — or nothing at
+/// all, which is what a git that is not there or would not start comes
+/// back as. Every one of those is the same answer to the only question
+/// asked: this is not a git that can write a checkout.
+fn git_version() -> String {
+    answer(Hardened::git(&["--version"], None))
+}
+
+/// The call arrives built so that a test can hand over one that really
+/// fails — a git pointed at a malformed config exits non-zero and says so
+/// — rather than asserting against an answer the test made up.
+///
+/// A git that ran and refused is kept word for word rather than reduced to
+/// its empty stdout: `fatal: bad config line 1 in file ...` is the one
+/// sentence that fixes that host, and a refusal quoting nothing throws it
+/// away. Whitespace is collapsed on the way out, because what git said
+/// lands mid-sentence in a refusal a person reads and git wraps its own
+/// output.
+fn answer(call: Hardened) -> String {
+    let Ok(output) = call.run() else {
+        return String::new();
+    };
+    let said = match output.status.success() {
+        true => &output.stdout,
+        false => &output.stderr,
+    };
+    String::from_utf8_lossy(said)
+        .split_whitespace()
+        .collect::<Vec<_>>()
+        .join(" ")
+}
+
+/// The one sentence a git that cannot write a checkout earns: what this
+/// host answered, what kendex needs instead, and what to do about it.
+///
+/// The remedy is both halves of it, because one sentence answers every
+/// reading: a git below the floor is upgraded, and a git that would not
+/// answer at all is not upgraded into one — it is made to answer first.
+fn too_old(reported: &str) -> String {
+    let (major, minor) = GIT_FLOOR;
+    format!(
+        "this host's git answered \"{reported}\", and kendex needs git {major}.{minor} or newer to write a checkout: install a current git and check that git --version answers here"
+    )
+}
+
+/// Whether a version line is one a checkout can be written under.
+fn clears(reported: &str) -> bool {
+    version_of(reported).is_some_and(|found| found >= GIT_FLOOR)
+}
+
+/// `git version 2.41.0`, Apple's `git version 2.39.5 (Apple Git-154)` and
+/// the Windows build's `git version 2.47.1.windows.1` all put major and
+/// minor in the same two places, which is the whole of what the floor is
+/// compared on.
+fn version_of(reported: &str) -> Option<(u32, u32)> {
+    let mut numbers = reported.strip_prefix("git version ")?.split('.');
+    Some((numbers.next()?.parse().ok()?, numbers.next()?.parse().ok()?))
 }
 
 /// A checkout kendex would not write, said as its own failure.
@@ -45,193 +112,6 @@ fn refused(commit: &str, reason: String) -> CoreError {
         command: format!("materializing {commit}"),
         stderr: reason,
     }
-}
-
-/// The first git that takes `--attr-source`, and so the first git kendex
-/// can write a checkout with. v2.41.0 introduced the option; v2.40 taught
-/// `git check-attr` an optional tree-ish, which is a different thing.
-///
-/// Older is refused, not worked around. The two settings that would do the
-/// same job — `attr.tree`, `GIT_ATTR_SOURCE` — are ignored without a word
-/// by a git that does not know them, and a checkout nothing told to skip
-/// attributes is one the catalog converted. Refusing is the only answer
-/// that cannot be wrong in silence.
-const GIT_FLOOR: (u32, u32) = (2, 41);
-
-/// What asking this host's git for its version came back with.
-///
-/// Three answers rather than one, because they call for three different
-/// sentences and only the first is about a version. A git that runs and
-/// refuses has already written the sentence that fixes the problem — a
-/// malformed gitconfig says `fatal: bad config line 1 in file ...` — and
-/// routing that through "kendex could not run git" would throw away the
-/// one useful thing said and point the reader at a version that is not
-/// the fault.
-#[cfg_attr(test, derive(Debug))]
-enum Probe {
-    /// The version line git printed, and where that git keeps its
-    /// programs when the version is one that cannot write a checkout.
-    Answered {
-        line: String,
-        installed: Option<String>,
-    },
-    /// git ran, refused, and said why.
-    Refused(String),
-    /// Nothing came back: the spawn did not happen, or the call did not
-    /// return, or it failed without a word.
-    Silent,
-}
-
-/// Asked once and then remembered — but only a reading that clears the
-/// floor is worth remembering.
-///
-/// A host whose git can write a checkout does not stop being one mid-run,
-/// so that answer is worth a process once and never again: a long session
-/// materializes many commits and only the first of them spends a spawn.
-///
-/// Every other reading is worth nothing, and keeping one would outlive its
-/// cause. Two of them are a person following the refusal's own advice: a
-/// Mac without the command line tools has a `/usr/bin/git` shim that exits
-/// non-zero until they are installed, and a host below the floor is told
-/// to upgrade — remembered, either reading keeps refusing after they have
-/// done it. Both recover on the next checkout instead of on the next
-/// restart, and the cost is one spawn per checkout only while kendex is
-/// refusing anyway.
-///
-/// The lock is held across the asking, not merely around the remembering,
-/// so two publishes starting together spend one spawn between them rather
-/// than one each. On the paths that ask again they each spend one, which
-/// are the paths that end in a refusal either way.
-fn git_version() -> Probe {
-    static CLEARED: Mutex<Option<String>> = Mutex::new(None);
-    reading(&CLEARED, ask_git)
-}
-
-/// The asking and the remembering, given the cell to remember in, so that
-/// what it keeps and what it asks for again can be shown without a git
-/// that fails and without a git that is old.
-fn reading(cell: &Mutex<Option<String>>, ask: impl FnOnce() -> Probe) -> Probe {
-    let mut kept = cell.lock().unwrap_or_else(PoisonError::into_inner);
-    if let Some(cleared) = kept.as_deref() {
-        return Probe::Answered {
-            line: cleared.to_owned(),
-            installed: None,
-        };
-    }
-    let probe = ask();
-    if let Probe::Answered { line, .. } = &probe
-        && clears(line)
-    {
-        *kept = Some(line.clone());
-    }
-    probe
-}
-
-/// The one call, kept whole rather than reduced to its stdout: a failing
-/// git says what is wrong on stderr, and the status is what tells the two
-/// apart.
-///
-/// Whitespace in what git said is collapsed on the way in, because it
-/// lands mid-sentence in a refusal a person reads and git wraps its own
-/// output.
-fn ask_git() -> Probe {
-    probed(Hardened::git(&["--version"], None))
-}
-
-/// The call arrives built so that a test can hand over one that really
-/// fails — a git pointed at a malformed config exits non-zero and says so
-/// — rather than asserting against a `Probe` the test made up.
-fn probed(call: Hardened) -> Probe {
-    let Ok(output) = call.run() else {
-        return Probe::Silent;
-    };
-    if !output.status.success() {
-        let said = collapsed(&output.stderr);
-        return match said.is_empty() {
-            true => Probe::Silent,
-            false => Probe::Refused(said),
-        };
-    }
-    let line = collapsed(&output.stdout);
-    // Only a reading that cannot write a checkout has to say where it came
-    // from, and only that reading pays the second spawn for it.
-    let installed = (!clears(&line)).then(exec_path).flatten();
-    Probe::Answered { line, installed }
-}
-
-/// Where the git that just answered keeps its programs, asked of git
-/// rather than worked out here: kendex searches no directories of its own
-/// and reads no `PATH`, it runs `git --exec-path` and repeats the answer.
-/// A second spawn, resolved the way the first one was.
-///
-/// Worth saying at all because a person who installed a newer git
-/// elsewhere can see from it that this is not the one kendex reached.
-fn exec_path() -> Option<String> {
-    let output = Hardened::git(&["--exec-path"], None).run().ok()?;
-    let path = collapsed(&output.stdout);
-    output
-        .status
-        .success()
-        .then_some(path)
-        .filter(|at| !at.is_empty())
-}
-
-fn collapsed(bytes: &[u8]) -> String {
-    String::from_utf8_lossy(bytes)
-        .split_whitespace()
-        .collect::<Vec<_>>()
-        .join(" ")
-}
-
-/// Whether a version line is one a checkout can be written under.
-fn clears(line: &str) -> bool {
-    version_of(line).is_some_and(|found| found >= GIT_FLOOR)
-}
-
-/// What a reading earns, or `None` when it clears the floor. Kept apart
-/// from the taking of it so every sentence can be held to on hosts that
-/// have none of these gits.
-fn below_floor(probe: &Probe) -> Option<String> {
-    let (want_major, want_minor) = GIT_FLOOR;
-    let needed = format!(
-        "kendex needs git {want_major}.{want_minor} or newer to write a checkout: it is the first git that can be told to read no attributes, and one that cannot be told converts the files in silence"
-    );
-    match probe {
-        // `clears` and nothing beside it, so the memo and the refusal
-        // cannot come to differ: a line one keeps and the other rejects
-        // would be remembered and then refused at every later checkout.
-        Probe::Answered { line, .. } if clears(line) => None,
-        Probe::Answered { line, installed } => match version_of(line) {
-            // Which git it was, when git said: a Mac that has a newer one
-            // in another directory is otherwise told to install what it
-            // already has.
-            Some((major, minor)) => Some(format!(
-                "this host runs git {major}.{minor}{}, and {needed}",
-                installed
-                    .as_deref()
-                    .map_or(String::new(), |at| format!(", whose programs live at {at}"))
-            )),
-            None => Some(format!(
-                "this host's git did not say which version it is, answering \"{line}\", and {needed}"
-            )),
-        },
-        // git's own sentence, which is the one that fixes the problem.
-        Probe::Refused(said) => Some(format!(
-            "git here answered \"{said}\" instead of a version, and {needed}"
-        )),
-        Probe::Silent => Some(format!(
-            "kendex could not run git --version here, and {needed}"
-        )),
-    }
-}
-
-/// `git version 2.41.0`, Apple's `git version 2.39.5 (Apple Git-154)` and
-/// the Windows build's `git version 2.47.1.windows.1` all put major and
-/// minor in the same two places, which is the whole of what the floor is
-/// compared on.
-fn version_of(reported: &str) -> Option<(u32, u32)> {
-    let mut numbers = reported.strip_prefix("git version ")?.split('.');
-    Some((numbers.next()?.parse().ok()?, numbers.next()?.parse().ok()?))
 }
 
 /// The empty tree, which is the tree with no `.gitattributes` in it, in

--- a/crates/core/src/remote/store/attribute_source/tests.rs
+++ b/crates/core/src/remote/store/attribute_source/tests.rs
@@ -1,245 +1,126 @@
 use super::*;
 
-fn answered(line: &str) -> Probe {
-    Probe::Answered {
-        line: line.to_owned(),
-        installed: None,
-    }
-}
-
-/// The number, written out rather than read back off the constant. The
-/// floor is a promise the README and a **Breaking:** changelog line
-/// both make in words, so a test that formats its expectation from
-/// `GIT_FLOOR` checks the sentence against its own echo and holds
-/// nothing. Both neighbours are named, because 2.40 is the value most
-/// likely to be reached for by mistake: it is the release that taught
-/// `git check-attr` a tree-ish, one short of the release that taught
-/// git itself the option.
+/// The floor, held to in both directions on the sentence a person reads:
+/// a git below it stops the write and says which git it found, what
+/// kendex needs, and what to do; one at or above it names the tree with
+/// no `.gitattributes` in it.
 ///
-/// The lines are the shapes real hosts print: Apple's command line
-/// tools carry a build suffix, the Windows build carries a fourth
-/// number. A git below the floor cannot be installed on the machine
-/// running this, so the sentence is held to here instead.
-#[test]
-fn a_git_below_the_floor_is_refused_by_both_versions() {
-    const NEEDED: &str = "git 2.41 or newer";
-
-    assert_eq!(below_floor(&answered("git version 2.41.0")), None);
-    assert_eq!(below_floor(&answered("git version 2.55.0")), None);
-    assert_eq!(below_floor(&answered("git version 3.0.0")), None);
-
-    for (line, found) in [
-        ("git version 2.40.1", "git 2.40"),
-        ("git version 2.39.5 (Apple Git-154)", "git 2.39"),
-        ("git version 2.34.1", "git 2.34"),
-        ("git version 1.9.1", "git 1.9"),
-    ] {
-        let refusal = below_floor(&answered(line)).expect("a git below the floor was accepted");
-        assert!(refusal.contains(found), "{line}: {refusal}");
-        assert!(refusal.contains(NEEDED), "{line}: {refusal}");
-    }
-
-    // An answer nothing could read is quoted back, the empty one
-    // included — `contains(sample)` would be true of every refusal for
-    // that one and so would hold nothing.
-    for unreadable in ["", "git version", "hg 5.9"] {
-        let refusal =
-            below_floor(&answered(unreadable)).expect("an unreadable answer was accepted");
-        assert!(
-            refusal.contains(&format!("answering \"{unreadable}\"")),
-            "{unreadable:?}: {refusal}"
-        );
-        assert!(refusal.contains(NEEDED), "{unreadable:?}: {refusal}");
-    }
-
-    // Three ways of not having a version, and they are three sentences:
-    // only the first is about the version, only the second has git's
-    // own words to pass on, and only the third is kendex's own failure.
-    let refused_by_git = below_floor(&Probe::Refused(
-        "fatal: bad config line 1 in file /home/x/.gitconfig".to_owned(),
-    ))
-    .expect("a git that refused to answer was accepted");
-    assert!(
-        refused_by_git.contains("bad config line 1 in file /home/x/.gitconfig"),
-        "git said what was wrong and kendex dropped it: {refused_by_git}"
-    );
-    assert!(refused_by_git.contains(NEEDED), "{refused_by_git}");
-
-    let silent = below_floor(&Probe::Silent).expect("a silent probe was accepted");
-    assert!(silent.contains("could not run git --version"), "{silent}");
-    assert!(silent.contains(NEEDED), "{silent}");
-}
-
-/// The three readings, taken off a real git rather than made up: this
-/// host's own answers a version, and the same git pointed at a
-/// malformed config exits non-zero with the one sentence that fixes
-/// the problem. That sentence is what a probe reduced to its stdout
-/// throws away.
-#[test]
-fn a_git_that_refuses_to_answer_is_kept_word_for_word() {
-    let answered = probed(Hardened::git(&["--version"], None));
-    let Probe::Answered { line, .. } = &answered else {
-        panic!("this host's git did not answer its version: {answered:?}");
-    };
-    assert!(line.starts_with("git version"), "{line}");
-
-    let tmp = tempfile::tempdir().unwrap();
-    let malformed = tmp.path().join("gitconfig");
-    std::fs::write(&malformed, "this is not a config\n").unwrap();
-    let refused = probed(
-        Hardened::git(&["--version"], None).env("GIT_CONFIG_GLOBAL", malformed.to_str().unwrap()),
-    );
-    let Probe::Refused(said) = &refused else {
-        panic!("a git that refused to answer was not kept: {refused:?}");
-    };
-    assert!(
-        said.contains("bad config line 1"),
-        "git said what was wrong and the probe dropped it: {said}"
-    );
-
-    // What a below-floor reading would be asked to say about itself.
-    // Only the asking can be shown here — this host's git clears the
-    // floor, so nothing on it takes the branch that spends this call.
-    let at = exec_path().expect("git did not say where it keeps its programs");
-    assert!(at.contains("git"), "{at}");
-}
-
-/// Where the git it found keeps its programs, said alongside the version
-/// it reported. On a Mac a newer git can sit in another directory while
-/// the one kendex reaches is Xcode's, and a refusal naming only the
-/// version tells that person to install what they already have.
-#[test]
-fn a_refusal_names_where_the_git_it_found_keeps_its_programs() {
-    let xcode = "/Library/Developer/CommandLineTools/usr/libexec/git-core";
-    let refusal = below_floor(&Probe::Answered {
-        line: "git version 2.39.5 (Apple Git-154)".to_owned(),
-        installed: Some(xcode.to_owned()),
-    })
-    .expect("a git below the floor was accepted");
-
-    assert!(refusal.contains("git 2.39"), "{refusal}");
-    assert!(refusal.contains(xcode), "{refusal}");
-}
-
-/// Only a reading that clears the floor is kept, and every other one
-/// is asked for again on the next checkout.
+/// The numbers are written out rather than formatted from `GIT_FLOOR`: a
+/// test that builds its expectation from the constant checks the sentence
+/// against its own echo and holds nothing. Both neighbours are named,
+/// because 2.40 is the value most likely to be reached for by mistake —
+/// it is the release that taught `git check-attr` a tree-ish, one short
+/// of the release that taught git itself the option.
 ///
-/// Every other one is a person doing what the refusal told them to. A
-/// Mac whose `/usr/bin/git` shim exits non-zero until the command line
-/// tools arrive would be told to install them and then refused all the
-/// same; a host on 2.34 would be told to upgrade and then refused
-/// after upgrading. Remembering either makes the app's own advice take
-/// a restart to work.
-///
-/// The keeping is what bounds the asking, so the count is asserted
-/// with it: one spawn for a host that clears the floor, however many
-/// checkouts follow.
+/// The lines are the shapes real hosts print: Apple's command line tools
+/// carry a build suffix, the Windows build a fourth number. A git below
+/// the floor cannot be installed on the machine running this, so the
+/// refusal is held to here instead.
 #[test]
-fn only_a_reading_that_clears_the_floor_is_remembered() {
-    let cell = Mutex::new(None);
-    let probes = std::cell::Cell::new(0);
-    let line = |probe: &Probe| match probe {
-        Probe::Answered { line, .. } => Some(line.clone()),
-        _ => None,
-    };
-    let ask = |probe: Probe| {
-        let mut once = Some(probe);
-        line(&reading(&cell, || {
-            probes.set(probes.get() + 1);
-            once.take().expect("asked twice for one reading")
-        }))
-    };
-
-    assert_eq!(ask(Probe::Silent), None);
-    assert_eq!(ask(Probe::Refused("fatal: nope".to_owned())), None);
-    assert_eq!(
-        probes.get(),
-        2,
-        "a failure was remembered instead of asked again"
-    );
-
-    let old = "git version 2.34.1";
-    assert_eq!(ask(answered(old)).as_deref(), Some(old));
-    assert_eq!(ask(answered(old)).as_deref(), Some(old));
-    assert_eq!(
-        probes.get(),
-        4,
-        "a git below the floor was remembered, so upgrading it would take a restart"
-    );
-
-    let current = "git version 2.55.0";
-    assert_eq!(ask(answered(current)).as_deref(), Some(current));
-    for _ in 0..29 {
-        assert_eq!(
-            ask(Probe::Silent).as_deref(),
-            Some(current),
-            "the reading was not kept, so every checkout would ask again"
-        );
-    }
-    assert_eq!(
-        probes.get(),
-        5,
-        "the reading cost one asking and the 29 checkouts after it cost none"
-    );
-}
-
-/// The floor is asked before anything else about a checkout, and a git
-/// below it stops the write whatever the commit is. Only reachable from
-/// here: every host that runs this suite carries a git above the floor,
-/// so no end-to-end test can put one below it.
-#[test]
-fn a_checkout_is_refused_on_an_old_git_whatever_the_commit_is() {
+fn a_git_below_the_floor_is_refused_and_a_newer_one_writes_the_checkout() {
     let commit = "a".repeat(40);
-    let (_, sha1_empty_tree) = NO_ATTRIBUTES[0];
+    let (_, empty_tree) = NO_ATTRIBUTES[0];
 
-    assert_eq!(
-        pinned(&answered("git version 2.41.0"), &commit).unwrap(),
-        sha1_empty_tree
-    );
-    let refusal = pinned(&answered("git version 2.34.1"), &commit)
-        .expect_err("an old git was allowed to write a checkout")
-        .to_string();
-    assert!(refusal.contains("git 2.34"), "{refusal}");
-}
+    for cleared in [
+        "git version 2.41.0",
+        "git version 2.47.1.windows.1",
+        "git version 2.55.0",
+        "git version 3.0.0",
+    ] {
+        assert_eq!(checked(cleared, &commit).unwrap(), empty_tree, "{cleared}");
+    }
 
-/// Every refusal this file writes is a sentence a person reads, and it is
-/// written where nothing reflows it: rustfmt leaves string contents alone,
-/// so a line continuation that keeps the source narrow can leave a run of
-/// indentation in the message. The refusals name the operation kendex
-/// declined rather than a git call, because none was made.
-#[test]
-fn a_refusal_reads_as_one_sentence_about_what_kendex_declined() {
-    let commit = "abc1234";
-    // Every refusal the module can write, not a sample of them: the
-    // one branch left out is the one a space run lands in next. What
-    // git said arrives wrapped, so the branch carrying it is given a
-    // wrapped sentence here too.
-    let said = |probe| refused(commit, below_floor(&probe).unwrap()).to_string();
-    let refusals = [
-        no_attributes(commit).unwrap_err().to_string(),
-        said(answered("git version 2.34.1")),
-        said(Probe::Answered {
-            line: "git version 2.34.1".to_owned(),
-            installed: Some("/usr/lib/git-core".to_owned()),
-        }),
-        said(answered("hg 5.9")),
-        said(Probe::Refused(collapsed(
-            b"fatal: bad config line 1\n  in file /home/x/.gitconfig",
-        ))),
-        said(Probe::Silent),
-    ];
-    for refusal in refusals {
+    // Every answer that is not a git at the floor or above it, including
+    // the ones no version can be read out of at all: the last row is what
+    // a git that would not run, would not answer, or is not there leaves.
+    for old in [
+        "git version 2.40.1",
+        "git version 2.39.5 (Apple Git-154)",
+        "git version 2.34.1",
+        "git version 1.9.1",
+        "git version",
+        "hg 5.9",
+        "",
+    ] {
+        let refusal = checked(old, &commit)
+            .expect_err("a git that cannot write a checkout was accepted")
+            .to_string();
         assert!(
-            !refusal.contains("  "),
-            "a run of spaces reached the reader: {refusal}"
+            refusal.contains(&format!("answered \"{old}\"")),
+            "the refusal does not say which git it found: {refusal}"
         );
+        assert!(
+            refusal.contains("kendex needs git 2.41 or newer to write a checkout"),
+            "the refusal does not say what kendex needs: {refusal}"
+        );
+        assert!(
+            refusal.contains("install a current git and check that git --version answers here"),
+            "the refusal does not say what to do about it: {refusal}"
+        );
+        // The refusal names the operation kendex declined, because no git
+        // call was made: a reader sent looking for one in a log would find
+        // no counterpart for it.
         assert!(
             refusal.starts_with(&format!("materializing {commit} failed:")),
             "the refusal names something other than what kendex declined: {refusal}"
         );
-        assert!(
-            !refusal.contains("git checkout-index"),
-            "the refusal names a git call that was never made: {refusal}"
-        );
     }
+}
+
+/// The reading the floor is compared against comes off a real git, not a
+/// string a test made up, and it arrives as the one line a refusal can
+/// quote mid-sentence — git ends its own with a newline.
+///
+/// Both readings a real git gives are taken here, because they are the two
+/// this host can produce: its own answer, which clears the floor, and the
+/// same git pointed at a malformed config, which exits non-zero and says
+/// what is wrong. That sentence is what a reading reduced to stdout throws
+/// away, leaving the refusal quoting nothing.
+#[test]
+fn a_real_git_is_read_as_one_line_whether_it_answers_or_refuses() {
+    let reported = git_version();
+
+    assert!(reported.starts_with("git version "), "{reported}");
+    assert!(!reported.contains('\n'), "{reported:?}");
+    assert!(clears(&reported), "{reported}");
+
+    let tmp = tempfile::tempdir().unwrap();
+    let malformed = tmp.path().join("gitconfig");
+    std::fs::write(&malformed, "this is not a config\n").unwrap();
+    let refused = answer(
+        Hardened::git(&["--version"], None).env("GIT_CONFIG_GLOBAL", malformed.to_str().unwrap()),
+    );
+
+    assert!(
+        refused.contains("bad config line 1"),
+        "git said what was wrong and the reading dropped it: {refused:?}"
+    );
+    assert!(!clears(&refused), "{refused}");
+}
+
+/// A commit id no object format has is refused rather than written under
+/// no attribute source at all, which is the one answer that converts in
+/// silence. Both formats git has are named, so neither loses its tree to
+/// a typo.
+#[test]
+fn a_commit_id_no_object_format_has_is_refused() {
+    let current = "git version 2.41.0";
+
+    for (length, tree) in NO_ATTRIBUTES {
+        assert_eq!(checked(current, &"a".repeat(length)).unwrap(), tree);
+    }
+
+    let refusal = checked(current, "abc1234")
+        .expect_err("an id no object format has was accepted")
+        .to_string();
+    // Asserted through the join, not up to it: this sentence is the
+    // module's one line continuation, and dropping that backslash would
+    // ship a run of source indentation to the reader.
+    assert!(
+        refusal.contains(
+            "no object format has ids of 7 characters, so the attribute source this checkout \
+             must be written under cannot be named"
+        ),
+        "{refusal}"
+    );
 }

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -4,7 +4,7 @@ For people and agents working on kendex itself. Installing and using it starts a
 
 ## Build
 
-Rust at the version in `rust-toolchain.toml`, Node at the version in `.nvmrc`, and git 2.41 or newer, the first git that takes `--attr-source`, which is how kendex materializes a catalog checkout.
+Rust at the version in `rust-toolchain.toml`, Node at the version in `.nvmrc`, and git 2.41 or newer.
 
 ```sh
 cargo build --release -p kendex-cli                     # the kendex command


### PR DESCRIPTION
The owner ruled on KEN-1028: keep the git 2.41 floor, and collapse the probe behind it to one check with one refusal that names the version found, the version needed and the remedy. No README call-out and no special mention elsewhere.

## What changed

`crates/core/src/remote/store/attribute_source.rs` now answers the only question asked: read `git --version`, compare to `(2, 41)`, refuse with one sentence. Deleted: the three-arm `Probe` enum, the `Mutex` memo that remembered a passing reading, the second `git --exec-path` spawn, and three of the four refusal sentences. The empty-tree selection (`no_attributes`) and `for_commit`'s signature are untouched, so `store.rs`'s `check_out` is unchanged.

A git that ran and refused is still kept word for word. `git --version` parses the host's gitconfig, so a malformed one exits non-zero with `fatal: bad config line 1 in file ...` — the sentence that fixes that host. The single refusal quotes whatever git said, and its remedy covers both readings: install a current git, and check that `git --version` answers here.

The README's git-2.41 call-out is deleted. `docs/DEVELOPMENT.md` keeps the bare prerequisite beside Rust and Node, without the `--attr-source` explanation.

## Tests

`crates/core/src/remote/store/attribute_source/tests.rs` keeps one control per direction: a table of below-floor and unreadable answers, each refused with the one sentence, against a table of clearing answers that name the empty tree; a real-git reading taken both ways (this host's answer, and the same git pointed at a malformed config); and the commit-id length refusal, asserted through its line continuation.

Four must-fail controls ran red before their green counted: the floor not enforced (`if false`), the remedy clause dropped, `stderr` discarded on a refusing git, and the line continuation removed from the id-length sentence.

## For the overseer

`changelog.d/changed/KEN-850.md` was left in place. It is the unreleased **Breaking:** entry for the floor itself (installing from a git repository now needs 2.41; Ubuntu 22.04, Debian 12 and Xcode 16's command line tools ship older). Deleting it would drop the only release notice of a breaking change that has never shipped, which reads as a different decision from "no README call-out". Say the word and it goes in one line.

Architecture-docs program: KEN-1203. Fixes KEN-1028.

https://claude.ai/code/session_01GG3mKKNo5tavNNMr3hihgN
