### PR TITLE
fix(KEN-1380): preflight judges shell text inside single-quoted template strings as the script's own command, so a moved hook template blocks the commit

### DIFF
--- a/.agents/skills/preflight/scripts/preflight
+++ b/.agents/skills/preflight/scripts/preflight
@@ -81,8 +81,12 @@ Lanes:
                   reader fed a here-string or a file, a reader that runs to
                   the end of its input (tr, sed, wc), a command after ||
                   rather than after a pipe, or the same text on a comment
-                  line. A file with no pipefail preamble of its own is out of
-                  scope even where a sourcing caller supplies one.
+                  line. A quoted message IS read as a pipeline when it also
+                  carries a command substitution: the span is kept whole
+                  because the substitution runs, and the pipe inside it
+                  cannot be told from the one outside. A file with no
+                  pipefail preamble of its own is out of scope even where a
+                  sourcing caller supplies one.
   unwired-suite   a new suite file no runner invokes. Suites are
                   tests/*.test.sh, tests/test-*.sh, a shell file with a
                   test-<name> basename and no extension, *.test.ts, *.test.js
@@ -902,52 +906,105 @@ is_comment_line() { # LINE — leading-whitespace-then-# only; a trailing commen
 # one. A double-quoted span still runs whatever a `$(` inside it opens, so
 # that one is kept whole. The delimiters stay, so the command-position anchor
 # every line-shape lane carries still reads the word boundary a quote makes.
-# A pair is required: the lone apostrophe of `don't` closes no span, and a
-# string whose closing quote is on another line is not one of these.
 #
 # One blanking step for every lane that judges a line as this script's own
 # commands (both the fail-open shapes the text decides, mktemp-trap,
 # early-close-pipe). hardcoded-temp-path is not one of them: its subject is
 # the quoted literal itself, in any language. masked-returns is not either,
 # because a parse of the whole file owns that lane's reading.
+#
+# A double-quoted span ends at the first `"` OUTSIDE any substitution it
+# opened, never at the next `"` in the text: shell restarts quoting inside
+# `$( … )`, so the inner quotes of `x="$(cmd "$arg")"` belong to the
+# substitution. Ending the span at one of those would cut the line at the
+# inner quote and drop the rest of the command, including the `)` that
+# `substitution_status_checked` reads and the pipeline `early-close-pipe`
+# looks for. `st` is the nesting stack that holds that property, innermost
+# context last: `'` a single-quoted span, `"` a double-quoted one, `(` a
+# substitution or subshell. Only `$(` opens one from inside double quotes,
+# where a bare paren is literal; inside a substitution every quote opens
+# again. A span that never closes on this line is not a span: its opening
+# quote is emitted as ordinary text and the scan resumes after it, so an
+# unpaired apostrophe cannot swallow a double-quoted span behind it.
+#
 # In-shell and out through a global, never a subprocess: this runs on every
 # added shell line that carries a quote, and a fork per line costs more than
-# all the lanes it feeds. Each turn takes the leftmost span that actually
-# closes, so an unpaired apostrophe cannot swallow a double-quoted span
-# behind it.
+# all the lanes it feeds. Each turn jumps to the next character its own state
+# cares about rather than walking the line one character at a time.
 shell_command_text() { # LINE — sets SHELL_COMMAND_TEXT
-  local rest="$1" out="" pre="" body="" q="" sq_pre="" dq_pre="" sq_closes=0 dq_closes=0
+  local rest="$1" out="" st="" top="" span="" openq="" resume="" pre="" tok=""
   while :; do
-    sq_pre="${rest%%\'*}"
-    dq_pre="${rest%%\"*}"
-    sq_closes=0
-    dq_closes=0
-    if [ "$sq_pre" != "$rest" ]; then
-      case "${rest#"$sq_pre'"}" in *\'*) sq_closes=1 ;; esac
-    fi
-    if [ "$dq_pre" != "$rest" ]; then
-      case "${rest#"$dq_pre\""}" in *\"*) dq_closes=1 ;; esac
-    fi
-    if [ "$sq_closes" = 1 ] && { [ "$dq_closes" = 0 ] || [ "${#sq_pre}" -lt "${#dq_pre}" ]; }; then
-      q="'"
-      pre="$sq_pre"
-    elif [ "$dq_closes" = 1 ]; then
-      q='"'
-      pre="$dq_pre"
-    else
+    case "$top" in
+      '') pre="${rest%%[\"\']*}" ;;
+      "'") pre="${rest%%\'*}" ;;
+      '"') pre="${rest%%[\"\$]*}" ;;
+      *) pre="${rest%%[\"\'()]*}" ;;
+    esac
+    if [ "$pre" = "$rest" ]; then
+      if [ -n "$st" ]; then
+        out="$out$openq"
+        rest="$resume"
+        st=""
+        top=""
+        span=""
+        continue
+      fi
+      out="$out$rest"
       break
     fi
-    rest="${rest#"$pre$q"}"
-    body="${rest%%"$q"*}"
-    rest="${rest#"$body$q"}"
-    if [ "$q" = '"' ]; then
-      case "$body" in
-        *'$('*) out="$out$pre$q$body$q"; continue ;;
-      esac
+    tok="${rest#"$pre"}"
+    tok="${tok%"${tok#?}"}"
+    rest="${rest#"$pre$tok"}"
+    if [ -z "$st" ]; then
+      out="$out$pre"
+      openq="$tok"
+      span="$tok"
+      resume="$rest"
+      st="$tok"
+      top="$tok"
+      continue
     fi
-    out="$out$pre$q$q"
+    span="$span$pre$tok"
+    case "$top" in
+      "'" | '"')
+        if [ "$tok" = "$top" ]; then
+          st="${st%?}"
+          top="${st#"${st%?}"}"
+        elif [ "$tok" = '$' ]; then
+          case "$rest" in
+            '('*)
+              span="$span("
+              rest="${rest#?}"
+              st="$st("
+              top="("
+              ;;
+          esac
+        fi
+        ;;
+      *)
+        case "$tok" in
+          ')')
+            st="${st%?}"
+            top="${st#"${st%?}"}"
+            ;;
+          *)
+            st="$st$tok"
+            top="$tok"
+            ;;
+        esac
+        ;;
+    esac
+    if [ -z "$st" ]; then
+      case "$span" in
+        \'*) out="$out''" ;;
+        *'$('*) out="$out$span" ;;
+        *) out="$out\"\"" ;;
+      esac
+      span=""
+      openq=""
+    fi
   done
-  SHELL_COMMAND_TEXT="$out$rest"
+  SHELL_COMMAND_TEXT="$out"
 }
 
 # The `|| true` shape on a command whose exit 2 means "could not read" or

--- a/.agents/skills/preflight/scripts/preflight
+++ b/.agents/skills/preflight/scripts/preflight
@@ -914,36 +914,60 @@ is_comment_line() { # LINE — leading-whitespace-then-# only; a trailing commen
 # the quoted literal itself, in any language. masked-returns is not either,
 # because a parse of the whole file owns that lane's reading.
 #
-# A double-quoted span ends at the first `"` OUTSIDE any substitution it
-# opened, never at the next `"` in the text: shell restarts quoting inside a
-# substitution, so the inner quotes of `x="$(cmd "$arg")"` belong to it.
-# Ending the span at one of those would cut the line at the inner quote and
-# drop the rest of the command, including the `)` that
-# `substitution_status_checked` reads and the pipeline `early-close-pipe`
-# looks for. `st` is the nesting stack that holds that property, innermost
-# context last: `'` a single-quoted span, `"` a double-quoted one, `(` a
-# substitution or subshell, ``` the older substitution spelling, which
-# closes at its matching backtick rather than at a paren. Both spellings run
-# a command from inside double quotes, and both are what the mktemp-trap and
-# early-close-pipe anchors already name as a command position; a bare paren
-# there is literal, and inside a substitution every quote opens again. A span
-# that never closes on this line is not a span: its opening quote is emitted
-# as ordinary text and the scan resumes after it, so an unpaired apostrophe
-# cannot swallow a double-quoted span behind it.
+# This is a lexer, and the set of shell rules it implements is the whole of
+# what it promises. A gap in the set is a lane going blind, not a cosmetic
+# miss, so the set is written out here for a reader to check against rather
+# than discover one shape at a time. Implemented:
+#
+#   - A single-quoted span runs to the next `'`. Nothing inside it expands,
+#     escapes or opens anything.
+#   - A double-quoted span runs to the first `"` OUTSIDE any substitution it
+#     opened. Shell restarts quoting inside a substitution, so the inner
+#     quotes of `x="$(cmd "$arg")"` belong to it; ending the span at one of
+#     those would cut the line at the inner quote and drop the rest of the
+#     command, the `)` that `substitution_status_checked` reads and the
+#     pipeline `early-close-pipe` looks for with it.
+#   - Both substitution spellings open a nesting from inside double quotes:
+#     `$( … )`, closing at its matching paren with nested parens counted, and
+#     `` … ``, closing at its matching backtick. Both run a command, and
+#     both are what the mktemp-trap and early-close-pipe anchors already name
+#     as a command position. A bare paren inside double quotes is literal.
+#   - A backslash escapes the character after it everywhere except inside a
+#     single-quoted span, where it is literal. So `"a\"b"` is one span, not
+#     two, and the code after it is not read as this file's own.
+#   - A span that never closes on this line is not a span: its opening quote
+#     is emitted as ordinary text and the scan resumes after it, so an
+#     unpaired apostrophe cannot swallow a double-quoted span behind it.
+#
+# Deliberately not implemented, each because it leaves inert text mis-split
+# rather than losing a command, which over-reports instead of going blind:
+#
+#   - Quote context across physical lines. preflight judges added lines one
+#     at a time, so the middle line of a multi-line template carries no quote
+#     and is read as code.
+#   - `$'…'` ANSI-C quoting, where a backslash DOES escape inside single
+#     quotes. The span ends early at the escaped quote.
+#   - Quotes nested inside `${…}`, which are lexed as adjacent spans. Nothing
+#     inside a parameter expansion runs a command.
+#   - Heredoc bodies, which are lines of data this scan reads as code.
+#
+# `st` is the nesting stack that holds all of it, innermost context last:
+# `'` a single-quoted span, `"` a double-quoted one, `(` a substitution or
+# subshell, ``` the backtick substitution.
 #
 # In-shell and out through a global, never a subprocess: this runs on every
 # added shell line that carries a quote, and a fork per line costs more than
 # all the lanes it feeds. Each turn jumps to the next character its own state
 # cares about rather than walking the line one character at a time.
 shell_command_text() { # LINE — sets SHELL_COMMAND_TEXT
-  local rest="$1" out="" st="" top="" span="" openq="" resume="" pre="" tok=""
+  local rest="$1" out="" st="" top="" span="" openq="" resume="" pre="" tok="" esc=""
   while :; do
     case "$top" in
-      '') pre="${rest%%[\"\']*}" ;;
+      '') pre="${rest%%[\"\'\\]*}" ;;
       "'") pre="${rest%%\'*}" ;;
-      '"') pre="${rest%%[\"\$\`]*}" ;;
-      '`') pre="${rest%%[\"\'(\`]*}" ;;
-      *) pre="${rest%%[\"\'()\`]*}" ;;
+      '"') pre="${rest%%[\"\$\`\\]*}" ;;
+      '`') pre="${rest%%[\"\'(\`\\]*}" ;;
+      *) pre="${rest%%[\"\'()\`\\]*}" ;;
     esac
     if [ "$pre" = "$rest" ]; then
       if [ -n "$st" ]; then
@@ -960,6 +984,16 @@ shell_command_text() { # LINE — sets SHELL_COMMAND_TEXT
     tok="${rest#"$pre"}"
     tok="${tok%"${tok#?}"}"
     rest="${rest#"$pre$tok"}"
+    if [ "$tok" = '\' ]; then
+      esc="${rest%"${rest#?}"}"
+      rest="${rest#?}"
+      if [ -z "$st" ]; then
+        out="$out$pre\\$esc"
+      else
+        span="$span$pre\\$esc"
+      fi
+      continue
+    fi
     if [ -z "$st" ]; then
       out="$out$pre"
       openq="$tok"

--- a/.agents/skills/preflight/scripts/preflight
+++ b/.agents/skills/preflight/scripts/preflight
@@ -914,6 +914,35 @@ is_comment_line() { # LINE — leading-whitespace-then-# only; a trailing commen
 # the quoted literal itself, in any language. masked-returns is not either,
 # because a parse of the whole file owns that lane's reading.
 #
+# A quoted span standing as the code argument of an interpreter is executed,
+# whatever quotes it wears, so it is this file's commands and not its text:
+# `eval` and the `-c` form of sh, bash, zsh, dash and ksh, the interpreter
+# word at a command position. Any word may sit between it and the `-c`,
+# because a flag with a detached value (bash -euo pipefail -c) is ordinary
+# and keeping a span that is not code only gives a lane more to read, while
+# blanking one that is loses the commands it carries.
+INTERP_CODE_RE='(^[[:space:]]*|[;(`{&|][[:space:]]*)(eval|([^[:space:]]*/)?(sh|bash|zsh|dash|ksh)([[:space:]]+[^[:space:]]+)*[[:space:]]+-c)[[:space:]]+$'
+
+# A line's shell command text: the quoted spans that run nothing, blanked to
+# their delimiters. Single quotes suppress every expansion, so their span is
+# literal text wherever it stands — the hook and script templates a tool
+# writes to disk carry commands that run in the written file, never in this
+# one. A span that DOES run something is kept whole.
+#
+# Two questions decide each span, and both are answered by the scan itself
+# rather than by re-reading the span's bytes. A byte search cannot answer
+# either one: it cannot tell a substitution the scan entered from an escaped
+# `\$(` the scan consumed as text, and it cannot see the interpreter word
+# that stands outside the span. `runs` records whether the scan entered a
+# substitution state while the span was open; `INTERP_CODE_RE` reads the
+# text before the span.
+#
+# One blanking step for every lane that judges a line as this script's own
+# commands (both the fail-open shapes the text decides, mktemp-trap,
+# early-close-pipe). hardcoded-temp-path is not one of them: its subject is
+# the quoted literal itself, in any language. masked-returns is not either,
+# because a parse of the whole file owns that lane's reading.
+#
 # This is a lexer, and the set of shell rules it implements is the whole of
 # what it promises. A gap in the set is a lane going blind, not a cosmetic
 # miss, so the set is written out here for a reader to check against rather
@@ -921,6 +950,9 @@ is_comment_line() { # LINE — leading-whitespace-then-# only; a trailing commen
 #
 #   - A single-quoted span runs to the next `'`. Nothing inside it expands,
 #     escapes or opens anything.
+#   - An ANSI-C span, `$'…'`, runs to the first UNESCAPED `'`, because a
+#     backslash escapes there and does not in the ordinary single-quoted
+#     form. Nothing in it runs either.
 #   - A double-quoted span runs to the first `"` OUTSIDE any substitution it
 #     opened. Shell restarts quoting inside a substitution, so the inner
 #     quotes of `x="$(cmd "$arg")"` belong to it; ending the span at one of
@@ -932,35 +964,42 @@ is_comment_line() { # LINE — leading-whitespace-then-# only; a trailing commen
 #     `` … ``, closing at its matching backtick. Both run a command, and
 #     both are what the mktemp-trap and early-close-pipe anchors already name
 #     as a command position. A bare paren inside double quotes is literal.
-#   - A backslash escapes the character after it everywhere except inside a
-#     single-quoted span, where it is literal. So `"a\"b"` is one span, not
-#     two, and the code after it is not read as this file's own.
+#   - A backslash escapes the character after it in every context but the
+#     ordinary single-quoted span, where it is literal. So `"a\"b"` is one
+#     span, not two, and the code after it is not read as this file's own.
 #   - A span that never closes on this line is not a span: its opening quote
 #     is emitted as ordinary text and the scan resumes after it, so an
 #     unpaired apostrophe cannot swallow a double-quoted span behind it.
 #
-# Deliberately not implemented, each because it leaves inert text mis-split
-# rather than losing a command, which over-reports instead of going blind:
+# Three rules are not implemented. Each one's direction is DERIVED by
+# constructing a line that exercises it and reading what the scan returns,
+# never asserted, because an omission that can lose a command is a fail-open
+# path and not a documented limitation:
 #
-#   - Quote context across physical lines. preflight judges added lines one
-#     at a time, so the middle line of a multi-line template carries no quote
-#     and is read as code.
-#   - `$'…'` ANSI-C quoting, where a backslash DOES escape inside single
-#     quotes. The span ends early at the escaped quote.
-#   - Quotes nested inside `${…}`, which are lexed as adjacent spans. Nothing
-#     inside a parameter expansion runs a command.
-#   - Heredoc bodies, which are lines of data this scan reads as code.
-#
-# `st` is the nesting stack that holds all of it, innermost context last:
-# `'` a single-quoted span, `"` a double-quoted one, `(` a substitution or
-# subshell, ``` the backtick substitution.
-#
-# In-shell and out through a global, never a subprocess: this runs on every
-# added shell line that carries a quote, and a fork per line costs more than
-# all the lanes it feeds. Each turn jumps to the next character its own state
-# cares about rather than walking the line one character at a time.
+#   - Quotes nested inside `${…}`, lexed as adjacent spans. Constructed:
+#     `a="${p:-"x"}"; git rev-parse --git-dir || true` returns the git
+#     command intact and exposes the bare `x`. A parameter expansion runs no
+#     command, so the mis-split text is inert and a substitution inside one
+#     is kept by `runs`. Over-reports, never loses.
+#   - Heredoc bodies, which are data this scan reads as code. Constructed: a
+#     body line `git rev-parse --git-dir || true` is returned unchanged and
+#     judged, so the lane fires on data. A data line carries no command to
+#     lose. Over-reports, never loses.
+#   - Quote context across physical lines. THIS ONE LOSES COMMANDS and is a
+#     known fail-open, not a limitation. preflight judges added lines one at
+#     a time, so a line holding one template's closing quote and the next
+#     one's opening quote pairs those two and blanks everything between.
+#     Constructed: on `  end'; mktemp -d; start='begin` and on the same line
+#     with `printf %s "$v" | head -1` in place of the mktemp, this step
+#     returns `  end''begin` and the command is gone. Its reach is a line
+#     that closes one quoted template and opens another with live code
+#     between them. main reports mktemp-trap and early-close-pipe on both of
+#     those lines, because those two lanes read the raw line there, so this
+#     step is worse than main on that shape; the swallowed-status shape is
+#     unchanged, since main blanked quoted spans for that lane already.
 shell_command_text() { # LINE — sets SHELL_COMMAND_TEXT
-  local rest="$1" out="" st="" top="" span="" openq="" resume="" pre="" tok="" esc=""
+  local rest="$1" out="" st="" top="" span="" openq="" resume="" pre="" tok=""
+  local esc="" prevch="" opens="" runs=0 keep=0
   while :; do
     # One arm per context, and no catch-all: a state whose arm stops
     # matching would otherwise borrow its neighbour's set and go on looking
@@ -970,6 +1009,7 @@ shell_command_text() { # LINE — sets SHELL_COMMAND_TEXT
     case "$top" in
       '') pre="${rest%%[\"\'\\]*}" ;;
       "'") pre="${rest%%\'*}" ;;
+      A) pre="${rest%%[\'\\]*}" ;;
       '"') pre="${rest%%[\"\$\`\\]*}" ;;
       '`') pre="${rest%%[\"\'(\`\\]*}" ;;
       '(') pre="${rest%%[\"\'()\`\\]*}" ;;
