### PR TITLE
fix(KEN-1351): ci-wait reads a pull request that was already green as a timeout, and submit-pr routes it to ci-status-unconfirmed

### DIFF
--- a/.agents/skills/orch/scripts/ci-wait
+++ b/.agents/skills/orch/scripts/ci-wait
@@ -168,11 +168,13 @@ failures (max 1 retry).
   --json         emit the machine-readable result object on stdout
 
 Verdicts (JSON "verdict"):
-  pass     every current-head check settled green
+  pass     every current-head check settled green, only ever paired with
+           status "complete"
   fail     a settled current-head failure — current-run failures are
            terminal
-  pending  checks still running or not yet registered; at the deadline the
-           result is status "timeout", never silent success
+  pending  checks still running, not yet registered, or settled green but
+           never confirmed to belong to the current run; at the deadline the
+           result is status "timeout" with this verdict, never silent success
   none     (with status "complete") the repo has no CI to wait for: no
            active workflows, no branch protection, and no required-check
            rules on the PR's base branch, each probe answering
@@ -191,6 +193,14 @@ original run id — keeps the verdict pending; a newest same-workflow run
 that completed successfully discards the stale failures; a failed newest
 run, or a cancelled run with no newer or fresher sibling, stays terminal.
 A missing replacement reaches the timeout rather than passing.
