### PR TITLE
fix(KEN-1342): orch waiters bind the repository from the working directory and ignore GH_REPO, returning another repository's verdict

### DIFF
--- a/.agents/skills/orch/scripts/approval-wait
+++ b/.agents/skills/orch/scripts/approval-wait
@@ -23,7 +23,11 @@ approval_message() {
       ;;
     repo-unresolved)
       printf 'approval-wait: repo-unresolved remote=%s\n' "origin"
-      printf '%s\n' "could not resolve GitHub repo (gh repo view and git remote both failed)"
+      printf '%s\n' "could not resolve GitHub repo (GH_REPO unset, gh repo view and git remote both failed)"
+      ;;
+    repo-shape)
+      printf 'approval-wait: repo-shape repo=%q\n' "$REPO"
+      printf '%s\n' "could not read '$REPO' as owner/repo for the review-gate queries"
       ;;
     pr-view-failed)
       printf 'approval-wait: pr-view-failed pr=%s repo=%s\n' "$PR_NUM" "$REPO"
@@ -104,6 +108,13 @@ export PROJECT_ROOT
 
 # shellcheck source=lib/gh-auth.sh
 source "$SCRIPT_DIR/lib/gh-auth.sh"
+# shellcheck source=lib/gh-repo.sh
+source "$SCRIPT_DIR/lib/gh-repo.sh"
+
+# Named in every result, so a verdict states the repository it read. Empty
+# until the resolver below runs, which is after the auth ladder: an auth
+# failure is a verdict about no repository.
+REPO=""
 # shellcheck source=lib/review-threads.sh
 source "$SCRIPT_DIR/lib/review-threads.sh"
 
@@ -257,6 +268,9 @@ JSON output (always when --json):
   {
     "status": "approved" | "reviewed" | "changes_requested" | "comments"
               | "timeout" | "proceeded" | "unreviewable" | "error",
+    "repo": <string>,             # the repository this verdict is about,
+                                  # "" only when the wait ended before it
+                                  # was resolved (missing gh, no auth)
     "review_decision": <string>,  # raw reviewDecision ("" when unset)
     "approvals": <int>,           # reviewers whose latest review is APPROVED
     "changes_requested": <int>,   # reviewers at CHANGES_REQUESTED
@@ -277,6 +291,14 @@ JSON output (always when --json):
     "transient_api_errors": <int>,  # only when > 0
     "error": <string>             # only when status == "error"
   }
+
+Repository: resolved through lib/gh-repo.sh, shared with ci-wait and
+queue-wait — GH_REPO first, then the working directory (`gh repo view`, then
+the origin remote) when GH_REPO is unset. `gh repo view` ignores GH_REPO and
+answers for the working directory, so a wait on another repository's PR from
+this checkout reads GH_REPO or nothing else will. Every result names the
+repository it read; a GH_REPO that is not owner/name is refused (repo-shape,
+exit 1) rather than sent to an API path that cannot hold it.
 
 Auth: resolved through lib/gh-auth.sh, shared with ci-wait and queue-wait
 (kendex#19) — env-first: already-resolved GH_TOKEN/GITHUB_TOKEN/GH_BOT_TOKEN
@@ -566,6 +588,7 @@ emit_result() {
     fi
     jq -n \
       --arg s "$status" \
+      --arg repo "$REPO" \
       --arg decision "$last_review_decision" \
       --arg base_ref "$last_base_ref" \
       --argjson auto_targeted "$last_auto_review_targeted" \
@@ -580,6 +603,7 @@ emit_result() {
       --arg error "$error_msg" \
       '{
         status: $s,
+        repo: $repo,
         review_decision: $decision,
         approvals: $approvals,
         changes_requested: $changes,
@@ -594,7 +618,7 @@ emit_result() {
         + (if $error == "" then {} else {error: $error} end)' || return $?
     return 0
   fi
-  printf 'approval-wait: result status=%s pr=%s mode=%s elapsed=%s unresolved=%s\n' "$status" "$PR_NUM" "$MODE" "$elapsed" "$last_unresolved"
+  printf 'approval-wait: result status=%s pr=%s repo=%s mode=%s elapsed=%s unresolved=%s\n' "$status" "$PR_NUM" "${REPO:-unresolved}" "$MODE" "$elapsed" "$last_unresolved"
   case "$status" in
     approved)
       echo "Approval: approved (decision: ${last_review_decision:-none}, approvals: $last_approvals, unresolved threads: $last_unresolved)"
@@ -711,14 +735,14 @@ if [[ "$AUTH_READY" != "true" ]]; then
 fi
 
 # --- Resolve repo explicitly so gh calls don't depend on local auth/inference ---
-REPO=$(gh repo view --json nameWithOwner -q .nameWithOwner 2>/dev/null || true)
-if [ -z "$REPO" ]; then
-  origin_url=$(git -C "$PROJECT_ROOT" remote get-url origin 2>/dev/null || true)
-  # Strip a trailing ".git" with parameter expansion, not the ERE.
-  REPO=$(echo "$origin_url" | sed -nE 's#^.*github\.com[:/]+([^/]+/[^/]+)$#\1#p')
-  REPO="${REPO%.git}"
+repo_status=0
+REPO=$(orch_resolve_gh_repo "$PROJECT_ROOT") || repo_status=$?
+if [ "$repo_status" -eq 2 ]; then
+  emit_error repo-shape
+
+  exit 1
 fi
-if [ -z "$REPO" ]; then
+if [ "$repo_status" -ne 0 ]; then
   emit_error repo-unresolved
 
   exit 1

--- a/.agents/skills/orch/scripts/approval-wait
+++ b/.agents/skills/orch/scripts/approval-wait
@@ -26,8 +26,8 @@ approval_message() {
       printf '%s\n' "could not resolve GitHub repo (GH_REPO unset, gh repo view and git remote both failed)"
       ;;
     repo-shape)
-      printf 'approval-wait: repo-shape repo=%q\n' "$REPO"
-      printf '%s\n' "could not read '$REPO' as owner/repo for the review-gate queries"
+      printf 'approval-wait: repo-shape repo=%q\n' "$REPO_REJECTED"
+      printf '%s\n' "could not read '$REPO_REJECTED' as owner/repo for the review-gate queries"
       ;;
     pr-view-failed)
       printf 'approval-wait: pr-view-failed pr=%s repo=%s\n' "$PR_NUM" "$REPO"
@@ -113,8 +113,11 @@ source "$SCRIPT_DIR/lib/gh-repo.sh"
 
 # Named in every result, so a verdict states the repository it read. Empty
 # until the resolver below runs, which is after the auth ladder: an auth
-# failure is a verdict about no repository.
+# failure is a verdict about no repository. A candidate the resolver refuses
+# is no repository either: it lands in REPO_REJECTED for the diagnostic to
+# name, never in REPO, so no consumer reads it as one that resolved.
 REPO=""
+REPO_REJECTED=""
 # shellcheck source=lib/review-threads.sh
 source "$SCRIPT_DIR/lib/review-threads.sh"
 
@@ -269,8 +272,9 @@ JSON output (always when --json):
     "status": "approved" | "reviewed" | "changes_requested" | "comments"
               | "timeout" | "proceeded" | "unreviewable" | "error",
     "repo": <string>,             # the repository this verdict is about,
-                                  # "" only when the wait ended before it
-                                  # was resolved (missing gh, no auth)
+                                  # "" whenever the wait ended before one
+                                  # was resolved: missing gh, no auth,
+                                  # repo-unresolved, repo-shape
     "review_decision": <string>,  # raw reviewDecision ("" when unset)
     "approvals": <int>,           # reviewers whose latest review is APPROVED
     "changes_requested": <int>,   # reviewers at CHANGES_REQUESTED
@@ -298,7 +302,9 @@ the origin remote) when GH_REPO is unset. `gh repo view` ignores GH_REPO and
 answers for the working directory, so a wait on another repository's PR from
 this checkout reads GH_REPO or nothing else will. Every result names the
 repository it read; a GH_REPO that is not owner/name is refused (repo-shape,
-exit 1) rather than sent to an API path that cannot hold it.
+exit 1) rather than sent to an API path that cannot hold it. The
+refusal names the rejected value in its diagnostic line and leaves the JSON
+`repo` field empty, since a refusal is a verdict about no repository.
 
 Auth: resolved through lib/gh-auth.sh, shared with ci-wait and queue-wait
 (kendex#19) — env-first: already-resolved GH_TOKEN/GITHUB_TOKEN/GH_BOT_TOKEN
@@ -738,6 +744,8 @@ fi
 repo_status=0
 REPO=$(orch_resolve_gh_repo "$PROJECT_ROOT") || repo_status=$?
 if [ "$repo_status" -eq 2 ]; then
+  REPO_REJECTED="$REPO"
+  REPO=""
   emit_error repo-shape
 
   exit 1

--- a/.agents/skills/orch/scripts/ci-wait
+++ b/.agents/skills/orch/scripts/ci-wait
@@ -70,8 +70,8 @@ ci_message() {
       printf '%s\n' "Could not resolve GitHub repo (GH_REPO unset, gh repo view and git remote both failed)"
       ;;
     repo-shape)
-      printf 'ci-wait: repo-shape repo=%q\n' "$REPO"
-      printf '%s\n' "could not read '$REPO' as owner/repo for the check queries"
+      printf 'ci-wait: repo-shape repo=%q\n' "$REPO_REJECTED"
+      printf '%s\n' "could not read '$REPO_REJECTED' as owner/repo for the check queries"
       ;;
     conflicting)
       printf 'ci-wait: conflicting pr=%s state=%s\n' "$PR_NUM" "$merge_state"
@@ -146,8 +146,11 @@ source "$SCRIPT_DIR/lib/gh-repo.sh"
 
 # Named in every result, so a verdict states the repository it read. Empty
 # until the resolver below runs, which is after the auth ladder: an auth
-# failure is a verdict about no repository.
+# failure is a verdict about no repository. A candidate the resolver refuses
+# is no repository either: it lands in REPO_REJECTED for the diagnostic to
+# name, never in REPO, so no consumer reads it as one that resolved.
 REPO=""
+REPO_REJECTED=""
 
 print_usage() {
   cat <<'USAGE'
@@ -194,8 +197,9 @@ JSON output (always when --json):
     "status": "complete" | "timeout" | "error",
     "verdict": "pass" | "fail" | "pending" | "none",
     "repo": <string>,             # the repository this verdict is about,
-                                  # "" only when the wait ended before it
-                                  # was resolved (missing gh, no auth)
+                                  # "" whenever the wait ended before one
+                                  # was resolved: missing gh, no auth,
+                                  # repo-unresolved, repo-shape
     "elapsed_seconds": <int>,
     "error": <string>,            # only when status == "error"
     "pending_checks": [ {name,state} ... ],
@@ -220,7 +224,9 @@ the origin remote) when GH_REPO is unset. `gh repo view` ignores GH_REPO and
 answers for the working directory, so a wait on another repository's PR from
 this checkout reads GH_REPO or nothing else will. Every result names the
 repository it read; a GH_REPO that is not owner/name is refused (repo-shape,
-exit 1) rather than sent to an API path that cannot hold it.
+exit 1) rather than sent to an API path that cannot hold it. The
+refusal names the rejected value in its diagnostic line and leaves the JSON
+`repo` field empty, since a refusal is a verdict about no repository.
 
 Auth: resolved through lib/gh-auth.sh, shared with approval-wait and
 queue-wait (kendex#19) — env-first: already-resolved GH_TOKEN /
@@ -420,6 +426,8 @@ fi
 repo_status=0
 REPO=$(orch_resolve_gh_repo "$PROJECT_ROOT") || repo_status=$?
 if [ "$repo_status" -eq 2 ]; then
+  REPO_REJECTED="$REPO"
+  REPO=""
   emit_error repo-shape
   ci_message repo-shape "$@" >&2
   exit 1

--- a/.agents/skills/orch/scripts/ci-wait
+++ b/.agents/skills/orch/scripts/ci-wait
@@ -30,19 +30,19 @@ ci_message() {
       printf '%s\n' "ci-wait: max_wait must be a positive integer (got '$MAX_WAIT')"
       ;;
     passed)
-      printf 'ci-wait: passed pr=%s\n' "$PR_NUM"
+      printf 'ci-wait: passed pr=%s repo=%s\n' "$PR_NUM" "${REPO:-unresolved}"
       printf '%s\n' "CI passed"
       ;;
     failed)
-      printf 'ci-wait: failed pr=%s\n' "$PR_NUM"
+      printf 'ci-wait: failed pr=%s repo=%s\n' "$PR_NUM" "${REPO:-unresolved}"
       printf '%s\n' "CI failed:"
       ;;
     timeout)
-      printf 'ci-wait: timeout elapsed=%s verdict=%s\n' "$elapsed" "$verdict"
+      printf 'ci-wait: timeout elapsed=%s verdict=%s repo=%s\n' "$elapsed" "$verdict" "${REPO:-unresolved}"
       printf '%s\n' "CI timeout after ${elapsed}s (verdict: $verdict)"
       ;;
     error)
-      printf 'ci-wait: error pr=%s\n' "$PR_NUM"
+      printf 'ci-wait: error pr=%s repo=%s\n' "$PR_NUM" "${REPO:-unresolved}"
       printf '%s\n' "CI error: $error_msg"
       ;;
     missing-gh)
@@ -67,7 +67,11 @@ ci_message() {
       ;;
     repo-unresolved)
       printf 'ci-wait: repo-unresolved remote=%s\n' "origin"
-      printf '%s\n' "Could not resolve GitHub repo (gh repo view and git remote both failed)"
+      printf '%s\n' "Could not resolve GitHub repo (GH_REPO unset, gh repo view and git remote both failed)"
+      ;;
+    repo-shape)
+      printf 'ci-wait: repo-shape repo=%q\n' "$REPO"
+      printf '%s\n' "could not read '$REPO' as owner/repo for the check queries"
       ;;
     conflicting)
       printf 'ci-wait: conflicting pr=%s state=%s\n' "$PR_NUM" "$merge_state"
@@ -137,6 +141,13 @@ PROJECT_ROOT="$(git rev-parse --show-toplevel 2>/dev/null || pwd)"
 
 # shellcheck source=lib/gh-auth.sh
 source "$SCRIPT_DIR/lib/gh-auth.sh"
