### PR TITLE
fix(KEN-1365): branch-size-check takes repo test paths [no-changelog]

### DIFF
--- a/.agents/skills/orch/README.md
+++ b/.agents/skills/orch/README.md
@@ -44,5 +44,6 @@ Non-secret settings go in committed `kendex.settings.toml` under `[env]`; secret
 | Review-gate settings | `REVIEW_GATE_MODE`, `PR_REVIEW_GATE`, `PR_REVIEW_CHECK`, `PR_REVIEW_WAIT_SECS`: [references/gates.md](references/gates.md) | |
 | Lane settings | `ORCH_LANE_DIRS`, `ORCH_LANE_ALIASES`, `ORCH_LANE_MAX_PCT`, `ORCH_TMUX_VERIFY_SECS`: `lanes --help`, `open-terminal --help` | |
 | `ORCH_SIZE_RENDER_ROOTS` | Render-mirror roots `branch-size-check` excludes when the render's source changed in the same diff | `.agents .claude .codex .pi` |
+| `ORCH_SIZE_TEST_PATHS` | Path globs `branch-size-check` counts as test lines in addition to its built-in test rule | empty |
 
 Maintainer notes and the test entry point: [DEVELOPMENT.md](DEVELOPMENT.md).

--- a/.agents/skills/orch/kendex.settings.toml.example
+++ b/.agents/skills/orch/kendex.settings.toml.example
@@ -85,6 +85,11 @@ ORCH_OVERSEER_LANES = "3"
 # of the count only when what remains after the root names a source changed
 # in the same diff; a render whose source did not change is counted.
 # ORCH_SIZE_RENDER_ROOTS = ".agents .claude .codex .pi"
+# Extra test-path globs, blank separated, added to the built-in test rule
+# (test/, tests/, __tests__/, tests.rs, *test_util.rs, *.test.*, *.spec.*).
+# A glob matches the whole repository-relative path; `*` spans `/` and every
+# character but `*` and `?` is literal. Empty, the built-in rule stands alone.
+# ORCH_SIZE_TEST_PATHS = "scripts/check-*.py"
 
 # Hours before an In Progress / In Review item counts as started-stale in
 # reconcile-work-items sweeps.

--- a/.agents/skills/orch/scripts/branch-size-check
+++ b/.agents/skills/orch/scripts/branch-size-check
@@ -22,9 +22,17 @@
 # against the base branch: a pure move costs nothing and a rewrite costs what
 # it adds. They are shown in three parts — production; test, a path under
 # test/, tests/ or __tests__/ or named tests.rs, *test_util.rs, *.test.* or
-# *.spec.*; render mirror, a path under ORCH_SIZE_RENDER_ROOTS whose source
-# changed in the same diff — and only the first two are judged. The split is
-# by path: a test module inside a source file counts with its file.
+# *.spec.*, or matching a glob in ORCH_SIZE_TEST_PATHS; render mirror, a path
+# under ORCH_SIZE_RENDER_ROOTS whose source changed in the same diff — and
+# only the first two are judged. The split is by path: a test module inside a
+# source file counts with its file.
+#
+# ORCH_SIZE_TEST_PATHS only adds to that rule, never takes from it. A glob
+# matches the whole repository-relative path, with `*` any run of characters
+# including `/`, `?` any single character, and everything else literal. Left
+# empty, or matching nothing, every line stays where the built-in rule put it,
+# which for a path that rule does not name is production and the stricter
+# allowance.
 #
 # The allowance is the issue's own `**Expected delta**` line and nothing else,
 # in one of two forms:
@@ -45,6 +53,8 @@
 #
 # ORCH_SIZE_RENDER_ROOTS   render-mirror roots, blank separated
 #                          (default ".agents .claude .codex .pi")
+# ORCH_SIZE_TEST_PATHS     extra test-path globs, blank separated, added to
+#                          the built-in test rule (default empty)
 
 set -euo pipefail
 
@@ -200,6 +210,7 @@ source "$SCRIPT_DIR/lib/kendex-env.sh"
 kendex_load_project_env "$REPO_ROOT"
 
 render_roots="${ORCH_SIZE_RENDER_ROOTS:-.agents .claude .codex .pi}"
+test_paths="${ORCH_SIZE_TEST_PATHS:-}"
 
 # --- The issue's own text is the one source of the allowance ----------------
 # A tracker that cannot be read leaves no allowance to judge by and no way to
@@ -243,7 +254,8 @@ if [[ -n "$delta_line" ]]; then
 fi
 
 # --- Measure ----------------------------------------------------------------
-if ! branch_size_classified "$worktree" "$SCRIPT_DIR/resolve-base-branch" HEAD "$render_roots"; then
+if ! branch_size_classified "$worktree" "$SCRIPT_DIR/resolve-base-branch" HEAD \
+  "$render_roots" "$test_paths"; then
   die measurement-failed "$@"
 fi
 production_lines="$BRANCH_SIZE_PRODUCTION"

