### PR TITLE
fix(KEN-1327): Template install: a bundle and a plugin under one name share manifest.bundles but contested() keys on kind

### DIFF
--- a/changelog.d/fixed/KEN-1327.md
+++ b/changelog.d/fixed/KEN-1327.md
@@ -1,0 +1,1 @@
+- A template holding a bundle and a plugin under one name is refused as one contested name before anything is written, instead of installing the first and refusing the second part-way.

--- a/crates/core/src/template/install.rs
+++ b/crates/core/src/template/install.rs
@@ -22,7 +22,7 @@ use crate::manifest::{ItemDecl, LOCAL_SOURCE_NAME, Manifest, Method};
 use crate::model::{HarnessId, ItemKind, Scope};
 use crate::source::local_slot;
 
-use super::{MemberKind, MemberSource, Template, store};
+use super::{MemberKind, MemberSource, Namespace, Template, store};
 
 /// One package a resolved group installs.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Type)]
@@ -167,7 +167,7 @@ pub fn resolve(env: &Env, template: &Template) -> Result<Resolution> {
     let contested = contested(&template.members);
     let mut missing: Vec<MissingMember> = contested.values().cloned().collect();
     for member in &template.members {
-        if contested.contains_key(&(member.kind, member.name.clone())) {
+        if contested.contains_key(&(member.kind.namespace(), member.name.clone())) {
             continue;
         }
         match &member.source {
@@ -200,24 +200,25 @@ pub fn resolve(env: &Env, template: &Template) -> Result<Resolution> {
                     });
                     continue;
                 }
-                match member.kind.item() {
-                    // A plugin is its registry's own curated set, so it
-                    // installs as one — the same reading every install
-                    // path gives it. It keeps its own kind on the row, so
-                    // a surface acting on that row can still name it.
-                    None | Some(ItemKind::Plugin) => group.bundles.push(ResolvedSet {
+                // Routed by the table the member declares in, the same
+                // judge `contested` keys on, so what this offers and what
+                // that refuses cannot disagree. A set keeps its own kind
+                // on the row, so a surface acting on that row can still
+                // name a plugin as one.
+                match member.kind.namespace() {
+                    Namespace::Set => group.bundles.push(ResolvedSet {
                         name: member.name.clone(),
                         enabled: member.enabled,
                         kind: member.kind,
                     }),
-                    Some(ItemKind::PiExtension) => missing.push(MissingMember {
+                    Namespace::Item(ItemKind::PiExtension) => missing.push(MissingMember {
                         kind: member.kind,
                         name: member.name.clone(),
                         repo: Some(repo.clone()),
                         which: which_of(member),
                         why: super::PI_EXTENSION_DIRECT.to_owned(),
                     }),
-                    Some(kind) => group.items.push(ResolvedItem {
+                    Namespace::Item(kind) => group.items.push(ResolvedItem {
                         kind,
                         name: member.name.clone(),
                         enabled: member.enabled,
@@ -489,20 +490,28 @@ fn no_longer_offered(repo: &str) -> String {
 /// with the first group's writes already on disk, and a copy taken after a
 /// marketplace member of the same name replaces the declaration this run
 /// had just written.
-fn contested(members: &[super::Member]) -> BTreeMap<(MemberKind, String), MissingMember> {
-    let mut claimed: BTreeMap<(MemberKind, String), Vec<&super::Member>> = BTreeMap::new();
+///
+/// Keyed on the table a member declares in rather than on its kind, because
+/// that is what a place keys on: a bundle and a plugin under one name are
+/// two kinds and one `[bundles.<name>]`, and `resolve` routes both there by
+/// the same judge.
+fn contested(members: &[super::Member]) -> BTreeMap<(Namespace, String), MissingMember> {
+    let mut claimed: BTreeMap<(Namespace, String), Vec<&super::Member>> = BTreeMap::new();
     for member in members {
         claimed
-            .entry((member.kind, member.name.clone()))
+            .entry((member.kind.namespace(), member.name.clone()))
             .or_default()
             .push(member);
     }
     claimed
         .into_iter()
         .filter(|(_, claimants)| claimants.len() > 1)
-        .map(|((kind, name), claimants)| {
+        .map(|((namespace, name), claimants)| {
             let row = MissingMember {
-                kind,
+                // The first claimant's kind: the row carries one, and the
+                // way out the text names is removing one claimant, which a
+                // surface acting on this row does by that kind and name.
+                kind: claimants[0].kind,
                 name: name.clone(),
                 // Neither claimant's repository, because the row is about
                 // the name rather than about one of them — and a surface
@@ -510,15 +519,18 @@ fn contested(members: &[super::Member]) -> BTreeMap<(MemberKind, String), Missin
                 // name, which is what [`super::MemberWhich::Any`] says.
                 repo: None,
                 which: super::MemberWhich::Any,
-                why: two_claims(kind, &name, &claimants),
+                why: two_claims(&name, &claimants),
             };
-            ((kind, name), row)
+            ((namespace, name), row)
         })
         .collect()
 }
 
-/// Said for a name two members claim, naming where each of them came from.
-fn two_claims(kind: MemberKind, name: &str, claimants: &[&super::Member]) -> String {
+/// Said for a name two members claim, naming what each of them was saved
+/// as and where it came from. The kind rides on each claimant rather than
+/// once up front because the claimants need not share one: a bundle and a
+/// plugin collide too.
+fn two_claims(name: &str, claimants: &[&super::Member]) -> String {
     let came_from = |member: &super::Member| match &member.source {
         MemberSource::Marketplace { repo, .. } => {
             format!("from {}", crate::names::shown(repo))
@@ -531,11 +543,13 @@ fn two_claims(kind: MemberKind, name: &str, claimants: &[&super::Member]) -> Str
         ),
         MemberSource::Copy { from: None, .. } => "as this template's own copy".to_owned(),
     };
-    let each: Vec<String> = claimants.iter().map(|member| came_from(member)).collect();
+    let shown = crate::names::shown(name);
+    let each: Vec<String> = claimants
+        .iter()
+        .map(|member| format!("{} '{shown}' {}", member.kind.name(), came_from(member)))
+        .collect();
     format!(
-        "this template holds {} '{}' {} — a place declares one package under a name, so remove one of them or save them in two templates",
-        kind.name(),
-        crate::names::shown(name),
+        "this template holds {} — a place declares one package under a name, so remove one of them or save them in two templates",
         each.join(" and ")
     )
 }
@@ -740,7 +754,9 @@ pub fn install(
                 ItemKind::Hook => request.hooks.push(item.name.clone()),
                 ItemKind::Command => request.commands.push(item.name.clone()),
                 ItemKind::McpServer => request.mcp_servers.push(item.name.clone()),
-                ItemKind::Plugin => request.bundles.push(item.name.clone()),
+                ItemKind::Plugin => unreachable!(
+                    "a plugin declares in [bundles.<name>]: MemberKind::namespace routes it to the group's sets, never its items"
+                ),
                 ItemKind::PiExtension => request.pi_extensions.push(item.name.clone()),
             }
         }

--- a/crates/core/src/template/mod.rs
+++ b/crates/core/src/template/mod.rs
@@ -80,6 +80,25 @@ impl MemberKind {
         }
     }
 
+    /// Where a place declares this member: the manifest table its name
+    /// lands in. The one judge of what an install writes and of which
+    /// members can collide — two members that land in one table under one
+    /// name are one declaration, whatever kind each was saved as.
+    pub fn namespace(self) -> Namespace {
+        match self {
+            // A plugin is its registry's own curated set and installs as
+            // one, so it is declared beside a bundle rather than beside the
+            // kind it names.
+            MemberKind::Plugin | MemberKind::Bundle => Namespace::Set,
+            MemberKind::Agent => Namespace::Item(ItemKind::Agent),
+            MemberKind::Skill => Namespace::Item(ItemKind::Skill),
+            MemberKind::Hook => Namespace::Item(ItemKind::Hook),
+            MemberKind::Command => Namespace::Item(ItemKind::Command),
+            MemberKind::McpServer => Namespace::Item(ItemKind::McpServer),
+            MemberKind::PiExtension => Namespace::Item(ItemKind::PiExtension),
+        }
+    }
+
     pub fn of(kind: ItemKind) -> MemberKind {
         match kind {
             ItemKind::Agent => MemberKind::Agent,
@@ -98,6 +117,17 @@ impl MemberKind {
             None => "bundle",
         }
     }
+}
+
+/// The manifest table a member's name is declared in when the template is
+/// installed. Read off [`MemberKind::namespace`] and nowhere else.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+pub enum Namespace {
+    /// `[<kind>.<name>]`, the table for that kind of package. Never
+    /// [`ItemKind::Plugin`], which has no such table: a plugin is a set.
+    Item(ItemKind),
+    /// `[bundles.<name>]`, where a bundle and a plugin alike land.
+    Set,
 }
 
 /// Where a member's content comes from when the template is installed.

--- a/crates/core/src/template/tests/install.rs
+++ b/crates/core/src/template/tests/install.rs
@@ -687,6 +687,118 @@ fn one_name_claimed_by_two_members_refuses_before_anything_is_written() {
     }
 }
 
+/// A bundle and a plugin are two kinds and one `[bundles.<name>]`, so one
+/// name held as both is one contested name: resolution refuses it before
+/// anything is written, naming both claimants, and under two names the
+/// pair installs. Keyed on the member kind instead, the preview offered
+/// both and the install declared the first and refused the second with the
+/// first's writes on disk.
+#[test]
+#[allow(clippy::unwrap_used)]
+fn a_bundle_and_a_plugin_under_one_name_are_one_contested_name() {
+    let project = seeded();
+    let market = |kind: MemberKind, name: &str, repo: &str| Member {
+        kind,
+        name: name.to_owned(),
+        enabled: true,
+        source: MemberSource::Marketplace {
+            repo: repo.to_owned(),
+            rev: None,
+        },
+    };
+
+    let clash = create_from_selection(
+        &project.env,
+        "Clash",
+        vec![
+            market(MemberKind::Bundle, "review", "owner/first"),
+            market(MemberKind::Plugin, "review", "owner/second"),
+        ],
+    )
+    .unwrap();
+    let resolution = resolve(&project.env, &clash).unwrap();
+    assert_eq!(resolution.missing.len(), 1, "{:?}", resolution.missing);
+    let row = &resolution.missing[0];
+    assert_eq!(
+        (row.kind, row.name.as_str(), &row.which),
+        (MemberKind::Bundle, "review", &MemberWhich::Any)
+    );
+    for claimant in [
+        "bundle 'review' from owner/first",
+        "plugin 'review' from owner/second",
+    ] {
+        assert!(row.why.contains(claimant), "{}", row.why);
+    }
+    assert_eq!(resolution.groups, Vec::new());
+
+    let target = destination(&project, "into-clash");
+    let Scope::Project { root } = &target else {
+        unreachable!("built as a project scope")
+    };
+    let before = snapshot(root);
+    let refused = install(
+        &project.env,
+        &clash,
+        &target,
+        Some(vec![HarnessId::Claude]),
+        None,
+    );
+    let Err(CoreError::TemplateMemberUnavailable { why, .. }) = refused else {
+        panic!("a contested name should refuse the install: {refused:?}");
+    };
+    assert!(why.contains("declares one package under a name"), "{why}");
+    assert_eq!(
+        snapshot(root),
+        before,
+        "the refused install wrote into {}",
+        root.display()
+    );
+
+    // Under two names the pair is two sets of one group, and both land.
+    fs::write(
+        project.catalog.join("kendex.toml"),
+        "[marketplace]\nname = \"cat\"\nlicense = \"MIT\"\n\
+         [bundles.review]\nskills = [\"gh\"]\n\
+         [bundles.other]\ncommands = [\"note\"]\n",
+    )
+    .unwrap();
+    let repo = crate::paths::slashed(&project.catalog);
+    let apart = create_from_selection(
+        &project.env,
+        "Apart",
+        vec![
+            market(MemberKind::Bundle, "review", &repo),
+            market(MemberKind::Plugin, "other", &repo),
+        ],
+    )
+    .unwrap();
+    let resolution = resolve(&project.env, &apart).unwrap();
+    assert_eq!(resolution.missing, Vec::new());
+    assert_eq!(resolution.groups.len(), 1, "{:?}", resolution.groups);
+    assert_eq!(
+        resolution.groups[0].bundles.len(),
+        2,
+        "{:?}",
+        resolution.groups
+    );
+    let landed = install(
+        &project.env,
+        &apart,
+        &destination(&project, "into-apart"),
+        Some(vec![HarnessId::Claude]),
+        None,
+    )
+    .unwrap();
+    assert_eq!(landed.stopped, None);
+    for wanted in ["bundle review", "plugin other"] {
+        assert!(
+            landed.declared.contains(&wanted.to_owned()),
+            "{:?}",
+            landed.declared
+        );
+    }
+}
+
 /// A plugin is its registry's own curated set, so it installs whole the
 /// way a bundle does — and the resolved row keeps saying it is a plugin,
 /// so a reference built from that row reaches the member rather than


### PR DESCRIPTION
## Summary
- `MemberKind::namespace()` is now the one judge of the manifest table a template member declares in (`Namespace::Item(kind)` or `Namespace::Set`). `resolve`'s routing and `contested()` both read it, so a bundle and a plugin under one name — two kinds, one `[bundles.<name>]` — resolve to one contested row naming both claimants, and the install refuses before writing anything.
- The install's own `ItemKind::Plugin => request.bundles` arm was a second copy of that routing; it is now `unreachable!` naming the invariant.
- The contested row's `why` names each claimant with its own kind, since the claimants no longer need to share one.

Premise checked against current source: `contested()` keyed on `(MemberKind, name)` (`crates/core/src/template/install.rs`), while resolve routed both Bundle and Plugin to `group.bundles` and `declare_bundle` writes `manifest.bundles` under the bare name (`crates/core/src/engine/ops/add/bundles.rs`). The reported part-way install holds.

## Completed Issues
- Closes KEN-1327 - Template install: a bundle and a plugin under one name share manifest.bundles but contested() keys on kind

## Done-when map
- One contested row naming both claimants, install writes nothing; different names still install → `crates/core/src/template/mod.rs` (`namespace`), `crates/core/src/template/install.rs` (`resolve`, `contested`, `two_claims`), test `a_bundle_and_a_plugin_under_one_name_are_one_contested_name` in `crates/core/src/template/tests/install.rs`.
- Must-fail control → the same test: `contested()` keyed on `MemberKind` again fails it at `missing.len()` (0, expected 1).
- Changelog → `changelog.d/fixed/KEN-1327.md`. `ui/src/bindings.ts` unchanged: no command-surface change.

## Size
production=71 tests=112 (the issue states no allowance)

## Test Plan
- `cargo test -p kendex-core --lib template::tests::install` (19 passed), including the must-fail control above.
- `env -u TMPDIR tools/guard --full` on the final head; preflight clean.

https://claude.ai/code/session_014y9gQCgZWECCoBro22MrcU
