### PR TITLE
fix(KEN-1179): a set landing on no tool is refused, not recorded

### DIFF
--- a/changelog.d/fixed/KEN-1179.md
+++ b/changelog.d/fixed/KEN-1179.md
@@ -1,0 +1,1 @@
+- `kendex add --bundle` refuses a set whose members land on none of the tools the install targets, naming the set and the tools, instead of recording an install that puts nothing on disk.

--- a/crates/core/src/engine/desired.rs
+++ b/crates/core/src/engine/desired.rs
@@ -220,7 +220,7 @@ mod artifact;
 mod places;
 pub use artifact::{artifact_disk_hash, artifact_paths};
 pub(crate) use places::{effective_method, skill_dir};
-pub(crate) use places::{harnesses_for, target_harnesses};
+pub(crate) use places::{harnesses_for, requested_or_default, target_harnesses};
 pub use places::{native_dir, own_dir, read_dirs, skill_canonical};
 pub(super) mod hold;
 

--- a/crates/core/src/engine/desired/places.rs
+++ b/crates/core/src/engine/desired/places.rs
@@ -118,10 +118,22 @@ pub(crate) fn harnesses_for(
     kind: ItemKind,
     scope: &Scope,
 ) -> Vec<HarnessId> {
-    requested
-        .map(<[HarnessId]>::to_vec)
-        .unwrap_or_else(|| manifest.install.harnesses.clone())
+    requested_or_default(requested, manifest)
         .into_iter()
         .filter(|harness| crate::harness::installs_here(*harness, kind, scope))
         .collect()
+}
+
+/// The tools a request or declaration aims at, before any kind can narrow
+/// them: the ones it names, or the scope's own list where it names none.
+/// Read on its own where a refusal has to say which tools it turned the
+/// install down for — the answer must be the one the filter above started
+/// from, not a second spelling of the fallback.
+pub(crate) fn requested_or_default(
+    requested: Option<&[HarnessId]>,
+    manifest: &Manifest,
+) -> Vec<HarnessId> {
+    requested
+        .map(<[HarnessId]>::to_vec)
+        .unwrap_or_else(|| manifest.install.harnesses.clone())
 }

--- a/crates/core/src/engine/ops/add.rs
+++ b/crates/core/src/engine/ops/add.rs
@@ -245,7 +245,15 @@ fn add_from(
         source_name,
         request,
     )?);
-    let sets = resolve_sets(&sealed, &config, source_name, &wanted.bundles)?;
+    let sets = resolve_sets(
+        &sealed,
+        &config,
+        source_name,
+        &wanted.bundles,
+        request,
+        manifest,
+        scope,
+    )?;
 
     // Bundles first: declaring a set folds in the equal-option members
     // declared earlier, while an item this same request asks for by name

--- a/crates/core/src/engine/ops/add/bundles.rs
+++ b/crates/core/src/engine/ops/add/bundles.rs
@@ -4,7 +4,7 @@
 use super::AddRequest;
 use crate::error::{CoreError, Result};
 use crate::manifest::{ItemDecl, Manifest};
-use crate::model::ItemKind;
+use crate::model::{ItemKind, Scope};
 use crate::source::CatalogBundle;
 
 /// Declare one curated set, carried the way the request asked. Asking for
@@ -154,15 +154,21 @@ pub(super) fn shaped_by_user(
 }
 
 /// The sets one request names, as the catalog offers them. A name it does
-/// not offer is refused, and so is a set it offers and can hand nothing
-/// over for: what a set installs derives at plan time, so declaring one
-/// would record the set, plan nothing, and report a successful install of
-/// no files — the shape a member list nothing backs leaves behind.
+/// not offer is refused, and so is a set that would put nothing on disk:
+/// what a set installs derives at plan time, so declaring one would record
+/// the set, plan nothing, and report a successful install of no files.
+///
+/// Two ways a set gets there, both answered from the one list of members
+/// the catalog actually offers: the source hands none of them over, or it
+/// hands them over and no tool this install targets holds their kinds.
 pub(super) fn resolve_sets(
     sealed: &crate::source_read::SealedSource,
     config: &crate::source::SourceConfig,
     source_name: &str,
     wanted: &[String],
+    request: &AddRequest,
+    manifest: &Manifest,
+    scope: &Scope,
 ) -> Result<Vec<CatalogBundle>> {
     let mut sets = Vec::new();
     for name in wanted {
@@ -172,9 +178,15 @@ pub(super) fn resolve_sets(
                 source_name: source_name.to_owned(),
             });
         };
