### PR TITLE
fix(KEN-1372): Home, Library and project badges publish a definite installed count after a failed re-check that kept rows

### DIFF
--- a/changelog.d/fixed/1372.md
+++ b/changelog.d/fixed/1372.md
@@ -1,1 +1,1 @@
-- Show no installed count on Home, in My Library or on a project card after an update check that failed, and count packages whose rendering was deleted in all three.
+- Withhold the installed count on Home, in My Library and on a project card when the update check failed or missed that place, say so with a retry, and count packages whose rendering was deleted.

--- a/changelog.d/fixed/1372.md
+++ b/changelog.d/fixed/1372.md
@@ -1,0 +1,1 @@
+- Show no installed count on Home, in My Library or on a project card after an update check that failed, and count packages whose rendering was deleted in all three.

--- a/changelog.d/fixed/1372.md
+++ b/changelog.d/fixed/1372.md
@@ -1,1 +1,1 @@
-- Withhold the installed count on Home, in My Library and on a project card when the update check failed or missed that place, say so with a retry, and count packages whose rendering was deleted.
+- Show no installed count on Home, My Library or a project card after a failed update check, nor on a card whose place it missed; Home and My Library say why. Count packages whose files are missing.

--- a/ui/src/components/harnesses/harness-list.tsx
+++ b/ui/src/components/harnesses/harness-list.tsx
@@ -3,6 +3,7 @@ import { HarnessRow } from "@/components/harnesses/harness-row";
 import { Button } from "@/components/ui/button";
 import { installedCountByKind } from "@/lib/derive";
 import { CONTENT_WIDTH, PAGE_BODY } from "@/lib/layout";
