### PR TITLE
fix(KEN-1241): stabilize extension manager diagnostics

### DIFF
--- a/pi-extensions/pi-extension-manager/extensions/extension-manager.ts
+++ b/pi-extensions/pi-extension-manager/extensions/extension-manager.ts
@@ -20,6 +20,7 @@ import {
 	mergedManagerState,
 	updateManagerState,
 } from "./manager/settings.js";
+import { managerNotice } from "./manager/format.js";
 import { kickNpmUpdateCheck } from "./manager/versions.js";
 import { INSTALL_SYMBOL, MANAGER_ID, KENDEX_OPEN_QUICK_SETTINGS_SYMBOL } from "./manager/types.js";
 
@@ -38,13 +39,13 @@ export default async function extensionManager(pi: ExtensionAPI): Promise<void> 
 			updateManagerState(file, (state) => {
 				state.config[MANAGER_ID] = { ...(state.config[MANAGER_ID] ?? {}), enabled: true };
 			});
-			ctx.ui.notify("Extension manager enabled. Run /reload to restore the full UI.", "info");
+			ctx.ui.notify(managerNotice("manager-enabled", MANAGER_ID, "Extension manager enabled. Run /reload to restore the full UI."), "info");
 		};
 		pi.registerCommand(host.commands.manager, {
 			description: "Extension manager recovery command.",
 			handler: async (args, ctx) => {
 				if (args.trim().toLowerCase() !== "enable") {
-					ctx.ui.notify(`Extension manager UI is disabled. Run /${host.commands.recover}, then /reload, to restore it.`, "warning");
+					ctx.ui.notify(managerNotice("manager-disabled", MANAGER_ID, `Extension manager UI is disabled. Run /${host.commands.recover}, then /reload, to restore it.`), "warning");
 					return;
 				}
 				await enableRecovery(ctx);
@@ -139,7 +140,7 @@ export default async function extensionManager(pi: ExtensionAPI): Promise<void> 
 					const suffix = withUpdates.length > 3 ? `, +${withUpdates.length - 3} more` : "";
 					message = `${withUpdates.length} extension updates available: ${names}${suffix}. Run /${host.commands.manager} for update commands.`;
 				}
-				(ctx as ExtensionContext).ui?.notify(message, "warning");
+				(ctx as ExtensionContext).ui?.notify(managerNotice("updates-available", withUpdates.length, message), "warning");
 			}
 		}
 	});

--- a/pi-extensions/pi-extension-manager/extensions/manager/actions.ts
+++ b/pi-extensions/pi-extension-manager/extensions/manager/actions.ts
@@ -2,7 +2,7 @@ import type { ExtensionAPI, ExtensionCommandContext, ExtensionContext } from "@e
 import { mkdirSync } from "node:fs";
 import { join, sep } from "node:path";
 import { removeAppendSystemBlockForUninstall, syncAppendSystemForPackage } from "./append-system.js";
-import { managerNotice, stringifyError } from "./format.js";
+import { managerFailure, managerNotice, stringifyError } from "./format.js";
 import { host } from "./host.js";
 import { normalizePackageEntry } from "./inventory.js";
 import { runCommand } from "./process.js";
@@ -276,7 +276,7 @@ export function toggleItem(_pi: ExtensionAPI, ctx: ExtensionCommandContext | Ext
 			return;
 		}
 	} catch (error) {
-		ctx.ui.notify(managerNotice("toggle-failed", item.id, stringifyError(error)), "error");
+		ctx.ui.notify(managerFailure("toggle-failed", item.id, error), "error");
 		return;
 	}
 	const scope = defaultWriteScope(item, inventory.settingsFiles, inventory.managerState);

--- a/pi-extensions/pi-extension-manager/extensions/manager/actions.ts
+++ b/pi-extensions/pi-extension-manager/extensions/manager/actions.ts
@@ -2,7 +2,7 @@ import type { ExtensionAPI, ExtensionCommandContext, ExtensionContext } from "@e
 import { mkdirSync } from "node:fs";
 import { join, sep } from "node:path";
 import { removeAppendSystemBlockForUninstall, syncAppendSystemForPackage } from "./append-system.js";
-import { stringifyError } from "./format.js";
+import { managerNotice, stringifyError } from "./format.js";
 import { host } from "./host.js";
 import { normalizePackageEntry } from "./inventory.js";
 import { runCommand } from "./process.js";
@@ -16,6 +16,10 @@ import {
 	type UninstallPlan,
 	type UpdatePlan,
 } from "./types.js";
+
+function launchFailure(command: string, error: unknown): string {
+	return managerNotice("command-launch", command, `Could not start the command: ${stringifyError(error)}`);
+}
 
 function npmRootFromPackageDir(packageDir: string | undefined): string | undefined {
 	if (!packageDir) return undefined;
@@ -44,7 +48,7 @@ function npmCommandForScope(files: SettingsFile[], scope: InventoryItem["scope"]
 		const argv = raw.filter((value): value is string => typeof value === "string" && value.length > 0);
 		if (argv.length > 0) return { command: argv[0], argsPrefix: argv.slice(1), display: shellJoin(argv) };
 	}
-	if (raw !== undefined) return { command: "npm", argsPrefix: [], display: "npm", warning: `Warning: ${scope} settings.json has invalid npmCommand; falling back to npm.` };
+	if (raw !== undefined) return { command: "npm", argsPrefix: [], display: "npm", warning: managerNotice("npm-command-invalid", scope, "The npmCommand setting is invalid. Falling back to npm.") };
 	return { command: "npm", argsPrefix: [], display: "npm" };
 }
 
@@ -53,7 +57,7 @@ function ensureWorkingDir(cwd: string): { ok: true } | { ok: false; message: str
 		mkdirSync(cwd, { recursive: true });
 		return { ok: true };
 	} catch (error) {
-		return { ok: false, message: `Failed to prepare npm working directory ${cwd}: ${stringifyError(error)}` };
+		return { ok: false, message: managerNotice("npm-cwd", cwd, `Could not prepare the npm working directory: ${stringifyError(error)}`) };
 	}
 }
 
