### PR TITLE
fix(KEN-1352): the offer's title credits pending files to the action

### DIFF
--- a/changelog.d/fixed/KEN-1352.md
+++ b/changelog.d/fixed/KEN-1352.md
@@ -1,0 +1,1 @@
+- Head the commit window with what is uncommitted in the project, the way the terminal does, instead of attributing every pending file to the action just run.

--- a/docs/design/post-refresh-commit-flow.md
+++ b/docs/design/post-refresh-commit-flow.md
@@ -479,7 +479,7 @@ Every value in the copy below is of the moment. `12`, `4`, `site`, `origin`, `ma
 
 | Element | Copy |
 | --- | --- |
-| Title | `kendex changed 12 files in site` |
+| Title | `12 files kendex wrote in site are not committed` |
 | Description | `These are the files kendex writes in this repository. Nothing is committed yet.` |
 | Section heading | `Files` |
 | Section heading, only where kendex changed a shared file | `Shared files` |

--- a/ui/src/lib/copy-commit-offer.test.ts
+++ b/ui/src/lib/copy-commit-offer.test.ts
@@ -55,9 +55,11 @@ const refused = (over: Partial<Refused> = {}): Refused => ({
 describe("the offer state", () => {
   it("prints the design's words for its example values", () => {
     expect(commitOfferTitle(FILES, PROJECT)).toBe(
-      "kendex changed 12 files in site",
+      "12 files kendex wrote in site are not committed",
     );
-    expect(commitOfferTitle(1, PROJECT)).toBe("kendex changed 1 file in site");
+    expect(commitOfferTitle(1, PROJECT)).toBe(
+      "1 file kendex wrote in site is not committed",
+    );
     expect(otherNote(OTHERS)).toBe(
       "4 other files in this repository changed. kendex does not commit these.",
     );

--- a/ui/src/lib/copy-commit-offer.ts
+++ b/ui/src/lib/copy-commit-offer.ts
@@ -12,7 +12,7 @@ import type { Refused, Why } from "@/bindings";
 const plural = (n: number) => (n === 1 ? "" : "s");
 
 export const commitOfferTitle = (files: number, project: string) =>
-  `kendex changed ${files} file${plural(files)} in ${project}`;
+  `${files} file${plural(files)} kendex wrote in ${project} ${files === 1 ? "is" : "are"} not committed`;
 
 export const COMMIT_OFFER_STANDING =
   "These are the files kendex writes in this repository. Nothing is committed yet.";


### PR DESCRIPTION
## What the reader saw

The commit window's title read `kendex changed 12 files in site`. That count is
`offer.files.length`: every kendex-owned changed file in the repository, not
what the action just run wrote. The verb credited the whole pending set to that
action, while the Which-changes note further down states the action's own count
separately. A reader who took one small action in a project with other kendex
changes waiting saw the title claim all of them.

## What changed

The title is reworded to the neutral head the terminal already prints at
`crates/cli/src/commands/commit_offer/block.rs:26`:

- `12 files kendex wrote in site are not committed`
- `1 file kendex wrote in site is not committed`

It attributes nothing to the action, so the two counts on screen never read as
one claim.

## Why not a two-count title

The issue description proposed a title carrying both numbers. Root's adjustment
comment on KEN-1352 rejects that and is followed here:

- `offer.actionPaths` is empty when a person opened the offer rather than an
  action (`ui/src/bindings.ts:3845`), so a title built on its length would say
  `0 files` there and need a branch.
- The Which-changes note at `ui/src/components/commit-offer-dialog.tsx:396`
  already states both counts exactly when they differ, which is the only case
  where there is anything to tell apart.

The neutral head needs no branch and duplicates nothing.

## Verification

The issue's cause was re-verified against current source before the fix, not
taken from the report. `offer.files.length` is never 0 at the call site:
`crates/core/src/commit_offer/paths.rs:115` returns `Ok(None)` for an empty
owned set and `crates/app/src/commit_offer.rs:322` builds no `ProjectOffer`
from it. The reworded string therefore needs no zero case.

The new wording matches the app's own `uncommittedNoBranch` and
`uncommittedInProgress` in the same file, so the three places that name
uncommitted kendex files now say it the same way, and it matches the terminal
copy that `ui/src/lib/copy-commit-offer.ts:1-4` says is reviewed beside it.

## Files

- `ui/src/lib/copy-commit-offer.ts` — `commitOfferTitle` reworded; signature and
  position unchanged.
- `ui/src/lib/copy-commit-offer.test.ts` — the copy row pins both the plural and
  the singular string, the control the Done-when names.
- `docs/design/post-refresh-commit-flow.md` — the design table row that prints
  the same string moves with the code.
- `changelog.d/fixed/KEN-1352.md` — new fragment.

## Checks

- `npm --prefix ui run test -- src/lib/copy-commit-offer.test.ts`: 6 passed.
- Must-fail control: reverting the function reddens the pinned row with
  `expected 'kendex changed 12 files in site' to be '12 files kendex wrote in
  site are not committed'`. A second control on a scratch copy reddened the
  singular row by forcing its branch to `are`.
- `env -u TMPDIR tools/guard --full` on `d809fbf4d`: exit 0, no failures.
- Local correctness review: pass, no blockers.

Closes KEN-1352

https://claude.ai/code/session_01CmRzHGFf8CBeYQwWF92tVR
