### PR TITLE
fix(KEN-1347): adding a command, hook or MCP server from the local source fails, so a template carrying one installs nothing

### DIFF
--- a/changelog.d/fixed/KEN-1347.md
+++ b/changelog.d/fixed/KEN-1347.md
@@ -1,0 +1,1 @@
+- A hook, command or MCP server installs by name from the local source, so a template carrying one installs every member; a template install refused before anything went in says so, not "only some".

--- a/changelog.d/fixed/KEN-1347.md
+++ b/changelog.d/fixed/KEN-1347.md
@@ -1,1 +1,1 @@
-- A hook, command or MCP server installs by name from the local source, so a template carrying one installs every member; a template install refused before anything went in says so, not "only some".
+- A hook, command or MCP server installs by name from the local source, so a template carrying one installs every member; a template install that refused names what it wrote, or that nothing went in.

--- a/crates/app/src/marketplaces.rs
+++ b/crates/app/src/marketplaces.rs
@@ -34,11 +34,8 @@ fn open_catalog(
     let ready = kendex_core::source::require_ready(env, scope, source, &manifest)
         .map_err(|e| e.to_string())?;
     let sealed = SealedSource::open(&ready.root).map_err(|e| e.to_string())?;
-    let config = kendex_core::source::source_config(
-        &sealed,
-        kendex_core::source::repo_leaf(&ready.provenance),
-    )
-    .map_err(|e| e.to_string())?;
+    let config = kendex_core::source::source_config_for(&sealed, &ready.provenance)
+        .map_err(|e| e.to_string())?;
     Ok((sealed, config, ready.provenance))
 }
 

--- a/crates/core/src/engine/expansion.rs
+++ b/crates/core/src/engine/expansion.rs
@@ -14,7 +14,7 @@ use crate::env::Env;
 use crate::lock::Reason;
 use crate::manifest::{ItemDecl, Manifest};
 use crate::model::{HarnessId, ItemKind, Scope};
-use crate::source::{SourceConfig, SourceState, source_config};
+use crate::source::{SourceConfig, SourceState, source_config_for};
 use crate::source_read::SealedSource;
 
 use super::desired::{DesiredState, target_harnesses};
@@ -324,9 +324,8 @@ impl Catalogs<'_> {
         // failures. `origin::origin` is the wider one, and a failure shape
         // added here has to be added there too or a sweep keeps answering
         // that a catalog reads.
-        let leaf = crate::source::repo_leaf(&ready.provenance);
         let opened = SealedSource::open(&ready.root)