@@ -982,6 +1022,7 @@ shell_command_text() { # LINE — sets SHELL_COMMAND_TEXT
         st=""
         top=""
         span=""
+        runs=0
         continue
       fi
       out="$out$rest"
@@ -1000,18 +1041,36 @@ shell_command_text() { # LINE — sets SHELL_COMMAND_TEXT
       fi
       continue
     fi
+    # `$'…'` is its own context: a backslash escapes there, so the ordinary
+    # single-quoted arm would close the span at an escaped apostrophe and
+    # pair the real terminator with a later quote, swallowing the live code
+    # between them.
+    opens="$tok"
+    if [ "$tok" = "'" ]; then
+      if [ -n "$pre" ]; then
+        prevch="${pre#"${pre%?}"}"
+      elif [ -z "$st" ]; then
+        prevch="${out#"${out%?}"}"
+      else
+        prevch="${span#"${span%?}"}"
+      fi
+      if [ "$prevch" = '$' ]; then
+        opens=A
+      fi
+    fi
     if [ -z "$st" ]; then
       out="$out$pre"
       openq="$tok"
       span="$tok"
       resume="$rest"
-      st="$tok"
-      top="$tok"
+      st="$opens"
+      top="$opens"
+      runs=0
       continue
     fi
     span="$span$pre$tok"
     case "$top$tok" in
-      "''" | '""' | '``' | '()')
+      "''" | "A'" | '""' | '``' | '()')
         st="${st%?}"
         top="${st#"${st%?}"}"
         ;;
@@ -1022,24 +1081,43 @@ shell_command_text() { # LINE — sets SHELL_COMMAND_TEXT
             rest="${rest#?}"
             st="$st("
             top="("
+            runs=1
             ;;
         esac
         ;;
-      "'"*)
+      "'"* | A*)
         ;;
       *)
-        st="$st$tok"
-        top="$tok"
+        st="$st$opens"
+        top="$opens"
+        case "$opens" in
+          '(' | '`') runs=1 ;;
+        esac
         ;;
     esac
     if [ -z "$st" ]; then
-      case "$span" in
-        \'*) out="$out''" ;;
-        *'$('* | *'`'*) out="$out$span" ;;
-        *) out="$out\"\"" ;;
-      esac
+      keep="$runs"
+      if [ "$keep" = 0 ]; then
+        case "$out" in
+          *[[:space:]])
+            case "$out" in
+              *-c[[:space:]]* | *eval[[:space:]]*)
+                if grep -Eq -- "$INTERP_CODE_RE" <<<"$out"; then
+                  keep=1
+                fi
+                ;;
+            esac
+            ;;
+        esac
+      fi
+      if [ "$keep" = 1 ]; then
+        out="$out$span"
+      else
+        out="$out$openq$openq"
+      fi
       span=""
       openq=""
+      runs=0
     fi
   done
   SHELL_COMMAND_TEXT="$out"

--- a/.agents/skills/preflight/scripts/preflight
+++ b/.agents/skills/preflight/scripts/preflight
@@ -82,9 +82,9 @@ Lanes:
                   the end of its input (tr, sed, wc), a command after ||
                   rather than after a pipe, or the same text on a comment
                   line. A quoted message IS read as a pipeline when it also
-                  carries a command substitution: the span is kept whole
-                  because the substitution runs, and the pipe inside it
-                  cannot be told from the one outside. A file with no
+                  carries a command substitution, in either spelling: the
+                  span is kept whole because the substitution runs, and the
+                  pipe inside it cannot be told from the one outside. A file with no
                   pipefail preamble of its own is out of scope even where a
                   sourcing caller supplies one.
   unwired-suite   a new suite file no runner invokes. Suites are
@@ -152,10 +152,11 @@ Scope rules:
   delimiters. Single quotes suppress every expansion, so their span is text
   wherever it stands: the hook and script templates a tool writes to disk
   carry commands that run in the written file, never in the writer. A
-  double-quoted span is blanked too, unless a $( inside it opens a command
-  the line really runs. hardcoded-temp-path takes no blanking, since the
-  quoted literal is its subject; masked-returns takes none either, since
-  shellcheck parses the file and owns that reading.
+  double-quoted span is blanked too, unless a substitution inside it opens a
+  command the line really runs: $( … ) or the backtick spelling, both of
+  which these lanes already name as a command position. hardcoded-temp-path
+  takes no blanking, since the quoted literal is its subject; masked-returns
+  takes none either, since shellcheck parses the file and owns that reading.
   In an installed-artifact subtree (.agents/ and the harness directories'
   skills, agents, hooks, rules, instructions, packages and kendex trees)
   masked-returns, fail-open, early-close-pipe, unwired-suite, mktemp-trap and
@@ -914,18 +915,21 @@ is_comment_line() { # LINE — leading-whitespace-then-# only; a trailing commen
 # because a parse of the whole file owns that lane's reading.
 #
 # A double-quoted span ends at the first `"` OUTSIDE any substitution it
-# opened, never at the next `"` in the text: shell restarts quoting inside
-# `$( … )`, so the inner quotes of `x="$(cmd "$arg")"` belong to the
-# substitution. Ending the span at one of those would cut the line at the
-# inner quote and drop the rest of the command, including the `)` that
+# opened, never at the next `"` in the text: shell restarts quoting inside a
+# substitution, so the inner quotes of `x="$(cmd "$arg")"` belong to it.
+# Ending the span at one of those would cut the line at the inner quote and
+# drop the rest of the command, including the `)` that
 # `substitution_status_checked` reads and the pipeline `early-close-pipe`
 # looks for. `st` is the nesting stack that holds that property, innermost
 # context last: `'` a single-quoted span, `"` a double-quoted one, `(` a
-# substitution or subshell. Only `$(` opens one from inside double quotes,
-# where a bare paren is literal; inside a substitution every quote opens
-# again. A span that never closes on this line is not a span: its opening
-# quote is emitted as ordinary text and the scan resumes after it, so an
-# unpaired apostrophe cannot swallow a double-quoted span behind it.
+# substitution or subshell, ``` the older substitution spelling, which
+# closes at its matching backtick rather than at a paren. Both spellings run
+# a command from inside double quotes, and both are what the mktemp-trap and
+# early-close-pipe anchors already name as a command position; a bare paren
+# there is literal, and inside a substitution every quote opens again. A span
+# that never closes on this line is not a span: its opening quote is emitted
+# as ordinary text and the scan resumes after it, so an unpaired apostrophe
+# cannot swallow a double-quoted span behind it.
 #
 # In-shell and out through a global, never a subprocess: this runs on every
 # added shell line that carries a quote, and a fork per line costs more than
@@ -937,8 +941,9 @@ shell_command_text() { # LINE — sets SHELL_COMMAND_TEXT
     case "$top" in
       '') pre="${rest%%[\"\']*}" ;;
       "'") pre="${rest%%\'*}" ;;
-      '"') pre="${rest%%[\"\$]*}" ;;
-      *) pre="${rest%%[\"\'()]*}" ;;
+      '"') pre="${rest%%[\"\$\`]*}" ;;
+      '`') pre="${rest%%[\"\'(\`]*}" ;;
+      *) pre="${rest%%[\"\'()\`]*}" ;;
     esac
     if [ "$pre" = "$rest" ]; then
       if [ -n "$st" ]; then
@@ -965,39 +970,32 @@ shell_command_text() { # LINE — sets SHELL_COMMAND_TEXT
       continue
     fi
     span="$span$pre$tok"
-    case "$top" in
-      "'" | '"')
-        if [ "$tok" = "$top" ]; then
-          st="${st%?}"
-          top="${st#"${st%?}"}"
-        elif [ "$tok" = '$' ]; then
-          case "$rest" in
-            '('*)
-              span="$span("
-              rest="${rest#?}"
-              st="$st("
-              top="("
-              ;;
-          esac
-        fi
+    case "$top$tok" in
+      "''" | '""' | '``' | '()')
+        st="${st%?}"
+        top="${st#"${st%?}"}"
         ;;
-      *)
-        case "$tok" in
-          ')')
-            st="${st%?}"
-            top="${st#"${st%?}"}"
-            ;;
-          *)
-            st="$st$tok"
-            top="$tok"
+      '"$')
+        case "$rest" in
+          '('*)
+            span="$span("
+            rest="${rest#?}"
+            st="$st("
+            top="("
             ;;
         esac
+        ;;
+      "'"*)
+        ;;
+      *)
+        st="$st$tok"
+        top="$tok"
         ;;
     esac
     if [ -z "$st" ]; then
       case "$span" in
         \'*) out="$out''" ;;
-        *'$('*) out="$out$span" ;;
+        *'$('* | *'`'*) out="$out$span" ;;
         *) out="$out\"\"" ;;
       esac
       span=""

--- a/.agents/skills/preflight/scripts/preflight
+++ b/.agents/skills/preflight/scripts/preflight
@@ -962,12 +962,18 @@ is_comment_line() { # LINE — leading-whitespace-then-# only; a trailing commen
 shell_command_text() { # LINE — sets SHELL_COMMAND_TEXT
   local rest="$1" out="" st="" top="" span="" openq="" resume="" pre="" tok="" esc=""
   while :; do
+    # One arm per context, and no catch-all: a state whose arm stops
+    # matching would otherwise borrow its neighbour's set and go on looking
+    # correct, which is how the backtick arm was dead while every backtick
+    # test still passed. The refusal makes each arm reachable by any test
+    # that reaches its state.
     case "$top" in
       '') pre="${rest%%[\"\'\\]*}" ;;
       "'") pre="${rest%%\'*}" ;;
       '"') pre="${rest%%[\"\$\`\\]*}" ;;
       '`') pre="${rest%%[\"\'(\`\\]*}" ;;
-      *) pre="${rest%%[\"\'()\`\\]*}" ;;
+      '(') pre="${rest%%[\"\'()\`\\]*}" ;;
+      *) env_error lexer-state "$top" "shell_command_text reached a context its scan has no character set for; the stack holds only a quote, a paren or a backtick." ;;
     esac
     if [ "$pre" = "$rest" ]; then
       if [ -n "$st" ]; then

--- a/.agents/skills/preflight/scripts/preflight
+++ b/.agents/skills/preflight/scripts/preflight
@@ -81,10 +81,8 @@ Lanes:
                   reader fed a here-string or a file, a reader that runs to
                   the end of its input (tr, sed, wc), a command after ||
                   rather than after a pipe, or the same text on a comment
