### PR TITLE
test(KEN-1241): help-inert pins the command detector on a plant

### DIFF
--- a/tools/tests/help-inert.test.sh
+++ b/tools/tests/help-inert.test.sh
@@ -35,12 +35,17 @@ printf '%s\n' \
     '. "$PWD/.env.local"' \
     'printf "environment control\n"' \
     >"$FIXTURE/.agents/skills/control/scripts/environment-load"
+printf '%s\n' \
+    '#!/bin/sh' \
+    'printf "swallowed %s\n" "$*"' \
+    >"$FIXTURE/.agents/skills/control/scripts/command-swallow"
 cp "$FIXTURE/bin/blocked" "$FIXTURE/bin/gh"
 cp "$FIXTURE/bin/blocked" "$FIXTURE/bin/codex"
 cp "$FIXTURE/bin/blocked" "$FIXTURE/bin/curl"
 chmod +x "$FIXTURE/bin/blocked" "$FIXTURE/bin/gh" "$FIXTURE/bin/codex" \
     "$FIXTURE/bin/curl" "$FIXTURE/.agents/skills/control/scripts/dependency-call" \
-    "$FIXTURE/.agents/skills/control/scripts/environment-load"
+    "$FIXTURE/.agents/skills/control/scripts/environment-load" \
+    "$FIXTURE/.agents/skills/control/scripts/command-swallow"
 export HELP_INERT_CALLS="$CALLS"
 
 # The linear CLI's contract is Bash 4 or newer (skills/linear/tests/
@@ -91,6 +96,7 @@ while IFS=$'\t' read -r skill script token args expected; do
 done <<'ROWS'
 control	scripts/dependency-call	dependency control	--help	dependency
 control	scripts/environment-load	environment control	--help	environment
+control	scripts/command-swallow	command control	--help	command
 decider	scripts/decisions	Decision Lookup Tool	-
 decider	scripts/decisions	Decision Lookup Tool	help
 decider	scripts/decisions	Decision Lookup Tool	--help


### PR DESCRIPTION
Pins the command detector in `tools/tests/help-inert.test.sh` on a planted defect per code-quality § Prove Your Guards: its only red row for that detector (`cache cycles list --type --help`) rides on a live linear quirk and, probed, fires both detector arms, so fixing linear would redden it with no defect and the token arm had no control of its own. A third planted control in the `control` skill (`scripts/command-swallow`: exit 0, never the token) is built the way the two existing plants are and gets one row whose observed set is exactly `command`. All 104 existing rows are unchanged.

`tools/tests/*` renders nowhere; `tools/help-inert` is unchanged.

## Assertion and disposition map

104 rows kept by name; one row added as the control the existing detector claim lacked (the reviewer instrumented the loop and diffed every row's observed set against main: only the added line differs). Named gap, no row: the detector's status arm removed survives on main and on this head.

## Must-fail battery

`impl-controls/help-inert/mutants.txt` in the lane's scratchpad: the whole detector disabled is killed by the new row and the quirk row; with the quirk row out of the picture, by the new row alone; the token arm removed or weakened to empty output is killed by the new row alone (both survive main).

## Validation

`tools/guard --full` passed on this exact head, `3d9ef5d824f0fc1e462b78048b335a08331e8dde`: exit 0 with no `guard:` line, run once, no retry, in this worktree alone. From the run's own log, written before the guard started: the granted head, the external `TMPDIR`, and the five Pi coding-agent, session, background-task and diagnostic-log paths, each pointing into a root the run created for itself, with that root's removal recorded afterwards. From a caller record written as the caller ran, before the wrapper started: all six git redirect variables read and then cleared, the two the wrapper itself does not clear included, and Python bytecode writing turned off, both before any wrapper binding or import. The verdict was read from the run's own exit file and terminal line rather than from the launching shell, and the worktree, its source and its file modes were unchanged afterwards.

## Reviewer round

reviewer-test on 8ef916938: ACCEPT (the push rebased the commit onto main as 3d9ef5d82; the tools/ diff is byte-identical, cmp). Plant shape confirmed against the two existing plants; observed sets diffed row by row; green three times under jq 1.7.1 and under de_DE.UTF-8; `bash32-lint` reports only the pre-existing hit.

KEN-1241

https://claude.ai/code/session_0194La4B2JmyJDcsb9tZbYgn