-            .and_then(|sealed| Ok((source_config(&sealed, leaf)?, sealed)));
+            .and_then(|sealed| Ok((source_config_for(&sealed, &ready.provenance)?, sealed)));
         let (config, sealed) = match opened {
             Ok(opened) => opened,
             // The removal pass reads the mark and stays quiet, because this

--- a/crates/core/src/engine/ops/add.rs
+++ b/crates/core/src/engine/ops/add.rs
@@ -12,7 +12,7 @@ use crate::error::{CoreError, Result};
 use crate::lock::{Lock, lock_path};
 use crate::manifest::{self, ItemDecl, Manifest, Method};
 use crate::model::{HarnessId, ItemKind, Scope};
-use crate::source::{self, find_item, list_items, source_config};
+use crate::source::{self, find_item, list_items, source_config_for};
 
 #[derive(Debug, Default, Clone)]
 pub struct AddRequest {
@@ -225,7 +225,7 @@ fn add_from(
     let ready = source::require_ready(env, scope, source_name, manifest)?;
     let hold_at = hold_commit(request, source_name, &ready)?;
     let sealed = crate::source_read::SealedSource::open(&ready.root)?;
-    let config = source_config(&sealed, crate::source::repo_leaf(&ready.provenance))?;
+    let config = source_config_for(&sealed, &ready.provenance)?;
 
     let mut agents = wanted.agents.clone();
     let mut skills = wanted.skills.clone();

--- a/crates/core/src/engine/ops/add/place.rs
+++ b/crates/core/src/engine/ops/add/place.rs
@@ -17,7 +17,7 @@ use crate::env::Env;
 use crate::error::{CoreError, Result};
 use crate::manifest::{LOCAL_SOURCE_NAME, Manifest};
 use crate::model::{ItemKind, Scope};
-use crate::source::{self, SourceConfig, list_items, source_config};
+use crate::source::{self, SourceConfig, list_items, source_config_for};
 use crate::source_read::SealedSource;
 
 /// The qualifier separator. `::` never appears in an item name, an
@@ -151,7 +151,7 @@ fn open<'cache>(
     if !cache.opened.contains_key(alias) {
         let ready = source::require_ready(env, scope, alias, manifest)?;
         let sealed = SealedSource::open(&ready.root)?;
-        let config = source_config(&sealed, source::repo_leaf(&ready.provenance))?;
+        let config = source_config_for(&sealed, &ready.provenance)?;
         cache.opened.insert(
             alias.to_owned(),
             Opened {

--- a/crates/core/src/engine/origin.rs
+++ b/crates/core/src/engine/origin.rs
@@ -12,7 +12,7 @@ use std::collections::BTreeMap;
 use crate::env::Env;
 use crate::manifest::Manifest;
 use crate::model::Scope;
-use crate::source::{SourceState, source_config};
+use crate::source::{SourceState, source_config_for};
 use crate::source_read::SealedSource;
 
 use super::desired::DesiredState;
@@ -147,7 +147,7 @@ fn origin(
         }
     };
     let read = SealedSource::open(&ready.root).and_then(|sealed| {
-        let config = source_config(&sealed, crate::source::repo_leaf(&ready.provenance))?;
+        let config = source_config_for(&sealed, &ready.provenance)?;
         // A plugin-registry catalog's sets are its plugins, and enumerating
         // their members is the only read that can fail for one — the config
         // below reports nothing about a plugin whose items will not list. A

--- a/crates/core/src/package/detail.rs
+++ b/crates/core/src/package/detail.rs
@@ -91,8 +91,7 @@ fn effective_item(
         });
     };
     let sealed = SealedSource::open(&ready.root)?;
-    let config =
-        crate::source::source_config(&sealed, crate::source::repo_leaf(&ready.provenance))?;
+    let config = crate::source::source_config_for(&sealed, &ready.provenance)?;
     let Some(item_path) = crate::source::find_item(&sealed, &config, kind, name) else {
         return Err(CoreError::ItemNotInSource {
             name: name.to_owned(),

--- a/crates/core/src/package/diff.rs
+++ b/crates/core/src/package/diff.rs
@@ -172,7 +172,7 @@ fn commit_tree(env: &Env, scope: &Scope, kind: ItemKind, name: &str, commit: &st
         }
     };
     let sealed = SealedSource::open(&root)?;
-    let config = crate::source::source_config(&sealed, crate::source::repo_leaf(&repo))?;
+    let config = crate::source::source_config_for(&sealed, &repo)?;
     let Some(item_path) = crate::source::find_item(&sealed, &config, kind, name) else {
         return Err(CoreError::ItemMissingAtRev {
             name: name.to_owned(),

--- a/crates/core/src/package/mod.rs
+++ b/crates/core/src/package/mod.rs
@@ -105,7 +105,7 @@ pub(crate) fn package_ref_for(
         }
     };
     let sealed = SealedSource::open(&root)?;
-    let config = crate::source::source_config(&sealed, crate::source::repo_leaf(&repo))?;
+    let config = crate::source::source_config_for(&sealed, &repo)?;
     // The tip may not offer the item (moved, deleted); the effective
     // revision the declaration reads is the fallback that keeps the page
     // and the diff working for what is actually installed.
@@ -117,9 +117,7 @@ pub(crate) fn package_ref_for(
             return None;
         };
         let effective = SealedSource::open(&ready.root).ok()?;
-        let config =
-            crate::source::source_config(&effective, crate::source::repo_leaf(&ready.provenance))
-                .ok()?;
+        let config = crate::source::source_config_for(&effective, &ready.provenance).ok()?;
         crate::source::find_item(&effective, &config, kind, name)
             .and_then(|path| {
                 path.strip_prefix(effective.root())
@@ -260,12 +258,7 @@ pub fn resolve_hold(
         });
     };
     let resolution = resolve_selector(env, &repo, selector)?;
-    if !item_in_tree(
-        &resolution.root,
-        crate::source::repo_leaf(&repo),
-        kind,
-        name,
-    )? {
+    if !item_in_tree(&resolution.root, &repo, kind, name)? {
         return Err(CoreError::ItemMissingAtRev {
             name: name.to_owned(),
             repo,
@@ -297,12 +290,7 @@ pub fn prove_present(
             name: decl.source.clone(),
         });
     };
-    if !item_in_tree(
-        &ready.root,
-        crate::source::repo_leaf(&ready.provenance),
-        kind,
-        name,
-    )? {
+    if !item_in_tree(&ready.root, &ready.provenance, kind, name)? {
         return Err(CoreError::ItemNotInSource {
             name: name.to_owned(),
             source_name: decl.source.clone(),
@@ -313,9 +301,9 @@ pub fn prove_present(
 
 /// Whether one source tree offers the item — the shared reading behind
 /// both proofs above.
-fn item_in_tree(root: &Path, repo_leaf: &str, kind: ItemKind, name: &str) -> Result<bool> {
+fn item_in_tree(root: &Path, provenance: &str, kind: ItemKind, name: &str) -> Result<bool> {
     let sealed = SealedSource::open(root)?;
-    let config = crate::source::source_config(&sealed, repo_leaf)?;
+    let config = crate::source::source_config_for(&sealed, provenance)?;
     Ok(crate::source::find_item(&sealed, &config, kind, name).is_some())
 }
 

--- a/crates/core/src/source/header.rs
+++ b/crates/core/src/source/header.rs
@@ -181,7 +181,7 @@ impl DeclaredHeaders {
                 return None;
             }
             let sealed = SealedSource::open(&ready.root).ok()?;
-            let config = super::source_config(&sealed, super::repo_leaf(&ready.provenance)).ok()?;
+            let config = super::source_config_for(&sealed, &ready.provenance).ok()?;
             Some((sealed, config))
         });
         let (sealed, config) = opened.as_ref()?;

--- a/crates/core/src/template/install.rs
+++ b/crates/core/src/template/install.rs
@@ -141,15 +141,20 @@ pub struct TemplateInstall {
     /// Packages installed, by kind and name: each declared in the
     /// destination's manifest and rendered by an add that committed.
     pub declared: Vec<String>,
-    /// Copies written into the destination's own local packages.
+    /// Copies written into the destination's own local packages, by kind
+    /// and name: bytes in the local slot, declared from there in the same
+    /// write. Not a package installed: the add that renders a copy runs
+    /// after this write and can refuse, so a name here that `declared`
+    /// lacks is local bytes and a declaration with no render behind them.
     pub copied: Vec<String>,
     /// What a step said while it worked.
     pub notes: Vec<String>,
     /// Why the run stopped short of the whole template, or null where it
-    /// finished. Whatever the lists above name is installed either way —
-    /// that is what makes this an account rather than a refusal, and it is
-    /// why a run that stopped still answers rather than throwing its own
-    /// record away.
+    /// finished. What `subscribed` and `declared` name is on disk either
+    /// way, and `copied` names bytes that may sit ahead of a render that
+    /// refused — that is what makes this an account rather than a
+    /// refusal, and it is why a run that stopped still answers rather
+    /// than throwing its own record away.
     pub stopped: Option<String>,
 }
 

--- a/crates/core/src/template/install.rs
+++ b/crates/core/src/template/install.rs
@@ -630,19 +630,20 @@ impl Landing {
         Ok(())
     }
 
-    /// Whether a package this run installed is in the destination. What
+    /// Whether this run has written something a refusal would hide. What
     /// decides between an install that refused and one that stopped
     /// part-way.
     ///
-    /// A package went in when the add that declares and renders it
-    /// committed. The writes before that — a subscription, a copy into
-    /// the destination's local slot — are what a member needs before it
-    /// can go in, not a member gone in: a run whose add refuses after
-    /// them has put no package into the place, and reporting it as one
-    /// that stopped part-way would tell a person that some of the
-    /// template is installed when none of it is.
+    /// Two writes count. A package went in when the add that declares and
+    /// renders it committed. A subscription the run made is durable state
+    /// outside the destination: the personal manifest holds a marketplace
+    /// the person did not subscribe to by hand, so a refusal after it has
+    /// to name it. A copy into the destination's local slot is neither: it
+    /// is what a member needs before it can go in, not a member gone in,
+    /// and an account that counted it would tell a person that some of
+    /// the template is installed when none of it is.
     fn anything_landed(&self) -> bool {
-        !self.install.declared.is_empty()
+        !self.install.declared.is_empty() || !self.install.subscribed.is_empty()
     }
 
     /// Whether this run has already declared that package.

--- a/crates/core/src/template/install.rs
+++ b/crates/core/src/template/install.rs
@@ -138,7 +138,8 @@ pub struct TemplateInstall {
     /// The repositories subscribed to along the way, in the order they
     /// were.
     pub subscribed: Vec<String>,
-    /// Packages declared, by kind and name.
+    /// Packages installed, by kind and name: each declared in the
+    /// destination's manifest and rendered by an add that committed.
     pub declared: Vec<String>,
     /// Copies written into the destination's own local packages.
     pub copied: Vec<String>,
@@ -608,10 +609,6 @@ fn subscription_for(personal: &Manifest, repo: &str) -> Option<String> {
 #[derive(Default)]
 struct Landing {
     install: TemplateInstall,
-    /// How many plans this run committed. A plan is one transaction — it
-    /// applies whole or rolls back — so this counts writes that are on
-    /// disk.
-    committed: usize,
 }
 
 impl Landing {
@@ -629,15 +626,23 @@ impl Landing {
         if crate::apply::execute(env, plan)?.applied == 0 {
             return Ok(());
         }
-        self.committed += 1;
         wrote(&mut self.install);
         Ok(())
     }
 
-    /// Whether anything this run did is on disk. What decides between an
-    /// install that refused and one that stopped part-way.
+    /// Whether a package this run installed is in the destination. What
+    /// decides between an install that refused and one that stopped
+    /// part-way.
+    ///
+    /// A package went in when the add that declares and renders it
+    /// committed. The writes before that — a subscription, a copy into
+    /// the destination's local slot — are what a member needs before it
+    /// can go in, not a member gone in: a run whose add refuses after
+    /// them has put no package into the place, and reporting it as one
+    /// that stopped part-way would tell a person that some of the
+    /// template is installed when none of it is.
     fn anything_landed(&self) -> bool {
-        self.committed > 0
+        !self.install.declared.is_empty()
     }
 
     /// Whether this run has already declared that package.
@@ -656,9 +661,9 @@ impl Landing {
     }
 }
 
-/// What a failing step does to the run: nothing landed yet, so the
-/// failure is the whole answer; or something did, and the account of it
-/// travels back with the reason it stopped.
+/// What a failing step does to the run: no package went in yet, so the
+/// failure is the whole answer; or one did, and the account of it travels
+/// back with the reason it stopped.
 ///
 /// A template install is several writes and only the per-scope
 /// transactions are atomic, so a person whose third step failed still has
@@ -825,10 +830,11 @@ pub fn install(
 /// different bytes is a refusal naming it — this never writes over content
 /// somebody else owns.
 ///
-/// The run's record is handed in rather than made here. What this commits
-/// is on disk whatever happens next, so a refusal in the rendering below
-/// cannot take the account of it away: there is one record for the
-/// install, and this step has no copy of its own to drop.
+/// The run's record is handed in rather than made here. The copies are
+/// what the members need before the add below can install them, and
+/// their declarations enter the record with that add: a refusal in the
+/// rendering leaves the copied bytes and their declarations in place and
+/// counts no package from this step as gone in.
 fn install_local(
     env: &Env,
     template: &Template,
@@ -905,7 +911,6 @@ fn install_local(
     let plan = Plan::landed(destination.clone(), ops)?;
     landed.commit(env, &plan, |install| {
         install.copied.extend(copied);
-        install.declared.extend(declared);
     })?;
     // The declarations are in; rendering them is the ordinary apply every
     // other install ends on.
@@ -916,42 +921,30 @@ fn install_local(
             source: Some(LOCAL_SOURCE_NAME.to_owned()),
             harnesses,
             method,
-            skills: resolution
-                .copies
-                .iter()
-                .filter(|copy| copy.kind == ItemKind::Skill)
-                .map(|copy| copy.name.clone())
-                .collect(),
-            agents: resolution
-                .copies
-                .iter()
-                .filter(|copy| copy.kind == ItemKind::Agent)
-                .map(|copy| copy.name.clone())
-                .collect(),
-            hooks: resolution
-                .copies
-                .iter()
-                .filter(|copy| copy.kind == ItemKind::Hook)
-                .map(|copy| copy.name.clone())
-                .collect(),
-            commands: resolution
-                .copies
-                .iter()
-                .filter(|copy| copy.kind == ItemKind::Command)
-                .map(|copy| copy.name.clone())
-                .collect(),
-            mcp_servers: resolution
-                .copies
-                .iter()
-                .filter(|copy| copy.kind == ItemKind::McpServer)
-                .map(|copy| copy.name.clone())
-                .collect(),
+            skills: copies_of(resolution, ItemKind::Skill),
+            agents: copies_of(resolution, ItemKind::Agent),
+            hooks: copies_of(resolution, ItemKind::Hook),
+            commands: copies_of(resolution, ItemKind::Command),
+            mcp_servers: copies_of(resolution, ItemKind::McpServer),
             ..AddRequest::default()
         },
     )?;
-    landed.commit(env, &report.plan, |_| {})?;
+    landed.commit(env, &report.plan, |install| {
+        install.declared.extend(declared);
+    })?;
     landed.install.notes.extend(report.notes);
     Ok(())
+}
+
+/// The names of the template's own copies of one kind, as the add that
+/// renders them from the local slot wants them.
+fn copies_of(resolution: &Resolution, kind: ItemKind) -> Vec<String> {
+    resolution
+        .copies
+        .iter()
+        .filter(|copy| copy.kind == kind)
+        .map(|copy| copy.name.clone())
+        .collect()
 }
 
 /// The writes that carry the terms the copied bytes came under into the

--- a/crates/core/src/template/install.rs
+++ b/crates/core/src/template/install.rs
@@ -608,47 +608,46 @@ fn subscription_for(personal: &Manifest, repo: &str) -> Option<String> {
 /// What a caller reads — what is on disk, and whether the run stopped
 /// part-way — is decided from writes that committed, never from the
 /// members that were asked for. Every write an install makes goes through
-/// [`Landing::commit`], and that is what keeps the account and the writes
+/// [`Landing::prepare`], and that is what keeps the account and the writes
 /// one fact: a step cannot describe a write it did not make, and no step
 /// holds a record of its own to drop when a later one refuses.
 #[derive(Default)]
 struct Landing {
     install: TemplateInstall,
+    /// Whether a write a refusal would have to answer for has committed:
+    /// a refusal after one is a run that stopped part-way.
+    landed: bool,
 }
 
 impl Landing {
-    /// Execute one plan, and where it wrote, record what it wrote.
-    ///
-    /// The description travels with the plan rather than being pushed
-    /// beside it, so an entry in the record answers for an operation that
-    /// ran. A plan with nothing in it runs nothing and records nothing.
+    /// Execute one plan, and where it wrote, record it and count it landed.
     fn commit(
         &mut self,
         env: &Env,
         plan: &Plan,
         wrote: impl FnOnce(&mut TemplateInstall),
     ) -> Result<()> {
-        if crate::apply::execute(env, plan)?.applied == 0 {
-            return Ok(());
-        }
-        wrote(&mut self.install);
+        self.landed |= self.prepare(env, plan, wrote)?;
         Ok(())
     }
 
-    /// Whether this run has written something a refusal would hide. What
-    /// decides between an install that refused and one that stopped
-    /// part-way.
+    /// Execute one plan, and where it wrote, record what it wrote without
+    /// counting it as landed; whether it wrote is the answer.
     ///
-    /// Two writes count. A package went in when the add that declares and
-    /// renders it committed. A subscription the run made is durable state
-    /// outside the destination: the personal manifest holds a marketplace
-    /// the person did not subscribe to by hand, so a refusal after it has
-    /// to name it. A copy into the destination's local slot is neither: it
-    /// is what a member needs before it can go in, not a member gone in,
-    /// and an account that counted it would tell a person that some of
-    /// the template is installed when none of it is.
-    fn anything_landed(&self) -> bool {
-        !self.install.declared.is_empty() || !self.install.subscribed.is_empty()
+    /// The description travels with the plan rather than being pushed
+    /// beside it, so an entry in the record answers for an operation that
+    /// ran. A plan with nothing in it runs nothing and records nothing.
+    fn prepare(
+        &mut self,
+        env: &Env,
+        plan: &Plan,
+        wrote: impl FnOnce(&mut TemplateInstall),
+    ) -> Result<bool> {
+        if crate::apply::execute(env, plan)?.applied == 0 {
+            return Ok(false);
+        }
+        wrote(&mut self.install);
+        Ok(true)
     }
 
     /// Whether this run has already declared that package.
@@ -683,7 +682,7 @@ enum Stopped<T> {
 fn step<T>(landed: &Landing, result: Result<T>) -> Result<Stopped<T>> {
     match result {
         Ok(value) => Ok(Stopped::Went(value)),
-        Err(error) if landed.anything_landed() => Ok(Stopped::Short(error)),
+        Err(error) if landed.landed => Ok(Stopped::Short(error)),
         Err(error) => Err(error),
     }
 }
@@ -915,7 +914,8 @@ fn install_local(
         },
     });
     let plan = Plan::landed(destination.clone(), ops)?;
-    landed.commit(env, &plan, |install| {
+    // Not counted as landed: what a member needs before it can go in.
+    landed.prepare(env, &plan, |install| {
         install.copied.extend(copied);
     })?;
     // The declarations are in; rendering them is the ordinary apply every

--- a/crates/core/src/template/tests/create.rs
+++ b/crates/core/src/template/tests/create.rs
@@ -52,6 +52,11 @@ pub(super) fn seeded() -> Project {
     // The person's own package, captured into the project's local source.
     let local = root.join(crate::source::LOCAL_SOURCE_DIR);
     skill(&local.join("skills"), "house-style", "my own bytes");
+    file_item(
+        &local.join("commands"),
+        "preview.md",
+        "---\ndescription: preview the site\n---\nCommand body.\n",
+    );
     // Content nothing manages: the local opt-in's candidates.
     skill(&root.join(".claude/skills"), "stray", "unmanaged bytes");
     file_item(
@@ -68,6 +73,7 @@ pub(super) fn seeded() -> Project {
              [sources.cat]\n{}\n\
              [skills.gh]\nsource = \"cat\"\n\
              [skills.house-style]\nsource = \"local\"\n\
+             [commands.preview]\nsource = \"local\"\n\
              [commands.note]\nsource = \"cat\"\nenabled = false\n\
              [skill-instructions]\n\"gh\" = \"read this first\"\n\
              [bot-instructions]\nreviewers = [\"one\"]\n",
@@ -84,6 +90,7 @@ pub(super) fn seeded() -> Project {
     for (kind, name, source) in [
         (ItemKind::Skill, "gh", "cat"),
         (ItemKind::Skill, "house-style", "local"),
+        (ItemKind::Command, "preview", "local"),
         (ItemKind::Command, "note", "cat"),
     ] {
         lock.entries.insert(

--- a/crates/core/src/template/tests/install.rs
+++ b/crates/core/src/template/tests/install.rs
@@ -161,13 +161,21 @@ fn installing_twice_leaves_the_same_project() {
         unreachable!("built as a project scope")
     };
 
-    let landed = install(&project.env, &template, &target, None, None).unwrap();
+    let landed = install(
+        &project.env,
+        &template,
+        &target,
+        Some(vec![HarnessId::Claude]),
+        None,
+    )
+    .unwrap();
     assert_eq!(landed.subscribed, ["cat"].map(|_| project_repo(&project)));
     let declared = landed.declared.join(", ");
     for wanted in [
         "skill gh",
         "command note",
         "skill house-style",
+        "command preview",
         "skill stray",
     ] {
         assert!(declared.contains(wanted), "{declared}");
@@ -179,12 +187,23 @@ fn installing_twice_leaves_the_same_project() {
         .join("skills/house-style/SKILL.md");
     assert!(copied.is_file(), "{}", copied.display());
     assert!(!copied.is_symlink());
+    // A copied command is rendered from the local source like the skill
+    // beside it: the reserved source offers its commands by name.
+    let rendered = root.join(".claude/commands/preview.md");
+    assert!(rendered.is_file(), "{}", rendered.display());
     // The carried customization landed.
     let manifest = fs::read_to_string(root.join("kendex.toml")).unwrap();
     assert!(manifest.contains("read this first"), "{manifest}");
 
     let after_first = snapshot(root);
-    install(&project.env, &template, &target, None, None).unwrap();
+    install(
+        &project.env,
+        &template,
+        &target,
+        Some(vec![HarnessId::Claude]),
+        None,
+    )
+    .unwrap();
     assert_eq!(
         snapshot(root),
         after_first,
@@ -885,18 +904,19 @@ fn a_plugin_resolves_as_a_set_that_still_says_which_kind_it_is() {
     assert_eq!(after.members, Vec::new());
 }
 
-/// A refusal in the rendering after the copies are on disk answers with
-/// the copies and the reason it stopped, never as a total refusal.
+/// A refusal in the rendering after the copies are on disk is a refusal:
+/// no package went in, so the run does not answer as one that stopped
+/// part-way.
 ///
 /// The copy and its declaration commit in one plan and the rendering is a
-/// second one. The account of the first belongs to the run, not to the
-/// step that made it, so a step that refuses afterwards cannot take it
-/// away — a person told nothing landed would go looking for bytes that
-/// are in their project.
+/// second one. A copy in the local slot is what the member needs before
+/// it can be installed, not the member installed, and an account that
+/// counted it would tell a person some of the template is in a place
+/// that holds none of it.
 #[cfg(unix)]
 #[test]
 #[allow(clippy::unwrap_used)]
-fn a_render_that_refuses_after_the_copy_committed_reports_the_copy() {
+fn a_render_that_refuses_after_the_copy_committed_is_a_refusal() {
     use std::os::unix::fs::PermissionsExt;
     let project = seeded();
     // Copies only: a marketplace group writes before them, and its own
@@ -939,10 +959,13 @@ fn a_render_that_refuses_after_the_copy_committed_reports_the_copy() {
 
     match denied {
         true => {
-            let landed = landed.unwrap();
-            assert_eq!(landed.copied, ["skill stray"], "{landed:?}");
-            assert!(landed.stopped.is_some(), "{landed:?}");
-            // And the bytes the account names are where it says they are.
+            let refused = landed.unwrap_err();
+            assert!(
+                matches!(refused, CoreError::RolledBack { .. }),
+                "{refused:?}"
+            );
+            // The copy stays where the committed plan put it, and the
+            // refusal, not an account, is what says nothing was rendered.
             let copied = root
                 .join(crate::source::LOCAL_SOURCE_DIR)
                 .join("skills/stray/SKILL.md");

--- a/crates/core/src/template/tests/install.rs
+++ b/crates/core/src/template/tests/install.rs
@@ -975,6 +975,88 @@ fn a_render_that_refuses_after_the_copy_committed_is_a_refusal() {
     }
 }
 
+/// A subscription the run made is a write outside the destination, and a
+/// refusal after it answers as a run that stopped part-way, naming it:
+/// the personal manifest now holds a marketplace the person did not
+/// subscribe to by hand, and a bare error would leave that invisible.
+///
+/// The template names a marketplace nothing subscribes to yet, so the
+/// run subscribes personally before the add; the add then refuses in the
+/// rendering. No package went in, and the account says so — `declared`
+/// stays empty — while `subscribed` carries the repository.
+#[cfg(unix)]
+#[test]
+#[allow(clippy::unwrap_used)]
+fn a_render_that_refuses_after_the_subscription_committed_reports_the_subscription() {
+    use std::os::unix::fs::PermissionsExt;
+    let project = seeded();
+    // Marketplace members only: a copy would commit its own plan before
+    // the add, and this case is about the subscription alone.
+    let template = create_from_project(
+        &project.env,
+        &project.root,
+        &Chosen {
+            name: "Marketplace only".to_owned(),
+            members: vec!["skill:gh".to_owned()],
+            fingerprint: draft_from_project(&project.env, &project.root)
+                .unwrap()
+                .fingerprint,
+            ..Chosen::default()
+        },
+    )
+    .unwrap();
+    let resolution = resolve(&project.env, &template).unwrap();
+    assert_eq!(resolution.groups.len(), 1, "{:?}", resolution.groups);
+    assert_eq!(resolution.groups[0].source, None, "{:?}", resolution.groups);
+    let target = destination(&project, "unrenderable");
+    let Scope::Project { root } = &target else {
+        unreachable!("built as a project scope")
+    };
+    // The slot the render writes into, refusing writes; the harness root
+    // above it stays writable so a render is planned at all.
+    let slot = root.join(".claude/skills");
+    fs::create_dir_all(&slot).unwrap();
+    fs::set_permissions(&slot, fs::Permissions::from_mode(0o555)).unwrap();
+    // Root writes into a directory whatever its mode, so there the
+    // refusal under test does not exist and the install simply finishes.
+    let denied = !rustix::process::geteuid().is_root();
+    let landed = install(
+        &project.env,
+        &template,
+        &target,
+        Some(vec![HarnessId::Claude]),
+        None,
+    );
+    fs::set_permissions(&slot, fs::Permissions::from_mode(0o755)).unwrap();
+
+    let landed = landed.unwrap();
+    assert_eq!(landed.subscribed, ["cat"].map(|_| project_repo(&project)));
+    match denied {
+        true => {
+            assert!(landed.stopped.is_some(), "{landed:?}");
+            assert_eq!(landed.declared, Vec::<String>::new(), "{landed:?}");
+        }
+        false => assert!(landed.stopped.is_none(), "{landed:?}"),
+    }
+    // The write the account names is on disk: the personal manifest holds
+    // a subscription at the repository the run reported.
+    let personal = crate::manifest::load_current(&crate::manifest::manifest_path(
+        &project.env,
+        &Scope::Global,
+    ))
+    .unwrap()
+    .unwrap();
+    let repo = project_repo(&project);
+    assert!(
+        personal
+            .sources
+            .values()
+            .any(|decl| decl.path.as_deref() == Some(repo.as_str())),
+        "{:?}",
+        personal.sources
+    );
+}
+
 /// A notice belongs to the copy that required it. Taking the last copy
 /// from a licensed marketplace out takes its terms with it, so the
 /// template stops listing them and an install of what is left carries no

--- a/crates/core/tests/add_from_local.rs
+++ b/crates/core/tests/add_from_local.rs
@@ -1,0 +1,94 @@
+//! Adding a hook, command or MCP server by name from the reserved local
+//! source. The local source is kendex's own authored area, laid out in
+//! kendex's fixed dirs, so the add reads it as an explicit catalog and each
+//! of these kinds resolves by name — the way a discovered third-party
+//! repo's never do.
+#![cfg(unix)]
+
+#[path = "../../test_util.rs"]
+mod test_util;
+use test_util::rooted;
+
+use std::fs;
+
+use kendex_core::engine::ops;
+use kendex_core::env::{Env, FakeOs};
+use kendex_core::manifest::LOCAL_SOURCE_NAME;
+use kendex_core::model::{ItemKind, Scope};
+
+const HOOK: &str = "#!/usr/bin/env bash\n# ---\n# name: audit\n# event: PreToolUse\n# matcher: Bash\n# description: log shell commands\n# timeout: 10\n# ---\nexit 0\n";
+const COMMAND: &str = "---\ndescription: preview the site\n---\n\nRun the preview.\n";
+const MCP: &str = "command = \"gh-mcp\"\nargs = [\"--stdio\"]\n";
+
+/// Each executable kind at its fixed place in the local source, and the
+/// request that names it.
+#[test]
+#[allow(clippy::unwrap_used)]
+fn an_executable_kind_in_the_local_source_installs_by_name() {
+    for (kind, file, body, request) in [
+        (
+            ItemKind::Hook,
+            "hooks/audit.sh",
+            HOOK,
+            ops::AddRequest {
+                hooks: vec!["audit".to_owned()],
+                ..ops::AddRequest::default()
+            },
+        ),
+        (
+            ItemKind::Command,
+            "commands/preview.md",
+            COMMAND,
+            ops::AddRequest {
+                commands: vec!["preview".to_owned()],
+                ..ops::AddRequest::default()
+            },
+        ),
+        (
+            ItemKind::McpServer,
+            "mcp/gh.toml",
+            MCP,
+            ops::AddRequest {
+                mcp_servers: vec!["gh".to_owned()],
+                ..ops::AddRequest::default()
+            },
+        ),
+    ] {
+        let tmp = tempfile::tempdir().unwrap();
+        let home = rooted(&tmp);
+        let env = Env::fake(&home, FakeOs::Linux);
+        let project = home.join("app");
+        fs::create_dir_all(project.join(".claude")).unwrap();
+        fs::write(
+            project.join("kendex.toml"),
+            "schema = 6\n\n[install]\nharnesses = [\"claude\"]\nmethod = \"copy\"\n",
+        )
+        .unwrap();
+        let scope = Scope::Project {
+            root: project.clone(),
+        };
+        let item = kendex_core::source::local_source_root(&env, &scope).join(file);
+        fs::create_dir_all(item.parent().unwrap()).unwrap();
+        fs::write(&item, body).unwrap();
+
+        let report = ops::add(
+            &env,
+            &scope,
+            &ops::AddRequest {
+                source: Some(LOCAL_SOURCE_NAME.to_owned()),
+                ..request
+            },
+        )
+        .unwrap_or_else(|error| panic!("{} from local: {error}", kind.name()));
+        kendex_core::apply::execute(&env, &report.plan).unwrap();
+        let lock = kendex_core::lock::load(&kendex_core::lock::lock_path(&env, &scope)).unwrap();
+        assert!(
+            lock.entries
+                .values()
+                .any(|entry| entry.kind == kind && entry.source_repo == LOCAL_SOURCE_NAME),
+            "{} is not installed from local: {:?}",
+            kind.name(),
+            lock.entries
+        );
+    }
+}

--- a/ui/src/bindings.ts
+++ b/ui/src/bindings.ts
@@ -5101,7 +5101,10 @@ export type TemplateInstall = {
 	 *  were.
 	 */
 	subscribed: string[],
-	/**  Packages declared, by kind and name. */
+	/**
+	 *  Packages installed, by kind and name: each declared in the
+	 *  destination's manifest and rendered by an add that committed.
+	 */
 	declared: string[],
 	/**  Copies written into the destination's own local packages. */
 	copied: string[],

--- a/ui/src/bindings.ts
+++ b/ui/src/bindings.ts
@@ -5106,16 +5106,23 @@ export type TemplateInstall = {
 	 *  destination's manifest and rendered by an add that committed.
 	 */
 	declared: string[],
-	/**  Copies written into the destination's own local packages. */
+	/**
+	 *  Copies written into the destination's own local packages, by kind
+	 *  and name: bytes in the local slot, declared from there in the same
+	 *  write. Not a package installed: the add that renders a copy runs
+	 *  after this write and can refuse, so a name here that `declared`
+	 *  lacks is local bytes and a declaration with no render behind them.
+	 */
 	copied: string[],
 	/**  What a step said while it worked. */
 	notes: string[],
 	/**
 	 *  Why the run stopped short of the whole template, or null where it
-	 *  finished. Whatever the lists above name is installed either way —
-	 *  that is what makes this an account rather than a refusal, and it is
-	 *  why a run that stopped still answers rather than throwing its own
-	 *  record away.
+	 *  finished. What `subscribed` and `declared` name is on disk either
+	 *  way, and `copied` names bytes that may sit ahead of a render that
+	 *  refused — that is what makes this an account rather than a
+	 *  refusal, and it is why a run that stopped still answers rather
+	 *  than throwing its own record away.
 	 */
 	stopped: string | null,
 };


### PR DESCRIPTION
## Summary

- The add path and the bare-name place search read a source's catalog through `source_config_for`, the promoted reader, so the reserved local source is read as an explicit catalog and its hooks, commands and MCP servers resolve by name. Every reader that holds a provenance now goes through that one call.
- A template install no longer counts a local-slot copy as a package that went in. The declarations enter the run's record when the add that renders them commits, so a rendering refusal before any package went in is reported as a refusal instead of "only some of N packages went in".
- One control per changed surface: `crates/core/tests/add_from_local.rs` installs a hook, a command and an MCP server by name from local; the template refusal test asserts the refusal.

## Verified cause

The issue's description and root's adjustment comment both hold against source at `3ac296fef`. `crates/core/src/engine/ops/add.rs:228` and `crates/core/src/engine/ops/add/place.rs:154` called the unpromoted `source_config`, so `find_item` answered `None` for `Hook | Command | McpServer` (`crates/core/src/source/config.rs:382`) and the whole add refused with `ItemNotInSource`. The template's own member check at `install.rs:389` already used the promoted reader, which is why a template resolved its members and then failed to install them. The "only some" wording came from the template run: the local-slot copy plan committed before the add refused, and `anything_landed` counted that plan, so the `went!` macro returned a `stopped` report rather than the error.

## Left out

- `crates/cli/src/commands/add_collection.rs:357` keeps the unpromoted reader. It reads a collection step's remote repository, where the promotion cannot apply, and root's site list did not name it.

## Size

Production 65 lines, tests 137 lines, render mirror 0. The issue states no `**Expected delta**` allowance, so the check judged nothing.

## Completed Issues

- Closes KEN-1347 - Adding a command, hook or MCP server from the local source fails, so a template carrying one installs nothing

## Test Plan

- `cargo test -p kendex-core --test add_from_local`: a hook, a command and an MCP server each install by name from the local source and appear in the lock with `source_repo = local`. Reverting the add reader to the unpromoted call fails this test with `'audit' not found in source 'local'`.
- `cargo test -p kendex-core` template suites: `installing_twice_leaves_the_same_project` asserts the copied command is declared and rendered; `a_render_that_refuses_after_the_copy_committed_is_a_refusal` asserts the refusal. Moving the declarations back into the copy plan makes that test fail with an `Ok` carrying a stopped report.
- `env -u TMPDIR tools/guard --full` on the final tree: exit 0, no `guard:` failure lines.

https://claude.ai/code/session_01JuFmZqiUeCP5bnRHKUaPnp
