### PR TITLE
fix(KEN-1350): a disabled button inside an openable row opens the package page

### DIFF
--- a/changelog.d/fixed/1350.md
+++ b/changelog.d/fixed/1350.md
@@ -1,0 +1,1 @@
+- Pressing a greyed-out button inside a row or card that opens something, such as Update while an update runs, now does nothing instead of opening the package page.

--- a/ui/src/lib/click-asks-to-open.ts
+++ b/ui/src/lib/click-asks-to-open.ts
@@ -24,7 +24,8 @@ const CONTROLS =
  *  package page. The answer has to come from the geometry, and from the
  *  element's own box rather than the point: `elementsFromPoint` honours
  *  `pointer-events: none` exactly as the click did, so it cannot see the
- *  control either.
+ *  control either. The box covers [left, right) and [top, bottom), so the
+ *  line along its far edges belongs to what is drawn beyond it.
  *
  *  Only for a pressed point. Keyboard and assistive activation arrive with
  *  detail 0 and no meaningful coordinates, and a disabled control cannot hold
@@ -34,9 +35,9 @@ function pressLandsOnDisabledControl(event: MouseEvent<HTMLElement>): boolean {
     const box = control.getBoundingClientRect();
     if (
       event.clientX >= box.left &&
-      event.clientX <= box.right &&
+      event.clientX < box.right &&
       event.clientY >= box.top &&
-      event.clientY <= box.bottom
+      event.clientY < box.bottom
     )
       return true;
   }

--- a/ui/src/lib/click-asks-to-open.ts
+++ b/ui/src/lib/click-asks-to-open.ts
@@ -17,10 +17,37 @@ import type { MouseEvent } from "react";
 const CONTROLS =
   'a, button, input, select, textarea, [role="button"], [role="checkbox"], [data-slot="tooltip-content"], [data-slot="dialog-content"], [data-slot="dialog-overlay"], [data-slot^="dropdown-menu-"]';
 
