### PR TITLE
fix(core): give hook notices stable values (KEN-1241)

### DIFF
--- a/changelog.d/changed/core-hook-messages.md
+++ b/changelog.d/changed/core-hook-messages.md
@@ -1,1 +1,1 @@
-- Session drift notices, missing project-hook refusals and unsupported hook events start with stable keys and their relevant values. Explanations follow on separate lines.
+- Hook and rendering notices start with stable reason keys and relevant values, followed by their English explanation.

--- a/changelog.d/changed/core-hook-messages.md
+++ b/changelog.d/changed/core-hook-messages.md
@@ -1,1 +1,1 @@
-- Hook and rendering notices start with stable reason keys and escaped values, followed by their English explanation.
+- Hook and rendering notices start with stable reason keys, escaped values and the source of hook exclusions, followed by their English explanation.

--- a/changelog.d/changed/core-hook-messages.md
+++ b/changelog.d/changed/core-hook-messages.md
@@ -1,0 +1,1 @@
+- Session drift notices, missing project-hook refusals and unsupported hook events start with stable keys and their relevant values. Explanations follow on separate lines.

--- a/changelog.d/changed/core-hook-messages.md
+++ b/changelog.d/changed/core-hook-messages.md
@@ -1,1 +1,1 @@
-- Hook and rendering notices start with stable reason keys and relevant values, followed by their English explanation.
+- Hook and rendering notices start with stable reason keys and escaped values, followed by their English explanation.

--- a/crates/cli/tests/refresh_ledger/conflicts.rs
+++ b/crates/cli/tests/refresh_ledger/conflicts.rs
@@ -257,15 +257,13 @@ fn a_hook_that_skips_a_tool_names_the_file_that_decides_it() {
         "[hooks.block-unsafe-rm]\nsource = \"cat\"\n",
     );
 
-    let printed = said(&kendex(
-        home,
-        &project,
-        &["apply", "--plan", "--scope", "project"],
-    ));
+    let output = kendex(home, &project, &["apply", "--plan", "--scope", "project"]);
+    let printed = said(&output);
+    assert_eq!(output.status.code(), Some(0), "{printed}");
     assert!(
-        printed.contains(
-            "hook block-unsafe-rm: skips pi — pi is not in the hook's own harnesses line in the catalog; add it there, or list this hook's harnesses in kendex.toml without pi"
-        ),
-        "the note names what decides the skip and both answers to it: {printed}"
+        printed.lines().any(|line| line.starts_with(
+            r"note: kendex-hook-excluded: hook=block-unsafe-rm harness=pi source=catalog field=harnesses\n"
+        )),
+        "the note identifies the catalog field that decides the skip: {printed}"
     );
 }

--- a/crates/core/src/discover.rs
+++ b/crates/core/src/discover.rs
@@ -166,26 +166,28 @@ mod tests {
 
     #[test]
     fn project_root_walks_up_and_lock_file_wins_at_home() {
-        let tmp = tempfile::tempdir().unwrap();
-        let home = tmp.path();
-        fs::create_dir_all(home.join("dev/app/.claude")).unwrap();
-        fs::create_dir_all(home.join("dev/app/src/nested")).unwrap();
-
-        let found = project_root_from(&home.join("dev/app/src/nested"), home).unwrap();
-        assert_eq!(
-            found,
-            crate::paths::canonical(&home.join("dev/app")).unwrap()
-        );
-
-        // Markers at home itself never make home the project…
-        fs::create_dir_all(home.join(".claude")).unwrap();
-        assert_eq!(project_root_from(&home.join("dev"), home), None);
-
-        // …but a lock file there does.
-        fs::write(home.join(".kendex-lock.json"), "{}").unwrap();
-        assert_eq!(
-            project_root_from(&home.join("dev"), home).unwrap(),
-            crate::paths::canonical(home).unwrap()
-        );
+        for (start, lock_at_home, expected) in [
+            ("home/dev/app/src/nested", false, "home/dev/app"),
+            ("home/dev", false, ""),
+            ("home/dev", true, "home"),
+        ] {
+            let tmp = tempfile::tempdir().unwrap();
+            let root = crate::paths::canonical(tmp.path()).unwrap();
+            let home = root.join("home");
+            // The private ancestor catches a walk past home before any
+            // real marker above the fixture can decide the answer.
+            fs::create_dir_all(root.join(".claude")).unwrap();
+            fs::create_dir_all(home.join(".claude")).unwrap();
+            fs::create_dir_all(home.join("dev/app/.claude")).unwrap();
+            fs::create_dir_all(home.join("dev/app/src/nested")).unwrap();
+            if lock_at_home {
+                fs::write(home.join(".kendex-lock.json"), "{}").unwrap();
+            }
+            assert_eq!(
+                project_root_from(&root.join(start), &home),
+                Some(root.join(expected)),
+                "{start}, home lock={lock_at_home}",
+            );
+        }
     }
 }

--- a/crates/core/src/drift/hook.rs
+++ b/crates/core/src/drift/hook.rs
@@ -14,15 +14,8 @@ use crate::model::{HarnessId, Scope};
 
 pub const HOOK_NAME: &str = "kendex-drift";
 
-/// The hook script, in the catalog hook format. The contract lines:
-/// `KENDEX_DRIFT_HOOK=off` kills it, resumed and compacted
-/// sessions are skipped, a missing binary prints one "skipped" line, and
-/// it always exits 0 — a drift report must never block a session. Exit
-/// codes classify the way `hooks/session-drift-check.sh` and the pi-hooks
-/// port classify them: 1 is the report verbatim, 2 is the report under an
-/// "incomplete" line — or "could not run" when the output is an Error:
-/// or usage error: line from before the check read anything, or nothing
-/// at all — and any other code is "could not run".
+/// The session-start script. Its header defines the CLI report protocol and
+/// the stable keys of notices the hook adds. It never blocks a session.
 pub const HOOK_SCRIPT: &str = r#"#!/bin/sh
 # ---
 # name: kendex-drift
@@ -31,9 +24,23 @@ pub const HOOK_SCRIPT: &str = r#"#!/bin/sh
 # timeout: 20
 # harnesses: [claude-code, pi]
 # ---
-# kendex drift report — what is stale, gone from its source, broken, or
-# not evaluated yet, each line naming its fix. Silent when everything is
-# current: a clean session starts clean.
+# kendex check --quiet protocol: exit 0 is silent, exit 1 relays the report.
+# Exit 2 with empty output or a leading Error:/error: is a pre-check failure;
+# other exit-2 output is an incomplete report. Other exits are failures.
+# Error:/error: belongs to the CLI's parsed error protocol. The remaining
+# report is opaque data; Claude and Pi receive it without interpretation.
+# Shell substitution removes trailing newlines; a relayed report gets one.
+# Hook notices start with a stable key and command or exit value. English
+# follows on the next line, then any report. The hook always exits 0.
+
+notice() {
+  case "$1" in
+    unavailable) explanation="The drift check was skipped because kendex is not on PATH." ;;
+    failed) explanation="The drift check could not run. Drift status is unknown." ;;
+    incomplete) explanation="The drift check is incomplete. Some drift status is unknown." ;;
+  esac
+  printf 'kendex-drift-%s: %s\n%s\n' "$1" "$2" "$explanation"
+}
 
 [ "${KENDEX_DRIFT_HOOK:-}" = "off" ] && exit 0
 
@@ -51,7 +58,7 @@ case "$input" in
 esac
 
 if ! command -v kendex >/dev/null 2>&1; then
-  echo "kendex: drift check skipped (kendex is not on PATH)"
+  notice unavailable "command=kendex"
   exit 0
 fi
 
@@ -65,18 +72,11 @@ case "$code" in
   1) ;;
   2)
     case "$report" in
-      "") echo "kendex check could not run (exit 2); drift status unknown" ;;
-      Error:* | error:*)
-        printf 'kendex check could not run (exit 2); drift status unknown:\n%s\n' "$report" ;;
-      *)
-        printf 'kendex check incomplete (exit 2); some drift status unknown:\n%s\n' "$report" ;;
+      "" | Error:* | error:*) notice failed "exit=$code" ;;
+      *) notice incomplete "exit=$code" ;;
     esac
-    exit 0
     ;;
-  *)
-    printf 'kendex check could not run (exit %s); drift status unknown:\n%s\n' "$code" "$report"
-    exit 0
-    ;;
+  *) notice failed "exit=$code" ;;
 esac
 if [ -n "$report" ]; then
   printf '%s\n' "$report"

