### PR TITLE
fix(KEN-1306): early-close-pipe judges the test tree

### DIFF
--- a/.agents/skills/preflight/scripts/preflight
+++ b/.agents/skills/preflight/scripts/preflight
@@ -135,9 +135,11 @@ Scope rules:
   any lane; the whole-file lanes still see its path. A deleted path leaves the
   change set, and applied-migration-edited reads it from the diff instead.
   The test tree sets its own rules: a tests/ or fixtures/ tree, and a suite
-  as unwired-suite defines one, wherever it lives. early-close-pipe,
-  mktemp-trap, the source-file direction of docs-cited-paths, and the
-  strict-mode and swallowed-status shapes of fail-open stand down there. In a
+  as unwired-suite defines one, wherever it lives. mktemp-trap, the
+  source-file direction of docs-cited-paths, and the strict-mode and
+  swallowed-status shapes of fail-open stand down there. early-close-pipe is
+  judged there like anywhere else: a suite that sets pipefail dies of the
+  same 141, and its own rules are about observing a status, not SIGPIPE. In a
   test-named source file (tests.rs, *_test.*, *_tests.*, *.test.*, *.spec.*,
   test_*) only the swallowed-status shape and that same docs-cited-paths
   direction stand down. The mktemp assignment shape of fail-open is judged in
@@ -1397,7 +1399,11 @@ while IFS= read -r f; do
       esac
     fi
 
-    if [ "$is_sh" = 1 ] && [ "$own_rules" = 0 ] && [ "$vendored_mirror" = 0 ] && [ "$has_pf" = 1 ]; then
+    # The test tree is judged here, unlike in the lanes above: its own rules
+    # buy a suite the right to observe a status errexit would abort on, which
+    # is no licence to take a 141 that ends the run in the middle of a
+    # section. The file's own pipefail is already the condition above.
+    if [ "$is_sh" = 1 ] && [ "$vendored_mirror" = 0 ] && [ "$has_pf" = 1 ]; then
       case "$content" in
         *"|"*)
           if ! is_comment_line "$content" && grep -Eq -- "$EARLY_CLOSE_RE" <<<"$content"; then

--- a/.agents/skills/preflight/tests/lanes-must-fail.test.sh
+++ b/.agents/skills/preflight/tests/lanes-must-fail.test.sh
@@ -71,6 +71,18 @@ pf_world() {
     # fixture pushes several hundred KB before it blocks, so it passes
     # either way.
     earlyclose) printf '#!/usr/bin/env bash\nset -euo pipefail\nif echo "$1" | grep -q x; then echo hit; fi\n' >"$R/scripts/existing.sh" ;;
+    # The same lane inside the test tree, on the mid-pipeline shape: the
+    # reader is two stages down and another stage runs after it, and the
+    # suite's own pipefail is what turns the writer's SIGPIPE into the 141
+    # that ends the run mid-section. The pipeline is halved across two
+    # variables so this suite's own committed line does not carry the shape.
+    # The suite is the one the seeded workflow names, so it is wired.
+    earlyclosesuite)
+      seed_runner
+      ec_writer='n=$(printf "%s\n" "$1" '
+      ec_reader='| grep -n x | head -1 | cut -d: -f1)'
+      printf '#!/usr/bin/env bash\nset -euo pipefail\n%s%s\necho "$n"\n' "$ec_writer" "$ec_reader" >"$R/tests/known.test.sh"
+      ;;
     # The guard sits at the far edge of the look-ahead window: the
     # assignment is on line 3 and the test of $ROOT on line 7, four lines
     # below it. A narrower window stops finding this. The assignment is bare
@@ -170,6 +182,7 @@ a new script that never sets -e/-u/pipefail fails as fail-open|strict|-|-|1|scri
 a grep whose status or-true drops fails as fail-open, naming the command|swallow|-|-|1|scripts/existing.sh:4: [fail-open]|grep || true swallows exit 2
 the shape is caught inside a command substitution too|swallowsubst|-|-|1|scripts/existing.sh:4: [fail-open]|git || true swallows exit 2
 a condition piping echo into grep -q fails as early-close-pipe|earlyclose|-|-|1|scripts/existing.sh:3: [early-close-pipe]|a shell writer piped into a reader that stops before EOF
+a suite that sets pipefail is judged too, mid-pipeline reader included|earlyclosesuite|-|-|1|tests/known.test.sh:3: [early-close-pipe]|-
 an assignment whose guard errexit kills first fails as fail-open|bareassign|-|-|1|scripts/bare.sh:3: [fail-open]|bare command-substitution assignment under errexit
 an operator inside the substitution does not exempt the assignment|bareinner|-|-|1|scripts/bare.sh:3: [fail-open]|bare command-substitution assignment under errexit
 a new script with mktemp and no EXIT trap fails as mktemp-trap|scratch|-|-|1|scripts/scratch.sh:3: [mktemp-trap]|mktemp without an EXIT trap

