### PR TITLE
fix(KEN-1332): pre-push reads an untracked work-tree policy file its help says no lane consults

### DIFF
--- a/.agents/skills/commit-guards/scripts/byte-ceiling
+++ b/.agents/skills/commit-guards/scripts/byte-ceiling
@@ -203,7 +203,7 @@ case "$MODE" in
     # never-staged file must not hold the swept index to rows it does not
     # carry.
     baseline_status=0
-    gg_policy_content "$BASELINE_FILE" tracked >"$GG_TMP/baseline.tsv" || baseline_status=$?
+    gg_policy_content "$BASELINE_FILE" >"$GG_TMP/baseline.tsv" || baseline_status=$?
     case "$baseline_status" in
       0) gg_validate_baseline "$GG_TMP/baseline.tsv" "$BASELINE_FILE" ;;
       1) : >"$GG_TMP/baseline.tsv" ;;

--- a/.agents/skills/commit-guards/scripts/lib/configured-paths.sh
+++ b/.agents/skills/commit-guards/scripts/lib/configured-paths.sh
@@ -327,26 +327,21 @@ GG_EXCLUDE_PATTERNS=()
 # shellcheck source=generated-paths.sh
 source "${BASH_SOURCE[0]%/*}/generated-paths.sh"
 
-# The scans read the INDEX, so policy files come from the index too: staged
-# edits to one govern staged scans, and a sparse checkout that omits the
-# tracked file from disk still applies it. A path staged for DELETION governs
-# as ABSENT — the commit carries no such file — which is not the same as a
-# never-tracked path, where the worktree copy is all there is.
+# The scans read the INDEX, so policy files come from the index and nowhere
+# else: staged edits to one govern staged scans, and a sparse checkout that
+# omits the tracked file from disk still applies it. A path the index does not
+# carry is ABSENT — whether it is staged for deletion or was never tracked,
+# the commit carries no such file. Every caller is a policy that can only
+# loosen a verdict (an excludes list, the render inventory, a tighten-only
+# baseline), and a worktree file nobody staged would hold the commit to rows
+# it does not carry, so the worktree copy is not read here at all.
 #
-# Each probe reserves one status for its one expected answer and routes every
-# other status through gg_fail. A probe git could not answer must
-# not fall through to the worktree copy: that judges the commit against looser
-# policy than the index carries, and says nothing while doing it.
-#
-# `tracked` drops the never-tracked fallback: a path the index does not carry
-# is absent, for a policy that can only loosen a verdict, where a worktree
-# file nobody staged would hold the commit to rows it does not carry.
-gg_policy_content() { # FILE [tracked] — content on stdout; 1 = the commit has no such file
-  local file="$1" mode="${2:-}" status=0 head_status=0 tree_status=0 entry=""
-  case "$mode" in
-    "" | tracked) ;;
-    *) gg_fail policy-mode "$mode" "gg_policy_content takes no mode but tracked" ;;
-  esac
+# The index probe reserves one status for its one expected answer and routes
+# every other status through gg_fail: a probe git could not answer must not be
+# read as "untracked", which would judge the commit against looser policy than
+# the index carries, and say nothing while doing it.
+gg_policy_content() { # FILE — content on stdout; 1 = the commit has no such file
+  local file="$1" status=0
   # :(literal) — a path spelling a glob (`*`, `?`, `[`) must match itself in
   # the index, never whatever the glob happens to reach.
   git ls-files --error-unmatch -- ":(literal)$file" >/dev/null 2>&1 || status=$?
@@ -358,30 +353,9 @@ gg_policy_content() { # FILE [tracked] — content on stdout; 1 = the commit has
       git show ":0:$file" || gg_fail index-copy "$file" "could not read the staged copy of $(gg_shown "$file")"
       return 0
       ;;
-    1) [ "$mode" != tracked ] || return 1 ;;
+    1) return 1 ;;
     *) gg_fail index-query "$file:$status" "could not query the index for $(gg_shown "$file") (git ls-files exit $status); refusing to treat it as untracked" ;;
   esac