+# shellcheck source=lib/gh-repo.sh
+source "$SCRIPT_DIR/lib/gh-repo.sh"
+
+# Named in every result, so a verdict states the repository it read. Empty
+# until the resolver below runs, which is after the auth ladder: an auth
+# failure is a verdict about no repository.
+REPO=""
 
 print_usage() {
   cat <<'USAGE'
@@ -182,6 +193,9 @@ JSON output (always when --json):
   {
     "status": "complete" | "timeout" | "error",
     "verdict": "pass" | "fail" | "pending" | "none",
+    "repo": <string>,             # the repository this verdict is about,
+                                  # "" only when the wait ended before it
+                                  # was resolved (missing gh, no auth)
     "elapsed_seconds": <int>,
     "error": <string>,            # only when status == "error"
     "pending_checks": [ {name,state} ... ],
@@ -199,6 +213,14 @@ Environment:
                 can lag. Within the grace window the result stays verdict
                 "pending"; past it, the explicit "no checks registered"
                 diagnostic fires.
+
+Repository: resolved through lib/gh-repo.sh, shared with approval-wait and
+queue-wait — GH_REPO first, then the working directory (`gh repo view`, then
+the origin remote) when GH_REPO is unset. `gh repo view` ignores GH_REPO and
+answers for the working directory, so a wait on another repository's PR from
+this checkout reads GH_REPO or nothing else will. Every result names the
+repository it read; a GH_REPO that is not owner/name is refused (repo-shape,
+exit 1) rather than sent to an API path that cannot hold it.
 
 Auth: resolved through lib/gh-auth.sh, shared with approval-wait and
 queue-wait (kendex#19) — env-first: already-resolved GH_TOKEN /
@@ -297,12 +319,14 @@ emit_result() {
     jq -n \
       --arg s "$status" \
       --arg v "$verdict" \
+      --arg repo "$REPO" \
       --argjson elapsed "$elapsed" \
       --arg error "$error_msg" \
       --argjson classes "$(jq -c 'map_values(map({name, state: (.state // .bucket // "UNKNOWN")}))' <<<"$classes")" \
       '{
         status: $s,
         verdict: $v,
+        repo: $repo,
         elapsed_seconds: $elapsed,
         pending_checks: $classes.pending,
         failed_checks: $classes.failed,
@@ -393,19 +417,14 @@ if [[ "$AUTH_READY" != "true" ]]; then
 fi
 
 # --- Resolve repo explicitly so gh calls don't depend on local auth/inference ---
-REPO=$(gh repo view --json nameWithOwner -q .nameWithOwner 2>/dev/null || true)
-if [ -z "$REPO" ]; then
-  origin_url=$(git -C "$PROJECT_ROOT" remote get-url origin 2>/dev/null || true)
-  # Capture owner/repo greedily, then strip a trailing ".git" explicitly. GNU
-  # sed / POSIX ERE has no non-greedy quantifier, so a `[^/]+?(\.git)?$` pattern
-  # would greedily swallow ".git" into the slug. Do the suffix
-  # strip with bash parameter expansion instead — portable for both SSH
-  # (git@github.com:owner/repo.git) and HTTPS origins, with or without ".git",
-  # and safe for repo names that merely contain the substring "git".
-  REPO=$(echo "$origin_url" | sed -nE 's#^.*github\.com[:/]+([^/]+/[^/]+)$#\1#p')
-  REPO="${REPO%.git}"
+repo_status=0
+REPO=$(orch_resolve_gh_repo "$PROJECT_ROOT") || repo_status=$?
+if [ "$repo_status" -eq 2 ]; then
+  emit_error repo-shape
+  ci_message repo-shape "$@" >&2
+  exit 1
 fi
-if [ -z "$REPO" ]; then
+if [ "$repo_status" -ne 0 ]; then
   emit_error repo-unresolved
   ci_message repo-unresolved "$@" >&2
   exit 1

--- a/.agents/skills/orch/scripts/ci-wait
+++ b/.agents/skills/orch/scripts/ci-wait
@@ -110,7 +110,7 @@ ci_message() {
       printf '%s\n' "no-CI probe inconclusive ($probe_name not probed: the PR's $probe_input lookup failed); continuing to wait for checks"
       ;;
     none-configured)
-      printf 'ci-wait: none-configured base=%s\n' "$base_branch"
+      printf 'ci-wait: none-configured base=%s repo=%s\n' "$base_branch" "$REPO"
       printf '%s\n' "CI: none configured (no active workflows, no required checks on $base_branch)"
       ;;
     no-checks)
@@ -690,8 +690,13 @@ while [ "$elapsed" -lt "$MAX_WAIT" ]; do
       if [ "$wf_count" = "0" ] && [ "$protected" = "false" ] && [ "$rule_checks" = "0" ] && [ "$ext_statuses" = "0" ]; then
         update_elapsed
         if $JSON_OUTPUT; then
-          jq -n --argjson elapsed "$elapsed" --arg base "$base_branch" \
-            '{status: "complete", verdict: "none", elapsed_seconds: $elapsed,
+          # emit_result derives its verdict from the check classes and carries
+          # no reason, neither of which this route can say, so it builds its
+          # own object. Every field it shares with emit_result, repo included,
+          # holds the same value there: this verdict names the repository it
+          # read like every other one.
+          jq -n --argjson elapsed "$elapsed" --arg base "$base_branch" --arg repo "$REPO" \
+            '{status: "complete", verdict: "none", repo: $repo, elapsed_seconds: $elapsed,
               reason: ("no CI configured: no active workflows and no required checks on " + $base),
               pending_checks: [], failed_checks: [], passed_checks: []}'
         else

--- a/.agents/skills/orch/scripts/lib/gh-repo.sh
+++ b/.agents/skills/orch/scripts/lib/gh-repo.sh
@@ -1,0 +1,56 @@
+# shellcheck shell=bash
+#
+# The repository the orch waiters read, resolved in one place.
+#
+# Source this file; do not execute it directly.
+
+# Resolve the owner/name slug every `gh --repo` argument and `repos/<slug>/`
+# API path in a waiter carries, so one value decides which repository a
+# verdict is about.
+#
+# GH_REPO wins. `gh repo view` resolves from the working directory and ignores
+# GH_REPO (gh 2.100), unlike `gh pr view` and the rest, so a caller waiting on
+# another repository's PR from this checkout would otherwise be handed this
+# checkout's repository and a verdict about its same-numbered pull request.
+# With GH_REPO unset, the working directory answers: `gh repo view` first, then
+# the origin remote for a checkout gh cannot resolve.
+#
+# Arguments: the project root whose origin remote the fallback reads.
+# Stdout: the resolved slug, or the rejected candidate on exit 2.
+# Exit: 0 resolved, 1 nothing resolved, 2 resolved to something that is not
+# owner/name — two non-empty segments around a single slash, which is what an
+# API path and a `--repo` argument accept.
+orch_resolve_gh_repo() {
+  local project_root="${1:?orch_resolve_gh_repo: project_root required}"
+  local repo origin_url origin_status
+
+  if [ -n "${GH_REPO:-}" ]; then
+    repo="$GH_REPO"
+  else
+    repo=$(gh repo view --json nameWithOwner -q .nameWithOwner 2>/dev/null || true)
+    if [ -z "$repo" ]; then
+      origin_status=0
+      origin_url=$(git -C "$project_root" remote get-url origin 2>/dev/null) || origin_status=$?
+      # git answers 2 for "no such remote" — a checkout with no origin. Any
+      # other status means git could not answer at all, most often because the
+      # project root is no repository. Neither resolves anything, and the
+      # caller refuses on that rather than falling back to a repository
+      # nobody named.
+      [ "$origin_status" -eq 0 ] || return 1
+      # Capture owner/repo greedily, then strip a trailing ".git" explicitly.
+      # GNU sed / POSIX ERE has no non-greedy quantifier, so a
+      # `[^/]+?(\.git)?$` pattern would greedily swallow ".git" into the slug.
+      # Do the suffix strip with bash parameter expansion instead — portable
+      # for both SSH (git@github.com:owner/repo.git) and HTTPS origins, with
+      # or without ".git", and safe for repo names that merely contain the
+      # substring "git".
+      repo=$(printf '%s' "$origin_url" | sed -nE 's#^.*github\.com[:/]+([^/]+/[^/]+)$#\1#p')
+      repo="${repo%.git}"
+    fi
+  fi
+
+  [ -n "$repo" ] || return 1
+  printf '%s\n' "$repo"
+  [[ "$repo" =~ ^[^/[:space:]]+/[^/[:space:]]+$ ]] || return 2
+  return 0
+}

--- a/.agents/skills/orch/scripts/queue-wait
+++ b/.agents/skills/orch/scripts/queue-wait
@@ -23,7 +23,7 @@ queue_message() {
       ;;
     repo-unresolved)
       printf 'queue-wait: repo-unresolved remote=%s\n' "origin"
-      printf '%s\n' "could not resolve GitHub repo (gh repo view and git remote both failed)"
+      printf '%s\n' "could not resolve GitHub repo (GH_REPO unset, gh repo view and git remote both failed)"
       ;;
     pr-view-failed)
       printf 'queue-wait: pr-view-failed pr=%s repo=%s\n' "$PR_NUM" "$REPO"
@@ -118,8 +118,15 @@ PROJECT_ROOT="$(git rev-parse --show-toplevel 2>/dev/null || pwd)"
 
 # shellcheck source=lib/gh-auth.sh
 source "$SCRIPT_DIR/lib/gh-auth.sh"
+# shellcheck source=lib/gh-repo.sh
+source "$SCRIPT_DIR/lib/gh-repo.sh"
 # shellcheck source=lib/review-threads.sh
 source "$SCRIPT_DIR/lib/review-threads.sh"
+
+# Named in every result, so a verdict states the repository it read. Empty
+# until the resolver below runs, which is after the auth ladder: an auth
+# failure is a verdict about no repository.
+REPO=""
 
 print_usage() {
   printf 'queue-wait: usage command=%s\n' 'queue-wait'
@@ -268,6 +275,9 @@ JSON output (always when --json):
     "verdict": "merged" | "conflicting" | "ejected" | "disarmed"
                | "dequeued" | "closed" | "queued" | "not_queued"
                | "unknown",
+    "repo": <string>,              # the repository this verdict is about,
+                                   # "" only when the wait ended before it
+                                   # was resolved (missing gh, no auth)
     "elapsed_seconds": <int>,
     "polls": <int>,
     "pr_state": <string>,          # OPEN | MERGED | CLOSED | "" (never read)
@@ -294,6 +304,14 @@ JSON output (always when --json):
     "transient_api_errors": <int>, # only when > 0
     "error": <string>              # only when status == "error"
   }
+
+Repository: resolved through lib/gh-repo.sh, shared with approval-wait and
+ci-wait — GH_REPO first, then the working directory (`gh repo view`, then
+the origin remote) when GH_REPO is unset. `gh repo view` ignores GH_REPO and
+answers for the working directory, so a wait on another repository's PR from
+this checkout reads GH_REPO or nothing else will. Every result names the
+repository it read; a GH_REPO that is not owner/name is refused (repo-shape,
+exit 1) rather than sent to an API path that cannot hold it.
 
 Auth: resolved through lib/gh-auth.sh, shared with approval-wait and
 ci-wait (kendex#19) — env-first: already-resolved GH_TOKEN/GITHUB_TOKEN/
@@ -519,6 +537,7 @@ emit_result() {
       --arg v "$verdict" \
       --argjson elapsed "$elapsed" \
       --argjson polls "$polls" \
+      --arg repo "$REPO" \
       --arg pr_state "$last_pr_state" \
       --arg merged_at "$last_merged_at" \
       --argjson in_queue "$last_in_queue" \
@@ -536,6 +555,7 @@ emit_result() {
       '{
         status: $s,
         verdict: $v,
+        repo: $repo,
         elapsed_seconds: $elapsed,
         polls: $polls,
         pr_state: $pr_state,
@@ -554,7 +574,7 @@ emit_result() {
         + (if $error == "" then {} else {error: $error} end)'
     return 0
   fi
-  printf 'queue-wait: result status=%s verdict=%s pr=%s cause=%s polls=%s progressing=%s\n' "$status" "$verdict" "$PR_NUM" "${last_cause:-none}" "$polls" "$progressing"
+  printf 'queue-wait: result status=%s verdict=%s pr=%s repo=%s cause=%s polls=%s progressing=%s\n' "$status" "$verdict" "$PR_NUM" "${REPO:-unresolved}" "${last_cause:-none}" "$polls" "$progressing"
   case "$verdict" in
     merged)
       echo "Merge queue: merged (PR #$PR_NUM${last_merged_at:+ at $last_merged_at})"
@@ -662,26 +682,20 @@ if [[ "$AUTH_READY" != "true" ]]; then
 fi
 
 # --- Resolve repo explicitly so gh calls don't depend on local auth/inference ---
-REPO=$(gh repo view --json nameWithOwner -q .nameWithOwner 2>/dev/null || true)
-if [ -z "$REPO" ]; then
-  origin_url=$(git -C "$PROJECT_ROOT" remote get-url origin 2>/dev/null || true)
-  # Capture owner/repo greedily, then strip a trailing ".git" explicitly — the
-  # same portable form ci-wait uses.
-  REPO=$(echo "$origin_url" | sed -nE 's#^.*github\.com[:/]+([^/]+/[^/]+)$#\1#p')
-  REPO="${REPO%.git}"
+repo_status=0
+REPO=$(orch_resolve_gh_repo "$PROJECT_ROOT") || repo_status=$?
+if [ "$repo_status" -eq 2 ]; then
+  emit_error repo-shape
+
+  exit 1
 fi
-if [ -z "$REPO" ]; then
+if [ "$repo_status" -ne 0 ]; then
   emit_error repo-unresolved
 
   exit 1
 fi
 REPO_OWNER="${REPO%%/*}"
 REPO_NAME="${REPO#*/}"
-if [ -z "$REPO_OWNER" ] || [ -z "$REPO_NAME" ] || [ "$REPO_OWNER" = "$REPO" ]; then
-  emit_error repo-shape
-
-  exit 1
-fi
 
 # mergeQueueEntry.position and .headCommit are schema-verified fields
 # (`__type(name:"MergeQueueEntry")`); headCommit is the merge-group commit

--- a/.agents/skills/orch/scripts/queue-wait
+++ b/.agents/skills/orch/scripts/queue-wait
@@ -30,8 +30,8 @@ queue_message() {
       printf '%s\n' "gh pr view failed for PR #$PR_NUM in $REPO"
       ;;
     repo-shape)
-      printf 'queue-wait: repo-shape repo=%q\n' "$REPO"
-      printf '%s\n' "could not split '$REPO' into owner/repo for the merge-queue query"
+      printf 'queue-wait: repo-shape repo=%q\n' "$REPO_REJECTED"
+      printf '%s\n' "could not split '$REPO_REJECTED' into owner/repo for the merge-queue query"
       ;;
     queue-rejected)
       printf 'queue-wait: queue-rejected pr=%s detail=%q\n' "$PR_NUM" "$gql_error"
@@ -125,8 +125,11 @@ source "$SCRIPT_DIR/lib/review-threads.sh"
 
 # Named in every result, so a verdict states the repository it read. Empty
 # until the resolver below runs, which is after the auth ladder: an auth
-# failure is a verdict about no repository.
+# failure is a verdict about no repository. A candidate the resolver refuses
+# is no repository either: it lands in REPO_REJECTED for the diagnostic to
+# name, never in REPO, so no consumer reads it as one that resolved.
 REPO=""
+REPO_REJECTED=""
 
 print_usage() {
   printf 'queue-wait: usage command=%s\n' 'queue-wait'
@@ -276,8 +279,9 @@ JSON output (always when --json):
                | "dequeued" | "closed" | "queued" | "not_queued"
                | "unknown",
     "repo": <string>,              # the repository this verdict is about,
-                                   # "" only when the wait ended before it
-                                   # was resolved (missing gh, no auth)
+                                   # "" whenever the wait ended before one
+                                   # was resolved: missing gh, no auth,
+                                   # repo-unresolved, repo-shape
     "elapsed_seconds": <int>,
     "polls": <int>,
     "pr_state": <string>,          # OPEN | MERGED | CLOSED | "" (never read)
@@ -311,7 +315,9 @@ the origin remote) when GH_REPO is unset. `gh repo view` ignores GH_REPO and
 answers for the working directory, so a wait on another repository's PR from
 this checkout reads GH_REPO or nothing else will. Every result names the
 repository it read; a GH_REPO that is not owner/name is refused (repo-shape,
-exit 1) rather than sent to an API path that cannot hold it.
+exit 1) rather than sent to an API path that cannot hold it. The
+refusal names the rejected value in its diagnostic line and leaves the JSON
+`repo` field empty, since a refusal is a verdict about no repository.
 
 Auth: resolved through lib/gh-auth.sh, shared with approval-wait and
 ci-wait (kendex#19) — env-first: already-resolved GH_TOKEN/GITHUB_TOKEN/
@@ -685,6 +691,8 @@ fi
 repo_status=0
 REPO=$(orch_resolve_gh_repo "$PROJECT_ROOT") || repo_status=$?
 if [ "$repo_status" -eq 2 ]; then
+  REPO_REJECTED="$REPO"
+  REPO=""
   emit_error repo-shape
 
   exit 1

--- a/.agents/skills/orch/tests/acceptance-verdicts.test.sh
+++ b/.agents/skills/orch/tests/acceptance-verdicts.test.sh
@@ -1,7 +1,8 @@
 #!/usr/bin/env bash
 # dev-artifact-check --verdict field, review-artifact-check --path mode, and
 # ci-wait's none-configured route: each acceptance answer must be a single
-# deterministic word the orchestrator can act on without combining checks.
+# deterministic word the orchestrator can act on without combining checks, and
+# that route's result must name the repository it read like every other one.
 set -euo pipefail
 source "$(dirname "${BASH_SOURCE[0]}")/lib/git-env.sh"
 
@@ -90,6 +91,15 @@ out=$(cd "$WT" && PATH="$BIN:$PATH" env -u GH_REPO GH_STUB_LOG="$TMP/gh.log" \
   CI_WAIT_NO_CHECKS_GRACE=1 GH_TOKEN=stub "$SCRIPTS/ci-wait" 1 1 5 --json 2>/dev/null || true)
 check "no workflows + no protection + no rules → verdict none" "none" "$(jq -r '.verdict // empty' <<<"$out")"
 check "none-configured is status complete" "complete" "$(jq -r '.status // empty' <<<"$out")"
+# This route builds its own result object rather than routing through
+# emit_result, so the repository every other verdict names is asserted here
+# too, on both the JSON object and the plain line.
+check "none-configured names the repository it read" "owner/repo" "$(jq -r '.repo // empty' <<<"$out")"
+
+text=$(cd "$WT" && PATH="$BIN:$PATH" env -u GH_REPO GH_STUB_LOG="$TMP/gh-text.log" \
+  CI_WAIT_NO_CHECKS_GRACE=1 GH_TOKEN=stub "$SCRIPTS/ci-wait" 1 1 5 2>/dev/null || true)
+check "the plain none-configured line names its base and repository" \
+  "ci-wait: none-configured base=main repo=owner/repo" "${text%%$'\n'*}"
 
 # Teeth: with active workflows present the shortcut must NOT fire — the run
 # falls through to the grace path and, at grace 1s with no checks, errors out.

--- a/.agents/skills/orch/tests/acceptance-verdicts.test.sh
+++ b/.agents/skills/orch/tests/acceptance-verdicts.test.sh
@@ -73,6 +73,7 @@ case "$*" in
   *"actions/workflows"*) if [[ "${GH_STUB_WORKFLOWS:-0}" == "0" ]]; then echo "0"; else echo "${GH_STUB_WORKFLOWS}"; fi; exit 0 ;;
   *"rules/branches"*) echo "0"; exit 0 ;;
   *"branches/main"*) echo "false"; exit 0 ;;
