### PR TITLE
fix(KEN-1258): a tool choice the picker no longer offers no longer gates Install

### DIFF
--- a/changelog.d/fixed/KEN-1258.md
+++ b/changelog.d/fixed/KEN-1258.md
@@ -1,0 +1,1 @@
+- Hold the marketplace Install buttons back when ticking a set member narrows the tools on offer past the one chosen, instead of installing to no tool and reporting success.

--- a/changelog.d/fixed/KEN-1258.md
+++ b/changelog.d/fixed/KEN-1258.md
@@ -1,1 +1,1 @@
-- Hold the marketplace Install buttons back when ticking a set member narrows the tools on offer past the one chosen, instead of installing to no tool and reporting success.
+- Hold the marketplace Install buttons back when narrowing the tools on offer leaves nothing picked, rather than installing to no tool and reporting success; a hidden tool returns with its offer.

--- a/ui/src/components/marketplaces/harness-select.tsx
+++ b/ui/src/components/marketplaces/harness-select.tsx
@@ -36,10 +36,12 @@ export type Choice = {
  * install nowhere, which would report success over a plan that wrote
  * nothing; the untouched picker is not that — it is no choice at all.
  *
- * The list this reads holds only tools the picker offers: `HarnessSelect`
- * reconciles it against every answer it gets, so a choice narrowed to
- * nothing arrives here as an empty list rather than as tools no row shows.
- * That is what makes this gate and the trigger's label one answer. */
+ * A tool list here names only tools the picker's last answer offered:
+ * `HarnessSelect` narrows the reader's pick to that answer before handing
+ * it back, so a pick the answer holds nothing of arrives as an empty list
+ * rather than as tools no row shows. That is what makes this gate and the
+ * trigger's label one answer about a chosen list. The untouched picker is
+ * the state neither of them is about. */
 export function isInstallable(choice: Choice): boolean {
   return choice.harnesses === null || choice.harnesses.length > 0;
 }
@@ -75,62 +77,73 @@ export function HarnessSelect({
   // `ItemKind` has no variant for, so the command refuses the whole call
   // and the picker is left with no row to tick. Naming no kind is what an
   // empty key means, and the command reads that as every kind.
-  const wanted = kinds.join(",");
+  const asking = kinds.join(",");
   // The choice as it stands when an answer lands, which is not the one the
-  // read was started under: the reconciliation below runs in the answer's
-  // own callback so the rows and the choice reconciled against them reach
-  // the screen in one paint, and it cannot take either as a dependency
-  // without asking the command again on every tick.
+  // read was started under: the narrowing below runs in the answer's own
+  // callback so the rows and the choice narrowed to them reach the screen
+  // in one paint, and it cannot take either as a dependency without asking
+  // the command again on every tick.
   const latest = useRef({ value, onChange });
+  // What the reader actually picked, kept apart from the narrowed list the
+  // install is sent. Which tools are offered is a fact about the kinds
+  // being installed, and those change while the page is open — so the pick
+  // is answered against each new set rather than overwritten by the first
+  // one to narrow it, and a tool a narrowing hid comes back when the set
+  // widens again instead of being dropped from the install unremarked.
+  const wanted = useRef<HarnessId[] | null>(null);
   useEffect(() => {
     latest.current = { value, onChange };
+    // Put back to no choice at all — what a destination change does — and
+    // the pick goes with it: it was an answer about the place before.
+    if (value.harnesses === null) wanted.current = null;
   });
 
   useEffect(() => {
     let live = true;
-    const asked = wanted === "" ? [] : (wanted.split(",") as ItemKind[]);
+    const asked = asking === "" ? [] : (asking.split(",") as ItemKind[]);
     void commands.installTargets(scope, asked).then((r) => {
       if (!live || r.status !== "ok") return;
       setTargets(r.data);
-      // The one place the choice is reconciled against what is offered.
-      // A choice made against a wider set of kinds can name a tool this
-      // answer no longer offers; the display drops it either way, and
-      // dropping it from the choice too is what keeps the install gate
-      // reading the same answer the trigger shows. Left in, a narrowing
-      // that empties the picker leaves every Install button pressable
-      // over a plan that would write nothing.
+      // The one place a pick is answered against what is offered, so the
+      // install gate and the trigger's label read one list. A pick made
+      // against a wider set of kinds can name a tool this answer no longer
+      // offers; left in, a narrowing that holds none of the picked tools
+      // leaves every Install button pressable over a trigger reading "No
+      // tools" and a plan that would write nothing.
       const choice = latest.current.value;
-      if (choice.harnesses === null) return;
+      const picked = wanted.current;
+      if (picked === null || choice.harnesses === null) return;
       const offers = new Set(r.data.map((t) => t.harness));
-      const kept = choice.harnesses.filter((one) => offers.has(one));
-      if (kept.length !== choice.harnesses.length)
+      const kept = picked.filter((one) => offers.has(one));
+      if (kept.join(",") !== choice.harnesses.join(","))
         latest.current.onChange({ ...choice, harnesses: kept });
     });
     return () => {
       live = false;
     };
-  }, [scope, wanted]);
+  }, [scope, asking]);
 
   // Untouched, the picker shows what this machine has and sends nothing:
   // detection is re-read at install time, so the engine's own answer and
-  // the one drawn here are the same answer, taken a moment apart. A tool
-  // this destination cannot install to is dropped from the display — the
-  // rows come from the same filter the install refuses by, so a selection
-  // made before the destination changed cannot survive as a row. The
-  // filter still stands over the window before the first answer lands,
-  // where there is nothing yet to reconcile the choice against.
-  const offered = new Set(targets.map((t) => t.harness));
+  // the one drawn here are the same answer, taken a moment apart. Both
+  // lists come from the answer in hand — detection is a column of it, and
+  // a picked list was narrowed to it above — so a tool this destination
+  // cannot install to has no row here and is in neither.
   const detected = targets.filter((t) => t.detected).map((t) => t.harness);
-  const chosen = (value.harnesses ?? detected).filter((held) =>
-    offered.has(held),
-  );
+  const chosen = value.harnesses ?? detected;
+  // Every pick goes through here: it is the reader's answer, kept as such,
+  // and the list the install is sent is that answer narrowed to what the
+  // destination offers.
+  const pick = (harnesses: HarnessId[]) => {
+    wanted.current = harnesses;
+    onChange({ ...value, harnesses });
+  };
   const toggle = (harness: HarnessId) =>
-    onChange({
-      ...value,
-      harnesses: chosen.includes(harness)
+    pick(
+      chosen.includes(harness)
         ? chosen.filter((held) => held !== harness)
         : [...chosen, harness],
-    });
+    );
   const label =
     chosen.length === 0
       ? "No tools — pick at least one"
@@ -178,25 +191,11 @@ export function HarnessSelect({
           <Button
             variant="outline"
             size="sm"
-            onClick={() =>
-              onChange({
-                ...value,
-                harnesses: targets.map((t) => t.harness),
-              })
-            }
+            onClick={() => pick(targets.map((t) => t.harness))}
           >
             All tools
           </Button>
-          <Button
-            variant="outline"
-            size="sm"
-            onClick={() =>
-              onChange({
-                ...value,
-                harnesses: detected,
-              })
-            }
-          >
+          <Button variant="outline" size="sm" onClick={() => pick(detected)}>
             Just what I have
           </Button>
         </div>

--- a/ui/src/components/marketplaces/harness-select.tsx
+++ b/ui/src/components/marketplaces/harness-select.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import {
   commands,
   type HarnessId,
@@ -34,7 +34,12 @@ export type Choice = {
 
 /** Whether this choice can be installed. An empty tool list is a choice to
  * install nowhere, which would report success over a plan that wrote
- * nothing; the untouched picker is not that — it is no choice at all. */
+ * nothing; the untouched picker is not that — it is no choice at all.
+ *
+ * The list this reads holds only tools the picker offers: `HarnessSelect`
+ * reconciles it against every answer it gets, so a choice narrowed to
+ * nothing arrives here as an empty list rather than as tools no row shows.
+ * That is what makes this gate and the trigger's label one answer. */
 export function isInstallable(choice: Choice): boolean {
   return choice.harnesses === null || choice.harnesses.length > 0;
 }
@@ -71,12 +76,35 @@ export function HarnessSelect({
   // and the picker is left with no row to tick. Naming no kind is what an
   // empty key means, and the command reads that as every kind.
   const wanted = kinds.join(",");
+  // The choice as it stands when an answer lands, which is not the one the
+  // read was started under: the reconciliation below runs in the answer's
+  // own callback so the rows and the choice reconciled against them reach
+  // the screen in one paint, and it cannot take either as a dependency
+  // without asking the command again on every tick.
+  const latest = useRef({ value, onChange });
+  useEffect(() => {
+    latest.current = { value, onChange };
+  });
 
   useEffect(() => {
     let live = true;
     const asked = wanted === "" ? [] : (wanted.split(",") as ItemKind[]);
     void commands.installTargets(scope, asked).then((r) => {
-      if (live && r.status === "ok") setTargets(r.data);
+      if (!live || r.status !== "ok") return;
+      setTargets(r.data);
+      // The one place the choice is reconciled against what is offered.
+      // A choice made against a wider set of kinds can name a tool this
+      // answer no longer offers; the display drops it either way, and
+      // dropping it from the choice too is what keeps the install gate
+      // reading the same answer the trigger shows. Left in, a narrowing
+      // that empties the picker leaves every Install button pressable
+      // over a plan that would write nothing.
+      const choice = latest.current.value;
+      if (choice.harnesses === null) return;
+      const offers = new Set(r.data.map((t) => t.harness));
+      const kept = choice.harnesses.filter((one) => offers.has(one));
+      if (kept.length !== choice.harnesses.length)
+        latest.current.onChange({ ...choice, harnesses: kept });
     });
     return () => {
       live = false;
@@ -88,7 +116,9 @@ export function HarnessSelect({
   // the one drawn here are the same answer, taken a moment apart. A tool
   // this destination cannot install to is dropped from the display — the
   // rows come from the same filter the install refuses by, so a selection
-  // made before the destination changed cannot survive as a row.
+  // made before the destination changed cannot survive as a row. The
+  // filter still stands over the window before the first answer lands,
+  // where there is nothing yet to reconcile the choice against.
   const offered = new Set(targets.map((t) => t.harness));
   const detected = targets.filter((t) => t.detected).map((t) => t.harness);
   const chosen = (value.harnesses ?? detected).filter((held) =>

--- a/ui/src/pages/bundle-detail.dom.test.tsx
+++ b/ui/src/pages/bundle-detail.dom.test.tsx
@@ -68,6 +68,25 @@ async function toolBox(host: HTMLElement, tool: string) {
   return row?.querySelector<HTMLInputElement>('input[type="checkbox"]');
 }
 
+/** The tool picker's trigger, whose label is the choice as the page reads
+ *  it: the same value both Install buttons are gated on. */
+function toolTrigger(host: HTMLElement): HTMLButtonElement | undefined {
+  return [...host.querySelectorAll("button")].find((button) =>
+    button.textContent?.includes("Install for"),
+  );
+}
+
+/** Tick a tool row and close the picker over it, so the next click lands
+ *  on the page rather than on the open menu. */
+async function tickTool(host: HTMLElement, tool: string) {
+  const box = await toolBox(host, tool);
+  if (!box) throw new Error(`no ${tool} row rendered`);
+  await userEvent.click(box);
+  await settle();
+  await userEvent.keyboard("{Escape}");
+  await settle();
+}
+
 const starter: BundleDetail = {
   name: "starter",
   description: "the six things to begin with",
@@ -209,6 +228,58 @@ describe("the curated set page", () => {
     await settle();
 
     expect(installAll(host)?.disabled).toBe(true);
+  });
+
+  // Which tools are offered is a fact about the kinds being installed, and
+  // ticking a member narrows them. A choice made while the picker was
+  // wider can name a tool the narrowed answer no longer offers; it is not
+  // an answer here, and neither button may act on it — "Install all"
+  // declares every kind, so nothing refuses it and it would report success
+  // having written nothing.
+  it("holds both buttons back on a choice the narrowed picker dropped", async () => {
+    // Cursor takes a skill at project scope only, so this set's one member
+    // drops it from the answer the moment that member is ticked.
+    vi.mocked(commands.installTargets).mockImplementation(
+      async (_scope, kinds) => ({
+        status: "ok",
+        data: [
+          { harness: "claude", detected: true, sharesTheUniversalTree: true },
+          ...(kinds.length === 0
+            ? [
+                {
+                  harness: "cursor" as const,
+                  detected: false,
+                  sharesTheUniversalTree: true,
+                },
+              ]
+            : []),
+        ],
+      }),
+    );
+    const host = mount(<BundleDetailPage />);
+    await settle();
+
+    // Chosen against every kind, which is what nothing ticked asks about.
+    await tickTool(host, harnessName("cursor"));
+    await tickTool(host, harnessName("claude"));
+    expect(toolTrigger(host)?.textContent).toContain(harnessName("cursor"));
+    expect(installAll(host)?.disabled).toBe(false);
+
+    const box = host.querySelector<HTMLInputElement>('input[type="checkbox"]');
+    if (!box) throw new Error("no member checkbox rendered");
+    await userEvent.click(box);
+    await settle();
+
+    expect(commands.installTargets).toHaveBeenLastCalledWith(HOME, ["skill"]);
+    expect(toolTrigger(host)?.textContent).toContain(
+      "No tools — pick at least one",
+    );
+    expect(installAll(host)?.disabled).toBe(true);
+    expect(
+      [...host.querySelectorAll("button")].find(
+        (button) => button.textContent === "Install 1 selected",
+      )?.disabled,
+    ).toBe(true);
   });
 
   // A destination whose read fails is the one state the picker has to

--- a/ui/src/pages/bundle-detail.dom.test.tsx
+++ b/ui/src/pages/bundle-detail.dom.test.tsx
@@ -99,6 +99,13 @@ const starter: BundleDetail = {
   recordsUnreadable: false,
 };
 
+/** The bar's own button, whatever count it currently reads. */
+function installSelected(host: HTMLElement): HTMLButtonElement | undefined {
+  return [...host.querySelectorAll("button")].find((button) =>
+    button.textContent?.startsWith("Install 1 selected"),
+  );
+}
+
 /** Install all, whatever it currently reads. */
 function installAll(host: HTMLElement): HTMLButtonElement | undefined {
   return [...host.querySelectorAll("button")].find(
@@ -235,7 +242,10 @@ describe("the curated set page", () => {
   // wider can name a tool the narrowed answer no longer offers; it is not
   // an answer here, and neither button may act on it — "Install all"
   // declares every kind, so nothing refuses it and it would report success
-  // having written nothing.
+  // having written nothing. The tick is reversible, so the narrowing is
+  // too: the tool comes back on offer and the choice comes back with it,
+  // rather than the install quietly landing on fewer tools than the reader
+  // picked.
   it("holds both buttons back on a choice the narrowed picker dropped", async () => {
     // Cursor takes a skill at project scope only, so this set's one member
     // drops it from the answer the moment that member is ticked.
@@ -275,11 +285,16 @@ describe("the curated set page", () => {
       "No tools — pick at least one",
     );
     expect(installAll(host)?.disabled).toBe(true);
-    expect(
-      [...host.querySelectorAll("button")].find(
-        (button) => button.textContent === "Install 1 selected",
-      )?.disabled,
-    ).toBe(true);
+    expect(installSelected(host)?.disabled).toBe(true);
+
+    // Untick it and the picker is wide again, so the pick it narrowed away
+    // is an answer once more.
+    await userEvent.click(box);
+    await settle();
+
+    expect(commands.installTargets).toHaveBeenLastCalledWith(HOME, []);
+    expect(toolTrigger(host)?.textContent).toContain(harnessName("cursor"));
+    expect(installAll(host)?.disabled).toBe(false);
   });
 
   // A destination whose read fails is the one state the picker has to

--- a/ui/src/pages/bundle-detail.tsx
+++ b/ui/src/pages/bundle-detail.tsx
@@ -159,7 +159,10 @@ function BundleDetail({ bundleRef }: { bundleRef: BundleRef }) {
             // This installs with whatever the bar's tool picker last
             // answered, so a picker emptied by hand holds it back the same
             // way it holds back the bar's own button: an install to no tool
-            // reports success over a plan that wrote nothing.
+            // reports success over a plan that wrote nothing. Emptied by a
+            // tick counts too — ticking a member narrows which tools are
+            // offered, and the picker drops a chosen tool the narrowed
+            // answer no longer holds.
             <Button
               disabled={
                 busy || !detail || recordsUnknown || !isInstallable(choice)


### PR DESCRIPTION
Closes KEN-1258.

`isInstallable` read `choice.harnesses` raw while the picker's trigger read the same value filtered against the tools currently on offer. When a kinds change dropped every picked tool out of that offer, the trigger said "No tools — pick at least one" while every Install button stayed pressable. **Install all** then fails open: a bundle install declares `ItemKind::ALL`, so `lands_nowhere` refuses nothing, each member's `harnesses_for` filters to `[]`, and the install reports success having written nothing.

## The shape

The issue named two. This takes the second: `HarnessSelect` answers the pick against what is offered and hands the narrowed list back through `onChange`, so there is one list and the three gates read it unchanged — `bundle-detail.tsx` Install all, `bundle-install-bar.tsx` Install N selected, `available-package.tsx` Install. No call site moved.

The narrowing runs in the `install_targets` answer's own callback, so the rows and the list narrowed to them reach the screen in one paint rather than one frame apart. It cannot key on the choice without asking the command again on every tick, so a ref carries the current one.

The narrower alternative the issue records in its Context — sending the members' kinds in place of an empty list — is a separate call and is not taken here.

## The reviewer's finding, and the second commit

Narrowing the picked list in place is one-way, and the local reviewer round caught it: pick both tools, tick a member to look at it, untick it again, and Install all wrote to one tool with nothing on screen saying so. The tick is reversible; the narrowing was not.

So the pick and the list the install is sent are two things now. Every pick goes through one place that records what the reader asked for, and each answer sets the sent list to that pick narrowed to the answer. A tool a narrowing hides comes back when the offer widens; an emptied pick still holds both buttons back; a destination change clears the pick with the choice it belonged to. The display's own `.filter(offered)` went with it — the pick is kept inside the offered set, and detection is a column of the same answer, so nothing was left for it to drop.

## Control

One dom case in `bundle-detail.dom.test.tsx`: Cursor picked while nothing is ticked, then the skill member ticked — the trigger reads "No tools — pick at least one" and both Install all and Install 1 selected are disabled — then unticked, and the pick is an answer again. Its mock matches the real command (`caps.rs` gives `(Cursor, Skill)` project scope only, and `install.rs` reads an empty kind list as `ItemKind::ALL`), so `[]` answers `[claude, cursor]` and `["skill"]` answers `[claude]` at global scope.

Both halves ran red once. With the write-back disabled the trigger read "All tools" where "No tools" is required; reconciling from the sent list instead of the pick — the first commit's behaviour — left "No tools" where "Cursor" is required.

## Validation

`tools/guard --full` is clean but for one `ui` dom test that hits vitest's 5000ms per-test cap under load. It is flaky on `origin/main` too, measured three runs each in isolation on the same box: main 5359ms ✗ / 3590ms / 4894ms, this branch 4039ms / 3659ms / 5100ms ✗. Same range, same one-in-three, and it is not a test this change touches. Every other lane passes and the staged pre-commit guard chain is clean on both commits.

https://claude.ai/code/session_01DFueRXJao7WUWwwuziCYYR
