### PR TITLE
fix(KEN-1345): an installed hook is never counted in its marketplace's Installed in

### DIFF
--- a/changelog.d/fixed/1345.md
+++ b/changelog.d/fixed/1345.md
@@ -1,0 +1,1 @@
+- A marketplace's Packages tab counts an installed hook in the places holding it, and no longer credits a catalog name to an unrelated package whose registration happens to share it.

--- a/ui/src/lib/installed-places.test.ts
+++ b/ui/src/lib/installed-places.test.ts
@@ -30,6 +30,20 @@ const installed = (
   package: { kind: "skill", name },
 });
 
+/** A hook, whose observed name is the registration spelling — its event,
+ *  matcher and command stem — and never the name the catalog offers it
+ *  under, which only the record carries. */
+const hook = (observed: string, declared: string): ProvenanceRow => ({
+  scope: hyprtrade,
+  kind: "hook",
+  name: observed,
+  harness: "claude",
+  at: `${hyprtrade.root}/.claude/settings.json`,
+  origin: { origin: "marketplace", source: "kendex", repo: "a/b" },
+  summary: null,
+  package: { kind: "hook", name: declared },
+});
+
 // A subscription is a (scope, source, repository), not a name: the same
 // alias can be declared in the personal manifest and in a project's,
 // pointing at different repositories. A place named from the alias alone
@@ -51,6 +65,36 @@ describe("where a marketplace's packages are installed", () => {
 
     expect([...places.keys()]).toEqual([placesKey("skill", "gh")]);
     expect(places.get(placesKey("skill", "gh"))).toEqual([hyprtrade]);
+  });
+
+  // The registration spelling is not a package name, so a join on it finds
+  // the catalog's hook nowhere and the row is never counted.
+  it("counts a hook under the name its catalog offers it as", () => {
+    const places = installedPlaces(
+      [hook("PreToolUse:Bash:block-argv-kill", "block-argv-kill")],
+      catalog,
+      "a/b",
+    );
+
+    expect(places.get(placesKey("hook", "block-argv-kill"))).toEqual([
+      hyprtrade,
+    ]);
+  });
+
+  // The mirror: a registration spelling that happens to equal a catalog
+  // name says nothing about which package wrote the file, so the catalog
+  // name takes no place from it.
+  it("credits no catalog name a different package registered under", () => {
+    const places = installedPlaces(
+      [hook("gh", "unrelated-hook")],
+      catalog,
+      "a/b",
+    );
+
+    expect(places.get(placesKey("hook", "gh"))).toBeUndefined();
+    expect(places.get(placesKey("hook", "unrelated-hook"))).toEqual([
+      hyprtrade,
+    ]);
   });
 
   // A path-backed subscription has no repository at all, so a join keyed on

--- a/ui/src/lib/installed-places.test.ts
+++ b/ui/src/lib/installed-places.test.ts
@@ -97,6 +97,19 @@ describe("where a marketplace's packages are installed", () => {
     ]);
   });
 
+  // An installation the records establish no package for says nothing about
+  // which package wrote it, so its observed name names no place even when a
+  // catalog offers that very name.
+  it("names no place for a row the records establish no package for", () => {
+    const places = installedPlaces(
+      [{ ...installed(hyprtrade, "gh", "kendex", "a/b"), package: null }],
+      catalog,
+      "a/b",
+    );
+
+    expect(places.size).toBe(0);
+  });
+
   // A path-backed subscription has no repository at all, so a join keyed on
   // the declaration's own `repo` would leave every row of one unplaced.
   // Both sides carry what the subscription resolved to — a canonical path

--- a/ui/src/lib/installed-places.ts
+++ b/ui/src/lib/installed-places.ts
@@ -19,8 +19,15 @@ const personalFirst = (a: Scope, b: Scope): number =>
   Number(b.scope === "global") - Number(a.scope === "global") ||
   scopeKey(a).localeCompare(scopeKey(b));
 
