### PR TITLE
fix(KEN-1340): doc-drift-check names rendered harness files and kendex's own tools, .github, agents, commands and Cargo paths as uncovered at every stop

### DIFF
--- a/.claude/hooks/doc-drift-check.sh
+++ b/.claude/hooks/doc-drift-check.sh
@@ -80,7 +80,7 @@ refuse() { # KEY VALUE [DETAIL], or `drift` alone
         printf 'the render inventory .kendex-generated.json is present and could not be read\n'
         ;;
       inventory=invalid-json)
-        printf 'the render inventory .kendex-generated.json is not a JSON array of non-empty path strings; refusing rather than judging every render as code no document covers\n'
+        printf 'the render inventory .kendex-generated.json is not one JSON array of non-empty path strings, none holding a newline or a NUL; refusing rather than judging every render as code no document covers\n'
         ;;
       session-id=invalid)
         printf 'the payload carries no usable session_id, so naming these documents could not be recorded; refusing\n'
@@ -337,9 +337,22 @@ if [ -f "$INVENTORY" ]; then
   # reaches the refusal under its keyed line rather than ahead of it. Both are
   # silent when they succeed.
   INVENTORY_JSON=$(cat -- "$INVENTORY" 2>&1) || refuse inventory unreadable "$INVENTORY_JSON"
-  GENERATED=$(printf '%s' "$INVENTORY_JSON" | jq -r '
-    if type == "array" and all(.[]; type == "string" and length > 0)
-    then .[] else "" | halt_error(21) end' 2>&1) ||
+  # The shape check is the one
+  # `skills/commit-guards/scripts/lib/generated-paths.sh` runs on this same
+  # file, spelled again because a hook ships alone into a repository that need
+  # not have commit-guards installed. `-s` is what makes a count of documents
+  # visible at all: without it an empty, whitespace-only or truncated file
+  # yields no output and no error, which is the file being read as a project
+  # with nothing rendered. Exactly one document, an array whose members are
+  # non-empty strings holding neither a newline nor a NUL, since a path with a
+  # newline in it could not be matched a line at a time below.
+  GENERATED=$(printf '%s' "$INVENTORY_JSON" | jq -ers '
+    if length == 1 then .[0] else "" | halt_error(20) end
+    | if type == "array" and all(.[];
+        type == "string" and length > 0
+        and (contains("\n") or contains("\u0000") | not))
+      then join("\n")
+      else "" | halt_error(21) end' 2>&1) ||
     refuse inventory invalid-json "$GENERATED"
 fi
 

--- a/.claude/hooks/doc-drift-check.sh
+++ b/.claude/hooks/doc-drift-check.sh
@@ -3,9 +3,9 @@
 # name: doc-drift-check
 # event: Stop
 # matcher:
-# description: Blocks a stop once per set of findings so the agent, the only party that can act on them, is the one given the list. Three kinds are found: stale, a document covering changed code that did not change; dangling, an architecture topic `Covers:` entry that no tracked or untracked non-ignored path on disk matches; uncovered, a changed non-markdown path still on disk that no topic entry and no non-root AGENTS.md covers, judged only where some topic declares an entry. The refusal opens with one keyed line per kind that holds, in the order `doc-drift-check: stale=<count>`, `doc-drift-check: dangling=<count>`, `doc-drift-check: uncovered=<count>`, then `doc-drift-check: base=<ref>` — the ref it compared against, or `default-branch`, `none` or `unrelated` — and names each finding under them; stdout carries nothing and no user-facing notice is written. The set is recorded as `<git common dir>/kendex/doc-drift/<session_id>-<digest of the sorted set>`, so a later stop naming that same set passes and an agent that read the list and changed nothing is not asked again; a set that gains or loses a finding is a different set and blocks once. `stop_hook_active` true passes, and so does a stop with nothing changed; any change, markdown alone included, has every Covers entry judged. Uses the nearest non-root AGENTS.md, tracked or untracked and not ignored, and architecture topic Covers entries. Compares the branch with its default-branch merge-base, or the working tree when no comparison applies. Claude Code only.
+# description: Blocks a stop once per set of findings so the agent, the only party that can act on them, is the one given the list. Three kinds are found: stale, a document covering changed code that did not change; dangling, an architecture topic `Covers:` entry that no tracked or untracked non-ignored path on disk matches; uncovered, a changed non-markdown path still on disk that no topic entry and no non-root AGENTS.md covers, judged only where some topic declares an entry and never for a path the repository's `.kendex-generated.json` lists, a render being covered through the source it was rendered from. The refusal opens with one keyed line per kind that holds, in the order `doc-drift-check: stale=<count>`, `doc-drift-check: dangling=<count>`, `doc-drift-check: uncovered=<count>`, then `doc-drift-check: base=<ref>` — the ref it compared against, or `default-branch`, `none` or `unrelated` — and names each finding under them; stdout carries nothing and no user-facing notice is written. The set is recorded as `<git common dir>/kendex/doc-drift/<session_id>-<digest of the sorted set>`, so a later stop naming that same set passes and an agent that read the list and changed nothing is not asked again; a set that gains or loses a finding is a different set and blocks once. `stop_hook_active` true passes, and so does a stop with nothing changed; any change, markdown alone included, has every Covers entry judged. Uses the nearest non-root AGENTS.md, tracked or untracked and not ignored, and architecture topic Covers entries. Compares the branch with its default-branch merge-base, or the working tree when no comparison applies. Claude Code only.
 # summary: Stops an agent at the end of its turn when documents covering the code it changed did not change or an architecture topic names a path that does not exist, and hands it the list. Where some topic declares a Covers entry, changed code with no covering document is named too.
-# safety: Reads the payload, git state, the topic files and git's listing of what each Covers entry matches; the only write is the per-set marker under the repository's git common dir. Exit 2 names the findings and asks for each document to be confirmed or updated and each entry or path to be corrected, never bypassed. jq reads the payload and a sha256 tool names the set; every command the hook runs is checked before it is called, the payload readers ahead of the payload and the rest after `stop_hook_active` has been read, so a discovery command's absence costs one retry rather than refusing the retry too; only a missing payload reader refuses that as well, the flag being in the payload it cannot read. A payload, git state or marker the hook cannot read or write is refused, never passed. Every refusal opens with `doc-drift-check: <key>=<value>`; what a command this hook runs writes is captured at the site and replayed under that line, so nothing precedes the key.
+# safety: Reads the payload, git state, the topic files, the render inventory `.kendex-generated.json` and git's listing of what each Covers entry matches; the only write is the per-set marker under the repository's git common dir. Exit 2 names the findings and asks for each document to be confirmed or updated and each entry or path to be corrected, never bypassed. jq reads the payload and a sha256 tool names the set; every command the hook runs is checked before it is called, the payload readers ahead of the payload and the rest after `stop_hook_active` has been read, so a discovery command's absence costs one retry rather than refusing the retry too; only a missing payload reader refuses that as well, the flag being in the payload it cannot read. A payload, git state, render inventory or marker the hook cannot read or write is refused, never passed. Every refusal opens with `doc-drift-check: <key>=<value>`; what a command this hook runs writes is captured at the site and replayed under that line, so nothing precedes the key.
 # timeout: 30
 # harnesses: [claude-code]
 # ---
@@ -75,6 +75,12 @@ refuse() { # KEY VALUE [DETAIL], or `drift` alone
         ;;
       payload=invalid-json)
         printf 'the hook payload is not valid JSON, or a field it reads is not a string; refusing rather than skipping the check\n'
+        ;;
+      inventory=unreadable)
+        printf 'the render inventory .kendex-generated.json is present and could not be read\n'
+        ;;
+      inventory=invalid-json)
+        printf 'the render inventory .kendex-generated.json is not a JSON array of non-empty path strings; refusing rather than judging every render as code no document covers\n'
         ;;
       session-id=invalid)
         printf 'the payload carries no usable session_id, so naming these documents could not be recorded; refusing\n'
