### PR TITLE
fix(KEN-1241): stabilize reviewer diagnostics

### DIFF
--- a/.agents/skills/reviewer/scripts/mutation-stability
+++ b/.agents/skills/reviewer/scripts/mutation-stability
@@ -51,6 +51,13 @@ refuse() {
   exit 2
 }
 
+refuse_with_log() {
+  key="$1" field="$2" value="$3" text="$4" log="$5"
+  message error "$key" "$field" "$value" "$text"
+  [ ! -s "$log" ] || cat -- "$log" >&2
+  exit 2
+}
+
 notice() {
   message notice "$1" "$2" "$3" "$4"
 }
@@ -112,8 +119,15 @@ fi
 [ "$SETTLE" -ne 0 ] ||
   notice settle-disabled value "$SETTLE" "copies are not mtime-separated; verdicts assume BUILD shares no cache"
 
-ROOT=$(mktemp -d "${TMPDIR:-/tmp}/mutation-stability.XXXXXX") ||
-  refuse temp-create-failed path "${TMPDIR:-/tmp}" "could not create the mutation workspace"
+root_result=""
+root_status=0
+root_result=$(mktemp -d "${TMPDIR:-/tmp}/mutation-stability.XXXXXX" 2>&1) || root_status=$?
+if [ "$root_status" -ne 0 ]; then
+  message error temp-create-failed path "${TMPDIR:-/tmp}" "could not create the mutation workspace"
+  [ -z "$root_result" ] || printf '%s\n' "$root_result" >&2
+  exit 2
+fi
+ROOT="$root_result"
 ACTIVE_PID="" ACTIVE_GROUP=""
 
 group_leaves() {
@@ -272,7 +286,11 @@ cargo_selection_nonempty() {
   ' "$1"
 }
 
-extract "$ROOT/mutant" || refuse archive-failed sha "$SHA" "control archive failed"
+extract_status=0
+extract "$ROOT/mutant" >"$ROOT/control-archive.log" 2>&1 || extract_status=$?
+if [ "$extract_status" -ne 0 ]; then
+  refuse_with_log archive-failed sha "$SHA" "control archive failed" "$ROOT/control-archive.log"
+fi
 
 control_build_status=0
 run_command "$ROOT/mutant" "$BUILD" "$ROOT/control-build.log" "control build" || control_build_status=$?
@@ -299,7 +317,11 @@ if [ "$selection_status" = 1 ]; then
 fi
 
 outrank_last_build
-(cd "$ROOT/mutant" && bash -c "$MUTATE") || refuse mutate-command-failed exit "$?" "mutate command failed"
+mutate_status=0
+(cd "$ROOT/mutant" && bash -c "$MUTATE") >"$ROOT/mutate.log" 2>&1 || mutate_status=$?
+if [ "$mutate_status" -ne 0 ]; then
+  refuse_with_log mutate-command-failed exit "$mutate_status" "mutate command failed" "$ROOT/mutate.log"
+fi
 
 build_status=0
 run_command "$ROOT/mutant" "$BUILD" "$ROOT/build.log" "mutant build" || build_status=$?
@@ -315,7 +337,11 @@ KILLED=1
 [ "$mutant_status" -ne 0 ] || KILLED=0
 
 PASSES=0
-extract "$ROOT/clean" || refuse archive-failed sha "$SHA" "clean archive failed"
+extract_status=0
+extract "$ROOT/clean" >"$ROOT/clean-archive.log" 2>&1 || extract_status=$?
+if [ "$extract_status" -ne 0 ]; then
+  refuse_with_log archive-failed sha "$SHA" "clean archive failed" "$ROOT/clean-archive.log"
+fi
 i=0
 while [ "$i" -lt "$N" ]; do
   if run_test "$ROOT/clean" "$ROOT/stability-$i.log"; then PASSES=$((PASSES + 1)); fi

--- a/.agents/skills/reviewer/scripts/mutation-stability
+++ b/.agents/skills/reviewer/scripts/mutation-stability
@@ -42,7 +42,7 @@ USAGE
 
 message() {
   level="$1" key="$2" field="$3" value="$4" text="$5"
-  printf '%s=%s %s=%s\n' "$level" "$key" "$field" "$value" >&2
+  printf '%s=%s %s=%q\n' "$level" "$key" "$field" "$value" >&2
   printf '%s\n' "$text" >&2
 }
 

--- a/.agents/skills/reviewer/scripts/mutation-stability
+++ b/.agents/skills/reviewer/scripts/mutation-stability
@@ -9,6 +9,10 @@
 #
 #   mutation: killed 1/1; stability: N/N at T threads
 #
+# Diagnostic protocol: each refusal starts with error=KEY FIELD=VALUE, and each
+# notice starts with notice=KEY FIELD=VALUE. English detail follows. The final
+# mutation/stability summary above is the downstream result protocol.
+#
 # Exit: 0 killed and stable; 1 mutant survived or a stability run failed;
 # 2 instrument failure (control, empty selection, invalid mutant, timed-out run,
 # bad input).
@@ -36,12 +40,27 @@ usage: mutation-stability --worktree PATH --sha SHA --test CMD --build CMD
 USAGE
 }
 
+message() {
+  level="$1" key="$2" field="$3" value="$4" text="$5"
+  printf '%s=%s %s=%s\n' "$level" "$key" "$field" "$value" >&2
+  printf '%s\n' "$text" >&2
+}
+
+refuse() {
+  message error "$1" "$2" "$3" "$4"
+  exit 2
+}
+
+notice() {
+  message notice "$1" "$2" "$3" "$4"
+}
+
 WORKTREE="" SHA="" TEST="" BUILD="" MUTATE="" N=10 THREADS="" TIMEOUT=300 KEEP=0
 THREADS_SET=0
 while [ $# -gt 0 ]; do
   case "$1" in
     --worktree|--sha|--test|--build|--mutate|--stability|--threads|--timeout)
-      [ $# -ge 2 ] || { echo "$1 needs a value" >&2; usage >&2; exit 2; }
+      [ $# -ge 2 ] || { option="$1"; message error argument-value-missing option "$option" "$option needs a value"; usage >&2; exit 2; }
       case "$1" in
         --worktree) WORKTREE="$2" ;;
         --sha) SHA="$2" ;;
@@ -55,17 +74,19 @@ while [ $# -gt 0 ]; do
       shift ;;
     --keep) KEEP=1 ;;
     -h|--help) usage; exit 0 ;;
-    *) echo "unknown argument: $1" >&2; usage >&2; exit 2 ;;
+    *) argument="$1"; message error argument-unknown argument "$argument" "unknown argument: $argument"; usage >&2; exit 2 ;;
   esac
   shift
 done
 [ -n "$WORKTREE" ] && [ -n "$SHA" ] && [ -n "$TEST" ] && [ -n "$BUILD" ] && [ -n "$MUTATE" ] || {
-  usage >&2; exit 2
+  message error arguments-missing set worktree-sha-test-build-mutate "required options are missing"
+  usage >&2
+  exit 2
 }
 positive_integer() {
   option="$1" value="$2"
   case "$value" in
-    *[!0-9]*|''|0) echo "$option wants a positive integer" >&2; exit 2 ;;
+    *[!0-9]*|''|0) refuse positive-integer-invalid option "$option:$value" "$option wants a positive integer" ;;
   esac
 }
 
@@ -81,8 +102,7 @@ positive_integer --timeout "$TIMEOUT"
 # out the run on the first write to a copy.
 SETTLE="${MUTATION_STABILITY_SETTLE:-1}"
 if ! [[ "$SETTLE" =~ ^[0-9]{1,18}$ ]]; then
-  echo "MUTATION_STABILITY_SETTLE wants a whole number of seconds" >&2
-  exit 2
+  refuse settle-invalid value "$SETTLE" "MUTATION_STABILITY_SETTLE wants a whole number of seconds"
 fi
 # The precondition for skipping the boundary — that BUILD keeps no cache the
 # copies could share — is the caller's to know and this script cannot check
@@ -90,9 +110,10 @@ fi
 # as survived, and nothing about that verdict looks wrong afterwards. Say it
 # once, so a transcript shows which verdicts were produced without it.
 [ "$SETTLE" -ne 0 ] ||
