### PR TITLE
fix(KEN-1329): review-gate: a stacked PR draws no automatic review, and approval-wait reports the impossible wait as a timeout

### DIFF
--- a/.agents/skills/orch/references/gates.md
+++ b/.agents/skills/orch/references/gates.md
@@ -41,7 +41,7 @@ Work the chain in this order:
 
    Then re-run the wait. It works on a base the ruleset does not target.
 
-2. Merge the bottom of the stack. GitHub retargets the next PR onto the new base, and a base inside the target set draws a review on its own.
+2. Merge the bottom of the stack. GitHub retargets the next PR onto the new base, but a retarget is not a documented review trigger: request the review by hand as in step 1, or push a new head where the rule's `review_on_push` is on, then re-run the wait.
 3. Fallback, only when the manual request draws nothing: close the PR and open a fresh one against the default branch. Close-and-open, never reopen — reopening re-arms the reviewer only on a PR it has already reviewed once, and does nothing for one it never reviewed.
 
 ## Waiter auth ladder

--- a/.agents/skills/orch/references/gates.md
+++ b/.agents/skills/orch/references/gates.md
@@ -18,7 +18,7 @@ The reviewer-gate settings — `PR_REVIEW_GATE`, `PR_REVIEW_CHECK`, `PR_REVIEW_O
 
 | Waiting on | Tool |
 |------------|------|
-| Reviewer verdict on one PR | `approval-wait` — statuses `approved`/`reviewed`/`changes_requested`/`comments`/`timeout`/`proceeded`/`error` |
+| Reviewer verdict on one PR | `approval-wait` — statuses `approved`/`reviewed`/`changes_requested`/`comments`/`timeout`/`proceeded`/`unreviewable`/`error` |
 | CI on one PR | `ci-wait` — verdicts `pass`/`fail`/`pending`/`none` |
 | Merge-queue / auto-merge outcome | `queue-wait` — the growing verdict set documented in its § Verdicts table |
 | Many PRs, long horizon | `pr-watch.sh` — § Multi-PR watching |
@@ -26,6 +26,23 @@ The reviewer-gate settings — `PR_REVIEW_GATE`, `PR_REVIEW_CHECK`, `PR_REVIEW_O
 Per-verdict routing lives in the workflows (`submit-pr.md` § 4, `merge-pr.md` § 5); each verdict's semantics live in that script's `--help`.
 
 A wait is a running waiter, never a session sitting at its prompt.
+
+## Stacked pull requests
+
+`approval-wait` returns `unreviewable` (exit 1) when the deadline passes with no reviewer evidence and the PR's base sits outside the automatic-review ruleset's target set. Nothing was going to arrive on its own. Which bases draw an automatic review is per-repo configuration, read from the repo's rulesets: the review-gate skill's `.agents/skills/review-gate/references/automatic-review.md`.
+
+Work the chain in this order:
+
+1. Request the review by hand on the stacked PR. This is the remedy, not a workaround:
+
+   ```bash
+   gh pr edit [PR_NUMBER] --add-reviewer @copilot
+   ```
+
+   Then re-run the wait. It works on a base the ruleset does not target.
+
+2. Merge the bottom of the stack. GitHub retargets the next PR onto the new base, and a base inside the target set draws a review on its own.
+3. Fallback, only when the manual request draws nothing: close the PR and open a fresh one against the default branch. Close-and-open, never reopen — reopening re-arms the reviewer only on a PR it has already reviewed once, and does nothing for one it never reviewed.
 
 ## Waiter auth ladder
 

--- a/.agents/skills/orch/references/gates.md
+++ b/.agents/skills/orch/references/gates.md
@@ -29,7 +29,7 @@ A wait is a running waiter, never a session sitting at its prompt.
 
 ## Stacked pull requests
 
-`approval-wait` returns `unreviewable` (exit 1) when the deadline passes with no reviewer evidence and the PR's base sits outside the automatic-review ruleset's target set. Nothing was going to arrive on its own. Which bases draw an automatic review is per-repo configuration, read from the repo's rulesets: the review-gate skill's `.agents/skills/review-gate/references/automatic-review.md`.
+`approval-wait` returns `unreviewable` (exit 1) when the deadline passes with no reviewer evidence and the PR's base sits outside the target set of the repo's automatic-review rulesets. Nothing was going to arrive on its own. Which bases draw an automatic review is per-repo configuration, read from the repo's rulesets: the review-gate skill's `.agents/skills/review-gate/references/automatic-review.md`.
 
 Work the chain in this order:
 

--- a/.agents/skills/orch/scripts/approval-wait
+++ b/.agents/skills/orch/scripts/approval-wait
@@ -222,15 +222,22 @@ and the head is re-confirmed once more at the deadline itself, so proceed
 never bypasses a live gate and never attests a stale head.
 
 Automatic review and the base branch: GitHub's automatic reviewer is armed
-by an ACTIVE BRANCH RULESET carrying a rule of type copilot_code_review, and
-that ruleset's conditions.ref_name is the set of bases that draw one. It is
-per-repo configuration, never a GitHub constant. The set is resolved ONCE
-before the poll loop, from the repo's rulesets (source "ruleset"); when that
-read fails or no ruleset carries the rule, the repo's default branch is the
-whole set (source "default_branch"); when neither can be read the set is
-"unresolved". The PR's baseRefName is matched against it — "~ALL" matches
-any base, "~DEFAULT_BRANCH" the repo default, any other pattern is an
-fnmatch over refs/heads/<base>, and an exclude pattern beats an include.
+by any ACTIVE BRANCH RULESET carrying a rule of type copilot_code_review. A
+base draws one when such a ruleset's conditions.ref_name includes it and that
+same ruleset does not exclude it, so the target set is the union over those
+rulesets. It is per-repo configuration, never a GitHub constant. The set is
+resolved ONCE before the poll loop, from every page of the repo's ruleset
+listing and each active branch ruleset's detail (source "ruleset"). The
+repo's default branch is the whole set (source "default_branch") only when
+the listing is refused with HTTP 403 or 404 that is not a rate limit, or
+reads completely with no ruleset carrying the rule. Any other failed listing
+or detail read leaves the set "unresolved". The PR's baseRefName is matched
+against it: "~ALL" matches any base, "~DEFAULT_BRANCH" the repo default, and
+any other pattern must equal refs/heads/<base> exactly. GitHub matches a
+pattern with File.fnmatch under File::FNM_PATHNAME, where * does not match /;
+approval-wait does not reproduce that, so a pattern holding *, ?, [ or \
+leaves the set "unresolved", as does ~DEFAULT_BRANCH when the default branch
+cannot be read.
 
 A base outside that set draws no automatic review, so reviewer silence there
 is structural rather than a slow reviewer: the deadline reports
@@ -266,7 +273,7 @@ JSON output (always when --json):
     "base_ref": <string>,         # the PR's base branch
     "auto_review_targeted": <bool>,  # the base draws an automatic review
     "auto_review_target_source": "ruleset" | "default_branch" | "unresolved",
-    "auto_review_targets": [<string>],  # the ref_name include patterns
+    "auto_review_targets": [<string>],  # union of the ref_name include patterns
     "transient_api_errors": <int>,  # only when > 0
     "error": <string>             # only when status == "error"
   }
@@ -721,80 +728,132 @@ OWNER="${REPO%%/*}"
 REPO_NAME="${REPO#*/}"
 
 # --- automatic-review target set (resolved ONCE, before the poll loop) ---
-# GitHub's automatic reviewer is armed by an ACTIVE BRANCH RULESET carrying a
-# rule of type copilot_code_review; that ruleset's conditions.ref_name is the
-# set of bases that draw one. Which bases those are is per-repo configuration,
-# not a GitHub constant, so it is read rather than assumed. A PR based outside
-# the set draws no automatic review at all, which is why the deadline separates
-# that structural silence ("unreviewable") from a reviewer who merely did not
-# show ("timeout"/"proceeded").
+# GitHub's automatic reviewer is armed by any ACTIVE BRANCH RULESET carrying a
+# rule of type copilot_code_review, and the set of bases that draw one is the
+# union of those rulesets' conditions.ref_name. Which bases those are is
+# per-repo configuration, not a GitHub constant, so it is read rather than
+# assumed. A PR based outside the set draws no automatic review at all, which is
+# why the deadline separates that structural silence ("unreviewable") from a
+# reviewer who merely did not show ("timeout"/"proceeded").
+# AUTO_REVIEW_INCLUDE and AUTO_REVIEW_EXCLUDE hold one
+# "<ruleset-id><TAB><pattern>" record per line, so an exclude stays bound to the
+# ruleset that declares it.
+
+# Read every active branch ruleset carrying copilot_code_review into
+# AUTO_REVIEW_INCLUDE / AUTO_REVIEW_EXCLUDE. Returns 0 when at least one does;
+# 2 when no ruleset rule is visible, because the listing was refused as a
+# permission denial (HTTP 403 or 404 that is not a rate limit) or read
+# completely with no ruleset carrying the rule; 1 on every other failure, which
+# leaves the set unjudgeable. It classifies through gh_failure_is_transient, so
+# it runs only after that function is defined.
+read_auto_review_rules() {
+  local rulesets ruleset_ids ruleset_id detail carries includes excludes
+  local list_status=0 err_text found=false
+  AUTO_REVIEW_INCLUDE=""
+  AUTO_REVIEW_EXCLUDE=""
+  : > "$GH_ERR_FILE"
+  rulesets=$(gh api "repos/$REPO/rulesets" --paginate 2>"$GH_ERR_FILE") || list_status=$?
+  if [ "$list_status" -ne 0 ]; then
+    err_text=$(cat "$GH_ERR_FILE" 2>/dev/null) || err_text=""
+    case "$err_text" in
+      *"HTTP 403"*|*"HTTP 404"*) gh_failure_is_transient "$list_status" || return 2 ;;
+    esac
+    return 1
+  fi
+  # The listing carries no rules or conditions, so every active branch ruleset
+  # is opened. A zero-byte or non-list answer is a failed read, never an empty
+  # listing.
+  ruleset_ids=$(jq -r -s 'if length > 0 and all(.[]; type == "array")
+    then add | .[] | select(.target == "branch" and .enforcement == "active") | .id
+    else error("the ruleset listing is not a set of pages") end' <<<"$rulesets" 2>/dev/null) || return 1
+  while IFS= read -r ruleset_id; do
+    [ -n "$ruleset_id" ] || continue
+    detail=$(gh api "repos/$REPO/rulesets/$ruleset_id" 2>/dev/null) || return 1
+    carries=$(jq -r 'any(.rules[]?; .type == "copilot_code_review")' <<<"$detail" 2>/dev/null) || return 1
+    [ "$carries" = true ] || continue
+    includes=$(jq -r --arg id "$ruleset_id" '.conditions.ref_name.include[]? | "\($id)\t\(.)"' <<<"$detail") || return 1
+    excludes=$(jq -r --arg id "$ruleset_id" '.conditions.ref_name.exclude[]? | "\($id)\t\(.)"' <<<"$detail") || return 1
+    AUTO_REVIEW_INCLUDE="$AUTO_REVIEW_INCLUDE$includes"$'\n'
+    AUTO_REVIEW_EXCLUDE="$AUTO_REVIEW_EXCLUDE$excludes"$'\n'
+    found=true
+  done <<<"$ruleset_ids"
+  [ "$found" = true ] || return 2
+}
+
 resolve_auto_review_targets() {
-  local rulesets ruleset_ids ruleset_id detail
+  local rules_status=0 pattern
   DEFAULT_BRANCH=$(gh api "repos/$REPO" -q '.default_branch' 2>/dev/null) || DEFAULT_BRANCH=""
-  rulesets=$(gh api "repos/$REPO/rulesets" 2>/dev/null) || rulesets=""
-  if [ -n "$rulesets" ] && jq -e 'type == "array"' >/dev/null 2>&1 <<<"$rulesets"; then
-    # The listing carries no rules or conditions, so each active branch ruleset
-    # is opened until one carries the copilot_code_review rule.
-    ruleset_ids=$(jq -r '.[] | select(.target == "branch" and .enforcement == "active") | .id' <<<"$rulesets") || ruleset_ids=""
-    while IFS= read -r ruleset_id; do
-      [ -n "$ruleset_id" ] || continue
-      detail=$(gh api "repos/$REPO/rulesets/$ruleset_id" 2>/dev/null) || continue
-      jq -e 'any(.rules[]?; .type == "copilot_code_review")' >/dev/null 2>&1 <<<"$detail" || continue
-      AUTO_REVIEW_INCLUDE=$(jq -r '.conditions.ref_name.include[]? // empty' <<<"$detail") || AUTO_REVIEW_INCLUDE=""
-      AUTO_REVIEW_EXCLUDE=$(jq -r '.conditions.ref_name.exclude[]? // empty' <<<"$detail") || AUTO_REVIEW_EXCLUDE=""
-      AUTO_REVIEW_SOURCE="ruleset"
-      break
-    done <<<"$ruleset_ids"
-  fi
-  if [ "$AUTO_REVIEW_SOURCE" = "unresolved" ] && [ -n "$DEFAULT_BRANCH" ]; then
-    # No readable ruleset rule: the default branch is the whole target set,
-    # which is what the shipped "Copilot review for default branch" shape means.
-    AUTO_REVIEW_INCLUDE="~DEFAULT_BRANCH"
-    AUTO_REVIEW_EXCLUDE=""
-    AUTO_REVIEW_SOURCE="default_branch"
-  fi
-  # ~DEFAULT_BRANCH names a branch this run could not read, so the set cannot be
-  # judged. Unresolved is reported as unresolved rather than matched as a miss:
-  # a failed read must not manufacture an "unreviewable" verdict.
-  if [ -z "$DEFAULT_BRANCH" ] && [[ "$AUTO_REVIEW_INCLUDE$AUTO_REVIEW_EXCLUDE" == *'~DEFAULT_BRANCH'* ]]; then
-    AUTO_REVIEW_SOURCE="unresolved"
+  read_auto_review_rules || rules_status=$?
+  case "$rules_status" in
+    0) AUTO_REVIEW_SOURCE="ruleset" ;;
+    2)
+      # No ruleset rule is visible: the default branch is the whole target set,
+      # which is what the shipped "Copilot review for default branch" shape means.
+      AUTO_REVIEW_INCLUDE=$(printf 'default_branch\t~DEFAULT_BRANCH')
+      AUTO_REVIEW_EXCLUDE=""
+      AUTO_REVIEW_SOURCE="default_branch"
+      ;;
+    *)
+      # 1, or any status the reader does not define: a failed read decides nothing.
+      AUTO_REVIEW_SOURCE="unresolved"
+      ;;
+  esac
+  # A set this run cannot judge exactly is reported unresolved rather than
+  # matched as a hit or a miss. ~DEFAULT_BRANCH names a branch this run could not
+  # read. GitHub matches every other pattern with File.fnmatch under
+  # File::FNM_PATHNAME, where * does not cross / and a shell pattern's * does, so
+  # only a literal ref is compared and a pattern carrying glob syntax is not.
+  while IFS=$'\t' read -r _ pattern; do
+    case "$pattern" in
+      '~DEFAULT_BRANCH') [ -n "$DEFAULT_BRANCH" ] || AUTO_REVIEW_SOURCE="unresolved" ;;
+      *'*'*|*'?'*|*'['*|*'\'*) AUTO_REVIEW_SOURCE="unresolved" ;;
+    esac
+  done <<<"$AUTO_REVIEW_INCLUDE"$'\n'"$AUTO_REVIEW_EXCLUDE"
+  if [ "$AUTO_REVIEW_SOURCE" = "unresolved" ]; then
     AUTO_REVIEW_INCLUDE=""
     AUTO_REVIEW_EXCLUDE=""
   fi
-  AUTO_REVIEW_TARGETS_JSON=$(printf '%s' "$AUTO_REVIEW_INCLUDE" \
-    | jq -R -s 'split("\n") | map(select(length > 0))') || AUTO_REVIEW_TARGETS_JSON="[]"
-  AUTO_REVIEW_TARGETS_TEXT=$(printf '%s' "$AUTO_REVIEW_INCLUDE" | tr '\n' ' ') || AUTO_REVIEW_TARGETS_TEXT=""
-  AUTO_REVIEW_TARGETS_TEXT="${AUTO_REVIEW_TARGETS_TEXT% }"
+  AUTO_REVIEW_TARGETS_JSON=$(jq -R -s 'split("\n") | map(select(length > 0) | sub("^[^\t]*\t"; ""))
+    | reduce .[] as $pattern ([]; if any(.[]; . == $pattern) then . else . + [$pattern] end)' \
+    <<<"$AUTO_REVIEW_INCLUDE") || AUTO_REVIEW_TARGETS_JSON="[]"
+  AUTO_REVIEW_TARGETS_TEXT=$(jq -r 'join(" ")' <<<"$AUTO_REVIEW_TARGETS_JSON") || AUTO_REVIEW_TARGETS_TEXT=""
 }
 
 # Does one ref_name pattern cover this base? "~ALL" covers every base,
-# "~DEFAULT_BRANCH" the repo default, and any other pattern is an fnmatch over
-# the base's full ref, which is how a ruleset ref condition is spelled.
+# "~DEFAULT_BRANCH" the repo default, and any other pattern is a literal ref
+# compared with the base's full ref: resolution leaves a set holding a glob
+# unresolved, so no glob reaches this point.
 auto_review_pattern_matches() { # PATTERN BASE
   case "$1" in
     '~ALL') return 0 ;;
     '~DEFAULT_BRANCH') [ -n "$DEFAULT_BRANCH" ] && [ "$2" = "$DEFAULT_BRANCH" ] ;;
-    *) case "refs/heads/$2" in $1) return 0 ;; *) return 1 ;; esac ;;
+    *) [ "$1" = "refs/heads/$2" ] ;;
   esac
 }
 
