### PR TITLE
fix(KEN-1257): mktemp-trap reads the whole file before answering

### DIFF
--- a/.agents/skills/preflight/scripts/preflight
+++ b/.agents/skills/preflight/scripts/preflight
@@ -524,12 +524,19 @@ run_shellcheck() { # CONTENT-PATH — gcc-format output on stdout
   fi
 }
 
+# Both readers below take the whole diagnostic before answering, for the
+# reason has_exit_trap does: an awk that exits at the first hit closes the
+# pipe under it, printf takes SIGPIPE, and under pipefail the substitution
+# answers 141. On first_line that status lands on a plain assignment in the
+# caller and errexit ends the run; line_hint's own assignment sits inside a
+# command substitution, where bash inherits no errexit, so the shape there
+# is inert until a caller reads its status.
 line_hint() { # TEXT -> the line number a tool mentions, else 0
   local n
-  n="$(printf '%s' "$1" | awk 'match($0, /line [0-9]+/) { print substr($0, RSTART + 5, RLENGTH - 5); exit }')"
+  n="$(printf '%s' "$1" | awk '!seen && match($0, /line [0-9]+/) { n = substr($0, RSTART + 5, RLENGTH - 5); seen = 1 } END { print n }')"
   case "$n" in "" | *[!0-9]*) printf '0' ;; *) printf '%s' "$n" ;; esac
 }
-first_line() { printf '%s' "$1" | awk 'NF { print; exit }'; }
+first_line() { printf '%s' "$1" | awk 'NF && !seen { s = $0; seen = 1 } END { print s }'; }
 
 JSONC_GLOBS="${PREFLIGHT_JSONC_GLOBS-**/tsconfig*.json **/jsconfig*.json **/.vscode/*.json **/.devcontainer/*.json **/*-color-theme.json}"
 
@@ -575,7 +582,12 @@ MKTEMP_CALL_RE='(^[[:space:]]*|[;(`{&|][[:space:]]*)mktemp([^A-Za-z0-9_.-]|$)'
 # arms nothing.
 TRAP_EXIT_RE='(^[[:space:]]*|[;(`{&|][[:space:]]*)trap[[:space:]].*[[:space:]](EXIT|0)([[:space:]]|;|$)'
 has_exit_trap() { # FILE
-  grep -Ev -- '^[[:space:]]*#' "$1" 2>/dev/null | grep -Eq -- "$TRAP_EXIT_RE"
+  # The match reads its producer to EOF. `grep -q` exits at its first hit,
+  # the upstream grep takes SIGPIPE on its next write, and under pipefail
+  # the pipeline answers 141 — read here as "no trap" — for any file with
+  # more than a pipe buffer left below the trap line. `grep -c` reads to the
+  # end and still exits 1 when nothing matched.
+  grep -Ev -- '^[[:space:]]*#' "$1" 2>/dev/null | grep -Ec -- "$TRAP_EXIT_RE" >/dev/null
 }
 # A directory-CREATING call taking a literal absolute temp path (/tmp,
 # /var/tmp) as (part of) its first argument: mkdtemp/mkdir and their Sync

--- a/.agents/skills/preflight/tests/precision.test.sh
+++ b/.agents/skills/preflight/tests/precision.test.sh
@@ -475,6 +475,26 @@ run_pf
 fires "the same fixture staged reads the same way (trap)" "scripts/inerttrap.sh:5: [mktemp-trap]"
 case "$OUT" in *"tests/fresh.test.sh"*) bad "the staged workflow wires the staged suite" "$OUT" ;; *) ok "the staged workflow wires the staged suite" ;; esac
 