+  *"repo view"*) echo "owner/repo"; exit 0 ;;
   *"pr view"*"baseRefName"*) echo "main"; exit 0 ;;
   *"pr view"*"headRefOid"*) echo "deadbeefcafe"; exit 0 ;;
   *"/status"*) echo "${GH_STUB_EXT_STATUSES:-0}"; exit 0 ;;
@@ -85,15 +86,15 @@ esac
 EOF
 chmod +x "$BIN/gh"
 
-out=$(cd "$WT" && GH_STUB_LOG="$TMP/gh.log" CI_WAIT_NO_CHECKS_GRACE=1 \
-  PATH="$BIN:$PATH" GH_TOKEN=stub "$SCRIPTS/ci-wait" 1 1 5 --json 2>/dev/null || true)
+out=$(cd "$WT" && PATH="$BIN:$PATH" env -u GH_REPO GH_STUB_LOG="$TMP/gh.log" \
+  CI_WAIT_NO_CHECKS_GRACE=1 GH_TOKEN=stub "$SCRIPTS/ci-wait" 1 1 5 --json 2>/dev/null || true)
 check "no workflows + no protection + no rules → verdict none" "none" "$(jq -r '.verdict // empty' <<<"$out")"
 check "none-configured is status complete" "complete" "$(jq -r '.status // empty' <<<"$out")"
 
 # Teeth: with active workflows present the shortcut must NOT fire — the run
 # falls through to the grace path and, at grace 1s with no checks, errors out.
-out2=$(cd "$WT" && GH_STUB_WORKFLOWS=3 CI_WAIT_NO_CHECKS_GRACE=1 \
-  PATH="$BIN:$PATH" GH_TOKEN=stub "$SCRIPTS/ci-wait" 1 1 5 --json 2>/dev/null || true)
+out2=$(cd "$WT" && PATH="$BIN:$PATH" env -u GH_REPO GH_STUB_WORKFLOWS=3 \
+  CI_WAIT_NO_CHECKS_GRACE=1 GH_TOKEN=stub "$SCRIPTS/ci-wait" 1 1 5 --json 2>/dev/null || true)
 v2="$(jq -r '.verdict // empty' <<<"$out2")"
 if [[ "$v2" != "none" ]]; then
   ok "active workflows suppress the none-configured shortcut (teeth)"

--- a/.agents/skills/orch/tests/approval_wait.sh
+++ b/.agents/skills/orch/tests/approval_wait.sh
@@ -626,11 +626,13 @@ echo "=== the verdict names the repository it read ==="
 # wait launched from this checkout for another repository's PR read this
 # checkout's same-numbered PR. GH_REPO decides; a value that is not owner/name
 # is refused before any review read, never sent to an API path that cannot
-# hold it.
+# hold it. The refusal names the rejected value in its diagnostic and leaves
+# the result's repo empty, so nothing reads an unvalidated candidate as the
+# repository the verdict is about.
 table "$APPROVAL" \
   'GH_REPO names the repository, over the checkout gh repo view answers for||GH_REPO=other/elsewhere,STUB_APPROVAL_MODE=approved_decision|rc=0 status=approved repo=other/elsewhere' \
   'GH_REPO unset names the checkout||STUB_APPROVAL_MODE=approved_decision|rc=0 status=approved repo=owner/repo' \
-  'a GH_REPO that is not owner/name is refused||GH_REPO=elsewhere,STUB_APPROVAL_MODE=approved_decision|rc=1 status=error error_line=approval-wait:+repo-shape+repo=elsewhere'
+  'a GH_REPO that is not owner/name is refused||GH_REPO=elsewhere,STUB_APPROVAL_MODE=approved_decision|rc=1 status=error repo= error_line=approval-wait:+repo-shape+repo=elsewhere'
 
 echo "=== text mode prints a result line for every branch the emitter has ==="
 # The line's wording is not a contract anything parses; what holds is that no

--- a/.agents/skills/orch/tests/approval_wait.sh
+++ b/.agents/skills/orch/tests/approval_wait.sh
@@ -425,7 +425,7 @@ run_wait() {
   [[ -z "$env_list" ]] || IFS=',' read -ra env_args <<<"$env_list"
   set +e
   OUT=$(cd "$TMP_ROOT/repo" && PATH="$TMP_ROOT/bin:$PATH" \
-    env ${env_args[@]+"${env_args[@]}"} \
+    env -u GH_REPO ${env_args[@]+"${env_args[@]}"} \
         STUB_APPROVAL_COUNT_FILE="$RUN/approval-polls" \
         STUB_REVIEWS_COUNT_FILE="$RUN/review-polls" \
         STUB_HEAD_COUNT_FILE="$RUN/head-polls" \
@@ -453,6 +453,8 @@ count_lines() { # FILE — 0 when it was never written
 #   outage_marker                   whether the JSON carries that field
 #   target_patterns   auto_review_targets joined, so a row compares as one word
 #   transient_errors_seen           transient_api_errors >= 1
+#   text_repo the repo field on the plain result's first line
+#   error_line  first line of the JSON error, spaces encoded as +
 observe() {
   local got="" token name
   for token in $1; do
@@ -463,6 +465,8 @@ observe() {
       spent) got="$got spent=$(json '.elapsed_seconds >= 3')" ;;
       stdout) got="$got stdout=$([[ -n "$OUT" ]] && echo line || echo empty)" ;;
       text_status) got="$got text_status=$(sed -n '1s/^approval-wait: result status=\([^ ]*\).*$/\1/p' <<<"$OUT")" ;;
+      text_repo) got="$got text_repo=$(sed -n '1s/^approval-wait: result .* repo=\([^ ]*\).*$/\1/p' <<<"$OUT")" ;;
+      error_line) got="$got error_line=$(json '.error | split("\n")[0]' | tr ' ' '+')" ;;
       approval_polls) got="$got approval_polls=$(cat "$RUN/approval-polls" 2>/dev/null || echo 0)" ;;
       review_polls) got="$got review_polls=$(cat "$RUN/review-polls" 2>/dev/null || echo 0)" ;;
       status_queries) got="$got status_queries=$(count_lines "$RUN/status-queries")" ;;
@@ -617,6 +621,17 @@ table "$REVIEW" \
   'a 404 is terminal at once with no transient count||STUB_REVIEWS_MODE=http_404|rc=1 status=error transient_api_errors=null early=true' \
   'approval-mode pr view 503s then an approval is approved with the count|1 1 3 --json|STUB_APPROVAL_MODE=approved_after_503|rc=0 status=approved transient_api_errors=2'
 
+echo "=== the verdict names the repository it read ==="
+# `gh repo view` answers for the working directory and ignores GH_REPO, so a
+# wait launched from this checkout for another repository's PR read this
+# checkout's same-numbered PR. GH_REPO decides; a value that is not owner/name
+# is refused before any review read, never sent to an API path that cannot
+# hold it.
+table "$APPROVAL" \
+  'GH_REPO names the repository, over the checkout gh repo view answers for||GH_REPO=other/elsewhere,STUB_APPROVAL_MODE=approved_decision|rc=0 status=approved repo=other/elsewhere' \
+  'GH_REPO unset names the checkout||STUB_APPROVAL_MODE=approved_decision|rc=0 status=approved repo=owner/repo' \
+  'a GH_REPO that is not owner/name is refused||GH_REPO=elsewhere,STUB_APPROVAL_MODE=approved_decision|rc=1 status=error error_line=approval-wait:+repo-shape+repo=elsewhere'
+
 echo "=== text mode prints a result line for every branch the emitter has ==="
 # The line's wording is not a contract anything parses; what holds is that no
 # terminal status leaves stdout empty, with the same exit code as --json. The
@@ -638,7 +653,8 @@ table '1 1 3' \
   "review: timeout|$TEXT_REVIEW|STUB_REVIEWS_MODE=none|rc=1 text_status=timeout" \
   "review: error|$TEXT_REVIEW|GH_TOKEN=bad-token,STUB_GH_DENY_KEYRING=1|rc=3 text_status=error" \
   "review: proceeded|$TEXT_REVIEW|STUB_REVIEWS_MODE=none,PR_REVIEW_ON_TIMEOUT=proceed|rc=0 text_status=proceeded" \
-  "review: unreviewable|$TEXT_REVIEW|STUB_REVIEWS_MODE=none,STUB_BASE_REF=stack-base|rc=1 text_status=unreviewable"
+  "review: unreviewable|$TEXT_REVIEW|STUB_REVIEWS_MODE=none,STUB_BASE_REF=stack-base|rc=1 text_status=unreviewable" \
+  'the result line names the repository it read||GH_REPO=other/elsewhere,STUB_APPROVAL_MODE=approved_decision|rc=0 text_status=approved text_repo=other/elsewhere'
 
 echo "=== PR_REVIEW_WAIT_SECS: an absent max_wait positional resolves through orch-env ==="
 # Process env beats kendex.settings.toml [env], and an explicit positional