-/** Where each of a marketplace's packages is installed, keyed by kind and
- *  name — the places themselves, for the caller to name and open.
+/** Where each of a marketplace's packages is installed, keyed by the
+ *  package each installation belongs to — the places themselves, for the
+ *  caller to name and open.
+ *
+ *  The join is on that package reference, not on what the scan observed,
+ *  because an observed name is not a package name: a hook is registered
+ *  under its event, matcher and command stem, so a catalog's hook is never
+ *  found under the spelling the row carries, and an unrelated package whose
+ *  stem happens to equal a catalog name would be credited to it.
  *
  *  Built once for a whole table rather than per row: the provenance join is
  *  a flat list of every installation on the machine, and filtering it per
@@ -63,7 +70,10 @@ export function installedPlaces(
     if (row.origin.source !== catalog.source || row.origin.repo !== repo) {
       continue;
     }
-    const key = placesKey(row.kind, row.name);
+    // The package the records establish, or the observation's own kind and
+    // name where they establish none — `ProvenanceRow::package_ref`.
+    const ref = row.package ?? { kind: row.kind, name: row.name };
+    const key = placesKey(ref.kind, ref.name);
     const here = scopes.get(key) ?? new Map();
     here.set(scopeKey(row.scope), row.scope);
     scopes.set(key, here);

--- a/ui/src/lib/installed-places.ts
+++ b/ui/src/lib/installed-places.ts
@@ -23,11 +23,20 @@ const personalFirst = (a: Scope, b: Scope): number =>
  *  package each installation belongs to — the places themselves, for the
  *  caller to name and open.
  *
- *  The join is on that package reference, not on what the scan observed,
- *  because an observed name is not a package name: a hook is registered
- *  under its event, matcher and command stem, so a catalog's hook is never
- *  found under the spelling the row carries, and an unrelated package whose
- *  stem happens to equal a catalog name would be credited to it.
+ *  The join is on the package the records establish, not on what the scan
+ *  observed, because an observed name is not a package name: a hook is
+ *  registered under its event, matcher and command stem, so a catalog's
+ *  hook is never found under the spelling the row carries, and an unrelated
+ *  package whose stem happens to equal a catalog name would be credited to
+ *  it.
+ *
+ *  A row the records establish no package for names no place at all, for
+ *  the reason `package-identity.ts::packageIndex` answers null on one: what
+ *  a package is, is settled in core off the records of what each install
+ *  wrote, and nothing here decides it. Reading the observed kind and name
+ *  instead is the same credit defect in a narrower form — an observed name
+ *  equal to a catalog name would hand that catalog package a place it does
+ *  not hold.
  *
  *  Built once for a whole table rather than per row: the provenance join is
  *  a flat list of every installation on the machine, and filtering it per
@@ -70,10 +79,8 @@ export function installedPlaces(
     if (row.origin.source !== catalog.source || row.origin.repo !== repo) {
       continue;
     }
-    // The package the records establish, or the observation's own kind and
-    // name where they establish none — `ProvenanceRow::package_ref`.
-    const ref = row.package ?? { kind: row.kind, name: row.name };
-    const key = placesKey(ref.kind, ref.name);
+    if (!row.package) continue;
+    const key = placesKey(row.package.kind, row.package.name);
     const here = scopes.get(key) ?? new Map();
     here.set(scopeKey(row.scope), row.scope);
     scopes.set(key, here);


### PR DESCRIPTION
## Summary
- `installedPlaces` keys each installation on the package the records establish, `row.package`, so a marketplace's hook is counted in the places holding it. A hook's observed name is its event, matcher and command stem, never the name a catalog offers it under, so joining on the observed name found a marketplace's hook nowhere and credited a catalog name to any unrelated package registering under it.
- A row the records establish no package for names no place at all. The UI makes no identity decision of its own: it does not fall back to the observed kind and name, for the same reason `ui/src/lib/package-identity.ts::packageIndex` answers null on such a row. Falling back would be the same credit defect in a narrower form, since an observed name equal to a catalog name would hand that catalog package a place it does not hold.
- The fix is the one join site. `placesKey` stays the single keying convention, and the origin/source/repo filter, scope spanning, `personalFirst` order and the null-repo and non-subscription early return are unchanged.
- Three test rows, one per direction: a hook counted under the name its catalog offers it as, a catalog name taking no place from a different package that registered under it, and a row with no established package naming no place even when a catalog offers its observed name.

## Context
The issue's verified cause held against this head, not only against 8823ae24c where it was recorded:

- `ui/src/lib/installed-places.ts` keyed the index on the observed registration name and ignored `row.package`.
- The consumer sides were already correct. `ui/src/components/marketplaces/packages-table.tsx:467` and `bundlePlaces` both look up by declared catalog kind and name, so no call site needed a change and the producer owned the defect.
- `ProvenanceRow` already carried `package: PackageRef | null`, so the fix needed no new data, no shim and no second helper.
- The walk's originally stated cause (origin) stays refuted: the hook carries `Origin::Marketplace` with the same source and repo.

An earlier revision of this branch did mirror `ProvenanceRow::package_ref`'s observed-name fallback in the UI. That was removed in 403f61f5c: `ui/AGENTS.md` states domain logic lives in Rust and nothing under `ui/` decides, and `crates/core/src/library.rs` reaches `Origin::Marketplace` through `ownership::find` with `Subject::Observed`, which carries no claim, so a marketplace row can arrive with no established package. Crediting such a row by its observed name is the defect this issue exists to close. These rows are deliberately uncountable.

## Completed Issues
- Closes KEN-1345 - An installed hook is never counted in its marketplace's Installed in

## Size
No allowance was stated on the issue. Measured before the fix round: production 14, tests 44, render mirror 0.

## Test Plan
- `npx vitest run src/lib/installed-places.test.ts` in `ui/`: 8 passed.
- Must-fail control per changed direction: keying on the observed kind and name alone turns the two hook rows red; restoring the observed-name fallback turns the no-package row red.
- `env -u TMPDIR tools/guard --full` on the final head 403f61f5c: exit 0, no `guard:` failure lines.
- Local review round, reviewer-correctness: pass, no blockers and no suggestions.

https://claude.ai/code/session_01MYQ7bCXwRYrziGWo9H8Pmu
