### PR TITLE
fix(KEN-1346): Updates calls an empty machine up to date before any check

### DIFF
--- a/changelog.d/fixed/1346.md
+++ b/changelog.d/fixed/1346.md
@@ -1,1 +1,1 @@
-- The Updates page says when nothing is installed, and when no check has reached a source, instead of calling both machines up to date.
+- The Updates page tells an empty machine, one no check has reached a source for, and one a check found current apart, instead of calling all three up to date.

--- a/changelog.d/fixed/1346.md
+++ b/changelog.d/fixed/1346.md
@@ -1,1 +1,1 @@
-- The Updates page tells an empty machine, one no check has reached a source for, and one a check found current apart, instead of calling all three up to date.
+- The Updates page says when nothing is installed and when no check has run, instead of calling both up to date, and keeps the check where a scan failed or could not read every project.

--- a/changelog.d/fixed/1346.md
+++ b/changelog.d/fixed/1346.md
@@ -1,0 +1,1 @@
+- The Updates page says when nothing is installed, and when no check has reached a source, instead of calling both machines up to date.

--- a/changelog.d/fixed/1346.md
+++ b/changelog.d/fixed/1346.md
@@ -1,1 +1,1 @@
-- The Updates page says when nothing is installed and when no check has run, instead of calling both up to date, and keeps the check where a scan failed or could not read every project.
+- The Updates page says when nothing is installed and when no check has run, instead of calling both up to date, and keeps the check wherever a scan could not read the whole machine.

--- a/ui/src/components/library/table-empty.tsx
+++ b/ui/src/components/library/table-empty.tsx
@@ -1,5 +1,6 @@
 import { Button } from "@/components/ui/button";
 import { TableCell, TableRow } from "@/components/ui/table";
