### PR TITLE
test(KEN-1241): remove repo-copy prose pins

### DIFF
--- a/hooks/tests/block-repo-copy.test.sh
+++ b/hooks/tests/block-repo-copy.test.sh
@@ -182,9 +182,6 @@ run_hook "cargo build --target x86_64-unknown-linux-gnu"; assert_eq "$rc" 0 'a -
 echo "=== block-repo-copy: the refusal names the cause and the alternatives ==="
 run_hook "cp -r $REPO/target /tmp/copy"
 assert_contains "$err" "cp -r $REPO/target /tmp/copy" 'the refusal quotes the command it judged'
-assert_contains "$err" "ENOSPC" 'the refusal names the failure the copy causes'
-assert_contains "$err" "Read the source in place" 'the refusal offers reading in place'
-assert_contains "$err" "MINIMAL synthetic fixture" 'the refusal offers a minimal fixture'
 assert_contains "$err" 'mktemp -d' 'the refusal shows how to build the fixture'
 
 payload_table "$HOOK" "cp -r $REPO/.git /tmp/copy" "cp -r $REPO/src /tmp/copy"

--- a/hooks/tests/task-completed-check.test.sh
+++ b/hooks/tests/task-completed-check.test.sh
@@ -177,7 +177,7 @@ assert_contains "$err" "rev-parse failed" "names the probe that could not answer
 echo "task-completed-check: a changed set larger than the pipe buffer"
 REPO="$(new_repo bigset)"
 printf 'pub fn added() {}\n' >"$REPO/src/added.rs"
-# Sorts after src/, and long enough that the filter cannot have read it all
+# precondition: Sorts after src/, and long enough that the filter cannot have read it all
 # before an early-exiting reader would have quit on the .rs file.
 mkdir -p "$REPO/zpad"
 i=0


### PR DESCRIPTION
KEN-1241 H5 removes prose assertions that made the repository-copy test depend on wording. It keeps the quoted command and `mktemp -d` value checks. H5b adds only the `precondition:` label to the pipe-buffer padding comment in `task-completed-check.test.sh`.

- Deleted assertions: the ENOSPC explanation, reading-in-place advice, and minimal-fixture advice. No consumer parses these phrases.
- Preserved: command grammar, separator pairs, `/tmp-old`, all stated-limit rows, and the shared payload helper call. Production hooks stay unchanged.
- Narrow proof: `bash hooks/tests/block-repo-copy.test.sh` passed with 72 assertions and no failures in the owned worktree.
- H5b adds no test. Its assertions and fixture remain unchanged.
- The four granted controls covered the quoted command, `mktemp -d`, ampersand separation and the `/tmp-old` limit. Every modified hook passed its syntax check. Each control exited 1 with only its named assertion failing. Every restored-source partner exited 0 with 72 assertions passing.
- The single specialist review is complete with no blockers in `reviewer-test.json`. Its original held-measurement declaration is preserved. The later granted measurements are recorded separately.
- Installed normal pre-commit and commit-message checks passed for commit `9ca85a78d54283c577a4cb0084f2fe9508153736`. The worktree is clean. Source hashes match the accepted control evidence. Private agent, session, task and diagnostic paths were recorded and removed after execution.
- This head's own full guard completed at `9ca85a78d54283c577a4cb0084f2fe9508153736` with exit 0 in terminal 67216. The recorded private state paths were removed, and the worktree remains clean with unchanged accepted source bytes and modes. The single bot pass is complete. Root's current CI read is CLEAN with no pending or failed check and zero unresolved threads. Merge and main actions remain held for their separate grants.
- Existing limits remain: working-tree and variable sources, destination-before-source tar, quoted text, comment tails, redirection destinations, punctuation after `/tmp`, and wrapped or-list binding. Inherited payload gaps remain bare JSON strings and top-level precedence.

The complete assertion disposition map is in `tmp/audit-d8/h5/assertion-map.md`.