-  # ls-tree, never `cat-file -e`: with rev:path syntax git answers "no such
-  # path in HEAD" with the same 128 an operational failure returns, so only
-  # ls-tree (exit 0, empty output for an absent path) tells the two apart.
-  # An unborn HEAD carries nothing by definition — rev-parse reserves exit 1.
-  git rev-parse --verify --quiet HEAD >/dev/null 2>&1 || head_status=$?
-  case "$head_status" in
-    0)
-      entry="$(git ls-tree HEAD -- ":(literal)$file" 2>/dev/null)" || tree_status=$?
-      [ "$tree_status" -eq 0 ] \
-        || gg_fail head-query "$file:$tree_status" "could not probe HEAD for $(gg_shown "$file") (git ls-tree exit $tree_status); refusing to treat it as untracked"
-      # Tracked in HEAD, absent from the index: staged for deletion.
-      if [ -n "$entry" ]; then return 1; fi
-      ;;
-    1) ;;
-    *) gg_fail head-resolve "$file:$head_status" "could not resolve HEAD while reading $(gg_shown "$file") (git rev-parse exit $head_status); refusing to treat it as untracked" ;;
-  esac
-  if [ -f "$file" ]; then
-    cat -- "$file" || gg_fail file-read "$file" "could not read $(gg_shown "$file")"
-    return 0
-  fi
-  return 1
 }
 
 # Shell glob matched against the full repo-relative path (`*` crosses `/`);

--- a/.agents/skills/commit-guards/scripts/suppression-ban
+++ b/.agents/skills/commit-guards/scripts/suppression-ban
@@ -195,14 +195,13 @@ while IFS= read -r -d '' f; do
 done <"$GG_TMP/bare.z"
 LC_ALL=C sort "$GG_TMP/counts.raw" >"$GG_TMP/counts.tsv"
 
-# Baseline load + hygiene (gg_validate_baseline): worktree file first; a
-# tracked-but-absent baseline (sparse checkout) is read from the index so it
-# cannot degrade to empty; otherwise the baseline is empty.
+# Baseline load + hygiene (gg_validate_baseline). The scan is index-scoped, so
+# the baseline it is judged against is the index copy too: an unstaged row bump
+# must not authorize growth the commit does not carry, and a tracked baseline
+# absent from the work tree (a sparse checkout) still applies rather than
+# degrading to empty. A baseline the index does not carry is empty.
 #
-# The scan is index-scoped, so the baseline it is judged against is the index
-# copy too: an unstaged row bump must not authorize growth the commit does not
-# carry. Only a never-tracked baseline, and --update (which rewrites the
-# worktree copy), read from disk.
+# --update is the one reader of the file on disk, since it rewrites that file.
 BASELINE_FROM_INDEX=0
 if [ "$MODE" = "update" ] && [ -f "$BASELINE_FILE" ]; then
   gg_validate_baseline "$BASELINE_FILE" "$BASELINE_FILE"
@@ -212,7 +211,8 @@ else
   gg_policy_content "$BASELINE_FILE" >"$GG_TMP/baseline.tsv" || baseline_status=$?
   case "$baseline_status" in
     0)
-      # A readable policy with no worktree file came from the index.
+      # A baseline the index carries with no file on disk: --update below has
+      # nothing to rewrite and must say so rather than write a new file.
       [ -f "$BASELINE_FILE" ] || BASELINE_FROM_INDEX=1
       gg_validate_baseline "$GG_TMP/baseline.tsv" "$BASELINE_FILE"
       ;;