-  echo "settle: 0 — copies are not mtime-separated; verdicts assume BUILD shares no cache" >&2
+  notice settle-disabled value "$SETTLE" "copies are not mtime-separated; verdicts assume BUILD shares no cache"
 
-ROOT=$(mktemp -d "${TMPDIR:-/tmp}/mutation-stability.XXXXXX") || exit 2
+ROOT=$(mktemp -d "${TMPDIR:-/tmp}/mutation-stability.XXXXXX") ||
+  refuse temp-create-failed path "${TMPDIR:-/tmp}" "could not create the mutation workspace"
 ACTIVE_PID="" ACTIVE_GROUP=""
 
 group_leaves() {
@@ -223,8 +244,8 @@ run_command() { # run $2 in $1, capture output in $3, label it $4
   ACTIVE_PID="" ACTIVE_GROUP=""
 
   if [ "$timed_out" -eq 1 ]; then
-    echo "$label timed out after ${TIMEOUT}s" >&2
-    [ "$KEEP" = 1 ] && echo "kept: $ROOT" >&2
+    message error command-timeout seconds "$TIMEOUT" "$label timed out after ${TIMEOUT}s"
+    [ "$KEEP" = 1 ] && notice workspace-kept path "$ROOT" "kept mutation workspace: $ROOT"
     exit 2
   fi
   return "$status"
@@ -251,40 +272,40 @@ cargo_selection_nonempty() {
   ' "$1"
 }
 
-extract "$ROOT/mutant" || { echo "control: git archive failed for $SHA" >&2; exit 2; }
+extract "$ROOT/mutant" || refuse archive-failed sha "$SHA" "control archive failed"
 
 control_build_status=0
 run_command "$ROOT/mutant" "$BUILD" "$ROOT/control-build.log" "control build" || control_build_status=$?
 if [ "$control_build_status" -ne 0 ]; then
-  echo "control: build fails before any mutation — not a usable instrument" >&2
-  [ "$KEEP" = 1 ] && echo "kept: $ROOT" >&2
+  message error control-build-failed exit "$control_build_status" "control build fails before any mutation; the instrument is not usable"
+  [ "$KEEP" = 1 ] && notice workspace-kept path "$ROOT" "kept mutation workspace: $ROOT"
   exit 2
 fi
 
 control_status=0
 run_test "$ROOT/mutant" "$ROOT/control.log" || control_status=$?
 if [ "$control_status" -ne 0 ]; then
-  echo "control: test fails before any mutation — not a usable instrument" >&2
-  [ "$KEEP" = 1 ] && echo "kept: $ROOT" >&2
+  message error control-test-failed exit "$control_status" "control test fails before any mutation; the instrument is not usable"
+  [ "$KEEP" = 1 ] && notice workspace-kept path "$ROOT" "kept mutation workspace: $ROOT"
   exit 2
 fi
 
 selection_status=0
 cargo_selection_nonempty "$ROOT/control.log" || selection_status=$?
 if [ "$selection_status" = 1 ]; then
-  echo "control: filter selected no test — not a usable instrument" >&2
-  [ "$KEEP" = 1 ] && echo "kept: $ROOT" >&2
+  message error control-selection-empty count 0 "the control filter selected no test; the instrument is not usable"
+  [ "$KEEP" = 1 ] && notice workspace-kept path "$ROOT" "kept mutation workspace: $ROOT"
   exit 2
 fi
 
 outrank_last_build
-(cd "$ROOT/mutant" && bash -c "$MUTATE") || { echo "mutate command failed" >&2; exit 2; }
+(cd "$ROOT/mutant" && bash -c "$MUTATE") || refuse mutate-command-failed exit "$?" "mutate command failed"
 
 build_status=0
 run_command "$ROOT/mutant" "$BUILD" "$ROOT/build.log" "mutant build" || build_status=$?
 if [ "$build_status" -ne 0 ]; then
-  echo "mutation: invalid-mutant; build failed after mutation" >&2
-  [ "$KEEP" = 1 ] && echo "kept: $ROOT" >&2
+  message error mutant-build-failed exit "$build_status" "the build failed after mutation; the mutant is invalid"
+  [ "$KEEP" = 1 ] && notice workspace-kept path "$ROOT" "kept mutation workspace: $ROOT"
   exit 2
 fi
 
@@ -294,7 +315,7 @@ KILLED=1
 [ "$mutant_status" -ne 0 ] || KILLED=0
 
 PASSES=0
-extract "$ROOT/clean" || { echo "control: second archive failed" >&2; exit 2; }
+extract "$ROOT/clean" || refuse archive-failed sha "$SHA" "clean archive failed"
 i=0
 while [ "$i" -lt "$N" ]; do
   if run_test "$ROOT/clean" "$ROOT/stability-$i.log"; then PASSES=$((PASSES + 1)); fi
@@ -302,5 +323,5 @@ while [ "$i" -lt "$N" ]; do
 done
 
 echo "mutation: killed $KILLED/1; stability: $PASSES/$N at $THREADS threads"
-if [ "$KEEP" = 1 ]; then echo "kept: $ROOT" >&2; fi
+if [ "$KEEP" = 1 ]; then notice workspace-kept path "$ROOT" "kept mutation workspace: $ROOT"; fi
 [ "$KILLED" = 1 ] && [ "$PASSES" = "$N" ]

--- a/.agents/skills/reviewer/tests/mutation-stability.test.sh
+++ b/.agents/skills/reviewer/tests/mutation-stability.test.sh
@@ -160,13 +160,13 @@ while IFS=$'\t' read -r name revision test_cmd build_cmd mutation_token stabilit
       actual="rc=$rc;killed-zero=$(output_has 'mutation: killed 0/1;')"
       ;;
     control-failure)
-      actual="rc=$rc;before-mutation=$(output_has 'before any mutation')"
+      actual="rc=$rc;diagnostic=$(output_has 'error=control-test-failed exit=1')"
       ;;
     empty-selection)
-      actual="rc=$rc;empty-selection=$(output_has 'filter selected no test');survived=$(output_has 'survived')"
+      actual="rc=$rc;diagnostic=$(output_has 'error=control-selection-empty count=0');survived=$(output_has 'survived')"
       ;;
     invalid-mutant)
-      actual="rc=$rc;invalid-mutant=$(output_has 'invalid-mutant');killed=$(output_has 'killed')"
+      actual="rc=$rc;diagnostic=$(output_has 'error=mutant-build-failed exit=1');killed=$(output_has 'killed')"
       ;;
     partial-stability)
       actual="rc=$rc;partial=$(output_has 'stability: 1/3 at 2 threads')"
@@ -180,16 +180,16 @@ while IFS=$'\t' read -r name revision test_cmd build_cmd mutation_token stabilit
 done <<'ROWS'
 killed mutant	base	bash check.sh	true	kill	2	2	exact-summary	rc=0;last=mutation: killed 1/1; stability: 2/2 at 2 threads
 surviving decoy	base	bash check.sh	true	decoy	1	default	killed-zero	rc=1;killed-zero=yes
-red before mutation	base	false	true	none	1	default	control-failure	rc=2;before-mutation=yes
-empty Cargo selection	base	printf "test result: ok. 0 passed; 0 failed; 0 ignored\n"	true	none	1	default	empty-selection	rc=2;empty-selection=yes;survived=no
-non-compiling mutant	base	true	test -f lib.sh	remove	1	default	invalid-mutant	rc=2;invalid-mutant=yes;killed=no
+red before mutation	base	false	true	none	1	default	control-failure	rc=2;diagnostic=yes
+empty Cargo selection	base	printf "test result: ok. 0 passed; 0 failed; 0 ignored\n"	true	none	1	default	empty-selection	rc=2;diagnostic=yes;survived=no
+non-compiling mutant	base	true	test -f lib.sh	remove	1	default	invalid-mutant	rc=2;diagnostic=yes;killed=no
 partial stability	flaky	bash check.sh	true	kill	3	2	partial-stability	rc=1;partial=yes
 ROWS
 assert_table_executed "command outcome" "$command_rows"
 
 run_ms "$SHA_BASE" --test 'true' --build 'true' --mutate 'true' --timeout 0
 assert_case "numeric validator rejects zero" \
