### PR TITLE
fix(KEN-1241): stabilize Linear cache refusal

### DIFF
--- a/.agents/skills/linear/scripts/lib/cache.sh
+++ b/.agents/skills/linear/scripts/lib/cache.sh
@@ -128,6 +128,8 @@ cache_worktree_cache_clobbered() {
 
 cache_worktree_clobber_refusal() {
     {
+        printf 'Sync-refused: worktree=%s cache=%s expected=%s\n' \
+            "$CACHE_PROJECT_ROOT" "$CACHE_PROJECT_ROOT/.cache" "$CACHE_WORKTREE_MAIN_ROOT/.cache"
         echo "Sync refused: cache dir is a worktree-local real directory (kendex#1032)."
         echo "  Worktree:       $CACHE_PROJECT_ROOT"
         echo "  Cache dir here: $CACHE_PROJECT_ROOT/.cache (real directory)"

--- a/.agents/skills/linear/tests/sync-worktree-cache-guard.test.sh
+++ b/.agents/skills/linear/tests/sync-worktree-cache-guard.test.sh
@@ -22,6 +22,10 @@ source "$SCRIPT_DIR/lib/assert.sh"
 SKILL_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
 LINEAR="$SKILL_DIR/scripts/linear.sh"
 assert_tmpdir TMP_BASE
+TMP_BASE="$(cd "$TMP_BASE" && pwd -P)" || {
+  printf 'FAIL: could not canonicalize the test scratch root\n' >&2
+  exit 1
+}
 
 CURL_LOG="$TMP_BASE/curl.log"
 

--- a/.agents/skills/linear/tests/sync-worktree-cache-guard.test.sh
+++ b/.agents/skills/linear/tests/sync-worktree-cache-guard.test.sh
@@ -102,10 +102,6 @@ err="$(run_sync "$GUARD_ROOT/wt" 2>&1 >/dev/null)" || rc=$?
 assert_ne "sync into a clobbered worktree cache is refused" "$rc" 0
 assert_contains "the refusal key names the worktree cache and expected cache" "$err" \
   "Sync-refused: worktree=$GUARD_ROOT/wt cache=$GUARD_ROOT/wt/.cache expected=$(cd "$GUARD_ROOT/main" && pwd -P)/.cache"
-assert_contains "the refusal names the worktree" "$err" "$GUARD_ROOT/wt"
-assert_contains "the refusal names the expected symlink" \
-  "$err" ".cache -> $(cd "$GUARD_ROOT/main" && pwd -P)/.cache"
-assert_contains "the refusal names the repair command" "$err" "worktree fix-links"
 assert_not "no API call happens before the refusal" test -s "$CURL_LOG"
 assert_not "the refused sync created no worktree-local cache dir" \
   test -e "$GUARD_ROOT/wt/.cache/linear"

--- a/.agents/skills/linear/tests/sync-worktree-cache-guard.test.sh
+++ b/.agents/skills/linear/tests/sync-worktree-cache-guard.test.sh
@@ -100,7 +100,8 @@ rc=0
 err="$(run_sync "$GUARD_ROOT/wt" 2>&1 >/dev/null)" || rc=$?
 
 assert_ne "sync into a clobbered worktree cache is refused" "$rc" 0
-assert_contains "the refusal is loud and greppable" "$err" "Sync refused"
+assert_contains "the refusal key names the worktree cache and expected cache" "$err" \
+  "Sync-refused: worktree=$GUARD_ROOT/wt cache=$GUARD_ROOT/wt/.cache expected=$(cd "$GUARD_ROOT/main" && pwd -P)/.cache"
 assert_contains "the refusal names the worktree" "$err" "$GUARD_ROOT/wt"
 assert_contains "the refusal names the expected symlink" \
   "$err" ".cache -> $(cd "$GUARD_ROOT/main" && pwd -P)/.cache"
@@ -114,7 +115,8 @@ rc_full=0
 err_full="$(run_sync "$GUARD_ROOT/wt" --full 2>&1 >/dev/null)" || rc_full=$?
 
 assert_ne "--full is refused too" "$rc_full" 0
-assert_contains "the --full refusal is the same loud refusal" "$err_full" "Sync refused"
+assert_contains "the --full refusal has the same key and values" "$err_full" \
+  "Sync-refused: worktree=$GUARD_ROOT/wt cache=$GUARD_ROOT/wt/.cache expected=$(cd "$GUARD_ROOT/main" && pwd -P)/.cache"
 
 # --- control: bare sync on the healthy main checkout ---------------------------
 : >"$CURL_LOG"
@@ -152,7 +154,8 @@ rc_slash=0
 err_slash="$(run_sync "$SLASH_ROOT/wt" 2>&1 >/dev/null)" || rc_slash=$?
 
 assert_ne "'.cache//' is refused: the normalizer strips trailing slashes" "$rc_slash" 0
-assert_contains "the '.cache//' refusal is the same loud refusal" "$err_slash" "Sync refused"
+assert_contains "the '.cache//' refusal has the stable key" "$err_slash" \
+  "Sync-refused: worktree=$SLASH_ROOT/wt cache=$SLASH_ROOT/wt/.cache expected=$(cd "$SLASH_ROOT/main" && pwd -P)/.cache"
 
 # --- no worktree config at all: the issue's bare prescription still refuses ----
 BARE_ROOT="$TMP_BASE/bare"
@@ -161,4 +164,5 @@ rc_bare=0
 err_bare="$(run_sync "$BARE_ROOT/wt" 2>&1 >/dev/null)" || rc_bare=$?
 
 assert_ne "an unconfigured repo with a main .cache still refuses" "$rc_bare" 0
-assert_contains "the unconfigured refusal is the same loud refusal" "$err_bare" "Sync refused"
+assert_contains "the unconfigured refusal has the stable key" "$err_bare" \
+  "Sync-refused: worktree=$BARE_ROOT/wt cache=$BARE_ROOT/wt/.cache expected=$(cd "$BARE_ROOT/main" && pwd -P)/.cache"

--- a/skills/linear/scripts/lib/cache.sh
+++ b/skills/linear/scripts/lib/cache.sh
@@ -128,6 +128,8 @@ cache_worktree_cache_clobbered() {
 
 cache_worktree_clobber_refusal() {
     {
+        printf 'Sync-refused: worktree=%s cache=%s expected=%s\n' \
+            "$CACHE_PROJECT_ROOT" "$CACHE_PROJECT_ROOT/.cache" "$CACHE_WORKTREE_MAIN_ROOT/.cache"
         echo "Sync refused: cache dir is a worktree-local real directory (kendex#1032)."
         echo "  Worktree:       $CACHE_PROJECT_ROOT"
         echo "  Cache dir here: $CACHE_PROJECT_ROOT/.cache (real directory)"

--- a/skills/linear/tests/sync-worktree-cache-guard.test.sh
+++ b/skills/linear/tests/sync-worktree-cache-guard.test.sh
@@ -22,6 +22,10 @@ source "$SCRIPT_DIR/lib/assert.sh"
 SKILL_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
 LINEAR="$SKILL_DIR/scripts/linear.sh"
 assert_tmpdir TMP_BASE
+TMP_BASE="$(cd "$TMP_BASE" && pwd -P)" || {
+  printf 'FAIL: could not canonicalize the test scratch root\n' >&2
+  exit 1
+}
 
 CURL_LOG="$TMP_BASE/curl.log"
 

--- a/skills/linear/tests/sync-worktree-cache-guard.test.sh
+++ b/skills/linear/tests/sync-worktree-cache-guard.test.sh
@@ -102,10 +102,6 @@ err="$(run_sync "$GUARD_ROOT/wt" 2>&1 >/dev/null)" || rc=$?
 assert_ne "sync into a clobbered worktree cache is refused" "$rc" 0
 assert_contains "the refusal key names the worktree cache and expected cache" "$err" \
   "Sync-refused: worktree=$GUARD_ROOT/wt cache=$GUARD_ROOT/wt/.cache expected=$(cd "$GUARD_ROOT/main" && pwd -P)/.cache"
-assert_contains "the refusal names the worktree" "$err" "$GUARD_ROOT/wt"
-assert_contains "the refusal names the expected symlink" \
-  "$err" ".cache -> $(cd "$GUARD_ROOT/main" && pwd -P)/.cache"
-assert_contains "the refusal names the repair command" "$err" "worktree fix-links"
 assert_not "no API call happens before the refusal" test -s "$CURL_LOG"
 assert_not "the refused sync created no worktree-local cache dir" \
   test -e "$GUARD_ROOT/wt/.cache/linear"

--- a/skills/linear/tests/sync-worktree-cache-guard.test.sh
+++ b/skills/linear/tests/sync-worktree-cache-guard.test.sh
@@ -100,7 +100,8 @@ rc=0
 err="$(run_sync "$GUARD_ROOT/wt" 2>&1 >/dev/null)" || rc=$?
 
 assert_ne "sync into a clobbered worktree cache is refused" "$rc" 0
-assert_contains "the refusal is loud and greppable" "$err" "Sync refused"
+assert_contains "the refusal key names the worktree cache and expected cache" "$err" \
+  "Sync-refused: worktree=$GUARD_ROOT/wt cache=$GUARD_ROOT/wt/.cache expected=$(cd "$GUARD_ROOT/main" && pwd -P)/.cache"
 assert_contains "the refusal names the worktree" "$err" "$GUARD_ROOT/wt"
 assert_contains "the refusal names the expected symlink" \
   "$err" ".cache -> $(cd "$GUARD_ROOT/main" && pwd -P)/.cache"
@@ -114,7 +115,8 @@ rc_full=0
 err_full="$(run_sync "$GUARD_ROOT/wt" --full 2>&1 >/dev/null)" || rc_full=$?
 
 assert_ne "--full is refused too" "$rc_full" 0
-assert_contains "the --full refusal is the same loud refusal" "$err_full" "Sync refused"
+assert_contains "the --full refusal has the same key and values" "$err_full" \
+  "Sync-refused: worktree=$GUARD_ROOT/wt cache=$GUARD_ROOT/wt/.cache expected=$(cd "$GUARD_ROOT/main" && pwd -P)/.cache"
 
 # --- control: bare sync on the healthy main checkout ---------------------------
 : >"$CURL_LOG"
@@ -152,7 +154,8 @@ rc_slash=0
 err_slash="$(run_sync "$SLASH_ROOT/wt" 2>&1 >/dev/null)" || rc_slash=$?
 
 assert_ne "'.cache//' is refused: the normalizer strips trailing slashes" "$rc_slash" 0
-assert_contains "the '.cache//' refusal is the same loud refusal" "$err_slash" "Sync refused"
+assert_contains "the '.cache//' refusal has the stable key" "$err_slash" \
+  "Sync-refused: worktree=$SLASH_ROOT/wt cache=$SLASH_ROOT/wt/.cache expected=$(cd "$SLASH_ROOT/main" && pwd -P)/.cache"
 
 # --- no worktree config at all: the issue's bare prescription still refuses ----
 BARE_ROOT="$TMP_BASE/bare"
@@ -161,4 +164,5 @@ rc_bare=0
 err_bare="$(run_sync "$BARE_ROOT/wt" 2>&1 >/dev/null)" || rc_bare=$?
 
 assert_ne "an unconfigured repo with a main .cache still refuses" "$rc_bare" 0
-assert_contains "the unconfigured refusal is the same loud refusal" "$err_bare" "Sync refused"
+assert_contains "the unconfigured refusal has the stable key" "$err_bare" \
+  "Sync-refused: worktree=$BARE_ROOT/wt cache=$BARE_ROOT/wt/.cache expected=$(cd "$BARE_ROOT/main" && pwd -P)/.cache"


### PR DESCRIPTION
## Summary

- Linear cache sync refusals now start with `Sync-refused` and name the worktree cache and expected shared cache.
- The English repair explanation remains on the next line.
- The test checks the stable key, values, and exit status. The source and tracked render change together.

## Test plan

- The stable-key assertions failed against the old mechanism and passed after the mechanism change.
- `bash skills/linear/tests/sync-worktree-cache-guard.test.sh`: `ok: 19 assertions`.
- `skills/linear/tests/must-fail-controls.sh sync-worktree-cache-guard`: `1 controls, 0 failing, 0 orphaned`.
- The formal review finding is fixed in `2a63485f14bd267e4591cbcbb0469b3250c409be`. The test now canonicalizes its scratch root before it checks emitted paths.
- `env -u TMPDIR tools/guard --full` passed on `2a63485f14bd267e4591cbcbb0469b3250c409be`.

## Compliant files left unchanged

- `skills/linear/tests/action-aliases.test.sh`
- `skills/linear/tests/api-key-precedence.test.sh`
- `skills/linear/tests/assert-outstanding-jobs.test.sh`
- `skills/linear/tests/assert-subshell.test.sh`
- `skills/linear/tests/assert-verdict.test.sh`
- `skills/linear/tests/bash4-runtime-contract.test.sh`
- `skills/linear/tests/blocked-by-open.test.sh`
- `skills/linear/tests/bulk-update-diagnostics.test.sh`
- `skills/linear/tests/cache-corrupt-fail-closed.test.sh`
- `skills/linear/tests/cache-cycles-team-filter.test.sh`
- `skills/linear/tests/cache-date-comparison-utc.test.sh`
- `skills/linear/tests/cache-filters-fail-closed.test.sh`
- `skills/linear/tests/cache-isolation.test.sh`
- `skills/linear/tests/cache-issues-all-projects.test.sh`
- `skills/linear/tests/cache-issues-no-project.test.sh`
- `skills/linear/tests/cache-issues-relations.test.sh`
- `skills/linear/tests/cache-no-auth.test.sh`
- `skills/linear/tests/cache-projects-dependencies-single.test.sh`
- `skills/linear/tests/cache-projects-get-single.test.sh`
- `skills/linear/tests/cache-refresh-keeps-team.test.sh`
- `skills/linear/tests/cache-root-git-worktree.test.sh`
- `skills/linear/tests/cache-safe-format-parent-labels.test.sh`
- `skills/linear/tests/cache-truncation-warning.test.sh`
- `skills/linear/tests/comments-body-file.test.sh`
- `skills/linear/tests/comments-create-attach.test.sh`
- `skills/linear/tests/completed-blocker-relations-doc.test.sh`
- `skills/linear/tests/completion-validation-bundle-children.test.sh`
- `skills/linear/tests/completion-validation-parented-root.test.sh`
- `skills/linear/tests/estimate-clear.test.sh`
- `skills/linear/tests/graphql-document-classification.test.sh`
- `skills/linear/tests/issues-activate-agent.test.sh`
- `skills/linear/tests/issues-add-relation-hierarchy.test.sh`
- `skills/linear/tests/issues-archive-trash-entity-verify.test.sh`
- `skills/linear/tests/issues-complete-summary.test.sh`
- `skills/linear/tests/issues-create-agent-label-guard.test.sh`
- `skills/linear/tests/issues-create-attach.test.sh`
- `skills/linear/tests/issues-create-format-ids.test.sh`
- `skills/linear/tests/issues-create-parent.test.sh`
- `skills/linear/tests/issues-create-reach-guard.test.sh`
- `skills/linear/tests/issues-description-file.test.sh`
- `skills/linear/tests/issues-list-search-server-filter.test.sh`
- `skills/linear/tests/issues-update-attach.test.sh`
- `skills/linear/tests/issues-update-format-safe.test.sh`
- `skills/linear/tests/issues-update-unknown-label-refuses.test.sh`
- `skills/linear/tests/issues-view-action-hint.test.sh`
- `skills/linear/tests/label-name-spaces.test.sh`
- `skills/linear/tests/milestone-project-scope.test.sh`
- `skills/linear/tests/mutation-isolation.test.sh`
- `skills/linear/tests/no-repository-refusal.test.sh`
- `skills/linear/tests/project-name-canceled-duplicate.test.sh`
- `skills/linear/tests/projects-list-pagination.test.sh`
- `skills/linear/tests/rate-limited-http-400.test.sh`
- `skills/linear/tests/roster-orphan.test.sh`
- `skills/linear/tests/run-status-errexit.test.sh`
- `skills/linear/tests/sync-comments-pagination.test.sh`
- `skills/linear/tests/sync-issues-page-cap.test.sh`
- `skills/linear/tests/sync-merge-abort-error.test.sh`
- `skills/linear/tests/sync-reconcile-invalid-ids.test.sh`
- `skills/linear/tests/team-target-fail-closed.test.sh`

The shared `kendex-env.sh` copy remains unchanged. PR #2462 owns that source and its renders.

Refs KEN-1241.