--- a/.agents/skills/commit-guards/tests/index-reads.test.sh
+++ b/.agents/skills/commit-guards/tests/index-reads.test.sh
@@ -94,11 +94,6 @@ fx_never_tracked() { new_repo "$1"; printf 'seed\n' >"$R/seed.txt"; commit_all b
 fx_unborn() { new_repo unborn-head; mkdir -p "$R/tools"; printf 'ONDISK\treason\n' >"$R/tools/ex.tsv"; }
 fx_glob() { new_repo "$1"; mkdir -p "$R/tools"; printf 'REAL\treason\n' >"$R/tools/exA.tsv"; commit_all base; }
 printf 'not an index\n' >"$ROOT/corrupt.idx"
-# A git that cannot probe HEAD for the file: the probe's failure is never
-# read as "absent from HEAD".
-mkdir -p "$ROOT/git-shim-ls-tree"
-printf '#!/usr/bin/env bash\ncase " $* " in *" ls-tree "*) echo "git ls-tree: simulated failure" >&2; exit 128 ;; esac\nexec "%s" "$@"\n' "$(command -v git)" >"$ROOT/git-shim-ls-tree/git"
-chmod +x "$ROOT/git-shim-ls-tree/git"
 
 echo "=== gg_policy_content ==="
 # label | fixture | shim | snippet | expect
@@ -106,9 +101,8 @@ rows=(
   "the staged copy governs over an unstaged edit|fx_policy staged-wins INDEX WORKTREE||gg_policy_content tools/ex.tsv|rc=0 INDEX\\treason"
   "an unreadable index is a collection error, never the worktree copy|fx_policy corrupt INDEX WORKTREE||GIT_INDEX_FILE=$ROOT/corrupt.idx gg_policy_content tools/ex.tsv|rc=2 probe: index-query=tools/ex.tsv:128"
   "a staged deletion governs as absent with the worktree copy present|fx_staged_deletion||gg_policy_content tools/ex.tsv|rc=1"
-  "a never-tracked policy file falls back to the worktree copy|fx_never_tracked never-tracked||gg_policy_content tools/ex.tsv|rc=0 ONDISK\\treason"
-  "a HEAD probe that failed is a collection error, never the worktree copy|fx_never_tracked head-probe|$ROOT/git-shim-ls-tree|gg_policy_content tools/ex.tsv|rc=2 probe: head-query=tools/ex.tsv:128"
-  "an unborn HEAD carries nothing and does not fail the read|fx_unborn||gg_policy_content tools/ex.tsv|rc=0 ONDISK\\treason"
+  "a never-tracked policy file governs as absent: the worktree copy is not read|fx_never_tracked never-tracked||gg_policy_content tools/ex.tsv|rc=1"
+  "an unborn HEAD carries nothing, and neither does the worktree copy|fx_unborn||gg_policy_content tools/ex.tsv|rc=1"
   "a glob-shaped path matches only itself|fx_glob glob-path||gg_policy_content 'tools/ex?.tsv'|rc=1"
   "control: the literal path it names resolves|fx_glob literal-path||gg_policy_content tools/exA.tsv|rc=0 REAL\\treason"
 )

--- a/.agents/skills/commit-guards/tests/pre-push.test.sh
+++ b/.agents/skills/commit-guards/tests/pre-push.test.sh
@@ -281,6 +281,59 @@ assert_eq "a branch rebased into a breach is refused before it leaves the machin
 assert_eq "and refused again when the push spells its left side HEAD" \
   "$REFUSED" "$(push_ref "$REBASED" HEAD:refs/heads/topic)"
 
+# ------------------------------------------------------ the policy at push
+#
+# That breach is excludable: a row in byte-ceiling's excludes list leaves the
+# document out of the scan. Every lane reads its policy from the INDEX, so a
+# stray list nobody staged cannot excuse the document the push is carrying —
+# a verdict bought with a local file no commit holds is a fail-open in gate
+# code, and the lane's own help says neither untracked files nor unstaged
+# edits are consulted.
+EXCLUDES=tools/byte-ceiling-excludes
+excludes_row() { # REPO — the row that would leave big.md out of the scan, in the work tree
+  mkdir -p "$1/tools"
+  printf 'big.md\ta row that would excuse the document\n' >"$1/$EXCLUDES"
+}
+
+STRAY=""
+scenario STRAY stray 1
+excludes_row "$STRAY"
+assert_eq "an untracked excludes row excuses nothing: the rebased breach is still refused" \
+  "$REFUSED" "$(push_ref "$STRAY" topic)"
+
+# The inverse, which is what makes the row above a row that would have worked.
+# Staging it alone cannot answer this: the index-drift refusal fires first, so
+# the row reaches the index the only way a push carries one, in a commit.
+HONOURED=""
+scenario HONOURED honoured 1
+excludes_row "$HONOURED"
+q git -C "$HONOURED" add "$EXCLUDES"
+q git -C "$HONOURED" commit -q -m "chore: declare the document in the excludes list"
+assert_eq "control: the same row committed is honoured and the push passes" \
+  "rc=0 pre-push: step=base:<oid>;byte-ceiling: result=0:1:1:base:<oid>;pre-push: result=0" \
+  "$(push_ref "$HONOURED" topic)"
+
+# The must-fail control: a copy of the policy reader that falls back to the
+# worktree copy for a path the index does not carry. The stray row is then
+# honoured, and the document the push is carrying leaves under a clean verdict.
+FALLBACK="$TMP/.fallback/commit-guards"
+mkdir -p "$(dirname "$FALLBACK")"
+cp -R "$SKILL_TEMPLATE" "$FALLBACK"
+FALLBACK_LIB="$FALLBACK/scripts/lib/configured-paths.sh"
+FALLBACK_BEFORE="$(cat -- "$FALLBACK_LIB")"
+sed -i.bak 's#^    1) return 1 ;;$#    1) [ ! -f "$file" ] || { cat -- "$file"; return 0; }; return 1 ;;#' \
+  "$FALLBACK_LIB"
+rm -f -- "$FALLBACK_LIB.bak"
+assert_eq "the fallback edit took" "rewritten" \
+  "$(if [ "$FALLBACK_BEFORE" = "$(cat -- "$FALLBACK_LIB")" ]; then echo unchanged; else echo rewritten; fi)"
+
+FELLBACK=""
+scenario FELLBACK fellback 1 "$FALLBACK"
+excludes_row "$FELLBACK"
+assert_eq "must-fail: with the worktree fallback restored, the stray row excuses the breach and it pushes" \
+  "rc=0 pre-push: step=base:<oid>;byte-ceiling: result=0:0:1:base:<oid>;pre-push: result=0" \
+  "$(push_ref "$FELLBACK" topic)"
+
 # ------------------------------------------------------------- the subject
 #
 # The not-head refusal settles which commit is leaving; it settles nothing

--- a/.agents/skills/commit-guards/tests/suppression-ban.test.sh
+++ b/.agents/skills/commit-guards/tests/suppression-ban.test.sh
@@ -230,7 +230,7 @@ run_rows \
   "an unstaged emptying of the inventory changes nothing: the index copy governs|fx_inv_unstaged|||rc=0 $OK|-" \
   "the staged emptying exposes the render|fx_inv_staged|||rc=1 $INV_HIT|-" \
   "an inventory staged for deletion excludes nothing, whatever the work tree holds|fx_inv_deleted|||rc=1 $INV_HIT|-" \
-  "a never-tracked inventory on disk is all there is, and governs|fx_inv_untracked|||rc=0 $OK|-" \
+  "a never-tracked inventory excludes nothing either: the index is the only reader|fx_inv_untracked|||rc=1 $INV_HIT|-" \
   "no inventory anywhere excludes nothing: an all-in-place project has no renders|fx_inv_none|||rc=1 $INV_HIT|-" \
   "control: with no inventory a clean render passes|fx_inv_none_clean|||rc=0 $OK|-" \
   "an object is refused: the writer emits an array|fx_inv_object|||rc=2 $ERR_INV|-" \

--- a/skills/commit-guards/scripts/byte-ceiling
+++ b/skills/commit-guards/scripts/byte-ceiling
@@ -203,7 +203,7 @@ case "$MODE" in
     # never-staged file must not hold the swept index to rows it does not
     # carry.
     baseline_status=0
-    gg_policy_content "$BASELINE_FILE" tracked >"$GG_TMP/baseline.tsv" || baseline_status=$?
+    gg_policy_content "$BASELINE_FILE" >"$GG_TMP/baseline.tsv" || baseline_status=$?
     case "$baseline_status" in
       0) gg_validate_baseline "$GG_TMP/baseline.tsv" "$BASELINE_FILE" ;;
       1) : >"$GG_TMP/baseline.tsv" ;;