-  "rc=$rc;timeout-validator=$(output_has '--timeout wants a positive integer')" \
+  "rc=$rc;timeout-validator=$(output_has 'error=positive-integer-invalid option=--timeout:0')" \
   "rc=2;timeout-validator=yes"
 
 echo "=== settle validation table ==="
@@ -198,12 +198,12 @@ while IFS=$'\t' read -r name value expected; do
   rc=0
   out=""
   out=$(MUTATION_STABILITY_SETTLE="$value" "$MS" --worktree "$REPO" --sha "$SHA_BASE" --test 'true' --build 'true' --mutate 'true' --stability 1 2>&1) || rc=$?
-  actual="rc=$rc;setting-named=$(output_has 'MUTATION_STABILITY_SETTLE wants a whole number of seconds')"
+  actual="rc=$rc;diagnostic=$(output_has "error=settle-invalid value=$value")"
   assert_row "settle validation" "$name" "$actual" "$expected"
   settle_validation_rows=$((settle_validation_rows + 1))
 done <<'ROWS'
-non-numeric settle	soon	rc=2;setting-named=yes
-over-wide settle	18446744073709551616	rc=2;setting-named=yes
+non-numeric settle	soon	rc=2;diagnostic=yes
+over-wide settle	18446744073709551616	rc=2;diagnostic=yes
 ROWS
 assert_table_executed "settle validation" "$settle_validation_rows"
 
@@ -231,12 +231,12 @@ while IFS=$'\t' read -r name setting expected; do
   fi
   whole_sleeps=$(awk '/^[0-9]+$/ { if (seen++) printf ","; printf "%s", $0 }' "$sleep_log") || whole_sleeps=unreadable
   [ -n "$whole_sleeps" ] || whole_sleeps=absent
-  actual="rc=$rc;whole-sleeps=$whole_sleeps;skip-warning=$(output_has 'settle: 0')"
+  actual="rc=$rc;whole-sleeps=$whole_sleeps;skip-notice=$(output_has 'notice=settle-disabled value=0')"
   assert_row "settle setting" "$name" "$actual" "$expected"
   settle_setting_rows=$((settle_setting_rows + 1))
 done <<'ROWS'
-default settle	unset	rc=0;whole-sleeps=1,1,1;skip-warning=no
-zero settle	0	rc=0;whole-sleeps=absent;skip-warning=yes
+default settle	unset	rc=0;whole-sleeps=1,1,1;skip-notice=no
+zero settle	0	rc=0;whole-sleeps=absent;skip-notice=yes
 ROWS
 assert_table_executed "settle setting" "$settle_setting_rows"
 
@@ -272,7 +272,7 @@ observe_timeout() {
   elif [ -n "$child" ]; then
     kill -KILL "$child" 2>/dev/null || true
   fi
-  actual="rc=$rc;timeout=$(output_has 'timed out after 1s');child-stopped=$child_stopped"
+  actual="rc=$rc;timeout=$(output_has 'error=command-timeout seconds=1');child-stopped=$child_stopped"
 }
 
 observe_launch_window() {
@@ -324,7 +324,7 @@ for path in glob.glob("/proc/[0-9]*/stat"):
         pass
 print("inner-rc=%s;timeout=%s;zombies=%s" % (
     run.returncode,
-    "yes" if "timed out after 1s" in run.stderr else "no",
+    "yes" if "error=command-timeout seconds=1" in run.stderr else "no",
     "none" if not zombies else "present",
 ))
 ' "$MS" "$REPO" "$SHA_BASE" 2>&1) || rc=$?
@@ -371,7 +371,7 @@ observe_kept_copies() {
   rc=0
   out=""
   kept=$("$MS" --worktree "$REPO" --sha "$SHA_CACHED" --test 'bash check.sh' --build 'true' --mutate "$KILL_MUTATION" --stability 1 --threads 2 --keep 2>&1 >/dev/null) || rc=$?
-  root=$(printf '%s\n' "$kept" | sed -n 's/^kept: //p') || root=""
+  root=$(printf '%s\n' "$kept" | sed -n 's/^notice=workspace-kept path=//p') || root=""
   clean_present=no
   gap_ok=no
   case "$root" in

--- a/.agents/skills/reviewer/tests/mutation-stability.test.sh
+++ b/.agents/skills/reviewer/tests/mutation-stability.test.sh
@@ -47,6 +47,20 @@ output_has() {
   esac
 }
 
+output_first_line() {
+  printf '%s' "${out%%$'\n'*}"
+}
+
+output_error_line() {
+  local key="$1" line
+  while IFS= read -r line; do
+    case "$line" in
+      "error=$key "*) printf '%s' "$line"; return 0 ;;
+    esac
+  done <<< "$out"
+  printf 'absent'
+}
+
 stopped() {
   pid="$1" attempts=0
   while kill -0 "$pid" 2>/dev/null && [ "$attempts" -lt 20 ]; do
@@ -160,13 +174,13 @@ while IFS=$'\t' read -r name revision test_cmd build_cmd mutation_token stabilit
       actual="rc=$rc;killed-zero=$(output_has 'mutation: killed 0/1;')"
       ;;
     control-failure)
-      actual="rc=$rc;diagnostic=$(output_has 'error=control-test-failed exit=1')"
+      actual="rc=$rc;diagnostic=$(output_error_line control-test-failed)"
       ;;
     empty-selection)
-      actual="rc=$rc;diagnostic=$(output_has 'error=control-selection-empty count=0');survived=$(output_has 'survived')"
+      actual="rc=$rc;diagnostic=$(output_error_line control-selection-empty);survived=$(output_has 'survived')"
       ;;
     invalid-mutant)
-      actual="rc=$rc;diagnostic=$(output_has 'error=mutant-build-failed exit=1');killed=$(output_has 'killed')"
+      actual="rc=$rc;diagnostic=$(output_error_line mutant-build-failed);killed=$(output_has 'killed')"
       ;;
     partial-stability)
       actual="rc=$rc;partial=$(output_has 'stability: 1/3 at 2 threads')"
@@ -180,17 +194,45 @@ while IFS=$'\t' read -r name revision test_cmd build_cmd mutation_token stabilit
 done <<'ROWS'
 killed mutant	base	bash check.sh	true	kill	2	2	exact-summary	rc=0;last=mutation: killed 1/1; stability: 2/2 at 2 threads
 surviving decoy	base	bash check.sh	true	decoy	1	default	killed-zero	rc=1;killed-zero=yes
-red before mutation	base	false	true	none	1	default	control-failure	rc=2;diagnostic=yes
-empty Cargo selection	base	printf "test result: ok. 0 passed; 0 failed; 0 ignored\n"	true	none	1	default	empty-selection	rc=2;diagnostic=yes;survived=no
-non-compiling mutant	base	true	test -f lib.sh	remove	1	default	invalid-mutant	rc=2;diagnostic=yes;killed=no
+red before mutation	base	false	true	none	1	default	control-failure	rc=2;diagnostic=error=control-test-failed exit=1
+empty Cargo selection	base	printf "test result: ok. 0 passed; 0 failed; 0 ignored\n"	true	none	1	default	empty-selection	rc=2;diagnostic=error=control-selection-empty count=0;survived=no
+non-compiling mutant	base	true	test -f lib.sh	remove	1	default	invalid-mutant	rc=2;diagnostic=error=mutant-build-failed exit=1;killed=no
 partial stability	flaky	bash check.sh	true	kill	3	2	partial-stability	rc=1;partial=yes
 ROWS
 assert_table_executed "command outcome" "$command_rows"
 