-        if !bundle.members.iter().any(|member| {
-            crate::source::find_item(sealed, config, member.kind, &member.name).is_some()
-        }) {
+        let mut offered: Vec<ItemKind> = Vec::new();
+        for member in &bundle.members {
+            if crate::source::find_item(sealed, config, member.kind, &member.name).is_some()
+                && !offered.contains(&member.kind)
+            {
+                offered.push(member.kind);
+            }
+        }
+        if offered.is_empty() {
             return Err(CoreError::BundleInstallsNothing {
                 name: name.clone(),
                 source_name: source_name.to_owned(),
@@ -182,6 +194,17 @@ pub(super) fn resolve_sets(
                     .members
                     .iter()
                     .map(|member| crate::names::shown(&member.name))
+                    .collect(),
+            });
+        }
+        if let Some(harnesses) = super::lands::set_lands_nowhere(&offered, request, manifest, scope)
+        {
+            return Err(CoreError::BundleLandsNowhere {
+                name: name.clone(),
+                source_name: source_name.to_owned(),
+                harnesses: harnesses
+                    .into_iter()
+                    .map(|harness| harness.display_name().to_owned())
                     .collect(),
             });
         }

--- a/crates/core/src/engine/ops/add/bundles.rs
+++ b/crates/core/src/engine/ops/add/bundles.rs
@@ -4,7 +4,7 @@
 use super::AddRequest;
 use crate::error::{CoreError, Result};
 use crate::manifest::{ItemDecl, Manifest};
-use crate::model::{ItemKind, Scope};
+use crate::model::{HarnessId, ItemKind, Scope};
 use crate::source::CatalogBundle;
 
 /// Declare one curated set, carried the way the request asked. Asking for
@@ -18,14 +18,13 @@ pub(super) fn declare_bundle(
     request: &AddRequest,
     hold_at: Option<&str>,
 ) -> ItemDecl {
+    let harnesses = declared_harnesses(manifest, &bundle.name, request).map(<[HarnessId]>::to_vec);
     let decl = manifest
         .bundles
         .entry(bundle.name.clone())
         .or_insert_with(|| ItemDecl::from_source(source_name));
     decl.source = source_name.to_owned();
-    if let Some(harnesses) = &request.harnesses {
-        decl.harnesses = Some(harnesses.clone());
-    }
+    decl.harnesses = harnesses;
     if let Some(method) = request.method {
         decl.method = Some(method);
     }
@@ -40,6 +39,29 @@ pub(super) fn declare_bundle(
     }
     manifest.suppressed.retain(|_, held| !held.is_empty());
     declared
+}
+
+/// The tools this set will be declared with once the request is written:
+/// the ones the request names, and the ones the declaration already carries
+/// where it names none.
+///
+/// A request answers only what it says. Asking again for a set that was
+/// installed for one tool, without naming a tool this time, does not widen
+/// it to the scope's defaults — so a refusal that read the request alone
+/// would be answering for a declaration nobody is about to write, and the
+/// plan would then install against a different list than the one it was
+/// judged on.
+fn declared_harnesses<'a>(
+    manifest: &'a Manifest,
+    name: &str,
+    request: &'a AddRequest,
+) -> Option<&'a [HarnessId]> {
+    request.harnesses.as_deref().or_else(|| {
+        manifest
+            .bundles
+            .get(name)
+            .and_then(|decl| decl.harnesses.as_deref())
+    })
 }
 
 // Install-all subsumption, and the one-bundle-per-name rule.
@@ -197,8 +219,12 @@ pub(super) fn resolve_sets(
                     .collect(),
             });
         }