--- a/skills/commit-guards/scripts/lib/configured-paths.sh
+++ b/skills/commit-guards/scripts/lib/configured-paths.sh
@@ -327,26 +327,21 @@ GG_EXCLUDE_PATTERNS=()
 # shellcheck source=generated-paths.sh
 source "${BASH_SOURCE[0]%/*}/generated-paths.sh"
 
-# The scans read the INDEX, so policy files come from the index too: staged
-# edits to one govern staged scans, and a sparse checkout that omits the
-# tracked file from disk still applies it. A path staged for DELETION governs
-# as ABSENT — the commit carries no such file — which is not the same as a
-# never-tracked path, where the worktree copy is all there is.
+# The scans read the INDEX, so policy files come from the index and nowhere
+# else: staged edits to one govern staged scans, and a sparse checkout that
+# omits the tracked file from disk still applies it. A path the index does not
+# carry is ABSENT — whether it is staged for deletion or was never tracked,
+# the commit carries no such file. Every caller is a policy that can only
+# loosen a verdict (an excludes list, the render inventory, a tighten-only
+# baseline), and a worktree file nobody staged would hold the commit to rows
+# it does not carry, so the worktree copy is not read here at all.
 #
-# Each probe reserves one status for its one expected answer and routes every
-# other status through gg_fail. A probe git could not answer must
-# not fall through to the worktree copy: that judges the commit against looser
-# policy than the index carries, and says nothing while doing it.
-#
-# `tracked` drops the never-tracked fallback: a path the index does not carry
-# is absent, for a policy that can only loosen a verdict, where a worktree
-# file nobody staged would hold the commit to rows it does not carry.
-gg_policy_content() { # FILE [tracked] — content on stdout; 1 = the commit has no such file
-  local file="$1" mode="${2:-}" status=0 head_status=0 tree_status=0 entry=""
-  case "$mode" in
-    "" | tracked) ;;
-    *) gg_fail policy-mode "$mode" "gg_policy_content takes no mode but tracked" ;;
-  esac
+# The index probe reserves one status for its one expected answer and routes
+# every other status through gg_fail: a probe git could not answer must not be
+# read as "untracked", which would judge the commit against looser policy than
+# the index carries, and say nothing while doing it.
+gg_policy_content() { # FILE — content on stdout; 1 = the commit has no such file
+  local file="$1" status=0
   # :(literal) — a path spelling a glob (`*`, `?`, `[`) must match itself in
   # the index, never whatever the glob happens to reach.
   git ls-files --error-unmatch -- ":(literal)$file" >/dev/null 2>&1 || status=$?
@@ -358,30 +353,9 @@ gg_policy_content() { # FILE [tracked] — content on stdout; 1 = the commit has
       git show ":0:$file" || gg_fail index-copy "$file" "could not read the staged copy of $(gg_shown "$file")"
       return 0
       ;;
-    1) [ "$mode" != tracked ] || return 1 ;;
+    1) return 1 ;;
     *) gg_fail index-query "$file:$status" "could not query the index for $(gg_shown "$file") (git ls-files exit $status); refusing to treat it as untracked" ;;
   esac
