### PR TITLE
fix(KEN-985): a pane running a turn counts as a launched lane

### DIFF
--- a/.agents/skills/orch/scripts/lib/pane-working.sh
+++ b/.agents/skills/orch/scripts/lib/pane-working.sh
@@ -1,0 +1,27 @@
+# shellcheck shell=bash
+#
+# The one answer to "is this pane's harness running a turn right now", shared
+# by every script that has to tell a working lane from a parked one.
+#
+# Sourced, never run.
+
+# A turn in flight: the interrupt hint (both harnesses), the hint shown while
+# a foreground shell runs, or the streaming token counter of the status line.
+# Measured off running sessions of both harnesses.
+#
+# Deliberately NOT a spinner glyph. Claude Code animates one frame set
+# (`· ✢ * ✶ ✻ ✽`) across every long-running screen, its OAuth sign-in
+# included, so a spinner reads a lane parked at a login prompt as working;
+# `·` is also its separator character and `*` is in its startup banner. `✻`
+# additionally spells the idle end-of-turn line (`✻ Churned for 6s · done`),
+# so it survives the turn that drew it exactly as `●` does. The token counter
+# and the interrupt hint are drawn only while a turn is actually running.
+#
+# The counter appears a second or two INTO a turn, after streaming starts, so
+# a turn caught in its first moments reads as not working. Callers that poll
+# see it on a later pass; callers that must not act on a false negative say so
+# where they read it.
+WORKING_RE='to interrupt|to run in background|↓ [0-9][0-9.]*[kKmM]? tokens'
+
+# pane_working SCREEN — the predicate over one captured pane.
+pane_working() { grep -Eq -- "$WORKING_RE" <<<"$1"; }