+
+A rollup of nothing but settled checks, with none ever seen in progress, is
+either the prior run's leftovers or CI that finished before the wait started.
+It completes once that same picture has held for the stale window — 90
+seconds of wall clock, not a count of polls, so the threshold does not scale
+with poll_interval — which at the default interval is the second poll, well
+inside the default budget. Short of the window the wait keeps polling and the
+deadline reports status "timeout" with verdict "pending".
 
 JSON output (always when --json):
   {
@@ -311,15 +321,18 @@ last_check_classes="$EMPTY_CLASSES"
 # Emit the final machine-readable result on stdout. Every exit path routes
 # through here (or emit_error) so the script can never finish silently.
 #   status: complete | timeout | error
-#   verdict derives from the classes: pending > fail > pass.
+#   verdict derives from the classes: pending > fail > pass. "pass" needs
+#   status "complete": a rollup that reads green at a deadline or an error was
+#   never confirmed settled, and a caller routing on verdict alone would take
+#   an unfinished wait for a green one.
 emit_result() {
   local status="$1" classes="$2" error_msg="${3:-}"
   update_elapsed
   local verdict
-  verdict=$(jq -r '
+  verdict=$(jq -r --arg status "$status" '
     if (.pending | length) > 0 then "pending"
     elif (.failed | length) > 0 then "fail"
-    elif (.passed | length) > 0 then "pass"
+    elif ($status == "complete") and ((.passed | length) > 0) then "pass"
     else "pending" end' <<<"$classes")
   if $JSON_OUTPUT; then
     jq -n \
@@ -486,10 +499,17 @@ fi
 # triggered (push, review-approval dispatch), checks from an old run
 # (SUCCESS/SKIPPED) may be the only ones visible.
 # Only declare "passed" after we've seen at least one check go through
-# IN_PROGRESS/PENDING, proving a fresh run was observed.
+# IN_PROGRESS/PENDING, proving a fresh run was observed, or after the same
+# all-settled picture has held for STALE_WINDOW.
+# The window is wall-clock seconds because poll_interval is the caller's:
+# counting polls made the real threshold poll_interval times this window, so
+# at the default 180s interval a PR that was already green when the wait
+# started spent the whole budget and reported a timeout.
 seen_in_progress=false
-stale_count=0
-max_stale=6  # ~90s of only completed/skipped before assuming genuinely done
+STALE_WINDOW=90  # seconds of only completed/skipped before assuming genuinely done
+# Elapsed seconds at the start of the current all-settled streak; -1 when no
+# streak is open.
+stale_since=-1
 
 # The log is captured whole and windowed in-shell, and head and grep read
 # here-strings, which have no producer to signal: `gh | head -200`
@@ -739,7 +759,7 @@ while [ "$elapsed" -lt "$MAX_WAIT" ]; do
   # Track if we've observed a fresh run (guards against stale-check race)
   if [ "$pending_count" -gt 0 ]; then
     seen_in_progress=true
-    stale_count=0
+    stale_since=-1
   fi
 
   # Check for failure (only when all checks have settled). Before declaring
@@ -761,7 +781,7 @@ while [ "$elapsed" -lt "$MAX_WAIT" ]; do
         check_classes=$(jq -c '.pending += (.failed | map(.state = "EXPECTED" | .bucket = "pending")) | .failed = []' <<<"$check_classes")
         last_check_classes="$check_classes"
         seen_in_progress=true
-        stale_count=0
+        stale_since=-1
         sleep "$POLL_INTERVAL"
         update_elapsed
         continue
@@ -805,9 +825,12 @@ while [ "$elapsed" -lt "$MAX_WAIT" ]; do
     fi
     # Only seeing completed/skipped checks but never saw in-progress.
     # Could be stale checks from prior run, or CI already completed before
-    # we started watching. Use stale counter to distinguish.
-    stale_count=$((stale_count + 1))
-    if [ "$stale_count" -ge "$max_stale" ]; then
+    # we started watching. Hold the same picture for STALE_WINDOW to tell
+    # them apart.
+    if [ "$stale_since" -lt 0 ]; then
+      stale_since="$elapsed"
+    fi
+    if [ "$((elapsed - stale_since))" -ge "$STALE_WINDOW" ]; then
       # Waited long enough for subsequent checks to appear — genuinely complete
       emit_result "complete" "$check_classes"
       exit 0

--- a/.agents/skills/orch/scripts/ci-wait
+++ b/.agents/skills/orch/scripts/ci-wait
@@ -194,13 +194,13 @@ that completed successfully discards the stale failures; a failed newest
 run, or a cancelled run with no newer or fresher sibling, stays terminal.
 A missing replacement reaches the timeout rather than passing.
 
-A rollup of nothing but settled checks, none ever seen in progress, is either
-the prior run's leftovers or CI that finished before the wait started. It
-completes once the stale window has measured consecutive polls showing one
-unchanged rollup of every check's name and state: 90 seconds of wall clock,
-not a count of polls, which at the default interval is the second poll. Any
-other poll starts the window over, and short of it the deadline reports
-status "timeout" with verdict "pending".
+A rollup of settled checks with at least one passed, none ever seen in
+progress, is either the prior run's leftovers or CI that finished before the
+wait started. It completes once the stale window has measured consecutive
+polls showing one unchanged rollup of every check's name and state: 90
+seconds of wall clock, not a count of polls, which at the default interval is
+the second poll. Any other poll starts the window over, and short of it the
+deadline reports status "timeout" with verdict "pending".
 
 JSON output (always when --json):
   {
@@ -831,6 +831,9 @@ while [ "$elapsed" -lt "$MAX_WAIT" ]; do
     # which drop skipped entries: a check registering late as SKIPPED is a
     # different rollup and starts the window over.
     settled_this_poll=true
+    # The clock the streak is stamped and measured against is the one this
+    # rollup was read at, not the one before the request that fetched it.
+    update_elapsed
     settled_key=$(jq -cS '[.[] | {name, state}] | sort_by(.name, .state)' <<<"$checks_json")
     if [ "$settled_key" != "$stale_key" ]; then
       stale_key="$settled_key"

--- a/.agents/skills/orch/scripts/ci-wait
+++ b/.agents/skills/orch/scripts/ci-wait
@@ -199,10 +199,11 @@ either the prior run's leftovers or CI that finished before the wait started.
 It completes once that same picture has held for the stale window — 90
 seconds of wall clock, not a count of polls, so the threshold does not scale
 with poll_interval — which at the default interval is the second poll, well
-inside the default budget. The picture is every check's name and state, so a
-poll that differs from the one being held — a check registering late as a
-settled success, an emptied rollup, a run the wait itself asked for — starts
-the window over rather than inheriting the time already served. Short of the
+inside the default budget. The window measures consecutive polls showing one
+unchanged settled picture, that picture being every check's name and state:
+any other poll — a changed rollup, an emptied one, a failure, a rollup of
+nothing but skipped checks, a run the wait itself asked for — starts the
+window over rather than passing on the time already served. Short of the
 window the wait keeps polling and the deadline reports status "timeout" with
 verdict "pending".
 
@@ -666,8 +667,24 @@ classify_checks() {
 checks_stderr=$(mktemp)
 trap 'rm -f "$checks_stderr"' EXIT
 
+# Wait out one interval, carrying the settled streak only across consecutive
+# polls that reached the settled-check window. Every other poll shape — an
+# emptied rollup, a failure, a rerun, a rollup of nothing but skipped checks —
+# ends the streak here, so a later identical picture is confirmed on its own
+# rather than on time the wait already served. Every sleep in the loop runs
+# through this, which is what keeps the rule to one site.
+poll_sleep() {
+  local seconds="$1"
+  [ "$settled_this_poll" = true ] || stale_key=""
+  sleep "$seconds"
+  update_elapsed
+}
+
 update_elapsed
 while [ "$elapsed" -lt "$MAX_WAIT" ]; do
+  # Only the settled-check window sets this true, and only for the poll that
+  # reached it.
+  settled_this_poll=false
   # Capture stderr so we can distinguish auth/repo failures from "no checks yet".
   checks_status=0
   set +e
@@ -756,12 +773,7 @@ while [ "$elapsed" -lt "$MAX_WAIT" ]; do
       fi
       exit 1
     fi
-    # A rollup that went empty is not the picture any streak was holding, and
-    # the key comparison below never sees this poll: drop the streak so the
-    # checks that come back are confirmed on their own.
-    stale_key=""
-    sleep "$POLL_INTERVAL"
-    update_elapsed
+    poll_sleep "$POLL_INTERVAL"
     continue
   fi
 
@@ -804,8 +816,7 @@ while [ "$elapsed" -lt "$MAX_WAIT" ]; do
         check_classes=$(jq -c '.pending += (.failed | map(.state = "EXPECTED" | .bucket = "pending")) | .failed = []' <<<"$check_classes")
         last_check_classes="$check_classes"
         seen_in_progress=true
-        sleep "$POLL_INTERVAL"
-        update_elapsed
+        poll_sleep "$POLL_INTERVAL"
         continue
         ;;
       superseded)
@@ -826,13 +837,8 @@ while [ "$elapsed" -lt "$MAX_WAIT" ]; do
           ci_message retry "$@" >&2
           gh run rerun "$failed_run" --repo "$REPO" --failed 2>/dev/null || true
           retries=$((retries + 1))
-          # The rerun produces new checks, and the picture it replaces can be
-          # identical to the one that follows it, so the key comparison below
-          # cannot see this change: drop the streak explicitly.
-          seen_in_progress=false
-          stale_key=""
-          sleep 10
-          update_elapsed
+          seen_in_progress=false  # Reset because rerun will produce new checks
+          poll_sleep 10
           continue
         fi
 
@@ -855,6 +861,7 @@ while [ "$elapsed" -lt "$MAX_WAIT" ]; do
     # them apart: a poll whose picture differs from the one being held — a
     # check registering late as a settled success, say — starts the window
     # over rather than inheriting the elapsed time of a picture it replaced.
+    settled_this_poll=true
     settled_key=$(echo "$check_classes" | settled_checks_key)
     if [ "$settled_key" != "$stale_key" ]; then
       stale_key="$settled_key"
@@ -867,8 +874,7 @@ while [ "$elapsed" -lt "$MAX_WAIT" ]; do
     fi
   fi
 
-  sleep "$POLL_INTERVAL"
-  update_elapsed
+  poll_sleep "$POLL_INTERVAL"
 done
 
 # Deadline reached with checks still outstanding — report timeout, not

--- a/.agents/skills/orch/scripts/ci-wait
+++ b/.agents/skills/orch/scripts/ci-wait
@@ -173,8 +173,8 @@ Verdicts (JSON "verdict"):
   fail     a settled current-head failure — current-run failures are
            terminal
   pending  checks still running, not yet registered, or settled green but
-           never confirmed to belong to the current run; at the deadline the
-           result is status "timeout" with this verdict, never silent success
+           unconfirmed; at the deadline the result is status "timeout" with
+           this verdict, never silent success
   none     (with status "complete") the repo has no CI to wait for: no
            active workflows, no branch protection, and no required-check
            rules on the PR's base branch, each probe answering
@@ -194,18 +194,13 @@ that completed successfully discards the stale failures; a failed newest
 run, or a cancelled run with no newer or fresher sibling, stays terminal.
 A missing replacement reaches the timeout rather than passing.
 
-A rollup of nothing but settled checks, with none ever seen in progress, is
-either the prior run's leftovers or CI that finished before the wait started.
-It completes once that same picture has held for the stale window — 90
-seconds of wall clock, not a count of polls, so the threshold does not scale
-with poll_interval — which at the default interval is the second poll, well
-inside the default budget. The window measures consecutive polls showing one
-unchanged settled picture, that picture being every check's name and state:
-any other poll — a changed rollup, an emptied one, a failure, a rollup of
-nothing but skipped checks, a run the wait itself asked for — starts the
-window over rather than passing on the time already served. Short of the
-window the wait keeps polling and the deadline reports status "timeout" with
-verdict "pending".
+A rollup of nothing but settled checks, none ever seen in progress, is either
+the prior run's leftovers or CI that finished before the wait started. It
+completes once the stale window has measured consecutive polls showing one
+unchanged rollup of every check's name and state: 90 seconds of wall clock,
+not a count of polls, which at the default interval is the second poll. Any
+other poll starts the window over, and short of it the deadline reports
+status "timeout" with verdict "pending".
 
 JSON output (always when --json):
   {
@@ -323,18 +318,11 @@ EMPTY_CLASSES='{"pending":[],"failed":[],"passed":[]}'
 # report the checks that were still outstanding.
 last_check_classes="$EMPTY_CLASSES"
 
-# Each classified check as name and reported state, with the fallbacks older
-# gh output needs. One spelling, read by the result object and by the
-# settled-check window's key.
-CI_CHECK_VIEW_JQ='map_values([.[] | {name, state: (.state // .bucket // "UNKNOWN")}])'
-
 # Emit the final machine-readable result on stdout. Every exit path routes
 # through here (or emit_error) so the script can never finish silently.
 #   status: complete | timeout | error
-#   verdict derives from the classes: pending > fail > pass. "pass" needs
-#   status "complete": a rollup that reads green at a deadline or an error was
-#   never confirmed settled, and a caller routing on verdict alone would take
-#   an unfinished wait for a green one.
+#   verdict derives from the classes: pending > fail > pass, and "pass" only
+#   with status "complete", so an unfinished wait never reads as green.
 emit_result() {
   local status="$1" classes="$2" error_msg="${3:-}"
   update_elapsed
@@ -351,7 +339,7 @@ emit_result() {
       --arg repo "$REPO" \
       --argjson elapsed "$elapsed" \
       --arg error "$error_msg" \
-      --argjson classes "$(jq -c "$CI_CHECK_VIEW_JQ" <<<"$classes")" \
+      --argjson classes "$(jq -c 'map_values(map({name, state: (.state // .bucket // "UNKNOWN")}))' <<<"$classes")" \
       '{
         status: $s,
         verdict: $v,
@@ -509,18 +497,12 @@ fi
 # triggered (push, review-approval dispatch), checks from an old run
 # (SUCCESS/SKIPPED) may be the only ones visible.
 # Only declare "passed" after we've seen at least one check go through
-# IN_PROGRESS/PENDING, proving a fresh run was observed, or after the same
-# all-settled picture has held for STALE_WINDOW.
-# The window is wall-clock seconds because poll_interval is the caller's:
-# counting polls made the real threshold poll_interval times this window, so
-# at the default 180s interval a PR that was already green when the wait
-# started spent the whole budget and reported a timeout.
+# IN_PROGRESS/PENDING, proving a fresh run was observed, or after the window
+# below has measured one unchanged settled rollup.
 seen_in_progress=false
-STALE_WINDOW=90  # seconds of only completed/skipped before assuming genuinely done
-# The streak: the settled picture being held, and the elapsed second it was
-# first seen. A poll showing a different picture starts a new streak, so the
-# window measures one unchanging rollup and not merely the time since the
-# first settled poll. Empty means no streak is open.
+STALE_WINDOW=90  # seconds; wall clock, because poll_interval is the caller's
+# The rollup being held and the elapsed second it was first seen; an empty key
+# means no streak is open.
 stale_key=""
 stale_since=0
 
@@ -646,14 +628,6 @@ superseding_run_state() {
   ' <<<"$classes"
 }
 
-# One comparable line naming the settled picture a poll shows: every check's
-# name and state, ordered, so a rollup that only reorders its checks reads as
-# the same picture while a late-registered one does not. Reads classified
-# checks; the settled-check window compares consecutive polls with it.
-settled_checks_key() {
-  jq -cS "$CI_CHECK_VIEW_JQ"' | map_values(sort_by(.name, .state))'
-}
-
 classify_checks() {
   jq -c "$CI_RUN_JQ_DEFS"'
     {
@@ -667,12 +641,9 @@ classify_checks() {
 checks_stderr=$(mktemp)
 trap 'rm -f "$checks_stderr"' EXIT
 
-# Wait out one interval, carrying the settled streak only across consecutive
-# polls that reached the settled-check window. Every other poll shape — an
-# emptied rollup, a failure, a rerun, a rollup of nothing but skipped checks —
-# ends the streak here, so a later identical picture is confirmed on its own
-# rather than on time the wait already served. Every sleep in the loop runs
-# through this, which is what keeps the rule to one site.
+# Wait out one interval. The streak survives only across consecutive polls that
+# reached the settled-check window; every sleep in the loop runs through here,
+# which is what keeps that rule to one site.
 poll_sleep() {
   local seconds="$1"
   [ "$settled_this_poll" = true ] || stale_key=""
@@ -682,9 +653,7 @@ poll_sleep() {
 
 update_elapsed
 while [ "$elapsed" -lt "$MAX_WAIT" ]; do
-  # Only the settled-check window sets this true, and only for the poll that
-  # reached it.
-  settled_this_poll=false
+  settled_this_poll=false  # only the settled-check window below sets it true
   # Capture stderr so we can distinguish auth/repo failures from "no checks yet".
   checks_status=0
   set +e
@@ -857,12 +826,12 @@ while [ "$elapsed" -lt "$MAX_WAIT" ]; do
     fi
     # Only seeing completed/skipped checks but never saw in-progress.
     # Could be stale checks from prior run, or CI already completed before
-    # we started watching. Hold the same picture for STALE_WINDOW to tell
-    # them apart: a poll whose picture differs from the one being held — a
-    # check registering late as a settled success, say — starts the window
-    # over rather than inheriting the elapsed time of a picture it replaced.
+    # we started watching. Hold one unchanged rollup for STALE_WINDOW to tell
+    # them apart. The key reads the scoped rollup, not the classified checks,
+    # which drop skipped entries: a check registering late as SKIPPED is a
+    # different rollup and starts the window over.
     settled_this_poll=true
-    settled_key=$(echo "$check_classes" | settled_checks_key)
+    settled_key=$(jq -cS '[.[] | {name, state}] | sort_by(.name, .state)' <<<"$checks_json")
     if [ "$settled_key" != "$stale_key" ]; then
       stale_key="$settled_key"
       stale_since="$elapsed"

--- a/.agents/skills/orch/scripts/ci-wait
+++ b/.agents/skills/orch/scripts/ci-wait
@@ -804,7 +804,10 @@ while [ "$elapsed" -lt "$MAX_WAIT" ]; do
           ci_message retry "$@" >&2
           gh run rerun "$failed_run" --repo "$REPO" --failed 2>/dev/null || true
           retries=$((retries + 1))
-          seen_in_progress=false  # Reset because rerun will produce new checks
+          # Reset because rerun will produce new checks: the rollups before it
+          # confirm nothing about the run it just started.
+          seen_in_progress=false
+          stale_since=-1
           sleep 10
           update_elapsed
           continue

--- a/.agents/skills/orch/scripts/ci-wait
+++ b/.agents/skills/orch/scripts/ci-wait
@@ -199,8 +199,12 @@ either the prior run's leftovers or CI that finished before the wait started.
 It completes once that same picture has held for the stale window — 90
 seconds of wall clock, not a count of polls, so the threshold does not scale
 with poll_interval — which at the default interval is the second poll, well
-inside the default budget. Short of the window the wait keeps polling and the
-deadline reports status "timeout" with verdict "pending".
+inside the default budget. The picture is every check's name and state, so a
+poll that differs from the one being held — a check registering late as a
+settled success, an emptied rollup, a run the wait itself asked for — starts
+the window over rather than inheriting the time already served. Short of the
+window the wait keeps polling and the deadline reports status "timeout" with
+verdict "pending".
 
 JSON output (always when --json):
   {
@@ -318,6 +322,11 @@ EMPTY_CLASSES='{"pending":[],"failed":[],"passed":[]}'
 # report the checks that were still outstanding.
 last_check_classes="$EMPTY_CLASSES"
 
+# Each classified check as name and reported state, with the fallbacks older
+# gh output needs. One spelling, read by the result object and by the
+# settled-check window's key.
+CI_CHECK_VIEW_JQ='map_values([.[] | {name, state: (.state // .bucket // "UNKNOWN")}])'
+
 # Emit the final machine-readable result on stdout. Every exit path routes
 # through here (or emit_error) so the script can never finish silently.
 #   status: complete | timeout | error
@@ -341,7 +350,7 @@ emit_result() {
       --arg repo "$REPO" \
       --argjson elapsed "$elapsed" \
       --arg error "$error_msg" \
-      --argjson classes "$(jq -c 'map_values(map({name, state: (.state // .bucket // "UNKNOWN")}))' <<<"$classes")" \
+      --argjson classes "$(jq -c "$CI_CHECK_VIEW_JQ" <<<"$classes")" \
       '{
         status: $s,
         verdict: $v,
@@ -507,9 +516,12 @@ fi
 # started spent the whole budget and reported a timeout.
 seen_in_progress=false
 STALE_WINDOW=90  # seconds of only completed/skipped before assuming genuinely done
-# Elapsed seconds at the start of the current all-settled streak; -1 when no
-# streak is open.
-stale_since=-1
+# The streak: the settled picture being held, and the elapsed second it was
+# first seen. A poll showing a different picture starts a new streak, so the
+# window measures one unchanging rollup and not merely the time since the
+# first settled poll. Empty means no streak is open.
+stale_key=""
+stale_since=0
 
 # The log is captured whole and windowed in-shell, and head and grep read
 # here-strings, which have no producer to signal: `gh | head -200`
@@ -633,6 +645,14 @@ superseding_run_state() {
   ' <<<"$classes"
 }
 
+# One comparable line naming the settled picture a poll shows: every check's
+# name and state, ordered, so a rollup that only reorders its checks reads as
+# the same picture while a late-registered one does not. Reads classified
+# checks; the settled-check window compares consecutive polls with it.
+settled_checks_key() {
+  jq -cS "$CI_CHECK_VIEW_JQ"' | map_values(sort_by(.name, .state))'
+}
+
 classify_checks() {
   jq -c "$CI_RUN_JQ_DEFS"'
     {
@@ -736,6 +756,10 @@ while [ "$elapsed" -lt "$MAX_WAIT" ]; do
       fi
       exit 1
     fi
+    # A rollup that went empty is not the picture any streak was holding, and
+    # the key comparison below never sees this poll: drop the streak so the
+    # checks that come back are confirmed on their own.
+    stale_key=""
     sleep "$POLL_INTERVAL"
     update_elapsed
     continue
@@ -759,7 +783,6 @@ while [ "$elapsed" -lt "$MAX_WAIT" ]; do
   # Track if we've observed a fresh run (guards against stale-check race)
   if [ "$pending_count" -gt 0 ]; then
     seen_in_progress=true
-    stale_since=-1
   fi
 
   # Check for failure (only when all checks have settled). Before declaring
@@ -781,7 +804,6 @@ while [ "$elapsed" -lt "$MAX_WAIT" ]; do
         check_classes=$(jq -c '.pending += (.failed | map(.state = "EXPECTED" | .bucket = "pending")) | .failed = []' <<<"$check_classes")
         last_check_classes="$check_classes"
         seen_in_progress=true
-        stale_since=-1
         sleep "$POLL_INTERVAL"
         update_elapsed
         continue
@@ -804,10 +826,11 @@ while [ "$elapsed" -lt "$MAX_WAIT" ]; do
           ci_message retry "$@" >&2
           gh run rerun "$failed_run" --repo "$REPO" --failed 2>/dev/null || true
           retries=$((retries + 1))
-          # Reset because rerun will produce new checks: the rollups before it
-          # confirm nothing about the run it just started.
+          # The rerun produces new checks, and the picture it replaces can be
+          # identical to the one that follows it, so the key comparison below
+          # cannot see this change: drop the streak explicitly.
           seen_in_progress=false
-          stale_since=-1
+          stale_key=""
           sleep 10
           update_elapsed
           continue
@@ -829,8 +852,12 @@ while [ "$elapsed" -lt "$MAX_WAIT" ]; do
     # Only seeing completed/skipped checks but never saw in-progress.
     # Could be stale checks from prior run, or CI already completed before
     # we started watching. Hold the same picture for STALE_WINDOW to tell
-    # them apart.
-    if [ "$stale_since" -lt 0 ]; then
+    # them apart: a poll whose picture differs from the one being held — a
+    # check registering late as a settled success, say — starts the window
+    # over rather than inheriting the elapsed time of a picture it replaced.
+    settled_key=$(echo "$check_classes" | settled_checks_key)
+    if [ "$settled_key" != "$stale_key" ]; then
+      stale_key="$settled_key"
       stale_since="$elapsed"
     fi
     if [ "$((elapsed - stale_since))" -ge "$STALE_WINDOW" ]; then

--- a/.agents/skills/orch/tests/ci_wait.sh
+++ b/.agents/skills/orch/tests/ci_wait.sh
@@ -169,57 +169,33 @@ case "${1:-}" in
           exit 8
         fi
       fi
-      # Green, then a settled transient failure, then green again, phased on
-      # the rerun the script itself requests rather than on a call count: the
-      # retry path reads the rollup a second time through get_failed_run_id,
-      # so a count alone would put the failure's own lookup in the next phase.
-      if [[ "${STUB_PR_CHECKS_MODE:-}" == "rerun_then_green" ]]; then
+      # One rollup per poll, from STUB_PR_CHECKS_SEQUENCE: colon-separated
+      # tokens (a row's env list separates on commas), the count file giving
+      # the poll index, the last token repeating. `fail_rerun` phases on the
+      # rerun the script itself requests rather than on the index, because the
+      # retry path reads the rollup a second time through get_failed_run_id.
+      if [[ -n "${STUB_PR_CHECKS_SEQUENCE:-}" ]]; then
         count=0
         if [[ -f "${STUB_PR_CHECKS_COUNT_FILE:?}" ]]; then
           count="$(cat "$STUB_PR_CHECKS_COUNT_FILE")"
         fi
         count=$((count + 1))
         printf '%s' "$count" > "$STUB_PR_CHECKS_COUNT_FILE"
-        if [[ "$count" -gt 3 && ! -s "${STUB_RERUN_CALLS_FILE:-/dev/null}" ]]; then
-          echo '[{"name":"build","state":"FAILURE","bucket":"fail","link":"https://github.com/owner/repo/actions/runs/29099680623/job/301","workflow":"CI","startedAt":"2026-07-10T11:00:00Z","completedAt":"2026-07-10T11:05:00Z"}]'
-          exit 1
-        fi
-        echo '[{"name":"build","state":"SUCCESS"}]'
-        exit 0
-      fi
-      # A check that registers late and settled: one green check on the first
-      # poll, two on every later one. Nothing is ever pending, so only the
-      # settled-check window decides when the wait completes.
-      if [[ "${STUB_PR_CHECKS_MODE:-}" == "late_second_check" ]]; then
-        count=0
-        if [[ -f "${STUB_PR_CHECKS_COUNT_FILE:?}" ]]; then
-          count="$(cat "$STUB_PR_CHECKS_COUNT_FILE")"
-        fi
-        count=$((count + 1))
-        printf '%s' "$count" > "$STUB_PR_CHECKS_COUNT_FILE"
-        if [[ "$count" -eq 1 ]]; then
-          echo '[{"name":"build","state":"SUCCESS"}]'
-          exit 0
-        fi
-        echo '[{"name":"build","state":"SUCCESS"},{"name":"lint","state":"SUCCESS"}]'
-        exit 0
-      fi
-      # One check going SUCCESS, SKIPPED, SUCCESS. A skipped check is in no
-      # class, so the middle poll reaches neither the settled-check window nor
-      # any failure arm, and the greens either side of it are the same picture.
-      if [[ "${STUB_PR_CHECKS_MODE:-}" == "skipped_between_greens" ]]; then
-        count=0
-        if [[ -f "${STUB_PR_CHECKS_COUNT_FILE:?}" ]]; then
-          count="$(cat "$STUB_PR_CHECKS_COUNT_FILE")"
-        fi
-        count=$((count + 1))
-        printf '%s' "$count" > "$STUB_PR_CHECKS_COUNT_FILE"
-        if [[ "$count" -eq 2 ]]; then
-          echo '[{"name":"build","state":"SKIPPED"}]'
-          exit 0
-        fi
-        echo '[{"name":"build","state":"SUCCESS"}]'
-        exit 0
+        IFS=':' read -ra toks <<<"$STUB_PR_CHECKS_SEQUENCE"
+        idx=$((count - 1))
+        [[ "$idx" -lt "${#toks[@]}" ]] || idx=$((${#toks[@]} - 1))
+        case "${toks[$idx]}" in
+          green)   echo '[{"name":"build","state":"SUCCESS"}]'; exit 0 ;;
+          green2)  echo '[{"name":"build","state":"SUCCESS"},{"name":"lint","state":"SUCCESS"}]'; exit 0 ;;
+          mixed)   echo '[{"name":"build","state":"SUCCESS"},{"name":"docs","state":"SKIPPED"}]'; exit 0 ;;
+          skipped) echo '[{"name":"build","state":"SKIPPED"}]'; exit 0 ;;
+          fail_rerun)
+            [[ ! -s "${STUB_RERUN_CALLS_FILE:-/dev/null}" ]] || { echo '[{"name":"build","state":"SUCCESS"}]'; exit 0; }
+            echo '[{"name":"build","state":"FAILURE","bucket":"fail","link":"https://github.com/owner/repo/actions/runs/29099680623/job/301","workflow":"CI","startedAt":"2026-07-10T11:00:00Z"}]'
+            exit 1
+            ;;
+          *) printf 'unknown sequence token: %s\n' "${toks[$idx]}" >&2; exit 1 ;;
+        esac
       fi
       if [[ "${STUB_PR_CHECKS_MODE:-}" == "pending_always" ]]; then
         echo '[{"name":"build","state":"IN_PROGRESS"}]'
@@ -505,8 +481,9 @@ table "$JSON" \
   "a PR already green at the script's own defaults completes, not times out||$JSON_DEFAULTS||rc=0 status=complete verdict=pass passed=1" \
   "a pending check at those defaults still waits to the deadline||$JSON_DEFAULTS|STUB_PR_CHECKS_MODE=pending_always|rc=1 status=timeout verdict=pending check.build=IN_PROGRESS" \
   'a green rollup the budget never confirmed is pending at the deadline, not pass||1 10 30 --json||rc=1 status=timeout verdict=pending passed=1 pending=0' \
-  'a check registering late and settled restarts the window|||STUB_PR_CHECKS_MODE=late_second_check|rc=0 status=complete verdict=pass passed=2 elapsed_seconds=120' \
-  'a poll in no class breaks the streak the greens either side of it would share|||STUB_PR_CHECKS_MODE=skipped_between_greens|rc=0 status=complete verdict=pass passed=1 elapsed_seconds=150' \
+  'a check registering late and settled restarts the window|||STUB_PR_CHECKS_SEQUENCE=green:green2|rc=0 status=complete verdict=pass passed=2 elapsed_seconds=120' \
+  'a poll in no class breaks the streak the greens either side of it would share|||STUB_PR_CHECKS_SEQUENCE=green:skipped:green|rc=0 status=complete verdict=pass passed=1 elapsed_seconds=150' \
+  'a check registering late as skipped is a different rollup and restarts the window|||STUB_PR_CHECKS_SEQUENCE=green:mixed|rc=0 status=complete verdict=pass passed=1 elapsed_seconds=120' \
   "checks still in progress at the deadline are a timeout||$JSON_SHORT|STUB_PR_CHECKS_MODE=pending_always|rc=1 status=timeout verdict=pending check.build=IN_PROGRESS" \
   'no checks registered past the grace window is a named error|||STUB_PR_CHECKS_MODE=empty,CI_WAIT_NO_CHECKS_GRACE=3|rc=1 status=error error_named=true' \
   "no checks registered inside the default grace window stays pending||$JSON_SHORT|STUB_PR_CHECKS_MODE=empty|rc=1 status=timeout verdict=pending" \
@@ -607,7 +584,7 @@ assert_le 65536 "$transient_tail_bytes" "one pipe buffer fits inside the log pas
 table "$JSON" \
   "a transient marker in a large failed-job log reruns the failing run; the retried failure still settles terminal|||STUB_PR_CHECKS_FIXTURE=$FX/rerun-attempt-checks.json,$RERUN,STUB_ACTIONS_RUNS_FIXTURE=$FX/runs-rerun-attempt-failure.json,STUB_RUN_LOG_FILE=$transient_log|rc=1 verdict=fail reruns=29662812172" \
   "a gh failure reading the log is not transient: nothing is rerun|||STUB_PR_CHECKS_FIXTURE=$FX/rerun-attempt-checks.json,$RERUN,STUB_ACTIONS_RUNS_FIXTURE=$FX/runs-rerun-attempt-failure.json|rc=1 verdict=fail reruns=none" \
-  "a rerun restarts the settled-check window: the greens before it carry nothing|||STUB_PR_CHECKS_MODE=rerun_then_green,STUB_RUN_LOG_FILE=$transient_log|rc=0 status=complete verdict=pass reruns=29099680623 elapsed_seconds=190"
+  "a rerun restarts the settled-check window: the greens before it carry nothing|||STUB_PR_CHECKS_SEQUENCE=green:green:green:fail_rerun,STUB_RUN_LOG_FILE=$transient_log|rc=0 status=complete verdict=pass reruns=29099680623 elapsed_seconds=190"
 
 echo "=== argument validation ends in the parser, before any gh call ==="
 # The recording gh stub fails every call, so a case that reached auth or a

--- a/.agents/skills/orch/tests/ci_wait.sh
+++ b/.agents/skills/orch/tests/ci_wait.sh
@@ -204,6 +204,23 @@ case "${1:-}" in
         echo '[{"name":"build","state":"SUCCESS"},{"name":"lint","state":"SUCCESS"}]'
         exit 0
       fi
+      # One check going SUCCESS, SKIPPED, SUCCESS. A skipped check is in no
+      # class, so the middle poll reaches neither the settled-check window nor
+      # any failure arm, and the greens either side of it are the same picture.
+      if [[ "${STUB_PR_CHECKS_MODE:-}" == "skipped_between_greens" ]]; then
+        count=0
+        if [[ -f "${STUB_PR_CHECKS_COUNT_FILE:?}" ]]; then
+          count="$(cat "$STUB_PR_CHECKS_COUNT_FILE")"
+        fi
+        count=$((count + 1))
+        printf '%s' "$count" > "$STUB_PR_CHECKS_COUNT_FILE"
+        if [[ "$count" -eq 2 ]]; then
+          echo '[{"name":"build","state":"SKIPPED"}]'
+          exit 0
+        fi
+        echo '[{"name":"build","state":"SUCCESS"}]'
+        exit 0
+      fi
       if [[ "${STUB_PR_CHECKS_MODE:-}" == "pending_always" ]]; then
         echo '[{"name":"build","state":"IN_PROGRESS"}]'
         exit 8
@@ -489,6 +506,7 @@ table "$JSON" \
   "a pending check at those defaults still waits to the deadline||$JSON_DEFAULTS|STUB_PR_CHECKS_MODE=pending_always|rc=1 status=timeout verdict=pending check.build=IN_PROGRESS" \
   'a green rollup the budget never confirmed is pending at the deadline, not pass||1 10 30 --json||rc=1 status=timeout verdict=pending passed=1 pending=0' \
   'a check registering late and settled restarts the window|||STUB_PR_CHECKS_MODE=late_second_check|rc=0 status=complete verdict=pass passed=2 elapsed_seconds=120' \
+  'a poll in no class breaks the streak the greens either side of it would share|||STUB_PR_CHECKS_MODE=skipped_between_greens|rc=0 status=complete verdict=pass passed=1 elapsed_seconds=150' \
   "checks still in progress at the deadline are a timeout||$JSON_SHORT|STUB_PR_CHECKS_MODE=pending_always|rc=1 status=timeout verdict=pending check.build=IN_PROGRESS" \
   'no checks registered past the grace window is a named error|||STUB_PR_CHECKS_MODE=empty,CI_WAIT_NO_CHECKS_GRACE=3|rc=1 status=error error_named=true' \
   "no checks registered inside the default grace window stays pending||$JSON_SHORT|STUB_PR_CHECKS_MODE=empty|rc=1 status=timeout verdict=pending" \

--- a/.agents/skills/orch/tests/ci_wait.sh
+++ b/.agents/skills/orch/tests/ci_wait.sh
@@ -389,8 +389,15 @@ table() {
   done
 }
 
-JSON='1 1 30 --json'
+# The poll interval and budget every row inherits. Both are spent on the
+# virtual clock, so they are sized like production's rather than to save real
+# seconds: the settled-check window below is wall-clock seconds, and a budget
+# under it leaves a green PR unconfirmed at the deadline.
+JSON='1 30 300 --json'
 JSON_SHORT='1 1 5 --json'
+# The script's own defaults for poll interval and budget: positional args
+# omitted, so a row using this reads whatever ci-wait defaults to.
+JSON_DEFAULTS='1 --json'
 
 echo "=== the auth ladder: env token, keyring, bot token ==="
 # A stale inherited token is unset with a warning and the keyring tried; with
@@ -433,10 +440,19 @@ echo "=== the verdict over the checks sequence ==="
 # never success or silence; no checks registered is pending inside the
 # CI_WAIT_NO_CHECKS_GRACE window and an error past it; a settled failure is
 # terminal; an auth failure is a parseable error object.
+#
+# The settled-check window is wall-clock seconds, so the three rows taking the
+# script's own poll interval and budget are what a lane actually runs: a PR
+# already green before the wait started completes, a pending one still waits,
+# and a budget shorter than the window reports the unconfirmed green rollup as
+# pending — "pass" is paired with status "complete" and nothing else.
 table "$JSON" \
   'a pending exit with valid JSON keeps polling|||STUB_PR_CHECKS_MODE=pending_once|rc=0 verdict=pass checks_polls=2' \
   "an EXPECTED check is pending until it clears||$JSON_SHORT|STUB_PR_CHECKS_MODE=expected_once|rc=0 verdict=pass checks_polls=2" \
   'a pass is complete with its checks listed||||rc=0 status=complete verdict=pass passed=1' \
+  "a PR already green at the script's own defaults completes, not times out||$JSON_DEFAULTS||rc=0 status=complete verdict=pass passed=1" \
+  "a pending check at those defaults still waits to the deadline||$JSON_DEFAULTS|STUB_PR_CHECKS_MODE=pending_always|rc=1 status=timeout verdict=pending check.build=IN_PROGRESS" \
+  'a green rollup the budget never confirmed is pending at the deadline, not pass||1 10 30 --json||rc=1 status=timeout verdict=pending passed=1 pending=0' \
   "checks still in progress at the deadline are a timeout||$JSON_SHORT|STUB_PR_CHECKS_MODE=pending_always|rc=1 status=timeout verdict=pending check.build=IN_PROGRESS" \
   'no checks registered past the grace window is a named error|||STUB_PR_CHECKS_MODE=empty,CI_WAIT_NO_CHECKS_GRACE=3|rc=1 status=error error_named=true' \
   "no checks registered inside the default grace window stays pending||$JSON_SHORT|STUB_PR_CHECKS_MODE=empty|rc=1 status=timeout verdict=pending" \
@@ -446,7 +462,7 @@ table "$JSON" \
 echo "=== text mode prints a result line for every terminal status ==="
 # The line beyond its leading words is not a contract anything parses; the
 # leading words are text-only, so a JSON default flip fails these rows.
-table '1 1 30' \
+table '1 30 300' \
   'passed||||rc=0 stdout~ci-wait:+passed+pr=1+repo=owner/repo=true' \
   'failed|||STUB_PR_CHECKS_MODE=failure|rc=1 stdout~ci-wait:+failed+pr=1+repo=owner/repo=true' \
   'timeout||1 1 5|STUB_PR_CHECKS_MODE=pending_always|rc=1 stdout~ci-wait:+timeout+elapsed=5+verdict=pending+repo=owner/repo=true' \

--- a/.agents/skills/orch/tests/ci_wait.sh
+++ b/.agents/skills/orch/tests/ci_wait.sh
@@ -169,6 +169,24 @@ case "${1:-}" in
           exit 8
         fi
       fi
+      # Green, then a settled transient failure, then green again, phased on
+      # the rerun the script itself requests rather than on a call count: the
+      # retry path reads the rollup a second time through get_failed_run_id,
+      # so a count alone would put the failure's own lookup in the next phase.
+      if [[ "${STUB_PR_CHECKS_MODE:-}" == "rerun_then_green" ]]; then
+        count=0
+        if [[ -f "${STUB_PR_CHECKS_COUNT_FILE:?}" ]]; then
+          count="$(cat "$STUB_PR_CHECKS_COUNT_FILE")"
+        fi
+        count=$((count + 1))
+        printf '%s' "$count" > "$STUB_PR_CHECKS_COUNT_FILE"
+        if [[ "$count" -gt 3 && ! -s "${STUB_RERUN_CALLS_FILE:-/dev/null}" ]]; then
+          echo '[{"name":"build","state":"FAILURE","bucket":"fail","link":"https://github.com/owner/repo/actions/runs/29099680623/job/301","workflow":"CI","startedAt":"2026-07-10T11:00:00Z","completedAt":"2026-07-10T11:05:00Z"}]'
+          exit 1
+        fi
+        echo '[{"name":"build","state":"SUCCESS"}]'
+        exit 0
+      fi
       if [[ "${STUB_PR_CHECKS_MODE:-}" == "pending_always" ]]; then
         echo '[{"name":"build","state":"IN_PROGRESS"}]'
         exit 8
@@ -552,7 +570,8 @@ assert_le 131072 "$transient_window_bytes" "two pipe buffers fit inside the scan
 assert_le 65536 "$transient_tail_bytes" "one pipe buffer fits inside the log past the window"
 table "$JSON" \
   "a transient marker in a large failed-job log reruns the failing run; the retried failure still settles terminal|||STUB_PR_CHECKS_FIXTURE=$FX/rerun-attempt-checks.json,$RERUN,STUB_ACTIONS_RUNS_FIXTURE=$FX/runs-rerun-attempt-failure.json,STUB_RUN_LOG_FILE=$transient_log|rc=1 verdict=fail reruns=29662812172" \
-  "a gh failure reading the log is not transient: nothing is rerun|||STUB_PR_CHECKS_FIXTURE=$FX/rerun-attempt-checks.json,$RERUN,STUB_ACTIONS_RUNS_FIXTURE=$FX/runs-rerun-attempt-failure.json|rc=1 verdict=fail reruns=none"
+  "a gh failure reading the log is not transient: nothing is rerun|||STUB_PR_CHECKS_FIXTURE=$FX/rerun-attempt-checks.json,$RERUN,STUB_ACTIONS_RUNS_FIXTURE=$FX/runs-rerun-attempt-failure.json|rc=1 verdict=fail reruns=none" \
+  "a rerun restarts the settled-check window: the greens before it carry nothing|||STUB_PR_CHECKS_MODE=rerun_then_green,STUB_RUN_LOG_FILE=$transient_log|rc=0 status=complete verdict=pass reruns=29099680623 elapsed_seconds=190"
 
 echo "=== argument validation ends in the parser, before any gh call ==="
 # The recording gh stub fails every call, so a case that reached auth or a

--- a/.agents/skills/orch/tests/ci_wait.sh
+++ b/.agents/skills/orch/tests/ci_wait.sh
@@ -187,6 +187,23 @@ case "${1:-}" in
         echo '[{"name":"build","state":"SUCCESS"}]'
         exit 0
       fi
+      # A check that registers late and settled: one green check on the first
+      # poll, two on every later one. Nothing is ever pending, so only the
+      # settled-check window decides when the wait completes.
+      if [[ "${STUB_PR_CHECKS_MODE:-}" == "late_second_check" ]]; then
+        count=0
+        if [[ -f "${STUB_PR_CHECKS_COUNT_FILE:?}" ]]; then
+          count="$(cat "$STUB_PR_CHECKS_COUNT_FILE")"
+        fi
+        count=$((count + 1))
+        printf '%s' "$count" > "$STUB_PR_CHECKS_COUNT_FILE"
+        if [[ "$count" -eq 1 ]]; then
+          echo '[{"name":"build","state":"SUCCESS"}]'
+          exit 0
+        fi
+        echo '[{"name":"build","state":"SUCCESS"},{"name":"lint","state":"SUCCESS"}]'
+        exit 0
+      fi
       if [[ "${STUB_PR_CHECKS_MODE:-}" == "pending_always" ]]; then
         echo '[{"name":"build","state":"IN_PROGRESS"}]'
         exit 8
@@ -471,6 +488,7 @@ table "$JSON" \
   "a PR already green at the script's own defaults completes, not times out||$JSON_DEFAULTS||rc=0 status=complete verdict=pass passed=1" \
   "a pending check at those defaults still waits to the deadline||$JSON_DEFAULTS|STUB_PR_CHECKS_MODE=pending_always|rc=1 status=timeout verdict=pending check.build=IN_PROGRESS" \
   'a green rollup the budget never confirmed is pending at the deadline, not pass||1 10 30 --json||rc=1 status=timeout verdict=pending passed=1 pending=0' \
+  'a check registering late and settled restarts the window|||STUB_PR_CHECKS_MODE=late_second_check|rc=0 status=complete verdict=pass passed=2 elapsed_seconds=120' \
   "checks still in progress at the deadline are a timeout||$JSON_SHORT|STUB_PR_CHECKS_MODE=pending_always|rc=1 status=timeout verdict=pending check.build=IN_PROGRESS" \
   'no checks registered past the grace window is a named error|||STUB_PR_CHECKS_MODE=empty,CI_WAIT_NO_CHECKS_GRACE=3|rc=1 status=error error_named=true' \
   "no checks registered inside the default grace window stays pending||$JSON_SHORT|STUB_PR_CHECKS_MODE=empty|rc=1 status=timeout verdict=pending" \

--- a/.agents/skills/orch/workflows/submit-pr.md
+++ b/.agents/skills/orch/workflows/submit-pr.md
@@ -284,7 +284,7 @@ After any fix-up push: push → the Restart check, and on a restart wait for a N
 | `status=complete`, `verdict=fail` | → § 5.1 |
 | `status=timeout` or `status=error` | Re-run once. If it repeats, `auto-recommended` records `ci-status-unconfirmed`; `ask` presents `Skip CI` \| `Retry` \| `Abort`, with `Retry` recommended |
 
-A PR already green when the wait started reaches the first row, not the last: ci-wait pairs `verdict=pass` with `status=complete` alone, so neither a timeout nor an error can carry it.
+A PR already green when the wait started reaches the first row, never this one: `ci-wait --help` pairs `verdict=pass` with `status=complete` alone.
 
 ### 5.1 CI Failure Recovery
 

--- a/.agents/skills/orch/workflows/submit-pr.md
+++ b/.agents/skills/orch/workflows/submit-pr.md
@@ -284,6 +284,8 @@ After any fix-up push: push → the Restart check, and on a restart wait for a N
 | `status=complete`, `verdict=fail` | → § 5.1 |
 | `status=timeout` or `status=error` | Re-run once. If it repeats, `auto-recommended` records `ci-status-unconfirmed`; `ask` presents `Skip CI` \| `Retry` \| `Abort`, with `Retry` recommended |
 
+A PR already green when the wait started reaches the first row, not the last: ci-wait pairs `verdict=pass` with `status=complete` alone, so neither a timeout nor an error can carry it.
+
 ### 5.1 CI Failure Recovery
 
 ```bash

--- a/skills/orch/scripts/ci-wait
+++ b/skills/orch/scripts/ci-wait
@@ -168,11 +168,13 @@ failures (max 1 retry).
   --json         emit the machine-readable result object on stdout
 
 Verdicts (JSON "verdict"):
-  pass     every current-head check settled green
+  pass     every current-head check settled green, only ever paired with
+           status "complete"
   fail     a settled current-head failure — current-run failures are
            terminal
-  pending  checks still running or not yet registered; at the deadline the
-           result is status "timeout", never silent success
+  pending  checks still running, not yet registered, or settled green but
+           never confirmed to belong to the current run; at the deadline the
+           result is status "timeout" with this verdict, never silent success
   none     (with status "complete") the repo has no CI to wait for: no
            active workflows, no branch protection, and no required-check
            rules on the PR's base branch, each probe answering
@@ -191,6 +193,14 @@ original run id — keeps the verdict pending; a newest same-workflow run
 that completed successfully discards the stale failures; a failed newest
 run, or a cancelled run with no newer or fresher sibling, stays terminal.
 A missing replacement reaches the timeout rather than passing.
+
+A rollup of nothing but settled checks, with none ever seen in progress, is
+either the prior run's leftovers or CI that finished before the wait started.
+It completes once that same picture has held for the stale window — 90
+seconds of wall clock, not a count of polls, so the threshold does not scale
+with poll_interval — which at the default interval is the second poll, well
+inside the default budget. Short of the window the wait keeps polling and the
+deadline reports status "timeout" with verdict "pending".
 
 JSON output (always when --json):
   {
@@ -311,15 +321,18 @@ last_check_classes="$EMPTY_CLASSES"
 # Emit the final machine-readable result on stdout. Every exit path routes
 # through here (or emit_error) so the script can never finish silently.
 #   status: complete | timeout | error
-#   verdict derives from the classes: pending > fail > pass.
+#   verdict derives from the classes: pending > fail > pass. "pass" needs
+#   status "complete": a rollup that reads green at a deadline or an error was
+#   never confirmed settled, and a caller routing on verdict alone would take
+#   an unfinished wait for a green one.
 emit_result() {
   local status="$1" classes="$2" error_msg="${3:-}"
   update_elapsed
   local verdict
-  verdict=$(jq -r '
+  verdict=$(jq -r --arg status "$status" '
     if (.pending | length) > 0 then "pending"
     elif (.failed | length) > 0 then "fail"
-    elif (.passed | length) > 0 then "pass"
+    elif ($status == "complete") and ((.passed | length) > 0) then "pass"
     else "pending" end' <<<"$classes")
   if $JSON_OUTPUT; then
     jq -n \
@@ -486,10 +499,17 @@ fi
 # triggered (push, review-approval dispatch), checks from an old run
 # (SUCCESS/SKIPPED) may be the only ones visible.
 # Only declare "passed" after we've seen at least one check go through
-# IN_PROGRESS/PENDING, proving a fresh run was observed.
+# IN_PROGRESS/PENDING, proving a fresh run was observed, or after the same
+# all-settled picture has held for STALE_WINDOW.
+# The window is wall-clock seconds because poll_interval is the caller's:
+# counting polls made the real threshold poll_interval times this window, so
+# at the default 180s interval a PR that was already green when the wait
+# started spent the whole budget and reported a timeout.
 seen_in_progress=false
-stale_count=0
-max_stale=6  # ~90s of only completed/skipped before assuming genuinely done
+STALE_WINDOW=90  # seconds of only completed/skipped before assuming genuinely done
+# Elapsed seconds at the start of the current all-settled streak; -1 when no
+# streak is open.
+stale_since=-1
 
 # The log is captured whole and windowed in-shell, and head and grep read
 # here-strings, which have no producer to signal: `gh | head -200`
@@ -739,7 +759,7 @@ while [ "$elapsed" -lt "$MAX_WAIT" ]; do
   # Track if we've observed a fresh run (guards against stale-check race)
   if [ "$pending_count" -gt 0 ]; then
     seen_in_progress=true
-    stale_count=0
+    stale_since=-1
   fi
 
   # Check for failure (only when all checks have settled). Before declaring
@@ -761,7 +781,7 @@ while [ "$elapsed" -lt "$MAX_WAIT" ]; do
         check_classes=$(jq -c '.pending += (.failed | map(.state = "EXPECTED" | .bucket = "pending")) | .failed = []' <<<"$check_classes")
         last_check_classes="$check_classes"
         seen_in_progress=true
-        stale_count=0
+        stale_since=-1
         sleep "$POLL_INTERVAL"
         update_elapsed
         continue
@@ -805,9 +825,12 @@ while [ "$elapsed" -lt "$MAX_WAIT" ]; do
     fi
     # Only seeing completed/skipped checks but never saw in-progress.
     # Could be stale checks from prior run, or CI already completed before
-    # we started watching. Use stale counter to distinguish.
-    stale_count=$((stale_count + 1))
-    if [ "$stale_count" -ge "$max_stale" ]; then
+    # we started watching. Hold the same picture for STALE_WINDOW to tell
+    # them apart.
+    if [ "$stale_since" -lt 0 ]; then
+      stale_since="$elapsed"
+    fi
+    if [ "$((elapsed - stale_since))" -ge "$STALE_WINDOW" ]; then
       # Waited long enough for subsequent checks to appear — genuinely complete
       emit_result "complete" "$check_classes"
       exit 0

--- a/skills/orch/scripts/ci-wait
+++ b/skills/orch/scripts/ci-wait
@@ -194,13 +194,13 @@ that completed successfully discards the stale failures; a failed newest
 run, or a cancelled run with no newer or fresher sibling, stays terminal.
 A missing replacement reaches the timeout rather than passing.
 
-A rollup of nothing but settled checks, none ever seen in progress, is either
-the prior run's leftovers or CI that finished before the wait started. It
-completes once the stale window has measured consecutive polls showing one
-unchanged rollup of every check's name and state: 90 seconds of wall clock,
-not a count of polls, which at the default interval is the second poll. Any
-other poll starts the window over, and short of it the deadline reports
-status "timeout" with verdict "pending".
+A rollup of settled checks with at least one passed, none ever seen in
+progress, is either the prior run's leftovers or CI that finished before the
+wait started. It completes once the stale window has measured consecutive
+polls showing one unchanged rollup of every check's name and state: 90
+seconds of wall clock, not a count of polls, which at the default interval is
+the second poll. Any other poll starts the window over, and short of it the
+deadline reports status "timeout" with verdict "pending".
 
 JSON output (always when --json):
   {
@@ -831,6 +831,9 @@ while [ "$elapsed" -lt "$MAX_WAIT" ]; do
     # which drop skipped entries: a check registering late as SKIPPED is a
     # different rollup and starts the window over.
     settled_this_poll=true
+    # The clock the streak is stamped and measured against is the one this
+    # rollup was read at, not the one before the request that fetched it.
+    update_elapsed
     settled_key=$(jq -cS '[.[] | {name, state}] | sort_by(.name, .state)' <<<"$checks_json")
     if [ "$settled_key" != "$stale_key" ]; then
       stale_key="$settled_key"

--- a/skills/orch/scripts/ci-wait
+++ b/skills/orch/scripts/ci-wait
@@ -199,10 +199,11 @@ either the prior run's leftovers or CI that finished before the wait started.
 It completes once that same picture has held for the stale window — 90
 seconds of wall clock, not a count of polls, so the threshold does not scale
 with poll_interval — which at the default interval is the second poll, well
-inside the default budget. The picture is every check's name and state, so a
-poll that differs from the one being held — a check registering late as a
-settled success, an emptied rollup, a run the wait itself asked for — starts
-the window over rather than inheriting the time already served. Short of the
+inside the default budget. The window measures consecutive polls showing one
+unchanged settled picture, that picture being every check's name and state:
+any other poll — a changed rollup, an emptied one, a failure, a rollup of
+nothing but skipped checks, a run the wait itself asked for — starts the
+window over rather than passing on the time already served. Short of the
 window the wait keeps polling and the deadline reports status "timeout" with
 verdict "pending".
 
@@ -666,8 +667,24 @@ classify_checks() {
 checks_stderr=$(mktemp)
 trap 'rm -f "$checks_stderr"' EXIT
 
+# Wait out one interval, carrying the settled streak only across consecutive
+# polls that reached the settled-check window. Every other poll shape — an
+# emptied rollup, a failure, a rerun, a rollup of nothing but skipped checks —
+# ends the streak here, so a later identical picture is confirmed on its own
+# rather than on time the wait already served. Every sleep in the loop runs
+# through this, which is what keeps the rule to one site.
+poll_sleep() {
+  local seconds="$1"
+  [ "$settled_this_poll" = true ] || stale_key=""
+  sleep "$seconds"
+  update_elapsed
+}
+
 update_elapsed
 while [ "$elapsed" -lt "$MAX_WAIT" ]; do
+  # Only the settled-check window sets this true, and only for the poll that
+  # reached it.
+  settled_this_poll=false
   # Capture stderr so we can distinguish auth/repo failures from "no checks yet".
   checks_status=0
   set +e
@@ -756,12 +773,7 @@ while [ "$elapsed" -lt "$MAX_WAIT" ]; do
       fi
       exit 1
     fi
-    # A rollup that went empty is not the picture any streak was holding, and
-    # the key comparison below never sees this poll: drop the streak so the
-    # checks that come back are confirmed on their own.
-    stale_key=""
-    sleep "$POLL_INTERVAL"
-    update_elapsed
+    poll_sleep "$POLL_INTERVAL"
     continue
   fi
 
@@ -804,8 +816,7 @@ while [ "$elapsed" -lt "$MAX_WAIT" ]; do
         check_classes=$(jq -c '.pending += (.failed | map(.state = "EXPECTED" | .bucket = "pending")) | .failed = []' <<<"$check_classes")
         last_check_classes="$check_classes"
         seen_in_progress=true
-        sleep "$POLL_INTERVAL"
-        update_elapsed
+        poll_sleep "$POLL_INTERVAL"
         continue
         ;;
       superseded)
@@ -826,13 +837,8 @@ while [ "$elapsed" -lt "$MAX_WAIT" ]; do
           ci_message retry "$@" >&2
           gh run rerun "$failed_run" --repo "$REPO" --failed 2>/dev/null || true
           retries=$((retries + 1))
-          # The rerun produces new checks, and the picture it replaces can be
-          # identical to the one that follows it, so the key comparison below
-          # cannot see this change: drop the streak explicitly.
-          seen_in_progress=false
-          stale_key=""
-          sleep 10
-          update_elapsed
+          seen_in_progress=false  # Reset because rerun will produce new checks
+          poll_sleep 10
           continue
         fi
 
@@ -855,6 +861,7 @@ while [ "$elapsed" -lt "$MAX_WAIT" ]; do
     # them apart: a poll whose picture differs from the one being held — a
     # check registering late as a settled success, say — starts the window
     # over rather than inheriting the elapsed time of a picture it replaced.
+    settled_this_poll=true
     settled_key=$(echo "$check_classes" | settled_checks_key)
     if [ "$settled_key" != "$stale_key" ]; then
       stale_key="$settled_key"
@@ -867,8 +874,7 @@ while [ "$elapsed" -lt "$MAX_WAIT" ]; do
     fi
   fi
 
-  sleep "$POLL_INTERVAL"
-  update_elapsed
+  poll_sleep "$POLL_INTERVAL"
 done
 
 # Deadline reached with checks still outstanding — report timeout, not

--- a/skills/orch/scripts/ci-wait
+++ b/skills/orch/scripts/ci-wait
@@ -173,8 +173,8 @@ Verdicts (JSON "verdict"):
   fail     a settled current-head failure — current-run failures are
            terminal
   pending  checks still running, not yet registered, or settled green but
-           never confirmed to belong to the current run; at the deadline the
-           result is status "timeout" with this verdict, never silent success
+           unconfirmed; at the deadline the result is status "timeout" with
+           this verdict, never silent success
   none     (with status "complete") the repo has no CI to wait for: no
            active workflows, no branch protection, and no required-check
            rules on the PR's base branch, each probe answering
@@ -194,18 +194,13 @@ that completed successfully discards the stale failures; a failed newest
 run, or a cancelled run with no newer or fresher sibling, stays terminal.
 A missing replacement reaches the timeout rather than passing.
 
-A rollup of nothing but settled checks, with none ever seen in progress, is
-either the prior run's leftovers or CI that finished before the wait started.
-It completes once that same picture has held for the stale window — 90
-seconds of wall clock, not a count of polls, so the threshold does not scale
-with poll_interval — which at the default interval is the second poll, well
-inside the default budget. The window measures consecutive polls showing one
-unchanged settled picture, that picture being every check's name and state:
-any other poll — a changed rollup, an emptied one, a failure, a rollup of
-nothing but skipped checks, a run the wait itself asked for — starts the
-window over rather than passing on the time already served. Short of the
-window the wait keeps polling and the deadline reports status "timeout" with
-verdict "pending".
+A rollup of nothing but settled checks, none ever seen in progress, is either
+the prior run's leftovers or CI that finished before the wait started. It
+completes once the stale window has measured consecutive polls showing one
+unchanged rollup of every check's name and state: 90 seconds of wall clock,
+not a count of polls, which at the default interval is the second poll. Any
+other poll starts the window over, and short of it the deadline reports
+status "timeout" with verdict "pending".
 
 JSON output (always when --json):
   {
@@ -323,18 +318,11 @@ EMPTY_CLASSES='{"pending":[],"failed":[],"passed":[]}'
 # report the checks that were still outstanding.
 last_check_classes="$EMPTY_CLASSES"
 
-# Each classified check as name and reported state, with the fallbacks older
-# gh output needs. One spelling, read by the result object and by the
-# settled-check window's key.
-CI_CHECK_VIEW_JQ='map_values([.[] | {name, state: (.state // .bucket // "UNKNOWN")}])'
-
 # Emit the final machine-readable result on stdout. Every exit path routes
 # through here (or emit_error) so the script can never finish silently.
 #   status: complete | timeout | error
-#   verdict derives from the classes: pending > fail > pass. "pass" needs
-#   status "complete": a rollup that reads green at a deadline or an error was
-#   never confirmed settled, and a caller routing on verdict alone would take
-#   an unfinished wait for a green one.
+#   verdict derives from the classes: pending > fail > pass, and "pass" only
+#   with status "complete", so an unfinished wait never reads as green.
 emit_result() {
   local status="$1" classes="$2" error_msg="${3:-}"
   update_elapsed
@@ -351,7 +339,7 @@ emit_result() {
       --arg repo "$REPO" \
       --argjson elapsed "$elapsed" \
       --arg error "$error_msg" \
-      --argjson classes "$(jq -c "$CI_CHECK_VIEW_JQ" <<<"$classes")" \
+      --argjson classes "$(jq -c 'map_values(map({name, state: (.state // .bucket // "UNKNOWN")}))' <<<"$classes")" \
       '{
         status: $s,
         verdict: $v,
@@ -509,18 +497,12 @@ fi
 # triggered (push, review-approval dispatch), checks from an old run
 # (SUCCESS/SKIPPED) may be the only ones visible.
 # Only declare "passed" after we've seen at least one check go through
-# IN_PROGRESS/PENDING, proving a fresh run was observed, or after the same
-# all-settled picture has held for STALE_WINDOW.
-# The window is wall-clock seconds because poll_interval is the caller's:
-# counting polls made the real threshold poll_interval times this window, so
-# at the default 180s interval a PR that was already green when the wait
-# started spent the whole budget and reported a timeout.
+# IN_PROGRESS/PENDING, proving a fresh run was observed, or after the window
+# below has measured one unchanged settled rollup.
 seen_in_progress=false
-STALE_WINDOW=90  # seconds of only completed/skipped before assuming genuinely done
-# The streak: the settled picture being held, and the elapsed second it was
-# first seen. A poll showing a different picture starts a new streak, so the
-# window measures one unchanging rollup and not merely the time since the
-# first settled poll. Empty means no streak is open.
+STALE_WINDOW=90  # seconds; wall clock, because poll_interval is the caller's
+# The rollup being held and the elapsed second it was first seen; an empty key
+# means no streak is open.
 stale_key=""
 stale_since=0
 
@@ -646,14 +628,6 @@ superseding_run_state() {
   ' <<<"$classes"
 }
 
-# One comparable line naming the settled picture a poll shows: every check's
-# name and state, ordered, so a rollup that only reorders its checks reads as
-# the same picture while a late-registered one does not. Reads classified
-# checks; the settled-check window compares consecutive polls with it.
-settled_checks_key() {
-  jq -cS "$CI_CHECK_VIEW_JQ"' | map_values(sort_by(.name, .state))'
-}
-
 classify_checks() {
   jq -c "$CI_RUN_JQ_DEFS"'
     {
@@ -667,12 +641,9 @@ classify_checks() {
 checks_stderr=$(mktemp)
 trap 'rm -f "$checks_stderr"' EXIT
 
-# Wait out one interval, carrying the settled streak only across consecutive
-# polls that reached the settled-check window. Every other poll shape — an
-# emptied rollup, a failure, a rerun, a rollup of nothing but skipped checks —
-# ends the streak here, so a later identical picture is confirmed on its own
-# rather than on time the wait already served. Every sleep in the loop runs
-# through this, which is what keeps the rule to one site.
+# Wait out one interval. The streak survives only across consecutive polls that
+# reached the settled-check window; every sleep in the loop runs through here,
+# which is what keeps that rule to one site.
 poll_sleep() {
   local seconds="$1"
   [ "$settled_this_poll" = true ] || stale_key=""
@@ -682,9 +653,7 @@ poll_sleep() {
 
 update_elapsed
 while [ "$elapsed" -lt "$MAX_WAIT" ]; do
-  # Only the settled-check window sets this true, and only for the poll that
-  # reached it.
-  settled_this_poll=false
+  settled_this_poll=false  # only the settled-check window below sets it true
   # Capture stderr so we can distinguish auth/repo failures from "no checks yet".
   checks_status=0
   set +e
@@ -857,12 +826,12 @@ while [ "$elapsed" -lt "$MAX_WAIT" ]; do
     fi
     # Only seeing completed/skipped checks but never saw in-progress.
     # Could be stale checks from prior run, or CI already completed before
-    # we started watching. Hold the same picture for STALE_WINDOW to tell
-    # them apart: a poll whose picture differs from the one being held — a
-    # check registering late as a settled success, say — starts the window
-    # over rather than inheriting the elapsed time of a picture it replaced.
+    # we started watching. Hold one unchanged rollup for STALE_WINDOW to tell
+    # them apart. The key reads the scoped rollup, not the classified checks,
+    # which drop skipped entries: a check registering late as SKIPPED is a
+    # different rollup and starts the window over.
     settled_this_poll=true
-    settled_key=$(echo "$check_classes" | settled_checks_key)
+    settled_key=$(jq -cS '[.[] | {name, state}] | sort_by(.name, .state)' <<<"$checks_json")
     if [ "$settled_key" != "$stale_key" ]; then
       stale_key="$settled_key"
       stale_since="$elapsed"

--- a/skills/orch/scripts/ci-wait
+++ b/skills/orch/scripts/ci-wait
@@ -804,7 +804,10 @@ while [ "$elapsed" -lt "$MAX_WAIT" ]; do
           ci_message retry "$@" >&2
           gh run rerun "$failed_run" --repo "$REPO" --failed 2>/dev/null || true
           retries=$((retries + 1))
-          seen_in_progress=false  # Reset because rerun will produce new checks
+          # Reset because rerun will produce new checks: the rollups before it
+          # confirm nothing about the run it just started.
+          seen_in_progress=false
+          stale_since=-1
           sleep 10
           update_elapsed
           continue

--- a/skills/orch/scripts/ci-wait
+++ b/skills/orch/scripts/ci-wait
@@ -199,8 +199,12 @@ either the prior run's leftovers or CI that finished before the wait started.
 It completes once that same picture has held for the stale window — 90
 seconds of wall clock, not a count of polls, so the threshold does not scale
 with poll_interval — which at the default interval is the second poll, well
-inside the default budget. Short of the window the wait keeps polling and the
-deadline reports status "timeout" with verdict "pending".
+inside the default budget. The picture is every check's name and state, so a
+poll that differs from the one being held — a check registering late as a
+settled success, an emptied rollup, a run the wait itself asked for — starts
+the window over rather than inheriting the time already served. Short of the
+window the wait keeps polling and the deadline reports status "timeout" with
+verdict "pending".
 
 JSON output (always when --json):
   {
@@ -318,6 +322,11 @@ EMPTY_CLASSES='{"pending":[],"failed":[],"passed":[]}'
 # report the checks that were still outstanding.
 last_check_classes="$EMPTY_CLASSES"
 
+# Each classified check as name and reported state, with the fallbacks older
+# gh output needs. One spelling, read by the result object and by the
+# settled-check window's key.
+CI_CHECK_VIEW_JQ='map_values([.[] | {name, state: (.state // .bucket // "UNKNOWN")}])'
+
 # Emit the final machine-readable result on stdout. Every exit path routes
 # through here (or emit_error) so the script can never finish silently.
 #   status: complete | timeout | error
@@ -341,7 +350,7 @@ emit_result() {
       --arg repo "$REPO" \
       --argjson elapsed "$elapsed" \
       --arg error "$error_msg" \
-      --argjson classes "$(jq -c 'map_values(map({name, state: (.state // .bucket // "UNKNOWN")}))' <<<"$classes")" \
+      --argjson classes "$(jq -c "$CI_CHECK_VIEW_JQ" <<<"$classes")" \
       '{
         status: $s,
         verdict: $v,
@@ -507,9 +516,12 @@ fi
 # started spent the whole budget and reported a timeout.
 seen_in_progress=false
 STALE_WINDOW=90  # seconds of only completed/skipped before assuming genuinely done
-# Elapsed seconds at the start of the current all-settled streak; -1 when no
-# streak is open.
-stale_since=-1
+# The streak: the settled picture being held, and the elapsed second it was
+# first seen. A poll showing a different picture starts a new streak, so the
+# window measures one unchanging rollup and not merely the time since the
+# first settled poll. Empty means no streak is open.
+stale_key=""
+stale_since=0
 
 # The log is captured whole and windowed in-shell, and head and grep read
 # here-strings, which have no producer to signal: `gh | head -200`
@@ -633,6 +645,14 @@ superseding_run_state() {
   ' <<<"$classes"
 }
 
+# One comparable line naming the settled picture a poll shows: every check's
+# name and state, ordered, so a rollup that only reorders its checks reads as
+# the same picture while a late-registered one does not. Reads classified
+# checks; the settled-check window compares consecutive polls with it.
+settled_checks_key() {
+  jq -cS "$CI_CHECK_VIEW_JQ"' | map_values(sort_by(.name, .state))'
+}
+
 classify_checks() {
   jq -c "$CI_RUN_JQ_DEFS"'
     {
@@ -736,6 +756,10 @@ while [ "$elapsed" -lt "$MAX_WAIT" ]; do
       fi
       exit 1
     fi
+    # A rollup that went empty is not the picture any streak was holding, and
+    # the key comparison below never sees this poll: drop the streak so the
+    # checks that come back are confirmed on their own.
+    stale_key=""
     sleep "$POLL_INTERVAL"
     update_elapsed
     continue
@@ -759,7 +783,6 @@ while [ "$elapsed" -lt "$MAX_WAIT" ]; do
   # Track if we've observed a fresh run (guards against stale-check race)
   if [ "$pending_count" -gt 0 ]; then
     seen_in_progress=true
-    stale_since=-1
   fi
 
   # Check for failure (only when all checks have settled). Before declaring
@@ -781,7 +804,6 @@ while [ "$elapsed" -lt "$MAX_WAIT" ]; do
         check_classes=$(jq -c '.pending += (.failed | map(.state = "EXPECTED" | .bucket = "pending")) | .failed = []' <<<"$check_classes")
         last_check_classes="$check_classes"
         seen_in_progress=true
-        stale_since=-1
         sleep "$POLL_INTERVAL"
         update_elapsed
         continue
@@ -804,10 +826,11 @@ while [ "$elapsed" -lt "$MAX_WAIT" ]; do
           ci_message retry "$@" >&2
           gh run rerun "$failed_run" --repo "$REPO" --failed 2>/dev/null || true
           retries=$((retries + 1))
-          # Reset because rerun will produce new checks: the rollups before it
-          # confirm nothing about the run it just started.
+          # The rerun produces new checks, and the picture it replaces can be
+          # identical to the one that follows it, so the key comparison below
+          # cannot see this change: drop the streak explicitly.
           seen_in_progress=false
-          stale_since=-1
+          stale_key=""
           sleep 10
           update_elapsed
           continue
@@ -829,8 +852,12 @@ while [ "$elapsed" -lt "$MAX_WAIT" ]; do
     # Only seeing completed/skipped checks but never saw in-progress.
     # Could be stale checks from prior run, or CI already completed before
     # we started watching. Hold the same picture for STALE_WINDOW to tell
-    # them apart.
-    if [ "$stale_since" -lt 0 ]; then
+    # them apart: a poll whose picture differs from the one being held — a
+    # check registering late as a settled success, say — starts the window
+    # over rather than inheriting the elapsed time of a picture it replaced.
+    settled_key=$(echo "$check_classes" | settled_checks_key)
+    if [ "$settled_key" != "$stale_key" ]; then
+      stale_key="$settled_key"
       stale_since="$elapsed"
     fi
     if [ "$((elapsed - stale_since))" -ge "$STALE_WINDOW" ]; then

--- a/skills/orch/tests/ci_wait.sh
+++ b/skills/orch/tests/ci_wait.sh
@@ -169,57 +169,33 @@ case "${1:-}" in
           exit 8
         fi
       fi
-      # Green, then a settled transient failure, then green again, phased on
-      # the rerun the script itself requests rather than on a call count: the
-      # retry path reads the rollup a second time through get_failed_run_id,
-      # so a count alone would put the failure's own lookup in the next phase.
-      if [[ "${STUB_PR_CHECKS_MODE:-}" == "rerun_then_green" ]]; then
+      # One rollup per poll, from STUB_PR_CHECKS_SEQUENCE: colon-separated
+      # tokens (a row's env list separates on commas), the count file giving
+      # the poll index, the last token repeating. `fail_rerun` phases on the
+      # rerun the script itself requests rather than on the index, because the
+      # retry path reads the rollup a second time through get_failed_run_id.
+      if [[ -n "${STUB_PR_CHECKS_SEQUENCE:-}" ]]; then
         count=0
         if [[ -f "${STUB_PR_CHECKS_COUNT_FILE:?}" ]]; then
           count="$(cat "$STUB_PR_CHECKS_COUNT_FILE")"
         fi
         count=$((count + 1))
         printf '%s' "$count" > "$STUB_PR_CHECKS_COUNT_FILE"
-        if [[ "$count" -gt 3 && ! -s "${STUB_RERUN_CALLS_FILE:-/dev/null}" ]]; then
-          echo '[{"name":"build","state":"FAILURE","bucket":"fail","link":"https://github.com/owner/repo/actions/runs/29099680623/job/301","workflow":"CI","startedAt":"2026-07-10T11:00:00Z","completedAt":"2026-07-10T11:05:00Z"}]'
-          exit 1
-        fi
-        echo '[{"name":"build","state":"SUCCESS"}]'
-        exit 0
-      fi
-      # A check that registers late and settled: one green check on the first
-      # poll, two on every later one. Nothing is ever pending, so only the
-      # settled-check window decides when the wait completes.
-      if [[ "${STUB_PR_CHECKS_MODE:-}" == "late_second_check" ]]; then
-        count=0
-        if [[ -f "${STUB_PR_CHECKS_COUNT_FILE:?}" ]]; then
-          count="$(cat "$STUB_PR_CHECKS_COUNT_FILE")"
-        fi
-        count=$((count + 1))
-        printf '%s' "$count" > "$STUB_PR_CHECKS_COUNT_FILE"
-        if [[ "$count" -eq 1 ]]; then
-          echo '[{"name":"build","state":"SUCCESS"}]'
-          exit 0
-        fi
-        echo '[{"name":"build","state":"SUCCESS"},{"name":"lint","state":"SUCCESS"}]'
-        exit 0
-      fi
-      # One check going SUCCESS, SKIPPED, SUCCESS. A skipped check is in no
-      # class, so the middle poll reaches neither the settled-check window nor
-      # any failure arm, and the greens either side of it are the same picture.
-      if [[ "${STUB_PR_CHECKS_MODE:-}" == "skipped_between_greens" ]]; then
-        count=0
-        if [[ -f "${STUB_PR_CHECKS_COUNT_FILE:?}" ]]; then
-          count="$(cat "$STUB_PR_CHECKS_COUNT_FILE")"
-        fi
-        count=$((count + 1))
-        printf '%s' "$count" > "$STUB_PR_CHECKS_COUNT_FILE"
-        if [[ "$count" -eq 2 ]]; then
-          echo '[{"name":"build","state":"SKIPPED"}]'
-          exit 0
-        fi
-        echo '[{"name":"build","state":"SUCCESS"}]'
-        exit 0
+        IFS=':' read -ra toks <<<"$STUB_PR_CHECKS_SEQUENCE"
+        idx=$((count - 1))
+        [[ "$idx" -lt "${#toks[@]}" ]] || idx=$((${#toks[@]} - 1))
+        case "${toks[$idx]}" in
+          green)   echo '[{"name":"build","state":"SUCCESS"}]'; exit 0 ;;
+          green2)  echo '[{"name":"build","state":"SUCCESS"},{"name":"lint","state":"SUCCESS"}]'; exit 0 ;;
+          mixed)   echo '[{"name":"build","state":"SUCCESS"},{"name":"docs","state":"SKIPPED"}]'; exit 0 ;;
+          skipped) echo '[{"name":"build","state":"SKIPPED"}]'; exit 0 ;;
+          fail_rerun)
+            [[ ! -s "${STUB_RERUN_CALLS_FILE:-/dev/null}" ]] || { echo '[{"name":"build","state":"SUCCESS"}]'; exit 0; }
+            echo '[{"name":"build","state":"FAILURE","bucket":"fail","link":"https://github.com/owner/repo/actions/runs/29099680623/job/301","workflow":"CI","startedAt":"2026-07-10T11:00:00Z"}]'
+            exit 1
+            ;;
+          *) printf 'unknown sequence token: %s\n' "${toks[$idx]}" >&2; exit 1 ;;
+        esac
       fi
       if [[ "${STUB_PR_CHECKS_MODE:-}" == "pending_always" ]]; then
         echo '[{"name":"build","state":"IN_PROGRESS"}]'
@@ -505,8 +481,9 @@ table "$JSON" \
   "a PR already green at the script's own defaults completes, not times out||$JSON_DEFAULTS||rc=0 status=complete verdict=pass passed=1" \
   "a pending check at those defaults still waits to the deadline||$JSON_DEFAULTS|STUB_PR_CHECKS_MODE=pending_always|rc=1 status=timeout verdict=pending check.build=IN_PROGRESS" \
   'a green rollup the budget never confirmed is pending at the deadline, not pass||1 10 30 --json||rc=1 status=timeout verdict=pending passed=1 pending=0' \
-  'a check registering late and settled restarts the window|||STUB_PR_CHECKS_MODE=late_second_check|rc=0 status=complete verdict=pass passed=2 elapsed_seconds=120' \
-  'a poll in no class breaks the streak the greens either side of it would share|||STUB_PR_CHECKS_MODE=skipped_between_greens|rc=0 status=complete verdict=pass passed=1 elapsed_seconds=150' \
+  'a check registering late and settled restarts the window|||STUB_PR_CHECKS_SEQUENCE=green:green2|rc=0 status=complete verdict=pass passed=2 elapsed_seconds=120' \
+  'a poll in no class breaks the streak the greens either side of it would share|||STUB_PR_CHECKS_SEQUENCE=green:skipped:green|rc=0 status=complete verdict=pass passed=1 elapsed_seconds=150' \
+  'a check registering late as skipped is a different rollup and restarts the window|||STUB_PR_CHECKS_SEQUENCE=green:mixed|rc=0 status=complete verdict=pass passed=1 elapsed_seconds=120' \
   "checks still in progress at the deadline are a timeout||$JSON_SHORT|STUB_PR_CHECKS_MODE=pending_always|rc=1 status=timeout verdict=pending check.build=IN_PROGRESS" \
   'no checks registered past the grace window is a named error|||STUB_PR_CHECKS_MODE=empty,CI_WAIT_NO_CHECKS_GRACE=3|rc=1 status=error error_named=true' \
   "no checks registered inside the default grace window stays pending||$JSON_SHORT|STUB_PR_CHECKS_MODE=empty|rc=1 status=timeout verdict=pending" \
@@ -607,7 +584,7 @@ assert_le 65536 "$transient_tail_bytes" "one pipe buffer fits inside the log pas
 table "$JSON" \
   "a transient marker in a large failed-job log reruns the failing run; the retried failure still settles terminal|||STUB_PR_CHECKS_FIXTURE=$FX/rerun-attempt-checks.json,$RERUN,STUB_ACTIONS_RUNS_FIXTURE=$FX/runs-rerun-attempt-failure.json,STUB_RUN_LOG_FILE=$transient_log|rc=1 verdict=fail reruns=29662812172" \
   "a gh failure reading the log is not transient: nothing is rerun|||STUB_PR_CHECKS_FIXTURE=$FX/rerun-attempt-checks.json,$RERUN,STUB_ACTIONS_RUNS_FIXTURE=$FX/runs-rerun-attempt-failure.json|rc=1 verdict=fail reruns=none" \
-  "a rerun restarts the settled-check window: the greens before it carry nothing|||STUB_PR_CHECKS_MODE=rerun_then_green,STUB_RUN_LOG_FILE=$transient_log|rc=0 status=complete verdict=pass reruns=29099680623 elapsed_seconds=190"
+  "a rerun restarts the settled-check window: the greens before it carry nothing|||STUB_PR_CHECKS_SEQUENCE=green:green:green:fail_rerun,STUB_RUN_LOG_FILE=$transient_log|rc=0 status=complete verdict=pass reruns=29099680623 elapsed_seconds=190"
 
 echo "=== argument validation ends in the parser, before any gh call ==="
 # The recording gh stub fails every call, so a case that reached auth or a

--- a/skills/orch/tests/ci_wait.sh
+++ b/skills/orch/tests/ci_wait.sh
@@ -204,6 +204,23 @@ case "${1:-}" in
         echo '[{"name":"build","state":"SUCCESS"},{"name":"lint","state":"SUCCESS"}]'
         exit 0
       fi
+      # One check going SUCCESS, SKIPPED, SUCCESS. A skipped check is in no
+      # class, so the middle poll reaches neither the settled-check window nor
+      # any failure arm, and the greens either side of it are the same picture.
+      if [[ "${STUB_PR_CHECKS_MODE:-}" == "skipped_between_greens" ]]; then
+        count=0
+        if [[ -f "${STUB_PR_CHECKS_COUNT_FILE:?}" ]]; then
+          count="$(cat "$STUB_PR_CHECKS_COUNT_FILE")"
+        fi
+        count=$((count + 1))
+        printf '%s' "$count" > "$STUB_PR_CHECKS_COUNT_FILE"
+        if [[ "$count" -eq 2 ]]; then
+          echo '[{"name":"build","state":"SKIPPED"}]'
+          exit 0
+        fi
+        echo '[{"name":"build","state":"SUCCESS"}]'
+        exit 0
+      fi
       if [[ "${STUB_PR_CHECKS_MODE:-}" == "pending_always" ]]; then
         echo '[{"name":"build","state":"IN_PROGRESS"}]'
         exit 8
@@ -489,6 +506,7 @@ table "$JSON" \
   "a pending check at those defaults still waits to the deadline||$JSON_DEFAULTS|STUB_PR_CHECKS_MODE=pending_always|rc=1 status=timeout verdict=pending check.build=IN_PROGRESS" \
   'a green rollup the budget never confirmed is pending at the deadline, not pass||1 10 30 --json||rc=1 status=timeout verdict=pending passed=1 pending=0' \
   'a check registering late and settled restarts the window|||STUB_PR_CHECKS_MODE=late_second_check|rc=0 status=complete verdict=pass passed=2 elapsed_seconds=120' \
+  'a poll in no class breaks the streak the greens either side of it would share|||STUB_PR_CHECKS_MODE=skipped_between_greens|rc=0 status=complete verdict=pass passed=1 elapsed_seconds=150' \
   "checks still in progress at the deadline are a timeout||$JSON_SHORT|STUB_PR_CHECKS_MODE=pending_always|rc=1 status=timeout verdict=pending check.build=IN_PROGRESS" \
   'no checks registered past the grace window is a named error|||STUB_PR_CHECKS_MODE=empty,CI_WAIT_NO_CHECKS_GRACE=3|rc=1 status=error error_named=true' \
   "no checks registered inside the default grace window stays pending||$JSON_SHORT|STUB_PR_CHECKS_MODE=empty|rc=1 status=timeout verdict=pending" \

--- a/skills/orch/tests/ci_wait.sh
+++ b/skills/orch/tests/ci_wait.sh
@@ -389,8 +389,15 @@ table() {
   done
 }
 
-JSON='1 1 30 --json'
+# The poll interval and budget every row inherits. Both are spent on the
+# virtual clock, so they are sized like production's rather than to save real
+# seconds: the settled-check window below is wall-clock seconds, and a budget
+# under it leaves a green PR unconfirmed at the deadline.
+JSON='1 30 300 --json'
 JSON_SHORT='1 1 5 --json'
+# The script's own defaults for poll interval and budget: positional args
+# omitted, so a row using this reads whatever ci-wait defaults to.
+JSON_DEFAULTS='1 --json'
 
 echo "=== the auth ladder: env token, keyring, bot token ==="
 # A stale inherited token is unset with a warning and the keyring tried; with
@@ -433,10 +440,19 @@ echo "=== the verdict over the checks sequence ==="
 # never success or silence; no checks registered is pending inside the
 # CI_WAIT_NO_CHECKS_GRACE window and an error past it; a settled failure is
 # terminal; an auth failure is a parseable error object.
+#
+# The settled-check window is wall-clock seconds, so the three rows taking the
+# script's own poll interval and budget are what a lane actually runs: a PR
+# already green before the wait started completes, a pending one still waits,
+# and a budget shorter than the window reports the unconfirmed green rollup as
+# pending — "pass" is paired with status "complete" and nothing else.
 table "$JSON" \
   'a pending exit with valid JSON keeps polling|||STUB_PR_CHECKS_MODE=pending_once|rc=0 verdict=pass checks_polls=2' \
   "an EXPECTED check is pending until it clears||$JSON_SHORT|STUB_PR_CHECKS_MODE=expected_once|rc=0 verdict=pass checks_polls=2" \
   'a pass is complete with its checks listed||||rc=0 status=complete verdict=pass passed=1' \
+  "a PR already green at the script's own defaults completes, not times out||$JSON_DEFAULTS||rc=0 status=complete verdict=pass passed=1" \
+  "a pending check at those defaults still waits to the deadline||$JSON_DEFAULTS|STUB_PR_CHECKS_MODE=pending_always|rc=1 status=timeout verdict=pending check.build=IN_PROGRESS" \
+  'a green rollup the budget never confirmed is pending at the deadline, not pass||1 10 30 --json||rc=1 status=timeout verdict=pending passed=1 pending=0' \
   "checks still in progress at the deadline are a timeout||$JSON_SHORT|STUB_PR_CHECKS_MODE=pending_always|rc=1 status=timeout verdict=pending check.build=IN_PROGRESS" \
   'no checks registered past the grace window is a named error|||STUB_PR_CHECKS_MODE=empty,CI_WAIT_NO_CHECKS_GRACE=3|rc=1 status=error error_named=true' \
   "no checks registered inside the default grace window stays pending||$JSON_SHORT|STUB_PR_CHECKS_MODE=empty|rc=1 status=timeout verdict=pending" \
@@ -446,7 +462,7 @@ table "$JSON" \
 echo "=== text mode prints a result line for every terminal status ==="
 # The line beyond its leading words is not a contract anything parses; the
 # leading words are text-only, so a JSON default flip fails these rows.
-table '1 1 30' \
+table '1 30 300' \
   'passed||||rc=0 stdout~ci-wait:+passed+pr=1+repo=owner/repo=true' \
   'failed|||STUB_PR_CHECKS_MODE=failure|rc=1 stdout~ci-wait:+failed+pr=1+repo=owner/repo=true' \
   'timeout||1 1 5|STUB_PR_CHECKS_MODE=pending_always|rc=1 stdout~ci-wait:+timeout+elapsed=5+verdict=pending+repo=owner/repo=true' \

--- a/skills/orch/tests/ci_wait.sh
+++ b/skills/orch/tests/ci_wait.sh
@@ -169,6 +169,24 @@ case "${1:-}" in
           exit 8
         fi
       fi
+      # Green, then a settled transient failure, then green again, phased on
+      # the rerun the script itself requests rather than on a call count: the
+      # retry path reads the rollup a second time through get_failed_run_id,
+      # so a count alone would put the failure's own lookup in the next phase.
+      if [[ "${STUB_PR_CHECKS_MODE:-}" == "rerun_then_green" ]]; then
+        count=0
+        if [[ -f "${STUB_PR_CHECKS_COUNT_FILE:?}" ]]; then
+          count="$(cat "$STUB_PR_CHECKS_COUNT_FILE")"
+        fi
+        count=$((count + 1))
+        printf '%s' "$count" > "$STUB_PR_CHECKS_COUNT_FILE"
+        if [[ "$count" -gt 3 && ! -s "${STUB_RERUN_CALLS_FILE:-/dev/null}" ]]; then
+          echo '[{"name":"build","state":"FAILURE","bucket":"fail","link":"https://github.com/owner/repo/actions/runs/29099680623/job/301","workflow":"CI","startedAt":"2026-07-10T11:00:00Z","completedAt":"2026-07-10T11:05:00Z"}]'
+          exit 1
+        fi
+        echo '[{"name":"build","state":"SUCCESS"}]'
+        exit 0
+      fi
       if [[ "${STUB_PR_CHECKS_MODE:-}" == "pending_always" ]]; then
         echo '[{"name":"build","state":"IN_PROGRESS"}]'
         exit 8
@@ -552,7 +570,8 @@ assert_le 131072 "$transient_window_bytes" "two pipe buffers fit inside the scan
 assert_le 65536 "$transient_tail_bytes" "one pipe buffer fits inside the log past the window"
 table "$JSON" \
   "a transient marker in a large failed-job log reruns the failing run; the retried failure still settles terminal|||STUB_PR_CHECKS_FIXTURE=$FX/rerun-attempt-checks.json,$RERUN,STUB_ACTIONS_RUNS_FIXTURE=$FX/runs-rerun-attempt-failure.json,STUB_RUN_LOG_FILE=$transient_log|rc=1 verdict=fail reruns=29662812172" \
-  "a gh failure reading the log is not transient: nothing is rerun|||STUB_PR_CHECKS_FIXTURE=$FX/rerun-attempt-checks.json,$RERUN,STUB_ACTIONS_RUNS_FIXTURE=$FX/runs-rerun-attempt-failure.json|rc=1 verdict=fail reruns=none"
+  "a gh failure reading the log is not transient: nothing is rerun|||STUB_PR_CHECKS_FIXTURE=$FX/rerun-attempt-checks.json,$RERUN,STUB_ACTIONS_RUNS_FIXTURE=$FX/runs-rerun-attempt-failure.json|rc=1 verdict=fail reruns=none" \
+  "a rerun restarts the settled-check window: the greens before it carry nothing|||STUB_PR_CHECKS_MODE=rerun_then_green,STUB_RUN_LOG_FILE=$transient_log|rc=0 status=complete verdict=pass reruns=29099680623 elapsed_seconds=190"
 
 echo "=== argument validation ends in the parser, before any gh call ==="
 # The recording gh stub fails every call, so a case that reached auth or a

--- a/skills/orch/tests/ci_wait.sh
+++ b/skills/orch/tests/ci_wait.sh
@@ -187,6 +187,23 @@ case "${1:-}" in
         echo '[{"name":"build","state":"SUCCESS"}]'
         exit 0
       fi
+      # A check that registers late and settled: one green check on the first
+      # poll, two on every later one. Nothing is ever pending, so only the
+      # settled-check window decides when the wait completes.
+      if [[ "${STUB_PR_CHECKS_MODE:-}" == "late_second_check" ]]; then
+        count=0
+        if [[ -f "${STUB_PR_CHECKS_COUNT_FILE:?}" ]]; then
+          count="$(cat "$STUB_PR_CHECKS_COUNT_FILE")"
+        fi
+        count=$((count + 1))
+        printf '%s' "$count" > "$STUB_PR_CHECKS_COUNT_FILE"
+        if [[ "$count" -eq 1 ]]; then
+          echo '[{"name":"build","state":"SUCCESS"}]'
+          exit 0
+        fi
+        echo '[{"name":"build","state":"SUCCESS"},{"name":"lint","state":"SUCCESS"}]'
+        exit 0
+      fi
       if [[ "${STUB_PR_CHECKS_MODE:-}" == "pending_always" ]]; then
         echo '[{"name":"build","state":"IN_PROGRESS"}]'
         exit 8
@@ -471,6 +488,7 @@ table "$JSON" \
   "a PR already green at the script's own defaults completes, not times out||$JSON_DEFAULTS||rc=0 status=complete verdict=pass passed=1" \
   "a pending check at those defaults still waits to the deadline||$JSON_DEFAULTS|STUB_PR_CHECKS_MODE=pending_always|rc=1 status=timeout verdict=pending check.build=IN_PROGRESS" \
   'a green rollup the budget never confirmed is pending at the deadline, not pass||1 10 30 --json||rc=1 status=timeout verdict=pending passed=1 pending=0' \
+  'a check registering late and settled restarts the window|||STUB_PR_CHECKS_MODE=late_second_check|rc=0 status=complete verdict=pass passed=2 elapsed_seconds=120' \
   "checks still in progress at the deadline are a timeout||$JSON_SHORT|STUB_PR_CHECKS_MODE=pending_always|rc=1 status=timeout verdict=pending check.build=IN_PROGRESS" \
   'no checks registered past the grace window is a named error|||STUB_PR_CHECKS_MODE=empty,CI_WAIT_NO_CHECKS_GRACE=3|rc=1 status=error error_named=true' \
   "no checks registered inside the default grace window stays pending||$JSON_SHORT|STUB_PR_CHECKS_MODE=empty|rc=1 status=timeout verdict=pending" \

--- a/skills/orch/workflows/submit-pr.md
+++ b/skills/orch/workflows/submit-pr.md
@@ -284,7 +284,7 @@ After any fix-up push: push → the Restart check, and on a restart wait for a N
 | `status=complete`, `verdict=fail` | → § 5.1 |
 | `status=timeout` or `status=error` | Re-run once. If it repeats, `auto-recommended` records `ci-status-unconfirmed`; `ask` presents `Skip CI` \| `Retry` \| `Abort`, with `Retry` recommended |
 
-A PR already green when the wait started reaches the first row, not the last: ci-wait pairs `verdict=pass` with `status=complete` alone, so neither a timeout nor an error can carry it.
+A PR already green when the wait started reaches the first row, never this one: `ci-wait --help` pairs `verdict=pass` with `status=complete` alone.
 
 ### 5.1 CI Failure Recovery
 

--- a/skills/orch/workflows/submit-pr.md
+++ b/skills/orch/workflows/submit-pr.md
@@ -284,6 +284,8 @@ After any fix-up push: push → the Restart check, and on a restart wait for a N
 | `status=complete`, `verdict=fail` | → § 5.1 |
 | `status=timeout` or `status=error` | Re-run once. If it repeats, `auto-recommended` records `ci-status-unconfirmed`; `ask` presents `Skip CI` \| `Retry` \| `Abort`, with `Retry` recommended |
 
+A PR already green when the wait started reaches the first row, not the last: ci-wait pairs `verdict=pass` with `status=complete` alone, so neither a timeout nor an error can carry it.
+
 ### 5.1 CI Failure Recovery
 
 ```bash


### PR DESCRIPTION
## Summary
- `ci-wait`'s stale-check guard counted polls (`max_stale=6`, commented as about 90 s on a 15 s poll) while the defaults are a 180 s poll inside a 600 s budget, so a PR already green before the wait started never reached the complete path and fell out at the deadline as `status=timeout`, `verdict=pass`. The window is now 90 wall-clock seconds of an unchanged all-settled rollup, measured against elapsed time, so at the defaults the wait completes on its second poll.
- `verdict=pass` now requires `status=complete`; a green rollup at a deadline or error reports `pending`. That makes the timeout-carrying-pass shape unreachable at any settings, and submit-pr § 5 says so instead of routing it.
- The settled-check streak is keyed on the scoped rollup (every check's name and state, skipped included), is stamped at the time the rollup was read, and survives only across consecutive polls that reach the settled-check window (one rule in a poll_sleep helper): a differing rollup, an emptied or all-skipped one, a failure, or a rerun the wait requested starts the window over instead of inheriting time already served (three review threads plus four suppressed Copilot findings, commits two to six; the fifth is also the size cut: one per-poll sequence stub mode replaces three bespoke modes).

## Completed Issues
- Closes KEN-1351 - ci-wait reads a pull request that was already green as a timeout, and submit-pr routes it to ci-status-unconfirmed

## Done-when map
- ci-wait returns complete/pass for an already-green PR, stale threshold in seconds: `skills/orch/scripts/ci-wait` (STALE_WINDOW, stale_since, emit_result verdict), rows in `skills/orch/tests/ci_wait.sh` (already-green at defaults completes; pending at defaults still waits; a budget under the window reports pending, not pass; a rerun restarts the window).
- submit-pr § 5 routes the timeout-with-pass shape or states it cannot occur: `skills/orch/workflows/submit-pr.md` § 5 (one sentence: pass is paired with complete alone).
- Tracked renders under `.agents/skills/orch/` replayed from the source diff.

## Size
production=43 tests=38 mirror=81 at PR open (issue states no allowance); the branch was cut back under the fix-round cap at the fifth commit (256 of 292 changed lines).

## Test Plan
- `skills/orch/tests/ci_wait.sh` green on both commits; each new row reddens alone when its fix is reverted (poll-count threshold, status-blind verdict, missing rerun reset, missing picture comparison, streak surviving a non-settled poll, skipped checks missing from the picture).
- `env -u TMPDIR tools/guard --full` clean on every head, including the pushed head 1bb2707ee (six commits, restacked onto main after KEN-1342 merged).
- preflight clean on 9b0459624 (pre-rebase).

https://claude.ai/code/session_01RYv4AtZFtwrwFq2HqFYtDS