@@ -311,6 +317,32 @@ fi
 CODE_CHANGED=$(printf '%s\n' "$ALL_CHANGED" | sed '/\.md$/d' 2>&1) ||
   refuse exit "$?" "$CODE_CHANGED"
 
+# What kendex rendered into this repository, one path per line. The render
+# writer keeps this inventory and is the one judge of whether a path is a
+# render, so the hook reads it rather than matching harness directory names of
+# its own. A render is never the thing a document covers — the source it was
+# rendered from is — so a changed render is not named uncovered below.
+#
+# The read discipline is the one commit-guards' suppression-ban applies to the
+# same file: an absent inventory is a repository with nothing rendered and
+# excludes nothing, while a present one that does not parse is refused rather
+# than read as empty, which would name every render as uncovered and say
+# nothing about why. It is read from the working tree, as the topic files are:
+# a refresh writes the inventory and the renders it lists together, so the
+# working-tree copy is the one that describes the renders being judged.
+GENERATED=""
+INVENTORY="$REPO_ROOT/.kendex-generated.json"
+if [ -f "$INVENTORY" ]; then
+  # cat's and jq's own words are captured where each is read, so a failure
+  # reaches the refusal under its keyed line rather than ahead of it. Both are
+  # silent when they succeed.
+  INVENTORY_JSON=$(cat -- "$INVENTORY" 2>&1) || refuse inventory unreadable "$INVENTORY_JSON"
+  GENERATED=$(printf '%s' "$INVENTORY_JSON" | jq -r '
+    if type == "array" and all(.[]; type == "string" and length > 0)
+    then .[] else "" | halt_error(21) end' 2>&1) ||
+    refuse inventory invalid-json "$GENERATED"
+fi
+
 # Covering docs. `:(top)` roots the pattern at the repository whatever the
 # cwd, and `*` crosses `/`, so this is every AGENTS.md below the root and
 # not the root's own, which covers nothing. Untracked non-ignored ones count,
@@ -416,6 +448,8 @@ EOF
 # repository without one has no map to be incomplete, and naming every changed
 # path there would block each stop of a repository that never adopted topics.
 # A deleted path is never uncovered: an entry added for it would match nothing.
+# Nor is a render the inventory lists: the document to correct covers its
+# source, and an entry added for the render would name a generated file.
 while IFS= read -r path; do
   # An empty code set reads as one empty line.
   [ -n "$path" ] || continue
@@ -423,6 +457,7 @@ while IFS= read -r path; do
   if [ -z "$docs" ]; then
     [ -n "$COVERS" ] || continue
     on_disk "$path" || continue
+    in_list "$GENERATED" "$path" && continue
     NAMED="$NAMED"uncovered$'\t'"$path"$'\n'
     UNCOVERED="$UNCOVERED  $path"$'\n'
     UNCOVERED_COUNT=$((UNCOVERED_COUNT + 1))

--- a/.github/AGENTS.md
+++ b/.github/AGENTS.md
@@ -1,0 +1,10 @@
+# .github/
+
+This repository's own continuous integration and the instruction files its review bots read. Nothing here is catalog content.
+
+- `copilot-instructions.md` and `instructions/*.instructions.md` are rendered by the bot-instructions package and each names its generator on its first line; change `[bot-instructions]` in the effective manifest and re-render, never the file.
+- Every job runs on a GitHub-hosted runner. This repository is public and declares no self-hosted runner.
+- `own-catalog.yml` holds this repository to the same check a consumer gets by calling `catalog-check.yml`, which is the reusable workflow consumers call; keep the caller's content out of the reusable one.
+- `skill-tests.yml` is the suite runner [`../skills/AGENTS.md`](../skills/AGENTS.md) names; it carries the `tools/` and `hooks/` suites and the Bash 3.2 legs as well.
+- `review-gate-writer.yml` is a relay whose body must equal the review-gate package's template, which [`../skills/review-gate/scripts/validate-workflow.sh`](../skills/review-gate/scripts/validate-workflow.sh) checks.
+- `release.yml` is [`../docs/RELEASING.md`](../docs/RELEASING.md).

--- a/.github/AGENTS.md
+++ b/.github/AGENTS.md
@@ -2,7 +2,7 @@
 
 This repository's own continuous integration and the instruction files its review bots read. Nothing here is catalog content.
 
-- `copilot-instructions.md` and `instructions/*.instructions.md` are rendered by the bot-instructions package and each names its generator on its first line; change `[bot-instructions]` in the effective manifest and re-render, never the file.
+- `copilot-instructions.md` and `instructions/*.instructions.md` are rendered by the bot-instructions package and each names its generator in a comment: line 1 of `copilot-instructions.md`, and below the `applyTo` frontmatter in an `instructions/*.instructions.md`. Change `[bot-instructions]` in the effective manifest and re-render, never the file.
 - Every job runs on a GitHub-hosted runner. This repository is public and declares no self-hosted runner.
 - `own-catalog.yml` holds this repository to the same check a consumer gets by calling `catalog-check.yml`, which is the reusable workflow consumers call; keep the caller's content out of the reusable one.
 - `skill-tests.yml` is the suite runner [`../skills/AGENTS.md`](../skills/AGENTS.md) names; it carries the `tools/` and `hooks/` suites and the Bash 3.2 legs as well.

--- a/.github/CLAUDE.md
+++ b/.github/CLAUDE.md
@@ -1,0 +1,1 @@
+@AGENTS.md

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -28,6 +28,8 @@ Desktop app and thin CLI (Rust + Tauri + React) for managing AI coding-harness c
 - `skills/AGENTS.md`: when working under `skills/`, `agents/` or `hooks/`.
 - `hooks/AGENTS.md`: when writing or changing a hook script.
 - `pi-extensions/AGENTS.md`: when working under `pi-extensions/`.
+- `tools/AGENTS.md`: when working under `tools/`.
+- `.github/AGENTS.md`: when changing a workflow or a review-bot instruction file.
 - `docs/DEVELOPMENT.md`: building from source and where a debug build writes.
 - `docs/RELEASING.md`: cutting a release.
 

--- a/docs/architecture/overview.md
+++ b/docs/architecture/overview.md
@@ -1,5 +1,7 @@
 # kendex architecture
 
+Covers: Cargo.toml, Cargo.lock
+
 ## The one idea
 
 The desktop app and CLI project one Rust model: scan, declare, diff and apply. The per-scope manifest stores user intent. Drift compares that intent with observed harness state. Apply makes disk match the declaration; adopt records observed state as intent. App pages and CLI commands own no separate domain logic. Manifests, locks and harness directories hold all state; kendex has no server.
@@ -73,5 +75,5 @@ The desktop app and CLI project one Rust model: scan, declare, diff and apply. T
 - [registry.md](registry.md): read before changing the community directory, sign-in or the skills.sh lead.
 - [../adapters/README.md](../adapters/README.md): the per-harness on-disk facts, one page per harness; read when touching one adapter's paths or formats.
 - [../authoring/README.md](../authoring/README.md): how a marketplace repository is laid out and checked; read when changing what a catalog may declare.
-- [../DEVELOPMENT.md](../DEVELOPMENT.md): building from source and the debug sandbox.
-- [../RELEASING.md](../RELEASING.md): cutting a release and what the workflow publishes.
+- [../DEVELOPMENT.md](../DEVELOPMENT.md): building from source.
+- [../RELEASING.md](../RELEASING.md): cutting a release.

--- a/hooks/doc-drift-check.sh
+++ b/hooks/doc-drift-check.sh
@@ -80,7 +80,7 @@ refuse() { # KEY VALUE [DETAIL], or `drift` alone
         printf 'the render inventory .kendex-generated.json is present and could not be read\n'
         ;;
       inventory=invalid-json)
-        printf 'the render inventory .kendex-generated.json is not a JSON array of non-empty path strings; refusing rather than judging every render as code no document covers\n'
+        printf 'the render inventory .kendex-generated.json is not one JSON array of non-empty path strings, none holding a newline or a NUL; refusing rather than judging every render as code no document covers\n'
         ;;
       session-id=invalid)
         printf 'the payload carries no usable session_id, so naming these documents could not be recorded; refusing\n'