+import { useCountableMissingRows } from "@/lib/missing-files";
 import {
   packagesUncounted,
   usePackageIndex,
@@ -34,6 +35,12 @@ export function HarnessList() {
   // narrowing, so both wait on the one read that says which installations
   // are one package.
   const uncounted = packagesUncounted(usePackagesKnown(), usePackagesRead());
+  // Handed on as what there is, for `installedCountByKind` to weigh against
+  // the narrowing. A package with no copy left carries no tool, so that
+  // count admits none of these rows under a harness and a row keeps its
+  // number whatever the update check did. Deciding it here instead would be
+  // a second answer to a question that count already owns.
+  const countableMissing = useCountableMissingRows();
 
   const anyDetected = ALL_HARNESSES.some((id) =>
     result?.harnesses.some((h) => h.harness === id),
@@ -77,8 +84,13 @@ export function HarnessList() {
             // No index means no count, which `uncounted` says in the
             // badges' place.
             const counts = packageOf
-              ? installedCountByKind(result?.items ?? [], place, packageOf)
-              : new Map();
+              ? installedCountByKind(
+                  result?.items ?? [],
+                  place,
+                  packageOf,
+                  countableMissing,
+                )
+              : null;
             return (
               <HarnessRow
                 key={id}
@@ -86,7 +98,7 @@ export function HarnessList() {
                 uncounted={uncounted}
                 detectedRoot={info?.root ?? null}
                 version={info?.version ?? null}
-                counts={[...counts.entries()]}
+                counts={counts ? [...counts.entries()] : []}
                 folder={settings?.["harness-roots"]?.[id] ?? ""}
                 onFolderChange={(root) => void setHarnessRoot(id, root)}
               />

--- a/ui/src/components/harnesses/project-card.tsx
+++ b/ui/src/components/harnesses/project-card.tsx
@@ -218,8 +218,15 @@ export function ProjectCard({
           ) : (
             <>
               {/* With nothing installed, the way to install something is the
-                empty state rather than a sentence with no way out of it. */}
-              {counts.length === 0 && onAddPackages && addPackagesLabel ? (
+                empty state rather than a sentence with no way out of it.
+                Not while `uncounted` stands: no count was taken, so an
+                empty list of them is not a place with nothing in it, and
+                an offer worded for one would be the same wrong claim the
+                badges are withholding. */}
+              {counts.length === 0 &&
+              !uncounted &&
+              onAddPackages &&
+              addPackagesLabel ? (
                 <Button size="sm" variant="outline" onClick={onAddPackages}>
                   {addPackagesLabel}
                 </Button>

--- a/ui/src/components/harnesses/project-list.dom.test.tsx
+++ b/ui/src/components/harnesses/project-list.dom.test.tsx
@@ -768,6 +768,46 @@ describe("a place card's kind badge", () => {
     }
   });
 
+  // A place the update read could not cover at all contributes no rows, so
+  // the packages there whose rendering is gone are missing from its badges
+  // and nothing on the card would say so. The card's own rule — only a
+  // landed read puts a number on it, and a place the read could not cover
+  // has no number to put — is what `outOfDate` already follows.
+  it("puts no number on a place the update read could not cover", () => {
+    const cases: [string, Scope[], number | null][] = [
+      ["a place the read covered", [], 1],
+      ["a place it could not read", [ACME], null],
+    ];
+    expect(cases).toHaveLength(2);
+    for (const [name, places, count] of cases) {
+      useUpdatesStore.setState({
+        rows: [],
+        read: READ_LANDED,
+        unreadable: places.map((scope) => ({ scope, message: "no lock" })),
+      });
+      const host = mount(<ProjectList />);
+      const card = [...host.querySelectorAll<HTMLElement>('[data-slot="card"]')]
+        .filter((el) => el.textContent?.startsWith("acme"))
+        .at(0);
+      if (!card) throw new Error("no acme card");
+      if (count !== null) {
+        expect(badgeCount(host, "acme"), name).toBe(count);
+        expect(card.textContent, name).not.toContain(PLACE_UNCHECKED_LABEL);
+      } else {
+        expect(
+          [...card.querySelectorAll("button")].some((one) =>
+            SKILL_BADGE.test(one.textContent ?? ""),
+          ),
+          name,
+        ).toBe(false);
+        expect(card.textContent, name).toContain(PLACE_UNCHECKED_LABEL);
+      }
+      // Personal is in the same list and this one is not in it, so its own
+      // badges are untouched either way.
+      expect(badgeCount(host, "Personal"), name).toBe(2);
+    }
+  });
+
   // The card reads as one target, so the keyboard opens it too — asking
   // for everything at that place, which is what the card's name is for.
   it("opens the whole place from the card on Enter", async () => {

--- a/ui/src/components/harnesses/project-list.dom.test.tsx
+++ b/ui/src/components/harnesses/project-list.dom.test.tsx
@@ -15,7 +15,11 @@ import { commands, PACKAGE_CHECK_HARNESSES } from "@/bindings";
 import { InstalledView } from "@/components/library/installed-view";
 import { updateRow } from "@/components/updates-test-rows";
 import { ADOPTABLE } from "@/lib/adoptable";
-import { unmanagedHereLabel } from "@/lib/copy";
+import {
+  PLACE_COUNTING_LABEL,
+  PLACE_UNCHECKED_LABEL,
+  unmanagedHereLabel,
+} from "@/lib/copy";
 import { NOT_CHECKED_BADGE } from "@/lib/copy-commit-offer";
 import { ADD_PACKAGES_LABEL } from "@/lib/copy-install";
 import {
@@ -704,6 +708,64 @@ describe("a place card's kind badge", () => {
       kind: "skill",
     });
     expect(badge).toBe(destinationRows());
+  });
+
+  // A package whose rendering was deleted by hand is installed at this
+  // place — the record says so, and the Library's table the badge opens
+  // stands its row up from the same rows. A badge without it lands on a
+  // table one row longer than its number. Those rows are also what a failed
+  // re-check was asked to confirm, so the badges go rather than publishing
+  // a number short by exactly them, and the card says which read is missing.
+  it("counts a package with no copy left, and says so when nothing may count it", () => {
+    const gone = updateRow("orch", ACME.root, { filesMissing: true });
+    const cases: [string, ReadState, number | null, string | null][] = [
+      [
+        "a read that landed counts it beside the one on disk",
+        READ_LANDED,
+        2,
+        null,
+      ],
+      [
+        "a re-check that failed over the rows it kept counts nothing",
+        readFailed("no network"),
+        null,
+        PLACE_UNCHECKED_LABEL,
+      ],
+      [
+        "a read still on its way is not a failure and says so",
+        READ_PENDING,
+        null,
+        PLACE_COUNTING_LABEL,
+      ],
+    ];
+    expect(cases).toHaveLength(3);
+    for (const [name, read, count, said] of cases) {
+      useUpdatesStore.setState({ rows: [gone], read });
+      const host = mount(<ProjectList />);
+      const card = [...host.querySelectorAll<HTMLElement>('[data-slot="card"]')]
+        .filter((el) => el.textContent?.startsWith("acme"))
+        .at(0);
+      if (!card) throw new Error("no acme card");
+      if (count !== null) {
+        expect(badgeCount(host, "acme"), name).toBe(count);
+      } else {
+        expect(
+          [...card.querySelectorAll("button")].some((one) =>
+            SKILL_BADGE.test(one.textContent ?? ""),
+          ),
+          name,
+        ).toBe(false);
+        // Nor the offer worded for a place with nothing in it, which is the
+        // same wrong claim the badges are withholding.
+        expect(
+          [...card.querySelectorAll("button")].some((one) =>
+            one.textContent?.startsWith(ADD_PACKAGES_LABEL),
+          ),
+          name,
+        ).toBe(false);
+      }
+      if (said !== null) expect(card.textContent, name).toContain(said);
+    }
   });
 
   // The card reads as one target, so the keyboard opens it too — asking

--- a/ui/src/components/harnesses/project-list.tsx
+++ b/ui/src/components/harnesses/project-list.tsx
@@ -21,6 +21,7 @@ import {
 } from "@/components/ui/dropdown-menu";
 import { UpdateReviewDialog } from "@/components/updates/update-review-dialog";
 import { unmanagedCount } from "@/lib/audit-counts";
+import { PLACE_UNCHECKED_LABEL } from "@/lib/copy";
 import {
   NOT_CHECKED_BADGE,
   notChecked,
@@ -366,9 +367,14 @@ export function ProjectList() {
   // in the same words the Updates page uses rather than letting the click
   // answer with an error.
   const updatesHeld = useUpdatesStore(readUnsettled);
+  // Whether the update read has no standing for this place at all. Such a
+  // place contributes no rows, so every number read off them is short by
+  // exactly what it holds — and the read's own status says nothing about
+  // it, because the read landed and this place simply was not in it.
+  const uncovered = (scope: Scope): boolean =>
+    unreadable.some((place) => sameScope(place.scope, scope));
   const outOfDate = (scope: Scope): number | null =>
-    updatesCountable &&
-    !unreadable.some((place) => sameScope(place.scope, scope))
+    updatesCountable && !uncovered(scope)
       ? outOfDateIn(updateRows, scope)
       : null;
   // The place whose updates are being reviewed, with what it is called: one
@@ -419,17 +425,32 @@ export function ProjectList() {
   const countableMissing = useCountableMissingRows();
   // What one place holds, by kind — null where no number may be taken. Both
   // cards below ask the same way, so Personal and a project cannot count a
-  // package one of them admits and the other does not.
-  const countsAt = (place: ItemPlace): Map<ItemKind, number> | null =>
-    packageOf
+  // package one of them admits and the other does not. The place is named
+  // twice because a badge counts a narrowing and belongs to a place: the
+  // narrowing is what the click opens, and the standing is what the update
+  // read has about that place.
+  const countsAt = (
+    place: ItemPlace,
+    scope: Scope,
+  ): Map<ItemKind, number> | null =>
+    packageOf && !uncovered(scope)
       ? installedCountByKind(items, place, packageOf, countableMissing)
       : null;
-  // What a place's badges say instead of a number: the join's own reason
-  // where it has one, and the update check that could not confirm the rows
-  // otherwise. One string, because a card has one slot for it and the
-  // counts are gone either way.
-  const uncountedHere = (counts: Map<ItemKind, number> | null): string | null =>
-    uncounted ?? (counts === null ? uncountedRead(updatesRead) : null);
+  // What a place's badges say instead of a number. One string, because a
+  // card has one slot for it and the counts are gone either way — and never
+  // null while there is no number, or the card would fall through to its
+  // own "nothing here" and state the very thing nothing counted.
+  //
+  // The update read's own status where it has one to give. A landed read
+  // that could not cover this place has none: it answered, and this place
+  // was not in what it answered about, which is the fall-through.
+  const uncountedHere = (
+    counts: Map<ItemKind, number> | null,
+  ): string | null => {
+    if (uncounted) return uncounted;
+    if (counts !== null) return null;
+    return uncountedRead(updatesRead) ?? PLACE_UNCHECKED_LABEL;
+  };
   const projects = settings?.projects ?? [];
   // What a place is called where it is named ALONE, away from its card: a
   // card's menu opens dialogs that say which place's files an action
@@ -443,7 +464,7 @@ export function ProjectList() {
   // A card counts one place and links to that place. Both read the same
   // object, so the badge cannot name a narrowing its click does not make.
   const personal: ItemPlace = { scope: "global" };
-  const personalCounts = countsAt(personal);
+  const personalCounts = countsAt(personal, GLOBAL);
 
   return (
     <div className={PAGE_BODY}>
@@ -503,7 +524,7 @@ export function ProjectList() {
             // under a path nobody has looked at is the same claim made
             // from silence. One judge, shared with the guided install.
             const reachable = placeIsReachable(root, result);
-            const counts = countsAt(place);
+            const counts = countsAt(place, scope);
             return (
               <ProjectCard
                 key={root}

--- a/ui/src/components/harnesses/project-list.tsx
+++ b/ui/src/components/harnesses/project-list.tsx
@@ -1,6 +1,6 @@
 import { MoreHorizontal } from "lucide-react";
 import { useEffect, useState } from "react";
-import type { ChangesState, MissingProject, Scope } from "@/bindings";
+import type { ChangesState, ItemKind, MissingProject, Scope } from "@/bindings";
 import { PACKAGE_CHECK_HARNESSES } from "@/bindings";
 import { ConfirmDialog } from "@/components/confirm-dialog";
 import { AddProjectDialog } from "@/components/harnesses/add-project-dialog";
@@ -54,9 +54,11 @@ import {
 } from "@/lib/derive";
 import { scopeNames } from "@/lib/labels";
 import { CONTENT_WIDTH, PAGE_BODY } from "@/lib/layout";
+import { useCountableMissingRows } from "@/lib/missing-files";
 import { checksStanding } from "@/lib/package-checks";
 import {
   packagesUncounted,
+  uncountedRead,
   useOriginIndex,
   usePackageIndex,
   usePackagesKnown,
@@ -66,7 +68,7 @@ import { pickFolder } from "@/lib/pick-folder";
 import { placeIsReachable } from "@/lib/reachable-projects";
 import { everyPlace, sameScope } from "@/lib/scope";
 import { availableUpdatesIn, outOfDateIn } from "@/lib/update-groups";
-import { readUnsettled } from "@/lib/updates-read-state";
+import { readUnsettled, rowsCountable } from "@/lib/updates-read-state";
 import { cn } from "@/lib/utils";
 import { useAuditOnMount, useAuditStore } from "@/stores/audit";
 import { useNavStore } from "@/stores/nav";
@@ -355,7 +357,8 @@ export function ProjectList() {
   // date" over that is the one thing a card must not do. Both are drawn as
   // nothing here, because Home and Problems carry the reason.
   const updateRows = useUpdatesStore((s) => s.rows);
-  const updatesLanded = useUpdatesStore((s) => s.read.status === "landed");
+  const updatesRead = useUpdatesStore((s) => s.read);
+  const updatesCountable = useUpdatesStore(rowsCountable);
   const unreadable = useUpdatesStore((s) => s.unreadable);
   const updatesBusy = useUpdatesStore((s) => s.busy);
   // A count is a fact worth drawing while a read runs; a write read off
@@ -364,7 +367,8 @@ export function ProjectList() {
   // answer with an error.
   const updatesHeld = useUpdatesStore(readUnsettled);
   const outOfDate = (scope: Scope): number | null =>
-    updatesLanded && !unreadable.some((place) => sameScope(place.scope, scope))
+    updatesCountable &&
+    !unreadable.some((place) => sameScope(place.scope, scope))
       ? outOfDateIn(updateRows, scope)
       : null;
   // The place whose updates are being reviewed, with what it is called: one
@@ -407,6 +411,25 @@ export function ProjectList() {
   // narrowing, so both wait on the one read that says which installations
   // are one package.
   const uncounted = packagesUncounted(usePackagesKnown(), usePackagesRead());
+  // A place's total holds the packages whose rendering is gone — the record
+  // says they are installed here — so the badges count them, and a check
+  // that could not confirm them takes the badges away rather than publishing
+  // a number short by exactly those. `installedCountByKind` is what weighs
+  // the two, because only it knows whether this narrowing admits such a row.
+  const countableMissing = useCountableMissingRows();
+  // What one place holds, by kind — null where no number may be taken. Both
+  // cards below ask the same way, so Personal and a project cannot count a
+  // package one of them admits and the other does not.
+  const countsAt = (place: ItemPlace): Map<ItemKind, number> | null =>
+    packageOf
+      ? installedCountByKind(items, place, packageOf, countableMissing)
+      : null;
+  // What a place's badges say instead of a number: the join's own reason
+  // where it has one, and the update check that could not confirm the rows
+  // otherwise. One string, because a card has one slot for it and the
+  // counts are gone either way.
+  const uncountedHere = (counts: Map<ItemKind, number> | null): string | null =>
+    uncounted ?? (counts === null ? uncountedRead(updatesRead) : null);
   const projects = settings?.projects ?? [];
   // What a place is called where it is named ALONE, away from its card: a
   // card's menu opens dialogs that say which place's files an action
@@ -420,6 +443,7 @@ export function ProjectList() {
   // A card counts one place and links to that place. Both read the same
   // object, so the badge cannot name a narrowing its click does not make.
   const personal: ItemPlace = { scope: "global" };
+  const personalCounts = countsAt(personal);
 
   return (
     <div className={PAGE_BODY}>
@@ -437,12 +461,8 @@ export function ProjectList() {
         <ProjectCard
           name="Personal"
           subtitle="Works in every project on this computer"
-          counts={
-            packageOf
-              ? [...installedCountByKind(items, personal, packageOf).entries()]
-              : []
-          }
-          uncounted={uncounted}
+          counts={personalCounts ? [...personalCounts.entries()] : []}
+          uncounted={uncountedHere(personalCounts)}
           emptyLabel="Nothing from kendex yet."
           onOpen={() => goToLibrary(personal)}
           onKindClick={(kind) => goToLibrary({ ...personal, kind })}
@@ -483,24 +503,15 @@ export function ProjectList() {
             // under a path nobody has looked at is the same claim made
             // from silence. One judge, shared with the guided install.
             const reachable = placeIsReachable(root, result);
+            const counts = countsAt(place);
             return (
               <ProjectCard
                 key={root}
                 name={name}
                 subtitle={root}
                 path={root}
-                counts={
-                  packageOf
-                    ? [
-                        ...installedCountByKind(
-                          items,
-                          place,
-                          packageOf,
-                        ).entries(),
-                      ]
-                    : []
-                }
-                uncounted={uncounted}
+                counts={counts ? [...counts.entries()] : []}
+                uncounted={uncountedHere(counts)}
                 emptyLabel="Nothing from kendex yet."
                 badge={badgeFor(
                   missing,

--- a/ui/src/components/harnesses/project-setup.dom.test.tsx
+++ b/ui/src/components/harnesses/project-setup.dom.test.tsx
@@ -34,7 +34,9 @@ import { useProjectSetupStore } from "@/stores/project-setup";
 import { useScanStore } from "@/stores/scan";
 import { useSettingsStore } from "@/stores/settings";
 import type { Discovered } from "@/stores/settings-projects";
+import { useUpdatesStore } from "@/stores/updates";
 import { mount, settle } from "@/test/dom";
+import { joinAnswered } from "@/test/identity-join";
 import { AddProjectDialog } from "./add-project-dialog";
 import { FindProjectsDialog } from "./find-projects-dialog";
 import { ProjectList } from "./project-list";
@@ -528,10 +530,14 @@ describe("a project's card while its contents are being read", () => {
 
   // The next step from a place with nothing in it, on the card that says
   // so — and it carries the project, so the guided install opens on it.
+  // Both reads a count stands on have answered: the offer is the empty
+  // state, and a place nothing has counted yet is not empty.
   it("browses on the project's behalf from the card", async () => {
     useSettingsStore.setState({
       settings: { projects: [ACME.root] } as never,
     });
+    joinAnswered();
+    useUpdatesStore.setState({ rows: [], read: READ_LANDED });
     const host = mount(<ProjectList />);
     await settle();
 

--- a/ui/src/components/library/installed-view.dom.test.tsx
+++ b/ui/src/components/library/installed-view.dom.test.tsx
@@ -705,6 +705,71 @@ describe("a package whose rendering is gone everywhere", () => {
       scope: VG,
     });
   });
+
+  /** The counter under the filter strip: `n items`, or the dash where
+   *  there is no total to state. */
+  const counter = (host: HTMLElement) =>
+    host.querySelector(".tabular-nums")?.textContent?.trim();
+
+  // A row is a last-known fact about one package and stands whatever the
+  // last check did — that is what the rows above are for. The total is a
+  // claim about the whole set at once, and that set is precisely what a
+  // re-check that failed was asked to confirm, so the number goes and the
+  // rows stay.
+  it("keeps the row and withholds the total after a failed re-check", () => {
+    const cases: [string, ReadState, string | undefined][] = [
+      ["a read that landed states the total", READ_LANDED, "1 items"],
+      [
+        "a re-check that failed over the rows it kept states none",
+        readFailed("no network"),
+        "—",
+      ],
+    ];
+    expect(cases).toHaveLength(2);
+    for (const [name, read, shown] of cases) {
+      scanIs([]);
+      joinAnswered([seeded] as never);
+      useUpdatesStore.setState({
+        rows: [row({ filesMissing: true })] as never,
+        read,
+      });
+      const host = mount(<InstalledView />);
+      expect(counter(host), name).toBe(shown);
+      // The row itself is unchanged: the fact it carries is the last thing
+      // anything observed about that place.
+      expect(names(host), name).toContain("gh");
+    }
+  });
+
+  // Which emptiness this is — nothing installed, or nothing matching — is
+  // as definite a claim as the total. A package with no copy left has no
+  // observation anywhere, so the rows a failed re-check could not confirm
+  // are the only thing that would have made this table non-empty.
+  it("claims no emptiness from a missing set nothing confirmed", () => {
+    const cases: [string, ReadState, boolean][] = [
+      ["a read that landed found the machine empty", READ_LANDED, true],
+      [
+        "a re-check that failed confirmed no such thing",
+        readFailed("no network"),
+        false,
+      ],
+    ];
+    expect(cases).toHaveLength(2);
+    for (const [name, read, claimed] of cases) {
+      scanIs([]);
+      joinAnswered([] as never);
+      // Rows kept from before the failure, none of them about a rendering
+      // that is gone — the unconfirmed empty missing set.
+      useUpdatesStore.setState({
+        rows: [row({ filesMissing: false })] as never,
+        read,
+      });
+      const host = mount(<InstalledView />);
+      expect((host.textContent ?? "").includes(NOTHING_INSTALLED), name).toBe(
+        claimed,
+      );
+    }
+  });
 });
 
 // A chip or a place clicked on a Library row asks for a view of the Library

--- a/ui/src/components/library/installed-view.dom.test.tsx
+++ b/ui/src/components/library/installed-view.dom.test.tsx
@@ -12,6 +12,7 @@ import type {
 import { InstalledView } from "@/components/library/installed-view";
 import { openLibraryAt } from "@/components/library/use-filter-handoff";
 import {
+  CHECK_FOR_UPDATES_LABEL,
   FORKED_BADGE_LABEL,
   MISSING_FILES_BADGE_LABEL,
   UPDATES_NOTHING_INSTALLED as NOTHING_INSTALLED,
@@ -19,6 +20,7 @@ import {
   PACKAGES_UNCONFIRMED_TITLE,
   TAGS_ROW_LABEL,
   TRY_AGAIN_LABEL,
+  UPDATES_ATTENTION_TITLE,
 } from "@/lib/copy";
 import { STATUS_LABELS } from "@/lib/copy-customize";
 import { addPackagesTo, nothingInstalledIn } from "@/lib/copy-install";
@@ -738,6 +740,87 @@ describe("a package whose rendering is gone everywhere", () => {
       // The row itself is unchanged: the fact it carries is the last thing
       // anything observed about that place.
       expect(names(host), name).toContain("gh");
+    }
+  });
+
+  // Withholding the wording is right only where those rows could have made
+  // the table non-empty. A tool or a tag is a question no package with no
+  // copy left can answer, so under one of those the emptiness is the
+  // scan's alone — and suppressing it there leaves a blank table with no
+  // wording and no way out of the filter doing the hiding.
+  it("still says what an emptiness the update read cannot touch is", () => {
+    /** The package rows, told from the empty row by that row's one
+     *  spanning cell — which carries a name button of its own. */
+    const packageRows = (host: HTMLElement) =>
+      [...host.querySelectorAll("tbody tr")].filter(
+        (line) => line.querySelectorAll("td").length > 1,
+      );
+    const cases: [string, Partial<typeof NO_FILTERS>, string, boolean][] = [
+      ["narrowed by a tool", { harness: "codex" }, "", true],
+      ["narrowed by a tag", { tag: "git" }, "", true],
+      [
+        "narrowed by a kind, which such a row does carry",
+        { kind: "agent" },
+        "",
+        false,
+      ],
+      [
+        "narrowed by a search, which it also answers",
+        {},
+        "no such name",
+        false,
+      ],
+    ];
+    expect(cases).toHaveLength(4);
+    for (const [name, filters, search, said] of cases) {
+      scanIs([here]);
+      joinAnswered([observedRow] as never);
+      // Rows kept from before the failure, so the table's own rows stand
+      // and only the total and the emptiness are in question.
+      useUpdatesStore.setState({
+        rows: [row({ filesMissing: false })] as never,
+        read: readFailed("no network"),
+      });
+      useLibraryViewStore.setState({ ...NO_FILTERS, ...filters });
+      useNavStore.setState({ libraryScope: "all", search });
+      const host = mount(<InstalledView />);
+      expect(packageRows(host), name).toHaveLength(0);
+      expect((host.textContent ?? "").includes("Nothing matches"), name).toBe(
+        said,
+      );
+    }
+  });
+
+  // A withheld total is a dash, and a dash nobody can act on is what
+  // `ui/AGENTS.md` forbids: a failed read shows its error with a retry.
+  // Home already does this for the same failure through its attention row;
+  // the Library says it beside the table the number belongs to.
+  it("says the update check failed and offers it again, beside the dash", () => {
+    const cases: [string, ReadState, boolean][] = [
+      ["a check that failed", readFailed("no network"), true],
+      ["a read that landed", READ_LANDED, false],
+    ];
+    expect(cases).toHaveLength(2);
+    for (const [name, read, noted] of cases) {
+      scanIs([here]);
+      joinAnswered([observedRow] as never);
+      useUpdatesStore.setState({
+        rows: [row({ filesMissing: false })] as never,
+        read,
+      });
+      const host = mount(<InstalledView />);
+      const text = host.textContent ?? "";
+      expect(text.includes(UPDATES_ATTENTION_TITLE), name).toBe(noted);
+      // The read's own reason, not a wording of this page's.
+      expect(text.includes("no network"), name).toBe(noted);
+      expect(
+        [...host.querySelectorAll("button")].some(
+          (one) => one.textContent?.trim() === CHECK_FOR_UPDATES_LABEL,
+        ),
+        name,
+      ).toBe(noted);
+      // And the number it explains is gone exactly when the note stands.
+      expect(counter(host), name).toBe(noted ? "—" : "1 items");
     }
   });
 

--- a/ui/src/components/library/installed-view.tsx
+++ b/ui/src/components/library/installed-view.tsx
@@ -14,6 +14,8 @@ import {
 } from "@/components/library/use-filter-handoff";
 import { PackagesNote } from "@/components/packages-note";
 import { ChangesLine } from "@/components/project-changes/changes-line";
+import { StatusNote } from "@/components/status-note";
+import { Button } from "@/components/ui/button";
 import {
   Table,
   TableBody,
@@ -21,8 +23,13 @@ import {
   TableHeader,
   TableRow,
 } from "@/components/ui/table";
-import { TAGS_ROW_LABEL } from "@/lib/copy";
 import {
+  CHECK_FOR_UPDATES_LABEL,
+  TAGS_ROW_LABEL,
+  UPDATES_ATTENTION_TITLE,
+} from "@/lib/copy";
+import {
+  admitsMissing,
   filterItems,
   groupItems,
   groupMatches,
@@ -52,6 +59,7 @@ import {
 } from "@/lib/package-identity";
 import { everyPlace, scopeKey } from "@/lib/scope";
 import { afforded, type ColumnBudget, useRoom } from "@/lib/table-room";
+import { workOut } from "@/lib/updates-read-state";
 import { cn } from "@/lib/utils";
 import { useEditorStore } from "@/stores/editor";
 import {
@@ -70,6 +78,7 @@ import {
 import { useScanStore } from "@/stores/scan";
 import { useSettingsStore } from "@/stores/settings";
 import { projectsOf } from "@/stores/settings-projects";
+import { useUpdatesStore } from "@/stores/updates";
 
 /** Every optional column this table has to draw. Unlike the marketplace
  *  table, whose pages declare different sets, the Library's list is one
@@ -228,6 +237,14 @@ export function InstalledView() {
   // last check did; the total under the filters is a claim about the whole
   // set, and the check that failed was asked to confirm exactly that set.
   const countableMissing = useCountableMissingRows();
+  // The update read's own outcome, and the way to ask again. A page that
+  // withholds a figure on this read has to say so and offer the check,
+  // which is what `ui/AGENTS.md` requires of every failed read.
+  const updatesRead = useUpdatesStore((s) => s.read);
+  const checkUpdates = useUpdatesStore((s) => s.check);
+  // A check builds its report once and a write reads off those rows, so
+  // neither may start while the other is out. The store's own rule.
+  const updatesWorking = useUpdatesStore(workOut);
   // Every group the table holds, before any narrowing.
   const everywhere = useMemo(
     () =>
@@ -263,6 +280,19 @@ export function InstalledView() {
     [missingIn, scope],
   );
 
+  // One narrowing object for every half of this list: what the scan is
+  // filtered by, which packages with no copy left it admits, and — below
+  // the table — whether an emptiness under it is the update read's to
+  // decide at all.
+  const narrowing: ItemFilter = useMemo(
+    () => ({
+      scope,
+      harness: harness === "any" ? undefined : harness,
+      tag: tag === "any" ? undefined : (tag as Tag),
+    }),
+    [scope, harness, tag],
+  );
+
   const groups = useMemo(() => {
     // Nothing may be drawn until the read that says which observations are
     // one package has answered: grouped with an empty index every row is an
@@ -270,13 +300,6 @@ export function InstalledView() {
     // this page exists to stop. With the read failed and nothing retained
     // the note above stands in their place instead.
     if (!result || !packageOf || packagesUnreadable) return [];
-    // One narrowing object for both halves of the list: what the scan is
-    // filtered by, and which packages with no copy left it admits.
-    const narrowing: ItemFilter = {
-      scope,
-      harness: harness === "any" ? undefined : harness,
-      tag: tag === "any" ? undefined : (tag as Tag),
-    };
     const filtered = filterItems(result.items, narrowing);
     // Searched after grouping, because what a search reads is the
     // package's name and its author's words, and both belong to the
@@ -306,10 +329,8 @@ export function InstalledView() {
     return grouped;
   }, [
     result,
-    scope,
+    narrowing,
     kind,
-    harness,
-    tag,
     from,
     edited,
     search,
@@ -359,14 +380,21 @@ export function InstalledView() {
   // Nothing has been counted yet — distinct from "counted, found nothing"
   // and from "counting failed". The join is waited on with the scan: until
   // it answers nothing knows which observations are one package, and a
-  // total taken then would count installations. Narrowed to edited
-  // packages, the count also waits on the updates read that says which are
-  // edited.
+  // total taken then would count installations. The first update read is
+  // waited on too: a package with no copy left is in this total and those
+  // rows are the only thing that says so, so a total taken before they
+  // land is short by exactly them. Narrowed to edited packages, the count
+  // also waits on that read for which packages are edited.
+  //
+  // Only the FIRST update read. A later check leaves `read` landed and
+  // raises `checking` instead, so asking again never pulls the counter
+  // back to a skeleton over rows that are still on screen.
   const scanning =
     packagesUnreadable === null &&
     !packagesStale &&
     (result === null ||
       !packageOf ||
+      updatesRead.status === "pending" ||
       (edited === "edited" && editedAnywhere === null));
   // Asked of the rows the table has, not of the scan: the empty state
   // picks its words from this, and a machine whose only packages lost
@@ -433,6 +461,34 @@ export function InstalledView() {
         {packagesRead.status === "failed" ? (
           <div className={cn("pb-4", WIDE_CONTENT_WIDTH)}>
             <PackagesNote />
+          </div>
+        ) : null}
+        {/* The other read a total stands on. A package with no copy left is
+            on this machine and these rows are the only thing that says so,
+            so a check that failed takes the total away — and a figure
+            withheld without its reason is a dash nobody can act on. The
+            rows the table draws are last-known rather than absent, which is
+            the warning tone; the check is offered again here, because this
+            is where the reader is looking. Its own words, from the read
+            that failed. */}
+        {updatesRead.status === "failed" ? (
+          <div className={cn("pb-4", WIDE_CONTENT_WIDTH)}>
+            <StatusNote
+              tone="warning"
+              title={UPDATES_ATTENTION_TITLE}
+              action={
+                <Button
+                  size="sm"
+                  variant="outline"
+                  disabled={updatesWorking}
+                  onClick={() => void checkUpdates()}
+                >
+                  {CHECK_FOR_UPDATES_LABEL}
+                </Button>
+              }
+            >
+              {updatesRead.error}
+            </StatusNote>
           </div>
         ) : null}
         {/* The project's own view of what kendex has written here and not
@@ -541,11 +597,21 @@ export function InstalledView() {
                       claim as the total is, and a re-check that failed was
                       asked about the very rows that would have made the
                       table non-empty. Suppressed the way a packages read
-                      that cannot answer suppresses it. */}
+                      that cannot answer suppresses it.
+
+                      Only where the narrowing could hold such a row at
+                      all. A tool or a tag is a question no package with no
+                      copy left can answer, so under one of those the
+                      emptiness is the scan's alone and the update read
+                      decides nothing about it — withholding the wording
+                      there leaves a reader a blank table with no way out
+                      of the filter hiding it. `admitsMissing` is the one
+                      owner of that rule; the list above asks it through
+                      `missingUnder` over the same narrowing. */}
                   {!scanning &&
                   !packagesUnreadable &&
                   !packagesStale &&
-                  countableMissing !== null &&
+                  (countableMissing !== null || !admitsMissing(narrowing)) &&
                   groups.length === 0 ? (
                     <TableEmptyRow
                       span={drawn}

--- a/ui/src/components/library/installed-view.tsx
+++ b/ui/src/components/library/installed-view.tsx
@@ -42,7 +42,7 @@ import { scopeNames } from "@/lib/labels";
 import { PAGE_GUTTER, WIDE_CONTENT_WIDTH } from "@/lib/layout";
 import { isNarrowed, UNFILTERED } from "@/lib/library-handoff";
 import { useLibraryStandings } from "@/lib/library-standings";
-import { useMissingRows } from "@/lib/missing-files";
+import { useCountableMissingRows, useMissingRows } from "@/lib/missing-files";
 import {
   usePackageIndex,
   usePackagesEverKnown,
@@ -223,6 +223,11 @@ export function InstalledView() {
   // counts. A package the scan cannot see at all has no observation to
   // group, so these are what put its row on this list.
   const missingRows = useMissingRows();
+  // The same rows where a number may be taken over them. A row on this
+  // table is a last-known fact about one package and stands whatever the
+  // last check did; the total under the filters is a claim about the whole
+  // set, and the check that failed was asked to confirm exactly that set.
+  const countableMissing = useCountableMissingRows();
   // Every group the table holds, before any narrowing.
   const everywhere = useMemo(
     () =>
@@ -339,10 +344,11 @@ export function InstalledView() {
   // No number while either read that decides the row set is silent. A
   // total counted from an older identity answer is not the last-known
   // total; and a package can be installed with nothing observed of it, so
-  // one counted before the missing rows answered leaves those out.
+  // one counted over update rows nothing confirmed is definite about a set
+  // the failed check was asked about and could not answer for.
   const total = useMemo(
-    () => (packageOf && missingRows ? installedCount(everywhere) : null),
-    [everywhere, packageOf, missingRows],
+    () => (packageOf && countableMissing ? installedCount(everywhere) : null),
+    [everywhere, packageOf, countableMissing],
   );
   // The filter's vocabulary is what the join actually says, so a value
   // is never offered that no row carries.
@@ -529,16 +535,17 @@ export function InstalledView() {
                     );
                   })}
                   {scanning ? <InstalledSkeleton columns={columns} /> : null}
-                  {/* Not while the missing rows are unread: which of the
-                      two emptinesses this is — nothing installed, or
-                      nothing matching — is a claim about that read as
-                      much as about the scan, and neither wording is
-                      available until it answers. Suppressed the way a
-                      packages read that cannot answer suppresses it. */}
+                  {/* Not while no number may be taken over the missing
+                      rows: which of the two emptinesses this is — nothing
+                      installed, or nothing matching — is as definite a
+                      claim as the total is, and a re-check that failed was
+                      asked about the very rows that would have made the
+                      table non-empty. Suppressed the way a packages read
+                      that cannot answer suppresses it. */}
                   {!scanning &&
                   !packagesUnreadable &&
                   !packagesStale &&
-                  missingRows !== null &&
+                  countableMissing !== null &&
                   groups.length === 0 ? (
                     <TableEmptyRow
                       span={drawn}

--- a/ui/src/components/library/library-filters.tsx
+++ b/ui/src/components/library/library-filters.tsx
@@ -74,11 +74,15 @@ export function LibraryFilters({
   projects: string[];
   /** Rows the table is showing, against every row it could show. */
   shown: number;
-  /** Every row the table could show, or null where the read that says which
-   *  installations are one package could not answer — there is no total
-   *  then, and a number would be a count of something else. */
+  /** Every row the table could show, or null where a read behind that set
+   *  could not answer — the one saying which installations are one package,
+   *  or the one standing behind the packages no copy of which is left.
+   *  There is no total then, and a number would be a count of something
+   *  else. */
   total: number | null;
-  /** The first scan hasn't landed, so there is no count to state yet. */
+  /** A first read behind that set hasn't landed, so there is no count to
+   *  state yet — told apart from a read that failed, which the page says
+   *  in a note of its own. */
   counting: boolean;
   filtered: boolean;
   onClear: () => void;
@@ -181,7 +185,10 @@ export function LibraryFilters({
               <Skeleton className="h-3 w-16" />
             ) : total === null ? (
               // Not still counting and not a number: the count is
-              // unavailable, and the note above says why.
+              // unavailable. Two reads can take it away — the one saying
+              // which installations are one package, and the one standing
+              // behind the packages no copy of which is left — and the
+              // page draws a note above for whichever of them failed.
               <span className="tabular-nums">—</span>
             ) : (
               <span className="tabular-nums">

--- a/ui/src/lib/derive.test.ts
+++ b/ui/src/lib/derive.test.ts
@@ -14,6 +14,7 @@ import {
   groupsOfKind,
   groupVendor,
   type ItemFilter,
+  type ItemPlace,
   installationAt,
   installedCount,
   installedCountByKind,
@@ -261,9 +262,12 @@ describe("groupItems by package identity", () => {
       installedCount(groupItems([native, rule, instruction], () => hook)),
     ).toBe(1);
     expect(
-      installedCountByKind([native, rule, instruction], {}, () => hook).get(
-        "hook",
-      ),
+      installedCountByKind(
+        [native, rule, instruction],
+        {},
+        () => hook,
+        [],
+      )?.get("hook"),
     ).toBe(1);
   });
 });
@@ -633,9 +637,10 @@ describe("installedCountByKind", () => {
       [item({}), item({ name: "x" }), item({ kind: "agent" })],
       {},
       unrecorded,
+      [],
     );
-    expect(counts.get("skill")).toBe(2);
-    expect(counts.get("agent")).toBe(1);
+    expect(counts?.get("skill")).toBe(2);
+    expect(counts?.get("agent")).toBe(1);
   });
 
   it("counts packages, not installations", () => {
@@ -647,8 +652,9 @@ describe("installedCountByKind", () => {
       ],
       {},
       unrecorded,
+      [],
     );
-    expect(counts.get("skill")).toBe(1);
+    expect(counts?.get("skill")).toBe(1);
   });
 
   it("counts only what the place holds", () => {
@@ -658,17 +664,22 @@ describe("installedCountByKind", () => {
       item({ name: "over-there", scope: { scope: "project", root: "/p" } }),
     ];
     expect(
-      installedCountByKind(items, { harness: "claude" }, unrecorded).get(
+      installedCountByKind(items, { harness: "claude" }, unrecorded, [])?.get(
         "skill",
       ),
     ).toBe(2);
     expect(
-      installedCountByKind(items, { scope: "global" }, unrecorded).get("skill"),
-    ).toBe(2);
-    expect(
-      installedCountByKind(items, { scope: { project: "/p" } }, unrecorded).get(
+      installedCountByKind(items, { scope: "global" }, unrecorded, [])?.get(
         "skill",
       ),
+    ).toBe(2);
+    expect(
+      installedCountByKind(
+        items,
+        { scope: { project: "/p" } },
+        unrecorded,
+        [],
+      )?.get("skill"),
     ).toBe(1);
   });
 
@@ -677,9 +688,9 @@ describe("installedCountByKind", () => {
   // groups hands back the wire order instead.
   it("hands the kinds back in the order the app shows them in", () => {
     const items = KINDS.map((kind) => item({ kind, name: `one-${kind}` }));
-    expect([...installedCountByKind(items, {}, unrecorded).keys()]).toEqual(
-      KINDS,
-    );
+    expect([
+      ...(installedCountByKind(items, {}, unrecorded, [])?.keys() ?? []),
+    ]).toEqual(KINDS);
   });
 
   it("leaves out a kind the place holds nothing of", () => {
@@ -687,8 +698,70 @@ describe("installedCountByKind", () => {
       [item({ kind: "agent" })],
       {},
       unrecorded,
+      [],
     );
-    expect(counts.has("skill")).toBe(false);
+    expect(counts?.has("skill")).toBe(false);
+    expect(counts?.has("agent")).toBe(true);
+  });
+
+  // A package whose rendering was deleted by hand is installed and has no
+  // observation anywhere: the record is the only thing that says so, and
+  // the Library's own table stands its row up from the same rows. A badge
+  // that left it out would land on a table one row longer than its number.
+  // Nothing may be counted over those rows while no read confirms them, so
+  // a narrowing they belong to has no number at all — one that could never
+  // hold such a row keeps its number, because none was ever missing from it.
+  it("counts the packages with no copy left that the place admits", () => {
+    const gone = (overrides: Record<string, unknown>) =>
+      ({
+        kind: "skill",
+        name: "orch",
+        scope: { scope: "global" },
+        filesMissing: true,
+        ...overrides,
+      }) as never;
+    const elsewhere = gone({ scope: { scope: "project", root: "/p" } });
+    const items = [item({})];
+    const cases: [string, ItemPlace, unknown[] | null, number | undefined][] = [
+      ["counts it beside what the scan saw", {}, [gone({})], 2],
+      [
+        "counts it at the place its record names",
+        { scope: "global" },
+        [gone({})],
+        2,
+      ],
+      [
+        "leaves out one another place's record names",
+        { scope: "global" },
+        [elsewhere],
+        1,
+      ],
+      [
+        "takes no number while nothing may be counted over them",
+        {},
+        null,
+        undefined,
+      ],
+      [
+        "keeps a tool's number, which no such row can be in",
+        { harness: "claude" },
+        null,
+        1,
+      ],
+    ];
+    expect(cases).toHaveLength(5);
+    for (const [name, place, missing, count] of cases) {
+      const counts = installedCountByKind(
+        items,
+        place,
+        unrecorded,
+        missing as never,
+      );
+      expect(counts?.get("skill"), name).toBe(count);
+    }
+    // The withheld answer is the absent map, not a map that counts nothing:
+    // a caller reading an empty tally would draw "nothing installed here".
+    expect(installedCountByKind(items, {}, unrecorded, null)).toBe(null);
   });
 });
 

--- a/ui/src/lib/derive.ts
+++ b/ui/src/lib/derive.ts
@@ -250,13 +250,14 @@ const byRowOrder = (a: ItemGroup, b: ItemGroup): number =>
  *  the package under it would be a wrong answer rather than a missing one.
  *  Its place it does carry, so that narrowing it does answer.
  *
- *  Asked of the narrowing alone, because a count has to know whether those
- *  rows belong in its total before it is given any: {@link missingUnder} is
- *  this same rule applied to rows in hand, and
- *  {@link installedCountByKind} is what asks it without them. Private,
- *  because a caller weighing it itself would be a second answer to the one
- *  question those two share. */
-const admitsMissing = (filter: ItemFilter): boolean =>
+ *  Asked of the narrowing alone, because a surface has to know whether
+ *  those rows belong in what it is drawing before it is given any:
+ *  {@link missingUnder} is this same rule applied to rows in hand,
+ *  {@link installedCountByKind} asks it without them, and the Library's
+ *  empty state asks it to tell an emptiness the update read decides from
+ *  one the scan decides alone. The one owner of that rule, because a
+ *  caller spelling it out would be a second answer to the same question. */
+export const admitsMissing = (filter: ItemFilter): boolean =>
   !filter.harness && !filter.tag;
 
 /** The rows for packages with no copy left that a narrowing admits. */

--- a/ui/src/lib/derive.ts
+++ b/ui/src/lib/derive.ts
@@ -243,17 +243,28 @@ const byRowOrder = (a: ItemGroup, b: ItemGroup): number =>
   a.name.localeCompare(b.name) ||
   a.key.localeCompare(b.key);
 
-/** The rows for packages with no copy left that a narrowing admits.
+/** Whether a narrowing can admit a row for a package with no copy left.
  *
  *  Such a row carries no tool and no tags — there is no copy to carry them
  *  — so a narrowing by either is a question it cannot answer, and drawing
  *  the package under it would be a wrong answer rather than a missing one.
- *  Its place it does carry, so that narrowing it does answer. */
+ *  Its place it does carry, so that narrowing it does answer.
+ *
+ *  Asked of the narrowing alone, because a count has to know whether those
+ *  rows belong in its total before it is given any: {@link missingUnder} is
+ *  this same rule applied to rows in hand, and
+ *  {@link installedCountByKind} is what asks it without them. Private,
+ *  because a caller weighing it itself would be a second answer to the one
+ *  question those two share. */
+const admitsMissing = (filter: ItemFilter): boolean =>
+  !filter.harness && !filter.tag;
+
+/** The rows for packages with no copy left that a narrowing admits. */
 export function missingUnder(
   missing: UpdateRow[],
   filter: ItemFilter,
 ): UpdateRow[] {
-  if (filter.harness || filter.tag) return [];
+  if (!admitsMissing(filter)) return [];
   return missing.filter((row) => scopeMatches(row, filter.scope));
 }
 
@@ -397,18 +408,37 @@ export interface ItemPlace {
  *  opens. A package installed on two harnesses, or in two locations, is one
  *  package here as it is there. A kind the place holds nothing of is absent
  *  rather than zero: the badges are what a place has, not a checklist of
- *  what it hasn't. */
+ *  what it hasn't.
+ *
+ *  Counts a package whose rendering is gone the way the Library's own list
+ *  draws it, through {@link withRecordedMissing}: the record says it is
+ *  installed here, so leaving it out would be a number the table its badge
+ *  opens disagrees with.
+ *
+ *  Null where those rows are part of this place's total and no read may be
+ *  counted over them — a figure taken then is definite over a set the
+ *  failed check could not confirm. A narrowing {@link admitsMissing} refuses
+ *  has a number whatever that read did, because no such row was ever in it. */
 export function installedCountByKind(
   items: ObservedItem[],
   place: ItemPlace,
   packageOf: PackageOf,
-): Map<ItemKind, number> {
-  const tally = new Map<ItemKind, number>();
-  const here = filterItems(items, {
+  /** The rows saying a recorded rendering is gone, or null where nothing
+   *  may be counted over them — `missing-files.ts::useCountableMissingRows`. */
+  missing: UpdateRow[] | null,
+): Map<ItemKind, number> | null {
+  const filter: ItemFilter = {
     scope: place.scope ?? "all",
     harness: place.harness,
-  });
-  for (const group of groupItems(here, packageOf)) {
+  };
+  if (missing === null && admitsMissing(filter)) return null;
+  const tally = new Map<ItemKind, number>();
+  const here = filterItems(items, filter);
+  const groups = withRecordedMissing(
+    groupItems(here, packageOf),
+    missingUnder(missing ?? [], filter),
+  );
+  for (const group of groups) {
     tally.set(group.kind, (tally.get(group.kind) ?? 0) + 1);
   }
   // Handed back in the app's kind order, not the grouping's: the badges sit

--- a/ui/src/lib/library-standings.ts
+++ b/ui/src/lib/library-standings.ts
@@ -10,7 +10,7 @@ import type { ItemGroup } from "@/lib/derive";
 import { groupPlaces, packageKey } from "@/lib/derive";
 import { useMissingRows } from "@/lib/missing-files";
 import { availableUpdates } from "@/lib/update-groups";
-import { rowsKnown } from "@/lib/updates-read-state";
+import { rowsCountable, rowsKnown } from "@/lib/updates-read-state";
 import { useEditorStore } from "@/stores/editor";
 import { useUpdatesStore } from "@/stores/updates";
 
@@ -45,7 +45,7 @@ export function useLibraryStandings(groups: ItemGroup[]): {
   const savedSettings = useEditorStore((s) => s.savedSettings);
   const updateRows = useUpdatesStore((s) => s.rows);
   const updatesLoaded = useUpdatesStore(rowsKnown);
-  const updatesLanded = useUpdatesStore((s) => s.read.status === "landed");
+  const updatesCountable = useUpdatesStore(rowsCountable);
   const places = useMemo(
     () => placesSource(saved, updateRows, updatesLoaded, savedSettings),
     [saved, updateRows, updatesLoaded, savedSettings],
@@ -114,10 +114,10 @@ export function useLibraryStandings(groups: ItemGroup[]): {
   );
   const outOfDateAnywhere = useMemo(
     () =>
-      updatesLanded
+      updatesCountable
         ? (group: ItemGroup) => outOfDate.has(`${group.kind}:${group.name}`)
         : null,
-    [outOfDate, updatesLanded],
+    [outOfDate, updatesCountable],
   );
   const missingIn = useMemo(
     () => (updatesLoaded ? missingScopes : null),

--- a/ui/src/lib/missing-files.ts
+++ b/ui/src/lib/missing-files.ts
@@ -1,6 +1,6 @@
 import { useMemo } from "react";
 import type { UpdateRow } from "@/bindings";
-import { rowsKnown } from "@/lib/updates-read-state";
+import { rowsCountable, rowsKnown } from "@/lib/updates-read-state";
 import { useUpdatesStore } from "@/stores/updates";
 
 /** The rows saying a file kendex recorded writing is gone from disk: the
@@ -19,7 +19,9 @@ const missingFiles = (rows: UpdateRow[]): UpdateRow[] =>
  *  as about the scan.
  *
  *  Known on {@link rowsKnown}, the rule every reader of the per-place facts
- *  takes: a landed read, or a failed re-check over the rows it kept.
+ *  takes: a landed read, or a failed re-check over the rows it kept. A
+ *  caller putting a NUMBER on screen takes {@link useCountableMissingRows}
+ *  instead.
  *
  *  Memoized because it is grouped against: a fresh array every render
  *  re-groups the whole scan on every render. */
@@ -27,4 +29,23 @@ export function useMissingRows(): UpdateRow[] | null {
   const rows = useUpdatesStore((s) => s.rows);
   const known = useUpdatesStore(rowsKnown);
   return useMemo(() => (known ? missingFiles(rows) : null), [rows, known]);
+}
+
+/** The same rows where a definite count may be taken over them, and null
+ *  where one may not — {@link rowsCountable}, which is a landed read and
+ *  nothing else.
+ *
+ *  A package with no copy left is on this machine and in every total of
+ *  what is installed; these rows are the only thing that says so. So a
+ *  total taken while they stand unconfirmed is a definite figure over a set
+ *  the failed check could not confirm, and the surfaces that draw one —
+ *  Home's Installed tile, the Library's total, a place's kind badges — ask
+ *  this rather than {@link useMissingRows}.
+ *
+ *  Handed back as the same array, so a caller memoizing against it is not
+ *  re-grouped for a question about the read. */
+export function useCountableMissingRows(): UpdateRow[] | null {
+  const rows = useMissingRows();
+  const countable = useUpdatesStore(rowsCountable);
+  return countable ? rows : null;
 }

--- a/ui/src/lib/package-identity.ts
+++ b/ui/src/lib/package-identity.ts
@@ -214,6 +214,22 @@ export function packagesUncounted(
   return known ? null : PLACE_COUNTING_LABEL;
 }
 
+/** Why a read a count stands on puts no number on a place, or null where
+ *  it puts one — the same two labels in the same slot, for a read with no
+ *  scan generation to weigh against. The update read is one: it speaks for
+ *  the whole machine at once, so whether its rows are current is the read's
+ *  own status and nothing else. */
+export function uncountedRead(read: ReadState): string | null {
+  switch (read.status) {
+    case "failed":
+      return PLACE_UNCHECKED_LABEL;
+    case "pending":
+      return PLACE_COUNTING_LABEL;
+    case "landed":
+      return null;
+  }
+}
+
 /** Whether a page opened on this reference may address a declaration.
  *
  *  The one place that question is answered. A recorded package has a

--- a/ui/src/lib/updates-read-state.test.ts
+++ b/ui/src/lib/updates-read-state.test.ts
@@ -1,7 +1,17 @@
 import { describe, expect, it } from "vitest";
 import type { ScanWarning } from "@/bindings";
 import type { PackageOf } from "@/lib/package-identity";
-import { scannedInstalled } from "@/lib/updates-read-state";
+import {
+  READ_LANDED,
+  READ_PENDING,
+  type ReadState,
+  readFailed,
+} from "@/lib/read-state";
+import {
+  rowsCountable,
+  rowsKnown,
+  scannedInstalled,
+} from "@/lib/updates-read-state";
 import { observedSkill, scanFound } from "@/test/observed";
 
 /** A join that recognises nothing, so fixtures group as the scan saw them. */
@@ -71,6 +81,43 @@ describe("the installed count an empty Updates page may be read from", () => {
         scannedInstalled(row.scan, row.error ?? null, row.packageOf),
         row.name,
       ).toBe(row.count);
+    }
+  });
+});
+
+// Two rules over one set of rows, and which one a surface takes decides
+// whether a number reaches the page. A fact is about one place and outlives
+// a re-check that failed over the rows it kept — the fork badge, the edit,
+// the places a package's files are gone from. A number is about all of them
+// at once, and that set is precisely what the failed check was asked to
+// confirm.
+describe("what the update rows may be read as", () => {
+  const kept = [{ kind: "skill", name: "deploy" }];
+
+  it("tells a fact from a number for every read a page can be in", () => {
+    const rows: [string, ReadState, unknown[], boolean, boolean][] = [
+      ["a read that landed answers both", READ_LANDED, kept, true, true],
+      ["a landed read over no rows answers both", READ_LANDED, [], true, true],
+      [
+        "a failed re-check keeps its facts and loses its number",
+        readFailed("no network"),
+        kept,
+        true,
+        false,
+      ],
+      [
+        "a first read that failed has neither",
+        readFailed("no network"),
+        [],
+        false,
+        false,
+      ],
+      ["a read still on its way has neither", READ_PENDING, kept, false, false],
+    ];
+    expect(rows).toHaveLength(5);
+    for (const [name, read, rows_, known, countable] of rows) {
+      expect(rowsKnown({ read, rows: rows_ }), name).toBe(known);
+      expect(rowsCountable({ read }), name).toBe(countable);
     }
   });
 });

--- a/ui/src/lib/updates-read-state.ts
+++ b/ui/src/lib/updates-read-state.ts
@@ -81,13 +81,32 @@ export const emptyStanding = (
  *  every reader of the per-place facts — the Library, the package header
  *  and the Customize page — so a fork or an edit is never a fact on one
  *  page and unknown on the next. A read still on its way, or a first
- *  read that failed with nothing kept, has nothing to read. */
+ *  read that failed with nothing kept, has nothing to read.
+ *
+ *  Counting those rows is a stricter question, and {@link rowsCountable}
+ *  is where it is answered. */
 export const rowsKnown = (state: {
   read: { status: string };
   rows: unknown[];
 }): boolean =>
   state.read.status === "landed" ||
   (state.read.status === "failed" && state.rows.length > 0);
+
+/** Whether a definite number may be taken over the update rows: a read
+ *  that landed, and nothing else.
+ *
+ *  Stricter than {@link rowsKnown}, and the difference between them is why
+ *  both exist. A fact is about one place — a fork, an edit, which places a
+ *  package's files are gone from — and rows a failed re-check kept are the
+ *  last thing anything observed about those places, which is what the page
+ *  says they are. A number is about all of them at once: it says this many
+ *  and no more, over the very set the failed check was asked to confirm and
+ *  could not. A mark saying a package is out of date anywhere is that same
+ *  claim taken over that same set, and asks this too.
+ *
+ *  `grep -rn rowsCountable ui/src` is the list of surfaces that ask. */
+export const rowsCountable = (state: { read: { status: string } }): boolean =>
+  state.read.status === "landed";
 
 /** Whether work the writes exclude is already out: a check building its
  *  report, or a write about to commit under it. One write at a time is what

--- a/ui/src/pages/overview.test.tsx
+++ b/ui/src/pages/overview.test.tsx
@@ -4,6 +4,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { ObservedItem, ScanResult, UnreadableScope } from "@/bindings";
 import {
   AUDIT_ATTENTION_TITLE,
+  PACKAGES_UNCHECKED_DETAIL,
   SCAN_AGAIN_LABEL,
   SCAN_FAILED_TITLE,
   SCAN_STALE_TITLE,
@@ -37,6 +38,7 @@ const { stub, wrap } = vi.hoisted(() => {
       scanning: false,
     },
     updates: {
+      rows: [] as unknown[],
       read: { status: "landed", error: null } as ReadState,
       unreadable: [] as UnreadableScope[],
     },
@@ -140,7 +142,7 @@ beforeEach(() => {
   // the scan saw them, and the tile may count.
   stub.provenance = { rows: [], loaded: true, answeredFor: 0 };
   stub.scan = { result: null, error: null, scanning: false };
-  stub.updates = { read: READ_LANDED, unreadable: [] };
+  stub.updates = { rows: [], read: READ_LANDED, unreadable: [] };
   stub.market = { read: READ_LANDED };
   stub.audit = { auditedAt: null, read: READ_LANDED };
 });
@@ -250,7 +252,7 @@ describe("Home when the update check fails", () => {
     for (const row of rows) {
       stub.scan = { result: scanned, error: null, scanning: false };
       stub.audit = { auditedAt: Date.now(), read: READ_LANDED };
-      stub.updates = { read: row.read, unreadable: [] };
+      stub.updates = { rows: [], read: row.read, unreadable: [] };
       expect(
         renderToStaticMarkup(<OverviewPage />).includes(
           esc(UPDATES_ATTENTION_TITLE),
@@ -270,6 +272,7 @@ describe("Home when a place cannot be read at all", () => {
     stub.scan = { result: scanned, error: null, scanning: false };
     stub.audit = { auditedAt: Date.now(), read: READ_LANDED };
     stub.updates = {
+      rows: [],
       read: READ_LANDED,
       unreadable: [
         {
@@ -339,7 +342,7 @@ describe("Home when the audit fails", () => {
         scanning: row.result === null,
       };
       stub.audit = row.audit;
-      stub.updates = { read: row.updates, unreadable: [] };
+      stub.updates = { rows: [], read: row.updates, unreadable: [] };
       const html = renderToStaticMarkup(<OverviewPage />);
       expect(
         {
@@ -390,6 +393,46 @@ describe("the Installed tile", () => {
     };
     const html = renderToStaticMarkup(<OverviewPage />);
     expect(tileValue(html, "Installed")).toBe("—");
+  });
+
+  // A package whose rendering was deleted by hand is still installed: the
+  // record says so, and the Library's table the tile opens stands its row
+  // up from the update rows. Left out, the tile is short by exactly the
+  // packages its own missing-files row above is about. Those rows are also
+  // the set a failed re-check was asked to confirm, so a total taken over
+  // them then would be definite about what nothing has counted.
+  it("counts a package with no copy left, and only while a read confirms it", () => {
+    const gone = {
+      kind: "skill",
+      name: "orch",
+      scope: { scope: "global" },
+      filesMissing: true,
+    };
+    stub.scan = {
+      result: { ...scanned, items: [installed({})] },
+      error: null,
+      scanning: false,
+    };
+    const rows: [string, ReadState, string][] = [
+      ["a landed read counts it beside the one on disk", READ_LANDED, "2"],
+      [
+        "a failed re-check over the same rows publishes no total",
+        readFailed("no network"),
+        "—",
+      ],
+      ["a read still on its way publishes none either", READ_PENDING, "—"],
+    ];
+    expect(rows).toHaveLength(3);
+    for (const [name, read, value] of rows) {
+      stub.updates = { rows: [gone], read, unreadable: [] };
+      const html = renderToStaticMarkup(<OverviewPage />);
+      expect(tileValue(html, "Installed"), name).toBe(value);
+      // The dash is not the whole answer: a failed read says so beside it,
+      // where one still on its way has nothing to say yet.
+      expect(html.includes(esc(PACKAGES_UNCHECKED_DETAIL)), name).toBe(
+        read.status === "failed",
+      );
+    }
   });
 });
 

--- a/ui/src/pages/overview.tsx
+++ b/ui/src/pages/overview.tsx
@@ -19,9 +19,15 @@ import {
   SCAN_STALE_TITLE,
 } from "@/lib/copy";
 import { MARKETPLACES_UNCHECKED_DETAIL } from "@/lib/copy-marketplaces";
-import { groupItems, installedCount, recentItems } from "@/lib/derive";
+import {
+  groupItems,
+  installedCount,
+  recentItems,
+  withRecordedMissing,
+} from "@/lib/derive";
 import { harnessName } from "@/lib/labels";
 import { CONTENT_WIDTH, PAGE_BODY } from "@/lib/layout";
+import { useCountableMissingRows } from "@/lib/missing-files";
 import {
   usePackageIndex,
   usePackagesKnown,
@@ -29,6 +35,7 @@ import {
 } from "@/lib/package-identity";
 import { rescanEverything } from "@/lib/rescan";
 import { availableUpdateCount } from "@/lib/update-groups";
+import { rowsCountable } from "@/lib/updates-read-state";
 import { cn } from "@/lib/utils";
 import { useAuditOnMount, useAuditStore } from "@/stores/audit";
 import { useMarketplacesStore } from "@/stores/marketplaces";
@@ -61,13 +68,13 @@ export function OverviewPage() {
   const editedPackages = updateRows.filter((row) => row.blockedByLocalEdit);
   const missingPackages = updateRows.filter((row) => row.filesMissing);
   const updatesError = useUpdatesStore((s) => s.read.error);
-  // Only a landed read may put a number on the page. `rows` survives a
-  // failed re-check as last-known facts, which is enough for the edited
-  // row above and not enough for a count. Counted as updates and not as
-  // news: the sidebar's badge stands for the Updates page's whole list,
-  // this row's words promise an update to take.
+  // The rows survive a failed re-check as last-known facts, which is enough
+  // for the edited row above and not enough for a number —
+  // [rowsCountable] is the one rule for that difference. Counted as updates
+  // and not as news: the sidebar's badge stands for the Updates page's
+  // whole list, this row's words promise an update to take.
   const updates = useUpdatesStore((s) =>
-    s.read.status === "landed" ? availableUpdateCount(s.rows) : null,
+    rowsCountable(s) ? availableUpdateCount(s.rows) : null,
   );
   const unreadable = useUpdatesStore((s) => s.unreadable);
   const goTo = useNavStore((s) => s.goTo);
@@ -94,9 +101,21 @@ export function OverviewPage() {
   const packageOf = usePackageIndex();
   const packagesKnown = usePackagesKnown();
   const packagesRead = usePackagesRead();
+  // The packages whose rendering a record says is gone. They are installed
+  // and the scan has nothing to observe of them, so the tile counts them
+  // the way the Library's list draws them — otherwise the tile is short by
+  // exactly the packages its own missing-files row above is about. Null
+  // where no read may be counted over them, which takes the number away.
+  const missingRows = useCountableMissingRows();
   const groups = useMemo(
-    () => (result && packageOf ? groupItems(result.items, packageOf) : []),
-    [result, packageOf],
+    () =>
+      result && packageOf
+        ? withRecordedMissing(
+            groupItems(result.items, packageOf),
+            missingRows ?? [],
+          )
+        : [],
+    [result, packageOf, missingRows],
   );
 
   const scanAgain = (
@@ -162,6 +181,9 @@ export function OverviewPage() {
   const harnessNames = (result?.harnesses ?? [])
     .map((h) => harnessName(h.harness))
     .join(", ");
+  // A package with no copy left has no mtime anywhere, so the rows standing
+  // one up carry none and this list is the same one it was before they
+  // joined `groups`: "Recently changed" is about files, and there are none.
   const recent = recentItems(groups, RECENT_ACTIVITY_LIMIT);
 
   return (
@@ -223,16 +245,22 @@ export function OverviewPage() {
                 />
                 {/* Counted in the Library's unit — packages, not
                     installations — so the number matches the table the
-                    click lands on, and only once the read that says which
-                    installations are one package has answered. A number
-                    taken before it would count installations under a label
-                    that says packages; one kept from an earlier answer is
-                    last-known, and says so rather than passing as current. */}
+                    click lands on, and only once both reads behind that
+                    set have answered. A number taken before the join would
+                    count installations under a label that says packages;
+                    one taken over rows a failed update check could not
+                    confirm is a definite figure for a set nothing stands
+                    behind. Either way the dash, with the reason beside it
+                    and, for the update check, its own row above. */}
                 <StatTile
                   label="Installed"
-                  value={packagesKnown ? installedCount(groups) : null}
+                  value={
+                    packagesKnown && missingRows !== null
+                      ? installedCount(groups)
+                      : null
+                  }
                   detail={
-                    packagesRead.status === "failed"
+                    packagesRead.status === "failed" || updatesError !== null
                       ? PACKAGES_UNCHECKED_DETAIL
                       : undefined
                   }


### PR DESCRIPTION
## Summary

- The update rows had one rule, `rowsKnown`: a landed read, or a failed re-check over the rows it kept. That is right for a fact about one place and wrong for a number. `ui/src/lib/updates-read-state.ts::rowsCountable` is the second rule — a landed read and nothing else — with the difference between them stated once, in its doc comment.
- Home's Installed tile, My Library's total and a place's kind badges each now count the packages whose rendering was deleted, and each withholds its number on that judge rather than publishing a definite count over rows a failed check could not confirm. Before this, the tile and the badges counted the scan alone while the Library counted the missing rows too, so the three disagreed — against `derive.ts::installedCount`'s own stated contract that the tile can never disagree with the table it opens.
- Four inline copies of the counting rule are gone, reading the judge instead: `library-standings.ts`, `project-list.tsx::outOfDate`, `project-list.tsx::countsAt` and Home's own updates count. The issue names this defect the second appearance of a class an earlier round patched in the same hook, so the class is closed at its owner rather than patched per site.

## Context

This branch was cut from #2570 (KEN-1369) under the size tripwire and is based on it: `missing-files.ts`, `withRecordedMissing` and `missingUnder` arrive with that merge, and the defect arrives with them. On main before #2570 the three surfaces counted the scan alone and never read the updates store, so the reported symptom could not occur there.

## Completed Issues

- Closes KEN-1372 - Home, Library and project badges publish a definite installed count after a failed re-check that kept rows

## Size

The issue states no `**Expected delta**`, so `branch-size-check` judged nothing and reported the counts: **336 production lines, 439 test lines, 0 mirror lines** added, over 18 files.

The test count is the larger half by design. The Done-when asks for one row per surface for the failed-after-success state and its inverse, and the surfaces are three; the fix round added three more pairs.

## Test Plan

Six rows for the Done-when, one per surface for the failed-after-success state and one pinning the count on a landed read, plus one pair per fix-round item:

- `ui/src/pages/overview.test.tsx` — Home's tile withholds its number after a failed re-check and states the reason beside it; a landed read pins the count, the recorded-missing packages included.
- `ui/src/components/library/installed-view.dom.test.tsx` — the Library's total and its empty row after a failed re-check; the inverse pins both. Plus: the empty row still draws its wording under a Harness or Tag narrowing, where no missing row could ever appear; and the page states why its total is withheld.
- `ui/src/components/harnesses/project-list.dom.test.tsx` — the kind badges after a failed re-check and on a landed read. Plus: a place the update read could not cover shows the unchecked label rather than a number.
- `ui/src/lib/updates-read-state.test.ts`, `ui/src/lib/derive.test.ts` — `rowsCountable` against `rowsKnown` at the boundary, and `installedCountByKind`'s narrowing: a place admits the missing rows and has no number without a read, a harness narrowing admits none and keeps its number.

Each was proved by planting its defect and watching that row alone redden: nine plants across the two rounds. `env -u TMPDIR tools/guard --full` exits 0 on the final head with no `guard:` lines. Preflight clean over 18 files; 1540 UI tests passing.

## Notes for review

Two changes reach past the three surfaces the Done-when names, both landing enablers rather than scope:

- `project-card.tsx`'s "Add packages" empty state now yields to `uncounted`. Without it the badge fix does not reach the card: the count goes, `counts` is empty, and the card claims the place is empty in a different shape. The card's dropdown still offers "Add packages", so no route is lost.
- `harness-list.tsx` is the second caller of `installedCountByKind`, whose signature changed; its diff is a parameter pass-through plus null handling. A harness narrowing admits no missing rows, so that row keeps its number.

One sibling is deliberately not fixed here. With one project's update read refusing and that project holding a deleted rendering, Home's tile and the Library's total each publish a number short by that project's packages. The trigger is a landed read that missed one place, not the failed re-check this issue names, and it needs two uncommon conditions at once for a count that is merely low. `updates-read-state.ts::scannedInstalled` is the precedent for the fix — it already returns null for a machine-wide figure when the scan missed any project. Raised to the maintainer to route rather than widened here.

https://claude.ai/code/session_01PQS9gNtBa75EEr7CHZS9zK