-# Whether the automatic reviewer is armed for BASE. An exclude pattern beats an
-# include, matching GitHub's own ruleset evaluation.
-auto_review_targets_base() { # BASE
-  local pattern
-  [ -n "$1" ] || return 1
-  while IFS= read -r pattern; do
-    [ -n "$pattern" ] || continue
-    if auto_review_pattern_matches "$pattern" "$1"; then return 1; fi
+# Whether RULESET_ID's own exclude patterns cover BASE.
+auto_review_ruleset_excludes() { # RULESET_ID BASE
+  local ruleset_id pattern
+  while IFS=$'\t' read -r ruleset_id pattern; do
+    [ "$ruleset_id" = "$1" ] || continue
+    if auto_review_pattern_matches "$pattern" "$2"; then return 0; fi
   done <<<"$AUTO_REVIEW_EXCLUDE"
-  while IFS= read -r pattern; do
-    [ -n "$pattern" ] || continue
-    if auto_review_pattern_matches "$pattern" "$1"; then return 0; fi
-  done <<<"$AUTO_REVIEW_INCLUDE"
   return 1
 }
 
-resolve_auto_review_targets
+# Whether the automatic reviewer is armed for BASE: some ruleset includes it
+# and that same ruleset does not exclude it. An exclude narrows only its own
+# ruleset, since GitHub evaluates each ruleset on its own.
+auto_review_targets_base() { # BASE
+  local ruleset_id pattern
+  [ -n "$1" ] || return 1
+  while IFS=$'\t' read -r ruleset_id pattern; do
+    [ -n "$ruleset_id" ] || continue
+    auto_review_pattern_matches "$pattern" "$1" || continue
+    auto_review_ruleset_excludes "$ruleset_id" "$1" || return 0
+  done <<<"$AUTO_REVIEW_INCLUDE"
+  return 1
+}
 
 # The reviewThreads walk is lib/review-threads.sh's, shared with queue-wait's
 # late-findings guard so the waiter and the guard cannot disagree about what an
@@ -875,6 +934,8 @@ read_base_ref() {
     last_auto_review_targeted=false
   fi
 }
+
+resolve_auto_review_targets
 
 update_elapsed
 while true; do

--- a/.agents/skills/orch/scripts/approval-wait
+++ b/.agents/skills/orch/scripts/approval-wait
@@ -221,6 +221,25 @@ change during this wait. A mid-wait force-push falls back to "timeout",
 and the head is re-confirmed once more at the deadline itself, so proceed
 never bypasses a live gate and never attests a stale head.
 
+Automatic review and the base branch: GitHub's automatic reviewer is armed
+by an ACTIVE BRANCH RULESET carrying a rule of type copilot_code_review, and
+that ruleset's conditions.ref_name is the set of bases that draw one. It is
+per-repo configuration, never a GitHub constant. The set is resolved ONCE
+before the poll loop, from the repo's rulesets (source "ruleset"); when that
+read fails or no ruleset carries the rule, the repo's default branch is the
+whole set (source "default_branch"); when neither can be read the set is
+"unresolved". The PR's baseRefName is matched against it — "~ALL" matches
+any base, "~DEFAULT_BRANCH" the repo default, any other pattern is an
+fnmatch over refs/heads/<base>, and an exclude pattern beats an include.
+
+A base outside that set draws no automatic review, so reviewer silence there
+is structural rather than a slow reviewer: the deadline reports
+"unreviewable" (exit 1) and never degrades to "proceeded", whatever
+PR_REVIEW_ON_TIMEOUT says. A review can still be requested by hand on such a
+base (gh pr edit <PR#> --add-reviewer @copilot), which is why the wait runs
+its full budget rather than returning early. An "unresolved" target set
+likewise never proceeds: it reports "timeout".
+
 Transient GitHub API failures (kendex#748) — HTTP 5xx, HTTP 429, timeout,
 transport error — are retried with doubling backoff (capped at 8x) inside
 the existing max_wait budget and reported as a transient_api_errors count;
@@ -230,7 +249,7 @@ a fully successful poll resets the backoff. Non-transient failures (HTTP
 JSON output (always when --json):
   {
     "status": "approved" | "reviewed" | "changes_requested" | "comments"
-              | "timeout" | "proceeded" | "error",
+              | "timeout" | "proceeded" | "unreviewable" | "error",
     "review_decision": <string>,  # raw reviewDecision ("" when unset)
     "approvals": <int>,           # reviewers whose latest review is APPROVED
     "changes_requested": <int>,   # reviewers at CHANGES_REQUESTED
@@ -244,6 +263,10 @@ JSON output (always when --json):
                                   # (PR_REVIEW_CHECK success)
     "review_evidence_surface": <string>,  # alongside review_evidence
                                   # "check": "check_run" or "status"
+    "base_ref": <string>,         # the PR's base branch
+    "auto_review_targeted": <bool>,  # the base draws an automatic review
+    "auto_review_target_source": "ruleset" | "default_branch" | "unresolved",
+    "auto_review_targets": [<string>],  # the ref_name include patterns
     "transient_api_errors": <int>,  # only when > 0
     "error": <string>             # only when status == "error"
   }
@@ -259,8 +282,9 @@ selected). Full ladder: orch DEVELOPMENT.md.
 Exit codes:
   0  approved (approval mode) / reviewed (review mode) / proceeded
      (deadline reached under PR_REVIEW_ON_TIMEOUT=proceed)
-  1  changes requested, unresolved comments pending, timeout, or a
-     non-auth error
+  1  changes requested, unresolved comments pending, timeout,
+     unreviewable (no automatic reviewer targets the PR's base and none
+     arrived), or a non-auth error
   2  usage error: missing or empty argument, invalid --mode value, or
      unknown flag
   3  hard GitHub auth/CLI failure (matches ci-wait and queue-wait)
@@ -451,6 +475,17 @@ last_changes=0
 last_unresolved=0
 last_head_sha=""
 last_reviews_at_head=0
+last_base_ref=""
+# The automatic-review target set and this PR's standing against it. Declared
+# beside the other snapshot state because emit_error runs on the pre-repo
+# failure paths, before resolve_auto_review_targets can fill them in.
+last_auto_review_targeted=false
+AUTO_REVIEW_SOURCE="unresolved"
+AUTO_REVIEW_INCLUDE=""
+AUTO_REVIEW_EXCLUDE=""
+AUTO_REVIEW_TARGETS_JSON="[]"
+AUTO_REVIEW_TARGETS_TEXT=""
+DEFAULT_BRANCH=""
 # Approval mode only: non-author, non-dismissed latest reviews of ANY state
 # (COMMENTED included). Distinguishes "a reviewer engaged but did not approve"
 # from "no reviewer showed at all", so the PR_REVIEW_ON_TIMEOUT=proceed degrade
@@ -499,7 +534,7 @@ run_approved_gate() {
 # Emit the final machine-readable result on stdout. Every exit path routes
 # through here (or emit_error) so the script can never finish silently.
 #   status: approved | reviewed | changes_requested | comments | timeout
-#         | proceeded | error
+#         | proceeded | unreviewable | error
 emit_result() {
   local status="$1" error_msg="${2:-}" mode_fields
   update_elapsed
@@ -525,6 +560,10 @@ emit_result() {
     jq -n \
       --arg s "$status" \
       --arg decision "$last_review_decision" \
+      --arg base_ref "$last_base_ref" \
+      --argjson auto_targeted "$last_auto_review_targeted" \
+      --arg auto_source "$AUTO_REVIEW_SOURCE" \
+      --argjson auto_targets "$AUTO_REVIEW_TARGETS_JSON" \
       --argjson approvals "$last_approvals" \
       --argjson changes "$last_changes" \
       --argjson unresolved "$last_unresolved" \
@@ -538,7 +577,11 @@ emit_result() {
         approvals: $approvals,
         changes_requested: $changes,
         unresolved_count: $unresolved,
-        elapsed_seconds: $elapsed
+        elapsed_seconds: $elapsed,
+        base_ref: $base_ref,
+        auto_review_targeted: $auto_targeted,
+        auto_review_target_source: $auto_source,
+        auto_review_targets: $auto_targets
       } + $mode_fields
         + (if $transient > 0 then {transient_api_errors: $transient} else {} end)
         + (if $error == "" then {} else {error: $error} end)' || return $?
@@ -578,6 +621,9 @@ emit_result() {
       else
         echo "Approval: $last_unresolved unresolved review thread(s) pending triage, no approval verdict yet"
       fi
+      ;;
+    unreviewable)
+      echo "No automatic review for base '${last_base_ref:-unknown}' after ${elapsed}s: the automatic-review target set (${AUTO_REVIEW_TARGETS_TEXT:-none}, source: $AUTO_REVIEW_SOURCE) does not cover it. Request one with: gh pr edit $PR_NUM --add-reviewer @copilot"
       ;;
     timeout)
       if [[ "$MODE" == "review" ]]; then
@@ -674,6 +720,83 @@ fi
 OWNER="${REPO%%/*}"
 REPO_NAME="${REPO#*/}"
 
+# --- automatic-review target set (resolved ONCE, before the poll loop) ---
+# GitHub's automatic reviewer is armed by an ACTIVE BRANCH RULESET carrying a
+# rule of type copilot_code_review; that ruleset's conditions.ref_name is the
+# set of bases that draw one. Which bases those are is per-repo configuration,
+# not a GitHub constant, so it is read rather than assumed. A PR based outside
+# the set draws no automatic review at all, which is why the deadline separates
+# that structural silence ("unreviewable") from a reviewer who merely did not
+# show ("timeout"/"proceeded"). The ruleset cannot change the answer mid-wait,
+# so this costs two reads, not two per poll.
+resolve_auto_review_targets() {
+  local rulesets ruleset_ids ruleset_id detail
+  DEFAULT_BRANCH=$(gh api "repos/$REPO" -q '.default_branch' 2>/dev/null) || DEFAULT_BRANCH=""
+  rulesets=$(gh api "repos/$REPO/rulesets" 2>/dev/null) || rulesets=""
+  if [ -n "$rulesets" ] && jq -e 'type == "array"' >/dev/null 2>&1 <<<"$rulesets"; then
+    # The listing carries no rules or conditions, so each active branch ruleset
+    # is opened until one carries the copilot_code_review rule.
+    ruleset_ids=$(jq -r '.[] | select(.target == "branch" and .enforcement == "active") | .id' <<<"$rulesets") || ruleset_ids=""
+    while IFS= read -r ruleset_id; do
+      [ -n "$ruleset_id" ] || continue
+      detail=$(gh api "repos/$REPO/rulesets/$ruleset_id" 2>/dev/null) || continue
+      jq -e 'any(.rules[]?; .type == "copilot_code_review")' >/dev/null 2>&1 <<<"$detail" || continue
+      AUTO_REVIEW_INCLUDE=$(jq -r '.conditions.ref_name.include[]? // empty' <<<"$detail") || AUTO_REVIEW_INCLUDE=""
+      AUTO_REVIEW_EXCLUDE=$(jq -r '.conditions.ref_name.exclude[]? // empty' <<<"$detail") || AUTO_REVIEW_EXCLUDE=""
+      AUTO_REVIEW_SOURCE="ruleset"
+      break
+    done <<<"$ruleset_ids"
+  fi
+  if [ "$AUTO_REVIEW_SOURCE" = "unresolved" ] && [ -n "$DEFAULT_BRANCH" ]; then
+    # No readable ruleset rule: the default branch is the whole target set,
+    # which is what the shipped "Copilot review for default branch" shape means.
+    AUTO_REVIEW_INCLUDE="~DEFAULT_BRANCH"
+    AUTO_REVIEW_EXCLUDE=""
+    AUTO_REVIEW_SOURCE="default_branch"
+  fi
+  # ~DEFAULT_BRANCH names a branch this run could not read, so the set cannot be
+  # judged. Unresolved is reported as unresolved rather than matched as a miss:
+  # a failed read must not manufacture an "unreviewable" verdict.
+  if [ -z "$DEFAULT_BRANCH" ] && [[ "$AUTO_REVIEW_INCLUDE$AUTO_REVIEW_EXCLUDE" == *'~DEFAULT_BRANCH'* ]]; then
+    AUTO_REVIEW_SOURCE="unresolved"
+    AUTO_REVIEW_INCLUDE=""
+    AUTO_REVIEW_EXCLUDE=""
+  fi
+  AUTO_REVIEW_TARGETS_JSON=$(printf '%s' "$AUTO_REVIEW_INCLUDE" \
+    | jq -R -s 'split("\n") | map(select(length > 0))') || AUTO_REVIEW_TARGETS_JSON="[]"
+  AUTO_REVIEW_TARGETS_TEXT=$(printf '%s' "$AUTO_REVIEW_INCLUDE" | tr '\n' ' ') || AUTO_REVIEW_TARGETS_TEXT=""
+  AUTO_REVIEW_TARGETS_TEXT="${AUTO_REVIEW_TARGETS_TEXT% }"
+}
+
+# Does one ref_name pattern cover this base? "~ALL" covers every base,
+# "~DEFAULT_BRANCH" the repo default, and any other pattern is an fnmatch over
+# the base's full ref, which is how a ruleset ref condition is spelled.
+auto_review_pattern_matches() { # PATTERN BASE
+  case "$1" in
+    '~ALL') return 0 ;;
+    '~DEFAULT_BRANCH') [ -n "$DEFAULT_BRANCH" ] && [ "$2" = "$DEFAULT_BRANCH" ] ;;
+    *) case "refs/heads/$2" in $1) return 0 ;; *) return 1 ;; esac ;;
+  esac
+}
+
+# Whether the automatic reviewer is armed for BASE. An exclude pattern beats an
+# include, matching GitHub's own ruleset evaluation.
+auto_review_targets_base() { # BASE
+  local pattern
+  [ -n "$1" ] || return 1
+  while IFS= read -r pattern; do
+    [ -n "$pattern" ] || continue
+    if auto_review_pattern_matches "$pattern" "$1"; then return 1; fi
+  done <<<"$AUTO_REVIEW_EXCLUDE"
+  while IFS= read -r pattern; do
+    [ -n "$pattern" ] || continue
+    if auto_review_pattern_matches "$pattern" "$1"; then return 0; fi
+  done <<<"$AUTO_REVIEW_INCLUDE"
+  return 1
+}
+
+resolve_auto_review_targets
+
 # The reviewThreads walk is lib/review-threads.sh's, shared with queue-wait's
 # late-findings guard so the waiter and the guard cannot disagree about what an
 # open thread is. gh's stderr lands in GH_ERR_FILE for the transient/terminal
@@ -742,6 +865,18 @@ confirm_head_unchanged() {
   [ -n "$cur" ] && [ "$cur" = "$last_head_sha" ]
 }
 
+# Record the base this poll saw and whether the automatic reviewer targets it.
+# The base rides along on the poll's own pr view call, so a mid-wait retarget
+# (GitHub moves a stacked PR's base when its base branch merges) is picked up.
+read_base_ref() {
+  last_base_ref=$(jq -r '.baseRefName // ""' <<<"$view_json")
+  if auto_review_targets_base "$last_base_ref"; then
+    last_auto_review_targeted=true
+  else
+    last_auto_review_targeted=false
+  fi
+}
+
 update_elapsed
 while true; do
   if [ "$MODE" = "review" ]; then
@@ -749,7 +884,7 @@ while true; do
     # head, and only reviews of the CURRENT head satisfy the gate) ---
     view_status=0
     set +e
-    view_json=$(gh pr view "$PR_NUM" --repo "$REPO" --json headRefOid,author 2>"$GH_ERR_FILE")
+    view_json=$(gh pr view "$PR_NUM" --repo "$REPO" --json headRefOid,author,baseRefName 2>"$GH_ERR_FILE")
     view_status=$?
     set -e
     if [ "$view_status" -ne 0 ] || ! jq -e 'type == "object"' >/dev/null 2>&1 <<<"$view_json"; then
@@ -763,6 +898,7 @@ while true; do
     fi
     last_head_sha=$(jq -r '.headRefOid // ""' <<<"$view_json")
     pr_author=$(jq -r '.author.login // ""' <<<"$view_json")
+    read_base_ref
 
     # --- submitted reviews snapshot (REST carries commit_id; latestReviews
     # does not, so head pinning needs the pulls/reviews listing). Captured in
@@ -901,7 +1037,7 @@ while true; do
     # bookkeeping the proceed guard reads) ---
     view_status=0
     set +e
-    view_json=$(gh pr view "$PR_NUM" --repo "$REPO" --json reviewDecision,latestReviews,headRefOid,author 2>"$GH_ERR_FILE")
+    view_json=$(gh pr view "$PR_NUM" --repo "$REPO" --json reviewDecision,latestReviews,headRefOid,author,baseRefName 2>"$GH_ERR_FILE")
     view_status=$?
     set -e
     if [ "$view_status" -ne 0 ] || ! jq -e 'type == "object"' >/dev/null 2>&1 <<<"$view_json"; then
@@ -917,6 +1053,7 @@ while true; do
     last_review_decision=$(jq -r '.reviewDecision // ""' <<<"$view_json")
     last_head_sha=$(jq -r '.headRefOid // ""' <<<"$view_json")
     pr_author=$(jq -r '.author.login // ""' <<<"$view_json")
+    read_base_ref
     # latestReviews already holds the latest review per reviewer; count formal
     # verdict states only. COMMENTED/DISMISSED reviews neither approve nor block.
     last_approvals=$(jq '[.latestReviews[]? | select(.state == "APPROVED")] | length' <<<"$view_json")
@@ -1023,15 +1160,38 @@ done
 #     START_TIME, so a force-push near MAX_WAIT would otherwise proceed seconds
 #     after the new commit appeared, before the reviewer could re-review it;
 #     fall back to timeout so the caller re-waits on the now-stable head.
+#   - a readable automatic-review target set that covers this PR's base. The
+#     two cases that fails are handled below.
 # The caller records "proceeded" as a reviewer-down override; CI and the
 # comment-hygiene gate still apply.
-if [ "$ON_TIMEOUT" = "proceed" ] && [ "$last_unresolved" -eq 0 ] \
-  && [ "$last_reviews_present" -eq 0 ] && [ "$head_changed_during_wait" = false ] \
+reviewer_silent=false
+if [ "$last_unresolved" -eq 0 ] && [ "$last_reviews_present" -eq 0 ]; then
+  reviewer_silent=true
+fi
+
+# Silence over a base no automatic-review ruleset targets is not a reviewer who
+# failed to show — nothing was ever going to arrive on its own. That is its own
+# verdict, exit 1, whatever PR_REVIEW_ON_TIMEOUT says: proceed is the one
+# fail-open path this script has, and a structurally impossible wait must never
+# reach it. The wait still spends its budget rather than returning early,
+# because a review CAN be requested by hand on such a base and may land during
+# it. An unresolved target set is not a miss: it falls through to the timeout
+# below, since a failed read must not manufacture either verdict.
+if [ "$reviewer_silent" = true ] && [ "$AUTO_REVIEW_SOURCE" != "unresolved" ] \
+  && [ "$last_auto_review_targeted" = false ]; then
+  emit_result "unreviewable"
+  exit 1
+fi
+
+if [ "$ON_TIMEOUT" = "proceed" ] && [ "$reviewer_silent" = true ] \
+  && [ "$AUTO_REVIEW_SOURCE" != "unresolved" ] \
+  && [ "$head_changed_during_wait" = false ] \
   && confirm_head_unchanged; then
   emit_result "proceeded"
   exit 0
 fi
-# Either not a proceed, or the head moved in the final window (confirm failed):
-# report timeout so the caller re-waits on the current head.
+# Either not a proceed, the target set could not be read, or the head moved in
+# the final window (confirm failed): report timeout so the caller re-waits on
+# the current head.
 emit_result "timeout"
 exit 1

--- a/.agents/skills/orch/scripts/approval-wait
+++ b/.agents/skills/orch/scripts/approval-wait
@@ -727,8 +727,7 @@ REPO_NAME="${REPO#*/}"
 # not a GitHub constant, so it is read rather than assumed. A PR based outside
 # the set draws no automatic review at all, which is why the deadline separates
 # that structural silence ("unreviewable") from a reviewer who merely did not
-# show ("timeout"/"proceeded"). The ruleset cannot change the answer mid-wait,
-# so this costs two reads, not two per poll.
+# show ("timeout"/"proceeded").
 resolve_auto_review_targets() {
   local rulesets ruleset_ids ruleset_id detail
   DEFAULT_BRANCH=$(gh api "repos/$REPO" -q '.default_branch' 2>/dev/null) || DEFAULT_BRANCH=""

--- a/.agents/skills/orch/tests/approval_wait.sh
+++ b/.agents/skills/orch/tests/approval_wait.sh
@@ -46,6 +46,12 @@ git -C "$TMP_ROOT/repo" config user.name Test
 #   "Review Bot" run (older failure + newer terminal run, plus an unrelated
 #   "Other Check") on headsha1 only; success_stale publishes it on oldsha
 #   only, so the current-head query finds nothing.
+#   Automatic-review target set: `api repos/owner/repo` answers the default
+#   branch (STUB_DEFAULT_BRANCH, or a 500 under STUB_DEFAULT_BRANCH_MODE=fail);
+#   `api repos/*/rulesets` and its detail answer the ruleset carrying the
+#   copilot_code_review rule — STUB_RULESET_INCLUDE / STUB_RULESET_EXCLUDE are
+#   its space-separated ref_name conditions, and STUB_RULESETS_MODE=none/fail
+#   drops the rule or the read. Every `pr view` payload carries STUB_BASE_REF.
 #   Commit statuses: `api repos/*/commits/<sha>/status` (combined status)
 #   answers likewise — STUB_STATUS_MODE=success_at_head/pending_at_head/
 #   failure_at_head/error_at_head publishes a "Review Bot" context (older
@@ -65,6 +71,16 @@ _stub_auth_ok() {
   fi
   [[ "${STUB_GH_DENY_KEYRING:-0}" == "1" ]] && return 1
   return 0
+}
+
+# A JSON array from space-separated words, for the ruleset ref_name conditions.
+_stub_json_array() { # WORDS
+  local out="" word
+  for word in $1; do
+    [[ -n "$out" ]] && out+=","
+    out+="\"$word\""
+  done
+  printf '[%s]' "$out"
 }
 
 _bump_count() {
@@ -102,6 +118,42 @@ case "${1:-}" in
     if [[ "${2:-}" == "user" ]]; then
       _stub_auth_ok || { echo "HTTP 401: Bad credentials" >&2; exit 1; }
       echo "test-user"
+      exit 0
+    fi
+    # Repository metadata: approval-wait reads only .default_branch, through
+    # gh's own -q filter, so the stub answers with the branch name.
+    if [[ "${2:-}" == "repos/owner/repo" ]]; then
+      _stub_auth_ok || { echo "HTTP 401: Bad credentials" >&2; exit 1; }
+      if [[ "${STUB_DEFAULT_BRANCH_MODE:-ok}" == "fail" ]]; then
+        echo "HTTP 500: Internal Server Error" >&2
+        exit 1
+      fi
+      printf '%s\n' "${STUB_DEFAULT_BRANCH:-main}"
+      exit 0
+    fi
+    # Ruleset listing: no rules or conditions, exactly as GitHub's does. The
+    # copilot_code_review rule lives on ruleset 1 alone, behind a tag ruleset, an
+    # inactive branch ruleset and a branch ruleset with only a deletion rule, so
+    # the walk must filter and step past all three to find it.
+    if [[ "${2:-}" == repos/*/rulesets ]]; then
+      _stub_auth_ok || { echo "HTTP 401: Bad credentials" >&2; exit 1; }
+      case "${STUB_RULESETS_MODE:-copilot}" in
+        fail) echo "HTTP 500: Internal Server Error" >&2; exit 1 ;;
+        none) echo '[{"id":2,"target":"branch","enforcement":"active"}]' ;;
+        *) echo '[{"id":3,"target":"tag","enforcement":"active"},{"id":4,"target":"branch","enforcement":"evaluate"},{"id":2,"target":"branch","enforcement":"active"},{"id":1,"target":"branch","enforcement":"active"}]' ;;
+      esac
+      exit 0
+    fi
+    if [[ "${2:-}" == repos/*/rulesets/* ]]; then
+      _stub_auth_ok || { echo "HTTP 401: Bad credentials" >&2; exit 1; }
+      ruleset_id="${2##*/}"
+      if [[ "$ruleset_id" != "1" ]]; then
+        printf '{"id":%s,"target":"branch","enforcement":"active","conditions":{"ref_name":{"include":["~ALL"],"exclude":[]}},"rules":[{"type":"deletion"}]}\n' "$ruleset_id"
+        exit 0
+      fi
+      printf '{"id":1,"target":"branch","enforcement":"active","conditions":{"ref_name":{"include":%s,"exclude":%s}},"rules":[{"type":"deletion"},{"type":"copilot_code_review","parameters":{"review_on_push":true,"review_draft_pull_requests":false}}]}\n' \
+        "$(_stub_json_array "${STUB_RULESET_INCLUDE:-~DEFAULT_BRANCH}")" \
+        "$(_stub_json_array "${STUB_RULESET_EXCLUDE:-}")"
       exit 0
     fi
     if [[ "${2:-}" == repos/*/pulls/*/reviews ]]; then
@@ -277,22 +329,22 @@ case "${1:-}" in
         fi
         case "$mode" in
           approved_decision)
-            echo '{"reviewDecision":"APPROVED","headRefOid":"headsha1","latestReviews":[{"author":{"login":"reviewer1"},"state":"APPROVED"}]}'
+            echo '{"reviewDecision":"APPROVED","headRefOid":"headsha1","baseRefName":"'"${STUB_BASE_REF:-main}"'","latestReviews":[{"author":{"login":"reviewer1"},"state":"APPROVED"}]}'
             ;;
           approved_latest)
-            echo '{"reviewDecision":"","headRefOid":"headsha1","latestReviews":[{"author":{"login":"reviewer1"},"state":"APPROVED"},{"author":{"login":"colleague"},"state":"COMMENTED"}]}'
+            echo '{"reviewDecision":"","headRefOid":"headsha1","baseRefName":"'"${STUB_BASE_REF:-main}"'","latestReviews":[{"author":{"login":"reviewer1"},"state":"APPROVED"},{"author":{"login":"colleague"},"state":"COMMENTED"}]}'
             ;;
           changes)