--- a/.agents/skills/orch/tests/ci_wait.sh
+++ b/.agents/skills/orch/tests/ci_wait.sh
@@ -285,7 +285,7 @@ run_wait() {
   [[ -z "$env_list" ]] || IFS=',' read -ra env_args <<<"$env_list"
   set +e
   OUT=$(cd "$TMP_ROOT/repo" && PATH="$TMP_ROOT/bin:$PATH" \
-    env ${env_args[@]+"${env_args[@]}"} \
+    env -u GH_REPO ${env_args[@]+"${env_args[@]}"} \
         STUB_GH_API_USER_COUNT_FILE="$RUN/api-user-calls" \
         STUB_PR_CHECKS_COUNT_FILE="$RUN/checks-polls" \
         STUB_REPO_ARG_FILE="$RUN/repo-arg" \
@@ -447,10 +447,21 @@ echo "=== text mode prints a result line for every terminal status ==="
 # The line beyond its leading words is not a contract anything parses; the
 # leading words are text-only, so a JSON default flip fails these rows.
 table '1 1 30' \
-  'passed||||rc=0 stdout~ci-wait:+passed+pr=1=true' \
-  'failed|||STUB_PR_CHECKS_MODE=failure|rc=1 stdout~ci-wait:+failed+pr=1=true' \
-  'timeout||1 1 5|STUB_PR_CHECKS_MODE=pending_always|rc=1 stdout~ci-wait:+timeout+elapsed=5+verdict=pending=true' \
-  'error|||STUB_PR_CHECKS_MODE=empty,CI_WAIT_NO_CHECKS_GRACE=3|rc=1 stdout~ci-wait:+error+pr=1=true'
+  'passed||||rc=0 stdout~ci-wait:+passed+pr=1+repo=owner/repo=true' \
+  'failed|||STUB_PR_CHECKS_MODE=failure|rc=1 stdout~ci-wait:+failed+pr=1+repo=owner/repo=true' \
+  'timeout||1 1 5|STUB_PR_CHECKS_MODE=pending_always|rc=1 stdout~ci-wait:+timeout+elapsed=5+verdict=pending+repo=owner/repo=true' \
+  'error|||STUB_PR_CHECKS_MODE=empty,CI_WAIT_NO_CHECKS_GRACE=3|rc=1 stdout~ci-wait:+error+pr=1+repo=owner/repo=true'
+
+echo "=== the verdict names the repository it read ==="
+# `gh repo view` answers for the working directory and ignores GH_REPO, so a
+# wait launched from this checkout for another repository's PR read this
+# checkout's same-numbered PR. GH_REPO decides, and the slug it names is what
+# reaches `gh --repo`; a value that is not owner/name is refused before any
+# check read.
+table "$JSON" \
+  'GH_REPO names the repository, over the checkout gh repo view answers for|||GH_REPO=other/elsewhere|rc=0 verdict=pass repo=other/elsewhere repo_arg=other/elsewhere' \
+  'GH_REPO unset names the checkout||||rc=0 verdict=pass repo=owner/repo repo_arg=owner/repo' \
+  'a GH_REPO that is not owner/name is refused|||GH_REPO=elsewhere|rc=1 status=error error_named=true stderr~ci-wait:+repo-shape+repo=elsewhere=true repo_arg=none'
 
 echo "=== the repo slug falls back to the origin URL without its .git suffix ==="
 # When `gh repo view` answers empty, owner/repo comes from the origin URL; the

--- a/.agents/skills/orch/tests/ci_wait.sh
+++ b/.agents/skills/orch/tests/ci_wait.sh
@@ -457,11 +457,13 @@ echo "=== the verdict names the repository it read ==="
 # wait launched from this checkout for another repository's PR read this
 # checkout's same-numbered PR. GH_REPO decides, and the slug it names is what
 # reaches `gh --repo`; a value that is not owner/name is refused before any
-# check read.
+# check read. The refusal names the rejected value in its diagnostic and
+# leaves the result's repo empty, so nothing reads an unvalidated candidate
+# as the repository the verdict is about.
 table "$JSON" \
   'GH_REPO names the repository, over the checkout gh repo view answers for|||GH_REPO=other/elsewhere|rc=0 verdict=pass repo=other/elsewhere repo_arg=other/elsewhere' \
   'GH_REPO unset names the checkout||||rc=0 verdict=pass repo=owner/repo repo_arg=owner/repo' \
-  'a GH_REPO that is not owner/name is refused|||GH_REPO=elsewhere|rc=1 status=error error_named=true stderr~ci-wait:+repo-shape+repo=elsewhere=true repo_arg=none'
+  'a GH_REPO that is not owner/name is refused|||GH_REPO=elsewhere|rc=1 status=error error_named=true repo= stderr~ci-wait:+repo-shape+repo=elsewhere=true repo_arg=none'
 
 echo "=== the repo slug falls back to the origin URL without its .git suffix ==="
 # When `gh repo view` answers empty, owner/repo comes from the origin URL; the

--- a/.agents/skills/orch/tests/gh-repo-resolve.test.sh
+++ b/.agents/skills/orch/tests/gh-repo-resolve.test.sh
@@ -1,0 +1,135 @@
+#!/usr/bin/env bash
+# Tests for orch/scripts/lib/gh-repo.sh, the one resolver ci-wait, queue-wait
+# and approval-wait ask which repository they are waiting on.
+#
+# Its reason to exist: `gh repo view` answers for the working directory and
+# ignores GH_REPO, so three inline copies of it handed a caller waiting on
+# another repository's PR from this checkout a verdict about this checkout's
+# same-numbered PR. GH_REPO decides; the working directory answers only when
+# GH_REPO is unset.
+#
+# One case per behaviour surface; shaped input is one table, one asserted row
+# per shape.
+set -euo pipefail
+source "$(dirname "${BASH_SOURCE[0]}")/lib/git-env.sh"
+TEST_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$TEST_DIR/../../.." && pwd)"
+TMP_ROOT="$(mktemp -d)"
+trap 'rm -rf "$TMP_ROOT"' EXIT
+
+# shellcheck source=lib/waiter-assertions.sh
+source "$TEST_DIR/lib/waiter-assertions.sh"
+
+LIVE_LIB="$REPO_ROOT/skills/orch/scripts/lib/gh-repo.sh"
+
+# `gh repo view` stand-in. STUB_REPO_VIEW is what it answers; empty means it
+# printed nothing, the shape a checkout gh cannot resolve produces.
+mkdir -p "$TMP_ROOT/bin"
+cat > "$TMP_ROOT/bin/gh" <<'EOF'
+#!/usr/bin/env bash
+set -uo pipefail
+if [[ "${1:-}" == "repo" && "${2:-}" == "view" ]]; then
+  [[ -n "${STUB_REPO_VIEW:-}" ]] && printf '%s\n' "$STUB_REPO_VIEW"
+  exit 0
+fi
+printf 'unexpected gh call: %s\n' "$*" >&2
+exit 1
+EOF
+chmod +x "$TMP_ROOT/bin/gh"
+
+# Two project roots: one with a github.com origin for the remote fallback, one
+# with no remote at all, where nothing resolves.
+for name in origin-repo no-remote; do
+  mkdir -p "$TMP_ROOT/$name"
+  git -C "$TMP_ROOT/$name" init -q
+  git -C "$TMP_ROOT/$name" config user.email test@example.com
+  git -C "$TMP_ROOT/$name" config user.name Test
+done
+git -C "$TMP_ROOT/origin-repo" remote add origin git@github.com:remote-owner/remote-repo.git
+
+# run_resolve ENV ROOT LIB — call the resolver with ENV (a comma-separated
+# list of `env` arguments) against ROOT, through LIB. Sets OUT and RC.
+# GH_REPO comes off first so a row's own value is the only one in play.
+run_resolve() {
+  local env_list="$1" root="$2" lib="$3" env_args=()
+  [[ -z "$env_list" ]] || IFS=',' read -ra env_args <<<"$env_list"
+  ERR="$TMP_ROOT/stderr"
+  set +e
+  OUT=$(PATH="$TMP_ROOT/bin:$PATH" \
+    env -u GH_REPO ${env_args[@]+"${env_args[@]}"} \
+      bash -c 'set -uo pipefail; . "$1"; orch_resolve_gh_repo "$2"' \
+      bash "$lib" "$TMP_ROOT/$root" 2>"$ERR")
+  RC=$?
+  set -e
+}
+
+# observe EXPECT — the run's value of every `name=` field EXPECT names, in
+# EXPECT's order, so a row compares as one string.
+#   rc   the resolver's exit status
+#   out  its stdout with spaces encoded as `+`, `empty` when it printed
+#        nothing — a row's fields are whitespace-separated
+observe() {
+  local got="" token name value
+  for token in $1; do
+    name="${token%%=*}"
+    case "$name" in
+      rc) value="$RC" ;;
+      out) value="${OUT:-empty}"; value="${value// /+}" ;;
+      *) printf 'observe: unknown field %s\n' "$name" >&2; exit 1 ;;
+    esac
+    got="$got $name=$value"
+  done
+  printf '%s' "${got# }"
+}
+
+# table ROW... — one run and one assertion per row.
+# A row is `label|env|root|expect`.
+table() {
+  local row label env root expect
+  for row in "$@"; do
+    IFS='|' read -r label env root expect <<<"$row"
+    [[ -n "$expect" ]] || { printf 'table: a row with no expect asserts nothing: %s\n' "$row" >&2; exit 1; }
+    run_resolve "$env" "$root" "$LIVE_LIB"
+    assert_eq "$(observe "$expect")" "$expect" "$label" "$ERR"
+  done
+}
+
+echo "=== GH_REPO decides; the working directory answers only without it ==="
+# The fail-open this resolver exists to close: with GH_REPO naming another
+# repository, a `gh repo view` that answers for this checkout must not win.
+table \
+  'GH_REPO names the repository, over a resolvable checkout|GH_REPO=other/elsewhere,STUB_REPO_VIEW=cwd-owner/cwd-repo|origin-repo|rc=0 out=other/elsewhere' \
+  'GH_REPO unset reads the checkout|STUB_REPO_VIEW=cwd-owner/cwd-repo|origin-repo|rc=0 out=cwd-owner/cwd-repo' \
+  'GH_REPO wins even where the checkout resolves to nothing|GH_REPO=other/elsewhere|no-remote|rc=0 out=other/elsewhere' \
+  'an unresolvable checkout falls back to the origin remote, without its .git suffix||origin-repo|rc=0 out=remote-owner/remote-repo' \
+  'no GH_REPO, no gh answer and no origin resolves nothing, never a default||no-remote|rc=1 out=empty'
+
+echo "=== a GH_REPO that is not owner/name is refused, never queried ==="
+# The refused value is still printed, so the waiter's repo-shape line names
+# what it rejected. A bare name, a three-segment host form and a value
+# carrying whitespace each reach an API path that cannot hold them.
+table \
+  'a bare name has no owner|GH_REPO=elsewhere|origin-repo|rc=2 out=elsewhere' \
+  'a host-prefixed three-segment form|GH_REPO=github.com/other/elsewhere|origin-repo|rc=2 out=github.com/other/elsewhere' \
+  'an empty owner segment|GH_REPO=/elsewhere|origin-repo|rc=2 out=/elsewhere' \
+  'an empty name segment|GH_REPO=other/|origin-repo|rc=2 out=other/' \
+  'a value carrying whitespace|GH_REPO=other/else where|origin-repo|rc=2 out=other/else+where'
+
+echo "=== must-fail control ==="
+# Remove the GH_REPO-first behaviour while keeping its lines: the first row
+# above is the one that reddens, and it reddens with the checkout's repository
+# — exactly the wrong-repository verdict the issue reported.
+MUTANT="$TMP_ROOT/gh-repo-mutant.sh"
+cp "$LIVE_LIB" "$MUTANT"
+assert_eq "$(grep -Fc 'if [ -n "${GH_REPO:-}" ]; then' "$MUTANT")" "1" \
+  "control finds exactly one live GH_REPO branch"
+sed -i.bak 's/^  if \[ -n "${GH_REPO:-}" \]; then$/  if [ -n "" ]; then/' "$MUTANT"
+assert_eq "$(grep -Fc 'if [ -n "" ]; then' "$MUTANT")" "1" \
+  "control applied the mutation"
+run_resolve 'GH_REPO=other/elsewhere,STUB_REPO_VIEW=cwd-owner/cwd-repo' origin-repo "$MUTANT"
+assert_eq "$(observe 'rc=0 out=cwd-owner/cwd-repo')" "rc=0 out=cwd-owner/cwd-repo" \
+  "must-fail control: without the GH_REPO branch the checkout's repository wins" "$ERR"
+
+echo
+printf 'pass: %d   fail: %d\n' "$PASS" "$FAIL"
+[[ "$FAIL" -eq 0 ]]

--- a/.agents/skills/orch/tests/queue_wait.sh
+++ b/.agents/skills/orch/tests/queue_wait.sh
@@ -370,6 +370,8 @@ STAGE_SEQ=0
 # how production invokes it, with the staged sequence directory and the
 # suite's default knobs; ENV is a comma-separated list of `env` arguments
 # that may override those knobs. Sets OUT, RC and ERR (the stderr file).
+# GH_REPO comes off first: it decides which repository the wait reads, so the
+# runner's own value would otherwise answer for every row.
 run_wait() {
   local env_list="$1" env_args=()
   shift
@@ -377,7 +379,7 @@ run_wait() {
   ERR="$SEQ_DIR/stderr"
   set +e
   OUT=$(cd "$TMP_ROOT/repo" && PATH="$TMP_ROOT/bin:$PATH" \
-    env STUB_SEQ_DIR="$SEQ_DIR" \
+    env -u GH_REPO STUB_SEQ_DIR="$SEQ_DIR" \
         QUEUE_WAIT_CONFIRM_POLLS=2 \
         QUEUE_WAIT_ARM_GRACE=120 \
         QUEUE_WAIT_PROBE_INTERVAL=0 \
@@ -396,6 +398,7 @@ json() { jq -r "$1" <<<"$OUT" 2>/dev/null || echo UNPARSEABLE; }
 #   error_line        first line of the JSON error, spaces encoded as +
 #   stdout            `line` when anything was printed, `empty` otherwise
 #   text_verdict      the verdict field on the plain result's first line
+#   text_repo         the repo field on that same line
 #   help_record       stable usage record, spaces encoded as +
 #   mutations         the GraphQL mutations issued, in order: `disable`,
 #                     `dequeue`, or `none`
@@ -414,6 +417,7 @@ observe() {
       error_line) value="$(json '.error | split("\n")[0]')"; value="${value// /+}" ;;
       stdout) value="$([[ -n "$OUT" ]] && echo line || echo empty)" ;;
       text_verdict) value="$(sed -n '1s/^queue-wait: result status=[^ ]* verdict=\([^ ]*\).*$/\1/p' <<<"$OUT")" ;;
+      text_repo) value="$(sed -n '1s/^queue-wait: result .* repo=\([^ ]*\).*$/\1/p' <<<"$OUT")" ;;
       help_record) value="${OUT%%$'\n'*}"; value="${value// /+}" ;;
       mutations)
         value="$(sed -e 's/^disablePullRequestAutoMerge .*/disable/' -e 's/^dequeuePullRequest .*/dequeue/' "$SEQ_DIR/mutations.log" 2>/dev/null | paste -sd, - || true)"
@@ -533,6 +537,17 @@ table '1 1 8 --json --no-check-probe' \
   'a failed read between two reads does not erase the movement|open_queued_head,checkruns:1=c1.0,checkruns:2=fail502,checkruns:last=c2.0|1 1 4 --json --no-check-probe||verdict=queued progressing=true cause=still_progressing' \
   'a merged verdict carries progressing and no cause|state:last=merged,queue:last=in_head|1 1 10 --json --no-check-probe||verdict=merged has_progressing=true has_cause=false'
 
+echo "=== the verdict names the repository it read ==="
+# `gh repo view` answers for the working directory and ignores GH_REPO, so a
+# wait launched from this checkout for another repository's PR read this
+# checkout's same-numbered PR and called it merged. GH_REPO decides; a value
+# that is not owner/name is refused before any poll, never sent to an API
+# path that cannot hold it.
+table "$QW" \
+  'GH_REPO names the repository, over the checkout gh repo view answers for|state:last=merged,queue:last=in|1 1 10 --json --no-check-probe|GH_REPO=other/elsewhere|rc=0 verdict=merged repo=other/elsewhere' \
+  'GH_REPO unset names the checkout|state:last=merged,queue:last=in|1 1 10 --json --no-check-probe||rc=0 verdict=merged repo=owner/repo' \
+  'a GH_REPO that is not owner/name is refused|open_queued||GH_REPO=elsewhere|rc=1 status=error verdict=unknown error_line=queue-wait:+repo-shape+repo=elsewhere'
+
 echo "=== text mode names the verdict on stdout ==="
 # The line's wording beyond the verdict word is not a contract anything
 # parses; what holds is that every verdict prints its own line, with the same
@@ -541,7 +556,8 @@ table '1 1 20 --no-check-probe' \
   'ejected|state:last=open,queue:1=in,queue:last=out|||rc=1 text_verdict=ejected' \
   "dequeued|open_queued,threads:last=late,$DQ|||rc=1 text_verdict=dequeued" \
   'queued after one poll|open_queued|1 1 1 --no-check-probe||rc=1 text_verdict=queued' \
-  'queued and stalled|open_queued_head,checkruns:last=c1.0|1 1 8 --no-check-probe||rc=1 text_verdict=queued'
+  'queued and stalled|open_queued_head,checkruns:last=c1.0|1 1 8 --no-check-probe||rc=1 text_verdict=queued' \
+  'the result line names the repository it read|state:last=merged,queue:last=in|1 1 10 --no-check-probe|GH_REPO=other/elsewhere|rc=0 text_verdict=merged text_repo=other/elsewhere'
 
 echo "=== argument validation ends in the parser, before any gh call ==="
 # The recording gh stub fails every call, so a case that reached auth or a

--- a/.agents/skills/orch/tests/queue_wait.sh
+++ b/.agents/skills/orch/tests/queue_wait.sh
@@ -542,11 +542,13 @@ echo "=== the verdict names the repository it read ==="
 # wait launched from this checkout for another repository's PR read this
 # checkout's same-numbered PR and called it merged. GH_REPO decides; a value
 # that is not owner/name is refused before any poll, never sent to an API
-# path that cannot hold it.
+# path that cannot hold it. The refusal names the rejected value in its
+# diagnostic and leaves the result's repo empty, so nothing reads an
+# unvalidated candidate as the repository the verdict is about.
 table "$QW" \
   'GH_REPO names the repository, over the checkout gh repo view answers for|state:last=merged,queue:last=in|1 1 10 --json --no-check-probe|GH_REPO=other/elsewhere|rc=0 verdict=merged repo=other/elsewhere' \
   'GH_REPO unset names the checkout|state:last=merged,queue:last=in|1 1 10 --json --no-check-probe||rc=0 verdict=merged repo=owner/repo' \
-  'a GH_REPO that is not owner/name is refused|open_queued||GH_REPO=elsewhere|rc=1 status=error verdict=unknown error_line=queue-wait:+repo-shape+repo=elsewhere'
+  'a GH_REPO that is not owner/name is refused|open_queued||GH_REPO=elsewhere|rc=1 status=error verdict=unknown repo= error_line=queue-wait:+repo-shape+repo=elsewhere'
 
 echo "=== text mode names the verdict on stdout ==="
 # The line's wording beyond the verdict word is not a contract anything

--- a/.agents/skills/orch/tests/queue_wait_conflicting.sh
+++ b/.agents/skills/orch/tests/queue_wait_conflicting.sh
@@ -163,7 +163,7 @@ run_queue_wait() {
   shift || true
   (cd "$TMP_ROOT/repo" \
     && PATH="$TMP_ROOT/bin:$PATH" \
-       env STUB_SEQ_DIR="$SEQ_DIR" \
+       env -u GH_REPO STUB_SEQ_DIR="$SEQ_DIR" \
            QUEUE_WAIT_CONFIRM_POLLS=2 \
            QUEUE_WAIT_ARM_GRACE=120 \
            QUEUE_WAIT_PROBE_INTERVAL=0 \
@@ -291,7 +291,7 @@ err="$TMP_ROOT/e6"
 out="$(run_queue_wait -- 1 1 20 --no-check-probe 2>"$err")" && rc=0 || rc=$?
 assert_eq "$rc" "1" "plain conflicting result exits 1" "$err"
 assert_eq "$(sed -n '1p' <<<"$out")" \
-  "queue-wait: result status=complete verdict=conflicting pr=1 cause=base_conflict polls=2 progressing=null" \
+  "queue-wait: result status=complete verdict=conflicting pr=1 repo=owner/repo cause=base_conflict polls=2 progressing=null" \
   "the plain result carries the confirmed verdict and cause" "$err"
 
 # queue-verdict-routing-lint.test.sh checks the help enum against emitted verdicts.

--- a/skills/orch/scripts/approval-wait
+++ b/skills/orch/scripts/approval-wait
@@ -23,7 +23,11 @@ approval_message() {
       ;;
     repo-unresolved)
       printf 'approval-wait: repo-unresolved remote=%s\n' "origin"
-      printf '%s\n' "could not resolve GitHub repo (gh repo view and git remote both failed)"
+      printf '%s\n' "could not resolve GitHub repo (GH_REPO unset, gh repo view and git remote both failed)"
+      ;;
+    repo-shape)
+      printf 'approval-wait: repo-shape repo=%q\n' "$REPO"
+      printf '%s\n' "could not read '$REPO' as owner/repo for the review-gate queries"
       ;;
     pr-view-failed)
       printf 'approval-wait: pr-view-failed pr=%s repo=%s\n' "$PR_NUM" "$REPO"
@@ -104,6 +108,13 @@ export PROJECT_ROOT
 
 # shellcheck source=lib/gh-auth.sh
 source "$SCRIPT_DIR/lib/gh-auth.sh"
+# shellcheck source=lib/gh-repo.sh
+source "$SCRIPT_DIR/lib/gh-repo.sh"
+
+# Named in every result, so a verdict states the repository it read. Empty
+# until the resolver below runs, which is after the auth ladder: an auth
+# failure is a verdict about no repository.
+REPO=""
 # shellcheck source=lib/review-threads.sh
 source "$SCRIPT_DIR/lib/review-threads.sh"
 