+echo "=== input and dependency refusal table ==="
+input_rows=0
+while IFS=$'\t' read -r name kind expected_line; do
+  rc=0
+  out=""
+  case "$kind" in
+    missing-value) out=$("$MS" --worktree 2>&1) || rc=$? ;;
+    unknown) out=$("$MS" --unknown 2>&1) || rc=$? ;;
+    arguments) out=$("$MS" 2>&1) || rc=$? ;;
+    temp) out=$(MUTATION_STABILITY_SETTLE=1 TMPDIR="$TMP/absent" "$MS" --worktree "$REPO" --sha "$SHA_BASE" --test true --build true --mutate true 2>&1) || rc=$? ;;
+    archive) out=$(MUTATION_STABILITY_SETTLE=1 "$MS" --worktree "$REPO" --sha not-a-sha --test true --build true --mutate true 2>&1) || rc=$? ;;
+    control-build) out=$(MUTATION_STABILITY_SETTLE=1 "$MS" --worktree "$REPO" --sha "$SHA_BASE" --test true --build false --mutate true 2>&1) || rc=$? ;;
+    mutate) out=$(MUTATION_STABILITY_SETTLE=1 "$MS" --worktree "$REPO" --sha "$SHA_BASE" --test 'printf "test result: ok. 1 passed; 0 failed; 0 ignored\n"' --build true --mutate 'printf "mutation detail\n" >&2; false' 2>&1) || rc=$? ;;
+    *) fail "input refusal fixture" "unknown kind: $kind" ;;
+  esac
+  assert_row "input refusal" "$name" "rc=$rc;first=$(output_first_line)" "rc=2;first=$expected_line"
+  input_rows=$((input_rows + 1))
+done <<ROWS
+missing option value	missing-value	error=argument-value-missing option=--worktree
+unknown option	unknown	error=argument-unknown argument=--unknown
+missing required options	arguments	error=arguments-missing set=worktree-sha-test-build-mutate
+temporary workspace failure	temp	error=temp-create-failed path=$TMP/absent
+archive failure	archive	error=archive-failed sha=not-a-sha
+control build failure	control-build	error=control-build-failed exit=1
+mutation command failure	mutate	error=mutate-command-failed exit=1
+ROWS
+assert_table_executed "input refusal" "$input_rows"
+
 run_ms "$SHA_BASE" --test 'true' --build 'true' --mutate 'true' --timeout 0
 assert_case "numeric validator rejects zero" \
-  "rc=$rc;timeout-validator=$(output_has 'error=positive-integer-invalid option=--timeout:0')" \
-  "rc=2;timeout-validator=yes"
+  "rc=$rc;diagnostic=$(output_first_line)" \
+  "rc=2;diagnostic=error=positive-integer-invalid option=--timeout:0"
 
 echo "=== settle validation table ==="
 settle_validation_rows=0
@@ -198,12 +240,12 @@ while IFS=$'\t' read -r name value expected; do
   rc=0
   out=""
   out=$(MUTATION_STABILITY_SETTLE="$value" "$MS" --worktree "$REPO" --sha "$SHA_BASE" --test 'true' --build 'true' --mutate 'true' --stability 1 2>&1) || rc=$?
-  actual="rc=$rc;diagnostic=$(output_has "error=settle-invalid value=$value")"
+  actual="rc=$rc;diagnostic=$(output_first_line)"
   assert_row "settle validation" "$name" "$actual" "$expected"
   settle_validation_rows=$((settle_validation_rows + 1))
 done <<'ROWS'
-non-numeric settle	soon	rc=2;diagnostic=yes
-over-wide settle	18446744073709551616	rc=2;diagnostic=yes
+non-numeric settle	soon	rc=2;diagnostic=error=settle-invalid value=soon
+over-wide settle	18446744073709551616	rc=2;diagnostic=error=settle-invalid value=18446744073709551616
 ROWS
 assert_table_executed "settle validation" "$settle_validation_rows"
 
@@ -231,12 +273,13 @@ while IFS=$'\t' read -r name setting expected; do
   fi
   whole_sleeps=$(awk '/^[0-9]+$/ { if (seen++) printf ","; printf "%s", $0 }' "$sleep_log") || whole_sleeps=unreadable
   [ -n "$whole_sleeps" ] || whole_sleeps=absent
-  actual="rc=$rc;whole-sleeps=$whole_sleeps;skip-notice=$(output_has 'notice=settle-disabled value=0')"
+  if [ "$setting" = 0 ]; then skip_notice="$(output_first_line)"; else skip_notice=absent; fi
+  actual="rc=$rc;whole-sleeps=$whole_sleeps;skip-notice=$skip_notice"
   assert_row "settle setting" "$name" "$actual" "$expected"
   settle_setting_rows=$((settle_setting_rows + 1))
 done <<'ROWS'
-default settle	unset	rc=0;whole-sleeps=1,1,1;skip-notice=no
-zero settle	0	rc=0;whole-sleeps=absent;skip-notice=yes
+default settle	unset	rc=0;whole-sleeps=1,1,1;skip-notice=absent
+zero settle	0	rc=0;whole-sleeps=absent;skip-notice=notice=settle-disabled value=0
 ROWS
 assert_table_executed "settle setting" "$settle_setting_rows"
 
@@ -272,7 +315,7 @@ observe_timeout() {
   elif [ -n "$child" ]; then
     kill -KILL "$child" 2>/dev/null || true
   fi
-  actual="rc=$rc;timeout=$(output_has 'error=command-timeout seconds=1');child-stopped=$child_stopped"
+  actual="rc=$rc;timeout=$(output_error_line command-timeout);child-stopped=$child_stopped"
 }
 
 observe_launch_window() {
@@ -349,7 +392,7 @@ while IFS=$'\t' read -r name kind expected; do
   assert_row "process cleanup" "$name" "$actual" "$expected"
   process_rows=$((process_rows + 1))
 done <<'ROWS'
-timed-out child exits, reports, and stops	timeout	rc=2;timeout=yes;child-stopped=yes
+timed-out child exits, reports, and stops	timeout	rc=2;timeout=error=command-timeout seconds=1;child-stopped=yes
 launch-window cancellation owns and stops its child	launch-window	rc=143;signalled=yes;child-recorded=yes;child-stopped=yes
 non-reaping PID 1 adopts no zombie	namespace	outer-rc=0;inner-rc=2;timeout=yes;zombies=none
 ROWS

--- a/.agents/skills/reviewer/tests/mutation-stability.test.sh
+++ b/.agents/skills/reviewer/tests/mutation-stability.test.sh
@@ -211,6 +211,7 @@ while IFS=$'\t' read -r name kind expected_line; do
     unknown) out=$("$MS" --unknown 2>&1) || rc=$? ;;
     arguments) out=$("$MS" 2>&1) || rc=$? ;;
     temp) out=$(MUTATION_STABILITY_SETTLE=1 TMPDIR="$TMP/absent" "$MS" --worktree "$REPO" --sha "$SHA_BASE" --test true --build true --mutate true 2>&1) || rc=$? ;;
+    temp-space) out=$(MUTATION_STABILITY_SETTLE=1 TMPDIR="$TMP/space absent" "$MS" --worktree "$REPO" --sha "$SHA_BASE" --test true --build true --mutate true 2>&1) || rc=$? ;;
     archive) out=$(MUTATION_STABILITY_SETTLE=1 "$MS" --worktree "$REPO" --sha not-a-sha --test true --build true --mutate true 2>&1) || rc=$? ;;
     control-build) out=$(MUTATION_STABILITY_SETTLE=1 "$MS" --worktree "$REPO" --sha "$SHA_BASE" --test true --build false --mutate true 2>&1) || rc=$? ;;
     mutate) out=$(MUTATION_STABILITY_SETTLE=1 "$MS" --worktree "$REPO" --sha "$SHA_BASE" --test 'printf "test result: ok. 1 passed; 0 failed; 0 ignored\n"' --build true --mutate 'printf "mutation detail\n" >&2; false' 2>&1) || rc=$? ;;
@@ -223,6 +224,7 @@ missing option value	missing-value	error=argument-value-missing option=--worktre
 unknown option	unknown	error=argument-unknown argument=--unknown
 missing required options	arguments	error=arguments-missing set=worktree-sha-test-build-mutate
 temporary workspace failure	temp	error=temp-create-failed path=$TMP/absent
+temporary workspace path escaping	temp-space	error=temp-create-failed path=$TMP/space\ absent
 archive failure	archive	error=archive-failed sha=not-a-sha
 control build failure	control-build	error=control-build-failed exit=1
 mutation command failure	mutate	error=mutate-command-failed exit=1

--- a/skills/reviewer/scripts/mutation-stability
+++ b/skills/reviewer/scripts/mutation-stability
@@ -51,6 +51,13 @@ refuse() {
   exit 2
 }
 
