### PR TITLE
fix(KEN-1266): DOM tests stop failing on wall clock alone

### DIFF
--- a/ui/vite.config.ts
+++ b/ui/vite.config.ts
@@ -17,6 +17,21 @@ export default defineConfig({
     // per-file choice, on the `// @vitest-environment jsdom` line the files
     // that need a DOM carry.
     setupFiles: ["./src/test/unhandled-rejections.ts"],
+    // vitest's 5000 ms default is a wall clock, and the jsdom cases spend
+    // theirs on CPU they compete for rather than on a sleep they could be
+    // fast-forwarded through: they mount a React tree and drain microtasks,
+    // yielding to the real loop only for the tick `user-event` puts between
+    // simulated events. Fake timers and a shorter fixture have nothing to
+    // bite on there, so the bound is what has to move. On the machine that
+    // runs the pre-commit chain — 32 cores under a load average around 110,
+    // several cargo and vitest lanes at once — a full run measured 4469 ms
+    // for the slowest case, while a different handful crossed 5000 ms on
+    // each run and every one of them passed alone. 30000 ms is six times
+    // that measured worst case, which absorbs the deeper starvation of an
+    // even busier box. Nothing under it bounds a case that truly hangs:
+    // `tools/guard` sets no timeout of its own, and CI caps the whole
+    // `ui-tests` job at 15 minutes rather than any single case.
+    testTimeout: 30_000,
   },
   server: {
     // A port of kendex's own. 5173 is Vite's default, so every other project


### PR DESCRIPTION
`ui/vite.config.ts` gains `testTimeout: 30_000`. One file, fifteen lines, no retry.

## Why the bound and not the fixtures

The issue offered two routes — raise the cap, or stop the slow tests waiting on real time. I measured before choosing, with an instrumented full run (`npx vitest run --testTimeout=180000`) on this 32-core box at load average ~110:

| | |
|---|---|
| tests | 1218 passed, 0 failed |
| slowest case | **4469 ms** — `src/pages/bundle-detail.dom.test.tsx` |
| p99 | 2392 ms |
| p50 | 6 ms |
| cases over 5000 ms | 4, all in `src/test/unhandled-rejections.test.ts`, which already carries its own 60 s per-case overrides |

The second route has nothing to bite on. Neither file the issue names contains a `waitFor`, a `setTimeout`, or a fixed sleep — the jsdom cases mount a React tree and drain microtasks, so what they measure is CPU they compete for. Fake timers fast-forward a clock nothing is waiting on, and a shorter fixture would only shrink a tree that is not the reason the case is slow. So the bound is what moves.

**30000 ms is six times the measured worst case.** That absorbs the deeper starvation of a busier box: the same measurement at load ~44 puts the slowest DOM case at 649 ms against 4469 ms at load ~110, so the curve is steep and the margin is there to cover it.

There is no vitest `projects` split in this repo — the jsdom environment is a per-file `// @vitest-environment jsdom` choice — so the value applies to the whole suite rather than to a "DOM project" that would have to be invented for it.

## What the change does not reach

The nested fixture configs keep vitest's 5000 ms default: `guarded.config.ts` picks only `setupFiles` off the base config and `unguarded.config.ts` imports nothing from it, and `--config` replaces rather than merges. The `an exported KENDEX_CLOSING_WINDOW_MS` control, which depends on a child dying at the default hook timeout, keeps its discriminator.

## Proof — three consecutive `tools/guard --full` runs

All on the pushed head `900ab8cd1`:

| run | exit | vitest | cumulative test time |
|---|---|---|---|
| 1 | 0 | 152 files, **1219/1219 passed** | 29.20 s |
| 2 | 0 | 152 files, **1219/1219 passed** | 36.43 s |
| 3 | 0 | 152 files, **1219/1219 passed** | 29.88 s |

Reported honestly: the box drained while this ran (load average fell from ~130 to ~20 as sibling lanes finished), so these three lanes are green but not themselves a loaded-box result. Three earlier `tools/guard --full` runs on the pre-rebase base were also all exit 0 with 1218/1218, and the first two of those did cross the loaded regime — run 1's 5-minute load average was 126 at its vitest lane, and run 2's `tsc` lane ran at 125–155. The number itself rests on the instrumented measurement at load ~110 above, not on the colour of a lane.

The full pre-commit chain is clean on this head: `doc-limits`, `preflight`, `bot-instructions`, `commit-guards` (including `md-refs` and `md-format`), `tools/guard`, `commit-msg`.

## Review

One local round, `reviewer-correctness`: **pass**, no blockers, four suggestions.

- **Fixed.** The comment claimed the bound "still ends a genuinely hung case long before the guard gives up". `tools/guard` has no timeout at all; the only ceiling is CI's `ui-tests` job at `timeout-minutes: 15`. Rewritten to say so.
- **Fixed.** The comment asserted no test in the suite waits on real time. False for nine `vi.waitFor` sites, three real `setTimeout` ticks, the nested `vitest run` spawns, the 50 ms `afterAll`, and `user-event`'s per-event real-timer yield. Narrowed to the claim that was actually measured.
- **Declined on measurement.** `vi.waitFor`'s 1000 ms bound is hardcoded in vitest and not derived from `testTimeout`. In the instrumented run the slowest whole case in `use-package-data.test.ts` was 124 ms and in `settings-zoom.test.ts` 71 ms — 8x inside the bound, in node-env files with no jsdom render. Not the observed failure class, and no run has produced one.
- **Declined on measurement.** `hookTimeout` stays at 10000 ms. Across all 152 files the largest non-test time in any file was 174 ms, so the hook bound carries ~57x headroom against the test bound's 6.7x. It is the looser of the two, not the tighter.

Closes KEN-1266.

https://claude.ai/code/session_01J2KgPUTM158AEYw22ceT8X
