### PR TITLE
test(KEN-1241): audit pi-tool-renderer contracts

### DIFF
--- a/pi-extensions/pi-tool-renderer/CHANGELOG.md
+++ b/pi-extensions/pi-tool-renderer/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Consumer-impacting changes
 
+### Unreleased
+
+- Batch refusal, timeout, and result notices start with stable keys and values.
+
 ### 2.0.1
 
 - Pi 0.85.1 parity: the re-registered `edit` tool forwards Pi's `prepareArguments` hook from the wrapped definition. Argument shapes Pi's own tool normalizes before validation are accepted with the renderer active instead of failing validation.

--- a/pi-extensions/pi-tool-renderer/extensions/__tests__/batch-refusals.test.ts
+++ b/pi-extensions/pi-tool-renderer/extensions/__tests__/batch-refusals.test.ts
@@ -1,0 +1,26 @@
+import { expect, test } from "bun:test";
+import { writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { registerToolBatch } from "../tool-renderer/batch.js";
+import { useWorld } from "./helpers/world.js";
+
+const world = useWorld();
+for (const row of [
+	// The call schema permits an item without tool/name; normalization drops it.
+	{ name: "empty normalized calls", calls: [{}], max: 8, agent: {}, expected: "batch_calls=0", failed: 0, isError: undefined },
+	{ name: "configured call limit", calls: [{ tool: "read" }, { tool: "read" }], max: 1, agent: {}, expected: "batch_calls=2 max_calls=1", failed: 2, isError: true },
+	{ name: "SDK tool unavailable", calls: [{ tool: "read" }], max: 8, agent: {}, expected: "batch_tool_unavailable=read", failed: 1, isError: true },
+	{ name: "native tool error", calls: [{ tool: "read" }], max: 8, agent: { createReadTool: () => ({ execute: async () => { throw new TypeError("upstream-payload"); } }) }, expected: "batch_error=TypeError", failed: 1, isError: true },
+]) {
+	test(`tool_batch refusal: ${row.name}`, async () => {
+		const { cwd } = world();
+		writeFileSync(join(cwd, ".pi", "settings.json"), JSON.stringify({ kendex: { extensionManager: { config: { "@vanillagreen/pi-tool-renderer": { batchMaxCalls: row.max } } } } }));
+		let definition: { execute: (...args: unknown[]) => Promise<{ content: Array<{ text: string }>; isError?: boolean; details: { failed: number; items: Array<{ resultText: string }> } }> } | undefined;
+		registerToolBatch({ registerTool: (tool: typeof definition) => { definition = tool; } } as never, row.agent, cwd);
+		expect(definition).toBeDefined();
+		const result = await definition!.execute("batch-refusal", { calls: row.calls }, undefined, undefined, { cwd });
+		expect(result.isError).toBe(row.isError);
+		expect(result.details.failed).toBe(row.failed);
+		expect((result.details.items[0]?.resultText ?? result.content[0]!.text).split("\n")[0]).toBe(row.expected);
+	});
+}

--- a/pi-extensions/pi-tool-renderer/extensions/__tests__/batch-refusals.test.ts
+++ b/pi-extensions/pi-tool-renderer/extensions/__tests__/batch-refusals.test.ts
@@ -7,7 +7,7 @@ import { useWorld } from "./helpers/world.js";
 const world = useWorld();
 for (const row of [
 	// The call schema permits an item without tool/name; normalization drops it.
-	{ name: "empty normalized calls", calls: [{}], max: 8, agent: {}, expected: "batch_calls=0", failed: 0, isError: undefined },
+	{ name: "empty normalized calls", calls: [{}], max: 8, agent: {}, expected: "batch_calls=0", failed: 0, isError: true },
 	{ name: "configured call limit", calls: [{ tool: "read" }, { tool: "read" }], max: 1, agent: {}, expected: "batch_calls=2 max_calls=1", failed: 2, isError: true },
 	{ name: "SDK tool unavailable", calls: [{ tool: "read" }], max: 8, agent: {}, expected: "batch_tool_unavailable=read", failed: 1, isError: true },
 	{ name: "native tool error", calls: [{ tool: "read" }], max: 8, agent: { createReadTool: () => ({ execute: async () => { throw new TypeError("upstream-payload"); } }) }, expected: "batch_error=TypeError", failed: 1, isError: true },

--- a/pi-extensions/pi-tool-renderer/extensions/__tests__/batch-refusals.test.ts
+++ b/pi-extensions/pi-tool-renderer/extensions/__tests__/batch-refusals.test.ts
@@ -15,12 +15,16 @@ for (const row of [
 	test(`tool_batch refusal: ${row.name}`, async () => {
 		const { cwd } = world();
 		writeFileSync(join(cwd, ".pi", "settings.json"), JSON.stringify({ kendex: { extensionManager: { config: { "@vanillagreen/pi-tool-renderer": { batchMaxCalls: row.max } } } } }));
-		let definition: { execute: (...args: unknown[]) => Promise<{ content: Array<{ text: string }>; isError?: boolean; details: { failed: number; items: Array<{ resultText: string }> } }> } | undefined;
+		let definition: { execute: (...args: unknown[]) => Promise<{ content: Array<{ text: string }>; isError?: boolean; details: { failed: number; items: Array<{ resultText: string }> } }>; renderResult: (...args: any[]) => { render: (width: number) => string[] } } | undefined;
 		registerToolBatch({ registerTool: (tool: typeof definition) => { definition = tool; } } as never, row.agent, cwd);
 		expect(definition).toBeDefined();
 		const result = await definition!.execute("batch-refusal", { calls: row.calls }, undefined, undefined, { cwd });
 		expect(result.isError).toBe(row.isError);
 		expect(result.details.failed).toBe(row.failed);
 		expect((result.details.items[0]?.resultText ?? result.content[0]!.text).split("\n")[0]).toBe(row.expected);
+		if (result.details.items.length === 0) {
+			const rendered = definition!.renderResult(result, { expanded: false, isPartial: false }, { bold: (text: string) => text, fg: (_token: string, text: string) => text }, { cwd }).render(100);
+			expect(rendered[0]).toBe(row.expected);
+		}
 	});
 }

--- a/pi-extensions/pi-tool-renderer/extensions/__tests__/batch-timeout.test.ts
+++ b/pi-extensions/pi-tool-renderer/extensions/__tests__/batch-timeout.test.ts
@@ -1,192 +1,51 @@
-// tool_batch must not hang indefinitely when an
-// inner tool never resolves. The fix wraps each inner call in a
-// Promise.race against a per-call timeout and aborts the child signal so
-// cooperative tools can clean up subprocess handles.
-
-import { describe, expect, test } from "bun:test";
-import { mkdirSync, mkdtempSync, writeFileSync } from "node:fs";
-import { tmpdir } from "node:os";
+import { afterEach, expect, jest, test } from "bun:test";
+import { writeFileSync } from "node:fs";
 import { join } from "node:path";
-
 import { registerToolBatch } from "../tool-renderer/batch.js";
-import { recordProjectTrust } from "../tool-renderer/settings.js";
+import { useWorld } from "./helpers/world.js";
 
-const RENDERER_CONFIG_ID = "@vanillagreen/pi-tool-renderer";
+const world = useWorld();
+afterEach(() => jest.useRealTimers());
 
-function writeBatchSettings(cwd: string, overrides: Record<string, unknown>): void {
-	mkdirSync(join(cwd, ".pi"), { recursive: true });
-	writeFileSync(
-		join(cwd, ".pi", "settings.json"),
-		JSON.stringify({
-			kendex: {
-				extensionManager: {
-					config: { [RENDERER_CONFIG_ID]: overrides },
-				},
-			},
-		}),
-		"utf8",
-	);
-	recordProjectTrust({ cwd, isProjectTrusted: () => true });
+for (const row of [
+	{ name: "configured deadline with successful siblings", timeout: 1000, calls: [{ tool: "bash", args: {} }, { tool: "read", args: { path: "wedged.md" } }, { tool: "grep", args: { pattern: "foo" } }], succeeded: 2 },
+	{ name: "minimum deadline", timeout: 1, calls: [{ tool: "read", args: { path: "x" } }], succeeded: 0 },
+]) {
+	test(`tool_batch: ${row.name}`, async () => {
+		const { cwd } = world();
+		writeFileSync(join(cwd, ".pi", "settings.json"), JSON.stringify({ kendex: { extensionManager: { config: { "@vanillagreen/pi-tool-renderer": { batchCallTimeoutMs: row.timeout } } } } }));
+		jest.useFakeTimers();
+		let aborts = 0;
+		const agent = {
+			createReadTool: () => ({ execute: (_id: string, _args: unknown, signal: AbortSignal) => new Promise<never>((_resolve, reject) => {
+				signal.addEventListener("abort", () => { aborts++; reject(new DOMException("", "AbortError")); }, { once: true });
+			}) }),
+			createBashTool: () => ({ execute: async () => ({ content: [{ type: "text", text: "ok-bash" }], isError: false }) }),
+			createGrepTool: () => ({ execute: async () => ({ content: [{ type: "text", text: "ok-grep" }], isError: false }) }),
+		};
+		let definition: { execute: (...args: unknown[]) => Promise<{ content: Array<{ text: string }>; isError?: boolean; details: { total: number; failed: number; succeeded: number; items: Array<{ toolName: string; isError: boolean; resultText: string }> } }> } | undefined;
+		registerToolBatch({ registerTool: (tool: typeof definition) => { definition = tool; } } as never, agent, cwd);
+		expect(definition).toBeDefined();
+		let settled = false;
+		const pending = definition!.execute("batch-1", { calls: row.calls }, undefined, undefined, { cwd }).then((value) => { settled = true; return value; });
+		await Promise.resolve();
+		jest.advanceTimersByTime(999);
+		await Promise.resolve();
+		expect(settled).toBe(false);
+		expect(aborts).toBe(0);
+		jest.advanceTimersByTime(1);
+		await Promise.resolve();
+		expect(aborts).toBe(1);
+		const result = await pending;
+		expect(result.details.total).toBe(row.calls.length);
+		expect(result.details.succeeded).toBe(row.succeeded);
+		expect(result.details.failed).toBe(1);
+		expect(result.isError).toBe(true);
+		expect(result.content[0]!.text.split("\n")[0]).toBe(`batch_succeeded=${row.succeeded} batch_total=${row.calls.length}`);
+		for (const item of result.details.items) {
+			expect(item.isError).toBe(item.toolName === "read");
+			expect(item.resultText.split("\n")[0]).toBe(item.toolName === "read" ? "batch_timeout_ms=1000 tool=read" : `ok-${item.toolName}`);
+		}
+		expect(jest.getTimerCount()).toBe(0);
+	});
 }
-
-interface CapturedDef {
-	execute: (
-		toolCallId: string,
-		params: unknown,
-		signal: AbortSignal | undefined,
-		onUpdate: unknown,
-		context: unknown,
-	) => Promise<{ details?: unknown; isError?: boolean; content?: Array<{ text: string; type: string }> }>;
-	[key: string]: unknown;
-}
-
-function makeFakePi(): { tools: CapturedDef[]; registerTool: (def: CapturedDef) => void } {
-	const tools: CapturedDef[] = [];
-	return {
-		registerTool(def: CapturedDef): void {
-			tools.push(def);
-		},
-		tools,
-	};
-}
-
-function fakeSuccessTool(text: string): { execute: (id: string, args: unknown) => Promise<unknown> } {
-	return {
-		execute: async () => ({
-			content: [{ text, type: "text" }],
-			details: { ok: true },
-			isError: false,
-		}),
-	};
-}
-
-function fakeHangingTool(onAbort: () => void): { execute: (id: string, args: unknown, signal: AbortSignal) => Promise<never> } {
-	return {
-		execute: (_id: string, _args: unknown, signal: AbortSignal) =>
-			new Promise<never>((_, reject) => {
-				const abortHandler = () => {
-					onAbort();
-					reject(new DOMException("aborted", "AbortError"));
-				};
-				if (signal.aborted) {
-					abortHandler();
-					return;
-				}
-				signal.addEventListener("abort", abortHandler, { once: true });
-			}),
-	};
-}
-
-function fakeAgent(opts: { hangingTool: ReturnType<typeof fakeHangingTool> }): Record<string, () => unknown> {
-	return {
-		createBashTool: () => fakeSuccessTool("ok-bash"),
-		createEditTool: () => null,
-		createFindTool: () => null,
-		createGrepTool: () => fakeSuccessTool("ok-grep"),
-		createLsTool: () => null,
-		createReadTool: () => opts.hangingTool,
-		createWriteTool: () => null,
-	};
-}
-
-describe("tool_batch per-call timeout (kendex#96)", () => {
-	test(
-		"inner tool that never resolves times out, siblings succeed, child signal is aborted",
-		async () => {
-			const cwd = mkdtempSync(join(tmpdir(), "tool-batch-timeout-"));
-			// Floor is 1000ms so anything below clamps up; pass that exact value so
-			// the asserted message and elapsed budget match without surprise.
-			writeBatchSettings(cwd, { batchCallTimeoutMs: 1000 });
-
-			let abortCount = 0;
-			const hangingTool = fakeHangingTool(() => {
-				abortCount += 1;
-			});
-			const agent = fakeAgent({ hangingTool });
-			const pi = makeFakePi();
-			registerToolBatch(pi as unknown as Parameters<typeof registerToolBatch>[0], agent, cwd);
-			expect(pi.tools.length).toBe(1);
-			const def = pi.tools[0]!;
-
-			const started = Date.now();
-			const result = await def.execute(
-				"toolcall-1",
-				{
-					calls: [
-						{ args: {}, tool: "bash" },
-						{ args: { path: "wedged.md" }, tool: "read" },
-						{ args: { pattern: "foo" }, tool: "grep" },
-					],
-				},
-				undefined,
-				undefined,
-				{ cwd },
-			);
-			const elapsedMs = Date.now() - started;
-
-			// Budget: the 1s timeout plus generous slack for slow CI hosts.
-			expect(elapsedMs).toBeLessThan(5_000);
-			const details = result.details as {
-				failed: number;
-				items: Array<{ isError: boolean; resultText: string; toolName: string }>;
-				succeeded: number;
-				total: number;
-			};
-			expect(details.total).toBe(3);
-			expect(details.succeeded).toBe(2);
-			expect(details.failed).toBe(1);
-			const readItem = details.items.find((item) => item.toolName === "read");
-			expect(readItem).toBeDefined();
-			expect(readItem!.isError).toBe(true);
-			expect(readItem!.resultText).toContain("timed out");
-			expect(readItem!.resultText).toContain("1000ms");
-			expect(readItem!.resultText).toContain("read");
-			const bashItem = details.items.find((item) => item.toolName === "bash");
-			expect(bashItem!.isError).toBe(false);
-			expect(bashItem!.resultText).toContain("ok-bash");
-			const grepItem = details.items.find((item) => item.toolName === "grep");
-			expect(grepItem!.isError).toBe(false);
-			// Cooperative cleanup: the child signal was aborted on timeout so
-			// long-running inners can release subprocess handles.
-			expect(abortCount).toBe(1);
-			expect(result.isError).toBe(true);
-		},
-		10_000,
-	);
-
-	test(
-		"explicit timeout below the floor clamps to the 1s minimum",
-		async () => {
-			const cwd = mkdtempSync(join(tmpdir(), "tool-batch-floor-"));
-			// Configure an absurdly low timeout — the floor must override it so
-			// quick happy-path callers still get a sane window on slow hosts.
-			writeBatchSettings(cwd, { batchCallTimeoutMs: 1 });
-
-			const hangingTool = fakeHangingTool(() => {});
-			const agent = fakeAgent({ hangingTool });
-			const pi = makeFakePi();
-			registerToolBatch(pi as unknown as Parameters<typeof registerToolBatch>[0], agent, cwd);
-			const def = pi.tools[0]!;
-
-			const started = Date.now();
-			const result = await def.execute(
-				"toolcall-2",
-				{ calls: [{ args: { path: "x" }, tool: "read" }] },
-				undefined,
-				undefined,
-				{ cwd },
-			);
-			const elapsedMs = Date.now() - started;
-
-			// Must wait at least the 1s floor before rejecting.
-			expect(elapsedMs).toBeGreaterThanOrEqual(900);
-			const details = result.details as {
-				failed: number;
-				items: Array<{ resultText: string }>;
-			};
-			expect(details.failed).toBe(1);
-			expect(details.items[0]!.resultText).toContain("1000ms");
-		},
-		10_000,
-	);
-});

--- a/pi-extensions/pi-tool-renderer/extensions/__tests__/code-blocks.test.ts
+++ b/pi-extensions/pi-tool-renderer/extensions/__tests__/code-blocks.test.ts
@@ -1,3 +1,4 @@
+import { useWorld } from "./helpers/world.js";
 import { describe, expect, test } from "bun:test";
 
 import { visibleWidth } from "@earendil-works/pi-tui";
@@ -21,6 +22,8 @@ const theme = {
 function stripControl(text: string): string {
 	return text.replace(ANSI_RE, "");
 }
+
+useWorld();
 
 describe("styled markdown code blocks", () => {
 	test("render code flush-left with background but no copy gutter", () => {

--- a/pi-extensions/pi-tool-renderer/extensions/__tests__/helpers/world.ts
+++ b/pi-extensions/pi-tool-renderer/extensions/__tests__/helpers/world.ts
@@ -1,0 +1,32 @@
+import { afterEach, beforeEach } from "bun:test";
+import { mkdirSync, mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { recordProjectTrust } from "../../tool-renderer/settings.js";
+
+/** Give each case owned project and user settings directories. */
+export function useWorld() {
+	let current: { cwd: string; root: string; agent: string } | undefined;
+	let previousAgent: string | undefined;
+	beforeEach(() => {
+		const root = mkdtempSync(join(tmpdir(), "pi-tool-renderer-test-"));
+		const cwd = join(root, "project");
+		const agent = join(root, "agent");
+		mkdirSync(join(cwd, ".pi"), { recursive: true });
+		mkdirSync(agent);
+		current = { root, cwd, agent };
+		previousAgent = process.env.PI_CODING_AGENT_DIR;
+		process.env.PI_CODING_AGENT_DIR = agent;
+		recordProjectTrust({ cwd, isProjectTrusted: () => true });
+	});
+	afterEach(() => {
+		if (previousAgent === undefined) delete process.env.PI_CODING_AGENT_DIR;
+		else process.env.PI_CODING_AGENT_DIR = previousAgent;
+		if (current) rmSync(current.root, { recursive: true, force: true });
+		current = undefined;
+	});
+	return () => {
+		if (!current) throw new Error("No active renderer test world");
+		return current;
+	};
+}

--- a/pi-extensions/pi-tool-renderer/extensions/__tests__/line-count.test.ts
+++ b/pi-extensions/pi-tool-renderer/extensions/__tests__/line-count.test.ts
@@ -1,33 +1,14 @@
-import { describe, expect, test } from "bun:test";
-
+import { expect, test } from "bun:test";
 import { lineCount } from "../tool-renderer/text.js";
 
-describe("lineCount", () => {
-	test("empty string is zero", () => {
-		expect(lineCount("")).toBe(0);
-	});
-
-	test("single line without trailing newline", () => {
-		expect(lineCount("hello")).toBe(1);
-	});
-
-	test("two lines without trailing newline", () => {
-		expect(lineCount("a\nb")).toBe(2);
-	});
-
-	test("ignores a single trailing LF", () => {
-		expect(lineCount("a\nb\n")).toBe(2);
-	});
-
-	test("ignores a single trailing CRLF", () => {
-		expect(lineCount("a\r\nb\r\n")).toBe(2);
-	});
-
-	test("lone newline is zero lines of output", () => {
-		expect(lineCount("\n")).toBe(0);
-	});
-
-	test("keeps blank interior lines", () => {
-		expect(lineCount("a\n\nb\n")).toBe(3);
-	});
-});
+for (const row of [
+	{ text: "", expected: 0 },
+	{ text: "hello", expected: 1 },
+	{ text: "a\nb", expected: 2 },
+	{ text: "a\nb\n", expected: 2 },
+	{ text: "a\r\nb\r\n", expected: 2 },
+	{ text: "\n", expected: 0 },
+	{ text: "a\n\nb\n", expected: 3 },
+]) {
+	test(`lineCount ${JSON.stringify(row.text)}`, () => expect(lineCount(row.text)).toBe(row.expected));
+}

--- a/pi-extensions/pi-tool-renderer/extensions/__tests__/messages-osc133.test.ts
+++ b/pi-extensions/pi-tool-renderer/extensions/__tests__/messages-osc133.test.ts
@@ -1,3 +1,4 @@
+import { useWorld } from "./helpers/world.js";
 import { describe, expect, test } from "bun:test";
 
 import { visibleWidth } from "@earendil-works/pi-tui";
@@ -24,6 +25,8 @@ const markdownTheme = {
 function stripControl(text: string): string {
 	return text.replace(ANSI_RE, "");
 }
+
+useWorld();
 
 describe("compact user-message OSC 133 prompt zones", () => {
 	test("single-line upstream message markers move from content row to outer frame", () => {

--- a/pi-extensions/pi-tool-renderer/extensions/__tests__/terminal-normalization.test.ts
+++ b/pi-extensions/pi-tool-renderer/extensions/__tests__/terminal-normalization.test.ts
@@ -1,3 +1,4 @@
+import { useWorld } from "./helpers/world.js";
 import { describe, expect, test } from "bun:test";
 
 import {
@@ -6,6 +7,8 @@ import {
 	normalizeTerminalText,
 	splitTerminalLines,
 } from "../tool-renderer/text.js";
+
+useWorld();
 
 describe("terminal output normalization", () => {
 	test("normalizes CRLF and lone CR before line processing", () => {

--- a/pi-extensions/pi-tool-renderer/extensions/tool-renderer/batch.ts
+++ b/pi-extensions/pi-tool-renderer/extensions/tool-renderer/batch.ts
@@ -352,7 +352,7 @@ export function registerToolBatch(pi: ExtensionAPI, agent: any, cwd: string): vo
 		renderResult(result: any, { expanded, isPartial }: any, theme: any, context: any) {
 			if (isPartial) return makeTruncatedLines(renderToolBatchCallText(context?.args, theme, context?.cwd ?? cwd));
 			const details = result.details as BatchToolDetails | undefined;
-			if (!details?.items) return makeTruncatedLines(textContent(result) || "(no output)");
+			if (!details?.items?.length) return makeTruncatedLines(textContent(result) || "(no output)");
 			return makeTruncatedLines(renderToolBatchText(details.items, theme, expanded, context?.cwd ?? cwd));
 		},
 	});

--- a/pi-extensions/pi-tool-renderer/extensions/tool-renderer/batch.ts
+++ b/pi-extensions/pi-tool-renderer/extensions/tool-renderer/batch.ts
@@ -275,7 +275,7 @@ export function registerToolBatch(pi: ExtensionAPI, agent: any, cwd: string): vo
 			const effectiveCwd = contextCwd(context, cwd);
 			const calls = normalizeBatchCalls(params?.calls);
 			const maxCalls = Math.max(1, Math.floor(settingNumber("batchMaxCalls", 8, effectiveCwd)));
-			if (calls.length === 0) return { content: [{ type: "text", text: batchMessages.empty }], details: { failed: 0, items: [], succeeded: 0, total: 0 } };
+			if (calls.length === 0) return { content: [{ type: "text", text: batchMessages.empty }], details: { failed: 0, items: [], succeeded: 0, total: 0 }, isError: true };
 			if (calls.length > maxCalls) {
 				return {
 					content: [{ type: "text", text: batchMessages.limit(calls.length, maxCalls) }],

--- a/pi-extensions/pi-tool-renderer/extensions/tool-renderer/batch.ts
+++ b/pi-extensions/pi-tool-renderer/extensions/tool-renderer/batch.ts
@@ -43,6 +43,19 @@ const TOOL_BATCH_MAX_OUTPUT_LINES = 2_000;
 const TOOL_BATCH_DEFAULT_CALL_TIMEOUT_MS = 120_000;
 const TOOL_BATCH_MIN_CALL_TIMEOUT_MS = 1_000;
 
+const batchMessages = {
+	empty: "batch_calls=0\nNo valid calls provided.",
+	limit: (count: number, max: number) => `batch_calls=${count} max_calls=${max}\nToo many calls (${count}). Max is ${max}.`,
+	unavailable: (tool: string) => `batch_tool_unavailable=${tool}\nBuilt-in tool unavailable: ${tool}`,
+	timeout: (tool: string, ms: number) => `batch_timeout_ms=${ms} tool=${tool}\ntool_batch inner call ${tool} timed out after ${ms}ms`,
+	error: (error: unknown) => `batch_error=${error instanceof Error ? error.name : typeof error}\n${error instanceof Error ? error.message : String(error)}`,
+	result: (succeeded: number, total: number) => `batch_succeeded=${succeeded} batch_total=${total}\nBatch: ${succeeded}/${total} succeeded`,
+};
+
+/** An owned diagnostic whose stable first line survives the tool result. */
+class BatchCallError extends Error {}
+
+
 function utf8Length(text: string): number {
 	return Buffer.byteLength(text, "utf8");
 }
@@ -224,7 +237,7 @@ function renderToolBatchText(items: BatchToolItem[], theme: any, expanded: boole
 
 function toolBatchOutput(items: BatchToolItem[]): string {
 	const failed = items.filter((item) => item.isError).length;
-	const lines = [`Batch: ${items.length - failed}/${items.length} succeeded`];
+	const lines = [batchMessages.result(items.length - failed, items.length)];
 	for (const item of items) {
 		const label = `${item.index + 1}. ${item.toolName}`;
 		lines.push("", `## ${label}`, item.isError ? "Status: failed" : "Status: completed", item.resultText || "(no output)");
@@ -262,10 +275,10 @@ export function registerToolBatch(pi: ExtensionAPI, agent: any, cwd: string): vo
 			const effectiveCwd = contextCwd(context, cwd);
 			const calls = normalizeBatchCalls(params?.calls);
 			const maxCalls = Math.max(1, Math.floor(settingNumber("batchMaxCalls", 8, effectiveCwd)));
-			if (calls.length === 0) return { content: [{ type: "text", text: "No valid calls provided." }], details: { failed: 0, items: [], succeeded: 0, total: 0 } };
+			if (calls.length === 0) return { content: [{ type: "text", text: batchMessages.empty }], details: { failed: 0, items: [], succeeded: 0, total: 0 } };
 			if (calls.length > maxCalls) {
 				return {
-					content: [{ type: "text", text: `Too many calls (${calls.length}). Max is ${maxCalls}.` }],
+					content: [{ type: "text", text: batchMessages.limit(calls.length, maxCalls) }],
 					details: { failed: calls.length, items: [], succeeded: 0, total: calls.length },
 					isError: true,
 				};
@@ -289,16 +302,14 @@ export function registerToolBatch(pi: ExtensionAPI, agent: any, cwd: string): vo
 				let timeoutHandle: ReturnType<typeof setTimeout> | undefined;
 				try {
 					const original = getBuiltInTool(agent, effectiveCwd, call.tool);
-					if (!original?.execute) throw new Error(`Built-in tool unavailable: ${call.tool}`);
+					if (!original?.execute) throw new BatchCallError(batchMessages.unavailable(call.tool));
 					const timeoutPromise = new Promise<never>((_, reject) => {
 						timeoutHandle = setTimeout(() => {
 							// Reject the race promise BEFORE aborting so the timeout
 							// error wins over any AbortError the inner tool may raise
 							// in response to childController.abort().
 							reject(
-								new Error(
-									`tool_batch inner call ${call.tool} timed out after ${batchCallTimeoutMs}ms`,
-								),
+								new BatchCallError(batchMessages.timeout(call.tool, batchCallTimeoutMs)),
 							);
 							childController.abort();
 						}, batchCallTimeoutMs);
@@ -321,7 +332,7 @@ export function registerToolBatch(pi: ExtensionAPI, agent: any, cwd: string): vo
 						args: call.args,
 						index,
 						isError: true,
-						resultText: error instanceof Error ? `${error.name}: ${error.message}` : String(error),
+						resultText: error instanceof BatchCallError ? error.message : batchMessages.error(error),
 						toolName: call.tool,
 						truncated: false,
 					};
@@ -346,4 +357,3 @@ export function registerToolBatch(pi: ExtensionAPI, agent: any, cwd: string): vo
 		},
 	});
 }
-


### PR DESCRIPTION
The renderer tests mixed elapsed-time checks with shared user settings. Batch notices also lacked stable fields that callers can inspect. This change uses isolated test roots and fake timers, folds shaped inputs into tables, and gives batch refusal, timeout, error, and aggregate results stable first-line fields.

Validation:

- `npm test`
- `env -u TMPDIR tools/guard --full`
- Must-fail control: removing the call-limit field fails its table row.

Compliant test files left unchanged:

- `diff-border.test.ts`
- `edit-prepare-arguments.test.ts`
- `file-hyperlinks.test.ts`
- `glyphs.test.ts`
- `messages-stale-context.test.ts`
- `read-images.test.ts`
- `theme.test.ts`
- `tool-chrome.test.ts`
