### PR TITLE
fix(KEN-1155): a milestone name resolves inside its project

### DIFF
--- a/.agents/skills/linear/scripts/commands/issues.sh
+++ b/.agents/skills/linear/scripts/commands/issues.sh
@@ -1194,10 +1194,26 @@ create_issue() {
     require_agent_routing_label "$labels" "$no_agent_label" || return 1
     require_issue_reach "$description" "$priority" "$review_born" || return 1
 
-    # Same rule as the label pre-resolution below, for a refusal that needs no
-    # API call at all: a milestone name with no --project can only be refused,
-    # and refusing it after the upload strands the asset in Linear storage.
-    require_milestone_project "$milestone" "$project" || return 1
+    # Resolve --project and --milestone BEFORE uploading, for the reason the
+    # label pre-resolution below states: each can still refuse — an unknown
+    # project, a milestone name with no project, an ambiguous one, a failed
+    # lookup — and a refusal after the upload strands the asset in Linear
+    # storage with no issue referencing it. The ids they yield are what the
+    # input below carries.
+    local project_id=""
+    if [ -n "$project" ]; then
+        project_id=$(resolve_project_id "$project")
+        if [ -z "$project_id" ]; then
+            return 1
+        fi
+    fi
+    local milestone_id=""
+    if [ -n "$milestone" ]; then
+        milestone_id=$(resolve_milestone_id "$milestone" "$project_id")
+        if [ -z "$milestone_id" ]; then
+            return 1
+        fi
+    fi
 
     # --attach: refuse unreadable paths before any API call, then upload
     # (uploads run only after the routing guard above has passed). Images
@@ -1293,14 +1309,8 @@ create_issue() {
         fi
     fi
 
-    # Handle project (auto-resolves name or UUID). The id outlives this block:
-    # milestone resolution below is scoped to it.
-    local project_id=""
-    if [ -n "$project" ]; then
-        project_id=$(resolve_project_id "$project")
-        if [ -z "$project_id" ]; then
-            return 1
-        fi
+    # Resolved above, before the attachment upload.
+    if [ -n "$project_id" ]; then
         input_parts+=("\"projectId\": \"$project_id\"")
     fi
 
@@ -1348,15 +1358,8 @@ create_issue() {
         input_parts+=("\"parentId\": \"$requested_parent_id\"")
     fi
 
-    # Handle milestone (auto-resolves name or UUID, fail fast on miss). A name
-    # is resolved inside the project resolved above; with none, the argument
-    # check above refused before any upload.
-    if [ -n "$milestone" ]; then
-        local milestone_id
-        milestone_id=$(resolve_milestone_id "$milestone" "$project_id")
-        if [ -z "$milestone_id" ]; then
-            return 1
-        fi
+    # Resolved above, before the attachment upload.
+    if [ -n "$milestone_id" ]; then
         input_parts+=("\"projectMilestoneId\": \"$milestone_id\"")
     fi
 
@@ -1690,7 +1693,6 @@ update_issue() {
     # it is in would move it to satisfy a lookup.
     local issue_project_id
     issue_project_id=$(echo "$issue_result" | jq -r '.issue.project.id // empty')
-    local milestone_scope="${project:-$issue_project_id}"
 
     # Same rule as the label resolution below, applied to the pure argument
     # check: a combination that can only be refused must be refused before any
@@ -1699,7 +1701,24 @@ update_issue() {
         echo '{"error": "Use either --labels <names> or --clear-labels, not both"}' >&2
         return 1
     fi
-    require_milestone_project "$milestone" "$milestone_scope" || return 1
+    # Resolved before the attachment upload below, for the reason the label
+    # resolution states: an unknown project, a milestone name with no project,
+    # an ambiguous one and a failed lookup all still refuse, and a refusal
+    # after the upload strands the asset in Linear storage.
+    local project_id=""
+    if [ -n "$project" ]; then
+        project_id=$(resolve_project_id "$project")
+        if [ -z "$project_id" ]; then
+            return 1
+        fi
+    fi
+    local milestone_id=""
+    if [ -n "$milestone" ]; then
+        milestone_id=$(resolve_milestone_id "$milestone" "${project_id:-$issue_project_id}")
+        if [ -z "$milestone_id" ]; then
+            return 1
+        fi
+    fi
 
     # Resolve --labels BEFORE any attachment upload: an unresolvable label
     # refuses the whole update below, and an upload done first would strand
@@ -1823,14 +1842,8 @@ update_issue() {
         input_parts+=("\"labelIds\": $resolved_label_json")
     fi
 
-    # Handle project (auto-resolves name or UUID). The id outlives this block:
-    # milestone resolution below is scoped to it.
-    local project_id=""
-    if [ -n "$project" ]; then
-        project_id=$(resolve_project_id "$project")
-        if [ -z "$project_id" ]; then
-            return 1
-        fi
+    # Resolved above, before the attachment upload.
+    if [ -n "$project_id" ]; then
         input_parts+=("\"projectId\": \"$project_id\"")
     fi
 
@@ -1870,15 +1883,8 @@ update_issue() {
         input_parts+=("\"parentId\": \"$parent_id\"")
     fi
 
-    # Handle milestone (auto-resolves name or UUID, fail fast on miss). A name
-    # is resolved inside the project this update moves the issue to, or the one
-    # it is already in; with neither it was refused before the upload above.
-    if [ -n "$milestone" ]; then
-        local milestone_id
-        milestone_id=$(resolve_milestone_id "$milestone" "${project_id:-$issue_project_id}")
-        if [ -z "$milestone_id" ]; then
-            return 1
-        fi
+    # Resolved above, before the attachment upload.
+    if [ -n "$milestone_id" ]; then
         input_parts+=("\"projectMilestoneId\": \"$milestone_id\"")
     fi
 

--- a/.agents/skills/linear/scripts/commands/issues.sh
+++ b/.agents/skills/linear/scripts/commands/issues.sh
@@ -86,7 +86,7 @@ Create Options:
   --estimate <1-5>      Effort estimate (points)
   --assignee <name|me>  Assignee
   --parent <id>         Parent issue ID (creates sub-issue)
-  --milestone <name|uuid> Project milestone (name or UUID)
+  --milestone <name|uuid> Project milestone (a name needs --project; a UUID does not)
   --cycle <id>          Cycle (sprint) ID
   --attach <path>       Upload a file to Linear and attach it (repeatable).
                         Images (png/jpg/jpeg/gif/webp/svg) embed into the
@@ -129,7 +129,7 @@ Update Options:
   --assignee <name|me>  Change assignee
   --parent <id>         Set parent issue (convert to sub-issue)
   --remove-parent       Remove parent (convert to top-level issue)
-  --milestone <name|uuid> Set project milestone (name or UUID)
+  --milestone <name|uuid> Set project milestone (a name needs --project; a UUID does not)
   --cycle <id>          Set cycle (sprint) ID
   --clear-cycle         Remove cycle assignment
   --attach <path>       Upload a file to Linear and attach it (repeatable).
@@ -1287,9 +1287,10 @@ create_issue() {
         fi
     fi
 
-    # Handle project (auto-resolves name or UUID)
+    # Handle project (auto-resolves name or UUID). The id outlives this block:
+    # milestone resolution below is scoped to it.
+    local project_id=""
     if [ -n "$project" ]; then
-        local project_id
         project_id=$(resolve_project_id "$project")
         if [ -z "$project_id" ]; then
             return 1
@@ -1341,10 +1342,11 @@ create_issue() {
         input_parts+=("\"parentId\": \"$requested_parent_id\"")
     fi
 
-    # Handle milestone (auto-resolves name or UUID, fail fast on miss)
+    # Handle milestone (auto-resolves name or UUID, fail fast on miss). A name
+    # is resolved inside the project resolved above; without one it is refused.
     if [ -n "$milestone" ]; then
         local milestone_id
-        milestone_id=$(resolve_milestone_id "$milestone")
+        milestone_id=$(resolve_milestone_id "$milestone" "$project_id")
         if [ -z "$milestone_id" ]; then
             return 1
         fi
@@ -1807,9 +1809,10 @@ update_issue() {
         input_parts+=("\"labelIds\": $resolved_label_json")
     fi
 
-    # Handle project (auto-resolves name or UUID)
+    # Handle project (auto-resolves name or UUID). The id outlives this block:
+    # milestone resolution below is scoped to it.
+    local project_id=""
     if [ -n "$project" ]; then
-        local project_id
         project_id=$(resolve_project_id "$project")
         if [ -z "$project_id" ]; then
             return 1
@@ -1853,10 +1856,11 @@ update_issue() {
         input_parts+=("\"parentId\": \"$parent_id\"")
     fi
 
-    # Handle milestone (auto-resolves name or UUID, fail fast on miss)
+    # Handle milestone (auto-resolves name or UUID, fail fast on miss). A name
+    # is resolved inside the project resolved above; without one it is refused.
     if [ -n "$milestone" ]; then
         local milestone_id
-        milestone_id=$(resolve_milestone_id "$milestone")
+        milestone_id=$(resolve_milestone_id "$milestone" "$project_id")
         if [ -z "$milestone_id" ]; then
             return 1
         fi

--- a/.agents/skills/linear/scripts/commands/issues.sh
+++ b/.agents/skills/linear/scripts/commands/issues.sh
@@ -1194,6 +1194,14 @@ create_issue() {
     require_agent_routing_label "$labels" "$no_agent_label" || return 1
     require_issue_reach "$description" "$priority" "$review_born" || return 1
 
+    # --attach: refuse unreadable paths before ANY API call, which is what
+    # `--help` promises, so this stays ahead of the resolvers below. Images
+    # embed into the description; other files become Linear attachments on
+    # the created issue after the create (attachmentCreate needs its id).
+    if [ ${#attach_paths[@]} -gt 0 ]; then
+        attach_preflight_files "${attach_paths[@]}" || return 1
+    fi
+
     # Resolve --project and --milestone BEFORE uploading, for the reason the
     # label pre-resolution below states: each can still refuse — an unknown
     # project, a milestone name with no project, an ambiguous one, a failed
@@ -1215,12 +1223,8 @@ create_issue() {
         fi
     fi
 
-    # --attach: refuse unreadable paths before any API call, then upload
-    # (uploads run only after the routing guard above has passed). Images
-    # embed into the description; other files become Linear attachments on
-    # the created issue after the create (attachmentCreate needs its id).
+    # Uploads run only after the routing guard and the resolvers above.
     if [ ${#attach_paths[@]} -gt 0 ]; then
-        attach_preflight_files "${attach_paths[@]}" || return 1
         # Resolve declared agent labels BEFORE uploading: under a declared
         # taxonomy an unresolvable agent label refuses the create later
         # (routed-or-refused), and uploads done first would strand orphaned

--- a/.agents/skills/linear/scripts/commands/issues.sh
+++ b/.agents/skills/linear/scripts/commands/issues.sh
@@ -129,7 +129,8 @@ Update Options:
   --assignee <name|me>  Change assignee
   --parent <id>         Set parent issue (convert to sub-issue)
   --remove-parent       Remove parent (convert to top-level issue)
-  --milestone <name|uuid> Set project milestone (a name needs --project; a UUID does not)
+  --milestone <name|uuid> Set project milestone (a name resolves in --project,
+                        else the issue's own project)
   --cycle <id>          Set cycle (sprint) ID
   --clear-cycle         Remove cycle assignment
   --attach <path>       Upload a file to Linear and attach it (repeatable).
@@ -1193,6 +1194,11 @@ create_issue() {
     require_agent_routing_label "$labels" "$no_agent_label" || return 1
     require_issue_reach "$description" "$priority" "$review_born" || return 1
 
+    # Same rule as the label pre-resolution below, for a refusal that needs no
+    # API call at all: a milestone name with no --project can only be refused,
+    # and refusing it after the upload strands the asset in Linear storage.
+    require_milestone_project "$milestone" "$project" || return 1
+
     # --attach: refuse unreadable paths before any API call, then upload
     # (uploads run only after the routing guard above has passed). Images
     # embed into the description; other files become Linear attachments on
@@ -1343,7 +1349,8 @@ create_issue() {
     fi
 
     # Handle milestone (auto-resolves name or UUID, fail fast on miss). A name
-    # is resolved inside the project resolved above; without one it is refused.
+    # is resolved inside the project resolved above; with none, the argument
+    # check above refused before any upload.
     if [ -n "$milestone" ]; then
         local milestone_id
         milestone_id=$(resolve_milestone_id "$milestone" "$project_id")
@@ -1678,6 +1685,12 @@ update_issue() {
     issue_result=$(get_issue "$issue_id" --format=raw)
     local team_name
     team_name=$(echo "$issue_result" | jq -r '.issue.team.name // empty')
+    # The scope a milestone name resolves in when --project is absent: the
+    # issue is already in a project, and asking for --project to name the one
+    # it is in would move it to satisfy a lookup.
+    local issue_project_id
+    issue_project_id=$(echo "$issue_result" | jq -r '.issue.project.id // empty')
+    local milestone_scope="${project:-$issue_project_id}"
 
     # Same rule as the label resolution below, applied to the pure argument
     # check: a combination that can only be refused must be refused before any
@@ -1686,6 +1699,7 @@ update_issue() {
         echo '{"error": "Use either --labels <names> or --clear-labels, not both"}' >&2
         return 1
     fi
+    require_milestone_project "$milestone" "$milestone_scope" || return 1
 
     # Resolve --labels BEFORE any attachment upload: an unresolvable label
     # refuses the whole update below, and an upload done first would strand
@@ -1857,10 +1871,11 @@ update_issue() {
     fi
 
     # Handle milestone (auto-resolves name or UUID, fail fast on miss). A name
-    # is resolved inside the project resolved above; without one it is refused.
+    # is resolved inside the project this update moves the issue to, or the one
+    # it is already in; with neither it was refused before the upload above.
     if [ -n "$milestone" ]; then
         local milestone_id
-        milestone_id=$(resolve_milestone_id "$milestone" "$project_id")
+        milestone_id=$(resolve_milestone_id "$milestone" "${project_id:-$issue_project_id}")
         if [ -z "$milestone_id" ]; then
             return 1
         fi

--- a/.agents/skills/linear/scripts/lib/common.sh
+++ b/.agents/skills/linear/scripts/lib/common.sh
@@ -795,6 +795,42 @@ resolve_label_id() {
     echo "$label_id"
 }
 
+# A milestone reference that is already a UUID, and so needs no project to
+# resolve it in. One statement of the rule: the pre-upload guard below and
+# resolve_milestone_id must agree on it, or a reference one calls a name the
+# other calls resolved.
+milestone_ref_is_uuid() {
+    [[ "$1" =~ ^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$ ]]
+}
+
+# Refuse a milestone NAME that has no project to resolve it in.
+# Usage: require_milestone_project "$milestone" "$project_scope"
+#
+# The scope is any project reference the caller has: the --project argument
+# before it is resolved, or the issue's own project on the update path. Only
+# whether one exists is judged here, never which.
+#
+# Both call sites run this from their arguments BEFORE uploading --attach
+# files: a refusal after an upload strands the asset in Linear storage with no
+# issue referencing it, which is the rule issues.sh states at its label
+# pre-resolution. resolve_milestone_id runs it again on the resolved id.
+# Plain `if`, not `test && return`: a false `&&` compound is a non-zero status
+# under this file's errexit, which would end a bare call before its diagnostic.
+require_milestone_project() {
+    local milestone_ref="$1" project_scope="${2:-}"
+
+    if [ -z "$milestone_ref" ] || [ -n "$project_scope" ]; then
+        return 0
+    fi
+    if milestone_ref_is_uuid "$milestone_ref"; then
+        return 0
+    fi
+
+    jq -cn --arg ref "$milestone_ref" \
+        '{error: ("Cannot resolve milestone " + ($ref | tojson) + " without a project: the same milestone name exists in other projects. Pass --project, or pass the milestone UUID.")}' >&2
+    return 1
+}
+
 # Resolve milestone name or UUID to UUID, within one project
 # Usage: resolve_milestone_id "Alpha" "project-uuid" or resolve_milestone_id "uuid-here"
 #
@@ -808,16 +844,12 @@ resolve_milestone_id() {
     local project_id="${2:-}"
 
     # Check if it's already a UUID
-    if [[ "$milestone_ref" =~ ^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$ ]]; then
+    if milestone_ref_is_uuid "$milestone_ref"; then
         echo "$milestone_ref"
         return 0
     fi
 
-    if [ -z "$project_id" ]; then
-        jq -cn --arg ref "$milestone_ref" \
-            '{error: ("Cannot resolve milestone " + ($ref | tojson) + " without a project: the same milestone name exists in other projects. Pass --project, or pass the milestone UUID.")}' >&2
-        return 1
-    fi
+    require_milestone_project "$milestone_ref" "$project_id" || return 1
 
     # Look up by name within the project.
     local query='query GetMilestone($name: String!, $projectId: ID!) { projectMilestones(filter: {name: {eq: $name}, project: {id: {eq: $projectId}}}) { nodes { id } } }'

--- a/.agents/skills/linear/scripts/lib/common.sh
+++ b/.agents/skills/linear/scripts/lib/common.sh
@@ -798,9 +798,12 @@ resolve_label_id() {
 # A milestone reference that is already a UUID, and so needs no project to
 # resolve it in. One statement of the rule: the pre-upload guard below and
 # resolve_milestone_id must agree on it, or a reference one calls a name the
-# other calls resolved.
+# other calls resolved. LINEAR_UUID_PATTERN is that grammar everywhere else,
+# `--cycle` included, and it accepts uppercase hex; a second, lowercase-only
+# spelling here would refuse an uppercase UUID for want of a project the
+# option's contract says it does not need.
 milestone_ref_is_uuid() {
-    [[ "$1" =~ ^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$ ]]
+    [[ "$1" =~ $LINEAR_UUID_PATTERN ]]
 }
 
 # Refuse a milestone NAME that has no project to resolve it in.

--- a/.agents/skills/linear/scripts/lib/common.sh
+++ b/.agents/skills/linear/scripts/lib/common.sh
@@ -795,10 +795,17 @@ resolve_label_id() {
     echo "$label_id"
 }
 
-# Resolve milestone name or UUID to UUID
-# Usage: resolve_milestone_id "Alpha" or resolve_milestone_id "uuid-here"
+# Resolve milestone name or UUID to UUID, within one project
+# Usage: resolve_milestone_id "Alpha" "project-uuid" or resolve_milestone_id "uuid-here"
+#
+# A milestone name is unique to its project and nothing more: "Alpha" exists in
+# as many projects as reuse it, and an unscoped name query returns all of them
+# in no fixed order, so nodes[0] filed the issue under whichever project the API
+# listed first. The project the caller already resolved is the scope, and a name
+# with no project to scope it is refused rather than guessed at.
 resolve_milestone_id() {
     local milestone_ref="$1"
+    local project_id="${2:-}"
 
     # Check if it's already a UUID
     if [[ "$milestone_ref" =~ ^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$ ]]; then
@@ -806,18 +813,40 @@ resolve_milestone_id() {
         return 0
     fi
 
-    # Look up by name
-    local query='query GetMilestone($name: String!) { projectMilestones(filter: {name: {eq: $name}}) { nodes { id } } }'
-    local vars result
-    vars=$(jq -cn --arg name "$milestone_ref" '{name: $name}')
-    result=$(graphql_query "$query" "$vars")
-    local milestone_id
-    milestone_id=$(echo "$result" | jq -r '.projectMilestones.nodes[0].id // empty')
+    if [ -z "$project_id" ]; then
+        jq -cn --arg ref "$milestone_ref" \
+            '{error: ("Cannot resolve milestone " + ($ref | tojson) + " without a project: the same milestone name exists in other projects. Pass --project, or pass the milestone UUID.")}' >&2
+        return 1
+    fi
 
-    if [ -z "$milestone_id" ]; then
+    # Look up by name within the project.
+    local query='query GetMilestone($name: String!, $projectId: ID!) { projectMilestones(filter: {name: {eq: $name}, project: {id: {eq: $projectId}}}) { nodes { id } } }'
+    local vars result
+    vars=$(jq -cn --arg name "$milestone_ref" --arg projectId "$project_id" '{name: $name, projectId: $projectId}')
+    # A FAILED query is an API failure (rate limit, outage); "Milestone not
+    # found" is only true of a lookup that succeeded and matched nothing.
+    if ! result=$(graphql_query "$query" "$vars"); then
+        jq -cn --arg ref "$milestone_ref" \
+            '{error: ("Could not resolve milestone " + ($ref | tojson) + ": Linear API request failed (see previous error)")}' >&2
+        return 1
+    fi
+
+    # The whole match set, joined: a UUID holds no comma, so a comma in the
+    # join is exactly a second match, and the same string names the candidates
+    # in the refusal.
+    local milestone_ids
+    milestone_ids=$(echo "$result" | jq -r '[(.projectMilestones.nodes // [])[].id] | join(", ")')
+
+    if [ -z "$milestone_ids" ]; then
         jq -cn --arg ref "$milestone_ref" '{error: ("Milestone not found: " + $ref)}' >&2
         return 1
     fi
 
-    echo "$milestone_id"
+    if [[ "$milestone_ids" == *,* ]]; then
+        jq -cn --arg ref "$milestone_ref" --arg matches "$milestone_ids" \
+            '{error: ("Milestone name is ambiguous within the project: " + ($ref | tojson) + " matches " + $matches + "; pass a milestone UUID to target one)")}' >&2
+        return 1
+    fi
+
+    echo "$milestone_ids"
 }

--- a/.agents/skills/linear/tests/controls/milestone-project-scope.control.sh
+++ b/.agents/skills/linear/tests/controls/milestone-project-scope.control.sh
@@ -1,0 +1,35 @@
+# Drop the scope at both call sites, so the resolver is asked for a milestone
+# name with no project to resolve it in — which is what the two call sites did
+# before, having resolved the project id and then not passed it.
+control_expect "issues create files the issue under the project's own milestone"
+control_replace scripts/commands/issues.sh 2 \
+    '        milestone_id=$(resolve_milestone_id "$milestone" "$project_id")' \
+    '        milestone_id=$(resolve_milestone_id "$milestone")'
+
+# Ask the name query without the project filter, as it shipped. The fixture then
+# answers from every project, foreign milestone first.
+control_expect "issues update sets the project's own milestone"
+control_replace scripts/lib/common.sh 1 \
+    "    local query='query GetMilestone(\$name: String!, \$projectId: ID!) { projectMilestones(filter: {name: {eq: \$name}, project: {id: {eq: \$projectId}}}) { nodes { id } } }'" \
+    "    local query='query GetMilestone(\$name: String!) { projectMilestones(filter: {name: {eq: \$name}}) { nodes { id } } }'"
+
+# Take the first match instead of the whole set, so a second milestone of that
+# name is picked from rather than refused.
+control_expect "the ambiguity refusal names the second candidate UUID"
+control_replace scripts/lib/common.sh 1 \
+    "    milestone_ids=\$(echo \"\$result\" | jq -r '[(.projectMilestones.nodes // [])[].id] | join(\", \")')" \
+    "    milestone_ids=\$(echo \"\$result\" | jq -r '.projectMilestones.nodes[0].id // empty')"
+
+# Let every name resolver take a failed lookup for an empty one. Only the
+# milestone lookup fails in this suite, so this is the unchecked exit status
+# resolve_milestone_id shipped with: an outage reported as a missing milestone.
+control_expect "a failed lookup reports the API failure"
+control_replace scripts/lib/common.sh 3 \
+    '    if ! result=$(graphql_query "$query" "$vars"); then' \
+    '    if ! result=$(graphql_query "$query" "$vars" || true); then'
+
+# Resolve a name with no project rather than refusing it.
+control_expect "the refusal names the missing project"
+control_replace scripts/lib/common.sh 1 \
+    '    if [ -z "$project_id" ]; then' \
+    '    if false; then'

--- a/.agents/skills/linear/tests/controls/milestone-project-scope.control.sh
+++ b/.agents/skills/linear/tests/controls/milestone-project-scope.control.sh
@@ -41,17 +41,18 @@ control_replace scripts/commands/issues.sh 1 \
     '        milestone_id=$(resolve_milestone_id "$milestone" "${project_id:-$issue_project_id}")' \
     '        milestone_id=$(resolve_milestone_id "$milestone" "$project_id")'
 
-# Leave the create's refusal to the resolver, which runs after the upload.
-control_expect "no upload is sent before the create refusal"
+# Leave the create's milestone unresolved where it is hoisted, so the refusal
+# falls back to whatever runs after the upload.
+control_expect "no upload is sent before the create ambiguity refusal"
 control_replace scripts/commands/issues.sh 1 \
-    '    require_milestone_project "$milestone" "$project" || return 1' \
-    '    true'
+    '        milestone_id=$(resolve_milestone_id "$milestone" "$project_id")' \
+    '        milestone_id=deferred-uuid'
 
 # Same for the update's.
-control_expect "no upload is sent before the update refusal"
+control_expect "no upload is sent before the update ambiguity refusal"
 control_replace scripts/commands/issues.sh 1 \
-    '    require_milestone_project "$milestone" "$milestone_scope" || return 1' \
-    '    true'
+    '        milestone_id=$(resolve_milestone_id "$milestone" "${project_id:-$issue_project_id}")' \
+    '        milestone_id=deferred-uuid'
 
 # Scope the update to the issue's own project even when --project names another,
 # so setting a milestone while moving an issue resolves in the project it is
@@ -60,6 +61,7 @@ control_expect "--project wins over the project the issue is already in"
 control_replace scripts/commands/issues.sh 1 \
     '        milestone_id=$(resolve_milestone_id "$milestone" "${project_id:-$issue_project_id}")' \
     '        milestone_id=$(resolve_milestone_id "$milestone" "$issue_project_id")'
+
 
 # Stop treating a UUID as already resolved, so the project requirement reaches
 # a reference that names one milestone on its own.

--- a/.agents/skills/linear/tests/controls/milestone-project-scope.control.sh
+++ b/.agents/skills/linear/tests/controls/milestone-project-scope.control.sh
@@ -69,3 +69,10 @@ control_expect "a milestone UUID needs no project"
 control_replace scripts/lib/common.sh 2 \
     '    if milestone_ref_is_uuid "$milestone_ref"; then' \
     '    if false; then'
+
+# Skip the --attach preflight, so an unreadable path reaches the resolvers this
+# change hoisted and costs API calls before the refusal --help promises.
+control_expect "no project lookup precedes the missing-path refusal"
+control_replace scripts/commands/issues.sh 2 \
+    '        attach_preflight_files "${attach_paths[@]}" || return 1' \
+    '        true'

--- a/.agents/skills/linear/tests/controls/milestone-project-scope.control.sh
+++ b/.agents/skills/linear/tests/controls/milestone-project-scope.control.sh
@@ -8,7 +8,7 @@ control_replace scripts/commands/issues.sh 1 \
 
 # Ask the name query without the project filter, as it shipped. The fixture then
 # answers from every project, foreign milestone first.
-control_expect "issues update sets the project's own milestone"
+control_expect "issues update succeeds without --project on an issue that has one"
 control_replace scripts/lib/common.sh 1 \
     "    local query='query GetMilestone(\$name: String!, \$projectId: ID!) { projectMilestones(filter: {name: {eq: \$name}, project: {id: {eq: \$projectId}}}) { nodes { id } } }'" \
     "    local query='query GetMilestone(\$name: String!) { projectMilestones(filter: {name: {eq: \$name}}) { nodes { id } } }'"
@@ -52,3 +52,18 @@ control_expect "no upload is sent before the update refusal"
 control_replace scripts/commands/issues.sh 1 \
     '    require_milestone_project "$milestone" "$milestone_scope" || return 1' \
     '    true'
+
+# Scope the update to the issue's own project even when --project names another,
+# so setting a milestone while moving an issue resolves in the project it is
+# leaving.
+control_expect "--project wins over the project the issue is already in"
+control_replace scripts/commands/issues.sh 1 \
+    '        milestone_id=$(resolve_milestone_id "$milestone" "${project_id:-$issue_project_id}")' \
+    '        milestone_id=$(resolve_milestone_id "$milestone" "$issue_project_id")'
+
+# Stop treating a UUID as already resolved, so the project requirement reaches
+# a reference that names one milestone on its own.
+control_expect "a milestone UUID needs no project"
+control_replace scripts/lib/common.sh 2 \
+    '    if milestone_ref_is_uuid "$milestone_ref"; then' \
+    '    if false; then'

--- a/.agents/skills/linear/tests/controls/milestone-project-scope.control.sh
+++ b/.agents/skills/linear/tests/controls/milestone-project-scope.control.sh
@@ -1,8 +1,8 @@
-# Drop the scope at both call sites, so the resolver is asked for a milestone
-# name with no project to resolve it in — which is what the two call sites did
-# before, having resolved the project id and then not passed it.
+# Drop the scope at the create call site, so the resolver is asked for a
+# milestone name with no project to resolve it in — which is what both call
+# sites did before, having resolved the project id and then not passed it.
 control_expect "issues create files the issue under the project's own milestone"
-control_replace scripts/commands/issues.sh 2 \
+control_replace scripts/commands/issues.sh 1 \
     '        milestone_id=$(resolve_milestone_id "$milestone" "$project_id")' \
     '        milestone_id=$(resolve_milestone_id "$milestone")'
 
@@ -31,5 +31,24 @@ control_replace scripts/lib/common.sh 3 \
 # Resolve a name with no project rather than refusing it.
 control_expect "the refusal names the missing project"
 control_replace scripts/lib/common.sh 1 \
-    '    if [ -z "$project_id" ]; then' \
-    '    if false; then'
+    '    if [ -z "$milestone_ref" ] || [ -n "$project_scope" ]; then' \
+    '    if true; then'
+
+# Scope the update's name to --project alone, so an issue already in a project
+# is refused unless the caller re-sends the project it is in.
+control_expect "issues update scopes the name to the issue's own project"
+control_replace scripts/commands/issues.sh 1 \
+    '        milestone_id=$(resolve_milestone_id "$milestone" "${project_id:-$issue_project_id}")' \
+    '        milestone_id=$(resolve_milestone_id "$milestone" "$project_id")'
+
+# Leave the create's refusal to the resolver, which runs after the upload.
+control_expect "no upload is sent before the create refusal"
+control_replace scripts/commands/issues.sh 1 \
+    '    require_milestone_project "$milestone" "$project" || return 1' \
+    '    true'
+
+# Same for the update's.
+control_expect "no upload is sent before the update refusal"
+control_replace scripts/commands/issues.sh 1 \
+    '    require_milestone_project "$milestone" "$milestone_scope" || return 1' \
+    '    true'

--- a/.agents/skills/linear/tests/milestone-project-scope.test.sh
+++ b/.agents/skills/linear/tests/milestone-project-scope.test.sh
@@ -76,7 +76,16 @@ case "$query" in
   fi
   ;;
 *"issues(filter:"* | *"issue(id:"*)
-  printf '%s' '{"data":{"issue":{"id":"iss-uuid","identifier":"ISS-1","team":{"id":"team-uuid"}}}}___HTTP_CODE___200'
+  # ISS-1 is in a project; ISS-2 is in none, which is the only issue a
+  # milestone name on the update path can still be refused for.
+  if [ "$(jq -r '.variables.id // empty' <<<"$payload")" = "ISS-2" ]; then
+    printf '%s' '{"data":{"issue":{"id":"iss2-uuid","identifier":"ISS-2","team":{"id":"team-uuid"},"project":null}}}___HTTP_CODE___200'
+  else
+    printf '%s' '{"data":{"issue":{"id":"iss-uuid","identifier":"ISS-1","team":{"id":"team-uuid"},"project":{"id":"live-uuid","name":"Dup"}}}}___HTTP_CODE___200'
+  fi
+  ;;
+*"fileUpload"*)
+  printf '%s' '{"data":{"fileUpload":{"success":false}}}___HTTP_CODE___200'
   ;;
 *"issueCreate(input:"*)
   printf '%s' '{"data":{"issueCreate":{"success":true,"issue":{"id":"child-uuid","identifier":"CC-900","title":"t","description":"d","state":{"name":"Todo","type":"unstarted"},"assignee":null,"project":{"id":"live-uuid","name":"Dup"},"projectMilestone":null,"cycle":null,"parent":null,"team":{"name":"TestTeam"},"labels":{"nodes":[{"name":"agent:rust"}]},"priority":3,"estimate":null,"sortOrder":1.0,"url":"https://linear.app/test/issue/CC-900","createdAt":"2026-09-02T00:00:00Z","updatedAt":"2026-09-02T00:00:00Z","archivedAt":null,"trashed":null,"relations":{"nodes":[]},"inverseRelations":{"nodes":[]}}}}}___HTTP_CODE___200'
@@ -150,3 +159,33 @@ assert_ne "a milestone name without a project refuses the create" "$unscoped_rc"
 assert_file_contains "the refusal names the missing project" "$ERR_FILE" "without a project"
 assert_file_lacks "no milestone lookup is sent without a project to scope it" \
   "$CURL_LOG" "projectMilestones"
+
+# Surface: on update, the issue's own project scopes the name. Asking for
+# --project to name the project the issue is already in would move it to
+# satisfy a lookup.
+: >"$CURL_LOG"
+run_status own_project_rc run_linear issues update ISS-1 --milestone Alpha
+assert_eq "issues update succeeds without --project on an issue that has one" "$own_project_rc" 0
+assert "issues update scopes the name to the issue's own project" \
+  jq -s -e 'any(.[]; (.query | contains("issueUpdate")) and .variables.input.projectMilestoneId == "alpha-here")' \
+  "$CURL_LOG" >/dev/null
+
+# Surface: the refusal is decided from the arguments, so it lands before
+# --attach uploads. A refusal after an upload strands the asset in Linear
+# storage with no issue referencing it.
+printf 'x' >"$TMP_ROOT/asset.bin"
+
+: >"$CURL_LOG"
+run_status create_attach_rc run_linear issues create --title t --team TestTeam \
+  --labels agent:rust --priority 3 --description d --milestone Alpha \
+  --attach "$TMP_ROOT/asset.bin"
+assert_ne "a project-less milestone name refuses the create that carries --attach" \
+  "$create_attach_rc" 0
+assert_file_lacks "no upload is sent before the create refusal" "$CURL_LOG" "fileUpload"
+
+: >"$CURL_LOG"
+run_status update_attach_rc run_linear issues update ISS-2 --milestone Alpha \
+  --attach "$TMP_ROOT/asset.bin"
+assert_ne "a milestone name refuses the update of an issue in no project" \
+  "$update_attach_rc" 0
+assert_file_lacks "no upload is sent before the update refusal" "$CURL_LOG" "fileUpload"

--- a/.agents/skills/linear/tests/milestone-project-scope.test.sh
+++ b/.agents/skills/linear/tests/milestone-project-scope.test.sh
@@ -64,13 +64,15 @@ case "$query" in
   case "$query" in *"project: {id:"*) scoped=yes ;; esac
   if [ "$scoped" = no ]; then
     printf '%s' '{"data":{"projectMilestones":{"nodes":[{"id":"alpha-elsewhere"},{"id":"alpha-here"}]}}}___HTTP_CODE___200'
-  elif [ "$project" != "live-uuid" ]; then
-    printf '%s' '{"data":{"projectMilestones":{"nodes":[]}}}___HTTP_CODE___200'
   else
-    case "$name" in
-    Alpha) printf '%s' '{"data":{"projectMilestones":{"nodes":[{"id":"alpha-here"}]}}}___HTTP_CODE___200' ;;
-    Twin) printf '%s' '{"data":{"projectMilestones":{"nodes":[{"id":"twin-one"},{"id":"twin-two"}]}}}___HTTP_CODE___200' ;;
-    Boom) printf '%s' '{"errors":[{"message":"Rate limited"}]}___HTTP_CODE___200' ;;
+    case "$project/$name" in
+    # The project --project names.
+    live-uuid/Alpha) printf '%s' '{"data":{"projectMilestones":{"nodes":[{"id":"alpha-here"}]}}}___HTTP_CODE___200' ;;
+    # The project ISS-1 is already in. Its Alpha is a different milestone, so
+    # a case that passes --project proves which of the two won.
+    old-uuid/Alpha) printf '%s' '{"data":{"projectMilestones":{"nodes":[{"id":"alpha-old"}]}}}___HTTP_CODE___200' ;;
+    live-uuid/Twin) printf '%s' '{"data":{"projectMilestones":{"nodes":[{"id":"twin-one"},{"id":"twin-two"}]}}}___HTTP_CODE___200' ;;
+    live-uuid/Boom) printf '%s' '{"errors":[{"message":"Rate limited"}]}___HTTP_CODE___200' ;;
     *) printf '%s' '{"data":{"projectMilestones":{"nodes":[]}}}___HTTP_CODE___200' ;;
     esac
   fi
@@ -81,7 +83,7 @@ case "$query" in
   if [ "$(jq -r '.variables.id // empty' <<<"$payload")" = "ISS-2" ]; then
     printf '%s' '{"data":{"issue":{"id":"iss2-uuid","identifier":"ISS-2","team":{"id":"team-uuid"},"project":null}}}___HTTP_CODE___200'
   else
-    printf '%s' '{"data":{"issue":{"id":"iss-uuid","identifier":"ISS-1","team":{"id":"team-uuid"},"project":{"id":"live-uuid","name":"Dup"}}}}___HTTP_CODE___200'
+    printf '%s' '{"data":{"issue":{"id":"iss-uuid","identifier":"ISS-1","team":{"id":"team-uuid"},"project":{"id":"old-uuid","name":"Old"}}}}___HTTP_CODE___200'
   fi
   ;;
 *"fileUpload"*)
@@ -128,7 +130,7 @@ assert "issues create files the issue under the project's own milestone" \
 : >"$CURL_LOG"
 run_status update_rc update_with_milestone Alpha
 assert_eq "issues update succeeds with a project-scoped milestone name" "$update_rc" 0
-assert "issues update sets the project's own milestone" \
+assert "--project wins over the project the issue is already in" \
   jq -s -e 'any(.[]; (.query | contains("issueUpdate")) and .variables.input.projectMilestoneId == "alpha-here")' \
   "$CURL_LOG" >/dev/null
 
@@ -167,8 +169,19 @@ assert_file_lacks "no milestone lookup is sent without a project to scope it" \
 run_status own_project_rc run_linear issues update ISS-1 --milestone Alpha
 assert_eq "issues update succeeds without --project on an issue that has one" "$own_project_rc" 0
 assert "issues update scopes the name to the issue's own project" \
-  jq -s -e 'any(.[]; (.query | contains("issueUpdate")) and .variables.input.projectMilestoneId == "alpha-here")' \
+  jq -s -e 'any(.[]; (.query | contains("issueUpdate")) and .variables.input.projectMilestoneId == "alpha-old")' \
   "$CURL_LOG" >/dev/null
+
+# Surface: a milestone UUID resolves with no project at all. It names one
+# milestone already, and refusing it would take `--milestone <uuid>` with it.
+: >"$CURL_LOG"
+run_status uuid_rc run_linear issues update ISS-2 \
+  --milestone 11111111-2222-3333-4444-555555555555
+assert_eq "a milestone UUID needs no project" "$uuid_rc" 0
+assert "the UUID reaches the mutation as given" \
+  jq -s -e 'any(.[]; (.query | contains("issueUpdate")) and .variables.input.projectMilestoneId == "11111111-2222-3333-4444-555555555555")' \
+  "$CURL_LOG" >/dev/null
+assert_file_lacks "a milestone UUID is not looked up by name" "$CURL_LOG" "projectMilestones"
 
 # Surface: the refusal is decided from the arguments, so it lands before
 # --attach uploads. A refusal after an upload strands the asset in Linear

--- a/.agents/skills/linear/tests/milestone-project-scope.test.sh
+++ b/.agents/skills/linear/tests/milestone-project-scope.test.sh
@@ -202,3 +202,22 @@ run_status update_attach_rc run_linear issues update ISS-2 --milestone Alpha \
 assert_ne "a milestone name refuses the update of an issue in no project" \
   "$update_attach_rc" 0
 assert_file_lacks "no upload is sent before the update refusal" "$CURL_LOG" "fileUpload"
+
+# The ambiguity refusal needs the lookup, not just the arguments, so it is the
+# one that proves the whole resolution runs ahead of the upload.
+: >"$CURL_LOG"
+run_status create_twin_attach_rc run_linear issues create --title t --team TestTeam \
+  --labels agent:rust --priority 3 --description d --project Dup --milestone Twin \
+  --attach "$TMP_ROOT/asset.bin"
+assert_ne "an ambiguous milestone name refuses the create that carries --attach" \
+  "$create_twin_attach_rc" 0
+assert_file_lacks "no upload is sent before the create ambiguity refusal" \
+  "$CURL_LOG" "fileUpload"
+
+: >"$CURL_LOG"
+run_status update_twin_attach_rc run_linear issues update ISS-1 --project Dup \
+  --milestone Twin --attach "$TMP_ROOT/asset.bin"
+assert_ne "an ambiguous milestone name refuses the update that carries --attach" \
+  "$update_twin_attach_rc" 0
+assert_file_lacks "no upload is sent before the update ambiguity refusal" \
+  "$CURL_LOG" "fileUpload"

--- a/.agents/skills/linear/tests/milestone-project-scope.test.sh
+++ b/.agents/skills/linear/tests/milestone-project-scope.test.sh
@@ -203,6 +203,20 @@ assert_ne "a milestone name refuses the update of an issue in no project" \
   "$update_attach_rc" 0
 assert_file_lacks "no upload is sent before the update refusal" "$CURL_LOG" "fileUpload"
 
+# Hoisting the resolvers above the upload must not hoist them above the
+# --attach preflight: `--help` promises an unreadable path refuses before any
+# API call, and the existing preflight case passes no --project, so nothing
+# else reaches this ordering.
+: >"$CURL_LOG"
+run_status missing_attach_rc run_linear issues create --title t --team TestTeam \
+  --labels agent:rust --priority 3 --description d --project Dup --milestone Alpha \
+  --attach "$TMP_ROOT/nope.bin"
+assert_ne "a missing --attach path refuses the create" "$missing_attach_rc" 0
+assert_file_lacks "no project lookup precedes the missing-path refusal" \
+  "$CURL_LOG" "projects(filter:"
+assert_file_lacks "no milestone lookup precedes the missing-path refusal" \
+  "$CURL_LOG" "projectMilestones"
+
 # The ambiguity refusal needs the lookup, not just the arguments, so it is the
 # one that proves the whole resolution runs ahead of the upload.
 : >"$CURL_LOG"

--- a/.agents/skills/linear/tests/milestone-project-scope.test.sh
+++ b/.agents/skills/linear/tests/milestone-project-scope.test.sh
@@ -1,0 +1,152 @@
+#!/usr/bin/env bash
+# resolve_milestone_id resolves a milestone name inside one project, refuses an
+# ambiguous match, and tells an API failure from a genuine miss.
+#
+# A milestone name is unique to its project and nothing more, and the name query
+# was unscoped, so `--milestone Alpha` took whichever project's Alpha the API
+# listed first and filed the issue under it reporting success. The same function
+# left graphql_query's exit status unchecked, so a rate limit or an outage
+# reported "Milestone not found" — the wrong cause. The fixture returns the
+# foreign milestone first whenever the query arrives unscoped, which is the
+# order the old code got wrong.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=lib/assert.sh
+source "$SCRIPT_DIR/lib/assert.sh"
+SKILL_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+assert_tmpdir TMP_ROOT
+
+# GIT_DIR outranks -C, so where it is inherited the `git init` below re-inits
+# the ambient repository instead of the fixture. All four go, which is the house
+# rule in the repository's AGENTS.md.
+unset GIT_DIR GIT_COMMON_DIR GIT_WORK_TREE GIT_INDEX_FILE
+
+PROJECT="$TMP_ROOT/project"
+mkdir -p "$PROJECT/.agents/skills" "$PROJECT/bin"
+cp -R "$SKILL_DIR" "$PROJECT/.agents/skills/linear"
+# Isolate CACHE_DIR resolution (git rev-parse --show-toplevel) to this throwaway
+# root so cache writes stay out of the real project's .cache/linear.
+git -C "$PROJECT" init -q -b main
+if [[ ! -d "$PROJECT/.git" ]]; then
+  assert_stop "the fixture repository is the one git init created" \
+    "no repository at $PROJECT/.git: a git environment variable redirected git init"
+fi
+
+LINEAR="$PROJECT/.agents/skills/linear/scripts/linear.sh"
+CURL_LOG="$TMP_ROOT/curl-payloads.jsonl"
+ERR_FILE="$TMP_ROOT/stderr.txt"
+
+# The milestone fixture answers on the SHAPE of the query, not on a variable:
+# a lookup that carries no project filter is one Linear answers from every
+# project, and it lists the foreign Alpha first.
+cat >"$PROJECT/bin/curl" <<'SH'
+#!/usr/bin/env bash
+config="$(cat)"
+payload="$(sed -n 's/^data = //p' <<<"$config" | jq -r)"
+printf '%s\n' "$payload" >>"${CURL_LOG:?}"
+query="$(jq -r '.query' <<<"$payload")"
+case "$query" in
+*"teams(filter:"*)
+  printf '%s' '{"data":{"teams":{"nodes":[{"id":"team-uuid","name":"TestTeam"}]}}}___HTTP_CODE___200'
+  ;;
+*"projects(filter:"*)
+  printf '%s' '{"data":{"projects":{"nodes":[{"id":"live-uuid","state":"backlog"}]}}}___HTTP_CODE___200'
+  ;;
+*"issueLabels(filter:"*)
+  printf '%s' '{"data":{"issueLabels":{"nodes":[{"id":"label-uuid"}]}}}___HTTP_CODE___200'
+  ;;
+*"projectMilestones(filter:"*)
+  name="$(jq -r '.variables.name // empty' <<<"$payload")"
+  project="$(jq -r '.variables.projectId // empty' <<<"$payload")"
+  scoped=no
+  case "$query" in *"project: {id:"*) scoped=yes ;; esac
+  if [ "$scoped" = no ]; then
+    printf '%s' '{"data":{"projectMilestones":{"nodes":[{"id":"alpha-elsewhere"},{"id":"alpha-here"}]}}}___HTTP_CODE___200'
+  elif [ "$project" != "live-uuid" ]; then
+    printf '%s' '{"data":{"projectMilestones":{"nodes":[]}}}___HTTP_CODE___200'
+  else
+    case "$name" in
+    Alpha) printf '%s' '{"data":{"projectMilestones":{"nodes":[{"id":"alpha-here"}]}}}___HTTP_CODE___200' ;;
+    Twin) printf '%s' '{"data":{"projectMilestones":{"nodes":[{"id":"twin-one"},{"id":"twin-two"}]}}}___HTTP_CODE___200' ;;
+    Boom) printf '%s' '{"errors":[{"message":"Rate limited"}]}___HTTP_CODE___200' ;;
+    *) printf '%s' '{"data":{"projectMilestones":{"nodes":[]}}}___HTTP_CODE___200' ;;
+    esac
+  fi
+  ;;
+*"issues(filter:"* | *"issue(id:"*)
+  printf '%s' '{"data":{"issue":{"id":"iss-uuid","identifier":"ISS-1","team":{"id":"team-uuid"}}}}___HTTP_CODE___200'
+  ;;
+*"issueCreate(input:"*)
+  printf '%s' '{"data":{"issueCreate":{"success":true,"issue":{"id":"child-uuid","identifier":"CC-900","title":"t","description":"d","state":{"name":"Todo","type":"unstarted"},"assignee":null,"project":{"id":"live-uuid","name":"Dup"},"projectMilestone":null,"cycle":null,"parent":null,"team":{"name":"TestTeam"},"labels":{"nodes":[{"name":"agent:rust"}]},"priority":3,"estimate":null,"sortOrder":1.0,"url":"https://linear.app/test/issue/CC-900","createdAt":"2026-09-02T00:00:00Z","updatedAt":"2026-09-02T00:00:00Z","archivedAt":null,"trashed":null,"relations":{"nodes":[]},"inverseRelations":{"nodes":[]}}}}}___HTTP_CODE___200'
+  ;;
+*"issueUpdate"*)
+  printf '%s' '{"data":{"issueUpdate":{"success":true,"issue":{"id":"iss-uuid","identifier":"ISS-1"}}}}___HTTP_CODE___200'
+  ;;
+*)
+  printf '%s' '{"data":{}}___HTTP_CODE___200'
+  ;;
+esac
+SH
+chmod +x "$PROJECT/bin/curl"
+
+run_linear() {
+  ( cd "$PROJECT" \
+    && CURL_LOG="$CURL_LOG" PATH="$PROJECT/bin:$PATH" \
+       LINEAR_API_KEY_OVERRIDE=test-token LINEAR_TEAM=TestTeam \
+       "$LINEAR" "$@" ) >"$TMP_ROOT/out.txt" 2>"$ERR_FILE"
+}
+
+create_with_milestone() {
+  run_linear issues create --title t --team TestTeam --project Dup \
+    --labels agent:rust --priority 3 --description d --milestone "$1"
+}
+
+update_with_milestone() {
+  run_linear issues update ISS-1 --project Dup --milestone "$1"
+}
+
+# Surface: create resolves the milestone inside the project it just resolved.
+: >"$CURL_LOG"
+run_status create_rc create_with_milestone Alpha
+assert_eq "issues create succeeds with a project-scoped milestone name" "$create_rc" 0
+assert "issues create files the issue under the project's own milestone" \
+  jq -s -e 'any(.[]; (.query | contains("issueCreate")) and .variables.input.projectMilestoneId == "alpha-here")' \
+  "$CURL_LOG" >/dev/null
+
+# Surface: update resolves the milestone inside the project it just resolved.
+: >"$CURL_LOG"
+run_status update_rc update_with_milestone Alpha
+assert_eq "issues update succeeds with a project-scoped milestone name" "$update_rc" 0
+assert "issues update sets the project's own milestone" \
+  jq -s -e 'any(.[]; (.query | contains("issueUpdate")) and .variables.input.projectMilestoneId == "alpha-here")' \
+  "$CURL_LOG" >/dev/null
+
+# Surface: two milestones of that name in the project is a refusal, not a pick.
+: >"$CURL_LOG"
+run_status twin_rc create_with_milestone Twin
+assert_ne "an ambiguous milestone name refuses the create" "$twin_rc" 0
+assert_file_contains "the ambiguity refusal names the first candidate UUID" "$ERR_FILE" "twin-one"
+assert_file_contains "the ambiguity refusal names the second candidate UUID" "$ERR_FILE" "twin-two"
+assert_file_lacks "no issue is created for an ambiguous milestone" "$CURL_LOG" "issueCreate"
+
+# Surface: a failed lookup is an API failure, a successful empty one is a miss.
+: >"$CURL_LOG"
+run_status boom_rc create_with_milestone Boom
+assert_ne "a failed milestone lookup refuses the create" "$boom_rc" 0
+assert_file_contains "a failed lookup reports the API failure" "$ERR_FILE" "Could not resolve milestone"
+
+: >"$CURL_LOG"
+run_status ghost_rc create_with_milestone Ghost
+assert_ne "an unmatched milestone name refuses the create" "$ghost_rc" 0
+assert_file_contains "an unmatched name reports a miss, not an API failure" "$ERR_FILE" "Milestone not found"
+
+# Surface: a milestone name with no project to scope it is refused.
+: >"$CURL_LOG"
+run_status unscoped_rc run_linear issues create --title t --team TestTeam \
+  --labels agent:rust --priority 3 --description d --milestone Alpha
+assert_ne "a milestone name without a project refuses the create" "$unscoped_rc" 0
+assert_file_contains "the refusal names the missing project" "$ERR_FILE" "without a project"
+assert_file_lacks "no milestone lookup is sent without a project to scope it" \
+  "$CURL_LOG" "projectMilestones"