-                  line. A pipe inside a quoted message on a line that also
-                  opens with a writer is judged as a pipeline. A file with no
-                  pipefail preamble of its own is out of scope even where a
-                  sourcing caller supplies one.
+                  line. A file with no pipefail preamble of its own is out of
+                  scope even where a sourcing caller supplies one.
   unwired-suite   a new suite file no runner invokes. Suites are
                   tests/*.test.sh, tests/test-*.sh, a shell file with a
                   test-<name> basename and no extension, *.test.ts, *.test.js
@@ -144,6 +142,16 @@ Scope rules:
   test_*) only the swallowed-status shape and that same docs-cited-paths
   direction stand down. The mktemp assignment shape of fail-open is judged in
   every tree.
+  A lane that reads a line as this script's own commands — the
+  swallowed-status and mktemp-assignment shapes of fail-open, mktemp-trap and
+  early-close-pipe — judges it with its inert quoted spans blanked to their
+  delimiters. Single quotes suppress every expansion, so their span is text
+  wherever it stands: the hook and script templates a tool writes to disk
+  carry commands that run in the written file, never in the writer. A
+  double-quoted span is blanked too, unless a $( inside it opens a command
+  the line really runs. hardcoded-temp-path takes no blanking, since the
+  quoted literal is its subject; masked-returns takes none either, since
+  shellcheck parses the file and owns that reading.
   In an installed-artifact subtree (.agents/ and the harness directories'
   skills, agents, hooks, rules, instructions, packages and kendex trees)
   masked-returns, fail-open, early-close-pipe, unwired-suite, mktemp-trap and
@@ -887,30 +895,76 @@ is_comment_line() { # LINE — leading-whitespace-then-# only; a trailing commen
   return 1
 }
 
+# A line's shell command text: the quoted spans that run nothing, blanked to
+# their delimiters. Single quotes suppress every expansion, so their span is
+# literal text wherever it stands — the hook and script templates a tool
+# writes to disk carry commands that run in the written file, never in this
+# one. A double-quoted span still runs whatever a `$(` inside it opens, so
+# that one is kept whole. The delimiters stay, so the command-position anchor
+# every line-shape lane carries still reads the word boundary a quote makes.
+# A pair is required: the lone apostrophe of `don't` closes no span, and a
+# string whose closing quote is on another line is not one of these.
+#
+# One blanking step for every lane that judges a line as this script's own
+# commands (both the fail-open shapes the text decides, mktemp-trap,
+# early-close-pipe). hardcoded-temp-path is not one of them: its subject is
+# the quoted literal itself, in any language. masked-returns is not either,
+# because a parse of the whole file owns that lane's reading.
+# In-shell and out through a global, never a subprocess: this runs on every
+# added shell line that carries a quote, and a fork per line costs more than
+# all the lanes it feeds. Each turn takes the leftmost span that actually
+# closes, so an unpaired apostrophe cannot swallow a double-quoted span
+# behind it.
+shell_command_text() { # LINE — sets SHELL_COMMAND_TEXT
+  local rest="$1" out="" pre="" body="" q="" sq_pre="" dq_pre="" sq_closes=0 dq_closes=0
+  while :; do
+    sq_pre="${rest%%\'*}"
+    dq_pre="${rest%%\"*}"
+    sq_closes=0
+    dq_closes=0
+    if [ "$sq_pre" != "$rest" ]; then
+      case "${rest#"$sq_pre'"}" in *\'*) sq_closes=1 ;; esac
+    fi
+    if [ "$dq_pre" != "$rest" ]; then
+      case "${rest#"$dq_pre\""}" in *\"*) dq_closes=1 ;; esac
+    fi
+    if [ "$sq_closes" = 1 ] && { [ "$dq_closes" = 0 ] || [ "${#sq_pre}" -lt "${#dq_pre}" ]; }; then
+      q="'"
+      pre="$sq_pre"
+    elif [ "$dq_closes" = 1 ]; then
+      q='"'
+      pre="$dq_pre"
+    else
+      break
+    fi
+    rest="${rest#"$pre$q"}"
+    body="${rest%%"$q"*}"
+    rest="${rest#"$body$q"}"
+    if [ "$q" = '"' ]; then
+      case "$body" in
+        *'$('*) out="$out$pre$q$body$q"; continue ;;
+      esac
+    fi
+    out="$out$pre$q$q"
+  done
+  SHELL_COMMAND_TEXT="$out$rest"
+}
+
 # The `|| true` shape on a command whose exit 2 means "could not read" or
 # "invoked wrong": true erases that status and the caller reads the empty
 # result as a clean answer. The command must stand at a command position, so
-# the same text quoted inside a message is not a finding. Prints the
-# swallowed command, nothing when the shape is absent — a status-capturing
-# `|| status=$?` is a different line.
-swallowed_cmd() { # LINE -> command name on stdout
-  printf '%s\n' "$1" | LC_ALL=C awk '
-    # Blank quoted spans that carry no substitution: text in a message runs
-    # nothing, but "$(git … || true)" is a command inside quotes.
-    {
-      out = ""; rest = $0
-      while (match(rest, /"[^"]*"|\047[^\047]*\047/)) {
-        seg = substr(rest, RSTART, RLENGTH)
-        out = out substr(rest, 1, RSTART - 1) (index(seg, "$(") ? seg : substr(seg, 1, 1) substr(seg, 1, 1))
-        rest = substr(rest, RSTART + RLENGTH)
-      }
-      $0 = out rest
-    }
+# the same text quoted inside a message is not a finding. Sets the swallowed
+# command, empty when the shape is absent — a status-capturing
+# `|| status=$?` is a different line. Out through a global like the scan
+# above it, so the awk that cannot run ends the script here rather than
+# reading as a line with no shape.
+swallowed_cmd() { # COMMAND-TEXT (shell_command_text) — sets SWALLOWED_CMD
+  SWALLOWED_CMD="$(printf '%s\n' "$1" | LC_ALL=C awk '
     match($0, /(^[[:space:]]*|[;(`{&|][[:space:]]*)(grep|find|git|jq|diff|cmp)([[:space:]][^|]*)?\|\|[[:space:]]*(true|:)([^A-Za-z0-9_.-]|$)/) {
       s = substr($0, RSTART, RLENGTH)
       if (match(s, /(grep|find|git|jq|diff|cmp)/)) print substr(s, RSTART, RLENGTH)
       exit
-    }'
+    }')"
 }
 
 # The test tree sets its own rules, and this is its one grammar. A suite is
@@ -1324,10 +1378,20 @@ while IFS= read -r f; do
   while IFS= read -r rec; do
     n="${rec%%"$TAB"*}"
     content="${rec#*"$TAB"}"
+    # What this script's own shell would run on this line: the lanes below
+    # that judge a command read `code`, and the one that judges a quoted
+    # literal (hardcoded-temp-path) reads `content`. Scanned only where a
+    # quote can open a span, which most lines never do.
+    code="$content"
+    if [ "$is_sh" = 1 ]; then
+      case "$content" in
+        *\'* | *'"'*) shell_command_text "$content"; code="$SHELL_COMMAND_TEXT" ;;
+      esac
+    fi
 
     if [ "$is_sh" = 1 ] && [ "$vendored_mirror" = 0 ] && [ "$has_ee" = 0 ] \
-      && grep -Eq -- "$MKTEMP_ASSIGN" <<<"$content" \
-      && ! substitution_status_checked "$content"; then
+      && grep -Eq -- "$MKTEMP_ASSIGN" <<<"$code" \
+      && ! substitution_status_checked "$code"; then
       emit "$f" "$n" fail-open "unchecked mktemp in a file without errexit — a failed mktemp leaves the variable empty and the script runs on"
     fi
 
@@ -1340,10 +1404,10 @@ while IFS= read -r f; do
     # of the line, so a `#` in front of the shape already fails to match.
     if [ "$is_sh" = 1 ] && [ "$own_rules" = 0 ] && [ "$vendored_mirror" = 0 ] \
       && [ "$has_ee" = 1 ] && [ "$has_noee" = 0 ]; then
-      case "$content" in
+      case "$code" in
         *'$('*)
-          if ! substitution_status_checked "$content" && grep -Eq -- "$SUBST_ASSIGN_RE" <<<"$content"; then
-            assign_var="${content#"${content%%[![:space:]]*}"}"
+          if ! substitution_status_checked "$code" && grep -Eq -- "$SUBST_ASSIGN_RE" <<<"$code"; then
+            assign_var="${code#"${code%%[![:space:]]*}"}"
             assign_var="${assign_var%%=*}"
             if guard_tests_var "$cpath" "$n" "$assign_var"; then
               emit "$f" "$n" fail-open "bare command-substitution assignment under errexit — its status ends the script here, so the test of \$$assign_var below never runs; move the assignment into the condition"
@@ -1356,9 +1420,9 @@ while IFS= read -r f; do
     # The literal prefilters keep the regex passes off the lines that cannot
     # carry either shape — most of them.
     if [ "$is_sh" = 1 ] && [ "$own_rules" = 0 ] && [ "$vendored_mirror" = 0 ] && [ "$is_new" = 1 ] && [ "$has_trap" = 0 ] && [ "$mktemp_reported" = 0 ]; then
-      case "$content" in
+      case "$code" in
         *mktemp*)
-          if ! is_comment_line "$content" && printf '%s' "$content" | grep -Eq -- "$MKTEMP_CALL_RE"; then
+          if ! is_comment_line "$content" && grep -Eq -- "$MKTEMP_CALL_RE" <<<"$code"; then
             mktemp_reported=1
             emit "$f" "$n" mktemp-trap "mktemp without an EXIT trap — scratch is never removed"
           fi
@@ -1387,12 +1451,12 @@ while IFS= read -r f; do
     fi
 
     if [ "$is_sh" = 1 ] && [ "$own_rules" = 0 ] && [ "$vendored_mirror" = 0 ] && [ "$is_testname" = 0 ]; then
-      case "$content" in
+      case "$code" in
         *"||"*)
           if ! is_comment_line "$content"; then
-            swallowed="$(swallowed_cmd "$content")"
-            if [ -n "$swallowed" ]; then
-              emit "$f" "$n" fail-open "$swallowed || true swallows exit 2 (unreadable input, broken invocation) — capture the status and treat >1 as failure"
+            swallowed_cmd "$code"
+            if [ -n "$SWALLOWED_CMD" ]; then
+              emit "$f" "$n" fail-open "$SWALLOWED_CMD || true swallows exit 2 (unreadable input, broken invocation) — capture the status and treat >1 as failure"
             fi
           fi
           ;;
@@ -1404,9 +1468,9 @@ while IFS= read -r f; do
     # is no licence to take a 141 that ends the run in the middle of a
     # section. The file's own pipefail is already the condition above.
     if [ "$is_sh" = 1 ] && [ "$vendored_mirror" = 0 ] && [ "$has_pf" = 1 ]; then
-      case "$content" in
+      case "$code" in
         *"|"*)
-          if ! is_comment_line "$content" && grep -Eq -- "$EARLY_CLOSE_RE" <<<"$content"; then
+          if ! is_comment_line "$content" && grep -Eq -- "$EARLY_CLOSE_RE" <<<"$code"; then
             emit "$f" "$n" early-close-pipe "a shell writer piped into a reader that stops before EOF — pipefail turns the writer's SIGPIPE into a 141 that aborts the branch under errexit, and reads as a plain no-match in condition position; capture whole and window in-shell, or feed the reader a here-string"
           fi
           ;;

--- a/.agents/skills/preflight/tests/lanes-must-fail.test.sh
+++ b/.agents/skills/preflight/tests/lanes-must-fail.test.sh
@@ -62,7 +62,11 @@ pf_world() {
   case "$1" in
     syntax) printf '#!/usr/bin/env bash\nset -euo pipefail\nif [ 1 = 1 ]; then\n' >"$R/scripts/broken.sh" ;;
     scerror) printf '#!/usr/bin/env bash\nset -euo pipefail\nexit 300\n' >"$R/scripts/exitcode.sh" ;;
-    masked) printf '#!/usr/bin/env bash\nset -euo pipefail\ntrap '"'"'echo done'"'"' EXIT\nf() {\n  local d="$(mktemp -d)"\n  echo "$d"\n}\nf\n' >"$R/scripts/masked.sh" ;;
+    # Line 6 is the same declaration with the substitution inside single
+    # quotes, where it expands to nothing and masks no status. shellcheck
+    # parses the file and owns that reading, so this lane takes no blanking
+    # step of its own; the row's whole-set pin is what holds it to one head.
+    masked) printf '#!/usr/bin/env bash\nset -euo pipefail\ntrap '"'"'echo done'"'"' EXIT\nf() {\n  local d="$(mktemp -d)"\n  local tpl='"'"'e=$(mktemp -d)'"'"'\n  echo "$d$tpl"\n}\nf\n' >"$R/scripts/masked.sh" ;;
     mktemp) printf '#!/usr/bin/env bash\necho loose\nTMP="$(mktemp -d)"\necho "$TMP"\n' >"$R/scripts/loose.sh" ;;
     strict) printf '#!/usr/bin/env bash\necho fresh\n' >"$R/scripts/fresh.sh" ;;
     swallow) printf '#!/usr/bin/env bash\nset -euo pipefail\necho existing\ngrep -q x -- "$1" || true\n' >"$R/scripts/existing.sh" ;;
@@ -120,6 +124,9 @@ pf_world() {
     scratch) printf '#!/usr/bin/env bash\nset -euo pipefail\nD="$(mktemp -d)"\necho "$D"\n' >"$R/scripts/scratch.sh" ;;
     scratchfile) printf '#!/usr/bin/env bash\nset -euo pipefail\nF="$(mktemp)"\necho "$F"\n' >"$R/scripts/scratchfile.sh" ;;
     shellmk) printf '#!/usr/bin/env bash\nset -euo pipefail\nmkdir -p %s/cache\n' /tmp >"$R/scripts/shellmk.sh" ;;
+    # This lane's subject IS the quoted literal, in every language, so the
+    # blanking step the command-judging lanes share must not reach it.
+    shellmkquoted) printf '#!/usr/bin/env bash\nset -euo pipefail\nmkdir -p %s%s/cache%s\n' "'" /tmp "'" >"$R/scripts/shellmk.sh" ;;
     mkjs) printf 'const fs = require("fs");\nfs.mkdirSync("%s/out");\n' /tmp >"$R/src/mk.js" ;;
     mkjsprefix) printf 'const fs = require("fs");\nfs.mkdtempSync("%s/app-");\n' /tmp >"$R/src/mk.js" ;;
     mkjsroot) printf 'const fs = require("fs");\nfs.mkdtempSync("%s");\n' /tmp >"$R/src/mk.js" ;;
@@ -176,7 +183,7 @@ pf_world() {
 IFS= read -r -d '' rows <<'ROWS' || :
 an unparseable new script fails, attributed to shell-syntax|syntax|-|-|1|scripts/broken.sh:4: [shell-syntax]|-
 an out-of-range exit status fails as a shellcheck error|scerror|-|shellcheck|1|scripts/exitcode.sh:3: [shellcheck-errors]|SC2242
-a masking local-and-assign fails on the line that introduced it|masked|-|shellcheck|1|scripts/masked.sh:5: [masked-returns]|SC2155
+a masking local-and-assign fails on the line that introduced it, and the single-quoted declaration under it masks nothing|masked|-|shellcheck|1|scripts/masked.sh:5: [masked-returns]|SC2155
 an mktemp assignment in an errexit-less file fails as fail-open|mktemp|-|-|1|scripts/loose.sh:3: [fail-open]|unchecked mktemp
 a new script that never sets -e/-u/pipefail fails as fail-open|strict|-|-|1|scripts/fresh.sh:0: [fail-open]|new shell file without strict mode
 a grep whose status or-true drops fails as fail-open, naming the command|swallow|-|-|1|scripts/existing.sh:4: [fail-open]|grep || true swallows exit 2
@@ -188,6 +195,7 @@ an operator inside the substitution does not exempt the assignment|bareinner|-|-
 a new script with mktemp and no EXIT trap fails as mktemp-trap|scratch|-|-|1|scripts/scratch.sh:3: [mktemp-trap]|mktemp without an EXIT trap
 an mktemp with no arguments is the same finding|scratchfile|-|-|1|scripts/scratchfile.sh:3: [mktemp-trap]|mktemp without an EXIT trap
 a shell mkdir -p at a literal /tmp path fails|shellmk|-|-|1|scripts/shellmk.sh:3: [hardcoded-temp-path]|-
+the same path in single quotes is the same finding|shellmkquoted|-|-|1|scripts/shellmk.sh:3: [hardcoded-temp-path]|-
 a JS mkdirSync taking the literal fails|mkjs|-|-|1|src/mk.js:2: [hardcoded-temp-path]|-
 a JS mkdtempSync prefix under /tmp is the same finding|mkjsprefix|-|-|1|src/mk.js:2: [hardcoded-temp-path]|-
 the JS bare-root prefix form (mkdtempSync(/tmp) making a /tmpXXXXXX sibling) fails|mkjsroot|-|-|1|src/mk.js:2: [hardcoded-temp-path]|-

--- a/.agents/skills/preflight/tests/lanes-must-fail.test.sh
+++ b/.agents/skills/preflight/tests/lanes-must-fail.test.sh
@@ -88,6 +88,13 @@ pf_world() {
       ecn_reader='| head -1)"'
       printf '#!/usr/bin/env bash\nset -euo pipefail\n%s%s\necho "$n"\n' "$ecn_writer" "$ecn_reader" >"$R/scripts/existing.sh"
       ;;
+    # The same 141 where the substitution carries an ESCAPED quote. A scan
+    # that reads that quote as the span's end loses the pipeline behind it.
+    earlycloseescape)
+      ece_writer='n="$(printf "a\"b" '
+      ece_reader='| head -1)"'
+      printf '#!/usr/bin/env bash\nset -euo pipefail\n%s%s\necho "$n"\n' "$ece_writer" "$ece_reader" >"$R/scripts/existing.sh"
+      ;;
     # The same 141 in the backtick spelling: EARLY_CLOSE_WRITER names the
     # backtick as a command position too.
     earlyclosetick)
@@ -221,6 +228,7 @@ a quoted argument inside that substitution does not end its span early|swallowne
 a condition piping echo into grep -q fails as early-close-pipe|earlyclose|-|-|1|scripts/existing.sh:3: [early-close-pipe]|a shell writer piped into a reader that stops before EOF
 a pipeline inside a substitution that carries a quoted argument is still one|earlyclosenested|-|-|1|scripts/existing.sh:3: [early-close-pipe]|a shell writer piped into a reader that stops before EOF
 the backtick spelling of that substitution is judged too|earlyclosetick|-|-|1|scripts/existing.sh:3: [early-close-pipe]|a shell writer piped into a reader that stops before EOF
+an escaped quote inside that substitution does not end its span|earlycloseescape|-|-|1|scripts/existing.sh:3: [early-close-pipe]|a shell writer piped into a reader that stops before EOF
 a suite that sets pipefail is judged too, mid-pipeline reader included|earlyclosesuite|-|-|1|tests/known.test.sh:3: [early-close-pipe]|-
 an assignment whose guard errexit kills first fails as fail-open|bareassign|-|-|1|scripts/bare.sh:3: [fail-open]|bare command-substitution assignment under errexit
 an operator inside the substitution does not exempt the assignment|bareinner|-|-|1|scripts/bare.sh:3: [fail-open]|bare command-substitution assignment under errexit

--- a/.agents/skills/preflight/tests/lanes-must-fail.test.sh
+++ b/.agents/skills/preflight/tests/lanes-must-fail.test.sh
@@ -88,6 +88,14 @@ pf_world() {
       ecn_reader='| head -1)"'
       printf '#!/usr/bin/env bash\nset -euo pipefail\n%s%s\necho "$n"\n' "$ecn_writer" "$ecn_reader" >"$R/scripts/existing.sh"
       ;;
+    # The same 141 in the backtick spelling: EARLY_CLOSE_WRITER names the
+    # backtick as a command position too.
+    earlyclosetick)
+      bt='`'
+      ect_writer='n="%sprintf "%%s\\n" "$1" '
+      ect_reader='| head -1%s"'
+      printf '#!/usr/bin/env bash\nset -euo pipefail\n'"$ect_writer$ect_reader"'\necho "$n"\n' "$bt" "$bt" >"$R/scripts/existing.sh"
+      ;;
     # The same lane inside the test tree, on the mid-pipeline shape: the
     # reader is two stages down and another stage runs after it, and the
     # suite's own pipefail is what turns the writer's SIGPIPE into the 141
@@ -135,6 +143,14 @@ pf_world() {
       } >"$R/scripts/bare.sh"
       ;;
     scratch) printf '#!/usr/bin/env bash\nset -euo pipefail\nD="$(mktemp -d)"\necho "$D"\n' >"$R/scripts/scratch.sh" ;;
+    # The older substitution spelling, which runs a command inside double
+    # quotes exactly as $( ) does and which MKTEMP_CALL_RE already names as a
+    # command position. Written through a variable so this suite's own
+    # committed line does not carry the shape.
+    scratchtick)
+      bt='`'
+      printf '#!/usr/bin/env bash\nset -euo pipefail\nD="%smktemp -d%s"\necho "$D"\n' "$bt" "$bt" >"$R/scripts/scratch.sh"
+      ;;
     scratchfile) printf '#!/usr/bin/env bash\nset -euo pipefail\nF="$(mktemp)"\necho "$F"\n' >"$R/scripts/scratchfile.sh" ;;
     shellmk) printf '#!/usr/bin/env bash\nset -euo pipefail\nmkdir -p %s/cache\n' /tmp >"$R/scripts/shellmk.sh" ;;
     # This lane's subject IS the quoted literal, in every language, so the
@@ -204,10 +220,12 @@ the shape is caught inside a command substitution too|swallowsubst|-|-|1|scripts
 a quoted argument inside that substitution does not end its span early|swallownested|-|-|1|scripts/existing.sh:4: [fail-open]|git || true swallows exit 2
 a condition piping echo into grep -q fails as early-close-pipe|earlyclose|-|-|1|scripts/existing.sh:3: [early-close-pipe]|a shell writer piped into a reader that stops before EOF
 a pipeline inside a substitution that carries a quoted argument is still one|earlyclosenested|-|-|1|scripts/existing.sh:3: [early-close-pipe]|a shell writer piped into a reader that stops before EOF
+the backtick spelling of that substitution is judged too|earlyclosetick|-|-|1|scripts/existing.sh:3: [early-close-pipe]|a shell writer piped into a reader that stops before EOF
 a suite that sets pipefail is judged too, mid-pipeline reader included|earlyclosesuite|-|-|1|tests/known.test.sh:3: [early-close-pipe]|-
 an assignment whose guard errexit kills first fails as fail-open|bareassign|-|-|1|scripts/bare.sh:3: [fail-open]|bare command-substitution assignment under errexit
 an operator inside the substitution does not exempt the assignment|bareinner|-|-|1|scripts/bare.sh:3: [fail-open]|bare command-substitution assignment under errexit
 a new script with mktemp and no EXIT trap fails as mktemp-trap|scratch|-|-|1|scripts/scratch.sh:3: [mktemp-trap]|mktemp without an EXIT trap
+the backtick spelling of that substitution is the same finding|scratchtick|-|-|1|scripts/scratch.sh:3: [mktemp-trap]|mktemp without an EXIT trap
 an mktemp with no arguments is the same finding|scratchfile|-|-|1|scripts/scratchfile.sh:3: [mktemp-trap]|mktemp without an EXIT trap
 a shell mkdir -p at a literal /tmp path fails|shellmk|-|-|1|scripts/shellmk.sh:3: [hardcoded-temp-path]|-
 the same path in single quotes is the same finding|shellmkquoted|-|-|1|scripts/shellmk.sh:3: [hardcoded-temp-path]|-

--- a/.agents/skills/preflight/tests/lanes-must-fail.test.sh
+++ b/.agents/skills/preflight/tests/lanes-must-fail.test.sh
@@ -71,10 +71,23 @@ pf_world() {
     strict) printf '#!/usr/bin/env bash\necho fresh\n' >"$R/scripts/fresh.sh" ;;
     swallow) printf '#!/usr/bin/env bash\nset -euo pipefail\necho existing\ngrep -q x -- "$1" || true\n' >"$R/scripts/existing.sh" ;;
     swallowsubst) printf '#!/usr/bin/env bash\nset -euo pipefail\necho existing\nn="$(git rev-list --count HEAD || true)"\necho "$n"\n' >"$R/scripts/existing.sh" ;;
+    # The same shape where the substitution carries a quoted argument of its
+    # own. A read that ends the span at that inner quote loses the `|| true`
+    # with the rest of the command, and the lane goes quiet on the line it
+    # exists for.
+    swallownested) printf '#!/usr/bin/env bash\nset -euo pipefail\nref="$1"\nn="$(git rev-list --count "$ref" || true)"\necho "$n"\n' >"$R/scripts/existing.sh" ;;
     # Written from the shell, never with cat reading a file: a cat-fed
     # fixture pushes several hundred KB before it blocks, so it passes
     # either way.
     earlyclose) printf '#!/usr/bin/env bash\nset -euo pipefail\nif echo "$1" | grep -q x; then echo hit; fi\n' >"$R/scripts/existing.sh" ;;
+    # The same 141 inside a substitution that carries a quoted argument. The
+    # pipeline is halved so this suite's own committed line does not carry
+    # the shape at a command position.
+    earlyclosenested)
+      ecn_writer='n="$(printf "%s\n" "$1" '
+      ecn_reader='| head -1)"'
+      printf '#!/usr/bin/env bash\nset -euo pipefail\n%s%s\necho "$n"\n' "$ecn_writer" "$ecn_reader" >"$R/scripts/existing.sh"
+      ;;
     # The same lane inside the test tree, on the mid-pipeline shape: the
     # reader is two stages down and another stage runs after it, and the
     # suite's own pipefail is what turns the writer's SIGPIPE into the 141
@@ -188,7 +201,9 @@ an mktemp assignment in an errexit-less file fails as fail-open|mktemp|-|-|1|scr
 a new script that never sets -e/-u/pipefail fails as fail-open|strict|-|-|1|scripts/fresh.sh:0: [fail-open]|new shell file without strict mode
 a grep whose status or-true drops fails as fail-open, naming the command|swallow|-|-|1|scripts/existing.sh:4: [fail-open]|grep || true swallows exit 2
 the shape is caught inside a command substitution too|swallowsubst|-|-|1|scripts/existing.sh:4: [fail-open]|git || true swallows exit 2
+a quoted argument inside that substitution does not end its span early|swallownested|-|-|1|scripts/existing.sh:4: [fail-open]|git || true swallows exit 2
 a condition piping echo into grep -q fails as early-close-pipe|earlyclose|-|-|1|scripts/existing.sh:3: [early-close-pipe]|a shell writer piped into a reader that stops before EOF
+a pipeline inside a substitution that carries a quoted argument is still one|earlyclosenested|-|-|1|scripts/existing.sh:3: [early-close-pipe]|a shell writer piped into a reader that stops before EOF
 a suite that sets pipefail is judged too, mid-pipeline reader included|earlyclosesuite|-|-|1|tests/known.test.sh:3: [early-close-pipe]|-
 an assignment whose guard errexit kills first fails as fail-open|bareassign|-|-|1|scripts/bare.sh:3: [fail-open]|bare command-substitution assignment under errexit
 an operator inside the substitution does not exempt the assignment|bareinner|-|-|1|scripts/bare.sh:3: [fail-open]|bare command-substitution assignment under errexit

--- a/.agents/skills/preflight/tests/lanes-must-fail.test.sh
+++ b/.agents/skills/preflight/tests/lanes-must-fail.test.sh
@@ -88,6 +88,14 @@ pf_world() {
       ecn_reader='| head -1)"'
       printf '#!/usr/bin/env bash\nset -euo pipefail\n%s%s\necho "$n"\n' "$ecn_writer" "$ecn_reader" >"$R/scripts/existing.sh"
       ;;
+    # An ANSI-C string whose escaped apostrophe the ordinary single-quote
+    # state reads as the terminator, pairing the real one with a later quote
+    # and blanking the live command between them.
+    ansiswallow)
+      sq="'"
+      printf '#!/usr/bin/env bash\nset -euo pipefail\nmsg=$%sa\\%sb%s; git rev-parse --git-dir || true; echo %sdone%s\n' \
+        "$sq" "$sq" "$sq" "$sq" "$sq" >"$R/scripts/existing.sh"
+      ;;
     # The same 141 where the substitution carries an ESCAPED quote. A scan
     # that reads that quote as the span's end loses the pipeline behind it.
     earlycloseescape)
@@ -154,6 +162,20 @@ pf_world() {
     # quotes exactly as $( ) does and which MKTEMP_CALL_RE already names as a
     # command position. Written through a variable so this suite's own
     # committed line does not carry the shape.
+    # A single-quoted span that is an interpreter's code argument runs, so
+    # blanking it loses the commands it carries. Two lanes, one row each.
+    interpmktemp)
+      sq="'"
+      printf '#!/usr/bin/env bash\nset -euo pipefail\nbash -c %scd "$1"; mktemp -d%s\n' "$sq" "$sq" >"$R/scripts/scratch.sh"
+      ;;
+    # Halved so this suite's own committed line carries no writer at a
+    # command position, the one lane the test tree is judged by.
+    interpearly)
+      sq="'"
+      ie_writer='v=$1; printf "%s\n" "$v" '
+      ie_reader='| head -1'
+      printf '#!/usr/bin/env bash\nset -euo pipefail\neval %s%s%s%s\n' "$sq" "$ie_writer" "$ie_reader" "$sq" >"$R/scripts/existing.sh"
+      ;;
     scratchtick)
       bt='`'
       printf '#!/usr/bin/env bash\nset -euo pipefail\nD="%smktemp -d%s"\necho "$D"\n' "$bt" "$bt" >"$R/scripts/scratch.sh"
@@ -229,11 +251,14 @@ a condition piping echo into grep -q fails as early-close-pipe|earlyclose|-|-|1|
 a pipeline inside a substitution that carries a quoted argument is still one|earlyclosenested|-|-|1|scripts/existing.sh:3: [early-close-pipe]|a shell writer piped into a reader that stops before EOF
 the backtick spelling of that substitution is judged too|earlyclosetick|-|-|1|scripts/existing.sh:3: [early-close-pipe]|a shell writer piped into a reader that stops before EOF
 an escaped quote inside that substitution does not end its span|earlycloseescape|-|-|1|scripts/existing.sh:3: [early-close-pipe]|a shell writer piped into a reader that stops before EOF
+an eval's single-quoted code argument is judged by that lane too|interpearly|-|-|1|scripts/existing.sh:3: [early-close-pipe]|a shell writer piped into a reader that stops before EOF
+an ANSI-C string does not swallow the command after it|ansiswallow|-|-|1|scripts/existing.sh:3: [fail-open]|git || true swallows exit 2
 a suite that sets pipefail is judged too, mid-pipeline reader included|earlyclosesuite|-|-|1|tests/known.test.sh:3: [early-close-pipe]|-
 an assignment whose guard errexit kills first fails as fail-open|bareassign|-|-|1|scripts/bare.sh:3: [fail-open]|bare command-substitution assignment under errexit
 an operator inside the substitution does not exempt the assignment|bareinner|-|-|1|scripts/bare.sh:3: [fail-open]|bare command-substitution assignment under errexit
 a new script with mktemp and no EXIT trap fails as mktemp-trap|scratch|-|-|1|scripts/scratch.sh:3: [mktemp-trap]|mktemp without an EXIT trap
 the backtick spelling of that substitution is the same finding|scratchtick|-|-|1|scripts/scratch.sh:3: [mktemp-trap]|mktemp without an EXIT trap
+an interpreter's single-quoted code argument is judged, not blanked|interpmktemp|-|-|1|scripts/scratch.sh:3: [mktemp-trap]|mktemp without an EXIT trap
 an mktemp with no arguments is the same finding|scratchfile|-|-|1|scripts/scratchfile.sh:3: [mktemp-trap]|mktemp without an EXIT trap
 a shell mkdir -p at a literal /tmp path fails|shellmk|-|-|1|scripts/shellmk.sh:3: [hardcoded-temp-path]|-
 the same path in single quotes is the same finding|shellmkquoted|-|-|1|scripts/shellmk.sh:3: [hardcoded-temp-path]|-

--- a/.agents/skills/preflight/tests/precision.test.sh
+++ b/.agents/skills/preflight/tests/precision.test.sh
@@ -679,6 +679,11 @@ EOF
 printf "window_line='%s%s'\n" "$ec_head" "$ec_tail" >>"$R/scripts/writer.sh"
 printf 'echo "the idiom is %s%s"\n' "$dq_head" "$ec_tail" >>"$R/scripts/writer.sh"
 printf 'printf "%%s\\n" "$hook_line" "$scratch_line" "$window_line" >"$1"\n' >>"$R/scripts/writer.sh"
+# A backtick runs a command inside double quotes and is literal inside single
+# ones, so the single-quoted spelling is the written file's command too. Built
+# through a variable so this suite's own committed line does not carry it.
+bt='`'
+printf "tick_line='cd \"\$d\"; %smktemp -d%s'\n" "$bt" "$bt" >>"$R/scripts/writer.sh"
 # The assignment shape needs a file that never sets errexit, and a sourced
 # lib is the one such file that is not itself a strict-mode finding.
 cat >"$R/scripts/lib/tpl.sh" <<'EOF'
@@ -689,7 +694,7 @@ echo "$assign_line"
 EOF
 git -C "$R" add -A
 run_pf
-clean "a swallowed status, an mktemp invocation, an early-closing pipeline and an mktemp assignment inside single quotes are the written file's commands, and a pipeline named in a double-quoted message is nobody's" 2
+clean "a swallowed status, an mktemp invocation in both substitution spellings, an early-closing pipeline and an mktemp assignment inside single quotes are the written file's commands, and a pipeline named in a double-quoted message is nobody's" 2
 
 echo "=== control: the same four shapes outside the quotes are this script's own ==="
 {

--- a/.agents/skills/preflight/tests/precision.test.sh
+++ b/.agents/skills/preflight/tests/precision.test.sh
@@ -653,4 +653,64 @@ git -C "$R" add -A
 run_pf --staged
 fires "the base's own migration, staged, still fails" "store/migrations/V1__init.sql:0: [applied-migration-edited]"
 
+echo "=== a shell template inside single quotes is text, not this script's commands ==="
+seed quotedtemplate
+mkdir -p "$R/scripts/lib"
+# Every shape sits after a `;` INSIDE the quotes, which is the command
+# position each lane anchors on: a template whose first word opened the span
+# would match no anchor and would pin nothing. The early-close pipeline is
+# halved across two variables so this suite's own committed line never
+# carries the shape at that position — the one lane the test tree is judged
+# by.
+ec_head='v=$1; printf "%s\n" "$v" '
+ec_tail='| head -1'
+# The double-quoted half of the same rule: a span with no `$(` in it opens no
+# command either, so the message naming the shape is not the shape. It takes
+# the same reader half, and its own writer half for the same reason.
+dq_head='cmd '
+cat >"$R/scripts/writer.sh" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+# A hook this script writes to disk: the commands between the quotes run in
+# the written file, never in this one.
+hook_line='cd "$d"; git rev-parse --git-dir 2>/dev/null || true'
+scratch_line='cd "$d"; mktemp -d'
+EOF
+printf "window_line='%s%s'\n" "$ec_head" "$ec_tail" >>"$R/scripts/writer.sh"
+printf 'echo "the idiom is %s%s"\n' "$dq_head" "$ec_tail" >>"$R/scripts/writer.sh"
+printf 'printf "%%s\\n" "$hook_line" "$scratch_line" "$window_line" >"$1"\n' >>"$R/scripts/writer.sh"
+# The assignment shape needs a file that never sets errexit, and a sourced
+# lib is the one such file that is not itself a strict-mode finding.
+cat >"$R/scripts/lib/tpl.sh" <<'EOF'
+#!/usr/bin/env bash
+# Sourced by the scripts beside it: the caller's shell owns the mode.
+assign_line='d=$(mktemp -d)'
+echo "$assign_line"
+EOF
+git -C "$R" add -A
+run_pf
+clean "a swallowed status, an mktemp invocation, an early-closing pipeline and an mktemp assignment inside single quotes are the written file's commands, and a pipeline named in a double-quoted message is nobody's" 2
+
+echo "=== control: the same four shapes outside the quotes are this script's own ==="
+{
+  printf '#!/usr/bin/env bash\n'
+  printf 'set -euo pipefail\n'
+  printf 'd=$1\n'
+  printf 'cd "$d"; git rev-parse --git-dir 2>/dev/null || true\n'
+  printf 'cd "$d"; mktemp -d\n'
+  printf '%s%s\n' "$ec_head" "$ec_tail"
+} >"$R/scripts/writer.sh"
+cat >"$R/scripts/lib/tpl.sh" <<'EOF'
+#!/usr/bin/env bash
+# Sourced by the scripts beside it: the caller's shell owns the mode.
+d=$(mktemp -d)
+echo "$d"
+EOF
+git -C "$R" add -A
+run_pf
+fires "unquoting the hook line makes the swallowed status this script's" "scripts/writer.sh:4: [fail-open] git || true swallows exit 2"
+fires "unquoting the scratch line makes the mktemp invocation this script's" "scripts/writer.sh:5: [mktemp-trap] mktemp without an EXIT trap"
+fires "unquoting the window line makes the early-closing pipeline this script's" "scripts/writer.sh:6: [early-close-pipe]"
+fires "unquoting the assignment makes the unchecked mktemp this lib's" "scripts/lib/tpl.sh:3: [fail-open] unchecked mktemp"
+
 pf_summary

--- a/.agents/skills/preflight/tests/precision.test.sh
+++ b/.agents/skills/preflight/tests/precision.test.sh
@@ -713,4 +713,53 @@ fires "unquoting the scratch line makes the mktemp invocation this script's" "sc
 fires "unquoting the window line makes the early-closing pipeline this script's" "scripts/writer.sh:6: [early-close-pipe]"
 fires "unquoting the assignment makes the unchecked mktemp this lib's" "scripts/lib/tpl.sh:3: [fail-open] unchecked mktemp"
 
+echo "=== a substitution's own quoted arguments belong to the substitution ==="
+seed nestedsubst
+mkdir -p "$R/scripts/lib"
+# Shell restarts quoting inside `$( … )`, so the span of x="$(cmd "$arg")"
+# ends at the LAST quote, not at the inner one. Ending it early cuts the line
+# at the inner argument and drops the rest of the command with it: the `)`
+# that the status test reads, and the pipeline the early-close lane looks
+# for. Both directions are one line each.
+cat >"$R/scripts/nested.sh" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+base="$1"
+# The status is captured on the same line, so the test below is reachable —
+# and it is reachable only if the `)` before `||` survived the read.
+ROOT="$(git -C "$base" rev-parse --show-toplevel 2>/dev/null)" || ROOT=""
+if [ -z "$ROOT" ]; then
+  exit 1
+fi
+echo "$ROOT"
+EOF
+# An errexit-less lib, where the mktemp assignment shape is judged: its
+# status is checked by the OR-list the mangled read used to swallow.
+cat >"$R/scripts/lib/scratch.sh" <<'EOF'
+#!/usr/bin/env bash
+# Sourced by the scripts beside it: the caller's shell owns the mode.
+make_scratch() {
+  TMP="$(mktemp -d "$1/xxXXXX")" || return 1
+  trap 'rmdir -- "${TMP:?}"' EXIT
+}
+EOF
+git -C "$R" add -A
+run_pf
+clean "a substitution carrying its own quoted argument keeps the status test that follows its closing paren" 2
+
+echo "=== control: the early-close shape inside such a substitution still fires ==="
+# Halved so this suite's own committed line does not carry the shape at a
+# command position; the fixture line joins the halves.
+ns_head='n="$(printf "%s\n" "$1" '
+ns_tail='| head -1)"'
+{
+  printf '#!/usr/bin/env bash\n'
+  printf 'set -euo pipefail\n'
+  printf '%s%s\n' "$ns_head" "$ns_tail"
+  printf 'echo "$n"\n'
+} >"$R/scripts/nested.sh"
+git -C "$R" add -A
+run_pf
+fires "a pipeline inside a substitution that also carries a quoted argument is still a pipeline" "scripts/nested.sh:3: [early-close-pipe]"
+
 pf_summary

--- a/.agents/skills/preflight/tests/precision.test.sh
+++ b/.agents/skills/preflight/tests/precision.test.sh
@@ -675,6 +675,9 @@ set -euo pipefail
 # the written file, never in this one.
 hook_line='cd "$d"; git rev-parse --git-dir 2>/dev/null || true'
 scratch_line='cd "$d"; mktemp -d'
+# An escaped quote does not end the message it stands in, so the shape it
+# names is still inside the message and not this file's command.
+note="he said \"cd x; git log || true\" once"
 EOF
 printf "window_line='%s%s'\n" "$ec_head" "$ec_tail" >>"$R/scripts/writer.sh"
 printf 'echo "the idiom is %s%s"\n' "$dq_head" "$ec_tail" >>"$R/scripts/writer.sh"
@@ -694,7 +697,7 @@ echo "$assign_line"
 EOF
 git -C "$R" add -A
 run_pf
-clean "a swallowed status, an mktemp invocation in both substitution spellings, an early-closing pipeline and an mktemp assignment inside single quotes are the written file's commands, and a pipeline named in a double-quoted message is nobody's" 2
+clean "a swallowed status, an mktemp invocation in both substitution spellings, an early-closing pipeline and an mktemp assignment inside single quotes are the written file's commands, and a pipeline or a swallowed status named in a double-quoted message, past an escaped quote or not, is nobody's" 2
 
 echo "=== control: the same four shapes outside the quotes are this script's own ==="
 {

--- a/.agents/skills/preflight/tests/precision.test.sh
+++ b/.agents/skills/preflight/tests/precision.test.sh
@@ -678,6 +678,12 @@ scratch_line='cd "$d"; mktemp -d'
 # An escaped quote does not end the message it stands in, so the shape it
 # names is still inside the message and not this file's command.
 note="he said \"cd x; git log || true\" once"
+# An escaped substitution marker opens nothing, in either spelling. The scan
+# consumed both as escaped text, so the span runs nothing and is the written
+# file's message; only a decision taken from the scan's own state can tell
+# these two lines from the substitutions they imitate.
+note_paren="see \$(cd x; git log || true) for the idiom"
+note_tick="see \`cd x; git log || true\` for the idiom"
 EOF
 printf "window_line='%s%s'\n" "$ec_head" "$ec_tail" >>"$R/scripts/writer.sh"
 printf 'echo "the idiom is %s%s"\n' "$dq_head" "$ec_tail" >>"$R/scripts/writer.sh"
@@ -697,7 +703,7 @@ echo "$assign_line"
 EOF
 git -C "$R" add -A
 run_pf
-clean "a swallowed status, an mktemp invocation in both substitution spellings, an early-closing pipeline and an mktemp assignment inside single quotes are the written file's commands, and a pipeline or a swallowed status named in a double-quoted message, past an escaped quote or not, is nobody's" 2
+clean "a swallowed status, an mktemp invocation in both substitution spellings, an early-closing pipeline and an mktemp assignment inside single quotes are the written file's commands, and a pipeline or a swallowed status named in a double-quoted message is nobody's, past an escaped quote or behind an escaped substitution marker in either spelling" 2
 
 echo "=== control: the same four shapes outside the quotes are this script's own ==="
 {

--- a/skills/preflight/scripts/preflight
+++ b/skills/preflight/scripts/preflight
@@ -81,8 +81,12 @@ Lanes:
                   reader fed a here-string or a file, a reader that runs to
                   the end of its input (tr, sed, wc), a command after ||
                   rather than after a pipe, or the same text on a comment
-                  line. A file with no pipefail preamble of its own is out of
-                  scope even where a sourcing caller supplies one.
+                  line. A quoted message IS read as a pipeline when it also
+                  carries a command substitution: the span is kept whole
+                  because the substitution runs, and the pipe inside it
+                  cannot be told from the one outside. A file with no
+                  pipefail preamble of its own is out of scope even where a
+                  sourcing caller supplies one.
   unwired-suite   a new suite file no runner invokes. Suites are
                   tests/*.test.sh, tests/test-*.sh, a shell file with a
                   test-<name> basename and no extension, *.test.ts, *.test.js
@@ -902,52 +906,105 @@ is_comment_line() { # LINE — leading-whitespace-then-# only; a trailing commen
 # one. A double-quoted span still runs whatever a `$(` inside it opens, so
 # that one is kept whole. The delimiters stay, so the command-position anchor
 # every line-shape lane carries still reads the word boundary a quote makes.
-# A pair is required: the lone apostrophe of `don't` closes no span, and a
-# string whose closing quote is on another line is not one of these.
 #
 # One blanking step for every lane that judges a line as this script's own
 # commands (both the fail-open shapes the text decides, mktemp-trap,
 # early-close-pipe). hardcoded-temp-path is not one of them: its subject is
 # the quoted literal itself, in any language. masked-returns is not either,
 # because a parse of the whole file owns that lane's reading.
+#
+# A double-quoted span ends at the first `"` OUTSIDE any substitution it
+# opened, never at the next `"` in the text: shell restarts quoting inside
+# `$( … )`, so the inner quotes of `x="$(cmd "$arg")"` belong to the
+# substitution. Ending the span at one of those would cut the line at the
+# inner quote and drop the rest of the command, including the `)` that
+# `substitution_status_checked` reads and the pipeline `early-close-pipe`
+# looks for. `st` is the nesting stack that holds that property, innermost
+# context last: `'` a single-quoted span, `"` a double-quoted one, `(` a
+# substitution or subshell. Only `$(` opens one from inside double quotes,
+# where a bare paren is literal; inside a substitution every quote opens
+# again. A span that never closes on this line is not a span: its opening
+# quote is emitted as ordinary text and the scan resumes after it, so an
+# unpaired apostrophe cannot swallow a double-quoted span behind it.
+#
 # In-shell and out through a global, never a subprocess: this runs on every
 # added shell line that carries a quote, and a fork per line costs more than
-# all the lanes it feeds. Each turn takes the leftmost span that actually
-# closes, so an unpaired apostrophe cannot swallow a double-quoted span
-# behind it.
+# all the lanes it feeds. Each turn jumps to the next character its own state
+# cares about rather than walking the line one character at a time.
 shell_command_text() { # LINE — sets SHELL_COMMAND_TEXT
-  local rest="$1" out="" pre="" body="" q="" sq_pre="" dq_pre="" sq_closes=0 dq_closes=0
+  local rest="$1" out="" st="" top="" span="" openq="" resume="" pre="" tok=""
   while :; do
-    sq_pre="${rest%%\'*}"
-    dq_pre="${rest%%\"*}"
-    sq_closes=0
-    dq_closes=0
-    if [ "$sq_pre" != "$rest" ]; then
-      case "${rest#"$sq_pre'"}" in *\'*) sq_closes=1 ;; esac
-    fi
-    if [ "$dq_pre" != "$rest" ]; then
-      case "${rest#"$dq_pre\""}" in *\"*) dq_closes=1 ;; esac
-    fi
-    if [ "$sq_closes" = 1 ] && { [ "$dq_closes" = 0 ] || [ "${#sq_pre}" -lt "${#dq_pre}" ]; }; then
-      q="'"
-      pre="$sq_pre"
-    elif [ "$dq_closes" = 1 ]; then
-      q='"'
-      pre="$dq_pre"
-    else
+    case "$top" in
+      '') pre="${rest%%[\"\']*}" ;;
+      "'") pre="${rest%%\'*}" ;;
+      '"') pre="${rest%%[\"\$]*}" ;;
+      *) pre="${rest%%[\"\'()]*}" ;;
+    esac
+    if [ "$pre" = "$rest" ]; then
+      if [ -n "$st" ]; then
+        out="$out$openq"
+        rest="$resume"
+        st=""
+        top=""
+        span=""
+        continue
+      fi
+      out="$out$rest"
       break
     fi
-    rest="${rest#"$pre$q"}"
-    body="${rest%%"$q"*}"
-    rest="${rest#"$body$q"}"
-    if [ "$q" = '"' ]; then
-      case "$body" in
-        *'$('*) out="$out$pre$q$body$q"; continue ;;
-      esac
+    tok="${rest#"$pre"}"
+    tok="${tok%"${tok#?}"}"
+    rest="${rest#"$pre$tok"}"
+    if [ -z "$st" ]; then
+      out="$out$pre"
+      openq="$tok"
+      span="$tok"
+      resume="$rest"
+      st="$tok"
+      top="$tok"
+      continue
     fi
-    out="$out$pre$q$q"
+    span="$span$pre$tok"
+    case "$top" in
+      "'" | '"')
+        if [ "$tok" = "$top" ]; then
+          st="${st%?}"
+          top="${st#"${st%?}"}"
+        elif [ "$tok" = '$' ]; then
+          case "$rest" in
+            '('*)
+              span="$span("
+              rest="${rest#?}"
+              st="$st("
+              top="("
+              ;;
+          esac
+        fi
+        ;;
+      *)
+        case "$tok" in
+          ')')
+            st="${st%?}"
+            top="${st#"${st%?}"}"
+            ;;
+          *)
+            st="$st$tok"
+            top="$tok"
+            ;;
+        esac
+        ;;
+    esac
+    if [ -z "$st" ]; then
+      case "$span" in
+        \'*) out="$out''" ;;
+        *'$('*) out="$out$span" ;;
+        *) out="$out\"\"" ;;
+      esac
+      span=""
+      openq=""
+    fi
   done
-  SHELL_COMMAND_TEXT="$out$rest"
+  SHELL_COMMAND_TEXT="$out"
 }
 
 # The `|| true` shape on a command whose exit 2 means "could not read" or

--- a/skills/preflight/scripts/preflight
+++ b/skills/preflight/scripts/preflight
@@ -914,36 +914,60 @@ is_comment_line() { # LINE — leading-whitespace-then-# only; a trailing commen
 # the quoted literal itself, in any language. masked-returns is not either,
 # because a parse of the whole file owns that lane's reading.
 #
-# A double-quoted span ends at the first `"` OUTSIDE any substitution it
-# opened, never at the next `"` in the text: shell restarts quoting inside a
-# substitution, so the inner quotes of `x="$(cmd "$arg")"` belong to it.
-# Ending the span at one of those would cut the line at the inner quote and
-# drop the rest of the command, including the `)` that
-# `substitution_status_checked` reads and the pipeline `early-close-pipe`
-# looks for. `st` is the nesting stack that holds that property, innermost
-# context last: `'` a single-quoted span, `"` a double-quoted one, `(` a
-# substitution or subshell, ``` the older substitution spelling, which
-# closes at its matching backtick rather than at a paren. Both spellings run
-# a command from inside double quotes, and both are what the mktemp-trap and
-# early-close-pipe anchors already name as a command position; a bare paren
-# there is literal, and inside a substitution every quote opens again. A span
-# that never closes on this line is not a span: its opening quote is emitted
-# as ordinary text and the scan resumes after it, so an unpaired apostrophe
-# cannot swallow a double-quoted span behind it.
+# This is a lexer, and the set of shell rules it implements is the whole of
+# what it promises. A gap in the set is a lane going blind, not a cosmetic
+# miss, so the set is written out here for a reader to check against rather
+# than discover one shape at a time. Implemented:
+#
+#   - A single-quoted span runs to the next `'`. Nothing inside it expands,
+#     escapes or opens anything.
+#   - A double-quoted span runs to the first `"` OUTSIDE any substitution it
+#     opened. Shell restarts quoting inside a substitution, so the inner
+#     quotes of `x="$(cmd "$arg")"` belong to it; ending the span at one of
+#     those would cut the line at the inner quote and drop the rest of the
+#     command, the `)` that `substitution_status_checked` reads and the
+#     pipeline `early-close-pipe` looks for with it.
+#   - Both substitution spellings open a nesting from inside double quotes:
+#     `$( … )`, closing at its matching paren with nested parens counted, and
+#     `` … ``, closing at its matching backtick. Both run a command, and
+#     both are what the mktemp-trap and early-close-pipe anchors already name
+#     as a command position. A bare paren inside double quotes is literal.
+#   - A backslash escapes the character after it everywhere except inside a
+#     single-quoted span, where it is literal. So `"a\"b"` is one span, not
+#     two, and the code after it is not read as this file's own.
+#   - A span that never closes on this line is not a span: its opening quote
+#     is emitted as ordinary text and the scan resumes after it, so an
+#     unpaired apostrophe cannot swallow a double-quoted span behind it.
+#
+# Deliberately not implemented, each because it leaves inert text mis-split
+# rather than losing a command, which over-reports instead of going blind:
+#
+#   - Quote context across physical lines. preflight judges added lines one
+#     at a time, so the middle line of a multi-line template carries no quote
+#     and is read as code.
+#   - `$'…'` ANSI-C quoting, where a backslash DOES escape inside single
+#     quotes. The span ends early at the escaped quote.
+#   - Quotes nested inside `${…}`, which are lexed as adjacent spans. Nothing
+#     inside a parameter expansion runs a command.
+#   - Heredoc bodies, which are lines of data this scan reads as code.
+#
+# `st` is the nesting stack that holds all of it, innermost context last:
+# `'` a single-quoted span, `"` a double-quoted one, `(` a substitution or
+# subshell, ``` the backtick substitution.
 #
 # In-shell and out through a global, never a subprocess: this runs on every
 # added shell line that carries a quote, and a fork per line costs more than
 # all the lanes it feeds. Each turn jumps to the next character its own state
 # cares about rather than walking the line one character at a time.
 shell_command_text() { # LINE — sets SHELL_COMMAND_TEXT
-  local rest="$1" out="" st="" top="" span="" openq="" resume="" pre="" tok=""
+  local rest="$1" out="" st="" top="" span="" openq="" resume="" pre="" tok="" esc=""
   while :; do
     case "$top" in
-      '') pre="${rest%%[\"\']*}" ;;
+      '') pre="${rest%%[\"\'\\]*}" ;;
       "'") pre="${rest%%\'*}" ;;
-      '"') pre="${rest%%[\"\$\`]*}" ;;
-      '`') pre="${rest%%[\"\'(\`]*}" ;;
-      *) pre="${rest%%[\"\'()\`]*}" ;;
+      '"') pre="${rest%%[\"\$\`\\]*}" ;;
+      '`') pre="${rest%%[\"\'(\`\\]*}" ;;
+      *) pre="${rest%%[\"\'()\`\\]*}" ;;
     esac
     if [ "$pre" = "$rest" ]; then
       if [ -n "$st" ]; then
@@ -960,6 +984,16 @@ shell_command_text() { # LINE — sets SHELL_COMMAND_TEXT
     tok="${rest#"$pre"}"
     tok="${tok%"${tok#?}"}"
     rest="${rest#"$pre$tok"}"
+    if [ "$tok" = '\' ]; then
+      esc="${rest%"${rest#?}"}"
+      rest="${rest#?}"
+      if [ -z "$st" ]; then
+        out="$out$pre\\$esc"
+      else
+        span="$span$pre\\$esc"
+      fi
+      continue
+    fi
     if [ -z "$st" ]; then
       out="$out$pre"
       openq="$tok"

--- a/skills/preflight/scripts/preflight
+++ b/skills/preflight/scripts/preflight
@@ -914,6 +914,35 @@ is_comment_line() { # LINE — leading-whitespace-then-# only; a trailing commen
 # the quoted literal itself, in any language. masked-returns is not either,
 # because a parse of the whole file owns that lane's reading.
 #
+# A quoted span standing as the code argument of an interpreter is executed,
+# whatever quotes it wears, so it is this file's commands and not its text:
+# `eval` and the `-c` form of sh, bash, zsh, dash and ksh, the interpreter
+# word at a command position. Any word may sit between it and the `-c`,
+# because a flag with a detached value (bash -euo pipefail -c) is ordinary
+# and keeping a span that is not code only gives a lane more to read, while
+# blanking one that is loses the commands it carries.
+INTERP_CODE_RE='(^[[:space:]]*|[;(`{&|][[:space:]]*)(eval|([^[:space:]]*/)?(sh|bash|zsh|dash|ksh)([[:space:]]+[^[:space:]]+)*[[:space:]]+-c)[[:space:]]+$'
+
+# A line's shell command text: the quoted spans that run nothing, blanked to
+# their delimiters. Single quotes suppress every expansion, so their span is
+# literal text wherever it stands — the hook and script templates a tool
+# writes to disk carry commands that run in the written file, never in this
+# one. A span that DOES run something is kept whole.
+#
+# Two questions decide each span, and both are answered by the scan itself
+# rather than by re-reading the span's bytes. A byte search cannot answer
+# either one: it cannot tell a substitution the scan entered from an escaped
+# `\$(` the scan consumed as text, and it cannot see the interpreter word
+# that stands outside the span. `runs` records whether the scan entered a
+# substitution state while the span was open; `INTERP_CODE_RE` reads the
+# text before the span.
+#
+# One blanking step for every lane that judges a line as this script's own
+# commands (both the fail-open shapes the text decides, mktemp-trap,
+# early-close-pipe). hardcoded-temp-path is not one of them: its subject is
+# the quoted literal itself, in any language. masked-returns is not either,
+# because a parse of the whole file owns that lane's reading.
+#
 # This is a lexer, and the set of shell rules it implements is the whole of
 # what it promises. A gap in the set is a lane going blind, not a cosmetic
 # miss, so the set is written out here for a reader to check against rather