@@ -337,9 +337,22 @@ if [ -f "$INVENTORY" ]; then
   # reaches the refusal under its keyed line rather than ahead of it. Both are
   # silent when they succeed.
   INVENTORY_JSON=$(cat -- "$INVENTORY" 2>&1) || refuse inventory unreadable "$INVENTORY_JSON"
-  GENERATED=$(printf '%s' "$INVENTORY_JSON" | jq -r '
-    if type == "array" and all(.[]; type == "string" and length > 0)
-    then .[] else "" | halt_error(21) end' 2>&1) ||
+  # The shape check is the one
+  # `skills/commit-guards/scripts/lib/generated-paths.sh` runs on this same
+  # file, spelled again because a hook ships alone into a repository that need
+  # not have commit-guards installed. `-s` is what makes a count of documents
+  # visible at all: without it an empty, whitespace-only or truncated file
+  # yields no output and no error, which is the file being read as a project
+  # with nothing rendered. Exactly one document, an array whose members are
+  # non-empty strings holding neither a newline nor a NUL, since a path with a
+  # newline in it could not be matched a line at a time below.
+  GENERATED=$(printf '%s' "$INVENTORY_JSON" | jq -ers '
+    if length == 1 then .[0] else "" | halt_error(20) end
+    | if type == "array" and all(.[];
+        type == "string" and length > 0
+        and (contains("\n") or contains("\u0000") | not))
+      then join("\n")
+      else "" | halt_error(21) end' 2>&1) ||
     refuse inventory invalid-json "$GENERATED"
 fi
 

--- a/hooks/doc-drift-check.sh
+++ b/hooks/doc-drift-check.sh
@@ -3,9 +3,9 @@
 # name: doc-drift-check
 # event: Stop
 # matcher:
-# description: Blocks a stop once per set of findings so the agent, the only party that can act on them, is the one given the list. Three kinds are found: stale, a document covering changed code that did not change; dangling, an architecture topic `Covers:` entry that no tracked or untracked non-ignored path on disk matches; uncovered, a changed non-markdown path still on disk that no topic entry and no non-root AGENTS.md covers, judged only where some topic declares an entry. The refusal opens with one keyed line per kind that holds, in the order `doc-drift-check: stale=<count>`, `doc-drift-check: dangling=<count>`, `doc-drift-check: uncovered=<count>`, then `doc-drift-check: base=<ref>` — the ref it compared against, or `default-branch`, `none` or `unrelated` — and names each finding under them; stdout carries nothing and no user-facing notice is written. The set is recorded as `<git common dir>/kendex/doc-drift/<session_id>-<digest of the sorted set>`, so a later stop naming that same set passes and an agent that read the list and changed nothing is not asked again; a set that gains or loses a finding is a different set and blocks once. `stop_hook_active` true passes, and so does a stop with nothing changed; any change, markdown alone included, has every Covers entry judged. Uses the nearest non-root AGENTS.md, tracked or untracked and not ignored, and architecture topic Covers entries. Compares the branch with its default-branch merge-base, or the working tree when no comparison applies. Claude Code only.
+# description: Blocks a stop once per set of findings so the agent, the only party that can act on them, is the one given the list. Three kinds are found: stale, a document covering changed code that did not change; dangling, an architecture topic `Covers:` entry that no tracked or untracked non-ignored path on disk matches; uncovered, a changed non-markdown path still on disk that no topic entry and no non-root AGENTS.md covers, judged only where some topic declares an entry and never for a path the repository's `.kendex-generated.json` lists, a render being covered through the source it was rendered from. The refusal opens with one keyed line per kind that holds, in the order `doc-drift-check: stale=<count>`, `doc-drift-check: dangling=<count>`, `doc-drift-check: uncovered=<count>`, then `doc-drift-check: base=<ref>` — the ref it compared against, or `default-branch`, `none` or `unrelated` — and names each finding under them; stdout carries nothing and no user-facing notice is written. The set is recorded as `<git common dir>/kendex/doc-drift/<session_id>-<digest of the sorted set>`, so a later stop naming that same set passes and an agent that read the list and changed nothing is not asked again; a set that gains or loses a finding is a different set and blocks once. `stop_hook_active` true passes, and so does a stop with nothing changed; any change, markdown alone included, has every Covers entry judged. Uses the nearest non-root AGENTS.md, tracked or untracked and not ignored, and architecture topic Covers entries. Compares the branch with its default-branch merge-base, or the working tree when no comparison applies. Claude Code only.
 # summary: Stops an agent at the end of its turn when documents covering the code it changed did not change or an architecture topic names a path that does not exist, and hands it the list. Where some topic declares a Covers entry, changed code with no covering document is named too.
-# safety: Reads the payload, git state, the topic files and git's listing of what each Covers entry matches; the only write is the per-set marker under the repository's git common dir. Exit 2 names the findings and asks for each document to be confirmed or updated and each entry or path to be corrected, never bypassed. jq reads the payload and a sha256 tool names the set; every command the hook runs is checked before it is called, the payload readers ahead of the payload and the rest after `stop_hook_active` has been read, so a discovery command's absence costs one retry rather than refusing the retry too; only a missing payload reader refuses that as well, the flag being in the payload it cannot read. A payload, git state or marker the hook cannot read or write is refused, never passed. Every refusal opens with `doc-drift-check: <key>=<value>`; what a command this hook runs writes is captured at the site and replayed under that line, so nothing precedes the key.
+# safety: Reads the payload, git state, the topic files, the render inventory `.kendex-generated.json` and git's listing of what each Covers entry matches; the only write is the per-set marker under the repository's git common dir. Exit 2 names the findings and asks for each document to be confirmed or updated and each entry or path to be corrected, never bypassed. jq reads the payload and a sha256 tool names the set; every command the hook runs is checked before it is called, the payload readers ahead of the payload and the rest after `stop_hook_active` has been read, so a discovery command's absence costs one retry rather than refusing the retry too; only a missing payload reader refuses that as well, the flag being in the payload it cannot read. A payload, git state, render inventory or marker the hook cannot read or write is refused, never passed. Every refusal opens with `doc-drift-check: <key>=<value>`; what a command this hook runs writes is captured at the site and replayed under that line, so nothing precedes the key.
 # timeout: 30
 # harnesses: [claude-code]
 # ---
@@ -75,6 +75,12 @@ refuse() { # KEY VALUE [DETAIL], or `drift` alone
         ;;
       payload=invalid-json)
         printf 'the hook payload is not valid JSON, or a field it reads is not a string; refusing rather than skipping the check\n'
+        ;;
+      inventory=unreadable)
+        printf 'the render inventory .kendex-generated.json is present and could not be read\n'
+        ;;
+      inventory=invalid-json)
+        printf 'the render inventory .kendex-generated.json is not a JSON array of non-empty path strings; refusing rather than judging every render as code no document covers\n'
         ;;
       session-id=invalid)
         printf 'the payload carries no usable session_id, so naming these documents could not be recorded; refusing\n'
