### PR TITLE
test(KEN-1241): audit Codex tool behavior contracts

### DIFF
--- a/pi-extensions/pi-codex-minimal-tools/CHANGELOG.md
+++ b/pi-extensions/pi-codex-minimal-tools/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Consumer-impacting changes
 
+### Unreleased
+
+- Patch and image validation errors expose stable error codes. Grammar schema and response-header timeout errors include a stable key and value before their explanation.
+
 ### 2.0.1
 
 - Pi 0.85.1 parity: the SSE transport no longer fails with "Stream closed before response.completed" when the backend closes the stream right after the terminal event without a trailing blank line. The last frame is parsed at end of stream.

--- a/pi-extensions/pi-codex-minimal-tools/src/patch/apply.ts
+++ b/pi-extensions/pi-codex-minimal-tools/src/patch/apply.ts
@@ -34,7 +34,7 @@ export function resolvePatchPath(pathValue: string, options: ApplyPatchOptions):
 	const cwd = resolve(options.cwd);
 	const rel = relative(cwd, absolute);
 	const insideCwd = rel === "" || (!rel.startsWith("..") && !isAbsolute(rel));
-	if (!insideCwd && !options.allowAbsolutePaths) throw new Error(`Patch path escapes cwd: ${pathValue}`);
+	if (!insideCwd && !options.allowAbsolutePaths) throw Object.assign(new Error(`patch_path_outside=${pathValue}\nPatch path escapes cwd: ${pathValue}`), { code: "PATCH_PATH_OUTSIDE", path: pathValue });
 	return absolute;
 }
 
@@ -85,14 +85,14 @@ async function readUtf8(path: string): Promise<string> {
 	try {
 		return await readFile(path, "utf8");
 	} catch (error) {
-		throw new Error(`Failed to read ${path}: ${error instanceof Error ? error.message : String(error)}`);
+		throw Object.assign(new Error(`patch_read_failed=${path}\nFailed to read ${path}: ${error instanceof Error ? error.message : String(error)}`, { cause: error }), { code: "PATCH_READ_FAILED", path });
 	}
 }
 
 function replaceUnique(content: string, oldText: string, newText: string, path: string): string | undefined {
 	const first = content.indexOf(oldText);
 	if (first < 0) return undefined;
-	if (content.indexOf(oldText, first + oldText.length) >= 0) throw new Error(`Patch context is ambiguous in ${path}`);
+	if (content.indexOf(oldText, first + oldText.length) >= 0) throw Object.assign(new Error(`patch_context_ambiguous=${path}\nPatch context is ambiguous in ${path}`), { code: "PATCH_CONTEXT_AMBIGUOUS", path });
 	return `${content.slice(0, first)}${newText}${content.slice(first + oldText.length)}`;
 }
 