+refuse_with_log() {
+  key="$1" field="$2" value="$3" text="$4" log="$5"
+  message error "$key" "$field" "$value" "$text"
+  [ ! -s "$log" ] || cat -- "$log" >&2
+  exit 2
+}
+
 notice() {
   message notice "$1" "$2" "$3" "$4"
 }
@@ -112,8 +119,15 @@ fi
 [ "$SETTLE" -ne 0 ] ||
   notice settle-disabled value "$SETTLE" "copies are not mtime-separated; verdicts assume BUILD shares no cache"
 
-ROOT=$(mktemp -d "${TMPDIR:-/tmp}/mutation-stability.XXXXXX") ||
-  refuse temp-create-failed path "${TMPDIR:-/tmp}" "could not create the mutation workspace"
+root_result=""
+root_status=0
+root_result=$(mktemp -d "${TMPDIR:-/tmp}/mutation-stability.XXXXXX" 2>&1) || root_status=$?
+if [ "$root_status" -ne 0 ]; then
+  message error temp-create-failed path "${TMPDIR:-/tmp}" "could not create the mutation workspace"
+  [ -z "$root_result" ] || printf '%s\n' "$root_result" >&2
+  exit 2
+fi
+ROOT="$root_result"
 ACTIVE_PID="" ACTIVE_GROUP=""
 
 group_leaves() {
@@ -272,7 +286,11 @@ cargo_selection_nonempty() {
   ' "$1"
 }
 
-extract "$ROOT/mutant" || refuse archive-failed sha "$SHA" "control archive failed"
+extract_status=0
+extract "$ROOT/mutant" >"$ROOT/control-archive.log" 2>&1 || extract_status=$?
+if [ "$extract_status" -ne 0 ]; then
+  refuse_with_log archive-failed sha "$SHA" "control archive failed" "$ROOT/control-archive.log"
+fi
 
 control_build_status=0
 run_command "$ROOT/mutant" "$BUILD" "$ROOT/control-build.log" "control build" || control_build_status=$?
@@ -299,7 +317,11 @@ if [ "$selection_status" = 1 ]; then
 fi
 
 outrank_last_build
-(cd "$ROOT/mutant" && bash -c "$MUTATE") || refuse mutate-command-failed exit "$?" "mutate command failed"
+mutate_status=0
+(cd "$ROOT/mutant" && bash -c "$MUTATE") >"$ROOT/mutate.log" 2>&1 || mutate_status=$?
+if [ "$mutate_status" -ne 0 ]; then
+  refuse_with_log mutate-command-failed exit "$mutate_status" "mutate command failed" "$ROOT/mutate.log"
+fi
 
 build_status=0
 run_command "$ROOT/mutant" "$BUILD" "$ROOT/build.log" "mutant build" || build_status=$?
@@ -315,7 +337,11 @@ KILLED=1
 [ "$mutant_status" -ne 0 ] || KILLED=0
 
 PASSES=0
-extract "$ROOT/clean" || refuse archive-failed sha "$SHA" "clean archive failed"
+extract_status=0
+extract "$ROOT/clean" >"$ROOT/clean-archive.log" 2>&1 || extract_status=$?
+if [ "$extract_status" -ne 0 ]; then
+  refuse_with_log archive-failed sha "$SHA" "clean archive failed" "$ROOT/clean-archive.log"
+fi
 i=0
 while [ "$i" -lt "$N" ]; do
   if run_test "$ROOT/clean" "$ROOT/stability-$i.log"; then PASSES=$((PASSES + 1)); fi

--- a/skills/reviewer/scripts/mutation-stability
+++ b/skills/reviewer/scripts/mutation-stability
@@ -42,7 +42,7 @@ USAGE
 
 message() {
   level="$1" key="$2" field="$3" value="$4" text="$5"
-  printf '%s=%s %s=%s\n' "$level" "$key" "$field" "$value" >&2
+  printf '%s=%s %s=%q\n' "$level" "$key" "$field" "$value" >&2
   printf '%s\n' "$text" >&2
 }
 

--- a/skills/reviewer/scripts/mutation-stability
+++ b/skills/reviewer/scripts/mutation-stability
@@ -9,6 +9,10 @@
 #
 #   mutation: killed 1/1; stability: N/N at T threads
 #
+# Diagnostic protocol: each refusal starts with error=KEY FIELD=VALUE, and each
+# notice starts with notice=KEY FIELD=VALUE. English detail follows. The final
+# mutation/stability summary above is the downstream result protocol.
+#
 # Exit: 0 killed and stable; 1 mutant survived or a stability run failed;
 # 2 instrument failure (control, empty selection, invalid mutant, timed-out run,
 # bad input).
@@ -36,12 +40,27 @@ usage: mutation-stability --worktree PATH --sha SHA --test CMD --build CMD
 USAGE
 }
 
+message() {
+  level="$1" key="$2" field="$3" value="$4" text="$5"
+  printf '%s=%s %s=%s\n' "$level" "$key" "$field" "$value" >&2
+  printf '%s\n' "$text" >&2
+}
+
+refuse() {
+  message error "$1" "$2" "$3" "$4"
+  exit 2
+}
+
+notice() {
+  message notice "$1" "$2" "$3" "$4"
+}
+
 WORKTREE="" SHA="" TEST="" BUILD="" MUTATE="" N=10 THREADS="" TIMEOUT=300 KEEP=0
 THREADS_SET=0
 while [ $# -gt 0 ]; do
   case "$1" in
     --worktree|--sha|--test|--build|--mutate|--stability|--threads|--timeout)
-      [ $# -ge 2 ] || { echo "$1 needs a value" >&2; usage >&2; exit 2; }
+      [ $# -ge 2 ] || { option="$1"; message error argument-value-missing option "$option" "$option needs a value"; usage >&2; exit 2; }
       case "$1" in
         --worktree) WORKTREE="$2" ;;
         --sha) SHA="$2" ;;
@@ -55,17 +74,19 @@ while [ $# -gt 0 ]; do
       shift ;;
     --keep) KEEP=1 ;;
     -h|--help) usage; exit 0 ;;
-    *) echo "unknown argument: $1" >&2; usage >&2; exit 2 ;;
+    *) argument="$1"; message error argument-unknown argument "$argument" "unknown argument: $argument"; usage >&2; exit 2 ;;
   esac
   shift
 done
 [ -n "$WORKTREE" ] && [ -n "$SHA" ] && [ -n "$TEST" ] && [ -n "$BUILD" ] && [ -n "$MUTATE" ] || {
-  usage >&2; exit 2
+  message error arguments-missing set worktree-sha-test-build-mutate "required options are missing"
+  usage >&2
+  exit 2
 }
 positive_integer() {
   option="$1" value="$2"
   case "$value" in
-    *[!0-9]*|''|0) echo "$option wants a positive integer" >&2; exit 2 ;;
+    *[!0-9]*|''|0) refuse positive-integer-invalid option "$option:$value" "$option wants a positive integer" ;;
   esac
 }
 
@@ -81,8 +102,7 @@ positive_integer --timeout "$TIMEOUT"
 # out the run on the first write to a copy.
 SETTLE="${MUTATION_STABILITY_SETTLE:-1}"
 if ! [[ "$SETTLE" =~ ^[0-9]{1,18}$ ]]; then
-  echo "MUTATION_STABILITY_SETTLE wants a whole number of seconds" >&2
-  exit 2
+  refuse settle-invalid value "$SETTLE" "MUTATION_STABILITY_SETTLE wants a whole number of seconds"
 fi
 # The precondition for skipping the boundary — that BUILD keeps no cache the
 # copies could share — is the caller's to know and this script cannot check
@@ -90,9 +110,10 @@ fi
 # as survived, and nothing about that verdict looks wrong afterwards. Say it
 # once, so a transcript shows which verdicts were produced without it.
 [ "$SETTLE" -ne 0 ] ||
-  echo "settle: 0 — copies are not mtime-separated; verdicts assume BUILD shares no cache" >&2
+  notice settle-disabled value "$SETTLE" "copies are not mtime-separated; verdicts assume BUILD shares no cache"
 