--- a/skills/preflight/scripts/preflight
+++ b/skills/preflight/scripts/preflight
@@ -135,9 +135,11 @@ Scope rules:
   any lane; the whole-file lanes still see its path. A deleted path leaves the
   change set, and applied-migration-edited reads it from the diff instead.
   The test tree sets its own rules: a tests/ or fixtures/ tree, and a suite
-  as unwired-suite defines one, wherever it lives. early-close-pipe,
-  mktemp-trap, the source-file direction of docs-cited-paths, and the
-  strict-mode and swallowed-status shapes of fail-open stand down there. In a
+  as unwired-suite defines one, wherever it lives. mktemp-trap, the
+  source-file direction of docs-cited-paths, and the strict-mode and
+  swallowed-status shapes of fail-open stand down there. early-close-pipe is
+  judged there like anywhere else: a suite that sets pipefail dies of the
+  same 141, and its own rules are about observing a status, not SIGPIPE. In a
   test-named source file (tests.rs, *_test.*, *_tests.*, *.test.*, *.spec.*,
   test_*) only the swallowed-status shape and that same docs-cited-paths
   direction stand down. The mktemp assignment shape of fail-open is judged in
@@ -1397,7 +1399,11 @@ while IFS= read -r f; do
       esac
     fi
 
-    if [ "$is_sh" = 1 ] && [ "$own_rules" = 0 ] && [ "$vendored_mirror" = 0 ] && [ "$has_pf" = 1 ]; then
+    # The test tree is judged here, unlike in the lanes above: its own rules
+    # buy a suite the right to observe a status errexit would abort on, which
+    # is no licence to take a 141 that ends the run in the middle of a
+    # section. The file's own pipefail is already the condition above.
+    if [ "$is_sh" = 1 ] && [ "$vendored_mirror" = 0 ] && [ "$has_pf" = 1 ]; then
       case "$content" in
         *"|"*)
           if ! is_comment_line "$content" && grep -Eq -- "$EARLY_CLOSE_RE" <<<"$content"; then

--- a/skills/preflight/tests/lanes-must-fail.test.sh
+++ b/skills/preflight/tests/lanes-must-fail.test.sh
@@ -71,6 +71,18 @@ pf_world() {
     # fixture pushes several hundred KB before it blocks, so it passes
     # either way.
     earlyclose) printf '#!/usr/bin/env bash\nset -euo pipefail\nif echo "$1" | grep -q x; then echo hit; fi\n' >"$R/scripts/existing.sh" ;;
+    # The same lane inside the test tree, on the mid-pipeline shape: the
+    # reader is two stages down and another stage runs after it, and the
+    # suite's own pipefail is what turns the writer's SIGPIPE into the 141
+    # that ends the run mid-section. The pipeline is halved across two
+    # variables so this suite's own committed line does not carry the shape.
+    # The suite is the one the seeded workflow names, so it is wired.
+    earlyclosesuite)
+      seed_runner
+      ec_writer='n=$(printf "%s\n" "$1" '
+      ec_reader='| grep -n x | head -1 | cut -d: -f1)'
+      printf '#!/usr/bin/env bash\nset -euo pipefail\n%s%s\necho "$n"\n' "$ec_writer" "$ec_reader" >"$R/tests/known.test.sh"
+      ;;
     # The guard sits at the far edge of the look-ahead window: the
     # assignment is on line 3 and the test of $ROOT on line 7, four lines
     # below it. A narrower window stops finding this. The assignment is bare
@@ -170,6 +182,7 @@ a new script that never sets -e/-u/pipefail fails as fail-open|strict|-|-|1|scri
 a grep whose status or-true drops fails as fail-open, naming the command|swallow|-|-|1|scripts/existing.sh:4: [fail-open]|grep || true swallows exit 2
 the shape is caught inside a command substitution too|swallowsubst|-|-|1|scripts/existing.sh:4: [fail-open]|git || true swallows exit 2
 a condition piping echo into grep -q fails as early-close-pipe|earlyclose|-|-|1|scripts/existing.sh:3: [early-close-pipe]|a shell writer piped into a reader that stops before EOF
+a suite that sets pipefail is judged too, mid-pipeline reader included|earlyclosesuite|-|-|1|tests/known.test.sh:3: [early-close-pipe]|-
 an assignment whose guard errexit kills first fails as fail-open|bareassign|-|-|1|scripts/bare.sh:3: [fail-open]|bare command-substitution assignment under errexit
 an operator inside the substitution does not exempt the assignment|bareinner|-|-|1|scripts/bare.sh:3: [fail-open]|bare command-substitution assignment under errexit
 a new script with mktemp and no EXIT trap fails as mktemp-trap|scratch|-|-|1|scripts/scratch.sh:3: [mktemp-trap]|mktemp without an EXIT trap


### PR DESCRIPTION
## Summary

