### PR TITLE
probe(KEN-1329): stacked-PR reviewer request test (do not merge)

### DIFF
--- a/probe/ken-1329-probe.sh
+++ b/probe/ken-1329-probe.sh
@@ -10,4 +10,11 @@ probe_sum() {
   printf "%s\n" "$total"
 }
 
-probe_sum "$@"
+probe_mean() {
+  local count=$#
+  local sum
+  sum=$(probe_sum "$@")
+  printf "%s\n" $((sum / count))
+}
+
+probe_mean $@


### PR DESCRIPTION
Throwaway probe for KEN-1329. Base is `ken-1329-probe-base`, **not** the default branch, so the
`copilot_code_review` ruleset (16519713, target `~DEFAULT_BRANCH`) does not arm an automatic review here.

The probe answers one question: does `gh pr edit N --add-reviewer @copilot` draw a Copilot review on a
pull request whose base the ruleset does not target?

This pull request will be closed and both branches deleted as soon as the question is answered.
It is never merged.
