### PR TITLE
fix(KEN-645): a global skill lands in ~/.agents/skills

### DIFF
--- a/changelog.d/changed/KEN-645-global-skills.md
+++ b/changelog.d/changed/KEN-645-global-skills.md
@@ -1,0 +1,1 @@
+- **Breaking:** a global skill installs into `~/.agents/skills/<name>`, the tree Codex, OpenCode, Pi, Gemini and Copilot read; Claude Code and Antigravity link at it. Reinstall global skills once.

--- a/changelog.d/fixed/KEN-645-agent-skill-paths.md
+++ b/changelog.d/fixed/KEN-645-agent-skill-paths.md
@@ -1,0 +1,1 @@
+- A globally installed agent is told to read its required skills from the directory they are installed in. It named its harness's own directory, where the default delivery no longer writes them.

--- a/changelog.d/fixed/KEN-645-command-cross-read.md
+++ b/changelog.d/fixed/KEN-645-command-cross-read.md
@@ -1,0 +1,1 @@
+- The warning that a command installed as a skill is offered by other tools names every tool that reads the directory it landed in, not Pi alone.

--- a/changelog.d/fixed/KEN-645-copy-content.md
+++ b/changelog.d/fixed/KEN-645-copy-content.md
@@ -1,0 +1,1 @@
+- Forking, diffing or updating a skill installed with `method = "copy"` reads that tool's own copy. It could read a same-named skill out of the shared tree instead, or find nothing at all.

--- a/changelog.d/fixed/KEN-645-refused-note.md
+++ b/changelog.d/fixed/KEN-645-refused-note.md
@@ -1,0 +1,1 @@
+- A skill whose shared rendering is refused no longer reports that the other tools reading that directory can see it; nothing is installed there to see.

--- a/crates/core/src/engine/adopt/shared.rs
+++ b/crates/core/src/engine/adopt/shared.rs
@@ -12,6 +12,7 @@ use crate::model::{HarnessId, ItemKind, Scope};
 use crate::source::local_source_root;
 
 use super::{destination, position};
+use crate::engine::desired::skill_canonical;
 
 // Adopting a shared folder through the link a tool reads it by: the
 // boundary that decides what a link may be adopted through, and the ops
@@ -74,13 +75,14 @@ pub(super) fn shared_target(
         env.journal_dir(),
         local_source_root(env, scope),
     ];
