### PR TITLE
test(KEN-1241): require widget lifecycle execution

### DIFF
--- a/pi-extensions/pi-background-tasks/tests/fixtures/widget-lifecycle.ts
+++ b/pi-extensions/pi-background-tasks/tests/fixtures/widget-lifecycle.ts
@@ -169,3 +169,4 @@ try {
 } finally {
 	await active.emit("session_shutdown");
 }
+console.log(`widget lifecycle completed: ${scenario}`);

--- a/pi-extensions/pi-background-tasks/tests/widget-lifecycle.test.ts
+++ b/pi-extensions/pi-background-tasks/tests/widget-lifecycle.test.ts
@@ -3,9 +3,7 @@ import { spawnSync } from "node:child_process";
 import { mkdirSync, mkdtempSync, rmSync } from "node:fs";
 import { resolve } from "node:path";
 
-// Separate processes isolate peer mocks, the stack registry, settings and the clock
-// from other suites that run real background tasks.
-for (const [scenario, seconds] of [
+const lifecycleCases = [
 	["expiry-above", 15],
 	["expiry-below", 15],
 	["sibling", 15],
@@ -16,8 +14,14 @@ for (const [scenario, seconds] of [
 	["boundary-at", 2_147_483.647],
 	["thirty-days", 2_592_000],
 	["overflow", 1e308],
-] as const) {
-	test(`widget lifecycle: ${scenario}`, () => {
+] as const;
+
+// Separate processes isolate peer mocks, the stack registry, settings and the clock
+// from other suites that run real background tasks.
+test("widget lifecycle scenarios", () => {
+	expect.assertions(lifecycleCases.length + 1);
+	expect(lifecycleCases.length).toBeGreaterThan(0);
+	for (const [scenario, seconds] of lifecycleCases) {
 		const root = resolve(import.meta.dir, "../../../tmp");
 		mkdirSync(root, { recursive: true });
 		const dir = mkdtempSync(resolve(root, "widget-lifecycle-"));
@@ -28,9 +32,11 @@ for (const [scenario, seconds] of [
 				encoding: "utf8",
 				timeout: 10_000,
 			});
-			expect({ error: result.error?.message, status: result.status, stderr: result.stderr }).toEqual({ error: undefined, status: 0, stderr: "" });
+			expect({ scenario, error: result.error?.message, status: result.status, stderr: result.stderr, stdout: result.stdout }).toEqual({
+				scenario, error: undefined, status: 0, stderr: "", stdout: `widget lifecycle completed: ${scenario}\n`,
+			});
 		} finally {
 			rmSync(dir, { recursive: true, force: true });
 		}
-	});
-}
+	}
+}, lifecycleCases.length * 10_000);


### PR DESCRIPTION
An empty widget-lifecycle registration table previously passed with no tests. A child that returned success before its checks could also pass. The runner now requires a nonempty table, one result assertion per scenario and exact completion output from each child after its checks and shutdown.

The scenario list is unchanged. Every former fixture assertion remains byte-for-byte. Each row retains the error, exit-status and stderr checks. Process isolation, timeouts and owned-directory cleanup remain.

Validation: full guard, preflight, document limits, Pi package policy and the focused suite pass. Compiled controls reject empty tables, skipped rows, missing assertions and a no-op child. Real expiry, deadline, shutdown-cleanup and placement mutations fail. The specialist test review found no defects; its independent expiry and skipped-fixture controls each killed their mutant and passed 10 stability samples with 4 parallel processes.

KEN-1241
