### PR TITLE
fix(KEN-1357): doc-drift-check names every root-level non-markdown file as uncovered

### DIFF
--- a/.claude/hooks/doc-drift-check.sh
+++ b/.claude/hooks/doc-drift-check.sh
@@ -3,7 +3,7 @@
 # name: doc-drift-check
 # event: Stop
 # matcher:
-# description: Blocks a stop once per set of findings so the agent, the only party that can act on them, is the one given the list. Three kinds are found: stale, a document covering changed code that did not change; dangling, an architecture topic `Covers:` entry that no tracked or untracked non-ignored path on disk matches; uncovered, a changed non-markdown path still on disk that no topic entry and no AGENTS.md covers, judged only where some topic declares an entry and never for a path the repository's `.kendex-generated.json` lists, a render being covered through the source it was rendered from. The refusal opens with one keyed line per kind that holds, in the order `doc-drift-check: stale=<count>`, `doc-drift-check: dangling=<count>`, `doc-drift-check: uncovered=<count>`, then `doc-drift-check: base=<ref>` — the ref it compared against, or `default-branch`, `none` or `unrelated` — and names each finding under them; stdout carries nothing and no user-facing notice is written. The set is recorded as `<git common dir>/kendex/doc-drift/<session_id>-<digest of the sorted set>`, so a later stop naming that same set passes and an agent that read the list and changed nothing is not asked again; a set that gains or loses a finding is a different set and blocks once. `stop_hook_active` true passes, and so does a stop with nothing changed; any change, markdown alone included, has every Covers entry judged. Uses the nearest AGENTS.md, tracked or untracked and not ignored, which for a path directly at the repository root is the root's own and for a path below it is one below the root, and architecture topic Covers entries. Compares the branch with its default-branch merge-base, or the working tree when no comparison applies. Claude Code only.
+# description: Blocks a stop once per set of findings so the agent, the only party that can act on them, is the one given the list. Three kinds are found: stale, a document covering changed code that did not change; dangling, an architecture topic `Covers:` entry that no tracked or untracked non-ignored path on disk matches; uncovered, a changed non-markdown path still on disk that no topic entry and no AGENTS.md covers, judged only where some topic declares an entry. A changed path the repository's `.kendex-generated.json` lists is named at neither kind, a render being covered through the source it was rendered from. The refusal opens with one keyed line per kind that holds, in the order `doc-drift-check: stale=<count>`, `doc-drift-check: dangling=<count>`, `doc-drift-check: uncovered=<count>`, then `doc-drift-check: base=<ref>` — the ref it compared against, or `default-branch`, `none` or `unrelated` — and names each finding under them; stdout carries nothing and no user-facing notice is written. The set is recorded as `<git common dir>/kendex/doc-drift/<session_id>-<digest of the sorted set>`, so a later stop naming that same set passes and an agent that read the list and changed nothing is not asked again; a set that gains or loses a finding is a different set and blocks once. `stop_hook_active` true passes, and so does a stop with nothing changed; any change, markdown alone included, has every Covers entry judged. Uses the nearest AGENTS.md, tracked or untracked and not ignored, which for a path directly at the repository root is the root's own and for a path below it is one below the root, and architecture topic Covers entries. Compares the branch with its default-branch merge-base, or the working tree when no comparison applies. Claude Code only.
 # summary: Stops an agent at the end of its turn when documents covering the code it changed did not change or an architecture topic names a path that does not exist, and hands it the list. Where some topic declares a Covers entry, changed code with no covering document is named too.
 # safety: Reads the payload, git state, the topic files, the render inventory `.kendex-generated.json` and git's listing of what each Covers entry matches; the only write is the per-set marker under the repository's git common dir. Exit 2 names the findings and asks for each document to be confirmed or updated and each entry or path to be corrected, never bypassed. jq reads the payload and a sha256 tool names the set; every command the hook runs is checked before it is called, the payload readers ahead of the payload and the rest after `stop_hook_active` has been read, so a discovery command's absence costs one retry rather than refusing the retry too; only a missing payload reader refuses that as well, the flag being in the payload it cannot read. A payload, git state, render inventory or marker the hook cannot read or write is refused, never passed. Every refusal opens with `doc-drift-check: <key>=<value>`; what a command this hook runs writes is captured at the site and replayed under that line, so nothing precedes the key.
 # timeout: 30
@@ -80,7 +80,7 @@ refuse() { # KEY VALUE [DETAIL], or `drift` alone
         printf 'the render inventory .kendex-generated.json is present and could not be read\n'
         ;;
       inventory=invalid-json)
-        printf 'the render inventory .kendex-generated.json is not one JSON array of non-empty path strings, none holding a newline or a NUL; refusing rather than judging every render as code no document covers\n'
+        printf 'the render inventory .kendex-generated.json is not one JSON array of non-empty path strings, none holding a newline or a NUL; refusing rather than judging every render as code a document was meant to cover\n'
         ;;
       session-id=invalid)
         printf 'the payload carries no usable session_id, so naming these documents could not be recorded; refusing\n'
@@ -321,12 +321,12 @@ CODE_CHANGED=$(printf '%s\n' "$ALL_CHANGED" | sed '/\.md$/d' 2>&1) ||
 # writer keeps this inventory and is the one judge of whether a path is a
 # render, so the hook reads it rather than matching harness directory names of
 # its own. A render is never the thing a document covers — the source it was