--- a/.agents/skills/orch/scripts/lib/branch-growth.sh
+++ b/.agents/skills/orch/scripts/lib/branch-growth.sh
@@ -125,11 +125,16 @@ BRANCH_SIZE_MIRROR=""
 # everything else literal. The list only adds: empty, or matching nothing, it
 # leaves every line where the built-in rule put it, which for a path that rule
 # does not name is production and the stricter allowance.
+#
+# The globs reach awk through the environment, not a `-v` assignment: awk
+# processes escape sequences in a `-v` value before the program sees it, so a
+# backslash in a configured glob would be rewritten, and rewritten differently
+# by gawk and mawk. An ENVIRON entry arrives byte for byte.
 branch_size_classified() {
   local worktree="$1" base_resolver="$2" commit="$3" render_roots="$4" test_paths="$5"
   local numstat measured
   branch_size_numstat "$worktree" "$base_resolver" "$commit" numstat || return 1
-  if ! measured="$(awk -F '\t' -v roots="$render_roots" -v test_paths="$test_paths" '
+  if ! measured="$(BRANCH_GROWTH_TEST_PATHS="$test_paths" awk -F '\t' -v roots="$render_roots" '
     function new_path(p,   open_at, close_at, prefix, suffix, moved) {
       if (index(p, " => ") == 0) return p
       open_at = index(p, "{")
@@ -193,7 +198,7 @@ branch_size_classified() {
     }
     BEGIN {
       nroots = split(roots, root, " ")
-      npats = split(test_paths, pattern, " ")
+      npats = split(ENVIRON["BRANCH_GROWTH_TEST_PATHS"], pattern, " ")
       for (i = 1; i <= npats; i++) pattern[i] = glob_to_regex(pattern[i])
     }
     NF == 0 || ($1 == "-" && $2 == "-") { next }

--- a/.agents/skills/orch/scripts/lib/branch-growth.sh
+++ b/.agents/skills/orch/scripts/lib/branch-growth.sh
@@ -118,11 +118,18 @@ BRANCH_SIZE_MIRROR=""
 # render root. A render whose own source did not
 # change pairs with nothing and is measured in full, and so is a render-only
 # branch.
+#
+# $5 is the blank-separated list of extra test-path globs a repository adds to
+# the built-in test rule. A pattern matches the whole repository-relative path,
+# with `*` any run of characters including `/`, `?` any single character, and
+# everything else literal. The list only adds: empty, or matching nothing, it
+# leaves every line where the built-in rule put it, which for a path that rule
+# does not name is production and the stricter allowance.
 branch_size_classified() {
-  local worktree="$1" base_resolver="$2" commit="$3" render_roots="$4"
+  local worktree="$1" base_resolver="$2" commit="$3" render_roots="$4" test_paths="$5"
   local numstat measured
   branch_size_numstat "$worktree" "$base_resolver" "$commit" numstat || return 1
-  if ! measured="$(awk -F '\t' -v roots="$render_roots" '
+  if ! measured="$(awk -F '\t' -v roots="$render_roots" -v test_paths="$test_paths" '
     function new_path(p,   open_at, close_at, prefix, suffix, moved) {
       if (index(p, " => ") == 0) return p
       open_at = index(p, "{")
@@ -154,10 +161,26 @@ branch_size_classified() {
       for (i = 1; i <= nroots; i++) if (first == root[i]) return substr(p, length(first) + 2)
       return ""
     }
-    function is_test(p,   b) {
+    # A glob anchored over the whole path: only `*` and `?` are wild, and
+    # every other regex metacharacter is escaped, so the dot in check-*.py
+    # matches a dot and nothing else.
+    function glob_to_regex(g,   out, i, c) {
+      out = "^"
+      for (i = 1; i <= length(g); i++) {
+        c = substr(g, i, 1)
+        if (c == "*") out = out ".*"
+        else if (c == "?") out = out "."
+        else if (index("\\^$.[]|()+{}", c) > 0) out = out "\\" c
+        else out = out c
+      }
+      return out "$"
+    }
+    function is_test(p,   b, i) {
       if (p ~ /(^|\/)(test|tests|__tests__)\//) return 1
       b = base_name(p)
-      return (b == "tests.rs") || (b ~ /test_util\.rs$/) || (b ~ /\.(test|spec)\./)
+      if ((b == "tests.rs") || (b ~ /test_util\.rs$/) || (b ~ /\.(test|spec)\./)) return 1
+      for (i = 1; i <= npats; i++) if (p ~ pattern[i]) return 1
+      return 0
     }
     function pairs_with_source(rest,   rest_stem, s) {
       rest_stem = stem_path(rest)
@@ -168,7 +191,11 @@ branch_size_classified() {
       }
       return 0
     }
-    BEGIN { nroots = split(roots, root, " ") }
+    BEGIN {
+      nroots = split(roots, root, " ")
+      npats = split(test_paths, pattern, " ")
+      for (i = 1; i <= npats; i++) pattern[i] = glob_to_regex(pattern[i])
+    }
     NF == 0 || ($1 == "-" && $2 == "-") { next }
     $1 !~ /^[0-9]+$/ || $2 !~ /^[0-9]+$/ { failed = 1; next }
     {

--- a/.agents/skills/orch/tests/branch_size_check.sh
+++ b/.agents/skills/orch/tests/branch_size_check.sh
@@ -271,14 +271,25 @@ assert_eq "$("$STATE" --state-dir "$STATE_DIR" get KEN-SIZE '.pr.size_check.verd
 # so the setting is the only thing that can move its lines to the test count.
 mk 7 scripts/check-helper.py
 mk 3 scripts/check-helperXpy        # the glob's dot is literal, so not this
+mk 2 scripts/probe-a.sh             # one character where the glob's ? sits
+mk 4 scripts/probe-ab.sh            # two, so a ? read as * moves this one too
+mk 6 scripts/star-x.py              # what a backslash-stripped star would take
 commit_files repo-test-path
-capture declared_json run_check env ORCH_SIZE_TEST_PATHS='scripts/check-*.py' \
-  "$CHECK_BIN" --json
-assert_eq "$(jq -r '.production_lines, .test_lines' <<<"$declared_json" | paste -sd, -)" "53,57" \
-  "a declared test-path glob moves its own file alone, its dot matching a dot"
+capture declared_json run_check \
+  env ORCH_SIZE_TEST_PATHS='scripts/check-*.py scripts/probe-?.sh' "$CHECK_BIN" --json
+assert_eq "$(jq -r '.production_lines, .test_lines' <<<"$declared_json" | paste -sd, -)" "63,59" \
+  "a declared glob moves the paths it names alone, its dot matching a dot and its ? one character"
 capture undeclared_json run_check "$CHECK_BIN" --json
-assert_eq "$(jq -r '.production_lines, .test_lines' <<<"$undeclared_json" | paste -sd, -)" "60,50" \
+assert_eq "$(jq -r '.production_lines, .test_lines' <<<"$undeclared_json" | paste -sd, -)" "72,50" \
   "must-fail control: with the setting unset the same lines are production"
+# The globs reach the classifier through the environment, where awk performs no
+# escape processing on them. Carried by a -v assignment instead, gawk would
+# strip the backslash below and the bare star would take star-x.py, while mawk
+# would leave the same setting matching nothing.
+capture escaped_json run_check \
+  env ORCH_SIZE_TEST_PATHS='scripts/probe-a.sh scripts/star-\*.py' "$CHECK_BIN" --json
+assert_eq "$(jq -r '.production_lines, .test_lines' <<<"$escaped_json" | paste -sd, -)" "70,52" \
+  "a backslash arrives as itself, so a glob carrying one names a path with a backslash and moves none of these"
 
 printf '\npass: %d  fail: %d\n' "$PASS" "$FAIL"
 [[ "$FAIL" -eq 0 ]]

--- a/.agents/skills/orch/tests/branch_size_check.sh
+++ b/.agents/skills/orch/tests/branch_size_check.sh
@@ -77,10 +77,12 @@ write_issue() {
 mk() { mkdir -p "$(dirname "$WT/$2")"; seq 1 "$1" > "$WT/$2"; }
 commit_files() { git -C "$WT" add -A; git -C "$WT" commit -q -m "$1"; }
 
-# The one setting the check reads is pinned here: a value exported by whoever
-# runs the suite would otherwise decide its assertions.
+# Both settings the check reads are pinned here: a value exported by whoever
+# runs the suite would otherwise decide its assertions. A case that wants one
+# sets it back through its own `env` in the command it passes.
 run_check() {
-  env -u ORCH_SIZE_RENDER_ROOTS ORCH_STATE_DIR="$WT/tmp" "$@" --worktree "$WT" --issue KEN-SIZE
+  env -u ORCH_SIZE_RENDER_ROOTS -u ORCH_SIZE_TEST_PATHS ORCH_STATE_DIR="$WT/tmp" \
+    "$@" --worktree "$WT" --issue KEN-SIZE
 }
 # Every capture is guarded: a bare command substitution under errexit ends the
 # suite at that line, with no tally and every later assertion unrun.
@@ -263,6 +265,20 @@ set +e
 set -e
 assert_eq "$("$STATE" --state-dir "$STATE_DIR" get KEN-SIZE '.pr.size_check.verdict')" "pass" \
   "--state-dir decides which state is read and written, not the caller's directory"
+
+# --- ORCH_SIZE_TEST_PATHS adds to the built-in test rule --------------------
+# A suite the repository keeps at a production path: no built-in rule names it,
+# so the setting is the only thing that can move its lines to the test count.
+mk 7 scripts/check-helper.py
+mk 3 scripts/check-helperXpy        # the glob's dot is literal, so not this
+commit_files repo-test-path
+capture declared_json run_check env ORCH_SIZE_TEST_PATHS='scripts/check-*.py' \
+  "$CHECK_BIN" --json
+assert_eq "$(jq -r '.production_lines, .test_lines' <<<"$declared_json" | paste -sd, -)" "53,57" \
+  "a declared test-path glob moves its own file alone, its dot matching a dot"
+capture undeclared_json run_check "$CHECK_BIN" --json
+assert_eq "$(jq -r '.production_lines, .test_lines' <<<"$undeclared_json" | paste -sd, -)" "60,50" \
+  "must-fail control: with the setting unset the same lines are production"
 
 printf '\npass: %d  fail: %d\n' "$PASS" "$FAIL"
 [[ "$FAIL" -eq 0 ]]

--- a/.agents/skills/orch/tests/branch_size_check.sh
+++ b/.agents/skills/orch/tests/branch_size_check.sh
@@ -274,13 +274,15 @@ mk 3 scripts/check-helperXpy        # the glob's dot is literal, so not this
 mk 2 scripts/probe-a.sh             # one character where the glob's ? sits
 mk 4 scripts/probe-ab.sh            # two, so a ? read as * moves this one too
 mk 6 scripts/star-x.py              # what a backslash-stripped star would take
+mk 5 scripts/check-nested/deep.py   # only a star spanning a slash reaches this
+mk 8 vendor/scripts/probe-z.sh      # carries a glob, so only the anchors refuse it
 commit_files repo-test-path
 capture declared_json run_check \
   env ORCH_SIZE_TEST_PATHS='scripts/check-*.py scripts/probe-?.sh' "$CHECK_BIN" --json
-assert_eq "$(jq -r '.production_lines, .test_lines' <<<"$declared_json" | paste -sd, -)" "63,59" \
-  "a declared glob moves the paths it names alone, its dot matching a dot and its ? one character"
+assert_eq "$(jq -r '.production_lines, .test_lines' <<<"$declared_json" | paste -sd, -)" "71,64" \
+  "a declared glob moves the paths it names alone, its dot matching a dot, its ? one character, its star a slash, and its whole-path anchors refusing a path that merely carries it"
 capture undeclared_json run_check "$CHECK_BIN" --json
-assert_eq "$(jq -r '.production_lines, .test_lines' <<<"$undeclared_json" | paste -sd, -)" "72,50" \
+assert_eq "$(jq -r '.production_lines, .test_lines' <<<"$undeclared_json" | paste -sd, -)" "85,50" \
   "must-fail control: with the setting unset the same lines are production"
 # The globs reach the classifier through the environment, where awk performs no
 # escape processing on them. Carried by a -v assignment instead, gawk would
@@ -288,7 +290,7 @@ assert_eq "$(jq -r '.production_lines, .test_lines' <<<"$undeclared_json" | past
 # would leave the same setting matching nothing.
 capture escaped_json run_check \
   env ORCH_SIZE_TEST_PATHS='scripts/probe-a.sh scripts/star-\*.py' "$CHECK_BIN" --json
-assert_eq "$(jq -r '.production_lines, .test_lines' <<<"$escaped_json" | paste -sd, -)" "70,52" \
+assert_eq "$(jq -r '.production_lines, .test_lines' <<<"$escaped_json" | paste -sd, -)" "83,52" \
   "a backslash arrives as itself, so a glob carrying one names a path with a backslash and moves none of these"
 
 printf '\npass: %d  fail: %d\n' "$PASS" "$FAIL"

--- a/skills/orch/README.md
+++ b/skills/orch/README.md
@@ -44,5 +44,6 @@ Non-secret settings go in committed `kendex.settings.toml` under `[env]`; secret
 | Review-gate settings | `REVIEW_GATE_MODE`, `PR_REVIEW_GATE`, `PR_REVIEW_CHECK`, `PR_REVIEW_WAIT_SECS`: [references/gates.md](references/gates.md) | |
 | Lane settings | `ORCH_LANE_DIRS`, `ORCH_LANE_ALIASES`, `ORCH_LANE_MAX_PCT`, `ORCH_TMUX_VERIFY_SECS`: `lanes --help`, `open-terminal --help` | |
 | `ORCH_SIZE_RENDER_ROOTS` | Render-mirror roots `branch-size-check` excludes when the render's source changed in the same diff | `.agents .claude .codex .pi` |
+| `ORCH_SIZE_TEST_PATHS` | Path globs `branch-size-check` counts as test lines in addition to its built-in test rule | empty |
 
 Maintainer notes and the test entry point: [DEVELOPMENT.md](DEVELOPMENT.md).

--- a/skills/orch/kendex.settings.toml.example
+++ b/skills/orch/kendex.settings.toml.example
@@ -85,6 +85,11 @@ ORCH_OVERSEER_LANES = "3"
 # of the count only when what remains after the root names a source changed
 # in the same diff; a render whose source did not change is counted.
 # ORCH_SIZE_RENDER_ROOTS = ".agents .claude .codex .pi"
+# Extra test-path globs, blank separated, added to the built-in test rule
+# (test/, tests/, __tests__/, tests.rs, *test_util.rs, *.test.*, *.spec.*).
+# A glob matches the whole repository-relative path; `*` spans `/` and every
+# character but `*` and `?` is literal. Empty, the built-in rule stands alone.
+# ORCH_SIZE_TEST_PATHS = "scripts/check-*.py"
 
 # Hours before an In Progress / In Review item counts as started-stale in
 # reconcile-work-items sweeps.

--- a/skills/orch/scripts/branch-size-check
+++ b/skills/orch/scripts/branch-size-check
@@ -22,9 +22,17 @@
 # against the base branch: a pure move costs nothing and a rewrite costs what
 # it adds. They are shown in three parts — production; test, a path under
 # test/, tests/ or __tests__/ or named tests.rs, *test_util.rs, *.test.* or
-# *.spec.*; render mirror, a path under ORCH_SIZE_RENDER_ROOTS whose source
-# changed in the same diff — and only the first two are judged. The split is
-# by path: a test module inside a source file counts with its file.
+# *.spec.*, or matching a glob in ORCH_SIZE_TEST_PATHS; render mirror, a path
+# under ORCH_SIZE_RENDER_ROOTS whose source changed in the same diff — and
+# only the first two are judged. The split is by path: a test module inside a
+# source file counts with its file.
+#
+# ORCH_SIZE_TEST_PATHS only adds to that rule, never takes from it. A glob
+# matches the whole repository-relative path, with `*` any run of characters
+# including `/`, `?` any single character, and everything else literal. Left
+# empty, or matching nothing, every line stays where the built-in rule put it,
+# which for a path that rule does not name is production and the stricter
+# allowance.
 #
 # The allowance is the issue's own `**Expected delta**` line and nothing else,
 # in one of two forms:
@@ -45,6 +53,8 @@
 #
 # ORCH_SIZE_RENDER_ROOTS   render-mirror roots, blank separated
 #                          (default ".agents .claude .codex .pi")
+# ORCH_SIZE_TEST_PATHS     extra test-path globs, blank separated, added to
+#                          the built-in test rule (default empty)
 
 set -euo pipefail
 
@@ -200,6 +210,7 @@ source "$SCRIPT_DIR/lib/kendex-env.sh"
 kendex_load_project_env "$REPO_ROOT"
 
 render_roots="${ORCH_SIZE_RENDER_ROOTS:-.agents .claude .codex .pi}"
+test_paths="${ORCH_SIZE_TEST_PATHS:-}"
 
 # --- The issue's own text is the one source of the allowance ----------------
 # A tracker that cannot be read leaves no allowance to judge by and no way to
@@ -243,7 +254,8 @@ if [[ -n "$delta_line" ]]; then
 fi
 
 # --- Measure ----------------------------------------------------------------
-if ! branch_size_classified "$worktree" "$SCRIPT_DIR/resolve-base-branch" HEAD "$render_roots"; then
+if ! branch_size_classified "$worktree" "$SCRIPT_DIR/resolve-base-branch" HEAD \
+  "$render_roots" "$test_paths"; then
   die measurement-failed "$@"
 fi
 production_lines="$BRANCH_SIZE_PRODUCTION"

--- a/skills/orch/scripts/lib/branch-growth.sh
+++ b/skills/orch/scripts/lib/branch-growth.sh
@@ -125,11 +125,16 @@ BRANCH_SIZE_MIRROR=""
 # everything else literal. The list only adds: empty, or matching nothing, it
 # leaves every line where the built-in rule put it, which for a path that rule
 # does not name is production and the stricter allowance.
+#
+# The globs reach awk through the environment, not a `-v` assignment: awk
+# processes escape sequences in a `-v` value before the program sees it, so a
+# backslash in a configured glob would be rewritten, and rewritten differently
+# by gawk and mawk. An ENVIRON entry arrives byte for byte.
 branch_size_classified() {
   local worktree="$1" base_resolver="$2" commit="$3" render_roots="$4" test_paths="$5"
   local numstat measured
   branch_size_numstat "$worktree" "$base_resolver" "$commit" numstat || return 1
-  if ! measured="$(awk -F '\t' -v roots="$render_roots" -v test_paths="$test_paths" '
+  if ! measured="$(BRANCH_GROWTH_TEST_PATHS="$test_paths" awk -F '\t' -v roots="$render_roots" '
     function new_path(p,   open_at, close_at, prefix, suffix, moved) {
       if (index(p, " => ") == 0) return p
       open_at = index(p, "{")
@@ -193,7 +198,7 @@ branch_size_classified() {
     }
     BEGIN {
       nroots = split(roots, root, " ")
-      npats = split(test_paths, pattern, " ")
+      npats = split(ENVIRON["BRANCH_GROWTH_TEST_PATHS"], pattern, " ")
       for (i = 1; i <= npats; i++) pattern[i] = glob_to_regex(pattern[i])
     }
     NF == 0 || ($1 == "-" && $2 == "-") { next }

--- a/skills/orch/scripts/lib/branch-growth.sh
+++ b/skills/orch/scripts/lib/branch-growth.sh
@@ -118,11 +118,18 @@ BRANCH_SIZE_MIRROR=""
 # render root. A render whose own source did not
 # change pairs with nothing and is measured in full, and so is a render-only
 # branch.
+#
+# $5 is the blank-separated list of extra test-path globs a repository adds to
+# the built-in test rule. A pattern matches the whole repository-relative path,
+# with `*` any run of characters including `/`, `?` any single character, and
+# everything else literal. The list only adds: empty, or matching nothing, it
+# leaves every line where the built-in rule put it, which for a path that rule
+# does not name is production and the stricter allowance.
 branch_size_classified() {
-  local worktree="$1" base_resolver="$2" commit="$3" render_roots="$4"
+  local worktree="$1" base_resolver="$2" commit="$3" render_roots="$4" test_paths="$5"
   local numstat measured
   branch_size_numstat "$worktree" "$base_resolver" "$commit" numstat || return 1
-  if ! measured="$(awk -F '\t' -v roots="$render_roots" '
+  if ! measured="$(awk -F '\t' -v roots="$render_roots" -v test_paths="$test_paths" '
     function new_path(p,   open_at, close_at, prefix, suffix, moved) {
       if (index(p, " => ") == 0) return p
       open_at = index(p, "{")
@@ -154,10 +161,26 @@ branch_size_classified() {
       for (i = 1; i <= nroots; i++) if (first == root[i]) return substr(p, length(first) + 2)
       return ""
     }
-    function is_test(p,   b) {
+    # A glob anchored over the whole path: only `*` and `?` are wild, and
+    # every other regex metacharacter is escaped, so the dot in check-*.py
+    # matches a dot and nothing else.
+    function glob_to_regex(g,   out, i, c) {
+      out = "^"
+      for (i = 1; i <= length(g); i++) {
+        c = substr(g, i, 1)
+        if (c == "*") out = out ".*"
+        else if (c == "?") out = out "."
+        else if (index("\\^$.[]|()+{}", c) > 0) out = out "\\" c
+        else out = out c
+      }
+      return out "$"
+    }
+    function is_test(p,   b, i) {
       if (p ~ /(^|\/)(test|tests|__tests__)\//) return 1
       b = base_name(p)
-      return (b == "tests.rs") || (b ~ /test_util\.rs$/) || (b ~ /\.(test|spec)\./)
+      if ((b == "tests.rs") || (b ~ /test_util\.rs$/) || (b ~ /\.(test|spec)\./)) return 1
+      for (i = 1; i <= npats; i++) if (p ~ pattern[i]) return 1
+      return 0
     }
     function pairs_with_source(rest,   rest_stem, s) {
       rest_stem = stem_path(rest)
@@ -168,7 +191,11 @@ branch_size_classified() {
       }
       return 0
     }
-    BEGIN { nroots = split(roots, root, " ") }
+    BEGIN {
+      nroots = split(roots, root, " ")
+      npats = split(test_paths, pattern, " ")
+      for (i = 1; i <= npats; i++) pattern[i] = glob_to_regex(pattern[i])
+    }
     NF == 0 || ($1 == "-" && $2 == "-") { next }
     $1 !~ /^[0-9]+$/ || $2 !~ /^[0-9]+$/ { failed = 1; next }
     {

--- a/skills/orch/tests/branch_size_check.sh
+++ b/skills/orch/tests/branch_size_check.sh
@@ -271,14 +271,25 @@ assert_eq "$("$STATE" --state-dir "$STATE_DIR" get KEN-SIZE '.pr.size_check.verd
 # so the setting is the only thing that can move its lines to the test count.
 mk 7 scripts/check-helper.py
 mk 3 scripts/check-helperXpy        # the glob's dot is literal, so not this
+mk 2 scripts/probe-a.sh             # one character where the glob's ? sits
+mk 4 scripts/probe-ab.sh            # two, so a ? read as * moves this one too
+mk 6 scripts/star-x.py              # what a backslash-stripped star would take
 commit_files repo-test-path
-capture declared_json run_check env ORCH_SIZE_TEST_PATHS='scripts/check-*.py' \
-  "$CHECK_BIN" --json
-assert_eq "$(jq -r '.production_lines, .test_lines' <<<"$declared_json" | paste -sd, -)" "53,57" \
-  "a declared test-path glob moves its own file alone, its dot matching a dot"
+capture declared_json run_check \
+  env ORCH_SIZE_TEST_PATHS='scripts/check-*.py scripts/probe-?.sh' "$CHECK_BIN" --json
+assert_eq "$(jq -r '.production_lines, .test_lines' <<<"$declared_json" | paste -sd, -)" "63,59" \
+  "a declared glob moves the paths it names alone, its dot matching a dot and its ? one character"
 capture undeclared_json run_check "$CHECK_BIN" --json
-assert_eq "$(jq -r '.production_lines, .test_lines' <<<"$undeclared_json" | paste -sd, -)" "60,50" \
+assert_eq "$(jq -r '.production_lines, .test_lines' <<<"$undeclared_json" | paste -sd, -)" "72,50" \
   "must-fail control: with the setting unset the same lines are production"
+# The globs reach the classifier through the environment, where awk performs no
+# escape processing on them. Carried by a -v assignment instead, gawk would
+# strip the backslash below and the bare star would take star-x.py, while mawk
+# would leave the same setting matching nothing.
+capture escaped_json run_check \
+  env ORCH_SIZE_TEST_PATHS='scripts/probe-a.sh scripts/star-\*.py' "$CHECK_BIN" --json
+assert_eq "$(jq -r '.production_lines, .test_lines' <<<"$escaped_json" | paste -sd, -)" "70,52" \
+  "a backslash arrives as itself, so a glob carrying one names a path with a backslash and moves none of these"
 
 printf '\npass: %d  fail: %d\n' "$PASS" "$FAIL"
 [[ "$FAIL" -eq 0 ]]

--- a/skills/orch/tests/branch_size_check.sh
+++ b/skills/orch/tests/branch_size_check.sh
@@ -77,10 +77,12 @@ write_issue() {
 mk() { mkdir -p "$(dirname "$WT/$2")"; seq 1 "$1" > "$WT/$2"; }
 commit_files() { git -C "$WT" add -A; git -C "$WT" commit -q -m "$1"; }
 
-# The one setting the check reads is pinned here: a value exported by whoever
-# runs the suite would otherwise decide its assertions.
+# Both settings the check reads are pinned here: a value exported by whoever
+# runs the suite would otherwise decide its assertions. A case that wants one
+# sets it back through its own `env` in the command it passes.
 run_check() {
-  env -u ORCH_SIZE_RENDER_ROOTS ORCH_STATE_DIR="$WT/tmp" "$@" --worktree "$WT" --issue KEN-SIZE
+  env -u ORCH_SIZE_RENDER_ROOTS -u ORCH_SIZE_TEST_PATHS ORCH_STATE_DIR="$WT/tmp" \
+    "$@" --worktree "$WT" --issue KEN-SIZE
 }
 # Every capture is guarded: a bare command substitution under errexit ends the
 # suite at that line, with no tally and every later assertion unrun.
@@ -263,6 +265,20 @@ set +e
 set -e
 assert_eq "$("$STATE" --state-dir "$STATE_DIR" get KEN-SIZE '.pr.size_check.verdict')" "pass" \
   "--state-dir decides which state is read and written, not the caller's directory"
+
+# --- ORCH_SIZE_TEST_PATHS adds to the built-in test rule --------------------
+# A suite the repository keeps at a production path: no built-in rule names it,
+# so the setting is the only thing that can move its lines to the test count.
+mk 7 scripts/check-helper.py
+mk 3 scripts/check-helperXpy        # the glob's dot is literal, so not this
+commit_files repo-test-path
+capture declared_json run_check env ORCH_SIZE_TEST_PATHS='scripts/check-*.py' \
+  "$CHECK_BIN" --json
+assert_eq "$(jq -r '.production_lines, .test_lines' <<<"$declared_json" | paste -sd, -)" "53,57" \
+  "a declared test-path glob moves its own file alone, its dot matching a dot"
+capture undeclared_json run_check "$CHECK_BIN" --json
+assert_eq "$(jq -r '.production_lines, .test_lines' <<<"$undeclared_json" | paste -sd, -)" "60,50" \
+  "must-fail control: with the setting unset the same lines are production"
 
 printf '\npass: %d  fail: %d\n' "$PASS" "$FAIL"
 [[ "$FAIL" -eq 0 ]]

--- a/skills/orch/tests/branch_size_check.sh
+++ b/skills/orch/tests/branch_size_check.sh
@@ -274,13 +274,15 @@ mk 3 scripts/check-helperXpy        # the glob's dot is literal, so not this
 mk 2 scripts/probe-a.sh             # one character where the glob's ? sits
 mk 4 scripts/probe-ab.sh            # two, so a ? read as * moves this one too
 mk 6 scripts/star-x.py              # what a backslash-stripped star would take
+mk 5 scripts/check-nested/deep.py   # only a star spanning a slash reaches this
+mk 8 vendor/scripts/probe-z.sh      # carries a glob, so only the anchors refuse it
 commit_files repo-test-path
 capture declared_json run_check \
   env ORCH_SIZE_TEST_PATHS='scripts/check-*.py scripts/probe-?.sh' "$CHECK_BIN" --json
-assert_eq "$(jq -r '.production_lines, .test_lines' <<<"$declared_json" | paste -sd, -)" "63,59" \
-  "a declared glob moves the paths it names alone, its dot matching a dot and its ? one character"
+assert_eq "$(jq -r '.production_lines, .test_lines' <<<"$declared_json" | paste -sd, -)" "71,64" \
+  "a declared glob moves the paths it names alone, its dot matching a dot, its ? one character, its star a slash, and its whole-path anchors refusing a path that merely carries it"
 capture undeclared_json run_check "$CHECK_BIN" --json
-assert_eq "$(jq -r '.production_lines, .test_lines' <<<"$undeclared_json" | paste -sd, -)" "72,50" \
+assert_eq "$(jq -r '.production_lines, .test_lines' <<<"$undeclared_json" | paste -sd, -)" "85,50" \
   "must-fail control: with the setting unset the same lines are production"
 # The globs reach the classifier through the environment, where awk performs no
 # escape processing on them. Carried by a -v assignment instead, gawk would
@@ -288,7 +290,7 @@ assert_eq "$(jq -r '.production_lines, .test_lines' <<<"$undeclared_json" | past
 # would leave the same setting matching nothing.
 capture escaped_json run_check \
   env ORCH_SIZE_TEST_PATHS='scripts/probe-a.sh scripts/star-\*.py' "$CHECK_BIN" --json
-assert_eq "$(jq -r '.production_lines, .test_lines' <<<"$escaped_json" | paste -sd, -)" "70,52" \
+assert_eq "$(jq -r '.production_lines, .test_lines' <<<"$escaped_json" | paste -sd, -)" "83,52" \
   "a backslash arrives as itself, so a glob carrying one names a path with a backslash and moves none of these"
 
 printf '\npass: %d  fail: %d\n' "$PASS" "$FAIL"


### PR DESCRIPTION
## Summary

- `branch-size-check` split added lines into production and test by a fixed path rule, so a repository whose suite lives in a file at a production path had every test line charged to its production allowance, and the `**Expected delta**` test count judged nothing. The reported case is `vanillagreencom/vgs`, whose whole helper suite is `scripts/check-vshell-helper.py`; two lanes there were refused at the pre-push gate by this alone.
- `ORCH_SIZE_TEST_PATHS` is a blank-separated list of path globs a repository adds to the built-in test rule, in the shape `ORCH_SIZE_RENDER_ROOTS` already has and read the same way. A glob matches the whole repository-relative path; `*` spans `/`, `?` matches one character, and every other regex metacharacter is escaped, so the dot in `scripts/check-*.py` matches a dot and nothing else.
- The setting only adds. `is_test` answers on the built-in rule before it reads any pattern, so no pattern can take a path out of the test count, and an empty or unmatched list leaves every line where the built-in rule put it, which for an unnamed path is production and the stricter allowance. No repository that does not set it changes.

## Completed Issues

- Closes KEN-1365 - branch-size-check charges tests to the production allowance where a repo keeps its suite at a production path

## Size

The issue states no `**Expected delta**` line, so nothing was judged. Measured against `f6358c848`: 54 production, 19 test, 73 render-mirror lines added. The render-mirror count is the tracked `.agents/skills/orch/**` replay of the same five source files.

## Test Plan

`skills/orch/tests/branch_size_check.sh`, 38 pass, 0 fail. Two new controls, one per direction, over one planted file:

- `scripts/check-helper.py` with `ORCH_SIZE_TEST_PATHS='scripts/check-*.py'` set: its lines land in the test count.
- The same file with the setting unset: its lines land in the production count. This is the must-fail control for the first.

A sibling file `scripts/check-helperXpy` sits beside it, which an unescaped dot would match. It adds no assertion row; it is what makes the first control's claim about escaping falsifiable.

Two planted defects each reddened the first control: removing the pattern loop, and removing the metacharacter escaping. The four sibling suites that source `lib/branch-growth.sh` are green, so the added fifth parameter broke no other caller. `env -u TMPDIR tools/guard --full` passed on this head.

Consumer follow-up is the consumer's: `vgs` sets the value in its own `kendex.settings.toml` once this package lands.

https://claude.ai/code/session_016RM2s9P9QTp6HcdjYxTxqm