+echo "=== a trap on an early line of a large file is still read ==="
+seed bigtrap
+# The trap sits four lines in and the file runs past a pipe buffer below it,
+# so a predicate whose match stops at the first hit leaves its producer
+# writing into a closed pipe: under pipefail that reads as "no trap" and the
+# lane reports a file that cleans up after itself, differently from run to
+# run. 200 KB is the size the report reproduced at.
+{
+  printf '#!/usr/bin/env bash\nset -euo pipefail\nD="$(mktemp -d)"\ntrap %s EXIT\n' "'rm -rf \"\$D\"'"
+  awk 'BEGIN { for (i = 0; i < 4200; i++) print "echo padding line " i " keeps this file past a pipe buffer" }'
+} >"$R/scripts/big.sh"
+run_pf
+clean "a 200 KB new script whose trap is on line 4 is not reported as untrapped"
+
+echo "=== control: the same large file without the trap still fires ==="
+grep -v '^trap ' -- "$R/scripts/big.sh" >"$R/scripts/big.new"
+mv "$R/scripts/big.new" "$R/scripts/big.sh"
+run_pf
+fires "deleting the trap line from the same large file restores the finding" "scripts/big.sh:3: [mktemp-trap] mktemp without an EXIT trap"
+
 echo "=== a temp-path literal is a finding only in a creation call's hands ==="
 seed tmppath
 mkdir -p "$R/src"

--- a/changelog.d/fixed/2257.md
+++ b/changelog.d/fixed/2257.md
@@ -1,0 +1,1 @@
+- Preflight's `mktemp-trap` lane finds an `EXIT` trap in a shell file of any size, so a large new script is no longer reported as untrapped at random.

--- a/skills/preflight/scripts/preflight
+++ b/skills/preflight/scripts/preflight
@@ -524,12 +524,19 @@ run_shellcheck() { # CONTENT-PATH — gcc-format output on stdout
   fi
 }
 
+# Both readers below take the whole diagnostic before answering, for the
+# reason has_exit_trap does: an awk that exits at the first hit closes the
+# pipe under it, printf takes SIGPIPE, and under pipefail the substitution
+# answers 141. On first_line that status lands on a plain assignment in the
+# caller and errexit ends the run; line_hint's own assignment sits inside a
+# command substitution, where bash inherits no errexit, so the shape there
+# is inert until a caller reads its status.
 line_hint() { # TEXT -> the line number a tool mentions, else 0
   local n
-  n="$(printf '%s' "$1" | awk 'match($0, /line [0-9]+/) { print substr($0, RSTART + 5, RLENGTH - 5); exit }')"
+  n="$(printf '%s' "$1" | awk '!seen && match($0, /line [0-9]+/) { n = substr($0, RSTART + 5, RLENGTH - 5); seen = 1 } END { print n }')"
   case "$n" in "" | *[!0-9]*) printf '0' ;; *) printf '%s' "$n" ;; esac
 }
-first_line() { printf '%s' "$1" | awk 'NF { print; exit }'; }
+first_line() { printf '%s' "$1" | awk 'NF && !seen { s = $0; seen = 1 } END { print s }'; }
 
 JSONC_GLOBS="${PREFLIGHT_JSONC_GLOBS-**/tsconfig*.json **/jsconfig*.json **/.vscode/*.json **/.devcontainer/*.json **/*-color-theme.json}"
 
@@ -575,7 +582,12 @@ MKTEMP_CALL_RE='(^[[:space:]]*|[;(`{&|][[:space:]]*)mktemp([^A-Za-z0-9_.-]|$)'
 # arms nothing.
 TRAP_EXIT_RE='(^[[:space:]]*|[;(`{&|][[:space:]]*)trap[[:space:]].*[[:space:]](EXIT|0)([[:space:]]|;|$)'
 has_exit_trap() { # FILE
-  grep -Ev -- '^[[:space:]]*#' "$1" 2>/dev/null | grep -Eq -- "$TRAP_EXIT_RE"
+  # The match reads its producer to EOF. `grep -q` exits at its first hit,
+  # the upstream grep takes SIGPIPE on its next write, and under pipefail
+  # the pipeline answers 141 — read here as "no trap" — for any file with
+  # more than a pipe buffer left below the trap line. `grep -c` reads to the
+  # end and still exits 1 when nothing matched.
+  grep -Ev -- '^[[:space:]]*#' "$1" 2>/dev/null | grep -Ec -- "$TRAP_EXIT_RE" >/dev/null
 }
 # A directory-CREATING call taking a literal absolute temp path (/tmp,
 # /var/tmp) as (part of) its first argument: mkdtemp/mkdir and their Sync

--- a/skills/preflight/tests/precision.test.sh
+++ b/skills/preflight/tests/precision.test.sh
@@ -475,6 +475,26 @@ run_pf
 fires "the same fixture staged reads the same way (trap)" "scripts/inerttrap.sh:5: [mktemp-trap]"
 case "$OUT" in *"tests/fresh.test.sh"*) bad "the staged workflow wires the staged suite" "$OUT" ;; *) ok "the staged workflow wires the staged suite" ;; esac
 