@@ -311,6 +317,32 @@ fi
 CODE_CHANGED=$(printf '%s\n' "$ALL_CHANGED" | sed '/\.md$/d' 2>&1) ||
   refuse exit "$?" "$CODE_CHANGED"
 
+# What kendex rendered into this repository, one path per line. The render
+# writer keeps this inventory and is the one judge of whether a path is a
+# render, so the hook reads it rather than matching harness directory names of
+# its own. A render is never the thing a document covers — the source it was
+# rendered from is — so a changed render is not named uncovered below.
+#
+# The read discipline is the one commit-guards' suppression-ban applies to the
+# same file: an absent inventory is a repository with nothing rendered and
+# excludes nothing, while a present one that does not parse is refused rather
+# than read as empty, which would name every render as uncovered and say
+# nothing about why. It is read from the working tree, as the topic files are:
+# a refresh writes the inventory and the renders it lists together, so the
+# working-tree copy is the one that describes the renders being judged.
+GENERATED=""
+INVENTORY="$REPO_ROOT/.kendex-generated.json"
+if [ -f "$INVENTORY" ]; then
+  # cat's and jq's own words are captured where each is read, so a failure
+  # reaches the refusal under its keyed line rather than ahead of it. Both are
+  # silent when they succeed.
+  INVENTORY_JSON=$(cat -- "$INVENTORY" 2>&1) || refuse inventory unreadable "$INVENTORY_JSON"
+  GENERATED=$(printf '%s' "$INVENTORY_JSON" | jq -r '
+    if type == "array" and all(.[]; type == "string" and length > 0)
+    then .[] else "" | halt_error(21) end' 2>&1) ||
+    refuse inventory invalid-json "$GENERATED"
+fi
+
 # Covering docs. `:(top)` roots the pattern at the repository whatever the
 # cwd, and `*` crosses `/`, so this is every AGENTS.md below the root and
 # not the root's own, which covers nothing. Untracked non-ignored ones count,
@@ -416,6 +448,8 @@ EOF
 # repository without one has no map to be incomplete, and naming every changed
 # path there would block each stop of a repository that never adopted topics.
 # A deleted path is never uncovered: an entry added for it would match nothing.
+# Nor is a render the inventory lists: the document to correct covers its
+# source, and an entry added for the render would name a generated file.
 while IFS= read -r path; do
   # An empty code set reads as one empty line.
   [ -n "$path" ] || continue
@@ -423,6 +457,7 @@ while IFS= read -r path; do
   if [ -z "$docs" ]; then
     [ -n "$COVERS" ] || continue
     on_disk "$path" || continue
+    in_list "$GENERATED" "$path" && continue
     NAMED="$NAMED"uncovered$'\t'"$path"$'\n'
     UNCOVERED="$UNCOVERED  $path"$'\n'
     UNCOVERED_COUNT=$((UNCOVERED_COUNT + 1))

--- a/hooks/tests/doc-drift-check.test.sh
+++ b/hooks/tests/doc-drift-check.test.sh
@@ -4,7 +4,8 @@
 # above it, tracked or untracked, and every topic file whose Covers entry
 # reaches it; a covering doc left unchanged, a Covers entry no path on disk
 # matches, and a changed path on disk no doc covers where some topic declares
-# an entry are each named
+# an entry and the render inventory `.kendex-generated.json` does not list it
+# are each named
 # once on stderr with exit 2, the channel the harness gives Claude, and stdout
 # stays empty. The set is recorded under
 # `<git common dir>/kendex/doc-drift/<session_id>-<digest>`, so a later stop
@@ -193,6 +194,11 @@ build() { # WORLD — the row's repository, its run directory and PATH
         seal
         ;;
       file-topic) printf '# Selected path\n\nCovers: ui/src/app.ts\n' >"$REPO/docs/architecture/selected.md"; seal ;;
+      # The render inventory kendex writes, listing one of the two paths no
+      # document covers, so one row asks what a render does and the other what
+      # a path the same inventory does not list still does.
+      generated) printf '["top.rs"]\n' >"$REPO/.kendex-generated.json"; seal ;;
+      bad-generated) printf 'not json\n' >"$REPO/.kendex-generated.json"; seal ;;
       root-topic) printf '# All\n\nCovers: . ./ /\n' >"$REPO/docs/architecture/all.md"; seal ;;
       with-master) fgit -C "$REPO" branch master ;;
       master) fgit -C "$REPO" branch -m main master ;;