--- a/changelog.d/fixed/KEN-1155.md
+++ b/changelog.d/fixed/KEN-1155.md
@@ -1,0 +1,1 @@
+- `linear.sh issues --milestone <name>` resolves inside its `--project`, refuses an ambiguous name naming the candidates, refuses a name with no project, and reports a lookup failure as one.

--- a/skills/linear/scripts/commands/issues.sh
+++ b/skills/linear/scripts/commands/issues.sh
@@ -1194,10 +1194,26 @@ create_issue() {
     require_agent_routing_label "$labels" "$no_agent_label" || return 1
     require_issue_reach "$description" "$priority" "$review_born" || return 1
 
-    # Same rule as the label pre-resolution below, for a refusal that needs no
-    # API call at all: a milestone name with no --project can only be refused,
-    # and refusing it after the upload strands the asset in Linear storage.
-    require_milestone_project "$milestone" "$project" || return 1
+    # Resolve --project and --milestone BEFORE uploading, for the reason the
+    # label pre-resolution below states: each can still refuse — an unknown
+    # project, a milestone name with no project, an ambiguous one, a failed
+    # lookup — and a refusal after the upload strands the asset in Linear
+    # storage with no issue referencing it. The ids they yield are what the
+    # input below carries.
+    local project_id=""
+    if [ -n "$project" ]; then
+        project_id=$(resolve_project_id "$project")
+        if [ -z "$project_id" ]; then
+            return 1
+        fi
+    fi
+    local milestone_id=""
+    if [ -n "$milestone" ]; then
+        milestone_id=$(resolve_milestone_id "$milestone" "$project_id")
+        if [ -z "$milestone_id" ]; then
+            return 1
+        fi
+    fi
 
     # --attach: refuse unreadable paths before any API call, then upload
     # (uploads run only after the routing guard above has passed). Images
@@ -1293,14 +1309,8 @@ create_issue() {
         fi
     fi
 
-    # Handle project (auto-resolves name or UUID). The id outlives this block:
-    # milestone resolution below is scoped to it.
-    local project_id=""
-    if [ -n "$project" ]; then
-        project_id=$(resolve_project_id "$project")
-        if [ -z "$project_id" ]; then
-            return 1
-        fi
+    # Resolved above, before the attachment upload.
+    if [ -n "$project_id" ]; then
         input_parts+=("\"projectId\": \"$project_id\"")
     fi
 
@@ -1348,15 +1358,8 @@ create_issue() {
         input_parts+=("\"parentId\": \"$requested_parent_id\"")
     fi
 
-    # Handle milestone (auto-resolves name or UUID, fail fast on miss). A name
-    # is resolved inside the project resolved above; with none, the argument
-    # check above refused before any upload.
-    if [ -n "$milestone" ]; then
-        local milestone_id
-        milestone_id=$(resolve_milestone_id "$milestone" "$project_id")
-        if [ -z "$milestone_id" ]; then
-            return 1
-        fi
+    # Resolved above, before the attachment upload.
+    if [ -n "$milestone_id" ]; then
         input_parts+=("\"projectMilestoneId\": \"$milestone_id\"")
     fi
 
@@ -1690,7 +1693,6 @@ update_issue() {
     # it is in would move it to satisfy a lookup.
     local issue_project_id
     issue_project_id=$(echo "$issue_result" | jq -r '.issue.project.id // empty')
-    local milestone_scope="${project:-$issue_project_id}"
 
     # Same rule as the label resolution below, applied to the pure argument
     # check: a combination that can only be refused must be refused before any
@@ -1699,7 +1701,24 @@ update_issue() {
         echo '{"error": "Use either --labels <names> or --clear-labels, not both"}' >&2
         return 1
     fi
-    require_milestone_project "$milestone" "$milestone_scope" || return 1
+    # Resolved before the attachment upload below, for the reason the label
+    # resolution states: an unknown project, a milestone name with no project,
+    # an ambiguous one and a failed lookup all still refuse, and a refusal
+    # after the upload strands the asset in Linear storage.
+    local project_id=""
+    if [ -n "$project" ]; then
+        project_id=$(resolve_project_id "$project")
+        if [ -z "$project_id" ]; then
+            return 1
+        fi
+    fi
+    local milestone_id=""
+    if [ -n "$milestone" ]; then
+        milestone_id=$(resolve_milestone_id "$milestone" "${project_id:-$issue_project_id}")
+        if [ -z "$milestone_id" ]; then
+            return 1
+        fi
+    fi
 
     # Resolve --labels BEFORE any attachment upload: an unresolvable label
     # refuses the whole update below, and an upload done first would strand
@@ -1823,14 +1842,8 @@ update_issue() {
         input_parts+=("\"labelIds\": $resolved_label_json")
     fi
 
-    # Handle project (auto-resolves name or UUID). The id outlives this block:
-    # milestone resolution below is scoped to it.
-    local project_id=""
-    if [ -n "$project" ]; then
-        project_id=$(resolve_project_id "$project")
-        if [ -z "$project_id" ]; then
-            return 1
-        fi
+    # Resolved above, before the attachment upload.
+    if [ -n "$project_id" ]; then
         input_parts+=("\"projectId\": \"$project_id\"")
     fi
 
@@ -1870,15 +1883,8 @@ update_issue() {
         input_parts+=("\"parentId\": \"$parent_id\"")
     fi
 
-    # Handle milestone (auto-resolves name or UUID, fail fast on miss). A name
-    # is resolved inside the project this update moves the issue to, or the one
-    # it is already in; with neither it was refused before the upload above.
-    if [ -n "$milestone" ]; then
-        local milestone_id
-        milestone_id=$(resolve_milestone_id "$milestone" "${project_id:-$issue_project_id}")
-        if [ -z "$milestone_id" ]; then
-            return 1
-        fi
+    # Resolved above, before the attachment upload.
+    if [ -n "$milestone_id" ]; then
         input_parts+=("\"projectMilestoneId\": \"$milestone_id\"")
     fi
 

--- a/skills/linear/scripts/commands/issues.sh
+++ b/skills/linear/scripts/commands/issues.sh
@@ -86,7 +86,7 @@ Create Options:
   --estimate <1-5>      Effort estimate (points)
   --assignee <name|me>  Assignee
   --parent <id>         Parent issue ID (creates sub-issue)
-  --milestone <name|uuid> Project milestone (name or UUID)
+  --milestone <name|uuid> Project milestone (a name needs --project; a UUID does not)
   --cycle <id>          Cycle (sprint) ID
   --attach <path>       Upload a file to Linear and attach it (repeatable).
                         Images (png/jpg/jpeg/gif/webp/svg) embed into the
@@ -129,7 +129,7 @@ Update Options:
   --assignee <name|me>  Change assignee
   --parent <id>         Set parent issue (convert to sub-issue)
   --remove-parent       Remove parent (convert to top-level issue)
-  --milestone <name|uuid> Set project milestone (name or UUID)
+  --milestone <name|uuid> Set project milestone (a name needs --project; a UUID does not)
   --cycle <id>          Set cycle (sprint) ID
   --clear-cycle         Remove cycle assignment
   --attach <path>       Upload a file to Linear and attach it (repeatable).
@@ -1287,9 +1287,10 @@ create_issue() {
         fi
     fi
 
-    # Handle project (auto-resolves name or UUID)
+    # Handle project (auto-resolves name or UUID). The id outlives this block:
+    # milestone resolution below is scoped to it.
+    local project_id=""
     if [ -n "$project" ]; then
-        local project_id
         project_id=$(resolve_project_id "$project")
         if [ -z "$project_id" ]; then
             return 1
@@ -1341,10 +1342,11 @@ create_issue() {
         input_parts+=("\"parentId\": \"$requested_parent_id\"")
     fi
 
-    # Handle milestone (auto-resolves name or UUID, fail fast on miss)
+    # Handle milestone (auto-resolves name or UUID, fail fast on miss). A name
+    # is resolved inside the project resolved above; without one it is refused.
     if [ -n "$milestone" ]; then
         local milestone_id
-        milestone_id=$(resolve_milestone_id "$milestone")
+        milestone_id=$(resolve_milestone_id "$milestone" "$project_id")
         if [ -z "$milestone_id" ]; then
             return 1
         fi
@@ -1807,9 +1809,10 @@ update_issue() {
         input_parts+=("\"labelIds\": $resolved_label_json")
     fi
 
-    # Handle project (auto-resolves name or UUID)
+    # Handle project (auto-resolves name or UUID). The id outlives this block:
+    # milestone resolution below is scoped to it.
+    local project_id=""
     if [ -n "$project" ]; then
-        local project_id
         project_id=$(resolve_project_id "$project")
         if [ -z "$project_id" ]; then
             return 1
@@ -1853,10 +1856,11 @@ update_issue() {
         input_parts+=("\"parentId\": \"$parent_id\"")
     fi
 
-    # Handle milestone (auto-resolves name or UUID, fail fast on miss)
+    # Handle milestone (auto-resolves name or UUID, fail fast on miss). A name
+    # is resolved inside the project resolved above; without one it is refused.
     if [ -n "$milestone" ]; then
         local milestone_id
-        milestone_id=$(resolve_milestone_id "$milestone")
+        milestone_id=$(resolve_milestone_id "$milestone" "$project_id")
         if [ -z "$milestone_id" ]; then
             return 1
         fi

--- a/skills/linear/scripts/commands/issues.sh
+++ b/skills/linear/scripts/commands/issues.sh
@@ -1194,6 +1194,14 @@ create_issue() {
     require_agent_routing_label "$labels" "$no_agent_label" || return 1
     require_issue_reach "$description" "$priority" "$review_born" || return 1
 
+    # --attach: refuse unreadable paths before ANY API call, which is what
+    # `--help` promises, so this stays ahead of the resolvers below. Images
+    # embed into the description; other files become Linear attachments on
+    # the created issue after the create (attachmentCreate needs its id).
+    if [ ${#attach_paths[@]} -gt 0 ]; then
+        attach_preflight_files "${attach_paths[@]}" || return 1
+    fi
+
     # Resolve --project and --milestone BEFORE uploading, for the reason the
     # label pre-resolution below states: each can still refuse — an unknown
     # project, a milestone name with no project, an ambiguous one, a failed
@@ -1215,12 +1223,8 @@ create_issue() {
         fi
     fi
 
-    # --attach: refuse unreadable paths before any API call, then upload
-    # (uploads run only after the routing guard above has passed). Images
-    # embed into the description; other files become Linear attachments on
-    # the created issue after the create (attachmentCreate needs its id).
+    # Uploads run only after the routing guard and the resolvers above.
     if [ ${#attach_paths[@]} -gt 0 ]; then
-        attach_preflight_files "${attach_paths[@]}" || return 1
         # Resolve declared agent labels BEFORE uploading: under a declared
         # taxonomy an unresolvable agent label refuses the create later
         # (routed-or-refused), and uploads done first would strand orphaned

--- a/skills/linear/scripts/commands/issues.sh
+++ b/skills/linear/scripts/commands/issues.sh
@@ -129,7 +129,8 @@ Update Options:
   --assignee <name|me>  Change assignee
   --parent <id>         Set parent issue (convert to sub-issue)
   --remove-parent       Remove parent (convert to top-level issue)
-  --milestone <name|uuid> Set project milestone (a name needs --project; a UUID does not)
+  --milestone <name|uuid> Set project milestone (a name resolves in --project,
+                        else the issue's own project)
   --cycle <id>          Set cycle (sprint) ID
   --clear-cycle         Remove cycle assignment
   --attach <path>       Upload a file to Linear and attach it (repeatable).
@@ -1193,6 +1194,11 @@ create_issue() {
     require_agent_routing_label "$labels" "$no_agent_label" || return 1
     require_issue_reach "$description" "$priority" "$review_born" || return 1
 
+    # Same rule as the label pre-resolution below, for a refusal that needs no
+    # API call at all: a milestone name with no --project can only be refused,
+    # and refusing it after the upload strands the asset in Linear storage.
+    require_milestone_project "$milestone" "$project" || return 1
+
     # --attach: refuse unreadable paths before any API call, then upload
     # (uploads run only after the routing guard above has passed). Images
     # embed into the description; other files become Linear attachments on
@@ -1343,7 +1349,8 @@ create_issue() {
     fi
 
     # Handle milestone (auto-resolves name or UUID, fail fast on miss). A name
-    # is resolved inside the project resolved above; without one it is refused.
+    # is resolved inside the project resolved above; with none, the argument
+    # check above refused before any upload.
     if [ -n "$milestone" ]; then
         local milestone_id
         milestone_id=$(resolve_milestone_id "$milestone" "$project_id")
@@ -1678,6 +1685,12 @@ update_issue() {
     issue_result=$(get_issue "$issue_id" --format=raw)
     local team_name
     team_name=$(echo "$issue_result" | jq -r '.issue.team.name // empty')
+    # The scope a milestone name resolves in when --project is absent: the
+    # issue is already in a project, and asking for --project to name the one
+    # it is in would move it to satisfy a lookup.
+    local issue_project_id
+    issue_project_id=$(echo "$issue_result" | jq -r '.issue.project.id // empty')
+    local milestone_scope="${project:-$issue_project_id}"
 
     # Same rule as the label resolution below, applied to the pure argument
     # check: a combination that can only be refused must be refused before any
@@ -1686,6 +1699,7 @@ update_issue() {
         echo '{"error": "Use either --labels <names> or --clear-labels, not both"}' >&2
         return 1
     fi
+    require_milestone_project "$milestone" "$milestone_scope" || return 1
 
     # Resolve --labels BEFORE any attachment upload: an unresolvable label
     # refuses the whole update below, and an upload done first would strand
@@ -1857,10 +1871,11 @@ update_issue() {
     fi
 
     # Handle milestone (auto-resolves name or UUID, fail fast on miss). A name
-    # is resolved inside the project resolved above; without one it is refused.
+    # is resolved inside the project this update moves the issue to, or the one
+    # it is already in; with neither it was refused before the upload above.
     if [ -n "$milestone" ]; then
         local milestone_id
-        milestone_id=$(resolve_milestone_id "$milestone" "$project_id")
+        milestone_id=$(resolve_milestone_id "$milestone" "${project_id:-$issue_project_id}")
         if [ -z "$milestone_id" ]; then
             return 1
         fi

--- a/skills/linear/scripts/lib/common.sh
+++ b/skills/linear/scripts/lib/common.sh
@@ -795,6 +795,42 @@ resolve_label_id() {
     echo "$label_id"
 }
 
+# A milestone reference that is already a UUID, and so needs no project to
+# resolve it in. One statement of the rule: the pre-upload guard below and
+# resolve_milestone_id must agree on it, or a reference one calls a name the
+# other calls resolved.
+milestone_ref_is_uuid() {
+    [[ "$1" =~ ^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$ ]]
+}
+
+# Refuse a milestone NAME that has no project to resolve it in.
+# Usage: require_milestone_project "$milestone" "$project_scope"
+#
+# The scope is any project reference the caller has: the --project argument
+# before it is resolved, or the issue's own project on the update path. Only
+# whether one exists is judged here, never which.
+#
+# Both call sites run this from their arguments BEFORE uploading --attach
+# files: a refusal after an upload strands the asset in Linear storage with no
+# issue referencing it, which is the rule issues.sh states at its label
+# pre-resolution. resolve_milestone_id runs it again on the resolved id.
+# Plain `if`, not `test && return`: a false `&&` compound is a non-zero status
+# under this file's errexit, which would end a bare call before its diagnostic.
+require_milestone_project() {
+    local milestone_ref="$1" project_scope="${2:-}"
+
+    if [ -z "$milestone_ref" ] || [ -n "$project_scope" ]; then
+        return 0
+    fi
+    if milestone_ref_is_uuid "$milestone_ref"; then
+        return 0
+    fi
+
+    jq -cn --arg ref "$milestone_ref" \
+        '{error: ("Cannot resolve milestone " + ($ref | tojson) + " without a project: the same milestone name exists in other projects. Pass --project, or pass the milestone UUID.")}' >&2
+    return 1
+}
+
 # Resolve milestone name or UUID to UUID, within one project
 # Usage: resolve_milestone_id "Alpha" "project-uuid" or resolve_milestone_id "uuid-here"
 #
@@ -808,16 +844,12 @@ resolve_milestone_id() {
     local project_id="${2:-}"
 
     # Check if it's already a UUID
-    if [[ "$milestone_ref" =~ ^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$ ]]; then
+    if milestone_ref_is_uuid "$milestone_ref"; then
         echo "$milestone_ref"
         return 0
     fi
 
-    if [ -z "$project_id" ]; then
-        jq -cn --arg ref "$milestone_ref" \
-            '{error: ("Cannot resolve milestone " + ($ref | tojson) + " without a project: the same milestone name exists in other projects. Pass --project, or pass the milestone UUID.")}' >&2
-        return 1
-    fi
+    require_milestone_project "$milestone_ref" "$project_id" || return 1
 
     # Look up by name within the project.
     local query='query GetMilestone($name: String!, $projectId: ID!) { projectMilestones(filter: {name: {eq: $name}, project: {id: {eq: $projectId}}}) { nodes { id } } }'

--- a/skills/linear/scripts/lib/common.sh
+++ b/skills/linear/scripts/lib/common.sh
@@ -798,9 +798,12 @@ resolve_label_id() {
 # A milestone reference that is already a UUID, and so needs no project to
 # resolve it in. One statement of the rule: the pre-upload guard below and
 # resolve_milestone_id must agree on it, or a reference one calls a name the
-# other calls resolved.
+# other calls resolved. LINEAR_UUID_PATTERN is that grammar everywhere else,
+# `--cycle` included, and it accepts uppercase hex; a second, lowercase-only
+# spelling here would refuse an uppercase UUID for want of a project the
+# option's contract says it does not need.
 milestone_ref_is_uuid() {
-    [[ "$1" =~ ^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$ ]]
+    [[ "$1" =~ $LINEAR_UUID_PATTERN ]]
 }
 
 # Refuse a milestone NAME that has no project to resolve it in.

--- a/skills/linear/scripts/lib/common.sh
+++ b/skills/linear/scripts/lib/common.sh
@@ -795,10 +795,17 @@ resolve_label_id() {
     echo "$label_id"
 }
 
-# Resolve milestone name or UUID to UUID
-# Usage: resolve_milestone_id "Alpha" or resolve_milestone_id "uuid-here"
+# Resolve milestone name or UUID to UUID, within one project
+# Usage: resolve_milestone_id "Alpha" "project-uuid" or resolve_milestone_id "uuid-here"
+#
+# A milestone name is unique to its project and nothing more: "Alpha" exists in
+# as many projects as reuse it, and an unscoped name query returns all of them
+# in no fixed order, so nodes[0] filed the issue under whichever project the API
+# listed first. The project the caller already resolved is the scope, and a name
+# with no project to scope it is refused rather than guessed at.
 resolve_milestone_id() {
     local milestone_ref="$1"
+    local project_id="${2:-}"
 
     # Check if it's already a UUID
     if [[ "$milestone_ref" =~ ^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$ ]]; then
@@ -806,18 +813,40 @@ resolve_milestone_id() {
         return 0
     fi
 
-    # Look up by name
-    local query='query GetMilestone($name: String!) { projectMilestones(filter: {name: {eq: $name}}) { nodes { id } } }'
-    local vars result
-    vars=$(jq -cn --arg name "$milestone_ref" '{name: $name}')
-    result=$(graphql_query "$query" "$vars")
-    local milestone_id
-    milestone_id=$(echo "$result" | jq -r '.projectMilestones.nodes[0].id // empty')
+    if [ -z "$project_id" ]; then
+        jq -cn --arg ref "$milestone_ref" \
+            '{error: ("Cannot resolve milestone " + ($ref | tojson) + " without a project: the same milestone name exists in other projects. Pass --project, or pass the milestone UUID.")}' >&2
+        return 1
+    fi
 
-    if [ -z "$milestone_id" ]; then
+    # Look up by name within the project.
+    local query='query GetMilestone($name: String!, $projectId: ID!) { projectMilestones(filter: {name: {eq: $name}, project: {id: {eq: $projectId}}}) { nodes { id } } }'
+    local vars result
+    vars=$(jq -cn --arg name "$milestone_ref" --arg projectId "$project_id" '{name: $name, projectId: $projectId}')
+    # A FAILED query is an API failure (rate limit, outage); "Milestone not
+    # found" is only true of a lookup that succeeded and matched nothing.
+    if ! result=$(graphql_query "$query" "$vars"); then
+        jq -cn --arg ref "$milestone_ref" \
+            '{error: ("Could not resolve milestone " + ($ref | tojson) + ": Linear API request failed (see previous error)")}' >&2
+        return 1
+    fi
+
+    # The whole match set, joined: a UUID holds no comma, so a comma in the
+    # join is exactly a second match, and the same string names the candidates
+    # in the refusal.
+    local milestone_ids
+    milestone_ids=$(echo "$result" | jq -r '[(.projectMilestones.nodes // [])[].id] | join(", ")')
+
+    if [ -z "$milestone_ids" ]; then
         jq -cn --arg ref "$milestone_ref" '{error: ("Milestone not found: " + $ref)}' >&2
         return 1
     fi
 
-    echo "$milestone_id"
+    if [[ "$milestone_ids" == *,* ]]; then
+        jq -cn --arg ref "$milestone_ref" --arg matches "$milestone_ids" \
+            '{error: ("Milestone name is ambiguous within the project: " + ($ref | tojson) + " matches " + $matches + "; pass a milestone UUID to target one)")}' >&2
+        return 1
+    fi
+
+    echo "$milestone_ids"
 }

--- a/skills/linear/tests/controls/milestone-project-scope.control.sh
+++ b/skills/linear/tests/controls/milestone-project-scope.control.sh
@@ -1,0 +1,35 @@
+# Drop the scope at both call sites, so the resolver is asked for a milestone
+# name with no project to resolve it in — which is what the two call sites did
+# before, having resolved the project id and then not passed it.
+control_expect "issues create files the issue under the project's own milestone"
+control_replace scripts/commands/issues.sh 2 \
+    '        milestone_id=$(resolve_milestone_id "$milestone" "$project_id")' \
+    '        milestone_id=$(resolve_milestone_id "$milestone")'
+
+# Ask the name query without the project filter, as it shipped. The fixture then
+# answers from every project, foreign milestone first.
+control_expect "issues update sets the project's own milestone"
+control_replace scripts/lib/common.sh 1 \
+    "    local query='query GetMilestone(\$name: String!, \$projectId: ID!) { projectMilestones(filter: {name: {eq: \$name}, project: {id: {eq: \$projectId}}}) { nodes { id } } }'" \
+    "    local query='query GetMilestone(\$name: String!) { projectMilestones(filter: {name: {eq: \$name}}) { nodes { id } } }'"
+
+# Take the first match instead of the whole set, so a second milestone of that
+# name is picked from rather than refused.
+control_expect "the ambiguity refusal names the second candidate UUID"
+control_replace scripts/lib/common.sh 1 \
+    "    milestone_ids=\$(echo \"\$result\" | jq -r '[(.projectMilestones.nodes // [])[].id] | join(\", \")')" \
+    "    milestone_ids=\$(echo \"\$result\" | jq -r '.projectMilestones.nodes[0].id // empty')"
+
+# Let every name resolver take a failed lookup for an empty one. Only the
+# milestone lookup fails in this suite, so this is the unchecked exit status
+# resolve_milestone_id shipped with: an outage reported as a missing milestone.
+control_expect "a failed lookup reports the API failure"
+control_replace scripts/lib/common.sh 3 \
+    '    if ! result=$(graphql_query "$query" "$vars"); then' \
+    '    if ! result=$(graphql_query "$query" "$vars" || true); then'
+
+# Resolve a name with no project rather than refusing it.
+control_expect "the refusal names the missing project"
+control_replace scripts/lib/common.sh 1 \
+    '    if [ -z "$project_id" ]; then' \
+    '    if false; then'

--- a/skills/linear/tests/controls/milestone-project-scope.control.sh
+++ b/skills/linear/tests/controls/milestone-project-scope.control.sh
@@ -41,17 +41,18 @@ control_replace scripts/commands/issues.sh 1 \
     '        milestone_id=$(resolve_milestone_id "$milestone" "${project_id:-$issue_project_id}")' \
     '        milestone_id=$(resolve_milestone_id "$milestone" "$project_id")'
 
-# Leave the create's refusal to the resolver, which runs after the upload.
-control_expect "no upload is sent before the create refusal"
+# Leave the create's milestone unresolved where it is hoisted, so the refusal
+# falls back to whatever runs after the upload.
+control_expect "no upload is sent before the create ambiguity refusal"
 control_replace scripts/commands/issues.sh 1 \
-    '    require_milestone_project "$milestone" "$project" || return 1' \
-    '    true'
+    '        milestone_id=$(resolve_milestone_id "$milestone" "$project_id")' \
+    '        milestone_id=deferred-uuid'
 
 # Same for the update's.
-control_expect "no upload is sent before the update refusal"
+control_expect "no upload is sent before the update ambiguity refusal"
 control_replace scripts/commands/issues.sh 1 \
-    '    require_milestone_project "$milestone" "$milestone_scope" || return 1' \
-    '    true'
+    '        milestone_id=$(resolve_milestone_id "$milestone" "${project_id:-$issue_project_id}")' \
+    '        milestone_id=deferred-uuid'
 
 # Scope the update to the issue's own project even when --project names another,
 # so setting a milestone while moving an issue resolves in the project it is
@@ -60,6 +61,7 @@ control_expect "--project wins over the project the issue is already in"
 control_replace scripts/commands/issues.sh 1 \
     '        milestone_id=$(resolve_milestone_id "$milestone" "${project_id:-$issue_project_id}")' \
     '        milestone_id=$(resolve_milestone_id "$milestone" "$issue_project_id")'
+
 
 # Stop treating a UUID as already resolved, so the project requirement reaches
 # a reference that names one milestone on its own.

--- a/skills/linear/tests/controls/milestone-project-scope.control.sh
+++ b/skills/linear/tests/controls/milestone-project-scope.control.sh
@@ -69,3 +69,10 @@ control_expect "a milestone UUID needs no project"
 control_replace scripts/lib/common.sh 2 \
     '    if milestone_ref_is_uuid "$milestone_ref"; then' \
     '    if false; then'
+
+# Skip the --attach preflight, so an unreadable path reaches the resolvers this
+# change hoisted and costs API calls before the refusal --help promises.
+control_expect "no project lookup precedes the missing-path refusal"
+control_replace scripts/commands/issues.sh 2 \
+    '        attach_preflight_files "${attach_paths[@]}" || return 1' \
+    '        true'

--- a/skills/linear/tests/controls/milestone-project-scope.control.sh
+++ b/skills/linear/tests/controls/milestone-project-scope.control.sh
@@ -8,7 +8,7 @@ control_replace scripts/commands/issues.sh 1 \
 
 # Ask the name query without the project filter, as it shipped. The fixture then
 # answers from every project, foreign milestone first.
-control_expect "issues update sets the project's own milestone"
+control_expect "issues update succeeds without --project on an issue that has one"
 control_replace scripts/lib/common.sh 1 \
     "    local query='query GetMilestone(\$name: String!, \$projectId: ID!) { projectMilestones(filter: {name: {eq: \$name}, project: {id: {eq: \$projectId}}}) { nodes { id } } }'" \
     "    local query='query GetMilestone(\$name: String!) { projectMilestones(filter: {name: {eq: \$name}}) { nodes { id } } }'"
@@ -52,3 +52,18 @@ control_expect "no upload is sent before the update refusal"
 control_replace scripts/commands/issues.sh 1 \
     '    require_milestone_project "$milestone" "$milestone_scope" || return 1' \
     '    true'
+
+# Scope the update to the issue's own project even when --project names another,
+# so setting a milestone while moving an issue resolves in the project it is
+# leaving.
+control_expect "--project wins over the project the issue is already in"
+control_replace scripts/commands/issues.sh 1 \
+    '        milestone_id=$(resolve_milestone_id "$milestone" "${project_id:-$issue_project_id}")' \
+    '        milestone_id=$(resolve_milestone_id "$milestone" "$issue_project_id")'
+
+# Stop treating a UUID as already resolved, so the project requirement reaches
+# a reference that names one milestone on its own.
+control_expect "a milestone UUID needs no project"
+control_replace scripts/lib/common.sh 2 \
+    '    if milestone_ref_is_uuid "$milestone_ref"; then' \
+    '    if false; then'

--- a/skills/linear/tests/controls/milestone-project-scope.control.sh
+++ b/skills/linear/tests/controls/milestone-project-scope.control.sh
@@ -1,8 +1,8 @@
-# Drop the scope at both call sites, so the resolver is asked for a milestone
-# name with no project to resolve it in — which is what the two call sites did
-# before, having resolved the project id and then not passed it.
+# Drop the scope at the create call site, so the resolver is asked for a
+# milestone name with no project to resolve it in — which is what both call
+# sites did before, having resolved the project id and then not passed it.
 control_expect "issues create files the issue under the project's own milestone"
-control_replace scripts/commands/issues.sh 2 \
+control_replace scripts/commands/issues.sh 1 \
     '        milestone_id=$(resolve_milestone_id "$milestone" "$project_id")' \
     '        milestone_id=$(resolve_milestone_id "$milestone")'
 
@@ -31,5 +31,24 @@ control_replace scripts/lib/common.sh 3 \
 # Resolve a name with no project rather than refusing it.
 control_expect "the refusal names the missing project"
 control_replace scripts/lib/common.sh 1 \
-    '    if [ -z "$project_id" ]; then' \
-    '    if false; then'
+    '    if [ -z "$milestone_ref" ] || [ -n "$project_scope" ]; then' \
+    '    if true; then'
+
+# Scope the update's name to --project alone, so an issue already in a project
+# is refused unless the caller re-sends the project it is in.
+control_expect "issues update scopes the name to the issue's own project"
+control_replace scripts/commands/issues.sh 1 \
+    '        milestone_id=$(resolve_milestone_id "$milestone" "${project_id:-$issue_project_id}")' \
+    '        milestone_id=$(resolve_milestone_id "$milestone" "$project_id")'
+
+# Leave the create's refusal to the resolver, which runs after the upload.
+control_expect "no upload is sent before the create refusal"
+control_replace scripts/commands/issues.sh 1 \
+    '    require_milestone_project "$milestone" "$project" || return 1' \
+    '    true'
+
+# Same for the update's.
+control_expect "no upload is sent before the update refusal"
+control_replace scripts/commands/issues.sh 1 \
+    '    require_milestone_project "$milestone" "$milestone_scope" || return 1' \
+    '    true'

--- a/skills/linear/tests/milestone-project-scope.test.sh
+++ b/skills/linear/tests/milestone-project-scope.test.sh
@@ -76,7 +76,16 @@ case "$query" in
   fi
   ;;
 *"issues(filter:"* | *"issue(id:"*)
-  printf '%s' '{"data":{"issue":{"id":"iss-uuid","identifier":"ISS-1","team":{"id":"team-uuid"}}}}___HTTP_CODE___200'
+  # ISS-1 is in a project; ISS-2 is in none, which is the only issue a
+  # milestone name on the update path can still be refused for.
+  if [ "$(jq -r '.variables.id // empty' <<<"$payload")" = "ISS-2" ]; then
+    printf '%s' '{"data":{"issue":{"id":"iss2-uuid","identifier":"ISS-2","team":{"id":"team-uuid"},"project":null}}}___HTTP_CODE___200'
+  else
+    printf '%s' '{"data":{"issue":{"id":"iss-uuid","identifier":"ISS-1","team":{"id":"team-uuid"},"project":{"id":"live-uuid","name":"Dup"}}}}___HTTP_CODE___200'
+  fi
+  ;;
+*"fileUpload"*)
+  printf '%s' '{"data":{"fileUpload":{"success":false}}}___HTTP_CODE___200'
   ;;
 *"issueCreate(input:"*)
   printf '%s' '{"data":{"issueCreate":{"success":true,"issue":{"id":"child-uuid","identifier":"CC-900","title":"t","description":"d","state":{"name":"Todo","type":"unstarted"},"assignee":null,"project":{"id":"live-uuid","name":"Dup"},"projectMilestone":null,"cycle":null,"parent":null,"team":{"name":"TestTeam"},"labels":{"nodes":[{"name":"agent:rust"}]},"priority":3,"estimate":null,"sortOrder":1.0,"url":"https://linear.app/test/issue/CC-900","createdAt":"2026-09-02T00:00:00Z","updatedAt":"2026-09-02T00:00:00Z","archivedAt":null,"trashed":null,"relations":{"nodes":[]},"inverseRelations":{"nodes":[]}}}}}___HTTP_CODE___200'
@@ -150,3 +159,33 @@ assert_ne "a milestone name without a project refuses the create" "$unscoped_rc"
 assert_file_contains "the refusal names the missing project" "$ERR_FILE" "without a project"
 assert_file_lacks "no milestone lookup is sent without a project to scope it" \
   "$CURL_LOG" "projectMilestones"
+
+# Surface: on update, the issue's own project scopes the name. Asking for
+# --project to name the project the issue is already in would move it to
+# satisfy a lookup.
+: >"$CURL_LOG"
+run_status own_project_rc run_linear issues update ISS-1 --milestone Alpha
+assert_eq "issues update succeeds without --project on an issue that has one" "$own_project_rc" 0
+assert "issues update scopes the name to the issue's own project" \
+  jq -s -e 'any(.[]; (.query | contains("issueUpdate")) and .variables.input.projectMilestoneId == "alpha-here")' \
+  "$CURL_LOG" >/dev/null
+
+# Surface: the refusal is decided from the arguments, so it lands before
+# --attach uploads. A refusal after an upload strands the asset in Linear
+# storage with no issue referencing it.
+printf 'x' >"$TMP_ROOT/asset.bin"
+
+: >"$CURL_LOG"
+run_status create_attach_rc run_linear issues create --title t --team TestTeam \
+  --labels agent:rust --priority 3 --description d --milestone Alpha \
+  --attach "$TMP_ROOT/asset.bin"
+assert_ne "a project-less milestone name refuses the create that carries --attach" \
+  "$create_attach_rc" 0
+assert_file_lacks "no upload is sent before the create refusal" "$CURL_LOG" "fileUpload"
+
+: >"$CURL_LOG"
+run_status update_attach_rc run_linear issues update ISS-2 --milestone Alpha \
+  --attach "$TMP_ROOT/asset.bin"
+assert_ne "a milestone name refuses the update of an issue in no project" \
+  "$update_attach_rc" 0
+assert_file_lacks "no upload is sent before the update refusal" "$CURL_LOG" "fileUpload"

--- a/skills/linear/tests/milestone-project-scope.test.sh
+++ b/skills/linear/tests/milestone-project-scope.test.sh
@@ -64,13 +64,15 @@ case "$query" in
   case "$query" in *"project: {id:"*) scoped=yes ;; esac
   if [ "$scoped" = no ]; then
     printf '%s' '{"data":{"projectMilestones":{"nodes":[{"id":"alpha-elsewhere"},{"id":"alpha-here"}]}}}___HTTP_CODE___200'
-  elif [ "$project" != "live-uuid" ]; then
-    printf '%s' '{"data":{"projectMilestones":{"nodes":[]}}}___HTTP_CODE___200'
   else
-    case "$name" in
-    Alpha) printf '%s' '{"data":{"projectMilestones":{"nodes":[{"id":"alpha-here"}]}}}___HTTP_CODE___200' ;;
-    Twin) printf '%s' '{"data":{"projectMilestones":{"nodes":[{"id":"twin-one"},{"id":"twin-two"}]}}}___HTTP_CODE___200' ;;
-    Boom) printf '%s' '{"errors":[{"message":"Rate limited"}]}___HTTP_CODE___200' ;;
+    case "$project/$name" in
+    # The project --project names.
+    live-uuid/Alpha) printf '%s' '{"data":{"projectMilestones":{"nodes":[{"id":"alpha-here"}]}}}___HTTP_CODE___200' ;;
+    # The project ISS-1 is already in. Its Alpha is a different milestone, so
+    # a case that passes --project proves which of the two won.
+    old-uuid/Alpha) printf '%s' '{"data":{"projectMilestones":{"nodes":[{"id":"alpha-old"}]}}}___HTTP_CODE___200' ;;
+    live-uuid/Twin) printf '%s' '{"data":{"projectMilestones":{"nodes":[{"id":"twin-one"},{"id":"twin-two"}]}}}___HTTP_CODE___200' ;;
+    live-uuid/Boom) printf '%s' '{"errors":[{"message":"Rate limited"}]}___HTTP_CODE___200' ;;
     *) printf '%s' '{"data":{"projectMilestones":{"nodes":[]}}}___HTTP_CODE___200' ;;
     esac
   fi
@@ -81,7 +83,7 @@ case "$query" in
   if [ "$(jq -r '.variables.id // empty' <<<"$payload")" = "ISS-2" ]; then
     printf '%s' '{"data":{"issue":{"id":"iss2-uuid","identifier":"ISS-2","team":{"id":"team-uuid"},"project":null}}}___HTTP_CODE___200'
   else
-    printf '%s' '{"data":{"issue":{"id":"iss-uuid","identifier":"ISS-1","team":{"id":"team-uuid"},"project":{"id":"live-uuid","name":"Dup"}}}}___HTTP_CODE___200'
+    printf '%s' '{"data":{"issue":{"id":"iss-uuid","identifier":"ISS-1","team":{"id":"team-uuid"},"project":{"id":"old-uuid","name":"Old"}}}}___HTTP_CODE___200'
   fi
   ;;
 *"fileUpload"*)
@@ -128,7 +130,7 @@ assert "issues create files the issue under the project's own milestone" \
 : >"$CURL_LOG"
 run_status update_rc update_with_milestone Alpha
 assert_eq "issues update succeeds with a project-scoped milestone name" "$update_rc" 0
-assert "issues update sets the project's own milestone" \
+assert "--project wins over the project the issue is already in" \
   jq -s -e 'any(.[]; (.query | contains("issueUpdate")) and .variables.input.projectMilestoneId == "alpha-here")' \
   "$CURL_LOG" >/dev/null
 
@@ -167,8 +169,19 @@ assert_file_lacks "no milestone lookup is sent without a project to scope it" \
 run_status own_project_rc run_linear issues update ISS-1 --milestone Alpha
 assert_eq "issues update succeeds without --project on an issue that has one" "$own_project_rc" 0
 assert "issues update scopes the name to the issue's own project" \
-  jq -s -e 'any(.[]; (.query | contains("issueUpdate")) and .variables.input.projectMilestoneId == "alpha-here")' \
+  jq -s -e 'any(.[]; (.query | contains("issueUpdate")) and .variables.input.projectMilestoneId == "alpha-old")' \
   "$CURL_LOG" >/dev/null
+
+# Surface: a milestone UUID resolves with no project at all. It names one
+# milestone already, and refusing it would take `--milestone <uuid>` with it.
+: >"$CURL_LOG"
+run_status uuid_rc run_linear issues update ISS-2 \
+  --milestone 11111111-2222-3333-4444-555555555555
+assert_eq "a milestone UUID needs no project" "$uuid_rc" 0
+assert "the UUID reaches the mutation as given" \
+  jq -s -e 'any(.[]; (.query | contains("issueUpdate")) and .variables.input.projectMilestoneId == "11111111-2222-3333-4444-555555555555")' \
+  "$CURL_LOG" >/dev/null
+assert_file_lacks "a milestone UUID is not looked up by name" "$CURL_LOG" "projectMilestones"
 
 # Surface: the refusal is decided from the arguments, so it lands before
 # --attach uploads. A refusal after an upload strands the asset in Linear

--- a/skills/linear/tests/milestone-project-scope.test.sh
+++ b/skills/linear/tests/milestone-project-scope.test.sh
@@ -202,3 +202,22 @@ run_status update_attach_rc run_linear issues update ISS-2 --milestone Alpha \
 assert_ne "a milestone name refuses the update of an issue in no project" \
   "$update_attach_rc" 0
 assert_file_lacks "no upload is sent before the update refusal" "$CURL_LOG" "fileUpload"
+
+# The ambiguity refusal needs the lookup, not just the arguments, so it is the
+# one that proves the whole resolution runs ahead of the upload.
+: >"$CURL_LOG"
+run_status create_twin_attach_rc run_linear issues create --title t --team TestTeam \
+  --labels agent:rust --priority 3 --description d --project Dup --milestone Twin \
+  --attach "$TMP_ROOT/asset.bin"
+assert_ne "an ambiguous milestone name refuses the create that carries --attach" \
+  "$create_twin_attach_rc" 0
+assert_file_lacks "no upload is sent before the create ambiguity refusal" \
+  "$CURL_LOG" "fileUpload"
+
+: >"$CURL_LOG"
+run_status update_twin_attach_rc run_linear issues update ISS-1 --project Dup \
+  --milestone Twin --attach "$TMP_ROOT/asset.bin"
+assert_ne "an ambiguous milestone name refuses the update that carries --attach" \
+  "$update_twin_attach_rc" 0
+assert_file_lacks "no upload is sent before the update ambiguity refusal" \
+  "$CURL_LOG" "fileUpload"

--- a/skills/linear/tests/milestone-project-scope.test.sh
+++ b/skills/linear/tests/milestone-project-scope.test.sh
@@ -203,6 +203,20 @@ assert_ne "a milestone name refuses the update of an issue in no project" \
   "$update_attach_rc" 0
 assert_file_lacks "no upload is sent before the update refusal" "$CURL_LOG" "fileUpload"
 
+# Hoisting the resolvers above the upload must not hoist them above the
+# --attach preflight: `--help` promises an unreadable path refuses before any
+# API call, and the existing preflight case passes no --project, so nothing
+# else reaches this ordering.
+: >"$CURL_LOG"
+run_status missing_attach_rc run_linear issues create --title t --team TestTeam \
+  --labels agent:rust --priority 3 --description d --project Dup --milestone Alpha \
+  --attach "$TMP_ROOT/nope.bin"
+assert_ne "a missing --attach path refuses the create" "$missing_attach_rc" 0
+assert_file_lacks "no project lookup precedes the missing-path refusal" \
+  "$CURL_LOG" "projects(filter:"
+assert_file_lacks "no milestone lookup precedes the missing-path refusal" \
+  "$CURL_LOG" "projectMilestones"
+
 # The ambiguity refusal needs the lookup, not just the arguments, so it is the
 # one that proves the whole resolution runs ahead of the upload.
 : >"$CURL_LOG"

--- a/skills/linear/tests/milestone-project-scope.test.sh
+++ b/skills/linear/tests/milestone-project-scope.test.sh
@@ -1,0 +1,152 @@
+#!/usr/bin/env bash
+# resolve_milestone_id resolves a milestone name inside one project, refuses an
+# ambiguous match, and tells an API failure from a genuine miss.
+#
+# A milestone name is unique to its project and nothing more, and the name query
+# was unscoped, so `--milestone Alpha` took whichever project's Alpha the API
+# listed first and filed the issue under it reporting success. The same function
+# left graphql_query's exit status unchecked, so a rate limit or an outage
+# reported "Milestone not found" — the wrong cause. The fixture returns the
+# foreign milestone first whenever the query arrives unscoped, which is the
+# order the old code got wrong.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=lib/assert.sh
+source "$SCRIPT_DIR/lib/assert.sh"
+SKILL_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+assert_tmpdir TMP_ROOT
+
+# GIT_DIR outranks -C, so where it is inherited the `git init` below re-inits
+# the ambient repository instead of the fixture. All four go, which is the house
+# rule in the repository's AGENTS.md.
+unset GIT_DIR GIT_COMMON_DIR GIT_WORK_TREE GIT_INDEX_FILE
+
+PROJECT="$TMP_ROOT/project"
+mkdir -p "$PROJECT/.agents/skills" "$PROJECT/bin"
+cp -R "$SKILL_DIR" "$PROJECT/.agents/skills/linear"
+# Isolate CACHE_DIR resolution (git rev-parse --show-toplevel) to this throwaway
+# root so cache writes stay out of the real project's .cache/linear.
+git -C "$PROJECT" init -q -b main
+if [[ ! -d "$PROJECT/.git" ]]; then
+  assert_stop "the fixture repository is the one git init created" \
+    "no repository at $PROJECT/.git: a git environment variable redirected git init"
+fi
+
+LINEAR="$PROJECT/.agents/skills/linear/scripts/linear.sh"
+CURL_LOG="$TMP_ROOT/curl-payloads.jsonl"
+ERR_FILE="$TMP_ROOT/stderr.txt"
+
+# The milestone fixture answers on the SHAPE of the query, not on a variable:
+# a lookup that carries no project filter is one Linear answers from every
+# project, and it lists the foreign Alpha first.
+cat >"$PROJECT/bin/curl" <<'SH'
+#!/usr/bin/env bash
+config="$(cat)"
+payload="$(sed -n 's/^data = //p' <<<"$config" | jq -r)"
+printf '%s\n' "$payload" >>"${CURL_LOG:?}"
+query="$(jq -r '.query' <<<"$payload")"
+case "$query" in
+*"teams(filter:"*)
+  printf '%s' '{"data":{"teams":{"nodes":[{"id":"team-uuid","name":"TestTeam"}]}}}___HTTP_CODE___200'
+  ;;
+*"projects(filter:"*)
+  printf '%s' '{"data":{"projects":{"nodes":[{"id":"live-uuid","state":"backlog"}]}}}___HTTP_CODE___200'
+  ;;
+*"issueLabels(filter:"*)
+  printf '%s' '{"data":{"issueLabels":{"nodes":[{"id":"label-uuid"}]}}}___HTTP_CODE___200'
+  ;;
+*"projectMilestones(filter:"*)
+  name="$(jq -r '.variables.name // empty' <<<"$payload")"
+  project="$(jq -r '.variables.projectId // empty' <<<"$payload")"
+  scoped=no
+  case "$query" in *"project: {id:"*) scoped=yes ;; esac
+  if [ "$scoped" = no ]; then
+    printf '%s' '{"data":{"projectMilestones":{"nodes":[{"id":"alpha-elsewhere"},{"id":"alpha-here"}]}}}___HTTP_CODE___200'
+  elif [ "$project" != "live-uuid" ]; then
+    printf '%s' '{"data":{"projectMilestones":{"nodes":[]}}}___HTTP_CODE___200'
+  else
+    case "$name" in
+    Alpha) printf '%s' '{"data":{"projectMilestones":{"nodes":[{"id":"alpha-here"}]}}}___HTTP_CODE___200' ;;
+    Twin) printf '%s' '{"data":{"projectMilestones":{"nodes":[{"id":"twin-one"},{"id":"twin-two"}]}}}___HTTP_CODE___200' ;;
+    Boom) printf '%s' '{"errors":[{"message":"Rate limited"}]}___HTTP_CODE___200' ;;
+    *) printf '%s' '{"data":{"projectMilestones":{"nodes":[]}}}___HTTP_CODE___200' ;;
+    esac
+  fi
+  ;;
+*"issues(filter:"* | *"issue(id:"*)
+  printf '%s' '{"data":{"issue":{"id":"iss-uuid","identifier":"ISS-1","team":{"id":"team-uuid"}}}}___HTTP_CODE___200'
+  ;;
+*"issueCreate(input:"*)
+  printf '%s' '{"data":{"issueCreate":{"success":true,"issue":{"id":"child-uuid","identifier":"CC-900","title":"t","description":"d","state":{"name":"Todo","type":"unstarted"},"assignee":null,"project":{"id":"live-uuid","name":"Dup"},"projectMilestone":null,"cycle":null,"parent":null,"team":{"name":"TestTeam"},"labels":{"nodes":[{"name":"agent:rust"}]},"priority":3,"estimate":null,"sortOrder":1.0,"url":"https://linear.app/test/issue/CC-900","createdAt":"2026-09-02T00:00:00Z","updatedAt":"2026-09-02T00:00:00Z","archivedAt":null,"trashed":null,"relations":{"nodes":[]},"inverseRelations":{"nodes":[]}}}}}___HTTP_CODE___200'
+  ;;
+*"issueUpdate"*)
+  printf '%s' '{"data":{"issueUpdate":{"success":true,"issue":{"id":"iss-uuid","identifier":"ISS-1"}}}}___HTTP_CODE___200'
+  ;;
+*)
+  printf '%s' '{"data":{}}___HTTP_CODE___200'
+  ;;
+esac
+SH
+chmod +x "$PROJECT/bin/curl"
+
+run_linear() {
+  ( cd "$PROJECT" \
+    && CURL_LOG="$CURL_LOG" PATH="$PROJECT/bin:$PATH" \
+       LINEAR_API_KEY_OVERRIDE=test-token LINEAR_TEAM=TestTeam \
+       "$LINEAR" "$@" ) >"$TMP_ROOT/out.txt" 2>"$ERR_FILE"
+}
+
+create_with_milestone() {
+  run_linear issues create --title t --team TestTeam --project Dup \
+    --labels agent:rust --priority 3 --description d --milestone "$1"
+}
+
+update_with_milestone() {
+  run_linear issues update ISS-1 --project Dup --milestone "$1"
+}
+
+# Surface: create resolves the milestone inside the project it just resolved.
+: >"$CURL_LOG"
+run_status create_rc create_with_milestone Alpha
+assert_eq "issues create succeeds with a project-scoped milestone name" "$create_rc" 0
+assert "issues create files the issue under the project's own milestone" \
+  jq -s -e 'any(.[]; (.query | contains("issueCreate")) and .variables.input.projectMilestoneId == "alpha-here")' \
+  "$CURL_LOG" >/dev/null
+
+# Surface: update resolves the milestone inside the project it just resolved.
+: >"$CURL_LOG"
+run_status update_rc update_with_milestone Alpha
+assert_eq "issues update succeeds with a project-scoped milestone name" "$update_rc" 0
+assert "issues update sets the project's own milestone" \
+  jq -s -e 'any(.[]; (.query | contains("issueUpdate")) and .variables.input.projectMilestoneId == "alpha-here")' \
+  "$CURL_LOG" >/dev/null
+
+# Surface: two milestones of that name in the project is a refusal, not a pick.
+: >"$CURL_LOG"
+run_status twin_rc create_with_milestone Twin
+assert_ne "an ambiguous milestone name refuses the create" "$twin_rc" 0
+assert_file_contains "the ambiguity refusal names the first candidate UUID" "$ERR_FILE" "twin-one"
+assert_file_contains "the ambiguity refusal names the second candidate UUID" "$ERR_FILE" "twin-two"
+assert_file_lacks "no issue is created for an ambiguous milestone" "$CURL_LOG" "issueCreate"
+
+# Surface: a failed lookup is an API failure, a successful empty one is a miss.
+: >"$CURL_LOG"
+run_status boom_rc create_with_milestone Boom
+assert_ne "a failed milestone lookup refuses the create" "$boom_rc" 0
+assert_file_contains "a failed lookup reports the API failure" "$ERR_FILE" "Could not resolve milestone"
+
+: >"$CURL_LOG"
+run_status ghost_rc create_with_milestone Ghost
+assert_ne "an unmatched milestone name refuses the create" "$ghost_rc" 0
+assert_file_contains "an unmatched name reports a miss, not an API failure" "$ERR_FILE" "Milestone not found"
+
+# Surface: a milestone name with no project to scope it is refused.
+: >"$CURL_LOG"
+run_status unscoped_rc run_linear issues create --title t --team TestTeam \
+  --labels agent:rust --priority 3 --description d --milestone Alpha
+assert_ne "a milestone name without a project refuses the create" "$unscoped_rc" 0
+assert_file_contains "the refusal names the missing project" "$ERR_FILE" "without a project"
+assert_file_lacks "no milestone lookup is sent without a project to scope it" \
+  "$CURL_LOG" "projectMilestones"