-        if let Some(harnesses) = super::lands::set_lands_nowhere(&offered, request, manifest, scope)
-        {
+        if let Some(harnesses) = super::lands::set_lands_nowhere(
+            &offered,
+            declared_harnesses(manifest, name, request),
+            manifest,
+            scope,
+        ) {
             return Err(CoreError::BundleLandsNowhere {
                 name: name.clone(),
                 source_name: source_name.to_owned(),

--- a/crates/core/src/engine/ops/add/lands.rs
+++ b/crates/core/src/engine/ops/add/lands.rs
@@ -5,9 +5,14 @@
 //! reports done — so it is refused here, before the manifest is touched,
 //! and the same filter draws the picker so the choice can never be made in
 //! the first place.
+//!
+//! A curated set is the same question asked one step later: what it holds
+//! is the catalog's to say, so it is answered where the request's sets have
+//! been resolved rather than from the request alone.
 
 use super::AddRequest;
-use crate::model::{ItemKind, Scope};
+use crate::manifest::Manifest;
+use crate::model::{HarnessId, ItemKind, Scope};
 
 /// Why this request would install nothing, or `None` where at least one
 /// named tool can take at least one of the kinds asked for.
@@ -43,9 +48,45 @@ pub(super) fn lands_nowhere(request: &AddRequest, scope: &Scope) -> Option<Strin
     ))
 }
 
+/// The same question for one curated set, asked once its members are
+/// known: `None` where at least one kind the catalog offers for the set
+/// reaches a tool this request installs to, and the tools it turned the
+/// install down for otherwise.
+///
+/// A set has to be asked separately because the manifest records only that
+/// the set is installed — what it holds derives at plan time, so
+/// [`requested_kinds`] can only widen a bundle request to every kind and
+/// any tool taking any kind passes it. This reads what the plan itself
+/// will read for each member, so the two cannot disagree about whether a
+/// declaration puts bytes on disk.
+///
+/// The tools are the ones the request names, or the scope's own list where
+/// it names none — by here that list has already been brought up to date
+/// against the machine, so it is what the plan will read too.
+pub(super) fn set_lands_nowhere(
+    offered: &[ItemKind],
+    request: &AddRequest,
+    manifest: &Manifest,
+    scope: &Scope,
+) -> Option<Vec<HarnessId>> {
+    let lands = offered.iter().any(|kind| {
+        !crate::engine::desired::harnesses_for(request.harnesses.as_deref(), manifest, *kind, scope)
+            .is_empty()
+    });
+    match lands {
+        true => None,
+        false => Some(crate::engine::desired::requested_or_default(
+            request.harnesses.as_deref(),
+            manifest,
+        )),
+    }
+}
+
 /// The kinds this request would declare. A whole-source or bundle install
 /// carries whatever the catalog holds, so it is every kind — narrowing it
 /// to what happens to be named would refuse a request that is not empty.
+/// What a named set actually holds is [`set_lands_nowhere`]'s question,
+/// asked where its members have been resolved.
 pub fn requested_kinds(request: &AddRequest) -> Vec<ItemKind> {
     if request.all || !request.bundles.is_empty() {
         return ItemKind::ALL.to_vec();

--- a/crates/core/src/engine/ops/add/lands.rs
+++ b/crates/core/src/engine/ops/add/lands.rs
@@ -60,24 +60,24 @@ pub(super) fn lands_nowhere(request: &AddRequest, scope: &Scope) -> Option<Strin
 /// will read for each member, so the two cannot disagree about whether a
 /// declaration puts bytes on disk.
 ///
-/// The tools are the ones the request names, or the scope's own list where
-/// it names none — by here that list has already been brought up to date
-/// against the machine, so it is what the plan will read too.
+/// `harnesses` is the list the set will be declared with, which the caller
+/// derives — not the request's own, which answers for a declaration nobody
+/// is about to write. `None` falls back to the scope's list, and by here
+/// that list has already been brought up to date against the machine, so it
+/// is what the plan will read too.
 pub(super) fn set_lands_nowhere(
     offered: &[ItemKind],
-    request: &AddRequest,
+    harnesses: Option<&[HarnessId]>,
     manifest: &Manifest,
     scope: &Scope,
 ) -> Option<Vec<HarnessId>> {
     let lands = offered.iter().any(|kind| {
-        !crate::engine::desired::harnesses_for(request.harnesses.as_deref(), manifest, *kind, scope)
-            .is_empty()
+        !crate::engine::desired::harnesses_for(harnesses, manifest, *kind, scope).is_empty()
     });
     match lands {
         true => None,
         false => Some(crate::engine::desired::requested_or_default(
-            request.harnesses.as_deref(),
-            manifest,
+            harnesses, manifest,
         )),
     }
 }

--- a/crates/core/src/error.rs
+++ b/crates/core/src/error.rs
@@ -430,6 +430,30 @@ pub enum CoreError {
         members: Vec<String>,
     },
 
+    /// The source offers the set and its members, and no tool this install
+    /// targets holds any of their kinds — a set of MCP servers asked for on
+    /// a tool that has nowhere to put one. The same refusal as
+    /// [`Self::BundleInstallsNothing`] one step further in: the set would be
+    /// recorded and every member of it filtered away at plan time, leaving
+    /// an install that put nothing anywhere.
+    #[error(
+        "the bundle '{name}' from source '{source_name}' would install nothing — {}",
+        match harnesses.is_empty() {
+            true => "this scope installs to no tool at all".to_owned(),
+            false => format!(
+                "{} {} none of what it carries at this scope",
+                harnesses.join(", "),
+                match harnesses.len() { 1 => "takes", _ => "take" },
+            ),
+        }
+    )]
+    BundleLandsNowhere {
+        name: String,
+        source_name: String,
+        /// The tools the install targets, named as the user sees them.
+        harnesses: Vec<String>,
+    },
+
     /// Nothing was left behind, and `cause` is the failure that stopped it
     /// — kept whole rather than flattened into `reason`, because what a
     /// caller does about a rollback depends on why: a precondition that

--- a/crates/core/tests/install_seam/bundles.rs
+++ b/crates/core/tests/install_seam/bundles.rs
@@ -10,6 +10,7 @@ use kendex_core::apply;
 use kendex_core::engine::{audit, ops};
 use kendex_core::error::CoreError;
 use kendex_core::lock::{BundleRef, Reason, load as load_lock, lock_path};
+use kendex_core::model::HarnessId;
 
 use super::{Fixture, add_and_apply, manifest_of, manifest_with, skill, world, write};
 
@@ -253,6 +254,78 @@ fn a_set_whose_member_the_catalog_offers_installs() {
     manifest_with(&f, &[("cat", &catalog)], "");
     add_and_apply(&f, &request("starter"));
     assert!(f.project.join(".claude/skills/dev").exists());
+}
+
+/// A catalog offering `servers`, a set carrying only MCP servers.
+fn servers_catalog(f: &Fixture) -> PathBuf {
+    let catalog = f.home.join("catalog");
+    write(
+        &catalog,
+        "mcp/db.toml",
+        "command = \"db-mcp\"\nargs = [\"--stdio\"]\n",
+    );
+    write(
+        &catalog,
+        "kendex.toml",
+        "is_source_catalog = true\n\n[bundles.servers]\nmcp-servers = [\"db\"]\n",
+    );
+    catalog
+}
+
+/// A set every offered member of which lands on no tool this install
+/// targets is refused at the declaration, naming the set and the tools.
+/// Pi has nowhere to put an MCP server, so declaring `servers` for Pi would
+/// record the set, filter its only member away at plan time, and report a
+/// successful install of no files.
+#[test]
+#[allow(clippy::unwrap_used)]
+fn an_mcp_server_set_asked_for_on_pi_alone_is_refused() {
+    let f = world();
+    let catalog = servers_catalog(&f);
+    manifest_with(&f, &[("cat", &catalog)], "");
+    let before = fs::read_to_string(f.project.join("kendex.toml")).unwrap();
+
+    let error = ops::add(&f.env, &f.scope, &for_harness("servers", HarnessId::Pi)).unwrap_err();
+
+    let said = error.to_string();
+    assert!(
+        matches!(error, CoreError::BundleLandsNowhere { ref name, .. } if name == "servers"),
+        "{said}"
+    );
+    assert!(
+        said.contains(HarnessId::Pi.display_name()),
+        "the tool it was turned down for: {said}"
+    );
+    assert_eq!(
+        fs::read_to_string(f.project.join("kendex.toml")).unwrap(),
+        before,
+        "a refusal writes nothing"
+    );
+}
+
+/// The must-fail counterpart: the same set asked for on a tool that does
+/// hold an MCP server installs it. The refusal is about where the members
+/// land, not about sets of MCP servers.
+#[test]
+#[allow(clippy::unwrap_used)]
+fn the_same_set_asked_for_on_claude_installs() {
+    let f = world();
+    let catalog = servers_catalog(&f);
+    manifest_with(&f, &[("cat", &catalog)], "");
+
+    add_and_apply(&f, &for_harness("servers", HarnessId::Claude));
+
+    assert!(manifest_of(&f).bundles.contains_key("servers"));
+    let mcp = fs::read_to_string(f.project.join(".mcp.json")).unwrap();
+    assert!(mcp.contains("db-mcp"), "{mcp}");
+}
+
+/// One `add --bundle <name> --harness <tool>` from that catalog.
+fn for_harness(name: &str, harness: HarnessId) -> ops::AddRequest {
+    ops::AddRequest {
+        harnesses: Some(vec![harness]),
+        ..request(name)
+    }
 }
 
 /// One `add --bundle <name>` from the catalog these tests declare.

--- a/crates/core/tests/install_seam/bundles.rs
+++ b/crates/core/tests/install_seam/bundles.rs
@@ -320,6 +320,60 @@ fn the_same_set_asked_for_on_claude_installs() {
     assert!(mcp.contains("db-mcp"), "{mcp}");
 }
 
+/// Asking again for a set already installed for one tool, without naming a
+/// tool this time, is judged on the list that set keeps — not on the
+/// scope's defaults, which the declaration does not widen to. Read the
+/// request alone and both directions are wrong: the Pi-only set below is
+/// let through because the scope also lists Claude, and the Claude-only one
+/// is refused because the scope lists only Pi.
+#[test]
+#[allow(clippy::unwrap_used)]
+fn a_set_already_declared_for_one_tool_is_judged_on_that_tool() {
+    let f = world();
+    let catalog = servers_catalog(&f);
+    manifest_with(&f, &[("cat", &catalog)], "");
+    let held = f.project.join("kendex.toml");
+    let claude_and_pi = fs::read_to_string(&held).unwrap().replace(
+        "harnesses = [\"claude\"]",
+        "harnesses = [\"claude\", \"pi\"]",
+    );
+    fs::write(
+        &held,
+        format!("{claude_and_pi}[bundles.servers]\nsource = \"cat\"\nharnesses = [\"pi\"]\n"),
+    )
+    .unwrap();
+    let before = fs::read_to_string(&held).unwrap();
+
+    let error = ops::add(&f.env, &f.scope, &request("servers")).unwrap_err();
+
+    assert!(
+        matches!(error, CoreError::BundleLandsNowhere { ref name, .. } if name == "servers"),
+        "a set kept on Pi alone was judged on the scope's wider list: {error}"
+    );
+    assert_eq!(
+        fs::read_to_string(&held).unwrap(),
+        before,
+        "a refusal writes nothing"
+    );
+
+    let pi_only = fs::read_to_string(&held)
+        .unwrap()
+        .replace("harnesses = [\"claude\", \"pi\"]", "harnesses = [\"pi\"]")
+        .replace(
+            "[bundles.servers]\nsource = \"cat\"\nharnesses = [\"pi\"]\n",
+            "[bundles.servers]\nsource = \"cat\"\nharnesses = [\"claude\"]\n",
+        );
+    fs::write(&held, pi_only).unwrap();
+
+    add_and_apply(&f, &request("servers"));
+
+    let mcp = fs::read_to_string(f.project.join(".mcp.json")).unwrap();
+    assert!(
+        mcp.contains("db-mcp"),
+        "a set kept on Claude was refused for the scope's Pi-only list: {mcp}"
+    );
+}
+
 /// One `add --bundle <name> --harness <tool>` from that catalog.
 fn for_harness(name: &str, harness: HarnessId) -> ops::AddRequest {
     ops::AddRequest {


### PR DESCRIPTION
`kendex add --bundle` asked only whether the catalog offered a member, never whether any member reaches a chosen tool. A set of MCP servers requested for Pi returned `Ok`, wrote `[bundles.servers]` into `kendex.toml`, and planned one op — the manifest write. Every member was filtered away at plan time and the install put nothing anywhere.

`lands.rs` now owns the question for a set too. `set_lands_nowhere` answers it for one resolved set by reading the plan's own `harnesses_for`, so add and plan cannot disagree about whether a declaration puts bytes on disk, and `resolve_sets` collects the kinds the catalog actually offers once and refuses on both arms: the source hands no member over, or no tool this install targets holds their kinds. `CoreError::BundleLandsNowhere` names the set, its source and the tools; nothing is persisted before the refusal, so `kendex.toml` is byte-identical.

Per the issue's triage there is no new plan machinery. `requested_kinds` still widens a bundle request to every kind, which is the honest answer before its members are known, and now points at the function that answers the narrowed one.

The second commit closes what the local reviewer found: `declare_bundle` overwrites the declaration's harness list only when the request names one, so a set already installed for one tool and asked for again without `--harness` was judged on a list nobody was about to write — let through when the scope's defaults happened to hold the kind, and turned down when they did not, for an install that works. `declared_harnesses` is now the one place that says what list a set will carry, and both the writer and the refusal read it.

**Tests.** One install-seam control (an mcp-servers-only set for Pi alone is refused, `kendex.toml` byte-identical) and its must-fail counterpart (the same set on Claude installs), plus one case pinning both directions of the declared-list rule. Each guard was killed on a copy to prove it runs red: stubbing the refusal reproduces the original symptom verbatim — `Ok` with a single `WriteManifest` op and no package files.

Closes KEN-1179.

https://claude.ai/code/session_01NAg35WFB7Qb3jEaeCL836i