-            echo '{"reviewDecision":"","headRefOid":"headsha1","latestReviews":[{"author":{"login":"reviewer1"},"state":"CHANGES_REQUESTED"},{"author":{"login":"colleague"},"state":"APPROVED"}]}'
+            echo '{"reviewDecision":"","headRefOid":"headsha1","baseRefName":"'"${STUB_BASE_REF:-main}"'","latestReviews":[{"author":{"login":"reviewer1"},"state":"CHANGES_REQUESTED"},{"author":{"login":"colleague"},"state":"APPROVED"}]}'
             ;;
           commented_only)
-            echo '{"reviewDecision":"","headRefOid":"headsha1","latestReviews":[{"author":{"login":"reviewer1"},"state":"COMMENTED"}]}'
+            echo '{"reviewDecision":"","headRefOid":"headsha1","baseRefName":"'"${STUB_BASE_REF:-main}"'","latestReviews":[{"author":{"login":"reviewer1"},"state":"COMMENTED"}]}'
             ;;
           required_pending)
-            echo '{"reviewDecision":"REVIEW_REQUIRED","headRefOid":"headsha1","latestReviews":[{"author":{"login":"colleague"},"state":"APPROVED"}]}'
+            echo '{"reviewDecision":"REVIEW_REQUIRED","headRefOid":"headsha1","baseRefName":"'"${STUB_BASE_REF:-main}"'","latestReviews":[{"author":{"login":"colleague"},"state":"APPROVED"}]}'
             ;;
           none|*)
-            echo '{"reviewDecision":"","headRefOid":"headsha1","latestReviews":[]}'
+            echo '{"reviewDecision":"","headRefOid":"headsha1","baseRefName":"'"${STUB_BASE_REF:-main}"'","latestReviews":[]}'
             ;;
         esac
         exit 0
@@ -310,7 +362,7 @@ case "${1:-}" in
             head="headsha2"
           fi
         fi
-        printf '{"headRefOid":"%s","author":{"login":"pr-author"}}\n' "$head"
+        printf '{"headRefOid":"%s","author":{"login":"pr-author"},"baseRefName":"%s"}\n' "$head" "${STUB_BASE_REF:-main}"
         exit 0
       fi
     fi
@@ -373,6 +425,7 @@ count_lines() { # FILE — 0 when it was never written
 #   status_queries                  combined-status reads the stub served
 #   marker_posts                    commit-status POSTs the stub received
 #   outage_marker                   whether the JSON carries that field
+#   target_patterns   auto_review_targets joined, so a row compares as one word
 #   transient_errors_seen           transient_api_errors >= 1
 observe() {
   local got="" token name
@@ -390,6 +443,7 @@ observe() {
       marker_posts) got="$got marker_posts=$(count_lines "$RUN/marker-posts")" ;;
       outage_marker) got="$got outage_marker=$(json 'has("outage_marker")')" ;;
       transient_errors_seen) got="$got transient_errors_seen=$(json '.transient_api_errors >= 1')" ;;
+      target_patterns) got="$got target_patterns=$(json '.auto_review_targets | join(",")')" ;;
       *) got="$got $name=$(json ".$name")" ;;
     esac
   done
@@ -491,6 +545,29 @@ table "$REVIEW" \
   'a head that moved in the last-poll to emit window falls back to timeout||STUB_REVIEWS_MODE=none,STUB_CONFIRM_HEAD=headsha2,PR_REVIEW_ON_TIMEOUT=proceed|rc=1 status=timeout' \
   'a proceed posts no commit status and emits no outage marker||STUB_REVIEWS_MODE=none,PR_REVIEW_ON_TIMEOUT=proceed,PR_REVIEW_OUTAGE_CONTEXT=kendex-reviewer-outage|rc=0 status=proceeded marker_posts=0 outage_marker=false'
 
+echo "=== the automatic-review target set decides whether silence is a timeout or unreviewable ==="
+# The automatic reviewer is armed by an active branch ruleset carrying a
+# copilot_code_review rule, and its conditions.ref_name is the set of bases that
+# draw one. A base outside that set can never draw one, so silence there is
+# "unreviewable" (exit 1) under either on-timeout policy, never the fail-open
+# "proceeded" — while the same silence on a covered base still proceeds. A
+# reviewer that engaged is a timeout wherever the base sits, and a target set
+# that could not be read is a timeout too: a failed read decides nothing.
+# The include/exclude patterns are shaped input, one asserted row per shape.
+table "$REVIEW" \
+  'an untargeted base under proceed is unreviewable, not proceeded||STUB_REVIEWS_MODE=none,STUB_BASE_REF=stack-base,PR_REVIEW_ON_TIMEOUT=proceed|rc=1 status=unreviewable base_ref=stack-base auto_review_targeted=false auto_review_target_source=ruleset target_patterns=~DEFAULT_BRANCH' \
+  'an untargeted base under block is unreviewable, not a timeout||STUB_REVIEWS_MODE=none,STUB_BASE_REF=stack-base,PR_REVIEW_ON_TIMEOUT=block|rc=1 status=unreviewable' \
+  'control: the same silence on the targeted base still proceeds||STUB_REVIEWS_MODE=none,STUB_BASE_REF=main,PR_REVIEW_ON_TIMEOUT=proceed|rc=0 status=proceeded auto_review_targeted=true' \
+  'a reviewer engaged on an untargeted base is a timeout, not unreviewable||STUB_REVIEWS_MODE=none,STUB_CHECKS_MODE=failure_at_head,PR_REVIEW_CHECK=Review Bot,STUB_BASE_REF=stack-base,PR_REVIEW_ON_TIMEOUT=proceed|rc=1 status=timeout' \
+  'approval mode reads the same base and reaches the same verdict|1 1 3 --json|STUB_APPROVAL_MODE=none,STUB_BASE_REF=stack-base,PR_REVIEW_ON_TIMEOUT=proceed|rc=1 status=unreviewable base_ref=stack-base' \
+  'a ~ALL ruleset covers a stacked base||STUB_REVIEWS_MODE=none,STUB_RULESET_INCLUDE=~ALL,STUB_BASE_REF=stack-base,PR_REVIEW_ON_TIMEOUT=proceed|rc=0 status=proceeded auto_review_targeted=true target_patterns=~ALL' \
+  'a ref pattern is matched over the full ref||STUB_REVIEWS_MODE=none,STUB_RULESET_INCLUDE=refs/heads/stack-*,STUB_BASE_REF=stack-base,PR_REVIEW_ON_TIMEOUT=proceed|rc=0 status=proceeded auto_review_targeted=true' \
+  'an exclude pattern beats the include||STUB_REVIEWS_MODE=none,STUB_RULESET_INCLUDE=~ALL,STUB_RULESET_EXCLUDE=refs/heads/stack-*,STUB_BASE_REF=stack-base,PR_REVIEW_ON_TIMEOUT=proceed|rc=1 status=unreviewable auto_review_targeted=false' \
+  'no ruleset carries the rule, so the default branch is the whole set||STUB_REVIEWS_MODE=none,STUB_RULESETS_MODE=none,STUB_BASE_REF=stack-base,PR_REVIEW_ON_TIMEOUT=proceed|rc=1 status=unreviewable auto_review_target_source=default_branch target_patterns=~DEFAULT_BRANCH' \
+  'an unreadable ruleset listing falls back to the default branch||STUB_REVIEWS_MODE=none,STUB_RULESETS_MODE=fail,STUB_BASE_REF=main,PR_REVIEW_ON_TIMEOUT=proceed|rc=0 status=proceeded auto_review_target_source=default_branch' \
+  'an unresolvable target set is a timeout, never proceeded||STUB_REVIEWS_MODE=none,STUB_RULESETS_MODE=fail,STUB_DEFAULT_BRANCH_MODE=fail,STUB_BASE_REF=main,PR_REVIEW_ON_TIMEOUT=proceed|rc=1 status=timeout auto_review_target_source=unresolved target_patterns=' \
+  'a ruleset naming ~DEFAULT_BRANCH with no readable default branch is unresolved||STUB_REVIEWS_MODE=none,STUB_DEFAULT_BRANCH_MODE=fail,STUB_BASE_REF=stack-base,PR_REVIEW_ON_TIMEOUT=proceed|rc=1 status=timeout auto_review_target_source=unresolved'
+
 echo "=== transient GitHub API failures are retried inside the budget and counted ==="
 # A 5xx or 429 from the reviews listing, or from the approval-mode pr view, is
 # absorbed with backoff and reported as transient_api_errors on the eventual
@@ -523,7 +600,8 @@ table '1 1 3' \
   "review: comments|$TEXT_REVIEW|STUB_REVIEWS_MODE=commented_at_head,STUB_THREADS_UNRESOLVED=2|rc=1 text_status=comments" \
   "review: timeout|$TEXT_REVIEW|STUB_REVIEWS_MODE=none|rc=1 text_status=timeout" \
   "review: error|$TEXT_REVIEW|GH_TOKEN=bad-token,STUB_GH_DENY_KEYRING=1|rc=3 text_status=error" \
-  "review: proceeded|$TEXT_REVIEW|STUB_REVIEWS_MODE=none,PR_REVIEW_ON_TIMEOUT=proceed|rc=0 text_status=proceeded"
+  "review: proceeded|$TEXT_REVIEW|STUB_REVIEWS_MODE=none,PR_REVIEW_ON_TIMEOUT=proceed|rc=0 text_status=proceeded" \
+  "review: unreviewable|$TEXT_REVIEW|STUB_REVIEWS_MODE=none,STUB_BASE_REF=stack-base|rc=1 text_status=unreviewable"
 
 echo "=== PR_REVIEW_WAIT_SECS: an absent max_wait positional resolves through orch-env ==="
 # Process env beats kendex.settings.toml [env], and an explicit positional

--- a/.agents/skills/orch/tests/approval_wait.sh
+++ b/.agents/skills/orch/tests/approval_wait.sh
@@ -48,10 +48,15 @@ git -C "$TMP_ROOT/repo" config user.name Test
 #   only, so the current-head query finds nothing.
 #   Automatic-review target set: `api repos/owner/repo` answers the default
 #   branch (STUB_DEFAULT_BRANCH, or a 500 under STUB_DEFAULT_BRANCH_MODE=fail);
-#   `api repos/*/rulesets` and its detail answer the ruleset carrying the
+#   `api repos/*/rulesets` and its detail answer ruleset 1 carrying the
 #   copilot_code_review rule — STUB_RULESET_INCLUDE / STUB_RULESET_EXCLUDE are
-#   its space-separated ref_name conditions, and STUB_RULESETS_MODE=none/fail
-#   drops the rule or the read. Every `pr view` payload carries STUB_BASE_REF.
+#   its space-separated ref_name conditions and STUB_RULESET_DETAIL_MODE=fail
+#   fails its detail read; STUB_RULESET2_INCLUDE / STUB_RULESET2_EXCLUDE give
+#   ruleset 2, walked first, a rule of its own. STUB_RULESETS_MODE=none drops
+#   the rule; fail, denied, not_found and rate_limited fail the listing with a
+#   500, a 403, a 404 and a rate-limited 403; paged moves ruleset 1 to a second
+#   page that only --paginate reads. Every `pr view` payload carries
+#   STUB_BASE_REF.
 #   Commit statuses: `api repos/*/commits/<sha>/status` (combined status)
 #   answers likewise — STUB_STATUS_MODE=success_at_head/pending_at_head/
 #   failure_at_head/error_at_head publishes a "Review Bot" context (older
@@ -81,6 +86,12 @@ _stub_json_array() { # WORDS
     out+="\"$word\""
   done
   printf '[%s]' "$out"
+}
+
+# A ruleset detail carrying the copilot_code_review rule beside a deletion rule.
+_stub_copilot_ruleset() { # ID INCLUDE_WORDS EXCLUDE_WORDS
+  printf '{"id":%s,"target":"branch","enforcement":"active","conditions":{"ref_name":{"include":%s,"exclude":%s}},"rules":[{"type":"deletion"},{"type":"copilot_code_review","parameters":{"review_on_push":true,"review_draft_pull_requests":false}}]}\n' \
+    "$1" "$(_stub_json_array "$2")" "$(_stub_json_array "$3")"
 }
 
 _bump_count() {
@@ -139,7 +150,16 @@ case "${1:-}" in
       _stub_auth_ok || { echo "HTTP 401: Bad credentials" >&2; exit 1; }
       case "${STUB_RULESETS_MODE:-copilot}" in
         fail) echo "HTTP 500: Internal Server Error" >&2; exit 1 ;;
+        denied) echo "HTTP 403: Resource not accessible by integration" >&2; exit 1 ;;
+        not_found) echo "HTTP 404: Not Found" >&2; exit 1 ;;
+        rate_limited) echo "HTTP 403: API rate limit exceeded for installation ID 1." >&2; exit 1 ;;
         none) echo '[{"id":2,"target":"branch","enforcement":"active"}]' ;;
+        paged)
+          echo '[{"id":3,"target":"tag","enforcement":"active"},{"id":2,"target":"branch","enforcement":"active"}]'
+          if [[ " $* " == *" --paginate "* ]]; then
+            echo '[{"id":1,"target":"branch","enforcement":"active"}]'
+          fi
+          ;;
         *) echo '[{"id":3,"target":"tag","enforcement":"active"},{"id":4,"target":"branch","enforcement":"evaluate"},{"id":2,"target":"branch","enforcement":"active"},{"id":1,"target":"branch","enforcement":"active"}]' ;;
       esac
       exit 0