-  # ls-tree, never `cat-file -e`: with rev:path syntax git answers "no such
-  # path in HEAD" with the same 128 an operational failure returns, so only
-  # ls-tree (exit 0, empty output for an absent path) tells the two apart.
-  # An unborn HEAD carries nothing by definition — rev-parse reserves exit 1.
-  git rev-parse --verify --quiet HEAD >/dev/null 2>&1 || head_status=$?
-  case "$head_status" in
-    0)
-      entry="$(git ls-tree HEAD -- ":(literal)$file" 2>/dev/null)" || tree_status=$?
-      [ "$tree_status" -eq 0 ] \
-        || gg_fail head-query "$file:$tree_status" "could not probe HEAD for $(gg_shown "$file") (git ls-tree exit $tree_status); refusing to treat it as untracked"
-      # Tracked in HEAD, absent from the index: staged for deletion.
-      if [ -n "$entry" ]; then return 1; fi
-      ;;
-    1) ;;
-    *) gg_fail head-resolve "$file:$head_status" "could not resolve HEAD while reading $(gg_shown "$file") (git rev-parse exit $head_status); refusing to treat it as untracked" ;;
-  esac
-  if [ -f "$file" ]; then
-    cat -- "$file" || gg_fail file-read "$file" "could not read $(gg_shown "$file")"
-    return 0
-  fi
-  return 1
 }
 
 # Shell glob matched against the full repo-relative path (`*` crosses `/`);

--- a/skills/commit-guards/scripts/suppression-ban
+++ b/skills/commit-guards/scripts/suppression-ban
@@ -195,14 +195,13 @@ while IFS= read -r -d '' f; do
 done <"$GG_TMP/bare.z"
 LC_ALL=C sort "$GG_TMP/counts.raw" >"$GG_TMP/counts.tsv"
 
