### PR TITLE
docs(KEN-1241): define stable script message contracts

### DIFF
--- a/.agents/skills/code-quality/SKILL.md
+++ b/.agents/skills/code-quality/SKILL.md
@@ -58,7 +58,8 @@ A new or modified check, guard, assertion, or test ships with a must-fail contro
 - One control per behaviour surface, a public function, command, rule or contract, plus its inverse: the must-fail control § Prove Your Guards demands.
 - N planted defects means N asserted rows. A fixture that plants several defects under one verdict passes while any one of them is caught, and is never allowed.
 - Shaped input (positions, settings keys, tamper classes) is one table-driven case: one loop, one assertion per row, the row list visible in the file.
-- Assert the code, the enum or the exit status. Pin a human-readable message only inside a contract a consumer parses.
+- Every hook or script refusal and notice starts with a stable first line: a short key and the relevant path, count, exit code or other value. Put the English explanation on following lines. Keep message text in one place per hook or script.
+- Assert codes, enums and exit status. For refusals and notices, assert the key, value and exit status, never an English sentence. When a downstream consumer parses a text protocol, state that contract in the script header and pin the whole protocol. Change the message mechanism and its tests in the same package PR.
 - A row pins the clause only its own guard emits: an expectation a neighbouring gate or the production helper on both sides can also produce is not a pin, a value read as a truthiness bit is not a pin, and a fold keeps every assertion of its former cases.
 - No test of the test harness: a pin on a manifest script string or a runner configuration proves nothing about behaviour.
 - A shared fixture is a neutral world (a seeded repository, a fake SDK). A fixture that carries a planted defect is private to its case.

--- a/skills/code-quality/SKILL.md
+++ b/skills/code-quality/SKILL.md
@@ -50,7 +50,8 @@ A new or modified check, guard, assertion, or test ships with a must-fail contro
 - One control per behaviour surface, a public function, command, rule or contract, plus its inverse: the must-fail control § Prove Your Guards demands.
 - N planted defects means N asserted rows. A fixture that plants several defects under one verdict passes while any one of them is caught, and is never allowed.
 - Shaped input (positions, settings keys, tamper classes) is one table-driven case: one loop, one assertion per row, the row list visible in the file.
-- Assert the code, the enum or the exit status. Pin a human-readable message only inside a contract a consumer parses.
+- Every hook or script refusal and notice starts with a stable first line: a short key and the relevant path, count, exit code or other value. Put the English explanation on following lines. Keep message text in one place per hook or script.
+- Assert codes, enums and exit status. For refusals and notices, assert the key, value and exit status, never an English sentence. When a downstream consumer parses a text protocol, state that contract in the script header and pin the whole protocol. Change the message mechanism and its tests in the same package PR.
 - A row pins the clause only its own guard emits: an expectation a neighbouring gate or the production helper on both sides can also produce is not a pin, a value read as a truthiness bit is not a pin, and a fold keeps every assertion of its former cases.
 - No test of the test harness: a pin on a manifest script string or a runner configuration proves nothing about behaviour.
 - A shared fixture is a neutral world (a seeded repository, a fake SDK). A fixture that carries a planted defect is private to its case.


### PR DESCRIPTION
Hook and script message tests can break when only the English explanation changes. The code-quality Tests section now requires a stable key and relevant value on the first line, with the explanation below and message text in one place per hook or script.

Tests assert the key, value and exit status. A text protocol parsed by a downstream consumer must be declared in the script header and asserted as a whole. The mechanism and its tests land in the same package PR.

Changed: `skills/code-quality/SKILL.md` and its tracked render. Test files judged compliant and left unchanged: none; this package contains no test files. No executable behavior changed, so no test or must-fail control was added for prose.

Validation: preflight and normal commit checks passed. The own `tools/guard --full` run passed at the published head with `TMPDIR=/var/tmp/ken-c`. The first run failed the unchanged CLI outside-project test because the inherited temporary directory was below the real home's harness markers. The failed run is preserved. The successful run includes Rust workspace checks and tests, cross-target checks, and the UI checks and tests. Formal bot review is complete with no comments; the review gate is approved. CI passed on Linux, macOS and Windows.

KEN-1241