@@ -422,6 +428,8 @@ an entry naming a file deleted and not yet staged is named|repo file-topic|rm-ui
 a glob entry is satisfied by a path its * reaches across /|repo glob-topic|md|0|-|-
 an entry whose only match is an untracked new file is satisfied|repo|covered-new|0|-|-
 a changed path no doc covers is named|repo|top|2|top.rs|uncovered=1;base=default-branch
+a changed path the render inventory lists is a render, not uncovered|repo generated|top|0|-|-
+a changed path the same inventory does not list is still uncovered|repo generated|ui|2|ui/src/app.ts|uncovered=1;base=default-branch
 a deleted path no doc covers is not named|repo|rm-ui|0|-|-
 an untracked AGENTS.md covers the new code beside it|repo|newpkg|0|-|-
 an AGENTS.md deleted and not yet staged no longer covers the code beside it|repo ui-agents|rm-ui-agents ui|2|ui/src/app.ts|uncovered=1;base=default-branch
@@ -468,6 +476,7 @@ a default-branch probe git cannot answer is not read as absent|clone break:symbo
 a payload that cannot be read|repo break:cat|code|stop|2|-|payload=unreadable;fixture: cat failed
 a payload that is not JSON|repo|code|raw|2|-|payload=invalid-json
 a jq that cannot answer for the payload, with its own words below|repo break:jq|code|stop|2|-|payload=invalid-json;fixture: jq failed
