### PR TITLE
fix(KEN-1326): parse the command substitution bodies Bash 3.2 leaves unread [no-changelog]

### DIFF
--- a/tools/bash32-parse
+++ b/tools/bash32-parse
@@ -10,12 +10,21 @@
 # three tool suites with it. The judge for "does this file parse under Bash
 # 3.2" is Bash 3.2, so this lane runs one.
 #
+# `bash -n` alone is not that judge. Bash parses a command substitution's
+# body when it EXPANDS it, not when it reads the file, so under 3.2 `bash -n`
+# descends into no `$( )` and no backquote in any spelling — quoted,
+# unquoted or nested. The construct above sits inside one, which is why a
+# pass built on `bash -n` over the file alone read the file that carried it
+# as clean. Each body is therefore delimited the way 3.2 delimits one and
+# parsed on its own; § the extractor states how, and what that reaches.
+#
 # Usage: tools/bash32-parse [--list] [DIR...]
 #   no argument   parse the covered set below
 #   DIR...        parse those directories instead, each inside this repository
 #   --list        print the covered set the discovery resolved to
 #   --check FILE...
-#                 parse those files with the shell running this script, and
+#                 parse those files, and every command substitution body
+#                 inside them, with the shell running this script, and
 #                 answer on the protocol below. This is the mode the resolved
 #                 Bash 3.2 re-enters this file in, never one to run by hand:
 #                 under any other shell it answers for that shell, which is
@@ -115,9 +124,13 @@ message_text() { # KEY VALUE [EXTRA...] — the English for one key, and all of 
   no-verdict)
     echo "the pass under Bash 3.2 exited with that status and answered with nothing this run can read, so it reached no verdict; its own output follows." ;;
   syntax)
-    echo "shell files that do not parse under Bash 3.2; that shell names each below." ;;
+    echo "shell files Bash 3.2 refuses, in the file's own text or in a command substitution body inside it; that shell names each below." ;;
+  extractor)
+    echo "the command substitution bodies could not be extracted: the value names the step that failed, or the status the extractor exited with, and whatever it wrote follows. A file whose substitutions went unread is never reported as parsed." ;;
+  unscannable)
+    echo "shell files Bash 3.2 parsed and this pass could not follow to the end of, named below." ;;
   clean)
-    printf '%s shell file(s), each parsed by Bash %s via %s.\n' "$2" "$3" "$4" ;;
+    printf '%s shell file(s), each parsed by Bash %s via %s, and every command substitution body inside them parsed on its own.\n' "$2" "$3" "$4" ;;
   *)
     echo "no explanation is defined for this key: tools/bash32-parse is broken." ;;
   esac
@@ -143,15 +156,217 @@ die_cause() { # KEY VALUE CAUSE — CAUSE is the failing command's own words
   exit 2
 }
 
+# --- the extractor ------------------------------------------------------
+# Bash 3.2 finds the END of a `$( )` by counting parens — aware of quoting,
+# of comments and of nesting, and of nothing else — and parses whatever that
+# delimited only once it expands it. `foo)` in a case pattern closes the
+# substitution there, so the text 3.2 ends up parsing is not the text the
+# author wrote, and `bash -n` over the file asks it to parse neither.
+#
+# The program below delimits every body the same way, so the text it hands to
+# `bash -n` is the text 3.2 would parse at expansion. That is what makes a
+# mis-scan a RED rather than a silent green: a body cut at the wrong paren
+# does not parse. Backquote bodies are taken as well — their delimiter is the
+# next unescaped backquote, so the early close above cannot reach them, but
+# `bash -n` leaves their body unparsed exactly as it leaves a `$( )` body.
+#
+# What it does not reach, each an under-read that reports nothing rather than
+# something wrong: the inside of `$(( ))`, which is arithmetic and not a
+# command list; and a heredoc body at the top level, which Bash reads as a
+# word and expands later, and which a quoted delimiter makes literal text, so
+# scanning it as code would red on correct source. A heredoc opened INSIDE a
+# body is scanned, because 3.2's paren count runs straight through one —
+# measured under the pinned image, not assumed.
+extractor_program() { # the awk program, on stdout
+  cat <<'EXTRACTOR'
+# Every command substitution body in the files named on the command line,
+# delimited the way Bash 3.2 delimits one.
+#
+# `dir` receives one file per body, named by its id. `lost` receives the name
+# of any file the scan did not reach the end of in a settled state. stdout
+# carries one line per body: `<id> <line> <file>`, the file last so a path
+# holding a blank stays whole.
+function word_start(c) {
+  return c == "\n" || c == " " || c == "\t" || c == ";" || c == "&" || c == "|"
+}
+function keep(text, ln,   f) {
+  id++
+  f = dir "/" id
+  printf "%s", text > f
+  close(f)
+  print id, ln, file
+}
+# A file whose last line leaves a substitution, a quote, a backquote,
+# arithmetic or a heredoc open is one this scan lost track of. Every caller
+# has already seen Bash 3.2 parse that file, so the open state is this
+# scanner being wrong about a construct rather than the file being broken,
+# and the pass refuses instead of reporting what it did reach.
+#
+# `paren` is deliberately not among them. A case pattern at the top level
+# ends in a `)` with no `(` before it, so the count there is not a balance
+# and a file can settle with it anywhere.
+function settle() {
+  if (file == "") return
+  if (depth != 0 || quote != "" || bq != 0 || arith != 0 || pending != 0)
+    print file > lost
+}
+BEGIN { id = 0; file = "" }
+FNR == 1 {
+  settle()
+  file = FILENAME
+  depth = 0; quote = ""; paren = 0; arith = 0; bq = 0; pending = 0; in_heredoc = 0
+}
+{
+  line = $0
+  # A heredoc body at the top level is a word Bash reads whole and expands
+  # later, and a quoted delimiter makes it literal text, so it is passed over
+  # rather than scanned as code. Inside a body it is NOT passed over: 3.2's
+  # paren count runs straight through a heredoc body, quoted or not.
+  if (in_heredoc) {
+    term = line
+    if (strip_tabs) sub(/^\t+/, "", term)
+    if (term == delim[1]) {
+      for (k = 1; k < pending; k++) { delim[k] = delim[k + 1]; dash[k] = dash[k + 1] }
+      pending--
+      if (pending == 0) in_heredoc = 0
+      else strip_tabs = dash[1]
+    }
+    next
+  }
+  i = 1
+  last = length(line)
+  prev = "\n"
+  while (i <= last) {
+    c = substr(line, i, 1)
+    # `$(( ))` is arithmetic, not a command list, and its parens balance, so
+    # the scan steps over it rather than handing its text to a shell parser.
+    if (arith > 0) {
+      if (c == "\\") { i += 2; prev = "x"; continue }
+      if (c == "(") arith++
+      else if (c == ")") arith--
+      i++; prev = c; continue
+    }
+    # A backquote body ends at the next unescaped backquote, whatever parens
+    # or quotes it holds. That delimiter cannot be closed early the way a
+    # paren count can, but its body goes unparsed by `bash -n` all the same.
+    if (bq) {
+      if (c == "\\") { i += 2; prev = "x"; continue }
+      if (c == "`") {
+        bqbody = bqbody substr(line, bqstart, i - bqstart)
+        bq = 0
+        keep(bqbody, bqline)
+        bqbody = ""
+      }
+      i++; prev = c; continue
+    }
+    if (quote == "'") {
+      if (c == "'") quote = ""
+      i++; prev = c; continue
+    }
+    if (quote == "\"") {
+      if (c == "\\") { i += 2; prev = "x"; continue }
+      if (c == "\"") { quote = ""; i++; prev = c; continue }
+      if (c == "`") { bq = 1; bqstart = i + 1; bqline = FNR; i++; prev = c; continue }
+      if (c == "$" && substr(line, i + 1, 1) == "(") {
+        if (substr(line, i + 2, 1) == "(") { arith = 2; i += 3; prev = "x"; continue }
+        held_quote[depth] = quote; held_paren[depth] = paren
+        depth++
+        quote = ""; paren = 0
+        body[depth] = ""; start[depth] = i + 2; opened[depth] = FNR
+        i += 2; prev = "x"; continue
+      }
+      i++; prev = c; continue
+    }
+    if (c == "\\") { i += 2; prev = "x"; continue }
+    if (c == "'") { quote = "'"; i++; prev = c; continue }
+    if (c == "\"") { quote = "\""; i++; prev = c; continue }
+    if (c == "#" && word_start(prev)) break
+    if (c == "`") { bq = 1; bqstart = i + 1; bqline = FNR; i++; prev = c; continue }
+    if (c == "$" && substr(line, i + 1, 1) == "(") {
+      if (substr(line, i + 2, 1) == "(") { arith = 2; i += 3; prev = "x"; continue }
+      held_quote[depth] = quote; held_paren[depth] = paren
+      depth++
+      quote = ""; paren = 0
+      body[depth] = ""; start[depth] = i + 2; opened[depth] = FNR
+      i += 2; prev = "x"; continue
+    }
+    if (c == "(") {
+      # `(( ))` opening a word is an arithmetic command, not two subshells,
+      # and inside it `<<` is a shift rather than a heredoc.
+      if (substr(line, i + 1, 1) == "(" && word_start(prev)) {
+        arith = 2; i += 2; prev = "x"; continue
+      }
+      paren++; i++; prev = c; continue
+    }
+    if (c == ")") {
+      if (paren > 0) paren--
+      else if (depth > 0) {
+        body[depth] = body[depth] substr(line, start[depth], i - start[depth])
+        keep(body[depth], opened[depth])
+        depth--
+        quote = held_quote[depth]; paren = held_paren[depth]
+      }
+      i++; prev = c; continue
+    }
+    if (c == "<" && substr(line, i + 1, 1) == "<") {
+      if (substr(line, i + 2, 1) == "<") { i += 3; prev = "x"; continue }
+      j = i + 2
+      indented = 0
+      if (substr(line, j, 1) == "-") { indented = 1; j++ }
+      while (substr(line, j, 1) == " " || substr(line, j, 1) == "\t") j++
+      word = ""
+      # Quoting inside the delimiter word decides whether the body expands,
+      # which this scan does not care about, and Bash strips it before
+      # matching the terminator line, which it does.
+      c2 = substr(line, j, 1)
+      if (c2 == "'" || c2 == "\"") {
+        j++
+        while (j <= last && substr(line, j, 1) != c2) { word = word substr(line, j, 1); j++ }
+        j++
+      } else {
+        while (j <= last) {
+          c2 = substr(line, j, 1)
+          if (c2 == " " || c2 == "\t" || c2 == ";" || c2 == "&" || c2 == "|" ||
+              c2 == "<" || c2 == ">" || c2 == ")") break
+          if (c2 == "\\") { j++; c2 = substr(line, j, 1); if (c2 == "") break }
+          else if (c2 == "'" || c2 == "\"") {
+            j++
+            while (j <= last && substr(line, j, 1) != c2) { word = word substr(line, j, 1); j++ }
+            j++
+            continue
+          }
+          word = word c2; j++
+        }
+      }
+      if (word != "") { pending++; delim[pending] = word; dash[pending] = indented }
+      i = j; prev = "x"; continue
+    }
+    i++; prev = c; continue
+  }
+  for (k = 1; k <= depth; k++) {
+    body[k] = body[k] substr(line, start[k]) "\n"
+    start[k] = 1
+  }
+  if (bq) { bqbody = bqbody substr(line, bqstart) "\n"; bqstart = 1 }
+  if (pending > 0 && depth == 0 && !bq) { in_heredoc = 1; strip_tabs = dash[1] }
+  else if (pending > 0) pending = 0
+}
+END { settle() }
+EXTRACTOR
+}
+
 # --- the inner pass -----------------------------------------------------
 # THE PROTOCOL between the two passes, which the outer one holds this pass to:
 # two lines on stdout, in this order, whatever the outcome —
 #
 #   bash32-parse: parsed=<files this pass ran bash -n over>
