### PR TITLE
fix(KEN-1241): stabilize deep research diagnostics

### DIFF
--- a/.agents/skills/deep-research/scripts/deep-research
+++ b/.agents/skills/deep-research/scripts/deep-research
@@ -35,7 +35,7 @@ const defaultOutputSchema = {
 };
 
 function jsonOut(stream, value) { stream.write(`${JSON.stringify(value)}\n`); }
-function fail(key, value, message, extra = {}) { jsonOut(process.stderr, { ok: false, key, value, error: message, ...extra }); process.exit(1); }
+function fail(key, value, message, extra = {}) { jsonOut(process.stderr, { ok: false, key, value: value ?? null, error: message, ...extra }); process.exit(1); }
 
 function helpPayload() {
   return {
@@ -446,11 +446,11 @@ async function validateCommand(options) {
   const problems = [];
   const recordError = (key, value, message, extra = {}) => {
     errors.push(message);
-    problems.push({ level: "error", key, value, ...extra });
+    problems.push({ level: "error", key, value: value ?? null, ...extra });
   };
   const recordWarning = (key, value, message, extra = {}) => {
     warnings.push(message);
-    problems.push({ level: "warning", key, value, ...extra });
+    problems.push({ level: "warning", key, value: value ?? null, ...extra });
   };
 
   let report = "";

--- a/.agents/skills/deep-research/scripts/deep-research
+++ b/.agents/skills/deep-research/scripts/deep-research
@@ -2,7 +2,7 @@
 // Diagnostic protocol: command refusals write one JSON object to stderr with
 // {ok:false,key,value,error}. Validate keeps errors/warnings and adds problems
 // with {level,key,value}; English remains display text, not a test contract.
-import { existsSync } from "node:fs";
+import { existsSync, writeSync } from "node:fs";
 import { mkdir, readdir, readFile, rename, writeFile } from "node:fs/promises";
 import { dirname, extname, join, resolve } from "node:path";
 import { spawnSync } from "node:child_process";
@@ -35,7 +35,22 @@ const defaultOutputSchema = {
 };
 
 function jsonOut(stream, value) { stream.write(`${JSON.stringify(value)}\n`); }
-function fail(key, value, message, extra = {}) { jsonOut(process.stderr, { ok: false, key, value: value ?? null, error: message, ...extra }); process.exit(1); }
+function fail(key, value, message, extra = {}) {
+  const body = Buffer.from(`${JSON.stringify({ ok: false, key, value: value ?? null, error: message, ...extra })}\n`);
+  let offset = 0;
+  const pause = new Int32Array(new SharedArrayBuffer(4));
+  while (offset < body.length) {
+    try {
+      const written = writeSync(process.stderr.fd, body, offset, body.length - offset);
+      if (written > 0) offset += written;
+      else Atomics.wait(pause, 0, 0, 1);
+    } catch (error) {
+      if (error?.code !== "EAGAIN") throw error;
+      Atomics.wait(pause, 0, 0, 1);
+    }
+  }
+  process.exit(1);
+}
 
 function helpPayload() {
   return {

--- a/.agents/skills/deep-research/scripts/deep-research
+++ b/.agents/skills/deep-research/scripts/deep-research
@@ -1,4 +1,7 @@
 #!/usr/bin/env node
+// Diagnostic protocol: command refusals write one JSON object to stderr with
+// {ok:false,key,value,error}. Validate keeps errors/warnings and adds problems
+// with {level,key,value}; English remains display text, not a test contract.
 import { existsSync } from "node:fs";
 import { mkdir, readdir, readFile, rename, writeFile } from "node:fs/promises";
 import { dirname, extname, join, resolve } from "node:path";
@@ -32,7 +35,7 @@ const defaultOutputSchema = {
 };
 
 function jsonOut(stream, value) { stream.write(`${JSON.stringify(value)}\n`); }
-function fail(message, extra = {}) { jsonOut(process.stderr, { ok: false, error: message, ...extra }); process.exit(1); }
+function fail(key, value, message, extra = {}) { jsonOut(process.stderr, { ok: false, key, value, error: message, ...extra }); process.exit(1); }
 
 function helpPayload() {
   return {
@@ -95,7 +98,7 @@ function resolveSecretRef(value, name) {
   if (!value || !value.startsWith("op://")) return value;
   const result = spawnSync("op", ["read", value], { encoding: "utf8" });
   if (result.status === 0 && result.stdout.trim()) return result.stdout.trim();
-  fail(`${name} is a 1Password reference but could not be resolved. Install/sign in to the op CLI and run: op read '${value}'`);
+  fail("secret-reference-unresolved", name, `${name} is a 1Password reference but could not be resolved. Install/sign in to the op CLI and run: op read '${value}'`);
 }
 
 function parseArgs(argv) {
@@ -103,7 +106,7 @@ function parseArgs(argv) {
   const options = { command, positional: [], context: [], additionalQuery: [], includeDomain: [], excludeDomain: [], format: "findings", mode: "standard", explicit: new Set(), rawOutputDefault: true };
   while (argv.length) {
     const arg = argv.shift();
-    const value = () => argv.shift() ?? fail(`Missing value for ${arg}`);
+    const value = () => argv.shift() ?? fail("argument-value-missing", arg, `Missing value for ${arg}`);
     if (arg === "--output") options.output = value();
     else if (arg === "--query-file") options.queryFile = value();
     else if (arg === "--context") options.context.push(value());
@@ -114,16 +117,16 @@ function parseArgs(argv) {
     else if (arg === "--exclude-domain") options.excludeDomain.push(value());
     else if (arg === "--start-date") options.startDate = value();
     else if (arg === "--end-date") options.endDate = value();
-    else if (arg === "--num-results") { options.numResults = Number(value()); options.explicit.add("numResults"); }
-    else if (arg === "--text-max-characters") { options.textMaxCharacters = Number(value()); options.explicit.add("textMaxCharacters"); }
+    else if (arg === "--num-results") { options.numResultsInput = value(); options.numResults = Number(options.numResultsInput); options.explicit.add("numResults"); }
+    else if (arg === "--text-max-characters") { options.textMaxCharactersInput = value(); options.textMaxCharacters = Number(options.textMaxCharactersInput); options.explicit.add("textMaxCharacters"); }
     else if (arg === "--format") options.format = value();
     else if (arg === "--raw-output") options.rawOutput = value();
     else if (arg === "--no-raw-output") options.rawOutputDefault = false;
-    else if (arg === "--timeout") { options.timeout = Number(value()); options.explicit.add("timeout"); }
+    else if (arg === "--timeout") { options.timeoutInput = value(); options.timeout = Number(options.timeoutInput); options.explicit.add("timeout"); }
     else if (arg === "--type") { options.type = value(); options.explicit.add("type"); }
     else if (arg === "--mode" || arg === "--research-mode") options.mode = value();
     else if (arg === "--help" || arg === "-h") options.help = true;
-    else if (arg?.startsWith("--")) fail(`Unknown flag: ${arg}`);
+    else if (arg?.startsWith("--")) fail("argument-unknown", arg, `Unknown flag: ${arg}`);
     else options.positional.push(arg);
   }
   return options;
@@ -149,35 +152,35 @@ async function expandSimpleGlob(rawGlob, limit = MAX_CONTEXT_FILES) {
   const slash = normalized.lastIndexOf("/");
   const dirPart = slash >= 0 ? normalized.slice(0, slash) : ".";
   const basePattern = slash >= 0 ? normalized.slice(slash + 1) : normalized;
-  if (basePattern.split("*").length > 2) fail(`--context-glob supports one '*' wildcard in the file name: ${rawGlob}`);
+  if (basePattern.split("*").length > 2) fail("context-glob-invalid", rawGlob, `--context-glob supports one '*' wildcard in the file name: ${rawGlob}`);
   const [prefix, suffix] = basePattern.split("*");
   const dir = resolve(dirPart);
   const entries = await readdir(dir, { withFileTypes: true });
   const matches = entries.filter((entry) => entry.isFile() && entry.name.startsWith(prefix) && entry.name.endsWith(suffix)).map((entry) => join(dir, entry.name)).sort();
-  if (matches.length > limit) fail(`--context-glob matched ${matches.length} files; limit is ${limit}: ${rawGlob}`);
+  if (matches.length > limit) fail("context-glob-limit", matches.length, `--context-glob matched ${matches.length} files; limit is ${limit}: ${rawGlob}`, { limit });
   return matches;
 }
 
 function applyMode(options) {
-  if (!researchModes.has(options.mode)) fail(`Invalid --mode ${options.mode}. Expected one of: ${Array.from(researchModes).join(", ")}.`);
+  if (!researchModes.has(options.mode)) fail("mode-invalid", options.mode, `Invalid --mode ${options.mode}. Expected one of: ${Array.from(researchModes).join(", ")}.`);
   const defaults = modeDefaults[options.mode];
   options.type = options.explicit.has("type") ? options.type : defaults.type;
   options.numResults = options.explicit.has("numResults") ? options.numResults : defaults.numResults;
   options.textMaxCharacters = options.explicit.has("textMaxCharacters") ? options.textMaxCharacters : defaults.textMaxCharacters;
   options.timeout = options.explicit.has("timeout") ? options.timeout : defaults.timeout;
-  if (!deepTypes.has(options.type)) fail(`Invalid --type ${options.type}`);
-  if (!formats.has(options.format)) fail(`Invalid --format ${options.format}`);
-  if (!Number.isInteger(options.numResults) || options.numResults < 1 || options.numResults > EXA_MAX_NUM_RESULTS) fail(`Invalid --num-results ${options.numResults}. Exa /search accepts 1-${EXA_MAX_NUM_RESULTS} (INVALID_NUM_RESULTS).`);
-  if (!Number.isInteger(options.textMaxCharacters) || options.textMaxCharacters < 1 || options.textMaxCharacters > EXA_MAX_TEXT_CHARACTERS) fail(`Invalid --text-max-characters ${options.textMaxCharacters}. Exa text.maxCharacters accepts 1-${EXA_MAX_TEXT_CHARACTERS}.`);
-  if (!Number.isInteger(options.timeout) || options.timeout < 1) fail(`Invalid --timeout ${options.timeout}. Expected a positive whole number of seconds.`);
-  if (options.additionalQuery.length > EXA_MAX_ADDITIONAL_QUERIES) fail(`Too many --additional-query values (${options.additionalQuery.length}). Exa additionalQueries accepts at most ${EXA_MAX_ADDITIONAL_QUERIES}.`);
+  if (!deepTypes.has(options.type)) fail("type-invalid", options.type, `Invalid --type ${options.type}`);
+  if (!formats.has(options.format)) fail("format-invalid", options.format, `Invalid --format ${options.format}`);
+  if (!Number.isInteger(options.numResults) || options.numResults < 1 || options.numResults > EXA_MAX_NUM_RESULTS) fail("num-results-invalid", options.numResultsInput, `Invalid --num-results ${options.numResultsInput}. Exa /search accepts 1-${EXA_MAX_NUM_RESULTS} (INVALID_NUM_RESULTS).`, { min: 1, max: EXA_MAX_NUM_RESULTS });
+  if (!Number.isInteger(options.textMaxCharacters) || options.textMaxCharacters < 1 || options.textMaxCharacters > EXA_MAX_TEXT_CHARACTERS) fail("text-max-characters-invalid", options.textMaxCharactersInput, `Invalid --text-max-characters ${options.textMaxCharactersInput}. Exa text.maxCharacters accepts 1-${EXA_MAX_TEXT_CHARACTERS}.`, { min: 1, max: EXA_MAX_TEXT_CHARACTERS });
+  if (!Number.isInteger(options.timeout) || options.timeout < 1) fail("timeout-invalid", options.timeoutInput, `Invalid --timeout ${options.timeoutInput}. Expected a positive whole number of seconds.`);
+  if (options.additionalQuery.length > EXA_MAX_ADDITIONAL_QUERIES) fail("additional-query-limit", options.additionalQuery.length, `Too many --additional-query values (${options.additionalQuery.length}). Exa additionalQueries accepts at most ${EXA_MAX_ADDITIONAL_QUERIES}.`, { limit: EXA_MAX_ADDITIONAL_QUERIES });
   return options;
 }
 
 async function resolveQuery(options) {
   let query = options.positional.join(" ").trim();
   if (options.queryFile) query = (await readFile(resolvePath(options.queryFile), "utf8")).trim();
-  if (!query) fail("A query or --query-file is required.");
+  if (!query) fail("query-missing", "query-or-file", "A query or --query-file is required.");
   return query;
 }
 
@@ -371,11 +374,11 @@ async function callExaBody(body, options, controller) {
     if (Array.isArray(mock)) return mock[Math.min(options.mockIndex++, mock.length - 1)];
     return mock;
   }
-  if (typeof fetch !== "function") fail("This Node runtime does not provide fetch. Use Node 18+.");
+  if (typeof fetch !== "function") fail("runtime-fetch-missing", process.version, "This Node runtime does not provide fetch. Use Node 18+.");
   const key = resolveSecretRef(process.env.EXA_API_KEY, "EXA_API_KEY");
-  if (!key) fail("EXA_API_KEY is required for Exa deep research. Set EXA_API_KEY or add it to .env.local.");
+  if (!key) fail("credential-missing", "EXA_API_KEY", "EXA_API_KEY is required for Exa deep research. Set EXA_API_KEY or add it to .env.local.");
   const response = await fetch("https://api.exa.ai/search", { method: "POST", headers: { "content-type": "application/json", "x-api-key": key }, body: JSON.stringify(body), signal: controller.signal });
-  if (!response.ok) fail(`Exa request failed (${response.status}): ${await response.text().catch(() => response.statusText)}`);
+  if (!response.ok) fail("exa-request-failed", response.status, `Exa request failed (${response.status}): ${await response.text().catch(() => response.statusText)}`);
   return response.json();
 }
 
@@ -435,69 +438,78 @@ function normalizedProse(text) {
 
 async function validateCommand(options) {
   const [reportArg, rawArg] = options.positional;
-  if (!reportArg || !rawArg) fail("Usage: deep-research validate <findings.md> <findings.raw.json>");
+  if (!reportArg || !rawArg) fail("argument-missing", "report+raw", "Usage: deep-research validate <findings.md> <findings.raw.json>");
   const reportPath = resolvePath(reportArg);
   const rawPath = resolvePath(rawArg);
   const errors = [];
   const warnings = [];
+  const problems = [];
+  const recordError = (key, value, message, extra = {}) => {
+    errors.push(message);
+    problems.push({ level: "error", key, value, ...extra });
+  };
+  const recordWarning = (key, value, message, extra = {}) => {
+    warnings.push(message);
+    problems.push({ level: "warning", key, value, ...extra });
+  };
 
   let report = "";
-  if (!existsSync(reportPath)) errors.push(`Report not found: ${reportPath}`);
+  if (!existsSync(reportPath)) recordError("report-not-found", reportPath, `Report not found: ${reportPath}`);
   else {
     report = await readFile(reportPath, "utf8");
-    if (!report.trim()) errors.push(`Report is empty: ${reportPath}`);
+    if (!report.trim()) recordError("report-empty", reportPath, `Report is empty: ${reportPath}`);
   }
 
   let sidecar;
-  if (!existsSync(rawPath)) errors.push(`Raw sidecar not found: ${rawPath}`);
+  if (!existsSync(rawPath)) recordError("raw-sidecar-not-found", rawPath, `Raw sidecar not found: ${rawPath}`);
   else {
     try { sidecar = JSON.parse(await readFile(rawPath, "utf8")); }
-    catch (parseError) { errors.push(`Raw sidecar is not valid JSON: ${parseError.message}`); }
+    catch (parseError) { recordError("raw-sidecar-invalid-json", rawPath, `Raw sidecar is not valid JSON: ${parseError.message}`); }
   }
 
   const metadata = sidecar && typeof sidecar.metadata === "object" && sidecar.metadata ? sidecar.metadata : undefined;
   const payload = sidecar && typeof sidecar.raw === "object" && sidecar.raw ? sidecar.raw : undefined;
-  if (sidecar && !metadata) errors.push("Raw sidecar has no metadata object.");
-  if (sidecar && !payload) errors.push("Raw sidecar has no raw provider payload.");
+  if (sidecar && !metadata) recordError("raw-sidecar-metadata-missing", rawPath, "Raw sidecar has no metadata object.");
+  if (sidecar && !payload) recordError("raw-sidecar-payload-missing", rawPath, "Raw sidecar has no raw provider payload.");
 
   const sections = report ? reportSections(report) : {};
   for (const section of requiredReportSections) {
-    if (report && !(section in sections)) errors.push(`Report is missing required section: ## ${section}`);
+    if (report && !(section in sections)) recordError("report-section-missing", section, `Report is missing required section: ## ${section}`);
   }
 
   if (metadata) {
     if (Array.isArray(metadata.additionalQueries)) {
       const expected = 1 + metadata.additionalQueries.length;
-      if (metadata.queryCount !== expected) errors.push(`metadata.queryCount is ${metadata.queryCount} but 1 primary + ${metadata.additionalQueries.length} additional queries were recorded (expected ${expected}).`);
-      if (!additionalQueriesAppliedValues.has(metadata.additionalQueriesApplied)) errors.push(`metadata.additionalQueriesApplied is ${JSON.stringify(metadata.additionalQueriesApplied)}; expected one of: ${Array.from(additionalQueriesAppliedValues).join(", ")}.`);
-      else if ((metadata.additionalQueriesApplied === "none") !== (metadata.additionalQueries.length === 0)) errors.push("metadata.additionalQueriesApplied contradicts metadata.additionalQueries.");
-    } else warnings.push("Sidecar does not record how additional queries were applied (metadata.additionalQueries missing — sidecar predates this check or was produced by another tool). Re-run with the current script to verify query expansion.");
+      if (metadata.queryCount !== expected) recordError("query-count-mismatch", metadata.queryCount, `metadata.queryCount is ${metadata.queryCount} but 1 primary + ${metadata.additionalQueries.length} additional queries were recorded (expected ${expected}).`, { expected });
+      if (!additionalQueriesAppliedValues.has(metadata.additionalQueriesApplied)) recordError("additional-queries-applied-invalid", metadata.additionalQueriesApplied, `metadata.additionalQueriesApplied is ${JSON.stringify(metadata.additionalQueriesApplied)}; expected one of: ${Array.from(additionalQueriesAppliedValues).join(", ")}.`);
+      else if ((metadata.additionalQueriesApplied === "none") !== (metadata.additionalQueries.length === 0)) recordError("additional-queries-applied-conflict", metadata.additionalQueriesApplied, "metadata.additionalQueriesApplied contradicts metadata.additionalQueries.");
+    } else recordWarning("additional-queries-metadata-missing", rawPath, "Sidecar does not record how additional queries were applied (metadata.additionalQueries missing — sidecar predates this check or was produced by another tool). Re-run with the current script to verify query expansion.");
   }
 
   const synthesis = payload ? hasSynthesis(payload) : false;
-  if (metadata && typeof metadata.synthesis === "boolean" && metadata.synthesis !== synthesis) warnings.push(`metadata.synthesis is ${metadata.synthesis} but the raw payload ${synthesis ? "contains" : "lacks"} a synthesized answer.`);
+  if (metadata && typeof metadata.synthesis === "boolean" && metadata.synthesis !== synthesis) recordWarning("synthesis-metadata-mismatch", metadata.synthesis, `metadata.synthesis is ${metadata.synthesis} but the raw payload ${synthesis ? "contains" : "lacks"} a synthesized answer.`, { actual: synthesis });
   if (payload && !synthesis) {
     const mode = metadata?.researchMode;
-    if (mode === "standard" || mode === "full") errors.push(`Mode ${mode} requests server-side synthesis (outputSchema) but the raw payload has no synthesized answer. Re-run, or treat the report as an evidence brief only.`);
-    else warnings.push("No synthesized answer in the raw payload — this is an evidence brief. Do not use it as a decision recommendation; re-run with --mode standard or --mode full if the deliverable is a recommendation.");
+    if (mode === "standard" || mode === "full") recordError("synthesis-missing", mode, `Mode ${mode} requests server-side synthesis (outputSchema) but the raw payload has no synthesized answer. Re-run, or treat the report as an evidence brief only.`);
+    else recordWarning("synthesis-missing", mode, "No synthesized answer in the raw payload — this is an evidence brief. Do not use it as a decision recommendation; re-run with --mode standard or --mode full if the deliverable is a recommendation.");
   }
-  if (payload && !normalizeResults(payload).length) warnings.push("Raw payload contains zero sources. Re-run with broader terms or fewer filters.");
+  if (payload && !normalizeResults(payload).length) recordWarning("sources-empty", 0, "Raw payload contains zero sources. Re-run with broader terms or fewer filters.");
 
   const summarySection = normalizedProse(sections["Executive Summary"]);
   const findingsSection = normalizedProse(sections["Key Findings"]);
   if (summarySection && findingsSection) {
     const [shorter, longer] = summarySection.length <= findingsSection.length ? [summarySection, findingsSection] : [findingsSection, summarySection];
-    if (summarySection === findingsSection || (shorter.length > 200 && longer.includes(shorter))) warnings.push("Key Findings duplicates the Executive Summary text. Regenerate, or rewrite Key Findings as distinct claims.");
+    if (summarySection === findingsSection || (shorter.length > 200 && longer.includes(shorter))) recordWarning("report-sections-duplicate", "Executive Summary+Key Findings", "Key Findings duplicates the Executive Summary text. Regenerate, or rewrite Key Findings as distinct claims.");
   }
 
   const sidecarRef = report.match(/Raw metadata sidecar:\s*(\S+)/);
   if (sidecarRef) {
     const referenced = stripMarkdownPathDelimiters(sidecarRef[1]);
-    if (resolve(referenced) !== rawPath) warnings.push(`Report references sidecar ${referenced} but ${rawPath} was validated.`);
+    if (resolve(referenced) !== rawPath) recordWarning("sidecar-reference-mismatch", referenced, `Report references sidecar ${referenced} but ${rawPath} was validated.`, { validated: rawPath });
   }
 
   const ok = errors.length === 0;
-  jsonOut(process.stdout, { ok, report: reportPath, raw: rawPath, mode: metadata?.researchMode, synthesis, queryCount: metadata?.queryCount, errors, warnings });
+  jsonOut(process.stdout, { ok, report: reportPath, raw: rawPath, mode: metadata?.researchMode, synthesis, queryCount: metadata?.queryCount, errors, warnings, problems });
   process.exit(ok ? 0 : 1);
 }
 
@@ -513,7 +525,7 @@ async function main() {
     return;
   }
   if (options.command === "validate") { await validateCommand(options); return; }
-  if (options.command !== "report" && options.command !== "json") fail(`Unknown command: ${options.command}`);
+  if (options.command !== "report" && options.command !== "json") fail("command-unknown", options.command, `Unknown command: ${options.command}`);
   const query = await resolveQuery(options);
   const { raw, metadata } = await callExa(query, options);
   const format = options.command === "json" ? "json" : options.format;
@@ -526,4 +538,4 @@ async function main() {
   jsonOut(process.stdout, { ok: true, output, rawOutput: rawOutput ? resolve(rawOutput) : undefined, mode: metadata.researchMode, queryCount: metadata.queryCount, sources: normalizeResults(raw).length, uniqueSources: metadata.uniqueSourceCount });
 }
 
-main().catch((error) => fail(error?.message || String(error)));
+main().catch((error) => fail("unexpected-error", error?.name || "Error", error?.message || String(error)));

--- a/.agents/skills/deep-research/tests/deep-research.test.mjs
+++ b/.agents/skills/deep-research/tests/deep-research.test.mjs
@@ -25,6 +25,21 @@ function hasProblem(result, level, key, value) {
   return problems.some((problem) => problem.key === key && problem.value === value);
 }
 
+function completeReport() {
+  return [
+    "# Findings: q",
+    "## Research Question", "q",
+    "## Executive Summary", "Summary",
+    "## Key Findings", "Finding",
+    "## Evidence and Sources", "- [1] Source — https://example.com",
+    "## Tradeoffs / Alternatives", "Tradeoff",
+    "## Recommendation / Decision Criteria", "Recommendation",
+    "## Risks / Unknowns", "Risk",
+    "## Revisit Conditions", "Condition",
+    "## Research Metadata", "- Mode: lite",
+  ].join("\n\n");
+}
+
 test("doctor reports runtime status", () => {
   const result = spawnSync(process.execPath, [script, "doctor"], { encoding: "utf8" });
   assert.equal(result.status, 0);
@@ -186,6 +201,50 @@ test("large refusal JSON is complete before exit", () => {
   const parsed = diagnostic(result);
   assert.equal(parsed.key, "command-unknown");
   assert.equal(parsed.value, command);
+});
+
+test("every command refusal keeps its stable key and value", () => {
+  const dir = mkdtempSync(join(tmpdir(), "deep-research-refusals-"));
+  const bin = join(dir, "bin");
+  mkdirSync(bin);
+  writeFileSync(join(bin, "op"), "#!/usr/bin/env bash\nexit 1\n");
+  chmodSync(join(bin, "op"), 0o755);
+  for (let index = 0; index < 26; index += 1) writeFileSync(join(dir, `context-${index}.md`), "context");
+
+  const noSecrets = { ...process.env };
+  delete noSecrets.EXA_API_KEY;
+  delete noSecrets.EXA_MOCK_RESPONSE_FILE;
+
+  const noFetch = join(dir, "no-fetch.mjs");
+  writeFileSync(noFetch, "globalThis.fetch = undefined;\n");
+  const failedFetch = join(dir, "failed-fetch.mjs");
+  writeFileSync(failedFetch, "globalThis.fetch = async () => ({ ok: false, status: 503, statusText: 'unavailable', text: async () => 'unavailable' });\n");
+  const invalidMock = join(dir, "invalid.json");
+  writeFileSync(invalidMock, "{");
+
+  const additionalQueries = Array.from({ length: 11 }, () => ["--additional-query", "variant"]).flat();
+  const cases = [
+    { args: ["report", "q", "--output"], key: "argument-value-missing", value: "--output" },
+    { args: ["report", "q", "--unknown"], key: "argument-unknown", value: "--unknown" },
+    { args: ["report", "q", "--context-glob", "a*b*c"], key: "context-glob-invalid", value: "a*b*c", cwd: dir },
+    { args: ["report", "q", "--context-glob", "context-*.md"], key: "context-glob-limit", value: 26, cwd: dir },
+    { args: ["report", "q", "--type", "unknown"], key: "type-invalid", value: "unknown" },
+    { args: ["report", "q", "--format", "unknown"], key: "format-invalid", value: "unknown" },
+    { args: ["report", "q", ...additionalQueries], key: "additional-query-limit", value: 11 },
+    { args: ["report"], key: "query-missing", value: "query-or-file" },
+    { args: ["validate"], key: "argument-missing", value: "report+raw" },
+    { args: ["report", "q"], key: "secret-reference-unresolved", value: "EXA_API_KEY", env: { ...noSecrets, EXA_API_KEY: "op://vault/exa/key", PATH: `${bin}:${process.env.PATH}` } },
+    { args: ["report", "q"], key: "runtime-fetch-missing", value: process.version, env: { ...noSecrets, NODE_OPTIONS: `--import=${noFetch}` } },
+    { args: ["report", "q"], key: "exa-request-failed", value: 503, env: { ...noSecrets, EXA_API_KEY: "key", NODE_OPTIONS: `--import=${failedFetch}` } },
+    { args: ["report", "q"], key: "unexpected-error", value: "SyntaxError", env: { ...noSecrets, EXA_MOCK_RESPONSE_FILE: invalidMock } },
+  ];
+
+  for (const row of cases) {
+    const result = spawnSync(process.execPath, [script, ...row.args], { encoding: "utf8", cwd: row.cwd, env: row.env ?? noSecrets });
+    const parsed = diagnostic(result);
+    assert.equal(parsed.key, row.key, row.key);
+    assert.equal(parsed.value, row.value, row.key);
+  }
 });
 
 test("full mode aggregates multiple mock responses and dedupes URLs", () => {
@@ -357,6 +416,35 @@ test("validate warns when Key Findings duplicates the Executive Summary", () => 
   assert.equal(result.status, 0, result.stderr);
   const json = JSON.parse(result.stdout);
   assert.equal(hasProblem(json, "warning", "report-sections-duplicate", "Executive Summary+Key Findings"), true);
+});
+
+test("every validation problem keeps its stable key and value", () => {
+  const validSidecar = {
+    metadata: { researchMode: "lite", queryCount: 1, additionalQueries: [], additionalQueriesApplied: "none", synthesis: true },
+    raw: { answer: "Answer", results: [{ url: "https://example.com" }] },
+  };
+  const cases = [
+    { key: "report-empty", level: "error", status: 1, value: "report", report: "" },
+    { key: "raw-sidecar-invalid-json", level: "error", status: 1, value: "raw", rawText: "{" },
+    { key: "raw-sidecar-metadata-missing", level: "error", status: 1, value: "raw", sidecar: { raw: validSidecar.raw } },
+    { key: "raw-sidecar-payload-missing", level: "error", status: 1, value: "raw", sidecar: { metadata: validSidecar.metadata } },
+    { key: "additional-queries-applied-conflict", level: "error", status: 1, value: "none", sidecar: { ...validSidecar, metadata: { ...validSidecar.metadata, queryCount: 2, additionalQueries: ["variant"] } } },
+    { key: "additional-queries-metadata-missing", level: "warning", status: 0, value: "raw", sidecar: { ...validSidecar, metadata: { researchMode: "lite", queryCount: 1, additionalQueriesApplied: "none", synthesis: true } } },
+    { key: "synthesis-metadata-mismatch", level: "warning", status: 0, value: false, sidecar: { ...validSidecar, metadata: { ...validSidecar.metadata, synthesis: false } } },
+    { key: "sources-empty", level: "warning", status: 0, value: 0, sidecar: { ...validSidecar, raw: { answer: "Answer", results: [] } } },
+  ];
+
+  for (const row of cases) {
+    const dir = mkdtempSync(join(tmpdir(), `deep-research-${row.key}-`));
+    const report = join(dir, "findings.md");
+    const raw = join(dir, "findings.raw.json");
+    writeFileSync(report, row.report ?? completeReport());
+    writeFileSync(raw, row.rawText ?? JSON.stringify(row.sidecar ?? validSidecar));
+    const result = spawnSync(process.execPath, [script, "validate", report, raw], { encoding: "utf8" });
+    assert.equal(result.status, row.status, row.key);
+    const expectedValue = row.value === "report" ? report : row.value === "raw" ? raw : row.value;
+    assert.equal(hasProblem(JSON.parse(result.stdout), row.level, row.key, expectedValue), true, row.key);
+  }
 });
 
 // The loader reads .env.local only — the .env fallback is removed — and an

--- a/.agents/skills/deep-research/tests/deep-research.test.mjs
+++ b/.agents/skills/deep-research/tests/deep-research.test.mjs
@@ -8,6 +8,7 @@ import test from "node:test";
 const script = new URL("../scripts/deep-research", import.meta.url).pathname;
 
 function diagnostic(result) {
+  assert.equal(result.status, 1);
   const parsed = JSON.parse(result.stderr.trim().split(/\r?\n/, 1)[0]);
   assert.equal(parsed.ok, false);
   assert.equal(typeof parsed.error, "string");
@@ -16,7 +17,12 @@ function diagnostic(result) {
 }
 
 function hasProblem(result, level, key, value) {
-  return result.problems.some((problem) => problem.level === level && problem.key === key && problem.value === value);
+  const problems = result.problems.filter((problem) => problem.level === level);
+  const legacy = result[`${level}s`];
+  assert.equal(Array.isArray(legacy), true);
+  assert.equal(legacy.length, problems.length);
+  assert.equal(legacy.every((message) => typeof message === "string" && message.length > 0), true);
+  return problems.some((problem) => problem.key === key && problem.value === value);
 }
 
 test("doctor reports runtime status", () => {

--- a/.agents/skills/deep-research/tests/deep-research.test.mjs
+++ b/.agents/skills/deep-research/tests/deep-research.test.mjs
@@ -8,7 +8,11 @@ import test from "node:test";
 const script = new URL("../scripts/deep-research", import.meta.url).pathname;
 
 function diagnostic(result) {
-  return JSON.parse(result.stderr.trim().split(/\r?\n/, 1)[0]);
+  const parsed = JSON.parse(result.stderr.trim().split(/\r?\n/, 1)[0]);
+  assert.equal(parsed.ok, false);
+  assert.equal(typeof parsed.error, "string");
+  assert.notEqual(parsed.error.length, 0);
+  return parsed;
 }
 
 function hasProblem(result, level, key, value) {
@@ -290,6 +294,12 @@ test("validate errors when standard mode lacks synthesis and flags evidence-brie
   const liteJson = JSON.parse(liteValidate.stdout);
   assert.equal(liteJson.ok, true);
   assert.equal(hasProblem(liteJson, "warning", "synthesis-missing", "lite"), true);
+  const unknownModeSidecar = JSON.parse(readFileSync(raw, "utf8"));
+  delete unknownModeSidecar.metadata.researchMode;
+  writeFileSync(raw, JSON.stringify(unknownModeSidecar));
+  const unknownModeValidate = spawnSync(process.execPath, [script, "validate", output, raw], { encoding: "utf8" });
+  assert.equal(unknownModeValidate.status, 0, unknownModeValidate.stderr);
+  assert.equal(hasProblem(JSON.parse(unknownModeValidate.stdout), "warning", "synthesis-missing", null), true);
 });
 
 test("validate errors on queryCount mismatch and missing files", () => {
@@ -306,6 +316,14 @@ test("validate errors on queryCount mismatch and missing files", () => {
   const mismatch = spawnSync(process.execPath, [script, "validate", output, raw], { encoding: "utf8" });
   assert.equal(mismatch.status, 1);
   assert.equal(hasProblem(JSON.parse(mismatch.stdout), "error", "query-count-mismatch", 5), true);
+  delete sidecar.metadata.queryCount;
+  delete sidecar.metadata.additionalQueriesApplied;
+  writeFileSync(raw, JSON.stringify(sidecar));
+  const omitted = spawnSync(process.execPath, [script, "validate", output, raw], { encoding: "utf8" });
+  assert.equal(omitted.status, 1);
+  const omittedJson = JSON.parse(omitted.stdout);
+  assert.equal(hasProblem(omittedJson, "error", "query-count-mismatch", null), true);
+  assert.equal(hasProblem(omittedJson, "error", "additional-queries-applied-invalid", null), true);
   const missing = spawnSync(process.execPath, [script, "validate", join(dir, "nope.md"), join(dir, "nope.json")], { encoding: "utf8" });
   assert.equal(missing.status, 1);
   const missingJson = JSON.parse(missing.stdout);

--- a/.agents/skills/deep-research/tests/deep-research.test.mjs
+++ b/.agents/skills/deep-research/tests/deep-research.test.mjs
@@ -180,6 +180,14 @@ test("invalid mode fails clearly", () => {
   assert.equal(diagnostic(result).value, "slow");
 });
 
+test("large refusal JSON is complete before exit", () => {
+  const command = "x".repeat(96 * 1024);
+  const result = spawnSync(process.execPath, [script, command], { encoding: "utf8" });
+  const parsed = diagnostic(result);
+  assert.equal(parsed.key, "command-unknown");
+  assert.equal(parsed.value, command);
+});
+
 test("full mode aggregates multiple mock responses and dedupes URLs", () => {
   const dir = mkdtempSync(join(tmpdir(), "deep-research-full-"));
   const mock = join(dir, "mock.json");

--- a/.agents/skills/deep-research/tests/deep-research.test.mjs
+++ b/.agents/skills/deep-research/tests/deep-research.test.mjs
@@ -7,6 +7,14 @@ import test from "node:test";
 
 const script = new URL("../scripts/deep-research", import.meta.url).pathname;
 
+function diagnostic(result) {
+  return JSON.parse(result.stderr.trim().split(/\r?\n/, 1)[0]);
+}
+
+function hasProblem(result, level, key, value) {
+  return result.problems.some((problem) => problem.level === level && problem.key === key && problem.value === value);
+}
+
 test("doctor reports runtime status", () => {
   const result = spawnSync(process.execPath, [script, "doctor"], { encoding: "utf8" });
   assert.equal(result.status, 0);
@@ -36,10 +44,12 @@ test("out-of-range num-results and text-max-characters fail with Exa limits", ()
   const env = { ...process.env, EXA_MOCK_RESPONSE_FILE: mock };
   const tooMany = spawnSync(process.execPath, [script, "report", "q", "--num-results", "150"], { encoding: "utf8", env });
   assert.notEqual(tooMany.status, 0);
-  assert.match(tooMany.stderr, /Invalid --num-results 150.*1-100/);
+  assert.equal(diagnostic(tooMany).key, "num-results-invalid");
+  assert.equal(diagnostic(tooMany).value, "150");
   const tooLong = spawnSync(process.execPath, [script, "report", "q", "--text-max-characters", "16000"], { encoding: "utf8", env });
   assert.notEqual(tooLong.status, 0);
-  assert.match(tooLong.stderr, /Invalid --text-max-characters 16000.*1-10000/);
+  assert.equal(diagnostic(tooLong).key, "text-max-characters-invalid");
+  assert.equal(diagnostic(tooLong).value, "16000");
 });
 
 // The template and the validator's required-section list must not drift apart:
@@ -65,7 +75,7 @@ test("findings template carries every section validate requires", () => {
   writeFileSync(gutted, filled.replace("## Risks / Unknowns", "## Unrelated Heading"));
   const caught = spawnSync(process.execPath, [script, "validate", gutted, raw], { encoding: "utf8" });
   assert.notEqual(caught.status, 0);
-  assert.ok(JSON.parse(caught.stdout).errors.some((e) => /Risks \/ Unknowns/.test(e)));
+  assert.equal(hasProblem(JSON.parse(caught.stdout), "error", "report-section-missing", "Risks / Unknowns"), true);
 });
 
 test("invalid --timeout names the flag rather than aborting the request", () => {
@@ -76,7 +86,8 @@ test("invalid --timeout names the flag rather than aborting the request", () => 
   for (const bad of ["abc", "0", "1.5"]) {
     const result = spawnSync(process.execPath, [script, "report", "q", "--timeout", bad], { encoding: "utf8", env });
     assert.notEqual(result.status, 0);
-    assert.match(result.stderr, /Invalid --timeout/);
+    assert.equal(diagnostic(result).key, "timeout-invalid");
+    assert.equal(diagnostic(result).value, bad);
   }
 });
 
@@ -87,7 +98,8 @@ test("missing key fails with setup instructions", () => {
   const cwd = mkdtempSync(join(tmpdir(), "deep-research-no-env-"));
   const result = spawnSync(process.execPath, [script, "report", "question"], { encoding: "utf8", env, cwd });
   assert.notEqual(result.status, 0);
-  assert.match(result.stderr, /EXA_API_KEY/);
+  assert.equal(diagnostic(result).key, "credential-missing");
+  assert.equal(diagnostic(result).value, "EXA_API_KEY");
 });
 
 test("mocked report writes findings and raw output", () => {
@@ -154,7 +166,8 @@ test("invalid mode fails clearly", () => {
   writeFileSync(mock, JSON.stringify({ answer: "Answer", results: [] }));
   const result = spawnSync(process.execPath, [script, "report", "question", "--mode", "slow"], { encoding: "utf8", env: { ...process.env, EXA_MOCK_RESPONSE_FILE: mock } });
   assert.notEqual(result.status, 0);
-  assert.match(result.stderr, /Invalid --mode slow/);
+  assert.equal(diagnostic(result).key, "mode-invalid");
+  assert.equal(diagnostic(result).value, "slow");
 });
 
 test("full mode aggregates multiple mock responses and dedupes URLs", () => {
@@ -249,12 +262,12 @@ test("validate ignores Markdown backticks around a report-referenced sidecar pat
   writeFileSync(output, readFileSync(output, "utf8").replace(/- Raw metadata sidecar: .*/, "- Raw metadata sidecar: `" + raw + "`"));
   const okJson = JSON.parse(spawnSync(process.execPath, [script, "validate", output, raw], { encoding: "utf8" }).stdout);
   assert.equal(okJson.ok, true);
-  assert.ok(!okJson.warnings.some((w) => w.startsWith("Report references sidecar")), `unexpected sidecar warning: ${JSON.stringify(okJson.warnings)}`);
+  assert.equal(okJson.problems.some((problem) => problem.key === "sidecar-reference-mismatch"), false);
 
   // A genuinely-different (still backticked) path must still warn — the fix must not over-suppress.
   writeFileSync(output, readFileSync(output, "utf8").replace(/- Raw metadata sidecar: .*/, "- Raw metadata sidecar: `" + join(dir, "other.raw.json") + "`"));
   const mismatchJson = JSON.parse(spawnSync(process.execPath, [script, "validate", output, raw], { encoding: "utf8" }).stdout);
-  assert.ok(mismatchJson.warnings.some((w) => w.startsWith("Report references sidecar")), `expected a sidecar mismatch warning: ${JSON.stringify(mismatchJson.warnings)}`);
+  assert.equal(hasProblem(mismatchJson, "warning", "sidecar-reference-mismatch", join(dir, "other.raw.json")), true);
 });
 
 test("validate errors when standard mode lacks synthesis and flags evidence-brief lite", () => {
@@ -269,14 +282,14 @@ test("validate errors when standard mode lacks synthesis and flags evidence-brie
   assert.equal(standardValidate.status, 1);
   const standardJson = JSON.parse(standardValidate.stdout);
   assert.equal(standardJson.ok, false);
-  assert.ok(standardJson.errors.some((e) => /Mode standard requests server-side synthesis/.test(e)));
+  assert.equal(hasProblem(standardJson, "error", "synthesis-missing", "standard"), true);
   const lite = spawnSync(process.execPath, [script, "report", "question", "--mode", "lite", "--output", output], { encoding: "utf8", env: { ...process.env, EXA_MOCK_RESPONSE_FILE: mock } });
   assert.equal(lite.status, 0, lite.stderr);
   const liteValidate = spawnSync(process.execPath, [script, "validate", output, raw], { encoding: "utf8" });
   assert.equal(liteValidate.status, 0, liteValidate.stderr);
   const liteJson = JSON.parse(liteValidate.stdout);
   assert.equal(liteJson.ok, true);
-  assert.ok(liteJson.warnings.some((w) => /evidence brief/.test(w)));
+  assert.equal(hasProblem(liteJson, "warning", "synthesis-missing", "lite"), true);
 });
 
 test("validate errors on queryCount mismatch and missing files", () => {
@@ -292,12 +305,12 @@ test("validate errors on queryCount mismatch and missing files", () => {
   writeFileSync(raw, JSON.stringify(sidecar));
   const mismatch = spawnSync(process.execPath, [script, "validate", output, raw], { encoding: "utf8" });
   assert.equal(mismatch.status, 1);
-  assert.ok(JSON.parse(mismatch.stdout).errors.some((e) => /queryCount is 5/.test(e)));
+  assert.equal(hasProblem(JSON.parse(mismatch.stdout), "error", "query-count-mismatch", 5), true);
   const missing = spawnSync(process.execPath, [script, "validate", join(dir, "nope.md"), join(dir, "nope.json")], { encoding: "utf8" });
   assert.equal(missing.status, 1);
   const missingJson = JSON.parse(missing.stdout);
-  assert.ok(missingJson.errors.some((e) => /Report not found/.test(e)));
-  assert.ok(missingJson.errors.some((e) => /Raw sidecar not found/.test(e)));
+  assert.equal(hasProblem(missingJson, "error", "report-not-found", join(dir, "nope.md")), true);
+  assert.equal(hasProblem(missingJson, "error", "raw-sidecar-not-found", join(dir, "nope.json")), true);
 });
 
 test("validate warns when Key Findings duplicates the Executive Summary", () => {
@@ -311,7 +324,7 @@ test("validate warns when Key Findings duplicates the Executive Summary", () => 
   const result = spawnSync(process.execPath, [script, "validate", report, raw], { encoding: "utf8" });
   assert.equal(result.status, 0, result.stderr);
   const json = JSON.parse(result.stdout);
-  assert.ok(json.warnings.some((w) => /duplicates the Executive Summary/.test(w)));
+  assert.equal(hasProblem(json, "warning", "report-sections-duplicate", "Executive Summary+Key Findings"), true);
 });
 
 // The loader reads .env.local only — the .env fallback is removed — and an
@@ -336,7 +349,8 @@ test("a key present only in .env is ignored; .env.local and process env keep the
   writeFileSync(join(dir, ".env"), `EXA_MOCK_RESPONSE_FILE=${dotenvMock}\nEXA_API_KEY=from-dotenv\n`);
   const ignored = spawnSync(process.execPath, [script, "report", "q"], { encoding: "utf8", env, cwd: dir });
   assert.notEqual(ignored.status, 0);
-  assert.match(ignored.stderr, /EXA_API_KEY is required/);
+  assert.equal(diagnostic(ignored).key, "credential-missing");
+  assert.equal(diagnostic(ignored).value, "EXA_API_KEY");
 
   // .env.local supplies the value when the process does not carry the key.
   const localOut = join(dir, "local.md");
@@ -364,7 +378,8 @@ test("a key present only in .env is ignored; .env.local and process env keep the
     cwd: dir,
   });
   assert.notEqual(emptied.status, 0);
-  assert.match(emptied.stderr, /EXA_API_KEY is required/);
+  assert.equal(diagnostic(emptied).key, "credential-missing");
+  assert.equal(diagnostic(emptied).value, "EXA_API_KEY");
 
   // Within the file itself, dotenv last-wins: a repeated key's LATER line
   // replaces the earlier one — the first assignment must not block its own

--- a/skills/deep-research/scripts/deep-research
+++ b/skills/deep-research/scripts/deep-research
@@ -35,7 +35,7 @@ const defaultOutputSchema = {
 };
 
 function jsonOut(stream, value) { stream.write(`${JSON.stringify(value)}\n`); }
-function fail(key, value, message, extra = {}) { jsonOut(process.stderr, { ok: false, key, value, error: message, ...extra }); process.exit(1); }
+function fail(key, value, message, extra = {}) { jsonOut(process.stderr, { ok: false, key, value: value ?? null, error: message, ...extra }); process.exit(1); }
 
 function helpPayload() {
   return {
@@ -446,11 +446,11 @@ async function validateCommand(options) {
   const problems = [];
   const recordError = (key, value, message, extra = {}) => {
     errors.push(message);
-    problems.push({ level: "error", key, value, ...extra });
+    problems.push({ level: "error", key, value: value ?? null, ...extra });
   };
   const recordWarning = (key, value, message, extra = {}) => {
     warnings.push(message);
-    problems.push({ level: "warning", key, value, ...extra });
+    problems.push({ level: "warning", key, value: value ?? null, ...extra });
   };
 
   let report = "";

--- a/skills/deep-research/scripts/deep-research
+++ b/skills/deep-research/scripts/deep-research
@@ -2,7 +2,7 @@
 // Diagnostic protocol: command refusals write one JSON object to stderr with
 // {ok:false,key,value,error}. Validate keeps errors/warnings and adds problems
 // with {level,key,value}; English remains display text, not a test contract.
-import { existsSync } from "node:fs";
+import { existsSync, writeSync } from "node:fs";
 import { mkdir, readdir, readFile, rename, writeFile } from "node:fs/promises";
 import { dirname, extname, join, resolve } from "node:path";
 import { spawnSync } from "node:child_process";
@@ -35,7 +35,22 @@ const defaultOutputSchema = {
 };
 
 function jsonOut(stream, value) { stream.write(`${JSON.stringify(value)}\n`); }
-function fail(key, value, message, extra = {}) { jsonOut(process.stderr, { ok: false, key, value: value ?? null, error: message, ...extra }); process.exit(1); }
+function fail(key, value, message, extra = {}) {
+  const body = Buffer.from(`${JSON.stringify({ ok: false, key, value: value ?? null, error: message, ...extra })}\n`);
+  let offset = 0;
+  const pause = new Int32Array(new SharedArrayBuffer(4));
+  while (offset < body.length) {
+    try {
+      const written = writeSync(process.stderr.fd, body, offset, body.length - offset);
+      if (written > 0) offset += written;
+      else Atomics.wait(pause, 0, 0, 1);
+    } catch (error) {
+      if (error?.code !== "EAGAIN") throw error;
+      Atomics.wait(pause, 0, 0, 1);
+    }
+  }
+  process.exit(1);
+}
 
 function helpPayload() {
   return {

--- a/skills/deep-research/scripts/deep-research
+++ b/skills/deep-research/scripts/deep-research
@@ -1,4 +1,7 @@
 #!/usr/bin/env node
+// Diagnostic protocol: command refusals write one JSON object to stderr with
+// {ok:false,key,value,error}. Validate keeps errors/warnings and adds problems
+// with {level,key,value}; English remains display text, not a test contract.
 import { existsSync } from "node:fs";
 import { mkdir, readdir, readFile, rename, writeFile } from "node:fs/promises";
 import { dirname, extname, join, resolve } from "node:path";
@@ -32,7 +35,7 @@ const defaultOutputSchema = {
 };
 
 function jsonOut(stream, value) { stream.write(`${JSON.stringify(value)}\n`); }
-function fail(message, extra = {}) { jsonOut(process.stderr, { ok: false, error: message, ...extra }); process.exit(1); }
+function fail(key, value, message, extra = {}) { jsonOut(process.stderr, { ok: false, key, value, error: message, ...extra }); process.exit(1); }
 
 function helpPayload() {
   return {
@@ -95,7 +98,7 @@ function resolveSecretRef(value, name) {
   if (!value || !value.startsWith("op://")) return value;
   const result = spawnSync("op", ["read", value], { encoding: "utf8" });
   if (result.status === 0 && result.stdout.trim()) return result.stdout.trim();
-  fail(`${name} is a 1Password reference but could not be resolved. Install/sign in to the op CLI and run: op read '${value}'`);
+  fail("secret-reference-unresolved", name, `${name} is a 1Password reference but could not be resolved. Install/sign in to the op CLI and run: op read '${value}'`);
 }
 
 function parseArgs(argv) {
@@ -103,7 +106,7 @@ function parseArgs(argv) {
   const options = { command, positional: [], context: [], additionalQuery: [], includeDomain: [], excludeDomain: [], format: "findings", mode: "standard", explicit: new Set(), rawOutputDefault: true };
   while (argv.length) {
     const arg = argv.shift();
-    const value = () => argv.shift() ?? fail(`Missing value for ${arg}`);
+    const value = () => argv.shift() ?? fail("argument-value-missing", arg, `Missing value for ${arg}`);
     if (arg === "--output") options.output = value();
     else if (arg === "--query-file") options.queryFile = value();
     else if (arg === "--context") options.context.push(value());
@@ -114,16 +117,16 @@ function parseArgs(argv) {
     else if (arg === "--exclude-domain") options.excludeDomain.push(value());
     else if (arg === "--start-date") options.startDate = value();
     else if (arg === "--end-date") options.endDate = value();
-    else if (arg === "--num-results") { options.numResults = Number(value()); options.explicit.add("numResults"); }
-    else if (arg === "--text-max-characters") { options.textMaxCharacters = Number(value()); options.explicit.add("textMaxCharacters"); }
+    else if (arg === "--num-results") { options.numResultsInput = value(); options.numResults = Number(options.numResultsInput); options.explicit.add("numResults"); }
+    else if (arg === "--text-max-characters") { options.textMaxCharactersInput = value(); options.textMaxCharacters = Number(options.textMaxCharactersInput); options.explicit.add("textMaxCharacters"); }
     else if (arg === "--format") options.format = value();
     else if (arg === "--raw-output") options.rawOutput = value();
     else if (arg === "--no-raw-output") options.rawOutputDefault = false;
-    else if (arg === "--timeout") { options.timeout = Number(value()); options.explicit.add("timeout"); }
+    else if (arg === "--timeout") { options.timeoutInput = value(); options.timeout = Number(options.timeoutInput); options.explicit.add("timeout"); }
     else if (arg === "--type") { options.type = value(); options.explicit.add("type"); }
     else if (arg === "--mode" || arg === "--research-mode") options.mode = value();
     else if (arg === "--help" || arg === "-h") options.help = true;
-    else if (arg?.startsWith("--")) fail(`Unknown flag: ${arg}`);
+    else if (arg?.startsWith("--")) fail("argument-unknown", arg, `Unknown flag: ${arg}`);
     else options.positional.push(arg);
   }
   return options;
@@ -149,35 +152,35 @@ async function expandSimpleGlob(rawGlob, limit = MAX_CONTEXT_FILES) {
   const slash = normalized.lastIndexOf("/");
   const dirPart = slash >= 0 ? normalized.slice(0, slash) : ".";
   const basePattern = slash >= 0 ? normalized.slice(slash + 1) : normalized;
-  if (basePattern.split("*").length > 2) fail(`--context-glob supports one '*' wildcard in the file name: ${rawGlob}`);
+  if (basePattern.split("*").length > 2) fail("context-glob-invalid", rawGlob, `--context-glob supports one '*' wildcard in the file name: ${rawGlob}`);
   const [prefix, suffix] = basePattern.split("*");
   const dir = resolve(dirPart);
   const entries = await readdir(dir, { withFileTypes: true });
   const matches = entries.filter((entry) => entry.isFile() && entry.name.startsWith(prefix) && entry.name.endsWith(suffix)).map((entry) => join(dir, entry.name)).sort();
-  if (matches.length > limit) fail(`--context-glob matched ${matches.length} files; limit is ${limit}: ${rawGlob}`);
+  if (matches.length > limit) fail("context-glob-limit", matches.length, `--context-glob matched ${matches.length} files; limit is ${limit}: ${rawGlob}`, { limit });
   return matches;
 }
 
 function applyMode(options) {
-  if (!researchModes.has(options.mode)) fail(`Invalid --mode ${options.mode}. Expected one of: ${Array.from(researchModes).join(", ")}.`);
+  if (!researchModes.has(options.mode)) fail("mode-invalid", options.mode, `Invalid --mode ${options.mode}. Expected one of: ${Array.from(researchModes).join(", ")}.`);
   const defaults = modeDefaults[options.mode];
   options.type = options.explicit.has("type") ? options.type : defaults.type;
   options.numResults = options.explicit.has("numResults") ? options.numResults : defaults.numResults;
   options.textMaxCharacters = options.explicit.has("textMaxCharacters") ? options.textMaxCharacters : defaults.textMaxCharacters;
   options.timeout = options.explicit.has("timeout") ? options.timeout : defaults.timeout;
-  if (!deepTypes.has(options.type)) fail(`Invalid --type ${options.type}`);
-  if (!formats.has(options.format)) fail(`Invalid --format ${options.format}`);
-  if (!Number.isInteger(options.numResults) || options.numResults < 1 || options.numResults > EXA_MAX_NUM_RESULTS) fail(`Invalid --num-results ${options.numResults}. Exa /search accepts 1-${EXA_MAX_NUM_RESULTS} (INVALID_NUM_RESULTS).`);
-  if (!Number.isInteger(options.textMaxCharacters) || options.textMaxCharacters < 1 || options.textMaxCharacters > EXA_MAX_TEXT_CHARACTERS) fail(`Invalid --text-max-characters ${options.textMaxCharacters}. Exa text.maxCharacters accepts 1-${EXA_MAX_TEXT_CHARACTERS}.`);
-  if (!Number.isInteger(options.timeout) || options.timeout < 1) fail(`Invalid --timeout ${options.timeout}. Expected a positive whole number of seconds.`);
-  if (options.additionalQuery.length > EXA_MAX_ADDITIONAL_QUERIES) fail(`Too many --additional-query values (${options.additionalQuery.length}). Exa additionalQueries accepts at most ${EXA_MAX_ADDITIONAL_QUERIES}.`);
+  if (!deepTypes.has(options.type)) fail("type-invalid", options.type, `Invalid --type ${options.type}`);
+  if (!formats.has(options.format)) fail("format-invalid", options.format, `Invalid --format ${options.format}`);
+  if (!Number.isInteger(options.numResults) || options.numResults < 1 || options.numResults > EXA_MAX_NUM_RESULTS) fail("num-results-invalid", options.numResultsInput, `Invalid --num-results ${options.numResultsInput}. Exa /search accepts 1-${EXA_MAX_NUM_RESULTS} (INVALID_NUM_RESULTS).`, { min: 1, max: EXA_MAX_NUM_RESULTS });
+  if (!Number.isInteger(options.textMaxCharacters) || options.textMaxCharacters < 1 || options.textMaxCharacters > EXA_MAX_TEXT_CHARACTERS) fail("text-max-characters-invalid", options.textMaxCharactersInput, `Invalid --text-max-characters ${options.textMaxCharactersInput}. Exa text.maxCharacters accepts 1-${EXA_MAX_TEXT_CHARACTERS}.`, { min: 1, max: EXA_MAX_TEXT_CHARACTERS });
+  if (!Number.isInteger(options.timeout) || options.timeout < 1) fail("timeout-invalid", options.timeoutInput, `Invalid --timeout ${options.timeoutInput}. Expected a positive whole number of seconds.`);
+  if (options.additionalQuery.length > EXA_MAX_ADDITIONAL_QUERIES) fail("additional-query-limit", options.additionalQuery.length, `Too many --additional-query values (${options.additionalQuery.length}). Exa additionalQueries accepts at most ${EXA_MAX_ADDITIONAL_QUERIES}.`, { limit: EXA_MAX_ADDITIONAL_QUERIES });
   return options;
 }
 
 async function resolveQuery(options) {
   let query = options.positional.join(" ").trim();
   if (options.queryFile) query = (await readFile(resolvePath(options.queryFile), "utf8")).trim();
-  if (!query) fail("A query or --query-file is required.");
+  if (!query) fail("query-missing", "query-or-file", "A query or --query-file is required.");
   return query;
 }
 
@@ -371,11 +374,11 @@ async function callExaBody(body, options, controller) {
     if (Array.isArray(mock)) return mock[Math.min(options.mockIndex++, mock.length - 1)];
     return mock;
   }
-  if (typeof fetch !== "function") fail("This Node runtime does not provide fetch. Use Node 18+.");
+  if (typeof fetch !== "function") fail("runtime-fetch-missing", process.version, "This Node runtime does not provide fetch. Use Node 18+.");
   const key = resolveSecretRef(process.env.EXA_API_KEY, "EXA_API_KEY");
-  if (!key) fail("EXA_API_KEY is required for Exa deep research. Set EXA_API_KEY or add it to .env.local.");
+  if (!key) fail("credential-missing", "EXA_API_KEY", "EXA_API_KEY is required for Exa deep research. Set EXA_API_KEY or add it to .env.local.");
   const response = await fetch("https://api.exa.ai/search", { method: "POST", headers: { "content-type": "application/json", "x-api-key": key }, body: JSON.stringify(body), signal: controller.signal });
-  if (!response.ok) fail(`Exa request failed (${response.status}): ${await response.text().catch(() => response.statusText)}`);
+  if (!response.ok) fail("exa-request-failed", response.status, `Exa request failed (${response.status}): ${await response.text().catch(() => response.statusText)}`);
   return response.json();
 }
 
@@ -435,69 +438,78 @@ function normalizedProse(text) {
 
 async function validateCommand(options) {
   const [reportArg, rawArg] = options.positional;
-  if (!reportArg || !rawArg) fail("Usage: deep-research validate <findings.md> <findings.raw.json>");
+  if (!reportArg || !rawArg) fail("argument-missing", "report+raw", "Usage: deep-research validate <findings.md> <findings.raw.json>");
   const reportPath = resolvePath(reportArg);
   const rawPath = resolvePath(rawArg);
   const errors = [];
   const warnings = [];
+  const problems = [];
+  const recordError = (key, value, message, extra = {}) => {
+    errors.push(message);
+    problems.push({ level: "error", key, value, ...extra });
+  };
+  const recordWarning = (key, value, message, extra = {}) => {
+    warnings.push(message);
+    problems.push({ level: "warning", key, value, ...extra });
+  };
 
   let report = "";
-  if (!existsSync(reportPath)) errors.push(`Report not found: ${reportPath}`);
+  if (!existsSync(reportPath)) recordError("report-not-found", reportPath, `Report not found: ${reportPath}`);
   else {
     report = await readFile(reportPath, "utf8");
-    if (!report.trim()) errors.push(`Report is empty: ${reportPath}`);
+    if (!report.trim()) recordError("report-empty", reportPath, `Report is empty: ${reportPath}`);
   }
 
   let sidecar;
-  if (!existsSync(rawPath)) errors.push(`Raw sidecar not found: ${rawPath}`);
+  if (!existsSync(rawPath)) recordError("raw-sidecar-not-found", rawPath, `Raw sidecar not found: ${rawPath}`);
   else {
     try { sidecar = JSON.parse(await readFile(rawPath, "utf8")); }
-    catch (parseError) { errors.push(`Raw sidecar is not valid JSON: ${parseError.message}`); }
+    catch (parseError) { recordError("raw-sidecar-invalid-json", rawPath, `Raw sidecar is not valid JSON: ${parseError.message}`); }
   }
 
   const metadata = sidecar && typeof sidecar.metadata === "object" && sidecar.metadata ? sidecar.metadata : undefined;
   const payload = sidecar && typeof sidecar.raw === "object" && sidecar.raw ? sidecar.raw : undefined;
-  if (sidecar && !metadata) errors.push("Raw sidecar has no metadata object.");
-  if (sidecar && !payload) errors.push("Raw sidecar has no raw provider payload.");
+  if (sidecar && !metadata) recordError("raw-sidecar-metadata-missing", rawPath, "Raw sidecar has no metadata object.");
+  if (sidecar && !payload) recordError("raw-sidecar-payload-missing", rawPath, "Raw sidecar has no raw provider payload.");
 
   const sections = report ? reportSections(report) : {};
   for (const section of requiredReportSections) {
-    if (report && !(section in sections)) errors.push(`Report is missing required section: ## ${section}`);
+    if (report && !(section in sections)) recordError("report-section-missing", section, `Report is missing required section: ## ${section}`);
   }
 
   if (metadata) {
     if (Array.isArray(metadata.additionalQueries)) {
       const expected = 1 + metadata.additionalQueries.length;
-      if (metadata.queryCount !== expected) errors.push(`metadata.queryCount is ${metadata.queryCount} but 1 primary + ${metadata.additionalQueries.length} additional queries were recorded (expected ${expected}).`);
-      if (!additionalQueriesAppliedValues.has(metadata.additionalQueriesApplied)) errors.push(`metadata.additionalQueriesApplied is ${JSON.stringify(metadata.additionalQueriesApplied)}; expected one of: ${Array.from(additionalQueriesAppliedValues).join(", ")}.`);
-      else if ((metadata.additionalQueriesApplied === "none") !== (metadata.additionalQueries.length === 0)) errors.push("metadata.additionalQueriesApplied contradicts metadata.additionalQueries.");
-    } else warnings.push("Sidecar does not record how additional queries were applied (metadata.additionalQueries missing — sidecar predates this check or was produced by another tool). Re-run with the current script to verify query expansion.");
+      if (metadata.queryCount !== expected) recordError("query-count-mismatch", metadata.queryCount, `metadata.queryCount is ${metadata.queryCount} but 1 primary + ${metadata.additionalQueries.length} additional queries were recorded (expected ${expected}).`, { expected });
+      if (!additionalQueriesAppliedValues.has(metadata.additionalQueriesApplied)) recordError("additional-queries-applied-invalid", metadata.additionalQueriesApplied, `metadata.additionalQueriesApplied is ${JSON.stringify(metadata.additionalQueriesApplied)}; expected one of: ${Array.from(additionalQueriesAppliedValues).join(", ")}.`);
+      else if ((metadata.additionalQueriesApplied === "none") !== (metadata.additionalQueries.length === 0)) recordError("additional-queries-applied-conflict", metadata.additionalQueriesApplied, "metadata.additionalQueriesApplied contradicts metadata.additionalQueries.");
+    } else recordWarning("additional-queries-metadata-missing", rawPath, "Sidecar does not record how additional queries were applied (metadata.additionalQueries missing — sidecar predates this check or was produced by another tool). Re-run with the current script to verify query expansion.");
   }
 
   const synthesis = payload ? hasSynthesis(payload) : false;
-  if (metadata && typeof metadata.synthesis === "boolean" && metadata.synthesis !== synthesis) warnings.push(`metadata.synthesis is ${metadata.synthesis} but the raw payload ${synthesis ? "contains" : "lacks"} a synthesized answer.`);
+  if (metadata && typeof metadata.synthesis === "boolean" && metadata.synthesis !== synthesis) recordWarning("synthesis-metadata-mismatch", metadata.synthesis, `metadata.synthesis is ${metadata.synthesis} but the raw payload ${synthesis ? "contains" : "lacks"} a synthesized answer.`, { actual: synthesis });
   if (payload && !synthesis) {
     const mode = metadata?.researchMode;
-    if (mode === "standard" || mode === "full") errors.push(`Mode ${mode} requests server-side synthesis (outputSchema) but the raw payload has no synthesized answer. Re-run, or treat the report as an evidence brief only.`);
-    else warnings.push("No synthesized answer in the raw payload — this is an evidence brief. Do not use it as a decision recommendation; re-run with --mode standard or --mode full if the deliverable is a recommendation.");
+    if (mode === "standard" || mode === "full") recordError("synthesis-missing", mode, `Mode ${mode} requests server-side synthesis (outputSchema) but the raw payload has no synthesized answer. Re-run, or treat the report as an evidence brief only.`);
+    else recordWarning("synthesis-missing", mode, "No synthesized answer in the raw payload — this is an evidence brief. Do not use it as a decision recommendation; re-run with --mode standard or --mode full if the deliverable is a recommendation.");
   }
-  if (payload && !normalizeResults(payload).length) warnings.push("Raw payload contains zero sources. Re-run with broader terms or fewer filters.");
+  if (payload && !normalizeResults(payload).length) recordWarning("sources-empty", 0, "Raw payload contains zero sources. Re-run with broader terms or fewer filters.");
 
   const summarySection = normalizedProse(sections["Executive Summary"]);
   const findingsSection = normalizedProse(sections["Key Findings"]);
   if (summarySection && findingsSection) {
     const [shorter, longer] = summarySection.length <= findingsSection.length ? [summarySection, findingsSection] : [findingsSection, summarySection];
-    if (summarySection === findingsSection || (shorter.length > 200 && longer.includes(shorter))) warnings.push("Key Findings duplicates the Executive Summary text. Regenerate, or rewrite Key Findings as distinct claims.");
+    if (summarySection === findingsSection || (shorter.length > 200 && longer.includes(shorter))) recordWarning("report-sections-duplicate", "Executive Summary+Key Findings", "Key Findings duplicates the Executive Summary text. Regenerate, or rewrite Key Findings as distinct claims.");
   }
 
   const sidecarRef = report.match(/Raw metadata sidecar:\s*(\S+)/);
   if (sidecarRef) {
     const referenced = stripMarkdownPathDelimiters(sidecarRef[1]);
-    if (resolve(referenced) !== rawPath) warnings.push(`Report references sidecar ${referenced} but ${rawPath} was validated.`);
+    if (resolve(referenced) !== rawPath) recordWarning("sidecar-reference-mismatch", referenced, `Report references sidecar ${referenced} but ${rawPath} was validated.`, { validated: rawPath });
   }
 
   const ok = errors.length === 0;
-  jsonOut(process.stdout, { ok, report: reportPath, raw: rawPath, mode: metadata?.researchMode, synthesis, queryCount: metadata?.queryCount, errors, warnings });
+  jsonOut(process.stdout, { ok, report: reportPath, raw: rawPath, mode: metadata?.researchMode, synthesis, queryCount: metadata?.queryCount, errors, warnings, problems });
   process.exit(ok ? 0 : 1);
 }
 
@@ -513,7 +525,7 @@ async function main() {
     return;
   }
   if (options.command === "validate") { await validateCommand(options); return; }
-  if (options.command !== "report" && options.command !== "json") fail(`Unknown command: ${options.command}`);
+  if (options.command !== "report" && options.command !== "json") fail("command-unknown", options.command, `Unknown command: ${options.command}`);
   const query = await resolveQuery(options);
   const { raw, metadata } = await callExa(query, options);
   const format = options.command === "json" ? "json" : options.format;
@@ -526,4 +538,4 @@ async function main() {
   jsonOut(process.stdout, { ok: true, output, rawOutput: rawOutput ? resolve(rawOutput) : undefined, mode: metadata.researchMode, queryCount: metadata.queryCount, sources: normalizeResults(raw).length, uniqueSources: metadata.uniqueSourceCount });
 }
 
-main().catch((error) => fail(error?.message || String(error)));
+main().catch((error) => fail("unexpected-error", error?.name || "Error", error?.message || String(error)));

--- a/skills/deep-research/tests/deep-research.test.mjs
+++ b/skills/deep-research/tests/deep-research.test.mjs
@@ -25,6 +25,21 @@ function hasProblem(result, level, key, value) {
   return problems.some((problem) => problem.key === key && problem.value === value);
 }
 
+function completeReport() {
+  return [
+    "# Findings: q",
+    "## Research Question", "q",
+    "## Executive Summary", "Summary",
+    "## Key Findings", "Finding",
+    "## Evidence and Sources", "- [1] Source — https://example.com",
+    "## Tradeoffs / Alternatives", "Tradeoff",
+    "## Recommendation / Decision Criteria", "Recommendation",
+    "## Risks / Unknowns", "Risk",
+    "## Revisit Conditions", "Condition",
+    "## Research Metadata", "- Mode: lite",
+  ].join("\n\n");
+}
+
 test("doctor reports runtime status", () => {
   const result = spawnSync(process.execPath, [script, "doctor"], { encoding: "utf8" });
   assert.equal(result.status, 0);
@@ -186,6 +201,50 @@ test("large refusal JSON is complete before exit", () => {
   const parsed = diagnostic(result);
   assert.equal(parsed.key, "command-unknown");
   assert.equal(parsed.value, command);
+});
+
+test("every command refusal keeps its stable key and value", () => {
+  const dir = mkdtempSync(join(tmpdir(), "deep-research-refusals-"));
+  const bin = join(dir, "bin");
+  mkdirSync(bin);
+  writeFileSync(join(bin, "op"), "#!/usr/bin/env bash\nexit 1\n");
+  chmodSync(join(bin, "op"), 0o755);
+  for (let index = 0; index < 26; index += 1) writeFileSync(join(dir, `context-${index}.md`), "context");
+
+  const noSecrets = { ...process.env };
+  delete noSecrets.EXA_API_KEY;
+  delete noSecrets.EXA_MOCK_RESPONSE_FILE;
+
+  const noFetch = join(dir, "no-fetch.mjs");
+  writeFileSync(noFetch, "globalThis.fetch = undefined;\n");
+  const failedFetch = join(dir, "failed-fetch.mjs");
+  writeFileSync(failedFetch, "globalThis.fetch = async () => ({ ok: false, status: 503, statusText: 'unavailable', text: async () => 'unavailable' });\n");
+  const invalidMock = join(dir, "invalid.json");
+  writeFileSync(invalidMock, "{");
+
+  const additionalQueries = Array.from({ length: 11 }, () => ["--additional-query", "variant"]).flat();
+  const cases = [
+    { args: ["report", "q", "--output"], key: "argument-value-missing", value: "--output" },
+    { args: ["report", "q", "--unknown"], key: "argument-unknown", value: "--unknown" },
+    { args: ["report", "q", "--context-glob", "a*b*c"], key: "context-glob-invalid", value: "a*b*c", cwd: dir },
+    { args: ["report", "q", "--context-glob", "context-*.md"], key: "context-glob-limit", value: 26, cwd: dir },
+    { args: ["report", "q", "--type", "unknown"], key: "type-invalid", value: "unknown" },
+    { args: ["report", "q", "--format", "unknown"], key: "format-invalid", value: "unknown" },
+    { args: ["report", "q", ...additionalQueries], key: "additional-query-limit", value: 11 },
+    { args: ["report"], key: "query-missing", value: "query-or-file" },
+    { args: ["validate"], key: "argument-missing", value: "report+raw" },
+    { args: ["report", "q"], key: "secret-reference-unresolved", value: "EXA_API_KEY", env: { ...noSecrets, EXA_API_KEY: "op://vault/exa/key", PATH: `${bin}:${process.env.PATH}` } },
+    { args: ["report", "q"], key: "runtime-fetch-missing", value: process.version, env: { ...noSecrets, NODE_OPTIONS: `--import=${noFetch}` } },
+    { args: ["report", "q"], key: "exa-request-failed", value: 503, env: { ...noSecrets, EXA_API_KEY: "key", NODE_OPTIONS: `--import=${failedFetch}` } },
+    { args: ["report", "q"], key: "unexpected-error", value: "SyntaxError", env: { ...noSecrets, EXA_MOCK_RESPONSE_FILE: invalidMock } },
+  ];
+
+  for (const row of cases) {
+    const result = spawnSync(process.execPath, [script, ...row.args], { encoding: "utf8", cwd: row.cwd, env: row.env ?? noSecrets });
+    const parsed = diagnostic(result);
+    assert.equal(parsed.key, row.key, row.key);
+    assert.equal(parsed.value, row.value, row.key);
+  }
 });
 
 test("full mode aggregates multiple mock responses and dedupes URLs", () => {
@@ -357,6 +416,35 @@ test("validate warns when Key Findings duplicates the Executive Summary", () => 
   assert.equal(result.status, 0, result.stderr);
   const json = JSON.parse(result.stdout);
   assert.equal(hasProblem(json, "warning", "report-sections-duplicate", "Executive Summary+Key Findings"), true);
+});
+
+test("every validation problem keeps its stable key and value", () => {
+  const validSidecar = {
+    metadata: { researchMode: "lite", queryCount: 1, additionalQueries: [], additionalQueriesApplied: "none", synthesis: true },
+    raw: { answer: "Answer", results: [{ url: "https://example.com" }] },
+  };
+  const cases = [
+    { key: "report-empty", level: "error", status: 1, value: "report", report: "" },
+    { key: "raw-sidecar-invalid-json", level: "error", status: 1, value: "raw", rawText: "{" },
+    { key: "raw-sidecar-metadata-missing", level: "error", status: 1, value: "raw", sidecar: { raw: validSidecar.raw } },
+    { key: "raw-sidecar-payload-missing", level: "error", status: 1, value: "raw", sidecar: { metadata: validSidecar.metadata } },
+    { key: "additional-queries-applied-conflict", level: "error", status: 1, value: "none", sidecar: { ...validSidecar, metadata: { ...validSidecar.metadata, queryCount: 2, additionalQueries: ["variant"] } } },
+    { key: "additional-queries-metadata-missing", level: "warning", status: 0, value: "raw", sidecar: { ...validSidecar, metadata: { researchMode: "lite", queryCount: 1, additionalQueriesApplied: "none", synthesis: true } } },
+    { key: "synthesis-metadata-mismatch", level: "warning", status: 0, value: false, sidecar: { ...validSidecar, metadata: { ...validSidecar.metadata, synthesis: false } } },
+    { key: "sources-empty", level: "warning", status: 0, value: 0, sidecar: { ...validSidecar, raw: { answer: "Answer", results: [] } } },
+  ];
+
+  for (const row of cases) {
+    const dir = mkdtempSync(join(tmpdir(), `deep-research-${row.key}-`));
+    const report = join(dir, "findings.md");
+    const raw = join(dir, "findings.raw.json");
+    writeFileSync(report, row.report ?? completeReport());
+    writeFileSync(raw, row.rawText ?? JSON.stringify(row.sidecar ?? validSidecar));
+    const result = spawnSync(process.execPath, [script, "validate", report, raw], { encoding: "utf8" });
+    assert.equal(result.status, row.status, row.key);
+    const expectedValue = row.value === "report" ? report : row.value === "raw" ? raw : row.value;
+    assert.equal(hasProblem(JSON.parse(result.stdout), row.level, row.key, expectedValue), true, row.key);
+  }
 });
 
 // The loader reads .env.local only — the .env fallback is removed — and an

--- a/skills/deep-research/tests/deep-research.test.mjs
+++ b/skills/deep-research/tests/deep-research.test.mjs
@@ -8,6 +8,7 @@ import test from "node:test";
 const script = new URL("../scripts/deep-research", import.meta.url).pathname;
 
 function diagnostic(result) {
+  assert.equal(result.status, 1);
   const parsed = JSON.parse(result.stderr.trim().split(/\r?\n/, 1)[0]);
   assert.equal(parsed.ok, false);
   assert.equal(typeof parsed.error, "string");
@@ -16,7 +17,12 @@ function diagnostic(result) {
 }
 
 function hasProblem(result, level, key, value) {
-  return result.problems.some((problem) => problem.level === level && problem.key === key && problem.value === value);
+  const problems = result.problems.filter((problem) => problem.level === level);
+  const legacy = result[`${level}s`];
+  assert.equal(Array.isArray(legacy), true);
+  assert.equal(legacy.length, problems.length);
+  assert.equal(legacy.every((message) => typeof message === "string" && message.length > 0), true);
+  return problems.some((problem) => problem.key === key && problem.value === value);
 }
 
 test("doctor reports runtime status", () => {

--- a/skills/deep-research/tests/deep-research.test.mjs
+++ b/skills/deep-research/tests/deep-research.test.mjs
@@ -8,7 +8,11 @@ import test from "node:test";
 const script = new URL("../scripts/deep-research", import.meta.url).pathname;
 
 function diagnostic(result) {
-  return JSON.parse(result.stderr.trim().split(/\r?\n/, 1)[0]);
+  const parsed = JSON.parse(result.stderr.trim().split(/\r?\n/, 1)[0]);
+  assert.equal(parsed.ok, false);
+  assert.equal(typeof parsed.error, "string");
+  assert.notEqual(parsed.error.length, 0);
+  return parsed;
 }
 
 function hasProblem(result, level, key, value) {
@@ -290,6 +294,12 @@ test("validate errors when standard mode lacks synthesis and flags evidence-brie
   const liteJson = JSON.parse(liteValidate.stdout);
   assert.equal(liteJson.ok, true);
   assert.equal(hasProblem(liteJson, "warning", "synthesis-missing", "lite"), true);
+  const unknownModeSidecar = JSON.parse(readFileSync(raw, "utf8"));
+  delete unknownModeSidecar.metadata.researchMode;
+  writeFileSync(raw, JSON.stringify(unknownModeSidecar));
+  const unknownModeValidate = spawnSync(process.execPath, [script, "validate", output, raw], { encoding: "utf8" });
+  assert.equal(unknownModeValidate.status, 0, unknownModeValidate.stderr);
+  assert.equal(hasProblem(JSON.parse(unknownModeValidate.stdout), "warning", "synthesis-missing", null), true);
 });
 
 test("validate errors on queryCount mismatch and missing files", () => {
@@ -306,6 +316,14 @@ test("validate errors on queryCount mismatch and missing files", () => {
   const mismatch = spawnSync(process.execPath, [script, "validate", output, raw], { encoding: "utf8" });
   assert.equal(mismatch.status, 1);
   assert.equal(hasProblem(JSON.parse(mismatch.stdout), "error", "query-count-mismatch", 5), true);
+  delete sidecar.metadata.queryCount;
+  delete sidecar.metadata.additionalQueriesApplied;
+  writeFileSync(raw, JSON.stringify(sidecar));
+  const omitted = spawnSync(process.execPath, [script, "validate", output, raw], { encoding: "utf8" });
+  assert.equal(omitted.status, 1);
+  const omittedJson = JSON.parse(omitted.stdout);
+  assert.equal(hasProblem(omittedJson, "error", "query-count-mismatch", null), true);
+  assert.equal(hasProblem(omittedJson, "error", "additional-queries-applied-invalid", null), true);
   const missing = spawnSync(process.execPath, [script, "validate", join(dir, "nope.md"), join(dir, "nope.json")], { encoding: "utf8" });
   assert.equal(missing.status, 1);
   const missingJson = JSON.parse(missing.stdout);

--- a/skills/deep-research/tests/deep-research.test.mjs
+++ b/skills/deep-research/tests/deep-research.test.mjs
@@ -180,6 +180,14 @@ test("invalid mode fails clearly", () => {
   assert.equal(diagnostic(result).value, "slow");
 });
 
+test("large refusal JSON is complete before exit", () => {
+  const command = "x".repeat(96 * 1024);
+  const result = spawnSync(process.execPath, [script, command], { encoding: "utf8" });
+  const parsed = diagnostic(result);
+  assert.equal(parsed.key, "command-unknown");
+  assert.equal(parsed.value, command);
+});
+
 test("full mode aggregates multiple mock responses and dedupes URLs", () => {
   const dir = mkdtempSync(join(tmpdir(), "deep-research-full-"));
   const mock = join(dir, "mock.json");

--- a/skills/deep-research/tests/deep-research.test.mjs
+++ b/skills/deep-research/tests/deep-research.test.mjs
@@ -7,6 +7,14 @@ import test from "node:test";
 
 const script = new URL("../scripts/deep-research", import.meta.url).pathname;
 
+function diagnostic(result) {
+  return JSON.parse(result.stderr.trim().split(/\r?\n/, 1)[0]);
+}
+
+function hasProblem(result, level, key, value) {
+  return result.problems.some((problem) => problem.level === level && problem.key === key && problem.value === value);
+}
+
 test("doctor reports runtime status", () => {
   const result = spawnSync(process.execPath, [script, "doctor"], { encoding: "utf8" });
   assert.equal(result.status, 0);
@@ -36,10 +44,12 @@ test("out-of-range num-results and text-max-characters fail with Exa limits", ()
   const env = { ...process.env, EXA_MOCK_RESPONSE_FILE: mock };
   const tooMany = spawnSync(process.execPath, [script, "report", "q", "--num-results", "150"], { encoding: "utf8", env });
   assert.notEqual(tooMany.status, 0);
-  assert.match(tooMany.stderr, /Invalid --num-results 150.*1-100/);
+  assert.equal(diagnostic(tooMany).key, "num-results-invalid");
+  assert.equal(diagnostic(tooMany).value, "150");
   const tooLong = spawnSync(process.execPath, [script, "report", "q", "--text-max-characters", "16000"], { encoding: "utf8", env });
   assert.notEqual(tooLong.status, 0);
-  assert.match(tooLong.stderr, /Invalid --text-max-characters 16000.*1-10000/);
+  assert.equal(diagnostic(tooLong).key, "text-max-characters-invalid");
+  assert.equal(diagnostic(tooLong).value, "16000");
 });
 
 // The template and the validator's required-section list must not drift apart:
@@ -65,7 +75,7 @@ test("findings template carries every section validate requires", () => {
   writeFileSync(gutted, filled.replace("## Risks / Unknowns", "## Unrelated Heading"));
   const caught = spawnSync(process.execPath, [script, "validate", gutted, raw], { encoding: "utf8" });
   assert.notEqual(caught.status, 0);
-  assert.ok(JSON.parse(caught.stdout).errors.some((e) => /Risks \/ Unknowns/.test(e)));
+  assert.equal(hasProblem(JSON.parse(caught.stdout), "error", "report-section-missing", "Risks / Unknowns"), true);
 });
 
 test("invalid --timeout names the flag rather than aborting the request", () => {
@@ -76,7 +86,8 @@ test("invalid --timeout names the flag rather than aborting the request", () => 
   for (const bad of ["abc", "0", "1.5"]) {
     const result = spawnSync(process.execPath, [script, "report", "q", "--timeout", bad], { encoding: "utf8", env });
     assert.notEqual(result.status, 0);
-    assert.match(result.stderr, /Invalid --timeout/);
+    assert.equal(diagnostic(result).key, "timeout-invalid");
+    assert.equal(diagnostic(result).value, bad);
   }
 });
 
@@ -87,7 +98,8 @@ test("missing key fails with setup instructions", () => {
   const cwd = mkdtempSync(join(tmpdir(), "deep-research-no-env-"));
   const result = spawnSync(process.execPath, [script, "report", "question"], { encoding: "utf8", env, cwd });
   assert.notEqual(result.status, 0);
-  assert.match(result.stderr, /EXA_API_KEY/);
+  assert.equal(diagnostic(result).key, "credential-missing");
+  assert.equal(diagnostic(result).value, "EXA_API_KEY");
 });
 
 test("mocked report writes findings and raw output", () => {
@@ -154,7 +166,8 @@ test("invalid mode fails clearly", () => {
   writeFileSync(mock, JSON.stringify({ answer: "Answer", results: [] }));
   const result = spawnSync(process.execPath, [script, "report", "question", "--mode", "slow"], { encoding: "utf8", env: { ...process.env, EXA_MOCK_RESPONSE_FILE: mock } });
   assert.notEqual(result.status, 0);
-  assert.match(result.stderr, /Invalid --mode slow/);
+  assert.equal(diagnostic(result).key, "mode-invalid");
+  assert.equal(diagnostic(result).value, "slow");
 });
 
 test("full mode aggregates multiple mock responses and dedupes URLs", () => {
@@ -249,12 +262,12 @@ test("validate ignores Markdown backticks around a report-referenced sidecar pat
   writeFileSync(output, readFileSync(output, "utf8").replace(/- Raw metadata sidecar: .*/, "- Raw metadata sidecar: `" + raw + "`"));
   const okJson = JSON.parse(spawnSync(process.execPath, [script, "validate", output, raw], { encoding: "utf8" }).stdout);
   assert.equal(okJson.ok, true);
-  assert.ok(!okJson.warnings.some((w) => w.startsWith("Report references sidecar")), `unexpected sidecar warning: ${JSON.stringify(okJson.warnings)}`);
+  assert.equal(okJson.problems.some((problem) => problem.key === "sidecar-reference-mismatch"), false);
 
   // A genuinely-different (still backticked) path must still warn — the fix must not over-suppress.
   writeFileSync(output, readFileSync(output, "utf8").replace(/- Raw metadata sidecar: .*/, "- Raw metadata sidecar: `" + join(dir, "other.raw.json") + "`"));
   const mismatchJson = JSON.parse(spawnSync(process.execPath, [script, "validate", output, raw], { encoding: "utf8" }).stdout);
-  assert.ok(mismatchJson.warnings.some((w) => w.startsWith("Report references sidecar")), `expected a sidecar mismatch warning: ${JSON.stringify(mismatchJson.warnings)}`);
+  assert.equal(hasProblem(mismatchJson, "warning", "sidecar-reference-mismatch", join(dir, "other.raw.json")), true);
 });
 
 test("validate errors when standard mode lacks synthesis and flags evidence-brief lite", () => {
@@ -269,14 +282,14 @@ test("validate errors when standard mode lacks synthesis and flags evidence-brie
   assert.equal(standardValidate.status, 1);
   const standardJson = JSON.parse(standardValidate.stdout);
   assert.equal(standardJson.ok, false);
-  assert.ok(standardJson.errors.some((e) => /Mode standard requests server-side synthesis/.test(e)));
+  assert.equal(hasProblem(standardJson, "error", "synthesis-missing", "standard"), true);
   const lite = spawnSync(process.execPath, [script, "report", "question", "--mode", "lite", "--output", output], { encoding: "utf8", env: { ...process.env, EXA_MOCK_RESPONSE_FILE: mock } });
   assert.equal(lite.status, 0, lite.stderr);
   const liteValidate = spawnSync(process.execPath, [script, "validate", output, raw], { encoding: "utf8" });
   assert.equal(liteValidate.status, 0, liteValidate.stderr);
   const liteJson = JSON.parse(liteValidate.stdout);
   assert.equal(liteJson.ok, true);
-  assert.ok(liteJson.warnings.some((w) => /evidence brief/.test(w)));
+  assert.equal(hasProblem(liteJson, "warning", "synthesis-missing", "lite"), true);
 });
 
 test("validate errors on queryCount mismatch and missing files", () => {
@@ -292,12 +305,12 @@ test("validate errors on queryCount mismatch and missing files", () => {
   writeFileSync(raw, JSON.stringify(sidecar));
   const mismatch = spawnSync(process.execPath, [script, "validate", output, raw], { encoding: "utf8" });
   assert.equal(mismatch.status, 1);
-  assert.ok(JSON.parse(mismatch.stdout).errors.some((e) => /queryCount is 5/.test(e)));
+  assert.equal(hasProblem(JSON.parse(mismatch.stdout), "error", "query-count-mismatch", 5), true);
   const missing = spawnSync(process.execPath, [script, "validate", join(dir, "nope.md"), join(dir, "nope.json")], { encoding: "utf8" });
   assert.equal(missing.status, 1);
   const missingJson = JSON.parse(missing.stdout);
-  assert.ok(missingJson.errors.some((e) => /Report not found/.test(e)));
-  assert.ok(missingJson.errors.some((e) => /Raw sidecar not found/.test(e)));
+  assert.equal(hasProblem(missingJson, "error", "report-not-found", join(dir, "nope.md")), true);
+  assert.equal(hasProblem(missingJson, "error", "raw-sidecar-not-found", join(dir, "nope.json")), true);
 });
 
 test("validate warns when Key Findings duplicates the Executive Summary", () => {
@@ -311,7 +324,7 @@ test("validate warns when Key Findings duplicates the Executive Summary", () => 
   const result = spawnSync(process.execPath, [script, "validate", report, raw], { encoding: "utf8" });
   assert.equal(result.status, 0, result.stderr);
   const json = JSON.parse(result.stdout);
-  assert.ok(json.warnings.some((w) => /duplicates the Executive Summary/.test(w)));
+  assert.equal(hasProblem(json, "warning", "report-sections-duplicate", "Executive Summary+Key Findings"), true);
 });
 
 // The loader reads .env.local only — the .env fallback is removed — and an
@@ -336,7 +349,8 @@ test("a key present only in .env is ignored; .env.local and process env keep the
   writeFileSync(join(dir, ".env"), `EXA_MOCK_RESPONSE_FILE=${dotenvMock}\nEXA_API_KEY=from-dotenv\n`);
   const ignored = spawnSync(process.execPath, [script, "report", "q"], { encoding: "utf8", env, cwd: dir });
   assert.notEqual(ignored.status, 0);
-  assert.match(ignored.stderr, /EXA_API_KEY is required/);
+  assert.equal(diagnostic(ignored).key, "credential-missing");
+  assert.equal(diagnostic(ignored).value, "EXA_API_KEY");
 
   // .env.local supplies the value when the process does not carry the key.
   const localOut = join(dir, "local.md");
@@ -364,7 +378,8 @@ test("a key present only in .env is ignored; .env.local and process env keep the
     cwd: dir,
   });
   assert.notEqual(emptied.status, 0);
-  assert.match(emptied.stderr, /EXA_API_KEY is required/);
+  assert.equal(diagnostic(emptied).key, "credential-missing");
+  assert.equal(diagnostic(emptied).value, "EXA_API_KEY");
 
   // Within the file itself, dotenv last-wins: a repeated key's LATER line
   // replaces the earlier one — the first assignment must not block its own


### PR DESCRIPTION
## Summary

- Add stable key/value fields to Deep Research command failures.
- Add stable problem objects to validation results while preserving the existing errors and warnings arrays.
- Replace English test pins with key, value, and exit-status assertions.
- Preserve source and tracked-render copies in the same change.

## Changed files

- `scripts/deep-research`
- `tests/deep-research.test.mjs`
- The matching `.agents/skills/deep-research` renders.

## Compliant files left unchanged

- `SKILL.md`
- `README.md`
- `templates/findings.md`
- The matching tracked renders.

## Validation

- The Deep Research package suite passes on `3841f49c38f88adce740aff88c6930f8d3998322`.
- Command and validation failures provide the must-fail controls.
- `env -u TMPDIR tools/guard --full` passes on that head.

Linear: KEN-1241
