### PR TITLE
test(KEN-1325): plant the package_setup write set off its declaration

### DIFF
--- a/crates/app/tests/package_setup.rs
+++ b/crates/app/tests/package_setup.rs
@@ -111,18 +111,23 @@ fn the_setup_block_is_the_install_s_own_disclosure() {
 /// and no file the repository happens to hold may license one.
 ///
 /// The whole trust rule, planted rather than argued. Every path the
-/// package declares is on disk — its helper and all three hook files,
-/// exactly as a repository armed by another tool or by a hostile clone's
-/// own installer would carry them — and its `--check` is executable.
-/// kendex never armed this effect here, so nothing runs.
+/// package declares is on disk, exactly as a repository armed by another
+/// tool or by a hostile clone's own installer would carry them, and its
+/// `--check` is executable. kendex never armed this effect here, so
+/// nothing runs.
 ///
 /// The declared paths are planted because a licence read off one of them
-/// would pass here. Only a record kendex wrote itself is one.
+/// would pass here. Only a record kendex wrote itself is one. The set is
+/// read off the declaration the install loaded, so a path added to it is
+/// planted too, and the plant is checked against that declaration.
 #[test]
 #[allow(clippy::unwrap_used)]
 fn no_file_the_repository_holds_licenses_the_checkout_s_scripts() {
     let f = fixture();
-    install_skills(&f, &["commit-guards"], None);
+    let installed = install_skills(&f, &["commit-guards"], None);
+    let [offer] = installed.repo_effects.shown.as_slice() else {
+        panic!("one offer: {:?}", installed.repo_effects);
+    };
     // The package's own checker, replaced with one that records having
     // run. A clone's scripts are whatever its author wrote.
     let checker = f
@@ -135,16 +140,26 @@ fn no_file_the_repository_holds_licenses_the_checkout_s_scripts() {
     )
     .unwrap();
     fs::set_permissions(&checker, fs::Permissions::from_mode(0o755)).unwrap();
-    // Every path the declaration lists, present and looking armed.
-    for written in [
-        HELPER,
-        ".git/hooks/pre-commit",
-        ".git/hooks/commit-msg",
-        ".git/hooks/pre-push",
-    ] {
+    // Every path the declaration lists, present and looking armed. The
+    // declaration's own repo-relative paths, under the project, rather
+    // than the disclosure's absolute lines: the claim is about what the
+    // package declares, and it must still name the helper, or the plant
+    // is empty and this proves nothing.
+    let declared = &offer.declared.effects.writes;
+    assert!(
+        declared.iter().any(|written| written == HELPER),
+        "the declaration no longer names the helper: {declared:?}"
+    );
+    for written in declared {
         let path = f.project.join(written);
         fs::create_dir_all(path.parent().unwrap()).unwrap();
         fs::write(&path, "#!/bin/sh\n").unwrap();
+    }
+    for written in declared {
+        assert!(
+            f.project.join(written).is_file(),
+            "declared path not planted: {written}"
+        );
     }
 
     assert_eq!(


### PR DESCRIPTION
## Summary

- `no_file_the_repository_holds_licenses_the_checkout_s_scripts` in `crates/app/tests/package_setup.rs` planted commit-guards' declared write set from an array written in the test — a second copy of the package's `repo-effects.writes`. A path added to the declaration was not planted, and the suite stayed green while the case no longer covered what it claims.
- The plant now iterates the writes of the declaration the install already loaded (the offer's `DeclaredEffects`, whose repo-relative paths join under the project), so a declaration change cannot desynchronize the fixture. The disclosure's absolute `Written` lines were not used: they are kendex's rendering of the same declaration, and the claim is about what the package declares.
- `HELPER` stays at this site as a required member of the declaration. Without it an empty declaration would plant nothing and pass. A check over the declared set follows the plant, which is what makes the must-fail control redden.

## Completed Issues

- Closes KEN-1325 - package_setup fixture keeps a second copy of the commit-guards declaration and cannot notice a new declared path

## Size

The issue states no allowance. Measured: production 0, tests 28, render mirror 0.

## Test Plan

- `cargo test -p kendex-app --test package_setup` — 7 passed.
- Must-fail control (the one the issue's Done-when names): drop one declared path from the plant. With `HELPER` filtered out of the plant loop the case fails at `declared path not planted: .git/hooks/kendex-guards`; restored, 7 passed again.
- `cargo clippy -p kendex-app --tests -- -D warnings`, `cargo fmt --check`, preflight and doc-limits clean.
- `env -u TMPDIR tools/guard --full` on this head: exit 0, no `guard:` failure lines.

## Review notes

One local round: `reviewer-correctness` and `reviewer-security`, both `pass`, zero blockers. `reviewer-security` was on the panel because this test is the trust case itself (opening a package's page must not run a script the checkout supplies); it found nothing the change weakens.

`reviewer-correctness` raised one non-blocking suggestion: the post-plant `is_file()` check re-asserts the postcondition of the loop directly above it, so no production path can make it fire. Declined. Its measurement is the reason: with that check deleted, the must-fail control the issue's Done-when names (drop one declared path from the plant) *passes* instead of reddening, so removing it would leave the stated acceptance criterion unmet. The derivation alone carries the desynchronization protection; the check is what proves it red.

## Restack onto KEN-1321 (#2520)

#2520 merged while this PR was queued and edited the same fixture, adding `.git/hooks/pre-push` to commit-guards' `repo-effects.writes` **and** hand-patching the literal array in this test to a fourth entry — the exact desync this issue exists to remove. Restacked onto `64b0ec319` through the supported guarded restack; both conflicts compose to the derivation, which subsumes main's new entry:

- The plant loop: main's four-element literal is replaced by the declaration-derived loop, so `pre-push` is planted because the declaration names it, not because someone remembered to add it.
- The doc comment: main's "its helper and all three hook files" enumeration is dropped rather than re-updated. That enumeration is the same second copy, one level up in the prose.

Re-verified on the composed head `103c36f4f`: `cargo test -p kendex-app --test package_setup` 7 passed (the plant now covers all four declared paths), and `env -u TMPDIR tools/guard --full` exit 0 with no `guard:` failure lines.

https://claude.ai/code/session_01MBFKRQuRDPFTQTBhJatmHd