+/** Whether the point pressed lies over a control inside the surface that is
+ *  switched off. A disabled control carries `pointer-events: none`, so the
+ *  browser hands the click to the surface behind it and the walk up from the
+ *  target never meets the button: pressing a greyed-out Update would open the
+ *  package page. The answer has to come from the geometry, and from the
+ *  element's own box rather than the point: `elementsFromPoint` honours
+ *  `pointer-events: none` exactly as the click did, so it cannot see the
+ *  control either.
+ *
+ *  Only for a pressed point. Keyboard and assistive activation arrive with
+ *  detail 0 and no meaningful coordinates, and a disabled control cannot hold
+ *  focus, so there is nothing here for them to answer. */
+function pressLandsOnDisabledControl(event: MouseEvent<HTMLElement>): boolean {
+  for (const control of event.currentTarget.querySelectorAll(":disabled")) {
+    const box = control.getBoundingClientRect();
+    if (
+      event.clientX >= box.left &&
+      event.clientX <= box.right &&
+      event.clientY >= box.top &&
+      event.clientY <= box.bottom
+    )
+      return true;
+  }
+  return false;
+}
+
 /**
  * Whether a click on a whole-surface shortcut — a project card, a Library
  * row, a marketplace row — is asking to open it. False when a control
- * inside the surface already answered the click, and false when the click
+ * inside the surface already answered the click, false when the point
+ * pressed lies over a control that is switched off, and false when the click
  * ended a text selection: a drag across the surface's text was someone
  * keeping the text, not asking to leave the page. Keyboard and assistive
  * activation arrive as clicks with detail 0 and leave any standing
@@ -35,5 +62,6 @@ const CONTROLS =
 export function clickAsksToOpen(event: MouseEvent<HTMLElement>): boolean {
   if ((event.target as HTMLElement).closest(CONTROLS)) return false;
   if (event.detail === 0) return true;
+  if (pressLandsOnDisabledControl(event)) return false;
   return window.getSelection()?.isCollapsed !== false;
 }

--- a/ui/src/lib/opens-on-activate.dom.test.tsx
+++ b/ui/src/lib/opens-on-activate.dom.test.tsx
@@ -25,6 +25,9 @@ describe("a surface that opens what it names", () => {
         <button type="button" onClick={inside}>
           Update
         </button>
+        <button type="button" disabled data-testid="off" onClick={inside}>
+          Update
+        </button>
       </div>,
     );
     const at = (id: string) => {
@@ -36,6 +39,16 @@ describe("a surface that opens what it names", () => {
     if (!control) throw new Error("no control inside the surface");
     const box = host.querySelector<HTMLElement>('[aria-label="Select gh"]');
     if (!box) throw new Error("no tick box inside the surface");
+    // jsdom lays nothing out, so every box is zero-sized at the origin —
+    // where a click carrying no coordinates also lands. Give the
+    // switched-off button a place of its own, so a press over it and a
+    // press anywhere else are two different points.
+    vi.spyOn(at("off"), "getBoundingClientRect").mockReturnValue({
+      left: 40,
+      right: 90,
+      top: 10,
+      bottom: 34,
+    } as DOMRect);
     return { host, onOpen, inside, ticked, at, control, box };
   };
 
@@ -84,6 +97,25 @@ describe("a surface that opens what it names", () => {
         ran: 0,
         ticks: 1,
       },
+      // A switched-off control takes no pointer events, so the click lands
+      // on the surface behind it. Pressing a greyed-out Update asked for
+      // nothing and must open nothing.
+      {
+        name: "press over a switched-off control",
+        act: "press-off",
+        opens: 0,
+        ran: 0,
+        ticks: 0,
+      },
+      // The inverse: the enabled control beside it still answers its own
+      // press, and still keeps the surface out of it.
+      {
+        name: "press on the control beside it",
+        act: "click-control",
+        opens: 0,
+        ran: 1,
+        ticks: 0,
+      },
       // A click ending a drag across the surface's text was someone keeping
       // the text, not asking to leave the page.
       {
@@ -94,7 +126,7 @@ describe("a surface that opens what it names", () => {
         ticks: 0,
       },
     ];
-    expect(cases).toHaveLength(6);
+    expect(cases).toHaveLength(8);
     for (const entry of cases) {
       const { onOpen, inside, ticked, at, control, box } = mountSurface();
       expect(at("surface").getAttribute("tabindex"), entry.name).toBe("0");
@@ -119,6 +151,12 @@ describe("a surface that opens what it names", () => {
         await userEvent.keyboard("{Enter}");
       } else if (entry.act === "click-control") {
         await userEvent.click(control);
+      } else if (entry.act === "press-off") {
+        await userEvent.pointer({
+          target: at("surface"),
+          coords: { clientX: 50, clientY: 20 },
+          keys: "[MouseLeft]",
+        });
       } else if (entry.act === "click-box") {
         await userEvent.click(box);
       } else {

--- a/ui/src/lib/opens-on-activate.dom.test.tsx
+++ b/ui/src/lib/opens-on-activate.dom.test.tsx
@@ -107,13 +107,13 @@ describe("a surface that opens what it names", () => {
         ran: 0,
         ticks: 0,
       },
-      // The inverse: the enabled control beside it still answers its own
-      // press, and still keeps the surface out of it.
+      // The inverse: a press on the same row clear of that control's box
+      // still opens, so the refusal covers the button and not the row.
       {
-        name: "press on the control beside it",
-        act: "click-control",
-        opens: 0,
-        ran: 1,
+        name: "press clear of the switched-off control",
+        act: "press-clear",
+        opens: 1,
+        ran: 0,
         ticks: 0,
       },
       // A click ending a drag across the surface's text was someone keeping
@@ -151,10 +151,16 @@ describe("a surface that opens what it names", () => {
         await userEvent.keyboard("{Enter}");
       } else if (entry.act === "click-control") {
         await userEvent.click(control);
-      } else if (entry.act === "press-off") {
+      } else if (entry.act === "press-off" || entry.act === "press-clear") {
+        // 50 lies inside the switched-off button's stubbed box, 120 beyond
+        // its right edge; both are presses on the surface, since a
+        // switched-off control never becomes the target.
         await userEvent.pointer({
           target: at("surface"),
-          coords: { clientX: 50, clientY: 20 },
+          coords: {
+            clientX: entry.act === "press-off" ? 50 : 120,
+            clientY: 20,
+          },
           keys: "[MouseLeft]",
         });
       } else if (entry.act === "click-box") {


### PR DESCRIPTION
## Summary

- Pressing a greyed-out control inside a row or card that opens something now does nothing, instead of opening the package page. The refusal is decided once, in `ui/src/lib/click-asks-to-open.ts`, so every openable surface gets it from one place.
- The answer is geometric: over `event.currentTarget.querySelectorAll(":disabled")`, the open is refused when the pressed point lies inside a control's own box. `elementsFromPoint` cannot answer this — it honours `pointer-events: none` exactly as the click did, so it cannot see the control either.
- Keyboard and assistive activation skip the check for free. They return at the existing `detail === 0` line above it, carry no meaningful coordinates, and a disabled control cannot hold focus.
- One control per changed surface plus its inverse: two rows join the existing case table in `ui/src/lib/opens-on-activate.dom.test.tsx`. A press inside the switched-off button's box opens nothing; a press on the same row clear of that box still opens.

## Verified cause

The issue's description holds against source at `679177866`, the merge-base this branch was cut from. `ui/src/components/ui/button.tsx:8` carries `disabled:pointer-events-none` in the shared variant string, so the browser hands a press over a greyed-out button to the surface behind it. `ui/src/lib/click-asks-to-open.ts:36` walked up from `event.target` through `closest(CONTROLS)` and never met that button, so the row opened through `ui/src/lib/opens-on-activate.ts:54`.

Two paths in the issue text were stale and are corrected here. The affected files are `ui/src/components/updates-table.tsx` (openable row at :152, disabled Button at :233; place row at :258), `ui/src/components/update-place-cells.tsx` (disabled Button at :141) and `ui/src/components/marketplaces/package-row.tsx` (row at :134, disabled Buttons at :298 and :319). The issue named the first two under a `ui/src/components/updates/` directory that does not exist.

Root's adjustment comment on the issue supersedes the description's "hit test on the point" and is what this implements.

## Coverage of `:disabled`

Every disabled control in the twelve openable surfaces under `ui/src` is the shared `Button`. Base UI's `useFocusableWhenDisabled` sets the native `disabled` attribute when `isNativeButton` is true and `focusableWhenDisabled` is false, which is the default, and nothing under `ui/src` passes `focusableWhenDisabled` or `aria-disabled`. A control disabled by `aria-disabled` alone keeps its pointer events and is already answered by the `closest(CONTROLS)` line above.

## Left out

- Removing `disabled:pointer-events-none` from the shared `Button` stays excluded; root named that exclusion on the issue.
- No test pins the box's far edges. The comparisons use the half-open ranges `[left, right)` and `[top, bottom)`, which the function's comment states, and the two case-table rows already pin the behaviour that matters.

## Size

Production 31 lines, tests 45 lines, render mirror 0. The issue states no `**Expected delta**` allowance, so the check judged nothing.

## Completed Issues

- Closes KEN-1350 - A disabled button inside an openable row opens the package page

## Test Plan

- `ui/src/lib/opens-on-activate.dom.test.tsx`: the mounted surface holds a disabled button whose box is stubbed to left 40, right 90, top 10, bottom 34, because jsdom lays nothing out and reports every box as zero-sized at the origin — the same shape `ui/src/test/dom.tsx` already uses for `roomIs`. The row `press over a switched-off control` presses at clientX 50 and asserts nothing opens; the row `press clear of the switched-off control` presses at clientX 120 and asserts the row opens.
- Must-fail control: removing the `pressLandsOnDisabledControl` call fails the first of those rows with `expected "vi.fn()" to be called +0 times, but got 1 times`. Making the refusal unconditional for any pressed point fails the existing `click on the text` row, so the check cannot grow into a blanket refusal unnoticed.
- Full UI suite: 201 files, 1480 tests pass; `tsc --noEmit` and `biome check` clean.
- `env -u TMPDIR tools/guard --full` on the final tree: exit 0, no `guard:` failure lines.

https://claude.ai/code/session_01QyrZ2y9HWMaRDMA5NnQ5F2
