### PR TITLE
fix(KEN-1338): reviewer-stop-check judges agent_id in jq before the shell reads it, refusing . and .. ids

### DIFF
--- a/.claude/hooks/reviewer-stop-check.sh
+++ b/.claude/hooks/reviewer-stop-check.sh
@@ -5,7 +5,7 @@
 # matcher:
 # description: Blocks a reviewer subagent's stop once when the worktree it reviewed is not clean. The worktree is the one the artifact path in the subagent's transcript names (`<worktree>/tmp/review-<agent>-*.json`, the newest mention); `git status --porcelain --untracked-files=all` there listing anything blocks, naming each path, and a transcript naming no artifact path blocks the same way, since the review contract is an artifact at that path. An agent_type not starting with `reviewer-` passes, as does `stop_hook_active` true; a block is recorded per agent_id under `<git common dir>/kendex/reviewer-stop/` so a later stop of the same subagent passes. Claude Code only, the harness with a SubagentStop event that names the agent.
 # summary: Stops a reviewer agent from finishing while the worktree it reviewed still holds files it left behind.
-# safety: Reads the payload, the transcript and git status; the only write is the per-agent marker under the reviewed repository's git common dir. Exit 2 names the paths and asks for the reviewer's own files to be deleted and the rest reported, never bypassed. jq is required to read the payload; a payload, transcript or git that cannot be read is refused, never passed. Every refusal opens with `reviewer-stop-check: <key>=<value>`; what a command this hook runs writes is captured at the site and replayed under that line, so nothing precedes the key.
+# safety: Reads the payload, the transcript and git status; the only write is the per-agent marker under the reviewed repository's git common dir. Exit 2 names the paths and asks for the reviewer's own files to be deleted and the rest reported, never bypassed. jq is required to read the payload; a payload, transcript or git that cannot be read is refused, never passed, and so is an `agent_id` that is not a string of ASCII letters, digits, `_` and `-`, the alphabet the harness names subagents in, which is judged in jq before the shell reads it so that a NUL, a `/`, a newline, `.` or `..` never names another subagent's marker. Every refusal opens with `reviewer-stop-check: <key>=<value>`; what a command this hook runs writes is captured at the site and replayed under that line, so nothing precedes the key.
 # timeout: 30
 # harnesses: [claude-code]
 # ---
@@ -45,7 +45,7 @@ refuse() { # KEY VALUE [DETAIL]
         echo "the hook payload is not valid JSON, or a field it reads is not a string; refusing rather than skipping the guard"
         ;;
       agent-id=invalid)
-        echo "the payload carries no usable agent_id, so a block could not be recorded; refusing"
+        echo "the payload's agent_id is not spelled in the alphabet the harness names subagents in, ASCII letters, digits, underscore and hyphen, so the marker a block would be recorded under is not this subagent's; refusing"
         ;;
       transcript=unreadable)
         echo "the payload's transcript_path $TRANSCRIPT is not a readable file, so the reviewed worktree is unknown; refusing"
@@ -94,9 +94,23 @@ done
 # diagnostic on the passing side.
 INPUT=$(cat 2>&1) || refuse payload unreadable "$INPUT"
 