-ROOT=$(mktemp -d "${TMPDIR:-/tmp}/mutation-stability.XXXXXX") || exit 2
+ROOT=$(mktemp -d "${TMPDIR:-/tmp}/mutation-stability.XXXXXX") ||
+  refuse temp-create-failed path "${TMPDIR:-/tmp}" "could not create the mutation workspace"
 ACTIVE_PID="" ACTIVE_GROUP=""
 
 group_leaves() {
@@ -223,8 +244,8 @@ run_command() { # run $2 in $1, capture output in $3, label it $4
   ACTIVE_PID="" ACTIVE_GROUP=""
 
   if [ "$timed_out" -eq 1 ]; then
-    echo "$label timed out after ${TIMEOUT}s" >&2
-    [ "$KEEP" = 1 ] && echo "kept: $ROOT" >&2
+    message error command-timeout seconds "$TIMEOUT" "$label timed out after ${TIMEOUT}s"
+    [ "$KEEP" = 1 ] && notice workspace-kept path "$ROOT" "kept mutation workspace: $ROOT"
     exit 2
   fi
   return "$status"
@@ -251,40 +272,40 @@ cargo_selection_nonempty() {
   ' "$1"
 }
 
-extract "$ROOT/mutant" || { echo "control: git archive failed for $SHA" >&2; exit 2; }
+extract "$ROOT/mutant" || refuse archive-failed sha "$SHA" "control archive failed"
 
 control_build_status=0
 run_command "$ROOT/mutant" "$BUILD" "$ROOT/control-build.log" "control build" || control_build_status=$?
 if [ "$control_build_status" -ne 0 ]; then
-  echo "control: build fails before any mutation — not a usable instrument" >&2
-  [ "$KEEP" = 1 ] && echo "kept: $ROOT" >&2
+  message error control-build-failed exit "$control_build_status" "control build fails before any mutation; the instrument is not usable"
+  [ "$KEEP" = 1 ] && notice workspace-kept path "$ROOT" "kept mutation workspace: $ROOT"
   exit 2
 fi
 
 control_status=0
 run_test "$ROOT/mutant" "$ROOT/control.log" || control_status=$?
 if [ "$control_status" -ne 0 ]; then
-  echo "control: test fails before any mutation — not a usable instrument" >&2
-  [ "$KEEP" = 1 ] && echo "kept: $ROOT" >&2
+  message error control-test-failed exit "$control_status" "control test fails before any mutation; the instrument is not usable"
+  [ "$KEEP" = 1 ] && notice workspace-kept path "$ROOT" "kept mutation workspace: $ROOT"
   exit 2
 fi
 
 selection_status=0
 cargo_selection_nonempty "$ROOT/control.log" || selection_status=$?
 if [ "$selection_status" = 1 ]; then
-  echo "control: filter selected no test — not a usable instrument" >&2
-  [ "$KEEP" = 1 ] && echo "kept: $ROOT" >&2
+  message error control-selection-empty count 0 "the control filter selected no test; the instrument is not usable"
+  [ "$KEEP" = 1 ] && notice workspace-kept path "$ROOT" "kept mutation workspace: $ROOT"
   exit 2
 fi
 
 outrank_last_build
-(cd "$ROOT/mutant" && bash -c "$MUTATE") || { echo "mutate command failed" >&2; exit 2; }
+(cd "$ROOT/mutant" && bash -c "$MUTATE") || refuse mutate-command-failed exit "$?" "mutate command failed"
 
 build_status=0
 run_command "$ROOT/mutant" "$BUILD" "$ROOT/build.log" "mutant build" || build_status=$?
 if [ "$build_status" -ne 0 ]; then
-  echo "mutation: invalid-mutant; build failed after mutation" >&2
-  [ "$KEEP" = 1 ] && echo "kept: $ROOT" >&2
+  message error mutant-build-failed exit "$build_status" "the build failed after mutation; the mutant is invalid"
+  [ "$KEEP" = 1 ] && notice workspace-kept path "$ROOT" "kept mutation workspace: $ROOT"
   exit 2
 fi
 
@@ -294,7 +315,7 @@ KILLED=1
 [ "$mutant_status" -ne 0 ] || KILLED=0
 
 PASSES=0
-extract "$ROOT/clean" || { echo "control: second archive failed" >&2; exit 2; }
+extract "$ROOT/clean" || refuse archive-failed sha "$SHA" "clean archive failed"
 i=0
 while [ "$i" -lt "$N" ]; do
   if run_test "$ROOT/clean" "$ROOT/stability-$i.log"; then PASSES=$((PASSES + 1)); fi
@@ -302,5 +323,5 @@ while [ "$i" -lt "$N" ]; do
 done
 
 echo "mutation: killed $KILLED/1; stability: $PASSES/$N at $THREADS threads"
-if [ "$KEEP" = 1 ]; then echo "kept: $ROOT" >&2; fi
+if [ "$KEEP" = 1 ]; then notice workspace-kept path "$ROOT" "kept mutation workspace: $ROOT"; fi
 [ "$KILLED" = 1 ] && [ "$PASSES" = "$N" ]

--- a/skills/reviewer/tests/mutation-stability.test.sh
+++ b/skills/reviewer/tests/mutation-stability.test.sh
@@ -160,13 +160,13 @@ while IFS=$'\t' read -r name revision test_cmd build_cmd mutation_token stabilit
       actual="rc=$rc;killed-zero=$(output_has 'mutation: killed 0/1;')"
       ;;
     control-failure)
-      actual="rc=$rc;before-mutation=$(output_has 'before any mutation')"
+      actual="rc=$rc;diagnostic=$(output_has 'error=control-test-failed exit=1')"
       ;;
     empty-selection)
-      actual="rc=$rc;empty-selection=$(output_has 'filter selected no test');survived=$(output_has 'survived')"
+      actual="rc=$rc;diagnostic=$(output_has 'error=control-selection-empty count=0');survived=$(output_has 'survived')"
       ;;
     invalid-mutant)
-      actual="rc=$rc;invalid-mutant=$(output_has 'invalid-mutant');killed=$(output_has 'killed')"
+      actual="rc=$rc;diagnostic=$(output_has 'error=mutant-build-failed exit=1');killed=$(output_has 'killed')"
       ;;
     partial-stability)
       actual="rc=$rc;partial=$(output_has 'stability: 1/3 at 2 threads')"
@@ -180,16 +180,16 @@ while IFS=$'\t' read -r name revision test_cmd build_cmd mutation_token stabilit
 done <<'ROWS'
 killed mutant	base	bash check.sh	true	kill	2	2	exact-summary	rc=0;last=mutation: killed 1/1; stability: 2/2 at 2 threads
 surviving decoy	base	bash check.sh	true	decoy	1	default	killed-zero	rc=1;killed-zero=yes
-red before mutation	base	false	true	none	1	default	control-failure	rc=2;before-mutation=yes
-empty Cargo selection	base	printf "test result: ok. 0 passed; 0 failed; 0 ignored\n"	true	none	1	default	empty-selection	rc=2;empty-selection=yes;survived=no
-non-compiling mutant	base	true	test -f lib.sh	remove	1	default	invalid-mutant	rc=2;invalid-mutant=yes;killed=no
+red before mutation	base	false	true	none	1	default	control-failure	rc=2;diagnostic=yes
+empty Cargo selection	base	printf "test result: ok. 0 passed; 0 failed; 0 ignored\n"	true	none	1	default	empty-selection	rc=2;diagnostic=yes;survived=no
+non-compiling mutant	base	true	test -f lib.sh	remove	1	default	invalid-mutant	rc=2;diagnostic=yes;killed=no
 partial stability	flaky	bash check.sh	true	kill	3	2	partial-stability	rc=1;partial=yes
 ROWS
 assert_table_executed "command outcome" "$command_rows"
 
 run_ms "$SHA_BASE" --test 'true' --build 'true' --mutate 'true' --timeout 0
 assert_case "numeric validator rejects zero" \
-  "rc=$rc;timeout-validator=$(output_has '--timeout wants a positive integer')" \
+  "rc=$rc;timeout-validator=$(output_has 'error=positive-integer-invalid option=--timeout:0')" \
   "rc=2;timeout-validator=yes"
 
 echo "=== settle validation table ==="
@@ -198,12 +198,12 @@ while IFS=$'\t' read -r name value expected; do
   rc=0
   out=""
   out=$(MUTATION_STABILITY_SETTLE="$value" "$MS" --worktree "$REPO" --sha "$SHA_BASE" --test 'true' --build 'true' --mutate 'true' --stability 1 2>&1) || rc=$?
