### PR TITLE
test(KEN-1241): control budget driver lifecycle callbacks

### DIFF
--- a/pi-extensions/pi-qol/tests/budget-guard-runtime.test.ts
+++ b/pi-extensions/pi-qol/tests/budget-guard-runtime.test.ts
@@ -510,7 +510,7 @@ for (const { name, expected, run } of lifecycleRows) {
 		expect.hasAssertions();
 		const driver = new BudgetGuardDriver();
 		try {
-			expect(await run(driver)).toEqual(expected);
+			expect(await run(driver)).toStrictEqual(expected);
 		} finally {
 			driver.reset();
 		}

--- a/pi-extensions/pi-qol/tests/budget-guard-runtime.test.ts
+++ b/pi-extensions/pi-qol/tests/budget-guard-runtime.test.ts
@@ -40,290 +40,479 @@ function recorder() {
 	const statusCalls: Array<string | undefined> = [];
 	const notify = (message: string, level: GuardLevel) => { notifyCalls.push({ level, message }); };
 	const onStatus = (message: string | undefined) => { statusCalls.push(message); };
-	const makeCompact = (mode: "success" | "fail" | "throw" | "swallow") => {
-		return (options: GuardCompactOptions) => {
-			compactCalls.push(options);
-			if (mode === "throw") throw new Error("dispatch failed");
-			if (mode === "swallow") return; // simulate ctx.compact accepting then never calling callbacks
-			if (mode === "success") setTimeout(() => options.onComplete?.(), 0);
-			if (mode === "fail") setTimeout(() => options.onError?.(new Error("model down")), 0);
-		};
+	const compact = (options: GuardCompactOptions) => { compactCalls.push(options); };
+	const complete = (index = 0) => {
+		const callback = compactCalls[index]?.onComplete;
+		if (!callback) throw new Error(`Missing compaction completion callback at ${index}`);
+		callback();
 	};
-	return { compactCalls, makeCompact, notify, notifyCalls, onStatus, statusCalls };
+	const fail = (message: string, index = 0) => {
+		const callback = compactCalls[index]?.onError;
+		if (!callback) throw new Error(`Missing compaction error callback at ${index}`);
+		callback(new Error(message));
+	};
+	return { compactCalls, complete, fail, compact, notify, notifyCalls, onStatus, statusCalls };
 }
 
-test("dispatch fires once per crossing key", () => {
-	const driver = new BudgetGuardDriver();
-	const { compactCalls, makeCompact, notify, notifyCalls } = recorder();
-	const t = trigger("percent:85:1", "90% context >= 85% budget guard");
-	const first = dispatch(driver, { compact: makeCompact("swallow"), notify, trigger: t });
-	expect((first as Extract<DispatchOutcome, { kind: "dispatched" }>).kind).toBe("dispatched");
-	expect(compactCalls.length).toBe(1);
-	expect(driver.currentKey).toBe(t.key);
-	expect(notifyCalls[0]?.message).toContain("starting compaction");
-	const second = dispatch(driver, { compact: makeCompact("swallow"), notify, trigger: t });
-	// Same crossing key while compaction is still in-flight - should be deduped.
-	expect(second.kind).toBe("in-flight");
-});
+const lifecycleRows = [
+	{
+		name: "dispatch fires once per crossing key",
+		expected: {
+			firstOutcome: "dispatched",
+			compactCalls: 1,
+			currentKey: "percent:85:1",
+			startingNotification: true,
+			repeatOutcome: "in-flight",
+		},
+		run: async (driver: BudgetGuardDriver) => {
+			const observed: Record<string, unknown> = {};
+			const { compactCalls, compact, notify, notifyCalls } = recorder();
+			const t = trigger("percent:85:1", "90% context >= 85% budget guard");
+			const first = dispatch(driver, { compact, notify, trigger: t });
+			observed.firstOutcome = first.kind;
+			observed.compactCalls = compactCalls.length;
+			observed.currentKey = driver.currentKey;
+			observed.startingNotification = (notifyCalls[0]?.message)?.includes("starting compaction");
+			const second = dispatch(driver, { compact, notify, trigger: t });
+			// Same crossing key while compaction is still in-flight - should be deduped.
+			observed.repeatOutcome = second.kind;
+			return observed;
+		},
+	},
+	{
+		name: "dispatch deduplicates a repeated trigger after completion within the same bucket",
+		expected: {
+			canFireAfterCompletion: true,
+			repeatOutcome: "dedup",
+			compactCalls: 1,
+		},
+		run: async (driver: BudgetGuardDriver) => {
+			const observed: Record<string, unknown> = {};
+			const { complete, compactCalls, compact, notify } = recorder();
+			const t = trigger("percent:85:1", "reason");
+			const lifecycle = dispatchLifecycle(driver, { compact, notify, trigger: t });
+			complete();
+			await lifecycle.completion;
+			observed.canFireAfterCompletion = driver.canFire;
+			const repeat = dispatch(driver, { compact, notify, trigger: t });
+			observed.repeatOutcome = repeat.kind;
+			observed.compactCalls = compactCalls.length;
+			return observed;
+		},
+	},
+	{
+		name: "session_compact satisfies the current crossing key",
+		expected: {
+			satisfiedKey: "percent:85:1",
+			repeatOutcome: "dedup",
+			compactCalls: 1,
+		},
+		run: async (driver: BudgetGuardDriver) => {
+			const observed: Record<string, unknown> = {};
+			const { complete, compactCalls, compact, notify } = recorder();
+			const t = trigger("percent:85:1", "reason");
+			const lifecycle = dispatchLifecycle(driver, { compact, notify, trigger: t });
+			complete();
+			await lifecycle.completion;
+			driver.noteSessionCompacted();
+			observed.satisfiedKey = driver.currentKey;
+			const next = dispatch(driver, { compact, notify, trigger: t });
+			observed.repeatOutcome = next.kind;
+			observed.compactCalls = compactCalls.length;
+			return observed;
+		},
+	},
+	{
+		name: "session_compact clears suppression after usage falls below the trigger",
+		expected: {
+			belowBudgetOutcome: "no-trigger",
+			recrossingOutcome: "dispatched",
+			compactCalls: 2,
+		},
+		run: async (driver: BudgetGuardDriver) => {
+			const observed: Record<string, unknown> = {};
+			const { complete, compactCalls, compact, notify } = recorder();
+			const t = trigger("percent:85:1", "reason");
+			const lifecycle = dispatchLifecycle(driver, { compact, notify, trigger: t });
+			complete();
+			await lifecycle.completion;
+			driver.noteSessionCompacted();
+			observed.belowBudgetOutcome = dispatch(driver, { compact, notify, trigger: undefined }).kind;
+			observed.recrossingOutcome = dispatch(driver, { compact, notify, trigger: t }).kind;
+			observed.compactCalls = compactCalls.length;
+			return observed;
+		},
+	},
+	{
+		name: "session_compact allows a genuinely new trigger key",
+		expected: {
+			newBucketOutcome: "dispatched",
+			compactCalls: 2,
+		},
+		run: async (driver: BudgetGuardDriver) => {
+			const observed: Record<string, unknown> = {};
+			const { complete, compactCalls, compact, notify } = recorder();
+			const first = trigger("percent:85:1", "first bucket");
+			const second = trigger("percent:85:2", "second bucket");
+			const lifecycle = dispatchLifecycle(driver, { compact, notify, trigger: first });
+			complete();
+			await lifecycle.completion;
+			driver.noteSessionCompacted();
+			observed.newBucketOutcome = dispatch(driver, { compact, notify, trigger: second }).kind;
+			observed.compactCalls = compactCalls.length;
+			return observed;
+		},
+	},
+	{
+		name: "Already compacted is benign only after a later session_compact",
+		expected: {
+			satisfiedKey: "percent:85:1",
+			canFire: true,
+			finalStatus: undefined,
+			errorNotification: false,
+			repeatOutcome: "dedup",
+		},
+		run: async (driver: BudgetGuardDriver) => {
+			const observed: Record<string, unknown> = {};
+			const { compactCalls, notify, notifyCalls, onStatus, statusCalls } = recorder();
+			const t = trigger("percent:85:1", "reason");
+			const lifecycle = dispatchLifecycle(driver, {
+				compact: (options) => compactCalls.push(options),
+				notify,
+				onStatus,
+				trigger: t,
+			});
+			driver.noteSessionCompacted();
+			compactCalls[0]?.onError?.(new Error("Already compacted"));
+			await lifecycle.completion;
+			observed.satisfiedKey = driver.currentKey;
+			observed.canFire = driver.canFire;
+			observed.finalStatus = statusCalls.at(-1);
+			observed.errorNotification = notifyCalls.some((call) => call.level === "error");
+			observed.repeatOutcome = dispatch(driver, { compact: () => {}, notify, trigger: t }).kind;
+			return observed;
+		},
+	},
+	{
+		name: "Already compacted remains an error without a later session_compact",
+		expected: {
+			currentKey: undefined,
+			alreadyCompactedError: true,
+		},
+		run: async (driver: BudgetGuardDriver) => {
+			const observed: Record<string, unknown> = {};
+			const { fail, compact, notify, notifyCalls } = recorder();
+			const lifecycle = dispatchLifecycle(driver, {
+				compact,
+				notify,
+				trigger: trigger("percent:85:1", "reason"),
+			});
+			fail("Already compacted");
+			await lifecycle.completion;
+			observed.currentKey = driver.currentKey;
+			observed.alreadyCompactedError = notifyCalls.some((call) => call.level === "error" && call.message.includes("Already compacted"));
+			return observed;
+		},
+	},
+	{
+		name: "a delayed unrelated error stays visible without clearing a session-satisfied key",
+		expected: {
+			modelDownError: true,
+			satisfiedKey: "percent:85:1",
+			repeatOutcome: "dedup",
+		},
+		run: async (driver: BudgetGuardDriver) => {
+			const observed: Record<string, unknown> = {};
+			const { compactCalls, notify, notifyCalls } = recorder();
+			const t = trigger("percent:85:1", "reason");
+			dispatch(driver, {
+				compact: (options) => compactCalls.push(options),
+				notify,
+				trigger: t,
+			});
+			driver.noteSessionCompacted();
+			compactCalls[0]?.onError?.(new Error("model down"));
+			observed.modelDownError = notifyCalls.some((call) => call.level === "error" && call.message.includes("model down"));
+			observed.satisfiedKey = driver.currentKey;
+			observed.repeatOutcome = dispatch(driver, { compact: () => {}, notify, trigger: t }).kind;
+			return observed;
+		},
+	},
+	{
+		name: "dispatch refuses a new bucket while the first crossing is in flight",
+		expected: {
+			firstOutcome: "dispatched",
+			newBucketOutcome: "in-flight",
+		},
+		run: async (driver: BudgetGuardDriver) => {
+			const observed: Record<string, unknown> = {};
+			const { compact, notify } = recorder();
+			const first = dispatch(driver, { compact, notify, trigger: trigger("percent:85:1", "1x") });
+			observed.firstOutcome = first.kind;
+			// In-flight; subsequent triggers (regardless of key) return in-flight.
+			const second = dispatch(driver, { compact, notify, trigger: trigger("percent:85:2", "2x") });
+			observed.newBucketOutcome = second.kind;
+			return observed;
+		},
+	},
+	{
+		name: "dispatch with no trigger clears the crossing key",
+		expected: {
+			currentKey: undefined,
+		},
+		run: async (driver: BudgetGuardDriver) => {
+			const observed: Record<string, unknown> = {};
+			const { complete, compact, notify } = recorder();
+			const lifecycle = dispatchLifecycle(driver, { compact, notify, trigger: trigger("percent:85:1", "x") });
+			driver.noteSessionCompacted();
+			complete();
+			await lifecycle.completion;
+			dispatch(driver, { compact, notify, trigger: undefined });
+			observed.currentKey = driver.currentKey;
+			return observed;
+		},
+	},
+	{
+		name: "dispatch refuses when ctx.compact is missing and notifies the user",
+		expected: {
+			outcome: "no-compact-fn",
+			canFire: true,
+			unavailableWarning: true,
+		},
+		run: async (driver: BudgetGuardDriver) => {
+			const observed: Record<string, unknown> = {};
+			const { notify, notifyCalls } = recorder();
+			const result = dispatch(driver, { compact: undefined, notify, trigger: trigger("p:85:1", "r") });
+			observed.outcome = result.kind;
+			observed.canFire = driver.canFire;
+			observed.unavailableWarning = notifyCalls.some((call) => call.message.includes("ctx.compact is unavailable") && call.level === "warning");
+			return observed;
+		},
+	},
+	{
+		name: "dispatch propagates the sentinel in customInstructions",
+		expected: {
+			sentinelPresent: true,
+		},
+		run: async (driver: BudgetGuardDriver) => {
+			const observed: Record<string, unknown> = {};
+			const { compactCalls, compact, notify } = recorder();
+			dispatch(driver, { compact, notify, trigger: trigger("p:85:1", "r") });
+			observed.sentinelPresent = (compactCalls[0]?.customInstructions ?? "")?.includes(QOL_BUDGET_GUARD_SENTINEL);
+			return observed;
+		},
+	},
+	{
+		name: "dispatch exposes persistent status until compaction callback finishes",
+		expected: {
+			compactingStatus: true,
+			finalStatus: undefined,
+		},
+		run: async (driver: BudgetGuardDriver) => {
+			const observed: Record<string, unknown> = {};
+			const { complete, compact, notify, onStatus, statusCalls } = recorder();
+			const lifecycle = dispatchLifecycle(driver, { compact, notify, onStatus, trigger: trigger("p:85:1", "90% context >= 85% budget guard") });
+			observed.compactingStatus = (statusCalls[0])?.includes("QOL budget guard compacting session");
+			complete();
+			await lifecycle.completion;
+			observed.finalStatus = statusCalls.at(-1);
+			return observed;
+		},
+	},
+	{
+		name: "dispatch clears persistent status on async compact failure",
+		expected: {
+			compactingStatus: true,
+			finalStatus: undefined,
+		},
+		run: async (driver: BudgetGuardDriver) => {
+			const observed: Record<string, unknown> = {};
+			const { fail, compact, notify, onStatus, statusCalls } = recorder();
+			const lifecycle = dispatchLifecycle(driver, { compact, notify, onStatus, trigger: trigger("p:85:1", "r") });
+			observed.compactingStatus = (statusCalls[0])?.includes("QOL budget guard compacting session");
+			fail("model down");
+			await lifecycle.completion;
+			observed.finalStatus = statusCalls.at(-1);
+			return observed;
+		},
+	},
+	{
+		name: "dispatch clears state and notifies on synchronous compact throw",
+		expected: {
+			outcome: "dispatch-threw",
+			canFire: true,
+			currentKey: undefined,
+			finalStatus: undefined,
+			startError: true,
+		},
+		run: async (driver: BudgetGuardDriver) => {
+			const observed: Record<string, unknown> = {};
+			const { notify, notifyCalls, onStatus, statusCalls } = recorder();
+			const result = dispatch(driver, { compact: () => { throw new Error("boom"); }, notify, onStatus, trigger: trigger("p:85:1", "r") });
+			observed.outcome = result.kind;
+			observed.canFire = driver.canFire;
+			// On throw, the crossing key is cleared so the next agent_end can retry.
+			observed.currentKey = driver.currentKey;
+			observed.finalStatus = statusCalls.at(-1);
+			observed.startError = notifyCalls.some((call) => call.message.includes("failed to start") && call.level === "error");
+			return observed;
+		},
+	},
+	{
+		name: "dispatch onError clears the crossing key so the next agent_end retries",
+		expected: {
+			canFire: true,
+			currentKey: undefined,
+			failureNotification: true,
+		},
+		run: async (driver: BudgetGuardDriver) => {
+			const observed: Record<string, unknown> = {};
+			const { fail, compact, notify, notifyCalls } = recorder();
+			const lifecycle = dispatchLifecycle(driver, { compact, notify, trigger: trigger("p:85:1", "r") });
+			fail("model down");
+			await lifecycle.completion;
+			observed.canFire = driver.canFire;
+			observed.currentKey = driver.currentKey;
+			observed.failureNotification = notifyCalls.some((call) => call.message.includes("failed") && call.level === "error");
+			return observed;
+		},
+	},
+	{
+		name: "dispatch respects a stale-context callback by ignoring the call",
+		expected: {
+			outcome: "ignored",
+			compactCalls: 0,
+		},
+		run: async (driver: BudgetGuardDriver) => {
+			const observed: Record<string, unknown> = {};
+			const { compactCalls, compact, notify } = recorder();
+			const result = dispatch(driver, { compact, notify, staleCtx: () => true, trigger: trigger("p:85:1", "r") });
+			observed.outcome = result.kind;
+			observed.compactCalls = compactCalls.length;
+			return observed;
+		},
+	},
+	{
+		name: "reset clears in-flight and key state",
+		expected: {
+			canFireBeforeReset: false,
+			canFireAfterReset: true,
+			currentKey: undefined,
+		},
+		run: async (driver: BudgetGuardDriver) => {
+			const observed: Record<string, unknown> = {};
+			const { compact, notify } = recorder();
+			dispatch(driver, { compact, notify, trigger: trigger("p:85:1", "r") });
+			observed.canFireBeforeReset = driver.canFire;
+			driver.reset();
+			observed.canFireAfterReset = driver.canFire;
+			observed.currentKey = driver.currentKey;
+			return observed;
+		},
+	},
+	{
+		name: "session_compact from an old reset generation cannot satisfy the current trigger",
+		expected: {
+			acceptedOldGeneration: false,
+			outcome: "dispatched",
+			currentKey: "percent:85:b",
+		},
+		run: async (driver: BudgetGuardDriver) => {
+			const observed: Record<string, unknown> = {};
+			const generationA = driver.reset();
+			driver.stage(trigger("percent:85:a", "session A"), undefined, generationA);
+			const generationB = driver.reset();
+			const current = trigger("percent:85:b", "session B");
+			driver.stage(current, undefined, generationB);
+			observed.acceptedOldGeneration = driver.noteSessionCompacted(generationA);
+			const compactCalls: GuardCompactOptions[] = [];
+			const lifecycle = driver.dispatchPending({
+				compact: (options) => compactCalls.push(options),
+				generation: generationB,
+				notify: () => {},
+			});
+			observed.outcome = lifecycle.outcome.kind;
+			observed.currentKey = driver.currentKey;
+			compactCalls[0]?.onComplete?.();
+			await lifecycle.completion;
+			return observed;
+		},
+	},
+	{
+		name: "reset invalidates delayed callbacks without mutating the next dispatch",
+		expected: {
+			completedBeforeCallback: false,
+			keyBeforeCallback: "percent:85:2",
+			canFireBeforeCallback: false,
+			statusBeforeCallback: true,
+			completedAfterOldCallbacks: false,
+			keyAfterOldCallbacks: "percent:85:2",
+			canFireAfterOldCallbacks: false,
+			statusAfterOldCallbacks: true,
+			oldCallbackNotification: false,
+			canFireAfterCompletion: true,
+			keyAfterCompletion: "percent:85:2",
+		},
+		run: async (driver: BudgetGuardDriver) => {
+			const observed: Record<string, unknown> = {};
+			const compactCalls: GuardCompactOptions[] = [];
+			const notifyCalls: NotifyCall[] = [];
+			const statusCalls: Array<string | undefined> = [];
+			const notify = (message: string, level: GuardLevel) => notifyCalls.push({ level, message });
+			const onStatus = (message: string | undefined) => statusCalls.push(message);
+			const first = trigger("percent:85:1", "first dispatch");
+			const second = trigger("percent:85:2", "second dispatch");
+			const firstLifecycle = dispatchLifecycle(driver, {
+				compact: (options) => compactCalls.push(options),
+				notify,
+				onStatus,
+				trigger: first,
+			});
+			driver.reset();
+			await firstLifecycle.completion;
+			const secondLifecycle = dispatchLifecycle(driver, {
+				compact: (options) => compactCalls.push(options),
+				notify,
+				onStatus,
+				trigger: second,
+			});
+			let secondCompleted = false;
+			void secondLifecycle.completion.then(() => { secondCompleted = true; });
+			await Promise.resolve();
+			observed.completedBeforeCallback = secondCompleted;
+			observed.keyBeforeCallback = driver.currentKey;
+			observed.canFireBeforeCallback = driver.canFire;
+			observed.statusBeforeCallback = (statusCalls.at(-1))?.includes("second dispatch");
+		
+			compactCalls[0]?.onComplete?.();
+			compactCalls[0]?.onError?.(new Error("late first error"));
+			await Promise.resolve();
+		
+			observed.completedAfterOldCallbacks = secondCompleted;
+			observed.keyAfterOldCallbacks = driver.currentKey;
+			observed.canFireAfterOldCallbacks = driver.canFire;
+			observed.statusAfterOldCallbacks = (statusCalls.at(-1))?.includes("second dispatch");
+			observed.oldCallbackNotification = notifyCalls.some((call) => call.message.includes("completed") || call.message.includes("late first error"));
+		
+			compactCalls[1]?.onComplete?.();
+			await secondLifecycle.completion;
+			observed.canFireAfterCompletion = driver.canFire;
+			observed.keyAfterCompletion = driver.currentKey;
+			return observed;
+		},
+	},
+];
 
-test("dispatch deduplicates a repeated trigger after completion within the same bucket", async () => {
-	const driver = new BudgetGuardDriver();
-	const { compactCalls, makeCompact, notify } = recorder();
-	const t = trigger("percent:85:1", "reason");
-	dispatch(driver, { compact: makeCompact("success"), notify, trigger: t });
-	await new Promise((resolve) => setTimeout(resolve, 5));
-	expect(driver.canFire).toBe(true);
-	const repeat = dispatch(driver, { compact: makeCompact("success"), notify, trigger: t });
-	expect(repeat.kind).toBe("dedup");
-	expect(compactCalls.length).toBe(1);
-});
+if (lifecycleRows.length === 0) throw new Error("Budget lifecycle table is empty");
 
-test("session_compact satisfies the current crossing key", async () => {
-	const driver = new BudgetGuardDriver();
-	const { compactCalls, makeCompact, notify } = recorder();
-	const t = trigger("percent:85:1", "reason");
-	dispatch(driver, { compact: makeCompact("success"), notify, trigger: t });
-	await new Promise((resolve) => setTimeout(resolve, 5));
-	driver.noteSessionCompacted();
-	expect(driver.currentKey).toBe(t.key);
-	const next = dispatch(driver, { compact: makeCompact("success"), notify, trigger: t });
-	expect(next.kind).toBe("dedup");
-	expect(compactCalls.length).toBe(1);
-});
-
-test("session_compact clears suppression after usage falls below the trigger", async () => {
-	const driver = new BudgetGuardDriver();
-	const { compactCalls, makeCompact, notify } = recorder();
-	const t = trigger("percent:85:1", "reason");
-	dispatch(driver, { compact: makeCompact("success"), notify, trigger: t });
-	await new Promise((resolve) => setTimeout(resolve, 5));
-	driver.noteSessionCompacted();
-	expect(dispatch(driver, { compact: makeCompact("success"), notify, trigger: undefined }).kind).toBe("no-trigger");
-	expect(dispatch(driver, { compact: makeCompact("success"), notify, trigger: t }).kind).toBe("dispatched");
-	expect(compactCalls.length).toBe(2);
-});
-
-test("session_compact allows a genuinely new trigger key", async () => {
-	const driver = new BudgetGuardDriver();
-	const { compactCalls, makeCompact, notify } = recorder();
-	const first = trigger("percent:85:1", "first bucket");
-	const second = trigger("percent:85:2", "second bucket");
-	dispatch(driver, { compact: makeCompact("success"), notify, trigger: first });
-	await new Promise((resolve) => setTimeout(resolve, 5));
-	driver.noteSessionCompacted();
-	expect(dispatch(driver, { compact: makeCompact("success"), notify, trigger: second }).kind).toBe("dispatched");
-	expect(compactCalls.length).toBe(2);
-});
-
-test("Already compacted is benign only after a later session_compact", async () => {
-	const driver = new BudgetGuardDriver();
-	const { compactCalls, notify, notifyCalls, onStatus, statusCalls } = recorder();
-	const t = trigger("percent:85:1", "reason");
-	dispatch(driver, {
-		compact: (options) => compactCalls.push(options),
-		notify,
-		onStatus,
-		trigger: t,
+for (const { name, expected, run } of lifecycleRows) {
+	test(name, async () => {
+		expect.hasAssertions();
+		const driver = new BudgetGuardDriver();
+		try {
+			expect(await run(driver)).toEqual(expected);
+		} finally {
+			driver.reset();
+		}
 	});
-	driver.noteSessionCompacted();
-	compactCalls[0]?.onError?.(new Error("Already compacted"));
-	await new Promise((resolve) => setTimeout(resolve, 0));
-	expect(driver.currentKey).toBe(t.key);
-	expect(driver.canFire).toBe(true);
-	expect(statusCalls.at(-1)).toBeUndefined();
-	expect(notifyCalls.some((call) => call.level === "error")).toBe(false);
-	expect(dispatch(driver, { compact: () => {}, notify, trigger: t }).kind).toBe("dedup");
-});
-
-test("Already compacted remains an error without a later session_compact", async () => {
-	const driver = new BudgetGuardDriver();
-	const { notify, notifyCalls } = recorder();
-	dispatch(driver, {
-		compact: (options) => setTimeout(() => options.onError?.(new Error("Already compacted")), 0),
-		notify,
-		trigger: trigger("percent:85:1", "reason"),
-	});
-	await new Promise((resolve) => setTimeout(resolve, 5));
-	expect(driver.currentKey).toBeUndefined();
-	expect(notifyCalls.some((call) => call.level === "error" && call.message.includes("Already compacted"))).toBe(true);
-});
-
-test("a delayed unrelated error stays visible without clearing a session-satisfied key", () => {
-	const driver = new BudgetGuardDriver();
-	const { compactCalls, notify, notifyCalls } = recorder();
-	const t = trigger("percent:85:1", "reason");
-	dispatch(driver, {
-		compact: (options) => compactCalls.push(options),
-		notify,
-		trigger: t,
-	});
-	driver.noteSessionCompacted();
-	compactCalls[0]?.onError?.(new Error("model down"));
-	expect(notifyCalls.some((call) => call.level === "error" && call.message.includes("model down"))).toBe(true);
-	expect(driver.currentKey).toBe(t.key);
-	expect(dispatch(driver, { compact: () => {}, notify, trigger: t }).kind).toBe("dedup");
-});
-
-test("dispatch fires for a new bucket key after the first crossing", () => {
-	const driver = new BudgetGuardDriver();
-	const { makeCompact, notify } = recorder();
-	const first = dispatch(driver, { compact: makeCompact("swallow"), notify, trigger: trigger("percent:85:1", "1x") });
-	expect(first.kind).toBe("dispatched");
-	// In-flight; subsequent triggers (regardless of key) return in-flight.
-	const second = dispatch(driver, { compact: makeCompact("swallow"), notify, trigger: trigger("percent:85:2", "2x") });
-	expect(second.kind).toBe("in-flight");
-});
-
-test("dispatch with no trigger clears the crossing key", async () => {
-	const driver = new BudgetGuardDriver();
-	const { makeCompact, notify } = recorder();
-	const lifecycle = dispatchLifecycle(driver, { compact: makeCompact("success"), notify, trigger: trigger("percent:85:1", "x") });
-	driver.noteSessionCompacted();
-	await lifecycle.completion;
-	dispatch(driver, { compact: makeCompact("success"), notify, trigger: undefined });
-	expect(driver.currentKey).toBeUndefined();
-});
-
-test("dispatch refuses when ctx.compact is missing and notifies the user", () => {
-	const driver = new BudgetGuardDriver();
-	const { notify, notifyCalls } = recorder();
-	const result = dispatch(driver, { compact: undefined, notify, trigger: trigger("p:85:1", "r") });
-	expect(result.kind).toBe("no-compact-fn");
-	expect(driver.canFire).toBe(true);
-	expect(notifyCalls.some((call) => call.message.includes("ctx.compact is unavailable") && call.level === "warning")).toBe(true);
-});
-
-test("dispatch propagates the sentinel in customInstructions", () => {
-	const driver = new BudgetGuardDriver();
-	const { compactCalls, makeCompact, notify } = recorder();
-	dispatch(driver, { compact: makeCompact("swallow"), notify, trigger: trigger("p:85:1", "r") });
-	expect(compactCalls[0]?.customInstructions ?? "").toContain(QOL_BUDGET_GUARD_SENTINEL);
-});
-
-test("dispatch exposes persistent status until compaction callback finishes", async () => {
-	const driver = new BudgetGuardDriver();
-	const { makeCompact, notify, onStatus, statusCalls } = recorder();
-	dispatch(driver, { compact: makeCompact("success"), notify, onStatus, trigger: trigger("p:85:1", "90% context >= 85% budget guard") });
-	expect(statusCalls[0]).toContain("QOL budget guard compacting session");
-	await new Promise((resolve) => setTimeout(resolve, 5));
-	expect(statusCalls.at(-1)).toBeUndefined();
-});
-
-test("dispatch clears persistent status on async compact failure", async () => {
-	const driver = new BudgetGuardDriver();
-	const { makeCompact, notify, onStatus, statusCalls } = recorder();
-	dispatch(driver, { compact: makeCompact("fail"), notify, onStatus, trigger: trigger("p:85:1", "r") });
-	expect(statusCalls[0]).toContain("QOL budget guard compacting session");
-	await new Promise((resolve) => setTimeout(resolve, 5));
-	expect(statusCalls.at(-1)).toBeUndefined();
-});
-
-test("dispatch clears state and notifies on synchronous compact throw", () => {
-	const driver = new BudgetGuardDriver();
-	const { notify, notifyCalls, onStatus, statusCalls } = recorder();
-	const result = dispatch(driver, { compact: () => { throw new Error("boom"); }, notify, onStatus, trigger: trigger("p:85:1", "r") });
-	expect(result.kind).toBe("dispatch-threw");
-	expect(driver.canFire).toBe(true);
-	// On throw, the crossing key is cleared so the next agent_end can retry.
-	expect(driver.currentKey).toBeUndefined();
-	expect(statusCalls.at(-1)).toBeUndefined();
-	expect(notifyCalls.some((call) => call.message.includes("failed to start") && call.level === "error")).toBe(true);
-});
-
-test("dispatch onError clears the crossing key so the next agent_end retries", async () => {
-	const driver = new BudgetGuardDriver();
-	const { notify, notifyCalls } = recorder();
-	const compact = (options: GuardCompactOptions) => {
-		setTimeout(() => options.onError?.(new Error("model down")), 0);
-	};
-	dispatch(driver, { compact, notify, trigger: trigger("p:85:1", "r") });
-	await new Promise((resolve) => setTimeout(resolve, 5));
-	expect(driver.canFire).toBe(true);
-	expect(driver.currentKey).toBeUndefined();
-	expect(notifyCalls.some((call) => call.message.includes("failed") && call.level === "error")).toBe(true);
-});
-
-test("dispatch respects a stale-context callback by ignoring the call", () => {
-	const driver = new BudgetGuardDriver();
-	const { compactCalls, makeCompact, notify } = recorder();
-	const result = dispatch(driver, { compact: makeCompact("swallow"), notify, staleCtx: () => true, trigger: trigger("p:85:1", "r") });
-	expect(result.kind).toBe("ignored");
-	expect(compactCalls.length).toBe(0);
-});
-
-test("reset clears in-flight and key state", () => {
-	const driver = new BudgetGuardDriver();
-	const { makeCompact, notify } = recorder();
-	dispatch(driver, { compact: makeCompact("swallow"), notify, trigger: trigger("p:85:1", "r") });
-	expect(driver.canFire).toBe(false);
-	driver.reset();
-	expect(driver.canFire).toBe(true);
-	expect(driver.currentKey).toBeUndefined();
-});
-
-test("session_compact from an old reset generation cannot satisfy the current trigger", async () => {
-	const driver = new BudgetGuardDriver();
-	const generationA = driver.reset();
-	driver.stage(trigger("percent:85:a", "session A"), undefined, generationA);
-	const generationB = driver.reset();
-	const current = trigger("percent:85:b", "session B");
-	driver.stage(current, undefined, generationB);
-	expect(driver.noteSessionCompacted(generationA)).toBe(false);
-	const compactCalls: GuardCompactOptions[] = [];
-	const lifecycle = driver.dispatchPending({
-		compact: (options) => compactCalls.push(options),
-		generation: generationB,
-		notify: () => {},
-	});
-	expect(lifecycle.outcome.kind).toBe("dispatched");
-	expect(driver.currentKey).toBe(current.key);
-	compactCalls[0]?.onComplete?.();
-	await lifecycle.completion;
-});
-
-test("reset invalidates delayed callbacks without mutating the next dispatch", async () => {
-	const driver = new BudgetGuardDriver();
-	const compactCalls: GuardCompactOptions[] = [];
-	const notifyCalls: NotifyCall[] = [];
-	const statusCalls: Array<string | undefined> = [];
-	const notify = (message: string, level: GuardLevel) => notifyCalls.push({ level, message });
-	const onStatus = (message: string | undefined) => statusCalls.push(message);
-	const first = trigger("percent:85:1", "first dispatch");
-	const second = trigger("percent:85:2", "second dispatch");
-	const firstLifecycle = dispatchLifecycle(driver, {
-		compact: (options) => compactCalls.push(options),
-		notify,
-		onStatus,
-		trigger: first,
-	});
-	driver.reset();
-	await firstLifecycle.completion;
-	const secondLifecycle = dispatchLifecycle(driver, {
-		compact: (options) => compactCalls.push(options),
-		notify,
-		onStatus,
-		trigger: second,
-	});
-	let secondCompleted = false;
-	void secondLifecycle.completion.then(() => { secondCompleted = true; });
-	await Promise.resolve();
-	expect(secondCompleted).toBe(false);
-	expect(driver.currentKey).toBe(second.key);
-	expect(driver.canFire).toBe(false);
-	expect(statusCalls.at(-1)).toContain("second dispatch");
-
-	compactCalls[0]?.onComplete?.();
-	compactCalls[0]?.onError?.(new Error("late first error"));
-	await Promise.resolve();
-
-	expect(secondCompleted).toBe(false);
-	expect(driver.currentKey).toBe(second.key);
-	expect(driver.canFire).toBe(false);
-	expect(statusCalls.at(-1)).toContain("second dispatch");
-	expect(notifyCalls.some((call) => call.message.includes("completed") || call.message.includes("late first error"))).toBe(false);
-
-	compactCalls[1]?.onComplete?.();
-	await secondLifecycle.completion;
-	expect(driver.canFire).toBe(true);
-	expect(driver.currentKey).toBe(second.key);
-});
+}


### PR DESCRIPTION
The budget-driver tests now call saved compaction callbacks and await the driver's completion promises. Wall-time waits no longer determine callback completion.

- Preserve the former 64 observations in 20 named lifecycle rows, including intermediate status, deduplication, session reset and delayed callback results.
- Reject an empty table and a row with no assertion. Compare generated observation records strictly so omitted undefined captures also fail. Reset each row's driver during cleanup.
- Change only the budget-driver test. This Pi test has no tracked render and is excluded from the published package.

Part of KEN-1241. The remaining audit stays open.

## Validation

- Focused suite: 20 rows pass. Pi QoL package: 115 tests pass, including after the strict observation correction. The saved initial specialist round and root source/map/control proof remain recorded; the narrow correction has separate omission controls.
- Compiling copied controls fail for lost deduplication, unresolved completion, old completion/error callbacks, old session generation, empty table, absent assertion, inactive row and an omitted currentKey observation. The omitted observation passes the former comparison and fails the strict comparison.
- Preflight, document limits, Pi package policy and commit hooks pass.
- Repository validation at c603ef4 used the preserved full-guard lanes and an isolated Rust workspace rerun. The original Cargo invocation stopped at the unchanged CLI outside-project test because the launcher inherited a temporary root below the real home directory. The identical compiled test reproduces that environment failure. `cargo test --workspace --quiet` then passed with `TMPDIR=/var/tmp/ken-c` and cleared Git redirects. Formatting, documentation, lint and UI lanes remain preserved, including 1286 passing UI tests. The subsequent assertion-only correction reran the affected Pi QoL package and required commit checks. Original failure and recovery receipts remain separate.

## Size

The branch adds 0 production lines, 470 test lines and 0 render-mirror lines. KEN-1241 states no line allowance.