+# The agent id names the marker a block is recorded under, so it is judged as
+# the payload holds it, before the shell reads it: a NUL the shell drops from
+# a command substitution would leave an id naming another subagent's marker,
+# and `.` or `..` name the marker directory and its parent, each of which
+# exists, so the recorded-block test would pass the stop unchecked. It passes
+# only when it is spelled in the alphabet the harness names subagents in,
+# ASCII letters, digits, `_` and `-`, which removing every such character
+# proves by leaving nothing; an anchored match would not, since `$` also
+# matches before a trailing newline. jq hands back an id it accepted or the
+# empty string, and an accepted id is never empty, so the two cannot be
+# mistaken for one another downstream.
 FIELDS=$(printf '%s' "$INPUT" | jq -r '
   def str($v): if $v == null then "" elif ($v | type) == "string" then $v else error("not a string") end;
-  [str(.agent_type), str(.agent_id), str(.transcript_path), (.stop_hook_active == true | tostring)] | @tsv' 2>/dev/null) ||
+  [str(.agent_type),
+   (str(.agent_id) | if . != "" and gsub("[A-Za-z0-9_-]"; "") == "" then . else "" end),
+   str(.transcript_path),
+   (.stop_hook_active == true | tostring)] | @tsv' 2>/dev/null) ||
   refuse payload invalid-json
 TAB=$'\t'
 AGENT_TYPE=${FIELDS%%"$TAB"*}
@@ -114,8 +128,10 @@ if [ "$ACTIVE" = "true" ]; then
   exit 0
 fi
 
-AGENT_SHAPE='^[A-Za-z0-9._-]+$'
-if ! [[ "$AGENT_ID" =~ $AGENT_SHAPE ]]; then
+# Empty is the refusal jq made above, read here rather than there so the two
+# stops that need no marker — an agent that is not a reviewer, and a stop the
+# harness is already re-running — keep passing whatever id they carry.
+if [ -z "$AGENT_ID" ]; then
   refuse agent-id invalid
 fi
 if [ ! -r "$TRANSCRIPT" ] || [ ! -f "$TRANSCRIPT" ]; then

--- a/.claude/hooks/reviewer-stop-check.sh
+++ b/.claude/hooks/reviewer-stop-check.sh
@@ -5,7 +5,7 @@
 # matcher:
 # description: Blocks a reviewer subagent's stop once when the worktree it reviewed is not clean. The worktree is the one the artifact path in the subagent's transcript names (`<worktree>/tmp/review-<agent>-*.json`, the newest mention); `git status --porcelain --untracked-files=all` there listing anything blocks, naming each path, and a transcript naming no artifact path blocks the same way, since the review contract is an artifact at that path. An agent_type not starting with `reviewer-` passes, as does `stop_hook_active` true; a block is recorded per agent_id under `<git common dir>/kendex/reviewer-stop/` so a later stop of the same subagent passes. Claude Code only, the harness with a SubagentStop event that names the agent.
 # summary: Stops a reviewer agent from finishing while the worktree it reviewed still holds files it left behind.
-# safety: Reads the payload, the transcript and git status; the only write is the per-agent marker under the reviewed repository's git common dir. Exit 2 names the paths and asks for the reviewer's own files to be deleted and the rest reported, never bypassed. jq is required to read the payload; a payload, transcript or git that cannot be read is refused, never passed, and so is an `agent_id` that is not a string of ASCII letters, digits, `_` and `-`, the alphabet the harness names subagents in, which is judged in jq before the shell reads it so that a NUL, a `/`, a newline, `.` or `..` never names another subagent's marker. Every refusal opens with `reviewer-stop-check: <key>=<value>`; what a command this hook runs writes is captured at the site and replayed under that line, so nothing precedes the key.
+# safety: Reads the payload, the transcript and git status; the only write is the per-agent marker under the reviewed repository's git common dir. Exit 2 names the paths and asks for the reviewer's own files to be deleted and the rest reported, never bypassed. jq is required to read the payload; a payload, transcript or git that cannot be read is refused, never passed, and so is an `agent_id` that is not a string of ASCII letters, digits, `_` and `-`, the alphabet the harness names subagents in; it is judged in jq where the payload holds it, so a NUL, a `/`, a newline, `.` or `..` never reaches the marker path, whatever encoding the read passes through. Every refusal opens with `reviewer-stop-check: <key>=<value>`; what a command this hook runs writes is captured at the site and replayed under that line, so nothing precedes the key.
 # timeout: 30
 # harnesses: [claude-code]
 # ---
@@ -94,12 +94,16 @@ done
 # diagnostic on the passing side.
 INPUT=$(cat 2>&1) || refuse payload unreadable "$INPUT"
 
-# The agent id names the marker a block is recorded under, so it is judged as
-# the payload holds it, before the shell reads it: a NUL the shell drops from
-# a command substitution would leave an id naming another subagent's marker,
-# and `.` or `..` name the marker directory and its parent, each of which
-# exists, so the recorded-block test would pass the stop unchecked. It passes
-# only when it is spelled in the alphabet the harness names subagents in,
+# The agent id names the marker a block is recorded under, so it is judged
+# where the payload holds it rather than after an encoding has carried it to
+# the shell: no spelling outside the alphabet reaches the marker path,
+# whatever that encoding does. The encoding here is @tsv, which escapes a
+# NUL, a tab, a newline, a carriage return and a backslash, so the ids a
+# shell-side test could ever be handed were the dotted ones — `.` and `..`
+# name the marker directory and its parent, each of which exists once a block
+# has recorded the directory, and the recorded-block test below read them as
+# this subagent's own and passed the stop unchecked. An id passes only when
+# it is spelled in the alphabet the harness names subagents in,
 # ASCII letters, digits, `_` and `-`, which removing every such character
 # proves by leaving nothing; an anchored match would not, since `$` also
 # matches before a trailing newline. jq hands back an id it accepted or the

--- a/hooks/reviewer-stop-check.sh
+++ b/hooks/reviewer-stop-check.sh
@@ -5,7 +5,7 @@
 # matcher:
 # description: Blocks a reviewer subagent's stop once when the worktree it reviewed is not clean. The worktree is the one the artifact path in the subagent's transcript names (`<worktree>/tmp/review-<agent>-*.json`, the newest mention); `git status --porcelain --untracked-files=all` there listing anything blocks, naming each path, and a transcript naming no artifact path blocks the same way, since the review contract is an artifact at that path. An agent_type not starting with `reviewer-` passes, as does `stop_hook_active` true; a block is recorded per agent_id under `<git common dir>/kendex/reviewer-stop/` so a later stop of the same subagent passes. Claude Code only, the harness with a SubagentStop event that names the agent.
 # summary: Stops a reviewer agent from finishing while the worktree it reviewed still holds files it left behind.
-# safety: Reads the payload, the transcript and git status; the only write is the per-agent marker under the reviewed repository's git common dir. Exit 2 names the paths and asks for the reviewer's own files to be deleted and the rest reported, never bypassed. jq is required to read the payload; a payload, transcript or git that cannot be read is refused, never passed. Every refusal opens with `reviewer-stop-check: <key>=<value>`; what a command this hook runs writes is captured at the site and replayed under that line, so nothing precedes the key.
+# safety: Reads the payload, the transcript and git status; the only write is the per-agent marker under the reviewed repository's git common dir. Exit 2 names the paths and asks for the reviewer's own files to be deleted and the rest reported, never bypassed. jq is required to read the payload; a payload, transcript or git that cannot be read is refused, never passed, and so is an `agent_id` that is not a string of ASCII letters, digits, `_` and `-`, the alphabet the harness names subagents in, which is judged in jq before the shell reads it so that a NUL, a `/`, a newline, `.` or `..` never names another subagent's marker. Every refusal opens with `reviewer-stop-check: <key>=<value>`; what a command this hook runs writes is captured at the site and replayed under that line, so nothing precedes the key.
 # timeout: 30
 # harnesses: [claude-code]
 # ---
@@ -45,7 +45,7 @@ refuse() { # KEY VALUE [DETAIL]
         echo "the hook payload is not valid JSON, or a field it reads is not a string; refusing rather than skipping the guard"
         ;;
       agent-id=invalid)
-        echo "the payload carries no usable agent_id, so a block could not be recorded; refusing"
+        echo "the payload's agent_id is not spelled in the alphabet the harness names subagents in, ASCII letters, digits, underscore and hyphen, so the marker a block would be recorded under is not this subagent's; refusing"
         ;;
       transcript=unreadable)
         echo "the payload's transcript_path $TRANSCRIPT is not a readable file, so the reviewed worktree is unknown; refusing"