@@ -921,6 +950,9 @@ is_comment_line() { # LINE — leading-whitespace-then-# only; a trailing commen
 #
 #   - A single-quoted span runs to the next `'`. Nothing inside it expands,
 #     escapes or opens anything.
+#   - An ANSI-C span, `$'…'`, runs to the first UNESCAPED `'`, because a
+#     backslash escapes there and does not in the ordinary single-quoted
+#     form. Nothing in it runs either.
 #   - A double-quoted span runs to the first `"` OUTSIDE any substitution it
 #     opened. Shell restarts quoting inside a substitution, so the inner
 #     quotes of `x="$(cmd "$arg")"` belong to it; ending the span at one of
@@ -932,35 +964,42 @@ is_comment_line() { # LINE — leading-whitespace-then-# only; a trailing commen
 #     `` … ``, closing at its matching backtick. Both run a command, and
 #     both are what the mktemp-trap and early-close-pipe anchors already name
 #     as a command position. A bare paren inside double quotes is literal.
-#   - A backslash escapes the character after it everywhere except inside a
-#     single-quoted span, where it is literal. So `"a\"b"` is one span, not
-#     two, and the code after it is not read as this file's own.
+#   - A backslash escapes the character after it in every context but the
+#     ordinary single-quoted span, where it is literal. So `"a\"b"` is one
+#     span, not two, and the code after it is not read as this file's own.
 #   - A span that never closes on this line is not a span: its opening quote
 #     is emitted as ordinary text and the scan resumes after it, so an
 #     unpaired apostrophe cannot swallow a double-quoted span behind it.
 #
-# Deliberately not implemented, each because it leaves inert text mis-split
-# rather than losing a command, which over-reports instead of going blind:
+# Three rules are not implemented. Each one's direction is DERIVED by
+# constructing a line that exercises it and reading what the scan returns,
+# never asserted, because an omission that can lose a command is a fail-open
+# path and not a documented limitation:
 #
-#   - Quote context across physical lines. preflight judges added lines one
-#     at a time, so the middle line of a multi-line template carries no quote
-#     and is read as code.
-#   - `$'…'` ANSI-C quoting, where a backslash DOES escape inside single
-#     quotes. The span ends early at the escaped quote.
-#   - Quotes nested inside `${…}`, which are lexed as adjacent spans. Nothing
-#     inside a parameter expansion runs a command.
-#   - Heredoc bodies, which are lines of data this scan reads as code.
-#
-# `st` is the nesting stack that holds all of it, innermost context last:
-# `'` a single-quoted span, `"` a double-quoted one, `(` a substitution or
-# subshell, ``` the backtick substitution.
-#
-# In-shell and out through a global, never a subprocess: this runs on every
-# added shell line that carries a quote, and a fork per line costs more than
-# all the lanes it feeds. Each turn jumps to the next character its own state
-# cares about rather than walking the line one character at a time.
+#   - Quotes nested inside `${…}`, lexed as adjacent spans. Constructed:
+#     `a="${p:-"x"}"; git rev-parse --git-dir || true` returns the git
+#     command intact and exposes the bare `x`. A parameter expansion runs no
+#     command, so the mis-split text is inert and a substitution inside one
+#     is kept by `runs`. Over-reports, never loses.
+#   - Heredoc bodies, which are data this scan reads as code. Constructed: a
+#     body line `git rev-parse --git-dir || true` is returned unchanged and
+#     judged, so the lane fires on data. A data line carries no command to
+#     lose. Over-reports, never loses.
+#   - Quote context across physical lines. THIS ONE LOSES COMMANDS and is a
+#     known fail-open, not a limitation. preflight judges added lines one at
+#     a time, so a line holding one template's closing quote and the next
+#     one's opening quote pairs those two and blanks everything between.
+#     Constructed: on `  end'; mktemp -d; start='begin` and on the same line
+#     with `printf %s "$v" | head -1` in place of the mktemp, this step
+#     returns `  end''begin` and the command is gone. Its reach is a line
+#     that closes one quoted template and opens another with live code
+#     between them. main reports mktemp-trap and early-close-pipe on both of
+#     those lines, because those two lanes read the raw line there, so this
+#     step is worse than main on that shape; the swallowed-status shape is
+#     unchanged, since main blanked quoted spans for that lane already.
 shell_command_text() { # LINE — sets SHELL_COMMAND_TEXT
-  local rest="$1" out="" st="" top="" span="" openq="" resume="" pre="" tok="" esc=""
+  local rest="$1" out="" st="" top="" span="" openq="" resume="" pre="" tok=""
+  local esc="" prevch="" opens="" runs=0 keep=0
   while :; do
     # One arm per context, and no catch-all: a state whose arm stops
     # matching would otherwise borrow its neighbour's set and go on looking
@@ -970,6 +1009,7 @@ shell_command_text() { # LINE — sets SHELL_COMMAND_TEXT
     case "$top" in
       '') pre="${rest%%[\"\'\\]*}" ;;
       "'") pre="${rest%%\'*}" ;;
+      A) pre="${rest%%[\'\\]*}" ;;
       '"') pre="${rest%%[\"\$\`\\]*}" ;;
       '`') pre="${rest%%[\"\'(\`\\]*}" ;;
       '(') pre="${rest%%[\"\'()\`\\]*}" ;;
