### PR TITLE
test(KEN-1241): table background task finalization

### DIFF
--- a/pi-extensions/pi-background-tasks/tests/finalize-lifecycle.test.ts
+++ b/pi-extensions/pi-background-tasks/tests/finalize-lifecycle.test.ts
@@ -1,289 +1,78 @@
-// E2E coverage of the real finalizeTask / replayMissedExits code paths
-// using the extracted lifecycle helpers. Drives the exact same functions
-// the extension uses; only the I/O surfaces (sendTaskEvent, persist,
-// rememberSnapshot, refreshUi, clearTaskTimers) are stubbed so the test
-// runs without a Pi runtime.
+import { expect, test } from "bun:test";
+import { finalizeTaskLifecycle } from "../extensions/lifecycle.js";
+import type { BackgroundTaskStatus, BackgroundTaskTerminationReason, ManagedTask } from "../extensions/types.js";
+import { fakeTask, recordingHooks } from "./fixtures/lifecycle.js";
 
-import { describe, expect, test } from "bun:test";
-import { finalizeTaskLifecycle, replayMissedExitsLifecycle, type LifecycleHooks } from "../extensions/lifecycle.js";
-import { restoredTaskFromSnapshot, selectMissedExits } from "../extensions/snapshot.js";
-import type { BackgroundTaskSnapshot, ManagedTask, ProcessIdentity, TaskEventType } from "../extensions/types.js";
-
-function fakeIdent(pid: number): ProcessIdentity {
-	return { pid, startToken: `start-${pid}`, comm: "approval-wait" };
-}
-const probeDead = () => null;
-const probeAlive = (pid: number) => fakeIdent(pid);
-
-function fakeSnapshot(overrides: Partial<BackgroundTaskSnapshot> = {}): BackgroundTaskSnapshot {
-	return {
-		command: "approval-wait 81",
-		cwd: "/tmp/worktree",
-		exitCode: null,
-		exitNotified: false,
-		expiresAt: null,
-		id: "bg-3",
-		lastOutputAt: null,
-		logFile: "/tmp/log.txt",
-		notifyOnExit: true,
-		notifyOnOutput: false,
-		notifyPattern: undefined,
-		outputBytes: 0,
-		pid: 2409160,
-		sessionId: "sess-1",
-		startedAt: 1_700_000_000_000,
-		status: "running",
-		title: "bot review wait PR 81",
-		updatedAt: 1_700_000_000_000,
-		...overrides,
+interface FinalizeRow {
+	name: string;
+	task?: Partial<ManagedTask>;
+	exitCode: number | null;
+	statusOverride?: BackgroundTaskStatus;
+	reasonOverride?: BackgroundTaskTerminationReason;
+	sendReturns?: boolean;
+	secondClose?: boolean;
+	expected: {
+		status: BackgroundTaskStatus;
+		reason: BackgroundTaskTerminationReason;
+		exitNotified?: boolean;
+		persists?: number;
+		output?: string;
+		outputBytes?: number;
 	};
 }
 
-function fakeTask(overrides: Partial<ManagedTask> = {}): ManagedTask {
-	const snapshot = fakeSnapshot(overrides);
-	return {
-		...snapshot,
-		child: null,
-		closed: false,
-		forceKillTimer: null,
-		lastAnnouncedLength: 0,
-		matcher: null,
-		output: "",
-		outputTimer: null,
-		stopReason: null,
-		timeoutTimer: null,
-		...overrides,
-	};
-}
+const partialOutput = "Warning: GH_TOKEN/GITHUB_TOKEN failed gh auth; unsetting them and using gh keyring auth.\n";
+const rows: FinalizeRow[] = [
+	{ name: "clean self-exit", exitCode: 0, expected: { status: "completed", reason: "self-exit" } },
+	{ name: "null exit code is external", exitCode: null, expected: { status: "failed", reason: "external" } },
+	{ name: "nonzero self-exit", exitCode: 1, expected: { status: "failed", reason: "self-exit" } },
+	{ name: "user stop derives extension-stop", task: { stopReason: "user" }, exitCode: null, expected: { status: "stopped", reason: "extension-stop" } },
+	{ name: "timeout stop derives timeout", task: { stopReason: "timeout" }, exitCode: null, expected: { status: "timed_out", reason: "timeout" } },
+	{ name: "status override wins over user stop and successful exit", task: { stopReason: "user" }, exitCode: 0, statusOverride: "failed", expected: { status: "failed", reason: "extension-stop" } },
+	{ name: "sender false retains pending exit notification", exitCode: 0, sendReturns: false, expected: { status: "completed", reason: "self-exit", exitNotified: false, persists: 1 } },
+	// The sender result is injected; this row does not test the host sender's setting gate.
+	{ name: "sender false with notifyOnExit disabled", task: { notifyOnExit: false }, exitCode: 0, sendReturns: false, expected: { status: "completed", reason: "self-exit", exitNotified: false, persists: 1 } },
+	{ name: "second close leaves task and every hook unchanged", exitCode: 0, secondClose: true, expected: { status: "completed", reason: "self-exit" } },
+	{ name: "partial output survives external termination", task: { output: partialOutput, outputBytes: 89 }, exitCode: null, expected: { status: "failed", reason: "external", output: partialOutput, outputBytes: 89 } },
+	{ name: "zero output still sends an exit", task: { output: "", outputBytes: 0 }, exitCode: 0, expected: { status: "completed", reason: "self-exit", output: "", outputBytes: 0 } },
+	{ name: "pre-stamped extension-stop survives finalize", task: { stopReason: "user", terminationReason: "extension-stop" }, exitCode: null, expected: { status: "stopped", reason: "extension-stop" } },
+	{ name: "shutdown stop derives session-shutdown", task: { stopReason: "shutdown" }, exitCode: null, expected: { status: "stopped", reason: "session-shutdown" } },
+	{ name: "explicit reason wins over pre-stamped and derived reason", task: { stopReason: "user", terminationReason: "extension-stop" }, exitCode: null, reasonOverride: "orphaned-pid-reused", expected: { status: "stopped", reason: "orphaned-pid-reused" } },
+	{ name: "pre-stamped reason wins over a different derivation", task: { terminationReason: "extension-stop" }, exitCode: 0, expected: { status: "completed", reason: "extension-stop" } },
+];
 
-interface RecordedHooks {
-	events: { type: TaskEventType; task: ManagedTask }[];
-	persists: number;
-	remembers: number;
-	refreshes: number;
-	timerClears: number;
-}
-
-function recordingHooks(sendReturns: boolean = true): LifecycleHooks & { record: RecordedHooks } {
-	const record: RecordedHooks = { events: [], persists: 0, remembers: 0, refreshes: 0, timerClears: 0 };
-	const hooks: LifecycleHooks = {
-		rememberSnapshot(task) {
-			record.remembers += 1;
-			return { ...task };
-		},
-		persistSnapshots() {
-			record.persists += 1;
-			return { appendEntry: true, sidecar: true };
-		},
-		sendTaskEvent(type, task) {
-			record.events.push({ type, task });
-			return sendReturns;
-		},
-		refreshUi() {
-			record.refreshes += 1;
-		},
-		clearTaskTimers() {
-			record.timerClears += 1;
-		},
-	};
-	return Object.assign(hooks, { record });
-}
-
-describe("finalizeTaskLifecycle", () => {
-	test("normal exit (code 0) -> status=completed + exitNotified=true", () => {
-		const hooks = recordingHooks();
-		const task = fakeTask();
-		const result = finalizeTaskLifecycle(task, 0, hooks);
-		expect(result.status).toBe("completed");
-		expect(result.exitCode).toBe(0);
-		expect(result.exitNotified).toBe(true);
-		expect(result.closed).toBe(true);
-		expect(hooks.record.events).toHaveLength(1);
-		expect(hooks.record.events[0]?.type).toBe("exit");
-		expect(hooks.record.timerClears).toBe(1);
-		// Two persist calls: once after status mutation, once after
-		// exitNotified flip. Each persist follows a remember.
-		expect(hooks.record.persists).toBe(2);
-	});
-
-	test("abnormal exit (code null, no stopReason) -> status=failed", () => {
-		const hooks = recordingHooks();
-		const task = fakeTask();
-		const result = finalizeTaskLifecycle(task, null, hooks);
-		expect(result.status).toBe("failed");
-		expect(result.exitCode).toBeNull();
-		expect(result.exitNotified).toBe(true);
-	});
-
-	test("exit (code 1) -> status=failed", () => {
-		const hooks = recordingHooks();
-		const task = fakeTask();
-		const result = finalizeTaskLifecycle(task, 1, hooks);
-		expect(result.status).toBe("failed");
-		expect(result.exitCode).toBe(1);
-	});
-
-	test("stopReason=user -> status=stopped, exitNotified=true", () => {
-		const hooks = recordingHooks();
-		const task = fakeTask({ stopReason: "user" });
-		const result = finalizeTaskLifecycle(task, null, hooks);
-		expect(result.status).toBe("stopped");
-		expect(result.exitNotified).toBe(true);
-	});
-
-	test("stopReason=timeout -> status=timed_out", () => {
-		const hooks = recordingHooks();
-		const task = fakeTask({ stopReason: "timeout" });
-		const result = finalizeTaskLifecycle(task, null, hooks);
-		expect(result.status).toBe("timed_out");
-	});
-
-	test("statusOverride wins over stopReason and exitCode", () => {
-		const hooks = recordingHooks();
-		const task = fakeTask({ stopReason: "user" });
-		const result = finalizeTaskLifecycle(task, 0, hooks, "failed");
-		expect(result.status).toBe("failed");
-	});
-
-	test("sendTaskEvent failure (shuttingDown) leaves exitNotified=false for replay", () => {
-		const hooks = recordingHooks(false);
-		const task = fakeTask();
-		const result = finalizeTaskLifecycle(task, 0, hooks);
-		expect(result.status).toBe("completed");
-		expect(result.exitNotified).toBe(false);
-		// Persist still fires once for status mutation; the second persist
-		// (after notify) is skipped because no flip happened.
-		expect(hooks.record.persists).toBe(1);
-		expect(hooks.record.events).toHaveLength(1);
-	});
-
-	test("notifyOnExit=false records the call but leaves exitNotified=false", () => {
-		// sendTaskEvent returning false simulates the shuttingDown /
-		// !notifyOnExit early-return in the real implementation.
-		const hooks = recordingHooks(false);
-		const task = fakeTask({ notifyOnExit: false });
-		const result = finalizeTaskLifecycle(task, 0, hooks);
-		expect(result.exitNotified).toBe(false);
-	});
-
-	test("second close is a no-op (idempotent)", () => {
-		const hooks = recordingHooks();
-		const task = fakeTask();
-		finalizeTaskLifecycle(task, 0, hooks);
-		const before = { ...hooks.record };
-		finalizeTaskLifecycle(task, 99, hooks);
-		// No further events, persistence, memory writes, or refreshes after close.
-		expect(hooks.record.events.length).toBe(before.events.length);
-		expect(hooks.record.persists).toBe(before.persists);
-		expect(task.exitCode).toBe(0);
-	});
-
-	test("partial output is preserved through finalize", () => {
-		// Finalize must retain partial output so the dashboard and log inspection
-		// can show it even when no exit event arrives.
-		const hooks = recordingHooks();
-		const task = fakeTask({
-			outputBytes: 89,
-			output: "Warning: GH_TOKEN/GITHUB_TOKEN failed gh auth; unsetting them and using gh keyring auth.\n",
+test("finalize lifecycle outcomes", () => {
+	expect.assertions(rows.length + 1);
+	expect(rows.length, "finalize table must contain rows").toBeGreaterThan(0);
+	for (const row of rows) {
+		const task = fakeTask(row.task);
+		const recorder = recordingHooks(row.sendReturns);
+		const result = finalizeTaskLifecycle(task, row.exitCode, recorder.hooks, row.statusOverride, row.reasonOverride);
+		const observe = () => ({
+			sameTask: result === task, status: task.status, exitCode: task.exitCode,
+			exitNotified: task.exitNotified, closed: task.closed, reason: task.terminationReason,
+			output: task.output, outputBytes: task.outputBytes, hooks: recorder.observe([task]),
 		});
-		const result = finalizeTaskLifecycle(task, null, hooks);
-		expect(result.output.length).toBeGreaterThan(0);
-		expect(result.outputBytes).toBe(89);
-		expect(result.exitNotified).toBe(true);
-	});
-
-	test("zero output is fine (no spurious wake skip)", () => {
-		const hooks = recordingHooks();
-		const task = fakeTask({ outputBytes: 0, output: "" });
-		const result = finalizeTaskLifecycle(task, 0, hooks);
-		expect(result.exitNotified).toBe(true);
-	});
-});
-
-describe("replayMissedExitsLifecycle", () => {
-	test("replays only terminal tasks with exitNotified=false", () => {
-		const hooks = recordingHooks();
-		const tasks: ManagedTask[] = [
-			fakeTask({ id: "bg-1", status: "running" }),
-			fakeTask({ id: "bg-2", status: "stopped", exitNotified: false, notifyOnExit: true }),
-			fakeTask({ id: "bg-3", status: "completed", exitNotified: true, exitCode: 0 }),
-			fakeTask({ id: "bg-4", status: "failed", exitNotified: false, exitCode: 1, notifyOnExit: false }),
-		];
-		const replayed = replayMissedExitsLifecycle(tasks, hooks);
-		expect(replayed).toBe(1);
-		expect(hooks.record.events[0]?.task.id).toBe("bg-2");
-		expect(tasks.find((t) => t.id === "bg-2")?.exitNotified).toBe(true);
-	});
-
-	test("sendTaskEvent failure does not flip exitNotified", () => {
-		const hooks = recordingHooks(false);
-		const tasks: ManagedTask[] = [
-			fakeTask({ id: "bg-2", status: "stopped", exitNotified: false }),
-		];
-		const replayed = replayMissedExitsLifecycle(tasks, hooks);
-		expect(replayed).toBe(0);
-		expect(tasks[0]?.exitNotified).toBe(false);
-	});
-
-	test("zero missed exits -> no persist call", () => {
-		const hooks = recordingHooks();
-		const tasks: ManagedTask[] = [fakeTask({ status: "running" })];
-		replayMissedExitsLifecycle(tasks, hooks);
-		expect(hooks.record.persists).toBe(0);
-	});
-});
-
-describe("session_start E2E (restore + replay)", () => {
-	test("CC-503-style restore: persisted running snapshot triggers exit wake", () => {
-		const hooks = recordingHooks();
-		const persisted = fakeSnapshot({
-			id: "bg-3",
-			status: "running",
-			exitCode: null,
-			outputBytes: 89,
-			exitNotified: false,
-			notifyOnExit: true,
-			procIdent: fakeIdent(2409160),
+		const first = observe();
+		const expected = {
+			sameTask: true, status: row.expected.status, exitCode: row.exitCode,
+			exitNotified: row.expected.exitNotified ?? true, closed: true, reason: row.expected.reason,
+			output: row.expected.output ?? "", outputBytes: row.expected.outputBytes ?? 0,
+			hooks: {
+				events: [{ type: "exit", id: "bg-3", reason: row.expected.reason, sameTask: true }],
+				persists: row.expected.persists ?? 2, remembers: row.expected.persists ?? 2,
+				refreshes: 1, timerClears: 1,
+			},
+		};
+		let second;
+		if (row.secondClose) {
+			const taskBefore = { ...task };
+			const secondResult = finalizeTaskLifecycle(task, 99, recorder.hooks);
+			second = { before: first, after: observe(), taskBefore, taskAfter: { ...task }, sameTask: secondResult === task };
+		}
+		expect({ first, second }, row.name).toStrictEqual({
+			first: expected,
+			second: row.secondClose ? { before: expected, after: expected, taskBefore: second?.taskBefore, taskAfter: second?.taskBefore, sameTask: true } : undefined,
 		});
-		const restored = restoredTaskFromSnapshot(persisted, { identityProbe: probeDead, sessionId: "sess-1" });
-		expect(restored.status).toBe("stopped");
-		expect(restored.exitNotified).toBe(false);
-		const replayed = replayMissedExitsLifecycle([restored], hooks);
-		expect(replayed).toBe(1);
-		expect(hooks.record.events).toHaveLength(1);
-		expect(hooks.record.events[0]?.type).toBe("exit");
-		expect(hooks.record.events[0]?.task.id).toBe("bg-3");
-		expect(restored.exitNotified).toBe(true);
-	});
-
-	test("orphan-running restore: pid alive + identity match -> no fake exit", () => {
-		const hooks = recordingHooks();
-		const persisted = fakeSnapshot({
-			id: "bg-3",
-			status: "running",
-			pid: 4242,
-			notifyOnExit: true,
-			procIdent: fakeIdent(4242),
-		});
-		const restored = restoredTaskFromSnapshot(persisted, { identityProbe: probeAlive, sessionId: "sess-1" });
-		expect(restored.status).toBe("running");
-		expect(restored.closed).toBe(false);
-		const replayed = replayMissedExitsLifecycle([restored], hooks);
-		expect(replayed).toBe(0);
-		expect(hooks.record.events).toHaveLength(0);
-	});
-
-	test("cross-session restore: snapshot from different sessionId does not replay", () => {
-		const hooks = recordingHooks();
-		const persisted = fakeSnapshot({
-			id: "bg-other",
-			status: "running",
-			exitNotified: false,
-			notifyOnExit: true,
-			sessionId: "sess-OTHER",
-		});
-		const restored = restoredTaskFromSnapshot(persisted, { identityProbe: probeDead, sessionId: "sess-1" });
-		expect(restored.exitNotified).toBe(true);
-		expect(replayMissedExitsLifecycle([restored], hooks)).toBe(0);
-	});
+	}
 });

--- a/pi-extensions/pi-background-tasks/tests/fixtures/lifecycle.ts
+++ b/pi-extensions/pi-background-tasks/tests/fixtures/lifecycle.ts
@@ -1,0 +1,55 @@
+import type { LifecycleHooks } from "../../extensions/lifecycle.js";
+import type { BackgroundTaskSnapshot, ManagedTask, ProcessIdentity, TaskEventType } from "../../extensions/types.js";
+
+export function fakeIdent(pid: number): ProcessIdentity {
+	return { pid, startToken: `start-${pid}`, comm: "approval-wait" };
+}
+
+export function fakeSnapshot(overrides: Partial<BackgroundTaskSnapshot> = {}): BackgroundTaskSnapshot {
+	return {
+		command: "approval-wait 81", cwd: "/private/worktree", exitCode: null,
+		exitNotified: false, expiresAt: null, id: "bg-3", lastOutputAt: null,
+		logFile: "/private/log.txt", notifyOnExit: true, notifyOnOutput: false,
+		notifyPattern: undefined, outputBytes: 0, pid: 2409160, sessionId: "sess-1",
+		startedAt: 1_700_000_000_000, status: "running", title: "bot review wait PR 81",
+		updatedAt: 1_700_000_000_000, ...overrides,
+	};
+}
+
+export function fakeTask(overrides: Partial<ManagedTask> = {}): ManagedTask {
+	return {
+		...fakeSnapshot(overrides), child: null, closed: false, forceKillTimer: null,
+		lastAnnouncedLength: 0, matcher: null, output: "", outputTimer: null,
+		stopReason: null, timeoutTimer: null, ...overrides,
+	};
+}
+
+// Hooks replace host effects only. Event fields are copied when the sender runs.
+export function recordingHooks(sendReturns = true) {
+	const events: { type: TaskEventType; task: ManagedTask; id: string; reason: ManagedTask["terminationReason"] }[] = [];
+	let persists = 0;
+	let remembers = 0;
+	let refreshes = 0;
+	let timerClears = 0;
+	const hooks: LifecycleHooks = {
+		rememberSnapshot(task) { remembers++; return { ...task }; },
+		persistSnapshots() { persists++; return { appendEntry: true, sidecar: true }; },
+		sendTaskEvent(type, task) {
+			events.push({ type, task, id: task.id, reason: task.terminationReason });
+			return sendReturns;
+		},
+		refreshUi() { refreshes++; },
+		clearTaskTimers() { timerClears++; },
+	};
+	return {
+		hooks,
+		observe(tasks: readonly ManagedTask[]) {
+			return {
+				events: events.map(({ type, task, id, reason }) => ({
+					type, id, reason, sameTask: tasks.find((candidate) => candidate.id === id) === task,
+				})),
+				persists, remembers, refreshes, timerClears,
+			};
+		},
+	};
+}

--- a/pi-extensions/pi-background-tasks/tests/replay-missed-exits.test.ts
+++ b/pi-extensions/pi-background-tasks/tests/replay-missed-exits.test.ts
@@ -1,0 +1,53 @@
+import { expect, test } from "bun:test";
+import { replayMissedExitsLifecycle } from "../extensions/lifecycle.js";
+import type { ManagedTask } from "../extensions/types.js";
+import { fakeTask, recordingHooks } from "./fixtures/lifecycle.js";
+
+interface ReplayRow {
+	name: string;
+	tasks: Partial<ManagedTask>[];
+	sendReturns?: boolean;
+	expected: { replayed: number; eventIds: string[]; notified: boolean[]; persists: number; remembers: number };
+}
+
+const rows: ReplayRow[] = [
+	{
+		name: "mixed tasks replay only the pending enabled terminal exit",
+		tasks: [
+			{ id: "bg-1", status: "running" },
+			{ id: "bg-2", status: "stopped", exitNotified: false, notifyOnExit: true },
+			{ id: "bg-3", status: "completed", exitNotified: true, exitCode: 0 },
+			{ id: "bg-4", status: "failed", exitNotified: false, exitCode: 1, notifyOnExit: false },
+		],
+		expected: { replayed: 1, eventIds: ["bg-2"], notified: [false, true, true, false], persists: 1, remembers: 1 },
+	},
+	{ name: "running task causes no event or persistence", tasks: [{ status: "running" }], expected: { replayed: 0, eventIds: [], notified: [false], persists: 0, remembers: 0 } },
+	{ name: "already notified terminal task is excluded", tasks: [{ status: "completed", exitNotified: true, exitCode: 0 }], expected: { replayed: 0, eventIds: [], notified: [true], persists: 0, remembers: 0 } },
+	{ name: "disabled terminal notification is excluded", tasks: [{ status: "failed", notifyOnExit: false, exitCode: 1 }], expected: { replayed: 0, eventIds: [], notified: [false], persists: 0, remembers: 0 } },
+	{ name: "pending stopped exit is replayed", tasks: [{ status: "stopped" }], expected: { replayed: 1, eventIds: ["bg-3"], notified: [true], persists: 1, remembers: 1 } },
+	{ name: "sender false leaves notification pending", tasks: [{ id: "bg-2", status: "stopped", exitNotified: false }], sendReturns: false, expected: { replayed: 0, eventIds: ["bg-2"], notified: [false], persists: 0, remembers: 0 } },
+	{ name: "empty task collection causes no effects", tasks: [], expected: { replayed: 0, eventIds: [], notified: [], persists: 0, remembers: 0 } },
+	{
+		name: "multiple successful replays persist once",
+		tasks: [{ id: "bg-1", status: "completed", exitCode: 0 }, { id: "bg-2", status: "failed", exitCode: 1 }],
+		expected: { replayed: 2, eventIds: ["bg-1", "bg-2"], notified: [true, true], persists: 1, remembers: 2 },
+	},
+];
+
+test("missed exit replay outcomes", () => {
+	expect.assertions(rows.length + 1);
+	expect(rows.length, "replay table must contain rows").toBeGreaterThan(0);
+	for (const row of rows) {
+		const tasks = row.tasks.map((task) => fakeTask(task));
+		const recorder = recordingHooks(row.sendReturns);
+		const replayed = replayMissedExitsLifecycle(tasks, recorder.hooks);
+		expect({ replayed, notified: tasks.map((task) => task.exitNotified), hooks: recorder.observe(tasks) }, row.name).toStrictEqual({
+			replayed: row.expected.replayed,
+			notified: row.expected.notified,
+			hooks: {
+				events: row.expected.eventIds.map((id) => ({ type: "exit", id, reason: undefined, sameTask: true })),
+				persists: row.expected.persists, remembers: row.expected.remembers, refreshes: 0, timerClears: 0,
+			},
+		});
+	}
+});

--- a/pi-extensions/pi-background-tasks/tests/restore-replay.test.ts
+++ b/pi-extensions/pi-background-tasks/tests/restore-replay.test.ts
@@ -1,0 +1,63 @@
+import { expect, test } from "bun:test";
+import { replayMissedExitsLifecycle } from "../extensions/lifecycle.js";
+import { restoredTaskFromSnapshot } from "../extensions/snapshot.js";
+import type { BackgroundTaskSnapshot, BackgroundTaskStatus, BackgroundTaskTerminationReason, ProcessIdentity } from "../extensions/types.js";
+import { fakeIdent, fakeSnapshot, recordingHooks } from "./fixtures/lifecycle.js";
+
+interface RestoreReplayRow {
+	name: string;
+	snapshot: Partial<BackgroundTaskSnapshot>;
+	identity: ProcessIdentity | null;
+	expected: {
+		status: BackgroundTaskStatus;
+		closed: boolean;
+		beforeNotified: boolean;
+		afterNotified: boolean;
+		reason: BackgroundTaskTerminationReason | undefined;
+		replayed: number;
+		eventIds: string[];
+	};
+}
+
+const rows: RestoreReplayRow[] = [
+	{
+		name: "dead same-session running snapshot is stopped before exit replay",
+		snapshot: { id: "bg-3", status: "running", exitCode: null, outputBytes: 89, exitNotified: false, notifyOnExit: true, procIdent: fakeIdent(2409160) },
+		identity: null,
+		expected: { status: "stopped", closed: true, beforeNotified: false, afterNotified: true, reason: "reconcile-on-restart", replayed: 1, eventIds: ["bg-3"] },
+	},
+	{
+		name: "matching live identity remains running without an exit replay",
+		snapshot: { id: "bg-3", status: "running", pid: 4242, notifyOnExit: true, procIdent: fakeIdent(4242) },
+		identity: fakeIdent(4242),
+		expected: { status: "running", closed: false, beforeNotified: false, afterNotified: false, reason: undefined, replayed: 0, eventIds: [] },
+	},
+	{
+		name: "foreign-session snapshot is ineligible before replay",
+		snapshot: { id: "bg-other", status: "running", exitNotified: false, notifyOnExit: true, sessionId: "sess-OTHER" },
+		identity: null,
+		expected: { status: "stopped", closed: true, beforeNotified: true, afterNotified: true, reason: "reconcile-on-restart", replayed: 0, eventIds: [] },
+	},
+];
+
+test("restore followed by missed exit replay", () => {
+	expect.assertions(rows.length + 1);
+	expect(rows.length, "restore-replay table must contain rows").toBeGreaterThan(0);
+	for (const row of rows) {
+		const recorder = recordingHooks();
+		const restored = restoredTaskFromSnapshot(fakeSnapshot(row.snapshot), {
+			identityProbe: () => row.identity, sessionId: "sess-1", now: 1_700_000_100_000,
+		});
+		// Capture the restore result before replay can change exitNotified.
+		const before = { status: restored.status, closed: restored.closed, exitNotified: restored.exitNotified };
+		const replayed = replayMissedExitsLifecycle([restored], recorder.hooks);
+		expect({ before, replayed, afterNotified: restored.exitNotified, hooks: recorder.observe([restored]) }, row.name).toStrictEqual({
+			before: { status: row.expected.status, closed: row.expected.closed, exitNotified: row.expected.beforeNotified },
+			replayed: row.expected.replayed, afterNotified: row.expected.afterNotified,
+			hooks: {
+				events: row.expected.eventIds.map((id) => ({ type: "exit", id, reason: row.expected.reason, sameTask: true })),
+				persists: row.expected.replayed, remembers: row.expected.replayed, refreshes: 0, timerClears: 0,
+			},
+		});
+	}
+});

--- a/pi-extensions/pi-background-tasks/tests/termination-reason.test.ts
+++ b/pi-extensions/pi-background-tasks/tests/termination-reason.test.ts
@@ -5,13 +5,12 @@
 
 import { describe, expect, test } from "bun:test";
 
-import { finalizeTaskLifecycle, type LifecycleHooks } from "../extensions/lifecycle.js";
+import type { LifecycleHooks } from "../extensions/lifecycle.js";
 import { createOrphanWatcher } from "../extensions/orphan-watcher.js";
 import { summarizeTaskStatus } from "../extensions/format.js";
 import { restoredTaskFromSnapshot, taskSnapshot } from "../extensions/snapshot.js";
 import type {
 	BackgroundTaskSnapshot,
-	BackgroundTaskTerminationReason,
 	ManagedTask,
 	ProcessIdentity,
 } from "../extensions/types.js";
@@ -71,70 +70,6 @@ function recordingHooks(): LifecycleHooks & { events: Array<{ type: string; reas
 		events,
 	};
 }
-
-describe("terminationReason annotation (kendex#97)", () => {
-	test("clean self-exit (exitCode 0, no stopReason) stamps self-exit", () => {
-		const task = fakeTask();
-		const hooks = recordingHooks();
-		finalizeTaskLifecycle(task, 0, hooks);
-		expect(task.status).toBe("completed");
-		expect(task.terminationReason).toBe("self-exit");
-		expect(hooks.events[0]?.reason).toBe("self-exit");
-	});
-
-	test("non-zero exit with no stopReason stamps self-exit (failed)", () => {
-		const task = fakeTask();
-		const hooks = recordingHooks();
-		finalizeTaskLifecycle(task, 1, hooks);
-		expect(task.status).toBe("failed");
-		expect(task.terminationReason).toBe("self-exit");
-	});
-
-	test("null exit code with no stopReason stamps external (signal we did not issue)", () => {
-		const task = fakeTask();
-		const hooks = recordingHooks();
-		finalizeTaskLifecycle(task, null, hooks);
-		expect(task.status).toBe("failed");
-		expect(task.terminationReason).toBe("external");
-	});
-
-	test("pre-stamped extension-stop survives the finalize", () => {
-		const task = fakeTask({ stopReason: "user", terminationReason: "extension-stop" });
-		const hooks = recordingHooks();
-		finalizeTaskLifecycle(task, null, hooks);
-		expect(task.status).toBe("stopped");
-		expect(task.terminationReason).toBe("extension-stop");
-	});
-
-	test("session-shutdown stopReason derives session-shutdown", () => {
-		const task = fakeTask({ stopReason: "shutdown" });
-		const hooks = recordingHooks();
-		finalizeTaskLifecycle(task, null, hooks);
-		expect(task.status).toBe("stopped");
-		expect(task.terminationReason).toBe("session-shutdown");
-	});
-
-	test("timeout stopReason derives timeout (status timed_out)", () => {
-		const task = fakeTask({ stopReason: "timeout" });
-		const hooks = recordingHooks();
-		finalizeTaskLifecycle(task, null, hooks);
-		expect(task.status).toBe("timed_out");
-		expect(task.terminationReason).toBe("timeout");
-	});
-
-	test("explicit terminationReason argument wins over the derivation", () => {
-		const task = fakeTask({ stopReason: "user", terminationReason: "extension-stop" });
-		const hooks = recordingHooks();
-		finalizeTaskLifecycle(
-			task,
-			null,
-			hooks,
-			undefined,
-			"orphaned-pid-reused" as BackgroundTaskTerminationReason,
-		);
-		expect(task.terminationReason).toBe("orphaned-pid-reused");
-	});
-});
 
 describe("restoredTaskFromSnapshot annotation (kendex#97)", () => {
 	test("running -> stopped coercion annotates reconcile-on-restart", () => {


### PR DESCRIPTION
The background-task lifecycle tests now detect extra effects after a task closes and require the original output text to survive completion. The previous event-count comparison shared its saved event array with the recorder, so another event could remain undetected.

- Split finalize, missed-exit replay, and restore followed by replay into named tables. Each former comparison maps to a surviving row in the audit assertion map.
- Preserve restore status and notification state before replay changes the task. Preserve event identity, persistence counts, zero-output notification, cross-session refusal, and reason precedence.
- Compare generated observations exactly, including keys whose values are undefined. Keep raw optional termination-reason semantics unchanged. The second-close row compares the same task's exact prior state.
- Reject empty tables and removed row assertions. The injected false sender tests caller handling, not the production notification-setting gate.
- Introduce the neutral lifecycle fixture. Later suites inherit it after this change lands. Move only the finalize-specific termination-reason group here; snapshot, log-format, and orphan-watcher groups move in later parts of the series.

Part of KEN-1241. The audit remains open. Production code is unchanged.

## Validation

- Current focused tests and compilation pass: 13 tests and 49 assertions.
- All 34 original controls compile and fail at their intended diagnostics. Clean and restored runs pass. The 2 previously completed empty/no-op controls were reused.
- Both supplementary omission controls compile, pass with the previous loose comparator, and fail with exact comparison. Exact-comparator clean and restored runs pass. The original proof and its source checkpoint remain separate from this supplement.
- Required validation is complete on the unchanged reviewed source. The original full guard passed every lane except Cargo workspace tests. Its unchanged login-shell app test returned `Silent` instead of `Printed`; the cause remains unknown. One isolated current-head run passed, followed by the granted `cargo test --workspace --quiet` remainder passing at this head. The original failed result is preserved; the other passed lanes were reused.
- The single reviewer-test round passed on a273048e8fc70d711e75af2d94bae93d655a7e34 with no findings. The saved artifact reuses the completed controls. The single bot pass submitted a formal review on that same head with no findings or unresolved threads.

## Size

- Added lines: 0 production, 244 test, 0 render mirror. KEN-1241 states no size allowance.