-    // A project link reaching the global shared tree names a global
-    // install, which this scope's lock cannot see and which is not this
-    // scope's to capture. At global scope that same tree is where adoption
-    // lands, so it is settled below by the rules that settle a project's
-    // own shared tree — a folder someone wrote there by hand, with tools
-    // linking at it, is a sharing layout to adopt, not one to refuse.
-    if matches!(scope, Scope::Project { .. }) {
+    // The global shared tree holds this skill's own place at global scope
+    // and every other skill's at either scope. The one place adoption
+    // would put THIS skill is the finished shape — a folder written there
+    // by hand with tools linking at it — and is settled below. Every other
+    // name in that tree is a second skill's content, and capturing it
+    // under this name would move it; a project link reaching any of it
+    // names a global install this scope's lock cannot see.
+    if canon(skill_canonical(env, scope, name)) != target {
         ours.push(env.global_skills_dir());
     }
     if ours.into_iter().any(|root| target.starts_with(canon(root))) {

--- a/crates/core/src/engine/adopt/shared.rs
+++ b/crates/core/src/engine/adopt/shared.rs
@@ -68,18 +68,13 @@ pub(super) fn shared_target(
         return Err(refuse());
     }
     let canon = |path: PathBuf| crate::paths::canonical(&path).unwrap_or(path);
-    let mut ours = vec![
-        env.rendered_skills_dir(),
+    let ours = [
+        env.global_skills_dir(),
         env.trash_dir(),
         env.source_cache_dir(),
         env.journal_dir(),
         local_source_root(env, scope),
     ];
-    ours.extend(
-        HarnessId::ALL
-            .iter()
-            .map(|h| env.rendered_skill_variants_dir(h.name())),
-    );
     if ours.into_iter().any(|root| target.starts_with(canon(root))) {
         return Err(refuse());
     }

--- a/crates/core/src/engine/adopt/shared.rs
+++ b/crates/core/src/engine/adopt/shared.rs
@@ -32,11 +32,11 @@ pub(super) struct SharedTarget {
 
 /// What a live link may be adopted through. The target must be a real
 /// skill folder — the `SKILL.md` marker is what keeps a link at `$HOME` or
-/// `/etc` refused — and must sit outside kendex's own machinery: the
-/// rendered canonical and variant trees, the trash, the source cache, the
-/// journal, and the local source the capture would write into (a managed
-/// tree is already ours, and capturing it under another name would steal
-/// it; capturing the destination would recurse). Everything is compared
+/// `/etc` refused — and must sit outside kendex's own machinery: the trash,
+/// the source cache, the journal, the local source the capture would write
+/// into, and, from a project, the global shared tree (a managed tree is
+/// already ours, and capturing it under another name would steal it;
+/// capturing the destination would recurse). Everything is compared
 /// resolved by `crate::paths::canonical`, so a `..`-laden link cannot
 /// dress one side up as the other, and a boundary derived from the scope
 /// root is held against a target spelled the way that root was. That rule
@@ -68,13 +68,21 @@ pub(super) fn shared_target(
         return Err(refuse());
     }
     let canon = |path: PathBuf| crate::paths::canonical(&path).unwrap_or(path);
-    let ours = [
-        env.global_skills_dir(),
+    let mut ours = vec![
         env.trash_dir(),
         env.source_cache_dir(),
         env.journal_dir(),
         local_source_root(env, scope),
     ];
+    // A project link reaching the global shared tree names a global
+    // install, which this scope's lock cannot see and which is not this
+    // scope's to capture. At global scope that same tree is where adoption
+    // lands, so it is settled below by the rules that settle a project's
+    // own shared tree — a folder someone wrote there by hand, with tools
+    // linking at it, is a sharing layout to adopt, not one to refuse.
+    if matches!(scope, Scope::Project { .. }) {
+        ours.push(env.global_skills_dir());
+    }
     if ours.into_iter().any(|root| target.starts_with(canon(root))) {
         return Err(refuse());
     }

--- a/crates/core/src/engine/adopt/tests/links.rs
+++ b/crates/core/src/engine/adopt/tests/links.rs
@@ -156,7 +156,7 @@ fn a_global_link_into_the_shared_tree_adopts() {
     fs::create_dir_all(env.home.join(".claude/skills")).unwrap();
     std::os::unix::fs::symlink(&shared, env.home.join(".claude/skills/gh")).unwrap();
 
-    adopt(
+    let plan = adopt(
         &env,
         &Scope::Global,
         ItemKind::Skill,
@@ -164,6 +164,24 @@ fn a_global_link_into_the_shared_tree_adopts() {
         &[HarnessId::Claude],
     )
     .unwrap();
+    crate::apply::execute(&env, &plan).unwrap();
+
+    // Global scope captures into the local source rather than in place, so
+    // the folder itself goes and the link that read it is cleared.
+    assert!(!shared.exists());
+    assert!(!env.home.join(".claude/skills/gh").is_symlink());
+
+    // The follow-up apply restores the sharing from kendex's copy: the tree
+    // back in the shared place, Claude Code reading it through its link.
+    let report = crate::engine::audit(&env, &Scope::Global).unwrap();
+    crate::apply::execute(&env, &report.plan).unwrap();
+    assert!(shared.join("SKILL.md").is_file());
+    let through_claude = fs::read_to_string(env.home.join(".claude/skills/gh/SKILL.md")).unwrap();
+    assert!(through_claude.contains("Theirs."));
+    assert_eq!(
+        crate::engine::audit(&env, &Scope::Global).unwrap().drift,
+        vec![]
+    );
 }
 
 /// Only this skill's own place in the shared tree is the finished shape.

--- a/crates/core/src/engine/adopt/tests/links.rs
+++ b/crates/core/src/engine/adopt/tests/links.rs
@@ -9,6 +9,7 @@
 use super::super::*;
 use crate::engine::audit;
 use crate::env::FakeOs;
+use crate::test_util::rooted;
 use std::fs;
 
 use super::trash_is_empty;
@@ -99,13 +100,12 @@ fn a_link_at_a_folder_without_the_marker_still_refuses() {
     assert!(elsewhere.join("notes.txt").is_file());
 }
 
-/// A link the user repointed into kendex's own trees is not theirs to
-/// adopt: capturing a managed tree under another name would steal it. The
-/// global shared tree is one of those — kendex renders a global skill into
-/// it, and a project link reaching it names content with a home already.
+/// A project link reaching the global shared tree is not this scope's to
+/// adopt: what sits there is a global install, which the project's lock
+/// cannot see, and capturing it under another name would steal it.
 #[cfg(unix)]
 #[test]
-fn a_link_into_kendexs_own_trees_refuses() {
+fn a_project_link_into_the_global_tree_refuses() {
     let tmp = tempfile::tempdir().unwrap();
     let env = Env::fake(tmp.path(), FakeOs::Linux);
     let project = tmp.path().join("app");
@@ -132,6 +132,38 @@ fn a_link_into_kendexs_own_trees_refuses() {
     .unwrap_err();
     assert!(matches!(error, CoreError::ForeignSymlink { .. }));
     assert!(managed.join("SKILL.md").is_file());
+}
+
+/// The same folder at the scope it belongs to is a sharing layout, not a
+/// refusal. `~/.agents/skills/<name>` is where a global install lands and
+/// where a person building this by hand puts the real folder, because
+/// Claude Code reads no shared tree and has to link at one. Adoption is
+/// the exit that keeps it; refusing would leave Replace, which sets the
+/// person's own folder aside into the trash.
+#[cfg(unix)]
+#[test]
+fn a_global_link_into_the_shared_tree_adopts() {
+    let tmp = tempfile::tempdir().unwrap();
+    let home = rooted(&tmp);
+    let env = Env::fake(&home, FakeOs::Linux);
+    let shared = env.global_skills_dir().join("gh");
+    fs::create_dir_all(&shared).unwrap();
+    fs::write(
+        shared.join("SKILL.md"),
+        "---\nname: gh\ndescription: written by hand\n---\nTheirs.\n",
+    )
+    .unwrap();
+    fs::create_dir_all(env.home.join(".claude/skills")).unwrap();
+    std::os::unix::fs::symlink(&shared, env.home.join(".claude/skills/gh")).unwrap();
+
+    adopt(
+        &env,
+        &Scope::Global,
+        ItemKind::Skill,
+        "gh",
+        &[HarnessId::Claude],
+    )
+    .unwrap();
 }
 
 /// The folder changing between the plan and the apply aborts the whole

--- a/crates/core/src/engine/adopt/tests/links.rs
+++ b/crates/core/src/engine/adopt/tests/links.rs
@@ -99,8 +99,10 @@ fn a_link_at_a_folder_without_the_marker_still_refuses() {
     assert!(elsewhere.join("notes.txt").is_file());
 }
 
-/// A link the user repointed into kendex's own store is not theirs to
-/// adopt: capturing a managed tree under another name would steal it.
+/// A link the user repointed into kendex's own trees is not theirs to
+/// adopt: capturing a managed tree under another name would steal it. The
+/// global shared tree is one of those — kendex renders a global skill into
+/// it, and a project link reaching it names content with a home already.
 #[cfg(unix)]
 #[test]
 fn a_link_into_kendexs_own_trees_refuses() {
@@ -110,7 +112,7 @@ fn a_link_into_kendexs_own_trees_refuses() {
     let scope = Scope::Project {
         root: project.clone(),
     };
-    let managed = env.rendered_skills_dir().join("other");
+    let managed = env.global_skills_dir().join("other");
     fs::create_dir_all(&managed).unwrap();
     fs::write(
         managed.join("SKILL.md"),

--- a/crates/core/src/engine/adopt/tests/links.rs
+++ b/crates/core/src/engine/adopt/tests/links.rs
@@ -166,6 +166,38 @@ fn a_global_link_into_the_shared_tree_adopts() {
     .unwrap();
 }
 
+/// Only this skill's own place in the shared tree is the finished shape.
+/// A link at one name pointing at another name's folder there would have
+/// adoption capture that folder under this name and move the original,
+/// taking a second skill's content with it.
+#[cfg(unix)]
+#[test]
+fn a_global_link_across_names_in_the_shared_tree_refuses() {
+    let tmp = tempfile::tempdir().unwrap();
+    let home = rooted(&tmp);
+    let env = Env::fake(&home, FakeOs::Linux);
+    let other = env.global_skills_dir().join("other");
+    fs::create_dir_all(&other).unwrap();
+    fs::write(
+        other.join("SKILL.md"),
+        "---\nname: other\ndescription: a second skill\n---\nTheirs.\n",
+    )
+    .unwrap();
+    fs::create_dir_all(env.home.join(".claude/skills")).unwrap();
+    std::os::unix::fs::symlink(&other, env.home.join(".claude/skills/alias")).unwrap();
+
+    let error = adopt(
+        &env,
+        &Scope::Global,
+        ItemKind::Skill,
+        "alias",
+        &[HarnessId::Claude],
+    )
+    .unwrap_err();
+    assert!(matches!(error, CoreError::ForeignSymlink { .. }));
+    assert!(other.join("SKILL.md").is_file());
+}
+
 /// The folder changing between the plan and the apply aborts the whole
 /// transaction: the trash op is bound to the bytes that were captured,
 /// so a stale snapshot can never become "the backup".

--- a/crates/core/src/engine/desired/places.rs
+++ b/crates/core/src/engine/desired/places.rs
@@ -88,13 +88,14 @@ fn item_dirs(
         .collect()
 }
 
-/// The shared tree several tools read one skill from. Its name holds the
-/// plugin a plugin-registry catalog put the skill in, joined the way the
-/// directory itself spells it.
+/// The shared tree several tools read one skill from: `.agents/skills`
+/// under the scope's own root, the project's or the home directory's. Its
+/// name holds the plugin a plugin-registry catalog put the skill in, joined
+/// the way the directory itself spells it.
 pub fn skill_canonical(env: &Env, scope: &Scope, name: &str) -> PathBuf {
     let name = crate::harness::canonical_name(name);
     match scope {
-        Scope::Global => env.rendered_skills_dir().join(name),
+        Scope::Global => env.global_skills_dir().join(name),
         Scope::Project { root } => root.join(".agents/skills").join(name),
     }
 }

--- a/crates/core/src/engine/desired_command.rs
+++ b/crates/core/src/engine/desired_command.rs
@@ -152,19 +152,35 @@ fn as_skill(
             remediation: Some(finding.remediation.clone()),
         });
     }
-    // Pi reads the same project skill directory Codex does, so the generated
-    // skill shows up there too. Saying so beats the user finding a command
-    // they never declared for Pi in Pi's skill list.
-    if native_dir(ctx.env, ctx.scope, HarnessId::Pi, ItemKind::Skill).as_ref() == Some(&dir) {
+    // The generated tree lands in a directory other tools read as well —
+    // the project's shared tree, and the home one at global scope — so
+    // they offer the command too. Which tools is derived from the same
+    // surface declarations the write used, never a list spelled here:
+    // saying "Pi" while three more tools also read it is the surprise this
+    // warning exists to prevent.
+    let also: Vec<&str> = HarnessId::ALL
+        .into_iter()
+        .filter(|other| *other != harness)
+        .filter(|other| {
+            native_dir(ctx.env, ctx.scope, *other, ItemKind::Skill).as_ref() == Some(&dir)
+        })
+        .map(HarnessId::display_name)
+        .collect();
+    if !also.is_empty() {
+        let reads = match also.len() {
+            1 => "reads",
+            _ => "read",
+        };
         state.warnings.push(ItemWarning {
             kind: ItemKind::Command,
             name: ctx.name.to_owned(),
             harness: Some(harness),
             message: format!(
-                "installed as skill {name} in a directory Pi also reads, so Pi offers it too"
+                "installed as skill {name} in a directory {} also {reads}, so it is offered there too",
+                also.join(", ")
             ),
             remediation: Some(format!(
-                "drop {} from this command's harnesses if Pi must not see it",
+                "drop {} from this command's harnesses if they must not see it",
                 harness.display_name()
             )),
         });

--- a/crates/core/src/engine/desired_skill.rs
+++ b/crates/core/src/engine/desired_skill.rs
@@ -37,13 +37,14 @@ struct Variant {
     refused: bool,
 }
 
-/// The tools that will read this skill without being installed to. Every
-/// harness but Claude Code reads a project's `.agents/skills` tree, so a
-/// skill written there is loaded by tools the person never named — one
-/// definition, counted once, and said out loud so a reader is not surprised
-/// by a tool that has it (matrix §R6).
+/// The tools that will read this skill without being installed to. The
+/// shared `.agents/skills` tree under the scope's root is read by every
+/// harness but Claude Code in a project, and by every one but Claude Code
+/// and Antigravity globally, so a skill written there is loaded by tools the
+/// person never named — one definition, counted once, and said out loud so a
+/// reader is not surprised by a tool that has it (matrix §R6).
 fn cross_read_note(ctx: &ItemCtx, method: Method, state: &mut DesiredState) {
-    if !matches!(ctx.scope, Scope::Project { .. }) || method == Method::Copy {
+    if method == Method::Copy {
         return;
     }
     let shared = skill_canonical(ctx.env, ctx.scope, ctx.name);
@@ -67,8 +68,12 @@ fn cross_read_note(ctx: &ItemCtx, method: Method, state: &mut DesiredState) {
     }
     // The reach is a fact about the directory, not about any one skill, so
     // it is said once however many skills a scope installs.
+    let where_ = match ctx.scope {
+        Scope::Global => "`~/.agents/skills`",
+        Scope::Project { .. } => "`.agents/skills`",
+    };
     let note = format!(
-        "skills: {} read `.agents/skills` too, so what is installed here is already visible to them — one definition, counted once",
+        "skills: {} read {where_} too, so what is installed here is already visible to them — one definition, counted once",
         readers.join(", ")
     );
     if !state.notes.contains(&note) {
@@ -138,8 +143,8 @@ pub(super) fn desired_skill(ctx: &ItemCtx, state: &mut DesiredState) -> Result<(
 
     // The base tree is the scope's shared location; the group that natively
     // reads it owns it, the first group otherwise. A variant with the base's
-    // bytes links to it; a divergent variant lives at its own surface
-    // (project) or in the per-tool store (global).
+    // bytes links to it; a divergent variant lives at its own surface, which
+    // every group has at either scope.
     let base = skill_canonical(ctx.env, ctx.scope, ctx.name);
     let owner = groups
         .iter()
@@ -160,15 +165,7 @@ pub(super) fn desired_skill(ctx: &ItemCtx, state: &mut DesiredState) -> Result<(
                 false => (base.clone(), Some(group.native.clone())),
             }
         } else {
-            match ctx.scope {
-                Scope::Project { .. } => (group.native.clone(), None),
-                Scope::Global => (
-                    ctx.env
-                        .rendered_skill_variants_dir(group.members[0].name())
-                        .join(&group.installed),
-                    Some(group.native.clone()),
-                ),
-            }
+            (group.native.clone(), None)
         };
         let artifact = Artifact::Tree {
             canonical,

--- a/crates/core/src/engine/desired_skill.rs
+++ b/crates/core/src/engine/desired_skill.rs
@@ -132,7 +132,6 @@ pub(super) fn desired_skill(ctx: &ItemCtx, state: &mut DesiredState) -> Result<(
             ),
         }
     }
-    cross_read_note(ctx, method, state);
     if ctx.harnesses.contains(&HarnessId::Copilot) {
         super::copilot::switched_off_elsewhere(ctx, ItemKind::Skill, state);
     }
@@ -150,6 +149,13 @@ pub(super) fn desired_skill(ctx: &ItemCtx, state: &mut DesiredState) -> Result<(
         .iter()
         .position(|group| group.native == base)
         .unwrap_or(0);
+    // Only once the tree that would sit in the shared place is known to
+    // render: a refused group installs nothing there, and saying what is
+    // installed here reaches other tools would name a tree that is about
+    // to be removed.
+    if !variants[owner].refused {
+        cross_read_note(ctx, method, state);
+    }
     for (index, group) in groups.iter().enumerate() {
         let variant = &variants[index];
         if variant.refused {

--- a/crates/core/src/engine/fork/skill_tree.rs
+++ b/crates/core/src/engine/fork/skill_tree.rs
@@ -1,8 +1,8 @@
 //! Where a skill's content actually lives for one harness. Every tool
-//! reads the same skill through a different path — its own copied tree, a
-//! link into the shared canonical tree, or a link into its own variant of
-//! it — and an operation that captures or compares bytes has to land on
-//! the tree that tool really reads, never on whichever one shares the name.
+//! reads the same skill through a different path — the shared canonical
+//! tree it reads directly, a link into that tree, or its own copied tree —
+//! and an operation that captures or compares bytes has to land on the
+//! tree that tool really reads, never on whichever one shares the name.
 
 use std::path::PathBuf;
 
@@ -22,11 +22,11 @@ pub(crate) fn skill_content_path(
 ) -> Option<PathBuf> {
     if let Some(dir) = native_dir(env, scope, harness, ItemKind::Skill) {
         let native = dir.join(crate::harness::rendered_name(harness, name));
-        // A real directory here is this tool's own copy (copy method). A
-        // symlink is followed to the tree this tool actually reads — the
-        // shared canonical tree, or its own divergent variant under the
-        // variants directory. Resolving it gives a real directory either
-        // way, never the wrong tool's bytes.
+        // A real directory here is this tool's own tree: its copy, or the
+        // shared tree where this tool reads that itself. A symlink is
+        // followed to the shared canonical tree it reads instead.
+        // Resolving it gives a real directory either way, never the wrong
+        // tool's bytes.
         if native.is_symlink() {
             if let Ok(target) = std::fs::read_link(&native) {
                 let resolved = if target.is_absolute() {
@@ -35,10 +35,10 @@ pub(crate) fn skill_content_path(
                     dir.join(target)
                 };
                 // Only a link into a location kendex itself manages is
-                // followed — the shared canonical tree or this tool's
-                // variant. A foreign link the user pointed elsewhere is
-                // not this skill's content, and reading (then trashing) it
-                // would expose and move whatever it happens to point at.
+                // followed — this scope's shared canonical tree. A foreign
+                // link the user pointed elsewhere is not this skill's
+                // content, and reading (then trashing) it would expose and
+                // move whatever it happens to point at.
                 if resolved.is_dir() && managed_skill_tree(env, scope, name, &resolved) {
                     return Some(resolved);
                 }

--- a/crates/core/src/engine/fork/skill_tree.rs
+++ b/crates/core/src/engine/fork/skill_tree.rs
@@ -51,21 +51,11 @@ pub(crate) fn skill_content_path(
     canonical.is_dir().then_some(canonical)
 }
 
-/// Whether `path` is a skill tree kendex manages for `name`: the shared
-/// canonical tree, or a per-tool variant under the rendered-variants
-/// directory. Compared canonically so a `..`-laden link cannot dress a
-/// foreign directory up as a managed one.
+/// Whether `path` is a skill tree kendex manages for `name`: the scope's
+/// shared canonical tree. Compared canonically so a `..`-laden link cannot
+/// dress a foreign directory up as a managed one.
 fn managed_skill_tree(env: &Env, scope: &Scope, name: &str, path: &std::path::Path) -> bool {
     let real = path.canonicalize().unwrap_or_else(|_| path.to_path_buf());
     let canonical = skill_canonical(env, scope, name);
-    if real == canonical.canonicalize().unwrap_or(canonical) {
-        return true;
-    }
-    // Variant trees live below the rendered-variants root, one dir per
-    // harness. Any harness's variant of this name is a managed tree.
-    let _ = scope;
-    HarnessId::ALL.iter().any(|h| {
-        let variant = env.rendered_skill_variants_dir(h.name()).join(name);
-        real == variant.canonicalize().unwrap_or(variant)
-    })
+    real == canonical.canonicalize().unwrap_or(canonical)
 }

--- a/crates/core/src/engine/fork/skill_tree.rs
+++ b/crates/core/src/engine/fork/skill_tree.rs
@@ -6,22 +6,33 @@
 
 use std::path::PathBuf;
 
-use crate::engine::desired::{native_dir, skill_canonical};
+use crate::engine::desired::{read_dirs, skill_canonical};
 use crate::env::Env;
 use crate::model::{HarnessId, ItemKind, Scope};
 
-/// The tree that holds a skill's content for one harness: its own native
-/// tree when it was copied there (each tool a real directory), or the
-/// shared canonical tree when tools symlink to one. Picking canonical-first
-/// would capture whichever tool happens to share it, not the one asked for.
+/// The tree that holds a skill's content for one harness: its own tree
+/// when it was copied there (each tool a real directory), or the shared
+/// canonical tree when the tool reads that instead — directly, where the
+/// tool reads the shared tree itself, or through a link.
+///
+/// The tool's own directory is asked first and the shared tree last, which
+/// is the reverse of the order an install writes in. A copy lands in the
+/// tool's own directory precisely so no other tool reads it, and the
+/// shared tree may hold another tool's skill of the same name; taking the
+/// shared one first would hand back bytes belonging to whichever tool
+/// happens to share the name, not the one asked for.
 pub(crate) fn skill_content_path(
     env: &Env,
     scope: &Scope,
     name: &str,
     harness: HarnessId,
 ) -> Option<PathBuf> {
-    if let Some(dir) = native_dir(env, scope, harness, ItemKind::Skill) {
-        let native = dir.join(crate::harness::rendered_name(harness, name));
+    let installed = crate::harness::rendered_name(harness, name);
+    for dir in read_dirs(env, scope, harness, ItemKind::Skill)
+        .into_iter()
+        .rev()
+    {
+        let native = dir.join(&installed);
         // A real directory here is this tool's own tree: its copy, or the
         // shared tree where this tool reads that itself. A symlink is
         // followed to the shared canonical tree it reads instead.
@@ -58,4 +69,57 @@ fn managed_skill_tree(env: &Env, scope: &Scope, name: &str, path: &std::path::Pa
     let real = path.canonicalize().unwrap_or_else(|_| path.to_path_buf());
     let canonical = skill_canonical(env, scope, name);
     real == canonical.canonicalize().unwrap_or(canonical)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::env::FakeOs;
+    use crate::test_util::rooted;
+    use std::fs;
+
+    fn tree(path: &std::path::Path, body: &str) {
+        fs::create_dir_all(path).expect("fixture dir");
+        fs::write(path.join("SKILL.md"), body).expect("fixture SKILL.md");
+    }
+
+    /// A global copy lands in the tool's own directory, which is the whole
+    /// point of a copy — no other tool reads it. The shared tree may hold
+    /// another tool's skill of the same name, so asking the shared tree
+    /// first would hand back that tool's bytes; the copy is what Codex has.
+    #[test]
+    fn a_global_copy_is_found_in_the_tools_own_directory() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let home = rooted(&tmp);
+        let env = Env::fake(&home, FakeOs::Linux);
+        let mine = home.join(".codex/skills/gh");
+        tree(
+            &mine,
+            "---\nname: gh\ndescription: codex's copy\n---\nMine.\n",
+        );
+        tree(
+            &env.global_skills_dir().join("gh"),
+            "---\nname: gh\ndescription: somebody else's\n---\nTheirs.\n",
+        );
+
+        assert_eq!(
+            skill_content_path(&env, &Scope::Global, "gh", HarnessId::Codex),
+            Some(mine)
+        );
+    }
+
+    /// With no copy of its own, the tool reads the shared tree it shares.
+    #[test]
+    fn without_a_copy_the_shared_tree_is_what_the_tool_reads() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let home = rooted(&tmp);
+        let env = Env::fake(&home, FakeOs::Linux);
+        let shared = env.global_skills_dir().join("gh");
+        tree(&shared, "---\nname: gh\ndescription: shared\n---\nOurs.\n");
+
+        assert_eq!(
+            skill_content_path(&env, &Scope::Global, "gh", HarnessId::Codex),
+            Some(shared)
+        );
+    }
 }

--- a/crates/core/src/engine/tree_plan/link.rs
+++ b/crates/core/src/engine/tree_plan/link.rs
@@ -182,8 +182,11 @@ fn respell(
 }
 
 /// The tree a link and its target both have to survive being moved inside,
-/// or nothing at global scope — where a harness directory and the app's own
-/// folder share no root a relative path could be read against.
+/// or nothing at global scope. A project link is committed and has to
+/// resolve in every clone, so it is spelled relative to the root the pair
+/// moves inside. Nothing commits a global install, and a home is not a
+/// tree anyone moves, so there the absolute spelling is the one that
+/// reaches.
 fn project_root(scope: &Scope) -> Option<&Path> {
     match scope {
         Scope::Project { root } => Some(root),

--- a/crates/core/src/env.rs
+++ b/crates/core/src/env.rs
@@ -229,20 +229,13 @@ impl Env {
         self.data_dir.join(APP_DIR).join("local-source")
     }
 
-    /// Rendered canonical trees for global-scope skills — the stable target
-    /// native dirs link to (never the source cache, which refresh resets).
-    pub fn rendered_skills_dir(&self) -> PathBuf {
-        self.data_dir.join(APP_DIR).join("rendered/skills")
-    }
-
-    /// Home of a per-tool skill variant that diverged from the shared
-    /// rendering. A sibling of `rendered/skills`, keyed by harness, so a
-    /// skill name can never collide with a variant directory.
-    pub fn rendered_skill_variants_dir(&self, harness: &str) -> PathBuf {
-        self.data_dir
-            .join(APP_DIR)
-            .join("rendered/variants")
-            .join(harness)
+    /// The shared skills tree at global scope — `.agents/skills` under the
+    /// home directory, the same layout a project has under its own root, and
+    /// the one every tool but Claude Code and Antigravity reads there. It is
+    /// nobody's private store: a global install lands where those tools
+    /// already look, so nothing has to be linked at it for them to see it.
+    pub fn global_skills_dir(&self) -> PathBuf {
+        self.home.join(".agents/skills")
     }
 
     pub fn project_manifest_file(project_root: &Path) -> PathBuf {

--- a/crates/core/src/harness/caps.rs
+++ b/crates/core/src/harness/caps.rs
@@ -342,8 +342,10 @@ pub fn capabilities(harness: HarnessId, kind: ItemKind) -> KindCaps {
         (Cursor, Agent) => managed(PROJECT),
         // Cursor reads the shared `.agents/skills` tree, which is where a
         // project skill goes; `.cursor/skills` is the directory only Cursor
-        // reads, for a copy delivery. No documented global skills path, so
-        // global stays unsupported.
+        // reads, for a copy delivery. Its global pair, `~/.agents/skills` and
+        // `~/.cursor/skills`, is not modelled, so global stays unsupported; a
+        // global skill installed there for another tool reaches Cursor
+        // through the shared tree all the same.
         (Cursor, Skill) => managed(PROJECT),
         // A cursor hook is a `.mdc` rule with no registration behind it.
         (Cursor, Hook) => advisory(KindCaps {

--- a/crates/core/src/harness/codex.rs
+++ b/crates/core/src/harness/codex.rs
@@ -22,13 +22,16 @@ impl HarnessAdapter for Codex {
         &[ProjectMarker::Dir(".codex"), ProjectMarker::Dir(".agents")]
     }
 
-    fn global_surfaces(&self, kind: ItemKind, root: &Path, _env: &Env) -> Vec<Surface> {
+    fn global_surfaces(&self, kind: ItemKind, root: &Path, env: &Env) -> Vec<Surface> {
         match kind {
             ItemKind::Agent => vec![Surface::files(root.join("agents"), &["toml"])],
-            ItemKind::Skill => vec![Surface::SubdirPerItem {
-                dir: root.join("skills"),
-                marker: "SKILL.md",
-            }],
+            // `$HOME/.agents/skills` is the only user-level skills location
+            // Codex documents, so it leads here as it does in a project;
+            // `~/.codex/skills` stays on the list for what an older install
+            // left there and for a copy delivery.
+            ItemKind::Skill => {
+                super::shared_first(Some(&env.global_skills_dir()), root.join("skills"))
+            }
             ItemKind::Hook => vec![Surface::Structured {
                 path: root.join("hooks.json"),
                 reader: Reader::HooksObject,

--- a/crates/core/src/harness/codex.rs
+++ b/crates/core/src/harness/codex.rs
@@ -26,9 +26,12 @@ impl HarnessAdapter for Codex {
         match kind {
             ItemKind::Agent => vec![Surface::files(root.join("agents"), &["toml"])],
             // `$HOME/.agents/skills` is the only user-level skills location
-            // Codex documents, so it leads here as it does in a project;
-            // `~/.codex/skills` stays on the list for what an older install
-            // left there and for a copy delivery.
+            // Codex documents, so it leads here as it does in a project.
+            // `~/.codex/skills` stays on the list to read back what an
+            // older install left there. It is also where a copy delivery
+            // writes, being the only directory of Codex's own — and Codex
+            // does not read it, so a global copy is reported installed and
+            // is loaded by nothing.
             ItemKind::Skill => {
                 super::shared_first(Some(&env.global_skills_dir()), root.join("skills"))
             }

--- a/crates/core/src/harness/copilot/mod.rs
+++ b/crates/core/src/harness/copilot/mod.rs
@@ -85,14 +85,16 @@ impl HarnessAdapter for Copilot {
         ]
     }
 
-    fn global_surfaces(&self, kind: ItemKind, root: &Path, _env: &Env) -> Vec<Surface> {
+    fn global_surfaces(&self, kind: ItemKind, root: &Path, env: &Env) -> Vec<Surface> {
         let settings = root.join("settings.json");
         match kind {
             ItemKind::Agent => vec![Surface::files(root.join("agents"), &["agent.md"])],
-            ItemKind::Skill => vec![Surface::SubdirPerItem {
-                dir: root.join("skills"),
-                marker: "SKILL.md",
-            }],
+            // A personal skill lives in `~/.copilot/skills` or
+            // `~/.agents/skills`; the shared one leads, as it does in a
+            // project.
+            ItemKind::Skill => {
+                super::shared_first(Some(&env.global_skills_dir()), root.join("skills"))
+            }
             // Each file under `hooks/` is a whole `{version, hooks}`
             // document, and the settings file carries a `hooks` key of the
             // same entries. Both are read; only the files are written, since

--- a/crates/core/src/harness/gemini/mod.rs
+++ b/crates/core/src/harness/gemini/mod.rs
@@ -115,14 +115,14 @@ impl HarnessAdapter for Gemini {
         ]
     }
 
-    fn global_surfaces(&self, kind: ItemKind, root: &Path, _env: &Env) -> Vec<Surface> {
+    fn global_surfaces(&self, kind: ItemKind, root: &Path, env: &Env) -> Vec<Surface> {
         match kind {
             // An installed extension is a directory carrying its manifest.
             ItemKind::Plugin => vec![Surface::SubdirPerItem {
                 dir: root.join("extensions"),
                 marker: "gemini-extension.json",
             }],
-            other => surfaces(other, root, None),
+            other => surfaces(other, root, Some(&env.global_skills_dir())),
         }
     }
 

--- a/crates/core/src/harness/opencode.rs
+++ b/crates/core/src/harness/opencode.rs
@@ -82,7 +82,7 @@ impl HarnessAdapter for Opencode {
 
     fn global_surfaces(&self, kind: ItemKind, root: &Path, env: &Env) -> Vec<Surface> {
         let config = global_config_file(root, env);
-        surfaces(kind, root, config, None)
+        surfaces(kind, root, config, Some(&env.global_skills_dir()))
     }
 
     fn project_surfaces(&self, kind: ItemKind, project: &Path, _env: &Env) -> Vec<Surface> {

--- a/crates/core/src/harness/pi.rs
+++ b/crates/core/src/harness/pi.rs
@@ -129,13 +129,14 @@ impl HarnessAdapter for Pi {
         &[ProjectMarker::Dir(".pi"), ProjectMarker::Dir(".agents")]
     }
 
-    fn global_surfaces(&self, kind: ItemKind, root: &Path, _env: &Env) -> Vec<Surface> {
+    fn global_surfaces(&self, kind: ItemKind, root: &Path, env: &Env) -> Vec<Surface> {
         match kind {
             ItemKind::Agent => vec![Surface::files(root.join("agents"), &["md"])],
-            ItemKind::Skill => vec![Surface::SubdirPerItem {
-                dir: root.join("skills"),
-                marker: "SKILL.md",
-            }],
+            // Pi loads `~/.agents/skills` as well as its own global tree, so
+            // the shared one leads here as it does in a project.
+            ItemKind::Skill => {
+                super::shared_first(Some(&env.global_skills_dir()), root.join("skills"))
+            }
             // Hooks ride the pi-hooks carrier: the registry kendex renders
             // is what the carrier's listeners execute. pi has no MCP.
             ItemKind::Hook => hook_surfaces(root),

--- a/crates/core/src/render/agent/codex.rs
+++ b/crates/core/src/render/agent/codex.rs
@@ -1,6 +1,6 @@
 use super::{EffectiveAgent, GENERATED_BANNER, RenderedAgent, Role, hooks_prose, skills_prose};
 use crate::harness::models::resolve_model;
-use crate::model::{HarnessId, Scope};
+use crate::model::HarnessId;
 use crate::render::permission::PermissionIntent;
 use crate::render::vocab::rewrite_prose;
 
@@ -161,10 +161,7 @@ fn instructions(
     warnings.extend(reworded);
     out.push_str(&prose);
     out.push('\n');
-    let skill_root = match agent.scope {
-        Scope::Global => "$CODEX_HOME/skills",
-        Scope::Project { .. } => ".agents/skills",
-    };
+    let skill_root = super::skill_root(HarnessId::Codex, agent.scope);
     if let Some(skills) = skills_prose(agent, skill_root) {
         out.push_str(&format!("\n{skills}"));
     }
@@ -217,7 +214,7 @@ mod tests {
     use super::super::{SourceAgent, parse_source_agent};
     use super::*;
     use crate::manifest::FrontmatterOverrides;
-    use crate::model::HarnessId;
+    use crate::model::{HarnessId, Scope};
 
     fn source(name: &str, role: &str) -> SourceAgent {
         parse_source_agent(&format!(
@@ -344,7 +341,7 @@ mod tests {
             "nickname_candidates = [\"Reviewer-Arch-Atlas\", \"Reviewer-Arch-Delta\", \"Reviewer-Arch-Echo\", \"Reviewer-Arch-Nova\", \"Reviewer-Arch-Orion\", \"Reviewer-Arch-Vector\"]"
         ));
         assert!(tpm.contains("\"TPM-Atlas\""));
-        assert!(tpm.contains("- dev: $CODEX_HOME/skills/dev/SKILL.md"));
+        assert!(tpm.contains("- dev: ~/.agents/skills/dev/SKILL.md"));
     }
 
     #[test]

--- a/crates/core/src/render/agent/copilot.rs
+++ b/crates/core/src/render/agent/copilot.rs
@@ -1,6 +1,6 @@
 use super::{EffectiveAgent, GENERATED_BANNER, RenderedAgent, hooks_prose, skills_prose};
 use crate::harness::models::resolve_model;
-use crate::model::{HarnessId, Scope};
+use crate::model::HarnessId;
 use crate::render::permission::PermissionIntent;
 use crate::render::vocab::{copilot_tool_name, rewrite_prose};
 use crate::render::{RenderWarning, yaml_quoted, yaml_scalar};
@@ -62,10 +62,7 @@ pub fn generate(agent: &EffectiveAgent) -> RenderedAgent {
     body.push('\n');
     // Neither skills nor hooks are agent frontmatter fields, so both travel
     // as prose the agent's own instructions carry (matrix §2).
-    let skill_root = match agent.scope {
-        Scope::Global => "~/.copilot/skills",
-        Scope::Project { .. } => ".agents/skills",
-    };
+    let skill_root = super::skill_root(HarnessId::Copilot, agent.scope);
     if let Some(skills) = skills_prose(agent, skill_root) {
         body.push_str(&format!("\n{skills}"));
     }
@@ -99,6 +96,7 @@ mod tests {
     use super::super::{SourceAgent, parse_source_agent};
     use super::*;
     use crate::manifest::{CustomHook, FrontmatterOverrides, HookAgents};
+    use crate::model::Scope;
 
     fn engineer() -> SourceAgent {
         parse_source_agent(
@@ -150,7 +148,7 @@ mod tests {
         let scope = Scope::Global;
         let text = generate(&effective(&source, &scope, vec![])).text;
         assert!(!text.contains("model:"), "{text}");
-        assert!(text.contains("- dev: ~/.copilot/skills/dev/SKILL.md"));
+        assert!(text.contains("- dev: ~/.agents/skills/dev/SKILL.md"));
     }
 
     #[test]

--- a/crates/core/src/render/agent/gemini.rs
+++ b/crates/core/src/render/agent/gemini.rs
@@ -1,6 +1,6 @@
 use super::{EffectiveAgent, GENERATED_BANNER, RenderedAgent, hooks_prose, skills_prose};
 use crate::harness::models::resolve_model;
-use crate::model::{HarnessId, Scope};
+use crate::model::HarnessId;
 use crate::render::permission::PermissionIntent;
 use crate::render::vocab::{gemini_tool_name, rewrite_prose};
 use crate::render::{RenderWarning, yaml_quoted, yaml_scalar};
@@ -68,10 +68,7 @@ pub fn generate(agent: &EffectiveAgent) -> RenderedAgent {
     body.push('\n');
     // Neither skills nor per-agent hooks are subagent frontmatter fields, so
     // both travel as prose the system prompt carries (matrix §1).
-    let skill_root = match agent.scope {
-        Scope::Global => "~/.gemini/skills",
-        Scope::Project { .. } => ".agents/skills",
-    };
+    let skill_root = super::skill_root(HarnessId::Gemini, agent.scope);
     if let Some(skills) = skills_prose(agent, skill_root) {
         body.push_str(&format!("\n{skills}"));
     }
@@ -105,6 +102,7 @@ mod tests {
     use super::super::{SourceAgent, parse_source_agent};
     use super::*;
     use crate::manifest::{CustomHook, FrontmatterOverrides, HookAgents};
+    use crate::model::Scope;
 
     fn engineer() -> SourceAgent {
         parse_source_agent(
@@ -155,7 +153,7 @@ mod tests {
         assert!(text.contains(
             "tools:\n  - read_file\n  - run_shell_command\n  - google_web_search\n---\n"
         ));
-        assert!(text.contains("- dev: ~/.gemini/skills/dev/SKILL.md"));
+        assert!(text.contains("- dev: ~/.agents/skills/dev/SKILL.md"));
 
         agent.permissions = PermissionIntent::allow_only(vec![]);
         assert!(generate(&agent).text.contains("tools: []\n"));

--- a/crates/core/src/render/agent/mod.rs
+++ b/crates/core/src/render/agent/mod.rs
@@ -246,6 +246,27 @@ pub fn file_name(harness: HarnessId, agent_name: &str) -> String {
 }
 
 /// Skills prose section for harnesses without a native skills field.
+/// Where an agent is told to read its required skills: the directory the
+/// install writes for this harness at this scope.
+///
+/// One owner, because five renderers each spelling it is five chances to
+/// name a place the install stopped writing. Every tool but Claude Code
+/// and Antigravity reads the shared tree, so that is where their skills
+/// are; those two read only their own directory and are linked into it.
+/// A `method = "copy"` delivery writes each tool's own directory instead,
+/// which this does not distinguish — the prose has never said so, at
+/// either scope.
+pub fn skill_root(harness: HarnessId, scope: &Scope) -> &'static str {
+    match scope {
+        Scope::Project { .. } => ".agents/skills",
+        Scope::Global => match harness {
+            HarnessId::Claude => "~/.claude/skills",
+            HarnessId::Antigravity => "~/.gemini/config/skills",
+            _ => "~/.agents/skills",
+        },
+    }
+}
+
 pub fn skills_prose(agent: &EffectiveAgent, skill_root_hint: &str) -> Option<String> {
     if agent.skills.is_empty() {
         return None;
@@ -443,6 +464,47 @@ mod tests {
         assert_eq!(
             merged.deny_tools,
             Some(vec!["WebSearch".into(), "WebFetch".into()])
+        );
+    }
+
+    /// The path an agent is told to read a skill from is the one the
+    /// install writes. Globally that is the shared tree for every tool
+    /// that reads it, and its own directory for the two that do not; a
+    /// project's is the shared tree for all of them. A renderer naming a
+    /// tool's own global directory would send the agent to a path the
+    /// default delivery no longer creates.
+    #[test]
+    fn an_agent_reads_its_skills_from_the_place_the_install_writes() {
+        let project = Scope::Project {
+            root: std::path::PathBuf::from("/p"),
+        };
+        for harness in HarnessId::ALL {
+            assert_eq!(
+                skill_root(harness, &project),
+                ".agents/skills",
+                "{harness:?} in a project"
+            );
+        }
+        for harness in [
+            HarnessId::Codex,
+            HarnessId::Pi,
+            HarnessId::Opencode,
+            HarnessId::Gemini,
+            HarnessId::Copilot,
+        ] {
+            assert_eq!(
+                skill_root(harness, &Scope::Global),
+                "~/.agents/skills",
+                "{harness:?} reads the shared global tree"
+            );
+        }
+        assert_eq!(
+            skill_root(HarnessId::Claude, &Scope::Global),
+            "~/.claude/skills"
+        );
+        assert_eq!(
+            skill_root(HarnessId::Antigravity, &Scope::Global),
+            "~/.gemini/config/skills"
         );
     }
 }

--- a/crates/core/src/render/agent/opencode.rs
+++ b/crates/core/src/render/agent/opencode.rs
@@ -1,7 +1,7 @@
 use super::{EffectiveAgent, GENERATED_BANNER, RenderedAgent, Role, hooks_prose, skills_prose};
 use crate::harness::models::resolve_model;
 use crate::manifest::FrontmatterOverrides;
-use crate::model::{HarnessId, Scope};
+use crate::model::HarnessId;
 use crate::render::permission::PermissionIntent;
 use crate::render::vocab::{opencode_permission, rewrite_prose};
 use crate::render::yaml_scalar;
@@ -162,10 +162,7 @@ fn body(agent: &EffectiveAgent, warnings: &mut Vec<crate::render::RenderWarning>
     warnings.extend(reworded);
     out.push_str(&prose);
     out.push('\n');
-    let skill_root = match agent.scope {
-        Scope::Global => "~/.config/opencode/skills",
-        Scope::Project { .. } => ".agents/skills",
-    };
+    let skill_root = super::skill_root(HarnessId::Opencode, agent.scope);
     if let Some(skills) = skills_prose(agent, skill_root) {
         out.push_str(&format!("\n{skills}"));
     }
@@ -189,7 +186,7 @@ fn is_none_value(value: &str) -> bool {
 mod tests {
     use super::super::{SourceAgent, parse_source_agent};
     use super::*;
-    use crate::model::HarnessId;
+    use crate::model::{HarnessId, Scope};
 
     fn source(name: &str) -> SourceAgent {
         parse_source_agent(&format!(

--- a/crates/core/src/render/agent/pi.rs
+++ b/crates/core/src/render/agent/pi.rs
@@ -1,7 +1,7 @@
 use super::{
     EffectiveAgent, GENERATED_BANNER, RenderedAgent, Role, default_pane, hooks_prose, skills_prose,
 };
-use crate::model::{HarnessId, Scope};
+use crate::model::HarnessId;
 use crate::render::permission::PermissionIntent;
 use crate::render::vocab::rewrite_prose;
 use crate::render::yaml_scalar;
@@ -177,10 +177,7 @@ fn body(agent: &EffectiveAgent, warnings: &mut Vec<crate::render::RenderWarning>
     warnings.extend(reworded);
     out.push_str(&prose);
     out.push('\n');
-    let skill_root = match agent.scope {
-        Scope::Global => "~/.pi/agent/skills",
-        Scope::Project { .. } => ".agents/skills",
-    };
+    let skill_root = super::skill_root(HarnessId::Pi, agent.scope);
     if let Some(skills) = skills_prose(agent, skill_root) {
         out.push_str(&format!("\n{skills}"));
     }
@@ -205,7 +202,7 @@ mod tests {
     use super::super::{SourceAgent, parse_source_agent};
     use super::*;
     use crate::manifest::FrontmatterOverrides;
-    use crate::model::HarnessId;
+    use crate::model::{HarnessId, Scope};
 
     fn source(name: &str, role: &str, model: &str) -> SourceAgent {
         parse_source_agent(&format!(

--- a/crates/core/tests/commands.rs
+++ b/crates/core/tests/commands.rs
@@ -165,7 +165,9 @@ fn a_command_installs_as_a_skill_at_global_scope_too() {
     let report = audit(&f.env, &Scope::Global).unwrap();
     apply::execute(&f.env, &report.plan).unwrap();
 
-    let skill = f.env.home.join(".codex/skills/ship/SKILL.md");
+    // Codex reads `~/.agents/skills` globally, so that is where the
+    // generated skill lands, not in a directory of its own.
+    let skill = f.env.global_skills_dir().join("ship/SKILL.md");
     assert!(
         fs::read_to_string(&skill)
             .unwrap()

--- a/crates/core/tests/review_fixes/main.rs
+++ b/crates/core/tests/review_fixes/main.rs
@@ -264,20 +264,23 @@ fn narrowing_harnesses_orphans_the_stranded_installation() {
         "[skills.gh]\nsource = \"cat\"\nharnesses = [\"claude\", \"codex\"]\n",
     );
     apply_now(&w, &scope);
-    let codex_link = w.home.join(".codex/skills/gh");
-    assert!(codex_link.is_symlink());
+    // Codex reads `~/.agents/skills` itself, so the shared tree is its
+    // installation; Claude Code reads only its own directory, and the link
+    // sitting there is what narrowing strands.
+    let claude_link = w.home.join(".claude/skills/gh");
+    assert!(claude_link.is_symlink());
 
     declare(
         &w,
         &scope,
-        "[skills.gh]\nsource = \"cat\"\nharnesses = [\"claude\"]\n",
+        "[skills.gh]\nsource = \"cat\"\nharnesses = [\"codex\"]\n",
     );
     let report = audit(&w.env, &scope).unwrap();
     assert!(
         report
             .drift
             .iter()
-            .any(|row| row.harness == HarnessId::Codex && row.state == DriftState::Orphaned)
+            .any(|row| row.harness == HarnessId::Claude && row.state == DriftState::Orphaned)
     );
 
     let report = plan_scope(
@@ -294,8 +297,9 @@ fn narrowing_harnesses_orphans_the_stranded_installation() {
     .unwrap();
     apply::execute(&w.env, &report.plan).unwrap();
 
-    assert!(!codex_link.is_symlink() && !codex_link.exists());
-    assert!(w.home.join(".claude/skills/gh").is_symlink());
+    assert!(!claude_link.is_symlink() && !claude_link.exists());
+    // The shared tree stays: Codex still reads it.
+    assert!(w.env.global_skills_dir().join("gh/SKILL.md").is_file());
     assert_eq!(audit(&w.env, &scope).unwrap().drift, vec![]);
 }
 

--- a/crates/core/tests/source_store.rs
+++ b/crates/core/tests/source_store.rs
@@ -127,7 +127,7 @@ fn install(w: &World, scope: &Scope) {
 #[allow(clippy::unwrap_used)]
 fn rendered(w: &World, scope: &Scope) -> String {
     let path = match scope {
-        Scope::Global => w.env.rendered_skills_dir().join("gh/SKILL.md"),
+        Scope::Global => w.env.global_skills_dir().join("gh/SKILL.md"),
         Scope::Project { root } => root.join(".agents/skills/gh/SKILL.md"),
     };
     fs::read_to_string(path).unwrap()

--- a/crates/core/tests/structural_claims.rs
+++ b/crates/core/tests/structural_claims.rs
@@ -93,7 +93,7 @@ fn refresh_reads_each_installs_own_recorded_source_across_scopes() {
     apply_scope(&w, &global);
     apply_scope(&w, &project);
 
-    let global_body = fs::read_to_string(w.env.rendered_skills_dir().join("gh/SKILL.md")).unwrap();
+    let global_body = fs::read_to_string(w.env.global_skills_dir().join("gh/SKILL.md")).unwrap();
     let project_body = fs::read_to_string(w.project.join(".agents/skills/gh/SKILL.md")).unwrap();
     assert!(global_body.contains("A, revised."), "{global_body}");
     assert!(project_body.contains("B, revised."), "{project_body}");

--- a/crates/core/tests/surfaces.rs
+++ b/crates/core/tests/surfaces.rs
@@ -5,7 +5,7 @@
 
 #[path = "../../test_util.rs"]
 mod test_util;
-use test_util::source_path;
+use test_util::{rooted, source_path};
 
 use std::fs;
 
@@ -125,4 +125,90 @@ fn a_large_skill_is_one_tree_every_surface_links_to() {
     assert_eq!(fs::read_to_string(claude.join("SKILL.md")).unwrap(), body);
 
     assert!(audit(&env, &scope).unwrap().drift.is_empty());
+}
+
+/// A global install lands in `~/.agents/skills`, the tree Codex, OpenCode,
+/// Pi, Gemini and Copilot read there, and nothing is written into a store of
+/// kendex's own. The tools that read it get no link, because they are already
+/// looking at the tree itself; Claude Code, which reads only its own
+/// directory, gets one onto it.
+#[test]
+#[allow(clippy::unwrap_used)]
+fn a_global_skill_lands_in_the_shared_tree_and_only_claude_links_at_it() {
+    let tmp = tempfile::tempdir().unwrap();
+    let home = rooted(&tmp);
+    let env = Env::fake(&home, FakeOs::Linux);
+
+    let source = home.join("catalog");
+    fs::create_dir_all(source.join("skills/gh")).unwrap();
+    fs::write(
+        source.join("skills/gh/SKILL.md"),
+        "---\nname: gh\ndescription: github\n---\nBody.\n",
+    )
+    .unwrap();
+    let manifest = env.global_manifest_file();
+    fs::create_dir_all(manifest.parent().unwrap()).unwrap();
+    fs::write(
+        &manifest,
+        format!(
+            "schema = 6\n\n[sources.cat]\n{}\n\n[install]\nharnesses = [\"claude\", \"codex\", \"pi\"]\nmethod = \"symlink\"\n\n[skills.gh]\nsource = \"cat\"\n",
+            source_path(&source)
+        ),
+    )
+    .unwrap();
+
+    let report = audit(&env, &Scope::Global).unwrap();
+    apply::execute(&env, &report.plan).unwrap();
+
+    let shared = home.join(".agents/skills/gh");
+    assert!(shared.join("SKILL.md").is_file());
+    assert!(!shared.is_symlink(), "the shared tree holds the bytes");
+    // Codex and Pi read that tree themselves, so a link in their own
+    // directory would be a second position for one definition.
+    assert!(!home.join(".codex/skills/gh").exists());
+    assert!(!home.join(".pi/agent/skills/gh").exists());
+    // Claude Code reads neither shared tree, so its own directory holds a
+    // link — the only harness here that demands one.
+    let claude = home.join(".claude/skills/gh");
+    assert_eq!(fs::read_link(&claude).unwrap(), shared);
+    // Nothing is kept in a store of kendex's own any more. The app's data
+    // root is read off `Env`, never spelled: it is a different path per
+    // platform.
+    let app_data = env.trash_dir().parent().unwrap().to_path_buf();
+    assert!(!app_data.join("rendered").exists());
+}
+
+/// Verify reads a global skill back from the shared tree: a clean install
+/// drifts on nothing, and a tree edited underneath it is reported.
+#[test]
+#[allow(clippy::unwrap_used)]
+fn verify_reads_a_global_skill_from_the_shared_tree() {
+    let tmp = tempfile::tempdir().unwrap();
+    let home = rooted(&tmp);
+    let env = Env::fake(&home, FakeOs::Linux);
+
+    let source = home.join("catalog");
+    fs::create_dir_all(source.join("skills/gh")).unwrap();
+    fs::write(
+        source.join("skills/gh/SKILL.md"),
+        "---\nname: gh\ndescription: github\n---\nBody.\n",
+    )
+    .unwrap();
+    let manifest = env.global_manifest_file();
+    fs::create_dir_all(manifest.parent().unwrap()).unwrap();
+    fs::write(
+        &manifest,
+        format!(
+            "schema = 6\n\n[sources.cat]\n{}\n\n[install]\nharnesses = [\"codex\"]\nmethod = \"symlink\"\n\n[skills.gh]\nsource = \"cat\"\n",
+            source_path(&source)
+        ),
+    )
+    .unwrap();
+
+    apply::execute(&env, &audit(&env, &Scope::Global).unwrap().plan).unwrap();
+    assert!(audit(&env, &Scope::Global).unwrap().drift.is_empty());
+
+    fs::write(home.join(".agents/skills/gh/SKILL.md"), "edited\n").unwrap();
+    let drift = audit(&env, &Scope::Global).unwrap().drift;
+    assert!(drift.iter().any(|row| row.name == "gh"), "{drift:?}");
 }

--- a/crates/core/tests/surfaces.rs
+++ b/crates/core/tests/surfaces.rs
@@ -130,11 +130,11 @@ fn a_large_skill_is_one_tree_every_surface_links_to() {
 /// A global install lands in `~/.agents/skills`, the tree Codex, OpenCode,
 /// Pi, Gemini and Copilot read there, and nothing is written into a store of
 /// kendex's own. The tools that read it get no link, because they are already
-/// looking at the tree itself; Claude Code, which reads only its own
-/// directory, gets one onto it.
+/// looking at the tree itself; Claude Code and Antigravity, which read only
+/// their own directories, each get one onto it.
 #[test]
 #[allow(clippy::unwrap_used)]
-fn a_global_skill_lands_in_the_shared_tree_and_only_claude_links_at_it() {
+fn a_global_skill_lands_in_the_shared_tree_and_only_non_readers_link_at_it() {
     let tmp = tempfile::tempdir().unwrap();
     let home = rooted(&tmp);
     let env = Env::fake(&home, FakeOs::Linux);
@@ -151,7 +151,7 @@ fn a_global_skill_lands_in_the_shared_tree_and_only_claude_links_at_it() {
     fs::write(
         &manifest,
         format!(
-            "schema = 6\n\n[sources.cat]\n{}\n\n[install]\nharnesses = [\"claude\", \"codex\", \"pi\"]\nmethod = \"symlink\"\n\n[skills.gh]\nsource = \"cat\"\n",
+            "schema = 6\n\n[sources.cat]\n{}\n\n[install]\nharnesses = [\"claude\", \"codex\", \"pi\", \"antigravity\"]\nmethod = \"symlink\"\n\n[skills.gh]\nsource = \"cat\"\n",
             source_path(&source)
         ),
     )
@@ -167,10 +167,13 @@ fn a_global_skill_lands_in_the_shared_tree_and_only_claude_links_at_it() {
     // directory would be a second position for one definition.
     assert!(!home.join(".codex/skills/gh").exists());
     assert!(!home.join(".pi/agent/skills/gh").exists());
-    // Claude Code reads neither shared tree, so its own directory holds a
-    // link — the only harness here that demands one.
+    // Claude Code and Antigravity read neither shared tree, so each one's
+    // own directory holds a link — the harnesses that demand one, and the
+    // only ones that get one.
     let claude = home.join(".claude/skills/gh");
     assert_eq!(fs::read_link(&claude).unwrap(), shared);
+    let antigravity = home.join(".gemini/config/skills/gh");
+    assert_eq!(fs::read_link(&antigravity).unwrap(), shared);
     // Nothing is kept in a store of kendex's own any more. The app's data
     // root is read off `Env`, never spelled: it is a different path per
     // platform.

--- a/crates/core/tests/surfaces.rs
+++ b/crates/core/tests/surfaces.rs
@@ -151,7 +151,7 @@ fn a_global_skill_lands_in_the_shared_tree_and_only_non_readers_link_at_it() {
     fs::write(
         &manifest,
         format!(
-            "schema = 6\n\n[sources.cat]\n{}\n\n[install]\nharnesses = [\"claude\", \"codex\", \"pi\", \"antigravity\"]\nmethod = \"symlink\"\n\n[skills.gh]\nsource = \"cat\"\n",
+            "schema = 6\n\n[sources.cat]\n{}\n\n[install]\nharnesses = [\"claude\", \"codex\", \"pi\", \"antigravity\", \"opencode\", \"gemini\", \"copilot\"]\nmethod = \"symlink\"\n\n[skills.gh]\nsource = \"cat\"\n",
             source_path(&source)
         ),
     )
@@ -163,10 +163,20 @@ fn a_global_skill_lands_in_the_shared_tree_and_only_non_readers_link_at_it() {
     let shared = home.join(".agents/skills/gh");
     assert!(shared.join("SKILL.md").is_file());
     assert!(!shared.is_symlink(), "the shared tree holds the bytes");
-    // Codex and Pi read that tree themselves, so a link in their own
-    // directory would be a second position for one definition.
-    assert!(!home.join(".codex/skills/gh").exists());
-    assert!(!home.join(".pi/agent/skills/gh").exists());
+    // Every tool that reads that tree reads it itself, so a link in its own
+    // directory would be a second position for one definition. All five are
+    // named: each is a surface this change moved, and a regression in any
+    // one of them would otherwise sit behind a test that only knew two.
+    for own in [
+        ".codex/skills/gh",
+        ".pi/agent/skills/gh",
+        ".config/opencode/skills/gh",
+        ".gemini/skills/gh",
+        ".copilot/skills/gh",
+    ] {
+        let path = home.join(own);
+        assert!(!path.exists() && !path.is_symlink(), "{own} was written");
+    }
     // Claude Code and Antigravity read neither shared tree, so each one's
     // own directory holds a link — the harnesses that demand one, and the
     // only ones that get one.

--- a/crates/core/tests/transitions.rs
+++ b/crates/core/tests/transitions.rs
@@ -128,42 +128,13 @@ fn two_tools_refusing_one_shared_tree_still_applies() {
     apply::execute(&w.env, &after.plan).unwrap();
 }
 
-/// Globally each tool links to one rendered tree. A refusal takes away the
-/// refusing tool's own link and nothing else — trashing the shared tree
-/// would uninstall the skill for every tool that still renders fine.
+/// Two tools pointed at one directory read one physical skill folder, and
+/// globally they read the shared tree as well, so the pair is one surface
+/// group holding one tree. Planning that position twice would fail the
+/// second op and roll the whole apply back.
 #[test]
 #[allow(clippy::unwrap_used)]
-fn a_refusal_keeps_the_tree_another_tool_still_reads() {
-    let w = world();
-    declare(&w, &w.env.global_manifest_file(), "\"claude\", \"codex\"");
-    let scope = Scope::Global;
-    apply_now(&w.env, &scope);
-
-    let rendered = w.env.rendered_skills_dir().join("big");
-    let claude = w.home.join(".claude/skills/big");
-    let codex = w.home.join(".codex/skills/big");
-    assert_eq!(fs::read_link(&claude).unwrap(), rendered);
-    assert_eq!(fs::read_link(&codex).unwrap(), rendered);
-
-    put(&w.source.join("skills/big/SKILL.md"), &long_description());
-    let report = audit(&w.env, &scope).unwrap();
-    assert_eq!(trashes(&report, &rendered), 0, "{:?}", report.plan.ops);
-    apply::execute(&w.env, &report.plan).unwrap();
-
-    assert!(!codex.exists() && !codex.is_symlink());
-    assert_eq!(fs::read_link(&claude).unwrap(), rendered);
-    assert_eq!(
-        fs::read_to_string(rendered.join("SKILL.md")).unwrap(),
-        long_description()
-    );
-}
-
-/// Two tools pointed at one directory read one physical skill folder, so
-/// they also share the link into the rendered tree. Planning that link twice
-/// fails the second op and rolls the whole apply back.
-#[test]
-#[allow(clippy::unwrap_used)]
-fn two_tools_sharing_one_link_position_still_applies() {
+fn two_tools_sharing_one_root_still_applies() {
     let w = world();
     let shared_root = w.home.join(".codex");
     let env = Env::fake(&w.home, FakeOs::Linux)
@@ -181,10 +152,10 @@ fn two_tools_sharing_one_link_position_still_applies() {
     let report = audit(&env, &scope).unwrap();
     apply::execute(&env, &report.plan).unwrap();
 
-    let link = shared_root.join("skills/big");
-    assert_eq!(
-        fs::read_link(&link).unwrap(),
-        env.rendered_skills_dir().join("big")
-    );
+    let shared = env.global_skills_dir().join("big");
+    assert!(shared.join("SKILL.md").is_file());
+    assert!(!shared.is_symlink());
+    // Both tools read the shared tree, so neither gets a link of its own.
+    assert!(!shared_root.join("skills/big").exists());
     assert!(audit(&env, &scope).unwrap().drift.is_empty());
 }

--- a/docs/adapters/README.md
+++ b/docs/adapters/README.md
@@ -50,7 +50,7 @@ A surface is one of four shapes, declared per kind and scope by each adapter (`S
 - `Structured`: items are entries inside one structured file; a `Reader` names the on-disk format.
 - `StructuredDir`: every `*.<ext>` in a directory is a document holding entries; a document holding none reports none.
 
-Every harness but Claude Code reads a project's `.agents/skills`, so one rendered tree serves them all and a per-harness directory stays on the surface list for what is already there and for a copy delivery. Claude's own `.claude/skills/<name>` collapses onto the shared tree through a relative link when the bytes match. An adapter claims only its own namespace; a cross-read is reported as an input to effective state, never as a second installation.
+The shared skills tree is `.agents/skills` under the scope's own root: the project's, or the home directory. Every harness but Claude Code reads the project's, and every one but Claude Code and Antigravity reads `~/.agents/skills`, so one rendered tree serves them all at either scope and a per-harness directory stays on the surface list for what is already there and for a copy delivery. A harness that does not read the shared tree gets a link in its own directory onto it when the bytes match — relative in a project, absolute globally. An adapter claims only its own namespace; a cross-read is reported as an input to effective state, never as a second installation.
 
 ## Hook commands
 

--- a/docs/adapters/antigravity.md
+++ b/docs/adapters/antigravity.md
@@ -20,7 +20,7 @@ A project root reaches a session only through a folder that session is attached 
 | Kind | Global | Project | Caps |
 |---|---|---|---|
 | agent | `~/.gemini/config/agents/*.md` | — | managed, global |
-| skill | `~/.gemini/config/skills/<name>/SKILL.md` | `.agents/skills/<name>/SKILL.md`, shared with Codex and Pi | managed, both |
+| skill | `~/.gemini/config/skills/<name>/SKILL.md`, a link onto `~/.agents/skills/<name>` | `.agents/skills/<name>/SKILL.md`, shared with Codex and Pi | managed, both |
 | command | — | — | unsupported: a skill is the slash command |
 | hook | `~/.gemini/config/hooks.json`, scripts under `~/.gemini/config/hooks/` | `.agents/hooks.json`, scripts under `.agents/hooks/` | managed, both, enforced |
 | mcp-server | `~/.gemini/config/mcp_config.json` | `.agents/mcp_config.json` | managed, both |

--- a/docs/adapters/claude.md
+++ b/docs/adapters/claude.md
@@ -25,7 +25,7 @@ Project markers: a `.claude/` directory, or a `.mcp.json` file at the repo root.
 
 MCP servers are written to `~/.claude.json` at global scope and to the repository's `.mcp.json` at project scope (`mcp_registry`, `crates/core/src/engine/targets.rs`). `settings.local.json` is observed and never written. Only the plugin enable flip is written.
 
-A project skill lives in the shared `.agents/skills/<name>` tree, and `.claude/skills/<name>` is a relative link onto it (`../../.agents/skills/<name>`) when the bytes match, committed once and resolving in every clone; an absolute link from an older install is drift and is rewritten on the next apply. Global variants live under the app data directory (`rendered_skills_dir`, `crates/core/src/env.rs`).
+Claude Code reads no shared skills tree at either scope, so its own directory holds a link onto one. A project skill lives in the shared `.agents/skills/<name>` tree, and `.claude/skills/<name>` is a relative link onto it (`../../.agents/skills/<name>`) when the bytes match, committed once and resolving in every clone; an absolute link from an older install is drift and is rewritten on the next apply. A global skill lives in `~/.agents/skills/<name>` and `~/.claude/skills/<name>` is an absolute link onto it (`global_skills_dir`, `crates/core/src/env.rs`).
 
 ## Format
 

--- a/docs/adapters/codex.md
+++ b/docs/adapters/codex.md
@@ -16,7 +16,7 @@ Project markers: a `.codex/` or `.agents/` directory.
 | Kind | Global | Project | Caps |
 |---|---|---|---|
 | agent | `~/.codex/agents/*.toml` | `.codex/agents/*.toml` | managed, both |
-| skill | `~/.codex/skills/<name>/SKILL.md` | `.agents/skills/<name>/SKILL.md`, shared with Pi and Antigravity | managed, both |
+| skill | `~/.agents/skills/<name>/SKILL.md`, shared with Pi, OpenCode, Gemini and Copilot; `~/.codex/skills/<name>/SKILL.md` for a copy delivery | `.agents/skills/<name>/SKILL.md`, shared with Pi and Antigravity | managed, both |
 | command | — | — | install, toggle, remove, refresh both; `installs_as: skill` |
 | hook | `~/.codex/hooks.json` | `.codex/hooks.json` | managed, both, enforced |
 | mcp-server | `~/.codex/config.toml` `[mcp_servers.<name>]` | `.codex/config.toml` | managed, both |

--- a/docs/adapters/codex.md
+++ b/docs/adapters/codex.md
@@ -16,7 +16,7 @@ Project markers: a `.codex/` or `.agents/` directory.
 | Kind | Global | Project | Caps |
 |---|---|---|---|
 | agent | `~/.codex/agents/*.toml` | `.codex/agents/*.toml` | managed, both |
-| skill | `~/.agents/skills/<name>/SKILL.md`, shared with Pi, OpenCode, Gemini and Copilot; `~/.codex/skills/<name>/SKILL.md` for a copy delivery | `.agents/skills/<name>/SKILL.md`, shared with Pi and Antigravity | managed, both |
+| skill | `~/.agents/skills/<name>/SKILL.md`, shared with Pi, OpenCode, Gemini and Copilot; `~/.codex/skills/<name>/SKILL.md` read back only | `.agents/skills/<name>/SKILL.md`, shared with Pi and Antigravity | managed, both |
 | command | — | — | install, toggle, remove, refresh both; `installs_as: skill` |
 | hook | `~/.codex/hooks.json` | `.codex/hooks.json` | managed, both, enforced |
 | mcp-server | `~/.codex/config.toml` `[mcp_servers.<name>]` | `.codex/config.toml` | managed, both |
@@ -24,6 +24,8 @@ Project markers: a `.codex/` or `.agents/` directory.
 | pi-extension | — | — | unsupported |
 
 Codex removed custom prompts in 0.118 (2026-03), so `~/.codex/prompts` is read by nothing and kendex neither scans nor writes it; a command is a skill there, invoked as `$name` or through `/skills`.
+
+`$HOME/.agents/skills` is the only user-level skills location Codex documents, so a global install lands there and `~/.codex/skills` is read back only. A global copy delivery still writes `~/.codex/skills`, which Codex does not read: it is the only directory of Codex's own, and what a copy should do instead is open.
 
 ## Format
 

--- a/docs/adapters/copilot.md
+++ b/docs/adapters/copilot.md
@@ -16,7 +16,7 @@ Project markers: `.github/copilot-instructions.md`, or a `.github/agents`, `.git
 | Kind | Global | Project | Caps |
 |---|---|---|---|
 | agent | `~/.copilot/agents/*.agent.md` | `.github/agents/*.agent.md` | managed, both |
-| skill | `~/.copilot/skills/<name>/SKILL.md` | `.agents/skills/<name>/SKILL.md`, or `.github/skills/<name>/SKILL.md` for a copy delivery | managed, both |
+| skill | `~/.agents/skills/<name>/SKILL.md`, or `~/.copilot/skills/<name>/SKILL.md` for a copy delivery | `.agents/skills/<name>/SKILL.md`, or `.github/skills/<name>/SKILL.md` for a copy delivery | managed, both |
 | hook | `~/.copilot/hooks/*.json`, each file a document, plus `~/.copilot/settings.json` → `hooks` | `.github/hooks/*.json`, plus `.github/copilot/settings.json` and `settings.local.json` → `hooks` | managed, both, enforced |
 | mcp-server | `~/.copilot/mcp-config.json` | `.github/mcp.json` | managed, both |
 | plugin | `~/.copilot/settings.json` → `enabledPlugins` | `.github/copilot/settings.json` and `settings.local.json` → `enabledPlugins` | observe and toggle, both |

--- a/docs/adapters/cursor.md
+++ b/docs/adapters/cursor.md
@@ -23,7 +23,7 @@ Project marker: a `.cursor/` directory.
 | plugin | `~/.cursor/plugins/{local,cache}` with `.cursor-plugin/plugin.json` | — | observe only, global |
 | pi-extension | — | — | unsupported |
 
-Cursor has no global rules directory and no documented global skills path, so both stay unsupported at global scope while the global command and plugin surfaces are scanned. `hooks.json` is observed at both scopes and never written.
+Cursor has no global rules directory, so agents stay unsupported at global scope while the global command and plugin surfaces are scanned. Cursor documents `~/.agents/skills` and `~/.cursor/skills`, but kendex models neither, so a global skill is never installed for Cursor; one installed there for another tool reaches it through the shared tree. `hooks.json` is observed at both scopes and never written.
 
 ## Format
 

--- a/docs/adapters/gemini.md
+++ b/docs/adapters/gemini.md
@@ -18,7 +18,7 @@ Global detection: `~/.gemini/settings.json`, the file the CLI writes on its firs
 | Kind | Global | Project | Caps |
 |---|---|---|---|
 | agent | `~/.gemini/agents/*.md` | `.gemini/agents/*.md` | managed, both |
-| skill | `~/.gemini/skills/<name>/SKILL.md` | `.agents/skills/<name>/SKILL.md`, or `.gemini/skills/<name>/SKILL.md` for a copy delivery | managed, both |
+| skill | `~/.agents/skills/<name>/SKILL.md`, or `~/.gemini/skills/<name>/SKILL.md` for a copy delivery | `.agents/skills/<name>/SKILL.md`, or `.gemini/skills/<name>/SKILL.md` for a copy delivery | managed, both |
 | command | `~/.gemini/commands/**/*.toml` | `.gemini/commands/**/*.toml` | managed, both |
 | hook | `~/.gemini/settings.json` → `hooks` | `.gemini/settings.json` → `hooks` | managed, both, enforced |
 | mcp-server | `~/.gemini/settings.json` → `mcpServers` | `.gemini/settings.json` → `mcpServers` | install, remove, refresh both; toggle global only |

--- a/docs/adapters/opencode.md
+++ b/docs/adapters/opencode.md
@@ -18,7 +18,7 @@ The config file for a scope is `opencode.jsonc` when it exists, else `opencode.j
 | Kind | Path | Caps |
 |---|---|---|
 | agent | `<base>/agents/*.md` | managed, both |
-| skill | `.agents/skills/<name>/SKILL.md` in a project; `<base>/skills/<name>/SKILL.md` globally and for a copy delivery | managed, both |
+| skill | `.agents/skills/<name>/SKILL.md` in a project, `~/.agents/skills/<name>/SKILL.md` globally; `<base>/skills/<name>/SKILL.md` for a copy delivery | managed, both |
 | hook | `<base>/instructions/kendex-hook-<name>.md` | managed, both, advisory |
 | command | `<base>/commands/*.md`, plus the legacy singular `<base>/command/*.md` for what is already there | managed, both |
 | mcp-server | config `mcp` key, jsonc tolerated on read, per-entry `enabled` | managed, both |

--- a/docs/adapters/pi.md
+++ b/docs/adapters/pi.md
@@ -18,7 +18,7 @@ Project markers: a `.pi/` or `.agents/` directory.
 | Kind | Global | Project | Caps |
 |---|---|---|---|
 | agent | `~/.pi/agent/agents/*.md` | `.pi/agents/*.md` | managed, both |
-| skill | `~/.pi/agent/skills/<name>/SKILL.md` | `.agents/skills/<name>/SKILL.md`, shared with Codex and Antigravity | managed, both |
+| skill | `~/.agents/skills/<name>/SKILL.md`, shared with Codex, OpenCode, Gemini and Copilot; `~/.pi/agent/skills/<name>/SKILL.md` for a copy delivery | `.agents/skills/<name>/SKILL.md`, shared with Codex and Antigravity | managed, both |
 | command | `~/.pi/agent/prompts/*.md` | `.pi/prompts/*.md` | managed, both |
 | hook | `~/.pi/agent/kendex/hooks/<name>.sh` plus `kendex/hooks.json` | `.pi/kendex/hooks/<name>.sh` plus `.pi/kendex/hooks.json` | managed, both; enforced while the `pi-hooks` carrier is registered |
 | mcp-server | — | — | unsupported |

--- a/docs/architecture/harnesses.md
+++ b/docs/architecture/harnesses.md
@@ -27,5 +27,5 @@ An adapter owns one harness's paths and rendering, and nothing else. What kendex
 
 - Every capability ships cross-harness through the table; a harness without native support for a kind is marked unsupported, never shimmed.
 - A column exists in the table only if a verb reads it; what a tool's own config holds down (Copilot's `disabledSkills`) is reported per item where it is read, and kendex's own switch still works both ways because it is a rename kendex can undo.
-- Every harness but Claude Code reads a project's `.agents/skills`, so one tree serves them all and copy delivery writes each harness's own directory; no harness caps a SKILL.md body.
+- The shared skills tree is `.agents/skills` under the scope's own root, a project's or the home directory's; every harness but Claude Code reads the project's and every one but Claude Code and Antigravity reads `~/.agents/skills`, so one tree serves them all at either scope, a harness that reads neither gets a link onto it, and copy delivery writes each harness's own directory. No harness caps a SKILL.md body.
 - The drift-relaying hook is first-party, shipped in the binary, offered at project registration, never fetched from a catalog, and still a declared, user-approved per-scope install rendered and removed like any other hook. Enforced by `crates/core/tests/drift_hook_install.rs`.


### PR DESCRIPTION
Closes KEN-645.

Global scope kept its own store under the app data directory and linked every harness's global skills directory at it, so a globally installed skill was invisible to any tool that only knows `~/.agents/skills`. Codex documents that folder as the **only** user-level skills location it reads, so the old layout was writing where Codex never looks.

Global scope now holds the same shape as project scope: the shared skills tree is `.agents/skills` under the scope's own root, so a global install lands in `~/.agents/skills/<name>`.

## Which harness reads what, globally

Checked against each vendor's own documentation on 2026-09-06.

| Harness | Reads `~/.agents/skills` | Result |
|---|---|---|
| Codex | yes, and nothing else at user level | reads the shared tree, no link |
| OpenCode | yes, beside `~/.config/opencode/skills` | reads the shared tree, no link |
| Pi | yes, beside `~/.pi/agent/skills` | reads the shared tree, no link |
| Gemini | yes, as an alias outranking `~/.gemini/skills` | reads the shared tree, no link |
| Copilot | yes, beside `~/.copilot/skills` | reads the shared tree, no link |
| Claude Code | no, `~/.claude/skills` only | link onto the shared tree |
| Antigravity | no, `~/.gemini/config/skills` only | link onto the shared tree |
| Cursor | yes, but its global surfaces are not modelled | unchanged, see below |

The five that read the tree list it first, so their surface group **is** the shared tree and no link is written for them. The two that read neither take a link in their own directory onto it — which is the dedupe project scope already performs, not a special case.

## Clean cut

Per the v1 rule: no shim, no migration reader. `Env::rendered_skills_dir` and `Env::rendered_skill_variants_dir` are deleted, and with them the global-only variant store, whose job every group's own surface already does. `Env::global_skills_dir` replaces them. Existing global installs are reinstalled fresh; the changelog fragment says so.

## Cursor is deliberately untouched

Cursor documents `~/.agents/skills` and `~/.cursor/skills` globally, which its capability row still called undocumented. That row and `docs/adapters/cursor.md` are corrected to say the surfaces are not modelled. Modelling them is a capability change rather than this issue's Done-when, so it is left as follow-up. One consequence: the global cross-read note derives its reader list from modelled surfaces, so it cannot name Cursor yet.

## A test deleted

`transitions.rs::a_refusal_keeps_the_tree_another_tool_still_reads` asserted that the canonical global tree survives a refusal by one of its readers. That is false once the tree **is** that reader's own surface, and the project-scope test directly above it pins the same behaviour. The reviewer ran the global refusal shape independently and confirmed it: the shared tree is trashed exactly once, Claude keeps its own real tree, Codex reports a Conflict row, and the follow-up apply re-converges.

## Review round

One local reviewer round found one blocker, which is fixed in the second commit. Adding the global shared tree to adoption's refusal list was scope-blind: at global scope that tree is where adoption lands, so the ordinary layout refused itself — a real skill folder in `~/.agents/skills` with `~/.claude/skills` linked at it, which is both what kendex now writes and what a person building it by hand writes. The entry is a project's now. Suggestions taken: three comments still describing the deleted variant store, one explaining the global link's absolute spelling by a shared root that now exists, and the claim that `~/.codex/skills` is a copy destination when Codex does not read it.

## Checks

- `cargo test --workspace` — 142 test binaries, 0 failures
- `tools/guard --full` — clean
- UI vitest — 149 files, 1202 tests, 0 failures
- `doc-limits` (715 documents), `preflight`, the staged pre-commit chain and the commit-msg gate — all clean
- `ui/src/bindings.ts` unchanged; no command surface change, so no regeneration

Program tracking issue: KEN-1203.

https://claude.ai/code/session_01WDeECbUFrYEGLexjFaeq7K