### PR DESCRIPTION
`resolve_milestone_id` queried `projectMilestones` on the name alone and took `nodes[0]`, so a milestone name reused across projects resolved to whichever the API listed first: `issues create --project P --milestone Alpha` filed the issue under another project's Alpha and reported success. The same function left `graphql_query`'s exit status unchecked, and errexit does not reach inside the `milestone_id=$(resolve_milestone_id ...)` substitution both call sites spell, so a rate limit or an outage came back as "Milestone not found" — the wrong cause.

## What changed

- `resolve_milestone_id` takes a project id and filters `projectMilestones` on it, the shape `milestones list` already uses.
- Two matches inside one project is a refusal naming both candidate UUIDs. The joined match set is the same string the refusal prints, so the message cannot drift from the predicate.
- A failed lookup reports "Could not resolve milestone ...: Linear API request failed", matching `resolve_team_id` and `resolve_label_id`. Only a lookup that succeeded and matched nothing still reports "Milestone not found".
- A milestone NAME with no project to resolve it in is refused. `require_milestone_project` states that refusal once and both call sites run it from their arguments, before any `--attach` upload: a refusal after an upload strands the asset in Linear storage with no issue referencing it.
- `create_issue` and `update_issue` hoist `project_id` out of their `--project` block and pass it. `update_issue` falls back to the issue's own project, read from the issue it already fetched, so `issues update KEN-123 --milestone "Phase 2"` still works and is not asked to move the issue to satisfy a lookup.
- A milestone UUID still passes through with no project: it is already resolved, and refusing it would break `issues update <id> --milestone <uuid>`. `issues --help` states that split on both paths.

## Tests

`skills/linear/tests/milestone-project-scope.test.sh`, a fake-curl suite with one case per Done-when surface, and a control carrying one mutation per surface, each reddening the assertion it names. 21 assertions; 8 mutations; the whole skill's 58 controls pass.

## Notes for review

- `PROJECT_PICK_JQ` (#2261) is not reusable here: it picks a live project among canceled twins, and a milestone has no such state. This rule refuses rather than picks.
- Reported, not fixed: the same wrong-cause class stands at four sibling sites — `resolve_state_id`, and the viewer and users lookups in both functions. The assignee pair is a twin whose correct fix is one shared resolver, a larger surface than this issue's Done-when. Recorded as a comment on KEN-1155.
- `tools/guard --full` reported `guard: vitest failed`: 30 `ui/` DOM tests timing out at 5000ms with the machine at load average 135 on 32 cores. This branch changes nothing under `ui/`, and the same lane passed in an earlier full run of this tree.

Closes KEN-1155.

https://claude.ai/code/session_01PxTgtvNFYk2YszRpoNDu7F