-# Baseline load + hygiene (gg_validate_baseline): worktree file first; a
-# tracked-but-absent baseline (sparse checkout) is read from the index so it
-# cannot degrade to empty; otherwise the baseline is empty.
+# Baseline load + hygiene (gg_validate_baseline). The scan is index-scoped, so
+# the baseline it is judged against is the index copy too: an unstaged row bump
+# must not authorize growth the commit does not carry, and a tracked baseline
+# absent from the work tree (a sparse checkout) still applies rather than
+# degrading to empty. A baseline the index does not carry is empty.
 #
-# The scan is index-scoped, so the baseline it is judged against is the index
-# copy too: an unstaged row bump must not authorize growth the commit does not
-# carry. Only a never-tracked baseline, and --update (which rewrites the
-# worktree copy), read from disk.
+# --update is the one reader of the file on disk, since it rewrites that file.
 BASELINE_FROM_INDEX=0
 if [ "$MODE" = "update" ] && [ -f "$BASELINE_FILE" ]; then
   gg_validate_baseline "$BASELINE_FILE" "$BASELINE_FILE"
@@ -212,7 +211,8 @@ else
   gg_policy_content "$BASELINE_FILE" >"$GG_TMP/baseline.tsv" || baseline_status=$?
   case "$baseline_status" in
     0)
-      # A readable policy with no worktree file came from the index.
+      # A baseline the index carries with no file on disk: --update below has
+      # nothing to rewrite and must say so rather than write a new file.
       [ -f "$BASELINE_FILE" ] || BASELINE_FROM_INDEX=1
       gg_validate_baseline "$GG_TMP/baseline.tsv" "$BASELINE_FILE"
       ;;