-#   bash32-parse: failed=<how many of them did not parse>
+#   bash32-parse: failed=<how many of them Bash 3.2 refused>
 #
-# with the shell's own complaint about each failure on stderr, and the exit
-# status 0 when failed is 0 and 1 when it is not. Those two lines are the
+# Both counts are FILES, and a file is one of the failed whether its own text
+# or a command substitution body inside it is what 3.2 refused, so the outer
+# pass's count check against the list it handed over still holds. The shell's
+# own complaint about each failure goes to stderr, and the exit status is 0
+# when failed is 0 and 1 when it is not. Those two lines are the
 # WHOLE of stdout, and the outer pass holds this one to that: anything else —
 # silence, noise before them, anything after them, a short count, a status
 # that disagrees with the count — is a pass that reached no verdict, and the
@@ -162,12 +377,66 @@ die_cause() { # KEY VALUE CAUSE — CAUSE is the failing command's own words
 # tree with whatever the host has, which is the whole defect.
 if [ "${1-}" = "--check" ]; then
   shift
+  SCRATCH=""
+  SCRATCH="$(mktemp -d)" || die extractor mktemp
+  trap 'rm -rf -- "${SCRATCH:?}"' EXIT
+  mkdir -p "$SCRATCH/bodies" || die extractor "$SCRATCH/bodies"
+  extractor_program >"$SCRATCH/substs.awk" || die extractor "$SCRATCH/substs.awk"
+  : >"$SCRATCH/lost" || die extractor "$SCRATCH/lost"
+
+  # The file's own text first. A file 3.2 already refuses says nothing about
+  # the extractor and is not handed to it, which is what leaves an open state
+  # at the end of a scanned file meaning one thing only: the scan is wrong
+  # about a construct in a file 3.2 accepted, and the run ends rather than
+  # reporting the bodies it did reach.
   parsed=0
   failed=0
+  taken=0
+  scanned=()
   for f in "$@"; do
     parsed=$((parsed + 1))
-    "$BASH" -n -- "$f" || failed=$((failed + 1))
+    if "$BASH" -n -- "$f"; then
+      scanned[$taken]="$f"
+      taken=$((taken + 1))
+    else
+      failed=$((failed + 1))
+    fi
   done
+
+  : >"$SCRATCH/index" || die extractor "$SCRATCH/index"
+  if [ "$taken" -gt 0 ]; then
+    status=0
+    awk -v dir="$SCRATCH/bodies" -v lost="$SCRATCH/lost" \
+      -f "$SCRATCH/substs.awk" -- "${scanned[@]}" \
+      >"$SCRATCH/index" 2>"$SCRATCH/extract-err" || status=$?
+    [ "$status" -eq 0 ] ||
+      die_cause extractor "$status" "$(cat "$SCRATCH/extract-err")"
+    [ ! -s "$SCRATCH/lost" ] ||
+      die_cause unscannable "$(wc -l <"$SCRATCH/lost" | tr -d ' ')" \
+        "$(cat "$SCRATCH/lost")"
+  fi
+
+  # Each body on stdin, so what the shell says names a line in the body it
+  # was given rather than a path in a directory that is gone by the time
+  # anyone reads it; the line above its words names the file and the line the
+  # body was cut from. A file is counted once however many of its bodies
+  # fail, and its bodies are consecutive here because they are emitted in the
+  # order the files were handed over.
+  last_bad=""
+  while read -r id at src; do
+    [ -n "$id" ] || continue
+    if "$BASH" -n <"$SCRATCH/bodies/$id" 2>"$SCRATCH/body-err"; then
+      continue
+    fi
+    printf '%s: line %s: the command substitution body Bash 3.2 delimits here does not parse:\n' \
+      "$src" "$at" >&2
+    sed 's/^/  /' "$SCRATCH/body-err" >&2
+    if [ "$src" != "$last_bad" ]; then
+      failed=$((failed + 1))
+      last_bad="$src"
+    fi
+  done <"$SCRATCH/index"
+
   printf 'bash32-parse: parsed=%s\n' "$parsed"
   printf 'bash32-parse: failed=%s\n' "$failed"
   [ "$failed" -eq 0 ] || exit 1

--- a/tools/bash32-parse
+++ b/tools/bash32-parse
@@ -128,7 +128,7 @@ message_text() { # KEY VALUE [EXTRA...] — the English for one key, and all of 
   extractor)
     echo "the command substitution bodies could not be extracted: the value names the step that failed, or the status the extractor exited with, and whatever it wrote follows. A file whose substitutions went unread is never reported as parsed." ;;
   unscannable)