+echo "=== a trap on an early line of a large file is still read ==="
+seed bigtrap
+# The trap sits four lines in and the file runs past a pipe buffer below it,
+# so a predicate whose match stops at the first hit leaves its producer
+# writing into a closed pipe: under pipefail that reads as "no trap" and the
+# lane reports a file that cleans up after itself, differently from run to
+# run. 200 KB is the size the report reproduced at.
+{
+  printf '#!/usr/bin/env bash\nset -euo pipefail\nD="$(mktemp -d)"\ntrap %s EXIT\n' "'rm -rf \"\$D\"'"
+  awk 'BEGIN { for (i = 0; i < 4200; i++) print "echo padding line " i " keeps this file past a pipe buffer" }'
+} >"$R/scripts/big.sh"
+run_pf
+clean "a 200 KB new script whose trap is on line 4 is not reported as untrapped"
+
+echo "=== control: the same large file without the trap still fires ==="
+grep -v '^trap ' -- "$R/scripts/big.sh" >"$R/scripts/big.new"
+mv "$R/scripts/big.new" "$R/scripts/big.sh"
+run_pf
+fires "deleting the trap line from the same large file restores the finding" "scripts/big.sh:3: [mktemp-trap] mktemp without an EXIT trap"
+
 echo "=== a temp-path literal is a finding only in a creation call's hands ==="
 seed tmppath
 mkdir -p "$R/src"


### PR DESCRIPTION
## What

`preflight`'s `mktemp-trap` lane reported a large new shell file as untrapped even when it carries a `trap … EXIT` line, differently from run to run.

`has_exit_trap` piped a producer into `grep -Eq`. The downstream grep exits at its first hit, the upstream grep takes SIGPIPE on its next write, and under the script's `set -euo pipefail` the pipeline answers 141 — which the caller at `has_exit_trap "$cpath" && has_trap=1` reads as "no trap". Any file with more than a pipe buffer below its trap line was exposed. The lane is fail-closed, so this refused the commit outright through the pre-commit chain; hyprtrade PR 12 reproduced it 20/20 on a 198 KB suite.

The match is now `grep -Ec … >/dev/null`, which reads to EOF and still exits 1 when nothing matched.

## Sweep

Every other `producer | grep -q` site in the script was checked. `has_shebang`, the shebang-interpreter match, the three `printf '%s' "$content" | grep -Eq` lane matches and `swallowed_cmd` all feed a single line into their consumer, which cannot decide before consuming all of it — probed at 500 KB, 10/10 status 0. None hold the shape.

`first_line` and `line_hint` do hold it, with an awk that exits at its first hit: on a parser diagnostic past a pipe buffer they answer 141. On `first_line` that status lands on a plain assignment in the caller and errexit ends the run; on `line_hint` it lands inside a command substitution, where bash inherits no errexit, so that one is inert until a caller reads its status. Both now read to EOF in an `END` block. They carry no test: no shipped producer emits a jq, taplo or tomllib diagnostic past a pipe buffer.

## Tests

Two rows in the precision suite, in that suite's clean-plus-control shape:

- a 200 KB new script with its trap on line 4 must stay clean. This row **fails on the shipped predicate** and passes on the fix.
- the control deletes the trap line from the same fixture and requires the `mktemp-trap` finding back, so the clean verdict cannot mean the lane stayed silent.

## Checks

- preflight suites: `lanes-must-fail` 33/0, `modes` 58/0, `precision` 78/0, `unavailable-tools` 13/0.
- `tools/guard --full`: one failure, `guard: vitest failed` — a single UI DOM test timing out at 5000ms while the machine was under enough memory pressure to reap background jobs. That file passes 2/2 on its own, and nothing here touches the UI.
- pre-commit chain clean on the staged diff; `bash32-lint` clean across 481 shell files.
- `.agents/skills/preflight/**` renders byte-identical to their `skills/preflight/**` sources.

Closes KEN-1257.

Program tracking: architecture-docs program, kendex lane.

https://claude.ai/code/session_01HY8jF3sUQto5CHS8ydb1V9