-# rendered from is — so a changed render is not named uncovered below.
+# rendered from is — so a changed render is named at neither kind below.
 #
 # The read discipline is the one commit-guards' suppression-ban applies to the
 # same file: an absent inventory is a repository with nothing rendered and
 # excludes nothing, while a present one that does not parse is refused rather
-# than read as empty, which would name every render as uncovered and say
+# than read as empty, which would name every render as a finding and say
 # nothing about why. It is read from the working tree, as the topic files are:
 # a refresh writes the inventory and the renders it lists together, so the
 # working-tree copy is the one that describes the renders being judged.
@@ -472,16 +472,19 @@ EOF
 # repository without one has no map to be incomplete, and naming every changed
 # path there would block each stop of a repository that never adopted topics.
 # A deleted path is never uncovered: an entry added for it would match nothing.
-# Nor is a render the inventory lists: the document to correct covers its
-# source, and an entry added for the render would name a generated file.
 while IFS= read -r path; do
   # An empty code set reads as one empty line.
   [ -n "$path" ] || continue
+  # A render the inventory lists is named at neither kind, and the judgement is
+  # made before coverage so that holds wherever the render sits, the repository
+  # root included. The document to correct covers the source the render was
+  # written from, so a render neither leaves a document stale nor asks for a
+  # Covers entry that would name a generated file.
+  in_list "$GENERATED" "$path" && continue
   docs=$(covering_docs "$path")
   if [ -z "$docs" ]; then
     [ -n "$COVERS" ] || continue
     on_disk "$path" || continue
-    in_list "$GENERATED" "$path" && continue
     NAMED="$NAMED"uncovered$'\t'"$path"$'\n'
     UNCOVERED="$UNCOVERED  $path"$'\n'
     UNCOVERED_COUNT=$((UNCOVERED_COUNT + 1))

--- a/.claude/hooks/doc-drift-check.sh
+++ b/.claude/hooks/doc-drift-check.sh
@@ -3,7 +3,7 @@
 # name: doc-drift-check
 # event: Stop
 # matcher:
-# description: Blocks a stop once per set of findings so the agent, the only party that can act on them, is the one given the list. Three kinds are found: stale, a document covering changed code that did not change; dangling, an architecture topic `Covers:` entry that no tracked or untracked non-ignored path on disk matches; uncovered, a changed non-markdown path still on disk that no topic entry and no non-root AGENTS.md covers, judged only where some topic declares an entry and never for a path the repository's `.kendex-generated.json` lists, a render being covered through the source it was rendered from. The refusal opens with one keyed line per kind that holds, in the order `doc-drift-check: stale=<count>`, `doc-drift-check: dangling=<count>`, `doc-drift-check: uncovered=<count>`, then `doc-drift-check: base=<ref>` — the ref it compared against, or `default-branch`, `none` or `unrelated` — and names each finding under them; stdout carries nothing and no user-facing notice is written. The set is recorded as `<git common dir>/kendex/doc-drift/<session_id>-<digest of the sorted set>`, so a later stop naming that same set passes and an agent that read the list and changed nothing is not asked again; a set that gains or loses a finding is a different set and blocks once. `stop_hook_active` true passes, and so does a stop with nothing changed; any change, markdown alone included, has every Covers entry judged. Uses the nearest non-root AGENTS.md, tracked or untracked and not ignored, and architecture topic Covers entries. Compares the branch with its default-branch merge-base, or the working tree when no comparison applies. Claude Code only.
+# description: Blocks a stop once per set of findings so the agent, the only party that can act on them, is the one given the list. Three kinds are found: stale, a document covering changed code that did not change; dangling, an architecture topic `Covers:` entry that no tracked or untracked non-ignored path on disk matches; uncovered, a changed non-markdown path still on disk that no topic entry and no AGENTS.md covers, judged only where some topic declares an entry and never for a path the repository's `.kendex-generated.json` lists, a render being covered through the source it was rendered from. The refusal opens with one keyed line per kind that holds, in the order `doc-drift-check: stale=<count>`, `doc-drift-check: dangling=<count>`, `doc-drift-check: uncovered=<count>`, then `doc-drift-check: base=<ref>` — the ref it compared against, or `default-branch`, `none` or `unrelated` — and names each finding under them; stdout carries nothing and no user-facing notice is written. The set is recorded as `<git common dir>/kendex/doc-drift/<session_id>-<digest of the sorted set>`, so a later stop naming that same set passes and an agent that read the list and changed nothing is not asked again; a set that gains or loses a finding is a different set and blocks once. `stop_hook_active` true passes, and so does a stop with nothing changed; any change, markdown alone included, has every Covers entry judged. Uses the nearest AGENTS.md, tracked or untracked and not ignored, which for a path directly at the repository root is the root's own and for a path below it is one below the root, and architecture topic Covers entries. Compares the branch with its default-branch merge-base, or the working tree when no comparison applies. Claude Code only.
 # summary: Stops an agent at the end of its turn when documents covering the code it changed did not change or an architecture topic names a path that does not exist, and hands it the list. Where some topic declares a Covers entry, changed code with no covering document is named too.
 # safety: Reads the payload, git state, the topic files, the render inventory `.kendex-generated.json` and git's listing of what each Covers entry matches; the only write is the per-set marker under the repository's git common dir. Exit 2 names the findings and asks for each document to be confirmed or updated and each entry or path to be corrected, never bypassed. jq reads the payload and a sha256 tool names the set; every command the hook runs is checked before it is called, the payload readers ahead of the payload and the rest after `stop_hook_active` has been read, so a discovery command's absence costs one retry rather than refusing the retry too; only a missing payload reader refuses that as well, the flag being in the payload it cannot read. A payload, git state, render inventory or marker the hook cannot read or write is refused, never passed. Every refusal opens with `doc-drift-check: <key>=<value>`; what a command this hook runs writes is captured at the site and replayed under that line, so nothing precedes the key.
 # timeout: 30
