### PR TITLE
test(KEN-1241): isolate successful secret process response

### DIFF
--- a/pi-extensions/pi-web-tools/tests/settings-secrets.test.ts
+++ b/pi-extensions/pi-web-tools/tests/settings-secrets.test.ts
@@ -1,20 +1,22 @@
 import assert from "node:assert/strict";
+import childProcess from "node:child_process";
 import { chmodSync, mkdirSync, writeFileSync } from "node:fs";
+import { syncBuiltinESMExports } from "node:module";
 import { join } from "node:path";
 import test from "node:test";
 import { loadSettings } from "../src/settings.js";
 import { isolateEnvironment, settingsEnvironment, tempDir } from "./fixtures.js";
 
-for (const { name, program, expected } of [
+for (const { name, timeout, expected } of [
 	{
 		name: "timeout returns with key unset",
-		program: 'Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, 5000); process.stdout.write("late-secret");',
-		expected: { key: undefined, bounded: true, warnings: 2, keyName: true, timeout: true, referenceDisclosed: false },
+		timeout: true,
+		expected: { key: undefined, bounded: true, warnings: 2, keyName: true, timeout: true, referenceDisclosed: false, requests: [] },
 	},
 	{
 		name: "resolved secret",
-		program: 'if (process.argv[2] !== "read" || process.argv[3] !== "op://vault/exa/key") process.exit(1); process.stdout.write("resolved-exa");',
-		expected: { key: "resolved-exa", bounded: true, warnings: 1, keyName: false, timeout: false, referenceDisclosed: false },
+		timeout: false,
+		expected: { key: "resolved-exa", bounded: undefined, warnings: 1, keyName: false, timeout: false, referenceDisclosed: false, requests: [{ command: "op", args: ["read", "op://vault/exa/key"] }] },
 	},
 ]) {
 	test(`settings secret process: ${name}`, (t) => {
@@ -27,9 +29,20 @@ for (const { name, program, expected } of [
 		mkdirSync(user);
 		mkdirSync(project);
 		mkdirSync(bin);
-		// The executable is the child itself. It creates no descendants that can outlive spawnSync.
-		writeFileSync(join(bin, "op"), `#!${process.execPath}\n${program}\n`);
-		chmodSync(join(bin, "op"), 0o755);
+		const requests: Array<{ command: string; args: readonly string[] }> = [];
+		if (timeout) {
+			// The executable is the child itself. It creates no descendants that can outlive spawnSync.
+			writeFileSync(join(bin, "op"), `#!${process.execPath}\nAtomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, 5000); process.stdout.write("late-secret");\n`);
+			chmodSync(join(bin, "op"), 0o755);
+		} else {
+			// Successful secret parsing does not depend on a child starting before the timeout fixture's deadline.
+			const spawn = t.mock.method(childProcess, "spawnSync", (command: string, args: readonly string[]) => {
+				requests.push({ command, args });
+				return { pid: 1, output: [null, "resolved-exa", ""], stdout: "resolved-exa", stderr: "", status: 0, signal: null };
+			});
+			syncBuiltinESMExports();
+			t.after(() => { spawn.mock.restore(); syncBuiltinESMExports(); });
+		}
 		writeFileSync(join(user, "settings.json"), JSON.stringify({ kendex: { extensionManager: { config: { "@vanillagreen/pi-web-tools": { exaApiKey: "op://vault/exa/key" } } } } }));
 		process.env.PI_CODING_AGENT_DIR = user;
 		process.env.PATH = `${bin}:${path ?? ""}`;
@@ -38,11 +51,12 @@ for (const { name, program, expected } of [
 		const result = loadSettings(project);
 		assert.deepEqual({
 			key: result.apiKeys.exa,
-			bounded: performance.now() - started < 1500,
+			bounded: timeout ? performance.now() - started < 1500 : undefined,
 			warnings: result.warnings.length,
 			keyName: result.warnings.some((warning) => warning.includes("EXA_API_KEY")),
 			timeout: result.warnings.some((warning) => warning.includes("100ms")),
 			referenceDisclosed: result.warnings.some((warning) => warning.includes("op://")),
+			requests,
 		}, expected);
 	});
 }


### PR DESCRIPTION
The resolved-secret test shared the timeout case's short process deadline. A real Node process could miss that deadline before it returned the fixture secret, which made the success test depend on process startup speed.

The success row now intercepts the process response and checks the actual `op read` command and arguments. Per-case teardown restores the built-in process export. The timeout row still launches its owned child without descendants. It still checks key removal, timeout diagnostics, reference non-disclosure, and bounded return. Only `pi-extensions/pi-web-tools/tests/settings-secrets.test.ts` changes.

## Validation

- Focused secret tests: 2 passed in the ordinary temp environment.
- TypeScript: passed.
- Must-fail control: discarding production stdout fails the resolved-secret row with exit 1.
- Full guard passes at `8fae2796650aba9a46a2e27a00a7980c284f57b0` with the ordinary system temp selected by removing `TMPDIR`. The package suite passes 225 tests. The Rust workspace and UI pass. Current CI is still running. Copilot completed a formal review on this head with no findings, and no review threads are open.
- Evidence: `/home/method/dev/kendex/tmp/audit-i2/web-tools/secret-resume-*` and `secret-corrective-*`.