@@ -147,13 +167,19 @@ case "${1:-}" in
     if [[ "${2:-}" == repos/*/rulesets/* ]]; then
       _stub_auth_ok || { echo "HTTP 401: Bad credentials" >&2; exit 1; }
       ruleset_id="${2##*/}"
+      if [[ "$ruleset_id" == "2" && -n "${STUB_RULESET2_INCLUDE:-}" ]]; then
+        _stub_copilot_ruleset 2 "$STUB_RULESET2_INCLUDE" "${STUB_RULESET2_EXCLUDE:-}"
+        exit 0
+      fi
       if [[ "$ruleset_id" != "1" ]]; then
         printf '{"id":%s,"target":"branch","enforcement":"active","conditions":{"ref_name":{"include":["~ALL"],"exclude":[]}},"rules":[{"type":"deletion"}]}\n' "$ruleset_id"
         exit 0
       fi
-      printf '{"id":1,"target":"branch","enforcement":"active","conditions":{"ref_name":{"include":%s,"exclude":%s}},"rules":[{"type":"deletion"},{"type":"copilot_code_review","parameters":{"review_on_push":true,"review_draft_pull_requests":false}}]}\n' \
-        "$(_stub_json_array "${STUB_RULESET_INCLUDE:-~DEFAULT_BRANCH}")" \
-        "$(_stub_json_array "${STUB_RULESET_EXCLUDE:-}")"
+      if [[ "${STUB_RULESET_DETAIL_MODE:-ok}" == "fail" ]]; then
+        echo "HTTP 500: Internal Server Error" >&2
+        exit 1
+      fi
+      _stub_copilot_ruleset 1 "${STUB_RULESET_INCLUDE:-~DEFAULT_BRANCH}" "${STUB_RULESET_EXCLUDE:-}"
       exit 0
     fi
     if [[ "${2:-}" == repos/*/pulls/*/reviews ]]; then
@@ -546,14 +572,17 @@ table "$REVIEW" \
   'a proceed posts no commit status and emits no outage marker||STUB_REVIEWS_MODE=none,PR_REVIEW_ON_TIMEOUT=proceed,PR_REVIEW_OUTAGE_CONTEXT=kendex-reviewer-outage|rc=0 status=proceeded marker_posts=0 outage_marker=false'
 
 echo "=== the automatic-review target set decides whether silence is a timeout or unreviewable ==="
-# The automatic reviewer is armed by an active branch ruleset carrying a
-# copilot_code_review rule, and its conditions.ref_name is the set of bases that
-# draw one. A base outside that set can never draw one, so silence there is
-# "unreviewable" (exit 1) under either on-timeout policy, never the fail-open
-# "proceeded" — while the same silence on a covered base still proceeds. A
-# reviewer that engaged is a timeout wherever the base sits, and a target set
-# that could not be read is a timeout too: a failed read decides nothing.
-# The include/exclude patterns are shaped input, one asserted row per shape.
+# The automatic reviewer is armed by any active branch ruleset carrying a
+# copilot_code_review rule; a base draws one when such a ruleset includes it
+# and that same ruleset does not exclude it. A base outside that set can never
+# draw one, so silence there is "unreviewable" (exit 1) under either on-timeout
+# policy, never the fail-open "proceeded" — while the same silence on a covered
+# base still proceeds. A reviewer that engaged is a timeout wherever the base
+# sits, and a target set that could not be read or judged is a timeout too: only
+# a listing denied as a permission, or one with no ruleset carrying the rule,
+# lets the default branch stand in, and a glob pattern is never matched.
+# The patterns and the listing answers are shaped input, one asserted row per
+# shape.
 table "$REVIEW" \
   'an untargeted base under proceed is unreviewable, not proceeded||STUB_REVIEWS_MODE=none,STUB_BASE_REF=stack-base,PR_REVIEW_ON_TIMEOUT=proceed|rc=1 status=unreviewable base_ref=stack-base auto_review_targeted=false auto_review_target_source=ruleset target_patterns=~DEFAULT_BRANCH' \
   'an untargeted base under block is unreviewable, not a timeout||STUB_REVIEWS_MODE=none,STUB_BASE_REF=stack-base,PR_REVIEW_ON_TIMEOUT=block|rc=1 status=unreviewable' \
@@ -561,11 +590,19 @@ table "$REVIEW" \
   'a reviewer engaged on an untargeted base is a timeout, not unreviewable||STUB_REVIEWS_MODE=none,STUB_CHECKS_MODE=failure_at_head,PR_REVIEW_CHECK=Review Bot,STUB_BASE_REF=stack-base,PR_REVIEW_ON_TIMEOUT=proceed|rc=1 status=timeout' \
   'approval mode reads the same base and reaches the same verdict|1 1 3 --json|STUB_APPROVAL_MODE=none,STUB_BASE_REF=stack-base,PR_REVIEW_ON_TIMEOUT=proceed|rc=1 status=unreviewable base_ref=stack-base' \
   'a ~ALL ruleset covers a stacked base||STUB_REVIEWS_MODE=none,STUB_RULESET_INCLUDE=~ALL,STUB_BASE_REF=stack-base,PR_REVIEW_ON_TIMEOUT=proceed|rc=0 status=proceeded auto_review_targeted=true target_patterns=~ALL' \
-  'a ref pattern is matched over the full ref||STUB_REVIEWS_MODE=none,STUB_RULESET_INCLUDE=refs/heads/stack-*,STUB_BASE_REF=stack-base,PR_REVIEW_ON_TIMEOUT=proceed|rc=0 status=proceeded auto_review_targeted=true' \
-  'an exclude pattern beats the include||STUB_REVIEWS_MODE=none,STUB_RULESET_INCLUDE=~ALL,STUB_RULESET_EXCLUDE=refs/heads/stack-*,STUB_BASE_REF=stack-base,PR_REVIEW_ON_TIMEOUT=proceed|rc=1 status=unreviewable auto_review_targeted=false' \
+  'a ref pattern is matched as the full literal ref||STUB_REVIEWS_MODE=none,STUB_RULESET_INCLUDE=refs/heads/stack-base,STUB_BASE_REF=stack-base,PR_REVIEW_ON_TIMEOUT=proceed|rc=0 status=proceeded auto_review_targeted=true' \
+  'an exclude pattern beats the include||STUB_REVIEWS_MODE=none,STUB_RULESET_INCLUDE=~ALL,STUB_RULESET_EXCLUDE=refs/heads/stack-base,STUB_BASE_REF=stack-base,PR_REVIEW_ON_TIMEOUT=proceed|rc=1 status=unreviewable auto_review_targeted=false' \
+  'a base any one Copilot ruleset covers is targeted, over the union of includes||STUB_REVIEWS_MODE=none,STUB_RULESET2_INCLUDE=~DEFAULT_BRANCH,STUB_RULESET_INCLUDE=refs/heads/stack-base,STUB_BASE_REF=stack-base,PR_REVIEW_ON_TIMEOUT=proceed|rc=0 status=proceeded auto_review_targeted=true target_patterns=~DEFAULT_BRANCH,refs/heads/stack-base' \
+  "an exclude narrows only its own ruleset, not another's include||STUB_REVIEWS_MODE=none,STUB_RULESET2_INCLUDE=~ALL,STUB_RULESET2_EXCLUDE=refs/heads/stack-base,STUB_RULESET_INCLUDE=refs/heads/stack-base,STUB_BASE_REF=stack-base,PR_REVIEW_ON_TIMEOUT=proceed|rc=0 status=proceeded auto_review_targeted=true" \
+  'a Copilot ruleset on a later listing page is read||STUB_REVIEWS_MODE=none,STUB_RULESETS_MODE=paged,STUB_RULESET_INCLUDE=refs/heads/stack-base,STUB_BASE_REF=stack-base,PR_REVIEW_ON_TIMEOUT=proceed|rc=0 status=proceeded auto_review_target_source=ruleset' \
+  'a glob pattern leaves the set unresolved, since GitHub does not match * across /||STUB_REVIEWS_MODE=none,STUB_RULESET_INCLUDE=refs/heads/release/*,STUB_BASE_REF=release/foo/bar,PR_REVIEW_ON_TIMEOUT=proceed|rc=1 status=timeout auto_review_target_source=unresolved' \
   'no ruleset carries the rule, so the default branch is the whole set||STUB_REVIEWS_MODE=none,STUB_RULESETS_MODE=none,STUB_BASE_REF=stack-base,PR_REVIEW_ON_TIMEOUT=proceed|rc=1 status=unreviewable auto_review_target_source=default_branch target_patterns=~DEFAULT_BRANCH' \
-  'an unreadable ruleset listing falls back to the default branch||STUB_REVIEWS_MODE=none,STUB_RULESETS_MODE=fail,STUB_BASE_REF=main,PR_REVIEW_ON_TIMEOUT=proceed|rc=0 status=proceeded auto_review_target_source=default_branch' \
-  'an unresolvable target set is a timeout, never proceeded||STUB_REVIEWS_MODE=none,STUB_RULESETS_MODE=fail,STUB_DEFAULT_BRANCH_MODE=fail,STUB_BASE_REF=main,PR_REVIEW_ON_TIMEOUT=proceed|rc=1 status=timeout auto_review_target_source=unresolved target_patterns=' \
+  'a listing denied with 403 falls back to the default branch||STUB_REVIEWS_MODE=none,STUB_RULESETS_MODE=denied,STUB_BASE_REF=main,PR_REVIEW_ON_TIMEOUT=proceed|rc=0 status=proceeded auto_review_target_source=default_branch' \
+  'a listing answered 404 falls back to the default branch||STUB_REVIEWS_MODE=none,STUB_RULESETS_MODE=not_found,STUB_BASE_REF=main,PR_REVIEW_ON_TIMEOUT=proceed|rc=0 status=proceeded auto_review_target_source=default_branch' \
+  'a rate-limited 403 listing is unresolved, not a denial||STUB_REVIEWS_MODE=none,STUB_RULESETS_MODE=rate_limited,STUB_BASE_REF=main,PR_REVIEW_ON_TIMEOUT=proceed|rc=1 status=timeout auto_review_target_source=unresolved' \
+  'any other listing failure is unresolved, not the default branch||STUB_REVIEWS_MODE=none,STUB_RULESETS_MODE=fail,STUB_BASE_REF=main,PR_REVIEW_ON_TIMEOUT=proceed|rc=1 status=timeout auto_review_target_source=unresolved' \
+  'a failed ruleset detail read is unresolved||STUB_REVIEWS_MODE=none,STUB_RULESET_DETAIL_MODE=fail,STUB_BASE_REF=main,PR_REVIEW_ON_TIMEOUT=proceed|rc=1 status=timeout auto_review_target_source=unresolved' \
+  'a denied listing with no readable default branch is unresolved||STUB_REVIEWS_MODE=none,STUB_RULESETS_MODE=denied,STUB_DEFAULT_BRANCH_MODE=fail,STUB_BASE_REF=main,PR_REVIEW_ON_TIMEOUT=proceed|rc=1 status=timeout auto_review_target_source=unresolved target_patterns=' \
   'a ruleset naming ~DEFAULT_BRANCH with no readable default branch is unresolved||STUB_REVIEWS_MODE=none,STUB_DEFAULT_BRANCH_MODE=fail,STUB_BASE_REF=stack-base,PR_REVIEW_ON_TIMEOUT=proceed|rc=1 status=timeout auto_review_target_source=unresolved'
 
 echo "=== transient GitHub API failures are retried inside the budget and counted ==="

--- a/.agents/skills/orch/workflows/ci-fix.md
+++ b/.agents/skills/orch/workflows/ci-fix.md
@@ -153,6 +153,7 @@ Re-confirm the review gate at the new head **before** waiting on CI, on every re
 
 - `approved` / `reviewed` / `proceeded` → wait for CI. `proceeded` is returned to the caller, not persisted here; it is a LOCAL verdict — orch posts no status.
 - `comments` / `changes_requested` → new feedback on the fix push. Managed: return it to the caller's review-gate handling. Standalone: run that triage pass, then re-run this step.
+- `unreviewable` → this PR's base draws no automatic review ([references/gates.md](../references/gates.md) § Stacked pull requests). Request one with `gh pr edit [PR_NUMBER] --add-reviewer @copilot` and re-run this step once. If it repeats, `auto-recommended` records `ci-gate-unreviewable`; under `ask`, hand back the unconfirmed gate. Never treat it as a met gate.
 - `timeout` → no exact-head evidence yet; a missing or red CI run here is not a fix failure. Re-run this step once. If it repeats, `auto-recommended` records `ci-gate-unconfirmed`; under `ask`, hand back the unconfirmed gate.
 
 ```bash

--- a/.agents/skills/orch/workflows/merge-pr.md
+++ b/.agents/skills/orch/workflows/merge-pr.md
@@ -118,6 +118,8 @@ Two warnings are merge gates, not advice:
 
   With `PR_REVIEW_ON_TIMEOUT=proceed`, a deadline reached with zero unresolved threads and no reviewer evidence returns `proceeded` (exit 0) instead of `timeout` in both modes — treat it as a met gate and record it in the § 6 report. An open thread or a `changes_requested` still blocks. The proceed is a LOCAL verdict — orch posts no status.
 
+  An `unreviewable` status is never a met gate: no automatic reviewer targets this PR's base, so the silence is structural. Follow [references/gates.md](../references/gates.md) § Stacked pull requests, then re-run the wait. If it repeats, `auto-recommended` records `review-gate-unreviewable`, while `ask` presents the wait or stop choice.
+
   Merge past a missing gate verdict only on an explicit user `Force merge`.
 
 Bot-specific signals — emoji reactions, sticky-comment prose, checklist text — are never parsed as merge gates. Only GitHub-native review state and the thread-resolution count count.

--- a/.agents/skills/orch/workflows/submit-pr.md
+++ b/.agents/skills/orch/workflows/submit-pr.md
@@ -221,6 +221,7 @@ For `off`, skip the wait and go to § 5 — the internal review, CI, and comment
    | `reviewed` | Clear the review-wait budget, then → step 2 |
    | `proceeded` | Reviewer-down degrade under `PR_REVIEW_ON_TIMEOUT=proceed`. Clear the review-wait budget, record `pr_approval.reviewer_down` (below), then → step 2. CI and gate 3 still apply in full. Orch posts no status and manufactures no review evidence |
    | `changes_requested` or `comments` | Run the triage pass, then the Restart check |
+   | `unreviewable` | No automatic reviewer targets this PR's base ([references/gates.md](../references/gates.md) § Stacked pull requests). Run `gh pr edit [PR_NUMBER] --add-reviewer @copilot` once, then the Restart check. If the wait returns `unreviewable` again, `auto-recommended` records `review-gate-unreviewable`; `ask` presents `Force merge` \| `Keep waiting` \| `Stop here`, with `Stop here` recommended |
    | `timeout` | `auto-recommended` logs `Keep waiting` and enters the Restart check; `ask` presents `Force merge` \| `Keep waiting` \| `Stop here`, with `Keep waiting` recommended |
    | `error` | Re-run step 1 once. If it repeats, `auto-recommended` records `review-gate-read-failed`; `ask` presents `Keep waiting` \| `Stop here`, with `Keep waiting` recommended |
 

--- a/.agents/skills/review-gate/SKILL.md
+++ b/.agents/skills/review-gate/SKILL.md
@@ -105,6 +105,8 @@ Keys a repo decides: [references/adoption.md](references/adoption.md) § Keys a 
 
 **Watching one or many PRs without stalling.** Never key a hand-rolled monitor on gate-state transitions. Run `.agents/skills/review-gate/scripts/pr-watch.sh` (optionally `--heal`) on the harness's wake-up mechanism: silence + exit 0 means nothing needs you; attention lines name exactly what does. See [Watching PRs as an agent](references/adoption.md#watching-prs-as-an-agent-pr-watch).
 
+**A pull request drew no automatic review.** The automatic reviewer is armed by a branch ruleset, and a base outside that ruleset's target set never draws one. Request the review by hand with `gh pr edit <PR#> --add-reviewer @copilot`. The target set, the ruleset parameters, and the fallbacks when the manual request draws nothing: [references/automatic-review.md](references/automatic-review.md).
+
 **Reviewers are down / nothing is reviewing.** Run the internal review loop: fix findings, resolve every thread, then post the override status with a real reason. It cannot bypass an objection or an open thread.
 
 **A PR that repairs the gate itself.** The writer always runs the merged engine. Merge the repair PR with the ruleset's bypass actor and say so in the commit message.

--- a/.agents/skills/review-gate/references/automatic-review.md
+++ b/.agents/skills/review-gate/references/automatic-review.md
@@ -1,0 +1,32 @@
+# Automatic review and the base branch
+
+Which pull requests draw GitHub's automatic Copilot review, and what to do when one does not. The gate reads evidence and never requests a review; this file names where the evidence comes from.
+
+## What arms the reviewer
+
+| Fact | Value |
+|---|---|
+| Arming mechanism | an active branch ruleset carrying a rule of type `copilot_code_review` |
+| Set of bases that draw a review | that ruleset's `conditions.ref_name` — the `include` patterns, minus the `exclude` patterns |
+| Pattern forms | `~ALL` (every branch), `~DEFAULT_BRANCH` (the repo default), any other pattern as an fnmatch over `refs/heads/<base>` |
+| Re-review on a new head | the rule's `review_on_push` parameter |
+| Draft pull requests | the rule's `review_draft_pull_requests` parameter |
+
+Read a repo's own set with `gh api repos/<owner>/<repo>/rulesets`, then the detail of each `target: "branch"`, `enforcement: "active"` entry.
+
+The target set is per-repo configuration, not GitHub behaviour. In `vanillagreencom/kendex` it is ruleset `16519713`, "Copilot review for default branch", whose `conditions.ref_name.include` is `["~DEFAULT_BRANCH"]`. A pull request based on any branch other than `main` therefore draws no automatic review in this repo. A repo whose ruleset targets more branches reviews stacked pull requests.
+
+## When no review arrives
+
+| Situation | Action |
+|---|---|
+| The base is outside the target set | request the reviewer by hand: `gh pr edit <PR#> --add-reviewer @copilot`. It works on a base the ruleset does not target |
+| The manual request draws nothing | close the pull request and open a fresh one against the default branch |
+| The reviewer already reviewed this pull request once and a new review is needed | reopen it, which re-arms the reviewer |
+| The reviewer never reviewed this pull request | reopening does nothing. Only the manual request, or a new pull request against a targeted base, draws one |
+
+Evidence for the manual route: probe pull request `vanillagreencom/kendex#2527`, based on `ken-1329-probe-base`, which the ruleset does not target. `gh pr edit 2527 --add-reviewer @copilot` was accepted, and `copilot_work_started` followed 36 seconds later.
+
+## What the waiter reports
+
+Orch's `approval-wait` resolves the same target set once per wait and matches the pull request's `baseRefName` against it. Reviewer silence on a base outside the set is reported as status `unreviewable` (exit 1), never the fail-open `proceeded`. Its JSON carries `base_ref`, `auto_review_targeted`, `auto_review_target_source` and `auto_review_targets`. Full contract: `approval-wait --help`. The stacked-chain sequence is orch's `references/gates.md` § Stacked pull requests.

--- a/.agents/skills/review-gate/references/automatic-review.md
+++ b/.agents/skills/review-gate/references/automatic-review.md
@@ -7,12 +7,12 @@ Which pull requests draw GitHub's automatic Copilot review, and what to do when 
 | Fact | Value |
 |---|---|
 | Arming mechanism | an active branch ruleset carrying a rule of type `copilot_code_review` |
-| Set of bases that draw a review | that ruleset's `conditions.ref_name` — the `include` patterns, minus the `exclude` patterns |
-| Pattern forms | `~ALL` (every branch), `~DEFAULT_BRANCH` (the repo default), any other pattern as an fnmatch over `refs/heads/<base>` |
+| Set of bases that draw a review | the union over every such ruleset: a base draws one when a ruleset's `conditions.ref_name.include` covers it and the same ruleset's `exclude` does not |
+| Pattern forms | `~ALL` (every branch), `~DEFAULT_BRANCH` (the repo default), any other pattern matched against `refs/heads/<base>` by `File.fnmatch` with `File::FNM_PATHNAME`, so `*` does not match `/` |
 | Re-review on a new head | the rule's `review_on_push` parameter |
 | Draft pull requests | the rule's `review_draft_pull_requests` parameter |
 
-Read a repo's own set with `gh api repos/<owner>/<repo>/rulesets`, then the detail of each `target: "branch"`, `enforcement: "active"` entry.
+Read a repo's own set with `gh api --paginate repos/<owner>/<repo>/rulesets`, then the detail of each `target: "branch"`, `enforcement: "active"` entry.
 
 The target set is per-repo configuration, not GitHub behaviour. In `vanillagreencom/kendex` it is ruleset `16519713`, "Copilot review for default branch", whose `conditions.ref_name.include` is `["~DEFAULT_BRANCH"]`. A pull request based on any branch other than `main` therefore draws no automatic review in this repo. A repo whose ruleset targets more branches reviews stacked pull requests.
 
@@ -29,4 +29,4 @@ Evidence for the manual route: probe pull request `vanillagreencom/kendex#2527`,
 
 ## What the waiter reports
 
-Orch's `approval-wait` resolves the same target set once per wait and matches the pull request's `baseRefName` against it. Reviewer silence on a base outside the set is reported as status `unreviewable` (exit 1), never the fail-open `proceeded`. Its JSON carries `base_ref`, `auto_review_targeted`, `auto_review_target_source` and `auto_review_targets`. Full contract: `approval-wait --help`. The stacked-chain sequence is orch's `references/gates.md` § Stacked pull requests.
+Orch's `approval-wait` resolves the same target set once per wait and matches the pull request's `baseRefName` against it. It compares `~ALL`, `~DEFAULT_BRANCH` and literal refs only. A set holding any glob pattern (`*`, `?`, `[` or `\`) is `unresolved`, and so is a set behind a failed ruleset read other than a permission denial. Reviewer silence on a base outside the set is reported as status `unreviewable` (exit 1), and on an `unresolved` set as `timeout`; neither is the fail-open `proceeded`. Its JSON carries `base_ref`, `auto_review_targeted`, `auto_review_target_source` and `auto_review_targets`. Full contract: `approval-wait --help`. The stacked-chain sequence is orch's `references/gates.md` § Stacked pull requests.

--- a/skills/orch/references/gates.md
+++ b/skills/orch/references/gates.md
@@ -41,7 +41,7 @@ Work the chain in this order:
 
    Then re-run the wait. It works on a base the ruleset does not target.
 
-2. Merge the bottom of the stack. GitHub retargets the next PR onto the new base, and a base inside the target set draws a review on its own.
+2. Merge the bottom of the stack. GitHub retargets the next PR onto the new base, but a retarget is not a documented review trigger: request the review by hand as in step 1, or push a new head where the rule's `review_on_push` is on, then re-run the wait.
 3. Fallback, only when the manual request draws nothing: close the PR and open a fresh one against the default branch. Close-and-open, never reopen — reopening re-arms the reviewer only on a PR it has already reviewed once, and does nothing for one it never reviewed.
 
 ## Waiter auth ladder

--- a/skills/orch/references/gates.md
+++ b/skills/orch/references/gates.md
@@ -18,7 +18,7 @@ The reviewer-gate settings — `PR_REVIEW_GATE`, `PR_REVIEW_CHECK`, `PR_REVIEW_O
 
 | Waiting on | Tool |
 |------------|------|
-| Reviewer verdict on one PR | `approval-wait` — statuses `approved`/`reviewed`/`changes_requested`/`comments`/`timeout`/`proceeded`/`error` |
+| Reviewer verdict on one PR | `approval-wait` — statuses `approved`/`reviewed`/`changes_requested`/`comments`/`timeout`/`proceeded`/`unreviewable`/`error` |
 | CI on one PR | `ci-wait` — verdicts `pass`/`fail`/`pending`/`none` |
 | Merge-queue / auto-merge outcome | `queue-wait` — the growing verdict set documented in its § Verdicts table |
 | Many PRs, long horizon | `pr-watch.sh` — § Multi-PR watching |
@@ -26,6 +26,23 @@ The reviewer-gate settings — `PR_REVIEW_GATE`, `PR_REVIEW_CHECK`, `PR_REVIEW_O
 Per-verdict routing lives in the workflows (`submit-pr.md` § 4, `merge-pr.md` § 5); each verdict's semantics live in that script's `--help`.
 
 A wait is a running waiter, never a session sitting at its prompt.
+
+## Stacked pull requests
+
+`approval-wait` returns `unreviewable` (exit 1) when the deadline passes with no reviewer evidence and the PR's base sits outside the automatic-review ruleset's target set. Nothing was going to arrive on its own. Which bases draw an automatic review is per-repo configuration, read from the repo's rulesets: the review-gate skill's `.agents/skills/review-gate/references/automatic-review.md`.
+
+Work the chain in this order:
+
+1. Request the review by hand on the stacked PR. This is the remedy, not a workaround:
+
+   ```bash
+   gh pr edit [PR_NUMBER] --add-reviewer @copilot
+   ```
+
+   Then re-run the wait. It works on a base the ruleset does not target.
+
+2. Merge the bottom of the stack. GitHub retargets the next PR onto the new base, and a base inside the target set draws a review on its own.
+3. Fallback, only when the manual request draws nothing: close the PR and open a fresh one against the default branch. Close-and-open, never reopen — reopening re-arms the reviewer only on a PR it has already reviewed once, and does nothing for one it never reviewed.
 
 ## Waiter auth ladder
 

--- a/skills/orch/references/gates.md
+++ b/skills/orch/references/gates.md
@@ -29,7 +29,7 @@ A wait is a running waiter, never a session sitting at its prompt.
 
 ## Stacked pull requests
 
-`approval-wait` returns `unreviewable` (exit 1) when the deadline passes with no reviewer evidence and the PR's base sits outside the automatic-review ruleset's target set. Nothing was going to arrive on its own. Which bases draw an automatic review is per-repo configuration, read from the repo's rulesets: the review-gate skill's `.agents/skills/review-gate/references/automatic-review.md`.
+`approval-wait` returns `unreviewable` (exit 1) when the deadline passes with no reviewer evidence and the PR's base sits outside the target set of the repo's automatic-review rulesets. Nothing was going to arrive on its own. Which bases draw an automatic review is per-repo configuration, read from the repo's rulesets: the review-gate skill's `.agents/skills/review-gate/references/automatic-review.md`.
 
 Work the chain in this order:
 

--- a/skills/orch/scripts/approval-wait
+++ b/skills/orch/scripts/approval-wait
@@ -222,15 +222,22 @@ and the head is re-confirmed once more at the deadline itself, so proceed
 never bypasses a live gate and never attests a stale head.
 
 Automatic review and the base branch: GitHub's automatic reviewer is armed
-by an ACTIVE BRANCH RULESET carrying a rule of type copilot_code_review, and
-that ruleset's conditions.ref_name is the set of bases that draw one. It is
-per-repo configuration, never a GitHub constant. The set is resolved ONCE
-before the poll loop, from the repo's rulesets (source "ruleset"); when that
-read fails or no ruleset carries the rule, the repo's default branch is the
-whole set (source "default_branch"); when neither can be read the set is
-"unresolved". The PR's baseRefName is matched against it — "~ALL" matches
-any base, "~DEFAULT_BRANCH" the repo default, any other pattern is an
-fnmatch over refs/heads/<base>, and an exclude pattern beats an include.
+by any ACTIVE BRANCH RULESET carrying a rule of type copilot_code_review. A
+base draws one when such a ruleset's conditions.ref_name includes it and that
+same ruleset does not exclude it, so the target set is the union over those
+rulesets. It is per-repo configuration, never a GitHub constant. The set is
+resolved ONCE before the poll loop, from every page of the repo's ruleset
+listing and each active branch ruleset's detail (source "ruleset"). The
+repo's default branch is the whole set (source "default_branch") only when
+the listing is refused with HTTP 403 or 404 that is not a rate limit, or
+reads completely with no ruleset carrying the rule. Any other failed listing
+or detail read leaves the set "unresolved". The PR's baseRefName is matched
+against it: "~ALL" matches any base, "~DEFAULT_BRANCH" the repo default, and
+any other pattern must equal refs/heads/<base> exactly. GitHub matches a
+pattern with File.fnmatch under File::FNM_PATHNAME, where * does not match /;
+approval-wait does not reproduce that, so a pattern holding *, ?, [ or \
+leaves the set "unresolved", as does ~DEFAULT_BRANCH when the default branch
+cannot be read.
 
 A base outside that set draws no automatic review, so reviewer silence there
 is structural rather than a slow reviewer: the deadline reports
@@ -266,7 +273,7 @@ JSON output (always when --json):
     "base_ref": <string>,         # the PR's base branch
     "auto_review_targeted": <bool>,  # the base draws an automatic review
     "auto_review_target_source": "ruleset" | "default_branch" | "unresolved",
-    "auto_review_targets": [<string>],  # the ref_name include patterns
+    "auto_review_targets": [<string>],  # union of the ref_name include patterns
     "transient_api_errors": <int>,  # only when > 0
     "error": <string>             # only when status == "error"
   }
@@ -721,80 +728,132 @@ OWNER="${REPO%%/*}"
 REPO_NAME="${REPO#*/}"
 
 # --- automatic-review target set (resolved ONCE, before the poll loop) ---
-# GitHub's automatic reviewer is armed by an ACTIVE BRANCH RULESET carrying a
-# rule of type copilot_code_review; that ruleset's conditions.ref_name is the
-# set of bases that draw one. Which bases those are is per-repo configuration,
-# not a GitHub constant, so it is read rather than assumed. A PR based outside
-# the set draws no automatic review at all, which is why the deadline separates
-# that structural silence ("unreviewable") from a reviewer who merely did not
-# show ("timeout"/"proceeded").
+# GitHub's automatic reviewer is armed by any ACTIVE BRANCH RULESET carrying a
+# rule of type copilot_code_review, and the set of bases that draw one is the
+# union of those rulesets' conditions.ref_name. Which bases those are is
+# per-repo configuration, not a GitHub constant, so it is read rather than
+# assumed. A PR based outside the set draws no automatic review at all, which is
+# why the deadline separates that structural silence ("unreviewable") from a
+# reviewer who merely did not show ("timeout"/"proceeded").
+# AUTO_REVIEW_INCLUDE and AUTO_REVIEW_EXCLUDE hold one
+# "<ruleset-id><TAB><pattern>" record per line, so an exclude stays bound to the
+# ruleset that declares it.
+
+# Read every active branch ruleset carrying copilot_code_review into
+# AUTO_REVIEW_INCLUDE / AUTO_REVIEW_EXCLUDE. Returns 0 when at least one does;
+# 2 when no ruleset rule is visible, because the listing was refused as a
+# permission denial (HTTP 403 or 404 that is not a rate limit) or read
+# completely with no ruleset carrying the rule; 1 on every other failure, which
+# leaves the set unjudgeable. It classifies through gh_failure_is_transient, so
+# it runs only after that function is defined.
+read_auto_review_rules() {
+  local rulesets ruleset_ids ruleset_id detail carries includes excludes
+  local list_status=0 err_text found=false
+  AUTO_REVIEW_INCLUDE=""
+  AUTO_REVIEW_EXCLUDE=""
+  : > "$GH_ERR_FILE"
+  rulesets=$(gh api "repos/$REPO/rulesets" --paginate 2>"$GH_ERR_FILE") || list_status=$?
+  if [ "$list_status" -ne 0 ]; then
+    err_text=$(cat "$GH_ERR_FILE" 2>/dev/null) || err_text=""
+    case "$err_text" in
+      *"HTTP 403"*|*"HTTP 404"*) gh_failure_is_transient "$list_status" || return 2 ;;
+    esac
+    return 1
+  fi
+  # The listing carries no rules or conditions, so every active branch ruleset
+  # is opened. A zero-byte or non-list answer is a failed read, never an empty
+  # listing.
+  ruleset_ids=$(jq -r -s 'if length > 0 and all(.[]; type == "array")
+    then add | .[] | select(.target == "branch" and .enforcement == "active") | .id
+    else error("the ruleset listing is not a set of pages") end' <<<"$rulesets" 2>/dev/null) || return 1
+  while IFS= read -r ruleset_id; do
+    [ -n "$ruleset_id" ] || continue
+    detail=$(gh api "repos/$REPO/rulesets/$ruleset_id" 2>/dev/null) || return 1
+    carries=$(jq -r 'any(.rules[]?; .type == "copilot_code_review")' <<<"$detail" 2>/dev/null) || return 1
+    [ "$carries" = true ] || continue
+    includes=$(jq -r --arg id "$ruleset_id" '.conditions.ref_name.include[]? | "\($id)\t\(.)"' <<<"$detail") || return 1
+    excludes=$(jq -r --arg id "$ruleset_id" '.conditions.ref_name.exclude[]? | "\($id)\t\(.)"' <<<"$detail") || return 1
+    AUTO_REVIEW_INCLUDE="$AUTO_REVIEW_INCLUDE$includes"$'\n'
+    AUTO_REVIEW_EXCLUDE="$AUTO_REVIEW_EXCLUDE$excludes"$'\n'
+    found=true
+  done <<<"$ruleset_ids"
+  [ "$found" = true ] || return 2
+}
+
 resolve_auto_review_targets() {
-  local rulesets ruleset_ids ruleset_id detail
+  local rules_status=0 pattern
   DEFAULT_BRANCH=$(gh api "repos/$REPO" -q '.default_branch' 2>/dev/null) || DEFAULT_BRANCH=""
-  rulesets=$(gh api "repos/$REPO/rulesets" 2>/dev/null) || rulesets=""
-  if [ -n "$rulesets" ] && jq -e 'type == "array"' >/dev/null 2>&1 <<<"$rulesets"; then
-    # The listing carries no rules or conditions, so each active branch ruleset
-    # is opened until one carries the copilot_code_review rule.
-    ruleset_ids=$(jq -r '.[] | select(.target == "branch" and .enforcement == "active") | .id' <<<"$rulesets") || ruleset_ids=""
-    while IFS= read -r ruleset_id; do
-      [ -n "$ruleset_id" ] || continue
-      detail=$(gh api "repos/$REPO/rulesets/$ruleset_id" 2>/dev/null) || continue
-      jq -e 'any(.rules[]?; .type == "copilot_code_review")' >/dev/null 2>&1 <<<"$detail" || continue
-      AUTO_REVIEW_INCLUDE=$(jq -r '.conditions.ref_name.include[]? // empty' <<<"$detail") || AUTO_REVIEW_INCLUDE=""
-      AUTO_REVIEW_EXCLUDE=$(jq -r '.conditions.ref_name.exclude[]? // empty' <<<"$detail") || AUTO_REVIEW_EXCLUDE=""
-      AUTO_REVIEW_SOURCE="ruleset"
-      break
-    done <<<"$ruleset_ids"
-  fi
-  if [ "$AUTO_REVIEW_SOURCE" = "unresolved" ] && [ -n "$DEFAULT_BRANCH" ]; then
-    # No readable ruleset rule: the default branch is the whole target set,
-    # which is what the shipped "Copilot review for default branch" shape means.
-    AUTO_REVIEW_INCLUDE="~DEFAULT_BRANCH"
-    AUTO_REVIEW_EXCLUDE=""
-    AUTO_REVIEW_SOURCE="default_branch"
-  fi
-  # ~DEFAULT_BRANCH names a branch this run could not read, so the set cannot be
-  # judged. Unresolved is reported as unresolved rather than matched as a miss:
-  # a failed read must not manufacture an "unreviewable" verdict.
-  if [ -z "$DEFAULT_BRANCH" ] && [[ "$AUTO_REVIEW_INCLUDE$AUTO_REVIEW_EXCLUDE" == *'~DEFAULT_BRANCH'* ]]; then
-    AUTO_REVIEW_SOURCE="unresolved"
+  read_auto_review_rules || rules_status=$?
+  case "$rules_status" in
+    0) AUTO_REVIEW_SOURCE="ruleset" ;;
+    2)
+      # No ruleset rule is visible: the default branch is the whole target set,
+      # which is what the shipped "Copilot review for default branch" shape means.
+      AUTO_REVIEW_INCLUDE=$(printf 'default_branch\t~DEFAULT_BRANCH')
+      AUTO_REVIEW_EXCLUDE=""
+      AUTO_REVIEW_SOURCE="default_branch"
+      ;;
+    *)
+      # 1, or any status the reader does not define: a failed read decides nothing.
+      AUTO_REVIEW_SOURCE="unresolved"
+      ;;
+  esac
+  # A set this run cannot judge exactly is reported unresolved rather than
+  # matched as a hit or a miss. ~DEFAULT_BRANCH names a branch this run could not
+  # read. GitHub matches every other pattern with File.fnmatch under
+  # File::FNM_PATHNAME, where * does not cross / and a shell pattern's * does, so
+  # only a literal ref is compared and a pattern carrying glob syntax is not.
+  while IFS=$'\t' read -r _ pattern; do
+    case "$pattern" in
+      '~DEFAULT_BRANCH') [ -n "$DEFAULT_BRANCH" ] || AUTO_REVIEW_SOURCE="unresolved" ;;
+      *'*'*|*'?'*|*'['*|*'\'*) AUTO_REVIEW_SOURCE="unresolved" ;;
+    esac
+  done <<<"$AUTO_REVIEW_INCLUDE"$'\n'"$AUTO_REVIEW_EXCLUDE"
+  if [ "$AUTO_REVIEW_SOURCE" = "unresolved" ]; then
     AUTO_REVIEW_INCLUDE=""
     AUTO_REVIEW_EXCLUDE=""
   fi
-  AUTO_REVIEW_TARGETS_JSON=$(printf '%s' "$AUTO_REVIEW_INCLUDE" \
-    | jq -R -s 'split("\n") | map(select(length > 0))') || AUTO_REVIEW_TARGETS_JSON="[]"
-  AUTO_REVIEW_TARGETS_TEXT=$(printf '%s' "$AUTO_REVIEW_INCLUDE" | tr '\n' ' ') || AUTO_REVIEW_TARGETS_TEXT=""
-  AUTO_REVIEW_TARGETS_TEXT="${AUTO_REVIEW_TARGETS_TEXT% }"
+  AUTO_REVIEW_TARGETS_JSON=$(jq -R -s 'split("\n") | map(select(length > 0) | sub("^[^\t]*\t"; ""))
+    | reduce .[] as $pattern ([]; if any(.[]; . == $pattern) then . else . + [$pattern] end)' \
+    <<<"$AUTO_REVIEW_INCLUDE") || AUTO_REVIEW_TARGETS_JSON="[]"
+  AUTO_REVIEW_TARGETS_TEXT=$(jq -r 'join(" ")' <<<"$AUTO_REVIEW_TARGETS_JSON") || AUTO_REVIEW_TARGETS_TEXT=""
 }
 
 # Does one ref_name pattern cover this base? "~ALL" covers every base,
-# "~DEFAULT_BRANCH" the repo default, and any other pattern is an fnmatch over
-# the base's full ref, which is how a ruleset ref condition is spelled.
+# "~DEFAULT_BRANCH" the repo default, and any other pattern is a literal ref
+# compared with the base's full ref: resolution leaves a set holding a glob
+# unresolved, so no glob reaches this point.
 auto_review_pattern_matches() { # PATTERN BASE
   case "$1" in
     '~ALL') return 0 ;;
     '~DEFAULT_BRANCH') [ -n "$DEFAULT_BRANCH" ] && [ "$2" = "$DEFAULT_BRANCH" ] ;;
-    *) case "refs/heads/$2" in $1) return 0 ;; *) return 1 ;; esac ;;
+    *) [ "$1" = "refs/heads/$2" ] ;;
   esac
 }
 
-# Whether the automatic reviewer is armed for BASE. An exclude pattern beats an
-# include, matching GitHub's own ruleset evaluation.
-auto_review_targets_base() { # BASE
-  local pattern
-  [ -n "$1" ] || return 1
-  while IFS= read -r pattern; do
-    [ -n "$pattern" ] || continue
-    if auto_review_pattern_matches "$pattern" "$1"; then return 1; fi
+# Whether RULESET_ID's own exclude patterns cover BASE.
+auto_review_ruleset_excludes() { # RULESET_ID BASE
+  local ruleset_id pattern
+  while IFS=$'\t' read -r ruleset_id pattern; do
+    [ "$ruleset_id" = "$1" ] || continue
+    if auto_review_pattern_matches "$pattern" "$2"; then return 0; fi
   done <<<"$AUTO_REVIEW_EXCLUDE"
-  while IFS= read -r pattern; do
-    [ -n "$pattern" ] || continue
-    if auto_review_pattern_matches "$pattern" "$1"; then return 0; fi
-  done <<<"$AUTO_REVIEW_INCLUDE"
   return 1
 }
 
-resolve_auto_review_targets
+# Whether the automatic reviewer is armed for BASE: some ruleset includes it
+# and that same ruleset does not exclude it. An exclude narrows only its own
+# ruleset, since GitHub evaluates each ruleset on its own.
+auto_review_targets_base() { # BASE
+  local ruleset_id pattern
+  [ -n "$1" ] || return 1
+  while IFS=$'\t' read -r ruleset_id pattern; do
+    [ -n "$ruleset_id" ] || continue
+    auto_review_pattern_matches "$pattern" "$1" || continue
+    auto_review_ruleset_excludes "$ruleset_id" "$1" || return 0
+  done <<<"$AUTO_REVIEW_INCLUDE"
+  return 1
+}
 
 # The reviewThreads walk is lib/review-threads.sh's, shared with queue-wait's
 # late-findings guard so the waiter and the guard cannot disagree about what an
@@ -875,6 +934,8 @@ read_base_ref() {
     last_auto_review_targeted=false
   fi
 }
+
+resolve_auto_review_targets
 
 update_elapsed
 while true; do

--- a/skills/orch/scripts/approval-wait
+++ b/skills/orch/scripts/approval-wait
@@ -221,6 +221,25 @@ change during this wait. A mid-wait force-push falls back to "timeout",
 and the head is re-confirmed once more at the deadline itself, so proceed
 never bypasses a live gate and never attests a stale head.
 
+Automatic review and the base branch: GitHub's automatic reviewer is armed
+by an ACTIVE BRANCH RULESET carrying a rule of type copilot_code_review, and
+that ruleset's conditions.ref_name is the set of bases that draw one. It is
+per-repo configuration, never a GitHub constant. The set is resolved ONCE
+before the poll loop, from the repo's rulesets (source "ruleset"); when that
+read fails or no ruleset carries the rule, the repo's default branch is the
+whole set (source "default_branch"); when neither can be read the set is
+"unresolved". The PR's baseRefName is matched against it — "~ALL" matches
+any base, "~DEFAULT_BRANCH" the repo default, any other pattern is an
+fnmatch over refs/heads/<base>, and an exclude pattern beats an include.
+
+A base outside that set draws no automatic review, so reviewer silence there
+is structural rather than a slow reviewer: the deadline reports
+"unreviewable" (exit 1) and never degrades to "proceeded", whatever
+PR_REVIEW_ON_TIMEOUT says. A review can still be requested by hand on such a
+base (gh pr edit <PR#> --add-reviewer @copilot), which is why the wait runs
+its full budget rather than returning early. An "unresolved" target set
+likewise never proceeds: it reports "timeout".
+
 Transient GitHub API failures (kendex#748) — HTTP 5xx, HTTP 429, timeout,
 transport error — are retried with doubling backoff (capped at 8x) inside
 the existing max_wait budget and reported as a transient_api_errors count;
@@ -230,7 +249,7 @@ a fully successful poll resets the backoff. Non-transient failures (HTTP
 JSON output (always when --json):
   {
     "status": "approved" | "reviewed" | "changes_requested" | "comments"
-              | "timeout" | "proceeded" | "error",
+              | "timeout" | "proceeded" | "unreviewable" | "error",
     "review_decision": <string>,  # raw reviewDecision ("" when unset)
     "approvals": <int>,           # reviewers whose latest review is APPROVED
     "changes_requested": <int>,   # reviewers at CHANGES_REQUESTED
@@ -244,6 +263,10 @@ JSON output (always when --json):
                                   # (PR_REVIEW_CHECK success)
     "review_evidence_surface": <string>,  # alongside review_evidence
                                   # "check": "check_run" or "status"
+    "base_ref": <string>,         # the PR's base branch
+    "auto_review_targeted": <bool>,  # the base draws an automatic review
+    "auto_review_target_source": "ruleset" | "default_branch" | "unresolved",
+    "auto_review_targets": [<string>],  # the ref_name include patterns
     "transient_api_errors": <int>,  # only when > 0
     "error": <string>             # only when status == "error"
   }
@@ -259,8 +282,9 @@ selected). Full ladder: orch DEVELOPMENT.md.
 Exit codes:
   0  approved (approval mode) / reviewed (review mode) / proceeded
      (deadline reached under PR_REVIEW_ON_TIMEOUT=proceed)
-  1  changes requested, unresolved comments pending, timeout, or a
-     non-auth error
+  1  changes requested, unresolved comments pending, timeout,
+     unreviewable (no automatic reviewer targets the PR's base and none
+     arrived), or a non-auth error
   2  usage error: missing or empty argument, invalid --mode value, or
      unknown flag
   3  hard GitHub auth/CLI failure (matches ci-wait and queue-wait)
@@ -451,6 +475,17 @@ last_changes=0
 last_unresolved=0
 last_head_sha=""
 last_reviews_at_head=0
+last_base_ref=""
+# The automatic-review target set and this PR's standing against it. Declared
+# beside the other snapshot state because emit_error runs on the pre-repo
+# failure paths, before resolve_auto_review_targets can fill them in.
+last_auto_review_targeted=false
+AUTO_REVIEW_SOURCE="unresolved"
+AUTO_REVIEW_INCLUDE=""
+AUTO_REVIEW_EXCLUDE=""
+AUTO_REVIEW_TARGETS_JSON="[]"
+AUTO_REVIEW_TARGETS_TEXT=""
+DEFAULT_BRANCH=""
 # Approval mode only: non-author, non-dismissed latest reviews of ANY state
 # (COMMENTED included). Distinguishes "a reviewer engaged but did not approve"
 # from "no reviewer showed at all", so the PR_REVIEW_ON_TIMEOUT=proceed degrade
@@ -499,7 +534,7 @@ run_approved_gate() {
 # Emit the final machine-readable result on stdout. Every exit path routes
 # through here (or emit_error) so the script can never finish silently.
 #   status: approved | reviewed | changes_requested | comments | timeout
-#         | proceeded | error
+#         | proceeded | unreviewable | error
 emit_result() {
   local status="$1" error_msg="${2:-}" mode_fields
   update_elapsed
@@ -525,6 +560,10 @@ emit_result() {
     jq -n \
       --arg s "$status" \
       --arg decision "$last_review_decision" \
+      --arg base_ref "$last_base_ref" \
+      --argjson auto_targeted "$last_auto_review_targeted" \
+      --arg auto_source "$AUTO_REVIEW_SOURCE" \
+      --argjson auto_targets "$AUTO_REVIEW_TARGETS_JSON" \
       --argjson approvals "$last_approvals" \
       --argjson changes "$last_changes" \
       --argjson unresolved "$last_unresolved" \
@@ -538,7 +577,11 @@ emit_result() {
         approvals: $approvals,
         changes_requested: $changes,
         unresolved_count: $unresolved,
-        elapsed_seconds: $elapsed
+        elapsed_seconds: $elapsed,
+        base_ref: $base_ref,
+        auto_review_targeted: $auto_targeted,
+        auto_review_target_source: $auto_source,
+        auto_review_targets: $auto_targets
       } + $mode_fields
         + (if $transient > 0 then {transient_api_errors: $transient} else {} end)
         + (if $error == "" then {} else {error: $error} end)' || return $?
@@ -578,6 +621,9 @@ emit_result() {
       else
         echo "Approval: $last_unresolved unresolved review thread(s) pending triage, no approval verdict yet"
       fi
+      ;;
+    unreviewable)
+      echo "No automatic review for base '${last_base_ref:-unknown}' after ${elapsed}s: the automatic-review target set (${AUTO_REVIEW_TARGETS_TEXT:-none}, source: $AUTO_REVIEW_SOURCE) does not cover it. Request one with: gh pr edit $PR_NUM --add-reviewer @copilot"
       ;;
     timeout)
       if [[ "$MODE" == "review" ]]; then
@@ -674,6 +720,83 @@ fi
 OWNER="${REPO%%/*}"
 REPO_NAME="${REPO#*/}"
 
+# --- automatic-review target set (resolved ONCE, before the poll loop) ---
+# GitHub's automatic reviewer is armed by an ACTIVE BRANCH RULESET carrying a
+# rule of type copilot_code_review; that ruleset's conditions.ref_name is the
+# set of bases that draw one. Which bases those are is per-repo configuration,
+# not a GitHub constant, so it is read rather than assumed. A PR based outside
+# the set draws no automatic review at all, which is why the deadline separates
+# that structural silence ("unreviewable") from a reviewer who merely did not
+# show ("timeout"/"proceeded"). The ruleset cannot change the answer mid-wait,
+# so this costs two reads, not two per poll.
+resolve_auto_review_targets() {
+  local rulesets ruleset_ids ruleset_id detail
+  DEFAULT_BRANCH=$(gh api "repos/$REPO" -q '.default_branch' 2>/dev/null) || DEFAULT_BRANCH=""
+  rulesets=$(gh api "repos/$REPO/rulesets" 2>/dev/null) || rulesets=""
+  if [ -n "$rulesets" ] && jq -e 'type == "array"' >/dev/null 2>&1 <<<"$rulesets"; then
+    # The listing carries no rules or conditions, so each active branch ruleset
+    # is opened until one carries the copilot_code_review rule.
+    ruleset_ids=$(jq -r '.[] | select(.target == "branch" and .enforcement == "active") | .id' <<<"$rulesets") || ruleset_ids=""
+    while IFS= read -r ruleset_id; do
+      [ -n "$ruleset_id" ] || continue
+      detail=$(gh api "repos/$REPO/rulesets/$ruleset_id" 2>/dev/null) || continue
+      jq -e 'any(.rules[]?; .type == "copilot_code_review")' >/dev/null 2>&1 <<<"$detail" || continue
+      AUTO_REVIEW_INCLUDE=$(jq -r '.conditions.ref_name.include[]? // empty' <<<"$detail") || AUTO_REVIEW_INCLUDE=""
+      AUTO_REVIEW_EXCLUDE=$(jq -r '.conditions.ref_name.exclude[]? // empty' <<<"$detail") || AUTO_REVIEW_EXCLUDE=""
+      AUTO_REVIEW_SOURCE="ruleset"
+      break
+    done <<<"$ruleset_ids"
+  fi
+  if [ "$AUTO_REVIEW_SOURCE" = "unresolved" ] && [ -n "$DEFAULT_BRANCH" ]; then
+    # No readable ruleset rule: the default branch is the whole target set,
+    # which is what the shipped "Copilot review for default branch" shape means.
+    AUTO_REVIEW_INCLUDE="~DEFAULT_BRANCH"
+    AUTO_REVIEW_EXCLUDE=""
+    AUTO_REVIEW_SOURCE="default_branch"
+  fi
+  # ~DEFAULT_BRANCH names a branch this run could not read, so the set cannot be
+  # judged. Unresolved is reported as unresolved rather than matched as a miss:
+  # a failed read must not manufacture an "unreviewable" verdict.
+  if [ -z "$DEFAULT_BRANCH" ] && [[ "$AUTO_REVIEW_INCLUDE$AUTO_REVIEW_EXCLUDE" == *'~DEFAULT_BRANCH'* ]]; then
+    AUTO_REVIEW_SOURCE="unresolved"
+    AUTO_REVIEW_INCLUDE=""
+    AUTO_REVIEW_EXCLUDE=""
+  fi
+  AUTO_REVIEW_TARGETS_JSON=$(printf '%s' "$AUTO_REVIEW_INCLUDE" \
+    | jq -R -s 'split("\n") | map(select(length > 0))') || AUTO_REVIEW_TARGETS_JSON="[]"
+  AUTO_REVIEW_TARGETS_TEXT=$(printf '%s' "$AUTO_REVIEW_INCLUDE" | tr '\n' ' ') || AUTO_REVIEW_TARGETS_TEXT=""
+  AUTO_REVIEW_TARGETS_TEXT="${AUTO_REVIEW_TARGETS_TEXT% }"
+}
+
+# Does one ref_name pattern cover this base? "~ALL" covers every base,
+# "~DEFAULT_BRANCH" the repo default, and any other pattern is an fnmatch over
+# the base's full ref, which is how a ruleset ref condition is spelled.
+auto_review_pattern_matches() { # PATTERN BASE
+  case "$1" in
+    '~ALL') return 0 ;;
+    '~DEFAULT_BRANCH') [ -n "$DEFAULT_BRANCH" ] && [ "$2" = "$DEFAULT_BRANCH" ] ;;
+    *) case "refs/heads/$2" in $1) return 0 ;; *) return 1 ;; esac ;;
+  esac
+}
+
+# Whether the automatic reviewer is armed for BASE. An exclude pattern beats an
+# include, matching GitHub's own ruleset evaluation.
+auto_review_targets_base() { # BASE
+  local pattern
+  [ -n "$1" ] || return 1
+  while IFS= read -r pattern; do
+    [ -n "$pattern" ] || continue
+    if auto_review_pattern_matches "$pattern" "$1"; then return 1; fi
+  done <<<"$AUTO_REVIEW_EXCLUDE"
+  while IFS= read -r pattern; do
+    [ -n "$pattern" ] || continue
+    if auto_review_pattern_matches "$pattern" "$1"; then return 0; fi
+  done <<<"$AUTO_REVIEW_INCLUDE"
+  return 1
+}
+
+resolve_auto_review_targets
+
 # The reviewThreads walk is lib/review-threads.sh's, shared with queue-wait's
 # late-findings guard so the waiter and the guard cannot disagree about what an
 # open thread is. gh's stderr lands in GH_ERR_FILE for the transient/terminal
@@ -742,6 +865,18 @@ confirm_head_unchanged() {
   [ -n "$cur" ] && [ "$cur" = "$last_head_sha" ]
 }
 
+# Record the base this poll saw and whether the automatic reviewer targets it.
+# The base rides along on the poll's own pr view call, so a mid-wait retarget
+# (GitHub moves a stacked PR's base when its base branch merges) is picked up.
+read_base_ref() {
+  last_base_ref=$(jq -r '.baseRefName // ""' <<<"$view_json")
+  if auto_review_targets_base "$last_base_ref"; then
+    last_auto_review_targeted=true
+  else
+    last_auto_review_targeted=false
+  fi
+}
+
 update_elapsed
 while true; do
   if [ "$MODE" = "review" ]; then
@@ -749,7 +884,7 @@ while true; do
     # head, and only reviews of the CURRENT head satisfy the gate) ---
     view_status=0
     set +e
-    view_json=$(gh pr view "$PR_NUM" --repo "$REPO" --json headRefOid,author 2>"$GH_ERR_FILE")
+    view_json=$(gh pr view "$PR_NUM" --repo "$REPO" --json headRefOid,author,baseRefName 2>"$GH_ERR_FILE")
     view_status=$?
     set -e
     if [ "$view_status" -ne 0 ] || ! jq -e 'type == "object"' >/dev/null 2>&1 <<<"$view_json"; then
@@ -763,6 +898,7 @@ while true; do
     fi
     last_head_sha=$(jq -r '.headRefOid // ""' <<<"$view_json")
     pr_author=$(jq -r '.author.login // ""' <<<"$view_json")
+    read_base_ref
 
     # --- submitted reviews snapshot (REST carries commit_id; latestReviews
     # does not, so head pinning needs the pulls/reviews listing). Captured in
@@ -901,7 +1037,7 @@ while true; do
     # bookkeeping the proceed guard reads) ---
     view_status=0
     set +e
-    view_json=$(gh pr view "$PR_NUM" --repo "$REPO" --json reviewDecision,latestReviews,headRefOid,author 2>"$GH_ERR_FILE")
+    view_json=$(gh pr view "$PR_NUM" --repo "$REPO" --json reviewDecision,latestReviews,headRefOid,author,baseRefName 2>"$GH_ERR_FILE")
     view_status=$?
     set -e
     if [ "$view_status" -ne 0 ] || ! jq -e 'type == "object"' >/dev/null 2>&1 <<<"$view_json"; then
@@ -917,6 +1053,7 @@ while true; do
     last_review_decision=$(jq -r '.reviewDecision // ""' <<<"$view_json")
     last_head_sha=$(jq -r '.headRefOid // ""' <<<"$view_json")
     pr_author=$(jq -r '.author.login // ""' <<<"$view_json")
+    read_base_ref
     # latestReviews already holds the latest review per reviewer; count formal
     # verdict states only. COMMENTED/DISMISSED reviews neither approve nor block.
     last_approvals=$(jq '[.latestReviews[]? | select(.state == "APPROVED")] | length' <<<"$view_json")
@@ -1023,15 +1160,38 @@ done
 #     START_TIME, so a force-push near MAX_WAIT would otherwise proceed seconds
 #     after the new commit appeared, before the reviewer could re-review it;
 #     fall back to timeout so the caller re-waits on the now-stable head.
+#   - a readable automatic-review target set that covers this PR's base. The
+#     two cases that fails are handled below.
 # The caller records "proceeded" as a reviewer-down override; CI and the
 # comment-hygiene gate still apply.
-if [ "$ON_TIMEOUT" = "proceed" ] && [ "$last_unresolved" -eq 0 ] \
-  && [ "$last_reviews_present" -eq 0 ] && [ "$head_changed_during_wait" = false ] \
+reviewer_silent=false
+if [ "$last_unresolved" -eq 0 ] && [ "$last_reviews_present" -eq 0 ]; then
+  reviewer_silent=true
+fi
+
+# Silence over a base no automatic-review ruleset targets is not a reviewer who
+# failed to show — nothing was ever going to arrive on its own. That is its own
+# verdict, exit 1, whatever PR_REVIEW_ON_TIMEOUT says: proceed is the one
+# fail-open path this script has, and a structurally impossible wait must never
+# reach it. The wait still spends its budget rather than returning early,
+# because a review CAN be requested by hand on such a base and may land during
+# it. An unresolved target set is not a miss: it falls through to the timeout
+# below, since a failed read must not manufacture either verdict.
+if [ "$reviewer_silent" = true ] && [ "$AUTO_REVIEW_SOURCE" != "unresolved" ] \
+  && [ "$last_auto_review_targeted" = false ]; then
+  emit_result "unreviewable"
+  exit 1
+fi
+
+if [ "$ON_TIMEOUT" = "proceed" ] && [ "$reviewer_silent" = true ] \
+  && [ "$AUTO_REVIEW_SOURCE" != "unresolved" ] \
+  && [ "$head_changed_during_wait" = false ] \
   && confirm_head_unchanged; then
   emit_result "proceeded"
   exit 0
 fi
-# Either not a proceed, or the head moved in the final window (confirm failed):
-# report timeout so the caller re-waits on the current head.
+# Either not a proceed, the target set could not be read, or the head moved in
+# the final window (confirm failed): report timeout so the caller re-waits on
+# the current head.
 emit_result "timeout"
 exit 1

--- a/skills/orch/scripts/approval-wait
+++ b/skills/orch/scripts/approval-wait
@@ -727,8 +727,7 @@ REPO_NAME="${REPO#*/}"
 # not a GitHub constant, so it is read rather than assumed. A PR based outside
 # the set draws no automatic review at all, which is why the deadline separates
 # that structural silence ("unreviewable") from a reviewer who merely did not
-# show ("timeout"/"proceeded"). The ruleset cannot change the answer mid-wait,
-# so this costs two reads, not two per poll.
+# show ("timeout"/"proceeded").
 resolve_auto_review_targets() {
   local rulesets ruleset_ids ruleset_id detail
   DEFAULT_BRANCH=$(gh api "repos/$REPO" -q '.default_branch' 2>/dev/null) || DEFAULT_BRANCH=""

--- a/skills/orch/tests/approval_wait.sh
+++ b/skills/orch/tests/approval_wait.sh
@@ -46,6 +46,12 @@ git -C "$TMP_ROOT/repo" config user.name Test
 #   "Review Bot" run (older failure + newer terminal run, plus an unrelated
 #   "Other Check") on headsha1 only; success_stale publishes it on oldsha
 #   only, so the current-head query finds nothing.
+#   Automatic-review target set: `api repos/owner/repo` answers the default
+#   branch (STUB_DEFAULT_BRANCH, or a 500 under STUB_DEFAULT_BRANCH_MODE=fail);
+#   `api repos/*/rulesets` and its detail answer the ruleset carrying the
+#   copilot_code_review rule — STUB_RULESET_INCLUDE / STUB_RULESET_EXCLUDE are
+#   its space-separated ref_name conditions, and STUB_RULESETS_MODE=none/fail
+#   drops the rule or the read. Every `pr view` payload carries STUB_BASE_REF.
 #   Commit statuses: `api repos/*/commits/<sha>/status` (combined status)
 #   answers likewise — STUB_STATUS_MODE=success_at_head/pending_at_head/
 #   failure_at_head/error_at_head publishes a "Review Bot" context (older
@@ -65,6 +71,16 @@ _stub_auth_ok() {
   fi
   [[ "${STUB_GH_DENY_KEYRING:-0}" == "1" ]] && return 1
   return 0
+}
+
+# A JSON array from space-separated words, for the ruleset ref_name conditions.
+_stub_json_array() { # WORDS
+  local out="" word
+  for word in $1; do
+    [[ -n "$out" ]] && out+=","
+    out+="\"$word\""
+  done
+  printf '[%s]' "$out"
 }
 
 _bump_count() {
@@ -102,6 +118,42 @@ case "${1:-}" in
     if [[ "${2:-}" == "user" ]]; then
       _stub_auth_ok || { echo "HTTP 401: Bad credentials" >&2; exit 1; }
       echo "test-user"
+      exit 0
+    fi
+    # Repository metadata: approval-wait reads only .default_branch, through
+    # gh's own -q filter, so the stub answers with the branch name.
+    if [[ "${2:-}" == "repos/owner/repo" ]]; then
+      _stub_auth_ok || { echo "HTTP 401: Bad credentials" >&2; exit 1; }
+      if [[ "${STUB_DEFAULT_BRANCH_MODE:-ok}" == "fail" ]]; then
+        echo "HTTP 500: Internal Server Error" >&2
+        exit 1
+      fi
+      printf '%s\n' "${STUB_DEFAULT_BRANCH:-main}"
+      exit 0
+    fi
+    # Ruleset listing: no rules or conditions, exactly as GitHub's does. The
+    # copilot_code_review rule lives on ruleset 1 alone, behind a tag ruleset, an
+    # inactive branch ruleset and a branch ruleset with only a deletion rule, so
+    # the walk must filter and step past all three to find it.
+    if [[ "${2:-}" == repos/*/rulesets ]]; then
+      _stub_auth_ok || { echo "HTTP 401: Bad credentials" >&2; exit 1; }
+      case "${STUB_RULESETS_MODE:-copilot}" in
+        fail) echo "HTTP 500: Internal Server Error" >&2; exit 1 ;;
+        none) echo '[{"id":2,"target":"branch","enforcement":"active"}]' ;;
+        *) echo '[{"id":3,"target":"tag","enforcement":"active"},{"id":4,"target":"branch","enforcement":"evaluate"},{"id":2,"target":"branch","enforcement":"active"},{"id":1,"target":"branch","enforcement":"active"}]' ;;
+      esac
+      exit 0
+    fi
+    if [[ "${2:-}" == repos/*/rulesets/* ]]; then
+      _stub_auth_ok || { echo "HTTP 401: Bad credentials" >&2; exit 1; }
+      ruleset_id="${2##*/}"
+      if [[ "$ruleset_id" != "1" ]]; then
+        printf '{"id":%s,"target":"branch","enforcement":"active","conditions":{"ref_name":{"include":["~ALL"],"exclude":[]}},"rules":[{"type":"deletion"}]}\n' "$ruleset_id"
+        exit 0
+      fi
+      printf '{"id":1,"target":"branch","enforcement":"active","conditions":{"ref_name":{"include":%s,"exclude":%s}},"rules":[{"type":"deletion"},{"type":"copilot_code_review","parameters":{"review_on_push":true,"review_draft_pull_requests":false}}]}\n' \
+        "$(_stub_json_array "${STUB_RULESET_INCLUDE:-~DEFAULT_BRANCH}")" \
+        "$(_stub_json_array "${STUB_RULESET_EXCLUDE:-}")"
       exit 0
     fi
     if [[ "${2:-}" == repos/*/pulls/*/reviews ]]; then
@@ -277,22 +329,22 @@ case "${1:-}" in
         fi
         case "$mode" in
           approved_decision)
-            echo '{"reviewDecision":"APPROVED","headRefOid":"headsha1","latestReviews":[{"author":{"login":"reviewer1"},"state":"APPROVED"}]}'
+            echo '{"reviewDecision":"APPROVED","headRefOid":"headsha1","baseRefName":"'"${STUB_BASE_REF:-main}"'","latestReviews":[{"author":{"login":"reviewer1"},"state":"APPROVED"}]}'
             ;;
           approved_latest)
-            echo '{"reviewDecision":"","headRefOid":"headsha1","latestReviews":[{"author":{"login":"reviewer1"},"state":"APPROVED"},{"author":{"login":"colleague"},"state":"COMMENTED"}]}'
+            echo '{"reviewDecision":"","headRefOid":"headsha1","baseRefName":"'"${STUB_BASE_REF:-main}"'","latestReviews":[{"author":{"login":"reviewer1"},"state":"APPROVED"},{"author":{"login":"colleague"},"state":"COMMENTED"}]}'
             ;;
           changes)
-            echo '{"reviewDecision":"","headRefOid":"headsha1","latestReviews":[{"author":{"login":"reviewer1"},"state":"CHANGES_REQUESTED"},{"author":{"login":"colleague"},"state":"APPROVED"}]}'
+            echo '{"reviewDecision":"","headRefOid":"headsha1","baseRefName":"'"${STUB_BASE_REF:-main}"'","latestReviews":[{"author":{"login":"reviewer1"},"state":"CHANGES_REQUESTED"},{"author":{"login":"colleague"},"state":"APPROVED"}]}'
             ;;
           commented_only)
-            echo '{"reviewDecision":"","headRefOid":"headsha1","latestReviews":[{"author":{"login":"reviewer1"},"state":"COMMENTED"}]}'
+            echo '{"reviewDecision":"","headRefOid":"headsha1","baseRefName":"'"${STUB_BASE_REF:-main}"'","latestReviews":[{"author":{"login":"reviewer1"},"state":"COMMENTED"}]}'
             ;;
           required_pending)
-            echo '{"reviewDecision":"REVIEW_REQUIRED","headRefOid":"headsha1","latestReviews":[{"author":{"login":"colleague"},"state":"APPROVED"}]}'
+            echo '{"reviewDecision":"REVIEW_REQUIRED","headRefOid":"headsha1","baseRefName":"'"${STUB_BASE_REF:-main}"'","latestReviews":[{"author":{"login":"colleague"},"state":"APPROVED"}]}'
             ;;
           none|*)
-            echo '{"reviewDecision":"","headRefOid":"headsha1","latestReviews":[]}'
+            echo '{"reviewDecision":"","headRefOid":"headsha1","baseRefName":"'"${STUB_BASE_REF:-main}"'","latestReviews":[]}'
             ;;
         esac
         exit 0
@@ -310,7 +362,7 @@ case "${1:-}" in
             head="headsha2"
           fi
         fi
-        printf '{"headRefOid":"%s","author":{"login":"pr-author"}}\n' "$head"
+        printf '{"headRefOid":"%s","author":{"login":"pr-author"},"baseRefName":"%s"}\n' "$head" "${STUB_BASE_REF:-main}"
         exit 0
       fi
     fi
@@ -373,6 +425,7 @@ count_lines() { # FILE — 0 when it was never written
 #   status_queries                  combined-status reads the stub served
 #   marker_posts                    commit-status POSTs the stub received
 #   outage_marker                   whether the JSON carries that field
+#   target_patterns   auto_review_targets joined, so a row compares as one word
 #   transient_errors_seen           transient_api_errors >= 1
 observe() {
   local got="" token name
@@ -390,6 +443,7 @@ observe() {
       marker_posts) got="$got marker_posts=$(count_lines "$RUN/marker-posts")" ;;
       outage_marker) got="$got outage_marker=$(json 'has("outage_marker")')" ;;
       transient_errors_seen) got="$got transient_errors_seen=$(json '.transient_api_errors >= 1')" ;;
+      target_patterns) got="$got target_patterns=$(json '.auto_review_targets | join(",")')" ;;
       *) got="$got $name=$(json ".$name")" ;;
     esac
   done
@@ -491,6 +545,29 @@ table "$REVIEW" \
   'a head that moved in the last-poll to emit window falls back to timeout||STUB_REVIEWS_MODE=none,STUB_CONFIRM_HEAD=headsha2,PR_REVIEW_ON_TIMEOUT=proceed|rc=1 status=timeout' \
   'a proceed posts no commit status and emits no outage marker||STUB_REVIEWS_MODE=none,PR_REVIEW_ON_TIMEOUT=proceed,PR_REVIEW_OUTAGE_CONTEXT=kendex-reviewer-outage|rc=0 status=proceeded marker_posts=0 outage_marker=false'
 
+echo "=== the automatic-review target set decides whether silence is a timeout or unreviewable ==="
+# The automatic reviewer is armed by an active branch ruleset carrying a
+# copilot_code_review rule, and its conditions.ref_name is the set of bases that
+# draw one. A base outside that set can never draw one, so silence there is
+# "unreviewable" (exit 1) under either on-timeout policy, never the fail-open
+# "proceeded" — while the same silence on a covered base still proceeds. A
+# reviewer that engaged is a timeout wherever the base sits, and a target set
+# that could not be read is a timeout too: a failed read decides nothing.
+# The include/exclude patterns are shaped input, one asserted row per shape.
+table "$REVIEW" \
+  'an untargeted base under proceed is unreviewable, not proceeded||STUB_REVIEWS_MODE=none,STUB_BASE_REF=stack-base,PR_REVIEW_ON_TIMEOUT=proceed|rc=1 status=unreviewable base_ref=stack-base auto_review_targeted=false auto_review_target_source=ruleset target_patterns=~DEFAULT_BRANCH' \
+  'an untargeted base under block is unreviewable, not a timeout||STUB_REVIEWS_MODE=none,STUB_BASE_REF=stack-base,PR_REVIEW_ON_TIMEOUT=block|rc=1 status=unreviewable' \
+  'control: the same silence on the targeted base still proceeds||STUB_REVIEWS_MODE=none,STUB_BASE_REF=main,PR_REVIEW_ON_TIMEOUT=proceed|rc=0 status=proceeded auto_review_targeted=true' \
+  'a reviewer engaged on an untargeted base is a timeout, not unreviewable||STUB_REVIEWS_MODE=none,STUB_CHECKS_MODE=failure_at_head,PR_REVIEW_CHECK=Review Bot,STUB_BASE_REF=stack-base,PR_REVIEW_ON_TIMEOUT=proceed|rc=1 status=timeout' \
+  'approval mode reads the same base and reaches the same verdict|1 1 3 --json|STUB_APPROVAL_MODE=none,STUB_BASE_REF=stack-base,PR_REVIEW_ON_TIMEOUT=proceed|rc=1 status=unreviewable base_ref=stack-base' \
+  'a ~ALL ruleset covers a stacked base||STUB_REVIEWS_MODE=none,STUB_RULESET_INCLUDE=~ALL,STUB_BASE_REF=stack-base,PR_REVIEW_ON_TIMEOUT=proceed|rc=0 status=proceeded auto_review_targeted=true target_patterns=~ALL' \
+  'a ref pattern is matched over the full ref||STUB_REVIEWS_MODE=none,STUB_RULESET_INCLUDE=refs/heads/stack-*,STUB_BASE_REF=stack-base,PR_REVIEW_ON_TIMEOUT=proceed|rc=0 status=proceeded auto_review_targeted=true' \
+  'an exclude pattern beats the include||STUB_REVIEWS_MODE=none,STUB_RULESET_INCLUDE=~ALL,STUB_RULESET_EXCLUDE=refs/heads/stack-*,STUB_BASE_REF=stack-base,PR_REVIEW_ON_TIMEOUT=proceed|rc=1 status=unreviewable auto_review_targeted=false' \
+  'no ruleset carries the rule, so the default branch is the whole set||STUB_REVIEWS_MODE=none,STUB_RULESETS_MODE=none,STUB_BASE_REF=stack-base,PR_REVIEW_ON_TIMEOUT=proceed|rc=1 status=unreviewable auto_review_target_source=default_branch target_patterns=~DEFAULT_BRANCH' \
+  'an unreadable ruleset listing falls back to the default branch||STUB_REVIEWS_MODE=none,STUB_RULESETS_MODE=fail,STUB_BASE_REF=main,PR_REVIEW_ON_TIMEOUT=proceed|rc=0 status=proceeded auto_review_target_source=default_branch' \
+  'an unresolvable target set is a timeout, never proceeded||STUB_REVIEWS_MODE=none,STUB_RULESETS_MODE=fail,STUB_DEFAULT_BRANCH_MODE=fail,STUB_BASE_REF=main,PR_REVIEW_ON_TIMEOUT=proceed|rc=1 status=timeout auto_review_target_source=unresolved target_patterns=' \
+  'a ruleset naming ~DEFAULT_BRANCH with no readable default branch is unresolved||STUB_REVIEWS_MODE=none,STUB_DEFAULT_BRANCH_MODE=fail,STUB_BASE_REF=stack-base,PR_REVIEW_ON_TIMEOUT=proceed|rc=1 status=timeout auto_review_target_source=unresolved'
+
 echo "=== transient GitHub API failures are retried inside the budget and counted ==="
 # A 5xx or 429 from the reviews listing, or from the approval-mode pr view, is
 # absorbed with backoff and reported as transient_api_errors on the eventual
@@ -523,7 +600,8 @@ table '1 1 3' \
   "review: comments|$TEXT_REVIEW|STUB_REVIEWS_MODE=commented_at_head,STUB_THREADS_UNRESOLVED=2|rc=1 text_status=comments" \
   "review: timeout|$TEXT_REVIEW|STUB_REVIEWS_MODE=none|rc=1 text_status=timeout" \
   "review: error|$TEXT_REVIEW|GH_TOKEN=bad-token,STUB_GH_DENY_KEYRING=1|rc=3 text_status=error" \
-  "review: proceeded|$TEXT_REVIEW|STUB_REVIEWS_MODE=none,PR_REVIEW_ON_TIMEOUT=proceed|rc=0 text_status=proceeded"
+  "review: proceeded|$TEXT_REVIEW|STUB_REVIEWS_MODE=none,PR_REVIEW_ON_TIMEOUT=proceed|rc=0 text_status=proceeded" \
+  "review: unreviewable|$TEXT_REVIEW|STUB_REVIEWS_MODE=none,STUB_BASE_REF=stack-base|rc=1 text_status=unreviewable"
 
 echo "=== PR_REVIEW_WAIT_SECS: an absent max_wait positional resolves through orch-env ==="
 # Process env beats kendex.settings.toml [env], and an explicit positional

--- a/skills/orch/tests/approval_wait.sh
+++ b/skills/orch/tests/approval_wait.sh
@@ -48,10 +48,15 @@ git -C "$TMP_ROOT/repo" config user.name Test
 #   only, so the current-head query finds nothing.
 #   Automatic-review target set: `api repos/owner/repo` answers the default
 #   branch (STUB_DEFAULT_BRANCH, or a 500 under STUB_DEFAULT_BRANCH_MODE=fail);
-#   `api repos/*/rulesets` and its detail answer the ruleset carrying the
+#   `api repos/*/rulesets` and its detail answer ruleset 1 carrying the
 #   copilot_code_review rule — STUB_RULESET_INCLUDE / STUB_RULESET_EXCLUDE are
-#   its space-separated ref_name conditions, and STUB_RULESETS_MODE=none/fail
-#   drops the rule or the read. Every `pr view` payload carries STUB_BASE_REF.
+#   its space-separated ref_name conditions and STUB_RULESET_DETAIL_MODE=fail
+#   fails its detail read; STUB_RULESET2_INCLUDE / STUB_RULESET2_EXCLUDE give
+#   ruleset 2, walked first, a rule of its own. STUB_RULESETS_MODE=none drops
+#   the rule; fail, denied, not_found and rate_limited fail the listing with a
+#   500, a 403, a 404 and a rate-limited 403; paged moves ruleset 1 to a second
+#   page that only --paginate reads. Every `pr view` payload carries
+#   STUB_BASE_REF.
 #   Commit statuses: `api repos/*/commits/<sha>/status` (combined status)
 #   answers likewise — STUB_STATUS_MODE=success_at_head/pending_at_head/
 #   failure_at_head/error_at_head publishes a "Review Bot" context (older
@@ -81,6 +86,12 @@ _stub_json_array() { # WORDS
     out+="\"$word\""
   done
   printf '[%s]' "$out"
+}
+
+# A ruleset detail carrying the copilot_code_review rule beside a deletion rule.
+_stub_copilot_ruleset() { # ID INCLUDE_WORDS EXCLUDE_WORDS
+  printf '{"id":%s,"target":"branch","enforcement":"active","conditions":{"ref_name":{"include":%s,"exclude":%s}},"rules":[{"type":"deletion"},{"type":"copilot_code_review","parameters":{"review_on_push":true,"review_draft_pull_requests":false}}]}\n' \
+    "$1" "$(_stub_json_array "$2")" "$(_stub_json_array "$3")"
 }
 
 _bump_count() {
@@ -139,7 +150,16 @@ case "${1:-}" in
       _stub_auth_ok || { echo "HTTP 401: Bad credentials" >&2; exit 1; }
       case "${STUB_RULESETS_MODE:-copilot}" in
         fail) echo "HTTP 500: Internal Server Error" >&2; exit 1 ;;
+        denied) echo "HTTP 403: Resource not accessible by integration" >&2; exit 1 ;;
+        not_found) echo "HTTP 404: Not Found" >&2; exit 1 ;;
+        rate_limited) echo "HTTP 403: API rate limit exceeded for installation ID 1." >&2; exit 1 ;;
         none) echo '[{"id":2,"target":"branch","enforcement":"active"}]' ;;
+        paged)
+          echo '[{"id":3,"target":"tag","enforcement":"active"},{"id":2,"target":"branch","enforcement":"active"}]'
+          if [[ " $* " == *" --paginate "* ]]; then
+            echo '[{"id":1,"target":"branch","enforcement":"active"}]'
+          fi
+          ;;
         *) echo '[{"id":3,"target":"tag","enforcement":"active"},{"id":4,"target":"branch","enforcement":"evaluate"},{"id":2,"target":"branch","enforcement":"active"},{"id":1,"target":"branch","enforcement":"active"}]' ;;
       esac
       exit 0
@@ -147,13 +167,19 @@ case "${1:-}" in
     if [[ "${2:-}" == repos/*/rulesets/* ]]; then
       _stub_auth_ok || { echo "HTTP 401: Bad credentials" >&2; exit 1; }
       ruleset_id="${2##*/}"
+      if [[ "$ruleset_id" == "2" && -n "${STUB_RULESET2_INCLUDE:-}" ]]; then
+        _stub_copilot_ruleset 2 "$STUB_RULESET2_INCLUDE" "${STUB_RULESET2_EXCLUDE:-}"
+        exit 0
+      fi
       if [[ "$ruleset_id" != "1" ]]; then
         printf '{"id":%s,"target":"branch","enforcement":"active","conditions":{"ref_name":{"include":["~ALL"],"exclude":[]}},"rules":[{"type":"deletion"}]}\n' "$ruleset_id"
         exit 0
       fi
-      printf '{"id":1,"target":"branch","enforcement":"active","conditions":{"ref_name":{"include":%s,"exclude":%s}},"rules":[{"type":"deletion"},{"type":"copilot_code_review","parameters":{"review_on_push":true,"review_draft_pull_requests":false}}]}\n' \
-        "$(_stub_json_array "${STUB_RULESET_INCLUDE:-~DEFAULT_BRANCH}")" \
-        "$(_stub_json_array "${STUB_RULESET_EXCLUDE:-}")"
+      if [[ "${STUB_RULESET_DETAIL_MODE:-ok}" == "fail" ]]; then
+        echo "HTTP 500: Internal Server Error" >&2
+        exit 1
+      fi
+      _stub_copilot_ruleset 1 "${STUB_RULESET_INCLUDE:-~DEFAULT_BRANCH}" "${STUB_RULESET_EXCLUDE:-}"
       exit 0
     fi
     if [[ "${2:-}" == repos/*/pulls/*/reviews ]]; then
@@ -546,14 +572,17 @@ table "$REVIEW" \
   'a proceed posts no commit status and emits no outage marker||STUB_REVIEWS_MODE=none,PR_REVIEW_ON_TIMEOUT=proceed,PR_REVIEW_OUTAGE_CONTEXT=kendex-reviewer-outage|rc=0 status=proceeded marker_posts=0 outage_marker=false'
 
 echo "=== the automatic-review target set decides whether silence is a timeout or unreviewable ==="
-# The automatic reviewer is armed by an active branch ruleset carrying a
-# copilot_code_review rule, and its conditions.ref_name is the set of bases that
-# draw one. A base outside that set can never draw one, so silence there is
-# "unreviewable" (exit 1) under either on-timeout policy, never the fail-open
-# "proceeded" — while the same silence on a covered base still proceeds. A
-# reviewer that engaged is a timeout wherever the base sits, and a target set
-# that could not be read is a timeout too: a failed read decides nothing.
-# The include/exclude patterns are shaped input, one asserted row per shape.
+# The automatic reviewer is armed by any active branch ruleset carrying a
+# copilot_code_review rule; a base draws one when such a ruleset includes it
+# and that same ruleset does not exclude it. A base outside that set can never
+# draw one, so silence there is "unreviewable" (exit 1) under either on-timeout
+# policy, never the fail-open "proceeded" — while the same silence on a covered
+# base still proceeds. A reviewer that engaged is a timeout wherever the base
+# sits, and a target set that could not be read or judged is a timeout too: only
+# a listing denied as a permission, or one with no ruleset carrying the rule,
+# lets the default branch stand in, and a glob pattern is never matched.
+# The patterns and the listing answers are shaped input, one asserted row per
+# shape.
 table "$REVIEW" \
   'an untargeted base under proceed is unreviewable, not proceeded||STUB_REVIEWS_MODE=none,STUB_BASE_REF=stack-base,PR_REVIEW_ON_TIMEOUT=proceed|rc=1 status=unreviewable base_ref=stack-base auto_review_targeted=false auto_review_target_source=ruleset target_patterns=~DEFAULT_BRANCH' \
   'an untargeted base under block is unreviewable, not a timeout||STUB_REVIEWS_MODE=none,STUB_BASE_REF=stack-base,PR_REVIEW_ON_TIMEOUT=block|rc=1 status=unreviewable' \
@@ -561,11 +590,19 @@ table "$REVIEW" \
   'a reviewer engaged on an untargeted base is a timeout, not unreviewable||STUB_REVIEWS_MODE=none,STUB_CHECKS_MODE=failure_at_head,PR_REVIEW_CHECK=Review Bot,STUB_BASE_REF=stack-base,PR_REVIEW_ON_TIMEOUT=proceed|rc=1 status=timeout' \
   'approval mode reads the same base and reaches the same verdict|1 1 3 --json|STUB_APPROVAL_MODE=none,STUB_BASE_REF=stack-base,PR_REVIEW_ON_TIMEOUT=proceed|rc=1 status=unreviewable base_ref=stack-base' \
   'a ~ALL ruleset covers a stacked base||STUB_REVIEWS_MODE=none,STUB_RULESET_INCLUDE=~ALL,STUB_BASE_REF=stack-base,PR_REVIEW_ON_TIMEOUT=proceed|rc=0 status=proceeded auto_review_targeted=true target_patterns=~ALL' \
-  'a ref pattern is matched over the full ref||STUB_REVIEWS_MODE=none,STUB_RULESET_INCLUDE=refs/heads/stack-*,STUB_BASE_REF=stack-base,PR_REVIEW_ON_TIMEOUT=proceed|rc=0 status=proceeded auto_review_targeted=true' \
-  'an exclude pattern beats the include||STUB_REVIEWS_MODE=none,STUB_RULESET_INCLUDE=~ALL,STUB_RULESET_EXCLUDE=refs/heads/stack-*,STUB_BASE_REF=stack-base,PR_REVIEW_ON_TIMEOUT=proceed|rc=1 status=unreviewable auto_review_targeted=false' \
+  'a ref pattern is matched as the full literal ref||STUB_REVIEWS_MODE=none,STUB_RULESET_INCLUDE=refs/heads/stack-base,STUB_BASE_REF=stack-base,PR_REVIEW_ON_TIMEOUT=proceed|rc=0 status=proceeded auto_review_targeted=true' \
+  'an exclude pattern beats the include||STUB_REVIEWS_MODE=none,STUB_RULESET_INCLUDE=~ALL,STUB_RULESET_EXCLUDE=refs/heads/stack-base,STUB_BASE_REF=stack-base,PR_REVIEW_ON_TIMEOUT=proceed|rc=1 status=unreviewable auto_review_targeted=false' \
+  'a base any one Copilot ruleset covers is targeted, over the union of includes||STUB_REVIEWS_MODE=none,STUB_RULESET2_INCLUDE=~DEFAULT_BRANCH,STUB_RULESET_INCLUDE=refs/heads/stack-base,STUB_BASE_REF=stack-base,PR_REVIEW_ON_TIMEOUT=proceed|rc=0 status=proceeded auto_review_targeted=true target_patterns=~DEFAULT_BRANCH,refs/heads/stack-base' \
+  "an exclude narrows only its own ruleset, not another's include||STUB_REVIEWS_MODE=none,STUB_RULESET2_INCLUDE=~ALL,STUB_RULESET2_EXCLUDE=refs/heads/stack-base,STUB_RULESET_INCLUDE=refs/heads/stack-base,STUB_BASE_REF=stack-base,PR_REVIEW_ON_TIMEOUT=proceed|rc=0 status=proceeded auto_review_targeted=true" \
+  'a Copilot ruleset on a later listing page is read||STUB_REVIEWS_MODE=none,STUB_RULESETS_MODE=paged,STUB_RULESET_INCLUDE=refs/heads/stack-base,STUB_BASE_REF=stack-base,PR_REVIEW_ON_TIMEOUT=proceed|rc=0 status=proceeded auto_review_target_source=ruleset' \
+  'a glob pattern leaves the set unresolved, since GitHub does not match * across /||STUB_REVIEWS_MODE=none,STUB_RULESET_INCLUDE=refs/heads/release/*,STUB_BASE_REF=release/foo/bar,PR_REVIEW_ON_TIMEOUT=proceed|rc=1 status=timeout auto_review_target_source=unresolved' \
   'no ruleset carries the rule, so the default branch is the whole set||STUB_REVIEWS_MODE=none,STUB_RULESETS_MODE=none,STUB_BASE_REF=stack-base,PR_REVIEW_ON_TIMEOUT=proceed|rc=1 status=unreviewable auto_review_target_source=default_branch target_patterns=~DEFAULT_BRANCH' \
-  'an unreadable ruleset listing falls back to the default branch||STUB_REVIEWS_MODE=none,STUB_RULESETS_MODE=fail,STUB_BASE_REF=main,PR_REVIEW_ON_TIMEOUT=proceed|rc=0 status=proceeded auto_review_target_source=default_branch' \
-  'an unresolvable target set is a timeout, never proceeded||STUB_REVIEWS_MODE=none,STUB_RULESETS_MODE=fail,STUB_DEFAULT_BRANCH_MODE=fail,STUB_BASE_REF=main,PR_REVIEW_ON_TIMEOUT=proceed|rc=1 status=timeout auto_review_target_source=unresolved target_patterns=' \
+  'a listing denied with 403 falls back to the default branch||STUB_REVIEWS_MODE=none,STUB_RULESETS_MODE=denied,STUB_BASE_REF=main,PR_REVIEW_ON_TIMEOUT=proceed|rc=0 status=proceeded auto_review_target_source=default_branch' \
+  'a listing answered 404 falls back to the default branch||STUB_REVIEWS_MODE=none,STUB_RULESETS_MODE=not_found,STUB_BASE_REF=main,PR_REVIEW_ON_TIMEOUT=proceed|rc=0 status=proceeded auto_review_target_source=default_branch' \
+  'a rate-limited 403 listing is unresolved, not a denial||STUB_REVIEWS_MODE=none,STUB_RULESETS_MODE=rate_limited,STUB_BASE_REF=main,PR_REVIEW_ON_TIMEOUT=proceed|rc=1 status=timeout auto_review_target_source=unresolved' \
+  'any other listing failure is unresolved, not the default branch||STUB_REVIEWS_MODE=none,STUB_RULESETS_MODE=fail,STUB_BASE_REF=main,PR_REVIEW_ON_TIMEOUT=proceed|rc=1 status=timeout auto_review_target_source=unresolved' \
+  'a failed ruleset detail read is unresolved||STUB_REVIEWS_MODE=none,STUB_RULESET_DETAIL_MODE=fail,STUB_BASE_REF=main,PR_REVIEW_ON_TIMEOUT=proceed|rc=1 status=timeout auto_review_target_source=unresolved' \
+  'a denied listing with no readable default branch is unresolved||STUB_REVIEWS_MODE=none,STUB_RULESETS_MODE=denied,STUB_DEFAULT_BRANCH_MODE=fail,STUB_BASE_REF=main,PR_REVIEW_ON_TIMEOUT=proceed|rc=1 status=timeout auto_review_target_source=unresolved target_patterns=' \
   'a ruleset naming ~DEFAULT_BRANCH with no readable default branch is unresolved||STUB_REVIEWS_MODE=none,STUB_DEFAULT_BRANCH_MODE=fail,STUB_BASE_REF=stack-base,PR_REVIEW_ON_TIMEOUT=proceed|rc=1 status=timeout auto_review_target_source=unresolved'
 
 echo "=== transient GitHub API failures are retried inside the budget and counted ==="

--- a/skills/orch/workflows/ci-fix.md
+++ b/skills/orch/workflows/ci-fix.md
@@ -153,6 +153,7 @@ Re-confirm the review gate at the new head **before** waiting on CI, on every re
 
 - `approved` / `reviewed` / `proceeded` → wait for CI. `proceeded` is returned to the caller, not persisted here; it is a LOCAL verdict — orch posts no status.
 - `comments` / `changes_requested` → new feedback on the fix push. Managed: return it to the caller's review-gate handling. Standalone: run that triage pass, then re-run this step.
+- `unreviewable` → this PR's base draws no automatic review ([references/gates.md](../references/gates.md) § Stacked pull requests). Request one with `gh pr edit [PR_NUMBER] --add-reviewer @copilot` and re-run this step once. If it repeats, `auto-recommended` records `ci-gate-unreviewable`; under `ask`, hand back the unconfirmed gate. Never treat it as a met gate.
 - `timeout` → no exact-head evidence yet; a missing or red CI run here is not a fix failure. Re-run this step once. If it repeats, `auto-recommended` records `ci-gate-unconfirmed`; under `ask`, hand back the unconfirmed gate.
 
 ```bash

--- a/skills/orch/workflows/merge-pr.md
+++ b/skills/orch/workflows/merge-pr.md
@@ -118,6 +118,8 @@ Two warnings are merge gates, not advice:
 
   With `PR_REVIEW_ON_TIMEOUT=proceed`, a deadline reached with zero unresolved threads and no reviewer evidence returns `proceeded` (exit 0) instead of `timeout` in both modes — treat it as a met gate and record it in the § 6 report. An open thread or a `changes_requested` still blocks. The proceed is a LOCAL verdict — orch posts no status.
 
+  An `unreviewable` status is never a met gate: no automatic reviewer targets this PR's base, so the silence is structural. Follow [references/gates.md](../references/gates.md) § Stacked pull requests, then re-run the wait. If it repeats, `auto-recommended` records `review-gate-unreviewable`, while `ask` presents the wait or stop choice.
+
   Merge past a missing gate verdict only on an explicit user `Force merge`.
 
 Bot-specific signals — emoji reactions, sticky-comment prose, checklist text — are never parsed as merge gates. Only GitHub-native review state and the thread-resolution count count.

--- a/skills/orch/workflows/submit-pr.md
+++ b/skills/orch/workflows/submit-pr.md
@@ -221,6 +221,7 @@ For `off`, skip the wait and go to § 5 — the internal review, CI, and comment
    | `reviewed` | Clear the review-wait budget, then → step 2 |
    | `proceeded` | Reviewer-down degrade under `PR_REVIEW_ON_TIMEOUT=proceed`. Clear the review-wait budget, record `pr_approval.reviewer_down` (below), then → step 2. CI and gate 3 still apply in full. Orch posts no status and manufactures no review evidence |
    | `changes_requested` or `comments` | Run the triage pass, then the Restart check |
+   | `unreviewable` | No automatic reviewer targets this PR's base ([references/gates.md](../references/gates.md) § Stacked pull requests). Run `gh pr edit [PR_NUMBER] --add-reviewer @copilot` once, then the Restart check. If the wait returns `unreviewable` again, `auto-recommended` records `review-gate-unreviewable`; `ask` presents `Force merge` \| `Keep waiting` \| `Stop here`, with `Stop here` recommended |
    | `timeout` | `auto-recommended` logs `Keep waiting` and enters the Restart check; `ask` presents `Force merge` \| `Keep waiting` \| `Stop here`, with `Keep waiting` recommended |
    | `error` | Re-run step 1 once. If it repeats, `auto-recommended` records `review-gate-read-failed`; `ask` presents `Keep waiting` \| `Stop here`, with `Keep waiting` recommended |
 

--- a/skills/review-gate/SKILL.md
+++ b/skills/review-gate/SKILL.md
@@ -97,6 +97,8 @@ Keys a repo decides: [references/adoption.md](references/adoption.md) § Keys a 
 
 **Watching one or many PRs without stalling.** Never key a hand-rolled monitor on gate-state transitions. Run `.agents/skills/review-gate/scripts/pr-watch.sh` (optionally `--heal`) on the harness's wake-up mechanism: silence + exit 0 means nothing needs you; attention lines name exactly what does. See [Watching PRs as an agent](references/adoption.md#watching-prs-as-an-agent-pr-watch).
 
+**A pull request drew no automatic review.** The automatic reviewer is armed by a branch ruleset, and a base outside that ruleset's target set never draws one. Request the review by hand with `gh pr edit <PR#> --add-reviewer @copilot`. The target set, the ruleset parameters, and the fallbacks when the manual request draws nothing: [references/automatic-review.md](references/automatic-review.md).
+
 **Reviewers are down / nothing is reviewing.** Run the internal review loop: fix findings, resolve every thread, then post the override status with a real reason. It cannot bypass an objection or an open thread.
 
 **A PR that repairs the gate itself.** The writer always runs the merged engine. Merge the repair PR with the ruleset's bypass actor and say so in the commit message.

--- a/skills/review-gate/references/automatic-review.md
+++ b/skills/review-gate/references/automatic-review.md
@@ -1,0 +1,32 @@
+# Automatic review and the base branch
+
+Which pull requests draw GitHub's automatic Copilot review, and what to do when one does not. The gate reads evidence and never requests a review; this file names where the evidence comes from.
+
+## What arms the reviewer
+
+| Fact | Value |
+|---|---|
+| Arming mechanism | an active branch ruleset carrying a rule of type `copilot_code_review` |
+| Set of bases that draw a review | that ruleset's `conditions.ref_name` — the `include` patterns, minus the `exclude` patterns |
+| Pattern forms | `~ALL` (every branch), `~DEFAULT_BRANCH` (the repo default), any other pattern as an fnmatch over `refs/heads/<base>` |
+| Re-review on a new head | the rule's `review_on_push` parameter |
+| Draft pull requests | the rule's `review_draft_pull_requests` parameter |
+
+Read a repo's own set with `gh api repos/<owner>/<repo>/rulesets`, then the detail of each `target: "branch"`, `enforcement: "active"` entry.
+
+The target set is per-repo configuration, not GitHub behaviour. In `vanillagreencom/kendex` it is ruleset `16519713`, "Copilot review for default branch", whose `conditions.ref_name.include` is `["~DEFAULT_BRANCH"]`. A pull request based on any branch other than `main` therefore draws no automatic review in this repo. A repo whose ruleset targets more branches reviews stacked pull requests.
+
+## When no review arrives
+
+| Situation | Action |
+|---|---|
+| The base is outside the target set | request the reviewer by hand: `gh pr edit <PR#> --add-reviewer @copilot`. It works on a base the ruleset does not target |
+| The manual request draws nothing | close the pull request and open a fresh one against the default branch |
+| The reviewer already reviewed this pull request once and a new review is needed | reopen it, which re-arms the reviewer |
+| The reviewer never reviewed this pull request | reopening does nothing. Only the manual request, or a new pull request against a targeted base, draws one |
+
+Evidence for the manual route: probe pull request `vanillagreencom/kendex#2527`, based on `ken-1329-probe-base`, which the ruleset does not target. `gh pr edit 2527 --add-reviewer @copilot` was accepted, and `copilot_work_started` followed 36 seconds later.
+
+## What the waiter reports
+
+Orch's `approval-wait` resolves the same target set once per wait and matches the pull request's `baseRefName` against it. Reviewer silence on a base outside the set is reported as status `unreviewable` (exit 1), never the fail-open `proceeded`. Its JSON carries `base_ref`, `auto_review_targeted`, `auto_review_target_source` and `auto_review_targets`. Full contract: `approval-wait --help`. The stacked-chain sequence is orch's `references/gates.md` § Stacked pull requests.

--- a/skills/review-gate/references/automatic-review.md
+++ b/skills/review-gate/references/automatic-review.md
@@ -7,12 +7,12 @@ Which pull requests draw GitHub's automatic Copilot review, and what to do when 
 | Fact | Value |
 |---|---|
 | Arming mechanism | an active branch ruleset carrying a rule of type `copilot_code_review` |
-| Set of bases that draw a review | that ruleset's `conditions.ref_name` — the `include` patterns, minus the `exclude` patterns |
-| Pattern forms | `~ALL` (every branch), `~DEFAULT_BRANCH` (the repo default), any other pattern as an fnmatch over `refs/heads/<base>` |
+| Set of bases that draw a review | the union over every such ruleset: a base draws one when a ruleset's `conditions.ref_name.include` covers it and the same ruleset's `exclude` does not |
+| Pattern forms | `~ALL` (every branch), `~DEFAULT_BRANCH` (the repo default), any other pattern matched against `refs/heads/<base>` by `File.fnmatch` with `File::FNM_PATHNAME`, so `*` does not match `/` |
 | Re-review on a new head | the rule's `review_on_push` parameter |
 | Draft pull requests | the rule's `review_draft_pull_requests` parameter |
 
-Read a repo's own set with `gh api repos/<owner>/<repo>/rulesets`, then the detail of each `target: "branch"`, `enforcement: "active"` entry.
+Read a repo's own set with `gh api --paginate repos/<owner>/<repo>/rulesets`, then the detail of each `target: "branch"`, `enforcement: "active"` entry.
 
 The target set is per-repo configuration, not GitHub behaviour. In `vanillagreencom/kendex` it is ruleset `16519713`, "Copilot review for default branch", whose `conditions.ref_name.include` is `["~DEFAULT_BRANCH"]`. A pull request based on any branch other than `main` therefore draws no automatic review in this repo. A repo whose ruleset targets more branches reviews stacked pull requests.
 
@@ -29,4 +29,4 @@ Evidence for the manual route: probe pull request `vanillagreencom/kendex#2527`,
 
 ## What the waiter reports
 
-Orch's `approval-wait` resolves the same target set once per wait and matches the pull request's `baseRefName` against it. Reviewer silence on a base outside the set is reported as status `unreviewable` (exit 1), never the fail-open `proceeded`. Its JSON carries `base_ref`, `auto_review_targeted`, `auto_review_target_source` and `auto_review_targets`. Full contract: `approval-wait --help`. The stacked-chain sequence is orch's `references/gates.md` § Stacked pull requests.
+Orch's `approval-wait` resolves the same target set once per wait and matches the pull request's `baseRefName` against it. It compares `~ALL`, `~DEFAULT_BRANCH` and literal refs only. A set holding any glob pattern (`*`, `?`, `[` or `\`) is `unresolved`, and so is a set behind a failed ruleset read other than a permission denial. Reviewer silence on a base outside the set is reported as status `unreviewable` (exit 1), and on an `unresolved` set as `timeout`; neither is the fail-open `proceeded`. Its JSON carries `base_ref`, `auto_review_targeted`, `auto_review_target_source` and `auto_review_targets`. Full contract: `approval-wait --help`. The stacked-chain sequence is orch's `references/gates.md` § Stacked pull requests.


### PR DESCRIPTION
## Summary

- `approval-wait` resolves the automatic-review target set once per wait — the `conditions.ref_name` of the active branch ruleset carrying a `copilot_code_review` rule, falling back to the default branch — and matches the PR's `baseRefName` against it. Reviewer silence at the deadline on a base outside that set is a new status, `unreviewable` (exit 1), whatever `PR_REVIEW_ON_TIMEOUT` says; a target set it cannot read reports `timeout`. Every case this adds moves **off** `proceeded`, the script's only exit-0 degrade; none moves onto it. New JSON fields: `base_ref`, `auto_review_targeted`, `auto_review_target_source`, `auto_review_targets`.
- `unreviewable` is routed explicitly in every consumer that cases on the status: `submit-pr.md` § 4, `ci-fix.md`, `merge-pr.md`.
- Documentation: a new review-gate reference, `references/automatic-review.md`, states what arms the reviewer and what to do when none arrives; orch `references/gates.md` gains § Stacked pull requests with the chain sequence.

## Two premises in the issue are false for this repo

Both were verified against the live repository before design, as the root triage comment on KEN-1329 required.

1. **"Automatic review fires only on the default branch" is ruleset configuration, not GitHub behaviour.** `GET /repos/vanillagreencom/kendex/rulesets/16519713` carries `{"type":"copilot_code_review","parameters":{"review_on_push":true,"review_draft_pull_requests":false}}` with `conditions.ref_name.include: ["~DEFAULT_BRANCH"]`. The waiter therefore reads the target set instead of assuming it.
2. **"The reviewer cannot be requested by hand" is false.** Tested on a stacked PR: probe #2527, base `ken-1329-probe-base`, which the ruleset does not target. `gh pr edit 2527 --add-reviewer @copilot` was accepted at 20:11:00Z, `copilot_work_started` followed at 20:11:36Z, and a formal COMMENTED review pinned to the head commit landed at 20:13:04Z. The probe PR is closed and both branches are deleted. The manual request is documented as the remedy; close-and-open against the default branch is the fallback.

## Deliberate departure from the issue

The issue asks for the wait to return early on a non-targeted base. It does not. Premise 2 shows a review can legitimately arrive on such a base during the wait, and an early return would refuse a caller who had just requested one by hand on every re-run. The structural condition is named at the deadline, where "nobody came" is what it explains.

## Answering the PR review

Copilot's review of the first push left one thread and three findings suppressed into its review body. The review gate fails on either, and clears the suppressed ones only on a fresh review at a new head, so all four are fixed rather than declined:

- **Thread: an overbroad comment.** `resolve_auto_review_targets` claimed the ruleset "cannot change the answer mid-wait" and that the resolution "costs two reads". Both are broader than the code, which snapshots the set once per wait. The sentence is deleted.
- **A failed read no longer guesses (Blocking).** The ruleset reads swallowed every error into the default-branch fallback. Only a non-transient HTTP 403/404 on the listing (the token cannot see rulesets), or a complete read with no Copilot rule, now falls back to the default branch. A 5xx, a timeout, a rate-limited 403, an empty or malformed listing, or a failed detail read leaves the set `unresolved`, which reports `timeout` and never `proceeded`.
- **Every Copilot ruleset counts.** A base is targeted when any ruleset carrying `copilot_code_review` includes it and that same ruleset does not exclude it. The listing is read across every page.
- **No shell glob stands in for GitHub's matcher (Blocking).** GitHub matches ruleset ref patterns with `File::FNM_PATHNAME`, where `*` does not match `/`; a Bash `case` glob does, so a nested branch could read as targeted and let silence proceed. `approval-wait` now matches `~ALL`, `~DEFAULT_BRANCH` and literal refs exactly, and a glob pattern leaves the set `unresolved` rather than guessing. `automatic-review.md` states the same.

## Completed Issues

- Closes KEN-1329 - review-gate: a stacked PR draws no automatic review, and approval-wait reports the impossible wait as a timeout

## Size

KEN-1329 states no `**Expected delta**`, so nothing was judged. Measured by `branch-size-check` on the pushed head: 287 production lines, 123 test lines, 410 render-mirror lines.

## Test Plan

- `skills/orch/tests/approval_wait.sh` — 95 pass / 0 fail. The rows cover:
  - the untargeted-base deadline verdict, and the targeted base still reaching `proceeded`
  - a permission-denied listing (403/404) falling back to the default branch
  - a 5xx, rate-limited 403 or failed detail read staying `unresolved`
  - the union across Copilot rulesets, with each exclude bound to its own ruleset
  - a Copilot ruleset on a later listing page
  - a glob target leaving the set `unresolved`
- Every changed rule has a planted must-fail control that was confirmed red.
- `approval_wait_cli.sh` 34/0; help-inert 105/0.
- `env -u TMPDIR tools/guard --full` on the pushed head: exit 0, no `guard:` failure lines.
  - Its first run failed one test unrelated to this diff, `kendex-cli` `arming::a_wedged_installer_gives_up_inside_the_session_start_bound`, a timing race under load. That test passed 3/3 on the same head and reads nothing this branch changes; the whole guard was then re-run once.
- preflight clean over 16 files on the pushed head; the pre-commit chain was clean on both commits.
- Local review: reviewer-correctness, verdict pass. It raised one unsupported doc claim — that a PR retargeted after the bottom of a stack merges "draws a review on its own". GitHub does not document a base change as an automatic-review trigger, so `gates.md` step 2 now says to request the review by hand, or push a new head where `review_on_push` is on.

https://claude.ai/code/session_01Qr3QAznJxvu5MqczbBLzjw