- `preflight`'s `early-close-pipe` lane stood down over the entire test tree. Its guard dropped one condition — `own_rules` — and now reads `[ "$is_sh" = 1 ] && [ "$vendored_mirror" = 0 ] && [ "$has_pf" = 1 ]`, so a suite that turns pipefail on itself is judged like any other shell file.
- `preflight --help` § Scope rules listed this lane among the test-tree stand-downs. That sentence no longer does, and says why the lane is judged in every tree. The installed-artifact paragraph still names it, correctly: `vendored_mirror` is kept.
- One must-fail row in `skills/preflight/tests/lanes-must-fail.test.sh` plants the shipped shape in a wired `tests/known.test.sh`.

## The issue's stated cause is half wrong

KEN-1306 reports that `EARLY_CLOSE_RE` misses a writer piped into a **mid-pipeline** `head`. It does not. The pattern's intermediate-stage group `[^|]*(\|[[:space:]]*[^|[:space:]][^|]*)*\|[[:space:]]*` accepts any number of stages between writer and reader, and the `grep -E` is unanchored, so stages after `head` are irrelevant. Checked directly against the shipped regex before any code was written — `printf … | head -1`, `printf … | grep -n 'x' | head -1`, `printf … | grep -n 'x' | head -1 | cut -d: -f1`, and each inside `$( )` — all match. **The regex is unchanged.**

The real cause is the lane's own guard. `own_rules` comes from `test_tree_role`, which claims every `*/tests/*.test.sh`, `*/tests/test-*.sh`, `*/fixtures/*` and residual `*/tests/*` path. The six sites that shipped in #2464 were added **in a test suite**, so the lane never ran on them.

Proved on a scratch repo: the byte-identical line `n=$(printf '%s\n' "$OUT" | grep -n 'b' | head -1 | cut -d: -f1)` reports `early-close-pipe` in `scripts/demo` and reports nothing in `tests/demo.test.sh` — one finding across two changed files.

`own_rules` has a stated rationale in the source: a suite "may observe a status errexit would abort on". That governs the strict-mode preamble and swallowed-status shapes. It says nothing about SIGPIPE, and the lane already requires `has_pf=1`, so it only ever spoke about suites that turn pipefail on themselves — exactly where a 141 ends the run mid-section. That is the failure that reached `Skill suites shard (guards, macos-latest)`. A lane that passes six instances of its own shape reports a safety it does not have; gate code fails closed.

The repo's own engineering rule already said so without qualification — `skills/code-quality/SKILL.md` § Language Discipline: "In any `pipefail` script, never pipe a shell writer into an early-closing reader". It states no test-tree exemption, and it is also where the control's `printf`-not-`cat` requirement comes from. The lane was the one place that disagreed with it, so this closes a gap rather than opening one.

## Why the cut was kept whole

`*/fixtures/*` material is judged too, rather than carved out. No committed fixture in this repo carries the shape — preflight's own must-fail fixtures are written at run time by `printf` — so a fixtures exemption would be an exemption with no producer, and a guard change here adds no enumerated exemption list.

## Latent sites, deliberately untouched

14 pre-existing instances of the shape live in 12 of this repo's own pipefail test files. None is in this diff. They are latent rather than breakage: preflight is line-scoped and CI dogfoods it diff-scoped (`.github/workflows/skill-tests.yml`), so each stays quiet until a change touches its line. Clearing them is outside this issue's Done-when and would blow this diff; the list is with the orchestrator for a separate scheduling decision.

## Completed Issues

- Closes KEN-1306 - preflight early-close-pipe misses a pipe into head mid-pipeline

## Size

No allowance stated on the issue. Measured: production 10, tests 13, render mirror 23.

## Test Plan

- **Must-fail control, proved both directions.** The new `earlyclosesuite` row plants `n=$(printf "%s\n" "$1" | grep -n x | head -1 | cut -d: -f1)` into a wired `tests/known.test.sh` — shell writer, reader two stages down, another stage after it, in a bare command-substitution assignment under errexit where the 141 really does abort. Against the pre-fix script in a scratch copy the suite is 35 passed / 1 failed with only that row red; against the fix, 36 passed / 0 failed. The writer is `printf` from the shell, not `cat` reading a file — a file-backed writer fills the pipe buffer and passes either way, so it would prove nothing.
- **No new false positives.** All six preflight suites green: 214 assertions, 0 failed. `precision.test.sh` at 59 assertions covers the benign-neighbour block (here-string reader, file-fed reader, run-to-EOF reader, `||` rather than a pipe, the shape named in a comment or a message).
- **No self-inflicted CI failure.** The changed suite file is now judged by the lane it tests, so the fixture line is split across two shell variables and its own committed line does not carry the shape. Dogfooding `preflight --base origin/main` on this branch — the same invocation `.github/workflows/skill-tests.yml` runs — prints `clean=4` with no findings.
- **Reach confined to the one lane.** The five other `own_rules` gates are intact and `own_rules` is still bound.
- **Renders.** Both tracked renders under `.agents/skills/preflight/` were synced by replaying the source diff with `patch --no-backup-if-mismatch`, in the same commit, and their diffs are byte-identical to their sources.
- `tools/bash32-lint` clean=544 repo-wide; `env -u TMPDIR tools/guard --full` on the final head.

https://claude.ai/code/session_01Dj1dmLTeCNhcG2LRYgcXPu
