### PR TITLE
fix(KEN-1286): Whole-app usability walk: every screen and state on the consumer paths, findings fixed or handed to the owning sibling

### DIFF
--- a/changelog.d/fixed/ken-1286-dialogs-fit.md
+++ b/changelog.d/fixed/ken-1286-dialogs-fit.md
@@ -1,0 +1,1 @@
+- Long folder paths no longer push the Install and Create template dialogs past the window edge; the folders shorten and the buttons stay in view.

--- a/changelog.d/fixed/ken-1286-narrow-place-count.md
+++ b/changelog.d/fixed/ken-1286-narrow-place-count.md
@@ -1,0 +1,1 @@
+- In a narrow window, each row of a marketplace's package list still says how many places hold the package, under its name, and opens those places.

--- a/changelog.d/fixed/ken-1286-template-breadcrumb.md
+++ b/changelog.d/fixed/ken-1286-template-breadcrumb.md
@@ -1,0 +1,1 @@
+- A template's page lines its breadcrumb up with its title.

--- a/changelog.d/fixed/ken-1286-tick-boxes.md
+++ b/changelog.d/fixed/ken-1286-tick-boxes.md
@@ -1,0 +1,1 @@
+- Pressing a row's tick box in a marketplace's package list or in Bookmarks selects the row instead of opening the package, so Install selected and Add to template appear.

--- a/changelog.d/fixed/ken-1286-update-counts.md
+++ b/changelog.d/fixed/ken-1286-update-counts.md
@@ -1,0 +1,1 @@
+- The Updates page counts the places its updates are in, not its rows, and the update review says "Update 1 package?" for one package in several places.

--- a/ui/src/components/bookmarks/bookmarks-view.tsx
+++ b/ui/src/components/bookmarks/bookmarks-view.tsx
@@ -413,9 +413,9 @@ function SavedRow({
       )}
     >
       <div className="flex items-center gap-3">