@@ -982,6 +1022,7 @@ shell_command_text() { # LINE — sets SHELL_COMMAND_TEXT
         st=""
         top=""
         span=""
+        runs=0
         continue
       fi
       out="$out$rest"
@@ -1000,18 +1041,36 @@ shell_command_text() { # LINE — sets SHELL_COMMAND_TEXT
       fi
       continue
     fi
+    # `$'…'` is its own context: a backslash escapes there, so the ordinary
+    # single-quoted arm would close the span at an escaped apostrophe and
+    # pair the real terminator with a later quote, swallowing the live code
+    # between them.
+    opens="$tok"
+    if [ "$tok" = "'" ]; then
+      if [ -n "$pre" ]; then
+        prevch="${pre#"${pre%?}"}"
+      elif [ -z "$st" ]; then
+        prevch="${out#"${out%?}"}"
+      else
+        prevch="${span#"${span%?}"}"
+      fi
+      if [ "$prevch" = '$' ]; then
+        opens=A
+      fi
+    fi
     if [ -z "$st" ]; then
       out="$out$pre"
       openq="$tok"
       span="$tok"
       resume="$rest"
-      st="$tok"
-      top="$tok"
+      st="$opens"
+      top="$opens"
+      runs=0
       continue
     fi
     span="$span$pre$tok"
     case "$top$tok" in
-      "''" | '""' | '``' | '()')
+      "''" | "A'" | '""' | '``' | '()')
         st="${st%?}"
         top="${st#"${st%?}"}"
         ;;
@@ -1022,24 +1081,43 @@ shell_command_text() { # LINE — sets SHELL_COMMAND_TEXT
             rest="${rest#?}"
             st="$st("
             top="("
+            runs=1
             ;;
         esac
         ;;
-      "'"*)
+      "'"* | A*)
         ;;
       *)
-        st="$st$tok"
-        top="$tok"
+        st="$st$opens"
+        top="$opens"
+        case "$opens" in
+          '(' | '`') runs=1 ;;
+        esac
         ;;
     esac
     if [ -z "$st" ]; then
-      case "$span" in
-        \'*) out="$out''" ;;
-        *'$('* | *'`'*) out="$out$span" ;;
-        *) out="$out\"\"" ;;
-      esac
+      keep="$runs"
+      if [ "$keep" = 0 ]; then
+        case "$out" in
+          *[[:space:]])
+            case "$out" in
+              *-c[[:space:]]* | *eval[[:space:]]*)
+                if grep -Eq -- "$INTERP_CODE_RE" <<<"$out"; then
+                  keep=1
+                fi
+                ;;
+            esac
+            ;;
+        esac
+      fi
+      if [ "$keep" = 1 ]; then
+        out="$out$span"
+      else
+        out="$out$openq$openq"
+      fi
       span=""
       openq=""
+      runs=0
     fi
   done
   SHELL_COMMAND_TEXT="$out"

