### PR TITLE
fix(KEN-1264): the Packages table keeps Safety and Status at every width

### DIFF
--- a/changelog.d/fixed/1264.md
+++ b/changelog.d/fixed/1264.md
@@ -1,0 +1,1 @@
+- Keep Name, Kind, Safety and Status on screen in the Packages table at every window width, giving up the other columns by priority as the window narrows.

--- a/ui/src/components/marketplaces/package-row.tsx
+++ b/ui/src/components/marketplaces/package-row.tsx
@@ -43,6 +43,16 @@ export interface PackageEntry {
   revision?: string | null;
 }
 
+/** Which of the columns beyond the four every width keeps are on screen.
+ * The table settles this once from its own room and hands it down, so the
+ * header and every row draw the same set. */
+export interface PackageColumns {
+  tags: boolean;
+  marketplace: boolean;
+  updated: boolean;
+  places: boolean;
+}
+
 /** One row of [PackagesTable]: the package, what it is, when it last
  * changed, how it scored, where it is installed from this marketplace, and
  * the one thing this table can do with it. Whether a bare repository's row
@@ -50,16 +60,16 @@ export interface PackageEntry {
  * same reading the page header uses. */
 export function PackageRow({
   entry,
-  showMarketplace,
-  showPlaces,
+  columns,
   places,
   offerSubscribe,
 }: {
   entry: PackageEntry;
-  showMarketplace: boolean;
-  /** A marketplace's own page says where each of its packages landed; the
+  /** Which of the optional columns this row draws. The table settles it
+   *  from its own room, so the header and the body never disagree. A
+   *  marketplace's own page says where each of its packages landed; the
    *  cross-marketplace list names the marketplace in that room instead. */
-  showPlaces: boolean;
+  columns: PackageColumns;
   /** Where this package is installed from this marketplace, already
    *  worded. The table builds the whole index once — see
    *  `lib/installed-places.ts` — so a row neither scans the provenance
@@ -92,10 +102,24 @@ export function PackageRow({
   };
 
   const updated = row.updatedAt ? Date.parse(row.updatedAt) : Number.NaN;
+  const onlyKept =
+    !columns.tags &&
+    !columns.marketplace &&
+    !columns.updated &&
+    !columns.places;
 
   return (
     <TableRow className="cursor-pointer" onClick={open}>
-      <TableCell>
+      {/* The one column with no width of its own, so without a ceiling a
+          long summary sets the whole table's, pushes every other column
+          past the right edge, and leaves the reader a name and nothing
+          else. Same measure the Library's name column takes — except in
+          the state where every optional column is already gone and the
+          name is the only room left to give, where it asks for less so
+          the four that stay fit the narrowest window kendex opens. A
+          ceiling caps what the column asks for, not what it may have:
+          where the table has room to spare the name still takes it. */}
+      <TableCell className={onlyKept ? "max-w-72" : "max-w-[22rem]"}>
         <div className="flex min-w-0 items-center gap-2.5">
           <Icon className="size-4 shrink-0 text-muted-foreground" />
           <div className="min-w-0">
@@ -113,11 +137,13 @@ export function PackageRow({
       <TableCell className="text-muted-foreground">
         {kindLabel(row.kind)}
       </TableCell>
-      <TableCell>
-        <TagBadges tags={row.tags} />
-      </TableCell>
-      {showMarketplace ? (
-        <TableCell className="text-muted-foreground">
+      {columns.tags ? (
+        <TableCell className="max-w-48">
+          <TagBadges tags={row.tags} />
+        </TableCell>
+      ) : null}
+      {columns.marketplace ? (
+        <TableCell className="max-w-40 text-muted-foreground">
           <div className="truncate">{catalogLabel(catalog)}</div>
           {entry.revision ? (
             <div className="truncate font-mono text-xs">
@@ -126,15 +152,18 @@ export function PackageRow({
           ) : null}
         </TableCell>
       ) : null}
-      <TableCell className="text-muted-foreground">
-        {Number.isNaN(updated) ? (
-          // A catalog kendex keeps no history for has no date to show, and
-          // a guess would be this machine's clock rather than the package's.
-          <span aria-hidden>—</span>
-        ) : (
-          <Ago at={updated} exact={row.updatedAt} />
-        )}
-      </TableCell>
+      {columns.updated ? (
+        <TableCell className="text-muted-foreground">
+          {Number.isNaN(updated) ? (
+            // A catalog kendex keeps no history for has no date to show,
+            // and a guess would be this machine's clock rather than the
+            // package's.
+            <span aria-hidden>—</span>
+          ) : (
+            <Ago at={updated} exact={row.updatedAt} />
+          )}
+        </TableCell>
+      ) : null}
       <TableCell>
         {safety ? (
           <SafetyDot
@@ -149,8 +178,8 @@ export function PackageRow({
           <SafetyDot tone="muted" words={SAFETY_DOT_UNCHECKED} />
         )}
       </TableCell>
-      {showPlaces ? (
-        <TableCell className="truncate text-muted-foreground">
+      {columns.places ? (
+        <TableCell className="max-w-40 truncate text-muted-foreground">
           {places || <span aria-hidden>—</span>}
         </TableCell>
       ) : null}

--- a/ui/src/components/marketplaces/package-row.tsx
+++ b/ui/src/components/marketplaces/package-row.tsx
@@ -102,24 +102,13 @@ export function PackageRow({
   };
 
   const updated = row.updatedAt ? Date.parse(row.updatedAt) : Number.NaN;
-  const onlyKept =
-    !columns.tags &&
-    !columns.marketplace &&
-    !columns.updated &&
-    !columns.places;
-
   return (
     <TableRow className="cursor-pointer" onClick={open}>
       {/* The one column with no width of its own, so without a ceiling a
           long summary sets the whole table's, pushes every other column
           past the right edge, and leaves the reader a name and nothing
-          else. Same measure the Library's name column takes — except in
-          the state where every optional column is already gone and the
-          name is the only room left to give, where it asks for less so
-          the four that stay fit the narrowest window kendex opens. A
-          ceiling caps what the column asks for, not what it may have:
-          where the table has room to spare the name still takes it. */}
-      <TableCell className={onlyKept ? "max-w-72" : "max-w-[22rem]"}>
+          else. `packages-table.tsx` sets the number and says what by. */}
+      <TableCell className="max-w-72">
         <div className="flex min-w-0 items-center gap-2.5">
           <Icon className="size-4 shrink-0 text-muted-foreground" />
           <div className="min-w-0">

--- a/ui/src/components/marketplaces/packages-table.test.tsx
+++ b/ui/src/components/marketplaces/packages-table.test.tsx
@@ -28,7 +28,7 @@ import { subscription } from "@/stores/marketplaces-shared";
 import { useNavStore } from "@/stores/nav";
 import { safetyKey } from "@/stores/preinstall-safety";
 import { useProvenanceStore } from "@/stores/provenance";
-import { mount as mountTree } from "@/test/dom";
+import { mount as mountTree, roomIs } from "@/test/dom";
 import { PackagesTable } from "./packages-table";
 
 // Static rendering reads a zustand store's initial snapshot, so the score
@@ -537,4 +537,81 @@ describe("re-sorting a marketplace's packages", () => {
     });
     expect(names()).toEqual(["review", "apply"]);
   });
+});
+
+// The table's room is the page's, and a marketplace catalogue is wider than
+// most windows: below about 1400 logical px the columns used to run off the
+// right edge behind an overflow nothing drew, leaving the reader a Name and
+// no way to know a Safety or a Status was ever there.
+describe("the columns a narrow table keeps", () => {
+  const heads = (host: HTMLElement): string[] =>
+    [...host.querySelectorAll("thead th")].map(
+      (cell) => cell.textContent?.trim() ?? "",
+    );
+
+  const entry: PackageEntry = {
+    catalog,
+    recordsUnreadable: false,
+    row: { ...row, tags: ["review"], updatedAt: "2026-08-30T12:00:00Z" },
+  };
+
+  // Both pages the table serves: the Marketplaces tab, which names each
+  // row's marketplace, and one marketplace's own Packages tab, which names
+  // where each package landed instead.
+  const PAGES = [
+    {
+      page: "the Marketplaces tab",
+      table: <PackagesTable entries={[entry]} showMarketplace />,
+      wide: [
+        "Name",
+        "Kind",
+        "For",
+        "Marketplace",
+        "Last updated",
+        "Safety",
+        "Status",
+      ],
+    },
+    {
+      page: "a marketplace's Packages tab",
+      table: (
+        <PackagesTable
+          entries={[entry]}
+          showMarketplace={false}
+          subscription={{ catalog, repo: "a/b" }}
+        />
+      ),
+      wide: [
+        "Name",
+        "Kind",
+        "For",
+        "Last updated",
+        "Safety",
+        "Installed in",
+        "Status",
+      ],
+    },
+  ];
+
+  for (const { page, table, wide } of PAGES) {
+    it(`keeps Name, Kind, Safety and Status on ${page}`, () => {
+      stub.scores = {};
+      useProvenanceStore.setState({ loaded: true, rows: [] });
+      roomIs(700);
+      const host = mountTree(table);
+      expect(heads(host)).toEqual(["Name", "Kind", "Safety", "Status"]);
+      // Reachable, not merely present: the dot's words are what a reader
+      // gets from the row, and the Status cell still offers the install.
+      expect(trigger(host.innerHTML)).toContain(SAFETY_DOT_UNCHECKED);
+      expect(host.textContent ?? "").toContain("Install");
+    });
+
+    it(`gives every column back on ${page} once there is room`, () => {
+      stub.scores = {};
+      useProvenanceStore.setState({ loaded: true, rows: [] });
+      roomIs(1400);
+      const host = mountTree(table);
+      expect(heads(host)).toEqual(wide);
+    });
+  }
 });

--- a/ui/src/components/marketplaces/packages-table.tsx
+++ b/ui/src/components/marketplaces/packages-table.tsx
@@ -51,10 +51,14 @@ const EMPTY: ProvenanceRow[] = [];
 // column toward its content: the tags stack a badge to a line and the row
 // grows by a third. That is a squashed table rather than a cut one, but it
 // is not a designed width, so a column goes rather than shrinks. Under the
-// first sum there is no column left to give, and the name cell lowers its
-// own ceiling instead so the four that stay fit the narrowest window
-// kendex opens.
-const NAME_ROOM = 352; // `max-w-[22rem]` on the name cell
+// first sum there is nothing left to give, so the name's ceiling is the
+// one that makes the four kept columns fit the narrowest window kendex
+// opens beside the widest control the Status column carries.
+//
+// A ceiling caps what a column asks for, not what it may have: wherever
+// the table has room to spare, the name takes it, so the ceiling shows
+// only at a rung's own width.
+const NAME_ROOM = 288; // `max-w-72` on the name cell
 const KEPT_ROOM = NAME_ROOM + 112 + 80 + 128; // Name, Kind, Safety, Status
 const OPTIONAL_ROOM: Record<keyof PackageColumns, number> = {
   marketplace: 160,
@@ -113,9 +117,14 @@ function useRoom(ref: RefObject<HTMLElement | null>): number | null {
   useLayoutEffect(() => {
     const element = ref.current;
     if (!element) return;
+    // Read once here, before the browser paints. A ResizeObserver reports
+    // even its first observation on a later task, so left to it alone the
+    // table draws every column once at whatever width it has — which at a
+    // narrow one is the cut this fixes, on screen for a frame.
+    const measured = (width: number) => setRoom(width > 0 ? width : null);
+    measured(element.getBoundingClientRect().width);
     const observer = new ResizeObserver((entries) => {
-      const width = entries[0]?.contentRect.width ?? 0;
-      setRoom(width > 0 ? width : null);
+      measured(entries[0]?.contentRect.width ?? 0);
     });
     observer.observe(element);
     return () => observer.disconnect();

--- a/ui/src/components/marketplaces/packages-table.tsx
+++ b/ui/src/components/marketplaces/packages-table.tsx
@@ -1,7 +1,15 @@
 import { ArrowDown, ArrowUp } from "lucide-react";
-import { useEffect, useMemo, useState } from "react";
+import {
+  type RefObject,
+  useEffect,
+  useLayoutEffect,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
 import type { Catalog, ProvenanceRow } from "@/bindings";
 import {
+  type PackageColumns,
   type PackageEntry,
   PackageRow,
 } from "@/components/marketplaces/package-row";
@@ -32,6 +40,88 @@ import { useProvenanceStore } from "@/stores/provenance";
 /** A stable empty list, so a table that never reads the provenance join
  *  does not take a fresh array identity on every store read. */
 const EMPTY: ProvenanceRow[] = [];
+
+// What each column costs the table: the width its own header declares,
+// which is the whole of it — these widths are border-box, so the cell's
+// padding is already inside them. Name declares none, taking what is left;
+// what it costs is the ceiling its cell carries, which is also the width
+// at which a package name and the summary under it read in full.
+//
+// Below one of these sums the table still lays out, by squeezing every
+// column toward its content: the tags stack a badge to a line and the row
+// grows by a third. That is a squashed table rather than a cut one, but it
+// is not a designed width, so a column goes rather than shrinks. Under the
+// first sum there is no column left to give, and the name cell lowers its
+// own ceiling instead so the four that stay fit the narrowest window
+// kendex opens.
+const NAME_ROOM = 352; // `max-w-[22rem]` on the name cell
+const KEPT_ROOM = NAME_ROOM + 112 + 80 + 128; // Name, Kind, Safety, Status
+const OPTIONAL_ROOM: Record<keyof PackageColumns, number> = {
+  marketplace: 160,
+  places: 160,
+  updated: 128,
+  tags: 192,
+};
+
+/** The order the columns come back in as the table's room grows, and in
+ *  reverse the order it gives them up. Where a package came from and where
+ *  it landed are the first back because they say something no other column
+ *  does; the tags are the last because the filter above the table asks the
+ *  same question and the row's own page answers it in full. */
+const RESTORE_ORDER: (keyof PackageColumns)[] = [
+  "marketplace",
+  "places",
+  "updated",
+  "tags",
+];
+
+const NONE: PackageColumns = {
+  tags: false,
+  marketplace: false,
+  updated: false,
+  places: false,
+};
+
+/** The columns `room` pixels can hold, out of the ones this table declares.
+ *
+ *  Name, Kind, Safety and Status are what a reader needs to tell one
+ *  package from another and decide about it, so they stay at every width
+ *  and the rest are spent against what is left over. A `room` of null is a
+ *  width nothing has measured yet: the table opens on everything it
+ *  declares and narrows once its own layout has answered. */
+function afforded(
+  room: number | null,
+  declared: PackageColumns,
+): PackageColumns {
+  if (room === null) return declared;
+  const shown = { ...NONE };
+  let used = KEPT_ROOM;
+  for (const column of RESTORE_ORDER) {
+    if (!declared[column]) continue;
+    used += OPTIONAL_ROOM[column];
+    if (used > room) break;
+    shown[column] = true;
+  }
+  return shown;
+}
+
+/** How wide the element the ref is on is, kept current as it changes.
+ *  Null until a layout has answered: a zero width is an element nothing has
+ *  laid out yet, not a table with no room to give a column. */
+function useRoom(ref: RefObject<HTMLElement | null>): number | null {
+  const [room, setRoom] = useState<number | null>(null);
+  useLayoutEffect(() => {
+    const element = ref.current;
+    if (!element) return;
+    const observer = new ResizeObserver((entries) => {
+      const width = entries[0]?.contentRect.width ?? 0;
+      setRoom(width > 0 ? width : null);
+    });
+    observer.observe(element);
+    return () => observer.disconnect();
+  }, [ref]);
+  return room;
+}
 
 /** A column header that re-sorts the table. Clicking the column already
  *  sorted turns it around; clicking another takes it over, ascending. The
@@ -133,7 +223,29 @@ export function PackagesTable({
     if (showPlaces) void reloadProvenance();
   }, [showPlaces, reloadProvenance]);
 
-  const ordered = useMemo(() => orderPackages(entries, sort), [entries, sort]);
+  // The room the table has is the room the page gives it, which no column
+  // it draws can change: the wrapper fills the page's content column
+  // whatever the table inside it does, so measuring it cannot chase itself.
+  const roomRef = useRef<HTMLDivElement>(null);
+  const room = useRoom(roomRef);
+  const columns = useMemo(
+    () =>
+      afforded(room, {
+        tags: true,
+        updated: true,
+        marketplace: showMarketplace,
+        places: showPlaces,
+      }),
+    [room, showMarketplace, showPlaces],
+  );
+  // A column that is not on screen carries no control the reader can see or
+  // undo, so an order it holds goes back to the one every width shows.
+  const order = sort.key === "updated" && !columns.updated ? BY_NAME : sort;
+
+  const ordered = useMemo(
+    () => orderPackages(entries, order),
+    [entries, order],
+  );
   // One pass over the join for the whole table, rather than a full scan of
   // every installation on the machine per row, once per render.
   const places = useMemo(
@@ -145,7 +257,7 @@ export function PackagesTable({
   );
 
   return (
-    <>
+    <div ref={roomRef}>
       {offerSubscribe ? (
         <p className="mb-3 text-xs text-muted-foreground">
           {SUBSCRIBE_TO_INSTALL_MEANS}
@@ -154,31 +266,33 @@ export function PackagesTable({
       <Table>
         <TableHeader>
           <TableRow>
-            <SortHead column="name" sort={sort} onSort={setSort}>
+            <SortHead column="name" sort={order} onSort={setSort}>
               Name
             </SortHead>
             <SortHead
               column="kind"
-              sort={sort}
+              sort={order}
               onSort={setSort}
               className="w-28"
             >
               Kind
             </SortHead>
-            <TableHead className="w-48">For</TableHead>
-            {showMarketplace ? (
+            {columns.tags ? <TableHead className="w-48">For</TableHead> : null}
+            {columns.marketplace ? (
               <TableHead className="w-40">Marketplace</TableHead>
             ) : null}
-            <SortHead
-              column="updated"
-              sort={sort}
-              onSort={setSort}
-              className="w-32"
-            >
-              Last updated
-            </SortHead>
+            {columns.updated ? (
+              <SortHead
+                column="updated"
+                sort={order}
+                onSort={setSort}
+                className="w-32"
+              >
+                Last updated
+              </SortHead>
+            ) : null}
             <TableHead className="w-20">Safety</TableHead>
-            {showPlaces ? (
+            {columns.places ? (
               <TableHead className="w-40">Installed in</TableHead>
             ) : null}
             <TableHead className="w-32 text-right">Status</TableHead>
@@ -189,8 +303,7 @@ export function PackagesTable({
             <PackageRow
               key={`${catalogKey(entry.catalog)}:${entry.row.kind}:${entry.row.name}`}
               entry={entry}
-              showMarketplace={showMarketplace}
-              showPlaces={showPlaces}
+              columns={columns}
               places={
                 places.get(placesKey(entry.row.kind, entry.row.name)) ?? ""
               }
@@ -199,6 +312,6 @@ export function PackagesTable({
           ))}
         </TableBody>
       </Table>
-    </>
+    </div>
   );
 }

--- a/ui/src/test/dom.tsx
+++ b/ui/src/test/dom.tsx
@@ -72,12 +72,17 @@ export function mount(
 export const settle = (): Promise<void> => act(async () => {});
 
 // jsdom lays nothing out and ships no ResizeObserver, so a component that
-// sizes itself from its own room gets neither. This is the browser's
-// contract filled in: observing an element reports a width at once, as a
-// browser does on the first observation, and [roomIs] re-reports it the way
-// a resize would. The width starts at zero — what an element that has not
-// been laid out reports — so a test that never sets one sees exactly what
-// the unmeasured case renders.
+// sizes itself from its own room gets neither. This fills the gap: an
+// observed element reports the width [roomIs] last set, and re-reports it
+// when that changes, the way a resize does. The width starts at zero —
+// what an element nothing has laid out reports — so a test that never sets
+// one sees exactly what the unmeasured case renders.
+//
+// It reports from inside `observe`, where a real ResizeObserver delivers
+// even its first observation on a later task. That is what keeps these
+// tests synchronous, and it is also why no test here can see the frame a
+// browser draws before the first observation lands. A component that must
+// be right on that frame reads its own width and does not wait.
 const observing = new Map<ResizeObserverCallback, Set<Element>>();
 let room = 0;
 

--- a/ui/src/test/dom.tsx
+++ b/ui/src/test/dom.tsx
@@ -70,3 +70,66 @@ export function mount(
  *  resolves on the microtask queue, and the state it sets is not on
  *  screen until that has drained. */
 export const settle = (): Promise<void> => act(async () => {});
+
+// jsdom lays nothing out and ships no ResizeObserver, so a component that
+// sizes itself from its own room gets neither. This is the browser's
+// contract filled in: observing an element reports a width at once, as a
+// browser does on the first observation, and [roomIs] re-reports it the way
+// a resize would. The width starts at zero — what an element that has not
+// been laid out reports — so a test that never sets one sees exactly what
+// the unmeasured case renders.
+const observing = new Map<ResizeObserverCallback, Set<Element>>();
+let room = 0;
+
+function report(
+  callback: ResizeObserverCallback,
+  targets: Iterable<Element>,
+): void {
+  const entries = [...targets].map(
+    (target) =>
+      ({
+        target,
+        contentRect: { width: room, height: 0 } as DOMRectReadOnly,
+      }) as ResizeObserverEntry,
+  );
+  if (entries.length > 0)
+    callback(entries, undefined as unknown as ResizeObserver);
+}
+
+class StubResizeObserver implements ResizeObserver {
+  private readonly targets = new Set<Element>();
+
+  constructor(private readonly callback: ResizeObserverCallback) {
+    observing.set(callback, this.targets);
+  }
+
+  observe(target: Element): void {
+    this.targets.add(target);
+    report(this.callback, [target]);
+  }
+
+  unobserve(target: Element): void {
+    this.targets.delete(target);
+  }
+
+  disconnect(): void {
+    this.targets.clear();
+    observing.delete(this.callback);
+  }
+}
+
+globalThis.ResizeObserver = StubResizeObserver;
+
+/** Report `width` as the room every observed element has, and tell the
+ *  observers, the way a browser does when the window changes size. */
+export function roomIs(width: number): void {
+  room = width;
+  act(() => {
+    for (const [callback, targets] of observing) report(callback, targets);
+  });
+}
+
+afterEach(() => {
+  observing.clear();
+  room = 0;
+});


### PR DESCRIPTION
Closes KEN-1264.

## What was wrong

The Name cell carried no width ceiling, so the longest package summary in a catalogue set the whole table's width. Measured in headless Chromium against the app's own built CSS, at a 1170 px window (882 px of table room): the table asked for **1383 px**, so **501 px** — every column but Name — sat behind the table container's `overflow-x-auto` with nothing on screen saying so. That is `shots/n05.png` from the app-screens lane, reproduced.

## What changed

**The name cell takes a ceiling.** It is the one column with no width of its own, so without one a long summary sets the table's.

**The table gives up columns by priority.** It measures its own room and drops the optional columns as that room shrinks: the tags first, then Last updated, then the marketplace or the places a package landed in. Name, Kind, Safety and Status stay at every width — the priority the issue names. Below the last rung there is nothing left to give, and the ceiling is set so those four fit the narrowest window kendex opens (900 px) beside the widest control the Status column carries, `Subscribe and install`.

The room is read in the layout effect before the browser paints, as well as observed. A ResizeObserver reports even its first observation on a later task, and the frame before it would have drawn the cut.

A column carries no sort control once it is off screen, so an order held by Last updated falls back to name until the column returns.

## Measured, at each rung's own boundary

Headless Chromium, this branch's built CSS, the component's own dumped markup. `min` is the scroller's content width; `room` is what the page gives it.

| rung | room | min | overflow | columns |
|---|---|---|---|---|
| kept only, widest Status | 608 | 608 | 0 | Name 288, Kind, Safety, Status |
| kept only, widest Status | 767 | 767 | 0 | Name 408, Kind, Safety, Status |
| + marketplace | 768 | 768 | 0 | Name 288, Kind 112, Marketplace 160, Safety 80, Status 128 |
| + Last updated | 896 | 896 | 0 | Name 288, and every column at its declared width |
| all | 1088 | 1088 | 0 | Name 288, For 192, and the rest at their declared widths |
| all | 1280 | 1280 | 0 | Name 480 |

Before and after at the reported 1170 px window: **1383 px asked for, 501 px cut** → **882 px asked for, 0 cut**.

A ceiling caps what a column asks for, not what it may have: the name runs to 480 px at a 1280 px room and further above that.

## Tests

One table-driven control over both pages the table serves — the Marketplaces tab and a marketplace's own Packages tab — mounted at a narrow room, asserting the four kept columns with the safety dot's words and the Status control reachable there. The wide room is its inverse.

Must-fail controls, each red once:

- the collapse disabled (`afforded` always returns what the table declares) turns both narrow cases red;
- the budget scaled so nothing is afforded turns both wide cases red.

jsdom lays nothing out and ships no ResizeObserver, so the shared dom harness supplies one and a `roomIs(width)` helper. It reports from inside `observe`, where a browser delivers on a later task — that is what keeps these tests synchronous, and it is why no test here can see the first painted frame. The comment says so, and the component reads its own width rather than waiting.

No test pins the ceiling itself. jsdom computes no layout, so an assertion there could only pin a class name; the ceiling is proven by the measurements above.

## Checks

Full ui suite 1225/1225, `tsc`, `biome`, preflight, doc-limits, `tools/guard --full`, and the staged guard chain on both commits.

The branch was restacked onto current main mid-round: `b04e172b7` (KEN-1249) landed a stricter `md-refs` that the installed hook picked up, and it judged this worktree's older catalogue rather than the branch's own change.

https://claude.ai/code/session_014HqASXPyHijqsPucjARUw4