@@ -257,6 +268,9 @@ JSON output (always when --json):
   {
     "status": "approved" | "reviewed" | "changes_requested" | "comments"
               | "timeout" | "proceeded" | "unreviewable" | "error",
+    "repo": <string>,             # the repository this verdict is about,
+                                  # "" only when the wait ended before it
+                                  # was resolved (missing gh, no auth)
     "review_decision": <string>,  # raw reviewDecision ("" when unset)
     "approvals": <int>,           # reviewers whose latest review is APPROVED
     "changes_requested": <int>,   # reviewers at CHANGES_REQUESTED
@@ -277,6 +291,14 @@ JSON output (always when --json):
     "transient_api_errors": <int>,  # only when > 0
     "error": <string>             # only when status == "error"
   }
+
+Repository: resolved through lib/gh-repo.sh, shared with ci-wait and
+queue-wait — GH_REPO first, then the working directory (`gh repo view`, then
+the origin remote) when GH_REPO is unset. `gh repo view` ignores GH_REPO and
+answers for the working directory, so a wait on another repository's PR from
+this checkout reads GH_REPO or nothing else will. Every result names the
+repository it read; a GH_REPO that is not owner/name is refused (repo-shape,
+exit 1) rather than sent to an API path that cannot hold it.
 
 Auth: resolved through lib/gh-auth.sh, shared with ci-wait and queue-wait
 (kendex#19) — env-first: already-resolved GH_TOKEN/GITHUB_TOKEN/GH_BOT_TOKEN
@@ -566,6 +588,7 @@ emit_result() {
     fi
     jq -n \
       --arg s "$status" \
+      --arg repo "$REPO" \
       --arg decision "$last_review_decision" \
       --arg base_ref "$last_base_ref" \
       --argjson auto_targeted "$last_auto_review_targeted" \
@@ -580,6 +603,7 @@ emit_result() {
       --arg error "$error_msg" \
       '{
         status: $s,
+        repo: $repo,
         review_decision: $decision,
         approvals: $approvals,
         changes_requested: $changes,
@@ -594,7 +618,7 @@ emit_result() {
         + (if $error == "" then {} else {error: $error} end)' || return $?
     return 0
   fi
-  printf 'approval-wait: result status=%s pr=%s mode=%s elapsed=%s unresolved=%s\n' "$status" "$PR_NUM" "$MODE" "$elapsed" "$last_unresolved"
+  printf 'approval-wait: result status=%s pr=%s repo=%s mode=%s elapsed=%s unresolved=%s\n' "$status" "$PR_NUM" "${REPO:-unresolved}" "$MODE" "$elapsed" "$last_unresolved"
   case "$status" in
     approved)
       echo "Approval: approved (decision: ${last_review_decision:-none}, approvals: $last_approvals, unresolved threads: $last_unresolved)"
@@ -711,14 +735,14 @@ if [[ "$AUTH_READY" != "true" ]]; then
 fi
 
 # --- Resolve repo explicitly so gh calls don't depend on local auth/inference ---
-REPO=$(gh repo view --json nameWithOwner -q .nameWithOwner 2>/dev/null || true)
-if [ -z "$REPO" ]; then
-  origin_url=$(git -C "$PROJECT_ROOT" remote get-url origin 2>/dev/null || true)
-  # Strip a trailing ".git" with parameter expansion, not the ERE.
-  REPO=$(echo "$origin_url" | sed -nE 's#^.*github\.com[:/]+([^/]+/[^/]+)$#\1#p')
-  REPO="${REPO%.git}"
+repo_status=0
+REPO=$(orch_resolve_gh_repo "$PROJECT_ROOT") || repo_status=$?
+if [ "$repo_status" -eq 2 ]; then
+  emit_error repo-shape
+
+  exit 1
 fi
-if [ -z "$REPO" ]; then
+if [ "$repo_status" -ne 0 ]; then
   emit_error repo-unresolved
 
   exit 1

--- a/skills/orch/scripts/approval-wait
+++ b/skills/orch/scripts/approval-wait
@@ -26,8 +26,8 @@ approval_message() {
       printf '%s\n' "could not resolve GitHub repo (GH_REPO unset, gh repo view and git remote both failed)"
       ;;
     repo-shape)
-      printf 'approval-wait: repo-shape repo=%q\n' "$REPO"
-      printf '%s\n' "could not read '$REPO' as owner/repo for the review-gate queries"
+      printf 'approval-wait: repo-shape repo=%q\n' "$REPO_REJECTED"
+      printf '%s\n' "could not read '$REPO_REJECTED' as owner/repo for the review-gate queries"
       ;;
     pr-view-failed)
       printf 'approval-wait: pr-view-failed pr=%s repo=%s\n' "$PR_NUM" "$REPO"
@@ -113,8 +113,11 @@ source "$SCRIPT_DIR/lib/gh-repo.sh"
 
 # Named in every result, so a verdict states the repository it read. Empty
 # until the resolver below runs, which is after the auth ladder: an auth
-# failure is a verdict about no repository.
+# failure is a verdict about no repository. A candidate the resolver refuses
+# is no repository either: it lands in REPO_REJECTED for the diagnostic to
+# name, never in REPO, so no consumer reads it as one that resolved.
 REPO=""
+REPO_REJECTED=""
 # shellcheck source=lib/review-threads.sh
 source "$SCRIPT_DIR/lib/review-threads.sh"
 
@@ -269,8 +272,9 @@ JSON output (always when --json):
     "status": "approved" | "reviewed" | "changes_requested" | "comments"
               | "timeout" | "proceeded" | "unreviewable" | "error",
     "repo": <string>,             # the repository this verdict is about,
-                                  # "" only when the wait ended before it
-                                  # was resolved (missing gh, no auth)
+                                  # "" whenever the wait ended before one
+                                  # was resolved: missing gh, no auth,
+                                  # repo-unresolved, repo-shape
     "review_decision": <string>,  # raw reviewDecision ("" when unset)
     "approvals": <int>,           # reviewers whose latest review is APPROVED
     "changes_requested": <int>,   # reviewers at CHANGES_REQUESTED
@@ -298,7 +302,9 @@ the origin remote) when GH_REPO is unset. `gh repo view` ignores GH_REPO and
 answers for the working directory, so a wait on another repository's PR from
 this checkout reads GH_REPO or nothing else will. Every result names the
 repository it read; a GH_REPO that is not owner/name is refused (repo-shape,
-exit 1) rather than sent to an API path that cannot hold it.
+exit 1) rather than sent to an API path that cannot hold it. The
+refusal names the rejected value in its diagnostic line and leaves the JSON
+`repo` field empty, since a refusal is a verdict about no repository.
 
 Auth: resolved through lib/gh-auth.sh, shared with ci-wait and queue-wait
 (kendex#19) — env-first: already-resolved GH_TOKEN/GITHUB_TOKEN/GH_BOT_TOKEN
@@ -738,6 +744,8 @@ fi
 repo_status=0
 REPO=$(orch_resolve_gh_repo "$PROJECT_ROOT") || repo_status=$?
 if [ "$repo_status" -eq 2 ]; then
+  REPO_REJECTED="$REPO"
+  REPO=""
   emit_error repo-shape
 
   exit 1

--- a/skills/orch/scripts/ci-wait
+++ b/skills/orch/scripts/ci-wait
@@ -70,8 +70,8 @@ ci_message() {
       printf '%s\n' "Could not resolve GitHub repo (GH_REPO unset, gh repo view and git remote both failed)"
       ;;
     repo-shape)
-      printf 'ci-wait: repo-shape repo=%q\n' "$REPO"
-      printf '%s\n' "could not read '$REPO' as owner/repo for the check queries"
+      printf 'ci-wait: repo-shape repo=%q\n' "$REPO_REJECTED"
+      printf '%s\n' "could not read '$REPO_REJECTED' as owner/repo for the check queries"
       ;;
     conflicting)
       printf 'ci-wait: conflicting pr=%s state=%s\n' "$PR_NUM" "$merge_state"
@@ -146,8 +146,11 @@ source "$SCRIPT_DIR/lib/gh-repo.sh"
 
 # Named in every result, so a verdict states the repository it read. Empty
 # until the resolver below runs, which is after the auth ladder: an auth
-# failure is a verdict about no repository.
+# failure is a verdict about no repository. A candidate the resolver refuses
+# is no repository either: it lands in REPO_REJECTED for the diagnostic to
+# name, never in REPO, so no consumer reads it as one that resolved.
 REPO=""
+REPO_REJECTED=""
 
 print_usage() {
   cat <<'USAGE'
@@ -194,8 +197,9 @@ JSON output (always when --json):
     "status": "complete" | "timeout" | "error",
     "verdict": "pass" | "fail" | "pending" | "none",
     "repo": <string>,             # the repository this verdict is about,
-                                  # "" only when the wait ended before it
-                                  # was resolved (missing gh, no auth)
+                                  # "" whenever the wait ended before one
+                                  # was resolved: missing gh, no auth,
+                                  # repo-unresolved, repo-shape
     "elapsed_seconds": <int>,
     "error": <string>,            # only when status == "error"
     "pending_checks": [ {name,state} ... ],
@@ -220,7 +224,9 @@ the origin remote) when GH_REPO is unset. `gh repo view` ignores GH_REPO and
 answers for the working directory, so a wait on another repository's PR from
 this checkout reads GH_REPO or nothing else will. Every result names the
 repository it read; a GH_REPO that is not owner/name is refused (repo-shape,
-exit 1) rather than sent to an API path that cannot hold it.
+exit 1) rather than sent to an API path that cannot hold it. The
+refusal names the rejected value in its diagnostic line and leaves the JSON
+`repo` field empty, since a refusal is a verdict about no repository.
 
 Auth: resolved through lib/gh-auth.sh, shared with approval-wait and
 queue-wait (kendex#19) — env-first: already-resolved GH_TOKEN /
@@ -420,6 +426,8 @@ fi
 repo_status=0
 REPO=$(orch_resolve_gh_repo "$PROJECT_ROOT") || repo_status=$?
 if [ "$repo_status" -eq 2 ]; then
+  REPO_REJECTED="$REPO"
+  REPO=""
   emit_error repo-shape
   ci_message repo-shape "$@" >&2
   exit 1

--- a/skills/orch/scripts/ci-wait
+++ b/skills/orch/scripts/ci-wait
@@ -30,19 +30,19 @@ ci_message() {
       printf '%s\n' "ci-wait: max_wait must be a positive integer (got '$MAX_WAIT')"
       ;;
     passed)
-      printf 'ci-wait: passed pr=%s\n' "$PR_NUM"
+      printf 'ci-wait: passed pr=%s repo=%s\n' "$PR_NUM" "${REPO:-unresolved}"
       printf '%s\n' "CI passed"
       ;;
     failed)
-      printf 'ci-wait: failed pr=%s\n' "$PR_NUM"
+      printf 'ci-wait: failed pr=%s repo=%s\n' "$PR_NUM" "${REPO:-unresolved}"
       printf '%s\n' "CI failed:"
       ;;
     timeout)
-      printf 'ci-wait: timeout elapsed=%s verdict=%s\n' "$elapsed" "$verdict"
+      printf 'ci-wait: timeout elapsed=%s verdict=%s repo=%s\n' "$elapsed" "$verdict" "${REPO:-unresolved}"
       printf '%s\n' "CI timeout after ${elapsed}s (verdict: $verdict)"
       ;;
     error)
-      printf 'ci-wait: error pr=%s\n' "$PR_NUM"
+      printf 'ci-wait: error pr=%s repo=%s\n' "$PR_NUM" "${REPO:-unresolved}"
       printf '%s\n' "CI error: $error_msg"
       ;;
     missing-gh)
@@ -67,7 +67,11 @@ ci_message() {
       ;;
     repo-unresolved)
       printf 'ci-wait: repo-unresolved remote=%s\n' "origin"
-      printf '%s\n' "Could not resolve GitHub repo (gh repo view and git remote both failed)"
+      printf '%s\n' "Could not resolve GitHub repo (GH_REPO unset, gh repo view and git remote both failed)"
+      ;;
+    repo-shape)
+      printf 'ci-wait: repo-shape repo=%q\n' "$REPO"
+      printf '%s\n' "could not read '$REPO' as owner/repo for the check queries"
       ;;
     conflicting)
       printf 'ci-wait: conflicting pr=%s state=%s\n' "$PR_NUM" "$merge_state"
@@ -137,6 +141,13 @@ PROJECT_ROOT="$(git rev-parse --show-toplevel 2>/dev/null || pwd)"
 
 # shellcheck source=lib/gh-auth.sh
 source "$SCRIPT_DIR/lib/gh-auth.sh"
