### PR TITLE
The commit's literal selection stops reaching repo hooks (KEN-1309)

### DIFF
--- a/changelog.d/fixed/1309.md
+++ b/changelog.d/fixed/1309.md
@@ -1,0 +1,1 @@
+- Give a repository's own pre-commit hooks the git a plain commit gives them when kendex commits: their glob pathspecs match their files again, and `git check-ignore` answers instead of exiting 128.

--- a/crates/cli/tests/commit_offer_cli.rs
+++ b/crates/cli/tests/commit_offer_cli.rs
@@ -17,17 +17,27 @@ use std::process::{Command, Output};
 
 use kendex_core::process::Hardened;
 
-#[allow(clippy::expect_used)]
 fn kendex(home: &Path, cwd: &Path, args: &[&str]) -> Output {
-    Command::new(env!("CARGO_BIN_EXE_kendex"))
+    kendex_under(home, cwd, args, &[])
+}
+
+/// The same, with `ambient` added to the environment the binary starts
+/// under — for a case whose subject is what kendex does with a variable
+/// the shell it was launched from had set.
+#[allow(clippy::expect_used)]
+fn kendex_under(home: &Path, cwd: &Path, args: &[&str], ambient: &[(&str, &str)]) -> Output {
+    let mut command = Command::new(env!("CARGO_BIN_EXE_kendex"));
+    command
         .args(args)
         .current_dir(cwd)
         .env_clear()
         .envs(test_util::fixture_env(home))
         .env("KENDEX_BACKGROUND_REFRESH", "off")
-        .env("PATH", path_with_fake_gh(home))
-        .output()
-        .expect("kendex binary runs")
+        .env("PATH", path_with_fake_gh(home));
+    for (key, value) in ambient {
+        command.env(key, value);
+    }
+    command.output().expect("kendex binary runs")
 }
 
 fn said(output: &Output) -> String {
@@ -152,9 +162,19 @@ exit 1
 "#;
 
 fn apply(home: &Path, project: &Path, flags: &[&str]) -> (Output, String) {
+    apply_under(home, project, flags, &[])
+}
+
+/// The same, run under `ambient` in the binary's own environment.
+fn apply_under(
+    home: &Path,
+    project: &Path,
+    flags: &[&str],
+    ambient: &[(&str, &str)],
+) -> (Output, String) {
     let mut args = vec!["apply", "--yes"];
     args.extend_from_slice(flags);
-    let output = kendex(home, project, &args);
+    let output = kendex_under(home, project, &args, ambient);
     let text = said(&output);
     (output, text)
 }
@@ -227,6 +247,39 @@ fn the_commit_flag_commits_the_set_with_the_commands_message() {
     assert!(
         git(&project, &["status", "--porcelain"]).contains(" M AGENTS.md"),
         "the person's own change was swept into the commit"
+    );
+}
+
+/// The shell kendex was launched from decides nothing about which files
+/// the commit selects. Every entry in the pathspec file is written behind
+/// a `:(literal)` prefix, and `GIT_LITERAL_PATHSPECS=1` in the ambient
+/// environment would have git read that whole entry as a filename: the
+/// staging step exits 128 `did not match any files` and the commit is
+/// refused. `Hardened` drops the variable before it reaches git, so the
+/// run is the ordinary one.
+///
+/// The must-fail control is the entry in `GIT_REDIRECTS`: take
+/// `GIT_LITERAL_PATHSPECS` out of that list and this case reddens. Driven
+/// through the binary because the variable has to sit in a real process's
+/// environment, and the workspace forbids the `unsafe` that setting one on
+/// this process would need.
+#[test]
+fn an_ambient_pathspec_variable_does_not_reach_the_commits_git() {
+    let tmp = tempfile::tempdir().unwrap();
+    let home = rooted(&tmp);
+    let project = project(&tmp);
+    let (output, text) = apply_under(
+        &home,
+        &project,
+        &["--commit"],
+        &[("GIT_LITERAL_PATHSPECS", "1")],
+    );
+    assert!(output.status.success(), "{text}");
+    assert!(text.contains("committed 2 files as "), "{text}");
+    let files = git(&project, &["show", "--name-only", "--format=", "HEAD"]);
+    assert!(
+        files.contains("CLAUDE.md") && files.contains(".kendex-generated.json"),
+        "{files}"
     );
 }
 

--- a/crates/cli/tests/commit_offer_cli.rs
+++ b/crates/cli/tests/commit_offer_cli.rs
@@ -17,27 +17,17 @@ use std::process::{Command, Output};
 
 use kendex_core::process::Hardened;
 
-fn kendex(home: &Path, cwd: &Path, args: &[&str]) -> Output {
-    kendex_under(home, cwd, args, &[])
-}
-
-/// The same, with `ambient` added to the environment the binary starts
-/// under — for a case whose subject is what kendex does with a variable
-/// the shell it was launched from had set.
 #[allow(clippy::expect_used)]
-fn kendex_under(home: &Path, cwd: &Path, args: &[&str], ambient: &[(&str, &str)]) -> Output {
-    let mut command = Command::new(env!("CARGO_BIN_EXE_kendex"));
-    command
+fn kendex(home: &Path, cwd: &Path, args: &[&str]) -> Output {
+    Command::new(env!("CARGO_BIN_EXE_kendex"))
         .args(args)
         .current_dir(cwd)
         .env_clear()
         .envs(test_util::fixture_env(home))
         .env("KENDEX_BACKGROUND_REFRESH", "off")
-        .env("PATH", path_with_fake_gh(home));
-    for (key, value) in ambient {
-        command.env(key, value);
-    }
-    command.output().expect("kendex binary runs")
+        .env("PATH", path_with_fake_gh(home))
+        .output()
+        .expect("kendex binary runs")
 }
 
 fn said(output: &Output) -> String {
@@ -162,19 +152,9 @@ exit 1
 "#;
 
 fn apply(home: &Path, project: &Path, flags: &[&str]) -> (Output, String) {
-    apply_under(home, project, flags, &[])
-}
-
-/// The same, run under `ambient` in the binary's own environment.
-fn apply_under(
-    home: &Path,
-    project: &Path,
-    flags: &[&str],
-    ambient: &[(&str, &str)],
-) -> (Output, String) {
     let mut args = vec!["apply", "--yes"];
     args.extend_from_slice(flags);
-    let output = kendex_under(home, project, &args, ambient);
+    let output = kendex(home, project, &args);
     let text = said(&output);
     (output, text)
 }
@@ -247,39 +227,6 @@ fn the_commit_flag_commits_the_set_with_the_commands_message() {
     assert!(
         git(&project, &["status", "--porcelain"]).contains(" M AGENTS.md"),
         "the person's own change was swept into the commit"
-    );
-}
-
-/// The shell kendex was launched from decides nothing about which files
-/// the commit selects. Every entry in the pathspec file is written behind
-/// a `:(literal)` prefix, and `GIT_LITERAL_PATHSPECS=1` in the ambient
-/// environment would have git read that whole entry as a filename: the
-/// staging step exits 128 `did not match any files` and the commit is
-/// refused. `Hardened` drops the variable before it reaches git, so the
-/// run is the ordinary one.
-///
-/// The must-fail control is the entry in `GIT_REDIRECTS`: take
-/// `GIT_LITERAL_PATHSPECS` out of that list and this case reddens. Driven
-/// through the binary because the variable has to sit in a real process's
-/// environment, and the workspace forbids the `unsafe` that setting one on
-/// this process would need.
-#[test]
-fn an_ambient_pathspec_variable_does_not_reach_the_commits_git() {
-    let tmp = tempfile::tempdir().unwrap();
-    let home = rooted(&tmp);
-    let project = project(&tmp);
-    let (output, text) = apply_under(
-        &home,
-        &project,
-        &["--commit"],
-        &[("GIT_LITERAL_PATHSPECS", "1")],
-    );
-    assert!(output.status.success(), "{text}");
-    assert!(text.contains("committed 2 files as "), "{text}");
-    let files = git(&project, &["show", "--name-only", "--format=", "HEAD"]);
-    assert!(
-        files.contains("CLAUDE.md") && files.contains(".kendex-generated.json"),
-        "{files}"
     );
 }
 

--- a/crates/core/src/commit_offer/changes.rs
+++ b/crates/core/src/commit_offer/changes.rs
@@ -25,7 +25,7 @@ use std::path::{Component, Path, PathBuf};
 
 use crate::package::diff::{PackageDiff, Tree, diff_trees};
 
-use super::{Failed, Refusal, Scan, Step, git, pathspec::Spec};
+use super::{Failed, Refusal, Scan, Step, git, pathspec};
 
 /// The file's mode on each side, in git's own spelling: `100644` an
 /// ordinary file, `100755` one that can be run, `120000` a symbolic link.
@@ -104,7 +104,10 @@ pub fn file_changes(scan: &Scan, path: &str) -> Result<Changes, Failed> {
 /// git lists no entry for — one this change adds, which `HEAD` has no side
 /// of — has no mode change to report.
 fn mode_change(root: &Path, path: &str) -> Result<Option<ModeChange>, Failed> {
-    let listed = git::read_required(root, &[Spec::LITERAL, "diff", "--raw", "HEAD", "--", path])?;
+    let listed = git::read_required(
+        root,
+        &["diff", "--raw", "HEAD", "--", &pathspec::literal(path)],
+    )?;
     let text = String::from_utf8_lossy(&listed);
     let Some(entry) = text.lines().next() else {
         return Ok(None);
@@ -144,18 +147,19 @@ fn mode_change(root: &Path, path: &str) -> Result<Option<ModeChange>, Failed> {
 /// would put git's own inventory of a folder on screen as though the
 /// commit were rewriting it.
 ///
-/// The path sits in a pathspec position, so it carries [`Spec::LITERAL`]
-/// the way every other pathspec this module hands git does. `ls-tree` was
-/// measured not to glob `[`, `*` or `?` against tree paths, so the option
-/// is not what makes this read exact today; it is what keeps it exact, and
-/// it is the whole of the answer for a path opening with the `:` a
-/// pathspec magic prefix starts with. The `HEAD:./<path>` read below is a
-/// revision spec rather than a pathspec and names its object exactly.
+/// The path sits in a pathspec position, so it goes through
+/// [`pathspec::literal`] the way every other pathspec this module hands
+/// git does. `ls-tree` was measured not to glob `[`, `*` or `?` against
+/// tree paths, so the prefix is not what makes this read exact today; it
+/// is what keeps it exact, and it is the whole of the answer for a path
+/// opening with the `:` a pathspec magic prefix starts with. The
+/// `HEAD:./<path>` read below is a revision spec rather than a pathspec
+/// and names its object exactly.
 fn committed(root: &Path, path: &str, born: bool) -> Result<Option<Vec<u8>>, Failed> {
     if !born {
         return Ok(None);
     }
-    let listed = git::read_required(root, &[Spec::LITERAL, "ls-tree", "HEAD", "--", path])?;
+    let listed = git::read_required(root, &["ls-tree", "HEAD", "--", &pathspec::literal(path)])?;
     let text = String::from_utf8_lossy(&listed);
     let Some(kind) = text.lines().next().and_then(entry_kind) else {
         return Ok(None);

--- a/crates/core/src/commit_offer/pathspec.rs
+++ b/crates/core/src/commit_offer/pathspec.rs
@@ -59,7 +59,8 @@ impl Spec {
         ]
     }
 
-    /// The magic prefix every entry in the file is written behind.
+    /// The magic prefix every pathspec this module hands git is written
+    /// behind, whether it goes in the file or in argv.
     ///
     /// `--pathspec-file-nul` fixes the separator, not the matching: git
     /// still reads each entry as a pathspec, so a rendered path holding
@@ -69,6 +70,16 @@ impl Spec {
     /// start of an entry, so a `:` inside a path is a character like any
     /// other rather than the opening of a second prefix.
     const LITERAL: &'static str = ":(literal)";
+}
+
+/// One path as a pathspec on a command line, for a read that names a
+/// single path in argv rather than through the file above.
+///
+/// The same prefix and the same guarantee as an entry in that file, so the
+/// crate has one spelling of "this text is a path" rather than a file-only
+/// one and an argv-only one that could drift apart.
+pub fn literal(path: &str) -> String {
+    format!("{}{path}", Spec::LITERAL)
 }
 
 impl Drop for Spec {

--- a/crates/core/src/commit_offer/pathspec.rs
+++ b/crates/core/src/commit_offer/pathspec.rs
@@ -9,6 +9,16 @@
 //!
 //! The file is outside the checkout, so it is never a path the offer could
 //! then find, and it is removed when the step ends.
+//!
+//! Each entry carries its own [`Spec::LITERAL`] magic prefix rather than
+//! the step passing git's `--literal-pathspecs`. The two select the same
+//! files, but the git-wide option is one git re-exports as
+//! `GIT_LITERAL_PATHSPECS=1` to everything it starts, and `git commit`
+//! starts the repository's hooks. A hook is other people's code reading
+//! their own repository: under that variable a hook's `git ls-files --
+//! ':(glob)docs/**/*.md'` matches nothing and its `git check-ignore`
+//! exits 128 on magic it never wrote. The prefix keeps the selection
+//! inside the file, where only the step that wrote it reads it.
 
 use std::io::Write;
 use std::path::PathBuf;
@@ -28,7 +38,8 @@ impl Spec {
             .tempfile()
             .map_err(|error| failure(step, &error))?;
         for path in paths {
-            file.write_all(path.as_bytes())
+            file.write_all(Spec::LITERAL.as_bytes())
+                .and_then(|()| file.write_all(path.as_bytes()))
                 .and_then(|()| file.write_all(&[0]))
                 .map_err(|error| failure(step, &error))?;
         }
@@ -48,16 +59,16 @@ impl Spec {
         ]
     }
 
-    /// The git-wide option every step passing this file carries, placed
-    /// before the subcommand, where git reads it.
+    /// The magic prefix every entry in the file is written behind.
     ///
     /// `--pathspec-file-nul` fixes the separator, not the matching: git
     /// still reads each entry as a pathspec, so a rendered path holding
     /// `[`, `*` or `?` would match a different file and put a path in the
-    /// commit that was never in the set. This takes every entry as the
-    /// path it is, including one beginning with the `:` a pathspec magic
-    /// prefix starts with.
-    pub const LITERAL: &'static str = "--literal-pathspecs";
+    /// commit that was never in the set. Behind this prefix git takes the
+    /// rest of the entry as the path it is, and it is read only at the
+    /// start of an entry, so a `:` inside a path is a character like any
+    /// other rather than the opening of a second prefix.
+    const LITERAL: &'static str = ":(literal)";
 }
 
 impl Drop for Spec {

--- a/crates/core/src/commit_offer/run.rs
+++ b/crates/core/src/commit_offer/run.rs
@@ -114,7 +114,7 @@ fn stage(root: &Path, untracked: &[String]) -> Result<(), Failed> {
         return Ok(());
     }
     let spec = Spec::write(untracked, Step::Stage)?;
-    let mut args = vec![Spec::LITERAL.to_owned(), "add".to_owned()];
+    let mut args = vec!["add".to_owned()];
     args.extend(spec.args());
     git::run(Hardened::git(&borrowed(&args), Some(root)), Step::Stage)?;
     Ok(())
@@ -122,11 +122,7 @@ fn stage(root: &Path, untracked: &[String]) -> Result<(), Failed> {
 
 fn make(root: &Path, all: &[String], message: &str) -> Result<(), Failed> {
     let spec = Spec::write(all, Step::Commit)?;
-    let mut args = vec![
-        Spec::LITERAL.to_owned(),
-        "commit".to_owned(),
-        "--only".to_owned(),
-    ];
+    let mut args = vec!["commit".to_owned(), "--only".to_owned()];
     args.extend(spec.args());
     args.push("-m".to_owned());
     args.push(message.to_owned());
@@ -143,11 +139,7 @@ fn unstage(root: &Path, untracked: &[String]) -> Result<(), Failed> {
         return Ok(());
     }
     let spec = Spec::write(untracked, Step::Unstage)?;
-    let mut args = vec![
-        Spec::LITERAL.to_owned(),
-        "reset".to_owned(),
-        "--quiet".to_owned(),
-    ];
+    let mut args = vec!["reset".to_owned(), "--quiet".to_owned()];
     args.extend(spec.args());
     git::run(Hardened::git(&borrowed(&args), Some(root)), Step::Unstage)?;
     Ok(())

--- a/crates/core/src/commit_offer/tests.rs
+++ b/crates/core/src/commit_offer/tests.rs
@@ -1247,8 +1247,9 @@ fn a_folder_replaced_by_a_file_of_the_same_name_shows_both_halves() {
 }
 
 /// Both reads that name a covered path hand it to git in a pathspec
-/// position, so both carry `--literal-pathspecs`. A path opening with the
-/// `:` a pathspec magic prefix starts with is read as magic without it and
+/// position, so both go through `pathspec::literal`. A path opening with
+/// the `:` a pathspec magic prefix starts with is read as magic without it
+/// and
 /// matches nothing at all: `ls-tree` then reports no before side and the
 /// file draws as one this change adds, when it is one the change rewrites.
 #[cfg(unix)]
@@ -1271,7 +1272,7 @@ fn a_path_git_would_read_as_pathspec_magic_is_taken_as_the_path_it_is() {
 }
 
 /// A rendered path can also hold `[`, `*` or `?`, and `git diff` globs a
-/// pathspec. Without the literal option the mode read gets a row per file
+/// pathspec. Without the literal prefix the mode read gets a row per file
 /// the path's shape names, and it reads the first — so a changed file of
 /// the person's own that sorts ahead of the one they opened hands over its
 /// mode as though it were theirs.

--- a/crates/core/src/commit_offer/tests.rs
+++ b/crates/core/src/commit_offer/tests.rs
@@ -216,20 +216,26 @@ impl Repo {
         scan(&self.scope(), generated).unwrap()
     }
 
+    /// A hook in this repository: `body` under `/bin/sh`, ending at `exit`.
+    #[cfg(unix)]
+    fn hook(&self, name: &str, body: &str, exit: u8) {
+        use std::os::unix::fs::PermissionsExt;
+        let hooks = self.root.join(".git/hooks");
+        fs::create_dir_all(&hooks).unwrap();
+        let path = hooks.join(name);
+        fs::write(&path, format!("#!/bin/sh\n{body}\nexit {exit}\n")).unwrap();
+        fs::set_permissions(&path, fs::Permissions::from_mode(0o755)).unwrap();
+    }
+
     /// A hook in this repository that prints `lines` on stderr and exits 1.
     #[cfg(unix)]
     fn refusing_hook(&self, name: &str, lines: &[&str], then: &str) {
-        use std::os::unix::fs::PermissionsExt;
         let body = lines
             .iter()
             .map(|line| format!("echo '{line}' >&2"))
             .collect::<Vec<_>>()
             .join("\n");
-        let hooks = self.root.join(".git/hooks");
-        fs::create_dir_all(&hooks).unwrap();
-        let path = hooks.join(name);
-        fs::write(&path, format!("#!/bin/sh\n{body}\n{then}\nexit 1\n")).unwrap();
-        fs::set_permissions(&path, fs::Permissions::from_mode(0o755)).unwrap();
+        self.hook(name, &format!("{body}\n{then}"), 1);
     }
 
     /// A bare repository this one calls `origin`, so a push has somewhere
@@ -559,8 +565,8 @@ fn the_commit_takes_the_set_and_leaves_the_persons_changes_alone() {
 }
 
 /// A rendered path holding pathspec metacharacters names itself and no
-/// other file. The must-fail control is the literal option: without it
-/// `a[b].md` is a glob that matches `ab.md`, the person's file.
+/// other file. The must-fail control is the entries' `:(literal)` prefix:
+/// without it `a[b].md` is a glob that matches `ab.md`, the person's file.
 #[test]
 fn a_path_with_metacharacters_commits_itself_and_nothing_it_would_match() {
     let repo = Repo::new(&[(OWNED[0], "one\n")]);
@@ -576,6 +582,61 @@ fn a_path_with_metacharacters_commits_itself_and_nothing_it_would_match() {
         BTreeSet::from(["docs/a[b].md".to_owned()])
     );
     assert!(repo.status().contains("?? docs/ab.md"), "{}", repo.status());
+}
+
+/// A hook reads the same git a plain `git commit` gives it. The selection
+/// travels inside the pathspec file, so no git-wide option becomes
+/// `GIT_LITERAL_PATHSPECS=1` in the environment git hands the hook — where
+/// the hook's own `:(glob)` pathspec would match nothing and its `git
+/// check-ignore` would exit 128 on magic the hook never wrote. Both are
+/// read from the hook child itself, the only place the leak is visible:
+/// the argv kendex builds shows nothing either way.
+///
+/// The must-fail control is the git-wide option: put `--literal-pathspecs`
+/// back on the commit and all three lines change.
+#[cfg(unix)]
+#[test]
+fn a_hook_reads_the_git_a_plain_commit_would_give_it() {
+    let repo = Repo::new(&[
+        (OWNED[0], "one\n"),
+        ("docs/one.md", "a\n"),
+        ("docs/deep/two.md", "b\n"),
+        (".gitignore", "ignored/\n"),
+    ]);
+    let generated = repo.generated(OWNED, &[]);
+    repo.write(OWNED[0], "two\n");
+    repo.write(OWNED[1], "@AGENTS.md\n");
+    // Outside the checkout: a file the hook wrote inside it would be one
+    // more change in the working tree the commit is being made from.
+    let record = repo.root.parent().unwrap().join("hook-record");
+    repo.hook(
+        "pre-commit",
+        &format!(
+            "{{ echo \"literal=${{GIT_LITERAL_PATHSPECS-unset}}\"\n\
+             echo \"glob=$(git ls-files -- ':(glob)docs/**/*.md' | wc -l | tr -d ' ')\"\n\
+             echo ignored/x.md | git check-ignore --stdin >/dev/null 2>&1\n\
+             echo \"check-ignore=$?\"; }} > '{}'",
+            record.display()
+        ),
+        0,
+    );
+
+    let Committed::Made { files, .. } = commit(&repo.root, &generated, "m").unwrap() else {
+        panic!("nothing was committed");
+    };
+    assert_eq!(files, 2);
+
+    // What the glob is expected to reach is the repository's own answer to
+    // the same pathspec, not a number written here: a fixture that grew a
+    // markdown file would otherwise pin a total nothing produces.
+    let matched = repo.git(&["ls-files", "--", ":(glob)docs/**/*.md"]);
+    let expected = matched.lines().count();
+    assert!(expected > 0, "the fixture matched nothing: {matched:?}");
+    let seen = fs::read_to_string(&record).unwrap();
+    assert_eq!(
+        seen,
+        format!("literal=unset\nglob={expected}\ncheck-ignore=0\n")
+    );
 }
 
 /// A hook's refusal reaches the person whole and in order, and the index

--- a/crates/core/src/commit_offer/tests.rs
+++ b/crates/core/src/commit_offer/tests.rs
@@ -565,23 +565,50 @@ fn the_commit_takes_the_set_and_leaves_the_persons_changes_alone() {
 }
 
 /// A rendered path holding pathspec metacharacters names itself and no
-/// other file. The must-fail control is the entries' `:(literal)` prefix:
-/// without it `a[b].md` is a glob that matches `ab.md`, the person's file.
+/// other file. Each row is an owned path and the person's file the row
+/// would reach if the path were read as a pattern; an item name carries
+/// any of these, since the render validator rejects only `/`, `\\` and
+/// `..` in one.
+///
+/// The colon in the second row sits inside a segment. An entry never
+/// begins with one, because every render lands under a directory or a
+/// fixed top-level name, so what the row covers is a colon git reads as
+/// ordinary text rather than one opening a prefix.
+///
+/// The must-fail control is the entries' `:(literal)` prefix: without it
+/// `a[b].md` is a glob that matches `ab.md` and `:(glob)x*.md` one that
+/// matches `:(glob)xy.md`, and the person's file lands in the commit.
 #[test]
 fn a_path_with_metacharacters_commits_itself_and_nothing_it_would_match() {
     let repo = Repo::new(&[(OWNED[0], "one\n")]);
-    let generated = repo.generated(&["docs/a[b].md"], &[]);
-    repo.write("docs/a[b].md", "ours\n");
-    repo.write("docs/ab.md", "theirs\n");
+    let mut rows = vec![("docs/a[b].md", "docs/ab.md")];
+    // A `:` cannot be in a Windows filename, so the shape that opens a
+    // segment with pathspec magic is exercised where it can exist. The
+    // row above is its portable twin.
+    if cfg!(unix) {
+        rows.push(("docs/:(glob)x*.md", "docs/:(glob)xy.md"));
+    }
+    let owned: Vec<&str> = rows.iter().map(|(ours, _)| *ours).collect();
+    let generated = repo.generated(&owned, &[]);
+    for (ours, theirs) in &rows {
+        repo.write(ours, "ours\n");
+        repo.write(theirs, "theirs\n");
+    }
     let Committed::Made { files, .. } = commit(&repo.root, &generated, "m").unwrap() else {
         panic!("nothing was committed");
     };
-    assert_eq!(files, 1);
+    assert_eq!(files, rows.len());
     assert_eq!(
         repo.head_files(),
-        BTreeSet::from(["docs/a[b].md".to_owned()])
+        owned
+            .iter()
+            .map(|p| (*p).to_owned())
+            .collect::<BTreeSet<_>>()
     );
-    assert!(repo.status().contains("?? docs/ab.md"), "{}", repo.status());
+    let status = repo.status();
+    for (_, theirs) in &rows {
+        assert!(status.contains(&format!("?? {theirs}")), "{status}");
+    }
 }
 
 /// A hook reads the same git a plain `git commit` gives it. The selection

--- a/crates/core/src/process/mod.rs
+++ b/crates/core/src/process/mod.rs
@@ -55,6 +55,17 @@ const GROUP_GRACE: Duration = Duration::from_millis(100);
 /// below; on a read it would have `status` judge a working tree against
 /// some other commit's rules. The second is the worse of the two and only
 /// scrubbing everywhere prevents it.
+///
+/// The four `*_PATHSPECS` variables redirect which files a pathspec picks
+/// out rather than which repository it is read against, which is the same
+/// thing done to the other half of a git call. They belong here because
+/// the caller names its paths on the command line and nothing ambient may
+/// re-decide what those paths mean: the commit offer selects a rendered
+/// path behind a `:(literal)` prefix, and `GIT_LITERAL_PATHSPECS=1` makes
+/// git read that whole entry as a filename and match nothing, while
+/// `GIT_ICASE_PATHSPECS=1` case-folds the comparison the prefix asked to
+/// be exact. Scrubbed on every git call rather than at that one, because
+/// a redirect is answered where the process is built.
 const GIT_REDIRECTS: &[&str] = &[
     "GIT_DIR",
     "GIT_WORK_TREE",
@@ -64,6 +75,10 @@ const GIT_REDIRECTS: &[&str] = &[
     "GIT_COMMON_DIR",
     "GIT_NAMESPACE",
     "GIT_ATTR_SOURCE",
+    "GIT_LITERAL_PATHSPECS",
+    "GIT_ICASE_PATHSPECS",
+    "GIT_GLOB_PATHSPECS",
+    "GIT_NOGLOB_PATHSPECS",
 ];
 
 /// Configuration every git call settles on its own command line, where no

--- a/crates/core/src/process/tests.rs
+++ b/crates/core/src/process/tests.rs
@@ -27,6 +27,10 @@ fn git_runs_without_redirecting_environment_and_without_prompts() {
         "GIT_COMMON_DIR",
         "GIT_NAMESPACE",
         "GIT_ATTR_SOURCE",
+        "GIT_LITERAL_PATHSPECS",
+        "GIT_ICASE_PATHSPECS",
+        "GIT_GLOB_PATHSPECS",
+        "GIT_NOGLOB_PATHSPECS",
     ] {
         assert_eq!(
             env.get(OsStr::new(variable)),

--- a/docs/design/post-refresh-commit-flow.md
+++ b/docs/design/post-refresh-commit-flow.md
@@ -156,9 +156,9 @@ The set runs to a thousand paths in a large project, about 58 KB of path text in
 
 kendex writes the set to a file in the system temp directory, NUL-separated, and passes `--pathspec-from-file=<file> --pathspec-file-nul` to `git add`, `git commit` and `git reset`. All three take it. The file is removed when the step ends. It is outside the checkout, so it is never a path the offer could then find.
 
-`--pathspec-file-nul` fixes the separator, not the matching: git still reads each entry as a pathspec, so a rendered path holding `[`, `*` or `?` would match a different file and put a path in the commit that was never in the set. Every one of those three calls therefore runs as `git --literal-pathspecs <subcommand> …`, the git-wide option placed before the subcommand, which takes every entry as the path it is. One option rather than a `:(literal)` prefix per entry, because a path that itself begins with `:` cannot defeat it.
+`--pathspec-file-nul` fixes the separator, not the matching: git still reads each entry as a pathspec, so a rendered path holding `[`, `*` or `?` would match a different file and put a path in the commit that was never in the set. Every entry is therefore written behind a `:(literal)` prefix, which takes the rest of the entry as the path it is.
 
-`git status` takes no such option, which is why the status call is unscoped and filtered in kendex instead.
+The prefix rather than git's `--literal-pathspecs`, which selects the same files: the git-wide option is one git re-exports as `GIT_LITERAL_PATHSPECS=1` to every process it starts, and `git commit` starts the repository's hooks. A hook is other people's code reading their own repository, and under that variable it reads a different git — a hook's own `git ls-files -- ':(glob)docs/**/*.md'` matches nothing, and its `git check-ignore` exits 128 on pathspec magic the hook never wrote. The prefix keeps the selection inside the file, where only the step that wrote it reads it.
 
 ### What a refusal leaves behind
 

--- a/docs/design/post-refresh-commit-flow.md
+++ b/docs/design/post-refresh-commit-flow.md
@@ -160,6 +160,8 @@ kendex writes the set to a file in the system temp directory, NUL-separated, and
 
 The prefix rather than git's `--literal-pathspecs`, which selects the same files: the git-wide option is one git re-exports as `GIT_LITERAL_PATHSPECS=1` to every process it starts, and `git commit` starts the repository's hooks. A hook is other people's code reading their own repository, and under that variable it reads a different git — a hook's own `git ls-files -- ':(glob)docs/**/*.md'` matches nothing, and its `git check-ignore` exits 128 on pathspec magic the hook never wrote. The prefix keeps the selection inside the file, where only the step that wrote it reads it.
 
+The four `GIT_*_PATHSPECS` variables are in `Hardened`'s `GIT_REDIRECTS`, so the shell kendex was launched from cannot re-decide what the entries mean. An inherited `GIT_LITERAL_PATHSPECS=1` would have git read a whole entry as a filename spelled `:(literal)<path>` and match nothing; an inherited `GIT_ICASE_PATHSPECS=1` would case-fold the comparison the prefix asked to be exact.
+
 ### What a refusal leaves behind
 
 The one mark the sequence leaves is the `git add` above: a path that was untracked stays staged. kendex unstages exactly the paths it staged, so the index ends as it began.


### PR DESCRIPTION
## What

The commit route passed `--literal-pathspecs` as a git-wide option before the subcommand. Git turns that into `GIT_LITERAL_PATHSPECS=1` in its own environment, and `git commit` starts the repository's own hooks, so a consumer's gates read a different git than a plain commit gives them.

Reached by `kendex refresh --yes --pull-request` in drovr on 2026-09-09: a documentation gate saw 0 markdown files where its glob finds 33, and another gate's `git check-ignore --stdin` exited 128 on `pathspec magic not supported by this command: 'literal'`. The same staged content under an ordinary `git commit` passed those 101 tests. Kendex refused the commit and unwound the checkout. The desktop commit offer uses the same core route.

The literal guarantee itself is wanted — a rendered path holding `[`, `*`, `?` or a leading `:` would otherwise match a different file and commit a path that was never selected. The defect was the transport, not the guarantee.

## How

The selection moves out of the process environment and into the pathspec text itself: one `:(literal)` prefix per entry, written by `Spec::write` into the NUL-separated file the three steps already pass. `stage`, `make` and `unstage` no longer place a git-wide option before their subcommand, so they sit on one transport by construction and set nothing a hook child can inherit.

`pathspec::literal(path)` puts the same prefix on an argv pathspec. The two reads KEN-1284 added in `commit_offer/changes.rs` (`mode_change`, `committed`) move onto it, so the crate keeps one spelling of "this text is a path" rather than two free to drift. `Spec::LITERAL` is now private to `pathspec.rs`.

The four `GIT_*_PATHSPECS` variables join `GIT_REDIRECTS`. Removing the git-wide option also removed git's refusal of a competing global pathspec setting inherited from the environment: with `GIT_LITERAL_PATHSPECS=1` exported, the staging step read every entry as a filename spelled `:(literal)<path>` and exited 128, refusing a commit that used to work. That refusal was introduced by this branch's own first commit. The other three names join on the same principle, that nothing ambient may re-decide what a named path means.

Verified against git 2.55.0 that `--pathspec-from-file` with `--pathspec-file-nul` parses per-entry magic on `commit --only`, `add` and `reset`, and that the two spellings are mutually exclusive: under `--literal-pathspecs`, git reads `:(literal)foo` as a filename and refuses, so a leftover call site would break loudly rather than silently.

## Done-when

| Requirement | Where it is served |
| --- | --- |
| Hooks run by a kendex commit see the same git matching behavior as a normal commit | `commit_offer/run.rs`, `commit_offer/pathspec.rs`; control `a_hook_reads_the_git_a_plain_commit_would_give_it` |
| Glob pathspecs find their files; `check-ignore` returns its normal result | same control, which reads `literal`, a glob count and a `check-ignore` exit from the hook child itself, not from kendex's argv |
| Literal filenames stay confined to the selected commit set, with the required must-fail control | `commit_offer/tests.rs` metacharacter fixture, two rows, each an owned path beside the decoy it would reach as a pattern |
| No general Git wrapper or compatibility shim | one prefix, written in one place, plus one helper for argv pathspecs |

Must-fail controls, each proven by planting the defect, running, and restoring:

- Leak returns (`--literal-pathspecs` put back on the commit): the hook control fails with `literal=1 / glob=0 / check-ignore=128` against `literal=unset / glob=2 / check-ignore=0` — the two drovr shapes exactly.
- Guarantee dropped (prefix removed from `Spec::write`): the metacharacter fixture fails with `{"docs/a[b].md", "docs/ab.md"}` against `{"docs/a[b].md"}` — the person's own file in the commit.
- Scrub removed (`GIT_LITERAL_PATHSPECS` taken out of `GIT_REDIRECTS`): the enumerated control in `process/tests.rs` reddens naming the variable.
- Helper drops the prefix: KEN-1284's own two controls redden, `a_path_git_would_read_as_pathspec_magic_is_taken_as_the_path_it_is` and `a_glob_shaped_path_reads_its_own_mode_and_not_a_neighbours`.

## Notes for review

- Two of KEN-1284's test doc comments named `--literal-pathspecs` and "the literal option", which this change makes false. Text only, no assertion touched; their behaviour was verified unchanged by mutation rather than by reading.
- An earlier revision of this branch carried a one-word citation repoint in `docs/architecture/harnesses.md`. KEN-1317 (#2506) has since fixed that citation and the stale sentence around it on main, so this branch takes main's file whole and carries no diff to it.
- An ambient `GIT_ICASE_PATHSPECS=1` was investigated as a possible widening path and does **not** widen the selection here: a case fold only reaches a different file when the entry names one that does not exist, and every entry kendex writes names a file the scan just saw. Probed across five shapes on git 2.55.0. The scrub is justified by the `GIT_LITERAL_PATHSPECS` refusal above, not by a fail-open.
- Declined: an empty pathspec entry would become a bare `:(literal)` and select the whole tree. No shipped producer emits one — `paths::rows` guarantees every produced path is at least one byte, and `paths::scan` returns `None` on an empty owned set, so `make` never sees one.

## Size

No `**Expected delta**` line on the issue, so the counts are reported rather than judged: production 66, tests 110, render mirror 0.

## Validation

`env -u TMPDIR tools/guard --full` on `b01ac0bc6`: exit 0, zero `guard: ` lines. Preflight 0 findings across 9 changed files. `kendex-core` lib 915 passed; `commit_offer` suite green.

Closes KEN-1309

https://claude.ai/code/session_01Sxw3zefP114zeyppWcPJzt