-  actual="rc=$rc;setting-named=$(output_has 'MUTATION_STABILITY_SETTLE wants a whole number of seconds')"
+  actual="rc=$rc;diagnostic=$(output_has "error=settle-invalid value=$value")"
   assert_row "settle validation" "$name" "$actual" "$expected"
   settle_validation_rows=$((settle_validation_rows + 1))
 done <<'ROWS'
-non-numeric settle	soon	rc=2;setting-named=yes
-over-wide settle	18446744073709551616	rc=2;setting-named=yes
+non-numeric settle	soon	rc=2;diagnostic=yes
+over-wide settle	18446744073709551616	rc=2;diagnostic=yes
 ROWS
 assert_table_executed "settle validation" "$settle_validation_rows"
 
@@ -231,12 +231,12 @@ while IFS=$'\t' read -r name setting expected; do
   fi
   whole_sleeps=$(awk '/^[0-9]+$/ { if (seen++) printf ","; printf "%s", $0 }' "$sleep_log") || whole_sleeps=unreadable
   [ -n "$whole_sleeps" ] || whole_sleeps=absent
-  actual="rc=$rc;whole-sleeps=$whole_sleeps;skip-warning=$(output_has 'settle: 0')"
+  actual="rc=$rc;whole-sleeps=$whole_sleeps;skip-notice=$(output_has 'notice=settle-disabled value=0')"
   assert_row "settle setting" "$name" "$actual" "$expected"
   settle_setting_rows=$((settle_setting_rows + 1))
 done <<'ROWS'
-default settle	unset	rc=0;whole-sleeps=1,1,1;skip-warning=no
-zero settle	0	rc=0;whole-sleeps=absent;skip-warning=yes
+default settle	unset	rc=0;whole-sleeps=1,1,1;skip-notice=no
+zero settle	0	rc=0;whole-sleeps=absent;skip-notice=yes
 ROWS
 assert_table_executed "settle setting" "$settle_setting_rows"
 
@@ -272,7 +272,7 @@ observe_timeout() {
   elif [ -n "$child" ]; then
     kill -KILL "$child" 2>/dev/null || true
   fi
-  actual="rc=$rc;timeout=$(output_has 'timed out after 1s');child-stopped=$child_stopped"
+  actual="rc=$rc;timeout=$(output_has 'error=command-timeout seconds=1');child-stopped=$child_stopped"
 }
 
 observe_launch_window() {
@@ -324,7 +324,7 @@ for path in glob.glob("/proc/[0-9]*/stat"):
         pass
 print("inner-rc=%s;timeout=%s;zombies=%s" % (
     run.returncode,
-    "yes" if "timed out after 1s" in run.stderr else "no",
+    "yes" if "error=command-timeout seconds=1" in run.stderr else "no",
     "none" if not zombies else "present",
 ))
 ' "$MS" "$REPO" "$SHA_BASE" 2>&1) || rc=$?
@@ -371,7 +371,7 @@ observe_kept_copies() {
   rc=0
   out=""
   kept=$("$MS" --worktree "$REPO" --sha "$SHA_CACHED" --test 'bash check.sh' --build 'true' --mutate "$KILL_MUTATION" --stability 1 --threads 2 --keep 2>&1 >/dev/null) || rc=$?
-  root=$(printf '%s\n' "$kept" | sed -n 's/^kept: //p') || root=""
+  root=$(printf '%s\n' "$kept" | sed -n 's/^notice=workspace-kept path=//p') || root=""
   clean_present=no
   gap_ok=no
   case "$root" in

--- a/skills/reviewer/tests/mutation-stability.test.sh
+++ b/skills/reviewer/tests/mutation-stability.test.sh
@@ -47,6 +47,20 @@ output_has() {
   esac
 }
 
+output_first_line() {
+  printf '%s' "${out%%$'\n'*}"
+}
+
+output_error_line() {
+  local key="$1" line
+  while IFS= read -r line; do
+    case "$line" in
+      "error=$key "*) printf '%s' "$line"; return 0 ;;
+    esac
+  done <<< "$out"
+  printf 'absent'
+}
+
 stopped() {
   pid="$1" attempts=0
   while kill -0 "$pid" 2>/dev/null && [ "$attempts" -lt 20 ]; do
@@ -160,13 +174,13 @@ while IFS=$'\t' read -r name revision test_cmd build_cmd mutation_token stabilit
       actual="rc=$rc;killed-zero=$(output_has 'mutation: killed 0/1;')"
       ;;
     control-failure)
-      actual="rc=$rc;diagnostic=$(output_has 'error=control-test-failed exit=1')"
+      actual="rc=$rc;diagnostic=$(output_error_line control-test-failed)"
       ;;
     empty-selection)
-      actual="rc=$rc;diagnostic=$(output_has 'error=control-selection-empty count=0');survived=$(output_has 'survived')"
+      actual="rc=$rc;diagnostic=$(output_error_line control-selection-empty);survived=$(output_has 'survived')"
       ;;
     invalid-mutant)
-      actual="rc=$rc;diagnostic=$(output_has 'error=mutant-build-failed exit=1');killed=$(output_has 'killed')"
+      actual="rc=$rc;diagnostic=$(output_error_line mutant-build-failed);killed=$(output_has 'killed')"
       ;;
     partial-stability)
       actual="rc=$rc;partial=$(output_has 'stability: 1/3 at 2 threads')"
@@ -180,17 +194,45 @@ while IFS=$'\t' read -r name revision test_cmd build_cmd mutation_token stabilit
 done <<'ROWS'
 killed mutant	base	bash check.sh	true	kill	2	2	exact-summary	rc=0;last=mutation: killed 1/1; stability: 2/2 at 2 threads
 surviving decoy	base	bash check.sh	true	decoy	1	default	killed-zero	rc=1;killed-zero=yes
-red before mutation	base	false	true	none	1	default	control-failure	rc=2;diagnostic=yes
-empty Cargo selection	base	printf "test result: ok. 0 passed; 0 failed; 0 ignored\n"	true	none	1	default	empty-selection	rc=2;diagnostic=yes;survived=no
-non-compiling mutant	base	true	test -f lib.sh	remove	1	default	invalid-mutant	rc=2;diagnostic=yes;killed=no
+red before mutation	base	false	true	none	1	default	control-failure	rc=2;diagnostic=error=control-test-failed exit=1
+empty Cargo selection	base	printf "test result: ok. 0 passed; 0 failed; 0 ignored\n"	true	none	1	default	empty-selection	rc=2;diagnostic=error=control-selection-empty count=0;survived=no
+non-compiling mutant	base	true	test -f lib.sh	remove	1	default	invalid-mutant	rc=2;diagnostic=error=mutant-build-failed exit=1;killed=no
 partial stability	flaky	bash check.sh	true	kill	3	2	partial-stability	rc=1;partial=yes
 ROWS
 assert_table_executed "command outcome" "$command_rows"
 
+echo "=== input and dependency refusal table ==="
+input_rows=0
+while IFS=$'\t' read -r name kind expected_line; do
+  rc=0
+  out=""
+  case "$kind" in
+    missing-value) out=$("$MS" --worktree 2>&1) || rc=$? ;;
+    unknown) out=$("$MS" --unknown 2>&1) || rc=$? ;;
+    arguments) out=$("$MS" 2>&1) || rc=$? ;;
+    temp) out=$(MUTATION_STABILITY_SETTLE=1 TMPDIR="$TMP/absent" "$MS" --worktree "$REPO" --sha "$SHA_BASE" --test true --build true --mutate true 2>&1) || rc=$? ;;
+    archive) out=$(MUTATION_STABILITY_SETTLE=1 "$MS" --worktree "$REPO" --sha not-a-sha --test true --build true --mutate true 2>&1) || rc=$? ;;
+    control-build) out=$(MUTATION_STABILITY_SETTLE=1 "$MS" --worktree "$REPO" --sha "$SHA_BASE" --test true --build false --mutate true 2>&1) || rc=$? ;;
+    mutate) out=$(MUTATION_STABILITY_SETTLE=1 "$MS" --worktree "$REPO" --sha "$SHA_BASE" --test 'printf "test result: ok. 1 passed; 0 failed; 0 ignored\n"' --build true --mutate 'printf "mutation detail\n" >&2; false' 2>&1) || rc=$? ;;
+    *) fail "input refusal fixture" "unknown kind: $kind" ;;
+  esac
+  assert_row "input refusal" "$name" "rc=$rc;first=$(output_first_line)" "rc=2;first=$expected_line"
+  input_rows=$((input_rows + 1))
+done <<ROWS
+missing option value	missing-value	error=argument-value-missing option=--worktree
+unknown option	unknown	error=argument-unknown argument=--unknown
+missing required options	arguments	error=arguments-missing set=worktree-sha-test-build-mutate
+temporary workspace failure	temp	error=temp-create-failed path=$TMP/absent
+archive failure	archive	error=archive-failed sha=not-a-sha
+control build failure	control-build	error=control-build-failed exit=1
+mutation command failure	mutate	error=mutate-command-failed exit=1
+ROWS
+assert_table_executed "input refusal" "$input_rows"
+
 run_ms "$SHA_BASE" --test 'true' --build 'true' --mutate 'true' --timeout 0
 assert_case "numeric validator rejects zero" \