--- a/skills/preflight/scripts/preflight
+++ b/skills/preflight/scripts/preflight
@@ -82,9 +82,9 @@ Lanes:
                   the end of its input (tr, sed, wc), a command after ||
                   rather than after a pipe, or the same text on a comment
                   line. A quoted message IS read as a pipeline when it also
-                  carries a command substitution: the span is kept whole
-                  because the substitution runs, and the pipe inside it
-                  cannot be told from the one outside. A file with no
+                  carries a command substitution, in either spelling: the
+                  span is kept whole because the substitution runs, and the
+                  pipe inside it cannot be told from the one outside. A file with no
                   pipefail preamble of its own is out of scope even where a
                   sourcing caller supplies one.
   unwired-suite   a new suite file no runner invokes. Suites are
@@ -152,10 +152,11 @@ Scope rules:
   delimiters. Single quotes suppress every expansion, so their span is text
   wherever it stands: the hook and script templates a tool writes to disk
   carry commands that run in the written file, never in the writer. A
-  double-quoted span is blanked too, unless a $( inside it opens a command
-  the line really runs. hardcoded-temp-path takes no blanking, since the
-  quoted literal is its subject; masked-returns takes none either, since
-  shellcheck parses the file and owns that reading.
+  double-quoted span is blanked too, unless a substitution inside it opens a
+  command the line really runs: $( … ) or the backtick spelling, both of
+  which these lanes already name as a command position. hardcoded-temp-path
+  takes no blanking, since the quoted literal is its subject; masked-returns
+  takes none either, since shellcheck parses the file and owns that reading.
   In an installed-artifact subtree (.agents/ and the harness directories'
   skills, agents, hooks, rules, instructions, packages and kendex trees)
   masked-returns, fail-open, early-close-pipe, unwired-suite, mktemp-trap and
@@ -914,18 +915,21 @@ is_comment_line() { # LINE — leading-whitespace-then-# only; a trailing commen
 # because a parse of the whole file owns that lane's reading.
 #
 # A double-quoted span ends at the first `"` OUTSIDE any substitution it
-# opened, never at the next `"` in the text: shell restarts quoting inside
-# `$( … )`, so the inner quotes of `x="$(cmd "$arg")"` belong to the
-# substitution. Ending the span at one of those would cut the line at the
-# inner quote and drop the rest of the command, including the `)` that
+# opened, never at the next `"` in the text: shell restarts quoting inside a
+# substitution, so the inner quotes of `x="$(cmd "$arg")"` belong to it.
+# Ending the span at one of those would cut the line at the inner quote and
+# drop the rest of the command, including the `)` that
 # `substitution_status_checked` reads and the pipeline `early-close-pipe`
 # looks for. `st` is the nesting stack that holds that property, innermost
 # context last: `'` a single-quoted span, `"` a double-quoted one, `(` a
-# substitution or subshell. Only `$(` opens one from inside double quotes,
-# where a bare paren is literal; inside a substitution every quote opens
-# again. A span that never closes on this line is not a span: its opening
-# quote is emitted as ordinary text and the scan resumes after it, so an
-# unpaired apostrophe cannot swallow a double-quoted span behind it.
+# substitution or subshell, ``` the older substitution spelling, which
+# closes at its matching backtick rather than at a paren. Both spellings run
+# a command from inside double quotes, and both are what the mktemp-trap and
+# early-close-pipe anchors already name as a command position; a bare paren
+# there is literal, and inside a substitution every quote opens again. A span
+# that never closes on this line is not a span: its opening quote is emitted
+# as ordinary text and the scan resumes after it, so an unpaired apostrophe
+# cannot swallow a double-quoted span behind it.
 #
 # In-shell and out through a global, never a subprocess: this runs on every
 # added shell line that carries a quote, and a fork per line costs more than
@@ -937,8 +941,9 @@ shell_command_text() { # LINE — sets SHELL_COMMAND_TEXT
     case "$top" in
       '') pre="${rest%%[\"\']*}" ;;
       "'") pre="${rest%%\'*}" ;;
-      '"') pre="${rest%%[\"\$]*}" ;;
-      *) pre="${rest%%[\"\'()]*}" ;;
+      '"') pre="${rest%%[\"\$\`]*}" ;;
+      '`') pre="${rest%%[\"\'(\`]*}" ;;
+      *) pre="${rest%%[\"\'()\`]*}" ;;
     esac
     if [ "$pre" = "$rest" ]; then
       if [ -n "$st" ]; then
@@ -965,39 +970,32 @@ shell_command_text() { # LINE — sets SHELL_COMMAND_TEXT
       continue
     fi
     span="$span$pre$tok"
-    case "$top" in
-      "'" | '"')
-        if [ "$tok" = "$top" ]; then
-          st="${st%?}"
-          top="${st#"${st%?}"}"
-        elif [ "$tok" = '$' ]; then
-          case "$rest" in
-            '('*)
-              span="$span("
-              rest="${rest#?}"
-              st="$st("
-              top="("
-              ;;
-          esac
-        fi
+    case "$top$tok" in
+      "''" | '""' | '``' | '()')
+        st="${st%?}"
+        top="${st#"${st%?}"}"
         ;;
-      *)
-        case "$tok" in
-          ')')
-            st="${st%?}"
-            top="${st#"${st%?}"}"
-            ;;
-          *)
-            st="$st$tok"
-            top="$tok"
+      '"$')
+        case "$rest" in
+          '('*)
+            span="$span("
+            rest="${rest#?}"
+            st="$st("
+            top="("
             ;;
         esac
+        ;;
+      "'"*)
+        ;;
+      *)
+        st="$st$tok"
+        top="$tok"
         ;;
     esac
     if [ -z "$st" ]; then
       case "$span" in
         \'*) out="$out''" ;;
-        *'$('*) out="$out$span" ;;
+        *'$('* | *'`'*) out="$out$span" ;;
         *) out="$out\"\"" ;;
       esac
       span=""

--- a/skills/preflight/scripts/preflight
+++ b/skills/preflight/scripts/preflight
@@ -962,12 +962,18 @@ is_comment_line() { # LINE — leading-whitespace-then-# only; a trailing commen
 shell_command_text() { # LINE — sets SHELL_COMMAND_TEXT
   local rest="$1" out="" st="" top="" span="" openq="" resume="" pre="" tok="" esc=""
   while :; do
+    # One arm per context, and no catch-all: a state whose arm stops
+    # matching would otherwise borrow its neighbour's set and go on looking
+    # correct, which is how the backtick arm was dead while every backtick
+    # test still passed. The refusal makes each arm reachable by any test
+    # that reaches its state.
     case "$top" in
       '') pre="${rest%%[\"\'\\]*}" ;;
       "'") pre="${rest%%\'*}" ;;
       '"') pre="${rest%%[\"\$\`\\]*}" ;;
       '`') pre="${rest%%[\"\'(\`\\]*}" ;;
-      *) pre="${rest%%[\"\'()\`\\]*}" ;;
+      '(') pre="${rest%%[\"\'()\`\\]*}" ;;
+      *) env_error lexer-state "$top" "shell_command_text reached a context its scan has no character set for; the stack holds only a quote, a paren or a backtick." ;;
     esac
     if [ "$pre" = "$rest" ]; then
       if [ -n "$st" ]; then

--- a/skills/preflight/scripts/preflight
+++ b/skills/preflight/scripts/preflight
@@ -81,10 +81,8 @@ Lanes:
                   reader fed a here-string or a file, a reader that runs to
                   the end of its input (tr, sed, wc), a command after ||
                   rather than after a pipe, or the same text on a comment
