### PR TITLE
test(KEN-1241): label-taxonomy control softens the category

### DIFF
--- a/tools/tests/label-taxonomy.test.sh
+++ b/tools/tests/label-taxonomy.test.sh
@@ -95,16 +95,47 @@ else
     "$(diff <(printf '%s\n' "$declared") <(printf '%s\n' "$rendered") | head -20 | tr '\n' ' ')"
 fi
 
-# Must-fail: the same document without the surface category — this
-# repository's state before KEN-1057, and the exact regression the control
-# exists to catch. The predicate must reject it.
-without_surface="$(printf '%s' "$declared" |
-  jq 'del(.categories.surface) | .required_categories_for_new_issues -= ["surface"]')"
-if printf '%s' "$without_surface" | jq -e --argjson surfaces "$SURFACES" "$predicate" >/dev/null; then
-  bad "a taxonomy with no surface category is rejected" "the predicate accepted it"
-else
-  ok "a taxonomy with no surface category is rejected"
-fi
+# Must-fail: the regression the header names keeps the category and softens
+# it, so each row plants one softening in the declared document and asks the
+# predicate for its verdict. A row is label|mutation|expected: the mutation is
+# a jq filter over the declared document (no pipe, the field separator), the
+# expected verdict `accepted` or `rejected`. A mutation that does not apply
+# stops the run: an unapplied mutation would read as a rejection.
+run_table() {
+  local title="$1" rows="$2" label mutation expected row field mutated got before=$((PASS + FAIL))
+  echo "=== $title ==="
+  while IFS= read -r row; do
+    [ "$row" != "" ] || continue
+    IFS='|' read -r label mutation expected <<<"$row"
+    for field in "$label" "$mutation" "$expected"; do
+      [ "$field" != "" ] || { printf 'a row with an empty field asserts nothing: %s\n' "$row" >&2; exit 1; }
+    done
+    mutated="$(printf '%s' "$declared" | jq "$mutation")" ||
+      { printf 'the mutation did not apply: %s\n' "$row" >&2; exit 1; }
+    if printf '%s' "$mutated" | jq -e --argjson surfaces "$SURFACES" "$predicate" >/dev/null; then
+      got=accepted
+    else
+      got=rejected
+    fi
+    # A rendering aid for writing rows; the run is refused after the loop.
+    if [ "${TAXONOMY_TABLE_PROBE:-}" = 1 ]; then
+      printf '%s => %s\n' "$label" "$got"
+      continue
+    fi
+    if [ "$got" = "$expected" ]; then
+      ok "$label"
+    else
+      bad "$label" "the predicate said $got"
+    fi
+  done <<<"$rows"
+  [ "$((PASS + FAIL))" -gt "$before" ] || { echo "no row was asserted (a probe run renders rows instead)" >&2; exit 2; }
+}
+
+run_table "the surface category softened" "\
+surface softened to optional|.categories.surface.required = false|rejected
+surface softened to non-exclusive|.categories.surface.exclusive = false|rejected
+one surface name dropped|del(.categories.surface.labels[0])|rejected
+"
 
 printf '\npass: %d   fail: %d\n' "$PASS" "$FAIL"
 [ "$FAIL" -eq 0 ]


### PR DESCRIPTION
Corrects the one must-fail control in `tools/tests/label-taxonomy.test.sh` per code-quality § Prove Your Guards: the old control deleted the surface category outright, a fixture that falsified all four predicate clauses at once, so removing any single clause from the predicate left the suite green (measured on main for each clause) and the control pinned only that the predicate runs. It is replaced by a table `label|mutation|expected` of three jq softenings on a scratch copy (`required` off, `exclusive` off, one surface label dropped), each expected `rejected`, each reddening only when its own clause is removed; a mutation that fails to parse exits 1 rather than reading as a rejection; a blank field exits 1, an empty row list exits 2, and the probe aid (`TAXONOMY_TABLE_PROBE=1`) renders then exits 2. Everything above the old control, the extractor, the declared-taxonomy row and the render check, is byte-identical.

`tools/tests/*` renders nowhere; the taxonomy in `kendex-local.toml` and its render are unchanged.

## Assertion and disposition map

The declared-taxonomy and verbatim-render assertions stay by name. The old "a taxonomy with no surface category is rejected" control is a named loss of the deletes-the-code shape, its claim covered by the union of the three rows (the old fixture is rejected wherever a clause lives). No row for a branch no old assertion covered: the `required_categories_for_new_issues` clause and a `required` weakened to not-false are recorded as pre-existing unpinned clauses and take no row.

## Must-fail battery

`impl-controls/label-taxonomy/mutants.txt` in the lane's scratchpad: 9 of 10, each row killing only its own predicate clause; worlds softening the manifest and render together kill only the declared-taxonomy row and the render alone only the verbatim row. The reviewer reproduced each pin (a clause removed reddens exactly its row; every clause made true reddens all three) and all four mechanism controls.

## Validation

`tools/guard --full` passed on this exact head, `e7737bb0c731e049943b1ec8cd0fbf193d00d211`: exit 0 with no `guard:` line, run once, in this worktree alone. Two kinds of evidence back that, kept apart. From the run's own log, written before the guard started: the granted head, the external `TMPDIR`, and the five Pi coding-agent, session, background-task and diagnostic-log paths, each pointing into a root the run created for itself, with that root's removal recorded afterwards. From a post-run transcription of the launch command's output, which the log does not print: all six git redirect variables read and cleared in the calling shell before the runner and its bindings, the two the runner itself does not clear included, and Python bytecode writing turned off there. That second kind is weaker than the first and is labelled so deliberately: no caller-record file was written at launch, and no independent live process-environment capture of the run exists, so those two conditions rest on the launch command's own output as transcribed afterwards rather than on an artefact captured at the time. The verdict was read from the run's own exit file and terminal line rather than from the launching shell, and the worktree, its source and its file modes were unchanged afterwards.

## Reviewer round

reviewer-test on 1e2b1076b: ACCEPT (the push rebased the commit onto main as e7737bb0c; the tools/ diff is byte-identical, cmp). Lines 1–97 confirmed byte-identical to main; the old control confirmed as a masked union; green three times under jq 1.7.1 and under de_DE.UTF-8; `bash32-lint` reports only the pre-existing hit.

KEN-1241

https://claude.ai/code/session_0194La4B2JmyJDcsb9tZbYgn