-    echo "shell files Bash 3.2 parsed and this pass could not follow to the end of, named below." ;;
+    echo "shell files, or command substitution bodies inside them, that Bash 3.2 parsed and this pass could not follow to the end of, named below; a body is named by the file and the line it was cut from." ;;
   clean)
     printf '%s shell file(s), each parsed by Bash %s via %s, and every command substitution body inside them parsed on its own.\n' "$2" "$3" "$4" ;;
   *)
@@ -169,6 +169,17 @@ die_cause() { # KEY VALUE CAUSE — CAUSE is the failing command's own words
 # does not parse. Backquote bodies are taken as well — their delimiter is the
 # next unescaped backquote, so the early close above cannot reach them, but
 # `bash -n` leaves their body unparsed exactly as it leaves a `$( )` body.
+# A backquote body is handed over with the backslashes 3.2 removes before
+# parsing it already removed, so an escaped backquote inside it is the nested
+# body it becomes.
+#
+# A body is a script `bash -n` does not descend into either, so --check hands
+# every body 3.2 accepted back to this program as a file of its own, round
+# after round, until a round takes no body. The program therefore takes only
+# the OUTERMOST bodies of the text it scans: whatever a body holds — a `$( )`,
+# a backquote, a heredoc — is found when that body is scanned in turn, read
+# the way 3.2 reads it at expansion rather than by a second set of rules for
+# each context a substitution can sit in.
 #
 # A heredoc body at the top level is a WORD Bash reads whole and expands
 # later, so the spelling that opened it decides everything. A quoted
@@ -178,22 +189,29 @@ die_cause() { # KEY VALUE CAUSE — CAUSE is the failing command's own words
 # expand it, and a `$( )` in there carries the construct above as surely as
 # one in code, so that body is scanned in the only mode true of a word —
 # `$(`, a backquote and a backslash act, and a loose quote or paren outside
-# an open body is a character. A heredoc opened INSIDE a body is neither,
-# because 3.2's paren count runs straight through one — measured under the
-# pinned image, not assumed.
+# an open body is a character. A heredoc opened INSIDE a body is neither
+# while that body is being delimited, because 3.2's paren count runs straight
+# through one — measured under the pinned image, not assumed — and it is a
+# heredoc at the top level once that body is scanned in turn.
 #
-# What it does not reach: the inside of `$(( ))`, which is arithmetic and not
-# a command list. That is an under-read, reporting nothing rather than
-# something wrong.
+# `$(( ))` is arithmetic, not a body, so no round reaches inside it. The scan
+# counts its parens and opens a `$( )` or a backquote inside it as it does
+# anywhere else.
+#
+# What it does not reach: the body of a process substitution, `<( )` or
+# `>( )`, which 3.2 also parses only once it expands it — measured — and this
+# scan counts as a plain pair of parens. A `$( )` or a backquote inside one is
+# still taken.
 extractor_program() { # the awk program, on stdout
   cat <<'EXTRACTOR'
-# Every command substitution body in the files named on the command line,
-# delimited the way Bash 3.2 delimits one.
+# Every outermost command substitution body in the files named on the command
+# line, delimited the way Bash 3.2 delimits one.
 #
-# `dir` receives one file per body, named by its id. `lost` receives the name
-# of any file the scan did not reach the end of in a settled state. stdout
-# carries one line per body: `<id> <line> <file>`, the file last so a path
-# holding a blank stays whole.
+# `dir` receives one file per body, named by its id; ids continue from
+# `first`, the last one an earlier round used. `lost` receives the name of any
+# file the scan did not reach the end of in a settled state. stdout carries
+# one line per body: `<id> <line> <file>`, the file last so a path holding a
+# blank stays whole.
 function word_start(c) {
   return c == "\n" || c == " " || c == "\t" || c == ";" || c == "&" || c == "|"
 }
@@ -203,6 +221,41 @@ function keep(text, ln,   f) {
   printf "%s", text > f
   close(f)
   print id, ln, file
+}
+# The text 3.2 parses when it expands a backquote body: the backslash before
+# a backslash, a backquote or a dollar sign is removed, and the one before a
+# double quote as well when `dq` is set.
+function unescape(text, dq,   out, k, n, ch, nx) {
+  out = ""
+  n = length(text)
+  for (k = 1; k <= n; k++) {
+    ch = substr(text, k, 1)
+    if (ch == "\\" && k < n) {
+      nx = substr(text, k + 1, 1)
+      if (nx == "\\" || nx == "`" || nx == "$" || (dq && nx == "\"")) {
+        ch = nx
+        k++
+      }
+    }
+    out = out ch
+  }
+  return out
+}
+# A `$( )` opens at `i`. Whatever the scan held open is saved for the `)` that
+# closes it, the body starts with nothing open, and only a body at the
+# outermost level is gathered.
+function open_subst() {
+  held_quote[depth] = quote; held_paren[depth] = paren; held_arith[depth] = arith
+  depth++
+  quote = ""; paren = 0; arith = 0
+  if (depth == 1) { body = ""; start = i + 2; opened = FNR }
+}
+# A backquote opens at `i`. 3.2 also removes the backslash before a `"` in its
+# body when it opens inside a double-quoted string, and not inside `$(( ))`
+# or a heredoc body there, measured under the pinned image.
+function open_bq() {
+  bq = 1; bqstart = i + 1; bqline = FNR
+  bqdq = (quote == "\"" && arith == 0 && !(word_body && depth == 0))
 }
 # A file whose last line leaves a substitution, a quote, a backquote,
 # arithmetic or a heredoc open is one this scan lost track of. Every caller
@@ -225,7 +278,7 @@ function open_body() {
   strip_tabs = dash[1]
   if (bare[1]) { word_body = 1; quote = "\"" }
 }
-BEGIN { id = 0; file = "" }
+BEGIN { id = first; file = "" }
 FNR == 1 {
   settle()
   file = FILENAME
@@ -262,25 +315,31 @@ FNR == 1 {
   prev = "\n"
   while (i <= last) {
     c = substr(line, i, 1)
-    # `$(( ))` is arithmetic, not a command list, and its parens balance, so
-    # the scan steps over it rather than handing its text to a shell parser.
-    if (arith > 0) {
-      if (c == "\\") { i += 2; prev = "x"; continue }
-      if (c == "(") arith++
-      else if (c == ")") arith--
-      i++; prev = c; continue
-    }
     # A backquote body ends at the next unescaped backquote, whatever parens
     # or quotes it holds. That delimiter cannot be closed early the way a
     # paren count can, but its body goes unparsed by `bash -n` all the same.
+    # Looked for ahead of arithmetic, which a backquote can open inside.
     if (bq) {
       if (c == "\\") { i += 2; prev = "x"; continue }
       if (c == "`") {
         bqbody = bqbody substr(line, bqstart, i - bqstart)
         bq = 0
-        keep(bqbody, bqline)
+        if (depth == 0) keep(unescape(bqbody, bqdq), bqline)
         bqbody = ""
       }
+      i++; prev = c; continue
+    }
+    # `$(( ))` is arithmetic, not a command list, and its parens balance, so
+    # the scan counts them rather than handing its text to a shell parser. A
+    # `$( )` or a backquote inside it is a command list all the same.
+    if (arith > 0) {
+      if (c == "\\") { i += 2; prev = "x"; continue }
+      if (c == "`") { open_bq(); i++; prev = c; continue }
+      if (c == "$" && substr(line, i + 1, 1) == "(" && substr(line, i + 2, 1) != "(") {
+        open_subst(); i += 2; prev = "x"; continue
+      }
+      if (c == "(") arith++
+      else if (c == ")") arith--
       i++; prev = c; continue
     }
     if (quote == "'") {
@@ -293,14 +352,10 @@ FNR == 1 {
     if (quote == "\"") {
       if (c == "\\") { i += 2; prev = "x"; continue }
       if (c == "\"" && !(word_body && depth == 0)) { quote = ""; i++; prev = c; continue }
-      if (c == "`") { bq = 1; bqstart = i + 1; bqline = FNR; i++; prev = c; continue }
+      if (c == "`") { open_bq(); i++; prev = c; continue }
       if (c == "$" && substr(line, i + 1, 1) == "(") {
         if (substr(line, i + 2, 1) == "(") { arith = 2; i += 3; prev = "x"; continue }
-        held_quote[depth] = quote; held_paren[depth] = paren
-        depth++
-        quote = ""; paren = 0
-        body[depth] = ""; start[depth] = i + 2; opened[depth] = FNR
-        i += 2; prev = "x"; continue
+        open_subst(); i += 2; prev = "x"; continue
       }
       i++; prev = c; continue
     }
@@ -308,14 +363,10 @@ FNR == 1 {
     if (c == "'") { quote = "'"; ansi_c = (prev == "$"); i++; prev = c; continue }
     if (c == "\"") { quote = "\""; i++; prev = c; continue }
     if (c == "#" && word_start(prev)) break
-    if (c == "`") { bq = 1; bqstart = i + 1; bqline = FNR; i++; prev = c; continue }
+    if (c == "`") { open_bq(); i++; prev = c; continue }
     if (c == "$" && substr(line, i + 1, 1) == "(") {
       if (substr(line, i + 2, 1) == "(") { arith = 2; i += 3; prev = "x"; continue }
-      held_quote[depth] = quote; held_paren[depth] = paren
-      depth++
-      quote = ""; paren = 0
-      body[depth] = ""; start[depth] = i + 2; opened[depth] = FNR
-      i += 2; prev = "x"; continue
+      open_subst(); i += 2; prev = "x"; continue
     }
     if (c == "(") {
       # `(( ))` opening a word is an arithmetic command, not two subshells,
@@ -328,10 +379,9 @@ FNR == 1 {
     if (c == ")") {
       if (paren > 0) paren--
       else if (depth > 0) {
-        body[depth] = body[depth] substr(line, start[depth], i - start[depth])
-        keep(body[depth], opened[depth])
+        if (depth == 1) keep(body substr(line, start, i - start), opened)
         depth--
-        quote = held_quote[depth]; paren = held_paren[depth]
+        quote = held_quote[depth]; paren = held_paren[depth]; arith = held_arith[depth]
       }
       i++; prev = c; continue
     }
@@ -378,10 +428,7 @@ FNR == 1 {
     }
     i++; prev = c; continue
   }
-  for (k = 1; k <= depth; k++) {
-    body[k] = body[k] substr(line, start[k]) "\n"
-    start[k] = 1
-  }
+  if (depth > 0) { body = body substr(line, start) "\n"; start = 1 }
   if (bq) { bqbody = bqbody substr(line, bqstart) "\n"; bqstart = 1 }
   if (in_heredoc) next
   if (pending > 0 && depth == 0 && quote == "" && !bq) {
@@ -429,51 +476,85 @@ if [ "${1-}" = "--check" ]; then
   # reporting the bodies it did reach.
   parsed=0
   failed=0
-  taken=0
-  scanned=()
+  fed=0
+  feed=()
   for f in "$@"; do
     parsed=$((parsed + 1))
     if "$BASH" -n -- "$f"; then
-      scanned[$taken]="$f"
-      taken=$((taken + 1))
+      feed[$fed]="$f"
+      fed=$((fed + 1))
     else
       failed=$((failed + 1))
     fi
   done
 
-  : >"$SCRATCH/index" || die extractor "$SCRATCH/index"
-  if [ "$taken" -gt 0 ]; then
+  # Then the bodies, in rounds: each round scans what the one before it
+  # accepted, the files and then bodies, and the rounds end when one takes no
+  # body, which they must, every body being shorter than the text it was cut
+  # from. Rounds after the first run inside the body directory and name each
+  # body by its bare id, so the argument list stays short however many bodies
+  # a round feeds.
+  #
+  # Each body is parsed on stdin, so what the shell says names a line in the
+  # body it was given rather than a path in a directory that is gone by the
+  # time anyone reads it; the line above its words names the file and the
+  # line the body was cut from, carried through every round. A file is
+  # counted once however many of its bodies fail, in whichever round.
+  NL='
+'
+  failed_src=""
+  origin_src=()
+  origin_line=()
+  last_id=0
+  round=0
+  here="$PWD"
+  while [ "$fed" -gt 0 ]; do
     status=0
-    awk -v dir="$SCRATCH/bodies" -v lost="$SCRATCH/lost" \
-      -f "$SCRATCH/substs.awk" -- "${scanned[@]}" \
+    (cd -- "$here" && awk -v dir="$SCRATCH/bodies" -v lost="$SCRATCH/lost" \
+      -v first="$last_id" -f "$SCRATCH/substs.awk" -- "${feed[@]}") \
       >"$SCRATCH/index" 2>"$SCRATCH/extract-err" || status=$?
     [ "$status" -eq 0 ] ||
       die_cause extractor "$status" "$(cat "$SCRATCH/extract-err")"
-    [ ! -s "$SCRATCH/lost" ] ||
-      die_cause unscannable "$(wc -l <"$SCRATCH/lost" | tr -d ' ')" \
-        "$(cat "$SCRATCH/lost")"
-  fi
-
-  # Each body on stdin, so what the shell says names a line in the body it
-  # was given rather than a path in a directory that is gone by the time
-  # anyone reads it; the line above its words names the file and the line the
-  # body was cut from. A file is counted once however many of its bodies
-  # fail, and its bodies are consecutive here because they are emitted in the
-  # order the files were handed over.
-  last_bad=""
-  while read -r id at src; do
-    [ -n "$id" ] || continue
-    if "$BASH" -n <"$SCRATCH/bodies/$id" 2>"$SCRATCH/body-err"; then
-      continue
+    if [ -s "$SCRATCH/lost" ]; then
+      where=""
+      while IFS= read -r from; do
+        [ "$round" -eq 0 ] ||
+          from="${origin_src[$from]}: line ${origin_line[$from]}"
+        where="$where$NL$from"
+      done <"$SCRATCH/lost"
+      die_cause unscannable "$(wc -l <"$SCRATCH/lost" | tr -d ' ')" "${where#"$NL"}"
     fi
-    printf '%s: line %s: the command substitution body Bash 3.2 delimits here does not parse:\n' \
-      "$src" "$at" >&2
-    sed 's/^/  /' "$SCRATCH/body-err" >&2
-    if [ "$src" != "$last_bad" ]; then
-      failed=$((failed + 1))
-      last_bad="$src"
-    fi
-  done <"$SCRATCH/index"
+    fed=0
+    feed=()
+    while read -r id at from; do
+      [ -n "$id" ] || continue
+      last_id="$id"
+      src="$from"
+      if [ "$round" -gt 0 ]; then
+        src="${origin_src[$from]}"
+        at=$((${origin_line[$from]} + at - 1))
+      fi
+      if "$BASH" -n <"$SCRATCH/bodies/$id" 2>"$SCRATCH/body-err"; then
+        origin_src[$id]="$src"
+        origin_line[$id]="$at"
+        feed[$fed]="$id"
+        fed=$((fed + 1))
+        continue
+      fi
+      printf '%s: line %s: the command substitution body Bash 3.2 delimits here does not parse:\n' \
+        "$src" "$at" >&2
+      sed 's/^/  /' "$SCRATCH/body-err" >&2
+      case "$NL$failed_src$NL" in
+      *"$NL$src$NL"*) ;;
+      *)
+        failed_src="$failed_src$NL$src"
+        failed=$((failed + 1))
+        ;;
+      esac
+    done <"$SCRATCH/index"
+    here="$SCRATCH/bodies"
+    round=$((round + 1))
+  done
 
   printf 'bash32-parse: parsed=%s\n' "$parsed"
   printf 'bash32-parse: failed=%s\n' "$failed"

--- a/tools/bash32-parse
+++ b/tools/bash32-parse
@@ -170,13 +170,21 @@ die_cause() { # KEY VALUE CAUSE — CAUSE is the failing command's own words
 # next unescaped backquote, so the early close above cannot reach them, but
 # `bash -n` leaves their body unparsed exactly as it leaves a `$( )` body.
 #
-# What it does not reach, each an under-read that reports nothing rather than
-# something wrong: the inside of `$(( ))`, which is arithmetic and not a
-# command list; and a heredoc body at the top level, which Bash reads as a
-# word and expands later, and which a quoted delimiter makes literal text, so
-# scanning it as code would red on correct source. A heredoc opened INSIDE a
-# body is scanned, because 3.2's paren count runs straight through one —
-# measured under the pinned image, not assumed.
+# A heredoc body at the top level is a WORD Bash reads whole and expands
+# later, so the spelling that opened it decides everything. A quoted
+# delimiter (`<<'EOF'`, `<<"EOF"`, `<<\EOF`) makes the body literal text that
+# is never expanded and so never parsed, and it is passed over: scanning
+# prose as code would red on correct source. An unquoted delimiter DOES
+# expand it, and a `$( )` in there carries the construct above as surely as
+# one in code, so that body is scanned in the only mode true of a word —
+# `$(`, a backquote and a backslash act, and a loose quote or paren outside
+# an open body is a character. A heredoc opened INSIDE a body is neither,
+# because 3.2's paren count runs straight through one — measured under the
+# pinned image, not assumed.
+#
+# What it does not reach: the inside of `$(( ))`, which is arithmetic and not
+# a command list. That is an under-read, reporting nothing rather than
+# something wrong.
 extractor_program() { # the awk program, on stdout
   cat <<'EXTRACTOR'
 # Every command substitution body in the files named on the command line,
@@ -210,28 +218,44 @@ function settle() {
   if (depth != 0 || quote != "" || bq != 0 || arith != 0 || pending != 0)
     print file > lost
 }
+# The body of the heredoc now at the head of the queue. An unquoted delimiter
+# expands it, and an expanded word is what a double-quoted string is with the
+# closing `"` taken away, which is how `word_body` reads below.
+function open_body() {
+  strip_tabs = dash[1]
+  if (bare[1]) { word_body = 1; quote = "\"" }
+}
 BEGIN { id = 0; file = "" }
 FNR == 1 {
   settle()
   file = FILENAME
-  depth = 0; quote = ""; paren = 0; arith = 0; bq = 0; pending = 0; in_heredoc = 0
+  depth = 0; quote = ""; paren = 0; arith = 0; bq = 0; ansi_c = 0
+  pending = 0; in_heredoc = 0; word_body = 0
 }
 {
   line = $0
-  # A heredoc body at the top level is a word Bash reads whole and expands
-  # later, and a quoted delimiter makes it literal text, so it is passed over
-  # rather than scanned as code. Inside a body it is NOT passed over: 3.2's
-  # paren count runs straight through a heredoc body, quoted or not.
+  # The terminator line is found at READ time, before any expansion, so it is
+  # looked for first and whatever the body left open does not hold it back.
+  # What follows depends on the spelling that opened the heredoc: an unquoted
+  # delimiter leaves `word_body` set and the line falls through to be scanned
+  # as an expanded word, a quoted one passes the line over.
   if (in_heredoc) {
     term = line
     if (strip_tabs) sub(/^\t+/, "", term)
     if (term == delim[1]) {
-      for (k = 1; k < pending; k++) { delim[k] = delim[k + 1]; dash[k] = dash[k + 1] }
+      # A substitution still open where the body ends is one Bash 3.2 runs off
+      # the end of too, and this scan can no more say where it ends.
+      if (depth != 0 || bq != 0 || arith != 0) print file > lost
+      depth = 0; quote = ""; paren = 0; bq = 0; arith = 0; word_body = 0
+      for (k = 1; k < pending; k++) {
+        delim[k] = delim[k + 1]; dash[k] = dash[k + 1]; bare[k] = bare[k + 1]
+      }
       pending--
       if (pending == 0) in_heredoc = 0
-      else strip_tabs = dash[1]
+      else open_body()
+      next
     }
-    next
+    if (!word_body) next
   }
   i = 1
   last = length(line)
@@ -260,12 +284,15 @@ FNR == 1 {
       i++; prev = c; continue
     }
     if (quote == "'") {
-      if (c == "'") quote = ""
+      # `$'...'` takes backslash escapes, `'...'` does not, so `\'` ends the
+      # word in one spelling and is a character in the other.
+      if (ansi_c && c == "\\") { i += 2; prev = "x"; continue }
+      if (c == "'") { quote = ""; ansi_c = 0 }
       i++; prev = c; continue
     }
     if (quote == "\"") {
       if (c == "\\") { i += 2; prev = "x"; continue }
-      if (c == "\"") { quote = ""; i++; prev = c; continue }
+      if (c == "\"" && !(word_body && depth == 0)) { quote = ""; i++; prev = c; continue }
       if (c == "`") { bq = 1; bqstart = i + 1; bqline = FNR; i++; prev = c; continue }
       if (c == "$" && substr(line, i + 1, 1) == "(") {
         if (substr(line, i + 2, 1) == "(") { arith = 2; i += 3; prev = "x"; continue }
@@ -278,7 +305,7 @@ FNR == 1 {
       i++; prev = c; continue
     }
     if (c == "\\") { i += 2; prev = "x"; continue }
-    if (c == "'") { quote = "'"; i++; prev = c; continue }
+    if (c == "'") { quote = "'"; ansi_c = (prev == "$"); i++; prev = c; continue }
     if (c == "\"") { quote = "\""; i++; prev = c; continue }
     if (c == "#" && word_start(prev)) break
     if (c == "`") { bq = 1; bqstart = i + 1; bqline = FNR; i++; prev = c; continue }
@@ -315,11 +342,13 @@ FNR == 1 {
       if (substr(line, j, 1) == "-") { indented = 1; j++ }
       while (substr(line, j, 1) == " " || substr(line, j, 1) == "\t") j++
       word = ""
-      # Quoting inside the delimiter word decides whether the body expands,
-      # which this scan does not care about, and Bash strips it before
-      # matching the terminator line, which it does.
+      # Quoting inside the delimiter word decides BOTH things this scan needs:
+      # Bash strips it before matching the terminator line, and its presence
+      # anywhere in the word is what stops the body from being expanded.
+      unquoted = 1
       c2 = substr(line, j, 1)
       if (c2 == "'" || c2 == "\"") {
+        unquoted = 0
         j++
         while (j <= last && substr(line, j, 1) != c2) { word = word substr(line, j, 1); j++ }
         j++
@@ -328,8 +357,9 @@ FNR == 1 {
           c2 = substr(line, j, 1)
           if (c2 == " " || c2 == "\t" || c2 == ";" || c2 == "&" || c2 == "|" ||
               c2 == "<" || c2 == ">" || c2 == ")") break
-          if (c2 == "\\") { j++; c2 = substr(line, j, 1); if (c2 == "") break }
+          if (c2 == "\\") { unquoted = 0; j++; c2 = substr(line, j, 1); if (c2 == "") break }
           else if (c2 == "'" || c2 == "\"") {
+            unquoted = 0
             j++
             while (j <= last && substr(line, j, 1) != c2) { word = word substr(line, j, 1); j++ }
             j++
@@ -338,7 +368,12 @@ FNR == 1 {
           word = word c2; j++
         }
       }
-      if (word != "") { pending++; delim[pending] = word; dash[pending] = indented }
+      # Not while a heredoc body is open: the queue in hand is that body's own
+      # terminator, and a `<<` inside a substitution in it would displace it.
+      if (word != "" && !in_heredoc) {
+        pending++
+        delim[pending] = word; dash[pending] = indented; bare[pending] = unquoted
+      }
       i = j; prev = "x"; continue
     }
     i++; prev = c; continue
@@ -348,8 +383,11 @@ FNR == 1 {
     start[k] = 1
   }
   if (bq) { bqbody = bqbody substr(line, bqstart) "\n"; bqstart = 1 }
-  if (pending > 0 && depth == 0 && !bq) { in_heredoc = 1; strip_tabs = dash[1] }
-  else if (pending > 0) pending = 0
+  if (in_heredoc) next
+  if (pending > 0 && depth == 0 && quote == "" && !bq) {
+    in_heredoc = 1
+    open_body()
+  } else if (pending > 0) pending = 0
 }
 END { settle() }
 EXTRACTOR

--- a/tools/tests/bash32-parse.test.sh
+++ b/tools/tests/bash32-parse.test.sh
@@ -243,6 +243,38 @@ else
   fi
 fi
 
+# The same construct inside a heredoc body. An unquoted delimiter makes the
+# body a word Bash expands, so 3.2 parses its substitution at expansion and
+# refuses it as it refuses the ones above; a quoted delimiter makes the body
+# text that is never expanded, so the identical body is correct source there.
+plant refuse "the same case inside an unquoted heredoc body reds the lane" \
+  'cat <<EOF' \
+  '$(for v in a b; do' \
+  '  case "$v" in' \
+  '    a) echo one ;;' \
+  '    b) echo two ;;' \
+  '  esac' \
+  'done)' \
+  'EOF'
+plant pass "the same case inside a quoted heredoc body passes, never being expanded" \
+  "cat <<'EOF'" \
+  '$(for v in a b; do' \
+  '  case "$v" in' \
+  '    a) echo one ;;' \
+  '    b) echo two ;;' \
+  '  esac' \
+  'done)' \
+  'EOF'
+
+# A backslash escapes a quote inside `$'...'` and is a plain character inside
+# `'...'`. A scan that reads either spelling the other way is still inside a
+# quote at the end of the file, and the run ends at 2 instead of passing. The
+# plain spelling comes first: a scan that misreads `$'...'` is left inside a
+# quote that a `'\'` after it would close again.
+plant pass "ANSI-C and plain single quotes each close where Bash closes them" \
+  "sep='\\'" \
+  "msg=\$'don\\'t'"
+
 # --- 4. the fail-closed paths, each proven red ---------------------------
 # A row is `label|mutation|argv|exit|first`:
 #   mutation  a copy of the lane with one or two of its declaration lines
@@ -492,8 +524,13 @@ extractor_mutant() { # extractor_mutant DIR FROM TO — a lane copy, one line re
 #               than report the bodies it did reach.
 #   BEGIN       the extractor program itself no longer parses, so awk exits
 #               without having read anything.
+#
+# `from` is read twice: as the sed pattern that replaces the line and as the
+# text grep -F counts back afterwards. It is spelled as the lane spells the
+# line, because an escape sed takes is a character grep counts, and a count
+# of a line that never existed passes whether or not the replacement landed.
 extractor_rows="\
-a file the scan loses track of ends the run|      if (substr(line, i + 1, 1) == \"(\" \&\& word_start(prev)) {|      if (0) {|shifted=0; (( shifted = 1 << 2 ))|unscannable=1
+a file the scan loses track of ends the run|      if (substr(line, i + 1, 1) == \"(\" && word_start(prev)) {|      if (0) {|shifted=0; (( shifted = 1 << 2 ))|unscannable=1
 an extractor that cannot run ends the run|BEGIN { id = 0; file = \"\" }|BEGIN { id = 0; file = \"\"|shifted=0|extractor=1"
 
 while IFS='|' read -r label from to fixture inner; do

--- a/tools/tests/bash32-parse.test.sh
+++ b/tools/tests/bash32-parse.test.sh
@@ -266,6 +266,26 @@ plant pass "the same case inside a quoted heredoc body passes, never being expan
   'done)' \
   'EOF'
 
+# The same construct one context further in than a file's own scan reaches,
+# and quoted, so no stray paren is left for a parse of the file to red on:
+# inside a backquote body, and inside `$(( ))`.
+plant refuse "the same case in a quoted substitution inside a backquote body reds the lane" \
+  'x=`y="$(case a in a) echo hi;; esac)"; echo "$y"`' \
+  'printf "%s\n" "$x"'
+plant pass "the same backquote body with balanced patterns passes" \
+  'x=`y="$(case a in (a) echo hi;; esac)"; echo "$y"`' \
+  'printf "%s\n" "$x"'
+plant refuse "the same case in a quoted substitution inside arithmetic reds the lane" \
+  'x=$(( "$(case a in a) echo 1;; esac)" + 1 ))' \
+  'printf "%s\n" "$x"'
+
+# Two backquotes deep, where the raw text hides the substitution: `\\\$` is a
+# `$` only once each level's body has its backslashes removed the way 3.2
+# removes them, so this reds only when every round unescapes and re-feeds.
+plant refuse "the same case behind an escaped backquote inside a backquote body reds the lane" \
+  'x=`echo \`echo "\\\$(case a in a) echo hi;; esac)"\``' \
+  'printf "%s\n" "$x"'
+
 # A backslash escapes a quote inside `$'...'` and is a plain character inside
 # `'...'`. A scan that reads either spelling the other way is still inside a
 # quote at the end of the file, and the run ends at 2 instead of passing. The
@@ -531,7 +551,7 @@ extractor_mutant() { # extractor_mutant DIR FROM TO — a lane copy, one line re
 # of a line that never existed passes whether or not the replacement landed.
 extractor_rows="\
 a file the scan loses track of ends the run|      if (substr(line, i + 1, 1) == \"(\" && word_start(prev)) {|      if (0) {|shifted=0; (( shifted = 1 << 2 ))|unscannable=1
-an extractor that cannot run ends the run|BEGIN { id = 0; file = \"\" }|BEGIN { id = 0; file = \"\"|shifted=0|extractor=1"
+an extractor that cannot run ends the run|BEGIN { id = first; file = \"\" }|BEGIN { id = first; file = \"\"|shifted=0|extractor=1"
 
 while IFS='|' read -r label from to fixture inner; do
   [ -n "$label" ] || continue

--- a/tools/tests/bash32-parse.test.sh
+++ b/tools/tests/bash32-parse.test.sh
@@ -189,6 +189,38 @@ plant pass "the same case with balanced patterns passes" \
   'done)' \
   'printf "%s\n" "$verdicts"'
 
+# The same construct with the substitution inside double quotes. Unquoted, the
+# `)` that ends the case pattern closes the substitution early and leaves a
+# stray one at the top level, which is what the row above reds on; quoted, it
+# lands inside the string and NO Bash refuses the file — 3.2 because it never
+# descends into a body, 5 because it parses the body correctly. That pair is
+# the reach the body parse adds, and the row after them asserts the silence.
+plant refuse "the same case inside a quoted command substitution reds the lane" \
+  'verdicts="$(for v in a b; do' \
+  '  case "$v" in' \
+  '    a) echo one ;;' \
+  '    b) echo two ;;' \
+  '  esac' \
+  'done)"' \
+  'printf "%s\n" "$verdicts"'
+QUOTED_DIR="$PLANT_DIR"
+plant pass "the same quoted case with balanced patterns passes" \
+  'verdicts="$(for v in a b; do' \
+  '  case "$v" in' \
+  '    (a) echo one ;;' \
+  '    (b) echo two ;;' \
+  '  esac' \
+  'done)"' \
+  'printf "%s\n" "$verdicts"'
+
+if [ -z "$QUOTED_DIR" ] || [ ! -f "$QUOTED_DIR/planted.sh" ]; then
+  bad "the quoted planted case file was not kept, so the silence below went unasserted"
+elif bash -n -- "$QUOTED_DIR/planted.sh" 2>/dev/null; then
+  ok "Bash $BASH_VERSION parses the quoted planted file whole, so the red above came from the body parse"
+else
+  bad "Bash $BASH_VERSION refused the quoted planted file whole, so the red above proves nothing about the body parse"
+fi
+
 # The two readers that miss it, asserted on the very file the row above
 # reddened: the host shell parses it, and the lint's text scan calls the
 # directory clean. Without both, the red above could be any syntax error.
@@ -427,6 +459,63 @@ EOF
   printf 'no fail-closed row was asserted\n' >&2
   exit 2
 }
+
+# --- 4b. the extractor's own two ways of not running ---------------------
+# Both rows run the SHIPPED lane end to end under the real Bash 3.2, because
+# the stub worlds in section 4 answer the check pass themselves and never
+# reach the extractor inside it. Each stages a copy of the lane with ONE line
+# of its extractor replaced, so the row turns on that line's absence and not
+# on the extractor being gone.
+#
+# The keyed line the outer pass answers with is `no-verdict`: the inner pass
+# writes its own refusal to stderr and nothing at all to stdout, which is
+# what the outer can honestly say it read. The inner key is asserted under
+# it, so the row tells the two apart.
+extractor_mutant() { # extractor_mutant DIR FROM TO — a lane copy, one line replaced
+  mkdir -p "$1/tools" || return 1
+  cp "$LINT" "$1/tools/bash32-lint" || return 1
+  sed "s|^$2\$|$3|" "$PARSE" >"$1/tools/bash32-parse" || return 1
+  chmod +x "$1/tools/bash32-parse" || return 1
+  # Asserted in both directions: an expression that matched nothing would run
+  # the shipped extractor and score the row it was meant to force.
+  [ "$(grep -Fxc -- "$3" "$1/tools/bash32-parse")" -eq 1 ] || return 1
+  [ "$(grep -Fxc -- "$2" "$1/tools/bash32-parse")" -eq 0 ] || return 1
+}
+
+# A row is `label|from|to|fixture|inner key`. The fixture is one line of
+# correct Bash 3.2 that the shipped extractor reads and the copy cannot; both
+# fixtures also carry a command substitution, so a copy that reached the body
+# parse at all would have had one to report.
+#   arithmetic  `(( ))` is an arithmetic command, where `<<` is a shift. A
+#               copy that reads it as two subshells takes the shift for a
+#               heredoc, loses the rest of the file, and must refuse rather
+#               than report the bodies it did reach.
+#   BEGIN       the extractor program itself no longer parses, so awk exits
+#               without having read anything.
+extractor_rows="\
+a file the scan loses track of ends the run|      if (substr(line, i + 1, 1) == \"(\" \&\& word_start(prev)) {|      if (0) {|shifted=0; (( shifted = 1 << 2 ))|unscannable=1
+an extractor that cannot run ends the run|BEGIN { id = 0; file = \"\" }|BEGIN { id = 0; file = \"\"|shifted=0|extractor=1"
+
+while IFS='|' read -r label from to fixture inner; do
+  [ -n "$label" ] || continue
+  EW="$W/extractor-$((PASS + FAIL))"
+  if ! mkdir -p "$EW/world" || ! extractor_mutant "$EW" "$from" "$to"; then
+    bad "$label" "the row's lane copy could not be staged"
+    continue
+  fi
+  printf '%s\n' '#!/usr/bin/env bash' "$fixture" 'seen="$(printf %s body)"' \
+    'printf "%s\n" "$seen"' >"$EW/world/real.sh"
+  run "$EW/tools/bash32-parse" "$EW/world"
+  if [ "$RC" -eq 2 ] && [ "$FIRST" = "no-verdict=2" ] &&
+    [ "${OUT#*"bash32-parse: $inner"}" != "$OUT" ]; then
+    ok "$label"
+  else
+    bad "$label (want rc=2 first=no-verdict=2 carrying $inner, got rc=$RC first=$FIRST)" \
+      "$(printf '%s' "$OUT" | tr '\n' ';')"
+  fi
+done <<EOF
+$extractor_rows
+EOF
 
 # --- 5. a runtime that cannot deliver does not shadow one that can -------
 # The lane names more than one, and what a candidate ANSWERS decides it, not

--- a/tools/tests/bash32-parse.test.sh
+++ b/tools/tests/bash32-parse.test.sh
@@ -534,7 +534,11 @@ extractor_mutant() { # extractor_mutant DIR FROM TO — a lane copy, one line re
   [ "$(grep -Fxc -- "$2" "$1/tools/bash32-parse")" -eq 0 ] || return 1
 }
 
-# A row is `label|from|to|fixture|inner key`. The fixture is one line of
+# A row is `label|from|to|fixture|inner`, `inner` being the refusal the pass
+# under 3.2 writes as `<key>=<value>`. The value `nonzero` is any nonzero
+# status: `extractor=` carries awk's own exit status, and awks disagree on it
+# (BSD awk and mawk exit 2 on a program that does not parse, gawk and busybox
+# exit 1). The fixture is one line of
 # correct Bash 3.2 that the shipped extractor reads and the copy cannot; both
 # fixtures also carry a command substitution, so a copy that reached the body
 # parse at all would have had one to report.
@@ -551,7 +555,7 @@ extractor_mutant() { # extractor_mutant DIR FROM TO — a lane copy, one line re
 # of a line that never existed passes whether or not the replacement landed.
 extractor_rows="\
 a file the scan loses track of ends the run|      if (substr(line, i + 1, 1) == \"(\" && word_start(prev)) {|      if (0) {|shifted=0; (( shifted = 1 << 2 ))|unscannable=1
-an extractor that cannot run ends the run|BEGIN { id = first; file = \"\" }|BEGIN { id = first; file = \"\"|shifted=0|extractor=1"
+an extractor that cannot run ends the run|BEGIN { id = first; file = \"\" }|BEGIN { id = first; file = \"\"|shifted=0|extractor=nonzero"
 
 while IFS='|' read -r label from to fixture inner; do
   [ -n "$label" ] || continue
@@ -563,11 +567,19 @@ while IFS='|' read -r label from to fixture inner; do
   printf '%s\n' '#!/usr/bin/env bash' "$fixture" 'seen="$(printf %s body)"' \
     'printf "%s\n" "$seen"' >"$EW/world/real.sh"
   run "$EW/tools/bash32-parse" "$EW/world"
-  if [ "$RC" -eq 2 ] && [ "$FIRST" = "no-verdict=2" ] &&
-    [ "${OUT#*"bash32-parse: $inner"}" != "$OUT" ]; then
+  key="${inner%%=*}"
+  want="${inner#*=}"
+  got="$(printf '%s\n' "$OUT" | sed -n "s/^bash32-parse: $key=//p")"
+  matched=no
+  case "$want:$got" in
+  nonzero:'' | nonzero:0 | nonzero:*[!0-9]*) ;;
+  nonzero:*) matched=yes ;;
+  *) [ "$got" != "$want" ] || matched=yes ;;
+  esac
+  if [ "$RC" -eq 2 ] && [ "$FIRST" = "no-verdict=2" ] && [ "$matched" = yes ]; then
     ok "$label"
   else
-    bad "$label (want rc=2 first=no-verdict=2 carrying $inner, got rc=$RC first=$FIRST)" \
+    bad "$label (want rc=2 first=no-verdict=2 carrying $inner, got rc=$RC first=$FIRST $key=${got:--})" \
       "$(printf '%s' "$OUT" | tr '\n' ';')"
   fi
 done <<EOF


### PR DESCRIPTION
## Summary

- `tools/bash32-parse` now parses every command substitution body on its own under the real Bash 3.2, including bodies nested inside other bodies. Before this change, a `case` with no leading `(` on its patterns inside `$( )` passed the lane and failed only on the macOS shard. That construct is the one named in the lane's own header.
- An embedded POSIX awk program finds the end of each outermost `$( )` and backquote body the way Bash 3.2 does: it counts parens and tracks quotes, comments and nesting. Each body goes to `bash -n` inside the existing `--check` pass. Each body that parses is then fed back through the same program as its own script, over and over until no new bodies come out. That mirrors what 3.2 does at expansion, where it parses each body as a fresh script. The text handed to `bash -n` is the text 3.2 would parse, so a scan that cuts a body in the wrong place produces a body that does not parse. The result is a red, never a silent green.
- The pass refuses with exit 2 in two cases. `bash32-parse: unscannable=<n>` means the scan could not reach the end of a file or body that 3.2 already accepted; it names the source file and line. `bash32-parse: extractor=<step|status>` means the extractor could not run. The outer pass reports both as `no-verdict=2`. The two-line `--check` stdout protocol is unchanged: both counts are still files, and a file counts once however many of its bodies fail.

## Premise, verified

Measured under the pinned `bash:3.2.57` image. `bash -n` never parses a command substitution body, in any spelling:

| file body | `bash -n` | running it |
|---|---|---|
| `x="$(case "$v" in foo) echo one ;; esac)"` | exit 0, silent | `syntax error near unexpected token` |
| `` x=`case "$v" in foo) echo one ;; esac` `` | exit 0, silent | error |
| `x="$( if then fi )"`, `x=$( if then fi )` | exit 0, silent | error |
| `x=$(case "$v" in foo) ...)` unquoted | exit 2, caught only because the stray `)` closes the substitution early | |

Neither `--posix` nor `-O extglob` changes this. The cause: 3.2 finds the end of `$( )` by counting parens, not by parsing, so `foo)` in a case pattern ends the substitution early. 3.2 then parses what it cut out, at expansion rather than at read. This PR copies that rule for finding the end of a body instead of approximating a parser.

## What it reaches, and what it does not

- **Reached:** `$( )` and backquote bodies, quoted or unquoted, at any nesting depth. That includes a `$( )` inside a backquote body, a backquote inside `$( )`, and a `$( )` or backquote inside `$(( ))`. A backquote body is unescaped the way 3.2 does it before it is parsed: the backslash comes off before `\`, a backquote and `$`, and also before `"` when the backquote opens inside a double-quoted string. This was measured under the pinned image. Also reached: a heredoc body whose delimiter is unquoted. Bash expands that body, so its substitutions are scanned treating the body as one expanded word.
- **Passed over, stated in the file:** heredoc bodies with a quoted delimiter (`<<'EOF'`, `<<"EOF"`, `<<\EOF`), whose text is literal and never expanded. Also process substitution bodies, `<( )` and `>( )`. Those are also parsed only at expansion, but an error inside one fails at runtime on every bash, not just 3.2. A KEN-1326 `case` inside one still reds at the file level, because the early close leaves `;;` or `esac` at the top level.

## Review

**Local, before the PR.** One `reviewer-correctness` round found one blocker and two suggestions, all fixed:

1. **Blocker, fail-open.** The first cut skipped every top-level heredoc body, but its stated reason covered only a quoted delimiter. Reproduced: `cat <<EOF` / the construct / `EOF` got `clean=1` while 3.2 refuses the file. Fixed by recording whether the delimiter is quoted and scanning unquoted bodies as expanded text. The reviewer also offered narrowing the `clean=` message instead; that was declined, because this is gate code and the defect let a broken file pass.
2. `$'don\'t'` left the scanner inside a quote at end of file, so the whole run stopped with `unscannable` / exit 2. The scanner now honours `\'` only inside `$'...'`.
3. One test row's reverse assertion could not fail, because a literal `\&` never matched the file. It is now spelled so the assertion can fail.

**On this PR.**

1. **Nested substitutions (Copilot, real, fixed).** A quoted `$(case a in a) …)` inside a backquote body passed the lane while 3.2 fails the file at runtime. The same happened inside `"`…`"`, as an escaped nested backquote, and as a quoted `$( )` inside `$(( ))`. Fixed by the re-feed described above, which closes the whole class of substitutions nested in a body rather than patching only the backquote branch. A single re-feed round was measured to be not enough, so the loop runs until nothing new comes out.
2. **A `#` right after `$(` (Copilot, declined).** 3.2 treats that `#` as a comment only while reading the file. When it expands the substitution, it closes at the comment's `)`. The lane already matches 3.2 in every placement measured, and the suggested change would red files that 3.2 runs cleanly.
3. **macOS CI.** The row for an extractor that cannot run required `extractor=1`. That value is awk's own exit status for a program that does not parse: busybox awk and gawk exit 1, while BSD awk and mawk exit 2. So the macOS guards shard failed that row even though the refusal itself was correct there. The row now asserts the key and a nonzero value.

## Done-when → files

| Done-when | Files |
|---|---|
| `bash32-parse` reaches command-substitution bodies under Bash 3.2, so the header construct is refused before the macOS shard | `tools/bash32-parse` |
| A test plants the construct inside `$( )` and reddens; the leading-paren spelling stays clean | `tools/tests/bash32-parse.test.sh` |

## Completed Issues

- Closes KEN-1326 - bash32-parse cannot see a case inside a command substitution, the construct its header names

## Size

KEN-1326 states no `**Expected delta**`. Measured: production 395, test 158, render mirror 0.

## Test Plan

- `tools/tests/bash32-parse.test.sh`: 32 pass, 0 fail. Must-fail controls, each red against the lane from before its fix and green on this one:
  - the quoted `"$(case … foo) … esac)"` plant reds; the `$(case "$x" in (pat) … esac)` spelling stays clean
  - the construct inside an unquoted heredoc body reds; the quoted-delimiter spelling stays clean
  - `$'don\'t'` stays clean rather than ending the run at exit 2
  - a quoted `$(case …)` inside a backquote body reds, and its `(a)` inverse stays clean
  - an escaped nested backquote holding the construct reds, and goes clean again when the unescape step is removed or only one re-feed round runs
  - a quoted `$( )` holding the construct inside `$(( ))` reds
- `tools/bash32-parse` over the full covered set: `clean=570`, 0 unscannable. The re-feed runs five rounds over the tree: 8419, 796, 77, 1, then 0 bodies, 9293 in total. No repository source was rewritten to get there; every false red found along the way was a scanner fix.
- awk portability: the extractor output (index and body files) is byte-identical in every re-feed round under the pinned image's busybox awk, original-awk (one-true-awk, the lineage macOS ships), mawk and gawk.
- Lane cost goes from about 4s on main to about 13s.
- `env -u TMPDIR tools/guard --full` on the final head.

https://claude.ai/code/session_01HYKG6nZMD8wNiKnZEwUXLq
