### PR TITLE
fix(KEN-1241): stabilize GitHub ahead messages

### DIFF
--- a/.agents/skills/github/scripts/commands/pr-create.sh
+++ b/.agents/skills/github/scripts/commands/pr-create.sh
@@ -85,18 +85,17 @@ run_safety_checks() {
         base_ref="origin/$base"
         base_label="origin/$base"
     fi
-    local ahead
+    local ahead ahead_source=""
     ahead=$(git rev-list --count "$base_ref..$head" 2>/dev/null || echo "0")
+    [ "$base_ref" = "origin/$base" ] || ahead_source=" source=local"
     if [ "$ahead" = "0" ]; then
-        printf 'No-commits-ahead: base=%s count=%s\n' "$base_label" "$ahead" >&2
+        printf 'No-commits-ahead: base=%s count=%s%s\n' \
+            "$base_ref" "$ahead" "$ahead_source" >&2
         echo "  ✗ ERROR: No commits ahead of $base_label" >&2
         all_passed=false
     else
-        if [ "$base_ref" = "origin/$base" ]; then
-            printf 'Commits-ahead: base=%s count=%s\n' "$base_ref" "$ahead" >&2
-        else
-            printf 'Commits-ahead: base=%s count=%s source=local\n' "$base_ref" "$ahead" >&2
-        fi
+        printf 'Commits-ahead: base=%s count=%s%s\n' \
+            "$base_ref" "$ahead" "$ahead_source" >&2
         echo "  ✓ $ahead commit(s) ahead of $base_label" >&2
     fi
 

--- a/.agents/skills/github/scripts/commands/pr-create.sh
+++ b/.agents/skills/github/scripts/commands/pr-create.sh
@@ -88,9 +88,15 @@ run_safety_checks() {
     local ahead
     ahead=$(git rev-list --count "$base_ref..$head" 2>/dev/null || echo "0")
     if [ "$ahead" = "0" ]; then
+        printf 'No-commits-ahead: base=%s count=%s\n' "$base_label" "$ahead" >&2
         echo "  ✗ ERROR: No commits ahead of $base_label" >&2
         all_passed=false
     else
+        if [ "$base_ref" = "origin/$base" ]; then
+            printf 'Commits-ahead: base=%s count=%s\n' "$base_ref" "$ahead" >&2
+        else
+            printf 'Commits-ahead: base=%s count=%s source=local\n' "$base_ref" "$ahead" >&2
+        fi
         echo "  ✓ $ahead commit(s) ahead of $base_label" >&2
     fi
 

--- a/.agents/skills/github/tests/pr-create-ahead-count.test.sh
+++ b/.agents/skills/github/tests/pr-create-ahead-count.test.sh
@@ -88,11 +88,11 @@ out=$(run_pr_create --dry-run 2>&1)
 rc=$?
 set -e
 assert_eq "$rc" "0" "stale local main: dry-run passes safety checks"
-assert_contains "$out" "1 commit(s) ahead of origin/main" \
-  "stale local main: counts 1 commit ahead of origin/main"
-assert_not_contains "$out" "3 commit(s)" \
+assert_contains "$out" "Commits-ahead: base=origin/main count=1" \
+  "stale local main: notice key names remote base and count"
+assert_not_contains "$out" "Commits-ahead: base=main count=3 source=local" \
   "stale local main: does not report inflated local-base count"
-assert_not_contains "$out" "may be stale" \
+assert_not_contains "$out" "source=local" \
   "stale local main: no stale-count warning when origin is reachable"
 
 # 2. Branch pointing at the origin/main tip has NO commits to submit. Against the
@@ -104,8 +104,8 @@ out=$(run_pr_create --dry-run 2>&1)
 rc=$?
 set -e
 assert_eq "$rc" "1" "no-new-commits branch: safety checks fail"
-assert_contains "$out" "No commits ahead of origin/main" \
-  "no-new-commits branch: hard failure names remote base"
+assert_contains "$out" "No-commits-ahead: base=origin/main count=0" \
+  "no-new-commits branch: refusal key names remote base and count"
 
 # 3. Offline fallback: origin unreachable and no remote-tracking ref left.
 #    Falls back to local main and labels the count as possibly stale.
@@ -117,8 +117,8 @@ out=$(run_pr_create --dry-run 2>&1)
 rc=$?
 set -e
 assert_eq "$rc" "0" "offline fallback: dry-run still passes (push warning only)"
-assert_contains "$out" "3 commit(s) ahead of local main (origin unreachable; count may be stale)" \
-  "offline fallback: local-base count labeled as possibly stale"
+assert_contains "$out" "Commits-ahead: base=main count=3 source=local" \
+  "offline fallback: notice key names local base, count, and source"
 
 echo
 printf 'pass: %d   fail: %d\n' "$PASS" "$FAIL"

--- a/skills/github/scripts/commands/pr-create.sh
+++ b/skills/github/scripts/commands/pr-create.sh
@@ -85,18 +85,17 @@ run_safety_checks() {
         base_ref="origin/$base"
         base_label="origin/$base"
     fi
-    local ahead
+    local ahead ahead_source=""
     ahead=$(git rev-list --count "$base_ref..$head" 2>/dev/null || echo "0")
+    [ "$base_ref" = "origin/$base" ] || ahead_source=" source=local"
     if [ "$ahead" = "0" ]; then
-        printf 'No-commits-ahead: base=%s count=%s\n' "$base_label" "$ahead" >&2
+        printf 'No-commits-ahead: base=%s count=%s%s\n' \
+            "$base_ref" "$ahead" "$ahead_source" >&2
         echo "  ✗ ERROR: No commits ahead of $base_label" >&2
         all_passed=false
     else
-        if [ "$base_ref" = "origin/$base" ]; then
-            printf 'Commits-ahead: base=%s count=%s\n' "$base_ref" "$ahead" >&2
-        else
-            printf 'Commits-ahead: base=%s count=%s source=local\n' "$base_ref" "$ahead" >&2
-        fi
+        printf 'Commits-ahead: base=%s count=%s%s\n' \
+            "$base_ref" "$ahead" "$ahead_source" >&2
         echo "  ✓ $ahead commit(s) ahead of $base_label" >&2
     fi
 

--- a/skills/github/scripts/commands/pr-create.sh
+++ b/skills/github/scripts/commands/pr-create.sh
@@ -88,9 +88,15 @@ run_safety_checks() {
     local ahead
     ahead=$(git rev-list --count "$base_ref..$head" 2>/dev/null || echo "0")
     if [ "$ahead" = "0" ]; then
+        printf 'No-commits-ahead: base=%s count=%s\n' "$base_label" "$ahead" >&2
         echo "  ✗ ERROR: No commits ahead of $base_label" >&2
         all_passed=false
     else
+        if [ "$base_ref" = "origin/$base" ]; then
+            printf 'Commits-ahead: base=%s count=%s\n' "$base_ref" "$ahead" >&2
+        else
+            printf 'Commits-ahead: base=%s count=%s source=local\n' "$base_ref" "$ahead" >&2
+        fi
         echo "  ✓ $ahead commit(s) ahead of $base_label" >&2
     fi
 

--- a/skills/github/tests/pr-create-ahead-count.test.sh
+++ b/skills/github/tests/pr-create-ahead-count.test.sh
@@ -88,11 +88,11 @@ out=$(run_pr_create --dry-run 2>&1)
 rc=$?
 set -e
 assert_eq "$rc" "0" "stale local main: dry-run passes safety checks"
-assert_contains "$out" "1 commit(s) ahead of origin/main" \
-  "stale local main: counts 1 commit ahead of origin/main"
-assert_not_contains "$out" "3 commit(s)" \
+assert_contains "$out" "Commits-ahead: base=origin/main count=1" \
+  "stale local main: notice key names remote base and count"
+assert_not_contains "$out" "Commits-ahead: base=main count=3 source=local" \
   "stale local main: does not report inflated local-base count"
-assert_not_contains "$out" "may be stale" \
+assert_not_contains "$out" "source=local" \
   "stale local main: no stale-count warning when origin is reachable"
 
 # 2. Branch pointing at the origin/main tip has NO commits to submit. Against the
@@ -104,8 +104,8 @@ out=$(run_pr_create --dry-run 2>&1)
 rc=$?
 set -e
 assert_eq "$rc" "1" "no-new-commits branch: safety checks fail"
-assert_contains "$out" "No commits ahead of origin/main" \
-  "no-new-commits branch: hard failure names remote base"
+assert_contains "$out" "No-commits-ahead: base=origin/main count=0" \
+  "no-new-commits branch: refusal key names remote base and count"
 
 # 3. Offline fallback: origin unreachable and no remote-tracking ref left.
 #    Falls back to local main and labels the count as possibly stale.
@@ -117,8 +117,8 @@ out=$(run_pr_create --dry-run 2>&1)
 rc=$?
 set -e
 assert_eq "$rc" "0" "offline fallback: dry-run still passes (push warning only)"
-assert_contains "$out" "3 commit(s) ahead of local main (origin unreachable; count may be stale)" \
-  "offline fallback: local-base count labeled as possibly stale"
+assert_contains "$out" "Commits-ahead: base=main count=3 source=local" \
+  "offline fallback: notice key names local base, count, and source"
 
 echo
 printf 'pass: %d   fail: %d\n' "$PASS" "$FAIL"


### PR DESCRIPTION
## Summary

- `pr-create` now starts each ahead-count refusal or notice with a stable key, base, and count.
- Remote and local fallback counts use one message mechanism. The English explanation remains on the next line.
- The source and tracked render change together.

## Test plan

- The stable-key control failed against the old mechanism and passed after the mechanism change.
- `bash skills/github/tests/pr-create-ahead-count.test.sh`: `pass: 8 fail: 0`.
- `env -u TMPDIR tools/guard --full` passed on `bc3db3ef920d1f6baec5f01b7720388f106d5af7`.

## Compliant files left unchanged

- `skills/github/tests/bounded-signal.test.sh`
- `skills/github/tests/ci-classify-refusal.test.sh`
- `skills/github/tests/ci-logs-large-log.test.sh`
- `skills/github/tests/ci-run-correlation.test.sh`
- `skills/github/tests/gh-stub-restage.test.sh`
- `skills/github/tests/git-diff-summary-default-base.test.sh`
- `skills/github/tests/git-diff-summary.test.sh`
- `skills/github/tests/git-https-auth.test.sh`
- `skills/github/tests/github-router.test.sh`
- `skills/github/tests/graphql-threads-paging.test.sh`
- `skills/github/tests/label-add.test.sh`
- `skills/github/tests/post-reply.test.sh`
- `skills/github/tests/pr-list-ready-rollup.test.sh`
- `skills/github/tests/pr-merge.test.sh`
- `skills/github/tests/pr-threads.test.sh`
- `skills/github/tests/pr-view.test.sh`
- `skills/github/tests/sticky-comment-cli.test.sh`
- `skills/github/tests/sticky-verdict.test.sh`
- `skills/github/tests/verify-lib.test.sh`

The shared `kendex-env.sh` copy remains unchanged. PR #2462 owns that source and its renders.

Refs KEN-1241.