+import { BROWSE_MARKETPLACES_LABEL } from "@/lib/copy";
 import {
   ADD_PACKAGES_HELP,
   addPackagesTo,
@@ -65,7 +66,7 @@ export function TableEmptyRow({
               </p>
             </div>
             <Button variant="outline" size="sm" onClick={onBrowse}>
-              Browse Marketplaces
+              {BROWSE_MARKETPLACES_LABEL}
             </Button>
           </div>
         )}

--- a/ui/src/components/updates-before-list.tsx
+++ b/ui/src/components/updates-before-list.tsx
@@ -112,8 +112,8 @@ function emptyAnswer(
   }: { retry: ReactNode; lastChecked: string; onBrowse: () => void },
 ): ReactNode {
   switch (standing.kind) {
-    // Nothing is recorded here, so no check can bring news: the way on is
-    // a package, not the retry.
+    // The machine scan counts nothing installed, so no check can bring
+    // news: the way on is a package, not the retry.
     case "nothing-installed":
       return (
         <EmptyState

--- a/ui/src/components/updates-before-list.tsx
+++ b/ui/src/components/updates-before-list.tsx
@@ -18,11 +18,10 @@ import type { ReadState } from "@/lib/read-state";
 import type { EmptyStanding } from "@/lib/updates-read-state";
 
 /** What the Updates page shows while there is no list to show, or null
- *  once there is one. Five different answers that must never blur: a
- *  first read still on its way, a read that failed with nothing kept from
- *  a better one, a machine with nothing installed, packages no check has
- *  reached a source for, and packages a check found current — only the
- *  last may say "Everything is up to date". */
+ *  once there is one. Five answers that must never blur: a first read still
+ *  on its way, one that failed with nothing kept, a machine with nothing
+ *  installed, one no check has reached a source for, and one a check found
+ *  current — only the last may say "Everything is up to date". */
 export function updatesBeforeList({
   read,
   standing,
@@ -34,8 +33,7 @@ export function updatesBeforeList({
   onBrowse,
 }: {
   read: ReadState;
-  /** What an empty list means on this machine, once the read itself has
-   *  nothing left to say. */
+  /** What an empty list means, once the read has nothing left to say. */
   standing: EmptyStanding;
   empty: boolean;
   checking: boolean;
@@ -46,8 +44,7 @@ export function updatesBeforeList({
   /** How old the answer behind this page is, already worded. */
   lastChecked: string;
   onCheck: () => void;
-  /** Where a machine with nothing installed is sent, since a check has
-   *  nothing to reach for it. */
+  /** Where a machine with nothing installed is sent. */
   onBrowse: () => void;
 }): ReactNode | null {
   const retry = (
@@ -95,9 +92,8 @@ export function updatesBeforeList({
 }
 
 /** The one empty answer this machine is owed, drawn from the standing so
- *  the three cannot be reached by two different paths. The age of the
- *  check travels with the good news: this is the page where a stale answer
- *  looks exactly like a current one. */
+ *  the three cannot be reached two ways. The age of the check travels with
+ *  the good news: here a stale answer looks exactly like a current one. */
 function emptyAnswer(
   standing: EmptyStanding,
   {
@@ -107,8 +103,8 @@ function emptyAnswer(
   }: { retry: ReactNode; lastChecked: string; onBrowse: () => void },
 ): ReactNode {
   switch (standing.kind) {
-    // The machine scan counts nothing installed, so no check can bring
-    // news: the way on is a package, not the retry.
+    // No check can bring news to an empty machine: the way on is a
+    // package, not the retry.
     case "nothing-installed":
       return (
         <EmptyState
@@ -123,8 +119,8 @@ function emptyAnswer(
           {UPDATES_NOTHING_INSTALLED_BODY}
         </EmptyState>
       );
-    // Packages are recorded and none carries news, but nothing has reached
-    // a source to say so. The check is the offer; up-to-dateness is not.
+    // Nothing has reached a source, so the check is the offer and
+    // up-to-dateness is not.
     case "unchecked":
       return (
         <EmptyState icon={RefreshCw} title={NEVER_CHECKED} action={retry}>

--- a/ui/src/components/updates-before-list.tsx
+++ b/ui/src/components/updates-before-list.tsx
@@ -1,31 +1,42 @@
-import { CheckCircle2, TriangleAlert } from "lucide-react";
+import { CheckCircle2, Package, RefreshCw, TriangleAlert } from "lucide-react";
 import type { ReactNode } from "react";
 import { EmptyState } from "@/components/empty-state";
 import { DotSpinner } from "@/components/loading";
 import { Button } from "@/components/ui/button";
 import {
+  BROWSE_MARKETPLACES_LABEL,
   CHECK_FOR_UPDATES_LABEL,
   UPDATES_ATTENTION_TITLE,
   UPDATES_EMPTY,
   UPDATES_EMPTY_BODY,
+  UPDATES_NOTHING_INSTALLED,
+  UPDATES_NOTHING_INSTALLED_BODY,
+  UPDATES_UNCHECKED_BODY,
 } from "@/lib/copy";
-import { UPDATES_CHECKING } from "@/lib/copy-updates";
+import { NEVER_CHECKED, UPDATES_CHECKING } from "@/lib/copy-updates";
 import type { ReadState } from "@/lib/read-state";
+import type { EmptyStanding } from "@/lib/updates-read-state";
 
 /** What the Updates page shows while there is no list to show, or null
- *  once there is one. Three different answers that must never blur: a
+ *  once there is one. Five different answers that must never blur: a
  *  first read still on its way, a read that failed with nothing kept from
- *  a better one, and a completed error-free read that found nothing —
- *  only the last may say "Everything is up to date". */
+ *  a better one, a machine with nothing installed, packages no check has
+ *  reached a source for, and packages a check found current — only the
+ *  last may say "Everything is up to date". */
 export function updatesBeforeList({
   read,
+  standing,
   empty,
   checking,
   busy,
   lastChecked,
   onCheck,
+  onBrowse,
 }: {
   read: ReadState;
+  /** What an empty list means on this machine, once the read itself has
+   *  nothing left to say. */
+  standing: EmptyStanding;
   empty: boolean;
   checking: boolean;
   /** True while a write is out. The store refuses a check on it, so this
@@ -35,6 +46,9 @@ export function updatesBeforeList({
   /** How old the answer behind this page is, already worded. */
   lastChecked: string;
   onCheck: () => void;
+  /** Where a machine with nothing installed is sent, since a check has
+   *  nothing to reach for it. */
+  onBrowse: () => void;
 }): ReactNode | null {
   const retry = (
     <Button variant="outline" disabled={checking || busy} onClick={onCheck}>
@@ -70,19 +84,67 @@ export function updatesBeforeList({
       </div>
     );
   }
-  // With nothing to update there is nothing to introduce: a title and a
-  // sentence explaining a list that isn't there is furniture around good
-  // news. The sidebar already says which page this is. The age of the
-  // check is the exception — this is the page where a stale answer looks
-  // exactly like a current one, so the good news says how old it is.
   if (empty) {
     return (
       <div className="flex min-h-full items-center justify-center">
-        <EmptyState icon={CheckCircle2} title={UPDATES_EMPTY} action={retry}>
-          {`${UPDATES_EMPTY_BODY} ${lastChecked}.`}
-        </EmptyState>
+        {emptyAnswer(standing, { retry, lastChecked, onBrowse })}
       </div>
     );
   }
   return null;
+}
+
+/** The one empty answer this machine is owed, drawn from the standing so
+ *  the three cannot be reached by two different paths.
+ *
+ *  With nothing to update there is nothing to introduce: a title and a
+ *  sentence explaining a list that isn't there is furniture around good
+ *  news. The sidebar already says which page this is. The age of the check
+ *  is the exception — this is the page where a stale answer looks exactly
+ *  like a current one, so the good news says how old it is, and where no
+ *  check has run there is no good news to give. */
+function emptyAnswer(
+  standing: EmptyStanding,
+  {
+    retry,
+    lastChecked,
+    onBrowse,
+  }: { retry: ReactNode; lastChecked: string; onBrowse: () => void },
+): ReactNode {
+  switch (standing.kind) {
+    // Nothing is recorded here, so no check can bring news: the way on is
+    // a package, not the retry.
+    case "nothing-installed":
+      return (
+        <EmptyState
+          icon={Package}
+          title={UPDATES_NOTHING_INSTALLED}
+          action={
+            <Button variant="outline" onClick={onBrowse}>
+              {BROWSE_MARKETPLACES_LABEL}
+            </Button>
+          }
+        >
+          {UPDATES_NOTHING_INSTALLED_BODY}
+        </EmptyState>
+      );
+    // Packages are recorded and none carries news, but nothing has reached
+    // a source to say so. The check is the offer; up-to-dateness is not.
+    case "unchecked":
+      return (
+        <EmptyState icon={RefreshCw} title={NEVER_CHECKED} action={retry}>
+          {UPDATES_UNCHECKED_BODY}
+        </EmptyState>
+      );
+    case "current":
+      return (
+        <EmptyState icon={CheckCircle2} title={UPDATES_EMPTY} action={retry}>
+          {`${UPDATES_EMPTY_BODY} ${lastChecked}.`}
+        </EmptyState>
+      );
+  }
+
+  // A fourth standing has to be answered above before this compiles.
+  const unanswered: never = standing;
+  return unanswered;
 }

--- a/ui/src/components/updates-before-list.tsx
+++ b/ui/src/components/updates-before-list.tsx
@@ -95,14 +95,9 @@ export function updatesBeforeList({
 }
 
 /** The one empty answer this machine is owed, drawn from the standing so
- *  the three cannot be reached by two different paths.
- *
- *  With nothing to update there is nothing to introduce: a title and a
- *  sentence explaining a list that isn't there is furniture around good
- *  news. The sidebar already says which page this is. The age of the check
- *  is the exception — this is the page where a stale answer looks exactly
- *  like a current one, so the good news says how old it is, and where no
- *  check has run there is no good news to give. */
+ *  the three cannot be reached by two different paths. The age of the
+ *  check travels with the good news: this is the page where a stale answer
+ *  looks exactly like a current one. */
 function emptyAnswer(
   standing: EmptyStanding,
   {

--- a/ui/src/components/updates-before-list.tsx
+++ b/ui/src/components/updates-before-list.tsx
@@ -17,11 +17,11 @@ import { NEVER_CHECKED, UPDATES_CHECKING } from "@/lib/copy-updates";
 import type { ReadState } from "@/lib/read-state";
 import type { EmptyStanding } from "@/lib/updates-read-state";
 
-/** What the Updates page shows while there is no list to show, or null
- *  once there is one. Five answers that must never blur: a first read still
- *  on its way, one that failed with nothing kept, a machine with nothing
- *  installed, one no check has reached a source for, and one a check found
- *  current — only the last may say "Everything is up to date". */
+/** What the Updates page shows while there is no list to show, or null once
+ *  there is one. Five answers that must never blur: a first read on its way,
+ *  one that failed with nothing kept, a machine with nothing installed, one
+ *  no check has reached, and one a check found current — only the last may
+ *  say "Everything is up to date". */
 export function updatesBeforeList({
   read,
   standing,
@@ -91,9 +91,9 @@ export function updatesBeforeList({
   return null;
 }
 
-/** The one empty answer this machine is owed, drawn from the standing so
- *  the three cannot be reached two ways. The age of the check travels with
- *  the good news: here a stale answer looks exactly like a current one. */
+/** The one empty answer this machine is owed, drawn from the standing so the
+ *  three cannot be reached two ways. The age travels with the good news:
+ *  here a stale answer looks exactly like a current one. */
 function emptyAnswer(
   standing: EmptyStanding,
   {
@@ -103,8 +103,7 @@ function emptyAnswer(
   }: { retry: ReactNode; lastChecked: string; onBrowse: () => void },
 ): ReactNode {
   switch (standing.kind) {
-    // No check can bring news to an empty machine: the way on is a
-    // package, not the retry.
+    // No check can bring an empty machine news: the way on is a package.
     case "nothing-installed":
       return (
         <EmptyState
@@ -119,8 +118,7 @@ function emptyAnswer(
           {UPDATES_NOTHING_INSTALLED_BODY}
         </EmptyState>
       );
-    // Nothing has reached a source, so the check is the offer and
-    // up-to-dateness is not.
+    // Nothing reached a source, so the check is the offer and currency not.
     case "unchecked":
       return (
         <EmptyState icon={RefreshCw} title={NEVER_CHECKED} action={retry}>

--- a/ui/src/lib/copy.ts
+++ b/ui/src/lib/copy.ts
@@ -182,9 +182,9 @@ export const DIFF_TRUNCATED_NOTE =
 export const VERSION_ERROR_TITLE = "Couldn't switch versions";
 
 // Updates page. Three different empty pages, worded together so no one of
-// them can drift into claiming what the next one refuses: a machine with
-// nothing recorded, recorded packages no fetch has spoken for, and
-// recorded packages a fetch found current.
+// them can drift into claiming what the next one refuses: a machine the
+// scan finds nothing installed on, an installed machine no fetch has
+// spoken for, and one a fetch found current.
 export const UPDATES_EMPTY = "Everything is up to date";
 export const UPDATES_EMPTY_BODY =
   "Every package you installed is on its latest version.";

--- a/ui/src/lib/copy.ts
+++ b/ui/src/lib/copy.ts
@@ -181,8 +181,7 @@ export const DIFF_TRUNCATED_NOTE =
   "This comparison is long; only the first part is shown.";
 export const VERSION_ERROR_TITLE = "Couldn't switch versions";
 
-// Updates page. Three empty pages, worded together so none drifts into
-// claiming what the next refuses.
+// Updates page. Three empty pages, worded so none claims what another refuses.
 export const UPDATES_EMPTY = "Everything is up to date";
 export const UPDATES_EMPTY_BODY =
   "Every package you installed is on its latest version.";

--- a/ui/src/lib/copy.ts
+++ b/ui/src/lib/copy.ts
@@ -150,6 +150,10 @@ export const AUDIT_ATTENTION_TITLE = "Couldn't check installed content";
 export const AUDIT_ATTENTION_DETAIL =
   "Problems and pending changes may be missing here.";
 export const TRY_AGAIN_LABEL = "Try again";
+// The way on from every page that is empty because nothing is installed —
+// the Library's table and the Updates page — worded once so the two offers
+// read as the same door.
+export const BROWSE_MARKETPLACES_LABEL = "Browse Marketplaces";
 
 // Package page: files, versions, and the diff between them. The Files
 // tab's own words live in `copy-files.ts`, beside the tree and preview
@@ -177,10 +181,18 @@ export const DIFF_TRUNCATED_NOTE =
   "This comparison is long; only the first part is shown.";
 export const VERSION_ERROR_TITLE = "Couldn't switch versions";
 
-// Updates page.
+// Updates page. Three different empty pages, worded together so no one of
+// them can drift into claiming what the next one refuses: a machine with
+// nothing recorded, recorded packages no fetch has spoken for, and
+// recorded packages a fetch found current.
 export const UPDATES_EMPTY = "Everything is up to date";
 export const UPDATES_EMPTY_BODY =
   "Every package you installed is on its latest version.";
+export const UPDATES_NOTHING_INSTALLED = "Nothing installed yet";
+export const UPDATES_NOTHING_INSTALLED_BODY =
+  "Install a skill, agent or hook and this page says when a newer version appears.";
+export const UPDATES_UNCHECKED_BODY =
+  "Check to see whether the packages you installed have newer versions.";
 export const UPDATES_UNCHECKED_TITLE = "Couldn't be checked";
 export const REMOVED_UPSTREAM_TAG = "No longer in its source";
 export const UPDATE_ALL_LABEL = "Update all…";

--- a/ui/src/lib/copy.ts
+++ b/ui/src/lib/copy.ts
@@ -182,9 +182,7 @@ export const DIFF_TRUNCATED_NOTE =
 export const VERSION_ERROR_TITLE = "Couldn't switch versions";
 
 // Updates page. Three different empty pages, worded together so no one of
-// them can drift into claiming what the next one refuses: a machine the
-// scan finds nothing installed on, an installed machine no fetch has
-// spoken for, and one a fetch found current.
+// them can drift into claiming what the next one refuses.
 export const UPDATES_EMPTY = "Everything is up to date";
 export const UPDATES_EMPTY_BODY =
   "Every package you installed is on its latest version.";

--- a/ui/src/lib/copy.ts
+++ b/ui/src/lib/copy.ts
@@ -181,8 +181,8 @@ export const DIFF_TRUNCATED_NOTE =
   "This comparison is long; only the first part is shown.";
 export const VERSION_ERROR_TITLE = "Couldn't switch versions";
 
-// Updates page. Three different empty pages, worded together so no one of
-// them can drift into claiming what the next one refuses.
+// Updates page. Three empty pages, worded together so none drifts into
+// claiming what the next refuses.
 export const UPDATES_EMPTY = "Everything is up to date";
 export const UPDATES_EMPTY_BODY =
   "Every package you installed is on its latest version.";

--- a/ui/src/lib/updates-read-state.test.ts
+++ b/ui/src/lib/updates-read-state.test.ts
@@ -3,13 +3,11 @@ import type { PackageOf } from "@/lib/package-identity";
 import { scannedInstalled } from "@/lib/updates-read-state";
 import { observedSkill, scanFound } from "@/test/observed";
 
-/** The join a landed scan's own read gives, which recognises nothing: these
- *  fixtures group as the scan saw them, which is all the count needs. */
+/** A join that recognises nothing, so fixtures group as the scan saw them. */
 const joined: PackageOf = () => null;
 
-// Only a settled, complete, successful scan may produce a count. Every
-// other reading is null and not zero, because the caller words a zero as
-// "Nothing installed yet" and takes the check away with it.
+// Every reading but a settled, complete, successful scan is null and not
+// zero, because the caller words a zero as "Nothing installed yet".
 describe("the installed count an empty Updates page may be read from", () => {
   it("counts only what a settled, complete, successful scan found", () => {
     const rows = [

--- a/ui/src/lib/updates-read-state.test.ts
+++ b/ui/src/lib/updates-read-state.test.ts
@@ -1,19 +1,7 @@
 import { describe, expect, it } from "vitest";
-import type { ObservedItem, ScanResult } from "@/bindings";
 import type { PackageOf } from "@/lib/package-identity";
 import { scannedInstalled } from "@/lib/updates-read-state";
-import { observedSkill } from "@/test/observed";
-
-const scanOf = (
-  items: ObservedItem[],
-  missingProjects: ScanResult["missingProjects"] = [],
-): ScanResult => ({
-  harnesses: [],
-  items,
-  missingProjects,
-  readProjects: [],
-  warnings: [],
-});
+import { observedSkill, scanFound } from "@/test/observed";
 
 /** The join a landed scan's own read gives, which recognises nothing: these
  *  fixtures group as the scan saw them, which is all the count needs. */
@@ -27,14 +15,14 @@ describe("the installed count an empty Updates page may be read from", () => {
     const rows = [
       {
         name: "counts an empty machine as empty",
-        scan: scanOf([]),
+        scan: scanFound([]),
         error: null,
         packageOf: joined,
         count: 0,
       },
       {
         name: "counts the packages a scan found",
-        scan: scanOf([observedSkill("deploy"), observedSkill("review")]),
+        scan: scanFound([observedSkill("deploy"), observedSkill("review")]),
         error: null,
         packageOf: joined,
         count: 2,
@@ -48,21 +36,24 @@ describe("the installed count an empty Updates page may be read from", () => {
       },
       {
         name: "takes no count from a result kept behind a failed scan",
-        scan: scanOf([]),
+        scan: scanFound([]),
         error: "config unreadable",
         packageOf: joined,
         count: null,
       },
       {
         name: "takes no count from a scan that could not read a project",
-        scan: scanOf([], [{ root: "/work/hyprtrade", why: { kind: "gone" } }]),
+        scan: scanFound(
+          [],
+          [{ root: "/work/hyprtrade", why: { kind: "gone" } }],
+        ),
         error: null,
         packageOf: joined,
         count: null,
       },
       {
         name: "takes no count from a join that answers about another scan",
-        scan: scanOf([]),
+        scan: scanFound([]),
         error: null,
         packageOf: null,
         count: null,

--- a/ui/src/lib/updates-read-state.test.ts
+++ b/ui/src/lib/updates-read-state.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from "vitest";
+import type { ScanWarning } from "@/bindings";
 import type { PackageOf } from "@/lib/package-identity";
 import { scannedInstalled } from "@/lib/updates-read-state";
 import { observedSkill, scanFound } from "@/test/observed";
@@ -6,29 +7,35 @@ import { observedSkill, scanFound } from "@/test/observed";
 /** A join that recognises nothing, so fixtures group as the scan saw them. */
 const joined: PackageOf = () => null;
 
-// Every reading but a settled, complete, successful scan is null and not
-// zero, because the caller words a zero as "Nothing installed yet".
+/** A surface the scan could not read, still asking the reader to act. */
+const unread: ScanWarning = {
+  harness: "claude",
+  kind: "skill",
+  path: "/h/.claude/skills",
+  problem: { kind: "unreadable", message: "denied" },
+  standing: "actionable",
+};
+
+// Every reading but a whole-machine scan is null, not zero: the caller
+// words a zero as "Nothing installed yet".
 describe("the installed count an empty Updates page may be read from", () => {
   it("counts only what a settled, complete, successful scan found", () => {
     const rows = [
       {
         name: "counts an empty machine as empty",
         scan: scanFound([]),
-        error: null,
         packageOf: joined,
         count: 0,
       },
       {
         name: "counts the packages a scan found",
         scan: scanFound([observedSkill("deploy"), observedSkill("review")]),
-        error: null,
         packageOf: joined,
         count: 2,
       },
       {
         name: "takes no count before the scan has landed",
         scan: null,
-        error: null,
         packageOf: joined,
         count: null,
       },
@@ -41,26 +48,27 @@ describe("the installed count an empty Updates page may be read from", () => {
       },
       {
         name: "takes no count from a scan that could not read a project",
-        scan: scanFound(
-          [],
-          [{ root: "/work/hyprtrade", why: { kind: "gone" } }],
-        ),
-        error: null,
+        scan: scanFound([], [{ root: "/p", why: { kind: "gone" } }]),
+        packageOf: joined,
+        count: null,
+      },
+      {
+        name: "takes no count from a scan warning about a surface it could not read",
+        scan: scanFound([], [], [unread]),
         packageOf: joined,
         count: null,
       },
       {
         name: "takes no count from a join that answers about another scan",
         scan: scanFound([]),
-        error: null,
         packageOf: null,
         count: null,
       },
     ];
-    expect(rows).toHaveLength(6);
+    expect(rows).toHaveLength(7);
     for (const row of rows) {
       expect(
-        scannedInstalled(row.scan, row.error, row.packageOf),
+        scannedInstalled(row.scan, row.error ?? null, row.packageOf),
         row.name,
       ).toBe(row.count);
     }

--- a/ui/src/lib/updates-read-state.test.ts
+++ b/ui/src/lib/updates-read-state.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, it } from "vitest";
+import type { ObservedItem, ScanResult } from "@/bindings";
+import type { PackageOf } from "@/lib/package-identity";
+import { scannedInstalled } from "@/lib/updates-read-state";
+import { observedSkill } from "@/test/observed";
+
+const scanOf = (
+  items: ObservedItem[],
+  missingProjects: ScanResult["missingProjects"] = [],
+): ScanResult => ({
+  harnesses: [],
+  items,
+  missingProjects,
+  readProjects: [],
+  warnings: [],
+});
+
+/** The join a landed scan's own read gives, which recognises nothing: these
+ *  fixtures group as the scan saw them, which is all the count needs. */
+const joined: PackageOf = () => null;
+
+// Only a settled, complete, successful scan may produce a count. Every
+// other reading is null and not zero, because the caller words a zero as
+// "Nothing installed yet" and takes the check away with it.
+describe("the installed count an empty Updates page may be read from", () => {
+  it("counts only what a settled, complete, successful scan found", () => {
+    const rows = [
+      {
+        name: "counts an empty machine as empty",
+        scan: scanOf([]),
+        error: null,
+        packageOf: joined,
+        count: 0,
+      },
+      {
+        name: "counts the packages a scan found",
+        scan: scanOf([observedSkill("deploy"), observedSkill("review")]),
+        error: null,
+        packageOf: joined,
+        count: 2,
+      },
+      {
+        name: "takes no count before the scan has landed",
+        scan: null,
+        error: null,
+        packageOf: joined,
+        count: null,
+      },
+      {
+        name: "takes no count from a result kept behind a failed scan",
+        scan: scanOf([]),
+        error: "config unreadable",
+        packageOf: joined,
+        count: null,
+      },
+      {
+        name: "takes no count from a scan that could not read a project",
+        scan: scanOf([], [{ root: "/work/hyprtrade", why: { kind: "gone" } }]),
+        error: null,
+        packageOf: joined,
+        count: null,
+      },
+      {
+        name: "takes no count from a join that answers about another scan",
+        scan: scanOf([]),
+        error: null,
+        packageOf: null,
+        count: null,
+      },
+    ];
+    expect(rows).toHaveLength(6);
+    for (const row of rows) {
+      expect(
+        scannedInstalled(row.scan, row.error, row.packageOf),
+        row.name,
+      ).toBe(row.count);
+    }
+  });
+});

--- a/ui/src/lib/updates-read-state.ts
+++ b/ui/src/lib/updates-read-state.ts
@@ -1,4 +1,5 @@
 import type { ItemKind, ScanResult, Scope, UpdateRow } from "@/bindings";
+import { isActionable } from "@/lib/copy-scan";
 import {
   NO_UPDATE_STANDING_NOTE,
   UPDATE_NEEDS_CHECK_HERE,
@@ -36,21 +37,19 @@ interface PageState {
 export const readUnsettled = (state: PageState): boolean =>
   state.read.status !== "landed" || state.checking || state.reading;
 
-/** What an Updates page with nothing to list is saying about this machine:
- *  nothing is installed, nothing has been checked, or a check found
- *  everything current. Asked only where the page has no list to draw. */
+/** What an Updates page with nothing to list is saying: nothing installed,
+ *  nothing checked, or a check that found everything current. */
 export type EmptyStanding =
   | { kind: "nothing-installed" }
   | { kind: "unchecked" }
   | { kind: "current" };
 
 /** How many packages the machine holds, in the package unit the Library
- *  counts in, or null where nothing can say. Only a settled, complete,
- *  successful scan produces a count, because the caller words a zero as
- *  "Nothing installed yet" and takes the check away with it: a failed
- *  re-read leaves the last result standing (`stores/scan.ts`), a scan
- *  carrying `missingProjects` read part of the machine, and a join
- *  answering about another scan cannot group what is on screen. */
+ *  counts in, or null where nothing can say. Only a scan reporting it read
+ *  the WHOLE machine produces a count, because the caller words a zero as
+ *  "Nothing installed yet" and takes the check away with it. A failed
+ *  re-read leaves the last result standing (`stores/scan.ts`); every other
+ *  clause below is the scan itself admitting it saw less. */
 export const scannedInstalled = (
   scan: ScanResult | null,
   /** The standing error, which outlives the result it failed to replace. */
@@ -59,16 +58,15 @@ export const scannedInstalled = (
 ): number | null => {
   if (scan === null || packageOf === null || scanError !== null) return null;
   if (scan.missingProjects.length > 0) return null;
+  if (scan.warnings.some(isActionable)) return null;
   return installedCount(groupItems(scan.items, packageOf));
 };
 
 /** Only a count that says the machine is empty makes it empty, and never
  *  the update rows: core's `updates()` walks the planned REMOTE
- *  declarations alone, so a machine of adopted, local, in-place or
- *  unmanaged content has no rows while the Library counts its packages. A
- *  count nobody can take falls to the `unchecked`/`current` pair, which
- *  keeps the check on screen rather than offering a marketplace to a
- *  machine that may be full. */
+ *  declarations alone, so adopted, local, in-place and unmanaged content
+ *  has no rows while the Library counts it. A count nobody can take falls
+ *  to the `unchecked`/`current` pair, which keeps the check on screen. */
 export const emptyStanding = (
   installed: number | null,
   /** Unix seconds of the last successful fetch, as the overview reports it. */

--- a/ui/src/lib/updates-read-state.ts
+++ b/ui/src/lib/updates-read-state.ts
@@ -34,6 +34,34 @@ interface PageState {
 export const readUnsettled = (state: PageState): boolean =>
   state.read.status !== "landed" || state.checking || state.reading;
 
+/** What an Updates page with nothing to list is actually saying about this
+ *  machine. Three answers one judge keeps apart, because two of them are
+ *  routinely mistaken for the third:
+ *
+ *  - `nothing-installed`: core records one row per declared package, so no
+ *    rows at all is a machine with nothing to update. No check can make it
+ *    current, and offering one is a dead end.
+ *  - `unchecked`: packages are recorded and none of them is noteworthy, but
+ *    no fetch has ever reached a source. Nothing here has standing to call
+ *    them current.
+ *  - `current`: a fetch reached a source and left nothing noteworthy.
+ *
+ *  Asked only where the page has no list to draw; the rows themselves are
+ *  the answer wherever there is one. */
+export type EmptyStanding =
+  | { kind: "nothing-installed" }
+  | { kind: "unchecked" }
+  | { kind: "current" };
+
+export const emptyStanding = (
+  rows: UpdateRow[],
+  /** Unix seconds of the last successful fetch, as the overview reports it. */
+  lastFetched: number | null,
+): EmptyStanding => {
+  if (rows.length === 0) return { kind: "nothing-installed" };
+  return lastFetched === null ? { kind: "unchecked" } : { kind: "current" };
+};
+
 /** Whether the update rows can be read as last-known facts: a read that
  *  landed, or a failed re-check that kept the rows it had. One rule for
  *  every reader of the per-place facts — the Library, the package header

--- a/ui/src/lib/updates-read-state.ts
+++ b/ui/src/lib/updates-read-state.ts
@@ -36,45 +36,21 @@ interface PageState {
 export const readUnsettled = (state: PageState): boolean =>
   state.read.status !== "landed" || state.checking || state.reading;
 
-/** What an Updates page with nothing to list is actually saying about this
- *  machine. Three answers one judge keeps apart, because two of them are
- *  routinely mistaken for the third:
- *
- *  - `nothing-installed`: the machine scan counts nothing installed, so no
- *    check could speak for anything. Read from that count and never from
- *    the update rows: core's `updates()` walks the planned REMOTE
- *    declarations alone, so a machine holding adopted, local, in-place or
- *    unmanaged content has no update rows at all while the Library's table
- *    and Home's Installed tile count its packages. Deciding it from the
- *    rows would answer that machine "Nothing installed yet" and take away
- *    its check.
- *  - `unchecked`: something is installed, nothing noteworthy is on the
- *    page, and no fetch has ever reached a source. Nothing here has
- *    standing to call anything current.
- *  - `current`: a fetch reached a source and left nothing noteworthy.
- *
- *  Asked only where the page has no list to draw; the rows themselves are
- *  the answer wherever there is one. */
+/** What an Updates page with nothing to list is saying about this machine:
+ *  nothing is installed, nothing has been checked, or a check found
+ *  everything current. Asked only where the page has no list to draw. */
 export type EmptyStanding =
   | { kind: "nothing-installed" }
   | { kind: "unchecked" }
   | { kind: "current" };
 
-/** How many packages the machine holds, or null where nothing can say —
- *  the count [`emptyStanding`] may call a machine empty on. Only a
- *  settled, complete, successful scan produces one, because the caller
- *  words a zero as "Nothing installed yet" and takes the check away with
- *  it.
- *
- *  A failed re-read leaves the last result and its generation standing
- *  (`stores/scan.ts`), so a kept zero would report a machine nothing has
- *  looked at since. A landed scan carrying `missingProjects` read part of
- *  the machine, and a project it could not open is where the content may
- *  be. A join answering about another scan cannot group what is on screen,
- *  which is the gate `usePackageIndex` puts on every other counter.
- *
- *  Counted in the package unit through [`installedCount`], so this and the
- *  Library's table can never disagree about what one package is. */
+/** How many packages the machine holds, in the package unit the Library
+ *  counts in, or null where nothing can say. Only a settled, complete,
+ *  successful scan produces a count, because the caller words a zero as
+ *  "Nothing installed yet" and takes the check away with it: a failed
+ *  re-read leaves the last result standing (`stores/scan.ts`), a scan
+ *  carrying `missingProjects` read part of the machine, and a join
+ *  answering about another scan cannot group what is on screen. */
 export const scannedInstalled = (
   scan: ScanResult | null,
   /** The scan store's standing error, which outlives the result it failed
@@ -87,13 +63,14 @@ export const scannedInstalled = (
   return installedCount(groupItems(scan.items, packageOf));
 };
 
-/** Only a count that says the machine is empty makes it empty. A count
- *  nobody can take yet falls to the `unchecked`/`current` pair, which keeps
- *  the check on screen rather than offering a marketplace to a machine that
- *  may be full. */
+/** Only a count that says the machine is empty makes it empty, and never
+ *  the update rows: core's `updates()` walks the planned REMOTE
+ *  declarations alone, so a machine of adopted, local, in-place or
+ *  unmanaged content has no rows while the Library counts its packages. A
+ *  count nobody can take falls to the `unchecked`/`current` pair, which
+ *  keeps the check on screen rather than offering a marketplace to a
+ *  machine that may be full. */
 export const emptyStanding = (
-  /** Packages the machine scan counts, or null where the scan has not
-   *  landed or its join has not answered for what is on screen. */
   installed: number | null,
   /** Unix seconds of the last successful fetch, as the overview reports it. */
   lastFetched: number | null,

--- a/ui/src/lib/updates-read-state.ts
+++ b/ui/src/lib/updates-read-state.ts
@@ -1,9 +1,11 @@
-import type { ItemKind, Scope, UpdateRow } from "@/bindings";
+import type { ItemKind, ScanResult, Scope, UpdateRow } from "@/bindings";
 import {
   NO_UPDATE_STANDING_NOTE,
   UPDATE_NEEDS_CHECK_HERE,
   UPDATES_CHECKING,
 } from "@/lib/copy-updates";
+import { groupItems, installedCount } from "@/lib/derive";
+import type { PackageOf } from "@/lib/package-identity";
 import type { ReadState } from "@/lib/read-state";
 import { sameScope } from "@/lib/scope";
 import { updateWithheld } from "@/lib/update-groups";
@@ -57,6 +59,33 @@ export type EmptyStanding =
   | { kind: "nothing-installed" }
   | { kind: "unchecked" }
   | { kind: "current" };
+
+/** How many packages the machine holds, or null where nothing can say —
+ *  the count [`emptyStanding`] may call a machine empty on. Only a
+ *  settled, complete, successful scan produces one, because the caller
+ *  words a zero as "Nothing installed yet" and takes the check away with
+ *  it.
+ *
+ *  A failed re-read leaves the last result and its generation standing
+ *  (`stores/scan.ts`), so a kept zero would report a machine nothing has
+ *  looked at since. A landed scan carrying `missingProjects` read part of
+ *  the machine, and a project it could not open is where the content may
+ *  be. A join answering about another scan cannot group what is on screen,
+ *  which is the gate `usePackageIndex` puts on every other counter.
+ *
+ *  Counted in the package unit through [`installedCount`], so this and the
+ *  Library's table can never disagree about what one package is. */
+export const scannedInstalled = (
+  scan: ScanResult | null,
+  /** The scan store's standing error, which outlives the result it failed
+   *  to replace. */
+  scanError: string | null,
+  packageOf: PackageOf | null,
+): number | null => {
+  if (scan === null || packageOf === null || scanError !== null) return null;
+  if (scan.missingProjects.length > 0) return null;
+  return installedCount(groupItems(scan.items, packageOf));
+};
 
 /** Only a count that says the machine is empty makes it empty. A count
  *  nobody can take yet falls to the `unchecked`/`current` pair, which keeps

--- a/ui/src/lib/updates-read-state.ts
+++ b/ui/src/lib/updates-read-state.ts
@@ -38,12 +38,17 @@ export const readUnsettled = (state: PageState): boolean =>
  *  machine. Three answers one judge keeps apart, because two of them are
  *  routinely mistaken for the third:
  *
- *  - `nothing-installed`: core records one row per declared package, so no
- *    rows at all is a machine with nothing to update. No check can make it
- *    current, and offering one is a dead end.
- *  - `unchecked`: packages are recorded and none of them is noteworthy, but
- *    no fetch has ever reached a source. Nothing here has standing to call
- *    them current.
+ *  - `nothing-installed`: the machine scan counts nothing installed, so no
+ *    check could speak for anything. Read from that count and never from
+ *    the update rows: core's `updates()` walks the planned REMOTE
+ *    declarations alone, so a machine holding adopted, local, in-place or
+ *    unmanaged content has no update rows at all while the Library's table
+ *    and Home's Installed tile count its packages. Deciding it from the
+ *    rows would answer that machine "Nothing installed yet" and take away
+ *    its check.
+ *  - `unchecked`: something is installed, nothing noteworthy is on the
+ *    page, and no fetch has ever reached a source. Nothing here has
+ *    standing to call anything current.
  *  - `current`: a fetch reached a source and left nothing noteworthy.
  *
  *  Asked only where the page has no list to draw; the rows themselves are
@@ -53,12 +58,18 @@ export type EmptyStanding =
   | { kind: "unchecked" }
   | { kind: "current" };
 
+/** Only a count that says the machine is empty makes it empty. A count
+ *  nobody can take yet falls to the `unchecked`/`current` pair, which keeps
+ *  the check on screen rather than offering a marketplace to a machine that
+ *  may be full. */
 export const emptyStanding = (
-  rows: UpdateRow[],
+  /** Packages the machine scan counts, or null where the scan has not
+   *  landed or its join has not answered for what is on screen. */
+  installed: number | null,
   /** Unix seconds of the last successful fetch, as the overview reports it. */
   lastFetched: number | null,
 ): EmptyStanding => {
-  if (rows.length === 0) return { kind: "nothing-installed" };
+  if (installed === 0) return { kind: "nothing-installed" };
   return lastFetched === null ? { kind: "unchecked" } : { kind: "current" };
 };
 

--- a/ui/src/lib/updates-read-state.ts
+++ b/ui/src/lib/updates-read-state.ts
@@ -53,8 +53,7 @@ export type EmptyStanding =
  *  answering about another scan cannot group what is on screen. */
 export const scannedInstalled = (
   scan: ScanResult | null,
-  /** The scan store's standing error, which outlives the result it failed
-   *  to replace. */
+  /** The standing error, which outlives the result it failed to replace. */
   scanError: string | null,
   packageOf: PackageOf | null,
 ): number | null => {

--- a/ui/src/pages/updates.dom.test.tsx
+++ b/ui/src/pages/updates.dom.test.tsx
@@ -1,8 +1,7 @@
 // @vitest-environment jsdom
-// Where an empty machine's Updates page leads. Browse Marketplaces is the
-// only action that state offers, the check being deliberately absent, so a
-// handler that goes nowhere leaves the page with no way on — and a static
-// render, which invokes no handler, cannot tell.
+// Where an empty machine's Updates page leads. Browse Marketplaces is its
+// only action, so a handler that goes nowhere leaves the page with no way
+// on, and a static render invokes no handler to tell.
 import userEvent from "@testing-library/user-event";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { commands } from "@/bindings";
@@ -17,10 +16,7 @@ import { scanFound } from "@/test/observed";
 import { UpdatesPage } from "./updates";
 
 vi.mock("@/bindings", () => ({
-  commands: {
-    auditAll: vi.fn(),
-    updatesOverview: vi.fn(),
-  },
+  commands: { auditAll: vi.fn(), updatesOverview: vi.fn() },
 }));
 vi.mock("sonner", () => ({ toast: { error: vi.fn(), success: vi.fn() } }));
 

--- a/ui/src/pages/updates.dom.test.tsx
+++ b/ui/src/pages/updates.dom.test.tsx
@@ -15,6 +15,7 @@ import { useProvenanceStore } from "@/stores/provenance";
 import { useScanStore } from "@/stores/scan";
 import { useUpdatesStore } from "@/stores/updates";
 import { mount, settle } from "@/test/dom";
+import { scanFound } from "@/test/observed";
 import { UpdatesPage } from "./updates";
 
 vi.mock("@/bindings", () => ({
@@ -40,13 +41,7 @@ beforeEach(() => {
   // and a join that answered about that scan: the one state in which the
   // page may say the machine is empty.
   useScanStore.setState({
-    result: {
-      harnesses: [],
-      items: [],
-      missingProjects: [],
-      readProjects: [],
-      warnings: [],
-    },
+    result: scanFound([]),
     error: null,
     scanning: false,
     generation: 1,

--- a/ui/src/pages/updates.dom.test.tsx
+++ b/ui/src/pages/updates.dom.test.tsx
@@ -10,7 +10,6 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import { commands } from "@/bindings";
 import { BROWSE_MARKETPLACES_LABEL } from "@/lib/copy";
 import { READ_LANDED } from "@/lib/read-state";
-import { useAuditStore } from "@/stores/audit";
 import { useNavStore } from "@/stores/nav";
 import { useProvenanceStore } from "@/stores/provenance";
 import { useScanStore } from "@/stores/scan";
@@ -21,8 +20,6 @@ import { UpdatesPage } from "./updates";
 vi.mock("@/bindings", () => ({
   commands: {
     auditAll: vi.fn(),
-    libraryProvenance: vi.fn(),
-    scanMachine: vi.fn(),
     updatesOverview: vi.fn(),
   },
 }));
@@ -63,11 +60,6 @@ beforeEach(() => {
     lastFetched: null,
     busy: false,
     checking: false,
-  });
-  useAuditStore.setState({
-    views: [],
-    auditedAt: Date.now(),
-    read: READ_LANDED,
   });
   useNavStore.setState({ page: "updates", history: [], future: [] });
 });

--- a/ui/src/pages/updates.dom.test.tsx
+++ b/ui/src/pages/updates.dom.test.tsx
@@ -1,10 +1,8 @@
 // @vitest-environment jsdom
-// Where the Updates page leads when it has nothing to list. The static
-// table beside this file pins what each empty state says; this pins the one
-// thing a static render cannot reach — whether the control an empty machine
-// is given actually goes anywhere. Browse Marketplaces is the only action
-// that state offers, the check being deliberately absent, so a handler that
-// leads nowhere leaves the page with no way on.
+// Where an empty machine's Updates page leads. Browse Marketplaces is the
+// only action that state offers, the check being deliberately absent, so a
+// handler that goes nowhere leaves the page with no way on — and a static
+// render, which invokes no handler, cannot tell.
 import userEvent from "@testing-library/user-event";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { commands } from "@/bindings";
@@ -31,32 +29,19 @@ beforeEach(() => {
     status: "ok",
     data: [],
   } as never);
-  // The page reloads the standing on mount; an empty machine answers with
-  // nothing in every field, which is the state under test.
+  // The page reloads the standing on mount, and that answer replaces the
+  // staged one, so it carries the same empty machine.
   vi.mocked(commands.updatesOverview).mockResolvedValue({
     status: "ok",
     data: { rows: [], warnings: [], unreadable: [], fetchedAt: null },
   } as never);
-  // A settled, complete, successful scan of a machine with nothing on it,
-  // and a join that answered about that scan: the one state in which the
-  // page may say the machine is empty.
-  useScanStore.setState({
-    result: scanFound([]),
-    error: null,
-    scanning: false,
-    generation: 1,
-  });
-  useProvenanceStore.setState({ rows: [], loaded: true, answeredFor: 1 });
-  useUpdatesStore.setState({
-    rows: [],
-    warnings: [],
-    unreadable: [],
-    read: READ_LANDED,
-    lastFetched: null,
-    busy: false,
-    checking: false,
-  });
-  useNavStore.setState({ page: "updates", history: [], future: [] });
+  // A settled scan of a machine with nothing on it, and a join answering
+  // about that scan: the one state in which the page may say so. Only what
+  // differs from each store's own defaults is set.
+  useScanStore.setState({ result: scanFound([]), generation: 1 });
+  useProvenanceStore.setState({ loaded: true, answeredFor: 1 });
+  useUpdatesStore.setState({ read: READ_LANDED });
+  useNavStore.setState({ page: "updates" });
 });
 
 describe("where an empty machine's Updates page leads", () => {

--- a/ui/src/pages/updates.dom.test.tsx
+++ b/ui/src/pages/updates.dom.test.tsx
@@ -1,0 +1,86 @@
+// @vitest-environment jsdom
+// Where the Updates page leads when it has nothing to list. The static
+// table beside this file pins what each empty state says; this pins the one
+// thing a static render cannot reach — whether the control an empty machine
+// is given actually goes anywhere. Browse Marketplaces is the only action
+// that state offers, the check being deliberately absent, so a handler that
+// leads nowhere leaves the page with no way on.
+import userEvent from "@testing-library/user-event";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { commands } from "@/bindings";
+import { BROWSE_MARKETPLACES_LABEL } from "@/lib/copy";
+import { READ_LANDED } from "@/lib/read-state";
+import { useAuditStore } from "@/stores/audit";
+import { useNavStore } from "@/stores/nav";
+import { useProvenanceStore } from "@/stores/provenance";
+import { useScanStore } from "@/stores/scan";
+import { useUpdatesStore } from "@/stores/updates";
+import { mount, settle } from "@/test/dom";
+import { UpdatesPage } from "./updates";
+
+vi.mock("@/bindings", () => ({
+  commands: {
+    auditAll: vi.fn(),
+    libraryProvenance: vi.fn(),
+    scanMachine: vi.fn(),
+    updatesOverview: vi.fn(),
+  },
+}));
+vi.mock("sonner", () => ({ toast: { error: vi.fn(), success: vi.fn() } }));
+
+beforeEach(() => {
+  vi.mocked(commands.auditAll).mockResolvedValue({
+    status: "ok",
+    data: [],
+  } as never);
+  // The page reloads the standing on mount; an empty machine answers with
+  // nothing in every field, which is the state under test.
+  vi.mocked(commands.updatesOverview).mockResolvedValue({
+    status: "ok",
+    data: { rows: [], warnings: [], unreadable: [], fetchedAt: null },
+  } as never);
+  // A settled, complete, successful scan of a machine with nothing on it,
+  // and a join that answered about that scan: the one state in which the
+  // page may say the machine is empty.
+  useScanStore.setState({
+    result: {
+      harnesses: [],
+      items: [],
+      missingProjects: [],
+      readProjects: [],
+      warnings: [],
+    },
+    error: null,
+    scanning: false,
+    generation: 1,
+  });
+  useProvenanceStore.setState({ rows: [], loaded: true, answeredFor: 1 });
+  useUpdatesStore.setState({
+    rows: [],
+    warnings: [],
+    unreadable: [],
+    read: READ_LANDED,
+    lastFetched: null,
+    busy: false,
+    checking: false,
+  });
+  useAuditStore.setState({
+    views: [],
+    auditedAt: Date.now(),
+    read: READ_LANDED,
+  });
+  useNavStore.setState({ page: "updates", history: [], future: [] });
+});
+
+describe("where an empty machine's Updates page leads", () => {
+  it("opens the marketplaces from Browse Marketplaces", async () => {
+    const host = mount(<UpdatesPage />);
+    await settle();
+    const button = [...host.querySelectorAll("button")].find(
+      (one) => one.textContent?.trim() === BROWSE_MARKETPLACES_LABEL,
+    );
+    if (!button) throw new Error("no Browse Marketplaces on screen");
+    await userEvent.click(button);
+    expect(useNavStore.getState().page).toBe("marketplaces");
+  });
+});

--- a/ui/src/pages/updates.test.tsx
+++ b/ui/src/pages/updates.test.tsx
@@ -1,7 +1,7 @@
 // @vitest-environment jsdom
 import { renderToStaticMarkup } from "react-dom/server";
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import type { ObservedItem, ScanResult, UpdateRow } from "@/bindings";
+import type { UpdateRow } from "@/bindings";
 import { updateRow } from "@/components/updates-test-rows";
 import {
   BROWSE_MARKETPLACES_LABEL,
@@ -18,7 +18,7 @@ import {
   UPDATES_CHECKING,
   UPDATES_UNCONFIRMED_TITLE,
 } from "@/lib/copy-updates";
-import { observedSkill } from "@/test/observed";
+import { observedSkill, scanFound } from "@/test/observed";
 import { UpdatesPage } from "./updates";
 
 // Static markup escapes apostrophes, so a pinned copy token must be
@@ -46,8 +46,8 @@ const stub = vi.hoisted(() => ({
   lastFetched: null as number | null,
   busy: false,
   unreadable: [] as unknown[],
-  /** What the machine scan found, and whether its join has answered for
-   *  it — the pair the page counts installed packages through. */
+  /** What the machine scan found — where the page reads whether anything
+   *  is installed. */
   scan: null as unknown,
 }));
 
@@ -82,24 +82,13 @@ vi.mock("@/stores/scan", async (importOriginal) => {
   return { ...mod, useScanStore: Object.assign(hook, mod.useScanStore) };
 });
 
-vi.mock("@/stores/provenance", async (importOriginal) => {
-  const mod = await importOriginal<typeof import("@/stores/provenance")>();
-  const hook = (selector?: (state: unknown) => unknown) => {
-    const state = {
-      ...mod.useProvenanceStore.getState(),
-      rows: [],
-      loaded: true,
-      // The scan store's untouched generation, so the join answers for the
-      // scan these rows stage. Which readings may be counted from is the
-      // moved judgement's, not this table's.
-      answeredFor: 0,
-    };
-    return selector ? selector(state) : state;
-  };
-  return {
-    ...mod,
-    useProvenanceStore: Object.assign(hook, mod.useProvenanceStore),
-  };
+// The join that recognises nothing, so these fixtures group as the scan saw
+// them. Which readings may be counted from at all is `scannedInstalled`'s,
+// pinned in `lib/updates-read-state.test.ts`, and the real gate is walked
+// end to end by `updates.dom.test.tsx`.
+vi.mock("@/lib/package-identity", async (importOriginal) => {
+  const mod = await importOriginal<typeof import("@/lib/package-identity")>();
+  return { ...mod, usePackageIndex: () => () => null };
 });
 
 beforeEach(() => {
@@ -111,15 +100,7 @@ beforeEach(() => {
   // A landed scan holding one package, with its join answering for that
   // scan: the ordinary machine, on which no empty state may claim the
   // machine is empty.
-  stub.scan = scanOf([observedSkill("deploy")]);
-});
-
-const scanOf = (items: ObservedItem[]): ScanResult => ({
-  harnesses: [],
-  items,
-  missingProjects: [],
-  readProjects: [],
-  warnings: [],
+  stub.scan = scanFound([observedSkill("deploy")]);
 });
 
 /** A recorded package with nothing noteworthy about it — the row core
@@ -271,7 +252,7 @@ describe("what an empty Updates page says about this machine", () => {
       {
         name: "says nothing is installed, and offers a marketplace rather than a check",
         updates: [],
-        scan: scanOf([]),
+        scan: scanFound([]),
         age: null,
         present: [UPDATES_NOTHING_INSTALLED, BROWSE_MARKETPLACES_LABEL],
         absent: [UPDATES_EMPTY, NEVER_CHECKED, CHECK_FOR_UPDATES_LABEL],
@@ -279,7 +260,7 @@ describe("what an empty Updates page says about this machine", () => {
       {
         name: "keeps the check on a machine the scan sees and the update read lists nothing for",
         updates: [],
-        scan: scanOf([observedSkill("adopted")]),
+        scan: scanFound([observedSkill("adopted")]),
         age: null,
         present: [NEVER_CHECKED, CHECK_FOR_UPDATES_LABEL],
         absent: [
@@ -291,7 +272,7 @@ describe("what an empty Updates page says about this machine", () => {
       {
         name: "says no check has run where something is installed and no fetch reached a source",
         updates: [currentRow("gh")],
-        scan: scanOf([observedSkill("deploy")]),
+        scan: scanFound([observedSkill("deploy")]),
         age: null,
         present: [NEVER_CHECKED, CHECK_FOR_UPDATES_LABEL],
         absent: [UPDATES_EMPTY, UPDATES_NOTHING_INSTALLED],
@@ -299,7 +280,7 @@ describe("what an empty Updates page says about this machine", () => {
       {
         name: "calls the machine up to date once a check has reached a source",
         updates: [currentRow("gh")],
-        scan: scanOf([observedSkill("deploy")]),
+        scan: scanFound([observedSkill("deploy")]),
         age: 5 * 86_400,
         present: [UPDATES_EMPTY, CHECK_FOR_UPDATES_LABEL],
         absent: [NEVER_CHECKED, UPDATES_NOTHING_INSTALLED],

--- a/ui/src/pages/updates.test.tsx
+++ b/ui/src/pages/updates.test.tsx
@@ -1,12 +1,7 @@
 // @vitest-environment jsdom
 import { renderToStaticMarkup } from "react-dom/server";
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import type {
-  MissingProject,
-  ObservedItem,
-  ScanResult,
-  UpdateRow,
-} from "@/bindings";
+import type { ObservedItem, ScanResult, UpdateRow } from "@/bindings";
 import { updateRow } from "@/components/updates-test-rows";
 import {
   BROWSE_MARKETPLACES_LABEL,
@@ -23,7 +18,7 @@ import {
   UPDATES_CHECKING,
   UPDATES_UNCONFIRMED_TITLE,
 } from "@/lib/copy-updates";
-import { observed } from "@/test/observed";
+import { observedSkill } from "@/test/observed";
 import { UpdatesPage } from "./updates";
 
 // Static markup escapes apostrophes, so a pinned copy token must be
@@ -54,9 +49,6 @@ const stub = vi.hoisted(() => ({
   /** What the machine scan found, and whether its join has answered for
    *  it — the pair the page counts installed packages through. */
   scan: null as unknown,
-  scanError: null as string | null,
-  generation: 1,
-  answeredFor: 1 as number | null,
 }));
 
 vi.mock("@/stores/updates", async (importOriginal) => {
@@ -84,8 +76,6 @@ vi.mock("@/stores/scan", async (importOriginal) => {
     const state = {
       ...mod.useScanStore.getState(),
       result: stub.scan,
-      error: stub.scanError,
-      generation: stub.generation,
     };
     return selector ? selector(state) : state;
   };
@@ -99,7 +89,10 @@ vi.mock("@/stores/provenance", async (importOriginal) => {
       ...mod.useProvenanceStore.getState(),
       rows: [],
       loaded: true,
-      answeredFor: stub.answeredFor,
+      // The scan store's untouched generation, so the join answers for the
+      // scan these rows stage. Which readings may be counted from is the
+      // moved judgement's, not this table's.
+      answeredFor: 0,
     };
     return selector ? selector(state) : state;
   };
@@ -118,46 +111,16 @@ beforeEach(() => {
   // A landed scan holding one package, with its join answering for that
   // scan: the ordinary machine, on which no empty state may claim the
   // machine is empty.
-  stub.scan = scanOf([installedItem("deploy")]);
-  stub.scanError = null;
-  stub.generation = 1;
-  stub.answeredFor = 1;
+  stub.scan = scanOf([observedSkill("deploy")]);
 });
 
-/** One installation the machine scan found. */
-const installedItem = (name: string): ObservedItem =>
-  observed({
-    kind: "skill",
-    name,
-    harness: "claude",
-    scope: { scope: "global" },
-    path: `/h/.claude/skills/${name}`,
-    fileState: { state: "dir" },
-    enabled: true,
-    origin: null,
-    summary: null,
-    action: null,
-    tags: [],
-    modifiedAt: null,
-    vendor: null,
-  });
-
-const scanOf = (
-  items: ObservedItem[],
-  missingProjects: MissingProject[] = [],
-): ScanResult => ({
+const scanOf = (items: ObservedItem[]): ScanResult => ({
   harnesses: [],
   items,
-  missingProjects,
+  missingProjects: [],
   readProjects: [],
   warnings: [],
 });
-
-/** A registered project the scan could not read as one. */
-const unreadProject: MissingProject = {
-  root: "/work/hyprtrade",
-  why: { kind: "not-a-folder" },
-};
 
 /** A recorded package with nothing noteworthy about it — the row core
  *  emits for something installed and current. */
@@ -299,7 +262,9 @@ describe("the Updates page across its read states", () => {
 // good news. The update read covers declared remote packages alone, so a
 // machine of adopted, local or unmanaged content produces no rows at all
 // while the Library counts its packages: the scan says whether the machine
-// is empty, and the update rows never do.
+// is empty, and the update rows never do. Which scans may be counted from
+// is `scannedInstalled`'s, pinned in `lib/updates-read-state.test.ts`; the
+// rows here are what each verdict puts on screen.
 describe("what an empty Updates page says about this machine", () => {
   it("reads the machine from the scan and up-to-dateness from the check", () => {
     const rows = [
@@ -307,7 +272,6 @@ describe("what an empty Updates page says about this machine", () => {
         name: "says nothing is installed, and offers a marketplace rather than a check",
         updates: [],
         scan: scanOf([]),
-        joined: true,
         age: null,
         present: [UPDATES_NOTHING_INSTALLED, BROWSE_MARKETPLACES_LABEL],
         absent: [UPDATES_EMPTY, NEVER_CHECKED, CHECK_FOR_UPDATES_LABEL],
@@ -315,8 +279,7 @@ describe("what an empty Updates page says about this machine", () => {
       {
         name: "keeps the check on a machine the scan sees and the update read lists nothing for",
         updates: [],
-        scan: scanOf([installedItem("adopted")]),
-        joined: true,
+        scan: scanOf([observedSkill("adopted")]),
         age: null,
         present: [NEVER_CHECKED, CHECK_FOR_UPDATES_LABEL],
         absent: [
@@ -328,8 +291,7 @@ describe("what an empty Updates page says about this machine", () => {
       {
         name: "says no check has run where something is installed and no fetch reached a source",
         updates: [currentRow("gh")],
-        scan: scanOf([installedItem("deploy")]),
-        joined: true,
+        scan: scanOf([observedSkill("deploy")]),
         age: null,
         present: [NEVER_CHECKED, CHECK_FOR_UPDATES_LABEL],
         absent: [UPDATES_EMPTY, UPDATES_NOTHING_INSTALLED],
@@ -337,56 +299,16 @@ describe("what an empty Updates page says about this machine", () => {
       {
         name: "calls the machine up to date once a check has reached a source",
         updates: [currentRow("gh")],
-        scan: scanOf([installedItem("deploy")]),
-        joined: true,
+        scan: scanOf([observedSkill("deploy")]),
         age: 5 * 86_400,
         present: [UPDATES_EMPTY, CHECK_FOR_UPDATES_LABEL],
         absent: [NEVER_CHECKED, UPDATES_NOTHING_INSTALLED],
       },
-      {
-        name: "calls no machine empty before the scan has landed",
-        updates: [],
-        scan: null,
-        joined: true,
-        age: null,
-        present: [NEVER_CHECKED, CHECK_FOR_UPDATES_LABEL],
-        absent: [UPDATES_NOTHING_INSTALLED, BROWSE_MARKETPLACES_LABEL],
-      },
-      {
-        name: "calls no machine empty on a join that answered about another scan",
-        updates: [],
-        scan: scanOf([]),
-        joined: false,
-        age: null,
-        present: [NEVER_CHECKED, CHECK_FOR_UPDATES_LABEL],
-        absent: [UPDATES_NOTHING_INSTALLED, BROWSE_MARKETPLACES_LABEL],
-      },
-      {
-        name: "calls no machine empty on a zero kept behind a failed scan",
-        updates: [],
-        scan: scanOf([]),
-        scanError: "config unreadable",
-        joined: true,
-        age: null,
-        present: [NEVER_CHECKED, CHECK_FOR_UPDATES_LABEL],
-        absent: [UPDATES_NOTHING_INSTALLED, BROWSE_MARKETPLACES_LABEL],
-      },
-      {
-        name: "calls no machine empty where the scan could not read a project",
-        updates: [],
-        scan: scanOf([], [unreadProject]),
-        joined: true,
-        age: null,
-        present: [NEVER_CHECKED, CHECK_FOR_UPDATES_LABEL],
-        absent: [UPDATES_NOTHING_INSTALLED, BROWSE_MARKETPLACES_LABEL],
-      },
     ];
-    expect(rows).toHaveLength(8);
+    expect(rows).toHaveLength(4);
     for (const row of rows) {
       stub.rows = row.updates;
       stub.scan = row.scan;
-      stub.scanError = row.scanError ?? null;
-      stub.answeredFor = row.joined ? stub.generation : stub.generation - 1;
       stub.lastFetched = row.age === null ? null : secondsAgo(row.age);
       const html = renderToStaticMarkup(<UpdatesPage />);
       expect(

--- a/ui/src/pages/updates.test.tsx
+++ b/ui/src/pages/updates.test.tsx
@@ -1,7 +1,12 @@
 // @vitest-environment jsdom
 import { renderToStaticMarkup } from "react-dom/server";
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import type { ObservedItem, ScanResult, UpdateRow } from "@/bindings";
+import type {
+  MissingProject,
+  ObservedItem,
+  ScanResult,
+  UpdateRow,
+} from "@/bindings";
 import { updateRow } from "@/components/updates-test-rows";
 import {
   BROWSE_MARKETPLACES_LABEL,
@@ -49,6 +54,7 @@ const stub = vi.hoisted(() => ({
   /** What the machine scan found, and whether its join has answered for
    *  it — the pair the page counts installed packages through. */
   scan: null as unknown,
+  scanError: null as string | null,
   generation: 1,
   answeredFor: 1 as number | null,
 }));
@@ -78,6 +84,7 @@ vi.mock("@/stores/scan", async (importOriginal) => {
     const state = {
       ...mod.useScanStore.getState(),
       result: stub.scan,
+      error: stub.scanError,
       generation: stub.generation,
     };
     return selector ? selector(state) : state;
@@ -112,6 +119,7 @@ beforeEach(() => {
   // scan: the ordinary machine, on which no empty state may claim the
   // machine is empty.
   stub.scan = scanOf([installedItem("deploy")]);
+  stub.scanError = null;
   stub.generation = 1;
   stub.answeredFor = 1;
 });
@@ -134,13 +142,22 @@ const installedItem = (name: string): ObservedItem =>
     vendor: null,
   });
 
-const scanOf = (items: ObservedItem[]): ScanResult => ({
+const scanOf = (
+  items: ObservedItem[],
+  missingProjects: MissingProject[] = [],
+): ScanResult => ({
   harnesses: [],
   items,
-  missingProjects: [],
+  missingProjects,
   readProjects: [],
   warnings: [],
 });
+
+/** A registered project the scan could not read as one. */
+const unreadProject: MissingProject = {
+  root: "/work/hyprtrade",
+  why: { kind: "not-a-folder" },
+};
 
 /** A recorded package with nothing noteworthy about it — the row core
  *  emits for something installed and current. */
@@ -344,11 +361,31 @@ describe("what an empty Updates page says about this machine", () => {
         present: [NEVER_CHECKED, CHECK_FOR_UPDATES_LABEL],
         absent: [UPDATES_NOTHING_INSTALLED, BROWSE_MARKETPLACES_LABEL],
       },
+      {
+        name: "calls no machine empty on a zero kept behind a failed scan",
+        updates: [],
+        scan: scanOf([]),
+        scanError: "config unreadable",
+        joined: true,
+        age: null,
+        present: [NEVER_CHECKED, CHECK_FOR_UPDATES_LABEL],
+        absent: [UPDATES_NOTHING_INSTALLED, BROWSE_MARKETPLACES_LABEL],
+      },
+      {
+        name: "calls no machine empty where the scan could not read a project",
+        updates: [],
+        scan: scanOf([], [unreadProject]),
+        joined: true,
+        age: null,
+        present: [NEVER_CHECKED, CHECK_FOR_UPDATES_LABEL],
+        absent: [UPDATES_NOTHING_INSTALLED, BROWSE_MARKETPLACES_LABEL],
+      },
     ];
-    expect(rows).toHaveLength(6);
+    expect(rows).toHaveLength(8);
     for (const row of rows) {
       stub.rows = row.updates;
       stub.scan = row.scan;
+      stub.scanError = row.scanError ?? null;
       stub.answeredFor = row.joined ? stub.generation : stub.generation - 1;
       stub.lastFetched = row.age === null ? null : secondsAgo(row.age);
       const html = renderToStaticMarkup(<UpdatesPage />);

--- a/ui/src/pages/updates.test.tsx
+++ b/ui/src/pages/updates.test.tsx
@@ -78,8 +78,7 @@ vi.mock("@/stores/scan", async (importOriginal) => {
   return { ...mod, useScanStore: Object.assign(hook, mod.useScanStore) };
 });
 
-// The join that recognises nothing, so these fixtures group as the scan saw
-// them. Which readings may be counted from at all is `scannedInstalled`'s,
+// A join that recognises nothing; which scans may be counted from at all is
 // pinned in `lib/updates-read-state.test.ts`.
 vi.mock("@/lib/package-identity", async (importOriginal) => {
   const mod = await importOriginal<typeof import("@/lib/package-identity")>();

--- a/ui/src/pages/updates.test.tsx
+++ b/ui/src/pages/updates.test.tsx
@@ -4,10 +4,12 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { UpdateRow } from "@/bindings";
 import { updateRow } from "@/components/updates-test-rows";
 import {
+  BROWSE_MARKETPLACES_LABEL,
   CHECK_FOR_UPDATES_LABEL,
   UPDATE_ALL_LABEL,
   UPDATES_ATTENTION_TITLE,
   UPDATES_EMPTY,
+  UPDATES_NOTHING_INSTALLED,
 } from "@/lib/copy";
 import {
   NEVER_CHECKED,
@@ -71,6 +73,11 @@ beforeEach(() => {
   stub.busy = false;
   stub.unreadable = [];
 });
+
+/** A recorded package with nothing noteworthy about it — the row core
+ *  emits for something installed and current. */
+const currentRow = (name: string) =>
+  updateRow(name, null, { updateAvailable: false, latest: null });
 
 /** Unix seconds `ago` seconds before now — the shape the overview reports,
  *  read against the same clock the page renders against. */
@@ -145,7 +152,7 @@ describe("the Updates page across its read states", () => {
       {
         name: "holds the empty state's retry while a write is out",
         read: landed,
-        updates: [],
+        updates: [currentRow("gh")],
         busy: true,
         present: [],
         absent: [],
@@ -203,6 +210,50 @@ describe("the Updates page across its read states", () => {
   });
 });
 
+// An empty list carries three different meanings, and only one of them is
+// good news: a machine with nothing recorded and recorded packages no fetch
+// has spoken for both look exactly like a machine a check found current.
+describe("what an empty Updates page says about this machine", () => {
+  it("claims up-to-dateness only where a check produced it", () => {
+    const rows = [
+      {
+        name: "says nothing is installed, and offers a marketplace rather than a check",
+        updates: [],
+        age: null,
+        present: [UPDATES_NOTHING_INSTALLED, BROWSE_MARKETPLACES_LABEL],
+        absent: [UPDATES_EMPTY, NEVER_CHECKED, CHECK_FOR_UPDATES_LABEL],
+      },
+      {
+        name: "says no check has run where packages are recorded and no fetch reached a source",
+        updates: [currentRow("gh")],
+        age: null,
+        present: [NEVER_CHECKED, CHECK_FOR_UPDATES_LABEL],
+        absent: [UPDATES_EMPTY, UPDATES_NOTHING_INSTALLED],
+      },
+      {
+        name: "calls the machine up to date once a check has reached a source",
+        updates: [currentRow("gh")],
+        age: 5 * 86_400,
+        present: [UPDATES_EMPTY, CHECK_FOR_UPDATES_LABEL],
+        absent: [NEVER_CHECKED, UPDATES_NOTHING_INSTALLED],
+      },
+    ];
+    expect(rows).toHaveLength(3);
+    for (const row of rows) {
+      stub.rows = row.updates;
+      stub.lastFetched = row.age === null ? null : secondsAgo(row.age);
+      const html = renderToStaticMarkup(<UpdatesPage />);
+      expect(
+        {
+          present: row.present.filter((value) => html.includes(value)),
+          absent: row.absent.filter((value) => html.includes(value)),
+        },
+        row.name,
+      ).toEqual({ present: row.present, absent: [] });
+    }
+  });
+});
+
 // Both the list and the empty state disclose when their answer was checked.
 describe("how fresh the page says its answer is", () => {
   it("dates only answers a check produced", () => {
@@ -216,7 +267,7 @@ describe("how fresh the page says its answer is", () => {
       },
       {
         name: "dates the up-to-date state, which is the one that hides its age",
-        updates: [],
+        updates: [currentRow("gh")],
         age: 5 * 86_400,
         present: [UPDATES_EMPTY, "Last checked 5d ago"],
         absent: [],
@@ -228,15 +279,8 @@ describe("how fresh the page says its answer is", () => {
         present: [NEVER_CHECKED],
         absent: ["Last checked"],
       },
-      {
-        name: "calls a completed, error-free empty read up to date and says it has never checked",
-        updates: [],
-        age: null,
-        present: [UPDATES_EMPTY, NEVER_CHECKED],
-        absent: ["Last checked"],
-      },
     ];
-    expect(rows).toHaveLength(4);
+    expect(rows).toHaveLength(3);
     for (const row of rows) {
       stub.rows = row.updates;
       stub.lastFetched = row.age === null ? null : secondsAgo(row.age);

--- a/ui/src/pages/updates.test.tsx
+++ b/ui/src/pages/updates.test.tsx
@@ -1,7 +1,7 @@
 // @vitest-environment jsdom
 import { renderToStaticMarkup } from "react-dom/server";
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import type { UpdateRow } from "@/bindings";
+import type { ObservedItem, ScanResult, UpdateRow } from "@/bindings";
 import { updateRow } from "@/components/updates-test-rows";
 import {
   BROWSE_MARKETPLACES_LABEL,
@@ -18,6 +18,7 @@ import {
   UPDATES_CHECKING,
   UPDATES_UNCONFIRMED_TITLE,
 } from "@/lib/copy-updates";
+import { observed } from "@/test/observed";
 import { UpdatesPage } from "./updates";
 
 // Static markup escapes apostrophes, so a pinned copy token must be
@@ -45,6 +46,11 @@ const stub = vi.hoisted(() => ({
   lastFetched: null as number | null,
   busy: false,
   unreadable: [] as unknown[],
+  /** What the machine scan found, and whether its join has answered for
+   *  it — the pair the page counts installed packages through. */
+  scan: null as unknown,
+  generation: 1,
+  answeredFor: 1 as number | null,
 }));
 
 vi.mock("@/stores/updates", async (importOriginal) => {
@@ -66,12 +72,74 @@ vi.mock("@/stores/updates", async (importOriginal) => {
   return { ...mod, useUpdatesStore: Object.assign(hook, mod.useUpdatesStore) };
 });
 
+vi.mock("@/stores/scan", async (importOriginal) => {
+  const mod = await importOriginal<typeof import("@/stores/scan")>();
+  const hook = (selector?: (state: unknown) => unknown) => {
+    const state = {
+      ...mod.useScanStore.getState(),
+      result: stub.scan,
+      generation: stub.generation,
+    };
+    return selector ? selector(state) : state;
+  };
+  return { ...mod, useScanStore: Object.assign(hook, mod.useScanStore) };
+});
+
+vi.mock("@/stores/provenance", async (importOriginal) => {
+  const mod = await importOriginal<typeof import("@/stores/provenance")>();
+  const hook = (selector?: (state: unknown) => unknown) => {
+    const state = {
+      ...mod.useProvenanceStore.getState(),
+      rows: [],
+      loaded: true,
+      answeredFor: stub.answeredFor,
+    };
+    return selector ? selector(state) : state;
+  };
+  return {
+    ...mod,
+    useProvenanceStore: Object.assign(hook, mod.useProvenanceStore),
+  };
+});
+
 beforeEach(() => {
   stub.rows = [];
   stub.read = { status: "landed", error: null };
   stub.lastFetched = null;
   stub.busy = false;
   stub.unreadable = [];
+  // A landed scan holding one package, with its join answering for that
+  // scan: the ordinary machine, on which no empty state may claim the
+  // machine is empty.
+  stub.scan = scanOf([installedItem("deploy")]);
+  stub.generation = 1;
+  stub.answeredFor = 1;
+});
+
+/** One installation the machine scan found. */
+const installedItem = (name: string): ObservedItem =>
+  observed({
+    kind: "skill",
+    name,
+    harness: "claude",
+    scope: { scope: "global" },
+    path: `/h/.claude/skills/${name}`,
+    fileState: { state: "dir" },
+    enabled: true,
+    origin: null,
+    summary: null,
+    action: null,
+    tags: [],
+    modifiedAt: null,
+    vendor: null,
+  });
+
+const scanOf = (items: ObservedItem[]): ScanResult => ({
+  harnesses: [],
+  items,
+  missingProjects: [],
+  readProjects: [],
+  warnings: [],
 });
 
 /** A recorded package with nothing noteworthy about it — the row core
@@ -211,21 +279,40 @@ describe("the Updates page across its read states", () => {
 });
 
 // An empty list carries three different meanings, and only one of them is
-// good news: a machine with nothing recorded and recorded packages no fetch
-// has spoken for both look exactly like a machine a check found current.
+// good news. The update read covers declared remote packages alone, so a
+// machine of adopted, local or unmanaged content produces no rows at all
+// while the Library counts its packages: the scan says whether the machine
+// is empty, and the update rows never do.
 describe("what an empty Updates page says about this machine", () => {
-  it("claims up-to-dateness only where a check produced it", () => {
+  it("reads the machine from the scan and up-to-dateness from the check", () => {
     const rows = [
       {
         name: "says nothing is installed, and offers a marketplace rather than a check",
         updates: [],
+        scan: scanOf([]),
+        joined: true,
         age: null,
         present: [UPDATES_NOTHING_INSTALLED, BROWSE_MARKETPLACES_LABEL],
         absent: [UPDATES_EMPTY, NEVER_CHECKED, CHECK_FOR_UPDATES_LABEL],
       },
       {
-        name: "says no check has run where packages are recorded and no fetch reached a source",
+        name: "keeps the check on a machine the scan sees and the update read lists nothing for",
+        updates: [],
+        scan: scanOf([installedItem("adopted")]),
+        joined: true,
+        age: null,
+        present: [NEVER_CHECKED, CHECK_FOR_UPDATES_LABEL],
+        absent: [
+          UPDATES_NOTHING_INSTALLED,
+          BROWSE_MARKETPLACES_LABEL,
+          UPDATES_EMPTY,
+        ],
+      },
+      {
+        name: "says no check has run where something is installed and no fetch reached a source",
         updates: [currentRow("gh")],
+        scan: scanOf([installedItem("deploy")]),
+        joined: true,
         age: null,
         present: [NEVER_CHECKED, CHECK_FOR_UPDATES_LABEL],
         absent: [UPDATES_EMPTY, UPDATES_NOTHING_INSTALLED],
@@ -233,14 +320,36 @@ describe("what an empty Updates page says about this machine", () => {
       {
         name: "calls the machine up to date once a check has reached a source",
         updates: [currentRow("gh")],
+        scan: scanOf([installedItem("deploy")]),
+        joined: true,
         age: 5 * 86_400,
         present: [UPDATES_EMPTY, CHECK_FOR_UPDATES_LABEL],
         absent: [NEVER_CHECKED, UPDATES_NOTHING_INSTALLED],
       },
+      {
+        name: "calls no machine empty before the scan has landed",
+        updates: [],
+        scan: null,
+        joined: true,
+        age: null,
+        present: [NEVER_CHECKED, CHECK_FOR_UPDATES_LABEL],
+        absent: [UPDATES_NOTHING_INSTALLED, BROWSE_MARKETPLACES_LABEL],
+      },
+      {
+        name: "calls no machine empty on a join that answered about another scan",
+        updates: [],
+        scan: scanOf([]),
+        joined: false,
+        age: null,
+        present: [NEVER_CHECKED, CHECK_FOR_UPDATES_LABEL],
+        absent: [UPDATES_NOTHING_INSTALLED, BROWSE_MARKETPLACES_LABEL],
+      },
     ];
-    expect(rows).toHaveLength(3);
+    expect(rows).toHaveLength(6);
     for (const row of rows) {
       stub.rows = row.updates;
+      stub.scan = row.scan;
+      stub.answeredFor = row.joined ? stub.generation : stub.generation - 1;
       stub.lastFetched = row.age === null ? null : secondsAgo(row.age);
       const html = renderToStaticMarkup(<UpdatesPage />);
       expect(

--- a/ui/src/pages/updates.test.tsx
+++ b/ui/src/pages/updates.test.tsx
@@ -46,8 +46,7 @@ const stub = vi.hoisted(() => ({
   lastFetched: null as number | null,
   busy: false,
   unreadable: [] as unknown[],
-  /** What the machine scan found — where the page reads whether anything
-   *  is installed. */
+  /** What the machine scan found, where the page reads what is installed. */
   scan: null as unknown,
 }));
 
@@ -73,10 +72,7 @@ vi.mock("@/stores/updates", async (importOriginal) => {
 vi.mock("@/stores/scan", async (importOriginal) => {
   const mod = await importOriginal<typeof import("@/stores/scan")>();
   const hook = (selector?: (state: unknown) => unknown) => {
-    const state = {
-      ...mod.useScanStore.getState(),
-      result: stub.scan,
-    };
+    const state = { ...mod.useScanStore.getState(), result: stub.scan };
     return selector ? selector(state) : state;
   };
   return { ...mod, useScanStore: Object.assign(hook, mod.useScanStore) };
@@ -84,8 +80,7 @@ vi.mock("@/stores/scan", async (importOriginal) => {
 
 // The join that recognises nothing, so these fixtures group as the scan saw
 // them. Which readings may be counted from at all is `scannedInstalled`'s,
-// pinned in `lib/updates-read-state.test.ts`, and the real gate is walked
-// end to end by `updates.dom.test.tsx`.
+// pinned in `lib/updates-read-state.test.ts`.
 vi.mock("@/lib/package-identity", async (importOriginal) => {
   const mod = await importOriginal<typeof import("@/lib/package-identity")>();
   return { ...mod, usePackageIndex: () => () => null };
@@ -97,14 +92,11 @@ beforeEach(() => {
   stub.lastFetched = null;
   stub.busy = false;
   stub.unreadable = [];
-  // A landed scan holding one package, with its join answering for that
-  // scan: the ordinary machine, on which no empty state may claim the
-  // machine is empty.
+  // The ordinary machine: a scan that found something.
   stub.scan = scanFound([observedSkill("deploy")]);
 });
 
-/** A recorded package with nothing noteworthy about it — the row core
- *  emits for something installed and current. */
+/** The row core emits for something installed and current. */
 const currentRow = (name: string) =>
   updateRow(name, null, { updateAvailable: false, latest: null });
 

--- a/ui/src/pages/updates.tsx
+++ b/ui/src/pages/updates.tsx
@@ -81,8 +81,7 @@ export function UpdatesPage() {
   const setShowVersion = useUpdatesView((s) => s.setShowVersion);
   const goToMarketplaces = useNavStore((s) => s.goToMarketplaces);
   // Whether anything is installed comes from the machine scan, never from
-  // the update rows, and which scans may be counted from is
-  // `scannedInstalled`'s to say.
+  // the update rows; which scans may be counted from is the judge's.
   const scan = useScanStore((s) => s.result);
   const scanError = useScanStore((s) => s.error);
   const packageOf = usePackageIndex();

--- a/ui/src/pages/updates.tsx
+++ b/ui/src/pages/updates.tsx
@@ -81,17 +81,31 @@ export function UpdatesPage() {
   // check covers declared remote packages, and a machine of adopted, local
   // or unmanaged content produces no rows while holding plenty. So the
   // count comes from the machine scan the Library and Home count through,
-  // in their unit, and is null until the join answers for the scan on
-  // screen — the same gate `usePackageIndex` puts on every other counter.
+  // in their unit.
   const scan = useScanStore((s) => s.result);
+  const scanError = useScanStore((s) => s.error);
   const packageOf = usePackageIndex();
-  const installed = useMemo(
-    () =>
-      scan && packageOf
-        ? installedCount(groupItems(scan.items, packageOf))
-        : null,
-    [scan, packageOf],
-  );
+  // Only a settled, complete, successful scan may say a machine is empty,
+  // and the three ways it is none of those are answered here rather than
+  // at the branch that words the answer.
+  //
+  // A failed re-read leaves the last result and its generation standing
+  // (`stores/scan.ts`), so a kept zero would go on reporting a machine
+  // nothing has looked at since. A landed scan with `missingProjects` read
+  // part of the machine, and a project it could not open is where the
+  // content may be. And a join answering about another scan cannot group
+  // what is on screen, which is the gate `usePackageIndex` already puts on
+  // every other counter.
+  //
+  // Each of them is null, not zero: `emptyStanding` sends null to the pair
+  // that keeps Check for updates on screen, and offering a marketplace to
+  // a machine that may be full is the claim this page exists to stop
+  // making.
+  const installed = useMemo(() => {
+    if (!scan || !packageOf || scanError !== null) return null;
+    if (scan.missingProjects.length > 0) return null;
+    return installedCount(groupItems(scan.items, packageOf));
+  }, [scan, scanError, packageOf]);
   const [showHidden, setShowHidden] = useState(false);
   const [confirmIgnore, setConfirmIgnore] = useState<UpdateRow | null>(null);
   // WHICH places an update was asked for, never the rows themselves, and

--- a/ui/src/pages/updates.tsx
+++ b/ui/src/pages/updates.tsx
@@ -80,8 +80,7 @@ export function UpdatesPage() {
   // main table, or on the muted one when it is the only table drawn.
   const setShowVersion = useUpdatesView((s) => s.setShowVersion);
   const goToMarketplaces = useNavStore((s) => s.goToMarketplaces);
-  // Whether anything is installed comes from the machine scan, never from
-  // the update rows; which scans may be counted from is the judge's.
+  // What is installed comes from the machine scan, never the update rows.
   const scan = useScanStore((s) => s.result);
   const scanError = useScanStore((s) => s.error);
   const packageOf = usePackageIndex();

--- a/ui/src/pages/updates.tsx
+++ b/ui/src/pages/updates.tsx
@@ -36,7 +36,6 @@ import {
   updatePlaceItem,
   updatesSubtitle,
 } from "@/lib/copy-updates";
-import { groupItems, installedCount } from "@/lib/derive";
 import { PAGE_GUTTER, WIDE_CONTENT_WIDTH } from "@/lib/layout";
 import { usePackageIndex } from "@/lib/package-identity";
 import { exactTime } from "@/lib/relative-time";
@@ -51,7 +50,11 @@ import {
   updatablePlaces,
   visibleUpdates,
 } from "@/lib/update-groups";
-import { emptyStanding, readUnsettled } from "@/lib/updates-read-state";
+import {
+  emptyStanding,
+  readUnsettled,
+  scannedInstalled,
+} from "@/lib/updates-read-state";
 import { useNowTick } from "@/lib/use-now-tick";
 import { cn } from "@/lib/utils";
 import { useAuditOnMount } from "@/stores/audit";
@@ -80,32 +83,15 @@ export function UpdatesPage() {
   // What an empty list means is not this page's read to answer: the update
   // check covers declared remote packages, and a machine of adopted, local
   // or unmanaged content produces no rows while holding plenty. So the
-  // count comes from the machine scan the Library and Home count through,
-  // in their unit.
+  // count comes from the machine scan, and which scans may produce one is
+  // `scannedInstalled`'s to say.
   const scan = useScanStore((s) => s.result);
   const scanError = useScanStore((s) => s.error);
   const packageOf = usePackageIndex();
-  // Only a settled, complete, successful scan may say a machine is empty,
-  // and the three ways it is none of those are answered here rather than
-  // at the branch that words the answer.
-  //
-  // A failed re-read leaves the last result and its generation standing
-  // (`stores/scan.ts`), so a kept zero would go on reporting a machine
-  // nothing has looked at since. A landed scan with `missingProjects` read
-  // part of the machine, and a project it could not open is where the
-  // content may be. And a join answering about another scan cannot group
-  // what is on screen, which is the gate `usePackageIndex` already puts on
-  // every other counter.
-  //
-  // Each of them is null, not zero: `emptyStanding` sends null to the pair
-  // that keeps Check for updates on screen, and offering a marketplace to
-  // a machine that may be full is the claim this page exists to stop
-  // making.
-  const installed = useMemo(() => {
-    if (!scan || !packageOf || scanError !== null) return null;
-    if (scan.missingProjects.length > 0) return null;
-    return installedCount(groupItems(scan.items, packageOf));
-  }, [scan, scanError, packageOf]);
+  const installed = useMemo(
+    () => scannedInstalled(scan, scanError, packageOf),
+    [scan, scanError, packageOf],
+  );
   const [showHidden, setShowHidden] = useState(false);
   const [confirmIgnore, setConfirmIgnore] = useState<UpdateRow | null>(null);
   // WHICH places an update was asked for, never the rows themselves, and

--- a/ui/src/pages/updates.tsx
+++ b/ui/src/pages/updates.tsx
@@ -80,10 +80,8 @@ export function UpdatesPage() {
   // main table, or on the muted one when it is the only table drawn.
   const setShowVersion = useUpdatesView((s) => s.setShowVersion);
   const goToMarketplaces = useNavStore((s) => s.goToMarketplaces);
-  // What an empty list means is not this page's read to answer: the update
-  // check covers declared remote packages, and a machine of adopted, local
-  // or unmanaged content produces no rows while holding plenty. So the
-  // count comes from the machine scan, and which scans may produce one is
+  // Whether anything is installed comes from the machine scan, never from
+  // the update rows, and which scans may be counted from is
   // `scannedInstalled`'s to say.
   const scan = useScanStore((s) => s.result);
   const scanError = useScanStore((s) => s.error);

--- a/ui/src/pages/updates.tsx
+++ b/ui/src/pages/updates.tsx
@@ -1,5 +1,5 @@
 import { ChevronDown, ChevronRight, RefreshCw } from "lucide-react";
-import { useEffect, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import type { Scope, UpdateRow } from "@/bindings";
 import { ConfirmDialog } from "@/components/confirm-dialog";
 import { PageHeader } from "@/components/page-header";
@@ -36,7 +36,9 @@ import {
   updatePlaceItem,
   updatesSubtitle,
 } from "@/lib/copy-updates";
+import { groupItems, installedCount } from "@/lib/derive";
 import { PAGE_GUTTER, WIDE_CONTENT_WIDTH } from "@/lib/layout";
+import { usePackageIndex } from "@/lib/package-identity";
 import { exactTime } from "@/lib/relative-time";
 import { scopeKey } from "@/lib/scope";
 import {
@@ -54,6 +56,7 @@ import { useNowTick } from "@/lib/use-now-tick";
 import { cn } from "@/lib/utils";
 import { useAuditOnMount } from "@/stores/audit";
 import { useNavStore } from "@/stores/nav";
+import { useScanStore } from "@/stores/scan";
 import { useUpdatesStore } from "@/stores/updates";
 import { useUpdatesView } from "@/stores/updates-view";
 
@@ -74,6 +77,21 @@ export function UpdatesPage() {
   // main table, or on the muted one when it is the only table drawn.
   const setShowVersion = useUpdatesView((s) => s.setShowVersion);
   const goToMarketplaces = useNavStore((s) => s.goToMarketplaces);
+  // What an empty list means is not this page's read to answer: the update
+  // check covers declared remote packages, and a machine of adopted, local
+  // or unmanaged content produces no rows while holding plenty. So the
+  // count comes from the machine scan the Library and Home count through,
+  // in their unit, and is null until the join answers for the scan on
+  // screen — the same gate `usePackageIndex` puts on every other counter.
+  const scan = useScanStore((s) => s.result);
+  const packageOf = usePackageIndex();
+  const installed = useMemo(
+    () =>
+      scan && packageOf
+        ? installedCount(groupItems(scan.items, packageOf))
+        : null,
+    [scan, packageOf],
+  );
   const [showHidden, setShowHidden] = useState(false);
   const [confirmIgnore, setConfirmIgnore] = useState<UpdateRow | null>(null);
   // WHICH places an update was asked for, never the rows themselves, and
@@ -120,7 +138,7 @@ export function UpdatesPage() {
 
   const beforeList = updatesBeforeList({
     read,
-    standing: emptyStanding(rows, lastFetched),
+    standing: emptyStanding(installed, lastFetched),
     empty,
     checking,
     busy,

--- a/ui/src/pages/updates.tsx
+++ b/ui/src/pages/updates.tsx
@@ -1,13 +1,7 @@
-import {
-  CheckCircle2,
-  ChevronDown,
-  ChevronRight,
-  RefreshCw,
-} from "lucide-react";
+import { ChevronDown, ChevronRight, RefreshCw } from "lucide-react";
 import { useEffect, useState } from "react";
 import type { Scope, UpdateRow } from "@/bindings";
 import { ConfirmDialog } from "@/components/confirm-dialog";
-import { EmptyState } from "@/components/empty-state";
 import { PageHeader } from "@/components/page-header";
 import { StatusNote } from "@/components/status-note";
 import { Button } from "@/components/ui/button";
@@ -29,8 +23,6 @@ import {
   IGNORE_CONFIRM_LABEL,
   ignoreConfirmTitle,
   UPDATE_ALL_LABEL,
-  UPDATES_EMPTY,
-  UPDATES_EMPTY_BODY,
   UPDATES_UNCHECKED_TITLE,
 } from "@/lib/copy";
 import {
@@ -57,10 +49,11 @@ import {
   updatablePlaces,
   visibleUpdates,
 } from "@/lib/update-groups";
-import { readUnsettled } from "@/lib/updates-read-state";
+import { emptyStanding, readUnsettled } from "@/lib/updates-read-state";
 import { useNowTick } from "@/lib/use-now-tick";
 import { cn } from "@/lib/utils";
 import { useAuditOnMount } from "@/stores/audit";
+import { useNavStore } from "@/stores/nav";
 import { useUpdatesStore } from "@/stores/updates";
 import { useUpdatesView } from "@/stores/updates-view";
 
@@ -80,6 +73,7 @@ export function UpdatesPage() {
   // One choice for every table on the page; the `…` menu lives on the
   // main table, or on the muted one when it is the only table drawn.
   const setShowVersion = useUpdatesView((s) => s.setShowVersion);
+  const goToMarketplaces = useNavStore((s) => s.goToMarketplaces);
   const [showHidden, setShowHidden] = useState(false);
   const [confirmIgnore, setConfirmIgnore] = useState<UpdateRow | null>(null);
   // WHICH places an update was asked for, never the rows themselves, and
@@ -126,11 +120,13 @@ export function UpdatesPage() {
 
   const beforeList = updatesBeforeList({
     read,
+    standing: emptyStanding(rows, lastFetched),
     empty,
     checking,
     busy,
     lastChecked,
     onCheck: () => void check(),
+    onBrowse: () => goToMarketplaces(),
   });
   if (beforeList) return beforeList;
 
@@ -207,16 +203,13 @@ export function UpdatesPage() {
             </StatusNote>
           ) : null}
           <UnreadablePlacesNote places={unreadable} />
-          {visible.length === 0 ? (
-            // Only a read that covered every project may call the machine
-            // up to date: a project with no standing is not a project with
-            // nothing to update.
-            read.error === null && unreadable.length === 0 ? (
-              <EmptyState icon={CheckCircle2} title={UPDATES_EMPTY}>
-                {UPDATES_EMPTY_BODY}
-              </EmptyState>
-            ) : null
-          ) : (
+          {/* Nothing is drawn where the list is empty: this branch is
+              reached only with hidden rows, warnings or unreadable places
+              keeping the page on, and each of those draws itself below.
+              An up-to-date claim over muted updates or a place nobody
+              could read is the contradiction `updatesBeforeList` answers,
+              and only it may make that claim. */}
+          {visible.length === 0 ? null : (
             <UpdatesTable
               rows={visible}
               onIgnore={setConfirmIgnore}

--- a/ui/src/test/observed.ts
+++ b/ui/src/test/observed.ts
@@ -1,4 +1,4 @@
-import type { ObservedItem } from "@/bindings";
+import type { ObservedItem, ScanResult } from "@/bindings";
 
 /** The separator between a shared file and the entry inside it, the way
  *  core spells it — a character no path and no command can hold. Written
@@ -47,3 +47,16 @@ export const observedSkill = (name: string): ObservedItem =>
     modifiedAt: null,
     vendor: null,
   });
+
+/** A landed machine scan of exactly these installations, complete unless a
+ *  test hands it projects it could not read. */
+export const scanFound = (
+  items: ObservedItem[],
+  missingProjects: ScanResult["missingProjects"] = [],
+): ScanResult => ({
+  harnesses: [],
+  items,
+  missingProjects,
+  readProjects: [],
+  warnings: [],
+});

--- a/ui/src/test/observed.ts
+++ b/ui/src/test/observed.ts
@@ -28,3 +28,22 @@ const identityOf = (item: Omit<ObservedItem, "at">): string => {
     ? item.fileState.target
     : item.path;
 };
+
+/** A plain skill at the personal level, for a test that needs the scan to
+ *  have found an installation rather than a particular one. */
+export const observedSkill = (name: string): ObservedItem =>
+  observed({
+    kind: "skill",
+    name,
+    harness: "claude",
+    scope: { scope: "global" },
+    path: `/h/.claude/skills/${name}`,
+    fileState: { state: "dir" },
+    enabled: true,
+    origin: null,
+    summary: null,
+    action: null,
+    tags: [],
+    modifiedAt: null,
+    vendor: null,
+  });

--- a/ui/src/test/observed.ts
+++ b/ui/src/test/observed.ts
@@ -1,4 +1,4 @@
-import type { ObservedItem, ScanResult } from "@/bindings";
+import type { ObservedItem, ScanResult, ScanWarning } from "@/bindings";
 
 /** The separator between a shared file and the entry inside it, the way
  *  core spells it — a character no path and no command can hold. Written
@@ -48,15 +48,16 @@ export const observedSkill = (name: string): ObservedItem =>
     vendor: null,
   });
 
-/** A landed scan of these installations, complete unless given projects it
- *  could not read. */
+/** A landed scan of these installations, whole unless given unread projects
+ *  or warnings. */
 export const scanFound = (
   items: ObservedItem[],
   missingProjects: ScanResult["missingProjects"] = [],
+  warnings: ScanWarning[] = [],
 ): ScanResult => ({
   harnesses: [],
   items,
   missingProjects,
   readProjects: [],
-  warnings: [],
+  warnings,
 });

--- a/ui/src/test/observed.ts
+++ b/ui/src/test/observed.ts
@@ -48,8 +48,8 @@ export const observedSkill = (name: string): ObservedItem =>
     vendor: null,
   });
 
-/** A landed machine scan of exactly these installations, complete unless a
- *  test hands it projects it could not read. */
+/** A landed scan of these installations, complete unless given projects it
+ *  could not read. */
 export const scanFound = (
   items: ObservedItem[],
   missingProjects: ScanResult["missingProjects"] = [],


### PR DESCRIPTION
## Summary

- The Updates page gave three different machines the same words. One judge, `emptyStanding` in `ui/src/lib/updates-read-state.ts`, now tells them apart: nothing installed, packages no check has reached a source for, and packages a check found current. `updatesBeforeList` switches on it exhaustively, so a fourth state cannot compile without an answer.
- Nothing installed says so and offers Browse Marketplaces. A check has nothing to reach on that machine, so the retry there was a dead end. The two states that do have something to check both keep the Check control.
- The page carried a second copy of the "Everything is up to date" claim, drawn over muted updates, warnings and unreadable places. That block is deleted; each of those sections already draws itself.

## Correction to the issue's stated cause

The issue's root adjustment comment says core "emits one `UpdateRow` per recorded package whether or not an update exists". That holds only for packages declared against a **remote** source, so the first implementation read zero update rows as an empty machine and was wrong. Verified against current source:

- `crates/core/src/package/updates.rs` `updates()` is documented as "Every planned remote package's standing" and walks `planned_declarations` only.
- `crates/core/src/package/updates/eval.rs` `unevaluated()` states the skip: "Path and local sources have no versions and are silently no row — except a fork". Its `ItemRevUnsupported` arm pushes a row only when the item is a fork.
- `crates/core/src/package/mod.rs` `package_ref_for` raises that error for every source with no `repo`, which is every `local` and `in-place` source.
- Content no manifest declares never enters the loop at all.

So a machine whose items were adopted (`kendex adopt` declares them `local` or `in-place`), one holding only local packages, and a fresh install over existing harness files all produce zero update rows while holding content. Reading those rows as an empty machine would have told each of them "Nothing installed yet" while the Library's table and Home's Installed tile counted their packages, and would have taken away their Check control.

The shipped rule reads the installed count from the machine scan that does know it, through the same `installedCount` the Library and Home count through. It answers nothing-installed only on a zero from a scan that actually saw the whole machine: landed, no standing `error`, an empty `missingProjects`, and a join answering for the scan on screen. A count nobody can take yet is null, not zero, and null falls to the unchecked/current pair, which keep the check on screen rather than offering a marketplace to a machine that may be full.

## Completed Issues

- Closes KEN-1346 - Updates calls an empty machine up to date before any check

## Size

No allowance was stated on the issue. Measured: 155 production lines added, 254 test lines, 0 render-mirror lines. The branch's round tripwire, which counts additions plus deletions, stands at 458 against a limit of 462.

## Review round 1

Two findings from the review bot, both accepted and fixed.

- A non-null scan result is not an authoritative zero: `ui/src/stores/scan.ts` `scan()` leaves `result` and `generation` standing on a failed read, and a landed scan flags a project it could not open in `missingProjects` rather than dropping it. Either way a stale or partial zero would have drawn "Nothing installed yet" and removed the Check control. The count is now null unless the scan landed, carries no standing `error`, and has an empty `missingProjects`. Null falls to the pair that keeps the check on screen.
- The nothing-installed row proved only that the Browse Marketplaces label rendered, since `renderToStaticMarkup` never invokes a handler. `ui/src/pages/updates.dom.test.tsx` now mounts the state, activates the button and asserts the navigation, matching the existing `overview.test.tsx` / `overview.dom.test.tsx` split.

## Review round 2

One finding, split. The actionable-warning half was accepted and fixed; the in-flight-scan half was declined.

- `ScanWarning.standing` is documented as leaving its surface actionable until `standing::classify` clears it "on evidence that nothing is missing", so a landed, error-free scan with an empty `missingProjects` can still carry one. `scannedInstalled` now refuses a count on it, through the `isActionable` that Home's attention rows and `stores/problems.ts` already share. The whole rule lives in that one function and its doc states it as a whole-machine scan, so a future way the scan admits it saw less is added in one place.
- Declined: returning null while `scanning` is true. Home reads the same store, shows `installedCount` from the retained result while a scan runs, and heads it with `SCAN_STALE_TITLE` only when `error` is not null (`ui/src/pages/overview.tsx:171-179`, whose comment states the convention). Home uses `scanning` only to disable its Scan again button. Gating on it here would also flip the onboarding page's wording back and forth on every window focus, since focus starts a scan, in exchange for a window the install path already closes through `rescan.ts`.

## Size cut

The round tripwire refused a further fix round at 510 churn against a 462 limit, so the branch was cut in three rounds before the last finding landed. The authoritative-count rule moved out of the page into `scannedInstalled` with its own unit table, the scan fixtures were shared, and test setup and duplicated prose were compressed. No assertion, must-fail control, or reachable state was removed, and no size-ratchet exclusion was added.

## Test Plan

- `ui/src/lib/updates-read-state.test.ts` pins which readings may be counted from at all, in seven rows: an empty machine, a counted machine, an unlanded scan, a result kept behind a failed scan, a scan that could not read a project, a scan warning about a surface it could not read, and a join answering about another scan. The last five must all answer null rather than zero, since a zero is worded as "Nothing installed yet" and takes the check away with it.
- `ui/src/pages/updates.test.tsx` pins what each state says on screen, in four rows: nothing installed, a machine the scan sees that the update read lists nothing for, recorded packages with no fetch, and recorded packages a fetch found current.
- Twelve must-fail controls, one per claim, each reddening only its own rows. One restores the rejected rule that decided the machine from `rows.length`; another empties the browse handler.
- `ui/src/pages/updates.dom.test.tsx` mounts the empty-machine state and asserts Browse Marketplaces navigates.
- `env -u TMPDIR tools/guard --full` exit 0 on the final head bdb9a109, with no `guard:` failure line. vitest 204 files / 1507 tests passed. Re-run after the rebase pulled main's rewrite of `ui/src/stores/updates.ts` into the tree.

https://claude.ai/code/session_01REshdTH3XBVowcAAYVKWLp