+an inventory that does not parse is not read as nothing rendered|repo bad-generated|top|stop|2|-|inventory=invalid-json
 a payload carrying no session id|repo|code|noid|2|-|session-id=invalid
 a marker that cannot be recorded|repo sealed-marker|code|stop|2|-|marker=<path>
 no command the hook runs on PATH names the payload readers alone|repo nopath|code|stop|2|-|missing-tools=jq,cat

--- a/hooks/tests/doc-drift-check.test.sh
+++ b/hooks/tests/doc-drift-check.test.sh
@@ -198,7 +198,7 @@ build() { # WORLD — the row's repository, its run directory and PATH
       # document covers, so one row asks what a render does and the other what
       # a path the same inventory does not list still does.
       generated) printf '["top.rs"]\n' >"$REPO/.kendex-generated.json"; seal ;;
-      bad-generated) printf 'not json\n' >"$REPO/.kendex-generated.json"; seal ;;
+      empty-generated) : >"$REPO/.kendex-generated.json"; seal ;;
       root-topic) printf '# All\n\nCovers: . ./ /\n' >"$REPO/docs/architecture/all.md"; seal ;;
       with-master) fgit -C "$REPO" branch master ;;
       master) fgit -C "$REPO" branch -m main master ;;
@@ -476,7 +476,7 @@ a default-branch probe git cannot answer is not read as absent|clone break:symbo
 a payload that cannot be read|repo break:cat|code|stop|2|-|payload=unreadable;fixture: cat failed
 a payload that is not JSON|repo|code|raw|2|-|payload=invalid-json
 a jq that cannot answer for the payload, with its own words below|repo break:jq|code|stop|2|-|payload=invalid-json;fixture: jq failed
