### PR TITLE
test(KEN-1241): disable fixture maintenance

### DIFF
--- a/.agents/skills/review-gate/tests/lib/sandbox.sh
+++ b/.agents/skills/review-gate/tests/lib/sandbox.sh
@@ -50,6 +50,7 @@ printf 'sandbox\n' >"$PRISTINE/AGENTS.md"
 (
   cd "$PRISTINE"
   git init -q .
+  git config maintenance.auto false
   git config user.name "review-gate tests"
   git config user.email "tests@example.invalid"
   git add -A

--- a/skills/review-gate/tests/lib/sandbox.sh
+++ b/skills/review-gate/tests/lib/sandbox.sh
@@ -50,6 +50,7 @@ printf 'sandbox\n' >"$PRISTINE/AGENTS.md"
 (
   cd "$PRISTINE"
   git init -q .
+  git config maintenance.auto false
   git config user.name "review-gate tests"
   git config user.email "tests@example.invalid"
   git add -A


### PR DESCRIPTION
The review-gate test fixture now disables Git automatic maintenance before its first commit.

Copied test cases keep real Git repositories. They inherit the repository-local setting.

CI run `34216749266` failed while `cp -R` copied a transient `.git/objects/maintenance.lock`. The saved evidence establishes a permitted Git maintenance race. It does not identify the process that removed the observed file.

Part of KEN-1241. The remaining audit stays open.

## Validation

- The focused `validate-workflow.test.sh` suite passed with `51` passes and no failures.
- Git `2.55.0` Trace2 evidence records the pristine commit and copied-case commit.
- The corrected fixture produced no automatic-maintenance child from either commit.
- Removing only the new setting preserved both commits, both tracked-workflow queries, and the validator pass.
- The counterfactual then launched `git maintenance run --auto --quiet --detach` from each commit and failed the intended assertion.
- The reviewer-test specialist passed the unchanged head with no findings.
- The commit checks passed.
- This branch's own required full guard passed at exact head `074a47df6e1813e06ba7c111b4aa111f6a1a3bc3` with external temporary storage, cleared Git redirects, and private Pi paths.
- The Copilot formal review by `copilot-pull-request-reviewer` completed at the exact head with no review threads.
- Current CI passed at the exact head, including the review gate.
- Merge remains pending root grant.