@@ -113,18 +117,18 @@ function packageEntryMatches(item: InventoryItem, normalized: { source: string; 
 }
 
 export function runUninstall(plan: UninstallPlan, inventory: Inventory): { ok: boolean; message: string } {
-	if (!host.packageActions) return { ok: false, message: "Package uninstall is unsupported on this host; use its native plugin manager." };
+	if (!host.packageActions) return { ok: false, message: managerNotice("uninstall-unsupported", plan.item.id, "Package uninstall is unsupported on this host; use its native plugin manager.") };
 	if (plan.method.kind === "kendex") {
 		const args = ["remove", plan.method.packageName];
 		if (plan.method.scope === "user") args.push("--global");
 		const result = runCommand("kendex", args);
-		if (result.error) return { ok: false, message: `Failed to launch kendex: ${stringifyError(result.error)}` };
+		if (result.error) return { ok: false, message: launchFailure("kendex", result.error) };
 		if ((result.status ?? 1) !== 0) {
 			const stderr = (result.stderr ?? "").trim() || (result.stdout ?? "").trim() || `exit ${result.status}`;
-			return { ok: false, message: `kendex remove failed: ${stderr}` };
+			return { ok: false, message: managerNotice("kendex-uninstall-exit", result.status ?? 1, stderr) };
 		}
 		// `kendex remove` already handled APPEND_SYSTEM.md, so no extra cleanup here.
-		return { ok: true, message: `Removed via kendex: ${plan.item.displayName}.` };
+		return { ok: true, message: managerNotice("kendex-uninstalled", plan.item.packageName!, `Removed ${plan.item.displayName} via kendex.`) };
 	}
 	if (plan.method.kind === "npm") {
 		const args = ["uninstall", plan.method.npmName];
@@ -135,21 +139,21 @@ export function runUninstall(plan: UninstallPlan, inventory: Inventory): { ok: b
 		// APPEND_SYSTEM.md block goes with the tree.
 		removeAppendSystemBlockForUninstall(plan.item);
 		const result = runCommand(plan.method.command, [...plan.method.argsPrefix, ...args], { cwd: plan.method.cwd });
-		if (result.error) return { ok: false, message: `Failed to launch ${plan.method.command}: ${stringifyError(result.error)}` };
+		if (result.error) return { ok: false, message: launchFailure(plan.method.command, result.error) };
 		if ((result.status ?? 1) !== 0) {
 			const stderr = (result.stderr ?? "").trim() || (result.stdout ?? "").trim() || `exit ${result.status}`;
-			return { ok: false, message: `npm uninstall failed: ${stderr}` };
+			return { ok: false, message: managerNotice("npm-uninstall-exit", result.status ?? 1, stderr) };
 		}
 		const stripped = removePackageEntryFromSettings(plan.item, inventory.settingsFiles);
-		return { ok: true, message: `npm uninstall ${plan.method.npmName} succeeded${stripped ? "; removed Pi settings entry." : " (no settings entry to remove)."}` };
+		return { ok: true, message: managerNotice("npm-uninstalled", plan.method.npmName, `Uninstall succeeded${stripped ? "; removed Pi settings entry." : " (no settings entry to remove)."}`) };
 	}
 	const stripped = removePackageEntryFromSettings(plan.item, inventory.settingsFiles);
 	// Orphan branch: the settings.json strip is the only other cleanup, so
 	// remove this package's APPEND_SYSTEM.md block too.
 	removeAppendSystemBlockForUninstall(plan.item);
 	return stripped
-		? { ok: true, message: `Removed ${plan.item.sourceName} from ${plan.item.scope} settings.json.` }
-		: { ok: false, message: `Could not find a matching entry for ${plan.item.sourceName} in ${plan.item.scope} settings.json.` };
+		? { ok: true, message: managerNotice("settings-entry-removed", plan.item.sourceName, `Removed the entry from ${plan.item.scope} settings.json.`) }
+		: { ok: false, message: managerNotice("settings-entry-missing", plan.item.sourceName, `No matching entry exists in ${plan.item.scope} settings.json.`) };
 }
 
 export function planUpdate(item: InventoryItem, inventory: Inventory, ctx: ExtensionCommandContext | ExtensionContext): UpdatePlan | undefined {
@@ -178,29 +182,29 @@ export function planUpdate(item: InventoryItem, inventory: Inventory, ctx: Exten
 }
 
 export function runUpdate(plan: UpdatePlan): { ok: boolean; message: string } {
-	if (!host.packageActions) return { ok: false, message: "Package update is unsupported on this host; use its native plugin manager." };
+	if (!host.packageActions) return { ok: false, message: managerNotice("update-unsupported", plan.item.id, "Package update is unsupported on this host; use its native plugin manager.") };
 	if (plan.method.kind === "kendex") {
 		const args = ["add", plan.method.sourceRepo];
 		if (plan.method.scope === "user") args.push("--global");
 		args.push("--pi-extension", plan.method.packageName, "--harness", "pi", "-y");
 		const result = runCommand("kendex", args);
-		if (result.error) return { ok: false, message: `Failed to launch kendex: ${stringifyError(result.error)}` };
+		if (result.error) return { ok: false, message: launchFailure("kendex", result.error) };
 		if ((result.status ?? 1) !== 0) {
 			const stderr = (result.stderr ?? "").trim() || (result.stdout ?? "").trim() || `exit ${result.status}`;
-			return { ok: false, message: `kendex update failed: ${stderr}` };
+			return { ok: false, message: managerNotice("kendex-update-exit", result.status ?? 1, stderr) };
 		}
-		return { ok: true, message: `Updated via kendex: ${plan.item.displayName}.` };
+		return { ok: true, message: managerNotice("kendex-updated", plan.item.packageName!, `Updated ${plan.item.displayName} via kendex.`) };
 	}
 	const args = ["install", `${plan.method.npmName}@latest`];
 	const prepared = ensureWorkingDir(plan.method.cwd);
 	if (!prepared.ok) return prepared;
 	const result = runCommand(plan.method.command, [...plan.method.argsPrefix, ...args], { cwd: plan.method.cwd });
-	if (result.error) return { ok: false, message: `Failed to launch ${plan.method.command}: ${stringifyError(result.error)}` };
+	if (result.error) return { ok: false, message: launchFailure(plan.method.command, result.error) };
 	if ((result.status ?? 1) !== 0) {
 		const stderr = (result.stderr ?? "").trim() || (result.stdout ?? "").trim() || `exit ${result.status}`;
-		return { ok: false, message: `npm update failed: ${stderr}` };
+		return { ok: false, message: managerNotice("npm-update-exit", result.status ?? 1, stderr) };
 	}
-	return { ok: true, message: `Updated via npm: ${plan.method.npmName}.` };
+	return { ok: true, message: managerNotice("npm-updated", plan.method.npmName, "Package updated via npm.") };
 }
 
 function setPackageFiltered(item: InventoryItem, files: SettingsFile[], disabled: boolean): boolean {
@@ -263,16 +267,16 @@ function setPackageExtensionFiltered(item: InventoryItem, files: SettingsFile[],
 
 export function toggleItem(_pi: ExtensionAPI, ctx: ExtensionCommandContext | ExtensionContext, inventory: Inventory, item: InventoryItem): void {
 	if ((item.id === `package:${MANAGER_ID}` || item.packageName === MANAGER_ID) && item.state !== "disabled") {
-		ctx.ui.notify("Refusing to disable pi-extension-manager from inside itself. Use the host's controls outside this manager if needed.", "warning");
+		ctx.ui.notify(managerNotice("self-disable", MANAGER_ID, "The manager cannot disable itself. Use the host controls outside this manager."), "warning");
 		return;
 	}
 	try {
 		if (host.toggle(item)) {
-			ctx.ui.notify("Native plugin state updated. Restart the host to apply all plugin contributions.", "warning");
+			ctx.ui.notify(managerNotice("native-state-updated", item.id, "Native plugin state updated. Restart the host to apply all plugin contributions."), "warning");
 			return;
 		}
 	} catch (error) {
-		ctx.ui.notify(stringifyError(error), "error");
+		ctx.ui.notify(managerNotice("toggle-failed", item.id, stringifyError(error)), "error");
 		return;
 	}
 	const scope = defaultWriteScope(item, inventory.settingsFiles, inventory.managerState);
@@ -289,15 +293,15 @@ export function toggleItem(_pi: ExtensionAPI, ctx: ExtensionCommandContext | Ext
 	if (item.kind === "package" && item.packageName) {
 		const changed = setPackageFiltered(item, inventory.settingsFiles, willDisable);
 		syncAppendSystemForPackage(item, willDisable);
-		ctx.ui.notify(changed ? "Package setting updated. Run /reload or restart Pi to apply module loading changes." : "Item toggle saved. Reload may be required.", "warning");
+		ctx.ui.notify(managerNotice("package-toggle-saved", item.id, changed ? "Package setting updated. Run /reload or restart Pi to apply module loading changes." : "Item toggle saved. Reload may be required."), "warning");
 		return;
 	}
 
 	if (item.kind === "extension module" && item.packageName && item.entrypoint) {
 		const changed = setPackageExtensionFiltered(item, inventory.settingsFiles, willDisable);
-		ctx.ui.notify(changed ? "Extension module filter updated. Run /reload or restart Pi to apply." : "Module toggle saved. Reload may be required.", "warning");
+		ctx.ui.notify(managerNotice("module-toggle-saved", item.id, changed ? "Extension module filter updated. Run /reload or restart Pi to apply." : "Module toggle saved. Reload may be required."), "warning");
 		return;
 	}
 
-	ctx.ui.notify("Item toggle saved. Pi cannot unload this resource type live; /reload or restart may be required.", "warning");
+	ctx.ui.notify(managerNotice("item-toggle-saved", item.id, "Item toggle saved. Pi cannot unload this resource type live; /reload or restart may be required."), "warning");
 }

--- a/pi-extensions/pi-extension-manager/extensions/manager/actions.ts
+++ b/pi-extensions/pi-extension-manager/extensions/manager/actions.ts
@@ -17,8 +17,8 @@ import {
 	type UpdatePlan,
 } from "./types.js";
 
-function launchFailure(command: string, error: unknown): string {
-	return managerNotice("command-launch", command, `Could not start the command: ${stringifyError(error)}`);
+function launchFailure(key: string, command: string, error: unknown): string {
+	return managerNotice(key, command, `Could not start the command: ${stringifyError(error)}`);
 }
 
 function exitFailure(key: string, result: ReturnType<typeof runCommand>): string {
@@ -59,12 +59,12 @@ function npmCommandForScope(files: SettingsFile[], scope: InventoryItem["scope"]
 	return { command: "npm", argsPrefix: [], display: "npm" };
 }
 
-function ensureWorkingDir(cwd: string): { ok: true } | { ok: false; message: string } {
+function ensureWorkingDir(key: string, cwd: string): { ok: true } | { ok: false; message: string } {
 	try {
 		mkdirSync(cwd, { recursive: true });
 		return { ok: true };
 	} catch (error) {
-		return { ok: false, message: managerNotice("npm-cwd", cwd, `Could not prepare the npm working directory: ${stringifyError(error)}`) };
+		return { ok: false, message: managerNotice(key, cwd, `Could not prepare the npm working directory: ${stringifyError(error)}`) };
 	}
 }
 
@@ -129,7 +129,7 @@ export function runUninstall(plan: UninstallPlan, inventory: Inventory): { ok: b
 		const args = ["remove", plan.method.packageName];
 		if (plan.method.scope === "user") args.push("--global");
 		const result = runCommand("kendex", args);
-		if (result.error) return { ok: false, message: launchFailure("kendex", result.error) };
+		if (result.error) return { ok: false, message: launchFailure("kendex-uninstall-launch", "kendex", result.error) };
 		if ((result.status ?? 1) !== 0) {
 			return { ok: false, message: exitFailure("kendex-uninstall-exit", result) };
 		}
@@ -138,14 +138,14 @@ export function runUninstall(plan: UninstallPlan, inventory: Inventory): { ok: b
 	}
 	if (plan.method.kind === "npm") {
 		const args = ["uninstall", plan.method.npmName];
-		const prepared = ensureWorkingDir(plan.method.cwd);
+		const prepared = ensureWorkingDir("npm-uninstall-cwd", plan.method.cwd);
 		if (!prepared.ok) return prepared;
 		// Before npm deletes the package tree: npm 7+ does not reliably run a
 		// removed package's own `preuninstall`, and the script that owns the
 		// APPEND_SYSTEM.md block goes with the tree.
 		removeAppendSystemBlockForUninstall(plan.item);
 		const result = runCommand(plan.method.command, [...plan.method.argsPrefix, ...args], { cwd: plan.method.cwd });
-		if (result.error) return { ok: false, message: launchFailure(plan.method.command, result.error) };
+		if (result.error) return { ok: false, message: launchFailure("npm-uninstall-launch", plan.method.command, result.error) };
 		if ((result.status ?? 1) !== 0) {
 			return { ok: false, message: exitFailure("npm-uninstall-exit", result) };
 		}
@@ -193,17 +193,17 @@ export function runUpdate(plan: UpdatePlan): { ok: boolean; message: string } {
 		if (plan.method.scope === "user") args.push("--global");
 		args.push("--pi-extension", plan.method.packageName, "--harness", "pi", "-y");
 		const result = runCommand("kendex", args);
-		if (result.error) return { ok: false, message: launchFailure("kendex", result.error) };
+		if (result.error) return { ok: false, message: launchFailure("kendex-update-launch", "kendex", result.error) };
 		if ((result.status ?? 1) !== 0) {
 			return { ok: false, message: exitFailure("kendex-update-exit", result) };
 		}
 		return { ok: true, message: managerNotice("kendex-updated", plan.item.packageName!, `Updated ${plan.item.displayName} via kendex.`) };
 	}
 	const args = ["install", `${plan.method.npmName}@latest`];
-	const prepared = ensureWorkingDir(plan.method.cwd);
+	const prepared = ensureWorkingDir("npm-update-cwd", plan.method.cwd);
 	if (!prepared.ok) return prepared;
 	const result = runCommand(plan.method.command, [...plan.method.argsPrefix, ...args], { cwd: plan.method.cwd });
-	if (result.error) return { ok: false, message: launchFailure(plan.method.command, result.error) };
+	if (result.error) return { ok: false, message: launchFailure("npm-update-launch", plan.method.command, result.error) };
 	if ((result.status ?? 1) !== 0) {
 		return { ok: false, message: exitFailure("npm-update-exit", result) };
 	}

--- a/pi-extensions/pi-extension-manager/extensions/manager/actions.ts
+++ b/pi-extensions/pi-extension-manager/extensions/manager/actions.ts
@@ -82,7 +82,7 @@ export function planUninstall(item: InventoryItem, inventory: Inventory, ctx: Ex
 			item,
 			method: { kind: "npm", npmName, scope: item.scope, cwd, command: npm.command, argsPrefix: npm.argsPrefix },
 			command: `(cd ${shellQuote(cwd)} && ${npm.display} uninstall ${npmName})`,
-			description: `${npm.warning ? `${npm.warning} ` : ""}Installed via npm — runs npm uninstall in Pi's scope-local npm directory, then strips the npm: entry from Pi settings.json.`,
+			description: `${npm.warning ? `${npm.warning}\n` : ""}Installed via npm — runs npm uninstall in Pi's scope-local npm directory, then strips the npm: entry from Pi settings.json.`,
 		};
 	}
 	return {
@@ -175,7 +175,7 @@ export function planUpdate(item: InventoryItem, inventory: Inventory, ctx: Exten
 			item,
 			method: { kind: "npm", npmName: item.npmName, scope: item.scope, cwd, command: npm.command, argsPrefix: npm.argsPrefix },
 			command: `(cd ${shellQuote(cwd)} && ${npm.display} install ${item.npmName}@latest)`,
-			description: `${npm.warning ? `${npm.warning} ` : ""}Installed via npm — installs the latest published package version in Pi's scope-local npm directory, then Pi can load it after /reload or restart.`,
+			description: `${npm.warning ? `${npm.warning}\n` : ""}Installed via npm — installs the latest published package version in Pi's scope-local npm directory, then Pi can load it after /reload or restart.`,
 		};
 	}
 	return undefined;

--- a/pi-extensions/pi-extension-manager/extensions/manager/actions.ts
+++ b/pi-extensions/pi-extension-manager/extensions/manager/actions.ts
@@ -21,6 +21,13 @@ function launchFailure(command: string, error: unknown): string {
 	return managerNotice("command-launch", command, `Could not start the command: ${stringifyError(error)}`);
 }
 
+function exitFailure(key: string, result: ReturnType<typeof runCommand>): string {
+	const value = result.status ?? result.signal ?? "unknown";
+	const detail = (result.stderr ?? "").trim() || (result.stdout ?? "").trim()
+		|| (result.signal ? `signal ${result.signal}` : result.status !== null ? `exit ${result.status}` : "unknown termination");
+	return managerNotice(key, value, detail);
+}
+
 function npmRootFromPackageDir(packageDir: string | undefined): string | undefined {
 	if (!packageDir) return undefined;
 	const marker = `${sep}node_modules${sep}`;
@@ -124,8 +131,7 @@ export function runUninstall(plan: UninstallPlan, inventory: Inventory): { ok: b
 		const result = runCommand("kendex", args);
 		if (result.error) return { ok: false, message: launchFailure("kendex", result.error) };
 		if ((result.status ?? 1) !== 0) {
-			const stderr = (result.stderr ?? "").trim() || (result.stdout ?? "").trim() || `exit ${result.status}`;
-			return { ok: false, message: managerNotice("kendex-uninstall-exit", result.status ?? 1, stderr) };
+			return { ok: false, message: exitFailure("kendex-uninstall-exit", result) };
 		}
 		// `kendex remove` already handled APPEND_SYSTEM.md, so no extra cleanup here.
 		return { ok: true, message: managerNotice("kendex-uninstalled", plan.item.packageName!, `Removed ${plan.item.displayName} via kendex.`) };
@@ -141,8 +147,7 @@ export function runUninstall(plan: UninstallPlan, inventory: Inventory): { ok: b
 		const result = runCommand(plan.method.command, [...plan.method.argsPrefix, ...args], { cwd: plan.method.cwd });
 		if (result.error) return { ok: false, message: launchFailure(plan.method.command, result.error) };
 		if ((result.status ?? 1) !== 0) {
-			const stderr = (result.stderr ?? "").trim() || (result.stdout ?? "").trim() || `exit ${result.status}`;
-			return { ok: false, message: managerNotice("npm-uninstall-exit", result.status ?? 1, stderr) };
+			return { ok: false, message: exitFailure("npm-uninstall-exit", result) };
 		}
 		const stripped = removePackageEntryFromSettings(plan.item, inventory.settingsFiles);
 		return { ok: true, message: managerNotice("npm-uninstalled", plan.method.npmName, `Uninstall succeeded${stripped ? "; removed Pi settings entry." : " (no settings entry to remove)."}`) };
@@ -190,8 +195,7 @@ export function runUpdate(plan: UpdatePlan): { ok: boolean; message: string } {
 		const result = runCommand("kendex", args);
 		if (result.error) return { ok: false, message: launchFailure("kendex", result.error) };
 		if ((result.status ?? 1) !== 0) {
-			const stderr = (result.stderr ?? "").trim() || (result.stdout ?? "").trim() || `exit ${result.status}`;
-			return { ok: false, message: managerNotice("kendex-update-exit", result.status ?? 1, stderr) };
+			return { ok: false, message: exitFailure("kendex-update-exit", result) };
 		}
 		return { ok: true, message: managerNotice("kendex-updated", plan.item.packageName!, `Updated ${plan.item.displayName} via kendex.`) };
 	}
@@ -201,8 +205,7 @@ export function runUpdate(plan: UpdatePlan): { ok: boolean; message: string } {
 	const result = runCommand(plan.method.command, [...plan.method.argsPrefix, ...args], { cwd: plan.method.cwd });
 	if (result.error) return { ok: false, message: launchFailure(plan.method.command, result.error) };
 	if ((result.status ?? 1) !== 0) {
-		const stderr = (result.stderr ?? "").trim() || (result.stdout ?? "").trim() || `exit ${result.status}`;
-		return { ok: false, message: managerNotice("npm-update-exit", result.status ?? 1, stderr) };
+		return { ok: false, message: exitFailure("npm-update-exit", result) };
 	}
 	return { ok: true, message: managerNotice("npm-updated", plan.method.npmName, "Package updated via npm.") };
 }

--- a/pi-extensions/pi-extension-manager/extensions/manager/append-system.ts
+++ b/pi-extensions/pi-extension-manager/extensions/manager/append-system.ts
@@ -1,5 +1,6 @@
 import { existsSync } from "node:fs";
 import { join } from "node:path";
+import { managerNotice } from "./format.js";
 import { runCommand } from "./process.js";
 import type { InventoryItem } from "./types.js";
 
@@ -25,7 +26,7 @@ function runAppendSystemScript(packageDir: string | undefined, action: "install"
 	const result = runCommand("node", [script, action], { cwd: packageDir, killSignal: "SIGKILL", timeout: APPEND_SYSTEM_TIMEOUT_MS });
 	// Best-effort, like the script itself: never block a toggle or uninstall
 	// on an APPEND_SYSTEM.md write.
-	if (result.error) console.warn(`pi-extension-manager: append-system ${action} failed to launch: ${String(result.error)}`);
+	if (result.error) console.warn(managerNotice("append-system-launch", `${action}:${script}`, String(result.error)));
 }
 
 export function syncAppendSystemForPackage(item: InventoryItem, willDisable: boolean): void {

--- a/pi-extensions/pi-extension-manager/extensions/manager/format.ts
+++ b/pi-extensions/pi-extension-manager/extensions/manager/format.ts
@@ -10,6 +10,12 @@ export function ansiGreen(text: string): string { return `${ANSI_GREEN_FG}${text
 export function ansiYellow(text: string): string { return `${ANSI_YELLOW_FG}${text}${ANSI_FG_RESET}`; }
 export function ansiRed(text: string): string { return `${ANSI_RED_FG}${text}${ANSI_FG_RESET}`; }
 
+/** Stable notification header; explanation remains free to change. */
+export function managerNotice(key: string, value: string | number, explanation: string): string {
+	const shown = String(value).replace(/[\u0000-\u001f\u007f]/g, "?");
+	return `pi-extension-manager: ${key}=${shown}\n${explanation}`;
+}
+
 export function stringifyError(error: unknown): string {
 	if (error instanceof Error) return `${error.name}: ${error.message}`;
 	return String(error);
@@ -41,17 +47,17 @@ export function parseSettingInput(schema: SettingsSchema, input: string): unknow
 			const lower = input.trim().toLowerCase();
 			if (["true", "yes", "on", "1", "enabled"].includes(lower)) return true;
 			if (["false", "no", "off", "0", "disabled"].includes(lower)) return false;
-			throw new Error("Expected boolean: true/false, on/off, yes/no");
+			throw new Error(managerNotice("setting-boolean", schema.key, "Expected boolean: true/false, on/off, yes/no"));
 		}
 		case "number": {
 			const parsed = Number(input.trim());
-			if (!Number.isFinite(parsed)) throw new Error("Expected a number");
+			if (!Number.isFinite(parsed)) throw new Error(managerNotice("setting-number", schema.key, "Expected a number"));
 			return parsed;
 		}
 		case "enum": {
 			const value = input.trim();
 			if (schema.enumValues?.length && !schema.enumValues.includes(value)) {
-				throw new Error(`Expected one of: ${schema.enumValues.join(", ")}`);
+				throw new Error(managerNotice("setting-enum", schema.key, `Expected one of: ${schema.enumValues.join(", ")}`));
 			}
 			return value;
 		}
@@ -95,12 +101,12 @@ export function hasDeferredApply(schemas: SettingsSchema[]): boolean {
 
 export function applyMessage(schema: SettingsSchema): string {
 	const apply = applyOf(schema);
-	if (apply === "live") return "Setting saved and available to extensions immediately.";
-	if (apply === "reload") return "Setting saved. Run /reload for extensions that read it at load time.";
-	if (apply === "session") return "Setting saved. Start/resume a session to fully apply it.";
-	return "Setting saved. Restart Pi to fully apply it.";
+	if (apply === "live") return managerNotice("setting-saved", `${schema.key}:${apply}`, "Setting saved and available to extensions immediately.");
+	if (apply === "reload") return managerNotice("setting-saved", `${schema.key}:${apply}`, "Setting saved. Run /reload for extensions that read it at load time.");
+	if (apply === "session") return managerNotice("setting-saved", `${schema.key}:${apply}`, "Setting saved. Start/resume a session to fully apply it.");
+	return managerNotice("setting-saved", `${schema.key}:${apply}`, "Setting saved. Restart Pi to fully apply it.");
 }
 
 export function notifyReset(ctx: ExtensionCommandContext | ExtensionContext, label: string, schemas: SettingsSchema[]): void {
-	ctx.ui.notify(`${label} reset to default${schemas.length === 1 ? "" : "s"}.${hasDeferredApply(schemas) ? " Reload/restart may be required for deferred settings." : ""}`, hasDeferredApply(schemas) ? "warning" : "info");
+	ctx.ui.notify(managerNotice("settings-reset", schemas.map((schema) => schema.key).join(","), `${label} reset to default${schemas.length === 1 ? "" : "s"}.${hasDeferredApply(schemas) ? " Reload/restart may be required for deferred settings." : ""}`), hasDeferredApply(schemas) ? "warning" : "info");
 }

--- a/pi-extensions/pi-extension-manager/extensions/manager/format.ts
+++ b/pi-extensions/pi-extension-manager/extensions/manager/format.ts
@@ -5,6 +5,7 @@ const ANSI_GREEN_FG = "\x1b[32m";
 const ANSI_YELLOW_FG = "\x1b[33m";
 const ANSI_RED_FG = "\x1b[31m";
 const ANSI_FG_RESET = "\x1b[39m";
+const MANAGER_NOTICE_PREFIX = "pi-extension-manager: ";
 
 export function ansiGreen(text: string): string { return `${ANSI_GREEN_FG}${text}${ANSI_FG_RESET}`; }
 export function ansiYellow(text: string): string { return `${ANSI_YELLOW_FG}${text}${ANSI_FG_RESET}`; }
@@ -13,12 +14,18 @@ export function ansiRed(text: string): string { return `${ANSI_RED_FG}${text}${A
 /** Stable notification header; explanation remains free to change. */
 export function managerNotice(key: string, value: string | number, explanation: string): string {
 	const shown = String(value).replace(/[\u0000-\u001f\u007f]/g, "?");
-	return `pi-extension-manager: ${key}=${shown}\n${explanation}`;
+	return `${MANAGER_NOTICE_PREFIX}${key}=${shown}\n${explanation}`;
 }
 
 export function stringifyError(error: unknown): string {
 	if (error instanceof Error) return `${error.name}: ${error.message}`;
 	return String(error);
+}
+
+/** Preserve a specific manager refusal when a UI boundary catches it. */
+export function managerFailure(key: string, value: string | number, error: unknown): string {
+	if (error instanceof Error && error.message.startsWith(MANAGER_NOTICE_PREFIX)) return error.message;
+	return managerNotice(key, value, stringifyError(error));
 }
 
 export function isPlainSearchInput(data: string): boolean {

--- a/pi-extensions/pi-extension-manager/extensions/manager/host.ts
+++ b/pi-extensions/pi-extension-manager/extensions/manager/host.ts
@@ -1,5 +1,6 @@
 import { existsSync, lstatSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
 import { basename, dirname, extname, join, resolve } from "node:path";
+import { managerNotice, stringifyError } from "./format.js";
 import { findProjectPiDir, rootAnchored, userPiDir } from "./paths.js";
 import { MANAGER_ID, type InventoryItem, type PackageManifest, type SettingsFile } from "./types.js";
 
@@ -16,7 +17,7 @@ export interface OmpRuntime {
 type Context = { cwd: string; isProjectTrusted?: () => boolean };
 
 function record(value: unknown, label: string): Record<string, unknown> {
-	if (!value || typeof value !== "object" || Array.isArray(value)) throw new Error(`${label} must be an object`);
+	if (!value || typeof value !== "object" || Array.isArray(value)) throw new Error(managerNotice("object-required", label, "Expected an object."));
 	return value as Record<string, unknown>;
 }
 
@@ -26,7 +27,7 @@ function optionalRecord(value: unknown, label: string): Record<string, unknown> 
 
 function strings(value: unknown, label: string): string[] {
 	if (value === undefined) return [];
-	if (!Array.isArray(value) || value.some((v) => typeof v !== "string")) throw new Error(`${label} must be a string array`);
+	if (!Array.isArray(value) || value.some((v) => typeof v !== "string")) throw new Error(managerNotice("string-array-required", label, "Expected an array of strings."));
 	return value;
 }
 
@@ -64,7 +65,12 @@ export class HostAdapter {
 	read(path: string): Record<string, unknown> {
 		if (!existsSync(path)) return {};
 		const text = readFileSync(path, "utf8");
-		const parsed = this.omp && /\.ya?ml$/.test(path) ? this.omp.YAML.parse(text) : JSON.parse(text);
+		let parsed: unknown;
+		try {
+			parsed = this.omp && /\.ya?ml$/.test(path) ? this.omp.YAML.parse(text) : JSON.parse(text);
+		} catch (error) {
+			throw new Error(managerNotice("config-parse", path, stringifyError(error)));
+		}
 		const json = record(parsed, path);
 		const kendex = optionalRecord(json.kendex, `${path}: kendex`);
 		const manager = optionalRecord(kendex.extensionManager, `${path}: extensionManager`);
@@ -94,7 +100,7 @@ export class HostAdapter {
 	}
 
 	write(file: SettingsFile): void {
-		if (file.projectTrusted === false) throw new Error(`Project settings are not trusted: ${file.path}`);
+		if (file.projectTrusted === false) throw new Error(managerNotice("project-untrusted", file.path, "Project settings are not trusted."));
 		// Revalidate before writing: malformed persisted input is never replaced with defaults.
 		this.read(file.path);
 		const text = this.omp && /\.ya?ml$/.test(file.path) ? this.omp.YAML.stringify(file.json) : JSON.stringify(file.json, null, 2);
@@ -122,7 +128,7 @@ export class HostAdapter {
 	settingsSupported(packageName: string): boolean { return !this.omp || packageName === MANAGER_ID; }
 
 	assertSettingsSupported(packageName: string): void {
-		if (!this.settingsSupported(packageName)) throw new Error("Settings for other extensions are unsupported on this host; use the owning extension's settings.");
+		if (!this.settingsSupported(packageName)) throw new Error(managerNotice("settings-unsupported", packageName, "Use the owning extension to change its settings on this host."));
 	}
 
 	private lock(path: string): Record<string, unknown> {
@@ -130,7 +136,7 @@ export class HostAdapter {
 		const plugins = optionalRecord(json.plugins, `${path}: plugins`);
 		for (const [name, value] of Object.entries(plugins)) {
 			const state = record(value, `${path}: ${name}`);
-			if (typeof state.enabled !== "boolean") throw new Error(`${path}: ${name}.enabled must be boolean`);
+			if (typeof state.enabled !== "boolean") throw new Error(managerNotice("boolean-required", `${path}: ${name}.enabled`, "Expected a boolean."));
 			if (state.enabledFeatures !== null) strings(state.enabledFeatures, `${path}: ${name}.enabledFeatures`);
 		}
 		return json;
@@ -139,7 +145,7 @@ export class HostAdapter {
 	/** Undefined selects Pi's package-settings inventory, not an empty native inventory. */
 	installedItems(cwd: string): InventoryItem[] | undefined {
 		if (!this.omp) return undefined;
-		if (!this.projectRoots.has(cwd)) throw new Error("Host project paths have not been prepared");
+		if (!this.projectRoots.has(cwd)) throw new Error(managerNotice("project-unprepared", cwd, "Host project paths have not been prepared."));
 		const registry = this.projectRoots.get(cwd);
 		const userRoot = this.omp.getPluginsDir();
 		const roots: { root: string; scope: "user" | "project" }[] = [{ root: userRoot, scope: "user" }];
@@ -212,8 +218,8 @@ export class HostAdapter {
 	/** A refusal shared by the action handler and its UI hint. */
 	toggleUnavailable(item: InventoryItem): string | undefined {
 		if (!this.omp) return undefined;
-		if (item.kind !== "package" || !item.packageName || item.state === "shadowed" || typeof item.metadata?.lockPath !== "string") return "Module and shadowed-item toggles are unsupported; use the host extension controls.";
-		if (item.metadata.suppressed) return `Enable is blocked by project plugin overrides: ${item.metadata.overridesPath}`;
+		if (item.kind !== "package" || !item.packageName || item.state === "shadowed" || typeof item.metadata?.lockPath !== "string") return managerNotice("toggle-unsupported", item.id, "Use the host extension controls to change modules or shadowed items.");
+		if (item.metadata.suppressed) return managerNotice("plugin-override", String(item.metadata.overridesPath), "Project plugin overrides block enablement.");
 		return undefined;
 	}
 
@@ -238,7 +244,7 @@ export let host = new HostAdapter();
 
 /** Select by runtime API, never by the existence of another host's directories. */
 export async function selectHost(runtime: Record<string, unknown>, loadOmp: () => Promise<OmpRuntime>): Promise<HostAdapter> {
-	if (typeof runtime.getAgentDir !== "function") throw new Error("Unsupported host: missing getAgentDir");
+	if (typeof runtime.getAgentDir !== "function") throw new Error(managerNotice("host-api-missing", "getAgentDir", "The host does not provide getAgentDir."));
 	const agent = runtime.getAgentDir as () => string;
 	if (typeof runtime.Settings === "function") return host = new HostAdapter(agent, await loadOmp());
 	if (typeof runtime.SettingsManager === "function") {
@@ -247,7 +253,7 @@ export async function selectHost(runtime: Record<string, unknown>, loadOmp: () =
 			return rootAnchored(reported, process.platform === "win32") ? resolve(reported) : userPiDir();
 		});
 	}
-	throw new Error("Unsupported host settings API");
+	throw new Error(managerNotice("host-api-missing", "settings", "The host settings API is unsupported."));
 }
 
 export async function initializeHost(): Promise<void> {

--- a/pi-extensions/pi-extension-manager/extensions/manager/manager-ui.ts
+++ b/pi-extensions/pi-extension-manager/extensions/manager/manager-ui.ts
@@ -2,7 +2,7 @@ import type { ExtensionAPI, ExtensionCommandContext, ExtensionContext, Theme } f
 import { matchesKey, truncateToWidth, visibleWidth } from "@earendil-works/pi-tui";
 import { planUninstall, planUpdate, runUninstall, runUpdate, toggleItem } from "./actions.js";
 import { filteredItems, packageExtensions } from "./filters.js";
-import { ansiGreen, ansiRed, ansiYellow, isPlainSearchInput, kindLabel, scopeFilterLabel } from "./format.js";
+import { ansiGreen, ansiRed, ansiYellow, isPlainSearchInput, kindLabel, managerNotice, scopeFilterLabel } from "./format.js";
 import { applyUpdateMetadata, buildInventory, npmCandidatesFromInventory } from "./inventory.js";
 import { compactPath } from "./paths.js";
 import { glyphs } from "./glyphs.js";
@@ -418,7 +418,7 @@ export async function openManager(pi: ExtensionAPI, ctx: ExtensionCommandContext
 				if (!item) continue;
 				const plan = planUpdate(item, inventory, ctx);
 				if (!plan) {
-					ctx.ui.notify(host.packageActions ? `${item.displayName} does not have an available update.` : "Package updates are unsupported here; use the host's native plugin manager.", "info");
+					ctx.ui.notify(managerNotice(host.packageActions ? "update-unavailable" : "update-unsupported", item.id, host.packageActions ? `${item.displayName} does not have an available update.` : "Package updates are unsupported here; use the host native plugin manager."), "info");
 					continue;
 				}
 				const body = [
@@ -442,12 +442,12 @@ export async function openManager(pi: ExtensionAPI, ctx: ExtensionCommandContext
 				const item = inventory.items.find((candidate) => candidate.id === action.itemId);
 				if (!item) continue;
 				if (item.packageName === MANAGER_ID) {
-					ctx.ui.notify("Refusing to uninstall pi-extension-manager from inside itself.", "warning");
+					ctx.ui.notify(managerNotice("self-uninstall", MANAGER_ID, "The extension manager cannot uninstall itself."), "warning");
 					continue;
 				}
 				const plan = planUninstall(item, inventory, ctx);
 				if (!plan) {
-					ctx.ui.notify(host.packageActions ? `${item.displayName} is not an uninstallable package.` : "Package uninstall is unsupported here; use the host's native plugin manager.", "warning");
+					ctx.ui.notify(managerNotice(host.packageActions ? "uninstall-unavailable" : "uninstall-unsupported", item.id, host.packageActions ? `${item.displayName} is not an uninstallable package.` : "Package uninstall is unsupported here; use the host native plugin manager."), "warning");
 					continue;
 				}
 				const body = [

--- a/pi-extensions/pi-extension-manager/extensions/manager/quick-settings-ui.ts
+++ b/pi-extensions/pi-extension-manager/extensions/manager/quick-settings-ui.ts
@@ -5,6 +5,7 @@ import {
 	ansiYellow,
 	applyMessage,
 	formatSettingValue,
+	managerNotice,
 	isPlainSearchInput,
 	nextSettingValue,
 	notifyReset,
@@ -142,11 +143,11 @@ function resetQuickSetting(pi: ExtensionAPI, ctx: ExtensionCommandContext | Exte
 	const config = getConfigValue(inventory, row.extensionId, row.schema);
 	const label = row.schema.label ?? row.schema.key;
 	if (!config.explicit) {
-		ctx.ui.notify(`${label} is already using its default.`, "info");
+		ctx.ui.notify(managerNotice("setting-default", row.schema.key, `${label} is already using its default.`), "info");
 		return;
 	}
 	if (!isManagerOwned(config)) {
-		ctx.ui.notify(`${label} is set by ${externalSource(config)} and cannot be reset from here. Edit that file, or press enter to override it in Pi settings.`, "warning");
+		ctx.ui.notify(managerNotice("setting-external", externalSource(config), `${label} cannot be reset here. Edit the source file, or press enter to override it in Pi settings.`), "warning");
 		return;
 	}
 	resetConfigKeys(inventory, row.extensionId, [row.schema.key]);
@@ -161,10 +162,10 @@ function resetQuickSettingsForExtension(pi: ExtensionAPI, ctx: ExtensionCommandC
 	if (managed.length === 0) {
 		if (external.length > 0) {
 			const sources = [...new Set(external.map((entry) => externalSource(entry.config)))].join(", ");
-			ctx.ui.notify(`${label} has no settings stored in Pi settings; ${external.length === 1 ? "1 value comes" : `${external.length} values come`} from ${sources}.`, "warning");
+			ctx.ui.notify(managerNotice("settings-external", `${extensionId}:${external.length}:${sources}`, `${label} has no settings stored in Pi settings.`), "warning");
 			return;
 		}
-		ctx.ui.notify(`${label} settings are already using defaults.`, "info");
+		ctx.ui.notify(managerNotice("settings-default", extensionId, `${label} settings are already using defaults.`), "info");
 		return;
 	}
 	resetConfigKeys(inventory, extensionId, managed.map((entry) => entry.row.schema.key));
@@ -172,7 +173,7 @@ function resetQuickSettingsForExtension(pi: ExtensionAPI, ctx: ExtensionCommandC
 	notifyReset(ctx, `${label} settings`, managed.map((entry) => entry.row.schema));
 	if (external.length > 0) {
 		const sources = [...new Set(external.map((entry) => externalSource(entry.config)))].join(", ");
-		ctx.ui.notify(`${external.length} ${label} value${external.length === 1 ? " is" : "s are"} still set by ${sources}.`, "warning");
+		ctx.ui.notify(managerNotice("settings-external-remain", `${extensionId}:${external.length}:${sources}`, `${label} still has values set by external files.`), "warning");
 	}
 }
 
@@ -233,7 +234,7 @@ function createQuickSettingsComponent(pi: ExtensionAPI, ctx: ExtensionCommandCon
 			ui.editing = undefined;
 			requestRender();
 		} catch (error) {
-			ctx.ui.notify(stringifyError(error), "error");
+			ctx.ui.notify(managerNotice("setting-save-failed", row.schema.key, stringifyError(error)), "error");
 		}
 	};
 
@@ -422,7 +423,7 @@ export async function openQuickSettings(pi: ExtensionAPI, ctx: ExtensionCommandC
 	await host.prepare(ctx.cwd);
 	const inventory = buildInventory(pi, ctx as ExtensionContext);
 	if (settingPackages(inventory).length === 0) {
-		ctx.ui.notify("No kendex extension settings are declared by installed packages.", "info");
+		ctx.ui.notify(managerNotice("settings-packages", 0, "No kendex extension settings are declared by installed packages."), "info");
 		return;
 	}
 	let initialTab: TopTab = TAB_ALL;
@@ -430,7 +431,7 @@ export async function openQuickSettings(pi: ExtensionAPI, ctx: ExtensionCommandC
 		const tabs = quickSettingsTabs(quickSettingRows(inventory));
 		const resolved = resolveQuickSettingsTab(tabs, initialTabHint);
 		if (resolved) initialTab = resolved;
-		else ctx.ui.notify(`No settings tab matches "${initialTabHint}". Showing All.`, "warning");
+		else ctx.ui.notify(managerNotice("settings-tab-missing", initialTabHint, "No matching settings tab exists. Showing All."), "warning");
 	}
 	const ui: QuickSettingsUiState = { scroll: 0, search: "", selected: 0, tab: initialTab };
 	const releaseModalLock = acquirekendexModalLock();

--- a/pi-extensions/pi-extension-manager/extensions/manager/quick-settings-ui.ts
+++ b/pi-extensions/pi-extension-manager/extensions/manager/quick-settings-ui.ts
@@ -5,14 +5,14 @@ import {
 	ansiYellow,
 	applyMessage,
 	formatSettingValue,
-	managerNotice,
 	isPlainSearchInput,
+	managerFailure,
+	managerNotice,
 	nextSettingValue,
 	notifyReset,
 	packageNameForTab,
 	packageTabId,
 	parseSettingInput,
-	stringifyError,
 	stringifySettingValue,
 } from "./format.js";
 import { handleInlineEditInput, renderInlineEditValue } from "./inline-edit.js";
@@ -234,7 +234,7 @@ function createQuickSettingsComponent(pi: ExtensionAPI, ctx: ExtensionCommandCon
 			ui.editing = undefined;
 			requestRender();
 		} catch (error) {
-			ctx.ui.notify(managerNotice("setting-save-failed", row.schema.key, stringifyError(error)), "error");
+			ctx.ui.notify(managerFailure("setting-save-failed", row.schema.key, error), "error");
 		}
 	};
 

--- a/pi-extensions/pi-extension-manager/extensions/manager/settings.ts
+++ b/pi-extensions/pi-extension-manager/extensions/manager/settings.ts
@@ -1,4 +1,5 @@
 import type { ExtensionContext } from "@earendil-works/pi-coding-agent";
+import { managerNotice } from "./format.js";
 import { host } from "./host.js";
 import {
 	EXTERNAL_CONFIG_RESOLVER_SYMBOL,
@@ -31,7 +32,7 @@ export function asRecord(value: unknown): Record<string, unknown> | undefined {
 export function getOrCreateRecord(parent: Record<string, unknown>, key: string): Record<string, unknown> {
 	const current = asRecord(parent[key]);
 	if (current) return current;
-	if (parent[key] !== undefined) throw new Error(`${key} must be an object`);
+	if (parent[key] !== undefined) throw new Error(managerNotice("object-required", key, "Expected an object."));
 	const created: Record<string, unknown> = {};
 	parent[key] = created;
 	return created;

--- a/pi-extensions/pi-extension-manager/test/actions.test.ts
+++ b/pi-extensions/pi-extension-manager/test/actions.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, beforeEach, expect, mock, test } from "bun:test";
+import { afterEach, beforeEach, expect, mock, spyOn, test } from "bun:test";
 import { spawnSync as realSpawnSync } from "node:child_process";
 import { copyFileSync, existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { dirname, join } from "node:path";
@@ -100,12 +100,14 @@ test("npm update and uninstall execution use configured npmCommand and scope-loc
 
 	const update = planUpdate(item, inv, { cwd: project } as never)!;
 	expect(update.command).toContain("'mise' 'exec' 'node@22.19' '--' 'npm' install @scope/pkg@latest");
-	expect(runUpdate(update).ok).toBe(true);
+	const updated = runUpdate(update);
+	expect([updated.ok, updated.message.split("\n")[0]]).toEqual([true, "pi-extension-manager: npm-updated=@scope/pkg"]);
 	expect(spawnSyncMock).toHaveBeenLastCalledWith("mise", ["exec", "node@22.19", "--", "npm", "install", "@scope/pkg@latest"], expect.objectContaining({ cwd: npmDir }));
 
 	const uninstall = planUninstall(item, inv, { cwd: project } as never)!;
 	expect(uninstall.command).toContain("'mise' 'exec' 'node@22.19' '--' 'npm' uninstall @scope/pkg");
-	expect(runUninstall(uninstall, inv).ok).toBe(true);
+	const removed = runUninstall(uninstall, inv);
+	expect([removed.ok, removed.message.split("\n")[0]]).toEqual([true, "pi-extension-manager: npm-uninstalled=@scope/pkg"]);
 	expect(spawnSyncMock).toHaveBeenLastCalledWith("mise", ["exec", "node@22.19", "--", "npm", "uninstall", "@scope/pkg"], expect.objectContaining({ cwd: npmDir }));
 });
 
@@ -122,7 +124,7 @@ test("npm update reports cwd preparation failures", async () => {
 		description: "",
 	});
 	expect(result.ok).toBe(false);
-	expect(result.message).toContain("Failed to prepare npm working directory");
+	expect(result.message.split("\n")[0]).toBe(`pi-extension-manager: npm-cwd=${badCwd}`);
 	expect(spawnSyncMock).not.toHaveBeenCalled();
 });
 
@@ -142,7 +144,7 @@ test("invalid npmCommand is surfaced in npm action plans", async () => {
 	item.updateSource = "npm";
 	item.npmName = "@scope/bad-command";
 	const plan = planUpdate(item, inv, { cwd: project } as never)!;
-	expect(plan.description).toContain("invalid npmCommand");
+	expect(plan.description.split("\n")[0]).toBe("pi-extension-manager: npm-command-invalid=user");
 });
 
 // The strip has to precede `npm uninstall`: npm 7+ does not reliably run a
@@ -209,4 +211,21 @@ test("toggling a package under the kendex packages/ layout writes and removes it
 	const on = buildInventory({} as never, ctx);
 	toggleItem({} as never, ctx, on, on.packages.find((pkg) => pkg.packageName === "@scope/clonepkg")!);
 	expect(readFileSync(target, "utf8")).toContain("Append pkg instructions");
+});
+
+test("append-system launch failures expose the action and script path", async () => {
+	const packageDir = join(rootTmp, "append-launch");
+	mkdirSync(join(packageDir, "scripts"), { recursive: true });
+	writeFileSync(join(packageDir, "scripts", "append-system.mjs"), "");
+	spawnSyncMock.mockImplementation(() => ({ status: null, stdout: "", stderr: "", error: new Error("node unavailable"), signal: null, output: [], pid: 0 }));
+	await useSpawnMock();
+	const warning = spyOn(console, "warn").mockImplementation(() => {});
+	try {
+		const { syncAppendSystemForPackage } = await import("../extensions/manager/append-system.ts");
+		syncAppendSystemForPackage({ kind: "package", packageName: "@scope/append", packageDir } as never, false);
+		expect(warning).toHaveBeenCalledTimes(1);
+		expect(String(warning.mock.calls[0]![0]).split("\n")[0]).toBe(`pi-extension-manager: append-system-launch=install:${join(packageDir, "scripts", "append-system.mjs")}`);
+	} finally {
+		warning.mockRestore();
+	}
 });

--- a/pi-extensions/pi-extension-manager/test/actions.test.ts
+++ b/pi-extensions/pi-extension-manager/test/actions.test.ts
@@ -232,3 +232,19 @@ test("append-system launch failures expose the action and script path", async ()
 		warning.mockRestore();
 	}
 });
+
+test("npm action exits expose an exit code or signal", async () => {
+	await useSpawnMock();
+	const { runUninstall, runUpdate } = await import("../extensions/manager/actions.ts");
+	const item = { id: "package:@scope/pkg", displayName: "Pkg", kind: "package", state: "active", stateReason: "", description: "", provider: "npm", scope: "user", sourcePath: "", sourceName: "npm:@scope/pkg", packageName: "@scope/pkg" };
+	const method = { kind: "npm", npmName: "@scope/pkg", scope: "user", cwd: rootTmp, command: "npm", argsPrefix: [] };
+	const rows = [
+		{ result: { status: 7, signal: null }, run: () => runUpdate({ item, method } as never), firstLine: "pi-extension-manager: npm-update-exit=7" },
+		{ result: { status: null, signal: "SIGTERM" }, run: () => runUninstall({ item, method } as never, { settingsFiles: [] } as never), firstLine: "pi-extension-manager: npm-uninstall-exit=SIGTERM" },
+	] as const;
+	for (const row of rows) {
+		spawnSyncMock.mockImplementation(() => ({ ...row.result, stdout: "", stderr: "", error: undefined, output: [], pid: 0 } as never));
+		const outcome = row.run();
+		expect([outcome.ok, outcome.message.split("\n")[0]]).toEqual([false, row.firstLine]);
+	}
+});

--- a/pi-extensions/pi-extension-manager/test/actions.test.ts
+++ b/pi-extensions/pi-extension-manager/test/actions.test.ts
@@ -111,20 +111,22 @@ test("npm update and uninstall execution use configured npmCommand and scope-loc
 	expect(spawnSyncMock).toHaveBeenLastCalledWith("mise", ["exec", "node@22.19", "--", "npm", "uninstall", "@scope/pkg"], expect.objectContaining({ cwd: npmDir }));
 });
 
-test("npm update reports cwd preparation failures", async () => {
+test("npm actions report cwd preparation failures", async () => {
 	await useSpawnMock();
-	const { runUpdate } = await import("../extensions/manager/actions.ts");
+	const { runUninstall, runUpdate } = await import("../extensions/manager/actions.ts");
 	const badCwd = join(rootTmp, "not-a-directory");
 	writeFileSync(badCwd, "file blocks mkdir");
 	spawnSyncMock.mockClear();
-	const result = runUpdate({
-		item: { id: "package:@scope/pkg", displayName: "Pkg", kind: "package", state: "active", stateReason: "", description: "", provider: "npm", scope: "user", sourcePath: "", sourceName: "npm:@scope/pkg", packageName: "@scope/pkg" },
-		method: { kind: "npm", npmName: "@scope/pkg", scope: "user", cwd: badCwd, command: "npm", argsPrefix: [] },
-		command: "npm install @scope/pkg@latest",
-		description: "",
-	});
-	expect(result.ok).toBe(false);
-	expect(result.message.split("\n")[0]).toBe(`pi-extension-manager: npm-cwd=${badCwd}`);
+	const item = { id: "package:@scope/pkg", displayName: "Pkg", kind: "package", state: "active", stateReason: "", description: "", provider: "npm", scope: "user", sourcePath: "", sourceName: "npm:@scope/pkg", packageName: "@scope/pkg" };
+	const method = { kind: "npm", npmName: "@scope/pkg", scope: "user", cwd: badCwd, command: "npm", argsPrefix: [] };
+	const rows = [
+		{ run: () => runUpdate({ item, method } as never), firstLine: `pi-extension-manager: npm-update-cwd=${badCwd}` },
+		{ run: () => runUninstall({ item, method } as never, { settingsFiles: [] } as never), firstLine: `pi-extension-manager: npm-uninstall-cwd=${badCwd}` },
+	];
+	for (const row of rows) {
+		const result = row.run();
+		expect([result.ok, result.message.split("\n")[0]]).toEqual([false, row.firstLine]);
+	}
 	expect(spawnSyncMock).not.toHaveBeenCalled();
 });
 
@@ -247,4 +249,17 @@ test("npm action exits expose an exit code or signal", async () => {
 		const outcome = row.run();
 		expect([outcome.ok, outcome.message.split("\n")[0]]).toEqual([false, row.firstLine]);
 	}
+});
+
+test("npm action launch failures identify the action", async () => {
+	await useSpawnMock();
+	const { runUninstall, runUpdate } = await import("../extensions/manager/actions.ts");
+	const item = { id: "package:@scope/pkg", displayName: "Pkg", kind: "package", state: "active", stateReason: "", description: "", provider: "npm", scope: "user", sourcePath: "", sourceName: "npm:@scope/pkg", packageName: "@scope/pkg" };
+	const method = { kind: "npm", npmName: "@scope/pkg", scope: "user", cwd: rootTmp, command: "npm", argsPrefix: [] };
+	spawnSyncMock.mockImplementation(() => ({ status: null, signal: null, stdout: "", stderr: "", error: new Error("missing"), output: [], pid: 0 } as never));
+	const rows = [
+		{ outcome: runUpdate({ item, method } as never), firstLine: "pi-extension-manager: npm-update-launch=npm" },
+		{ outcome: runUninstall({ item, method } as never, { settingsFiles: [] } as never), firstLine: "pi-extension-manager: npm-uninstall-launch=npm" },
+	];
+	for (const row of rows) expect([row.outcome.ok, row.outcome.message.split("\n")[0]]).toEqual([false, row.firstLine]);
 });

--- a/pi-extensions/pi-extension-manager/test/actions.test.ts
+++ b/pi-extensions/pi-extension-manager/test/actions.test.ts
@@ -131,7 +131,7 @@ test("npm update reports cwd preparation failures", async () => {
 test("invalid npmCommand is surfaced in npm action plans", async () => {
 	await useSpawnMock();
 	const { buildInventory } = await import("../extensions/manager/inventory.ts");
-	const { planUpdate } = await import("../extensions/manager/actions.ts");
+	const { planUninstall, planUpdate } = await import("../extensions/manager/actions.ts");
 	const project = join(rootTmp, "project");
 	const userPi = process.env.PI_CODING_AGENT_DIR!;
 	const packageDir = join(userPi, "npm", "node_modules", "@scope", "bad-command");
@@ -143,8 +143,11 @@ test("invalid npmCommand is surfaced in npm action plans", async () => {
 	item.updateAvailable = true;
 	item.updateSource = "npm";
 	item.npmName = "@scope/bad-command";
-	const plan = planUpdate(item, inv, { cwd: project } as never)!;
-	expect(plan.description.split("\n")[0]).toBe("pi-extension-manager: npm-command-invalid=user");
+	const plans = [planUpdate(item, inv, { cwd: project } as never)!, planUninstall(item, inv, { cwd: project } as never)!];
+	for (const plan of plans) {
+		expect(plan.description.split("\n")[0]).toBe("pi-extension-manager: npm-command-invalid=user");
+		expect(plan.description.split("\n")).toHaveLength(3);
+	}
 });
 
 // The strip has to precede `npm uninstall`: npm 7+ does not reliably run a

--- a/pi-extensions/pi-extension-manager/test/bootstrap.test.ts
+++ b/pi-extensions/pi-extension-manager/test/bootstrap.test.ts
@@ -8,8 +8,7 @@ const fixture = join(import.meta.dir, "fixtures", "bootstrap.ts");
 test("runtime bootstrap registers host commands and recovery updates the global layer", async () => {
 	mkdirSync(root, { recursive: true });
 	try {
-		for (const kind of ["pi", "omp"]) {
-			for (const mode of ["enabled", "disabled"]) {
+		for (const [kind, mode] of [["pi", "enabled"], ["pi", "disabled"], ["omp", "enabled"], ["omp", "disabled"]]) {
 				const home = join(root, `${kind}-${mode}`);
 				const child = Bun.spawn([process.execPath, fixture, home, kind, mode], {
 					stdout: "ignore", stderr: "pipe", timeout: 10_000,
@@ -18,7 +17,6 @@ test("runtime bootstrap registers host commands and recovery updates the global 
 				const stderr = await new Response(child.stderr).text();
 				const status = await child.exited;
 				expect({ kind, mode, status, stderr }).toEqual({ kind, mode, status: 0, stderr: "" });
-			}
 		}
 	} finally {
 		rmSync(root, { recursive: true, force: true });

--- a/pi-extensions/pi-extension-manager/test/fixtures/bootstrap.ts
+++ b/pi-extensions/pi-extension-manager/test/fixtures/bootstrap.ts
@@ -35,7 +35,11 @@ await extensionManager(api as never);
 const manager = kind === "omp" ? "kendex:extensions" : "extensions";
 assert.deepEqual([...commands.keys()], mode === "disabled" ? [manager, `${manager}:enable`] : [manager, `${manager}:settings`]);
 if (mode === "disabled") {
-	await commands.get(`${manager}:enable`)!.handler("", { cwd, isProjectTrusted: () => true, ui: { notify() {} } });
+	const notices: string[] = [];
+	const ctx = { cwd, isProjectTrusted: () => true, ui: { notify(message: string) { notices.push(message.split("\n")[0]); } } };
+	await commands.get(manager)!.handler("", ctx);
+	await commands.get(`${manager}:enable`)!.handler("", ctx);
+	assert.deepEqual(notices, ["pi-extension-manager: manager-disabled=@vanillagreen/pi-extension-manager", "pi-extension-manager: manager-enabled=@vanillagreen/pi-extension-manager"]);
 	const parsed = (kind === "omp" ? YAML.parse : JSON.parse)(readFileSync(userPath, "utf8")) as ReturnType<typeof config>;
 	assert.equal(parsed.kendex.extensionManager.config["@vanillagreen/pi-extension-manager"].enabled, true);
 	assert.deepEqual(parsed.unknown, { keep: true });

--- a/pi-extensions/pi-extension-manager/test/host.test.ts
+++ b/pi-extensions/pi-extension-manager/test/host.test.ts
@@ -42,6 +42,10 @@ function write(path: string, content: string): void {
 	writeFileSync(path, content);
 }
 function json(path: string, value: unknown): void { write(path, JSON.stringify(value)); }
+function thrownFirstLine(fn: () => unknown): string {
+	try { fn(); } catch (error) { return (error instanceof Error ? error.message : String(error)).split("\n")[0]!; }
+	throw new Error("Expected the function to throw");
+}
 function nativePackage(rootDir = plugins, packageName = name, enabled = true, entrypoint = "./extensions/index.ts"): void {
 	json(join(rootDir, "package.json"), { private: true, dependencies: { [packageName]: "^1.2.3" } });
 	json(join(rootDir, "omp-plugins.lock.json"), { plugins: { [packageName]: { version: "1.2.3", enabled, enabledFeatures: null, custom: "keep" } }, settings: { [packageName]: { color: "blue" } }, unknown: 17 });
@@ -100,7 +104,8 @@ test("runtime capabilities select the host with coexisting directories and use i
 	expect(host.agentDir()).toBe(piAgent);
 	expect(host.commands.manager).toBe("extensions");
 	expect(host.settings(ctx)[0]?.path).toBe(join(piAgent, "settings.json"));
-	await expect(selectHost({ getAgentDir: () => piAgent }, async () => runtime)).rejects.toThrow();
+	await expect(selectHost({ getAgentDir: () => piAgent }, async () => runtime)).rejects.toThrow("pi-extension-manager: host-api-missing=settings");
+	await expect(selectHost({}, async () => runtime)).rejects.toThrow("pi-extension-manager: host-api-missing=getAgentDir");
 });
 
 test("config.yaml manager edits preserve nested and unknown data and feed glyph settings", () => {
@@ -120,22 +125,22 @@ test("config.yaml manager edits preserve nested and unknown data and feed glyph 
 test("malformed YAML, JSON and native records refuse without overwriting", () => {
 	nativePackage();
 	const cases = [
-		{ path: join(agent, "config.yml"), text: "compaction: [broken" },
-		{ path: join(agent, "config.yml"), text: "- not-a-mapping" },
-		{ path: join(agent, "config.yml"), text: "kendex:\n  extensionManager:\n    config: invalid" },
-		{ path: lockPath, text: "{" },
-		{ path: lockPath, text: '{"plugins":{"@example/native":{"enabled":"false"}}}' },
+		{ path: join(agent, "config.yml"), text: "compaction: [broken", firstLine: `pi-extension-manager: config-parse=${join(agent, "config.yml")}` },
+		{ path: join(agent, "config.yml"), text: "- not-a-mapping", firstLine: `pi-extension-manager: object-required=${join(agent, "config.yml")}` },
+		{ path: join(agent, "config.yml"), text: "kendex:\n  extensionManager:\n    config: invalid", firstLine: `pi-extension-manager: object-required=${join(agent, "config.yml")}: manager config` },
+		{ path: lockPath, text: "{", firstLine: `pi-extension-manager: config-parse=${lockPath}` },
+		{ path: lockPath, text: '{"plugins":{"@example/native":{"enabled":"false"}}}', firstLine: `pi-extension-manager: boolean-required=${lockPath}: @example/native.enabled` },
 	];
-	for (const { path, text } of cases) {
+	for (const { path, text, firstLine } of cases) {
 		const original = existsSync(path) ? readFileSync(path, "utf8") : undefined;
 		write(path, text);
-		expect(() => inventory()).toThrow();
+		expect(thrownFirstLine(() => inventory())).toBe(firstLine);
 		expect(readFileSync(path, "utf8")).toBe(text);
 		if (original === undefined) rmSync(path); else write(path, original);
 	}
 	const file = host.settings(ctx)[0]!;
 	write(file.path, "kendex: [broken");
-	expect(() => updateManagerState(file, (state) => { state.config[MANAGER_ID] = { enabled: true }; })).toThrow();
+	expect(thrownFirstLine(() => updateManagerState(file, (state) => { state.config[MANAGER_ID] = { enabled: true }; }))).toBe(`pi-extension-manager: config-parse=${file.path}`);
 	expect(readFileSync(file.path, "utf8")).toBe("kendex: [broken");
 });
 
@@ -145,14 +150,17 @@ test("native capabilities refuse Pi update, uninstall, module toggles and other-
 	const item = inv.packages[0]!;
 	expect(planUninstall(item, inv, ctx as never)).toBeUndefined();
 	expect(planUpdate({ ...item, updateAvailable: true, updateSource: "npm", npmName: name }, inv, ctx as never)).toBeUndefined();
-	expect(runUpdate({ item } as never).ok).toBe(false);
-	expect(runUninstall({ item } as never, inv).ok).toBe(false);
+	const update = runUpdate({ item } as never);
+	const uninstall = runUninstall({ item } as never, inv);
+	expect([update.ok, update.message.split("\n")[0]]).toEqual([false, `pi-extension-manager: update-unsupported=${item.id}`]);
+	expect([uninstall.ok, uninstall.message.split("\n")[0]]).toEqual([false, `pi-extension-manager: uninstall-unsupported=${item.id}`]);
 	expect(npmCandidatesFromInventory(inv)).toEqual([]);
 	expect(item.settingsSchema).toEqual([]);
 	const before = readFileSync(lockPath, "utf8");
-	expect(() => host.toggle(inv.items.find((i) => i.kind === "extension module")!)).toThrow();
-	expect(() => setConfigValue(inv, item, { key: "enabled" } as never, true)).toThrow();
-	expect(() => resetConfigKeys(inv, name, ["enabled"])).toThrow();
+	const module = inv.items.find((i) => i.kind === "extension module")!;
+	expect(thrownFirstLine(() => host.toggle(module))).toBe(`pi-extension-manager: toggle-unsupported=${module.id}`);
+	expect(thrownFirstLine(() => setConfigValue(inv, item, { key: "enabled" } as never, true))).toBe(`pi-extension-manager: settings-unsupported=${name}`);
+	expect(thrownFirstLine(() => resetConfigKeys(inv, name, ["enabled"]))).toBe(`pi-extension-manager: settings-unsupported=${name}`);
 	expect(readFileSync(lockPath, "utf8")).toBe(before);
 	expect(existsSync(join(agent, "settings.json"))).toBe(false);
 });
@@ -246,6 +254,36 @@ async function popup(open: typeof openManager, search = ""): Promise<string> {
 	return output;
 }
 
+test("manager and quick-settings notices expose stable keys and values", async () => {
+	const emptyNotices: string[] = [];
+	await openQuickSettings({} as never, { ...ctx, ui: {
+		notify: (message: string) => emptyNotices.push(message.split("\n")[0]!),
+	} } as never);
+	expect(emptyNotices).toEqual(["pi-extension-manager: settings-packages=0"]);
+
+	nativePackage(plugins, MANAGER_ID);
+	const item = inventory().packages[0]!;
+	for (const row of [
+		{ action: { type: "update-package", itemId: item.id }, firstLine: `pi-extension-manager: update-unsupported=${item.id}` },
+		{ action: { type: "uninstall-package", itemId: item.id }, firstLine: `pi-extension-manager: self-uninstall=${MANAGER_ID}` },
+	] as const) {
+		const notices: string[] = [];
+		let first = true;
+		await openManager({} as never, { ...ctx, ui: {
+			custom: async () => first ? (first = false, row.action) : { type: "close" },
+			notify: (message: string) => notices.push(message.split("\n")[0]!),
+		} } as never);
+		expect(notices).toEqual([row.firstLine]);
+	}
+
+	const notices: string[] = [];
+	await openQuickSettings({} as never, { ...ctx, ui: {
+		custom: async () => ({ type: "close" }),
+		notify: (message: string) => notices.push(message.split("\n")[0]!),
+	} } as never, "missing-tab");
+	expect(notices).toEqual(["pi-extension-manager: settings-tab-missing=missing-tab"]);
+});
+
 for (const row of installations) {
 	test(`native installation grouping user=${row.user} project=${row.project}`, async () => {
 		nativePackage(plugins, MANAGER_ID, row.user, "./useronly.ts");
@@ -313,7 +351,7 @@ test("native module suppression shows basename collisions without offering packa
 	expect(modules).toHaveLength(2);
 	for (const item of modules) {
 		expect(item.state).toBe("disabled");
-		expect(() => host.toggle(item)).toThrow();
+		expect(thrownFirstLine(() => host.toggle(item))).toBe(`pi-extension-manager: toggle-unsupported=${item.id}`);
 	}
 });
 
@@ -342,6 +380,6 @@ test("native project suppression is visible and refuses a misleading global enab
 	const item = inventory().packages[0]!;
 	expect(item.state).toBe("disabled");
 	const before = readFileSync(path, "utf8");
-	expect(() => host.toggle(item)).toThrow();
+	expect(thrownFirstLine(() => host.toggle(item))).toBe(`pi-extension-manager: plugin-override=${path}`);
 	expect(readFileSync(path, "utf8")).toBe(before);
 });

--- a/pi-extensions/pi-extension-manager/test/settings.test.ts
+++ b/pi-extensions/pi-extension-manager/test/settings.test.ts
@@ -3,7 +3,7 @@ import { mkdirSync, rmSync, writeFileSync } from "node:fs";
 import { dirname, join } from "node:path";
 
 import { buildInventory } from "../extensions/manager/inventory.ts";
-import { applyMessage, managerNotice, parseSettingInput } from "../extensions/manager/format.ts";
+import { applyMessage, managerFailure, managerNotice, parseSettingInput } from "../extensions/manager/format.ts";
 import { getConfigValue, getOrCreateRecord } from "../extensions/manager/settings.ts";
 import { EXTERNAL_CONFIG_RESOLVER_SYMBOL, type ExternalConfigResolver, type SettingsSchema } from "../extensions/manager/types.ts";
 
@@ -160,4 +160,6 @@ test("setting schema refusals and save notices expose stable keys and values", (
 
 	expect(() => getOrCreateRecord({ config: false }, "config")).toThrow("pi-extension-manager: object-required=config");
 	expect(managerNotice("sample", "line\nbreak", "details").split("\n")[0]).toBe("pi-extension-manager: sample=line?break");
+	expect(managerFailure("setting-save-failed", "style", new Error(managerNotice("setting-enum", "style", "details"))).split("\n")[0]).toBe("pi-extension-manager: setting-enum=style");
+	expect(managerFailure("setting-save-failed", "style", new Error("disk full")).split("\n")[0]).toBe("pi-extension-manager: setting-save-failed=style");
 });

--- a/pi-extensions/pi-extension-manager/test/settings.test.ts
+++ b/pi-extensions/pi-extension-manager/test/settings.test.ts
@@ -3,7 +3,8 @@ import { mkdirSync, rmSync, writeFileSync } from "node:fs";
 import { dirname, join } from "node:path";
 
 import { buildInventory } from "../extensions/manager/inventory.ts";
-import { getConfigValue } from "../extensions/manager/settings.ts";
+import { applyMessage, managerNotice, parseSettingInput } from "../extensions/manager/format.ts";
+import { getConfigValue, getOrCreateRecord } from "../extensions/manager/settings.ts";
 import { EXTERNAL_CONFIG_RESOLVER_SYMBOL, type ExternalConfigResolver, type SettingsSchema } from "../extensions/manager/types.ts";
 
 const rootTmp = join(process.cwd(), "tmp", "pi-extension-manager-settings-tests");
@@ -89,29 +90,20 @@ test("a registered resolver supplies the value when no manager scope holds the k
 	expect(seen).toEqual([["enabled", project]]);
 });
 
-test("manager project scope outranks a registered resolver", () => {
-	const project = setupProject({ scope: "project", value: true });
-	registerResolver(() => ({ explicit: true, source: "~/.pi/agent/external.json", value: false }));
-
-	const config = getConfigValue(inventory(project), PACKAGE_ID, SCHEMA);
-	expect(config).toEqual({ explicit: true, scope: "project", value: true });
+test("manager scopes outrank a registered resolver", () => {
+	for (const scope of ["project", "user"] as const) {
+		const project = setupProject({ scope, value: true });
+		registerResolver(() => ({ explicit: true, source: "~/.pi/agent/external.json", value: false }));
+		expect(getConfigValue(inventory(project), PACKAGE_ID, SCHEMA)).toEqual({ explicit: true, scope, value: true });
+	}
 });
 
-test("manager user scope outranks a registered resolver", () => {
-	const project = setupProject({ scope: "user", value: true });
-	registerResolver(() => ({ explicit: true, source: "~/.pi/agent/external.json", value: false }));
-
-	const config = getConfigValue(inventory(project), PACKAGE_ID, SCHEMA);
-	expect(config).toEqual({ explicit: true, scope: "user", value: true });
-});
-
-test("a resolver that reports nothing falls back to the schema default", () => {
+test("a resolver without an explicit value falls back to the schema default", () => {
 	const project = setupProject();
-	registerResolver(() => undefined);
-	expect(getConfigValue(inventory(project), PACKAGE_ID, SCHEMA)).toEqual({ explicit: false, scope: "default", value: true });
-
-	registerResolver(() => ({ explicit: false, value: false }));
-	expect(getConfigValue(inventory(project), PACKAGE_ID, SCHEMA)).toEqual({ explicit: false, scope: "default", value: true });
+	for (const resolution of [undefined, { explicit: false, value: false }]) {
+		registerResolver(() => resolution);
+		expect(getConfigValue(inventory(project), PACKAGE_ID, SCHEMA)).toEqual({ explicit: false, scope: "default", value: true });
+	}
 });
 
 test("a throwing resolver falls back to the schema default instead of breaking the modal", () => {
@@ -149,4 +141,23 @@ test("resolver results are reused across reads of one inventory", () => {
 
 	expect(getConfigValue(inventory(project), PACKAGE_ID, SCHEMA).value).toBe(false);
 	expect(calls).toBe(2);
+});
+
+test("setting schema refusals and save notices expose stable keys and values", () => {
+	const refusals = [
+		{ schema: { key: "flag", type: "boolean" }, input: "maybe", firstLine: "pi-extension-manager: setting-boolean=flag" },
+		{ schema: { key: "limit", type: "number" }, input: "many", firstLine: "pi-extension-manager: setting-number=limit" },
+		{ schema: { key: "style", type: "enum", enumValues: ["plain"] }, input: "fancy", firstLine: "pi-extension-manager: setting-enum=style" },
+	] as const;
+	for (const row of refusals) {
+		expect(() => parseSettingInput(row.schema as SettingsSchema, row.input)).toThrow(row.firstLine);
+	}
+
+	const saveModes = ["live", "reload", "session", "restart"] as const;
+	for (const apply of saveModes) {
+		expect(applyMessage({ key: "style", type: "string", apply }).split("\n")[0]).toBe(`pi-extension-manager: setting-saved=style:${apply}`);
+	}
+
+	expect(() => getOrCreateRecord({ config: false }, "config")).toThrow("pi-extension-manager: object-required=config");
+	expect(managerNotice("sample", "line\nbreak", "details").split("\n")[0]).toBe("pi-extension-manager: sample=line?break");
 });


### PR DESCRIPTION
The extension manager emitted English-only notices and refusals. Consumers could not identify an action result, setting error, host refusal, or UI notice without parsing prose.

This change gives each extension-manager notice and refusal a stable `pi-extension-manager: key=value` first line. The following line keeps the human explanation. Host JSON and YAML parse failures now identify the rejected path. The tests assert keys, values, and outcomes across Pi and oh-my-pi.

Test audit changes:

- `test/actions.test.ts`: Pins npm results, working-directory failures, invalid commands, and append-system launch warnings.
- `test/bootstrap.test.ts` and `test/fixtures/bootstrap.ts`: Use explicit host and mode rows. Pins recovery notices and global-scope writes.
- `test/host.test.ts`: Pins host and schema refusals plus manager and quick-settings UI notices.
- `test/settings.test.ts`: Folds scope and resolver shapes into tables. Pins setting parse, apply, and object-shape diagnostics.

Compliant files left unchanged:

- `test/inventory.test.ts`
- `test/popup-perf.test.ts`

Validation:

- `bun test ./test`
- `node --test pi-extensions/package-policy.test.mjs`
- Must-fail controls for each changed behavior surface
- `env -u TMPDIR tools/guard --full`

Declined findings: None.