-                  line. A pipe inside a quoted message on a line that also
-                  opens with a writer is judged as a pipeline. A file with no
-                  pipefail preamble of its own is out of scope even where a
-                  sourcing caller supplies one.
+                  line. A file with no pipefail preamble of its own is out of
+                  scope even where a sourcing caller supplies one.
   unwired-suite   a new suite file no runner invokes. Suites are
                   tests/*.test.sh, tests/test-*.sh, a shell file with a
                   test-<name> basename and no extension, *.test.ts, *.test.js
@@ -144,6 +142,16 @@ Scope rules:
   test_*) only the swallowed-status shape and that same docs-cited-paths
   direction stand down. The mktemp assignment shape of fail-open is judged in
   every tree.
+  A lane that reads a line as this script's own commands — the
+  swallowed-status and mktemp-assignment shapes of fail-open, mktemp-trap and
+  early-close-pipe — judges it with its inert quoted spans blanked to their
+  delimiters. Single quotes suppress every expansion, so their span is text
+  wherever it stands: the hook and script templates a tool writes to disk
+  carry commands that run in the written file, never in the writer. A
+  double-quoted span is blanked too, unless a $( inside it opens a command
+  the line really runs. hardcoded-temp-path takes no blanking, since the
+  quoted literal is its subject; masked-returns takes none either, since
+  shellcheck parses the file and owns that reading.
   In an installed-artifact subtree (.agents/ and the harness directories'
   skills, agents, hooks, rules, instructions, packages and kendex trees)
   masked-returns, fail-open, early-close-pipe, unwired-suite, mktemp-trap and
@@ -887,30 +895,76 @@ is_comment_line() { # LINE — leading-whitespace-then-# only; a trailing commen
   return 1
 }
 
+# A line's shell command text: the quoted spans that run nothing, blanked to
+# their delimiters. Single quotes suppress every expansion, so their span is
+# literal text wherever it stands — the hook and script templates a tool
+# writes to disk carry commands that run in the written file, never in this
+# one. A double-quoted span still runs whatever a `$(` inside it opens, so
+# that one is kept whole. The delimiters stay, so the command-position anchor
+# every line-shape lane carries still reads the word boundary a quote makes.
+# A pair is required: the lone apostrophe of `don't` closes no span, and a
+# string whose closing quote is on another line is not one of these.
+#
+# One blanking step for every lane that judges a line as this script's own
+# commands (both the fail-open shapes the text decides, mktemp-trap,
+# early-close-pipe). hardcoded-temp-path is not one of them: its subject is
+# the quoted literal itself, in any language. masked-returns is not either,
+# because a parse of the whole file owns that lane's reading.
+# In-shell and out through a global, never a subprocess: this runs on every
+# added shell line that carries a quote, and a fork per line costs more than
+# all the lanes it feeds. Each turn takes the leftmost span that actually
+# closes, so an unpaired apostrophe cannot swallow a double-quoted span
+# behind it.
+shell_command_text() { # LINE — sets SHELL_COMMAND_TEXT
+  local rest="$1" out="" pre="" body="" q="" sq_pre="" dq_pre="" sq_closes=0 dq_closes=0
+  while :; do
+    sq_pre="${rest%%\'*}"
+    dq_pre="${rest%%\"*}"
+    sq_closes=0
+    dq_closes=0
+    if [ "$sq_pre" != "$rest" ]; then
+      case "${rest#"$sq_pre'"}" in *\'*) sq_closes=1 ;; esac
+    fi
+    if [ "$dq_pre" != "$rest" ]; then
+      case "${rest#"$dq_pre\""}" in *\"*) dq_closes=1 ;; esac
+    fi
+    if [ "$sq_closes" = 1 ] && { [ "$dq_closes" = 0 ] || [ "${#sq_pre}" -lt "${#dq_pre}" ]; }; then
+      q="'"
+      pre="$sq_pre"
+    elif [ "$dq_closes" = 1 ]; then
+      q='"'
+      pre="$dq_pre"
+    else
+      break
+    fi
+    rest="${rest#"$pre$q"}"
+    body="${rest%%"$q"*}"
+    rest="${rest#"$body$q"}"
+    if [ "$q" = '"' ]; then
+      case "$body" in
+        *'$('*) out="$out$pre$q$body$q"; continue ;;
+      esac
+    fi
+    out="$out$pre$q$q"
+  done
+  SHELL_COMMAND_TEXT="$out$rest"
+}
+
 # The `|| true` shape on a command whose exit 2 means "could not read" or
 # "invoked wrong": true erases that status and the caller reads the empty
 # result as a clean answer. The command must stand at a command position, so
-# the same text quoted inside a message is not a finding. Prints the
-# swallowed command, nothing when the shape is absent — a status-capturing
-# `|| status=$?` is a different line.
-swallowed_cmd() { # LINE -> command name on stdout
-  printf '%s\n' "$1" | LC_ALL=C awk '
-    # Blank quoted spans that carry no substitution: text in a message runs
-    # nothing, but "$(git … || true)" is a command inside quotes.
-    {
-      out = ""; rest = $0
-      while (match(rest, /"[^"]*"|\047[^\047]*\047/)) {
-        seg = substr(rest, RSTART, RLENGTH)
-        out = out substr(rest, 1, RSTART - 1) (index(seg, "$(") ? seg : substr(seg, 1, 1) substr(seg, 1, 1))
-        rest = substr(rest, RSTART + RLENGTH)
-      }
-      $0 = out rest
-    }
+# the same text quoted inside a message is not a finding. Sets the swallowed
+# command, empty when the shape is absent — a status-capturing
+# `|| status=$?` is a different line. Out through a global like the scan
+# above it, so the awk that cannot run ends the script here rather than
+# reading as a line with no shape.
+swallowed_cmd() { # COMMAND-TEXT (shell_command_text) — sets SWALLOWED_CMD
+  SWALLOWED_CMD="$(printf '%s\n' "$1" | LC_ALL=C awk '
     match($0, /(^[[:space:]]*|[;(`{&|][[:space:]]*)(grep|find|git|jq|diff|cmp)([[:space:]][^|]*)?\|\|[[:space:]]*(true|:)([^A-Za-z0-9_.-]|$)/) {
       s = substr($0, RSTART, RLENGTH)
       if (match(s, /(grep|find|git|jq|diff|cmp)/)) print substr(s, RSTART, RLENGTH)
       exit
-    }'
+    }')"
 }
 
 # The test tree sets its own rules, and this is its one grammar. A suite is
@@ -1324,10 +1378,20 @@ while IFS= read -r f; do
   while IFS= read -r rec; do
     n="${rec%%"$TAB"*}"
     content="${rec#*"$TAB"}"
+    # What this script's own shell would run on this line: the lanes below
+    # that judge a command read `code`, and the one that judges a quoted
+    # literal (hardcoded-temp-path) reads `content`. Scanned only where a
+    # quote can open a span, which most lines never do.
+    code="$content"
+    if [ "$is_sh" = 1 ]; then
+      case "$content" in
+        *\'* | *'"'*) shell_command_text "$content"; code="$SHELL_COMMAND_TEXT" ;;
+      esac
+    fi
 
     if [ "$is_sh" = 1 ] && [ "$vendored_mirror" = 0 ] && [ "$has_ee" = 0 ] \
-      && grep -Eq -- "$MKTEMP_ASSIGN" <<<"$content" \
-      && ! substitution_status_checked "$content"; then
+      && grep -Eq -- "$MKTEMP_ASSIGN" <<<"$code" \
+      && ! substitution_status_checked "$code"; then
       emit "$f" "$n" fail-open "unchecked mktemp in a file without errexit — a failed mktemp leaves the variable empty and the script runs on"
     fi
 
@@ -1340,10 +1404,10 @@ while IFS= read -r f; do
     # of the line, so a `#` in front of the shape already fails to match.
     if [ "$is_sh" = 1 ] && [ "$own_rules" = 0 ] && [ "$vendored_mirror" = 0 ] \
       && [ "$has_ee" = 1 ] && [ "$has_noee" = 0 ]; then
-      case "$content" in
+      case "$code" in
         *'$('*)
-          if ! substitution_status_checked "$content" && grep -Eq -- "$SUBST_ASSIGN_RE" <<<"$content"; then
-            assign_var="${content#"${content%%[![:space:]]*}"}"
+          if ! substitution_status_checked "$code" && grep -Eq -- "$SUBST_ASSIGN_RE" <<<"$code"; then
+            assign_var="${code#"${code%%[![:space:]]*}"}"
             assign_var="${assign_var%%=*}"
             if guard_tests_var "$cpath" "$n" "$assign_var"; then
               emit "$f" "$n" fail-open "bare command-substitution assignment under errexit — its status ends the script here, so the test of \$$assign_var below never runs; move the assignment into the condition"
@@ -1356,9 +1420,9 @@ while IFS= read -r f; do
     # The literal prefilters keep the regex passes off the lines that cannot
     # carry either shape — most of them.
     if [ "$is_sh" = 1 ] && [ "$own_rules" = 0 ] && [ "$vendored_mirror" = 0 ] && [ "$is_new" = 1 ] && [ "$has_trap" = 0 ] && [ "$mktemp_reported" = 0 ]; then
-      case "$content" in
+      case "$code" in
         *mktemp*)
-          if ! is_comment_line "$content" && printf '%s' "$content" | grep -Eq -- "$MKTEMP_CALL_RE"; then
+          if ! is_comment_line "$content" && grep -Eq -- "$MKTEMP_CALL_RE" <<<"$code"; then
             mktemp_reported=1
             emit "$f" "$n" mktemp-trap "mktemp without an EXIT trap — scratch is never removed"
           fi
@@ -1387,12 +1451,12 @@ while IFS= read -r f; do
     fi
 
     if [ "$is_sh" = 1 ] && [ "$own_rules" = 0 ] && [ "$vendored_mirror" = 0 ] && [ "$is_testname" = 0 ]; then
-      case "$content" in
+      case "$code" in
         *"||"*)
           if ! is_comment_line "$content"; then
-            swallowed="$(swallowed_cmd "$content")"
-            if [ -n "$swallowed" ]; then
-              emit "$f" "$n" fail-open "$swallowed || true swallows exit 2 (unreadable input, broken invocation) — capture the status and treat >1 as failure"
+            swallowed_cmd "$code"
+            if [ -n "$SWALLOWED_CMD" ]; then
+              emit "$f" "$n" fail-open "$SWALLOWED_CMD || true swallows exit 2 (unreadable input, broken invocation) — capture the status and treat >1 as failure"
             fi
           fi
           ;;
@@ -1404,9 +1468,9 @@ while IFS= read -r f; do
     # is no licence to take a 141 that ends the run in the middle of a
     # section. The file's own pipefail is already the condition above.
     if [ "$is_sh" = 1 ] && [ "$vendored_mirror" = 0 ] && [ "$has_pf" = 1 ]; then
-      case "$content" in
+      case "$code" in
         *"|"*)
-          if ! is_comment_line "$content" && grep -Eq -- "$EARLY_CLOSE_RE" <<<"$content"; then
+          if ! is_comment_line "$content" && grep -Eq -- "$EARLY_CLOSE_RE" <<<"$code"; then
             emit "$f" "$n" early-close-pipe "a shell writer piped into a reader that stops before EOF — pipefail turns the writer's SIGPIPE into a 141 that aborts the branch under errexit, and reads as a plain no-match in condition position; capture whole and window in-shell, or feed the reader a here-string"
           fi
           ;;

--- a/skills/preflight/tests/lanes-must-fail.test.sh
+++ b/skills/preflight/tests/lanes-must-fail.test.sh
@@ -62,7 +62,11 @@ pf_world() {
   case "$1" in
     syntax) printf '#!/usr/bin/env bash\nset -euo pipefail\nif [ 1 = 1 ]; then\n' >"$R/scripts/broken.sh" ;;
     scerror) printf '#!/usr/bin/env bash\nset -euo pipefail\nexit 300\n' >"$R/scripts/exitcode.sh" ;;
-    masked) printf '#!/usr/bin/env bash\nset -euo pipefail\ntrap '"'"'echo done'"'"' EXIT\nf() {\n  local d="$(mktemp -d)"\n  echo "$d"\n}\nf\n' >"$R/scripts/masked.sh" ;;
+    # Line 6 is the same declaration with the substitution inside single
+    # quotes, where it expands to nothing and masks no status. shellcheck
+    # parses the file and owns that reading, so this lane takes no blanking
+    # step of its own; the row's whole-set pin is what holds it to one head.
+    masked) printf '#!/usr/bin/env bash\nset -euo pipefail\ntrap '"'"'echo done'"'"' EXIT\nf() {\n  local d="$(mktemp -d)"\n  local tpl='"'"'e=$(mktemp -d)'"'"'\n  echo "$d$tpl"\n}\nf\n' >"$R/scripts/masked.sh" ;;
     mktemp) printf '#!/usr/bin/env bash\necho loose\nTMP="$(mktemp -d)"\necho "$TMP"\n' >"$R/scripts/loose.sh" ;;
     strict) printf '#!/usr/bin/env bash\necho fresh\n' >"$R/scripts/fresh.sh" ;;
     swallow) printf '#!/usr/bin/env bash\nset -euo pipefail\necho existing\ngrep -q x -- "$1" || true\n' >"$R/scripts/existing.sh" ;;
@@ -120,6 +124,9 @@ pf_world() {
     scratch) printf '#!/usr/bin/env bash\nset -euo pipefail\nD="$(mktemp -d)"\necho "$D"\n' >"$R/scripts/scratch.sh" ;;
     scratchfile) printf '#!/usr/bin/env bash\nset -euo pipefail\nF="$(mktemp)"\necho "$F"\n' >"$R/scripts/scratchfile.sh" ;;
     shellmk) printf '#!/usr/bin/env bash\nset -euo pipefail\nmkdir -p %s/cache\n' /tmp >"$R/scripts/shellmk.sh" ;;
+    # This lane's subject IS the quoted literal, in every language, so the
+    # blanking step the command-judging lanes share must not reach it.
+    shellmkquoted) printf '#!/usr/bin/env bash\nset -euo pipefail\nmkdir -p %s%s/cache%s\n' "'" /tmp "'" >"$R/scripts/shellmk.sh" ;;
     mkjs) printf 'const fs = require("fs");\nfs.mkdirSync("%s/out");\n' /tmp >"$R/src/mk.js" ;;
     mkjsprefix) printf 'const fs = require("fs");\nfs.mkdtempSync("%s/app-");\n' /tmp >"$R/src/mk.js" ;;
     mkjsroot) printf 'const fs = require("fs");\nfs.mkdtempSync("%s");\n' /tmp >"$R/src/mk.js" ;;
@@ -176,7 +183,7 @@ pf_world() {
 IFS= read -r -d '' rows <<'ROWS' || :
 an unparseable new script fails, attributed to shell-syntax|syntax|-|-|1|scripts/broken.sh:4: [shell-syntax]|-
 an out-of-range exit status fails as a shellcheck error|scerror|-|shellcheck|1|scripts/exitcode.sh:3: [shellcheck-errors]|SC2242
-a masking local-and-assign fails on the line that introduced it|masked|-|shellcheck|1|scripts/masked.sh:5: [masked-returns]|SC2155
+a masking local-and-assign fails on the line that introduced it, and the single-quoted declaration under it masks nothing|masked|-|shellcheck|1|scripts/masked.sh:5: [masked-returns]|SC2155
 an mktemp assignment in an errexit-less file fails as fail-open|mktemp|-|-|1|scripts/loose.sh:3: [fail-open]|unchecked mktemp
 a new script that never sets -e/-u/pipefail fails as fail-open|strict|-|-|1|scripts/fresh.sh:0: [fail-open]|new shell file without strict mode
 a grep whose status or-true drops fails as fail-open, naming the command|swallow|-|-|1|scripts/existing.sh:4: [fail-open]|grep || true swallows exit 2
@@ -188,6 +195,7 @@ an operator inside the substitution does not exempt the assignment|bareinner|-|-
 a new script with mktemp and no EXIT trap fails as mktemp-trap|scratch|-|-|1|scripts/scratch.sh:3: [mktemp-trap]|mktemp without an EXIT trap
 an mktemp with no arguments is the same finding|scratchfile|-|-|1|scripts/scratchfile.sh:3: [mktemp-trap]|mktemp without an EXIT trap
 a shell mkdir -p at a literal /tmp path fails|shellmk|-|-|1|scripts/shellmk.sh:3: [hardcoded-temp-path]|-
+the same path in single quotes is the same finding|shellmkquoted|-|-|1|scripts/shellmk.sh:3: [hardcoded-temp-path]|-
 a JS mkdirSync taking the literal fails|mkjs|-|-|1|src/mk.js:2: [hardcoded-temp-path]|-
 a JS mkdtempSync prefix under /tmp is the same finding|mkjsprefix|-|-|1|src/mk.js:2: [hardcoded-temp-path]|-
 the JS bare-root prefix form (mkdtempSync(/tmp) making a /tmpXXXXXX sibling) fails|mkjsroot|-|-|1|src/mk.js:2: [hardcoded-temp-path]|-

--- a/skills/preflight/tests/lanes-must-fail.test.sh
+++ b/skills/preflight/tests/lanes-must-fail.test.sh
@@ -88,6 +88,13 @@ pf_world() {
       ecn_reader='| head -1)"'
       printf '#!/usr/bin/env bash\nset -euo pipefail\n%s%s\necho "$n"\n' "$ecn_writer" "$ecn_reader" >"$R/scripts/existing.sh"
       ;;
+    # The same 141 where the substitution carries an ESCAPED quote. A scan
+    # that reads that quote as the span's end loses the pipeline behind it.
+    earlycloseescape)
+      ece_writer='n="$(printf "a\"b" '
+      ece_reader='| head -1)"'
+      printf '#!/usr/bin/env bash\nset -euo pipefail\n%s%s\necho "$n"\n' "$ece_writer" "$ece_reader" >"$R/scripts/existing.sh"
+      ;;
     # The same 141 in the backtick spelling: EARLY_CLOSE_WRITER names the
     # backtick as a command position too.
     earlyclosetick)
@@ -221,6 +228,7 @@ a quoted argument inside that substitution does not end its span early|swallowne
 a condition piping echo into grep -q fails as early-close-pipe|earlyclose|-|-|1|scripts/existing.sh:3: [early-close-pipe]|a shell writer piped into a reader that stops before EOF
 a pipeline inside a substitution that carries a quoted argument is still one|earlyclosenested|-|-|1|scripts/existing.sh:3: [early-close-pipe]|a shell writer piped into a reader that stops before EOF
 the backtick spelling of that substitution is judged too|earlyclosetick|-|-|1|scripts/existing.sh:3: [early-close-pipe]|a shell writer piped into a reader that stops before EOF
+an escaped quote inside that substitution does not end its span|earlycloseescape|-|-|1|scripts/existing.sh:3: [early-close-pipe]|a shell writer piped into a reader that stops before EOF
 a suite that sets pipefail is judged too, mid-pipeline reader included|earlyclosesuite|-|-|1|tests/known.test.sh:3: [early-close-pipe]|-
 an assignment whose guard errexit kills first fails as fail-open|bareassign|-|-|1|scripts/bare.sh:3: [fail-open]|bare command-substitution assignment under errexit
 an operator inside the substitution does not exempt the assignment|bareinner|-|-|1|scripts/bare.sh:3: [fail-open]|bare command-substitution assignment under errexit

--- a/skills/preflight/tests/lanes-must-fail.test.sh
+++ b/skills/preflight/tests/lanes-must-fail.test.sh
@@ -88,6 +88,14 @@ pf_world() {
       ecn_reader='| head -1)"'
       printf '#!/usr/bin/env bash\nset -euo pipefail\n%s%s\necho "$n"\n' "$ecn_writer" "$ecn_reader" >"$R/scripts/existing.sh"
       ;;
+    # The same 141 in the backtick spelling: EARLY_CLOSE_WRITER names the
+    # backtick as a command position too.
+    earlyclosetick)
+      bt='`'
+      ect_writer='n="%sprintf "%%s\\n" "$1" '
+      ect_reader='| head -1%s"'
+      printf '#!/usr/bin/env bash\nset -euo pipefail\n'"$ect_writer$ect_reader"'\necho "$n"\n' "$bt" "$bt" >"$R/scripts/existing.sh"
+      ;;
     # The same lane inside the test tree, on the mid-pipeline shape: the
     # reader is two stages down and another stage runs after it, and the
     # suite's own pipefail is what turns the writer's SIGPIPE into the 141
@@ -135,6 +143,14 @@ pf_world() {
       } >"$R/scripts/bare.sh"
       ;;
     scratch) printf '#!/usr/bin/env bash\nset -euo pipefail\nD="$(mktemp -d)"\necho "$D"\n' >"$R/scripts/scratch.sh" ;;
+    # The older substitution spelling, which runs a command inside double
+    # quotes exactly as $( ) does and which MKTEMP_CALL_RE already names as a
+    # command position. Written through a variable so this suite's own
+    # committed line does not carry the shape.
+    scratchtick)
+      bt='`'
+      printf '#!/usr/bin/env bash\nset -euo pipefail\nD="%smktemp -d%s"\necho "$D"\n' "$bt" "$bt" >"$R/scripts/scratch.sh"
+      ;;
     scratchfile) printf '#!/usr/bin/env bash\nset -euo pipefail\nF="$(mktemp)"\necho "$F"\n' >"$R/scripts/scratchfile.sh" ;;
     shellmk) printf '#!/usr/bin/env bash\nset -euo pipefail\nmkdir -p %s/cache\n' /tmp >"$R/scripts/shellmk.sh" ;;
     # This lane's subject IS the quoted literal, in every language, so the
@@ -204,10 +220,12 @@ the shape is caught inside a command substitution too|swallowsubst|-|-|1|scripts
 a quoted argument inside that substitution does not end its span early|swallownested|-|-|1|scripts/existing.sh:4: [fail-open]|git || true swallows exit 2
 a condition piping echo into grep -q fails as early-close-pipe|earlyclose|-|-|1|scripts/existing.sh:3: [early-close-pipe]|a shell writer piped into a reader that stops before EOF
 a pipeline inside a substitution that carries a quoted argument is still one|earlyclosenested|-|-|1|scripts/existing.sh:3: [early-close-pipe]|a shell writer piped into a reader that stops before EOF
+the backtick spelling of that substitution is judged too|earlyclosetick|-|-|1|scripts/existing.sh:3: [early-close-pipe]|a shell writer piped into a reader that stops before EOF
 a suite that sets pipefail is judged too, mid-pipeline reader included|earlyclosesuite|-|-|1|tests/known.test.sh:3: [early-close-pipe]|-
 an assignment whose guard errexit kills first fails as fail-open|bareassign|-|-|1|scripts/bare.sh:3: [fail-open]|bare command-substitution assignment under errexit
 an operator inside the substitution does not exempt the assignment|bareinner|-|-|1|scripts/bare.sh:3: [fail-open]|bare command-substitution assignment under errexit
 a new script with mktemp and no EXIT trap fails as mktemp-trap|scratch|-|-|1|scripts/scratch.sh:3: [mktemp-trap]|mktemp without an EXIT trap
+the backtick spelling of that substitution is the same finding|scratchtick|-|-|1|scripts/scratch.sh:3: [mktemp-trap]|mktemp without an EXIT trap
 an mktemp with no arguments is the same finding|scratchfile|-|-|1|scripts/scratchfile.sh:3: [mktemp-trap]|mktemp without an EXIT trap
 a shell mkdir -p at a literal /tmp path fails|shellmk|-|-|1|scripts/shellmk.sh:3: [hardcoded-temp-path]|-
 the same path in single quotes is the same finding|shellmkquoted|-|-|1|scripts/shellmk.sh:3: [hardcoded-temp-path]|-

--- a/skills/preflight/tests/lanes-must-fail.test.sh
+++ b/skills/preflight/tests/lanes-must-fail.test.sh
@@ -71,10 +71,23 @@ pf_world() {
     strict) printf '#!/usr/bin/env bash\necho fresh\n' >"$R/scripts/fresh.sh" ;;
     swallow) printf '#!/usr/bin/env bash\nset -euo pipefail\necho existing\ngrep -q x -- "$1" || true\n' >"$R/scripts/existing.sh" ;;
     swallowsubst) printf '#!/usr/bin/env bash\nset -euo pipefail\necho existing\nn="$(git rev-list --count HEAD || true)"\necho "$n"\n' >"$R/scripts/existing.sh" ;;
+    # The same shape where the substitution carries a quoted argument of its
+    # own. A read that ends the span at that inner quote loses the `|| true`
+    # with the rest of the command, and the lane goes quiet on the line it
+    # exists for.
+    swallownested) printf '#!/usr/bin/env bash\nset -euo pipefail\nref="$1"\nn="$(git rev-list --count "$ref" || true)"\necho "$n"\n' >"$R/scripts/existing.sh" ;;
     # Written from the shell, never with cat reading a file: a cat-fed
     # fixture pushes several hundred KB before it blocks, so it passes
     # either way.
     earlyclose) printf '#!/usr/bin/env bash\nset -euo pipefail\nif echo "$1" | grep -q x; then echo hit; fi\n' >"$R/scripts/existing.sh" ;;
+    # The same 141 inside a substitution that carries a quoted argument. The
+    # pipeline is halved so this suite's own committed line does not carry
+    # the shape at a command position.
+    earlyclosenested)
+      ecn_writer='n="$(printf "%s\n" "$1" '
+      ecn_reader='| head -1)"'
+      printf '#!/usr/bin/env bash\nset -euo pipefail\n%s%s\necho "$n"\n' "$ecn_writer" "$ecn_reader" >"$R/scripts/existing.sh"
+      ;;
     # The same lane inside the test tree, on the mid-pipeline shape: the
     # reader is two stages down and another stage runs after it, and the
     # suite's own pipefail is what turns the writer's SIGPIPE into the 141
@@ -188,7 +201,9 @@ an mktemp assignment in an errexit-less file fails as fail-open|mktemp|-|-|1|scr
 a new script that never sets -e/-u/pipefail fails as fail-open|strict|-|-|1|scripts/fresh.sh:0: [fail-open]|new shell file without strict mode
 a grep whose status or-true drops fails as fail-open, naming the command|swallow|-|-|1|scripts/existing.sh:4: [fail-open]|grep || true swallows exit 2
 the shape is caught inside a command substitution too|swallowsubst|-|-|1|scripts/existing.sh:4: [fail-open]|git || true swallows exit 2
+a quoted argument inside that substitution does not end its span early|swallownested|-|-|1|scripts/existing.sh:4: [fail-open]|git || true swallows exit 2
 a condition piping echo into grep -q fails as early-close-pipe|earlyclose|-|-|1|scripts/existing.sh:3: [early-close-pipe]|a shell writer piped into a reader that stops before EOF
+a pipeline inside a substitution that carries a quoted argument is still one|earlyclosenested|-|-|1|scripts/existing.sh:3: [early-close-pipe]|a shell writer piped into a reader that stops before EOF
 a suite that sets pipefail is judged too, mid-pipeline reader included|earlyclosesuite|-|-|1|tests/known.test.sh:3: [early-close-pipe]|-
 an assignment whose guard errexit kills first fails as fail-open|bareassign|-|-|1|scripts/bare.sh:3: [fail-open]|bare command-substitution assignment under errexit
 an operator inside the substitution does not exempt the assignment|bareinner|-|-|1|scripts/bare.sh:3: [fail-open]|bare command-substitution assignment under errexit

--- a/skills/preflight/tests/lanes-must-fail.test.sh
+++ b/skills/preflight/tests/lanes-must-fail.test.sh
@@ -88,6 +88,14 @@ pf_world() {
       ecn_reader='| head -1)"'
       printf '#!/usr/bin/env bash\nset -euo pipefail\n%s%s\necho "$n"\n' "$ecn_writer" "$ecn_reader" >"$R/scripts/existing.sh"
       ;;
+    # An ANSI-C string whose escaped apostrophe the ordinary single-quote
+    # state reads as the terminator, pairing the real one with a later quote
+    # and blanking the live command between them.
+    ansiswallow)
+      sq="'"
+      printf '#!/usr/bin/env bash\nset -euo pipefail\nmsg=$%sa\\%sb%s; git rev-parse --git-dir || true; echo %sdone%s\n' \
+        "$sq" "$sq" "$sq" "$sq" "$sq" >"$R/scripts/existing.sh"
+      ;;
     # The same 141 where the substitution carries an ESCAPED quote. A scan
     # that reads that quote as the span's end loses the pipeline behind it.
     earlycloseescape)
@@ -154,6 +162,20 @@ pf_world() {
     # quotes exactly as $( ) does and which MKTEMP_CALL_RE already names as a
     # command position. Written through a variable so this suite's own
     # committed line does not carry the shape.
+    # A single-quoted span that is an interpreter's code argument runs, so
+    # blanking it loses the commands it carries. Two lanes, one row each.
+    interpmktemp)
+      sq="'"
+      printf '#!/usr/bin/env bash\nset -euo pipefail\nbash -c %scd "$1"; mktemp -d%s\n' "$sq" "$sq" >"$R/scripts/scratch.sh"
+      ;;
+    # Halved so this suite's own committed line carries no writer at a
+    # command position, the one lane the test tree is judged by.
+    interpearly)
+      sq="'"
+      ie_writer='v=$1; printf "%s\n" "$v" '
+      ie_reader='| head -1'
+      printf '#!/usr/bin/env bash\nset -euo pipefail\neval %s%s%s%s\n' "$sq" "$ie_writer" "$ie_reader" "$sq" >"$R/scripts/existing.sh"
+      ;;
     scratchtick)
       bt='`'
       printf '#!/usr/bin/env bash\nset -euo pipefail\nD="%smktemp -d%s"\necho "$D"\n' "$bt" "$bt" >"$R/scripts/scratch.sh"
@@ -229,11 +251,14 @@ a condition piping echo into grep -q fails as early-close-pipe|earlyclose|-|-|1|
 a pipeline inside a substitution that carries a quoted argument is still one|earlyclosenested|-|-|1|scripts/existing.sh:3: [early-close-pipe]|a shell writer piped into a reader that stops before EOF
 the backtick spelling of that substitution is judged too|earlyclosetick|-|-|1|scripts/existing.sh:3: [early-close-pipe]|a shell writer piped into a reader that stops before EOF
 an escaped quote inside that substitution does not end its span|earlycloseescape|-|-|1|scripts/existing.sh:3: [early-close-pipe]|a shell writer piped into a reader that stops before EOF
+an eval's single-quoted code argument is judged by that lane too|interpearly|-|-|1|scripts/existing.sh:3: [early-close-pipe]|a shell writer piped into a reader that stops before EOF
+an ANSI-C string does not swallow the command after it|ansiswallow|-|-|1|scripts/existing.sh:3: [fail-open]|git || true swallows exit 2
 a suite that sets pipefail is judged too, mid-pipeline reader included|earlyclosesuite|-|-|1|tests/known.test.sh:3: [early-close-pipe]|-
 an assignment whose guard errexit kills first fails as fail-open|bareassign|-|-|1|scripts/bare.sh:3: [fail-open]|bare command-substitution assignment under errexit
 an operator inside the substitution does not exempt the assignment|bareinner|-|-|1|scripts/bare.sh:3: [fail-open]|bare command-substitution assignment under errexit
 a new script with mktemp and no EXIT trap fails as mktemp-trap|scratch|-|-|1|scripts/scratch.sh:3: [mktemp-trap]|mktemp without an EXIT trap
 the backtick spelling of that substitution is the same finding|scratchtick|-|-|1|scripts/scratch.sh:3: [mktemp-trap]|mktemp without an EXIT trap
+an interpreter's single-quoted code argument is judged, not blanked|interpmktemp|-|-|1|scripts/scratch.sh:3: [mktemp-trap]|mktemp without an EXIT trap
 an mktemp with no arguments is the same finding|scratchfile|-|-|1|scripts/scratchfile.sh:3: [mktemp-trap]|mktemp without an EXIT trap
 a shell mkdir -p at a literal /tmp path fails|shellmk|-|-|1|scripts/shellmk.sh:3: [hardcoded-temp-path]|-
 the same path in single quotes is the same finding|shellmkquoted|-|-|1|scripts/shellmk.sh:3: [hardcoded-temp-path]|-

--- a/skills/preflight/tests/precision.test.sh
+++ b/skills/preflight/tests/precision.test.sh
@@ -679,6 +679,11 @@ EOF
 printf "window_line='%s%s'\n" "$ec_head" "$ec_tail" >>"$R/scripts/writer.sh"
 printf 'echo "the idiom is %s%s"\n' "$dq_head" "$ec_tail" >>"$R/scripts/writer.sh"
 printf 'printf "%%s\\n" "$hook_line" "$scratch_line" "$window_line" >"$1"\n' >>"$R/scripts/writer.sh"
+# A backtick runs a command inside double quotes and is literal inside single
+# ones, so the single-quoted spelling is the written file's command too. Built
+# through a variable so this suite's own committed line does not carry it.
+bt='`'
+printf "tick_line='cd \"\$d\"; %smktemp -d%s'\n" "$bt" "$bt" >>"$R/scripts/writer.sh"
 # The assignment shape needs a file that never sets errexit, and a sourced
 # lib is the one such file that is not itself a strict-mode finding.
 cat >"$R/scripts/lib/tpl.sh" <<'EOF'
@@ -689,7 +694,7 @@ echo "$assign_line"
 EOF
 git -C "$R" add -A
 run_pf
-clean "a swallowed status, an mktemp invocation, an early-closing pipeline and an mktemp assignment inside single quotes are the written file's commands, and a pipeline named in a double-quoted message is nobody's" 2
+clean "a swallowed status, an mktemp invocation in both substitution spellings, an early-closing pipeline and an mktemp assignment inside single quotes are the written file's commands, and a pipeline named in a double-quoted message is nobody's" 2
 
 echo "=== control: the same four shapes outside the quotes are this script's own ==="
 {

--- a/skills/preflight/tests/precision.test.sh
+++ b/skills/preflight/tests/precision.test.sh
@@ -653,4 +653,64 @@ git -C "$R" add -A
 run_pf --staged
 fires "the base's own migration, staged, still fails" "store/migrations/V1__init.sql:0: [applied-migration-edited]"
 
+echo "=== a shell template inside single quotes is text, not this script's commands ==="
+seed quotedtemplate
+mkdir -p "$R/scripts/lib"
+# Every shape sits after a `;` INSIDE the quotes, which is the command
+# position each lane anchors on: a template whose first word opened the span
+# would match no anchor and would pin nothing. The early-close pipeline is
+# halved across two variables so this suite's own committed line never
+# carries the shape at that position — the one lane the test tree is judged
+# by.
+ec_head='v=$1; printf "%s\n" "$v" '
+ec_tail='| head -1'
+# The double-quoted half of the same rule: a span with no `$(` in it opens no
+# command either, so the message naming the shape is not the shape. It takes
+# the same reader half, and its own writer half for the same reason.
+dq_head='cmd '
+cat >"$R/scripts/writer.sh" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+# A hook this script writes to disk: the commands between the quotes run in
+# the written file, never in this one.
+hook_line='cd "$d"; git rev-parse --git-dir 2>/dev/null || true'
+scratch_line='cd "$d"; mktemp -d'
+EOF
+printf "window_line='%s%s'\n" "$ec_head" "$ec_tail" >>"$R/scripts/writer.sh"
+printf 'echo "the idiom is %s%s"\n' "$dq_head" "$ec_tail" >>"$R/scripts/writer.sh"
+printf 'printf "%%s\\n" "$hook_line" "$scratch_line" "$window_line" >"$1"\n' >>"$R/scripts/writer.sh"
+# The assignment shape needs a file that never sets errexit, and a sourced
+# lib is the one such file that is not itself a strict-mode finding.
+cat >"$R/scripts/lib/tpl.sh" <<'EOF'
+#!/usr/bin/env bash
+# Sourced by the scripts beside it: the caller's shell owns the mode.
+assign_line='d=$(mktemp -d)'
+echo "$assign_line"
+EOF
+git -C "$R" add -A
+run_pf
+clean "a swallowed status, an mktemp invocation, an early-closing pipeline and an mktemp assignment inside single quotes are the written file's commands, and a pipeline named in a double-quoted message is nobody's" 2
+
+echo "=== control: the same four shapes outside the quotes are this script's own ==="
+{
+  printf '#!/usr/bin/env bash\n'
+  printf 'set -euo pipefail\n'
+  printf 'd=$1\n'
+  printf 'cd "$d"; git rev-parse --git-dir 2>/dev/null || true\n'
+  printf 'cd "$d"; mktemp -d\n'
+  printf '%s%s\n' "$ec_head" "$ec_tail"
+} >"$R/scripts/writer.sh"
+cat >"$R/scripts/lib/tpl.sh" <<'EOF'
+#!/usr/bin/env bash
+# Sourced by the scripts beside it: the caller's shell owns the mode.
+d=$(mktemp -d)
+echo "$d"
+EOF
+git -C "$R" add -A
+run_pf
+fires "unquoting the hook line makes the swallowed status this script's" "scripts/writer.sh:4: [fail-open] git || true swallows exit 2"
+fires "unquoting the scratch line makes the mktemp invocation this script's" "scripts/writer.sh:5: [mktemp-trap] mktemp without an EXIT trap"
+fires "unquoting the window line makes the early-closing pipeline this script's" "scripts/writer.sh:6: [early-close-pipe]"
+fires "unquoting the assignment makes the unchecked mktemp this lib's" "scripts/lib/tpl.sh:3: [fail-open] unchecked mktemp"
+
 pf_summary

--- a/skills/preflight/tests/precision.test.sh
+++ b/skills/preflight/tests/precision.test.sh
@@ -713,4 +713,53 @@ fires "unquoting the scratch line makes the mktemp invocation this script's" "sc
 fires "unquoting the window line makes the early-closing pipeline this script's" "scripts/writer.sh:6: [early-close-pipe]"
 fires "unquoting the assignment makes the unchecked mktemp this lib's" "scripts/lib/tpl.sh:3: [fail-open] unchecked mktemp"
 
+echo "=== a substitution's own quoted arguments belong to the substitution ==="
+seed nestedsubst
+mkdir -p "$R/scripts/lib"
+# Shell restarts quoting inside `$( … )`, so the span of x="$(cmd "$arg")"
+# ends at the LAST quote, not at the inner one. Ending it early cuts the line
+# at the inner argument and drops the rest of the command with it: the `)`
+# that the status test reads, and the pipeline the early-close lane looks
+# for. Both directions are one line each.
+cat >"$R/scripts/nested.sh" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+base="$1"
+# The status is captured on the same line, so the test below is reachable —
+# and it is reachable only if the `)` before `||` survived the read.
+ROOT="$(git -C "$base" rev-parse --show-toplevel 2>/dev/null)" || ROOT=""
+if [ -z "$ROOT" ]; then
+  exit 1
+fi
+echo "$ROOT"
+EOF
+# An errexit-less lib, where the mktemp assignment shape is judged: its
+# status is checked by the OR-list the mangled read used to swallow.
+cat >"$R/scripts/lib/scratch.sh" <<'EOF'
+#!/usr/bin/env bash
+# Sourced by the scripts beside it: the caller's shell owns the mode.
+make_scratch() {
+  TMP="$(mktemp -d "$1/xxXXXX")" || return 1
+  trap 'rmdir -- "${TMP:?}"' EXIT
+}
+EOF
+git -C "$R" add -A
+run_pf
+clean "a substitution carrying its own quoted argument keeps the status test that follows its closing paren" 2
+
+echo "=== control: the early-close shape inside such a substitution still fires ==="
+# Halved so this suite's own committed line does not carry the shape at a
+# command position; the fixture line joins the halves.
+ns_head='n="$(printf "%s\n" "$1" '
+ns_tail='| head -1)"'
+{
+  printf '#!/usr/bin/env bash\n'
+  printf 'set -euo pipefail\n'
+  printf '%s%s\n' "$ns_head" "$ns_tail"
+  printf 'echo "$n"\n'
+} >"$R/scripts/nested.sh"
+git -C "$R" add -A
+run_pf
+fires "a pipeline inside a substitution that also carries a quoted argument is still a pipeline" "scripts/nested.sh:3: [early-close-pipe]"
+
 pf_summary

--- a/skills/preflight/tests/precision.test.sh
+++ b/skills/preflight/tests/precision.test.sh
@@ -675,6 +675,9 @@ set -euo pipefail
 # the written file, never in this one.
 hook_line='cd "$d"; git rev-parse --git-dir 2>/dev/null || true'
 scratch_line='cd "$d"; mktemp -d'
+# An escaped quote does not end the message it stands in, so the shape it
+# names is still inside the message and not this file's command.
+note="he said \"cd x; git log || true\" once"
 EOF
 printf "window_line='%s%s'\n" "$ec_head" "$ec_tail" >>"$R/scripts/writer.sh"
 printf 'echo "the idiom is %s%s"\n' "$dq_head" "$ec_tail" >>"$R/scripts/writer.sh"
@@ -694,7 +697,7 @@ echo "$assign_line"
 EOF
 git -C "$R" add -A
 run_pf
-clean "a swallowed status, an mktemp invocation in both substitution spellings, an early-closing pipeline and an mktemp assignment inside single quotes are the written file's commands, and a pipeline named in a double-quoted message is nobody's" 2
+clean "a swallowed status, an mktemp invocation in both substitution spellings, an early-closing pipeline and an mktemp assignment inside single quotes are the written file's commands, and a pipeline or a swallowed status named in a double-quoted message, past an escaped quote or not, is nobody's" 2
 
 echo "=== control: the same four shapes outside the quotes are this script's own ==="
 {

--- a/skills/preflight/tests/precision.test.sh
+++ b/skills/preflight/tests/precision.test.sh
@@ -678,6 +678,12 @@ scratch_line='cd "$d"; mktemp -d'
 # An escaped quote does not end the message it stands in, so the shape it
 # names is still inside the message and not this file's command.
 note="he said \"cd x; git log || true\" once"
+# An escaped substitution marker opens nothing, in either spelling. The scan
+# consumed both as escaped text, so the span runs nothing and is the written
+# file's message; only a decision taken from the scan's own state can tell
+# these two lines from the substitutions they imitate.
+note_paren="see \$(cd x; git log || true) for the idiom"
+note_tick="see \`cd x; git log || true\` for the idiom"
 EOF
 printf "window_line='%s%s'\n" "$ec_head" "$ec_tail" >>"$R/scripts/writer.sh"
 printf 'echo "the idiom is %s%s"\n' "$dq_head" "$ec_tail" >>"$R/scripts/writer.sh"
@@ -697,7 +703,7 @@ echo "$assign_line"
 EOF
 git -C "$R" add -A
 run_pf
-clean "a swallowed status, an mktemp invocation in both substitution spellings, an early-closing pipeline and an mktemp assignment inside single quotes are the written file's commands, and a pipeline or a swallowed status named in a double-quoted message, past an escaped quote or not, is nobody's" 2
+clean "a swallowed status, an mktemp invocation in both substitution spellings, an early-closing pipeline and an mktemp assignment inside single quotes are the written file's commands, and a pipeline or a swallowed status named in a double-quoted message is nobody's, past an escaped quote or behind an escaped substitution marker in either spelling" 2
 
 echo "=== control: the same four shapes outside the quotes are this script's own ==="
 {


### PR DESCRIPTION
## Summary

- One shared blanking step, `shell_command_text`, runs before every preflight lane that judges a line as the script's own commands: the swallowed-status and mktemp-assignment shapes of fail-open, mktemp-trap, and early-close-pipe. A single-quoted span is always blanked, because single quotes suppress every expansion, so a hook or script template a tool writes to disk carries commands that run in the written file and never in the writer.
- `hardcoded-temp-path` and `masked-returns` deliberately take no blanking, and each keeps a test row that goes red if a later change routes it through the step.
- The reported blocker is gone: the moved hook template at `skills/worktree/scripts/worktree:1486` produced `[fail-open] git || true swallows exit 2` before and produces nothing now.

## Completed Issues

- Closes KEN-1380 - preflight judges shell text inside single-quoted template strings as the script's own command, so a moved hook template blocks the commit

## The scan is a lexer, and review found three gaps in it

The first commit read quoting with a scanner that did not know shell's rules. Review found three separate gaps, each one text that really runs being blanked, which is the fail-open direction in gate code. All are fixed here.

| gap | consequence | fixed in |
|---|---|---|
| a double-quoted span ended at the next `"` rather than at the substitution's closing paren, so `VAR="$(cmd "$arg")"` was cut at the inner quote | 90 lines newly fired `fail-open` that main leaves clean, 54 outside the test tree; 30 lines lost an `early-close-pipe` match main makes | `57b41724b` |
| a backtick substitution inside double quotes was blanked, though `MKTEMP_CALL_RE` and `EARLY_CLOSE_WRITER` both list a backtick among their command-position anchors | an untrapped scratch directory and an early-closing pipeline written with backticks both pass | `9de9c08e3` |
| a backslash escape was not honoured, so `\"` inside a double-quoted span read as that span's closing delimiter | a pipeline tail and a closing paren are lost, and `early-close-pipe` misses a pipeline that runs | `f840f5bbe` |

### The rule set, so the next reader can check it rather than discover a hole

Implemented: a single-quoted span running to the next quote with nothing inside it active; a double-quoted span ending at the first quote outside any substitution it opened; both substitution spellings opening a nesting from inside double quotes, `$(` closing at its matching paren with nested parens counted and the backtick form at its matching backtick; a backslash escape everywhere but inside single quotes; an unclosed span read as ordinary text rather than as a span.

Not implemented: quote context across physical lines; ANSI-C `$'...'` quoting, where a backslash does escape inside single quotes; quotes inside a parameter expansion, which runs no command; heredoc bodies, which are data this scan reads as code.

**Correction.** An earlier revision of this section claimed each omission mis-splits inert text rather than losing a command, so the scan over-reports rather than going blind. That claim is false for ANSI-C quoting, and review proved it: on `msg=$'a\'b'; git rev-parse --git-dir || true; echo 'done'` the single-quote state closes at the escaped apostrophe, pairs the real terminator with the later quote, and blanks the live `git ... || true` away. Main misses that line too, so the lane is no worse than main, but the direction claim was asserted for four omissions and verified for three. It is being implemented, and the direction for every remaining omission re-derived by construction rather than asserted.

### `env_error lexer-state` is a backstop, not dead code with a missing test

`467b7f2a8`/`fe1671dd7` replaces the dispatch's catch-all with one arm per context and a refusal on any other state. That refusal cannot fire from the shipped entry point, and no test pretends to exercise it: an instrumented copy over 51,891 lines entered exactly five states across 315,535 dispatch entries, and the stand-in for the refusal never fired.

It exists because the backtick arm was already dead on this branch while every backtick test passed. The backtick and paren character sets differ by exactly one character, `)`, and a bare unquoted `)` inside backticks is not valid shell outside a `case` or a quoted string, so no realistic input distinguishes a live backtick arm from a dead one. The class cannot be tested for, so it is removed instead. Arm coverage is pinned the other way: planting the original dead-pattern defect in each arm reddens the suites, outside 41/16, single 28/2, double 39/15, paren 28/10, backtick 0/2. The backtick row is the proof, since it failed nothing before this change.

## Scope notes

The issue's Done-when names `masked-returns` among the line-shape lanes. It reads shellcheck's parse of the whole file rather than the line's text, so it has no line text to blank; the shared step reaches every lane that does judge line text. `hardcoded-temp-path` is excluded for the opposite reason: the quoted literal IS its subject, so blanking quoted spans would make that lane fail open.

Four of the five routed sites ship the control pair the Done-when asks for. The fifth, the bare command-substitution assignment under errexit, cannot take one in that form: `SUBST_ASSIGN_RE` requires `$(` immediately after `=` or `="`, so a single quote in that position never matches and such a control would pass identically with and without the step. The site is still routed, because the rule is one step with no per-lane exception.

## Accepted broadening

Fixing the nesting lets the swallowed-status lane see 40 lines main was blind to, the shape `n="$(git rev-list --count "$ref" || true)"`. These are not a new class: the lane's pattern anchors a command position on `(`, and `$(` is that character, so a command substitution has always opened a command position by the lane's design. Main already reports 63 findings of this exact shape where no nesting hides the `|| true`. Suppressing the 40 would add a fail-open path deliberately.

The cost, named rather than discovered later: 28 of the 40 carry no finding on main, and 21 of those are in `skills/worktree/scripts/worktree`, the file KEN-1361 splits. KEN-1361 was blocked by a false finding and will now meet true ones, which is a different thing from being unable to commit at all.

Per-lane differential against main, 1182 tracked shell files staged as added:

| lane | main | only-main | only-new |
|---|---|---|---|
| fail-open | 375 | 1 | 40 |
| mktemp-trap | 10 | 1 | 0 |
| early-close-pipe | 48 | 0 | 0 |
| every other lane | - | 0 | 0 |

The two removals are the intended ones: the KEN-1380 template at `skills/worktree/scripts/worktree:1486`, and a single-quoted `mktemp -d` example printed in a diagnostic at `hooks/block-repo-copy.sh:45`.

## Size

No allowance stated on the issue. Measured: production 191, tests 168, render mirror 359.

## Test Plan

- `skills/preflight/tests/precision.test.sh` and `skills/preflight/tests/lanes-must-fail.test.sh`: six suites, 227 assertions. Each new row was proved red on the head before its fix, with the lane silent rather than merely wrong for the fail-open ones.
- Per-lane differential against main's preflight over 1182 tracked shell files, re-run on every head.
- `env -u TMPDIR tools/guard --full` on the final head: exit 0, zero `guard:` lines.
- `preflight --base origin/main` over this branch's own diff: clean across 6 changed files.

https://claude.ai/code/session_01PkpC1FpfroyEv9MRdfaKjb