--- a/crates/core/src/engine/antigravity.rs
+++ b/crates/core/src/engine/antigravity.rs
@@ -12,8 +12,9 @@ use crate::model::{HarnessId, ItemKind};
 pub(super) fn hook(name: &str, hook: &HookSpec, state: &mut DesiredState) -> Option<HookSpec> {
     if hook.harnesses.is_none() {
         state.notes.push(format!(
-            "kendex-hook-unlisted: harness=antigravity hook={name}\n{}",
-            crate::hook::by_name_only(HarnessId::Antigravity)
+            "kendex-hook-unlisted: harness=antigravity hook={record_name}\n{arg0}",
+            arg0 = crate::hook::by_name_only(HarnessId::Antigravity),
+            record_name = crate::names::shown(name),
         ));
         return None;
     }
@@ -31,8 +32,9 @@ pub(super) fn hook(name: &str, hook: &HookSpec, state: &mut DesiredState) -> Opt
             name: name.to_owned(),
             harness: Some(HarnessId::Antigravity),
             message: format!(
-                "Antigravity matches `{}` against its own tool names, and this matcher carries syntax kendex cannot restate in them — it installs as written and may never match",
-                hook.matcher.as_deref().unwrap_or_default()
+                "kendex-hook-matcher-untranslated: harness=antigravity hook={record_name} matcher={record_arg0}\nAntigravity matches this against its own tool names, and this matcher carries syntax kendex cannot restate in them — it installs as written and may never match",
+                record_name = crate::names::shown(name),
+                record_arg0 = crate::names::shown(hook.matcher.as_deref().unwrap_or_default()),
             ),
             remediation: Some(
                 "write the matcher as plain tool names separated by `|`, or check it against Antigravity's names (`run_command`, `view_file`, `write_to_file`)"

--- a/crates/core/src/engine/antigravity.rs
+++ b/crates/core/src/engine/antigravity.rs
@@ -12,15 +12,16 @@ use crate::model::{HarnessId, ItemKind};
 pub(super) fn hook(name: &str, hook: &HookSpec, state: &mut DesiredState) -> Option<HookSpec> {
     if hook.harnesses.is_none() {
         state.notes.push(format!(
-            "hook {name}: skips antigravity — {}",
+            "kendex-hook-unlisted: harness=antigravity hook={name}\n{}",
             crate::hook::by_name_only(HarnessId::Antigravity)
         ));
         return None;
     }
     let Some(registered) = crate::harness::antigravity::hook_for(hook) else {
-        state.notes.push(format!(
-            "hook {name}: event {} has no Antigravity counterpart, and hanging it on a near-miss would run it at the wrong moment",
-            hook.event
+        state.notes.push(super::targets::unsupported_hook_event(
+            name,
+            &hook.event,
+            HarnessId::Antigravity,
         ));
         return None;
     };
@@ -69,16 +70,22 @@ mod server_tests {
 
     #[test]
     fn a_remote_server_is_keyed_server_url_and_a_command_server_kept() {
-        assert_eq!(
-            super::server(&json!({"type": "http", "url": "https://mcp.example"})),
-            json!({"serverUrl": "https://mcp.example"})
-        );
-        assert_eq!(
-            super::server(&json!({"type": "sse", "url": "https://mcp.example/sse"})),
-            json!({"serverUrl": "https://mcp.example/sse"})
-        );
-        let stdio = json!({"command": "gh-mcp", "args": ["--stdio"]});
-        assert_eq!(super::server(&stdio), stdio);
+        for (input, expected) in [
+            (
+                json!({"type": "http", "url": "https://mcp.example"}),
+                json!({"serverUrl": "https://mcp.example"}),
+            ),
+            (
+                json!({"type": "sse", "url": "https://mcp.example/sse"}),
+                json!({"serverUrl": "https://mcp.example/sse"}),
+            ),
+            (
+                json!({"command": "gh-mcp", "args": ["--stdio"]}),
+                json!({"command": "gh-mcp", "args": ["--stdio"]}),
+            ),
+        ] {
+            assert_eq!(super::server(&input), expected, "{input}");
+        }
         // The endpoint stays visible to the safety rules under its new key.
         let scored = crate::quality::McpEntry::from_json(&super::server(
             &json!({"type": "http", "url": "https://u:secret@mcp.example"}),

--- a/crates/core/src/engine/copilot.rs
+++ b/crates/core/src/engine/copilot.rs
@@ -49,9 +49,10 @@ pub(super) fn hook(
         remediation,
     };
     let Some(registered) = crate::harness::copilot::hook_for(hook) else {
-        state.notes.push(format!(
-            "hook {name}: event {} has no Copilot counterpart, and hanging it on a near-miss would run it at the wrong moment",
-            hook.event
+        state.notes.push(super::targets::unsupported_hook_event(
+            name,
+            &hook.event,
+            HarnessId::Copilot,
         ));
         return None;
     };
@@ -70,7 +71,7 @@ pub(super) fn hook(
     if let Some(path) = settings::hooks_switched_off_by(env, scope) {
         state.warnings.push(named(
             format!(
-                "`disableAllHooks` is on in {}, which switches off every Copilot hook — as configured, this one installs but stays inert",
+                "kendex-hooks-disabled: harness=copilot hook={name} setting=disableAllHooks\n`disableAllHooks` is on in {}, which switches off every Copilot hook — as configured, this one installs but stays inert",
                 path.display()
             ),
             Some(
@@ -102,7 +103,7 @@ pub(super) fn switched_off_elsewhere(ctx: &ItemCtx, kind: ItemKind, state: &mut 
         ctx,
         kind,
         format!(
-            "your personal Copilot settings list {} in `{key}`, and a repository can only add names to that list — as configured, this project cannot switch it back on",
+            "kendex-item-disabled: harness=copilot item={0} setting={key}\nYour personal Copilot settings list {0} in `{key}`, and a repository can only add names to that list — as configured, this project cannot switch it back on",
             ctx.name
         ),
         Some(format!(
@@ -132,7 +133,9 @@ pub(super) fn agent_notices(ctx: &ItemCtx, state: &mut DesiredState, model: Opti
         ctx,
         ItemKind::Agent,
         format!(
-            "this repository's `.github/allowed_models.txt` allows {} and not {model} — as configured, Copilot will not run this agent on the model it names",
+            "kendex-model-disallowed: harness=copilot agent={} requested={model} allowed={}\nThis repository's `.github/allowed_models.txt` allows {} and not {model} — as configured, Copilot will not run this agent on the model it names",
+            ctx.name,
+            patterns.join(","),
             patterns.join(", ")
         ),
         Some("pick a model the repository allows, or add this one to that file".to_owned()),

--- a/crates/core/src/engine/copilot.rs
+++ b/crates/core/src/engine/copilot.rs
@@ -171,13 +171,21 @@ mod tests {
 
     #[test]
     fn a_command_server_is_typed_local_and_a_url_server_keeps_its_transport() {
-        assert_eq!(
-            server(&json!({"command": "gh-mcp", "args": ["--stdio"]})),
-            json!({"type": "local", "command": "gh-mcp", "args": ["--stdio"]})
-        );
-        let http = json!({"type": "http", "url": "https://mcp.example"});
-        assert_eq!(server(&http), http);
-        let sse = json!({"type": "sse", "url": "https://mcp.example"});
-        assert_eq!(server(&sse), sse);
+        for (input, expected) in [
+            (
+                json!({"command": "gh-mcp", "args": ["--stdio"]}),
+                json!({"type": "local", "command": "gh-mcp", "args": ["--stdio"]}),
+            ),
+            (
+                json!({"type": "http", "url": "https://mcp.example"}),
+                json!({"type": "http", "url": "https://mcp.example"}),
+            ),
+            (
+                json!({"type": "sse", "url": "https://mcp.example"}),
+                json!({"type": "sse", "url": "https://mcp.example"}),
+            ),
+        ] {
+            assert_eq!(server(&input), expected, "{input}");
+        }
     }
 }

--- a/crates/core/src/engine/copilot.rs
+++ b/crates/core/src/engine/copilot.rs
@@ -59,8 +59,9 @@ pub(super) fn hook(
     if registered.matcher_as_authored {
         state.warnings.push(named(
             format!(
-                "Copilot matches `{}` against its own tool names, and this matcher carries syntax kendex cannot restate in them — it installs as written and may never match",
-                hook.matcher.as_deref().unwrap_or_default()
+                "kendex-hook-matcher-untranslated: harness=copilot hook={record_name} matcher={record_arg0}\nCopilot matches this against its own tool names, and this matcher carries syntax kendex cannot restate in them — it installs as written and may never match",
+                record_name = crate::names::shown(name),
+                record_arg0 = crate::names::shown(hook.matcher.as_deref().unwrap_or_default()),
             ),
             Some(
                 "write the matcher as plain tool names separated by `|`, or check it against Copilot's names (`bash`, `read`, `write`)"
@@ -71,8 +72,9 @@ pub(super) fn hook(
     if let Some(path) = settings::hooks_switched_off_by(env, scope) {
         state.warnings.push(named(
             format!(
-                "kendex-hooks-disabled: harness=copilot hook={name} setting=disableAllHooks\n`disableAllHooks` is on in {}, which switches off every Copilot hook — as configured, this one installs but stays inert",
-                path.display()
+                "kendex-hooks-disabled: harness=copilot hook={record_name} setting=disableAllHooks\n`disableAllHooks` is on in {arg0}, which switches off every Copilot hook — as configured, this one installs but stays inert",
+                arg0 = path.display(),
+                record_name = crate::names::shown(name),
             ),
             Some(
                 "set `disableAllHooks` to false there, or drop Copilot from this hook's harnesses"
@@ -103,8 +105,10 @@ pub(super) fn switched_off_elsewhere(ctx: &ItemCtx, kind: ItemKind, state: &mut 
         ctx,
         kind,
         format!(
-            "kendex-item-disabled: harness=copilot item={0} setting={key}\nYour personal Copilot settings list {0} in `{key}`, and a repository can only add names to that list — as configured, this project cannot switch it back on",
-            ctx.name
+            "kendex-item-disabled: harness=copilot item={record_arg0} setting={record_key}\nYour personal Copilot settings list {arg0} in `{key}`, and a repository can only add names to that list — as configured, this project cannot switch it back on",
+            arg0 = ctx.name,
+            record_arg0 = crate::names::shown(ctx.name),
+            record_key = crate::names::shown(key),
         ),
         Some(format!(
             "take {} out of `{key}` in {}",
@@ -133,10 +137,11 @@ pub(super) fn agent_notices(ctx: &ItemCtx, state: &mut DesiredState, model: Opti
         ctx,
         ItemKind::Agent,
         format!(
-            "kendex-model-disallowed: harness=copilot agent={} requested={model} allowed={}\nThis repository's `.github/allowed_models.txt` allows {} and not {model} — as configured, Copilot will not run this agent on the model it names",
-            ctx.name,
-            patterns.join(","),
-            patterns.join(", ")
+            "kendex-model-disallowed: harness=copilot agent={record_arg0} requested={record_model} allowed={record_arg1}\nThis repository's `.github/allowed_models.txt` allows {arg2} and not {model} — as configured, Copilot will not run this agent on the model it names",
+            arg2 = patterns.join(", "),
+            record_arg0 = crate::names::shown(ctx.name),
+            record_model = crate::names::shown(model),
+            record_arg1 = crate::names::shown(&patterns.join(",")),
         ),
         Some("pick a model the repository allows, or add this one to that file".to_owned()),
     ));

--- a/crates/core/src/engine/desired_custom_hooks.rs
+++ b/crates/core/src/engine/desired_custom_hooks.rs
@@ -67,9 +67,9 @@ pub(super) fn desired_custom_hooks(
                 // silence as enforcement.
                 Delivery::NotInstallable(reason) if harness.hooks_by_name_only() => {
                     state.notes.push(format!(
-                        "hook {}: skips {} — {reason}",
-                        name,
-                        harness.name()
+                        "kendex-custom-hook-unlisted: hook={record_arg0} harness={record_arg1}\n{reason}",
+                        record_arg0 = crate::names::shown(&name),
+                        record_arg1 = crate::names::shown(harness.name()),
                     ));
                     continue;
                 }
@@ -126,13 +126,18 @@ fn advisory_downgrade(harness: HarnessId, spec: &HookSpec) -> String {
         && !spec.every_agent()
     {
         return format!(
-            "{} cannot tell agents apart at runtime, so a hook for specific agents is written into them as instructions — nothing enforces it there",
-            harness.display_name()
+            "kendex-custom-hook-unscoped: harness={record_arg0} hook={record_arg1}\n{arg2} cannot tell agents apart at runtime, so a hook for specific agents is written into them as instructions — nothing enforces it there",
+            arg2 = harness.display_name(),
+            record_arg0 = crate::names::shown(harness.name()),
+            record_arg1 = crate::names::shown(&spec.name),
         );
     }
     format!(
-        "{} never fires {}, so this hook is written into the agents as instructions — nothing enforces it there",
-        harness.display_name(),
-        spec.event
+        "kendex-custom-hook-advisory: harness={record_arg0} hook={record_arg1} event={record_arg2}\n{arg3} never fires {arg4}, so this hook is written into the agents as instructions — nothing enforces it there",
+        arg3 = harness.display_name(),
+        arg4 = spec.event,
+        record_arg0 = crate::names::shown(harness.name()),
+        record_arg1 = crate::names::shown(&spec.name),
+        record_arg2 = crate::names::shown(&spec.event),
     )
 }

--- a/crates/core/src/engine/desired_item.rs
+++ b/crates/core/src/engine/desired_item.rs
@@ -69,9 +69,10 @@ pub(super) fn no_harness_note(
         .as_ref()
         .unwrap_or(&manifest.install.harnesses);
     state.notes.push(format!(
-        "kendex-item-unsupported: kind={} name={name} harnesses={}\n{} cannot hold one at this scope — nothing was installed",
-        kind.name(),
-        asked.iter().map(|harness| harness.name()).collect::<Vec<_>>().join(","),
-        asked.iter().map(|harness| harness.display_name()).collect::<Vec<_>>().join(", "),
+        "kendex-item-unsupported: kind={record_arg0} name={record_name} harnesses={record_arg1}\n{arg2} cannot hold one at this scope — nothing was installed",
+        arg2 = asked.iter().map(|harness| harness.display_name()).collect::<Vec<_>>().join(", "),
+        record_arg0 = crate::names::shown(kind.name()),
+        record_name = crate::names::shown(name),
+        record_arg1 = crate::names::shown(&asked.iter().map(|harness| harness.name()).collect::<Vec<_>>().join(",")),
     ));
 }

--- a/crates/core/src/engine/desired_item.rs
+++ b/crates/core/src/engine/desired_item.rs
@@ -64,16 +64,14 @@ pub(super) fn no_harness_note(
     state: &mut DesiredState,
 ) {
     state.mark_incomplete();
-    let asked: Vec<&str> = decl
+    let asked = decl
         .harnesses
         .as_ref()
-        .unwrap_or(&manifest.install.harnesses)
-        .iter()
-        .map(|harness| harness.display_name())
-        .collect();
+        .unwrap_or(&manifest.install.harnesses);
     state.notes.push(format!(
-        "{} {name}: {} cannot hold one at this scope — nothing was installed",
+        "kendex-item-unsupported: kind={} name={name} harnesses={}\n{} cannot hold one at this scope — nothing was installed",
         kind.name(),
-        asked.join(", ")
+        asked.iter().map(|harness| harness.name()).collect::<Vec<_>>().join(","),
+        asked.iter().map(|harness| harness.display_name()).collect::<Vec<_>>().join(", "),
     ));
 }

--- a/crates/core/src/engine/desired_kinds.rs
+++ b/crates/core/src/engine/desired_kinds.rs
@@ -73,7 +73,7 @@ pub(super) fn desired_hook(ctx: &ItemCtx, state: &mut DesiredState) -> Result<()
             // own frontmatter, not the manifest — a remedy naming the
             // manifest would widen the install set and change nothing.
             state.notes.push(format!(
-                "kendex-hook-excluded: hook={record_arg0} harness={record_arg1}\n{arg2} is not in the hook's own harnesses line in the catalog; add it there, or list this hook's harnesses in kendex.toml without {arg3}",
+                "kendex-hook-excluded: hook={record_arg0} harness={record_arg1} source=catalog field=harnesses\n{arg2} is not in the hook's own harnesses line in the catalog; add it there, or list this hook's harnesses in kendex.toml without {arg3}",
                 arg2 = harness.name(),
                 arg3 = harness.name(),
                 record_arg0 = crate::names::shown(ctx.name ),

--- a/crates/core/src/engine/desired_kinds.rs
+++ b/crates/core/src/engine/desired_kinds.rs
@@ -110,35 +110,21 @@ pub(super) fn restated_hook_artifact(
     harness: HarnessId,
     state: &mut DesiredState,
 ) -> Option<Artifact> {
-    if harness == HarnessId::Codex && codex_event(&hook.event).is_none() {
+    let event = match harness {
+        HarnessId::Codex => codex_event(&hook.event).map(|_| hook.event.as_str()),
+        HarnessId::Pi => crate::harness::pi_listener(&hook.event),
+        _ => Some(hook.event.as_str()),
+    };
+    let Some(event) = event else {
         state.notes.push(format!(
-            "hook {name}: event {} unsupported on codex — advisory prose lands with the customization editor",
-            hook.event
+            "kendex-hook-unsupported: harness={} event={} hook={name}\nThis harness cannot run the hook event. Nothing is installed for it.",
+            harness.name(), hook.event
         ));
         return None;
-    }
-    // Pi fires a fixed set of listeners through the pi-hooks carrier;
-    // an event outside that set cannot run there and installs nothing —
-    // honesty over prose (a stale advisory drift claim is worse than
-    // none). A mappable event is restated in the listener's name, and
-    // a scope with no carrier registered anywhere Pi loads gets the
-    // downgrade said per item, because the rendered registry is prose
-    // until something executes it.
-    let hook = match harness {
-        HarnessId::Pi => {
-            let Some(listener) = crate::harness::pi_listener(&hook.event) else {
-                state.notes.push(format!(
-                    "hook {name}: event {} unsupported on pi — pi fires no such listener",
-                    hook.event
-                ));
-                return None;
-            };
-            HookSpec {
-                event: listener.to_owned(),
-                ..hook.clone()
-            }
-        }
-        _ => hook.clone(),
+    };
+    let hook = HookSpec {
+        event: event.to_owned(),
+        ..hook.clone()
     };
     // Gemini and Copilot each name the lifecycle events their own way,
     // so the hook is restated in the reader's words — and whatever their

--- a/crates/core/src/engine/desired_kinds.rs
+++ b/crates/core/src/engine/desired_kinds.rs
@@ -57,7 +57,10 @@ pub(super) fn desired_hook(ctx: &ItemCtx, state: &mut DesiredState) -> Result<()
             state.unreadable(
                 ItemKind::Hook,
                 ctx.name,
-                format!("hook {}: unreadable — {problem}", ctx.name),
+                format!(
+                    "kendex-hook-unreadable: hook={record_arg0}\nThe hook could not be read: {problem}",
+                    record_arg0 = crate::names::shown(ctx.name ),
+                ),
             );
             return Ok(());
         }
@@ -70,11 +73,11 @@ pub(super) fn desired_hook(ctx: &ItemCtx, state: &mut DesiredState) -> Result<()
             // own frontmatter, not the manifest — a remedy naming the
             // manifest would widen the install set and change nothing.
             state.notes.push(format!(
-                "hook {}: skips {} — {} is not in the hook's own harnesses line in the catalog; add it there, or list this hook's harnesses in kendex.toml without {}",
-                ctx.name,
-                harness.name(),
-                harness.name(),
-                harness.name()
+                "kendex-hook-excluded: hook={record_arg0} harness={record_arg1}\n{arg2} is not in the hook's own harnesses line in the catalog; add it there, or list this hook's harnesses in kendex.toml without {arg3}",
+                arg2 = harness.name(),
+                arg3 = harness.name(),
+                record_arg0 = crate::names::shown(ctx.name ),
+                record_arg1 = crate::names::shown(harness.name() ),
             ));
             continue;
         }

--- a/crates/core/src/engine/desired_kinds.rs
+++ b/crates/core/src/engine/desired_kinds.rs
@@ -116,9 +116,10 @@ pub(super) fn restated_hook_artifact(
         _ => Some(hook.event.as_str()),
     };
     let Some(event) = event else {
-        state.notes.push(format!(
-            "kendex-hook-unsupported: harness={} event={} hook={name}\nThis harness cannot run the hook event. Nothing is installed for it.",
-            harness.name(), hook.event
+        state.notes.push(super::targets::unsupported_hook_event(
+            name,
+            &hook.event,
+            harness,
         ));
         return None;
     };

--- a/crates/core/src/engine/desired_mcp.rs
+++ b/crates/core/src/engine/desired_mcp.rs
@@ -125,7 +125,7 @@ fn refusal(harness: HarnessId, value: &Value) -> Option<String> {
                 .and_then(Value::as_object)
                 .is_some_and(|env| !env.is_empty()) =>
         {
-            Some("Antigravity documents no substitution for an environment value, so a $NAME reference would reach the server as text — declare the server without env, or drop Antigravity from its harnesses".to_owned())
+            Some("kendex-mcp-env-unsupported: harness=antigravity\nAntigravity documents no substitution for an environment value, so a $NAME reference would reach the server as text — declare the server without env, or drop Antigravity from its harnesses".to_owned())
         }
         HarnessId::Codex => env.and_then(|env| crate::configedit::codex_env_vars(env).err()),
         _ => None,

--- a/crates/core/src/engine/desired_skill.rs
+++ b/crates/core/src/engine/desired_skill.rs
@@ -85,18 +85,21 @@ fn cross_read_note(ctx: &ItemCtx, method: Method, state: &mut DesiredState) {
         Scope::Project { .. } => "`.agents/skills`",
     };
     let note = format!(
-        "kendex-shared-skills: readers={} path={}\n{} read {where_} too, so what is installed here is already visible to them — one definition, counted once",
-        readers
-            .iter()
-            .map(|harness| harness.name())
-            .collect::<Vec<_>>()
-            .join(","),
-        where_.trim_matches('`'),
-        readers
+        "kendex-shared-skills: readers={record_arg0} path={record_arg1}\n{arg2} read {where_} too, so what is installed here is already visible to them — one definition, counted once",
+        arg2 = readers
             .iter()
             .map(|harness| harness.display_name())
             .collect::<Vec<_>>()
-            .join(", ")
+            .join(", "),
+        record_arg0 = crate::names::shown(
+            &(readers
+                .iter()
+                .map(|harness| harness.name())
+                .collect::<Vec<_>>()
+                .join(","))
+            .to_string()
+        ),
+        record_arg1 = crate::names::shown(where_.trim_matches('`')),
     );
     if !state.notes.contains(&note) {
         state.notes.push(note);

--- a/crates/core/src/engine/desired_skill.rs
+++ b/crates/core/src/engine/desired_skill.rs
@@ -51,7 +51,7 @@ fn cross_read_note(ctx: &ItemCtx, method: Method, state: &mut DesiredState) {
     // The name the shared tree lists it under, which is what each reader's
     // loader is held to.
     let installed = crate::harness::canonical_name(ctx.name);
-    let readers: Vec<String> = HarnessId::ALL
+    let readers: Vec<HarnessId> = HarnessId::ALL
         .into_iter()
         .filter(|harness| !ctx.harnesses.contains(harness))
         .filter(|harness| {
@@ -74,7 +74,6 @@ fn cross_read_note(ctx: &ItemCtx, method: Method, state: &mut DesiredState) {
                 .iter()
                 .all(|finding| !finding.is_breakage())
         })
-        .map(|harness| harness.display_name().to_owned())
         .collect();
     if readers.is_empty() {
         return;
@@ -86,8 +85,18 @@ fn cross_read_note(ctx: &ItemCtx, method: Method, state: &mut DesiredState) {
         Scope::Project { .. } => "`.agents/skills`",
     };
     let note = format!(
-        "skills: {} read {where_} too, so what is installed here is already visible to them — one definition, counted once",
-        readers.join(", ")
+        "kendex-shared-skills: readers={} path={}\n{} read {where_} too, so what is installed here is already visible to them — one definition, counted once",
+        readers
+            .iter()
+            .map(|harness| harness.name())
+            .collect::<Vec<_>>()
+            .join(","),
+        where_.trim_matches('`'),
+        readers
+            .iter()
+            .map(|harness| harness.display_name())
+            .collect::<Vec<_>>()
+            .join(", ")
     );
     if !state.notes.contains(&note) {
         state.notes.push(note);

--- a/crates/core/src/engine/gemini.rs
+++ b/crates/core/src/engine/gemini.rs
@@ -243,15 +243,21 @@ mod tests {
 
     #[test]
     fn a_streamable_http_server_is_keyed_apart_from_an_sse_one() {
-        assert_eq!(
-            server(&json!({"type": "http", "url": "https://mcp.example"})),
-            json!({"httpUrl": "https://mcp.example"})
-        );
-        assert_eq!(
-            server(&json!({"type": "sse", "url": "https://mcp.example"})),
-            json!({"url": "https://mcp.example"})
-        );
-        let stdio = json!({"command": "gh-mcp", "args": ["--stdio"]});
-        assert_eq!(server(&stdio), stdio);
+        for (input, expected) in [
+            (
+                json!({"type": "http", "url": "https://mcp.example"}),
+                json!({"httpUrl": "https://mcp.example"}),
+            ),
+            (
+                json!({"type": "sse", "url": "https://mcp.example"}),
+                json!({"url": "https://mcp.example"}),
+            ),
+            (
+                json!({"command": "gh-mcp", "args": ["--stdio"]}),
+                json!({"command": "gh-mcp", "args": ["--stdio"]}),
+            ),
+        ] {
+            assert_eq!(server(&input), expected, "{input}");
+        }
     }
 }

--- a/crates/core/src/engine/gemini.rs
+++ b/crates/core/src/engine/gemini.rs
@@ -36,7 +36,7 @@ fn overridden_named(env: &Env, name: &str, kind: ItemKind, key: &str) -> Option<
         name: name.to_owned(),
         harness: Some(HarnessId::Gemini),
         message: format!(
-            "this machine's system-wide Gemini settings also set `{key}`, which outranks both your settings and this project — as configured, what kendex writes here can be overridden"
+            "kendex-settings-overridden: harness=gemini item={name} key={key}\nThis machine's system-wide Gemini settings also set `{key}`, which outranks both your settings and this project — as configured, what kendex writes here can be overridden"
         ),
         remediation: Some(format!(
             "ask whoever manages {} to make room for it, or install this at a scope that file leaves alone",
@@ -56,9 +56,10 @@ pub(super) fn agent_notices(ctx: &ItemCtx, state: &mut DesiredState) {
             kind: ItemKind::Agent,
             name: ctx.name.to_owned(),
             harness: Some(HarnessId::Gemini),
-            message:
-                "Gemini's subagents are switched off in its settings, so this agent installs but stays inert"
-                    .to_owned(),
+            message: format!(
+                "kendex-agents-disabled: harness=gemini agent={} setting=experimental.enableAgents\nGemini's subagents are switched off in its settings, so this agent installs but stays inert",
+                ctx.name,
+            ),
             remediation: Some(
                 "turn `experimental.enableAgents` on in Gemini's settings, or drop Gemini from this agent's harnesses"
                     .to_owned(),
@@ -82,14 +83,15 @@ pub(super) fn hook(
 ) -> Option<HookSpec> {
     if let Some(reason) = read(&settings_file(env, scope)).unmanageable() {
         state.notes.push(format!(
-            "hook {name}: {reason} — nothing was registered for Gemini"
+            "kendex-settings-unmanageable: harness=gemini kind=hook item={name}\n{reason} — nothing was registered for Gemini"
         ));
         return None;
     }
     let Some(registered) = crate::harness::gemini::hook_for(hook) else {
-        state.notes.push(format!(
-            "hook {name}: event {} has no Gemini counterpart, and hanging it on a near-miss would run it at the wrong moment",
-            hook.event
+        state.notes.push(super::targets::unsupported_hook_event(
+            name,
+            &hook.event,
+            HarnessId::Gemini,
         ));
         return None;
     };
@@ -123,7 +125,7 @@ fn switched_off_machine_wide(ctx: &ItemCtx) -> Option<ItemWarning> {
         name: ctx.name.to_owned(),
         harness: Some(HarnessId::Gemini),
         message: format!(
-            "Gemini records whether a server is on in one file for the whole machine, and {} is switched off there — as configured, it is declared for this project but stays inert",
+            "kendex-mcp-disabled: harness=gemini server={0}\nGemini records whether a server is on in one file for the whole machine, and {0} is switched off there — as configured, it is declared for this project but stays inert",
             ctx.name
         ),
         remediation: Some(format!(
@@ -142,7 +144,7 @@ fn gated_out(ctx: &ItemCtx) -> Option<ItemWarning> {
         name: ctx.name.to_owned(),
         harness: Some(HarnessId::Gemini),
         message: format!(
-            "Gemini's settings in {} gate which servers load, and {} is not among them — as configured, it installs but stays inert",
+            "kendex-mcp-filtered: harness=gemini server={1}\nGemini's settings in {0} gate which servers load, and {1} is not among them — as configured, it installs but stays inert",
             path.display(),
             ctx.name
         ),
@@ -186,7 +188,7 @@ pub(super) fn mcp_edits(
 ) -> Option<Vec<(PathBuf, ConfigEdit)>> {
     if let Some(reason) = settings(ctx).unmanageable() {
         state.notes.push(format!(
-            "mcp {}: {reason} — nothing was declared for Gemini",
+            "kendex-settings-unmanageable: harness=gemini kind=mcp-server item={}\n{reason} — nothing was declared for Gemini",
             ctx.name
         ));
         return None;

--- a/crates/core/src/engine/gemini.rs
+++ b/crates/core/src/engine/gemini.rs
@@ -36,7 +36,9 @@ fn overridden_named(env: &Env, name: &str, kind: ItemKind, key: &str) -> Option<
         name: name.to_owned(),
         harness: Some(HarnessId::Gemini),
         message: format!(
-            "kendex-settings-overridden: harness=gemini item={name} key={key}\nThis machine's system-wide Gemini settings also set `{key}`, which outranks both your settings and this project — as configured, what kendex writes here can be overridden"
+            "kendex-settings-overridden: harness=gemini item={record_name} key={record_key}\nThis machine's system-wide Gemini settings also set `{key}`, which outranks both your settings and this project — as configured, what kendex writes here can be overridden",
+            record_name = crate::names::shown(name),
+            record_key = crate::names::shown(key),
         ),
         remediation: Some(format!(
             "ask whoever manages {} to make room for it, or install this at a scope that file leaves alone",
@@ -57,8 +59,8 @@ pub(super) fn agent_notices(ctx: &ItemCtx, state: &mut DesiredState) {
             name: ctx.name.to_owned(),
             harness: Some(HarnessId::Gemini),
             message: format!(
-                "kendex-agents-disabled: harness=gemini agent={} setting=experimental.enableAgents\nGemini's subagents are switched off in its settings, so this agent installs but stays inert",
-                ctx.name,
+                "kendex-agents-disabled: harness=gemini agent={record_arg0} setting=experimental.enableAgents\nGemini's subagents are switched off in its settings, so this agent installs but stays inert",
+                record_arg0 = crate::names::shown(ctx.name),
             ),
             remediation: Some(
                 "turn `experimental.enableAgents` on in Gemini's settings, or drop Gemini from this agent's harnesses"
@@ -83,7 +85,8 @@ pub(super) fn hook(
 ) -> Option<HookSpec> {
     if let Some(reason) = read(&settings_file(env, scope)).unmanageable() {
         state.notes.push(format!(
-            "kendex-settings-unmanageable: harness=gemini kind=hook item={name}\n{reason} — nothing was registered for Gemini"
+            "kendex-settings-unmanageable: harness=gemini kind=hook item={record_name}\n{reason} — nothing was registered for Gemini",
+            record_name = crate::names::shown(name),
         ));
         return None;
     }
@@ -101,8 +104,9 @@ pub(super) fn hook(
             name: name.to_owned(),
             harness: Some(HarnessId::Gemini),
             message: format!(
-                "Gemini matches `{}` against its own tool names, and this matcher carries syntax kendex cannot restate in them — it installs as written and may never match",
-                hook.matcher.as_deref().unwrap_or_default()
+                "kendex-hook-matcher-untranslated: harness=gemini hook={record_name} matcher={record_arg0}\nGemini matches this against its own tool names, and this matcher carries syntax kendex cannot restate in them — it installs as written and may never match",
+                record_name = crate::names::shown(name),
+                record_arg0 = crate::names::shown(hook.matcher.as_deref().unwrap_or_default()),
             ),
             remediation: Some(
                 "write the matcher as plain tool names separated by `|`, or check it against Gemini's names (`run_shell_command`, `read_file`, `write_file`)"
@@ -125,8 +129,9 @@ fn switched_off_machine_wide(ctx: &ItemCtx) -> Option<ItemWarning> {
         name: ctx.name.to_owned(),
         harness: Some(HarnessId::Gemini),
         message: format!(
-            "kendex-mcp-disabled: harness=gemini server={0}\nGemini records whether a server is on in one file for the whole machine, and {0} is switched off there — as configured, it is declared for this project but stays inert",
-            ctx.name
+            "kendex-mcp-disabled: harness=gemini server={record_arg0}\nGemini records whether a server is on in one file for the whole machine, and {arg0} is switched off there — as configured, it is declared for this project but stays inert",
+            arg0 = ctx.name,
+            record_arg0 = crate::names::shown(ctx.name),
         ),
         remediation: Some(format!(
             "switch it back on for the whole machine, in {}",
@@ -144,9 +149,10 @@ fn gated_out(ctx: &ItemCtx) -> Option<ItemWarning> {
         name: ctx.name.to_owned(),
         harness: Some(HarnessId::Gemini),
         message: format!(
-            "kendex-mcp-filtered: harness=gemini server={1}\nGemini's settings in {0} gate which servers load, and {1} is not among them — as configured, it installs but stays inert",
-            path.display(),
-            ctx.name
+            "kendex-mcp-filtered: harness=gemini server={record_arg1}\nGemini's settings in {arg0} gate which servers load, and {arg1} is not among them — as configured, it installs but stays inert",
+            arg0 = path.display(),
+            arg1 = ctx.name,
+            record_arg1 = crate::names::shown(ctx.name),
         ),
         remediation: Some(format!(
             "take it out of `mcp.excluded`, or add it to `mcp.allowed`, in {}",
@@ -188,8 +194,8 @@ pub(super) fn mcp_edits(
 ) -> Option<Vec<(PathBuf, ConfigEdit)>> {
     if let Some(reason) = settings(ctx).unmanageable() {
         state.notes.push(format!(
-            "kendex-settings-unmanageable: harness=gemini kind=mcp-server item={}\n{reason} — nothing was declared for Gemini",
-            ctx.name
+            "kendex-settings-unmanageable: harness=gemini kind=mcp-server item={record_arg0}\n{reason} — nothing was declared for Gemini",
+            record_arg0 = crate::names::shown(ctx.name),
         ));
         return None;
     }

--- a/crates/core/src/engine/targets.rs
+++ b/crates/core/src/engine/targets.rs
@@ -5,6 +5,14 @@ use crate::env::Env;
 use crate::harness::{Enforcement, adapter};
 use crate::model::{HarnessId, ItemKind, Scope};
 
+/// The notice every native event adapter emits when no listener can run it.
+pub(super) fn unsupported_hook_event(name: &str, event: &str, harness: HarnessId) -> String {
+    format!(
+        "kendex-hook-unsupported: harness={} event={event} hook={name}\nThis harness cannot run the hook event. Nothing is installed for it.",
+        harness.name(),
+    )
+}
+
 /// What installing a hook on this harness actually buys. A tool that only
 /// reads the file must never be presented as one that acts on it: the
 /// warning travels with the plan, the preview, and the audit page. Read
@@ -116,6 +124,8 @@ pub(super) fn opencode_instruction_prefix(scope: &Scope) -> &'static str {
 /// never reaches `/`. When nothing from the start up holds the script, the
 /// command refuses, naming the start and the file: a hook that did not run
 /// must not read as one that allowed.
+/// Its own output starts with `kendex-hook-missing`; a launching shell may
+/// emit a startup diagnostic before it executes this registered command.
 ///
 /// `rel` goes through [`crate::names::quoted`], never interpolated inside
 /// double quotes, so a segment holding a `$` or a backtick is read as the

--- a/crates/core/src/engine/targets.rs
+++ b/crates/core/src/engine/targets.rs
@@ -8,8 +8,10 @@ use crate::model::{HarnessId, ItemKind, Scope};
 /// The notice every native event adapter emits when no listener can run it.
 pub(super) fn unsupported_hook_event(name: &str, event: &str, harness: HarnessId) -> String {
     format!(
-        "kendex-hook-unsupported: harness={} event={event} hook={name}\nThis harness cannot run the hook event. Nothing is installed for it.",
-        harness.name(),
+        "kendex-hook-unsupported: harness={record_arg0} event={record_event} hook={record_name}\nThis harness cannot run the hook event. Nothing is installed for it.",
+        record_arg0 = crate::names::shown(harness.name()),
+        record_event = crate::names::shown(event),
+        record_name = crate::names::shown(name),
     )
 }
 
@@ -30,12 +32,20 @@ pub(super) fn advisory_notice(
     }
     let (message, remediation) = match harness {
         HarnessId::Pi => (
-            "the pi-hooks carrier is not registered in any settings pi loads here — the hook is written but nothing will run it".to_owned(),
-            format!("install the {} extension at either scope", crate::pi_ext::carrier::CARRIER),
+            format!(
+                "kendex-hook-carrier-missing: harness=pi hook={record_name} carrier=pi-hooks\nThe pi-hooks carrier is not registered in any settings pi loads here — the hook is written but nothing will run it",
+                record_name = crate::names::shown(name),
+            ),
+            format!(
+                "install the {} extension at either scope",
+                crate::pi_ext::carrier::CARRIER
+            ),
         ),
         _ => (
             format!(
-                "this protection is advisory on {tool} — it installs as text the model may ignore, not a check the tool runs"
+                "kendex-hook-advisory: harness={record_arg0} hook={record_name}\nThis protection is advisory on {tool} — it installs as text the model may ignore, not a check the tool runs",
+                record_arg0 = crate::names::shown(harness.name()),
+                record_name = crate::names::shown(name),
             ),
             format!(
                 "keep it for the tools that run hooks — Claude Code, Codex, Gemini CLI, GitHub Copilot, Antigravity — or accept it as guidance on {tool}"

--- a/crates/core/src/engine/targets.rs
+++ b/crates/core/src/engine/targets.rs
@@ -124,9 +124,9 @@ pub(super) fn opencode_instruction_prefix(scope: &Scope) -> &'static str {
 /// command's first path-shaped word.
 fn project_command(rel: &str) -> String {
     format!(
-        "p={}; r=$(cd -P . && pwd); case $r in /*) ;; *) r=;; esac; \
+        "p={}; r=$({{ cd -P . && pwd; }} 2>/dev/null); case $r in /*) ;; *) r=;; esac; \
 while [ -n \"$r\" ] && ! [ -f \"$r/$p\" ]; do [ \"$r\" = / ] && r= || {{ r=${{r%/*}}; [ -n \"$r\" ] || r=/; }}; done; \
-[ -n \"$r\" ] || {{ echo \"kendex: no directory above $PWD holds $p; run kendex refresh in the project\" >&2; exit 1; }}; bash \"$r/$p\"",
+[ -n \"$r\" ] || {{ printf 'kendex-hook-missing: %s\\nNo directory above %s holds this script. Run kendex refresh in the project.\\n' \"$p\" \"$PWD\" >&2; exit 1; }}; bash \"$r/$p\"",
         crate::names::quoted(rel),
     )
 }

--- a/crates/core/src/render/validate/agent.rs
+++ b/crates/core/src/render/validate/agent.rs
@@ -28,11 +28,17 @@ fn model_finding(harness: HarnessId, model: &str) -> Option<Finding> {
         .is_some_and(|(provider, id)| !provider.is_empty() && !id.is_empty());
     match (model_shape(harness), model.contains('/'), qualified) {
         (ModelShape::Bare, true, _) => Some(Finding::breakage(
-            format!("`model: {model}` names a provider, and {tool} reaches one vendor only"),
+            format!(
+                "kendex-model-shape: harness={} model={model} expected=bare\n`model: {model}` names a provider, and {tool} reaches one vendor only",
+                harness.name()
+            ),
             "name a bare model id this tool lists, a tier alias, or `inherit`",
         )),
         (ModelShape::ProviderQualified, _, false) => Some(Finding::breakage(
-            format!("`model: {model}` is not `provider/model`, which is how {tool} loads a model"),
+            format!(
+                "kendex-model-shape: harness={} model={model} expected=provider/model\n`model: {model}` is not `provider/model`, which is how {tool} loads a model",
+                harness.name()
+            ),
             "write the model as `provider/model`, or `inherit` to follow the session",
         )),
         _ => None,
@@ -50,7 +56,9 @@ fn effort_finding(harness: HarnessId, key: &str, value: &str) -> Option<Finding>
     }
     Some(Finding::breakage(
         format!(
-            "`{key}: {value}` is not an effort level {} accepts",
+            "kendex-effort-rejected: harness={} key={key} value={value} allowed={}\n`{key}: {value}` is not an effort level {} accepts",
+            harness.name(),
+            levels.join(","),
             harness.display_name()
         ),
         format!("use one of {}", levels.join(", ")),
@@ -64,7 +72,9 @@ pub(super) fn codex(text: &str) -> Vec<Finding> {
         Ok(table) => table,
         Err(problem) => {
             return vec![Finding::breakage(
-                format!("Codex reads agents as TOML and this one does not parse — {problem}"),
+                format!(
+                    "kendex-agent-invalid: harness=codex format=toml\nCodex reads agents as TOML and this one does not parse — {problem}"
+                ),
                 "check the agent's frontmatter and body in the catalog for stray quotes or control characters",
             )];
         }
@@ -79,7 +89,7 @@ pub(super) fn codex(text: &str) -> Vec<Finding> {
             continue;
         }
         findings.push(Finding::breakage(
-            format!("the Codex agent has no `{key}`, so Codex will not load it"),
+            format!("kendex-agent-key-missing: harness=codex key={key}\nthe Codex agent has no `{key}`, so Codex will not load it"),
             match key {
                 "developer_instructions" => {
                     "write the agent a body in the catalog — there is nothing to instruct it with"
@@ -93,7 +103,7 @@ pub(super) fn codex(text: &str) -> Vec<Finding> {
         let shown = mode.as_str().unwrap_or("not text");
         if !SANDBOX_MODES.contains(&shown) {
             findings.push(Finding::breakage(
-                format!("`sandbox_mode = \"{shown}\"` is not a sandbox Codex knows"),
+                format!("kendex-sandbox-rejected: harness=codex value={shown} allowed={}\n`sandbox_mode = \"{shown}\"` is not a sandbox Codex knows", SANDBOX_MODES.join(",")),
                 format!("use one of {}", SANDBOX_MODES.join(", ")),
             ));
         }
@@ -116,7 +126,7 @@ pub(super) fn codex(text: &str) -> Vec<Finding> {
 /// OpenCode reads agent frontmatter strictly: a mode or permission value it
 /// does not know drops the agent rather than defaulting it.
 pub(super) fn opencode(text: &str) -> Vec<Finding> {
-    let map = match frontmatter_map(text, "OpenCode") {
+    let map = match frontmatter_map(text, HarnessId::Opencode) {
         Ok(map) => map,
         Err(finding) => return vec![finding],
     };
@@ -125,7 +135,7 @@ pub(super) fn opencode(text: &str) -> Vec<Finding> {
         && !MODES.contains(&mode)
     {
         findings.push(Finding::breakage(
-            format!("`mode: {mode}` is not a mode OpenCode knows"),
+            format!("kendex-agent-mode-rejected: harness=opencode value={mode} allowed={}\n`mode: {mode}` is not a mode OpenCode knows", MODES.join(",")),
             format!("set the agent's mode to one of {}", MODES.join(", ")),
         ));
     }
@@ -152,7 +162,7 @@ pub(super) fn opencode(text: &str) -> Vec<Finding> {
                 if !PERMISSION_VALUES.contains(&shown) {
                     findings.push(Finding::breakage(
                         format!(
-                            "permission `{key}` is set to `{shown}`, which OpenCode cannot read"
+                            "kendex-permission-rejected: harness=opencode key={key} value={shown} allowed={}\npermission `{key}` is set to `{shown}`, which OpenCode cannot read", PERMISSION_VALUES.join(",")
                         ),
                         format!("set it to one of {}", PERMISSION_VALUES.join(", ")),
                     ));
@@ -170,7 +180,7 @@ pub(super) fn opencode(text: &str) -> Vec<Finding> {
 /// Claude registers an agent under its frontmatter name, so a name that
 /// disagrees with the declared one answers to something nobody typed.
 pub(super) fn claude(name: &str, text: &str) -> Vec<Finding> {
-    let map = match frontmatter_map(text, "Claude Code") {
+    let map = match frontmatter_map(text, HarnessId::Claude) {
         Ok(map) => map,
         Err(finding) => return vec![finding],
     };
@@ -181,14 +191,16 @@ pub(super) fn claude(name: &str, text: &str) -> Vec<Finding> {
         .trim();
     if declared.is_empty() {
         return vec![Finding::breakage(
-            format!("the Claude agent for `{name}` has no name, so nothing can call it"),
+            format!(
+                "kendex-agent-key-missing: harness=claude name={name} key=name\nthe Claude agent for `{name}` has no name, so nothing can call it"
+            ),
             format!("add `name: {name}` to the agent's frontmatter in the catalog"),
         )];
     }
     if declared != name {
         return vec![Finding::breakage(
             format!(
-                "the agent installs as `{name}` but calls itself `{declared}`, so Claude answers to the wrong one"
+                "kendex-agent-name-mismatch: harness=claude installed={name} declared={declared}\nthe agent installs as `{name}` but calls itself `{declared}`, so Claude answers to the wrong one"
             ),
             format!("rename it to `{name}` in the catalog, or declare the agent as `{declared}`"),
         )];
@@ -208,7 +220,7 @@ pub(super) fn claude(name: &str, text: &str) -> Vec<Finding> {
 /// optional `:level` suffix, and `effort` as one of Pi's thinking levels;
 /// a bare id loads no model and an unknown level is ignored.
 pub(super) fn pi(text: &str) -> Vec<Finding> {
-    let map = match frontmatter_map(text, "Pi") {
+    let map = match frontmatter_map(text, HarnessId::Pi) {
         Ok(map) => map,
         Err(finding) => return vec![finding],
     };
@@ -233,7 +245,7 @@ pub(super) fn pi(text: &str) -> Vec<Finding> {
 /// nobody typed. Its `model` accepts a Gemini id or the literal `inherit`
 /// (matrix §1, §4).
 pub(super) fn gemini(name: &str, text: &str) -> Vec<Finding> {
-    let map = match frontmatter_map(text, "Gemini CLI") {
+    let map = match frontmatter_map(text, HarnessId::Gemini) {
         Ok(map) => map,
         Err(finding) => return vec![finding],
     };
@@ -280,7 +292,7 @@ pub(super) fn gemini(name: &str, text: &str) -> Vec<Finding> {
 /// tiers (<https://antigravity.google/docs/subagents>).
 pub(super) fn antigravity(name: &str, text: &str) -> Vec<Finding> {
     const TIERS: [&str; 3] = ["inherit", "flash", "pro"];
-    let map = match frontmatter_map(text, "Antigravity") {
+    let map = match frontmatter_map(text, HarnessId::Antigravity) {
         Ok(map) => map,
         Err(finding) => return vec![finding],
     };
@@ -330,7 +342,7 @@ pub(super) fn antigravity(name: &str, text: &str) -> Vec<Finding> {
 /// name nobody declared, and its model is free text a repository allowlist
 /// may still refuse (matrix §2, §4).
 pub(super) fn copilot(name: &str, text: &str) -> Vec<Finding> {
-    let map = match frontmatter_map(text, "Copilot") {
+    let map = match frontmatter_map(text, HarnessId::Copilot) {
         Ok(map) => map,
         Err(finding) => return vec![finding],
     };
@@ -361,7 +373,7 @@ pub(super) fn copilot(name: &str, text: &str) -> Vec<Finding> {
 }
 
 pub(super) fn cursor(text: &str) -> Vec<Finding> {
-    let map = match frontmatter_map(text, "Cursor") {
+    let map = match frontmatter_map(text, HarnessId::Cursor) {
         Ok(map) => map,
         Err(finding) => return vec![finding],
     };
@@ -369,7 +381,7 @@ pub(super) fn cursor(text: &str) -> Vec<Finding> {
         .filter(|(key, _)| !CURSOR_KEYS.contains(key))
         .map(|(key, _)| {
             Finding::advisory(
-                format!("Cursor ignores `{key}:` in a rule file"),
+                format!("kendex-rule-key-ignored: harness=cursor key={key}\nCursor ignores `{key}:` in a rule file"),
                 format!(
                     "keep rule frontmatter to {} — every other key is folklore",
                     CURSOR_KEYS.join(", ")

--- a/crates/core/src/render/validate/agent.rs
+++ b/crates/core/src/render/validate/agent.rs
@@ -29,15 +29,17 @@ fn model_finding(harness: HarnessId, model: &str) -> Option<Finding> {
     match (model_shape(harness), model.contains('/'), qualified) {
         (ModelShape::Bare, true, _) => Some(Finding::breakage(
             format!(
-                "kendex-model-shape: harness={} model={model} expected=bare\n`model: {model}` names a provider, and {tool} reaches one vendor only",
-                harness.name()
+                "kendex-model-shape: harness={record_arg0} model={record_model} expected=bare\n`model: {model}` names a provider, and {tool} reaches one vendor only",
+                record_arg0 = crate::names::shown(harness.name()),
+                record_model = crate::names::shown(model),
             ),
             "name a bare model id this tool lists, a tier alias, or `inherit`",
         )),
         (ModelShape::ProviderQualified, _, false) => Some(Finding::breakage(
             format!(
-                "kendex-model-shape: harness={} model={model} expected=provider/model\n`model: {model}` is not `provider/model`, which is how {tool} loads a model",
-                harness.name()
+                "kendex-model-shape: harness={record_arg0} model={record_model} expected=provider/model\n`model: {model}` is not `provider/model`, which is how {tool} loads a model",
+                record_arg0 = crate::names::shown(harness.name()),
+                record_model = crate::names::shown(model),
             ),
             "write the model as `provider/model`, or `inherit` to follow the session",
         )),
@@ -56,10 +58,12 @@ fn effort_finding(harness: HarnessId, key: &str, value: &str) -> Option<Finding>
     }
     Some(Finding::breakage(
         format!(
-            "kendex-effort-rejected: harness={} key={key} value={value} allowed={}\n`{key}: {value}` is not an effort level {} accepts",
-            harness.name(),
-            levels.join(","),
-            harness.display_name()
+            "kendex-effort-rejected: harness={record_arg0} key={record_key} value={record_value} allowed={record_arg1}\n`{key}: {value}` is not an effort level {arg2} accepts",
+            arg2 = harness.display_name(),
+            record_arg0 = crate::names::shown(harness.name()),
+            record_key = crate::names::shown(key),
+            record_value = crate::names::shown(value),
+            record_arg1 = crate::names::shown(&levels.join(",")),
         ),
         format!("use one of {}", levels.join(", ")),
     ))
@@ -89,7 +93,10 @@ pub(super) fn codex(text: &str) -> Vec<Finding> {
             continue;
         }
         findings.push(Finding::breakage(
-            format!("kendex-agent-key-missing: harness=codex key={key}\nthe Codex agent has no `{key}`, so Codex will not load it"),
+            format!(
+                "kendex-agent-key-missing: harness=codex key={record_key}\nthe Codex agent has no `{key}`, so Codex will not load it",
+                record_key = crate::names::shown(key ),
+            ),
             match key {
                 "developer_instructions" => {
                     "write the agent a body in the catalog — there is nothing to instruct it with"
@@ -103,7 +110,11 @@ pub(super) fn codex(text: &str) -> Vec<Finding> {
         let shown = mode.as_str().unwrap_or("not text");
         if !SANDBOX_MODES.contains(&shown) {
             findings.push(Finding::breakage(
-                format!("kendex-sandbox-rejected: harness=codex value={shown} allowed={}\n`sandbox_mode = \"{shown}\"` is not a sandbox Codex knows", SANDBOX_MODES.join(",")),
+                format!(
+                    "kendex-sandbox-rejected: harness=codex value={record_shown} allowed={record_arg0}\n`sandbox_mode = \"{shown}\"` is not a sandbox Codex knows",
+                    record_shown = crate::names::shown(shown ),
+                    record_arg0 = crate::names::shown(&SANDBOX_MODES.join(",")),
+                ),
                 format!("use one of {}", SANDBOX_MODES.join(", ")),
             ));
         }
@@ -135,7 +146,11 @@ pub(super) fn opencode(text: &str) -> Vec<Finding> {
         && !MODES.contains(&mode)
     {
         findings.push(Finding::breakage(
-            format!("kendex-agent-mode-rejected: harness=opencode value={mode} allowed={}\n`mode: {mode}` is not a mode OpenCode knows", MODES.join(",")),
+            format!(
+                "kendex-agent-mode-rejected: harness=opencode value={record_mode} allowed={record_arg0}\n`mode: {mode}` is not a mode OpenCode knows",
+                record_mode = crate::names::shown(mode ),
+                record_arg0 = crate::names::shown(&MODES.join(",")),
+            ),
             format!("set the agent's mode to one of {}", MODES.join(", ")),
         ));
     }
@@ -162,7 +177,10 @@ pub(super) fn opencode(text: &str) -> Vec<Finding> {
                 if !PERMISSION_VALUES.contains(&shown) {
                     findings.push(Finding::breakage(
                         format!(
-                            "kendex-permission-rejected: harness=opencode key={key} value={shown} allowed={}\npermission `{key}` is set to `{shown}`, which OpenCode cannot read", PERMISSION_VALUES.join(",")
+                            "kendex-permission-rejected: harness=opencode key={record_key} value={record_shown} allowed={record_arg0}\npermission `{key}` is set to `{shown}`, which OpenCode cannot read",
+                            record_key = crate::names::shown(key ),
+                            record_shown = crate::names::shown(shown ),
+                            record_arg0 = crate::names::shown(&PERMISSION_VALUES.join(",")),
                         ),
                         format!("set it to one of {}", PERMISSION_VALUES.join(", ")),
                     ));
@@ -170,7 +188,7 @@ pub(super) fn opencode(text: &str) -> Vec<Finding> {
             }
         }
         Some(_) => findings.push(Finding::breakage(
-            "`permission:` is not a block of permission names",
+            "kendex-permission-invalid: harness=opencode key=permission\n`permission:` is not a block of permission names",
             "write permission as indented `<name>: allow|ask|deny` lines",
         )),
     }
@@ -192,7 +210,8 @@ pub(super) fn claude(name: &str, text: &str) -> Vec<Finding> {
     if declared.is_empty() {
         return vec![Finding::breakage(
             format!(
-                "kendex-agent-key-missing: harness=claude name={name} key=name\nthe Claude agent for `{name}` has no name, so nothing can call it"
+                "kendex-agent-key-missing: harness=claude name={record_name} key=name\nthe Claude agent for `{name}` has no name, so nothing can call it",
+                record_name = crate::names::shown(name),
             ),
             format!("add `name: {name}` to the agent's frontmatter in the catalog"),
         )];
@@ -200,7 +219,9 @@ pub(super) fn claude(name: &str, text: &str) -> Vec<Finding> {
     if declared != name {
         return vec![Finding::breakage(
             format!(
-                "kendex-agent-name-mismatch: harness=claude installed={name} declared={declared}\nthe agent installs as `{name}` but calls itself `{declared}`, so Claude answers to the wrong one"
+                "kendex-agent-name-mismatch: harness=claude installed={record_name} declared={record_declared}\nthe agent installs as `{name}` but calls itself `{declared}`, so Claude answers to the wrong one",
+                record_name = crate::names::shown(name),
+                record_declared = crate::names::shown(declared),
             ),
             format!("rename it to `{name}` in the catalog, or declare the agent as `{declared}`"),
         )];
@@ -258,12 +279,17 @@ pub(super) fn gemini(name: &str, text: &str) -> Vec<Finding> {
     let mut findings = Vec::new();
     match text_at("name") {
         "" => findings.push(Finding::breakage(
-            format!("the Gemini agent for `{name}` has no name, so nothing can call it"),
+            format!(
+                "kendex-agent-key-missing: harness=gemini name={record_name} key=name\nthe Gemini agent for `{name}` has no name, so nothing can call it",
+                record_name = crate::names::shown(name ),
+            ),
             format!("add `name: {name}` to the agent's frontmatter in the catalog"),
         )),
         declared if declared != name => findings.push(Finding::breakage(
             format!(
-                "the agent installs as `{name}` but calls itself `{declared}`, so Gemini answers to the wrong one"
+                "kendex-agent-name-mismatch: harness=gemini installed={record_name} declared={record_declared}\nthe agent installs as `{name}` but calls itself `{declared}`, so Gemini answers to the wrong one",
+                record_name = crate::names::shown(name ),
+                record_declared = crate::names::shown(declared ),
             ),
             format!("rename it to `{name}` in the catalog, or declare the agent as `{declared}`"),
         )),
@@ -271,7 +297,10 @@ pub(super) fn gemini(name: &str, text: &str) -> Vec<Finding> {
     }
     if text_at("description").is_empty() {
         findings.push(Finding::breakage(
-            format!("the Gemini agent for `{name}` has no description, so Gemini will not load it"),
+            format!(
+                "kendex-agent-key-missing: harness=gemini name={record_name} key=description\nthe Gemini agent for `{name}` has no description, so Gemini will not load it",
+                record_name = crate::names::shown(name ),
+            ),
             "add `description:` to the agent's frontmatter in the catalog",
         ));
     }
@@ -280,7 +309,10 @@ pub(super) fn gemini(name: &str, text: &str) -> Vec<Finding> {
         findings.push(finding);
     } else if !model.is_empty() && model != "inherit" && !model.starts_with("gemini-") {
         findings.push(Finding::advisory(
-            format!("`model: {model}` is not a Gemini model id, so Gemini falls back to its own"),
+            format!(
+                "kendex-agent-model-fallback: harness=gemini model={record_model}\n`model: {model}` is not a Gemini model id, so Gemini falls back to its own",
+                record_model = crate::names::shown(model ),
+            ),
             "name a `gemini-*` model, or use a tier alias so kendex picks one",
         ));
     }
@@ -305,12 +337,17 @@ pub(super) fn antigravity(name: &str, text: &str) -> Vec<Finding> {
     let mut findings = Vec::new();
     match text_at("name") {
         "" => findings.push(Finding::breakage(
-            format!("the Antigravity agent for `{name}` has no name, so nothing can call it"),
+            format!(
+                "kendex-agent-key-missing: harness=antigravity name={record_name} key=name\nthe Antigravity agent for `{name}` has no name, so nothing can call it",
+                record_name = crate::names::shown(name ),
+            ),
             format!("add `name: {name}` to the agent's frontmatter in the catalog"),
         )),
         declared if declared != name => findings.push(Finding::breakage(
             format!(
-                "the agent installs as `{name}` but calls itself `{declared}`, so Antigravity answers to the wrong one"
+                "kendex-agent-name-mismatch: harness=antigravity installed={record_name} declared={record_declared}\nthe agent installs as `{name}` but calls itself `{declared}`, so Antigravity answers to the wrong one",
+                record_name = crate::names::shown(name ),
+                record_declared = crate::names::shown(declared ),
             ),
             format!("rename it to `{name}` in the catalog, or declare the agent as `{declared}`"),
         )),
@@ -319,7 +356,8 @@ pub(super) fn antigravity(name: &str, text: &str) -> Vec<Finding> {
     if text_at("description").is_empty() {
         findings.push(Finding::breakage(
             format!(
-                "the Antigravity agent for `{name}` has no description, so it is never delegated to"
+                "kendex-agent-key-missing: harness=antigravity name={record_name} key=description\nthe Antigravity agent for `{name}` has no description, so it is never delegated to",
+                record_name = crate::names::shown(name ),
             ),
             "add `description:` to the agent's frontmatter in the catalog",
         ));
@@ -327,7 +365,11 @@ pub(super) fn antigravity(name: &str, text: &str) -> Vec<Finding> {
     let model = text_at("model");
     if !model.is_empty() && !TIERS.contains(&model) {
         findings.push(Finding::breakage(
-            format!("`model: {model}` is not a tier Antigravity reads"),
+            format!(
+                "kendex-agent-model-rejected: harness=antigravity model={record_model} allowed={record_arg0}\n`model: {model}` is not a tier Antigravity reads",
+                record_model = crate::names::shown(model ),
+                record_arg0 = crate::names::shown(&TIERS.join(",")),
+            ),
             format!(
                 "use one of {}, or a tier alias so kendex picks one",
                 TIERS.join(", ")
@@ -355,7 +397,10 @@ pub(super) fn copilot(name: &str, text: &str) -> Vec<Finding> {
     let mut findings = Vec::new();
     if text_at("description").is_empty() {
         findings.push(Finding::breakage(
-            format!("the Copilot agent for `{name}` has no description, and Copilot needs one to load it"),
+            format!(
+                "kendex-agent-key-missing: harness=copilot name={record_name} key=description\nthe Copilot agent for `{name}` has no description, and Copilot needs one to load it",
+                record_name = crate::names::shown(name ),
+            ),
             "add `description:` to the agent's frontmatter in the catalog",
         ));
     }
@@ -363,7 +408,9 @@ pub(super) fn copilot(name: &str, text: &str) -> Vec<Finding> {
     if !declared.is_empty() && declared != name {
         findings.push(Finding::breakage(
             format!(
-                "the agent installs as `{name}` but calls itself `{declared}`, so Copilot lists it under the wrong one"
+                "kendex-agent-name-mismatch: harness=copilot installed={record_name} declared={record_declared}\nthe agent installs as `{name}` but calls itself `{declared}`, so Copilot lists it under the wrong one",
+                record_name = crate::names::shown(name ),
+                record_declared = crate::names::shown(declared ),
             ),
             format!("rename it to `{name}` in the catalog, or declare the agent as `{declared}`"),
         ));
@@ -381,7 +428,10 @@ pub(super) fn cursor(text: &str) -> Vec<Finding> {
         .filter(|(key, _)| !CURSOR_KEYS.contains(key))
         .map(|(key, _)| {
             Finding::advisory(
-                format!("kendex-rule-key-ignored: harness=cursor key={key}\nCursor ignores `{key}:` in a rule file"),
+                format!(
+                    "kendex-rule-key-ignored: harness=cursor key={record_key}\nCursor ignores `{key}:` in a rule file",
+                    record_key = crate::names::shown(key ),
+                ),
                 format!(
                     "keep rule frontmatter to {} — every other key is folklore",
                     CURSOR_KEYS.join(", ")

--- a/crates/core/src/render/validate/command.rs
+++ b/crates/core/src/render/validate/command.rs
@@ -9,7 +9,9 @@ pub(super) fn gemini(text: &str) -> Vec<Finding> {
         Ok(table) => table,
         Err(problem) => {
             return vec![Finding::breakage(
-                format!("Gemini reads commands as TOML and this one does not parse — {problem}"),
+                format!(
+                    "kendex-command-invalid: harness=gemini format=toml\nGemini reads commands as TOML and this one does not parse — {problem}"
+                ),
                 "check the command's body in the catalog for control characters",
             )];
         }
@@ -23,13 +25,13 @@ pub(super) fn gemini(text: &str) -> Vec<Finding> {
     let mut findings = Vec::new();
     if !filled("prompt") {
         findings.push(Finding::breakage(
-            "the Gemini command has no prompt, so typing it would do nothing",
+            "kendex-command-key-missing: harness=gemini key=prompt\nthe Gemini command has no prompt, so typing it would do nothing",
             "give the command a body in the catalog",
         ));
     }
     if !filled("description") {
         findings.push(Finding::advisory(
-            "the Gemini command has no description, so it lists with nothing beside it",
+            "kendex-command-key-missing: harness=gemini key=description\nthe Gemini command has no description, so it lists with nothing beside it",
             "add `description:` to the command's frontmatter, or open its body with a line saying what it does",
         ));
     }
@@ -53,7 +55,7 @@ pub(super) fn pi(text: &str) -> Vec<Finding> {
         return Vec::new();
     }
     vec![Finding::advisory(
-        "the command runs a shell inline with !`…`, which Pi does not expand — the model reads the backticked command as text",
+        "kendex-command-inline-unsupported: harness=pi syntax=!`command`\nthe command runs a shell inline with !`…`, which Pi does not expand — the model reads the backticked command as text",
         "state the command's output in the prose, or drop Pi from this command's harnesses",
     )]
 }

--- a/crates/core/src/render/validate/mod.rs
+++ b/crates/core/src/render/validate/mod.rs
@@ -146,7 +146,8 @@ fn segment_findings(harness: HarnessId, name: &str) -> Vec<Finding> {
     }
     vec![Finding::breakage(
         format!(
-            "`{name}` points out of the directory {} reads, so the item lands somewhere it is never loaded from",
+            "kendex-name-outside-directory: harness={} name={name}\n`{name}` points out of the directory {} reads, so the item lands somewhere it is never loaded from",
+            harness.name(),
             harness.display_name()
         ),
         "rename the item to a plain name with no `/`, `\\` or `..`",
@@ -160,7 +161,7 @@ fn kebab_findings(harness: HarnessId, name: &str, max_len: Option<usize>) -> Vec
         let legal = to_lower_kebab(name);
         findings.push(Finding::breakage(
             format!(
-                "{tool} will not load `{name}` — it takes lowercase letters, digits and single hyphens"
+                "kendex-name-rejected: harness={} name={name} suggested={legal}\n{tool} will not load `{name}` — it takes lowercase letters, digits and single hyphens", harness.name()
             ),
             match legal.is_empty() {
                 true => format!(
@@ -175,7 +176,7 @@ fn kebab_findings(harness: HarnessId, name: &str, max_len: Option<usize>) -> Vec
     let length = name.chars().count();
     if let Some(max_len) = max_len.filter(|max| length > *max) {
         findings.push(Finding::breakage(
-            format!("`{name}` is {length} characters and {tool} stops at {max_len}"),
+            format!("kendex-name-too-long: harness={} name={name} length={length} limit={max_len}\n`{name}` is {length} characters and {tool} stops at {max_len}", harness.name()),
             format!("shorten the name to {max_len} characters or fewer"),
         ));
     }
@@ -208,10 +209,11 @@ fn to_lower_kebab(name: &str) -> String {
 
 /// The frontmatter of a generated markdown file, or the finding that says
 /// the loader has nothing to read.
-fn frontmatter_map(text: &str, tool: &str) -> Result<crate::frontmatter::Map, Finding> {
+fn frontmatter_map(text: &str, harness: HarnessId) -> Result<crate::frontmatter::Map, Finding> {
+    let tool = harness.display_name();
     let (yaml, _) = crate::frontmatter::split(text).map_err(|problem| {
         Finding::breakage(
-            format!("{tool} reads this file's frontmatter and there is none — {problem}"),
+            format!("kendex-frontmatter-missing: harness={}\n{tool} reads this file's frontmatter and there is none — {problem}", harness.name()),
             "give the item `---` frontmatter with a name and a description in the catalog",
         )
     })?;
@@ -219,7 +221,7 @@ fn frontmatter_map(text: &str, tool: &str) -> Result<crate::frontmatter::Map, Fi
         .map(|parsed| parsed.map)
         .map_err(|problem| {
             Finding::breakage(
-                format!("{tool} cannot read this file's frontmatter — {problem}"),
+                format!("kendex-frontmatter-invalid: harness={}\n{tool} cannot read this file's frontmatter — {problem}", harness.name()),
                 "fix the item's frontmatter in the catalog: one `key: value` per line, no tabs",
             )
         })

--- a/crates/core/src/render/validate/mod.rs
+++ b/crates/core/src/render/validate/mod.rs
@@ -51,6 +51,9 @@ pub enum Severity {
 }
 
 /// One structural problem with a rendering, and what to do about it.
+/// Validator messages start with a stable reason and relevant values.
+/// Values use `names::shown` so quoted input cannot split the record line.
+/// English explanation follows the record; remediation is separate.
 #[derive(Debug, Clone, PartialEq)]
 pub struct Finding {
     pub message: String,
@@ -146,9 +149,10 @@ fn segment_findings(harness: HarnessId, name: &str) -> Vec<Finding> {
     }
     vec![Finding::breakage(
         format!(
-            "kendex-name-outside-directory: harness={} name={name}\n`{name}` points out of the directory {} reads, so the item lands somewhere it is never loaded from",
-            harness.name(),
-            harness.display_name()
+            "kendex-name-outside-directory: harness={record_arg0} name={record_name}\n`{name}` points out of the directory {arg1} reads, so the item lands somewhere it is never loaded from",
+            arg1 = harness.display_name(),
+            record_arg0 = crate::names::shown(harness.name()),
+            record_name = crate::names::shown(name),
         ),
         "rename the item to a plain name with no `/`, `\\` or `..`",
     )]
@@ -161,7 +165,10 @@ fn kebab_findings(harness: HarnessId, name: &str, max_len: Option<usize>) -> Vec
         let legal = to_lower_kebab(name);
         findings.push(Finding::breakage(
             format!(
-                "kendex-name-rejected: harness={} name={name} suggested={legal}\n{tool} will not load `{name}` — it takes lowercase letters, digits and single hyphens", harness.name()
+                "kendex-name-rejected: harness={record_arg0} name={record_name} suggested={record_legal}\n{tool} will not load `{name}` — it takes lowercase letters, digits and single hyphens",
+                record_arg0 = crate::names::shown(harness.name()),
+                record_name = crate::names::shown(name),
+                record_legal = crate::names::shown(&legal),
             ),
             match legal.is_empty() {
                 true => format!(
@@ -176,7 +183,13 @@ fn kebab_findings(harness: HarnessId, name: &str, max_len: Option<usize>) -> Vec
     let length = name.chars().count();
     if let Some(max_len) = max_len.filter(|max| length > *max) {
         findings.push(Finding::breakage(
-            format!("kendex-name-too-long: harness={} name={name} length={length} limit={max_len}\n`{name}` is {length} characters and {tool} stops at {max_len}", harness.name()),
+            format!(
+                "kendex-name-too-long: harness={record_arg0} name={record_name} length={record_length} limit={record_max_len}\n`{name}` is {length} characters and {tool} stops at {max_len}",
+                record_arg0 = crate::names::shown(harness.name()),
+                record_name = crate::names::shown(name),
+                record_length = length,
+                record_max_len = max_len,
+            ),
             format!("shorten the name to {max_len} characters or fewer"),
         ));
     }
@@ -213,7 +226,10 @@ fn frontmatter_map(text: &str, harness: HarnessId) -> Result<crate::frontmatter:
     let tool = harness.display_name();
     let (yaml, _) = crate::frontmatter::split(text).map_err(|problem| {
         Finding::breakage(
-            format!("kendex-frontmatter-missing: harness={}\n{tool} reads this file's frontmatter and there is none — {problem}", harness.name()),
+            format!(
+                "kendex-frontmatter-missing: harness={record_arg0}\n{tool} reads this file's frontmatter and there is none — {problem}",
+                record_arg0 = crate::names::shown(harness.name()),
+            ),
             "give the item `---` frontmatter with a name and a description in the catalog",
         )
     })?;
@@ -221,7 +237,10 @@ fn frontmatter_map(text: &str, harness: HarnessId) -> Result<crate::frontmatter:
         .map(|parsed| parsed.map)
         .map_err(|problem| {
             Finding::breakage(
-                format!("kendex-frontmatter-invalid: harness={}\n{tool} cannot read this file's frontmatter — {problem}", harness.name()),
+                format!(
+                    "kendex-frontmatter-invalid: harness={record_arg0}\n{tool} cannot read this file's frontmatter — {problem}",
+                    record_arg0 = crate::names::shown(harness.name()),
+                ),
                 "fix the item's frontmatter in the catalog: one `key: value` per line, no tabs",
             )
         })

--- a/crates/core/src/render/validate/skill.rs
+++ b/crates/core/src/render/validate/skill.rs
@@ -31,8 +31,9 @@ pub(super) fn findings(
     let Some(bytes) = skill_md(files) else {
         return vec![Finding::breakage(
             format!(
-                "kendex-skill-file-missing: harness={} name={name} path=SKILL.md\nthe tree for `{name}` has no SKILL.md, which is the only file {tool} looks for",
-                harness.name()
+                "kendex-skill-file-missing: harness={record_arg0} name={record_name} path=SKILL.md\nthe tree for `{name}` has no SKILL.md, which is the only file {tool} looks for",
+                record_arg0 = crate::names::shown(harness.name()),
+                record_name = crate::names::shown(name),
             ),
             "add SKILL.md to the skill's directory in the catalog",
         )];
@@ -50,7 +51,11 @@ pub(super) fn findings(
         .trim();
     if in_file.is_empty() {
         findings.push(Finding::breakage(
-            format!("SKILL.md has no `name:`, so {tool} has nothing to list `{name}` under"),
+            format!(
+                "kendex-skill-name-missing: harness={record_arg0} name={record_name}\nSKILL.md has no `name:`, so {tool} has nothing to list `{name}` under",
+                record_arg0 = crate::names::shown(harness.name() ),
+                record_name = crate::names::shown(name ),
+            ),
             format!("add `name: {name}` to the skill's SKILL.md in the catalog"),
         ));
     } else if in_file != name {
@@ -71,7 +76,12 @@ pub(super) fn findings(
         };
         findings.push(Finding::breakage(
             format!(
-                "kendex-skill-name-mismatch: harness={} installed={name} declared={declared} in-file={in_file} fix={fix}\nSKILL.md calls the skill `{in_file}` but it installs as `{name}`, so {tool} offers a name nobody declared", harness.name()
+                "kendex-skill-name-mismatch: harness={record_arg0} installed={record_name} declared={record_declared} in-file={record_in_file} fix={record_fix}\nSKILL.md calls the skill `{in_file}` but it installs as `{name}`, so {tool} offers a name nobody declared",
+                record_arg0 = crate::names::shown(harness.name() ),
+                record_name = crate::names::shown(name ),
+                record_declared = crate::names::shown(declared ),
+                record_in_file = crate::names::shown(in_file ),
+                record_fix = crate::names::shown(fix ),
             ),
             remediation,
         ));
@@ -82,7 +92,11 @@ pub(super) fn findings(
         .is_some_and(|text| !text.trim().is_empty());
     if !described {
         findings.push(Finding::advisory(
-            format!("kendex-skill-description-missing: harness={} name={name}\nSKILL.md has no description, so {tool} has nothing to decide when to use `{name}` on", harness.name()),
+            format!(
+                "kendex-skill-description-missing: harness={record_arg0} name={record_name}\nSKILL.md has no description, so {tool} has nothing to decide when to use `{name}` on",
+                record_arg0 = crate::names::shown(harness.name() ),
+                record_name = crate::names::shown(name ),
+            ),
             "add a one-line `description:` saying when the skill applies",
         ));
     }
@@ -95,8 +109,12 @@ pub(super) fn findings(
     {
         findings.push(Finding::breakage(
             format!(
-                "kendex-skill-description-too-long: harness={} name={name} length={} limit={CODEX_DESCRIPTION_MAX_CHARS}\n`{name}`'s description is {} characters and {tool} rejects a skill whose description runs past {CODEX_DESCRIPTION_MAX_CHARS}",
-                harness.name(), description.chars().count(), description.chars().count()
+                "kendex-skill-description-too-long: harness={record_arg0} name={record_name} length={record_arg1} limit={record_CODEX_DESCRIPTION_MAX_CHARS}\n`{name}`'s description is {arg2} characters and {tool} rejects a skill whose description runs past {CODEX_DESCRIPTION_MAX_CHARS}",
+                arg2 = description.chars().count(),
+                record_arg0 = crate::names::shown(harness.name() ),
+                record_name = crate::names::shown(name ),
+                record_arg1 = description.chars().count(),
+                record_CODEX_DESCRIPTION_MAX_CHARS = CODEX_DESCRIPTION_MAX_CHARS,
             ),
             "shorten the `description:` in the skill's SKILL.md — say when the skill applies, and leave the how to the body",
         ));

--- a/crates/core/src/render/validate/skill.rs
+++ b/crates/core/src/render/validate/skill.rs
@@ -31,13 +31,14 @@ pub(super) fn findings(
     let Some(bytes) = skill_md(files) else {
         return vec![Finding::breakage(
             format!(
-                "the tree for `{name}` has no SKILL.md, which is the only file {tool} looks for"
+                "kendex-skill-file-missing: harness={} name={name} path=SKILL.md\nthe tree for `{name}` has no SKILL.md, which is the only file {tool} looks for",
+                harness.name()
             ),
             "add SKILL.md to the skill's directory in the catalog",
         )];
     };
     let text = String::from_utf8_lossy(bytes);
-    let map = match frontmatter_map(&text, tool) {
+    let map = match frontmatter_map(&text, harness) {
         Ok(map) => map,
         Err(finding) => return vec![finding],
     };
@@ -53,23 +54,26 @@ pub(super) fn findings(
             format!("add `name: {name}` to the skill's SKILL.md in the catalog"),
         ));
     } else if in_file != name {
-        findings.push(Finding::breakage(
-            format!(
-                "SKILL.md calls the skill `{in_file}` but it installs as `{name}`, so {tool} offers a name nobody declared"
-            ),
-            match declared == name {
-                true => format!(
+        let (fix, remediation) = match declared == name {
+            true => (
+                "name",
+                format!(
                     "set `name: {name}` in the skill's SKILL.md, or declare the skill as `{in_file}`"
                 ),
-                // The installed name carries the plugin the item lives in,
-                // which no catalog file knows and no declaration can spell.
-                // kendex writes it into its own copy, and the one shape it
-                // cannot write into is frontmatter that is not a plain
-                // `---` block.
-                false => format!(
+            ),
+            // A plugin-derived installed name is repaired in the generated file.
+            false => (
+                "frontmatter",
+                format!(
                     "give this skill's SKILL.md a plain `---` frontmatter block — that is what kendex writes `name: {name}` into when it installs `{declared}`"
                 ),
-            },
+            ),
+        };
+        findings.push(Finding::breakage(
+            format!(
+                "kendex-skill-name-mismatch: harness={} installed={name} declared={declared} in-file={in_file} fix={fix}\nSKILL.md calls the skill `{in_file}` but it installs as `{name}`, so {tool} offers a name nobody declared", harness.name()
+            ),
+            remediation,
         ));
     }
     let described = map
@@ -78,7 +82,7 @@ pub(super) fn findings(
         .is_some_and(|text| !text.trim().is_empty());
     if !described {
         findings.push(Finding::advisory(
-            format!("SKILL.md has no description, so {tool} has nothing to decide when to use `{name}` on"),
+            format!("kendex-skill-description-missing: harness={} name={name}\nSKILL.md has no description, so {tool} has nothing to decide when to use `{name}` on", harness.name()),
             "add a one-line `description:` saying when the skill applies",
         ));
     }
@@ -91,8 +95,8 @@ pub(super) fn findings(
     {
         findings.push(Finding::breakage(
             format!(
-                "`{name}`'s description is {} characters and {tool} rejects a skill whose description runs past {CODEX_DESCRIPTION_MAX_CHARS}",
-                description.chars().count()
+                "kendex-skill-description-too-long: harness={} name={name} length={} limit={CODEX_DESCRIPTION_MAX_CHARS}\n`{name}`'s description is {} characters and {tool} rejects a skill whose description runs past {CODEX_DESCRIPTION_MAX_CHARS}",
+                harness.name(), description.chars().count(), description.chars().count()
             ),
             "shorten the `description:` in the skill's SKILL.md — say when the skill applies, and leave the how to the body",
         ));

--- a/crates/core/src/render/validate/tests.rs
+++ b/crates/core/src/render/validate/tests.rs
@@ -186,6 +186,104 @@ fn a_rendering_a_harness_would_refuse_is_named_with_what_it_got_wrong() {
             breakage: &[],
             advice: &[],
         },
+        Row {
+            harness: HarnessId::Gemini,
+            name: "rust",
+            text: "---\ndescription: Rust engineer\n---\nBody.\n".to_owned(),
+            breakage: &["kendex-agent-key-missing: harness=gemini name=rust key=name"],
+            advice: &[],
+        },
+        Row {
+            harness: HarnessId::Gemini,
+            name: "rust",
+            text: "---\nname: other\ndescription: Rust engineer\n---\nBody.\n".to_owned(),
+            breakage: &["kendex-agent-name-mismatch: harness=gemini installed=rust declared=other"],
+            advice: &[],
+        },
+        Row {
+            harness: HarnessId::Gemini,
+            name: "rust",
+            text: "---\nname: rust\n---\nBody.\n".to_owned(),
+            breakage: &["kendex-agent-key-missing: harness=gemini name=rust key=description"],
+            advice: &[],
+        },
+        Row {
+            harness: HarnessId::Antigravity,
+            name: "rust",
+            text: "---\ndescription: Rust engineer\n---\nBody.\n".to_owned(),
+            breakage: &["kendex-agent-key-missing: harness=antigravity name=rust key=name"],
+            advice: &[],
+        },
+        Row {
+            harness: HarnessId::Antigravity,
+            name: "rust",
+            text: "---\nname: other\ndescription: Rust engineer\n---\nBody.\n".to_owned(),
+            breakage: &["kendex-agent-name-mismatch: harness=antigravity installed=rust declared=other"],
+            advice: &[],
+        },
+        Row {
+            harness: HarnessId::Antigravity,
+            name: "rust",
+            text: "---\nname: rust\n---\nBody.\n".to_owned(),
+            breakage: &["kendex-agent-key-missing: harness=antigravity name=rust key=description"],
+            advice: &[],
+        },
+        Row {
+            harness: HarnessId::Copilot,
+            name: "rust",
+            text: "---\nname: other\ndescription: Rust engineer\n---\nBody.\n".to_owned(),
+            breakage: &["kendex-agent-name-mismatch: harness=copilot installed=rust declared=other"],
+            advice: &[],
+        },
+        Row {
+            harness: HarnessId::Copilot,
+            name: "rust",
+            text: "---\nname: rust\n---\nBody.\n".to_owned(),
+            breakage: &["kendex-agent-key-missing: harness=copilot name=rust key=description"],
+            advice: &[],
+        },
+        Row {
+            harness: HarnessId::Opencode,
+            name: "rust",
+            text: "---\ndescription: Rust engineer\nmode: subagent\npermission: deny\n---\nBody.\n".to_owned(),
+            breakage: &["kendex-permission-invalid: harness=opencode key=permission"],
+            advice: &[],
+        },
+        Row {
+            harness: HarnessId::Gemini,
+            name: "rust",
+            text: "---\nname: rust\ndescription: Rust engineer\nmodel: other\n---\nBody.\n".to_owned(),
+            breakage: &[],
+            advice: &["kendex-agent-model-fallback: harness=gemini model=other"],
+        },
+        Row {
+            harness: HarnessId::Antigravity,
+            name: "rust",
+            text: "---\nname: rust\ndescription: Rust engineer\nmodel: other\n---\nBody.\n".to_owned(),
+            breakage: &["kendex-agent-model-rejected: harness=antigravity model=other allowed=inherit,flash,pro"],
+            advice: &[],
+        },
+        Row {
+            harness: HarnessId::Opencode,
+            name: "rust",
+            text: "---\ndescription: Rust engineer\nmodel: \"bad\\nmodel\"\n---\nBody.\n".to_owned(),
+            breakage: &["kendex-model-shape: harness=opencode model=bad\\nmodel expected=provider/model"],
+            advice: &[],
+        },
+        Row {
+            harness: HarnessId::Codex,
+            name: "rust",
+            text: "name = \"rust\"\ndescription = \"Rust engineer\"\ndeveloper_instructions = \"Body.\"\nmodel = \"openai/bad\\nmodel\"\n".to_owned(),
+            breakage: &["kendex-model-shape: harness=codex model=openai/bad\\nmodel expected=bare"],
+            advice: &[],
+        },
+        Row {
+            harness: HarnessId::Claude,
+            name: "rust",
+            text: "---\nname: \"other\\nagent\"\ndescription: Rust engineer\n---\nBody.\n".to_owned(),
+            breakage: &["kendex-agent-name-mismatch: harness=claude installed=rust declared=other\\nagent"],
+            advice: &[],
+        },
     ];
     for row in rows {
         let label = format!("{} {}", row.harness.name(), row.name);
@@ -392,6 +490,21 @@ fn a_skill_tree_must_carry_a_skill_md_that_names_its_own_directory() {
         (
             "gh",
             "gh",
+            skill_tree("---\ndescription: d\n---\n"),
+            Some((true, "kendex-skill-name-missing: harness=claude name=gh")),
+        ),
+        (
+            "gh",
+            "gh",
+            skill_tree("---\nname: \"git\\nhub\"\ndescription: d\n---\n"),
+            Some((
+                true,
+                "kendex-skill-name-mismatch: harness=claude installed=gh declared=gh in-file=git\\nhub fix=name",
+            )),
+        ),
+        (
+            "gh",
+            "gh",
             vec![],
             Some((
                 true,
@@ -489,5 +602,59 @@ fn a_skill_whose_description_runs_past_codexs_limit_is_refused_there_and_install
                 .collect::<Vec<_>>(),
             "{harness:?} {length}: {findings:?}"
         );
+    }
+}
+
+/// Command-file findings carry the same record and severity contract.
+#[test]
+fn command_refusals_and_notices_identify_the_rejected_field() {
+    for (harness, text, expected) in [
+        (
+            HarnessId::Gemini,
+            "prompt = broken",
+            vec![(true, "kendex-command-invalid: harness=gemini format=toml")],
+        ),
+        (
+            HarnessId::Gemini,
+            "description = \"Run it\"",
+            vec![(
+                true,
+                "kendex-command-key-missing: harness=gemini key=prompt",
+            )],
+        ),
+        (
+            HarnessId::Gemini,
+            "prompt = \"Run it\"",
+            vec![(
+                false,
+                "kendex-command-key-missing: harness=gemini key=description",
+            )],
+        ),
+        (
+            HarnessId::Gemini,
+            "prompt = \"Run it\"\ndescription = \"Command\"",
+            vec![],
+        ),
+        (
+            HarnessId::Pi,
+            "Report !`git status`",
+            vec![(
+                false,
+                "kendex-command-inline-unsupported: harness=pi syntax=!`command`",
+            )],
+        ),
+        (HarnessId::Pi, "Report the current status", vec![]),
+    ] {
+        let findings = super::validate_command(harness, text);
+        let records: Vec<_> = findings
+            .iter()
+            .map(|finding| {
+                (
+                    finding.is_breakage(),
+                    finding.message.lines().next().unwrap_or_default(),
+                )
+            })
+            .collect();
+        assert_eq!(records, expected, "{harness:?} {text}: {findings:?}");
     }
 }

--- a/crates/core/src/render/validate/tests.rs
+++ b/crates/core/src/render/validate/tests.rs
@@ -17,16 +17,11 @@ fn blocking(findings: &[Finding]) -> Vec<&Finding> {
     findings.iter().filter(|f| f.is_breakage()).collect()
 }
 
-/// Whether some finding's message carries the fragment: the clause the
-/// check emits, read apart from the fix beside it.
-fn said(findings: &[Finding], fragment: &str) -> bool {
-    findings.iter().any(|f| f.message.contains(fragment))
-}
-
-/// Whether some finding's fix carries the value: read only where a fix
-/// spells something computed, never for its wording.
-fn fixed(findings: &[Finding], value: &str) -> bool {
-    findings.iter().any(|f| f.remediation.contains(value))
+/// Stable refusal record, apart from the English explanation.
+fn said(findings: &[Finding], record: &str) -> bool {
+    findings
+        .iter()
+        .any(|f| f.message.lines().next() == Some(record))
 }
 
 /// Findings joined for a failure's diagnostic.
@@ -40,22 +35,18 @@ fn spoken(findings: &[Finding]) -> String {
 
 #[test]
 fn a_sound_rendering_of_every_kind_has_nothing_to_say() {
-    assert_eq!(
-        validate_agent(HarnessId::Codex, "rust", CODEX_AGENT),
-        Vec::new()
-    );
-    assert_eq!(
-        validate_agent(HarnessId::Opencode, "rust", OPENCODE_AGENT),
-        Vec::new()
-    );
-    assert_eq!(
-        validate_agent(HarnessId::Claude, "rust", CLAUDE_AGENT),
-        Vec::new()
-    );
-    assert_eq!(
-        validate_agent(HarnessId::Cursor, "rust", CURSOR_RULE),
-        Vec::new()
-    );
+    for (harness, text) in [
+        (HarnessId::Codex, CODEX_AGENT),
+        (HarnessId::Opencode, OPENCODE_AGENT),
+        (HarnessId::Claude, CLAUDE_AGENT),
+        (HarnessId::Cursor, CURSOR_RULE),
+    ] {
+        assert_eq!(
+            validate_agent(harness, "rust", text),
+            Vec::new(),
+            "{harness:?}"
+        );
+    }
     assert_eq!(
         validate_skill_tree(
             HarnessId::Codex,
@@ -83,18 +74,8 @@ fn every_finding_carries_a_fix() {
     }
 }
 
-/// One row per rendering a harness would refuse or query, and what the
-/// findings say: one message fragment per breakage finding in order, one
-/// per advisory finding in order, and the values the remediations carry
-/// where a fix spells something computed (a name, the accepted set). The
-/// `Finding` carries no rule code, so the message fragment a row pins is
-/// the clause only that check emits; a remedy's wording is not pinned. A
-/// Codex agent must parse as TOML and carry its keys, and name a sandbox
-/// Codex knows. An OpenCode agent must declare a mode and permissions it
-/// can read, a `provider/model` id, and a lowercase-kebab name of at most
-/// 64 characters, which the fix spells. A Claude agent must answer to the
-/// name it installs under. Cursor rule keys outside the three are
-/// folklore, and only advice.
+/// Each invalid rendering has its own stable refusal record and severity.
+/// Accepted alternatives and computed replacement names belong to that record.
 #[test]
 #[allow(clippy::too_many_lines)]
 fn a_rendering_a_harness_would_refuse_is_named_with_what_it_got_wrong() {
@@ -104,104 +85,108 @@ fn a_rendering_a_harness_would_refuse_is_named_with_what_it_got_wrong() {
         text: String,
         breakage: &'static [&'static str],
         advice: &'static [&'static str],
-        remedy: &'static [&'static str],
     }
     let rows = [
         Row {
             harness: HarnessId::Codex,
             name: "rust",
             text: "name = \"rust\ndescription = 1\n".to_owned(),
-            breakage: &["does not parse"],
+            breakage: &["kendex-agent-invalid: harness=codex format=toml"],
             advice: &[],
-            remedy: &[],
         },
         Row {
             harness: HarnessId::Codex,
             name: "rust",
             text: "name = \"\"\nother = \"x\"\n".to_owned(),
-            breakage: &["`name`", "`description`", "`developer_instructions`"],
+            breakage: &[
+                "kendex-agent-key-missing: harness=codex key=name",
+                "kendex-agent-key-missing: harness=codex key=description",
+                "kendex-agent-key-missing: harness=codex key=developer_instructions",
+            ],
             advice: &[],
-            remedy: &[],
         },
         Row {
             harness: HarnessId::Codex,
             name: "rust",
             text: CODEX_AGENT.replace("workspace-write", "yolo"),
-            breakage: &["not a sandbox Codex knows"],
+            breakage: &[
+                "kendex-sandbox-rejected: harness=codex value=yolo allowed=read-only,workspace-write,danger-full-access",
+            ],
             advice: &[],
-            remedy: &["danger-full-access"],
         },
         Row {
             harness: HarnessId::Opencode,
             name: "rust",
             text: OPENCODE_AGENT.replace("mode: subagent", "mode: helper"),
-            breakage: &["`mode: helper`"],
+            breakage: &[
+                "kendex-agent-mode-rejected: harness=opencode value=helper allowed=primary,subagent,all",
+            ],
             advice: &[],
-            remedy: &[],
         },
         Row {
             harness: HarnessId::Opencode,
             name: "rust",
             text: OPENCODE_AGENT.replace("bash: deny", "bash: maybe"),
-            breakage: &["permission `bash`"],
+            breakage: &[
+                "kendex-permission-rejected: harness=opencode key=bash value=maybe allowed=allow,ask,deny",
+            ],
             advice: &[],
-            remedy: &["allow, ask, deny"],
         },
         Row {
             harness: HarnessId::Opencode,
             name: "rust",
             text: "no frontmatter here\n".to_owned(),
-            breakage: &["there is none"],
+            breakage: &["kendex-frontmatter-missing: harness=opencode"],
             advice: &[],
-            remedy: &[],
         },
         Row {
             harness: HarnessId::Opencode,
             name: "rust",
             text: OPENCODE_AGENT.replace("anthropic/claude", "opus"),
-            breakage: &["provider/model"],
+            breakage: &["kendex-model-shape: harness=opencode model=opus expected=provider/model"],
             advice: &[],
-            remedy: &[],
         },
         Row {
             harness: HarnessId::Claude,
             name: "rust",
             text: CLAUDE_AGENT.replace("name: rust", "name: rustacean"),
-            breakage: &["calls itself `rustacean`"],
+            breakage: &[
+                "kendex-agent-name-mismatch: harness=claude installed=rust declared=rustacean",
+            ],
             advice: &[],
-            remedy: &["`rustacean`"],
         },
         Row {
             harness: HarnessId::Claude,
             name: "rust",
             text: CLAUDE_AGENT.replace("name: rust\n", ""),
-            breakage: &["has no name"],
+            breakage: &["kendex-agent-key-missing: harness=claude name=rust key=name"],
             advice: &[],
-            remedy: &[],
         },
         Row {
             harness: HarnessId::Cursor,
             name: "rust",
             text: CURSOR_RULE.replace("alwaysApply: false", "agentRequested: true\nmode: auto"),
             breakage: &[],
-            advice: &["`agentRequested:`", "`mode:`"],
-            remedy: &[],
+            advice: &[
+                "kendex-rule-key-ignored: harness=cursor key=agentRequested",
+                "kendex-rule-key-ignored: harness=cursor key=mode",
+            ],
         },
         Row {
             harness: HarnessId::Opencode,
             name: "My_Skill",
             text: OPENCODE_AGENT.to_owned(),
-            breakage: &["will not load `My_Skill`"],
+            breakage: &["kendex-name-rejected: harness=opencode name=My_Skill suggested=my-skill"],
             advice: &[],
-            remedy: &["`my-skill`"],
         },
         Row {
             harness: HarnessId::Opencode,
             name: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
             text: OPENCODE_AGENT.to_owned(),
-            breakage: &["65 characters"],
+            breakage: &[
+                "kendex-name-too-long: harness=opencode name=aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa length=65 limit=64",
+            ],
             advice: &[],
-            remedy: &[],
         },
         Row {
             harness: HarnessId::Opencode,
@@ -209,7 +194,6 @@ fn a_rendering_a_harness_would_refuse_is_named_with_what_it_got_wrong() {
             text: OPENCODE_AGENT.to_owned(),
             breakage: &[],
             advice: &[],
-            remedy: &[],
         },
     ];
     for row in rows {
@@ -219,17 +203,16 @@ fn a_rendering_a_harness_would_refuse_is_named_with_what_it_got_wrong() {
             findings.iter().partition(|finding| finding.is_breakage());
         assert_eq!(breakage.len(), row.breakage.len(), "{label}: {findings:?}");
         for (finding, fragment) in breakage.iter().zip(row.breakage) {
-            assert!(finding.message.contains(fragment), "{label}: {finding:?}");
+            assert!(
+                finding.message.lines().next() == Some(*fragment),
+                "{label}: {finding:?}"
+            );
         }
         assert_eq!(advice.len(), row.advice.len(), "{label}: {findings:?}");
         for (finding, fragment) in advice.iter().zip(row.advice) {
-            assert!(finding.message.contains(fragment), "{label}: {finding:?}");
-        }
-        let remedies: Vec<&str> = findings.iter().map(|f| f.remediation.as_str()).collect();
-        for value in row.remedy {
             assert!(
-                remedies.iter().any(|r| r.contains(value)),
-                "{label}: {remedies:?}"
+                finding.message.lines().next() == Some(*fragment),
+                "{label}: {finding:?}"
             );
         }
     }
@@ -283,7 +266,15 @@ fn an_effort_level_the_harness_does_not_accept_is_refused() {
             spoken(&refused)
         );
         assert!(
-            said(&refused, bad),
+            refused
+                .iter()
+                .any(
+                    |finding| finding.message.lines().next().is_some_and(|record| record
+                        .starts_with("kendex-effort-rejected: ")
+                        && record
+                            .split_whitespace()
+                            .any(|field| field == format!("value={bad}")))
+                ),
             "{}: {}",
             harness.name(),
             spoken(&refused)
@@ -304,42 +295,84 @@ fn a_model_of_the_wrong_shape_for_the_harness_is_refused() {
     };
     let opencode =
         |model: &str| format!("---\ndescription: r\nmode: subagent\nmodel: {model}\n---\nBody.\n");
-    for (harness, text) in [
-        (HarnessId::Claude, md("anthropic/claude-opus-5")),
-        (HarnessId::Codex, toml("openai/gpt-6-astra")),
-        (HarnessId::Gemini, md("google/gemini-3-pro-preview")),
-        (HarnessId::Copilot, md("anthropic/claude-sonnet-4.6")),
-        (HarnessId::Pi, md("claude-opus-5")),
-        (HarnessId::Pi, md("claude-opus-5:high")),
-        (HarnessId::Pi, md("/claude-opus-5")),
-        (HarnessId::Pi, md("anthropic/")),
-        (HarnessId::Pi, md("anthropic/claude-opus-5:ultra")),
-        (HarnessId::Opencode, opencode("openai/")),
+    for (harness, text, expected) in [
+        (
+            HarnessId::Claude,
+            md("anthropic/claude-opus-5"),
+            Some("kendex-model-shape: harness=claude model=anthropic/claude-opus-5 expected=bare"),
+        ),
+        (
+            HarnessId::Codex,
+            toml("openai/gpt-6-astra"),
+            Some("kendex-model-shape: harness=codex model=openai/gpt-6-astra expected=bare"),
+        ),
+        (
+            HarnessId::Gemini,
+            md("google/gemini-3-pro-preview"),
+            Some(
+                "kendex-model-shape: harness=gemini model=google/gemini-3-pro-preview expected=bare",
+            ),
+        ),
+        (
+            HarnessId::Copilot,
+            md("anthropic/claude-sonnet-4.6"),
+            Some(
+                "kendex-model-shape: harness=copilot model=anthropic/claude-sonnet-4.6 expected=bare",
+            ),
+        ),
+        (
+            HarnessId::Pi,
+            md("claude-opus-5"),
+            Some("kendex-model-shape: harness=pi model=claude-opus-5 expected=provider/model"),
+        ),
+        (
+            HarnessId::Pi,
+            md("claude-opus-5:high"),
+            Some("kendex-model-shape: harness=pi model=claude-opus-5 expected=provider/model"),
+        ),
+        (
+            HarnessId::Pi,
+            md("/claude-opus-5"),
+            Some("kendex-model-shape: harness=pi model=/claude-opus-5 expected=provider/model"),
+        ),
+        (
+            HarnessId::Pi,
+            md("anthropic/"),
+            Some("kendex-model-shape: harness=pi model=anthropic/ expected=provider/model"),
+        ),
+        (
+            HarnessId::Pi,
+            md("anthropic/claude-opus-5:ultra"),
+            Some(
+                "kendex-effort-rejected: harness=pi key=model :suffix value=ultra allowed=minimal,low,medium,high,xhigh,max",
+            ),
+        ),
+        (
+            HarnessId::Opencode,
+            opencode("openai/"),
+            Some("kendex-model-shape: harness=opencode model=openai/ expected=provider/model"),
+        ),
+        (HarnessId::Claude, md("opus"), None),
+        (HarnessId::Claude, md("inherit"), None),
+        (HarnessId::Codex, toml("gpt-6-astra"), None),
+        (HarnessId::Gemini, md("gemini-3-pro-preview"), None),
+        (HarnessId::Copilot, md("claude-sonnet-4.6"), None),
+        (HarnessId::Pi, md("anthropic/claude-opus-5:high"), None),
+        (
+            HarnessId::Opencode,
+            opencode("anthropic/claude-opus-5"),
+            None,
+        ),
     ] {
         let findings = validate_agent(harness, "rust", &text);
+        let records: Vec<_> = blocking(&findings)
+            .into_iter()
+            .map(|finding| finding.message.lines().next().unwrap_or_default())
+            .collect();
         assert_eq!(
-            blocking(&findings).len(),
-            1,
-            "{}: {}",
-            harness.name(),
-            spoken(&findings)
-        );
-    }
-    for (harness, text) in [
-        (HarnessId::Claude, md("opus")),
-        (HarnessId::Claude, md("inherit")),
-        (HarnessId::Codex, toml("gpt-6-astra")),
-        (HarnessId::Gemini, md("gemini-3-pro-preview")),
-        (HarnessId::Copilot, md("claude-sonnet-4.6")),
-        (HarnessId::Pi, md("anthropic/claude-opus-5:high")),
-        (HarnessId::Opencode, opencode("anthropic/claude-opus-5")),
-    ] {
-        let findings = validate_agent(harness, "rust", &text);
-        assert!(
-            blocking(&findings).is_empty(),
-            "{}: {}",
-            harness.name(),
-            spoken(&findings)
+            records,
+            expected.into_iter().collect::<Vec<_>>(),
+            "{harness:?}: {findings:?}"
         );
     }
 }
@@ -361,7 +394,10 @@ fn other_harnesses_refuse_names_that_leave_their_own_directory() {
             &skill_tree(&format!("---\nname: {name}\ndescription: d\n---\n")),
         );
         assert!(
-            said(&findings, "points out of the directory"),
+            said(
+                &findings,
+                &format!("kendex-name-outside-directory: harness=claude name={name}")
+            ),
             "{name}: {findings:?}"
         );
     }
@@ -369,74 +405,106 @@ fn other_harnesses_refuse_names_that_leave_their_own_directory() {
 
 #[test]
 fn a_skill_tree_must_carry_a_skill_md_that_names_its_own_directory() {
-    let missing = validate_skill_tree(HarnessId::Claude, "gh", "gh", &[]);
-    assert_eq!(blocking(&missing).len(), 1);
-    assert!(said(&missing, "no SKILL.md"), "{missing:?}");
-
-    let mismatch = validate_skill_tree(
-        HarnessId::Claude,
-        "gh",
-        "gh",
-        &skill_tree("---\nname: github\ndescription: d\n---\n"),
-    );
-    assert_eq!(blocking(&mismatch).len(), 1, "{mismatch:?}");
-    assert!(said(&mismatch, "calls the skill `github`"), "{mismatch:?}");
-    assert!(fixed(&mismatch, "`name: gh`"), "{mismatch:?}");
-
-    // An item that carries its plugin installs under a name no catalog file
-    // knows and no declaration can spell, so the fix has to be about the
-    // file kendex rewrites — never about renaming what nobody controls.
-    let derived = validate_skill_tree(
-        HarnessId::Claude,
-        "data-science/eda",
-        "data-science__eda",
-        &skill_tree("---\nname: eda\ndescription: d\n---\n"),
-    );
-    assert!(!fixed(&derived, "declare the skill as"), "{derived:?}");
-    assert!(fixed(&derived, "frontmatter"), "{derived:?}");
-
-    let no_description = validate_skill_tree(
-        HarnessId::Claude,
-        "gh",
-        "gh",
-        &skill_tree("---\nname: gh\n---\nBody.\n"),
-    );
-    assert!(blocking(&no_description).is_empty(), "{no_description:?}");
-    assert!(
-        said(&no_description, "no description"),
-        "{no_description:?}"
-    );
-
-    // A disabled tree parks the same content under `.disabled`.
-    let disabled = vec![(
-        PathBuf::from("SKILL.md.disabled"),
-        b"---\nname: gh\ndescription: d\n---\n".to_vec(),
-    )];
-    assert!(validate_skill_tree(HarnessId::Claude, "gh", "gh", &disabled).is_empty());
+    let cases = [
+        (
+            "gh",
+            "gh",
+            vec![],
+            Some((
+                true,
+                "kendex-skill-file-missing: harness=claude name=gh path=SKILL.md",
+            )),
+        ),
+        (
+            "gh",
+            "gh",
+            skill_tree("---\nname: github\ndescription: d\n---\n"),
+            Some((
+                true,
+                "kendex-skill-name-mismatch: harness=claude installed=gh declared=gh in-file=github fix=name",
+            )),
+        ),
+        // A plugin-derived name needs frontmatter repair in the generated file.
+        (
+            "data-science/eda",
+            "data-science__eda",
+            skill_tree("---\nname: eda\ndescription: d\n---\n"),
+            Some((
+                true,
+                "kendex-skill-name-mismatch: harness=claude installed=data-science__eda declared=data-science/eda in-file=eda fix=frontmatter",
+            )),
+        ),
+        (
+            "gh",
+            "gh",
+            skill_tree("---\nname: gh\n---\nBody.\n"),
+            Some((
+                false,
+                "kendex-skill-description-missing: harness=claude name=gh",
+            )),
+        ),
+        (
+            "gh",
+            "gh",
+            vec![(
+                PathBuf::from("SKILL.md.disabled"),
+                b"---\nname: gh\ndescription: d\n---\n".to_vec(),
+            )],
+            None,
+        ),
+    ];
+    for (declared, installed, files, expected) in cases {
+        let findings = validate_skill_tree(HarnessId::Claude, declared, installed, &files);
+        let records: Vec<_> = findings
+            .iter()
+            .map(|finding| {
+                (
+                    finding.is_breakage(),
+                    finding.message.lines().next().unwrap_or_default(),
+                )
+            })
+            .collect();
+        assert_eq!(
+            records,
+            expected.into_iter().collect::<Vec<_>>(),
+            "{declared}: {findings:?}"
+        );
+    }
 }
 
 #[test]
 fn a_skill_whose_description_runs_past_codexs_limit_is_refused_there_and_installs_on_claude() {
-    let body = format!(
-        "---\nname: gh\ndescription: {}\n---\nBody.\n",
-        "é".repeat(1025)
-    );
-    let files = skill_tree(&body);
-    let codex = validate_skill_tree(HarnessId::Codex, "gh", "gh", &files);
-    assert_eq!(blocking(&codex).len(), 1, "{codex:?}");
-    assert!(
-        said(&codex, "`gh`'s description is 1025 characters"),
-        "{codex:?}"
-    );
-    assert!(said(&codex, "past 1024"), "{codex:?}");
-    assert!(validate_skill_tree(HarnessId::Claude, "gh", "gh", &files).is_empty());
-
-    // Exactly at the limit is fine, and the body's length is nobody's
-    // concern: Codex reads the whole file.
-    let long = format!(
-        "---\nname: gh\ndescription: {}\n---\n{}",
-        "d".repeat(1024),
-        "prose ".repeat(4000)
-    );
-    assert!(validate_skill_tree(HarnessId::Codex, "gh", "gh", &skill_tree(&long)).is_empty());
+    for (harness, length, body, expected) in [
+        (
+            HarnessId::Codex,
+            1025,
+            "Body.".to_owned(),
+            Some("kendex-skill-description-too-long: harness=codex name=gh length=1025 limit=1024"),
+        ),
+        (HarnessId::Claude, 1025, "Body.".to_owned(), None),
+        (HarnessId::Codex, 1024, "prose ".repeat(4000), None),
+    ] {
+        let text = format!(
+            "---\nname: gh\ndescription: {}\n---\n{body}\n",
+            "é".repeat(length)
+        );
+        let findings = validate_skill_tree(harness, "gh", "gh", &skill_tree(&text));
+        let records: Vec<_> = findings
+            .iter()
+            .map(|finding| {
+                (
+                    finding.is_breakage(),
+                    finding.message.lines().next().unwrap_or_default(),
+                )
+            })
+            .collect();
+        assert_eq!(
+            records,
+            expected
+                .map(|record| (true, record))
+                .into_iter()
+                .collect::<Vec<_>>(),
+            "{harness:?} {length}: {findings:?}"
+        );
+    }
 }

--- a/crates/core/src/render/validate/tests.rs
+++ b/crates/core/src/render/validate/tests.rs
@@ -24,15 +24,6 @@ fn said(findings: &[Finding], record: &str) -> bool {
         .any(|f| f.message.lines().next() == Some(record))
 }
 
-/// Findings joined for a failure's diagnostic.
-fn spoken(findings: &[Finding]) -> String {
-    findings
-        .iter()
-        .map(|f| format!("{} — {}", f.message, f.remediation))
-        .collect::<Vec<_>>()
-        .join(" | ")
-}
-
 #[test]
 fn a_sound_rendering_of_every_kind_has_nothing_to_say() {
     for (harness, text) in [
@@ -229,56 +220,48 @@ fn an_effort_level_the_harness_does_not_accept_is_refused() {
             "---\nname: rust\ndescription: r\neffort: {}\n---\nBody.\n",
             "max",
             "ultra",
+            "kendex-effort-rejected: harness=claude key=effort value=ultra allowed=low,medium,high,xhigh,max",
         ),
         (
             HarnessId::Codex,
             "name = \"rust\"\ndescription = \"r\"\nmodel_reasoning_effort = \"{}\"\ndeveloper_instructions = '''\nBody.\n'''\n",
             "xhigh",
             "max",
+            "kendex-effort-rejected: harness=codex key=model_reasoning_effort value=max allowed=minimal,low,medium,high,xhigh",
         ),
         (
             HarnessId::Opencode,
             "---\ndescription: r\nmode: subagent\noptions:\n  reasoningEffort: {}\n---\nBody.\n",
             "high",
             "ultra",
+            "kendex-effort-rejected: harness=opencode key=reasoningEffort value=ultra allowed=minimal,low,medium,high,xhigh",
         ),
         (
             HarnessId::Pi,
             "---\nname: rust\ndescription: r\neffort: {}\n---\nBody.\n",
             "max",
             "ultra",
+            "kendex-effort-rejected: harness=pi key=effort value=ultra allowed=minimal,low,medium,high,xhigh,max",
         ),
     ];
-    for (harness, shape, good, bad) in cases {
-        let accepted = validate_agent(harness, "rust", &shape.replace("{}", good));
-        assert!(
-            accepted.is_empty(),
-            "{}: {}",
-            harness.name(),
-            spoken(&accepted)
-        );
-        let refused = validate_agent(harness, "rust", &shape.replace("{}", bad));
-        assert_eq!(
-            blocking(&refused).len(),
-            1,
-            "{}: {}",
-            harness.name(),
-            spoken(&refused)
-        );
-        assert!(
-            refused
+    for (harness, shape, good, bad, refusal) in cases {
+        for (value, expected) in [(good, None), (bad, Some((true, refusal)))] {
+            let findings = validate_agent(harness, "rust", &shape.replace("{}", value));
+            let records: Vec<_> = findings
                 .iter()
-                .any(
-                    |finding| finding.message.lines().next().is_some_and(|record| record
-                        .starts_with("kendex-effort-rejected: ")
-                        && record
-                            .split_whitespace()
-                            .any(|field| field == format!("value={bad}")))
-                ),
-            "{}: {}",
-            harness.name(),
-            spoken(&refused)
-        );
+                .map(|finding| {
+                    (
+                        finding.is_breakage(),
+                        finding.message.lines().next().unwrap_or_default(),
+                    )
+                })
+                .collect();
+            assert_eq!(
+                records,
+                expected.into_iter().collect::<Vec<_>>(),
+                "{harness:?} {value}: {findings:?}"
+            );
+        }
     }
 }
 

--- a/crates/core/tests/antigravity.rs
+++ b/crates/core/tests/antigravity.rs
@@ -198,8 +198,8 @@ fn a_project_agent_installs_nothing_and_the_report_says_why() {
     let f = fixture("[agents.rust]\nsource = \"cat\"\n");
     let report = apply_now(&f);
     assert!(
-        report.notes.iter().any(|note| note
-            == "agent rust: Antigravity cannot hold one at this scope — nothing was installed"),
+        report.notes.iter().any(|note| note.lines().next()
+            == Some("kendex-item-unsupported: kind=agent name=rust harnesses=antigravity")),
         "{:?}",
         report.notes
     );
@@ -259,7 +259,7 @@ fn a_hook_registers_under_its_name_in_the_roots_hooks_json() {
     // The command finds the script when it runs and names no directory of
     // this machine's, so a repository can commit the registry it is in.
     let command = entry["command"].as_str().unwrap();
-    assert!(command.contains("p='.agents/hooks/audit.sh'"), "{command}");
+    assert_eq!(kendex_core::hook::command_stem(command), "audit");
     assert!(
         !command.contains(&*f.project.to_string_lossy()),
         "{command}"
@@ -292,26 +292,38 @@ fn a_hook_registers_under_its_name_in_the_roots_hooks_json() {
     assert_eq!(after["lint"]["PostToolUse"][0]["matcher"], "run_command");
 }
 
-/// A hook that names no harness is written for the `tool_input` payload;
-/// Antigravity sends `toolCall.args`, so the hook would run and read
-/// nothing. It installs nowhere on Antigravity and the plan says why.
+/// Unlisted payloads and unsupported events both refuse registration with
+/// the reason that applies to the supplied hook.
 #[test]
 #[allow(clippy::unwrap_used)]
-fn a_hook_naming_no_harness_stays_out_of_antigravity() {
-    let f = fixture("[hooks.audit]\nsource = \"cat\"\n");
-    fs::write(f.env.home.join("catalog/hooks/audit.sh"), UNNAMED_HOOK).unwrap();
-    let report = apply_now(&f);
-
-    assert!(!f.project.join(".agents/hooks.json").exists());
-    assert!(!f.project.join(".agents/hooks/audit.sh").exists());
-    assert!(
-        report
-            .notes
-            .iter()
-            .any(|note| note.starts_with("hook audit: skips antigravity")),
-        "{:?}",
-        report.notes
-    );
+fn a_hook_the_harness_cannot_run_stays_out_of_antigravity() {
+    for (hook, record) in [
+        (
+            UNNAMED_HOOK.to_owned(),
+            "kendex-hook-unlisted: harness=antigravity hook=audit",
+        ),
+        (
+            AUDIT_HOOK.replace("PreToolUse", "TaskCompleted"),
+            "kendex-hook-unsupported: harness=antigravity event=TaskCompleted hook=audit",
+        ),
+    ] {
+        let f = fixture("[hooks.audit]\nsource = \"cat\"\n");
+        fs::write(f.env.home.join("catalog/hooks/audit.sh"), hook).unwrap();
+        let report = apply_now(&f);
+        assert!(!f.project.join(".agents/hooks.json").exists(), "{record}");
+        assert!(
+            !f.project.join(".agents/hooks/audit.sh").exists(),
+            "{record}"
+        );
+        assert!(
+            report
+                .notes
+                .iter()
+                .any(|note| note.lines().next() == Some(record)),
+            "{record}: {:?}",
+            report.notes
+        );
+    }
 }
 
 /// What kendex writes is what kendex reads back: the scan finds the entry
@@ -464,10 +476,13 @@ fn a_server_with_env_references_is_refused_with_the_reason() {
     let f = fixture("[mcp-servers.tokened]\nsource = \"cat\"\n");
     let report = apply_now(&f);
     assert!(
-        report
-            .drift
-            .iter()
-            .any(|row| row.name == "tokened" && row.detail.contains("documents no substitution")),
+        report.drift.iter().any(|row| row.name == "tokened"
+            && row.kind == kendex_core::model::ItemKind::McpServer
+            && row.harness == kendex_core::model::HarnessId::Antigravity
+            && row.state == kendex_core::engine::DriftState::Conflict
+            && row.cause.is_none()
+            && row.detail.lines().next()
+                == Some("kendex-mcp-env-unsupported: harness=antigravity")),
         "{:?}",
         report.drift
     );

--- a/crates/core/tests/copilot_reports.rs
+++ b/crates/core/tests/copilot_reports.rs
@@ -96,10 +96,8 @@ fn an_event_copilot_does_not_have_is_reported_never_faked() {
     let f = fixture("\"copilot\"", "[hooks.done]\nsource = \"cat\"\n");
     let report = audit(&f.env, &f.scope).unwrap();
     assert!(
-        report
-            .notes
-            .iter()
-            .any(|note| note.contains("event TaskCompleted has no Copilot counterpart")),
+        report.notes.iter().any(|note| note.lines().next()
+            == Some("kendex-hook-unsupported: harness=copilot event=TaskCompleted hook=done")),
         "{:?}",
         report.notes
     );
@@ -114,31 +112,22 @@ fn an_event_copilot_does_not_have_is_reported_never_faked() {
 fn hooks_switched_off_in_claudes_settings_are_reported_inert() {
     let f = fixture("\"copilot\"", "[hooks.audit]\nsource = \"cat\"\n");
     let claude = f.project.join(".claude/settings.json");
-    fs::write(&claude, r#"{"disableAllHooks": true}"#).unwrap();
-
-    let report = apply_now(&f);
-    assert!(
-        report
-            .warnings
-            .iter()
-            .any(|w| w.message.contains("installs but stays inert")),
-        "{:?}",
-        report.warnings
-    );
-    // Said, not obeyed: the registration still lands where Copilot reads it.
-    let registry = f.project.join(".github/hooks/audit.json");
-    assert_eq!(json(&registry)["hooks"]["preToolUse"][0]["matcher"], "bash");
-
-    fs::write(&claude, r#"{"disableAllHooks": false}"#).unwrap();
-    let quiet = audit(&f.env, &f.scope).unwrap();
-    assert!(
-        !quiet
-            .warnings
-            .iter()
-            .any(|w| w.message.contains("stays inert")),
-        "{:?}",
-        quiet.warnings
-    );
+    for disabled in [true, false] {
+        fs::write(&claude, format!("{{\"disableAllHooks\": {disabled}}}")).unwrap();
+        let report = apply_now(&f);
+        assert_eq!(
+            report.warnings.iter().any(|w| w.message.lines().next()
+                == Some(
+                    "kendex-hooks-disabled: harness=copilot hook=audit setting=disableAllHooks"
+                )),
+            disabled,
+            "disabled={disabled}: {:?}",
+            report.warnings
+        );
+        // The report names the switch but keeps the requested registration.
+        let registry = f.project.join(".github/hooks/audit.json");
+        assert_eq!(json(&registry)["hooks"]["preToolUse"][0]["matcher"], "bash");
+    }
 }
 
 /// A repository file may add a name to `disabledSkills` but never take one
@@ -155,10 +144,8 @@ fn a_skill_a_personal_setting_holds_down_cannot_be_switched_back_on_here() {
 
     let report = apply_now(&f);
     assert!(
-        report
-            .warnings
-            .iter()
-            .any(|w| w.message.contains("this project cannot switch it back on")),
+        report.warnings.iter().any(|w| w.message.lines().next()
+            == Some("kendex-item-disabled: harness=copilot item=deploy setting=disabledSkills")),
         "{:?}",
         report.warnings
     );
@@ -167,62 +154,46 @@ fn a_skill_a_personal_setting_holds_down_cannot_be_switched_back_on_here() {
     assert!(f.project.join(".agents/skills/deploy/SKILL.md").is_file());
 }
 
-/// One tree, two readers. Copilot sees a skill installed for Claude Code,
-/// and saying so must never turn one installation into two.
+/// A shared skill names Copilot as a reader only when its loader accepts
+/// the name. The note does not create another installation.
 #[test]
 #[allow(clippy::unwrap_used)]
-fn a_skill_installed_for_another_tool_is_noted_as_visible_to_copilot() {
-    let f = fixture("\"claude\"", "[skills.deploy]\nsource = \"cat\"\n");
-    let report = apply_now(&f);
-    assert!(
-        report
-            .notes
-            .iter()
-            .any(|note| note.contains("GitHub Copilot")
-                && note.contains("read `.agents/skills` too")
-                && note.contains("one definition, counted once")),
-        "{:?}",
-        report.notes
-    );
-    // Nothing was installed into Copilot's own directory, and nothing in the
-    // report claims Copilot has an installation of its own.
-    assert!(!f.project.join(".github/skills").exists());
-    assert!(
-        !report
-            .drift
-            .iter()
-            .any(|row| row.harness == kendex_core::model::HarnessId::Copilot)
-    );
-}
-
-/// The same note, over a name that reader's loader will not take. Copilot
-/// keys a skill on a lowercase-hyphen slug, so `Deploy` is unloadable
-/// there rather than renamed — counting Copilot as already having the
-/// definition would be counting one it cannot read. The test above is the
-/// pair: the same install under a plain name does name Copilot, so this
-/// cannot pass by the note having gone silent.
-#[test]
-#[allow(clippy::unwrap_used)]
-fn the_cross_read_note_skips_a_loader_that_would_reject_the_name() {
-    let f = fixture("\"claude\"", "[skills.Deploy]\nsource = \"cat\"\n");
-    let source = f.env.home.join("catalog/skills/Deploy");
-    fs::create_dir_all(&source).unwrap();
-    fs::write(
-        source.join("SKILL.md"),
-        "---\nname: Deploy\ndescription: Ship it\n---\n\nSteps.\n",
-    )
-    .unwrap();
-
-    let report = apply_now(&f);
-    assert!(f.project.join(".agents/skills/Deploy/SKILL.md").is_file());
-    assert!(
-        !report
-            .notes
-            .iter()
-            .any(|note| note.contains("GitHub Copilot")),
-        "Copilot cannot load `Deploy`: {:?}",
-        report.notes
-    );
+fn a_shared_skill_names_only_readers_that_accept_its_name() {
+    for (name, expected) in [("deploy", true), ("Deploy", false)] {
+        let f = fixture(
+            "\"claude\"",
+            &format!("[skills.{name}]\nsource = \"cat\"\n"),
+        );
+        let source = f.env.home.join("catalog/skills").join(name);
+        fs::create_dir_all(&source).unwrap();
+        fs::write(
+            source.join("SKILL.md"),
+            format!("---\nname: {name}\ndescription: Ship it\n---\n\nSteps.\n"),
+        )
+        .unwrap();
+        let report = apply_now(&f);
+        assert_eq!(
+            report.notes.iter().any(|note| note.lines().next()
+                == Some("kendex-shared-skills: readers=copilot path=.agents/skills")),
+            expected,
+            "{name}: {:?}",
+            report.notes
+        );
+        assert!(
+            f.project
+                .join(".agents/skills")
+                .join(name)
+                .join("SKILL.md")
+                .is_file()
+        );
+        assert!(!f.project.join(".github/skills").exists());
+        assert!(
+            !report
+                .drift
+                .iter()
+                .any(|row| row.harness == kendex_core::model::HarnessId::Copilot)
+        );
+    }
 }
 
 #[test]
@@ -237,9 +208,7 @@ fn a_model_the_repository_will_not_run_is_named() {
 
     let report = apply_now(&f);
     assert!(
-        report.warnings.iter().any(|w| w
-            .message
-            .contains("allows gpt-5.4 and not claude-sonnet-4.6")),
+        report.warnings.iter().any(|w| w.message.lines().next() == Some("kendex-model-disallowed: harness=copilot agent=rust requested=claude-sonnet-4.6 allowed=gpt-5.4")),
         "{:?}",
         report.warnings
     );
@@ -264,8 +233,14 @@ fn a_name_copilots_loader_rejects_is_refused_with_the_one_that_works() {
     let report = apply_now(&f);
     assert!(
         report.drift.iter().any(|row| row.name == "Deploy_Thing"
-            && row.detail.contains("will not load `Deploy_Thing`")
-            && row.detail.contains("deploy-thing")),
+            && row.kind == kendex_core::model::ItemKind::Skill
+            && row.harness == kendex_core::model::HarnessId::Copilot
+            && row.state == kendex_core::engine::DriftState::Conflict
+            && row.cause.is_none()
+            && row.detail.lines().next()
+                == Some(
+                    "kendex-name-rejected: harness=copilot name=Deploy_Thing suggested=deploy-thing"
+                )),
         "{:?}",
         report.drift
     );
@@ -288,9 +263,8 @@ fn a_command_declared_only_for_copilot_says_it_installed_nowhere() {
 
     let report = apply_now(&f);
     assert!(
-        report.notes.iter().any(|note| note
-            .contains("command ship: GitHub Copilot cannot hold one at this scope")
-            && note.contains("nothing was installed")),
+        report.notes.iter().any(|note| note.lines().next()
+            == Some("kendex-item-unsupported: kind=command name=ship harnesses=copilot")),
         "{:?}",
         report.notes
     );

--- a/crates/core/tests/copilot_reports.rs
+++ b/crates/core/tests/copilot_reports.rs
@@ -199,20 +199,38 @@ fn a_shared_skill_names_only_readers_that_accept_its_name() {
 #[test]
 #[allow(clippy::unwrap_used)]
 fn a_model_the_repository_will_not_run_is_named() {
-    let f = fixture("\"copilot\"", "[agents.rust]\nsource = \"cat\"\n");
-    fs::write(
-        f.project.join(".github/allowed_models.txt"),
-        "gpt-5.4\nfallback: gpt-5.4\n",
-    )
-    .unwrap();
-
-    let report = apply_now(&f);
-    assert!(
-        report.warnings.iter().any(|w| w.message.lines().next() == Some("kendex-model-disallowed: harness=copilot agent=rust requested=claude-sonnet-4.6 allowed=gpt-5.4")),
-        "{:?}",
-        report.warnings
-    );
-    assert!(f.project.join(".github/agents/rust.agent.md").is_file());
+    for (model, record) in [
+        (
+            "claude-sonnet-4.6",
+            "kendex-model-disallowed: harness=copilot agent=rust requested=claude-sonnet-4.6 allowed=gpt-5.4",
+        ),
+        (
+            "claude-sonnet-4.6\nother",
+            "kendex-model-disallowed: harness=copilot agent=rust requested=claude-sonnet-4.6\\nother allowed=gpt-5.4",
+        ),
+    ] {
+        let f = fixture("\"copilot\"", "[agents.rust]\nsource = \"cat\"\n");
+        let agent = format!(
+            "---\nname: rust\ndescription: Rust engineer\nmodel: {}\n---\nBody.\n",
+            serde_json::to_string(model).unwrap()
+        );
+        fs::write(f.env.home.join("catalog/agents/rust.md"), agent).unwrap();
+        fs::write(
+            f.project.join(".github/allowed_models.txt"),
+            "gpt-5.4\nfallback: gpt-5.4\n",
+        )
+        .unwrap();
+        let report = apply_now(&f);
+        assert!(
+            report
+                .warnings
+                .iter()
+                .any(|warning| warning.message.lines().next() == Some(record)),
+            "{record}: {:?}",
+            report.warnings
+        );
+        assert!(f.project.join(".github/agents/rust.agent.md").is_file());
+    }
 }
 
 /// Copilot's skills reference requires a lowercase-hyphen `name`, so a name

--- a/crates/core/tests/custom_hooks.rs
+++ b/crates/core/tests/custom_hooks.rs
@@ -61,16 +61,18 @@ fn an_every_agent_hook_registers_on_codex_and_removal_reverses_it() {
     kendex_core::apply::execute(&w.env, &report.plan).unwrap();
 
     let registry = fs::read_to_string(w.project.join(".codex/hooks.json")).unwrap();
-    assert!(
-        registry.contains("./scripts/guard.sh"),
-        "the person's command is registered verbatim: {registry}"
+    let registry: serde_json::Value = serde_json::from_str(&registry).unwrap();
+    assert_eq!(
+        registry["hooks"]["PreToolUse"][0]["hooks"][0]["command"],
+        "./scripts/guard.sh"
     );
     assert!(
         !w.project.join(".codex/hooks").exists(),
         "a command-bodied hook writes no script of its own"
     );
     let config = fs::read_to_string(w.project.join(".codex/config.toml")).unwrap();
-    assert!(config.contains("hooks"), "the feature flag rides along");
+    let config: toml::Value = toml::from_str(&config).unwrap();
+    assert_eq!(config["features"]["hooks"].as_bool(), Some(true));
 
     // The registration is in sync — a second audit owes nothing.
     let clean = audit(&w.env, &scope(&w)).unwrap();
@@ -93,36 +95,59 @@ fn an_every_agent_hook_registers_on_codex_and_removal_reverses_it() {
     .unwrap();
     kendex_core::apply::execute(&w.env, &removal.plan).unwrap();
     let registry = fs::read_to_string(w.project.join(".codex/hooks.json")).unwrap();
-    assert!(
-        !registry.contains("guard.sh"),
-        "the registration is reversed: {registry}"
+    let registry: serde_json::Value = serde_json::from_str(&registry).unwrap();
+    assert_eq!(
+        registry["hooks"]["PreToolUse"]
+            .as_array()
+            .map(Vec::len)
+            .unwrap_or_default(),
+        0
     );
 }
 
 #[test]
 #[allow(clippy::unwrap_used)]
-fn a_scoped_hook_off_claude_is_prose_plus_a_warning_and_no_registration() {
-    let w = world();
-    declare(
-        &w,
-        "name = \"guard-pretooluse\"\nevent = \"PreToolUse\"\ncommand = \"./scripts/guard.sh\"\nagents = \"reviewer\"\n",
-    );
-
-    let report = audit(&w.env, &scope(&w)).unwrap();
-    let warning = report
-        .warnings
-        .iter()
-        .find(|warning| warning.name == "guard-pretooluse")
-        .expect("the downgrade is said per item");
-    assert!(
-        warning.message.contains("cannot tell agents apart"),
-        "{warning:?}"
-    );
-    kendex_core::apply::execute(&w.env, &report.plan).unwrap();
-    assert!(
-        !w.project.join(".codex/hooks.json").exists(),
-        "nothing is registered for a hook codex cannot scope"
-    );
+fn a_custom_hook_refusal_names_its_delivery_limit() {
+    for (harness, event, agents, record) in [
+        (
+            "codex",
+            "PreToolUse",
+            "reviewer",
+            "kendex-custom-hook-unscoped: harness=codex hook=guard-pretooluse",
+        ),
+        (
+            "codex",
+            "TaskCompleted",
+            "all",
+            "kendex-custom-hook-advisory: harness=codex hook=guard-pretooluse event=TaskCompleted",
+        ),
+        (
+            "antigravity",
+            "PreToolUse",
+            "all",
+            "kendex-custom-hook-unlisted: hook=guard-pretooluse harness=antigravity",
+        ),
+    ] {
+        let w = world();
+        fs::create_dir_all(w.project.join(".agents")).unwrap();
+        fs::write(w.project.join("kendex.toml"), format!("schema = 6\n[install]\nharnesses = [\"{harness}\"]\n[[custom-hooks]]\nname = \"guard-pretooluse\"\nevent = \"{event}\"\ncommand = \"./scripts/guard.sh\"\nagents = \"{agents}\"\n")).unwrap();
+        let report = audit(&w.env, &scope(&w)).unwrap();
+        let notices: Vec<_> = report
+            .warnings
+            .iter()
+            .map(|warning| warning.message.as_str())
+            .chain(report.notes.iter().map(String::as_str))
+            .collect();
+        assert!(
+            notices
+                .iter()
+                .any(|notice| notice.lines().next() == Some(record)),
+            "{record}: {notices:?}"
+        );
+        kendex_core::apply::execute(&w.env, &report.plan).unwrap();
+        assert!(!w.project.join(".codex/hooks.json").exists(), "{record}");
+        assert!(!w.project.join(".agents/hooks.json").exists(), "{record}");
+    }
 }
 
 #[test]
@@ -160,9 +185,10 @@ fn an_every_agent_hook_on_claude_lives_in_settings_not_agent_files() {
     kendex_core::apply::execute(&w.env, &report.plan).unwrap();
 
     let settings = fs::read_to_string(w.project.join(".claude/settings.json")).unwrap();
-    assert!(
-        settings.contains("./scripts/guard.sh"),
-        "the hook is registered where the whole session reads it: {settings}"
+    let settings: serde_json::Value = serde_json::from_str(&settings).unwrap();
+    assert_eq!(
+        settings["hooks"]["PreToolUse"][0]["hooks"][0]["command"],
+        "./scripts/guard.sh"
     );
     let clean = audit(&w.env, &scope(&w)).unwrap();
     assert!(clean.drift.is_empty(), "{:?}", clean.drift);

--- a/crates/core/tests/drift_hook_install.rs
+++ b/crates/core/tests/drift_hook_install.rs
@@ -87,9 +87,11 @@ fn the_drift_hook_installs_as_a_declared_item_and_is_idempotent() {
             ][..]
         )
     );
-    assert!(
-        drift::hook::HOOK_SCRIPT.contains("harnesses: [claude-code, pi]"),
-        "the script itself must apply to pi"
+    assert_eq!(
+        kendex_core::hook::parse_hook(drift::hook::HOOK_SCRIPT)
+            .unwrap()
+            .harnesses,
+        Some(vec!["claude-code".to_owned(), "pi".to_owned()]),
     );
 
     // The ordinary refresh renders it.

--- a/crates/core/tests/drift_hook_script.rs
+++ b/crates/core/tests/drift_hook_script.rs
@@ -120,6 +120,14 @@ const CASES: &[HookCase] = &[
         "Error: loading lock file\n",
     ),
     (
+        "CLI usage failure",
+        "{}",
+        &[],
+        Some("#!/bin/sh\necho 'error: unrecognized subcommand' >&2\nexit 2\n"),
+        Some("kendex-drift-failed: exit=2"),
+        "error: unrecognized subcommand\n",
+    ),
+    (
         "incomplete",
         "{}",
         &[],

--- a/crates/core/tests/drift_hook_script.rs
+++ b/crates/core/tests/drift_hook_script.rs
@@ -1,6 +1,5 @@
-//! The session-start hook script's contract, exercised against /bin/sh:
-//! every failure path emits exactly one line, resumed and compacted
-//! sessions stay silent, and the hook never exits non-zero.
+//! The generated hook preserves the CLI report protocol, identifies its own
+//! notices by stable keys, and never blocks a session.
 #![cfg(unix)]
 
 use std::fs;
@@ -8,9 +7,11 @@ use std::path::Path;
 
 use kendex_core::drift;
 
-/// The hook script's contract, exercised against /bin/sh with a stub
-/// `kendex` on PATH: every failure path emits exactly one line, and the
-/// hook never exits non-zero.
+#[path = "../../test_util.rs"]
+mod test_util;
+use test_util::rooted;
+
+/// Run the actual generated script with a private CLI stub.
 #[allow(clippy::unwrap_used)]
 fn run_hook(dir: &Path, stdin: &str, env: &[(&str, &str)], stub: Option<&str>) -> (String, i32) {
     use std::io::Write;
@@ -52,130 +53,143 @@ fn run_hook(dir: &Path, stdin: &str, env: &[(&str, &str)], stub: Option<&str>) -
     )
 }
 
-#[test]
-#[allow(clippy::unwrap_used)]
-fn the_hook_script_honors_its_contract() {
-    let tmp = tempfile::tempdir().unwrap();
-    let dir = tmp.path();
+type HookCase = (
+    &'static str,
+    &'static str,
+    &'static [(&'static str, &'static str)],
+    Option<&'static str>,
+    Option<&'static str>,
+    &'static str,
+);
 
-    // Kill switch: silent, exit 0.
-    let (out, code) = run_hook(dir, "{}", &[("KENDEX_DRIFT_HOOK", "off")], None);
-    assert_eq!((out.as_str(), code), ("", 0));
-
-    // Resumed and compacted sessions are skipped.
-    let (out, code) = run_hook(
-        dir,
+const CASES: &[HookCase] = &[
+    (
+        "disabled",
+        "{}",
+        &[("KENDEX_DRIFT_HOOK", "off")],
+        None,
+        None,
+        "",
+    ),
+    (
+        "resume",
         r#"{"source":"resume"}"#,
         &[],
         Some("#!/bin/sh\necho drift\nexit 1\n"),
-    );
-    assert_eq!((out.as_str(), code), ("", 0));
-    let (out, code) = run_hook(
-        dir,
+        None,
+        "",
+    ),
+    (
+        "compact",
         r#"{"source":"compact"}"#,
         &[],
         Some("#!/bin/sh\necho drift\nexit 1\n"),
-    );
-    assert_eq!((out.as_str(), code), ("", 0));
-    // Pi's carrier re-runs extensions in place on reload — an already
-    // delivered report must not repeat.
-    let (out, code) = run_hook(
-        dir,
+        None,
+        "",
+    ),
+    (
+        "reload",
         r#"{"source":"reload"}"#,
         &[],
         Some("#!/bin/sh\necho drift\nexit 1\n"),
-    );
-    assert_eq!((out.as_str(), code), ("", 0));
-
-    // Missing binary: exactly one "skipped" line, exit 0.
-    let (out, code) = run_hook(dir, "{}", &[], None);
-    assert_eq!(out.lines().count(), 1, "{out}");
-    assert!(out.contains("skipped"), "{out}");
-    assert_eq!(code, 0);
-
-    // Exit 2 and nothing said: exactly one "could not run" line.
-    let (out, code) = run_hook(dir, "{}", &[], Some("#!/bin/sh\nexit 2\n"));
-    assert_eq!(out.lines().count(), 1, "{out}");
-    assert!(out.contains("could not run (exit 2)"), "{out}");
-    assert_eq!(code, 0);
-
-    // Exit 2 with kendex's own Error: line (stderr): nothing was checked,
-    // so it is a failure to run, and the diagnostic reaches the agent.
-    let (out, code) = run_hook(
-        dir,
+        None,
+        "",
+    ),
+    (
+        "unavailable",
+        "{}",
+        &[],
+        None,
+        Some("kendex-drift-unavailable: command=kendex"),
+        "",
+    ),
+    (
+        "empty failure",
+        "{}",
+        &[],
+        Some("#!/bin/sh\nexit 2\n"),
+        Some("kendex-drift-failed: exit=2"),
+        "",
+    ),
+    (
+        "CLI failure",
         "{}",
         &[],
         Some("#!/bin/sh\necho 'Error: loading lock file' >&2\nexit 2\n"),
-    );
-    assert!(
-        out.starts_with("kendex check could not run (exit 2)"),
-        "{out}"
-    );
-    assert!(out.contains("Error: loading lock file"), "{out}");
-    assert!(!out.contains("incomplete"), "{out}");
-    assert_eq!(code, 0);
-
-    // Exit 2 with a report: the check ran and says what it could not
-    // check, so the report is relayed under an "incomplete" line.
-    let (out, code) = run_hook(
-        dir,
+        Some("kendex-drift-failed: exit=2"),
+        "Error: loading lock file\n",
+    ),
+    (
+        "incomplete",
         "{}",
         &[],
         Some("#!/bin/sh\nprintf 'stale:\\n  x\\ncould not check:\\n  lock: bad\\n'\nexit 2\n"),
-    );
-    assert!(out.starts_with("kendex check incomplete (exit 2)"), "{out}");
-    assert!(out.contains("stale:") && out.contains("lock: bad"), "{out}");
-    assert!(!out.contains("could not run"), "{out}");
-    assert_eq!(code, 0);
-
-    // Any other exit code is not a kendex verdict.
-    let (out, code) = run_hook(dir, "{}", &[], Some("#!/bin/sh\necho fatal\nexit 3\n"));
-    assert!(
-        out.starts_with("kendex check could not run (exit 3)"),
-        "{out}"
-    );
-    assert!(out.contains("fatal"), "{out}");
-    assert_eq!(code, 0);
-
-    // A signal or a timeout kills the check before it says anything. The
-    // empty-output arm belongs to exit 2 alone, so this keeps the colon
-    // over a blank line — the same text the shell and Pi hooks print.
-    let (out, code) = run_hook(dir, "{}", &[], Some("#!/bin/sh\nexit 3\n"));
-    assert_eq!(
-        (out.as_str(), code),
-        (
-            "kendex check could not run (exit 3); drift status unknown:\n\n",
-            0
-        )
-    );
-
-    // Drift: the report passes through, exit stays 0.
-    let (out, code) = run_hook(
-        dir,
+        Some("kendex-drift-incomplete: exit=2"),
+        "stale:\n  x\ncould not check:\n  lock: bad\n",
+    ),
+    (
+        "unexpected exit",
+        "{}",
+        &[],
+        Some("#!/bin/sh\necho fatal\nexit 3\n"),
+        Some("kendex-drift-failed: exit=3"),
+        "fatal\n",
+    ),
+    (
+        "empty unexpected exit",
+        "{}",
+        &[],
+        Some("#!/bin/sh\nexit 3\n"),
+        Some("kendex-drift-failed: exit=3"),
+        "",
+    ),
+    (
+        "drift relay",
         r#"{"source":"startup"}"#,
         &[],
         Some("#!/bin/sh\necho 'stale:'\nexit 1\n"),
-    );
-    assert_eq!((out.as_str(), code), ("stale:\n", 0));
-
-    // Clean: silent, whatever kendex said on stderr on the way.
-    let (out, code) = run_hook(dir, "{}", &[], Some("#!/bin/sh\nexit 0\n"));
-    assert_eq!((out.as_str(), code), ("", 0));
-    let (out, code) = run_hook(dir, "{}", &[], Some("#!/bin/sh\necho noise >&2\nexit 0\n"));
-    assert_eq!((out.as_str(), code), ("", 0));
-
-    // #3: an error: line inside a could-not-check line is part of a
-    // completed report, not the pre-check failure shape.
-    let (out, code) = run_hook(
-        dir,
+        None,
+        "stale:\n",
+    ),
+    ("clean", "{}", &[], Some("#!/bin/sh\nexit 0\n"), None, ""),
+    (
+        "clean stderr",
+        "{}",
+        &[],
+        Some("#!/bin/sh\necho noise >&2\nexit 0\n"),
+        None,
+        "",
+    ),
+    (
+        "error inside report",
         "{}",
         &[],
         Some(
             "#!/bin/sh\nprintf 'could not check:\\n  source github.com/x/y unreachable since 2026-08-01: error: cannot lock ref\\n'\nexit 2\n",
         ),
-    );
-    assert!(out.starts_with("kendex check incomplete (exit 2)"), "{out}");
-    assert!(out.contains("error: cannot lock ref"), "{out}");
-    assert!(!out.contains("could not run"), "{out}");
-    assert_eq!(code, 0);
+        Some("kendex-drift-incomplete: exit=2"),
+        "could not check:\n  source github.com/x/y unreachable since 2026-08-01: error: cannot lock ref\n",
+    ),
+];
+
+#[test]
+#[allow(clippy::unwrap_used)]
+fn the_hook_script_honors_its_contract() {
+    let tmp = tempfile::tempdir().unwrap();
+    let dir = rooted(&tmp);
+
+    // A notice has a key line, an unpinned explanation line, and the CLI
+    // report. Without a notice, the complete output is relayed CLI data.
+    for &(name, input, env, stub, key, report) in CASES {
+        let (out, code) = run_hook(&dir, input, env, stub);
+        let observed = match key {
+            Some(_) => {
+                let (first, rest) = out.split_once('\n').unwrap();
+                let (_, payload) = rest.split_once('\n').unwrap();
+                (Some(first), payload, code)
+            }
+            None => (None, out.as_str(), code),
+        };
+        assert_eq!(observed, (key, report, 0), "{name}: {out}");
+    }
 }

--- a/crates/core/tests/gemini_reports.rs
+++ b/crates/core/tests/gemini_reports.rs
@@ -104,10 +104,8 @@ fn an_event_gemini_does_not_have_is_reported_never_faked() {
     let f = fixture("[hooks.done]\nsource = \"cat\"\n");
     let report = audit(&f.env, &f.scope).unwrap();
     assert!(
-        report
-            .notes
-            .iter()
-            .any(|note| note.contains("event TaskCompleted has no Gemini counterpart")),
+        report.notes.iter().any(|note| note.lines().next()
+            == Some("kendex-hook-unsupported: harness=gemini event=TaskCompleted hook=done")),
         "{:?}",
         report.notes
     );
@@ -121,32 +119,17 @@ fn an_event_gemini_does_not_have_is_reported_never_faked() {
 #[allow(clippy::unwrap_used)]
 fn an_agent_installed_while_the_feature_is_off_is_reported_inert() {
     let f = fixture("[agents.rust]\nsource = \"cat\"\n");
-    fs::write(
-        settings(&f),
-        "{\"experimental\": {\"enableAgents\": false}}",
-    )
-    .unwrap();
-    let report = apply_now(&f);
-    assert!(
-        report
-            .warnings
-            .iter()
-            .any(|w| w.message.contains("installs but stays inert")),
-        "{:?}",
-        report.warnings
-    );
-    assert!(f.project.join(".gemini/agents/rust.md").is_file());
-
-    fs::write(settings(&f), "{\"experimental\": {\"enableAgents\": true}}").unwrap();
-    let quiet = audit(&f.env, &f.scope).unwrap();
-    assert!(
-        !quiet
-            .warnings
-            .iter()
-            .any(|w| w.message.contains("stays inert")),
-        "{:?}",
-        quiet.warnings
-    );
+    apply_now(&f);
+    for (enabled, expected) in [(false, true), (true, false)] {
+        fs::write(
+            settings(&f),
+            format!("{{\"experimental\": {{\"enableAgents\": {enabled}}}}}"),
+        )
+        .unwrap();
+        let report = audit(&f.env, &f.scope).unwrap();
+        assert_eq!(report.warnings.iter().any(|w| w.message.lines().next() == Some("kendex-agents-disabled: harness=gemini agent=rust setting=experimental.enableAgents")), expected, "enabled={enabled}: {:?}", report.warnings);
+        assert!(f.project.join(".gemini/agents/rust.md").is_file());
+    }
 }
 
 /// A settings file that never met the nested schema belongs to a CLI that
@@ -162,17 +145,19 @@ fn an_un_upgraded_settings_file_blocks_the_kinds_that_live_in_it() {
     fs::write(settings(&f), legacy).unwrap();
 
     let report = apply_now(&f);
-    let said = |text: &str| report.notes.iter().any(|note| note.contains(text));
-    assert!(
-        said("nothing was registered for Gemini"),
-        "{:?}",
-        report.notes
-    );
-    assert!(
-        said("nothing was declared for Gemini"),
-        "{:?}",
-        report.notes
-    );
+    for record in [
+        "kendex-settings-unmanageable: harness=gemini kind=hook item=audit",
+        "kendex-settings-unmanageable: harness=gemini kind=mcp-server item=gh",
+    ] {
+        assert!(
+            report
+                .notes
+                .iter()
+                .any(|note| note.lines().next() == Some(record)),
+            "{record}: {:?}",
+            report.notes
+        );
+    }
     assert_eq!(fs::read_to_string(settings(&f)).unwrap(), legacy);
     assert!(!f.project.join(".gemini/hooks").exists());
     // The agent is a file of its own, so nothing about the settings file
@@ -196,9 +181,8 @@ fn a_system_wide_override_is_named_rather_than_argued_with() {
 
     let report = apply_now(&f);
     assert!(
-        report.warnings.iter().any(|w| w
-            .message
-            .contains("system-wide Gemini settings also set `hooks`")),
+        report.warnings.iter().any(|w| w.message.lines().next()
+            == Some("kendex-settings-overridden: harness=gemini item=audit key=hooks")),
         "{:?}",
         report.warnings
     );
@@ -224,7 +208,8 @@ fn a_project_declaration_leaves_the_machine_wide_record_exactly_as_it_was() {
         report
             .warnings
             .iter()
-            .any(|w| w.message.contains("stays inert")),
+            .any(|w| w.message.lines().next()
+                == Some("kendex-mcp-disabled: harness=gemini server=gh")),
         "{:?}",
         report.warnings
     );
@@ -250,7 +235,8 @@ fn a_server_gemini_gates_out_of_its_list_is_reported_inert() {
         report
             .warnings
             .iter()
-            .any(|w| w.message.contains("gate which servers load")),
+            .any(|w| w.message.lines().next()
+                == Some("kendex-mcp-filtered: harness=gemini server=gh")),
         "{:?}",
         report.warnings
     );
@@ -266,9 +252,8 @@ fn a_skill_installed_for_another_tool_is_noted_as_visible_to_gemini() {
     let f = fixture("[skills.deploy]\nsource = \"cat\"\nharnesses = [\"claude\"]\n");
     let report = apply_now(&f);
     assert!(
-        report.notes.iter().any(|note| note.contains("Gemini CLI")
-            && note.contains("read `.agents/skills` too")
-            && note.contains("one definition, counted once")),
+        report.notes.iter().any(|note| note.lines().next()
+            == Some("kendex-shared-skills: readers=gemini path=.agents/skills")),
         "{:?}",
         report.notes
     );

--- a/crates/core/tests/hook_promises.rs
+++ b/crates/core/tests/hook_promises.rs
@@ -197,7 +197,7 @@ fn a_catalog_hook_refusal_names_its_own_reason() {
         ),
         (
             GUARD.replace("# event:", "# harnesses: [claude]\n# event:"),
-            "kendex-hook-excluded: hook=guard harness=codex",
+            "kendex-hook-excluded: hook=guard harness=codex source=catalog field=harnesses",
         ),
     ] {
         let f = fixture("\"codex\"", "[hooks.guard]\nsource = \"cat\"\n");

--- a/crates/core/tests/hook_promises.rs
+++ b/crates/core/tests/hook_promises.rs
@@ -12,7 +12,8 @@ use std::path::PathBuf;
 
 use kendex_core::engine::{EngineReport, audit};
 use kendex_core::env::{Env, FakeOs};
-use kendex_core::model::{HarnessId, Scope};
+use kendex_core::harness::{Enforcement, hook_enforcement};
+use kendex_core::model::{HarnessId, ItemKind, Scope};
 
 /// Authored in Claude's vocabulary, like every hook a catalog ships.
 const GUARD: &str = "#!/usr/bin/env bash\n# ---\n# name: guard\n# event: PreToolUse\n# matcher: Bash\n# description: check shell commands\n# ---\nexit 0\n";
@@ -64,7 +65,7 @@ fn plan(f: &Fixture) -> EngineReport {
 /// Cursor and OpenCode have no hook surface of their own: what installs
 /// there is prose the model is free to ignore. Presenting that as the same
 /// protection Claude Code runs is the failure the enforcement axis exists
-/// to prevent, so it is said in the warning and in the plan itself.
+/// to prevent. The warning and typed enforcement result must agree.
 #[test]
 #[allow(clippy::unwrap_used)]
 fn a_hook_says_which_tools_run_it_and_which_only_read_it() {
@@ -74,43 +75,34 @@ fn a_hook_says_which_tools_run_it_and_which_only_read_it() {
     );
     let report = plan(&f);
 
-    let advisory: Vec<HarnessId> = report
+    let advisory: Vec<_> = report
         .warnings
         .iter()
-        .filter(|w| w.message.contains("advisory on"))
-        .filter_map(|w| w.harness)
+        .filter(|warning| warning.kind == ItemKind::Hook && warning.name == "guard")
+        .map(|warning| (warning.harness, warning.remediation.is_some()))
         .collect();
     assert_eq!(
         advisory,
-        [HarnessId::Opencode, HarnessId::Cursor],
-        "{:?}",
-        report.warnings
+        [
+            (Some(HarnessId::Opencode), true),
+            (Some(HarnessId::Cursor), true),
+            (Some(HarnessId::Pi), true),
+        ]
     );
-    for warning in report
-        .warnings
-        .iter()
-        .filter(|w| w.message.contains("advisory"))
-    {
-        assert!(
-            warning
-                .remediation
-                .as_ref()
-                .is_some_and(|fix| fix.contains("or accept it as guidance on")),
-            "{warning:?}"
-        );
-    }
 
-    let described = |text: &str| report.plan.ops.iter().any(|op| op.line().contains(text));
-    assert!(described("Install hook guard for Cursor (advisory)"));
-    assert!(described("Install hook guard for OpenCode (advisory)"));
-    for tool in ["Claude Code", "Codex", "Gemini CLI", "GitHub Copilot"] {
-        assert!(
-            described(&format!("Install hook guard for {tool}")),
-            "{tool}"
-        );
-        assert!(
-            !described(&format!("Install hook guard for {tool} (advisory)")),
-            "{tool}"
+    for (harness, expected) in [
+        (HarnessId::Opencode, Enforcement::Advisory),
+        (HarnessId::Cursor, Enforcement::Advisory),
+        (HarnessId::Pi, Enforcement::Advisory),
+        (HarnessId::Claude, Enforcement::Enforced),
+        (HarnessId::Codex, Enforcement::Enforced),
+        (HarnessId::Gemini, Enforcement::Enforced),
+        (HarnessId::Copilot, Enforcement::Enforced),
+    ] {
+        assert_eq!(
+            hook_enforcement(&f.env, &f.scope, harness),
+            expected,
+            "{harness:?}"
         );
     }
 }
@@ -130,7 +122,7 @@ fn a_matcher_that_cannot_be_translated_installs_as_written_and_is_named() {
     let named: Vec<HarnessId> = report
         .warnings
         .iter()
-        .filter(|w| w.message.contains("may never match"))
+        .filter(|w| w.kind == ItemKind::Hook && w.name == "loose")
         .filter_map(|w| w.harness)
         .collect();
     assert_eq!(

--- a/crates/core/tests/hook_promises.rs
+++ b/crates/core/tests/hook_promises.rs
@@ -5,7 +5,7 @@
 
 #[path = "../../test_util.rs"]
 mod test_util;
-use test_util::source_path;
+use test_util::{rooted, source_path};
 
 use std::fs;
 use std::path::PathBuf;
@@ -19,7 +19,7 @@ use kendex_core::model::{HarnessId, ItemKind, Scope};
 const GUARD: &str = "#!/usr/bin/env bash\n# ---\n# name: guard\n# event: PreToolUse\n# matcher: Bash\n# description: check shell commands\n# ---\nexit 0\n";
 
 /// A matcher that is a regex, not a tool name.
-const LOOSE: &str = "#!/usr/bin/env bash\n# ---\n# name: loose\n# event: PreToolUse\n# matcher: Bash.*\n# description: check shell commands\n# ---\nexit 0\n";
+const LOOSE: &str = "#!/usr/bin/env bash\n# ---\n# name: loose\n# event: PreToolUse\n# matcher: Bash.*\n# harnesses: [gemini, copilot, antigravity]\n# description: check shell commands\n# ---\nexit 0\n";
 
 struct Fixture {
     _tmp: tempfile::TempDir,
@@ -30,7 +30,7 @@ struct Fixture {
 #[allow(clippy::unwrap_used)]
 fn fixture(harnesses: &str, declarations: &str) -> Fixture {
     let tmp = tempfile::tempdir().unwrap();
-    let home = tmp.path().to_path_buf();
+    let home = rooted(&tmp);
     let env = Env::fake(&home, FakeOs::Linux);
     let project: PathBuf = home.join("dev/app");
     fs::create_dir_all(project.join(".claude")).unwrap();
@@ -79,14 +79,32 @@ fn a_hook_says_which_tools_run_it_and_which_only_read_it() {
         .warnings
         .iter()
         .filter(|warning| warning.kind == ItemKind::Hook && warning.name == "guard")
-        .map(|warning| (warning.harness, warning.remediation.is_some()))
+        .map(|warning| {
+            (
+                warning.harness,
+                warning.remediation.is_some(),
+                warning.message.lines().next(),
+            )
+        })
         .collect();
     assert_eq!(
         advisory,
         [
-            (Some(HarnessId::Opencode), true),
-            (Some(HarnessId::Cursor), true),
-            (Some(HarnessId::Pi), true),
+            (
+                Some(HarnessId::Opencode),
+                true,
+                Some("kendex-hook-advisory: harness=opencode hook=guard")
+            ),
+            (
+                Some(HarnessId::Cursor),
+                true,
+                Some("kendex-hook-advisory: harness=cursor hook=guard")
+            ),
+            (
+                Some(HarnessId::Pi),
+                true,
+                Some("kendex-hook-carrier-missing: harness=pi hook=guard carrier=pi-hooks")
+            ),
         ]
     );
 
@@ -114,20 +132,35 @@ fn a_hook_says_which_tools_run_it_and_which_only_read_it() {
 #[allow(clippy::unwrap_used)]
 fn a_matcher_that_cannot_be_translated_installs_as_written_and_is_named() {
     let f = fixture(
-        "\"gemini\", \"copilot\"",
+        "\"gemini\", \"copilot\", \"antigravity\"",
         "[hooks.loose]\nsource = \"cat\"\n",
     );
     let report = plan(&f);
 
-    let named: Vec<HarnessId> = report
+    let named: Vec<_> = report
         .warnings
         .iter()
         .filter(|w| w.kind == ItemKind::Hook && w.name == "loose")
-        .filter_map(|w| w.harness)
+        .map(|w| (w.harness, w.message.lines().next()))
         .collect();
     assert_eq!(
         named,
-        [HarnessId::Gemini, HarnessId::Copilot],
+        [
+            (
+                Some(HarnessId::Gemini),
+                Some("kendex-hook-matcher-untranslated: harness=gemini hook=loose matcher=Bash.*")
+            ),
+            (
+                Some(HarnessId::Copilot),
+                Some("kendex-hook-matcher-untranslated: harness=copilot hook=loose matcher=Bash.*")
+            ),
+            (
+                Some(HarnessId::Antigravity),
+                Some(
+                    "kendex-hook-matcher-untranslated: harness=antigravity hook=loose matcher=Bash.*"
+                )
+            )
+        ],
         "{:?}",
         report.warnings
     );
@@ -139,12 +172,49 @@ fn a_matcher_that_cannot_be_translated_installs_as_written_and_is_named() {
     let registered = |path: PathBuf| -> serde_json::Value {
         serde_json::from_str(&fs::read_to_string(path).unwrap()).unwrap()
     };
-    assert_eq!(
-        registered(root.join(".gemini/settings.json"))["hooks"]["BeforeTool"][0]["matcher"],
-        "Bash.*"
-    );
-    assert_eq!(
-        registered(root.join(".github/hooks/loose.json"))["hooks"]["preToolUse"][0]["matcher"],
-        "Bash.*"
-    );
+    for (path, matcher) in [
+        (".gemini/settings.json", vec!["hooks", "BeforeTool"]),
+        (".github/hooks/loose.json", vec!["hooks", "preToolUse"]),
+        (".agents/hooks.json", vec!["loose", "PreToolUse"]),
+    ] {
+        assert_eq!(
+            registered(root.join(path))[matcher[0]][matcher[1]][0]["matcher"],
+            "Bash.*",
+            "{path}"
+        );
+    }
+}
+
+/// Catalog scripts supply their own frontmatter; a refused script names
+/// whether that input was unreadable or excluded the requested harness.
+#[test]
+#[allow(clippy::unwrap_used)]
+fn a_catalog_hook_refusal_names_its_own_reason() {
+    for (text, record) in [
+        (
+            "not a hook".to_owned(),
+            "kendex-hook-unreadable: hook=guard",
+        ),
+        (
+            GUARD.replace("# event:", "# harnesses: [claude]\n# event:"),
+            "kendex-hook-excluded: hook=guard harness=codex",
+        ),
+    ] {
+        let f = fixture("\"codex\"", "[hooks.guard]\nsource = \"cat\"\n");
+        fs::write(f.env.home.join("catalog/hooks/guard.sh"), text).unwrap();
+        let report = plan(&f);
+        assert!(
+            report
+                .notes
+                .iter()
+                .any(|note| note.lines().next() == Some(record)),
+            "{record}: {:?}",
+            report.notes
+        );
+        kendex_core::apply::execute(&f.env, &report.plan).unwrap();
+        let Scope::Project { root } = &f.scope else {
+            panic!("fixture is a project")
+        };
+        assert!(!root.join(".codex/hooks.json").exists(), "{record}");
+    }
 }

--- a/crates/core/tests/hook_records.rs
+++ b/crates/core/tests/hook_records.rs
@@ -16,7 +16,7 @@ use std::fs;
 use std::path::PathBuf;
 
 use kendex_core::apply;
-use kendex_core::engine::audit;
+use kendex_core::engine::{DriftState, audit};
 use kendex_core::env::{Env, FakeOs};
 use kendex_core::model::Scope;
 
@@ -143,7 +143,7 @@ fn a_record_that_names_no_registration_leaves_their_duplicate_alone() {
         report
             .drift
             .iter()
-            .all(|row| !row.detail.contains("more than once")),
+            .all(|row| row.state != DriftState::Conflict),
         "their duplicate is not kendex's to wonder about: {:?}",
         report.drift
     );
@@ -278,7 +278,7 @@ fn a_record_that_names_no_registration_leaves_a_moved_entry_alone() {
         report
             .drift
             .iter()
-            .all(|row| !row.detail.contains("no longer runs")),
+            .all(|row| row.state != DriftState::Conflict),
         "the moved entry is not kendex's to wonder about: {:?}",
         report.drift
     );
@@ -329,7 +329,7 @@ fn an_exact_duplicate_of_the_recorded_entry_does_not_wedge_the_refresh() {
         report
             .drift
             .iter()
-            .all(|row| !row.detail.contains("more than once")),
+            .all(|row| row.state != DriftState::Conflict),
         "an exact duplicate is not a wedge: {:?}",
         report.drift
     );
@@ -373,7 +373,7 @@ fn a_recorded_entry_moved_by_hand_does_not_hold_the_hook() {
         report
             .drift
             .iter()
-            .all(|row| !row.detail.contains("no longer runs")),
+            .all(|row| row.state != DriftState::Conflict),
         "what they moved is theirs, not a conflict: {:?}",
         report.drift
     );
@@ -426,14 +426,11 @@ fn a_command_spelled_another_way_replaces_the_entry_it_left() {
     };
     let rendered = commands();
     assert_eq!(rendered.len(), 1);
-    assert!(
-        rendered[0].contains("p='.codex/hooks/guard.sh'"),
-        "{rendered:?}"
-    );
 
     // What an older kendex left: the subshell that asked git for the root,
     // in the document and in the record alike.
     let deferred = "bash \"$(git rev-parse --show-toplevel)/.codex/hooks/guard.sh\"".to_owned();
+    assert_ne!(rendered, vec![deferred.clone()]);
     let mut document: serde_json::Value =
         serde_json::from_str(&fs::read_to_string(&registry).unwrap()).unwrap();
     document["hooks"]["PreToolUse"][0]["hooks"][0]["command"] =

--- a/crates/core/tests/hook_sweep.rs
+++ b/crates/core/tests/hook_sweep.rs
@@ -156,40 +156,30 @@ fn sweep(f: &Fixture) -> kendex_core::engine::EngineReport {
 #[test]
 #[allow(clippy::unwrap_used)]
 fn the_sweep_proves_an_anchored_hook_before_taking_it() {
-    for state in ["edited", "untouched"] {
+    for edited in [true, false] {
         let f = fixture();
         apply_now(&f);
         let script = f.project.join(".claude/hooks/guard.sh");
         assert!(script.is_file());
-        if state == "edited" {
+        if edited {
             fs::write(&script, GUARD.replace("exit 0", "exit 1")).unwrap();
         }
 
         undeclare(&f);
         let report = sweep(&f);
         apply::execute(&f.env, &report.plan).unwrap();
-
-        match state {
-            "edited" => {
-                assert!(
-                    report.drift.iter().any(|row| row.detail.contains("edited")),
-                    "their edit is a conflict, not a casualty: {:?}",
-                    report.drift
-                );
-                assert!(script.is_file(), "and the edited script stays");
-            }
-            _ => {
-                assert!(
-                    report
-                        .drift
-                        .iter()
-                        .all(|row| !row.detail.contains("edited")),
-                    "untouched bytes are provably ours: {:?}",
-                    report.drift
-                );
-                assert!(!script.exists(), "so the sweep takes them");
-            }
-        }
+        assert_eq!(
+            (
+                report
+                    .drift
+                    .iter()
+                    .any(|row| row.cause == Some(DriftCause::LocalEdit)),
+                script.exists(),
+            ),
+            (edited, edited),
+            "edited={edited}: {:?}",
+            report.drift,
+        );
     }
 }
 
@@ -212,11 +202,16 @@ fn the_sweep_holds_a_hook_whose_current_record_has_no_anchor() {
         // the registration is really in: unwrapping a wrong path to an
         // empty string would pass the after-check on nothing at all.
         let registry = harness.registry(&f.project);
-        assert!(
-            fs::read_to_string(&registry).unwrap().contains("guard.sh"),
-            "{}",
-            registry.display()
-        );
+        let registered: serde_json::Value =
+            serde_json::from_str(&fs::read_to_string(&registry).unwrap()).unwrap();
+        let event = match harness {
+            Harness::Claude => "PreToolUse",
+            Harness::Pi => "tool_call",
+        };
+        let command = registered["hooks"][event][0]["hooks"][0]["command"]
+            .as_str()
+            .unwrap();
+        assert_eq!(kendex_core::hook::command_stem(command), "guard");
 
         // Take the anchor out and leave the version alone. The record
         // stays one this build wrote and would read; what it does not
@@ -257,10 +252,8 @@ fn the_sweep_holds_a_hook_whose_current_record_has_no_anchor() {
             "the sweep leaves the script: {}",
             script.display()
         );
-        let after = fs::read_to_string(&registry).unwrap();
-        assert!(
-            after.contains("guard.sh"),
-            "and leaves it registered to run: {after}"
-        );
+        let after: serde_json::Value =
+            serde_json::from_str(&fs::read_to_string(&registry).unwrap()).unwrap();
+        assert_eq!(after, registered);
     }
 }

--- a/crates/core/tests/kinds/main.rs
+++ b/crates/core/tests/kinds/main.rs
@@ -211,10 +211,8 @@ fn an_event_codex_cannot_run_is_reported_never_faked() {
     let f = fixture("[hooks.done]\nsource = \"cat\"\nharnesses = [\"codex\"]\n");
     let report = audit(&f.env, &f.scope).unwrap();
     assert!(
-        report
-            .notes
-            .iter()
-            .any(|note| note.contains("hook done: event TaskCompleted unsupported on codex")),
+        report.notes.iter().any(|note| note.lines().next()
+            == Some("kendex-hook-unsupported: harness=codex event=TaskCompleted hook=done")),
         "{:?}",
         report.notes
     );

--- a/crates/core/tests/pi_carrier.rs
+++ b/crates/core/tests/pi_carrier.rs
@@ -15,8 +15,9 @@ use std::path::{Path, PathBuf};
 use kendex_core::engine::audit;
 use kendex_core::env::{Env, FakeOs};
 use kendex_core::harness::{Enforcement, pi_listener};
-use kendex_core::model::Scope;
+use kendex_core::model::{HarnessId, ItemKind, Scope};
 use kendex_core::pi_ext::carrier;
+use serde_json::Value;
 
 struct World {
     _tmp: tempfile::TempDir,
@@ -84,17 +85,17 @@ const DISPATCHED: [&str; 4] = ["tool_call", "tool_result", "turn_end", "session_
 
 #[test]
 fn events_map_onto_the_listeners_pi_actually_fires() {
-    assert_eq!(pi_listener("PreToolUse"), Some("tool_call"));
-    assert_eq!(pi_listener("PostToolUse"), Some("tool_result"));
-    assert_eq!(pi_listener("Stop"), Some("turn_end"));
-    assert_eq!(pi_listener("TaskCompleted"), Some("turn_end"));
-    assert_eq!(pi_listener("SessionStart"), Some("session_start"));
-    assert_eq!(
-        pi_listener("PostCompact"),
-        None,
-        "pi fires no such listener"
-    );
-    assert_eq!(pi_listener("UserPromptSubmit"), None);
+    for (event, listener) in [
+        ("PreToolUse", Some("tool_call")),
+        ("PostToolUse", Some("tool_result")),
+        ("Stop", Some("turn_end")),
+        ("TaskCompleted", Some("turn_end")),
+        ("SessionStart", Some("session_start")),
+        ("PostCompact", None),
+        ("UserPromptSubmit", None),
+    ] {
+        assert_eq!(pi_listener(event), listener, "{event}");
+    }
 }
 
 #[test]
@@ -151,14 +152,17 @@ fn a_mappable_event_renders_the_registry_in_pi_listener_names() {
         script.is_file(),
         "the hook script lands beside the registry"
     );
-    let registry = fs::read_to_string(w.project.join(".pi/kendex/hooks.json")).unwrap();
-    assert!(
-        registry.contains("tool_call"),
-        "the registry speaks pi's listener names: {registry}"
-    );
-    assert!(
-        !registry.contains("PreToolUse"),
-        "the harness event name never reaches pi: {registry}"
+    let registry: Value =
+        serde_json::from_str(&fs::read_to_string(w.project.join(".pi/kendex/hooks.json")).unwrap())
+            .unwrap();
+    assert_eq!(
+        registry["hooks"]
+            .as_object()
+            .unwrap()
+            .keys()
+            .map(String::as_str)
+            .collect::<Vec<_>>(),
+        ["tool_call"],
     );
 
     // No downgrade warning while the carrier is registered.
@@ -167,7 +171,9 @@ fn a_mappable_event_renders_the_registry_in_pi_listener_names() {
         !report
             .warnings
             .iter()
-            .any(|warning| warning.message.contains("carrier")),
+            .any(|warning| warning.kind == ItemKind::Hook
+                && warning.name == "guard"
+                && warning.harness == Some(HarnessId::Pi)),
         "{:?}",
         report.warnings
     );
@@ -183,10 +189,8 @@ fn an_unmappable_event_installs_nothing_on_pi() {
 
     let report = audit(&w.env, &scope(&w)).unwrap();
     assert!(
-        report
-            .notes
-            .iter()
-            .any(|note| note.contains("unsupported on pi")),
+        report.notes.iter().any(|note| note.lines().next()
+            == Some("kendex-hook-unsupported: harness=pi event=PostCompact hook=guard")),
         "{:?}",
         report.notes
     );
@@ -208,7 +212,11 @@ fn labels_downgrade_per_item_when_the_carrier_is_missing() {
     let warning = report
         .warnings
         .iter()
-        .find(|warning| warning.message.contains("carrier"))
+        .find(|warning| {
+            warning.kind == ItemKind::Hook
+                && warning.name == "guard"
+                && warning.harness == Some(HarnessId::Pi)
+        })
         .unwrap_or_else(|| panic!("no carrier warning: {:?}", report.warnings));
     assert!(
         warning
@@ -272,10 +280,15 @@ fn the_older_layout_beside_the_root_is_left_exactly_where_it_is() {
     let report = audit(&w.env, &scope(&w)).unwrap();
     kendex_core::apply::execute(&w.env, &report.plan).unwrap();
     assert!(home.join("hooks/guard.sh").is_file());
-    assert!(
-        fs::read_to_string(home.join("hooks.json"))
-            .unwrap()
-            .contains("guard.sh")
+    let restored: Value =
+        serde_json::from_str(&fs::read_to_string(home.join("hooks.json")).unwrap()).unwrap();
+    assert_eq!(
+        kendex_core::hook::command_stem(
+            restored["hooks"]["tool_call"][0]["hooks"][0]["command"]
+                .as_str()
+                .unwrap()
+        ),
+        "guard"
     );
 
     // And the pass after it settles.
@@ -359,10 +372,12 @@ fn a_declared_custom_hook_fires_through_the_carrier() {
 
     let report = audit(&w.env, &scope(&w)).unwrap();
     kendex_core::apply::execute(&w.env, &report.plan).unwrap();
-    let registry = fs::read_to_string(w.project.join(".pi/kendex/hooks.json")).unwrap();
-    assert!(
-        registry.contains("ken-941-fired"),
-        "the person's command rides in the registry: {registry}"
+    let registry: Value =
+        serde_json::from_str(&fs::read_to_string(w.project.join(".pi/kendex/hooks.json")).unwrap())
+            .unwrap();
+    assert_eq!(
+        registry["hooks"]["tool_call"][0]["hooks"][0]["command"],
+        "echo ken-941-fired >&2; exit 2",
     );
 
     // The real carrier, driven the way Pi drives it: one bash tool call.
@@ -394,10 +409,14 @@ fn a_declared_custom_hook_fires_through_the_carrier() {
         "carrier run failed: {}",
         String::from_utf8_lossy(&run.stderr)
     );
-    let verdict = String::from_utf8_lossy(&run.stdout);
+    let verdict: Value = serde_json::from_slice(&run.stdout).unwrap();
+    assert_eq!(verdict["block"], true);
     assert!(
-        verdict.contains("\"block\":true") && verdict.contains("ken-941-fired"),
-        "the declared hook did not fire: {verdict}"
+        verdict["reason"]
+            .as_str()
+            .unwrap()
+            .contains("ken-941-fired"),
+        "{verdict}"
     );
 }
 
@@ -432,13 +451,18 @@ fn a_declared_hook_on_the_other_listeners_fires_through_the_carrier() {
 
     let report = audit(&w.env, &scope(&w)).unwrap();
     kendex_core::apply::execute(&w.env, &report.plan).unwrap();
-    let registry = fs::read_to_string(w.project.join(".pi/kendex/hooks.json")).unwrap();
-    for listener in DISPATCHED {
-        assert!(
-            registry.contains(listener),
-            "no {listener} registration in the render: {registry}"
-        );
-    }
+    let registry: Value =
+        serde_json::from_str(&fs::read_to_string(w.project.join(".pi/kendex/hooks.json")).unwrap())
+            .unwrap();
+    assert_eq!(
+        registry["hooks"]
+            .as_object()
+            .unwrap()
+            .keys()
+            .map(String::as_str)
+            .collect::<std::collections::BTreeSet<_>>(),
+        DISPATCHED.into_iter().collect(),
+    );
 
     // The real carrier, driven the way Pi drives a tool result.
     let repo = Path::new(env!("CARGO_MANIFEST_DIR")).join("../..");
@@ -466,13 +490,19 @@ fn a_declared_hook_on_the_other_listeners_fires_through_the_carrier() {
         "carrier run failed: {}",
         String::from_utf8_lossy(&run.stderr)
     );
-    let patch = String::from_utf8_lossy(&run.stdout);
+    let patch: Value = serde_json::from_slice(&run.stdout).unwrap();
+    let text: Vec<_> = patch["content"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .map(|block| block["text"].as_str().unwrap())
+        .collect();
     assert!(
-        patch.contains("ken-1189-post"),
+        text.iter().any(|text| text.contains("ken-1189-post")),
         "the declared PostToolUse hook did not reach the tool result: {patch}"
     );
     assert!(
-        patch.contains("Everything up-to-date"),
+        text.contains(&"Everything up-to-date"),
         "the tool's own result was dropped rather than added to: {patch}"
     );
 }

--- a/crates/core/tests/pi_commands.rs
+++ b/crates/core/tests/pi_commands.rs
@@ -176,7 +176,7 @@ fn a_shell_inline_installs_with_a_warning() {
     let warned: Vec<_> = report
         .warnings
         .iter()
-        .map(|w| (w.kind, w.name.as_str(), w.harness, w.message.as_str()))
+        .map(|w| (w.kind, w.name.as_str(), w.harness, w.message.lines().next()))
         .collect();
     assert_eq!(
         warned,
@@ -184,7 +184,7 @@ fn a_shell_inline_installs_with_a_warning() {
             ItemKind::Command,
             "diff",
             Some(HarnessId::Pi),
-            "the command runs a shell inline with !`…`, which Pi does not expand — the model reads the backticked command as text",
+            Some("kendex-command-inline-unsupported: harness=pi syntax=!`command`"),
         )]
     );
 }

--- a/crates/core/tests/project_hook_root.rs
+++ b/crates/core/tests/project_hook_root.rs
@@ -304,10 +304,7 @@ fn a_hook_with_no_script_above_the_working_directory_refuses() {
         ("from a directory with no script above it", command.clone()),
         (
             "from a directory removed under the shell",
-            format!(
-                "rmdir \"$PWD\" && exec sh -c {}",
-                kendex_core::names::quoted(&command)
-            ),
+            format!("rmdir \"$PWD\" && {{ {command}; }}"),
         ),
     ] {
         let mut child = scrubbed(
@@ -336,11 +333,10 @@ fn a_hook_with_no_script_above_the_working_directory_refuses() {
             .unwrap()
             .read_to_string(&mut stderr)
             .unwrap();
-        assert_eq!(status.code(), Some(1), "{what}: {stderr}");
-        assert!(
-            stderr.contains("kendex: no directory above")
-                && stderr.contains(".codex/hooks/audit.sh"),
-            "{what}: the refusal names the start and the file: {stderr}"
+        assert_eq!(
+            (status.code(), stderr.lines().next()),
+            (Some(1), Some("kendex-hook-missing: .codex/hooks/audit.sh")),
+            "{what}: {stderr}"
         );
     }
 }

--- a/crates/core/tests/project_hook_root.rs
+++ b/crates/core/tests/project_hook_root.rs
@@ -300,11 +300,21 @@ fn a_hook_with_no_script_above_the_working_directory_refuses() {
     let gone = f.project.parent().unwrap().join("gone");
     fs::create_dir_all(&gone).unwrap();
 
+    // Capture the registered command's output after shell initialization.
+    // A fresh shell may diagnose its deleted cwd before executing our body.
+    let hook_stderr = f.project.parent().unwrap().join("hook.stderr");
+    let captured = format!(
+        "{{ {command}; }} 2> {}",
+        kendex_core::names::quoted(hook_stderr.to_str().unwrap()),
+    );
     for (what, script) in [
-        ("from a directory with no script above it", command.clone()),
+        ("from a directory with no script above it", captured.clone()),
         (
-            "from a directory removed under the shell",
-            format!("rmdir \"$PWD\" && {{ {command}; }}"),
+            "from a directory removed under a fresh shell",
+            format!(
+                "rmdir \"$PWD\" && exec sh -c {}",
+                kendex_core::names::quoted(&captured),
+            ),
         ),
     ] {
         let mut child = scrubbed(
@@ -333,10 +343,11 @@ fn a_hook_with_no_script_above_the_working_directory_refuses() {
             .unwrap()
             .read_to_string(&mut stderr)
             .unwrap();
+        let emitted = fs::read_to_string(&hook_stderr).unwrap();
         assert_eq!(
-            (status.code(), stderr.lines().next()),
+            (status.code(), emitted.lines().next()),
             (Some(1), Some("kendex-hook-missing: .codex/hooks/audit.sh")),
-            "{what}: {stderr}"
+            "{what}: hook={emitted}, shell={stderr}"
         );
     }
 }


### PR DESCRIPTION
Hook and renderer refusals now identify their reason with stable first-line keys and relevant values. English explanations follow. The records retain settings keys, requested and allowed models, unsupported events, affected items, shared readers and computed replacement names. Existing typed conflict and enforcement fields remain the assertions where they identify the claim.

The generated drift hook preserves the CLI exit classification and relays complete report data. Its header states the parsed `Error:`/`error:` contract. The missing-script test launches a fresh shell after the working directory is removed. It checks the registered command's own stderr after shell initialization; a launching shell can issue its separate startup diagnostic before it executes that command.

This core package includes the reached report and rendering cases alongside the hook audit. Drift scenarios, Pi event mappings, shared-reader names, settings switches, Antigravity refusals and renderer input families use tables. The project-root fixture uses a private marked ancestor, so its home-exclusion claim does not depend on the real directories above the temporary directory.

Changed tests: `drift_hook_script.rs`, `drift_hook_install.rs`, `project_hook_root.rs`, `pi_carrier.rs`, `hook_promises.rs`, `hook_records.rs`, `hook_sweep.rs`, `custom_hooks.rs`, `pi_commands.rs`, `kinds/main.rs`, `gemini_reports.rs`, `copilot_reports.rs`, `antigravity.rs`, plus unit cases in `src/discover.rs`, `src/engine/{antigravity,copilot,gemini}.rs` and `src/render/validate/tests.rs`. The separate Copilot shared-reader tests are folded into one name table with their installation and report assertions retained.

Compliant file retained: `crates/core/tests/guard_timeout_budget.rs`. It compares the parsed timeout with the check's numeric budget. Prior core audit evidence remains reusable; this PR corrects the concrete failures reached in this package.

Validation: affected hook suites, native report suites, renderer unit cases and core all-target Clippy pass. Required must-fail controls include the private-ancestor fixture, original hook contracts and the added notice records. The final full guard runs on the published final head with ordinary system temp: `env -u TMPDIR tools/guard --full`. CI and formal bot review must pass before merge. No dependency on the CLI fixture PR #2445.

<details>
<summary>Compliant integration files retained from the earlier core classification</summary>

Paths are relative to `crates/core/tests`, with the `.rs` suffix. This list reuses the existing classification; the reached files corrected above are excluded.

`adopt_many_tools`, `agent_skill_roots`, `app_update`, `authoring_check`, `browse_unreadable_lock`, `bundles/contested`, `bundles/main`, `bundles/more`, `byte_faithful`, `codex_mcp`, `collections`, `collision_refusal`, `command_names`, `commands`, `copilot`, `credential_lock_process`, `cursor_mcp`, `dependencies/more`, `discovery`, `edits_and_forks/access`, `edits_and_forks/agent_capture`, `edits_and_forks/agent_tables`, `edits_and_forks/available`, `edits_and_forks/beside`, `edits_and_forks/disabled`, `edits_and_forks/edited_harness`, `edits_and_forks/vacant`, `fixture_manifest_paths`, `gemini`, `guard_repo_paths`, `guard_skill_roots`, `guard_timeout_budget`, `hook_removal`, `install_seam/bundles`, `install_seam/main`, `install_seam/naming`, `install_targets`, `invariants`, `kinds/config_files`, `lock_from_another_project`, `marketplace_index`, `not_offered_note`, `opencode_commands`, `opencode_mcp`, `package_detail`, `package_diff`, `package_pins/batched_update`, `package_pins/main`, `package_pins/single_update`, `package_pins/validate`, `package_versions`, `permissions`, `plugin_registry`, `plugin_targets`, `process_guard_env`, `quality/advisory`, `quality/corpus`, `quality/kinds`, `quality/reading`, `quality/rules_fetch`, `quality/rules_shapes`, `quality/scoring`, `repo_effects_leaving`, `review_fixes/agent_skills`, `review_fixes/main`, `review_fixes/roots`, `sealed_source`, `settings_edits`, `settings_grammar`, `settings_seed/apply`, `settings_seed/notes`, `settings_seed_repo`, `skill_records`, `source_store`, `surfaces`, `symlinked_harness_dir`, `transitions`, `unmanaged_check/kinds`, `unmanaged_check/main`, `unsubscribe_keep`, `v1_lock`, `validate_output`.

</details>

All agent, skill and command renderer finding branches now have stable records. Hook catalog refusals, custom-hook downgrades, matcher warnings and advisory delivery use records too. Dynamic record values use the existing `names::shown` encoder. Quoted YAML/TOML newlines are covered in renderer and Copilot model rows.

Direct consumer correction: `crates/cli/tests/refresh_ledger/conflicts.rs` checks the hook-exclusion record instead of the old sentence. The record names `source=catalog field=harnesses`, preserving the test's ownership claim. The existing drift table includes lowercase CLI usage errors as exit-2 failures with the complete report bytes relayed.

The Pi command warning consumer compares the stable record while retaining typed item identity and complete installed prompt content. This replaces the last complete English-message assertion exposed by CI in the changed warning path.