@@ -63,7 +63,7 @@ refuse() { # KEY VALUE [DETAIL], or `drift` alone
         [ -z "$DANGLING" ] ||
           printf 'these architecture topic Covers entries match no path in the tree, so each covers nothing; correct or remove it:\n%s' "$DANGLING"
         [ -z "$UNCOVERED" ] ||
-          printf 'code changed at these paths, and no topic Covers entry or AGENTS.md below the root covers them; add each to the Covers line of the topic that describes it:\n%s' "$UNCOVERED"
+          printf 'code changed at these paths, and no topic Covers entry or AGENTS.md covers them; add each to the Covers line of the topic that describes it:\n%s' "$UNCOVERED"
         printf 'Compared %s\n' "$JUDGED"
         printf 'Handle each, then finish.\n'
         ;;
@@ -268,9 +268,9 @@ git_paths() { # LABEL ARGS... — sets PATHS; LABEL is the git= value on failure
 # The paths present in the tree for one pathspec, one per line in PATHS: tracked
 # and untracked non-ignored, as the changed set reads them, and only those on
 # disk, since the index still lists a file deleted and not yet staged.
-tree_paths() { # PATHSPEC — sets PATHS
+tree_paths() { # PATHSPEC... — sets PATHS
   local listed="" path
-  git_paths 'ls-files' ls-files -z --cached --others --exclude-standard --full-name -- "$1"
+  git_paths 'ls-files' ls-files -z --cached --others --exclude-standard --full-name -- "$@"
   while IFS= read -r path; do
     [ -z "$path" ] || ! on_disk "$path" || listed="$listed$path"$'\n'
   done <<EOF
@@ -357,18 +357,18 @@ if [ -f "$INVENTORY" ]; then
 fi
 
 # Covering docs. `:(top)` roots the pattern at the repository whatever the
-# cwd, and `*` crosses `/`, so this is every AGENTS.md below the root and
-# not the root's own, which covers nothing. Untracked non-ignored ones count,
-# as a topic written this session does: a new directory's AGENTS.md covers the
-# code beside it before either is committed.
-tree_paths ':(top)*/AGENTS.md'
+# cwd, and `*` crosses `/`, so this is the root's own AGENTS.md and every
+# AGENTS.md below it. Untracked non-ignored ones count, as a topic written
+# this session does: a new directory's AGENTS.md covers the code beside it
+# before either is committed.
+tree_paths ':(top)AGENTS.md' ':(top)*/AGENTS.md'
 AGENTS_DOCS=$PATHS
 
 # Topic files are read from the working tree, so a file written this session
 # already covers what it says it covers; a tracked one deleted this session
 # covers nothing, and is in the changed set besides. Each pair is one line,
-# "<path pattern><TAB><topic path>". An entry of "." would cover the root, which
-# nothing does. `set -f` around the split: an entry is split on blanks,
+# "<path pattern><TAB><topic path>". An entry of "." would cover the whole
+# tree, which no topic does. `set -f` around the split: an entry is split on blanks,
 # never globbed, while the topic glob itself still expands.
 COVERS=""
 for topic in "$REPO_ROOT"/docs/architecture/*.md; do
@@ -420,7 +420,18 @@ covering_docs() {
   done <<EOF
 $COVERS
 EOF
+  # The nearest AGENTS.md above the path. A path whose directory is the root
+  # has the root's own, the one document that describes the repository as a
+  # whole, and only such a path has it: the walk below stops before the root,
+  # so a path in a directory still needs an AGENTS.md below the root at or
+  # above it, or a topic entry.
   dir=$(dirname "$path")
+  if [ "$dir" = "." ]; then
+    if in_list "$AGENTS_DOCS" AGENTS.md; then
+      printf '%s\n' AGENTS.md
+    fi
+    return 0
+  fi
   while [ "$dir" != "." ] && [ "$dir" != "/" ]; do
     if [ -z "$nearest" ] && in_list "$AGENTS_DOCS" "$dir/AGENTS.md"; then
       nearest="$dir/AGENTS.md"

--- a/hooks/doc-drift-check.sh
+++ b/hooks/doc-drift-check.sh
@@ -3,7 +3,7 @@
 # name: doc-drift-check
 # event: Stop
 # matcher:
-# description: Blocks a stop once per set of findings so the agent, the only party that can act on them, is the one given the list. Three kinds are found: stale, a document covering changed code that did not change; dangling, an architecture topic `Covers:` entry that no tracked or untracked non-ignored path on disk matches; uncovered, a changed non-markdown path still on disk that no topic entry and no AGENTS.md covers, judged only where some topic declares an entry and never for a path the repository's `.kendex-generated.json` lists, a render being covered through the source it was rendered from. The refusal opens with one keyed line per kind that holds, in the order `doc-drift-check: stale=<count>`, `doc-drift-check: dangling=<count>`, `doc-drift-check: uncovered=<count>`, then `doc-drift-check: base=<ref>` — the ref it compared against, or `default-branch`, `none` or `unrelated` — and names each finding under them; stdout carries nothing and no user-facing notice is written. The set is recorded as `<git common dir>/kendex/doc-drift/<session_id>-<digest of the sorted set>`, so a later stop naming that same set passes and an agent that read the list and changed nothing is not asked again; a set that gains or loses a finding is a different set and blocks once. `stop_hook_active` true passes, and so does a stop with nothing changed; any change, markdown alone included, has every Covers entry judged. Uses the nearest AGENTS.md, tracked or untracked and not ignored, which for a path directly at the repository root is the root's own and for a path below it is one below the root, and architecture topic Covers entries. Compares the branch with its default-branch merge-base, or the working tree when no comparison applies. Claude Code only.
+# description: Blocks a stop once per set of findings so the agent, the only party that can act on them, is the one given the list. Three kinds are found: stale, a document covering changed code that did not change; dangling, an architecture topic `Covers:` entry that no tracked or untracked non-ignored path on disk matches; uncovered, a changed non-markdown path still on disk that no topic entry and no AGENTS.md covers, judged only where some topic declares an entry. A changed path the repository's `.kendex-generated.json` lists is named at neither kind, a render being covered through the source it was rendered from. The refusal opens with one keyed line per kind that holds, in the order `doc-drift-check: stale=<count>`, `doc-drift-check: dangling=<count>`, `doc-drift-check: uncovered=<count>`, then `doc-drift-check: base=<ref>` — the ref it compared against, or `default-branch`, `none` or `unrelated` — and names each finding under them; stdout carries nothing and no user-facing notice is written. The set is recorded as `<git common dir>/kendex/doc-drift/<session_id>-<digest of the sorted set>`, so a later stop naming that same set passes and an agent that read the list and changed nothing is not asked again; a set that gains or loses a finding is a different set and blocks once. `stop_hook_active` true passes, and so does a stop with nothing changed; any change, markdown alone included, has every Covers entry judged. Uses the nearest AGENTS.md, tracked or untracked and not ignored, which for a path directly at the repository root is the root's own and for a path below it is one below the root, and architecture topic Covers entries. Compares the branch with its default-branch merge-base, or the working tree when no comparison applies. Claude Code only.
 # summary: Stops an agent at the end of its turn when documents covering the code it changed did not change or an architecture topic names a path that does not exist, and hands it the list. Where some topic declares a Covers entry, changed code with no covering document is named too.
 # safety: Reads the payload, git state, the topic files, the render inventory `.kendex-generated.json` and git's listing of what each Covers entry matches; the only write is the per-set marker under the repository's git common dir. Exit 2 names the findings and asks for each document to be confirmed or updated and each entry or path to be corrected, never bypassed. jq reads the payload and a sha256 tool names the set; every command the hook runs is checked before it is called, the payload readers ahead of the payload and the rest after `stop_hook_active` has been read, so a discovery command's absence costs one retry rather than refusing the retry too; only a missing payload reader refuses that as well, the flag being in the payload it cannot read. A payload, git state, render inventory or marker the hook cannot read or write is refused, never passed. Every refusal opens with `doc-drift-check: <key>=<value>`; what a command this hook runs writes is captured at the site and replayed under that line, so nothing precedes the key.
 # timeout: 30
@@ -80,7 +80,7 @@ refuse() { # KEY VALUE [DETAIL], or `drift` alone
         printf 'the render inventory .kendex-generated.json is present and could not be read\n'
         ;;
       inventory=invalid-json)
-        printf 'the render inventory .kendex-generated.json is not one JSON array of non-empty path strings, none holding a newline or a NUL; refusing rather than judging every render as code no document covers\n'
+        printf 'the render inventory .kendex-generated.json is not one JSON array of non-empty path strings, none holding a newline or a NUL; refusing rather than judging every render as code a document was meant to cover\n'
         ;;
       session-id=invalid)
         printf 'the payload carries no usable session_id, so naming these documents could not be recorded; refusing\n'
@@ -321,12 +321,12 @@ CODE_CHANGED=$(printf '%s\n' "$ALL_CHANGED" | sed '/\.md$/d' 2>&1) ||
 # writer keeps this inventory and is the one judge of whether a path is a
 # render, so the hook reads it rather than matching harness directory names of
 # its own. A render is never the thing a document covers — the source it was
-# rendered from is — so a changed render is not named uncovered below.
+# rendered from is — so a changed render is named at neither kind below.
 #
 # The read discipline is the one commit-guards' suppression-ban applies to the
 # same file: an absent inventory is a repository with nothing rendered and
 # excludes nothing, while a present one that does not parse is refused rather
-# than read as empty, which would name every render as uncovered and say
+# than read as empty, which would name every render as a finding and say
 # nothing about why. It is read from the working tree, as the topic files are:
 # a refresh writes the inventory and the renders it lists together, so the
 # working-tree copy is the one that describes the renders being judged.
@@ -472,16 +472,19 @@ EOF
 # repository without one has no map to be incomplete, and naming every changed
 # path there would block each stop of a repository that never adopted topics.
 # A deleted path is never uncovered: an entry added for it would match nothing.
-# Nor is a render the inventory lists: the document to correct covers its
-# source, and an entry added for the render would name a generated file.
 while IFS= read -r path; do
   # An empty code set reads as one empty line.
   [ -n "$path" ] || continue
+  # A render the inventory lists is named at neither kind, and the judgement is
+  # made before coverage so that holds wherever the render sits, the repository
+  # root included. The document to correct covers the source the render was
+  # written from, so a render neither leaves a document stale nor asks for a
+  # Covers entry that would name a generated file.
+  in_list "$GENERATED" "$path" && continue
   docs=$(covering_docs "$path")
   if [ -z "$docs" ]; then
     [ -n "$COVERS" ] || continue
     on_disk "$path" || continue
-    in_list "$GENERATED" "$path" && continue
     NAMED="$NAMED"uncovered$'\t'"$path"$'\n'
     UNCOVERED="$UNCOVERED  $path"$'\n'
     UNCOVERED_COUNT=$((UNCOVERED_COUNT + 1))

--- a/hooks/doc-drift-check.sh
+++ b/hooks/doc-drift-check.sh
@@ -3,7 +3,7 @@
 # name: doc-drift-check
 # event: Stop
 # matcher:
-# description: Blocks a stop once per set of findings so the agent, the only party that can act on them, is the one given the list. Three kinds are found: stale, a document covering changed code that did not change; dangling, an architecture topic `Covers:` entry that no tracked or untracked non-ignored path on disk matches; uncovered, a changed non-markdown path still on disk that no topic entry and no non-root AGENTS.md covers, judged only where some topic declares an entry and never for a path the repository's `.kendex-generated.json` lists, a render being covered through the source it was rendered from. The refusal opens with one keyed line per kind that holds, in the order `doc-drift-check: stale=<count>`, `doc-drift-check: dangling=<count>`, `doc-drift-check: uncovered=<count>`, then `doc-drift-check: base=<ref>` — the ref it compared against, or `default-branch`, `none` or `unrelated` — and names each finding under them; stdout carries nothing and no user-facing notice is written. The set is recorded as `<git common dir>/kendex/doc-drift/<session_id>-<digest of the sorted set>`, so a later stop naming that same set passes and an agent that read the list and changed nothing is not asked again; a set that gains or loses a finding is a different set and blocks once. `stop_hook_active` true passes, and so does a stop with nothing changed; any change, markdown alone included, has every Covers entry judged. Uses the nearest non-root AGENTS.md, tracked or untracked and not ignored, and architecture topic Covers entries. Compares the branch with its default-branch merge-base, or the working tree when no comparison applies. Claude Code only.
+# description: Blocks a stop once per set of findings so the agent, the only party that can act on them, is the one given the list. Three kinds are found: stale, a document covering changed code that did not change; dangling, an architecture topic `Covers:` entry that no tracked or untracked non-ignored path on disk matches; uncovered, a changed non-markdown path still on disk that no topic entry and no AGENTS.md covers, judged only where some topic declares an entry and never for a path the repository's `.kendex-generated.json` lists, a render being covered through the source it was rendered from. The refusal opens with one keyed line per kind that holds, in the order `doc-drift-check: stale=<count>`, `doc-drift-check: dangling=<count>`, `doc-drift-check: uncovered=<count>`, then `doc-drift-check: base=<ref>` — the ref it compared against, or `default-branch`, `none` or `unrelated` — and names each finding under them; stdout carries nothing and no user-facing notice is written. The set is recorded as `<git common dir>/kendex/doc-drift/<session_id>-<digest of the sorted set>`, so a later stop naming that same set passes and an agent that read the list and changed nothing is not asked again; a set that gains or loses a finding is a different set and blocks once. `stop_hook_active` true passes, and so does a stop with nothing changed; any change, markdown alone included, has every Covers entry judged. Uses the nearest AGENTS.md, tracked or untracked and not ignored, which for a path directly at the repository root is the root's own and for a path below it is one below the root, and architecture topic Covers entries. Compares the branch with its default-branch merge-base, or the working tree when no comparison applies. Claude Code only.
 # summary: Stops an agent at the end of its turn when documents covering the code it changed did not change or an architecture topic names a path that does not exist, and hands it the list. Where some topic declares a Covers entry, changed code with no covering document is named too.
 # safety: Reads the payload, git state, the topic files, the render inventory `.kendex-generated.json` and git's listing of what each Covers entry matches; the only write is the per-set marker under the repository's git common dir. Exit 2 names the findings and asks for each document to be confirmed or updated and each entry or path to be corrected, never bypassed. jq reads the payload and a sha256 tool names the set; every command the hook runs is checked before it is called, the payload readers ahead of the payload and the rest after `stop_hook_active` has been read, so a discovery command's absence costs one retry rather than refusing the retry too; only a missing payload reader refuses that as well, the flag being in the payload it cannot read. A payload, git state, render inventory or marker the hook cannot read or write is refused, never passed. Every refusal opens with `doc-drift-check: <key>=<value>`; what a command this hook runs writes is captured at the site and replayed under that line, so nothing precedes the key.
 # timeout: 30
@@ -63,7 +63,7 @@ refuse() { # KEY VALUE [DETAIL], or `drift` alone
         [ -z "$DANGLING" ] ||
           printf 'these architecture topic Covers entries match no path in the tree, so each covers nothing; correct or remove it:\n%s' "$DANGLING"
         [ -z "$UNCOVERED" ] ||
-          printf 'code changed at these paths, and no topic Covers entry or AGENTS.md below the root covers them; add each to the Covers line of the topic that describes it:\n%s' "$UNCOVERED"
+          printf 'code changed at these paths, and no topic Covers entry or AGENTS.md covers them; add each to the Covers line of the topic that describes it:\n%s' "$UNCOVERED"
         printf 'Compared %s\n' "$JUDGED"
         printf 'Handle each, then finish.\n'
         ;;
@@ -268,9 +268,9 @@ git_paths() { # LABEL ARGS... — sets PATHS; LABEL is the git= value on failure
 # The paths present in the tree for one pathspec, one per line in PATHS: tracked
 # and untracked non-ignored, as the changed set reads them, and only those on
 # disk, since the index still lists a file deleted and not yet staged.
-tree_paths() { # PATHSPEC — sets PATHS
+tree_paths() { # PATHSPEC... — sets PATHS
   local listed="" path
-  git_paths 'ls-files' ls-files -z --cached --others --exclude-standard --full-name -- "$1"
+  git_paths 'ls-files' ls-files -z --cached --others --exclude-standard --full-name -- "$@"
   while IFS= read -r path; do
     [ -z "$path" ] || ! on_disk "$path" || listed="$listed$path"$'\n'
   done <<EOF
@@ -357,18 +357,18 @@ if [ -f "$INVENTORY" ]; then
 fi
 
 # Covering docs. `:(top)` roots the pattern at the repository whatever the
-# cwd, and `*` crosses `/`, so this is every AGENTS.md below the root and
-# not the root's own, which covers nothing. Untracked non-ignored ones count,
-# as a topic written this session does: a new directory's AGENTS.md covers the
-# code beside it before either is committed.
-tree_paths ':(top)*/AGENTS.md'
+# cwd, and `*` crosses `/`, so this is the root's own AGENTS.md and every
+# AGENTS.md below it. Untracked non-ignored ones count, as a topic written
+# this session does: a new directory's AGENTS.md covers the code beside it
+# before either is committed.
+tree_paths ':(top)AGENTS.md' ':(top)*/AGENTS.md'
 AGENTS_DOCS=$PATHS
 
 # Topic files are read from the working tree, so a file written this session
 # already covers what it says it covers; a tracked one deleted this session
 # covers nothing, and is in the changed set besides. Each pair is one line,
-# "<path pattern><TAB><topic path>". An entry of "." would cover the root, which
-# nothing does. `set -f` around the split: an entry is split on blanks,
+# "<path pattern><TAB><topic path>". An entry of "." would cover the whole
+# tree, which no topic does. `set -f` around the split: an entry is split on blanks,
 # never globbed, while the topic glob itself still expands.
 COVERS=""
 for topic in "$REPO_ROOT"/docs/architecture/*.md; do
@@ -420,7 +420,18 @@ covering_docs() {
   done <<EOF
 $COVERS
 EOF
+  # The nearest AGENTS.md above the path. A path whose directory is the root
+  # has the root's own, the one document that describes the repository as a
+  # whole, and only such a path has it: the walk below stops before the root,
+  # so a path in a directory still needs an AGENTS.md below the root at or
+  # above it, or a topic entry.
   dir=$(dirname "$path")
+  if [ "$dir" = "." ]; then
+    if in_list "$AGENTS_DOCS" AGENTS.md; then
+      printf '%s\n' AGENTS.md
+    fi
+    return 0
+  fi
   while [ "$dir" != "." ] && [ "$dir" != "/" ]; do
     if [ -z "$nearest" ] && in_list "$AGENTS_DOCS" "$dir/AGENTS.md"; then
       nearest="$dir/AGENTS.md"

--- a/hooks/tests/doc-drift-check.test.sh
+++ b/hooks/tests/doc-drift-check.test.sh
@@ -3,15 +3,15 @@
 # changed non-markdown path is matched against the nearest AGENTS.md above it,
 # tracked or untracked — the root's own for a path whose directory is the
 # repository root, one below the root for anything deeper — and every topic
-# file whose Covers entry
-# reaches it; a covering doc left unchanged, a Covers entry no path on disk
-# matches, and a changed path on disk no doc covers where some topic declares
-# an entry and the render inventory `.kendex-generated.json` does not list it
-# are each named
+# file whose Covers entry reaches it; a covering doc left unchanged, a Covers
+# entry no path on disk matches, and a changed path on disk no doc covers
+# where some topic declares an entry are each named
 # once on stderr with exit 2, the channel the harness gives Claude, and stdout
 # stays empty. The set is recorded under
 # `<git common dir>/kendex/doc-drift/<session_id>-<digest>`, so a later stop
-# naming that same set passes and a set that differs blocks once more. The
+# naming that same set passes and a set that differs blocks once more. A
+# changed path the render inventory `.kendex-generated.json` lists is named at
+# neither kind, judged before coverage so that holds at the root too. The
 # changed set is read against the branch's merge-base with the default branch,
 # or the working tree alone where no base applies. A payload, git state or
 # marker the hook cannot read or write is refused, never passed.
@@ -197,10 +197,11 @@ build() { # WORLD — the row's repository, its run directory and PATH
         seal
         ;;
       file-topic) printf '# Selected path\n\nCovers: ui/src/app.ts\n' >"$REPO/docs/architecture/selected.md"; seal ;;
-      # The render inventory kendex writes, listing one of the two paths below
-      # the root that no document covers, so one row asks what a render does
-      # and the other what a path the same inventory does not list still does.
-      generated) printf '["ui/src/app.ts"]\n' >"$REPO/.kendex-generated.json"; seal ;;
+      # The render inventory kendex writes, listing the changed path at the
+      # root, the one a covering document reaches, so one row asks what a
+      # render does where coverage would otherwise name it and the other what
+      # a path the same inventory does not list still does.
+      generated) printf '["top.rs"]\n' >"$REPO/.kendex-generated.json"; seal ;;
       empty-generated) : >"$REPO/.kendex-generated.json"; seal ;;
       root-topic) printf '# All\n\nCovers: . ./ /\n' >"$REPO/docs/architecture/all.md"; seal ;;
       with-master) fgit -C "$REPO" branch master ;;
@@ -431,8 +432,8 @@ an entry naming a file deleted and not yet staged is named|repo file-topic|rm-ui
 a glob entry is satisfied by a path its * reaches across /|repo glob-topic|md|0|-|-
 an entry whose only match is an untracked new file is satisfied|repo|covered-new|0|-|-
 a changed path at the root names the root AGENTS.md as stale, never itself as uncovered|repo|top|2|AGENTS.md(top.rs)|stale=1;base=default-branch
-a changed path the render inventory lists is a render, not uncovered|repo generated|ui|0|-|-
-a changed path the same inventory does not list is still uncovered|repo generated|other|2|ui/src/app.tsx|uncovered=1;base=default-branch
+a changed path the render inventory lists is a render, named at neither kind though the root AGENTS.md covers it|repo generated|top|0|-|-
+a changed path the same inventory does not list is still uncovered|repo generated|ui|2|ui/src/app.ts|uncovered=1;base=default-branch
 a deleted path no doc covers is not named|repo|rm-ui|0|-|-
 an untracked AGENTS.md covers the new code beside it|repo|newpkg|0|-|-
 an AGENTS.md deleted and not yet staged no longer covers the code beside it|repo ui-agents|rm-ui-agents ui|2|ui/src/app.ts|uncovered=1;base=default-branch

--- a/hooks/tests/doc-drift-check.test.sh
+++ b/hooks/tests/doc-drift-check.test.sh
@@ -1,7 +1,9 @@
 #!/usr/bin/env bash
 # doc-drift-check: a Stop hook that blocks once per set of findings. Every
-# changed non-markdown path is matched against the nearest non-root AGENTS.md
-# above it, tracked or untracked, and every topic file whose Covers entry
+# changed non-markdown path is matched against the nearest AGENTS.md above it,
+# tracked or untracked — the root's own for a path whose directory is the
+# repository root, one below the root for anything deeper — and every topic
+# file whose Covers entry
 # reaches it; a covering doc left unchanged, a Covers entry no path on disk
 # matches, and a changed path on disk no doc covers where some topic declares
 # an entry and the render inventory `.kendex-generated.json` does not list it
@@ -88,8 +90,9 @@ fgit() {
 }
 
 # A repository on a branch named main with no remote: a root AGENTS.md
-# (covers nothing), crates/core with its own AGENTS.md, a topic covering
-# crates/core, and ui/ under no doc at all.
+# (covering the paths directly at the root and nothing deeper), crates/core
+# with its own AGENTS.md, a topic covering crates/core, and ui/ under no doc
+# at all.
 seed_repo() { # DIR
   mkdir -p "$1/crates/core/src" "$1/docs/architecture" "$1/ui/src"
   fgit init -q "$1"
@@ -194,10 +197,10 @@ build() { # WORLD — the row's repository, its run directory and PATH
         seal
         ;;
       file-topic) printf '# Selected path\n\nCovers: ui/src/app.ts\n' >"$REPO/docs/architecture/selected.md"; seal ;;
-      # The render inventory kendex writes, listing one of the two paths no
-      # document covers, so one row asks what a render does and the other what
-      # a path the same inventory does not list still does.
-      generated) printf '["top.rs"]\n' >"$REPO/.kendex-generated.json"; seal ;;
+      # The render inventory kendex writes, listing one of the two paths below
+      # the root that no document covers, so one row asks what a render does
+      # and the other what a path the same inventory does not list still does.
+      generated) printf '["ui/src/app.ts"]\n' >"$REPO/.kendex-generated.json"; seal ;;
       empty-generated) : >"$REPO/.kendex-generated.json"; seal ;;
       root-topic) printf '# All\n\nCovers: . ./ /\n' >"$REPO/docs/architecture/all.md"; seal ;;
       with-master) fgit -C "$REPO" branch master ;;
@@ -408,7 +411,7 @@ the farther AGENTS.md is never named|repo crates-agents|code|$CORE_DOCS
 a markdown-only change names nothing|repo|md|-
 an untracked new file is a change, named by its path|repo|new|crates/core/AGENTS.md(crates/core/src/added.rs),docs/architecture/core.md(crates/core/src/added.rs)
 a staged new file is a change, named by its path|repo|new stage|crates/core/AGENTS.md(crates/core/src/added.rs),docs/architecture/core.md(crates/core/src/added.rs)
-code under no doc at all is named as uncovered|repo|ui top|top.rs,ui/src/app.ts
+a path at the root is covered by the root AGENTS.md, while code below the root under no doc at all is named as uncovered|repo|ui top|AGENTS.md(top.rs),ui/src/app.ts
 an untracked new file from a subdirectory is named by its repository path|repo subdir|new|crates/core/AGENTS.md(crates/core/src/added.rs),docs/architecture/core.md(crates/core/src/added.rs)
 an ignored path is not a change|repo ignore-target|target|-
 a trailing-slash entry covers the directory|repo ui-topic|ui|docs/architecture/ui.md(ui/src/app.ts)
@@ -427,14 +430,14 @@ a Covers entry matching no path is named on a markdown-only change|repo dangling
 an entry naming a file deleted and not yet staged is named|repo file-topic|rm-ui|2|docs/architecture/selected.md(Covers: ui/src/app.ts),docs/architecture/selected.md(ui/src/app.ts)|stale=1;dangling=1;base=default-branch
 a glob entry is satisfied by a path its * reaches across /|repo glob-topic|md|0|-|-
 an entry whose only match is an untracked new file is satisfied|repo|covered-new|0|-|-
-a changed path no doc covers is named|repo|top|2|top.rs|uncovered=1;base=default-branch
-a changed path the render inventory lists is a render, not uncovered|repo generated|top|0|-|-
-a changed path the same inventory does not list is still uncovered|repo generated|ui|2|ui/src/app.ts|uncovered=1;base=default-branch
+a changed path at the root names the root AGENTS.md as stale, never itself as uncovered|repo|top|2|AGENTS.md(top.rs)|stale=1;base=default-branch
+a changed path the render inventory lists is a render, not uncovered|repo generated|ui|0|-|-
+a changed path the same inventory does not list is still uncovered|repo generated|other|2|ui/src/app.tsx|uncovered=1;base=default-branch
 a deleted path no doc covers is not named|repo|rm-ui|0|-|-
 an untracked AGENTS.md covers the new code beside it|repo|newpkg|0|-|-
 an AGENTS.md deleted and not yet staged no longer covers the code beside it|repo ui-agents|rm-ui-agents ui|2|ui/src/app.ts|uncovered=1;base=default-branch
 a warning git writes on a read that succeeds is not a path|repo autocrlf|code agents topic|0|-|-
-each kind that holds has its keyed line, stale then dangling then uncovered|repo dangling-topic|code top|2|$CORE_DOCS,docs/architecture/gone.md(Covers: crates/gone),top.rs|stale=2;dangling=1;uncovered=1;base=default-branch
+each kind that holds has its keyed line, stale then dangling then uncovered|repo dangling-topic|code ui|2|$CORE_DOCS,docs/architecture/gone.md(Covers: crates/gone),ui/src/app.ts|stale=2;dangling=1;uncovered=1;base=default-branch
 "
 
 run_table "base selection: what the branch is compared against" "world change rc out base" "\
@@ -461,9 +464,9 @@ another session is told the same set|repo|code stopped|stop2|2|$CORE_DOCS
 a set that gained a document blocks again|repo ui-topic|ui stopped code|stop|2|$CORE_AND_UI
 a set named earlier passes after another set intervened|repo ui-topic|ui stopped code stopped revert-code|stop|0|-
 a dangling entry named once passes on a later stop|repo dangling-topic|md stopped|stop|0|-
-an uncovered path named once passes on a later stop|repo|top stopped|stop|0|-
+an uncovered path named once passes on a later stop|repo|ui stopped|stop|0|-
 a set that gained a dangling entry blocks again|repo|code stopped dangle|stop|2|$CORE_DOCS,docs/architecture/gone.md(Covers: crates/gone)
-a set that gained an uncovered path blocks again|repo|code stopped top|stop|2|$CORE_DOCS,top.rs
+a set that gained an uncovered path blocks again|repo|code stopped ui|stop|2|$CORE_DOCS,ui/src/app.ts
 "
 
 run_table "a state the hook cannot read or a marker it cannot write is refused" "world change payload rc out err" "\


### PR DESCRIPTION
## Summary
- `hooks/doc-drift-check.sh`: `covering_docs` treats the root `AGENTS.md` as the nearest covering document for a path whose directory is the repository root, and only for such a path; the AGENTS.md listing now includes the root's own beside every one below it. A file below the root still needs a non-root `AGENTS.md` at or above it or a topic `Covers` entry. No per-file `Covers` list.
- The outcome is re-kinded, not removed: the root `AGENTS.md` is judged stale like any other covering document, so a session that edits `kendex.toml` or `skills-lock.json` without touching `AGENTS.md` meets the ordinary once-per-set `stale=1` ask instead of the nameless `uncovered=1` block, the same trade KEN-1340 accepted for `Cargo.lock` and `overview.md`.
- A path the render inventory `.kendex-generated.json` lists is judged before coverage, so a render is named at neither kind wherever it sits. The local review found that once the root `AGENTS.md` covered root paths, the inventory's own self-listing at the root would have named `AGENTS.md` stale on every `kendex refresh`; the exclusion moved to the top of the changed-path loop, its single owner.
- `.claude/hooks/doc-drift-check.sh` is the byte-identical render, in each commit. `hooks/tests/doc-drift-check.test.sh` re-kinds the rows whose outcome changed; the render fixture stays at the root, where coverage would otherwise reach it.

## Review
- Local round: reviewer-correctness, one blocker (fixed in 179495ccc), one suggestion declined. The suggestion asked to gate root coverage on a topic map existing: declined, since the stale kind has never been topic-gated for any `AGENTS.md` (a `crates/core` change in a topic-less repository already names `crates/core/AGENTS.md` stale), the Done-when covers root files unconditionally, and the frontmatter now states the widened contract.

## Completed Issues
- Closes KEN-1357 - doc-drift-check names every root-level non-markdown file as uncovered

## Size
- branch-size-check: production=31 tests=21 mirror=31, no allowance stated on the issue.

## Test Plan
- `hooks/tests/doc-drift-check.test.sh`: 82 rows green. One control per direction: a changed root file names `AGENTS.md(top.rs)` as stale with no `uncovered=` line; a changed file one directory down with no covering document is still named uncovered.
- Must-fail controls, each reddening rows: the root `AGENTS.md` dropped from the listing (2 rows), the root branch in `covering_docs` removed (2 rows), the root `AGENTS.md` made to cover every path (18 rows), the render judgement put back inside the uncovered arm (1 row).
- `env -u TMPDIR tools/guard --full` on each head: clean.

https://claude.ai/code/session_018zung31GVN9KPESkpLrC1C