-an inventory that does not parse is not read as nothing rendered|repo bad-generated|top|stop|2|-|inventory=invalid-json
+an inventory holding no document is not read as nothing rendered|repo empty-generated|top|stop|2|-|inventory=invalid-json
 a payload carrying no session id|repo|code|noid|2|-|session-id=invalid
 a marker that cannot be recorded|repo sealed-marker|code|stop|2|-|marker=<path>
 no command the hook runs on PATH names the payload readers alone|repo nopath|code|stop|2|-|missing-tools=jq,cat

--- a/tools/AGENTS.md
+++ b/tools/AGENTS.md
@@ -1,0 +1,10 @@
+# tools/
+
+This repository's own scripts and the exclusion lists its commit guards read. Nothing here is catalog content: these run in this repository's commit chain and in CI, never on a consumer's machine.
+
+- Each script has its suite at `tests/<n>.test.sh`, and the guards shard of `../.github/workflows/skill-tests.yml` runs them.
+- An exclusion list is `<n>-excludes`, read by the one commit-guards lane named in its own header; the row format and what may be excluded are [`../skills/commit-guards/SKILL.md`](../skills/commit-guards/SKILL.md).
+- `guard` and `setup` are described in the root [`../AGENTS.md`](../AGENTS.md) § Commands; `guard` is where a repo-specific rule is added, one lane per rule.
+- `bash32-lint` and `bash32-parse` hold this directory and the shell the catalog ships to Bash 3.2; where each runs is [`../skills/AGENTS.md`](../skills/AGENTS.md).
+- `release-digests` and `release-channel-point` belong to the release feed, which [`../docs/architecture/updates.md`](../docs/architecture/updates.md) covers.
+- `harness-smoke` answers which harness CLIs are usable on the machine it runs on; it reads installed CLIs and writes nothing to the repository.

--- a/tools/AGENTS.md
+++ b/tools/AGENTS.md
@@ -2,7 +2,7 @@
 
 This repository's own scripts and the exclusion lists its commit guards read. Nothing here is catalog content: these run in this repository's commit chain and in CI, never on a consumer's machine.
 
-- Each script has its suite at `tests/<n>.test.sh`, and the guards shard of `../.github/workflows/skill-tests.yml` runs them.
+- A script's suite belongs at `tests/<n>.test.sh`, where the guards shard of `../.github/workflows/skill-tests.yml` runs it; `release-channel-point` is the one script with none, exercised from [`../crates/cli/tests/release_workflow/`](../crates/cli/tests/release_workflow/) instead.
 - An exclusion list is `<n>-excludes`, read by the one commit-guards lane named in its own header; the row format and what may be excluded are [`../skills/commit-guards/SKILL.md`](../skills/commit-guards/SKILL.md).
 - `guard` and `setup` are described in the root [`../AGENTS.md`](../AGENTS.md) § Commands; `guard` is where a repo-specific rule is added, one lane per rule.
 - `bash32-lint` and `bash32-parse` hold this directory and the shell the catalog ships to Bash 3.2; where each runs is [`../skills/AGENTS.md`](../skills/AGENTS.md).