+# shellcheck source=lib/gh-repo.sh
+source "$SCRIPT_DIR/lib/gh-repo.sh"
+
+# Named in every result, so a verdict states the repository it read. Empty
+# until the resolver below runs, which is after the auth ladder: an auth
+# failure is a verdict about no repository.
+REPO=""
 
 print_usage() {
   cat <<'USAGE'
@@ -182,6 +193,9 @@ JSON output (always when --json):
   {
     "status": "complete" | "timeout" | "error",
     "verdict": "pass" | "fail" | "pending" | "none",
+    "repo": <string>,             # the repository this verdict is about,
+                                  # "" only when the wait ended before it
+                                  # was resolved (missing gh, no auth)
     "elapsed_seconds": <int>,
     "error": <string>,            # only when status == "error"
     "pending_checks": [ {name,state} ... ],
@@ -199,6 +213,14 @@ Environment:
                 can lag. Within the grace window the result stays verdict
                 "pending"; past it, the explicit "no checks registered"
                 diagnostic fires.
+
+Repository: resolved through lib/gh-repo.sh, shared with approval-wait and
+queue-wait — GH_REPO first, then the working directory (`gh repo view`, then
+the origin remote) when GH_REPO is unset. `gh repo view` ignores GH_REPO and
+answers for the working directory, so a wait on another repository's PR from
+this checkout reads GH_REPO or nothing else will. Every result names the
+repository it read; a GH_REPO that is not owner/name is refused (repo-shape,
+exit 1) rather than sent to an API path that cannot hold it.
 
 Auth: resolved through lib/gh-auth.sh, shared with approval-wait and
 queue-wait (kendex#19) — env-first: already-resolved GH_TOKEN /
@@ -297,12 +319,14 @@ emit_result() {
     jq -n \
       --arg s "$status" \
       --arg v "$verdict" \
+      --arg repo "$REPO" \
       --argjson elapsed "$elapsed" \
       --arg error "$error_msg" \
       --argjson classes "$(jq -c 'map_values(map({name, state: (.state // .bucket // "UNKNOWN")}))' <<<"$classes")" \
       '{
         status: $s,
         verdict: $v,
+        repo: $repo,
         elapsed_seconds: $elapsed,
         pending_checks: $classes.pending,
         failed_checks: $classes.failed,
@@ -393,19 +417,14 @@ if [[ "$AUTH_READY" != "true" ]]; then
 fi
 
 # --- Resolve repo explicitly so gh calls don't depend on local auth/inference ---
-REPO=$(gh repo view --json nameWithOwner -q .nameWithOwner 2>/dev/null || true)
-if [ -z "$REPO" ]; then
-  origin_url=$(git -C "$PROJECT_ROOT" remote get-url origin 2>/dev/null || true)
-  # Capture owner/repo greedily, then strip a trailing ".git" explicitly. GNU
-  # sed / POSIX ERE has no non-greedy quantifier, so a `[^/]+?(\.git)?$` pattern
-  # would greedily swallow ".git" into the slug. Do the suffix
-  # strip with bash parameter expansion instead — portable for both SSH
-  # (git@github.com:owner/repo.git) and HTTPS origins, with or without ".git",
-  # and safe for repo names that merely contain the substring "git".
-  REPO=$(echo "$origin_url" | sed -nE 's#^.*github\.com[:/]+([^/]+/[^/]+)$#\1#p')
-  REPO="${REPO%.git}"
+repo_status=0
+REPO=$(orch_resolve_gh_repo "$PROJECT_ROOT") || repo_status=$?
+if [ "$repo_status" -eq 2 ]; then
+  emit_error repo-shape
+  ci_message repo-shape "$@" >&2
+  exit 1
 fi
-if [ -z "$REPO" ]; then
+if [ "$repo_status" -ne 0 ]; then
   emit_error repo-unresolved
   ci_message repo-unresolved "$@" >&2
   exit 1

--- a/skills/orch/scripts/ci-wait
+++ b/skills/orch/scripts/ci-wait
@@ -110,7 +110,7 @@ ci_message() {
       printf '%s\n' "no-CI probe inconclusive ($probe_name not probed: the PR's $probe_input lookup failed); continuing to wait for checks"
       ;;
     none-configured)
-      printf 'ci-wait: none-configured base=%s\n' "$base_branch"
+      printf 'ci-wait: none-configured base=%s repo=%s\n' "$base_branch" "$REPO"
       printf '%s\n' "CI: none configured (no active workflows, no required checks on $base_branch)"
       ;;
     no-checks)
@@ -690,8 +690,13 @@ while [ "$elapsed" -lt "$MAX_WAIT" ]; do
       if [ "$wf_count" = "0" ] && [ "$protected" = "false" ] && [ "$rule_checks" = "0" ] && [ "$ext_statuses" = "0" ]; then
         update_elapsed
         if $JSON_OUTPUT; then
-          jq -n --argjson elapsed "$elapsed" --arg base "$base_branch" \
-            '{status: "complete", verdict: "none", elapsed_seconds: $elapsed,
+          # emit_result derives its verdict from the check classes and carries
+          # no reason, neither of which this route can say, so it builds its
+          # own object. Every field it shares with emit_result, repo included,
+          # holds the same value there: this verdict names the repository it
+          # read like every other one.
+          jq -n --argjson elapsed "$elapsed" --arg base "$base_branch" --arg repo "$REPO" \
+            '{status: "complete", verdict: "none", repo: $repo, elapsed_seconds: $elapsed,
               reason: ("no CI configured: no active workflows and no required checks on " + $base),
               pending_checks: [], failed_checks: [], passed_checks: []}'
         else

--- a/skills/orch/scripts/lib/gh-repo.sh
+++ b/skills/orch/scripts/lib/gh-repo.sh
@@ -1,0 +1,56 @@
+# shellcheck shell=bash
+#
+# The repository the orch waiters read, resolved in one place.
+#
+# Source this file; do not execute it directly.
+
+# Resolve the owner/name slug every `gh --repo` argument and `repos/<slug>/`
+# API path in a waiter carries, so one value decides which repository a
+# verdict is about.
+#
+# GH_REPO wins. `gh repo view` resolves from the working directory and ignores
+# GH_REPO (gh 2.100), unlike `gh pr view` and the rest, so a caller waiting on
+# another repository's PR from this checkout would otherwise be handed this
+# checkout's repository and a verdict about its same-numbered pull request.
+# With GH_REPO unset, the working directory answers: `gh repo view` first, then
+# the origin remote for a checkout gh cannot resolve.
+#
+# Arguments: the project root whose origin remote the fallback reads.
+# Stdout: the resolved slug, or the rejected candidate on exit 2.
+# Exit: 0 resolved, 1 nothing resolved, 2 resolved to something that is not
+# owner/name — two non-empty segments around a single slash, which is what an
+# API path and a `--repo` argument accept.
+orch_resolve_gh_repo() {
+  local project_root="${1:?orch_resolve_gh_repo: project_root required}"
+  local repo origin_url origin_status
+
+  if [ -n "${GH_REPO:-}" ]; then
+    repo="$GH_REPO"
+  else
+    repo=$(gh repo view --json nameWithOwner -q .nameWithOwner 2>/dev/null || true)
+    if [ -z "$repo" ]; then
+      origin_status=0
+      origin_url=$(git -C "$project_root" remote get-url origin 2>/dev/null) || origin_status=$?
+      # git answers 2 for "no such remote" — a checkout with no origin. Any
+      # other status means git could not answer at all, most often because the
+      # project root is no repository. Neither resolves anything, and the
+      # caller refuses on that rather than falling back to a repository
+      # nobody named.
+      [ "$origin_status" -eq 0 ] || return 1
+      # Capture owner/repo greedily, then strip a trailing ".git" explicitly.
+      # GNU sed / POSIX ERE has no non-greedy quantifier, so a
+      # `[^/]+?(\.git)?$` pattern would greedily swallow ".git" into the slug.
+      # Do the suffix strip with bash parameter expansion instead — portable
+      # for both SSH (git@github.com:owner/repo.git) and HTTPS origins, with
+      # or without ".git", and safe for repo names that merely contain the
+      # substring "git".
+      repo=$(printf '%s' "$origin_url" | sed -nE 's#^.*github\.com[:/]+([^/]+/[^/]+)$#\1#p')
+      repo="${repo%.git}"
+    fi
+  fi
+
+  [ -n "$repo" ] || return 1
+  printf '%s\n' "$repo"
+  [[ "$repo" =~ ^[^/[:space:]]+/[^/[:space:]]+$ ]] || return 2
+  return 0
+}

--- a/skills/orch/scripts/queue-wait
+++ b/skills/orch/scripts/queue-wait
@@ -23,7 +23,7 @@ queue_message() {
       ;;
     repo-unresolved)
       printf 'queue-wait: repo-unresolved remote=%s\n' "origin"
-      printf '%s\n' "could not resolve GitHub repo (gh repo view and git remote both failed)"
+      printf '%s\n' "could not resolve GitHub repo (GH_REPO unset, gh repo view and git remote both failed)"
       ;;
     pr-view-failed)
       printf 'queue-wait: pr-view-failed pr=%s repo=%s\n' "$PR_NUM" "$REPO"
@@ -118,8 +118,15 @@ PROJECT_ROOT="$(git rev-parse --show-toplevel 2>/dev/null || pwd)"
 
 # shellcheck source=lib/gh-auth.sh
 source "$SCRIPT_DIR/lib/gh-auth.sh"
+# shellcheck source=lib/gh-repo.sh
+source "$SCRIPT_DIR/lib/gh-repo.sh"
 # shellcheck source=lib/review-threads.sh
 source "$SCRIPT_DIR/lib/review-threads.sh"
+
+# Named in every result, so a verdict states the repository it read. Empty
+# until the resolver below runs, which is after the auth ladder: an auth
+# failure is a verdict about no repository.
+REPO=""
 
 print_usage() {
   printf 'queue-wait: usage command=%s\n' 'queue-wait'
@@ -268,6 +275,9 @@ JSON output (always when --json):
     "verdict": "merged" | "conflicting" | "ejected" | "disarmed"
                | "dequeued" | "closed" | "queued" | "not_queued"
                | "unknown",
+    "repo": <string>,              # the repository this verdict is about,
+                                   # "" only when the wait ended before it
+                                   # was resolved (missing gh, no auth)
     "elapsed_seconds": <int>,
     "polls": <int>,
     "pr_state": <string>,          # OPEN | MERGED | CLOSED | "" (never read)
@@ -294,6 +304,14 @@ JSON output (always when --json):
     "transient_api_errors": <int>, # only when > 0
     "error": <string>              # only when status == "error"
   }
+
+Repository: resolved through lib/gh-repo.sh, shared with approval-wait and
+ci-wait — GH_REPO first, then the working directory (`gh repo view`, then
+the origin remote) when GH_REPO is unset. `gh repo view` ignores GH_REPO and
+answers for the working directory, so a wait on another repository's PR from
+this checkout reads GH_REPO or nothing else will. Every result names the
+repository it read; a GH_REPO that is not owner/name is refused (repo-shape,
+exit 1) rather than sent to an API path that cannot hold it.
 
 Auth: resolved through lib/gh-auth.sh, shared with approval-wait and
 ci-wait (kendex#19) — env-first: already-resolved GH_TOKEN/GITHUB_TOKEN/
@@ -519,6 +537,7 @@ emit_result() {
       --arg v "$verdict" \
       --argjson elapsed "$elapsed" \
       --argjson polls "$polls" \
+      --arg repo "$REPO" \
       --arg pr_state "$last_pr_state" \
       --arg merged_at "$last_merged_at" \
       --argjson in_queue "$last_in_queue" \
@@ -536,6 +555,7 @@ emit_result() {
       '{
         status: $s,
         verdict: $v,
+        repo: $repo,
         elapsed_seconds: $elapsed,
         polls: $polls,
         pr_state: $pr_state,
@@ -554,7 +574,7 @@ emit_result() {
         + (if $error == "" then {} else {error: $error} end)'
     return 0
   fi
-  printf 'queue-wait: result status=%s verdict=%s pr=%s cause=%s polls=%s progressing=%s\n' "$status" "$verdict" "$PR_NUM" "${last_cause:-none}" "$polls" "$progressing"
+  printf 'queue-wait: result status=%s verdict=%s pr=%s repo=%s cause=%s polls=%s progressing=%s\n' "$status" "$verdict" "$PR_NUM" "${REPO:-unresolved}" "${last_cause:-none}" "$polls" "$progressing"
   case "$verdict" in
     merged)
       echo "Merge queue: merged (PR #$PR_NUM${last_merged_at:+ at $last_merged_at})"
@@ -662,26 +682,20 @@ if [[ "$AUTH_READY" != "true" ]]; then
 fi
 
 # --- Resolve repo explicitly so gh calls don't depend on local auth/inference ---
-REPO=$(gh repo view --json nameWithOwner -q .nameWithOwner 2>/dev/null || true)
-if [ -z "$REPO" ]; then
-  origin_url=$(git -C "$PROJECT_ROOT" remote get-url origin 2>/dev/null || true)
-  # Capture owner/repo greedily, then strip a trailing ".git" explicitly — the
-  # same portable form ci-wait uses.
-  REPO=$(echo "$origin_url" | sed -nE 's#^.*github\.com[:/]+([^/]+/[^/]+)$#\1#p')
-  REPO="${REPO%.git}"
+repo_status=0
+REPO=$(orch_resolve_gh_repo "$PROJECT_ROOT") || repo_status=$?
+if [ "$repo_status" -eq 2 ]; then
+  emit_error repo-shape
+
+  exit 1
 fi
-if [ -z "$REPO" ]; then
+if [ "$repo_status" -ne 0 ]; then
   emit_error repo-unresolved
 
   exit 1
 fi
 REPO_OWNER="${REPO%%/*}"
 REPO_NAME="${REPO#*/}"
-if [ -z "$REPO_OWNER" ] || [ -z "$REPO_NAME" ] || [ "$REPO_OWNER" = "$REPO" ]; then
-  emit_error repo-shape
-
-  exit 1
-fi
 
 # mergeQueueEntry.position and .headCommit are schema-verified fields
 # (`__type(name:"MergeQueueEntry")`); headCommit is the merge-group commit

--- a/skills/orch/scripts/queue-wait
+++ b/skills/orch/scripts/queue-wait
@@ -30,8 +30,8 @@ queue_message() {
       printf '%s\n' "gh pr view failed for PR #$PR_NUM in $REPO"
       ;;
     repo-shape)
-      printf 'queue-wait: repo-shape repo=%q\n' "$REPO"
-      printf '%s\n' "could not split '$REPO' into owner/repo for the merge-queue query"
+      printf 'queue-wait: repo-shape repo=%q\n' "$REPO_REJECTED"
+      printf '%s\n' "could not split '$REPO_REJECTED' into owner/repo for the merge-queue query"
       ;;
     queue-rejected)
       printf 'queue-wait: queue-rejected pr=%s detail=%q\n' "$PR_NUM" "$gql_error"
@@ -125,8 +125,11 @@ source "$SCRIPT_DIR/lib/review-threads.sh"
 
 # Named in every result, so a verdict states the repository it read. Empty
 # until the resolver below runs, which is after the auth ladder: an auth
-# failure is a verdict about no repository.
+# failure is a verdict about no repository. A candidate the resolver refuses
+# is no repository either: it lands in REPO_REJECTED for the diagnostic to
+# name, never in REPO, so no consumer reads it as one that resolved.
 REPO=""
+REPO_REJECTED=""
 
 print_usage() {
   printf 'queue-wait: usage command=%s\n' 'queue-wait'
@@ -276,8 +279,9 @@ JSON output (always when --json):
                | "dequeued" | "closed" | "queued" | "not_queued"
                | "unknown",
     "repo": <string>,              # the repository this verdict is about,
-                                   # "" only when the wait ended before it
-                                   # was resolved (missing gh, no auth)
+                                   # "" whenever the wait ended before one
+                                   # was resolved: missing gh, no auth,
+                                   # repo-unresolved, repo-shape
     "elapsed_seconds": <int>,
     "polls": <int>,
     "pr_state": <string>,          # OPEN | MERGED | CLOSED | "" (never read)
@@ -311,7 +315,9 @@ the origin remote) when GH_REPO is unset. `gh repo view` ignores GH_REPO and
 answers for the working directory, so a wait on another repository's PR from
 this checkout reads GH_REPO or nothing else will. Every result names the
 repository it read; a GH_REPO that is not owner/name is refused (repo-shape,
-exit 1) rather than sent to an API path that cannot hold it.
+exit 1) rather than sent to an API path that cannot hold it. The
+refusal names the rejected value in its diagnostic line and leaves the JSON
+`repo` field empty, since a refusal is a verdict about no repository.
 
 Auth: resolved through lib/gh-auth.sh, shared with approval-wait and
 ci-wait (kendex#19) — env-first: already-resolved GH_TOKEN/GITHUB_TOKEN/
@@ -685,6 +691,8 @@ fi
 repo_status=0
 REPO=$(orch_resolve_gh_repo "$PROJECT_ROOT") || repo_status=$?
 if [ "$repo_status" -eq 2 ]; then
+  REPO_REJECTED="$REPO"
+  REPO=""
   emit_error repo-shape
 
   exit 1

--- a/skills/orch/tests/acceptance-verdicts.test.sh
+++ b/skills/orch/tests/acceptance-verdicts.test.sh
@@ -1,7 +1,8 @@
 #!/usr/bin/env bash
 # dev-artifact-check --verdict field, review-artifact-check --path mode, and
 # ci-wait's none-configured route: each acceptance answer must be a single
-# deterministic word the orchestrator can act on without combining checks.
+# deterministic word the orchestrator can act on without combining checks, and
+# that route's result must name the repository it read like every other one.
 set -euo pipefail
 source "$(dirname "${BASH_SOURCE[0]}")/lib/git-env.sh"
 
@@ -90,6 +91,15 @@ out=$(cd "$WT" && PATH="$BIN:$PATH" env -u GH_REPO GH_STUB_LOG="$TMP/gh.log" \
   CI_WAIT_NO_CHECKS_GRACE=1 GH_TOKEN=stub "$SCRIPTS/ci-wait" 1 1 5 --json 2>/dev/null || true)
 check "no workflows + no protection + no rules → verdict none" "none" "$(jq -r '.verdict // empty' <<<"$out")"
 check "none-configured is status complete" "complete" "$(jq -r '.status // empty' <<<"$out")"
+# This route builds its own result object rather than routing through
+# emit_result, so the repository every other verdict names is asserted here
+# too, on both the JSON object and the plain line.
+check "none-configured names the repository it read" "owner/repo" "$(jq -r '.repo // empty' <<<"$out")"
+
+text=$(cd "$WT" && PATH="$BIN:$PATH" env -u GH_REPO GH_STUB_LOG="$TMP/gh-text.log" \
+  CI_WAIT_NO_CHECKS_GRACE=1 GH_TOKEN=stub "$SCRIPTS/ci-wait" 1 1 5 2>/dev/null || true)
+check "the plain none-configured line names its base and repository" \
+  "ci-wait: none-configured base=main repo=owner/repo" "${text%%$'\n'*}"
 
 # Teeth: with active workflows present the shortcut must NOT fire — the run
 # falls through to the grace path and, at grace 1s with no checks, errors out.

--- a/skills/orch/tests/acceptance-verdicts.test.sh
+++ b/skills/orch/tests/acceptance-verdicts.test.sh
@@ -73,6 +73,7 @@ case "$*" in
   *"actions/workflows"*) if [[ "${GH_STUB_WORKFLOWS:-0}" == "0" ]]; then echo "0"; else echo "${GH_STUB_WORKFLOWS}"; fi; exit 0 ;;
   *"rules/branches"*) echo "0"; exit 0 ;;
   *"branches/main"*) echo "false"; exit 0 ;;
+  *"repo view"*) echo "owner/repo"; exit 0 ;;
   *"pr view"*"baseRefName"*) echo "main"; exit 0 ;;
   *"pr view"*"headRefOid"*) echo "deadbeefcafe"; exit 0 ;;
   *"/status"*) echo "${GH_STUB_EXT_STATUSES:-0}"; exit 0 ;;
@@ -85,15 +86,15 @@ esac
 EOF
 chmod +x "$BIN/gh"
 