@@ -159,7 +159,7 @@ export async function applyParsedPatch(parsed: ParsedPatch, options: ApplyPatchO
 		const applied = files.map((file) => `${file.kind} ${file.path}`).join(", ") || "none";
 		const message = error instanceof Error ? error.message : String(error);
 		await restoreSnapshots([...snapshots.values()]);
-		throw new Error(`${message}\nPartial apply status: completed actions before failure: ${applied}. Rolled back touched files; review the working tree before retrying.`);
+		throw Object.assign(new Error(`${message}\nPartial apply status: completed actions before failure: ${applied}. Rolled back touched files; review the working tree before retrying.`, { cause: error }), error instanceof Error ? { code: (error as NodeJS.ErrnoException).code, path: (error as NodeJS.ErrnoException).path } : {});
 	}
 	return {
 		files,

--- a/pi-extensions/pi-codex-minimal-tools/src/provider-shim.ts
+++ b/pi-extensions/pi-codex-minimal-tools/src/provider-shim.ts
@@ -1,3 +1,5 @@
+// Pi retry classification consumes HTTP status prefixes in errorMessage.
+// withHttpStatusPrefix preserves an existing HTTP <status> prefix verbatim.
 import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
 import { readFileSync } from "node:fs";
 import { access } from "node:fs/promises";
@@ -628,7 +630,7 @@ export async function fetchWithResponseHeaderTimeout(
 	const controller = new AbortController();
 	let timedOut = false;
 	let parentAborted = false;
-	const timeoutMessage = `Codex Responses SSE response headers timed out after ${timeoutMs}ms`;
+	const timeoutError = Object.assign(new Error(`response_header_timeout_ms=${timeoutMs}\nCodex Responses SSE response headers timed out after ${timeoutMs}ms`), { code: "RESPONSE_HEADER_TIMEOUT", timeoutMs });
 
 	const onParentAbort = () => {
 		parentAborted = true;
@@ -638,13 +640,13 @@ export async function fetchWithResponseHeaderTimeout(
 	if (parentSignal) parentSignal.addEventListener("abort", onParentAbort, { once: true });
 	const timeout = setTimeout(() => {
 		timedOut = true;
-		controller.abort(new Error(timeoutMessage));
+		controller.abort(timeoutError);
 	}, Math.max(1, timeoutMs));
 
 	try {
 		return await fetch(url, { ...init, signal: controller.signal });
 	} catch (error) {
-		if (timedOut) throw new Error(timeoutMessage);
+		if (timedOut) throw timeoutError;
 		if (parentAborted || parentSignal?.aborted) throw new Error("Request was aborted");
 		throw error;
 	} finally {

--- a/pi-extensions/pi-codex-minimal-tools/src/providers/openai-responses-compat.ts
+++ b/pi-extensions/pi-codex-minimal-tools/src/providers/openai-responses-compat.ts
@@ -47,7 +47,7 @@ export function resolveGrammarSampling(tool: Tool, supported: boolean): { format
 	try {
 		return { format: hasLark ? "lark" : "regex", definition: hasLark ? lark : regex, inputProperty: inferGrammarInputProperty(constrainedTool) };
 	} catch (error) {
-		throw new Error(`Tool "${tool.name}" cannot use grammar constrained sampling: ${error instanceof Error ? error.message : String(error)}.`);
+		throw Object.assign(new Error(`grammar_schema=${tool.name}\nTool "${tool.name}" cannot use grammar constrained sampling: ${error instanceof Error ? error.message : String(error)}.`, { cause: error }), { code: "GRAMMAR_SCHEMA", tool: tool.name });
 	}
 }
 
@@ -55,7 +55,7 @@ export function resolveStrictSampling(tool: Tool, supported: boolean): boolean |
 	const config = (tool as ToolWithConstrainedSampling).constrainedSampling;
 	if (!config || config.type !== "json_schema") return undefined;
 	if (supported) return true;
-	if (config.strict === "require") throw new Error(`Tool "${tool.name}" requires JSON-schema constrained sampling, but strict tools are unsupported.`);
+	if (config.strict === "require") throw Object.assign(new Error(`strict_sampling=${tool.name}\nTool "${tool.name}" requires JSON-schema constrained sampling, but strict tools are unsupported.`), { code: "STRICT_SAMPLING_UNSUPPORTED", tool: tool.name });
 	return undefined;
 }
 
@@ -79,7 +79,7 @@ export function appendGrammarToolInputJsonDelta(buffer: GrammarInputBuffer, prop
 		if (close && nextInput === buffer.input) return undefined;
 		throw new Error(`grammar tool input for property "${property}" changed after it was closed`);
 	}
-	if (!nextInput.startsWith(buffer.input)) throw new Error(`grammar tool input for property "${property}" changed non-monotonically`);
+	if (!nextInput.startsWith(buffer.input)) throw Object.assign(new Error(`grammar tool input for property "${property}" changed non-monotonically`), { code: "GRAMMAR_INPUT_NON_MONOTONIC", property });
 	const inputDelta = nextInput.slice(buffer.input.length);
 	if (!close && inputDelta.length === 0) return undefined;
 	let delta = "";

--- a/pi-extensions/pi-codex-minimal-tools/src/providers/openai-responses-shared.ts
+++ b/pi-extensions/pi-codex-minimal-tools/src/providers/openai-responses-shared.ts
@@ -808,7 +808,7 @@ export async function processResponsesStream<TApi extends Api>(
 		}
 	}
 	if (!sawTerminalResponseEvent) {
-		throw new Error("OpenAI Responses stream ended before a terminal response event");
+		throw Object.assign(new Error("OpenAI Responses stream ended before a terminal response event"), { code: "RESPONSES_TERMINAL_MISSING" });
 	}
 }
 

--- a/pi-extensions/pi-codex-minimal-tools/src/tools/view-image.ts
+++ b/pi-extensions/pi-codex-minimal-tools/src/tools/view-image.ts
@@ -36,7 +36,7 @@ function assertWithinCwd(absolutePath: string, cwd: string, displayPath: string)
 	const cwdAbsolute = resolve(cwd);
 	const rel = relative(cwdAbsolute, absolutePath);
 	if (rel === "" || (!rel.startsWith("..") && !isAbsolute(rel))) return;
-	throw new Error(`view_image path escapes the workspace: ${displayPath}`);
+	throw Object.assign(new Error(`image_path_outside=${displayPath}\nview_image path escapes the workspace: ${displayPath}`), { code: "IMAGE_PATH_OUTSIDE", path: displayPath });
 }
 
 export function normalizeImagePath(pathValue: string, cwd: string, options?: ViewImageOptions): { absolutePath: string; displayPath: string } {
@@ -63,18 +63,18 @@ export async function validateImagePath(input: ViewImageInput, cwd: string, opti
 	} catch {
 		throw new Error(`Image not found: ${normalized.displayPath}`);
 	}
-	if (fileStat.isDirectory()) throw new Error(`view_image expected a file but got a directory: ${normalized.displayPath}`);
+	if (fileStat.isDirectory()) throw Object.assign(new Error(`image_directory=${normalized.displayPath}\nview_image expected a file but got a directory: ${normalized.displayPath}`), { code: "IMAGE_DIRECTORY", path: normalized.displayPath });
 	if (!fileStat.isFile()) throw new Error(`view_image expected a regular image file: ${normalized.displayPath}`);
 	if (options?.workspaceOnly) {
 		try {
 			assertWithinCwd(await realpath(normalized.absolutePath), await realpath(cwd), normalized.displayPath);
 		} catch (error) {
-			if (error instanceof Error && error.message.includes("escapes the workspace")) throw error;
+			if (error instanceof Error && (error as NodeJS.ErrnoException).code === "IMAGE_PATH_OUTSIDE") throw error;
 			throw new Error(`Unable to validate image path: ${normalized.displayPath}`);
 		}
 	}
 	const mimeType = mimeTypeForImagePath(normalized.absolutePath);
-	if (!mimeType) throw new Error(`Unsupported image file type for view_image: ${normalized.displayPath}`);
+	if (!mimeType) throw Object.assign(new Error(`image_type=${normalized.displayPath}\nUnsupported image file type for view_image: ${normalized.displayPath}`), { code: "IMAGE_TYPE", path: normalized.displayPath });
 	return { ...normalized, detail, mimeType, sizeBytes: fileStat.size };
 }
 

--- a/pi-extensions/pi-codex-minimal-tools/tests/activation.test.ts
+++ b/pi-extensions/pi-codex-minimal-tools/tests/activation.test.ts
@@ -1,11 +1,11 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 import codexMinimalTools from "../src/index.js";
-import { hasOpenAiModelsLoaded } from "../src/activation.js";
+import { environment, world } from "./helpers/world.js";
 
 function fakePi() {
-	const handlers: Record<string, Function[]> = {};
-	const tools: any[] = [];
+	const handlers: Record<string, Array<(event: unknown, ctx: unknown) => unknown>> = {};
+	const tools: Array<{ name: string }> = [];
 	let activeTools = ["read", "bash"];
 	return {
 		activeTools,
@@ -14,60 +14,45 @@ function fakePi() {
 		registerCommand() {},
 		registerProvider() {},
 		registerMessageRenderer() {},
-		registerTool(tool: any) { tools.push(tool); },
-		on(event: string, handler: Function) { (handlers[event] ??= []).push(handler); },
+		registerTool(tool: { name: string }) { tools.push(tool); },
+		on(event: string, handler: (event: unknown, ctx: unknown) => unknown) { (handlers[event] ??= []).push(handler); },
 		getActiveTools() { return activeTools; },
 		setActiveTools(next: string[]) { activeTools = next; this.activeTools = next; },
 	};
 }
 
-async function emit(pi: ReturnType<typeof fakePi>, event: string, ctx: any): Promise<void> {
-	for (const handler of pi.handlers[event] ?? []) await handler({}, ctx);
+async function emit(pi: ReturnType<typeof fakePi>, event: string, ctx: unknown): Promise<void> {
+	assert.ok(pi.handlers[event], event);
+	for (const handler of pi.handlers[event]) await handler({}, ctx);
 }
 
-test("hasOpenAiModelsLoaded detects active or registry OpenAI models", () => {
-	assert.equal(hasOpenAiModelsLoaded({ model: { provider: "anthropic", id: "claude" }, modelRegistry: { getAll: () => [] } }), false);
-	assert.equal(hasOpenAiModelsLoaded({ model: { provider: "notopenai", id: "claude" }, modelRegistry: { getAll: () => [] } }), false);
-	assert.equal(hasOpenAiModelsLoaded({ model: { provider: "openai-codex", id: "gpt-6-astra" }, modelRegistry: { getAll: () => [] } }), true);
-	assert.equal(hasOpenAiModelsLoaded({ modelRegistry: { getAll: () => [{ provider: "openai", id: "gpt-6-astra" }] } }), true);
-	assert.equal(hasOpenAiModelsLoaded({ modelRegistry: { find: (provider, id) => provider === "openai" && id === "gpt-5.2" ? { provider, id } : undefined } }), true);
-});
-
-test("extension does not register tools until OpenAI models are loaded", async () => {
-	const pi = fakePi();
-	codexMinimalTools(pi as any);
-	assert.equal(pi.tools.length, 0);
-
-	await emit(pi, "session_start", {
-		cwd: process.cwd(),
-		model: { provider: "anthropic", id: "claude", input: ["text"] },
-		modelRegistry: { getAll: () => [{ provider: "anthropic", id: "claude" }] },
+const openai = { provider: "openai-codex", id: "gpt-6-astra", input: ["text", "image"] };
+const anthropic = { provider: "anthropic", id: "claude", input: ["text"] };
+const packageNames = ["apply_patch", "image_generation", "view_image"];
+for (const row of [
+	{
+		name: "deferred registration then model switch", initial: ["read", "bash"],
+		steps: [
+			{ event: "session_start", model: anthropic, registry: [anthropic], registered: [], active: ["read", "bash"] },
+			{ event: "model_select", model: openai, registry: [openai], registered: packageNames, active: ["read", "bash", "apply_patch", "image_generation"] },
+		],
+	},
+	{
+		name: "unsupported active model with OpenAI still registered", initial: ["read", "view_image", "apply_patch", "image_generation"],
+		steps: [{ event: "model_select", model: { provider: "claude-bridge", id: "claude-opus-4-7", input: ["text", "image"] }, registry: [openai], registered: packageNames, active: ["read"] }],
+	},
+]) {
+	test(`extension activation: ${row.name}`, async (t) => {
+		const { cwd, agent } = world(t);
+		environment(t, { PI_CODING_AGENT_DIR: agent });
+		const pi = fakePi();
+		pi.setActiveTools(row.initial);
+		codexMinimalTools(pi as never);
+		assert.equal(pi.tools.length, 0);
+		for (const step of row.steps) {
+			await emit(pi, step.event, { cwd, model: step.model, modelRegistry: { getAll: () => step.registry } });
+			assert.deepEqual(pi.tools.map((tool) => tool.name).sort(), [...step.registered].sort());
+			assert.deepEqual([...pi.activeTools].sort(), [...step.active].sort());
+		}
 	});
-	assert.equal(pi.tools.length, 0);
-	assert.deepEqual(pi.activeTools, ["read", "bash"]);
-
-	await emit(pi, "model_select", {
-		cwd: process.cwd(),
-		model: { provider: "openai-codex", id: "gpt-6-astra", input: ["text", "image"] },
-		modelRegistry: { getAll: () => [{ provider: "openai-codex", id: "gpt-6-astra" }] },
-	});
-	assert.equal(pi.tools.length, 3);
-	assert.deepEqual(pi.tools.map((tool) => tool.name).sort(), ["apply_patch", "image_generation", "view_image"].sort());
-	assert.ok(pi.activeTools.includes("read"));
-	assert.ok(pi.activeTools.includes("bash"));
-	assert.ok(pi.activeTools.includes("apply_patch"));
-});
-
-test("active non-OpenAI models remove package tools even when OpenAI models exist in registry", async () => {
-	const pi = fakePi();
-	pi.setActiveTools(["read", "view_image", "apply_patch", "image_generation"]);
-	codexMinimalTools(pi as any);
-
-	await emit(pi, "model_select", {
-		cwd: process.cwd(),
-		model: { provider: "claude-bridge", id: "claude-opus-4-7", input: ["text", "image"] },
-		modelRegistry: { getAll: () => [{ provider: "openai-codex", id: "gpt-6-astra", input: ["text", "image"] }] },
-	});
-
-	assert.deepEqual(pi.activeTools, ["read"]);
-});
+}

--- a/pi-extensions/pi-codex-minimal-tools/tests/api-key-compat.test.ts
+++ b/pi-extensions/pi-codex-minimal-tools/tests/api-key-compat.test.ts
@@ -1,0 +1,15 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { getEnvApiKeyCompat } from "../src/provider-shim.js";
+
+for (const row of [
+	{ name: "compat", root: {}, expected: "key-for-openai-codex", compatCalls: 1 },
+	{ name: "root", root: { getEnvApiKey: (provider: string) => `root-key-for-${provider}` }, expected: "root-key-for-openai-codex", compatCalls: 0 },
+]) {
+	test(`API key lookup: ${row.name}`, async () => {
+		let calls = 0;
+		const key = await getEnvApiKeyCompat("openai-codex", { root: row.root, loadCompat: async () => { calls++; return { getEnvApiKey: (provider: string) => `key-for-${provider}` }; } });
+		assert.equal(key, row.expected);
+		assert.equal(calls, row.compatCalls);
+	});
+}

--- a/pi-extensions/pi-codex-minimal-tools/tests/apply-patch-output.test.ts
+++ b/pi-extensions/pi-codex-minimal-tools/tests/apply-patch-output.test.ts
@@ -1,0 +1,18 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import test from "node:test";
+import { createApplyPatchToolDefinition, executeApplyPatchTool } from "../src/tools/apply-patch.js";
+import { world } from "./helpers/world.js";
+
+test("registered apply_patch returns text and file details without a custom renderer", async (t) => {
+	const { cwd } = world(t);
+	const tool = createApplyPatchToolDefinition({ cwd, deferRendering: true });
+	const execute = tool.execute as (id: string, params: { input: string }, signal: undefined, update: undefined, ctx: { cwd: string }) => ReturnType<typeof executeApplyPatchTool>;
+	assert.equal(typeof execute, "function");
+	const result = await execute("patch-1", { input: "*** Begin Patch\n*** Add File: hello.txt\n+hello\n*** End Patch" }, undefined, undefined, { cwd });
+	assert.equal(result.content[0]?.type, "text");
+	assert.ok(result.content[0]?.text.length > 0);
+	assert.deepEqual(result.details.files.map(({ kind, path }) => ({ kind, path })), [{ kind: "add", path: "hello.txt" }]);
+	assert.equal(readFileSync(join(cwd, "hello.txt"), "utf8"), "hello");
+});

--- a/pi-extensions/pi-codex-minimal-tools/tests/apply-patch.test.ts
+++ b/pi-extensions/pi-codex-minimal-tools/tests/apply-patch.test.ts
@@ -1,113 +1,52 @@
 import assert from "node:assert/strict";
-import { existsSync, mkdtempSync, readFileSync, writeFileSync } from "node:fs";
-import { tmpdir } from "node:os";
+import { existsSync, readFileSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import test from "node:test";
 import { applyPatch } from "../src/patch/apply.js";
-import { parseApplyPatch } from "../src/patch/parser.js";
+import { world } from "./helpers/world.js";
 
-function tempDir(): string {
-	return mkdtempSync(join(tmpdir(), "pi-apply-patch-"));
+const cases = [
+	{
+		name: "add, update, delete, then move in one transaction",
+		seed: { "update.txt": "alpha\nold\nomega", "delete.txt": "remove me" },
+		patch: "*** Add File: added.txt\n+hello\n+world\n*** Update File: update.txt\n@@\n alpha\n-old\n+new\n omega\n*** Delete File: delete.txt\n*** Update File: update.txt\n*** Move to: moved.txt\n@@\n alpha\n-new\n+newer\n omega",
+		files: { "added.txt": "hello\nworld", "moved.txt": "alpha\nnewer\nomega", "update.txt": null, "delete.txt": null },
+		count: 4,
+	},
+	{
+		name: "traversal refusal",
+		seed: {}, patch: "*** Add File: ../escape.txt\n+nope",
+		files: { "../escape.txt": null }, errorPath: "../escape.txt", code: "PATCH_PATH_OUTSIDE",
+	},
+	{
+		name: "rollback after missing update target",
+		seed: {}, patch: "*** Add File: ok.txt\n+ok\n*** Update File: missing.txt\n@@\n-old\n+new",
+		files: { "ok.txt": null }, errorPath: "missing.txt", code: "PATCH_READ_FAILED",
+	},
+	{
+		name: "ambiguous context refusal",
+		seed: { "ambiguous.txt": "same\nsame\n" },
+		patch: "*** Update File: ambiguous.txt\n@@\n-same\n+different",
+		files: { "ambiguous.txt": "same\nsame\n" }, errorPath: "ambiguous.txt", code: "PATCH_CONTEXT_AMBIGUOUS",
+	},
+	{
+		name: "CRLF preservation with LF context",
+		seed: { "crlf.txt": "alpha\r\nold\r\nomega\r\n" },
+		patch: "*** Update File: crlf.txt\n@@\n alpha\n-old\n+new\n omega",
+		files: { "crlf.txt": "alpha\r\nnew\r\nomega\r\n" }, count: 1,
+	},
+] satisfies Array<{ name: string; seed: Record<string, string>; patch: string; files: Record<string, string | null>; code?: string; errorPath?: string; count?: number }>;
+
+for (const row of cases) {
+	test(`applyPatch: ${row.name}`, async (t) => {
+		const { cwd } = world(t);
+		for (const [name, bytes] of Object.entries(row.seed)) writeFileSync(join(cwd, name), bytes!);
+		const apply = () => applyPatch(`*** Begin Patch\n${row.patch}\n*** End Patch`, { cwd });
+		if (row.code) await assert.rejects(apply, { code: row.code, path: row.code === "PATCH_READ_FAILED" ? join(cwd, row.errorPath!) : row.errorPath });
+		else assert.equal((await apply()).files.length, row.count);
+		for (const [name, bytes] of Object.entries(row.files)) {
+			if (bytes === null) assert.equal(existsSync(join(cwd, name)), false, name);
+			else assert.equal(readFileSync(join(cwd, name), "utf8"), bytes, name);
+		}
+	});
 }
-
-test("parseApplyPatch parses add/update/delete actions", () => {
-	const parsed = parseApplyPatch(`*** Begin Patch
-*** Add File: a.txt
-+hello
-*** Update File: b.txt
-@@
--old
-+new
-*** Delete File: c.txt
-*** End Patch`);
-	assert.equal(parsed.actions.length, 3);
-	assert.equal(parsed.actions[0]?.kind, "add");
-	assert.equal(parsed.actions[1]?.kind, "update");
-	assert.equal(parsed.actions[2]?.kind, "delete");
-});
-
-test("applyPatch adds, updates, deletes, and moves files", async () => {
-	const cwd = tempDir();
-	writeFileSync(join(cwd, "update.txt"), "alpha\nold\nomega");
-	writeFileSync(join(cwd, "delete.txt"), "remove me");
-	const result = await applyPatch(`*** Begin Patch
-*** Add File: added.txt
-+hello
-+world
-*** Update File: update.txt
-@@
- alpha
--old
-+new
- omega
-*** Delete File: delete.txt
-*** Update File: update.txt
-*** Move to: moved.txt
-@@
- alpha
--new
-+newer
- omega
-*** End Patch`, { cwd });
-	assert.equal(readFileSync(join(cwd, "added.txt"), "utf8"), "hello\nworld");
-	assert.equal(readFileSync(join(cwd, "moved.txt"), "utf8"), "alpha\nnewer\nomega");
-	assert.equal(existsSync(join(cwd, "update.txt")), false);
-	assert.equal(existsSync(join(cwd, "delete.txt")), false);
-	assert.equal(result.files.length, 4);
-});
-
-test("applyPatch rejects path traversal by default", async () => {
-	const cwd = tempDir();
-	await assert.rejects(
-		() => applyPatch(`*** Begin Patch
-*** Add File: ../escape.txt
-+nope
-*** End Patch`, { cwd }),
-		/escapes cwd/,
-	);
-});
-
-test("applyPatch reports partial failure and rolls back touched files", async () => {
-	const cwd = tempDir();
-	await assert.rejects(
-		() => applyPatch(`*** Begin Patch
-*** Add File: ok.txt
-+ok
-*** Update File: missing.txt
-@@
--old
-+new
-*** End Patch`, { cwd }),
-		/Rolled back touched files/,
-	);
-	assert.equal(existsSync(join(cwd, "ok.txt")), false);
-});
-
-test("applyPatch rejects ambiguous update context", async () => {
-	const cwd = tempDir();
-	writeFileSync(join(cwd, "ambiguous.txt"), "same\nsame\n");
-	await assert.rejects(
-		() => applyPatch(`*** Begin Patch
-*** Update File: ambiguous.txt
-@@
--same
-+different
-*** End Patch`, { cwd }),
-		/ambiguous/,
-	);
-	assert.equal(readFileSync(join(cwd, "ambiguous.txt"), "utf8"), "same\nsame\n");
-});
-
-test("applyPatch preserves CRLF files when patch context uses LF", async () => {
-	const cwd = tempDir();
-	writeFileSync(join(cwd, "crlf.txt"), "alpha\r\nold\r\nomega\r\n");
-	await applyPatch(`*** Begin Patch
-*** Update File: crlf.txt
-@@
- alpha
--old
-+new
- omega
-*** End Patch`, { cwd });
-	assert.equal(readFileSync(join(cwd, "crlf.txt"), "utf8"), "alpha\r\nnew\r\nomega\r\n");
-});

--- a/pi-extensions/pi-codex-minimal-tools/tests/background-image-generation.test.ts
+++ b/pi-extensions/pi-codex-minimal-tools/tests/background-image-generation.test.ts
@@ -1,88 +1,21 @@
 import assert from "node:assert/strict";
 import test from "node:test";
-import { buildBackgroundImageRequest, buildHeaders, parseImageGenCommandArgs, selectCodexImageModel, summarizeNonImageResponse } from "../src/background-image-generation.js";
+import { buildBackgroundImageRequest } from "../src/background-image-generation.js";
 
-function codexToken(accountId: string): string {
-	const payload = Buffer.from(JSON.stringify({ "https://api.openai.com/auth": { chatgpt_account_id: accountId } })).toString("base64");
-	return `header.${payload}.signature`;
+for (const row of [
+	{ action: "generate", prompt: "draw a red apple", referenceImages: [] },
+	{ action: "edit", prompt: "change icon to green", referenceImages: [{ path: "/tmp/icon.png", mimeType: "image/png", base64: "abc" }] },
+]) {
+	test(`background image request: ${row.action}`, () => {
+		const body = buildBackgroundImageRequest({ prompt: row.prompt, referenceImages: row.referenceImages, responsesModel: "gpt-6-astra", imageModel: "gpt-image-2" });
+		assert.equal(body.model, "gpt-6-astra");
+		assert.deepEqual(body.tools, [{ type: "image_generation", model: "gpt-image-2", output_format: "png", action: row.action }]);
+		assert.deepEqual(body.tool_choice, { type: "image_generation" });
+		if (row.action === "edit") {
+			const input = body.input as Array<{ content: Array<{ type: string; text?: string; image_url?: string }> }>;
+			assert.ok(input[0].content[0].text?.includes(row.prompt));
+			assert.equal(input[0].content[1].type, "input_image");
+			assert.equal(input[0].content[1].image_url, "data:image/png;base64,abc");
+		}
+	});
 }
-
-test("parseImageGenCommandArgs separates @reference images from prompt", () => {
-	assert.deepEqual(parseImageGenCommandArgs("make it green @icon.png 'with soft shadows' @refs/logo.webp"), {
-		prompt: "make it green with soft shadows",
-		imagePaths: ["icon.png", "refs/logo.webp"],
-	});
-});
-
-test("parseImageGenCommandArgs treats pasted image paths as references", () => {
-	assert.deepEqual(parseImageGenCommandArgs("make this button green /tmp/pi-clipboard-abc.png"), {
-		prompt: "make this button green",
-		imagePaths: ["/tmp/pi-clipboard-abc.png"],
-	});
-	assert.deepEqual(parseImageGenCommandArgs("edit file:///tmp/reference.webp."), {
-		prompt: "edit",
-		imagePaths: ["/tmp/reference.webp"],
-	});
-});
-
-test("buildBackgroundImageRequest requests generate without reference images", () => {
-	const body = buildBackgroundImageRequest({ prompt: "draw a red apple", referenceImages: [], responsesModel: "gpt-6-astra", imageModel: "gpt-image-2" });
-	assert.equal(body.model, "gpt-6-astra");
-	assert.deepEqual(body.tools, [{ type: "image_generation", model: "gpt-image-2", output_format: "png", action: "generate" }]);
-	assert.deepEqual(body.tool_choice, { type: "image_generation" });
-});
-
-test("buildBackgroundImageRequest requests edit with reference images", () => {
-	const body = buildBackgroundImageRequest({
-		prompt: "change icon to green",
-		referenceImages: [{ path: "/tmp/icon.png", mimeType: "image/png", base64: "abc" }],
-		responsesModel: "gpt-6-astra",
-		imageModel: "gpt-image-2",
-	});
-	assert.deepEqual(body.tools, [{ type: "image_generation", model: "gpt-image-2", output_format: "png", action: "edit" }]);
-	const input = body.input as Array<{ content: Array<{ type: string; text?: string; image_url?: string }> }>;
-	assert.equal(input[0].content[0].text, "Edit the provided image(s): change icon to green");
-	assert.equal(input[0].content[1].type, "input_image");
-	assert.equal(input[0].content[1].image_url, "data:image/png;base64,abc");
-});
-
-test("selectCodexImageModel prefers current image-capable Codex model and registry fallback", () => {
-	const current = { provider: "openai-codex", id: "gpt-5.4", input: ["text", "image"] };
-	assert.equal(selectCodexImageModel(current, undefined), current);
-	const fallback = { provider: "openai-codex", id: "gpt-6-astra", input: ["text", "image"] };
-	assert.equal(selectCodexImageModel({ provider: "anthropic", id: "claude", input: ["text", "image"] }, { getAll: () => [fallback] }), fallback);
-	assert.equal(selectCodexImageModel({ provider: "anthropic", id: "claude", input: ["text", "image"] }, { getAvailable: () => [fallback] }), fallback);
-	assert.equal(selectCodexImageModel({ provider: "openai-codex", id: "text-only", input: ["text"] }, { find: (_provider, _id) => fallback }), fallback);
-	assert.equal(selectCodexImageModel({ provider: "openai-codex", id: "text-only", input: ["text"] }, { getAll: () => [{ provider: "openai-codex", id: "also-text-only", input: ["text"] }] }), undefined);
-});
-
-test("buildHeaders treats null provider headers as deletions, not the string \"null\"", () => {
-	const model = { headers: { "x-inherited": "keep", "x-dropped": "stale" } } as never;
-	const headers = buildHeaders(model, codexToken("acct-1"), { "x-dropped": null, "x-added": "value" });
-	assert.equal(headers.get("x-dropped"), null);
-	assert.equal(headers.get("x-inherited"), "keep");
-	assert.equal(headers.get("x-added"), "value");
-});
-
-test("buildHeaders keeps the request's own pinned headers even when nulled by the provider", () => {
-	const model = { headers: {} } as never;
-	const headers = buildHeaders(model, codexToken("acct-2"), {
-		Authorization: null,
-		"chatgpt-account-id": null,
-		originator: null,
-		"content-type": null,
-	});
-	assert.equal(headers.get("authorization"), `Bearer ${codexToken("acct-2")}`);
-	assert.equal(headers.get("chatgpt-account-id"), "acct-2");
-	assert.equal(headers.get("originator"), "pi");
-	assert.equal(headers.get("content-type"), "application/json");
-});
-
-test("summarizeNonImageResponse includes status, error, and text output", () => {
-	const summary = summarizeNonImageResponse({
-		status: "failed",
-		error: { message: "image tool failed" },
-		output: [{ type: "message", content: [{ type: "output_text", text: "Could not generate that image." }] }],
-	});
-	assert.equal(summary, "No image was returned by Codex: status failed · image tool failed · Could not generate that image.");
-});

--- a/pi-extensions/pi-codex-minimal-tools/tests/capabilities.test.ts
+++ b/pi-extensions/pi-codex-minimal-tools/tests/capabilities.test.ts
@@ -1,52 +1,24 @@
 import assert from "node:assert/strict";
 import test from "node:test";
-import { computeNextActiveTools, computeToolCapabilities } from "../src/capabilities.js";
+import { computeNextActiveTools } from "../src/capabilities.js";
 import { DEFAULT_SETTINGS } from "../src/settings.js";
 
-const codex6Astra = { provider: "openai-codex", id: "gpt-6-astra", input: ["text", "image"] };
-const textOnlyCodex = { provider: "openai-codex", id: "text-only-codex", input: ["text"] };
-const openai = { provider: "openai", id: "gpt-6-astra", input: ["text", "image"] };
-
-test("capability gating follows provider and image support", () => {
-	const withViewImage = { ...DEFAULT_SETTINGS, viewImage: true };
-
-	const codex = computeToolCapabilities(codex6Astra, withViewImage);
-	assert.equal(codex.image_generation.enabled, true);
-	assert.equal(codex.view_image.enabled, true);
-	assert.equal(codex.apply_patch.enabled, true);
-
-	const textOnlyCodexCaps = computeToolCapabilities(textOnlyCodex, withViewImage);
-	assert.equal(textOnlyCodexCaps.image_generation.enabled, false);
-	assert.equal(textOnlyCodexCaps.view_image.enabled, false);
-	assert.equal(textOnlyCodexCaps.apply_patch.enabled, true);
-
-	const openaiCaps = computeToolCapabilities(openai, withViewImage);
-	assert.equal(openaiCaps.image_generation.enabled, false);
-	assert.equal(openaiCaps.view_image.enabled, true);
-	assert.equal(openaiCaps.apply_patch.enabled, true);
-
-	const nonOpenAiVision = computeToolCapabilities({ provider: "claude-bridge", id: "claude-opus-4-7", input: ["text", "image"] }, withViewImage);
-	assert.equal(nonOpenAiVision.image_generation.enabled, false);
-	assert.equal(nonOpenAiVision.view_image.enabled, false);
-	assert.equal(nonOpenAiVision.apply_patch.enabled, false);
-
-	const defaults = computeToolCapabilities(codex6Astra, DEFAULT_SETTINGS);
-	assert.equal(defaults.view_image.enabled, false, "view_image is gated off by default");
-});
-
-test("active tool sync preserves native tools and only manages package tools", () => {
-	const current = ["read", "grep", "find", "ls", "bash", "edit", "write", "old_custom"];
-	const next = computeNextActiveTools(current, codex6Astra, { ...DEFAULT_SETTINGS, viewImage: true });
-	for (const nativeTool of ["read", "grep", "find", "ls", "bash", "edit", "write"]) assert.ok(next.activeTools.includes(nativeTool));
-	assert.ok(next.activeTools.includes("old_custom"));
-	assert.ok(next.activeTools.includes("image_generation"));
-	assert.ok(next.activeTools.includes("view_image"));
-	assert.ok(next.activeTools.includes("apply_patch"));
-});
-
-test("unsupported package tools are removed without touching native tools", () => {
-	const current = ["read", "edit", "write", "image_generation", "view_image", "apply_patch"];
-	const next = computeNextActiveTools(current, { provider: "anthropic", id: "claude", input: ["text"] }, { ...DEFAULT_SETTINGS, viewImage: true });
-	assert.deepEqual(next.activeTools, ["read", "edit", "write"]);
-	assert.deepEqual(next.removed.sort(), ["apply_patch", "image_generation", "view_image"].sort());
-});
+for (const row of [
+	{
+		provider: "openai-codex", input: ["text", "image"],
+		current: ["read", "grep", "find", "ls", "bash", "edit", "write", "old_custom"],
+		active: ["read", "grep", "find", "ls", "bash", "edit", "write", "old_custom", "image_generation", "view_image", "apply_patch"],
+		removed: [],
+	},
+	{
+		provider: "anthropic", input: ["text"],
+		current: ["read", "edit", "write", "image_generation", "view_image", "apply_patch"],
+		active: ["read", "edit", "write"], removed: ["apply_patch", "image_generation", "view_image"],
+	},
+]) {
+	test(`active tool synchronization: ${row.provider}`, () => {
+		const next = computeNextActiveTools(row.current, { provider: row.provider, id: "model", input: row.input }, { ...DEFAULT_SETTINGS, viewImage: true });
+		assert.deepEqual([...next.activeTools].sort(), [...row.active].sort());
+		assert.deepEqual([...next.removed].sort(), [...row.removed].sort());
+	});
+}

--- a/pi-extensions/pi-codex-minimal-tools/tests/empty-tool-result.test.ts
+++ b/pi-extensions/pi-codex-minimal-tools/tests/empty-tool-result.test.ts
@@ -1,0 +1,16 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { convertResponsesMessages } from "../src/providers/openai-responses-shared.js";
+import { model } from "./helpers/responses.js";
+
+test("empty tool results emit a non-empty function output", () => {
+	const messages = convertResponsesMessages(model, {
+		messages: [{ role: "toolResult", toolCallId: "call_1|fc_1", toolName: "noop", content: [], isError: false, timestamp: Date.now() }],
+	} as any, new Set(["openai-codex"]));
+	assert.equal(messages.length, 1);
+	const message = messages[0] as { type: string; call_id: string; output: string };
+	assert.equal(message.type, "function_call_output");
+	assert.equal(message.call_id, "call_1");
+	assert.equal(typeof message.output, "string");
+	assert.ok(message.output.length > 0);
+});

--- a/pi-extensions/pi-codex-minimal-tools/tests/helpers/provider.ts
+++ b/pi-extensions/pi-codex-minimal-tools/tests/helpers/provider.ts
@@ -1,0 +1,104 @@
+import type { AssistantMessage, AssistantMessageEventStream } from "@earendil-works/pi-ai";
+import assert from "node:assert/strict";
+import { setImmediate } from "node:timers/promises";
+import type { TestContext } from "node:test";
+import { registerOpenAICodexCustomProvider } from "../../src/provider-shim.js";
+import { environment, noProxyEnvironment, world } from "./world.js";
+
+let providerCwd: string | undefined;
+
+/** Restore transport globals and isolate settings for each provider case. */
+export function providerWorld(t: Pick<TestContext, "after">) {
+	const fixture = world(t);
+	providerCwd = fixture.cwd;
+	t.after(() => { providerCwd = undefined; });
+	environment(t, { ...noProxyEnvironment, PI_CODING_AGENT_DIR: fixture.agent });
+	const fetch = globalThis.fetch;
+	t.after(() => { globalThis.fetch = fetch; });
+	return fixture;
+}
+
+/** Advance the test clock only after pending request promises have settled. */
+export async function finishRetries<T>(t: TestContext, pending: Promise<T>): Promise<T> {
+	let settled = false;
+	const observed = pending.finally(() => { settled = true; });
+	for (let step = 0; step < 12 && !settled; step++) {
+		await setImmediate();
+		if (!settled) t.mock.timers.tick(10_000);
+	}
+	assert.equal(settled, true, "provider did not settle under the controlled retry clock");
+	return observed;
+}
+
+function codexJwt(): string {
+	const payload = Buffer.from(JSON.stringify({ "https://api.openai.com/auth": { chatgpt_account_id: "acct_test" } })).toString("base64");
+	return `header.${payload}.signature`;
+}
+
+type Provider = { streamSimple(model: unknown, context: unknown, options: unknown): AssistantMessageEventStream };
+
+function createCodexProvider(): Provider {
+	let provider: Provider | undefined;
+	const pi = {
+		registerProvider(name: string, value: Provider) {
+			assert.equal(name, "openai-codex");
+			provider = value;
+		},
+		on() {},
+		registerMessageRenderer() {},
+	};
+	registerOpenAICodexCustomProvider(pi as never, { getCurrentCwd: () => { assert.ok(providerCwd); return providerCwd; } });
+	assert.ok(provider);
+	return provider;
+}
+
+export async function runCodexProvider(
+	streamOptions: Record<string, unknown> = {},
+	modelOverrides: Record<string, unknown> = {},
+	contextOverrides: Record<string, unknown> = {},
+): Promise<AssistantMessage> {
+	const provider = createCodexProvider();
+	const stream = provider.streamSimple(
+		{
+			provider: "openai-codex",
+			api: "openai-codex-responses",
+			id: "gpt-6-astra",
+			baseUrl: "https://example.test/backend-api",
+			headers: {},
+			input: ["text"],
+			reasoning: false,
+			cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+			...modelOverrides,
+		},
+		{
+			systemPrompt: "",
+			messages: [{ role: "user", content: "hello" }],
+			tools: [],
+			...contextOverrides,
+		},
+		{ apiKey: codexJwt(), transport: "sse", ...streamOptions },
+	);
+	return stream.result();
+}
+
+export function errorResponse(status: number, body: unknown, statusText = "Error"): Response {
+	return new Response(typeof body === "string" ? body : JSON.stringify(body), { status, statusText });
+}
+
+export const completedEvent = {
+	type: "response.completed",
+	response: {
+		id: "resp_ok",
+		status: "completed",
+		usage: { input_tokens: 0, output_tokens: 0, total_tokens: 0, input_tokens_details: { cached_tokens: 0 } },
+	},
+};
+
+export function sseResponse(body: string): Response {
+	return new Response(body, { status: 200, headers: { "content-type": "text/event-stream" } });
+}
+
+export function successSseResponse(): Response {
+	return sseResponse(`data: ${JSON.stringify(completedEvent)}\n\n`);
+}
+

--- a/pi-extensions/pi-codex-minimal-tools/tests/helpers/responses.ts
+++ b/pi-extensions/pi-codex-minimal-tools/tests/helpers/responses.ts
@@ -1,0 +1,21 @@
+import type { ResponseStreamEvent } from "openai/resources/responses/responses.js";
+import type { AssistantMessage, Model } from "@earendil-works/pi-ai";
+
+export async function* asAsyncIterable(events: unknown[]) {
+	for (const event of events) yield event as ResponseStreamEvent;
+}
+
+export function createAssistantOutput(): AssistantMessage {
+	return {
+		role: "assistant", content: [], api: "openai-codex-responses",
+		provider: "openai-codex", model: "gpt-6-astra",
+		usage: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, totalTokens: 0, cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 } },
+		stopReason: "stop", timestamp: 0,
+	};
+}
+
+export const model: Model<"openai-codex-responses"> = {
+	provider: "openai-codex", api: "openai-codex-responses", id: "gpt-6-astra", name: "GPT-6 Astra",
+	baseUrl: "https://example.test/backend-api", input: ["text", "image"], reasoning: true,
+	cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 }, contextWindow: 272000, maxTokens: 128000,
+};

--- a/pi-extensions/pi-codex-minimal-tools/tests/helpers/world.ts
+++ b/pi-extensions/pi-codex-minimal-tools/tests/helpers/world.ts
@@ -1,0 +1,35 @@
+import { mkdirSync, mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import type { TestContext } from "node:test";
+
+/** Own the project and settings directories until the case completes. */
+export function world(t: Pick<TestContext, "after">) {
+	const root = mkdtempSync(join(tmpdir(), "pi-codex-test-"));
+	const cwd = join(root, "project");
+	const agent = join(root, "agent");
+	mkdirSync(join(cwd, ".pi"), { recursive: true });
+	mkdirSync(agent);
+	t.after(() => rmSync(root, { recursive: true, force: true }));
+	return { root, cwd, agent };
+}
+
+/** Restore the complete environment change, including missing variables. */
+export function environment(t: Pick<TestContext, "after">, values: Record<string, string | undefined>) {
+	const previous = Object.fromEntries(Object.keys(values).map((key) => [key, process.env[key]]));
+	const apply = (entries: Record<string, string | undefined>) => {
+		for (const [key, value] of Object.entries(entries)) {
+			if (value === undefined) delete process.env[key];
+			else process.env[key] = value;
+		}
+	};
+	t.after(() => apply(previous));
+	apply(values);
+}
+
+/** Transport fixtures do not create dispatchers from the developer's proxy. */
+export const noProxyEnvironment = {
+	HTTP_PROXY: undefined, http_proxy: undefined, HTTPS_PROXY: undefined,
+	https_proxy: undefined, ALL_PROXY: undefined, all_proxy: undefined,
+	NO_PROXY: undefined, no_proxy: undefined,
+};

--- a/pi-extensions/pi-codex-minimal-tools/tests/http-status-prefix.test.ts
+++ b/pi-extensions/pi-codex-minimal-tools/tests/http-status-prefix.test.ts
@@ -1,0 +1,11 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { withHttpStatusPrefix } from "../src/provider-shim.js";
+
+for (const row of [
+	{ status: 503, message: "upstream-token", expected: "HTTP 503: upstream-token" },
+	{ status: 429, message: "HTTP 429: upstream-token", expected: "HTTP 429: upstream-token" },
+	{ status: 503, message: "HTTP 503 upstream-token", expected: "HTTP 503 upstream-token" },
+]) {
+	test(`HTTP status prefix: ${row.message}`, () => assert.equal(withHttpStatusPrefix(row.status, row.message), row.expected));
+}

--- a/pi-extensions/pi-codex-minimal-tools/tests/image-command-args.test.ts
+++ b/pi-extensions/pi-codex-minimal-tools/tests/image-command-args.test.ts
@@ -1,0 +1,13 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { parseImageGenCommandArgs } from "../src/background-image-generation.js";
+
+for (const row of [
+	{ input: "make it green @icon.png 'with soft shadows' @refs/logo.webp", prompt: "make it green with soft shadows", imagePaths: ["icon.png", "refs/logo.webp"] },
+	{ input: "make this button green /tmp/pi-clipboard-abc.png", prompt: "make this button green", imagePaths: ["/tmp/pi-clipboard-abc.png"] },
+	{ input: "edit file:///tmp/reference.webp.", prompt: "edit", imagePaths: ["/tmp/reference.webp"] },
+]) {
+	test(`image command arguments: ${row.input}`, () => {
+		assert.deepEqual(parseImageGenCommandArgs(row.input), { prompt: row.prompt, imagePaths: row.imagePaths });
+	});
+}

--- a/pi-extensions/pi-codex-minimal-tools/tests/image-generation.test.ts
+++ b/pi-extensions/pi-codex-minimal-tools/tests/image-generation.test.ts
@@ -1,20 +1,16 @@
 import assert from "node:assert/strict";
-import { mkdtempSync } from "node:fs";
-import { tmpdir } from "node:os";
-import { join } from "node:path";
 import test from "node:test";
 import { directImageGeneration } from "../src/tools/image-generation.js";
 import { DEFAULT_SETTINGS } from "../src/settings.js";
 
-function tempDir(): string {
-	return mkdtempSync(join(tmpdir(), "pi-image-generation-"));
-}
+import { world } from "./helpers/world.js";
 
-test("directImageGeneration omits deprecated response_format and passes abort signal", async () => {
+test("directImageGeneration omits deprecated response_format and passes abort signal", async (t) => {
+	const { cwd } = world(t);
 	const previousKey = process.env.OPENAI_API_KEY;
 	const previousFetch = globalThis.fetch;
 	const controller = new AbortController();
-	let body: any;
+	let body: Record<string, unknown> = {};
 	let seenSignal: AbortSignal | undefined;
 	process.env.OPENAI_API_KEY = "test";
 	globalThis.fetch = (async (_url: string | URL | Request, init?: RequestInit) => {
@@ -23,7 +19,7 @@ test("directImageGeneration omits deprecated response_format and passes abort si
 		return new Response(JSON.stringify({ data: [{ b64_json: Buffer.from("png").toString("base64") }] }), { status: 200, headers: { "content-type": "application/json" } });
 	}) as typeof fetch;
 	try {
-		await directImageGeneration({ prompt: "test" }, tempDir(), { ...DEFAULT_SETTINGS, directImageApiFallback: true }, controller.signal);
+		await directImageGeneration({ prompt: "test" }, cwd, { ...DEFAULT_SETTINGS, directImageApiFallback: true }, controller.signal);
 		assert.equal("response_format" in body, false);
 		assert.equal(seenSignal, controller.signal);
 	} finally {

--- a/pi-extensions/pi-codex-minimal-tools/tests/image-model-selection.test.ts
+++ b/pi-extensions/pi-codex-minimal-tools/tests/image-model-selection.test.ts
@@ -1,0 +1,17 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { selectCodexImageModel } from "../src/background-image-generation.js";
+
+const current = { provider: "openai-codex", id: "gpt-5.4", input: ["text", "image"] };
+const fallback = { provider: "openai-codex", id: "gpt-6-astra", input: ["text", "image"] };
+const anthropic = { provider: "anthropic", id: "claude", input: ["text", "image"] };
+const textOnly = { provider: "openai-codex", id: "text-only", input: ["text"] };
+for (const row of [
+	{ name: "current", current, registry: undefined, expected: current },
+	{ name: "getAll", current: anthropic, registry: { getAll: () => [fallback] }, expected: fallback },
+	{ name: "getAvailable", current: anthropic, registry: { getAvailable: () => [fallback] }, expected: fallback },
+	{ name: "find", current: textOnly, registry: { find: () => fallback }, expected: fallback },
+	{ name: "no image model", current: textOnly, registry: { getAll: () => [textOnly] }, expected: undefined },
+]) {
+	test(`image model selection: ${row.name}`, () => assert.equal(selectCodexImageModel(row.current, row.registry), row.expected));
+}

--- a/pi-extensions/pi-codex-minimal-tools/tests/image-request-headers.test.ts
+++ b/pi-extensions/pi-codex-minimal-tools/tests/image-request-headers.test.ts
@@ -1,0 +1,15 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { buildHeaders } from "../src/background-image-generation.js";
+
+const token = `header.${Buffer.from(JSON.stringify({ "https://api.openai.com/auth": { chatgpt_account_id: "acct-1" } })).toString("base64")}.signature`;
+const rows: Array<{ name: string; model: Record<string, string>; overrides: Record<string, string | null>; expected: Record<string, string | null> }> = [
+	{ name: "nullable overrides", model: { "x-inherited": "keep", "x-dropped": "stale" }, overrides: { "x-dropped": null, "x-added": "value" }, expected: { "x-dropped": null, "x-inherited": "keep", "x-added": "value" } },
+	{ name: "pinned request headers", model: {}, overrides: { Authorization: null, "chatgpt-account-id": null, originator: null, "content-type": null }, expected: { authorization: `Bearer ${token}`, "chatgpt-account-id": "acct-1", originator: "pi", "content-type": "application/json" } },
+];
+for (const row of rows) {
+	test(`image request headers: ${row.name}`, () => {
+		const headers = buildHeaders({ headers: row.model } as never, token, row.overrides);
+		assert.deepEqual(Object.fromEntries(Object.keys(row.expected).map((key) => [key, headers.get(key)])), row.expected);
+	});
+}

--- a/pi-extensions/pi-codex-minimal-tools/tests/image-response-summary.test.ts
+++ b/pi-extensions/pi-codex-minimal-tools/tests/image-response-summary.test.ts
@@ -1,0 +1,9 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { summarizeNonImageResponse } from "../src/background-image-generation.js";
+
+test("non-image response summary retains upstream status, error and text", () => {
+	const response = { status: "failed", error: { message: "upstream-error-token" }, output: [{ type: "message", content: [{ type: "output_text", text: "upstream-output-token" }] }] };
+	const summary = summarizeNonImageResponse(response);
+	for (const value of [response.status, response.error.message, response.output[0].content[0].text]) assert.ok(summary.includes(value), value);
+});

--- a/pi-extensions/pi-codex-minimal-tools/tests/images-util.test.ts
+++ b/pi-extensions/pi-codex-minimal-tools/tests/images-util.test.ts
@@ -1,16 +1,14 @@
 import assert from "node:assert/strict";
-import { existsSync, mkdtempSync } from "node:fs";
-import { tmpdir } from "node:os";
-import { basename, join } from "node:path";
+import { existsSync } from "node:fs";
+import { basename } from "node:path";
 import test from "node:test";
 import { saveBase64Image } from "../src/utils/images.js";
 
-function tempDir(): string {
-	return mkdtempSync(join(tmpdir(), "pi-images-util-"));
-}
+import { world } from "./helpers/world.js";
 
-test("saveBase64Image uses unique filenames and writes format-specific latest path", async () => {
-	const cwd = tempDir();
+test("saveBase64Image uses unique filenames and writes format-specific latest path", async (t) => {
+	const { cwd } = world(t);
+	t.mock.timers.enable({ apis: ["Date"], now: 0 });
 	const settings = { imageOutputDir: "images" };
 	const base64 = Buffer.from("image").toString("base64");
 	const first = await saveBase64Image({ base64, callId: "call", cwd, format: "jpeg", responseId: "resp", settings });

--- a/pi-extensions/pi-codex-minimal-tools/tests/native-image-persistence.test.ts
+++ b/pi-extensions/pi-codex-minimal-tools/tests/native-image-persistence.test.ts
@@ -1,0 +1,18 @@
+import assert from "node:assert/strict";
+import fs from "node:fs/promises";
+import path from "node:path";
+import test from "node:test";
+import { saveOpenAICodexGeneratedImage } from "../src/provider-shim.js";
+import { environment, world } from "./helpers/world.js";
+
+test("saveOpenAICodexGeneratedImage writes generated images under the configured default output dir", async (t) => {
+	const { cwd, agent } = world(t);
+	environment(t, { PI_CODING_AGENT_DIR: agent });
+	const encoded = Buffer.from("png-bytes").toString("base64");
+		const saved = await saveOpenAICodexGeneratedImage(cwd, { responseId: "resp_123", callId: "ig_456", result: encoded, outputFormat: "png", imageModel: "gpt-image-2" });
+		assert.match(saved.relativePath, /^\.pi[/\\]openai-codex-images[/\\][\dTZ-]+-[a-f0-9]{8}\.png$/);
+		assert.equal(saved.latestRelativePath, path.join(".pi", "openai-codex-images", "latest.png"));
+		assert.equal(saved.imageModel, "gpt-image-2");
+		assert.deepEqual(await fs.readFile(saved.absolutePath), Buffer.from("png-bytes"));
+		assert.deepEqual(await fs.readFile(saved.latestAbsolutePath), Buffer.from("png-bytes"));
+});

--- a/pi-extensions/pi-codex-minimal-tools/tests/native-image-provider.test.ts
+++ b/pi-extensions/pi-codex-minimal-tools/tests/native-image-provider.test.ts
@@ -1,134 +1,36 @@
 import assert from "node:assert/strict";
-import fs from "node:fs/promises";
-import os from "node:os";
-import path from "node:path";
 import test from "node:test";
 import { convertResponsesMessages, processResponsesStream } from "../src/providers/openai-responses-shared.js";
-import { saveOpenAICodexGeneratedImage } from "../src/provider-shim.js";
+import { asAsyncIterable, createAssistantOutput, model } from "./helpers/responses.js";
 
-async function* asAsyncIterable(events: any[]) {
-	for (const event of events) yield event;
-}
+const completed = { type: "image_generation_call", id: "ig_123", status: "completed", result: Buffer.from("png-bytes").toString("base64"), revised_prompt: "A tiny red square icon" };
+const inProgress = { type: "image_generation_call", id: "ig_123", status: "in_progress" };
+const terminal = { type: "response.completed", response: { id: "resp_1", status: "completed", usage: { input_tokens: 0, output_tokens: 0, total_tokens: 0, input_tokens_details: { cached_tokens: 0 } } } };
 
-function createAssistantOutput() {
-	return {
-		role: "assistant",
-		content: [],
-		api: "openai-codex-responses",
-		provider: "openai-codex",
-		model: "gpt-6-astra",
-		usage: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, totalTokens: 0, cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 } },
-		stopReason: "stop",
-		timestamp: Date.now(),
-	} as any;
-}
-
-const model = {
-	provider: "openai-codex",
-	api: "openai-codex-responses",
-	id: "gpt-6-astra",
-	input: ["text", "image"],
-	reasoning: true,
-	cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
-} as any;
-
-test("processResponsesStream preserves completed image_generation_call items for later turns", async () => {
-	const output = createAssistantOutput();
-	const base64 = Buffer.from("png-bytes").toString("base64");
-	const rawImageItem = {
-		type: "image_generation_call",
-		id: "ig_123",
-		status: "completed",
-		result: base64,
-		output_format: "png",
-		revised_prompt: "A tiny red square icon",
-		quality: "high",
-	};
-	const expectedImageItem = {
-		type: "image_generation_call",
-		id: "ig_123",
-		status: "completed",
-		result: base64,
-		revised_prompt: "A tiny red square icon",
-	};
-
-	await processResponsesStream(
-		asAsyncIterable([
+// Image-call preservation is the image sub-surface of the Responses stream.
+for (const row of [
+	{
+		name: "completed item drops unsupported fields and survives transcript conversion",
+		events: [
 			{ type: "response.created", response: { id: "resp_1" } },
-			{ type: "response.output_item.added", output_index: 0, item: { type: "image_generation_call", id: "ig_123", status: "in_progress" } },
-			{ type: "response.output_item.done", output_index: 0, item: rawImageItem },
-			{ type: "response.completed", response: { id: "resp_1", status: "completed", usage: { input_tokens: 0, output_tokens: 0, total_tokens: 0, input_tokens_details: { cached_tokens: 0 } } } },
-		]),
-		output,
-		{ push() {} } as any,
-		model,
-	);
-
-	assert.deepEqual(output.content.filter((block: any) => block.type === "image_generation_call"), [
-		{ type: "image_generation_call", item: expectedImageItem },
-	]);
-	assert.deepEqual(convertResponsesMessages(model, { messages: [output] } as any, new Set(["openai-codex"])), [expectedImageItem]);
-});
-
-test("processResponsesStream ignores in-progress image_generation_call items", async () => {
-	const output = createAssistantOutput();
-	await processResponsesStream(
-		asAsyncIterable([
-			{ type: "response.created", response: { id: "resp_1" } },
-			{ type: "response.output_item.added", output_index: 0, item: { type: "image_generation_call", id: "ig_123", status: "in_progress" } },
-			{ type: "response.completed", response: { id: "resp_1", status: "completed", usage: { input_tokens: 0, output_tokens: 0, total_tokens: 0, input_tokens_details: { cached_tokens: 0 } } } },
-		]),
-		output,
-		{ push() {} } as any,
-		model,
-	);
-	assert.deepEqual(output.content.filter((block: any) => block.type === "image_generation_call"), []);
-});
-
-test("processResponsesStream preserves image_generation_call items from terminal response output", async () => {
-	const output = createAssistantOutput();
-	const base64 = Buffer.from("png-bytes").toString("base64");
-	const imageItem = {
-		type: "image_generation_call",
-		id: "ig_terminal",
-		status: "completed",
-		result: base64,
-		revised_prompt: "A terminal-output image",
-	};
-
-	await processResponsesStream(
-		asAsyncIterable([
-			{
-				type: "response.completed",
-				response: {
-					id: "resp_terminal",
-					status: "completed",
-					output: [imageItem],
-					usage: { input_tokens: 0, output_tokens: 0, total_tokens: 0, input_tokens_details: { cached_tokens: 0 } },
-				},
-			},
-		]),
-		output,
-		{ push() {} } as any,
-		model,
-	);
-
-	assert.deepEqual(output.content.filter((block: any) => block.type === "image_generation_call"), [
-		{ type: "image_generation_call", item: imageItem },
-	]);
-});
-
-test("saveOpenAICodexGeneratedImage writes generated images under the configured default output dir", async () => {
-	const cwd = await fs.mkdtemp(path.join(os.tmpdir(), "pi-codex-minimal-image-"));
-	const encoded = Buffer.from("png-bytes").toString("base64");
-	try {
-		const saved = await saveOpenAICodexGeneratedImage(cwd, { responseId: "resp_123", callId: "ig_456", result: encoded, outputFormat: "png", imageModel: "gpt-image-2" });
-		assert.match(saved.relativePath, /^\.pi[/\\]openai-codex-images[/\\][\dTZ-]+-[a-f0-9]{8}\.png$/);
-		assert.equal(saved.latestRelativePath, path.join(".pi", "openai-codex-images", "latest.png"));
-		assert.equal(saved.imageModel, "gpt-image-2");
-		assert.deepEqual(await fs.readFile(saved.absolutePath), Buffer.from("png-bytes"));
-		assert.deepEqual(await fs.readFile(saved.latestAbsolutePath), Buffer.from("png-bytes"));
-	} finally {
-		await fs.rm(cwd, { recursive: true, force: true });
-	}
-});
+			{ type: "response.output_item.added", output_index: 0, item: inProgress },
+			{ type: "response.output_item.done", output_index: 0, item: { ...completed, output_format: "png", quality: "high" } },
+			terminal,
+		], expected: [completed],
+	},
+	{
+		name: "in-progress item is not preserved",
+		events: [{ type: "response.created", response: { id: "resp_1" } }, { type: "response.output_item.added", output_index: 0, item: inProgress }, terminal], expected: [],
+	},
+	{
+		name: "terminal response output",
+		events: [{ ...terminal, response: { ...terminal.response, output: [completed] } }], expected: [completed],
+	},
+]) {
+	test(`image stream: ${row.name}`, async () => {
+		const output = createAssistantOutput();
+		await processResponsesStream(asAsyncIterable(row.events), output, { push() {} } as never, model);
+		assert.deepEqual((output.content as Array<{ type: string }>).filter((block) => block.type === "image_generation_call"), row.expected.map((item) => ({ type: "image_generation_call", item })));
+		assert.deepEqual(convertResponsesMessages(model, { messages: [output] }, new Set(["openai-codex"])), row.expected);
+	});
+}

--- a/pi-extensions/pi-codex-minimal-tools/tests/openai-model-detection.test.ts
+++ b/pi-extensions/pi-codex-minimal-tools/tests/openai-model-detection.test.ts
@@ -1,0 +1,13 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { hasOpenAiModelsLoaded } from "../src/activation.js";
+
+for (const row of [
+	{ name: "anthropic", ctx: { model: { provider: "anthropic", id: "claude" }, modelRegistry: { getAll: () => [] } }, expected: false },
+	{ name: "substring", ctx: { model: { provider: "notopenai", id: "claude" }, modelRegistry: { getAll: () => [] } }, expected: false },
+	{ name: "current", ctx: { model: { provider: "openai-codex", id: "gpt-6-astra" }, modelRegistry: { getAll: () => [] } }, expected: true },
+	{ name: "getAll", ctx: { modelRegistry: { getAll: () => [{ provider: "openai", id: "gpt-6-astra" }] } }, expected: true },
+	{ name: "find", ctx: { modelRegistry: { find: (provider: string, id: string) => provider === "openai" && id === "gpt-5.2" ? { provider, id } : undefined } }, expected: true },
+]) {
+	test(`OpenAI model detection: ${row.name}`, () => assert.equal(hasOpenAiModelsLoaded(row.ctx), row.expected));
+}

--- a/pi-extensions/pi-codex-minimal-tools/tests/patch-parser.test.ts
+++ b/pi-extensions/pi-codex-minimal-tools/tests/patch-parser.test.ts
@@ -1,0 +1,19 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { parseApplyPatch } from "../src/patch/parser.js";
+
+test("parseApplyPatch parses add/update/delete actions", () => {
+	const parsed = parseApplyPatch(`*** Begin Patch
+*** Add File: a.txt
++hello
+*** Update File: b.txt
+@@
+-old
++new
+*** Delete File: c.txt
+*** End Patch`);
+	assert.equal(parsed.actions.length, 3);
+	assert.equal(parsed.actions[0]?.kind, "add");
+	assert.equal(parsed.actions[1]?.kind, "update");
+	assert.equal(parsed.actions[2]?.kind, "delete");
+});

--- a/pi-extensions/pi-codex-minimal-tools/tests/previous-response-error.test.ts
+++ b/pi-extensions/pi-codex-minimal-tools/tests/previous-response-error.test.ts
@@ -1,0 +1,11 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { isPreviousResponseNotFoundError } from "../src/provider-shim.js";
+
+for (const row of [
+	{ name: "code", error: { code: "previous_response_not_found" }, expected: true },
+	{ name: "message", error: new Error("Codex error: previous_response_not_found"), expected: true },
+	{ name: "unrelated", error: new Error("other failure"), expected: false },
+]) {
+	test(`missing previous response: ${row.name}`, () => assert.equal(isPreviousResponseNotFoundError(row.error), row.expected));
+}

--- a/pi-extensions/pi-codex-minimal-tools/tests/prompt-cache-key.test.ts
+++ b/pi-extensions/pi-codex-minimal-tools/tests/prompt-cache-key.test.ts
@@ -1,0 +1,10 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { clampOpenAIPromptCacheKey } from "../src/provider-shim.js";
+
+test("Codex prompt cache keys clamp to 64 Unicode characters", () => {
+	const key = `${"a".repeat(63)}😀suffix`;
+	const clamped = clampOpenAIPromptCacheKey(key);
+	assert.equal(Array.from(clamped ?? "").length, 64);
+	assert.equal(clamped, `${"a".repeat(63)}😀`);
+});

--- a/pi-extensions/pi-codex-minimal-tools/tests/provider-grammar-settlement.test.ts
+++ b/pi-extensions/pi-codex-minimal-tools/tests/provider-grammar-settlement.test.ts
@@ -1,0 +1,24 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { providerWorld, runCodexProvider, successSseResponse } from "./helpers/provider.js";
+
+test("invalid grammar schema settles provider stream as an error", async (t) => {
+	providerWorld(t);
+	globalThis.fetch = async () => successSseResponse();
+	const result = await runCodexProvider(
+		{},
+		{ compat: { supportsOpenAIGrammarTools: true } },
+		{
+			tools: [{
+				name: "bad_grammar",
+				description: "Bad grammar",
+				parameters: { type: "object", properties: { a: { type: "string" }, b: { type: "string" } }, required: ["a", "b"] },
+				constrainedSampling: { type: "grammar", variants: { openai_lark: "start: /.+/" } },
+			}],
+		},
+	);
+
+	assert.equal(result.stopReason, "error");
+	assert.equal(result.errorMessage?.split("\n")[0], "grammar_schema=bad_grammar");
+});
+

--- a/pi-extensions/pi-codex-minimal-tools/tests/provider-header-deadline.test.ts
+++ b/pi-extensions/pi-codex-minimal-tools/tests/provider-header-deadline.test.ts
@@ -1,0 +1,35 @@
+import assert from "node:assert/strict";
+import { setImmediate } from "node:timers/promises";
+import test from "node:test";
+import { finishRetries, providerWorld, runCodexProvider } from "./helpers/provider.js";
+
+test("provider applies the configured response-header deadline", async (t) => {
+	providerWorld(t);
+	t.mock.timers.enable({ apis: ["setTimeout"] });
+	const signals: AbortSignal[] = [];
+	globalThis.fetch = (_url, init) => new Promise<Response>((_resolve, reject) => {
+		assert.ok(init?.signal);
+		signals.push(init.signal);
+		init.signal.addEventListener("abort", () => reject(init.signal?.reason), { once: true });
+	});
+	const pending = runCodexProvider({ timeoutMs: 45_000 });
+	await setImmediate();
+	assert.equal(signals.length, 1);
+	t.mock.timers.tick(44_999);
+	await setImmediate();
+	assert.equal(signals[0].aborted, false);
+	t.mock.timers.tick(1);
+	await setImmediate();
+	assert.equal(signals[0].aborted, true);
+	// Each subsequent retry also owns its own response-header deadline.
+	let settled = false;
+	void pending.then(() => { settled = true; });
+	for (let step = 0; step < 12 && !settled; step++) {
+		t.mock.timers.tick(45_000);
+		await setImmediate();
+	}
+	assert.equal(settled, true);
+	const result = await pending;
+	assert.equal(result.stopReason, "error");
+	assert.equal(result.errorMessage?.split("\n")[0], "response_header_timeout_ms=45000");
+});

--- a/pi-extensions/pi-codex-minimal-tools/tests/provider-header-deadline.test.ts
+++ b/pi-extensions/pi-codex-minimal-tools/tests/provider-header-deadline.test.ts
@@ -1,7 +1,7 @@
 import assert from "node:assert/strict";
 import { setImmediate } from "node:timers/promises";
 import test from "node:test";
-import { finishRetries, providerWorld, runCodexProvider } from "./helpers/provider.js";
+import { providerWorld, runCodexProvider } from "./helpers/provider.js";
 
 test("provider applies the configured response-header deadline", async (t) => {
 	providerWorld(t);

--- a/pi-extensions/pi-codex-minimal-tools/tests/provider-retry-classification.test.ts
+++ b/pi-extensions/pi-codex-minimal-tools/tests/provider-retry-classification.test.ts
@@ -1,0 +1,22 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { isRetryableError } from "../src/provider-shim.js";
+
+for (const row of [
+	{ status: 524, message: "Cloudflare timeout", expected: true },
+	{ status: 400, message: "grpc ResourceExhausted", expected: true },
+	{ status: 400, message: "socket connection was closed unexpectedly", expected: true },
+	{ status: 400, message: "please retry your request", expected: true },
+	{ status: 400, message: "you can retry your request", expected: true },
+	{ status: 400, message: "Service unavailable", expected: true },
+	{ status: 400, message: "server error", expected: true },
+	{ status: 400, message: "Internal server error", expected: true },
+	{ status: 400, message: "HTTP 503", expected: true },
+	{ status: 429, message: "insufficient_quota", expected: false },
+	{ status: 429, message: "ResourceExhausted: quota exceeded", expected: false },
+	{ status: 400, message: "Do not retry the request: invalid schema", expected: false },
+	{ status: 400, message: "billing account disabled", expected: false },
+	{ status: 400, message: "invalid schema", expected: false },
+]) {
+	test(`retry classification: ${row.status}/${row.message}`, () => assert.equal(isRetryableError(row.status, row.message), row.expected));
+}

--- a/pi-extensions/pi-codex-minimal-tools/tests/provider-shim-http-status.test.ts
+++ b/pi-extensions/pi-codex-minimal-tools/tests/provider-shim-http-status.test.ts
@@ -1,250 +1,32 @@
 import assert from "node:assert/strict";
-import test, { afterEach } from "node:test";
-import { zstdDecompressSync } from "node:zlib";
-import { registerOpenAICodexCustomProvider, withHttpStatusPrefix } from "../src/provider-shim.js";
+import test from "node:test";
+import { errorResponse, finishRetries, providerWorld, runCodexProvider, successSseResponse } from "./helpers/provider.js";
 
-const originalFetch = globalThis.fetch;
-const originalSetTimeout = globalThis.setTimeout;
-
-interface FetchFactory {
-	(): Response;
-}
-
-afterEach(() => {
-	globalThis.fetch = originalFetch;
-	globalThis.setTimeout = originalSetTimeout;
-});
-
-function installImmediateRetryTimers(): void {
-	globalThis.setTimeout = ((callback: TimerHandler, delay?: number, ...args: unknown[]) => {
-		if (delay === 20_000) return 0 as unknown as ReturnType<typeof setTimeout>;
-		queueMicrotask(() => {
-			if (typeof callback === "function") {
-				callback(...args);
-			}
-		});
-		return 0 as unknown as ReturnType<typeof setTimeout>;
-	}) as unknown as typeof setTimeout;
-}
-
-function codexJwt(): string {
-	const payload = Buffer.from(JSON.stringify({ "https://api.openai.com/auth": { chatgpt_account_id: "acct_test" } })).toString("base64");
-	return `header.${payload}.signature`;
-}
-
-function createCodexProvider(): any {
-	let provider: any;
-	const pi = {
-		registerProvider(name: string, value: any) {
-			assert.equal(name, "openai-codex");
-			provider = value;
-		},
-		on() {},
-		registerMessageRenderer() {},
-	};
-	registerOpenAICodexCustomProvider(pi as any, { getCurrentCwd: () => process.cwd() });
-	assert.ok(provider);
-	return provider;
-}
-
-function mockFetch(factories: FetchFactory[]): () => number {
-	let calls = 0;
-	globalThis.fetch = (async () => {
-		const factory = factories[Math.min(calls, factories.length - 1)];
-		calls++;
-		return factory();
-	}) as typeof fetch;
-	return () => calls;
-}
-
-async function runCodexProvider(
-	streamOptions: Record<string, unknown> = {},
-	modelOverrides: Record<string, unknown> = {},
-	contextOverrides: Record<string, unknown> = {},
-): Promise<any> {
-	const provider = createCodexProvider();
-	const stream = provider.streamSimple(
-		{
-			provider: "openai-codex",
-			api: "openai-codex-responses",
-			id: "gpt-6-astra",
-			baseUrl: "https://example.test/backend-api",
-			headers: {},
-			input: ["text"],
-			reasoning: false,
-			cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
-			...modelOverrides,
-		},
-		{
-			systemPrompt: "",
-			messages: [{ role: "user", content: "hello" }],
-			tools: [],
-			...contextOverrides,
-		},
-		{ apiKey: codexJwt(), transport: "sse", ...streamOptions },
-	);
-	return stream.result();
-}
-
-function errorResponse(status: number, body: unknown, statusText = "Error"): Response {
-	return new Response(typeof body === "string" ? body : JSON.stringify(body), { status, statusText });
-}
-
-const completedEvent = {
-	type: "response.completed",
-	response: {
-		id: "resp_ok",
-		status: "completed",
-		usage: { input_tokens: 0, output_tokens: 0, total_tokens: 0, input_tokens_details: { cached_tokens: 0 } },
-	},
-};
-
-function sseResponse(body: string): Response {
-	return new Response(body, { status: 200, headers: { "content-type": "text/event-stream" } });
-}
-
-function successSseResponse(): Response {
-	return sseResponse(`data: ${JSON.stringify(completedEvent)}\n\n`);
-}
-
-// The Codex backend can close the stream right after the terminal event
-// without the blank line that ends an SSE frame. EOF ends that frame.
-const unterminatedTerminalFrames: Array<{ name: string; body: string }> = [
-	{ name: "LF-terminated final line", body: `data: ${JSON.stringify(completedEvent)}\n` },
-	{ name: "CRLF-terminated final line", body: `data: ${JSON.stringify(completedEvent)}\r\n` },
-	{ name: "no line terminator", body: `data: ${JSON.stringify(completedEvent)}` },
-];
-
-for (const frame of unterminatedTerminalFrames) {
-	test(`SSE terminal event without a trailing blank line completes the stream (${frame.name})`, async () => {
-		globalThis.fetch = (async () => sseResponse(frame.body)) as typeof fetch;
-
-		const result = await runCodexProvider();
-
-		assert.equal(result.errorMessage, undefined);
-		assert.equal(result.stopReason, "stop");
+for (const row of [
+	{ name: "terminal quota", status: 429, code: "usage_limit_reached", message: "upstream-quota", calls: 1, stopReason: "error", success: false },
+	{ name: "invalid request", status: 400, code: "invalid_request", message: "Do not retry the request: invalid schema", calls: 1, stopReason: "error", success: false },
+	{ name: "transient failure exhausted", status: 503, code: "server_error", message: "upstream-unavailable", calls: 4, stopReason: "error", success: false },
+	{ name: "transient then success", status: 503, code: "server_error", message: "upstream-unavailable", calls: 2, stopReason: "stop", success: true },
+]) {
+	test(`provider HTTP outcome: ${row.name}`, async (t) => {
+		providerWorld(t);
+		t.mock.timers.enable({ apis: ["setTimeout"] });
+		let calls = 0;
+		globalThis.fetch = async () => {
+			calls++;
+			return row.success && calls > 1 ? successSseResponse() : errorResponse(row.status, { error: { code: row.code, plan_type: "PLUS", message: row.message } });
+		};
+		const result = await finishRetries(t, runCodexProvider());
+		assert.equal(calls, row.calls);
+		assert.equal(result.stopReason, row.stopReason);
+		if (row.success) assert.equal(result.errorMessage, undefined);
+		else {
+			assert.ok(result.errorMessage);
+			assert.ok(result.errorMessage.startsWith(`HTTP ${row.status}: `));
+			if (row.code === "usage_limit_reached") {
+				assert.ok(result.errorMessage.includes("plus"));
+				assert.equal(result.errorMessage.includes(row.message), false);
+			} else assert.equal(result.errorMessage, `HTTP ${row.status}: ${row.message}`);
+		}
 	});
 }
-
-test("malformed residual SSE data at EOF is ignored like any malformed frame", async () => {
-	globalThis.fetch = (async () => sseResponse(`data: ${JSON.stringify(completedEvent)}\n\ndata: {not json`)) as typeof fetch;
-
-	const result = await runCodexProvider();
-
-	assert.equal(result.stopReason, "stop");
-});
-
-test("SSE transport sends compressed tool choice and applies nullable header overrides", async () => {
-	let captured: RequestInit | undefined;
-	globalThis.fetch = (async (_url: RequestInfo | URL, init?: RequestInit) => {
-		captured = init;
-		return successSseResponse();
-	}) as typeof fetch;
-
-	const result = await runCodexProvider(
-		{ toolChoice: "required", headers: { "x-added": "stream", "x-remove": null } },
-		{ headers: { "x-model": "model", "x-remove": "model" } },
-	);
-
-	assert.equal(result.stopReason, "stop");
-	assert.ok(captured);
-	const headers = new Headers(captured.headers);
-	assert.equal(headers.get("content-encoding"), "zstd");
-	assert.equal(headers.get("x-added"), "stream");
-	assert.equal(headers.get("x-model"), "model");
-	assert.equal(headers.has("x-remove"), false);
-	assert.ok(captured.body instanceof Uint8Array);
-	const payload = JSON.parse(zstdDecompressSync(captured.body).toString("utf8"));
-	assert.equal(payload.tool_choice, "required");
-});
-
-test("withHttpStatusPrefix adds status once", () => {
-	assert.equal(withHttpStatusPrefix(503, "Service unavailable"), "HTTP 503: Service unavailable");
-	assert.equal(withHttpStatusPrefix(429, "HTTP 429: Too many requests"), "HTTP 429: Too many requests");
-	assert.equal(withHttpStatusPrefix(503, "HTTP 503 upstream unavailable"), "HTTP 503 upstream unavailable");
-});
-
-test("final HTTP 429 provider failure preserves friendly usage-limit text after status prefix", async () => {
-	installImmediateRetryTimers();
-	const fetchCalls = mockFetch([
-		() => errorResponse(429, { error: { code: "usage_limit_reached", plan_type: "PLUS", message: "Upstream quota body" } }, "Too Many Requests"),
-	]);
-
-	const result = await runCodexProvider();
-
-	assert.equal(fetchCalls(), 1);
-	assert.equal(result.stopReason, "error");
-	assert.equal(result.errorMessage, "HTTP 429: You have hit your ChatGPT usage limit (plus plan).");
-});
-
-test("deterministic HTTP 400 guidance is not retried", async () => {
-	installImmediateRetryTimers();
-	const fetchCalls = mockFetch([
-		() => errorResponse(400, { error: { code: "invalid_request", message: "Do not retry the request: invalid schema" } }, "Bad Request"),
-	]);
-
-	const result = await runCodexProvider();
-
-	assert.equal(fetchCalls(), 1);
-	assert.equal(result.stopReason, "error");
-	assert.match(result.errorMessage, /Do not retry the request/);
-});
-
-test("final HTTP 503 provider failure preserves HTTP status prefix", async () => {
-	installImmediateRetryTimers();
-	const fetchCalls = mockFetch([
-		() => errorResponse(503, { error: { code: "server_error", message: "Service unavailable" } }, "Service Unavailable"),
-	]);
-
-	const result = await runCodexProvider();
-
-	assert.equal(fetchCalls(), 4);
-	assert.equal(result.stopReason, "error");
-	assert.equal(result.errorMessage, "HTTP 503: Service unavailable");
-});
-
-test("successful SSE retry hides intermediate HTTP failure", async () => {
-	installImmediateRetryTimers();
-	const fetchCalls = mockFetch([
-		() => errorResponse(503, { error: { code: "server_error", message: "Service unavailable" } }, "Service Unavailable"),
-		() => successSseResponse(),
-	]);
-
-	const result = await runCodexProvider();
-
-	assert.equal(fetchCalls(), 2);
-	assert.equal(result.stopReason, "stop");
-	assert.equal(result.errorMessage, undefined);
-});
-
-test("invalid grammar schema settles provider stream as an error", async () => {
-	const result = await runCodexProvider(
-		{},
-		{ compat: { supportsOpenAIGrammarTools: true } },
-		{
-			tools: [{
-				name: "bad_grammar",
-				description: "Bad grammar",
-				parameters: { type: "object", properties: { a: { type: "string" }, b: { type: "string" } }, required: ["a", "b"] },
-				constrainedSampling: { type: "grammar", variants: { openai_lark: "start: /.+/" } },
-			}],
-		},
-	);
-
-	assert.equal(result.stopReason, "error");
-	assert.match(result.errorMessage, /exactly one required string property/);
-});
-
-test("SSE response-header timeout uses configured stream timeout", async () => {
-	installImmediateRetryTimers();
-	globalThis.fetch = ((_url: RequestInfo | URL, init?: RequestInit) =>
-		new Promise<Response>((_resolve, reject) => {
-			init?.signal?.addEventListener("abort", () => reject((init.signal as AbortSignal).reason), { once: true });
-		})) as typeof fetch;
-
-	const result = await runCodexProvider({ timeoutMs: 1 });
-
-	assert.equal(result.stopReason, "error");
-	assert.match(result.errorMessage, /Codex Responses SSE response headers timed out after 1ms/);
-	assert.doesNotMatch(result.errorMessage, /20000ms/);
-});

--- a/pi-extensions/pi-codex-minimal-tools/tests/provider-shim-parity.test.ts
+++ b/pi-extensions/pi-codex-minimal-tools/tests/provider-shim-parity.test.ts
@@ -1,124 +1,39 @@
 import assert from "node:assert/strict";
 import test from "node:test";
-import { zstdDecompressSync } from "node:zlib";
-import {
-	buildCodexUserAgent,
-	buildRequestBody,
-	clampOpenAIPromptCacheKey,
-	compressRequestBodyZstd,
-	createCodexRequestId,
-	getEnvApiKeyCompat,
-	isPreviousResponseNotFoundError,
-	isRetryableError,
-} from "../src/provider-shim.js";
-import { convertResponsesMessages } from "../src/providers/openai-responses-shared.js";
+import { buildRequestBody } from "../src/provider-shim.js";
+import { model } from "./helpers/responses.js";
 
-const model = {
-	id: "gpt-6-astra",
-	name: "GPT-6 Astra",
-	api: "openai-codex-responses",
-	provider: "openai-codex",
-	baseUrl: "https://chatgpt.com/backend-api",
-	reasoning: true,
-	input: ["text"],
-	cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
-	contextWindow: 272000,
-	maxTokens: 128000,
-} as any;
+for (const row of [
+	{ name: "strict supported", strict: true, supported: true, code: undefined },
+	{ name: "strict unsupported", strict: true, supported: false, code: "STRICT_SAMPLING_UNSUPPORTED" },
+]) {
+	test(`request constrained sampling: ${row.name}`, () => {
+		const build = () => buildRequestBody({ ...model, compat: { supportsStrictMode: row.supported } } as never, { messages: [], tools: [{ name: "strict_tool", description: "Strict tool", parameters: { type: "object", properties: { value: { type: "string" } }, required: ["value"] }, constrainedSampling: { type: "json_schema", strict: "require" } }] } as never);
+		if (row.code) assert.throws(build, { code: row.code });
+		else assert.equal((build().tools?.[0] as { strict: boolean }).strict, true);
+	});
+}
+
+for (const row of [
+	{ name: "Lark", supported: true, variant: "openai_lark", definition: " start: /.+/ ", syntax: "lark", malformed: false },
+	{ name: "function fallback", supported: false, variant: "openai_regex", definition: ".+", syntax: "regex", malformed: false },
+	{ name: "regex", supported: true, variant: "openai_regex", definition: "[a-z]+", syntax: "regex", malformed: false },
+	{ name: "whitespace regex", supported: true, variant: "openai_regex", definition: " ^foo$ ", syntax: "regex", malformed: false },
+	{ name: "malformed schema", supported: true, variant: "openai_lark", definition: "start: /.+/", syntax: "lark", malformed: true },
+]) {
+	test(`request grammar: ${row.name}`, () => {
+		const parameters = row.malformed ? { type: "object", properties: { first: { type: "string" }, second: { type: "string" } }, required: ["first", "second"] } : { type: "object", properties: { query: { type: "string" } }, required: ["query"] };
+		const build = () => buildRequestBody({ ...model, compat: { supportsOpenAIGrammarTools: row.supported } } as never, { messages: [], tools: [{ name: "sql", description: "Generate SQL", parameters, constrainedSampling: { type: "grammar", variants: { [row.variant]: row.definition } } }] } as never);
+		if (row.malformed) assert.throws(build, { code: "GRAMMAR_SCHEMA", tool: "sql" });
+		else if (row.supported) assert.deepEqual(build().tools?.[0], { type: "custom", name: "sql", description: "Generate SQL", format: { type: "grammar", syntax: row.syntax, definition: row.definition } });
+		else assert.equal((build().tools?.[0] as { type: string }).type, "function");
+	});
+}
 
 test("Codex request body forwards required tool choice", () => {
 	const body = buildRequestBody(model, { messages: [], tools: [] } as any, { toolChoice: "required" } as any);
 	assert.equal(body.tool_choice, "required");
 });
-
-test("Codex request body enables required strict JSON-schema tools", () => {
-	const body = buildRequestBody(model, {
-		messages: [],
-		tools: [{
-			name: "strict_tool",
-			description: "Strict tool",
-			parameters: { type: "object", properties: { value: { type: "string" } }, required: ["value"] },
-			constrainedSampling: { type: "json_schema", strict: "require" },
-		}],
-	} as any);
-	assert.equal((body.tools?.[0] as any).strict, true);
-});
-
-test("Codex request body rejects required strict tools when model disables strict mode", () => {
-	assert.throws(() => buildRequestBody({ ...model, compat: { supportsStrictMode: false } }, {
-		messages: [],
-		tools: [{
-			name: "strict_tool",
-			description: "Strict tool",
-			parameters: { type: "object", properties: { value: { type: "string" } }, required: ["value"] },
-			constrainedSampling: { type: "json_schema", strict: "require" },
-		}],
-	} as any), /requires JSON-schema constrained sampling/);
-});
-
-test("Codex request body emits supported grammar tools as OpenAI custom tools", () => {
-	const body = buildRequestBody({ ...model, compat: { supportsOpenAIGrammarTools: true } }, {
-		messages: [],
-		tools: [{
-			name: "sql",
-			description: "Generate SQL",
-			parameters: { type: "object", properties: { query: { type: "string" } }, required: ["query"] },
-			constrainedSampling: { type: "grammar", variants: { openai_lark: " start: /.+/ " } },
-		}],
-	} as any);
-	assert.deepEqual(body.tools?.[0], {
-		type: "custom",
-		name: "sql",
-		description: "Generate SQL",
-		format: { type: "grammar", syntax: "lark", definition: " start: /.+/ " },
-	});
-});
-
-test("Codex request body falls back to function tools when grammar capability is off", () => {
-	const body = buildRequestBody(model, {
-		messages: [],
-		tools: [{
-			name: "sql",
-			description: "Generate SQL",
-			parameters: { type: "object", properties: { query: { type: "string" } }, required: ["query"] },
-			constrainedSampling: { type: "grammar", variants: { openai_regex: ".+" } },
-		}],
-	} as any);
-	assert.equal((body.tools?.[0] as any).type, "function");
-});
-
-test("Codex request body supports regex grammar and rejects malformed grammar schemas", () => {
-	const regexBody = buildRequestBody({ ...model, compat: { supportsOpenAIGrammarTools: true } }, {
-		messages: [],
-		tools: [{
-			name: "regex_tool",
-			description: "Regex",
-			parameters: { type: "object", properties: { input: { type: "string" } }, required: ["input"] },
-			constrainedSampling: { type: "grammar", variants: { openai_regex: "[a-z]+" } },
-		}],
-	} as any);
-	assert.deepEqual((regexBody.tools?.[0] as any).format, { type: "grammar", syntax: "regex", definition: "[a-z]+" });
-	const whitespaceBody = buildRequestBody({ ...model, compat: { supportsOpenAIGrammarTools: true } }, {
-		messages: [],
-		tools: [{
-			name: "whitespace_regex",
-			description: "Whitespace-sensitive regex",
-			parameters: { type: "object", properties: { input: { type: "string" } }, required: ["input"] },
-			constrainedSampling: { type: "grammar", variants: { openai_regex: " ^foo$ " } },
-		}],
-	} as any);
-	assert.equal((whitespaceBody.tools?.[0] as any).format.definition, " ^foo$ ");
-	assert.throws(() => buildRequestBody({ ...model, compat: { supportsOpenAIGrammarTools: true } }, {
-		messages: [],
-		tools: [{
-			name: "bad_grammar",
-			description: "Bad",
-			parameters: { type: "object", properties: { first: { type: "string" }, second: { type: "string" } }, required: ["first", "second"] },
-			constrainedSampling: { type: "grammar", variants: { openai_lark: "start: /.+/" } },
-		}],
-	} as any), /exactly one required string property/);
-});
-
 test("Codex request body places dynamically added tools at transcript load point", () => {
 	const loader = { name: "search_tools", description: "Search", parameters: { type: "object", properties: {} } };
 	const deferred = { name: "special_tool", description: "Special", parameters: { type: "object", properties: {} } };
@@ -140,7 +55,6 @@ test("Codex request body places dynamically added tools at transcript load point
 	assert.equal(searchOutput.tools[0].name, "special_tool");
 	assert.equal(searchOutput.tools[0].defer_loading, true);
 });
-
 test("Codex deferred tool loading emits each definition once", () => {
 	const deferred = { name: "special_tool", description: "Special", parameters: { type: "object", properties: {} } };
 	const toolResult = (id: string) => ({
@@ -158,80 +72,10 @@ test("Codex deferred tool loading emits each definition once", () => {
 	} as any);
 	assert.equal(body.input.filter((item: any) => item.type === "tool_search_output").length, 1);
 });
-
 test("Codex cache retention none suppresses session cache key", () => {
 	const body = buildRequestBody(model, { messages: [], tools: [] } as any, {
 		cacheRetention: "none",
 		sessionId: "session-123",
 	} as any);
 	assert.equal(body.prompt_cache_key, undefined);
-});
-
-test("Codex prompt cache keys clamp to 64 Unicode characters", () => {
-	const key = `${"a".repeat(63)}😀suffix`;
-	const clamped = clampOpenAIPromptCacheKey(key);
-	assert.equal(Array.from(clamped ?? "").length, 64);
-	assert.equal(clamped, `${"a".repeat(63)}😀`);
-});
-
-test("Codex sessionless request IDs are UUIDv7", () => {
-	assert.match(createCodexRequestId(), /^[0-9a-f]{8}-[0-9a-f]{4}-7[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/);
-});
-
-test("Codex retry classifier mirrors upstream transient and terminal cases", () => {
-	assert.equal(isRetryableError(524, "Cloudflare timeout"), true);
-	assert.equal(isRetryableError(400, "grpc ResourceExhausted"), true);
-	assert.equal(isRetryableError(400, "socket connection was closed unexpectedly"), true);
-	assert.equal(isRetryableError(400, "please retry your request"), true);
-	assert.equal(isRetryableError(400, "you can retry your request"), true);
-	for (const message of ["Service unavailable", "server error", "Internal server error", "HTTP 503"]) {
-		assert.equal(isRetryableError(400, message), true, message);
-	}
-	assert.equal(isRetryableError(429, "insufficient_quota"), false);
-	assert.equal(isRetryableError(429, "ResourceExhausted: quota exceeded"), false);
-	assert.equal(isRetryableError(400, "Do not retry the request: invalid schema"), false);
-	assert.equal(isRetryableError(400, "billing account disabled"), false);
-	assert.equal(isRetryableError(400, "invalid schema"), false);
-});
-
-test("Codex detects missing cached continuations by code or message", () => {
-	assert.equal(isPreviousResponseNotFoundError({ code: "previous_response_not_found" }), true);
-	assert.equal(isPreviousResponseNotFoundError(new Error("Codex error: previous_response_not_found")), true);
-	assert.equal(isPreviousResponseNotFoundError(new Error("other failure")), false);
-});
-
-test("Codex SSE request bodies use reversible zstd compression", () => {
-	const source = JSON.stringify({ model: "gpt-6-astra", input: [{ role: "user", content: "hello" }] });
-	const compressed = compressRequestBodyZstd(source);
-	assert.ok(compressed, "Node runtime must expose zstd compression");
-	assert.equal(zstdDecompressSync(compressed).toString("utf8"), source);
-});
-
-test("Codex user agent synchronously includes OS metadata", () => {
-	const userAgent = buildCodexUserAgent();
-	assert.match(userAgent, /^pi \(.+; .+\)$/);
-	assert.notEqual(userAgent, "pi (browser)");
-});
-
-test("Codex API-key lookup falls back to the pi-ai compat entrypoint", async () => {
-	const key = await getEnvApiKeyCompat("openai-codex", {
-		root: {},
-		loadCompat: async () => ({ getEnvApiKey: (provider: string) => `key-for-${provider}` }),
-	});
-	assert.equal(key, "key-for-openai-codex");
-});
-
-test("Codex API-key lookup prefers the legacy root export", async () => {
-	const key = await getEnvApiKeyCompat("openai-codex", {
-		root: { getEnvApiKey: (provider: string) => `root-key-for-${provider}` },
-		loadCompat: async () => { throw new Error("compat should not load"); },
-	});
-	assert.equal(key, "root-key-for-openai-codex");
-});
-
-test("empty tool results use no-output placeholder instead of image placeholder", () => {
-	const messages = convertResponsesMessages(model, {
-		messages: [{ role: "toolResult", toolCallId: "call_1|fc_1", toolName: "noop", content: [], isError: false, timestamp: Date.now() }],
-	} as any, new Set(["openai-codex"]));
-	assert.deepEqual(messages, [{ type: "function_call_output", call_id: "call_1", output: "(no tool output)" }]);
 });

--- a/pi-extensions/pi-codex-minimal-tools/tests/provider-shim-proxy.test.ts
+++ b/pi-extensions/pi-codex-minimal-tools/tests/provider-shim-proxy.test.ts
@@ -1,44 +1,16 @@
 import assert from "node:assert/strict";
-import test, { afterEach } from "node:test";
-import { proxyForWebSocketUrl, webSocketOptionsForUrl } from "../src/provider-shim.js";
+import test from "node:test";
+import { proxyForWebSocketUrl } from "../src/provider-shim.js";
+import { environment, noProxyEnvironment } from "./helpers/world.js";
 
-const originalEnv = {
-	HTTP_PROXY: process.env.HTTP_PROXY,
-	http_proxy: process.env.http_proxy,
-	HTTPS_PROXY: process.env.HTTPS_PROXY,
-	https_proxy: process.env.https_proxy,
-	NO_PROXY: process.env.NO_PROXY,
-	no_proxy: process.env.no_proxy,
-};
-
-afterEach(() => {
-	for (const [key, value] of Object.entries(originalEnv)) {
-		if (value === undefined) delete process.env[key];
-		else process.env[key] = value;
-	}
-});
-
-test("proxyForWebSocketUrl maps websocket transports through proxy envs", () => {
-	process.env.HTTPS_PROXY = "http://proxy.example:8080";
-	process.env.HTTP_PROXY = "http://plain-proxy.example:8080";
-	delete process.env.NO_PROXY;
-	delete process.env.no_proxy;
-	assert.equal(proxyForWebSocketUrl("wss://chatgpt.com/backend-api/codex/responses"), "http://proxy.example:8080");
-	assert.equal(proxyForWebSocketUrl("ws://localhost:8080/socket"), "http://plain-proxy.example:8080");
-});
-
-test("webSocketOptionsForUrl passes proxy configuration as an undici dispatcher", async () => {
-	process.env.HTTPS_PROXY = "http://proxy.example:8080";
-	delete process.env.NO_PROXY;
-	const options = await webSocketOptionsForUrl("wss://chatgpt.com/backend-api/codex/responses", { Authorization: "Bearer token" });
-	assert.equal(options.headers.Authorization, "Bearer token");
-	assert.equal("proxy" in options, false);
-	assert.ok(options.dispatcher);
-});
-
-test("proxyForWebSocketUrl honors NO_PROXY host entries", () => {
-	process.env.HTTPS_PROXY = "http://proxy.example:8080";
-	process.env.NO_PROXY = ".chatgpt.com,localhost";
-	assert.equal(proxyForWebSocketUrl("wss://chatgpt.com/backend-api/codex/responses"), undefined);
-	assert.equal(proxyForWebSocketUrl("wss://api.chatgpt.com/backend-api/codex/responses"), undefined);
-});
+for (const row of [
+	{ name: "secure", url: "wss://chatgpt.com/backend-api/codex/responses", noProxy: undefined, expected: "http://proxy.example:8080" },
+	{ name: "plain", url: "ws://localhost:8080/socket", noProxy: undefined, expected: "http://plain-proxy.example:8080" },
+	{ name: "root bypass", url: "wss://chatgpt.com/backend-api/codex/responses", noProxy: ".chatgpt.com,localhost", expected: undefined },
+	{ name: "subdomain bypass", url: "wss://api.chatgpt.com/backend-api/codex/responses", noProxy: ".chatgpt.com,localhost", expected: undefined },
+]) {
+	test(`websocket proxy: ${row.name}`, (t) => {
+		environment(t, { ...noProxyEnvironment, HTTPS_PROXY: "http://proxy.example:8080", HTTP_PROXY: "http://plain-proxy.example:8080", NO_PROXY: row.noProxy });
+		assert.equal(proxyForWebSocketUrl(row.url), row.expected);
+	});
+}

--- a/pi-extensions/pi-codex-minimal-tools/tests/provider-shim-timeout.test.ts
+++ b/pi-extensions/pi-codex-minimal-tools/tests/provider-shim-timeout.test.ts
@@ -1,32 +1,23 @@
 import assert from "node:assert/strict";
-import test, { afterEach } from "node:test";
-import { fetchWithResponseHeaderTimeout, responseHeaderTimeoutMsFromOptions } from "../src/provider-shim.js";
+import { setImmediate } from "node:timers/promises";
+import test from "node:test";
+import { fetchWithResponseHeaderTimeout } from "../src/provider-shim.js";
 
-const originalFetch = globalThis.fetch;
-
-afterEach(() => {
-	globalThis.fetch = originalFetch;
-});
-
-test("responseHeaderTimeoutMsFromOptions uses Pi HTTP timeout when provided", () => {
-	assert.equal(responseHeaderTimeoutMsFromOptions({ timeoutMs: 45_000 } as any), 45_000);
-	assert.equal(responseHeaderTimeoutMsFromOptions({ timeoutMs: 0 } as any), 20_000);
-	assert.equal(responseHeaderTimeoutMsFromOptions(undefined), 20_000);
-});
-
-test("fetchWithResponseHeaderTimeout aborts when SSE response headers stall", async () => {
-	globalThis.fetch = ((_url: RequestInfo | URL, init?: RequestInit) =>
-		new Promise<Response>((_resolve, reject) => {
-			const signal = init?.signal;
-			if (signal?.aborted) {
-				reject(new Error("aborted before fetch"));
-				return;
-			}
-			signal?.addEventListener("abort", () => reject(new Error("aborted by test")), { once: true });
-		})) as typeof fetch;
-
-	await assert.rejects(
-		() => fetchWithResponseHeaderTimeout("https://example.test/backend-api/codex/responses", { method: "POST" }, undefined, 1),
-		/Codex Responses SSE response headers timed out after 1ms/,
-	);
+test("response header timeout aborts a pending fetch at its configured deadline", async (t) => {
+	t.mock.timers.enable({ apis: ["setTimeout"] });
+	let signal: AbortSignal | null | undefined;
+	t.mock.method(globalThis, "fetch", (_url: RequestInfo | URL, init?: RequestInit) => new Promise<Response>((_resolve, reject) => {
+		signal = init?.signal;
+		signal?.addEventListener("abort", () => reject(signal?.reason), { once: true });
+	}));
+	const pending = fetchWithResponseHeaderTimeout("https://example.test/backend-api/codex/responses", { method: "POST" }, undefined, 45_000);
+	const rejection = assert.rejects(pending, { code: "RESPONSE_HEADER_TIMEOUT", timeoutMs: 45_000 });
+	assert.ok(signal);
+	t.mock.timers.tick(44_999);
+	await setImmediate();
+	assert.equal(signal.aborted, false);
+	t.mock.timers.tick(1);
+	await setImmediate();
+	assert.equal(signal.aborted, true);
+	await rejection;
 });

--- a/pi-extensions/pi-codex-minimal-tools/tests/provider-sse-framing.test.ts
+++ b/pi-extensions/pi-codex-minimal-tools/tests/provider-sse-framing.test.ts
@@ -1,0 +1,33 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { completedEvent, providerWorld, runCodexProvider, sseResponse } from "./helpers/provider.js";
+
+// The Codex backend can close the stream right after the terminal event
+// without the blank line that ends an SSE frame. EOF ends that frame.
+const unterminatedTerminalFrames: Array<{ name: string; body: string }> = [
+	{ name: "LF-terminated final line", body: `data: ${JSON.stringify(completedEvent)}\n` },
+	{ name: "CRLF-terminated final line", body: `data: ${JSON.stringify(completedEvent)}\r\n` },
+	{ name: "no line terminator", body: `data: ${JSON.stringify(completedEvent)}` },
+];
+
+for (const frame of unterminatedTerminalFrames) {
+	test(`SSE terminal event without a trailing blank line completes the stream (${frame.name})`, async (t) => {
+		providerWorld(t);
+		globalThis.fetch = (async () => sseResponse(frame.body)) as typeof fetch;
+
+		const result = await runCodexProvider();
+
+		assert.equal(result.errorMessage, undefined);
+		assert.equal(result.stopReason, "stop");
+	});
+}
+
+test("malformed residual SSE data at EOF is ignored like any malformed frame", async (t) => {
+		providerWorld(t);
+	globalThis.fetch = (async () => sseResponse(`data: ${JSON.stringify(completedEvent)}\n\ndata: {not json`)) as typeof fetch;
+
+	const result = await runCodexProvider();
+
+	assert.equal(result.stopReason, "stop");
+});
+

--- a/pi-extensions/pi-codex-minimal-tools/tests/provider-sse-request.test.ts
+++ b/pi-extensions/pi-codex-minimal-tools/tests/provider-sse-request.test.ts
@@ -1,0 +1,30 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { zstdDecompressSync } from "node:zlib";
+import { providerWorld, runCodexProvider, successSseResponse } from "./helpers/provider.js";
+
+test("SSE transport sends compressed tool choice and applies nullable header overrides", async (t) => {
+		providerWorld(t);
+	let captured: RequestInit | undefined;
+	globalThis.fetch = (async (_url: RequestInfo | URL, init?: RequestInit) => {
+		captured = init;
+		return successSseResponse();
+	}) as typeof fetch;
+
+	const result = await runCodexProvider(
+		{ toolChoice: "required", headers: { "x-added": "stream", "x-remove": null } },
+		{ headers: { "x-model": "model", "x-remove": "model" } },
+	);
+
+	assert.equal(result.stopReason, "stop");
+	assert.ok(captured);
+	const headers = new Headers(captured.headers);
+	assert.equal(headers.get("content-encoding"), "zstd");
+	assert.equal(headers.get("x-added"), "stream");
+	assert.equal(headers.get("x-model"), "model");
+	assert.equal(headers.has("x-remove"), false);
+	assert.ok(captured.body instanceof Uint8Array);
+	const payload = JSON.parse(zstdDecompressSync(captured.body).toString("utf8"));
+	assert.equal(payload.tool_choice, "required");
+});
+

--- a/pi-extensions/pi-codex-minimal-tools/tests/provider-user-agent.test.ts
+++ b/pi-extensions/pi-codex-minimal-tools/tests/provider-user-agent.test.ts
@@ -1,0 +1,9 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { buildCodexUserAgent } from "../src/provider-shim.js";
+
+test("Codex user agent synchronously includes OS metadata", () => {
+	const userAgent = buildCodexUserAgent();
+	assert.match(userAgent, /^pi \(.+; .+\)$/);
+	assert.notEqual(userAgent, "pi (browser)");
+});

--- a/pi-extensions/pi-codex-minimal-tools/tests/renderer-compatibility.test.ts
+++ b/pi-extensions/pi-codex-minimal-tools/tests/renderer-compatibility.test.ts
@@ -11,10 +11,3 @@ test("apply_patch definition is compatible with pi-tool-renderer assumptions", (
 	assert.equal("renderCall" in tool, false);
 	assert.equal("renderResult" in tool, false);
 });
-
-test("fallback output remains readable without a custom renderer", async () => {
-	const tool = createApplyPatchToolDefinition({ cwd: process.cwd(), deferRendering: true }) as Record<string, any>;
-	assert.equal(typeof tool.execute, "function");
-	assert.match(tool.description, /Codex-style patch/);
-	assert.match(tool.promptSnippet, /input/);
-});

--- a/pi-extensions/pi-codex-minimal-tools/tests/request-compression.test.ts
+++ b/pi-extensions/pi-codex-minimal-tools/tests/request-compression.test.ts
@@ -1,0 +1,11 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { zstdDecompressSync } from "node:zlib";
+import { compressRequestBodyZstd } from "../src/provider-shim.js";
+
+test("Codex SSE request bodies use reversible zstd compression", () => {
+	const source = JSON.stringify({ model: "gpt-6-astra", input: [{ role: "user", content: "hello" }] });
+	const compressed = compressRequestBodyZstd(source);
+	assert.ok(compressed, "Node runtime must expose zstd compression");
+	assert.equal(zstdDecompressSync(compressed).toString("utf8"), source);
+});

--- a/pi-extensions/pi-codex-minimal-tools/tests/request-id.test.ts
+++ b/pi-extensions/pi-codex-minimal-tools/tests/request-id.test.ts
@@ -1,0 +1,7 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { createCodexRequestId } from "../src/provider-shim.js";
+
+test("Codex sessionless request IDs are UUIDv7", () => {
+	assert.match(createCodexRequestId(), /^[0-9a-f]{8}-[0-9a-f]{4}-7[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/);
+});

--- a/pi-extensions/pi-codex-minimal-tools/tests/response-header-timeout-options.test.ts
+++ b/pi-extensions/pi-codex-minimal-tools/tests/response-header-timeout-options.test.ts
@@ -1,0 +1,11 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { responseHeaderTimeoutMsFromOptions } from "../src/provider-shim.js";
+
+for (const row of [
+	{ name: "configured", options: { timeoutMs: 45_000 }, expected: 45_000 },
+	{ name: "zero", options: { timeoutMs: 0 }, expected: 20_000 },
+	{ name: "absent", options: undefined, expected: 20_000 },
+]) {
+	test(`response header timeout option: ${row.name}`, () => assert.equal(responseHeaderTimeoutMsFromOptions(row.options), row.expected));
+}

--- a/pi-extensions/pi-codex-minimal-tools/tests/responses-stream-null-content.test.ts
+++ b/pi-extensions/pi-codex-minimal-tools/tests/responses-stream-null-content.test.ts
@@ -1,40 +1,14 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 import { processResponsesStream } from "../src/providers/openai-responses-shared.js";
+import { asAsyncIterable, createAssistantOutput, model } from "./helpers/responses.js";
 
-async function* asAsyncIterable(events: any[]) {
-	for (const event of events) yield event;
-}
-
-function createAssistantOutput() {
-	return {
-		role: "assistant",
-		content: [],
-		api: "openai-codex-responses",
-		provider: "openai-codex",
-		model: "gpt-6-astra",
-		usage: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, totalTokens: 0, cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 } },
-		stopReason: "stop",
-		timestamp: Date.now(),
-	} as any;
-}
-
-const model = {
-	provider: "openai-codex",
-	api: "openai-codex-responses",
-	id: "gpt-6-astra",
-	input: ["text"],
-	reasoning: true,
-	cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
-} as any;
-
-// OpenAI-compatible streams can emit reasoning -> empty message (content: null)
-// -> function_call. The tool call must survive the null-content message item.
-test("processResponsesStream tolerates a null-content message item before a function_call", async () => {
-	const output = createAssistantOutput();
-
-	await processResponsesStream(
-		asAsyncIterable([
+const escapedInput = "SELECT \\\"quoted\\\"\\nline";
+// Text, reasoning and grammar event sequences share the non-image stream contract.
+const cases = [
+	{
+		name: "processResponsesStream tolerates a null-content message item before a function_call",
+		events: [
 			{ type: "response.created", response: { id: "resp_1" } },
 			{ type: "response.output_item.added", output_index: 0, item: { type: "message", id: "msg_1" } },
 			{ type: "response.output_item.done", output_index: 0, item: { type: "message", id: "msg_1", content: null } },
@@ -42,129 +16,104 @@ test("processResponsesStream tolerates a null-content message item before a func
 			{ type: "response.function_call_arguments.done", output_index: 1, arguments: '{"path":"/tmp/x"}' },
 			{ type: "response.output_item.done", output_index: 1, item: { type: "function_call", id: "fc_1", call_id: "call_1", name: "read", arguments: '{"path":"/tmp/x"}' } },
 			{ type: "response.completed", response: { id: "resp_1", status: "completed", usage: { input_tokens: 0, output_tokens: 0, total_tokens: 0, input_tokens_details: { cached_tokens: 0 } } } },
-		]),
-		output,
-		{ push() {} } as any,
-		model,
-	);
-
-	const toolCalls = output.content.filter((block: any) => block.type === "toolCall");
+		],
+		grammar: false,
+		check(output: ReturnType<typeof createAssistantOutput>, events: any[]) {
+	const toolCalls = output.content.filter((block) => block.type === "toolCall");
 	assert.equal(toolCalls.length, 1, "tool call should survive a null-content message item");
 	assert.equal(toolCalls[0].name, "read");
 	assert.deepEqual(toolCalls[0].arguments, { path: "/tmp/x" });
 	assert.equal(output.stopReason, "toolUse");
 
-	const textBlocks = output.content.filter((block: any) => block.type === "text");
+	const textBlocks = output.content.filter((block) => block.type === "text");
 	assert.equal(textBlocks[0]?.text, "", "null message content collapses to empty text");
-});
-
-test("processResponsesStream records reasoning token usage and incomplete stop reason", async () => {
-	const output = createAssistantOutput();
-
-	await processResponsesStream(
-		asAsyncIterable([
+		},
+	},
+	{
+		name: "processResponsesStream records reasoning token usage and incomplete stop reason",
+		events: [
 			{ type: "response.created", response: { id: "resp_2" } },
 			{ type: "response.output_item.added", output_index: 0, item: { type: "reasoning", id: "rs_1" } },
 			{ type: "response.reasoning_text.delta", output_index: 0, delta: "hidden chain" },
 			{ type: "response.output_item.done", output_index: 0, item: { type: "reasoning", id: "rs_1", summary: [], content: [{ text: "preserved reasoning" }] } },
 			{ type: "response.incomplete", response: { id: "resp_2", status: "incomplete", usage: { input_tokens: 11, output_tokens: 7, total_tokens: 18, input_tokens_details: { cached_tokens: 3, cache_write_tokens: 2 }, output_tokens_details: { reasoning_tokens: 5 } } } },
-		]),
-		output,
-		{ push() {} } as any,
-		model,
-	);
-
+		],
+		grammar: false,
+		check(output: ReturnType<typeof createAssistantOutput>, events: any[]) {
 	assert.equal(output.stopReason, "length");
 	assert.equal(output.usage.input, 6);
 	assert.equal(output.usage.cacheWrite, 2);
 	assert.equal((output.usage as any).reasoning, 5);
-	const thinking = output.content.find((block: any) => block.type === "thinking") as any;
+	const thinking = output.content.find((block) => block.type === "thinking") as any;
 	assert.equal(thinking.thinking, "preserved reasoning");
-});
-
-test("processResponsesStream converts streamed grammar input into normal tool arguments", async () => {
-	const output = createAssistantOutput();
-	const events: any[] = [];
-
-	await processResponsesStream(
-		asAsyncIterable([
+		},
+	},
+	{
+		name: "processResponsesStream converts streamed grammar input into normal tool arguments",
+		events: [
 			{ type: "response.created", response: { id: "resp_grammar" } },
 			{ type: "response.output_item.added", output_index: 0, item: { type: "custom_tool_call", id: "ctc_1", call_id: "call_1", name: "sql", input: "" } },
 			{ type: "response.custom_tool_call_input.delta", output_index: 0, delta: "SELECT " },
 			{ type: "response.custom_tool_call_input.done", output_index: 0, input: "SELECT 1" },
 			{ type: "response.output_item.done", output_index: 0, item: { type: "custom_tool_call", id: "ctc_1", call_id: "call_1", name: "sql", input: "SELECT 1" } },
 			{ type: "response.completed", response: { id: "resp_grammar", status: "completed", usage: { input_tokens: 0, output_tokens: 0, total_tokens: 0, input_tokens_details: { cached_tokens: 0 } } } },
-		]),
-		output,
-		{ push(event: any) { events.push(event); } } as any,
-		model,
-		{ grammarToolInputProperties: new Map([["sql", "query"]]) },
-	);
-
-	const toolCall = output.content.find((block: any) => block.type === "toolCall") as any;
+		],
+		grammar: true,
+		check(output: ReturnType<typeof createAssistantOutput>, events: any[]) {
+	const toolCall = output.content.find((block) => block.type === "toolCall") as any;
 	assert.deepEqual(toolCall.arguments, { query: "SELECT 1" });
 	assert.equal(toolCall.partialJson, undefined);
 	assert.equal(output.stopReason, "toolUse");
 	assert.equal(events.filter((event) => event.type === "toolcall_end").length, 1);
 	const streamedJson = events.filter((event) => event.type === "toolcall_delta").map((event) => event.delta).join("");
 	assert.deepEqual(JSON.parse(streamedJson), { query: "SELECT 1" });
-});
-
-test("processResponsesStream handles done-only grammar input with escaping", async () => {
-	const output = createAssistantOutput();
-	const events: any[] = [];
-	const input = "SELECT \\\"quoted\\\"\\nline";
-
-	await processResponsesStream(
-		asAsyncIterable([
+		},
+	},
+	{
+		name: "processResponsesStream handles done-only grammar input with escaping",
+		events: [
 			{ type: "response.created", response: { id: "resp_done_only" } },
 			{ type: "response.output_item.added", output_index: 0, item: { type: "custom_tool_call", id: "ctc_2", call_id: "call_2", name: "sql", input: "" } },
-			{ type: "response.output_item.done", output_index: 0, item: { type: "custom_tool_call", id: "ctc_2", call_id: "call_2", name: "sql", input } },
+			{ type: "response.output_item.done", output_index: 0, item: { type: "custom_tool_call", id: "ctc_2", call_id: "call_2", name: "sql", input: escapedInput } },
 			{ type: "response.completed", response: { id: "resp_done_only", status: "completed", usage: { input_tokens: 0, output_tokens: 0, total_tokens: 0, input_tokens_details: { cached_tokens: 0 } } } },
-		]),
-		output,
-		{ push(event: any) { events.push(event); } } as any,
-		model,
-		{ grammarToolInputProperties: new Map([["sql", "query"]]) },
-	);
-
+		],
+		grammar: true,
+		check(output: ReturnType<typeof createAssistantOutput>, events: any[]) {
 	const streamedJson = events.filter((event) => event.type === "toolcall_delta").map((event) => event.delta).join("");
-	assert.deepEqual(JSON.parse(streamedJson), { query: input });
-	assert.deepEqual((output.content.find((block: any) => block.type === "toolCall") as any).arguments, { query: input });
-});
-
-test("processResponsesStream rejects non-monotonic grammar input", async () => {
-	const output = createAssistantOutput();
-	await assert.rejects(
-		() => processResponsesStream(
-			asAsyncIterable([
+	assert.deepEqual(JSON.parse(streamedJson), { query: escapedInput });
+	assert.deepEqual((output.content.find((block) => block.type === "toolCall") as any).arguments, { query: escapedInput });
+		},
+	},
+	{
+		name: "processResponsesStream rejects non-monotonic grammar input",
+		events: [
 				{ type: "response.created", response: { id: "resp_bad_grammar" } },
 				{ type: "response.output_item.added", output_index: 0, item: { type: "custom_tool_call", id: "ctc_3", call_id: "call_3", name: "sql", input: "" } },
 				{ type: "response.custom_tool_call_input.delta", output_index: 0, delta: "SELECT" },
 				{ type: "response.custom_tool_call_input.done", output_index: 0, input: "DROP" },
-			]),
-			output,
-			{ push() {} } as any,
-			model,
-			{ grammarToolInputProperties: new Map([["sql", "query"]]) },
-		),
-		/non-monotonically/,
-	);
-});
-
-test("processResponsesStream fails when stream ends before terminal response event", async () => {
-	const output = createAssistantOutput();
-	await assert.rejects(
-		() => processResponsesStream(
-			asAsyncIterable([
+		],
+		grammar: true,
+		code: "GRAMMAR_INPUT_NON_MONOTONIC",
+	},
+	{
+		name: "processResponsesStream fails when stream ends before terminal response event",
+		events: [
 				{ type: "response.created", response: { id: "resp_missing_terminal" } },
 				{ type: "response.output_item.added", output_index: 0, item: { type: "message", id: "msg_1" } },
 				{ type: "response.output_text.delta", output_index: 0, content_index: 0, delta: "partial" },
-			]),
-			output,
-			{ push() {} } as any,
-			model,
-		),
-		/OpenAI Responses stream ended before a terminal response event/,
-	);
-});
+		],
+		grammar: false,
+		code: "RESPONSES_TERMINAL_MISSING",
+	}
+];
+
+for (const row of cases) {
+	test(row.name, async () => {
+		const output = createAssistantOutput();
+		const events: any[] = [];
+		const run = () => processResponsesStream(asAsyncIterable(row.events), output, { push(event: unknown) { events.push(event); } } as never, model,
+			row.grammar ? { grammarToolInputProperties: new Map([["sql", "query"]]) } : undefined);
+		if (row.code) await assert.rejects(run, { code: row.code });
+		else { await run(); row.check!(output, events); }
+	});
+}

--- a/pi-extensions/pi-codex-minimal-tools/tests/settings-defaults.test.ts
+++ b/pi-extensions/pi-codex-minimal-tools/tests/settings-defaults.test.ts
@@ -1,0 +1,11 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import test from "node:test";
+import { DEFAULT_SETTINGS } from "../src/settings.js";
+
+test("package settings defaults match runtime defaults", () => {
+	const manifest = JSON.parse(readFileSync(new URL("../package.json", import.meta.url), "utf8"));
+	const settings = manifest.kendex.extensionManager.settings as Array<{ key: keyof typeof DEFAULT_SETTINGS; default: unknown }>;
+	const manifestDefaults = Object.fromEntries(settings.map((item) => [item.key, item.default]));
+	assert.deepEqual(manifestDefaults, DEFAULT_SETTINGS);
+});

--- a/pi-extensions/pi-codex-minimal-tools/tests/settings-diagnostics.test.ts
+++ b/pi-extensions/pi-codex-minimal-tools/tests/settings-diagnostics.test.ts
@@ -1,0 +1,15 @@
+import assert from "node:assert/strict";
+import { writeFileSync } from "node:fs";
+import { join } from "node:path";
+import test from "node:test";
+import { settingsDiagnostics } from "../src/settings.js";
+import { environment, world } from "./helpers/world.js";
+
+test("settingsDiagnostics identifies the malformed settings file", (t) => {
+	const { cwd, agent } = world(t);
+	environment(t, { PI_CODING_AGENT_DIR: agent });
+	writeFileSync(join(agent, "settings.json"), "{");
+	const diagnostics = settingsDiagnostics(cwd);
+	assert.equal(diagnostics.length, 1);
+	assert.ok(diagnostics[0]!.includes(join(agent, "settings.json")));
+});

--- a/pi-extensions/pi-codex-minimal-tools/tests/settings.test.ts
+++ b/pi-extensions/pi-codex-minimal-tools/tests/settings.test.ts
@@ -1,81 +1,33 @@
 import assert from "node:assert/strict";
-import { mkdtempSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
-import { tmpdir } from "node:os";
+import { writeFileSync } from "node:fs";
 import { join } from "node:path";
 import test from "node:test";
-import { DEFAULT_SETTINGS, loadSettings, recordProjectTrust, settingsDiagnostics } from "../src/settings.js";
+import { loadSettings, recordProjectTrust } from "../src/settings.js";
+import { environment, world } from "./helpers/world.js";
 
-function tempDir(): string {
-	return mkdtempSync(join(tmpdir(), "pi-codex-minimal-tools-"));
+for (const row of [
+	{
+		name: "user then project, invalid model falls back",
+		user: { autoEnable: false, imageOutputDir: "user-images", imageModel: "gpt-image-1" },
+		project: { autoEnable: true, imageOutputDir: "project-images", imageModel: "bad-model", directImageApiFallback: true },
+		steps: [{ trust: true, expected: { autoEnable: true, imageOutputDir: "project-images", imageModel: "gpt-image-2", directImageApiFallback: true, applyPatchEnabled: true } }],
+	},
+	{
+		name: "project settings require trust",
+		user: { autoEnable: false }, project: { autoEnable: true },
+		steps: [{ trust: false, expected: { autoEnable: false } }, { trust: true, expected: { autoEnable: true } }],
+	},
+]) {
+	test(`loadSettings: ${row.name}`, (t) => {
+		const { cwd, agent } = world(t);
+		environment(t, { PI_CODING_AGENT_DIR: agent });
+		for (const [file, config] of [[join(agent, "settings.json"), row.user], [join(cwd, ".pi", "settings.json"), row.project]] as const) {
+			writeFileSync(file, JSON.stringify({ kendex: { extensionManager: { config: { "@vanillagreen/pi-codex-minimal-tools": config } } } }));
+		}
+		for (const step of row.steps) {
+			recordProjectTrust({ cwd, isProjectTrusted: () => step.trust });
+			const settings = loadSettings(cwd);
+			assert.deepEqual(Object.fromEntries(Object.keys(step.expected).map((key) => [key, settings[key as keyof typeof settings]])), step.expected);
+		}
+	});
 }
-
-test("package settings defaults match runtime defaults", () => {
-	const manifest = JSON.parse(readFileSync(new URL("../package.json", import.meta.url), "utf8"));
-	const settings = manifest.kendex.extensionManager.settings as Array<{ key: keyof typeof DEFAULT_SETTINGS; default: unknown }>;
-	const manifestDefaults = Object.fromEntries(settings.map((item) => [item.key, item.default]));
-	assert.deepEqual(manifestDefaults, DEFAULT_SETTINGS);
-});
-
-test("settingsDiagnostics reports malformed JSON settings", () => {
-	const root = tempDir();
-	const user = join(root, "agent");
-	const project = join(root, "project");
-	mkdirSync(user, { recursive: true });
-	mkdirSync(join(project, ".pi"), { recursive: true });
-	writeFileSync(join(user, "settings.json"), "{");
-	const previous = process.env.PI_CODING_AGENT_DIR;
-	process.env.PI_CODING_AGENT_DIR = user;
-	try {
-		const diagnostics = settingsDiagnostics(project);
-		assert.equal(diagnostics.length, 1);
-		assert.match(diagnostics[0]!, /settings\.json/);
-	} finally {
-		if (previous === undefined) delete process.env.PI_CODING_AGENT_DIR;
-		else process.env.PI_CODING_AGENT_DIR = previous;
-	}
-});
-
-test("loadSettings merges user settings then project settings", () => {
-	const root = tempDir();
-	const user = join(root, "agent");
-	const project = join(root, "project");
-	mkdirSync(user, { recursive: true });
-	mkdirSync(join(project, ".pi"), { recursive: true });
-	writeFileSync(join(user, "settings.json"), JSON.stringify({ kendex: { extensionManager: { config: { "@vanillagreen/pi-codex-minimal-tools": { autoEnable: false, imageOutputDir: "user-images", imageModel: "gpt-image-1" } } } } }));
-	writeFileSync(join(project, ".pi", "settings.json"), JSON.stringify({ kendex: { extensionManager: { config: { "@vanillagreen/pi-codex-minimal-tools": { autoEnable: true, imageOutputDir: "project-images", imageModel: "bad-model", directImageApiFallback: true } } } } }));
-	const previous = process.env.PI_CODING_AGENT_DIR;
-	process.env.PI_CODING_AGENT_DIR = user;
-	try {
-		recordProjectTrust({ cwd: project, isProjectTrusted: () => true });
-		const settings = loadSettings(project);
-		assert.equal(settings.autoEnable, true);
-		assert.equal(settings.imageOutputDir, "project-images");
-		assert.equal(settings.imageModel, "gpt-image-2");
-		assert.equal(settings.directImageApiFallback, true);
-		assert.equal(settings.applyPatchEnabled, true);
-	} finally {
-		if (previous === undefined) delete process.env.PI_CODING_AGENT_DIR;
-		else process.env.PI_CODING_AGENT_DIR = previous;
-	}
-});
-
-test("loadSettings skips project settings until project trust is recorded", () => {
-	const root = tempDir();
-	const user = join(root, "agent");
-	const project = join(root, "project");
-	mkdirSync(user, { recursive: true });
-	mkdirSync(join(project, ".pi"), { recursive: true });
-	writeFileSync(join(user, "settings.json"), JSON.stringify({ kendex: { extensionManager: { config: { "@vanillagreen/pi-codex-minimal-tools": { autoEnable: false } } } } }));
-	writeFileSync(join(project, ".pi", "settings.json"), JSON.stringify({ kendex: { extensionManager: { config: { "@vanillagreen/pi-codex-minimal-tools": { autoEnable: true } } } } }));
-	const previous = process.env.PI_CODING_AGENT_DIR;
-	process.env.PI_CODING_AGENT_DIR = user;
-	try {
-		recordProjectTrust({ cwd: project, isProjectTrusted: () => false });
-		assert.equal(loadSettings(project).autoEnable, false);
-		recordProjectTrust({ cwd: project, isProjectTrusted: () => true });
-		assert.equal(loadSettings(project).autoEnable, true);
-	} finally {
-		if (previous === undefined) delete process.env.PI_CODING_AGENT_DIR;
-		else process.env.PI_CODING_AGENT_DIR = previous;
-	}
-});

--- a/pi-extensions/pi-codex-minimal-tools/tests/tool-capabilities.test.ts
+++ b/pi-extensions/pi-codex-minimal-tools/tests/tool-capabilities.test.ts
@@ -1,0 +1,17 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { computeToolCapabilities } from "../src/capabilities.js";
+import { DEFAULT_SETTINGS } from "../src/settings.js";
+
+for (const row of [
+	{ provider: "openai-codex", input: ["text", "image"], viewImage: true, enabled: [true, true, true] },
+	{ provider: "openai-codex", input: ["text"], viewImage: true, enabled: [false, false, true] },
+	{ provider: "openai", input: ["text", "image"], viewImage: true, enabled: [false, true, true] },
+	{ provider: "claude-bridge", input: ["text", "image"], viewImage: true, enabled: [false, false, false] },
+	{ provider: "openai-codex", input: ["text", "image"], viewImage: false, enabled: [true, false, true] },
+]) {
+	test(`capabilities: ${row.provider}/${row.input.join("+")}/view=${row.viewImage}`, () => {
+		const caps = computeToolCapabilities({ provider: row.provider, id: "model", input: row.input }, { ...DEFAULT_SETTINGS, viewImage: row.viewImage });
+		assert.deepEqual([caps.image_generation.enabled, caps.view_image.enabled, caps.apply_patch.enabled], row.enabled);
+	});
+}

--- a/pi-extensions/pi-codex-minimal-tools/tests/view-image-output.test.ts
+++ b/pi-extensions/pi-codex-minimal-tools/tests/view-image-output.test.ts
@@ -1,0 +1,17 @@
+import assert from "node:assert/strict";
+import { writeFileSync } from "node:fs";
+import { join } from "node:path";
+import test from "node:test";
+import { viewImage } from "../src/tools/view-image.js";
+import { world } from "./helpers/world.js";
+
+test("viewImage emits the selected file as an image block", async (t) => {
+	const { cwd } = world(t);
+	const bytes = Buffer.from([0x89, 0x50, 0x4e, 0x47]);
+	writeFileSync(join(cwd, "image.png"), bytes);
+	const result = await viewImage({ path: "image.png" }, cwd);
+	assert.equal(result.content[0]?.type, "image");
+	assert.equal(result.content[0]?.mimeType, "image/png");
+	assert.equal(typeof result.content[0]?.data, "string");
+	assert.equal(result.content[0]?.data, bytes.toString("base64"));
+});

--- a/pi-extensions/pi-codex-minimal-tools/tests/view-image.test.ts
+++ b/pi-extensions/pi-codex-minimal-tools/tests/view-image.test.ts
@@ -1,57 +1,41 @@
 import assert from "node:assert/strict";
-import { mkdirSync, mkdtempSync, symlinkSync, writeFileSync } from "node:fs";
-import { tmpdir } from "node:os";
+import { mkdirSync, symlinkSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import test from "node:test";
-import { validateImagePath, viewImage } from "../src/tools/view-image.js";
+import { validateImagePath } from "../src/tools/view-image.js";
+import { world } from "./helpers/world.js";
 
-function tempDir(): string {
-	return mkdtempSync(join(tmpdir(), "pi-view-image-"));
+for (const row of [
+	{ name: "at prefix", kind: "image", path: "@image.png", workspaceOnly: false, detail: "high" },
+	{ name: "directory", kind: "directory", path: "dir", workspaceOnly: false, code: "IMAGE_DIRECTORY" },
+	{ name: "non-image", kind: "text", path: "notes.txt", workspaceOnly: false, code: "IMAGE_TYPE" },
+	{ name: "relative escape", kind: "outside", path: "../secret.png", workspaceOnly: true, code: "IMAGE_PATH_OUTSIDE" },
+	{ name: "absolute escape", kind: "outside", path: "absolute", workspaceOnly: true, code: "IMAGE_PATH_OUTSIDE" },
+	{ name: "symlink escape", kind: "symlink", path: "linked.png", workspaceOnly: true, code: "IMAGE_PATH_OUTSIDE" },
+	{ name: "outside allowed by default", kind: "outside", path: "absolute", workspaceOnly: undefined },
+] as const) {
+	test(`validateImagePath: ${row.name}`, async (t) => {
+		const { cwd, root } = world(t);
+		const bytes = Buffer.from([0x89, 0x50, 0x4e, 0x47]);
+		const outside = join(root, "secret.png");
+		if (row.kind === "directory") mkdirSync(join(cwd, "dir"));
+		else if (row.kind === "text") writeFileSync(join(cwd, "notes.txt"), "hello");
+		else if (row.kind === "image") writeFileSync(join(cwd, "image.png"), bytes);
+		else {
+			writeFileSync(outside, bytes);
+			if (row.kind === "symlink") symlinkSync(outside, join(cwd, "linked.png"));
+		}
+		const input = { path: row.path === "absolute" ? outside : row.path, detail: "detail" in row ? row.detail : undefined };
+		const validate = () => validateImagePath(input, cwd, { workspaceOnly: row.workspaceOnly });
+		if ("code" in row) await assert.rejects(validate, { code: row.code, path: input.path });
+		else {
+			const result = await validate();
+			assert.equal(result.mimeType, "image/png");
+			assert.equal(result.absolutePath, row.kind === "outside" ? outside : join(cwd, "image.png"));
+			if (row.kind === "image") {
+				assert.equal(result.displayPath, "image.png");
+				assert.equal(result.detail, "high");
+			}
+		}
+	});
 }
-
-test("view_image validates local image files and strips @ prefix", async () => {
-	const cwd = tempDir();
-	writeFileSync(join(cwd, "image.png"), Buffer.from([0x89, 0x50, 0x4e, 0x47]));
-	const validated = await validateImagePath({ path: "@image.png", detail: "high" }, cwd);
-	assert.equal(validated.displayPath, "image.png");
-	assert.equal(validated.mimeType, "image/png");
-	assert.equal(validated.detail, "high");
-	const result = await viewImage({ path: "image.png" }, cwd);
-	assert.equal(result.content[0]?.type, "image");
-	assert.equal(result.content[0]?.mimeType, "image/png");
-	assert.equal(typeof result.content[0]?.data, "string");
-});
-
-test("view_image rejects directories and non-images", async () => {
-	const cwd = tempDir();
-	mkdirSync(join(cwd, "dir"));
-	writeFileSync(join(cwd, "notes.txt"), "hello");
-	await assert.rejects(() => validateImagePath({ path: "dir" }, cwd), /directory/);
-	await assert.rejects(() => validateImagePath({ path: "notes.txt" }, cwd), /Unsupported image file type/);
-});
-
-test("view_image rejects paths outside cwd when workspaceOnly", async () => {
-	const cwd = tempDir();
-	const outside = tempDir();
-	writeFileSync(join(outside, "secret.png"), Buffer.from([0x89, 0x50, 0x4e, 0x47]));
-	await assert.rejects(() => validateImagePath({ path: "../secret.png" }, cwd, { workspaceOnly: true }), /escapes the workspace/);
-	await assert.rejects(() => validateImagePath({ path: join(outside, "secret.png") }, cwd, { workspaceOnly: true }), /escapes the workspace/);
-});
-
-test("view_image rejects symlinks that resolve outside cwd when workspaceOnly", async () => {
-	const cwd = tempDir();
-	const outside = tempDir();
-	writeFileSync(join(outside, "secret.png"), Buffer.from([0x89, 0x50, 0x4e, 0x47]));
-	symlinkSync(join(outside, "secret.png"), join(cwd, "linked.png"));
-	await assert.rejects(() => validateImagePath({ path: "linked.png" }, cwd, { workspaceOnly: true }), /escapes the workspace/);
-});
-
-test("view_image allows paths outside cwd by default", async () => {
-	const cwd = tempDir();
-	const outside = tempDir();
-	const outsidePath = join(outside, "clip.png");
-	writeFileSync(outsidePath, Buffer.from([0x89, 0x50, 0x4e, 0x47]));
-	const validated = await validateImagePath({ path: outsidePath }, cwd);
-	assert.equal(validated.absolutePath, outsidePath);
-	assert.equal(validated.mimeType, "image/png");
-});

--- a/pi-extensions/pi-codex-minimal-tools/tests/websocket-options.test.ts
+++ b/pi-extensions/pi-codex-minimal-tools/tests/websocket-options.test.ts
@@ -1,0 +1,14 @@
+import type { Dispatcher } from "undici";
+import assert from "node:assert/strict";
+import test from "node:test";
+import { webSocketOptionsForUrl } from "../src/provider-shim.js";
+import { environment, noProxyEnvironment } from "./helpers/world.js";
+
+test("websocket options carry the proxy dispatcher and authorization", async (t) => {
+	environment(t, { ...noProxyEnvironment, HTTPS_PROXY: "http://proxy.example:8080" });
+	const options = await webSocketOptionsForUrl("wss://chatgpt.com/backend-api/codex/responses", { Authorization: "Bearer token" });
+	t.after(async () => { await (options.dispatcher as Dispatcher | undefined)?.close(); });
+	assert.equal(options.headers.Authorization, "Bearer token");
+	assert.equal("proxy" in options, false);
+	assert.ok(options.dispatcher);
+});


### PR DESCRIPTION
Codex tool tests can read personal Pi settings and write fixture images into the configured user image directory. The tests now own their project, settings, and image directories. Request deadline tests use a controlled clock and wait for the real abort signal.

- Audit scope: `pi-extensions/pi-codex-minimal-tools`. Split mixed test files by production function. Table the provider, grammar, stream-event, settings, and path cases. Keep patch transaction sequencing and each file-effect assertion.
- Patch and image refusals expose codes and paths. Grammar schema and header-timeout failures expose stable first-line values. Tests use those values instead of English explanations. The provider header records the HTTP-prefix protocol consumed by Pi retry classification.
- Compliant file left unchanged: `tests/provider-native-tools.test.ts`. The declaration, image-save, image-request, and pure utility rows retain their behavioral assertions in their named destination files.
- Removed prose-only claims: renderer description/prompt text is replaced by registered-tool execution, returned content, and file effects. Empty tool results assert a non-empty function output instead of a specific English placeholder. Image request and error-summary tests assert upstream payload values instead of fixed explanatory wording.
- Validation: package type checking and all 118 package tests pass. One must-fail control per changed behavior surface catches planted defects. `env -u TMPDIR tools/guard --full` exits 0 on `00e476579`. The inherited temporary directory is inside the user project ancestry; the standard system temporary directory preserves the CLI fixture contract. CI results are recorded on this PR.

Part of KEN-1241. This PR does not close the issue.