@@ -94,9 +94,23 @@ done
 # diagnostic on the passing side.
 INPUT=$(cat 2>&1) || refuse payload unreadable "$INPUT"
 
+# The agent id names the marker a block is recorded under, so it is judged as
+# the payload holds it, before the shell reads it: a NUL the shell drops from
+# a command substitution would leave an id naming another subagent's marker,
+# and `.` or `..` name the marker directory and its parent, each of which
+# exists, so the recorded-block test would pass the stop unchecked. It passes
+# only when it is spelled in the alphabet the harness names subagents in,
+# ASCII letters, digits, `_` and `-`, which removing every such character
+# proves by leaving nothing; an anchored match would not, since `$` also
+# matches before a trailing newline. jq hands back an id it accepted or the
+# empty string, and an accepted id is never empty, so the two cannot be
+# mistaken for one another downstream.
 FIELDS=$(printf '%s' "$INPUT" | jq -r '
   def str($v): if $v == null then "" elif ($v | type) == "string" then $v else error("not a string") end;
-  [str(.agent_type), str(.agent_id), str(.transcript_path), (.stop_hook_active == true | tostring)] | @tsv' 2>/dev/null) ||
+  [str(.agent_type),
+   (str(.agent_id) | if . != "" and gsub("[A-Za-z0-9_-]"; "") == "" then . else "" end),
+   str(.transcript_path),
+   (.stop_hook_active == true | tostring)] | @tsv' 2>/dev/null) ||
   refuse payload invalid-json
 TAB=$'\t'
 AGENT_TYPE=${FIELDS%%"$TAB"*}
@@ -114,8 +128,10 @@ if [ "$ACTIVE" = "true" ]; then
   exit 0
 fi
 
-AGENT_SHAPE='^[A-Za-z0-9._-]+$'
-if ! [[ "$AGENT_ID" =~ $AGENT_SHAPE ]]; then
+# Empty is the refusal jq made above, read here rather than there so the two
+# stops that need no marker — an agent that is not a reviewer, and a stop the
+# harness is already re-running — keep passing whatever id they carry.
+if [ -z "$AGENT_ID" ]; then
   refuse agent-id invalid
 fi
 if [ ! -r "$TRANSCRIPT" ] || [ ! -f "$TRANSCRIPT" ]; then

--- a/hooks/reviewer-stop-check.sh
+++ b/hooks/reviewer-stop-check.sh
@@ -5,7 +5,7 @@
 # matcher:
 # description: Blocks a reviewer subagent's stop once when the worktree it reviewed is not clean. The worktree is the one the artifact path in the subagent's transcript names (`<worktree>/tmp/review-<agent>-*.json`, the newest mention); `git status --porcelain --untracked-files=all` there listing anything blocks, naming each path, and a transcript naming no artifact path blocks the same way, since the review contract is an artifact at that path. An agent_type not starting with `reviewer-` passes, as does `stop_hook_active` true; a block is recorded per agent_id under `<git common dir>/kendex/reviewer-stop/` so a later stop of the same subagent passes. Claude Code only, the harness with a SubagentStop event that names the agent.
 # summary: Stops a reviewer agent from finishing while the worktree it reviewed still holds files it left behind.
-# safety: Reads the payload, the transcript and git status; the only write is the per-agent marker under the reviewed repository's git common dir. Exit 2 names the paths and asks for the reviewer's own files to be deleted and the rest reported, never bypassed. jq is required to read the payload; a payload, transcript or git that cannot be read is refused, never passed, and so is an `agent_id` that is not a string of ASCII letters, digits, `_` and `-`, the alphabet the harness names subagents in, which is judged in jq before the shell reads it so that a NUL, a `/`, a newline, `.` or `..` never names another subagent's marker. Every refusal opens with `reviewer-stop-check: <key>=<value>`; what a command this hook runs writes is captured at the site and replayed under that line, so nothing precedes the key.
+# safety: Reads the payload, the transcript and git status; the only write is the per-agent marker under the reviewed repository's git common dir. Exit 2 names the paths and asks for the reviewer's own files to be deleted and the rest reported, never bypassed. jq is required to read the payload; a payload, transcript or git that cannot be read is refused, never passed, and so is an `agent_id` that is not a string of ASCII letters, digits, `_` and `-`, the alphabet the harness names subagents in; it is judged in jq where the payload holds it, so a NUL, a `/`, a newline, `.` or `..` never reaches the marker path, whatever encoding the read passes through. Every refusal opens with `reviewer-stop-check: <key>=<value>`; what a command this hook runs writes is captured at the site and replayed under that line, so nothing precedes the key.
 # timeout: 30
 # harnesses: [claude-code]
 # ---
@@ -94,12 +94,16 @@ done
 # diagnostic on the passing side.
 INPUT=$(cat 2>&1) || refuse payload unreadable "$INPUT"
 
-# The agent id names the marker a block is recorded under, so it is judged as
-# the payload holds it, before the shell reads it: a NUL the shell drops from
-# a command substitution would leave an id naming another subagent's marker,
-# and `.` or `..` name the marker directory and its parent, each of which
-# exists, so the recorded-block test would pass the stop unchecked. It passes
-# only when it is spelled in the alphabet the harness names subagents in,
+# The agent id names the marker a block is recorded under, so it is judged
+# where the payload holds it rather than after an encoding has carried it to
+# the shell: no spelling outside the alphabet reaches the marker path,
+# whatever that encoding does. The encoding here is @tsv, which escapes a
+# NUL, a tab, a newline, a carriage return and a backslash, so the ids a
+# shell-side test could ever be handed were the dotted ones — `.` and `..`
+# name the marker directory and its parent, each of which exists once a block
+# has recorded the directory, and the recorded-block test below read them as
+# this subagent's own and passed the stop unchecked. An id passes only when
+# it is spelled in the alphabet the harness names subagents in,
 # ASCII letters, digits, `_` and `-`, which removing every such character
 # proves by leaving nothing; an anchored match would not, since `$` also
 # matches before a trailing newline. jq hands back an id it accepted or the

--- a/hooks/tests/reviewer-stop-check.test.sh
+++ b/hooks/tests/reviewer-stop-check.test.sh
@@ -290,8 +290,11 @@ assert_eq "$rc" 2 "no transcript_path refuses"
 run_payload "{\"agent_type\":\"reviewer-test\",\"agent_id\":\"../x\",\"transcript_path\":\"$T\"}"
 assert_eq "rc=$rc first=$(first_line)" "rc=2 first=reviewer-stop-check: agent-id=invalid" \
   "an agent_id that is not a name refuses"
-# The id is judged as the payload holds it: the shell drops a NUL out of what
-# jq prints, and the id left over names another subagent's marker.
+# The id is judged as the payload holds it, so no spelling outside the
+# alphabet reaches the marker path whatever the encoding between. This row
+# pins that refusal rather than a defect the old hook had: @tsv escaped a NUL
+# to a backslash and a zero, and the old shell-side test refused that for the
+# backslash.
 run_payload "{\"agent_type\":\"reviewer-test\",\"agent_id\":\"a1\\u0000a2\",\"transcript_path\":\"$T\"}"
 assert_eq "rc=$rc first=$(first_line)" "rc=2 first=reviewer-stop-check: agent-id=invalid" \
   "an agent_id carrying a NUL refuses"

--- a/hooks/tests/reviewer-stop-check.test.sh
+++ b/hooks/tests/reviewer-stop-check.test.sh
@@ -9,7 +9,8 @@
 # file, one inside an untracked directory), the once-per-agent marker under the
 # reviewed repository's git common dir, that a sibling worktree's dirt is
 # not this worktree's, and the fail-closed edges — an unreadable payload,
-# a transcript that cannot be read, a git that cannot answer.
+# a transcript that cannot be read, a git that cannot answer, an agent_id not
+# spelled in the alphabet the harness names subagents in.
 #
 # Fixtures are throwaway git repositories built under a HOME of their own.
 #
@@ -289,6 +290,23 @@ assert_eq "$rc" 2 "no transcript_path refuses"
 run_payload "{\"agent_type\":\"reviewer-test\",\"agent_id\":\"../x\",\"transcript_path\":\"$T\"}"
 assert_eq "rc=$rc first=$(first_line)" "rc=2 first=reviewer-stop-check: agent-id=invalid" \
   "an agent_id that is not a name refuses"
+# The id is judged as the payload holds it: the shell drops a NUL out of what
+# jq prints, and the id left over names another subagent's marker.
+run_payload "{\"agent_type\":\"reviewer-test\",\"agent_id\":\"a1\\u0000a2\",\"transcript_path\":\"$T\"}"
+assert_eq "rc=$rc first=$(first_line)" "rc=2 first=reviewer-stop-check: agent-id=invalid" \
+  "an agent_id carrying a NUL refuses"
+# `..` names the marker directory's parent, which exists once a first block
+# has recorded the directory, so an id the alphabet let through reads as this
+# subagent's own recorded block and passes a dirty worktree's stop unchecked.
+REPO_DOTS="$(new_repo dots)"
+T_DOTS="$(transcript_for "$REPO_DOTS")"
+printf 'probe\n' >"$REPO_DOTS/probe.txt"
+run_hook "$T_DOTS" reviewer-test k1
+assert_eq "$rc" 2 "a first block records the marker directory"
+run_payload "{\"agent_type\":\"reviewer-test\",\"agent_id\":\"..\",\"transcript_path\":\"$T_DOTS\"}"
+assert_eq "rc=$rc first=$(first_line)" "rc=2 first=reviewer-stop-check: agent-id=invalid" \
+  "an agent_id of .. refuses rather than reading the marker directory's parent as a recorded block"
+assert_eq "$(ls -A "$REPO_DOTS/.git/kendex/reviewer-stop")" "k1" "and records no marker of its own"
 run_payload "{\"agent_type\":\"reviewer-test\",\"transcript_path\":\"$T\"}"
 assert_eq "$rc" 2 "no agent_id refuses"
 T2="$TMP_ROOT/transcript.gone.jsonl"


### PR DESCRIPTION
## Summary
- `hooks/reviewer-stop-check.sh` judges `agent_id` inside the jq program that reads the payload, before the shell reads it. It passes only when spelled in the alphabet the harness names subagents in, ASCII letters, digits, `_` and `-` (the alphabet KEN-1331 settled on for `code-quality-load-check`). jq hands back the accepted id or the empty string; the shell refuses the empty string with the unchanged first line `reviewer-stop-check: agent-id=invalid`. The shell-side `AGENT_SHAPE` regex, which admitted `.`, is gone.
- The refusal stays after the non-reviewer and `stop_hook_active` early passes, so a stop that never needs a marker still passes whatever id it carries.
- The tracked render `.claude/hooks/reviewer-stop-check.sh` lands byte-identical in the same commits. `.codex/hooks` and `.pi/kendex/hooks` track no copy of this hook.
- `hooks/tests/reviewer-stop-check.test.sh` gains one row per rule: an `agent_id` carrying a NUL, and an `agent_id` of `..` over a repository whose marker directory a first block already created, each refused with the keyed line and exit 2, the `..` row also asserting no marker of its own was recorded.

## Premise check
- The `.`/`..` half of the issue reproduces: on the pre-fix hook, once any earlier block has created `<git common dir>/kendex/reviewer-stop/`, a stop carrying `..` (or `.`) exits 0 because `[ -e "$MARKER" ]` finds the directory's parent. The `..` row reddens against `origin/main`'s hook under `HOOK_UNDER_TEST` (exit 0, stop passed unchecked) and passes on the new one.
- The NUL half does not reproduce on this hook. jq's `@tsv` escapes a NUL field to the two characters backslash-zero, on jq 1.7.1 (ubuntu-latest) and 1.8.2, so the id the old bash regex judged carried a backslash it already refused. The NUL row therefore stays green against the pre-fix hook. It is kept because the Done-when names it: it pins the refusal the new rule makes deliberate, and the jq-side `gsub` predicate refuses a NUL on its own, independent of the output encoding. This differs from `code-quality-load-check`, which read the id with a bare `jq -r` and no `@tsv`, where the NUL half was real. The comments in the hook and the test say this; the second commit corrected an earlier wording that restated the issue's premise.
- Both local reviewers (correctness, security) independently confirmed the two points above. The security reviewer swept 27 adversarial ids (`.`, `..`, `/`, NUL, tab, newline, CR, space, backslash, non-ASCII letters, U+2028, a surrogate pair, a zero-width joiner) through the predicate on both jq versions: only `[A-Za-z0-9_-]+` is accepted, and the refusal precedes every filesystem probe. Every marker the shipped hook has written on the dev machine is spelled inside the new alphabet.

## Completed Issues
- Closes KEN-1338 - reviewer-stop-check: agent_id is judged after the shell reads it, so a NUL, . or .. id passes the stop on another marker

## Size
- No allowance stated on the issue. `branch-size-check`: production=25 tests=22 mirror=25.

## Changelog
- No fragment: `hooks/` is outside the configured consumer paths, and the existing `changelog.d/added/reviewer-hooks.md` describes behavior this change does not alter.

## Test Plan
- `bash hooks/tests/reviewer-stop-check.test.sh`: 52 passed, 0 failed.
- Must-fail: `HOOK_UNDER_TEST=<origin/main copy> bash hooks/tests/reviewer-stop-check.test.sh` reddens the `..` row (stop passed with exit 0) and nothing else.
- `tools/bash32-lint hooks`: clean.
- `env -u TMPDIR tools/guard --full`: exit 0 on e7a966fcc; re-run on the final head 29c52fed3 (comment-only delta) in this lane.

https://claude.ai/code/session_019oMvH1LqMbAGdXxW3mH5E5