-out=$(cd "$WT" && GH_STUB_LOG="$TMP/gh.log" CI_WAIT_NO_CHECKS_GRACE=1 \
-  PATH="$BIN:$PATH" GH_TOKEN=stub "$SCRIPTS/ci-wait" 1 1 5 --json 2>/dev/null || true)
+out=$(cd "$WT" && PATH="$BIN:$PATH" env -u GH_REPO GH_STUB_LOG="$TMP/gh.log" \
+  CI_WAIT_NO_CHECKS_GRACE=1 GH_TOKEN=stub "$SCRIPTS/ci-wait" 1 1 5 --json 2>/dev/null || true)
 check "no workflows + no protection + no rules → verdict none" "none" "$(jq -r '.verdict // empty' <<<"$out")"
 check "none-configured is status complete" "complete" "$(jq -r '.status // empty' <<<"$out")"
 
 # Teeth: with active workflows present the shortcut must NOT fire — the run
 # falls through to the grace path and, at grace 1s with no checks, errors out.
-out2=$(cd "$WT" && GH_STUB_WORKFLOWS=3 CI_WAIT_NO_CHECKS_GRACE=1 \
-  PATH="$BIN:$PATH" GH_TOKEN=stub "$SCRIPTS/ci-wait" 1 1 5 --json 2>/dev/null || true)
+out2=$(cd "$WT" && PATH="$BIN:$PATH" env -u GH_REPO GH_STUB_WORKFLOWS=3 \
+  CI_WAIT_NO_CHECKS_GRACE=1 GH_TOKEN=stub "$SCRIPTS/ci-wait" 1 1 5 --json 2>/dev/null || true)
 v2="$(jq -r '.verdict // empty' <<<"$out2")"
 if [[ "$v2" != "none" ]]; then
   ok "active workflows suppress the none-configured shortcut (teeth)"

--- a/skills/orch/tests/approval_wait.sh
+++ b/skills/orch/tests/approval_wait.sh
@@ -626,11 +626,13 @@ echo "=== the verdict names the repository it read ==="
 # wait launched from this checkout for another repository's PR read this
 # checkout's same-numbered PR. GH_REPO decides; a value that is not owner/name
 # is refused before any review read, never sent to an API path that cannot
-# hold it.
+# hold it. The refusal names the rejected value in its diagnostic and leaves
+# the result's repo empty, so nothing reads an unvalidated candidate as the
+# repository the verdict is about.
 table "$APPROVAL" \
   'GH_REPO names the repository, over the checkout gh repo view answers for||GH_REPO=other/elsewhere,STUB_APPROVAL_MODE=approved_decision|rc=0 status=approved repo=other/elsewhere' \
   'GH_REPO unset names the checkout||STUB_APPROVAL_MODE=approved_decision|rc=0 status=approved repo=owner/repo' \
-  'a GH_REPO that is not owner/name is refused||GH_REPO=elsewhere,STUB_APPROVAL_MODE=approved_decision|rc=1 status=error error_line=approval-wait:+repo-shape+repo=elsewhere'
+  'a GH_REPO that is not owner/name is refused||GH_REPO=elsewhere,STUB_APPROVAL_MODE=approved_decision|rc=1 status=error repo= error_line=approval-wait:+repo-shape+repo=elsewhere'
 
 echo "=== text mode prints a result line for every branch the emitter has ==="
 # The line's wording is not a contract anything parses; what holds is that no

--- a/skills/orch/tests/approval_wait.sh
+++ b/skills/orch/tests/approval_wait.sh
@@ -425,7 +425,7 @@ run_wait() {
   [[ -z "$env_list" ]] || IFS=',' read -ra env_args <<<"$env_list"
   set +e
   OUT=$(cd "$TMP_ROOT/repo" && PATH="$TMP_ROOT/bin:$PATH" \
-    env ${env_args[@]+"${env_args[@]}"} \
+    env -u GH_REPO ${env_args[@]+"${env_args[@]}"} \
         STUB_APPROVAL_COUNT_FILE="$RUN/approval-polls" \
         STUB_REVIEWS_COUNT_FILE="$RUN/review-polls" \
         STUB_HEAD_COUNT_FILE="$RUN/head-polls" \
@@ -453,6 +453,8 @@ count_lines() { # FILE — 0 when it was never written
 #   outage_marker                   whether the JSON carries that field
 #   target_patterns   auto_review_targets joined, so a row compares as one word
 #   transient_errors_seen           transient_api_errors >= 1
+#   text_repo the repo field on the plain result's first line
+#   error_line  first line of the JSON error, spaces encoded as +
 observe() {
   local got="" token name
   for token in $1; do
@@ -463,6 +465,8 @@ observe() {
       spent) got="$got spent=$(json '.elapsed_seconds >= 3')" ;;
       stdout) got="$got stdout=$([[ -n "$OUT" ]] && echo line || echo empty)" ;;
       text_status) got="$got text_status=$(sed -n '1s/^approval-wait: result status=\([^ ]*\).*$/\1/p' <<<"$OUT")" ;;
+      text_repo) got="$got text_repo=$(sed -n '1s/^approval-wait: result .* repo=\([^ ]*\).*$/\1/p' <<<"$OUT")" ;;
+      error_line) got="$got error_line=$(json '.error | split("\n")[0]' | tr ' ' '+')" ;;
       approval_polls) got="$got approval_polls=$(cat "$RUN/approval-polls" 2>/dev/null || echo 0)" ;;
       review_polls) got="$got review_polls=$(cat "$RUN/review-polls" 2>/dev/null || echo 0)" ;;
       status_queries) got="$got status_queries=$(count_lines "$RUN/status-queries")" ;;
@@ -617,6 +621,17 @@ table "$REVIEW" \
   'a 404 is terminal at once with no transient count||STUB_REVIEWS_MODE=http_404|rc=1 status=error transient_api_errors=null early=true' \
   'approval-mode pr view 503s then an approval is approved with the count|1 1 3 --json|STUB_APPROVAL_MODE=approved_after_503|rc=0 status=approved transient_api_errors=2'
 
+echo "=== the verdict names the repository it read ==="
+# `gh repo view` answers for the working directory and ignores GH_REPO, so a
+# wait launched from this checkout for another repository's PR read this
+# checkout's same-numbered PR. GH_REPO decides; a value that is not owner/name
+# is refused before any review read, never sent to an API path that cannot
+# hold it.
+table "$APPROVAL" \
+  'GH_REPO names the repository, over the checkout gh repo view answers for||GH_REPO=other/elsewhere,STUB_APPROVAL_MODE=approved_decision|rc=0 status=approved repo=other/elsewhere' \
+  'GH_REPO unset names the checkout||STUB_APPROVAL_MODE=approved_decision|rc=0 status=approved repo=owner/repo' \
+  'a GH_REPO that is not owner/name is refused||GH_REPO=elsewhere,STUB_APPROVAL_MODE=approved_decision|rc=1 status=error error_line=approval-wait:+repo-shape+repo=elsewhere'
+
 echo "=== text mode prints a result line for every branch the emitter has ==="
 # The line's wording is not a contract anything parses; what holds is that no
 # terminal status leaves stdout empty, with the same exit code as --json. The
@@ -638,7 +653,8 @@ table '1 1 3' \
   "review: timeout|$TEXT_REVIEW|STUB_REVIEWS_MODE=none|rc=1 text_status=timeout" \
   "review: error|$TEXT_REVIEW|GH_TOKEN=bad-token,STUB_GH_DENY_KEYRING=1|rc=3 text_status=error" \
   "review: proceeded|$TEXT_REVIEW|STUB_REVIEWS_MODE=none,PR_REVIEW_ON_TIMEOUT=proceed|rc=0 text_status=proceeded" \
-  "review: unreviewable|$TEXT_REVIEW|STUB_REVIEWS_MODE=none,STUB_BASE_REF=stack-base|rc=1 text_status=unreviewable"
+  "review: unreviewable|$TEXT_REVIEW|STUB_REVIEWS_MODE=none,STUB_BASE_REF=stack-base|rc=1 text_status=unreviewable" \
+  'the result line names the repository it read||GH_REPO=other/elsewhere,STUB_APPROVAL_MODE=approved_decision|rc=0 text_status=approved text_repo=other/elsewhere'
 
 echo "=== PR_REVIEW_WAIT_SECS: an absent max_wait positional resolves through orch-env ==="
 # Process env beats kendex.settings.toml [env], and an explicit positional

--- a/skills/orch/tests/ci_wait.sh
+++ b/skills/orch/tests/ci_wait.sh
@@ -285,7 +285,7 @@ run_wait() {
   [[ -z "$env_list" ]] || IFS=',' read -ra env_args <<<"$env_list"
   set +e
   OUT=$(cd "$TMP_ROOT/repo" && PATH="$TMP_ROOT/bin:$PATH" \
-    env ${env_args[@]+"${env_args[@]}"} \
+    env -u GH_REPO ${env_args[@]+"${env_args[@]}"} \
         STUB_GH_API_USER_COUNT_FILE="$RUN/api-user-calls" \
         STUB_PR_CHECKS_COUNT_FILE="$RUN/checks-polls" \
         STUB_REPO_ARG_FILE="$RUN/repo-arg" \
@@ -447,10 +447,21 @@ echo "=== text mode prints a result line for every terminal status ==="
 # The line beyond its leading words is not a contract anything parses; the
 # leading words are text-only, so a JSON default flip fails these rows.
 table '1 1 30' \
-  'passed||||rc=0 stdout~ci-wait:+passed+pr=1=true' \
-  'failed|||STUB_PR_CHECKS_MODE=failure|rc=1 stdout~ci-wait:+failed+pr=1=true' \
-  'timeout||1 1 5|STUB_PR_CHECKS_MODE=pending_always|rc=1 stdout~ci-wait:+timeout+elapsed=5+verdict=pending=true' \
-  'error|||STUB_PR_CHECKS_MODE=empty,CI_WAIT_NO_CHECKS_GRACE=3|rc=1 stdout~ci-wait:+error+pr=1=true'
+  'passed||||rc=0 stdout~ci-wait:+passed+pr=1+repo=owner/repo=true' \
+  'failed|||STUB_PR_CHECKS_MODE=failure|rc=1 stdout~ci-wait:+failed+pr=1+repo=owner/repo=true' \
+  'timeout||1 1 5|STUB_PR_CHECKS_MODE=pending_always|rc=1 stdout~ci-wait:+timeout+elapsed=5+verdict=pending+repo=owner/repo=true' \
+  'error|||STUB_PR_CHECKS_MODE=empty,CI_WAIT_NO_CHECKS_GRACE=3|rc=1 stdout~ci-wait:+error+pr=1+repo=owner/repo=true'
+
+echo "=== the verdict names the repository it read ==="
+# `gh repo view` answers for the working directory and ignores GH_REPO, so a
+# wait launched from this checkout for another repository's PR read this
+# checkout's same-numbered PR. GH_REPO decides, and the slug it names is what
+# reaches `gh --repo`; a value that is not owner/name is refused before any
+# check read.
+table "$JSON" \
+  'GH_REPO names the repository, over the checkout gh repo view answers for|||GH_REPO=other/elsewhere|rc=0 verdict=pass repo=other/elsewhere repo_arg=other/elsewhere' \
+  'GH_REPO unset names the checkout||||rc=0 verdict=pass repo=owner/repo repo_arg=owner/repo' \
+  'a GH_REPO that is not owner/name is refused|||GH_REPO=elsewhere|rc=1 status=error error_named=true stderr~ci-wait:+repo-shape+repo=elsewhere=true repo_arg=none'
 
 echo "=== the repo slug falls back to the origin URL without its .git suffix ==="
 # When `gh repo view` answers empty, owner/repo comes from the origin URL; the

--- a/skills/orch/tests/ci_wait.sh
+++ b/skills/orch/tests/ci_wait.sh
@@ -457,11 +457,13 @@ echo "=== the verdict names the repository it read ==="
 # wait launched from this checkout for another repository's PR read this
 # checkout's same-numbered PR. GH_REPO decides, and the slug it names is what
 # reaches `gh --repo`; a value that is not owner/name is refused before any
-# check read.
+# check read. The refusal names the rejected value in its diagnostic and
+# leaves the result's repo empty, so nothing reads an unvalidated candidate
+# as the repository the verdict is about.
 table "$JSON" \
   'GH_REPO names the repository, over the checkout gh repo view answers for|||GH_REPO=other/elsewhere|rc=0 verdict=pass repo=other/elsewhere repo_arg=other/elsewhere' \
   'GH_REPO unset names the checkout||||rc=0 verdict=pass repo=owner/repo repo_arg=owner/repo' \
-  'a GH_REPO that is not owner/name is refused|||GH_REPO=elsewhere|rc=1 status=error error_named=true stderr~ci-wait:+repo-shape+repo=elsewhere=true repo_arg=none'
+  'a GH_REPO that is not owner/name is refused|||GH_REPO=elsewhere|rc=1 status=error error_named=true repo= stderr~ci-wait:+repo-shape+repo=elsewhere=true repo_arg=none'
 
 echo "=== the repo slug falls back to the origin URL without its .git suffix ==="
 # When `gh repo view` answers empty, owner/repo comes from the origin URL; the

--- a/skills/orch/tests/gh-repo-resolve.test.sh
+++ b/skills/orch/tests/gh-repo-resolve.test.sh
@@ -1,0 +1,135 @@
+#!/usr/bin/env bash
+# Tests for orch/scripts/lib/gh-repo.sh, the one resolver ci-wait, queue-wait
+# and approval-wait ask which repository they are waiting on.
+#
+# Its reason to exist: `gh repo view` answers for the working directory and
+# ignores GH_REPO, so three inline copies of it handed a caller waiting on
+# another repository's PR from this checkout a verdict about this checkout's
+# same-numbered PR. GH_REPO decides; the working directory answers only when
+# GH_REPO is unset.
+#
+# One case per behaviour surface; shaped input is one table, one asserted row
+# per shape.
+set -euo pipefail
+source "$(dirname "${BASH_SOURCE[0]}")/lib/git-env.sh"
+TEST_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$TEST_DIR/../../.." && pwd)"
+TMP_ROOT="$(mktemp -d)"
+trap 'rm -rf "$TMP_ROOT"' EXIT
+
+# shellcheck source=lib/waiter-assertions.sh
+source "$TEST_DIR/lib/waiter-assertions.sh"
+
+LIVE_LIB="$REPO_ROOT/skills/orch/scripts/lib/gh-repo.sh"
+
+# `gh repo view` stand-in. STUB_REPO_VIEW is what it answers; empty means it
+# printed nothing, the shape a checkout gh cannot resolve produces.
+mkdir -p "$TMP_ROOT/bin"
+cat > "$TMP_ROOT/bin/gh" <<'EOF'
+#!/usr/bin/env bash
+set -uo pipefail
+if [[ "${1:-}" == "repo" && "${2:-}" == "view" ]]; then
+  [[ -n "${STUB_REPO_VIEW:-}" ]] && printf '%s\n' "$STUB_REPO_VIEW"
+  exit 0
+fi
+printf 'unexpected gh call: %s\n' "$*" >&2
+exit 1
+EOF
+chmod +x "$TMP_ROOT/bin/gh"
+
+# Two project roots: one with a github.com origin for the remote fallback, one
+# with no remote at all, where nothing resolves.
+for name in origin-repo no-remote; do
+  mkdir -p "$TMP_ROOT/$name"
+  git -C "$TMP_ROOT/$name" init -q
+  git -C "$TMP_ROOT/$name" config user.email test@example.com
+  git -C "$TMP_ROOT/$name" config user.name Test
+done
+git -C "$TMP_ROOT/origin-repo" remote add origin git@github.com:remote-owner/remote-repo.git
+
+# run_resolve ENV ROOT LIB — call the resolver with ENV (a comma-separated
+# list of `env` arguments) against ROOT, through LIB. Sets OUT and RC.
+# GH_REPO comes off first so a row's own value is the only one in play.
+run_resolve() {
+  local env_list="$1" root="$2" lib="$3" env_args=()
+  [[ -z "$env_list" ]] || IFS=',' read -ra env_args <<<"$env_list"
+  ERR="$TMP_ROOT/stderr"
+  set +e
+  OUT=$(PATH="$TMP_ROOT/bin:$PATH" \
+    env -u GH_REPO ${env_args[@]+"${env_args[@]}"} \
+      bash -c 'set -uo pipefail; . "$1"; orch_resolve_gh_repo "$2"' \
+      bash "$lib" "$TMP_ROOT/$root" 2>"$ERR")
+  RC=$?
+  set -e
+}
+
+# observe EXPECT — the run's value of every `name=` field EXPECT names, in
+# EXPECT's order, so a row compares as one string.
+#   rc   the resolver's exit status
+#   out  its stdout with spaces encoded as `+`, `empty` when it printed
+#        nothing — a row's fields are whitespace-separated
+observe() {
+  local got="" token name value
+  for token in $1; do
+    name="${token%%=*}"
+    case "$name" in
+      rc) value="$RC" ;;
+      out) value="${OUT:-empty}"; value="${value// /+}" ;;
+      *) printf 'observe: unknown field %s\n' "$name" >&2; exit 1 ;;
+    esac
+    got="$got $name=$value"
+  done
+  printf '%s' "${got# }"
+}
+
+# table ROW... — one run and one assertion per row.
+# A row is `label|env|root|expect`.
+table() {
+  local row label env root expect
+  for row in "$@"; do
+    IFS='|' read -r label env root expect <<<"$row"
+    [[ -n "$expect" ]] || { printf 'table: a row with no expect asserts nothing: %s\n' "$row" >&2; exit 1; }
+    run_resolve "$env" "$root" "$LIVE_LIB"
+    assert_eq "$(observe "$expect")" "$expect" "$label" "$ERR"
+  done
+}
+
+echo "=== GH_REPO decides; the working directory answers only without it ==="
+# The fail-open this resolver exists to close: with GH_REPO naming another
+# repository, a `gh repo view` that answers for this checkout must not win.
+table \
+  'GH_REPO names the repository, over a resolvable checkout|GH_REPO=other/elsewhere,STUB_REPO_VIEW=cwd-owner/cwd-repo|origin-repo|rc=0 out=other/elsewhere' \
+  'GH_REPO unset reads the checkout|STUB_REPO_VIEW=cwd-owner/cwd-repo|origin-repo|rc=0 out=cwd-owner/cwd-repo' \
+  'GH_REPO wins even where the checkout resolves to nothing|GH_REPO=other/elsewhere|no-remote|rc=0 out=other/elsewhere' \
+  'an unresolvable checkout falls back to the origin remote, without its .git suffix||origin-repo|rc=0 out=remote-owner/remote-repo' \
+  'no GH_REPO, no gh answer and no origin resolves nothing, never a default||no-remote|rc=1 out=empty'
+
+echo "=== a GH_REPO that is not owner/name is refused, never queried ==="
+# The refused value is still printed, so the waiter's repo-shape line names
+# what it rejected. A bare name, a three-segment host form and a value
+# carrying whitespace each reach an API path that cannot hold them.
+table \
+  'a bare name has no owner|GH_REPO=elsewhere|origin-repo|rc=2 out=elsewhere' \
+  'a host-prefixed three-segment form|GH_REPO=github.com/other/elsewhere|origin-repo|rc=2 out=github.com/other/elsewhere' \
+  'an empty owner segment|GH_REPO=/elsewhere|origin-repo|rc=2 out=/elsewhere' \
+  'an empty name segment|GH_REPO=other/|origin-repo|rc=2 out=other/' \
+  'a value carrying whitespace|GH_REPO=other/else where|origin-repo|rc=2 out=other/else+where'
+
+echo "=== must-fail control ==="
+# Remove the GH_REPO-first behaviour while keeping its lines: the first row
+# above is the one that reddens, and it reddens with the checkout's repository
+# — exactly the wrong-repository verdict the issue reported.
+MUTANT="$TMP_ROOT/gh-repo-mutant.sh"
+cp "$LIVE_LIB" "$MUTANT"
+assert_eq "$(grep -Fc 'if [ -n "${GH_REPO:-}" ]; then' "$MUTANT")" "1" \
+  "control finds exactly one live GH_REPO branch"
+sed -i.bak 's/^  if \[ -n "${GH_REPO:-}" \]; then$/  if [ -n "" ]; then/' "$MUTANT"
+assert_eq "$(grep -Fc 'if [ -n "" ]; then' "$MUTANT")" "1" \
+  "control applied the mutation"
+run_resolve 'GH_REPO=other/elsewhere,STUB_REPO_VIEW=cwd-owner/cwd-repo' origin-repo "$MUTANT"
+assert_eq "$(observe 'rc=0 out=cwd-owner/cwd-repo')" "rc=0 out=cwd-owner/cwd-repo" \
+  "must-fail control: without the GH_REPO branch the checkout's repository wins" "$ERR"
+
+echo
+printf 'pass: %d   fail: %d\n' "$PASS" "$FAIL"
+[[ "$FAIL" -eq 0 ]]

