### PR TITLE
fix(KEN-1374): a narrowed Library row computes Where, fork standing and its click target from every missing scope

### DIFF
--- a/changelog.d/fixed/1374.md
+++ b/changelog.d/fixed/1374.md
@@ -1,0 +1,1 @@
+- A narrowed My Library row names only the places its narrowing admits: under a harness or a tag the missing-files marks go, and the Where cell and the source follow the narrowed list.

--- a/changelog.d/fixed/1374.md
+++ b/changelog.d/fixed/1374.md
@@ -1,1 +1,1 @@
-- A narrowed My Library row names only the places that narrowing shows, and two forks in same-named folders no longer share one label on buttons that open different projects.
+- A narrowed My Library row takes its Where cell, its missing-files badges, its source and its click from the places that narrowing shows. Fork badges still name every place a package is forked in.

--- a/changelog.d/fixed/1374.md
+++ b/changelog.d/fixed/1374.md
@@ -1,1 +1,1 @@
-- A narrowed My Library row names only the places its narrowing admits: under a harness or a tag the missing-files marks go, and the Where cell and the source follow the narrowed list.
+- A narrowed My Library row names only the places that narrowing shows, and two forks in same-named folders no longer share one label on buttons that open different projects.

--- a/ui/src/components/library/installed-row.tsx
+++ b/ui/src/components/library/installed-row.tsx
@@ -76,8 +76,10 @@ export function InstalledRow({
    *  the same one flow wherever it is taken, and this row's own click
    *  already opens the package. */
   outOfDate: boolean;
-  /** The places where a file kendex installed for this package is gone.
-   *  The repair lives on the package page, so the badge opens it there. */
+  /** The places where a file kendex installed for this package is gone, as
+   *  the table's own narrowing has them — the caller narrows, because a
+   *  place a row cannot be seen under is one this row must not name. The
+   *  repair lives on the package page, so the badge opens it there. */
   missingIn: Scope[];
   onOpen: (scope?: Scope) => void;
   /** Open one of the tools this package is installed for. */

--- a/ui/src/components/library/installed-row.tsx
+++ b/ui/src/components/library/installed-row.tsx
@@ -77,9 +77,9 @@ export function InstalledRow({
    *  already opens the package. */
   outOfDate: boolean;
   /** The places where a file kendex installed for this package is gone, as
-   *  the table's own narrowing has them — the caller narrows, because a
-   *  place a row cannot be seen under is one this row must not name. The
-   *  repair lives on the package page, so the badge opens it there. */
+   *  the table's own narrowing has them — the caller narrows, and the Where
+   *  cell counts exactly these. The repair lives on the package page, so
+   *  the badge opens it there. */
   missingIn: Scope[];
   onOpen: (scope?: Scope) => void;
   /** Open one of the tools this package is installed for. */
@@ -101,6 +101,13 @@ export function InstalledRow({
   // provenance lookup reads, so the From column and this cell can never
   // name different places.
   const scopes = groupPlaces(group, missingIn);
+  // What a badge's place label is told apart from: every place this row
+  // names, forks included. A fork answers for the package wherever it was
+  // made, so its place can sit outside the narrowed set the Where cell
+  // counts — and `placeName` shortens a root only against the places it is
+  // handed, so two forks in same-named folders would carry one label on
+  // two buttons opening different projects.
+  const named = groupPlaces(group, [...missingIn, ...forkedIn]);
   const status = groupStatus(group);
   const whereLabel =
     scopes.length === 1 ? scopeName(scopes[0]) : `${scopes.length} locations`;
@@ -174,7 +181,7 @@ export function InstalledRow({
                         render={
                           <button type="button" onClick={() => onOpen(where)}>
                             <span className="min-w-0 truncate">
-                              {`${FORKED_BADGE_LABEL} in ${placeName(where, scopes)}`}
+                              {`${FORKED_BADGE_LABEL} in ${placeName(where, named)}`}
                             </span>
                             <span className="sr-only">{FORKED_BADGE_HELP}</span>
                           </button>
@@ -197,7 +204,7 @@ export function InstalledRow({
                         render={
                           <button type="button" onClick={() => onOpen(where)}>
                             <span className="min-w-0 truncate">
-                              {`${MISSING_FILES_BADGE_LABEL} in ${placeName(where, scopes)}`}
+                              {`${MISSING_FILES_BADGE_LABEL} in ${placeName(where, named)}`}
                             </span>
                             <span className="sr-only">
                               {MISSING_FILES_BADGE_HELP}

--- a/ui/src/components/library/installed-view.dom.test.tsx
+++ b/ui/src/components/library/installed-view.dom.test.tsx
@@ -530,6 +530,47 @@ describe("the places a narrowed Library row names", () => {
     ]);
   });
 
+  // Where a tool-narrowed row's own click lands, and where the badge on the
+  // place it is observed in lands. The Done-when names the click destination
+  // beside Where, and nothing else in this file clicks a row narrowed by
+  // anything but a location.
+  //
+  // The row's default click has no control of its own: `groupPlaces` puts a
+  // group's observed places before its missing ones, and a row drawn under a
+  // tool or a tag facet always has an observed place, so the first place is
+  // the same whatever the missing half returns. What that assertion holds is
+  // the pairing — the click and the Where cell above name one place. The
+  // badge's click does have one: it is the row that item 1's control
+  // removes, since dropping the observed branch leaves no badge to press.
+  it("opens the narrowed place from a tool-narrowed row and its badge", async () => {
+    useUpdatesStore.setState({
+      rows: [gone(HYPR), gone(VG)] as never,
+      read: READ_LANDED,
+    });
+    useLibraryViewStore.setState({ ...NO_FILTERS, harness: "claude" });
+    const opened = { kind: "skill", name: "gh", identity: "recorded" };
+    const host = mount(<InstalledView />);
+    const line = host.querySelector("tbody tr");
+    if (!line) throw new Error("no row");
+
+    await userEvent.click(line);
+    expect(useNavStore.getState().packageRef).toEqual({
+      ...opened,
+      scope: HYPR,
+    });
+
+    useNavStore.setState({ packageRef: null });
+    const badge = [...host.querySelectorAll("button")].find((button) =>
+      (button.textContent ?? "").startsWith(MISSING_FILES_BADGE_LABEL),
+    );
+    if (!badge) throw new Error("no missing files badge");
+    await userEvent.click(badge);
+    expect(useNavStore.getState().packageRef).toEqual({
+      ...opened,
+      scope: HYPR,
+    });
+  });
+
   // A fork answers for the package wherever it was made, so a fork badge
   // names a place the narrowing excludes. `placeName` shortens a root only
   // against the places it is handed, so labelling those badges against the

--- a/ui/src/components/library/installed-view.dom.test.tsx
+++ b/ui/src/components/library/installed-view.dom.test.tsx
@@ -511,6 +511,63 @@ describe("the places a narrowed Library row names", () => {
       expect(missingPlaces(host), name).toEqual(places);
     }
   });
+
+  // A place the row is observed in has answered the tool and tag questions
+  // by being drawn there: a registration a harness still reads whose file
+  // is gone reads as missing while the scan sees the registration. The
+  // badge is the only route to the repair, so a narrowing that draws the
+  // row keeps it — the inverse, a place with no copy left under the same
+  // narrowing, is the "a tool" row above.
+  it("keeps the badge for a place the narrowed row is observed in", () => {
+    useUpdatesStore.setState({
+      rows: [gone(HYPR)] as never,
+      read: READ_LANDED,
+    });
+    useLibraryViewStore.setState({ ...NO_FILTERS, harness: "claude" });
+    const host = mount(<InstalledView />);
+    expect(missingPlaces(host)).toEqual([
+      `${MISSING_FILES_BADGE_LABEL} in hyprtrade`,
+    ]);
+  });
+
+  // A fork answers for the package wherever it was made, so a fork badge
+  // names a place the narrowing excludes. `placeName` shortens a root only
+  // against the places it is handed, so labelling those badges against the
+  // Where cell's narrowed set alone puts one folder name on two buttons
+  // that open different projects.
+  it("tells two forks in same-named folders apart under a narrowing", () => {
+    const ONE: Scope = { scope: "project", root: "/work/one/app" };
+    const TWO: Scope = { scope: "project", root: "/work/two/app" };
+    const forked = {
+      schema: 1,
+      install: {},
+      forks: { skill: { gh: { source: "local", "forked-at": "2026-01-01" } } },
+    };
+    useEditorStore.setState({
+      saved: { [ONE.root]: forked as never, [TWO.root]: forked as never },
+    });
+    // The fork places reach the row's standings through its missing rows,
+    // which is what a fork whose last rendering was deleted looks like.
+    useUpdatesStore.setState({
+      rows: [gone(ONE), gone(TWO)] as never,
+      read: READ_LANDED,
+    });
+    useLibraryViewStore.setState({ ...NO_FILTERS, harness: "claude" });
+    const host = mount(<InstalledView />);
+    const forks = [...host.querySelectorAll("tbody tr button span")]
+      .map((label) => label.textContent ?? "")
+      .filter((text) => text.startsWith(FORKED_BADGE_LABEL));
+    expect(forks).toEqual([
+      `${FORKED_BADGE_LABEL} in one/app`,
+      `${FORKED_BADGE_LABEL} in two/app`,
+    ]);
+    // The Where cell keeps the narrowed set alone: neither fork place is
+    // one this row is observed in.
+    const cells = [
+      ...(host.querySelector("tbody tr")?.querySelectorAll("td") ?? []),
+    ];
+    expect(cells[4].textContent).toBe("hyprtrade");
+  });
 });
 
 // Deleting a package's rendering by hand leaves the record behind, and the

--- a/ui/src/components/library/installed-view.dom.test.tsx
+++ b/ui/src/components/library/installed-view.dom.test.tsx
@@ -25,7 +25,7 @@ import {
 import { STATUS_LABELS } from "@/lib/copy-customize";
 import { addPackagesTo, nothingInstalledIn } from "@/lib/copy-install";
 import { UPDATE_AVAILABLE_BADGE } from "@/lib/copy-updates";
-import { observedAt } from "@/lib/derive";
+import { observedAt, type ScopeSelection } from "@/lib/derive";
 import {
   READ_LANDED,
   READ_PENDING,
@@ -33,7 +33,11 @@ import {
   readFailed,
 } from "@/lib/read-state";
 import { useEditorStore } from "@/stores/editor";
-import { NO_FILTERS, useLibraryViewStore } from "@/stores/library-view";
+import {
+  type FilterSelection,
+  NO_FILTERS,
+  useLibraryViewStore,
+} from "@/stores/library-view";
 import { useNavStore } from "@/stores/nav";
 import { useProvenanceStore } from "@/stores/provenance";
 import { useScanStore } from "@/stores/scan";
@@ -362,6 +366,149 @@ describe("the missing files badge on a Library row", () => {
         (host.textContent ?? "").includes(MISSING_FILES_BADGE_LABEL),
         name,
       ).toBe(marked);
+    }
+  });
+});
+
+// The places one row names follow the same narrowing the list itself was
+// built with, through the one `missingUnder` rule. A package with no copy
+// left carries no tool and no tags, so under either of those facets the row
+// answers from what the scan saw alone; under a place it answers for that
+// place. The Where cell, the badges naming a place and the record the From
+// column reads take that one set, and unnarrowed it is the whole of it.
+describe("the places a narrowed Library row names", () => {
+  const GH = { kind: "skill" as const, name: "gh" };
+  // The only copy the scan can see, tagged so the tag facet has something
+  // to narrow on.
+  const seen = {
+    ...installed(HYPR),
+    at: installed(HYPR).path,
+    tags: ["git"],
+  } as unknown as ObservedItem;
+  // The record for the place whose copy is gone is listed first, so a
+  // lookup reaching past the narrowing reads that place's marketplace.
+  const records = [
+    {
+      ...GH,
+      scope: VG,
+      harness: "claude",
+      at: null,
+      origin: { origin: "marketplace", source: "cat", repo: "o/r" },
+      summary: null,
+      package: GH,
+    },
+    {
+      ...GH,
+      scope: HYPR,
+      harness: "claude",
+      at: seen.at,
+      origin: { origin: "marketplace", source: "hyprcat", repo: "o/h" },
+      summary: null,
+      package: GH,
+    },
+  ];
+  const gone = (scope: Scope) => ({
+    ...GH,
+    scope,
+    updateAvailable: false,
+    removedUpstream: false,
+    mixed: false,
+    ignored: false,
+    blockedByLocalEdit: false,
+    filesMissing: true,
+    editedHarnesses: [],
+  });
+
+  beforeEach(() => {
+    vi.spyOn(useProvenanceStore.getState(), "load").mockResolvedValue();
+    vi.spyOn(useEditorStore.getState(), "loadAll").mockResolvedValue();
+    useEditorStore.setState({ saved: {} });
+    useScanStore.setState({
+      result: {
+        harnesses: [],
+        items: [seen],
+        missingProjects: [],
+        readProjects: [],
+        warnings: [],
+      } as never,
+    });
+    joinAnswered(records as never);
+    // Gone in the reader's own setup and in one project, present in the
+    // project the scan sees it in.
+    useUpdatesStore.setState({
+      rows: [gone(VG), gone({ scope: "global" })] as never,
+      read: READ_LANDED,
+    });
+    useNavStore.setState({ libraryScope: "all", search: "" });
+    useLibraryViewStore.setState({ ...NO_FILTERS });
+    roomIs(1400);
+  });
+
+  /** The place each badge names, read off the badge's own label — the row's
+   *  text would also carry the Where cell, which answers the same question
+   *  and would stand in for a badge that says nothing. */
+  const missingPlaces = (host: HTMLElement) =>
+    [...host.querySelectorAll("tbody tr button span")]
+      .map((label) => label.textContent ?? "")
+      .filter((text) => text.startsWith(MISSING_FILES_BADGE_LABEL));
+
+  it("narrows a row's places by every facet, not the location alone", () => {
+    const cases: [
+      string,
+      FilterSelection,
+      ScopeSelection,
+      string,
+      string[],
+      string,
+    ][] = [
+      [
+        "narrowed by nothing",
+        NO_FILTERS,
+        "all",
+        "3 locations",
+        [
+          `${MISSING_FILES_BADGE_LABEL} in vg`,
+          `${MISSING_FILES_BADGE_LABEL} in User level`,
+        ],
+        "cat",
+      ],
+      [
+        "a place",
+        NO_FILTERS,
+        { project: VG.root },
+        "vg",
+        [`${MISSING_FILES_BADGE_LABEL} in vg`],
+        "cat",
+      ],
+      [
+        "a tool",
+        { ...NO_FILTERS, harness: "claude" },
+        "all",
+        "hyprtrade",
+        [],
+        "hyprcat",
+      ],
+      [
+        "a tag",
+        { ...NO_FILTERS, tag: "git" },
+        "all",
+        "hyprtrade",
+        [],
+        "hyprcat",
+      ],
+    ];
+    expect(cases).toHaveLength(4);
+    for (const [name, filters, scope, where, places, from] of cases) {
+      useNavStore.setState({ libraryScope: scope });
+      useLibraryViewStore.setState(filters);
+      const host = mount(<InstalledView />);
+      const cells = [
+        ...(host.querySelector("tbody tr")?.querySelectorAll("td") ?? []),
+      ];
+      expect(cells, name).toHaveLength(8);
+      expect(cells[4].textContent, name).toBe(where);
+      expect(cells[5].textContent, name).toBe(from);
+      expect(missingPlaces(host), name).toEqual(places);
     }
   });
 });

--- a/ui/src/components/library/installed-view.tsx
+++ b/ui/src/components/library/installed-view.tsx
@@ -30,6 +30,7 @@ import {
 } from "@/lib/copy";
 import {
   admitsMissing,
+  EVERYWHERE,
   filterItems,
   groupItems,
   groupMatches,
@@ -261,25 +262,6 @@ export function InstalledView() {
   // which places a fork badge names.
   const { standingsFor, editedAnywhere, outOfDateAnywhere, missingIn } =
     useLibraryStandings(everywhere);
-  // The places on a row that the table's own narrowing admits, falling
-  // back to all of them where it admits none.
-  //
-  // A badge names every place the package is missing in, because the fact
-  // is about the package wherever it sits — so a row's places can include
-  // one this table is not showing. Everything that has to answer for the
-  // table on screen reads this instead: the row's click, and the record
-  // its From column names and filters on, since a marketplace alias is
-  // declared at a place and another place's alias can address a
-  // subscription that exists at neither.
-  const here = useMemo(
-    () => (group: ItemGroup) => {
-      const all = groupPlaces(group, missingIn?.(group) ?? []);
-      const admitted = all.filter((one) => scopeMatches({ scope: one }, scope));
-      return admitted.length > 0 ? admitted : all;
-    },
-    [missingIn, scope],
-  );
-
   // One narrowing object for every half of this list: what the scan is
   // filtered by, which packages with no copy left it admits, and — below
   // the table — whether an emptiness under it is the update read's to
@@ -291,6 +273,29 @@ export function InstalledView() {
       tag: tag === "any" ? undefined : (tag as Tag),
     }),
     [scope, harness, tag],
+  );
+
+  // The places a row stands in as the table's own narrowing has them,
+  // falling back to all of them where the location facet admits none.
+  //
+  // Narrowed by every facet, not the location alone: the places where the
+  // copy is gone come through the same `missingUnder` the list above builds
+  // its rows with, so a tool or a tag — which a row with no copy left
+  // carries neither of — leaves the row answering from what the scan saw.
+  // Everything that has to answer for the table on screen reads this: the
+  // row's Where cell and badges, its click, and the record its From column
+  // names and filters on, since a marketplace alias is declared at a place
+  // and another place's alias can address a subscription that exists at
+  // neither.
+  const here = useMemo(
+    () => (group: ItemGroup) => {
+      const all = groupPlaces(group, missingIn?.(group, narrowing) ?? []);
+      const admitted = all.filter((one) =>
+        scopeMatches({ scope: one }, narrowing.scope),
+      );
+      return admitted.length > 0 ? admitted : all;
+    },
+    [missingIn, narrowing],
   );
 
   const groups = useMemo(() => {
@@ -350,8 +355,11 @@ export function InstalledView() {
   const projects = useMemo(
     () =>
       scopeChoices(
+        // Every place, narrowed by nothing: a pill is how a reader reaches
+        // a narrowing, so offering only the places the current one admits
+        // would leave a facet no way out of itself.
         everywhere.flatMap((group) =>
-          groupPlaces(group, missingIn?.(group) ?? []),
+          groupPlaces(group, missingIn?.(group, EVERYWHERE) ?? []),
         ),
         scope,
       ),
@@ -561,7 +569,7 @@ export function InstalledView() {
                           .filter((s) => s.why === "forked")
                           .map((s) => s.scope)}
                         outOfDate={outOfDateAnywhere?.(group) ?? false}
-                        missingIn={missingIn?.(group) ?? []}
+                        missingIn={missingIn?.(group, narrowing) ?? []}
                         onOpen={(scope) => {
                           const where = scope ?? here(group)[0];
                           if (!where) return;

--- a/ui/src/components/library/installed-view.tsx
+++ b/ui/src/components/library/installed-view.tsx
@@ -42,7 +42,6 @@ import {
   installedCount,
   missingUnder,
   scopeChoices,
-  scopeMatches,
   selectionOf,
   withRecordedMissing,
 } from "@/lib/derive";
@@ -275,26 +274,17 @@ export function InstalledView() {
     [scope, harness, tag],
   );
 
-  // The places a row stands in as the table's own narrowing has them,
-  // falling back to all of them where the location facet admits none.
-  //
-  // Narrowed by every facet, not the location alone: the places where the
-  // copy is gone come through the same `missingUnder` the list above builds
-  // its rows with, so a tool or a tag — which a row with no copy left
-  // carries neither of — leaves the row answering from what the scan saw.
-  // Everything that has to answer for the table on screen reads this: the
-  // row's Where cell and badges, its click, and the record its From column
-  // names and filters on, since a marketplace alias is declared at a place
-  // and another place's alias can address a subscription that exists at
-  // neither.
+  // The places a row stands in, which under this narrowing is the same set
+  // the row itself draws: its installations came through `filterItems` and
+  // its missing places through `missingPlacesOf`, both under `narrowing`,
+  // so nothing here is outside it. Everything that has to answer for the
+  // table on screen reads this — the row's click, and the record its From
+  // column names and filters on, since a marketplace alias is declared at
+  // a place and another place's alias can address a subscription that
+  // exists at neither.
   const here = useMemo(
-    () => (group: ItemGroup) => {
-      const all = groupPlaces(group, missingIn?.(group, narrowing) ?? []);
-      const admitted = all.filter((one) =>
-        scopeMatches({ scope: one }, narrowing.scope),
-      );
-      return admitted.length > 0 ? admitted : all;
-    },
+    () => (group: ItemGroup) =>
+      groupPlaces(group, missingIn?.(group, narrowing) ?? []),
     [missingIn, narrowing],
   );
 

--- a/ui/src/lib/derive.ts
+++ b/ui/src/lib/derive.ts
@@ -275,6 +275,37 @@ export function missingUnder(
   return missing.filter((row) => scopeMatches(row, filter.scope));
 }
 
+/** The places one row on screen is marked missing in, under the narrowing
+ *  that drew it. Its Where cell, the badges naming a place and the record
+ *  its source column reads all take this, so a row cannot mark a place it
+ *  does not otherwise name.
+ *
+ *  Two kinds of place, and a narrowing asks different things of them. Where
+ *  no copy is left, the row carries no tool and no tags, so a narrowing by
+ *  either is a question it cannot answer — {@link admitsMissing} refuses it,
+ *  which is the whole of {@link missingUnder}. Where this row IS observed,
+ *  it answered both by being drawn there: a registration a tool still reads
+ *  whose file is gone is exactly that place, and its badge is the only route
+ *  to the repair. Both are asked the place facet, which every place carries.
+ *
+ *  Both halves therefore read the group the narrowing drew, not the whole
+ *  package: an installation the narrowing filtered out is not a place this
+ *  row is observed in. */
+export function missingPlacesOf(
+  group: ItemGroup,
+  missing: UpdateRow[],
+  filter: ItemFilter,
+): Scope[] {
+  const observed = new Set(groupScopes(group).map(scopeKey));
+  return missing
+    .filter(
+      (row) =>
+        scopeMatches(row, filter.scope) &&
+        (admitsMissing(filter) || observed.has(scopeKey(row.scope))),
+    )
+    .map((row) => row.scope);
+}
+
 /** The grouped scan, plus a row for every recorded package it holds no
  *  observation of at all.
  *

--- a/ui/src/lib/derive.ts
+++ b/ui/src/lib/derive.ts
@@ -47,6 +47,12 @@ export interface ItemFilter {
   tag?: Tag;
 }
 
+/** The narrowing that holds nothing back. A surface answering for the whole
+ *  set states it with this rather than an empty filter of its own, so a
+ *  facet {@link ItemFilter} gains cannot mean "everything" at one call site
+ *  and something narrower at the next. */
+export const EVERYWHERE: ItemFilter = { scope: "all" };
+
 /** Narrowings that are true of one installation: where it is, which tool
  *  reads it, what its author said it is for. Which kind of package it is
  *  is not one of them — a tool stores a package under whatever kind it can

--- a/ui/src/lib/library-standings.ts
+++ b/ui/src/lib/library-standings.ts
@@ -10,7 +10,7 @@ import type { ItemFilter, ItemGroup } from "@/lib/derive";
 import {
   EVERYWHERE,
   groupPlaces,
-  missingUnder,
+  missingPlacesOf,
   packageKey,
 } from "@/lib/derive";
 import { useMissingRows } from "@/lib/missing-files";
@@ -43,12 +43,10 @@ export function useLibraryStandings(groups: ItemGroup[]): {
    *  as the given narrowing has them — the rows Home's missing-files row
    *  counts, so the badge and that row cannot disagree.
    *
-   *  Narrowed through `derive.ts::missingUnder`, the one rule saying what
-   *  a narrowing may ask of a row with no copy left, so a caller drawing
-   *  the narrowed table gets the same places its own list was built from:
-   *  a tool or a tag is a question such a row cannot answer, and its place
-   *  answers only the place facet. `EVERYWHERE` asks for the whole set,
-   *  which is what a fact about the package rather than about the table
+   *  Narrowed through `derive.ts::missingPlacesOf`, the one rule saying
+   *  which of a row's missing places a narrowing keeps, so the group handed
+   *  in must be the one that narrowing drew. `EVERYWHERE` asks for the whole
+   *  set, which is what a fact about the package rather than about the table
    *  takes.
    *
    *  A local disk fact like an edit, so it is read the way
@@ -87,9 +85,7 @@ export function useLibraryStandings(groups: ItemGroup[]): {
   const missingScopes = useMemo(
     () => (group: ItemGroup, filter: ItemFilter) =>
       group.package
-        ? missingUnder(missing.get(group.key) ?? [], filter).map(
-            (row) => row.scope,
-          )
+        ? missingPlacesOf(group, missing.get(group.key) ?? [], filter)
         : [],
     [missing],
   );

--- a/ui/src/lib/library-standings.ts
+++ b/ui/src/lib/library-standings.ts
@@ -1,13 +1,18 @@
 import { useMemo } from "react";
-import type { Scope } from "@/bindings";
+import type { Scope, UpdateRow } from "@/bindings";
 import {
   type PlaceStanding,
   placeFacts,
   placeStandings,
   placesSource,
 } from "@/lib/customized-places";
-import type { ItemGroup } from "@/lib/derive";
-import { groupPlaces, packageKey } from "@/lib/derive";
+import type { ItemFilter, ItemGroup } from "@/lib/derive";
+import {
+  EVERYWHERE,
+  groupPlaces,
+  missingUnder,
+  packageKey,
+} from "@/lib/derive";
 import { useMissingRows } from "@/lib/missing-files";
 import { availableUpdates } from "@/lib/update-groups";
 import { rowsCountable, rowsKnown } from "@/lib/updates-read-state";
@@ -34,12 +39,22 @@ export function useLibraryStandings(groups: ItemGroup[]): {
    *  Null until a read lands: a badge is a definite claim, and rows kept
    *  from a failed check have not confirmed one. */
   outOfDateAnywhere: ((group: ItemGroup) => boolean) | null;
-  /** The places where a file kendex installed for this package is gone
-   *  — the rows Home's missing-files row counts, so the badge and that
-   *  row cannot disagree. A local disk fact like an edit, so it is read
-   *  the way `editedAnywhere` is: from rows a landed read confirmed or a
-   *  failed re-check kept, and null before either. */
-  missingIn: ((group: ItemGroup) => Scope[]) | null;
+  /** The places where a file kendex installed for this package is gone,
+   *  as the given narrowing has them — the rows Home's missing-files row
+   *  counts, so the badge and that row cannot disagree.
+   *
+   *  Narrowed through `derive.ts::missingUnder`, the one rule saying what
+   *  a narrowing may ask of a row with no copy left, so a caller drawing
+   *  the narrowed table gets the same places its own list was built from:
+   *  a tool or a tag is a question such a row cannot answer, and its place
+   *  answers only the place facet. `EVERYWHERE` asks for the whole set,
+   *  which is what a fact about the package rather than about the table
+   *  takes.
+   *
+   *  A local disk fact like an edit, so it is read the way
+   *  `editedAnywhere` is: from rows a landed read confirmed or a failed
+   *  re-check kept, and null before either. */
+  missingIn: ((group: ItemGroup, filter: ItemFilter) => Scope[]) | null;
 } {
   const saved = useEditorStore((s) => s.saved);
   const savedSettings = useEditorStore((s) => s.savedSettings);
@@ -59,23 +74,32 @@ export function useLibraryStandings(groups: ItemGroup[]): {
   // cannot join that file's row, and a place set read across that line
   // would steer the Where cell, the fork badge and the row's own click.
   const missing = useMemo(() => {
-    const out = new Map<string, Scope[]>();
+    const out = new Map<string, UpdateRow[]>();
     for (const row of missingRows ?? []) {
       const key = packageKey(row);
-      out.set(key, [...(out.get(key) ?? []), row.scope]);
+      out.set(key, [...(out.get(key) ?? []), row]);
     }
     return out;
   }, [missingRows]);
-  // Where a record says this package's copy is gone. Nothing for a row the
-  // records account for nothing of: an observation answers only for
-  // itself, whatever it shares a kind and a name with.
+  // Where a record says this package's copy is gone, under one narrowing.
+  // Nothing for a row the records account for nothing of: an observation
+  // answers only for itself, whatever it shares a kind and a name with.
   const missingScopes = useMemo(
-    () => (group: ItemGroup) =>
-      group.package ? (missing.get(group.key) ?? []) : [],
+    () => (group: ItemGroup, filter: ItemFilter) =>
+      group.package
+        ? missingUnder(missing.get(group.key) ?? [], filter).map(
+            (row) => row.scope,
+          )
+        : [],
     [missing],
   );
+  // A standing is a fact about the package in a place, not about the table
+  // showing it, so the places it is asked over are every one the row stands
+  // in: a fork whose last rendering was deleted is still a fork under a
+  // narrowing that would not draw its missing badge.
   const placesOf = useMemo(
-    () => (group: ItemGroup) => groupPlaces(group, missingScopes(group)),
+    () => (group: ItemGroup) =>
+      groupPlaces(group, missingScopes(group, EVERYWHERE)),
     [missingScopes],
   );
   const byKey = useMemo(() => {
@@ -83,9 +107,6 @@ export function useLibraryStandings(groups: ItemGroup[]): {
     for (const group of groups)
       out.set(
         group.key,
-        // Every place the row stands in, not only the observed ones: a
-        // fork whose last rendering was deleted is still a fork, and its
-        // badge is read off the place it was made in.
         placeStandings(places, group.kind, group.name, placesOf(group)),
       );
     return out;


### PR DESCRIPTION
## Summary

- A My Library row narrowed by a project, a tool or a tag read its Where cell, its badge labels and its click target from every place the package's files are missing in, not from the narrowed ones. `here` filtered on location alone and `InstalledRow` received the unscoped set.
- `derive.ts` now owns the rule as `missingPlacesOf`, stated beside `missingUnder`: a place with no copy left at all is admitted only where `admitsMissing` allows it, and a place the narrowed row is itself observed in keeps its badge. Both halves ask the location facet. `library-standings.ts::missingIn` takes the narrowing and answers through it.
- Fork standings deliberately keep the whole place set — a fork is a fact about the package in a place, not about the table showing it, which the shipped comment above `forkedIn` already states. What changed is the set each badge label is resolved against: every place the row names on screen, so two forks in same-named folders stay distinguishable while the Where cell keeps reading the narrowed set alone.

## Completed Issues

- Closes KEN-1374 - A narrowed Library row computes Where, fork standing and its click target from every missing scope

## Size

No allowance stated on the issue. Measured: production 108, tests 206, render mirror 0.

## Test Plan

`ui/src/components/library/installed-view.dom.test.tsx` § "the places a narrowed Library row names": one row per facet (location, tool, tag), plus the unnarrowed inverse pinning the full set. Each row pins the Where cell, the places the badges name and the marketplace the From column reads. Two rows added in review: a registered hook whose script is gone keeps its badge under a tool narrowing, and forks in two same-named folders keep distinct labels.

Must-fail controls, each reverted after it reddened:

| Control | Row that went red |
|---|---|
| filter replaced by `EVERYWHERE` | a place |
| `{ scope: filter.scope }` | a tool |
| `{ scope: "all", tag: filter.tag }` | a place |
| `{ scope: filter.scope, harness: filter.harness }` | a tag |
| `{ ...filter, scope: "global" }` | narrowed by nothing |
| observed-place branch dropped from `missingPlacesOf` | the registered hook whose script is gone |
| badge labels resolved against the narrowed set alone | the two same-named fork folders |

Reachability of the code removed from `here` was re-proved after the rule changed: a probe throwing whenever the filter dropped a place or the fallback fired ran the whole 1545-test suite silently.

`env -u TMPDIR tools/guard --full` on the final tree: exit 0, no `guard:` failure lines. UI suite 204 files. `preflight` clean over 6 changed files.

https://claude.ai/code/session_011PeVcr59LqxDqEsnirCh6y
