### PR TITLE
docs(KEN-1337): dev-fix prescribes a commit header that commit-guards rejects

### DIFF
--- a/.agents/skills/dev/workflows/dev-fix.md
+++ b/.agents/skills/dev/workflows/dev-fix.md
@@ -56,19 +56,21 @@ Follow [dev-implement.md § 5. Validate](./dev-implement.md#5-validate) from the
 
 ```bash
 git -C [WORKTREE_PATH] add -A
-git -C [WORKTREE_PATH] commit -m "[PREFIX]([ISSUE_ID]): [MESSAGE]"
+git -C [WORKTREE_PATH] commit -m "[PREFIX]([ISSUE_ID]): [SUMMARY]" -m "[REVIEW_LABEL]"
 ```
 
-| Source | Commit Message |
-|--------|----------------|
-| `pr-review` | "Address PR review - [brief description]" |
-| `pr-comments` | "Address PR comments - [brief description]" |
-| `qa-review` | "Address QA review - [brief description]" |
-| `review` | "Address review - [brief description]" |
-| `local-review` | "Address local pre-PR review - [brief description]" |
+The header is the first `-m` alone: `[PREFIX]` is a Conventional Commits type such as `fix`, `test` or `docs`, and `[SUMMARY]` states the fix. The repository's commit-msg hook (commit-guards where installed) judges that line's shape and length. The review label is the body, the second `-m`:
+
+| Source | Review Label |
+|--------|--------------|
+| `pr-review` | "Address PR review" |
+| `pr-comments` | "Address PR comments" |
+| `qa-review` | "Address QA review" |
+| `review` | "Address review" |
+| `local-review` | "Address local pre-PR review" |
 | `suggestions` | "Address review suggestions" |
 
-Append `[validate: FAILING_CHECK]` when validation failures remain.
+When validation failures remain, add `[validate: FAILING_CHECK]` to the body as a further `-m`, never to the header.
 
 ---
 

--- a/.agents/skills/dev/workflows/dev-implement.md
+++ b/.agents/skills/dev/workflows/dev-implement.md
@@ -201,7 +201,7 @@ git -C [WORKTREE_PATH] commit -m "[PREFIX]([ISSUE_ID]): [DESCRIPTION]"
 git -C [WORKTREE_PATH] log -1 --oneline
 ```
 
-Use the CURRENT sub-issue ID when bundled, not the parent's. Never stage lock files the project gitignores — stage specific files by name. Append `[validate: FAILING_CHECK]` when validation failures remain.
+Use the CURRENT sub-issue ID when bundled, not the parent's. Never stage lock files the project gitignores — stage specific files by name. When validation failures remain, add `[validate: FAILING_CHECK]` to the body as a second `-m`, never to the header.
 
 ---
 

--- a/.agents/skills/orch/workflows/ci-fix.md
+++ b/.agents/skills/orch/workflows/ci-fix.md
@@ -97,7 +97,7 @@ Worktree: [WORKTREE_PATH]
 2. Fix the issue, editing files under `[WORKTREE_PATH]` by absolute path.
 3. Run the project's validation command from `[WORKTREE_PATH]`.
 4. If the target failure is fixed but OTHER failures remain: still commit, and note them in the message.
-5. Stage and commit: `git -C [WORKTREE_PATH] add -A`, then `git -C [WORKTREE_PATH] commit -m "fix([ISSUE_ID]): [DESCRIPTION]"`, appending `[validate: FAILING_CHECK]` to the message when other failures remain.
+5. Stage and commit: `git -C [WORKTREE_PATH] add -A`, then `git -C [WORKTREE_PATH] commit -m "fix([ISSUE_ID]): [DESCRIPTION]"`, adding `-m "[validate: FAILING_CHECK]"` as the body, never to the header, when other failures remain.
 6. Push: `git -C [WORKTREE_PATH] push`.
 
 Report: what was fixed, the validate status, and any unrelated failures.

--- a/skills/dev/workflows/dev-fix.md
+++ b/skills/dev/workflows/dev-fix.md
@@ -56,19 +56,21 @@ Follow [dev-implement.md § 5. Validate](./dev-implement.md#5-validate) from the
 
 ```bash
 git -C [WORKTREE_PATH] add -A
-git -C [WORKTREE_PATH] commit -m "[PREFIX]([ISSUE_ID]): [MESSAGE]"
+git -C [WORKTREE_PATH] commit -m "[PREFIX]([ISSUE_ID]): [SUMMARY]" -m "[REVIEW_LABEL]"
 ```
 
-| Source | Commit Message |
-|--------|----------------|
-| `pr-review` | "Address PR review - [brief description]" |
-| `pr-comments` | "Address PR comments - [brief description]" |
-| `qa-review` | "Address QA review - [brief description]" |
-| `review` | "Address review - [brief description]" |
-| `local-review` | "Address local pre-PR review - [brief description]" |
+The header is the first `-m` alone: `[PREFIX]` is a Conventional Commits type such as `fix`, `test` or `docs`, and `[SUMMARY]` states the fix. The repository's commit-msg hook (commit-guards where installed) judges that line's shape and length. The review label is the body, the second `-m`:
+
+| Source | Review Label |
+|--------|--------------|
+| `pr-review` | "Address PR review" |
+| `pr-comments` | "Address PR comments" |
+| `qa-review` | "Address QA review" |
+| `review` | "Address review" |
+| `local-review` | "Address local pre-PR review" |
 | `suggestions` | "Address review suggestions" |
 
-Append `[validate: FAILING_CHECK]` when validation failures remain.
+When validation failures remain, add `[validate: FAILING_CHECK]` to the body as a further `-m`, never to the header.
 
 ---
 

--- a/skills/dev/workflows/dev-implement.md
+++ b/skills/dev/workflows/dev-implement.md
@@ -201,7 +201,7 @@ git -C [WORKTREE_PATH] commit -m "[PREFIX]([ISSUE_ID]): [DESCRIPTION]"
 git -C [WORKTREE_PATH] log -1 --oneline
 ```
 
-Use the CURRENT sub-issue ID when bundled, not the parent's. Never stage lock files the project gitignores — stage specific files by name. Append `[validate: FAILING_CHECK]` when validation failures remain.
+Use the CURRENT sub-issue ID when bundled, not the parent's. Never stage lock files the project gitignores — stage specific files by name. When validation failures remain, add `[validate: FAILING_CHECK]` to the body as a second `-m`, never to the header.
 
 ---
 

--- a/skills/orch/workflows/ci-fix.md
+++ b/skills/orch/workflows/ci-fix.md
@@ -97,7 +97,7 @@ Worktree: [WORKTREE_PATH]
 2. Fix the issue, editing files under `[WORKTREE_PATH]` by absolute path.
 3. Run the project's validation command from `[WORKTREE_PATH]`.
 4. If the target failure is fixed but OTHER failures remain: still commit, and note them in the message.
-5. Stage and commit: `git -C [WORKTREE_PATH] add -A`, then `git -C [WORKTREE_PATH] commit -m "fix([ISSUE_ID]): [DESCRIPTION]"`, appending `[validate: FAILING_CHECK]` to the message when other failures remain.
+5. Stage and commit: `git -C [WORKTREE_PATH] add -A`, then `git -C [WORKTREE_PATH] commit -m "fix([ISSUE_ID]): [DESCRIPTION]"`, adding `-m "[validate: FAILING_CHECK]"` as the body, never to the header, when other failures remain.
 6. Push: `git -C [WORKTREE_PATH] push`.
 
 Report: what was fixed, the validate status, and any unrelated failures.


### PR DESCRIPTION
## Summary

- `dev-fix.md` § 3 now commits a Conventional Commits header, `[PREFIX]([ISSUE_ID]): [SUMMARY]`, and puts the review label (`Address PR review`, and the rest) in the body as a second `-m`. The repository's commit-msg hook (commit-guards where installed) judges the header line.
- `[validate: FAILING_CHECK]` goes in the body, never the header, in `dev-fix.md` § 3, `dev-implement.md` § 7 and `ci-fix.md` step 5.
- The `.agents/` renders land in the same commit.

## Premise

The issue says the table prescribes `Address PR review - <summary>` as the header. The commit line already wrapped the table value as `[PREFIX]([ISSUE_ID]): [MESSAGE]`, which is conventional in shape. The real defect was the table's label sitting in the subject. It read as the whole header to a dev agent, which is what the vgs fix rounds hit. It also used up the commit-msg `header-length` budget of 72 characters: `fix(KEN-1337): Address local pre-PR review - ` is 45 characters before any description. The appended validate marker added more. Nothing parses the labels or the marker, so moving them to the body breaks no reader.

## Completed Issues

- Closes KEN-1337 - dev-fix prescribes a commit header that commit-guards rejects

## Size

`branch-size-check`: no allowance stated; production=13, tests=0, mirror=13.

## Test Plan

- Instruction-only markdown; no tests added.
- preflight clean (6 files); doc-limits, md-format, md-refs clean in the commit's pre-commit chain; commit-msg `header-valid`.
- Local review: reviewer-correctness pass, no findings.
- `env -u TMPDIR tools/guard --full` on the final head.

https://claude.ai/code/session_01Mr9vh6BPZaAki9Zebbjz6b