--- a/skills/orch/tests/queue_wait.sh
+++ b/skills/orch/tests/queue_wait.sh
@@ -370,6 +370,8 @@ STAGE_SEQ=0
 # how production invokes it, with the staged sequence directory and the
 # suite's default knobs; ENV is a comma-separated list of `env` arguments
 # that may override those knobs. Sets OUT, RC and ERR (the stderr file).
+# GH_REPO comes off first: it decides which repository the wait reads, so the
+# runner's own value would otherwise answer for every row.
 run_wait() {
   local env_list="$1" env_args=()
   shift
@@ -377,7 +379,7 @@ run_wait() {
   ERR="$SEQ_DIR/stderr"
   set +e
   OUT=$(cd "$TMP_ROOT/repo" && PATH="$TMP_ROOT/bin:$PATH" \
-    env STUB_SEQ_DIR="$SEQ_DIR" \
+    env -u GH_REPO STUB_SEQ_DIR="$SEQ_DIR" \
         QUEUE_WAIT_CONFIRM_POLLS=2 \
         QUEUE_WAIT_ARM_GRACE=120 \
         QUEUE_WAIT_PROBE_INTERVAL=0 \
@@ -396,6 +398,7 @@ json() { jq -r "$1" <<<"$OUT" 2>/dev/null || echo UNPARSEABLE; }
 #   error_line        first line of the JSON error, spaces encoded as +
 #   stdout            `line` when anything was printed, `empty` otherwise
 #   text_verdict      the verdict field on the plain result's first line
+#   text_repo         the repo field on that same line
 #   help_record       stable usage record, spaces encoded as +
 #   mutations         the GraphQL mutations issued, in order: `disable`,
 #                     `dequeue`, or `none`
@@ -414,6 +417,7 @@ observe() {
       error_line) value="$(json '.error | split("\n")[0]')"; value="${value// /+}" ;;
       stdout) value="$([[ -n "$OUT" ]] && echo line || echo empty)" ;;
       text_verdict) value="$(sed -n '1s/^queue-wait: result status=[^ ]* verdict=\([^ ]*\).*$/\1/p' <<<"$OUT")" ;;
+      text_repo) value="$(sed -n '1s/^queue-wait: result .* repo=\([^ ]*\).*$/\1/p' <<<"$OUT")" ;;
       help_record) value="${OUT%%$'\n'*}"; value="${value// /+}" ;;
       mutations)
         value="$(sed -e 's/^disablePullRequestAutoMerge .*/disable/' -e 's/^dequeuePullRequest .*/dequeue/' "$SEQ_DIR/mutations.log" 2>/dev/null | paste -sd, - || true)"
@@ -533,6 +537,17 @@ table '1 1 8 --json --no-check-probe' \
   'a failed read between two reads does not erase the movement|open_queued_head,checkruns:1=c1.0,checkruns:2=fail502,checkruns:last=c2.0|1 1 4 --json --no-check-probe||verdict=queued progressing=true cause=still_progressing' \
   'a merged verdict carries progressing and no cause|state:last=merged,queue:last=in_head|1 1 10 --json --no-check-probe||verdict=merged has_progressing=true has_cause=false'
 
+echo "=== the verdict names the repository it read ==="
+# `gh repo view` answers for the working directory and ignores GH_REPO, so a
+# wait launched from this checkout for another repository's PR read this
+# checkout's same-numbered PR and called it merged. GH_REPO decides; a value
+# that is not owner/name is refused before any poll, never sent to an API
+# path that cannot hold it.
+table "$QW" \
+  'GH_REPO names the repository, over the checkout gh repo view answers for|state:last=merged,queue:last=in|1 1 10 --json --no-check-probe|GH_REPO=other/elsewhere|rc=0 verdict=merged repo=other/elsewhere' \
+  'GH_REPO unset names the checkout|state:last=merged,queue:last=in|1 1 10 --json --no-check-probe||rc=0 verdict=merged repo=owner/repo' \
+  'a GH_REPO that is not owner/name is refused|open_queued||GH_REPO=elsewhere|rc=1 status=error verdict=unknown error_line=queue-wait:+repo-shape+repo=elsewhere'
+
 echo "=== text mode names the verdict on stdout ==="
 # The line's wording beyond the verdict word is not a contract anything
 # parses; what holds is that every verdict prints its own line, with the same
@@ -541,7 +556,8 @@ table '1 1 20 --no-check-probe' \
   'ejected|state:last=open,queue:1=in,queue:last=out|||rc=1 text_verdict=ejected' \
   "dequeued|open_queued,threads:last=late,$DQ|||rc=1 text_verdict=dequeued" \
   'queued after one poll|open_queued|1 1 1 --no-check-probe||rc=1 text_verdict=queued' \
-  'queued and stalled|open_queued_head,checkruns:last=c1.0|1 1 8 --no-check-probe||rc=1 text_verdict=queued'
+  'queued and stalled|open_queued_head,checkruns:last=c1.0|1 1 8 --no-check-probe||rc=1 text_verdict=queued' \
+  'the result line names the repository it read|state:last=merged,queue:last=in|1 1 10 --no-check-probe|GH_REPO=other/elsewhere|rc=0 text_verdict=merged text_repo=other/elsewhere'
 
 echo "=== argument validation ends in the parser, before any gh call ==="
 # The recording gh stub fails every call, so a case that reached auth or a

--- a/skills/orch/tests/queue_wait.sh
+++ b/skills/orch/tests/queue_wait.sh
@@ -542,11 +542,13 @@ echo "=== the verdict names the repository it read ==="
 # wait launched from this checkout for another repository's PR read this
 # checkout's same-numbered PR and called it merged. GH_REPO decides; a value
 # that is not owner/name is refused before any poll, never sent to an API
-# path that cannot hold it.
+# path that cannot hold it. The refusal names the rejected value in its
+# diagnostic and leaves the result's repo empty, so nothing reads an
+# unvalidated candidate as the repository the verdict is about.
 table "$QW" \
   'GH_REPO names the repository, over the checkout gh repo view answers for|state:last=merged,queue:last=in|1 1 10 --json --no-check-probe|GH_REPO=other/elsewhere|rc=0 verdict=merged repo=other/elsewhere' \
   'GH_REPO unset names the checkout|state:last=merged,queue:last=in|1 1 10 --json --no-check-probe||rc=0 verdict=merged repo=owner/repo' \
-  'a GH_REPO that is not owner/name is refused|open_queued||GH_REPO=elsewhere|rc=1 status=error verdict=unknown error_line=queue-wait:+repo-shape+repo=elsewhere'
+  'a GH_REPO that is not owner/name is refused|open_queued||GH_REPO=elsewhere|rc=1 status=error verdict=unknown repo= error_line=queue-wait:+repo-shape+repo=elsewhere'
 
 echo "=== text mode names the verdict on stdout ==="
 # The line's wording beyond the verdict word is not a contract anything

--- a/skills/orch/tests/queue_wait_conflicting.sh
+++ b/skills/orch/tests/queue_wait_conflicting.sh
@@ -163,7 +163,7 @@ run_queue_wait() {
   shift || true
   (cd "$TMP_ROOT/repo" \
     && PATH="$TMP_ROOT/bin:$PATH" \
-       env STUB_SEQ_DIR="$SEQ_DIR" \
+       env -u GH_REPO STUB_SEQ_DIR="$SEQ_DIR" \
            QUEUE_WAIT_CONFIRM_POLLS=2 \
            QUEUE_WAIT_ARM_GRACE=120 \
            QUEUE_WAIT_PROBE_INTERVAL=0 \
@@ -291,7 +291,7 @@ err="$TMP_ROOT/e6"
 out="$(run_queue_wait -- 1 1 20 --no-check-probe 2>"$err")" && rc=0 || rc=$?
 assert_eq "$rc" "1" "plain conflicting result exits 1" "$err"
 assert_eq "$(sed -n '1p' <<<"$out")" \
-  "queue-wait: result status=complete verdict=conflicting pr=1 cause=base_conflict polls=2 progressing=null" \
+  "queue-wait: result status=complete verdict=conflicting pr=1 repo=owner/repo cause=base_conflict polls=2 progressing=null" \
   "the plain result carries the confirmed verdict and cause" "$err"
 
 # queue-verdict-routing-lint.test.sh checks the help enum against emitted verdicts.


### PR DESCRIPTION
## Summary
- `queue-wait`, `ci-wait` and `approval-wait` bound their repository with `gh repo view`, which reads the working directory and ignores `GH_REPO`. A wait launched from one checkout for another repository's pull request read the checkout's same-numbered PR and returned its verdict: queue-wait reported `merged` for PRs that were still open.
- One shared resolver, `skills/orch/scripts/lib/gh-repo.sh` (`orch_resolve_gh_repo`), replaces the three inline copies: `GH_REPO` first, then `gh repo view`, then the origin remote. A value that is not `owner/name` is refused with the stable line `<waiter>: repo-shape repo=<value>` and exit 1 instead of reaching an API path.
- Every verdict names the repository it read: a `repo` field in each waiter's JSON object and a `repo=` pair on the plain result's first line. Each script's `--help` gains a `Repository:` paragraph stating the rule.

## Done-when map
- GH_REPO-first resolution shared by the three waiters: `skills/orch/scripts/lib/gh-repo.sh`; call sites in `skills/orch/scripts/queue-wait`, `ci-wait`, `approval-wait`.
- Every verdict names its repository: `emit_result` and the plain-line printf in each of the three scripts.
- Controls: `skills/orch/tests/gh-repo-resolve.test.sh` (GH_REPO set from a checkout reads that repository; unset reads the checkout's; malformed refuses with key, value and exit status); one row per waiter in `queue_wait.sh`, `ci_wait.sh`, `approval_wait.sh` asserting the verdict's repo.
- `.agents/skills/orch/**`: the tracked render, replayed byte-for-byte.

## Review dispositions
- reviewer-correctness blocker (workflow sites outside `merge-pr.md` § 5 call the waiters without `env -u GH_REPO`, so an inherited value now retargets them): Declined. The github.sh commands at those same sites (`pr-merge --check`, `pr-threads`, `pr-create`) run bare `gh pr view` / `gh api`, which honour `GH_REPO`, so those sections already ran under GH_REPO semantics; the waiters were the one judge that disagreed, which is the symptom this issue names. The Done-when asks for GH_REPO-first parity with github.sh and a named repository on every verdict; a `--repo` flag that outranks `GH_REPO` would contradict it.
- Suggestion (unit test sources the resolver under `set -uo` while callers use `set -euo`): Declined as hypothetical with no producing run; the three waiter suites exercise the integrated path under the callers' options.
- Suggestion (`oversee-watch` and `open-terminal` keep inline `gh repo view` copies behind an explicit repo argument): proposed to the owner as a follow-up together with `label-add.sh`, which has the same call and no explicit argument.

## PR review round 1
- Copilot: a `repo-shape` refusal emitted the rejected candidate in the JSON `repo` field, contradicting the help contract. Fixed in de5c1dbd8: the refusal clears `REPO` before emitting, the diagnostic line still names the rejected value, the help lists the refusal cases, and each waiter suite's repo-shape row asserts the empty field.

## PR review round 2
- Copilot: the `verdict: none` (no CI configured) terminal path built its own result outside the repo-aware emitter, so it named no repository. Fixed in d86bd8a28: that JSON object carries `repo` and its first line a `repo=` pair; the acceptance-verdicts suite asserts both.

## Completed Issues
- Closes KEN-1342 - orch waiters bind the repository from the working directory and ignore GH_REPO, returning another repository's verdict

## Size
branch-size-check: production=154 tests=194 mirror=348, no allowance stated on the issue.

## Test Plan
- `skills/orch/tests/gh-repo-resolve.test.sh`, `queue_wait.sh`, `ci_wait.sh`, `approval_wait.sh`, `queue_wait_conflicting.sh`, `acceptance-verdicts.test.sh` pass; orch suite 67/67.
- `env -u TMPDIR tools/guard --full` exit 0 on each commit before the push rebased them (now a9803daf8 and de5c1dbd8), and exit 0 on d86bd8a28, no `guard:` lines; CI re-runs the suites on the rebased head.
- preflight against origin/main: clean across 20 changed files.

https://claude.ai/code/session_01UC2b8adyP4KVxf9HZdhfUW