--- a/tools/CLAUDE.md
+++ b/tools/CLAUDE.md
@@ -1,0 +1,1 @@
+@AGENTS.md


### PR DESCRIPTION
## Summary
- `hooks/doc-drift-check.sh` reads the repository's `.kendex-generated.json` and never names a path that inventory lists as uncovered: a render is covered through the source it was rendered from. The read discipline is suppression-ban's: an absent inventory excludes nothing; a present one that cannot be read, or is not exactly one JSON array of non-empty newline-free path strings (the shape commit-guards' generated-paths.sh applies, so an empty or truncated file is refused rather than read as nothing rendered), refuses with `doc-drift-check: inventory=unreadable` / `inventory=invalid-json` as the first line rather than being read as nothing rendered. The render under `.claude/hooks/` lands byte-identical in the same commit.
- In kendex, `tools/` and `.github/` each get a non-root `AGENTS.md` (plus the `CLAUDE.md` shim kendex writes beside every tracked one), and `docs/architecture/overview.md` carries a `Covers:` entry for `Cargo.toml` and `Cargo.lock`, the workspace its Boundaries and Stack sections describe. Root `AGENTS.md` § Read next points at the two new directory docs.
- Three rows in `hooks/tests/doc-drift-check.test.sh`: a changed path the inventory lists is not uncovered; the same path absent from the inventory is still named `uncovered=1`; an inventory holding no document refuses `inventory=invalid-json` with exit 2.

## Done-when map
- Hook reads the inventory, one control per direction: `hooks/doc-drift-check.sh`, `.claude/hooks/doc-drift-check.sh`, `hooks/tests/doc-drift-check.test.sh`.
- kendex covers tools/, .github/ and the root Cargo files: `tools/AGENTS.md`, `tools/CLAUDE.md`, `.github/AGENTS.md`, `.github/CLAUDE.md`, `docs/architecture/overview.md`, `AGENTS.md`.

## Corrections to the issue
- `agents/` and `commands/` hold only markdown, and the hook drops every `.md` path from the changed-code set before judging coverage, so neither has ever been named uncovered. A bare run on this tree with a planted file under each of the five named paths named exactly three: `.github/workflows/`, `Cargo.toml` and `tools/`. No coverage was added for `agents/` or `commands/`; an entry there would match nothing a run judges.
- The exclusion applies to the uncovered kind alone, not the stale kind. A change under `tools/`, `.github/` or to the Cargo pair now meets the hook's ordinary once-per-set stale ask on its covering document, the same ask every path under `crates/` meets through its `AGENTS.md`. The Done-when's "passes the stop" is read as "is no longer nameless": the stale set is keyed on the document, so several changed files under one document are one block, and the agent is the party who can confirm or update the document. A silent pass for mechanical churn such as a `Cargo.lock` bump would be a change to the stale kind, not to coverage, and is not made here.
- The inventory is read from the working tree, not the index as the pre-commit suppression-ban lane reads it: this hook measures the working tree and already reads the topic files from it, and a refresh writes the inventory and the renders it lists together.

## Completed Issues
- Closes KEN-1340 - doc-drift-check names rendered harness files and kendex's own tools, .github, agents, commands and Cargo paths as uncovered at every stop

## Review
- PR round 1 (Copilot): two threads, both fixed in a06dd48a2: the inventory read now slurps and counts documents, and `.github/AGENTS.md` names where each rendered instruction file carries its generator marker.
- Local round: reviewer-correctness, verdict pass, no blockers. Its one fix suggestion (a false fact in `tools/AGENTS.md` about which scripts have a suite) is fixed in 211cce3bc. Its two issue-category suggestions are outside this issue's enumeration and reported to the owner: root non-markdown files other than the Cargo pair (`kendex.toml`, `kendex-local.toml`, `kendex.settings.toml`, `install.sh`, `skills-lock.json`, `.gitignore`, `clippy.toml`, `rust-toolchain.toml`, `.gitattributes`, `.nvmrc`, `LICENSE`) are still named uncovered; and the uncovered-to-stale reading above.
- `.kendex-generated.json` does not yet list `tools/CLAUDE.md` and `.github/CLAUDE.md`; both hold exactly the bytes the shim writer emits, so the engine reads them as in sync and the owner's next `kendex refresh` adds the two rows. A refresh cannot run from a linked worktree.

## Size
production=65 tests=10 mirror=37; the issue states no allowance.

## Test Plan
- `hooks/tests/doc-drift-check.test.sh` passes with the three new rows.
- `env -u TMPDIR tools/guard --full` on the final head exits 0 (`tmp/guard-full-2.log`), no `guard:` lines.
- `preflight --base origin/main` clean across the 9 changed files.
- `cmp hooks/doc-drift-check.sh .claude/hooks/doc-drift-check.sh` identical.

https://claude.ai/code/session_01TLV5b1khLanYfRTYa6XyRx