--- a/.agents/skills/orch/scripts/open-terminal
+++ b/.agents/skills/orch/scripts/open-terminal
@@ -402,11 +402,23 @@ start_cmd() {
 # ordinary space. oversee-watch's PANE_MARKER_RE deliberately conflates the
 # two; telling them apart is this script's question, not its.
 #
+# Readiness is the EMPTY composer, which is that line and nothing after it.
+# A composer still holding text is not somewhere to type: `send-keys -l`
+# APPENDS, so typing the brief into a composer that already holds one submits
+# `/orch start CC-737/orch start CC-737`. Its own dismissing Enter submits
+# what is there instead, which is the right recovery when what is there is the
+# brief the launch arrived with — the state this whole path exists for.
+# Measured on the same captures: the empty form is on 35 of 35 idle screens
+# and 57 of 57 mid-turn ones that draw a composer at all, and on 0 draft
+# screens.
+#
 # The older spelling of readiness, the `? for shortcuts` footer, is kept
 # alongside it: this is another tool's surface, and a lane may be running a
-# build that still draws it.
+# build that still draws it. That footer says nothing about whether the
+# composer under it is occupied, so the append above is still reachable on
+# such a build, exactly as it was before this marker existed.
 COMPOSER_RE=$'^\xe2\x9d\xaf\xc2\xa0'
-READY_RE="$COMPOSER_RE"'|\? for shortcuts'
+READY_RE="$COMPOSER_RE"'[[:blank:]]*$|\? for shortcuts'
 
 # The launch took. Two independent proofs, either sufficient.
 #
@@ -440,6 +452,12 @@ tmux_lane_launched() {
   # first poll, and a viewport-only capture would misread that as
   # undelivered and queue a duplicate brief into a running session.
   screen="$(tmux capture-pane -pJ -S - -t "$pane" 2>/dev/null)" || return 1
+  lane_launched "$screen" "$brief"
+}
+
+# The same question against a screen already in hand.
+lane_launched() { # SCREEN BRIEF
+  local screen="$1" brief="$2"
   pane_working "$screen" && return 0
   # No short-circuiting `grep -q` pipelines over the capture: with -S - a
   # retained pane can exceed a pipe buffer, an early -q match SIGPIPEs the
@@ -472,18 +490,21 @@ tmux_wait_launched() {
 # An Enter into an already-ready empty composer is a no-op, so the nudge is
 # safe when the screen is merely slow.
 #
-# A lane that starts working during the wait is the third state, and the one
-# the nudge must stop for: further keystrokes land inside a running turn. It
-# ends the wait as a launched lane rather than a stuck one. WORKING_RE reads
-# false for the first second or two of a turn, before streaming starts, so a
-# turn beginning inside the last passes can still take an Enter — harmless in
-# a Claude Code turn, which Enter does not interrupt, and the pass after it
-# stops.
+# A lane that BECOMES launched during the wait is the third state, and the one
+# the nudge must stop for: further keystrokes land inside a running turn, and
+# the brief is already where it needed to go. It ends the wait as a launched
+# lane rather than a stuck one. This is not only a turn starting late: a
+# dismissing Enter into a composer holding the brief SUBMITS it, which is the
+# recovery this path exists to perform, and re-typing the brief after that
+# would run it twice. WORKING_RE reads false for the first second or two of a
+# turn, before streaming starts, so a turn beginning inside the last passes can
+# still take an Enter — harmless in a Claude Code turn, which Enter does not
+# interrupt, and the pass after it stops.
 #   0  a ready, empty composer: re-send the brief
-#   2  a turn in flight: the launch took, send nothing more
+#   2  the launch took after all: send nothing more
 #   1  neither within the window: the stuck or dead pane the failure exit is for
 tmux_wait_composer() {
-  local pane="$1" waited=0 screen
+  local pane="$1" brief="$2" waited=0 screen
   while (( waited < TMUX_VERIFY_SECS )); do
     # VISIBLE viewport only (no -S -): readiness is a property of the
     # current screen — a footer buried in scrollback behind a first-run
@@ -494,7 +515,7 @@ tmux_wait_composer() {
     # the re-send below was unreachable — every consumed brief fell to the
     # failure exit.
     screen="$(tmux capture-pane -pJ -t "$pane" 2>/dev/null)" || return 1
-    pane_working "$screen" && return 2
+    lane_launched "$screen" "$brief" && return 2
     grep -Eq -- "$READY_RE" <<<"$screen" && return 0
     tmux send-keys -t "$pane" Enter || return 1
     sleep 1
@@ -569,7 +590,7 @@ open_tmux() {
   # has the same delivery requirement.
   tmux_wait_launched "$pane" "$brief" && return 0
   local composer_rc=0
-  tmux_wait_composer "$pane" || composer_rc=$?
+  tmux_wait_composer "$pane" "$brief" || composer_rc=$?
   if (( composer_rc == 2 )); then
     echo "'$title' is already working; the launch took (its brief never read as delivered)"
     return 0

--- a/.agents/skills/orch/scripts/open-terminal
+++ b/.agents/skills/orch/scripts/open-terminal
@@ -54,9 +54,10 @@ Options:
                     as another session's claim. A worktree under a lease held
                     by a different owner is still skipped.
 
-On tmux lanes the brief's delivery is verified against the pane and re-sent
+On tmux lanes the launch is verified against the pane and the brief re-sent
 once if a first-run dialog consumed it ($ORCH_TMUX_VERIFY_SECS per pass,
-default 15, positive integer clamped to 120).
+default 15, positive integer clamped to 120). A pane already running a turn
+counts as launched and is not typed into.
 
 Each item's worktree is created here (worktree create, or create --reuse
 under --relaunch when the item's tree already exists). An item whose worktree
@@ -156,6 +157,8 @@ source "$SCRIPT_DIR/lib/kendex-env.sh"
 kendex_load_project_env "$PROJECT_ROOT"
 # shellcheck source=lib/lane-claims.sh
 source "$SCRIPT_DIR/lib/lane-claims.sh"
+# shellcheck source=lib/pane-working.sh
+source "$SCRIPT_DIR/lib/pane-working.sh"
 WORKTREE_CLI="${WORKTREE_CLI:-$SKILLS_DIR/worktree/scripts/worktree}"
 LANES_CLI="${LANES_CLI:-$SCRIPT_DIR/lanes}"
 GH_ISSUE_PATTERN="${GH_ISSUE_PATTERN:-[A-Z]+-[0-9]+}"
@@ -384,21 +387,35 @@ start_cmd() {
   esac
 }
 
-# Delivered means SUBMITTED, not merely present: the brief echoed in the
-# launch command (`claude -n` line) or sitting unsent in the composer's
-# │-bordered input box is not delivery. The predicate requires the brief on a
-# plain transcript line (neither of those) AND a transcript-activity marker
-# proving the TUI accepted the prompt: a ●/⏺ response bullet, a ✻/✳ working
-# spinner, or the esc-to-interrupt processing hint. -J joins wrapped lines so
-# a narrow pane cannot split the brief across a line break and fake an
-# undelivered screen.
-tmux_brief_visible() {
+# The launch took. Two independent proofs, either sufficient.
+#
+# A TURN IN FLIGHT (WORKING_RE, lib/pane-working.sh). A window this script
+# opened seconds ago has no work to run but the brief it was launched with,
+# and a first-run dialog that ate that brief leaves the harness parked, never
+# working. This is the half a long brief needs: the TUI wraps, truncates or
+# redraws its transcript line, and the delivery read below then misses a lane
+# that is plainly running — the working lane reported as a failed launch.
+#
+# THE BRIEF DELIVERED, which means SUBMITTED, not merely present: the brief
+# echoed in the launch command (`claude -n` line) or sitting unsent in the
+# composer's │-bordered input box is not delivery. That read requires the
+# brief on a plain transcript line (neither of those) AND a transcript-activity
+# marker proving the TUI accepted the prompt: a ●/⏺ response bullet, a ✻/✳
+# spinner or end-of-turn line, or the esc-to-interrupt hint. The conjunction
+# stays: alone, the plain-line read passes on an unsent draft in a composer
+# the harness no longer draws with │, and this is the last check before a lane
+# is called launched.
+#
+# -J joins wrapped lines so a narrow pane cannot split the brief across a line
+# break and fake an unlaunched screen.
+tmux_lane_launched() {
   local pane="$1" brief="$2" screen
   # -S -: capture from the start of history, not just the visible viewport —
   # a fast response can scroll the submitted prompt out of view before the
   # first poll, and a viewport-only capture would misread that as
   # undelivered and queue a duplicate brief into a running session.
   screen="$(tmux capture-pane -pJ -S - -t "$pane" 2>/dev/null)" || return 1
+  pane_working "$screen" && return 0
   # No short-circuiting `grep -q` pipelines over the capture: with -S - a
   # retained pane can exceed a pipe buffer, an early -q match SIGPIPEs the
   # upstream printf, and pipefail turns a FOUND brief into exit 141 — a
@@ -411,12 +428,12 @@ tmux_brief_visible() {
      "$screen" == *'✳'* || "$screen" == *'esc to interrupt'* ]]
 }
 
-tmux_verify_brief() {
+tmux_wait_launched() {
   local pane="$1" brief="$2" waited=0
   while (( waited < TMUX_VERIFY_SECS )); do
     sleep 1
     waited=$((waited + 1))
-    tmux_brief_visible "$pane" "$brief" && return 0
+    tmux_lane_launched "$pane" "$brief" && return 0
   done
   return 1
 }
@@ -429,14 +446,26 @@ tmux_verify_brief() {
 # an unattended lane needs) and waits for the main TUI's composer footer.
 # An Enter into an already-ready empty composer is a no-op, so the nudge is
 # safe when the screen is merely slow.
+#
+# A lane that starts working during the wait is the third state, and the one
+# the nudge must stop for: further keystrokes land inside a running turn. It
+# ends the wait as a launched lane rather than a stuck one. WORKING_RE reads
+# false for the first second or two of a turn, before streaming starts, so a
+# turn beginning inside the last passes can still take an Enter — harmless in
+# a Claude Code turn, which Enter does not interrupt, and the pass after it
+# stops.
+#   0  a ready, empty composer: re-send the brief
+#   2  a turn in flight: the launch took, send nothing more
+#   1  neither within the window: the stuck or dead pane the failure exit is for
 tmux_wait_composer() {
   local pane="$1" waited=0 screen
   while (( waited < TMUX_VERIFY_SECS )); do
     # VISIBLE viewport only (no -S -): readiness is a property of the
     # current screen — a footer buried in scrollback behind a first-run
     # dialog must not read as "composer ready" and send the brief into the
-    # dialog again.
+    # dialog again. The turn in flight is the current screen's question too.
     screen="$(tmux capture-pane -pJ -t "$pane" 2>/dev/null)" || return 1
+    pane_working "$screen" && return 2
     [[ "$screen" == *'? for shortcuts'* ]] && return 0
     tmux send-keys -t "$pane" Enter || return 1
     sleep 1
@@ -501,14 +530,22 @@ open_tmux() {
   fi
   echo "Opened tmux window '$title' in $dir"
   [[ -n "$brief" ]] || return 0
-  # Delivery verification: a first-run dialog (theme / trust /
+  # Launch verification: a first-run dialog (theme / trust /
   # browser integration) can consume the CLI-arg brief, leaving a healthy TUI
-  # at an empty composer while the launch looks successful. Confirm the brief
-  # actually reached the TUI; if not, re-send it once into the composer and
-  # re-verify; if still absent, fail this lane loudly instead of reporting
-  # success. The Codex kickoff path has the same delivery requirement.
-  tmux_verify_brief "$pane" "$brief" && return 0
-  if ! tmux_wait_composer "$pane"; then
+  # at an empty composer while the launch looks successful. Confirm the launch
+  # took; if it did not, re-send the brief once into the composer and
+  # re-verify; if it still has not, fail this lane loudly instead of reporting
+  # success. Between those sits the lane that is simply already working: it
+  # took, and all that is owed to it is to stop typing. The Codex kickoff path
+  # has the same delivery requirement.
+  tmux_wait_launched "$pane" "$brief" && return 0
+  local composer_rc=0
+  tmux_wait_composer "$pane" || composer_rc=$?
+  if (( composer_rc == 2 )); then
+    echo "'$title' is already working; the launch took (its brief never read as delivered)"
+    return 0
+  fi
+  if (( composer_rc != 0 )); then
     echo "Error: '$title' never reached a ready composer (first-run dialog stuck?) — attach and start it manually: $brief" >&2
     return 1
   fi
@@ -516,7 +553,7 @@ open_tmux() {
     echo "Error: tmux send-keys failed re-delivering the brief to '$title'" >&2
     return 1
   fi
-  if tmux_verify_brief "$pane" "$brief"; then
+  if tmux_wait_launched "$pane" "$brief"; then
     echo "Re-delivered brief to '$title' (initial CLI-arg prompt was consumed at boot)"
     return 0
   fi

--- a/.agents/skills/orch/scripts/open-terminal
+++ b/.agents/skills/orch/scripts/open-terminal
@@ -387,6 +387,27 @@ start_cmd() {
   esac
 }
 
+# The composer of the main TUI, at column 0: the harness's prompt marker
+# followed by the NON-BREAKING space it pads the input line with. That padding
+# is the whole discriminator, and it is spelled as bytes rather than typed,
+# because the character is invisible in source and a reformat would silently
+# turn it into an ordinary space:
+#
+#   ❯<U+00A0>            the composer, empty or holding an unsent draft
+#   ❯<space>some text    a SUBMITTED message, echoed into the transcript
+#
+# Measured over 146 pane captures of Claude Code v2.1.261: present on 93 of
+# 100 main-TUI screens and on 0 of 45 first-run screens (theme picker, login
+# method, sign-in, paste-code, trust dialog), whose own `❯ 1. …` rows take the
+# ordinary space. oversee-watch's PANE_MARKER_RE deliberately conflates the
+# two; telling them apart is this script's question, not its.
+#
+# The older spelling of readiness, the `? for shortcuts` footer, is kept
+# alongside it: this is another tool's surface, and a lane may be running a
+# build that still draws it.
+COMPOSER_RE=$'^\xe2\x9d\xaf\xc2\xa0'
+READY_RE="$COMPOSER_RE"'|\? for shortcuts'
+
 # The launch took. Two independent proofs, either sufficient.
 #
 # A TURN IN FLIGHT (WORKING_RE, lib/pane-working.sh). A window this script
@@ -398,13 +419,17 @@ start_cmd() {
 #
 # THE BRIEF DELIVERED, which means SUBMITTED, not merely present: the brief
 # echoed in the launch command (`claude -n` line) or sitting unsent in the
-# composer's │-bordered input box is not delivery. That read requires the
-# brief on a plain transcript line (neither of those) AND a transcript-activity
-# marker proving the TUI accepted the prompt: a ●/⏺ response bullet, a ✻/✳
-# spinner or end-of-turn line, or the esc-to-interrupt hint. The conjunction
-# stays: alone, the plain-line read passes on an unsent draft in a composer
-# the harness no longer draws with │, and this is the last check before a lane
-# is called launched.
+# composer is not delivery, so both lines are dropped before the brief is
+# looked for. The composer is dropped by COMPOSER_RE; the │ border an older
+# TUI drew around it is dropped too, for the same reason that spelling is
+# still read as ready. On the shipped v2.1.261 the │ filter matches nothing —
+# the composer is two ──── rules around the prompt line — so COMPOSER_RE is
+# what carries this now.
+# On top of that the read requires a transcript-activity marker proving the
+# TUI accepted the prompt: a ●/⏺ response bullet, a ✻/✳ spinner or end-of-turn
+# line, or the esc-to-interrupt hint. The conjunction stays, as the last check
+# before a lane is called launched: a draft the user is still typing sits on
+# the composer line under a status bar that already carries ●.
 #
 # -J joins wrapped lines so a narrow pane cannot split the brief across a line
 # break and fake an unlaunched screen.
@@ -422,7 +447,7 @@ tmux_lane_launched() {
   # submitted prompt then reads as missing and gets duplicated. grep -v
   # always reads its whole input; the containment checks are bash matches.
   local filtered
-  filtered="$(printf '%s\n' "$screen" | grep -vF 'claude -n' | grep -vF '│')" || true
+  filtered="$(printf '%s\n' "$screen" | grep -vF 'claude -n' | grep -vF '│' | grep -Ev -- "$COMPOSER_RE")" || true
   [[ "$filtered" == *"$brief"* ]] || return 1
   [[ "$screen" == *'●'* || "$screen" == *'⏺'* || "$screen" == *'✻'* ||
      "$screen" == *'✳'* || "$screen" == *'esc to interrupt'* ]]
@@ -464,9 +489,13 @@ tmux_wait_composer() {
     # current screen — a footer buried in scrollback behind a first-run
     # dialog must not read as "composer ready" and send the brief into the
     # dialog again. The turn in flight is the current screen's question too.
+    # READY_RE, not the `? for shortcuts` footer alone: v2.1.261 does not draw
+    # that footer at all, so keyed on it this wait could never return 0 and
+    # the re-send below was unreachable — every consumed brief fell to the
+    # failure exit.
     screen="$(tmux capture-pane -pJ -t "$pane" 2>/dev/null)" || return 1
     pane_working "$screen" && return 2
-    [[ "$screen" == *'? for shortcuts'* ]] && return 0
+    grep -Eq -- "$READY_RE" <<<"$screen" && return 0
     tmux send-keys -t "$pane" Enter || return 1
     sleep 1
     waited=$((waited + 1))

--- a/.agents/skills/orch/scripts/open-terminal
+++ b/.agents/skills/orch/scripts/open-terminal
@@ -437,11 +437,15 @@ READY_RE="$COMPOSER_RE"'[[:blank:]]*$|\? for shortcuts'
 # still read as ready. On the shipped v2.1.261 the │ filter matches nothing —
 # the composer is two ──── rules around the prompt line — so COMPOSER_RE is
 # what carries this now.
-# On top of that the read requires a transcript-activity marker proving the
-# TUI accepted the prompt: a ●/⏺ response bullet, a ✻/✳ spinner or end-of-turn
-# line, or the esc-to-interrupt hint. The conjunction stays, as the last check
-# before a lane is called launched: a draft the user is still typing sits on
-# the composer line under a status bar that already carries ●.
+# Dropping the composer line is the WHOLE of that guard, and it has to be:
+# this read also decides whether the launcher may type, and no
+# transcript-activity marker can be required of it. A turn's first second or
+# two draws a spinner frame this script deliberately does not read and no
+# token counter yet, while the composer is ALREADY EMPTY again — the empty
+# form is on 57 of 57 mid-turn captures. Ask for a marker on top and that
+# window reads as an idle, ready composer, and a second brief goes into a turn
+# that has just begun. The filter is measured instead: on 45 first-run
+# captures nothing survives it, and a draft never does.
 #
 # -J joins wrapped lines so a narrow pane cannot split the brief across a line
 # break and fake an unlaunched screen.
@@ -466,9 +470,7 @@ lane_launched() { # SCREEN BRIEF
   # always reads its whole input; the containment checks are bash matches.
   local filtered
   filtered="$(printf '%s\n' "$screen" | grep -vF 'claude -n' | grep -vF '│' | grep -Ev -- "$COMPOSER_RE")" || true
-  [[ "$filtered" == *"$brief"* ]] || return 1
-  [[ "$screen" == *'●'* || "$screen" == *'⏺'* || "$screen" == *'✻'* ||
-     "$screen" == *'✳'* || "$screen" == *'esc to interrupt'* ]]
+  [[ "$filtered" == *"$brief"* ]]
 }
 
 tmux_wait_launched() {

--- a/.agents/skills/orch/scripts/open-terminal
+++ b/.agents/skills/orch/scripts/open-terminal
@@ -503,9 +503,14 @@ tmux_wait_launched() {
 #   0  a ready, empty composer: re-send the brief
 #   2  the launch took after all: send nothing more
 #   1  neither within the window: the stuck or dead pane the failure exit is for
+# The loop READS before it decides whether it may still nudge, so the Enter of
+# the final pass is observed like every other: a dialog it dismissed or a draft
+# it submitted lands after the last nudge, and testing the budget before the
+# capture would report that lane stuck. At ORCH_TMUX_VERIFY_SECS=1 that is the
+# only Enter there is.
 tmux_wait_composer() {
   local pane="$1" brief="$2" waited=0 screen
-  while (( waited < TMUX_VERIFY_SECS )); do
+  while :; do
     # VISIBLE viewport only (no -S -): readiness is a property of the
     # current screen — a footer buried in scrollback behind a first-run
     # dialog must not read as "composer ready" and send the brief into the
@@ -517,11 +522,11 @@ tmux_wait_composer() {
     screen="$(tmux capture-pane -pJ -t "$pane" 2>/dev/null)" || return 1
     lane_launched "$screen" "$brief" && return 2
     grep -Eq -- "$READY_RE" <<<"$screen" && return 0
+    (( waited < TMUX_VERIFY_SECS )) || return 1
     tmux send-keys -t "$pane" Enter || return 1
     sleep 1
     waited=$((waited + 1))
   done
-  return 1
 }
 
 # The last layer before any window opens. A launch whose working directory is
@@ -592,7 +597,7 @@ open_tmux() {
   local composer_rc=0
   tmux_wait_composer "$pane" "$brief" || composer_rc=$?
   if (( composer_rc == 2 )); then
-    echo "'$title' is already working; the launch took (its brief never read as delivered)"
+    echo "Confirmed '$title' launched while waiting for its composer; nothing further sent"
     return 0
   fi
   if (( composer_rc != 0 )); then

--- a/.agents/skills/orch/scripts/oversee-watch
+++ b/.agents/skills/orch/scripts/oversee-watch
@@ -202,6 +202,8 @@ source "$SCRIPT_DIR/lib/usage-reset.sh"
 source "$SCRIPT_DIR/lib/lane-claims.sh"
 # shellcheck source=lib/pr-watch-pass.sh
 source "$SCRIPT_DIR/lib/pr-watch-pass.sh"
+# shellcheck source=lib/pane-working.sh
+source "$SCRIPT_DIR/lib/pane-working.sh"
 PR_WATCH="${OVERSEE_WATCH_PR_WATCH:-$SKILLS_DIR/review-gate/scripts/pr-watch.sh}"
 TRACKER="${OVERSEE_WATCH_TRACKER:-$SKILLS_DIR/linear/scripts/linear.sh}"
 WORKFLOW_STATE="${OVERSEE_WATCH_WORKFLOW_STATE:-$SCRIPT_DIR/workflow-state}"
@@ -290,9 +292,8 @@ LANE_ASKING_RE='(❯|›) [0-9]+\. |Do you want to|Enter to select|Esc to cancel
 # prints "Usage limit reached" and its out-of-credits wording. `.` stands in
 # for the apostrophe: ASCII in the binaries, typographic once rendered.
 USAGE_LIMIT_RE='You.(ve|re) (hit|reached) your [a-z ]*limit|[Uu]sage limit reached|hit usage limits|out of (usage )?credits|/usage-credits'
-# A turn in flight: the interrupt hint (both harnesses), the hint shown while
-# a foreground shell runs, or the streaming token counter of the status line.
-WORKING_RE='to interrupt|to run in background|↓ [0-9][0-9.]*[kKmM]? tokens'
+# A turn in flight is WORKING_RE, in lib/pane-working.sh: open-terminal reads
+# the same question off a launching pane, and one answer serves both.
 # The marker each harness draws at column 0 for a submitted user message
 # echoed into the transcript AND for the composer the lane sits at: Claude
 # Code `❯`, Codex `›`. Spelled as an alternation of literals and NEVER as a

--- a/.agents/skills/orch/tests/open-terminal-claude-handoff.sh
+++ b/.agents/skills/orch/tests/open-terminal-claude-handoff.sh
@@ -152,9 +152,11 @@ OT_UNDER_TEST="$OT"
 #              it from `delivered` is the non-breaking space after the caret.
 #              Not somewhere to type either: the composer is OCCUPIED, and
 #              `send-keys -l` would append a second copy of the brief
-#   plain      the brief submitted into the transcript, over a ready composer,
-#              with no response marker anywhere: UNDELIVERED on the activity
-#              requirement alone
+#   earlyturn  a turn in its FIRST FRAMES: the brief submitted into the
+#              transcript, a spinner frame this script deliberately does not
+#              read, no token counter yet, and the composer already empty
+#              again. LAUNCHED — and the screen that must never be typed into,
+#              since readiness alone would send a second brief into the turn
 #   working    a turn in flight: the verb, the elapsed time and the streaming
 #              token counter the harness draws only while one runs. The brief
 #              is nowhere but the echoed launch command, the screen a long
@@ -178,7 +180,7 @@ screen() {
     echo) printf '%s\n' "\$ claude -n CC-737 --dangerously-skip-permissions '$BRIEF'" '● Reading workflows/start.md' '╭─ Enable browser integration? ─╮' '> ' ;;
     delivered) printf '%s\n' "$CARET $BRIEF" '● Reading workflows/start.md' ;;
     composer) printf '%s\n' '● Reading workflows/start.md' '╭──────────────────────────────────────────╮' "│ > $BRIEF │" '╰──────────────────────────────────────────╯' '  ? for shortcuts' ;;
-    plain) printf '%s\n' "$CARET $BRIEF" "$RULE" "$CARET$NBSP" "$RULE" "$STATUS" ;;
+    earlyturn) printf '%s\n' "$CARET $BRIEF" '✶ Orchestrating…' "$RULE" "$CARET$NBSP" "$RULE" "$STATUS" ;;
     draft) printf '%s\n' '● Reading workflows/start.md' "$RULE" "$CARET$NBSP$BRIEF" "$RULE" "$STATUS" ;;
     working) printf '%s\n' "\$ claude -n CC-737 '$BRIEF'" '✻ Orchestrating… (3s · ↓ 79 tokens · thinking with high effort)' ;;
     signin) printf '%s\n' '  Select login method' '✻ Opening browser to sign in…' ;;
@@ -389,7 +391,7 @@ launch_table \
   "a composer that stays occupied is a failed lane, and never has a second brief typed into it|tmux|-|-|draft|rc=1 stderr~never+reached+a+ready+composer=true resends=0" \
   "a lane that comes up on the very last nudge is seen, not reported stuck|tmux|-|-|echo,echo,delivered|rc=0 out~Confirmed+'CC-737'+launched=true resends=0 enters=2" \
   "an older TUI's shortcuts footer is still read as ready|tmux|-|-|echo,ready-legacy,delivered|rc=0 out~Re-delivered+brief+to+'CC-737'=true resends=1" \
-  "the brief on a transcript line with no response begun is not delivery either|tmux|-|-|plain|rc=1 stderr~brief+undelivered+to+'CC-737'=true resends=1" \
+  "a turn in its first frames is launched and never typed into, before any counter or marker shows|tmux|-|-|earlyturn|rc=0 out~Done:+launched+1=true resends=0 enters=1" \
   "a turn in flight is a launched lane whatever its transcript line reads as: no re-send|tmux|-|-|working|rc=0 out~Done:+launched+1=true resends=0 enters=1" \
   "a lane that starts working while the launcher waits for a composer ends the wait launched, nothing typed into it|tmux|-|-|echo,working|rc=0 out~Confirmed+'CC-737'+launched=true resends=0 enters=1" \
   "a composer that never becomes ready is a failed lane, named as stuck|tmux|-|-|echo,echo|rc=1 stderr~never+reached+a+ready+composer=true out~Done:+launched+1=false" \
@@ -438,6 +440,13 @@ launch_table \
 mutant last-pass-blind open-terminal 's@^    screen="$(tmux capture-pane -pJ -t "$pane" 2>/dev/null)" || return 1$@    (( waited < TMUX_VERIFY_SECS )) || return 1; screen="$(tmux capture-pane -pJ -t "$pane" 2>/dev/null)" || return 1@;/^    (( waited < TMUX_VERIFY_SECS )) || return 1$/d' 'the read-before-budget order'
 launch_table \
   "control: deciding before the capture reports a lane that came up on the last nudge as stuck|tmux|-|-|echo,echo,delivered|rc=1 stderr~never+reached+a+ready+composer=true"
+# Require a transcript-activity marker on top of the brief and the first
+# frames of a turn read as an idle, ready composer: the counter is not drawn
+# yet, the spinner frame is one this script does not read, and the composer is
+# already empty — so a second brief goes into the turn.
+mutant activity-required open-terminal 's@^  \[\[ "$filtered" == \*"$brief"\* \]\]$@  [[ "$filtered" == *"$brief"* ]] || return 1; [[ "$screen" == *"\xe2\x97\x8f"* ]]@' 'the delivery read'
+launch_table \
+  "control: with a marker required on top, a turn in its first frames takes a second brief|tmux|-|-|earlyturn|resends=1"
 unmutate
 
 echo "=== open-terminal claude handoff: the verify timeout ==="

--- a/.agents/skills/orch/tests/open-terminal-claude-handoff.sh
+++ b/.agents/skills/orch/tests/open-terminal-claude-handoff.sh
@@ -12,10 +12,13 @@
 #
 # 2. The brief (initial '/orch start …' prompt) rides as a CLI arg; first-run
 #    dialogs (theme/trust/browser-integration) consume it, leaving a healthy
-#    TUI at an EMPTY composer. The tmux path must verify delivery by
-#    re-capturing the pane (the brief visible on a line other than the echoed
-#    launch command), re-send the brief once if absent, and emit a per-lane
-#    failure + nonzero exit if still absent.
+#    TUI at an EMPTY composer. The tmux path must verify the launch took by
+#    re-capturing the pane — the brief delivered (on a line other than the
+#    echoed launch command, with a response begun), or a turn in flight —
+#    re-send the brief once if neither shows, and emit a per-lane failure +
+#    nonzero exit if it still does not. A pane running a turn is a launched
+#    lane, reported as launched and never typed into. A first-run dialog is
+#    not, and animating a spinner does not make it one.
 #
 # The test runs a byte-identical copy of open-terminal inside a temp git repo
 # so `git rev-parse --show-toplevel` resolves to a hermetic PROJECT_ROOT, and
@@ -119,6 +122,9 @@ cp "$SRC_LIB_DIR"/*.sh "$REPO/scripts/lib/"
 chmod +x "$REPO/scripts/open-terminal"
 git -C "$REPO" init -q
 OT="$REPO/scripts/open-terminal"
+# Every row runs whatever binary this names; `mutant` repoints it at a copy
+# with the working predicate rewritten, and `unmutate` puts it back.
+OT_UNDER_TEST="$OT"
 
 # screen NAME — prints one pane capture, by name.
 #   echo       the brief appears ONLY inside the echoed launch command, which
@@ -133,6 +139,16 @@ OT="$REPO/scripts/open-terminal"
 #              on the composer-box filter alone
 #   plain      the brief on a plain transcript line with no response marker
 #              anywhere: UNDELIVERED on the activity requirement alone
+#   working    a turn in flight: the verb, the elapsed time and the streaming
+#              token counter the harness draws only while one runs. The brief
+#              is nowhere but the echoed launch command, the screen a long
+#              brief leaves once the TUI has redrawn its transcript line
+#              beyond recognition. LAUNCHED
+#   signin     a first-run sign-in step, animating the same spinner frame a
+#              running turn does and carrying no token counter, no interrupt
+#              hint, no brief and no composer. STUCK: the launcher's failure
+#              exit is what this pane needs, and a predicate keyed on the
+#              spinner would call it launched
 #   ready      the main TUI at a ready, EMPTY composer (the '? for shortcuts'
 #              footer is the readiness marker), where a re-send must land
 #   huge       delivered, then a pane larger than a pipe buffer: a
@@ -144,6 +160,8 @@ screen() {
     delivered) printf '%s\n' "> $BRIEF" '● Reading workflows/start.md' ;;
     composer) printf '%s\n' '● Reading workflows/start.md' '╭──────────────────────────────────────────╮' "│ > $BRIEF │" '╰──────────────────────────────────────────╯' '  ? for shortcuts' ;;
     plain) printf '%s\n' "> $BRIEF" '  ? for shortcuts' ;;
+    working) printf '%s\n' "\$ claude -n CC-737 '$BRIEF'" '✻ Orchestrating… (3s · ↓ 79 tokens · thinking with high effort)' ;;
+    signin) printf '%s\n' '  Select login method' '✻ Opening browser to sign in…' ;;
     ready) printf '%s\n' '╭──────────────────────────────────────────╮' '│ >                                         │' '╰──────────────────────────────────────────╯' '  ? for shortcuts' ;;
     huge) screen delivered; awk 'BEGIN { for (i = 0; i < 20000; i++) print "transcript filler line" }' ;;
     *) echo "screen: unknown capture $1" >&2; exit 1 ;;
@@ -189,7 +207,7 @@ run() {
   [[ "$flags" == - ]] || args+=(--launch-flags "$flags")
   if [[ "$mode" == github ]]; then args+=(42); else args+=(cc-737); fi
   set +e
-  OUT=$(env ${envs[@]+"${envs[@]}"} OT_CAPTURE="$CAP" PATH="$BIN:$PATH" WORKTREE_CLI="$STUB" "$OT" "${args[@]}" 2>"$ERR")
+  OUT=$(env ${envs[@]+"${envs[@]}"} OT_CAPTURE="$CAP" PATH="$BIN:$PATH" WORKTREE_CLI="$STUB" "$OT_UNDER_TEST" "${args[@]}" 2>"$ERR")
   RC=$?
   set -e
 }
@@ -242,6 +260,33 @@ observe() {
   set +f
   printf '%s' "${got# }"
 }
+
+# mutant NAME SED — stage open-terminal against a copy of lib/pane-working.sh
+# with SED applied, in a git repo of its own so PROJECT_ROOT still resolves
+# hermetically, and point every following row at it. `pane_working` is what
+# both controls rewrite, and it lives in that lib rather than in the script.
+# The copy is proven to differ from the original first, so a mutation whose
+# anchor moved cannot pass as a silent no-op.
+mutant() {
+  local name="$1" expr="$2" dir lib
+  dir="$TMP_ROOT/mutants/$name"
+  lib="$dir/scripts/lib/pane-working.sh"
+  mkdir -p "$dir/scripts/lib"
+  cp "$SRC_OT" "$dir/scripts/open-terminal"
+  cp "$SRC_LIB_DIR"/*.sh "$dir/scripts/lib/"
+  sed "$expr" "$SRC_LIB_DIR/pane-working.sh" > "$lib"
+  if cmp -s "$SRC_LIB_DIR/pane-working.sh" "$lib"; then
+    FAIL=$((FAIL + 1))
+    printf '  FAIL  control: the %s mutant is byte-identical to pane-working.sh\n' "$name"
+  else
+    pass "control: the $name mutant really rewrites pane_working"
+  fi
+  chmod +x "$dir/scripts/open-terminal"
+  git -C "$dir" init -q
+  OT_UNDER_TEST="$dir/scripts/open-terminal"
+}
+
+unmutate() { OT_UNDER_TEST="$OT"; }
 
 # launch_table ROW... — `label|mode|env|flags|screens|expect`, one launch and
 # one assertion per row.
@@ -300,7 +345,11 @@ echo "=== open-terminal claude handoff: tmux brief delivery ==="
 # The brief visible in the transcript on the first verification pass is
 # delivery: no re-send, and the capture includes scrollback (-S -), since a
 # fast response scrolling the prompt out of the viewport must not read as
-# undelivered. The brief only inside the echoed launch command is what a
+# undelivered. A turn in flight is the other, independent proof, whether it
+# was running from the first pass or starts while the launcher waits for a
+# composer: launched, no re-send, and no further keystroke into a session that
+# would take it mid-turn. A first-run dialog is not a turn, however it
+# animates. The brief only inside the echoed launch command is what a
 # dialog leaves: the launcher waits for a ready composer, sending one
 # dismissing Enter per dialog pass, types the brief once after readiness
 # (bare Enters: one at launch, one per dialog nudge, one submitting the
@@ -317,10 +366,31 @@ launch_table \
   "the echoed command alone is not delivery: one re-send, then a loud per-lane failure|tmux|-|-|echo,ready,ready|rc=1 stderr~brief+undelivered+to+'CC-737'=true stderr~handoff+lane(s)+failed=true out~Done:+launched+1=false resends=1" \
   "unsent composer text is not delivery: one re-send, then the failure|tmux|-|-|composer|rc=1 stderr~brief+undelivered+to+'CC-737'=true resends=1" \
   "the brief on a transcript line with no response begun is not delivery either|tmux|-|-|plain|rc=1 stderr~brief+undelivered+to+'CC-737'=true resends=1" \
+  "a turn in flight is a launched lane whatever its transcript line reads as: no re-send|tmux|-|-|working|rc=0 out~Done:+launched+1=true resends=0 enters=1" \
+  "a lane that starts working while the launcher waits for a composer ends the wait launched, nothing typed into it|tmux|-|-|echo,working|rc=0 out~already+working=true resends=0 enters=1" \
   "a composer that never becomes ready is a failed lane, named as stuck|tmux|-|-|echo,echo|rc=1 stderr~never+reached+a+ready+composer=true out~Done:+launched+1=false" \
+  "a sign-in step animating a spinner is still a stuck lane, not a working one|tmux|-|-|signin|rc=1 stderr~never+reached+a+ready+composer=true out~Done:+launched+1=false" \
   "a huge scrollback with the delivered brief near its start is delivery: no duplicate brief|tmux|-|-|huge|rc=0 resends=0" \
   "a window that was never created is a failed lane, not a launched one|tmux|OT_TMUX_FAIL=new-window|-|delivered|rc=1 stderr~new-window+failed=true stderr~handoff+lane(s)+failed=true out~Done:+launched+1=false" \
   "launch keystrokes failing on a briefless lane is a failed lane too|tmux-codex|OT_TMUX_FAIL=send-keys|-|-|rc=1 stderr~send-keys+failed+launching=true out~Done:+launched+1=false"
+
+echo "=== the turn-in-flight reading can fail, both ways ==="
+# `pane_working` is the whole of it, so it is the mutation both controls take.
+# Cut it to always-false and the two working rows go back to the false alarm
+# this closed: a healthy mid-turn lane reported as a stuck composer, exit 1.
+mutant working-blind 's/^pane_working() {/pane_working() { return 1;/'
+launch_table \
+  "control: with the turn reading gone, a turn in flight fails as a stuck composer|tmux|-|-|working|rc=1 stderr~never+reached+a+ready+composer=true out~Done:+launched+1=false" \
+  "control: and so does a lane that starts working during the composer wait|tmux|-|-|echo,working|rc=1 stderr~never+reached+a+ready+composer=true"
+# Widen it to the spinner frames — the shape this fix was first written with —
+# and the failure exit stops covering the pane it is for: Claude Code animates
+# one frame set across every long-running screen, sign-in included, so the
+# stuck lane above reports launched and an unattended login prompt is called a
+# success.
+mutant working-spinner "s/^pane_working() {/pane_working() { grep -q '\xe2\x9c\xbb' <<<\"\$1\" \&\& return 0;/"
+launch_table \
+  "control: keyed on the spinner instead, the sign-in step reports launched|tmux|-|-|signin|rc=0 out~Done:+launched+1=true stderr~never+reached+a+ready+composer=false"
+unmutate
 
 echo "=== open-terminal claude handoff: the verify timeout ==="
 # ORCH_TMUX_VERIFY_SECS is validated where it is read, and only there: a

--- a/.agents/skills/orch/tests/open-terminal-claude-handoff.sh
+++ b/.agents/skills/orch/tests/open-terminal-claude-handoff.sh
@@ -43,6 +43,15 @@ source "$TEST_DIR/lib/waiter-assertions.sh"
 TMP_ROOT="$(cd "$(mktemp -d)" && pwd -P)"
 trap 'rm -rf "$TMP_ROOT"' EXIT
 
+# The composer's prompt marker is `❯` followed by a NON-BREAKING space; a
+# SUBMITTED message is echoed into the transcript as `❯` followed by an
+# ordinary one. That invisible character is the whole discriminator between a
+# draft the operator is still typing and a prompt the TUI accepted, so both are
+# spelled here as escapes rather than typed into the fixture.
+NBSP=$'\xc2\xa0'
+CARET=$'\xe2\x9d\xaf'
+STATUS='  realwd Opus 5 (VG)                    /rc'
+RULE='────────────────────────────────────────'
 BRIEF='/orch start CC-737'
 BRIEFN='/orch+start+CC-737'   # the brief as a needle: `+` reads as a space
 RESEND="send-keys -t %7 -l $BRIEF"
@@ -133,12 +142,17 @@ OT_UNDER_TEST="$OT"
 #              delivery on the launch-line filter alone
 #   delivered  the brief on its own transcript line, distinct from the echoed
 #              launch command, and the response begun (● transcript marker)
-#   composer   the brief sitting UNSENT in the composer's │-bordered input
-#              box: delivery means SUBMITTED, so this is UNDELIVERED. Its
+#   composer   the brief sitting UNSENT in the │-bordered input box an older
+#              TUI drew: delivery means SUBMITTED, so this is UNDELIVERED. Its
 #              response marker is deliberate too: this screen fails delivery
 #              on the composer-box filter alone
-#   plain      the brief on a plain transcript line with no response marker
-#              anywhere: UNDELIVERED on the activity requirement alone
+#   draft      the same, in the shape v2.1.261 actually draws: two rules
+#              around the prompt line, no │ anywhere, and a status bar that
+#              already carries ●. UNDELIVERED, and the only thing separating
+#              it from `delivered` is the non-breaking space after the caret
+#   plain      the brief submitted into the transcript, over a ready composer,
+#              with no response marker anywhere: UNDELIVERED on the activity
+#              requirement alone
 #   working    a turn in flight: the verb, the elapsed time and the streaming
 #              token counter the harness draws only while one runs. The brief
 #              is nowhere but the echoed launch command, the screen a long
@@ -149,20 +163,25 @@ OT_UNDER_TEST="$OT"
 #              hint, no brief and no composer. STUCK: the launcher's failure
 #              exit is what this pane needs, and a predicate keyed on the
 #              spinner would call it launched
-#   ready      the main TUI at a ready, EMPTY composer (the '? for shortcuts'
-#              footer is the readiness marker), where a re-send must land
+#   ready      the main TUI at a ready, EMPTY composer in the shape v2.1.261
+#              draws it, where a re-send must land. Its readiness marker is
+#              the composer's own prompt line: the '? for shortcuts' footer
+#              appeared on 0 of 146 captures of that build
+#   ready-legacy  the same state as an older TUI drew it, on the footer alone
 #   huge       delivered, then a pane larger than a pipe buffer: a
 #              short-circuiting scan would SIGPIPE its upstream under pipefail
 #              and misread the submitted prompt as missing
 screen() {
   case "$1" in
     echo) printf '%s\n' "\$ claude -n CC-737 --dangerously-skip-permissions '$BRIEF'" '● Reading workflows/start.md' '╭─ Enable browser integration? ─╮' '> ' ;;
-    delivered) printf '%s\n' "> $BRIEF" '● Reading workflows/start.md' ;;
+    delivered) printf '%s\n' "$CARET $BRIEF" '● Reading workflows/start.md' ;;
     composer) printf '%s\n' '● Reading workflows/start.md' '╭──────────────────────────────────────────╮' "│ > $BRIEF │" '╰──────────────────────────────────────────╯' '  ? for shortcuts' ;;
-    plain) printf '%s\n' "> $BRIEF" '  ? for shortcuts' ;;
+    plain) printf '%s\n' "$CARET $BRIEF" "$RULE" "$CARET$NBSP" "$RULE" "$STATUS" ;;
+    draft) printf '%s\n' '● Reading workflows/start.md' "$RULE" "$CARET$NBSP$BRIEF" "$RULE" "$STATUS" ;;
     working) printf '%s\n' "\$ claude -n CC-737 '$BRIEF'" '✻ Orchestrating… (3s · ↓ 79 tokens · thinking with high effort)' ;;
     signin) printf '%s\n' '  Select login method' '✻ Opening browser to sign in…' ;;
-    ready) printf '%s\n' '╭──────────────────────────────────────────╮' '│ >                                         │' '╰──────────────────────────────────────────╯' '  ? for shortcuts' ;;
+    ready) printf '%s\n' "$RULE" "$CARET$NBSP" "$RULE" "$STATUS" ;;
+    ready-legacy) printf '%s\n' '╭──────────────────────────────────────────╮' '│ >                                         │' '╰──────────────────────────────────────────╯' '  ? for shortcuts' ;;
     huge) screen delivered; awk 'BEGIN { for (i = 0; i < 20000; i++) print "transcript filler line" }' ;;
     *) echo "screen: unknown capture $1" >&2; exit 1 ;;
   esac
@@ -261,25 +280,24 @@ observe() {
   printf '%s' "${got# }"
 }
 
-# mutant NAME SED — stage open-terminal against a copy of lib/pane-working.sh
-# with SED applied, in a git repo of its own so PROJECT_ROOT still resolves
-# hermetically, and point every following row at it. `pane_working` is what
-# both controls rewrite, and it lives in that lib rather than in the script.
-# The copy is proven to differ from the original first, so a mutation whose
-# anchor moved cannot pass as a silent no-op.
+# mutant NAME FILE SED WHAT — stage open-terminal and its libs in a git repo of
+# its own, so PROJECT_ROOT still resolves hermetically, with SED applied to
+# FILE (a path under scripts/), and point every following row at it. The copy
+# is proven to differ from the original first, so a mutation whose anchor moved
+# cannot pass as a silent no-op.
 mutant() {
-  local name="$1" expr="$2" dir lib
+  local name="$1" file="$2" expr="$3" what="$4" dir src
   dir="$TMP_ROOT/mutants/$name"
-  lib="$dir/scripts/lib/pane-working.sh"
+  src="$SCRIPTS_DIR/$file"
   mkdir -p "$dir/scripts/lib"
   cp "$SRC_OT" "$dir/scripts/open-terminal"
   cp "$SRC_LIB_DIR"/*.sh "$dir/scripts/lib/"
-  sed "$expr" "$SRC_LIB_DIR/pane-working.sh" > "$lib"
-  if cmp -s "$SRC_LIB_DIR/pane-working.sh" "$lib"; then
+  sed "$expr" "$src" > "$dir/scripts/$file"
+  if cmp -s "$src" "$dir/scripts/$file"; then
     FAIL=$((FAIL + 1))
-    printf '  FAIL  control: the %s mutant is byte-identical to pane-working.sh\n' "$name"
+    printf '  FAIL  control: the %s mutant is byte-identical to %s\n' "$name" "$file"
   else
-    pass "control: the $name mutant really rewrites pane_working"
+    pass "control: the $name mutant really rewrites $what"
   fi
   chmod +x "$dir/scripts/open-terminal"
   git -C "$dir" init -q
@@ -365,6 +383,8 @@ launch_table \
   "two dialog passes before readiness: one dismissing Enter per pass, the brief typed once after|tmux|ORCH_TMUX_VERIFY_SECS=3|-|echo,echo,echo,echo,echo,ready,delivered|rc=0 out~Re-delivered+brief+to+'CC-737'=true enters=4 resends=1" \
   "the echoed command alone is not delivery: one re-send, then a loud per-lane failure|tmux|-|-|echo,ready,ready|rc=1 stderr~brief+undelivered+to+'CC-737'=true stderr~handoff+lane(s)+failed=true out~Done:+launched+1=false resends=1" \
   "unsent composer text is not delivery: one re-send, then the failure|tmux|-|-|composer|rc=1 stderr~brief+undelivered+to+'CC-737'=true resends=1" \
+  "a draft in the composer the harness actually draws is not delivery either: one re-send, then the failure|tmux|-|-|draft|rc=1 stderr~brief+undelivered+to+'CC-737'=true resends=1" \
+  "an older TUI's shortcuts footer is still read as ready|tmux|-|-|echo,ready-legacy,delivered|rc=0 out~Re-delivered+brief+to+'CC-737'=true resends=1" \
   "the brief on a transcript line with no response begun is not delivery either|tmux|-|-|plain|rc=1 stderr~brief+undelivered+to+'CC-737'=true resends=1" \
   "a turn in flight is a launched lane whatever its transcript line reads as: no re-send|tmux|-|-|working|rc=0 out~Done:+launched+1=true resends=0 enters=1" \
   "a lane that starts working while the launcher waits for a composer ends the wait launched, nothing typed into it|tmux|-|-|echo,working|rc=0 out~already+working=true resends=0 enters=1" \
@@ -378,7 +398,7 @@ echo "=== the turn-in-flight reading can fail, both ways ==="
 # `pane_working` is the whole of it, so it is the mutation both controls take.
 # Cut it to always-false and the two working rows go back to the false alarm
 # this closed: a healthy mid-turn lane reported as a stuck composer, exit 1.
-mutant working-blind 's/^pane_working() {/pane_working() { return 1;/'
+mutant working-blind lib/pane-working.sh 's/^pane_working() {/pane_working() { return 1;/' pane_working
 launch_table \
   "control: with the turn reading gone, a turn in flight fails as a stuck composer|tmux|-|-|working|rc=1 stderr~never+reached+a+ready+composer=true out~Done:+launched+1=false" \
   "control: and so does a lane that starts working during the composer wait|tmux|-|-|echo,working|rc=1 stderr~never+reached+a+ready+composer=true"
@@ -387,9 +407,22 @@ launch_table \
 # one frame set across every long-running screen, sign-in included, so the
 # stuck lane above reports launched and an unattended login prompt is called a
 # success.
-mutant working-spinner "s/^pane_working() {/pane_working() { grep -q '\xe2\x9c\xbb' <<<\"\$1\" \&\& return 0;/"
+mutant working-spinner lib/pane-working.sh "s/^pane_working() {/pane_working() { grep -q '\xe2\x9c\xbb' <<<\"\$1\" \&\& return 0;/" pane_working
 launch_table \
   "control: keyed on the spinner instead, the sign-in step reports launched|tmux|-|-|signin|rc=0 out~Done:+launched+1=true stderr~never+reached+a+ready+composer=false"
+# The composer read can fail the same two ways. Drop the composer filter and
+# the draft above passes as a submitted prompt: the │ the old filter looks for
+# is on none of the 146 captures of v2.1.261, so nothing else stands between a
+# half-typed brief and a lane called launched.
+mutant composer-blind open-terminal 's/ | grep -Ev -- "\$COMPOSER_RE"//' 'the composer filter'
+launch_table \
+  "control: without the composer filter, a draft the operator is still typing reports launched|tmux|-|-|draft|rc=0 out~Done:+launched+1=true resends=0"
+# Key readiness on the old footer alone and the re-send path goes unreachable:
+# v2.1.261 never draws it, so a dialog that ate the brief can only ever reach
+# the failure exit, never the recovery the launcher exists to perform.
+mutant ready-legacy-only open-terminal 's/^READY_RE=.*/READY_RE="\\? for shortcuts"/' 'the readiness marker'
+launch_table \
+  "control: keyed on the old footer alone, a dialog that ate the brief can never be recovered|tmux|-|-|echo,ready,delivered|rc=1 stderr~never+reached+a+ready+composer=true resends=0"
 unmutate
 
 echo "=== open-terminal claude handoff: the verify timeout ==="

--- a/.agents/skills/orch/tests/open-terminal-claude-handoff.sh
+++ b/.agents/skills/orch/tests/open-terminal-claude-handoff.sh
@@ -149,7 +149,9 @@ OT_UNDER_TEST="$OT"
 #   draft      the same, in the shape v2.1.261 actually draws: two rules
 #              around the prompt line, no │ anywhere, and a status bar that
 #              already carries ●. UNDELIVERED, and the only thing separating
-#              it from `delivered` is the non-breaking space after the caret
+#              it from `delivered` is the non-breaking space after the caret.
+#              Not somewhere to type either: the composer is OCCUPIED, and
+#              `send-keys -l` would append a second copy of the brief
 #   plain      the brief submitted into the transcript, over a ready composer,
 #              with no response marker anywhere: UNDELIVERED on the activity
 #              requirement alone
@@ -383,7 +385,8 @@ launch_table \
   "two dialog passes before readiness: one dismissing Enter per pass, the brief typed once after|tmux|ORCH_TMUX_VERIFY_SECS=3|-|echo,echo,echo,echo,echo,ready,delivered|rc=0 out~Re-delivered+brief+to+'CC-737'=true enters=4 resends=1" \
   "the echoed command alone is not delivery: one re-send, then a loud per-lane failure|tmux|-|-|echo,ready,ready|rc=1 stderr~brief+undelivered+to+'CC-737'=true stderr~handoff+lane(s)+failed=true out~Done:+launched+1=false resends=1" \
   "unsent composer text is not delivery: one re-send, then the failure|tmux|-|-|composer|rc=1 stderr~brief+undelivered+to+'CC-737'=true resends=1" \
-  "a draft in the composer the harness actually draws is not delivery either: one re-send, then the failure|tmux|-|-|draft|rc=1 stderr~brief+undelivered+to+'CC-737'=true resends=1" \
+  "a brief left sitting in the composer is submitted by the nudge, not typed a second time|tmux|ORCH_TMUX_VERIFY_SECS=2|-|draft,draft,draft,delivered|rc=0 out~Done:+launched+1=true resends=0 enters=2" \
+  "a composer that stays occupied is a failed lane, and never has a second brief typed into it|tmux|-|-|draft|rc=1 stderr~never+reached+a+ready+composer=true resends=0" \
   "an older TUI's shortcuts footer is still read as ready|tmux|-|-|echo,ready-legacy,delivered|rc=0 out~Re-delivered+brief+to+'CC-737'=true resends=1" \
   "the brief on a transcript line with no response begun is not delivery either|tmux|-|-|plain|rc=1 stderr~brief+undelivered+to+'CC-737'=true resends=1" \
   "a turn in flight is a launched lane whatever its transcript line reads as: no re-send|tmux|-|-|working|rc=0 out~Done:+launched+1=true resends=0 enters=1" \
@@ -423,6 +426,12 @@ launch_table \
 mutant ready-legacy-only open-terminal 's/^READY_RE=.*/READY_RE="\\? for shortcuts"/' 'the readiness marker'
 launch_table \
   "control: keyed on the old footer alone, a dialog that ate the brief can never be recovered|tmux|-|-|echo,ready,delivered|rc=1 stderr~never+reached+a+ready+composer=true resends=0"
+# Readiness that does not insist on an EMPTY composer types into an occupied
+# one, and `send-keys -l` appends: the lane is handed
+# `/orch start CC-737/orch start CC-737` and submits it.
+mutant ready-occupied open-terminal 's/^READY_RE=.*/READY_RE="$COMPOSER_RE"/' 'the empty-composer requirement'
+launch_table \
+  "control: readiness without the empty test types a second brief into an occupied composer|tmux|-|-|draft|resends=1"
 unmutate
 
 echo "=== open-terminal claude handoff: the verify timeout ==="

--- a/.agents/skills/orch/tests/open-terminal-claude-handoff.sh
+++ b/.agents/skills/orch/tests/open-terminal-claude-handoff.sh
@@ -387,10 +387,11 @@ launch_table \
   "unsent composer text is not delivery: one re-send, then the failure|tmux|-|-|composer|rc=1 stderr~brief+undelivered+to+'CC-737'=true resends=1" \
   "a brief left sitting in the composer is submitted by the nudge, not typed a second time|tmux|ORCH_TMUX_VERIFY_SECS=2|-|draft,draft,draft,delivered|rc=0 out~Done:+launched+1=true resends=0 enters=2" \
   "a composer that stays occupied is a failed lane, and never has a second brief typed into it|tmux|-|-|draft|rc=1 stderr~never+reached+a+ready+composer=true resends=0" \
+  "a lane that comes up on the very last nudge is seen, not reported stuck|tmux|-|-|echo,echo,delivered|rc=0 out~Confirmed+'CC-737'+launched=true resends=0 enters=2" \
   "an older TUI's shortcuts footer is still read as ready|tmux|-|-|echo,ready-legacy,delivered|rc=0 out~Re-delivered+brief+to+'CC-737'=true resends=1" \
   "the brief on a transcript line with no response begun is not delivery either|tmux|-|-|plain|rc=1 stderr~brief+undelivered+to+'CC-737'=true resends=1" \
   "a turn in flight is a launched lane whatever its transcript line reads as: no re-send|tmux|-|-|working|rc=0 out~Done:+launched+1=true resends=0 enters=1" \
-  "a lane that starts working while the launcher waits for a composer ends the wait launched, nothing typed into it|tmux|-|-|echo,working|rc=0 out~already+working=true resends=0 enters=1" \
+  "a lane that starts working while the launcher waits for a composer ends the wait launched, nothing typed into it|tmux|-|-|echo,working|rc=0 out~Confirmed+'CC-737'+launched=true resends=0 enters=1" \
   "a composer that never becomes ready is a failed lane, named as stuck|tmux|-|-|echo,echo|rc=1 stderr~never+reached+a+ready+composer=true out~Done:+launched+1=false" \
   "a sign-in step animating a spinner is still a stuck lane, not a working one|tmux|-|-|signin|rc=1 stderr~never+reached+a+ready+composer=true out~Done:+launched+1=false" \
   "a huge scrollback with the delivered brief near its start is delivery: no duplicate brief|tmux|-|-|huge|rc=0 resends=0" \
@@ -425,13 +426,18 @@ launch_table \
 # the failure exit, never the recovery the launcher exists to perform.
 mutant ready-legacy-only open-terminal 's/^READY_RE=.*/READY_RE="\\? for shortcuts"/' 'the readiness marker'
 launch_table \
-  "control: keyed on the old footer alone, a dialog that ate the brief can never be recovered|tmux|-|-|echo,ready,delivered|rc=1 stderr~never+reached+a+ready+composer=true resends=0"
+  "control: keyed on the old footer alone, a dialog that ate the brief can never be recovered|tmux|-|-|echo,ready,ready|rc=1 stderr~never+reached+a+ready+composer=true resends=0"
 # Readiness that does not insist on an EMPTY composer types into an occupied
 # one, and `send-keys -l` appends: the lane is handed
 # `/orch start CC-737/orch start CC-737` and submits it.
 mutant ready-occupied open-terminal 's/^READY_RE=.*/READY_RE="$COMPOSER_RE"/' 'the empty-composer requirement'
 launch_table \
   "control: readiness without the empty test types a second brief into an occupied composer|tmux|-|-|draft|resends=1"
+# Test the nudge budget BEFORE the capture and the last Enter's result is
+# never looked at: the lane that came up on it is reported stuck.
+mutant last-pass-blind open-terminal 's@^    screen="$(tmux capture-pane -pJ -t "$pane" 2>/dev/null)" || return 1$@    (( waited < TMUX_VERIFY_SECS )) || return 1; screen="$(tmux capture-pane -pJ -t "$pane" 2>/dev/null)" || return 1@;/^    (( waited < TMUX_VERIFY_SECS )) || return 1$/d' 'the read-before-budget order'
+launch_table \
+  "control: deciding before the capture reports a lane that came up on the last nudge as stuck|tmux|-|-|echo,echo,delivered|rc=1 stderr~never+reached+a+ready+composer=true"
 unmutate
 
 echo "=== open-terminal claude handoff: the verify timeout ==="

--- a/skills/orch/scripts/lib/pane-working.sh
+++ b/skills/orch/scripts/lib/pane-working.sh
@@ -1,0 +1,27 @@
+# shellcheck shell=bash
+#
+# The one answer to "is this pane's harness running a turn right now", shared
+# by every script that has to tell a working lane from a parked one.
+#
+# Sourced, never run.
+
+# A turn in flight: the interrupt hint (both harnesses), the hint shown while
+# a foreground shell runs, or the streaming token counter of the status line.
+# Measured off running sessions of both harnesses.
+#
+# Deliberately NOT a spinner glyph. Claude Code animates one frame set
+# (`· ✢ * ✶ ✻ ✽`) across every long-running screen, its OAuth sign-in
+# included, so a spinner reads a lane parked at a login prompt as working;
+# `·` is also its separator character and `*` is in its startup banner. `✻`
+# additionally spells the idle end-of-turn line (`✻ Churned for 6s · done`),
+# so it survives the turn that drew it exactly as `●` does. The token counter
+# and the interrupt hint are drawn only while a turn is actually running.
+#
+# The counter appears a second or two INTO a turn, after streaming starts, so
+# a turn caught in its first moments reads as not working. Callers that poll
+# see it on a later pass; callers that must not act on a false negative say so
+# where they read it.
+WORKING_RE='to interrupt|to run in background|↓ [0-9][0-9.]*[kKmM]? tokens'
+
+# pane_working SCREEN — the predicate over one captured pane.
+pane_working() { grep -Eq -- "$WORKING_RE" <<<"$1"; }

--- a/skills/orch/scripts/open-terminal
+++ b/skills/orch/scripts/open-terminal
@@ -402,11 +402,23 @@ start_cmd() {
 # ordinary space. oversee-watch's PANE_MARKER_RE deliberately conflates the
 # two; telling them apart is this script's question, not its.
 #
+# Readiness is the EMPTY composer, which is that line and nothing after it.
+# A composer still holding text is not somewhere to type: `send-keys -l`
+# APPENDS, so typing the brief into a composer that already holds one submits
+# `/orch start CC-737/orch start CC-737`. Its own dismissing Enter submits
+# what is there instead, which is the right recovery when what is there is the
+# brief the launch arrived with — the state this whole path exists for.
+# Measured on the same captures: the empty form is on 35 of 35 idle screens
+# and 57 of 57 mid-turn ones that draw a composer at all, and on 0 draft
+# screens.
+#
 # The older spelling of readiness, the `? for shortcuts` footer, is kept
 # alongside it: this is another tool's surface, and a lane may be running a
-# build that still draws it.
+# build that still draws it. That footer says nothing about whether the
+# composer under it is occupied, so the append above is still reachable on
+# such a build, exactly as it was before this marker existed.
 COMPOSER_RE=$'^\xe2\x9d\xaf\xc2\xa0'
-READY_RE="$COMPOSER_RE"'|\? for shortcuts'
+READY_RE="$COMPOSER_RE"'[[:blank:]]*$|\? for shortcuts'
 
 # The launch took. Two independent proofs, either sufficient.
 #
@@ -440,6 +452,12 @@ tmux_lane_launched() {
   # first poll, and a viewport-only capture would misread that as
   # undelivered and queue a duplicate brief into a running session.
   screen="$(tmux capture-pane -pJ -S - -t "$pane" 2>/dev/null)" || return 1
+  lane_launched "$screen" "$brief"
+}
+
+# The same question against a screen already in hand.
+lane_launched() { # SCREEN BRIEF
+  local screen="$1" brief="$2"
   pane_working "$screen" && return 0
   # No short-circuiting `grep -q` pipelines over the capture: with -S - a
   # retained pane can exceed a pipe buffer, an early -q match SIGPIPEs the
@@ -472,18 +490,21 @@ tmux_wait_launched() {
 # An Enter into an already-ready empty composer is a no-op, so the nudge is
 # safe when the screen is merely slow.
 #
-# A lane that starts working during the wait is the third state, and the one
-# the nudge must stop for: further keystrokes land inside a running turn. It
-# ends the wait as a launched lane rather than a stuck one. WORKING_RE reads
-# false for the first second or two of a turn, before streaming starts, so a
-# turn beginning inside the last passes can still take an Enter — harmless in
-# a Claude Code turn, which Enter does not interrupt, and the pass after it
-# stops.
+# A lane that BECOMES launched during the wait is the third state, and the one
+# the nudge must stop for: further keystrokes land inside a running turn, and
+# the brief is already where it needed to go. It ends the wait as a launched
+# lane rather than a stuck one. This is not only a turn starting late: a
+# dismissing Enter into a composer holding the brief SUBMITS it, which is the
+# recovery this path exists to perform, and re-typing the brief after that
+# would run it twice. WORKING_RE reads false for the first second or two of a
+# turn, before streaming starts, so a turn beginning inside the last passes can
+# still take an Enter — harmless in a Claude Code turn, which Enter does not
+# interrupt, and the pass after it stops.
 #   0  a ready, empty composer: re-send the brief
-#   2  a turn in flight: the launch took, send nothing more
+#   2  the launch took after all: send nothing more
 #   1  neither within the window: the stuck or dead pane the failure exit is for
 tmux_wait_composer() {
-  local pane="$1" waited=0 screen
+  local pane="$1" brief="$2" waited=0 screen
   while (( waited < TMUX_VERIFY_SECS )); do
     # VISIBLE viewport only (no -S -): readiness is a property of the
     # current screen — a footer buried in scrollback behind a first-run
@@ -494,7 +515,7 @@ tmux_wait_composer() {
     # the re-send below was unreachable — every consumed brief fell to the
     # failure exit.
     screen="$(tmux capture-pane -pJ -t "$pane" 2>/dev/null)" || return 1
-    pane_working "$screen" && return 2
+    lane_launched "$screen" "$brief" && return 2
     grep -Eq -- "$READY_RE" <<<"$screen" && return 0
     tmux send-keys -t "$pane" Enter || return 1
     sleep 1
@@ -569,7 +590,7 @@ open_tmux() {
   # has the same delivery requirement.
   tmux_wait_launched "$pane" "$brief" && return 0
   local composer_rc=0
-  tmux_wait_composer "$pane" || composer_rc=$?
+  tmux_wait_composer "$pane" "$brief" || composer_rc=$?
   if (( composer_rc == 2 )); then
     echo "'$title' is already working; the launch took (its brief never read as delivered)"
     return 0

--- a/skills/orch/scripts/open-terminal
+++ b/skills/orch/scripts/open-terminal
@@ -54,9 +54,10 @@ Options:
                     as another session's claim. A worktree under a lease held
                     by a different owner is still skipped.
 
-On tmux lanes the brief's delivery is verified against the pane and re-sent
+On tmux lanes the launch is verified against the pane and the brief re-sent
 once if a first-run dialog consumed it ($ORCH_TMUX_VERIFY_SECS per pass,
-default 15, positive integer clamped to 120).
+default 15, positive integer clamped to 120). A pane already running a turn
+counts as launched and is not typed into.
 
 Each item's worktree is created here (worktree create, or create --reuse
 under --relaunch when the item's tree already exists). An item whose worktree
@@ -156,6 +157,8 @@ source "$SCRIPT_DIR/lib/kendex-env.sh"
 kendex_load_project_env "$PROJECT_ROOT"
 # shellcheck source=lib/lane-claims.sh
 source "$SCRIPT_DIR/lib/lane-claims.sh"
+# shellcheck source=lib/pane-working.sh
+source "$SCRIPT_DIR/lib/pane-working.sh"
 WORKTREE_CLI="${WORKTREE_CLI:-$SKILLS_DIR/worktree/scripts/worktree}"
 LANES_CLI="${LANES_CLI:-$SCRIPT_DIR/lanes}"
 GH_ISSUE_PATTERN="${GH_ISSUE_PATTERN:-[A-Z]+-[0-9]+}"
@@ -384,21 +387,35 @@ start_cmd() {
   esac
 }
 
-# Delivered means SUBMITTED, not merely present: the brief echoed in the
-# launch command (`claude -n` line) or sitting unsent in the composer's
-# │-bordered input box is not delivery. The predicate requires the brief on a
-# plain transcript line (neither of those) AND a transcript-activity marker
-# proving the TUI accepted the prompt: a ●/⏺ response bullet, a ✻/✳ working
-# spinner, or the esc-to-interrupt processing hint. -J joins wrapped lines so
-# a narrow pane cannot split the brief across a line break and fake an
-# undelivered screen.
-tmux_brief_visible() {
+# The launch took. Two independent proofs, either sufficient.
+#
+# A TURN IN FLIGHT (WORKING_RE, lib/pane-working.sh). A window this script
+# opened seconds ago has no work to run but the brief it was launched with,
+# and a first-run dialog that ate that brief leaves the harness parked, never
+# working. This is the half a long brief needs: the TUI wraps, truncates or
+# redraws its transcript line, and the delivery read below then misses a lane
+# that is plainly running — the working lane reported as a failed launch.
+#
+# THE BRIEF DELIVERED, which means SUBMITTED, not merely present: the brief
+# echoed in the launch command (`claude -n` line) or sitting unsent in the
+# composer's │-bordered input box is not delivery. That read requires the
+# brief on a plain transcript line (neither of those) AND a transcript-activity
+# marker proving the TUI accepted the prompt: a ●/⏺ response bullet, a ✻/✳
+# spinner or end-of-turn line, or the esc-to-interrupt hint. The conjunction
+# stays: alone, the plain-line read passes on an unsent draft in a composer
+# the harness no longer draws with │, and this is the last check before a lane
+# is called launched.
+#
+# -J joins wrapped lines so a narrow pane cannot split the brief across a line
+# break and fake an unlaunched screen.
+tmux_lane_launched() {
   local pane="$1" brief="$2" screen
   # -S -: capture from the start of history, not just the visible viewport —
   # a fast response can scroll the submitted prompt out of view before the
   # first poll, and a viewport-only capture would misread that as
   # undelivered and queue a duplicate brief into a running session.
   screen="$(tmux capture-pane -pJ -S - -t "$pane" 2>/dev/null)" || return 1
+  pane_working "$screen" && return 0
   # No short-circuiting `grep -q` pipelines over the capture: with -S - a
   # retained pane can exceed a pipe buffer, an early -q match SIGPIPEs the
   # upstream printf, and pipefail turns a FOUND brief into exit 141 — a
@@ -411,12 +428,12 @@ tmux_brief_visible() {
      "$screen" == *'✳'* || "$screen" == *'esc to interrupt'* ]]
 }
 
-tmux_verify_brief() {
+tmux_wait_launched() {
   local pane="$1" brief="$2" waited=0
   while (( waited < TMUX_VERIFY_SECS )); do
     sleep 1
     waited=$((waited + 1))
-    tmux_brief_visible "$pane" "$brief" && return 0
+    tmux_lane_launched "$pane" "$brief" && return 0
   done
   return 1
 }
@@ -429,14 +446,26 @@ tmux_verify_brief() {
 # an unattended lane needs) and waits for the main TUI's composer footer.
 # An Enter into an already-ready empty composer is a no-op, so the nudge is
 # safe when the screen is merely slow.
+#
+# A lane that starts working during the wait is the third state, and the one
+# the nudge must stop for: further keystrokes land inside a running turn. It
+# ends the wait as a launched lane rather than a stuck one. WORKING_RE reads
+# false for the first second or two of a turn, before streaming starts, so a
+# turn beginning inside the last passes can still take an Enter — harmless in
+# a Claude Code turn, which Enter does not interrupt, and the pass after it
+# stops.
+#   0  a ready, empty composer: re-send the brief
+#   2  a turn in flight: the launch took, send nothing more
+#   1  neither within the window: the stuck or dead pane the failure exit is for
 tmux_wait_composer() {
   local pane="$1" waited=0 screen
   while (( waited < TMUX_VERIFY_SECS )); do
     # VISIBLE viewport only (no -S -): readiness is a property of the
     # current screen — a footer buried in scrollback behind a first-run
     # dialog must not read as "composer ready" and send the brief into the
-    # dialog again.
+    # dialog again. The turn in flight is the current screen's question too.
     screen="$(tmux capture-pane -pJ -t "$pane" 2>/dev/null)" || return 1
+    pane_working "$screen" && return 2
     [[ "$screen" == *'? for shortcuts'* ]] && return 0
     tmux send-keys -t "$pane" Enter || return 1
     sleep 1
@@ -501,14 +530,22 @@ open_tmux() {
   fi
   echo "Opened tmux window '$title' in $dir"
   [[ -n "$brief" ]] || return 0
-  # Delivery verification: a first-run dialog (theme / trust /
+  # Launch verification: a first-run dialog (theme / trust /
   # browser integration) can consume the CLI-arg brief, leaving a healthy TUI
-  # at an empty composer while the launch looks successful. Confirm the brief
-  # actually reached the TUI; if not, re-send it once into the composer and
-  # re-verify; if still absent, fail this lane loudly instead of reporting
-  # success. The Codex kickoff path has the same delivery requirement.
-  tmux_verify_brief "$pane" "$brief" && return 0
-  if ! tmux_wait_composer "$pane"; then
+  # at an empty composer while the launch looks successful. Confirm the launch
+  # took; if it did not, re-send the brief once into the composer and
+  # re-verify; if it still has not, fail this lane loudly instead of reporting
+  # success. Between those sits the lane that is simply already working: it
+  # took, and all that is owed to it is to stop typing. The Codex kickoff path
+  # has the same delivery requirement.
+  tmux_wait_launched "$pane" "$brief" && return 0
+  local composer_rc=0
+  tmux_wait_composer "$pane" || composer_rc=$?
+  if (( composer_rc == 2 )); then
+    echo "'$title' is already working; the launch took (its brief never read as delivered)"
+    return 0
+  fi
+  if (( composer_rc != 0 )); then
     echo "Error: '$title' never reached a ready composer (first-run dialog stuck?) — attach and start it manually: $brief" >&2
     return 1
   fi
@@ -516,7 +553,7 @@ open_tmux() {
     echo "Error: tmux send-keys failed re-delivering the brief to '$title'" >&2
     return 1
   fi
-  if tmux_verify_brief "$pane" "$brief"; then
+  if tmux_wait_launched "$pane" "$brief"; then
     echo "Re-delivered brief to '$title' (initial CLI-arg prompt was consumed at boot)"
     return 0
   fi

--- a/skills/orch/scripts/open-terminal
+++ b/skills/orch/scripts/open-terminal
@@ -387,6 +387,27 @@ start_cmd() {
   esac
 }
 
+# The composer of the main TUI, at column 0: the harness's prompt marker
+# followed by the NON-BREAKING space it pads the input line with. That padding
+# is the whole discriminator, and it is spelled as bytes rather than typed,
+# because the character is invisible in source and a reformat would silently
+# turn it into an ordinary space:
+#
+#   ❯<U+00A0>            the composer, empty or holding an unsent draft
+#   ❯<space>some text    a SUBMITTED message, echoed into the transcript
+#
+# Measured over 146 pane captures of Claude Code v2.1.261: present on 93 of
+# 100 main-TUI screens and on 0 of 45 first-run screens (theme picker, login
+# method, sign-in, paste-code, trust dialog), whose own `❯ 1. …` rows take the
+# ordinary space. oversee-watch's PANE_MARKER_RE deliberately conflates the
+# two; telling them apart is this script's question, not its.
+#
+# The older spelling of readiness, the `? for shortcuts` footer, is kept
+# alongside it: this is another tool's surface, and a lane may be running a
+# build that still draws it.
+COMPOSER_RE=$'^\xe2\x9d\xaf\xc2\xa0'
+READY_RE="$COMPOSER_RE"'|\? for shortcuts'
+
 # The launch took. Two independent proofs, either sufficient.
 #
 # A TURN IN FLIGHT (WORKING_RE, lib/pane-working.sh). A window this script
@@ -398,13 +419,17 @@ start_cmd() {
 #
 # THE BRIEF DELIVERED, which means SUBMITTED, not merely present: the brief
 # echoed in the launch command (`claude -n` line) or sitting unsent in the
-# composer's │-bordered input box is not delivery. That read requires the
-# brief on a plain transcript line (neither of those) AND a transcript-activity
-# marker proving the TUI accepted the prompt: a ●/⏺ response bullet, a ✻/✳
-# spinner or end-of-turn line, or the esc-to-interrupt hint. The conjunction
-# stays: alone, the plain-line read passes on an unsent draft in a composer
-# the harness no longer draws with │, and this is the last check before a lane
-# is called launched.
+# composer is not delivery, so both lines are dropped before the brief is
+# looked for. The composer is dropped by COMPOSER_RE; the │ border an older
+# TUI drew around it is dropped too, for the same reason that spelling is
+# still read as ready. On the shipped v2.1.261 the │ filter matches nothing —
+# the composer is two ──── rules around the prompt line — so COMPOSER_RE is
+# what carries this now.
+# On top of that the read requires a transcript-activity marker proving the
+# TUI accepted the prompt: a ●/⏺ response bullet, a ✻/✳ spinner or end-of-turn
+# line, or the esc-to-interrupt hint. The conjunction stays, as the last check
+# before a lane is called launched: a draft the user is still typing sits on
+# the composer line under a status bar that already carries ●.
 #
 # -J joins wrapped lines so a narrow pane cannot split the brief across a line
 # break and fake an unlaunched screen.
@@ -422,7 +447,7 @@ tmux_lane_launched() {
   # submitted prompt then reads as missing and gets duplicated. grep -v
   # always reads its whole input; the containment checks are bash matches.
   local filtered
-  filtered="$(printf '%s\n' "$screen" | grep -vF 'claude -n' | grep -vF '│')" || true
+  filtered="$(printf '%s\n' "$screen" | grep -vF 'claude -n' | grep -vF '│' | grep -Ev -- "$COMPOSER_RE")" || true
   [[ "$filtered" == *"$brief"* ]] || return 1
   [[ "$screen" == *'●'* || "$screen" == *'⏺'* || "$screen" == *'✻'* ||
      "$screen" == *'✳'* || "$screen" == *'esc to interrupt'* ]]
@@ -464,9 +489,13 @@ tmux_wait_composer() {
     # current screen — a footer buried in scrollback behind a first-run
     # dialog must not read as "composer ready" and send the brief into the
     # dialog again. The turn in flight is the current screen's question too.
+    # READY_RE, not the `? for shortcuts` footer alone: v2.1.261 does not draw
+    # that footer at all, so keyed on it this wait could never return 0 and
+    # the re-send below was unreachable — every consumed brief fell to the
+    # failure exit.
     screen="$(tmux capture-pane -pJ -t "$pane" 2>/dev/null)" || return 1
     pane_working "$screen" && return 2
-    [[ "$screen" == *'? for shortcuts'* ]] && return 0
+    grep -Eq -- "$READY_RE" <<<"$screen" && return 0
     tmux send-keys -t "$pane" Enter || return 1
     sleep 1
     waited=$((waited + 1))

--- a/skills/orch/scripts/open-terminal
+++ b/skills/orch/scripts/open-terminal
@@ -437,11 +437,15 @@ READY_RE="$COMPOSER_RE"'[[:blank:]]*$|\? for shortcuts'
 # still read as ready. On the shipped v2.1.261 the │ filter matches nothing —
 # the composer is two ──── rules around the prompt line — so COMPOSER_RE is
 # what carries this now.
-# On top of that the read requires a transcript-activity marker proving the
-# TUI accepted the prompt: a ●/⏺ response bullet, a ✻/✳ spinner or end-of-turn
-# line, or the esc-to-interrupt hint. The conjunction stays, as the last check
-# before a lane is called launched: a draft the user is still typing sits on
-# the composer line under a status bar that already carries ●.
+# Dropping the composer line is the WHOLE of that guard, and it has to be:
+# this read also decides whether the launcher may type, and no
+# transcript-activity marker can be required of it. A turn's first second or
+# two draws a spinner frame this script deliberately does not read and no
+# token counter yet, while the composer is ALREADY EMPTY again — the empty
+# form is on 57 of 57 mid-turn captures. Ask for a marker on top and that
+# window reads as an idle, ready composer, and a second brief goes into a turn
+# that has just begun. The filter is measured instead: on 45 first-run
+# captures nothing survives it, and a draft never does.
 #
 # -J joins wrapped lines so a narrow pane cannot split the brief across a line
 # break and fake an unlaunched screen.
@@ -466,9 +470,7 @@ lane_launched() { # SCREEN BRIEF
   # always reads its whole input; the containment checks are bash matches.
   local filtered
   filtered="$(printf '%s\n' "$screen" | grep -vF 'claude -n' | grep -vF '│' | grep -Ev -- "$COMPOSER_RE")" || true
-  [[ "$filtered" == *"$brief"* ]] || return 1
-  [[ "$screen" == *'●'* || "$screen" == *'⏺'* || "$screen" == *'✻'* ||
-     "$screen" == *'✳'* || "$screen" == *'esc to interrupt'* ]]
+  [[ "$filtered" == *"$brief"* ]]
 }
 
 tmux_wait_launched() {

--- a/skills/orch/scripts/open-terminal
+++ b/skills/orch/scripts/open-terminal
@@ -503,9 +503,14 @@ tmux_wait_launched() {
 #   0  a ready, empty composer: re-send the brief
 #   2  the launch took after all: send nothing more
 #   1  neither within the window: the stuck or dead pane the failure exit is for
+# The loop READS before it decides whether it may still nudge, so the Enter of
+# the final pass is observed like every other: a dialog it dismissed or a draft
+# it submitted lands after the last nudge, and testing the budget before the
+# capture would report that lane stuck. At ORCH_TMUX_VERIFY_SECS=1 that is the
+# only Enter there is.
 tmux_wait_composer() {
   local pane="$1" brief="$2" waited=0 screen
-  while (( waited < TMUX_VERIFY_SECS )); do
+  while :; do
     # VISIBLE viewport only (no -S -): readiness is a property of the
     # current screen — a footer buried in scrollback behind a first-run
     # dialog must not read as "composer ready" and send the brief into the
@@ -517,11 +522,11 @@ tmux_wait_composer() {
     screen="$(tmux capture-pane -pJ -t "$pane" 2>/dev/null)" || return 1
     lane_launched "$screen" "$brief" && return 2
     grep -Eq -- "$READY_RE" <<<"$screen" && return 0
+    (( waited < TMUX_VERIFY_SECS )) || return 1
     tmux send-keys -t "$pane" Enter || return 1
     sleep 1
     waited=$((waited + 1))
   done
-  return 1
 }
 
 # The last layer before any window opens. A launch whose working directory is
@@ -592,7 +597,7 @@ open_tmux() {
   local composer_rc=0
   tmux_wait_composer "$pane" "$brief" || composer_rc=$?
   if (( composer_rc == 2 )); then
-    echo "'$title' is already working; the launch took (its brief never read as delivered)"
+    echo "Confirmed '$title' launched while waiting for its composer; nothing further sent"
     return 0
   fi
   if (( composer_rc != 0 )); then

--- a/skills/orch/scripts/oversee-watch
+++ b/skills/orch/scripts/oversee-watch
@@ -202,6 +202,8 @@ source "$SCRIPT_DIR/lib/usage-reset.sh"
 source "$SCRIPT_DIR/lib/lane-claims.sh"
 # shellcheck source=lib/pr-watch-pass.sh
 source "$SCRIPT_DIR/lib/pr-watch-pass.sh"
+# shellcheck source=lib/pane-working.sh
+source "$SCRIPT_DIR/lib/pane-working.sh"
 PR_WATCH="${OVERSEE_WATCH_PR_WATCH:-$SKILLS_DIR/review-gate/scripts/pr-watch.sh}"
 TRACKER="${OVERSEE_WATCH_TRACKER:-$SKILLS_DIR/linear/scripts/linear.sh}"
 WORKFLOW_STATE="${OVERSEE_WATCH_WORKFLOW_STATE:-$SCRIPT_DIR/workflow-state}"
@@ -290,9 +292,8 @@ LANE_ASKING_RE='(❯|›) [0-9]+\. |Do you want to|Enter to select|Esc to cancel
 # prints "Usage limit reached" and its out-of-credits wording. `.` stands in
 # for the apostrophe: ASCII in the binaries, typographic once rendered.
 USAGE_LIMIT_RE='You.(ve|re) (hit|reached) your [a-z ]*limit|[Uu]sage limit reached|hit usage limits|out of (usage )?credits|/usage-credits'
-# A turn in flight: the interrupt hint (both harnesses), the hint shown while
-# a foreground shell runs, or the streaming token counter of the status line.
-WORKING_RE='to interrupt|to run in background|↓ [0-9][0-9.]*[kKmM]? tokens'
+# A turn in flight is WORKING_RE, in lib/pane-working.sh: open-terminal reads
+# the same question off a launching pane, and one answer serves both.
 # The marker each harness draws at column 0 for a submitted user message
 # echoed into the transcript AND for the composer the lane sits at: Claude
 # Code `❯`, Codex `›`. Spelled as an alternation of literals and NEVER as a

--- a/skills/orch/tests/open-terminal-claude-handoff.sh
+++ b/skills/orch/tests/open-terminal-claude-handoff.sh
@@ -152,9 +152,11 @@ OT_UNDER_TEST="$OT"
 #              it from `delivered` is the non-breaking space after the caret.
 #              Not somewhere to type either: the composer is OCCUPIED, and
 #              `send-keys -l` would append a second copy of the brief
-#   plain      the brief submitted into the transcript, over a ready composer,
-#              with no response marker anywhere: UNDELIVERED on the activity
-#              requirement alone
+#   earlyturn  a turn in its FIRST FRAMES: the brief submitted into the
+#              transcript, a spinner frame this script deliberately does not
+#              read, no token counter yet, and the composer already empty
+#              again. LAUNCHED — and the screen that must never be typed into,
+#              since readiness alone would send a second brief into the turn
 #   working    a turn in flight: the verb, the elapsed time and the streaming
 #              token counter the harness draws only while one runs. The brief
 #              is nowhere but the echoed launch command, the screen a long
@@ -178,7 +180,7 @@ screen() {
     echo) printf '%s\n' "\$ claude -n CC-737 --dangerously-skip-permissions '$BRIEF'" '● Reading workflows/start.md' '╭─ Enable browser integration? ─╮' '> ' ;;
     delivered) printf '%s\n' "$CARET $BRIEF" '● Reading workflows/start.md' ;;
     composer) printf '%s\n' '● Reading workflows/start.md' '╭──────────────────────────────────────────╮' "│ > $BRIEF │" '╰──────────────────────────────────────────╯' '  ? for shortcuts' ;;
-    plain) printf '%s\n' "$CARET $BRIEF" "$RULE" "$CARET$NBSP" "$RULE" "$STATUS" ;;
+    earlyturn) printf '%s\n' "$CARET $BRIEF" '✶ Orchestrating…' "$RULE" "$CARET$NBSP" "$RULE" "$STATUS" ;;
     draft) printf '%s\n' '● Reading workflows/start.md' "$RULE" "$CARET$NBSP$BRIEF" "$RULE" "$STATUS" ;;
     working) printf '%s\n' "\$ claude -n CC-737 '$BRIEF'" '✻ Orchestrating… (3s · ↓ 79 tokens · thinking with high effort)' ;;
     signin) printf '%s\n' '  Select login method' '✻ Opening browser to sign in…' ;;
@@ -389,7 +391,7 @@ launch_table \
   "a composer that stays occupied is a failed lane, and never has a second brief typed into it|tmux|-|-|draft|rc=1 stderr~never+reached+a+ready+composer=true resends=0" \
   "a lane that comes up on the very last nudge is seen, not reported stuck|tmux|-|-|echo,echo,delivered|rc=0 out~Confirmed+'CC-737'+launched=true resends=0 enters=2" \
   "an older TUI's shortcuts footer is still read as ready|tmux|-|-|echo,ready-legacy,delivered|rc=0 out~Re-delivered+brief+to+'CC-737'=true resends=1" \
-  "the brief on a transcript line with no response begun is not delivery either|tmux|-|-|plain|rc=1 stderr~brief+undelivered+to+'CC-737'=true resends=1" \
+  "a turn in its first frames is launched and never typed into, before any counter or marker shows|tmux|-|-|earlyturn|rc=0 out~Done:+launched+1=true resends=0 enters=1" \
   "a turn in flight is a launched lane whatever its transcript line reads as: no re-send|tmux|-|-|working|rc=0 out~Done:+launched+1=true resends=0 enters=1" \
   "a lane that starts working while the launcher waits for a composer ends the wait launched, nothing typed into it|tmux|-|-|echo,working|rc=0 out~Confirmed+'CC-737'+launched=true resends=0 enters=1" \
   "a composer that never becomes ready is a failed lane, named as stuck|tmux|-|-|echo,echo|rc=1 stderr~never+reached+a+ready+composer=true out~Done:+launched+1=false" \
@@ -438,6 +440,13 @@ launch_table \
 mutant last-pass-blind open-terminal 's@^    screen="$(tmux capture-pane -pJ -t "$pane" 2>/dev/null)" || return 1$@    (( waited < TMUX_VERIFY_SECS )) || return 1; screen="$(tmux capture-pane -pJ -t "$pane" 2>/dev/null)" || return 1@;/^    (( waited < TMUX_VERIFY_SECS )) || return 1$/d' 'the read-before-budget order'
 launch_table \
   "control: deciding before the capture reports a lane that came up on the last nudge as stuck|tmux|-|-|echo,echo,delivered|rc=1 stderr~never+reached+a+ready+composer=true"
+# Require a transcript-activity marker on top of the brief and the first
+# frames of a turn read as an idle, ready composer: the counter is not drawn
+# yet, the spinner frame is one this script does not read, and the composer is
+# already empty — so a second brief goes into the turn.
+mutant activity-required open-terminal 's@^  \[\[ "$filtered" == \*"$brief"\* \]\]$@  [[ "$filtered" == *"$brief"* ]] || return 1; [[ "$screen" == *"\xe2\x97\x8f"* ]]@' 'the delivery read'
+launch_table \
+  "control: with a marker required on top, a turn in its first frames takes a second brief|tmux|-|-|earlyturn|resends=1"
 unmutate
 
 echo "=== open-terminal claude handoff: the verify timeout ==="

--- a/skills/orch/tests/open-terminal-claude-handoff.sh
+++ b/skills/orch/tests/open-terminal-claude-handoff.sh
@@ -12,10 +12,13 @@
 #
 # 2. The brief (initial '/orch start …' prompt) rides as a CLI arg; first-run
 #    dialogs (theme/trust/browser-integration) consume it, leaving a healthy
-#    TUI at an EMPTY composer. The tmux path must verify delivery by
-#    re-capturing the pane (the brief visible on a line other than the echoed
-#    launch command), re-send the brief once if absent, and emit a per-lane
-#    failure + nonzero exit if still absent.
+#    TUI at an EMPTY composer. The tmux path must verify the launch took by
+#    re-capturing the pane — the brief delivered (on a line other than the
+#    echoed launch command, with a response begun), or a turn in flight —
+#    re-send the brief once if neither shows, and emit a per-lane failure +
+#    nonzero exit if it still does not. A pane running a turn is a launched
+#    lane, reported as launched and never typed into. A first-run dialog is
+#    not, and animating a spinner does not make it one.
 #
 # The test runs a byte-identical copy of open-terminal inside a temp git repo
 # so `git rev-parse --show-toplevel` resolves to a hermetic PROJECT_ROOT, and
@@ -119,6 +122,9 @@ cp "$SRC_LIB_DIR"/*.sh "$REPO/scripts/lib/"
 chmod +x "$REPO/scripts/open-terminal"
 git -C "$REPO" init -q
 OT="$REPO/scripts/open-terminal"
+# Every row runs whatever binary this names; `mutant` repoints it at a copy
+# with the working predicate rewritten, and `unmutate` puts it back.
+OT_UNDER_TEST="$OT"
 
 # screen NAME — prints one pane capture, by name.
 #   echo       the brief appears ONLY inside the echoed launch command, which
@@ -133,6 +139,16 @@ OT="$REPO/scripts/open-terminal"
 #              on the composer-box filter alone
 #   plain      the brief on a plain transcript line with no response marker
 #              anywhere: UNDELIVERED on the activity requirement alone
+#   working    a turn in flight: the verb, the elapsed time and the streaming
+#              token counter the harness draws only while one runs. The brief
+#              is nowhere but the echoed launch command, the screen a long
+#              brief leaves once the TUI has redrawn its transcript line
+#              beyond recognition. LAUNCHED
+#   signin     a first-run sign-in step, animating the same spinner frame a
+#              running turn does and carrying no token counter, no interrupt
+#              hint, no brief and no composer. STUCK: the launcher's failure
+#              exit is what this pane needs, and a predicate keyed on the
+#              spinner would call it launched
 #   ready      the main TUI at a ready, EMPTY composer (the '? for shortcuts'
 #              footer is the readiness marker), where a re-send must land
 #   huge       delivered, then a pane larger than a pipe buffer: a
@@ -144,6 +160,8 @@ screen() {
     delivered) printf '%s\n' "> $BRIEF" '● Reading workflows/start.md' ;;
     composer) printf '%s\n' '● Reading workflows/start.md' '╭──────────────────────────────────────────╮' "│ > $BRIEF │" '╰──────────────────────────────────────────╯' '  ? for shortcuts' ;;
     plain) printf '%s\n' "> $BRIEF" '  ? for shortcuts' ;;
+    working) printf '%s\n' "\$ claude -n CC-737 '$BRIEF'" '✻ Orchestrating… (3s · ↓ 79 tokens · thinking with high effort)' ;;
+    signin) printf '%s\n' '  Select login method' '✻ Opening browser to sign in…' ;;
     ready) printf '%s\n' '╭──────────────────────────────────────────╮' '│ >                                         │' '╰──────────────────────────────────────────╯' '  ? for shortcuts' ;;
     huge) screen delivered; awk 'BEGIN { for (i = 0; i < 20000; i++) print "transcript filler line" }' ;;
     *) echo "screen: unknown capture $1" >&2; exit 1 ;;
@@ -189,7 +207,7 @@ run() {
   [[ "$flags" == - ]] || args+=(--launch-flags "$flags")
   if [[ "$mode" == github ]]; then args+=(42); else args+=(cc-737); fi
   set +e
-  OUT=$(env ${envs[@]+"${envs[@]}"} OT_CAPTURE="$CAP" PATH="$BIN:$PATH" WORKTREE_CLI="$STUB" "$OT" "${args[@]}" 2>"$ERR")
+  OUT=$(env ${envs[@]+"${envs[@]}"} OT_CAPTURE="$CAP" PATH="$BIN:$PATH" WORKTREE_CLI="$STUB" "$OT_UNDER_TEST" "${args[@]}" 2>"$ERR")
   RC=$?
   set -e
 }
@@ -242,6 +260,33 @@ observe() {
   set +f
   printf '%s' "${got# }"
 }
+
+# mutant NAME SED — stage open-terminal against a copy of lib/pane-working.sh
+# with SED applied, in a git repo of its own so PROJECT_ROOT still resolves
+# hermetically, and point every following row at it. `pane_working` is what
+# both controls rewrite, and it lives in that lib rather than in the script.
+# The copy is proven to differ from the original first, so a mutation whose
+# anchor moved cannot pass as a silent no-op.
+mutant() {
+  local name="$1" expr="$2" dir lib
+  dir="$TMP_ROOT/mutants/$name"
+  lib="$dir/scripts/lib/pane-working.sh"
+  mkdir -p "$dir/scripts/lib"
+  cp "$SRC_OT" "$dir/scripts/open-terminal"
+  cp "$SRC_LIB_DIR"/*.sh "$dir/scripts/lib/"
+  sed "$expr" "$SRC_LIB_DIR/pane-working.sh" > "$lib"
+  if cmp -s "$SRC_LIB_DIR/pane-working.sh" "$lib"; then
+    FAIL=$((FAIL + 1))
+    printf '  FAIL  control: the %s mutant is byte-identical to pane-working.sh\n' "$name"
+  else
+    pass "control: the $name mutant really rewrites pane_working"
+  fi
+  chmod +x "$dir/scripts/open-terminal"
+  git -C "$dir" init -q
+  OT_UNDER_TEST="$dir/scripts/open-terminal"
+}
+
+unmutate() { OT_UNDER_TEST="$OT"; }
 
 # launch_table ROW... — `label|mode|env|flags|screens|expect`, one launch and
 # one assertion per row.
@@ -300,7 +345,11 @@ echo "=== open-terminal claude handoff: tmux brief delivery ==="
 # The brief visible in the transcript on the first verification pass is
 # delivery: no re-send, and the capture includes scrollback (-S -), since a
 # fast response scrolling the prompt out of the viewport must not read as
-# undelivered. The brief only inside the echoed launch command is what a
+# undelivered. A turn in flight is the other, independent proof, whether it
+# was running from the first pass or starts while the launcher waits for a
+# composer: launched, no re-send, and no further keystroke into a session that
+# would take it mid-turn. A first-run dialog is not a turn, however it
+# animates. The brief only inside the echoed launch command is what a
 # dialog leaves: the launcher waits for a ready composer, sending one
 # dismissing Enter per dialog pass, types the brief once after readiness
 # (bare Enters: one at launch, one per dialog nudge, one submitting the
@@ -317,10 +366,31 @@ launch_table \
   "the echoed command alone is not delivery: one re-send, then a loud per-lane failure|tmux|-|-|echo,ready,ready|rc=1 stderr~brief+undelivered+to+'CC-737'=true stderr~handoff+lane(s)+failed=true out~Done:+launched+1=false resends=1" \
   "unsent composer text is not delivery: one re-send, then the failure|tmux|-|-|composer|rc=1 stderr~brief+undelivered+to+'CC-737'=true resends=1" \
   "the brief on a transcript line with no response begun is not delivery either|tmux|-|-|plain|rc=1 stderr~brief+undelivered+to+'CC-737'=true resends=1" \
+  "a turn in flight is a launched lane whatever its transcript line reads as: no re-send|tmux|-|-|working|rc=0 out~Done:+launched+1=true resends=0 enters=1" \
+  "a lane that starts working while the launcher waits for a composer ends the wait launched, nothing typed into it|tmux|-|-|echo,working|rc=0 out~already+working=true resends=0 enters=1" \
   "a composer that never becomes ready is a failed lane, named as stuck|tmux|-|-|echo,echo|rc=1 stderr~never+reached+a+ready+composer=true out~Done:+launched+1=false" \
+  "a sign-in step animating a spinner is still a stuck lane, not a working one|tmux|-|-|signin|rc=1 stderr~never+reached+a+ready+composer=true out~Done:+launched+1=false" \
   "a huge scrollback with the delivered brief near its start is delivery: no duplicate brief|tmux|-|-|huge|rc=0 resends=0" \
   "a window that was never created is a failed lane, not a launched one|tmux|OT_TMUX_FAIL=new-window|-|delivered|rc=1 stderr~new-window+failed=true stderr~handoff+lane(s)+failed=true out~Done:+launched+1=false" \
   "launch keystrokes failing on a briefless lane is a failed lane too|tmux-codex|OT_TMUX_FAIL=send-keys|-|-|rc=1 stderr~send-keys+failed+launching=true out~Done:+launched+1=false"
+
+echo "=== the turn-in-flight reading can fail, both ways ==="
+# `pane_working` is the whole of it, so it is the mutation both controls take.
+# Cut it to always-false and the two working rows go back to the false alarm
+# this closed: a healthy mid-turn lane reported as a stuck composer, exit 1.
+mutant working-blind 's/^pane_working() {/pane_working() { return 1;/'
+launch_table \
+  "control: with the turn reading gone, a turn in flight fails as a stuck composer|tmux|-|-|working|rc=1 stderr~never+reached+a+ready+composer=true out~Done:+launched+1=false" \
+  "control: and so does a lane that starts working during the composer wait|tmux|-|-|echo,working|rc=1 stderr~never+reached+a+ready+composer=true"
+# Widen it to the spinner frames — the shape this fix was first written with —
+# and the failure exit stops covering the pane it is for: Claude Code animates
+# one frame set across every long-running screen, sign-in included, so the
+# stuck lane above reports launched and an unattended login prompt is called a
+# success.
+mutant working-spinner "s/^pane_working() {/pane_working() { grep -q '\xe2\x9c\xbb' <<<\"\$1\" \&\& return 0;/"
+launch_table \
+  "control: keyed on the spinner instead, the sign-in step reports launched|tmux|-|-|signin|rc=0 out~Done:+launched+1=true stderr~never+reached+a+ready+composer=false"
+unmutate
 
 echo "=== open-terminal claude handoff: the verify timeout ==="
 # ORCH_TMUX_VERIFY_SECS is validated where it is read, and only there: a

--- a/skills/orch/tests/open-terminal-claude-handoff.sh
+++ b/skills/orch/tests/open-terminal-claude-handoff.sh
@@ -43,6 +43,15 @@ source "$TEST_DIR/lib/waiter-assertions.sh"
 TMP_ROOT="$(cd "$(mktemp -d)" && pwd -P)"
 trap 'rm -rf "$TMP_ROOT"' EXIT
 
+# The composer's prompt marker is `❯` followed by a NON-BREAKING space; a
+# SUBMITTED message is echoed into the transcript as `❯` followed by an
+# ordinary one. That invisible character is the whole discriminator between a
+# draft the operator is still typing and a prompt the TUI accepted, so both are
+# spelled here as escapes rather than typed into the fixture.
+NBSP=$'\xc2\xa0'
+CARET=$'\xe2\x9d\xaf'
+STATUS='  realwd Opus 5 (VG)                    /rc'
+RULE='────────────────────────────────────────'
 BRIEF='/orch start CC-737'
 BRIEFN='/orch+start+CC-737'   # the brief as a needle: `+` reads as a space
 RESEND="send-keys -t %7 -l $BRIEF"
@@ -133,12 +142,17 @@ OT_UNDER_TEST="$OT"
 #              delivery on the launch-line filter alone
 #   delivered  the brief on its own transcript line, distinct from the echoed
 #              launch command, and the response begun (● transcript marker)
-#   composer   the brief sitting UNSENT in the composer's │-bordered input
-#              box: delivery means SUBMITTED, so this is UNDELIVERED. Its
+#   composer   the brief sitting UNSENT in the │-bordered input box an older
+#              TUI drew: delivery means SUBMITTED, so this is UNDELIVERED. Its
 #              response marker is deliberate too: this screen fails delivery
 #              on the composer-box filter alone
-#   plain      the brief on a plain transcript line with no response marker
-#              anywhere: UNDELIVERED on the activity requirement alone
+#   draft      the same, in the shape v2.1.261 actually draws: two rules
+#              around the prompt line, no │ anywhere, and a status bar that
+#              already carries ●. UNDELIVERED, and the only thing separating
+#              it from `delivered` is the non-breaking space after the caret
+#   plain      the brief submitted into the transcript, over a ready composer,
+#              with no response marker anywhere: UNDELIVERED on the activity
+#              requirement alone
 #   working    a turn in flight: the verb, the elapsed time and the streaming
 #              token counter the harness draws only while one runs. The brief
 #              is nowhere but the echoed launch command, the screen a long
@@ -149,20 +163,25 @@ OT_UNDER_TEST="$OT"
 #              hint, no brief and no composer. STUCK: the launcher's failure
 #              exit is what this pane needs, and a predicate keyed on the
 #              spinner would call it launched
-#   ready      the main TUI at a ready, EMPTY composer (the '? for shortcuts'
-#              footer is the readiness marker), where a re-send must land
+#   ready      the main TUI at a ready, EMPTY composer in the shape v2.1.261
+#              draws it, where a re-send must land. Its readiness marker is
+#              the composer's own prompt line: the '? for shortcuts' footer
+#              appeared on 0 of 146 captures of that build
+#   ready-legacy  the same state as an older TUI drew it, on the footer alone
 #   huge       delivered, then a pane larger than a pipe buffer: a
 #              short-circuiting scan would SIGPIPE its upstream under pipefail
 #              and misread the submitted prompt as missing
 screen() {
   case "$1" in
     echo) printf '%s\n' "\$ claude -n CC-737 --dangerously-skip-permissions '$BRIEF'" '● Reading workflows/start.md' '╭─ Enable browser integration? ─╮' '> ' ;;
-    delivered) printf '%s\n' "> $BRIEF" '● Reading workflows/start.md' ;;
+    delivered) printf '%s\n' "$CARET $BRIEF" '● Reading workflows/start.md' ;;
     composer) printf '%s\n' '● Reading workflows/start.md' '╭──────────────────────────────────────────╮' "│ > $BRIEF │" '╰──────────────────────────────────────────╯' '  ? for shortcuts' ;;
-    plain) printf '%s\n' "> $BRIEF" '  ? for shortcuts' ;;
+    plain) printf '%s\n' "$CARET $BRIEF" "$RULE" "$CARET$NBSP" "$RULE" "$STATUS" ;;
+    draft) printf '%s\n' '● Reading workflows/start.md' "$RULE" "$CARET$NBSP$BRIEF" "$RULE" "$STATUS" ;;
     working) printf '%s\n' "\$ claude -n CC-737 '$BRIEF'" '✻ Orchestrating… (3s · ↓ 79 tokens · thinking with high effort)' ;;
     signin) printf '%s\n' '  Select login method' '✻ Opening browser to sign in…' ;;
-    ready) printf '%s\n' '╭──────────────────────────────────────────╮' '│ >                                         │' '╰──────────────────────────────────────────╯' '  ? for shortcuts' ;;
+    ready) printf '%s\n' "$RULE" "$CARET$NBSP" "$RULE" "$STATUS" ;;
+    ready-legacy) printf '%s\n' '╭──────────────────────────────────────────╮' '│ >                                         │' '╰──────────────────────────────────────────╯' '  ? for shortcuts' ;;
     huge) screen delivered; awk 'BEGIN { for (i = 0; i < 20000; i++) print "transcript filler line" }' ;;
     *) echo "screen: unknown capture $1" >&2; exit 1 ;;
   esac
@@ -261,25 +280,24 @@ observe() {
   printf '%s' "${got# }"
 }
 
-# mutant NAME SED — stage open-terminal against a copy of lib/pane-working.sh
-# with SED applied, in a git repo of its own so PROJECT_ROOT still resolves
-# hermetically, and point every following row at it. `pane_working` is what
-# both controls rewrite, and it lives in that lib rather than in the script.
-# The copy is proven to differ from the original first, so a mutation whose
-# anchor moved cannot pass as a silent no-op.
+# mutant NAME FILE SED WHAT — stage open-terminal and its libs in a git repo of
+# its own, so PROJECT_ROOT still resolves hermetically, with SED applied to
+# FILE (a path under scripts/), and point every following row at it. The copy
+# is proven to differ from the original first, so a mutation whose anchor moved
+# cannot pass as a silent no-op.
 mutant() {
-  local name="$1" expr="$2" dir lib
+  local name="$1" file="$2" expr="$3" what="$4" dir src
   dir="$TMP_ROOT/mutants/$name"
-  lib="$dir/scripts/lib/pane-working.sh"
+  src="$SCRIPTS_DIR/$file"
   mkdir -p "$dir/scripts/lib"
   cp "$SRC_OT" "$dir/scripts/open-terminal"
   cp "$SRC_LIB_DIR"/*.sh "$dir/scripts/lib/"
-  sed "$expr" "$SRC_LIB_DIR/pane-working.sh" > "$lib"
-  if cmp -s "$SRC_LIB_DIR/pane-working.sh" "$lib"; then
+  sed "$expr" "$src" > "$dir/scripts/$file"
+  if cmp -s "$src" "$dir/scripts/$file"; then
     FAIL=$((FAIL + 1))
-    printf '  FAIL  control: the %s mutant is byte-identical to pane-working.sh\n' "$name"
+    printf '  FAIL  control: the %s mutant is byte-identical to %s\n' "$name" "$file"
   else
-    pass "control: the $name mutant really rewrites pane_working"
+    pass "control: the $name mutant really rewrites $what"
   fi
   chmod +x "$dir/scripts/open-terminal"
   git -C "$dir" init -q
@@ -365,6 +383,8 @@ launch_table \
   "two dialog passes before readiness: one dismissing Enter per pass, the brief typed once after|tmux|ORCH_TMUX_VERIFY_SECS=3|-|echo,echo,echo,echo,echo,ready,delivered|rc=0 out~Re-delivered+brief+to+'CC-737'=true enters=4 resends=1" \
   "the echoed command alone is not delivery: one re-send, then a loud per-lane failure|tmux|-|-|echo,ready,ready|rc=1 stderr~brief+undelivered+to+'CC-737'=true stderr~handoff+lane(s)+failed=true out~Done:+launched+1=false resends=1" \
   "unsent composer text is not delivery: one re-send, then the failure|tmux|-|-|composer|rc=1 stderr~brief+undelivered+to+'CC-737'=true resends=1" \
+  "a draft in the composer the harness actually draws is not delivery either: one re-send, then the failure|tmux|-|-|draft|rc=1 stderr~brief+undelivered+to+'CC-737'=true resends=1" \
+  "an older TUI's shortcuts footer is still read as ready|tmux|-|-|echo,ready-legacy,delivered|rc=0 out~Re-delivered+brief+to+'CC-737'=true resends=1" \
   "the brief on a transcript line with no response begun is not delivery either|tmux|-|-|plain|rc=1 stderr~brief+undelivered+to+'CC-737'=true resends=1" \
   "a turn in flight is a launched lane whatever its transcript line reads as: no re-send|tmux|-|-|working|rc=0 out~Done:+launched+1=true resends=0 enters=1" \
   "a lane that starts working while the launcher waits for a composer ends the wait launched, nothing typed into it|tmux|-|-|echo,working|rc=0 out~already+working=true resends=0 enters=1" \
@@ -378,7 +398,7 @@ echo "=== the turn-in-flight reading can fail, both ways ==="
 # `pane_working` is the whole of it, so it is the mutation both controls take.
 # Cut it to always-false and the two working rows go back to the false alarm
 # this closed: a healthy mid-turn lane reported as a stuck composer, exit 1.
-mutant working-blind 's/^pane_working() {/pane_working() { return 1;/'
+mutant working-blind lib/pane-working.sh 's/^pane_working() {/pane_working() { return 1;/' pane_working
 launch_table \
   "control: with the turn reading gone, a turn in flight fails as a stuck composer|tmux|-|-|working|rc=1 stderr~never+reached+a+ready+composer=true out~Done:+launched+1=false" \
   "control: and so does a lane that starts working during the composer wait|tmux|-|-|echo,working|rc=1 stderr~never+reached+a+ready+composer=true"
@@ -387,9 +407,22 @@ launch_table \
 # one frame set across every long-running screen, sign-in included, so the
 # stuck lane above reports launched and an unattended login prompt is called a
 # success.
-mutant working-spinner "s/^pane_working() {/pane_working() { grep -q '\xe2\x9c\xbb' <<<\"\$1\" \&\& return 0;/"
+mutant working-spinner lib/pane-working.sh "s/^pane_working() {/pane_working() { grep -q '\xe2\x9c\xbb' <<<\"\$1\" \&\& return 0;/" pane_working
 launch_table \
   "control: keyed on the spinner instead, the sign-in step reports launched|tmux|-|-|signin|rc=0 out~Done:+launched+1=true stderr~never+reached+a+ready+composer=false"
+# The composer read can fail the same two ways. Drop the composer filter and
+# the draft above passes as a submitted prompt: the │ the old filter looks for
+# is on none of the 146 captures of v2.1.261, so nothing else stands between a
+# half-typed brief and a lane called launched.
+mutant composer-blind open-terminal 's/ | grep -Ev -- "\$COMPOSER_RE"//' 'the composer filter'
+launch_table \
+  "control: without the composer filter, a draft the operator is still typing reports launched|tmux|-|-|draft|rc=0 out~Done:+launched+1=true resends=0"
+# Key readiness on the old footer alone and the re-send path goes unreachable:
+# v2.1.261 never draws it, so a dialog that ate the brief can only ever reach
+# the failure exit, never the recovery the launcher exists to perform.
+mutant ready-legacy-only open-terminal 's/^READY_RE=.*/READY_RE="\\? for shortcuts"/' 'the readiness marker'
+launch_table \
+  "control: keyed on the old footer alone, a dialog that ate the brief can never be recovered|tmux|-|-|echo,ready,delivered|rc=1 stderr~never+reached+a+ready+composer=true resends=0"
 unmutate
 
 echo "=== open-terminal claude handoff: the verify timeout ==="

--- a/skills/orch/tests/open-terminal-claude-handoff.sh
+++ b/skills/orch/tests/open-terminal-claude-handoff.sh
@@ -149,7 +149,9 @@ OT_UNDER_TEST="$OT"
 #   draft      the same, in the shape v2.1.261 actually draws: two rules
 #              around the prompt line, no │ anywhere, and a status bar that
 #              already carries ●. UNDELIVERED, and the only thing separating
-#              it from `delivered` is the non-breaking space after the caret
+#              it from `delivered` is the non-breaking space after the caret.
+#              Not somewhere to type either: the composer is OCCUPIED, and
+#              `send-keys -l` would append a second copy of the brief
 #   plain      the brief submitted into the transcript, over a ready composer,
 #              with no response marker anywhere: UNDELIVERED on the activity
 #              requirement alone
@@ -383,7 +385,8 @@ launch_table \
   "two dialog passes before readiness: one dismissing Enter per pass, the brief typed once after|tmux|ORCH_TMUX_VERIFY_SECS=3|-|echo,echo,echo,echo,echo,ready,delivered|rc=0 out~Re-delivered+brief+to+'CC-737'=true enters=4 resends=1" \
   "the echoed command alone is not delivery: one re-send, then a loud per-lane failure|tmux|-|-|echo,ready,ready|rc=1 stderr~brief+undelivered+to+'CC-737'=true stderr~handoff+lane(s)+failed=true out~Done:+launched+1=false resends=1" \
   "unsent composer text is not delivery: one re-send, then the failure|tmux|-|-|composer|rc=1 stderr~brief+undelivered+to+'CC-737'=true resends=1" \
-  "a draft in the composer the harness actually draws is not delivery either: one re-send, then the failure|tmux|-|-|draft|rc=1 stderr~brief+undelivered+to+'CC-737'=true resends=1" \
+  "a brief left sitting in the composer is submitted by the nudge, not typed a second time|tmux|ORCH_TMUX_VERIFY_SECS=2|-|draft,draft,draft,delivered|rc=0 out~Done:+launched+1=true resends=0 enters=2" \
+  "a composer that stays occupied is a failed lane, and never has a second brief typed into it|tmux|-|-|draft|rc=1 stderr~never+reached+a+ready+composer=true resends=0" \
   "an older TUI's shortcuts footer is still read as ready|tmux|-|-|echo,ready-legacy,delivered|rc=0 out~Re-delivered+brief+to+'CC-737'=true resends=1" \
   "the brief on a transcript line with no response begun is not delivery either|tmux|-|-|plain|rc=1 stderr~brief+undelivered+to+'CC-737'=true resends=1" \
   "a turn in flight is a launched lane whatever its transcript line reads as: no re-send|tmux|-|-|working|rc=0 out~Done:+launched+1=true resends=0 enters=1" \
@@ -423,6 +426,12 @@ launch_table \
 mutant ready-legacy-only open-terminal 's/^READY_RE=.*/READY_RE="\\? for shortcuts"/' 'the readiness marker'
 launch_table \
   "control: keyed on the old footer alone, a dialog that ate the brief can never be recovered|tmux|-|-|echo,ready,delivered|rc=1 stderr~never+reached+a+ready+composer=true resends=0"
+# Readiness that does not insist on an EMPTY composer types into an occupied
+# one, and `send-keys -l` appends: the lane is handed
+# `/orch start CC-737/orch start CC-737` and submits it.
+mutant ready-occupied open-terminal 's/^READY_RE=.*/READY_RE="$COMPOSER_RE"/' 'the empty-composer requirement'
+launch_table \
+  "control: readiness without the empty test types a second brief into an occupied composer|tmux|-|-|draft|resends=1"
 unmutate
 
 echo "=== open-terminal claude handoff: the verify timeout ==="

--- a/skills/orch/tests/open-terminal-claude-handoff.sh
+++ b/skills/orch/tests/open-terminal-claude-handoff.sh
@@ -387,10 +387,11 @@ launch_table \
   "unsent composer text is not delivery: one re-send, then the failure|tmux|-|-|composer|rc=1 stderr~brief+undelivered+to+'CC-737'=true resends=1" \
   "a brief left sitting in the composer is submitted by the nudge, not typed a second time|tmux|ORCH_TMUX_VERIFY_SECS=2|-|draft,draft,draft,delivered|rc=0 out~Done:+launched+1=true resends=0 enters=2" \
   "a composer that stays occupied is a failed lane, and never has a second brief typed into it|tmux|-|-|draft|rc=1 stderr~never+reached+a+ready+composer=true resends=0" \
+  "a lane that comes up on the very last nudge is seen, not reported stuck|tmux|-|-|echo,echo,delivered|rc=0 out~Confirmed+'CC-737'+launched=true resends=0 enters=2" \
   "an older TUI's shortcuts footer is still read as ready|tmux|-|-|echo,ready-legacy,delivered|rc=0 out~Re-delivered+brief+to+'CC-737'=true resends=1" \
   "the brief on a transcript line with no response begun is not delivery either|tmux|-|-|plain|rc=1 stderr~brief+undelivered+to+'CC-737'=true resends=1" \
   "a turn in flight is a launched lane whatever its transcript line reads as: no re-send|tmux|-|-|working|rc=0 out~Done:+launched+1=true resends=0 enters=1" \
-  "a lane that starts working while the launcher waits for a composer ends the wait launched, nothing typed into it|tmux|-|-|echo,working|rc=0 out~already+working=true resends=0 enters=1" \
+  "a lane that starts working while the launcher waits for a composer ends the wait launched, nothing typed into it|tmux|-|-|echo,working|rc=0 out~Confirmed+'CC-737'+launched=true resends=0 enters=1" \
   "a composer that never becomes ready is a failed lane, named as stuck|tmux|-|-|echo,echo|rc=1 stderr~never+reached+a+ready+composer=true out~Done:+launched+1=false" \
   "a sign-in step animating a spinner is still a stuck lane, not a working one|tmux|-|-|signin|rc=1 stderr~never+reached+a+ready+composer=true out~Done:+launched+1=false" \
   "a huge scrollback with the delivered brief near its start is delivery: no duplicate brief|tmux|-|-|huge|rc=0 resends=0" \
@@ -425,13 +426,18 @@ launch_table \
 # the failure exit, never the recovery the launcher exists to perform.
 mutant ready-legacy-only open-terminal 's/^READY_RE=.*/READY_RE="\\? for shortcuts"/' 'the readiness marker'
 launch_table \
-  "control: keyed on the old footer alone, a dialog that ate the brief can never be recovered|tmux|-|-|echo,ready,delivered|rc=1 stderr~never+reached+a+ready+composer=true resends=0"
+  "control: keyed on the old footer alone, a dialog that ate the brief can never be recovered|tmux|-|-|echo,ready,ready|rc=1 stderr~never+reached+a+ready+composer=true resends=0"
 # Readiness that does not insist on an EMPTY composer types into an occupied
 # one, and `send-keys -l` appends: the lane is handed
 # `/orch start CC-737/orch start CC-737` and submits it.
 mutant ready-occupied open-terminal 's/^READY_RE=.*/READY_RE="$COMPOSER_RE"/' 'the empty-composer requirement'
 launch_table \
   "control: readiness without the empty test types a second brief into an occupied composer|tmux|-|-|draft|resends=1"
+# Test the nudge budget BEFORE the capture and the last Enter's result is
+# never looked at: the lane that came up on it is reported stuck.
+mutant last-pass-blind open-terminal 's@^    screen="$(tmux capture-pane -pJ -t "$pane" 2>/dev/null)" || return 1$@    (( waited < TMUX_VERIFY_SECS )) || return 1; screen="$(tmux capture-pane -pJ -t "$pane" 2>/dev/null)" || return 1@;/^    (( waited < TMUX_VERIFY_SECS )) || return 1$/d' 'the read-before-budget order'
+launch_table \
+  "control: deciding before the capture reports a lane that came up on the last nudge as stuck|tmux|-|-|echo,echo,delivered|rc=1 stderr~never+reached+a+ready+composer=true"
 unmutate
 
 echo "=== open-terminal claude handoff: the verify timeout ==="


### PR DESCRIPTION
`open_tmux` verified a tmux launch by one predicate: the brief on a plain transcript line AND a transcript-activity marker. A long brief whose transcript line the TUI wraps, truncates or redraws defeats the first half, so the launch fell through to `tmux_wait_composer`, whose only ready predicate is the idle `? for shortcuts` footer. A pane mid-turn never draws that footer, so the wait timed out into `never reached a ready composer` and exit 1 over a healthy working lane — six false alarms in one supervision night — while sending one Enter per pass into its running turn.

A turn in flight is now an independent second proof that the launch took. `tmux_wait_composer` returns a third status for that pane, so the wait ends without another keystroke. The failure exit is unchanged for a pane stuck at a first-run dialog or dead.

The predicate is `WORKING_RE`, which `oversee-watch` already owned and had measured off running sessions of both harnesses; it moves to `scripts/lib/pane-working.sh` and both scripts source it rather than keeping two answers to one question.

## What the review round changed

A first draft keyed on the spinner glyphs. Live captures of Claude Code v2.1.261 killed it:

* the same frame set (`· ✢ * ✶ ✻ ✽`) animates the OAuth sign-in screen, so a lane parked at a login prompt would have reported launched — a gate flipped from fail-closed to fail-open;
* `✻` also spells the idle end-of-turn line (`✻ Churned for 6s · done`), so it survives the turn that drew it;
* `esc to interrupt` is absent from that version's working footer.

`WORKING_RE` read false on every onboarding screen captured (theme picker, login method, sign-in spinner, paste-code, trust dialog, post-trust boot — 0 of 80 captures matched).

The brief half keeps its activity conjunction for the same reason: the captures show the composer no longer drawn with `│`, so the plain-line read alone would let an unsent draft pass as a submitted prompt.

## Tests

Three rows in `open-terminal-claude-handoff.sh` — a turn in flight, a turn starting during the composer wait, and a sign-in step animating the spinner that must still fail — and two mutants: `pane_working` cut to always-false restores the original false alarm, and widened to the spinner reports the sign-in step as launched.

All seven `open-terminal-*.sh` and all four `oversee_watch_*.sh` suites pass. `ui` vitest 1193/1193.

## Second commit: the composer the harness actually draws

Two more predicates in the same function were keyed on a TUI Claude Code no longer draws. Both were found by measurement during review and are folded in here rather than filed.

* The filter that keeps an unsent draft from counting as a submitted prompt dropped lines containing `│`, the border an older composer was boxed in. v2.1.261 draws two `────` rules around the prompt line, with no `│` on the screen at all, so that filter matched nothing and a half-typed brief read as delivered.
* The readiness marker was the `? for shortcuts` footer, which that build never draws. Keyed on it, `tmux_wait_composer` could not return 0, so the brief re-send it exists to perform was unreachable and every consumed brief fell to the failure exit.

One marker fixes both. The composer's prompt line is `❯` followed by a **non-breaking** space; a submitted message is echoed into the transcript as `❯` followed by an ordinary one. Over 146 pane captures of v2.1.261:

| screen group | n | composer marker | submitted echo |
|---|---|---|---|
| first-run (theme, login, sign-in, paste-code) | 5 | 0 | 0 |
| trust dialog and boot | 40 | 0 | 0 |
| idle composer | 40 | 35 | 0 |
| turn in flight | 60 | 57 | 56 |
| unsent draft | 1 | 1 | 0 |

So it drops the draft line from the delivery read, answers readiness, and cannot mistake a first-run dialog for a composer. It is spelled as bytes: the character is invisible in source and a reformat would turn it into an ordinary space.

Both older spellings stay alongside it — this is another tool's surface, and a lane may run a build that still draws them.

Four rows (a draft in the current shape, the older `│` box, the older footer read as ready, the recovery path over the current composer) and two mutants: dropping the composer filter reports the draft as launched, and keying readiness on the old footer alone leaves a dialog that ate the brief unrecoverable.

Program tracking: architecture-docs program, KEN-985.

https://claude.ai/code/session_016qGWpwsPnJZZi6oRMqiBrs
