### PR TITLE
fix(KEN-1353): Home's edited row promises remedies it cannot judge

### DIFF
--- a/changelog.d/fixed/1353-edited-row-remedies.md
+++ b/changelog.d/fixed/1353-edited-row-remedies.md
@@ -1,1 +1,1 @@
-- Stop Home's edited-packages row from promising to keep or discard the edits; the package's own page names what it can do for that package.
+- Stop Home's edited-packages row from promising to keep or discard the edits; those choices belong to the package's own page.

--- a/changelog.d/fixed/1353-edited-row-remedies.md
+++ b/changelog.d/fixed/1353-edited-row-remedies.md
@@ -1,0 +1,1 @@
+- Stop Home's edited-packages row from promising to keep or discard the edits; the package's own page names what it can do for that package.

--- a/ui/src/components/home/attention-rows.test.ts
+++ b/ui/src/components/home/attention-rows.test.ts
@@ -76,8 +76,9 @@ const row = (rows: ReturnType<typeof attentionRows>, key: string) => {
   return found as NonNullable<typeof found>;
 };
 
-// The row names the packages and where, says what "edited" is and what
-// the two ways out are, and its link lands on those packages alone.
+// The row names the packages and where, says what "edited" is and that
+// updates are paused, and its link lands on those packages alone. The
+// remedies belong to the package page, not to this row.
 describe("the edited packages row", () => {
   it("names each package by place and lands on the edited packages only", () => {
     const onEditedPackages = vi.fn();
@@ -100,7 +101,8 @@ describe("the edited packages row", () => {
       "commit-guards, second-opinion and worktree in hyprtrade; gh in vg.",
     );
     expect(found.detail).toContain("no longer matches its source");
-    expect(found.detail).toContain("Keep each as your own copy, or discard");
+    expect(found.detail).toContain("updates are paused there");
+    expect(found.detail).not.toMatch(/own copy|discard/i);
     expect(found.action?.label).toBe(EDITED_ATTENTION_ACTION);
     found.action?.onClick();
     expect(onEditedPackages).toHaveBeenCalledTimes(1);

--- a/ui/src/lib/copy.ts
+++ b/ui/src/lib/copy.ts
@@ -248,8 +248,9 @@ export const FORK_ERROR_TITLE = "Couldn't keep the edits";
 export const forkedToastLabel = (name: string): string =>
   `${name} is yours now — updates are paused`;
 // Home's row for installs whose files no longer match what kendex wrote:
-// which packages, where, what that means, and the two ways out. The row
-// never says who edited them — a commit in the project's own repository
+// which packages, where, and what that means. The remedies are named on
+// the package's own page, where each package's own answer is known. The
+// row never says who edited them — a commit in the project's own repository
 // changes the files the same as a hand does.
 export const editedAttentionTitle = (count: number): string =>
   count === 1
@@ -257,7 +258,7 @@ export const editedAttentionTitle = (count: number): string =>
     : `${count} installed packages were edited on disk`;
 /** `named` is the packages by place: "gh in vg; dev and orch in hyprtrade". */
 export const editedAttentionDetail = (named: string): string =>
-  `${named}. A file kendex installed no longer matches its source, so updates are paused there. Keep each as your own copy, or discard the edits.`;
+  `${named}. A file kendex installed no longer matches its source, so updates are paused there.`;
 export const EDITED_ATTENTION_ACTION = "Library";
 /** The Library's narrowing to those packages, in the filter strip. */
 export const EDITED_ON_DISK_LABEL = "Edited on disk";

--- a/ui/src/lib/copy.ts
+++ b/ui/src/lib/copy.ts
@@ -248,10 +248,10 @@ export const FORK_ERROR_TITLE = "Couldn't keep the edits";
 export const forkedToastLabel = (name: string): string =>
   `${name} is yours now — updates are paused`;
 // Home's row for installs whose files no longer match what kendex wrote:
-// which packages, where, and what that means. The remedies are named on
-// the package's own page, where each package's own answer is known. The
-// row never says who edited them — a commit in the project's own repository
-// changes the files the same as a hand does.
+// which packages, where, and what that means. The remedies belong to the
+// package's own page, which holds the per-package answers this row does
+// not. The row never says who edited them — a commit in the project's
+// own repository changes the files the same as a hand does.
 export const editedAttentionTitle = (count: number): string =>
   count === 1
     ? "1 installed package was edited on disk"


### PR DESCRIPTION
## Summary

- Home's edited-packages attention row promised "Keep each as your own copy, or discard the edits." for every row. The package page decides those two remedies per package from three separate inputs (`forkableHarness`, `canDiscard`, and which harnesses are edited; `ui/src/components/package/fork-notice.tsx:86,114`), and the Home row aggregates packages across places (`ui/src/components/home/attention-rows.ts:137`). For a package kind that cannot be forked, Home promised a Keep the page never offers.
- Drop the remedies sentence from `editedAttentionDetail` (`ui/src/lib/copy.ts`). Home keeps the paused-updates statement, and its action already lands on the page that holds the per-package answers.
- Update the two comment blocks that described the dropped sentence, and the row assertion in `ui/src/components/home/attention-rows.test.ts`.

## Why not conditioned copy

KEN-1353's original Done-when asked for Home copy conditioned on the same forkable answer the package page reads. The root adjustment on the issue (2026-09-11) rejects that, and this PR follows the adjustment.

Conditioning on one forkable answer would make the Home row a second judge of a question it does not hold the inputs for. The row covers a set of packages that can mix forkable and non-forkable kinds, and Keep and Discard turn on two different inputs, so a single sentence leaves the mixed case and the no-discard case unnamed. Dropping the sentence removes the false promise without adding a second judge.

## A related defect this PR does not fix

`crates/core/src/package/updates/eval.rs:233` sets `can_discard: false` on the removed-upstream path while `forkable_harness` is computed independently. `ui/src/components/package/fork-notice.tsx:82` renders `FORK_NOTICE_DETAIL` on `forkableHarness` alone, and that sentence says "or discard the edits and go back to the catalog's version" while `:114` withholds the Discard button. So a forkable package a person edited, whose source was then removed from its catalog, sees an offer to discard with no Discard button.

That is the same defect class as KEN-1353, one screen deeper. It is pre-existing, this diff neither introduces nor arms it, and it does not block this change from working, so it is not fixed here. It is raised with the repository owner as separate work.

The second commit (`c012d2bf7`) does correct what this PR itself said about that page: the comment above `editedAttentionTitle` and the changelog line asserted the page states each package's own answer. They now say only where the remedies belong.

## Completed Issues

- Closes KEN-1353 - Home promises Keep as your own copy for edits the package page can only discard

## Size

No allowance is stated on the issue. Measured at the first commit: 5 production lines added, 5 test lines added, 0 render-mirror lines. The second commit changes one comment and one changelog line.

## Validation

- `ui` vitest: the `attention-rows` suite (15 tests) and the full UI suite (202 files, 1504 tests) pass.
- Two must-fail controls, both red: restoring the remedies sentence reddens the `not.toMatch(/own copy|discard/i)` assertion; deleting the ", so updates are paused there" clause reddens the paused-updates assertion.
- `tsc --noEmit` exits 0.
- `env -u TMPDIR tools/guard --full` on each head, `add59af3c` and `c012d2bf7`: exit 0, no failure lines.
- `preflight --base origin/main`: clean, no findings.

## Review

One local correctness round: verdict pass, no blockers, no suggestions. It confirmed no stale reference to the dropped sentence remains in the repository, and that the new row assertion is non-vacuous.

https://claude.ai/code/session_01BX6AXXaMFhzUCc9umAfJ6v
