### PR TITLE
fix(KEN-1348): a narrow Library table drops a column, keeping Status

### DIFF
--- a/changelog.d/fixed/1348.md
+++ b/changelog.d/fixed/1348.md
@@ -1,0 +1,1 @@
+- My Library's Installed table now drops its lower-value columns on a narrow window instead of running the health dot off the right edge; they come back as the window widens.

--- a/ui/src/components/library/installed-row.test.tsx
+++ b/ui/src/components/library/installed-row.test.tsx
@@ -14,7 +14,16 @@ import {
 import { UPDATE_AVAILABLE_BADGE } from "@/lib/copy-updates";
 import { groupItems } from "@/lib/derive";
 import { mount as mountTree } from "@/test/dom";
-import { InstalledRow } from "./installed-row";
+import { type InstalledColumns, InstalledRow } from "./installed-row";
+
+// A row drawn with the room for everything it can say. Which columns
+// the table can afford is `installed-view.tsx`'s answer, not a row's.
+const EVERY_COLUMN: InstalledColumns = {
+  tags: true,
+  harnesses: true,
+  from: true,
+  updated: true,
+};
 
 const VG: Scope = { scope: "project", root: "/work/vg" };
 const HYPR: Scope = { scope: "project", root: "/work/hyprtrade" };
@@ -171,6 +180,7 @@ describe("the words a Library row's badges stand for", () => {
     const host = mountTree(
       <tbody>
         <InstalledRow
+          columns={EVERY_COLUMN}
           group={bundled}
           origin={null}
           forkedIn={[]}
@@ -255,6 +265,7 @@ describe("the other things a Library row names", () => {
     const host = mountTree(
       <tbody>
         <InstalledRow
+          columns={EVERY_COLUMN}
           group={groupItems([item(VG)] as never, () => null)[0]}
           origin={{
             origin: "marketplace",
@@ -294,6 +305,7 @@ describe("the other things a Library row names", () => {
     const host = mountTree(
       <tbody>
         <InstalledRow
+          columns={EVERY_COLUMN}
           group={group}
           origin={null}
           forkedIn={[]}
@@ -329,6 +341,7 @@ const mount = (
   const host = mountTree(
     <tbody>
       <InstalledRow
+        columns={EVERY_COLUMN}
         group={group}
         origin={null}
         forkedIn={forkedIn}

--- a/ui/src/components/library/installed-row.tsx
+++ b/ui/src/components/library/installed-row.tsx
@@ -119,7 +119,16 @@ export function InstalledRow({
       className="cursor-pointer"
     >
       {/* Cells are nowrap by default; the description is the one column that
-          wants to wrap rather than run out of the row and get cut mid-word. */}
+          wants to wrap rather than run out of the row and get cut mid-word.
+
+          Every cell whose content the reader supplies, or whose length they
+          decide, carries the ceiling its column is budgeted at in
+          `installed-view.tsx`. The table lays out automatically, where a
+          width on a header is what the column asks for rather than what it
+          gets, so without these the budget's arithmetic is a floor and one
+          long project name pushes Status off the narrowest window. What the
+          ceiling hides stays reachable: these cells carry the whole of it on
+          `title`, and the package's own page states it in full. */}
       <TableCell className="max-w-72 font-medium whitespace-normal">
         <span className="flex items-start gap-2">
           {/* The list says nothing about customization: whether a package
@@ -229,12 +238,12 @@ export function InstalledRow({
         {kindLabel(group.kind)}
       </TableCell>
       {columns.tags ? (
-        <TableCell className="align-top">
+        <TableCell className="max-w-40 align-top">
           <TagBadges tags={group.tags} />
         </TableCell>
       ) : null}
       {columns.harnesses ? (
-        <TableCell>
+        <TableCell className="max-w-40">
           <span className="flex flex-wrap gap-1">
             {/* A chip names a harness, so it opens that harness's own view
                 of what is installed for it. */}
@@ -253,11 +262,14 @@ export function InstalledRow({
       {/* A place names a thing, so it opens it — but only where the cell
           names one place. "3 locations" is a count, and the places behind
           it are listed on the package's own page. */}
-      <TableCell title={whereTitle} className="text-muted-foreground">
+      <TableCell
+        title={whereTitle}
+        className="max-w-28 truncate text-muted-foreground"
+      >
         {scopes.length === 1 ? (
           <button
             type="button"
-            className="hover:underline"
+            className="block max-w-full truncate hover:underline"
             onClick={() => onOpenPlace(scopes[0])}
           >
             {whereLabel}
@@ -272,12 +284,12 @@ export function InstalledRow({
       {columns.from ? (
         <TableCell
           title={originTitle(origin)}
-          className="text-muted-foreground"
+          className="max-w-32 truncate text-muted-foreground"
         >
           {onOpenFrom && originLabel(origin) ? (
             <button
               type="button"
-              className="hover:underline"
+              className="block max-w-full truncate hover:underline"
               onClick={onOpenFrom}
             >
               {originLabel(origin)}

--- a/ui/src/components/library/installed-row.tsx
+++ b/ui/src/components/library/installed-row.tsx
@@ -137,7 +137,17 @@ export function InstalledRow({
             <Icon className="size-4 text-muted-foreground" />
           </span>
           <span className="min-w-0">
-            <span className="flex items-center gap-1.5">
+            {/* The strip wraps. Every Badge is `shrink-0 whitespace-nowrap`
+                by design, so a row of them that cannot go to a second line
+                sets a min-content width for the column, and min-content
+                beats a max-width under an automatic table layout — the
+                cell's own ceiling stops binding and Status leaves the
+                narrowest window. The two badges naming a place also cap
+                what they ask for: `placeName` falls back to a whole root
+                where two places end alike, which no ceiling above them
+                bounds. Capping is visual only, so the label a screen
+                reader announces is still the whole of it. */}
+            <span className="flex flex-wrap items-center gap-1.5">
               {/* What a screen reader is told opens the package. The row
                   itself opens too, but a row announces its cells rather
                   than an action, so the name stays a real button. No
@@ -162,10 +172,12 @@ export function InstalledRow({
                     render={
                       <Badge
                         variant="outline"
-                        className="cursor-pointer"
+                        className="max-w-40 cursor-pointer"
                         render={
                           <button type="button" onClick={() => onOpen(where)}>
-                            {`${FORKED_BADGE_LABEL} in ${placeName(where, scopes)}`}
+                            <span className="min-w-0 truncate">
+                              {`${FORKED_BADGE_LABEL} in ${placeName(where, scopes)}`}
+                            </span>
                             <span className="sr-only">{FORKED_BADGE_HELP}</span>
                           </button>
                         }
@@ -183,10 +195,12 @@ export function InstalledRow({
                     render={
                       <Badge
                         variant="warning"
-                        className="cursor-pointer"
+                        className="max-w-40 cursor-pointer"
                         render={
                           <button type="button" onClick={() => onOpen(where)}>
-                            {`${MISSING_FILES_BADGE_LABEL} in ${placeName(where, scopes)}`}
+                            <span className="min-w-0 truncate">
+                              {`${MISSING_FILES_BADGE_LABEL} in ${placeName(where, scopes)}`}
+                            </span>
                             <span className="sr-only">
                               {MISSING_FILES_BADGE_HELP}
                             </span>
@@ -227,7 +241,7 @@ export function InstalledRow({
                 package runs, not what it is for, and the technical view
                 is where those belong. */}
             {group.summary ? (
-              <span className="line-clamp-2 text-xs font-normal text-muted-foreground">
+              <span className="line-clamp-2 text-xs font-normal break-words text-muted-foreground">
                 {group.summary}
               </span>
             ) : null}

--- a/ui/src/components/library/installed-row.tsx
+++ b/ui/src/components/library/installed-row.tsx
@@ -43,8 +43,18 @@ const STATUS_TONES: Record<GroupStatus, "good" | "warning" | "critical"> = {
   broken: "critical",
 };
 
+/** The columns this row draws only where the table has room for them —
+ *  `installed-view.tsx` decides, once, for every row. */
+export interface InstalledColumns {
+  tags: boolean;
+  harnesses: boolean;
+  from: boolean;
+  updated: boolean;
+}
+
 export function InstalledRow({
   group,
+  columns,
   origin,
   forkedIn,
   outOfDate,
@@ -55,6 +65,7 @@ export function InstalledRow({
   onOpenFrom,
 }: {
   group: ItemGroup;
+  columns: InstalledColumns;
   origin: Origin | null;
   /** The places whose copy is the reader's own fork. A fork belongs to the
    *  place it was made in, like every other per-place fact. */
@@ -109,7 +120,7 @@ export function InstalledRow({
     >
       {/* Cells are nowrap by default; the description is the one column that
           wants to wrap rather than run out of the row and get cut mid-word. */}
-      <TableCell className="max-w-[22rem] font-medium whitespace-normal">
+      <TableCell className="max-w-72 font-medium whitespace-normal">
         <span className="flex items-start gap-2">
           {/* The list says nothing about customization: whether a package
               is changed, and where, is the package page's to say. */}
@@ -217,24 +228,28 @@ export function InstalledRow({
       <TableCell className="align-top text-muted-foreground">
         {kindLabel(group.kind)}
       </TableCell>
-      <TableCell className="align-top">
-        <TagBadges tags={group.tags} />
-      </TableCell>
-      <TableCell>
-        <span className="flex flex-wrap gap-1">
-          {/* A chip names a harness, so it opens that harness's own view
-              of what is installed for it. */}
-          {group.harnesses.map((h) => (
-            <HarnessBadge
-              key={h}
-              harness={h as HarnessId}
-              compact
-              onOpen={() => onOpenHarness(h as HarnessId)}
-            />
-          ))}
-          <SharedFilesBadge files={shared} />
-        </span>
-      </TableCell>
+      {columns.tags ? (
+        <TableCell className="align-top">
+          <TagBadges tags={group.tags} />
+        </TableCell>
+      ) : null}
+      {columns.harnesses ? (
+        <TableCell>
+          <span className="flex flex-wrap gap-1">
+            {/* A chip names a harness, so it opens that harness's own view
+                of what is installed for it. */}
+            {group.harnesses.map((h) => (
+              <HarnessBadge
+                key={h}
+                harness={h as HarnessId}
+                compact
+                onOpen={() => onOpenHarness(h as HarnessId)}
+              />
+            ))}
+            <SharedFilesBadge files={shared} />
+          </span>
+        </TableCell>
+      ) : null}
       {/* A place names a thing, so it opens it — but only where the cell
           names one place. "3 locations" is a count, and the places behind
           it are listed on the package's own page. */}
@@ -254,22 +269,33 @@ export function InstalledRow({
       {/* Same rule for where the copy came from: a marketplace's name
           opens the marketplace. "Your own" and "Not managed" name no
           marketplace, so they stay text. */}
-      <TableCell title={originTitle(origin)} className="text-muted-foreground">
-        {onOpenFrom && originLabel(origin) ? (
-          <button
-            type="button"
-            className="hover:underline"
-            onClick={onOpenFrom}
-          >
-            {originLabel(origin)}
-          </button>
-        ) : (
-          originLabel(origin) || "—"
-        )}
-      </TableCell>
-      <TableCell className="text-right text-xs text-muted-foreground">
-        {group.modifiedAt != null ? <Ago at={group.modifiedAt * 1000} /> : "—"}
-      </TableCell>
+      {columns.from ? (
+        <TableCell
+          title={originTitle(origin)}
+          className="text-muted-foreground"
+        >
+          {onOpenFrom && originLabel(origin) ? (
+            <button
+              type="button"
+              className="hover:underline"
+              onClick={onOpenFrom}
+            >
+              {originLabel(origin)}
+            </button>
+          ) : (
+            originLabel(origin) || "—"
+          )}
+        </TableCell>
+      ) : null}
+      {columns.updated ? (
+        <TableCell className="text-right text-xs text-muted-foreground">
+          {group.modifiedAt != null ? (
+            <Ago at={group.modifiedAt * 1000} />
+          ) : (
+            "—"
+          )}
+        </TableCell>
+      ) : null}
       {/* A dot, not a word: seven rows of "Active" say nothing the colour
           doesn't, and the words are back on hover for anyone who wants them. */}
       <TableCell>

--- a/ui/src/components/library/installed-skeleton.tsx
+++ b/ui/src/components/library/installed-skeleton.tsx
@@ -1,3 +1,4 @@
+import type { InstalledColumns } from "@/components/library/installed-row";
 import { Skeleton } from "@/components/ui/skeleton";
 import { TableCell, TableRow } from "@/components/ui/table";
 
@@ -18,8 +19,12 @@ const NAME_WIDTHS = [
 
 /** What the table shows before the first scan lands. A table that says
  *  "Nothing installed yet" while it is still counting is telling the reader
- *  something false about their machine. */
-export function InstalledSkeleton() {
+ *  something false about their machine.
+ *
+ *  It draws the columns the table is drawing, one placeholder each: a
+ *  placeholder row wider or narrower than the header it sits under is a
+ *  loading state that moves the columns when the rows arrive. */
+export function InstalledSkeleton({ columns }: { columns: InstalledColumns }) {
   return (
     <>
       {NAME_WIDTHS.map((width) => (
@@ -36,21 +41,32 @@ export function InstalledSkeleton() {
           <TableCell>
             <Skeleton className="h-3.5 w-14" />
           </TableCell>
+          {columns.tags ? (
+            <TableCell>
+              <Skeleton className="h-3.5 w-16" />
+            </TableCell>
+          ) : null}
+          {columns.harnesses ? (
+            <TableCell>
+              <span className="flex gap-1">
+                <Skeleton className="h-5 w-6 rounded-md" />
+                <Skeleton className="h-5 w-6 rounded-md" />
+              </span>
+            </TableCell>
+          ) : null}
           <TableCell>
             <Skeleton className="h-3.5 w-16" />
           </TableCell>
-          <TableCell>
-            <span className="flex gap-1">
-              <Skeleton className="h-5 w-6 rounded-md" />
-              <Skeleton className="h-5 w-6 rounded-md" />
-            </span>
-          </TableCell>
-          <TableCell>
-            <Skeleton className="h-3.5 w-16" />
-          </TableCell>
-          <TableCell>
-            <Skeleton className="ml-auto h-3 w-12" />
-          </TableCell>
+          {columns.from ? (
+            <TableCell>
+              <Skeleton className="h-3.5 w-16" />
+            </TableCell>
+          ) : null}
+          {columns.updated ? (
+            <TableCell>
+              <Skeleton className="ml-auto h-3 w-12" />
+            </TableCell>
+          ) : null}
           <TableCell>
             <Skeleton className="mx-auto size-2 rounded-full" />
           </TableCell>

--- a/ui/src/components/library/installed-view.dom.test.tsx
+++ b/ui/src/components/library/installed-view.dom.test.tsx
@@ -1076,6 +1076,91 @@ describe("the columns a narrow Library table keeps", () => {
     expect(row[2].getAttribute("title")).toBe(LONG);
   });
 
+  // The two cases above hold the ends of the ladder. These hold its rungs:
+  // which column comes back first is the judgement this issue asked for,
+  // and a reordered BUDGET.order or a changed cost would leave both ends
+  // right and every width between them wrong. Each width is the rung's own
+  // — the sum of the kept columns and everything afforded up to it — so a
+  // cost that moves takes its rung with it.
+  it("brings each column back at its own width, in its own order", () => {
+    const RUNGS = [
+      { room: 752, back: ["Harnesses"] },
+      { room: 880, back: ["Harnesses", "From"] },
+      { room: 992, back: ["Harnesses", "From", "Updated"] },
+      { room: 1152, back: ["Harnesses", "From", "Updated", TAGS_ROW_LABEL] },
+    ];
+    expect(RUNGS).toHaveLength(4);
+    for (const { room, back } of RUNGS) {
+      roomIs(room);
+      const host = mount(<InstalledView />);
+      // Drawn in the header's own order, which is not the restore order:
+      // a column comes back where the table draws it, not at the end.
+      const drawn = heads(host);
+      expect(drawn, `${room}px`).toEqual(
+        [
+          "Name",
+          "Type",
+          TAGS_ROW_LABEL,
+          "Harnesses",
+          "Where",
+          "From",
+          "Updated",
+          "Status",
+        ].filter(
+          (head) =>
+            ["Name", "Type", "Where", "Status"].includes(head) ||
+            back.includes(head),
+        ),
+      );
+      // One rung below its own width the newest column is not there yet.
+      roomIs(room - 1);
+      expect(heads(mount(<InstalledView />)), `${room - 1}px`).toEqual(
+        drawn.filter((head) => head !== back[back.length - 1]),
+      );
+    }
+  });
+
+  // The table draws two other states, and both changed here: the skeleton
+  // now draws the columns the table draws, and the empty row spans the
+  // columns on screen rather than a fixed eight. A reader whose scan has
+  // not answered, or whose filters match nothing, sees one of them at the
+  // minimum window like any other row.
+  it("draws the skeleton to the columns on screen", () => {
+    useProvenanceStore.setState({
+      rows: [],
+      loaded: false,
+      answeredFor: null,
+      read: READ_PENDING,
+    });
+    roomIs(AT_MINIMUM_WINDOW);
+    const narrow = mount(<InstalledView />);
+    expect(narrow.querySelector('[data-slot="skeleton"]')).not.toBeNull();
+    expect(cells(narrow)).toHaveLength(4);
+
+    roomIs(1400);
+    expect(cells(mount(<InstalledView />))).toHaveLength(8);
+  });
+
+  it("spans the empty row across the columns on screen", () => {
+    useScanStore.setState({
+      result: {
+        harnesses: [],
+        items: [],
+        missingProjects: [],
+        warnings: [],
+      } as never,
+    });
+    joinAnswered();
+    roomIs(AT_MINIMUM_WINDOW);
+    const narrow = mount(<InstalledView />);
+    const empty = cells(narrow);
+    expect(empty).toHaveLength(1);
+    expect(empty[0].colSpan).toBe(4);
+
+    roomIs(1400);
+    expect(cells(mount(<InstalledView />))[0].colSpan).toBe(8);
+  });
+
   // Every Badge is shrink-0 and whitespace-nowrap, so a strip of them that
   // cannot wrap set the name column's min-content width, which beats the
   // cell's max-width under an automatic table layout. A fork badge names

--- a/ui/src/components/library/installed-view.dom.test.tsx
+++ b/ui/src/components/library/installed-view.dom.test.tsx
@@ -982,9 +982,14 @@ describe("the columns a narrow Library table keeps", () => {
    *  the sidebar and its border (`w-56` plus `border-r`, `sidebar.tsx`,
    *  which carries no responsive variant), the page gutters (`PAGE_GUTTER`
    *  is `px-5 md:px-8 2xl:px-12`, and a 900px viewport is past Tailwind's
-   *  768px `md`, so `px-8`) and the scroller's reserved scrollbar lane
-   *  (`pr-2`). */
-  const AT_MINIMUM_WINDOW = 900 - 225 - 64 - 8;
+   *  768px `md`, so `px-8`), the scroller's own `pr-2`, and the lane its
+   *  `[scrollbar-gutter:stable]` reserves — measured at 15px in Chromium,
+   *  which is what Windows runs. That last term is zero on an engine whose
+   *  scrollbars overlay, making the room 603 there; this takes the tighter
+   *  of the two, since a budget has to fit the narrower room to fit both.
+   *  The table draws the same four columns at either, the next rung up
+   *  being 752. */
+  const AT_MINIMUM_WINDOW = 900 - 225 - 64 - 8 - 15;
 
   const heads = (host: HTMLElement): string[] =>
     [...host.querySelectorAll("thead th")].map(

--- a/ui/src/components/library/installed-view.dom.test.tsx
+++ b/ui/src/components/library/installed-view.dom.test.tsx
@@ -996,6 +996,14 @@ describe("the columns a narrow Library table keeps", () => {
       (cell) => cell.textContent?.trim() ?? "",
     );
 
+  /** The cells of the first package row. The headers are the view's and the
+   *  cells are the row's, so a table that agrees with itself has to be read
+   *  on both sides: drop a conditional from one and the columns misalign
+   *  while the other still reads correctly. */
+  const cells = (host: HTMLElement): HTMLTableCellElement[] => [
+    ...host.querySelectorAll<HTMLTableCellElement>("tbody tr:first-child td"),
+  ];
+
   beforeEach(() => {
     vi.spyOn(useEditorStore.getState(), "loadAll").mockResolvedValue();
     useEditorStore.setState({ saved: {} });
@@ -1017,8 +1025,10 @@ describe("the columns a narrow Library table keeps", () => {
     roomIs(AT_MINIMUM_WINDOW);
     const narrow = mount(<InstalledView />);
     expect(heads(narrow)).toEqual(["Name", "Type", "Where", "Status"]);
-    // The column is on screen, and so is the row's own reading of it.
-    expect(narrow.querySelector("tbody tr")?.textContent).toContain("Active");
+    // The row draws what the header declares, and Status is the last of
+    // them: four cells, the fourth carrying the dot's own reading.
+    expect(cells(narrow)).toHaveLength(4);
+    expect(cells(narrow)[3].textContent).toContain("Active");
 
     roomIs(1400);
     const wide = mount(<InstalledView />);
@@ -1032,5 +1042,36 @@ describe("the columns a narrow Library table keeps", () => {
       "Updated",
       "Status",
     ]);
+    expect(cells(wide)).toHaveLength(8);
+    expect(cells(wide)[7].textContent).toContain("Active");
+  });
+
+  // A project basename is the reader's, and the table lays out
+  // automatically, so an uncapped Where cell took whatever its content
+  // asked for and carried the columns after it off the right edge.
+  it("keeps the row to its columns when a project name is long", () => {
+    const LONG = "/work/kendex-marketplace-integration";
+    const place: Scope = { scope: "project", root: LONG };
+    useScanStore.setState({
+      result: {
+        harnesses: [],
+        items: [installed(place)],
+        missingProjects: [],
+        warnings: [],
+      } as never,
+    });
+    joinAnswered();
+    roomIs(AT_MINIMUM_WINDOW);
+    const host = mount(<InstalledView />);
+
+    const row = cells(host);
+    expect(row).toHaveLength(4);
+    expect(row[3].textContent, "Status is still the last cell").toContain(
+      "Active",
+    );
+    // Capped on screen, whole on the cell: the reader loses no part of
+    // which project this is.
+    expect(row[2].textContent).toContain("kendex-marketplace-integration");
+    expect(row[2].getAttribute("title")).toBe(LONG);
   });
 });

--- a/ui/src/components/library/installed-view.dom.test.tsx
+++ b/ui/src/components/library/installed-view.dom.test.tsx
@@ -12,6 +12,7 @@ import type {
 import { InstalledView } from "@/components/library/installed-view";
 import { openLibraryAt } from "@/components/library/use-filter-handoff";
 import {
+  FORKED_BADGE_LABEL,
   MISSING_FILES_BADGE_LABEL,
   PACKAGES_CHECK_FAILED_TITLE,
   PACKAGES_UNCONFIRMED_TITLE,
@@ -1073,5 +1074,64 @@ describe("the columns a narrow Library table keeps", () => {
     // which project this is.
     expect(row[2].textContent).toContain("kendex-marketplace-integration");
     expect(row[2].getAttribute("title")).toBe(LONG);
+  });
+
+  // Every Badge is shrink-0 and whitespace-nowrap, so a strip of them that
+  // cannot wrap set the name column's min-content width, which beats the
+  // cell's max-width under an automatic table layout. A fork badge names
+  // its place, and `placeName` falls back to a whole root where two places
+  // end alike, so two of those made the column as wide as they pleased.
+  it("keeps the row to its columns when a package is forked in long places", () => {
+    const PLACES = [
+      "/work/kendex-marketplace-integration/apps/web",
+      "/home/me/experiments/kendex-marketplace-integration/apps/web",
+    ];
+    const forked = {
+      schema: 1,
+      install: {},
+      forks: { skill: { gh: { source: "local", "forked-at": "2026-01-01" } } },
+    };
+    useScanStore.setState({
+      result: {
+        harnesses: [],
+        items: PLACES.map((root) => installed({ scope: "project", root })),
+        missingProjects: [],
+        warnings: [],
+      } as never,
+    });
+    useEditorStore.setState({
+      saved: Object.fromEntries(PLACES.map((root) => [root, forked as never])),
+    });
+    joinAnswered(
+      PLACES.map((root) => ({
+        scope: { scope: "project", root },
+        kind: "skill" as const,
+        name: "gh",
+        harness: "claude" as const,
+        at: installed({ scope: "project", root }).path,
+        origin: { origin: "own" as const, forkedFrom: null, source: "local" },
+        summary: null,
+        package: { kind: "skill" as const, name: "gh" },
+      })) as never,
+    );
+    roomIs(AT_MINIMUM_WINDOW);
+    const host = mount(<InstalledView />);
+
+    const row = cells(host);
+    // Two badges, each naming a place long enough that the pair used to
+    // set the column's width on their own.
+    const badges = [...row[0].querySelectorAll("button")].filter((b) =>
+      (b.textContent ?? "").startsWith(FORKED_BADGE_LABEL),
+    );
+    expect(badges).toHaveLength(2);
+    // Clipped by CSS, never by the string: what a screen reader reads is
+    // still the whole place.
+    for (const badge of badges)
+      expect(badge.textContent).toContain("kendex-marketplace-integration");
+
+    expect(row).toHaveLength(4);
+    expect(row[3].textContent, "Status is still the last cell").toContain(
+      "Active",
+    );
   });
 });

--- a/ui/src/components/library/installed-view.dom.test.tsx
+++ b/ui/src/components/library/installed-view.dom.test.tsx
@@ -15,6 +15,7 @@ import {
   MISSING_FILES_BADGE_LABEL,
   PACKAGES_CHECK_FAILED_TITLE,
   PACKAGES_UNCONFIRMED_TITLE,
+  TAGS_ROW_LABEL,
   TRY_AGAIN_LABEL,
 } from "@/lib/copy";
 import { addPackagesTo, nothingInstalledIn } from "@/lib/copy-install";
@@ -33,7 +34,7 @@ import { useProvenanceStore } from "@/stores/provenance";
 import { useScanStore } from "@/stores/scan";
 import { useSettingsStore } from "@/stores/settings";
 import { useUpdatesStore } from "@/stores/updates";
-import { mount } from "@/test/dom";
+import { mount, roomIs } from "@/test/dom";
 import { joinAnswered } from "@/test/identity-join";
 import { observed } from "@/test/observed";
 
@@ -969,5 +970,62 @@ describe("the Library while the identity read has not answered", () => {
     expect(rows(host)).toBe(0);
     expect(host.textContent).toContain("no lock");
     expect(host.textContent).toContain("—");
+  });
+});
+
+// The table's room is the page's, and the Library draws eight columns: at
+// the 900x600 minimum window kendex opens, all eight used to run off the
+// right edge, taking the health dot with them — so the reader at the
+// supported minimum could not see which package needed attention.
+describe("the columns a narrow Library table keeps", () => {
+  /** The room the table has at the 900px minimum window: the window less
+   *  the sidebar and its border (`w-56` plus `border-r`, `sidebar.tsx`,
+   *  which carries no responsive variant), the page gutters (`PAGE_GUTTER`
+   *  is `px-5 md:px-8 2xl:px-12`, and a 900px viewport is past Tailwind's
+   *  768px `md`, so `px-8`) and the scroller's reserved scrollbar lane
+   *  (`pr-2`). */
+  const AT_MINIMUM_WINDOW = 900 - 225 - 64 - 8;
+
+  const heads = (host: HTMLElement): string[] =>
+    [...host.querySelectorAll("thead th")].map(
+      (cell) => cell.textContent?.trim() ?? "",
+    );
+
+  beforeEach(() => {
+    vi.spyOn(useEditorStore.getState(), "loadAll").mockResolvedValue();
+    useEditorStore.setState({ saved: {} });
+    useUpdatesStore.setState({ rows: [], read: READ_LANDED });
+    useScanStore.setState({
+      result: {
+        harnesses: [],
+        items: [installed(VG)],
+        missingProjects: [],
+        warnings: [],
+      } as never,
+    });
+    joinAnswered();
+    useLibraryViewStore.setState({ ...NO_FILTERS });
+    useNavStore.setState({ libraryScope: "all", search: "" });
+  });
+
+  it("keeps Status at the minimum window and every column at a wide one", () => {
+    roomIs(AT_MINIMUM_WINDOW);
+    const narrow = mount(<InstalledView />);
+    expect(heads(narrow)).toEqual(["Name", "Type", "Where", "Status"]);
+    // The column is on screen, and so is the row's own reading of it.
+    expect(narrow.querySelector("tbody tr")?.textContent).toContain("Active");
+
+    roomIs(1400);
+    const wide = mount(<InstalledView />);
+    expect(heads(wide)).toEqual([
+      "Name",
+      "Type",
+      TAGS_ROW_LABEL,
+      "Harnesses",
+      "Where",
+      "From",
+      "Updated",
+      "Status",
+    ]);
   });
 });

--- a/ui/src/components/library/installed-view.tsx
+++ b/ui/src/components/library/installed-view.tsx
@@ -85,10 +85,17 @@ const DECLARED: InstalledColumns = {
 // toward its content: the harness chips stack to a second line and the row
 // grows. That is a squashed table rather than a cut one, but it is not a
 // designed width, so a column goes rather than shrinks. The kept sum is
-// what the columns below cost inside the room a 900px window leaves this
-// table — the narrowest window kendex opens, less the sidebar and its
-// border, the page gutters `PAGE_GUTTER` draws at that viewport, and the
-// scroller's reserved scrollbar lane.
+// sized against the room a 900px window leaves this table — the narrowest
+// window kendex opens, less the sidebar and its border, the page gutters
+// `PAGE_GUTTER` draws at that viewport, the scroller's `pr-2`, and the
+// lane `[scrollbar-gutter:stable]` reserves beside it. That last term is
+// the engine's, zero where scrollbars overlay and about 15px where they
+// take their own column, so the room is 603 or 588 rather than one number.
+// The kept sum sits between them, which costs nothing: only the name
+// column carries a ceiling, and a ceiling has no floor under it, so at the
+// tighter figure the name gives back the few pixels and the other three
+// are drawn as declared. No column changes hands across that range either
+// — the next rung up is 752, where the harnesses come back.
 const NAME_ROOM = 288; // `max-w-72` on the name cell
 
 /** How many columns are drawn at every width. Name, Type, Where and Status
@@ -104,8 +111,11 @@ const KEPT_COLUMNS = 4;
  *  The tools a package is installed for are the first back, because the row
  *  says that nowhere else. The tags are the last, because the filter bar
  *  above the table asks the same question. Nothing that goes is out of
- *  reach: each of these four has its own filter above the table, and the
- *  row's own page lists every one of them for that package. */
+ *  reach: the harness, source and tag facets on that filter bar reach three
+ *  of them, and the package's own page carries all four — the date and the
+ *  shared-files badge, which the harness cell draws beside its chips, rest
+ *  on that page alone, since the bar's Files facet asks what a person
+ *  edited on disk rather than when the package last changed. */
 const BUDGET: ColumnBudget<keyof InstalledColumns> = {
   kept: NAME_ROOM + 112 + 112 + 80,
   optional: { harnesses: 160, from: 128, updated: 112, tags: 160 },

--- a/ui/src/components/library/installed-view.tsx
+++ b/ui/src/components/library/installed-view.tsx
@@ -1,6 +1,9 @@
 import { useEffect, useMemo, useRef } from "react";
 import type { ItemKind, Scope, Tag } from "@/bindings";
-import { InstalledRow } from "@/components/library/installed-row";
+import {
+  type InstalledColumns,
+  InstalledRow,
+} from "@/components/library/installed-row";
 import { InstalledSkeleton } from "@/components/library/installed-skeleton";
 import { LibraryFilters } from "@/components/library/library-filters";
 import { TableEmptyRow } from "@/components/library/table-empty";
@@ -42,6 +45,7 @@ import {
   useSummaryIndex,
 } from "@/lib/package-identity";
 import { everyPlace, scopeKey } from "@/lib/scope";
+import { afforded, type ColumnBudget, useRoom } from "@/lib/table-room";
 import { cn } from "@/lib/utils";
 import { useEditorStore } from "@/stores/editor";
 import {
@@ -60,6 +64,53 @@ import {
 import { useScanStore } from "@/stores/scan";
 import { useSettingsStore } from "@/stores/settings";
 import { projectsOf } from "@/stores/settings-projects";
+
+/** Every optional column this table has to draw. Unlike the marketplace
+ *  table, whose pages declare different sets, the Library's list is one
+ *  page and always asks for all four. */
+const DECLARED: InstalledColumns = {
+  tags: true,
+  harnesses: true,
+  from: true,
+  updated: true,
+};
+
+// What each column costs the table: the width its own header declares,
+// which is the whole of it — these widths are border-box, so the cell's
+// padding is already inside them. Name declares none, taking what is left;
+// what it costs is the ceiling its cell carries, which is also the width
+// at which a package name and the summary under it read in full.
+//
+// Below the kept sum the table still lays out, by squeezing every column
+// toward its content: the harness chips stack to a second line and the row
+// grows. That is a squashed table rather than a cut one, but it is not a
+// designed width, so a column goes rather than shrinks. The kept sum is
+// what the columns below cost inside the room a 900px window leaves this
+// table — the narrowest window kendex opens, less the sidebar and its
+// border, the page gutters `PAGE_GUTTER` draws at that viewport, and the
+// scroller's reserved scrollbar lane.
+const NAME_ROOM = 288; // `max-w-72` on the name cell
+
+/** How many columns are drawn at every width. Name, Type, Where and Status
+ *  are what a reader needs to tell one row from another and decide about
+ *  it: what the package is called, what kind of thing it is, which place
+ *  holds it — the list spans every place on the machine, so two rows of one
+ *  package are told apart by nothing else — and whether it is working. */
+const KEPT_COLUMNS = 4;
+
+/** What the kept columns cost, and what each of the rest costs against
+ *  what is left over.
+ *
+ *  The tools a package is installed for are the first back, because the row
+ *  says that nowhere else. The tags are the last, because the filter bar
+ *  above the table asks the same question. Nothing that goes is out of
+ *  reach: each of these four has its own filter above the table, and the
+ *  row's own page lists every one of them for that package. */
+const BUDGET: ColumnBudget<keyof InstalledColumns> = {
+  kept: NAME_ROOM + 112 + 112 + 80,
+  optional: { harnesses: 160, from: 128, updated: 112, tags: 160 },
+  order: ["harnesses", "from", "updated", "tags"],
+};
 
 /** "Installed": everything on this machine, filterable. A row opens the
  *  package's own page; the filters and scroll position live in a store so
@@ -119,6 +170,12 @@ export function InstalledView() {
   const setSearch = useNavStore((s) => s.setSearch);
   const projects = scopeChoices(result, scope);
   const scroller = useRef<HTMLDivElement | null>(null);
+  const roomRef = useRef<HTMLDivElement>(null);
+  const room = useRoom(roomRef);
+  const columns = useMemo(() => afforded(room, DECLARED, BUDGET), [room]);
+  // What the empty row has to span, and the width the placeholder rows are
+  // drawn at: the columns on screen, not the ones the table could draw.
+  const drawn = KEPT_COLUMNS + Object.values(columns).filter(Boolean).length;
   // Every scope's manifest, so a row can say whether you have changed the
   // package wherever it is installed — not only in the scope last edited.
   const loadAll = useEditorStore((s) => s.loadAll);
@@ -319,96 +376,112 @@ export function InstalledView() {
             ref={scroller}
             className="min-w-0 flex-1 overflow-y-auto pr-2 [scrollbar-gutter:stable]"
           >
-            <Table>
-              <TableHeader>
-                <TableRow>
-                  <TableHead>Name</TableHead>
-                  <TableHead>Type</TableHead>
-                  <TableHead>{TAGS_ROW_LABEL}</TableHead>
-                  <TableHead>Harnesses</TableHead>
-                  <TableHead>Where</TableHead>
-                  <TableHead>From</TableHead>
-                  <TableHead className="text-right">Updated</TableHead>
-                  <TableHead>Status</TableHead>
-                </TableRow>
-              </TableHeader>
-              <TableBody>
-                {groups.map((group) => {
-                  const primary = group.installations[0];
-                  // The origin and the place that recorded it, read as one
-                  // row: a marketplace source is an alias declared at a
-                  // place, so pairing this row's alias with another place's
-                  // scope can address a subscription that exists at neither.
-                  const record = provenanceFor(
-                    provenance,
-                    groupRef(group),
-                    groupScopes(group),
-                  );
-                  const origin = record?.origin ?? null;
-                  // The pair a marketplace is addressed by, taken from the
-                  // one row: the alias, and the place that declared it.
-                  const from =
-                    record && record.origin.origin === "marketplace"
-                      ? { scope: record.scope, source: record.origin.source }
-                      : null;
-                  return (
-                    <InstalledRow
-                      key={group.key}
-                      group={group}
-                      origin={origin}
-                      forkedIn={standingsFor(group)
-                        .filter((s) => s.why === "forked")
-                        .map((s) => s.scope)}
-                      outOfDate={outOfDateAnywhere?.(group) ?? false}
-                      missingIn={missingIn?.(group) ?? []}
-                      onOpen={(scope) => {
-                        const where = scope ?? primary?.scope;
-                        if (!where) return;
-                        goToPackage({
-                          ...groupRef(group),
-                          scope: where,
-                        });
-                      }}
-                      onOpenHarness={(harness) => narrowTo({ harness })}
-                      onOpenPlace={(where) =>
-                        narrowTo({ scope: selectionOf(where) })
-                      }
-                      // Only a marketplace has a page to open: a package
-                      // the reader wrote, and one nothing manages, name
-                      // none. The subscription is addressed with the same
-                      // row's own scope, which is the place that declared
-                      // the alias.
-                      onOpenFrom={
-                        from
-                          ? () =>
-                              goToMarketplace(
-                                subscription(from.scope, from.source),
-                              )
-                          : undefined
+            {/* The room the table has is the room the page gives it, which
+                no column it draws can change: this block fills the
+                scroller's content box whatever the table inside it does,
+                so measuring it cannot chase itself. */}
+            <div ref={roomRef}>
+              <Table>
+                <TableHeader>
+                  <TableRow>
+                    <TableHead>Name</TableHead>
+                    <TableHead className="w-28">Type</TableHead>
+                    {columns.tags ? (
+                      <TableHead className="w-40">{TAGS_ROW_LABEL}</TableHead>
+                    ) : null}
+                    {columns.harnesses ? (
+                      <TableHead className="w-40">Harnesses</TableHead>
+                    ) : null}
+                    <TableHead className="w-28">Where</TableHead>
+                    {columns.from ? (
+                      <TableHead className="w-32">From</TableHead>
+                    ) : null}
+                    {columns.updated ? (
+                      <TableHead className="w-28 text-right">Updated</TableHead>
+                    ) : null}
+                    <TableHead className="w-20">Status</TableHead>
+                  </TableRow>
+                </TableHeader>
+                <TableBody>
+                  {groups.map((group) => {
+                    const primary = group.installations[0];
+                    // The origin and the place that recorded it, read as one
+                    // row: a marketplace source is an alias declared at a
+                    // place, so pairing this row's alias with another place's
+                    // scope can address a subscription that exists at neither.
+                    const record = provenanceFor(
+                      provenance,
+                      groupRef(group),
+                      groupScopes(group),
+                    );
+                    const origin = record?.origin ?? null;
+                    // The pair a marketplace is addressed by, taken from the
+                    // one row: the alias, and the place that declared it.
+                    const from =
+                      record && record.origin.origin === "marketplace"
+                        ? { scope: record.scope, source: record.origin.source }
+                        : null;
+                    return (
+                      <InstalledRow
+                        key={group.key}
+                        group={group}
+                        columns={columns}
+                        origin={origin}
+                        forkedIn={standingsFor(group)
+                          .filter((s) => s.why === "forked")
+                          .map((s) => s.scope)}
+                        outOfDate={outOfDateAnywhere?.(group) ?? false}
+                        missingIn={missingIn?.(group) ?? []}
+                        onOpen={(scope) => {
+                          const where = scope ?? primary?.scope;
+                          if (!where) return;
+                          goToPackage({
+                            ...groupRef(group),
+                            scope: where,
+                          });
+                        }}
+                        onOpenHarness={(harness) => narrowTo({ harness })}
+                        onOpenPlace={(where) =>
+                          narrowTo({ scope: selectionOf(where) })
+                        }
+                        // Only a marketplace has a page to open: a package
+                        // the reader wrote, and one nothing manages, name
+                        // none. The subscription is addressed with the same
+                        // row's own scope, which is the place that declared
+                        // the alias.
+                        onOpenFrom={
+                          from
+                            ? () =>
+                                goToMarketplace(
+                                  subscription(from.scope, from.source),
+                                )
+                            : undefined
+                        }
+                      />
+                    );
+                  })}
+                  {scanning ? <InstalledSkeleton columns={columns} /> : null}
+                  {!scanning &&
+                  !packagesUnreadable &&
+                  !packagesStale &&
+                  groups.length === 0 ? (
+                    <TableEmptyRow
+                      span={drawn}
+                      hasAnyItems={hasAnyItems}
+                      place={placeName}
+                      onClearFilters={clearFilters}
+                      onBrowse={() => goToMarketplaces()}
+                      // Browsing on this place's behalf, so the guided
+                      // install opens on it rather than asking again where
+                      // the reader already said.
+                      onAddPackages={() =>
+                        onePlace && goToMarketplaces("packages", onePlace)
                       }
                     />
-                  );
-                })}
-                {scanning ? <InstalledSkeleton /> : null}
-                {!scanning &&
-                !packagesUnreadable &&
-                !packagesStale &&
-                groups.length === 0 ? (
-                  <TableEmptyRow
-                    hasAnyItems={hasAnyItems}
-                    place={placeName}
-                    onClearFilters={clearFilters}
-                    onBrowse={() => goToMarketplaces()}
-                    // Browsing on this place's behalf, so the guided
-                    // install opens on it rather than asking again where
-                    // the reader already said.
-                    onAddPackages={() =>
-                      onePlace && goToMarketplaces("packages", onePlace)
-                    }
-                  />
-                ) : null}
-              </TableBody>
-            </Table>
+                  ) : null}
+                </TableBody>
+              </Table>
+            </div>
           </div>
         </div>
       </div>

--- a/ui/src/components/library/table-empty.tsx
+++ b/ui/src/components/library/table-empty.tsx
@@ -15,12 +15,17 @@ import {
  *  filter is what is hiding the rows and clearing it is the way out. An
  *  empty library with no narrowing at all points at Marketplaces. */
 export function TableEmptyRow({
+  span,
   hasAnyItems,
   place,
   onClearFilters,
   onBrowse,
   onAddPackages,
 }: {
+  /** How many columns the table is drawing, which varies with its room —
+   *  a cell spanning more than the header has leaves the message off
+   *  centre and stretches the table past its own last column. */
+  span: number;
   hasAnyItems: boolean;
   /** The one place this table is narrowed to, and what it is called, where
    *  it is narrowed to one. Null for every wider view — including the
@@ -32,7 +37,7 @@ export function TableEmptyRow({
 }) {
   return (
     <TableRow>
-      <TableCell colSpan={8} className="py-10">
+      <TableCell colSpan={span} className="py-10">
         {place !== null ? (
           <div className="flex flex-col items-center gap-3 text-center">
             <div>

--- a/ui/src/components/marketplaces/packages-table.tsx
+++ b/ui/src/components/marketplaces/packages-table.tsx
@@ -1,11 +1,5 @@
 import { ArrowDown, ArrowUp } from "lucide-react";
-import {
-  type RefObject,
-  useLayoutEffect,
-  useMemo,
-  useRef,
-  useState,
-} from "react";
+import { useMemo, useRef, useState } from "react";
 import type { Catalog, Scope } from "@/bindings";
 import {
   type PackageColumns,
@@ -52,6 +46,7 @@ import {
   type PackageSort,
   type SortKey,
 } from "@/lib/package-order";
+import { afforded, type ColumnBudget, useRoom } from "@/lib/table-room";
 import { membersFor } from "@/lib/template-members";
 import { cn } from "@/lib/utils";
 import { type InstallSubject, useInstallFlow } from "@/stores/install-flow";
@@ -81,78 +76,21 @@ import {
 const NAME_ROOM = 288; // `max-w-72` on the name cell
 const SELECT_ROOM = 32; // `w-8` on the tick cell, at every width
 const BOOKMARK_ROOM = 40; // `w-10` on the bookmark cell, at every width
-const KEPT_ROOM = SELECT_ROOM + NAME_ROOM + 112 + 80 + BOOKMARK_ROOM + 128; // tick, Name, Kind, Safety, Bookmark, Status
-const OPTIONAL_ROOM: Record<keyof PackageColumns, number> = {
-  marketplace: 160,
-  places: 160,
-  updated: 128,
-  tags: 192,
-};
 
-/** The order the columns come back in as the table's room grows, and in
- *  reverse the order it gives them up. Where a package came from and where
- *  it landed are the first back because they say something no other column
- *  does; the tags are the last because the filter above the table asks the
- *  same question and the row's own page answers it in full. */
-const RESTORE_ORDER: (keyof PackageColumns)[] = [
-  "marketplace",
-  "places",
-  "updated",
-  "tags",
-];
-
-const NONE: PackageColumns = {
-  tags: false,
-  marketplace: false,
-  updated: false,
-  places: false,
-};
-
-/** The columns `room` pixels can hold, out of the ones this table declares.
- *
- *  Name, Kind, Safety and Status are what a reader needs to tell one
+/** Name, Kind, Safety and Status are what a reader needs to tell one
  *  package from another and decide about it, so they stay at every width
- *  and the rest are spent against what is left over. A `room` of null is a
- *  width nothing has measured yet: the table opens on everything it
- *  declares and narrows once its own layout has answered. */
-function afforded(
-  room: number | null,
-  declared: PackageColumns,
-): PackageColumns {
-  if (room === null) return declared;
-  const shown = { ...NONE };
-  let used = KEPT_ROOM;
-  for (const column of RESTORE_ORDER) {
-    if (!declared[column]) continue;
-    used += OPTIONAL_ROOM[column];
-    if (used > room) break;
-    shown[column] = true;
-  }
-  return shown;
-}
-
-/** How wide the element the ref is on is, kept current as it changes.
- *  Null until a layout has answered: a zero width is an element nothing has
- *  laid out yet, not a table with no room to give a column. */
-function useRoom(ref: RefObject<HTMLElement | null>): number | null {
-  const [room, setRoom] = useState<number | null>(null);
-  useLayoutEffect(() => {
-    const element = ref.current;
-    if (!element) return;
-    // Read once here, before the browser paints. A ResizeObserver reports
-    // even its first observation on a later task, so left to it alone the
-    // table draws every column once at whatever width it has — which at a
-    // narrow one is the cut this fixes, on screen for a frame.
-    const measured = (width: number) => setRoom(width > 0 ? width : null);
-    measured(element.getBoundingClientRect().width);
-    const observer = new ResizeObserver((entries) => {
-      measured(entries[0]?.contentRect.width ?? 0);
-    });
-    observer.observe(element);
-    return () => observer.disconnect();
-  }, [ref]);
-  return room;
-}
+ *  and the rest are spent against what is left over.
+ *
+ *  Where a package came from and where it landed are the first back
+ *  because they say something no other column does; the tags are the last
+ *  because the filter above the table asks the same question and the row's
+ *  own page answers it in full. */
+const BUDGET: ColumnBudget<keyof PackageColumns> = {
+  // tick, Name, Kind, Safety, Bookmark, Status
+  kept: SELECT_ROOM + NAME_ROOM + 112 + 80 + BOOKMARK_ROOM + 128,
+  optional: { marketplace: 160, places: 160, updated: 128, tags: 192 },
+  order: ["marketplace", "places", "updated", "tags"],
+};
 
 /** A column header that re-sorts the table. Clicking the column already
  *  sorted turns it around; clicking another takes it over, ascending. The
@@ -255,12 +193,16 @@ export function PackagesTable({
   const room = useRoom(roomRef);
   const columns = useMemo(
     () =>
-      afforded(room, {
-        tags: true,
-        updated: true,
-        marketplace: showMarketplace,
-        places: showPlaces,
-      }),
+      afforded(
+        room,
+        {
+          tags: true,
+          updated: true,
+          marketplace: showMarketplace,
+          places: showPlaces,
+        },
+        BUDGET,
+      ),
     [room, showMarketplace, showPlaces],
   );
   // A column that is not on screen carries no control the reader can see or

--- a/ui/src/lib/table-room.ts
+++ b/ui/src/lib/table-room.ts
@@ -1,0 +1,67 @@
+import { type RefObject, useLayoutEffect, useState } from "react";
+
+/** What a table's optional columns cost it, in the pixels its own cells
+ *  declare. Every table writes its own: the widths are the classes that
+ *  table's headers carry, and the order is a judgement about that table's
+ *  reader. Only the arithmetic below is shared. */
+export interface ColumnBudget<Column extends string> {
+  /** What the columns drawn at every width cost together, including the
+   *  ceiling the name column's cell carries. */
+  kept: number;
+  /** What each optional column costs when it is drawn. */
+  optional: Record<Column, number>;
+  /** The order the columns come back in as the table's room grows, and in
+   *  reverse the order it gives them up. */
+  order: readonly Column[];
+}
+
+/** The columns `room` pixels can hold, out of the ones a table declares.
+ *
+ *  The columns a reader needs to tell one row from another and decide about
+ *  it are the budget's `kept` sum: they stay at every width, and the rest
+ *  are spent against what is left over. A `room` of null is a width nothing
+ *  has measured yet: the table opens on everything it declares and narrows
+ *  once its own layout has answered. */
+export function afforded<Column extends string>(
+  room: number | null,
+  declared: Record<Column, boolean>,
+  budget: ColumnBudget<Column>,
+): Record<Column, boolean> {
+  if (room === null) return declared;
+  const shown = {} as Record<Column, boolean>;
+  // Off first, from what the table declares rather than from the restore
+  // order: a column the order forgot would otherwise come back as
+  // undefined, which every reader of the result takes for off silently.
+  for (const column of Object.keys(declared) as Column[]) shown[column] = false;
+  let used = budget.kept;
+  for (const column of budget.order) {
+    if (!declared[column]) continue;
+    used += budget.optional[column];
+    if (used > room) break;
+    shown[column] = true;
+  }
+  return shown;
+}
+
+/** How wide the element the ref is on is, kept current as it changes.
+ *  Null until a layout has answered: a zero width is an element nothing has
+ *  laid out yet, not a table with no room to give a column. */
+export function useRoom(ref: RefObject<HTMLElement | null>): number | null {
+  const [room, setRoom] = useState<number | null>(null);
+  useLayoutEffect(() => {
+    const element = ref.current;
+    if (!element) return;
+    // Read once here, before the browser paints. A ResizeObserver reports
+    // even its first observation on a later task, so left to it alone the
+    // table draws every column once at whatever width it has — which at a
+    // narrow one is the cut this fixes, on screen for a frame.
+    const measured = (width: number) => setRoom(width > 0 ? width : null);
+    measured(element.getBoundingClientRect().width);
+    const observer = new ResizeObserver((entries) => {
+      measured(entries[0]?.contentRect.width ?? 0);
+    });
+    observer.observe(element);
+    return () => observer.disconnect();
+  }, [ref]);
+  return room;
+}


### PR DESCRIPTION
## What this fixes

The Library's Installed table drew all eight of its columns at every width. At the 900x600
minimum window kendex opens (`crates/app/tauri.conf.json:25-26`), Updated and Status ran off
the right edge, so a reader at the supported minimum could not see which package needed
attention without widening the window.

The marketplace packages table already answered this with a column budget. That answer is now
one module both tables read: `ui/src/lib/table-room.ts` holds the budget arithmetic and the
measuring hook, generic over a table's own column keys. Each table keeps its own widths and
its own restore order; neither carries a copy of the mechanism, and there is no shim, alias or
re-export stub.

## Done when

> At 900x600 the Library's Installed table keeps Status visible and gives way on a lower-value
> column, through the same budget the marketplace table uses, lifted to `ui/src/lib/` rather
> than copied; a test at the minimum width sees Status and its inverse at a wide width sees
> every column.

| Half of the Done-when | Where it lands |
|---|---|
| Status visible at the minimum, a lower-value column gives way | `ui/src/components/library/installed-view.tsx` (`BUDGET`, conditional headers), `installed-row.tsx` (conditional cells) |
| Through the same budget, lifted to `ui/src/lib/` rather than copied | `ui/src/lib/table-room.ts`; `ui/src/components/marketplaces/packages-table.tsx` consumes it |
| A test at the minimum width, and its inverse at a wide width | `ui/src/components/library/installed-view.dom.test.tsx`, describe "the columns a narrow Library table keeps" |

The Library keeps Name, Type, Where and Status at every width. Where stays because the list
spans every place on the machine, so two rows of one package are told apart by nothing else.
Harnesses, From, Updated and tags give way, and come back in that order: the tools a package is
installed for are said nowhere else on the row, and the tags come back last because the filter
bar above the table asks the same question.

Two files follow the column count rather than a fixed eight: `table-empty.tsx` spans the
columns on screen, and `installed-skeleton.tsx` draws the columns the table draws. The skeleton
also gains a `From` placeholder it never had — on main it drew seven cells under an eight-cell
header.

## The issue's premise, verified

The issue named its cause with file and line at 8823ae24c. Every claim held against current
source, checked before any code was written: the 900x600 minimum, the eight unconditional
headers at `installed-view.tsx:325-332`, the Updated and Status cells at `installed-row.tsx:233`
and `:238-247`, the marketplace budget at `packages-table.tsx:118`, and a search of `ui/src`
confirming nothing under `ui/src/components/library/` used it. No correction was needed.

## The arithmetic, and one correction in flight

The room a 900px window leaves this table is the window less the sidebar and its border
(`w-56` + `border-r` = 225, no responsive variant), the page gutters, and the scroller's
padding.

An earlier revision of this branch put the gutters at 40px, reading `px-5` off `PAGE_GUTTER`.
`PAGE_GUTTER` is `px-5 md:px-8 2xl:px-12`, this repo overrides no Tailwind breakpoints, and a
900px viewport is past the 768px `md` — so the gutters are `px-8`, 64px. That made the room 603
rather than 627, and the kept sum was 608: five pixels wider than the window it was sized for,
with a test that passed only because it fed itself the generous figure. `Where` came down from
`w-32` to `w-28`, so the kept sum is 592.

Every budget figure equals the width its own header cell declares: Name 288 (`max-w-72`),
Type 112, Where 112, Status 80; harnesses 160, from 128, updated 112, tags 160. Only the name
cell declares a width in the row, so header and row cannot disagree.

## Scope deliberately left out

`ui/AGENTS.md` carries no bullet for the new shared module, though that file records exactly
this class of rule and the repo's doc-drift check flags it.

The file is 6141 bytes against a 6144-byte `*/AGENTS.md` ceiling, and the pre-commit chain
refuses any addition: `doc-limits FAIL: ui/AGENTS.md: 6417 bytes > 6144 bytes`. The tersest form
of the rule that still carries it is 165 bytes, so it is 162 over. Of the gate's own remedies,
raising the class or excluding the file weakens a guard for every `AGENTS.md` in every consumer,
and compressing an unrelated 895-byte rule about how a surface opens a thing puts a rewritten
rule in this diff that nothing in the Done-when asked for.

What the drift check asks is that each covered document still holds or is updated. Every bullet
in `ui/AGENTS.md` was confirmed to still hold, including the two nearest cases: the harness
bullet governs how a chip is drawn, not that its column is always drawn, and the
opens-that-thing bullet governs a drawn surface — when the Harnesses and From columns go their
routes go with them, but the row still opens the package page, which carries both. No
`--no-verify` was used at any point.

The ceiling itself is real and goes to the tracker separately: that file cannot take the next
rule it must carry.

## Validation

- UI suite on the branch: 201 files, 1484 tests, 0 failures. `tsc --noEmit` and `biome check`
  clean.
- Must-fail control: `afforded` forced to return `declared` unconditionally, the pre-fix
  behaviour. The new Library case fails with all eight headers against the expected four, and
  two marketplace cases fail alongside it. Restoring it returns the changed files' tests to
  green. Run by the author twice, before and after the gutter correction, and independently by
  the reviewer on a scratch copy: 3 of 42 failed, 39 passed.
- `tools/guard --full` on the final head.

## Review

`reviewer-correctness`: pass, no blockers. It re-derived all eight Library budget figures and
the marketplace table's ten from the cells that declare them, probed the lifted `afforded`
through vitest at six widths, and confirmed the lift leaves no copy behind and the marketplace
table's behaviour unchanged.

Its two suggestions are applied in this PR, both comment corrections:

1. The room derivation subtracts `pr-2`, the scroller's 8px padding, but not the lane
   `[scrollbar-gutter:stable]` reserves on the same element — measured at 15px in Chromium, the
   engine Windows WebView2 runs. The real room there is 588, not 603, so on that engine the
   592 kept sum sits 4px into the squashed state the comment says the design avoids. The test
   constant now takes the tighter figure, 588, and both comments name the range and its cause.
   No column is lost by it: `afforded` never drops a kept column, so 588 and 603 afford the
   same four, Status stays on screen on every engine, and the name cell's 288 is a ceiling
   with no floor, rendering at 284.
2. The comment claimed each of the four droppable columns has its own filter above the table.
   `Updated` has none — `library-filters.tsx` offers Type, Tags, Harness, From and Files, and
   Files is the `edited` facet, a different fact from the `group.modifiedAt` the column shows.
   The shared-files badge travels with the harnesses column and has no filter either. Both stay
   reachable on the package's own page, so the cut is unaffected; the sentence is narrowed to
   the three columns that do have a facet.

External cross-model review was attempted and failed: `codex exited with code 1`, the usage
limit signature. It is advisory and does not substitute for a pass.

## Restacked onto KEN-1349

This branch was restacked after KEN-1349 (91d5ae1c6) landed on the same Library files. The one
conflict, in `installed-view.tsx`, was composed from main's side with the column budget
re-applied on top, rather than taking either side whole — our side predated KEN-1349's
`missingIn` destructure and its `missingIn={missingIn?.(group) ?? []}` prop, and taking it
would have silently reverted them.

The files git merged cleanly were read rather than trusted. `installed-row.tsx` carries both
the `columns` prop with its four conditional cells and KEN-1349's `missingIn` with its warning
badge; that badge sits in the Name cell, a kept column, so the budget never takes it off screen
at any width. Both describe blocks survive in `installed-view.dom.test.tsx`. Every declared
width still equals its budget figure — KEN-1349 touched no cell width.

Library, home and packages-table suites at the restacked head: 7 files, 72 tests, 0 failures.

Closes KEN-1348

https://claude.ai/code/session_01AajTzYaxNvxDrTkE8JGnb7