-  "rc=$rc;timeout-validator=$(output_has 'error=positive-integer-invalid option=--timeout:0')" \
-  "rc=2;timeout-validator=yes"
+  "rc=$rc;diagnostic=$(output_first_line)" \
+  "rc=2;diagnostic=error=positive-integer-invalid option=--timeout:0"
 
 echo "=== settle validation table ==="
 settle_validation_rows=0
@@ -198,12 +240,12 @@ while IFS=$'\t' read -r name value expected; do
   rc=0
   out=""
   out=$(MUTATION_STABILITY_SETTLE="$value" "$MS" --worktree "$REPO" --sha "$SHA_BASE" --test 'true' --build 'true' --mutate 'true' --stability 1 2>&1) || rc=$?
-  actual="rc=$rc;diagnostic=$(output_has "error=settle-invalid value=$value")"
+  actual="rc=$rc;diagnostic=$(output_first_line)"
   assert_row "settle validation" "$name" "$actual" "$expected"
   settle_validation_rows=$((settle_validation_rows + 1))
 done <<'ROWS'
-non-numeric settle	soon	rc=2;diagnostic=yes
-over-wide settle	18446744073709551616	rc=2;diagnostic=yes
+non-numeric settle	soon	rc=2;diagnostic=error=settle-invalid value=soon
+over-wide settle	18446744073709551616	rc=2;diagnostic=error=settle-invalid value=18446744073709551616
 ROWS
 assert_table_executed "settle validation" "$settle_validation_rows"
 
@@ -231,12 +273,13 @@ while IFS=$'\t' read -r name setting expected; do
   fi
   whole_sleeps=$(awk '/^[0-9]+$/ { if (seen++) printf ","; printf "%s", $0 }' "$sleep_log") || whole_sleeps=unreadable
   [ -n "$whole_sleeps" ] || whole_sleeps=absent
-  actual="rc=$rc;whole-sleeps=$whole_sleeps;skip-notice=$(output_has 'notice=settle-disabled value=0')"
+  if [ "$setting" = 0 ]; then skip_notice="$(output_first_line)"; else skip_notice=absent; fi
+  actual="rc=$rc;whole-sleeps=$whole_sleeps;skip-notice=$skip_notice"
   assert_row "settle setting" "$name" "$actual" "$expected"
   settle_setting_rows=$((settle_setting_rows + 1))
 done <<'ROWS'
-default settle	unset	rc=0;whole-sleeps=1,1,1;skip-notice=no
-zero settle	0	rc=0;whole-sleeps=absent;skip-notice=yes
+default settle	unset	rc=0;whole-sleeps=1,1,1;skip-notice=absent
+zero settle	0	rc=0;whole-sleeps=absent;skip-notice=notice=settle-disabled value=0
 ROWS
 assert_table_executed "settle setting" "$settle_setting_rows"
 
@@ -272,7 +315,7 @@ observe_timeout() {
   elif [ -n "$child" ]; then
     kill -KILL "$child" 2>/dev/null || true
   fi
-  actual="rc=$rc;timeout=$(output_has 'error=command-timeout seconds=1');child-stopped=$child_stopped"
+  actual="rc=$rc;timeout=$(output_error_line command-timeout);child-stopped=$child_stopped"
 }
 
 observe_launch_window() {
@@ -349,7 +392,7 @@ while IFS=$'\t' read -r name kind expected; do
   assert_row "process cleanup" "$name" "$actual" "$expected"
   process_rows=$((process_rows + 1))
 done <<'ROWS'
-timed-out child exits, reports, and stops	timeout	rc=2;timeout=yes;child-stopped=yes
+timed-out child exits, reports, and stops	timeout	rc=2;timeout=error=command-timeout seconds=1;child-stopped=yes
 launch-window cancellation owns and stops its child	launch-window	rc=143;signalled=yes;child-recorded=yes;child-stopped=yes
 non-reaping PID 1 adopts no zombie	namespace	outer-rc=0;inner-rc=2;timeout=yes;zombies=none
 ROWS

--- a/skills/reviewer/tests/mutation-stability.test.sh
+++ b/skills/reviewer/tests/mutation-stability.test.sh
@@ -211,6 +211,7 @@ while IFS=$'\t' read -r name kind expected_line; do
     unknown) out=$("$MS" --unknown 2>&1) || rc=$? ;;
     arguments) out=$("$MS" 2>&1) || rc=$? ;;
     temp) out=$(MUTATION_STABILITY_SETTLE=1 TMPDIR="$TMP/absent" "$MS" --worktree "$REPO" --sha "$SHA_BASE" --test true --build true --mutate true 2>&1) || rc=$? ;;
+    temp-space) out=$(MUTATION_STABILITY_SETTLE=1 TMPDIR="$TMP/space absent" "$MS" --worktree "$REPO" --sha "$SHA_BASE" --test true --build true --mutate true 2>&1) || rc=$? ;;
     archive) out=$(MUTATION_STABILITY_SETTLE=1 "$MS" --worktree "$REPO" --sha not-a-sha --test true --build true --mutate true 2>&1) || rc=$? ;;
     control-build) out=$(MUTATION_STABILITY_SETTLE=1 "$MS" --worktree "$REPO" --sha "$SHA_BASE" --test true --build false --mutate true 2>&1) || rc=$? ;;
     mutate) out=$(MUTATION_STABILITY_SETTLE=1 "$MS" --worktree "$REPO" --sha "$SHA_BASE" --test 'printf "test result: ok. 1 passed; 0 failed; 0 ignored\n"' --build true --mutate 'printf "mutation detail\n" >&2; false' 2>&1) || rc=$? ;;
@@ -223,6 +224,7 @@ missing option value	missing-value	error=argument-value-missing option=--worktre
 unknown option	unknown	error=argument-unknown argument=--unknown
 missing required options	arguments	error=arguments-missing set=worktree-sha-test-build-mutate
 temporary workspace failure	temp	error=temp-create-failed path=$TMP/absent
+temporary workspace path escaping	temp-space	error=temp-create-failed path=$TMP/space\ absent
 archive failure	archive	error=archive-failed sha=not-a-sha
 control build failure	control-build	error=control-build-failed exit=1
 mutation command failure	mutate	error=mutate-command-failed exit=1


### PR DESCRIPTION
## Summary

- Add one stable key/value mechanism for mutation-stability refusals and notices.
- Keep English explanations on later lines.
- Replace English test pins with key, value, and exit-status assertions.
- Keep the documented mutation summary protocol unchanged.
- Preserve source and tracked-render copies in the same change.

## Changed files

- `scripts/mutation-stability`
- `tests/mutation-stability.test.sh`
- The matching `.agents/skills/reviewer` renders.

## Compliant files left unchanged

- `SKILL.md` and `README.md`
- `references/perf-qa.md`
- `schemas/review-finding.md`
- `tests/measurement-fail-closed.test.sh`
- `workflows/codebase-review.md`, `workflows/qa-review.md`, and `workflows/review.md`
- The matching tracked renders.

## Validation

- Both Reviewer package suites pass.
- The changed diagnostic surface has must-fail controls.
- The repository commit chain passes.

Linear: KEN-1241