--- a/skills/commit-guards/tests/index-reads.test.sh
+++ b/skills/commit-guards/tests/index-reads.test.sh
@@ -94,11 +94,6 @@ fx_never_tracked() { new_repo "$1"; printf 'seed\n' >"$R/seed.txt"; commit_all b
 fx_unborn() { new_repo unborn-head; mkdir -p "$R/tools"; printf 'ONDISK\treason\n' >"$R/tools/ex.tsv"; }
 fx_glob() { new_repo "$1"; mkdir -p "$R/tools"; printf 'REAL\treason\n' >"$R/tools/exA.tsv"; commit_all base; }
 printf 'not an index\n' >"$ROOT/corrupt.idx"
-# A git that cannot probe HEAD for the file: the probe's failure is never
-# read as "absent from HEAD".
-mkdir -p "$ROOT/git-shim-ls-tree"
-printf '#!/usr/bin/env bash\ncase " $* " in *" ls-tree "*) echo "git ls-tree: simulated failure" >&2; exit 128 ;; esac\nexec "%s" "$@"\n' "$(command -v git)" >"$ROOT/git-shim-ls-tree/git"
-chmod +x "$ROOT/git-shim-ls-tree/git"
 
 echo "=== gg_policy_content ==="
 # label | fixture | shim | snippet | expect
@@ -106,9 +101,8 @@ rows=(
   "the staged copy governs over an unstaged edit|fx_policy staged-wins INDEX WORKTREE||gg_policy_content tools/ex.tsv|rc=0 INDEX\\treason"
   "an unreadable index is a collection error, never the worktree copy|fx_policy corrupt INDEX WORKTREE||GIT_INDEX_FILE=$ROOT/corrupt.idx gg_policy_content tools/ex.tsv|rc=2 probe: index-query=tools/ex.tsv:128"
   "a staged deletion governs as absent with the worktree copy present|fx_staged_deletion||gg_policy_content tools/ex.tsv|rc=1"
-  "a never-tracked policy file falls back to the worktree copy|fx_never_tracked never-tracked||gg_policy_content tools/ex.tsv|rc=0 ONDISK\\treason"
-  "a HEAD probe that failed is a collection error, never the worktree copy|fx_never_tracked head-probe|$ROOT/git-shim-ls-tree|gg_policy_content tools/ex.tsv|rc=2 probe: head-query=tools/ex.tsv:128"
-  "an unborn HEAD carries nothing and does not fail the read|fx_unborn||gg_policy_content tools/ex.tsv|rc=0 ONDISK\\treason"
+  "a never-tracked policy file governs as absent: the worktree copy is not read|fx_never_tracked never-tracked||gg_policy_content tools/ex.tsv|rc=1"
+  "an unborn HEAD carries nothing, and neither does the worktree copy|fx_unborn||gg_policy_content tools/ex.tsv|rc=1"
   "a glob-shaped path matches only itself|fx_glob glob-path||gg_policy_content 'tools/ex?.tsv'|rc=1"
   "control: the literal path it names resolves|fx_glob literal-path||gg_policy_content tools/exA.tsv|rc=0 REAL\\treason"
 )

--- a/skills/commit-guards/tests/pre-push.test.sh
+++ b/skills/commit-guards/tests/pre-push.test.sh
@@ -281,6 +281,59 @@ assert_eq "a branch rebased into a breach is refused before it leaves the machin
 assert_eq "and refused again when the push spells its left side HEAD" \
   "$REFUSED" "$(push_ref "$REBASED" HEAD:refs/heads/topic)"
 
+# ------------------------------------------------------ the policy at push
+#
+# That breach is excludable: a row in byte-ceiling's excludes list leaves the
+# document out of the scan. Every lane reads its policy from the INDEX, so a
+# stray list nobody staged cannot excuse the document the push is carrying —
+# a verdict bought with a local file no commit holds is a fail-open in gate
+# code, and the lane's own help says neither untracked files nor unstaged
+# edits are consulted.
+EXCLUDES=tools/byte-ceiling-excludes
+excludes_row() { # REPO — the row that would leave big.md out of the scan, in the work tree
+  mkdir -p "$1/tools"
+  printf 'big.md\ta row that would excuse the document\n' >"$1/$EXCLUDES"
+}
+
+STRAY=""
+scenario STRAY stray 1
+excludes_row "$STRAY"
+assert_eq "an untracked excludes row excuses nothing: the rebased breach is still refused" \
+  "$REFUSED" "$(push_ref "$STRAY" topic)"
+
+# The inverse, which is what makes the row above a row that would have worked.
+# Staging it alone cannot answer this: the index-drift refusal fires first, so
+# the row reaches the index the only way a push carries one, in a commit.
+HONOURED=""
+scenario HONOURED honoured 1
+excludes_row "$HONOURED"
+q git -C "$HONOURED" add "$EXCLUDES"
+q git -C "$HONOURED" commit -q -m "chore: declare the document in the excludes list"
+assert_eq "control: the same row committed is honoured and the push passes" \
+  "rc=0 pre-push: step=base:<oid>;byte-ceiling: result=0:1:1:base:<oid>;pre-push: result=0" \
+  "$(push_ref "$HONOURED" topic)"
+
+# The must-fail control: a copy of the policy reader that falls back to the
+# worktree copy for a path the index does not carry. The stray row is then
+# honoured, and the document the push is carrying leaves under a clean verdict.
+FALLBACK="$TMP/.fallback/commit-guards"
+mkdir -p "$(dirname "$FALLBACK")"
+cp -R "$SKILL_TEMPLATE" "$FALLBACK"
+FALLBACK_LIB="$FALLBACK/scripts/lib/configured-paths.sh"
+FALLBACK_BEFORE="$(cat -- "$FALLBACK_LIB")"
+sed -i.bak 's#^    1) return 1 ;;$#    1) [ ! -f "$file" ] || { cat -- "$file"; return 0; }; return 1 ;;#' \
+  "$FALLBACK_LIB"
+rm -f -- "$FALLBACK_LIB.bak"
+assert_eq "the fallback edit took" "rewritten" \
+  "$(if [ "$FALLBACK_BEFORE" = "$(cat -- "$FALLBACK_LIB")" ]; then echo unchanged; else echo rewritten; fi)"
+
+FELLBACK=""
+scenario FELLBACK fellback 1 "$FALLBACK"
+excludes_row "$FELLBACK"
+assert_eq "must-fail: with the worktree fallback restored, the stray row excuses the breach and it pushes" \
+  "rc=0 pre-push: step=base:<oid>;byte-ceiling: result=0:0:1:base:<oid>;pre-push: result=0" \
+  "$(push_ref "$FELLBACK" topic)"
+
 # ------------------------------------------------------------- the subject
 #
 # The not-head refusal settles which commit is leaving; it settles nothing

--- a/skills/commit-guards/tests/suppression-ban.test.sh
+++ b/skills/commit-guards/tests/suppression-ban.test.sh
@@ -230,7 +230,7 @@ run_rows \
   "an unstaged emptying of the inventory changes nothing: the index copy governs|fx_inv_unstaged|||rc=0 $OK|-" \
   "the staged emptying exposes the render|fx_inv_staged|||rc=1 $INV_HIT|-" \
   "an inventory staged for deletion excludes nothing, whatever the work tree holds|fx_inv_deleted|||rc=1 $INV_HIT|-" \
-  "a never-tracked inventory on disk is all there is, and governs|fx_inv_untracked|||rc=0 $OK|-" \
+  "a never-tracked inventory excludes nothing either: the index is the only reader|fx_inv_untracked|||rc=1 $INV_HIT|-" \
   "no inventory anywhere excludes nothing: an all-in-place project has no renders|fx_inv_none|||rc=1 $INV_HIT|-" \
   "control: with no inventory a clean render passes|fx_inv_none_clean|||rc=0 $OK|-" \
   "an object is refused: the writer emits an array|fx_inv_object|||rc=2 $ERR_INV|-" \


### PR DESCRIPTION
## Summary
- `gg_policy_content` in `skills/commit-guards/scripts/lib/configured-paths.sh` reads the index and nothing else. The never-tracked work-tree fallback, the `mode` argument, the `policy-mode` refusal and the now-unreachable HEAD probe are gone, so an untracked excludes list or render inventory no commit carries can no longer loosen a push verdict.
- Every caller is a loosen-only policy (`gg_load_excludes`, suppression-ban's inventory and check-mode baseline, byte-ceiling's `--all` baseline), so the tracked reading is the only one. suppression-ban `--update` still reads the work-tree baseline through its own `cp`; it rewrites that file.
- `pre-push --help` already said neither untracked files nor unstaged edits are consulted. For every commit-guards lane that is now true.

## Design
Per the root triage comment on KEN-1332: the fallback goes, not the help. The HEAD probe existed only to tell a staged deletion from a never-tracked path; under the single reading both are absent, so nothing can observe the difference and it is deleted rather than left unreachable. The honoured-inverse control commits the excludes row rather than staging it because pre-push refuses index drift before any verdict.

## Completed Issues
- Closes KEN-1332 - pre-push reads an untracked work-tree policy file its help says no lane consults

## Residual surface (out of scope, proposed to root)
The doc-limits lane pre-push runs has its own policy reader (`skills/doc-limits/scripts/doc-limits`, `--staged` mode) that still reads a present-but-untracked excludes list from the work tree, so the issue's Reached-by example still reproduces through that lane. That is a separate skill with its own reader; the ruling scoped this fix to commit-guards' `gg_policy_content`. Proposed as a sibling issue in the lane status file.

## Size
production=24 tests=56 mirror=80 (no allowance stated on the issue)

## Test Plan
- `skills/commit-guards/tests/index-reads.test.sh`: never-tracked and unborn-HEAD rows now expect absent (rc=1); the failed-HEAD-probe row and its ls-tree shim are deleted with the probe.
- `skills/commit-guards/tests/suppression-ban.test.sh`: never-tracked inventory row now expects the render exposed.
- `skills/commit-guards/tests/pre-push.test.sh`: Done-when control plants an untracked `tools/byte-ceiling-excludes` row that would excuse the rebased over-ceiling document and sees the push still refused; the inverse commits the row and sees it honoured; a mutant copy of the reader with the fallback restored honours the stray row (must-fail control).
- Full commit-guards suite set: 36 suites, 0 failures. Pre-change probe on a scratch copy: index-reads 2, suppression-ban 1, pre-push 2 failures, one per changed surface.
- `env -u TMPDIR tools/guard --full` on 46129a65b: exit 0, no `guard:` lines.
- Render parity: `diff -r skills/commit-guards .agents/skills/commit-guards` differs only in SKILL.md's injected project-instructions block.
- Local review: reviewer-correctness pass, reviewer-security pass (four suites re-run, 231 assertions, 0 failures). External Codex lane failed to launch (usage limit).

https://claude.ai/code/session_017bifqZGpFDLiGYvyKjYckx