-        {/* Ticking a row is not opening it: the box draws as a button, and
-            `opensOnActivate` reads a control inside the card as having
-            answered the click. A row nothing can install carries no box. */}
+        {/* Ticking a row is not opening it: `clickAsksToOpen` counts the
+            box as a control that answered the click. A row nothing can
+            install carries no box. */}
         <div className="w-5 shrink-0">
           {offered ? (
             <Checkbox

--- a/ui/src/components/install/install-dialog.tsx
+++ b/ui/src/components/install/install-dialog.tsx
@@ -341,8 +341,12 @@ function PlacePicker({
               onChange(togglePlace(offered, places, place))
             }
           />
-          <span>{names[index]}</span>
-          <span className="truncate font-mono text-xs text-muted-foreground">
+          <span className="shrink-0">{names[index]}</span>
+          {/* A folder is the one unbreakable line here: it gives way to
+              the name, and only a folder is set in the code face. */}
+          <span
+            className={`min-w-0 truncate text-xs text-muted-foreground${scopePath(place) ? " font-mono" : ""}`}
+          >
             {scopePath(place) ?? PERSONAL_PLACE_HELP}
           </span>
         </Label>

--- a/ui/src/components/marketplaces/package-row.tsx
+++ b/ui/src/components/marketplaces/package-row.tsx
@@ -90,8 +90,10 @@ export function PackageRow({
   marketplace: MarketplaceDisplay | undefined;
   /** Where this package is installed from this marketplace. The table
    *  builds the whole index once — see `lib/installed-places.ts` — so a row
-   *  neither scans the provenance join nor subscribes to it. */
-  places: Scope[];
+   *  neither scans the provenance join nor subscribes to it. Absent on the
+   *  cross-marketplace list, which is a page for no single subscription and
+   *  names no places at all. */
+  places: Scope[] | undefined;
   /** Whether a bare repository's row may subscribe and install — decided
    * once for the table, never per row. */
   offerSubscribe: boolean;
@@ -137,9 +139,9 @@ export function PackageRow({
   const updated = row.updatedAt ? Date.parse(row.updatedAt) : Number.NaN;
   return (
     <TableRow className="group cursor-pointer" {...open}>
-      {/* Ticking a row is not opening it. The box draws as a button, and
-          `opensOnActivate` reads a control inside the surface as having
-          answered the click, so the row stays put under a tick. */}
+      {/* Ticking a row is not opening it. `clickAsksToOpen` counts the
+          box as a control that answered the click, so the row stays put
+          under a tick. */}
       <TableCell className="w-8">
         {selectable ? (
           <Checkbox
@@ -171,6 +173,14 @@ export function PackageRow({
             {row.summary ? (
               <div className="truncate text-xs text-muted-foreground">
                 {row.summary}
+              </div>
+            ) : null}
+            {/* A table too narrow for the Installed in column still owes
+                each package its count and the way to its places, so the
+                row says it under the name instead. */}
+            {places !== undefined && !columns.places && places.length > 0 ? (
+              <div className="text-xs text-muted-foreground">
+                <InstalledIn places={places} standalone />
               </div>
             ) : null}
           </div>
@@ -239,7 +249,7 @@ export function PackageRow({
           <SafetyDot tone="muted" words={SAFETY_DOT_UNCHECKED} />
         )}
       </TableCell>
-      {columns.places ? (
+      {columns.places && places !== undefined ? (
         <TableCell className="max-w-40 truncate text-muted-foreground">
           {places.length > 0 ? (
             <InstalledIn places={places} />

--- a/ui/src/components/marketplaces/packages-table.test.tsx
+++ b/ui/src/components/marketplaces/packages-table.test.tsx
@@ -22,6 +22,7 @@ import {
 } from "@/lib/copy-install";
 import {
   INSTALLED_IN_HEADING,
+  installedInLabel,
   PACKAGE_STATE_UNKNOWN,
   SUBSCRIBE_TO_INSTALL_LABEL,
 } from "@/lib/copy-marketplaces";
@@ -629,6 +630,46 @@ describe("the columns a narrow table keeps", () => {
       roomIs(1400);
       const wideHost = mountTree(table);
       expect(heads(wideHost), page).toEqual(wide);
+    }
+  });
+
+  // A marketplace's own page owes each package its count and the way to
+  // its places at every width: where the Installed in column has no room,
+  // the row says it under the name. The cross-marketplace list names no
+  // places at any width.
+  it("keeps a package's place count on its row once the column goes", () => {
+    const held: Scope[] = [
+      { scope: "global" } as Scope,
+      { scope: "project", root: "/home/me/hyprtrade" } as Scope,
+    ];
+    const index = new Map([[placesKey("skill", "gh"), held]]);
+    const entries = [entry, { ...entry, row: { ...entry.row, name: "zz" } }];
+    const CASES = [
+      { width: 700, places: index, underName: [installedInLabel(held), ""] },
+      { width: 1400, places: index, underName: ["", ""] },
+      { width: 700, places: undefined, underName: ["", ""] },
+    ];
+    expect(CASES).toHaveLength(3);
+    for (const { width, places, underName } of CASES) {
+      stub.scores = {};
+      useProvenanceStore.setState({ loaded: true, rows: [] });
+      roomIs(width);
+      const host = mountTree(
+        <PackagesTable
+          entries={entries}
+          showMarketplace={places === undefined}
+          places={places}
+        />,
+      );
+      // The Name cell of each row, after the tick cell.
+      const said = [...host.querySelectorAll("tbody tr")].map(
+        (each) =>
+          each.children[1]?.querySelector('button[aria-label^="Installed in"]')
+            ?.textContent ?? "",
+      );
+      expect(said, `${width}px, places ${places ? "named" : "absent"}`).toEqual(
+        underName,
+      );
     }
   });
 });

--- a/ui/src/components/marketplaces/packages-table.tsx
+++ b/ui/src/components/marketplaces/packages-table.tsx
@@ -463,7 +463,8 @@ export function PackagesTable({
               columns={columns}
               marketplace={named.get(catalogKey(entry.catalog))}
               places={
-                places?.get(placesKey(entry.row.kind, entry.row.name)) ?? []
+                places &&
+                (places.get(placesKey(entry.row.kind, entry.row.name)) ?? [])
               }
               offerSubscribe={offerSubscribe}
               selectable={installableRow(entry)}

--- a/ui/src/components/templates/create-template-dialog.tsx
+++ b/ui/src/components/templates/create-template-dialog.tsx
@@ -251,19 +251,23 @@ export function CreateTemplateDialog({
               </p>
             ) : null}
 
-            <section className="flex flex-col gap-2">
-              <SectionHeading>{INCLUDED_PACKAGES_LABEL}</SectionHeading>
-              {members.map((member) => (
-                <MemberChoice
-                  key={member.key}
-                  member={member}
-                  checked={!dropped.has(member.key)}
-                  onToggle={() => setDropped(toggle(dropped, member.key))}
-                  side={sides[member.key]}
-                  onSide={(side) => setSides({ ...sides, [member.key]: side })}
-                />
-              ))}
-            </section>
+            {members.length > 0 ? (
+              <section className="flex flex-col gap-2">
+                <SectionHeading>{INCLUDED_PACKAGES_LABEL}</SectionHeading>
+                {members.map((member) => (
+                  <MemberChoice
+                    key={member.key}
+                    member={member}
+                    checked={!dropped.has(member.key)}
+                    onToggle={() => setDropped(toggle(dropped, member.key))}
+                    side={sides[member.key]}
+                    onSide={(side) =>
+                      setSides({ ...sides, [member.key]: side })
+                    }
+                  />
+                ))}
+              </section>
+            ) : null}
 
             <section className="flex flex-col gap-2">
               <Label className="flex items-start gap-2 font-normal">
@@ -300,7 +304,7 @@ export function CreateTemplateDialog({
                       }
                       aria-label={`${local.kind} ${local.name}`}
                     />
-                    <span className="truncate">
+                    <span className="min-w-0 truncate" title={local.at}>
                       {local.name}
                       <span className="text-muted-foreground">
                         {" "}

--- a/ui/src/components/templates/templates.dom.test.tsx
+++ b/ui/src/components/templates/templates.dom.test.tsx
@@ -21,6 +21,7 @@ import {
   COPIES_GO_INTO_THIS_TEMPLATE,
   INCLUDE_CUSTOMIZATIONS_LABEL,
   INCLUDE_LOCAL_LABEL,
+  INCLUDED_PACKAGES_LABEL,
   LICENSE_CONFIRM,
   NEW_TEMPLATE_LABEL,
   NO_TEMPLATES_TO_INSTALL,
@@ -318,6 +319,7 @@ describe("creating a template from a project", () => {
     expect(document.body.textContent).toContain(
       "a catalog stores an agent as markdown",
     );
+    expect(document.body.textContent).toContain(INCLUDED_PACKAGES_LABEL);
 
     await act(async () => button(document, NEW_TEMPLATE_LABEL).click());
     expect(commands.templateCreateFromProject).toHaveBeenCalledWith(
@@ -331,6 +333,28 @@ describe("creating a template from a project", () => {
         fingerprint: "offer-1",
       },
     );
+  });
+
+  // A project kendex manages nothing in still offers its local packages,
+  // under no heading for a list with nothing in it.
+  it("heads no included packages where the project has none", async () => {
+    vi.mocked(commands.templateDraft).mockResolvedValue({
+      status: "ok",
+      data: { ...DRAFT, members: [] },
+    });
+    mount(
+      <CreateTemplateDialog
+        project="/work/acme"
+        place="acme"
+        open
+        onOpenChange={() => {}}
+      />,
+    );
+    await settle();
+
+    expect(document.body.textContent).not.toContain(INCLUDED_PACKAGES_LABEL);
+    expect(document.body.textContent).toContain(INCLUDE_LOCAL_LABEL);
+    expect(document.body.textContent).toContain("stray");
   });
 
   it("carries the local packages and the settings when both are ticked", async () => {

--- a/ui/src/components/ui/dialog.tsx
+++ b/ui/src/components/ui/dialog.tsx
@@ -58,7 +58,7 @@ function DialogContent({
       <DialogPrimitive.Popup
         data-slot="dialog-content"
         className={cn(
-          "fixed top-[50%] left-[50%] z-50 grid w-full max-w-[calc(100%-2rem)] translate-x-[-50%] translate-y-[-50%] gap-4 rounded-lg border bg-background p-6 shadow-lg outline-none transition-[opacity,transform] duration-200 data-starting-style:scale-95 data-starting-style:opacity-0 data-ending-style:scale-95 data-ending-style:opacity-0 sm:max-w-lg",
+          "fixed top-[50%] left-[50%] z-50 grid w-full max-w-[calc(100%-2rem)] grid-cols-[minmax(0,1fr)] translate-x-[-50%] translate-y-[-50%] gap-4 rounded-lg border bg-background p-6 shadow-lg outline-none transition-[opacity,transform] duration-200 data-starting-style:scale-95 data-starting-style:opacity-0 data-ending-style:scale-95 data-ending-style:opacity-0 sm:max-w-lg",
           className
         )}
         {...props}

--- a/ui/src/lib/click-asks-to-open.ts
+++ b/ui/src/lib/click-asks-to-open.ts
@@ -6,12 +6,16 @@ import type { MouseEvent } from "react";
  *  through the surface that owns it. A dialog opened from a card is read, not
  *  a request to leave the page; its backdrop is pressed to close it.
  *
+ *  A tick box is matched by its role: `components/ui/checkbox.tsx` draws the
+ *  box as a span, with its input hidden beside it, so a press on the box
+ *  reaches no element selector here.
+ *
  *  The menu is matched by the prefix its parts share rather than by their
  *  roles: a menu item renders as a plain div, so no element selector reaches
  *  it, and the popup's own padding lies between the items. One selector
  *  covers every part the wrapper draws, including any it grows. */
 const CONTROLS =
-  'a, button, input, select, textarea, [role="button"], [data-slot="tooltip-content"], [data-slot="dialog-content"], [data-slot="dialog-overlay"], [data-slot^="dropdown-menu-"]';
+  'a, button, input, select, textarea, [role="button"], [role="checkbox"], [data-slot="tooltip-content"], [data-slot="dialog-content"], [data-slot="dialog-overlay"], [data-slot^="dropdown-menu-"]';
 
 /**
  * Whether a click on a whole-surface shortcut — a project card, a Library

--- a/ui/src/lib/copy-updates.test.ts
+++ b/ui/src/lib/copy-updates.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it } from "vitest";
-import { lastCheckedLabel, NEVER_CHECKED } from "./copy-updates";
+import {
+  lastCheckedLabel,
+  NEVER_CHECKED,
+  updateReviewManyTitle,
+} from "./copy-updates";
 
 // The overview reports Unix seconds, while the UI clock uses milliseconds.
 const SECONDS = 1_700_000_000;
@@ -23,5 +27,24 @@ describe("how old the update standing is", () => {
   it("distinguishes a scope that was never fetched", () => {
     expect(lastCheckedLabel(null, at(0))).toBe(NEVER_CHECKED);
     expect(NEVER_CHECKED).not.toContain("ago");
+  });
+});
+
+// A review of several places can hold one package: the same package in two
+// places is two rows under a count of one.
+describe("the update review's title over several places", () => {
+  it("counts the packages in the words a count takes", () => {
+    const rows = [
+      { packages: 1, place: null, expected: "Update 1 package?" },
+      { packages: 2, place: null, expected: "Update 2 packages?" },
+      { packages: 1, place: "acme", expected: "Update 1 package in acme?" },
+      { packages: 3, place: "acme", expected: "Update 3 packages in acme?" },
+    ];
+    expect(rows).toHaveLength(4);
+    for (const row of rows)
+      expect(
+        updateReviewManyTitle(row.packages, row.place),
+        `${row.packages} in ${row.place}`,
+      ).toBe(row.expected);
   });
 });

--- a/ui/src/lib/copy-updates.ts
+++ b/ui/src/lib/copy-updates.ts
@@ -195,13 +195,17 @@ export const OPEN_PACKAGE_LABEL = "Open package";
 export const openPlaceLabel = (place: string): string => `Open ${place}`;
 export const updateReviewOneTitle = (name: string, place: string): string =>
   `Update ${name} in ${place}?`;
+/** More than one place to write, which can still be one package: the same
+ *  package in two places is two rows under one count. */
 export const updateReviewManyTitle = (
   packages: number,
   place: string | null,
-): string =>
-  place === null
-    ? `Update ${packages} packages?`
-    : `Update ${packages} packages in ${place}?`;
+): string => {
+  const counted = packages === 1 ? "1 package" : `${packages} packages`;
+  return place === null
+    ? `Update ${counted}?`
+    : `Update ${counted} in ${place}?`;
+};
 export const UPDATE_REVIEW_BODY =
   "kendex replaces the installed files with the newest version from the source. Nothing is committed — you choose what to do with the changed files when the update finishes.";
 export const UPDATE_REVIEW_CONFIRM = "Update";

--- a/ui/src/lib/layout.ts
+++ b/ui/src/lib/layout.ts
@@ -22,6 +22,7 @@ const WIDE_PAGES = new Set([
   "marketplaces",
   "marketplaceDetail",
   "availablePackage",
+  "template",
 ]);
 
 export function isWidePage(page: string): boolean {

--- a/ui/src/lib/opens-on-activate.dom.test.tsx
+++ b/ui/src/lib/opens-on-activate.dom.test.tsx
@@ -2,6 +2,7 @@
 import userEvent from "@testing-library/user-event";
 import { act } from "react";
 import { afterEach, describe, expect, it, vi } from "vitest";
+import { Checkbox } from "@/components/ui/checkbox";
 import { opensOnActivate } from "@/lib/opens-on-activate";
 import { mount } from "@/test/dom";
 
@@ -16,9 +17,11 @@ describe("a surface that opens what it names", () => {
   const mountSurface = () => {
     const onOpen = vi.fn();
     const inside = vi.fn();
+    const ticked = vi.fn();
     const host = mount(
       <div {...opensOnActivate(onOpen, "Open gh")} data-testid="surface">
         <span data-testid="text">gh</span>
+        <Checkbox aria-label="Select gh" onCheckedChange={ticked} />
         <button type="button" onClick={inside}>
           Update
         </button>
@@ -31,28 +34,69 @@ describe("a surface that opens what it names", () => {
     };
     const control = host.querySelector("button");
     if (!control) throw new Error("no control inside the surface");
-    return { host, onOpen, inside, at, control };
+    const box = host.querySelector<HTMLElement>('[aria-label="Select gh"]');
+    if (!box) throw new Error("no tick box inside the surface");
+    return { host, onOpen, inside, ticked, at, control, box };
   };
 
   it("takes focus, opens on Enter, and leaves its own controls alone", async () => {
     const cases = [
       // A keyboard reaches the surface and Enter opens it.
-      { name: "Enter on the surface", act: "enter-surface", opens: 1, ran: 0 },
+      {
+        name: "Enter on the surface",
+        act: "enter-surface",
+        opens: 1,
+        ran: 0,
+        ticks: 0,
+      },
       // Enter on a button inside runs that button, and only that button —
       // otherwise every keyboard press on a row's Update would leave the
       // page as well.
-      { name: "Enter on a control", act: "enter-control", opens: 0, ran: 1 },
+      {
+        name: "Enter on a control",
+        act: "enter-control",
+        opens: 0,
+        ran: 1,
+        ticks: 0,
+      },
       // A click anywhere the controls do not answer opens.
-      { name: "click on the text", act: "click-text", opens: 1, ran: 0 },
+      {
+        name: "click on the text",
+        act: "click-text",
+        opens: 1,
+        ran: 0,
+        ticks: 0,
+      },
       // A completed click on a control is that control's.
-      { name: "click on a control", act: "click-control", opens: 0, ran: 1 },
+      {
+        name: "click on a control",
+        act: "click-control",
+        opens: 0,
+        ran: 1,
+        ticks: 0,
+      },
+      // A tick box is drawn as a span rather than a button, and pressing it
+      // selects the row without leaving the page.
+      {
+        name: "click on a tick box",
+        act: "click-box",
+        opens: 0,
+        ran: 0,
+        ticks: 1,
+      },
       // A click ending a drag across the surface's text was someone keeping
       // the text, not asking to leave the page.
-      { name: "click ending a drag", act: "drag-text", opens: 0, ran: 0 },
+      {
+        name: "click ending a drag",
+        act: "drag-text",
+        opens: 0,
+        ran: 0,
+        ticks: 0,
+      },
     ];
-    expect(cases).toHaveLength(5);
+    expect(cases).toHaveLength(6);
     for (const entry of cases) {
-      const { onOpen, inside, at, control } = mountSurface();
+      const { onOpen, inside, ticked, at, control, box } = mountSurface();
       expect(at("surface").getAttribute("tabindex"), entry.name).toBe("0");
       // The extra focus stop says what it is and what opens it: a stop
       // that announced only the cells it holds would tell a reader
@@ -75,11 +119,14 @@ describe("a surface that opens what it names", () => {
         await userEvent.keyboard("{Enter}");
       } else if (entry.act === "click-control") {
         await userEvent.click(control);
+      } else if (entry.act === "click-box") {
+        await userEvent.click(box);
       } else {
         await userEvent.click(at("text"));
       }
       expect(onOpen, entry.name).toHaveBeenCalledTimes(entry.opens);
       expect(inside, entry.name).toHaveBeenCalledTimes(entry.ran);
+      expect(ticked, entry.name).toHaveBeenCalledTimes(entry.ticks);
       vi.restoreAllMocks();
     }
   });

--- a/ui/src/lib/update-groups.test.ts
+++ b/ui/src/lib/update-groups.test.ts
@@ -10,6 +10,7 @@ import {
   groupUpdates,
   outOfDateIn,
   packageCount,
+  placeCount,
   placeName,
   placesWithUpdates,
   skippedPlaces,
@@ -138,6 +139,20 @@ describe("update groups", () => {
     expect(
       packageCount([row("gh", null), row("gh", "/a"), row("x", "/a")]),
     ).toBe(2);
+  });
+
+  // The Updates page's "N updates across M places": a row is one package in
+  // one place, so the places are counted apart from the rows.
+  it("counts places, not rows", () => {
+    const CASES = [
+      { rows: [row("gh", null), row("gh", "/a"), row("x", "/a")], places: 2 },
+      { rows: [row("gh", "/a"), row("x", "/a")], places: 1 },
+      { rows: [row("gh", null)], places: 1 },
+    ];
+    expect(CASES).toHaveLength(3);
+    for (const { rows, places } of CASES) {
+      expect(placeCount(rows), `${rows.length} rows`).toBe(places);
+    }
   });
 
   it("leaves a place held by its owner out of a bulk update", () => {

--- a/ui/src/lib/update-groups.ts
+++ b/ui/src/lib/update-groups.ts
@@ -50,6 +50,12 @@ export function groupUpdates(rows: UpdateRow[]): UpdateGroup[] {
 export const packageCount = (rows: UpdateRow[]): number =>
   new Set(rows.map(groupKey)).size;
 
+/** How many distinct places those packages are out of date in. A row is
+ *  one package in one place, so two packages sharing a project are one
+ *  place, not two. */
+export const placeCount = (rows: UpdateRow[]): number =>
+  new Set(rows.map((row) => scopeKey(row.scope))).size;
+
 /** Why this place's Update is withheld, or null when nothing withholds it.
  *  Every surface that offers Update reads this one function — the update
  *  review dialog, the row's own button, and the package page through

--- a/ui/src/pages/updates.tsx
+++ b/ui/src/pages/updates.tsx
@@ -50,6 +50,7 @@ import { scopeKey } from "@/lib/scope";
 import {
   hiddenUpdates,
   packageCount,
+  placeCount,
   placeKey,
   placeName,
   placesWithUpdates,
@@ -141,7 +142,9 @@ export function UpdatesPage() {
         subtitle={
           <>
             {visible.length > 0 ? (
-              <p>{updatesSubtitle(packageCount(visible), visible.length)}</p>
+              <p>
+                {updatesSubtitle(packageCount(visible), placeCount(visible))}
+              </p>
             ) : null}
             <p
               className="text-xs"


### PR DESCRIPTION
## Summary

- A whole-app usability walk of the debug desktop app, run as a first-time user on a private display with a fixture home. It covers set up, subscribe, add a project, install, update, templates, bookmarks, inspect a package, delete, a broken install and the 900px minimum window. Every finding below links to runtime captures.
- Six small local findings are fixed here: the 900px per-package place count, tick boxes that opened rows, dialogs overflowing on long folders, the template breadcrumb, and two wrong counts on the update path.
- Larger findings went to root as proposals (P1–P10), and the lane filed none of them. Wording and sibling-owned findings are named for their owner.

## Completed Issues

- Closes KEN-1286 - Whole-app usability walk: every screen and state on the consumer paths, findings fixed or handed to the owning sibling

## The walk

The debug build keeps its own sandboxed home. It ran under a private Xvfb and dbus session with `HOME` and the XDG directories set to a fixture root, and was driven with `xdotool`. Captures are local PNG files, named in each row, which root keeps with the lane artifacts. No window reached a desktop session and no real remote was written.

### Fixed in this PR

| Surface | State | Finding | Fix | Before | After |
|---|---|---|---|---|---|
| Marketplace › Packages tab | 900x600 window, a package installed in one place | The Installed in column is dropped and the row gives no per-package count (the KEN-1281 case) | The row says `Installed in N places` under the name when the column has no room, and opens those places | `37-detail-packages-count-900-before.png`, `37b-detail-packages-count-900-before.png` | `60-detail-packages-count-900-after.png`, `59-detail-packages-count-1280-after.png` |
| Marketplace Packages table, Bookmarks | Pressing a row's tick box | The press opens the package instead of ticking, so Install selected and Add to template never appear | A tick box counts as a control inside an openable row | `74b-packages-tick-pressed.png`, `73b-bookmarks-box-clicked.png` | `82-packages-tick-after.png`, `83-bookmarks-tick-after.png` |
| Create a template from a project | Local packages in a project with a long folder | Each folder line widens the dialog, pushing the name field and buttons past its right edge. "Included packages" is headed with nothing under it | Dialog content cannot outgrow the dialog, folder lines truncate with the full folder on hover, and an empty Included packages section is not drawn | `54-create-template-from-project-optin-off.png`, `54b-create-template-scrolled-right.png`, `55-create-template-optin-on.png` | `61-create-template-optin-off-after.png`, `62-create-template-optin-on-after.png`, `81-create-template-after-build5.png` |
| Guided install | Installing into projects with long folders | The same overflow: description cut, project names wrapped, Cancel / Install off the edge. Personal's help text set in the code face | Names stay whole, folders truncate, and only a folder uses the code face | `76-template-install-guided-flow.png`, `76b-template-install-scrolled-right.png`, `26-install-dialog-single.png` | `78-template-install-guided-flow-after.png` |
| Template page | Any template | The breadcrumb starts at the reading gutter while the title starts at the wide gutter | The template page is a wide page for the breadcrumb strip too | `56-create-template-result.png` | `66-template-page-breadcrumb-after.png` |
| Updates page subtitle | tidy-notes out of date in Personal and notes-site, note-guard in Personal | `2 updates across 3 places` over two places: the page passed the row count, one row per package in a place | Counts distinct places beside the package count | `r2-12-updates-with-rows.png`, `r2-19-updates-after-pause.png` | `r2-27-updates-subtitle-after.png`, `r2-34a-updates-settled-repo-moved.png` |
| Update review title | One package in two places | `Update 1 packages?` | `Update 1 package?` | `r2-20-update-review-tidy-notes.png`, `r2-21-update-review-diff-user-level.png` | `r2-28-review-title-after.png`, `r2-34b-review-repo-moved.png` |

### Proposed to root (not filed from the lane)

| # | Surface | State | Finding | Captures |
|---|---|---|---|---|
| P1 | Community › kendex Subscribe | First run, no personal manifest | Refused as already subscribed; nothing written. Any first subscribe silently adds kendex | `16`–`17b`, `20`, `21b`, `22` |
| P2 | Marketplace page | Subscribed, never downloaded | A normal first state reads as a red error naming an action no control has | `23`, `24`, `24b` |
| P3 | Guided install | No harness detected | Reports `Installed … in Personal` over a write that installed nothing | `26`, `28`, `29`, `30`, `32` |
| P4 | Marketplace › Installed in | A hook installed (kendex and a second marketplace) | Row reads Installed and `—` places | `35`, `36`, `39`, `40`, `r2-10` |
| P5 | Updates | Nothing installed, never checked | `Everything is up to date` over nothing installed and no check (pinned by a test) | `07` |
| P6 | Install a template | Template made from a project's local packages, into a new project | `Only some of 3 packages went in` while none went in; `'preview' not found in source 'local'` | `75`, `78`, `79`, `80`, `84`, `56` |
| P7 | Marketplaces › Packages, Home | After the first write into a project | The project's seeded kendex subscription doubles every row; Home's marketplace count keeps growing (3, 4, 6) | `64`, `82`, `85`, `86`, `94` |
| P8 | My Library › Installed | 900x600 | Updated and Status sit past the right edge | `92`, `40` |
| P9 | Home, Library, package page | A managed hook's script deleted (an edited copy is detected) | Still reads healthy everywhere, with no problem and no repair | `94`, `95`, `96` |
| P10 | Updates, Home rows | A held (disabled) Update… pressed while the page waits | Opens the package page: `components/ui/button.tsx` sets `disabled:pointer-events-none`, so the press lands on the row's open | `r2-17`, `r2-18`, `r2-32b`, `r2-33` |

### Handed to the owning sibling (no change here)

| Surface | State | Finding | Owner | Captures |
|---|---|---|---|---|
| Account notice, Settings › Account | Fresh keyring, never signed in | Red `Couldn't check your account` with an internal error chain | No listed owner (with the P-list for root) | `03`, `10` |
| Projects, Add a project, install dialog, harness picker | Any | `tools` for packages or harnesses (`manage its tools`, `Tools`, `No tools — pick at least one`, `All tools`) | KEN-1285 | `05`, `26`, `27`, `47` |
| Updates table, update review, delete dialog, package setup | Personal place | `User level` (`ui/src/lib/copy-updates.ts::USER_LEVEL_PLACE`) where Projects and install say Personal | KEN-1285 | `43`, `98` |
| Customize | Personal scope | `Everything (global)` | KEN-1285 | `09` |
| Package page Details | Installed package | `Scope Personal`; two different ids both called version (`6b02cde`, `9eb3f5c` / `903ed32`); Version menu shows commit subjects with issue ids and PR numbers | KEN-1285 (words), KEN-1302 (which id) | `41`, `96`, `97` |
| Package page Projects / Customize tabs | Personal-only package | Tab named Projects, three removal words (Delete, Remove all, Remove); Customize tells a Personal-only package to open it in a project | KEN-1285, KEN-1296 | `43`, `45` |
| Files tab | Any | `readme` role repeated beside README.md | KEN-1284 | `42` |
| Bookmarks tab | Empty, one saved | `curated set` where the marketplace page says Bundles; the row names the repository, not the marketplace; Remove bookmark has no border beside a bordered Install | KEN-1285, KEN-1294 | `63`, `68` |
| Add a project | No templates saved | An empty `Install a template` offer opens over the new card; its sentence names Create template from a project with no control for it | KEN-1293 | `49` |
| Create a template | Suggested name already saved | Create template stays enabled; the refusal arrives in engine words at the foot of the form | KEN-1293, KEN-1285 | `69` |
| Template page | Any | Kinds in lowercase (`agent`, `skill`, `command`) | KEN-1285 | `56` |
| Not managed page | Project with a local command | `2 not managed yet` lists an agent and a skill, while the command preview is counted not-managed elsewhere and absent here; breadcrumb names the page itself | KEN-1282, KEN-1295 | `50`, `52` |
| Bundle page | Members ticked | The button stays `Install`; the guided install preselects the whole set over the ticked members | KEN-1279 | `89`, `90`, `91` |
| Bundle page | Any | The marketplace line under the summary is plain text, not a way to the marketplace | KEN-1282 | `88`, `89b` |
| Delete confirmation | While removing | Title keeps asking and both buttons only grey out, with no word that it is working; the packages it brought stay installed with no mention | KEN-1285, KEN-1297 | `99`, `100` |
| Available package page | Loading | Name, kind, source and a disabled Install with no sign it is loading | KEN-1285 | `70` |
| Library Installed, Marketplaces Packages | Empty | Filters and headers over an empty list; the empty Packages tab has no action | KEN-1285 | `06`, `11` |
| Home | First run | All-zero tiles with no next step | KEN-1285 | `02` |
| Marketplaces header | Any | `Create…` only switches to the Mine tab; the ellipsis promises a dialog | KEN-1285 | `15`, `19` |
| My Library rows | Update available | `2 locations` where Updates says places | KEN-1285 | `r2-16`, `r2-16b` |
| Updates page | About 40 s after Update | Every control held over stale rows with no word that it is working | KEN-1285 | `r2-22a`, `r2-22`, `r2-22b` |
| Updates, package page | Installed hook copy edited by hand | `Customized` for a hand edit; borderless `Open package` beside bordered controls | KEN-1285 | `r2-29`, `r2-30` |
| Commit offer after an update | notes-site updated | Title `changed 3 files` beside `this action changed 2 files` | KEN-1297 | `r2-23`, `r2-24` |
| Home, hook package page | Installed hook copy edited by hand | Home offers to keep each edit as your own copy; the hook's page offers only Discard and says it `can't be kept as your own` | KEN-1297 | `r2-30`, `r2-31` |

### Walked without a finding

Terms gate (`01`), Community (`12`), Mine (`13`), Subscribe dialog (`14`), fetched Bundles and Packages (`24b`, `25`), Harnesses (`33`), install with a harness (`34`), package Overview README and Safety tabs (`41b`, `44`), Projects populated (`46`), project card menu (`53`), project card opening the Library at the place (`51`), Templates tab (`57`), Bookmarks empty (`63`), bookmarking a row without opening it (`67`), bookmark open and Back (`71`, `72`), template offer with one template (`75`, `78c`), bundle cards with bookmark on hover (`87`), harness opening the Library filtered (`93`), Home populated (`58`), delete outcome (`100`), version preview before switching (`101`, `101b`), Updates populated and checked (`102`).

### The update path

The source moved inside the fixture only. A bare git repository under the fixture root was subscribed by its full `file://` URL, holding the skill `tidy-notes` and the hook `note-guard`. Both were installed from v1, and the fixture then committed v2 and v3. A folder marketplace does not work for this, because the update check gives path sources no rows (`crates/core/src/package/updates/eval.rs::unevaluated`).

| State | What the reader sees | Disposition | Captures |
|---|---|---|---|
| Subscribe by `file://` URL | `walk-market @ 6a63976 · 2 packages · In 1 place · Personal`, titled by its declared name | none | `r2-02`, `r2-03`, `r2-04`, `r2-06` |
| Install a skill into two places, a hook into one | `Installed tidy-notes in Personal and notes-site.`; the Tools picker gives way to `Each place installs for the tools it has.` | none; the hook's row reads Installed and `—` places (P4) | `r2-07a`, `r2-07b`, `r2-08`, `r2-09`, `r2-10` |
| Outdated on Home | Needs attention `2 packages have updates · See what changed and take the update on the Updates page.` | none | `r2-13` |
| Outdated on project cards | Personal `2 packages out of date`, notes-site `1 package out of date` | none | `r2-14` |
| Outdated on the project page | notes-site's view badges tidy-notes `Update available` | none | `r2-15` |
| Outdated in Library rows | `Update available` on tidy-notes and note-guard; tidy-notes' Where reads `2 locations` | `locations` -> KEN-1285 | `r2-16`, `r2-16b` |
| Updates with rows | Rows with safety, type, places, Update everywhere… / Update…, badge on the sidebar | subtitle count fixed; `User level` -> KEN-1285 | `r2-12`, `r2-17`, `r2-19` |
| Diff-first review | Places expand to `6a63976 → 29250db`, file list and unified diff; the hook's own review shows its one-line change | title fixed | `r2-20`, `r2-21`, `r2-26` |
| Update that succeeds | Locks move to the new commit in both places and both copies carry the change; after about 40 s the page catches up and the commit offer for notes-site opens | the 40 s hold -> KEN-1285; offer file counts -> KEN-1297 | `r2-22a`, `r2-22`, `r2-22b`, `r2-23`, `r2-24`, `r2-35` |
| Update that is refused | Editing the installed hook copy: Updates `Edited by you`, `Can't be updated — you've edited this copy`, `Open package`; Home offers keep or discard; the package page offers View changes and Discard edits… | Home and page disagree -> KEN-1297; `Customized`, borderless button -> KEN-1285 | `r2-29`, `r2-30`, `r2-31` |
| A held Update… pressed | A press on the disabled Update everywhere… opens the package page (reproduced twice) | P10 | `r2-17`, `r2-18`, `r2-32b`, `r2-33` |
| Update with the remote gone | Removing the fixture repository after a check does not fail the update: it installs from the fetched copy (`crates/core/src/remote.rs::sync` falls back to the cached commit when a fetch fails) | not a finding; no failed write is reachable this way, so the refused state covers "refused or fails" | `r2-34a`, `r2-34b`, `r2-34`, `r2-35` |

## Requirement to file

- 900px per-package count and access to its places (KEN-1281 case): `ui/src/components/marketplaces/package-row.tsx`, `ui/src/components/marketplaces/packages-table.tsx` (the row is told when the table has no places index); reuses `ui/src/lib/installed-places.ts` and `ui/src/components/marketplaces/installed-in.tsx`; test `packages-table.test.tsx` › "keeps a package's place count on its row once the column goes".
- Tick box selects, does not open: `ui/src/lib/click-asks-to-open.ts`; corrected premise comments in `package-row.tsx` and `ui/src/components/bookmarks/bookmarks-view.tsx`; test `ui/src/lib/opens-on-activate.dom.test.tsx` › row "click on a tick box".
- Dialogs fit: `ui/src/components/ui/dialog.tsx`, `ui/src/components/install/install-dialog.tsx`, `ui/src/components/templates/create-template-dialog.tsx`; test `templates.dom.test.tsx` › "heads no included packages where the project has none". The overflow has no DOM test, because jsdom does no layout; the before and after captures show it.
- Template breadcrumb: `ui/src/lib/layout.ts`. No test, because jsdom does no layout and a pin on the set's membership would only restate the set.
- Updates subtitle counts places: `ui/src/lib/update-groups.ts::placeCount`, `ui/src/pages/updates.tsx`; test `update-groups.test.ts` › "counts places, not rows".
- Update review title for one package: `ui/src/lib/copy-updates.ts::updateReviewManyTitle`; test `copy-updates.test.ts` › "counts the packages in the words a count takes".
- Changelog: `changelog.d/fixed/ken-1286-{tick-boxes,narrow-place-count,dialogs-fit,template-breadcrumb,update-counts}.md`.

## Changes to existing logic

- `ui/src/lib/click-asks-to-open.ts::CONTROLS` gains `[role="checkbox"]`. `ui/src/components/ui/checkbox.tsx` (Base UI 1.7.0) draws the box as a `<span role="checkbox">` with a hidden input, so a press on it matched no selector and reached the surface's open. Every surface built on `opensOnActivate` is affected.
- `ui/src/components/ui/dialog.tsx` `DialogContent` gains `grid-cols-[minmax(0,1fr)]`. The dialog is a grid whose single column grew to its widest unbreakable line, which caused both overflows. Every dialog takes the cap; the install, create-template and template-offer dialogs were re-captured in the rebuilt app (`78`, `78c`, `81`).
- `ui/src/lib/layout.ts::WIDE_PAGES` gains `template`. The template page's own header was already wide; this set also covers its breadcrumb strip.

## Size

The issue states no allowance. Measured added lines: 75 production, 159 test, 0 render mirror.

## Test Plan

- `packages-table.test.tsx` 21/21, `templates.dom.test.tsx` 20/20, `opens-on-activate.dom.test.tsx` 2/2; `ui/src/components/{install,templates,bookmarks,marketplaces}` suites 182/182.
- `update-groups.test.ts` and `pages/updates.test.tsx` 28/28; `copy-updates.test.ts`, `update-review-dialog.dom.test.tsx`, `project-list.dom.test.tsx` 30/30.
- One must-fail control per changed behaviour, each red on its own new case only and then restored: under-name count disabled; `[role="checkbox"]` removed; members condition forced true; place count returning the row count; title always plural.
- Local review: reviewer-correctness passed on `f4e1495a4` and again on `41c36cc25`, with no findings either time.
- `preflight --base origin/main`: clean across 21 changed files.
- `env -u TMPDIR tools/guard --full`: exit 0 on the rebased head `41c36cc25`, and on both commits before the rebase onto `8385fb4bb`.

https://claude.ai/code/session_01KPvKn59My8NY6Meaf9t8wT
